### PR TITLE
feat(PEPS): the unconditional orientation-uniform gauge family for TI pairs

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -418,6 +418,7 @@ import TNLean.PEPS.TorusTINormalGauge
 import TNLean.PEPS.TorusClassAgreement
 import TNLean.PEPS.TorusEdgeGaugeCovariance
 import TNLean.PEPS.TorusConjCovarianceFamily
+import TNLean.PEPS.TorusWitnessTransport
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -419,6 +419,7 @@ import TNLean.PEPS.TorusClassAgreement
 import TNLean.PEPS.TorusEdgeGaugeCovariance
 import TNLean.PEPS.TorusConjCovarianceFamily
 import TNLean.PEPS.TorusWitnessTransport
+import TNLean.PEPS.TorusWitnessTranslate
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -420,6 +420,7 @@ import TNLean.PEPS.TorusEdgeGaugeCovariance
 import TNLean.PEPS.TorusConjCovarianceFamily
 import TNLean.PEPS.TorusWitnessTransport
 import TNLean.PEPS.TorusWitnessTranslate
+import TNLean.PEPS.TorusWitnessCapstone
 import TNLean.PEPS.NormalSquareTI
 import TNLean.PEPS.NormalEdgeComplementCover
 import TNLean.PEPS.NormalRectangleTiling

--- a/TNLean/PEPS/EdgeGaugeFamily.lean
+++ b/TNLean/PEPS/EdgeGaugeFamily.lean
@@ -53,6 +53,14 @@ theorem reindexAlgEquiv_finCongr_symm_round {m n : ℕ} (h h' : m = n)
   subst h
   simp
 
+/-- Transporting an invertible matrix across two successive index-size equalities is transporting
+across their composite. -/
+theorem glReindex_glReindex {m n k : ℕ} (h₁ : m = n) (h₂ : n = k) (Z : GL (Fin m) ℂ) :
+    glReindex h₂ (glReindex h₁ Z) = glReindex (h₁.trans h₂) Z := by
+  subst h₁
+  subst h₂
+  rfl
+
 /-- The transpose of an invertible matrix, packaged as an invertible matrix. The
 inverse is the transpose of the inverse, since transposition is an
 anti-homomorphism. -/

--- a/TNLean/PEPS/TorusRectangleGauge.lean
+++ b/TNLean/PEPS/TorusRectangleGauge.lean
@@ -94,5 +94,64 @@ theorem exists_horizontalReferenceEdgeGauge_coeff
   exact exists_regionEdgeGauge_torus_coeff DA DB rfl rfl rfl hbond hAB hd hposA hposB hsingle
     hRB hCB
 
+/-- **The per-edge gauge at the torus vertical reference edge from rectangle injectivity.**
+
+The vertical counterpart of `exists_horizontalReferenceEdgeGauge_coeff`: for two torus tensors `A`,
+`B` with the same state, matched bond dimensions, positive bonds, and both satisfying the
+rectangular-injectivity hypotheses with union closure, the distinguished vertical reference edge
+carries the per-edge gauge realizing the region-insertion coefficient identity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_verticalReferenceEdgeGauge_coeff
+    {A B : Tensor (torusGraph width height) d} {xStart yStart : ℕ}
+    (hA : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    let e := torusVerticalReferenceEdge xStart yStart
+    let DA := torusVerticalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh'
+    ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ),
+        ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+          (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) DA.red)
+          (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (Finset.univ \ DA.red)),
+          regionInsertedCoeff (G := torusGraph width height) A DA.red
+              (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e
+                (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hA hUA hx0 hy0
+                  hxw hyh hxw' hyh' g)) M σ τ =
+            regionInsertedCoeff (G := torusGraph width height) B DA.red
+              (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e
+                (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hA hUA hx0 hy0
+                  hxw hyh hxw' hyh' g))
+              ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+                  Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+                  ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                    Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))
+              σ τ := by
+  intro e DA
+  let DB := torusVerticalRectangleBlockingDatum hB hUB hx0 hy0 hxw' hyh'
+  have hsingle := fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hA hUA hx0 hy0
+    hxw hyh hxw' hyh' g
+  have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B DA.red := by
+    have hi := hB.verticalEdgeRed_injective (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ DA.red) :=
+    regionBlockedTensorInjective_host DB hUB
+  exact exists_regionEdgeGauge_torus_coeff DA DB rfl rfl rfl hbond hAB hd hposA hposB hsingle
+    hRB hCB
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWitnessCapstone.lean
+++ b/TNLean/PEPS/TorusWitnessCapstone.lean
@@ -1,0 +1,344 @@
+import TNLean.PEPS.TorusWitnessTranslate
+
+/-!
+# The orientation-uniform-mod-scalar family from the torus rectangle hypotheses
+
+The orientation-uniform reduction of the normal PEPS Fundamental Theorem on the discrete torus is
+assembled from an `EdgeCoeffIdentityWitness` at every edge of each orientation class
+(`isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses`).  This file produces those
+witnesses for a translation-invariant pair from the source's rectangle-injectivity hypotheses, by
+transporting the reference-edge coefficient identity (`exists_horizontalReferenceEdgeGauge_coeff`)
+along each class translation (`edgeCoeffIdentityWitness_translate`).
+
+The per-edge gauge family `X` is supplied with the per-edge coefficient identity it realizes over
+the image of the reference region; this is the shape the per-edge gauge engine delivers.  Matching
+the transported reference gauge with the capstone's `glReindex (huni.horizontal he).symm Xh`
+(`glReindex_glReindex`) and gathering the two orientation classes gives the
+orientation-uniform-mod-scalar family the reduction concludes.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- A torus right edge is a horizontal edge. -/
+theorem isHorizontalTorusEdge_torusRightEdge (p : TorusVertex width height) :
+    IsHorizontalTorusEdge (torusRightEdge p) := by
+  have hadj : torusHorizontalNeighbor p (p.1 + 1, p.2) := ⟨rfl, Or.inl rfl⟩
+  rcases Edge.ofAdj_endpoints (torusGraph_adj_right p.1 p.2) with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · change torusHorizontalNeighbor (torusRightEdge p).1.1 (torusRightEdge p).1.2
+    rw [torusRightEdge, h1, h2]; exact hadj
+  · change torusHorizontalNeighbor (torusRightEdge p).1.1 (torusRightEdge p).1.2
+    rw [torusRightEdge, h1, h2]; exact torusHorizontalNeighbor_symm hadj
+
+/-- A torus up edge is a vertical edge. -/
+theorem isVerticalTorusEdge_torusUpEdge (p : TorusVertex width height) :
+    IsVerticalTorusEdge (torusUpEdge p) := by
+  have hadj : torusVerticalNeighbor p (p.1, p.2 + 1) := ⟨rfl, Or.inl rfl⟩
+  rcases Edge.ofAdj_endpoints (torusGraph_adj_up p.1 p.2) with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · change torusVerticalNeighbor (torusUpEdge p).1.1 (torusUpEdge p).1.2
+    rw [torusUpEdge, h1, h2]; exact hadj
+  · change torusVerticalNeighbor (torusUpEdge p).1.1 (torusUpEdge p).1.2
+    rw [torusUpEdge, h1, h2]; exact torusVerticalNeighbor_symm hadj
+
+/-- The reference horizontal edge is a horizontal edge. -/
+theorem isHorizontalTorusEdge_torusHorizontalReferenceEdge (xStart yStart : ℕ) :
+    IsHorizontalTorusEdge
+      (torusHorizontalReferenceEdge (width := width) (height := height) xStart yStart) :=
+  isHorizontalTorusEdge_torusRightEdge _
+
+/-- The reference vertical edge is a vertical edge. -/
+theorem isVerticalTorusEdge_torusVerticalReferenceEdge (xStart yStart : ℕ) :
+    IsVerticalTorusEdge
+      (torusVerticalReferenceEdge (width := width) (height := height) xStart yStart) :=
+  isVerticalTorusEdge_torusUpEdge _
+
+/-- The translation carrying the reference horizontal edge to a given horizontal edge `e`, packaged
+as data: the offset is the coordinate difference of the left endpoints. -/
+noncomputable def translate_horizontalReferenceEdge {xStart yStart : ℕ}
+    {e : Edge (torusGraph width height)} (he : IsHorizontalTorusEdge e) :
+    {ab : ZMod width × ZMod height //
+      e = Edge.map (translate ab.1 ab.2) (torusHorizontalReferenceEdge xStart yStart)} :=
+  ⟨((isHorizontalTorusEdge_eq_rightEdge he).choose.1 - (((xStart : ℕ) + 1 : ZMod width)),
+      (isHorizontalTorusEdge_eq_rightEdge he).choose.2 - (((yStart : ℕ) + 2 : ZMod height))),
+    by
+      conv_lhs => rw [(isHorizontalTorusEdge_eq_rightEdge he).choose_spec]
+      rw [← translateEdge_eq_map, torusHorizontalReferenceEdge, translateEdge_torusRightEdge]
+      congr 1
+      apply Prod.ext <;> push_cast <;> ring⟩
+
+/-- The translation carrying the reference vertical edge to a given vertical edge `e`, as data. -/
+noncomputable def translate_verticalReferenceEdge {xStart yStart : ℕ}
+    {e : Edge (torusGraph width height)} (he : IsVerticalTorusEdge e) :
+    {ab : ZMod width × ZMod height //
+      e = Edge.map (translate ab.1 ab.2) (torusVerticalReferenceEdge xStart yStart)} :=
+  ⟨((isVerticalTorusEdge_eq_upEdge he).choose.1 - (((xStart : ℕ) + 2 : ZMod width)),
+      (isVerticalTorusEdge_eq_upEdge he).choose.2 - (((yStart : ℕ) + 1 : ZMod height))),
+    by
+      conv_lhs => rw [(isVerticalTorusEdge_eq_upEdge he).choose_spec]
+      rw [← translateEdge_eq_map, torusVerticalReferenceEdge, translateEdge_torusUpEdge]
+      congr 1
+      apply Prod.ext <;> push_cast <;> ring⟩
+
+/-- **The horizontal coefficient-identity witness family on the torus from rectangle injectivity.**
+
+For a translation-invariant pair `A`, `B` on the torus with matched bond dimensions, positive
+bonds, the same state, and both satisfying the rectangular-injectivity hypotheses with union
+closure, every horizontal edge carries an `EdgeCoeffIdentityWitness` whose per-edge and reference
+gauges are both the reference horizontal gauge transported to that edge.
+
+The reference horizontal gauge `Zh` and its coefficient identity come from
+`exists_horizontalReferenceEdgeGauge_coeff` at the reference horizontal edge.  Writing each
+horizontal edge as the translation image of the reference edge
+(`translate_horizontalReferenceEdge`), the reference coefficient identity transports to that
+edge realized by the transported gauge (`edgeCoeffIdentityWitness_translate`), supplying both
+witness fields.  This is the horizontal half of the translation production the orientation-uniform
+selection `isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses` consumes; the per-edge
+gauge family is the transported reference, the source's *"X, the same matrix on all horizontal
+edges"*.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_edgeCoeffIdentityWitness_horizontalFamily
+    {A B : Tensor (torusGraph width height) d} {xStart yStart : ℕ}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (hAh : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hBh : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUAh : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUBh : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    ∀ (e : Edge (torusGraph width height)), IsHorizontalTorusEdge e →
+      ∃ (Z Zref : GL (Fin (B.bondDim e)) ℂ) (hE : A.bondDim e = B.bondDim e),
+        Nonempty (EdgeCoeffIdentityWitness A B e Z Zref hE) := by
+  -- The reference horizontal gauge and its coefficient identity at the reference edge.
+  obtain ⟨hEref, Zref, hZref⟩ :=
+    exists_horizontalReferenceEdgeGauge_coeff hAh hBh hUAh hUBh hx0 hy0 hxw hyh hxw' hyh'
+      hbond hAB hd hposA hposB
+  intro e he
+  -- Write `e` as the translation image of the reference horizontal edge.
+  obtain ⟨⟨a, b⟩, rfl⟩ := translate_horizontalReferenceEdge (xStart := xStart)
+    (yStart := yStart) he
+  -- Abbreviate the reference region and its single boundary edge.
+  set R := (torusHorizontalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw' hyh').red with hRdef
+  set f := singleBoundaryEdge (G := torusGraph width height) A R
+    (torusHorizontalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw' hyh').blue
+    (torusHorizontalReferenceEdge xStart yStart)
+    (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hAh hUAh hx0 hy0 hxw hyh
+      hxw' hyh' g) with hfdef
+  -- `B`'s reference region block and host block are injective.
+  have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R := by
+    have hi := hBh.horizontalEdgeRed_injective (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R) :=
+    regionBlockedTensorInjective_host
+      (torusHorizontalRectangleBlockingDatum hBh hUBh hx0 hy0 hxw' hyh') hUBh
+  -- The bond-dimension equality at the translated boundary edge, derived from the reference
+  -- equality and the two translation bond-dimension equalities.
+  have hEX : A.bondDim (boundaryEdgeMap (translate a b) R f).1 =
+      B.bondDim (boundaryEdgeMap (translate a b) R f).1 :=
+    (bondDim_boundaryEdgeMap_translate hA a b R f).trans
+      (hEref.trans (bondDim_boundaryEdgeMap_translate hB a b R f).symm)
+  -- The transported reference gauge realizes both the per-edge and reference coefficient identities
+  -- at the translated edge, by the transport lemma; the witness producer assembles the witness.
+  refine ⟨glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Zref,
+    glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Zref, hEX,
+    ⟨edgeCoeffIdentityWitness_translate hA hB a b R f hEref Zref hposB hRB hCB hZref
+      (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Zref) hEX ?_⟩⟩
+  -- The per-edge gauge identity is the transported reference identity; preimage the image-region
+  -- configurations through the configuration transport before the transported identity applies.
+  intro M σ' τ'
+  obtain ⟨σ, τ, rfl, rfl⟩ := exists_regionPhysicalConfig_translate_preimage (d := d) a b R σ' τ'
+  exact regionInsertedCoeff_translate_coeffIdentity_conj hA hB a b R f hEref Zref hZref
+    hEX (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Zref) rfl M σ τ
+
+/-- **The vertical coefficient-identity witness family on the torus from rectangle injectivity.**
+
+The vertical counterpart of `exists_edgeCoeffIdentityWitness_horizontalFamily`: every vertical edge
+carries an `EdgeCoeffIdentityWitness` whose per-edge and reference gauges are both the reference
+vertical gauge transported to that edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_edgeCoeffIdentityWitness_verticalFamily
+    {A B : Tensor (torusGraph width height) d} {xStart yStart : ℕ}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (hAh : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hBh : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUAh : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUBh : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    ∀ (e : Edge (torusGraph width height)), IsVerticalTorusEdge e →
+      ∃ (Z Zref : GL (Fin (B.bondDim e)) ℂ) (hE : A.bondDim e = B.bondDim e),
+        Nonempty (EdgeCoeffIdentityWitness A B e Z Zref hE) := by
+  obtain ⟨hEref, Zref, hZref⟩ :=
+    exists_verticalReferenceEdgeGauge_coeff hAh hBh hUAh hUBh hx0 hy0 hxw hyh hxw' hyh'
+      hbond hAB hd hposA hposB
+  intro e he
+  obtain ⟨⟨a, b⟩, rfl⟩ := translate_verticalReferenceEdge (xStart := xStart)
+    (yStart := yStart) he
+  set R := (torusVerticalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw' hyh').red with hRdef
+  set f := singleBoundaryEdge (G := torusGraph width height) A R
+    (torusVerticalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw' hyh').blue
+    (torusVerticalReferenceEdge xStart yStart)
+    (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hAh hUAh hx0 hy0 hxw hyh
+      hxw' hyh' g) with hfdef
+  have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R := by
+    have hi := hBh.verticalEdgeRed_injective (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R) :=
+    regionBlockedTensorInjective_host
+      (torusVerticalRectangleBlockingDatum hBh hUBh hx0 hy0 hxw' hyh') hUBh
+  have hEX : A.bondDim (boundaryEdgeMap (translate a b) R f).1 =
+      B.bondDim (boundaryEdgeMap (translate a b) R f).1 :=
+    (bondDim_boundaryEdgeMap_translate hA a b R f).trans
+      (hEref.trans (bondDim_boundaryEdgeMap_translate hB a b R f).symm)
+  refine ⟨glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Zref,
+    glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Zref, hEX,
+    ⟨edgeCoeffIdentityWitness_translate hA hB a b R f hEref Zref hposB hRB hCB hZref
+      (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Zref) hEX ?_⟩⟩
+  intro M σ' τ'
+  obtain ⟨σ, τ, rfl, rfl⟩ := exists_regionPhysicalConfig_translate_preimage (d := d) a b R σ' τ'
+  exact regionInsertedCoeff_translate_coeffIdentity_conj hA hB a b R f hEref Zref hZref
+    hEX (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Zref) rfl M σ τ
+
+/-- **The orientation-uniform-mod-scalar family from the torus rectangle hypotheses.**
+
+For a translation-invariant pair `A`, `B` on the torus with matched bond dimensions, positive
+bonds, the same state, and both satisfying the rectangular-injectivity hypotheses with union
+closure, there is a per-edge gauge family on the torus that is orientation uniform up to per-edge
+scalars.
+
+The horizontal and vertical coefficient-identity witness families
+(`exists_edgeCoeffIdentityWitness_horizontalFamily`,
+`exists_edgeCoeffIdentityWitness_verticalFamily`) provide, at every edge of each orientation class,
+a witness whose per-edge and reference gauges are both the reference gauge transported to that edge.
+Choosing the per-edge gauge family to be those transported reference gauges and feeding the
+witnesses to the orientation-uniform selection
+`isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses` assembles the family
+unconditionally from the source's rectangle hypotheses: this is the source's *"X and Y, the same
+matrix on all horizontal (vertical) edges"*, with the per-edge scalars all one.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle
+    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (hAr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hBr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
+    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
+    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
+    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
+    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
+    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    ∃ (X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ),
+      IsTorusOrientationUniformGaugeFamilyModScalar
+        (torusUniformBondDim_of_translationInvariant hB) X := by
+  classical
+  set huni := torusUniformBondDim_of_translationInvariant hB with hunidef
+  -- The two reference gauges and their per-edge witness families.
+  obtain ⟨hEh, Zh, hZh⟩ :=
+    exists_horizontalReferenceEdgeGauge_coeff hAr hBr hUA hUB hxh0 hyh0 hxhw hyhh hxhw' hyhh'
+      hbond hAB hd hposA hposB
+  obtain ⟨hEv, Zv, hZv⟩ :=
+    exists_verticalReferenceEdgeGauge_coeff hAr hBr hUA hUB hxv0 hyv0 hxvw hyvh hxvw' hyvh'
+      hbond hAB hd hposA hposB
+  -- The reference horizontal/vertical orientation matrices, read at the reference edges.
+  set Xh := glReindex
+    (huni.horizontal (isHorizontalTorusEdge_torusHorizontalReferenceEdge xhStart yhStart)) Zh
+    with hXhdef
+  set Xv := glReindex
+    (huni.vertical (isVerticalTorusEdge_torusVerticalReferenceEdge xvStart yvStart)) Zv
+    with hXvdef
+  refine ⟨torusOrientationUniformGauge huni Xh Xv,
+    isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses huni _ Xh Xv
+      (fun e => congrFun hbond e) (fun e he => ?_) (fun e he => ?_)⟩
+  · -- Horizontal witness: the per-edge gauge is `glReindex _ Xh`, which equals the transported
+    -- reference single matrix; supply the witness against it.
+    rw [torusOrientationUniformGauge_horizontal huni Xh Xv he]
+    -- Write `e` as the translation image of the reference horizontal edge.
+    obtain ⟨⟨a, b⟩, heq⟩ := translate_horizontalReferenceEdge (xStart := xhStart)
+      (yStart := yhStart) he
+    subst heq
+    exact edgeCoeffIdentityWitness_translateUniform hA hB a b
+      (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').red
+      (singleBoundaryEdge (G := torusGraph width height) A
+        (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').red
+        (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').blue
+        (torusHorizontalReferenceEdge xhStart yhStart)
+        (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hAr hUA hxh0 hyh0 hxhw
+          hyhh hxhw' hyhh' g))
+      hEh Zh hposB
+      (by
+        have hi := hBr.horizontalEdgeRed_injective (xStart := xhStart) (yStart := yhStart)
+          (by omega) (by omega)
+        rwa [regionInjectivityDataOf_isInjective] at hi)
+      (regionBlockedTensorInjective_host
+        (torusHorizontalRectangleBlockingDatum hBr hUB hxh0 hyh0 hxhw' hyhh') hUB)
+      hZh Xh
+      (huni.horizontal (isHorizontalTorusEdge_torusHorizontalReferenceEdge xhStart yhStart))
+      (huni.horizontal he) hXhdef
+  · rw [torusOrientationUniformGauge_vertical huni Xh Xv he]
+    obtain ⟨⟨a, b⟩, heq⟩ := translate_verticalReferenceEdge (xStart := xvStart)
+      (yStart := yvStart) he
+    subst heq
+    exact edgeCoeffIdentityWitness_translateUniform hA hB a b
+      (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').red
+      (singleBoundaryEdge (G := torusGraph width height) A
+        (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').red
+        (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').blue
+        (torusVerticalReferenceEdge xvStart yvStart)
+        (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hAr hUA hxv0 hyv0 hxvw
+          hyvh hxvw' hyvh' g))
+      hEv Zv hposB
+      (by
+        have hi := hBr.verticalEdgeRed_injective (xStart := xvStart) (yStart := yvStart)
+          (by omega) (by omega)
+        rwa [regionInjectivityDataOf_isInjective] at hi)
+      (regionBlockedTensorInjective_host
+        (torusVerticalRectangleBlockingDatum hBr hUB hxv0 hyv0 hxvw' hyvh') hUB)
+      hZv Xv
+      (huni.vertical (isVerticalTorusEdge_torusVerticalReferenceEdge xvStart yvStart))
+      (huni.vertical he) hXvdef
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWitnessTranslate.lean
+++ b/TNLean/PEPS/TorusWitnessTranslate.lean
@@ -134,5 +134,84 @@ noncomputable def edgeCoeffIdentityWitness_translate
     exact regionInsertedCoeff_translate_coeffIdentity_conj hA hB a b R f hE Z hid hEX
       (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z) rfl M σ τ
 
+/-- **The translated coefficient-identity witness against a transported single matrix.**
+
+A reformulation of `edgeCoeffIdentityWitness_translate` whose per-edge and reference gauges are both
+the single matrix `Xh` (read at the reference edge as `glReindex hDim0 Z`) transported back to the
+translated edge across `hDimE`, the shape the orientation-uniform selection consumes.  The
+transported reference gauge of `edgeCoeffIdentityWitness_translate` equals `glReindex hDimE.symm Xh`
+by the composition of the two transports (`glReindex_glReindex`) and proof irrelevance of the
+bond-dimension casts, so the witness is rephrased against that single matrix with no change of
+content.  The bond-dimension equalities `hDim0`/`hDimE` are supplied abstractly, so the producer
+applies to either orientation class.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def edgeCoeffIdentityWitness_translateUniform
+    {A B : Tensor (torusGraph width height) d} {Dh : ℕ}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (hE : A.bondDim f.1 = B.bondDim f.1)
+    (Z : GL (Fin (B.bondDim f.1)) ℂ)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R)
+    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R))
+    (hid : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B R f
+          ((Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+            (↑Z⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
+    (Xh : GL (Fin Dh) ℂ) (hDim0 : B.bondDim f.1 = Dh)
+    (hDimE : B.bondDim (boundaryEdgeMap (translate a b) R f).1 = Dh)
+    (hXh : Xh = glReindex hDim0 Z) :
+    EdgeCoeffIdentityWitness A B (boundaryEdgeMap (translate a b) R f).1
+      (glReindex hDimE.symm Xh) (glReindex hDimE.symm Xh)
+      ((bondDim_boundaryEdgeMap_translate hA a b R f).trans
+        (hE.trans (bondDim_boundaryEdgeMap_translate hB a b R f).symm)) := by
+  -- The transported single matrix equals the transported reference gauge.
+  have hgauge : glReindex hDimE.symm Xh =
+      glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z := by
+    rw [hXh, glReindex_glReindex]
+  -- The per-edge identity for the transported single matrix, read off the transport lemma.
+  have hidX : ∀ (M : Matrix (Fin (A.bondDim (boundaryEdgeMap (translate a b) R f).1))
+        (Fin (A.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (Region.map (translate a b) R))
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (Finset.univ \ Region.map (translate a b) R)),
+      regionInsertedCoeff (G := torusGraph width height) A (Region.map (translate a b) R)
+          (boundaryEdgeMap (translate a b) R f) M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B (Region.map (translate a b) R)
+          (boundaryEdgeMap (translate a b) R f)
+          ((glReindex hDimE.symm Xh :
+                Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
+                  (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr
+                ((bondDim_boundaryEdgeMap_translate hA a b R f).trans
+                  (hE.trans (bondDim_boundaryEdgeMap_translate hB a b R f).symm))) M *
+            (↑(glReindex hDimE.symm Xh)⁻¹ :
+                Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
+                  (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)) σ τ := by
+    intro M σ' τ'
+    obtain ⟨σ, τ, rfl, rfl⟩ :=
+      exists_regionPhysicalConfig_translate_preimage (d := d) a b R σ' τ'
+    rw [hgauge]
+    exact regionInsertedCoeff_translate_coeffIdentity_conj hA hB a b R f hE Z hid
+      ((bondDim_boundaryEdgeMap_translate hA a b R f).trans
+        (hE.trans (bondDim_boundaryEdgeMap_translate hB a b R f).symm))
+      (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z) rfl M σ τ
+  -- Assemble through the base producer, rewriting its reference gauge to the single matrix.
+  rw [hgauge]
+  exact edgeCoeffIdentityWitness_translate hA hB a b R f hE Z hposB hRB hCB hid
+    (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z)
+    ((bondDim_boundaryEdgeMap_translate hA a b R f).trans
+      (hE.trans (bondDim_boundaryEdgeMap_translate hB a b R f).symm))
+    (by rw [hgauge] at hidX; exact hidX)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWitnessTranslate.lean
+++ b/TNLean/PEPS/TorusWitnessTranslate.lean
@@ -1,0 +1,138 @@
+import TNLean.PEPS.TorusWitnessTransport
+
+/-!
+# The translated coefficient-identity witness on the torus
+
+The orientation-uniform reduction consumes an `EdgeCoeffIdentityWitness` at every edge of each
+orientation class.  This file produces such a witness at a translate `Edge.map (translate a b) f.1`
+of a reference boundary edge `f`, against the *transported* reference gauge.
+
+The region is the image `Region.map (translate a b) R` of the reference region `R`; both the
+second tensor's region block and its host block are blocked-tensor injective there, by transport
+of the reference injectivities for the translation-invariant second tensor.  The reference
+coefficient identity transports to the image region realized by the transported reference gauge
+(`regionInsertedCoeff_translate_coeffIdentity_conj`), giving the witness's reference field.  The
+per-edge gauge's own identity on the image region is supplied as the hypothesis `hidX`; an
+arbitrary region/complement physical configuration is preimaged through the configuration
+transport equivalences (`regionPhysicalConfigMapEquiv`, `regionPhysicalConfigCongr`) before the
+transported identities apply, the cast bookkeeping that aligns the image-region configurations
+with the translated ones.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- Every region/complement physical-configuration pair on the image region of a translation is the
+transport of a unique pair on the original region: the configuration transport equivalences are
+bijections, so any image configuration is the image of its preimage. -/
+theorem exists_regionPhysicalConfig_translate_preimage
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (σ' : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+      (Region.map (translate a b) R))
+    (τ' : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+      (Finset.univ \ Region.map (translate a b) R)) :
+    ∃ (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      σ' = regionPhysicalConfigMap (translate a b) R σ ∧
+      τ' = regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)
+        (regionPhysicalConfigMap (translate a b) (Finset.univ \ R) τ) := by
+  refine ⟨(regionPhysicalConfigMapEquiv (d := d) (translate a b) R).symm σ',
+    (regionPhysicalConfigMapEquiv (d := d) (translate a b) (Finset.univ \ R)).symm
+      ((regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)).symm τ'), ?_, ?_⟩
+  · exact ((regionPhysicalConfigMapEquiv (d := d) (translate a b) R).apply_symm_apply σ').symm
+  · rw [show regionPhysicalConfigMap (translate a b) (Finset.univ \ R)
+        ((regionPhysicalConfigMapEquiv (d := d) (translate a b) (Finset.univ \ R)).symm
+          ((regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)).symm τ')) =
+        (regionPhysicalConfigMapEquiv (d := d) (translate a b) (Finset.univ \ R))
+          ((regionPhysicalConfigMapEquiv (d := d) (translate a b) (Finset.univ \ R)).symm
+            ((regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)).symm τ'))
+        from rfl,
+      Equiv.apply_symm_apply, Equiv.apply_symm_apply]
+
+/-- **The translated coefficient-identity witness on the torus.**
+
+For translation-invariant tensors `A`, `B` with matched bond dimensions on the reference boundary
+edge `f` of `R`, positive bonds, and `B`'s reference region and host blocks blocked-tensor
+injective, suppose the reference coefficient identity at `f` is realized by conjugation with a gauge
+`Z`, and a per-edge gauge `X` realizes the coefficient identity over the image region
+`Region.map (translate a b) R` at the translated boundary edge.  Then the translated edge carries an
+`EdgeCoeffIdentityWitness` whose per-edge gauge is `X` and whose reference gauge is the transported
+gauge `glReindex _ Z`.
+
+The reference identity transports by `regionInsertedCoeff_translate_coeffIdentity_conj`; an
+arbitrary image-region configuration pair is preimaged through the configuration transport
+equivalences before the transported identity applies.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 377--457 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def edgeCoeffIdentityWitness_translate
+    {A B : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (hE : A.bondDim f.1 = B.bondDim f.1)
+    (Z : GL (Fin (B.bondDim f.1)) ℂ)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R)
+    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R))
+    (hid : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B R f
+          ((Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+            (↑Z⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
+    (X : GL (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)
+    (hEX : A.bondDim (boundaryEdgeMap (translate a b) R f).1 =
+      B.bondDim (boundaryEdgeMap (translate a b) R f).1)
+    (hidX : ∀ (M : Matrix (Fin (A.bondDim (boundaryEdgeMap (translate a b) R f).1))
+        (Fin (A.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (Region.map (translate a b) R))
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (Finset.univ \ Region.map (translate a b) R)),
+      regionInsertedCoeff (G := torusGraph width height) A (Region.map (translate a b) R)
+          (boundaryEdgeMap (translate a b) R f) M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B (Region.map (translate a b) R)
+          (boundaryEdgeMap (translate a b) R f)
+          ((X : Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
+                (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEX) M *
+            (↑X⁻¹ : Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
+                (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)) σ τ) :
+    EdgeCoeffIdentityWitness A B (boundaryEdgeMap (translate a b) R f).1 X
+      (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z) hEX where
+  region := Region.map (translate a b) R
+  isBoundary := (boundaryEdgeMap (translate a b) R f).2
+  hRB := by
+    have h := (regionBlockedTensorInjective_transport B (translate a b) R).mpr hRB
+    rwa [hB a b] at h
+  hCB := by
+    rw [show Finset.univ \ Region.map (translate a b) R =
+        Region.map (translate a b) (Finset.univ \ R) from (Region_map_compl (translate a b) R).symm]
+    have h := (regionBlockedTensorInjective_transport B (translate a b) (Finset.univ \ R)).mpr hCB
+    rwa [hB a b] at h
+  hposB := hposB
+  hidZ := hidX
+  hidZref := by
+    intro M σ' τ'
+    obtain ⟨σ, τ, rfl, rfl⟩ :=
+      exists_regionPhysicalConfig_translate_preimage (d := d) a b R σ' τ'
+    exact regionInsertedCoeff_translate_coeffIdentity_conj hA hB a b R f hE Z hid hEX
+      (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z) rfl M σ τ
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWitnessTransport.lean
+++ b/TNLean/PEPS/TorusWitnessTransport.lean
@@ -1,0 +1,128 @@
+import TNLean.PEPS.TorusRectangleWitness
+
+/-!
+# Transport of a conjugation coefficient identity along a torus translation
+
+The orientation-uniform reduction consumes, at every edge of an orientation class, an
+`EdgeCoeffIdentityWitness` whose reference field demands that the *transported* reference gauge
+realize the region-insertion coefficient identity at that edge.  This file supplies the
+matrix-algebra transport that produces that reference identity from the one at the class's
+reference edge: a coefficient identity realized at a reference boundary edge `f` by conjugation
+with `Z` transports, for a translation-invariant pair, to the same identity at the translated
+boundary edge realized by conjugation with the transported gauge `glReindex h Z`.
+
+The translation covariance of the bare coefficient identity is
+`regionInsertedCoeff_translate_coeffIdentity`; specializing its abstract transfer map to a
+conjugation `M ↦ Z · (reindex M) · Z⁻¹` and rewriting the nested bond-dimension reindexings with
+`reindexAlgEquiv_gaugeConj` identifies the transported transfer with conjugation by the
+reindexed gauge.  No new geometry enters: this is the cast bookkeeping that aligns the
+translated reference identity with the conjugation form the witness interface expects.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- The bond dimension of a translation-invariant tensor at the translated boundary edge of a
+region equals its bond dimension at the reference boundary edge, packaged for the inserted matrix
+at the translated edge. -/
+theorem bondDim_boundaryEdgeMap_translate_eq
+    {A : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f}) :
+    A.bondDim (boundaryEdgeMap (translate a b) R f).1 = A.bondDim f.1 :=
+  bondDim_boundaryEdgeMap_translate hA a b R f
+
+/-- **Transport of a conjugation coefficient identity along a torus translation.**
+
+For translation-invariant tensors `A`, `B` on the torus with matched bond dimensions on the
+reference boundary edge `f` of `R`, a coefficient identity realized by conjugation with an
+invertible gauge `Z` over `B`'s bond on `f` transports to the translated boundary edge
+`boundaryEdgeMap (translate a b) R f` of the translated region `Region.map (translate a b) R`,
+realized by conjugation with the transported gauge `glReindex hbond Z` over `B`'s bond on the
+translated edge.
+
+The translation covariance `regionInsertedCoeff_translate_coeffIdentity` carries the bare identity
+with its transfer map; specializing the transfer to the conjugation `M ↦ Z · (reindex M) · Z⁻¹`
+and collapsing the nested reindexings with `reindexAlgEquiv_gaugeConj` and
+`reindexAlgEquiv_finCongr_symm_round` identifies the transported map with conjugation by
+`glReindex hbond Z`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionInsertedCoeff_translate_coeffIdentity_conj
+    {A B : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (hE : A.bondDim f.1 = B.bondDim f.1)
+    (Z : GL (Fin (B.bondDim f.1)) ℂ)
+    (hid : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B R f
+          ((Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+            (↑Z⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
+    (hE' : A.bondDim (boundaryEdgeMap (translate a b) R f).1 =
+        B.bondDim (boundaryEdgeMap (translate a b) R f).1)
+    (Z' : GL (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)
+    (hZ' : Z' = glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z)
+    (M' : Matrix (Fin (A.bondDim (boundaryEdgeMap (translate a b) R f).1))
+      (Fin (A.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)
+    (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
+    (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := torusGraph width height) A
+        (Region.map (translate a b) R) (boundaryEdgeMap (translate a b) R f) M'
+        (regionPhysicalConfigMap (translate a b) R σ)
+        (regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)
+          (regionPhysicalConfigMap (translate a b) (Finset.univ \ R) τ)) =
+      regionInsertedCoeff (G := torusGraph width height) B
+        (Region.map (translate a b) R) (boundaryEdgeMap (translate a b) R f)
+        ((Z' : Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
+              (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ) *
+            Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE') M' *
+          (↑Z'⁻¹ : Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
+              (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ))
+        (regionPhysicalConfigMap (translate a b) R σ)
+        (regionPhysicalConfigCongr (d := d) (Region_map_compl (translate a b) R)
+          (regionPhysicalConfigMap (translate a b) (Finset.univ \ R) τ)) := by
+  -- The conjugation transfer map at the reference edge.
+  set g : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ →
+      Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ :=
+    fun M => (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+      (↑Z⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) with hg
+  -- Substitute the transported gauge.
+  subst hZ'
+  -- Transport the bare coefficient identity with this transfer map.
+  rw [regionInsertedCoeff_translate_coeffIdentity hA hB a b R f g hid M' σ τ]
+  -- It remains to align the transported transfer with conjugation by `glReindex hbB.symm Z`.
+  congr 1
+  -- Abbreviate the two bond-dimension reindexings.
+  set hbA := bondDim_boundaryEdgeMap_translate hA a b R f with hbAdef
+  set hbB := bondDim_boundaryEdgeMap_translate hB a b R f with hbBdef
+  -- Expand `g`, then pull the conjugation through the bond-dimension reindexing.
+  simp only [hg]
+  rw [reindexAlgEquiv_gaugeConj hbB.symm Z]
+  -- The two inner reindexings of `M'` agree by proof irrelevance of the bond casts: the nested
+  -- triple reindexing and the single reindexing across `hE'` both reindex `M'` by the composite
+  -- finite-index cast, which is the same cast up to proof irrelevance.
+  congr 1
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1725,17 +1725,46 @@ The remaining obligations are the following.
           and the transported reference gauge realize. Each witness yields the conjugation
           coincidence by the transfer-map determinacy, and gathering the two orientation
           classes assembles the orientation-uniform-up-to-scalar family. The reference edge
-          inhabits this witness interface directly. What remains is exactly the
-          translation production above: transporting the reference witness along each class
-          translation to obtain a witness at every edge against the \emph{transported}
-          reference matrix, matching the translated region and boundary edge of
-          \leanid{TNLean.PEPS.regionInsertedCoeff_translate_coeffIdentity} with those read off
-          the per-edge gauge of the translated blocking datum.\footnote{Formal declarations:
-          \leanid{TNLean.PEPS.exists_horizontalReferenceEdgeGauge_coeff},
-          \leanid{TNLean.PEPS.EdgeCoeffIdentityWitness},
-          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_of_edgeWitnesses},
-          and
-          \leanid{TNLean.PEPS.exists_edgeCoeffIdentityWitness_horizontalReference}.}
+          inhabits this witness interface directly.
+
+          The translation production is now carried out. The reference coefficient identity,
+          realized by conjugation with the reference gauge, transports along each class
+          translation to the same identity at every edge of the class, realized by conjugation
+          with the reference gauge carried across the bond-dimension reindexing. The translated
+          region is the image of the reference region; the second tensor's image region and its
+          host are injective there by transport of the reference injectivities, since the
+          second tensor is fixed by the translation; and an arbitrary region or complement
+          configuration on the image region is the transport of a unique configuration on the
+          reference region. Composing the two reindexings of the transported gauge collapses to
+          the single transported orientation matrix the selection expects, so the per-edge
+          witness against that matrix holds at every edge. Gathering the horizontal and vertical
+          witness families through the orientation-uniform selection produces, from the source's
+          rectangle hypotheses on a translation-invariant pair, the
+          orientation-uniform-up-to-scalar family unconditionally: the per-edge gauge family is
+          the single reference matrix per class transported to every edge, the source's
+          ``$X$ and $Y$, the same matrix on all horizontal (vertical) edges'', with the per-edge
+          scalars all one.\footnote{Formal declarations:
+          \leanid{TNLean.PEPS.regionInsertedCoeff_translate_coeffIdentity_conj},
+          \leanid{TNLean.PEPS.edgeCoeffIdentityWitness_translate},
+          \leanid{TNLean.PEPS.edgeCoeffIdentityWitness_translateUniform},
+          \leanid{TNLean.PEPS.exists_edgeCoeffIdentityWitness_horizontalFamily},
+          \leanid{TNLean.PEPS.exists_edgeCoeffIdentityWitness_verticalFamily}, and
+          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}.}
+
+          One strengthening remains. The family produced above takes the per-edge gauge to be the
+          transported reference matrix itself, so the witness's two coefficient identities are the
+          same single identity and the per-edge scalars are all one. The source's stronger claim is
+          that \emph{any} per-edge gauge independently produced by the edge-blocking engine at each
+          edge agrees with the transported reference up to a scalar. Reading that independent engine
+          gauge over the image of the reference region requires a blocking datum at the translated
+          edge whose red block is the image of the reference red block; but the lexicographic edge
+          convention reorders the endpoints under a wraparound translation, so the transported
+          datum's red block is the image of the reference \emph{blue} block on that branch, and the
+          reference coefficient identity — tied to the reference red region — does not transport to
+          it. Closing the independent-gauge strengthening therefore needs a branch-free reference
+          identity (one stated over the reference region's host orientation as well), which the
+          present reference engine does not supply. The unconditional family above does not depend
+          on this strengthening.
 
           The final region comparison setup is also formalized: a region and its set
           complement are wrapped as the two blocks consumed by the two-injective


### PR DESCRIPTION
## What

**The translation production of the TI Normal PEPS FT (#1373) is closed**: the
orientation-uniform mod-scalar gauge family for a translation-invariant tensor pair,
**unconditional from the source's own rectangle-injectivity hypotheses** — the source's
"the same matrix X on all horizontal edges and Y on all vertical edges" (Theorem 3,
paper_normal.tex:1498), with no vertex injectivity anywhere. All sorry-free;
`#print axioms` = `[propext, Classical.choice, Quot.sound]`; full root build green
(8,870 jobs).

## Highlights

- **`regionInsertedCoeff_translate_coeffIdentity_conj`** — the core cast-bookkeeping:
  conjugation coefficient identities transport along class translations (`glReindex`
  composition + the landed identity transport).
- **`edgeCoeffIdentityWitness_translate(Uniform)`** — the per-edge witness producer at
  every edge of each orientation class, with branch-free injectivity by transport.
- **`isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle`** — the capstone:
  TI pair + SameState + positivity + the torus 2×3/3×2 rectangle hypotheses + sizes ⟹
  the orientation-uniform family (per-edge scalars all one — the transported reference).
- The vertical reference gauge mirror + class-transitivity/orientation lemmas.

## Honest scope (documented)

The strengthening "any independently-chosen per-edge gauge agrees up to scalar" is blocked
by the lex endpoint flip on wraparound (the reference identity is tied to the red region);
the unconditional family does NOT depend on it. The remaining program step is the torus FT
capstone assembly (absorption + comparison + λ-counting with the merged region-injective
nonvanishing).

Refs #1373. CI failures are non-blocking automation (the recent blueprint-check pip failure
was a transient PyPI index blip — rerun if hit).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds sorry-free Lean proofs and documentation on the PEPS formalization path; no runtime services, auth, or data handling.
> 
> **Overview**
> Closes the **translation production** step for translation-invariant normal PEPS on the torus: from rectangle-injectivity hypotheses (no vertex injectivity), the PR builds an **orientation-uniform mod-scalar per-edge gauge family**—one reference matrix per horizontal/vertical class, transported to every edge.
> 
> New Lean modules chain **conjugation coefficient transport** along torus translations (`regionInsertedCoeff_translate_coeffIdentity_conj`), **per-edge `EdgeCoeffIdentityWitness` producers** at translated edges (`edgeCoeffIdentityWitness_translate` / `translateUniform`), and the capstone **`isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle`**. Supporting pieces include **`glReindex_glReindex`**, the vertical mirror **`exists_verticalReferenceEdgeGauge_coeff`**, and root imports for the three witness modules.
> 
> The route doc now states this step is done and points at the new declarations; it still records that matching **independently chosen** per-edge gauges up to scalar is blocked on wraparound endpoint reordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da85926d8ee80f29af2735e794dcdb651caf8184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->