### PR TITLE
doc(parent): update block-boundary gap note

### DIFF
--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -9,7 +9,7 @@
 
 \title{Block-Diagonal Boundary Conditions in the Degenerate Parent-Hamiltonian Ground Space}
 \author{}
-\date{2026-06-04}
+\date{2026-06-11}
 
 \begin{document}
 \maketitle
@@ -69,20 +69,20 @@ After blocking, the corresponding word-span statement is
   \prod_{j=1}^g M_{D_j}(\mathbb C).
 \end{align}
 
-The present formal block-separation route proves a one-site-injective
-special case of this statement.\footnote{This is the hypothesis mismatch tracked
-in \href{https://github.com/LionSR/TNLean/issues/2532}{issue \#2532}.}  Besides
-the common length-\(L\) block-injectivity assumption, the formalized BNT
-block-separation lemmas use
+The current Lean development separates the product-span input from
+the finite blocking hypothesis.  First, it proves the one-step PGVWC07
+intersection identity under the displayed product-span equation.  Then the
+normalized BNT theorems derive that product span in the finite Condition C1
+range from the injectivity of
 \begin{align}
-  \operatorname{span}\{A^j_a:a=1,\ldots,d\}=M_{D_j}(\mathbb C)
-  \qquad (j=1,\ldots,g).
+  \Gamma_{L_0}^{A_j}:M_{D_j}(\mathbb C)
+    \to(\mathbb C^d)^{\otimes L_0},
 \end{align}
-This is Condition C1 at length one for each block.  The source theorem only
-requires Condition C1 after a finite blocking length.  Thus the blueprint
-entries carrying the current formal statements must display the length-one
-span condition explicitly; removing it requires a separate proof deriving the
-same block-separation equations from the source's finite blocking range.
+together with the separated normalized block hypotheses.  Thus the current
+Lean statements no longer replace Condition C1 by a length-one span condition
+in the boundary-decomposition path.  The remaining mathematical boundary lies
+later in the argument: after the cyclic constraints have been propagated into
+the open-boundary sum, the boundary conditions themselves must be compared.
 
 The resulting parent-Hamiltonian theorem in \cite[Section~IV.C]{Cirac2021Matrix}
 is
@@ -145,7 +145,7 @@ for every $j,i_1,i_{m+1}$,
   =
   D^j_{i_{m+1}} A^j_{i_1}.
 \end{align}
-The source line defines \(E^j\) without an adjoint. The following calculation
+The source line defines $E^j$ without an adjoint. The following calculation
 uses instead the matrix
 \begin{align}
   E^j=\sum_{k} C^j_{k}A^{j\dagger}_{k}.
@@ -199,14 +199,27 @@ The proved one-step conclusion is therefore
   =
   \bigoplus_j \mathcal G_{m+1}^{A_j}
 \end{align}
-for all sufficiently large \(m\) satisfying the product-span hypotheses.\footnote{
+for all sufficiently large $m$ satisfying the product-span hypotheses.\footnote{
 Lean declarations:
 \leanid{MPSTensor.pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop},
 \leanid{MPSTensor.groundSpace_iSupIndep_of_wordTupleSpanTop}, and
 \leanid{MPSTensor.pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital}.}
-What is still missing is the derivation of the PGVWC07 source range from
-\(C1\) at the common length \(L_0\), and the periodic-chain iteration beginning
-from this one-step identity.
+The corresponding finite-Condition-C1 declarations then propagate the cyclic
+local constraints to
+\begin{align}
+  \mathcal K_{N,L}(\widetilde A)\subseteq
+  S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
+\end{align}
+and make the sum defining $S_N$ internal.\footnote{Lean declarations:
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1},
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1},
+\leanid{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1},
+and
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}.}
+What remains is the source boundary-condition comparison: starting with a
+periodic-chain vector in $\mathcal K_{N,L}(\widetilde A)$, produce
+block-diagonal boundary matrices whose block components are again periodic
+block-chain vectors.
 
 The live blueprint records that larger source statement in source notation,
 without claiming that it is proved.\footnote{Blueprint locations:
@@ -230,7 +243,7 @@ and
     \psi_j\in\mathcal K_{N,L}(A_j)
   \right\}.
 \end{align}
-The missing boundary-condition statement is then
+The missing source-level boundary-condition statement is then
 \begin{align}
   \left[
     b\ge2
@@ -253,24 +266,24 @@ The missing boundary-condition statement is then
 \end{align}
 
 The following implication is not available.  The open-boundary space
-\(\mathcal G_N^A\) is not contained in the cyclic-chain ground space
-\(\mathcal K_{N,L}(A)\) for an arbitrary boundary matrix \(X\).  If the
+$\mathcal G_N^A$ is not contained in the cyclic-chain ground space
+$\mathcal K_{N,L}(A)$ for an arbitrary boundary matrix $X$.  If the
 cyclic window crosses the chosen virtual boundary, then a vector
-\(\Gamma_N^A(X)\) has coefficients of the form
+$\Gamma_N^A(X)$ has coefficients of the form
 \begin{align}
   \tr\!\left(A^{\omega_{\mathrm{tail}}}
     X A^{\omega_{\mathrm{head}}} A^\rho\right),
 \end{align}
-where \(\omega_{\mathrm{tail}}\omega_{\mathrm{head}}\) is the word seen in the
-cyclic window and \(\rho\) is the complementary word.  This is not, for general
-\(X\), of the form
+where $\omega_{\mathrm{tail}}\omega_{\mathrm{head}}$ is the word seen in the
+cyclic window and $\rho$ is the complementary word.  This is not, for general
+$X$, of the form
 \begin{align}
   \tr\!\left(A^{\omega_{\mathrm{tail}}}
     A^{\omega_{\mathrm{head}}}Y_\rho\right)
 \end{align}
-with one matrix \(Y_\rho\) independent of the window word.  The missing step is
+with one matrix $Y_\rho$ independent of the window word.  The missing step is
 therefore a boundary-condition comparison, not the inclusion
-\(\mathcal G_N^A\subseteq\mathcal K_{N,L}(A)\).
+$\mathcal G_N^A\subseteq\mathcal K_{N,L}(A)$.
 The corresponding block-diagonal boundary-closing entries now record the
 multi-block hypothesis, the positive common injectivity length, the
 nonzero-weight hypothesis, and the conservative length range of \cite[Theorem
@@ -328,7 +341,7 @@ Thus the desired periodic-chain proof is the composition of the two implications
   \Gamma_j(X_j)\in\mathcal K_{N,L}(A_j)
   ,
 \end{align}
-and, for every \(X_1,\ldots,X_b\),
+and, for every $X_1,\ldots,X_b$,
 \begin{align}
   \forall\,1\le j\le b,\quad
   \Gamma_j(X_j)\in\mathcal K_{N,L}(A_j)
@@ -355,22 +368,22 @@ The composition gives
 
 \section{Conclusion}
 
-This is not a source-error claim. The present gap is the remaining implication
+This is not a source-error claim. The present gap is the boundary-condition
+comparison left after the inclusion into $S_N$:
 \begin{align}
-  \left[
-    \mathbb C^d\otimes S_m
-    \cap
-    S_m\otimes\mathbb C^d
-    =
-    S_{m+1}
-    \quad (m\ge L)
-  \right]
+  \psi\in\mathcal K_{N,L}(\widetilde A)
   &\Longrightarrow
-  \mathcal K_{N,L}(\widetilde A)
-  =
-  \sum_{j=1}^b \mathcal K_{N,L}(A_j),
+  \exists X_1,\ldots,X_b,\quad
+  \psi=\Gamma_N^{\widetilde A}\!\left(\bigoplus_{j=1}^bX_j\right),
   \notag\\
-  S_m&=\bigoplus_{j=1}^b \mathcal G_m^{A_j},
+  &\hphantom{\Longrightarrow}
+  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j)
+  \quad (j=1,\ldots,b).
+\end{align}
+The PGVWC07 propagation step now proved in Lean gives
+\begin{align}
+  \mathcal K_{N,L}(\widetilde A)\subseteq
+  S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
 \end{align}
 under
 \begin{align}
@@ -382,7 +395,14 @@ under
   \qquad
   N\ge L+L_0.
 \end{align}
-After this periodic-chain implication is proved, the final degenerate
+After this boundary-condition comparison is proved, the conditional boundary
+reduction gives
+\begin{align}
+  \mathcal K_{N,L}(\widetilde A)
+  =
+  \sum_{j=1}^b\mathcal K_{N,L}(A_j).
+\end{align}
+The final degenerate
 parent-Hamiltonian ground-space equality follows by applying the one-block
 uniqueness theorem to each block.
 

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -41,7 +41,7 @@ ground-space condition is
 \end{align}
 When weights are present, write
 \begin{align}
-  \widetilde A_i=\bigoplus_{j=1}^b\mu_jA_i^j,
+  \widehat A_i=\bigoplus_{j=1}^b\mu_jA_i^j,
   \qquad
   \mu_j\ne0,
 \end{align}
@@ -217,7 +217,7 @@ Lean declarations:
 The corresponding finite-Condition-C1 declarations then propagate the cyclic
 local constraints to
 \begin{align}
-  \mathcal K_{N,L}(\widetilde A)\subseteq
+  \mathcal K_{N,L}(\widehat A)\subseteq
   S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
 \end{align}
 and make the sum defining $S_N$ internal.\footnote{Lean declarations:
@@ -227,7 +227,7 @@ and make the sum defining $S_N$ internal.\footnote{Lean declarations:
 and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}.}
 What remains is the source boundary-condition comparison: starting with a
-periodic-chain vector in $\mathcal K_{N,L}(\widetilde A)$, produce
+periodic-chain vector in $\mathcal K_{N,L}(\widehat A)$, produce
 block-diagonal boundary matrices whose block components are again periodic
 block-chain vectors.
 
@@ -266,7 +266,7 @@ The missing source-level boundary-condition statement is then
   \right]
   \Longrightarrow
   \notag\\
-  \mathcal K_{N,L}(\widetilde A)
+  \mathcal K_{N,L}(\widehat A)
   =
   \sum_{j=1}^b \mathcal K_{N,L}(A_j).
 \end{align}
@@ -290,10 +290,9 @@ $X$, of the form
 with one matrix $Y_\rho$ independent of the window word.  The missing step is
 therefore a boundary-condition comparison, not the inclusion
 $\mathcal G_N^A\subseteq\mathcal K_{N,L}(A)$.
-The corresponding block-diagonal boundary-closing entries now record the
-multi-block hypothesis, the positive common injectivity length, the
-nonzero-weight hypothesis, and the conservative length range of \cite[Theorem
-\emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}:
+The source theorem uses the multi-block hypothesis, the positive common
+injectivity length, the nonzero-weight hypothesis, and the length range of
+\cite[Theorem \emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}:
 \begin{align}
   b\ge2,
   \qquad
@@ -312,17 +311,27 @@ $L\ge 3L_0+4>L_0$; the inequality $L_0<L$ is displayed separately because the
 one-block uniqueness input is used in that range.
 The one-block case is the injective parent-Hamiltonian theorem rather than the
 degenerate block-injective boundary theorem.
-The preceding conditional boundary-reduction entries still use weaker ambient
-length inequalities, but only together with the explicit hypothesis that the
-required commuting block-diagonal boundary representation is already available.
-They are not the source theorem.
+The finite-Condition-C1 propagation theorem currently proved in Lean is stated
+in the more conservative range
+\begin{align}
+  L\ge (L_0+1)+3(b-1)(L_0+1)+1.
+\end{align}
+The later boundary-closing reductions are conditional: they assume either a
+decomposition into periodic block-chain vectors or a block-diagonal boundary
+representation whose components already belong to the periodic block-chain
+spaces.\footnote{Lean declarations:
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition},
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap},
+and
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition}.}
+Those conditional reductions are not the source theorem.
 For
 \begin{align}
   X=\bigoplus_j X_j,
 \end{align}
 the boundary-matrix formula is
 \begin{align}
-  \Gamma_N^{\widetilde A}(X)(i_1,\ldots,i_N)
+  \Gamma_N^{\widehat A}(X)(i_1,\ldots,i_N)
   &=
   \sum_j \mu_j^N
   \tr(A^j_{i_1}\cdots A^j_{i_N}X_j) \notag\\
@@ -337,7 +346,7 @@ For the next display, abbreviate
 \end{align}
 Thus the desired periodic-chain proof is the composition of the two implications
 \begin{align}
-  \psi\in\mathcal K_{N,L}(\widetilde A)
+  \psi\in\mathcal K_{N,L}(\widehat A)
   &\Longrightarrow
   \exists (X_j)_{j=1}^b,\quad
   \psi=\sum_{j=1}^b\Gamma_j(X_j),
@@ -377,11 +386,15 @@ The composition gives
 This is not a source-error claim. The PGVWC07 propagation step now proved in
 Lean gives
 \begin{align}
-  \mathcal K_{N,L}(\widetilde A)\subseteq
+  \mathcal K_{N,L}(\widehat A)\subseteq
   S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
 \end{align}
-and the sum defining $S_N$ is internal.  Thus every
-$\psi\in\mathcal K_{N,L}(\widetilde A)$ has a unique vector decomposition
+in the finite-Condition-C1 Lean range
+\begin{align}
+  L\ge (L_0+1)+3(b-1)(L_0+1)+1.
+\end{align}
+The sum defining $S_N$ is internal.  Thus every
+$\psi\in\mathcal K_{N,L}(\widehat A)$ has a unique vector decomposition
 \begin{align}
   \psi=\sum_{j=1}^b\phi_j,
   \qquad
@@ -395,17 +408,17 @@ Equivalently,
 \begin{align}
   \psi
   =
-  \Gamma_N^{\widetilde A}\!\left(\bigoplus_{j=1}^bX_j\right)
+  \Gamma_N^{\widehat A}\!\left(\bigoplus_{j=1}^bX_j\right)
 \end{align}
 with open-boundary block components.  The present gap is the boundary-condition
 comparison: for every $j$,
 \begin{align}
-  \psi\in\mathcal K_{N,L}(\widetilde A)
+  \psi\in\mathcal K_{N,L}(\widehat A)
   \quad\Longrightarrow\quad
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
 This is the missing assertion for the block-diagonal boundary representation in
-the range
+the source range
 \begin{align}
   b\ge2,
   \qquad
@@ -418,7 +431,7 @@ the range
 After this boundary-condition comparison is proved, the conditional boundary
 reduction gives
 \begin{align}
-  \mathcal K_{N,L}(\widetilde A)
+  \mathcal K_{N,L}(\widehat A)
   =
   \sum_{j=1}^b\mathcal K_{N,L}(A_j).
 \end{align}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -39,6 +39,16 @@ ground-space condition is
   \bigcap_{s\in \mathbb Z/N\mathbb Z}
   \{\psi:\operatorname{res}_{s,L}(\psi)\in\mathcal G_L^A\}.
 \end{align}
+When weights are present, write
+\begin{align}
+  \widetilde A_i=\bigoplus_{j=1}^b\mu_jA_i^j,
+  \qquad
+  \mu_j\ne0,
+\end{align}
+for the corresponding block-diagonal tensor.  The letters $g$ and $b$ both
+denote the number of blocks below: $g$ follows the review's block-injective
+canonical form notation, while $b$ follows PGVWC07's notation around Theorem
+\emph{2blocks.2}.
 
 \section{The source assertion}
 
@@ -72,8 +82,8 @@ After blocking, the corresponding word-span statement is
 The current Lean development separates the product-span input from
 the finite blocking hypothesis.  First, it proves the one-step PGVWC07
 intersection identity under the displayed product-span equation.  Then the
-normalized BNT theorems derive that product span in the finite Condition C1
-range from the injectivity of
+normalized basis-of-normal-tensors (BNT) theorems derive that product span in
+the finite Condition C1 range from the injectivity of
 \begin{align}
   \Gamma_{L_0}^{A_j}:M_{D_j}(\mathbb C)
     \to(\mathbb C^d)^{\otimes L_0},
@@ -230,11 +240,7 @@ inclusion, \path{thm:block_diagonal_ground_space_intersection} for the
 PGVWC07 block-diagonal intersection identity,
 \path{thm:parent_ground_space_le_bnt_span} for the parent-ground-space
 containment, and \path{thm:gs_eq_bnt_span} for the final span statement in
-\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}.} Write
-\begin{align}
-  \widetilde A_i=\bigoplus_{j=1}^b\mu_j A_i^j
-\end{align}
-and
+\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex}.} With this notation,
 \begin{align}
   \sum_{j=1}^b\mathcal K_{N,L}(A_j)
   =
@@ -368,24 +374,38 @@ The composition gives
 
 \section{Conclusion}
 
-This is not a source-error claim. The present gap is the boundary-condition
-comparison left after the inclusion into $S_N$:
-\begin{align}
-  \psi\in\mathcal K_{N,L}(\widetilde A)
-  &\Longrightarrow
-  \exists X_1,\ldots,X_b,\quad
-  \psi=\Gamma_N^{\widetilde A}\!\left(\bigoplus_{j=1}^bX_j\right),
-  \notag\\
-  &\hphantom{\Longrightarrow}
-  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j)
-  \quad (j=1,\ldots,b).
-\end{align}
-The PGVWC07 propagation step now proved in Lean gives
+This is not a source-error claim. The PGVWC07 propagation step now proved in
+Lean gives
 \begin{align}
   \mathcal K_{N,L}(\widetilde A)\subseteq
   S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
 \end{align}
-under
+and the sum defining $S_N$ is internal.  Thus every
+$\psi\in\mathcal K_{N,L}(\widetilde A)$ has a unique vector decomposition
+\begin{align}
+  \psi=\sum_{j=1}^b\phi_j,
+  \qquad
+  \phi_j\in\mathcal G_N^{A_j}.
+\end{align}
+Since $\mu_j\ne0$, write
+\begin{align}
+  \phi_j=\Gamma_N^{A_j}(\mu_j^NX_j).
+\end{align}
+Equivalently,
+\begin{align}
+  \psi
+  =
+  \Gamma_N^{\widetilde A}\!\left(\bigoplus_{j=1}^bX_j\right)
+\end{align}
+with open-boundary block components.  The present gap is the boundary-condition
+comparison: for every $j$,
+\begin{align}
+  \psi\in\mathcal K_{N,L}(\widetilde A)
+  \quad\Longrightarrow\quad
+  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
+\end{align}
+This is the missing assertion for the block-diagonal boundary representation in
+the range
 \begin{align}
   b\ge2,
   \qquad


### PR DESCRIPTION
### Motivation
- The paper-gap note `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` documents the remaining formalization gap for the block-diagonal parent-Hamiltonian ground-space decomposition (PGVWC07 Theorem 2blocks.2, arXiv:2011.12127 §IV.C). The note's framing no longer matched the current state of the Lean development tracked in #905.
- The previous note described the gap as a length-one span / Condition C1 mismatch; the actual remaining step is the block-diagonal boundary-condition comparison, which is a distinct BNT block-decomposition problem.

### Description
- Updates `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`:
  - Records PGVWC07 propagation into $S_N$ and internal sums as proved, citing the relevant Lean declarations.
  - Reframes the remaining gap as the block-diagonal boundary-condition comparison: showing that block boundary matrices with components in cyclic block ground spaces satisfy the inclusion $\mathcal{G}_{N,L}(B) \subseteq \bigvee_j \mathcal{G}_{N,L}(A_j)$.
  - Rewrites the conclusion around the boundary-matrix target and the conditional reduction to $\sum_j \mathcal{K}_{N,L}(A_j)$.
  - Minor notation cleanup and date bump to 2026-06-11.

### Testing
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

---
Addresses #905

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits to a paper-gap note; no code or proof changes.
>
> **Overview**
> Updates **`cpgsv21_block_diagonal_parent_ground_space.tex`** so the documented Lean boundary matches **#905**: the note no longer frames the gap as a **length-one span / Condition C1 mismatch**, and instead says **product-span** is proved under explicit hypotheses while **finite Condition C1** is derived via normalized BNT injectivity.
>
> It **splits what is done from what is missing**: **PGVWC07 propagation** into \(S_N\) and internal sums are recorded as **proved** (with Lean declaration names), while the **remaining gap** is reframed as the **block-diagonal boundary-condition comparison** (block boundary matrices with components in cyclic block ground spaces), not periodic-chain iteration from the one-step identity alone. The **conclusion** is rewritten around that boundary-matrix target and the conditional reduction to \(\sum_j \mathcal K_{N,L}(A_j)\). Minor **notation** cleanup (\( \) → `$…$`) and a **date** bump to 2026-06-11.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aff0175ce6e955b5b56ac9086723bd99ce58e74d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits to a paper-gap note; no Lean proofs or application code change.
> 
> **Overview**
> Updates **`cpgsv21_block_diagonal_parent_ground_space.tex`** so the documented formalization gap matches the current Lean work on **#905**.
> 
> The note **no longer** describes the open problem as a **length-one span vs. finite Condition C1** mismatch. It now states that **product-span** feeds the one-step PGVWC07 identity and that **finite Condition C1** is obtained via **BNT injectivity**, and it **names Lean theorems** for the proved **cyclic propagation** into \(S_N\) and **internal** block sums.
> 
> The **remaining gap** is reframed as the **block-diagonal boundary-condition comparison** (from \(\mathcal K_{N,L}(\widehat A)\) to periodic block-chain constraints per block), with **\(\widetilde A\)** → **\(\widehat A\)**, explicit **conservative Lean length range**, and **conditional** boundary-closing lemmas distinguished from the source theorem. The **conclusion** is rewritten around the boundary-matrix target and the conditional equality \(\mathcal K_{N,L}(\widehat A)=\sum_j\mathcal K_{N,L}(A_j)\). Minor math-mode cleanup and date **2026-06-11**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b4ece1ee721ae3e1ce8d59dac5670f190df9e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->