### PR TITLE
feat(PEPS): the torus normal Fundamental Theorem capstone and the region-injective scalar condition

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -452,6 +452,7 @@ import TNLean.PEPS.NormalFundamentalTheorem
 import TNLean.PEPS.NormalSquareTIAbsorption
 import TNLean.PEPS.RegionComplementComparison
 import TNLean.PEPS.RegionScalarCondition
+import TNLean.PEPS.TorusFundamentalTheorem
 import TNLean.PEPS.NormalSquareFundamentalTheorem
 -- Region-blocked insertion-algebra isomorphism: the per-edge gauge engine for the
 -- normal PEPS Fundamental Theorem (region analogue of the injective edge gauge).

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -461,6 +461,7 @@ import TNLean.PEPS.RegionBlock.Algebra
 -- closed-state decomposition feeding the region analogue of the physical-to-virtual
 -- recovery.
 import TNLean.PEPS.RegionBlock.Recovery
+import TNLean.PEPS.RegionBlock.GaugeBridge
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -451,6 +451,7 @@ import TNLean.PEPS.FundamentalTheorem.Uniqueness
 import TNLean.PEPS.NormalFundamentalTheorem
 import TNLean.PEPS.NormalSquareTIAbsorption
 import TNLean.PEPS.RegionComplementComparison
+import TNLean.PEPS.RegionScalarCondition
 import TNLean.PEPS.NormalSquareFundamentalTheorem
 -- Region-blocked insertion-algebra isomorphism: the per-edge gauge engine for the
 -- normal PEPS Fundamental Theorem (region analogue of the injective edge gauge).

--- a/TNLean/PEPS/RegionBlock/GaugeBridge.lean
+++ b/TNLean/PEPS/RegionBlock/GaugeBridge.lean
@@ -1,0 +1,202 @@
+import TNLean.PEPS.RegionBlock.Recovery
+import TNLean.PEPS.FundamentalTheorem.EdgeInsertion
+
+/-!
+# Region-level gauge absorption on the region-inserted coefficient
+
+This file ports the open-edge gauge cancellation
+(`edgeInsertedCoeff_applyGauge`) to the region granularity: applying an oriented
+edge-gauge family to a PEPS tensor and reading the region-inserted coefficient on a
+boundary edge `f` of a region `R` equals reading the ungauged region-inserted
+coefficient with the inserted matrix conjugated by the transpose of the open-edge
+gauge `X f`.
+
+The bridge factors through the general-matrix region-to-edge factorization
+`regionInsertedCoeff_eq_smul_edgeInsertedCoeff`: a region-inserted coefficient on a
+boundary edge `f` of `R` equals the bond-dimension product over the edges not
+crossing the boundary of `R` (the overcounting multiplicity `regionInteriorBondProd`)
+times the edge-inserted coefficient on `f` of the assembled physical configuration.
+Because gauge absorption preserves bond dimensions, that multiplicity is unchanged
+by the gauge, so the region bridge reduces to the edge bridge
+`edgeInsertedCoeff_applyGauge`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--586 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The general-matrix double-global-configuration form
+
+The region-inserted coefficient with an arbitrary matrix `M` inserted on the
+boundary edge `f`, in its double-global-configuration form: a sum over pairs of
+global virtual configurations agreeing on every boundary edge of `R` other than
+`f`, weighted by the matrix entry `M` on the two `f`-values. This generalizes
+`regionInsertedCoeff_identity_eq_doubleSum`, which is the `M = 1` case after the
+identity forces agreement on `f` too. -/
+
+open scoped Classical in
+/-- A boundary-fibered double sum collapses to a single sum reading the boundary
+label: summing first over a boundary configuration `μ`, then over the global
+configurations whose region boundary label is `μ`, is the same as summing over all
+global configurations and reading the boundary label off each one. -/
+private theorem sum_regionBoundary_fiber (A : Tensor G d) (R : Finset V)
+    (F : RegionBoundaryConfig (G := G) A R → VirtualConfig A → ℂ) :
+    (∑ μ : RegionBoundaryConfig (G := G) A R,
+      ∑ ζ ∈ Finset.univ.filter
+          (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = μ),
+        F μ ζ) =
+      ∑ ζ : VirtualConfig A, F (regionBoundaryLabel (G := G) A R ζ) ζ := by
+  classical
+  simp only [Finset.sum_filter]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl (fun ζ _ => ?_)
+  rw [Finset.sum_eq_single (regionBoundaryLabel (G := G) A R ζ)]
+  · rw [if_pos rfl]
+  · intro μ _ hμ; rw [if_neg (fun h => hμ h.symm)]
+  · intro h; exact absurd (Finset.mem_univ _) h
+
+open scoped Classical in
+/-- The region-inserted coefficient with inserted matrix `M`, as a double sum over
+pairs of global virtual configurations agreeing on every boundary edge of `R`
+other than `f`, weighted by `M` on the two `f`-values. -/
+theorem regionInsertedCoeff_eq_doubleSum (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      ∑ p ∈ Finset.univ.filter
+          (fun p : VirtualConfig A × VirtualConfig A =>
+            ∀ c : {c : Edge G // IsRegionBoundaryEdge (G := G) R c}, c ≠ f →
+              p.1 c.1 = p.2 c.1),
+        M (p.1 f.1) (p.2 f.1) *
+          (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => p.1 ie.1) (σ w)) *
+            ∏ w : {w : V // w ∈ Finset.univ \ R},
+              A.component w.1 (fun ie => p.2 ie.1) (τ w) := by
+  classical
+  rw [regionInsertedCoeff_eq]
+  -- Expand each blocked-region weight as a filtered sum over global configurations.
+  simp only [regionBlockedWeight]
+  -- Pull each inner pair of weight sums into the (μ, ν) double sum.
+  rw [show (∑ μ : RegionBoundaryConfig (G := G) A R,
+        ∑ ν : RegionBoundaryConfig (G := G) A R,
+          (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+            (∑ ζ ∈ Finset.univ.filter
+                (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = μ),
+              ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+            ∑ ξ ∈ Finset.univ.filter
+              (fun ξ : VirtualConfig A =>
+                regionBoundaryLabel (G := G) A (Finset.univ \ R) ξ =
+                  regionComplementBoundaryConfig (G := G) A R ν),
+              ∏ w : {w : V // w ∈ Finset.univ \ R},
+                A.component w.1 (fun ie => ξ ie.1) (τ w)) =
+      ∑ μ : RegionBoundaryConfig (G := G) A R,
+        ∑ ν : RegionBoundaryConfig (G := G) A R,
+          ∑ ζ ∈ Finset.univ.filter
+              (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = μ),
+            ∑ ξ ∈ Finset.univ.filter
+              (fun ξ : VirtualConfig A => regionBoundaryLabel (G := G) A R ξ = ν),
+              (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+                (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+                  ∏ w : {w : V // w ∈ Finset.univ \ R},
+                    A.component w.1 (fun ie => ξ ie.1) (τ w) from ?_]
+  · -- Reindex the quadruple sum (μ, ν, ζ, ξ) onto the agreeing-off-`f` pair sum.
+    -- Collapse the μ-filter (forcing μ = label ζ) and the ν-filter (forcing ν = label ξ),
+    -- leaving a plain (ζ, ξ) double sum with the coupling read at the boundary labels.
+    rw [show (∑ μ : RegionBoundaryConfig (G := G) A R,
+          ∑ ν : RegionBoundaryConfig (G := G) A R,
+            ∑ ζ ∈ Finset.univ.filter
+                (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = μ),
+              ∑ ξ ∈ Finset.univ.filter
+                (fun ξ : VirtualConfig A => regionBoundaryLabel (G := G) A R ξ = ν),
+                (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+                  (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+                    ∏ w : {w : V // w ∈ Finset.univ \ R},
+                      A.component w.1 (fun ie => ξ ie.1) (τ w)) =
+        ∑ ζ : VirtualConfig A, ∑ ξ : VirtualConfig A,
+          (if SameAwayFromBond f (regionBoundaryLabel (G := G) A R ζ)
+              (regionBoundaryLabel (G := G) A R ξ) then
+            M (regionBoundaryLabel (G := G) A R ζ f) (regionBoundaryLabel (G := G) A R ξ f)
+            else 0) *
+            (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+              ∏ w : {w : V // w ∈ Finset.univ \ R},
+                A.component w.1 (fun ie => ξ ie.1) (τ w) from ?_]
+    · -- Now `(ζ, ξ)` against the agreeing-off-`f` filter; the predicate matches.
+      -- Convert the right-hand filtered pair sum into the `(ζ, ξ)` double sum.
+      rw [Finset.sum_filter, Fintype.sum_prod_type]
+      simp only [SameAwayFromBond, regionBoundaryLabel_apply]
+      refine Finset.sum_congr rfl (fun ζ _ => ?_)
+      refine Finset.sum_congr rfl (fun ξ _ => ?_)
+      by_cases hsame : ∀ c : {c : Edge G // IsRegionBoundaryEdge (G := G) R c}, c ≠ f →
+          ζ c.1 = ξ c.1
+      · rw [if_pos hsame, if_pos hsame]
+      · rw [if_neg hsame, if_neg hsame, zero_mul, zero_mul]
+    · -- Carry out the (μ, ν) collapse using the boundary-fiber lemma twice. First swap
+      -- the `ν`-sum inside the `ζ`-filtered sum so that `(μ, ζ)` are adjacent.
+      rw [show (∑ μ : RegionBoundaryConfig (G := G) A R,
+            ∑ ν : RegionBoundaryConfig (G := G) A R,
+              ∑ ζ ∈ Finset.univ.filter
+                  (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = μ),
+                ∑ ξ ∈ Finset.univ.filter
+                  (fun ξ : VirtualConfig A => regionBoundaryLabel (G := G) A R ξ = ν),
+                  (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+                    (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+                      ∏ w : {w : V // w ∈ Finset.univ \ R},
+                        A.component w.1 (fun ie => ξ ie.1) (τ w)) =
+          ∑ μ : RegionBoundaryConfig (G := G) A R,
+            ∑ ζ ∈ Finset.univ.filter
+                (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A R ζ = μ),
+              ∑ ν : RegionBoundaryConfig (G := G) A R,
+                ∑ ξ ∈ Finset.univ.filter
+                  (fun ξ : VirtualConfig A => regionBoundaryLabel (G := G) A R ξ = ν),
+                  (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+                    (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+                      ∏ w : {w : V // w ∈ Finset.univ \ R},
+                        A.component w.1 (fun ie => ξ ie.1) (τ w) from
+        Finset.sum_congr rfl (fun μ _ => (Finset.sum_comm).symm)]
+      -- Collapse the `(μ, ζ)` fiber, then the `(ν, ξ)` fiber.
+      rw [sum_regionBoundary_fiber A R
+        (fun μ ζ => ∑ ν : RegionBoundaryConfig (G := G) A R,
+          ∑ ξ ∈ Finset.univ.filter
+            (fun ξ : VirtualConfig A => regionBoundaryLabel (G := G) A R ξ = ν),
+            (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+              (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+                ∏ w : {w : V // w ∈ Finset.univ \ R},
+                  A.component w.1 (fun ie => ξ ie.1) (τ w))]
+      refine Finset.sum_congr rfl (fun ζ _ => ?_)
+      rw [sum_regionBoundary_fiber A R
+        (fun ν ξ =>
+          (if SameAwayFromBond f (regionBoundaryLabel (G := G) A R ζ) ν then
+            M (regionBoundaryLabel (G := G) A R ζ f) (ν f) else 0) *
+            (∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1) (σ w)) *
+              ∏ w : {w : V // w ∈ Finset.univ \ R},
+                A.component w.1 (fun ie => ξ ie.1) (τ w))]
+  · -- Distribute each `(μ, ν)` weight factor into the two inner filtered sums.
+    refine Finset.sum_congr rfl (fun μ _ => ?_)
+    refine Finset.sum_congr rfl (fun ν _ => ?_)
+    -- Reassociate the coupling out, distribute the product of sums, then push it back in.
+    rw [mul_assoc, Finset.sum_mul_sum, Finset.mul_sum]
+    refine Finset.sum_congr rfl (fun ζ _ => ?_)
+    rw [Finset.mul_sum]
+    refine Finset.sum_nbij' id id ?_ ?_ (fun _ _ => rfl) (fun _ _ => rfl) ?_
+    · intro ξ hξ
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
+      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R ν ξ).mp hξ
+    · intro ξ hξ
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
+      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R ν ξ).mpr hξ
+    · intro ξ _; simp only [id_eq]; ring
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/GaugeBridge.lean
+++ b/TNLean/PEPS/RegionBlock/GaugeBridge.lean
@@ -2,23 +2,22 @@ import TNLean.PEPS.RegionBlock.Recovery
 import TNLean.PEPS.FundamentalTheorem.EdgeInsertion
 
 /-!
-# Region-level gauge absorption on the region-inserted coefficient
+# General-matrix double-global-configuration form of the region-inserted coefficient
 
-This file ports the open-edge gauge cancellation
-(`edgeInsertedCoeff_applyGauge`) to the region granularity: applying an oriented
-edge-gauge family to a PEPS tensor and reading the region-inserted coefficient on a
-boundary edge `f` of a region `R` equals reading the ungauged region-inserted
-coefficient with the inserted matrix conjugated by the transpose of the open-edge
-gauge `X f`.
+This file gives the general-matrix double-global-configuration form of the
+region-inserted coefficient (`regionInsertedCoeff_eq_doubleSum`): inserting a matrix
+`M` on a boundary edge `f` of a region `R` and contracting `R` against its set
+complement equals a sum over pairs of global virtual configurations agreeing on every
+boundary edge of `R` other than `f`, weighted by the matrix entry of `M` on the two
+`f`-values.
 
-The bridge factors through the general-matrix region-to-edge factorization
-`regionInsertedCoeff_eq_smul_edgeInsertedCoeff`: a region-inserted coefficient on a
-boundary edge `f` of `R` equals the bond-dimension product over the edges not
-crossing the boundary of `R` (the overcounting multiplicity `regionInteriorBondProd`)
-times the edge-inserted coefficient on `f` of the assembled physical configuration.
-Because gauge absorption preserves bond dimensions, that multiplicity is unchanged
-by the gauge, so the region bridge reduces to the edge bridge
-`edgeInsertedCoeff_applyGauge`.
+This generalizes `regionInsertedCoeff_identity_eq_doubleSum`, the `M = 1` case where
+the identity forces agreement on `f` too. It is the region-granularity analogue of
+the open-bond expansion `edgeInsertedCoeff_eq_pairSum`, and the starting point for
+porting the open-edge gauge cancellation `edgeInsertedCoeff_applyGauge` to the region
+granularity: the two boundary configurations decouple only on `f`, where the gauge
+on the open edge survives and conjugates the inserted matrix, while every other
+boundary edge and every interior edge cancels pairwise.
 
 ## References
 

--- a/TNLean/PEPS/RegionScalarCondition.lean
+++ b/TNLean/PEPS/RegionScalarCondition.lean
@@ -1,0 +1,106 @@
+import TNLean.PEPS.RegionComplementComparison
+import TNLean.PEPS.RegionBlock.BlockRangeCoincidence
+
+/-!
+# The per-vertex scalar condition for region-injective normal PEPS
+
+This file proves the region-injective form of the per-vertex scalar condition of
+the normal PEPS Fundamental Theorem (arXiv:1804.04964, Section 3, Theorem 3, the
+passage after `eq:inj_equal_edge`, lines 1453--1471 of
+`Papers/1804.04964/paper_normal.tex`).
+
+For the injective square-lattice theorem
+(`TNLean.PEPS.prod_perVertexScalar_eq_one`) the nonvanishing state coefficient is
+supplied by vertex injectivity (`exists_stateCoeff_ne_zero`). The normal theorem
+assumes injectivity only *after blocking*, so vertex injectivity is unavailable.
+Here the nonvanishing state coefficient is supplied instead by the region-injective
+existence lemma `exists_stateCoeff_ne_zero_of_regionInjective`: a single region `R`
+together with its set complement, both blocked-tensor injective, with positive
+bonds, already forces a nonzero closed state coefficient. The rest of the argument
+(substituting the per-vertex relation, factoring out the scalar product, and
+cancelling with `applyGauge_stateCoeff`) is identical to the injective case.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Theorem 3,
+  lines 1453--1471 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- **The per-vertex scalars multiply to one (region-injective form).**
+
+If the per-vertex scalars `c` relate `A` to the gauge action of the second tensor
+family at every vertex (`A_v = c_v · gaugeVertex B Z v`), then under
+`SameState A B`, positive bonds, and a single region `R` whose block and complement
+block are both blocked-tensor injective, the nonvanishing closed state equality
+forces `∏_v c_v = 1`.
+
+This is the region-injective analogue of `prod_perVertexScalar_eq_one`: the
+nonvanishing state coefficient comes from region injectivity of `R` and its set
+complement (`exists_stateCoeff_ne_zero_of_regionInjective`) rather than from vertex
+injectivity. The substitution of the per-vertex relation into the state contraction,
+the factoring of `∏_v c_v`, and the cancellation against
+`applyGauge_stateCoeff B Z` are the same as in the injective case.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3, the passage after
+`eq:inj_equal_edge`, lines 1453--1471 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem prod_perVertexScalar_eq_one_of_regionInjective (A B : Tensor G d)
+    (R : Finset V)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e)
+    (hAB : SameState A B)
+    (Z : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (hbd : A.bondDim = B.bondDim)
+    (c : V → ℂ)
+    (hPV : ∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+      A.component v η σ =
+        c v * gaugeVertex B Z v (fun ie => Fin.cast (congr_fun hbd ie.1) (η ie)) σ) :
+    (∏ v, c v) = 1 := by
+  classical
+  have hkey : ∀ σ : V → Fin d,
+      stateCoeff A σ = (∏ v, c v) * stateCoeff (applyGauge B Z) σ := by
+    intro σ
+    have hAcoeff : stateCoeff A σ
+        = ∑ η : VirtualConfig A,
+            (∏ v, c v) * ∏ v, gaugeVertex B Z v
+              (fun ie => Fin.cast (congr_fun hbd ie.1) (η ie.1)) (σ v) := by
+      unfold stateCoeff
+      refine Finset.sum_congr rfl (fun η _ => ?_)
+      rw [← Finset.prod_mul_distrib]
+      refine Finset.prod_congr rfl (fun v _ => ?_)
+      exact hPV v (fun ie => η ie.1) (σ v)
+    rw [hAcoeff, ← Finset.mul_sum]
+    have hsum : (∑ η : VirtualConfig A, ∏ v, gaugeVertex B Z v
+            (fun ie => Fin.cast (congr_fun hbd ie.1) (η ie.1)) (σ v))
+        = stateCoeff (applyGauge B Z) σ := by
+      unfold stateCoeff
+      refine Fintype.sum_equiv
+        (Equiv.piCongrRight (fun e => finCongr (congr_fun hbd e)))
+        (fun η : VirtualConfig A => ∏ v, gaugeVertex B Z v
+            (fun ie => Fin.cast (congr_fun hbd ie.1) (η ie.1)) (σ v))
+        (fun ηB => ∏ v, (applyGauge B Z).component v (fun ie => ηB ie.1) (σ v))
+        (fun η => ?_)
+      refine Finset.prod_congr rfl (fun v _ => ?_)
+      rfl
+    rw [hsum]
+  obtain ⟨σ, hσ⟩ := exists_stateCoeff_ne_zero_of_regionInjective A R hRA hCA hpos
+  have hBσ : stateCoeff (applyGauge B Z) σ = stateCoeff A σ := by
+    rw [applyGauge_stateCoeff B Z σ, ← hAB σ]
+  have h1 : stateCoeff A σ = (∏ v, c v) * stateCoeff A σ :=
+    (hkey σ).trans (by rw [hBσ])
+  have h2 : (∏ v, c v) * stateCoeff A σ = 1 * stateCoeff A σ := by
+    rw [one_mul]; exact h1.symm
+  exact mul_right_cancel₀ hσ h2
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusFundamentalTheorem.lean
+++ b/TNLean/PEPS/TorusFundamentalTheorem.lean
@@ -1,0 +1,167 @@
+import TNLean.PEPS.RegionScalarCondition
+import TNLean.PEPS.TorusWitnessCapstone
+
+/-!
+# The normal PEPS Fundamental Theorem on the discrete torus
+
+This file assembles the scalar condition of the translationally invariant normal
+PEPS Fundamental Theorem on the discrete torus (arXiv:1804.04964, Section 3,
+Theorem 3, lines 1453--1471 of `Papers/1804.04964/paper_normal.tex`).
+
+The source theorem concludes that two normal translationally invariant PEPS that
+generate the same state on an `n × m` region with `n, m ≥ 7` are related by a
+gauge transformation `B = λ · (X, Y\text{-action on } A)` with `λ^{n·m} = 1` and
+`X, Y` invertible, unique up to a multiplicative constant. The orientation-uniform
+gauge family `(X, Y)` on the torus is produced unconditionally from the rectangle
+injectivity hypotheses (`isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle`).
+The final region comparison `A ∝ B̃` of the `R`/`S` regions gives the per-vertex
+relation `A_v = λ · gaugeVertex B Z v`; this file consumes that relation and proves
+the scalar condition `λ^{width·height} = 1`.
+
+The per-vertex relation is the output of the `R`/`S` region comparison
+(`RegionComplementComparison.regionComplement_comparison`); this capstone takes it
+as a hypothesis, exactly as the square-lattice
+`fundamentalTheorem_normalSquarePEPS` does, and discharges the scalar condition on
+top of it. The nonvanishing state coefficient needed for the scalar cancellation
+is supplied by region injectivity of a single comparison region and its complement
+(`prod_perVertexScalar_eq_one_of_regionInjective`), so no vertex injectivity of `A`
+is assumed: only injectivity after blocking, as the source requires.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Theorem 3,
+  lines 1449--1471 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+
+/-! ### The number of torus sites -/
+
+/-- The number of vertices of the discrete `width × height` torus is
+`width · height`. -/
+theorem card_torusVertex (width height : ℕ) [NeZero width] [NeZero height] :
+    Fintype.card (TorusVertex width height) = width * height := by
+  simp [TorusVertex, Fintype.card_prod, ZMod.card]
+
+/-! ### The scalar condition `λ^{width·height} = 1` on the torus -/
+
+/-- **The scalar condition `λ^{width·height} = 1` on the torus.**
+
+If a single scalar `λ` relates `A` to the gauge action of the second tensor at
+every torus vertex (`A_v = λ · gaugeVertex B Z v`, the translationally invariant
+per-vertex relation, all `c_v` equal to `λ`), then under the same state, positive
+bonds, and a single comparison region `R` whose block and complement block are both
+blocked-tensor injective, `λ` raised to the number of torus sites is one:
+`λ^{width·height} = 1`.
+
+This is the torus scalar condition of arXiv:1804.04964, Section 3, Theorem 3
+(line 1471: `λ^{n·m} = 1`). It follows from
+`prod_perVertexScalar_eq_one_of_regionInjective`: under translation invariance the
+per-vertex scalars are all equal to `λ`, so their product over the `width × height`
+torus is `λ^{width·height}`, and the region-injective nonvanishing state equality
+forces that product to be one.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3, line 1471 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem lambda_pow_card_torus_eq_one [Fact (1 < width)] [Fact (1 < height)]
+    (A B : Tensor (torusGraph width height) d)
+    (R : Finset (TorusVertex width height))
+    (hRA : RegionBlockedTensorInjective (G := torusGraph width height) A R)
+    (hCA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (Finset.univ \ R))
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (hAB : SameState A B)
+    (Z : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (hbd : A.bondDim = B.bondDim)
+    (lam : ℂ)
+    (hPV : ∀ (v : TorusVertex width height)
+      (η : (ie : IncidentEdge (torusGraph width height) v) → Fin (A.bondDim ie.1))
+      (σ : Fin d),
+      A.component v η σ =
+        lam * gaugeVertex B Z v (fun ie => Fin.cast (congr_fun hbd ie.1) (η ie)) σ) :
+    lam ^ (width * height) = 1 := by
+  have hprod := prod_perVertexScalar_eq_one_of_regionInjective A B R hRA hCA hpos hAB Z hbd
+    (fun _ => lam) hPV
+  rw [Finset.prod_const, Finset.card_univ, card_torusVertex width height] at hprod
+  exact hprod
+
+/-! ### The torus Fundamental Theorem
+
+The capstone gathers the two layers of Theorem 3 on the torus: the
+orientation-uniform gauge family `(X, Y)` produced from the rectangle injectivity
+hypotheses, and the scalar condition `λ^{width·height} = 1` produced from the
+per-vertex comparison relation. -/
+
+/-- **Normal PEPS Fundamental Theorem on the torus.**
+
+For a translation-invariant pair `A`, `B` on the discrete torus with matched bond
+dimensions, positive bonds, the same state, and both satisfying the
+rectangular-injectivity hypotheses with union closure, there is an
+orientation-uniform-up-to-scalar gauge family `X` (the source's horizontal and
+vertical matrices, the same on every edge of each orientation class), and for any
+single scalar `λ` whose gauge action relates `A` to `B` at every vertex against
+that family --- the output of the `R`/`S` region comparison `A ∝ B̃` --- and any
+comparison region `R` whose block and complement block over `A` are blocked-tensor
+injective, `λ` satisfies the scalar condition `λ^{width·height} = 1`.
+
+This is the torus form of Theorem 3 (arXiv:1804.04964, Section 3, lines 1453--1471
+of `Papers/1804.04964/paper_normal.tex`): `B = λ · (X, Y\text{-action on } A)` with
+`λ^{n·m} = 1`. The gauge family is produced unconditionally from the rectangle
+hypotheses (`isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle`). The
+per-vertex relation `hPV` is the conditional input, the comparison output `A ∝ B̃`,
+exactly as in the square-lattice `fundamentalTheorem_normalSquarePEPS`; the scalar
+condition is discharged on top of it by `lambda_pow_card_torus_eq_one`, whose
+nonvanishing state coefficient comes from region injectivity rather than vertex
+injectivity.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1471 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalTorusPEPS [Fact (1 < width)] [Fact (1 < height)]
+    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (hAr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hBr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
+    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
+    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
+    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
+    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
+    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (R : Finset (TorusVertex width height))
+    (hRA : RegionBlockedTensorInjective (G := torusGraph width height) A R)
+    (hCA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (Finset.univ \ R)) :
+    ∃ (X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ),
+      IsTorusOrientationUniformGaugeFamilyModScalar
+          (torusUniformBondDim_of_translationInvariant hB) X ∧
+        ∀ (lam : ℂ),
+          (∀ (v : TorusVertex width height)
+            (η : (ie : IncidentEdge (torusGraph width height) v) → Fin (A.bondDim ie.1))
+            (σ : Fin d),
+            A.component v η σ =
+              lam * gaugeVertex B X v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ) →
+            lam ^ (width * height) = 1 := by
+  obtain ⟨X, hX⟩ := isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle
+    hA hB hAr hBr hUA hUB hxh0 hyh0 hxhw hyhh hxhw' hyhh' hxv0 hyv0 hxvw hyvh hxvw' hyvh'
+    hbond hAB hd hposA hposB
+  refine ⟨X, hX, fun lam hPV => ?_⟩
+  exact lambda_pow_card_torus_eq_one A B R hRA hCA hposA hAB X hbond lam hPV
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -5218,6 +5218,29 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $\lambda^{nm}=1$. The unconditional source theorem awaits the per-edge gauge.
 \end{theorem}
 
+\begin{theorem}[Fundamental Theorem for normal PEPS on the torus]%
+    \label{thm:fundamentalTheorem_normalTorusPEPS}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS}
+    \notready
+    \uses{thm:fundamentalTheorem_normalSquarePEPS,
+        thm:peps_oneVertexComplementComparison,
+        def:GaugeEquivPEPS}
+    Let $A$ and $B$ be translationally invariant normal PEPS on the discrete
+    torus such that every $2\times 3$ and $3\times 2$ region is injective. If
+    they generate the same state on an $n\times m$ region with $n,m\geq 7$, then
+    they are related by horizontal and vertical gauges $X,Y$, up to a scalar
+    $\lambda$ satisfying $\lambda^{nm}=1$. This is
+    \cite[Theorem~3]{Molnar2018NormalPEPS} on the torus geometry, where every
+    edge is interior and translation acts freely.
+    The horizontal and vertical gauge family is produced unconditionally from the
+    rectangle injectivity hypotheses. The Lean statement records the per-vertex
+    single-scalar relation against that family --- the output of the final region
+    comparison $A\propto\widetilde B$ --- as a hypothesis, exactly as the
+    square-lattice statement does, and derives the scalar condition
+    $\lambda^{nm}=1$ on top of it. The nonvanishing state coefficient is supplied
+    by region injectivity of a single comparison region, not vertex injectivity.
+\end{theorem}
+
 \begin{definition}[Normal PEPS blocking hypotheses]%
     \label{def:peps_normalPEPSBlockingHypotheses}
     \lean{TNLean.PEPS.NormalPEPSBlockingHypotheses}


### PR DESCRIPTION
## What

**`fundamentalTheorem_normalTorusPEPS`** — the translation-invariant Normal PEPS
Fundamental Theorem on the torus (#1373, arXiv:1804.04964 §3 Theorem 3, lines 1453–1471):
from a TI pair + SameState + positivity + the source's rectangle-injectivity hypotheses +
window sizes, the orientation-uniform gauge family `X` is produced **unconditionally**, and
the scalar condition `λ^{width·height} = 1` follows for any λ satisfying the per-vertex
relation — the same conditional framing as the square-lattice version (the `hPV` input =
the R/S comparison output). All sorry-free; `#print axioms` =
`[propext, Classical.choice, Quot.sound]`; full root build green (8,873 jobs).

## Highlights

- **`prod_perVertexScalar_eq_one_of_regionInjective`** — the per-vertex scalar condition
  from REGION injectivity of one comparison region + complement (via the merged
  region-injective nonvanishing): **no vertex injectivity of A anywhere** — faithful to
  the source, which assumes injectivity only after blocking.
- **`fundamentalTheorem_normalTorusPEPS`** + `lambda_pow_card_torus_eq_one` +
  `card_torusVertex`.
- **`regionInsertedCoeff_eq_doubleSum`** (GaugeBridge.lean) — the general-matrix
  double-configuration form, the combinatorial half of the region gauge-absorption bridge
  (the remaining f-decoupled merge is documented with its full route).
- Blueprint: the faithful `thm:fundamentalTheorem_normalTorusPEPS` node (`\lean{}` +
  `\notready`, matching the square-lattice node's conditional framing).

## Remaining (documented)

Deriving `hPV` (the R/S one-site comparison combination — the same conditional input the
square-lattice version carries) and the bridge's f-decoupled merge (~150–200 lines, route
written out in the gap note).

Refs #1373. CI failures are non-blocking automation (PyPI blips: rerun).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean proofs and blueprint/docs only; no runtime, auth, or data-path changes. Remaining math gaps (deriving hPV, gauge merge) are documented, not silently assumed.
> 
> **Overview**
> Adds the **torus normal PEPS Fundamental Theorem** capstone (`fundamentalTheorem_normalTorusPEPS`): it builds the orientation-uniform gauge family from rectangle injectivity (via existing torus witness machinery) and, given the per-vertex single-scalar relation `hPV` as a hypothesis (same conditional framing as the square-lattice theorem), proves **λ^{width·height} = 1**.
> 
> Introduces **`prod_perVertexScalar_eq_one_of_regionInjective`**, which derives ∏_v c_v = 1 using a nonzero closed state coefficient from **blocked region injectivity** of one region and its complement—not vertex injectivity—matching the normal-theorem paper assumptions.
> 
> Adds **`regionInsertedCoeff_eq_doubleSum`** in `GaugeBridge.lean`: general-matrix double-configuration expansion for region-inserted coefficients (combinatorial step toward region-level gauge absorption).
> 
> Wires new modules into **`TNLean.lean`** and documents **`thm:fundamentalTheorem_normalTorusPEPS`** in the blueprint (`\notready`, conditional on `hPV` like the square node).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 675e246010af8a1993219cd779482d8b3bf204ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->