### PR TITLE
feat(PEPS): the gauge-bridge pair products toward the absorbed-coefficient identity

### DIFF
--- a/TNLean/PEPS/RegionBlock/GaugeBridge.lean
+++ b/TNLean/PEPS/RegionBlock/GaugeBridge.lean
@@ -272,7 +272,7 @@ theorem regionComplProd_gauge_eq (B : Tensor G d) (R : Finset V)
         (assembleRegionσ (V := V) (d := d) R σ τ w))]
     refine Finset.prod_congr rfl (fun w _ => ?_)
     have hw : w.1 ∉ R := by have := w.2; rw [Finset.mem_sdiff] at this; exact this.2
-    show gaugeVertex B Z w.1 _ _ = _
+    change gaugeVertex B Z w.1 _ _ = _
     rw [assembleRegionσ_notMem]
     congr 1
     funext ie
@@ -281,7 +281,7 @@ theorem regionComplProd_gauge_eq (B : Tensor G d) (R : Finset V)
       (fun w => gaugeVertex B Z w (pairOuter (G := G) B R p w)
         (assembleRegionσ (V := V) (d := d) R σ τ w))]
     refine Finset.prod_congr rfl (fun w _ => ?_)
-    show gaugeVertex B Z w.1 _ _ = _
+    change gaugeVertex B Z w.1 _ _ = _
     rw [assembleRegionσ_mem]
     congr 1
     funext ie

--- a/TNLean/PEPS/RegionBlock/GaugeBridge.lean
+++ b/TNLean/PEPS/RegionBlock/GaugeBridge.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.RegionBlock.Recovery
+import TNLean.PEPS.RegionBlock.Insertion
 import TNLean.PEPS.FundamentalTheorem.EdgeInsertion
 
 /-!
@@ -18,6 +19,17 @@ porting the open-edge gauge cancellation `edgeInsertedCoeff_applyGauge` to the r
 granularity: the two boundary configurations decouple only on `f`, where the gauge
 on the open edge survives and conjugates the inserted matrix, while every other
 boundary edge and every interior edge cancels pairwise.
+
+The file also records the first stage of that gauge-cancellation bridge
+(`regionComplProd_gauge_eq`): the region weight of a gauged tensor against the complement
+weight of an agreeing pair is one global gauge-vertex product over all vertices, reading the
+first configuration on the region and the second on the complement (`pairOuter`), with the
+physical legs assembled.  This brings the double-sum form of the gauged region-inserted
+coefficient into the single global gauge-vertex product whose `edgeGaugeAt` factors are ready
+to cancel edgewise.  The remaining stage of the bridge --- the gauge sum over the agreeing
+pair, so that interior edges cancel to consistency deltas while the boundary edge `f`
+conjugates the inserted matrix --- is the open obligation recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 ## References
 
@@ -196,6 +208,84 @@ theorem regionInsertedCoeff_eq_doubleSum (A : Tensor G d) (R : Finset V)
       simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
       exact (regionBoundaryLabel_compl_eq_iff (G := G) A R ν ξ).mpr hξ
     · intro ξ _; simp only [id_eq]; ring
+
+/-! ### The gauge-cancellation bridge
+
+The region-inserted coefficient of a gauged tensor `applyGauge B Z`, in its
+double-global-configuration form, expands each region and complement vertex weight as a
+gauge-vertex sum.  Collecting the per-vertex inner configurations into one global local
+configuration `ξ`, the gauge factors `edgeGaugeAt` over all vertices factor edgewise: every
+interior edge of `R` and of its complement cancels to a consistency delta on `ξ`, while the
+two endpoints of the single boundary edge `f` survive and conjugate the inserted matrix.  This
+is the region-granularity port of `edgeInsertedCoeff_applyGauge`. -/
+
+/-- The outer reading at a vertex of an agreeing pair: the region side reads the first
+configuration, the complement side reads the second.  This is the global outer configuration
+whose gauge factors cancel against the per-vertex inner configurations. -/
+noncomputable def pairOuter (B : Tensor G d) (R : Finset V)
+    (p : VirtualConfig B × VirtualConfig B) :
+    OpenLocalConfig (G := G) B :=
+  fun v _ie => if v ∈ R then p.1 _ie.1 else p.2 _ie.1
+
+omit [Fintype V] in
+/-- A region vertex reads the first configuration in `pairOuter`. -/
+theorem pairOuter_mem (B : Tensor G d) (R : Finset V)
+    (p : VirtualConfig B × VirtualConfig B) {v : V} (hv : v ∈ R)
+    (ie : IncidentEdge G v) : pairOuter (G := G) B R p v ie = p.1 ie.1 := by
+  simp [pairOuter, hv]
+
+omit [Fintype V] in
+/-- A complement vertex reads the second configuration in `pairOuter`. -/
+theorem pairOuter_not_mem (B : Tensor G d) (R : Finset V)
+    (p : VirtualConfig B × VirtualConfig B) {v : V} (hv : v ∉ R)
+    (ie : IncidentEdge G v) : pairOuter (G := G) B R p v ie = p.2 ie.1 := by
+  simp [pairOuter, hv]
+
+open scoped Classical in
+/-- The region weight against the complement weight of an agreeing pair, with the gauged
+tensor, expands as a single global gauge-vertex product over all vertices: the region side
+reads the first configuration, the complement side the second, and the physical legs assemble.
+
+This is the first stage of the region-granularity gauge-cancellation bridge: it brings the
+double-global-configuration form of the gauged region-inserted coefficient
+(`regionInsertedCoeff_eq_doubleSum`) into the single global gauge-vertex product whose
+`edgeGaugeAt` factors cancel edgewise.  The remaining stage --- summing the gauge factors over
+the agreeing pair, so that interior edges of `R` and of its complement cancel to consistency
+deltas while the two endpoints of the boundary edge `f` conjugate the inserted matrix --- is
+the open obligation recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+theorem regionComplProd_gauge_eq (B : Tensor G d) (R : Finset V)
+    (Z : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R))
+    (p : VirtualConfig B × VirtualConfig B) :
+    (∏ w : {w : V // w ∈ R}, (applyGauge B Z).component w.1 (fun ie => p.1 ie.1) (σ w)) *
+        ∏ w : {w : V // w ∈ Finset.univ \ R},
+          (applyGauge B Z).component w.1 (fun ie => p.2 ie.1) (τ w) =
+      ∏ v : V, gaugeVertex B Z v (pairOuter (G := G) B R p v)
+        (assembleRegionσ (V := V) (d := d) R σ τ v) := by
+  classical
+  rw [← Finset.prod_sdiff (Finset.subset_univ R), mul_comm]
+  congr 1
+  · rw [Finset.prod_subtype (Finset.univ \ R)
+      (p := fun w => w ∈ Finset.univ \ R) (fun w => Iff.rfl)
+      (fun w => gaugeVertex B Z w (pairOuter (G := G) B R p w)
+        (assembleRegionσ (V := V) (d := d) R σ τ w))]
+    refine Finset.prod_congr rfl (fun w _ => ?_)
+    have hw : w.1 ∉ R := by have := w.2; rw [Finset.mem_sdiff] at this; exact this.2
+    show gaugeVertex B Z w.1 _ _ = _
+    rw [assembleRegionσ_notMem]
+    congr 1
+    funext ie
+    exact (pairOuter_not_mem (G := G) B R p hw ie).symm
+  · rw [Finset.prod_subtype R (p := fun w => w ∈ R) (fun w => Iff.rfl)
+      (fun w => gaugeVertex B Z w (pairOuter (G := G) B R p w)
+        (assembleRegionσ (V := V) (d := d) R σ τ w))]
+    refine Finset.prod_congr rfl (fun w _ => ?_)
+    show gaugeVertex B Z w.1 _ _ = _
+    rw [assembleRegionσ_mem]
+    congr 1
+    funext ie
+    exact (pairOuter_mem (G := G) B R p w.2 ie).symm
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/GaugeBridge.lean
+++ b/TNLean/PEPS/RegionBlock/GaugeBridge.lean
@@ -287,5 +287,40 @@ theorem regionComplProd_gauge_eq (B : Tensor G d) (R : Finset V)
     funext ie
     exact (pairOuter_mem (G := G) B R p w.2 ie).symm
 
+open scoped Classical in
+/-- The ungauged region weight against the complement weight of an agreeing pair is one global
+vertex product over all vertices, reading the first configuration on the region and the second
+on the complement.  This is the gauge-free special case of `regionComplProd_gauge_eq`. -/
+theorem regionComplProd_eq (B : Tensor G d) (R : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R))
+    (p : VirtualConfig B × VirtualConfig B) :
+    (∏ w : {w : V // w ∈ R}, B.component w.1 (fun ie => p.1 ie.1) (σ w)) *
+        ∏ w : {w : V // w ∈ Finset.univ \ R},
+          B.component w.1 (fun ie => p.2 ie.1) (τ w) =
+      ∏ v : V, B.component v (pairOuter (G := G) B R p v)
+        (assembleRegionσ (V := V) (d := d) R σ τ v) := by
+  classical
+  rw [← Finset.prod_sdiff (Finset.subset_univ R), mul_comm]
+  congr 1
+  · rw [Finset.prod_subtype (Finset.univ \ R)
+      (p := fun w => w ∈ Finset.univ \ R) (fun w => Iff.rfl)
+      (fun w => B.component w (pairOuter (G := G) B R p w)
+        (assembleRegionσ (V := V) (d := d) R σ τ w))]
+    refine Finset.prod_congr rfl (fun w _ => ?_)
+    have hw : w.1 ∉ R := by have := w.2; rw [Finset.mem_sdiff] at this; exact this.2
+    rw [assembleRegionσ_notMem]
+    congr 1
+    funext ie
+    exact (pairOuter_not_mem (G := G) B R p hw ie).symm
+  · rw [Finset.prod_subtype R (p := fun w => w ∈ R) (fun w => Iff.rfl)
+      (fun w => B.component w (pairOuter (G := G) B R p w)
+        (assembleRegionσ (V := V) (d := d) R σ τ w))]
+    refine Finset.prod_congr rfl (fun w _ => ?_)
+    rw [assembleRegionσ_mem]
+    congr 1
+    funext ie
+    exact (pairOuter_mem (G := G) B R p w.2 ie).symm
+
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1776,6 +1776,55 @@ The remaining obligations are the following.
           Formal declarations:
           \leanid{TNLean.PEPS.regionComplement_comparison} and
           \leanid{TNLean.PEPS.regionComplement_comparison_of_vertexInjective}.}
+
+          The region-inserted-coefficient equality consumed by the region comparison is the
+          \emph{absorbed} form: \(A\) inserting \(M\) on \(f\) matches \(\widetilde B=
+          \operatorname{applyGauge} B\,X\) inserting the same \(M\) on \(f\). The per-edge gauge
+          delivered by the blocking is, however, the \emph{conjugation} form: \(A\) inserting
+          \(M\) matches \(B\) inserting \(X^{\mathsf T} M (X^{-1})^{\mathsf T}\) on \(f\). The
+          bridge between the two is the region-granularity port of the open-edge gauge
+          cancellation \leanid{TNLean.PEPS.edgeInsertedCoeff_applyGauge}: inserting \(M\) on the
+          gauged tensor cancels every interior gauge of the region and of its complement and
+          conjugates \(M\) by the gauge on the single boundary edge \(f\). Its first stage is
+          formalized: the double-global-configuration form of the gauged region-inserted
+          coefficient (\leanid{TNLean.PEPS.regionInsertedCoeff_eq_doubleSum}) has its region and
+          complement vertex weights collected into one global gauge-vertex product over all
+          vertices, the region side reading the first configuration of the agreeing pair and the
+          complement side the second (\leanid{TNLean.PEPS.pairOuter}), with the physical legs
+          assembled (\leanid{TNLean.PEPS.regionComplProd_gauge_eq}); the same identity holds
+          gauge-free for the ungauged tensor (\leanid{TNLean.PEPS.regionComplProd_eq}), so both
+          sides of the bridge are single global products over \leanid{TNLean.PEPS.pairOuter}. The
+          remaining stage is the gauge sum over the agreeing pair: expanding each gauge-vertex
+          into its inner-configuration sum and factoring the \leanid{TNLean.PEPS.edgeGaugeAt}
+          product edgewise, every interior edge of the region and of its complement contracts a
+          gauge against its inverse to a consistency delta on the inner configuration (with the
+          unread half of the pair on that edge summing to the interior bond multiplicity, the
+          same multiplicity carried by the ungauged double sum), while the two endpoints of \(f\)
+          survive and conjugate \(M\). This is the region analogue of the closed-network
+          cancellation \leanid{TNLean.PEPS.applyGauge_stateCoeff} with the bond \(f\) left open,
+          and is the open obligation; the modular sublemma is the gauge action on the blocked
+          region weight (the gauge cancels inside the region and acts only on the boundary
+          configuration), after which the region-inserted-coefficient bridge follows by
+          substitution into \leanid{TNLean.PEPS.regionInsertedCoeff_eq}.
+
+          On the torus the per-edge coefficient identity is currently produced at a single
+          boundary edge of each \emph{red blocking region} of the orientation-uniform family
+          (\leanid{TNLean.PEPS.exists_regionEdgeGauge_torus_coeff},
+          \leanid{TNLean.PEPS.isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle}). The
+          per-vertex relation \(A_v=\lambda\cdot\operatorname{gaugeVertex} B\,X\,v\) that the
+          torus Fundamental Theorem
+          (\leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS}) takes as the hypothesis
+          \path{hPV} requires, in addition to the bridge above, extending that identity to the
+          source comparison regions \(R\) and \(S\) (which differ in one site, both blocked-tensor
+          injective with injective complements), feeding the absorbed equality to
+          \leanid{TNLean.PEPS.regionComplement_comparison} at \(R\) and at \(S\) to obtain
+          \(A_R\propto\widetilde B_R\) and \(A_S\propto\widetilde B_S\), and quotienting the two
+          region proportionalities to isolate the single differing vertex. The block-granularity
+          one-site quotient that performs this isolation without single-vertex injectivity --- the
+          region analogue of \leanid{TNLean.PEPS.perVertexScalar}, whose present form rests on
+          \leanid{TNLean.PEPS.one_vertex_complement_comparison} and edge-level vertex injectivity
+          --- is not yet built, so \path{hPV} remains the conditional input of the torus theorem
+          rather than a derived consequence.
     \item Prove the scalar condition $\lambda^{nm}=1$ for the square-lattice
           theorem, and state separately the scalar freedom in the non-translation
           invariant normal theorem.


### PR DESCRIPTION
## What

The first stage of the region gauge-absorption bridge for the TI Normal PEPS FT (#1373):
the agreeing-pair outer configuration and the single global gauge-vertex product forms of
both sides of the bridge. All sorry-free; `#print axioms` =
`[propext, Classical.choice, Quot.sound]`; full root build green (8,873 jobs).

- **`pairOuter`** (+ membership lemmas) — the global outer configuration of an agreeing pair.
- **`regionComplProd_gauge_eq`** — the gauged region weight × complement weight = one global
  gauge-vertex product (the `edgeGaugeAt` factors positioned for edgewise cancellation).
- **`regionComplProd_eq`** — the gauge-free companion.

## Remaining (documented in the route note)

1. The bridge's second stage: the edgewise gauge sum (interior edges cancel to consistency
   deltas; f's endpoints conjugate the matrix) — the region analogue of
   `applyGauge_stateCoeff` with f open; modular sublemma `regionBlockedWeight_applyGauge`.
2. The block-granularity one-site R/S quotient (the region analogue of `perVertexScalar`)
   feeding `hPV`.

Refs #1373. CI failures are non-blocking automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in PEPS region-block theory; no runtime, auth, or infrastructure changes.
> 
> **Overview**
> Adds the **first stage** of the region-level gauge-absorption bridge toward matching absorbed vs conjugation region-inserted coefficients.
> 
> In **`GaugeBridge.lean`**, introduces **`pairOuter`** (region reads first virtual config, complement reads second) with membership lemmas, then proves **`regionComplProd_gauge_eq`** and **`regionComplProd_eq`**: agreeing-pair region × complement vertex products collapse to a single global product over all vertices using **`pairOuter`** and assembled physical legs (gauged via **`gaugeVertex`**, ungauged via **`component`**). This positions **`edgeGaugeAt`** factors for the planned edgewise cancellation, paralleling **`edgeInsertedCoeff_applyGauge`** at region granularity.
> 
> The **route note** documents this stage, the open second stage (gauge sum / interior cancellation / boundary **`f`** conjugation), and how the bridge feeds torus **`hPV`** and region comparison obligations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd3a76144883d307e17faf687c7eb23cb87b8e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->