### PR TITLE
feat(MPS/ParentHamiltonian): finite-range equality from block-boundary data

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -420,9 +420,11 @@ lies in \(\mathcal G_{N,L}(A_j)\). Then
 \[
   \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j).
 \]
-The remaining PGVWC07/CPGSV21 step is to obtain such a block-diagonal periodic
-boundary representation from the periodic constraints; compare PGVWC07, Theorem
-2blocks.2, proof lines 1454--1456, and arXiv:2011.12127, lines 2126--2128. -/
+The remaining source step is to obtain such a block-diagonal periodic boundary
+representation from the periodic constraints; compare Perez-Garcia, Verstraete,
+Wolf, and Cirac (arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1454--1456)
+and Cirac, Perez-Garcia, Schuch, and Verstraete (arXiv:2011.12127, lines
+2126--2128). -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -440,6 +442,71 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_gr
   rcases hBoundary ψ hψ with ⟨X, hψX, hX⟩
   rw [hψX]
   exact groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace μ A X hX
+
+/-- Block-diagonal boundary conditions give the periodic block-chain equality in
+the finite injectivity range.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j.
+\]
+Assume the normalized BNT block-separation hypotheses and the finite injectivity
+range. Suppose that every vector in \(\mathcal G_{N,L}(B)\) has a
+block-diagonal boundary representation
+\[
+  \psi=\Gamma_N^B\!\left(\bigoplus_jX_j\right)
+\]
+whose \(j\)-th component vector
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)
+\]
+belongs to \(\mathcal G_{N,L}(A_j)\). Then
+\[
+  \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j),
+\]
+and the sum \(\bigvee_jG_N(A_j)\) is internal.
+
+The remaining source step is to obtain the displayed block-diagonal boundary
+representation from the inverting-and-re-growing argument in Perez-Garcia,
+Verstraete, Wolf, and Cirac (arXiv:quant-ph/0608197) and Cirac, Perez-Garcia, Schuch,
+and Verstraete (arXiv:2011.12127), with block-diagonal boundary conditions. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hBoundary : ∀ ψ : NSiteSpace d N,
+      ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+          ∀ j : Fin r,
+            groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  have hClose :
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, chainGroundSpace (A j) L N :=
+    chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap
+      μ A hBoundary
+  refine ⟨?_, ?_⟩
+  · exact
+      chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing
+        μ A hμ hN hLN hClose
+  · exact
+      (chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
+        μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange).2
 
 /-- Conditional block-diagonal chain equality in the finite injectivity range.
 

--- a/TNLean/PEPS/TorusFundamentalTheorem.lean
+++ b/TNLean/PEPS/TorusFundamentalTheorem.lean
@@ -14,7 +14,7 @@ gauge transformation `B = λ · (X, Y\text{-action on } A)` with `λ^{n·m} = 1`
 `X, Y` invertible, unique up to a multiplicative constant. The orientation-uniform
 gauge family `(X, Y)` on the torus is produced unconditionally from the rectangle
 injectivity hypotheses (`isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle`).
-The final region comparison `A ∝ B̃` of the `R`/`S` regions gives the per-vertex
+The final region comparison \(A \propto \widetilde B\) of the `R`/`S` regions gives the per-vertex
 relation `A_v = λ · gaugeVertex B Z v`; this file consumes that relation and proves
 the scalar condition `λ^{width·height} = 1`.
 
@@ -107,7 +107,8 @@ rectangular-injectivity hypotheses with union closure, there is an
 orientation-uniform-up-to-scalar gauge family `X` (the source's horizontal and
 vertical matrices, the same on every edge of each orientation class), and for any
 single scalar `λ` whose gauge action relates `A` to `B` at every vertex against
-that family --- the output of the `R`/`S` region comparison `A ∝ B̃` --- and any
+that family --- the output of the `R`/`S` region comparison
+\(A \propto \widetilde B\) --- and any
 comparison region `R` whose block and complement block over `A` are blocked-tensor
 injective, `λ` satisfies the scalar condition `λ^{width·height} = 1`.
 
@@ -115,7 +116,8 @@ This is the torus form of Theorem 3 (arXiv:1804.04964, Section 3, lines 1453--14
 of `Papers/1804.04964/paper_normal.tex`): `B = λ · (X, Y\text{-action on } A)` with
 `λ^{n·m} = 1`. The gauge family is produced unconditionally from the rectangle
 hypotheses (`isTorusOrientationUniformGaugeFamilyModScalar_torus_rectangle`). The
-per-vertex relation `hPV` is the conditional input, the comparison output `A ∝ B̃`,
+per-vertex relation `hPV` is the conditional input, the comparison output
+\(A \propto \widetilde B\),
 exactly as in the square-lattice `fundamentalTheorem_normalSquarePEPS`; the scalar
 condition is discharged on top of it by `lambda_pow_card_torus_eq_one`, whose
 nonvanishing state coefficient comes from region injectivity rather than vertex

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6699,6 +6699,46 @@ formulation; the passage to $\ker H_N$ is kept separate.
     $\psi\in\mathcal G_{N,L}(B)$.
 \end{proof}
 
+\begin{lemma}[Block-diagonal boundary representation gives equality in the finite range]
+    \label{lem:bnt_block_diagonal_boundary_representation_equality}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary}
+    \leanok
+    \uses{lem:block_diagonal_boundary_representation_inclusion,
+        lem:block_diagonal_boundary_closing_equality,
+        lem:bnt_block_diagonal_periodic_constraints_internal_sum}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}, suppose
+    every vector $\psi\in\mathcal G_{N,L}(B)$ has block boundary matrices $X_j$
+    such that
+    \[
+        \psi=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right),
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
+    \]
+    Then
+    \[
+        \mathcal G_{N,L}(B)=
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j),
+    \]
+    and the sum defining $\bigvee_jG_N(A_j)$ is internal.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The block-diagonal boundary representation gives
+    \[
+        \mathcal G_{N,L}(B)
+        \subseteq
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j)
+    \]
+    by Lemma~\ref{lem:block_diagonal_boundary_representation_inclusion}. The
+    equality follows from Lemma~\ref{lem:block_diagonal_boundary_closing_equality};
+    the internality statement is
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}.
+\end{proof}
+
 \begin{lemma}[Boundary decomposition gives equality in the finite injectivity range]
     \label{lem:bnt_block_diagonal_boundary_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition}


### PR DESCRIPTION
### Motivation

Issue #905 is now localized to the boundary-condition comparison with block-diagonal boundary matrices in Perez-Garcia, Verstraete, Wolf, and Cirac (arXiv:quant-ph/0608197) and in Cirac, Perez-Garcia, Schuch, and Verstraete (arXiv:2011.12127). The existing formalization had the inclusion obtained from such block boundary data, and it also had a finite-range equality from an abstract componentwise decomposition. The missing intermediate statement was the finite-range equality obtained directly from the block-diagonal boundary representation.

### Description

This PR proves the finite-range equality obtained from explicit block-diagonal boundary data. Under the finite Condition C1 and basis-of-normal-tensors hypotheses, suppose that every vector
\[
  \psi \in \mathcal G_{N,L}(B), \qquad B = \bigoplus_j \mu_j A_j,
\]
has block boundary matrices \(X_j\) such that
\[
  \psi = \Gamma_N^B\left(\bigoplus_j X_j\right),
  \qquad
  \Gamma_N^{A_j}(\mu_j^N X_j) \in \mathcal G_{N,L}(A_j)
\]
for every block \(j\). Then
\[
  \mathcal G_{N,L}(B) = \bigvee_j \mathcal G_{N,L}(A_j),
\]
and the already established local block sum is internal.

The corresponding Chapter 14 entry now cites the block-boundary closing equality directly. The PEPS torus file also replaces decomposed Unicode notation by LaTeX notation after rebasing onto current `main`.

This does not close #905. The remaining source step is still to derive the displayed block-diagonal boundary representation and the component membership from the inverting-and-re-growing argument with block-diagonal boundary conditions.

### Testing

- `lake build TNLean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `lake build TNLean.PEPS.TorusFundamentalTheorem`
- `lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` (generated ignored `blueprint/lean_decls`)
- `lake exe checkdecls blueprint/lean_decls`

---
Refs #905.