### PR TITLE
doc(parent): retarget block-boundary gap note to #2641

### DIFF
--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -55,8 +55,11 @@ canonical form notation, while $b$ follows PGVWC07's notation around Theorem
 Cirac et al. describe the degenerate parent-Hamiltonian ground space for a
 matrix product state with more than one block in canonical form in Section~IV.C
 of \cite{Cirac2021Matrix}.\footnote{For
-traceability, this note corresponds to
-\href{https://github.com/LionSR/TNLean/issues/905}{issue \#905} and
+traceability, the remaining boundary-condition comparison is tracked by
+\href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641}. The
+closed periodic-chain decomposition issue was
+\href{https://github.com/LionSR/TNLean/issues/905}{issue \#905}; the related
+ground-state splitting issue is
 \href{https://github.com/LionSR/TNLean/issues/870}{issue \#870}. The relevant
 source lines are \path{Papers/2011.12127/TN-Review-main.tex}:2112--2128.}
 The source's block-injective canonical form is a block-diagonal
@@ -322,9 +325,12 @@ representation whose components already belong to the periodic block-chain
 spaces.\footnote{Lean declarations:
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition},
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap},
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition},
 and
-\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition}.}
-Those conditional reductions are not the source theorem.
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary}.}
+Those conditional reductions are not the source theorem: the last of them proves
+the equality only after the block-diagonal boundary representation has already
+been supplied.
 For
 \begin{align}
   X=\bigoplus_j X_j,
@@ -417,8 +423,9 @@ comparison: for every $j$,
   \quad\Longrightarrow\quad
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
-This is the missing assertion for the block-diagonal boundary representation in
-the source range
+This is the missing assertion recorded in
+\href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641}. It is the
+block-diagonal boundary representation needed in the source range
 \begin{align}
   b\ge2,
   \qquad
@@ -428,8 +435,8 @@ the source range
   \qquad
   N\ge L+L_0.
 \end{align}
-After this boundary-condition comparison is proved, the conditional boundary
-reduction gives
+After this boundary-condition comparison is proved, the conditional equality
+formalized in the current finite Condition C1 range gives
 \begin{align}
   \mathcal K_{N,L}(\widehat A)
   =


### PR DESCRIPTION
### Motivation

After #2631, the closed periodic-chain decomposition issue #905 is no longer the live issue for the block-diagonal boundary-condition comparison. The remaining source step is now #2641: from
\[
  \psi \in \mathcal K_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
\]
produce block-diagonal boundary matrices whose components are periodic block-chain vectors.

### Description

- Retargets `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` to #2641 as the live boundary-condition comparison.
- Keeps #905 as the closed periodic-chain decomposition issue and #870 as the related ground-state splitting issue.
- Records that the #2631 equality theorem is conditional: it proves the equality only after the block-diagonal boundary representation has been supplied.
- Restates the missing assertion in the source range and says the existing conditional equality applies in the current finite Condition C1 range.

No Lean statement or proof is changed.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

---
Addresses #2641

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to issue links and exposition; no runtime, proof, or API behavior changes.
> 
> **Overview**
> Updates the paper-gap note **`cpgsv21_block_diagonal_parent_ground_space.tex`** so issue tracking matches the current work: the open **block-diagonal boundary-condition comparison** points to **#2641**, while **#905** is described as the closed periodic-chain decomposition tracker and **#870** as the related ground-state splitting issue.
> 
> The prose now lists **`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`** among the conditional Lean reductions and clarifies that the equality theorem applies **only after** a block-diagonal boundary representation is already given—not as the full source theorem. The conclusion ties the remaining gap explicitly to **#2641** and says the ground-space equality follows from the existing conditional result in the finite Condition C1 range once that comparison is proved.
> 
> **No Lean code or proofs are modified**—documentation and traceability only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc2c1244f6405ff3bd77f05a47603a6f910ca62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->