### PR TITLE
feat(MPS/ParentHamiltonian): add open-boundary block representation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -263,9 +263,9 @@ Let
 \[
   B=\bigoplus_j\mu_jA_j.
 \]
-Under the normalized BNT block-separation hypotheses and the finite Condition
-C1 range, every \(\psi\in\mathcal G_{N,L}(B)\) can be represented with a
-block-diagonal boundary matrix
+Under the normalized BNT block-separation hypotheses and the \(L_0\)-block
+injectivity range bound, every \(\psi\in\mathcal G_{N,L}(B)\) can be
+represented with a block-diagonal boundary matrix
 \[
   \psi=\Gamma_N^B\!\left(\bigoplus_jX_j\right)
 \]
@@ -274,6 +274,11 @@ and each component vector
   \Gamma_N^{A_j}(\mu_j^NX_j)
 \]
 lies in the open-boundary local space \(G_N(A_j)\).
+
+The latter membership is the defining open-boundary range property of the
+displayed boundary matrix. The substantive assertion is the block-diagonal
+representation of \(\psi\), and the later periodic-chain upgrade remains
+separate.
 
 This proves only the open-boundary representation. The remaining
 Pérez-García--Verstraete--Wolf--Cirac boundary-condition comparison

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -256,6 +256,76 @@ theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_
   have hzero := hIndep Finset.univ (fun i => φ' i - φ i) hmem hsum j (Finset.mem_univ j)
   exact sub_eq_zero.mp hzero
 
+/-- Open-boundary block matrices for a vector satisfying the block-diagonal
+periodic constraints.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j.
+\]
+Under the normalized BNT block-separation hypotheses and the finite Condition
+C1 range, every \(\psi\in\mathcal G_{N,L}(B)\) can be represented with a
+block-diagonal boundary matrix
+\[
+  \psi=\Gamma_N^B\!\left(\bigoplus_jX_j\right)
+\]
+and each component vector
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)
+\]
+lies in the open-boundary local space \(G_N(A_j)\).
+
+This proves only the open-boundary representation. The remaining
+Pérez-García--Verstraete--Wolf--Cirac boundary-condition comparison
+(arXiv:quant-ph/0608197, proof lines 1454--1456; arXiv:2011.12127, lines
+2126--2128) is to show that these same component vectors lie in
+\(\mathcal G_{N,L}(A_j)\). -/
+theorem
+    exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ groundSpace (A j) N := by
+  classical
+  obtain ⟨φ, hφ, hψφ, _huniq⟩ :=
+    exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
+  have hφRange : ∀ j : Fin r, φ j ∈ (groundSpaceMap (A j) N).range := by
+    intro j
+    simpa [groundSpace] using hφ j
+  choose Y hY using hφRange
+  let X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j => ((μ j) ^ N)⁻¹ • Y j
+  refine ⟨X, ?_, ?_⟩
+  · rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+    calc
+      ψ = ∑ j : Fin r, φ j := hψφ
+      _ = ∑ j : Fin r, groundSpaceMap (A j) N ((μ j) ^ N • X j) := by
+            refine Finset.sum_congr rfl ?_
+            intro j _
+            have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
+            simp [X, hY j, hpow]
+  · intro j
+    have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
+    simpa [X, hY j, hpow] using hφ j
+
 /-- The current normalized BNT formalization gives two inclusions for the
 block-diagonal periodic chain space.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6549,6 +6549,53 @@ formulation; the passage to $\ker H_N$ is kept separate.
     boundary conditions.
 \end{proof}
 
+\begin{lemma}[Open-boundary block matrices for periodic chain vectors]
+    \label{lem:bnt_block_diagonal_open_boundary_matrices}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_decomposition,
+        lem:block_diagonal_boundary_condition_sum}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}, every
+    vector
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_{j=1}^g\mu_jA_j\right)
+    \]
+    admits block boundary matrices \(X_j\) such that
+    \[
+        \psi=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right),
+        \qquad
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j)
+    \]
+    for every \(j\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_decomposition} gives
+    \[
+        \psi=\sum_{j=1}^g\phi_j,
+        \qquad
+        \phi_j\in G_N(A_j).
+    \]
+    Choose \(Y_j\) with \(\phi_j=\Gamma_N^{A_j}(Y_j)\), and set
+    \(X_j=\mu_j^{-N}Y_j\). Since \(\mu_j\ne0\),
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)=\phi_j.
+    \]
+    The block-diagonal boundary formula then gives
+    \[
+        \Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right)
+        =
+        \sum_{j=1}^g \Gamma_N^{A_j}(\mu_j^NX_j)
+        =
+        \psi.
+    \]
+    This is still an open-boundary conclusion; it does not prove the periodic
+    block-chain membership of the components.
+\end{proof}
+
 \begin{lemma}[The block-diagonal chain space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}
@@ -6810,6 +6857,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:bnt_block_diagonal_periodic_constraints_propagated_sum,
         lem:bnt_block_diagonal_periodic_chain_inclusions,
         lem:bnt_block_diagonal_open_boundary_decomposition,
+        lem:bnt_block_diagonal_open_boundary_matrices,
         lem:block_diagonal_boundary_closing_equality,
         lem:block_diagonal_boundary_decomposition_inclusion,
         lem:bnt_block_diagonal_boundary_decomposition_equality,

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6553,8 +6553,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \label{lem:bnt_block_diagonal_open_boundary_matrices}
     \lean{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
     \leanok
-    \uses{lem:bnt_block_diagonal_open_boundary_decomposition,
-        lem:block_diagonal_boundary_condition_sum}
+    \uses{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}, every
     vector
@@ -6573,6 +6572,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_decomposition,
+        lem:block_diagonal_boundary_condition_sum}
     Lemma~\ref{lem:bnt_block_diagonal_open_boundary_decomposition} gives
     \[
         \psi=\sum_{j=1}^g\phi_j,


### PR DESCRIPTION
### Motivation

- Advances the formalization of the block-diagonal boundary representation for the periodic-chain ground space, tracked in #2641. The source is arXiv:quant-ph/0608197 (Pérez-García–Verstraete–Wolf–Cirac), Theorem 2blocks.2, proof lines 1454–1456, and arXiv:2011.12127 (Cirac–Pérez-García–Schuch–Verstraete), §IV.C, lines 2126–2128.
- PR #2631 proved the block-diagonal ground-space equality once the relevant block-boundary representation is assumed. This PR proves the open-boundary part of that representation as a separate lemma.

### Description

- **`TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`**: under the normalized basis-of-normal-tensors block-separation hypotheses and the $L_0$-block injectivity range bound, every $\psi \in \mathcal{G}_{N,L}(A^{\mathrm{tot}})$ can be written as $\psi = \Gamma_N(A^{\mathrm{tot}}, \operatorname{diag}(X_j)_j)$ with $\Gamma_N(A_j, \mu_j^N X_j) \in \mathcal{G}_N(A_j)$ for each block $j$.
- **`blueprint/src/chapter/ch14_parent_hamiltonian.tex`**: records the result as a separate Chapter 14 lemma and adds it as an input to the block-diagonal ground-space intersection theorem.
- This does not close #2641. The remaining step is to prove that the components lie in the finite-chain spaces $\mathcal{G}_{N,L}(A_j)$, as needed for the periodic boundary-condition argument.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `lake build TNLean`
- `lake exe lint_style --github`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check origin/main..HEAD`

Related to #2641