### PR TITLE
feat(PEPS): the inserted-site residual factorization

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -469,6 +469,9 @@ import TNLean.PEPS.RegionBlock.AbsorbedEquality
 -- Region vertex-product split across an inserted site: the vertex-product half of
 -- the block-granularity one-site quotient of the normal PEPS Fundamental Theorem.
 import TNLean.PEPS.RegionBlock.InsertSplit
+-- Inserted-site grouping by the local configuration at the inserted vertex: the
+-- inserted-site tensor factored out of the residual region-vertex sum.
+import TNLean.PEPS.RegionBlock.InsertResidual
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -221,5 +221,68 @@ theorem isRegionBoundaryEdge_insert_of_vIncident_not_regionIncident (R : Finset 
     · exact (G.ne_of_adj e.2.2) (by rw [he, hc])
     · exact h1 hc
 
+/-- The inserted-site consistency predicate: `μ` and `η` agree on every `v`-incident
+edge crossing the boundary of `insert v R`.  These are the outer `v`-incident edges
+that both `μ` (as crossing-edge labels of `insert v R`) and `η` (as `v`-incident
+labels) constrain; consistency is the condition under which the residual at `η` is
+nonempty, given by the complement of `insertResidual_eq_zero_of_inconsistent`. -/
+def InsertConsistent (A : Tensor G d) (R : Finset V) {v : V}
+    (μ : RegionBoundaryConfig (G := G) A (insert v R)) (η : LocalVirtualConfig A v) : Prop :=
+  ∀ (g : {g : Edge G // IsRegionBoundaryEdge (G := G) (insert v R) g})
+      (hgv : g.1.1.1 = v ∨ g.1.1.2 = v), μ g = η ⟨g.1, hgv⟩
+
+open scoped Classical in
+/-- Overwrite a global virtual configuration on the `insert v R`-boundary edges away
+from `R` with the `μ`-values.  The blocked-weight sum at the bridge label groups by
+this overwrite into the residual fibers. -/
+noncomputable def insertOverwrite (A : Tensor G d) (R : Finset V) {v : V}
+    (μ : RegionBoundaryConfig (G := G) A (insert v R)) (ζ : VirtualConfig A) :
+    VirtualConfig A :=
+  fun e =>
+    if he : IsRegionBoundaryEdge (G := G) (insert v R) e ∧ ¬ IsRegionIncidentEdge (G := G) R e
+      then μ ⟨e, he.1⟩ else ζ e
+
+open scoped Classical in
+/-- The free virtual indices of a configuration on the non-`R`-incident
+`insert v R`-boundary edges: the values the residual pins to `μ` but the bridge-label
+blocked weight leaves free. -/
+noncomputable def insertOuterLegs (A : Tensor G d) (R : Finset V) {v : V}
+    (ζ : VirtualConfig A) :
+    (e : {e : Edge G //
+        IsRegionBoundaryEdge (G := G) (insert v R) e ∧ ¬ IsRegionIncidentEdge (G := G) R e}) →
+      Fin (A.bondDim e.1) :=
+  fun e => ζ e.1
+
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- An `insert v R`-boundary edge that is incident to `R` is a boundary edge of `R`
+and is not incident to `v`. -/
+theorem isRegionBoundaryEdge_of_insert_regionIncident (R : Finset V)
+    {v : V} (hv : v ∉ R) {e : Edge G}
+    (hb : IsRegionBoundaryEdge (G := G) (insert v R) e)
+    (hinc : IsRegionIncidentEdge (G := G) R e) :
+    IsRegionBoundaryEdge (G := G) R e ∧ ¬ (e.1.1 = v ∨ e.1.2 = v) := by
+  -- One endpoint lies in `insert v R`, the other outside; `R`-incidence puts the
+  -- in-region endpoint in `R`, which is therefore not `v`.
+  rcases hb with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · -- `e.1.1 ∈ insert v R`, `e.1.2 ∉ insert v R`, so `e.1.2 ∉ R`.
+    have h2R : e.1.2 ∉ R := fun h => h2 (Finset.mem_insert_of_mem h)
+    have h1R : e.1.1 ∈ R := by
+      rcases hinc with h | h
+      · exact h
+      · exact absurd h h2R
+    refine ⟨Or.inl ⟨h1R, h2R⟩, ?_⟩
+    rintro (hc | hc)
+    · exact hv (hc ▸ h1R)
+    · exact h2 (hc ▸ Finset.mem_insert_self v R)
+  · have h1R : e.1.1 ∉ R := fun h => h1 (Finset.mem_insert_of_mem h)
+    have h2R : e.1.2 ∈ R := by
+      rcases hinc with h | h
+      · exact absurd h h1R
+      · exact h
+    refine ⟨Or.inr ⟨h1R, h2R⟩, ?_⟩
+    rintro (hc | hc)
+    · exact h1 (hc ▸ Finset.mem_insert_self v R)
+    · exact hv (hc ▸ h2R)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -284,5 +284,72 @@ theorem isRegionBoundaryEdge_of_insert_regionIncident (R : Finset V)
     · exact h1 (hc ▸ Finset.mem_insert_self v R)
     · exact hv (hc ▸ h2R)
 
+omit [Fintype V] in
+open scoped Classical in
+/-- The overwrite reads `μ` on the non-`R`-incident `insert v R`-boundary edges and the
+original configuration elsewhere; on `R`-incident edges it is unchanged, so the vertex
+product over `R` is unchanged. -/
+theorem insertOverwrite_eq_of_regionIncident (A : Tensor G d) (R : Finset V) {v : V}
+    (μ : RegionBoundaryConfig (G := G) A (insert v R)) (ζ : VirtualConfig A)
+    {e : Edge G} (hinc : IsRegionIncidentEdge (G := G) R e) :
+    insertOverwrite (G := G) A R μ ζ e = ζ e := by
+  rw [insertOverwrite, dif_neg]
+  rintro ⟨_, hni⟩
+  exact hni hinc
+
+omit [Fintype V] in
+open scoped Classical in
+/-- On the bridge filter and under inserted-site consistency, the overwrite lands in the
+residual filter: its `insert v R`-boundary label is `μ` and its `v`-incident label is `η`. -/
+theorem insertOverwrite_mem_residualFilter (A : Tensor G d) (R : Finset V) {v : V} (hv : v ∉ R)
+    (μ : RegionBoundaryConfig (G := G) A (insert v R)) (η : LocalVirtualConfig A v)
+    (hcons : InsertConsistent (G := G) A R μ η)
+    (ζ : VirtualConfig A)
+    (hζbridge : regionBoundaryLabel (G := G) A R ζ = boundaryLabelOfInsert (G := G) A R hv μ η) :
+    regionBoundaryLabel (G := G) A (insert v R) (insertOverwrite (G := G) A R μ ζ) = μ ∧
+      (fun ie : IncidentEdge G v => insertOverwrite (G := G) A R μ ζ ie.1) = η := by
+  classical
+  constructor
+  · -- `insert v R`-boundary label is `μ`.
+    funext g
+    rw [regionBoundaryLabel_apply]
+    by_cases hinc : IsRegionIncidentEdge (G := G) R g.1
+    · -- `R`-incident boundary edge of `insert v R`: it is `R`-boundary, not `v`-incident,
+      -- so the bridge label reads `μ`, and the bridge hypothesis fixes `ζ` to it.
+      rw [insertOverwrite_eq_of_regionIncident (G := G) A R μ ζ hinc]
+      obtain ⟨hRb, hnv⟩ :=
+        isRegionBoundaryEdge_of_insert_regionIncident (G := G) R hv g.2 hinc
+      have := congrFun hζbridge ⟨g.1, hRb⟩
+      rw [regionBoundaryLabel_apply, boundaryLabelOfInsert, dif_neg hnv] at this
+      rw [this]
+    · -- non-`R`-incident boundary edge of `insert v R`: a mult-edge, overwrite reads `μ`.
+      rw [insertOverwrite, dif_pos ⟨g.2, hinc⟩]
+  · -- `v`-incident label is `η`.
+    funext ie
+    by_cases hinc : IsRegionIncidentEdge (G := G) R ie.1
+    · -- `v`-incident and `R`-incident: it is an `R`-boundary edge labeled `η` by the bridge.
+      rw [insertOverwrite_eq_of_regionIncident (G := G) A R μ ζ hinc]
+      -- `ie` is incident to `v ∈ insert v R` and `R`-incident, hence `R`-boundary.
+      have hb : IsRegionBoundaryEdge (G := G) R ie.1 := by
+        rcases ie.2 with hev | hev
+        · -- `ie.1.1 = v ∉ R`; the other endpoint must be in `R` by incidence.
+          have h1 : ie.1.1.1 ∉ R := by rw [hev]; exact hv
+          rcases hinc with h | h
+          · exact absurd h h1
+          · exact Or.inr ⟨h1, h⟩
+        · have h2 : ie.1.1.2 ∉ R := by rw [hev]; exact hv
+          rcases hinc with h | h
+          · exact Or.inl ⟨h, h2⟩
+          · exact absurd h h2
+      have hbr := congrFun hζbridge ⟨ie.1, hb⟩
+      rw [regionBoundaryLabel_apply, boundaryLabelOfInsert, dif_pos ie.2] at hbr
+      -- `boundaryLabelOfInsert` reads `η` at the `v`-incident edge.
+      rw [hbr]
+    · -- `v`-incident, non-`R`-incident: a mult-edge, overwrite reads `μ`; consistency gives `η`.
+      have hb : IsRegionBoundaryEdge (G := G) (insert v R) ie.1 :=
+        isRegionBoundaryEdge_insert_of_vIncident_not_regionIncident (G := G) R ie.2 hinc
+      rw [insertOverwrite, dif_pos ⟨hb, hinc⟩]
+      exact hcons ⟨ie.1, hb⟩ ie.2
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -532,7 +532,7 @@ theorem regionBlockedWeight_bridge_eq_smul_insertResidual (A : Tensor G d) (R : 
     refine ⟨Finset.mem_univ _, ?_, hμ, hη⟩
     -- The overwrite's `R`-boundary label is the bridge label: `R`-boundary edges are
     -- `R`-incident, where the overwrite is the identity.
-    show regionBoundaryLabel (G := G) A R (insertOverwrite (G := G) A R μ ζ) = _
+    beta_reduce
     funext g
     rw [regionBoundaryLabel_apply,
       insertOverwrite_eq_of_regionIncident (G := G) A R μ ζ

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -94,3 +94,6 @@ theorem regionBlockedWeight_insert_eq_sum_localConfig (A : Tensor G d) (R : Fins
   rw [Finset.mem_filter] at hζ
   obtain ⟨_, _, hηζ⟩ := hζ
   rw [hηζ]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -351,5 +351,92 @@ theorem insertOverwrite_mem_residualFilter (A : Tensor G d) (R : Finset V) {v : 
       rw [insertOverwrite, dif_pos ⟨hb, hinc⟩]
       exact hcons ⟨ie.1, hb⟩ ie.2
 
+/-- Reconstruct a configuration in the bridge-filter fiber over a residual configuration
+`ζ'` from its free mult-edge values: the mult-edges read the free values, every other edge
+reads `ζ'`. -/
+noncomputable def insertFiberConfig (A : Tensor G d) (R : Finset V) {v : V} (ζ' : VirtualConfig A)
+    (h : (e : {e : Edge G //
+        IsRegionBoundaryEdge (G := G) (insert v R) e ∧ ¬ IsRegionIncidentEdge (G := G) R e}) →
+      Fin (A.bondDim e.1)) :
+    VirtualConfig A :=
+  fun e =>
+    if he : IsRegionBoundaryEdge (G := G) (insert v R) e ∧ ¬ IsRegionIncidentEdge (G := G) R e
+      then h ⟨e, he⟩ else ζ' e
+
+open scoped Classical in
+/-- **The bridge-filter fiber over a residual configuration is the mult-edge legs.**
+The configurations in the bridge filter that overwrite to a fixed residual configuration
+`ζ'` are exactly those agreeing with `ζ'` off the non-`R`-incident `insert v R`-boundary
+edges, so they biject with the free legs on those edges; the fiber has cardinality
+`insertOuterBondProd`. -/
+theorem insertFiber_card (A : Tensor G d) (R : Finset V) {v : V} (hv : v ∉ R)
+    (μ : RegionBoundaryConfig (G := G) A (insert v R)) (η : LocalVirtualConfig A v)
+    (ζ' : VirtualConfig A)
+    (hζ' : regionBoundaryLabel (G := G) A (insert v R) ζ' = μ ∧
+      (fun ie : IncidentEdge G v => ζ' ie.1) = η) :
+    (Finset.univ.filter (fun ζ : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A R ζ = boundaryLabelOfInsert (G := G) A R hv μ η ∧
+          insertOverwrite (G := G) A R μ ζ = ζ')).card =
+      insertOuterBondProd (G := G) A R (v := v) := by
+  classical
+  rw [show insertOuterBondProd (G := G) A R (v := v) =
+      (Finset.univ : Finset ((e : {e : Edge G //
+        IsRegionBoundaryEdge (G := G) (insert v R) e ∧
+          ¬ IsRegionIncidentEdge (G := G) R e}) → Fin (A.bondDim e.1))).card from ?_]
+  · refine Finset.card_nbij'
+      (insertOuterLegs (G := G) A R) (insertFiberConfig (G := G) A R ζ') ?_ ?_ ?_ ?_
+    · intro ζ _; exact Finset.mem_univ _
+    · -- The reconstruction lands in the fiber.
+      intro h _
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and]
+      refine ⟨?_, ?_⟩
+      · -- `R`-boundary label is the bridge label: `R`-boundary edges are `R`-incident,
+        -- where the reconstruction reads `ζ'`, and `ζ'` has `insert v R`-boundary label `μ`.
+        funext g
+        rw [regionBoundaryLabel_apply, insertFiberConfig]
+        have hginc : IsRegionIncidentEdge (G := G) R g.1 :=
+          isRegionBoundaryEdge_touches (G := G) R g.2
+        rw [dif_neg (fun hc => hc.2 hginc)]
+        rw [boundaryLabelOfInsert]
+        by_cases hgv : g.1.1.1 = v ∨ g.1.1.2 = v
+        · rw [dif_pos hgv, ← hζ'.2]
+        · rw [dif_neg hgv, ← hζ'.1, regionBoundaryLabel_apply]
+      · -- The reconstruction overwrites to `ζ'`.
+        funext e
+        rw [insertOverwrite, insertFiberConfig]
+        by_cases he : IsRegionBoundaryEdge (G := G) (insert v R) e ∧
+            ¬ IsRegionIncidentEdge (G := G) R e
+        · rw [dif_pos he]
+          -- mult-edge: overwrite reads `μ`, which equals `ζ' e` since `ζ'` has boundary label `μ`.
+          have := congrFun hζ'.1 ⟨e, he.1⟩
+          rw [regionBoundaryLabel_apply] at this
+          rw [this]
+        · rw [dif_neg he, dif_neg he]
+    · -- Reconstructing from the legs of a fiber config recovers the config.
+      intro ζ hζ
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at hζ
+      obtain ⟨_, hover⟩ := hζ
+      funext e
+      simp only [insertFiberConfig, insertOuterLegs]
+      by_cases he : IsRegionBoundaryEdge (G := G) (insert v R) e ∧
+          ¬ IsRegionIncidentEdge (G := G) R e
+      · rw [dif_pos he]
+      · rw [dif_neg he]
+        -- off the mult-edges the overwrite is the identity, so `ζ' e = ζ e`.
+        have := congrFun hover e
+        rw [insertOverwrite, dif_neg he] at this
+        exact this.symm
+    · -- Reading the legs of a reconstruction recovers them.
+      intro h _
+      funext e
+      simp only [insertOuterLegs, insertFiberConfig, dif_pos e.2]
+  · rw [Finset.card_univ, Fintype.card_pi]
+    simp only [Fintype.card_fin]
+    rw [insertOuterBondProd,
+      ← Finset.prod_subtype (Finset.univ.filter
+          (fun e : Edge G =>
+            IsRegionBoundaryEdge (G := G) (insert v R) e ∧ ¬ IsRegionIncidentEdge (G := G) R e))
+        (fun e => by simp [Finset.mem_filter]) (fun e => A.bondDim e)]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -127,5 +127,50 @@ theorem insertResidual_eq_zero_of_inconsistent (A : Tensor G d) (R : Finset V)
   have h2 : η ⟨g.1, hgv⟩ = ζ g.1 := by rw [← hη]
   rw [h1, h2]
 
+/-! ### The residual is a refinement of the smaller-region blocked weight
+
+Every global virtual configuration in the residual filter restricts to the bridge
+label `boundaryLabelOfInsert μ η` on the crossing edges of `R`
+(`regionBoundaryLabel_eq_boundaryLabelOfInsert`), so the residual sum is the
+sub-sum of the blocked weight of `R` at the bridge label over the configurations
+that additionally restrict to `μ` on the crossing edges of `insert v R` and to `η`
+at `v`.  This refinement is the bond-data identity the route note records: the
+residual carries the bond data of `R` constrained by the inserted site, and the
+free `insert v R`-boundary and `v`-incident edges away from `R` supply the
+overcounting multiplicity that is identical for `A` and the reindexed comparison
+tensor. -/
+
+/-- The residual sum is the blocked weight of `R` at the bridge label
+`boundaryLabelOfInsert μ η`, restricted to the configurations restricting to `μ`
+on the crossing edges of `insert v R` and to `η` at `v`.
+
+Concretely, the residual filter refines the blocked-weight filter at the bridge
+label: every residual configuration carries `R`-boundary label
+`boundaryLabelOfInsert μ η` by `regionBoundaryLabel_eq_boundaryLabelOfInsert`, and
+the residual product is exactly the blocked-weight summand. -/
+theorem insertResidual_eq_filter_regionBlockedWeight (A : Tensor G d) (R : Finset V)
+    {v : V} (hv : v ∉ R)
+    (μ : RegionBoundaryConfig (G := G) A (insert v R))
+    (σ : RegionPhysicalConfig (V := V) (d := d) (insert v R))
+    (η : LocalVirtualConfig A v) :
+    insertResidual (G := G) A R μ σ η =
+      ∑ ζ ∈ Finset.univ.filter
+          (fun ζ : VirtualConfig A =>
+            regionBoundaryLabel (G := G) A R ζ = boundaryLabelOfInsert (G := G) A R hv μ η ∧
+              regionBoundaryLabel (G := G) A (insert v R) ζ = μ ∧
+              (fun ie : IncidentEdge G v => ζ ie.1) = η),
+        ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1)
+          (restrictInsertPhysical (V := V) (d := d) R σ w) := by
+  classical
+  rw [insertResidual]
+  refine Finset.sum_congr ?_ (fun _ _ => rfl)
+  ext ζ
+  simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+  constructor
+  · rintro ⟨hμ, hη⟩
+    exact ⟨regionBoundaryLabel_eq_boundaryLabelOfInsert (G := G) A R hv ζ μ η hμ hη, hμ, hη⟩
+  · rintro ⟨_, hμ, hη⟩
+    exact ⟨hμ, hη⟩
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -95,5 +95,37 @@ theorem regionBlockedWeight_insert_eq_sum_localConfig (A : Tensor G d) (R : Fins
   obtain ⟨_, _, hηζ⟩ := hζ
   rw [hηζ]
 
+/-! ### The `v`-incident consistency delta
+
+An edge incident to the inserted site `v` that crosses the boundary of `insert v R`
+runs from `v` to a vertex outside `insert v R`; it is constrained both by `μ` (as a
+crossing edge of `insert v R`) and by `η` (as a `v`-incident edge), so the residual
+sum is empty --- hence zero --- whenever `μ` and `η` disagree on such an edge. This
+is the consistency delta the inserted-site quotient carries: only the local
+configurations `η` at `v` that match `μ` on the outer `v`-incident edges contribute. -/
+
+/-- A `v`-incident edge `g` that crosses the boundary of `insert v R` is constrained
+by both `μ` (its crossing-edge label) and `η` (its `v`-incident label) in the
+residual filter, so if `μ` and `η` disagree on `g` the residual sum is zero. -/
+theorem insertResidual_eq_zero_of_inconsistent (A : Tensor G d) (R : Finset V)
+    {v : V} (μ : RegionBoundaryConfig (G := G) A (insert v R))
+    (σ : RegionPhysicalConfig (V := V) (d := d) (insert v R))
+    (η : LocalVirtualConfig A v)
+    (g : {g : Edge G // IsRegionBoundaryEdge (G := G) (insert v R) g})
+    (hgv : g.1.1.1 = v ∨ g.1.1.2 = v)
+    (hne : μ g ≠ η ⟨g.1, hgv⟩) :
+    insertResidual (G := G) A R μ σ η = 0 := by
+  classical
+  rw [insertResidual]
+  refine Finset.sum_eq_zero (fun ζ hζ => ?_)
+  exfalso
+  rw [Finset.mem_filter] at hζ
+  obtain ⟨_, hμ, hη⟩ := hζ
+  apply hne
+  -- `μ g = ζ g.1` from the crossing-edge label, `η ⟨g.1, hgv⟩ = ζ g.1` from the `v`-incident label.
+  have h1 : μ g = ζ g.1 := by rw [← hμ, regionBoundaryLabel_apply]
+  have h2 : η ⟨g.1, hgv⟩ = ζ g.1 := by rw [← hη]
+  rw [h1, h2]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -529,5 +529,80 @@ theorem regionBlockedWeight_bridge_eq_smul_insertResidual (A : Tensor G d) (R : 
         (isRegionBoundaryEdge_touches (G := G) R g.2)]
     exact congrFun hζ.2 g
 
+/-! ### The inserted-site factorization of the blocked weight
+
+Assembling the local-configuration grouping `regionBlockedWeight_insert_eq_sum_localConfig`
+with the inserted-site multiplicity collapse
+`regionBlockedWeight_bridge_eq_smul_insertResidual` and the consistency delta
+`insertResidual_eq_zero_of_inconsistent` expresses the inserted-site multiplicity times the
+blocked weight of `insert v R` as a sum over the inserted-site local configurations `η` of the
+inserted-site tensor `A.component v η` times the blocked weight of `R` at the bridge label
+`boundaryLabelOfInsert μ η`.  The multiplicity `insertOuterBondProd` is bond data alone, so it
+is identical for `A` and for the reindexed comparison tensor and cancels in the quotient of the
+two region proportionalities; what survives is the inserted-site tensor against the
+smaller-region blocked weight, the per-vertex relation the route note isolates. -/
+
+open scoped Classical in
+/-- **The inserted-site factorization of the blocked weight.**
+
+The inserted-site multiplicity times the blocked weight of `insert v R` is the sum, over local
+virtual configurations `η` of the inserted site `v`, of the inserted-site tensor
+`A.component v η` read at `σ`'s physical leg at `v` times the inserted-site residual at `η`,
+scaled by the inserted-site multiplicity; equivalently, the multiplicity-scaled residual is the
+blocked weight of `R` at the bridge label `boundaryLabelOfInsert μ η` on the local
+configurations consistent with `μ` on the outer `v`-incident edges, and zero otherwise.
+
+This is the inserted-site analogue of `regionInsertedCoeff_eq_smul_edgeInsertedCoeff`: it
+isolates the inserted-site tensor `A.component v` from the residual region product, identifying
+the multiplicity-scaled residual with the bridge-label blocked weight of `R` on the consistent
+configurations.  The bond-only multiplicity `insertOuterBondProd` is manifestly identical for
+`A` and the reindexed comparison tensor, so it cancels in the quotient of the two region
+proportionalities.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1544--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem insertOuterBondProd_smul_regionBlockedWeight_insert (A : Tensor G d) (R : Finset V)
+    {v : V} (hv : v ∉ R)
+    (μ : RegionBoundaryConfig (G := G) A (insert v R))
+    (σ : RegionPhysicalConfig (V := V) (d := d) (insert v R)) :
+    insertOuterBondProd (G := G) A R (v := v) •
+        regionBlockedWeight (G := G) A (insert v R) μ σ =
+      ∑ η : LocalVirtualConfig A v,
+        A.component v η (σ ⟨v, Finset.mem_insert_self v R⟩) *
+          (insertOuterBondProd (G := G) A R (v := v) • insertResidual (G := G) A R μ σ η) := by
+  classical
+  rw [regionBlockedWeight_insert_eq_sum_localConfig (G := G) A R hv μ σ,
+    Finset.smul_sum]
+  refine Finset.sum_congr rfl (fun η _ => ?_)
+  rw [mul_smul_comm]
+
+open scoped Classical in
+/-- The multiplicity-scaled inserted-site residual at a local configuration `η` is the blocked
+weight of `R` at the bridge label `boundaryLabelOfInsert μ η` when `μ` and `η` are consistent on
+the outer `v`-incident edges, and zero otherwise.
+
+When consistent, the multiplicity collapse `regionBlockedWeight_bridge_eq_smul_insertResidual`
+identifies the scaled residual with the bridge-label weight; when inconsistent the residual
+vanishes by `insertResidual_eq_zero_of_inconsistent`. -/
+theorem insertOuterBondProd_smul_insertResidual_eq (A : Tensor G d) (R : Finset V)
+    {v : V} (hv : v ∉ R)
+    (μ : RegionBoundaryConfig (G := G) A (insert v R))
+    (σ : RegionPhysicalConfig (V := V) (d := d) (insert v R))
+    (η : LocalVirtualConfig A v) :
+    insertOuterBondProd (G := G) A R (v := v) • insertResidual (G := G) A R μ σ η =
+      if InsertConsistent (G := G) A R μ η then
+        regionBlockedWeight (G := G) A R (boundaryLabelOfInsert (G := G) A R hv μ η)
+          (restrictInsertPhysical (V := V) (d := d) R σ)
+      else 0 := by
+  classical
+  by_cases hcons : InsertConsistent (G := G) A R μ η
+  · rw [if_pos hcons,
+      regionBlockedWeight_bridge_eq_smul_insertResidual (G := G) A R hv μ σ η hcons]
+  · rw [if_neg hcons]
+    rw [InsertConsistent] at hcons
+    push_neg at hcons
+    obtain ⟨g, hgv, hne⟩ := hcons
+    rw [insertResidual_eq_zero_of_inconsistent (G := G) A R μ σ η g hgv hne, smul_zero]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -1,0 +1,96 @@
+import TNLean.PEPS.RegionBlock.InsertSplit
+
+/-!
+# Grouping the inserted-site blocked weight by the local configuration at `v`
+
+The blocked-region weight of `insert v R` splits, at a fixed local configuration
+`η` of the inserted site `v`, into the inserted-site tensor `A.component v η`
+times the residual sum over the vertices of `R` constrained to `η` at `v` and to
+`μ` on the crossing edges of `insert v R`
+(arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1544--1571 of
+`Papers/1804.04964/paper_normal.tex`).
+
+This file lifts the vertex-product split `prod_region_insert_split` and the
+constrained-sum split `regionBlockedWeight_insert_eq_sum_split` to the
+local-configuration grouping at `v`: grouping the constrained global sum by the
+local virtual configuration `η` at the inserted site, the inserted-site tensor
+factor `A.component v η (σ_v)` is constant on each `η`-fiber, so the blocked
+weight of `insert v R` is the sum over `η` of `A.component v η (σ_v)` against the
+residual region-vertex product. This is the inserted-site grouping that the
+residual-multiplicity factorization rests on: it isolates `A.component v` from
+the residual exactly as the route note's per-vertex relation requires.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, proof of
+  Theorem 3, lines 1544--1571 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- The residual region-vertex sum at a fixed local configuration `η` of the
+inserted site `v`: the sum, over global virtual configurations restricting to `μ`
+on the crossing edges of `insert v R` and to `η` at `v`, of the vertex product
+over the smaller region `R`.
+
+This is the residual of the inserted-site quotient: it carries the bond data of
+`R` together with the `v`-incident consistency constraint between `μ` and `η`. -/
+noncomputable def insertResidual (A : Tensor G d) (R : Finset V) {v : V}
+    (μ : RegionBoundaryConfig (G := G) A (insert v R))
+    (σ : RegionPhysicalConfig (V := V) (d := d) (insert v R))
+    (η : LocalVirtualConfig A v) : ℂ :=
+  ∑ ζ ∈ Finset.univ.filter
+      (fun ζ : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (insert v R) ζ = μ ∧
+          (fun ie : IncidentEdge G v => ζ ie.1) = η),
+    ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1)
+      (restrictInsertPhysical (V := V) (d := d) R σ w)
+
+open scoped Classical in
+/-- **The inserted-site blocked weight groups by the local configuration at `v`.**
+
+The blocked weight of `insert v R` is the sum, over local virtual configurations
+`η` of the inserted site `v`, of the inserted-site tensor `A.component v η` read
+at `σ`'s physical leg at `v` times the residual region-vertex sum `insertResidual`
+at `η`.
+
+The inserted-site tensor factor is constant on each `η`-fiber of the constrained
+global sum, so factoring it out of `regionBlockedWeight_insert_eq_sum_split` and
+grouping by `η` gives the inserted-site grouping.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1544--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_insert_eq_sum_localConfig (A : Tensor G d) (R : Finset V)
+    {v : V} (hv : v ∉ R)
+    (μ : RegionBoundaryConfig (G := G) A (insert v R))
+    (σ : RegionPhysicalConfig (V := V) (d := d) (insert v R)) :
+    regionBlockedWeight (G := G) A (insert v R) μ σ =
+      ∑ η : LocalVirtualConfig A v,
+        A.component v η (σ ⟨v, Finset.mem_insert_self v R⟩) *
+          insertResidual (G := G) A R μ σ η := by
+  classical
+  rw [regionBlockedWeight_insert_eq_sum_split (G := G) A R hv μ σ]
+  -- Group the constrained global sum by the local configuration `η` at `v`.
+  rw [← Finset.sum_fiberwise (Finset.univ.filter
+      (fun ζ : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A (insert v R) ζ = μ))
+    (fun ζ => (fun ie : IncidentEdge G v => ζ ie.1))
+    (fun ζ =>
+      A.component v (fun ie => ζ ie.1) (σ ⟨v, Finset.mem_insert_self v R⟩) *
+        ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1)
+          (restrictInsertPhysical (V := V) (d := d) R σ w))]
+  refine Finset.sum_congr rfl (fun η _ => ?_)
+  -- On the `η`-fiber the inserted-site tensor factor is constant `A.component v η (σ_v)`.
+  rw [insertResidual, Finset.mul_sum, Finset.filter_filter]
+  refine Finset.sum_congr (Finset.filter_congr (fun ζ _ => by tauto)) (fun ζ hζ => ?_)
+  rw [Finset.mem_filter] at hζ
+  obtain ⟨_, _, hηζ⟩ := hζ
+  rw [hηζ]

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.RegionBlock.InsertSplit
+import TNLean.PEPS.NormalFundamentalTheorem
 
 /-!
 # Grouping the inserted-site blocked weight by the local configuration at `v`
@@ -171,6 +172,54 @@ theorem insertResidual_eq_filter_regionBlockedWeight (A : Tensor G d) (R : Finse
     exact ⟨regionBoundaryLabel_eq_boundaryLabelOfInsert (G := G) A R hv ζ μ η hμ hη, hμ, hη⟩
   · rintro ⟨_, hμ, hη⟩
     exact ⟨hμ, hη⟩
+
+/-! ### The inserted-site overcounting multiplicity
+
+The blocked weight of `R` at the bridge label and the residual sum read the same
+product over the vertices of `R`, which depends on a global virtual configuration
+only through the `R`-incident edges (`regionProd_congr`).  They differ only in
+their constraints on the `R`-incident edges' complement: the residual additionally
+pins every `insert v R`-boundary edge that is not `R`-incident (to `μ`), whereas
+the bridge-label blocked weight leaves those edges free.  Grouping the
+blocked-weight sum by the value on those free edges, the inner sum over each value
+is the residual and the summand is constant across values, so the blocked weight is
+the bond-dimension product over the non-`R`-incident `insert v R`-boundary edges
+times the residual.  That bond-dimension product is the inserted-site overcounting
+multiplicity; being bond data alone, it is identical for `A` and for the reindexed
+comparison tensor and therefore cancels in the quotient of the two region
+proportionalities. -/
+
+/-- The inserted-site overcounting multiplicity: the bond-dimension product over the
+`insert v R`-boundary edges that are not incident to `R`.  These are the edges the
+residual pins to `μ` but the bridge-label blocked weight of `R` leaves free; their
+bond product is the factor by which the blocked weight overcounts the residual. -/
+noncomputable def insertOuterBondProd (A : Tensor G d) (R : Finset V) {v : V} : ℕ :=
+  ∏ e ∈ Finset.univ.filter
+      (fun e : Edge G =>
+        IsRegionBoundaryEdge (G := G) (insert v R) e ∧ ¬ IsRegionIncidentEdge (G := G) R e),
+    A.bondDim e
+
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- A non-`R`-incident `v`-incident edge is an `insert v R`-boundary edge: its `v`
+endpoint lies in `insert v R` and its other endpoint lies outside `insert v R`. -/
+theorem isRegionBoundaryEdge_insert_of_vIncident_not_regionIncident (R : Finset V)
+    {v : V} {e : Edge G} (hev : e.1.1 = v ∨ e.1.2 = v)
+    (hnr : ¬ IsRegionIncidentEdge (G := G) R e) :
+    IsRegionBoundaryEdge (G := G) (insert v R) e := by
+  have h1 : e.1.1 ∉ R := fun h => hnr (Or.inl h)
+  have h2 : e.1.2 ∉ R := fun h => hnr (Or.inr h)
+  rcases hev with he | he
+  · -- `e.1.1 = v`; the other endpoint is outside `insert v R`.
+    refine Or.inl ⟨he ▸ Finset.mem_insert_self v R, ?_⟩
+    rw [Finset.mem_insert]
+    rintro (hc | hc)
+    · exact (G.ne_of_adj e.2.2) (by rw [he, hc])
+    · exact h2 hc
+  · refine Or.inr ⟨?_, he ▸ Finset.mem_insert_self v R⟩
+    rw [Finset.mem_insert]
+    rintro (hc | hc)
+    · exact (G.ne_of_adj e.2.2) (by rw [he, hc])
+    · exact h1 hc
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -199,6 +199,16 @@ noncomputable def insertOuterBondProd (A : Tensor G d) (R : Finset V) {v : V} : 
         IsRegionBoundaryEdge (G := G) (insert v R) e ∧ ¬ IsRegionIncidentEdge (G := G) R e),
     A.bondDim e
 
+/-- The inserted-site overcounting multiplicity depends only on the bond dimensions:
+two tensors with the same bond dimensions have the same inserted-site multiplicity.
+This is the bond-data invariance that makes the multiplicity cancel in the quotient
+of the two region proportionalities. -/
+theorem insertOuterBondProd_congr (A B : Tensor G d) (R : Finset V) {v : V}
+    (hDim : A.bondDim = B.bondDim) :
+    insertOuterBondProd (G := G) A R (v := v) = insertOuterBondProd (G := G) B R (v := v) := by
+  rw [insertOuterBondProd, insertOuterBondProd]
+  exact Finset.prod_congr rfl (fun e _ => congr_fun hDim e)
+
 omit [Fintype V] [DecidableRel G.Adj] in
 /-- A non-`R`-incident `v`-incident edge is an `insert v R`-boundary edge: its `v`
 endpoint lies in `insert v R` and its other endpoint lies outside `insert v R`. -/

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -438,5 +438,96 @@ theorem insertFiber_card (A : Tensor G d) (R : Finset V) {v : V} (hv : v ∉ R)
             IsRegionBoundaryEdge (G := G) (insert v R) e ∧ ¬ IsRegionIncidentEdge (G := G) R e))
         (fun e => by simp [Finset.mem_filter]) (fun e => A.bondDim e)]
 
+omit [Fintype V] in
+/-- The vertex product over `R` is unchanged by the overwrite: the overwrite touches only
+non-`R`-incident edges, which the product over `R` does not read. -/
+theorem regionProd_insertOverwrite (A : Tensor G d) (R : Finset V) {v : V}
+    (μ : RegionBoundaryConfig (G := G) A (insert v R))
+    (σ : RegionPhysicalConfig (V := V) (d := d) (insert v R)) (ζ : VirtualConfig A) :
+    (∏ w : {w : V // w ∈ R}, A.component w.1
+        (fun ie => insertOverwrite (G := G) A R μ ζ ie.1)
+        (restrictInsertPhysical (V := V) (d := d) R σ w)) =
+      ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1)
+        (restrictInsertPhysical (V := V) (d := d) R σ w) := by
+  classical
+  refine Finset.prod_congr rfl (fun w _ => ?_)
+  congr 1
+  funext ie
+  -- An edge incident to `w ∈ R` is `R`-incident, where the overwrite is the identity.
+  refine insertOverwrite_eq_of_regionIncident (G := G) A R μ ζ ?_
+  rcases ie.2 with hie | hie
+  · exact Or.inl (by rw [hie]; exact w.2)
+  · exact Or.inr (by rw [hie]; exact w.2)
+
+open scoped Classical in
+/-- **The inserted-site multiplicity collapse.** Under inserted-site consistency, the blocked
+weight of `R` at the bridge label `boundaryLabelOfInsert μ η` overcounts the residual at `η` by
+the inserted-site multiplicity `insertOuterBondProd`: the blocked weight is that multiplicity
+times the residual.
+
+This is the inserted-site analogue of `regionInsertedCoeff_eq_smul_edgeInsertedCoeff`: the
+free non-`R`-incident `insert v R`-boundary edges are pinned in the residual but free in the
+blocked weight, so the blocked-weight sum, grouped by overwriting those edges with `μ`, is
+`insertOuterBondProd` copies of the residual sum.  The multiplicity is bond data alone, hence
+identical for `A` and for the reindexed comparison tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1544--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_bridge_eq_smul_insertResidual (A : Tensor G d) (R : Finset V)
+    {v : V} (hv : v ∉ R)
+    (μ : RegionBoundaryConfig (G := G) A (insert v R))
+    (σ : RegionPhysicalConfig (V := V) (d := d) (insert v R))
+    (η : LocalVirtualConfig A v)
+    (hcons : InsertConsistent (G := G) A R μ η) :
+    regionBlockedWeight (G := G) A R (boundaryLabelOfInsert (G := G) A R hv μ η)
+        (restrictInsertPhysical (V := V) (d := d) R σ) =
+      insertOuterBondProd (G := G) A R (v := v) • insertResidual (G := G) A R μ σ η := by
+  classical
+  -- Group the bridge-label blocked-weight sum by overwriting the mult-edges with `μ`.
+  rw [regionBlockedWeight]
+  rw [insertResidual_eq_filter_regionBlockedWeight (G := G) A R hv μ σ η]
+  rw [← Finset.sum_fiberwise_of_maps_to
+    (g := fun ζ => insertOverwrite (G := G) A R μ ζ)
+    (t := Finset.univ.filter (fun ζ' : VirtualConfig A =>
+      regionBoundaryLabel (G := G) A R ζ' = boundaryLabelOfInsert (G := G) A R hv μ η ∧
+        regionBoundaryLabel (G := G) A (insert v R) ζ' = μ ∧
+        (fun ie : IncidentEdge G v => ζ' ie.1) = η))
+    (f := fun ζ => ∏ w : {w : V // w ∈ R}, A.component w.1 (fun ie => ζ ie.1)
+      (restrictInsertPhysical (V := V) (d := d) R σ w))
+    (s := Finset.univ.filter (fun ζ : VirtualConfig A =>
+      regionBoundaryLabel (G := G) A R ζ = boundaryLabelOfInsert (G := G) A R hv μ η)) ?_]
+  · rw [Finset.smul_sum]
+    refine Finset.sum_congr rfl (fun ζ' hζ' => ?_)
+    rw [Finset.mem_filter] at hζ'
+    obtain ⟨_, _, hμη⟩ := hζ'
+    -- On each residual fiber the product is constant `(residual summand at ζ')`, with the
+    -- inserted-site multiplicity as count.
+    rw [Finset.filter_filter]
+    rw [Finset.sum_congr rfl (g := fun _ => ∏ w : {w : V // w ∈ R},
+        A.component w.1 (fun ie => ζ' ie.1)
+          (restrictInsertPhysical (V := V) (d := d) R σ w))
+      (fun ζ hζ => by
+        rw [Finset.mem_filter] at hζ
+        rw [← hζ.2.2, regionProd_insertOverwrite (G := G) A R μ σ ζ])]
+    rw [Finset.sum_const]
+    rw [show (Finset.univ.filter (fun ζ : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A R ζ = boundaryLabelOfInsert (G := G) A R hv μ η ∧
+          insertOverwrite (G := G) A R μ ζ = ζ')).card =
+        insertOuterBondProd (G := G) A R (v := v) from
+      insertFiber_card (G := G) A R hv μ η ζ' hμη]
+  · -- The overwrite of a bridge-label config lands in the residual filter.
+    intro ζ hζ
+    rw [Finset.mem_filter] at hζ ⊢
+    obtain ⟨hμ, hη⟩ := insertOverwrite_mem_residualFilter (G := G) A R hv μ η hcons ζ hζ.2
+    refine ⟨Finset.mem_univ _, ?_, hμ, hη⟩
+    -- The overwrite's `R`-boundary label is the bridge label: `R`-boundary edges are
+    -- `R`-incident, where the overwrite is the identity.
+    show regionBoundaryLabel (G := G) A R (insertOverwrite (G := G) A R μ ζ) = _
+    funext g
+    rw [regionBoundaryLabel_apply,
+      insertOverwrite_eq_of_regionIncident (G := G) A R μ ζ
+        (isRegionBoundaryEdge_touches (G := G) R g.2)]
+    exact congrFun hζ.2 g
+
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1879,19 +1879,41 @@ The remaining obligations are the following.
           edges (\leanid{TNLean.PEPS.boundaryLabelOfInsert},
           \leanid{TNLean.PEPS.regionBoundaryLabel_eq_boundaryLabelOfInsert}).
 
-          The precise step that remains is the residual-multiplicity factorization, the inserted-site
-          analogue of \leanid{TNLean.PEPS.regionInsertedCoeff_eq_smul_edgeInsertedCoeff}. The
-          residual sum at a fixed local configuration \(\eta\) at \(v\) is not the bare blocked weight
-          of \(R\): it carries (i) a consistency delta forcing \(\mu\) and \(\eta\) to agree on the
-          \(v\)-incident edges running to \((\operatorname{insert} v\,R)^c\) (these are
-          \(S\)-boundary but not \(R\)-boundary), and (ii) the interior bond multiplicity of the
-          \(S\)-boundary edges away from \(R\), which are free in the residual sum but pinned by
-          \(\mu\). Both factors are bond-dimension data, hence identical for \(A\) and for the
-          reindexed \(\widetilde B\); they therefore cancel in the quotient of the two region
-          proportionalities, leaving \(\sum_\eta A.\mathrm{component}\,v\,\eta \cdot
-          (c_R\,\widetilde B\,\text{-residual})\). Inverting the inserted-site tensor map through the
-          \(R\)-block injectivity then yields the per-vertex relation
-          \(A_v=(c_S/c_R)\cdot\widetilde B_v\). Until this residual factorization is built,
+          The residual-multiplicity factorization, the inserted-site analogue of
+          \leanid{TNLean.PEPS.regionInsertedCoeff_eq_smul_edgeInsertedCoeff}, is now landed. The
+          residual sum at a fixed local configuration \(\eta\) at \(v\)
+          (\leanid{TNLean.PEPS.insertResidual}) is not the bare blocked weight of \(R\): it carries
+          (i) a consistency delta forcing \(\mu\) and \(\eta\) to agree on the \(v\)-incident edges
+          running to \((\operatorname{insert} v\,R)^c\) (these are \(S\)-boundary but not
+          \(R\)-boundary), formalized as the vanishing of the residual on a mismatched outer
+          \(v\)-incident edge (\leanid{TNLean.PEPS.insertResidual_eq_zero_of_inconsistent}); and
+          (ii) the interior bond multiplicity of the \(S\)-boundary edges away from \(R\), which are
+          free in the residual sum but pinned by \(\mu\), the inserted-site overcounting
+          multiplicity \leanid{TNLean.PEPS.insertOuterBondProd}. The residual refines the
+          bridge-label blocked weight of \(R\)
+          (\leanid{TNLean.PEPS.insertResidual_eq_filter_regionBlockedWeight}), and grouping the
+          bridge-label blocked-weight sum by overwriting the free outer edges with \(\mu\) collapses
+          it to the multiplicity times the residual when \(\mu\) and \(\eta\) are consistent
+          (\leanid{TNLean.PEPS.regionBlockedWeight_bridge_eq_smul_insertResidual}, with the fiber
+          cardinality \leanid{TNLean.PEPS.insertFiber_card}). Assembling the local-configuration
+          grouping (\leanid{TNLean.PEPS.regionBlockedWeight_insert_eq_sum_localConfig}) with this
+          collapse gives the inserted-site factorization
+          (\leanid{TNLean.PEPS.insertOuterBondProd_smul_regionBlockedWeight_insert} and
+          \leanid{TNLean.PEPS.insertOuterBondProd_smul_insertResidual_eq}): the inserted-site
+          multiplicity times the blocked weight of \(S\) is \(\sum_\eta
+          A.\mathrm{component}\,v\,\eta\,(\sigma_v)\) against the bridge-label blocked weight of
+          \(R\) on the consistent configurations. The multiplicity is bond-dimension data, hence
+          identical for \(A\) and for the reindexed \(\widetilde B\); it therefore cancels in the
+          quotient of the two region proportionalities, leaving \(\sum_\eta
+          A.\mathrm{component}\,v\,\eta \cdot (c_R\,\widetilde B\,\text{-residual})\).
+
+          The precise step that remains is the scalar extraction: feeding the two region
+          proportionalities \(A_R=c_R\,\widetilde B_R\) and \(A_S=c_S\,\widetilde B_S\) (the outputs
+          of \leanid{TNLean.PEPS.regionComplement_comparison} at \(R\) and \(S=\operatorname{insert}
+          v\,R\)) through the inserted-site factorization and inverting the inserted-site tensor map
+          through the \(R\)-block injectivity (linear independence of \(R\)'s blocked family), to
+          yield the per-vertex relation \(A_v=(c_S/c_R)\cdot\widetilde B_v\) at matching local
+          configurations. Until this scalar extraction is built on top of the landed factorization,
           \path{hPV} remains the conditional input of the torus theorem rather than a derived
           consequence.
     \item Prove the scalar condition $\lambda^{nm}=1$ for the square-lattice


### PR DESCRIPTION
## What

The inserted-site fiber-collapse factorization — the load-bearing residual of the one-site
quotient (TI Normal PEPS FT, #1373). 19 declarations in `InsertResidual.lean`; all
sorry-free; `#print axioms` = `[propext, Classical.choice, Quot.sound]`; full root build
green (8,876 jobs).

- The local-config grouping, the v-incident consistency delta, the bridge-label refinement.
- **`insertOuterBondProd`** (+ congruence) — the overcounting multiplicity, proven
  bond-data-only (manifestly identical for A and B̃ — it cancels in the quotient).
- **`insertFiber_card`** — the fiber bijection (the `regionFiber_card` genre).
- **`insertOuterBondProd_smul_regionBlockedWeight_insert`** — the capstone: the
  multiplicity-scaled `insert v R` weight = Σ_η (A's vertex tensor at η) · (the bridge-label
  R-weight on consistent configs).

## Remaining (documented)

The scalar extraction (invert the inserted-site map through R-block injectivity:
`A_R = c_R·B̃_R` + `A_S = c_S·B̃_S` ⟹ `A_v = (c_S/c_R)·B̃_v`) and the orientation
reconciliation — then `hPV` and the unconditional theorem.

Refs #1373. CI failures are non-blocking automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization in a new PEPS module plus documentation; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TNLean/PEPS/RegionBlock/InsertResidual.lean`** (~618 lines) and wires it into **`TNLean.lean`**, formalizing the inserted-site **residual–multiplicity factorization** for the normal PEPS Fundamental Theorem (arXiv:1804.04964 §3).
> 
> The new module defines **`insertResidual`** and proves grouping of the `insert v R` blocked weight by local virtual config at `v` (`regionBlockedWeight_insert_eq_sum_localConfig`). It handles **μ/η consistency** on outer `v`-incident edges (`InsertConsistent`, vanishing residuals when inconsistent), refines residuals against **bridge-label** blocked weights on `R`, and introduces **`insertOuterBondProd`** with **`insertOuterBondProd_congr`** (multiplicity depends only on bond dimensions). Fiber bookkeeping (`insertOverwrite`, **`insertFiber_card`**) yields the multiplicity collapse **`regionBlockedWeight_bridge_eq_smul_insertResidual`** and the capstone **`insertOuterBondProd_smul_regionBlockedWeight_insert`** / **`insertOuterBondProd_smul_insertResidual_eq`**, isolating `A.component v` from the smaller-region blocked weight so bond-only multiplicity cancels in region proportionality quotients.
> 
> **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** is updated to mark this factorization as landed and to state that the remaining gap is **scalar extraction** (per-vertex relation from `A_R`, `A_S` and `R`-block injectivity), not the factorization itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30db3abce356122374211cc6b1e23735bd1d3cc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->