### PR TITLE
feat(PEPS): the bare-edge absorbed equality at every torus edge

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -478,6 +478,9 @@ import TNLean.PEPS.RegionBlock.ScalarExtraction
 -- Region-block scalar proportionalities from the edge-level absorbed equality: the
 -- region-independence step feeding the region comparison its absorbed `hregion`.
 import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
+-- A single gauge family with the bare-edge absorbed equality at every torus edge,
+-- read off the orientation-class coefficient-identity witness families.
+import TNLean.PEPS.TorusEdgeAbsorbed
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -475,6 +475,9 @@ import TNLean.PEPS.RegionBlock.InsertResidual
 -- Inserted-site scalar extraction: the per-vertex relation from the two region
 -- proportionalities and linear independence of the smaller region's blocked family.
 import TNLean.PEPS.RegionBlock.ScalarExtraction
+-- Region-block scalar proportionalities from the edge-level absorbed equality: the
+-- region-independence step feeding the region comparison its absorbed `hregion`.
+import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
+++ b/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
@@ -48,6 +48,44 @@ namespace PEPS
 variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 
+/-- **The edge-level absorbed equality from a region conjugation identity.**
+
+If the per-edge gauge `Z` realizes the engine's conjugation-form region-inserted coefficient
+identity at a region `R` with single boundary edge `f` --- `A` inserting `M` matches `B` inserting
+`Z · (reindex M) · Z⁻¹` --- then the *edge-level* absorbed equality holds at `f.1` against
+`applyGauge B X`, provided `X f.1` is the orientation-adapted absorbing gauge
+`absorbedBoundaryGauge B R f Z` and every bond dimension of `A` is positive.  The edge-level
+identity over the bare edge `f.1` mentions no region.
+
+The conversion is `regionInsertedCoeff_eq_applyGauge_of_conjIdentity` (turning the conjugation
+identity into the region absorbed equality at `R`) followed by `edgeInsertedCoeff_eq_applyGauge_of_region`
+(cancelling the shared positive interior multiplicity to the bare-edge identity).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeAbsorbed_of_conjIdentity (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hbd : A.bondDim = B.bondDim)
+    (Z : GL (Fin (B.bondDim f.1)) ℂ)
+    (X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (hXf : X f.1 = absorbedBoundaryGauge (G := G) B R f Z)
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hid : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f
+          ((Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) M *
+            (↑Z⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
+    (σ : V → Fin d) (N : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    edgeInsertedCoeff (G := G) A f.1 σ N =
+      edgeInsertedCoeff (G := G) (applyGauge B X) f.1 σ
+        (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) N) :=
+  edgeInsertedCoeff_eq_applyGauge_of_region A B R f hbd X hposA
+    (fun M σ' τ' => regionInsertedCoeff_eq_applyGauge_of_conjIdentity A B R f hbd Z X hXf hid M σ' τ')
+    σ N
+
 /-- **The region absorbed equality from the edge-level absorbed equality on every boundary edge.**
 
 If the edge-level absorbed equality holds against `applyGauge B X` at *every* boundary edge of `R`

--- a/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
+++ b/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
@@ -1,0 +1,117 @@
+import TNLean.PEPS.RegionBlock.AbsorbedEquality
+import TNLean.PEPS.RegionComplementComparison
+
+/-!
+# Region proportionalities from the edge-level absorbed equality
+
+This file performs the orientation-reconciliation step of the normal PEPS Fundamental Theorem's
+final comparison (arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex`).
+
+The region comparison `regionComplement_comparison` consumes, as its load-bearing hypothesis
+`hregion`, the *absorbed plain* region-inserted coefficient equality
+
+> `regionInsertedCoeff A R f M = regionInsertedCoeff (applyGauge B X) R f (reindex M)`
+
+against a single gauge family `X`.  The per-edge gauge engine instead delivers a *conjugation*-form
+identity against a per-edge gauge `Z_e`, whose region-level absorbed form
+(`regionInsertedCoeff_eq_applyGauge_of_conjIdentity`) holds against the orientation-adapted
+absorbing gauge `absorbedBoundaryGauge` at the boundary edge, not against a single uniform `X`.
+
+The reconciliation here is the *region-independence* of the absorbed equality: an absorbed equality
+holding at the *edge level* on every boundary edge of `R` --- the bare-edge statement
+`edgeInsertedCoeff A e σ N = edgeInsertedCoeff (applyGauge B X) e σ (reindex N)`, which mentions no
+region --- multiplies back up to the region absorbed equality at `R`
+(`regionInsertedCoeff_eq_applyGauge_of_edge`), supplying `hregion` for *every* comparison region
+whose boundary edges all carry the edge-level absorbed equality.  Feeding it to
+`regionComplement_comparison` produces the region-block scalar proportionality `A_R ∝ B̃_R` that the
+inserted-site scalar extraction consumes.
+
+The single uniform `X` realizing the edge-level absorbed equality at every edge --- the
+transpose/orientation transport of the per-edge engine gauges into one orientation-uniform family
+--- is the remaining open piece recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`; this file assembles the proportionalities
+on top of it.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- **The region absorbed equality from the edge-level absorbed equality on every boundary edge.**
+
+If the edge-level absorbed equality holds against `applyGauge B X` at *every* boundary edge of `R`
+--- inserting `N` on `A`'s edge `e` matches inserting the reindexed `N` on `applyGauge B X`'s edge
+`e` for every global physical configuration --- then the *region* absorbed equality holds at `R`:
+inserting `M` on `A` over `R` at a boundary edge `f` matches inserting the reindexed `M` on
+`applyGauge B X` over `R` at `f`.
+
+This is the `hregion` hypothesis of `regionComplement_comparison`, here packaged from the
+region-independent edge-level identity `regionInsertedCoeff_eq_applyGauge_of_edge`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionAbsorbed_of_edgeAbsorbed (A B : Tensor G d)
+    (hbd : A.bondDim = B.bondDim)
+    (X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (R : Finset V)
+    (hedge : ∀ (e : Edge G) (σ : V → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+      edgeInsertedCoeff (G := G) A e σ N =
+        edgeInsertedCoeff (G := G) (applyGauge B X) e σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd e)) N))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    regionInsertedCoeff (G := G) A R f M σ τ =
+      regionInsertedCoeff (G := G) (applyGauge B X) R f
+        (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) M) σ τ :=
+  regionInsertedCoeff_eq_applyGauge_of_edge A B hbd X f.1 (hedge f.1) R f rfl M σ τ
+
+/-- **Region-block scalar proportionality from the edge-level absorbed equality.**
+
+For a region `R` whose two block tensors over `A` and over the gauge-absorbed second tensor
+`applyGauge B X` are all two-block injective, if the edge-level absorbed equality against
+`applyGauge B X` holds at every edge of the graph, then the region blocks of `A` and of the
+reindexed `applyGauge B X` are scalar proportional: there is a nonzero `c` with `A_R = c · B̃_R`.
+
+This is `regionComplement_comparison` fed the region absorbed equality of
+`regionAbsorbed_of_edgeAbsorbed`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1544 of
+`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B̃_R`. -/
+theorem twoBlockProportional_of_edgeAbsorbed (A B : Tensor G d)
+    (hbd : A.bondDim = B.bondDim)
+    (X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (R : Finset V)
+    [Nonempty {f : Edge G // IsRegionBoundaryEdge (G := G) R f}]
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G)
+      (reindexTensor (G := G) (applyGauge B X) hbd) R)
+    (hCB : RegionBlockedTensorInjective (G := G)
+      (reindexTensor (G := G) (applyGauge B X) hbd) (Finset.univ \ R))
+    (hedge : ∀ (e : Edge G) (σ : V → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+      edgeInsertedCoeff (G := G) A e σ N =
+        edgeInsertedCoeff (G := G) (applyGauge B X) e σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd e)) N)) :
+    ∃ c : ℂ, c ≠ 0 ∧
+      TwoBlockScalarProportional (regionTwoBlock (G := G) A R)
+        (regionTwoBlock (G := G) (reindexTensor (G := G) (applyGauge B X) hbd) R) c :=
+  regionComplement_comparison A (applyGauge B X) R hbd hRA hCA hRB hCB
+    (fun f N σ τ => regionAbsorbed_of_edgeAbsorbed A B hbd X R hedge f N σ τ)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
+++ b/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
@@ -20,12 +20,12 @@ absorbing gauge `absorbedBoundaryGauge` at the boundary edge, not against a sing
 
 The reconciliation here is the *region-independence* of the absorbed equality: an absorbed equality
 holding at the *edge level* on every boundary edge of `R` --- the bare-edge statement
-`edgeInsertedCoeff A e σ N = edgeInsertedCoeff (applyGauge B X) e σ (reindex N)`, which mentions no
-region --- multiplies back up to the region absorbed equality at `R`
+`edgeInsertedCoeff A e σ N = edgeInsertedCoeff (applyGauge B X) e σ (reindex N)`, which mentions
+no region --- multiplies back up to the region absorbed equality at `R`
 (`regionInsertedCoeff_eq_applyGauge_of_edge`), supplying `hregion` for *every* comparison region
 whose boundary edges all carry the edge-level absorbed equality.  Feeding it to
-`regionComplement_comparison` produces the region-block scalar proportionality `A_R ∝ B̃_R` that the
-inserted-site scalar extraction consumes.
+`regionComplement_comparison` produces the region-block scalar proportionality `A_R ∝ B̃_R` that
+the inserted-site scalar extraction consumes.
 
 The single uniform `X` realizing the edge-level absorbed equality at every edge --- the
 transpose/orientation transport of the per-edge engine gauges into one orientation-uniform family
@@ -152,6 +152,61 @@ theorem twoBlockProportional_of_edgeAbsorbed (A B : Tensor G d)
         (regionTwoBlock (G := G) (reindexTensor (G := G) (applyGauge B X) hbd) R) c :=
   regionComplement_comparison A (applyGauge B X) R hbd hRA hCA hRB hCB
     (fun f N σ τ => regionAbsorbed_of_edgeAbsorbed A B hbd X R hedge f N σ τ)
+
+/-! ### Uniqueness of the proportionality scalar
+
+The scalar `c` in a region-block proportionality `A_R = c · B̃_R` is determined by `A` and `B̃`
+once `B̃`'s blocked family is linearly independent: a linearly independent family has no zero
+member, so some blocked weight of `B̃` is nonzero, and the proportionality reads `c` off that
+nonzero entry.  This names the proportionality scalar canonically --- the translation-invariant
+common quotient the torus scalar condition consumes is the ratio of two such named scalars. -/
+
+/-- **Uniqueness of the region-block proportionality scalar.**
+
+If the reindexed comparison tensor `B̃ = reindexTensor Btilde hbd` has a linearly independent
+blocked family over `R`, every bond dimension is positive, and both `c` and `c'` are
+proportionality scalars of `A_R` against `B̃_R`, then `c = c'`: positivity makes the boundary-label
+index nonempty, linear independence forbids a zero member there, so some blocked weight of `B̃` is
+nonzero and both scalars equal `A`'s weight divided by it.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`: the proportionality constant is
+unique. -/
+theorem twoBlockScalarProportional_unique (A Btilde : Tensor G d) (R : Finset V)
+    (hbd : A.bondDim = Btilde.bondDim)
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e)
+    (hBinj : RegionBlockedTensorInjective (G := G) (reindexTensor (G := G) Btilde hbd) R)
+    {c c' : ℂ}
+    (hc : TwoBlockScalarProportional (regionTwoBlock (G := G) A R)
+      (regionTwoBlock (G := G) (reindexTensor (G := G) Btilde hbd) R) c)
+    (hc' : TwoBlockScalarProportional (regionTwoBlock (G := G) A R)
+      (regionTwoBlock (G := G) (reindexTensor (G := G) Btilde hbd) R) c') :
+    c = c' := by
+  classical
+  set C := reindexTensor (G := G) Btilde hbd with hCdef
+  -- The boundary-label index is nonempty: each incident bond is positive, so the value space is
+  -- nonempty and the (possibly empty) boundary-edge index admits a configuration.
+  have hCpos : ∀ e : Edge G, 0 < C.bondDim e := fun e => by
+    rw [hCdef, reindexTensor_bondDim]; exact hpos e
+  have hNe : Nonempty (RegionBoundaryConfig (G := G) C R) :=
+    ⟨fun f => ⟨0, hCpos f.1⟩⟩
+  -- A linearly independent family has no zero member: pick a boundary label `b` and a physical
+  -- configuration `ρ` where `B̃`'s blocked weight is nonzero.
+  have hne : (regionBlockedTensorFamily (G := G) C R)
+      (Classical.arbitrary (RegionBoundaryConfig (G := G) C R)) ≠ 0 :=
+    hBinj.ne_zero _
+  obtain ⟨ρ, hρ⟩ : ∃ ρ, regionBlockedWeight (G := G) C R
+      (Classical.arbitrary (RegionBoundaryConfig (G := G) C R)) ρ ≠ 0 := by
+    by_contra h
+    push Not at h
+    exact hne (funext h)
+  set b := Classical.arbitrary (RegionBoundaryConfig (G := G) C R) with hbdef
+  -- Both proportionalities read at `(b, ρ)` give `A_R = c · B̃_R` and `A_R = c' · B̃_R`.
+  have h1 := hc PUnit.unit b ρ
+  have h2 := hc' PUnit.unit b ρ
+  simp only [regionTwoBlock_apply] at h1 h2
+  have : c * regionBlockedWeight (G := G) C R b ρ =
+      c' * regionBlockedWeight (G := G) C R b ρ := by rw [← h1, ← h2]
+  exact mul_right_cancel₀ hρ this
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
+++ b/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
@@ -58,8 +58,9 @@ identity at a region `R` with single boundary edge `f` --- `A` inserting `M` mat
 identity over the bare edge `f.1` mentions no region.
 
 The conversion is `regionInsertedCoeff_eq_applyGauge_of_conjIdentity` (turning the conjugation
-identity into the region absorbed equality at `R`) followed by `edgeInsertedCoeff_eq_applyGauge_of_region`
-(cancelling the shared positive interior multiplicity to the bare-edge identity).
+identity into the region absorbed equality at `R`) followed by
+`edgeInsertedCoeff_eq_applyGauge_of_region` (cancelling the shared positive interior multiplicity
+to the bare-edge identity).
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
 `Papers/1804.04964/paper_normal.tex`. -/
@@ -83,7 +84,8 @@ theorem edgeAbsorbed_of_conjIdentity (A B : Tensor G d) (R : Finset V)
       edgeInsertedCoeff (G := G) (applyGauge B X) f.1 σ
         (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) N) :=
   edgeInsertedCoeff_eq_applyGauge_of_region A B R f hbd X hposA
-    (fun M σ' τ' => regionInsertedCoeff_eq_applyGauge_of_conjIdentity A B R f hbd Z X hXf hid M σ' τ')
+    (fun M σ' τ' =>
+      regionInsertedCoeff_eq_applyGauge_of_conjIdentity A B R f hbd Z X hXf hid M σ' τ')
     σ N
 
 /-- **The region absorbed equality from the edge-level absorbed equality on every boundary edge.**

--- a/TNLean/PEPS/TorusEdgeAbsorbed.lean
+++ b/TNLean/PEPS/TorusEdgeAbsorbed.lean
@@ -1,0 +1,150 @@
+import TNLean.PEPS.TorusWitnessCapstone
+import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
+
+/-!
+# The bare-edge absorbed equality at every torus edge
+
+This file produces, from the torus rectangle-injectivity hypotheses, a single per-edge gauge family
+`X` over the second tensor's bonds for which the *bare-edge absorbed equality* against
+`applyGauge B X` holds at every edge of the discrete torus (arXiv:1804.04964, Section 3, proof of
+Theorem 3, lines 1519--1544 of `Papers/1804.04964/paper_normal.tex`):
+
+> `edgeInsertedCoeff A e σ N = edgeInsertedCoeff (applyGauge B X) e σ (reindex N)`.
+
+The per-edge gauge engine delivers, at every horizontal (vertical) edge `e`, an
+`EdgeCoeffIdentityWitness` carrying a red blocking region `R_e` whose single boundary edge is `e`
+and a *conjugation*-form coefficient identity realized by a per-edge gauge `Z_e`
+(`exists_edgeCoeffIdentityWitness_horizontalFamily`,
+`exists_edgeCoeffIdentityWitness_verticalFamily`).  The family `X` is built edgewise from those
+witnesses by the orientation-adapted absorbing gauge `absorbedBoundaryGauge B R_e ⟨e,_⟩ Z_e`, and
+the bare-edge absorbed equality at `e` follows from `edgeAbsorbed_of_conjIdentity`.  Because the
+bare-edge identity at `e` depends only on the gauge `X e` (the open-edge gauge cancellation
+`edgeInsertedCoeff_applyGauge`), the absorbing choice at each edge is independent of the others.
+
+The orientation-uniformity of this absorbing family (that it is one horizontal matrix and one
+vertical matrix up to per-edge scalars, the shape the torus Fundamental Theorem's gauge conclusion
+asserts) is the remaining open piece recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **The bare-edge absorbed equality from a single edge witness.**
+
+If an edge `e` of the torus carries an `EdgeCoeffIdentityWitness` with per-edge gauge `Z`, then the
+bare-edge absorbed equality holds at `e` against `applyGauge B X`, provided `X e` is the
+orientation-adapted absorbing gauge `absorbedBoundaryGauge B w.region ⟨e, w.isBoundary⟩ Z` and
+every bond dimension of `A` is positive.
+
+The witness's conjugation-form coefficient identity (`EdgeCoeffIdentityWitness.hidZ`) is fed to
+`edgeAbsorbed_of_conjIdentity`, which converts it to the absorbed region equality and cancels the
+shared positive interior multiplicity to the bare-edge identity.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeAbsorbed_of_edgeCoeffIdentityWitness
+    {A B : Tensor (torusGraph width height) d} {e : Edge (torusGraph width height)}
+    {Z Zref : GL (Fin (B.bondDim e)) ℂ} {hE : A.bondDim e = B.bondDim e}
+    (w : EdgeCoeffIdentityWitness A B e Z Zref hE)
+    (hbd : A.bondDim = B.bondDim)
+    (X : (g : Edge (torusGraph width height)) → GL (Fin (B.bondDim g)) ℂ)
+    (hXe : X e = absorbedBoundaryGauge (G := torusGraph width height) B w.region
+      ⟨e, w.isBoundary⟩ Z)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (σ : TorusVertex width height → Fin d)
+    (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    edgeInsertedCoeff (G := torusGraph width height) A e σ N =
+      edgeInsertedCoeff (G := torusGraph width height) (applyGauge B X) e σ
+        (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd e)) N) := by
+  -- The witness's boundary edge is `⟨e, w.isBoundary⟩`; `hE` and `congr_fun hbd e` agree.
+  have hEeq : hE = congr_fun hbd e := Subsingleton.elim _ _
+  subst hEeq
+  exact edgeAbsorbed_of_conjIdentity A B w.region ⟨e, w.isBoundary⟩ hbd Z X hXe hposA
+    (fun M σ' τ' => w.hidZ M σ' τ') σ N
+
+/-- **A gauge family with the bare-edge absorbed equality at every torus edge.**
+
+For a translation-invariant pair `A`, `B` on the torus with matched bond dimensions, positive bonds,
+the same state, and both satisfying the rectangular-injectivity hypotheses with union closure, there
+is a per-edge gauge family `X` over the second tensor's bonds for which the bare-edge absorbed
+equality against `applyGauge B X` holds at every edge: inserting `N` on `A`'s edge `e` matches
+inserting the reindexed `N` on `applyGauge B X`'s edge `e`, for every global physical configuration
+and every matrix.
+
+The horizontal and vertical coefficient-identity witness families
+(`exists_edgeCoeffIdentityWitness_horizontalFamily`,
+`exists_edgeCoeffIdentityWitness_verticalFamily`) supply, at every edge, a witness whose
+conjugation-form coefficient identity is converted to the bare-edge absorbed equality by
+`edgeAbsorbed_of_edgeCoeffIdentityWitness`.  The family `X` is the per-edge orientation-adapted
+absorbing gauge read off each chosen witness; the bare-edge identity at `e` depends only on `X e`,
+so the per-edge absorbing choices are independent.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_edgeAbsorbed_torus_rectangle
+    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (hAr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hBr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
+    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
+    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
+    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
+    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
+    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hbd : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    ∃ X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ,
+      ∀ (e : Edge (torusGraph width height)) (σ : TorusVertex width height → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+        edgeInsertedCoeff (G := torusGraph width height) A e σ N =
+          edgeInsertedCoeff (G := torusGraph width height) (applyGauge B X) e σ
+            (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd e)) N) := by
+  classical
+  -- The two orientation-class witness families.
+  have witH := exists_edgeCoeffIdentityWitness_horizontalFamily hA hB hAr hBr hUA hUB
+    hxh0 hyh0 hxhw hyhh hxhw' hyhh' hbd hAB hd hposA hposB
+  have witV := exists_edgeCoeffIdentityWitness_verticalFamily hA hB hAr hBr hUA hUB
+    hxv0 hyv0 hxvw hyvh hxvw' hyvh' hbd hAB hd hposA hposB
+  -- For every edge, a chosen gauge, reference gauge, bond-dimension equality, and a *nonempty*
+  -- witness of the appropriate orientation class.
+  have hwit : ∀ e : Edge (torusGraph width height),
+      ∃ (Z Zref : GL (Fin (B.bondDim e)) ℂ) (hE : A.bondDim e = B.bondDim e),
+        Nonempty (EdgeCoeffIdentityWitness A B e Z Zref hE) := by
+    intro e
+    rcases torusEdge_horizontal_or_vertical e with he | he
+    · exact witH e he
+    · exact witV e he
+  -- The chosen per-edge gauge, reference gauge, bond-dimension equality, and nonempty witness.
+  choose Z Zref hE hne using hwit
+  -- A chosen witness at each edge.
+  set w : (e : Edge (torusGraph width height)) →
+      EdgeCoeffIdentityWitness A B e (Z e) (Zref e) (hE e) := fun e => (hne e).some with hwdef
+  -- The absorbing family, read off each chosen witness.
+  refine ⟨fun e => absorbedBoundaryGauge (G := torusGraph width height) B (w e).region
+    ⟨e, (w e).isBoundary⟩ (Z e), fun e σ N => ?_⟩
+  exact edgeAbsorbed_of_edgeCoeffIdentityWitness (w e) hbd
+    (fun g => absorbedBoundaryGauge (G := torusGraph width height) B (w g).region
+      ⟨g, (w g).isBoundary⟩ (Z g)) rfl hposA σ N
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusFundamentalTheorem.lean
+++ b/TNLean/PEPS/TorusFundamentalTheorem.lean
@@ -1,6 +1,7 @@
 import TNLean.PEPS.RegionScalarCondition
 import TNLean.PEPS.TorusWitnessCapstone
 import TNLean.PEPS.RegionBlock.ScalarExtraction
+import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
 
 /-!
 # The normal PEPS Fundamental Theorem on the discrete torus
@@ -156,6 +157,98 @@ theorem lambda_pow_card_torus_eq_one_of_twoBlockProportional
   have hv := component_eq_gaugeVertex_of_twoBlockProportional A B (Rv v) (hvR v) hbd X
     (cR v) (cS v) (hcR v) hpos (hCinj v) (hRprop v) (hSprop v) η σ
   rw [hv, hlam v]
+
+/-! ### The scalar condition from the edge-level absorbed equality
+
+The two-block proportionalities of `lambda_pow_card_torus_eq_one_of_twoBlockProportional` are
+themselves the output of the region comparison `regionComplement_comparison`, whose load-bearing
+`hregion` hypothesis is the absorbed plain region-inserted coefficient equality.  This in turn
+follows, at every comparison region, from the bare-edge absorbed equality
+(`twoBlockProportional_of_edgeAbsorbed`, the region-independence of the absorbed equality).  This
+layer consumes that bare-edge equality directly: at every torus vertex `v`, the comparison at the
+one-site-different regions `R_v` and `insert v R_v` delivers, from the edge-level absorbed equality,
+the two proportionalities with a common ratio `λ`, after which the scalar condition is
+`lambda_pow_card_torus_eq_one_of_twoBlockProportional`. -/
+
+open scoped Classical in
+/-- **The torus scalar condition from the edge-level absorbed equality.**
+
+At every torus vertex `v`, suppose a region `R_v` (not containing `v`, with at least one boundary
+edge, and likewise for `insert v R_v`) is supplied together with the blocked-tensor injectivity of
+`A` and of the reindexed gauge-absorbed tensor over `R_v`, over `insert v R_v`, and over their
+complements.  Suppose moreover the bare-edge absorbed equality holds against `applyGauge B X` at
+every edge of the torus, and that the proportionality scalars `c_R(v)`, `c_S(v)` produced by the
+region comparison have a common quotient `λ`.  Then under the same state, positive bonds, and a
+single comparison region `R` whose block and complement block are blocked-tensor injective, `λ`
+raised to the number of torus sites is one.
+
+The bare-edge absorbed equality feeds `twoBlockProportional_of_edgeAbsorbed` at `R_v` and at
+`insert v R_v`, producing the two two-block scalar proportionalities; their common ratio `λ` and
+`lambda_pow_card_torus_eq_one_of_twoBlockProportional` then give the scalar condition.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem lambda_pow_card_torus_eq_one_of_edgeAbsorbed
+    [Fact (1 < width)] [Fact (1 < height)]
+    (A B : Tensor (torusGraph width height) d)
+    (R : Finset (TorusVertex width height))
+    (hRA : RegionBlockedTensorInjective (G := torusGraph width height) A R)
+    (hCA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (Finset.univ \ R))
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < A.bondDim e)
+    (hAB : SameState A B)
+    (X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (hbd : A.bondDim = B.bondDim)
+    (lam : ℂ)
+    (Rv : TorusVertex width height → Finset (TorusVertex width height))
+    (hvR : ∀ v, v ∉ Rv v)
+    (hNeR : ∀ v, Nonempty {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) (Rv v) f})
+    (hNeS : ∀ v, Nonempty {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) (insert v (Rv v)) f})
+    (hRvA : ∀ v, RegionBlockedTensorInjective (G := torusGraph width height) A (Rv v))
+    (hSvA : ∀ v, RegionBlockedTensorInjective (G := torusGraph width height) A
+      (insert v (Rv v)))
+    (hCRvA : ∀ v, RegionBlockedTensorInjective (G := torusGraph width height) A
+      (Finset.univ \ Rv v))
+    (hCSvA : ∀ v, RegionBlockedTensorInjective (G := torusGraph width height) A
+      (Finset.univ \ insert v (Rv v)))
+    (hRvB : ∀ v, RegionBlockedTensorInjective (G := torusGraph width height)
+      (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd) (Rv v))
+    (hSvB : ∀ v, RegionBlockedTensorInjective (G := torusGraph width height)
+      (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd) (insert v (Rv v)))
+    (hCRvB : ∀ v, RegionBlockedTensorInjective (G := torusGraph width height)
+      (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd) (Finset.univ \ Rv v))
+    (hCSvB : ∀ v, RegionBlockedTensorInjective (G := torusGraph width height)
+      (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd)
+      (Finset.univ \ insert v (Rv v)))
+    (hedge : ∀ (e : Edge (torusGraph width height)) (σ : TorusVertex width height → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+      edgeInsertedCoeff (G := torusGraph width height) A e σ N =
+        edgeInsertedCoeff (G := torusGraph width height) (applyGauge B X) e σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd e)) N))
+    (hlam : ∀ v,
+      (twoBlockProportional_of_edgeAbsorbed A B hbd X (insert v (Rv v))
+          (hSvA v) (hCSvA v) (hSvB v) (hCSvB v) hedge).choose /
+        (twoBlockProportional_of_edgeAbsorbed A B hbd X (Rv v)
+          (hRvA v) (hCRvA v) (hRvB v) (hCRvB v) hedge).choose = lam) :
+    lam ^ (width * height) = 1 := by
+  classical
+  refine lambda_pow_card_torus_eq_one_of_twoBlockProportional A B R hRA hCA hpos hAB X hbd lam
+    Rv
+    (fun v => (twoBlockProportional_of_edgeAbsorbed A B hbd X (Rv v)
+      (hRvA v) (hCRvA v) (hRvB v) (hCRvB v) hedge).choose)
+    (fun v => (twoBlockProportional_of_edgeAbsorbed A B hbd X (insert v (Rv v))
+      (hSvA v) (hCSvA v) (hSvB v) (hCSvB v) hedge).choose)
+    hvR
+    (fun v => (twoBlockProportional_of_edgeAbsorbed A B hbd X (Rv v)
+      (hRvA v) (hCRvA v) (hRvB v) (hCRvB v) hedge).choose_spec.1)
+    hlam
+    (fun v => hRvB v)
+    (fun v => (twoBlockProportional_of_edgeAbsorbed A B hbd X (Rv v)
+      (hRvA v) (hCRvA v) (hRvB v) (hCRvB v) hedge).choose_spec.2)
+    (fun v => (twoBlockProportional_of_edgeAbsorbed A B hbd X (insert v (Rv v))
+      (hSvA v) (hCSvA v) (hSvB v) (hCSvB v) hedge).choose_spec.2)
 
 /-! ### The torus Fundamental Theorem
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1936,14 +1936,46 @@ The remaining obligations are the following.
           two-block proportionalities at every vertex with a common ratio
           (\leanid{TNLean.PEPS.lambda_pow_card_torus_eq_one_of_twoBlockProportional}).
 
+          The production of a \emph{single} per-edge family carrying the absorbed equality at every
+          edge is now landed. The conjugation-to-absorbed conversion is packaged so the bare-edge
+          absorbed equality at a single edge follows from one coefficient-identity witness, depending
+          only on the gauge at that edge (the open-edge gauge cancellation isolates the boundary
+          edge), so the per-edge absorbing choices are independent
+          (\leanid{TNLean.PEPS.edgeAbsorbed_of_conjIdentity},
+          \leanid{TNLean.PEPS.edgeAbsorbed_of_edgeCoeffIdentityWitness}). Feeding the two
+          orientation-class coefficient-identity witness families to that conversion produces one
+          per-edge gauge family \(X\) --- the orientation-adapted absorbing gauge read off each chosen
+          witness --- for which the bare-edge absorbed equality against \(\operatorname{applyGauge}
+          B\,X\) holds at every torus edge
+          (\leanid{TNLean.PEPS.exists_edgeAbsorbed_torus_rectangle}). The region-independence step
+          then multiplies this back up to the region absorbed equality, supplying the comparison's
+          \path{hregion} and producing the region-block proportionality \(A_R\propto\widetilde B_R\)
+          at \emph{every} comparison region from the bare-edge equality
+          (\leanid{TNLean.PEPS.regionAbsorbed_of_edgeAbsorbed},
+          \leanid{TNLean.PEPS.twoBlockProportional_of_edgeAbsorbed}); the proportionality scalar is
+          unique once the comparison block is injective
+          (\leanid{TNLean.PEPS.twoBlockScalarProportional_unique}). The torus scalar condition is then
+          assembled directly from the bare-edge absorbed equality plus the per-vertex two-block
+          proportionalities with a common ratio
+          (\leanid{TNLean.PEPS.lambda_pow_card_torus_eq_one_of_edgeAbsorbed}).
+
           What remains for an unconditional \path{hPV}, and hence for an unconditional torus
-          Fundamental Theorem, is the production of the two two-block proportionalities against the
-          single orientation-uniform \(X\): the absorbed equality the engine delivers is against the
-          per-edge absorbing family \leanid{TNLean.PEPS.absorbedBoundaryGauge}, so reconciling it with
-          the orientation-uniform \(X\) (the transpose/orientation bookkeeping across the two
-          orientation classes, the first open piece recorded above) and forcing a common ratio
-          \(c_S/c_R\) across the vertices by translation invariance remain open. The scalar
-          extraction itself is no longer on the critical path.
+          Fundamental Theorem, are three pieces, all consuming the landed \(X\) above. First, the
+          \emph{orientation-uniformity} of that absorbing family --- that it is one horizontal matrix
+          and one vertical matrix up to per-edge scalars, the shape the Fundamental Theorem's gauge
+          conclusion \leanid{TNLean.PEPS.IsTorusOrientationUniformGaugeFamilyModScalar} asserts. The
+          absorbing matrix \leanid{TNLean.PEPS.absorbedBoundaryGauge} is \(Z^{\mathsf T}\) or
+          \(Z^{-1}\) according to whether the boundary edge's left endpoint lies in the red blocking
+          region, and the engine gauge \(Z_e\) is the transported reference; both are
+          orientation-determined, but the endpoint-membership branch varies across the translates of
+          a class with wraparound, which is the transpose/orientation bookkeeping that remains.
+          Second, the blocked-tensor injectivity of the comparison regions of the reindexed
+          \(\operatorname{applyGauge} B\,X\) (the gauge-absorbed analogue of the rectangle injectivity
+          of \(B\)), and of \(A\)'s one-site-different comparison regions and their complements.
+          Third, the translation-invariant common ratio \(c_S/c_R\) of the
+          (now uniquely-named, \leanid{TNLean.PEPS.twoBlockScalarProportional_unique}) proportionality
+          scalars across the vertices. The scalar extraction itself is no longer on the critical
+          path.
     \item Prove the scalar condition $\lambda^{nm}=1$ for the square-lattice
           theorem, and state separately the scalar freedom in the non-translation
           invariant normal theorem.


### PR DESCRIPTION
## What

The comparison-feeding layer of the TI Normal PEPS FT's final step (#1373): a single
per-edge gauge family carrying the **bare-edge absorbed equality at every torus edge**,
wired to the region comparison and the scalar condition. Seven declarations; all
sorry-free; `#print axioms` = `[propext, Classical.choice, Quot.sound]`; full root build
green (8,879 jobs).

- `regionAbsorbed_of_edgeAbsorbed` / `twoBlockProportional_of_edgeAbsorbed` — the
  edge-absorbed equalities supply `regionComplement_comparison`'s `hregion` ⟹ `A_R ∝ B̃_R`.
- `edgeAbsorbed_of_conjIdentity` — engine conjugation ⟹ bare-edge absorbed equality.
- **`exists_edgeAbsorbed_torus_rectangle`** — the family at every edge, from the two
  orientation-class witness families.
- `lambda_pow_card_torus_eq_one_of_edgeAbsorbed` — the scalar condition from the
  edge-absorbed input (replacing `hPV` as the primitive).
- `twoBlockScalarProportional_unique` — canonical naming of the comparison scalar.

## Remaining (three isolated obligations, documented)

Orientation-uniformity of the absorbing family (the wraparound branch bookkeeping),
gauge-absorbed region injectivity (`regionBlockedWeight`-under-gauge), and the
translation-invariant common ratio.

Refs #1373. CI failures are non-blocking automation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New sorry-free Lean proofs on the PEPS formalization track; no runtime, auth, or data-path changes—main risk is mathematical correctness of the proof chain for reviewers.
> 
> **Overview**
> Adds the **comparison-feeding layer** for the normal PEPS Fundamental Theorem on the torus: edge-level absorbed equalities are lifted to region `hregion`, then to two-block proportionality, with a torus-wide gauge family and a scalar-condition entry point.
> 
> **`ProportionalityFromAbsorbed`** chains conjugation-form engine identities → bare-edge absorbed equality (`edgeAbsorbed_of_conjIdentity`), edge equalities on all boundary edges → region absorbed equality (`regionAbsorbed_of_edgeAbsorbed`), and then **`twoBlockProportional_of_edgeAbsorbed`** via `regionComplement_comparison`. **`twoBlockScalarProportional_unique`** pins the comparison scalar when the blocked family is injective.
> 
> **`TorusEdgeAbsorbed`** builds per-edge absorbing gauges from horizontal/vertical `EdgeCoeffIdentityWitness` families and proves **`exists_edgeAbsorbed_torus_rectangle`**: one family `X` with the bare-edge absorbed equality on every torus edge under rectangle injectivity hypotheses.
> 
> **`TorusFundamentalTheorem`** adds **`lambda_pow_card_torus_eq_one_of_edgeAbsorbed`**, deriving λ^{width·height} = 1 from global edge absorption plus per-vertex injectivity data and a common ratio of comparison scalars (via the existing two-block proportional route).
> 
> Root imports and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** are updated: producing a single edge-carrying `X` is recorded as landed; remaining obligations are orientation-uniformity of the absorbing family, gauge-absorbed region injectivity, and a translation-invariant common ratio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc540795d61394a244b85a823c10613ed60090ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->