### PR TITLE
doc(MPS/ParentHamiltonian): align block-boundary terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -256,7 +256,7 @@ theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_
   have hzero := hIndep Finset.univ (fun i => φ' i - φ i) hmem hsum j (Finset.mem_univ j)
   exact sub_eq_zero.mp hzero
 
-/-- Open-boundary block matrices for a vector satisfying the block-diagonal
+/-- Block-diagonal boundary conditions for a vector satisfying the block-diagonal
 periodic constraints.
 
 Let
@@ -265,7 +265,7 @@ Let
 \]
 Under the normalized BNT block-separation hypotheses and the \(L_0\)-block
 injectivity range bound, every \(\psi\in\mathcal G_{N,L}(B)\) can be
-represented with a block-diagonal boundary matrix
+represented by block-diagonal boundary conditions
 \[
   \psi=\Gamma_N^B\!\left(\bigoplus_jX_j\right)
 \]
@@ -273,14 +273,14 @@ and each component vector
 \[
   \Gamma_N^{A_j}(\mu_j^NX_j)
 \]
-lies in the open-boundary local space \(G_N(A_j)\).
+lies in the open-boundary ground space \(G_N(A_j)\).
 
 The latter membership is the defining open-boundary range property of the
 displayed boundary matrix. The substantive assertion is the block-diagonal
 representation of \(\psi\), and the later periodic-chain upgrade remains
 separate.
 
-This proves only the open-boundary representation. The remaining
+This proves the displayed statement. The remaining
 Pérez-García--Verstraete--Wolf--Cirac boundary-condition comparison
 (arXiv:quant-ph/0608197, proof lines 1454--1456; arXiv:2011.12127, lines
 2126--2128) is to show that these same component vectors lie in

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6302,7 +6302,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \[
         B=\bigoplus_{j=1}^g\mu_jA_j.
     \]
-    For block boundary matrices \(X_j\),
+    For block-diagonal boundary conditions \(X_j\),
     \[
         \Gamma_L^B\!\left(\bigoplus_{j=1}^g X_j\right)
         =
@@ -6549,7 +6549,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     boundary conditions.
 \end{proof}
 
-\begin{lemma}[Open-boundary block matrices for periodic chain vectors]
+\begin{lemma}[Block-diagonal boundary conditions for periodic chain vectors]
     \label{lem:bnt_block_diagonal_open_boundary_matrices}
     \lean{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
     \leanok
@@ -6561,7 +6561,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_{j=1}^g\mu_jA_j\right)
     \]
-    admits block boundary matrices \(X_j\) such that
+    admits block-diagonal boundary conditions \(X_j\) such that
     \[
         \psi=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right),
         \qquad
@@ -6593,9 +6593,14 @@ formulation; the passage to $\ker H_N$ is kept separate.
         =
         \psi.
     \]
-    This is still an open-boundary conclusion; it does not prove the periodic
-    block-chain membership of the components.
+    This proves the displayed statement.
 \end{proof}
+
+The lemma gives membership in the open-boundary space \(G_N(A_j)\).  The later
+periodic comparison concerns the separate assertion
+\[
+    \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
+\]
 
 \begin{lemma}[The block-diagonal chain space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
@@ -6693,7 +6698,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \lean{MPSTensor.groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace}
     \leanok
     \uses{lem:block_diagonal_boundary_condition_sum}
-    Let $B=\bigoplus_{j=1}^g\mu_jA_j$. Fix block boundary matrices $X_j$.
+    Let $B=\bigoplus_{j=1}^g\mu_jA_j$. Fix block-diagonal boundary conditions
+    $X_j$.
     Suppose that, for every $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
@@ -6724,7 +6730,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \leanok
     \uses{lem:block_diagonal_boundary_vector_mem_chain_sum}
     Let $B=\bigoplus_{j=1}^g\mu_jA_j$. Suppose every
-    $\psi\in\mathcal G_{N,L}(B)$ admits block boundary matrices $X_j$ such that
+    $\psi\in\mathcal G_{N,L}(B)$ admits block-diagonal boundary conditions
+    $X_j$ such that
     \[
         \psi=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right),
     \]
@@ -6756,8 +6763,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:bnt_block_diagonal_periodic_constraints_internal_sum}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_propagated_sum}, suppose
-    every vector $\psi\in\mathcal G_{N,L}(B)$ has block boundary matrices $X_j$
-    such that
+    every vector $\psi\in\mathcal G_{N,L}(B)$ has block-diagonal boundary
+    conditions $X_j$ such that
     \[
         \psi=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right),
     \]


### PR DESCRIPTION
### Motivation
- The parent-Hamiltonian chapter 14 blueprint and `BNTBlockDiagonalChain.lean` docstrings used "open-boundary block matrices" rather than the source terminology from PGVWC07 and CPGSV21, where the component data are called "block-diagonal boundary conditions".
- The conflation obscures the boundary between what is proved — the block-diagonal boundary-condition representation — and what remains — the periodic-chain membership of the resulting component vectors.
- Related to #2651, but this PR does not close it.

### Description
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`: updated docstrings to replace "open-boundary block matrices" with "block-diagonal boundary conditions" (PGVWC07 / CPGSV21 source terminology), and to explicitly distinguish the boundary-condition representation ψ = Γ_N^B(⊕_j X_j) with each component in G_N(A_j) from the remaining periodic-membership step Γ_N^{A_j}(μ_j^N X_j) ∈ G_{N,L}(A_j).
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: matching terminology update in blueprint lemma statements and proof notes for `lem:bnt_block_diagonal_open_boundary_matrices`.
- No Lean theorem statements or proofs are modified.

### Testing
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean -q --log-level=info` — only pre-existing warnings in unrelated files; no new errors.
- `lake exe checkdecls blueprint/lean_decls`

---
Related to #2651; does not close it.

> [!NOTE]
> **Low Risk**
> Comments and blueprint prose only; no formal statements, proofs, or runtime behavior change.
>
> **Overview**
> Aligns Chapter 14 parent-Hamiltonian prose with PGVWC/CPGSV source wording by replacing **"open-boundary block matrices"** with **"block-diagonal boundary conditions"** in `BNTBlockDiagonalChain.lean` docstrings and matching blueprint lemmas in `ch14_parent_hamiltonian.tex`.
>
> The updated text also separates what is already proved — the **boundary-condition representation** with components in G_N(A_j) — from the **remaining boundary-closing step** showing periodic membership in G_{N,L}(A_j). **No Lean theorem statements or proofs are modified.**
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c72bfea4baf6a8e4dd6ec0042e8eb7422d9f7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and blueprint prose only; no formal statements, proofs, or runtime behavior change.
> 
> **Overview**
> Replaces **"open-boundary block matrices"** / **"block boundary matrices"** with **"block-diagonal boundary conditions"** (PGVWC07 / CPGSV21 wording) in `BNTBlockDiagonalChain.lean` docstrings and Chapter 14 blueprint lemmas in `ch14_parent_hamiltonian.tex`.
> 
> The updated text separates what is already proved—the representation \(\psi=\Gamma_N^B(\oplus_j X_j)\) with components in **open-boundary** \(G_N(A_j)\)—from the **remaining** boundary-closing step \(\Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j)\). Lemma titles and proof notes are aligned accordingly.
> 
> **No Lean theorem statements or proofs are modified.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f3a6eb06b0f78ca214566812a6a6e54727bde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->