### PR TITLE
feat(PEPS/RegionBlock): region incidence product regrouped by edges

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -462,6 +462,10 @@ import TNLean.PEPS.RegionBlock.Algebra
 -- recovery.
 import TNLean.PEPS.RegionBlock.Recovery
 import TNLean.PEPS.RegionBlock.GaugeBridge
+-- Region incidence product regrouped by edges: the region-restricted analogue of the
+-- incident-edge product split, the foundational regrouping for the gauge-absorbed region
+-- injectivity used by the normal PEPS Theorem 3 final comparison.
+import TNLean.PEPS.RegionBlock.GaugeInjectivity
 -- Region-level absorbed plain equality: turns the per-edge gauge's conjugation-form
 -- region-inserted coefficient identity into the absorbed `applyGauge` form the region
 -- comparison consumes (the first step of the normal PEPS Theorem 3 final comparison).

--- a/TNLean/PEPS/RegionBlock/GaugeInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/GaugeInjectivity.lean
@@ -1,0 +1,74 @@
+import TNLean.PEPS.RegionBlock.GaugeBridge
+
+/-!
+# Region-blocked injectivity is preserved by a gauge
+
+This file begins the gauge-absorbed analogue of the rectangle injectivity used in the final
+comparison of the normal PEPS Fundamental Theorem (arXiv:1804.04964, Section 3, proof of Theorem 3,
+lines 1519--1571 of `Papers/1804.04964/paper_normal.tex`).
+
+The region comparison `regionComplement_comparison` consumes blocked-tensor injectivity of the
+gauge-absorbed second tensor `applyGauge B X` over the comparison regions.  Because a gauge
+preserves the closed state (`applyGauge_stateCoeff`), it also preserves blocked-region linear
+independence: the gauge cancels pairwise on every interior edge of a region, and on every boundary
+edge it acts as an invertible matrix on the open boundary leg, so the blocked-region tensor family
+of `applyGauge B X` is the family of `B` precomposed with an invertible linear map of the boundary
+configuration space.
+
+This file supplies the foundational product regrouping: the product over the vertices of a region
+`R` of a per-incidence factor regroups, edge by edge, into the contributions of each edge's
+endpoints that lie in `R`.  An edge with both endpoints in `R` contributes both endpoint factors
+(an interior edge); an edge with exactly one endpoint in `R` contributes only that endpoint's
+factor (a boundary edge); an edge with no endpoint in `R` contributes nothing.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- **Region incidence product regrouped by edges.**
+
+The product, over the vertices of a region `R`, of a per-incidence factor `f w ie` over the edges
+`ie` incident to `w`, regroups edge by edge: each edge contributes its left-endpoint factor when
+that endpoint lies in `R` (and `1` otherwise) times its right-endpoint factor when that endpoint
+lies in `R` (and `1` otherwise).
+
+This is the region-restricted analogue of `prod_incident_eq_prod_edge`.  An edge with both
+endpoints in `R` contributes both factors; a boundary edge of `R` contributes exactly one; an edge
+disjoint from `R` contributes nothing.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem prod_region_incident_eq_prod_edge (R : Finset V) (f : (w : V) → IncidentEdge G w → ℂ) :
+    (∏ w : {w : V // w ∈ R}, ∏ ie : IncidentEdge G w.1, f w.1 ie) =
+      ∏ e : Edge G,
+        (if e.1.1 ∈ R then f e.1.1 (edgeLeftIncident (G := G) e) else 1) *
+          (if e.1.2 ∈ R then f e.1.2 (edgeRightIncident (G := G) e) else 1) := by
+  classical
+  have hLHS : (∏ w : {w : V // w ∈ R}, ∏ ie : IncidentEdge G w.1, f w.1 ie) =
+      ∏ w : V, ∏ ie : IncidentEdge G w,
+        (if w ∈ R then f w ie else (1 : ℂ)) := by
+    rw [Finset.prod_coe_sort R (fun w => ∏ ie : IncidentEdge G w, f w ie)]
+    have hsub : (∏ w ∈ R, ∏ ie : IncidentEdge G w, (if w ∈ R then f w ie else (1 : ℂ)))
+        = ∏ w ∈ (Finset.univ : Finset V), ∏ ie : IncidentEdge G w,
+            (if w ∈ R then f w ie else (1 : ℂ)) :=
+      Finset.prod_subset (Finset.subset_univ R) (fun w _ hw =>
+        Finset.prod_eq_one (fun ie _ => by rw [if_neg hw]))
+    rw [← hsub]
+    refine Finset.prod_congr rfl (fun w hw => ?_)
+    refine Finset.prod_congr rfl (fun ie _ => ?_)
+    rw [if_pos hw]
+  rw [hLHS, prod_incident_eq_prod_edge (G := G) (fun w ie => if w ∈ R then f w ie else (1 : ℂ))]
+
+end PEPS
+end TNLean


### PR DESCRIPTION
## Summary

Adds `TNLean/PEPS/RegionBlock/GaugeInjectivity.lean` with one lemma, `prod_region_incident_eq_prod_edge`: the product over a region's vertices of a per-incidence factor regroups edge by edge into each edge's region-endpoint contributions. An edge interior to the region contributes both endpoint factors, a boundary edge exactly one, an edge disjoint from the region none.

This is the region-restricted analogue of `prod_incident_eq_prod_edge` and the combinatorial core of the gauge-absorbed region injectivity step in the final comparison of the normal PEPS Fundamental Theorem (arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519–1571 of `Papers/1804.04964/paper_normal.tex`): in the gauged region-blocked weight it separates the interior edges (whose two endpoint gauges cancel) from the boundary edges (whose single surviving gauge becomes an invertible matrix on the open boundary leg).

Part of #1373.

## Verification

- Full root `lake build` green (8880 jobs).
- `#print axioms TNLean.PEPS.prod_region_incident_eq_prod_edge` = `[propext, Classical.choice, Quot.sound]`.
- No `sorry`/`axiom`/`admit`/`native_decide`/`maxHeartbeats`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, self-contained combinatorial lemma with no changes to auth, data, or existing theorem APIs beyond a new root import.
> 
> **Overview**
> Introduces **`TNLean/PEPS/RegionBlock/GaugeInjectivity.lean`** and registers it on the root **`TNLean.lean`** import surface for the normal PEPS Fundamental Theorem region-block track.
> 
> The new lemma **`prod_region_incident_eq_prod_edge`** rewrites a product over vertices in a region `R` of per-incidence factors into a product over graph edges, with each edge contributing only the endpoint factors whose vertices lie in `R` (interior vs boundary vs outside). The proof pads vertices outside `R` with `1` and invokes the existing global **`prod_incident_eq_prod_edge`** regrouping.
> 
> This is positioned as the combinatorial first step toward gauge-absorbed region injectivity in the Theorem 3 final comparison (`regionComplement_comparison`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c051ff3eb3dd6796f11e792a77948ee33bc8405. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->