### PR TITLE
feat(MPS/ParentHamiltonian): add boundary restriction sum identity

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -450,6 +450,34 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition
   rcases hBoundary ψ hψ with ⟨φ, hφ, rfl⟩
   exact Submodule.sum_mem _ fun j _ => Submodule.mem_iSup_of_mem j (hφ j)
 
+/-- Cyclic restriction preserves the block-diagonal boundary-condition
+decomposition.
+
+Let \(B=\bigoplus_j\mu_jA_j\). For block-diagonal boundary conditions
+\(\bigoplus_jX_j\), every cyclic window satisfies
+\[
+  R_{i,\tau}\!\left(\Gamma_N^B\!\left(\bigoplus_jX_j\right)\right)
+    =
+  \sum_j R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right).
+\]
+This is the cyclic-window form of the block-diagonal boundary-condition
+identity used in PGVWC07, Theorem 2blocks.2, proof lines 1430--1434. -/
+theorem cyclicRestrictₗ_groundSpaceMap_toTensorFromBlocks_blockDiagonal_eq_sum
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (i : Fin N) (τ : Fin N → Fin d)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ) :
+    cyclicRestrictₗ hN L i τ
+        (groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X))) =
+      ∑ j : Fin r,
+        cyclicRestrictₗ hN L i τ
+          (groundSpaceMap (A j) N ((μ j) ^ N • X j)) := by
+  classical
+  rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
+  exact map_sum (cyclicRestrictₗ hN L i τ)
+    (fun j : Fin r => groundSpaceMap (A j) N ((μ j) ^ N • X j)) Finset.univ
+
 /-- A block-diagonal boundary representation whose components are periodic block
 ground-space vectors lies in the blockwise periodic chain sum.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6602,6 +6602,31 @@ periodic comparison concerns the separate assertion
     \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
 \]
 
+\begin{lemma}[Cyclic restrictions of block-diagonal boundary vectors]
+    \label{lem:block_diagonal_boundary_cyclic_restriction_sum}
+    \lean{MPSTensor.cyclicRestrictₗ_groundSpaceMap_toTensorFromBlocks_blockDiagonal_eq_sum}
+    \leanok
+    \uses{lem:block_diagonal_boundary_condition_sum}
+    Let \(B=\bigoplus_{j=1}^g\mu_jA_j\), and fix block-diagonal boundary
+    conditions \(X_j\). For every cyclic restriction \(R_{i,\tau}\) from
+    \(N\) sites to \(L\) sites,
+    \[
+        R_{i,\tau}\!\left(
+            \Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right)
+        \right)
+        =
+        \sum_{j=1}^g
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_condition_sum}
+    Apply Lemma~\ref{lem:block_diagonal_boundary_condition_sum} at length \(N\),
+    then use linearity of the cyclic restriction \(R_{i,\tau}\).
+\end{proof}
+
 \begin{lemma}[The block-diagonal chain space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}


### PR DESCRIPTION
### Motivation
- The block-diagonal boundary-condition sum identity (proved in #2644) has an open-boundary form; the periodic variant — applying cyclic restriction $R_{i,\tau}$ — is needed to progress toward the periodic-chain membership result required by PGVWC07 Theorem 2blocks.2 (arXiv:quant-ph/0608197, lines 1454–1456), tracked in #2651.
- Chapter 14 of the blueprint lacks a displayed lemma for the cyclic-restriction form of the sum identity; this PR adds it.

### Description
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`: adds lemma `cyclicRestrictₗ_groundSpaceMap_toTensorFromBlocks_blockDiagonal_eq_sum`, proving that applying `cyclicRestrictₗ` to $\Gamma_N^B(\bigoplus_j X_j)$ equals $\sum_j R_{i,\tau}(\Gamma_N^{A_j}(\mu_j^N X_j))$. The proof applies `groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal` and linearity of `cyclicRestrictₗ` via `map_sum`.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: adds lemma **Cyclic restrictions of block-diagonal boundary vectors** in Chapter 14, wired to the above declaration and citing the prior block-diagonal boundary sum lemma.
- Advances #2651 without proving the full periodic-chain component membership theorem.

### Testing
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`
- `git diff --check`

---
Addresses #2651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive formalization and blueprint sync; no changes to auth, data, or existing proof logic beyond a short lemma derived from an existing sum identity.
> 
> **Overview**
> Adds the **cyclic-window** form of the block-diagonal boundary sum: applying a cyclic restriction \(R_{i,\tau}\) to \(\Gamma_N^B(\bigoplus_j X_j)\) equals the sum of restrictions of each block's \(\Gamma_N^{A_j}(\mu_j^N X_j)\).
> 
> In Lean, this is `cyclicRestrictₗ_groundSpaceMap_toTensorFromBlocks_blockDiagonal_eq_sum` in `BNTBlockDiagonalChain.lean`, proved by the existing `groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal` identity and linearity of `cyclicRestrictₗ` (`map_sum`). Chapter 14 gains the matching lemma **Cyclic restrictions of block-diagonal boundary vectors**, wired to that declaration and citing the prior block-diagonal boundary sum lemma.
> 
> This supports the PGVWC07 Theorem 2blocks.2 boundary argument (#2651) without proving component membership in \(\mathcal G_{N,L}(A_j)\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 753251064b8733e9469f25e568d1b1cc82d9f7f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->