### PR TITLE
feat(MPS/ParentHamiltonian): record local block-sum constraint

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -496,7 +496,8 @@ extraction step
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
 \]
-in PGVWC07, Theorem 2blocks.2. It does not yet identify the individual
+in Theorem 2blocks.2 of Perez-Garcia, Verstraete, Wolf, and Cirac (2007).
+It does not yet identify the individual
 summands with vectors in the corresponding \(G_L(A_j)\). -/
 theorem blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
     {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -478,6 +478,73 @@ theorem cyclicRestrictₗ_groundSpaceMap_toTensorFromBlocks_blockDiagonal_eq_sum
   exact map_sum (cyclicRestrictₗ hN L i τ)
     (fun j : Fin r => groundSpaceMap (A j) N ((μ j) ^ N • X j)) Finset.univ
 
+/-- A block-diagonal boundary condition satisfying the periodic local constraints
+has its local block sum in the direct sum of the block local spaces.
+
+Let \(B=\bigoplus_j\mu_jA_j\). If
+\[
+  \psi=\Gamma_N^B\!\left(\bigoplus_jX_j\right)
+\]
+and \(\psi\in\mathcal G_{N,L}(B)\), then each length-\(L\) local constraint of
+\(\psi\) gives
+\[
+  \sum_j R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+    \in \bigvee_j G_L(A_j).
+\]
+This is the direct-sum local constraint obtained before the source's blockwise
+extraction step
+\[
+  A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
+\]
+in PGVWC07, Theorem 2blocks.2. It does not yet identify the individual
+summands with vectors in the corresponding \(G_L(A_j)\). -/
+theorem blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hψX :
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)))
+    (i : Fin N) (τ : Fin N → Fin d) :
+    (∑ j : Fin r,
+        cyclicRestrictₗ hN L i τ
+          (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
+      ⨆ j : Fin r, groundSpace (A j) L := by
+  classical
+  have hLocal :
+      cyclicRestrictₗ hN L i τ ψ ∈
+        groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L := by
+    rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ
+    have hle :
+        (⨅ (i : Fin N) (τ : Fin N → Fin d),
+            (groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L).comap
+              (cyclicRestrictₗ hN L i τ)) ≤
+          (groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L).comap
+            (cyclicRestrictₗ hN L i τ) := by
+      exact le_trans
+        (iInf_le (fun i : Fin N =>
+          ⨅ τ : Fin N → Fin d,
+            (groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L).comap
+              (cyclicRestrictₗ hN L i τ)) i)
+        (iInf_le (fun τ : Fin N → Fin d =>
+          (groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L).comap
+            (cyclicRestrictₗ hN L i τ)) τ)
+    exact hle hψ
+  have hSum :
+      (∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
+        groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L := by
+    rw [← cyclicRestrictₗ_groundSpaceMap_toTensorFromBlocks_blockDiagonal_eq_sum
+      μ A hN i τ X]
+    rw [← hψX]
+    exact hLocal
+  simpa [groundSpace_toTensorFromBlocks_eq_iSup μ A hμ L] using hSum
+
 /-- A block-diagonal boundary representation whose components are periodic block
 ground-space vectors lies in the blockwise periodic chain sum.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -520,21 +520,17 @@ theorem blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
       cyclicRestrictₗ hN L i τ ψ ∈
         groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L := by
     rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ
-    have hle :
-        (⨅ (i : Fin N) (τ : Fin N → Fin d),
-            (groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L).comap
-              (cyclicRestrictₗ hN L i τ)) ≤
-          (groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L).comap
-            (cyclicRestrictₗ hN L i τ) := by
-      exact le_trans
-        (iInf_le (fun i : Fin N =>
-          ⨅ τ : Fin N → Fin d,
-            (groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L).comap
-              (cyclicRestrictₗ hN L i τ)) i)
-        (iInf_le (fun τ : Fin N → Fin d =>
-          (groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L).comap
-            (cyclicRestrictₗ hN L i τ)) τ)
-    exact hle hψ
+    let S : Submodule ℂ (NSiteSpace d L) :=
+      groundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L
+    change cyclicRestrictₗ hN L i τ ψ ∈ S
+    change ψ ∈
+      ⨅ (i : Fin N) (τ : Fin N → Fin d), S.comap (cyclicRestrictₗ hN L i τ) at hψ
+    have hAtI :
+        ψ ∈ ⨅ τ : Fin N → Fin d, S.comap (cyclicRestrictₗ hN L i τ) :=
+      (Submodule.mem_iInf (p := fun i : Fin N =>
+        ⨅ τ : Fin N → Fin d, S.comap (cyclicRestrictₗ hN L i τ))).mp hψ i
+    exact (Submodule.mem_iInf
+      (p := fun τ : Fin N → Fin d => S.comap (cyclicRestrictₗ hN L i τ))).mp hAtI τ
   have hSum :
       (∑ j : Fin r,
           cyclicRestrictₗ hN L i τ

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6627,6 +6627,45 @@ periodic comparison concerns the separate assertion
     then use linearity of the cyclic restriction \(R_{i,\tau}\).
 \end{proof}
 
+\begin{lemma}[Local direct-sum constraint from block-diagonal boundary conditions]
+    \label{lem:block_diagonal_boundary_local_sum_mem}
+    \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace}
+    \leanok
+    \uses{lem:block_diagonal_boundary_cyclic_restriction_sum,
+        lem:block_sum_local_ground_space}
+    Let \(B=\bigoplus_{j=1}^g\mu_jA_j\), with \(\mu_j\ne0\), and suppose
+    \[
+        \psi=\Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right),
+        \qquad
+        \psi\in\mathcal G_{N,L}(B).
+    \]
+    Then every local constraint of \(\psi\) gives
+    \[
+        \sum_{j=1}^g
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in
+        \bigvee_{j=1}^gG_L(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_cyclic_restriction_sum,
+        lem:block_sum_local_ground_space}
+    The hypothesis \(\psi\in\mathcal G_{N,L}(B)\) says that the left-hand side
+    before decomposition lies in \(G_L(B)\).  Lemma
+    \ref{lem:block_diagonal_boundary_cyclic_restriction_sum} rewrites this local
+    vector as the displayed sum, and Lemma~\ref{lem:block_sum_local_ground_space}
+    identifies \(G_L(B)\) with \(\bigvee_jG_L(A_j)\).
+
+    The next source step is not this membership statement, but the blockwise
+    extraction
+    \[
+        A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
+    \]
+    from PGVWC07, Theorem~2blocks.2.
+\end{proof}
+
 \begin{lemma}[The block-diagonal chain space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6663,7 +6663,7 @@ periodic comparison concerns the separate assertion
     \[
         A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
     \]
-    from PGVWC07, Theorem~2blocks.2.
+    from \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}.
 \end{proof}
 
 \begin{lemma}[The block-diagonal chain space lies between two block sums]


### PR DESCRIPTION
### Motivation

- Issue #2651 identifies that after the block-diagonal boundary construction of PR #2644, the remaining step is to show that each cyclic length-$L$ window's sum of per-block restricted boundary images lies in $\bigvee_j G_L(A_j)$ (the join of local ground spaces of the individual blocks).
- This is the local direct-sum constraint preceding the PGVWC07 blockwise extraction equation $A^j_{i_{m+1}}C^j_{i_1} = D^j_{i_{m+1}}A^j_{i_1}$; recording it as a named lemma isolates the gap between the current open-boundary conclusion and the individual per-summand membership needed by `chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap`.
- Source: `Papers/quant-ph_0608197/MPSarchive.tex`, Theorem 2blocks.2, proof lines 1454–1456 (arXiv:quant-ph/0608197); `blueprint/src/chapter/ch14_parent_hamiltonian.tex`, `lem:bnt_block_diagonal_open_boundary_matrices`.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`: adds `blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace`, proving that for block-diagonal boundary data representing a vector in the assembled periodic chain ground space, the sum of per-block restricted boundary images for each cyclic length-$L$ window lies in $\bigvee_j G_L(A_j)$. The proof chains periodic local membership, the existing cyclic block-diagonal sum identity, and `groundSpace_toTensorFromBlocks_eq_iSup`.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: adds `lem:block_diagonal_boundary_local_sum_mem` in Chapter 14 with a proof narrative. Docstrings and blueprint text record that this is the local direct-sum constraint only — not yet per-summand membership in each $G_L(A_j)$.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `(cd blueprint && leanblueprint web)`

---
Addresses #2651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and blueprint sync for an intermediate lemma; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace`** in `BNTBlockDiagonalChain.lean`: when a block-assembled periodic chain vector \(\psi\) is represented by block-diagonal boundary data and lies in \(\mathcal G_{N,L}(B)\), each cyclic length-\(L\) window’s **sum** of per-block restricted boundary images lies in \(\bigvee_j G_L(A_j)\). The proof is a short chain—local periodic membership, the existing cyclic block-diagonal sum identity, and `groundSpace_toTensorFromBlocks_eq_iSup`.
> 
> The blueprint gains **`lem:block_diagonal_boundary_local_sum_mem`** (Chapter 14) with the same statement and a proof narrative. Docstrings and blueprint text stress this is only the **join-level** local constraint, not yet per-summand membership in each \(G_L(A_j)\) (the PGVWC07 blockwise extraction step).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef0ce473c3db97a86cc091f83722f8471cf8fd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->