### PR TITLE
feat(MPS/ParentHamiltonian): record non-wrapping block windows

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -629,7 +629,7 @@ The boundary matrix remains outside the window, so the restricted vector is
 \[
   \Gamma_L^{A_j}(A_{\mathrm{right}}\mu_j^NX_jA_{\mathrm{left}}).
 \]
-For wrapping windows, the remaining source step is the matrix identity
+For wrapping windows, additionally needed is the matrix identity
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
 \]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -542,6 +542,112 @@ theorem blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
     exact hLocal
   simpa [groundSpace_toTensorFromBlocks_eq_iSup μ A hμ L] using hSum
 
+private theorem contiguousRestrictₗ_groundSpaceMap_mem_groundSpace
+    {A : MPSTensor d D} {s L N : ℕ} (hsL : s + L ≤ N)
+    (τ : Fin N → Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
+    contiguousRestrictₗ s L hsL τ (groundSpaceMap A N X) ∈ groundSpace A L := by
+  rw [groundSpace, LinearMap.mem_range]
+  let leftWord : List (Fin d) := List.ofFn fun k : Fin s => τ ⟨k.val, by omega⟩
+  let rightWord : List (Fin d) := List.ofFn fun k : Fin (N - (s + L)) =>
+    τ ⟨s + L + k.val, by omega⟩
+  refine ⟨evalWord A rightWord * X * evalWord A leftWord, ?_⟩
+  ext σ
+  simp only [contiguousRestrictₗ_apply, groundSpaceMap_apply]
+  have hlist :
+      List.ofFn (contiguousCfg s L σ τ) = leftWord ++ List.ofFn σ ++ rightWord := by
+    apply List.ext_getElem
+    · simp [leftWord, rightWord, List.length_ofFn]
+      omega
+    · intro k hk₁ hk₂
+      have hkN : k < N := by
+        simpa [List.length_ofFn] using hk₁
+      simp only [List.getElem_ofFn]
+      by_cases hkLeft : k < s
+      · have hkNotWin : ¬(s ≤ k ∧ k < s + L) := by omega
+        rw [contiguousCfg, dif_neg hkNotWin]
+        rw [List.getElem_append_left]
+        · rw [List.getElem_append_left]
+          · have hkLeftWord : k < leftWord.length := by
+              simpa only [leftWord, List.length_ofFn] using hkLeft
+            rw [show leftWord[k]'hkLeftWord = τ ⟨k, by omega⟩ from by
+              simp only [leftWord, List.getElem_ofFn]]
+          · simpa only [leftWord, List.length_ofFn] using hkLeft
+        · simpa only [leftWord, List.length_append, List.length_ofFn] using
+            (show k < s + L by omega)
+      · by_cases hkWin : k < s + L
+        · have hwin : s ≤ k ∧ k < s + L := by omega
+          rw [contiguousCfg, dif_pos hwin]
+          rw [List.getElem_append_left]
+          · rw [List.getElem_append_right]
+            · rw [List.getElem_ofFn]
+              congr 1
+              ext
+              simp [leftWord]
+            · simpa only [leftWord, List.length_ofFn] using
+                (show s ≤ k by omega)
+          · simpa only [leftWord, List.length_append, List.length_ofFn] using hkWin
+        · have hkRight : s + L ≤ k := by omega
+          have hkNotWin : ¬(s ≤ k ∧ k < s + L) := by omega
+          rw [contiguousCfg, dif_neg hkNotWin]
+          rw [List.getElem_append_right]
+          · have hRightIndex :
+                k - (leftWord ++ List.ofFn σ).length < rightWord.length := by
+              simp only [rightWord, leftWord, List.length_append, List.length_ofFn]
+              omega
+            rw [show rightWord[k - (leftWord ++ List.ofFn σ).length]'hRightIndex =
+                τ ⟨k, by omega⟩ from by
+              simp only [rightWord, List.getElem_ofFn]
+              congr 1
+              ext
+              simp only [leftWord, List.length_append, List.length_ofFn]
+              omega]
+          · simpa only [leftWord, List.length_append, List.length_ofFn] using
+              (show s + L ≤ k by omega)
+  rw [hlist, evalWord_append, evalWord_append]
+  calc
+    Matrix.trace (evalWord A (List.ofFn σ) *
+        (evalWord A rightWord * X * evalWord A leftWord))
+        = Matrix.trace ((evalWord A (List.ofFn σ) * (evalWord A rightWord * X)) *
+            evalWord A leftWord) := by
+          rw [← Matrix.mul_assoc (evalWord A (List.ofFn σ)) (evalWord A rightWord * X)
+            (evalWord A leftWord)]
+    _ = Matrix.trace (evalWord A leftWord *
+        (evalWord A (List.ofFn σ) * (evalWord A rightWord * X))) :=
+          Matrix.trace_mul_comm _ _
+    _ = Matrix.trace ((evalWord A leftWord * evalWord A (List.ofFn σ) *
+        evalWord A rightWord) * X) := by
+          rw [Matrix.mul_assoc, Matrix.mul_assoc]
+
+/-- Non-wrapping component windows already satisfy the block local constraint.
+
+For a block \(A_j\) and boundary matrix \(X_j\), if the cyclic window beginning
+at \(i\) does not cross the end of the chain, then
+\[
+  R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)\in G_L(A_j).
+\]
+The boundary matrix remains outside the window, so the restricted vector is
+\[
+  \Gamma_L^{A_j}(A_{\mathrm{right}}\mu_j^NX_jA_{\mathrm{left}}).
+\]
+For wrapping windows, the remaining source step is the matrix identity
+\[
+  A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
+\]
+from Theorem 2blocks.2 of Perez-Garcia, Verstraete, Wolf, and Cirac (2007). -/
+theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (j : Fin r) (i : Fin N) (τ : Fin N → Fin d)
+    (hi : i.val + L ≤ N) :
+    cyclicRestrictₗ hN L i τ
+        (groundSpaceMap (A j) N ((μ j) ^ N • X j)) ∈
+      groundSpace (A j) L := by
+  rw [cyclicRestrictₗ_eq_contiguousRestrictₗ hN hLN hi]
+  exact contiguousRestrictₗ_groundSpaceMap_mem_groundSpace (A := A j) (s := i.val)
+    (L := L) (N := N) (by omega) τ ((μ j) ^ N • X j)
+
 /-- A block-diagonal boundary representation whose components are periodic block
 ground-space vectors lies in the blockwise periodic chain sum.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6670,10 +6670,10 @@ periodic comparison concerns the separate assertion
     \label{lem:block_diagonal_boundary_nonwrapping_component}
     \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping}
     \leanok
-    \uses{def:ground_space_parent, def:extract_window}
-    Fix block-diagonal boundary conditions \(X_j\).  If the cyclic window
-    beginning at \(i\) does not cross the end of the chain, \(i+L\le N\), then
-    for every block \(j\),
+    \uses{def:ground_space_parent, rem:cyclic_window_operators}
+    Fix block-diagonal boundary conditions $X_j$.  If the cyclic window
+    beginning at $i$ does not cross the end of the chain, $i+L\le N$, then
+    for every block $j$,
     \[
         R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
         \in G_L(A_j).
@@ -6682,18 +6682,18 @@ periodic comparison concerns the separate assertion
 
 \begin{proof}
     \leanok
-    \uses{def:ground_space_parent, def:extract_window}
+    \uses{def:ground_space_parent, rem:cyclic_window_operators}
     In a non-wrapping window the boundary matrix stays outside the window.  Let
-    \(A_{\rm left}\) be the product on the sites before the window and
-    \(A_{\rm right}\) the product on the sites after the window.  Trace cyclicity
+    $A_{\rm left}$ be the product on the sites before the window and
+    $A_{\rm right}$ the product on the sites after the window.  Trace cyclicity
     gives
     \[
         R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
         =
         \Gamma_L^{A_j}\!\left(A_{\rm right}\,\mu_j^NX_j\,A_{\rm left}\right).
     \]
-    Hence the restricted vector lies in \(G_L(A_j)\).  For wrapping windows, the
-    remaining source step is the identity
+    Hence the restricted vector lies in $G_L(A_j)$.  The wrapping case is not
+    covered here; it requires additionally the identity
     \[
         A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6666,6 +6666,40 @@ periodic comparison concerns the separate assertion
     from \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}.
 \end{proof}
 
+\begin{lemma}[Non-wrapping component windows]
+    \label{lem:block_diagonal_boundary_nonwrapping_component}
+    \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping}
+    \leanok
+    \uses{def:ground_space, def:cyclic_window_restriction}
+    Fix block-diagonal boundary conditions \(X_j\).  If the cyclic window
+    beginning at \(i\) does not cross the end of the chain, \(i+L\le N\), then
+    for every block \(j\),
+    \[
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in G_L(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:ground_space, def:cyclic_window_restriction}
+    In a non-wrapping window the boundary matrix stays outside the window.  Let
+    \(A_{\rm left}\) be the product on the sites before the window and
+    \(A_{\rm right}\) the product on the sites after the window.  Trace cyclicity
+    gives
+    \[
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        =
+        \Gamma_L^{A_j}\!\left(A_{\rm right}\,\mu_j^NX_j\,A_{\rm left}\right).
+    \]
+    Hence the restricted vector lies in \(G_L(A_j)\).  For wrapping windows, the
+    remaining source step is the identity
+    \[
+        A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
+    \]
+    from \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}.
+\end{proof}
+
 \begin{lemma}[The block-diagonal chain space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6670,7 +6670,7 @@ periodic comparison concerns the separate assertion
     \label{lem:block_diagonal_boundary_nonwrapping_component}
     \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping}
     \leanok
-    \uses{def:ground_space, def:cyclic_window_restriction}
+    \uses{def:ground_space_parent, def:extract_window}
     Fix block-diagonal boundary conditions \(X_j\).  If the cyclic window
     beginning at \(i\) does not cross the end of the chain, \(i+L\le N\), then
     for every block \(j\),
@@ -6682,7 +6682,7 @@ periodic comparison concerns the separate assertion
 
 \begin{proof}
     \leanok
-    \uses{def:ground_space, def:cyclic_window_restriction}
+    \uses{def:ground_space_parent, def:extract_window}
     In a non-wrapping window the boundary matrix stays outside the window.  Let
     \(A_{\rm left}\) be the product on the sites before the window and
     \(A_{\rm right}\) the product on the sites after the window.  Trace cyclicity


### PR DESCRIPTION
### Motivation
- Issue #2651 identifies that the open-boundary conjunct $\Gamma_N^{A_j}(\mu_j^N X_j) \in G_N(A_j)$ does not imply periodic-chain membership $\Gamma_N^{A_j}(\mu_j^N X_j) \in \mathcal{G}_{N,L}(A_j)$, leaving a gap in the block-diagonal chain ground space decomposition needed for #460.
- This PR covers the non-wrapping case: when $i + L \le N$, the cyclic window restriction of each block boundary component lies in $G_L(A_j)$, provable without the PGVWC07 identity $A^j_{i_{m+1}} C^j_{i_1} = D^j_{i_{m+1}} A^j_{i_1}$.
- Source: `blueprint/src/chapter/ch14_parent_hamiltonian.tex`, Chapter 14; arXiv:quant-ph/0608197 (Pérez-García–Verstraete–Wolf–Cirac), Theorem 2blocks.2 for the remaining wrapping case.

### Description
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`: adds two lemmas:
  - `contiguousRestrictₗ_groundSpaceMap_mem_groundSpace`: a contiguous window restriction of $\Gamma_N^A(X)$ equals $\Gamma_L^A(A_{\mathrm{right}} X A_{\mathrm{left}})$ via word splitting and trace cyclicity, hence lies in $G_L(A)$.
  - `blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping`: rewrites the cyclic restriction as contiguous under $i + L \le N$, giving $R_{i,\tau}(\Gamma_N^{A_j}(\mu_j^N X_j)) \in G_L(A_j)$.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: adds the Chapter 14 Lemma (Non-wrapping component windows) with `\lean{...}` and `\leanok` tags; notes that wrapping windows require Theorem 2blocks.2 from Pérez-García et al. and remain open.
- This PR does not close #2651; the wrapping case is the remaining step.

### Testing
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `lake exe checkdecls blueprint/lean_decls`
- `(cd blueprint && leanblueprint web)`
- Prose review: `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Blueprint sync: `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses #2651

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and blueprint sync in parent-Hamiltonian theory; no runtime, auth, or data paths.
>
> **Overview**
> Adds a formal proof that **non-wrapping** cyclic windows of each block boundary component already lie in the block local ground space \(G_L(A_j)\) when \(i+L\le N\), without needing the PGVWC07 wrapping identity.
>
> The Lean work introduces `contiguousRestrictₗ_groundSpaceMap_mem_groundSpace`, showing a contiguous window restriction of \(\Gamma_N^A(X)\) is \(\Gamma_L^A(A_{\mathrm{right}} X A_{\mathrm{left}})\) via word splitting and trace cyclicity, then `blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping`, which rewrites the cyclic restriction as contiguous under the non-wrap hypothesis. Docstrings and Chapter 14 blueprint **Lemma (Non-wrapping component windows)** mirror this; **wrapping** windows are still called out as needing Theorem 2blocks.2 from Perez-Garcia et al.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb4d582f35e128c75cc5e489a8357777fcf258d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Mathlib proofs and blueprint prose only in parent-Hamiltonian MPS theory; no runtime, security, or data paths.
> 
> **Overview**
> Proves a **partial step** toward upgrading open-boundary block components to periodic local ground space \(G_L(A_j)\): when the cyclic window at \(i\) does **not** wrap (\(i+L\le N\)), each block’s restricted boundary vector \(R_{i,\tau}(\Gamma_N^{A_j}(\mu_j^N X_j))\) already lies in \(G_L(A_j)\), **without** the PGVWC07 wrapping identity.
> 
> Lean adds **`contiguousRestrictₗ_groundSpaceMap_mem_groundSpace`**, showing a contiguous window of \(\Gamma_N^A(X)\) matches \(\Gamma_L^A(A_{\mathrm{right}} X A_{\mathrm{left}})\) via site-word splitting and trace cyclicity, hence membership in `groundSpace A L`. **`blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping`** rewrites cyclic restriction as contiguous under the non-wrap hypothesis and applies that lemma.
> 
> Chapter 14 gains the matching **Lemma (Non-wrapping component windows)** with `\leanok`; docstrings note that **wrapping** windows still need Theorem 2blocks.2 from Pérez-García et al.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c49d0084aeea9ccb1171901173c501ae48a139d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->