### PR TITLE
doc(MPS/ParentHamiltonian): state block-diagonal boundary closing

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -9,14 +9,15 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 # Block-diagonal propagation for parent-Hamiltonian local spaces
 
 This file combines the normalized BNT block-separation hypotheses with the
-PGVWC07 one-step identity
+one-step identity from arXiv:quant-ph/0608197
 \[
   \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1},
   \qquad S_M=\bigvee_jG_M(A_j),
 \]
-as used in PGVWC07, Theorem 2blocks.2.  The later periodic step is the
-boundary-closing comparison with block-diagonal boundary conditions, as in the
-closing-boundary sentence of CPGSV21, Section IV.C.
+as used in Theorem 2blocks.2 of arXiv:quant-ph/0608197. The later periodic
+step is the boundary-closing comparison with block-diagonal boundary
+conditions, as in the closing-boundary sentence of arXiv:2011.12127,
+Section IV.C.
 -/
 
 open scoped Matrix BigOperators
@@ -33,8 +34,8 @@ Let
 \[
   B=\bigoplus_j\mu_jA_j,\qquad S_M=\bigvee_jG_M(A_j).
 \]
-Assume the normalized BNT block-separation hypotheses give the PGVWC one-step
-recursion in the range
+Assume the normalized BNT block-separation hypotheses give the one-step
+recursion from arXiv:quant-ph/0608197 in the range
 \[
   M>L_0+(r-1)(L_0+(L_0+L_0)).
 \]
@@ -42,10 +43,10 @@ Then, for every \(N\ge L\) in that range,
 \[
   \mathcal G_{N,L}(B)\subseteq S_N.
 \]
-This is the inclusion into \(S_N\) in PGVWC07, Theorem 2blocks.2
-(arXiv:quant-ph/0608197, proof lines 1430--1456). The step that closes the
-boundaries with block-diagonal boundary conditions, replacing \(S_N\) by the
-sum of periodic block ground spaces, is separate. -/
+This is the inclusion into \(S_N\) in Theorem 2blocks.2 of
+arXiv:quant-ph/0608197 (proof lines 1430--1456). The step that closes the
+boundaries with block-diagonal boundary conditions, replacing \(S_N\) by the sum
+of periodic block ground spaces, is separate. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -90,13 +91,13 @@ normalized BNT blocks, and
 \[
   M-1\ge (L_0+1)+(r-1)((L_0+1)+((L_0+1)+(L_0+1))).
 \]
-Then the PGVWC one-step identity for \(S_M\) holds. Consequently, for every
-\(N\ge L\) in this range,
+Then the one-step identity for \(S_M\) from arXiv:quant-ph/0608197 holds.
+Consequently, for every \(N\ge L\) in this range,
 \[
   \mathcal G_{N,L}(B)\subseteq S_N.
 \]
 This is the inclusion into the linear span of block local ground spaces used in
-PGVWC07, Theorem 2blocks.2 (arXiv:quant-ph/0608197, proof lines
+Theorem 2blocks.2 of arXiv:quant-ph/0608197 (proof lines
 1430--1456). The replacement of \(S_N\) by periodic block chain spaces is the
 separate step of closing the boundaries with block-diagonal boundary
 conditions. -/
@@ -141,7 +142,7 @@ Let
 \[
   B=\bigoplus_j\mu_jA_j,\qquad S_N=\bigvee_jG_N(A_j).
 \]
-At the lengths used in PGVWC07, Theorem 2blocks.2
+At the lengths used in Theorem 2blocks.2 of arXiv:quant-ph/0608197
 (arXiv:quant-ph/0608197, proof lines 1430--1456), one has
 \[
   \mathcal G_{N,L}(B)\subseteq S_N,
@@ -349,9 +350,9 @@ range,
   \subseteq
   \bigvee_j G_N(A_j),
 \]
-and the right-hand local block sum is internal. The remaining PGVWC07
-boundary-closing step with block-diagonal boundary conditions replaces
-\(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\). -/
+and the right-hand local block sum is internal. The remaining boundary-closing
+step from arXiv:quant-ph/0608197, with block-diagonal boundary conditions,
+replaces \(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\). -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -393,7 +394,8 @@ finite injectivity range,
   \subseteq
   \bigvee_j G_N(A_j),
 \]
-and the right-hand local block sum is internal. The remaining PGVWC07 step is
+and the right-hand local block sum is internal. The remaining step from
+arXiv:quant-ph/0608197 is
 to close the boundaries with block-diagonal boundary conditions. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -463,7 +465,8 @@ Let \(B=\bigoplus_j\mu_jA_j\). For block-diagonal boundary conditions
   \sum_j R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right).
 \]
 This is the cyclic-window form of the block-diagonal boundary-condition
-identity used in PGVWC07, Theorem 2blocks.2, proof lines 1430--1434. -/
+identity used in Theorem 2blocks.2 of arXiv:quant-ph/0608197, proof lines
+1430--1434. -/
 theorem cyclicRestrictₗ_groundSpaceMap_toTensorFromBlocks_blockDiagonal_eq_sum
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -700,13 +703,13 @@ lies in \(\mathcal G_{N,L}(A_j)\). Then
   \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j).
 \]
 The source boundary-closing step is to prove the displayed componentwise
-periodic constraint from the block-diagonal boundary conditions.  In PGVWC07,
-Theorem 2blocks.2, this is the comparison
+periodic constraint from the block-diagonal boundary conditions. In
+Theorem 2blocks.2 of arXiv:quant-ph/0608197, this is the comparison
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
 \]
-The CPGSV21 review describes the same step as closing the boundaries after
-inverting and re-growing tensors with block-diagonal boundary conditions
+The review arXiv:2011.12127 describes the same step as closing the boundaries
+after inverting and re-growing tensors with block-diagonal boundary conditions
 (arXiv:2011.12127, lines 2126--2128). -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap
     {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -14,7 +14,9 @@ PGVWC07 one-step identity
   \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1},
   \qquad S_M=\bigvee_jG_M(A_j),
 \]
-as used in PGVWC07, Theorem 2blocks.2.
+as used in PGVWC07, Theorem 2blocks.2.  The later periodic step is the
+boundary-closing comparison with block-diagonal boundary conditions, as in the
+closing-boundary sentence of CPGSV21, Section IV.C.
 -/
 
 open scoped Matrix BigOperators
@@ -76,15 +78,15 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
 
-/-- Condition C1 gives the periodic-chain inclusion into the sum of local block
-ground spaces.
+/-- Finite-length block injectivity gives the periodic-chain inclusion into the
+sum of local block ground spaces.
 
 Let
 \[
   B=\bigoplus_j\mu_jA_j,\qquad S_M=\bigvee_jG_M(A_j).
 \]
-Assume each block satisfies PGVWC07 Condition C1 at length \(L_0\), the blocks
-are separated normalized BNT blocks, and
+Assume each block is injective at length \(L_0\), the blocks are separated
+normalized BNT blocks, and
 \[
   M-1\ge (L_0+1)+(r-1)((L_0+1)+((L_0+1)+(L_0+1))).
 \]
@@ -170,8 +172,8 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
   · exact groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital (by omega)
 
-/-- Condition C1 gives the periodic-chain inclusion into \(S_N\), and \(S_N\)
-is an internal direct sum of local block ground spaces. -/
+/-- Finite-length block injectivity gives the periodic-chain inclusion into
+\(S_N\), and \(S_N\) is an internal direct sum of local block ground spaces. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -375,15 +377,15 @@ theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_
   · exact chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital hN hL hLN hRange
 
-/-- Condition C1 gives the two established inclusions for the block-diagonal
-periodic chain space.
+/-- Finite-length block injectivity gives the two established inclusions for the
+block-diagonal periodic chain space.
 
 Let
 \[
   B=\bigoplus_j\mu_jA_j.
 \]
-Under the normalized BNT block-separation hypotheses and the finite Condition
-C1 range,
+Under the normalized BNT block-separation hypotheses and the corresponding
+finite injectivity range,
 \[
   \bigvee_j \mathcal G_{N,L}(A_j)
   \subseteq
@@ -618,10 +620,11 @@ private theorem contiguousRestrictₗ_groundSpaceMap_mem_groundSpace
         evalWord A rightWord) * X) := by
           rw [Matrix.mul_assoc, Matrix.mul_assoc]
 
-/-- Non-wrapping component windows already satisfy the block local constraint.
+/-- Cyclic windows not crossing the chosen cut already satisfy the block local
+constraint.
 
 For a block \(A_j\) and boundary matrix \(X_j\), if the cyclic window beginning
-at \(i\) does not cross the end of the chain, then
+at \(i\) stays inside the linear interval \(\{0,\ldots,N-1\}\), then
 \[
   R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)\in G_L(A_j).
 \]
@@ -629,7 +632,9 @@ The boundary matrix remains outside the window, so the restricted vector is
 \[
   \Gamma_L^{A_j}(A_{\mathrm{right}}\mu_j^NX_jA_{\mathrm{left}}).
 \]
-For wrapping windows, additionally needed is the matrix identity
+If the cyclic window crosses the chosen cut, the boundary matrix lies between
+the two pieces of the window after trace rotation.  The remaining
+block-diagonal boundary-closing input is the matrix identity
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
 \]
@@ -648,8 +653,8 @@ theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwr
   exact contiguousRestrictₗ_groundSpaceMap_mem_groundSpace (A := A j) (s := i.val)
     (L := L) (N := N) (by omega) τ ((μ j) ^ N • X j)
 
-/-- A block-diagonal boundary representation whose components are periodic block
-ground-space vectors lies in the blockwise periodic chain sum.
+/-- A block-diagonal boundary representation whose component vectors satisfy the
+periodic block constraints lies in the blockwise periodic chain sum.
 
 Let \(B=\bigoplus_j\mu_jA_j\). If a boundary condition for \(B\) is block
 diagonal, say \(X=\bigoplus_jX_j\), and every component
@@ -662,7 +667,8 @@ belongs to \(\mathcal G_{N,L}(A_j)\), then
 \]
 This is the block-diagonal boundary-condition reduction preceding the step of
 inverting and re-growing tensors described in arXiv:2011.12127, lines
-2126--2128. -/
+2126--2128; this theorem assumes the componentwise periodic constraint rather
+than deriving it. -/
 theorem groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -677,8 +683,8 @@ theorem groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpac
   rw [BlockSumGroundSpace.groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal]
   exact Submodule.sum_mem _ fun j _ => Submodule.mem_iSup_of_mem j (hX j)
 
-/-- A block-diagonal boundary decomposition gives the reverse inclusion for the
-block-diagonal periodic chain.
+/-- Block-diagonal boundary conditions plus componentwise periodic constraints
+give the reverse inclusion for the block-diagonal periodic chain.
 
 Let \(B=\bigoplus_j\mu_jA_j\). Suppose every
 \(\psi\in\mathcal G_{N,L}(B)\) has a block-diagonal boundary representation
@@ -693,11 +699,15 @@ lies in \(\mathcal G_{N,L}(A_j)\). Then
 \[
   \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j).
 \]
-The remaining source step is to obtain such a block-diagonal periodic boundary
-representation from the periodic constraints; compare Perez-Garcia, Verstraete,
-Wolf, and Cirac (arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1454--1456)
-and Cirac, Perez-Garcia, Schuch, and Verstraete (arXiv:2011.12127, lines
-2126--2128). -/
+The source boundary-closing step is to prove the displayed componentwise
+periodic constraint from the block-diagonal boundary conditions.  In PGVWC07,
+Theorem 2blocks.2, this is the comparison
+\[
+  A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
+\]
+The CPGSV21 review describes the same step as closing the boundaries after
+inverting and re-growing tensors with block-diagonal boundary conditions
+(arXiv:2011.12127, lines 2126--2128). -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -716,7 +726,7 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_gr
   rw [hψX]
   exact groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace μ A X hX
 
-/-- Block-diagonal boundary conditions give the periodic block-chain equality in
+/-- Block-diagonal boundary closing gives the periodic block-chain equality in
 the finite injectivity range.
 
 Let
@@ -739,10 +749,11 @@ belongs to \(\mathcal G_{N,L}(A_j)\). Then
 \]
 and the sum \(\bigvee_jG_N(A_j)\) is internal.
 
-The remaining source step is to obtain the displayed block-diagonal boundary
-representation from the inverting-and-re-growing argument in Perez-Garcia,
-Verstraete, Wolf, and Cirac (arXiv:quant-ph/0608197) and Cirac, Perez-Garcia, Schuch,
-and Verstraete (arXiv:2011.12127), with block-diagonal boundary conditions. -/
+The source boundary-closing step is to obtain the displayed block-diagonal
+boundary representation and the componentwise periodic constraints from the
+inverting-and-re-growing argument in Perez-Garcia, Verstraete, Wolf, and Cirac
+(arXiv:quant-ph/0608197) and Cirac, Perez-Garcia, Schuch, and Verstraete
+(arXiv:2011.12127), with block-diagonal boundary conditions. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -7318,7 +7318,6 @@ boundary-closing step concerns the separate assertion
     \label{thm:parent_ground_space_le_bnt_span}
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
-        thm:block_diagonal_ground_space_intersection,
         thm:chain_ground_space_eq_mpv_normal}
     If $A^i=\bigoplus_j\mu_j A_j^i$ is in block-injective canonical form, where
     $A_1,\ldots,A_g$ is a basis of normal tensors, assume $g\ge2$ and
@@ -7330,6 +7329,12 @@ boundary-closing step concerns the separate assertion
         L\ge 3(g-1)(L_0+1)+1,
         \qquad
         N\ge L+L_0,
+    \]
+    and assume the cyclic boundary-closing inclusion
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
+        \subseteq
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j).
     \]
     then
     \[
@@ -7344,7 +7349,10 @@ boundary-closing step concerns the separate assertion
     The length hypotheses are the conservative range used in
     \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}. The shorter range stated in
     \cite[lines~2126--2128]{Cirac2021Matrix} requires the strengthened
-    block-diagonal re-growing step. Since $g\ge2$ and $L_0\ge1$,
+    block-diagonal re-growing step. These hypotheses do not by themselves give
+    the displayed cyclic boundary-closing inclusion; that inclusion is the
+    remaining periodic step for windows crossing the chosen cut. Since $g\ge2$
+    and $L_0\ge1$,
     \[
         L\ge 3(g-1)(L_0+1)+1 \ge 3L_0+4 > L_0,
         \qquad
@@ -7357,13 +7365,11 @@ boundary-closing step concerns the separate assertion
         \quad\Longrightarrow\quad
         \exists n\ge1,\; V^{(n)}(A_j)\ne V^{(n)}(A_k).
     \]
-    Thus the ambient hypotheses of the block-diagonal intersection theorem
-    are available. Theorem~\ref{thm:block_diagonal_ground_space_intersection}
-    gives the periodic decomposition
+    By the assumed cyclic boundary-closing inclusion,
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
-        =
-        \sum_j \mathcal G_{N,L}(A_j).
+        \subseteq
+        \bigvee_j \mathcal G_{N,L}(A_j).
     \]
     Theorem~\ref{thm:chain_ground_space_eq_mpv_normal} gives
     \[
@@ -7371,8 +7377,8 @@ boundary-closing step concerns the separate assertion
         =
         \spn\{V^{(N)}(A_j)\}
     \]
-    for every $j$. Substituting these one-block identities into the preceding
-    sum gives the displayed containment.
+    for every $j$. Substituting these one-block identities into the join gives
+    the displayed containment.
 \end{proof}
 
 \begin{theorem}[Cyclic-chain equality with the BNT span]
@@ -7390,6 +7396,12 @@ boundary-closing step concerns the separate assertion
         L\ge 3(g-1)(L_0+1)+1,
         \qquad
         N\ge L+L_0,
+    \]
+    and assume the cyclic boundary-closing inclusion
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
+        \subseteq
+        \bigvee_{j=1}^g\mathcal G_{N,L}(A_j).
     \]
     then
     \[

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6596,8 +6596,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     This proves the displayed statement.
 \end{proof}
 
-The lemma gives membership in the open-boundary space \(G_N(A_j)\).  The later
-periodic comparison concerns the separate assertion
+The lemma gives membership in the open-boundary space \(G_N(A_j)\). The later
+boundary-closing step concerns the separate assertion
 \[
     \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
 \]
@@ -6666,13 +6666,13 @@ periodic comparison concerns the separate assertion
     from \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}.
 \end{proof}
 
-\begin{lemma}[Non-wrapping component windows]
+\begin{lemma}[Cyclic windows not crossing the cut]
     \label{lem:block_diagonal_boundary_nonwrapping_component}
     \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping}
     \leanok
     \uses{def:ground_space_parent, rem:cyclic_window_operators}
-    Fix block-diagonal boundary conditions $X_j$.  If the cyclic window
-    beginning at $i$ does not cross the end of the chain, $i+L\le N$, then
+    Fix block-diagonal boundary conditions $X_j$. If the cyclic window beginning
+    at $i$ stays inside the chosen linear interval, $i+L\le N$, then
     for every block $j$,
     \[
         R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
@@ -6683,17 +6683,20 @@ periodic comparison concerns the separate assertion
 \begin{proof}
     \leanok
     \uses{def:ground_space_parent, rem:cyclic_window_operators}
-    In a non-wrapping window the boundary matrix stays outside the window.  Let
-    $A_{\rm left}$ be the product on the sites before the window and
-    $A_{\rm right}$ the product on the sites after the window.  Trace cyclicity
+    When the window stays inside the chosen linear interval, the boundary matrix
+    remains outside the window. Let $A_{\rm left}$ be the product on the sites
+    before the window and $A_{\rm right}$ the product on the sites after the
+    window. Trace cyclicity
     gives
     \[
         R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
         =
         \Gamma_L^{A_j}\!\left(A_{\rm right}\,\mu_j^NX_j\,A_{\rm left}\right).
     \]
-    Hence the restricted vector lies in $G_L(A_j)$.  The wrapping case is not
-    covered here; it requires additionally the identity
+    Hence the restricted vector lies in $G_L(A_j)$. If the cyclic window crosses
+    the chosen cut, the matrix $\mu_j^N X_j$ lies between the two pieces of the
+    window after trace rotation. The missing block-diagonal boundary-closing
+    comparison is the identity
     \[
         A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
     \]
@@ -6822,7 +6825,7 @@ periodic comparison concerns the separate assertion
     assumption, so the finite sum lies in the linear span of these spaces.
 \end{proof}
 
-\begin{lemma}[Block-diagonal boundary representation gives the reverse inclusion]
+\begin{lemma}[Block-diagonal boundary closing gives the reverse inclusion]
     \label{lem:block_diagonal_boundary_representation_inclusion}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap}
     \leanok
@@ -6852,7 +6855,7 @@ periodic comparison concerns the separate assertion
     $\psi\in\mathcal G_{N,L}(B)$.
 \end{proof}
 
-\begin{lemma}[Block-diagonal boundary representation gives equality in the finite range]
+\begin{lemma}[Block-diagonal boundary closing gives equality in the finite range]
     \label{lem:bnt_block_diagonal_boundary_representation_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary}
     \leanok
@@ -6940,7 +6943,7 @@ periodic comparison concerns the separate assertion
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}.
 \end{proof}
 
-\begin{theorem}[Block-diagonal intersection identity]
+\begin{theorem}[Block-diagonal local recursion and boundary closing]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
     \uses{def:ground_space_parent, def:chain_ground_space, def:l_blk_injective,
@@ -6984,26 +6987,32 @@ periodic comparison concerns the separate assertion
         \qquad
         L\ge 3(g-1)(L_0+1)+1,
     \]
-    the block-diagonal intersection property says that, for every $m\ge L$,
+    Put
     \[
-        \mathbb C^d\otimes
-        \left(\bigoplus_{j=1}^g G_m(A_j)\right)
+        S_m:=\bigoplus_{j=1}^gG_m(A_j).
+    \]
+    The open-segment recursion in
+    \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix} says that, for every
+    $m\ge L$,
+    \[
+        \mathbb C^d\otimes S_m
         \cap
-        \left(\bigoplus_{j=1}^g G_m(A_j)\right)\otimes\mathbb C^d
+        S_m\otimes\mathbb C^d
         =
-        \bigoplus_{j=1}^g G_{m+1}(A_j).
+        S_{m+1}.
     \]
-    For nonzero weights $\mu_j$ and every $N\ge L+L_0$, the corresponding
-    periodic chain ground spaces satisfy
+    Let $H_{S_L,N}$ denote the periodic parent Hamiltonian whose local
+    ground space is $S_L$. The boundary-closing conclusion of the same theorem is
     \[
-        \mathcal G_{N,L}\!\left(\bigoplus_{j=1}^g \mu_j A_j\right)
+        \ker H_{S_L,N}
         =
-        \sum_{j=1}^g \mathcal G_{N,L}(A_j).
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
     \]
+    for every $N\ge L+L_0$.
 \end{theorem}
-% This source-level structural theorem is intentionally separated from the
-% following conditional reductions, which assume the needed block-diagonal
-% boundary representation separately.
+% The cyclic-chain equality for \mathcal G_{N,L}(\oplus_j\mu_jA_j) is kept in
+% the following conditional reductions until the block-diagonal boundary-closing
+% comparison has been proved in Lean.
 
 \begin{proof}
     \notready
@@ -7131,14 +7140,15 @@ periodic comparison concerns the separate assertion
     $G_L(B)$ with the subspace denoted in the source by
     $S=\bigoplus_j\mathcal G_L^{A^j}$.
     The passage from the open-segment recursion to the periodic chain is the
-    separate closure step in \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}. It is
-    not the inclusion $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails
-    for a general open-boundary matrix crossing the periodic boundary. Under
-    $N\ge L+L_0$, the required boundary-condition comparison is
+    separate boundary-closing step in
+    \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}. It is not the inclusion
+    $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails for a general
+    open-boundary matrix crossing the periodic boundary. The source
+    boundary-closing conclusion is
     \[
-        \mathcal G_{N,L}(B)
+        \ker H_{S_L,N}
         =
-        \sum_{j=1}^g \mathcal G_{N,L}(A_j).
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
     \]
 \end{proof}
 
@@ -7304,7 +7314,7 @@ periodic comparison concerns the separate assertion
     equality follows after adding the forward inclusion.
 \end{proof}
 
-\begin{theorem}[Containment in the space generated by a basis of normal tensors]
+\begin{theorem}[Cyclic-chain containment in the BNT span]
     \label{thm:parent_ground_space_le_bnt_span}
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
@@ -7365,7 +7375,7 @@ periodic comparison concerns the separate assertion
     sum gives the displayed containment.
 \end{proof}
 
-\begin{theorem}[Chain ground space generated by a basis of normal tensors]
+\begin{theorem}[Cyclic-chain equality with the BNT span]
     \label{thm:gs_eq_bnt_span}
     \notready
     \uses{thm:parent_ground_space_le_bnt_span, lem:bnt_mpv_mem_ground_space,

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6728,7 +6728,8 @@ boundary-closing step concerns the separate assertion
     inclusion and internal directness are
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}. The
     claimed statement is their conjunction.
-    % The remaining PGVWC07 boundary-closing step with block-diagonal boundary
+    % The remaining arXiv:quant-ph/0608197 boundary-closing step with
+    % block-diagonal boundary
     % conditions replaces
     % $\bigvee_jG_N(A_j)$ by $\sum_j\mathcal G_{N,L}(A_j)$.
 \end{proof}


### PR DESCRIPTION
## Motivation

The block-diagonal parent-Hamiltonian prose should follow the source papers. Theorem 2blocks.2 of arXiv:quant-ph/0608197 states the open-segment recursion for
\[
  S_m=\bigoplus_j G_m(A_j),
  \qquad
  \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1},
\]
and then closes the periodic boundary to obtain the kernel statement
\[
  \ker H_{S_L,N}=\operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}.
\]
The cyclic-chain equality used later in Chapter 14 is a separate conditional target until the block-diagonal boundary-closing comparison is proved.

## Description

- Restate `thm:block_diagonal_ground_space_intersection` in the source form: local recursion plus the boundary-closing kernel conclusion.
- Replace reader-facing “wrapping” prose by “cyclic window crossing the chosen cut” and display the remaining identity
  \[
    A^j_{i_{m+1}} C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
  \]
- Clarify in Lean docstrings that current reverse-inclusion theorems assume the componentwise periodic constraints \(\Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j)\); they do not derive them.
- Keep the later BNT-span consequences conditional on the cyclic boundary-closing inclusion, so the source theorem is not used to prove a stronger periodic decomposition.

Documentation only; no proof or API changes. Does not close #2665 or #2651.

## Checks

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `lake exe checkdecls blueprint/lean_decls`

Refs #2665
Refs #2651