### PR TITLE
feat(MPS/ParentHamiltonian): reduce block boundary closing to crossing windows

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -656,6 +656,51 @@ theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwr
   exact contiguousRestrictₗ_groundSpaceMap_mem_groundSpace (A := A j) (s := i.val)
     (L := L) (N := N) (by omega) τ ((μ j) ^ N • X j)
 
+/-- Componentwise periodicity is reduced to the cyclic windows crossing the
+chosen cut.
+
+Let \(B=\bigoplus_j\mu_jA_j\), and fix block-diagonal boundary conditions
+\(X_j\). For a block component
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j),
+\]
+membership in \(\mathcal G_{N,L}(A_j)\) means that every cyclic
+length-\(L\) window lies in \(G_L(A_j)\). If a window beginning at \(i\)
+satisfies \(i+L\le N\), this is already the preceding non-crossing-window
+case.
+Thus it remains only to prove the same membership for the windows satisfying
+\[
+  N<i+L.
+\]
+
+In the notation of arXiv:quant-ph/0608197, Theorem 2blocks.2, these are the
+boundary-closing windows controlled by the comparison
+\[
+  A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
+\]
+This theorem records the reduction; it assumes the crossing-window membership
+rather than proving the displayed comparison. -/
+theorem blockDiagonal_boundary_component_chainGroundSpace_of_crossing_windows
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hCrossing : ∀ (j : Fin r) (i : Fin N) (τ : Fin N → Fin d),
+      N < i.val + L →
+        cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j)) ∈
+          groundSpace (A j) L) :
+    ∀ j : Fin r,
+      groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  intro j
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩]
+  simp only [Submodule.mem_iInf, Submodule.mem_comap]
+  intro i τ
+  by_cases hi : i.val + L ≤ N
+  · exact blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping
+      μ A hN hLN X j i τ hi
+  · exact hCrossing j i τ (Nat.lt_of_not_ge hi)
+
 /-- A block-diagonal boundary representation whose component vectors satisfy the
 periodic block constraints lies in the blockwise periodic chain sum.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6703,6 +6703,36 @@ boundary-closing step concerns the separate assertion
     from \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}.
 \end{proof}
 
+\begin{lemma}[Cyclic windows crossing the cut suffice]
+    \label{lem:block_diagonal_boundary_component_crossing_windows_suffice}
+    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_crossing_windows}
+    \leanok
+    \uses{def:chain_ground_space,
+        lem:block_diagonal_boundary_nonwrapping_component}
+    Assume \(0<N\) and \(L\le N\). Fix block-diagonal boundary conditions
+    \(X_j\). Suppose that, for every block \(j\), every cyclic window beginning
+    at \(i\) with \(N<i+L\), and every configuration \(\tau\),
+    \[
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in G_L(A_j).
+    \]
+    Then, for every block \(j\),
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in \mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:chain_ground_space,
+        lem:block_diagonal_boundary_nonwrapping_component}
+    By definition, membership in \(\mathcal G_{N,L}(A_j)\) is the collection of
+    all cyclic length-\(L\) local constraints. For a window beginning at \(i\),
+    either \(i+L\le N\) or \(N<i+L\). In the first case use
+    Lemma~\ref{lem:block_diagonal_boundary_nonwrapping_component}. In the second
+    case use the displayed hypothesis.
+\end{proof}
+
 \begin{lemma}[The block-diagonal chain space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}


### PR DESCRIPTION
### Motivation
- The wrapping-window cyclic-restriction membership is needed as the `hBoundary` input to `chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap` (see #2651). The non-wrapping case ($i + L \le N$) was established in #2664; this PR reduces the remaining obligation to the cut-crossing window case ($N < i + L$), which is the part controlled by the boundary-closing identity $A^j_{i_{m+1}} C^j_{i_1} = D^j_{i_{m+1}} A^j_{i_1}$ in arXiv:quant-ph/0608197, Theorem 2blocks.2.

### Description
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`: adds a reduction lemma proving that if every cut-crossing cyclic window ($N < i + L$) satisfies $R_{i,\tau}(\Gamma_N^{A_j}(\mu_j^N X_j)) \in G_L(A_j)$, then $\Gamma_N^{A_j}(\mu_j^N X_j) \in \mathcal{G}_{N,L}(A_j)$ for each block $j$. The non-crossing case is discharged by the existing component theorem; the crossing-window case is the isolated source-faithful obligation. This lemma is proved without `sorry`.
- `blueprint/src/chapter/ch14_parent_hamiltonian.tex`: records the same reduction in equations, without presenting a Lean declaration name as theorem content.
- The boundary-closing identity from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1454–1456, needed to discharge the crossing-window case, remains open (tracked in #2665).

### Testing
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- No new `sorry` tokens introduced; pre-existing warnings in untouched files are unchanged.

---
Addresses #2665
Refs #2651

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint prose only; no application logic, security, or data-path changes.
> 
> **Overview**
> Adds a **no-sorry reduction** for block-diagonal boundary closing: for each block component \(\Gamma_N^{A_j}(\mu_j^N X_j)\), membership in \(\mathcal G_{N,L}(A_j)\) follows if every **cut-crossing** cyclic window (\(N<i+L\)) already lies in \(G_L(A_j)\). Non-crossing windows (\(i+L\le N\)) are discharged via the existing `blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping` lemma; the new `blockDiagonal_boundary_component_chainGroundSpace_of_crossing_windows` theorem case-splits on that boundary.
> 
> The blueprint chapter records the same statement as Lemma "Cyclic windows crossing the cut suffice," linked to the Lean decl, without claiming the Pérez-García boundary matrix identity—that remains the isolated source-faithful obligation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfef568508988467c8edf84ddbb6d540011a6b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint text only; no runtime, security, or data-path changes.
> 
> **Overview**
> Adds **`blockDiagonal_boundary_component_chainGroundSpace_of_crossing_windows`**, a no-`sorry` reduction: for each block component \(\Gamma_N^{A_j}(\mu_j^N X_j)\), membership in \(\mathcal G_{N,L}(A_j)\) follows if every **cut-crossing** cyclic window (\(N < i+L\)) already restricts into \(G_L(A_j)\). The proof unfolds `chainGroundSpace` and **case-splits** on \(i+L \le N\) vs not, using the existing non-wrapping lemma for the former and the new hypothesis for the latter.
> 
> The blueprint gains matching Lemma *Cyclic windows crossing the cut suffice*, linked to that Lean decl, and explicitly leaves the Pérez-García boundary-closing matrix identity as the remaining obligation to prove crossing windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5680515e6049616ce81db1f782c19675e31521. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->