### PR TITLE
feat(MPS/ParentHamiltonian): derive boundary-crossing intervals from boundary matrix identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -215,6 +215,7 @@ import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
 import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
 import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -5,11 +5,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
 
 /-!
-# Crossing-window boundary equations for block-diagonal parent spaces
+# Boundary-crossing cyclic interval equations for block-diagonal parent spaces
 
-This file isolates the cyclic-window step for a block component when the window
-crosses the chosen cut.  The input is the blockwise matrix identity appearing in
-the boundary-closing part of arXiv:quant-ph/0608197, Theorem 2blocks.2.
+This file isolates the cyclic-interval step for a block component when the
+interval crosses the boundary cut.  The input is the blockwise matrix identity
+appearing in the boundary-closing part of arXiv:quant-ph/0608197, Theorem
+2blocks.2.
 -/
 
 open scoped Matrix BigOperators
@@ -18,14 +19,15 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- A crossing cyclic window is local when the boundary matrix satisfies the
-crossing identity for the wrapped head and the complementary interval.
+/-- A boundary-crossing cyclic interval is local when the boundary matrix
+satisfies the displayed boundary identity.
 
-Let the cyclic window beginning at \(i\) cross the cut, so \(N<i+L\). Write
-\(a=i+L-N\). The sites \(0,\ldots,a-1\) carry the wrapped head of the window,
-the sites \(a,\ldots,i-1\) carry the outside configuration, and the sites
-\(i,\ldots,N-1\) carry the tail of the window. If, for every head word
-\(\beta\), there is a matrix \(E\) such that
+Let the cyclic interval beginning at \(i\) cross the cut, so \(N<i+L\). Write
+\(a=i+L-N\). The sites \(0,\ldots,a-1\) carry the segment after the interval
+wraps past the cut, the sites \(a,\ldots,i-1\) carry the outside
+configuration, and the sites \(i,\ldots,N-1\) carry the segment before the
+cut. If, for every word \(\beta\) on the segment \(0,\ldots,a-1\), there is a
+matrix \(E\) such that
 \[
   \mu_j^N X_j A^j_\beta
     A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -26,8 +26,8 @@ Let the cyclic interval beginning at \(i\) cross the cut, so \(N<i+L\). Write
 \(a=i+L-N\). The sites \(0,\ldots,a-1\) carry the segment after the interval
 wraps past the cut, the sites \(a,\ldots,i-1\) carry the outside
 configuration, and the sites \(i,\ldots,N-1\) carry the segment before the
-cut. If, for every word \(\beta\) on the segment \(0,\ldots,a-1\), there is a
-matrix \(E\) such that
+cut. If there is a matrix \(E\) such that, for every word \(\beta\) on the
+segment \(0,\ldots,a-1\),
 \[
   \mu_j^N X_j A^j_\beta
     A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -1,0 +1,204 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
+
+/-!
+# Crossing-window boundary equations for block-diagonal parent spaces
+
+This file isolates the cyclic-window step for a block component when the window
+crosses the chosen cut.  The input is the blockwise matrix identity appearing in
+the boundary-closing part of arXiv:quant-ph/0608197, Theorem 2blocks.2.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- A crossing cyclic window is local when the boundary matrix satisfies the
+crossing identity for the wrapped head and the complementary interval.
+
+Let the cyclic window beginning at \(i\) cross the cut, so \(N<i+L\). Write
+\(a=i+L-N\). The sites \(0,\ldots,a-1\) carry the wrapped head of the window,
+the sites \(a,\ldots,i-1\) carry the outside configuration, and the sites
+\(i,\ldots,N-1\) carry the tail of the window. If, for every head word
+\(\beta\), there is a matrix \(E\) such that
+\[
+  \mu_j^N X_j A^j_\beta
+    A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}
+    =
+  A^j_\beta E,
+\]
+then the restriction is the local vector \(\Gamma_L^{A_j}(E)\).
+
+This is the matrix form of the boundary-closing comparison in
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1456. -/
+theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (j : Fin r) (i : Fin N) (τ : Fin N → Fin d)
+    (hi : N < i.val + L)
+    (hIdentity : ∃ E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ∀ β : Fin (i.val + L - N) → Fin d,
+        (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+            evalWord (A j) (List.ofFn fun k : Fin (N - L) =>
+              τ ⟨i.val + L - N + k.val, by omega⟩) =
+          evalWord (A j) (List.ofFn β) * E) :
+    cyclicRestrictₗ hN L i τ
+        (groundSpaceMap (A j) N ((μ j) ^ N • X j)) ∈
+      groundSpace (A j) L := by
+  classical
+  rcases hIdentity with ⟨E, hE⟩
+  rw [groundSpace, LinearMap.mem_range]
+  refine ⟨E, ?_⟩
+  ext σ
+  let headWord : List (Fin d) := List.ofFn fun k : Fin (i.val + L - N) =>
+    σ ⟨N - i.val + k.val, by omega⟩
+  let middleWord : List (Fin d) := List.ofFn fun k : Fin (N - L) =>
+    τ ⟨i.val + L - N + k.val, by omega⟩
+  let tailWord : List (Fin d) := List.ofFn fun k : Fin (N - i.val) =>
+    σ ⟨k.val, by omega⟩
+  let Xj : Matrix (Fin (dim j)) (Fin (dim j)) ℂ := (μ j) ^ N • X j
+  have hσ : List.ofFn σ = tailWord ++ headWord := by
+    apply List.ext_getElem
+    · simp [tailWord, headWord, List.length_ofFn]
+      omega
+    · intro k hk₁ hk₂
+      have hkL : k < L := by
+        simpa only [List.length_ofFn] using hk₁
+      simp only [List.getElem_ofFn]
+      by_cases hkTail : k < N - i.val
+      · rw [List.getElem_append_left]
+        · have htail :
+              tailWord[k]'(by simpa [tailWord, List.length_ofFn] using hkTail) =
+                σ ⟨k, hkL⟩ := by
+            simp only [tailWord, List.getElem_ofFn]
+          rw [htail]
+        · simpa [tailWord, List.length_ofFn] using hkTail
+      · rw [List.getElem_append_right]
+        · have hidx : k - tailWord.length < headWord.length := by
+            simp [tailWord, headWord, List.length_ofFn]
+            omega
+          have hhead :
+              headWord[k - tailWord.length]'hidx = σ ⟨k, hkL⟩ := by
+            simp only [headWord, List.getElem_ofFn]
+            congr 1
+            ext
+            simp [tailWord, List.length_ofFn]
+            omega
+          rw [hhead]
+        · simpa [tailWord, List.length_ofFn] using
+            (show tailWord.length ≤ k by simp [tailWord, List.length_ofFn]; omega)
+  have hcfg :
+      List.ofFn (cyclicCfg hN L i σ τ) = headWord ++ (middleWord ++ tailWord) := by
+    apply List.ext_getElem
+    · simp [headWord, middleWord, tailWord, List.length_ofFn]
+      omega
+    · intro k hk₁ hk₂
+      have hkN : k < N := by
+        simpa only [List.length_ofFn] using hk₁
+      simp only [List.getElem_ofFn]
+      by_cases hkHead : k < i.val + L - N
+      · have hoff : (k + N - i.val) % N = N - i.val + k := by
+          have hsum : k + N - i.val = N - i.val + k := by omega
+          rw [hsum]
+          exact Nat.mod_eq_of_lt (by omega)
+        have hoffLt : (k + N - i.val) % N < L := by
+          rw [hoff]
+          omega
+        rw [cyclicCfg, dif_pos hoffLt]
+        rw [List.getElem_append_left]
+        · have hhead :
+              headWord[k]'(by simpa [headWord, List.length_ofFn] using hkHead) =
+                σ ⟨N - i.val + k, by omega⟩ := by
+            simp only [headWord, List.getElem_ofFn]
+          rw [hhead]
+          exact congrArg σ (Fin.ext hoff)
+        · simpa [headWord, List.length_ofFn] using hkHead
+      · by_cases hkMiddle : k < i.val
+        · have hoff : (k + N - i.val) % N = k + N - i.val := by
+            exact Nat.mod_eq_of_lt (by omega)
+          have hoffNot : ¬(k + N - i.val) % N < L := by
+            rw [hoff]
+            omega
+          rw [cyclicCfg, dif_neg hoffNot]
+          rw [List.getElem_append_right]
+          · rw [List.getElem_append_left]
+            · have hidx :
+                  k - headWord.length < middleWord.length := by
+                simp [headWord, middleWord, List.length_ofFn]
+                omega
+              have hmiddle :
+                  middleWord[k - headWord.length]'hidx = τ ⟨k, hkN⟩ := by
+                simp only [middleWord, List.getElem_ofFn]
+                congr 1
+                ext
+                simp [headWord, List.length_ofFn]
+                omega
+              rw [hmiddle]
+            · simp [headWord, middleWord, List.length_ofFn]
+              omega
+          · simp [headWord, List.length_ofFn]
+            omega
+        · have hi_le_k : i.val ≤ k := by omega
+          have hoff : (k + N - i.val) % N = k - i.val := by
+            have hsum : k + N - i.val = k - i.val + N := by omega
+            rw [hsum, Nat.add_mod_right]
+            exact Nat.mod_eq_of_lt (by omega)
+          have hoffLt : (k + N - i.val) % N < L := by
+            rw [hoff]
+            omega
+          rw [cyclicCfg, dif_pos hoffLt]
+          rw [List.getElem_append_right]
+          · rw [List.getElem_append_right]
+            · have hidx :
+                  k - headWord.length - middleWord.length < tailWord.length := by
+                simp [headWord, middleWord, tailWord, List.length_ofFn]
+                omega
+              have htail :
+                  tailWord[k - headWord.length - middleWord.length]'hidx =
+                    σ ⟨k - i.val, by omega⟩ := by
+                simp only [tailWord, List.getElem_ofFn]
+                congr 1
+                ext
+                simp [headWord, middleWord, List.length_ofFn]
+                omega
+              rw [htail]
+              exact congrArg σ (Fin.ext hoff)
+            · simp [headWord, middleWord, List.length_ofFn]
+              omega
+          · simp [headWord, List.length_ofFn]
+            omega
+  have hIdentityσ :
+      (Xj * evalWord (A j) headWord) * evalWord (A j) middleWord =
+        evalWord (A j) headWord * E := by
+    simpa [Xj, headWord, middleWord] using
+      hE (fun k : Fin (i.val + L - N) => σ ⟨N - i.val + k.val, by omega⟩)
+  simp only [groundSpaceMap_apply, cyclicRestrictₗ_apply]
+  rw [hσ, hcfg, evalWord_append, evalWord_append, evalWord_append]
+  set H := evalWord (A j) headWord
+  set M := evalWord (A j) middleWord
+  set T := evalWord (A j) tailWord
+  calc
+    Matrix.trace ((T * H) * E) = Matrix.trace (T * (H * E)) := by
+      rw [Matrix.mul_assoc]
+    _ = Matrix.trace (T * ((Xj * H) * M)) := by
+      rw [hIdentityσ]
+    _ = Matrix.trace ((T * Xj) * (H * M)) := by
+      rw [← Matrix.mul_assoc T (Xj * H) M]
+      rw [← Matrix.mul_assoc T Xj H]
+      rw [Matrix.mul_assoc (T * Xj) H M]
+    _ = Matrix.trace ((H * M) * (T * Xj)) := Matrix.trace_mul_comm _ _
+    _ = Matrix.trace (((H * M) * T) * Xj) := by
+      rw [← Matrix.mul_assoc (H * M) T Xj]
+    _ = Matrix.trace ((H * (M * T)) * Xj) := by
+      rw [Matrix.mul_assoc H M T]
+    _ = Matrix.trace ((H * (M * T)) * ((μ j) ^ N • X j)) := by
+      rfl
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6703,6 +6703,55 @@ boundary-closing step concerns the separate assertion
     from \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}.
 \end{proof}
 
+\begin{lemma}[Crossing windows from the boundary matrix identity]
+    \label{lem:block_diagonal_boundary_crossing_matrix_identity}
+    \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix}
+    \leanok
+    \uses{def:ground_space_parent, rem:cyclic_window_operators}
+    Assume \(0<N\), \(L\le N\), and let the cyclic window beginning at \(i\)
+    cross the chosen cut, so \(N<i+L\). Put \(a=i+L-N\). Suppose that there is
+    a matrix \(E\) such that for every word \(\beta\) of length \(a\),
+    \[
+        \mu_j^N X_j A^j_\beta
+        A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}
+        =
+        A^j_\beta E.
+    \]
+    Then
+    \[
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in G_L(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:ground_space_parent, rem:cyclic_window_operators}
+    Write a length-\(L\) word in the crossing window as \(\alpha\beta\), where
+    \(\alpha\) is the tail inside the interval \(\{i,\ldots,N-1\}\) and
+    \(\beta\) is the wrapped head inside \(\{0,\ldots,a-1\}\). The full
+    \(N\)-site word appearing in the restriction is then
+    \[
+        \beta\,\tau_a\cdots\tau_{i-1}\,\alpha .
+    \]
+    Trace cyclicity gives
+    \[
+        \operatorname{tr}\!\left(
+        A^j_\beta A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}
+        A^j_\alpha \mu_j^NX_j\right)
+        =
+        \operatorname{tr}\!\left(
+        A^j_\alpha \mu_j^NX_j A^j_\beta
+        A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}\right).
+    \]
+    The assumed boundary matrix identity changes the last expression to
+    \[
+        \operatorname{tr}\!\left(A^j_\alpha A^j_\beta E\right),
+    \]
+    which is the coefficient of \(\Gamma_L^{A_j}(E)\) at the word
+    \(\alpha\beta\). Hence the restricted vector lies in \(G_L(A_j)\).
+\end{proof}
+
 \begin{lemma}[Cyclic windows crossing the cut suffice]
     \label{lem:block_diagonal_boundary_component_crossing_windows_suffice}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_crossing_windows}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6693,23 +6693,23 @@ boundary-closing step concerns the separate assertion
         =
         \Gamma_L^{A_j}\!\left(A_{\rm right}\,\mu_j^NX_j\,A_{\rm left}\right).
     \]
-    Hence the restricted vector lies in $G_L(A_j)$. If the cyclic window crosses
-    the chosen cut, the matrix $\mu_j^N X_j$ lies between the two pieces of the
-    window after trace rotation. The missing block-diagonal boundary-closing
-    comparison is the identity
+    Hence the restricted vector lies in $G_L(A_j)$. If the cyclic interval
+    crosses the boundary cut, the matrix $\mu_j^N X_j$ lies between the two
+    pieces of the interval after trace rotation. The missing block-diagonal
+    boundary-closing comparison is the identity
     \[
         A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
     \]
     from \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}.
 \end{proof}
 
-\begin{lemma}[Crossing windows from the boundary matrix identity]
+\begin{lemma}[Boundary-crossing cyclic intervals from the boundary matrix identity]
     \label{lem:block_diagonal_boundary_crossing_matrix_identity}
     \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix}
     \leanok
     \uses{def:ground_space_parent, rem:cyclic_window_operators}
-    Assume \(0<N\), \(L\le N\), and let the cyclic window beginning at \(i\)
-    cross the chosen cut, so \(N<i+L\). Put \(a=i+L-N\). Suppose that there is
+    Assume \(0<N\), \(L\le N\), and let the cyclic interval beginning at \(i\)
+    cross the boundary cut, so \(N<i+L\). Put \(a=i+L-N\). Suppose that there is
     a matrix \(E\) such that for every word \(\beta\) of length \(a\),
     \[
         \mu_j^N X_j A^j_\beta
@@ -6760,8 +6760,8 @@ boundary-closing step concerns the separate assertion
     \uses{def:chain_ground_space,
         lem:block_diagonal_boundary_nonwrapping_component}
     Assume \(0<N\) and \(L\le N\). Fix block-diagonal boundary conditions
-    \(X_j\). Suppose that, for every block \(j\), every cyclic window beginning
-    at \(i\) with \(N<i+L\), and every configuration \(\tau\),
+    \(X_j\). Suppose that, for every block \(j\), every cyclic interval
+    beginning at \(i\) with \(N<i+L\), and every configuration \(\tau\),
     \[
         R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
         \in G_L(A_j).
@@ -6777,7 +6777,7 @@ boundary-closing step concerns the separate assertion
     \uses{def:chain_ground_space,
         lem:block_diagonal_boundary_nonwrapping_component}
     By definition, membership in \(\mathcal G_{N,L}(A_j)\) is the collection of
-    all cyclic length-\(L\) local constraints. For a window beginning at \(i\),
+    all cyclic length-\(L\) local constraints. For an interval beginning at \(i\),
     either \(i+L\le N\) or \(N<i+L\). In the first case use
     Lemma~\ref{lem:block_diagonal_boundary_nonwrapping_component}. In the second
     case use the displayed hypothesis.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6727,9 +6727,10 @@ boundary-closing step concerns the separate assertion
 \begin{proof}
     \leanok
     \uses{def:ground_space_parent, rem:cyclic_window_operators}
-    Write a length-\(L\) word in the crossing window as \(\alpha\beta\), where
-    \(\alpha\) is the tail inside the interval \(\{i,\ldots,N-1\}\) and
-    \(\beta\) is the wrapped head inside \(\{0,\ldots,a-1\}\). The full
+    Write a length-\(L\) word in the boundary-crossing cyclic interval as
+    \(\alpha\beta\), where \(\alpha\) is the segment inside
+    \(\{i,\ldots,N-1\}\) and \(\beta\) is the segment after the interval wraps
+    past the cut, inside \(\{0,\ldots,a-1\}\). The full
     \(N\)-site word appearing in the restriction is then
     \[
         \beta\,\tau_a\cdots\tau_{i-1}\,\alpha .
@@ -6752,7 +6753,7 @@ boundary-closing step concerns the separate assertion
     \(\alpha\beta\). Hence the restricted vector lies in \(G_L(A_j)\).
 \end{proof}
 
-\begin{lemma}[Cyclic windows crossing the cut suffice]
+\begin{lemma}[Boundary-crossing cyclic intervals suffice]
     \label{lem:block_diagonal_boundary_component_crossing_windows_suffice}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_crossing_windows}
     \leanok


### PR DESCRIPTION
This PR is based on `main` after #2667 merged.

It adds the next boundary-closing step for #2665. For a boundary-crossing cyclic interval relative to the cut, it proves that the component restriction

\[
R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^N X_j)\right)
\]

lies in \(G_L(A_j)\) once the blockwise boundary matrix identity holds:

\[
\mu_j^N X_j A^j_\beta A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}
=
A^j_\beta E,
\qquad a=i+L-N.
\]

The proof decomposes the cyclic word as
\(\beta\,\tau_a\cdots\tau_{i-1}\,\alpha\), rotates the trace, applies the displayed matrix identity, and identifies the result with \(\Gamma_L^{A_j}(E)\). The theorem lives in `TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing` so `BNTBlockDiagonalChain.lean` remains below the file-length limit. The blueprint entry records the same statement in Chapter 14.

This does not yet prove the source-paper identity from the PGVWC07 block-separation argument; it isolates the exact matrix identity needed to finish the boundary-crossing membership.

Checks on the latest head:
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake exe checkdecls blueprint/lean_decls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof and documentation only in the parent-Hamiltonian/BNT chain; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`** and wires it into the root import list so the boundary-crossing step lives outside `BNTBlockDiagonalChain.lean`.
> 
> The new theorem **`blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix`** shows that when a cyclic interval crosses the cut (`N < i+L`), assuming the blockwise PGVWC07-style matrix identity ∃E with `μ_j^N X_j A^j_β … = A^j_β E`, the component restriction `R_{i,τ}(Γ_N^{A_j}(μ_j^N X_j))` lies in **`G_L(A_j)`** (identified with **`Γ_L^{A_j}(E)`** via trace cyclicity and word splits).
> 
> Chapter 14 blueprint gains a matching lemma and proof, renames “cyclic windows” to **“cyclic intervals”** where relevant, and links the Lean declaration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8c29d37e3a9754fb99969456f5cd7c23d29d6e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->