### PR TITLE
feat(MPS/ParentHamiltonian): reduce boundary-crossing intervals to boundary identities

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -203,4 +203,95 @@ theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_cross
     _ = Matrix.trace ((H * (M * T)) * ((μ j) ^ N • X j)) := by
       rfl
 
+/-- A right boundary-matrix identity on the segment after the interval wraps
+past the cut gives the local constraint.
+
+Let the cyclic interval beginning at \(i\) cross the cut, so \(N<i+L\), and put
+\(a=i+L-N\). If there is a boundary matrix \(Y\) such that, for every word
+\(\beta\) of length \(a\),
+\[
+  \mu_j^N X_j A^j_\beta=A^j_\beta Y
+\]
+then the restriction belongs to \(G_L(A_j)\).  The middle word
+\[
+  A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}
+\]
+is incorporated into the boundary matrix
+\(Y A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}\).
+
+This is the equation form of the boundary-closing reduction used after the
+blockwise comparison in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines
+1454--1456. -/
+theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_boundary_identity
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (j : Fin r) (i : Fin N) (τ : Fin N → Fin d)
+    (hi : N < i.val + L)
+    (hBoundary : ∃ Y : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ∀ β : Fin (i.val + L - N) → Fin d,
+        ((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) =
+          evalWord (A j) (List.ofFn β) * Y) :
+    cyclicRestrictₗ hN L i τ
+        (groundSpaceMap (A j) N ((μ j) ^ N • X j)) ∈
+      groundSpace (A j) L := by
+  rcases hBoundary with ⟨Y, hY⟩
+  refine blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix
+    μ A hN hLN X j i τ hi ?_
+  refine ⟨Y * evalWord (A j) (List.ofFn fun k : Fin (N - L) =>
+    τ ⟨i.val + L - N + k.val, by omega⟩), ?_⟩
+  intro β
+  calc
+    (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+          evalWord (A j) (List.ofFn fun k : Fin (N - L) =>
+            τ ⟨i.val + L - N + k.val, by omega⟩)
+        =
+      (evalWord (A j) (List.ofFn β) * Y) *
+          evalWord (A j) (List.ofFn fun k : Fin (N - L) =>
+            τ ⟨i.val + L - N + k.val, by omega⟩) := by
+          rw [hY β]
+    _ =
+      evalWord (A j) (List.ofFn β) *
+        (Y * evalWord (A j) (List.ofFn fun k : Fin (N - L) =>
+          τ ⟨i.val + L - N + k.val, by omega⟩)) := by
+          rw [Matrix.mul_assoc]
+
+/-- Right boundary-matrix identities give the componentwise periodic
+constraints.
+
+Fix block-diagonal boundary conditions \(X_j\).  For every boundary-crossing
+cyclic interval \(N<i+L\), put \(a=i+L-N\), and suppose that each block has a
+boundary matrix \(Y_{j,i,\tau}\) such that, for every word \(\beta\) of length
+\(a\),
+\[
+  \mu_j^N X_j A^j_\beta=A^j_\beta Y_{j,i,\tau}
+\]
+Then every component
+\[
+  \Gamma_N^{A_j}(\mu_j^N X_j)
+\]
+belongs to \(\mathcal G_{N,L}(A_j)\).
+
+This isolates the equation which remains after comparing the \(j\)-th block
+component in arXiv:quant-ph/0608197, Theorem 2blocks.2; the
+non-boundary-crossing intervals are handled by the contiguous calculation. -/
+theorem blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hBoundary : ∀ (j : Fin r) (i : Fin N) (_ : Fin N → Fin d),
+      N < i.val + L →
+        ∃ Y : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          ∀ β : Fin (i.val + L - N) → Fin d,
+            ((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) =
+              evalWord (A j) (List.ofFn β) * Y) :
+    ∀ j : Fin r,
+      groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  exact blockDiagonal_boundary_component_chainGroundSpace_of_crossing_windows
+    μ A hN hLN X fun j i τ hi =>
+      blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_boundary_identity
+        μ A hN hLN X j i τ hi (hBoundary j i τ hi)
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6753,6 +6753,42 @@ boundary-closing step concerns the separate assertion
     \(\alpha\beta\). Hence the restricted vector lies in \(G_L(A_j)\).
 \end{proof}
 
+\begin{lemma}[Boundary-crossing intervals from a right boundary-matrix identity]
+    \label{lem:block_diagonal_boundary_crossing_right_boundary_matrix}
+    \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_boundary_identity}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_matrix_identity}
+    Assume \(0<N\), \(L\le N\), and let the cyclic interval beginning at \(i\)
+    cross the boundary cut, so \(N<i+L\). Put \(a=i+L-N\). Suppose that there is
+    a matrix \(Y\) such that for every word \(\beta\) of length \(a\),
+    \[
+        \mu_j^N X_j A^j_\beta=A^j_\beta Y .
+    \]
+    Then
+    \[
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in G_L(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_matrix_identity}
+    Let
+    \[
+        E:=Y A^j_{\tau_a}\cdots A^j_{\tau_{i-1}} .
+    \]
+    Then, for every word \(\beta\) on the segment \(0,\ldots,a-1\),
+    \[
+        \mu_j^N X_j A^j_\beta
+        A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}
+        =
+        A^j_\beta E.
+    \]
+    Lemma~\ref{lem:block_diagonal_boundary_crossing_matrix_identity} gives the
+    stated local constraint.
+\end{proof}
+
 \begin{lemma}[Boundary-crossing cyclic intervals suffice]
     \label{lem:block_diagonal_boundary_component_crossing_windows_suffice}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_crossing_windows}
@@ -6781,6 +6817,45 @@ boundary-closing step concerns the separate assertion
     either \(i+L\le N\) or \(N<i+L\). In the first case use
     Lemma~\ref{lem:block_diagonal_boundary_nonwrapping_component}. In the second
     case use the displayed hypothesis.
+\end{proof}
+
+\begin{lemma}[Right boundary-matrix identities give componentwise periodic constraints]
+    \label{lem:block_diagonal_boundary_component_right_boundary_matrices}
+    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_right_boundary_matrix,
+        lem:block_diagonal_boundary_component_crossing_windows_suffice}
+    Assume \(0<N\) and \(L\le N\). Fix block-diagonal boundary conditions
+    \(X_j\). Suppose that, for every block \(j\), every boundary-crossing cyclic
+    interval beginning at \(i\), and every configuration \(\tau\), there is a
+    matrix \(Y_{j,i,\tau}\) such that, for every word \(\beta\) of length
+    \(a=i+L-N\),
+    \[
+        \mu_j^N X_j A^j_\beta
+        =
+        A^j_\beta Y_{j,i,\tau}
+    \]
+    Then,
+    for every block \(j\),
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in \mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_right_boundary_matrix,
+        lem:block_diagonal_boundary_component_crossing_windows_suffice}
+    Lemma~\ref{lem:block_diagonal_boundary_crossing_right_boundary_matrix}
+    turns the displayed boundary identity into the local constraint for each
+    boundary-crossing interval.
+    Lemma~\ref{lem:block_diagonal_boundary_component_crossing_windows_suffice}
+    then yields
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in \mathcal G_{N,L}(A_j),
+    \]
+    handling both boundary-crossing intervals \(N<i+L\) and non-crossing
+    intervals \(i+L\le N\).
 \end{proof}
 
 \begin{lemma}[The block-diagonal chain space lies between two block sums]


### PR DESCRIPTION
This PR is based on `main` after #2668 merged.

It proves the next boundary-closing reduction for #2665. Fix a block \(j\), a boundary-crossing cyclic interval beginning at \(i\), and an exterior configuration \(\tau\). Put \(a=i+L-N\). If there is a matrix \(Y_{j,i,\tau}\) such that, for every word \(\beta\) of length \(a\),

\[
\mu_j^N X_j A^j_\beta=A^j_\beta Y_{j,i,\tau},
\]

then the local restriction satisfies

\[
R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)\in G_L(A_j).
\]

Equivalently, these boundary identities for all boundary-crossing intervals put every component

\[
\Gamma_N^{A_j}(\mu_j^NX_j)
\]

in the periodic-chain constraint space \(\mathcal G_{N,L}(A_j)\). The proof applies #2668 with

\[
E=Y_{j,i,\tau}A^j_{\tau_a}\cdots A^j_{\tau_{i-1}},\qquad a=i+L-N.
\]

This still leaves the source-paper comparison step: deriving the displayed boundary identity from the comparison equation in arXiv:quant-ph/0608197, Theorem 2blocks.2,

\[
A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
\]

Checks on the rebased head:
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`

Addresses #2665.