### PR TITLE
feat(MPS/ParentHamiltonian): strip complementary word identities

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -294,4 +294,74 @@ theorem blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
       blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_boundary_identity
         μ A hN hLN X j i τ hi (hBoundary j i τ hi)
 
+/-- Boundary-crossing matrix identities for a spanning complementary segment give
+the componentwise periodic constraints.
+
+For each boundary-crossing cyclic interval, assume that the matrix identity from
+`blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix`
+holds for every word on the complementary segment. If those complementary word
+products span the full matrix algebra in each block, then the word-span
+stripping theorem gives a right boundary-matrix identity, and the preceding theorem gives
+the periodic-chain constraint. -/
+theorem blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hSpan : ∀ j : Fin r, wordSpan (A j) (N - L) = ⊤)
+    (hIdentity : ∀ (j : Fin r) (i : Fin N),
+      N < i.val + L →
+        ∀ ρ : Fin (N - L) → Fin d,
+          ∃ E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+            ∀ β : Fin (i.val + L - N) → Fin d,
+              (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                  evalWord (A j) (List.ofFn ρ) =
+                evalWord (A j) (List.ofFn β) * E) :
+    ∀ j : Fin r,
+      groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  exact blockDiagonal_boundary_component_chainGroundSpace_of_boundaryIdentities
+    μ A hN hLN X fun j i τ hi =>
+      exists_common_boundary_matrix_of_word_identities_of_wordSpan_eq_top
+        (A := A j)
+        (α := Fin (i.val + L - N) → Fin d)
+        (K := N - L)
+        (F := fun β => evalWord (A j) (List.ofFn β))
+        (Z := fun β => ((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β))
+        (hSpan j)
+        (hIdentity j i hi)
+
+/-- Boundary-crossing matrix identities over a long complementary segment give
+the componentwise periodic constraints under block injectivity and the
+normalization equation.
+
+This is the source-range version of
+`blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities`:
+the condition \(L+L_0\le N\) makes the complementary segment length at least
+\(L_0\), and homogeneous word-span propagation supplies the spanning hypothesis
+for each block. -/
+theorem
+    blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities_of_injective
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L₀ L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hBlk : ∀ j : Fin r, IsNBlkInjective (A j) L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hNlarge : L + L₀ ≤ N)
+    (hIdentity : ∀ (j : Fin r) (i : Fin N),
+      N < i.val + L →
+        ∀ ρ : Fin (N - L) → Fin d,
+          ∃ E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+            ∀ β : Fin (i.val + L - N) → Fin d,
+              (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                  evalWord (A j) (List.ofFn ρ) =
+                evalWord (A j) (List.ofFn β) * E) :
+    ∀ j : Fin r,
+      groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  refine blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities
+    μ A hN hLN X ?_ hIdentity
+  intro j
+  exact wordSpan_eq_top_of_ge_of_unital (A j) (hUnital j)
+    ((wordSpan_eq_top_iff_isNBlkInjective (A j) L₀).mpr (hBlk j)) (by omega)
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
+import TNLean.MPS.ParentHamiltonian.BlockStrip
 
 /-!
 # Boundary-crossing cyclic interval equations for block-diagonal parent spaces
@@ -297,13 +298,17 @@ theorem blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
 /-- Boundary-crossing matrix identities for a spanning complementary segment give
 the componentwise periodic constraints.
 
-For each boundary-crossing cyclic interval, assume that the matrix identity from
-`blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix`
-holds for every word on the complementary segment. If those complementary word
-products span the full matrix algebra in each block, then the word-span
-stripping theorem gives a right boundary-matrix identity, and the preceding theorem gives
-the periodic-chain constraint. -/
-theorem blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities
+For each boundary-crossing cyclic interval, assume that for every complementary
+word \(\rho\) there is a matrix \(E\) such that, for every wrapped word
+\(\beta\),
+\[
+  \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E
+\]
+If those complementary word products span the full matrix algebra in each
+block, then the word-span stripping theorem gives a right boundary-matrix
+identity, and the preceding theorem gives the
+periodic-chain constraint. -/
+theorem blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
@@ -319,7 +324,7 @@ theorem blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordId
                 evalWord (A j) (List.ofFn β) * E) :
     ∀ j : Fin r,
       groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
-  exact blockDiagonal_boundary_component_chainGroundSpace_of_boundaryIdentities
+  exact blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
     μ A hN hLN X fun j i τ hi =>
       exists_common_boundary_matrix_of_word_identities_of_wordSpan_eq_top
         (A := A j)
@@ -334,13 +339,11 @@ theorem blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordId
 the componentwise periodic constraints under block injectivity and the
 normalization equation.
 
-This is the source-range version of
-`blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities`:
-the condition \(L+L_0\le N\) makes the complementary segment length at least
-\(L_0\), and homogeneous word-span propagation supplies the spanning hypothesis
-for each block. -/
+When \(L+L_0\le N\), the complementary segment has length at least \(L_0\).
+Homogeneous word-span propagation then supplies the full matrix algebra in each
+block, so the spanning complementary-identity statement applies. -/
 theorem
-    blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities_of_injective
+    blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     {L₀ L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
@@ -358,7 +361,7 @@ theorem
                 evalWord (A j) (List.ofFn β) * E) :
     ∀ j : Fin r,
       groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
-  refine blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities
+  refine blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities
     μ A hN hLN X ?_ hIdentity
   intro j
   exact wordSpan_eq_top_of_ge_of_unital (A j) (hUnital j)

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -287,6 +287,34 @@ theorem groundSpace_iSupIndep_of_wordTupleSpanTop
     φ j = groundSpaceMap (A j) n (X j) := (hX j hj).symm
     _ = 0 := by simp [hXzero]
 
+/-- Equality of block matrices from equality of their trace pairings against a
+common word family.
+
+If the blockwise word tuples of length \(n\) span the product matrix algebra,
+then equality of the summed trace pairings
+\[
+  \sum_j\operatorname{tr}(X_jA^j_w)
+  =
+  \sum_j\operatorname{tr}(Y_jA^j_w)
+\]
+for every length-\(n\) word \(w\) forces \(X_j=Y_j\) for every block \(j\). -/
+theorem block_matrices_eq_of_wordTupleSpanTop_trace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n)
+    (X Y : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hTrace : ∀ w : Fin n → Fin d,
+      (∑ j : Fin r, Matrix.trace (X j * evalWord (A j) (List.ofFn w))) =
+      (∑ j : Fin r, Matrix.trace (Y j * evalWord (A j) (List.ofFn w)))) :
+    ∀ j : Fin r, X j = Y j := by
+  intro j
+  have hzero := block_matrices_eq_zero_of_wordTupleSpanTop_trace A hSpan
+    (fun k => X k - Y k) (by
+      intro w
+      simpa [Matrix.sub_mul, Matrix.trace_sub, Finset.sum_sub_distrib, sub_eq_zero]
+        using sub_eq_zero.mpr (hTrace w)) j
+  exact sub_eq_zero.mp hzero
+
 /-- Boundary-matrix compatibility from equality of the two coefficient
 decompositions in the PGVWC block-diagonal intersection proof.
 
@@ -315,12 +343,8 @@ theorem pgvwc07_blockwise_compatibility_of_trace_decomposition
       (∑ j : Fin r, Matrix.trace ((Dmat j b * A j a) * evalWord (A j) (List.ofFn w)))) :
     ∀ j : Fin r, ∀ a b : Fin d, A j b * C j a = Dmat j b * A j a := by
   intro j a b
-  have hzero := block_matrices_eq_zero_of_wordTupleSpanTop_trace A hSpan
-    (fun k => A k b * C k a - Dmat k b * A k a) (by
-      intro w
-      simpa [Matrix.sub_mul, Matrix.trace_sub, Finset.sum_sub_distrib, sub_eq_zero]
-        using sub_eq_zero.mpr (hCoeff a b w)) j
-  exact sub_eq_zero.mp hzero
+  exact block_matrices_eq_of_wordTupleSpanTop_trace A hSpan
+    (fun k => A k b * C k a) (fun k => Dmat k b * A k a) (hCoeff a b) j
 
 /-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof.
 

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -291,13 +291,13 @@ theorem groundSpace_iSupIndep_of_wordTupleSpanTop
 common word family.
 
 If the blockwise word tuples of length \(n\) span the product matrix algebra,
-then equality of the summed trace pairings
+and if, for every length-\(n\) word \(w\),
 \[
   \sum_j\operatorname{tr}(X_jA^j_w)
   =
   \sum_j\operatorname{tr}(Y_jA^j_w)
 \]
-for every length-\(n\) word \(w\) forces \(X_j=Y_j\) for every block \(j\). -/
+then \(X_j=Y_j\) for every block \(j\). -/
 theorem block_matrices_eq_of_wordTupleSpanTop_trace
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))

--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -184,6 +184,46 @@ theorem exists_right_factor_of_block_word_compatibility
         exact ⟨Xi, hXi⟩
       exact exists_right_factor_of_block_letter_compatibility hInj hL₀ hCompat1
 
+/-- If a family has a common right boundary matrix after multiplication by every
+length-\(K\) word product, and the length-\(K\) word products span the matrix
+algebra, then the same common boundary matrix exists before this multiplication.
+
+This is the spanning form used for boundary-condition comparisons. The family
+index set is arbitrary; only the length-\(K\) word is a physical word of the
+tensor. -/
+theorem exists_common_boundary_matrix_of_word_identities_of_wordSpan_eq_top
+    {A : MPSTensor d D} {α : Type*} {K : ℕ}
+    {F Z : α → Matrix (Fin D) (Fin D) ℂ}
+    (hWord : wordSpan A K = ⊤)
+    (hCompat : ∀ τ : Fin K → Fin d,
+      ∃ Yτ : Matrix (Fin D) (Fin D) ℂ,
+        ∀ a : α, Z a * evalWord A (List.ofFn τ) = F a * Yτ) :
+    ∃ Y : Matrix (Fin D) (Fin D) ℂ, ∀ a : α, Z a = F a * Y := by
+  have hspan : ∀ M ∈ wordSpan A K,
+      ∃ Y : Matrix (Fin D) (Fin D) ℂ, ∀ a : α, Z a * M = F a * Y := by
+    apply Submodule.span_induction
+    · intro M hM
+      rcases hM with ⟨τ, rfl⟩
+      exact hCompat τ
+    · exact ⟨0, by intro a; simp⟩
+    · intro M₁ M₂ _ _ h₁ h₂
+      rcases h₁ with ⟨Y₁, hY₁⟩
+      rcases h₂ with ⟨Y₂, hY₂⟩
+      refine ⟨Y₁ + Y₂, ?_⟩
+      intro a
+      simp [Matrix.mul_add, hY₁ a, hY₂ a]
+    · intro c M _ hM
+      rcases hM with ⟨Y, hY⟩
+      refine ⟨c • Y, ?_⟩
+      intro a
+      simp [hY a]
+  have hOne : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A K := by
+    simp [hWord]
+  obtain ⟨Y, hY⟩ := hspan 1 hOne
+  refine ⟨Y, ?_⟩
+  intro a
+  simpa using hY a
+
 /-- If a matrix commutes with all words of some length `m ≥ L₀`, then it already
 commutes with every block word of length `L₀`. -/
 theorem commutes_block_words_of_commutes_long_words_of_isNBlkInjective

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1750,24 +1750,38 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \uses{def:word_span}
     Let $A$ be a tensor whose length-$K$ word products span $\MN{D}$. Let
     $\{F_b\}_{b\in B}$ and $\{Z_b\}_{b\in B}$ be two families of matrices. If,
-    for every length-$K$ word $w$, there is a matrix $Y_w$ such that
+    for every length-$K$ word $w$, there is a matrix $Y_w$ such that, for every
+    \(b\in B\),
     \[
         Z_b A^w=F_bY_w
     \]
-    for every $b\in B$, then there is a single matrix $Y$ such that
+    then there is a single matrix $Y$ such that, for every \(b\in B\),
     \[
         Z_b=F_bY
     \]
-    for every $b\in B$.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The displayed hypothesis is stable under linear combinations of the word
-    matrix $A^w$: if it holds for two word matrices, it holds for their sum,
-    and scalar multiplication rescales the boundary matrix. Hence it holds for
-    every matrix in the span of the length-$K$ word products. Since this span is
-    all of $\MN{D}$, apply it to the identity matrix.
+    Suppose \(Z_bM_1=F_bY_1\) and \(Z_bM_2=F_bY_2\) for every \(b\in B\). Then
+    \[
+        Z_b(M_1+M_2)
+        =
+        Z_bM_1+Z_bM_2
+        =
+        F_b(Y_1+Y_2).
+    \]
+    For a scalar \(c\),
+    \[
+        Z_b(cM_1)
+        =
+        cZ_bM_1
+        =
+        F_b(cY_1).
+    \]
+    Thus the displayed identity holds for every matrix in the span of the
+    length-\(K\) word products. Since this span is all of \(\MN{D}\), apply it
+    to the identity matrix.
 \end{proof}
 
 \begin{theorem}[Block-word commutation from long-word commutation]
@@ -5658,22 +5672,31 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \leanok
     \uses{def:blockwise_product_word_span}
     Let \(A^1,\ldots,A^g\) be block tensors whose length-\(m\) simultaneous word
-    tuples span the product algebra. If two blockwise matrix families \(X_j\)
-    and \(Y_j\) satisfy
+    tuples span the product algebra. If, for every word \(w\) of length \(m\),
+    two blockwise matrix families \(X_j\) and \(Y_j\) satisfy
     \[
         \sum_j\operatorname{tr}(X_jA^j_w)
         =
         \sum_j\operatorname{tr}(Y_jA^j_w)
     \]
-    for every word \(w\) of length \(m\), then \(X_j=Y_j\) for every block \(j\).
+    then \(X_j=Y_j\) for every block \(j\).
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{def:blockwise_product_word_span}
-    Apply nondegeneracy of the product trace pairing to the difference
-    \(X_j-Y_j\). The trace pairing against every simultaneous word tuple
-    vanishes, and these tuples span the full product algebra.
+    For every word \(w\) of length \(m\),
+    \[
+        \sum_j\operatorname{tr}\!\left((X_j-Y_j)A^j_w\right)
+        =
+        \sum_j\operatorname{tr}(X_jA^j_w)
+        -
+        \sum_j\operatorname{tr}(Y_jA^j_w)
+        =
+        0.
+    \]
+    Nondegeneracy of the product trace pairing, together with the spanning
+    hypothesis, gives \(X_j-Y_j=0\) for every block \(j\).
 \end{proof}
 
 \begin{lemma}[Blockwise boundary compatibility from traces]
@@ -6913,7 +6936,7 @@ boundary-closing step concerns the separate assertion
 
 \begin{lemma}[Spanning complementary identities give componentwise constraints]
     \label{lem:block_diagonal_boundary_component_complementary_word_identities}
-    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities}
+    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities}
     \leanok
     \uses{thm:word_span_common_boundary_matrix,
         lem:block_diagonal_boundary_component_right_boundary_matrices}
@@ -6944,17 +6967,17 @@ boundary-closing step concerns the separate assertion
         Z_\beta=\mu_j^NX_jA^j_\beta,\qquad F_\beta=A^j_\beta.
     \]
     Since the length-\(N-L\) complementary-word products span the full matrix
-    algebra, there is a single matrix \(Y_{j,i}\) such that
+    algebra, there is a single matrix \(Y_{j,i}\) such that, for every \(\beta\),
     \[
         \mu_j^NX_jA^j_\beta=A^j_\beta Y_{j,i}
     \]
-    for every \(\beta\). Lemma~\ref{lem:block_diagonal_boundary_component_right_boundary_matrices}
+    Lemma~\ref{lem:block_diagonal_boundary_component_right_boundary_matrices}
     then gives the componentwise periodic-chain constraints.
 \end{proof}
 
-\begin{lemma}[Source-range complementary identities give componentwise constraints]
+\begin{lemma}[Complementary identities under block injectivity give componentwise constraints]
     \label{lem:block_diagonal_boundary_component_complementary_word_identities_injective}
-    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities_of_injective}
+    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective}
     \leanok
     \uses{lem:block_diagonal_boundary_component_complementary_word_identities,
         thm:wordspan_propagation_unital}
@@ -6977,11 +7000,12 @@ boundary-closing step concerns the separate assertion
     \uses{lem:block_diagonal_boundary_component_complementary_word_identities,
         thm:wordspan_propagation_unital}
     Since \(L+L_0\le N\), the complementary length satisfies \(L_0\le N-L\).
-    Theorem~\ref{thm:wordspan_propagation_unital} therefore gives
+    Theorem~\ref{thm:wordspan_propagation_unital} therefore gives, for every
+    block \(j\),
     \[
         S_{N-L}(A_j)=\MN{D_j}
     \]
-    for every block \(j\). Apply
+    Apply
     Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -1743,6 +1743,33 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     $\{A^u : |u| = L_0\}$ yields a common factor $X$.
 \end{proof}
 
+\begin{theorem}[Common boundary matrix from spanning word identities]
+    \label{thm:word_span_common_boundary_matrix}
+    \lean{MPSTensor.exists_common_boundary_matrix_of_word_identities_of_wordSpan_eq_top}
+    \leanok
+    \uses{def:word_span}
+    Let $A$ be a tensor whose length-$K$ word products span $\MN{D}$. Let
+    $\{F_b\}_{b\in B}$ and $\{Z_b\}_{b\in B}$ be two families of matrices. If,
+    for every length-$K$ word $w$, there is a matrix $Y_w$ such that
+    \[
+        Z_b A^w=F_bY_w
+    \]
+    for every $b\in B$, then there is a single matrix $Y$ such that
+    \[
+        Z_b=F_bY
+    \]
+    for every $b\in B$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The displayed hypothesis is stable under linear combinations of the word
+    matrix $A^w$: if it holds for two word matrices, it holds for their sum,
+    and scalar multiplication rescales the boundary matrix. Hence it holds for
+    every matrix in the span of the length-$K$ word products. Since this span is
+    all of $\MN{D}$, apply it to the identity matrix.
+\end{proof}
+
 \begin{theorem}[Block-word commutation from long-word commutation]
     \label{thm:block_word_strip_commutes}
     \lean{MPSTensor.commutes_block_words_of_commutes_long_words_of_isNBlkInjective}
@@ -5625,10 +5652,35 @@ formulation; the passage to $\ker H_N$ is kept separate.
     displayed product span.
 \end{proof}
 
+\begin{lemma}[Blockwise matrix equality from trace pairings]
+    \label{lem:block_matrices_equal_from_trace_pairings}
+    \lean{MPSTensor.block_matrices_eq_of_wordTupleSpanTop_trace}
+    \leanok
+    \uses{def:blockwise_product_word_span}
+    Let \(A^1,\ldots,A^g\) be block tensors whose length-\(m\) simultaneous word
+    tuples span the product algebra. If two blockwise matrix families \(X_j\)
+    and \(Y_j\) satisfy
+    \[
+        \sum_j\operatorname{tr}(X_jA^j_w)
+        =
+        \sum_j\operatorname{tr}(Y_jA^j_w)
+    \]
+    for every word \(w\) of length \(m\), then \(X_j=Y_j\) for every block \(j\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:blockwise_product_word_span}
+    Apply nondegeneracy of the product trace pairing to the difference
+    \(X_j-Y_j\). The trace pairing against every simultaneous word tuple
+    vanishes, and these tuples span the full product algebra.
+\end{proof}
+
 \begin{lemma}[Blockwise boundary compatibility from traces]
     \label{lem:blockwise_boundary_compatibility_from_traces}
     \lean{MPSTensor.pgvwc07_blockwise_compatibility_of_trace_decomposition}
     \leanok
+    \uses{lem:block_matrices_equal_from_trace_pairings}
     Let \(A^1,\ldots,A^g\) be block tensors with the following common
     word-span property: for a fixed \(m\), the simultaneous tuples
     \[
@@ -5654,6 +5706,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
+    \uses{lem:block_matrices_equal_from_trace_pairings}
     For fixed \(a,b\), set
     \[
         \Delta_j=A^j_bC^j_a-D^j_bA^j_a .
@@ -6856,6 +6909,80 @@ boundary-closing step concerns the separate assertion
     \]
     handling both boundary-crossing intervals \(N<i+L\) and non-crossing
     intervals \(i+L\le N\).
+\end{proof}
+
+\begin{lemma}[Spanning complementary identities give componentwise constraints]
+    \label{lem:block_diagonal_boundary_component_complementary_word_identities}
+    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities}
+    \leanok
+    \uses{thm:word_span_common_boundary_matrix,
+        lem:block_diagonal_boundary_component_right_boundary_matrices}
+    Assume \(0<N\), \(L\le N\), and that for every block \(j\), the
+    length-\(N-L\) word products of \(A_j\) span the full matrix algebra. Suppose
+    that, for every block \(j\), every boundary-crossing cyclic interval
+    beginning at \(i\), and every complementary word
+    \(\rho\) of length \(N-L\), there is a matrix \(E_{j,i,\rho}\) such
+    that for every word \(\beta\) of length \(i+L-N\),
+    \[
+        \mu_j^N X_j A^j_\beta A^j_\rho
+        =
+        A^j_\beta E_{j,i,\rho}.
+    \]
+    Then, for every block \(j\),
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:word_span_common_boundary_matrix,
+        lem:block_diagonal_boundary_component_right_boundary_matrices}
+    For fixed \(j,i\), apply
+    Theorem~\ref{thm:word_span_common_boundary_matrix} to the family
+    \[
+        Z_\beta=\mu_j^NX_jA^j_\beta,\qquad F_\beta=A^j_\beta.
+    \]
+    Since the length-\(N-L\) complementary-word products span the full matrix
+    algebra, there is a single matrix \(Y_{j,i}\) such that
+    \[
+        \mu_j^NX_jA^j_\beta=A^j_\beta Y_{j,i}
+    \]
+    for every \(\beta\). Lemma~\ref{lem:block_diagonal_boundary_component_right_boundary_matrices}
+    then gives the componentwise periodic-chain constraints.
+\end{proof}
+
+\begin{lemma}[Source-range complementary identities give componentwise constraints]
+    \label{lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementaryWordIdentities_of_injective}
+    \leanok
+    \uses{lem:block_diagonal_boundary_component_complementary_word_identities,
+        thm:wordspan_propagation_unital}
+    Assume \(0<N\), \(L\le N\), and \(L+L_0\le N\). Suppose each block \(A_j\)
+    is \(L_0\)-block-injective and satisfies the normalization equation
+    \[
+        \sum_a A^j_aA^{j\dagger}_a=I .
+    \]
+    Suppose also that the boundary-crossing matrix identities of
+    Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities}
+    hold for every complementary word \(\rho\) of length \(N-L\). Then, for
+    every block \(j\),
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_component_complementary_word_identities,
+        thm:wordspan_propagation_unital}
+    Since \(L+L_0\le N\), the complementary length satisfies \(L_0\le N-L\).
+    Theorem~\ref{thm:wordspan_propagation_unital} therefore gives
+    \[
+        S_{N-L}(A_j)=\MN{D_j}
+    \]
+    for every block \(j\). Apply
+    Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities}.
 \end{proof}
 
 \begin{lemma}[The block-diagonal chain space lies between two block sums]


### PR DESCRIPTION
This PR is based on `main` after #2669 merged.

It adds the complementary-word comparison step for #2665. The first ingredient is a blockwise trace-pairing comparison: if the simultaneous length-\(m\) block-word tuples span the product algebra and, for every word \(w\) of length \(m\),

\[
\sum_j \operatorname{tr}(X_j A^j_w)=\sum_j \operatorname{tr}(Y_j A^j_w),
\]

then \(X_j=Y_j\) for every block \(j\). This separates the block coefficients in the boundary comparison used in arXiv:quant-ph/0608197, Theorem 2blocks.2.

The second ingredient strips a complementary word from a family of right-boundary identities. If the length-\(K\) word products of a tensor \(A\) span \(M_D(\mathbb C)\), and for every word \(w\) of length \(K\) there is a matrix \(Y_w\) such that, for every member \(b\) of the family,

\[
Z_b A^w=F_bY_w,
\]

then there is a single matrix \(Y\) such that, for every \(b\),

\[
Z_b=F_bY.
\]

Applied to a boundary-crossing cyclic interval, this turns the identities

\[
\mu_j^N X_j A^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho}
\]

for all complementary words \(\rho\) of length \(N-L\) into the componentwise constraint

\[
\Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
\]

The block-injective variant assumes \(L+L_0\le N\), \(L_0\)-block injectivity, and the normalization equation

\[
\sum_a A^j_a A^{j\dagger}_a=I,
\]

so homogeneous word-span propagation supplies the required length-\(N-L\) span.

Checks:
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`
- `lake build TNLean.MPS.ParentHamiltonian.BlockStrip`
- `lake env lean TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BlockStrip.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `git diff --check origin/main...HEAD`
- `lake exe checkdecls blueprint/lean_decls`

Addresses #2665.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal-only additions and refactors in parent-Hamiltonian MPS proofs and blueprint prose; no runtime, auth, or data paths.
> 
> **Overview**
> Adds the **complementary-word** step for block-diagonal boundary crossing (#2665): per-interval identities that multiply a wrapped prefix by a complementary word \(\rho\) are collapsed to a single right boundary matrix, then fed into the existing boundary-identity → `chainGroundSpace` pipeline.
> 
> **`exists_common_boundary_matrix_of_word_identities_of_wordSpan_eq_top`** (`BlockStrip`): when length-\(K\) word products span the full algebra, families \(Z_b A^w = F_b Y_w\) for every word \(w\) imply one matrix \(Y\) with \(Z_b = F_b Y\) (span induction on `wordSpan`, applied at \(M = 1\)).
> 
> **`block_matrices_eq_of_wordTupleSpanTop_trace`** (`BlockIntersectionProperty`): matching summed trace pairings against spanning block words force \(X_j = Y_j\); **`pgvwc07_blockwise_compatibility_of_trace_decomposition`** is refactored to call this lemma instead of inlining the zero-trace argument.
> 
> **`BNTBlockDiagonalCrossing`**: imports `BlockStrip` and adds two theorems—spanning complementary length \(N-L\) words, and the injectivity/unital case \(L+L_0 \le N\) where word-span propagation supplies the span—both concluding \(\Gamma_N^{A_j}(\mu_j^N X_j) \in \mathcal G_{N,L}(A_j)\).
> 
> Blueprint chapter 14 documents the new strip lemma, trace-equality lemma, and complementary-identity lemmas with `\lean` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430fd406c0d77331e09aa49ec000c63ed0dfb3fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->