### PR TITLE
feat(PEPS): the unconditional normal PEPS Fundamental Theorem on the torus

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -499,6 +499,11 @@ import TNLean.PEPS.TorusCovariantAbsorbedFamily
 -- Translation covariance of the gauge-absorbed blocked weights: the comparison
 -- proportionality scalar is the same at every translate of the comparison region.
 import TNLean.PEPS.TorusGaugedWeightCovariance
+-- A bond-dimension reindex preserves blocked-region linear independence.
+import TNLean.PEPS.RegionBlock.ReindexInjectivity
+-- The corner comparison region: the 3x3 square minus its corner, its insert-completed
+-- square, the band decompositions of both complements, and their injectivity.
+import TNLean.PEPS.TorusCornerRegion
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -493,6 +493,9 @@ import TNLean.PEPS.TorusEdgeAbsorbed
 -- Translation covariance of the orientation-adapted absorbing gauge: the absorbing
 -- gauges at two translates of one reference witness determine each other.
 import TNLean.PEPS.TorusAbsorbedCovariance
+-- The translation-covariant absorbed gauge family: the every-edge bare-edge absorbed
+-- equality realized by one transported reference gauge per orientation class.
+import TNLean.PEPS.TorusCovariantAbsorbedFamily
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -496,6 +496,9 @@ import TNLean.PEPS.TorusAbsorbedCovariance
 -- The translation-covariant absorbed gauge family: the every-edge bare-edge absorbed
 -- equality realized by one transported reference gauge per orientation class.
 import TNLean.PEPS.TorusCovariantAbsorbedFamily
+-- Translation covariance of the gauge-absorbed blocked weights: the comparison
+-- proportionality scalar is the same at every translate of the comparison region.
+import TNLean.PEPS.TorusGaugedWeightCovariance
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -504,6 +504,9 @@ import TNLean.PEPS.RegionBlock.ReindexInjectivity
 -- The corner comparison region: the 3x3 square minus its corner, its insert-completed
 -- square, the band decompositions of both complements, and their injectivity.
 import TNLean.PEPS.TorusCornerRegion
+-- The unconditional torus Fundamental Theorem: the covariant gauge family, the single
+-- scalar, the per-vertex relation, and the scalar condition from the source hypotheses.
+import TNLean.PEPS.TorusFundamentalTheorem2
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -490,6 +490,9 @@ import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
 -- A single gauge family with the bare-edge absorbed equality at every torus edge,
 -- read off the orientation-class coefficient-identity witness families.
 import TNLean.PEPS.TorusEdgeAbsorbed
+-- Translation covariance of the orientation-adapted absorbing gauge: the absorbing
+-- gauges at two translates of one reference witness determine each other.
+import TNLean.PEPS.TorusAbsorbedCovariance
 -- Region physical realization: realizes a boundary-edge matrix insertion at the
 -- in-region endpoint vertex and expresses it through region state vectors.
 import TNLean.PEPS.RegionBlock.Realization

--- a/TNLean/PEPS/RegionBlock/ReindexInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/ReindexInjectivity.lean
@@ -1,0 +1,67 @@
+import TNLean.PEPS.RegionBlock.Insertion
+
+/-!
+# Blocked-region injectivity transports along a bond-dimension reindex
+
+The final comparison of the normal PEPS Fundamental Theorem reads the gauge-absorbed second
+tensor over the first tensor's bonds (`reindexTensor`).  This file records that the
+bond-dimension reindex preserves blocked-region linear independence: the blocked family of the
+reindexed tensor is the original family precomposed with the boundary-configuration cast
+bijection, and linear independence is invariant under reindexing the index type
+(arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex`).
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571
+  of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- The boundary configurations of a reindexed tensor correspond to those of the original tensor
+by casting every open leg across the bond-dimension equality. -/
+noncomputable def regionBoundaryConfigCastEquiv (T : Tensor G d) {bd : Edge G → ℕ}
+    (h : bd = T.bondDim) (R : Finset V) :
+    RegionBoundaryConfig (G := G) (reindexTensor (G := G) T h) R ≃
+      RegionBoundaryConfig (G := G) T R where
+  toFun bdry := fun f => Fin.cast (congr_fun h f.1) (bdry f)
+  invFun bdry := fun f => Fin.cast (congr_fun h f.1).symm (bdry f)
+  left_inv bdry := by
+    funext f
+    apply Fin.eq_of_val_eq
+    simp
+  right_inv bdry := by
+    funext f
+    apply Fin.eq_of_val_eq
+    simp
+
+/-- **A bond-dimension reindex preserves blocked-region linear independence.**
+
+If the blocked family of `T` over `R` is linearly independent, so is the blocked family of the
+reindexed tensor: the latter is the former precomposed with the boundary-configuration cast
+bijection.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedTensorInjective_reindexTensor (T : Tensor G d) {bd : Edge G → ℕ}
+    (h : bd = T.bondDim) (R : Finset V)
+    (hT : RegionBlockedTensorInjective (G := G) T R) :
+    RegionBlockedTensorInjective (G := G) (reindexTensor (G := G) T h) R := by
+  rw [RegionBlockedTensorInjective] at hT ⊢
+  have hfam : regionBlockedTensorFamily (G := G) (reindexTensor (G := G) T h) R =
+      regionBlockedTensorFamily (G := G) T R ∘ (regionBoundaryConfigCastEquiv T h R) := by
+    funext bdry τ
+    exact regionBlockedWeight_reindexTensor (G := G) T h R bdry τ
+  rw [hfam]
+  exact (linearIndependent_equiv (regionBoundaryConfigCastEquiv T h R)).mpr hT
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusAbsorbedCovariance.lean
+++ b/TNLean/PEPS/TorusAbsorbedCovariance.lean
@@ -47,6 +47,24 @@ theorem glReindex_self {m : ℕ} (h : m = m) (Z : GL (Fin m) ℂ) :
   rw [glReindex_coe]
   simp
 
+/-- Packaged transposition commutes with index transport. -/
+theorem glTranspose_glReindex {m n : ℕ} (h : m = n) (Z : GL (Fin m) ℂ) :
+    glTranspose (glReindex h Z) = glReindex h (glTranspose Z) := by
+  ext : 1
+  rw [glTranspose_coe, glReindex_coe, glReindex_coe, glTranspose_coe, reindexAlgEquiv_transpose]
+
+/-- The inverse of the packaged transpose is the packaged transpose of the inverse. -/
+theorem glTranspose_inv {m : ℕ} (Z : GL (Fin m) ℂ) :
+    (glTranspose Z)⁻¹ = glTranspose Z⁻¹ := by
+  ext : 1
+  rw [glTranspose_inv_coe, glTranspose_coe]
+
+/-- Packaged transposition is an involution. -/
+theorem glTranspose_glTranspose {m : ℕ} (Z : GL (Fin m) ℂ) :
+    glTranspose (glTranspose Z) = Z := by
+  ext : 1
+  rw [glTranspose_coe, glTranspose_coe, Matrix.transpose_transpose]
+
 /-! ### Composition of torus translations on edges -/
 
 /-- The edge action of two successive torus translations is the edge action of their composite
@@ -264,20 +282,12 @@ theorem transportedAbsorbedGauge_translate_pair
     (hsv : translate c g (translate a b f.1.1.2) = translate a' b' f.1.1.2)
     (h : B.bondDim (boundaryEdgeMap (translate a b) R f).1 =
       B.bondDim (boundaryEdgeMap (translate a' b') R f).1) :
-    (transportedAbsorbedGauge B hB R f Z a' b' :
-        Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a' b') R f).1))
-          (Fin (B.bondDim (boundaryEdgeMap (translate a' b') R f).1)) ℂ) =
+    transportedAbsorbedGauge B hB R f Z a' b' =
       if (boundaryEdgeMap (translate a' b') R f).1.1.1 =
           translate c g (boundaryEdgeMap (translate a b) R f).1.1.1 then
-        Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
-          (transportedAbsorbedGauge B hB R f Z a b :
-            Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
-              (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)
+        glReindex h (transportedAbsorbedGauge B hB R f Z a b)
       else
-        Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
-          ((↑(transportedAbsorbedGauge B hB R f Z a b)⁻¹ :
-            Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
-              (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)ᵀ) := by
+        glReindex h ((glTranspose (transportedAbsorbedGauge B hB R f Z a b))⁻¹) := by
   classical
   have hne : f.1.1.1 ≠ f.1.1.2 := ne_of_lt f.1.2.1
   -- Abbreviate the two transported reference gauges.
@@ -298,8 +308,7 @@ theorem transportedAbsorbedGauge_translate_pair
     have hQ : (boundaryEdgeMap (translate a' b') R f).1.1.1 =
         translate c g (boundaryEdgeMap (translate a b) R f).1.1.1 := by
       rw [hPiff'.mp hP', hPiff.mp hP, hsu]
-    rw [if_pos hP, if_pos hP', if_pos hQ, hZrel]
-    rw [glTranspose_coe, glTranspose_coe, glReindex_coe, reindexAlgEquiv_transpose]
+    rw [if_pos hP, if_pos hP', if_pos hQ, hZrel, glTranspose_glReindex]
   · -- Order preserved at `(a, b)`, swapped at `(a', b')`: the connecting translation swaps.
     have hQ : ¬((boundaryEdgeMap (translate a' b') R f).1.1.1 =
         translate c g (boundaryEdgeMap (translate a b) R f).1.1.1) := by
@@ -310,9 +319,7 @@ theorem transportedAbsorbedGauge_translate_pair
       rw [hfst', hPiff.mp hP, hsu]
       intro hcon
       exact hne ((translate a' b').toEquiv.injective hcon).symm
-    rw [if_pos hP, if_neg hP', if_neg hQ, hZrel]
-    rw [glTranspose_inv_coe, Matrix.transpose_transpose, ← map_inv, glReindex_coe,
-      Matrix.GeneralLinearGroup.coe_inv]
+    rw [if_pos hP, if_neg hP', if_neg hQ, hZrel, ← map_inv, glTranspose_glTranspose]
   · -- Order swapped at `(a, b)`, preserved at `(a', b')`: the connecting translation swaps.
     have hQ : ¬((boundaryEdgeMap (translate a' b') R f).1.1.1 =
         translate c g (boundaryEdgeMap (translate a b) R f).1.1.1) := by
@@ -322,10 +329,8 @@ theorem transportedAbsorbedGauge_translate_pair
       rw [hfst, hPiff'.mp hP', hsv]
       intro hcon
       exact hne ((translate a' b').toEquiv.injective hcon)
-    rw [if_neg hP, if_pos hP', if_neg hQ, hZrel]
-    rw [glTranspose_coe, Matrix.GeneralLinearGroup.coe_inv, Matrix.GeneralLinearGroup.coe_inv,
-      Matrix.nonsing_inv_nonsing_inv _ ((Matrix.isUnit_iff_isUnit_det _).mp Zs.isUnit),
-      glReindex_coe, reindexAlgEquiv_transpose]
+    rw [if_neg hP, if_pos hP', if_neg hQ, hZrel, glTranspose_glReindex, glTranspose_inv,
+      inv_inv]
   · -- Both orders swapped: the connecting translation preserves the order.
     have hQ : (boundaryEdgeMap (translate a' b') R f).1.1.1 =
         translate c g (boundaryEdgeMap (translate a b) R f).1.1.1 := by
@@ -337,8 +342,7 @@ theorem transportedAbsorbedGauge_translate_pair
         (boundaryEdgeMap_translate_fst_or R f a' b').resolve_left (fun hcon => hP' (by
           rw [hPiff']; exact hcon))
       rw [hfst, hfst', hsv]
-    rw [if_neg hP, if_neg hP', if_pos hQ, hZrel]
-    rw [← map_inv, glReindex_coe]
+    rw [if_neg hP, if_neg hP', if_pos hQ, hZrel, ← map_inv]
 
 /-! ### Translation-covariant gauge families -/
 
@@ -355,15 +359,9 @@ def IsTranslationCovariantGaugeFamily (B : Tensor (torusGraph width height) d)
     (X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ) : Prop :=
   ∀ (a : ZMod width) (b : ZMod height) (e : Edge (torusGraph width height))
     (h : B.bondDim e = B.bondDim (Edge.map (translate a b) e)),
-    (X (Edge.map (translate a b) e) :
-        Matrix (Fin (B.bondDim (Edge.map (translate a b) e)))
-          (Fin (B.bondDim (Edge.map (translate a b) e))) ℂ) =
-      if (Edge.map (translate a b) e).1.1 = translate a b e.1.1 then
-        Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
-          (X e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)
-      else
-        Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
-          ((↑(X e)⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)ᵀ)
+    X (Edge.map (translate a b) e) =
+      if (Edge.map (translate a b) e).1.1 = translate a b e.1.1 then glReindex h (X e)
+      else glReindex h ((glTranspose (X e))⁻¹)
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusAbsorbedCovariance.lean
+++ b/TNLean/PEPS/TorusAbsorbedCovariance.lean
@@ -1,0 +1,369 @@
+import TNLean.PEPS.RegionTransferCovariance
+import TNLean.PEPS.RegionBlock.AbsorbedEquality
+
+/-!
+# Translation covariance of the orientation-adapted absorbing gauge
+
+The bare-edge absorbed equality of the normal PEPS Fundamental Theorem on the torus is realized
+by the orientation-adapted absorbing gauge `absorbedBoundaryGauge` of a transported reference
+witness (arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+`Papers/1804.04964/paper_normal.tex`).  This file records how those absorbing gauges at two
+translates of one reference witness determine each other: the gauge at the farther translate is
+the gauge at the nearer one carried across the bond-dimension equality, *transposed-inverted*
+exactly when the connecting translation swaps the ordered endpoints of the edge
+(`transportedAbsorbedGauge_translate_pair`).
+
+The orientation flip is forced by the edge convention: an edge stores its endpoints in
+increasing order, and a wraparound translation may exchange them.  The absorbing gauge reads its
+branch off the membership of the *first* stored endpoint in the witness region, so an endpoint
+swap toggles the branch, replacing the absorbing matrix by its transposed inverse --- the matrix
+that makes the oriented endpoint gauge action (`edgeGaugeAt`) assign the same two matrices to
+the same two geometric endpoints.  A family with this covariance
+(`IsTranslationCovariantGaugeFamily`) is the faithful torus form of the source's *"the same
+matrix on all horizontal (vertical) edges"*: one reference matrix, transported to every edge of
+the class with the orientation of the edge convention accounted for.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544
+  of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-! ### Transport of an invertible matrix across a reflexive index equality -/
+
+/-- Transport of an invertible matrix across a reflexive index-size equality is the identity. -/
+theorem glReindex_self {m : ℕ} (h : m = m) (Z : GL (Fin m) ℂ) :
+    glReindex h Z = Z := by
+  ext : 1
+  rw [glReindex_coe]
+  simp
+
+/-! ### Composition of torus translations on edges -/
+
+/-- The edge action of two successive torus translations is the edge action of their composite
+translation: pushing an edge through `(a, b)` and then `(c, g)` lands on its `(a + c, b + g)`
+translate. -/
+theorem translateEdge_translateEdge (a c : ZMod width) (b g : ZMod height)
+    (e : Edge (torusGraph width height)) :
+    Edge.map (translate c g) (Edge.map (translate a b) e) =
+      Edge.map (translate (a + c) (b + g)) e := by
+  apply Edge.ofAdj_eq_of_endpoints
+  rcases Edge.map_endpoints (translate (a + c) (b + g)) e with ⟨o1, o2⟩ | ⟨o1, o2⟩ <;>
+    rcases Edge.map_endpoints (translate a b) e with ⟨p1, p2⟩ | ⟨p1, p2⟩
+  · exact Or.inl ⟨by rw [p1, o1]; apply Prod.ext <;> simp <;> ring,
+      by rw [p2, o2]; apply Prod.ext <;> simp <;> ring⟩
+  · exact Or.inr ⟨by rw [p1, o2]; apply Prod.ext <;> simp <;> ring,
+      by rw [p2, o1]; apply Prod.ext <;> simp <;> ring⟩
+  · exact Or.inr ⟨by rw [p1, o2]; apply Prod.ext <;> simp <;> ring,
+      by rw [p2, o1]; apply Prod.ext <;> simp <;> ring⟩
+  · exact Or.inl ⟨by rw [p1, o1]; apply Prod.ext <;> simp <;> ring,
+      by rw [p2, o2]; apply Prod.ext <;> simp <;> ring⟩
+
+/-! ### Rigidity of the translation parameter on an orientation class
+
+For widths and heights above two, a right (up) edge determines its left (lower) endpoint, so the
+translation carrying one fixed reference edge to a given edge of its orientation class is unique.
+This is the bookkeeping that identifies the per-edge choice of translation made by the gauge
+family with any other translation reaching the same edge. -/
+
+/-- For `2 < width`, distinct left endpoints give distinct right edges. -/
+theorem torusRightEdge_injective (hw : 2 < width) {p q : TorusVertex width height}
+    (h : torusRightEdge p = torusRightEdge q) : p = q := by
+  have h20 : ((2 : ℕ) : ZMod width) ≠ 0 := by
+    intro hcon
+    rw [ZMod.natCast_eq_zero_iff] at hcon
+    have := Nat.le_of_dvd (by norm_num) hcon
+    omega
+  have hp := Edge.ofAdj_endpoints (torusGraph_adj_right p.1 p.2)
+  have hq := Edge.ofAdj_endpoints (torusGraph_adj_right q.1 q.2)
+  rw [show Edge.ofAdj (torusGraph_adj_right p.1 p.2) = torusRightEdge q from h] at hp
+  rw [show Edge.ofAdj (torusGraph_adj_right q.1 q.2) = torusRightEdge q from rfl] at hq
+  simp only [Prod.mk.eta] at hp hq
+  rcases hp with ⟨hp1, hp2⟩ | ⟨hp1, hp2⟩ <;> rcases hq with ⟨hq1, hq2⟩ | ⟨hq1, hq2⟩
+  · exact hp1.symm.trans hq1
+  · -- `p = q + (1, 0)` and `p + (1, 0) = q`, so `2 = 0` in `ZMod width`.
+    exfalso
+    have e1 : p.1 = q.1 + 1 := congrArg Prod.fst (hp1.symm.trans hq1)
+    have e2 : p.1 + 1 = q.1 := congrArg Prod.fst (hp2.symm.trans hq2)
+    refine h20 (add_left_cancel (a := q.1) (b := ((2 : ℕ) : ZMod width)) (c := 0) ?_)
+    push_cast
+    linear_combination e2 - e1
+  · exfalso
+    have e1 : p.1 + 1 = q.1 := congrArg Prod.fst (hp1.symm.trans hq1)
+    have e2 : p.1 = q.1 + 1 := congrArg Prod.fst (hp2.symm.trans hq2)
+    refine h20 (add_left_cancel (a := q.1) (b := ((2 : ℕ) : ZMod width)) (c := 0) ?_)
+    push_cast
+    linear_combination e1 - e2
+  · exact hp2.symm.trans hq2
+
+/-- For `2 < height`, distinct lower endpoints give distinct up edges. -/
+theorem torusUpEdge_injective (hh : 2 < height) {p q : TorusVertex width height}
+    (h : torusUpEdge p = torusUpEdge q) : p = q := by
+  have h20 : ((2 : ℕ) : ZMod height) ≠ 0 := by
+    intro hcon
+    rw [ZMod.natCast_eq_zero_iff] at hcon
+    have := Nat.le_of_dvd (by norm_num) hcon
+    omega
+  have hp := Edge.ofAdj_endpoints (torusGraph_adj_up p.1 p.2)
+  have hq := Edge.ofAdj_endpoints (torusGraph_adj_up q.1 q.2)
+  rw [show Edge.ofAdj (torusGraph_adj_up p.1 p.2) = torusUpEdge q from h] at hp
+  rw [show Edge.ofAdj (torusGraph_adj_up q.1 q.2) = torusUpEdge q from rfl] at hq
+  simp only [Prod.mk.eta] at hp hq
+  rcases hp with ⟨hp1, hp2⟩ | ⟨hp1, hp2⟩ <;> rcases hq with ⟨hq1, hq2⟩ | ⟨hq1, hq2⟩
+  · exact hp1.symm.trans hq1
+  · exfalso
+    have e1 : p.2 = q.2 + 1 := congrArg Prod.snd (hp1.symm.trans hq1)
+    have e2 : p.2 + 1 = q.2 := congrArg Prod.snd (hp2.symm.trans hq2)
+    refine h20 (add_left_cancel (a := q.2) (b := ((2 : ℕ) : ZMod height)) (c := 0) ?_)
+    push_cast
+    linear_combination e2 - e1
+  · exfalso
+    have e1 : p.2 + 1 = q.2 := congrArg Prod.snd (hp1.symm.trans hq1)
+    have e2 : p.2 = q.2 + 1 := congrArg Prod.snd (hp2.symm.trans hq2)
+    refine h20 (add_left_cancel (a := q.2) (b := ((2 : ℕ) : ZMod height)) (c := 0) ?_)
+    push_cast
+    linear_combination e1 - e2
+  · exact hp2.symm.trans hq2
+
+/-- For `2 < width`, the translation carrying a right edge to a given edge is unique. -/
+theorem translate_param_unique_right (hw : 2 < width) (p : TorusVertex width height)
+    {a a' : ZMod width} {b b' : ZMod height}
+    (h : Edge.map (translate a b) (torusRightEdge p) =
+      Edge.map (translate a' b') (torusRightEdge p)) :
+    a = a' ∧ b = b' := by
+  rw [← translateEdge_eq_map, ← translateEdge_eq_map, translateEdge_torusRightEdge,
+    translateEdge_torusRightEdge] at h
+  have := torusRightEdge_injective hw h
+  exact ⟨add_left_cancel (congrArg Prod.fst this), add_left_cancel (congrArg Prod.snd this)⟩
+
+/-- For `2 < height`, the translation carrying an up edge to a given edge is unique. -/
+theorem translate_param_unique_up (hh : 2 < height) (p : TorusVertex width height)
+    {a a' : ZMod width} {b b' : ZMod height}
+    (h : Edge.map (translate a b) (torusUpEdge p) =
+      Edge.map (translate a' b') (torusUpEdge p)) :
+    a = a' ∧ b = b' := by
+  rw [← translateEdge_eq_map, ← translateEdge_eq_map, translateEdge_torusUpEdge,
+    translateEdge_torusUpEdge] at h
+  have := torusUpEdge_injective hh h
+  exact ⟨add_left_cancel (congrArg Prod.fst this), add_left_cancel (congrArg Prod.snd this)⟩
+
+/-! ### The endpoint geometry of a translated boundary edge -/
+
+/-- A boundary edge whose first stored endpoint lies in the region has its second stored
+endpoint outside the region. -/
+theorem boundary_snd_notMem {R : Finset (TorusVertex width height)}
+    {f : Edge (torusGraph width height)}
+    (hf : IsRegionBoundaryEdge (G := torusGraph width height) R f) (hmem : f.1.1 ∈ R) :
+    f.1.2 ∉ R := by
+  rcases hf with ⟨_, h2⟩ | ⟨h1, _⟩
+  · exact h2
+  · exact absurd hmem h1
+
+/-- The first stored endpoint of a translated boundary edge is the translate of one of the two
+stored endpoints of the original edge. -/
+theorem boundaryEdgeMap_translate_fst_or
+    (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (a : ZMod width) (b : ZMod height) :
+    (boundaryEdgeMap (translate a b) R f).1.1.1 = translate a b f.1.1.1 ∨
+      (boundaryEdgeMap (translate a b) R f).1.1.1 = translate a b f.1.1.2 := by
+  rw [boundaryEdgeMap_coe]
+  rcases Edge.map_endpoints (translate a b) f.1 with ⟨h1, _⟩ | ⟨h1, _⟩
+  · exact Or.inl h1
+  · exact Or.inr h1
+
+/-- **Membership reads orientation.**  For a boundary edge whose first stored endpoint lies in
+the region, the first stored endpoint of any translate of the edge lies in the translated region
+exactly when the translation preserved the stored endpoint order. -/
+theorem boundaryEdgeMap_translate_fst_mem_iff
+    (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (hmem : f.1.1.1 ∈ R) (a : ZMod width) (b : ZMod height) :
+    (boundaryEdgeMap (translate a b) R f).1.1.1 ∈ Region.map (translate a b) R ↔
+      (boundaryEdgeMap (translate a b) R f).1.1.1 = translate a b f.1.1.1 := by
+  have hne : f.1.1.1 ≠ f.1.1.2 := ne_of_lt f.1.2.1
+  rcases boundaryEdgeMap_translate_fst_or R f a b with h | h
+  · rw [h]
+    simp only [mem_Region_map_apply, hmem]
+  · rw [h]
+    constructor
+    · intro hmem2
+      rw [mem_Region_map_apply] at hmem2
+      exact absurd hmem2 (boundary_snd_notMem f.2 hmem)
+    · intro heq
+      exact absurd ((translate a b).toEquiv.injective heq).symm hne
+
+/-! ### The transported absorbing gauge and its translation covariance -/
+
+/-- The orientation-adapted absorbing gauge of the `(a, b)`-translate of a reference witness:
+the absorbing gauge (`absorbedBoundaryGauge`) of the translated region at the translated
+boundary edge, applied to the reference gauge `Z` carried across the bond-dimension equality of
+the translation-invariant second tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+noncomputable def transportedAbsorbedGauge (B : Tensor (torusGraph width height) d)
+    (hB : IsTorusTranslationInvariant B)
+    (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (Z : GL (Fin (B.bondDim f.1)) ℂ) (a : ZMod width) (b : ZMod height) :
+    GL (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ :=
+  absorbedBoundaryGauge (G := torusGraph width height) B (Region.map (translate a b) R)
+    (boundaryEdgeMap (translate a b) R f)
+    (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z)
+
+/-- The reference gauge transported to the `(a', b')`-translate is the reference gauge
+transported to the `(a, b)`-translate carried across the bond-dimension equality between the two
+translated edges. -/
+theorem glReindex_glReindex_bondDim
+    {B : Tensor (torusGraph width height) d} (hB : IsTorusTranslationInvariant B)
+    (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (Z : GL (Fin (B.bondDim f.1)) ℂ) (a a' : ZMod width) (b b' : ZMod height)
+    (h : B.bondDim (boundaryEdgeMap (translate a b) R f).1 =
+      B.bondDim (boundaryEdgeMap (translate a' b') R f).1) :
+    glReindex (bondDim_boundaryEdgeMap_translate hB a' b' R f).symm Z =
+      glReindex h (glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z) := by
+  rw [glReindex_glReindex]
+
+/-- **Translation covariance of the transported absorbing gauge.**
+
+The absorbing gauges of two translates of one reference witness determine each other: if the
+translation `(c, g)` carries the `(a, b)`-translate of the reference boundary edge onto the
+`(a', b')`-translate pointwise on the two stored endpoints, then the absorbing gauge at
+`(a', b')` is the absorbing gauge at `(a, b)` carried across the bond-dimension equality when
+the stored endpoint order is preserved, and its transposed inverse when the order is swapped.
+
+This is the faithful torus form of the source's single horizontal (vertical) matrix: one
+reference gauge, transported to every translate, with the wraparound endpoint swap of the edge
+convention accounted for by the transposed inverse.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem transportedAbsorbedGauge_translate_pair
+    (B : Tensor (torusGraph width height) d) (hB : IsTorusTranslationInvariant B)
+    (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (Z : GL (Fin (B.bondDim f.1)) ℂ) (hmem : f.1.1.1 ∈ R)
+    (a a' c : ZMod width) (b b' g : ZMod height)
+    (hsu : translate c g (translate a b f.1.1.1) = translate a' b' f.1.1.1)
+    (hsv : translate c g (translate a b f.1.1.2) = translate a' b' f.1.1.2)
+    (h : B.bondDim (boundaryEdgeMap (translate a b) R f).1 =
+      B.bondDim (boundaryEdgeMap (translate a' b') R f).1) :
+    (transportedAbsorbedGauge B hB R f Z a' b' :
+        Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a' b') R f).1))
+          (Fin (B.bondDim (boundaryEdgeMap (translate a' b') R f).1)) ℂ) =
+      if (boundaryEdgeMap (translate a' b') R f).1.1.1 =
+          translate c g (boundaryEdgeMap (translate a b) R f).1.1.1 then
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
+          (transportedAbsorbedGauge B hB R f Z a b :
+            Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
+              (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)
+      else
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
+          ((↑(transportedAbsorbedGauge B hB R f Z a b)⁻¹ :
+            Matrix (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1))
+              (Fin (B.bondDim (boundaryEdgeMap (translate a b) R f).1)) ℂ)ᵀ) := by
+  classical
+  have hne : f.1.1.1 ≠ f.1.1.2 := ne_of_lt f.1.2.1
+  -- Abbreviate the two transported reference gauges.
+  set Zs := glReindex (bondDim_boundaryEdgeMap_translate hB a b R f).symm Z with hZs
+  set Zs' := glReindex (bondDim_boundaryEdgeMap_translate hB a' b' R f).symm Z with hZs'
+  have hZrel : Zs' = glReindex h Zs := by
+    rw [hZs, hZs']
+    exact glReindex_glReindex_bondDim hB R f Z a a' b b' h
+  -- The two orientation conditions.
+  have hPiff := boundaryEdgeMap_translate_fst_mem_iff R f hmem a b
+  have hPiff' := boundaryEdgeMap_translate_fst_mem_iff R f hmem a' b'
+  rw [transportedAbsorbedGauge, transportedAbsorbedGauge, absorbedBoundaryGauge,
+    absorbedBoundaryGauge, ← hZs, ← hZs']
+  by_cases hP : (boundaryEdgeMap (translate a b) R f).1.1.1 ∈ Region.map (translate a b) R <;>
+    by_cases hP' :
+      (boundaryEdgeMap (translate a' b') R f).1.1.1 ∈ Region.map (translate a' b') R
+  · -- Both orders preserved: the connecting translation preserves the order.
+    have hQ : (boundaryEdgeMap (translate a' b') R f).1.1.1 =
+        translate c g (boundaryEdgeMap (translate a b) R f).1.1.1 := by
+      rw [hPiff'.mp hP', hPiff.mp hP, hsu]
+    rw [if_pos hP, if_pos hP', if_pos hQ, hZrel]
+    rw [glTranspose_coe, glTranspose_coe, glReindex_coe, reindexAlgEquiv_transpose]
+  · -- Order preserved at `(a, b)`, swapped at `(a', b')`: the connecting translation swaps.
+    have hQ : ¬((boundaryEdgeMap (translate a' b') R f).1.1.1 =
+        translate c g (boundaryEdgeMap (translate a b) R f).1.1.1) := by
+      have hfst' : (boundaryEdgeMap (translate a' b') R f).1.1.1 =
+          translate a' b' f.1.1.2 :=
+        (boundaryEdgeMap_translate_fst_or R f a' b').resolve_left (fun hcon => hP' (by
+          rw [hPiff']; exact hcon))
+      rw [hfst', hPiff.mp hP, hsu]
+      intro hcon
+      exact hne ((translate a' b').toEquiv.injective hcon).symm
+    rw [if_pos hP, if_neg hP', if_neg hQ, hZrel]
+    rw [glTranspose_inv_coe, Matrix.transpose_transpose, ← map_inv, glReindex_coe,
+      Matrix.GeneralLinearGroup.coe_inv]
+  · -- Order swapped at `(a, b)`, preserved at `(a', b')`: the connecting translation swaps.
+    have hQ : ¬((boundaryEdgeMap (translate a' b') R f).1.1.1 =
+        translate c g (boundaryEdgeMap (translate a b) R f).1.1.1) := by
+      have hfst : (boundaryEdgeMap (translate a b) R f).1.1.1 = translate a b f.1.1.2 :=
+        (boundaryEdgeMap_translate_fst_or R f a b).resolve_left (fun hcon => hP (by
+          rw [hPiff]; exact hcon))
+      rw [hfst, hPiff'.mp hP', hsv]
+      intro hcon
+      exact hne ((translate a' b').toEquiv.injective hcon)
+    rw [if_neg hP, if_pos hP', if_neg hQ, hZrel]
+    rw [glTranspose_coe, Matrix.GeneralLinearGroup.coe_inv, Matrix.GeneralLinearGroup.coe_inv,
+      Matrix.nonsing_inv_nonsing_inv _ ((Matrix.isUnit_iff_isUnit_det _).mp Zs.isUnit),
+      glReindex_coe, reindexAlgEquiv_transpose]
+  · -- Both orders swapped: the connecting translation preserves the order.
+    have hQ : (boundaryEdgeMap (translate a' b') R f).1.1.1 =
+        translate c g (boundaryEdgeMap (translate a b) R f).1.1.1 := by
+      have hfst : (boundaryEdgeMap (translate a b) R f).1.1.1 = translate a b f.1.1.2 :=
+        (boundaryEdgeMap_translate_fst_or R f a b).resolve_left (fun hcon => hP (by
+          rw [hPiff]; exact hcon))
+      have hfst' : (boundaryEdgeMap (translate a' b') R f).1.1.1 =
+          translate a' b' f.1.1.2 :=
+        (boundaryEdgeMap_translate_fst_or R f a' b').resolve_left (fun hcon => hP' (by
+          rw [hPiff']; exact hcon))
+      rw [hfst, hfst', hsv]
+    rw [if_neg hP, if_neg hP', if_pos hQ, hZrel]
+    rw [← map_inv, glReindex_coe]
+
+/-! ### Translation-covariant gauge families -/
+
+/-- A per-edge gauge family over the bonds of a translation-invariant tensor is **translation
+covariant** when the gauge at any translate of an edge is the gauge at the edge carried across
+the bond-dimension equality, transposed-inverted exactly when the translation swaps the stored
+endpoint order.  This is the faithful torus form of the source's *"the same matrix `X` (`Y`) on
+all horizontal (vertical) edges"*, with the wraparound endpoint swap of the ordered edge
+convention accounted for.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+def IsTranslationCovariantGaugeFamily (B : Tensor (torusGraph width height) d)
+    (X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ) : Prop :=
+  ∀ (a : ZMod width) (b : ZMod height) (e : Edge (torusGraph width height))
+    (h : B.bondDim e = B.bondDim (Edge.map (translate a b) e)),
+    (X (Edge.map (translate a b) e) :
+        Matrix (Fin (B.bondDim (Edge.map (translate a b) e)))
+          (Fin (B.bondDim (Edge.map (translate a b) e))) ℂ) =
+      if (Edge.map (translate a b) e).1.1 = translate a b e.1.1 then
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
+          (X e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)
+      else
+        Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
+          ((↑(X e)⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)ᵀ)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusCornerRegion.lean
+++ b/TNLean/PEPS/TorusCornerRegion.lean
@@ -1,0 +1,281 @@
+import TNLean.PEPS.TorusRectangleRegion
+import TNLean.PEPS.TorusTranslationInvariant
+import TNLean.PEPS.RegionBlock.Basic
+
+/-!
+# The corner comparison region of the torus Fundamental Theorem
+
+The final comparison of the normal PEPS Fundamental Theorem on the torus runs over a region `R`
+and the one-site-larger region `S = R ∪ {v}` (arXiv:1804.04964, Section 3, proof of Theorem 3,
+lines 1544--1571 of `Papers/1804.04964/paper_normal.tex`).  This file builds the reference
+instance of that pair from the source's rectangular-injectivity hypotheses: the **corner
+region** is a `3 × 3` coordinate square minus its lower-left corner, so that
+
+* the corner region is the union of a `2 × 3` and a `3 × 2` rectangle, hence injective;
+* inserting the corner vertex completes the square, a `3 × 3` rectangle, hence injective;
+* both complements decompose into coordinate bands (and one corner rectangle), all of source
+  shape, hence injective by union closure; and
+* both regions have a boundary edge.
+
+Every torus vertex is a translate of the corner vertex, so transporting this single reference
+pair along the translations supplies the comparison pair at every site.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1571
+  of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+
+/-! ### The corner square, corner region, and corner vertex -/
+
+/-- The `3 × 3` coordinate square at offset `(2, 2)`. -/
+def cornerSquare : Finset (TorusVertex width height) :=
+  torusContiguousRectangle 2 2 3 3
+
+/-- The corner region: the `3 × 3` square at `(2, 2)` minus its lower-left corner, presented as
+the union of a `2 × 3` rectangle and a `3 × 2` rectangle. -/
+def cornerRegion : Finset (TorusVertex width height) :=
+  torusContiguousRectangle 3 2 2 3 ∪ torusContiguousRectangle 2 3 3 2
+
+/-- The corner vertex `(2, 2)`, the lower-left corner of the corner square. -/
+def cornerVertex : TorusVertex width height :=
+  (((2 : ℕ) : ZMod width), ((2 : ℕ) : ZMod height))
+
+/-- Membership in the corner region, in coordinate values. -/
+theorem mem_cornerRegion (v : TorusVertex width height) :
+    v ∈ cornerRegion ↔
+      (3 ≤ v.1.val ∧ v.1.val < 5 ∧ 2 ≤ v.2.val ∧ v.2.val < 5) ∨
+        (2 ≤ v.1.val ∧ v.1.val < 5 ∧ 3 ≤ v.2.val ∧ v.2.val < 5) := by
+  simp only [cornerRegion, Finset.mem_union, mem_torusContiguousRectangle]
+
+/-- A vertex is the corner vertex exactly when its coordinate values are `(2, 2)`. -/
+theorem eq_cornerVertex_iff (hw : 7 ≤ width) (hh : 7 ≤ height)
+    (v : TorusVertex width height) :
+    v = cornerVertex ↔ v.1.val = 2 ∧ v.2.val = 2 := by
+  constructor
+  · rintro rfl
+    exact ⟨ZMod.val_cast_of_lt (by omega), ZMod.val_cast_of_lt (by omega)⟩
+  · rintro ⟨h1, h2⟩
+    refine Prod.ext (ZMod.val_injective width ?_) (ZMod.val_injective height ?_)
+    · rw [h1]
+      exact (ZMod.val_cast_of_lt (by omega : (2 : ℕ) < width)).symm
+    · rw [h2]
+      exact (ZMod.val_cast_of_lt (by omega : (2 : ℕ) < height)).symm
+
+/-- The corner vertex lies outside the corner region. -/
+theorem cornerVertex_notMem_cornerRegion (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    (cornerVertex : TorusVertex width height) ∉ cornerRegion := by
+  rw [mem_cornerRegion]
+  have h1 : (cornerVertex : TorusVertex width height).1.val = 2 :=
+    ZMod.val_cast_of_lt (by omega)
+  have h2 : (cornerVertex : TorusVertex width height).2.val = 2 :=
+    ZMod.val_cast_of_lt (by omega)
+  omega
+
+/-- Inserting the corner vertex into the corner region completes the corner square. -/
+theorem insert_cornerVertex_cornerRegion (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    insert (cornerVertex : TorusVertex width height) cornerRegion = cornerSquare := by
+  ext v
+  rw [Finset.mem_insert, mem_cornerRegion, eq_cornerVertex_iff hw hh,
+    cornerSquare, mem_torusContiguousRectangle]
+  omega
+
+/-! ### The band decompositions of the complements -/
+
+/-- The complement of the corner square is the union of four coordinate bands. -/
+theorem compl_cornerSquare_eq_bands (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    Finset.univ \ (cornerSquare : Finset (TorusVertex width height)) =
+      torusContiguousRectangle 0 0 2 height ∪
+        (torusContiguousRectangle 5 0 (width - 5) height ∪
+          (torusContiguousRectangle 2 0 3 2 ∪ torusContiguousRectangle 2 5 3 (height - 5))) := by
+  ext v
+  have hx := ZMod.val_lt v.1
+  have hy := ZMod.val_lt v.2
+  simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_union,
+    cornerSquare, mem_torusContiguousRectangle]
+  omega
+
+/-- The complement of the corner region is the union of the four bands and the corner
+rectangle covering the corner vertex. -/
+theorem compl_cornerRegion_eq_bands (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    Finset.univ \ (cornerRegion : Finset (TorusVertex width height)) =
+      torusContiguousRectangle 0 1 3 2 ∪
+        (torusContiguousRectangle 0 0 2 height ∪
+          (torusContiguousRectangle 5 0 (width - 5) height ∪
+            (torusContiguousRectangle 2 0 3 2 ∪
+              torusContiguousRectangle 2 5 3 (height - 5)))) := by
+  ext v
+  have hx := ZMod.val_lt v.1
+  have hy := ZMod.val_lt v.2
+  simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_union, mem_cornerRegion,
+    mem_torusContiguousRectangle]
+  omega
+
+/-! ### Injectivity of the corner regions and their complements -/
+
+namespace NormalTorusRectangleInjectivityHypotheses
+
+variable {κ : RegionInjectivityData (TorusVertex width height)}
+
+/-- The corner region is injective: it is the union of a `2 × 3` and a `3 × 2` source
+rectangle.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1452 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem cornerRegion_injective (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    κ.IsInjective (cornerRegion : Finset (TorusVertex width height)) :=
+  hUnion.union_injective (h.rect23_injective (by omega) (by omega))
+    (h.rect32_injective (by omega) (by omega))
+
+/-- The corner square is injective: it is a `3 × 3` rectangle.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1452 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem cornerSquare_injective (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    κ.IsInjective (cornerSquare : Finset (TorusVertex width height)) :=
+  h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
+
+/-- The complement of the corner square is injective: it is the union of four coordinate
+bands, each of source shape.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1452 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem compl_cornerSquare_injective (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    κ.IsInjective (Finset.univ \ (cornerSquare : Finset (TorusVertex width height))) := by
+  rw [compl_cornerSquare_eq_bands hw hh]
+  refine hUnion.union_injective
+    (h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  refine hUnion.union_injective
+    (h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  exact hUnion.union_injective
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega))
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega))
+
+/-- The complement of the corner region is injective: it is the union of the four bands and a
+`3 × 2` corner rectangle.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1452 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem compl_cornerRegion_injective (h : NormalTorusRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    κ.IsInjective (Finset.univ \ (cornerRegion : Finset (TorusVertex width height))) := by
+  rw [compl_cornerRegion_eq_bands hw hh]
+  refine hUnion.union_injective
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  refine hUnion.union_injective
+    (h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  refine hUnion.union_injective
+    (h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  exact hUnion.union_injective
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega))
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega))
+
+end NormalTorusRectangleInjectivityHypotheses
+
+/-! ### Boundary edges of the corner regions -/
+
+section BoundaryEdges
+
+variable [Fact (1 < width)] [Fact (1 < height)]
+
+/-- The up edge of the corner vertex is a boundary edge of the corner region: the corner
+vertex lies outside, its upper neighbour `(2, 3)` inside. -/
+theorem isRegionBoundaryEdge_cornerRegion (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    IsRegionBoundaryEdge (G := torusGraph width height) cornerRegion
+      (torusUpEdge (cornerVertex : TorusVertex width height)) := by
+  have hout : (cornerVertex : TorusVertex width height) ∉ cornerRegion :=
+    cornerVertex_notMem_cornerRegion hw hh
+  have hin : ((cornerVertex : TorusVertex width height).1,
+      (cornerVertex : TorusVertex width height).2 + 1) ∈ cornerRegion := by
+    rw [mem_cornerRegion]
+    have h1 : ((cornerVertex : TorusVertex width height).1).val = 2 :=
+      ZMod.val_cast_of_lt (by omega)
+    have h2 : ((cornerVertex : TorusVertex width height).2 + 1).val = 3 := by
+      rw [show (cornerVertex : TorusVertex width height).2 + 1 = ((3 : ℕ) : ZMod height) by
+        rw [cornerVertex]; push_cast; ring]
+      exact ZMod.val_cast_of_lt (by omega)
+    dsimp only
+    omega
+  rcases Edge.ofAdj_endpoints (torusGraph_adj_up
+      (cornerVertex : TorusVertex width height).1
+      (cornerVertex : TorusVertex width height).2) with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · refine Or.inr ⟨?_, ?_⟩
+    · rw [show (torusUpEdge (cornerVertex : TorusVertex width height)).1.1 =
+        ((cornerVertex : TorusVertex width height).1,
+          (cornerVertex : TorusVertex width height).2) from h1, Prod.mk.eta]
+      exact hout
+    · rw [show (torusUpEdge (cornerVertex : TorusVertex width height)).1.2 =
+        ((cornerVertex : TorusVertex width height).1,
+          (cornerVertex : TorusVertex width height).2 + 1) from h2]
+      exact hin
+  · refine Or.inl ⟨?_, ?_⟩
+    · rw [show (torusUpEdge (cornerVertex : TorusVertex width height)).1.1 =
+        ((cornerVertex : TorusVertex width height).1,
+          (cornerVertex : TorusVertex width height).2 + 1) from h1]
+      exact hin
+    · rw [show (torusUpEdge (cornerVertex : TorusVertex width height)).1.2 =
+        ((cornerVertex : TorusVertex width height).1,
+          (cornerVertex : TorusVertex width height).2) from h2, Prod.mk.eta]
+      exact hout
+
+/-- The vertex `(2, 1)` directly below the corner vertex. -/
+def belowCornerVertex : TorusVertex width height :=
+  (((2 : ℕ) : ZMod width), ((1 : ℕ) : ZMod height))
+
+/-- The up edge of `(2, 1)` is a boundary edge of the corner square: `(2, 1)` lies outside,
+its upper neighbour `(2, 2)` inside. -/
+theorem isRegionBoundaryEdge_cornerSquare (hw : 7 ≤ width) (hh : 7 ≤ height) :
+    IsRegionBoundaryEdge (G := torusGraph width height) cornerSquare
+      (torusUpEdge (belowCornerVertex : TorusVertex width height)) := by
+  have hout : (belowCornerVertex : TorusVertex width height) ∉ cornerSquare := by
+    rw [cornerSquare, mem_torusContiguousRectangle]
+    have h2 : ((belowCornerVertex : TorusVertex width height).2).val = 1 :=
+      ZMod.val_cast_of_lt (by omega)
+    omega
+  have hin : ((belowCornerVertex : TorusVertex width height).1,
+      (belowCornerVertex : TorusVertex width height).2 + 1) ∈ cornerSquare := by
+    rw [cornerSquare, mem_torusContiguousRectangle]
+    have h1 : ((belowCornerVertex : TorusVertex width height).1).val = 2 :=
+      ZMod.val_cast_of_lt (by omega)
+    have h2 : ((belowCornerVertex : TorusVertex width height).2 + 1).val = 2 := by
+      rw [show (belowCornerVertex : TorusVertex width height).2 + 1 =
+          ((2 : ℕ) : ZMod height) by
+        rw [belowCornerVertex]; push_cast; ring]
+      exact ZMod.val_cast_of_lt (by omega)
+    dsimp only
+    omega
+  rcases Edge.ofAdj_endpoints (torusGraph_adj_up
+      (belowCornerVertex : TorusVertex width height).1
+      (belowCornerVertex : TorusVertex width height).2) with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · refine Or.inr ⟨?_, ?_⟩
+    · rw [show (torusUpEdge (belowCornerVertex : TorusVertex width height)).1.1 =
+        ((belowCornerVertex : TorusVertex width height).1,
+          (belowCornerVertex : TorusVertex width height).2) from h1, Prod.mk.eta]
+      exact hout
+    · rw [show (torusUpEdge (belowCornerVertex : TorusVertex width height)).1.2 =
+        ((belowCornerVertex : TorusVertex width height).1,
+          (belowCornerVertex : TorusVertex width height).2 + 1) from h2]
+      exact hin
+  · refine Or.inl ⟨?_, ?_⟩
+    · rw [show (torusUpEdge (belowCornerVertex : TorusVertex width height)).1.1 =
+        ((belowCornerVertex : TorusVertex width height).1,
+          (belowCornerVertex : TorusVertex width height).2 + 1) from h1]
+      exact hin
+    · rw [show (torusUpEdge (belowCornerVertex : TorusVertex width height)).1.2 =
+        ((belowCornerVertex : TorusVertex width height).1,
+          (belowCornerVertex : TorusVertex width height).2) from h2, Prod.mk.eta]
+      exact hout
+
+end BoundaryEdges
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusCovariantAbsorbedFamily.lean
+++ b/TNLean/PEPS/TorusCovariantAbsorbedFamily.lean
@@ -1,0 +1,270 @@
+import TNLean.PEPS.TorusAbsorbedCovariance
+import TNLean.PEPS.TorusEdgeAbsorbed
+
+/-!
+# The translation-covariant absorbed gauge family on the torus
+
+This file rebuilds the every-edge bare-edge absorbed equality of
+`exists_edgeAbsorbed_torus_rectangle` with the per-edge gauge family *constructed* rather than
+chosen: every edge of each orientation class receives the orientation-adapted absorbing gauge of
+the transported reference witness, the reference gauge of its class carried along the unique
+translation reaching the edge (arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544
+of `Papers/1804.04964/paper_normal.tex`).
+
+Because the whole family is read off two reference gauges, it is translation covariant
+(`IsTranslationCovariantGaugeFamily`): the gauge at any translate of an edge is the gauge at the
+edge carried across the bond-dimension equality, transposed-inverted exactly when the
+translation swaps the stored endpoint order.  This covariance is the source's *"the same matrix
+`X` (`Y`) on all horizontal (vertical) edges"* in the ordered edge convention, and it is the
+input to the translation invariance of the comparison scalars in the final step of Theorem 3.
+
+The family is *not* literally one matrix per orientation class in the ordered edge convention:
+on the edges wrapping a torus seam the stored endpoint order is reversed, so the family carries
+the transposed inverse of the reference matrix there.  The lex-uniform predicate
+`IsTorusOrientationUniformGaugeFamilyModScalar` therefore does not describe this family; the
+covariance recorded here is the orientation-faithful uniformity statement.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544
+  of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- Transport across matching translation parameters collapses: if `a' = a` and `b' = b`, the
+reindexed absorbing gauge of the `(a', b')`-translate is the absorbing gauge of the
+`(a, b)`-translate. -/
+theorem glReindex_transportedAbsorbedGauge_eq (B : Tensor (torusGraph width height) d)
+    (hB : IsTorusTranslationInvariant B)
+    (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (Z : GL (Fin (B.bondDim f.1)) ℂ) {a a' : ZMod width} {b b' : ZMod height}
+    (ha : a' = a) (hb : b' = b)
+    (hcast : B.bondDim (boundaryEdgeMap (translate a' b') R f).1 =
+      B.bondDim (boundaryEdgeMap (translate a b) R f).1) :
+    glReindex hcast (transportedAbsorbedGauge B hB R f Z a' b') =
+      transportedAbsorbedGauge B hB R f Z a b := by
+  subst ha
+  subst hb
+  exact glReindex_self hcast _
+
+/-- **The translation-covariant absorbed gauge family on the torus.**
+
+For a translation-invariant pair `A`, `B` on the torus with matched bond dimensions, positive
+bonds, the same state, and both satisfying the rectangular-injectivity hypotheses with union
+closure, there is a per-edge gauge family `X` over the second tensor's bonds that
+
+* is translation covariant (`IsTranslationCovariantGaugeFamily`): the gauge at any translate of
+  an edge is the gauge at the edge carried across the bond-dimension equality,
+  transposed-inverted exactly when the translation swaps the stored endpoint order; and
+* satisfies the bare-edge absorbed equality against `applyGauge B X` at every edge: inserting
+  `N` on `A`'s edge `e` matches inserting the reindexed `N` on `applyGauge B X`'s edge `e`, for
+  every global physical configuration and every matrix.
+
+Unlike `exists_edgeAbsorbed_torus_rectangle`, whose per-edge witnesses are chosen independently,
+here every edge of each orientation class receives the orientation-adapted absorbing gauge of
+the *transported* reference witness: one horizontal reference gauge and one vertical reference
+gauge, carried along the unique translation reaching the edge.  The translation covariance is
+exactly the determinism of this construction.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_torusCovariantAbsorbedGaugeFamily
+    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (hAr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hBr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
+    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
+    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
+    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
+    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
+    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hbd : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    ∃ X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ,
+      IsTranslationCovariantGaugeFamily B X ∧
+      ∀ (e : Edge (torusGraph width height)) (σ : TorusVertex width height → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+        edgeInsertedCoeff (G := torusGraph width height) A e σ N =
+          edgeInsertedCoeff (G := torusGraph width height) (applyGauge B X) e σ
+            (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd e)) N) := by
+  classical
+  have hw : 2 < width := by omega
+  have hh : 2 < height := by omega
+  -- The two reference gauges and their coefficient identities at the reference edges.
+  obtain ⟨hEh, Zh, hZh⟩ :=
+    exists_horizontalReferenceEdgeGauge_coeff hAr hBr hUA hUB hxh0 hyh0 hxhw hyhh hxhw' hyhh'
+      hbd hAB hd hposA hposB
+  obtain ⟨hEv, Zv, hZv⟩ :=
+    exists_verticalReferenceEdgeGauge_coeff hAr hBr hUA hUB hxv0 hyv0 hxvw hyvh hxvw' hyvh'
+      hbd hAB hd hposA hposB
+  -- The reference regions and their distinguished boundary edges.
+  set Rh := (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').red with hRhdef
+  set fh := singleBoundaryEdge (G := torusGraph width height) A Rh
+    (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').blue
+    (torusHorizontalReferenceEdge xhStart yhStart)
+    (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hAr hUA hxh0 hyh0 hxhw
+      hyhh hxhw' hyhh' g) with hfhdef
+  set Rv := (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').red with hRvdef
+  set fv := singleBoundaryEdge (G := torusGraph width height) A Rv
+    (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').blue
+    (torusVerticalReferenceEdge xvStart yvStart)
+    (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hAr hUA hxv0 hyv0 hxvw
+      hyvh hxvw' hyvh' g) with hfvdef
+  -- The constructed family: at each edge, the absorbing gauge of the transported reference
+  -- witness of its orientation class, along the chosen translation reaching the edge.
+  set X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ := fun e =>
+    if he : IsHorizontalTorusEdge e then
+      glReindex
+        (congrArg B.bondDim
+          (translate_horizontalReferenceEdge (xStart := xhStart) (yStart := yhStart) he).2.symm)
+        (transportedAbsorbedGauge B hB Rh fh Zh
+          (translate_horizontalReferenceEdge (xStart := xhStart) (yStart := yhStart) he).1.1
+          (translate_horizontalReferenceEdge (xStart := xhStart) (yStart := yhStart) he).1.2)
+    else
+      glReindex
+        (congrArg B.bondDim
+          (translate_verticalReferenceEdge (xStart := xvStart) (yStart := yvStart)
+            ((torusEdge_horizontal_or_vertical e).resolve_left he)).2.symm)
+        (transportedAbsorbedGauge B hB Rv fv Zv
+          (translate_verticalReferenceEdge (xStart := xvStart) (yStart := yvStart)
+            ((torusEdge_horizontal_or_vertical e).resolve_left he)).1.1
+          (translate_verticalReferenceEdge (xStart := xvStart) (yStart := yvStart)
+            ((torusEdge_horizontal_or_vertical e).resolve_left he)).1.2)
+    with hXdef
+  -- The family at any translate of the horizontal reference edge is the transported absorbing
+  -- gauge of that translate: the chosen translation agrees with the given one by rigidity.
+  have hUh : ∀ (a : ZMod width) (b : ZMod height),
+      X (Edge.map (translate a b) (torusHorizontalReferenceEdge xhStart yhStart)) =
+        transportedAbsorbedGauge B hB Rh fh Zh a b := by
+    intro a b
+    have hhor : IsHorizontalTorusEdge
+        (Edge.map (translate a b) (torusHorizontalReferenceEdge xhStart yhStart)) := by
+      rw [← translateEdge_eq_map]
+      exact translateEdge_isHorizontal a b
+        (isHorizontalTorusEdge_torusHorizontalReferenceEdge xhStart yhStart)
+    rw [hXdef]
+    simp only
+    rw [dif_pos hhor]
+    generalize translate_horizontalReferenceEdge (xStart := xhStart) (yStart := yhStart) hhor
+      = pq
+    obtain ⟨⟨a', b'⟩, hspec⟩ := pq
+    have hmap : Edge.map (translate a' b') (torusHorizontalReferenceEdge xhStart yhStart) =
+        Edge.map (translate a b) (torusHorizontalReferenceEdge xhStart yhStart) := hspec.symm
+    obtain ⟨ha, hb⟩ := translate_param_unique_right hw _ hmap
+    exact glReindex_transportedAbsorbedGauge_eq B hB Rh fh Zh ha hb _
+  have hUv : ∀ (a : ZMod width) (b : ZMod height),
+      X (Edge.map (translate a b) (torusVerticalReferenceEdge xvStart yvStart)) =
+        transportedAbsorbedGauge B hB Rv fv Zv a b := by
+    intro a b
+    have hver : IsVerticalTorusEdge
+        (Edge.map (translate a b) (torusVerticalReferenceEdge xvStart yvStart)) := by
+      rw [← translateEdge_eq_map]
+      exact translateEdge_isVertical a b
+        (isVerticalTorusEdge_torusVerticalReferenceEdge xvStart yvStart)
+    have hnh : ¬ IsHorizontalTorusEdge
+        (Edge.map (translate a b) (torusVerticalReferenceEdge xvStart yvStart)) := fun hcon =>
+      torusEdge_not_horizontal_and_vertical _ ⟨hcon, hver⟩
+    rw [hXdef]
+    simp only
+    rw [dif_neg hnh]
+    generalize translate_verticalReferenceEdge (xStart := xvStart) (yStart := yvStart)
+      ((torusEdge_horizontal_or_vertical _).resolve_left hnh) = pq
+    obtain ⟨⟨a', b'⟩, hspec⟩ := pq
+    have hmap : Edge.map (translate a' b') (torusVerticalReferenceEdge xvStart yvStart) =
+        Edge.map (translate a b) (torusVerticalReferenceEdge xvStart yvStart) := hspec.symm
+    obtain ⟨ha, hb⟩ := translate_param_unique_up hh _ hmap
+    exact glReindex_transportedAbsorbedGauge_eq B hB Rv fv Zv ha hb _
+  -- The two reference boundary edges have their first stored endpoint in the reference region.
+  have hmemh : fh.1.1.1 ∈ Rh :=
+    (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').left_mem_red
+  have hmemv : fv.1.1.1 ∈ Rv :=
+    (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').left_mem_red
+  refine ⟨X, ?_, ?_⟩
+  · -- Translation covariance.
+    intro a b e
+    rcases torusEdge_horizontal_or_vertical e with he | he
+    · obtain ⟨⟨a₀, b₀⟩, rfl⟩ :=
+        translate_horizontalReferenceEdge (xStart := xhStart) (yStart := yhStart) he
+      rw [translateEdge_translateEdge]
+      intro h
+      rw [hUh a₀ b₀, hUh (a₀ + a) (b₀ + b)]
+      exact transportedAbsorbedGauge_translate_pair B hB Rh fh Zh hmemh a₀ (a₀ + a) a b₀
+        (b₀ + b) b (by apply Prod.ext <;> simp <;> ring) (by apply Prod.ext <;> simp <;> ring) h
+    · obtain ⟨⟨a₀, b₀⟩, rfl⟩ :=
+        translate_verticalReferenceEdge (xStart := xvStart) (yStart := yvStart) he
+      rw [translateEdge_translateEdge]
+      intro h
+      rw [hUv a₀ b₀, hUv (a₀ + a) (b₀ + b)]
+      exact transportedAbsorbedGauge_translate_pair B hB Rv fv Zv hmemv a₀ (a₀ + a) a b₀
+        (b₀ + b) b (by apply Prod.ext <;> simp <;> ring) (by apply Prod.ext <;> simp <;> ring) h
+  · -- The bare-edge absorbed equality at every edge.
+    intro e σ N
+    rcases torusEdge_horizontal_or_vertical e with he | he
+    · obtain ⟨⟨a, b⟩, rfl⟩ :=
+        translate_horizontalReferenceEdge (xStart := xhStart) (yStart := yhStart) he
+      -- `B`'s reference region block and host block are injective.
+      have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B Rh := by
+        have hi := hBr.horizontalEdgeRed_injective (xStart := xhStart) (yStart := yhStart)
+          (by omega) (by omega)
+        rwa [regionInjectivityDataOf_isInjective] at hi
+      have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+          (Finset.univ \ Rh) :=
+        regionBlockedTensorInjective_host
+          (torusHorizontalRectangleBlockingDatum hBr hUB hxh0 hyh0 hxhw' hyhh') hUB
+      have hEX : A.bondDim (boundaryEdgeMap (translate a b) Rh fh).1 =
+          B.bondDim (boundaryEdgeMap (translate a b) Rh fh).1 :=
+        (bondDim_boundaryEdgeMap_translate hA a b Rh fh).trans
+          (hEh.trans (bondDim_boundaryEdgeMap_translate hB a b Rh fh).symm)
+      refine edgeAbsorbed_of_edgeCoeffIdentityWitness
+        (edgeCoeffIdentityWitness_translate hA hB a b Rh fh hEh Zh hposB hRB hCB hZh
+          (glReindex (bondDim_boundaryEdgeMap_translate hB a b Rh fh).symm Zh) hEX ?_)
+        hbd X (hUh a b) hposA σ N
+      intro M σ' τ'
+      obtain ⟨σ₀, τ₀, rfl, rfl⟩ :=
+        exists_regionPhysicalConfig_translate_preimage (d := d) a b Rh σ' τ'
+      exact regionInsertedCoeff_translate_coeffIdentity_conj hA hB a b Rh fh hEh Zh hZh
+        hEX (glReindex (bondDim_boundaryEdgeMap_translate hB a b Rh fh).symm Zh) rfl M σ₀ τ₀
+    · obtain ⟨⟨a, b⟩, rfl⟩ :=
+        translate_verticalReferenceEdge (xStart := xvStart) (yStart := yvStart) he
+      have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B Rv := by
+        have hi := hBr.verticalEdgeRed_injective (xStart := xvStart) (yStart := yvStart)
+          (by omega) (by omega)
+        rwa [regionInjectivityDataOf_isInjective] at hi
+      have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+          (Finset.univ \ Rv) :=
+        regionBlockedTensorInjective_host
+          (torusVerticalRectangleBlockingDatum hBr hUB hxv0 hyv0 hxvw' hyvh') hUB
+      have hEX : A.bondDim (boundaryEdgeMap (translate a b) Rv fv).1 =
+          B.bondDim (boundaryEdgeMap (translate a b) Rv fv).1 :=
+        (bondDim_boundaryEdgeMap_translate hA a b Rv fv).trans
+          (hEv.trans (bondDim_boundaryEdgeMap_translate hB a b Rv fv).symm)
+      refine edgeAbsorbed_of_edgeCoeffIdentityWitness
+        (edgeCoeffIdentityWitness_translate hA hB a b Rv fv hEv Zv hposB hRB hCB hZv
+          (glReindex (bondDim_boundaryEdgeMap_translate hB a b Rv fv).symm Zv) hEX ?_)
+        hbd X (hUv a b) hposA σ N
+      intro M σ' τ'
+      obtain ⟨σ₀, τ₀, rfl, rfl⟩ :=
+        exists_regionPhysicalConfig_translate_preimage (d := d) a b Rv σ' τ'
+      exact regionInsertedCoeff_translate_coeffIdentity_conj hA hB a b Rv fv hEv Zv hZv
+        hEX (glReindex (bondDim_boundaryEdgeMap_translate hB a b Rv fv).symm Zv) rfl M σ₀ τ₀
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusFundamentalTheorem2.lean
+++ b/TNLean/PEPS/TorusFundamentalTheorem2.lean
@@ -1,4 +1,5 @@
 import TNLean.PEPS.TorusFundamentalTheorem
+import TNLean.PEPS.NormalSquareInjectivity
 import TNLean.PEPS.TorusCovariantAbsorbedFamily
 import TNLean.PEPS.TorusGaugedWeightCovariance
 import TNLean.PEPS.TorusCornerRegion
@@ -10,7 +11,8 @@ import TNLean.PEPS.RegionBlock.ReindexInjectivity
 This file removes the per-vertex hypothesis of the conditional torus capstone
 `fundamentalTheorem_normalTorusPEPS`: from the source hypotheses alone --- translation
 invariance, matched bond dimensions, positive bonds, the same state, and the
-rectangular-injectivity hypotheses with union closure --- it produces a per-edge gauge family
+rectangular-injectivity hypotheses (the union closure of injective regions is derived from the
+positive bonds) --- it produces a per-edge gauge family
 `X` and a single scalar `λ` with
 
 * the translation covariance of `X` (the faithful torus form of the source's *"the same matrix
@@ -141,10 +143,12 @@ theorem component_eq_gaugeVertex_of_cornerProportional
 /-- **Unconditional normal PEPS Fundamental Theorem on the torus.**
 
 For a translation-invariant pair `A`, `B` on the discrete torus with matched bond dimensions,
-positive bonds, the same state, and both satisfying the rectangular-injectivity hypotheses with
-union closure, there are a translation-covariant per-edge gauge family `X` realizing the
+positive bonds, the same state, and both satisfying the rectangular-injectivity hypotheses,
+there are a translation-covariant per-edge gauge family `X` realizing the
 bare-edge absorbed equality at every edge, and a single scalar `λ` with the per-vertex relation
-`A_v = λ · (gauge action of B at v)` at every torus vertex and `λ^{width·height} = 1`.
+`A_v = λ · (gauge action of B at v)` at every torus vertex and `λ^{width·height} = 1`.  The
+union closure of injective regions is derived from the positive bonds
+(`regionInjectivityUnionClosure_of_overlap`), not assumed.
 
 This is the torus form of Theorem 3 (arXiv:1804.04964, Section 3, lines 1453--1471 of
 `Papers/1804.04964/paper_normal.tex`): `B = λ · (X, Y\text{-action on } A)` with
@@ -167,10 +171,6 @@ theorem fundamentalTheorem_normalTorusPEPS_unconditional
     (hAr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hBr : NormalTorusRectangleInjectivityHypotheses
-      (regionInjectivityDataOf (G := torusGraph width height) B))
-    (hUA : RegionInjectivityUnionClosure
-      (regionInjectivityDataOf (G := torusGraph width height) A))
-    (hUB : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) B))
     (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
     (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
@@ -198,6 +198,13 @@ theorem fundamentalTheorem_normalTorusPEPS_unconditional
   classical
   have hw : 7 ≤ width := by omega
   have hh : 7 ≤ height := by omega
+  -- The union closure of injective regions, from positive bonds.
+  have hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A) :=
+    regionInjectivityUnionClosure_of_overlap A hposA
+  have hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B) :=
+    regionInjectivityUnionClosure_of_overlap B hposB
   -- The translation-covariant absorbed gauge family.
   obtain ⟨X, hXcov, hedge⟩ := exists_torusCovariantAbsorbedGaugeFamily hA hB hAr hBr hUA hUB
     hxh0 hyh0 hxhw hyhh hxhw' hyhh' hxv0 hyv0 hxvw hyvh hxvw' hyvh' hbond hAB hd hposA hposB

--- a/TNLean/PEPS/TorusFundamentalTheorem2.lean
+++ b/TNLean/PEPS/TorusFundamentalTheorem2.lean
@@ -1,0 +1,268 @@
+import TNLean.PEPS.TorusFundamentalTheorem
+import TNLean.PEPS.TorusCovariantAbsorbedFamily
+import TNLean.PEPS.TorusGaugedWeightCovariance
+import TNLean.PEPS.TorusCornerRegion
+import TNLean.PEPS.RegionBlock.ReindexInjectivity
+
+/-!
+# The unconditional normal PEPS Fundamental Theorem on the torus
+
+This file removes the per-vertex hypothesis of the conditional torus capstone
+`fundamentalTheorem_normalTorusPEPS`: from the source hypotheses alone --- translation
+invariance, matched bond dimensions, positive bonds, the same state, and the
+rectangular-injectivity hypotheses with union closure --- it produces a per-edge gauge family
+`X` and a single scalar `λ` with
+
+* the translation covariance of `X` (the faithful torus form of the source's *"the same matrix
+  on all horizontal (vertical) edges"*, with the wraparound endpoint swap of the ordered edge
+  convention accounted for),
+* the bare-edge absorbed equality at every edge,
+* the per-vertex relation `A_v = λ · (gauge action of B at v)` at every torus vertex, and
+* the scalar condition `λ^{width·height} = 1`
+
+(arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1471 of
+`Papers/1804.04964/paper_normal.tex`).
+
+The production: the translation-covariant absorbed gauge family
+(`exists_torusCovariantAbsorbedGaugeFamily`) supplies `X` with the bare-edge absorbed equality;
+the comparison at the corner region and its insert-completed square
+(`twoBlockProportional_of_edgeAbsorbed`) supplies two proportionality scalars `c_R`, `c_S`;
+translation covariance transports both proportionalities to every translate with the *same*
+scalars (`twoBlockScalarProportional_translate`), so the inserted-site scalar extraction
+(`component_eq_gaugeVertex_of_twoBlockProportional`) yields the per-vertex relation with the
+single ratio `λ = c_S / c_R` at every vertex; the scalar condition follows from
+`lambda_pow_card_torus_eq_one`.
+
+The conclusion does not assert `IsTorusOrientationUniformGaugeFamilyModScalar` of this `X`: the
+ordered edge convention stores a wraparound edge with its endpoints swapped, so the absorbing
+family carries the transposed inverse of the class matrix on the seam edges and is *not* one
+matrix per class up to scalars in that convention.  The translation covariance conjunct is the
+orientation-faithful statement of the source's uniformity.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1471 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- The vertex image of a translated region inserts the translated vertex. -/
+theorem Region_map_insert (a : ZMod width) (b : ZMod height)
+    (v : TorusVertex width height) (R : Finset (TorusVertex width height)) :
+    Region.map (translate a b) (insert v R) =
+      insert (translate a b v) (Region.map (translate a b) R) :=
+  Finset.map_insert _ _ _
+
+/-- Blocked-region injectivity of a translation-invariant tensor transports to every translated
+region. -/
+theorem regionBlockedTensorInjective_translate {T : Tensor (torusGraph width height) d}
+    (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
+    (R : Finset (TorusVertex width height))
+    (h : RegionBlockedTensorInjective (G := torusGraph width height) T R) :
+    RegionBlockedTensorInjective (G := torusGraph width height) T
+      (Region.map (translate a b) R) := by
+  have htr := (regionBlockedTensorInjective_transport T (translate a b) R).mpr h
+  rwa [hT a b] at htr
+
+/-- **The per-vertex gauge relation from the corner-region comparison.**
+
+For a translation-invariant pair with a translation-covariant gauge family, the two comparison
+proportionalities at the corner region and its insert-completed square transport to every
+vertex's translate with the same scalars, so the inserted-site scalar extraction yields the
+per-vertex relation `A_v = (c_S/c_R) · (gauge action of B at v)` with one ratio at every torus
+vertex.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1544--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem component_eq_gaugeVertex_of_cornerProportional
+    {A B : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    {X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ}
+    (hXcov : IsTranslationCovariantGaugeFamily B X)
+    (hbond : A.bondDim = B.bondDim)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hw : 7 ≤ width) (hh : 7 ≤ height) {cR cS : ℂ} (hcR0 : cR ≠ 0)
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B cornerRegion)
+    (hcRprop : TwoBlockScalarProportional.{0, 0, 0, 0}
+      (regionTwoBlock (G := torusGraph width height) A cornerRegion)
+      (regionTwoBlock (G := torusGraph width height)
+        (reindexTensor (G := torusGraph width height) (applyGauge B X) hbond)
+        cornerRegion) cR)
+    (hcSprop : TwoBlockScalarProportional.{0, 0, 0, 0}
+      (regionTwoBlock (G := torusGraph width height) A
+        (insert (cornerVertex : TorusVertex width height) cornerRegion))
+      (regionTwoBlock (G := torusGraph width height)
+        (reindexTensor (G := torusGraph width height) (applyGauge B X) hbond)
+        (insert (cornerVertex : TorusVertex width height) cornerRegion)) cS)
+    (v : TorusVertex width height)
+    (η : (ie : IncidentEdge (torusGraph width height) v) → Fin (A.bondDim ie.1))
+    (σ : Fin d) :
+    A.component v η σ =
+      (cS / cR) * gaugeVertex B X v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ := by
+  -- The translation carrying the corner vertex to `v`.
+  set a := v.1 - ((2 : ℕ) : ZMod width) with hadef
+  set b := v.2 - ((2 : ℕ) : ZMod height) with hbdef
+  have hvmap : translate a b (cornerVertex : TorusVertex width height) = v := by
+    apply Prod.ext
+    · rw [hadef]
+      simp [cornerVertex]
+    · rw [hbdef]
+      simp [cornerVertex]
+  -- The vertex lies outside the translated corner region.
+  have hvR : v ∉ Region.map (translate a b) cornerRegion := by
+    rw [← hvmap, mem_Region_map_apply]
+    exact cornerVertex_notMem_cornerRegion hw hh
+  -- The reindexed gauge-absorbed tensor is injective on the translated corner region.
+  have hRC_v : RegionBlockedTensorInjective (G := torusGraph width height)
+      (reindexTensor (G := torusGraph width height) (applyGauge B X) hbond)
+      (Region.map (translate a b) cornerRegion) :=
+    regionBlockedTensorInjective_reindexTensor (applyGauge B X) hbond _
+      (regionBlockedTensorInjective_applyGauge B X _
+        (regionBlockedTensorInjective_translate hB a b cornerRegion hRB))
+  -- The two transported proportionalities, with the base scalars.
+  have hRprop_v := twoBlockScalarProportional_translate hA hB hXcov hbond a b
+    cornerRegion hcRprop
+  have hSprop_v := twoBlockScalarProportional_translate hA hB hXcov hbond a b
+    (insert (cornerVertex : TorusVertex width height) cornerRegion) hcSprop
+  rw [Region_map_insert a b cornerVertex cornerRegion, hvmap] at hSprop_v
+  -- The inserted-site scalar extraction at `v`.
+  exact component_eq_gaugeVertex_of_twoBlockProportional A B
+    (Region.map (translate a b) cornerRegion) hvR hbond X cR cS hcR0 hposA hRC_v
+    hRprop_v hSprop_v η σ
+
+/-- **Unconditional normal PEPS Fundamental Theorem on the torus.**
+
+For a translation-invariant pair `A`, `B` on the discrete torus with matched bond dimensions,
+positive bonds, the same state, and both satisfying the rectangular-injectivity hypotheses with
+union closure, there are a translation-covariant per-edge gauge family `X` realizing the
+bare-edge absorbed equality at every edge, and a single scalar `λ` with the per-vertex relation
+`A_v = λ · (gauge action of B at v)` at every torus vertex and `λ^{width·height} = 1`.
+
+This is the torus form of Theorem 3 (arXiv:1804.04964, Section 3, lines 1453--1471 of
+`Papers/1804.04964/paper_normal.tex`): `B = λ · (X, Y\text{-action on } A)` with
+`λ^{n·m} = 1`, with no conditional per-vertex hypothesis.  The single `λ` is produced by
+transporting the corner-region comparison to every vertex along the translations; the
+translation covariance of the gauge family is what makes the transported comparison scalars
+agree.
+
+The gauge family is characterized here by its translation covariance rather than by the
+lex-uniform predicate `IsTorusOrientationUniformGaugeFamilyModScalar`: the ordered edge
+convention stores a wraparound edge with swapped endpoints, so the absorbing family carries the
+transposed inverse of the class matrix on the seam edges, which the lex-uniform predicate does
+not describe.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1471 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalTorusPEPS_unconditional
+    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    (hAr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hBr : NormalTorusRectangleInjectivityHypotheses
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
+    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
+    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
+    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
+    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
+    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
+    ∃ X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ,
+      IsTranslationCovariantGaugeFamily B X ∧
+      (∀ (e : Edge (torusGraph width height)) (σ : TorusVertex width height → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+        edgeInsertedCoeff (G := torusGraph width height) A e σ N =
+          edgeInsertedCoeff (G := torusGraph width height) (applyGauge B X) e σ
+            (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N)) ∧
+      ∃ lam : ℂ,
+        (∀ (v : TorusVertex width height)
+          (η : (ie : IncidentEdge (torusGraph width height) v) → Fin (A.bondDim ie.1))
+          (σ : Fin d),
+          A.component v η σ =
+            lam * gaugeVertex B X v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ) ∧
+        lam ^ (width * height) = 1 := by
+  classical
+  have hw : 7 ≤ width := by omega
+  have hh : 7 ≤ height := by omega
+  -- The translation-covariant absorbed gauge family.
+  obtain ⟨X, hXcov, hedge⟩ := exists_torusCovariantAbsorbedGaugeFamily hA hB hAr hBr hUA hUB
+    hxh0 hyh0 hxhw hyhh hxhw' hyhh' hxv0 hyv0 hxvw hyvh hxvw' hyvh' hbond hAB hd hposA hposB
+  -- The base injectivity facts at the corner region and its insert-completed square, for `A`.
+  have hRA : RegionBlockedTensorInjective (G := torusGraph width height) A cornerRegion := by
+    have hi := hAr.cornerRegion_injective hUA hw hh
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hSA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (insert (cornerVertex : TorusVertex width height) cornerRegion) := by
+    rw [insert_cornerVertex_cornerRegion hw hh]
+    have hi := hAr.cornerSquare_injective hUA hw hh
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCRA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (Finset.univ \ cornerRegion) := by
+    have hi := hAr.compl_cornerRegion_injective hUA hw hh
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCSA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (Finset.univ \ insert (cornerVertex : TorusVertex width height) cornerRegion) := by
+    rw [insert_cornerVertex_cornerRegion hw hh]
+    have hi := hAr.compl_cornerSquare_injective hUA hw hh
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  -- The same base facts for `B`, lifted through the gauge and the bond-dimension reindex.
+  have liftC : ∀ R : Finset (TorusVertex width height),
+      RegionBlockedTensorInjective (G := torusGraph width height) B R →
+      RegionBlockedTensorInjective (G := torusGraph width height)
+        (reindexTensor (G := torusGraph width height) (applyGauge B X) hbond) R := fun R hRB =>
+    regionBlockedTensorInjective_reindexTensor (applyGauge B X) hbond R
+      (regionBlockedTensorInjective_applyGauge B X R hRB)
+  have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B cornerRegion := by
+    have hi := hBr.cornerRegion_injective hUB hw hh
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hSB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (insert (cornerVertex : TorusVertex width height) cornerRegion) := by
+    rw [insert_cornerVertex_cornerRegion hw hh]
+    have hi := hBr.cornerSquare_injective hUB hw hh
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCRB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ cornerRegion) := by
+    have hi := hBr.compl_cornerRegion_injective hUB hw hh
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCSB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ insert (cornerVertex : TorusVertex width height) cornerRegion) := by
+    rw [insert_cornerVertex_cornerRegion hw hh]
+    have hi := hBr.compl_cornerSquare_injective hUB hw hh
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  -- Boundary edges of the two base comparison regions.
+  haveI hNeR : Nonempty {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) cornerRegion f} :=
+    ⟨⟨torusUpEdge cornerVertex, isRegionBoundaryEdge_cornerRegion hw hh⟩⟩
+  haveI hNeS : Nonempty {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height)
+        (insert (cornerVertex : TorusVertex width height) cornerRegion) f} := by
+    rw [insert_cornerVertex_cornerRegion hw hh]
+    exact ⟨⟨torusUpEdge belowCornerVertex, isRegionBoundaryEdge_cornerSquare hw hh⟩⟩
+  -- The two base comparison proportionalities.
+  obtain ⟨cR, hcR0, hcRprop⟩ := twoBlockProportional_of_edgeAbsorbed A B hbond X cornerRegion
+    hRA hCRA (liftC _ hRB) (liftC _ hCRB) hedge
+  obtain ⟨cS, hcS0, hcSprop⟩ := twoBlockProportional_of_edgeAbsorbed A B hbond X
+    (insert (cornerVertex : TorusVertex width height) cornerRegion)
+    hSA hCSA (liftC _ hSB) (liftC _ hCSB) hedge
+  -- The per-vertex relation with the single ratio `λ = c_S / c_R`.
+  have hPV := component_eq_gaugeVertex_of_cornerProportional hA hB hXcov hbond hposA hw hh
+    hcR0 hRB hcRprop hcSprop
+  exact ⟨X, hXcov, hedge, cS / cR, hPV,
+    lambda_pow_card_torus_eq_one A B cornerRegion hRA hCRA hposA hAB X hbond (cS / cR) hPV⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusGaugedWeightCovariance.lean
+++ b/TNLean/PEPS/TorusGaugedWeightCovariance.lean
@@ -1,0 +1,370 @@
+import TNLean.PEPS.TorusAbsorbedCovariance
+import TNLean.PEPS.RegionBlock.GaugeInjectivity2
+import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
+
+/-!
+# Translation covariance of the gauge-absorbed blocked weights
+
+The final comparison of the normal PEPS Fundamental Theorem on the torus produces, at every
+comparison region, a scalar proportionality between the blocked weights of the first tensor and
+of the gauge-absorbed second tensor (arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+1544--1571 of `Papers/1804.04964/paper_normal.tex`).  The single scalar `λ` of the theorem
+requires those proportionality scalars to be the *same at every translate* of the comparison
+region.  This file proves the covariance that delivers it: for a translation-invariant second
+tensor and a translation-covariant gauge family, the blocked weight of the gauge-absorbed tensor
+at a translated region, read at the transported boundary and physical configurations, equals the
+blocked weight at the original region (`regionBlockedWeight_applyGauge_translate`).  A scalar
+proportionality of the region blocks against the gauge-absorbed tensor therefore transports to
+every translate of the comparison region with the *same* scalar
+(`twoBlockScalarProportional_translate`).
+
+The per-edge content is the covariance of the surviving boundary gauge
+(`regionBoundaryGauge_translate`): on a boundary edge the surviving gauge of the translated
+region is the surviving gauge of the original region carried across the bond-dimension equality;
+the orientation flips of the translation and of the region membership cancel exactly.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1571
+  of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+/-! ### Congruence and reindexing helpers -/
+
+/-- Evaluating a reindexed matrix at the cast indices recovers the original entry. -/
+theorem reindexAlgEquiv_apply_cast {m n : ℕ} (h : m = n)
+    (M : Matrix (Fin m) (Fin m) ℂ) (i j : Fin m) :
+    Matrix.reindexAlgEquiv ℂ ℂ (finCongr h) M (Fin.cast h i) (Fin.cast h j) = M i j := by
+  rw [Matrix.reindexAlgEquiv_apply, Matrix.reindex_apply, Matrix.submatrix_apply]
+  congr 1
+
+section Generic
+
+variable {V W : Type*} [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  {G : SimpleGraph V} {G' : SimpleGraph W} {d : ℕ}
+variable [DecidableRel G.Adj] [DecidableRel G'.Adj]
+
+omit [Fintype W] [LinearOrder W] [DecidableRel G'.Adj] in
+/-- The blocked-region weight is congruent under an equality of tensors, with the boundary
+configuration carried across the (propositionally trivial) bond-dimension equality. -/
+theorem regionBlockedWeight_congrTensor {T₁ T₂ : Tensor G d} (h : T₁ = T₂) (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) T₁ R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) R) :
+    regionBlockedWeight (G := G) T₁ R bdry τ =
+      regionBlockedWeight (G := G) T₂ R
+        (fun f => Fin.cast (congrFun (congrArg Tensor.bondDim h) f.1) (bdry f)) τ := by
+  subst h
+  rfl
+
+omit [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
+  [DecidableRel G.Adj] [DecidableRel G'.Adj] in
+/-- Pushing a region physical configuration through a graph isomorphism is surjective. -/
+theorem regionPhysicalConfigMap_surjective (φ : G ≃g G') (R : Finset V) :
+    Function.Surjective (regionPhysicalConfigMap (d := d) φ R) := fun τ' =>
+  ⟨(regionPhysicalConfigMapEquiv (d := d) φ R).symm τ',
+    (regionPhysicalConfigMapEquiv (d := d) φ R).apply_symm_apply τ'⟩
+
+end Generic
+
+/-! ### The transported boundary configuration of a translation-invariant tensor -/
+
+section Torus
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- The boundary configuration of a translation-invariant tensor transported to the translated
+region: push through the geometric boundary-edge reindexing and carry each value across the
+bond-dimension equality of translation invariance. -/
+noncomputable def tiBoundaryConfigMap (T : Tensor (torusGraph width height) d)
+    (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
+    (R : Finset (TorusVertex width height))
+    (bdry : RegionBoundaryConfig (G := torusGraph width height) T R) :
+    RegionBoundaryConfig (G := torusGraph width height) T (Region.map (translate a b) R) :=
+  fun f => Fin.cast (congrFun (congrArg Tensor.bondDim (hT a b)) f.1)
+    (regionBoundaryConfigMap T (translate a b) R bdry f)
+
+/-- The transported boundary configuration as a bijection. -/
+noncomputable def tiBoundaryConfigEquiv (T : Tensor (torusGraph width height) d)
+    (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
+    (R : Finset (TorusVertex width height)) :
+    RegionBoundaryConfig (G := torusGraph width height) T R ≃
+      RegionBoundaryConfig (G := torusGraph width height) T (Region.map (translate a b) R) where
+  toFun := tiBoundaryConfigMap T hT a b R
+  invFun bdry' := (regionBoundaryConfigMapEquiv T (translate a b) R).symm
+    (fun f => Fin.cast (congrFun (congrArg Tensor.bondDim (hT a b)) f.1).symm (bdry' f))
+  left_inv bdry := by
+    beta_reduce
+    have hcollapse : (fun f => Fin.cast
+        (congrFun (congrArg Tensor.bondDim (hT a b)) f.1).symm
+        (tiBoundaryConfigMap T hT a b R bdry f)) =
+        regionBoundaryConfigMap T (translate a b) R bdry := by
+      funext f
+      apply Fin.eq_of_val_eq
+      simp [tiBoundaryConfigMap]
+    rw [hcollapse, ← regionBoundaryConfigMapEquiv_apply, Equiv.symm_apply_apply]
+  right_inv bdry' := by
+    beta_reduce
+    funext f
+    rw [tiBoundaryConfigMap, ← regionBoundaryConfigMapEquiv_apply, Equiv.apply_symm_apply]
+    apply Fin.eq_of_val_eq
+    simp
+
+@[simp] theorem tiBoundaryConfigEquiv_apply (T : Tensor (torusGraph width height) d)
+    (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
+    (R : Finset (TorusVertex width height))
+    (bdry : RegionBoundaryConfig (G := torusGraph width height) T R) :
+    tiBoundaryConfigEquiv T hT a b R bdry = tiBoundaryConfigMap T hT a b R bdry := rfl
+
+/-- The transported boundary configuration is surjective onto the boundary configurations of the
+translated region. -/
+theorem tiBoundaryConfigMap_surjective (T : Tensor (torusGraph width height) d)
+    (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
+    (R : Finset (TorusVertex width height)) :
+    Function.Surjective (tiBoundaryConfigMap T hT a b R) := fun bdry' =>
+  ⟨(tiBoundaryConfigEquiv T hT a b R).symm bdry',
+    (tiBoundaryConfigEquiv T hT a b R).apply_symm_apply bdry'⟩
+
+/-- Reading the transported boundary configuration at the translated distinguished boundary edge
+recovers the original value across the bond-dimension equality. -/
+theorem tiBoundaryConfigMap_boundaryEdgeMap (T : Tensor (torusGraph width height) d)
+    (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
+    (R : Finset (TorusVertex width height))
+    (bdry : RegionBoundaryConfig (G := torusGraph width height) T R)
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f}) :
+    tiBoundaryConfigMap T hT a b R bdry (boundaryEdgeMap (translate a b) R f) =
+      Fin.cast (bondDim_boundaryEdgeMap_translate hT a b R f).symm (bdry f) := by
+  rw [tiBoundaryConfigMap, regionBoundaryConfigMap_boundaryEdgeMap]
+  apply Fin.eq_of_val_eq
+  simp
+
+/-- **Translation covariance of the blocked weight of a translation-invariant tensor.**
+
+The blocked weight at the translated region, read at the transported boundary and physical
+configurations, is the blocked weight at the original region.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1572 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_tiBoundaryConfigMap (T : Tensor (torusGraph width height) d)
+    (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
+    (R : Finset (TorusVertex width height))
+    (bdry : RegionBoundaryConfig (G := torusGraph width height) T R)
+    (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R) :
+    regionBlockedWeight (G := torusGraph width height) T (Region.map (translate a b) R)
+        (tiBoundaryConfigMap T hT a b R bdry)
+        (regionPhysicalConfigMap (translate a b) R τ) =
+      regionBlockedWeight (G := torusGraph width height) T R bdry τ := by
+  have h1 := regionBlockedWeight_congrTensor (hT a b) (Region.map (translate a b) R)
+    (regionBoundaryConfigMap T (translate a b) R bdry)
+    (regionPhysicalConfigMap (translate a b) R τ)
+  have h2 := regionBlockedWeight_transport T (translate a b) R bdry τ
+  exact h1.symm.trans h2
+
+/-! ### Covariance of the surviving boundary gauge -/
+
+/-- **Translation covariance of the surviving boundary gauge.**
+
+For a translation-covariant gauge family, the surviving boundary gauge of the translated region
+at the translated boundary edge is the surviving boundary gauge of the original region carried
+across the bond-dimension equality: the endpoint-order flip of the translation and the membership
+flip of the translated region cancel.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1498 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBoundaryGauge_translate {B : Tensor (torusGraph width height) d}
+    {X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ}
+    (hX : IsTranslationCovariantGaugeFamily B X)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (f : {f : Edge (torusGraph width height) //
+      IsRegionBoundaryEdge (G := torusGraph width height) R f})
+    (h : B.bondDim f.1 = B.bondDim (boundaryEdgeMap (translate a b) R f).1) :
+    regionBoundaryGauge (G := torusGraph width height) B X (Region.map (translate a b) R)
+        (boundaryEdgeMap (translate a b) R f) =
+      Matrix.reindexAlgEquiv ℂ ℂ (finCongr h)
+        (regionBoundaryGauge (G := torusGraph width height) B X R f) := by
+  classical
+  have hGL : X (boundaryEdgeMap (translate a b) R f).1 =
+      if (boundaryEdgeMap (translate a b) R f).1.1.1 = translate a b f.1.1.1 then
+        glReindex h (X f.1)
+      else glReindex h ((glTranspose (X f.1))⁻¹) := hX a b f.1 h
+  have hne : f.1.1.1 ≠ f.1.1.2 := ne_of_lt f.1.2.1
+  have hor := boundaryEdgeMap_translate_fst_or R f a b
+  rw [regionBoundaryGauge, regionBoundaryGauge]
+  rcases hor with hfst | hfst
+  · -- The translation preserves the stored endpoint order.
+    rw [if_pos hfst] at hGL
+    have hmem : (boundaryEdgeMap (translate a b) R f).1.1.1 ∈ Region.map (translate a b) R ↔
+        f.1.1.1 ∈ R := by
+      rw [hfst]
+      exact mem_Region_map_apply (translate a b) R f.1.1.1
+    by_cases hPf : f.1.1.1 ∈ R
+    · rw [if_pos (hmem.mpr hPf), if_pos hPf, hGL, glReindex_coe]
+    · have hX' : (X (boundaryEdgeMap (translate a b) R f).1)⁻¹ =
+          glReindex h ((X f.1)⁻¹) := by
+        rw [hGL]
+        exact (map_inv (glReindex h) (X f.1)).symm
+      rw [if_neg (fun hcon => hPf (hmem.mp hcon)), if_neg hPf, hX', glReindex_coe,
+        reindexAlgEquiv_transpose]
+  · -- The translation swaps the stored endpoint order.
+    have hQ : ¬((boundaryEdgeMap (translate a b) R f).1.1.1 = translate a b f.1.1.1) := by
+      rw [hfst]
+      intro hcon
+      exact hne ((translate a b).toEquiv.injective hcon).symm
+    rw [if_neg hQ] at hGL
+    have hmem : (boundaryEdgeMap (translate a b) R f).1.1.1 ∈ Region.map (translate a b) R ↔
+        f.1.1.2 ∈ R := by
+      rw [hfst]
+      exact mem_Region_map_apply (translate a b) R f.1.1.2
+    have hexcl : (f.1.1.1 ∈ R ∧ f.1.1.2 ∉ R) ∨ (f.1.1.1 ∉ R ∧ f.1.1.2 ∈ R) := f.2
+    by_cases hPf : f.1.1.1 ∈ R
+    · -- First endpoint in: the translated first endpoint is the second, hence outside.
+      have hv : f.1.1.2 ∉ R := by
+        rcases hexcl with ⟨_, hv⟩ | ⟨hcon, _⟩
+        · exact hv
+        · exact absurd hPf hcon
+      have hX' : (X (boundaryEdgeMap (translate a b) R f).1)⁻¹ =
+          glReindex h (glTranspose (X f.1)) := by
+        rw [hGL, (map_inv (glReindex h) ((glTranspose (X f.1))⁻¹)).symm]
+        exact congrArg (glReindex h) (inv_inv (glTranspose (X f.1)))
+      rw [if_neg (fun hcon => hv (hmem.mp hcon)), if_pos hPf, hX',
+        glReindex_coe, glTranspose_coe, reindexAlgEquiv_transpose, Matrix.transpose_transpose]
+    · have hv : f.1.1.2 ∈ R := by
+        rcases hexcl with ⟨hcon, _⟩ | ⟨_, hv⟩
+        · exact absurd hcon hPf
+        · exact hv
+      rw [if_pos (hmem.mpr hv), if_neg hPf, hGL, glReindex_coe, glTranspose_inv_coe]
+
+/-! ### Covariance of the gauge-absorbed blocked weight -/
+
+/-- **Translation covariance of the gauge-absorbed blocked weight.**
+
+For a translation-invariant second tensor and a translation-covariant gauge family, the blocked
+weight of the gauge-absorbed tensor at the translated region, read at the transported boundary
+and physical configurations, equals the blocked weight at the original region.  The gauge
+factorization (`regionBlockedWeight_applyGauge`) reduces both sides to the boundary coupling
+against the blocked weights of the bare second tensor; the coupling is covariant edgewise
+(`regionBoundaryGauge_translate`) and the bare weights are covariant by translation invariance.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_applyGauge_translate {B : Tensor (torusGraph width height) d}
+    (hB : IsTorusTranslationInvariant B)
+    {X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ}
+    (hX : IsTranslationCovariantGaugeFamily B X)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (bdry : RegionBoundaryConfig (G := torusGraph width height) B R)
+    (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R) :
+    regionBlockedWeight (G := torusGraph width height) (applyGauge B X)
+        (Region.map (translate a b) R) (tiBoundaryConfigMap B hB a b R bdry)
+        (regionPhysicalConfigMap (translate a b) R τ) =
+      regionBlockedWeight (G := torusGraph width height) (applyGauge B X) R bdry τ := by
+  classical
+  rw [regionBlockedWeight_applyGauge (G := torusGraph width height) B X
+      (Region.map (translate a b) R) (tiBoundaryConfigMap B hB a b R bdry)
+      (regionPhysicalConfigMap (translate a b) R τ),
+    regionBlockedWeight_applyGauge (G := torusGraph width height) B X R bdry τ]
+  rw [← Equiv.sum_comp (tiBoundaryConfigEquiv B hB a b R)]
+  refine Finset.sum_congr rfl (fun bdry' _ => ?_)
+  simp only [tiBoundaryConfigEquiv_apply]
+  rw [regionBlockedWeight_tiBoundaryConfigMap B hB a b R bdry' τ]
+  congr 1
+  -- Reindex the boundary-edge product through the geometric boundary-edge bijection.
+  rw [← Equiv.prod_comp (regionBoundaryEdgeMapEquiv (translate a b) R).symm]
+  refine Finset.prod_congr rfl (fun f _ => ?_)
+  -- The per-edge coupling entries match across the bond-dimension casts.
+  have hcastB := tiBoundaryConfigMap_boundaryEdgeMap B hB a b R bdry f
+  have hcastB' := tiBoundaryConfigMap_boundaryEdgeMap B hB a b R bdry' f
+  have hK := regionBoundaryGauge_translate hX a b R f
+    (bondDim_boundaryEdgeMap_translate hB a b R f).symm
+  rw [show (regionBoundaryEdgeMapEquiv (translate a b) R).symm f =
+    boundaryEdgeMap (translate a b) R f from rfl]
+  rw [hcastB, hcastB', hK]
+  exact reindexAlgEquiv_apply_cast
+    (bondDim_boundaryEdgeMap_translate hB a b R f).symm _ (bdry f) (bdry' f)
+
+/-! ### Translation transport of the region-block scalar proportionality -/
+
+/-- **Translation covariance of the reindexed gauge-absorbed blocked weight.**
+
+The blocked weight of the gauge-absorbed second tensor, transported to the first tensor's
+bonds, at the translated region and the transported configurations, equals the blocked weight
+at the original region.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem regionBlockedWeight_reindexTensor_translate {A B : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    {X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ}
+    (hX : IsTranslationCovariantGaugeFamily B X)
+    (hbd : A.bondDim = B.bondDim)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height))
+    (bdry : RegionBoundaryConfig (G := torusGraph width height) A R)
+    (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R) :
+    regionBlockedWeight (G := torusGraph width height)
+        (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd)
+        (Region.map (translate a b) R) (tiBoundaryConfigMap A hA a b R bdry)
+        (regionPhysicalConfigMap (translate a b) R τ) =
+      regionBlockedWeight (G := torusGraph width height)
+        (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd) R bdry τ := by
+  have hswap : (fun f => (Fin.cast (congr_fun hbd f.1)
+      (tiBoundaryConfigMap A hA a b R bdry f) :
+        Fin ((applyGauge B X).bondDim f.1))) =
+      tiBoundaryConfigMap B hB a b R (fun f => Fin.cast (congr_fun hbd f.1) (bdry f)) := by
+    funext f
+    apply Fin.eq_of_val_eq
+    simp [tiBoundaryConfigMap, regionBoundaryConfigMap]
+  have h1 := regionBlockedWeight_reindexTensor (G := torusGraph width height)
+    (applyGauge B X) hbd (Region.map (translate a b) R)
+    (tiBoundaryConfigMap A hA a b R bdry) (regionPhysicalConfigMap (translate a b) R τ)
+  have h3 := regionBlockedWeight_applyGauge_translate hB hX a b R
+    (fun f => Fin.cast (congr_fun hbd f.1) (bdry f)) τ
+  have h4 := regionBlockedWeight_reindexTensor (G := torusGraph width height)
+    (applyGauge B X) hbd R bdry τ
+  exact (h1.trans ((congrArg (fun β => regionBlockedWeight (G := torusGraph width height)
+    (applyGauge B X) (Region.map (translate a b) R) β
+    (regionPhysicalConfigMap (translate a b) R τ)) hswap).trans h3)).trans h4.symm
+
+/-- **The region-block proportionality scalar is translation invariant.**
+
+For translation-invariant `A`, `B` and a translation-covariant gauge family `X`, a scalar
+proportionality of the region blocks of `A` against the reindexed gauge-absorbed tensor over `R`
+transports to the translated region `Region.map (translate a b) R` with the *same* scalar.
+
+This is the translation step pinning the single `λ` of Theorem 3: the comparison scalar read at
+any translate of the comparison region is the scalar at the reference position.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1544--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem twoBlockScalarProportional_translate {A B : Tensor (torusGraph width height) d}
+    (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
+    {X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ}
+    (hX : IsTranslationCovariantGaugeFamily B X)
+    (hbd : A.bondDim = B.bondDim)
+    (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height)) {c : ℂ}
+    (hprop : TwoBlockScalarProportional (regionTwoBlock (G := torusGraph width height) A R)
+      (regionTwoBlock (G := torusGraph width height)
+        (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd) R) c) :
+    TwoBlockScalarProportional
+      (regionTwoBlock (G := torusGraph width height) A (Region.map (translate a b) R))
+      (regionTwoBlock (G := torusGraph width height)
+        (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd)
+        (Region.map (translate a b) R)) c := by
+  intro u bdry' τ'
+  obtain ⟨bdry, rfl⟩ := tiBoundaryConfigMap_surjective A hA a b R bdry'
+  obtain ⟨τ, rfl⟩ := regionPhysicalConfigMap_surjective (d := d) (translate a b) R τ'
+  simp only [regionTwoBlock_apply]
+  rw [regionBlockedWeight_tiBoundaryConfigMap A hA a b R bdry τ,
+    regionBlockedWeight_reindexTensor_translate hA hB hX hbd a b R bdry τ]
+  exact hprop PUnit.unit bdry τ
+
+end Torus
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusGaugedWeightCovariance.lean
+++ b/TNLean/PEPS/TorusGaugedWeightCovariance.lean
@@ -348,10 +348,11 @@ theorem twoBlockScalarProportional_translate {A B : Tensor (torusGraph width hei
     (hX : IsTranslationCovariantGaugeFamily B X)
     (hbd : A.bondDim = B.bondDim)
     (a : ZMod width) (b : ZMod height) (R : Finset (TorusVertex width height)) {c : ℂ}
-    (hprop : TwoBlockScalarProportional (regionTwoBlock (G := torusGraph width height) A R)
+    (hprop : TwoBlockScalarProportional.{0, 0, 0, 0}
+      (regionTwoBlock (G := torusGraph width height) A R)
       (regionTwoBlock (G := torusGraph width height)
         (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd) R) c) :
-    TwoBlockScalarProportional
+    TwoBlockScalarProportional.{0, 0, 0, 0}
       (regionTwoBlock (G := torusGraph width height) A (Region.map (translate a b) R))
       (regionTwoBlock (G := torusGraph width height)
         (reindexTensor (G := torusGraph width height) (applyGauge B X) hbd)

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -5220,7 +5220,6 @@ injective and normal PEPS, following Theorems~2 and~3 of
 
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus]%
     \label{thm:fundamentalTheorem_normalTorusPEPS}
-    \lean{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS}
     \notready
     \uses{thm:fundamentalTheorem_normalSquarePEPS,
         thm:peps_oneVertexComplementComparison,
@@ -5229,16 +5228,66 @@ injective and normal PEPS, following Theorems~2 and~3 of
     torus such that every $2\times 3$ and $3\times 2$ region is injective. If
     they generate the same state on an $n\times m$ region with $n,m\geq 7$, then
     they are related by horizontal and vertical gauges $X,Y$, up to a scalar
-    $\lambda$ satisfying $\lambda^{nm}=1$. This is
+    $\lambda$ satisfying $\lambda^{nm}=1$, and $X$ and $Y$ are unique up to a
+    multiplicative constant. This is
     \cite[Theorem~3]{Molnar2018NormalPEPS} on the torus geometry, where every
     edge is interior and translation acts freely.
-    The horizontal and vertical gauge family is produced unconditionally from the
-    rectangle injectivity hypotheses. The Lean statement records the per-vertex
-    single-scalar relation against that family --- the output of the final region
-    comparison $A\propto\widetilde B$ --- as a hypothesis, exactly as the
-    square-lattice statement does, and derives the scalar condition
-    $\lambda^{nm}=1$ on top of it. The nonvanishing state coefficient is supplied
-    by region injectivity of a single comparison region, not vertex injectivity.
+    Theorem~\ref{thm:fundamentalTheorem_normalTorusPEPS_unconditional} proves
+    this with the torus large enough to host the two reference rectangles
+    ($n,m\geq 9$) and with the gauge family described by its translation
+    covariance; the present source-exact entry awaits the $n,m\geq 7$ sizes and
+    the uniqueness of $X$ and $Y$ up to a multiplicative constant.
+\end{theorem}
+
+\begin{theorem}[Fundamental Theorem for normal PEPS on the torus,
+    translation-covariant form]%
+    \label{thm:fundamentalTheorem_normalTorusPEPS_unconditional}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}
+    \leanok
+    \uses{thm:fundamentalTheorem_normalSquarePEPS,
+        thm:peps_oneVertexComplementComparison,
+        def:GaugeEquivPEPS}
+    Let $A$ and $B$ be translationally invariant PEPS tensors on the discrete
+    $n\times m$ torus with $n,m\geq 9$, with positive physical dimension, equal
+    and positive bond dimensions,
+    generating the same state, and such that every contiguous $2\times 3$ and
+    $3\times 2$ coordinate rectangle of either tensor is injective. Then there
+    are a family of invertible matrices, one on each edge, carried onto each
+    edge by the torus translations from a single matrix on a reference
+    horizontal edge and a single matrix on a reference vertical edge, and a
+    single scalar $\lambda$ with $\lambda^{nm}=1$, such that at every site the
+    tensor $A$ equals $\lambda$ times the gauge action of the family on $B$.
+    The family also realizes the absorbed inserted-coefficient equality at
+    every edge: inserting any matrix on an edge of $A$ gives the same
+    coefficient as inserting it on the corresponding edge of the gauge-absorbed
+    $B$.
+    This is \cite[Theorem~3]{Molnar2018NormalPEPS} on the torus with the sizes
+    enlarged to $n,m\geq 9$ and the horizontal and vertical gauges $X$, $Y$
+    described by translation covariance: the stored orientation of a
+    wraparound edge is reversed, so on the seam the family carries the
+    transposed inverse of the class matrix, and a family that is literally one
+    matrix per orientation class cannot realize the absorbed equality there.
+    The uniqueness of $X$ and $Y$ up to a multiplicative constant is not part
+    of this statement.
+    \begin{proof}
+        \leanok
+        \uses{lem:peps_injectiveRegion_union_pos}
+        The union closure of injective regions follows from the positive bond
+        dimensions and Lemma~\ref{lem:peps_injectiveRegion_union_pos}. The
+        coherent blocking frames at every edge produce per-edge gauges, whose
+        absorption into $B$ gives the absorbed inserted-coefficient equality at
+        every edge; the absorbing family is built by transporting one reference
+        gauge per orientation class, so it commutes with the torus
+        translations. A gauge preserves blocked-region linear independence, so
+        the region comparison applies to the gauge-absorbed tensor: comparing
+        the corner region with its one-site completion yields two
+        proportionality scalars, translation covariance transports the
+        comparison to every site with the same scalars, and the inserted-site
+        extraction gives the per-vertex relation with the single ratio
+        $\lambda = c_S/c_R$. The product of the per-vertex relations over the
+        torus against the invariance of the closed state forces
+        $\lambda^{nm}=1$.
+    \end{proof}
 \end{theorem}
 
 \begin{definition}[Normal PEPS blocking hypotheses]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2233,6 +2233,47 @@ coherent coarse blocking frames the source's edge geometry supplies. What remain
 the general theorem is constructing those frames at every edge from the source's
 finite-lattice blocking, the geometry obligation recorded earlier in this note.
 
+\section*{Closure on the torus: the unconditional theorem}
+
+The geometry obligation is discharged on the discrete torus. The coherent frames are
+instantiated at every edge from the contiguous-rectangle injectivity hypotheses, and
+the per-edge gauges are absorbed into the second tensor, giving the bare-edge absorbed
+inserted-coefficient equality at every torus edge. Three further steps complete the
+assembly. First, a gauge preserves blocked-region linear independence
+(\path{regionBlockedTensorInjective_applyGauge}): the gauged blocked weights are the
+original weights mixed by an invertible boundary coupling, the product over the
+boundary edges of the surviving endpoint gauges. Second, the absorbing family is
+constructed covariantly: each edge carries the transported reference gauge of its
+orientation class, so the family commutes with the torus translations
+(\path{exists_torusCovariantAbsorbedGaugeFamily}). Third, translation covariance
+transports the corner-region comparison to every site with the same proportionality
+scalars (\path{twoBlockScalarProportional_translate}), so the inserted-site extraction
+yields one ratio $\lambda = c_S/c_R$ at every vertex. The result is the unconditional
+torus theorem (\path{fundamentalTheorem_normalTorusPEPS_unconditional}): from
+translation invariance, matched positive bond dimensions, the same state, and the
+rectangle injectivity hypotheses alone, there are a translation-covariant gauge family
+and a single scalar $\lambda$ with $A_v = \lambda\cdot(\text{gauge action of } B)_v$ at
+every site and $\lambda^{nm}=1$. The union closure of injective regions is derived
+from the positive bond dimensions, not assumed.
+
+One convention finding accompanies the closure. The ordered-edge normal form stores a
+wraparound edge with its endpoints swapped, so the absorbing family carries the
+transposed inverse of the class matrix on the seam edges. A family that is one matrix
+per orientation class up to scalars in the stored convention cannot satisfy the
+absorbed equality at the seam (it would force $Z^{\mathsf T}$ proportional to
+$Z^{-1}$), so the lexicographic uniform-up-to-scalar predicate misstates the source's
+``same matrix on all horizontal (vertical) edges'' on the torus; translation
+covariance is the orientation-faithful form. The earlier conditional torus statement,
+whose per-vertex hypothesis is phrased against a lexicographically uniform family, is
+unsatisfiable at seam edges in general and is superseded.
+
+What remains against the source statement of Theorem~3: the torus sizes are
+$n,m\geq 9$ (large enough to host the two reference rectangles) where the source
+states $n,m\geq 7$; the uniqueness of $X$ and $Y$ up to a multiplicative constant is
+not yet formalized; and the source's square-lattice region form of the theorem is
+covered separately by the conditional square-lattice statement recorded earlier in
+this note.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## Summary

Closes the assembly of the translation-invariant normal PEPS Fundamental Theorem on the torus (#1373; arXiv:1804.04964, Section 3, Theorem 3, lines 1449–1471 of `Papers/1804.04964/paper_normal.tex`):

- **`fundamentalTheorem_normalTorusPEPS_unconditional`** (`TorusFundamentalTheorem2.lean`): from translation invariance, equal and positive bond dimensions, positive physical dimension, the same state, and the contiguous 2×3 / 3×2 rectangle injectivity hypotheses alone — no per-vertex hypothesis, no supplied comparison region — there are a translation-covariant per-edge gauge family `X` realizing the bare-edge absorbed equality at every edge, and a **single scalar λ** with `A_v = λ · (gauge action of B at v)` at every torus vertex and `λ^{width·height} = 1`. The union closure of injective regions is derived from positive bonds (`regionInjectivityUnionClosure_of_overlap`), not assumed.

Supporting chain (new files):

- `TorusAbsorbedCovariance.lean` — translation covariance of the orientation-adapted absorbing gauge; edge translation rigidity (`torusRightEdge_injective`, `translate_param_unique_right`).
- `TorusCovariantAbsorbedFamily.lean` — `exists_torusCovariantAbsorbedGaugeFamily`: the absorbing family built by transporting one reference gauge per orientation class, hence `IsTranslationCovariantGaugeFamily B X`, with the absorbed equality at every edge.
- `TorusGaugedWeightCovariance.lean` — `regionBlockedWeight_applyGauge_translate` and `twoBlockScalarProportional_translate`: the comparison scalar is the same at every translate.
- `RegionBlock/ReindexInjectivity.lean` — a bond-dimension reindex preserves blocked-region injectivity.
- `TorusCornerRegion.lean` — the corner comparison region (3×3 square minus its corner) and its insert-completion, with the four A-side and four B-side injectivity facts derived from the rectangle hypotheses and union closure; B's side lifted through `regionBlockedTensorInjective_applyGauge`.

## Structural finding (documented in the route note and docstrings)

The conclusion is phrased by translation covariance rather than the lex-uniform `IsTorusOrientationUniformGaugeFamilyModScalar`: the ordered-edge normal form stores a wraparound edge with swapped endpoints, so the absorbing family carries the transposed inverse of the class matrix on seam edges; a lex-uniform-mod-scalar family cannot realize the absorbed equality there (it would force `Zᵀ ∝ Z⁻¹`). Translation covariance is the orientation-faithful form of the source's "same matrix on all horizontal (vertical) edges".

## Blueprint (faithfulness rule applied)

- The source-labelled `thm:fundamentalTheorem_normalTorusPEPS` entry now states the full source theorem (including the X, Y uniqueness clause), carries no `\lean{}` tag, and stays `\notready`: the source-exact sizes (n,m ≥ 7) and the uniqueness clause are not yet formalized.
- A new scope-restricted sibling entry `thm:fundamentalTheorem_normalTorusPEPS_unconditional` states exactly the Lean theorem (n,m ≥ 9, translation-covariant family, no uniqueness clause) with statement and proof `\leanok`.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex` gains the closure section and the seam-orientation finding.

## Verification

- Full root `lake build` green (8887 jobs); `lake exe lint-style` clean.
- `#print axioms` (re-verified independently after the agent run, and again after the union-closure edit):
  - `fundamentalTheorem_normalTorusPEPS_unconditional` → `[propext, Classical.choice, Quot.sound]`
  - `exists_torusCovariantAbsorbedGaugeFamily` → `[propext, Classical.choice, Quot.sound]`
- No `sorry`/`axiom`/`admit`/`native_decide`/`maxHeartbeats`. No modifications to existing Lean files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new formal proof surface (~1.4k lines) in core PEPS torus FT assembly; mathematical risk is moderate (no auth/data), but regressions would show as build failures rather than silent behavior changes.
> 
> **Overview**
> Adds the **unconditional** torus normal PEPS Fundamental Theorem (`fundamentalTheorem_normalTorusPEPS_unconditional` in `TorusFundamentalTheorem2.lean`): from translation invariance, matched positive bonds, same state, and 2×3 / 3×2 rectangle injectivity alone (union closure derived from positive bonds), it builds a **translation-covariant** per-edge gauge with bare-edge absorbed equality at every edge, a **single** λ with `A_v = λ · (gauge action of B)_v` everywhere, and `λ^{width·height} = 1` — without the conditional per-vertex hypothesis of `fundamentalTheorem_normalTorusPEPS`.
> 
> The proof chain is new Lean only plus root imports: covariant absorbed gauges (`TorusAbsorbedCovariance`, `TorusCovariantAbsorbedFamily`), gauge-absorbed blocked-weight / comparison-scalar transport (`TorusGaugedWeightCovariance`), corner comparison region injectivity (`TorusCornerRegion`), and reindex injectivity (`RegionBlock/ReindexInjectivity`).
> 
> Blueprint splits the source-exact torus theorem (still `\notready`, no `\lean{}`, includes gauge uniqueness) from a **`\leanok`** sibling for the formalized translation-covariant statement (larger torus sizes n,m ≥ 9, no uniqueness). The route note documents torus closure and the seam-orientation finding (lex-uniform gauge predicate vs translation covariance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf0b7e1513fd27f3d962aec24fc2a498830231f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->