### PR TITLE
feat(MPS/ParentHamiltonian): specialize last crossing coefficients

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -21,6 +21,18 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+/-- The complementary word for the cyclic window of length `m+2` beginning at
+site `M` in a chain of length `M+1`.
+
+For an outside configuration `τ`, this is
+\[
+  \rho=\tau_{m+1}\cdots\tau_{M-1}.
+\] -/
+def lastCrossingComplementWord {m M : ℕ} (hLen : m + 2 ≤ M + 1)
+    (τ : Fin (M + 1) → Fin d) : List (Fin d) :=
+  List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
+    τ ⟨k.val + (m + 1), by omega⟩
+
 /-- At the cyclic window beginning at the last site, the block-diagonal local
 sum has the left-boundary trace form used in the blockwise coefficient
 comparison.
@@ -57,17 +69,15 @@ theorem blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents
       ∑ j : Fin r,
         pgvwc07LeftBoundaryComponent (A j)
           (fun a : Fin d =>
-            evalWord (A j) (List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
-              τ ⟨k.val + (m + 1), by omega⟩) *
-              A j a * ((μ j) ^ (M + 1) • X j))
+            evalWord (A j) (lastCrossingComplementWord hLen τ) * A j a *
+              ((μ j) ^ (M + 1) • X j))
           m := by
   classical
   ext σ
   simp only [Finset.sum_apply]
   refine Finset.sum_congr rfl ?_
   intro j _
-  let middleWord : List (Fin d) := List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
-    τ ⟨k.val + (m + 1), by omega⟩
+  let middleWord : List (Fin d) := lastCrossingComplementWord hLen τ
   let W : Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
     evalWord (A j) (List.ofFn (Fin.tail (Fin.init σ)))
   let b : Fin d := σ (Fin.last (m + 1))
@@ -149,16 +159,14 @@ theorem blockDiagonal_boundary_last_coefficients_of_sum_mem_iSup
     ∃ E : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
       ∀ j : Fin r, ∀ a b : Fin d,
         A j b *
-            (evalWord (A j) (List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
-                τ ⟨k.val + (m + 1), by omega⟩) *
-              A j a * ((μ j) ^ (M + 1) • X j)) =
+            (evalWord (A j) (lastCrossingComplementWord hLen τ) * A j a *
+              ((μ j) ^ (M + 1) • X j)) =
           A j b * E j * A j a := by
   classical
   let C : (j : Fin r) → Fin d → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
     fun j a =>
-      evalWord (A j) (List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
-        τ ⟨k.val + (m + 1), by omega⟩) *
-        A j a * ((μ j) ^ (M + 1) • X j)
+      evalWord (A j) (lastCrossingComplementWord hLen τ) * A j a *
+        ((μ j) ^ (M + 1) • X j)
   let ψ : NSiteSpace d (m + 2) :=
     ∑ j : Fin r,
       cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
@@ -205,9 +213,8 @@ theorem blockDiagonal_boundary_last_coefficients_of_blockDiagonal_chainGroundSpa
     ∃ E : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
       ∀ j : Fin r, ∀ a b : Fin d,
         A j b *
-            (evalWord (A j) (List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
-                τ ⟨k.val + (m + 1), by omega⟩) *
-              A j a * ((μ j) ^ (M + 1) • X j)) =
+            (evalWord (A j) (lastCrossingComplementWord hLen τ) * A j a *
+              ((μ j) ^ (M + 1) • X j)) =
           A j b * E j * A j a := by
   have hmem :=
     blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
 import TNLean.MPS.ParentHamiltonian.BlockStrip
+import TNLean.MPS.ParentHamiltonian.WrappingWindow
 
 /-!
 # Boundary-crossing cyclic interval equations for block-diagonal parent spaces
@@ -19,6 +20,200 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d : ℕ}
+
+/-- At the cyclic window beginning at the last site, the block-diagonal local
+sum has the left-boundary trace form used in the blockwise coefficient
+comparison.
+
+Let the total chain have length \(M+1\), and let the local window have length
+\(m+2\). The cyclic window beginning at \(M\) consists of the last site followed
+by the first \(m+1\) sites. If the complementary word is
+\[
+  \rho=\tau_{m+1}\cdots\tau_{M-1},
+\]
+then the \(j\)-th summand has coefficients
+\[
+  \operatorname{tr}\!\left(
+    A^j_b\, A^j_\rho A^j_a\,(\mu_j^{M+1}X_j)\, A^j_w
+  \right),
+\]
+where the local word is \(a w b\). Thus the block sum is the sum of
+left-boundary components with
+\[
+  C^j_a=A^j_\rho A^j_a\,(\mu_j^{M+1}X_j).
+\]
+This is the boundary-crossing cyclic specialization of the two trace
+decompositions in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines
+1436--1452. -/
+theorem blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {m M : ℕ} (hLen : m + 2 ≤ M + 1)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (τ : Fin (M + 1) → Fin d) :
+    (∑ j : Fin r,
+        cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
+          (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j))) =
+      ∑ j : Fin r,
+        pgvwc07LeftBoundaryComponent (A j)
+          (fun a : Fin d =>
+            evalWord (A j) (List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
+              τ ⟨k.val + (m + 1), by omega⟩) *
+              A j a * ((μ j) ^ (M + 1) • X j))
+          m := by
+  classical
+  ext σ
+  simp only [Finset.sum_apply]
+  refine Finset.sum_congr rfl ?_
+  intro j _
+  let middleWord : List (Fin d) := List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
+    τ ⟨k.val + (m + 1), by omega⟩
+  let W : Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    evalWord (A j) (List.ofFn (Fin.tail (Fin.init σ)))
+  let b : Fin d := σ (Fin.last (m + 1))
+  let a : Fin d := σ 0
+  let Xj : Matrix (Fin (dim j)) (Fin (dim j)) ℂ := (μ j) ^ (M + 1) • X j
+  have htail :
+      (Fin.tail σ : Fin (m + 1) → Fin d) =
+        Fin.snoc (Fin.tail (Fin.init σ)) b := by
+    have hinit : Fin.init (Fin.tail σ) = Fin.tail (Fin.init σ) := by
+      ext k
+      rfl
+    have hlast : (Fin.tail σ) (Fin.last m) = b := by
+      rfl
+    calc
+      Fin.tail σ = Fin.snoc (Fin.init (Fin.tail σ)) ((Fin.tail σ) (Fin.last m)) :=
+        (Fin.snoc_init_self (Fin.tail σ)).symm
+      _ = Fin.snoc (Fin.tail (Fin.init σ)) b := by rw [hinit, hlast]
+  have hEvalTail :
+      evalWord (A j) (List.ofFn (Fin.tail σ)) = W * A j b := by
+    rw [htail, evalWord_ofFn_snoc]
+  simp only [cyclicRestrictₗ_apply, groundSpaceMap_apply,
+    pgvwc07LeftBoundaryComponent]
+  rw [evalWord_cyclicCfg_snoc (A := A j) (M := M) (L := m + 2)
+    (by omega : 1 ≤ M) hLen (by omega : 1 < m + 2) σ τ]
+  rw [init_evalWord_split (A := A j) (M := M) (L := m + 2)
+    (by omega : 1 ≤ M) hLen (by omega : 1 < m + 2) σ τ]
+  change
+    Matrix.trace
+        (((evalWord (A j) (List.ofFn (Fin.tail σ)) *
+              evalWord (A j) middleWord) *
+            A j a) * Xj) =
+      Matrix.trace (A j b *
+        (evalWord (A j) middleWord * A j a * Xj) * W)
+  rw [hEvalTail]
+  calc
+    Matrix.trace
+        (((W * A j b * evalWord (A j) middleWord) * A j a) * Xj)
+        =
+      Matrix.trace (W *
+        (((A j b * evalWord (A j) middleWord) * A j a) * Xj)) := by
+          simp [Matrix.mul_assoc]
+    _ =
+      Matrix.trace ((((A j b * evalWord (A j) middleWord) * A j a) * Xj) * W) :=
+        Matrix.trace_mul_comm _ _
+    _ =
+      Matrix.trace (A j b *
+        (evalWord (A j) middleWord * A j a * Xj) * W) := by
+          simp [Matrix.mul_assoc]
+
+/-- The last boundary-crossing window gives the blockwise coefficient identity
+from the local block-sum condition.
+
+Let the complementary word be
+\(\rho=\tau_{m+1}\cdots\tau_{M-1}\). Suppose that the block sum of the last
+crossing-window restrictions lies in
+\(\bigvee_jG_{m+2}(A^j)\), and that length-\(m\) simultaneous word tuples span
+the product algebra. Then there are matrices \(E_j\) such that
+\[
+  A^j_b\bigl(A^j_\rho A^j_a(\mu_j^{M+1}X_j)\bigr)
+    =A^j_bE_jA^j_a
+\]
+for every block \(j\) and all boundary letters \(a,b\).
+
+This is the direct cyclic-window instance of the coefficient comparison
+\(A_bC_a=A_bEA_a\) in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines
+1436--1452. -/
+theorem blockDiagonal_boundary_last_coefficients_of_sum_mem_iSup
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {m M : ℕ} (hLen : m + 2 ≤ M + 1)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (τ : Fin (M + 1) → Fin d)
+    (hSpan : WordTupleSpanTop A m)
+    (hmem :
+      (∑ j : Fin r,
+          cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
+            (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j))) ∈
+        ⨆ j : Fin r, groundSpace (A j) (m + 2)) :
+    ∃ E : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ∀ j : Fin r, ∀ a b : Fin d,
+        A j b *
+            (evalWord (A j) (List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
+                τ ⟨k.val + (m + 1), by omega⟩) *
+              A j a * ((μ j) ^ (M + 1) • X j)) =
+          A j b * E j * A j a := by
+  classical
+  let C : (j : Fin r) → Fin d → Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    fun j a =>
+      evalWord (A j) (List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
+        τ ⟨k.val + (m + 1), by omega⟩) *
+        A j a * ((μ j) ^ (M + 1) • X j)
+  let ψ : NSiteSpace d (m + 2) :=
+    ∑ j : Fin r,
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
+        (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j))
+  have hψ :
+      ψ = ∑ j : Fin r, pgvwc07LeftBoundaryComponent (A j) (C j) m := by
+    dsimp [ψ, C]
+    exact blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents
+      μ A hLen X τ
+  exact pgvwc07_boundary_identities_of_leftBoundaryComponent_mem_iSup
+    A hSpan C ψ hψ hmem
+
+/-- A block-diagonal chain vector supplies the local block-sum condition for the
+last boundary-crossing coefficient identity.
+
+Let \(B=\bigoplus_j\mu_jA^j\). If
+\[
+  \psi=\Gamma_{M+1}^{B}\!\left(\bigoplus_jX_j\right)
+  \quad\text{and}\quad
+  \psi\in\mathcal G_{M+1,m+2}(B),
+\]
+then the local constraint at the cyclic window beginning at \(M\), together
+with the length-\(m\) simultaneous product span, gives matrices \(E_j\) with
+\[
+  A^j_b\bigl(A^j_\rho A^j_a(\mu_j^{M+1}X_j)\bigr)
+    =A^j_bE_jA^j_a .
+\]
+Here \(\rho=\tau_{m+1}\cdots\tau_{M-1}\) is the complementary word determined
+by the outside configuration. -/
+theorem blockDiagonal_boundary_last_coefficients_of_blockDiagonal_chainGroundSpace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    {m M : ℕ} (hLen : m + 2 ≤ M + 1)
+    {ψ : NSiteSpace d (M + 1)}
+    (hψ : ψ ∈
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) (m + 2) (M + 1))
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hψX :
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) (M + 1)
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)))
+    (τ : Fin (M + 1) → Fin d)
+    (hSpan : WordTupleSpanTop A m) :
+    ∃ E : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ∀ j : Fin r, ∀ a b : Fin d,
+        A j b *
+            (evalWord (A j) (List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
+                τ ⟨k.val + (m + 1), by omega⟩) *
+              A j a * ((μ j) ^ (M + 1) • X j)) =
+          A j b * E j * A j a := by
+  have hmem :=
+    blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
+      μ A hμ (show 0 < M + 1 by omega) hLen hψ X hψX ⟨M, by omega⟩ τ
+  exact blockDiagonal_boundary_last_coefficients_of_sum_mem_iSup
+    μ A hLen X τ hSpan hmem
 
 /-- A boundary-crossing cyclic interval is local when the boundary matrix
 satisfies the displayed boundary identity.

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -131,7 +131,7 @@ then split `init` into window-tail and complement parts. -/
 
 /-- The evalWord of the cyclic config at position `M` (= `N-1`) on `M+1` sites
 decomposes as `evalWord(init) * A(σ_w(0))` where `init` covers sites `0..M-1`. -/
-private theorem evalWord_cyclicCfg_snoc {A : MPSTensor d D}
+theorem evalWord_cyclicCfg_snoc {A : MPSTensor d D}
     {M L : ℕ} (hM : 1 ≤ M) (hLN : L ≤ M + 1) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin (M + 1) → Fin d) :
     evalWord A (List.ofFn (cyclicCfg (by omega : 0 < M + 1) L ⟨M, by omega⟩ σ_w τ)) =
@@ -158,7 +158,7 @@ private theorem evalWord_cyclicCfg_snoc {A : MPSTensor d D}
 
 /-- The init part of the cyclic config at position M decomposes into
 tail (window sites 1..L-1) and complement (sites L-1..M-1). -/
-private theorem init_evalWord_split {A : MPSTensor d D}
+theorem init_evalWord_split {A : MPSTensor d D}
     {M L : ℕ} (hM : 1 ≤ M) (hLN : L ≤ M + 1) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin (M + 1) → Fin d) :
     evalWord A (List.ofFn (fun k : Fin M =>

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -129,7 +129,7 @@ private theorem cyclicCfg_complement_site {N L : ℕ} (hN : 2 ≤ N) (_hLN : L �
 Factor the full cyclic config product as `evalWord(init) * A(σ_w(0))`,
 then split `init` into window-tail and complement parts. -/
 
-/-- The evalWord of the cyclic config at position `M` (= `N-1`) on `M+1` sites
+/-- The evalWord of the cyclic config at position `M` on `M+1` sites
 decomposes as `evalWord(init) * A(σ_w(0))` where `init` covers sites `0..M-1`. -/
 theorem evalWord_cyclicCfg_snoc {A : MPSTensor d D}
     {M L : ℕ} (hM : 1 ≤ M) (hLN : L ≤ M + 1) (hL : 1 < L)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6967,7 +6967,8 @@ boundary-closing step concerns the separate assertion
     \leanok
     \uses{lem:block_diagonal_boundary_local_sum_mem,
         lem:block_diagonal_last_crossing_coefficients_from_sum_membership}
-    Let \(B=\bigoplus_j\mu_jA^j\). Suppose
+    Let \(B=\bigoplus_j\mu_jA^j\), and assume \(\mu_j\ne0\) for every block
+    \(j\). Suppose
     \[
         \psi=\Gamma_{M+1}^{B}\!\left(\bigoplus_jX_j\right),
         \qquad

--- a/blueprint/src/chapter/ch14_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian.tex
@@ -6874,6 +6874,132 @@ boundary-closing step concerns the separate assertion
     \(\alpha\beta\). Hence the restricted vector lies in \(G_L(A_j)\).
 \end{proof}
 
+\begin{lemma}[Last crossing-window trace form]
+    \label{lem:block_diagonal_last_crossing_trace_form}
+    \lean{MPSTensor.blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    Write \(N=M+1\) and let the local length be \(m+2\le M+1\). Consider the
+    cyclic interval beginning at the last site \(M\). For an outside
+    configuration \(\tau\), put
+    \[
+        \rho=\tau_{m+1}\cdots\tau_{M-1},
+        \qquad
+        C^j_a=A^j_\rho A^j_a(\mu_j^{M+1}X_j).
+    \]
+    Then the block sum of the last crossing-window restrictions has the
+    left-boundary trace form
+    \[
+        \sum_j
+        R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
+        =
+        \sum_j \Phi^j,
+        \qquad
+        \Phi^j(a,w,b)=\operatorname{tr}\!\left(A^j_b C^j_a A^j_w\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    The cyclic interval beginning at \(M\) reads the last site first and then
+    wraps to the sites \(0,\ldots,m\). Thus, for the local word \(awb\), the
+    full word in the trace is
+    \[
+        w\,b\,\rho\,a .
+    \]
+    Hence the \(j\)-th coefficient is
+    \[
+        \operatorname{tr}\!\left(A^j_wA^j_bA^j_\rho A^j_a
+        (\mu_j^{M+1}X_j)\right).
+    \]
+    Trace cyclicity rotates this to
+    \[
+        \operatorname{tr}\!\left(
+        A^j_bA^j_\rho A^j_a(\mu_j^{M+1}X_j)A^j_w\right),
+    \]
+    which is the displayed left-boundary trace form.
+\end{proof}
+
+\begin{lemma}[Last crossing-window coefficient comparison]
+    \label{lem:block_diagonal_last_crossing_coefficients_from_sum_membership}
+    \lean{MPSTensor.blockDiagonal_boundary_last_coefficients_of_sum_mem_iSup}
+    \leanok
+    \uses{lem:block_diagonal_last_crossing_trace_form,
+        lem:blockwise_boundary_identities_from_left_trace_membership}
+    In the setting of Lemma~\ref{lem:block_diagonal_last_crossing_trace_form},
+    assume that the length-\(m\) simultaneous word tuples span the product
+    algebra and that
+    \[
+        \sum_j
+        R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
+        \in \bigvee_j G_{m+2}(A^j).
+    \]
+    Then there are matrices \(E_j\) such that, for every block \(j\) and all
+    boundary letters \(a,b\),
+    \[
+        A^j_b\bigl(A^j_\rho A^j_a(\mu_j^{M+1}X_j)\bigr)
+        =
+        A^j_bE_jA^j_a .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_last_crossing_trace_form,
+        lem:blockwise_boundary_identities_from_left_trace_membership}
+    Lemma~\ref{lem:block_diagonal_last_crossing_trace_form} writes the local
+    block sum in the form
+    \[
+        \Phi(a,w,b)=
+        \sum_j\operatorname{tr}\!\left(A^j_bC^j_aA^j_w\right),
+        \qquad
+        C^j_a=A^j_\rho A^j_a(\mu_j^{M+1}X_j).
+    \]
+    Applying
+    Lemma~\ref{lem:blockwise_boundary_identities_from_left_trace_membership}
+    gives the displayed blockwise equations.
+\end{proof}
+
+\begin{lemma}[Last crossing-window coefficients from a block-diagonal chain vector]
+    \label{lem:block_diagonal_last_crossing_coefficients_from_chain_ground_space}
+    \lean{MPSTensor.blockDiagonal_boundary_last_coefficients_of_blockDiagonal_chainGroundSpace}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        lem:block_diagonal_last_crossing_coefficients_from_sum_membership}
+    Let \(B=\bigoplus_j\mu_jA^j\). Suppose
+    \[
+        \psi=\Gamma_{M+1}^{B}\!\left(\bigoplus_jX_j\right),
+        \qquad
+        \psi\in\mathcal G_{M+1,m+2}(B).
+    \]
+    Assume also that the length-\(m\) simultaneous word tuples span the product
+    algebra. Then, for every outside configuration \(\tau\), with
+    \(\rho=\tau_{m+1}\cdots\tau_{M-1}\), there are matrices \(E_j\) such that
+    \[
+        A^j_b\bigl(A^j_\rho A^j_a(\mu_j^{M+1}X_j)\bigr)
+        =
+        A^j_bE_jA^j_a
+    \]
+    for every block \(j\) and all boundary letters \(a,b\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        lem:block_diagonal_last_crossing_coefficients_from_sum_membership}
+    The local constraint of \(\psi\) at the cyclic interval beginning at \(M\)
+    gives
+    \[
+        \sum_j
+        R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
+        \in \bigvee_j G_{m+2}(A^j)
+    \]
+    by Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}. Applying
+    Lemma~\ref{lem:block_diagonal_last_crossing_coefficients_from_sum_membership}
+    gives the displayed equations.
+\end{proof}
+
 \begin{lemma}[Boundary-crossing intervals from a right boundary-matrix identity]
     \label{lem:block_diagonal_boundary_crossing_right_boundary_matrix}
     \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_boundary_identity}


### PR DESCRIPTION
## Summary

This PR specializes the Perez-Garcia--Verstraete--Wolf--Cirac coefficient comparison to the cyclic interval beginning at the last site of a periodic chain.

For a chain of length \(M+1\), local length \(m+2\), outside word
\[
  \rho=\tau_{m+1}\cdots\tau_{M-1},
\]
and block-diagonal boundary matrices \(X_j\), the new statements prove that the last crossing-window block sum has the left-boundary trace form
\[
  \sum_j R_{M,\tau}\bigl(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\bigr)
  =
  \sum_j \Phi^j,
  \qquad
  \Phi^j(a,w,b)=\operatorname{tr}(A^j_b C^j_a A^j_w),
\]
with
\[
  C^j_a=A^j_\rho A^j_a(\mu_j^{M+1}X_j).
\]
If this block sum lies in \(\bigvee_j G_{m+2}(A^j)\) and the length-\(m\) simultaneous word tuples span the product algebra, the coefficient comparison gives matrices \(E_j\) satisfying
\[
  A^j_b\bigl(A^j_\rho A^j_a(\mu_j^{M+1}X_j)\bigr)
  =
  A^j_bE_jA^j_a.
\]
A second theorem supplies the same conclusion when the local block-sum condition comes from a block-diagonal periodic chain vector
\[
  \psi=\Gamma_{M+1}^{\oplus_j\mu_jA^j}\!\left(\bigoplus_jX_j\right),
  \qquad
  \psi\in\mathcal G_{M+1,m+2}\!\left(\bigoplus_j\mu_jA^j\right).
\]

This is a source-faithful cyclic-window instance of the comparison around arXiv:quant-ph/0608197, Theorem 2blocks.2, lines 1436--1452. It does not yet close #2665: the remaining step is to turn this last-window coefficient identity into the right boundary-matrix identity needed for all crossing starts.

## Blueprint

Chapter 14 now records the three equation-level steps:

- last crossing-window trace form,
- coefficient comparison from local block-sum membership,
- coefficient comparison from a block-diagonal chain vector.

## Validation

- `lake env lean TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check`
- Generated `blueprint/lean_decls` with `python3 scripts/blueprint_lean_sync.py --update-lean-decls`; `lake exe checkdecls blueprint/lean_decls` reaches the generated list but currently fails on the existing PEPS declaration name `TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional` on `main`.

Refs #2665

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics additions and visibility changes to helper lemmas; no runtime, auth, or data paths.
> 
> **Overview**
> Formalizes the **last-site** boundary-crossing cyclic window for block-diagonal parent Hamiltonian spaces: a new complement word `lastCrossingComplementWord`, a trace proof that the last-window block sum equals left-boundary components, and two theorems deriving blockwise \(A^j_b C^j_a = A^j_b E_j A^j_a\) from local ground-space membership (directly or via a block-diagonal chain vector).
> 
> **WrappingWindow** exposes `evalWord_cyclicCfg_snoc` and `init_evalWord_split` (no longer `private`) so the crossing proof can reuse cyclic `evalWord` factorizations.
> 
> **Blueprint** chapter 14 adds three linked lemmas with `\lean` anchors matching the new theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f1216dfa5e30362a92dcddf59fb282a69c4c89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->