### PR TITLE
style(PEPS): replace torus docstring terminology

### DIFF
--- a/TNLean/PEPS/TorusLatticeGraph.lean
+++ b/TNLean/PEPS/TorusLatticeGraph.lean
@@ -21,8 +21,8 @@ every-edge blocking construction only reaches interior edges
 (`docs/paper-gaps/peps_normal_ft_section3_route.tex`, remaining obligation 4).
 The torus removes the boundary, so on it every edge is interior and the
 construction is complete (same note, remaining obligation 6). This file records
-the torus geometry natively; the bridge transferring the merged interior-edge
-blocking machinery from the open lattice onto the torus is a separate step.
+the torus geometry; the transport of the interior-edge blocking argument from
+the open lattice onto the torus is a separate step.
 
 The vertex coordinate ring `ZMod width` is finite and nontrivial exactly when
 `1 < width`, recorded as the instances `[NeZero width]` (finiteness) and
@@ -39,9 +39,9 @@ v.2.val)`, mirroring the open-lattice instance
 (`TNLean.PEPS.instLinearOrderSquareLatticeVertex`). As there, the
 `toDecidableEq` field is pinned to the canonical product decidable equality
 `instDecidableEqProd` rather than the comparison-derived one that
-`LinearOrder.lift'` would synthesize, so the geometry layer (which builds its
-data over the product decidable equality) and the gauge interface (which
-synthesizes a decidable equality from the linear order) meet definitionally.
+`LinearOrder.lift'` would synthesize, so the geometry constructions over the
+product decidable equality and the gauge constructions using the linear-order
+decidable equality agree definitionally.
 
 ## References
 

--- a/TNLean/PEPS/TorusTranslationInvariant.lean
+++ b/TNLean/PEPS/TorusTranslationInvariant.lean
@@ -19,7 +19,7 @@ dimension at any edge equals the bond dimension at every translate of that edge
 (`bondDim_translateEdge_of_translationInvariant`); since the translations act
 transitively on each orientation class — every horizontal edge is the translate of
 every other, and likewise for vertical edges — this is the constant-bond content
-that makes the reduction to one horizontal and one vertical matrix well typed.  The
+that makes the reduction to one horizontal and one vertical matrix well-defined.  The
 transitivity is supported by the normal-form characterization
 `isHorizontalTorusEdge_eq_rightEdge` writing each horizontal edge as the right edge
 of its left endpoint; the full orientation-class constancy
@@ -114,8 +114,8 @@ Each horizontal edge is the right edge of a well-defined left endpoint `p`, the
 edge with unordered endpoints `p` and `p + (1, 0)`.  The lexicographic order may
 place either of these first (the coordinate value wraps around the torus), so the
 left endpoint is read from whichever incidence carries the `+1` step.  This normal
-form is the bookkeeping that makes the translations act transitively on the
-horizontal class: translating the left endpoint of one horizontal edge to the left
+form gives the transitivity of the translation action on the horizontal class:
+translating the left endpoint of one horizontal edge to the left
 endpoint of another carries the whole edge across. -/
 
 /-- The horizontal torus edge with left endpoint `p`, i.e. the edge on the adjacent
@@ -233,7 +233,7 @@ The bond dimension of a translation-invariant tensor is `Dh` on every horizontal
 edge and `Dv` on every vertical edge, where `Dh` and `Dv` are read off at a
 reference edge of each class.  This is the torus analogue of
 `SquareLatticeUniformBondDim`, the constant-bond content that makes the reduction
-to one horizontal and one vertical matrix well typed.  The lattice has at least one
+to one horizontal and one vertical matrix well-defined.  The lattice has at least one
 edge of each orientation, so the reference dimensions exist. -/
 
 /-- The bond-dimension function of a tensor on the torus is **orientation uniform**


### PR DESCRIPTION
### Motivation
- Two violations of the banned-vocabulary table (`docs/prose_style.md` §2) appear in torus PEPS module docstrings introduced in #2608.
- `TNLean/PEPS/TorusLatticeGraph.lean`: "bridge" appears as infrastructure vocabulary, which is listed as banned in `docs/prose_style.md` §2.
- `TNLean/PEPS/TorusTranslationInvariant.lean`: "well typed" is type-theory jargon prohibited by the same table.

### Description
- `TNLean/PEPS/TorusLatticeGraph.lean`: rewrites the module intro to describe the transport of the interior-edge blocking argument from the open lattice to the torus; rewrites a nearby passage to describe the geometry and gauge constructions directly instead of "layers/interfaces meeting."
- `TNLean/PEPS/TorusTranslationInvariant.lean`: replaces "well typed" with "well-defined" in the `IsTorusTranslationInvariant` docstring; rewrites the horizontal-edge normal-form passage to state that the normal form gives transitivity of translations on the horizontal class.
- No executable Lean code or proofs are changed; all edits are restricted to comments and docstrings.

### Testing
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Targeted vocabulary scan of `TNLean/PEPS/TorusLatticeGraph.lean` and `TNLean/PEPS/TorusTranslationInvariant.lean`.
- No local Lean elaboration was run; the change is restricted to comments and docstrings. Relies on Lean CI (`lean_action_ci.yml`) to validate the build.

---
Closes #2610

> [!NOTE]
> **Low Risk**
> Comments and docstrings only; no executable Lean or proof changes.
>
> **Overview**
> **Documentation-only** edits to torus PEPS module and section docstrings so reader-facing prose matches project style (no Lean definitions or proofs changed).
>
> In `TorusLatticeGraph.lean`, the module intro now describes **transport** of the interior-edge blocking argument from the open lattice to the torus instead of bridge/merged-machinery wording, and the linear-order note frames **geometry vs gauge** constructions agreeing definitionally rather than "layers/interfaces meeting."
>
> In `TorusTranslationInvariant.lean`, **"well typed"** is replaced with **"well-defined"** for the horizontal/vertical matrix reduction, and the horizontal-edge normal-form blurb states that the normal form **gives transitivity** of translations on the horizontal class instead of bookkeeping-for-transitivity phrasing.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b4e3bcab2f2f0eca51d72262dbc06eb87a95802. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>