### PR TITLE
doc(PEPS): scope-restrict torus singleton datum

### DIFF
--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1608,6 +1608,20 @@ The remaining obligations are the following.
           \leanid{TNLean.PEPS.isCrossingEdge_singletonEdgeBlockingData},
           \leanid{TNLean.PEPS.torusHorizontalReferenceBlockingDatum}, and
           \leanid{TNLean.PEPS.torusVerticalReferenceBlockingDatum}.}
+          \textbf{Scope restriction (NormalTorusRectangleInjectivityHypotheses):}
+          this singleton datum is a vertex-injective specialization of
+          the normality hypothesis in Theorem~3 of arXiv:1804.04964, lines
+          1449--1452.  The source-faithful
+          torus reference datum uses the rectangular injectivity hypotheses
+          directly: the reference red and blue blocks are the two source
+          rectangles adjacent to the distinguished edge, and the complement is
+          the union of the surrounding bands and fillers.\footnote{
+          Formal declarations:
+          \leanid{TNLean.PEPS.torusHorizontalRectangleBlockingDatum},
+          \leanid{TNLean.PEPS.torusVerticalRectangleBlockingDatum},
+          \leanid{TNLean.PEPS.isCrossingEdge_torusHorizontalRectangleBlockingDatum},
+          and
+          \leanid{TNLean.PEPS.isCrossingEdge_torusVerticalRectangleBlockingDatum}.}
           The per-edge gauge interface applies verbatim on the torus (it is stated
           over a general finite ordered vertex set), and the orientation-uniform
           reduction is ported to the torus, so the assembly above a class-agreement


### PR DESCRIPTION
### Motivation

- The paper-gap note (`docs/paper-gaps/peps_normal_ft_section3_route.tex`) was updated in #2620 to record construction of `torusHorizontal/VerticalReferenceBlockingDatum`, but the singleton-datum paragraph did not classify the construction as a scope restriction relative to Theorem 3 of arXiv:1804.04964 (lines 1407–1452, hypothesis `NormalTorusRectangleInjectivityHypotheses`).
- Per project conventions (CLAUDE.md §"Locally-fixable deviations"), a scope restriction must carry a `**Scope restriction (...):**` marker and reference the paper-gap document. The prior text read as a completed route step when it is a vertex-injective specialization of the rectangle normality hypothesis.
- Continues follow-up from #2620 and tracking issue #1373.

### Description

- Modified `docs/paper-gaps/peps_normal_ft_section3_route.tex` to:
  - Add a `**Scope restriction (NormalTorusRectangleInjectivityHypotheses):**` marker classifying the `IsVertexInjective`-based singleton datum as a specialization of Theorem 3 (arXiv:1804.04964, lines 1449–1452).
  - Add a pointer to `torusHorizontal/VerticalRectangleBlockingDatum` (`TorusRectangleReferenceData.lean`) as the source-faithful rectangle-based version using `NormalTorusRectangleInjectivityHypotheses`.
- LaTeX documentation only; no Lean or Mathlib code changes.

### Testing

- `git diff --check` passed.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` passed.
- Lean CI is not triggered (no `.lean` file changes); blueprint linter validates the `.tex` file.

---
Closes #2621

> [!NOTE]
> **Low Risk**
> LaTeX documentation only; no Lean or runtime code changes.
>
> **Overview**
> The PEPS normal fundamental theorem paper-gap note now **scopes the torus singleton reference blocking datum** as a vertex-injective specialization of the rectangle normality hypothesis in Theorem 3 of arXiv:1804.04964 (lines 1449–1452).
>
> It also documents the **source-faithful torus reference datum**: horizontal/vertical rectangle blocking data where the red and blue blocks are the two source rectangles adjacent to the distinguished edge, with Lean pointers to `torusHorizontalRectangleBlockingDatum`, `torusVerticalRectangleBlockingDatum`, and the corresponding `isCrossingEdge_*` lemmas.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946303c67abd873a001798b4834c5a2bfb354924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>