### PR TITLE
doc(PEPS): add coefficient conjugation blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -3449,6 +3449,113 @@ injective and normal PEPS, following Theorems~2 and~3 of
     algebras writes this equivalence as conjugation by an invertible matrix.
 \end{proof}
 
+\begin{theorem}[Determinacy of a region insertion transfer]
+    \label{thm:peps_regionInsertedCoeff_transferMap_unique}
+    \lean{TNLean.PEPS.regionInsertedCoeff_transferMap_unique}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:peps_region_out_endpoint_block_inverse}
+    Assume that the blocked tensors of \(B\) on \(R\) and \(R^c\) are injective
+    and that all virtual bonds of \(B\) have positive dimension.  Let
+    \(T_1,T_2:\MN{D_A(f)}\to\MN{D_B(f)}\) be two maps.  For \(i=1,2\), suppose
+    \(T_i\) satisfies, for every inserted matrix and every pair of physical
+    configurations,
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_B(R,f,T_i(M);\sigma,\tau).
+    \]
+    Then \(T_1(M)=T_2(M)\) for every \(M\).
+\end{theorem}
+\begin{proof}\leanok
+    For every pair of physical configurations, the two displayed identities give
+    \[
+        C_B(R,f,T_1(M);\sigma,\tau)
+        =
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_B(R,f,T_2(M);\sigma,\tau).
+    \]
+    Injectivity of the region and complement blocked tensors, together with
+    positivity of all virtual bonds of \(B\), gives
+    \[
+        \left(
+          \forall\sigma,\tau,\,
+          C_B(R,f,T_1(M);\sigma,\tau)
+          =
+          C_B(R,f,T_2(M);\sigma,\tau)
+        \right)
+        \Longrightarrow
+        T_1(M)=T_2(M).
+    \]
+\end{proof}
+
+\begin{theorem}[Reindexing commutes with conjugation]
+    \label{thm:peps_reindexAlgEquiv_gaugeConj}
+    \lean{TNLean.PEPS.reindexAlgEquiv_gaugeConj}
+    \leanok
+    Assume \(D=E\), let \(\iota:\MN{D}\simeq\MN{E}\) be the canonical
+    identification of matrix algebras, and let \(Z\in\GL(D)\).  Then for every
+    \(N\in\MN{D}\),
+    \[
+        \iota(ZNZ^{-1})
+        =
+        \iota(Z)\,\iota(N)\,\iota(Z)^{-1}.
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    The map \(\iota\) is an algebra equivalence, so it preserves products and
+    inverses.  Applying this to the three factors \(Z\), \(N\), and \(Z^{-1}\)
+    gives the displayed identity.
+\end{proof}
+
+\begin{theorem}[Coefficient identities determine the boundary conjugation]
+    \label{thm:peps_gaugeConj_eq_of_coeffIdentities}
+    \lean{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities}
+    \leanok
+    \uses{thm:peps_regionInsertedCoeff_transferMap_unique}
+    Assume that the blocked tensors of \(B\) on \(R\) and \(R^c\) are injective
+    and that all virtual bonds of \(B\) have positive dimension.  Suppose that
+    the equality \(D_A(f)=D_B(f)\) fixes the canonical identification
+    \[
+        \iota:\MN{D_A(f)}\simeq\MN{D_B(f)}.
+    \]
+    For \(i=1,2\), suppose that the invertible matrix \(Z_i\in\GL(D_B(f))\)
+    realizes the region-insertion identity
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_B(R,f,Z_i\,\iota(M)\,Z_i^{-1};\sigma,\tau).
+    \]
+    Then the two conjugations agree on every boundary matrix:
+    \[
+        Z_1\,\iota(M)\,Z_1^{-1}
+        =
+        Z_2\,\iota(M)\,Z_2^{-1}.
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    For \(i=1,2\), define the transfer map
+    \[
+        T_i(M):=Z_i\,\iota(M)\,Z_i^{-1}.
+    \]
+    Its coefficient identity is
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_B(R,f,T_i(M);\sigma,\tau).
+    \]
+    The preceding determinacy theorem gives
+    \[
+        T_1(M)=T_2(M).
+    \]
+    Substituting the definitions of \(T_1\) and \(T_2\) yields
+    \[
+        Z_1\,\iota(M)\,Z_1^{-1}
+        =
+        Z_2\,\iota(M)\,Z_2^{-1}.
+    \]
+\end{proof}
+
 \begin{definition}[Single-vertex two-block tensor]%
     \label{def:peps_vertexTwoBlock}
     \lean{TNLean.PEPS.vertexTwoBlock}


### PR DESCRIPTION
### Motivation

- `blueprint/src/chapter/ch13a_peps_ft.tex` (Ch. 13a) has no entries for two general-graph theorems in `TNLean/PEPS/TorusEdgeGaugeCovariance.lean`, as reported in #2618.
- A supporting determinacy result (`regionInsertedCoeff_transferMap_unique`) was also absent from the blueprint, leaving the displayed implication without a named mathematical predecessor; this is one item from the synchronization list in #2614.
- Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph` (`Papers/1804.04964/paper_normal.tex`, lines 377–457).

### Description

- Adds three theorem blocks to `blueprint/src/chapter/ch13a_peps_ft.tex`, immediately after the Skolem–Noether conjugation entry:
  - `regionInsertedCoeff_transferMap_unique`: under injective blocked tensors and positive bond dimensions, two maps that agree on all region-inserted coefficients must coincide on every inserted matrix.
  - `reindexAlgEquiv_gaugeConj`: the canonical boundary algebra identification intertwines conjugation by $Z$ with conjugation by $\iota_h(Z)$.
  - `gaugeConj_eq_of_coeffIdentities`: two boundary gauges satisfying the same region-insertion coefficient identity induce the same conjugation on boundary matrices, citing the two preceding results.
- All three entries carry `\lean{...}` / `\leanok` tags linking to `TNLean.PEPS`; proofs are prose sketches. No Lean source files are modified.

### Testing

- `lake exe cache get`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main..HEAD`

---
Closes #2618
Refs #2614

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX additions with Lean cross-references; no runtime or formal proof code changes.
> 
> **Overview**
> Adds **three blueprint theorem entries** in `ch13a_peps_ft.tex` right after the per-edge gauge / Skolem–Noether block, each with `\lean{...}` / `\leanok` links to existing `TNLean.PEPS` declarations (no Lean edits).
> 
> **Determinacy of region insertion transfer** (`regionInsertedCoeff_transferMap_unique`): under injective blocked tensors on \(R\) and \(R^c\) and positive virtual bonds, two maps that match on all region-inserted coefficients must agree on every inserted matrix.
> 
> **Reindexing and conjugation** (`reindexAlgEquiv_gaugeConj`): the canonical boundary algebra identification \(\iota\) intertwines \(ZNZ^{-1}\) with conjugation by \(\iota(Z)\).
> 
> **Uniqueness of boundary gauge from coefficients** (`gaugeConj_eq_of_coeffIdentities`): two invertible gauges satisfying the same region-insertion coefficient identity induce the same conjugation on boundary matrices, proved via the determinacy theorem.
> 
> Proofs in the blueprint are short prose sketches aligned with the paper (arXiv:1804.04964, Lemma `inj_isomorph`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9db0d5ead5f50a82a6268948b34289d1e4bab80f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->