### PR TITLE
feat(PEPS): interior absorbed family and comparison machinery on the open square lattice

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -587,3 +587,4 @@ import TNLean.PEPS.NormalSquareInjectivity
 -- The per-edge coefficient identity and absorbing gauge at interior edges of the
 -- open square lattice, the open-lattice port of the torus per-edge witness layer.
 import TNLean.PEPS.NormalSquareEdgeCoeff
+import TNLean.PEPS.NormalSquareInteriorAbsorbedFamily

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -588,3 +588,4 @@ import TNLean.PEPS.NormalSquareInjectivity
 -- open square lattice, the open-lattice port of the torus per-edge witness layer.
 import TNLean.PEPS.NormalSquareEdgeCoeff
 import TNLean.PEPS.NormalSquareInteriorAbsorbedFamily
+import TNLean.PEPS.NormalSquareComparisonRegion

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -584,3 +584,6 @@ import TNLean.PEPS.CoherentFrameInstance
 import TNLean.PEPS.CoherentFrameInstance2
 import TNLean.PEPS.NormalEdgeGaugeFamily
 import TNLean.PEPS.NormalSquareInjectivity
+-- The per-edge coefficient identity and absorbing gauge at interior edges of the
+-- open square lattice, the open-lattice port of the torus per-edge witness layer.
+import TNLean.PEPS.NormalSquareEdgeCoeff

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -589,3 +589,5 @@ import TNLean.PEPS.NormalSquareInjectivity
 import TNLean.PEPS.NormalSquareEdgeCoeff
 import TNLean.PEPS.NormalSquareInteriorAbsorbedFamily
 import TNLean.PEPS.NormalSquareComparisonRegion
+-- The unconditional interior-window Fundamental Theorem on the open square lattice.
+import TNLean.PEPS.NormalSquareFundamentalTheorem2

--- a/TNLean/PEPS/NormalSquareComparisonRegion.lean
+++ b/TNLean/PEPS/NormalSquareComparisonRegion.lean
@@ -1,0 +1,309 @@
+import TNLean.PEPS.NormalEdgeBlockingInterior
+import TNLean.PEPS.RegionBlock.Basic
+
+/-!
+# The comparison region of the open-lattice normal PEPS Fundamental Theorem
+
+The final comparison of the normal PEPS Fundamental Theorem runs over a region `R` and the
+one-site-larger region `S = R ∪ {v}` (arXiv:1804.04964, Section 3, proof of Theorem 3, lines
+1519--1571 of `Papers/1804.04964/paper_normal.tex`).  This file builds that pair on the finite
+open square lattice at a parametric offset `(a, b)`: the **comparison region** is the `3 × 3`
+coordinate square at `(a, b)` minus its lower-left corner, so that
+
+* the comparison region is the union of a `2 × 3` and a `3 × 2` source rectangle, hence
+  injective;
+* inserting the corner vertex completes the square, a `3 × 3` rectangle, hence injective;
+* both complements decompose into coordinate bands (and one corner rectangle), all of source
+  shape, hence injective by union closure (the source's "if the PEPS is at least `5 × 5`, their
+  complement regions are also injective", line 1543);
+* both regions have a boundary edge; and
+* with the offset in the **interior window** (`4 ≤ a`, `a + 9 ≤ width`, `4 ≤ b`,
+  `b + 9 ≤ height`), every boundary edge of both regions carries the interior margins of the
+  open edge-blocking geometry, so the bare-edge absorbed equality of the interior gauge family
+  is available on all of them.
+
+Unlike the torus, where one reference pair is transported to every site by the translations, the
+open lattice carries no translations, so the pair is placed afresh at every offset; the interior
+window is the set of offsets the open blocking geometry reaches.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1571
+  of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {width height : ℕ}
+
+/-! ### The comparison square, comparison region, and interior window -/
+
+/-- The `3 × 3` coordinate square at offset `(a, b)`. -/
+def normalSquareComparisonSquare (a b : ℕ) : Finset (SquareLatticeVertex width height) :=
+  squareLatticeContiguousRectangle a b 3 3
+
+/-- The comparison region: the `3 × 3` square at `(a, b)` minus its lower-left corner,
+presented as the union of a `2 × 3` rectangle and a `3 × 2` rectangle.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1544 of
+`Papers/1804.04964/paper_normal.tex` (the displayed regions `R` and `S`). -/
+def normalSquareComparisonRegion (a b : ℕ) : Finset (SquareLatticeVertex width height) :=
+  squareLatticeContiguousRectangle (a + 1) b 2 3 ∪
+    squareLatticeContiguousRectangle a (b + 1) 3 2
+
+/-- The interior window for the comparison offset: the placement margins under which every
+boundary edge of the comparison square and the comparison region carries the interior margins of
+the open edge-blocking geometry.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1571 of
+`Papers/1804.04964/paper_normal.tex`; the window records which offsets the open-lattice blocking
+frames reach. -/
+def IsNormalSquareComparisonWindow (width height a b : ℕ) : Prop :=
+  4 ≤ a ∧ a + 9 ≤ width ∧ 4 ≤ b ∧ b + 9 ≤ height
+
+/-- Membership in the comparison region, in coordinate values. -/
+theorem mem_normalSquareComparisonRegion (a b : ℕ) (v : SquareLatticeVertex width height) :
+    v ∈ (normalSquareComparisonRegion a b : Finset (SquareLatticeVertex width height)) ↔
+      (a + 1 ≤ v.1.1 ∧ v.1.1 < a + 3 ∧ b ≤ v.2.1 ∧ v.2.1 < b + 3) ∨
+        (a ≤ v.1.1 ∧ v.1.1 < a + 3 ∧ b + 1 ≤ v.2.1 ∧ v.2.1 < b + 3) := by
+  simp only [normalSquareComparisonRegion, Finset.mem_union,
+    mem_squareLatticeContiguousRectangle]
+
+/-- A vertex lies outside the comparison region at its own coordinates. -/
+theorem notMem_normalSquareComparisonRegion (v : SquareLatticeVertex width height) :
+    v ∉ (normalSquareComparisonRegion v.1.1 v.2.1 :
+      Finset (SquareLatticeVertex width height)) := by
+  rw [mem_normalSquareComparisonRegion]
+  omega
+
+/-- Inserting the corner vertex into the comparison region completes the comparison square. -/
+theorem insert_normalSquareComparisonRegion (v : SquareLatticeVertex width height) :
+    insert v (normalSquareComparisonRegion v.1.1 v.2.1) =
+      (normalSquareComparisonSquare v.1.1 v.2.1 :
+        Finset (SquareLatticeVertex width height)) := by
+  ext w
+  rw [Finset.mem_insert, mem_normalSquareComparisonRegion, normalSquareComparisonSquare,
+    mem_squareLatticeContiguousRectangle]
+  constructor
+  · rintro (rfl | hw)
+    · exact ⟨by omega, by omega, by omega, by omega⟩
+    · omega
+  · rintro ⟨h1, h2, h3, h4⟩
+    by_cases hw : w = v
+    · exact Or.inl hw
+    · refine Or.inr ?_
+      have hne : w.1.1 ≠ v.1.1 ∨ w.2.1 ≠ v.2.1 := by
+        by_contra hcon
+        push Not at hcon
+        exact hw (Prod.ext (Fin.ext hcon.1) (Fin.ext hcon.2))
+      omega
+
+/-! ### The band decompositions of the complements -/
+
+/-- The complement of the comparison square is the union of four coordinate bands. -/
+theorem compl_normalSquareComparisonSquare_eq_bands {a b : ℕ}
+    (ha : a + 3 ≤ width) (hb : b + 3 ≤ height) :
+    Finset.univ \
+        (normalSquareComparisonSquare a b : Finset (SquareLatticeVertex width height)) =
+      squareLatticeContiguousRectangle 0 0 a height ∪
+        (squareLatticeContiguousRectangle (a + 3) 0 (width - (a + 3)) height ∪
+          (squareLatticeContiguousRectangle a 0 3 b ∪
+            squareLatticeContiguousRectangle a (b + 3) 3 (height - (b + 3)))) := by
+  ext v
+  have hx := v.1.isLt
+  have hy := v.2.isLt
+  simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_union,
+    normalSquareComparisonSquare, mem_squareLatticeContiguousRectangle]
+  omega
+
+/-- The complement of the comparison region is the union of the four bands and the corner
+rectangle covering the corner vertex. -/
+theorem compl_normalSquareComparisonRegion_eq_bands {a b : ℕ}
+    (ha2 : 2 ≤ a) (hb1 : 1 ≤ b) (ha : a + 3 ≤ width) (hb : b + 3 ≤ height) :
+    Finset.univ \
+        (normalSquareComparisonRegion a b : Finset (SquareLatticeVertex width height)) =
+      squareLatticeContiguousRectangle (a - 2) (b - 1) 3 2 ∪
+        (squareLatticeContiguousRectangle 0 0 a height ∪
+          (squareLatticeContiguousRectangle (a + 3) 0 (width - (a + 3)) height ∪
+            (squareLatticeContiguousRectangle a 0 3 b ∪
+              squareLatticeContiguousRectangle a (b + 3) 3 (height - (b + 3))))) := by
+  ext v
+  have hx := v.1.isLt
+  have hy := v.2.isLt
+  simp only [Finset.mem_sdiff, Finset.mem_univ, true_and, Finset.mem_union,
+    mem_normalSquareComparisonRegion, mem_squareLatticeContiguousRectangle]
+  omega
+
+/-! ### Injectivity of the comparison regions and their complements -/
+
+namespace NormalSquareLatticeRectangleInjectivityHypotheses
+
+variable {κ : RegionInjectivityData (SquareLatticeVertex width height)}
+
+/-- The comparison region is injective: it is the union of a `2 × 3` and a `3 × 2` source
+rectangle.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1544 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem comparisonRegion_injective (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) {a b : ℕ}
+    (ha : a + 3 ≤ width) (hb : b + 3 ≤ height) :
+    κ.IsInjective
+      (normalSquareComparisonRegion a b : Finset (SquareLatticeVertex width height)) :=
+  hUnion.union_injective (h.rect23_injective (by omega) (by omega))
+    (h.rect32_injective (by omega) (by omega))
+
+/-- The comparison square is injective: it is a `3 × 3` rectangle.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1544 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem comparisonSquare_injective (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) {a b : ℕ}
+    (ha : a + 3 ≤ width) (hb : b + 3 ≤ height) :
+    κ.IsInjective
+      (normalSquareComparisonSquare a b : Finset (SquareLatticeVertex width height)) :=
+  h.wideRectangle_injective hUnion (by omega) (by omega) ha hb
+
+/-- The complement of the comparison square is injective: it is the union of four coordinate
+bands, each of source shape.  These are the placement margins of the source's "if the PEPS is at
+least `5 × 5`, their complement regions `R^c` and `S^c` are also injective" (line 1543).
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1544 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem compl_comparisonSquare_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) {a b : ℕ}
+    (ha2 : 2 ≤ a) (hb2 : 2 ≤ b) (ha : a + 5 ≤ width) (hb : b + 5 ≤ height) :
+    κ.IsInjective (Finset.univ \
+      (normalSquareComparisonSquare a b : Finset (SquareLatticeVertex width height))) := by
+  rw [compl_normalSquareComparisonSquare_eq_bands (by omega) (by omega)]
+  refine hUnion.union_injective
+    (h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  refine hUnion.union_injective
+    (h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  exact hUnion.union_injective
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega))
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega))
+
+/-- The complement of the comparison region is injective: it is the union of the four bands and
+a `3 × 2` corner rectangle.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and proof of Theorem 3, lines
+1322--1544 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem compl_comparisonRegion_injective
+    (h : NormalSquareLatticeRectangleInjectivityHypotheses κ)
+    (hUnion : RegionInjectivityUnionClosure κ) {a b : ℕ}
+    (ha2 : 2 ≤ a) (hb2 : 2 ≤ b) (ha : a + 5 ≤ width) (hb : b + 5 ≤ height) :
+    κ.IsInjective (Finset.univ \
+      (normalSquareComparisonRegion a b : Finset (SquareLatticeVertex width height))) := by
+  rw [compl_normalSquareComparisonRegion_eq_bands (by omega) (by omega) (by omega) (by omega)]
+  refine hUnion.union_injective
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  refine hUnion.union_injective
+    (h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  refine hUnion.union_injective
+    (h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)) ?_
+  exact hUnion.union_injective
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega))
+    (h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega))
+
+end NormalSquareLatticeRectangleInjectivityHypotheses
+
+/-! ### Boundary edges of the comparison regions -/
+
+/-- The up edge of the corner vertex is a boundary edge of the comparison region: the corner
+`(a, b)` lies outside, its upper neighbour `(a, b + 1)` inside. -/
+theorem isRegionBoundaryEdge_normalSquareComparisonRegion {a b : ℕ}
+    (ha : a < width) (hb : b + 2 < height) :
+    IsRegionBoundaryEdge (G := squareLatticeGraph width height)
+      (normalSquareComparisonRegion a b)
+      (squareLatticeUpEdge a b ha (by omega)) := by
+  refine Or.inr ⟨?_, ?_⟩
+  · rw [mem_normalSquareComparisonRegion]
+    simp only [squareLatticeUpEdge]
+    omega
+  · rw [mem_normalSquareComparisonRegion]
+    simp only [squareLatticeUpEdge]
+    omega
+
+/-- The up edge of the vertex below the corner is a boundary edge of the comparison square:
+`(a, b - 1)` lies outside, its upper neighbour `(a, b)` inside. -/
+theorem isRegionBoundaryEdge_normalSquareComparisonSquare {a b : ℕ}
+    (hb1 : 1 ≤ b) (ha : a < width) (hb : b + 2 < height) :
+    IsRegionBoundaryEdge (G := squareLatticeGraph width height)
+      (normalSquareComparisonSquare a b)
+      (squareLatticeUpEdge a (b - 1) ha (by omega)) := by
+  refine Or.inr ⟨?_, ?_⟩
+  · rw [normalSquareComparisonSquare, mem_squareLatticeContiguousRectangle]
+    simp only [squareLatticeUpEdge]
+    omega
+  · rw [normalSquareComparisonSquare, mem_squareLatticeContiguousRectangle]
+    simp only [squareLatticeUpEdge]
+    omega
+
+/-! ### Boundary edges of the comparison regions are interior edges
+
+With the offset in the interior window, every boundary edge of the comparison square and the
+comparison region carries the interior margins of the open edge-blocking geometry, so the
+bare-edge absorbed equality of the interior gauge family is available on all of them. -/
+
+/-- Every boundary edge of the comparison square at a window offset is an interior edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1571 of
+`Papers/1804.04964/paper_normal.tex`; the open-lattice placement margins. -/
+theorem normalSquareInteriorEdgeDatum_of_boundary_comparisonSquare {a b : ℕ}
+    (hwin : IsNormalSquareComparisonWindow width height a b)
+    {f : Edge (squareLatticeGraph width height)}
+    (hf : IsRegionBoundaryEdge (G := squareLatticeGraph width height)
+      (normalSquareComparisonSquare a b) f) :
+    NormalSquareInteriorEdgeDatum f := by
+  obtain ⟨ha4, haw, hb4, hbh⟩ := hwin
+  rcases squareLatticeEdge_horizontal_or_vertical f with hH | hV
+  · have hc := horizontalSquareLatticeEdge_coords f hH
+    have hy2 : f.1.2.2.1 = f.1.1.2.1 := (congrArg Fin.val hc.1).symm
+    have hx2 : f.1.2.1.1 = f.1.1.1.1 + 1 := hc.2.symm
+    refine NormalSquareInteriorEdgeDatum.horizontal hH ⟨?_, ?_, ?_, ?_⟩ <;>
+      (rcases hf with ⟨hin, hout⟩ | ⟨hout, hin⟩ <;>
+        simp only [normalSquareComparisonSquare,
+          mem_squareLatticeContiguousRectangle] at hin hout <;>
+        omega)
+  · have hc := verticalSquareLatticeEdge_coords f hV
+    have hx2 : f.1.2.1.1 = f.1.1.1.1 := (congrArg Fin.val hc.1).symm
+    have hy2 : f.1.2.2.1 = f.1.1.2.1 + 1 := hc.2.symm
+    refine NormalSquareInteriorEdgeDatum.vertical hV ⟨?_, ?_, ?_, ?_⟩ <;>
+      (rcases hf with ⟨hin, hout⟩ | ⟨hout, hin⟩ <;>
+        simp only [normalSquareComparisonSquare,
+          mem_squareLatticeContiguousRectangle] at hin hout <;>
+        omega)
+
+/-- Every boundary edge of the comparison region at a window offset is an interior edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1571 of
+`Papers/1804.04964/paper_normal.tex`; the open-lattice placement margins. -/
+theorem normalSquareInteriorEdgeDatum_of_boundary_comparisonRegion {a b : ℕ}
+    (hwin : IsNormalSquareComparisonWindow width height a b)
+    {f : Edge (squareLatticeGraph width height)}
+    (hf : IsRegionBoundaryEdge (G := squareLatticeGraph width height)
+      (normalSquareComparisonRegion a b) f) :
+    NormalSquareInteriorEdgeDatum f := by
+  obtain ⟨ha4, haw, hb4, hbh⟩ := hwin
+  rcases squareLatticeEdge_horizontal_or_vertical f with hH | hV
+  · have hc := horizontalSquareLatticeEdge_coords f hH
+    have hy2 : f.1.2.2.1 = f.1.1.2.1 := (congrArg Fin.val hc.1).symm
+    have hx2 : f.1.2.1.1 = f.1.1.1.1 + 1 := hc.2.symm
+    refine NormalSquareInteriorEdgeDatum.horizontal hH ⟨?_, ?_, ?_, ?_⟩ <;>
+      (rcases hf with ⟨hin, hout⟩ | ⟨hout, hin⟩ <;>
+        rw [mem_normalSquareComparisonRegion] at hin hout <;>
+        omega)
+  · have hc := verticalSquareLatticeEdge_coords f hV
+    have hx2 : f.1.2.1.1 = f.1.1.1.1 := (congrArg Fin.val hc.1).symm
+    have hy2 : f.1.2.2.1 = f.1.1.2.1 + 1 := hc.2.symm
+    refine NormalSquareInteriorEdgeDatum.vertical hV ⟨?_, ?_, ?_, ?_⟩ <;>
+      (rcases hf with ⟨hin, hout⟩ | ⟨hout, hin⟩ <;>
+        rw [mem_normalSquareComparisonRegion] at hin hout <;>
+        omega)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalSquareEdgeCoeff.lean
+++ b/TNLean/PEPS/NormalSquareEdgeCoeff.lean
@@ -1,0 +1,309 @@
+import TNLean.PEPS.NormalEdgeGaugeFamily
+import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
+
+/-!
+# The per-edge coefficient identity and absorbing gauge at interior square-lattice edges
+
+This file upgrades the per-edge gauge of the open square lattice
+(`exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge` and its vertical counterpart) to
+the two stronger per-edge outputs the torus assembly consumes:
+
+* the **coefficient-identity form** (the analogue of `exists_regionEdgeGauge_torus_coeff`): on
+  the distinguished edge of a translated interior blocking frame, the bond dimensions of the two
+  tensors coincide and an invertible gauge `Z` realizes the conjugation-form region-insertion
+  coefficient identity at the red block;
+* the **absorbing-gauge form**: an invertible matrix `Ze` on the distinguished edge such that any
+  per-edge gauge family taking the value `Ze` there satisfies the bare-edge absorbed equality at
+  that edge --- inserting `N` on the first tensor's edge matches inserting the reindexed `N` on
+  the gauge-absorbed second tensor's edge, for every global physical configuration.
+
+The conversion from the coefficient identity to the bare-edge absorbed equality is the
+graph-generic `edgeAbsorbed_of_conjIdentity`; the gauge engine is the graph-generic coherent
+frame interface `exists_regionEdgeGauge_of_blockingData` fed the cover-free interior blocking
+data.  No single-vertex injectivity is used anywhere: the injectivity inputs are the rectangular
+injectivity hypotheses of the two tensors and union closure.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544 of
+`Papers/1804.04964/paper_normal.tex`, where Lemma `inj_isomorph` is applied around every lattice
+edge and the resulting gauges are incorporated into the second tensor.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544
+  of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ}
+
+open scoped Classical in
+/-- **The per-edge gauge at a translated horizontal interior edge, with its coefficient
+identity.**
+
+The same inputs as `exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge`, but exposing
+the region-insertion coefficient identity the gauge conjugation realizes: on the single boundary
+edge of the red block of the translated horizontal interior frame, inserting `M` into `A` and
+contracting matches inserting the gauge conjugation `Z · (reindex M) · Z⁻¹` into `B`.  This is
+the square-lattice analogue of `exists_regionEdgeGauge_torus_coeff`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph` applied at a horizontal lattice edge,
+lines 1449--1500 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge_coeff
+    (A B : Tensor (squareLatticeGraph width height) d) {xStart yStart : ℕ}
+    (hA : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUA : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hB : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 8 ≤ width) (hyh : yStart + 8 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g) :
+    let e := normalSquareHorizontalTranslatedEdge xStart yStart (by omega) (by omega)
+    let hsingle := fun g => isCrossingEdge_normalSquareHorizontalTranslatedEdge
+      (width := width) (height := height) A (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega) g
+    ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ),
+        ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+          (σ : RegionPhysicalConfig (V := SquareLatticeVertex width height) (d := d)
+            (normalSquareHorizontalTranslatedEdgeRed xStart yStart))
+          (τ : RegionPhysicalConfig (V := SquareLatticeVertex width height) (d := d)
+            (Finset.univ \ normalSquareHorizontalTranslatedEdgeRed xStart yStart)),
+          regionInsertedCoeff (G := squareLatticeGraph width height) A
+              (normalSquareHorizontalTranslatedEdgeRed xStart yStart)
+              (singleBoundaryEdge (G := squareLatticeGraph width height) A
+                (normalSquareHorizontalTranslatedEdgeRed xStart yStart)
+                (normalSquareHorizontalTranslatedEdgeBlue xStart yStart) e hsingle) M σ τ =
+            regionInsertedCoeff (G := squareLatticeGraph width height) B
+              (normalSquareHorizontalTranslatedEdgeRed xStart yStart)
+              (singleBoundaryEdge (G := squareLatticeGraph width height) A
+                (normalSquareHorizontalTranslatedEdgeRed xStart yStart)
+                (normalSquareHorizontalTranslatedEdgeBlue xStart yStart) e hsingle)
+              ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+                  Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+                  ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                    Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))
+              σ τ := by
+  intro e hsingle
+  let DA := normalSquareHorizontalTranslatedEdge_blockingDatum_interior
+      (κ := regionInjectivityDataOf A) hA hUA hx0 hy0 hxw hyh
+  let DB := normalSquareHorizontalTranslatedEdge_blockingDatum_interior
+      (κ := regionInjectivityDataOf B) hB hUB hx0 hy0 hxw hyh
+  have hred : DA.red = DB.red := rfl
+  have hblue : DA.blue = DB.blue := rfl
+  have hcompl : DA.complement = DB.complement := rfl
+  have hRB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B DA.red :=
+    regionBlockedTensorInjective_red DB
+  have hCB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+      (Finset.univ \ DA.red) := regionBlockedTensorInjective_host DB hUB
+  obtain ⟨htransferAB, htransferBA, hmul, hEdge, Z, hZ⟩ :=
+    exists_regionEdgeGauge_of_blockingData (A := A) (B := B) (e := e) DA DB
+      hred hblue hcompl hbond hAB hd hposA hposB hsingle hRB hCB
+  refine ⟨hEdge, Z, fun M σ τ => ?_⟩
+  have hfwd := (regionInsertionTransfer_of_coeffTransfer A B DA.red
+    (singleBoundaryEdge (G := squareLatticeGraph width height) A DA.red DA.blue e hsingle)
+    hRB hCB hAB hposB hbond htransferAB htransferBA hmul).fwd_coeff M σ τ
+  rw [hZ M] at hfwd
+  exact hfwd
+
+open scoped Classical in
+/-- **The per-edge gauge at a translated vertical interior edge, with its coefficient
+identity.**
+
+The rotated counterpart of
+`exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge_coeff`: on the single boundary edge
+of the red block of the translated vertical interior frame, an invertible gauge `Z` realizes the
+conjugation-form region-insertion coefficient identity.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph` applied at a vertical lattice edge,
+lines 1449--1500 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge_coeff
+    (A B : Tensor (squareLatticeGraph width height) d) {xStart yStart : ℕ}
+    (hA : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUA : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hB : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 8 ≤ width) (hyh : yStart + 8 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g) :
+    let e := normalSquareVerticalTranslatedEdge xStart yStart (by omega) (by omega)
+    let hsingle := fun g => isCrossingEdge_normalSquareVerticalTranslatedEdge
+      (width := width) (height := height) A (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega) g
+    ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ),
+        ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+          (σ : RegionPhysicalConfig (V := SquareLatticeVertex width height) (d := d)
+            (normalSquareVerticalTranslatedEdgeRed xStart yStart))
+          (τ : RegionPhysicalConfig (V := SquareLatticeVertex width height) (d := d)
+            (Finset.univ \ normalSquareVerticalTranslatedEdgeRed xStart yStart)),
+          regionInsertedCoeff (G := squareLatticeGraph width height) A
+              (normalSquareVerticalTranslatedEdgeRed xStart yStart)
+              (singleBoundaryEdge (G := squareLatticeGraph width height) A
+                (normalSquareVerticalTranslatedEdgeRed xStart yStart)
+                (normalSquareVerticalTranslatedEdgeBlue xStart yStart) e hsingle) M σ τ =
+            regionInsertedCoeff (G := squareLatticeGraph width height) B
+              (normalSquareVerticalTranslatedEdgeRed xStart yStart)
+              (singleBoundaryEdge (G := squareLatticeGraph width height) A
+                (normalSquareVerticalTranslatedEdgeRed xStart yStart)
+                (normalSquareVerticalTranslatedEdgeBlue xStart yStart) e hsingle)
+              ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+                  Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
+                  ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
+                    Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))
+              σ τ := by
+  intro e hsingle
+  let DA := normalSquareVerticalTranslatedEdge_blockingDatum_interior
+      (κ := regionInjectivityDataOf A) hA hUA hx0 hy0 hxw hyh
+  let DB := normalSquareVerticalTranslatedEdge_blockingDatum_interior
+      (κ := regionInjectivityDataOf B) hB hUB hx0 hy0 hxw hyh
+  have hred : DA.red = DB.red := rfl
+  have hblue : DA.blue = DB.blue := rfl
+  have hcompl : DA.complement = DB.complement := rfl
+  have hRB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B DA.red :=
+    regionBlockedTensorInjective_red DB
+  have hCB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+      (Finset.univ \ DA.red) := regionBlockedTensorInjective_host DB hUB
+  obtain ⟨htransferAB, htransferBA, hmul, hEdge, Z, hZ⟩ :=
+    exists_regionEdgeGauge_of_blockingData (A := A) (B := B) (e := e) DA DB
+      hred hblue hcompl hbond hAB hd hposA hposB hsingle hRB hCB
+  refine ⟨hEdge, Z, fun M σ τ => ?_⟩
+  have hfwd := (regionInsertionTransfer_of_coeffTransfer A B DA.red
+    (singleBoundaryEdge (G := squareLatticeGraph width height) A DA.red DA.blue e hsingle)
+    hRB hCB hAB hposB hbond htransferAB htransferBA hmul).fwd_coeff M σ τ
+  rw [hZ M] at hfwd
+  exact hfwd
+
+/-! ### The absorbing gauge at an interior edge
+
+Feeding the coefficient identity to the graph-generic conversion
+`edgeAbsorbed_of_conjIdentity` yields, at each translated interior edge, an invertible matrix
+whose placement in any per-edge gauge family realizes the bare-edge absorbed equality at that
+edge.  Because the bare-edge identity at an edge depends only on the family's value there, the
+absorbing gauges of distinct edges can be assembled into one family edge by edge. -/
+
+open scoped Classical in
+/-- **The absorbing gauge at a translated horizontal interior edge.**
+
+There is an invertible matrix `Ze` on the distinguished horizontal edge of the translated
+interior frame such that every per-edge gauge family `X` with `X e = Ze` satisfies the bare-edge
+absorbed equality at `e` against `applyGauge B X`: inserting `N` on `A`'s edge `e` matches
+inserting the reindexed `N` on `applyGauge B X`'s edge `e`, for every global physical
+configuration.
+
+`Ze` is the orientation-adapted absorbing gauge of the per-edge engine gauge at `e`
+(`absorbedBoundaryGauge`); the conversion is `edgeAbsorbed_of_conjIdentity` fed the coefficient
+identity of `exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge_coeff`.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_absorbingGauge_normalSquareHorizontalTranslatedEdge
+    (A B : Tensor (squareLatticeGraph width height) d) {xStart yStart : ℕ}
+    (hA : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUA : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hB : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 8 ≤ width) (hyh : yStart + 8 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g) :
+    let e := normalSquareHorizontalTranslatedEdge xStart yStart (by omega) (by omega)
+    ∃ Ze : GL (Fin (B.bondDim e)) ℂ,
+      ∀ X : (g : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim g)) ℂ,
+        X e = Ze →
+        ∀ (σ : SquareLatticeVertex width height → Fin d)
+          (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+          edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+            edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+              (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) := by
+  intro e
+  obtain ⟨hEdge, Z, hid⟩ :=
+    exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge_coeff A B hA hUA hB hUB
+      hx0 hy0 hxw hyh hbond hAB hd hposA hposB
+  have hEeq : hEdge = congr_fun hbond e := Subsingleton.elim _ _
+  subst hEeq
+  set f := singleBoundaryEdge (G := squareLatticeGraph width height) A
+    (normalSquareHorizontalTranslatedEdgeRed xStart yStart)
+    (normalSquareHorizontalTranslatedEdgeBlue xStart yStart) e
+    (fun g => isCrossingEdge_normalSquareHorizontalTranslatedEdge
+      (width := width) (height := height) A (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega) g) with hfdef
+  refine ⟨absorbedBoundaryGauge (G := squareLatticeGraph width height) B
+    (normalSquareHorizontalTranslatedEdgeRed xStart yStart) f Z, fun X hXe σ N => ?_⟩
+  exact edgeAbsorbed_of_conjIdentity A B
+    (normalSquareHorizontalTranslatedEdgeRed xStart yStart) f hbond Z X hXe hposA
+    (fun M σ' τ' => hid M σ' τ') σ N
+
+open scoped Classical in
+/-- **The absorbing gauge at a translated vertical interior edge.**
+
+The rotated counterpart of `exists_absorbingGauge_normalSquareHorizontalTranslatedEdge`: an
+invertible matrix `Ze` on the distinguished vertical edge of the translated interior frame such
+that every per-edge gauge family taking the value `Ze` there satisfies the bare-edge absorbed
+equality at that edge against the gauge-absorbed second tensor.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1500--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_absorbingGauge_normalSquareVerticalTranslatedEdge
+    (A B : Tensor (squareLatticeGraph width height) d) {xStart yStart : ℕ}
+    (hA : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUA : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hB : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 8 ≤ width) (hyh : yStart + 8 ≤ height)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g) :
+    let e := normalSquareVerticalTranslatedEdge xStart yStart (by omega) (by omega)
+    ∃ Ze : GL (Fin (B.bondDim e)) ℂ,
+      ∀ X : (g : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim g)) ℂ,
+        X e = Ze →
+        ∀ (σ : SquareLatticeVertex width height → Fin d)
+          (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+          edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+            edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+              (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) := by
+  intro e
+  obtain ⟨hEdge, Z, hid⟩ :=
+    exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge_coeff A B hA hUA hB hUB
+      hx0 hy0 hxw hyh hbond hAB hd hposA hposB
+  have hEeq : hEdge = congr_fun hbond e := Subsingleton.elim _ _
+  subst hEeq
+  set f := singleBoundaryEdge (G := squareLatticeGraph width height) A
+    (normalSquareVerticalTranslatedEdgeRed xStart yStart)
+    (normalSquareVerticalTranslatedEdgeBlue xStart yStart) e
+    (fun g => isCrossingEdge_normalSquareVerticalTranslatedEdge
+      (width := width) (height := height) A (xStart := xStart) (yStart := yStart)
+      (by omega) (by omega) g) with hfdef
+  refine ⟨absorbedBoundaryGauge (G := squareLatticeGraph width height) B
+    (normalSquareVerticalTranslatedEdgeRed xStart yStart) f Z, fun X hXe σ N => ?_⟩
+  exact edgeAbsorbed_of_conjIdentity A B
+    (normalSquareVerticalTranslatedEdgeRed xStart yStart) f hbond Z X hXe hposA
+    (fun M σ' τ' => hid M σ' τ') σ N
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalSquareFundamentalTheorem2.lean
+++ b/TNLean/PEPS/NormalSquareFundamentalTheorem2.lean
@@ -1,0 +1,364 @@
+import TNLean.PEPS.NormalSquareInteriorAbsorbedFamily
+import TNLean.PEPS.NormalSquareComparisonRegion
+import TNLean.PEPS.NormalSquareInjectivity
+import TNLean.PEPS.RegionBlock.ScalarExtraction
+import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
+import TNLean.PEPS.RegionBlock.ReindexInjectivity
+import TNLean.PEPS.RegionBlock.GaugeInjectivity2
+
+/-!
+# The unconditional normal PEPS Fundamental Theorem on the open square lattice
+
+This file assembles the unconditional interior form of the normal PEPS Fundamental Theorem on
+the finite **open** `width × height` square lattice (arXiv:1804.04964, Section 3, Theorem 3,
+lines 1449--1571 of `Papers/1804.04964/paper_normal.tex`): from the source hypotheses alone ---
+the rectangular-injectivity hypotheses for both tensors, matched bond dimensions, positive
+bonds, and the same state --- it produces a per-edge gauge family `X` with
+
+* the bare-edge absorbed equality at every edge with interior margins, and
+* at every vertex in the interior comparison window, a nonzero scalar `λ_v` with the per-vertex
+  relation `A_v = λ_v · (gauge action of B at v)`.
+
+The union closure of injective regions is derived from the positive bonds
+(`regionInjectivityUnionClosure_of_overlap`), not assumed, and no single-vertex injectivity is
+used anywhere.  This is the open-lattice port of the torus assembly
+(`fundamentalTheorem_normalTorusPEPS_unconditional`), in the scope the open blocking geometry
+honestly supports.
+
+**Scope restriction (interior window, per-vertex scalars):** the conclusion is restricted in
+two ways relative to the source's Theorem 3, both documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining mathematical
+obligations".
+
+1. *Interior window.*  The open lattice's translated blocking frames require interior margins,
+   so the absorbed equality reaches only the interior edges and the comparison pair only the
+   offsets of `IsNormalSquareComparisonWindow` (`4 ≤ x ≤ width - 9`, `4 ≤ y ≤ height - 9`).
+   Vertices near the lattice boundary are not reached: the boundary edges of any comparison
+   region adjacent to them lie outside the interior margins.  On the torus every edge is a
+   translate of a reference edge, so no such window appears there.
+
+2. *Per-vertex scalars.*  The scalars `λ_v` of distinct vertices are not asserted equal, and no
+   product condition `λ^{n·m} = 1` is asserted.  The source's single `λ` comes from translation
+   invariance of the tensors, which transports one comparison pair (and its scalars) to every
+   site; the open coordinate lattice carries no translations and the present development has no
+   translation-invariance predicate on it, so the per-edge gauges and per-vertex scalars are
+   chosen independently.  A single `λ` is in fact false without a translation-invariance
+   hypothesis: rescaling `A`'s components at two interior vertices by `μ` and `μ⁻¹` preserves
+   the state and the rectangular injectivity but separates the two scalars.
+
+The structural findings behind this scope (recorded here as the port's scouting note): the open
+lattice encodes no translation structure --- `IsTorusTranslationInvariant` and the whole torus
+witness-transport layer act through the graph automorphisms `translate a b`, which have no
+open-lattice analogue, partial translations not being graph automorphisms; the open witness
+machinery (`exists_regionEdgeGauge_normalSquare*TranslatedEdge`) delivers per-edge gauges at
+interior edges only, each chosen independently, with the orientation-uniform reduction of
+`NormalSquareTI` having no derivation without a translation-invariance predicate; and the
+per-vertex relation is well formed at boundary vertices (the local virtual configuration ranges
+over the existing incident edges only) but not derivable there, the comparison regions' boundary
+edges falling outside the interior margins.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1571 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+/- Sealing `gaugeVertex` (file-locally irreducible) keeps the statements below within the
+default elaboration budget.  Elaborating `reindexTensor (applyGauge B X) hbond` checks
+`(applyGauge B X).bondDim ≡ B.bondDim`; before reducing the projection, the unifier first
+attempts the structure congruence `applyGauge B X ≡ B`, whose component comparison unfolds the
+`gaugeVertex` sums over `Finset.univ` of the concrete `Fin width × Fin height` lattice — a
+reduction that runs deep into the `List.finRange`/`Multiset.product` evaluation before sticking
+on the variable `width` and `height`, far past the heartbeat budget (the torus lattice `ZMod`
+coordinates stick immediately, which is why the torus assembly needs no seal).  With
+`gaugeVertex` irreducible the doomed congruence fails at once and the projection reduces
+normally.  All proofs below treat `gaugeVertex` as opaque, so nothing else changes. -/
+seal gaugeVertex
+
+variable {width height d : ℕ}
+
+/-- **The comparison-region proportionality at a window vertex.**
+
+The first half of the comparison pair at a window vertex `v`: the absorbed equality on the
+boundary edges of the `3 × 3`-minus-corner region at `v` yields the two-block scalar
+proportionality of `A` and the reindexed gauge-absorbed tensor over that region.  Isolated in
+its own declaration so that the comparison instantiation elaborates within the heartbeat
+budget.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem comparisonRegionProportional_of_interiorAbsorbed
+    (A B : Tensor (squareLatticeGraph width height) d)
+    (hAr : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hBr : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hbond : A.bondDim = B.bondDim)
+    (X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (hedge : ∀ e : Edge (squareLatticeGraph width height),
+      NormalSquareInteriorEdgeDatum e →
+      ∀ (σ : SquareLatticeVertex width height → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+        edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+          edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+            (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N))
+    (v : SquareLatticeVertex width height)
+    (hwin : IsNormalSquareComparisonWindow width height v.1.1 v.2.1) :
+    ∃ c : ℂ, c ≠ 0 ∧
+      TwoBlockScalarProportional.{0, 0, 0, 0}
+        (regionTwoBlock (G := squareLatticeGraph width height) A
+          (normalSquareComparisonRegion v.1.1 v.2.1))
+        (regionTwoBlock (G := squareLatticeGraph width height)
+          (reindexTensor (G := squareLatticeGraph width height) (applyGauge B X) hbond)
+          (normalSquareComparisonRegion v.1.1 v.2.1)) c := by
+  classical
+  obtain ⟨ha4, haw, hb4, hbh⟩ := hwin
+  have hRA : RegionBlockedTensorInjective (G := squareLatticeGraph width height) A
+      (normalSquareComparisonRegion v.1.1 v.2.1) := by
+    have hi := hAr.comparisonRegion_injective hUA (a := v.1.1) (b := v.2.1)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCRA : RegionBlockedTensorInjective (G := squareLatticeGraph width height) A
+      (Finset.univ \ normalSquareComparisonRegion v.1.1 v.2.1) := by
+    have hi := hAr.compl_comparisonRegion_injective hUA (a := v.1.1) (b := v.2.1)
+      (by omega) (by omega) (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hRB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+      (normalSquareComparisonRegion v.1.1 v.2.1) := by
+    have hi := hBr.comparisonRegion_injective hUB (a := v.1.1) (b := v.2.1)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCRB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+      (Finset.univ \ normalSquareComparisonRegion v.1.1 v.2.1) := by
+    have hi := hBr.compl_comparisonRegion_injective hUB (a := v.1.1) (b := v.2.1)
+      (by omega) (by omega) (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  haveI hNeR : Nonempty {f : Edge (squareLatticeGraph width height) //
+      IsRegionBoundaryEdge (G := squareLatticeGraph width height)
+        (normalSquareComparisonRegion v.1.1 v.2.1) f} :=
+    ⟨⟨squareLatticeUpEdge v.1.1 v.2.1 (by omega) (by omega),
+      isRegionBoundaryEdge_normalSquareComparisonRegion (by omega) (by omega)⟩⟩
+  exact twoBlockProportional_of_boundaryEdgeAbsorbed A B hbond X
+    (normalSquareComparisonRegion v.1.1 v.2.1) hRA hCRA
+    (regionBlockedTensorInjective_reindexTensor (applyGauge B X) hbond _
+      (regionBlockedTensorInjective_applyGauge B X _ hRB))
+    (regionBlockedTensorInjective_reindexTensor (applyGauge B X) hbond _
+      (regionBlockedTensorInjective_applyGauge B X _ hCRB))
+    (fun f σ N => hedge f.1
+      (normalSquareInteriorEdgeDatum_of_boundary_comparisonRegion
+        ⟨ha4, haw, hb4, hbh⟩ f.2) σ N)
+
+/-- **The completed-square proportionality at a window vertex.**
+
+The second half of the comparison pair: the absorbed equality on the boundary edges of the
+completed `3 × 3` square at `v` yields the two-block scalar proportionality over the one-site
+completion `insert v` of the comparison region.  Isolated in its own declaration so that the
+comparison instantiation elaborates within the heartbeat budget.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem comparisonSquareProportional_of_interiorAbsorbed
+    (A B : Tensor (squareLatticeGraph width height) d)
+    (hAr : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hBr : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hbond : A.bondDim = B.bondDim)
+    (X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (hedge : ∀ e : Edge (squareLatticeGraph width height),
+      NormalSquareInteriorEdgeDatum e →
+      ∀ (σ : SquareLatticeVertex width height → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+        edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+          edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+            (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N))
+    (v : SquareLatticeVertex width height)
+    (hwin : IsNormalSquareComparisonWindow width height v.1.1 v.2.1) :
+    ∃ c : ℂ, c ≠ 0 ∧
+      TwoBlockScalarProportional.{0, 0, 0, 0}
+        (regionTwoBlock (G := squareLatticeGraph width height) A
+          (insert v (normalSquareComparisonRegion v.1.1 v.2.1)))
+        (regionTwoBlock (G := squareLatticeGraph width height)
+          (reindexTensor (G := squareLatticeGraph width height) (applyGauge B X) hbond)
+          (insert v (normalSquareComparisonRegion v.1.1 v.2.1))) c := by
+  classical
+  obtain ⟨ha4, haw, hb4, hbh⟩ := hwin
+  rw [insert_normalSquareComparisonRegion v]
+  have hSA : RegionBlockedTensorInjective (G := squareLatticeGraph width height) A
+      (normalSquareComparisonSquare v.1.1 v.2.1) := by
+    have hi := hAr.comparisonSquare_injective hUA (a := v.1.1) (b := v.2.1)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCSA : RegionBlockedTensorInjective (G := squareLatticeGraph width height) A
+      (Finset.univ \ normalSquareComparisonSquare v.1.1 v.2.1) := by
+    have hi := hAr.compl_comparisonSquare_injective hUA (a := v.1.1) (b := v.2.1)
+      (by omega) (by omega) (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hSB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+      (normalSquareComparisonSquare v.1.1 v.2.1) := by
+    have hi := hBr.comparisonSquare_injective hUB (a := v.1.1) (b := v.2.1)
+      (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCSB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+      (Finset.univ \ normalSquareComparisonSquare v.1.1 v.2.1) := by
+    have hi := hBr.compl_comparisonSquare_injective hUB (a := v.1.1) (b := v.2.1)
+      (by omega) (by omega) (by omega) (by omega)
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  haveI hNeS : Nonempty {f : Edge (squareLatticeGraph width height) //
+      IsRegionBoundaryEdge (G := squareLatticeGraph width height)
+        (normalSquareComparisonSquare v.1.1 v.2.1) f} :=
+    ⟨⟨squareLatticeUpEdge v.1.1 (v.2.1 - 1) (by omega) (by omega),
+      isRegionBoundaryEdge_normalSquareComparisonSquare (by omega) (by omega) (by omega)⟩⟩
+  exact twoBlockProportional_of_boundaryEdgeAbsorbed A B hbond X
+    (normalSquareComparisonSquare v.1.1 v.2.1) hSA hCSA
+    (regionBlockedTensorInjective_reindexTensor (applyGauge B X) hbond _
+      (regionBlockedTensorInjective_applyGauge B X _ hSB))
+    (regionBlockedTensorInjective_reindexTensor (applyGauge B X) hbond _
+      (regionBlockedTensorInjective_applyGauge B X _ hCSB))
+    (fun f σ N => hedge f.1
+      (normalSquareInteriorEdgeDatum_of_boundary_comparisonSquare
+        ⟨ha4, haw, hb4, hbh⟩ f.2) σ N)
+
+/-- **The window scalar from the interior absorbed equality.**
+
+At a vertex `v` of the interior comparison window, the comparison pair (the `3 × 3` square at
+`v` minus its corner, and the completed square) together with the absorbed equality on interior
+edges produces a nonzero scalar `λ_v` with the per-vertex relation
+`A_v = λ_v · (gauge action of B at v)`.  The two comparison proportionalities are taken from
+their own declarations so each comparison instantiation elaborates within the heartbeat budget.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_windowScalar_of_interiorAbsorbed
+    (A B : Tensor (squareLatticeGraph width height) d)
+    (hAr : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hBr : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hbond : A.bondDim = B.bondDim)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ)
+    (hedge : ∀ e : Edge (squareLatticeGraph width height),
+      NormalSquareInteriorEdgeDatum e →
+      ∀ (σ : SquareLatticeVertex width height → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+        edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+          edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+            (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N))
+    (v : SquareLatticeVertex width height)
+    (hwin : IsNormalSquareComparisonWindow width height v.1.1 v.2.1) :
+    ∃ lam : ℂ, lam ≠ 0 ∧
+      ∀ (η : (ie : IncidentEdge (squareLatticeGraph width height) v) →
+          Fin (A.bondDim ie.1))
+        (σ : Fin d),
+        A.component v η σ =
+          lam * gaugeVertex B X v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ := by
+  classical
+  obtain ⟨cR, hcR0, hcRprop⟩ := comparisonRegionProportional_of_interiorAbsorbed A B hAr hBr
+    hUA hUB hbond X hedge v hwin
+  obtain ⟨cS, hcS0, hcSprop⟩ := comparisonSquareProportional_of_interiorAbsorbed A B hAr hBr
+    hUA hUB hbond X hedge v hwin
+  obtain ⟨ha4, haw, hb4, hbh⟩ := hwin
+  have hRC : RegionBlockedTensorInjective (G := squareLatticeGraph width height)
+      (reindexTensor (G := squareLatticeGraph width height) (applyGauge B X) hbond)
+      (normalSquareComparisonRegion v.1.1 v.2.1) := by
+    have hRB : RegionBlockedTensorInjective (G := squareLatticeGraph width height) B
+        (normalSquareComparisonRegion v.1.1 v.2.1) := by
+      have hi := hBr.comparisonRegion_injective hUB (a := v.1.1) (b := v.2.1)
+        (by omega) (by omega)
+      rwa [regionInjectivityDataOf_isInjective] at hi
+    exact regionBlockedTensorInjective_reindexTensor (applyGauge B X) hbond _
+      (regionBlockedTensorInjective_applyGauge B X _ hRB)
+  exact ⟨cS / cR, div_ne_zero hcS0 hcR0,
+    component_eq_gaugeVertex_of_twoBlockProportional A B
+      (normalSquareComparisonRegion v.1.1 v.2.1)
+      (notMem_normalSquareComparisonRegion v) hbond X cR cS hcR0 hposA
+      hRC hcRprop hcSprop⟩
+
+/-- **Unconditional normal PEPS Fundamental Theorem on the open square lattice (interior
+window).**
+
+For two tensors on the open `width × height` square lattice with the rectangular-injectivity
+hypotheses, matched bond dimensions, positive bonds, and the same state, there is a per-edge
+gauge family `X` over the second tensor's bonds such that
+
+* the bare-edge absorbed equality holds at every edge with interior margins: inserting `N` on
+  `A`'s edge matches inserting the reindexed `N` on `applyGauge B X`'s edge, for every global
+  physical configuration; and
+* every vertex `v` in the interior comparison window carries a nonzero scalar `λ_v` with
+  `A_v = λ_v · (gauge action of B at v)` on every local virtual configuration and physical
+  index.
+
+The union closure of injective regions is derived from the positive bonds; the comparison pair
+at `v` is the `3 × 3` square at `v` minus its corner and the completed square, whose
+proportionality scalars `c_R`, `c_S` give `λ_v = c_S / c_R` by the inserted-site scalar
+extraction.
+
+**Scope restriction (interior window, per-vertex scalars):** the absorbed equality is asserted
+on interior edges only, the per-vertex relation on window vertices only, and the scalars of
+distinct vertices are not asserted equal (no `λ^{n·m} = 1`); see the module docstring and
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining mathematical
+obligations".  The source's Theorem 3 obtains the single `λ` from translation invariance, which
+the open coordinate lattice does not encode.
+
+Source: arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalSquarePEPS_unconditional
+    (A B : Tensor (squareLatticeGraph width height) d)
+    (hAr : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hBr : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g) :
+    ∃ X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ,
+      (∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareInteriorEdgeDatum e →
+        ∀ (σ : SquareLatticeVertex width height → Fin d)
+          (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+          edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+            edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+              (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N)) ∧
+      ∀ v : SquareLatticeVertex width height,
+        IsNormalSquareComparisonWindow width height v.1.1 v.2.1 →
+        ∃ lam : ℂ, lam ≠ 0 ∧
+          ∀ (η : (ie : IncidentEdge (squareLatticeGraph width height) v) →
+              Fin (A.bondDim ie.1))
+            (σ : Fin d),
+            A.component v η σ =
+              lam * gaugeVertex B X v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ := by
+  classical
+  -- The union closure of injective regions, from positive bonds.
+  have hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := squareLatticeGraph width height) A) :=
+    regionInjectivityUnionClosure_of_overlap A hposA
+  have hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := squareLatticeGraph width height) B) :=
+    regionInjectivityUnionClosure_of_overlap B hposB
+  -- The interior absorbed gauge family.
+  obtain ⟨X, hedge⟩ := exists_normalSquareInteriorAbsorbedGaugeFamily A B hAr hUA hBr hUB
+    hbond hAB hd hposA hposB
+  exact ⟨X, hedge, fun v hwin => exists_windowScalar_of_interiorAbsorbed A B hAr hBr hUA hUB
+    hbond hposA X hedge v hwin⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalSquareInteriorAbsorbedFamily.lean
+++ b/TNLean/PEPS/NormalSquareInteriorAbsorbedFamily.lean
@@ -1,0 +1,162 @@
+import TNLean.PEPS.NormalSquareEdgeCoeff
+
+/-!
+# The interior absorbed gauge family on the open square lattice
+
+This file assembles the per-edge absorbing gauges of the interior edges of the finite open
+square lattice into a single per-edge gauge family `X` carrying the bare-edge absorbed equality
+
+> `edgeInsertedCoeff A e σ N = edgeInsertedCoeff (applyGauge B X) e σ (reindex N)`
+
+at every edge with interior margins (`NormalSquareInteriorEdgeDatum`).  This is the open-lattice
+counterpart of the torus family `exists_torusCovariantAbsorbedGaugeFamily`, restricted to the
+edges the open blocking geometry reaches: the bare-edge identity at an edge depends only on the
+family's value there, so the absorbing gauges of distinct interior edges combine edge by edge
+with no compatibility conditions.
+
+Unlike the torus, the open lattice carries no translations, so the family is *chosen* at each
+interior edge rather than transported from one reference witness per orientation class; no
+covariance between the gauges at distinct edges is asserted.  Edges without interior margins
+(those near the lattice boundary) receive the identity gauge and carry no absorbed equality;
+that boundary geometry is the residual open part recorded in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining mathematical
+obligations".
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544 of
+`Papers/1804.04964/paper_normal.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544
+  of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ}
+
+/-- **The absorbing gauge at an edge with interior margins.**
+
+An edge of the open square lattice carrying the cover-free interior datum --- horizontal or
+vertical with the corresponding interior margins --- admits an invertible matrix `Ze` such that
+every per-edge gauge family `X` with `X e = Ze` satisfies the bare-edge absorbed equality at `e`
+against `applyGauge B X`.
+
+The horizontal and vertical cases are
+`exists_absorbingGauge_normalSquareHorizontalTranslatedEdge` and its vertical counterpart,
+reached by rewriting the edge as the distinguished edge of the translated interior frame at
+offset `(x-1, y-2)` (horizontal) or `(x-2, y-1)` (vertical).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_absorbingGauge_of_normalSquareInteriorEdgeDatum
+    (A B : Tensor (squareLatticeGraph width height) d)
+    (hA : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUA : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hB : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g)
+    (e : Edge (squareLatticeGraph width height))
+    (he : NormalSquareInteriorEdgeDatum e) :
+    ∃ Ze : GL (Fin (B.bondDim e)) ℂ,
+      ∀ X : (g : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim g)) ℂ,
+        X e = Ze →
+        ∀ (σ : SquareLatticeVertex width height → Fin d)
+          (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+          edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+            edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+              (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) := by
+  rcases he with ⟨hEdge, hMargins⟩ | ⟨hEdge, hMargins⟩
+  · -- Horizontal interior edge: the translated frame at `(x-1, y-2)`.
+    obtain ⟨hx3, hx7, hy4, hy6⟩ := hMargins
+    have heq : e = normalSquareHorizontalTranslatedEdge
+        (e.1.1.1.1 - 1) (e.1.1.2.1 - 2) (by omega) (by omega) := by
+      rw [normalSquareHorizontalTranslatedEdge_sub_eq_rightEdge
+        (by omega) (by omega) (by omega) (by omega)]
+      exact horizontalSquareLatticeEdge_eq_rightEdge e hEdge
+    rw [heq]
+    exact exists_absorbingGauge_normalSquareHorizontalTranslatedEdge A B hA hUA hB hUB
+      (by omega) (by omega) (by omega) (by omega) hbond hAB hd hposA hposB
+  · -- Vertical interior edge: the translated frame at `(x-2, y-1)`.
+    obtain ⟨hx4, hx6, hy3, hy7⟩ := hMargins
+    have heq : e = normalSquareVerticalTranslatedEdge
+        (e.1.1.1.1 - 2) (e.1.1.2.1 - 1) (by omega) (by omega) := by
+      rw [normalSquareVerticalTranslatedEdge_sub_eq_upEdge
+        (by omega) (by omega) (by omega) (by omega)]
+      exact verticalSquareLatticeEdge_eq_upEdge e hEdge
+    rw [heq]
+    exact exists_absorbingGauge_normalSquareVerticalTranslatedEdge A B hA hUA hB hUB
+      (by omega) (by omega) (by omega) (by omega) hbond hAB hd hposA hposB
+
+/-- **The interior absorbed gauge family on the open square lattice.**
+
+For two tensors on the open square lattice with the rectangular-injectivity hypotheses, union
+closure, matched bond dimensions, the same state, and positive bonds, there is a per-edge gauge
+family `X` over the second tensor's bonds satisfying the bare-edge absorbed equality against
+`applyGauge B X` at every edge with interior margins: inserting `N` on `A`'s edge `e` matches
+inserting the reindexed `N` on `applyGauge B X`'s edge `e`, for every global physical
+configuration and every matrix.
+
+The family is built edge by edge: each interior edge receives its own absorbing gauge
+(`exists_absorbingGauge_of_normalSquareInteriorEdgeDatum`), and edges without interior margins
+receive the identity.  Because the bare-edge identity at an edge constrains only the family's
+value there, no compatibility between the choices is needed.  No covariance between the gauges
+of distinct edges is asserted; the translation-invariant reduction to one horizontal and one
+vertical matrix has no carrier on the open lattice, which carries no translations.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_normalSquareInteriorAbsorbedGaugeFamily
+    (A B : Tensor (squareLatticeGraph width height) d)
+    (hA : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hUA : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) A))
+    (hB : NormalSquareLatticeRectangleInjectivityHypotheses
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+            (regionInjectivityDataOf (G := squareLatticeGraph width height) B))
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (squareLatticeGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (squareLatticeGraph width height), 0 < B.bondDim g) :
+    ∃ X : (e : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim e)) ℂ,
+      ∀ e : Edge (squareLatticeGraph width height),
+        NormalSquareInteriorEdgeDatum e →
+        ∀ (σ : SquareLatticeVertex width height → Fin d)
+          (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+          edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+            edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+              (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) := by
+  classical
+  -- The per-edge selection: at interior edges the absorbing gauge, elsewhere the identity.
+  have hsel : ∀ e : Edge (squareLatticeGraph width height),
+      ∃ Ze : GL (Fin (B.bondDim e)) ℂ,
+        NormalSquareInteriorEdgeDatum e →
+        ∀ X : (g : Edge (squareLatticeGraph width height)) → GL (Fin (B.bondDim g)) ℂ,
+          X e = Ze →
+          ∀ (σ : SquareLatticeVertex width height → Fin d)
+            (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+            edgeInsertedCoeff (G := squareLatticeGraph width height) A e σ N =
+              edgeInsertedCoeff (G := squareLatticeGraph width height) (applyGauge B X) e σ
+                (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) := by
+    intro e
+    by_cases he : NormalSquareInteriorEdgeDatum e
+    · obtain ⟨Ze, hZe⟩ := exists_absorbingGauge_of_normalSquareInteriorEdgeDatum A B
+        hA hUA hB hUB hbond hAB hd hposA hposB e he
+      exact ⟨Ze, fun _ => hZe⟩
+    · exact ⟨1, fun hcon => absurd hcon he⟩
+  choose X hX using hsel
+  exact ⟨X, fun e he σ N => hX e he X rfl σ N⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
+++ b/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
@@ -153,6 +153,42 @@ theorem twoBlockProportional_of_edgeAbsorbed (A B : Tensor G d)
   regionComplement_comparison A (applyGauge B X) R hbd hRA hCA hRB hCB
     (fun f N σ τ => regionAbsorbed_of_edgeAbsorbed A B hbd X R hedge f N σ τ)
 
+/-- **Region-block scalar proportionality from the absorbed equality on the boundary edges.**
+
+The same conclusion as `twoBlockProportional_of_edgeAbsorbed`, with the edge-level absorbed
+equality required only at the *boundary edges* of the comparison region `R` rather than at every
+edge of the graph.  The comparison `regionComplement_comparison` consumes the region absorbed
+equality only at boundary edges of `R`, so the bare-edge identities there suffice.
+
+This restriction is what the open square lattice provides: the blocking frames reach only the
+edges with interior margins, so the absorbed equality is available on the boundary edges of a
+comparison region placed in the interior window, not on every lattice edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1544 of
+`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B̃_R`. -/
+theorem twoBlockProportional_of_boundaryEdgeAbsorbed (A B : Tensor G d)
+    (hbd : A.bondDim = B.bondDim)
+    (X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (R : Finset V)
+    [Nonempty {f : Edge G // IsRegionBoundaryEdge (G := G) R f}]
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G)
+      (reindexTensor (G := G) (applyGauge B X) hbd) R)
+    (hCB : RegionBlockedTensorInjective (G := G)
+      (reindexTensor (G := G) (applyGauge B X) hbd) (Finset.univ \ R))
+    (hedge : ∀ (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) (σ : V → Fin d)
+        (N : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ),
+      edgeInsertedCoeff (G := G) A f.1 σ N =
+        edgeInsertedCoeff (G := G) (applyGauge B X) f.1 σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) N)) :
+    ∃ c : ℂ, c ≠ 0 ∧
+      TwoBlockScalarProportional (regionTwoBlock (G := G) A R)
+        (regionTwoBlock (G := G) (reindexTensor (G := G) (applyGauge B X) hbd) R) c :=
+  regionComplement_comparison A (applyGauge B X) R hbd hRA hCA hRB hCB
+    (fun f M σ τ =>
+      regionInsertedCoeff_eq_applyGauge_of_edge A B hbd X f.1 (hedge f) R f rfl M σ τ)
+
 /-! ### Uniqueness of the proportionality scalar
 
 The scalar `c` in a region-block proportionality `A_R = c · B̃_R` is determined by `A` and `B̃`

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -5216,6 +5216,70 @@ injective and normal PEPS, following Theorems~2 and~3 of
     gauge of the edge blocking: from the orientation-uniform gauge absorption and
     the per-vertex single-scalar relation it derives the scalar condition
     $\lambda^{nm}=1$. The unconditional source theorem awaits the per-edge gauge.
+    Theorem~\ref{thm:fundamentalTheorem_normalSquarePEPS_unconditional} proves
+    an interior-window form of this statement from the source hypotheses alone,
+    without translation invariance and with per-vertex scalars in place of the
+    single $\lambda$.
+\end{theorem}
+
+\begin{theorem}[Fundamental Theorem for normal square-lattice PEPS,
+    interior-window form]%
+    \label{thm:fundamentalTheorem_normalSquarePEPS_unconditional}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_unconditional}
+    \leanok
+    \uses{thm:fundamentalTheorem_normalSquarePEPS,
+        def:peps_normalRectangleInjectivityHypotheses,
+        def:applyGauge,
+        def:peps_edgeInsertedCoeff}
+    Let $A$ and $B$ be PEPS tensors on the open $n\times m$ square lattice
+    with the same positive physical dimension, equal and positive bond
+    dimensions, generating the same state, and such that every contiguous
+    $2\times 3$ and $3\times 2$ coordinate rectangle of either tensor is
+    injective.  Then there is a family of invertible matrices, one on each
+    edge, such that:
+    \begin{enumerate}
+        \item at every edge with interior margins (for a horizontal edge with
+            left endpoint $(x,y)$: $3\le x$, $x+7\le n$, $4\le y$,
+            $y+6\le m$; for a vertical edge the mirrored margins), inserting
+            any matrix on the edge of $A$ gives the same coefficient as
+            inserting it on the corresponding edge of the gauge-absorbed $B$,
+            for every physical configuration; and
+        \item every vertex $v=(x,y)$ of the interior comparison window
+            $4\le x\le n-9$, $4\le y\le m-9$ carries a nonzero scalar
+            $\lambda_v$ such that $A_v$ equals $\lambda_v$ times the gauge
+            action of the family on $B$ at $v$, on every virtual configuration
+            of the incident edges and every physical index.
+    \end{enumerate}
+    This is the open-lattice form of \cite[Theorem~3]{Molnar2018NormalPEPS},
+    restricted in two ways. First, the conclusion reaches only the interior:
+    the absorbed equality holds at the edges with interior margins and the
+    per-vertex relation at the window vertices, while vertices near the
+    lattice boundary are not reached, the blocking frames of the open lattice
+    requiring interior margins. Second, the scalars of distinct vertices are
+    not asserted equal, and no condition $\lambda^{nm}=1$ is asserted: the
+    single $\lambda$ of the source comes from translation invariance, which is
+    not assumed here, and without it a single scalar is false --- rescaling
+    the components of $A$ at two interior vertices by $\mu$ and $\mu^{-1}$
+    preserves the state and the rectangular injectivity but separates the two
+    scalars. No lower bound on $n$ or $m$ is assumed; both conclusions are
+    empty when the lattice is too small to contain interior edges or window
+    vertices.
+    \begin{proof}
+        \leanok
+        \uses{lem:peps_injectiveRegion_union_pos}
+        The union closure of injective regions follows from the positive bond
+        dimensions and Lemma~\ref{lem:peps_injectiveRegion_union_pos}. The
+        translated blocking frames at the edges with interior margins produce
+        per-edge gauges, whose absorption into $B$ gives the absorbed
+        inserted-coefficient equality at every such edge. A gauge preserves
+        blocked-region linear independence, so at every window vertex the
+        region comparison applies to the gauge-absorbed tensor: comparing the
+        $3\times 3$ square at the vertex minus its corner with its one-site
+        completion yields two proportionality scalars $c_R$ and $c_S$, every
+        boundary edge of either region carrying interior margins, and the
+        inserted-site extraction gives the per-vertex relation with the ratio
+        $\lambda_v = c_S/c_R$.
+    \end{proof}
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus]%


### PR DESCRIPTION
## Summary

The first tranche of the open-square-lattice port of the unconditional normal PEPS Fundamental Theorem (arXiv:1804.04964, Section 3, Theorem 3 — the source's literal open n×m geometry; the torus form landed in #2672). Four pieces, all sorry-free:

- per-edge coefficient identity and absorbing gauge at interior square-lattice edges (the open-lattice analogue of the torus witness layer; interior margins required by the translated blocking frames);
- the interior absorbed gauge family: a single per-edge family with the bare-edge absorbed equality at every interior edge;
- `twoBlockProportional_of_boundaryEdgeAbsorbed` (graph-generic): the region comparison needs the absorbed equality only at the boundary edges of the comparison region — exactly what the interior-margin geometry provides;
- the comparison-region pair on the open lattice (3×3 square minus corner and its insert completion) with interior-window boundary edges.

The capstone assembly (interior-window per-vertex relation) follows in the next PR — its statement is drafted with two honest scope restrictions vs the source: the conclusion reaches the interior comparison window only, and the scalars are per-vertex (a single λ is false on the open lattice without a translation-invariance hypothesis: rescaling two interior vertices by μ and μ⁻¹ preserves the state and the rectangle injectivity but separates the scalars).

## Verification

- Full root `lake build` green (8888 jobs).
- No `sorry`/`axiom`/`admit`/`native_decide`/`maxHeartbeats`; no `IsVertexInjective`.

Part of #1373.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean proofs and blueprint documentation for PEPS theory; no runtime, auth, or data-path changes. Risk is mainly proof maintenance and build time on large imports.
> 
> **Overview**
> Ports the **unconditional interior-window** normal PEPS Fundamental Theorem (arXiv:1804.04964 §3) to the **open** square lattice, parallel to the torus assembly.
> 
> **New Lean chain:** interior per-edge **coefficient identities** and **absorbing gauges** (`NormalSquareEdgeCoeff`); edge-by-edge **interior absorbed gauge family** (`NormalSquareInteriorAbsorbedFamily`); **comparison regions** (3×3 minus corner vs completed square, injectivity, interior window) (`NormalSquareComparisonRegion`); capstone **`fundamentalTheorem_normalSquarePEPS_unconditional`** (`NormalSquareFundamentalTheorem2`) with bare-edge absorbed equality on interior-margin edges and **per-vertex** scalars λ_v in the comparison window.
> 
> **Graph-generic tweak:** `twoBlockProportional_of_boundaryEdgeAbsorbed` — region proportionality needs absorbed equality only on **boundary** edges of the comparison region (what open blocking geometry supplies).
> 
> **Scope vs source Theorem 3:** interior edges/window only; scalars not globalized (no single λ or λ^{nm}=1 without translation invariance). Blueprint documents the interior-window theorem and honest restrictions.
> 
> Root import surface updated; `gaugeVertex` sealed locally for elaboration budget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571d4ad0ca6928531026411212394044ede7615c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->