### PR TITLE
feat(PEPS): Fundamental Theorem for normal PEPS on a connected graph

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -600,3 +600,6 @@ import TNLean.PEPS.NormalAbsorbedFamily
 -- The per-vertex scalar of the general normal comparison: the one-site
 -- comparison pair on a connected graph, including the degenerate regions.
 import TNLean.PEPS.NormalComparisonScalar
+-- The Fundamental Theorem for normal PEPS on a connected graph: the
+-- scalar-free local gauge and its per-edge uniqueness up to a constant.
+import TNLean.PEPS.NormalGeneralFundamentalTheorem

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -597,3 +597,6 @@ import TNLean.PEPS.NormalPairBlocking
 -- The absorbed gauge family of a general normal PEPS blocking: the bare-edge
 -- absorbed equality at every edge of an arbitrary finite simple graph.
 import TNLean.PEPS.NormalAbsorbedFamily
+-- The per-vertex scalar of the general normal comparison: the one-site
+-- comparison pair on a connected graph, including the degenerate regions.
+import TNLean.PEPS.NormalComparisonScalar

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -594,3 +594,6 @@ import TNLean.PEPS.NormalSquareFundamentalTheorem2
 -- Shared blocking data for two normal PEPS tensors: the conjunction
 -- region-injectivity predicate and its one-edge projections.
 import TNLean.PEPS.NormalPairBlocking
+-- The absorbed gauge family of a general normal PEPS blocking: the bare-edge
+-- absorbed equality at every edge of an arbitrary finite simple graph.
+import TNLean.PEPS.NormalAbsorbedFamily

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -591,3 +591,6 @@ import TNLean.PEPS.NormalSquareInteriorAbsorbedFamily
 import TNLean.PEPS.NormalSquareComparisonRegion
 -- The unconditional interior-window Fundamental Theorem on the open square lattice.
 import TNLean.PEPS.NormalSquareFundamentalTheorem2
+-- Shared blocking data for two normal PEPS tensors: the conjunction
+-- region-injectivity predicate and its one-edge projections.
+import TNLean.PEPS.NormalPairBlocking

--- a/TNLean/PEPS/NormalAbsorbedFamily.lean
+++ b/TNLean/PEPS/NormalAbsorbedFamily.lean
@@ -1,0 +1,175 @@
+import TNLean.PEPS.NormalPairBlocking
+import TNLean.PEPS.CoherentFrameInstance2
+import TNLean.PEPS.NormalEdgeGaugeFamily
+import TNLean.PEPS.NormalSquareInjectivity
+import TNLean.PEPS.RegionBlock.ProportionalityFromAbsorbed
+
+/-!
+# The absorbed gauge family of a general normal PEPS blocking
+
+This file builds, from the general normal PEPS blocking hypotheses on an
+arbitrary finite simple graph (arXiv:1804.04964, Section 3, theorem labelled
+`normal`, lines 1576--1583 of `Papers/1804.04964/paper_normal.tex`), a single
+per-edge gauge family `X` with the bare-edge absorbed equality at *every* edge:
+
+> `edgeInsertedCoeff A e σ N = edgeInsertedCoeff (applyGauge B X) e σ (reindex N)`.
+
+Each edge receives its own absorbing gauge from the coherent-frame per-edge
+engine (`exists_regionEdgeGauge_of_blockingData`) fed the shared one-edge
+blocking datum of the pair predicate, and the conversion to the bare-edge
+absorbed form is the graph-generic `edgeAbsorbed_of_conjIdentity`.  Because the
+bare-edge identity at an edge constrains only the family's value there, the
+per-edge choices combine into one family with no compatibility conditions.
+This is the graph-general counterpart of the open-lattice family
+`exists_normalSquareInteriorAbsorbedGaugeFamily`, with no interior restriction:
+the blocking hypotheses supply a frame at every edge.
+
+**Scope restriction (single crossing edge):** the engine extracts the gauge on
+the distinguished edge `e` only when `e` is the *only* edge between the red and
+blue blocks, so the construction takes this single-crossing condition as an
+explicit hypothesis alongside the blocking bundle.  The source phrase "blocked
+into three partite injective MPS *around every edge*" is read here as: the
+chosen edge is the entire bond between the first two parties of the three-site
+chain, as in the source's Theorem 3 picture, where the two blocks adjacent to
+the edge touch only along it.  The recorded blocking bundle does not carry this
+condition as a field, so it is stated separately; see
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
+mathematical obligations".
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, theorem labelled `normal`, lines 1576--1583 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+open scoped Classical in
+/-- **The absorbing gauge at an edge of a shared blocking datum.**
+
+A one-edge blocking datum over the pair predicate of two tensors, whose
+distinguished edge is the single red-to-blue crossing, admits an invertible
+matrix `Ze` such that every per-edge gauge family `X` with `X e = Ze` satisfies
+the bare-edge absorbed equality at `e` against `applyGauge B X`: inserting `N`
+on `A`'s edge `e` matches inserting the reindexed `N` on `applyGauge B X`'s
+edge `e`, for every global physical configuration.
+
+The per-edge gauge comes from the coherent-frame engine
+(`exists_regionEdgeGauge_of_blockingData`) fed the two single-tensor
+projections of the shared datum; `Ze` is the orientation-adapted absorbing
+gauge of the engine gauge (`absorbedBoundaryGauge`), and the conversion is
+`edgeAbsorbed_of_conjIdentity`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph` applied around an
+edge, lines 1449--1544 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_absorbingGauge_of_pairBlockingDatum
+    (A B : Tensor G d) {e : Edge G}
+    (D : NormalEdgeBlockingData
+      (regionInjectivityDataPair (regionInjectivityDataOf (G := G) A)
+        (regionInjectivityDataOf (G := G) B)) G e)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A D.red D.blue g ↔ g = e)
+    (hUB : RegionInjectivityUnionClosure (regionInjectivityDataOf (G := G) B))
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g)
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g) :
+    ∃ Ze : GL (Fin (B.bondDim e)) ℂ,
+      ∀ X : (g : Edge G) → GL (Fin (B.bondDim g)) ℂ,
+        X e = Ze →
+        ∀ (σ : V → Fin d) (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+          edgeInsertedCoeff (G := G) A e σ N =
+            edgeInsertedCoeff (G := G) (applyGauge B X) e σ
+              (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) := by
+  classical
+  let DA := D.pairLeft
+  let DB := D.pairRight
+  have hred : DA.red = DB.red := rfl
+  have hblue : DA.blue = DB.blue := rfl
+  have hcompl : DA.complement = DB.complement := rfl
+  have hRB : RegionBlockedTensorInjective (G := G) B DA.red :=
+    regionBlockedTensorInjective_red DB
+  have hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ DA.red) :=
+    regionBlockedTensorInjective_host DB hUB
+  obtain ⟨htransferAB, htransferBA, hmul, hEdge, Z, hZ⟩ :=
+    exists_regionEdgeGauge_of_blockingData (A := A) (B := B) (e := e) DA DB
+      hred hblue hcompl hbond hAB hd hposA hposB hsingle hRB hCB
+  have hEeq : hEdge = congr_fun hbond e := Subsingleton.elim _ _
+  subst hEeq
+  set f := singleBoundaryEdge (G := G) A DA.red DA.blue e hsingle with hfdef
+  have hcoeff : ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
+      (σ : RegionPhysicalConfig (V := V) (d := d) DA.red)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ DA.red)),
+      regionInsertedCoeff (G := G) A DA.red f M σ τ =
+        regionInsertedCoeff (G := G) B DA.red f
+          ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
+              Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) M *
+            (↑Z⁻¹ : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ)) σ τ := by
+    intro M σ τ
+    have hfwd := (regionInsertionTransfer_of_coeffTransfer A B DA.red f
+      hRB hCB hAB hposB hbond htransferAB htransferBA hmul).fwd_coeff M σ τ
+    rw [hZ M] at hfwd
+    exact hfwd
+  refine ⟨absorbedBoundaryGauge (G := G) B DA.red f Z, fun X hXe σ N => ?_⟩
+  exact edgeAbsorbed_of_conjIdentity A B DA.red f hbond Z X hXe hposA
+    (fun M σ' τ' => hcoeff M σ' τ') σ N
+
+open scoped Classical in
+/-- **The absorbed gauge family of the general normal blocking hypotheses.**
+
+For two tensors on a finite simple graph satisfying the general normal PEPS
+blocking hypotheses over the pair predicate, with each distinguished edge the
+single red-to-blue crossing of its frame, matched bond dimensions, the same
+state, and positive bonds, there is a per-edge gauge family `X` over the second
+tensor's bonds with the bare-edge absorbed equality at every edge.
+
+The family is built edge by edge from
+`exists_absorbingGauge_of_pairBlockingDatum`; the bare-edge identity at an edge
+constrains only the family's value there, so the choices need no compatibility.
+
+**Scope restriction (single crossing edge):** the single-crossing condition
+`hsingle` is the formal content of blocking *around* each edge; see the module
+docstring and `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583, via the proof of Theorem 3, lines 1449--1544 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_normalAbsorbedGaugeFamily
+    (A B : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses
+      (regionInjectivityDataPair (regionInjectivityDataOf (G := G) A)
+        (regionInjectivityDataOf (G := G) B)) G)
+    (hsingle : ∀ e g : Edge G,
+      IsCrossingEdge (G := G) A (h.edgeBlocking.red e) (h.edgeBlocking.blue e) g ↔ g = e)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g)
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g) :
+    ∃ X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ,
+      ∀ (e : Edge G) (σ : V → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+        edgeInsertedCoeff (G := G) A e σ N =
+          edgeInsertedCoeff (G := G) (applyGauge B X) e σ
+            (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) := by
+  classical
+  have hUB : RegionInjectivityUnionClosure (regionInjectivityDataOf (G := G) B) :=
+    regionInjectivityUnionClosure_of_overlap B hposB
+  have hsel : ∀ e : Edge G, ∃ Ze : GL (Fin (B.bondDim e)) ℂ,
+      ∀ X : (g : Edge G) → GL (Fin (B.bondDim g)) ℂ,
+        X e = Ze →
+        ∀ (σ : V → Fin d) (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+          edgeInsertedCoeff (G := G) A e σ N =
+            edgeInsertedCoeff (G := G) (applyGauge B X) e σ
+              (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) :=
+    fun e => exists_absorbingGauge_of_pairBlockingDatum A B
+      (h.edgeBlocking.blockingData e) (hsingle e) hUB hbond hAB hd hposA hposB
+  choose X hX using hsel
+  exact ⟨X, fun e σ N => hX e X rfl σ N⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalComparisonScalar.lean
+++ b/TNLean/PEPS/NormalComparisonScalar.lean
@@ -1,0 +1,293 @@
+import TNLean.PEPS.NormalAbsorbedFamily
+import TNLean.PEPS.RegionBlock.ScalarExtraction
+import TNLean.PEPS.RegionBlock.ReindexInjectivity
+import TNLean.PEPS.RegionBlock.GaugeInjectivity2
+import TNLean.PEPS.FundamentalTheorem
+
+/-!
+# The per-vertex scalar of the general normal PEPS comparison
+
+This file performs the one-site comparison of the general normal PEPS theorem
+(arXiv:1804.04964, Section 3, theorem labelled `normal`, lines 1576--1583 of
+`Papers/1804.04964/paper_normal.tex`) on an arbitrary connected finite simple
+graph: at every vertex `v`, the two one-site-different injective regions of the
+blocking hypotheses, compared against the gauge-absorbed second tensor through
+the bare-edge absorbed equality, produce a nonzero scalar `λ_v` with
+
+> `A_v = λ_v · (gauge action of B at v)`.
+
+The comparison pair is `R = withoutSite v` and `insert v R = withSite v`; each
+member yields a region-block scalar proportionality
+(`twoBlockProportional_of_edgeAbsorbed`), and the inserted-site scalar
+extraction (`component_eq_gaugeVertex_of_twoBlockProportional`) divides the two
+proportionality scalars into `λ_v`.
+
+The hypothesis bundle allows two degenerate comparison regions on which the
+boundary-edge engine cannot run, because they have no boundary edges: the empty
+region (the site's region pair is `(∅, {v})`) and the full vertex set (the pair
+is `(V \ {v}, V)`).  At most one member of a pair is degenerate, and on the
+degenerate member the proportionality holds directly with scalar `1`: the
+empty-region block of any tensor is the constant counting the global virtual
+configurations, and the full-region block is the closed state coefficient,
+where `SameState` applies.  All other regions have a boundary edge by
+connectivity (`nonempty_regionBoundaryEdge_of_connected`).
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, theorem labelled `normal`, lines 1576--1583 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The two degenerate comparison regions
+
+The empty region and the full vertex set have no boundary edges, so their
+blocked tensors are a counting constant and the closed state coefficient
+respectively; in both cases the comparison proportionality holds with
+scalar `1`. -/
+
+/-- The blocked weight of the empty region is the number of global virtual
+configurations: there are no boundary edges, no vertices, and every global
+virtual configuration contributes the empty product.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex` (the degenerate end of the one-site
+comparison pair). -/
+theorem regionBlockedWeight_empty (A : Tensor G d)
+    (μ : RegionBoundaryConfig (G := G) A (∅ : Finset V))
+    (τ : RegionPhysicalConfig (V := V) (d := d) (∅ : Finset V)) :
+    regionBlockedWeight (G := G) A ∅ μ τ = (Fintype.card (VirtualConfig A) : ℂ) := by
+  classical
+  haveI hbdry : IsEmpty {f : Edge G // IsRegionBoundaryEdge (G := G) (∅ : Finset V) f} := by
+    refine ⟨fun f => ?_⟩
+    rcases f.2 with ⟨h1, _⟩ | ⟨_, h2⟩
+    · exact absurd h1 (Finset.notMem_empty _)
+    · exact absurd h2 (Finset.notMem_empty _)
+  haveI hvert : IsEmpty {w : V // w ∈ (∅ : Finset V)} :=
+    ⟨fun w => absurd w.2 (Finset.notMem_empty _)⟩
+  unfold regionBlockedWeight
+  have hfilter : (Finset.univ.filter
+      (fun ζ : VirtualConfig A => regionBoundaryLabel (G := G) A ∅ ζ = μ)) =
+        Finset.univ :=
+    Finset.filter_true_of_mem (fun ζ _ => funext fun f => hbdry.elim f)
+  rw [hfilter, Finset.sum_congr rfl (fun ζ _ => Finset.prod_of_isEmpty _),
+    Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one]
+
+/-- The blocked weight of the full vertex set is the closed state coefficient:
+there are no boundary edges, and the vertex product runs over all vertices.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex` (the degenerate end of the one-site
+comparison pair). -/
+theorem regionBlockedWeight_univ (A : Tensor G d)
+    (μ : RegionBoundaryConfig (G := G) A (Finset.univ : Finset V))
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ : Finset V)) :
+    regionBlockedWeight (G := G) A Finset.univ μ τ =
+      stateCoeff A (fun v => τ ⟨v, Finset.mem_univ v⟩) := by
+  classical
+  haveI hbdry :
+      IsEmpty {f : Edge G // IsRegionBoundaryEdge (G := G) (Finset.univ : Finset V) f} := by
+    refine ⟨fun f => ?_⟩
+    rcases f.2 with ⟨_, h2⟩ | ⟨h1, _⟩
+    · exact h2 (Finset.mem_univ _)
+    · exact h1 (Finset.mem_univ _)
+  unfold regionBlockedWeight stateCoeff
+  have hfilter : (Finset.univ.filter
+      (fun ζ : VirtualConfig A =>
+        regionBoundaryLabel (G := G) A Finset.univ ζ = μ)) = Finset.univ :=
+    Finset.filter_true_of_mem (fun ζ _ => funext fun f => hbdry.elim f)
+  rw [hfilter]
+  refine Finset.sum_congr rfl (fun ζ _ => ?_)
+  exact Fintype.prod_equiv (Equiv.subtypeUnivEquiv (fun v => Finset.mem_univ v))
+    _ _ (fun w => rfl)
+
+/-- **The empty-region comparison proportionality.**  Over the empty region the
+blocked tensors of `A` and of any reindexed tensor with `A`'s bond dimensions
+are both the counting constant of the global virtual configurations, so they
+are proportional with scalar `1`.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex` (the comparison pair at a
+site whose smaller region is empty). -/
+theorem twoBlockScalarProportional_one_of_empty (A C : Tensor G d)
+    (hbd : A.bondDim = C.bondDim) :
+    TwoBlockScalarProportional (regionTwoBlock (G := G) A (∅ : Finset V))
+      (regionTwoBlock (G := G) (reindexTensor (G := G) C hbd) (∅ : Finset V)) 1 := by
+  intro η μ σ
+  rw [regionTwoBlock_apply, regionTwoBlock_apply, one_mul,
+    regionBlockedWeight_empty, regionBlockedWeight_empty]
+  rfl
+
+/-- **The full-region comparison proportionality.**  Over the full vertex set
+the blocked tensor of `A` is the closed state coefficient and the blocked
+tensor of the reindexed gauge-absorbed second tensor is the second state's
+coefficient, so `SameState` gives the proportionality with scalar `1`.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex` (the comparison pair at a
+site whose larger region is the full lattice). -/
+theorem twoBlockScalarProportional_one_of_univ (A B : Tensor G d)
+    (hbond : A.bondDim = B.bondDim)
+    (X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ) (hAB : SameState A B) :
+    TwoBlockScalarProportional
+      (regionTwoBlock (G := G) A (Finset.univ : Finset V))
+      (regionTwoBlock (G := G) (reindexTensor (G := G) (applyGauge B X) hbond)
+        (Finset.univ : Finset V)) 1 := by
+  intro η μ τ
+  rw [regionTwoBlock_apply, regionTwoBlock_apply, one_mul,
+    regionBlockedWeight_univ, regionBlockedWeight_univ,
+    stateCoeff_reindexTensor (applyGauge B X) hbond, applyGauge_stateCoeff]
+  exact hAB _
+
+/-! ### The per-vertex scalar from the one-site comparison -/
+
+open scoped Classical in
+/-- **The per-vertex scalar of the general normal comparison.**
+
+Under the general normal PEPS blocking hypotheses over the pair predicate on a
+connected graph, with matched bond dimensions, the same state, positive bonds
+for the first tensor, and a gauge family `X` realizing the bare-edge absorbed
+equality at every edge, every vertex `v` carries a nonzero scalar `λ_v` with
+`A_v = λ_v · (gauge action of B at v)` on every local virtual configuration and
+physical index.
+
+The comparison pair at `v` is `withoutSite v` and
+`withSite v = insert v (withoutSite v)`; each member yields a region-block
+proportionality — through the boundary-edge engine when it has a boundary edge,
+and with scalar `1` directly on the degenerate members (the empty region and
+the full vertex set) — and the inserted-site scalar extraction gives
+`λ_v = c_S / c_R`.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583, via the proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem exists_normalPerVertexScalar
+    (A B : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses
+      (regionInjectivityDataPair (regionInjectivityDataOf (G := G) A)
+        (regionInjectivityDataOf (G := G) B)) G)
+    (hconn : G.Connected)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g)
+    (X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
+    (hedge : ∀ (e : Edge G) (σ : V → Fin d)
+        (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ),
+      edgeInsertedCoeff (G := G) A e σ N =
+        edgeInsertedCoeff (G := G) (applyGauge B X) e σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N))
+    (v : V) :
+    ∃ lam : ℂ, lam ≠ 0 ∧
+      ∀ (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+        A.component v η σ =
+          lam * gaugeVertex B X v
+            (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ := by
+  classical
+  have hvR : v ∉ h.oneSiteSeparation.withoutSite v :=
+    h.oneSiteSeparation.site_notMem_withoutSite v
+  have hSins : h.oneSiteSeparation.withSite v =
+      insert v (h.oneSiteSeparation.withoutSite v) :=
+    h.oneSiteSeparation.withSite_eq_insert v
+  -- Blocked-tensor injectivity of the comparison pair for `A`.
+  have hRA : RegionBlockedTensorInjective (G := G) A
+      (h.oneSiteSeparation.withoutSite v) := by
+    have hi := (h.oneSiteSeparation.withoutSite_injective v).1
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCA : RegionBlockedTensorInjective (G := G) A
+      (Finset.univ \ h.oneSiteSeparation.withoutSite v) := by
+    have hi := (h.oneSiteSeparation.withoutSite_complement_injective v).1
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hSA : RegionBlockedTensorInjective (G := G) A
+      (insert v (h.oneSiteSeparation.withoutSite v)) := by
+    have hi := (h.oneSiteSeparation.withSite_injective v).1
+    rw [regionInjectivityDataOf_isInjective] at hi
+    rwa [hSins] at hi
+  have hCSA : RegionBlockedTensorInjective (G := G) A
+      (Finset.univ \ insert v (h.oneSiteSeparation.withoutSite v)) := by
+    have hi := (h.oneSiteSeparation.withSite_complement_injective v).1
+    rw [regionInjectivityDataOf_isInjective] at hi
+    rwa [hSins] at hi
+  -- Blocked-tensor injectivity of the comparison pair for the reindexed
+  -- gauge-absorbed second tensor.
+  have hgauge : ∀ R : Finset V, RegionBlockedTensorInjective (G := G) B R →
+      RegionBlockedTensorInjective (G := G)
+        (reindexTensor (G := G) (applyGauge B X) hbond) R :=
+    fun R hi => regionBlockedTensorInjective_reindexTensor (applyGauge B X) hbond R
+      (regionBlockedTensorInjective_applyGauge B X R hi)
+  have hRC : RegionBlockedTensorInjective (G := G)
+      (reindexTensor (G := G) (applyGauge B X) hbond)
+      (h.oneSiteSeparation.withoutSite v) := by
+    refine hgauge _ ?_
+    have hi := (h.oneSiteSeparation.withoutSite_injective v).2
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCC : RegionBlockedTensorInjective (G := G)
+      (reindexTensor (G := G) (applyGauge B X) hbond)
+      (Finset.univ \ h.oneSiteSeparation.withoutSite v) := by
+    refine hgauge _ ?_
+    have hi := (h.oneSiteSeparation.withoutSite_complement_injective v).2
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hSC : RegionBlockedTensorInjective (G := G)
+      (reindexTensor (G := G) (applyGauge B X) hbond)
+      (insert v (h.oneSiteSeparation.withoutSite v)) := by
+    refine hgauge _ ?_
+    have hi := (h.oneSiteSeparation.withSite_injective v).2
+    rw [regionInjectivityDataOf_isInjective] at hi
+    rwa [hSins] at hi
+  have hCSC : RegionBlockedTensorInjective (G := G)
+      (reindexTensor (G := G) (applyGauge B X) hbond)
+      (Finset.univ \ insert v (h.oneSiteSeparation.withoutSite v)) := by
+    refine hgauge _ ?_
+    have hi := (h.oneSiteSeparation.withSite_complement_injective v).2
+    rw [regionInjectivityDataOf_isInjective] at hi
+    rwa [hSins] at hi
+  -- The proportionality over the comparison region.
+  have hpropR : ∃ cR : ℂ, cR ≠ 0 ∧
+      TwoBlockScalarProportional.{_, _, 0, _}
+        (regionTwoBlock (G := G) A (h.oneSiteSeparation.withoutSite v))
+        (regionTwoBlock (G := G)
+          (reindexTensor (G := G) (applyGauge B X) hbond)
+          (h.oneSiteSeparation.withoutSite v)) cR := by
+    by_cases hRempty : h.oneSiteSeparation.withoutSite v = ∅
+    · refine ⟨1, one_ne_zero, ?_⟩
+      rw [hRempty]
+      exact twoBlockScalarProportional_one_of_empty A (applyGauge B X) hbond
+    · have hRtop : h.oneSiteSeparation.withoutSite v ≠ Finset.univ := fun htop =>
+        hvR (htop ▸ Finset.mem_univ v)
+      haveI := nonempty_regionBoundaryEdge_of_connected hconn
+        (Finset.nonempty_iff_ne_empty.mpr hRempty) hRtop
+      exact twoBlockProportional_of_edgeAbsorbed A B hbond X
+        (h.oneSiteSeparation.withoutSite v) hRA hCA hRC hCC hedge
+  -- The proportionality over the one-site completion.
+  have hpropS : ∃ cS : ℂ, cS ≠ 0 ∧
+      TwoBlockScalarProportional.{_, _, 0, _}
+        (regionTwoBlock (G := G) A
+          (insert v (h.oneSiteSeparation.withoutSite v)))
+        (regionTwoBlock (G := G)
+          (reindexTensor (G := G) (applyGauge B X) hbond)
+          (insert v (h.oneSiteSeparation.withoutSite v))) cS := by
+    by_cases hStop : insert v (h.oneSiteSeparation.withoutSite v) = Finset.univ
+    · refine ⟨1, one_ne_zero, ?_⟩
+      rw [hStop]
+      exact twoBlockScalarProportional_one_of_univ A B hbond X hAB
+    · have hSne : (insert v (h.oneSiteSeparation.withoutSite v)).Nonempty :=
+        ⟨v, Finset.mem_insert_self v _⟩
+      haveI := nonempty_regionBoundaryEdge_of_connected hconn hSne hStop
+      exact twoBlockProportional_of_edgeAbsorbed A B hbond X
+        (insert v (h.oneSiteSeparation.withoutSite v)) hSA hCSA hSC hCSC hedge
+  obtain ⟨cR, hcR0, hcRprop⟩ := hpropR
+  obtain ⟨cS, hcS0, hcSprop⟩ := hpropS
+  exact ⟨cS / cR, div_ne_zero hcS0 hcR0,
+    component_eq_gaugeVertex_of_twoBlockProportional A B
+      (h.oneSiteSeparation.withoutSite v) hvR hbond X cR cS hcR0 hposA
+      hRC hcRprop hcSprop⟩
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalGeneralFundamentalTheorem.lean
+++ b/TNLean/PEPS/NormalGeneralFundamentalTheorem.lean
@@ -1,0 +1,343 @@
+import TNLean.PEPS.NormalComparisonScalar
+import TNLean.PEPS.RegionScalarCondition
+import TNLean.PEPS.TorusGaugeUniqueness
+
+/-!
+# The Fundamental Theorem for normal PEPS on a connected graph
+
+This file assembles the general normal PEPS Fundamental Theorem
+(arXiv:1804.04964, Section 3, theorem labelled `normal`, lines 1576--1583 of
+`Papers/1804.04964/paper_normal.tex`): two normal PEPS on a connected finite
+simple graph generating the same state, blocked into three partite injective
+chains around every edge and admitting one-site-different injective regions
+with injective complements at every site, have gauge-equivalent defining
+tensors; and the gauges are unique up to a multiplicative constant on each
+edge.
+
+The route follows the source.  The blocking hypotheses produce a per-edge
+absorbing gauge family with the bare-edge absorbed equality at every edge
+(`exists_normalAbsorbedGaugeFamily`); the one-site comparisons give a nonzero
+scalar `λ_v` at every vertex with `A_v = λ_v · (gauge action of B at v)`
+(`exists_normalPerVertexScalar`); the closed state pins `∏_v λ_v = 1`
+(`prod_perVertexScalar_eq_one_of_regionInjective`); and on the connected graph
+the scalars are absorbed into the edge gauges by the oriented-incidence solve
+of the injective Fundamental Theorem (`exists_edgeScalars_of_connected`,
+`perVertex_gauge_identity`), leaving the scalar-free gauge relation
+`GaugeEquiv A B`.  This matches the source remark after the theorem: the
+statement holds at fixed system size with no translation invariance, the
+proportionality constants being absorbed into the gauges.
+
+The added hypotheses relative to the source statement are documented:
+
+* **Scope restriction (single crossing edge):** the engine extracts the gauge
+  on the distinguished edge only when it is the entire bond between the red and
+  blue blocks; this reading of "blocked ... around every edge" is an explicit
+  hypothesis (see `TNLean.PEPS.NormalAbsorbedFamily` and
+  `docs/paper-gaps/peps_normal_ft_section3_route.tex`).
+* Matched bond dimensions are assumed, as in the torus and open-lattice
+  assemblies.
+* Positive bond dimensions and connectivity are the faithfulness fixes of the
+  injective Fundamental Theorem, both backed by machine-checked
+  counterexamples (`docs/paper-gaps/peps_injective_ft_section3_route.tex`,
+  `docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex`); the scalar
+  absorption is exactly the step that requires connectivity.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, theorem labelled `normal`, lines 1576--1583 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Existence of the local gauge -/
+
+/-- **Fundamental Theorem for normal PEPS on a connected graph**
+(arXiv:1804.04964, Section 3, theorem labelled `normal`).
+
+Two tensors on a connected finite simple graph satisfying the general normal
+PEPS blocking hypotheses over the pair predicate — every edge carries a
+three-region injective blocking shared by both tensors, and every site admits
+one-site-different injective regions with injective complements, also shared —
+with each distinguished edge the single red-to-blue crossing of its frame,
+matched bond dimensions, the same state, and positive bond dimensions, are
+gauge equivalent: there are invertible edge matrices relating the defining
+tensors with no leftover scalar.
+
+The per-vertex scalars `λ_v` produced by the one-site comparisons satisfy
+`∏_v λ_v = 1` by the closed state equality, so on the connected graph they are
+absorbed into the edge gauges, as in the source's remark that the
+proportionality constants can be incorporated into the gauge transformations.
+
+**Scope restriction (single crossing edge):** the hypothesis `hsingle` is the
+formal content of blocking *around* each edge — the distinguished edge is the
+entire bond between the first two parties of the three-site chain; see
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.  Matched bond dimensions
+are assumed; positive bonds and connectivity are the counterexample-backed
+faithfulness fixes of the injective Fundamental Theorem
+(`docs/paper-gaps/peps_injective_ft_section3_route.tex`,
+`docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex`).
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalPEPS
+    (A B : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses
+      (regionInjectivityDataPair (regionInjectivityDataOf (G := G) A)
+        (regionInjectivityDataOf (G := G) B)) G)
+    (hsingle : ∀ e g : Edge G,
+      IsCrossingEdge (G := G) A (h.edgeBlocking.red e) (h.edgeBlocking.blue e) g ↔ g = e)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g)
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hconn : G.Connected) :
+    GaugeEquiv A B := by
+  classical
+  -- The absorbing gauge family with the bare-edge absorbed equality everywhere.
+  obtain ⟨Z, hedge⟩ :=
+    exists_normalAbsorbedGaugeFamily A B h hsingle hbond hAB hd hposA hposB
+  -- The per-vertex scalars from the one-site comparisons.
+  have hpvs : ∀ v : V, ∃ lam : ℂ, lam ≠ 0 ∧
+      ∀ (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+        A.component v η σ =
+          lam * gaugeVertex B Z v
+            (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ :=
+    fun v => exists_normalPerVertexScalar A B h hconn hbond hAB hposA Z hedge v
+  choose c hcne hcPV using hpvs
+  -- The closed state pins the product of the scalars to one.
+  obtain ⟨v₀⟩ := hconn.nonempty
+  have hRA0 : RegionBlockedTensorInjective (G := G) A
+      (h.oneSiteSeparation.withoutSite v₀) := by
+    have hi := (h.oneSiteSeparation.withoutSite_injective v₀).1
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hCA0 : RegionBlockedTensorInjective (G := G) A
+      (Finset.univ \ h.oneSiteSeparation.withoutSite v₀) := by
+    have hi := (h.oneSiteSeparation.withoutSite_complement_injective v₀).1
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hprod : (∏ v, c v) = 1 :=
+    prod_perVertexScalar_eq_one_of_regionInjective A B
+      (h.oneSiteSeparation.withoutSite v₀) hRA0 hCA0 hposA hAB Z hbond c hcPV
+  -- The scalars are absorbed into the gauges on the connected graph.
+  set t : V → ℂˣ := fun v => (Units.mk0 (c v) (hcne v))⁻¹ with ht
+  have htprod : (∏ v, t v) = 1 := by
+    have hmk : (∏ v, (Units.mk0 (c v) (hcne v))) = 1 := by
+      apply Units.ext
+      rw [Units.val_one, Units.coe_prod]
+      simp only [Units.val_mk0]
+      exact hprod
+    rw [ht]
+    simp only
+    rw [Finset.prod_inv_distrib, hmk, inv_one]
+  obtain ⟨s, hs⟩ := exists_edgeScalars_of_connected hconn t htprod
+  refine ⟨hbond, globalGauge A B hbond Z s, ?_⟩
+  intro v η σ
+  have hcs : ∏ ie : IncidentEdge G v, (edgeScalarUnit (G := G) s v ie : ℂ) = (c v)⁻¹ := by
+    have hsv := hs v
+    rw [orientedIncidence] at hsv
+    have hval : ((∏ ie : IncidentEdge G v, edgeScalarUnit (G := G) s v ie : ℂˣ) : ℂ)
+        = (c v)⁻¹ := by
+      rw [hsv, ht]
+      simp [Units.val_mk0]
+    rwa [Units.coe_prod] at hval
+  exact perVertex_gauge_identity A B hbond Z s v (c v) (hcne v) hcs
+    (fun η σ => hcPV v η σ) η σ
+
+/-! ### Uniqueness of the gauges up to a multiplicative constant
+
+The last clause of the source theorem.  Two gauge families realizing the
+scalar-free per-vertex relation each induce the bare-edge absorbed equality at
+every edge, and on the single boundary edge of any region at which the first
+tensor is region- and complement-injective the absorbing gauges induce the same
+conjugation map, hence differ by a nonzero scalar. -/
+
+open scoped Classical in
+/-- **Per-edge uniqueness of an absorbing gauge family, from a comparison
+region.**
+
+Two gauge families `X`, `X'` both realizing the bare-edge absorbed equality at
+the boundary edge `f.1` of a region `R` at which `B` is region- and
+complement-injective are proportional at that edge: `X' f.1 = c · X f.1` for a
+nonzero scalar `c`.  This is the graph-general form of
+`torusAbsorbedGauge_unique_scalar_of_region`: both families induce the
+conjugation-form coefficient identity at `R`, `f`
+(`regionConjIdentity_of_edgeAbsorbed`), the region-insertion transfer map is
+determined by the identity (`gaugeConj_eq_of_coeffIdentities`), so the two
+absorbing gauges differ by a scalar (`gl_conj_unique_scalar`), and unwinding
+the orientation adaptation gives the proportionality of the gauges themselves.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 (the gauges are unique up to a multiplicative constant), via the
+conjugator determinacy of the isomorphism lemma, lines 560--583 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem absorbedGauge_unique_scalar_of_region
+    (A B : Tensor G d) (hbd : A.bondDim = B.bondDim)
+    (R : Finset V) (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (X X' : (g : Edge G) → GL (Fin (B.bondDim g)) ℂ)
+    (hedgeX : ∀ (σ : V → Fin d)
+      (N : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ),
+      edgeInsertedCoeff (G := G) A f.1 σ N =
+        edgeInsertedCoeff (G := G) (applyGauge B X) f.1 σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) N))
+    (hedgeX' : ∀ (σ : V → Fin d)
+      (N : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ),
+      edgeInsertedCoeff (G := G) A f.1 σ N =
+        edgeInsertedCoeff (G := G) (applyGauge B X') f.1 σ
+          (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1)) N)) :
+    ∃ c : ℂˣ, (X' f.1 : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) =
+      (c : ℂ) • (X f.1 : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) := by
+  -- The two absorbing gauges induce the same conjugation map.
+  have hconj : ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      (absorbedBoundaryGauge (G := G) B R f (X f.1) :
+          Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) * N *
+        (↑(absorbedBoundaryGauge (G := G) B R f (X f.1))⁻¹ :
+          Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) =
+      (absorbedBoundaryGauge (G := G) B R f (X' f.1) :
+          Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) * N *
+        (↑(absorbedBoundaryGauge (G := G) B R f (X' f.1))⁻¹ :
+          Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) := by
+    intro N
+    obtain ⟨M, rfl⟩ :=
+      (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbd f.1))).surjective N
+    exact gaugeConj_eq_of_coeffIdentities A B R f hRB hCB hposB
+      (hE₁ := congr_fun hbd f.1) (hE₂ := congr_fun hbd f.1)
+      (absorbedBoundaryGauge (G := G) B R f (X f.1))
+      (absorbedBoundaryGauge (G := G) B R f (X' f.1))
+      (fun M σ τ => regionConjIdentity_of_edgeAbsorbed A B hbd X R f hedgeX M σ τ)
+      (fun M σ τ => regionConjIdentity_of_edgeAbsorbed A B hbd X' R f hedgeX' M σ τ) M
+  obtain ⟨c, hc⟩ := gl_conj_unique_scalar
+    (absorbedBoundaryGauge (G := G) B R f (X f.1))
+    (absorbedBoundaryGauge (G := G) B R f (X' f.1)) hconj
+  -- Unwind the orientation adaptation on each branch.
+  by_cases hmem : f.1.1.1 ∈ R
+  · refine ⟨c, ?_⟩
+    have hZ : absorbedBoundaryGauge (G := G) B R f (X f.1) = glTranspose (X f.1) := by
+      unfold absorbedBoundaryGauge; rw [if_pos hmem]
+    have hZ' : absorbedBoundaryGauge (G := G) B R f (X' f.1) = glTranspose (X' f.1) := by
+      unfold absorbedBoundaryGauge; rw [if_pos hmem]
+    rw [hZ, hZ', glTranspose_coe, glTranspose_coe] at hc
+    have htr := congrArg Matrix.transpose hc
+    rwa [Matrix.transpose_transpose, Matrix.transpose_smul, Matrix.transpose_transpose] at htr
+  · refine ⟨c⁻¹, ?_⟩
+    have hZ : absorbedBoundaryGauge (G := G) B R f (X f.1) = (X f.1)⁻¹ := by
+      unfold absorbedBoundaryGauge; rw [if_neg hmem]
+    have hZ' : absorbedBoundaryGauge (G := G) B R f (X' f.1) = (X' f.1)⁻¹ := by
+      unfold absorbedBoundaryGauge; rw [if_neg hmem]
+    rw [hZ, hZ'] at hc
+    have hinv := gl_inv_coe_smul (W := (X f.1)⁻¹) (W' := (X' f.1)⁻¹) hc
+    rwa [inv_inv, inv_inv] at hinv
+
+open scoped Classical in
+/-- **The bare-edge absorbed equality from a scalar per-vertex relation.**
+
+If `A` satisfies `A_v = λ · (gauge action of B at v)` at every vertex with
+`λ^{|V|} = 1`, then the bare-edge absorbed equality holds at every edge.  This
+is the graph-general form of the torus `edgeAbsorbed_of_perVertex`: the
+edge-inserted coefficient picks up one factor of `λ` per site
+(`edgeInsertedCoeff_eq_pow_card_mul_reindexTensor`).
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1471 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem edgeAbsorbed_of_perVertex_card
+    (A B : Tensor G d) (hbond : A.bondDim = B.bondDim)
+    (X : (g : Edge G) → GL (Fin (B.bondDim g)) ℂ) {lam : ℂ}
+    (hPV : ∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+      A.component v η σ =
+        lam * gaugeVertex B X v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ)
+    (hlam : lam ^ (Fintype.card V) = 1)
+    (e : Edge G) (σ : V → Fin d)
+    (N : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) :
+    edgeInsertedCoeff (G := G) A e σ N =
+      edgeInsertedCoeff (G := G) (applyGauge B X) e σ
+        (Matrix.reindexAlgEquiv ℂ ℂ (finCongr (congr_fun hbond e)) N) := by
+  have hscale := edgeInsertedCoeff_eq_pow_card_mul_reindexTensor A (applyGauge B X) hbond lam
+    hPV e σ N
+  rw [hscale, edgeInsertedCoeff_reindexTensor (applyGauge B X) hbond e σ N, hlam, one_mul]
+  rfl
+
+open scoped Classical in
+/-- **Uniqueness clause of the Fundamental Theorem for normal PEPS**
+(arXiv:1804.04964, Section 3, theorem labelled `normal`: the gauges are unique
+up to a multiplicative constant).
+
+Two gauge families `X`, `X'` each realizing the scalar-free gauge relation of
+`fundamentalTheorem_normalPEPS` — `B_v = (gauge action of A at v)` at every
+vertex — are proportional at every edge: `X' e = c · X e` for a nonzero
+scalar `c`.  Each relation yields the bare-edge absorbed equality with the
+roles of the two tensors exchanged (`edgeAbsorbed_of_perVertex_card` with
+scalar `1`), and the equalities determine the gauge at `e` up to a scalar on
+the red block of `e`'s frame (`absorbedGauge_unique_scalar_of_region`), whose
+block and host injectivity for the first tensor come from the blocking
+hypotheses and union closure.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalPEPS_gauge_unique
+    (A B : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses
+      (regionInjectivityDataPair (regionInjectivityDataOf (G := G) A)
+        (regionInjectivityDataOf (G := G) B)) G)
+    (hbond : A.bondDim = B.bondDim)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g)
+    (X X' : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ)
+    (hX : ∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+      B.component v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ =
+        gaugeVertex A X v η σ)
+    (hX' : ∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+      B.component v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ =
+        gaugeVertex A X' v η σ)
+    (e : Edge G) :
+    ∃ c : ℂˣ, (X' e : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+      (c : ℂ) • (X e : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) := by
+  classical
+  -- The scalar-free relation in the exchanged-roles per-vertex form.
+  have hswap : ∀ (Y : (g : Edge G) → GL (Fin (A.bondDim g)) ℂ),
+      (∀ (v : V) (η : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1)) (σ : Fin d),
+        B.component v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ =
+          gaugeVertex A Y v η σ) →
+      ∀ (v : V) (ζ : (ie : IncidentEdge G v) → Fin (B.bondDim ie.1)) (σp : Fin d),
+        B.component v ζ σp =
+          (1 : ℂ) * gaugeVertex A Y v
+            (fun ie => Fin.cast (congr_fun hbond.symm ie.1) (ζ ie)) σp := by
+    intro Y hY v ζ σp
+    rw [one_mul]
+    have hζ : (fun ie : IncidentEdge G v => Fin.cast (congr_fun hbond ie.1)
+        (Fin.cast (congr_fun hbond.symm ie.1) (ζ ie))) = ζ := by
+      funext ie
+      exact Fin.ext (by simp)
+    have hcomp := hY v (fun ie => Fin.cast (congr_fun hbond.symm ie.1) (ζ ie)) σp
+    rwa [hζ] at hcomp
+  -- The exchanged-roles bare-edge absorbed equality at `e` for both families.
+  have hone : (1 : ℂ) ^ (Fintype.card V) = 1 := one_pow _
+  have hedgeX := fun (σ : V → Fin d)
+      (N : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) =>
+    edgeAbsorbed_of_perVertex_card B A hbond.symm X (hswap X hX) hone e σ N
+  have hedgeX' := fun (σ : V → Fin d)
+      (N : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) =>
+    edgeAbsorbed_of_perVertex_card B A hbond.symm X' (hswap X' hX') hone e σ N
+  -- The comparison region: the red block of `e`'s frame, injective for `A`.
+  have hUA : RegionInjectivityUnionClosure (regionInjectivityDataOf (G := G) A) :=
+    regionInjectivityUnionClosure_of_overlap A hposA
+  set D := h.edgeBlocking.blockingData e with hD
+  have hRA : RegionBlockedTensorInjective (G := G) A D.pairLeft.red :=
+    regionBlockedTensorInjective_red D.pairLeft
+  have hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ D.pairLeft.red) :=
+    regionBlockedTensorInjective_host D.pairLeft hUA
+  have hbdry : IsRegionBoundaryEdge (G := G) D.pairLeft.red e :=
+    Or.inl ⟨D.left_mem_red,
+      Finset.disjoint_right.mp D.red_disjoint_blue D.right_mem_blue⟩
+  exact absorbedGauge_unique_scalar_of_region B A hbond.symm D.pairLeft.red
+    ⟨e, hbdry⟩ hRA hCA hposA X X' hedgeX hedgeX'
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalPairBlocking.lean
+++ b/TNLean/PEPS/NormalPairBlocking.lean
@@ -1,0 +1,195 @@
+import TNLean.PEPS.NormalBlocking
+import TNLean.PEPS.RegionBlock.UnionClosure
+import Mathlib.Combinatorics.SimpleGraph.Connectivity.Connected
+
+/-!
+# Shared blocking data for two normal PEPS tensors
+
+The general normal PEPS theorem (arXiv:1804.04964, Section 3, theorem labelled
+`normal`, lines 1576--1583 of `Papers/1804.04964/paper_normal.tex`) assumes
+that *two* normal PEPS generating the same state "can be blocked into three
+partite injective MPS around every edge" and that "for every site, there are
+injective regions with their complements also being injective that differ only
+in the given site".  The blockings are shared between the two states: the
+source's final comparison contracts both tensors over the *same* regions, so
+each region in the hypothesis must be injective for both tensors at once.
+
+This file records that pairing at the level of the abstract region-injectivity
+predicate: the conjunction predicate `regionInjectivityDataPair` declares a
+region injective when it is injective for each of the two tensors, and a
+one-edge blocking datum over the conjunction projects to a datum over either
+single-tensor predicate with the same three regions.  It also proves the two
+small geometric facts the assembly needs: a region that is neither empty nor
+the full vertex set has a boundary edge on a connected graph, and the
+one-site-different region pair is an `insert`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, theorem labelled `normal`, lines 1576--1583 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### The conjunction of two region-injectivity predicates -/
+
+/-- The conjunction of two region-injectivity predicates: a region is injective
+when it is injective for each of the two tensors.
+
+The general normal PEPS theorem blocks *two* states by one shared geometry, and
+the source's final comparison applies the inverses of both blocked tensors over
+the same regions, so the blocking hypothesis asks each region to be injective
+for both tensors at once.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+def regionInjectivityDataPair (κ κ' : RegionInjectivityData V) :
+    RegionInjectivityData V where
+  IsInjective R := κ.IsInjective R ∧ κ'.IsInjective R
+
+omit [Fintype V] [LinearOrder V] in
+@[simp] theorem regionInjectivityDataPair_isInjective
+    (κ κ' : RegionInjectivityData V) (R : Finset V) :
+    (regionInjectivityDataPair κ κ').IsInjective R ↔
+      κ.IsInjective R ∧ κ'.IsInjective R :=
+  Iff.rfl
+
+/-! ### Projections of a one-edge blocking datum
+
+A one-edge blocking datum over a stronger predicate projects to a datum over a
+weaker one with the same three regions; in particular a datum over the
+conjunction predicate projects to a datum over either single-tensor predicate. -/
+
+/-- Weaken the region-injectivity predicate of a one-edge blocking datum: any
+predicate implied by the original one accepts the same three regions.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1475--1500 of
+`Papers/1804.04964/paper_normal.tex` (the blocking regions are shared; only the
+injectivity assertion is projected). -/
+def NormalEdgeBlockingData.ofLE {ι κ : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData ι G e)
+    (h : ∀ R : Finset V, ι.IsInjective R → κ.IsInjective R) :
+    NormalEdgeBlockingData κ G e where
+  red := D.red
+  blue := D.blue
+  complement := D.complement
+  left_mem_red := D.left_mem_red
+  right_mem_blue := D.right_mem_blue
+  red_injective := h _ D.red_injective
+  blue_injective := h _ D.blue_injective
+  complement_injective := h _ D.complement_injective
+  red_disjoint_blue := D.red_disjoint_blue
+  red_disjoint_complement := D.red_disjoint_complement
+  blue_disjoint_complement := D.blue_disjoint_complement
+  cover_univ := D.cover_univ
+
+/-- The first projection of a one-edge blocking datum over the conjunction
+predicate: the same three regions, injective for the first tensor.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+def NormalEdgeBlockingData.pairLeft {κ κ' : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataPair κ κ') G e) :
+    NormalEdgeBlockingData κ G e :=
+  D.ofLE fun _ h => h.1
+
+/-- The second projection of a one-edge blocking datum over the conjunction
+predicate: the same three regions, injective for the second tensor.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/
+def NormalEdgeBlockingData.pairRight {κ κ' : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataPair κ κ') G e) :
+    NormalEdgeBlockingData κ' G e :=
+  D.ofLE fun _ h => h.2
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem NormalEdgeBlockingData.pairLeft_red
+    {κ κ' : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataPair κ κ') G e) :
+    D.pairLeft.red = D.red := rfl
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem NormalEdgeBlockingData.pairLeft_blue
+    {κ κ' : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataPair κ κ') G e) :
+    D.pairLeft.blue = D.blue := rfl
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem NormalEdgeBlockingData.pairLeft_complement
+    {κ κ' : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataPair κ κ') G e) :
+    D.pairLeft.complement = D.complement := rfl
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem NormalEdgeBlockingData.pairRight_red
+    {κ κ' : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataPair κ κ') G e) :
+    D.pairRight.red = D.red := rfl
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem NormalEdgeBlockingData.pairRight_blue
+    {κ κ' : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataPair κ κ') G e) :
+    D.pairRight.blue = D.blue := rfl
+
+omit [DecidableRel G.Adj] in
+@[simp] theorem NormalEdgeBlockingData.pairRight_complement
+    {κ κ' : RegionInjectivityData V} {e : Edge G}
+    (D : NormalEdgeBlockingData (regionInjectivityDataPair κ κ') G e) :
+    D.pairRight.complement = D.complement := rfl
+
+/-! ### Boundary edges of a proper region on a connected graph
+
+A region that is neither empty nor the full vertex set has a boundary edge on a
+connected graph: a walk from a vertex inside the region to a vertex outside it
+crosses the boundary at some step. -/
+
+omit [DecidableRel G.Adj] in
+/-- On a connected graph, a nonempty region different from the full vertex set
+has a boundary edge.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
+`Papers/1804.04964/paper_normal.tex` (the comparison regions are compared
+through their boundary bonds, which exist because the lattice is connected). -/
+theorem nonempty_regionBoundaryEdge_of_connected (hconn : G.Connected)
+    {R : Finset V} (hR : R.Nonempty) (hRtop : R ≠ Finset.univ) :
+    Nonempty {f : Edge G // IsRegionBoundaryEdge (G := G) R f} := by
+  classical
+  obtain ⟨u, hu⟩ := hR
+  obtain ⟨w, hw⟩ : ∃ w : V, w ∉ R := by
+    by_contra hall
+    push Not at hall
+    exact hRtop (Finset.eq_univ_iff_forall.mpr hall)
+  obtain ⟨p⟩ := hconn.preconnected u w
+  obtain ⟨dart, -, hd1, hd2⟩ :=
+    p.exists_boundary_dart (↑R : Set V) (by simpa using hu) (by simpa using hw)
+  have hd1' : dart.fst ∈ R := by simpa using hd1
+  have hd2' : dart.snd ∉ R := by simpa using hd2
+  rcases Edge.ofAdj_endpoints dart.adj with ⟨h1, h2⟩ | ⟨h1, h2⟩
+  · exact ⟨⟨Edge.ofAdj dart.adj, Or.inl ⟨h1.symm ▸ hd1', h2.symm ▸ hd2'⟩⟩⟩
+  · exact ⟨⟨Edge.ofAdj dart.adj, Or.inr ⟨h1.symm ▸ hd2', h2.symm ▸ hd1'⟩⟩⟩
+
+/-! ### The one-site comparison pair as an `insert` -/
+
+/-- The region containing the distinguished site is the comparison region with
+that site inserted.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex` (the two regions differ only
+in the given site). -/
+theorem NormalOneSiteSeparationHypotheses.withSite_eq_insert
+    {ι : RegionInjectivityData V} (h : NormalOneSiteSeparationHypotheses ι)
+    (v : V) :
+    h.withSite v = insert v (h.withoutSite v) := by
+  ext w
+  rw [h.mem_withSite_iff v w, Finset.mem_insert]
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -5659,6 +5659,134 @@ injective and normal PEPS, following Theorems~2 and~3 of
     the gauges are unique up to the scalar freedom allowed by the graph. This
     is the general normal-PEPS theorem stated after
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
+    A connected-graph form with shared single-crossing blockings and matched
+    bond dimensions is
+    Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected}; its per-edge
+    uniqueness clause is
+    Theorem~\ref{thm:fundamentalTheorem_normalPEPS_gauge_unique}.
+\end{theorem}
+
+\begin{definition}[Doubly injective regions]%
+    \label{def:peps_regionInjectivityDataPair}
+    \lean{TNLean.PEPS.regionInjectivityDataPair}
+    \leanok
+    \uses{def:peps_regionInjectivityData}
+    For two region-injectivity assignments on the same vertex set, a region is
+    doubly injective when it is injective for each of the two.  The general
+    normal theorem blocks two states by one shared geometry, and its final
+    comparison contracts both tensors over the same regions, so its blocking
+    hypotheses are instantiated at the doubly injective assignment of the two
+    tensors.
+\end{definition}
+
+\begin{theorem}[Fundamental Theorem for normal PEPS, shared single-crossing
+    blockings]%
+    \label{thm:fundamentalTheorem_normalPEPS_connected}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalPEPS}
+    \leanok
+    % Scope restriction: this is the shared-blocking, single-crossing,
+    % matched-bond variant of the general normal theorem stated after
+    % Theorem 3 of \cite{Molnar2018NormalPEPS}; the deltas are recorded in
+    % \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
+    \uses{def:peps_normalPEPSBlockingHypotheses,
+        def:peps_regionInjectivityDataPair, def:GaugeEquivPEPS}
+    Let $A$ and $B$ be PEPS tensors on a connected finite simple graph with
+    the same positive physical dimension and equal and positive bond
+    dimensions, generating the same state.  Suppose the normal blocking
+    hypotheses hold at the doubly injective assignment of the two tensors:
+    around every edge the network blocks into three doubly injective regions
+    with the edge endpoints in the first two, and every site admits two doubly
+    injective regions, with doubly injective complements, differing exactly at
+    that site.  Suppose moreover that at every edge the distinguished edge is
+    the only edge of the graph joining its two adjacent blocks.  Then the
+    defining tensors are related by a local gauge: there are invertible
+    matrices, one on each edge, whose endpoint actions transform $A_v$ into
+    $B_v$ at every vertex, with no leftover scalar.
+    This is the general normal-PEPS theorem stated after
+    \cite[Theorem~3]{Molnar2018NormalPEPS}
+    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), restricted in three
+    ways. The blockings are shared between the two states with each region
+    injective for both tensors, the reading under which the source's final
+    comparison contracts both tensors over the same regions. The distinguished
+    edge of each frame is its only crossing between the two adjacent blocks,
+    which reads blocking \emph{around} an edge as: the chosen edge is the
+    entire bond between the first two parties of the three-site chain, as in
+    the picture of the proof of \cite[Theorem~3]{Molnar2018NormalPEPS}. The
+    bond dimensions are matched by hypothesis rather than derived. The
+    positive bond dimensions and the connectivity of the graph are the
+    counterexample-backed corrections carried over from the injective
+    Fundamental Theorem (Theorem~\ref{thm:fundamentalTheorem_PEPS}); the
+    absorption of the per-vertex constants into the gauges is exactly the step
+    that requires connectivity.
+    \begin{proof}
+        \leanok
+        \uses{lem:peps_injectiveRegion_union_pos,
+            thm:peps_region_edge_gauge_of_coeff_transfer,
+            thm:gaugeConsistency}
+        The union closure of injective regions for either tensor follows from
+        the positive bond dimensions and
+        Lemma~\ref{lem:peps_injectiveRegion_union_pos}.  At every edge the
+        shared blocking datum restricts to a datum for each tensor over the
+        same three regions, so the per-edge gauge of the region insertion
+        transfer (Theorem~\ref{thm:peps_region_edge_gauge_of_coeff_transfer})
+        and its orientation-adapted absorption give a family of invertible
+        matrices realizing the absorbed inserted-coefficient equality at every
+        edge.  A gauge preserves blocked-region linear independence, so at
+        every site the one-site comparison applies to the gauge-absorbed
+        tensor: comparing the smaller region with its one-site completion
+        yields two proportionality scalars whose ratio is a nonzero scalar
+        $\lambda_v$ with $A_v$ equal to $\lambda_v$ times the gauge action on
+        $B$ at $v$.  When the smaller region is empty its block is the count
+        of global virtual configurations, and when the completion is the full
+        vertex set its block is the closed state coefficient; in these
+        degenerate cases the proportionality holds with scalar one, and every
+        other comparison region has a boundary edge by connectivity.  The
+        per-vertex relations against the nonzero closed state force
+        $\prod_v \lambda_v = 1$, so on the connected graph a spanning-tree
+        construction realizes the reciprocals of the scalars as oriented
+        incidence products of edge scalars, which fold into the gauges as in
+        the absorption step of the injective Fundamental Theorem
+        (Theorem~\ref{thm:gaugeConsistency}).
+    \end{proof}
+\end{theorem}
+
+\begin{theorem}[Uniqueness of the normal-PEPS gauges up to a constant]%
+    \label{thm:fundamentalTheorem_normalPEPS_gauge_unique}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalPEPS_gauge_unique}
+    \leanok
+    \uses{def:peps_normalPEPSBlockingHypotheses,
+        def:peps_regionInjectivityDataPair, def:gaugeVertex}
+    Let $A$ and $B$ be PEPS tensors on a finite simple graph with equal bond
+    dimensions, the bond dimensions of the first tensor positive, satisfying
+    the normal blocking hypotheses at the doubly injective assignment of the
+    two tensors.  Suppose two families of invertible matrices, one on each
+    edge, each realize the scalar-free gauge relation of
+    Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected}: at every vertex
+    the endpoint actions of the family transform $A_v$ into $B_v$.  Then the
+    two families are proportional at every edge: $X'_e = c\cdot X_e$ for a
+    nonzero scalar $c$ depending on the edge.  This is the uniqueness clause
+    of the general normal-PEPS theorem stated after
+    \cite[Theorem~3]{Molnar2018NormalPEPS}, read against the scalar-free
+    relation; neither equality of the two states nor connectivity is needed.
+    \begin{proof}
+        \leanok
+        \uses{thm:peps_gaugeConj_eq_of_coeffIdentities,
+            lem:peps_injectiveRegion_union_pos}
+        The inserted-edge coefficient is multilinear in the site tensors, one
+        factor per site, so each scalar-free per-vertex relation makes every
+        inserted coefficient of $B$ equal the corresponding inserted
+        coefficient of the gauge-absorbed $A$: each family realizes the
+        absorbed inserted-coefficient equality at every edge, with the roles
+        of the two tensors exchanged.  On the first block of the edge's frame,
+        whose blocked map and complement blocked map are injective for $A$ by
+        the blocking hypotheses and union closure
+        (Lemma~\ref{lem:peps_injectiveRegion_union_pos}), the region insertion
+        transfer is determined by the absorbed equality
+        (Theorem~\ref{thm:peps_gaugeConj_eq_of_coeffIdentities}), so the two
+        orientation-adapted absorbing gauges induce the same conjugation and
+        differ by a nonzero scalar; unwinding the orientation adaptation gives
+        the proportionality of the gauges themselves.
+    \end{proof}
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal PEPS, vertex-injective case]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2138,8 +2138,69 @@ The remaining obligations are the following.
     \item Theorem \path{3}: blueprint
           \path{thm:fundamentalTheorem_normalSquarePEPS}, issue \#1375.
     \item General theorem \path{normal}: blueprint
-          \path{thm:fundamentalTheorem_normalPEPS}, issue \#1375.
+          \path{thm:fundamentalTheorem_normalPEPS}, issue \#1375.  A
+          scope-restricted connected-graph form is now proved; see the next
+          section.
 \end{itemize}
+
+\section{The general-graph assembly and its scope restrictions}
+
+The general theorem \path{normal} is now assembled on an arbitrary connected
+finite simple graph, in a scope-restricted form.\footnote{Formal declarations:
+    \leanid{TNLean.PEPS.fundamentalTheorem_normalPEPS} (existence, blueprint
+    \path{thm:fundamentalTheorem_normalPEPS_connected}) and
+    \leanid{TNLean.PEPS.fundamentalTheorem_normalPEPS_gauge_unique}
+    (uniqueness, blueprint
+    \path{thm:fundamentalTheorem_normalPEPS_gauge_unique}).}
+The route is the source's: the blocking hypotheses produce a per-edge gauge
+from the coherent three-block frames at every edge, the gauges are absorbed
+into the second tensor, the one-site comparisons give a nonzero scalar
+$\lambda_v$ at every site, the closed state forces $\prod_v\lambda_v=1$, and
+the spanning-tree edge-scalar solve of the injective theorem absorbs the
+scalars into the gauges, leaving the scalar-free local gauge relation.  The
+uniqueness clause is the per-edge conjugator determinacy: two families
+realizing the scalar-free relation are proportional at every edge.
+
+The deltas against the source statement (lines 1576--1583 of
+\path{Papers/1804.04964/paper_normal.tex}) are the following.
+
+\begin{enumerate}
+    \item \emph{Shared blockings, injective for both tensors.}  The formal
+          hypotheses instantiate the blocking bundle at the conjunction
+          predicate: each blocking region is injective for both tensors at
+          once.  This is the reading under which the source's final comparison
+          contracts both tensors over the same regions; the source phrase
+          ``\emph{they} can be blocked'' is about both states.
+    \item \emph{Single crossing edge.}  The per-edge gauge lives on the
+          distinguished edge only when that edge is the entire bond between
+          the red and blue blocks; with several red-to-blue crossings the
+          isomorphism lemma would produce a gauge on the collected bond, not
+          one matrix per edge.  The formalization takes the single-crossing
+          condition as an explicit hypothesis, reading ``blocked \emph{around}
+          every edge'' as in the source's Theorem \path{3} picture, where the
+          two blocks adjacent to the edge touch only along it.  The recorded
+          blocking bundle does not carry this condition as a field.
+    \item \emph{Matched bond dimensions.}  The equality of the two bond
+          dimension assignments is a hypothesis, as in the torus and
+          open-lattice assemblies.  The elimination plan is the region-level
+          analogue of the injective theorem's edgewise derivation: the blocked
+          insertion-algebra equivalence on each bond forces equal sizes.
+    \item \emph{Positive bonds and connectivity.}  These are the
+          counterexample-backed corrections carried over from the injective
+          theorem (\path{docs/paper-gaps/peps_injective_ft_section3_route.tex}
+          and \path{docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex});
+          the scalar absorption is exactly the step that requires
+          connectivity, matching the source's remark that the proportionality
+          constants can be incorporated into the gauges.
+\end{enumerate}
+
+Two degenerate one-site comparisons allowed by the hypothesis bundle are
+handled directly rather than through the boundary-edge engine: when the
+smaller comparison region is empty its block is the count of global virtual
+configurations, and when the one-site completion is the full vertex set its
+block is the closed state coefficient; in both cases the comparison
+proportionality holds with scalar one.  Every other comparison region has a
+boundary edge by connectivity.
 
 \section{Blueprint diagrams}
 


### PR DESCRIPTION
## Summary

Assembles the source's headline normal result — arXiv:1804.04964, Section 3, theorem labelled `normal` (lines 1576–1583 of `Papers/1804.04964/paper_normal.tex`) — on an arbitrary **connected finite simple graph**, at fixed system size with no translation invariance, with the per-vertex constants absorbed into the gauges (no leftover scalar), plus the per-edge uniqueness clause.

**Capstones** (each `#print axioms` = `[propext, Classical.choice, Quot.sound]`):
- `TNLean.PEPS.fundamentalTheorem_normalPEPS` (`NormalGeneralFundamentalTheorem.lean`): blocking bundle over the pair predicate + single-crossing edges + matched positive bonds + `SameState` + `0 < d` + `G.Connected` ⟹ `GaugeEquiv A B`.
- `TNLean.PEPS.fundamentalTheorem_normalPEPS_gauge_unique`: two families realizing the scalar-free per-vertex relation are proportional at every edge (needs neither `SameState` nor connectivity).

## Route

1. **Per-edge gauges**: `exists_regionEdgeGauge_of_blockingData` fed the two single-tensor projections of the shared one-edge datum (`NormalEdgeBlockingData.pairLeft/pairRight` over `regionInjectivityDataPair`); absorbed via `edgeAbsorbed_of_conjIdentity` into a family with the bare-edge absorbed equality at **every** edge (`exists_normalAbsorbedGaugeFamily`).
2. **Per-vertex scalars**: the one-site pair `(withoutSite v, insert v (withoutSite v))` through `twoBlockProportional_of_edgeAbsorbed` + `component_eq_gaugeVertex_of_twoBlockProportional`; the degenerate regions the bundle allows (∅ and `univ`, which have no boundary edges) are handled directly — the ∅-block is the virtual-configuration count, the `univ`-block is the closed state coefficient (proportional with scalar 1); all other regions get a boundary edge from connectivity (`nonempty_regionBoundaryEdge_of_connected`, via Mathlib's `Walk.exists_boundary_dart`).
3. **∏λᵥ = 1**: `prod_perVertexScalar_eq_one_of_regionInjective` at `withoutSite v₀`.
4. **Scalar absorption**: `exists_edgeScalars_of_connected` + `perVertex_gauge_identity` (the injective FT endgame), giving `GaugeEquiv` with the gauge `globalGauge A B hbond Z s`.
5. **Uniqueness**: graph-generic `absorbedGauge_unique_scalar_of_region` (conjugator determinacy via `gaugeConj_eq_of_coeffIdentities` + `gl_conj_unique_scalar`) against the absorbed equality induced by each per-vertex relation (`edgeAbsorbed_of_perVertex_card`, scalar 1), at the red block of each edge's frame.

## Scope restrictions vs the source statement

Documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex` (new section *The general-graph assembly and its scope restrictions*) and marked in-source:

1. **Shared blockings, doubly injective** — the bundle is instantiated at the conjunction predicate `regionInjectivityDataPair` (the reading under which the source's final comparison contracts both tensors over the same regions).
2. **Single crossing edge** — `hsingle` is an explicit hypothesis (`**Scope restriction (single crossing edge):**` markers); with several red-to-blue crossings the isomorphism lemma yields a gauge on the collected bond, not per edge.
3. **Matched bond dimensions** assumed, as in the torus/open-lattice assemblies.
4. **Positive bonds + connectivity** — counterexample-backed faithfulness fixes carried over from the injective FT.

## Blueprint

Per the faithfulness rule, the source-labelled `thm:fundamentalTheorem_normalPEPS` stays `\notready` and now points to the new scope-restricted siblings `thm:fundamentalTheorem_normalPEPS_connected` and `thm:fundamentalTheorem_normalPEPS_gauge_unique` (both `\leanok`), plus `def:peps_regionInjectivityDataPair`.

## Validation

- Full `lake build` green (8893 jobs); `lake exe lint-style` exit 0.
- `leanblueprint checkdecls` passes (lean_decls regenerated via `leanblueprint web`).
- No `sorry`/`axiom`/`native_decide`/`maxHeartbeats` in the new files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large formal proof addition with no runtime or security surface; main risk is mathematical correctness of the new theorems, which is the intended contribution and is documented with explicit hypotheses vs. the source paper.
> 
> **Overview**
> Adds a **sorry-free Lean assembly** of the general normal PEPS fundamental theorem (arXiv:1804.04964 §3 `normal`) on arbitrary **connected** finite simple graphs, plus blueprint and gap-doc alignment.
> 
> **New proof chain:** `regionInjectivityDataPair` and shared one-edge blocking projections (`NormalPairBlocking`); per-edge absorbed gauge families from blocking data with an explicit **single red–blue crossing** per frame (`NormalAbsorbedFamily`); per-vertex scalars from one-site comparisons, including ∅/`univ` degeneracies (`NormalComparisonScalar`); capstones `fundamentalTheorem_normalPEPS` → `GaugeEquiv` and `fundamentalTheorem_normalPEPS_gauge_unique` (`NormalGeneralFundamentalTheorem`), reusing the injective FT edge-scalar absorption on connected graphs.
> 
> **Docs:** `TNLean.lean` imports the four modules; blueprint gains `def:peps_regionInjectivityDataPair`, `thm:fundamentalTheorem_normalPEPS_connected`, and the gauge-uniqueness theorem; `docs/paper-gaps/peps_normal_ft_section3_route.tex` records scope vs. the paper (doubly injective shared blockings, `hsingle`, matched bonds, positivity + connectivity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba0e47ae82f1ef220d7688fda8fcb8cc458407e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->