### PR TITLE
feat(PEPS): derive the bond-dimension equality in the general normal Fundamental Theorem

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -594,6 +594,9 @@ import TNLean.PEPS.NormalPairBlocking
 -- The absorbed gauge family of a general normal PEPS blocking: the bare-edge
 -- absorbed equality at every edge of an arbitrary finite simple graph.
 import TNLean.PEPS.NormalAbsorbedFamily
+-- The per-edge bond-dimension equality of two normal PEPS generating the same
+-- state, derived from the blocking hypotheses by the isomorphism rigidity.
+import TNLean.PEPS.NormalBondDimension
 -- The per-vertex scalar of the general normal comparison: the one-site
 -- comparison pair on a connected graph, including the degenerate regions.
 import TNLean.PEPS.NormalComparisonScalar

--- a/TNLean/PEPS/NormalBondDimension.lean
+++ b/TNLean/PEPS/NormalBondDimension.lean
@@ -1,0 +1,286 @@
+import TNLean.PEPS.CoherentFrameInstance2
+import TNLean.PEPS.NormalPairBlocking
+import TNLean.PEPS.FundamentalTheorem
+
+/-!
+# Equal bond dimensions for normal PEPS generating the same state
+
+This file derives the per-edge bond-dimension equality of two normal PEPS
+generating the same state from the blocking hypotheses alone, removing the
+matched-bond-dimension assumption from the general normal Fundamental Theorem.
+
+The source derives the equality inside the isomorphism lemma (arXiv:1804.04964,
+Section 3, Lemma `inj_isomorph`, lines 560--583 of
+`Papers/1804.04964/paper_normal.tex`): the insertion correspondence `X ↦ Y` on
+the chosen bond is an algebra isomorphism between the two full bond matrix
+algebras, "this means that the bond dimensions on the LHS and the RHS are the
+same" (line 582).  The normal case inherits the argument through the blocked
+three-partite chains (lines 1449--1500): around each edge the two tensors block
+into coarse three-site chains which are injective by hypothesis, and the
+isomorphism rigidity applies to the coarse chains.
+
+One wrinkle separates this derivation from the matched-bond engine
+(`coarseTensor_sameState_of_sameState`): without matched bond dimensions the
+merge-collapse constants of the two coarse states differ, so the coarse states
+are only proportional, with the ratio of the two positive collapse constants.
+The proportionality is converted into an exact state equality by scaling one
+coarse super-site of each chain by the other chain's collapse constant
+(`scaleVertex`), which preserves the coarse injectivity and the coarse bond
+dimensions.  The injective-case algebra equivalence (`edgeTransferAlgEquiv`)
+then applies to the scaled chains, the finrank rigidity
+(`bondDim_eq_of_matrixAlgEquiv`) forces the coarse bond dimensions to agree,
+and the single-crossing bridge (`bridgeEquiv`) reads the coarse `r-b` bond as
+the original bond on the distinguished edge for each tensor.
+
+**Scope restriction (single crossing edge):** as everywhere in the general
+normal assembly, the distinguished edge is the single red-to-blue crossing of
+its frame; see `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, Lemma `inj_isomorph`, lines 560--583, and the theorem labelled
+  `normal`, lines 1576--1583 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-! ### Scaling one vertex component
+
+The proportional coarse states are rescaled into equal states by multiplying the
+component of a single vertex by a nonzero constant.  Scaling multiplies every
+state coefficient by the constant and preserves vertex injectivity and the bond
+dimensions. -/
+
+section ScaleVertex
+
+variable [DecidableEq V]
+
+/-- The tensor obtained from `A` by multiplying the component of the single
+vertex `v₀` by the constant `c`.  The bond dimensions are unchanged.  This is
+the rescaling device that converts proportional states into equal states, used
+to run the isomorphism lemma of arXiv:1804.04964, Section 3 (lines 560--583 of
+`Papers/1804.04964/paper_normal.tex`) on the blocked coarse chains, whose
+states match the original states only up to the merge-collapse constants. -/
+noncomputable def scaleVertex (A : Tensor G d) (v₀ : V) (c : ℂ) : Tensor G d where
+  bondDim := A.bondDim
+  component v η σ := (if v = v₀ then c else 1) * A.component v η σ
+
+omit [Fintype V] in
+@[simp] theorem scaleVertex_bondDim (A : Tensor G d) (v₀ : V) (c : ℂ) :
+    (scaleVertex A v₀ c).bondDim = A.bondDim := rfl
+
+/-- Scaling one vertex component multiplies every state coefficient by the
+constant: the contraction product picks up the factor exactly once, at `v₀`. -/
+theorem stateCoeff_scaleVertex (A : Tensor G d) (v₀ : V) (c : ℂ) (σ : V → Fin d) :
+    stateCoeff (scaleVertex A v₀ c) σ = c * stateCoeff A σ := by
+  rw [stateCoeff, stateCoeff, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun η _ => ?_
+  change (∏ v : V, (if v = v₀ then c else 1) * A.component v (fun ie => η ie.1) (σ v)) =
+    c * ∏ v : V, A.component v (fun ie => η ie.1) (σ v)
+  rw [Finset.prod_mul_distrib, Finset.prod_ite_eq' Finset.univ v₀ fun _ => c]
+  simp
+
+omit [Fintype V] in
+/-- Scaling one vertex component by a nonzero constant preserves vertex
+injectivity: the component family at the scaled vertex is the original family
+multiplied by a unit. -/
+theorem IsVertexInjective.scaleVertex {A : Tensor G d} (hA : IsVertexInjective A)
+    (v₀ : V) {c : ℂ} (hc : c ≠ 0) :
+    IsVertexInjective (PEPS.scaleVertex A v₀ c) := by
+  intro v
+  by_cases hv : v = v₀
+  · have hcomp : (PEPS.scaleVertex A v₀ c).component v =
+        (fun _ : (ie : IncidentEdge G v) → Fin (A.bondDim ie.1) => Units.mk0 c hc) •
+          A.component v := by
+      funext η σ
+      simp [PEPS.scaleVertex, hv, Units.smul_def]
+    rw [hcomp]
+    exact (hA v).units_smul _
+  · have hcomp : (PEPS.scaleVertex A v₀ c).component v = A.component v := by
+      funext η σ
+      simp [PEPS.scaleVertex, hv]
+    rw [hcomp]
+    exact hA v
+
+end ScaleVertex
+
+/-! ### Positivity of the merge-collapse constants -/
+
+/-- The bond-dimension product over the edges not incident to a region is
+positive when every bond dimension is positive. -/
+theorem regionNonIncidentBondProd_pos (A : Tensor G d) (R : Finset V)
+    (hpos : ∀ g : Edge G, 0 < A.bondDim g) :
+    0 < regionNonIncidentBondProd A R := by
+  rw [regionNonIncidentBondProd]
+  exact Finset.prod_pos fun g _ => hpos g
+
+/-! ### The per-edge bond-dimension equality -/
+
+variable {A B : Tensor G d}
+
+open scoped Classical in
+/-- **Equal bond dimensions on the distinguished edge of two coherent frames**
+(arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 560--583 of
+`Papers/1804.04964/paper_normal.tex`: the insertion correspondence is an
+algebra isomorphism, so "the bond dimensions on the LHS and the RHS are the
+same").
+
+Two coherent frames over `A` and `B` sharing the red and blue regions, with
+`A` and `B` generating the same state, positive bond dimensions, and the
+distinguished edge `e` the single red-to-blue crossing, force
+`A.bondDim e = B.bondDim e`.  The two coarse three-site chains have states
+proportional with ratio the two merge-collapse constants
+(`stateCoeff_coarseTensor_collapse`); scaling one coarse super-site of each by
+the other's constant (`scaleVertex`) gives equal coarse states with the coarse
+injectivities preserved, the injective-case algebra equivalence
+(`edgeTransferAlgEquiv`) and the finrank rigidity
+(`bondDim_eq_of_matrixAlgEquiv`) force equal coarse `r-b` bond dimensions, and
+the single-crossing bridge (`bridgeEquiv`) reads them as the original bond
+dimensions on `e`.
+
+No single-vertex injectivity of `A` or `B` is used: the only injectivity
+inputs are the blocked-region injectivities carried by the two frames. -/
+theorem bondDim_apply_eq_of_coherentFrames
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e) :
+    A.bondDim e = B.bondDim e := by
+  classical
+  -- The merge-collapse constants of the two coarse chains.
+  set cA : ℕ := regionNonIncidentBondProd A F.frame.red *
+      regionNonIncidentBondProd A F.frame.blue *
+      regionNonIncidentBondProd A F.frame.complement with hcA
+  set cB : ℕ := regionNonIncidentBondProd B F'.frame.red *
+      regionNonIncidentBondProd B F'.frame.blue *
+      regionNonIncidentBondProd B F'.frame.complement with hcB
+  have hcApos : 0 < cA :=
+    Nat.mul_pos
+      (Nat.mul_pos (regionNonIncidentBondProd_pos A _ hposA)
+        (regionNonIncidentBondProd_pos A _ hposA))
+      (regionNonIncidentBondProd_pos A _ hposA)
+  have hcBpos : 0 < cB :=
+    Nat.mul_pos
+      (Nat.mul_pos (regionNonIncidentBondProd_pos B _ hposB)
+        (regionNonIncidentBondProd_pos B _ hposB))
+      (regionNonIncidentBondProd_pos B _ hposB)
+  -- The cross-scaled coarse chains: each chain carries the other's constant.
+  set Ac : Tensor coarseGraph (coarseDim V d) :=
+    scaleVertex (F.frame.coarseTensor) (0 : Fin 3) (cB : ℂ) with hAc
+  set Bc : Tensor coarseGraph (coarseDim V d) :=
+    scaleVertex (F'.frame.coarseTensor) (0 : Fin 3) (cA : ℂ) with hBc
+  -- The cross-scaled coarse states are equal.
+  have hsame : SameState Ac Bc := by
+    intro s
+    rw [hAc, hBc, stateCoeff_scaleVertex, stateCoeff_scaleVertex,
+      stateCoeff_coarseTensor_collapse F hP s, stateCoeff_coarseTensor_collapse F' hP' s]
+    have hassem : assembleTri F hP (coarseProj F.frame.red (s 0))
+        (coarseProj F.frame.blue (s 1)) (coarseProj F.frame.complement (s 2)) =
+      assembleTri F' hP' (coarseProj F'.frame.red (s 0))
+        (coarseProj F'.frame.blue (s 1)) (coarseProj F'.frame.complement (s 2)) := by
+      funext w
+      rw [assembleTri_eq_decode F hP s w, assembleTri_eq_decode F' hP' s w, hred, hblue]
+    rw [hassem, hAB, nsmul_eq_mul, nsmul_eq_mul, ← hcA, ← hcB]
+    ring
+  -- The scaled chains keep the coarse injectivities and positive coarse bonds.
+  have hAcInj : IsVertexInjective Ac := by
+    rw [hAc]
+    exact F.frame.coarseTensor_isVertexInjective.scaleVertex (0 : Fin 3)
+      (Nat.cast_ne_zero.mpr hcBpos.ne')
+  have hBcInj : IsVertexInjective Bc := by
+    rw [hBc]
+    exact F'.frame.coarseTensor_isVertexInjective.scaleVertex (0 : Fin 3)
+      (Nat.cast_ne_zero.mpr hcApos.ne')
+  have hposAc : ∀ f : Edge coarseGraph, 0 < Ac.bondDim f := F.frame.coarseTensor_pos_bondDim
+  have hposBc : ∀ f : Edge coarseGraph, 0 < Bc.bondDim f := F'.frame.coarseTensor_pos_bondDim
+  -- The insertion algebra equivalence on the coarse `r-b` bond forces equal sizes.
+  have hΦ := edgeTransferAlgEquiv Ac Bc coarseEdgeRB
+    (hAcInj.edgeBlockedThreeSiteInjective hposAc coarseEdgeRB)
+    (hBcInj.edgeBlockedThreeSiteInjective hposBc coarseEdgeRB)
+    hsame hposAc hposBc
+  have hcoarse : F.frame.coarseBondDim coarseEdgeRB = F'.frame.coarseBondDim coarseEdgeRB :=
+    bondDim_eq_of_matrixAlgEquiv hΦ
+  -- The single-crossing bridges read the coarse `r-b` bond as the bond on `e`.
+  have h1 : F.frame.coarseBondDim coarseEdgeRB = A.bondDim e :=
+    Fin.equiv_iff_eq.mp ⟨bridgeEquiv (G := G) F e hsingle⟩
+  have h2 : F'.frame.coarseBondDim coarseEdgeRB = B.bondDim e :=
+    Fin.equiv_iff_eq.mp
+      ⟨bridgeEquiv (G := G) F' e (hsingle_transport F F' e hred hblue hsingle)⟩
+  exact h1.symm.trans (hcoarse.trans h2)
+
+open scoped Classical in
+/-- **Equal bond dimensions on the distinguished edge of two one-edge blocking
+data** (arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 560--583 of
+`Papers/1804.04964/paper_normal.tex`, applied to the blocked chains of the
+normal theorem, lines 1449--1500).
+
+Two one-edge blocking data over `A` and `B` sharing the red and blue regions,
+with `A` and `B` generating the same state, positive physical and bond
+dimensions, and the single-crossing hypothesis on `e`, force
+`A.bondDim e = B.bondDim e`. -/
+theorem bondDim_apply_eq_of_blockingData {e : Edge G}
+    (DA : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) A) G e)
+    (DB : NormalEdgeBlockingData (regionInjectivityDataOf (G := G) B) G e)
+    (hred : DA.red = DB.red) (hblue : DA.blue = DB.blue)
+    (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A DA.red DA.blue g ↔ g = e) :
+    A.bondDim e = B.bondDim e := by
+  set F := coherentFrameOfBlockingData DA hd hposA with hF
+  set F' := coherentFrameOfBlockingData DB hd hposB with hF'
+  have hPF : F.frame.IsPartition := coherentFrameOfBlockingData_isPartition DA hd hposA
+  have hPF' : F'.frame.IsPartition := coherentFrameOfBlockingData_isPartition DB hd hposB
+  have hr : F.frame.red = F'.frame.red := by simp [hF, hF', hred]
+  have hb : F.frame.blue = F'.frame.blue := by simp [hF, hF', hblue]
+  exact bondDim_apply_eq_of_coherentFrames F F' hPF hPF' hr hb hAB hposA hposB e hsingle
+
+open scoped Classical in
+/-- **Equal bond dimensions from the general normal blocking hypotheses**
+(arXiv:1804.04964, Section 3, theorem labelled `normal`, lines 1576--1583 of
+`Papers/1804.04964/paper_normal.tex`, via the isomorphism rigidity of Lemma
+`inj_isomorph`, lines 560--583).
+
+Two tensors on a finite simple graph satisfying the general normal PEPS
+blocking hypotheses over the pair predicate, with each distinguished edge the
+single red-to-blue crossing of its frame, the same state, and positive
+physical and bond dimensions, have equal bond dimensions on every edge.  This
+discharges the matched-bond-dimension hypothesis of the normal Fundamental
+Theorem from the blocking hypotheses, as the source derives it: the insertion
+correspondence on each blocked chain is an algebra isomorphism between the two
+full bond matrix algebras, forcing equal sizes.
+
+**Scope restriction (single crossing edge):** the hypothesis `hsingle` is the
+formal content of blocking *around* each edge; see
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+theorem bondDim_eq_of_normalBlocking
+    (A B : Tensor G d)
+    (h : NormalPEPSBlockingHypotheses
+      (regionInjectivityDataPair (regionInjectivityDataOf (G := G) A)
+        (regionInjectivityDataOf (G := G) B)) G)
+    (hsingle : ∀ e g : Edge G,
+      IsCrossingEdge (G := G) A (h.edgeBlocking.red e) (h.edgeBlocking.blue e) g ↔ g = e)
+    (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g)
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g) :
+    A.bondDim = B.bondDim := by
+  funext e
+  exact bondDim_apply_eq_of_blockingData
+    (h.edgeBlocking.blockingData e).pairLeft (h.edgeBlocking.blockingData e).pairRight
+    rfl rfl hAB hd hposA hposB (hsingle e)
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/NormalGeneralFundamentalTheorem.lean
+++ b/TNLean/PEPS/NormalGeneralFundamentalTheorem.lean
@@ -1,3 +1,4 @@
+import TNLean.PEPS.NormalBondDimension
 import TNLean.PEPS.NormalComparisonScalar
 import TNLean.PEPS.RegionScalarCondition
 import TNLean.PEPS.TorusGaugeUniqueness
@@ -14,8 +15,11 @@ with injective complements at every site, have gauge-equivalent defining
 tensors; and the gauges are unique up to a multiplicative constant on each
 edge.
 
-The route follows the source.  The blocking hypotheses produce a per-edge
-absorbing gauge family with the bare-edge absorbed equality at every edge
+The route follows the source.  The blocking hypotheses force equal bond
+dimensions on every edge (`bondDim_eq_of_normalBlocking`, the isomorphism
+rigidity of the source's Lemma `inj_isomorph`, lines 560--583, inherited
+through the blocked coarse chains); they produce a per-edge absorbing gauge
+family with the bare-edge absorbed equality at every edge
 (`exists_normalAbsorbedGaugeFamily`); the one-site comparisons give a nonzero
 scalar `λ_v` at every vertex with `A_v = λ_v · (gauge action of B at v)`
 (`exists_normalPerVertexScalar`); the closed state pins `∏_v λ_v = 1`
@@ -34,8 +38,6 @@ The added hypotheses relative to the source statement are documented:
   blue blocks; this reading of "blocked ... around every edge" is an explicit
   hypothesis (see `TNLean.PEPS.NormalAbsorbedFamily` and
   `docs/paper-gaps/peps_normal_ft_section3_route.tex`).
-* Matched bond dimensions are assumed, as in the torus and open-lattice
-  assemblies.
 * Positive bond dimensions and connectivity are the faithfulness fixes of the
   injective Fundamental Theorem, both backed by machine-checked
   counterexamples (`docs/paper-gaps/peps_injective_ft_section3_route.tex`,
@@ -68,9 +70,15 @@ PEPS blocking hypotheses over the pair predicate — every edge carries a
 three-region injective blocking shared by both tensors, and every site admits
 one-site-different injective regions with injective complements, also shared —
 with each distinguished edge the single red-to-blue crossing of its frame,
-matched bond dimensions, the same state, and positive bond dimensions, are
-gauge equivalent: there are invertible edge matrices relating the defining
-tensors with no leftover scalar.
+the same state, and positive bond dimensions, are gauge equivalent: there are
+invertible edge matrices relating the defining tensors with no leftover
+scalar.
+
+The bond-dimension equality is not assumed: the blocking hypotheses force it
+on every edge (`bondDim_eq_of_normalBlocking`), as in the source, where the
+insertion correspondence of Lemma `inj_isomorph` is an algebra isomorphism
+between the two full bond matrix algebras, so the bond dimensions agree
+(lines 560--583 of `Papers/1804.04964/paper_normal.tex`).
 
 The per-vertex scalars `λ_v` produced by the one-site comparisons satisfy
 `∏_v λ_v = 1` by the closed state equality, so on the connected graph they are
@@ -80,9 +88,9 @@ proportionality constants can be incorporated into the gauge transformations.
 **Scope restriction (single crossing edge):** the hypothesis `hsingle` is the
 formal content of blocking *around* each edge — the distinguished edge is the
 entire bond between the first two parties of the three-site chain; see
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`.  Matched bond dimensions
-are assumed; positive bonds and connectivity are the counterexample-backed
-faithfulness fixes of the injective Fundamental Theorem
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.  Positive bonds and
+connectivity are the counterexample-backed faithfulness fixes of the
+injective Fundamental Theorem
 (`docs/paper-gaps/peps_injective_ft_section3_route.tex`,
 `docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex`).
 
@@ -95,12 +103,15 @@ theorem fundamentalTheorem_normalPEPS
         (regionInjectivityDataOf (G := G) B)) G)
     (hsingle : ∀ e g : Edge G,
       IsCrossingEdge (G := G) A (h.edgeBlocking.red e) (h.edgeBlocking.blue e) g ↔ g = e)
-    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge G, 0 < A.bondDim g)
     (hposB : ∀ g : Edge G, 0 < B.bondDim g)
     (hconn : G.Connected) :
     GaugeEquiv A B := by
   classical
+  -- The blocking hypotheses force equal bond dimensions on every edge.
+  have hbond : A.bondDim = B.bondDim :=
+    bondDim_eq_of_normalBlocking A B h hsingle hAB hd hposA hposB
   -- The absorbing gauge family with the bare-edge absorbed equality everywhere.
   obtain ⟨Z, hedge⟩ :=
     exists_normalAbsorbedGaugeFamily A B h hsingle hbond hAB hd hposA hposB

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -5815,8 +5815,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     the gauges are unique up to the scalar freedom allowed by the graph. This
     is the general normal-PEPS theorem stated after
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
-    A connected-graph form with shared single-crossing blockings and matched
-    bond dimensions is
+    A connected-graph form with shared single-crossing blockings is
     Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected}; its per-edge
     uniqueness clause is
     Theorem~\ref{thm:fundamentalTheorem_normalPEPS_gauge_unique}.
@@ -5835,20 +5834,63 @@ injective and normal PEPS, following Theorems~2 and~3 of
     tensors.
 \end{definition}
 
+\begin{theorem}[Equal bond dimensions from the normal blocking hypotheses]%
+    \label{thm:peps_bondDim_eq_of_normalBlocking}
+    \lean{TNLean.PEPS.bondDim_eq_of_normalBlocking}
+    \leanok
+    \uses{def:peps_normalPEPSBlockingHypotheses,
+        def:peps_regionInjectivityDataPair}
+    Let $A$ and $B$ be PEPS tensors on a finite simple graph with the same
+    positive physical dimension and positive bond dimensions, generating the
+    same state and satisfying the normal blocking hypotheses at the doubly
+    injective assignment of the two tensors, with each distinguished edge the
+    only edge of the graph joining its two adjacent blocks.  Then the bond
+    dimensions of $A$ and $B$ agree on every edge.
+    In the source the equality is part of the isomorphism lemma of
+    \cite[Section~3]{Molnar2018NormalPEPS}: the insertion correspondence
+    $X\mapsto Y$ on the chosen bond is an algebra isomorphism between the two
+    full bond matrix algebras, so the bond dimensions on the two sides agree;
+    the normal case inherits the argument through the blocked three-site
+    chains.
+    \begin{proof}
+        \leanok
+        \uses{thm:peps_edgeBlockedThreeSiteInjective,
+            thm:peps_edgeBlockedInsertionAlgebraIsomorphism}
+        Fix an edge.  Blocking both networks into the shared three regions
+        around it produces two three-site chains on the three-vertex complete
+        graph whose super-sites carry the blocked-region weight families,
+        injective by hypothesis.  Each coarse state coefficient is a positive
+        merge-collapse constant, a product of bond dimensions over the edges
+        not incident to each region, times the corresponding original state
+        coefficient, so the two coarse states are proportional with ratio the
+        two constants.  Multiplying one super-site of each chain by the other
+        chain's constant yields chains with equal states, unchanged bond
+        dimensions, and the super-site injectivities preserved.  The matched
+        matrix insertions on the distinguished coarse bond of the two scaled
+        chains form an algebra isomorphism between the two full bond matrix
+        algebras
+        (Theorem~\ref{thm:peps_edgeBlockedInsertionAlgebraIsomorphism}), and
+        an isomorphism of full matrix algebras forces equal matrix sizes.
+        Under the single-crossing hypothesis the coarse bond carries the
+        original bond dimension of the distinguished edge for each tensor, so
+        the two original bond dimensions agree.
+    \end{proof}
+\end{theorem}
+
 \begin{theorem}[Fundamental Theorem for normal PEPS, shared single-crossing
     blockings]%
     \label{thm:fundamentalTheorem_normalPEPS_connected}
     \lean{TNLean.PEPS.fundamentalTheorem_normalPEPS}
     \leanok
-    % Scope restriction: this is the shared-blocking, single-crossing,
-    % matched-bond variant of the general normal theorem stated after
+    % Scope restriction: this is the shared-blocking, single-crossing variant
+    % of the general normal theorem stated after
     % Theorem 3 of \cite{Molnar2018NormalPEPS}; the deltas are recorded in
     % \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
     \uses{def:peps_normalPEPSBlockingHypotheses,
         def:peps_regionInjectivityDataPair, def:GaugeEquivPEPS}
     Let $A$ and $B$ be PEPS tensors on a connected finite simple graph with
-    the same positive physical dimension and equal and positive bond
-    dimensions, generating the same state.  Suppose the normal blocking
+    the same positive physical dimension and positive bond dimensions,
+    generating the same state.  Suppose the normal blocking
     hypotheses hold at the doubly injective assignment of the two tensors:
     around every edge the network blocks into three doubly injective regions
     with the edge endpoints in the first two, and every site admits two doubly
@@ -5860,7 +5902,7 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $B_v$ at every vertex, with no leftover scalar.
     This is the general normal-PEPS theorem stated after
     \cite[Theorem~3]{Molnar2018NormalPEPS}
-    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), restricted in three
+    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), restricted in two
     ways. The blockings are shared between the two states with each region
     injective for both tensors, the reading under which the source's final
     comparison contracts both tensors over the same regions. The distinguished
@@ -5868,7 +5910,10 @@ injective and normal PEPS, following Theorems~2 and~3 of
     which reads blocking \emph{around} an edge as: the chosen edge is the
     entire bond between the first two parties of the three-site chain, as in
     the picture of the proof of \cite[Theorem~3]{Molnar2018NormalPEPS}. The
-    bond dimensions are matched by hypothesis rather than derived. The
+    equality of the bond dimensions is not assumed; it is derived from the
+    blocking hypotheses
+    (Theorem~\ref{thm:peps_bondDim_eq_of_normalBlocking}), as in the source's
+    isomorphism lemma. The
     positive bond dimensions and the connectivity of the graph are the
     counterexample-backed corrections carried over from the injective
     Fundamental Theorem (Theorem~\ref{thm:fundamentalTheorem_PEPS}); the
@@ -5876,9 +5921,12 @@ injective and normal PEPS, following Theorems~2 and~3 of
     that requires connectivity.
     \begin{proof}
         \leanok
-        \uses{lem:peps_injectiveRegion_union_pos,
+        \uses{thm:peps_bondDim_eq_of_normalBlocking,
+            lem:peps_injectiveRegion_union_pos,
             thm:peps_region_edge_gauge_of_coeff_transfer,
             thm:gaugeConsistency}
+        The bond dimensions of the two tensors agree on every edge by
+        Theorem~\ref{thm:peps_bondDim_eq_of_normalBlocking}.
         The union closure of injective regions for either tensor follows from
         the positive bond dimensions and
         Lemma~\ref{lem:peps_injectiveRegion_union_pos}.  At every edge the

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2194,6 +2194,28 @@ The deltas against the source statement (lines 1576--1583 of
           constants can be incorporated into the gauges.
 \end{enumerate}
 
+The third delta is now eliminated: the equality of the two bond dimension
+assignments is no longer a hypothesis of the existence
+theorem.\footnote{Formal declaration:
+    \leanid{TNLean.PEPS.bondDim_eq_of_normalBlocking} (blueprint
+    \path{thm:peps_bondDim_eq_of_normalBlocking}), consumed by
+    \leanid{TNLean.PEPS.fundamentalTheorem_normalPEPS}.}  The derivation is
+the recorded elimination plan, the region-level analogue of the injective
+theorem's edgewise derivation, run on the coarse three-site chains: around
+each edge the two blocked chains have state coefficients equal to positive
+merge-collapse constants times the original state coefficients, hence
+proportional states; multiplying one super-site of each chain by the other
+chain's constant restores an exact state equality while preserving the
+super-site injectivities and the bond dimensions, the blocked
+insertion-algebra equivalence on the distinguished coarse bond then forces
+equal sizes (lines 560--583 of \path{Papers/1804.04964/paper_normal.tex}, the
+remark that the algebra isomorphism makes the bond dimensions on the two
+sides agree), and under the single-crossing hypothesis the coarse bond
+carries the original bond dimension of the distinguished edge for each
+tensor.  The per-edge uniqueness clause keeps the equality among its
+hypotheses, since the families of gauges it compares are typed by the
+identification of the two bond spaces that the existence theorem produces.
+
 Two degenerate one-site comparisons allowed by the hypothesis bundle are
 handled directly rather than through the boundary-edge engine: when the
 smaller comparison region is empty its block is the count of global virtual


### PR DESCRIPTION
## Summary

Eliminates the assumed `hbond : A.bondDim = B.bondDim` from the general normal Fundamental Theorem (`fundamentalTheorem_normalPEPS`, #2690): the source derives the equality (arXiv:1804.04964, Section 3, lines 560–583 — the insertion algebra isomorphism forces equal bond dimensions), so assuming it was a stricter-hypothesis deviation per the faithfulness rule.

New file `TNLean/PEPS/NormalBondDimension.lean`:

- Circularity finding: the per-edge gauge engine consumes the equality (one genuine use: without matched bonds the coarse three-site chains have only *proportional* states, the merge-collapse constants differing).
- The fix: `scaleVertex` (multiply one vertex component by a constant — bond dimensions unchanged, the state scales, vertex injectivity preserved for nonzero constants) cross-scales each coarse chain by the other's positive collapse constant, restoring exact `SameState`; then the injective-FT template (`edgeTransferAlgEquiv` + `bondDim_eq_of_matrixAlgEquiv`) applies, and the coarse bond reads back as the original edge bond under the single-crossing hypothesis.
- Layered `bondDim_apply_eq_of_coherentFrames` → `bondDim_apply_eq_of_blockingData` → `bondDim_eq_of_normalBlocking` (per-edge then funext). Needs **no connectivity**.
- `fundamentalTheorem_normalPEPS` restated without `hbond` (derived as the first proof step; `GaugeEquiv` already packages the equality existentially so the conclusion was cast-clean). `fundamentalTheorem_normalPEPS_gauge_unique` keeps `hbond` — load-bearing for *stating* its hypotheses; the existence theorem's conclusion supplies it (recorded in the route note).

## Blueprint

New `\leanok` entry `thm:peps_bondDim_eq_of_normalBlocking`; `thm:fundamentalTheorem_normalPEPS_connected` drops the equal-bond-dimension clause from its hypothesis text (restriction count three→two); the `\notready` source entry's pointer text updated. Route note records the executed elimination plan.

## Verification

- Full root `lake build` green (8891 jobs); `lake exe lint-style` exit 0; `leanblueprint checkdecls` exit 0.
- `#print axioms` re-verified independently: `bondDim_eq_of_normalBlocking` and the restated `fundamentalTheorem_normalPEPS` = `[propext, Classical.choice, Quot.sound]`.
- No `sorry`/`axiom`/`admit`/`native_decide`/`maxHeartbeats`.

Part of #1373.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the capstone normal PEPS existence theorem and a new multi-step formal proof chain; behavior is proof-only with no new axioms, but downstream callers must drop the `hbond` argument from `fundamentalTheorem_normalPEPS`.
> 
> **Overview**
> **Derives matched bond dimensions** from normal PEPS blocking hypotheses instead of assuming them, aligning `fundamentalTheorem_normalPEPS` with the paper’s isomorphism lemma.
> 
> Adds `TNLean/PEPS/NormalBondDimension.lean` with `scaleVertex` (rescales one vertex without changing bond dims or injectivity), uses cross-scaling of coarse three-site chains to turn proportional coarse states into `SameState`, then `edgeTransferAlgEquiv` / `bondDim_eq_of_matrixAlgEquiv` plus the single-crossing bridge to get `bondDim_eq_of_normalBlocking` edgewise.
> 
> **`fundamentalTheorem_normalPEPS`** drops the `hbond` argument and proves `hbond` as the first step before the existing gauge assembly; **`fundamentalTheorem_normalPEPS_gauge_unique`** still takes `hbond` for typing. Blueprint gets `thm:peps_bondDim_eq_of_normalBlocking`; the route note records that the “matched bonds” delta is closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4fb43ca2cc9ff22297ab03b7548b5bef08ba8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->