### PR TITLE
doc(PEPS): the single-crossing hypothesis is the source's chain blocking

### DIFF
--- a/TNLean/PEPS/NormalAbsorbedFamily.lean
+++ b/TNLean/PEPS/NormalAbsorbedFamily.lean
@@ -24,17 +24,23 @@ This is the graph-general counterpart of the open-lattice family
 `exists_normalSquareInteriorAbsorbedGaugeFamily`, with no interior restriction:
 the blocking hypotheses supply a frame at every edge.
 
-**Scope restriction (single crossing edge):** the engine extracts the gauge on
-the distinguished edge `e` only when `e` is the *only* edge between the red and
-blue blocks, so the construction takes this single-crossing condition as an
-explicit hypothesis alongside the blocking bundle.  The source phrase "blocked
-into three partite injective MPS *around every edge*" is read here as: the
-chosen edge is the entire bond between the first two parties of the three-site
-chain, as in the source's Theorem 3 picture, where the two blocks adjacent to
-the edge touch only along it.  The recorded blocking bundle does not carry this
-condition as a field, so it is stated separately; see
-`docs/paper-gaps/peps_normal_ft_section3_route.tex`, Section "Remaining
-mathematical obligations".
+**Single crossing edge (the source's chain blocking):** the hypothesis that
+the distinguished edge `e` is the *only* edge between the red and blue blocks
+is the chain structure carried by the source phrase "blocked into three
+partite injective MPS *around every edge*", not an added restriction.  The
+source's blocking around an edge takes the two endpoints of the chosen edge as
+the first two parties of the chain, so the chosen edge is the bond between
+them (arXiv:1804.04964, lines 981--1009 of
+`Papers/1804.04964/paper_normal.tex`); the Theorem 3 regions enlarge the first
+two parties to injective blocks meeting only along the distinguished edge
+(lines 1475--1498); and the proof reads the gauge of the isomorphism lemma as
+living on that edge of the original network (lines 1037 and 1498), which
+presupposes that the bond between the first two parties is the edge's own
+virtual leg.  Since every edge between the red and blue blocks lies in the
+red-to-blue bond of the chain, the edge being the entire bond is equivalent to
+the single-crossing condition.  The recorded blocking bundle does not carry
+the condition as a field, so it is stated separately; the reading is recorded
+in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 ## References
 
@@ -133,9 +139,12 @@ The family is built edge by edge from
 `exists_absorbingGauge_of_pairBlockingDatum`; the bare-edge identity at an edge
 constrains only the family's value there, so the choices need no compatibility.
 
-**Scope restriction (single crossing edge):** the single-crossing condition
-`hsingle` is the formal content of blocking *around* each edge; see the module
-docstring and `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+**Single crossing edge (the source's chain blocking):** the single-crossing
+condition `hsingle` is the formal content of blocking *around* each edge — the
+distinguished edge is the entire bond between the first two parties of the
+chain (arXiv:1804.04964, lines 981--1009 and 1475--1498 of
+`Papers/1804.04964/paper_normal.tex`); see the module docstring and
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
 1576--1583, via the proof of Theorem 3, lines 1449--1544 of

--- a/TNLean/PEPS/NormalBondDimension.lean
+++ b/TNLean/PEPS/NormalBondDimension.lean
@@ -32,9 +32,13 @@ then applies to the scaled chains, the finrank rigidity
 and the single-crossing bridge (`bridgeEquiv`) reads the coarse `r-b` bond as
 the original bond on the distinguished edge for each tensor.
 
-**Scope restriction (single crossing edge):** as everywhere in the general
-normal assembly, the distinguished edge is the single red-to-blue crossing of
-its frame; see `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+**Single crossing edge (the source's chain blocking):** as everywhere in the
+general normal assembly, the distinguished edge is the single red-to-blue
+crossing of its frame.  This is the chain structure of the source's blocking
+around an edge — the edge is the bond between the first two parties of the
+chain (arXiv:1804.04964, lines 981--1009 and 1475--1498 of
+`Papers/1804.04964/paper_normal.tex`) — not an added restriction; see
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 ## References
 
@@ -263,8 +267,11 @@ Theorem from the blocking hypotheses, as the source derives it: the insertion
 correspondence on each blocked chain is an algebra isomorphism between the two
 full bond matrix algebras, forcing equal sizes.
 
-**Scope restriction (single crossing edge):** the hypothesis `hsingle` is the
-formal content of blocking *around* each edge; see
+**Single crossing edge (the source's chain blocking):** the hypothesis
+`hsingle` is the formal content of blocking *around* each edge — the
+distinguished edge is the entire bond between the first two parties of the
+chain (arXiv:1804.04964, lines 981--1009 and 1475--1498 of
+`Papers/1804.04964/paper_normal.tex`); see
 `docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
 theorem bondDim_eq_of_normalBlocking
     (A B : Tensor G d)

--- a/TNLean/PEPS/NormalGeneralFundamentalTheorem.lean
+++ b/TNLean/PEPS/NormalGeneralFundamentalTheorem.lean
@@ -31,12 +31,18 @@ of the injective Fundamental Theorem (`exists_edgeScalars_of_connected`,
 statement holds at fixed system size with no translation invariance, the
 proportionality constants being absorbed into the gauges.
 
-The added hypotheses relative to the source statement are documented:
+The hypotheses beyond the source's wording are documented:
 
-* **Scope restriction (single crossing edge):** the engine extracts the gauge
-  on the distinguished edge only when it is the entire bond between the red and
-  blue blocks; this reading of "blocked ... around every edge" is an explicit
-  hypothesis (see `TNLean.PEPS.NormalAbsorbedFamily` and
+* **Single crossing edge (the source's chain blocking):** the hypothesis
+  `hsingle` — each distinguished edge is the entire bond between the red and
+  blue blocks — is the chain structure carried by the source's "blocked into
+  three partite injective MPS around every edge", not an added restriction:
+  the source's blocking around an edge takes the edge as the bond between its
+  first two parties, and the proof reads the resulting gauge as living on that
+  edge (lines 981--1009, 1037, and 1475--1498 of
+  `Papers/1804.04964/paper_normal.tex`).  It is stated explicitly because the
+  recorded blocking bundle does not carry it as a field (see
+  `TNLean.PEPS.NormalAbsorbedFamily` and
   `docs/paper-gaps/peps_normal_ft_section3_route.tex`).
 * Positive bond dimensions and connectivity are the faithfulness fixes of the
   injective Fundamental Theorem, both backed by machine-checked
@@ -85,9 +91,12 @@ The per-vertex scalars `λ_v` produced by the one-site comparisons satisfy
 absorbed into the edge gauges, as in the source's remark that the
 proportionality constants can be incorporated into the gauge transformations.
 
-**Scope restriction (single crossing edge):** the hypothesis `hsingle` is the
-formal content of blocking *around* each edge — the distinguished edge is the
-entire bond between the first two parties of the three-site chain; see
+**Single crossing edge (the source's chain blocking):** the hypothesis
+`hsingle` is the formal content of blocking *around* each edge — the
+distinguished edge is the entire bond between the first two parties of the
+three-site chain, as the source's blocking construction and the Theorem 3
+regions realize it (arXiv:1804.04964, lines 981--1009 and 1475--1498 of
+`Papers/1804.04964/paper_normal.tex`); see
 `docs/paper-gaps/peps_normal_ft_section3_route.tex`.  Positive bonds and
 connectivity are the counterexample-backed faithfulness fixes of the
 injective Fundamental Theorem

--- a/blueprint/src/chapter/ch13a_peps_ft.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft.tex
@@ -5851,7 +5851,9 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $X\mapsto Y$ on the chosen bond is an algebra isomorphism between the two
     full bond matrix algebras, so the bond dimensions on the two sides agree;
     the normal case inherits the argument through the blocked three-site
-    chains.
+    chains.  The single-crossing condition is the source's blocking around an
+    edge made explicit: the chosen edge is the entire bond between the first
+    two parties of the blocked chain.
     \begin{proof}
         \leanok
         \uses{thm:peps_edgeBlockedThreeSiteInjective,
@@ -5882,9 +5884,11 @@ injective and normal PEPS, following Theorems~2 and~3 of
     \label{thm:fundamentalTheorem_normalPEPS_connected}
     \lean{TNLean.PEPS.fundamentalTheorem_normalPEPS}
     \leanok
-    % Scope restriction: this is the shared-blocking, single-crossing variant
-    % of the general normal theorem stated after
-    % Theorem 3 of \cite{Molnar2018NormalPEPS}; the deltas are recorded in
+    % Reading note: this is the shared-blocking variant of the general normal
+    % theorem stated after Theorem 3 of \cite{Molnar2018NormalPEPS}.  The
+    % single-crossing hypothesis is the source's chain blocking around each
+    % edge made explicit, not a restriction; the reading and the remaining
+    % delta are recorded in
     % \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
     \uses{def:peps_normalPEPSBlockingHypotheses,
         def:peps_regionInjectivityDataPair, def:GaugeEquivPEPS}
@@ -5902,14 +5906,19 @@ injective and normal PEPS, following Theorems~2 and~3 of
     $B_v$ at every vertex, with no leftover scalar.
     This is the general normal-PEPS theorem stated after
     \cite[Theorem~3]{Molnar2018NormalPEPS}
-    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), restricted in two
-    ways. The blockings are shared between the two states with each region
+    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), restricted in one
+    way: the blockings are shared between the two states with each region
     injective for both tensors, the reading under which the source's final
-    comparison contracts both tensors over the same regions. The distinguished
-    edge of each frame is its only crossing between the two adjacent blocks,
-    which reads blocking \emph{around} an edge as: the chosen edge is the
-    entire bond between the first two parties of the three-site chain, as in
-    the picture of the proof of \cite[Theorem~3]{Molnar2018NormalPEPS}. The
+    comparison contracts both tensors over the same regions. The
+    single-crossing hypothesis is not a further restriction but the explicit
+    statement of the source's blocking \emph{around} an edge: the chosen edge
+    is the entire bond between the first two parties of the three-site chain.
+    In the source, blocking around an edge groups all vertices except the two
+    endpoints of the edge, so the edge is the bond between the first two
+    parties; the regions in the proof of
+    \cite[Theorem~3]{Molnar2018NormalPEPS} enlarge those parties to injective
+    blocks meeting only along the distinguished edge, and the gauge of the
+    isomorphism lemma lives on that edge of the original network. The
     equality of the bond dimensions is not assumed; it is derived from the
     blocking hypotheses
     (Theorem~\ref{thm:peps_bondDim_eq_of_normalBlocking}), as in the source's

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2216,6 +2216,39 @@ tensor.  The per-edge uniqueness clause keeps the equality among its
 hypotheses, since the families of gauges it compares are typed by the
 identification of the two bond spaces that the existence theorem produces.
 
+The second delta is resolved by reading the source: the single-crossing
+hypothesis is the chain structure of the source's hypothesis ``blocked into
+three partite injective MPS around every edge'' (line 1579 of
+\path{Papers/1804.04964/paper_normal.tex}), not a narrowing.  The source's
+blocking around an edge takes the two endpoints of the chosen edge as the
+first two parties of the chain, so the chosen edge is the bond between them:
+``Choose one edge of the PEPS and group together all vertices except the
+endpoints of the edge.  This regrouped tensor together with the two endpoints
+of the edge forms a three-partite MPS'' (lines 981--1009).  The normal case
+enlarges the first two parties to injective regions while keeping the
+distinguished edge their only contact: in the square-lattice picture of the
+proof of Theorem \path{3} (lines 1475--1498) the red and blue blocks meet
+only along the distinguished edge, which reappears as the bond between the
+first two coarse sites of the blocked chain.  The proof then reads the gauge
+of the isomorphism lemma as living on that edge of the original network
+(``This establishes a gauge transformation on the edge $(1,5)$ of the
+original PEPS'', line 1037; ``giving a gauge transformation on every edge'',
+line 1498), which presupposes that the bond between the first two parties is
+the edge's own virtual leg, and the general theorem requires exactly the
+blockings of that proof (``The above proof can be repeated for any PEPS as
+long as it is possible to block into injective regions as required by''
+the two lemmas, line 1574).  Since any edge between the red and blue regions
+necessarily belongs to the red-to-blue bond of a three-partite chain, the
+distinguished edge being the entire bond is equivalent to it being the only
+red-to-blue crossing.  The source nowhere blocks an edge into a collected
+multi-edge bond between the first two parties, and no per-edge factorization
+of a product-bond gauge appears in the proof of Theorem \path{3}.  The
+hypothesis is therefore kept in the formal statements unchanged and is no
+longer counted as a scope restriction; the in-source markers and the
+blueprint entries \path{thm:fundamentalTheorem_normalPEPS_connected} and
+\path{thm:peps_bondDim_eq_of_normalBlocking} state the reading explicitly so
+that it can be audited against the source lines above.
+
 Two degenerate one-site comparisons allowed by the hypothesis bundle are
 handled directly rather than through the boundary-edge engine: when the
 smaller comparison region is empty its block is the count of global virtual


### PR DESCRIPTION
## Verdict

A scoping-first investigation of the last marked scope restriction on
`fundamentalTheorem_normalPEPS`: the hypothesis `hsingle` (each
distinguished edge is the only crossing edge between its red and blue
blocks). **Verdict: faithful.** `hsingle` is the chain structure carried
by hypothesis (i) of the source theorem ("they can be blocked into three
partite injective MPS around every edge", arXiv:1804.04964), not a
narrowing. No Lean statement or proof is changed; this is a
documentation alignment.

## Source evidence (line numbers in `Papers/1804.04964/paper_normal.tex`)

- **Lines 981–1009** (the source's definition of blocking around an
  edge): "Choose one edge of the PEPS and group together all vertices
  except the endpoints of the edge. This regrouped tensor together with
  the two endpoints of the edge forms a three-partite MPS". The first
  two parties are the edge's endpoints, so on a simple graph the chosen
  edge is the entire bond between them.
- **Line 1037**: "hence \cref{lem:inj_isomorph} can be applied. This
  establishes a gauge transformation on the edge $(1,5)$ of the original
  PEPS." The gauge of the isomorphism lemma (a matrix on the bond
  between the first two blocks, lines 254–275) is read as a gauge on the
  original edge — meaningful only when that bond is the edge's own
  virtual leg.
- **Lines 1475–1498** (proof of Theorem 3, normal case): the red 2×3 and
  blue 3×2 regions around the distinguished (green) edge meet only along
  that edge (checked against the picture coordinates), and the green
  edge reappears as the bond between the first two coarse sites of the
  blocked chain; "Therefore \cref{lem:inj_isomorph} can be applied
  giving a gauge transformation on every edge."
- **Line 1574** ties the general theorem's hypothesis to exactly these
  blockings: "The above proof can be repeated for any PEPS as long as it
  is possible to block into injective regions as required by
  \cref{lem:inj_isomorph} and \cref{lem:inj_equal_tensors_2}."

Since any edge between the red and blue regions necessarily belongs to
the red-to-blue bond of a three-partite chain, "the distinguished edge
is the entire bond between the first two parties" is equivalent to
`hsingle`. The source nowhere blocks an edge into a collected multi-edge
bond between the first two parties, and no per-edge factorization of a
product-bond gauge appears anywhere in the proof of Theorem 3.

## Changes

- `TNLean/PEPS/NormalAbsorbedFamily.lean`,
  `TNLean/PEPS/NormalBondDimension.lean`,
  `TNLean/PEPS/NormalGeneralFundamentalTheorem.lean`: the
  `**Scope restriction (single crossing edge):**` markers become
  `**Single crossing edge (the source's chain blocking):**`
  explanations with the line citations above. Hypotheses, statements,
  and proofs unchanged.
- `blueprint/src/chapter/ch13a_peps_ft.tex`:
  `thm:fundamentalTheorem_normalPEPS_connected` is now "restricted in
  one way" (shared blockings); the single-crossing hypothesis is stated
  as the explicit reading of the source's blocking around an edge, so a
  reader can audit it. `thm:peps_bondDim_eq_of_normalBlocking` gains the
  same reading sentence.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex` (append-only): a
  paragraph recording the verdict with the source quotes and line
  citations, following the pattern of the eliminated bond-dimension
  delta.

## Checks

- `lake build`: green (8891 jobs).
- `lake exe lint-style`: exit 0.
- `chktex -q -l blueprint/.chktexrc` on `ch13a_peps_ft.tex`: clean.
- `cd blueprint && leanblueprint checkdecls`: exit 0.
- Note: `latexmk` on the route note fails identically at the
  origin/main baseline (a pre-existing `\path` inside math at the
  one-site-comparison passage, under TeX Live 2026 locally); not
  introduced here and not a PR gate (`docgen` is weekly-scheduled).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no formal statements, proofs, or runtime behavior change.
> 
> **Overview**
> Reframes the formal hypothesis `hsingle` (each distinguished edge is the only red–blue crossing) from an extra **scope restriction** to **faithful chain blocking** from Molnár et al. (arXiv:1804.04964), with line citations in `Papers/1804.04964/paper_normal.tex`. **No Lean statements or proofs change**—only docstrings in `NormalAbsorbedFamily.lean`, `NormalBondDimension.lean`, and `NormalGeneralFundamentalTheorem.lean`.
> 
> The blueprint (`ch13a_peps_ft.tex`) now says the connected normal fundamental theorem is restricted in **one** way (shared blockings), not two, and spells out the single-crossing reading for bond-dimension and gauge theorems. **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** gains an append-only paragraph that resolves the second “delta”: `hsingle` is no longer counted as a scope restriction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309c0d30fb569fd6289b0636beadbbe46cf0b136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->