### PR TITLE
doc(PEPS): shared blockings are the source's reading; record the TI-gauges remark

### DIFF
--- a/TNLean/PEPS/NormalGeneralFundamentalTheorem.lean
+++ b/TNLean/PEPS/NormalGeneralFundamentalTheorem.lean
@@ -33,6 +33,21 @@ proportionality constants being absorbed into the gauges.
 
 The hypotheses beyond the source's wording are documented:
 
+* **Shared blockings (the source's pair reading):** the blocking hypotheses
+  are instantiated at the conjunction predicate
+  (`regionInjectivityDataPair`): one family of regions, each injective for
+  both tensors at once.  This is the source's hypothesis, not an added
+  restriction: the theorem blocks both states by one blocking ("*they* can be
+  blocked into three partite injective MPS around every edge", lines
+  1577--1579 of `Papers/1804.04964/paper_normal.tex`); the proof it
+  generalizes chooses the regions once and feeds the two blocked chains, over
+  the same tripartition, to the isomorphism lemma, whose statement requires
+  all six blocks injective (lines 254--278, applied at lines 1475--1498); and
+  the final comparison contracts both tensors over the same
+  one-site-different regions, with all four blocked tensors injective by its
+  comparison lemma (lines 1067--1093, applied at lines 1519--1544).  See
+  `TNLean.PEPS.NormalPairBlocking` and
+  `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 * **Single crossing edge (the source's chain blocking):** the hypothesis
   `hsingle` — each distinguished edge is the entire bond between the red and
   blue blocks — is the chain structure carried by the source's "blocked into
@@ -49,6 +64,19 @@ The hypotheses beyond the source's wording are documented:
   counterexamples (`docs/paper-gaps/peps_injective_ft_section3_route.tex`,
   `docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex`); the scalar
   absorption is exactly the step that requires connectivity.
+
+The source's remark following the theorem (line 1584 of
+`Papers/1804.04964/paper_normal.tex`) — for a translationally invariant
+system the gauges are also translationally invariant, provided the
+proportionality constants are not absorbed into the gauges — is delivered on
+the torus, the development's translation-invariant setting:
+`exists_torusCovariantAbsorbedGaugeFamily` constructs a translation-covariant
+gauge family (`IsTranslationCovariantGaugeFamily`), and the unconditional
+torus theorem (`fundamentalTheorem_normalTorusPEPS_unconditional`) keeps the
+single scalar `λ` with `λ^{nm} = 1` separate from the gauges, exactly the
+source's parenthetical.  The present connected-graph statement takes the
+other branch of the remark: the per-vertex constants are absorbed into the
+edge gauges.
 
 ## References
 
@@ -90,6 +118,14 @@ The per-vertex scalars `λ_v` produced by the one-site comparisons satisfy
 `∏_v λ_v = 1` by the closed state equality, so on the connected graph they are
 absorbed into the edge gauges, as in the source's remark that the
 proportionality constants can be incorporated into the gauge transformations.
+
+**Shared blockings (the source's pair reading):** the pair predicate
+instantiates one blocking for the two states, each region injective for both
+tensors, as in the source, where one choice of regions blocks both networks
+and the two comparison lemmas take the blocked chains of both tensors over
+the same regions (arXiv:1804.04964, lines 1577--1579, 1475--1498, and
+1519--1544 of `Papers/1804.04964/paper_normal.tex`); see
+`TNLean.PEPS.NormalPairBlocking` and the module docstring.
 
 **Single crossing edge (the source's chain blocking):** the hypothesis
 `hsingle` is the formal content of blocking *around* each edge — the

--- a/TNLean/PEPS/NormalPairBlocking.lean
+++ b/TNLean/PEPS/NormalPairBlocking.lean
@@ -14,6 +14,17 @@ in the given site".  The blockings are shared between the two states: the
 source's final comparison contracts both tensors over the *same* regions, so
 each region in the hypothesis must be injective for both tensors at once.
 
+This pairing is the source's hypothesis, not a formal narrowing.  The theorem
+blocks both states by one blocking ("*they* can be blocked", lines 1577--1579
+of `Papers/1804.04964/paper_normal.tex`); the proof it generalizes chooses
+the regions once ("Let us block the TN into three injective parts around an
+edge.  This can be done with e.g. the following choice of regions", line
+1475) and feeds the two blocked chains, over the same tripartition, to the
+isomorphism lemma, whose statement requires all six blocks injective (lines
+254--278, applied at lines 1475--1498); and the final comparison takes all
+four blocked tensors injective over the same one-site-different regions
+(lines 1067--1093, applied at lines 1519--1544).
+
 This file records that pairing at the level of the abstract region-injectivity
 predicate: the conjunction predicate `regionInjectivityDataPair` declares a
 region injective when it is injective for each of the two tensors, and a
@@ -42,10 +53,13 @@ variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 /-- The conjunction of two region-injectivity predicates: a region is injective
 when it is injective for each of the two tensors.
 
-The general normal PEPS theorem blocks *two* states by one shared geometry, and
-the source's final comparison applies the inverses of both blocked tensors over
-the same regions, so the blocking hypothesis asks each region to be injective
-for both tensors at once.
+The general normal PEPS theorem blocks *two* states by one shared geometry
+("*they* can be blocked", lines 1577--1579 of
+`Papers/1804.04964/paper_normal.tex`), and the source's final comparison
+applies the inverses of both blocked tensors over the same regions (lines
+1519--1544, through the comparison lemma of lines 1067--1093), so the
+blocking hypothesis asks each region to be injective for both tensors at
+once.
 
 Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
 1576--1583 of `Papers/1804.04964/paper_normal.tex`. -/

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
@@ -69,10 +69,20 @@
     the gauges are unique up to the scalar freedom allowed by the graph. This
     is the general normal-PEPS theorem stated after
     \cite[Theorem~3]{Molnar2018NormalPEPS}.
-    A connected-graph form with shared single-crossing blockings is
+    A connected-graph form, with the blocking hypothesis stated as the
+    source's proof uses it (one blocking shared by the two states, each
+    distinguished edge the entire bond of its chain), is
     Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected}; its per-edge
     uniqueness clause is
     Theorem~\ref{thm:fundamentalTheorem_normalPEPS_gauge_unique}.
+    The source's remark following the theorem, that for a translationally
+    invariant system the gauges are also translationally invariant when the
+    proportionality constants are not absorbed into them, is realized on the
+    torus by
+    Theorem~\ref{thm:fundamentalTheorem_normalTorusPEPS_unconditional}: its
+    gauge family is carried onto every edge by the translations from one
+    reference matrix per orientation class, and its scalar $\lambda$ is kept
+    separate rather than absorbed.
 \end{theorem}
 
 \begin{definition}[Doubly injective regions]%
@@ -133,17 +143,15 @@
     \end{proof}
 \end{theorem}
 
-\begin{theorem}[Fundamental Theorem for normal PEPS, shared single-crossing
-    blockings]%
+\begin{theorem}[Fundamental Theorem for normal PEPS on a connected graph]%
     \label{thm:fundamentalTheorem_normalPEPS_connected}
     \lean{TNLean.PEPS.fundamentalTheorem_normalPEPS}
     \leanok
-    % Reading note: this is the shared-blocking variant of the general normal
-    % theorem stated after Theorem 3 of \cite{Molnar2018NormalPEPS}.  The
-    % single-crossing hypothesis is the source's chain blocking around each
-    % edge made explicit, not a restriction; the reading and the remaining
-    % delta are recorded in
-    % \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
+    % Reading note: this is the general normal theorem stated after Theorem 3
+    % of \cite{Molnar2018NormalPEPS} on a connected graph.  The shared
+    % blockings and the single-crossing hypothesis are the source's blocking
+    % hypothesis made explicit, not restrictions; both readings are recorded
+    % in \path{docs/paper-gaps/peps_normal_ft_section3_route.tex}.
     \uses{def:peps_normalPEPSBlockingHypotheses,
         def:peps_regionInjectivityDataPair, def:GaugeEquivPEPS}
     Let $A$ and $B$ be PEPS tensors on a connected finite simple graph with
@@ -160,11 +168,16 @@
     $B_v$ at every vertex, with no leftover scalar.
     This is the general normal-PEPS theorem stated after
     \cite[Theorem~3]{Molnar2018NormalPEPS}
-    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), restricted in one
-    way: the blockings are shared between the two states with each region
-    injective for both tensors, the reading under which the source's final
-    comparison contracts both tensors over the same regions. The
-    single-crossing hypothesis is not a further restriction but the explicit
+    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), with the source's
+    blocking hypothesis stated explicitly as its proof uses it, in two ways,
+    neither of which restricts the source statement.  First, the blockings
+    are shared between the two states, each region injective for both
+    tensors: the source blocks both states by one blocking (``\emph{they}
+    can be blocked''), its isomorphism lemma takes the two blocked chains
+    over the same tripartition with all six blocks injective, and its final
+    comparison contracts both tensors over the same one-site-different
+    regions, whose injectivity for both tensors its comparison lemma
+    requires.  Second, the single-crossing hypothesis is the explicit
     statement of the source's blocking \emph{around} an edge: the chosen edge
     is the entire bond between the first two parties of the three-site chain.
     In the source, blocking around an edge groups all vertices except the two

--- a/blueprint/src/chapter/ch13a_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_torus.tex
@@ -250,6 +250,12 @@
     wraparound edge is reversed, so on the seam the family carries the
     transposed inverse of the class matrix, and a family that is literally one
     matrix per orientation class cannot realize the absorbed equality there.
+    The translation covariance of the family, with the scalar $\lambda$ kept
+    separate rather than absorbed, realizes the remark of
+    \cite{Molnar2018NormalPEPS} following the general normal theorem: for a
+    translationally invariant system the gauges are also translationally
+    invariant, provided the proportionality constants are not absorbed into
+    the gauges.
     The uniqueness of $X$ and $Y$ up to a multiplicative constant is not part
     of this statement; the uniqueness clause is
     Theorem~\ref{thm:torusAbsorbedGauge_unique_scalar} (per edge, against the

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2366,7 +2366,7 @@ The remaining $v$-side row statement, however, does not close under blocked-regi
 injectivity alone. Discharging it evaluates the first tensor's endpoint operator,
 which factors as
 $\Phi^A_v \circ (\text{incident insertion}) \circ \Psi^A_v$ with $\Psi^A_v$ a left
-inverse of $\Phi^A_v=\path{localTensorMap}\ A\ v$, on the \emph{second} tensor's
+inverse of $\Phi^A_v$ (\path{localTensorMap} of the first tensor at $v$), on the \emph{second} tensor's
 region weight vectors. This requires the cross-tensor endpoint image inclusion
 $\operatorname{range}(\Phi^B_v)\subseteq\operatorname{range}(\Phi^A_v)$, i.e.\ the
 two single-vertex tensor images at $v$ coincide. That coincidence is available only

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2249,6 +2249,61 @@ blueprint entries \path{thm:fundamentalTheorem_normalPEPS_connected} and
 \path{thm:peps_bondDim_eq_of_normalBlocking} state the reading explicitly so
 that it can be audited against the source lines above.
 
+The first delta is also resolved by reading the source: the shared blockings
+are the source's hypothesis, not a narrowing.  The theorem blocks both
+states by one blocking: ``Suppose two normal PEPS generating the same state
+satisfy the following: \emph{they} can be blocked into three partite
+injective MPS around every edge'' (lines 1577--1579 of
+\path{Papers/1804.04964/paper_normal.tex}).  The proof it generalizes
+chooses the regions once, geometrically: ``Let us block the TN into three
+injective parts around an edge.  This can be done with e.g.\ the following
+choice of regions'' (line 1475), and feeds the two blocked chains to the
+isomorphism lemma, whose statement takes two three-site MPS over the same
+tripartition with all six blocks injective (lines 254--278, applied at line
+1498).  The insertion correspondence driving the comparison is stated bond
+by bond between the two networks blocked identically (``inserting a matrix
+$Z$ on any bond of the first PEPS gives the same state as inserting the same
+matrix $Z$ on the corresponding bond of the second PEPS'', line 1519), and
+the final comparison contracts both tensors over the same
+one-site-different regions $R$ and $S$ (``Let us denote the tensor on region
+$R$ as $A_R$ ($\tilde{B}_R$) and on region $S$ as $A_S$ ($\tilde{B}_S$)'',
+line 1544), through the comparison lemma, whose hypothesis makes all four
+blocked tensors injective (lines 1067--1093).  A pair of unrelated
+blockings, one per tensor, would not feed either lemma: the isomorphism
+lemma compares the two chains over one tripartition, and the comparison
+lemma cancels the common blocked region against both sides.  The conjunction
+predicate of the formal hypotheses, each region injective for both tensors
+at once, is therefore the source's hypothesis set, and the connected-graph
+entry \path{thm:fundamentalTheorem_normalPEPS_connected} no longer counts it
+as a restriction; the remaining additions against the source statement are
+the counterexample-backed positivity and connectivity corrections shared
+with the injective theorem.
+
+The source's remark after the theorem (line 1584 of
+\path{Papers/1804.04964/paper_normal.tex}) states that for a translationally
+invariant system the gauges are also translationally invariant, provided the
+proportionality constants are not absorbed into the gauges.  On the torus,
+the only translation-invariant geometry the formal development carries, this
+is already delivered: the absorbed gauge family of the unconditional torus
+theorem is translation covariant, the orientation-faithful form of ``the
+same matrix $X$ ($Y$) on all horizontal (vertical) edges'' with the
+transposed inverse on the seam edges of the ordered edge convention (see the
+section on closure on the torus), and the theorem keeps the single scalar
+$\lambda$ with $\lambda^{nm}=1$ separate from the gauges, matching the
+parenthetical.\footnote{Formal declarations:
+    \leanid{TNLean.PEPS.exists_torusCovariantAbsorbedGaugeFamily} and
+    \leanid{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}
+    (blueprint
+    \path{thm:fundamentalTheorem_normalTorusPEPS_unconditional}).}  A form
+of the remark for translation-invariant settings other than the torus is not
+formalized: the development carries no other translation-invariance
+predicate, and none of its statements assert translationally invariant
+gauges outside the torus.  This is recorded as a non-goal of the present
+route rather than a delta against the theorem: the remark follows the
+theorem instead of being part of its statement, and the connected-graph
+assembly takes the remark's other branch, absorbing the constants into the
+gauges.
+
 Two degenerate one-site comparisons allowed by the hypothesis bundle are
 handled directly rather than through the boundary-edge engine: when the
 smaller comparison region is empty its block is the count of global virtual


### PR DESCRIPTION
Documentation-only scoping pass on the general normal Fundamental Theorem (arXiv:1804.04964, theorem labelled `normal`, lines 1576--1583 of `Papers/1804.04964/paper_normal.tex`), mirroring the single-crossing pass of #2696. No Lean statement or proof changes.

## Verdict (a): the shared blockings are the source's reading, not a restriction

`fundamentalTheorem_normalPEPS` instantiates `NormalPEPSBlockingHypotheses` at the conjunction predicate `regionInjectivityDataPair`: one family of regions per edge and per site, each injective for **both** tensors. The source reads the same way:

- The theorem blocks both states by one blocking: *"Suppose two normal PEPS generating the same state satisfy the following: **they** can be blocked into three partite injective MPS around every edge"* (lines 1577--1579).
- The proof it generalizes chooses the regions once, geometrically: *"Let us block the TN into three injective parts around an edge. This can be done with e.g. the following choice of regions"* (line 1475), and feeds the two blocked chains to the isomorphism lemma, whose statement takes *"$A,B$ ... two injective ... MPS on three sites that generate the same state"* — two chains over the **same** tripartition, all six blocks injective (lines 254--278, applied at line 1498).
- The insertion correspondence is stated bond by bond between the two identically blocked networks: *"inserting a matrix $Z$ on any bond of the first PEPS gives the same state as inserting the same matrix $Z$ on the corresponding bond of the second PEPS"* (line 1519).
- The final comparison contracts both tensors over the same one-site-different regions: *"Let us denote the tensor on region $R$ as $A_R$ ($\tilde B_R$) and on region $S$ as $A_S$ ($\tilde B_S$)"* (line 1544), through `lem:inj_equal_tensors_2`, whose hypothesis makes all four blocked tensors injective (lines 1067--1093).
- Line 1574 ties the theorem's hypothesis to exactly these blockings: *"The above proof can be repeated for any PEPS as long as it is possible to block into injective regions as required by"* the two lemmas.

A pair of unrelated per-tensor blockings would not feed either lemma. Treatment (as in #2696): the in-source markers become reading notes with line citations (`NormalGeneralFundamentalTheorem.lean`, `NormalPairBlocking.lean`); the blueprint entry `thm:fundamentalTheorem_normalPEPS_connected` is retitled to the connected-graph form and now presents both explicitations (shared blockings, single crossing) as the source's hypothesis stated for audit, restrictions in zero ways; the remaining additions against the source are the counterexample-backed positivity and connectivity corrections. Route note records the verdict.

## Verdict (b): the TI-gauges remark is already realized on the torus

Source line 1584, right after the theorem: *"In case of a translational invariant system, the gauges are also translational invariant (if the proportionality constants are not absorbed into the gauges)."*

The repo delivers this on the torus, its only translation-invariant setting: `exists_torusCovariantAbsorbedGaugeFamily` (`TorusCovariantAbsorbedFamily.lean`) produces a translation-covariant family (`IsTranslationCovariantGaugeFamily`, the orientation-faithful form of "the same matrix $X$ ($Y$) on all horizontal (vertical) edges") with the bare-edge absorbed equality, and `fundamentalTheorem_normalTorusPEPS_unconditional` keeps the single scalar $\lambda$ with $\lambda^{nm}=1$ separate from the gauges — exactly the source's parenthetical. Doc/blueprint item only: cross-references added to the module doc of `NormalGeneralFundamentalTheorem.lean`, the general entry `thm:fundamentalTheorem_normalPEPS`, and the torus entry `thm:fundamentalTheorem_normalTorusPEPS_unconditional`. The route note records the remark's form for translation-invariant settings other than the torus as a non-goal (no other translation-invariance predicate exists in the development), not a delta: the remark follows the theorem rather than being part of its statement, and the connected-graph assembly takes the remark's other branch (constants absorbed).

## Checks

- `lake build` green (8891 jobs)
- `lake exe lint-style` exit 0
- `lake env lean` on both touched Lean files
- chktex clean on `ch13a_peps_ft.tex`
- `leanblueprint web` + `leanblueprint checkdecls` exit 0
- route note edits are append-only

## Pre-existing issue (not from this PR)

`docs/paper-gaps/peps_normal_ft_section3_route.tex` fails to compile standalone on `main` already: line 2314 (on main) has `$\Phi^A_v=\path{localTensorMap}\ A\ v$` — `\path` inside math mode aborts pdflatex. The weekly `docgen` run of `scripts/build-paper-gaps.sh` will hit it; worth a one-line follow-up fix. My appended paragraphs parse cleanly (pdflatex processes past them before halting at that line).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and blueprint/route prose only; no changes to Lean theorems, proofs, or runtime behavior.
> 
> **Overview**
> **Documentation-only** pass on the general normal PEPS Fundamental Theorem (arXiv:1804.04964): no Lean statement or proof changes.
> 
> **Shared blockings:** Docs now argue that `regionInjectivityDataPair` (one blocking, each region injective for both tensors) matches the paper’s “*they* can be blocked” reading—not a formal narrowing. Updates span Lean module/theorem docstrings (`NormalGeneralFundamentalTheorem.lean`, `NormalPairBlocking.lean`), blueprint `thm:fundamentalTheorem_normalPEPS_connected` (retitled to connected-graph form; shared blockings + single-crossing framed as explicit source hypotheses), and `docs/paper-gaps/peps_normal_ft_section3_route.tex` (treats the “first delta” as resolved).
> 
> **TI-gauges remark (line 1584):** Documentation links the remark to the torus: translation-covariant absorbed gauges with scalar `λ` kept separate (`fundamentalTheorem_normalTorusPEPS_unconditional`), vs the connected-graph theorem absorbing per-vertex constants. Blueprint capstone and torus chapters cross-reference this; the route note records non-torus TI as a non-goal.
> 
> **Minor fix:** In the route note, a math-mode `\path{localTensorMap}` reference is rewritten to prose with `\path{localTensorMap}` outside math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eb1809676f33eb249c265a96f5fdc414e9b5663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->