### PR TITLE
feat(MPS/ParentHamiltonian): prove last crossing block component membership

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -33,50 +33,31 @@ def lastCrossingComplementWord {m M : ℕ} (hLen : m + 2 ≤ M + 1)
   List.ofFn fun k : Fin (M + 1 - (m + 2)) =>
     τ ⟨k.val + (m + 1), by omega⟩
 
-/-- At the cyclic window beginning at the last site, the block-diagonal local
-sum has the left-boundary trace form used in the blockwise coefficient
-comparison.
+/-- At the cyclic window beginning at the last site, one block component has the
+left-boundary trace form used in the blockwise coefficient comparison.
 
-Let the total chain have length \(M+1\), and let the local window have length
-\(m+2\). The cyclic window beginning at \(M\) consists of the last site followed
-by the first \(m+1\) sites. If the complementary word is
+For an outside configuration with complementary word \(\rho\), the \(j\)-th
+summand is the left-boundary component with
 \[
-  \rho=\tau_{m+1}\cdots\tau_{M-1},
+  C^j_a=A^j_\rho A^j_a(\mu_j^{M+1}X_j).
 \]
-then the \(j\)-th summand has coefficients
-\[
-  \operatorname{tr}\!\left(
-    A^j_b\, A^j_\rho A^j_a\,(\mu_j^{M+1}X_j)\, A^j_w
-  \right),
-\]
-where the local word is \(a w b\). Thus the block sum is the sum of
-left-boundary components with
-\[
-  C^j_a=A^j_\rho A^j_a\,(\mu_j^{M+1}X_j).
-\]
-This is the boundary-crossing cyclic specialization of the two trace
-decompositions in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines
-1436--1452. -/
-theorem blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents
+This is the component form of the boundary-crossing specialization of
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1452. -/
+theorem blockDiagonal_boundary_last_cyclicRestrict_component_eq_leftBoundaryComponent
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
     {m M : ℕ} (hLen : m + 2 ≤ M + 1)
     (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
-    (τ : Fin (M + 1) → Fin d) :
-    (∑ j : Fin r,
-        cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
-          (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j))) =
-      ∑ j : Fin r,
-        pgvwc07LeftBoundaryComponent (A j)
-          (fun a : Fin d =>
-            evalWord (A j) (lastCrossingComplementWord hLen τ) * A j a *
-              ((μ j) ^ (M + 1) • X j))
-          m := by
+    (τ : Fin (M + 1) → Fin d) (j : Fin r) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
+        (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j)) =
+      pgvwc07LeftBoundaryComponent (A j)
+        (fun a : Fin d =>
+          evalWord (A j) (lastCrossingComplementWord hLen τ) * A j a *
+            ((μ j) ^ (M + 1) • X j))
+        m := by
   classical
   ext σ
-  simp only [Finset.sum_apply]
-  refine Finset.sum_congr rfl ?_
-  intro j _
   let middleWord : List (Fin d) := lastCrossingComplementWord hLen τ
   let W : Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
     evalWord (A j) (List.ofFn (Fin.tail (Fin.init σ)))
@@ -126,6 +107,54 @@ theorem blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents
       Matrix.trace (A j b *
         (evalWord (A j) middleWord * A j a * Xj) * W) := by
           simp [Matrix.mul_assoc]
+
+/-- At the cyclic window beginning at the last site, the block-diagonal local
+sum has the left-boundary trace form used in the blockwise coefficient
+comparison.
+
+Let the total chain have length \(M+1\), and let the local window have length
+\(m+2\). The cyclic window beginning at \(M\) consists of the last site followed
+by the first \(m+1\) sites. If the complementary word is
+\[
+  \rho=\tau_{m+1}\cdots\tau_{M-1},
+\]
+then the \(j\)-th summand has coefficients
+\[
+  \operatorname{tr}\!\left(
+    A^j_b\, A^j_\rho A^j_a\,(\mu_j^{M+1}X_j)\, A^j_w
+  \right),
+\]
+where the local word is \(a w b\). Thus the block sum is the sum of
+left-boundary components with
+\[
+  C^j_a=A^j_\rho A^j_a\,(\mu_j^{M+1}X_j).
+\]
+This is the boundary-crossing cyclic specialization of the two trace
+decompositions in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines
+1436--1452. -/
+theorem blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {m M : ℕ} (hLen : m + 2 ≤ M + 1)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (τ : Fin (M + 1) → Fin d) :
+    (∑ j : Fin r,
+        cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
+          (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j))) =
+      ∑ j : Fin r,
+        pgvwc07LeftBoundaryComponent (A j)
+          (fun a : Fin d =>
+            evalWord (A j) (lastCrossingComplementWord hLen τ) * A j a *
+              ((μ j) ^ (M + 1) • X j))
+          m := by
+  classical
+  ext σ
+  simp only [Finset.sum_apply]
+  refine Finset.sum_congr rfl ?_
+  intro j _
+  exact congrFun
+    (blockDiagonal_boundary_last_cyclicRestrict_component_eq_leftBoundaryComponent
+      μ A hLen X τ j) σ
 
 /-- The last boundary-crossing window gives the blockwise coefficient identity
 from the local block-sum condition.
@@ -179,6 +208,45 @@ theorem blockDiagonal_boundary_last_coefficients_of_sum_mem_iSup
   exact pgvwc07_boundary_identities_of_leftBoundaryComponent_mem_iSup
     A hSpan C ψ hψ hmem
 
+/-- The coefficient comparison puts each block component in the last
+boundary-crossing local ground space.
+
+Assume the block sum of the last crossing-window restrictions lies in
+\(\bigvee_jG_{m+2}(A^j)\), and assume the length-\(m\) simultaneous word tuples
+span the product algebra. Then the \(j\)-th cyclic restriction at the window
+beginning at the last site is a vector in
+\(G_{m+2}(A^j)\). This is the local membership consequence of the displayed
+identity \(A_b^jC_a^j=A_b^jE^jA_a^j\) in arXiv:quant-ph/0608197,
+Theorem 2blocks.2, proof lines 1436--1452. -/
+theorem
+    blockDiagonal_boundary_last_cyclicRestrict_component_mem_groundSpace_of_sum_mem_iSup
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {m M : ℕ} (hLen : m + 2 ≤ M + 1)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (τ : Fin (M + 1) → Fin d)
+    (hSpan : WordTupleSpanTop A m)
+    (hmem :
+      (∑ j : Fin r,
+          cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
+            (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j))) ∈
+        ⨆ j : Fin r, groundSpace (A j) (m + 2))
+    (j : Fin r) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
+        (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j)) ∈
+      groundSpace (A j) (m + 2) := by
+  classical
+  obtain ⟨E, hE⟩ :=
+    blockDiagonal_boundary_last_coefficients_of_sum_mem_iSup
+      μ A hLen X τ hSpan hmem
+  rw [blockDiagonal_boundary_last_cyclicRestrict_component_eq_leftBoundaryComponent
+    μ A hLen X τ j]
+  exact pgvwc07LeftBoundaryComponent_mem_groundSpace (A j)
+    (fun a : Fin d =>
+      evalWord (A j) (lastCrossingComplementWord hLen τ) * A j a *
+        ((μ j) ^ (M + 1) • X j))
+    (E j) m (hE j)
+
 /-- A block-diagonal chain vector supplies the local block-sum condition for the
 last boundary-crossing coefficient identity.
 
@@ -221,6 +289,44 @@ theorem blockDiagonal_boundary_last_coefficients_of_blockDiagonal_chainGroundSpa
       μ A hμ (show 0 < M + 1 by omega) hLen hψ X hψX ⟨M, by omega⟩ τ
   exact blockDiagonal_boundary_last_coefficients_of_sum_mem_iSup
     μ A hLen X τ hSpan hmem
+
+/-- A block-diagonal chain vector gives local membership for the last
+boundary-crossing component.
+
+Let \(B=\bigoplus_j\mu_jA^j\). If
+\[
+  \psi=\Gamma_{M+1}^{B}\!\left(\bigoplus_jX_j\right),
+  \qquad
+  \psi\in\mathcal G_{M+1,m+2}(B),
+\]
+then, for every outside configuration and every block \(j\), the restriction
+of \(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\) at the cyclic window beginning at
+the last site belongs to \(G_{m+2}(A^j)\). -/
+theorem
+    blockDiagonal_boundary_last_component_mem_groundSpace_of_blockDiagonal_chainGroundSpace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    {m M : ℕ} (hLen : m + 2 ≤ M + 1)
+    {ψ : NSiteSpace d (M + 1)}
+    (hψ : ψ ∈
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) (m + 2) (M + 1))
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hψX :
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) (M + 1)
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)))
+    (τ : Fin (M + 1) → Fin d)
+    (hSpan : WordTupleSpanTop A m)
+    (j : Fin r) :
+    cyclicRestrictₗ (show 0 < M + 1 by omega) (m + 2) ⟨M, by omega⟩ τ
+        (groundSpaceMap (A j) (M + 1) ((μ j) ^ (M + 1) • X j)) ∈
+      groundSpace (A j) (m + 2) := by
+  have hmem :=
+    blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
+      μ A hμ (show 0 < M + 1 by omega) hLen hψ X hψX ⟨M, by omega⟩ τ
+  exact
+    blockDiagonal_boundary_last_cyclicRestrict_component_mem_groundSpace_of_sum_mem_iSup
+      μ A hLen X τ hSpan hmem j
 
 /-- A boundary-crossing cyclic interval is local when the boundary matrix
 satisfies the displayed boundary identity.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -271,7 +271,7 @@
     \leanok
     \uses{lem:block_diagonal_last_crossing_component_trace_form,
         lem:block_diagonal_last_crossing_coefficients_from_sum_membership,
-        lem:left_boundary_summands_mem_block_ground_spaces}
+        lem:left_boundary_component_mem_ground_space}
     In the setting of Lemma~\ref{lem:block_diagonal_last_crossing_trace_form},
     assume that the length-\(m\) simultaneous word tuples span the product
     algebra and that
@@ -291,7 +291,7 @@
     \leanok
     \uses{lem:block_diagonal_last_crossing_component_trace_form,
         lem:block_diagonal_last_crossing_coefficients_from_sum_membership,
-        lem:left_boundary_summands_mem_block_ground_spaces}
+        lem:left_boundary_component_mem_ground_space}
     Lemma~\ref{lem:block_diagonal_last_crossing_coefficients_from_sum_membership}
     gives matrices \(E_j\) with
     \[
@@ -368,8 +368,13 @@
     \leanok
     \uses{lem:block_diagonal_boundary_local_sum_mem,
         lem:block_diagonal_last_crossing_component_membership_from_sum_membership}
-    The cyclic local constraint of \(\psi\) at the last-site window gives the
-    block-sum membership by Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}.
+    Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem} applied to the
+    window beginning at the last site gives
+    \[
+        \sum_j
+        R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
+        \in \bigvee_j G_{m+2}(A^j).
+    \]
     Lemma~\ref{lem:block_diagonal_last_crossing_component_membership_from_sum_membership}
     then applies to each block component.
 \end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -147,9 +147,9 @@
     \(\alpha\beta\). Hence the restricted vector lies in \(G_L(A_j)\).
 \end{proof}
 
-\begin{lemma}[Last crossing-window trace form]
-    \label{lem:block_diagonal_last_crossing_trace_form}
-    \lean{MPSTensor.blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents}
+\begin{lemma}[Last crossing-window component trace form]
+    \label{lem:block_diagonal_last_crossing_component_trace_form}
+    \lean{MPSTensor.blockDiagonal_boundary_last_cyclicRestrict_component_eq_leftBoundaryComponent}
     \leanok
     \uses{def:ground_space_map, rem:cyclic_window_operators}
     Write \(N=M+1\) and let the local length be \(m+2\le M+1\). Consider the
@@ -160,13 +160,12 @@
         \qquad
         C^j_a=A^j_\rho A^j_a(\mu_j^{M+1}X_j).
     \]
-    Then the block sum of the last crossing-window restrictions has the
-    left-boundary trace form
+    Then the \(j\)-th component of the last crossing-window restriction has
+    the left-boundary trace form
     \[
-        \sum_j
         R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
         =
-        \sum_j \Phi^j,
+        \Phi^j,
         \qquad
         \Phi^j(a,w,b)=\operatorname{tr}\!\left(A^j_b C^j_a A^j_w\right).
     \]
@@ -192,6 +191,38 @@
         A^j_bA^j_\rho A^j_a(\mu_j^{M+1}X_j)A^j_w\right),
     \]
     which is the displayed left-boundary trace form.
+\end{proof}
+
+\begin{lemma}[Last crossing-window trace form]
+    \label{lem:block_diagonal_last_crossing_trace_form}
+    \lean{MPSTensor.blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents}
+    \leanok
+    \uses{lem:block_diagonal_last_crossing_component_trace_form}
+    Write \(N=M+1\) and let the local length be \(m+2\le M+1\). Consider the
+    cyclic interval beginning at the last site \(M\). For an outside
+    configuration \(\tau\), put
+    \[
+        \rho=\tau_{m+1}\cdots\tau_{M-1},
+        \qquad
+        C^j_a=A^j_\rho A^j_a(\mu_j^{M+1}X_j).
+    \]
+    Then the block sum of the last crossing-window restrictions has the
+    left-boundary trace form
+    \[
+        \sum_j
+        R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
+        =
+        \sum_j \Phi^j,
+        \qquad
+        \Phi^j(a,w,b)=\operatorname{tr}\!\left(A^j_b C^j_a A^j_w\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_last_crossing_component_trace_form}
+    Sum Lemma~\ref{lem:block_diagonal_last_crossing_component_trace_form} over
+    the block index.
 \end{proof}
 
 \begin{lemma}[Last crossing-window coefficient comparison]
@@ -234,6 +265,44 @@
     gives the displayed blockwise equations.
 \end{proof}
 
+\begin{lemma}[Last crossing-window component membership]
+    \label{lem:block_diagonal_last_crossing_component_membership_from_sum_membership}
+    \lean{MPSTensor.blockDiagonal_boundary_last_cyclicRestrict_component_mem_groundSpace_of_sum_mem_iSup}
+    \leanok
+    \uses{lem:block_diagonal_last_crossing_component_trace_form,
+        lem:block_diagonal_last_crossing_coefficients_from_sum_membership,
+        lem:left_boundary_summands_mem_block_ground_spaces}
+    In the setting of Lemma~\ref{lem:block_diagonal_last_crossing_trace_form},
+    assume that the length-\(m\) simultaneous word tuples span the product
+    algebra and that
+    \[
+        \sum_j
+        R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
+        \in \bigvee_j G_{m+2}(A^j).
+    \]
+    Then, for every block \(j\),
+    \[
+        R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
+        \in G_{m+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_last_crossing_component_trace_form,
+        lem:block_diagonal_last_crossing_coefficients_from_sum_membership,
+        lem:left_boundary_summands_mem_block_ground_spaces}
+    Lemma~\ref{lem:block_diagonal_last_crossing_coefficients_from_sum_membership}
+    gives matrices \(E_j\) with
+    \[
+        A^j_bC^j_a=A^j_bE_jA^j_a.
+    \]
+    By Lemma~\ref{lem:block_diagonal_last_crossing_component_trace_form}, the
+    \(j\)-th cyclic restriction is the left-boundary component determined by
+    \(C^j_a\). The displayed identity makes that component equal to
+    \(\Gamma_{m+2}^{A_j}(E_j)\), hence it lies in \(G_{m+2}(A^j)\).
+\end{proof}
+
 \begin{lemma}[Last crossing-window coefficients from a block-diagonal chain vector]
     \label{lem:block_diagonal_last_crossing_coefficients_from_chain_ground_space}
     \lean{MPSTensor.blockDiagonal_boundary_last_coefficients_of_blockDiagonal_chainGroundSpace}
@@ -272,6 +341,37 @@
     by Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}. Applying
     Lemma~\ref{lem:block_diagonal_last_crossing_coefficients_from_sum_membership}
     gives the displayed equations.
+\end{proof}
+
+\begin{lemma}[Last crossing-window component membership from a chain vector]
+    \label{lem:block_diagonal_last_crossing_component_membership_from_chain_ground_space}
+    \lean{MPSTensor.blockDiagonal_boundary_last_component_mem_groundSpace_of_blockDiagonal_chainGroundSpace}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        lem:block_diagonal_last_crossing_component_membership_from_sum_membership}
+    Let \(B=\bigoplus_j\mu_jA^j\), and assume \(\mu_j\ne0\) for every block
+    \(j\). Suppose
+    \[
+        \psi=\Gamma_{M+1}^{B}\!\left(\bigoplus_jX_j\right),
+        \qquad
+        \psi\in\mathcal G_{M+1,m+2}(B).
+    \]
+    If the length-\(m\) simultaneous word tuples span the product algebra, then
+    for every outside configuration \(\tau\) and every block \(j\),
+    \[
+        R_{M,\tau}\!\left(\Gamma_{M+1}^{A_j}(\mu_j^{M+1}X_j)\right)
+        \in G_{m+2}(A^j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        lem:block_diagonal_last_crossing_component_membership_from_sum_membership}
+    The cyclic local constraint of \(\psi\) at the last-site window gives the
+    block-sum membership by Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}.
+    Lemma~\ref{lem:block_diagonal_last_crossing_component_membership_from_sum_membership}
+    then applies to each block component.
 \end{proof}
 
 \begin{lemma}[Boundary-crossing intervals from a right boundary-matrix identity]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -222,10 +222,52 @@
     $A_bC_a=A_bEA_a$.
 \end{proof}
 
+\begin{lemma}[A left-boundary summand is a ground-space vector]
+    \label{lem:left_boundary_component_mem_ground_space}
+    \lean{MPSTensor.pgvwc07LeftBoundaryComponent_mem_groundSpace}
+    \leanok
+    Let \(A\) be a block tensor, and let \(C_a,E\in M_D(\mathbb C)\)
+    satisfy
+    \[
+        A_b C_a=A_bEA_a
+    \]
+    for all physical indices \(a,b\).  For a word
+    \(\sigma=(\sigma_1,\ldots,\sigma_{n+2})\), define
+    \[
+        \alpha(\sigma)
+        =
+        \operatorname{tr}\!\left(
+            A_{\sigma_{n+2}} C_{\sigma_1}
+            A_{\sigma_2}\cdots A_{\sigma_{n+1}}
+        \right).
+    \]
+    Then \(\alpha\in G_{n+2}(A)\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The boundary identity gives
+    \[
+        A_{\sigma_{n+2}} C_{\sigma_1}
+        =
+        A_{\sigma_{n+2}}EA_{\sigma_1}.
+    \]
+    Hence, by cyclicity of the trace,
+    \[
+        \alpha(\sigma)
+        =
+        \operatorname{tr}\!\left(
+            A_{\sigma_1}A_{\sigma_2}\cdots A_{\sigma_{n+2}}E
+        \right),
+    \]
+    which is the ground-space parametrization of \(E\).
+\end{proof}
+
 \begin{lemma}[Left-boundary summands are ground-space vectors]
     \label{lem:left_boundary_summands_mem_block_ground_spaces}
     \lean{MPSTensor.pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace}
     \leanok
+    \uses{lem:left_boundary_component_mem_ground_space}
     Let \(A^1,\ldots,A^g\) be block tensors, and let
     \(C^j_a,E^j\in M_{D_j}(\mathbb C)\) satisfy
     \[
@@ -251,6 +293,7 @@
 
 \begin{proof}
     \leanok
+    \uses{lem:left_boundary_component_mem_ground_space}
     Fix \(j\).  By the assumed boundary identity and cyclicity of the
     trace,
     \[
@@ -464,4 +507,3 @@
     displayed equivalence for each vector \(\psi\).  Interpreting the two sides
     of that equivalence as subspaces gives the stated equality.
 \end{proof}
-


### PR DESCRIPTION
### Motivation
- Advances the degenerate-ground-space decomposition of #460 by proving the last-site crossing-window component membership, a remaining step after PR #2644 established the open-boundary block representation.
- Source: `Papers/quant-ph_0608197/MPSarchive.tex`, Theorem 2blocks.2, proof lines 1454–1456 (arXiv:quant-ph/0608197, Pérez-García–Verstraete–Wolf–Cirac); the same argument appears in arXiv:2011.12127, §IV.C, lines 2126–2128.
- Blueprint entry: `lem:bnt_block_diagonal_open_boundary_matrices` in `blueprint/src/chapter/ch14_parent_hamiltonian.tex` (existing proof note records the open-boundary gap being addressed here).

### Description
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean` (+141 / −35): adds a statement that for a block-diagonal boundary vector $\psi = \Gamma_{M+1}^{\oplus_j \mu_j A^j}(\bigoplus_j X_j)$ with $\psi \in \mathcal{G}_{M+1,m+2}(\oplus_j \mu_j A^j)$, each component restriction at the cyclic window beginning at the last site lies in $G_{m+2}(A^j)$, provided the length-$m$ simultaneous word tuples span the product algebra. The proof isolates the component trace form for the last crossing window, applies the Pérez-García–Verstraete–Wolf–Cirac coefficient comparison, and identifies the resulting left-boundary component with a ground-space vector.
- `blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex` (+107 / −7): adds the corresponding blueprint entry and proof sketch for the last-site cyclic-window case.
- Does not yet prove the right boundary-factor identity for every crossing start.

### Testing
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses #2651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean and blueprint documentation only; no runtime or security-sensitive code paths.
> 
> **Overview**
> **Last-site crossing window:** The proof is refactored so a **per-block** identity (`blockDiagonal_boundary_last_cyclicRestrict_component_eq_leftBoundaryComponent`) is proved first; the existing **sum** of left-boundary components is obtained by summing over blocks.
> 
> **New Lean results:** From membership of the **block sum** in \(\bigvee_j G_{m+2}(A^j)\) (plus word-span), each **individual** last-window cyclic restriction lies in \(G_{m+2}(A^j)\). The same conclusion is packaged when \(\psi\) is a **block-diagonal chain ground-space** vector \(\Gamma_{M+1}^B(\bigoplus X_j)\).
> 
> **Blueprint:** Adds lemmas for component trace form, component membership from sum membership, and component membership from a chain vector; the old “trace form” lemma is split into component + sum. **`ch14_parent_hamiltonian_block_intersection_trace.tex`** adds a single left-boundary summand ground-space lemma and wires the multi-block sum lemma through it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2756a72877fc661312c58d280a02e18e4e2791a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->