### PR TITLE
feat(PEPS): torus Fundamental Theorem at the source's sizes n,m >= 7

### DIFF
--- a/TNLean/PEPS/InjectiveRegion.lean
+++ b/TNLean/PEPS/InjectiveRegion.lean
@@ -82,6 +82,31 @@ theorem RegionInjectivityUnionClosure.biUnion_injective
       rw [Finset.cons_eq_insert, Finset.biUnion_insert]
       exact hUnion.union_injective (hR i (by simp)) (ih fun j hj => hR j (by simp [hj]))
 
+/-- A finite union of injective regions with at least one nonempty member is injective under
+union closure, with the injectivity required only of the nonempty members.
+
+This is the variant of the finite iteration of the source lemma used when a rectangular
+cover lists pieces that may degenerate to the empty region (a band of zero width at the
+torus seam): the empty pieces contribute nothing to the union and need no injectivity.
+
+Source: arXiv:1804.04964, Section 3, Lemma lem:injective_union and the examples following
+it, lines 1322--1430 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem RegionInjectivityUnionClosure.biUnion_injective_of_nonempty
+    {ι : Type*} {κ : RegionInjectivityData V} (hUnion : RegionInjectivityUnionClosure κ)
+    {s : Finset ι} (R : ι → Finset V)
+    (hne : ∃ i ∈ s, (R i).Nonempty)
+    (hR : ∀ i ∈ s, (R i).Nonempty → κ.IsInjective (R i)) :
+    κ.IsInjective (s.biUnion R) := by
+  classical
+  have heq : s.biUnion R = (s.filter fun i => (R i).Nonempty).biUnion R := by
+    ext v
+    simp only [Finset.mem_biUnion, Finset.mem_filter]
+    exact ⟨fun ⟨i, hi, hv⟩ => ⟨i, ⟨hi, ⟨v, hv⟩⟩, hv⟩, fun ⟨i, ⟨hi, _⟩, hv⟩ => ⟨i, hi, hv⟩⟩
+  obtain ⟨i, hi, hne'⟩ := hne
+  rw [heq]
+  exact hUnion.biUnion_injective ⟨i, Finset.mem_filter.mpr ⟨hi, hne'⟩⟩ R fun j hj =>
+    hR j (Finset.mem_filter.mp hj).1 (Finset.mem_filter.mp hj).2
+
 /-- The part of the left region outside the right region. -/
 def regionOnlyLeft (A B : Finset V) : Finset V :=
   A \ B

--- a/TNLean/PEPS/TorusCovariantAbsorbedFamily.lean
+++ b/TNLean/PEPS/TorusCovariantAbsorbedFamily.lean
@@ -90,11 +90,11 @@ theorem exists_torusCovariantAbsorbedGaugeFamily
     (hUB : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) B))
     (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
-    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
-    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
-    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
-    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
-    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hxhw : xhStart + 5 = width ∨ xhStart + 7 ≤ width)
+    (hyhh : yhStart + 5 = height ∨ yhStart + 7 ≤ height)
+    (hxv0 : 1 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
+    (hxvw : xvStart + 5 = width ∨ xvStart + 7 ≤ width)
+    (hyvh : yvStart + 5 = height ∨ yvStart + 7 ≤ height)
     (hbd : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
@@ -110,24 +110,24 @@ theorem exists_torusCovariantAbsorbedGaugeFamily
   have hh : 2 < height := by omega
   -- The two reference gauges and their coefficient identities at the reference edges.
   obtain ⟨hEh, Zh, hZh⟩ :=
-    exists_horizontalReferenceEdgeGauge_coeff hAr hBr hUA hUB hxh0 hyh0 hxhw hyhh hxhw' hyhh'
+    exists_horizontalReferenceEdgeGauge_coeff hAr hBr hUA hUB hxh0 hyh0 hxhw hyhh
       hbd hAB hd hposA hposB
   obtain ⟨hEv, Zv, hZv⟩ :=
-    exists_verticalReferenceEdgeGauge_coeff hAr hBr hUA hUB hxv0 hyv0 hxvw hyvh hxvw' hyvh'
+    exists_verticalReferenceEdgeGauge_coeff hAr hBr hUA hUB hxv0 hyv0 hxvw hyvh
       hbd hAB hd hposA hposB
   -- The reference regions and their distinguished boundary edges.
-  set Rh := (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').red with hRhdef
+  set Rh := (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw hyhh).red with hRhdef
   set fh := singleBoundaryEdge (G := torusGraph width height) A Rh
-    (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').blue
+    (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw hyhh).blue
     (torusHorizontalReferenceEdge xhStart yhStart)
     (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hAr hUA hxh0 hyh0 hxhw
-      hyhh hxhw' hyhh' g) with hfhdef
-  set Rv := (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').red with hRvdef
+      hyhh g) with hfhdef
+  set Rv := (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw hyvh).red with hRvdef
   set fv := singleBoundaryEdge (G := torusGraph width height) A Rv
-    (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').blue
+    (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw hyvh).blue
     (torusVerticalReferenceEdge xvStart yvStart)
     (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hAr hUA hxv0 hyv0 hxvw
-      hyvh hxvw' hyvh' g) with hfvdef
+      hyvh g) with hfvdef
   -- The constructed family: at each edge, the absorbing gauge of the transported reference
   -- witness of its orientation class, along the chosen translation reaching the edge.
   set X : (e : Edge (torusGraph width height)) → GL (Fin (B.bondDim e)) ℂ := fun e =>
@@ -194,9 +194,9 @@ theorem exists_torusCovariantAbsorbedGaugeFamily
     exact glReindex_transportedAbsorbedGauge_eq B hB Rv fv Zv ha hb _
   -- The two reference boundary edges have their first stored endpoint in the reference region.
   have hmemh : fh.1.1.1 ∈ Rh :=
-    (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw' hyhh').left_mem_red
+    (torusHorizontalRectangleBlockingDatum hAr hUA hxh0 hyh0 hxhw hyhh).left_mem_red
   have hmemv : fv.1.1.1 ∈ Rv :=
-    (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw' hyvh').left_mem_red
+    (torusVerticalRectangleBlockingDatum hAr hUA hxv0 hyv0 hxvw hyvh).left_mem_red
   refine ⟨X, ?_, ?_⟩
   · -- Translation covariance.
     intro a b e
@@ -228,7 +228,7 @@ theorem exists_torusCovariantAbsorbedGaugeFamily
       have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
           (Finset.univ \ Rh) :=
         regionBlockedTensorInjective_host
-          (torusHorizontalRectangleBlockingDatum hBr hUB hxh0 hyh0 hxhw' hyhh') hUB
+          (torusHorizontalRectangleBlockingDatum hBr hUB hxh0 hyh0 hxhw hyhh) hUB
       have hEX : A.bondDim (boundaryEdgeMap (translate a b) Rh fh).1 =
           B.bondDim (boundaryEdgeMap (translate a b) Rh fh).1 :=
         (bondDim_boundaryEdgeMap_translate hA a b Rh fh).trans
@@ -251,7 +251,7 @@ theorem exists_torusCovariantAbsorbedGaugeFamily
       have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
           (Finset.univ \ Rv) :=
         regionBlockedTensorInjective_host
-          (torusVerticalRectangleBlockingDatum hBr hUB hxv0 hyv0 hxvw' hyvh') hUB
+          (torusVerticalRectangleBlockingDatum hBr hUB hxv0 hyv0 hxvw hyvh) hUB
       have hEX : A.bondDim (boundaryEdgeMap (translate a b) Rv fv).1 =
           B.bondDim (boundaryEdgeMap (translate a b) Rv fv).1 :=
         (bondDim_boundaryEdgeMap_translate hA a b Rv fv).trans

--- a/TNLean/PEPS/TorusEdgeBlockingCrossing.lean
+++ b/TNLean/PEPS/TorusEdgeBlockingCrossing.lean
@@ -11,9 +11,13 @@ and vertical edge blockings of `TNLean/PEPS/TorusEdgeBlockingRegion.lean`, where
 blocks meet only along the distinguished edge.
 
 The discrete-torus subtlety over the open lattice is the cyclic adjacency: a horizontal step
-`v.1 + 1 = w.1` is read in `ZMod width`.  Away from the wraparound seam the coordinate values add
-without wrapping (`val_add_of_lt`), so inside the no-wraparound window of the blocking the cyclic
-step is the ordinary coordinate step, and the open-lattice crossing argument carries over.
+`v.1 + 1 = w.1` is read in `ZMod width`.  Inside the bounding window of the blocking a cyclic step
+either adds without wrapping (`val_add_of_lt`), where the open-lattice crossing argument carries
+over, or wraps to the zero coordinate; a wrapped step cannot cross between the red and blue
+blocks, because the zero column (row) lies strictly left of (below) both blocks whenever the
+window starts at coordinate one or later.  The blocking may therefore touch the seam on the far
+side (`xStart + 5 = width`, `yStart + 5 = height`), as it does at the anchor used for the
+source's sizes `n, m ≥ 7`.
 
 ## References
 
@@ -38,6 +42,14 @@ theorem torus_horizontal_step_val {v w : TorusVertex width height} (h : v.1 + 1 
     w.1.val = v.1.val + 1 := by
   rw [← h, ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]
 
+omit [NeZero height] [Fact (1 < height)] in
+/-- A horizontal cyclic step `v.1 + 1 = w.1` wraps to the zero column when the source value is
+the last column. -/
+theorem torus_horizontal_step_val_wrap {v w : TorusVertex width height} (h : v.1 + 1 = w.1)
+    (heq : v.1.val + 1 = width) :
+    w.1.val = 0 := by
+  rw [← h, ZMod.val_add, ZMod.val_one, heq, Nat.mod_self]
+
 omit [NeZero width] [NeZero height] [Fact (1 < width)] in
 /-- A vertical cyclic step `v.2 + 1 = w.2` reads as an ordinary coordinate step when the source
 value plus one stays below the height. -/
@@ -45,6 +57,14 @@ theorem torus_vertical_step_val {v w : TorusVertex width height} (h : v.2 + 1 = 
     (hlt : v.2.val + 1 < height) :
     w.2.val = v.2.val + 1 := by
   rw [← h, ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]
+
+omit [NeZero width] [Fact (1 < width)] in
+/-- A vertical cyclic step `v.2 + 1 = w.2` wraps to the zero row when the source value is the
+last row. -/
+theorem torus_vertical_step_val_wrap {v w : TorusVertex width height} (h : v.2 + 1 = w.2)
+    (heq : v.2.val + 1 = height) :
+    w.2.val = 0 := by
+  rw [← h, ZMod.val_add, ZMod.val_one, heq, Nat.mod_self]
 
 omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
 /-- The horizontal coordinate value is preserved by a vertical cyclic step. -/
@@ -131,13 +151,15 @@ edge.**
 
 The red block (the removed vertical edge block) and the blue block (the removed horizontal edge
 block) meet only along the distinguished horizontal edge.  Hence an edge crosses between them iff it
-is that edge.
+is that edge.  The bounding window may touch the seam on the right and top (`xStart + 5 = width`,
+`yStart + 5 = height`): a horizontal step wrapping the seam lands in the zero column, which lies
+strictly left of both blocks since `1 ≤ xStart`, so a wrapped step never crosses.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem isCrossingEdge_torusHorizontalEdge
     (A : Tensor (torusGraph width height) d) {xStart yStart : ℕ}
-    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hx0 : 1 ≤ xStart) (hxw : xStart + 5 ≤ width) (hyh : yStart + 5 ≤ height)
     (g : Edge (torusGraph width height)) :
     IsCrossingEdge (G := torusGraph width height) A
         (torusHorizontalEdgeRed xStart yStart) (torusHorizontalEdgeBlue xStart yStart) g ↔
@@ -148,7 +170,7 @@ theorem isCrossingEdge_torusHorizontalEdge
     simp only [IsRegionBoundaryEdge, mem_torusHorizontalEdgeRed, mem_torusHorizontalEdgeBlue]
       at hRed hBlue
     -- Both endpoints lie in the bounding window of the hole, so their coordinate values are
-    -- below `xStart + 5 < width` and `yStart + 5 < height`, hence no cyclic step wraps.
+    -- below `xStart + 5 ≤ width` and `yStart + 5 ≤ height`.
     have hwin : g.1.1.1.val < xStart + 5 ∧ g.1.2.1.val < xStart + 5 ∧
         g.1.1.2.val < yStart + 5 ∧ g.1.2.2.val < yStart + 5 := by
       rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
@@ -165,21 +187,38 @@ theorem isCrossingEdge_torusHorizontalEdge
     -- The adjacency of `g`, a horizontal or vertical cyclic step.
     have hadj := g.2.2
     rw [torusGraph_adj, torusHorizontalNeighbor, torusVerticalNeighbor] at hadj
-    -- Pin the four coordinate values of `g` to the distinguished edge's coordinates.
+    -- Pin the four coordinate values of `g` to the distinguished edge's coordinates.  A
+    -- horizontal step wrapping the seam lands in the zero column, left of both blocks.
     have hcoord : g.1.1.1.val = xStart + 1 ∧ g.1.1.2.val = yStart + 2 ∧
         g.1.2.1.val = xStart + 2 ∧ g.1.2.2.val = yStart + 2 := by
       rcases hadj with ⟨hrow, hcol⟩ | ⟨hcol, hrow⟩
       · -- Horizontal step: same vertical coordinate, adjacent horizontal coordinates.
         have hrow' := torus_eq_snd_val hrow
         rcases hcol with hstep | hstep
-        · have hxstep := torus_horizontal_step_val hstep (by omega)
-          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
-            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
-            (simp only [not_and, not_lt] at hrn hbn; omega)
-        · have hxstep := torus_horizontal_step_val hstep (by omega)
-          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
-            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
-            (simp only [not_and, not_lt] at hrn hbn; omega)
+        · by_cases hnowrap : g.1.1.1.val + 1 < width
+          · have hxstep := torus_horizontal_step_val hstep hnowrap
+            rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+              rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+              (simp only [not_and, not_lt] at hrn hbn; omega)
+          · have hwrap : g.1.1.1.val + 1 = width := by
+              have := ZMod.val_lt g.1.1.1
+              omega
+            have hxstep := torus_horizontal_step_val_wrap hstep hwrap
+            rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+              rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+              (simp only [not_and, not_lt] at hrn hbn; omega)
+        · by_cases hnowrap : g.1.2.1.val + 1 < width
+          · have hxstep := torus_horizontal_step_val hstep hnowrap
+            rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+              rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+              (simp only [not_and, not_lt] at hrn hbn; omega)
+          · have hwrap : g.1.2.1.val + 1 = width := by
+              have := ZMod.val_lt g.1.2.1
+              omega
+            have hxstep := torus_horizontal_step_val_wrap hstep hwrap
+            rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+              rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+              (simp only [not_and, not_lt] at hrn hbn; omega)
       · -- Vertical step: same horizontal coordinate, but red and blue columns are disjoint.
         exfalso
         have hcol' := torus_eq_fst_val hcol
@@ -238,13 +277,15 @@ edge.**
 
 The rotated counterpart of `isCrossingEdge_torusHorizontalEdge`: the red block (the removed
 horizontal edge block) and the blue block (the removed vertical edge block) meet only along the
-distinguished vertical edge.
+distinguished vertical edge.  The bounding window may touch the seam on the right and top: a
+vertical step wrapping the seam lands in the zero row, which lies strictly below both blocks
+since `1 ≤ yStart`, so a wrapped step never crosses.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem isCrossingEdge_torusVerticalEdge
     (A : Tensor (torusGraph width height) d) {xStart yStart : ℕ}
-    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
+    (hy0 : 1 ≤ yStart) (hxw : xStart + 5 ≤ width) (hyh : yStart + 5 ≤ height)
     (g : Edge (torusGraph width height)) :
     IsCrossingEdge (G := torusGraph width height) A
         (torusVerticalEdgeRed xStart yStart) (torusVerticalEdgeBlue xStart yStart) g ↔
@@ -269,30 +310,41 @@ theorem isCrossingEdge_torusVerticalEdge
     rw [torusGraph_adj, torusHorizontalNeighbor, torusVerticalNeighbor] at hadj
     have hcoord : g.1.1.1.val = xStart + 2 ∧ g.1.1.2.val = yStart + 1 ∧
         g.1.2.1.val = xStart + 2 ∧ g.1.2.2.val = yStart + 2 := by
-      rcases hadj with ⟨hrow, hcol⟩ | ⟨hcol, hrow⟩
+      rcases hadj with ⟨hrow, -⟩ | ⟨hcol, hrow⟩
       · -- Horizontal step: same vertical coordinate, but red and blue rows are disjoint.
         exfalso
         have hrow' := torus_eq_snd_val hrow
-        rcases hcol with hstep | hstep
-        · have hxstep := torus_horizontal_step_val hstep (by omega)
-          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
-            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
-            (simp only [not_and, not_lt] at hrn hbn; omega)
-        · have hxstep := torus_horizontal_step_val hstep (by omega)
-          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
-            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
-            (simp only [not_and, not_lt] at hrn hbn; omega)
-      · -- Vertical step: same horizontal coordinate, adjacent vertical coordinates.
+        rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+          rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+          (simp only [not_and, not_lt] at hrn hbn; omega)
+      · -- Vertical step: same horizontal coordinate, adjacent vertical coordinates.  A step
+        -- wrapping the seam lands in the zero row, below both blocks.
         have hcol' := torus_eq_fst_val hcol
         rcases hrow with hstep | hstep
-        · have hystep := torus_vertical_step_val hstep (by omega)
-          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
-            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
-            (simp only [not_and, not_lt] at hrn hbn; omega)
-        · have hystep := torus_vertical_step_val hstep (by omega)
-          rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
-            rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
-            (simp only [not_and, not_lt] at hrn hbn; omega)
+        · by_cases hnowrap : g.1.1.2.val + 1 < height
+          · have hystep := torus_vertical_step_val hstep hnowrap
+            rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+              rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+              (simp only [not_and, not_lt] at hrn hbn; omega)
+          · have hwrap : g.1.1.2.val + 1 = height := by
+              have := ZMod.val_lt g.1.1.2
+              omega
+            have hystep := torus_vertical_step_val_wrap hstep hwrap
+            rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+              rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+              (simp only [not_and, not_lt] at hrn hbn; omega)
+        · by_cases hnowrap : g.1.2.2.val + 1 < height
+          · have hystep := torus_vertical_step_val hstep hnowrap
+            rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+              rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+              (simp only [not_and, not_lt] at hrn hbn; omega)
+          · have hwrap : g.1.2.2.val + 1 = height := by
+              have := ZMod.val_lt g.1.2.2
+              omega
+            have hystep := torus_vertical_step_val_wrap hstep hwrap
+            rcases hRed with ⟨hr, hrn⟩ | ⟨hrn, hr⟩ <;>
+              rcases hBlue with ⟨hb, hbn⟩ | ⟨hbn, hb⟩ <;>
+              (simp only [not_and, not_lt] at hrn hbn; omega)
     obtain ⟨hc1, hc2, hc3, hc4⟩ := hcoord
     obtain ⟨hr11, hr12, hr21, hr22⟩ := verticalReferenceEdge_val
       (width := width) (height := height) (xStart := xStart) (yStart := yStart)

--- a/TNLean/PEPS/TorusEdgeBlockingRegion.lean
+++ b/TNLean/PEPS/TorusEdgeBlockingRegion.lean
@@ -16,9 +16,12 @@ nearest-neighbour pair with one endpoint in each is the edge from `(xStart + 1, 
 `(xStart + 2, yStart + 2)`.  The vertical analogue is the rotated picture, anchored so its single
 crossing is the edge from `(xStart + 2, yStart + 1)` to `(xStart + 2, yStart + 2)`.
 
-All regions stay clear of the wraparound seam: the surrounding bands are full coordinate ranges in
-one direction, which the value embedding covers without wraparound, and the removed blocks and
-fillers fit inside the coordinate window `[xStart - 1, xStart + 5) × [yStart - 1, yStart + 5)`.
+No region wraps the seam: the surrounding bands are full coordinate ranges in one direction, which
+the value embedding covers without wraparound, and the removed blocks and fillers fit inside the
+coordinate window `[xStart - 1, xStart + 5) × [yStart - 1, yStart + 5)`.  The window may touch the
+seam on the right and top (`xStart + 5 = width`, `yStart + 5 = height`), where the corresponding
+band is empty; this seam-touching anchor is what realizes the blocking on every torus with the
+source's sizes `n, m ≥ 7`.
 
 ## References
 
@@ -146,8 +149,8 @@ def torusHorizontalEdgeComplementPiece (xStart yStart : ℕ) :
   | 5 => torusContiguousRectangle (xStart + 2) (yStart + 3) 3 2
 
 /-- The horizontal edge-complement block on the torus is the union of its six covering pieces, for
-an interior offset with one row and column of margin below and to the left and enough room above
-and to the right so the removed blocks are surrounded on every side.
+an offset with one row of margin below and the removed blocks inside the coordinate ranges; the
+pieces on the seam side may be empty.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
@@ -209,10 +212,14 @@ theorem horizontalEdgeBlue_injective
 
 /-- **The horizontal edge-complement block on the torus is injective.**
 
-When the removed L-shape sits in the interior of a large enough torus — at least one row and column
-of margin below and to the left, and enough room above and to the right — the complementary block
-is the union of four surrounding bands and two filler rectangles, each a contiguous torus rectangle.
-Rectangular injectivity together with the union-of-injective-regions lemma proves it injective.
+The complementary block is the union of four surrounding bands and two filler rectangles, each a
+contiguous torus rectangle; rectangular injectivity together with the union-of-injective-regions
+lemma proves it injective.  Below and to the left the removed L-shape keeps a margin of at least
+two columns (`2 ≤ xStart`) and at least two rows (`1 ≤ yStart`, the filler dipping one further row
+down); above and to the right the margin is either zero — the blocking touches the seam, the band
+is empty — or at least two, so each nonempty band is a source-shaped rectangle.  The seam-touching
+choice `xStart + 5 = width`, `yStart + 5 = height` realizes the blocking on every torus with the
+source's sizes `n, m ≥ 7`.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
@@ -220,20 +227,28 @@ theorem horizontalEdgeComplement_injective
     (h : NormalTorusRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
     {xStart yStart : ℕ} (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
-    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height) :
     κ.IsInjective
       (torusHorizontalEdgeComplement (width := width) (height := height) xStart yStart) := by
   rw [torusHorizontalEdgeComplement_eq_biUnion_pieces (by omega) (by omega) (by omega)]
-  refine hUnion.biUnion_injective ⟨0, Finset.mem_univ _⟩ _ ?_
-  intro i _
+  refine hUnion.biUnion_injective_of_nonempty _
+    ⟨0, Finset.mem_univ _, ⟨((0 : ZMod width), (0 : ZMod height)), by
+      simp only [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle, ZMod.val_zero]
+      omega⟩⟩ ?_
+  intro i _ hne
   fin_cases i
   · -- bottom band: width × (yStart + 1), short rectangle (width ≥ 3, yStart + 1 ≥ 2)
     exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
-  · -- top band: width × (height - (yStart + 5)), short rectangle
+  · -- top band: width × (height - (yStart + 5)), short rectangle when nonempty
+    obtain ⟨v, hv⟩ := hne
+    simp only [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle] at hv
     exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
   · -- left band: xStart × 4, wide rectangle (xStart ≥ 2, 4 ≥ 3)
     exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
-  · -- right band: (width - (xStart + 5)) × 4, wide rectangle
+  · -- right band: (width - (xStart + 5)) × 4, wide rectangle when nonempty
+    obtain ⟨v, hv⟩ := hne
+    simp only [torusHorizontalEdgeComplementPiece, mem_torusContiguousRectangle] at hv
     exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
   · -- first filler: 2 × 3
     exact h.rect23_injective (by omega) (by omega)
@@ -421,30 +436,41 @@ theorem verticalEdgeBlue_injective
 
 /-- **The vertical edge-complement block on the torus is injective.**
 
-The rotated counterpart of `horizontalEdgeComplement_injective`: when the rotated removed L-shape
-sits in the interior of a large enough torus, the complementary block is the union of four
-surrounding bands and two filler rectangles, each a contiguous torus rectangle.
+The rotated counterpart of `horizontalEdgeComplement_injective`: the complementary block is the
+union of four surrounding bands and two filler rectangles, each a contiguous torus rectangle.
+Below and to the left the rotated removed L-shape keeps a margin of at least two rows
+(`2 ≤ yStart`) and at least two columns (`1 ≤ xStart`, counting the L-shape's own free column);
+above and to the right the margin is either zero — the blocking touches the seam, the band is
+empty — or at least two.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1430--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem verticalEdgeComplement_injective
     (h : NormalTorusRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
-    {xStart yStart : ℕ} (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
-    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    {xStart yStart : ℕ} (hx0 : 1 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height) :
     κ.IsInjective
       (torusVerticalEdgeComplement (width := width) (height := height) xStart yStart) := by
   rw [torusVerticalEdgeComplement_eq_biUnion_pieces (by omega) (by omega) (by omega)]
-  refine hUnion.biUnion_injective ⟨2, Finset.mem_univ _⟩ _ ?_
-  intro i _
+  refine hUnion.biUnion_injective_of_nonempty _
+    ⟨2, Finset.mem_univ _, ⟨((0 : ZMod width), (0 : ZMod height)), by
+      simp only [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle, ZMod.val_zero]
+      omega⟩⟩ ?_
+  intro i _ hne
   fin_cases i
   · -- bottom band: width × yStart, short rectangle (width ≥ 3, yStart ≥ 2)
     exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
-  · -- top band: width × (height - (yStart + 5)), short rectangle
+  · -- top band: width × (height - (yStart + 5)), short rectangle when nonempty
+    obtain ⟨v, hv⟩ := hne
+    simp only [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle] at hv
     exact h.shortRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
   · -- left band: (xStart + 1) × height, wide rectangle (xStart + 1 ≥ 2, height ≥ 3)
     exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
-  · -- right band: (width - (xStart + 5)) × height, wide rectangle
+  · -- right band: (width - (xStart + 5)) × height, wide rectangle when nonempty
+    obtain ⟨v, hv⟩ := hne
+    simp only [torusVerticalEdgeComplementPiece, mem_torusContiguousRectangle] at hv
     exact h.wideRectangle_injective hUnion (by omega) (by omega) (by omega) (by omega)
   · -- first filler: 2 × 3
     exact h.rect23_injective (by omega) (by omega)

--- a/TNLean/PEPS/TorusFundamentalTheorem2.lean
+++ b/TNLean/PEPS/TorusFundamentalTheorem2.lean
@@ -10,9 +10,9 @@ import TNLean.PEPS.RegionBlock.ReindexInjectivity
 
 This file proves the torus Fundamental Theorem with no conditional per-vertex hypothesis: from
 the source hypotheses alone --- translation
-invariance, matched bond dimensions, positive bonds, the same state, and the
+invariance, matched bond dimensions, positive bonds, the same state, the
 rectangular-injectivity hypotheses (the union closure of injective regions is derived from the
-positive bonds) --- it produces a per-edge gauge family
+positive bonds), and the source's own sizes `n, m ≥ 7` --- it produces a per-edge gauge family
 `X` and a single scalar `λ` with
 
 * the translation covariance of `X` (the faithful torus form of the source's *"the same matrix
@@ -144,8 +144,9 @@ theorem component_eq_gaugeVertex_of_cornerProportional
 
 /-- **Unconditional normal PEPS Fundamental Theorem on the torus.**
 
-For a translation-invariant pair `A`, `B` on the discrete torus with matched bond dimensions,
-positive bonds, the same state, and both satisfying the rectangular-injectivity hypotheses,
+For a translation-invariant pair `A`, `B` on the discrete `n × m` torus with `n, m ≥ 7` (the
+source's own sizes), matched bond dimensions, positive bonds, the same state, and both
+satisfying the rectangular-injectivity hypotheses,
 there are a translation-covariant per-edge gauge family `X` realizing the
 bare-edge absorbed equality at every edge, and a single scalar `λ` with the per-vertex relation
 `A_v = λ · (gauge action of B at v)` at every torus vertex and `λ^{width·height} = 1`.  The
@@ -157,7 +158,10 @@ This is the torus form of Theorem 3 (arXiv:1804.04964, Section 3, lines 1453--14
 `λ^{n·m} = 1`, with no conditional per-vertex hypothesis.  The single `λ` is produced by
 transporting the corner-region comparison to every vertex along the translations; the
 translation covariance of the gauge family is what makes the transported comparison scalars
-agree.
+agree.  The reference blockings are anchored at `(width - 5, height - 5)`, touching the seam on
+the right and top, which is what packs them into every torus with `n, m ≥ 7`; the source packs
+its example regions into a `7 × 7` torus through complement regions that wrap the seam, which
+the wraparound-free rectangle covers here avoid.
 
 The gauge family is characterized here by its translation covariance rather than by a
 lexicographic one-matrix-per-class predicate: the ordered edge
@@ -169,18 +173,13 @@ family cannot describe (see `docs/paper-gaps/peps_normal_ft_section3_route.tex`,
 Source: arXiv:1804.04964, Section 3, Theorem 3, lines 1449--1471 of
 `Papers/1804.04964/paper_normal.tex`. -/
 theorem fundamentalTheorem_normalTorusPEPS_unconditional
-    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    {A B : Tensor (torusGraph width height) d}
     (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
     (hAr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hBr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) B))
-    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
-    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
-    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
-    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
-    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
-    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hw : 7 ≤ width) (hh : 7 ≤ height)
     (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
@@ -199,8 +198,6 @@ theorem fundamentalTheorem_normalTorusPEPS_unconditional
             lam * gaugeVertex B X v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ) ∧
         lam ^ (width * height) = 1 := by
   classical
-  have hw : 7 ≤ width := by omega
-  have hh : 7 ≤ height := by omega
   -- The union closure of injective regions, from positive bonds.
   have hUA : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) A) :=
@@ -208,9 +205,11 @@ theorem fundamentalTheorem_normalTorusPEPS_unconditional
   have hUB : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) B) :=
     regionInjectivityUnionClosure_of_overlap B hposB
-  -- The translation-covariant absorbed gauge family.
-  obtain ⟨X, hXcov, hedge⟩ := exists_torusCovariantAbsorbedGaugeFamily hA hB hAr hBr hUA hUB
-    hxh0 hyh0 hxhw hyhh hxhw' hyhh' hxv0 hyv0 hxvw hyvh hxvw' hyvh' hbond hAB hd hposA hposB
+  -- The translation-covariant absorbed gauge family, at the seam-touching reference anchors.
+  obtain ⟨X, hXcov, hedge⟩ := exists_torusCovariantAbsorbedGaugeFamily
+    (xhStart := width - 5) (yhStart := height - 5) (xvStart := width - 5) (yvStart := height - 5)
+    hA hB hAr hBr hUA hUB (by omega) (by omega) (Or.inl (by omega)) (Or.inl (by omega))
+    (by omega) (by omega) (Or.inl (by omega)) (Or.inl (by omega)) hbond hAB hd hposA hposB
   -- The base injectivity facts at the corner region and its insert-completed square, for `A`.
   have hRA : RegionBlockedTensorInjective (G := torusGraph width height) A cornerRegion := by
     have hi := hAr.cornerRegion_injective hUA hw hh

--- a/TNLean/PEPS/TorusGaugeUniqueness.lean
+++ b/TNLean/PEPS/TorusGaugeUniqueness.lean
@@ -239,18 +239,13 @@ Source: arXiv:1804.04964, Section 3, Theorem 3, line 1471 of
 `Papers/1804.04964/paper_normal.tex` (*"X and Y are unique up to a multiplicative constant"*),
 via the conjugator determinacy of the isomorphism lemma, lines 560--583. -/
 theorem torusAbsorbedGauge_unique_scalar
-    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    {A B : Tensor (torusGraph width height) d}
     (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
     (hAr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hBr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) B))
-    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
-    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
-    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
-    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
-    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
-    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hw : 7 ≤ width) (hh : 7 ≤ height)
     (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
@@ -276,11 +271,13 @@ theorem torusAbsorbedGauge_unique_scalar
     regionInjectivityUnionClosure_of_overlap B hposB
   rcases torusEdge_horizontal_or_vertical e with he | he
   · obtain ⟨Z, Zref, hE, ⟨w⟩⟩ := exists_edgeCoeffIdentityWitness_horizontalFamily
-      hA hB hAr hBr hUA hUB hxh0 hyh0 hxhw hyhh hxhw' hyhh' hbond hAB hd hposA hposB e he
+      (xStart := width - 5) (yStart := height - 5) hA hB hAr hBr hUA hUB (by omega) (by omega)
+      (Or.inl (by omega)) (Or.inl (by omega)) hbond hAB hd hposA hposB e he
     exact torusAbsorbedGauge_unique_scalar_of_region hbond w.region ⟨e, w.isBoundary⟩
       w.hRB w.hCB hposB X X' hedgeX hedgeX'
   · obtain ⟨Z, Zref, hE, ⟨w⟩⟩ := exists_edgeCoeffIdentityWitness_verticalFamily
-      hA hB hAr hBr hUA hUB hxv0 hyv0 hxvw hyvh hxvw' hyvh' hbond hAB hd hposA hposB e he
+      (xStart := width - 5) (yStart := height - 5) hA hB hAr hBr hUA hUB (by omega) (by omega)
+      (Or.inl (by omega)) (Or.inl (by omega)) hbond hAB hd hposA hposB e he
     exact torusAbsorbedGauge_unique_scalar_of_region hbond w.region ⟨e, w.isBoundary⟩
       w.hRB w.hCB hposB X X' hedgeX hedgeX'
 
@@ -405,18 +402,13 @@ Source: arXiv:1804.04964, Section 3, Theorem 3, line 1471 of
 with `X`, `Y` the class matrices), via the conjugator determinacy of the isomorphism lemma,
 lines 560--583. -/
 theorem torusCovariantAbsorbedGauge_unique_classScalar
-    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    {A B : Tensor (torusGraph width height) d}
     (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
     (hAr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hBr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) B))
-    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
-    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
-    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
-    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
-    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
-    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hw : 7 ≤ width) (hh : 7 ≤ height)
     (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
@@ -450,19 +442,22 @@ theorem torusCovariantAbsorbedGauge_unique_classScalar
             ((cv⁻¹ : ℂˣ) : ℂ) • (X e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))) := by
   have hw2 : 2 < width := by omega
   have hh2 : 2 < height := by omega
+  -- The seam-touching reference anchors of the two orientation classes.
+  set xhStart := width - 5 with hxhdef
+  set yhStart := height - 5 with hyhdef
   -- The reference-edge scalars of the two orientation classes.
-  obtain ⟨ch, hch⟩ := torusAbsorbedGauge_unique_scalar hA hB hAr hBr hxh0 hyh0 hxhw hyhh
-    hxhw' hyhh' hxv0 hyv0 hxvw hyvh hxvw' hyvh' hbond hAB hd hposA hposB X X'
+  obtain ⟨ch, hch⟩ := torusAbsorbedGauge_unique_scalar hA hB hAr hBr hw hh
+    hbond hAB hd hposA hposB X X'
     (torusHorizontalReferenceEdge xhStart yhStart) (hedgeX _) (hedgeX' _)
-  obtain ⟨cv, hcv⟩ := torusAbsorbedGauge_unique_scalar hA hB hAr hBr hxh0 hyh0 hxhw hyhh
-    hxhw' hyhh' hxv0 hyv0 hxvw hyvh hxvw' hyvh' hbond hAB hd hposA hposB X X'
-    (torusVerticalReferenceEdge xvStart yvStart) (hedgeX _) (hedgeX' _)
+  obtain ⟨cv, hcv⟩ := torusAbsorbedGauge_unique_scalar hA hB hAr hBr hw hh
+    hbond hAB hd hposA hposB X X'
+    (torusVerticalReferenceEdge xhStart yhStart) (hedgeX _) (hedgeX' _)
   refine ⟨ch, cv, ?_, ?_⟩
   · -- The horizontal class.
     intro e he
     obtain ⟨⟨a, b⟩, rfl⟩ := translate_horizontalReferenceEdge (xStart := xhStart)
       (yStart := yhStart) he
-    -- The stored first endpoint of the (interior) reference edge is its left endpoint.
+    -- The stored first endpoint of the (non-wrapping) reference edge is its left endpoint.
     have hfst : (torusHorizontalReferenceEdge (width := width) (height := height)
         xhStart yhStart).1.1 =
         (((xhStart + 1 : ℕ) : ZMod width), ((yhStart + 2 : ℕ) : ZMod height)) :=
@@ -521,59 +516,59 @@ theorem torusCovariantAbsorbedGauge_unique_classScalar
       rw [gl_inv_coe_smul htr, reindexAlgEquiv_smul]
   · -- The vertical class.
     intro e he
-    obtain ⟨⟨a, b⟩, rfl⟩ := translate_verticalReferenceEdge (xStart := xvStart)
-      (yStart := yvStart) he
+    obtain ⟨⟨a, b⟩, rfl⟩ := translate_verticalReferenceEdge (xStart := xhStart)
+      (yStart := yhStart) he
     have hfst : (torusVerticalReferenceEdge (width := width) (height := height)
-        xvStart yvStart).1.1 =
-        (((xvStart + 2 : ℕ) : ZMod width), ((yvStart + 1 : ℕ) : ZMod height)) :=
+        xhStart yhStart).1.1 =
+        (((xhStart + 2 : ℕ) : ZMod width), ((yhStart + 1 : ℕ) : ZMod height)) :=
       (torusUpEdge_endpoints_of_lt
-        (p := (((xvStart + 2 : ℕ) : ZMod width), ((yvStart + 1 : ℕ) : ZMod height)))
-        (by show ((yvStart + 1 : ℕ) : ZMod height).val + 1 < height
-            rw [ZMod.val_cast_of_lt (by omega : yvStart + 1 < height)]
+        (p := (((xhStart + 2 : ℕ) : ZMod width), ((yhStart + 1 : ℕ) : ZMod height)))
+        (by show ((yhStart + 1 : ℕ) : ZMod height).val + 1 < height
+            rw [ZMod.val_cast_of_lt (by omega : yhStart + 1 < height)]
             omega)).1
     have hEeq : Edge.map (translate a b)
-        (torusVerticalReferenceEdge (width := width) (height := height) xvStart yvStart) =
-        torusUpEdge ((((xvStart + 2 : ℕ) : ZMod width) + a),
-          (((yvStart + 1 : ℕ) : ZMod height) + b)) := by
+        (torusVerticalReferenceEdge (width := width) (height := height) xhStart yhStart) =
+        torusUpEdge ((((xhStart + 2 : ℕ) : ZMod width) + a),
+          (((yhStart + 1 : ℕ) : ZMod height) + b)) := by
       rw [← translateEdge_eq_map, torusVerticalReferenceEdge, translateEdge_torusUpEdge]
     have hq : translate a b (torusVerticalReferenceEdge (width := width) (height := height)
-        xvStart yvStart).1.1 =
-        ((((xvStart + 2 : ℕ) : ZMod width) + a), (((yvStart + 1 : ℕ) : ZMod height) + b)) := by
+        xhStart yhStart).1.1 =
+        ((((xhStart + 2 : ℕ) : ZMod width) + a), (((yhStart + 1 : ℕ) : ZMod height) + b)) := by
       rw [hfst, translate_apply]
     have hiff : ((Edge.map (translate a b) (torusVerticalReferenceEdge (width := width)
-          (height := height) xvStart yvStart)).1.1 =
+          (height := height) xhStart yhStart)).1.1 =
         translate a b (torusVerticalReferenceEdge (width := width) (height := height)
-          xvStart yvStart).1.1) ↔
+          xhStart yhStart).1.1) ↔
         ((Edge.map (translate a b) (torusVerticalReferenceEdge (width := width)
-          (height := height) xvStart yvStart)).1.1.2 + 1 =
+          (height := height) xhStart yhStart)).1.1.2 + 1 =
         (Edge.map (translate a b) (torusVerticalReferenceEdge (width := width)
-          (height := height) xvStart yvStart)).1.2.2) := by
+          (height := height) xhStart yhStart)).1.2.2) := by
       rw [hq, hEeq]
       exact torusUpEdge_fst_eq_iff hh2 _
     have hbde : B.bondDim (Edge.map (translate a b) (torusVerticalReferenceEdge
-        (width := width) (height := height) xvStart yvStart)) =
+        (width := width) (height := height) xhStart yhStart)) =
         B.bondDim (torusVerticalReferenceEdge (width := width) (height := height)
-          xvStart yvStart) := by
+          xhStart yhStart) := by
       rw [← translateEdge_eq_map]
       exact bondDim_translateEdge_of_translationInvariant hB a b _
-    have hXe := hXcov a b (torusVerticalReferenceEdge xvStart yvStart) hbde.symm
-    have hX'e := hX'cov a b (torusVerticalReferenceEdge xvStart yvStart) hbde.symm
+    have hXe := hXcov a b (torusVerticalReferenceEdge xhStart yhStart) hbde.symm
+    have hX'e := hX'cov a b (torusVerticalReferenceEdge xhStart yhStart) hbde.symm
     constructor
     · intro hintr
       rw [hX'e, hXe, if_pos (hiff.mpr hintr), if_pos (hiff.mpr hintr), glReindex_coe,
         glReindex_coe, hcv, reindexAlgEquiv_smul]
     · intro hintr
       have hcond : ¬((Edge.map (translate a b) (torusVerticalReferenceEdge (width := width)
-          (height := height) xvStart yvStart)).1.1 =
+          (height := height) xhStart yhStart)).1.1 =
           translate a b (torusVerticalReferenceEdge (width := width) (height := height)
-            xvStart yvStart).1.1) := fun hcon => hintr (hiff.mp hcon)
+            xhStart yhStart).1.1) := fun hcon => hintr (hiff.mp hcon)
       rw [hX'e, hXe, if_neg hcond, if_neg hcond, glReindex_coe, glReindex_coe]
-      have htr : (glTranspose (X' (torusVerticalReferenceEdge xvStart yvStart)) :
-          Matrix (Fin (B.bondDim (torusVerticalReferenceEdge xvStart yvStart)))
-            (Fin (B.bondDim (torusVerticalReferenceEdge xvStart yvStart))) ℂ) =
-          (cv : ℂ) • (glTranspose (X (torusVerticalReferenceEdge xvStart yvStart)) :
-          Matrix (Fin (B.bondDim (torusVerticalReferenceEdge xvStart yvStart)))
-            (Fin (B.bondDim (torusVerticalReferenceEdge xvStart yvStart))) ℂ) := by
+      have htr : (glTranspose (X' (torusVerticalReferenceEdge xhStart yhStart)) :
+          Matrix (Fin (B.bondDim (torusVerticalReferenceEdge xhStart yhStart)))
+            (Fin (B.bondDim (torusVerticalReferenceEdge xhStart yhStart))) ℂ) =
+          (cv : ℂ) • (glTranspose (X (torusVerticalReferenceEdge xhStart yhStart)) :
+          Matrix (Fin (B.bondDim (torusVerticalReferenceEdge xhStart yhStart)))
+            (Fin (B.bondDim (torusVerticalReferenceEdge xhStart yhStart))) ℂ) := by
         rw [glTranspose_coe, glTranspose_coe, hcv, Matrix.transpose_smul]
       rw [gl_inv_coe_smul htr, reindexAlgEquiv_smul]
 
@@ -685,18 +680,13 @@ scalar `c`.  Each per-vertex relation yields the bare-edge absorbed equality
 Source: arXiv:1804.04964, Section 3, Theorem 3, line 1471 of
 `Papers/1804.04964/paper_normal.tex` (*"X and Y are unique up to a multiplicative constant"*). -/
 theorem torusGauge_unique_scalar_of_perVertex
-    {A B : Tensor (torusGraph width height) d} {xhStart yhStart xvStart yvStart : ℕ}
+    {A B : Tensor (torusGraph width height) d}
     (hA : IsTorusTranslationInvariant A) (hB : IsTorusTranslationInvariant B)
     (hAr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hBr : NormalTorusRectangleInjectivityHypotheses
       (regionInjectivityDataOf (G := torusGraph width height) B))
-    (hxh0 : 2 ≤ xhStart) (hyh0 : 1 ≤ yhStart)
-    (hxhw : xhStart + 5 < width) (hyhh : yhStart + 5 < height)
-    (hxhw' : xhStart + 7 ≤ width) (hyhh' : yhStart + 7 ≤ height)
-    (hxv0 : 2 ≤ xvStart) (hyv0 : 2 ≤ yvStart)
-    (hxvw : xvStart + 5 < width) (hyvh : yvStart + 5 < height)
-    (hxvw' : xvStart + 7 ≤ width) (hyvh' : yvStart + 7 ≤ height)
+    (hw : 7 ≤ width) (hh : 7 ≤ height)
     (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
@@ -717,8 +707,7 @@ theorem torusGauge_unique_scalar_of_perVertex
     (e : Edge (torusGraph width height)) :
     ∃ c : ℂˣ, (X' e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) =
       (c : ℂ) • (X e : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) :=
-  torusAbsorbedGauge_unique_scalar hA hB hAr hBr hxh0 hyh0 hxhw hyhh hxhw' hyhh'
-    hxv0 hyv0 hxvw hyvh hxvw' hyvh' hbond hAB hd hposA hposB X X' e
+  torusAbsorbedGauge_unique_scalar hA hB hAr hBr hw hh hbond hAB hd hposA hposB X X' e
     (edgeAbsorbed_of_perVertex hbond X hPV hlam e)
     (edgeAbsorbed_of_perVertex hbond X' hPV' hlam' e)
 

--- a/TNLean/PEPS/TorusRectangleGauge.lean
+++ b/TNLean/PEPS/TorusRectangleGauge.lean
@@ -52,13 +52,13 @@ theorem exists_horizontalReferenceEdgeGauge_coeff
     (hUB : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) B))
     (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
-    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
-    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height)
     (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
     let e := torusHorizontalReferenceEdge xStart yStart
-    let DA := torusHorizontalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh'
+    let DA := torusHorizontalRectangleBlockingDatum hA hUA hx0 hy0 hxw hyh
     ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ),
         ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
           (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) DA.red)
@@ -67,11 +67,11 @@ theorem exists_horizontalReferenceEdgeGauge_coeff
           regionInsertedCoeff (G := torusGraph width height) A DA.red
               (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e
                 (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hA hUA hx0 hy0
-                  hxw hyh hxw' hyh' g)) M σ τ =
+                  hxw hyh g)) M σ τ =
             regionInsertedCoeff (G := torusGraph width height) B DA.red
               (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e
                 (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hA hUA hx0 hy0
-                  hxw hyh hxw' hyh' g))
+                  hxw hyh g))
               ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
                   Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
                   ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
@@ -79,10 +79,10 @@ theorem exists_horizontalReferenceEdgeGauge_coeff
               σ τ := by
   intro e DA
   -- The datum for `B` over the same regions.
-  let DB := torusHorizontalRectangleBlockingDatum hB hUB hx0 hy0 hxw' hyh'
+  let DB := torusHorizontalRectangleBlockingDatum hB hUB hx0 hy0 hxw hyh
   -- The two data share the three regions, since the regions are tensor independent.
   have hsingle := fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hA hUA hx0 hy0
-    hxw hyh hxw' hyh' g
+    hxw hyh g
   -- `B`'s red and host blocks are blocked-tensor injective.
   have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B DA.red := by
     have hi := hB.horizontalEdgeRed_injective (xStart := xStart) (yStart := yStart)
@@ -113,14 +113,14 @@ theorem exists_verticalReferenceEdgeGauge_coeff
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hUB : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) B))
-    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
-    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
-    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hx0 : 1 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height)
     (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
     let e := torusVerticalReferenceEdge xStart yStart
-    let DA := torusVerticalRectangleBlockingDatum hA hUA hx0 hy0 hxw' hyh'
+    let DA := torusVerticalRectangleBlockingDatum hA hUA hx0 hy0 hxw hyh
     ∃ (hEdge : A.bondDim e = B.bondDim e) (Z : GL (Fin (B.bondDim e)) ℂ),
         ∀ (M : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ)
           (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) DA.red)
@@ -129,20 +129,20 @@ theorem exists_verticalReferenceEdgeGauge_coeff
           regionInsertedCoeff (G := torusGraph width height) A DA.red
               (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e
                 (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hA hUA hx0 hy0
-                  hxw hyh hxw' hyh' g)) M σ τ =
+                  hxw hyh g)) M σ τ =
             regionInsertedCoeff (G := torusGraph width height) B DA.red
               (singleBoundaryEdge (G := torusGraph width height) A DA.red DA.blue e
                 (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hA hUA hx0 hy0
-                  hxw hyh hxw' hyh' g))
+                  hxw hyh g))
               ((Z : Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ) *
                   Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
                   ((Z⁻¹ : GL (Fin (B.bondDim e)) ℂ) :
                     Matrix (Fin (B.bondDim e)) (Fin (B.bondDim e)) ℂ))
               σ τ := by
   intro e DA
-  let DB := torusVerticalRectangleBlockingDatum hB hUB hx0 hy0 hxw' hyh'
+  let DB := torusVerticalRectangleBlockingDatum hB hUB hx0 hy0 hxw hyh
   have hsingle := fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hA hUA hx0 hy0
-    hxw hyh hxw' hyh' g
+    hxw hyh g
   have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B DA.red := by
     have hi := hB.verticalEdgeRed_injective (xStart := xStart) (yStart := yStart)
       (by omega) (by omega)

--- a/TNLean/PEPS/TorusRectangleReferenceData.lean
+++ b/TNLean/PEPS/TorusRectangleReferenceData.lean
@@ -15,8 +15,11 @@ crossing is the reference edge.
 This is the source-faithful reference blocking datum the translation-invariant gauge family
 consumes.  Unlike the vertex-injective singleton datum of
 `TNLean/PEPS/TorusReferenceBlockingData.lean`, the injectivity inputs are exactly the source's
-rectangular-injectivity hypotheses, with no single-vertex injectivity.  The reference edge sits in
-the interior of the torus with enough margin that the regions avoid the wraparound seam.
+rectangular-injectivity hypotheses, with no single-vertex injectivity.  The reference edge keeps a
+margin of at least two columns and rows below and to the left, while above and to the right the
+blocking either touches the seam or keeps a margin of at least two; the seam-touching anchor
+`(width - 5, height - 5)` realizes the blocking on every torus with the source's sizes
+`n, m ≥ 7` (arXiv:1804.04964, Theorem 3).
 
 ## References
 
@@ -42,8 +45,9 @@ edge block, and complementary block the rest of the torus.  All three are inject
 injectivity and the union-of-injective-regions lemma; they partition the torus; the edge's left
 endpoint lies in red and its right endpoint in blue.
 
-The offset `(xStart, yStart)` must place the regions clear of the wraparound seam: at least two
-columns and one row of margin below and to the left, and enough room above and to the right.
+The offset `(xStart, yStart)` must keep at least two columns and one row of margin below and to
+the left, while above and to the right the removed blocks either touch the seam
+(`xStart + 5 = width`, `yStart + 5 = height`) or keep a margin of at least two.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1407--1500 of
 `Papers/1804.04964/paper_normal.tex`. -/
@@ -52,7 +56,8 @@ def torusHorizontalRectangleBlockingDatum
     (h : NormalTorusRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
     (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
-    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height) :
     NormalEdgeBlockingData κ (torusGraph width height)
       (torusHorizontalReferenceEdge xStart yStart) where
   red := torusHorizontalEdgeRed xStart yStart
@@ -81,7 +86,8 @@ def torusHorizontalRectangleBlockingDatum
     (h : NormalTorusRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
     (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
-    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height) :
     (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).red =
       torusHorizontalEdgeRed xStart yStart := rfl
 
@@ -90,7 +96,8 @@ def torusHorizontalRectangleBlockingDatum
     (h : NormalTorusRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
     (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
-    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height) :
     (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).blue =
       torusHorizontalEdgeBlue xStart yStart := rfl
 
@@ -107,15 +114,15 @@ theorem isCrossingEdge_torusHorizontalRectangleBlockingDatum
     (hUnion : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
-    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
-    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height)
     (g : Edge (torusGraph width height)) :
     IsCrossingEdge (G := torusGraph width height) A
-        (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw' hyh').red
-        (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw' hyh').blue g ↔
+        (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).red
+        (torusHorizontalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).blue g ↔
       g = torusHorizontalReferenceEdge xStart yStart := by
   rw [torusHorizontalRectangleBlockingDatum_red, torusHorizontalRectangleBlockingDatum_blue]
-  exact isCrossingEdge_torusHorizontalEdge A hxw hyh g
+  exact isCrossingEdge_torusHorizontalEdge A (by omega) (by omega) (by omega) g
 
 /-! ### The faithful vertical reference blocking datum -/
 
@@ -130,8 +137,9 @@ def torusVerticalRectangleBlockingDatum
     {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
     (h : NormalTorusRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
-    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
-    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (hx0 : 1 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height) :
     NormalEdgeBlockingData κ (torusGraph width height)
       (torusVerticalReferenceEdge xStart yStart) where
   red := torusVerticalEdgeRed xStart yStart
@@ -159,8 +167,9 @@ def torusVerticalRectangleBlockingDatum
     {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
     (h : NormalTorusRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
-    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
-    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (hx0 : 1 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height) :
     (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).red =
       torusVerticalEdgeRed xStart yStart := rfl
 
@@ -168,8 +177,9 @@ def torusVerticalRectangleBlockingDatum
     {κ : RegionInjectivityData (TorusVertex width height)} {xStart yStart : ℕ}
     (h : NormalTorusRectangleInjectivityHypotheses κ)
     (hUnion : RegionInjectivityUnionClosure κ)
-    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
-    (hxw : xStart + 7 ≤ width) (hyh : yStart + 7 ≤ height) :
+    (hx0 : 1 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height) :
     (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).blue =
       torusVerticalEdgeBlue xStart yStart := rfl
 
@@ -185,16 +195,16 @@ theorem isCrossingEdge_torusVerticalRectangleBlockingDatum
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hUnion : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) A))
-    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
-    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
-    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hx0 : 1 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height)
     (g : Edge (torusGraph width height)) :
     IsCrossingEdge (G := torusGraph width height) A
-        (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw' hyh').red
-        (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw' hyh').blue g ↔
+        (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).red
+        (torusVerticalRectangleBlockingDatum h hUnion hx0 hy0 hxw hyh).blue g ↔
       g = torusVerticalReferenceEdge xStart yStart := by
   rw [torusVerticalRectangleBlockingDatum_red, torusVerticalRectangleBlockingDatum_blue]
-  exact isCrossingEdge_torusVerticalEdge A hxw hyh g
+  exact isCrossingEdge_torusVerticalEdge A (by omega) (by omega) (by omega) g
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWitnessCapstone.lean
+++ b/TNLean/PEPS/TorusWitnessCapstone.lean
@@ -115,8 +115,8 @@ theorem exists_edgeCoeffIdentityWitness_horizontalFamily
     (hUBh : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) B))
     (hx0 : 2 ≤ xStart) (hy0 : 1 ≤ yStart)
-    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
-    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height)
     (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
@@ -125,19 +125,19 @@ theorem exists_edgeCoeffIdentityWitness_horizontalFamily
         Nonempty (EdgeCoeffIdentityWitness A B e Z Zref hE) := by
   -- The reference horizontal gauge and its coefficient identity at the reference edge.
   obtain ⟨hEref, Zref, hZref⟩ :=
-    exists_horizontalReferenceEdgeGauge_coeff hAh hBh hUAh hUBh hx0 hy0 hxw hyh hxw' hyh'
+    exists_horizontalReferenceEdgeGauge_coeff hAh hBh hUAh hUBh hx0 hy0 hxw hyh
       hbond hAB hd hposA hposB
   intro e he
   -- Write `e` as the translation image of the reference horizontal edge.
   obtain ⟨⟨a, b⟩, rfl⟩ := translate_horizontalReferenceEdge (xStart := xStart)
     (yStart := yStart) he
   -- Abbreviate the reference region and its single boundary edge.
-  set R := (torusHorizontalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw' hyh').red with hRdef
+  set R := (torusHorizontalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw hyh).red with hRdef
   set f := singleBoundaryEdge (G := torusGraph width height) A R
-    (torusHorizontalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw' hyh').blue
+    (torusHorizontalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw hyh).blue
     (torusHorizontalReferenceEdge xStart yStart)
     (fun g => isCrossingEdge_torusHorizontalRectangleBlockingDatum A hAh hUAh hx0 hy0 hxw hyh
-      hxw' hyh' g) with hfdef
+      g) with hfdef
   -- `B`'s reference region block and host block are injective.
   have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R := by
     have hi := hBh.horizontalEdgeRed_injective (xStart := xStart) (yStart := yStart)
@@ -145,7 +145,7 @@ theorem exists_edgeCoeffIdentityWitness_horizontalFamily
     rwa [regionInjectivityDataOf_isInjective] at hi
   have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R) :=
     regionBlockedTensorInjective_host
-      (torusHorizontalRectangleBlockingDatum hBh hUBh hx0 hy0 hxw' hyh') hUBh
+      (torusHorizontalRectangleBlockingDatum hBh hUBh hx0 hy0 hxw hyh) hUBh
   -- The bond-dimension equality at the translated boundary edge, derived from the reference
   -- equality and the two translation bond-dimension equalities.
   have hEX : A.bondDim (boundaryEdgeMap (translate a b) R f).1 =
@@ -184,9 +184,9 @@ theorem exists_edgeCoeffIdentityWitness_verticalFamily
       (regionInjectivityDataOf (G := torusGraph width height) A))
     (hUBh : RegionInjectivityUnionClosure
       (regionInjectivityDataOf (G := torusGraph width height) B))
-    (hx0 : 2 ≤ xStart) (hy0 : 2 ≤ yStart)
-    (hxw : xStart + 5 < width) (hyh : yStart + 5 < height)
-    (hxw' : xStart + 7 ≤ width) (hyh' : yStart + 7 ≤ height)
+    (hx0 : 1 ≤ xStart) (hy0 : 2 ≤ yStart)
+    (hxw : xStart + 5 = width ∨ xStart + 7 ≤ width)
+    (hyh : yStart + 5 = height ∨ yStart + 7 ≤ height)
     (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g) :
@@ -194,24 +194,24 @@ theorem exists_edgeCoeffIdentityWitness_verticalFamily
       ∃ (Z Zref : GL (Fin (B.bondDim e)) ℂ) (hE : A.bondDim e = B.bondDim e),
         Nonempty (EdgeCoeffIdentityWitness A B e Z Zref hE) := by
   obtain ⟨hEref, Zref, hZref⟩ :=
-    exists_verticalReferenceEdgeGauge_coeff hAh hBh hUAh hUBh hx0 hy0 hxw hyh hxw' hyh'
+    exists_verticalReferenceEdgeGauge_coeff hAh hBh hUAh hUBh hx0 hy0 hxw hyh
       hbond hAB hd hposA hposB
   intro e he
   obtain ⟨⟨a, b⟩, rfl⟩ := translate_verticalReferenceEdge (xStart := xStart)
     (yStart := yStart) he
-  set R := (torusVerticalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw' hyh').red with hRdef
+  set R := (torusVerticalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw hyh).red with hRdef
   set f := singleBoundaryEdge (G := torusGraph width height) A R
-    (torusVerticalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw' hyh').blue
+    (torusVerticalRectangleBlockingDatum hAh hUAh hx0 hy0 hxw hyh).blue
     (torusVerticalReferenceEdge xStart yStart)
     (fun g => isCrossingEdge_torusVerticalRectangleBlockingDatum A hAh hUAh hx0 hy0 hxw hyh
-      hxw' hyh' g) with hfdef
+      g) with hfdef
   have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R := by
     have hi := hBh.verticalEdgeRed_injective (xStart := xStart) (yStart := yStart)
       (by omega) (by omega)
     rwa [regionInjectivityDataOf_isInjective] at hi
   have hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R) :=
     regionBlockedTensorInjective_host
-      (torusVerticalRectangleBlockingDatum hBh hUBh hx0 hy0 hxw' hyh') hUBh
+      (torusVerticalRectangleBlockingDatum hBh hUBh hx0 hy0 hxw hyh) hUBh
   have hEX : A.bondDim (boundaryEdgeMap (translate a b) R f).1 =
       B.bondDim (boundaryEdgeMap (translate a b) R f).1 :=
     (bondDim_boundaryEdgeMap_translate hA a b R f).trans

--- a/blueprint/src/chapter/ch13a_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_torus.tex
@@ -210,13 +210,13 @@
     \cite[Theorem~3]{Molnar2018NormalPEPS} on the torus geometry, where every
     edge is interior and translation acts freely.
     Theorem~\ref{thm:fundamentalTheorem_normalTorusPEPS_unconditional} proves
-    this with the torus large enough to host the two reference rectangles
-    ($n,m\geq 9$) and with the gauge family described by its translation
-    covariance, and the uniqueness of $X$ and $Y$ up to a multiplicative
-    constant is proved at the same enlarged sizes in
+    this at the source's sizes $n,m\geq 7$ with the gauge family described
+    by its translation covariance, and the uniqueness of $X$ and $Y$ up to a
+    multiplicative constant is proved at the same sizes in
     Theorem~\ref{thm:torusAbsorbedGauge_unique_scalar} and
     Theorem~\ref{thm:torusGauge_unique_scalar_of_perVertex}; the present
-    source-exact entry awaits the $n,m\geq 7$ sizes.
+    source-exact entry awaits only the reading of the gauge family as the two
+    class matrices $X$ and $Y$.
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus,
@@ -231,7 +231,7 @@
         thm:peps_torusUniformBondDim_of_translationInvariant,
         def:GaugeEquivPEPS}
     Let $A$ and $B$ be translationally invariant PEPS tensors on the discrete
-    $n\times m$ torus with $n,m\geq 9$, with positive physical dimension, equal
+    $n\times m$ torus with $n,m\geq 7$, with positive physical dimension, equal
     and positive bond dimensions,
     generating the same state, and such that every contiguous $2\times 3$ and
     $3\times 2$ coordinate rectangle of either tensor is injective. Then there
@@ -244,8 +244,8 @@
     every edge: inserting any matrix on an edge of $A$ gives the same
     coefficient as inserting it on the corresponding edge of the gauge-absorbed
     $B$.
-    This is \cite[Theorem~3]{Molnar2018NormalPEPS} on the torus with the sizes
-    enlarged to $n,m\geq 9$ and the horizontal and vertical gauges $X$, $Y$
+    This is \cite[Theorem~3]{Molnar2018NormalPEPS} on the torus at the source's
+    sizes $n,m\geq 7$, with the horizontal and vertical gauges $X$, $Y$
     described by translation covariance: the stored orientation of a
     wraparound edge is reversed, so on the seam the family carries the
     transposed inverse of the class matrix, and a family that is literally one
@@ -268,6 +268,11 @@
         \uses{lem:peps_injectiveRegion_union_pos}
         The union closure of injective regions follows from the positive bond
         dimensions and Lemma~\ref{lem:peps_injectiveRegion_union_pos}. The
+        reference blockings are anchored against the far seam: the removed
+        blocks keep a margin of at least two rows and columns below and to
+        the left and end exactly at the seam above and to the right, so the
+        complementary region decomposes into wraparound-free rectangular
+        bands on every torus with $n,m\geq 7$. The
         coherent blocking frames at every edge produce per-edge gauges, whose
         absorption into $B$ gives the absorbed inserted-coefficient equality at
         every edge; the absorbing family is built by transporting one reference
@@ -297,9 +302,9 @@
     \leanok
     \uses{def:applyGauge, def:peps_edgeInsertedCoeff}
     Let $A$ and $B$ be translationally invariant PEPS tensors on the discrete
-    $n\times m$ torus with $n,m\geq 9$ (large enough to host the two reference
-    rectangles), with positive physical dimension, equal and positive bond
-    dimensions, generating the same state, and such that every contiguous
+    $n\times m$ torus with $n,m\geq 7$, with positive physical dimension,
+    equal and positive bond dimensions, generating the same state, and such
+    that every contiguous
     $2\times 3$ and $3\times 2$ coordinate rectangle of either tensor is
     injective.  Let $X$ and $X'$ be two families of invertible matrices, one
     on each edge of the torus, and let $e$ be an edge at which both families
@@ -309,7 +314,7 @@
     Then the two families are proportional at $e$: $X'_e = c\cdot X_e$ for a
     nonzero scalar $c$.
     This is the uniqueness clause of \cite[Theorem~3]{Molnar2018NormalPEPS}
-    read at one edge, with the sizes enlarged to $n,m\geq 9$ as in
+    read at one edge, at the source's sizes $n,m\geq 7$ as in
     Theorem~\ref{thm:fundamentalTheorem_normalTorusPEPS_unconditional}; the
     source proves it through the determinacy of the conjugator in the
     isomorphism lemma, whose realizing matrix is unique up to a multiplicative
@@ -406,9 +411,9 @@
     \leanok
     \uses{def:gaugeVertex, def:applyGauge}
     Let $A$ and $B$ be translationally invariant PEPS tensors on the discrete
-    $n\times m$ torus with $n,m\geq 9$ (large enough to host the two reference
-    rectangles), with positive physical dimension, equal and positive bond
-    dimensions, generating the same state, and such that every contiguous
+    $n\times m$ torus with $n,m\geq 7$, with positive physical dimension,
+    equal and positive bond dimensions, generating the same state, and such
+    that every contiguous
     $2\times 3$ and $3\times 2$ coordinate rectangle of either tensor is
     injective.  Suppose the families $X$ and $X'$ of invertible matrices, one
     on each edge, each realize the per-vertex relation of
@@ -419,8 +424,8 @@
     proportional at every edge: $X'_e = c\cdot X_e$ for a nonzero scalar $c$
     depending on the edge.
     This is the uniqueness clause of \cite[Theorem~3]{Molnar2018NormalPEPS}
-    read against the displayed relation $B = \lambda\cdot(X,Y)A$ itself, with
-    the sizes enlarged to $n,m\geq 9$.
+    read against the displayed relation $B = \lambda\cdot(X,Y)A$ itself, at
+    the source's sizes $n,m\geq 7$.
     \begin{proof}
         \leanok
         \uses{thm:torusAbsorbedGauge_unique_scalar,

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2489,11 +2489,43 @@ multilinear in the site tensors, so the relation $A_v = \lambda\cdot(\text{gauge
 action of }B)_v$ with $\lambda^{nm}=1$ already implies the bare-edge absorbed
 equality at every edge (\path{edgeAbsorbed_of_perVertex}).
 
-What remains against the source statement of Theorem~3: the torus sizes are
-$n,m\geq 9$ (large enough to host the two reference rectangles) where the source
-states $n,m\geq 7$; and the source's square-lattice region form of the theorem is
-covered separately by the conditional square-lattice statement recorded earlier in
-this note.
+What remains against the source statement of Theorem~3: the source's square-lattice
+region form of the theorem is covered separately by the conditional square-lattice
+statement recorded earlier in this note. The torus sizes match the source: the
+theorem and its uniqueness clauses hold for $n,m\geq 7$ (see the next section).
+
+\section*{The torus sizes: from $n,m\geq 9$ to the source's $n,m\geq 7$}
+
+An earlier formal statement required $n,m\geq 9$. The margin audit traced each size
+hypothesis to its consumer. The blocking around an edge removes a $2\times3$ block
+and a $3\times2$ block whose union has a $5\times4$ bounding box, and the
+complementary region is decomposed into wraparound-free rectangular bands; a band of
+width one is not a union of $2\times3$ and $3\times2$ rectangles, so each side
+margin of the bounding box must be zero or at least two, and the side where the
+filler rectangle dips below the removed blocks must be at least two. The earlier
+placement put the bounding box in the interior with margins of at least two on all
+four sides, forcing $5+2+2 = 9$ in the wide direction. The crossing-uniqueness
+window used the strict bounds only to rule out wrapped cyclic steps.
+
+The repaired placement anchors the bounding box against the far seam: margins of at
+least two below and to the left, margin exactly zero above and to the right
+(anchor $(n-5, m-5)$, hypothesis shape $x + 5 = n \lor x + 7 \le n$ per direction).
+The seam-side bands are empty and drop out of the cover, and a cyclic step wrapping
+the seam lands in the zero column or row, strictly outside both removed blocks, so
+crossing uniqueness survives. This packs both reference blockings and the $3\times3$
+corner comparison into every torus with $n,m\geq 7$, the source's sizes.
+
+The source's own packing is different: the example regions in the proof of
+Theorem~3 (lines 1475--1498 of \texttt{paper\_normal.tex}) sit on a $7\times7$
+patch with margins of width one on three sides, and the complementary region is
+read as connected through the torus seam --- its injectivity uses $2\times3$ and
+$3\times2$ regions that wrap. That reading is licensed by the source's hypothesis,
+which makes \emph{every} region of those shapes injective, wrapped translates
+included. The formal hypothesis (\path{NormalTorusRectangleInjectivityHypotheses})
+is weaker: it covers only the wraparound-free coordinate rectangles. The
+seam-anchored placement reaches the source's sizes from this weaker hypothesis, so
+no paper gap arises, and the source's $n,m\geq 7$ is justified under either
+reading.
 
 \section*{Removal of the conditional square-lattice skeleton}
 


### PR DESCRIPTION
## Summary

The last residual of the arXiv:1804.04964 Section-3 program: the torus Fundamental Theorem and its uniqueness clauses now hold at the source's sizes `n, m >= 7` (Theorem 3, lines 1453-1471 of `Papers/1804.04964/paper_normal.tex`). The previous statements took reference-anchor coordinates whose minimal instantiation forced `width, height >= 9`.

## Margin audit (Phase 1)

Each inequality hypothesis of the old capstones, its consumer, and the true minimal bound:

| Old hypothesis (horizontal blocking) | Consumer | Role | True minimal |
|---|---|---|---|
| `2 ≤ xhStart` | `horizontalEdgeComplement_injective`, left band `xStart × 4` | left margin must be a wide rectangle | `2 ≤ xStart` (margin 1 is uncoverable by unwrapped 2x3/3x2 rectangles; margin 0 would need a different cover and is unnecessary) |
| `1 ≤ yhStart` | complement cover filler 4 at `(xStart, yStart - 1)` + bottom band `width × (yStart + 1)` | the 2x1 strip below the red block needs a 2x3 filler dipping two rows below the hole | `1 ≤ yStart` (genuinely needed) |
| `xhStart + 5 < width` (strict) | `isCrossingEdge_torusHorizontalEdge` no-wrap window | rule out wrapped cyclic steps | `xStart + 5 ≤ width` with the wrap case handled (a wrapped step lands in column 0, outside both blocks when `1 ≤ xStart`) |
| `yhStart + 5 < height` (strict) | same | same | `yStart + 5 ≤ height` (vertical steps never cross: red/blue columns disjoint) |
| `xhStart + 7 ≤ width` | complement cover right band `(width - xStart - 5) × 4` | right margin ≥ 2 | `xStart + 5 = width ∨ xStart + 7 ≤ width` (zero or ≥ 2) |
| `yhStart + 7 ≤ height` | complement cover top band | top margin ≥ 2 | `yStart + 5 = height ∨ yStart + 7 ≤ height` |

Vertical blocking analogues: `2 ≤ xvStart` had true minimum `1 ≤ xStart` (left band is `(xStart + 1) × height`); `2 ≤ yvStart` is genuinely needed (bottom band plus the down-left filler dip); the `+7` bounds relax to the same disjunctions; the strict `+5` bounds relax to `≤` with the wrapped row landing in row 0, outside both blocks when `1 ≤ yStart`. The 3x3 corner comparison (`TorusCornerRegion`) already needed only `7 ≤ width/height` and is unchanged.

With all four margins forced to ≥ 2 the wide direction needs `5 + 2 + 2 = 9`: that was the whole source of >= 9.

## Verdict: (B) re-placement, executed

A seam-anchored placement — margins ≥ 2 below/left, margin exactly 0 above/right, anchor `(width - 5, height - 5)` — packs both reference blockings into every torus with `n, m ≥ 7`. The re-derivation was mechanical and confined to two geometry files:

* `TorusEdgeBlockingRegion`: complement-injectivity under the disjunctive margins; the seam-side cover bands may be empty, handled by a new `RegionInjectivityUnionClosure.biUnion_injective_of_nonempty` (`InjectiveRegion.lean`) that requires injectivity only of nonempty pieces.
* `TorusEdgeBlockingCrossing`: crossing uniqueness with the window allowed to touch the seam; new wrap-step lemmas (`torus_horizontal_step_val_wrap`, `torus_vertical_step_val_wrap`) show a wrapped step lands in the zero column/row, outside both blocks.

The bounds then thread through `TorusRectangleReferenceData`, `TorusRectangleGauge`, `TorusWitnessCapstone`, `TorusCovariantAbsorbedFamily` (parametric anchors kept, with the relaxed bounds — minimal instantiation now allows 7x7 at anchor (2,2)), and the five capstones take exactly `7 ≤ width`, `7 ≤ height`:

* `fundamentalTheorem_normalTorusPEPS_unconditional`
* `exists_torusCovariantAbsorbedGaugeFamily` (parametric; satisfiable at 7)
* `torusAbsorbedGauge_unique_scalar`
* `torusCovariantAbsorbedGauge_unique_classScalar`
* `torusGauge_unique_scalar_of_perVertex`

Instantiation at `width = height = 7` is `le_refl`-trivial: the capstone hypotheses are literally the source's `n, m ≥ 7`.

## On the source's own 7

The paper's example regions (lines 1475-1498) sit on a 7x7 patch with margins of width one on three sides; its complement region wraps the torus seam, so its injectivity uses wrapped 2x3/3x2 regions — licensed by the source hypothesis "every region of size 2x3 and 3x2 is injective". The Lean hypothesis (`NormalTorusRectangleInjectivityHypotheses`) is weaker (wraparound-free rectangles only), and the seam-anchored placement reaches the source's sizes from it. No paper gap: the source's `n, m ≥ 7` is justified under either reading. Recorded in `docs/paper-gaps/peps_normal_ft_section3_route.tex`, section "The torus sizes".

## Axioms

All seven restated declarations depend on exactly `[propext, Classical.choice, Quot.sound]` (checked with `#print axioms` for the five capstones plus the two witness families).

## Verification

* Full root `lake build`: green, 8891 jobs.
* `lake exe lint-style`: exit 0.
* `leanblueprint web` + `leanblueprint checkdecls`: exit 0.
* `chktex` with `blueprint/.chktexrc` on the changed chapter: clean.
* `docs/paper-gaps` route note compiles with `latexmk`.
* No `sorry`/`axiom`/`maxHeartbeats` introduced; all files well under 1000 lines.

## Blueprint

`blueprint/src/chapter/ch13a_peps_ft_torus.tex`: the four torus entries now state `n, m ≥ 7`; the source-exact entry `thm:fundamentalTheorem_normalTorusPEPS` (still `\notready`) now awaits only the reading of the gauge family as the two class matrices X and Y, not the sizes; the unconditional theorem's proof records why the seam-anchored blockings pack into 7.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof refactor across torus blocking geometry and main theorem statements; wrong margin or wrap cases would break injectivity or crossing uniqueness, though the change is localized to PEPS/torus Lean and docs.
> 
> **Overview**
> **Lowers the torus Fundamental Theorem and uniqueness results from `n, m ≥ 9` to the source’s `n, m ≥ 7`** by re-anchoring reference edge blockings at `(width - 5, height - 5)` so the bounding window can touch the right/top seam instead of requiring a two-cell margin on all sides.
> 
> **Geometry and injectivity:** Margin hypotheses become disjunctive (`xStart + 5 = width ∨ xStart + 7 ≤ width`, and the height analogue). Complement-region proofs switch to `RegionInjectivityUnionClosure.biUnion_injective_of_nonempty`, which only demands injectivity on **nonempty** cover pieces when seam-side bands vanish. Crossing uniqueness is extended with wrap-step lemmas (`torus_horizontal_step_val_wrap`, `torus_vertical_step_val_wrap`) so cyclic steps at the seam cannot fake red–blue crossings.
> 
> **API threading:** `exists_torusCovariantAbsorbedGaugeFamily`, rectangle blocking data, gauge witnesses, and the five capstones (`fundamentalTheorem_normalTorusPEPS_unconditional`, uniqueness theorems) drop per-anchor `+5 <` / `+7 ≤` parameter bundles in favor of the relaxed bounds internally and **`hw : 7 ≤ width`, `hh : 7 ≤ height`** at the top level. Blueprint chapter `ch13a_peps_ft_torus.tex` and `docs/paper-gaps/peps_normal_ft_section3_route.tex` are updated to document the margin audit and seam-anchored packing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914dbcd0c343dfb4368ede3d2527dec05cc6d236. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->