### PR TITLE
feat(MPS/ParentHamiltonian): record complementary boundary consequence

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -675,4 +675,121 @@ theorem
   exact wordSpan_eq_top_of_ge_of_unital (A j) (hUnital j)
     ((wordSpan_eq_top_iff_isNBlkInjective (A j) L₀).mpr (hBlk j)) (by omega)
 
+/-- Complementary-word identities upgrade the block-diagonal boundary
+representation to periodic block components.
+
+Under the normalized BNT hypotheses, every vector in the block-diagonal
+periodic chain space has block-diagonal boundary conditions \(X_j\).  If those
+same boundary conditions satisfy the complementary-word identities obtained
+from the Pérez-García--Verstraete--Wolf--Cirac \(C,D,E\) comparison: for every
+boundary-crossing interval \(i\), wrapped word \(\beta\), and complementary
+word \(\rho\),
+\[
+  \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho},
+\]
+then the component vectors
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)
+\]
+belong to \(\mathcal G_{N,L}(A_j)\).
+
+This result follows the block-diagonal boundary conditions of arXiv:2011.12127,
+lines 2126--2128, and precedes the final equality in
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1454--1456. -/
+theorem
+    exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (hIdentity :
+      ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+        ∀ (j : Fin r) (i : Fin N),
+          N < i.val + L →
+            ∀ ρ : Fin (N - L) → Fin d,
+              ∃ E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+                ∀ β : Fin (i.val + L - N) → Fin d,
+                  (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                      evalWord (A j) (List.ofFn ρ) =
+                    evalWord (A j) (List.ofFn β) * E) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  classical
+  obtain ⟨X, hψX, _hOpen⟩ :=
+    exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
+  refine ⟨X, hψX, ?_⟩
+  exact
+    blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective
+      μ A hN hLN X hBlk hUnital hNlarge (hIdentity X hψX)
+
+/-- Complementary-word identities give the block-diagonal periodic-chain
+equality in the finite BNT range.
+
+This theorem combines two steps of the source boundary-closing argument:
+first obtain block-diagonal boundary conditions, then use the
+Pérez-García--Verstraete--Wolf--Cirac complementary-word identities to put
+each component vector in the corresponding periodic block chain space. The
+hypothesis is exactly the still-separate \(C,D,E\) comparison for every
+boundary-crossing interval; the theorem does not assert that comparison. -/
+theorem
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hIdentity :
+      ∀ {ψ : NSiteSpace d N},
+        ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+          ∀ (j : Fin r) (i : Fin N),
+            N < i.val + L →
+              ∀ ρ : Fin (N - L) → Fin d,
+                ∃ E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+                  ∀ β : Fin (i.val + L - N) → Fin d,
+                    (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                        evalWord (A j) (List.ofFn ρ) =
+                      evalWord (A j) (List.ofFn β) * E) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  exact
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+      (fun ψ hψ =>
+        exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
+          μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+          hNlarge hψ (fun X hψX => hIdentity hψ X hψX))
+
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -558,3 +558,53 @@
     Apply
     Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities}.
 \end{proof}
+
+\begin{lemma}[Complementary identities give periodic block components]
+    \label{lem:block_diagonal_boundary_periodic_components_from_complementary_identities}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
+    addition that \(L+L_0\le N\).  Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right).
+    \]
+    Suppose that whenever
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+    \]
+    the corresponding boundary conditions satisfy the complementary-word
+    identities: for every boundary-crossing interval \(i\), every wrapped
+    word \(\beta\), and every complementary word \(\rho\),
+    \[
+        \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho}
+    \]
+    Then there are block-diagonal boundary conditions \(X_j\) such that
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+        \qquad
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
+    \]
+    for every \(j\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    By Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices} there are
+    matrices \(X_j\) with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
+    \]
+    These \(X_j\) satisfy the assumed complementary-word identities, so
+    Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    gives
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
+    \]
+    for every \(j\).
+\end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -582,13 +582,14 @@
     \[
         \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho}
     \]
-    Then there are block-diagonal boundary conditions \(X_j\) such that
+    Then there are block-diagonal boundary conditions \(X_j\) with
     \[
-        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
-        \qquad
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every \(j\),
+    \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
     \]
-    for every \(j\).
 \end{lemma}
 
 \begin{proof}
@@ -602,9 +603,8 @@
     \]
     These \(X_j\) satisfy the assumed complementary-word identities, so
     Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities_injective}
-    gives
+    gives, for every \(j\),
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
     \]
-    for every \(j\).
 \end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -193,6 +193,60 @@
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}.
 \end{proof}
 
+\begin{lemma}[Complementary identities give equality in the finite range]
+    \label{lem:bnt_block_diagonal_complementary_identities_equality}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}
+    \leanok
+    \uses{lem:block_diagonal_boundary_periodic_components_from_complementary_identities,
+        lem:bnt_block_diagonal_boundary_representation_equality}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
+    in addition that \(L+L_0\le N\). Suppose that for every
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+    \]
+    and every block-diagonal boundary representation
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+    \]
+    the complementary-word identities: for every boundary-crossing interval
+    \(i\), every wrapped word \(\beta\), and every complementary word \(\rho\),
+    \[
+        \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho}
+    \]
+    hold. Then
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =
+        \bigvee_j\mathcal G_{N,L}(A_j),
+    \]
+    and the \(N\)-site ground spaces \(G_N(A_j)=\mathcal G_{N,N}(A_j)\)
+    have internal sum.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_periodic_components_from_complementary_identities,
+        lem:bnt_block_diagonal_boundary_representation_equality}
+    For each \(\psi\),
+    Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_complementary_identities}
+    gives matrices \(X_j\) such that
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+        \qquad
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
+    \]
+    for every \(j\). Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}
+    then gives
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =
+        \bigvee_j\mathcal G_{N,L}(A_j),
+    \]
+    and the internality of the sum of the \(G_N(A_j)\).
+\end{proof}
+
 \begin{lemma}[Boundary decomposition gives equality in the finite injectivity range]
     \label{lem:bnt_block_diagonal_boundary_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -231,13 +231,15 @@
         lem:bnt_block_diagonal_boundary_representation_equality}
     For each \(\psi\),
     Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_complementary_identities}
-    gives matrices \(X_j\) such that
+    gives matrices \(X_j\) with
     \[
-        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
-        \qquad
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every \(j\),
+    \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
     \]
-    for every \(j\). Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}
     then gives
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)


### PR DESCRIPTION
## Summary

This PR records the conditional implication used in the block-diagonal parent-Hamiltonian boundary-closing argument.

The new Lean statements combine two existing ingredients:

- the BNT block-diagonal boundary representation for vectors in the periodic chain space;
- the complementary-word boundary identities needed to place each block component in its own periodic chain space.

The blueprint records the same conditional implication in the boundary-crossing and chain-equality subsections. The wording follows the source terminology around block-diagonal boundary conditions and the PGVWC/Cirac complementary-word comparison.

This PR does not prove the remaining \(C,D,E\) comparison for arbitrary boundary-crossing intervals.

Refs #2651.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls`

`lake build TNLean` reports only pre-existing warnings in unrelated PEPS, MPDO, periodic-overlap, and boundary-closing modules; no new warning came from the edited parent-Hamiltonian file.