### PR TITLE
feat(MPS/ParentHamiltonian): expose martingale compression constant

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -15,8 +15,12 @@ estimate remains an explicit hypothesis.
 
 * `parentHamiltonianES_gap_bound_of_friedrichs` — the explicit gap bound
   obtained from the overlapping-window norm-compression estimate.
+* `parentHamiltonianES_gap_bound_of_overlap_norm_constant` — the corresponding
+  positive-gap bound from a strict uniform compression coefficient.
 * `parentHamiltonian_gapped` — conditional uniform spectral gap for MPS parent
   Hamiltonians on injective tensors, under the same Friedrichs input.
+* `parentHamiltonian_gapped_of_overlap_norm_constant` — the corresponding
+  uniform spectral gap from a strict uniform compression coefficient.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -52,6 +56,40 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
           ‖parentHamiltonianES A L N v‖ := by
   exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound A L hL
     hOverlapNorm
+
+/-- Gap bound from a strict uniform overlapping cyclic-window compression
+coefficient for the MPS parent Hamiltonian.
+
+This is the source-faithful form of the remaining martingale input in
+arXiv:2011.12127, Section IV.C (the martingale-2 estimate), with an arbitrary
+compression constant.  It does not
+assert the special coefficient used in
+`parentHamiltonianES_gap_bound_of_friedrichs`; instead, it says that any uniform
+bound
+
+`‖p_i p_j v‖ ≤ η ‖p_i v‖`
+
+with `η * 2(L-1) < 1` yields the positive gap constant
+`1 - η * 2(L-1)`.  The comparison between this flexible cyclic-window
+hypothesis and the cited FNW--Nachtergaele--Kastoryano principal-angle estimates
+is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem parentHamiltonianES_gap_bound_of_overlap_norm_constant
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
+    (hηnonneg : 0 ≤ η)
+    (hηlt : η * (((2 * (L - 1) : ℕ) : ℝ)) < 1)
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L i v‖) :
+    0 < 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        (1 - η * (((2 * (L - 1) : ℕ) : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
+    A L hL hηnonneg hηlt hOverlapNorm
 
 /--
 **Conditional spectral gap for MPS parent Hamiltonians.**
@@ -105,5 +143,37 @@ theorem parentHamiltonian_gapped
   obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_friedrichs A hA L hL
     hOverlapNorm
   exact ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, hgap⟩
+
+/--
+**Conditional spectral gap from a strict overlapping-window compression
+coefficient.**
+
+For an MPS tensor `A` and interaction range `L > 1`, any uniform
+overlapping cyclic-window estimate
+`‖p_i p_j v‖ ≤ η ‖p_i v‖` with `0 ≤ η` and `η * 2(L-1) < 1` gives a uniform
+positive lower bound on the parent Hamiltonian, independent of the chain length.
+
+This is the version of `parentHamiltonian_gapped` with an arbitrary compression
+constant.  It is the appropriate target if the principal-angle estimates cited
+in arXiv:2011.12127, Section IV.C, first produce an unspecified positive
+compression constant rather than the explicit coefficient
+`(1 - 1/(4L)) / (2(L-1))`. -/
+theorem parentHamiltonian_gapped_of_overlap_norm_constant
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
+    (hηnonneg : 0 ≤ η)
+    (hηlt : η * (((2 * (L - 1) : ℕ) : ℝ)) < 1)
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L i v‖) :
+    ∃ γ > 0, ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
+  obtain ⟨hγ, hgap⟩ :=
+    parentHamiltonianES_gap_bound_of_overlap_norm_constant A L hL hηnonneg
+      hηlt hOverlapNorm
+  exact ⟨1 - η * (((2 * (L - 1) : ℕ) : ℝ)), hγ, hgap⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
@@ -217,6 +217,39 @@
     $\gamma_L=1/(4L)$.
 \end{proof}
 
+\begin{theorem}[Gap bound from a strict cyclic compression constant]
+    \label{thm:friedrichs_gap_bound_constant}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_overlap_norm_constant}
+    \leanok
+    \uses{lem:parent_hamiltonian_cyclic_overlap_norm_constant_gap}
+    Let $L>1$. Put $m=2(L-1)$. Suppose that there is a constant $\eta\ge0$
+    such that $\eta m<1$, and suppose that, for every
+    $N\ge2L$ and every overlapping off-diagonal pair of cyclic length-$L$
+    windows,
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le
+        \eta\,\|h_{i,\mathrm{ES}}v\|.
+    \]
+    Then the parent Hamiltonian has the gap constant $1-\eta m>0$. Concretely,
+    if $N\ge2L$ and $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$, then
+    \[
+        (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_constant_gap}, with
+    $\gamma=1-\eta m$, applies to the displayed hypothesis
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le
+        \eta\,\|h_{i,\mathrm{ES}}v\|.
+    \]
+    It gives $0<1-\eta m$ and the stated norm lower bound.
+\end{proof}
+
 \begin{theorem}[Conditional spectral gap for MPS parent Hamiltonians]
     \label{thm:parent_hamiltonian_gapped}
     \lean{MPSTensor.parentHamiltonian_gapped}
@@ -238,4 +271,30 @@
     \leanok
     This follows immediately from Theorem~\ref{thm:friedrichs_gap_bound} by
     taking $\gamma$ to be the explicit constant produced there.
+\end{proof}
+
+\begin{theorem}[Conditional spectral gap from a strict cyclic compression constant]
+    \label{thm:parent_hamiltonian_gapped_constant}
+    \lean{MPSTensor.parentHamiltonian_gapped_of_overlap_norm_constant}
+    \leanok
+    \uses{thm:friedrichs_gap_bound_constant}
+    For a tensor $A$ and a range $L>1$, suppose there is a constant
+    $\eta\ge0$ such that $\eta\,2(L-1)<1$ and, for every $N\ge2L$ and every
+    overlapping off-diagonal pair of cyclic length-$L$ windows,
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le
+        \eta\,\|h_{i,\mathrm{ES}}v\|.
+    \]
+    Then there exists $\gamma>0$ such that, for every $N\ge2L$ and every vector
+    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
+    \[
+        \gamma\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    This follows from Theorem~\ref{thm:friedrichs_gap_bound_constant} by taking
+    $\gamma=1-\eta\,2(L-1)$.
 \end{proof}


### PR DESCRIPTION
## Summary

This PR adds the positive-gap consequences for an arbitrary strict overlapping-window compression constant.

The new statements say that if the cyclic-window estimate has a constant \(\eta\ge 0\) satisfying \(\eta\,2(L-1)<1\), then the martingale argument gives the explicit positive lower bound \(1-\eta\,2(L-1)\), and hence a uniform spectral gap. This is the form needed when the FNW--Nachtergaele--Kastoryano principal-angle argument first supplies an unspecified strict compression constant.

The review update removes the surplus injectivity hypothesis from the two new arbitrary-constant statements and rewrites the blueprint proof sketch with the displayed compression inequality.

The PR does not prove the remaining Friedrichs/principal-angle estimate itself.

Refs #952.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Gap`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `cd blueprint && PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint checkdecls`