### PR TITLE
feat(MPS/ParentHamiltonian): record NNCPH ground-state clause

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.ParentHamiltonian.Defs
+import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.RFP.CommutingBridge
 import TNLean.MPS.RFP.Defs
@@ -21,6 +21,8 @@ parent Hamiltonians (NNCPH).
   Hamiltonian on `N` sites with block length `L` mutually commute.
 * `MPSTensor.IsNNCPH A N` — nearest-neighbor commuting parent Hamiltonian
   (`L = 2`).
+* `MPSTensor.IsNNCPHGroundState A N` — the nearest-neighbor local terms commute
+  and annihilate the periodic MPS vector.
 
 ## Main results
 
@@ -36,6 +38,8 @@ parent Hamiltonians (NNCPH).
   `Axioms.rfp_to_nncph_commute`.
 * `MPSTensor.rfp_implies_nncph` — construction for the RFP `⟹` NNCPH direction of
   Theorem 3.10.
+* `MPSTensor.rfp_implies_nncph_ground_state` — the same direction with the
+  frustration-free ground-state condition for the MPS vector included.
 * `MPSTensor.nncph_implies_rfp` — construction for the NNCPH `⟹` RFP direction of
   Theorem 3.10.
 
@@ -68,10 +72,41 @@ See arXiv:1606.00608, Definition 3.9. -/
 def IsNNCPH (A : MPSTensor d D) (N : ℕ) : Prop :=
   IsCommutingParentHam A 2 N
 
+/-- The ground-state condition for a nearest-neighbor commuting
+parent Hamiltonian: the length-two local terms commute and annihilate the
+periodic MPS vector V^{(N)}(A).
+
+See arXiv:1606.00608, Theorem 3.10(iii), source line 539. This predicate records
+the ground-vector part of the statement; the full source theorem also includes
+canonical-form and zero-correlation-length equivalences. -/
+def IsNNCPHGroundState (A : MPSTensor d D) (N : ℕ) : Prop :=
+  IsNNCPH A N ∧ IsFrustrationFree A 2 N (mpv A)
+
 /-- NNCPH is a special case of commuting parent Hamiltonian. -/
 theorem IsNNCPH.isCommutingParentHam {A : MPSTensor d D} {N : ℕ} (h : IsNNCPH A N) :
     IsCommutingParentHam A 2 N :=
   h
+
+/-- A nearest-neighbor commuting parent-Hamiltonian ground state has commuting
+length-two local terms. -/
+theorem IsNNCPHGroundState.isNNCPH {A : MPSTensor d D} {N : ℕ}
+    (h : IsNNCPHGroundState A N) :
+    IsNNCPH A N :=
+  h.1
+
+/-- A nearest-neighbor commuting parent-Hamiltonian ground state is
+frustration-free for the length-two parent Hamiltonian. -/
+theorem IsNNCPHGroundState.isFrustrationFree {A : MPSTensor d D} {N : ℕ}
+    (h : IsNNCPHGroundState A N) :
+    IsFrustrationFree A 2 N (mpv A) :=
+  h.2
+
+/-- If the length-two parent terms commute and N ≥ 2, then the periodic MPS
+vector is a ground state of a nearest-neighbor commuting parent Hamiltonian. -/
+theorem IsNNCPH.isNNCPHGroundState {A : MPSTensor d D} {N : ℕ}
+    (h : IsNNCPH A N) (hN : 2 ≤ N) :
+    IsNNCPHGroundState A N :=
+  ⟨h, parentHamiltonian_frustrationFree A 2 N hN⟩
 
 /-- If the two-site parent terms are idempotents `pᵢ` with
 `pᵢpⱼ = pⱼpᵢ`, then the nearest-neighbor parent Hamiltonian is commuting on
@@ -141,6 +176,20 @@ theorem rfp_implies_nncph (A : MPSTensor d D) [NeZero D]
   unfold IsNNCPH IsCommutingParentHam
   intro i j
   exact Axioms.rfp_to_nncph_commute A hNT hRFP N hN i j
+
+/-- **Theorem 3.10(i)⟹(iii)** (arXiv:1606.00608), ground-vector form:
+RFP implies that the periodic MPS vector is a ground state of a
+nearest-neighbor commuting parent Hamiltonian on every chain of length at least
+two.
+
+This theorem adds the frustration-free ground-state equation to
+`rfp_implies_nncph`. It does not prove the full three-way equivalence of
+Theorem 3.10. -/
+theorem rfp_implies_nncph_ground_state (A : MPSTensor d D) [NeZero D]
+    (hRFP : IsRFP A) (hNT : IsNormal A)
+    (N : ℕ) (hN : 2 ≤ N) :
+    IsNNCPHGroundState A N :=
+  (rfp_implies_nncph A hRFP hNT N hN).isNNCPHGroundState hN
 
 /-- **Theorem 3.10(iii)⟹(i)** (arXiv:1606.00608): NNCPH implies RFP.
 Gated on S. Beigi, *J. Phys. A: Math. Theor.* **45** (2012) 025306 —

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_commuting_parent_hamiltonians.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_commuting_parent_hamiltonians.tex
@@ -22,26 +22,73 @@ interaction projectors commute with each other.
     See Ref.~\cite[Definition~3.9]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{definition}[Ground state of a nearest-neighbor commuting parent Hamiltonian]%
+    \label{def:is_nncph_ground_state}
+    \lean{MPSTensor.IsNNCPHGroundState}
+    \leanok
+    \uses{def:is_nncph, def:is_frustration_free}
+    The MPS vector $V^{(N)}(A)$ is a ground state of a nearest-neighbor
+    commuting parent Hamiltonian when the length-two local terms commute and
+    annihilate the vector:
+    \[
+        h_i h_j = h_j h_i,\qquad
+        h_i V^{(N)}(A)=0.
+    \]
+    This is the ground-state condition appearing in
+    Ref.~\cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{remark}[Elementary consequences of the commuting definition]
     \lean{MPSTensor.IsNNCPH.isCommutingParentHam}
+    \lean{MPSTensor.IsNNCPHGroundState.isNNCPH}
+    \lean{MPSTensor.IsNNCPHGroundState.isFrustrationFree}
+    \lean{MPSTensor.IsNNCPH.isNNCPHGroundState}
     \lean{MPSTensor.IsCommutingParentHam.symm}
     \lean{MPSTensor.IsCommutingParentHam.ham_comm_localTerm}
     \leanok
-    The nearest-neighbor condition is simply the length-$2$ specialization of the general
-    commuting condition; the latter is symmetric in the two sites, and it implies that the
-    full parent Hamiltonian commutes with each local interaction term.
+    \uses{lem:parent_hamiltonian_ff}
+    The nearest-neighbor condition is the length-$2$ specialization of the
+    general commuting condition. The ground-state condition contains this
+    commuting equation and the frustration-free equation for $V^{(N)}(A)$.
+    For $N\ge 2$, Lemma~\ref{lem:parent_hamiltonian_ff} with $L=2$ gives
+    \[
+        h_i\,V^{(N)}(A)=0
+    \]
+    for every site $i$.
 \end{remark}
 
 \begin{theorem}[RFP implies NNCPH]\label{thm:rfp_implies_nncph}
     \lean{MPSTensor.rfp_implies_nncph}
     \leanok
     \uses{def:is_rfp, def:is_nncph, def:normal}
-    If $A$ is a normal renormalization fixed point, then for every chain length
-    $N \ge 2$ the parent Hamiltonian with $L = 2$ has commuting local terms.
+    If $A$ has nonzero virtual dimension and is a normal renormalization fixed
+    point, then for every chain length $N \ge 2$ the parent Hamiltonian with
+    $L = 2$ has commuting local terms.
     This implication is cited here from the product-of-entangled-pairs
     description in Appendix~B of
     Theorem~3.10 in~\cite{Cirac2016MPDO_arXiv}.
 \end{theorem}
+
+\begin{theorem}[RFP gives a ground state of a NNCPH]%
+    \label{thm:rfp_implies_nncph_ground_state}
+    \lean{MPSTensor.rfp_implies_nncph_ground_state}
+    \leanok
+    \uses{thm:rfp_implies_nncph, def:is_nncph_ground_state}
+    If $A$ has nonzero virtual dimension and is a normal renormalization fixed
+    point, then for every chain length $N \ge 2$ the MPS vector $V^{(N)}(A)$ is
+    a ground state of a nearest-neighbor commuting parent Hamiltonian:
+    \[
+        h_i h_j = h_j h_i,\qquad
+        h_i V^{(N)}(A)=0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:rfp_implies_nncph, lem:parent_hamiltonian_ff}
+    The first equation is Theorem~\ref{thm:rfp_implies_nncph}. The second is
+    Lemma~\ref{lem:parent_hamiltonian_ff} with $L=2$.
+\end{proof}
 
 \begin{remark}[Product-of-pairs equations for NNCPH]%
     \label{rem:product_pair_projectors}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -1,0 +1,109 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The NNCPH ground-state clause in Cirac--Perez-Garcia--Schuch--Verstraete 2016}
+\author{}
+\date{2026-06-12}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+The pure-state main theorem of \cite{Cirac2016MPDO_arXiv} states that, for a
+tensor $A$ in canonical form generating a family of MPS, the following
+conditions are equivalent:\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:534--540}, label
+\path{thm:main-MPS}.}
+\begin{align}
+  \mathrm{RFP}(A),\qquad
+  \mathrm{ZCL}(A),\qquad
+  \forall N>2,\; |V^{(N)}(A)\rangle
+  \text{ is a ground state of a NNCPH}.
+\end{align}
+The formal implication below is stated for $N\ge2$; it therefore includes the
+extra endpoint $N=2$.
+The preceding definition constructs
+\begin{align}
+  H_L^{(N)}=\sum_{j=0}^{N-1}\tau_j(P_L^\perp)
+\end{align}
+and says that a commuting parent Hamiltonian satisfies
+\begin{align}
+  [\tau_j(P_L),P_L]=0,\qquad j=1,\ldots,L-1.
+\end{align}
+A nearest-neighbor parent Hamiltonian has $L=2$.\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:517--524}.}
+For $L=2$, write
+\begin{align}
+  h_i=\tau_i(P_2^\perp)
+\end{align}
+for the translated two-site interaction. Under the periodic translation
+convention, the source commutation relation $[\tau_1(P_2),P_2]=0$ is the
+nearest-neighbor instance of the commutation relation for $h_i$ after passing to
+orthogonal complements; disjoint translated two-site terms commute by locality.
+
+\section{Formal boundary}
+
+With $h_i=\tau_i(P_2^\perp)$ as above, the current predicate
+\leanid{MPSTensor.IsNNCPH} records the resulting length-two commutation equation
+\begin{align}
+  h_i h_j = h_j h_i
+  \qquad (i,j\in\{0,\ldots,N-1\}).
+\end{align}
+The predicate
+\leanid{MPSTensor.IsNNCPHGroundState} adds the following frustration-free
+ground-vector equation for the same translated length-two interaction:
+\begin{align}
+  h_i\,V^{(N)}(A)=0
+  \qquad (i\in\{0,\ldots,N-1\}).
+\end{align}
+Thus it records the annihilation part of the ground-state clause of
+Theorem~3.10(iii) for the canonical projector parent interaction used in the
+formal development. The source definition of a parent Hamiltonian also requires
+the whole ground-state subspace to be spanned by the periodic MPS vectors for
+$N>L$. That spanning condition is not part of
+\leanid{MPSTensor.IsNNCPHGroundState}; the present predicate is therefore a
+necessary finite-chain ground-vector condition, not the complete source
+ground-space statement.
+
+This still does not prove the full source theorem.  The present declarations do
+not yet include the three-way equivalence with ZCL, the complete canonical-form
+hypotheses from the source statement, or the Beigi ground-space characterization
+as an internal theorem.  The reverse direction still depends on the axiom
+\leanid{Axioms.beigi_nncph_to_rfp}, and the RFP-to-NNCPH direction still depends
+on \leanid{Axioms.rfp_to_nncph_commute}.
+
+\section{Elimination plan}
+
+A source-faithful formalization should replace the axiom-backed implications by
+proved theorems and state the three-way equivalence for canonical-form tensors,
+including the spanning condition in the parent-Hamiltonian ground-space clause:
+\begin{align}
+  \mathrm{RFP}(A)
+  \Longleftrightarrow
+  \mathrm{ZCL}(A)
+  \Longleftrightarrow
+  \forall N>2,\; |V^{(N)}(A)\rangle
+  \text{ is a ground state of a NNCPH}.
+\end{align}
+The forward implication can use the product-of-entangled-pairs form in the proof
+of Theorem~3.11.  The reverse implication must internalize Beigi's
+one-dimensional nearest-neighbor commuting-Hamiltonian ground-space
+classification and identify the resulting locally orthogonal states with the
+basis of normal tensors of $A$.\footnote{Tracked by \ghissue{2633}.}
+
+The present formal result is therefore a scope restriction: it names the
+ground-state clause and proves the RFP-to-ground-state implication from the
+already axiomatized commutation direction together with frustration-freeness of
+the MPS vector for the canonical parent interaction.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

This PR adds a predicate for the ground-state clause in the pure-state NNCPH part of arXiv:1606.00608, Theorem 3.10.

The new Lean predicate records the two equations currently formalized for the canonical parent interaction:

\[
  h_i h_j = h_j h_i,
  \qquad
  h_i V^{(N)}(A)=0.
\]

It also adds the elementary implication from the existing RFP-to-NNCPH theorem to this ground-state predicate for nonzero virtual dimension, using the already-proved frustration-freeness of the MPS vector for the parent interaction.

This PR does not prove the full three-way equivalence RFP = ZCL = NNCPH ground state. The reverse direction is still axiom-backed, and the new paper-gap note records the remaining source-faithfulness boundary, including the still-missing spanning statement for the parent-Hamiltonian ground space.

Refs #2633.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.Commuting`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint checkdecls`
- `cd blueprint && PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `git diff --check`

The full build reports only pre-existing warnings in unrelated PEPS, MPDO, and periodic-overlap files.