### PR TITLE
feat(PEPS): Fundamental Theorem for normal MPS on a closed chain

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -603,3 +603,12 @@ import TNLean.PEPS.NormalComparisonScalar
 -- The Fundamental Theorem for normal PEPS on a connected graph: the
 -- scalar-free local gauge and its per-edge uniqueness up to a constant.
 import TNLean.PEPS.NormalGeneralFundamentalTheorem
+-- Arcs of consecutive sites on the cycle graph: the blocks of the
+-- closed-chain MPS corollary of the normal PEPS Fundamental Theorem.
+import TNLean.PEPS.CycleArcRegion
+-- The cycle blocking data: per-edge three-block chains, one-site comparison
+-- regions, and the single-crossing property on the closed chain.
+import TNLean.PEPS.CycleBlockingData
+-- The Fundamental Theorem for normal MPS on a closed chain: the MPS
+-- corollary of the normal PEPS Fundamental Theorem, with gauge uniqueness.
+import TNLean.PEPS.CycleFundamentalTheorem

--- a/TNLean/PEPS/CycleArcRegion.lean
+++ b/TNLean/PEPS/CycleArcRegion.lean
@@ -1,0 +1,297 @@
+import Mathlib.Combinatorics.SimpleGraph.Circulant
+import TNLean.PEPS.InjectiveRegion
+
+/-!
+# Arcs of consecutive sites on the cycle graph
+
+The first corollary after the general normal PEPS theorem (arXiv:1804.04964,
+Section 3, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`) is set on
+a closed chain of `n` sites: the sites are labelled `1, …, n` with
+`n + 1 ≡ 1`, and the hypothesis is that blocking any `L` consecutive sites
+gives an injective tensor.  The closed chain is the cycle graph on `Fin n`
+(`SimpleGraph.cycleGraph`), and a block of consecutive sites is an arc: the
+`len` consecutive vertices starting at `s` are the vertices `w` whose cyclic
+distance from `s` is less than `len`.
+
+This file records the arc geometry consumed by the cycle blocking
+construction: membership, arcs described from their last site, complements of
+arcs, the decomposition of a longer arc into a union of length-`L` arcs,
+disjointness of two adjacent arcs, the unique nearest-neighbour pair joining
+two adjacent arcs, and the resulting injectivity of all arcs of length at
+least `L` from the injectivity of the length-`L` arcs.  These are the cycle
+analogues of the torus rectangle lemmas of
+`TNLean/PEPS/TorusRectangleRegion.lean`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, first corollary after the theorem labelled `normal`, lines
+  1585--1622 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {n : ℕ}
+
+/-! ### Cyclic distance arithmetic
+
+The arc computations reduce to natural-number arithmetic through the
+if-then-else form of the value of a difference in `Fin n`.  This is the
+`ℕ`-valued counterpart of `Fin.intCast_val_sub_eq_sub_add_ite`. -/
+
+/-- The value of a difference in `Fin n`: the plain difference when the
+subtrahend value is not larger, and the wrapped difference otherwise. -/
+theorem val_sub_eq_ite (u v : Fin n) :
+    (u - v).val = if v.val ≤ u.val then u.val - v.val else u.val + n - v.val := by
+  have h := Fin.intCast_val_sub_eq_sub_add_ite u v
+  simp only [Fin.le_def] at h
+  have hu := u.isLt
+  split at h <;> split <;> omega
+
+/-! ### Arcs of consecutive vertices -/
+
+/-- The arc of `len` consecutive vertices starting at `s`: the vertices `w`
+whose cyclic distance from `s` is less than `len`.  This is the block of `len`
+consecutive sites of the source corollary, read clockwise from `s`.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`. -/
+def cycleArcFrom (s : Fin n) (len : ℕ) : Finset (Fin n) :=
+  Finset.univ.filter fun w => (w - s).val < len
+
+@[simp] theorem mem_cycleArcFrom {s w : Fin n} {len : ℕ} :
+    w ∈ cycleArcFrom s len ↔ (w - s).val < len := by
+  simp [cycleArcFrom]
+
+/-- The arc of `len` consecutive vertices ending at `t`: the vertices `w`
+whose cyclic distance to `t` is less than `len`.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`. -/
+def cycleArcTo (t : Fin n) (len : ℕ) : Finset (Fin n) :=
+  Finset.univ.filter fun w => (t - w).val < len
+
+@[simp] theorem mem_cycleArcTo {t w : Fin n} {len : ℕ} :
+    w ∈ cycleArcTo t len ↔ (t - w).val < len := by
+  simp [cycleArcTo]
+
+/-- A nonempty arc contains its first vertex. -/
+theorem start_mem_cycleArcFrom {s : Fin n} {len : ℕ} (hlen : 0 < len) :
+    s ∈ cycleArcFrom s len := by
+  simp [val_sub_eq_ite, hlen]
+
+/-- A nonempty arc contains its last vertex. -/
+theorem last_mem_cycleArcTo {t : Fin n} {len : ℕ} (hlen : 0 < len) :
+    t ∈ cycleArcTo t len := by
+  simp [val_sub_eq_ite, hlen]
+
+/-- An arc described from its last vertex is the arc starting `len - 1`
+vertices earlier. -/
+theorem cycleArcTo_eq_cycleArcFrom {t : Fin n} {len : ℕ} (hlen : 0 < len) (hn : len ≤ n) :
+    cycleArcTo t len = cycleArcFrom (t - ⟨len - 1, by omega⟩) len := by
+  ext w
+  simp only [mem_cycleArcTo, mem_cycleArcFrom, val_sub_eq_ite]
+  have hw := w.isLt
+  have ht := t.isLt
+  split_ifs <;> omega
+
+/-- The complement of an arc shorter than the whole cycle is the arc of the
+remaining vertices, starting where the first arc ends. -/
+theorem compl_cycleArcFrom {s : Fin n} {len : ℕ} (hlen : len < n) :
+    Finset.univ \ cycleArcFrom s len = cycleArcFrom (s + ⟨len, hlen⟩) (n - len) := by
+  ext w
+  simp only [Finset.mem_sdiff, Finset.mem_univ, mem_cycleArcFrom, true_and, not_lt,
+    val_sub_eq_ite, Fin.val_add_eq_ite]
+  have hw := w.isLt
+  have hs := s.isLt
+  split_ifs <;> omega
+
+/-- An arc of length between `L` and `n` is the union of its length-`L`
+subarcs.  This realizes a longer block of consecutive sites as a union of
+length-`L` blocks, the shape to which the source's union lemma applies.
+
+Source: arXiv:1804.04964, Section 3, Lemma labelled `injective_union` and the
+examples following it, lines 1322--1430 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem cycleArcFrom_eq_biUnion {s : Fin n} {L len : ℕ} (hL : 0 < L) (hlen : L ≤ len)
+    (hn : len ≤ n) :
+    cycleArcFrom s len =
+      (Finset.univ.filter fun c : Fin n => c.val ≤ len - L).biUnion
+        (fun c => cycleArcFrom (s + c) L) := by
+  ext w
+  simp only [mem_cycleArcFrom, Finset.mem_biUnion, Finset.mem_filter, Finset.mem_univ, true_and]
+  have hw := w.isLt
+  have hs := s.isLt
+  constructor
+  · intro hmem
+    by_cases hsmall : (w - s).val ≤ len - L
+    · refine ⟨w - s, hsmall, ?_⟩
+      simp only [val_sub_eq_ite, Fin.val_add_eq_ite] at hmem hsmall ⊢
+      split_ifs at hmem hsmall ⊢ <;> omega
+    · refine ⟨⟨len - L, by omega⟩, le_refl _, ?_⟩
+      simp only [val_sub_eq_ite, Fin.val_add_eq_ite] at hmem hsmall ⊢
+      split_ifs at hmem hsmall ⊢ <;> omega
+  · rintro ⟨c, hc, hwc⟩
+    have hclt := c.isLt
+    simp only [val_sub_eq_ite, Fin.val_add_eq_ite] at hwc ⊢
+    split_ifs at hwc ⊢ <;> omega
+
+/-! ### Injectivity of arcs of length at least `L`
+
+If every length-`L` arc is injective and injectivity is closed under unions,
+then every arc of length between `L` and `n` is injective, being a union of
+length-`L` arcs.  This is the source's use of the union lemma to make longer
+consecutive blocks injective. -/
+
+/-- Every arc of length between `L` and `n` is injective when every length-`L`
+arc is injective and injectivity is closed under unions.
+
+Source: arXiv:1804.04964, Section 3, Lemma labelled `injective_union`, lines
+1322--1404 of `Papers/1804.04964/paper_normal.tex`, applied to blocks of
+consecutive sites. -/
+theorem isInjective_cycleArcFrom_of_le {κ : RegionInjectivityData (Fin n)}
+    (hUnion : RegionInjectivityUnionClosure κ) {L : ℕ}
+    (harc : ∀ s : Fin n, κ.IsInjective (cycleArcFrom s L)) (hL : 0 < L)
+    {len : ℕ} (hlen : L ≤ len) (hn : len ≤ n) (s : Fin n) :
+    κ.IsInjective (cycleArcFrom s len) := by
+  rw [cycleArcFrom_eq_biUnion hL hlen hn]
+  have h0 : 0 < n := by omega
+  exact hUnion.biUnion_injective
+    ⟨⟨0, h0⟩, by simp⟩ _ (fun c _ => harc _)
+
+/-- Every length-`L` arc described from its last vertex is injective when
+every length-`L` arc is injective.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem isInjective_cycleArcTo {κ : RegionInjectivityData (Fin n)} {L : ℕ}
+    (harc : ∀ s : Fin n, κ.IsInjective (cycleArcFrom s L)) (hL : 0 < L)
+    (hn : L ≤ n) (t : Fin n) :
+    κ.IsInjective (cycleArcTo t L) := by
+  rw [cycleArcTo_eq_cycleArcFrom hL hn]
+  exact harc _
+
+section NeZero
+
+variable [NeZero n]
+
+/-! ### The cycle graph in successor form
+
+The cycle-graph adjacency of Mathlib is phrased through differences of
+values; the blocking construction reads it as "one endpoint is the cyclic
+successor of the other". -/
+
+theorem val_one_of_two_le (hn : 2 ≤ n) : ((1 : Fin n) : ℕ) = 1 := by
+  rw [Fin.val_one']; exact Nat.mod_eq_of_lt (by omega)
+
+/-- Two vertices of the cycle graph are adjacent exactly when one is the
+cyclic successor of the other. -/
+theorem cycleGraph_adj_iff_add_one (hn : 3 ≤ n) {u w : Fin n} :
+    (SimpleGraph.cycleGraph n).Adj u w ↔ u + 1 = w ∨ w + 1 = u := by
+  have h1 := val_one_of_two_le (n := n) (by omega)
+  rw [SimpleGraph.cycleGraph_adj']
+  simp only [Fin.ext_iff, val_sub_eq_ite, Fin.val_add_eq_ite, h1]
+  have hu := u.isLt
+  have hw := w.isLt
+  split_ifs <;> omega
+
+/-- On a cycle of at least three vertices, no pair of vertices is each the
+cyclic successor of the other. -/
+theorem not_add_one_eq_and_add_one_eq (hn : 3 ≤ n) {u w : Fin n} :
+    ¬(u + 1 = w ∧ w + 1 = u) := by
+  have h1 := val_one_of_two_le (n := n) (by omega)
+  simp only [Fin.ext_iff, Fin.val_add_eq_ite, h1]
+  have hu := u.isLt
+  have hw := w.isLt
+  split_ifs <;> omega
+
+/-! ### Two adjacent arcs around an edge
+
+For the edge between a vertex `a` and its cyclic successor `a + 1`, the source
+blocks the chain into the `L` sites ending at `a`, the `L` sites starting at
+`a + 1`, and the remaining `n - 2L` sites. -/
+
+/-- The `L` sites ending at `a` and the `L` sites starting at `a + 1` are
+disjoint on a cycle of at least `2L` sites. -/
+theorem disjoint_cycleArcTo_cycleArcFrom_add_one {a : Fin n} {L : ℕ} (hL : 0 < L)
+    (hn : 2 * L ≤ n) :
+    Disjoint (cycleArcTo a L) (cycleArcFrom (a + 1) L) := by
+  have h1 := val_one_of_two_le (n := n) (by omega)
+  rw [Finset.disjoint_left]
+  intro w hw hw'
+  simp only [mem_cycleArcTo, mem_cycleArcFrom, val_sub_eq_ite, Fin.val_add_eq_ite, h1]
+    at hw hw'
+  have hwlt := w.isLt
+  have ha := a.isLt
+  split_ifs at hw hw' <;> omega
+
+/-- The vertices outside the two adjacent length-`L` arcs around the edge from
+`a` to `a + 1` form the arc of the remaining `n - 2L` consecutive sites. -/
+theorem compl_cycleArcTo_union_cycleArcFrom_add_one {a : Fin n} {L : ℕ} (hL : 0 < L)
+    (hn : 3 * L ≤ n) :
+    Finset.univ \ (cycleArcTo a L ∪ cycleArcFrom (a + 1) L) =
+      cycleArcFrom (a + 1 + ⟨L, by omega⟩) (n - 2 * L) := by
+  have h1 := val_one_of_two_le (n := n) (by omega)
+  ext w
+  simp only [Finset.mem_sdiff, Finset.mem_univ, Finset.mem_union, mem_cycleArcTo,
+    mem_cycleArcFrom, true_and, val_sub_eq_ite, Fin.val_add_eq_ite, h1, not_or, not_lt]
+  have hwlt := w.isLt
+  have ha := a.isLt
+  split_ifs <;> omega
+
+/-- The only nearest-neighbour pair joining the `L` sites ending at `a` to the
+`L` sites starting at `a + 1` is the pair `(a, a + 1)` itself: on a cycle of
+at least `3L` sites the far ends of the two arcs are separated by the
+remaining `n - 2L ≥ L` sites.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`,
+via the blocking of the proof of Theorem 3 (lines 1475--1500). -/
+theorem eq_of_adj_mem_cycleArcTo_mem_cycleArcFrom {a u w : Fin n} {L : ℕ} (hL : 0 < L)
+    (hn : 3 * L ≤ n) (hadj : u + 1 = w ∨ w + 1 = u)
+    (hu : u ∈ cycleArcTo a L) (hw : w ∈ cycleArcFrom (a + 1) L) :
+    u = a ∧ w = a + 1 := by
+  have h1 := val_one_of_two_le (n := n) (by omega)
+  simp only [mem_cycleArcTo, mem_cycleArcFrom, val_sub_eq_ite, Fin.val_add_eq_ite, h1]
+    at hu hw
+  simp only [Fin.ext_iff, Fin.val_add_eq_ite, h1] at hadj ⊢
+  have hwlt := w.isLt
+  have ha := a.isLt
+  have hult := u.isLt
+  constructor
+  · split_ifs at hu hw hadj ⊢ <;> omega
+  · split_ifs at hu hw hadj ⊢ <;> omega
+
+/-! ### One-site comparison arcs
+
+The general normal PEPS theorem asks, at every site, for two injective
+regions with injective complements differing exactly at that site.  On the
+cycle these are the `L + 1` sites starting at `v` and the `L` sites starting
+at `v + 1`. -/
+
+/-- A vertex does not lie on the `L` sites starting at its cyclic successor
+when `L < n`. -/
+theorem self_notMem_cycleArcFrom_add_one {v : Fin n} {L : ℕ} (hL : 0 < L) (hn : L < n) :
+    v ∉ cycleArcFrom (v + 1) L := by
+  have h1 := val_one_of_two_le (n := n) (by omega)
+  simp only [mem_cycleArcFrom, val_sub_eq_ite, Fin.val_add_eq_ite, h1, not_lt]
+  have hv := v.isLt
+  split_ifs <;> omega
+
+/-- Away from `v`, the `L + 1` sites starting at `v` are the `L` sites
+starting at `v + 1`. -/
+theorem mem_cycleArcFrom_succ_iff_of_ne {v w : Fin n} {L : ℕ} (hn : 2 ≤ n) (hvw : w ≠ v) :
+    (w ∈ cycleArcFrom v (L + 1)) ↔ w ∈ cycleArcFrom (v + 1) L := by
+  have h1 := val_one_of_two_le (n := n) hn
+  have hne : w.val ≠ v.val := fun h => hvw (Fin.ext h)
+  simp only [mem_cycleArcFrom, val_sub_eq_ite, Fin.val_add_eq_ite, h1]
+  have hv := v.isLt
+  have hw := w.isLt
+  split_ifs <;> omega
+
+end NeZero
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/CycleBlockingData.lean
+++ b/TNLean/PEPS/CycleBlockingData.lean
@@ -1,0 +1,353 @@
+import TNLean.PEPS.CycleArcRegion
+import TNLean.PEPS.NormalBlocking
+import TNLean.PEPS.RegionBlock.CoarseThreeSite2
+
+/-!
+# Blocking data for normal MPS on the cycle graph
+
+The first corollary after the general normal PEPS theorem (arXiv:1804.04964,
+Section 3, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`) concerns
+two MPS on a closed chain of `n ≥ 3L` sites such that blocking any `L`
+consecutive sites gives an injective tensor.  This file builds, from that
+arc-injectivity hypothesis, the blocking hypotheses consumed by the general
+normal PEPS theorem on the cycle graph:
+
+* around the edge joining a vertex to its cyclic successor, the chain is
+  blocked into the `L` sites ending at the first endpoint, the `L` sites
+  starting at the second, and the remaining `n - 2L ≥ L` sites — three
+  injective blocks covering the chain;
+* at every site, the `L + 1` sites starting at the site and the `L` sites
+  starting at its successor are injective regions with injective complements
+  differing exactly at the site;
+* the only nearest-neighbour pair joining the two blocks around an edge is
+  the edge itself, the single-crossing hypothesis of the general theorem.
+
+Longer blocks of consecutive sites are injective as unions of length-`L`
+blocks, which is the source's use of its union lemma (arXiv:1804.04964,
+Section 3, Lemma labelled `injective_union`, lines 1322--1404).
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, first corollary after the theorem labelled `normal`, lines
+  1585--1622 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+namespace TNLean
+namespace PEPS
+
+variable {n : ℕ}
+
+/-! ### The arc-injectivity hypotheses -/
+
+/-- The arc-injectivity hypotheses of the source corollary: every block of `L`
+consecutive sites of the cycle is injective.  This is the cycle counterpart of
+the torus `NormalTorusRectangleInjectivityHypotheses`.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`:
+"blocking any `L` consecutive sites results in an injective tensor". -/
+structure NormalCycleArcInjectivityHypotheses (L : ℕ) (κ : RegionInjectivityData (Fin n)) where
+  /-- Every block of `L` consecutive sites is injective. -/
+  arc_injective : ∀ s : Fin n, κ.IsInjective (cycleArcFrom s L)
+
+section NeZero
+
+variable [NeZero n]
+
+/-! ### The two blocks around an edge
+
+The edge type orients an edge by the linear order on `Fin n`, while the
+blocking is described along the cyclic order: around the edge joining `a` to
+its cyclic successor `a + 1`, the first block is the `L` sites ending at `a`
+and the second is the `L` sites starting at `a + 1`.  The seam edge (between
+the last and the zeroth vertex) has its endpoints in the opposite linear
+order, so the two blocks are attached to the endpoints by cases on which
+endpoint is the cyclic predecessor of the other. -/
+
+/-- Every edge of the cycle graph joins a vertex to its cyclic successor, in
+one of the two endpoint orders. -/
+theorem cycleEdge_succ_or (hn : 3 ≤ n) (e : Edge (SimpleGraph.cycleGraph n)) :
+    e.1.1 + 1 = e.1.2 ∨ e.1.2 + 1 = e.1.1 :=
+  (cycleGraph_adj_iff_add_one hn).mp e.2.2
+
+/-- The block of `L` consecutive sites on the first-endpoint side of an edge
+of the cycle graph: the `L` sites ending at the first endpoint when the
+second endpoint is its cyclic successor, and the `L` sites starting at the
+first endpoint otherwise.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`,
+via the edge blocking of the proof of Theorem 3 (lines 1475--1500). -/
+def cycleEdgeRed (L : ℕ) (e : Edge (SimpleGraph.cycleGraph n)) : Finset (Fin n) :=
+  if e.1.1 + 1 = e.1.2 then cycleArcTo e.1.1 L else cycleArcFrom e.1.1 L
+
+/-- The block of `L` consecutive sites on the second-endpoint side of an edge
+of the cycle graph, complementary to `cycleEdgeRed`.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`,
+via the edge blocking of the proof of Theorem 3 (lines 1475--1500). -/
+def cycleEdgeBlue (L : ℕ) (e : Edge (SimpleGraph.cycleGraph n)) : Finset (Fin n) :=
+  if e.1.1 + 1 = e.1.2 then cycleArcFrom e.1.2 L else cycleArcTo e.1.2 L
+
+/-- The red block when the second endpoint is the cyclic successor of the
+first. -/
+theorem cycleEdgeRed_of_succ {L : ℕ} {e : Edge (SimpleGraph.cycleGraph n)}
+    (hsucc : e.1.1 + 1 = e.1.2) :
+    cycleEdgeRed L e = cycleArcTo e.1.1 L := if_pos hsucc
+
+/-- The blue block when the second endpoint is the cyclic successor of the
+first. -/
+theorem cycleEdgeBlue_of_succ {L : ℕ} {e : Edge (SimpleGraph.cycleGraph n)}
+    (hsucc : e.1.1 + 1 = e.1.2) :
+    cycleEdgeBlue L e = cycleArcFrom (e.1.1 + 1) L :=
+  (if_pos hsucc).trans (congrArg (fun a => cycleArcFrom a L) hsucc.symm)
+
+/-- The red block when the first endpoint is the cyclic successor of the
+second. -/
+theorem cycleEdgeRed_of_succ' {L : ℕ} {e : Edge (SimpleGraph.cycleGraph n)}
+    (hsucc : ¬e.1.1 + 1 = e.1.2) (hsucc2 : e.1.2 + 1 = e.1.1) :
+    cycleEdgeRed L e = cycleArcFrom (e.1.2 + 1) L :=
+  (if_neg hsucc).trans (congrArg (fun a => cycleArcFrom a L) hsucc2.symm)
+
+/-- The blue block when the first endpoint is the cyclic successor of the
+second. -/
+theorem cycleEdgeBlue_of_succ' {L : ℕ} {e : Edge (SimpleGraph.cycleGraph n)}
+    (hsucc : ¬e.1.1 + 1 = e.1.2) :
+    cycleEdgeBlue L e = cycleArcTo e.1.2 L := if_neg hsucc
+
+/-- The first endpoint of an edge lies in its red block. -/
+theorem left_mem_cycleEdgeRed {L : ℕ} (hL : 0 < L) (e : Edge (SimpleGraph.cycleGraph n)) :
+    e.1.1 ∈ cycleEdgeRed L e := by
+  unfold cycleEdgeRed
+  split_ifs
+  · exact last_mem_cycleArcTo hL
+  · exact start_mem_cycleArcFrom hL
+
+/-- The second endpoint of an edge lies in its blue block. -/
+theorem right_mem_cycleEdgeBlue {L : ℕ} (hL : 0 < L) (e : Edge (SimpleGraph.cycleGraph n)) :
+    e.1.2 ∈ cycleEdgeBlue L e := by
+  unfold cycleEdgeBlue
+  split_ifs
+  · exact start_mem_cycleArcFrom hL
+  · exact last_mem_cycleArcTo hL
+
+/-- The red and blue blocks of an edge are disjoint on a chain of at least
+`3L` sites. -/
+theorem disjoint_cycleEdgeRed_cycleEdgeBlue {L : ℕ} (hL : 0 < L) (hn : 3 * L ≤ n)
+    (e : Edge (SimpleGraph.cycleGraph n)) :
+    Disjoint (cycleEdgeRed L e) (cycleEdgeBlue L e) := by
+  have hn3 : 3 ≤ n := by omega
+  by_cases hsucc : e.1.1 + 1 = e.1.2
+  · rw [cycleEdgeRed_of_succ hsucc, cycleEdgeBlue_of_succ hsucc]
+    exact disjoint_cycleArcTo_cycleArcFrom_add_one hL (by omega)
+  · have hsucc2 := (cycleEdge_succ_or hn3 e).resolve_left hsucc
+    rw [cycleEdgeRed_of_succ' hsucc hsucc2, cycleEdgeBlue_of_succ' hsucc]
+    exact (disjoint_cycleArcTo_cycleArcFrom_add_one hL (by omega)).symm
+
+/-- The union of the red and blue blocks of an edge misses the arc of the
+remaining `n - 2L` consecutive sites; the complementary block is that arc. -/
+theorem compl_cycleEdgeRed_union_cycleEdgeBlue {L : ℕ} (hL : 0 < L) (hn : 3 * L ≤ n)
+    (e : Edge (SimpleGraph.cycleGraph n)) :
+    ∃ s : Fin n,
+      Finset.univ \ (cycleEdgeRed L e ∪ cycleEdgeBlue L e) = cycleArcFrom s (n - 2 * L) := by
+  have hn3 : 3 ≤ n := by omega
+  by_cases hsucc : e.1.1 + 1 = e.1.2
+  · refine ⟨e.1.1 + 1 + ⟨L, by omega⟩, ?_⟩
+    rw [cycleEdgeRed_of_succ hsucc, cycleEdgeBlue_of_succ hsucc]
+    exact compl_cycleArcTo_union_cycleArcFrom_add_one hL hn
+  · have hsucc2 := (cycleEdge_succ_or hn3 e).resolve_left hsucc
+    refine ⟨e.1.2 + 1 + ⟨L, by omega⟩, ?_⟩
+    rw [cycleEdgeRed_of_succ' hsucc hsucc2, cycleEdgeBlue_of_succ' hsucc,
+      Finset.union_comm]
+    exact compl_cycleArcTo_union_cycleArcFrom_add_one hL hn
+
+variable {κ : RegionInjectivityData (Fin n)}
+
+/-- The red block of every edge is injective under the arc-injectivity
+hypotheses. -/
+theorem cycleEdgeRed_injective {L : ℕ} (h : NormalCycleArcInjectivityHypotheses L κ)
+    (hL : 0 < L) (hn : 3 * L ≤ n) (e : Edge (SimpleGraph.cycleGraph n)) :
+    κ.IsInjective (cycleEdgeRed L e) := by
+  unfold cycleEdgeRed
+  split_ifs
+  · exact isInjective_cycleArcTo h.arc_injective hL (by omega) _
+  · exact h.arc_injective _
+
+/-- The blue block of every edge is injective under the arc-injectivity
+hypotheses. -/
+theorem cycleEdgeBlue_injective {L : ℕ} (h : NormalCycleArcInjectivityHypotheses L κ)
+    (hL : 0 < L) (hn : 3 * L ≤ n) (e : Edge (SimpleGraph.cycleGraph n)) :
+    κ.IsInjective (cycleEdgeBlue L e) := by
+  unfold cycleEdgeBlue
+  split_ifs
+  · exact h.arc_injective _
+  · exact isInjective_cycleArcTo h.arc_injective hL (by omega) _
+
+/-! ### The per-edge blocking datum -/
+
+/-- The blocking of the cycle around an edge: the `L` sites on the
+first-endpoint side, the `L` sites on the second-endpoint side, and the
+remaining `n - 2L ≥ L` sites, each block injective, the blocks pairwise
+disjoint and covering the chain.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`
+("two normal MPS on `n ≥ 3L` sites with the property that blocking any `L`
+consecutive sites results in an injective tensor"), realizing the blocking
+into three partite injective MPS around every edge required by the theorem
+labelled `normal` (lines 1576--1583). -/
+def cycleEdgeBlockingData {L : ℕ} (h : NormalCycleArcInjectivityHypotheses L κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hL : 0 < L) (hn : 3 * L ≤ n)
+    (e : Edge (SimpleGraph.cycleGraph n)) :
+    NormalEdgeBlockingData κ (SimpleGraph.cycleGraph n) e where
+  red := cycleEdgeRed L e
+  blue := cycleEdgeBlue L e
+  complement := Finset.univ \ (cycleEdgeRed L e ∪ cycleEdgeBlue L e)
+  left_mem_red := left_mem_cycleEdgeRed hL e
+  right_mem_blue := right_mem_cycleEdgeBlue hL e
+  red_injective := cycleEdgeRed_injective h hL hn e
+  blue_injective := cycleEdgeBlue_injective h hL hn e
+  complement_injective := by
+    obtain ⟨s, hs⟩ := compl_cycleEdgeRed_union_cycleEdgeBlue hL hn e
+    rw [hs]
+    exact isInjective_cycleArcFrom_of_le hUnion h.arc_injective hL (by omega) (by omega) s
+  red_disjoint_blue := disjoint_cycleEdgeRed_cycleEdgeBlue hL hn e
+  red_disjoint_complement :=
+    Disjoint.mono_left Finset.subset_union_left Finset.sdiff_disjoint.symm
+  blue_disjoint_complement :=
+    Disjoint.mono_left Finset.subset_union_right Finset.sdiff_disjoint.symm
+  cover_univ := Finset.union_sdiff_of_subset (Finset.subset_univ _)
+
+/-! ### The single red-to-blue crossing -/
+
+/-- **The red-to-blue crossings of the cycle edge blocking are the single
+distinguished edge.**  On a chain of `n ≥ 3L` sites the far ends of the two
+length-`L` blocks around an edge are separated by the remaining `n - 2L ≥ L`
+sites, so the only nearest-neighbour pair joining the blocks is the edge
+itself.  This is the single-crossing hypothesis of the general normal PEPS
+theorem.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`,
+via the edge blocking of the proof of Theorem 3 (lines 1475--1500). -/
+theorem isCrossingEdge_cycleEdge_iff {d : ℕ} (A : Tensor (SimpleGraph.cycleGraph n) d)
+    {L : ℕ} (hL : 0 < L) (hn : 3 * L ≤ n) (e g : Edge (SimpleGraph.cycleGraph n)) :
+    IsCrossingEdge (G := SimpleGraph.cycleGraph n) A
+        (cycleEdgeRed L e) (cycleEdgeBlue L e) g ↔ g = e := by
+  have hn3 : 3 ≤ n := by omega
+  have hdisj := disjoint_cycleEdgeRed_cycleEdgeBlue hL hn e
+  constructor
+  · rintro ⟨hbR, hbB⟩
+    -- One endpoint of `g` lies in the red block and the other in the blue block.
+    have hsplit : (g.1.1 ∈ cycleEdgeRed L e ∧ g.1.2 ∈ cycleEdgeBlue L e) ∨
+        (g.1.2 ∈ cycleEdgeRed L e ∧ g.1.1 ∈ cycleEdgeBlue L e) := by
+      rcases hbR with ⟨h1, h2⟩ | ⟨h1, h2⟩
+      · rcases hbB with ⟨hb1, hb2⟩ | ⟨hb1, hb2⟩
+        · exact absurd hb1 (Finset.disjoint_left.mp hdisj h1)
+        · exact Or.inl ⟨h1, hb2⟩
+      · rcases hbB with ⟨hb1, hb2⟩ | ⟨hb1, hb2⟩
+        · exact Or.inr ⟨h2, hb1⟩
+        · exact absurd hb2 (Finset.disjoint_left.mp hdisj h2)
+    have hadj : g.1.1 + 1 = g.1.2 ∨ g.1.2 + 1 = g.1.1 :=
+      (cycleGraph_adj_iff_add_one hn3).mp g.2.2
+    by_cases hsucc : e.1.1 + 1 = e.1.2
+    · rw [cycleEdgeRed_of_succ hsucc, cycleEdgeBlue_of_succ hsucc] at hsplit
+      rcases hsplit with ⟨hu, hw⟩ | ⟨hu, hw⟩
+      · obtain ⟨he1, he2⟩ :=
+          eq_of_adj_mem_cycleArcTo_mem_cycleArcFrom hL hn hadj hu hw
+        exact Subtype.ext (Prod.ext he1 (he2.trans hsucc))
+      · obtain ⟨he1, he2⟩ :=
+          eq_of_adj_mem_cycleArcTo_mem_cycleArcFrom hL hn (Or.symm hadj) hu hw
+        -- The crossed orientation contradicts the ordered-endpoint convention.
+        exfalso
+        have hlt := g.2.1
+        rw [he1, he2, hsucc] at hlt
+        exact lt_asymm e.2.1 hlt
+    · have hsucc2 := (cycleEdge_succ_or hn3 e).resolve_left hsucc
+      rw [cycleEdgeRed_of_succ' hsucc hsucc2, cycleEdgeBlue_of_succ' hsucc] at hsplit
+      rcases hsplit with ⟨hu, hw⟩ | ⟨hu, hw⟩
+      · obtain ⟨he1, he2⟩ :=
+          eq_of_adj_mem_cycleArcTo_mem_cycleArcFrom hL hn (Or.symm hadj) hw hu
+        exact Subtype.ext (Prod.ext (he2.trans hsucc2) he1)
+      · obtain ⟨he1, he2⟩ :=
+          eq_of_adj_mem_cycleArcTo_mem_cycleArcFrom hL hn hadj hw hu
+        -- The crossed orientation contradicts the ordered-endpoint convention.
+        exfalso
+        have hlt := g.2.1
+        rw [he1, he2, hsucc2] at hlt
+        exact lt_asymm e.2.1 hlt
+  · rintro rfl
+    have h1 := left_mem_cycleEdgeRed (n := n) hL g
+    have h2 := right_mem_cycleEdgeBlue (n := n) hL g
+    exact ⟨Or.inl ⟨h1, Finset.disjoint_right.mp hdisj h2⟩,
+      Or.inr ⟨Finset.disjoint_left.mp hdisj h1, h2⟩⟩
+
+/-! ### The one-site comparison regions -/
+
+/-- The one-site comparison regions on the cycle: at every site `v`, the
+`L + 1` sites starting at `v` and the `L` sites starting at `v + 1` are
+injective regions with injective complements differing exactly at `v`.
+
+Source: arXiv:1804.04964, Section 3, theorem labelled `normal`, lines
+1576--1583 of `Papers/1804.04964/paper_normal.tex` ("for every site, there
+are injective regions with their complements also being injective that
+differ only in the given site"), realized on the chain of the first
+corollary (lines 1585--1622) by blocks of consecutive sites. -/
+def cycleOneSiteSeparation {L : ℕ} (h : NormalCycleArcInjectivityHypotheses L κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hL : 0 < L) (hn : 3 * L ≤ n) :
+    NormalOneSiteSeparationHypotheses κ where
+  withSite v := cycleArcFrom v (L + 1)
+  withoutSite v := cycleArcFrom (v + 1) L
+  withSite_injective v :=
+    isInjective_cycleArcFrom_of_le hUnion h.arc_injective hL (by omega) (by omega) v
+  withoutSite_injective v := h.arc_injective (v + 1)
+  withSite_complement_injective v := by
+    simp only [regionComplement]
+    rw [compl_cycleArcFrom (show L + 1 < n by omega)]
+    exact isInjective_cycleArcFrom_of_le hUnion h.arc_injective hL (by omega) (by omega) _
+  withoutSite_complement_injective v := by
+    simp only [regionComplement]
+    rw [compl_cycleArcFrom (show L < n by omega)]
+    exact isInjective_cycleArcFrom_of_le hUnion h.arc_injective hL (by omega) (by omega) _
+  site_mem_withSite v := start_mem_cycleArcFrom (by omega)
+  site_notMem_withoutSite v := self_notMem_cycleArcFrom_add_one hL (by omega)
+  agree_away v w hvw := mem_cycleArcFrom_succ_iff_of_ne (by omega) hvw
+
+/-! ### The assembled blocking hypotheses -/
+
+/-- The blocking hypotheses of the general normal PEPS theorem on the cycle
+graph, assembled from the arc-injectivity hypotheses of the source corollary:
+the per-edge three-block chains and the one-site comparison regions.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`,
+supplying the hypotheses of the theorem labelled `normal` (lines 1576--1583)
+on the closed chain. -/
+def cycleNormalPEPSBlockingHypotheses {L : ℕ} (h : NormalCycleArcInjectivityHypotheses L κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hL : 0 < L) (hn : 3 * L ≤ n) :
+    NormalPEPSBlockingHypotheses κ (SimpleGraph.cycleGraph n) where
+  edgeBlocking :=
+    NormalEdgeBlockingHypotheses.ofBlockingData fun e => cycleEdgeBlockingData h hUnion hL hn e
+  oneSiteSeparation := cycleOneSiteSeparation h hUnion hL hn
+
+@[simp] theorem cycleNormalPEPSBlockingHypotheses_red {L : ℕ}
+    (h : NormalCycleArcInjectivityHypotheses L κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hL : 0 < L) (hn : 3 * L ≤ n)
+    (e : Edge (SimpleGraph.cycleGraph n)) :
+    (cycleNormalPEPSBlockingHypotheses h hUnion hL hn).edgeBlocking.red e =
+      cycleEdgeRed L e := rfl
+
+@[simp] theorem cycleNormalPEPSBlockingHypotheses_blue {L : ℕ}
+    (h : NormalCycleArcInjectivityHypotheses L κ)
+    (hUnion : RegionInjectivityUnionClosure κ) (hL : 0 < L) (hn : 3 * L ≤ n)
+    (e : Edge (SimpleGraph.cycleGraph n)) :
+    (cycleNormalPEPSBlockingHypotheses h hUnion hL hn).edgeBlocking.blue e =
+      cycleEdgeBlue L e := rfl
+
+end NeZero
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/CycleFundamentalTheorem.lean
+++ b/TNLean/PEPS/CycleFundamentalTheorem.lean
@@ -1,0 +1,184 @@
+import TNLean.PEPS.CycleBlockingData
+import TNLean.PEPS.NormalGeneralFundamentalTheorem
+
+/-!
+# The Fundamental Theorem for normal MPS on a closed chain
+
+This file specializes the Fundamental Theorem for normal PEPS on a connected
+graph (`fundamentalTheorem_normalPEPS`) to the cycle graph, obtaining the
+first corollary after the theorem labelled `normal` of arXiv:1804.04964
+(Section 3, lines 1585--1622 of `Papers/1804.04964/paper_normal.tex`): two
+normal MPS `{A_i}` and `{B_i}` on a closed chain of `n ≥ 3L` sites, each with
+the property that blocking any `L` consecutive sites gives an injective
+tensor, generating the same state, are related by invertible matrices `Z_i`
+(one per bond, `n + 1 ≡ 1`) with `B_i = Z_i⁻¹ A_i Z_{i+1}`; and the `Z_i` are
+unique up to a multiplicative constant.
+
+A site-dependent MPS on a closed chain of `n` sites is a PEPS on the cycle
+graph over `Fin n`: each vertex carries one tensor with two virtual legs (the
+two incident bonds) and the closed-chain state coefficient is the cyclic
+trace of the matrix product.  The corollary's per-bond gauges `Z_i` are the
+per-edge gauges of the graph-level gauge equivalence, and its blocks of `L`
+consecutive sites are the arcs of `TNLean/PEPS/CycleArcRegion.lean`.
+
+The hypotheses beyond the source's wording carry over from the general
+theorem and are documented there and in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`: positive physical and
+bond dimensions are the counterexample-backed faithfulness fixes of the
+injective Fundamental Theorem, and `0 < L` makes "blocking `L` consecutive
+sites" a blocking at all.  Connectivity holds on the cycle and is discharged,
+not assumed.
+
+## Relation to the matrix-product-state chapters
+
+The development's MPS chapters (`TNLean/MPS/`) treat one site-independent
+tensor (`MPSTensor`) generating the closed-chain states of *all* lengths at
+once: their equality (`SameMPV`) quantifies over every chain length, and
+their Fundamental Theorem (from arXiv:1606.00608) produces one global
+similarity.  The present corollary is a different statement, at a *fixed*
+chain length `n` with site-dependent tensors and one gauge per bond, and is
+obtained from the PEPS theorem rather than from the transfer-matrix route of
+the MPS chapters.  A dictionary between site-independent `MPSTensor` families
+and cycle-graph tensors would let the fixed-length statement be compared with
+the all-lengths one; it is not part of this file.  The source's second
+corollary (the translation-invariant form with a single gauge `Z` and a root
+of unity `λ`, lines 1624--1661) is likewise not delivered here: the
+development's translation-invariant setting is the torus
+(`fundamentalTheorem_normalTorusPEPS_unconditional`).
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section 3, first corollary after the theorem labelled `normal`, lines
+  1585--1622 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+
+namespace TNLean
+namespace PEPS
+
+/-! ### Union closure for the shared predicate -/
+
+/-- Union closure for the conjunction of two region-injectivity predicates,
+from union closure of each.
+
+Source: arXiv:1804.04964, Section 3, Lemma labelled `injective_union`, lines
+1322--1404 of `Papers/1804.04964/paper_normal.tex`, applied to each of the
+two tensors over the shared regions. -/
+theorem regionInjectivityUnionClosure_pair {V : Type*} [DecidableEq V]
+    {κ κ' : RegionInjectivityData V}
+    (h : RegionInjectivityUnionClosure κ) (h' : RegionInjectivityUnionClosure κ') :
+    RegionInjectivityUnionClosure (regionInjectivityDataPair κ κ') where
+  union_injective hA hB :=
+    ⟨h.union_injective hA.1 hB.1, h'.union_injective hA.2 hB.2⟩
+
+/-! ### The corollary for normal MPS on a closed chain -/
+
+/-- **Fundamental Theorem for normal MPS on a closed chain**
+(arXiv:1804.04964, Section 3, first corollary after the theorem labelled
+`normal`).
+
+Two MPS on the closed chain of `n ≥ 3L` sites — tensors on the cycle graph
+over `Fin n` — such that blocking any `L` consecutive sites gives an
+injective tensor for each, generating the same state, are gauge equivalent:
+there is an invertible matrix on every bond relating the defining tensors,
+which is the source's family `Z_i` (for `i = 1, …, n`, `n + 1 ≡ 1`) with
+`B_i = Z_i⁻¹ A_i Z_{i+1}`.
+
+The blocking hypotheses of the general theorem are discharged by the arc
+geometry: around every edge the chain splits into the `L` sites on one side,
+the `L` sites on the other, and the remaining `n - 2L ≥ L` sites, all
+injective (longer blocks by the source's union lemma); at every site the
+`L + 1` sites starting there and the `L` sites starting at its successor
+are injective with injective complements and differ exactly at the site; and
+the only nearest-neighbour pair joining the two blocks around an edge is the
+edge itself.  Connectivity of the cycle discharges the connectivity
+hypothesis.  The bond dimensions are not assumed equal: the general theorem
+forces them.
+
+The hypotheses `0 < d` and the positive bond dimensions are the
+counterexample-backed faithfulness fixes inherited from the injective
+Fundamental Theorem (`docs/paper-gaps/peps_injective_ft_section3_route.tex`,
+`docs/paper-gaps/peps_gaugeConsistency_connectivity_gap.tex`); `0 < L` is
+implicit in the source's blocking of `L` consecutive sites.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalMPS_cycle {n L d : ℕ}
+    (hL : 0 < L) (hn : 3 * L ≤ n)
+    (A B : Tensor (SimpleGraph.cycleGraph n) d)
+    (harcA : ∀ s : Fin n,
+      RegionBlockedTensorInjective (G := SimpleGraph.cycleGraph n) A (cycleArcFrom s L))
+    (harcB : ∀ s : Fin n,
+      RegionBlockedTensorInjective (G := SimpleGraph.cycleGraph n) B (cycleArcFrom s L))
+    (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge (SimpleGraph.cycleGraph n), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (SimpleGraph.cycleGraph n), 0 < B.bondDim g) :
+    GaugeEquiv A B := by
+  haveI : NeZero n := ⟨by omega⟩
+  have hU := regionInjectivityUnionClosure_pair
+    (regionInjectivityUnionClosure_of_overlap A hposA)
+    (regionInjectivityUnionClosure_of_overlap B hposB)
+  have harc : NormalCycleArcInjectivityHypotheses L
+      (regionInjectivityDataPair (regionInjectivityDataOf (G := SimpleGraph.cycleGraph n) A)
+        (regionInjectivityDataOf (G := SimpleGraph.cycleGraph n) B)) :=
+    ⟨fun s => ⟨harcA s, harcB s⟩⟩
+  have hconn : (SimpleGraph.cycleGraph n).Connected := by
+    obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+    exact SimpleGraph.cycleGraph_connected
+  exact fundamentalTheorem_normalPEPS A B
+    (cycleNormalPEPSBlockingHypotheses harc hU hL hn)
+    (fun e g => isCrossingEdge_cycleEdge_iff A hL hn e g) hAB hd hposA hposB hconn
+
+/-- **Uniqueness clause of the Fundamental Theorem for normal MPS on a closed
+chain** (arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`: the gauges `Z_i` are unique up to a multiplicative
+constant).
+
+Two per-bond gauge families each realizing the scalar-free gauge relation of
+`fundamentalTheorem_normalMPS_cycle` are proportional at every bond.  This is
+the general uniqueness clause instantiated on the cycle blocking.
+
+Source: arXiv:1804.04964, Section 3, first corollary after the theorem
+labelled `normal`, lines 1585--1622 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalMPS_cycle_gauge_unique {n L d : ℕ}
+    (hL : 0 < L) (hn : 3 * L ≤ n)
+    (A B : Tensor (SimpleGraph.cycleGraph n) d)
+    (harcA : ∀ s : Fin n,
+      RegionBlockedTensorInjective (G := SimpleGraph.cycleGraph n) A (cycleArcFrom s L))
+    (harcB : ∀ s : Fin n,
+      RegionBlockedTensorInjective (G := SimpleGraph.cycleGraph n) B (cycleArcFrom s L))
+    (hbond : A.bondDim = B.bondDim)
+    (hposA : ∀ g : Edge (SimpleGraph.cycleGraph n), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (SimpleGraph.cycleGraph n), 0 < B.bondDim g)
+    (X X' : (e : Edge (SimpleGraph.cycleGraph n)) → GL (Fin (A.bondDim e)) ℂ)
+    (hX : ∀ (v : Fin n)
+      (η : (ie : IncidentEdge (SimpleGraph.cycleGraph n) v) → Fin (A.bondDim ie.1))
+      (σ : Fin d),
+      B.component v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ =
+        gaugeVertex A X v η σ)
+    (hX' : ∀ (v : Fin n)
+      (η : (ie : IncidentEdge (SimpleGraph.cycleGraph n) v) → Fin (A.bondDim ie.1))
+      (σ : Fin d),
+      B.component v (fun ie => Fin.cast (congr_fun hbond ie.1) (η ie)) σ =
+        gaugeVertex A X' v η σ)
+    (e : Edge (SimpleGraph.cycleGraph n)) :
+    ∃ c : ℂˣ, (X' e : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) =
+      (c : ℂ) • (X e : Matrix (Fin (A.bondDim e)) (Fin (A.bondDim e)) ℂ) := by
+  haveI : NeZero n := ⟨by omega⟩
+  have hU := regionInjectivityUnionClosure_pair
+    (regionInjectivityUnionClosure_of_overlap A hposA)
+    (regionInjectivityUnionClosure_of_overlap B hposB)
+  have harc : NormalCycleArcInjectivityHypotheses L
+      (regionInjectivityDataPair (regionInjectivityDataOf (G := SimpleGraph.cycleGraph n) A)
+        (regionInjectivityDataOf (G := SimpleGraph.cycleGraph n) B)) :=
+    ⟨fun s => ⟨harcA s, harcB s⟩⟩
+  exact fundamentalTheorem_normalPEPS_gauge_unique A B
+    (cycleNormalPEPSBlockingHypotheses harc hU hL hn) hbond hposA X X' hX hX' e
+
+end PEPS
+end TNLean

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
@@ -281,8 +281,8 @@
     \uses{def:peps_normalPEPSBlockingHypotheses,
         def:peps_regionInjectivityData}
     A closed chain of $n$ sites is the cycle graph on $n$ vertices, and a
-    block of $\ell$ consecutive sites is an arc: the $\ell$ vertices reached
-    clockwise from a starting site.  Suppose $0 < L$, $3L \le n$, every arc
+    block of consecutive sites is an arc: the vertices reached clockwise
+    from a starting site.  Suppose $0 < L$, $3L \le n$, every arc
     of $L$ consecutive sites is injective for a region-injectivity
     assignment, and injectivity is closed under unions.  Then the chain
     satisfies the normal blocking hypotheses: around every edge it blocks

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
@@ -269,6 +269,110 @@
     \end{proof}
 \end{theorem}
 
+\begin{theorem}[Cycle blocking hypotheses from arc injectivity]%
+    \label{thm:peps_cycleNormalPEPSBlockingHypotheses}
+    \lean{TNLean.PEPS.cycleArcFrom}
+    \lean{TNLean.PEPS.NormalCycleArcInjectivityHypotheses}
+    \lean{TNLean.PEPS.cycleEdgeBlockingData}
+    \lean{TNLean.PEPS.cycleOneSiteSeparation}
+    \lean{TNLean.PEPS.cycleNormalPEPSBlockingHypotheses}
+    \lean{TNLean.PEPS.isCrossingEdge_cycleEdge_iff}
+    \leanok
+    \uses{def:peps_normalPEPSBlockingHypotheses,
+        def:peps_regionInjectivityData}
+    A closed chain of $n$ sites is the cycle graph on $n$ vertices, and a
+    block of $\ell$ consecutive sites is an arc: the $\ell$ vertices reached
+    clockwise from a starting site.  Suppose $0 < L$, $3L \le n$, every arc
+    of $L$ consecutive sites is injective for a region-injectivity
+    assignment, and injectivity is closed under unions.  Then the chain
+    satisfies the normal blocking hypotheses: around every edge it blocks
+    into the $L$ sites on one side, the $L$ sites on the other, and the
+    remaining $n - 2L \ge L$ sites, all injective and covering the chain;
+    and at every site the $L + 1$ sites starting there and the $L$ sites
+    starting at its successor are injective regions with injective
+    complements differing exactly at that site.  Moreover the only
+    nearest-neighbour pair joining the two blocks around an edge is the edge
+    itself, since the far ends of the two blocks are separated by the
+    remaining $n - 2L \ge L$ sites.
+\end{theorem}
+\begin{proof}\leanok
+    Membership in an arc is a cyclic-distance inequality, so the
+    disjointness, covering, and unique-crossing claims are modular
+    arithmetic on the distances.  Arcs of length between $L$ and $n$ are
+    unions of arcs of length $L$, hence injective by union closure; this
+    covers the two complements at a site and the third block around an
+    edge.
+\end{proof}
+
+\begin{corollary}[Fundamental Theorem for normal MPS on a closed chain]%
+    \label{cor:fundamentalTheorem_normalMPS_cycle}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_cycle}
+    \leanok
+    \uses{def:peps_regionInjectivityDataOf, def:GaugeEquivPEPS}
+    Let $A$ and $B$ be tensors on the closed chain of $n$ sites (the cycle
+    graph on $n$ vertices, one tensor per site with two virtual legs), with
+    the same positive physical dimension and positive bond dimensions, and
+    let $0 < L$ with $n \ge 3L$.  Suppose blocking any $L$ consecutive sites
+    gives an injective tensor, for $A$ and for $B$, and the two MPS generate
+    the same state.  Then the defining tensors are related by a local gauge:
+    there are invertible matrices, one on each bond, whose endpoint actions
+    transform $A_i$ into $B_i$ at every site with no leftover scalar.  This
+    is the source's family $Z_i$ ($i = 1, \dots, n$, $n + 1 \equiv 1$) with
+    $B_i = Z_i^{-1} A_i Z_{i+1}$, the first corollary following the general
+    normal-PEPS theorem of \cite[Section~3]{Molnar2018NormalPEPS}, the
+    statement for MPS without translation invariance at a fixed system size.
+    The positive physical and bond dimensions are the counterexample-backed
+    corrections carried over from the injective Fundamental Theorem
+    (Theorem~\ref{thm:fundamentalTheorem_PEPS}), and $0 < L$ is implicit in
+    the source's blocking of $L$ consecutive sites; the equality of the bond
+    dimensions is not assumed but derived, and the connectivity of the cycle
+    is proved, not assumed.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:peps_cycleNormalPEPSBlockingHypotheses,
+        thm:fundamentalTheorem_normalPEPS_connected,
+        lem:peps_injectiveRegion_union_pos}
+    Positive bond dimensions give union closure of injective regions for
+    each tensor (Lemma~\ref{lem:peps_injectiveRegion_union_pos}), hence for
+    the doubly injective assignment.  The arc-injectivity hypothesis then
+    yields the normal blocking hypotheses on the cycle with the unique
+    crossing property
+    (Theorem~\ref{thm:peps_cycleNormalPEPSBlockingHypotheses}), the cycle is
+    connected, and the Fundamental Theorem for normal PEPS on a connected
+    graph (Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected})
+    supplies the scalar-free local gauge.
+\end{proof}
+
+\begin{corollary}[Uniqueness of the closed-chain gauges up to a constant]%
+    \label{cor:fundamentalTheorem_normalMPS_cycle_gauge_unique}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_cycle_gauge_unique}
+    \leanok
+    \uses{def:peps_regionInjectivityDataOf, def:gaugeVertex}
+    In the setting of
+    Corollary~\ref{cor:fundamentalTheorem_normalMPS_cycle}, with the bond
+    dimensions of the two tensors equal and positive and the arcs of $L$
+    consecutive sites injective for each tensor, any two families of
+    invertible bond matrices realizing the scalar-free gauge relation are
+    proportional at every bond: $Z'_i = c \cdot Z_i$ for a nonzero scalar
+    $c$ depending on the bond.  This is the uniqueness clause of the first
+    corollary following the general normal-PEPS theorem of
+    \cite[Section~3]{Molnar2018NormalPEPS}: the gauges $Z_i$ are unique up
+    to a multiplicative constant.  Neither equality of the two states nor
+    connectivity is needed, as in the general uniqueness clause.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:peps_cycleNormalPEPSBlockingHypotheses,
+        thm:fundamentalTheorem_normalPEPS_gauge_unique,
+        lem:peps_injectiveRegion_union_pos}
+    The arc-injectivity hypothesis and union closure from the positive bond
+    dimensions (Lemma~\ref{lem:peps_injectiveRegion_union_pos}) assemble the
+    normal blocking hypotheses on the cycle
+    (Theorem~\ref{thm:peps_cycleNormalPEPSBlockingHypotheses}), and the
+    per-edge uniqueness of the general theorem
+    (Theorem~\ref{thm:fundamentalTheorem_normalPEPS_gauge_unique}) gives the
+    proportionality at every bond.
+\end{proof}
+
 \begin{theorem}[Fundamental Theorem for normal PEPS, vertex-injective case]%
     \label{thm:fundamentalTheorem_normalPEPS_of_vertexInjective}
     \lean{TNLean.PEPS.fundamentalTheorem_normalPEPS_of_vertexInjective}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2553,6 +2553,63 @@ source-exact translationally invariant square-lattice statement awaits a
 translation-invariance predicate on the open lattice, as the earlier sections
 record.
 
+\section*{The closed-chain MPS corollary}
+
+The first corollary after the theorem \path{normal} (lines 1585--1622 of
+\path{Papers/1804.04964/paper_normal.tex}) specializes it to one dimension:
+two normal MPS $\{A_i\}$, $\{B_i\}$ on $n\geq 3L$ sites such that blocking
+any $L$ consecutive sites gives an injective tensor, generating the same
+state, are related by invertible matrices $Z_i$ (one per bond, $n+1\equiv 1$)
+with $B_i=Z_i^{-1}A_iZ_{i+1}$, unique up to a multiplicative constant.  This
+corollary is now formalized by instantiating the connected-graph theorem on
+the cycle graph.\footnote{Formal declarations:
+    \leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_cycle} (existence,
+    blueprint \path{cor:fundamentalTheorem_normalMPS_cycle}) and
+    \leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_cycle_gauge_unique}
+    (uniqueness, blueprint
+    \path{cor:fundamentalTheorem_normalMPS_cycle_gauge_unique}), with the
+    blocking construction in \path{TNLean/PEPS/CycleArcRegion.lean} and
+    \path{TNLean/PEPS/CycleBlockingData.lean} (blueprint
+    \path{thm:peps_cycleNormalPEPSBlockingHypotheses}).}
+The closed chain is the cycle graph on $n$ vertices, a block of $L$
+consecutive sites is a cyclic arc, and the blocking hypotheses of the
+general theorem are discharged by arc arithmetic: around the edge joining a
+site to its cyclic successor the chain splits into the $L$ sites ending at
+the first endpoint, the $L$ sites starting at the second, and the remaining
+$n-2L\geq L$ sites; at every site the $L+1$ sites starting there and the $L$
+sites starting at its successor differ exactly at the site; arcs of length
+between $L$ and $n$ are unions of length-$L$ arcs, hence injective by the
+union lemma; and the single-crossing hypothesis holds because the far ends
+of the two blocks around an edge are separated by the remaining
+$n-2L\geq L$ sites, so the only nearest-neighbour pair joining them is the
+edge itself.  The hypotheses beyond the source's wording are those of the
+connected-graph theorem (positive physical and bond dimensions, recorded in
+the comparison points above), plus $0<L$, which is implicit in the source's
+``blocking any $L$ consecutive sites''; connectivity of the cycle is proved,
+not assumed, and the equality of bond dimensions is derived.
+
+Two relationships are worth recording.  First, the corollary is a different
+theorem from the Fundamental Theorem of the development's MPS chapters
+(\path{TNLean/MPS/FundamentalTheorem/}, after arXiv:1606.00608): those treat
+one site-independent tensor whose matrix-product traces agree at \emph{every}
+chain length (\path{SameMPV}) and produce one global similarity, whereas the
+corollary fixes one chain length $n$, allows site-dependent tensors, and
+produces one gauge per bond.  A dictionary between site-independent
+\path{MPSTensor} families and cycle-graph tensors (sending a single tensor to
+its repetition around the cycle and matching the trace coefficients with the
+closed-state coefficients) would let the two settings be compared; it is not
+small, because the cycle-graph tensor indexes its virtual legs by incident
+edges through the linear order on the vertices, and remains a follow-up.
+Second, the source's translationally invariant corollary (lines 1624--1661,
+single gauge $Z$ and a root of unity $\lambda$ with $\lambda^n=1$) is not
+delivered by this instantiation: it needs a translation apparatus on the
+cycle mirroring the torus one (\path{TNLean/PEPS/TorusTranslation.lean}), and
+the development's translation-invariant setting remains the torus
+(\path{fundamentalTheorem_normalTorusPEPS_unconditional}).  The
+strengthening of the corollary to $n\geq 2L+1$ announced by the source
+(line 1623, proved in its Section \path{normal_alt}) is likewise not
+formalized.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## Summary

Formalizes the **non-translation-invariant MPS corollary** of the normal PEPS Fundamental Theorem (arXiv:1804.04964, Section 3, first corollary after the theorem labelled `normal`, lines 1585–1622 of `Papers/1804.04964/paper_normal.tex`) by instantiating the just-landed general theorem `fundamentalTheorem_normalPEPS` (#2690/#2694) on the cycle graph.

**Source statement (lines 1585–1622):** two normal MPS `{A_i}`, `{B_i}` on `n ≥ 3L` sites with the property that blocking any `L` consecutive sites results in an injective tensor, generating the same state, are related by invertible matrices `Z_i` (`i = 1…n`, `n+1 ≡ 1`) with `B_i = Z_i⁻¹ A_i Z_{i+1}`; the gauges `Z_i` are unique up to a multiplicative constant.

## Scoping findings (Phase 0)

- **Graph choice:** `torusGraph n 1` is unusable (height-1 vertical neighbours are self-loops; the definition requires `Fact (1 < height)`). TNLean had no cycle graph; Mathlib's `SimpleGraph.cycleGraph n : SimpleGraph (Fin n)` is used directly — `Fin n` carries the canonical `Fintype`/`LinearOrder`/`DecidableEq` and Mathlib provides `DecidableRel` and connectivity (`cycleGraph_connected`), so the PEPS `Tensor`/`Edge` machinery instantiates with no new instances.
- **Blocking on the cycle:** around the edge joining `a` to its cyclic successor, red = the `L`-arc ending at `a`, blue = the `L`-arc starting at `a+1`, complement = the remaining `n−2L ≥ L` arc. The wrap-around red–blue contact is excluded by `n ≥ 3L > 2L`, so `hsingle` (unique red-to-blue crossing) holds. The `Edge` type orients by the linear order on `Fin n`, so the seam edge `(0, n−1)` attaches red/blue by cases on which endpoint is the cyclic predecessor.
- **One-site comparisons:** `withoutSite v` = the `L`-arc starting at `v+1`, `withSite v` = the `(L+1)`-arc starting at `v`; both and their complements (arcs of length `n−L`, `n−L−1 ≥ L`) are injective via the union lemma (`L`-arc unions), matching the `NormalOneSiteSeparationHypotheses` field shapes.
- **MPS-chapter relationship:** the corollary is a *different theorem* from `TNLean/MPS/FundamentalTheorem/` (arXiv:1606.00608 route): those fix one site-independent `MPSTensor` and quantify over **all** chain lengths (`SameMPV`), producing one global similarity; the corollary fixes one length `n`, allows site-dependent tensors, and produces one gauge per bond. An `MPSTensor` ↔ cycle-`Tensor` dictionary is not small (incident-edge indexing through the vertex order) and is recorded as a follow-up in the route note, not attempted here.

## What closed

| Lean | Blueprint | Content |
|---|---|---|
| `fundamentalTheorem_normalMPS_cycle` | `cor:fundamentalTheorem_normalMPS_cycle` | existence of the per-bond gauges |
| `fundamentalTheorem_normalMPS_cycle_gauge_unique` | `cor:fundamentalTheorem_normalMPS_cycle_gauge_unique` | per-bond uniqueness up to a constant |
| `cycleNormalPEPSBlockingHypotheses`, `cycleEdgeBlockingData`, `cycleOneSiteSeparation`, `isCrossingEdge_cycleEdge_iff`, `cycleArcFrom`, … | `thm:peps_cycleNormalPEPSBlockingHypotheses` | the cycle blocking bundle + hsingle |

New files: `TNLean/PEPS/CycleArcRegion.lean` (arc geometry), `TNLean/PEPS/CycleBlockingData.lean` (blocking bundle), `TNLean/PEPS/CycleFundamentalTheorem.lean` (capstones); all in root `TNLean.lean`.

Hypotheses beyond the source's wording, all documented in the docstrings and `docs/paper-gaps/peps_normal_ft_section3_route.tex` (new section "The closed-chain MPS corollary"): positive physical/bond dimensions (counterexample-backed fixes inherited from the injective FT) and `0 < L` (implicit in "blocking `L` consecutive sites"). Bond-dimension equality is derived, connectivity is proved.

## Verification

- Sorry-free; no `maxHeartbeats` bumps; files ≤ 1000 lines.
- `#print axioms TNLean.PEPS.fundamentalTheorem_normalMPS_cycle` → `[propext, Classical.choice, Quot.sound]`
- `#print axioms TNLean.PEPS.fundamentalTheorem_normalMPS_cycle_gauge_unique` → `[propext, Classical.choice, Quot.sound]`
- Full root `lake build` green; `lake exe lint-style` exit 0; `leanblueprint web` error-free; `lake exe checkdecls blueprint/lean_decls` exit 0.

## Residuals (recorded in the route note)

- The TI corollary (lines 1624–1661: single gauge `Z`, `λ^n = 1`) needs a cycle translation apparatus mirroring `TorusTranslation`; the development's TI setting remains the torus.
- The `n ≥ 2L+1` strengthening (line 1623, Section `normal_alt`) is not formalized.
- The `MPSTensor` ↔ cycle-`Tensor` dictionary is a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics (new Lean proofs and documentation); no runtime, auth, or data-path changes. Relies on existing `fundamentalTheorem_normalPEPS` machinery.
> 
> **Overview**
> Adds the **closed-chain normal MPS corollary** (arXiv:1804.04964 §3) by instantiating `fundamentalTheorem_normalPEPS` on `SimpleGraph.cycleGraph n`.
> 
> **Lean:** New modules define cyclic **arcs** (`cycleArcFrom` / `cycleArcTo`), build **normal blocking** from “every length-`L` arc injective” (`cycleNormalPEPSBlockingHypotheses`, `isCrossingEdge_cycleEdge_iff`), and prove **`fundamentalTheorem_normalMPS_cycle`** plus **`fundamentalTheorem_normalMPS_cycle_gauge_unique`**. Root `TNLean.lean` imports the three files.
> 
> **Docs:** Blueprint capstone gains the cycle blocking theorem and two corollaries; `peps_normal_ft_section3_route.tex` records the formalization and notes open follow-ups (TI cycle corollary, `MPSTensor` dictionary).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98d5360b16be2475f76cf0088ed4e43915c5e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->