### PR TITLE
doc(parent): record complementary identity boundary

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -13,6 +13,10 @@ This file isolates the cyclic-interval step for a block component when the
 interval crosses the boundary cut.  The input is the blockwise matrix identity
 appearing in the boundary-closing part of arXiv:quant-ph/0608197, Theorem
 2blocks.2.
+
+The final theorems here still assume the complementary-word identity obtained
+from the source \(C^j,D^j,E^j\) comparison. The remaining derivation is recorded
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 
 open scoped Matrix BigOperators
@@ -680,10 +684,10 @@ representation to periodic block components.
 
 Under the normalized BNT hypotheses, every vector in the block-diagonal
 periodic chain space has block-diagonal boundary conditions \(X_j\).  If those
-same boundary conditions satisfy the complementary-word identities obtained
-from the Pérez-García--Verstraete--Wolf--Cirac \(C,D,E\) comparison: for every
-boundary-crossing interval \(i\), wrapped word \(\beta\), and complementary
-word \(\rho\),
+same boundary conditions satisfy the complementary-word identities which the
+Pérez-García--Verstraete--Wolf--Cirac proof derives from the \(C^j,D^j,E^j\)
+comparison: for every boundary-crossing interval \(i\), wrapped word
+\(\beta\), and complementary word \(\rho\),
 \[
   \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho},
 \]
@@ -692,6 +696,10 @@ then the component vectors
   \Gamma_N^{A_j}(\mu_j^NX_j)
 \]
 belong to \(\mathcal G_{N,L}(A_j)\).
+
+The complementary-word identities are assumptions of this theorem; deriving
+them from the source comparison is the remaining step documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
 This result follows the block-diagonal boundary conditions of arXiv:2011.12127,
 lines 2126--2128, and precedes the final equality in

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -56,10 +56,10 @@ Cirac et al. describe the degenerate parent-Hamiltonian ground space for a
 matrix product state with more than one block in canonical form in Section~IV.C
 of \cite{Cirac2021Matrix}.\footnote{For
 traceability, the remaining boundary-condition comparison is tracked by
-\href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641}. The
-closed periodic-chain decomposition issue was
-\href{https://github.com/LionSR/TNLean/issues/905}{issue \#905}; the related
-ground-state splitting issue is
+\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}. Earlier
+reductions were tracked by
+\href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641},
+\href{https://github.com/LionSR/TNLean/issues/905}{issue \#905}, and
 \href{https://github.com/LionSR/TNLean/issues/870}{issue \#870}. The relevant
 source lines are \path{Papers/2011.12127/TN-Review-main.tex}:2112--2128.}
 The source's block-injective canonical form is a block-diagonal
@@ -233,6 +233,39 @@ What remains is the source boundary-condition comparison: starting with a
 periodic-chain vector in $\mathcal K_{N,L}(\widehat A)$, produce
 block-diagonal boundary matrices whose block components are again periodic
 block-chain vectors.
+
+The present formal boundary isolates the remaining source comparison as a
+family of complementary-word identities.  Suppose
+\begin{align}
+  \psi
+  =
+  \Gamma_N^{\widehat A}\!\left(\bigoplus_{j=1}^b X_j\right)
+  \in \mathcal K_{N,L}(\widehat A).
+\end{align}
+For a cyclic interval beginning at \(i\) and crossing the boundary cut, put
+\(a=i+L-N\).  The conditional theorem assumes that, for every block \(j\) and
+every complementary word \(\rho\) of length \(N-L\), there is a matrix
+\(E_{j,i,\rho}\) such that for every word \(\beta\) of length \(a\),
+\begin{align}
+  \mu_j^N X_j A^j_\beta A^j_\rho
+  =
+  A^j_\beta E_{j,i,\rho}.
+\end{align}
+Under the usual block-injectivity and normalization hypotheses this assumption
+implies
+\begin{align}
+  \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal K_{N,L}(A_j)
+  \qquad (1\le j\le b).
+\end{align}
+Thus the remaining problem is no longer the open-boundary representation of
+\(\psi\), but the derivation of the displayed complementary-word identity from
+the \(C^j,D^j,E^j\) comparison in
+\cite[Theorem~\emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}.
+\footnote{Formal declarations:
+\leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities},
+\leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective},
+\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1}, and
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}.}
 
 The live blueprint records that larger source statement in source notation,
 without claiming that it is proved.\footnote{Blueprint locations:
@@ -424,7 +457,7 @@ comparison: for every $j$,
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
 This is the missing assertion recorded in
-\href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641}. It is the
+\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}. It is the
 block-diagonal boundary representation needed in the source range
 \begin{align}
   b\ge2,


### PR DESCRIPTION
### Motivation

- Issue #2651 tracks the remaining periodic-chain membership step in the block-diagonal parent-Hamiltonian argument: each block-boundary component must lie in the local ground space of the periodic chain, not merely the open-boundary space.
- The paper-gap note `cpgsv21_block_diagonal_parent_ground_space.tex` previously pointed the remaining boundary-condition comparison at an earlier reduction issue; this PR updates it to track the gap at #2651.
- The conditional crossing theorems in `BNTBlockDiagonalCrossing.lean` assume the complementary-word identity without stating so explicitly; this PR records that assumption in the docstrings so the proof obligation is visible. Continues the parent-Hamiltonian formalization tracked in #190 and #460.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`: module and theorem docstrings updated to state that the conditional block-diagonal crossing theorems assume the complementary-word identity
  $$\mu_j^N X_j A^j_\beta A^j_\rho = A^j_\beta E_{j,i,\rho}$$
  from the PGVWC07 $C^j, D^j, E^j$ comparison; deriving this identity remains the open proof task for #2651.
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: paper-gap note updated to point the boundary-condition gap at #2651 (with #2641, #905, and #870 as earlier reductions); new subsection displays the assumed identity for boundary-crossing intervals and names the Lean declarations that will consume it once proved.
- No theorem statements or proof scripts are modified; no new `sorry` introduced.

### Testing

- `git diff --check origin/main...HEAD && git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv21_block_diagonal_parent_ground_space.tex`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing -q --log-level=info` — succeeds; the pre-existing `BoundaryClosingStripping.lean` sorry warning is unrelated to this change.

---
Addresses #2651
Refs #190
Refs #460

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no changes to theorem statements or proof scripts.
> 
> **Overview**
> Documentation only: it records where the block-diagonal parent-Hamiltonian argument stops for **#2651**, without changing Lean proofs.
> 
> **Lean** (`BNTBlockDiagonalCrossing.lean`): module and theorem docstrings now state that conditional crossing theorems **assume** the complementary-word identity from the PGVWC07 \(C^j,D^j,E^j\) comparison, and that deriving it is the open step in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
> 
> **Paper-gap note**: the live boundary-condition gap is tracked as **#2651** (with #2641/#905/#870 as earlier reductions). A new subsection spells out the assumed identity \(\mu_j^N X_j A^j_\beta A^j_\rho = A^j_\beta E_{j,i,\rho}\) for boundary-crossing intervals and names the Lean declarations that consume it once proved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5609b185347c2112463e8990344aae508c7200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>