### PR TITLE
doc(MPS/ParentHamiltonian): use source notation for periodic MPS vector

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -4,8 +4,9 @@ import TNLean.MPS.ParentHamiltonian.Defs
 # Basic parent-Hamiltonian properties
 
 The parent interaction is the orthogonal projector onto `(groundSpace A L)ᗮ`.
-It therefore annihilates any vector in the ground space. The MPS state `mpv A`
-lies in the ground space at every window, which gives frustration-freeness.
+It therefore annihilates any vector in the ground space. The periodic MPS vector
+`mpv A` lies in the ground space at every window, which gives
+frustration-freeness.
 -/
 
 open scoped BigOperators
@@ -45,9 +46,10 @@ private lemma trace_evalWord_append_comm (A : MPSTensor d D) (w₁ w₂ : List (
     Matrix.trace (evalWord A (w₁ ++ w₂)) = Matrix.trace (evalWord A (w₂ ++ w₁)) := by
   rw [evalWord_append, evalWord_append, Matrix.trace_mul_comm]
 
-/-! ### MPS window membership -/
+/-! ### Periodic MPS vector window membership -/
 
-/-- The MPS state restricted to any window of `L` sites lies in `groundSpace A L`.
+/-- The periodic MPS vector restricted to any window of `L` sites lies in
+`groundSpace A L`.
 
 The witness is the "complement matrix": the product of `A`-matrices on sites
 outside the `L`-site window, cyclically ordered starting from `i + L`. The proof
@@ -102,7 +104,7 @@ lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N)
       change (k + i.val) % N = (i.val + L + (k - L)) % N
       rw [show i.val + L + (k - L) = k + i.val from by omega]
 
-/-- Each local term annihilates the MPV state. -/
+/-- Each local term annihilates the periodic MPS vector. -/
 lemma localTerm_annihilates_mpv (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) (i : Fin N) :
     localTerm A L N i (mpv A) = 0 := by
   ext σ
@@ -115,13 +117,14 @@ lemma localTerm_annihilates_mpv (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) 
   rw [hkill]
   rfl
 
-/-- The parent Hamiltonian annihilates the MPV state: `H_N |ψ(A)⟩ = 0`. -/
+/-- The parent Hamiltonian annihilates the periodic MPS vector:
+`H_N V^{(N)}(A) = 0`. -/
 lemma parentHamiltonian_annihilates (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) :
     parentHamiltonian A L N (mpv A) = 0 := by
   simp only [parentHamiltonian, LinearMap.sum_apply]
   exact Finset.sum_eq_zero fun i _ => localTerm_annihilates_mpv A L N hLN i
 
-/-- The parent Hamiltonian model is frustration-free on the MPV state:
+/-- The parent Hamiltonian model is frustration-free on the periodic MPS vector:
 each local term individually annihilates `mpv A`. -/
 lemma parentHamiltonian_frustrationFree (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) :
     IsFrustrationFree A L N (mpv A) :=

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -39,20 +39,19 @@ variable {d D : ℕ}
 /-! ### Transport between `NSiteSpace` and `EuclideanSpace`
 
 `NSiteSpace d L = Cfg d L → ℂ` and `EuclideanSpace ℂ (Cfg d L)` is the same underlying
-function space equipped with the ℓ²-structure via `WithLp 2` (concretely,
-`EuclideanSpace ℂ (Cfg d L) = WithLp 2 (Cfg d L → ℂ)`). We use
-`WithLp.linearEquiv` to transport the ground space to `EuclideanSpace`, where Mathlib
-provides `InnerProductSpace` and orthogonal projection. -/
+function space equipped with the canonical ℓ² inner product via `WithLp 2`
+(concretely, `EuclideanSpace ℂ (Cfg d L) = WithLp 2 (Cfg d L → ℂ)`). We use
+`WithLp.linearEquiv` to view the local ground space in this ℓ² realization, where
+Mathlib provides `InnerProductSpace` and orthogonal projection. -/
 
-/-- The ground space of `A` on `L` sites, viewed as a submodule of
-`EuclideanSpace ℂ (Cfg d L)` (same underlying submodule, different typeclass
-instances for inner product). -/
+/-- The local ground space \(G_L(A)\) in the canonical ℓ² realization of the
+`L`-site configuration space. -/
 noncomputable def groundSpaceES (A : MPSTensor d D) (L : ℕ) :
     Submodule ℂ (EuclideanSpace ℂ (Cfg d L)) :=
   (groundSpace A L).map (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm.toLinearMap
 
-/-- Membership in the Euclidean version of the MPS ground space is the same as
-membership of the transported vector in the original function-space ground space. -/
+/-- Membership in the canonical ℓ² realization of \(G_L(A)\) is the same as
+membership of the corresponding function in the original local ground space. -/
 theorem mem_groundSpaceES_iff (A : MPSTensor d D) (L : ℕ)
     (v : EuclideanSpace ℂ (Cfg d L)) :
     v ∈ groundSpaceES A L ↔

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -28,7 +28,7 @@ The four components are:
 ## Argument
 
 1. **Frustration-freeness** (`parentHamiltonian_frustrationFree`): every local
-   term annihilates the MPV ground state.
+   term annihilates the periodic MPS vector \(V^{(N)}(A)\).
 2. **Local projector structure** (`parentInteraction`/`localTerm`): each local
    term is an orthogonal projector on its `L`-site window.
 3. **Intersection property** (`groundSpace_intersection`): for an injective

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -325,9 +325,9 @@ theorem contiguous_mem_groundSpace_of_isNBlkInjective
 block-injective tensors.
 
 This combines cyclic window monotonicity (peeling longer cyclic windows down to
-`L₀ + 1`), the non-wrapping cyclic/contiguous identification, and the
-open-chain range-reduction argument for block-injective tensors. It stops at
-open-chain membership; the boundary-closing scalarity step remains separate. -/
+`L₀ + 1`), the non-wrapping cyclic/contiguous identification, and the open-chain
+closure-property argument for block-injective tensors. It stops at open-chain
+membership; the boundary-closing scalarity step remains separate. -/
 theorem chainGroundSpace_le_groundSpace_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -892,7 +892,7 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     (A := A) hInj hL₀ (by omega : L₀ ≤ M) hψred hψX YAt hYAt η μ j
 
 /-- Closure-property containment
-\(\mathcal G_{N,L}(A) \subseteq \mathbb C\,\Omega_N(A)\) for \(L>L₀\).
+\(\mathcal G_{N,L}(A) \subseteq \mathbb C\,V^{(N)}(A)\) for \(L>L₀\).
 The source names the closure-property step in arXiv:2011.12127, Section IV.C,
 lines 2078--2079, and states the resulting uniqueness theorem in lines 2087--2090.
 **Open gap:** Depends on the comparison at the closed boundary; see
@@ -925,7 +925,7 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 
 /-- On a periodic chain, the normal parent-Hamiltonian ground space satisfies
 \[
-  \mathcal G_{N,L}(A)=\mathbb C\,\Omega_N(A)
+  \mathcal G_{N,L}(A)=\mathbb C\,V^{(N)}(A)
 \]
 for every \(L>L₀\), by the intersection property and closure property of
 arXiv:2011.12127, Section IV.C, lines 2078--2079.  The resulting
@@ -968,7 +968,7 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
 
 /-- Unique ground state for tensors injective after blocking at range \(2L₀\).
 
-**Open gap:** This uses the normal range-reduction equality; see
+**Open gap:** This uses the normal closure-property equality; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -986,7 +986,7 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
   \dim \mathcal G_{N,L₀+1}(A)=1.
 \]
 
-**Open gap:** This depends on the normal range-reduction equality above; see
+**Open gap:** This depends on the normal closure-property equality above; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_basic_local_parent.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_basic_local_parent.tex
@@ -121,7 +121,7 @@ The canonical parent interaction at range $L$ is
 The sources also allow any positive local interaction with this kernel; the
 orthogonal projector is the canonical representative used here.
 
-\begin{definition}[Hilbert-space copy of the local ground space]\label{def:ground_space_es}
+\begin{definition}[Local ground space in the canonical \texorpdfstring{$\ell^2$}{l2} realization]\label{def:ground_space_es}
     \lean{MPSTensor.groundSpaceES}
     \leanok
     \uses{def:nsite_space_parent, def:ground_space_parent}
@@ -131,15 +131,15 @@ orthogonal projector is the canonical representative used here.
         (\{0,\ldots,d{-}1\}^{L}\to\C)
         \simeq \ell^{2}(\{0,\ldots,d{-}1\}^{L})
     \]
-    be the canonical computational-basis identification. The Hilbert-space copy
-    of the local ground space is
+    be the canonical computational-basis identification. The local ground space
+    in this $\ell^2$ realization is
     \[
         G_{L}^{\mathrm{ES}}(A):=\iota_L(G_L(A))
         \subseteq \ell^{2}(\{0,\ldots,d{-}1\}^{L}).
     \]
 \end{definition}
 
-\begin{lemma}[Membership in the Hilbert-space copy]\label{lem:mem_ground_space_es}
+\begin{lemma}[Membership in the canonical \texorpdfstring{$\ell^2$}{l2} realization]\label{lem:mem_ground_space_es}
     \lean{MPSTensor.mem_groundSpaceES_iff}
     \leanok
     \uses{def:ground_space_es, def:ground_space_parent}
@@ -293,13 +293,13 @@ translated copies of the local interaction.
     \]
 \end{definition}
 
-\begin{lemma}[MPV window membership]\label{lem:mpv_window_mem_ground_space}
+\begin{lemma}[Periodic MPS vector window membership]\label{lem:mpv_window_mem_ground_space}
     \lean{MPSTensor.mpv_window_mem_groundSpace}
     \leanok
     \uses{def:ground_space_parent, def:mpv}
     For any window of $L$ consecutive sites starting at position~$i$ in an
-    $N$-site periodic chain ($L \le N$), the restriction of the MPV state to
-    that window lies in $G_L(A)$.
+    $N$-site periodic chain ($L \le N$), the restriction of the periodic MPS
+    vector $V^{(N)}(A)$ to that window lies in $G_L(A)$.
 \end{lemma}
 
 \begin{proof}
@@ -309,7 +309,7 @@ translated copies of the local interaction.
     indices come first, matching the ground-space map definition.
 \end{proof}
 
-\begin{lemma}[Local term annihilates the MPV]\label{lem:local_term_annihilates_mpv}
+\begin{lemma}[Local term annihilates the periodic MPS vector]\label{lem:local_term_annihilates_mpv}
     \lean{MPSTensor.localTerm_annihilates_mpv}
     \leanok
     \uses{def:local_term_parent, def:mpv, lem:mpv_window_mem_ground_space,
@@ -319,15 +319,15 @@ translated copies of the local interaction.
 
 \begin{proof}
     \leanok
-    Combines MPV window membership with the fact that the parent
+    Combines periodic-MPS-vector window membership with the fact that the parent
     interaction annihilates ground-space elements.
 \end{proof}
 
-\begin{lemma}[Parent Hamiltonian annihilates the MPV]\label{lem:parent_hamiltonian_annihilates}
+\begin{lemma}[Parent Hamiltonian annihilates the periodic MPS vector]\label{lem:parent_hamiltonian_annihilates}
     \lean{MPSTensor.parentHamiltonian_annihilates}
     \leanok
     \uses{def:parent_hamiltonian, def:mpv, lem:local_term_annihilates_mpv}
-    For every $N$, the MPV state satisfies
+    For every $N$ with $L\le N$, the periodic MPS vector satisfies
     \[
         H_N(A,L)\,V^{(N)}(A) = 0.
     \]
@@ -335,14 +335,14 @@ translated copies of the local interaction.
 
 \begin{proof}
     \leanok
-    Sum of zeros, since each local term annihilates the MPV.
+    Sum of zeros, since each local term annihilates the periodic MPS vector.
 \end{proof}
 
-\begin{lemma}[Frustration-freeness of the MPV]\label{lem:parent_hamiltonian_ff}
+\begin{lemma}[Frustration-freeness of the periodic MPS vector]\label{lem:parent_hamiltonian_ff}
     \lean{MPSTensor.parentHamiltonian_frustrationFree}
     \leanok
     \uses{def:is_frustration_free, def:mpv, lem:local_term_annihilates_mpv}
-    The MPS vector is a frustration-free ground state: for every site $i$,
+    The periodic MPS vector is a frustration-free ground state: for every site $i$,
     \[
         h_i V^{(N)}(A)=0.
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_periodic_unique_ground_state.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_periodic_unique_ground_state.tex
@@ -8,7 +8,7 @@
     $V^{(N)}(A)(\sigma) = \tr(A^{\sigma_0}\cdots A^{\sigma_{N-1}})$.
 \end{definition}
 
-\begin{lemma}[The MPV is the ground-space map at the identity]
+\begin{lemma}[The periodic MPS vector is the ground-space map at the identity]
     \label{lem:mpv_eq_ground_space_map_one}
     \lean{MPSTensor.mpv_eq_groundSpaceMap_one}
     \leanok
@@ -19,7 +19,7 @@
     \]
 \end{lemma}
 
-\begin{lemma}[MPV lies in the ground space]\label{lem:mpv_mem_ground_space}
+\begin{lemma}[The periodic MPS vector lies in the local ground space]\label{lem:mpv_mem_ground_space}
     \lean{MPSTensor.mpv_mem_groundSpace}
     \leanok
     \uses{def:ground_space_parent, def:mpv}
@@ -52,11 +52,12 @@
     nonzero vector.
 \end{proof}
 
-\begin{definition}[Periodic chain ground space]\label{def:chain_ground_space}
+\begin{definition}[Periodic parent-Hamiltonian ground space]\label{def:chain_ground_space}
     \lean{MPSTensor.chainGroundSpace}
     \leanok
     \uses{def:ground_space_parent}
-    For $N > 0$ and $L \le N$, define the \emph{periodic chain ground space}
+    For $N > 0$ and $L \le N$, define the \emph{periodic parent-Hamiltonian
+    ground space}
     \[
         \mathcal{G}_{N,L}(A) := \bigl\{\psi \in (\{0,\ldots,d{-}1\}^N \to \C)
         : \forall i \in \{0,\ldots,N{-}1\},\
@@ -73,7 +74,7 @@
     When $N = 0$ or $L > N$, set $\mathcal{G}_{N,L}(A) := \top$ by convention.
 \end{definition}
 
-\begin{lemma}[Cyclic-window witnesses inside the chain ground space]
+\begin{lemma}[Cyclic-window witnesses inside the periodic ground space]
     \label{lem:chain_ground_space_window_witnesses}
     \lean{MPSTensor.chainGroundSpace_window_witnesses}
     \leanok
@@ -90,7 +91,7 @@
     space as the range of $\Gamma_L$.
 \end{proof}
 
-\begin{lemma}[The MPV satisfies every cyclic window constraint]
+\begin{lemma}[The periodic MPS vector satisfies every cyclic window constraint]
     \label{lem:mpv_mem_chain_ground_space}
     \lean{MPSTensor.mpv_mem_chainGroundSpace}
     \leanok
@@ -101,7 +102,7 @@
     \]
 \end{lemma}
 
-\begin{theorem}[MPV nonvanishing for block-injective tensors]%
+\begin{theorem}[Periodic MPS vector nonvanishing for block-injective tensors]%
     \label{thm:mpv_ne_zero_blk_injective}
     \lean{MPSTensor.mpv_ne_zero_of_isNBlkInjective}
     \leanok


### PR DESCRIPTION
### Motivation

- Align reader-facing prose in the parent-Hamiltonian chapter with the source notation from arXiv:2011.12127 §IV.C: the paper writes `V^{(N)}(A)` for the periodic MPS vector and describes the unique-ground-state argument in terms of a closure property rather than "range-reduction". Continues the parent-Hamiltonian formalization tracked in #190.
- The previous wording used `MPV` / `Ω_N(A)` in touched sections, and "range-reduction" language for the normal unique-ground-state step, neither of which matches the source.

### Description

- `TNLean/MPS/ParentHamiltonian/Basic.lean`, `Defs.lean`, `Martingale.lean`, `UniqueGroundState.lean`: replace `MPV` / `Ω_N(A)` with `V^{(N)}(A)` and "periodic MPS vector" in docstrings and module comments; rewrite "range-reduction" wording as "closure-property" language in the unique-ground-state docstrings.
- `groundSpaceES` is described as the local ground space `G_L(A)` in the canonical ℓ² realization, matching the source treatment of `G_L(A)` as a local Hilbert-space subspace (arXiv:2011.12127 §IV.C).
- `blueprint/src/chapter/ch14_parent_hamiltonian_basic_local_parent.tex`, `ch14_parent_hamiltonian_periodic_unique_ground_state.tex`: corresponding notation and terminology updates in blueprint prose.
- No Lean proof bodies, theorem statements, or declaration names changed.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.Basic TNLean.MPS.ParentHamiltonian.UniqueGroundState TNLean.MPS.ParentHamiltonian.Martingale` succeeds; the only warning is the pre-existing `sorry` in `BoundaryClosingStripping.lean`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` passes with no violations.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` and `git diff --check` pass.

---
Addresses #190
Refs #952
Refs #2651

> [!NOTE]
> **Low Risk**
> Comment and LaTeX/blueprint text only; no executable Lean or proof logic changes in the diff.
>
> **Overview**
> Documentation-only alignment for the parent-Hamiltonian chapter: reader-facing **MPV** / **Ω_N(A)** / "MPS state" wording is replaced with **periodic MPS vector** and **\(V^{(N)}(A)\)** in touched Lean module docs (`Basic`, `Martingale`, `UniqueGroundState`) and matching blueprint sections (`ch14_parent_hamiltonian_basic_local_parent`, `ch14_parent_hamiltonian_periodic_unique_ground_state`).
>
> **`groundSpaceES`** is described as the local ground space **\(G_L(A)\)** in the **canonical ℓ² realization** (definitions/lemmas retitled accordingly), instead of "Hilbert-space copy" phrasing.
>
> In **`UniqueGroundState`**, open-gap comments and theorem docstrings now say **closure-property** where they previously said **range-reduction**; one reduction lemma comment uses **closure-property argument** for the block-injective step. **No Lean proof bodies or theorem names change** in the diff.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68342e0b864efd6356038bb337ec32fe890bfd1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>