### PR TITLE
doc(MPS/ParentHamiltonian): align NNCPH source scope

### DIFF
--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -7,13 +7,13 @@ import TNLean.MPS.ParentHamiltonian.Defs
 import TNLean.MPS.Periodic.Defs
 
 /-!
-# Beigi's ground-space theorem (axiomatized) and the RFP ↔ NNCPH split
+# Beigi's ground-space theorem (axiomatized) and the RFP--NNCPH split
 
-This module states two axioms that together realize the equivalence
-`IsRFP A ⇔ IsNNCPH A N` used in the proof of Theorem 3.10 of
-arXiv:1606.00608. Following the proof in Section 3.3 of that paper, the two
-directions have very different external provenance and so are
-stated here as **separate** axioms with **separate** citations:
+This module states two axioms that isolate the commutativity side of the
+RFP--NNCPH comparison used in the proof of Theorem 3.10 of arXiv:1606.00608.
+Following the proof in Section 3.3 of that paper, the two directions have very
+different external provenance and so are stated here as **separate** axioms with
+**separate** citations:
 
 * `Axioms.rfp_to_nncph_commute` — RFP ⟹ NNCPH. Per
   arXiv:1606.00608 Section 3.3 (line 1307 of the source): *"The implication
@@ -28,18 +28,25 @@ stated here as **separate** axioms with **separate** citations:
   theorem for nearest-neighbor commuting 1D Hamiltonians with finite
   degeneracy.
 
-To avoid a circular file dependency with
-`TNLean/MPS/ParentHamiltonian/Commuting.lean`, the nearest-neighbor
-commuting condition `IsNNCPH A N` is expressed in this file via its
-unfolded definition: pairwise commutativity of the two-site `localTerm`
+To avoid a circular file dependency with `TNLean/MPS/ParentHamiltonian/Commuting.lean`,
+the nearest-neighbor commuting condition `IsNNCPH A N` is expressed in this file
+via its unfolded definition: pairwise commutativity of the two-site `localTerm`
 projectors.
+
+**Scope restriction (ground-state condition):** The source theorem states a
+three-way equivalence for tensors in canonical form and uses the condition that
+`|V^{(N)}(A)⟩` is a ground state of a nearest-neighbor commuting parent
+Hamiltonian for every `N > 2`. That includes the parent-Hamiltonian
+ground-space condition. The axioms below state only the translated two-site
+commutativity conditions appearing in the parent-Hamiltonian hypotheses.
+Documented in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 ## Status
 
 The two statements `Axioms.rfp_to_nncph_commute` and
 `Axioms.beigi_nncph_to_rfp` below are introduced as **axioms** (not as
-proved theorems). They are the two axioms introduced by
-`TNLean/Axioms/Beigi.lean`. Downstream, they are consumed by
+proved theorems). They are the two axioms introduced in this file. They are used
+in the proofs of
 `MPSTensor.rfp_implies_nncph` and `MPSTensor.nncph_implies_rfp` in
 `TNLean/MPS/ParentHamiltonian/Commuting.lean`, respectively.
 
@@ -52,7 +59,7 @@ arXiv:1606.00608). The structural construction in
 encodes the key combinatorial content; the missing piece is the
 extraction of a `ProductPairBridge A` witness from `IsRFP A` and
 normality. In that construction one may pass to a normalized
-representative only for building the witness / establishing the NNCPH
+representative only for building the witness and establishing the NNCPH
 conclusion, whose content is insensitive to this scaling; this is not
 a claim that `IsRFP` itself is preserved under rescaling. This is
 internal to the library.
@@ -63,7 +70,7 @@ commuting Hamiltonians in 1D with finite degeneracy, exhibiting the
 ground space as the span of locally orthogonal product-of-pairs
 states. Formalization is expected to require:
 
-1. A tensor-product / local-support interface on `NSiteSpace d N` beyond the
+1. A tensor-product and local-support formalism for `NSiteSpace d N` beyond the
    current `Cfg`-based representation.
 2. A translation from the ground-space decomposition of [Beigi] to the
    RFP idempotence equation `transferMap A ∘ transferMap A =

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -58,12 +58,14 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- A parent Hamiltonian has **commuting** local terms when all translated
-interaction projectors commute with each other.
+/-- A parent Hamiltonian has **commuting** local terms when the translated
+interaction projectors commute.
 
-See arXiv:1606.00608, Definition 3.9. This predicate records only the
-commutativity clause; the source definition of a parent Hamiltonian also
-includes the ground-space spanning condition. -/
+See arXiv:1606.00608, Definition 3.9. The source writes the local translated
+condition as $[\tau_j(P_L),P_L]=0$ for the interacting translates; this
+predicate records the resulting pairwise commutativity of the translated local
+terms. The source definition of a parent Hamiltonian also includes the
+ground-space spanning condition. -/
 def IsCommutingParentHam (A : MPSTensor d D) (L N : ℕ) : Prop :=
   ∀ i j : Fin N,
     localTerm A L N i * localTerm A L N j = localTerm A L N j * localTerm A L N i
@@ -85,7 +87,12 @@ See arXiv:1606.00608, Theorem 3.10(iii), source line 539. This predicate records
 the commutativity and annihilation equations for the MPS vector. The full source
 parent-Hamiltonian condition also includes the ground-space spanning assertion
 from Definition 3.9, and Theorem 3.10 also includes the canonical-form and
-zero-correlation-length equivalences. -/
+zero-correlation-length equivalences.
+
+**Scope restriction (ground vector):** This is the zero-energy ground-vector
+clause for the canonical parent interaction, not the full source ground-space
+spanning condition. Documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 def IsNNCPHGroundState (A : MPSTensor d D) (N : ℕ) : Prop :=
   IsNNCPH A N ∧ IsFrustrationFree A 2 N (mpv A)
 
@@ -189,9 +196,14 @@ RFP implies that the periodic MPS vector is a ground state of a
 nearest-neighbor commuting parent Hamiltonian on every chain of length at least
 two.
 
-This theorem adds the frustration-free ground-state equation to
-`rfp_implies_nncph`. It does not prove the full three-way equivalence of
-Theorem 3.10. -/
+This theorem adds the frustration-free ground-vector equation to
+`rfp_implies_nncph`.
+
+**Scope restriction (ground vector):** The source theorem states the
+three-way equivalence for canonical-form tensors and requires the full
+parent-Hamiltonian ground-space condition. This theorem proves only the
+commutation and zero-energy equations for $V^{(N)}(A)$. Documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem rfp_implies_nncph_ground_state (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)
     (N : ℕ) (hN : 2 ≤ N) :
@@ -202,6 +214,13 @@ theorem rfp_implies_nncph_ground_state (A : MPSTensor d D) [NeZero D]
 Gated on S. Beigi, *J. Phys. A: Math. Theor.* **45** (2012) 025306 —
 the ground-space characterization of commuting nearest-neighbor 1D
 Hamiltonians with finite degeneracy (`Axioms.beigi_nncph_to_rfp`).
+
+**Scope restriction (ground-space input):** The source hypothesis is that
+$|V^{(N)}(A)\rangle$ is a ground state of a nearest-neighbor commuting parent
+Hamiltonian for every $N>2$, including the parent-Hamiltonian ground-space
+condition. The present theorem takes as hypothesis only the translated
+length-two commutativity equations. Documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Note: with the present Lean definition, `IsRFP` is a normalization-sensitive
 idempotence equation for `transferMap A`, whereas `IsNNCPH` is invariant under

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -6,11 +6,11 @@ import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Projection
 
 /-!
-# Decorrelation and commuting parent Hamiltonians
+# Decorrelation and parent commuting Hamiltonians
 
 This file defines the notion of **decorrelation** for a subspace with
 respect to two disjoint regions, and proves the backward direction of the
-decorrelation–commuting-parent-Hamiltonian equivalence: a commuting parent
+decorrelation--parent-commuting-Hamiltonian equivalence: a parent commuting
 Hamiltonian implies decorrelation when observables respect locality.
 
 This is the backward direction of Proposition D.3 from arXiv:1606.00608,
@@ -22,13 +22,13 @@ and is deferred.
 * `Decorrelation.IsDecorrelated` — regions A and B are decorrelated w.r.t. a
   subspace K when `P_K O_A (1 - P_K) O_B P_K = 0` for all observables
   O_A, O_B on the respective regions.
-* `Decorrelation.HasCommutingParentHam` — a subspace K equals the intersection
-  of two local kernels `K_AX ⊗ H_B ∩ H_A ⊗ K_XB` where the corresponding
-  projectors commute.
+* `Decorrelation.HasCommutingParentHam` — a subspace K corresponds to a parent
+  commuting Hamiltonian, expressed as the intersection of two local kernels
+  `K_AX ⊗ H_B ∩ H_A ⊗ K_XB` where the corresponding projectors commute.
 
 ## Main results
 
-* `Decorrelation.commutingHam_isDecorrelated` — commuting parent Hamiltonian →
+* `Decorrelation.commutingHam_isDecorrelated` — parent commuting Hamiltonian →
   decorrelation (Proposition D.3, backward direction)
 
 ## References
@@ -113,10 +113,10 @@ def IsDecorrelated (P_K : E →ₗ[ℂ] E)
   ∀ O_A ∈ ObsA, ∀ O_B ∈ ObsB,
     P_K ∘ₗ O_A ∘ₗ (LinearMap.id - P_K) ∘ₗ O_B ∘ₗ P_K = 0
 
-/-- **Commuting parent Hamiltonian structure**: a subspace (given by its
-idempotent endomorphism `P_K`) corresponds to a commuting parent Hamiltonian
-if there exist idempotent endomorphisms `P_AX` and `P_XB` (acting on regions
-AX and XB respectively) that commute and whose intersection recovers `P_K`.
+/-- **Parent commuting Hamiltonian representation**: a subspace (given by its
+idempotent endomorphism `P_K`) corresponds to a parent commuting Hamiltonian if
+there exist idempotent endomorphisms `P_AX` and `P_XB` (acting on regions AX and
+XB respectively) that commute and whose intersection recovers `P_K`.
 
 Formally: `[Q_AX, Q_XB] = 0` where `Q = 1 - P`, and
 `K = (K_AX ⊗ H_B) ∩ (H_A ⊗ K_XB)`, which in projector language means
@@ -168,7 +168,7 @@ def HasCommutingParentHam.ofIdem
   hK := hK_idem
 
 /-- **Proposition D.3, backward direction** (arXiv:1606.00608, Appendix D, Section D.2):
-If a subspace K has a commuting parent Hamiltonian decomposition
+If a subspace K corresponds to a parent commuting Hamiltonian through
 `P_K = P_AX ∘ P_XB` with `[P_AX, P_XB] = 0`, and observables on region A
 commute with `P_XB` while observables on region B commute with `P_AX`, then
 regions A and B are decorrelated w.r.t. K.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_commuting_parent_hamiltonians.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_commuting_parent_hamiltonians.tex
@@ -10,7 +10,8 @@ interaction projectors commute with each other.
     The parent Hamiltonian with block length~$L$ on $N$ sites has
     \emph{commuting} local terms if
     $h_i h_j = h_j h_i$ for all $i,j \in \{0,\ldots,N{-}1\}$.
-    This records the commutativity clause in
+    This records the translated commutativity clause
+    $[\tau_j(P_L),P_L]=0$ from
     Ref.~\cite[Definition~3.9]{Cirac2016MPDO_arXiv}; the ground-space spanning
     clause in the same definition is a separate parent-Hamiltonian condition.
 \end{definition}
@@ -46,6 +47,8 @@ interaction projectors commute with each other.
     Ref.~\cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}; the full source parent
     Hamiltonian condition also includes the spanning assertion from
     Definition~3.9.
+    % Scope restriction recorded in
+    % docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex.
 \end{definition}
 
 \begin{remark}[Elementary consequences of the commuting definition]
@@ -91,6 +94,8 @@ interaction projectors commute with each other.
         h_i h_j = h_j h_i,\qquad
         h_i V^{(N)}(A)=0.
     \]
+    % Scope restriction recorded in
+    % docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex.
 \end{theorem}
 
 \begin{proof}
@@ -165,23 +170,27 @@ interaction projectors commute with each other.
     factorization above together with the two-site projector identification.
 \end{remark}
 
-\begin{theorem}[NNCPH implies RFP]\label{thm:nncph_implies_rfp}
+\begin{theorem}[Pairwise length-two commutativity implies a renormalization fixed point]\label{thm:nncph_implies_rfp}
     \lean{MPSTensor.nncph_implies_rfp}
     \leanok
     \uses{def:is_rfp, def:is_nncph, def:normal}
-    If $A$ is normal, in left-canonical form, and its parent Hamiltonian with
-    $L = 2$ has commuting local terms for every chain length $N \ge 2$, then $A$
-    is a renormalization fixed point. This implication is cited here from Beigi's
-    ground-space
-    characterization of one-dimensional commuting nearest-neighbor Hamiltonians; the
-    left-canonical hypothesis fixes the normalization of the transfer map.
+    If $A$ is normal, in left-canonical form, and for every chain length
+    $N \ge 2$ and every $0\le i,j<N$ its length-two parent interaction
+    satisfies the pairwise commutativity equation
+    \[
+        h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2)
+    \]
+    then $A$ is a renormalization fixed point.
+    % Scope restriction: this theorem records only the translated two-site
+    % commutativity condition. The source definition's ground-space spanning
+    % clause is absent; see docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex.
 \end{theorem}
 
-\section{Decorrelation and commuting parent Hamiltonians}%
+\section{Decorrelation and parent commuting Hamiltonians}%
 \label{sec:decorrelation}
 
 This section develops the abstract operator-algebraic formulation of
-decorrelation and its connection to commuting parent Hamiltonians, following
+decorrelation and its connection to parent commuting Hamiltonians, following
 \cite[Appendix~D, Section~D.2]{Cirac2016MPDO_arXiv}.
 
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}
@@ -194,16 +203,16 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     for all $O_A \in \mathcal{O}_A$, $O_B \in \mathcal{O}_B$.
 \end{definition}
 
-\begin{definition}[Commuting parent Hamiltonian structure]\label{def:has_commuting_parent_ham}
+\begin{definition}[Parent commuting Hamiltonian representation]\label{def:has_commuting_parent_ham}
     \lean{Decorrelation.HasCommutingParentHam}
     \leanok
-    A subspace $K$ (given by its idempotent endomorphism $P_K$) has a
-    \emph{commuting parent Hamiltonian structure} if there exist idempotent
-    endomorphisms $P_{AX}$ and $P_{XB}$ that commute and satisfy
+    A subspace $K$ (given by its idempotent endomorphism $P_K$) corresponds to
+    a \emph{parent commuting Hamiltonian} if there exist idempotent endomorphisms
+    $P_{AX}$ and $P_{XB}$ that commute and satisfy
     $P_{AX} \circ P_{XB} = P_K$.
 \end{definition}
 
-\begin{theorem}[Idempotence gives a trivial commuting parent Hamiltonian]%
+\begin{theorem}[Idempotence gives a tautological parent commuting Hamiltonian]%
     \label{thm:has_commuting_parent_ham_of_idem}
     \lean{Decorrelation.HasCommutingParentHam.ofIdem}
     \leanok
@@ -212,7 +221,7 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \[
         P_K \circ P_K = P_K,
     \]
-    then $P_K$ has a commuting parent Hamiltonian structure.
+    then $P_K$ has a parent commuting Hamiltonian representation.
 \end{theorem}
 
 \begin{proof}
@@ -243,8 +252,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.pK_idem}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition, then
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation, then
     \[
         P_K \circ P_K = P_K.
     \]
@@ -263,8 +272,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.pAX_comp_pK}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition, then
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation, then
     \[
         P_{AX} \circ P_K = P_K.
     \]
@@ -287,8 +296,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.pK_comp_pXB}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition, then
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation, then
     \[
         P_K \circ P_{XB} = P_K.
     \]
@@ -311,8 +320,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.pXB_comp_pK}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition, then
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation, then
     \[
         P_{XB} \circ P_K = P_K.
     \]
@@ -332,8 +341,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.pK_comp_pAX}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition, then
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation, then
     \[
         P_K \circ P_{AX} = P_K.
     \]
@@ -353,8 +362,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.reverse_product}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition, then
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation, then
     \[
         P_{XB} \circ P_{AX} = P_K.
     \]
@@ -372,8 +381,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.complement_comm}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition and
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation and
     \[
         Q_{AX} = 1 - P_{AX}, \qquad Q_{XB} = 1 - P_{XB},
     \]
@@ -396,7 +405,7 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \leanok
     \uses{def:is_decorrelated, def:has_commuting_parent_ham,
         lem:comp_complement_comm_zero}
-    If a subspace $K$ has a commuting parent Hamiltonian decomposition
+    If a subspace $K$ corresponds to a parent commuting Hamiltonian through
     $P_K = P_{AX} \circ P_{XB}$ with $[P_{AX}, P_{XB}] = 0$, and
     $A$-observables commute with $P_{XB}$ while $B$-observables commute
     with $P_{AX}$, then regions $A$ and $B$ are decorrelated w.r.t.\ $K$.
@@ -411,13 +420,13 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     past $P_{AX}$, the five-fold composition factors through this zero term.
 \end{proof}
 
-\begin{theorem}[Decorrelating commuting parent Hamiltonian structure]%
+\begin{theorem}[Decorrelating parent commuting Hamiltonian representation]%
     \label{thm:has_commuting_parent_ham_is_decorrelated}
     \lean{Decorrelation.HasCommutingParentHam.isDecorrelated}
     \leanok
     \uses{thm:commuting_ham_is_decorrelated, def:has_commuting_parent_ham, def:is_decorrelated}
     Corollary of Theorem~\ref{thm:commuting_ham_is_decorrelated}: if
-    $P_K$ has a commuting parent Hamiltonian decomposition and the local
+    $P_K$ has a parent commuting Hamiltonian representation and the local
     observables commute with the corresponding opposite projectors, then regions
     $A$ and $B$ are decorrelated w.r.t.\ $K$.
 \end{theorem}
@@ -441,8 +450,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.hamiltonian_eq}
     \leanok
     \uses{def:has_commuting_parent_ham, lem:frustration_free_ham_eq}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition, then
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation, then
     \[
         Q_{AX} + Q_{XB} - Q_{AX} \circ Q_{XB} = 1 - P_K,
     \]
@@ -463,8 +472,8 @@ decorrelation and its connection to commuting parent Hamiltonians, following
     \lean{Decorrelation.HasCommutingParentHam.mem_ground_iff}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    If $P_K = P_{AX} \circ P_{XB}$ is a commuting parent Hamiltonian
-    decomposition, then
+    If $P_K = P_{AX} \circ P_{XB}$ is a parent commuting Hamiltonian
+    representation, then
     \[
         P_K v = v
         \quad\Longleftrightarrow\quad


### PR DESCRIPTION
### Motivation
- arXiv:1606.00608, Definition 3.9 (`Papers/1606.00608/MPDO-22-12-17-2.tex:517--524`) defines parent Hamiltonians with a ground-space spanning clause and writes the commuting clause as `[\tau_j(P_L),P_L]=0`.
- arXiv:1606.00608, Theorem 3.10(iii) (`Papers/1606.00608/MPDO-22-12-17-2.tex:534--540`) states that `|V^{(N)}(A)\rangle` is a ground state of a NNCPH, which is stronger than the current commutativity and zero-energy predicates.
- `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` records this scope restriction; the Lean and blueprint prose should point to it directly.

### Description
- Clarify that `IsCommutingParentHam` records the pairwise translated-local-term form corresponding to the source's translated commutation relation, not the full parent-Hamiltonian definition.
- Mark `IsNNCPHGroundState`, `rfp_implies_nncph_ground_state`, and `nncph_implies_rfp` with the existing ground-state-scope restriction note.
- Rephrase Appendix D decorrelation prose toward the source wording "corresponds to a parent commuting Hamiltonian" and remove the local phrase "commuting parent Hamiltonian structure" from the touched blueprint entries.
- No theorem statements or proofs are changed.

### Testing
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD && git diff --check`
- `lake build TNLean.Axioms.Beigi TNLean.MPS.ParentHamiltonian.Commuting TNLean.MPS.ParentHamiltonian.Decorrelation -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/Commuting.lean TNLean/MPS/ParentHamiltonian/Decorrelation.lean TNLean/Axioms/Beigi.lean` (reports only the pre-existing Beigi axiom module)

---
Addresses #2633
Refs #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and blueprint comments only; formal definitions and proofs are unchanged, so runtime behavior and proof obligations are unaffected.
> 
> **Overview**
> Documentation-only alignment between arXiv:1606.00608 (Definition 3.9 / Theorem 3.10) and the Lean formalization. **No theorem statements or proofs change.**
> 
> **NNCPH / parent Hamiltonian scope:** Docstrings and blueprint text now state that `IsCommutingParentHam` and related predicates capture **pairwise translated local-term commutativity** (the source’s `[\tau_j(P_L),P_L]=0` picture), not the full parent-Hamiltonian definition with **ground-space spanning**. `IsNNCPHGroundState`, `rfp_implies_nncph_ground_state`, `nncph_implies_rfp`, and the Beigi axiom module docstring add explicit **scope restriction** notes and point to `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. The blueprint renames the reverse implication theorem to stress **pairwise length-two commutativity** as the hypothesis.
> 
> **Appendix D wording:** Lean and blueprint prose shift from “commuting parent Hamiltonian structure” to **parent commuting Hamiltonian representation** / “corresponds to a parent commuting Hamiltonian,” matching the source phrasing in touched `Decorrelation` and ch14 entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceab0004232874eaab86689feedb035605ca36b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->