### PR TITLE
feat(MPS/ParentHamiltonian): add word-indexed PGVWC boundary identity

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -344,8 +344,8 @@ with coefficients
   \sum_j\operatorname{tr}(A^j_b C^j_a A^j_w)
 \]
 already lies in \(\bigvee_j G_{n+2}(A^j)\), and the length-\(n\) simultaneous
-word tuples span the product matrix algebra, then each block admits a boundary matrix
-\(E_j\) such that
+word tuples span the product matrix algebra, then each block has a boundary
+matrix \(E_j\) such that
 \[
   A^j_bC^j_a=A^j_bE_jA^j_a.
 \] -/
@@ -463,13 +463,14 @@ theorem pgvwc07_blockwise_compatibility_of_trace_decomposition
   exact block_matrices_eq_of_wordTupleSpanTop_trace A hSpan
     (fun k => A k b * C k a) (fun k => Dmat k b * A k a) (hCoeff a b) j
 
-/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof.
+/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof,
+for an arbitrary finite index set.
 
 Assume
 \[
   A_b C_a=D_b A_a
 \]
-for all physical indices \(a,b\), and assume the right normalization
+for all indices \(a,b\), and assume the right normalization
 \[
   \sum_a A_aA_a^\dagger=I.
 \]
@@ -478,6 +479,38 @@ Then, with \(E=\sum_a C_aA_a^\dagger\),
   D_b=A_bE,\qquad A_bC_a=A_bEA_a.
 \]
 -/
+theorem pgvwc07_boundary_matrix_identities_of_indexed_compatibility
+    {ι : Type*} [Fintype ι]
+    (A : ι → Matrix (Fin D) (Fin D) ℂ)
+    (C Dmat : ι → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital : ∑ a : ι, A a * (A a)ᴴ = 1)
+    (hCompat : ∀ a b : ι, A b * C a = Dmat b * A a) :
+    (∀ b : ι, Dmat b = A b * (∑ a : ι, C a * (A a)ᴴ)) ∧
+      (∀ a b : ι,
+        A b * C a = A b * (∑ c : ι, C c * (A c)ᴴ) * A a) := by
+  classical
+  have hD : ∀ b : ι, Dmat b = A b * (∑ a : ι, C a * (A a)ᴴ) := by
+    intro b
+    calc
+      Dmat b = Dmat b * 1 := by simp
+      _ = Dmat b * (∑ a : ι, A a * (A a)ᴴ) := by rw [hUnital]
+      _ = ∑ a : ι, Dmat b * (A a * (A a)ᴴ) := by
+            rw [Matrix.mul_sum]
+      _ = ∑ a : ι, (Dmat b * A a) * (A a)ᴴ := by
+            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
+      _ = ∑ a : ι, (A b * C a) * (A a)ᴴ := by
+            exact Finset.sum_congr rfl fun a _ => by rw [← hCompat a b]
+      _ = ∑ a : ι, A b * (C a * (A a)ᴴ) := by
+            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
+      _ = A b * (∑ a : ι, C a * (A a)ᴴ) := by
+            rw [Matrix.mul_sum]
+  refine ⟨hD, ?_⟩
+  intro a b
+  calc
+    A b * C a = Dmat b * A a := hCompat a b
+    _ = A b * (∑ c : ι, C c * (A c)ᴴ) * A a := by rw [hD b]
+
+/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof. -/
 theorem pgvwc07_boundary_matrix_identities_of_compatibility
     (A : MPSTensor d D)
     (C Dmat : Fin d → Matrix (Fin D) (Fin D) ℂ)
@@ -486,27 +519,37 @@ theorem pgvwc07_boundary_matrix_identities_of_compatibility
     (∀ b : Fin d, Dmat b = A b * (∑ a : Fin d, C a * (A a)ᴴ)) ∧
       (∀ a b : Fin d,
         A b * C a = A b * (∑ c : Fin d, C c * (A c)ᴴ) * A a) := by
-  classical
-  have hD : ∀ b : Fin d, Dmat b = A b * (∑ a : Fin d, C a * (A a)ᴴ) := by
-    intro b
-    calc
-      Dmat b = Dmat b * 1 := by simp
-      _ = Dmat b * (∑ a : Fin d, A a * (A a)ᴴ) := by rw [hUnital]
-      _ = ∑ a : Fin d, Dmat b * (A a * (A a)ᴴ) := by
-            rw [Matrix.mul_sum]
-      _ = ∑ a : Fin d, (Dmat b * A a) * (A a)ᴴ := by
-            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
-      _ = ∑ a : Fin d, (A b * C a) * (A a)ᴴ := by
-            exact Finset.sum_congr rfl fun a _ => by rw [← hCompat a b]
-      _ = ∑ a : Fin d, A b * (C a * (A a)ᴴ) := by
-            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
-      _ = A b * (∑ a : Fin d, C a * (A a)ᴴ) := by
-            rw [Matrix.mul_sum]
-  refine ⟨hD, ?_⟩
-  intro a b
-  calc
-    A b * C a = Dmat b * A a := hCompat a b
-    _ = A b * (∑ c : Fin d, C c * (A c)ᴴ) * A a := by rw [hD b]
+  exact pgvwc07_boundary_matrix_identities_of_indexed_compatibility
+    A C Dmat hUnital hCompat
+
+/-- Word-indexed boundary-matrix identities in the PGVWC boundary comparison.
+
+This is the same normalized matrix calculation with the finite index set taken
+to be words of a fixed length:
+\[
+  A_\beta=A_{\beta_1}\cdots A_{\beta_K}.
+\]
+It is the algebraic form needed before the complementary-word boundary identity
+in the periodic block-diagonal argument. -/
+theorem pgvwc07_boundary_word_matrix_identities_of_compatibility
+    (A : MPSTensor d D) {K : ℕ}
+    (C Dmat : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital :
+      ∑ β : Fin K → Fin d,
+        evalWord A (List.ofFn β) * (evalWord A (List.ofFn β))ᴴ = 1)
+    (hCompat : ∀ α β : Fin K → Fin d,
+      evalWord A (List.ofFn β) * C α = Dmat β * evalWord A (List.ofFn α)) :
+    (∀ β : Fin K → Fin d,
+      Dmat β =
+        evalWord A (List.ofFn β) *
+          (∑ α : Fin K → Fin d, C α * (evalWord A (List.ofFn α))ᴴ)) ∧
+      (∀ α β : Fin K → Fin d,
+        evalWord A (List.ofFn β) * C α =
+          evalWord A (List.ofFn β) *
+            (∑ γ : Fin K → Fin d, C γ * (evalWord A (List.ofFn γ))ᴴ) *
+              evalWord A (List.ofFn α)) := by
+  exact pgvwc07_boundary_matrix_identities_of_indexed_compatibility
+    (fun β : Fin K → Fin d => evalWord A (List.ofFn β)) C Dmat hUnital hCompat
 
 /-- The composed PGVWC open-segment step from the trace decompositions to
 membership in the supremum of block ground spaces.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -182,10 +182,12 @@
 
 \begin{lemma}[Normalized boundary matrix identities]
     \label{lem:normalized_boundary_matrix_identities}
+    \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_indexed_compatibility}
     \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_compatibility}
+    \lean{MPSTensor.pgvwc07_boundary_word_matrix_identities_of_compatibility}
     \leanok
-    Let $(A_a)_{a\in I}$, $(C_a)_{a\in I}$, and $(D_b)_{b\in I}$ be
-    matrices in $M_D(\mathbb C)$, indexed by a finite physical alphabet. If
+    Let $(A_a)_{a\in I}$, $(C_a)_{a\in I}$, and $(D_b)_{b\in I}$ be matrices in
+    $M_D(\mathbb C)$, indexed by a finite alphabet. If
     \[
         \sum_a A_a A_a^\dagger=\Id,
         \qquad
@@ -202,6 +204,10 @@
         A_bC_a=A_bEA_a
     \]
     for all $a,b\in I$.
+
+    In particular, the same calculation applies when the alphabet is the finite
+    set of words of a fixed length and $A_\beta$ denotes
+    $A_{\beta_1}\cdots A_{\beta_K}$.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
### Motivation
- PGVWC07 Theorem 2blocks.2 compares the two boundary trace decompositions and obtains the compatibility equation \(A_b C_a = D_b A_a\), then uses the normalization \(\sum_a A_a A_a^\dagger = I\) to set \(E = \sum_a C_a A_a^\dagger\) and derive \(D_b=A_bE\), hence \(A_bC_a=A_bEA_a\).
- The parent-Hamiltonian boundary-closing route in #2651 needs the same normalized matrix calculation for finite families indexed by words, before the remaining complementary-word comparison can be closed.

### Description
- Generalize `pgvwc07_boundary_matrix_identities_of_compatibility` to an arbitrary finite alphabet.
- Keep the physical-letter theorem as the `Fin d` specialization of the general statement.
- Add the word-indexed corollary for the family \(A_\beta=A_{\beta_1}\cdots A_{\beta_K}\).
- Update the normalized-boundary blueprint entry to record the finite-alphabet and word-indexed forms.

### Testing
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing -q --log-level=info` (reports only the pre-existing `BoundaryClosingStripping` `sorry` warning)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD && git diff --check`
- `rg -n "\bsorry\b|\baxiom\b|\badmit\b|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `#print axioms` for the two new declarations: ordinary Lean foundations only (`propext`, `Classical.choice`, `Quot.sound`).

---
Addresses #2651
Refs #190
Refs #460

> [!NOTE]
> **Low Risk**
> Formal Lean refactor and new corollaries in parent-Hamiltonian algebra only; no runtime, auth, or data paths change.
>
> **Overview**
> **Generalizes** the PGVWC normalized boundary-matrix lemma so compatibility \(A_b C_a = D_b A_a\) plus \(\sum_a A_a A_a^\dagger = I\) implies \(D_b = A_b E\) and \(A_b C_a = A_b E A_a\) for any **finite index type** `ι`, not only physical letters `Fin d`.
>
> The existing `Fin d` theorem is now a one-line specialization of `pgvwc07_boundary_matrix_identities_of_indexed_compatibility`. A new **word-indexed** corollary instantiates `ι` with length-\(K\) words and \(A_\beta = \mathrm{evalWord}(A,\beta)\), for the periodic block-diagonal boundary-closing route.
>
> The blueprint lemma `lem:normalized_boundary_matrix_identities` is synced with the indexed and word forms and `\lean` tags.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 632e6ef8df4b372bf7c3f04aabbd0a754792550f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean algebra in parent-Hamiltonian proofs; no runtime, security, or data paths change, and call sites of the original `Fin d` theorem remain behaviorally the same via delegation.
> 
> **Overview**
> **Refactors** the PGVWC normalized boundary-matrix lemma so the core proof lives in `pgvwc07_boundary_matrix_identities_of_indexed_compatibility`, indexed by any finite type `ι` instead of only `Fin d`. The existing physical-letter theorem is now a one-line specialization of that statement.
> 
> Adds **`pgvwc07_boundary_word_matrix_identities_of_compatibility`**, instantiating `ι` with length-\(K\) words and \(A_\beta = \mathrm{evalWord}(A,\beta)\), for the periodic block-diagonal boundary-closing route (#2651).
> 
> The blueprint lemma `lem:normalized_boundary_matrix_identities` is updated with `\lean` tags for the indexed and word forms and a short word-alphabet remark. A minor docstring wording fix (“has” vs “admits”) appears in an earlier theorem comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae995a20c81846fbcdc7367c9349e436753f8fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->