### PR TITLE
feat(MPS/ParentHamiltonian): add two-length PGVWC boundary identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -209,6 +209,7 @@ import TNLean.MPS.Symmetry.StringOrder
 
 -- Layer 5: Multi-block
 import TNLean.MPS.Core.MultiBlock
+import TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+import TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities
 import TNLean.MPS.MPDO.BiCFDerivation.Selectors
 
 /-!
@@ -462,94 +463,6 @@ theorem pgvwc07_blockwise_compatibility_of_trace_decomposition
   intro j a b
   exact block_matrices_eq_of_wordTupleSpanTop_trace A hSpan
     (fun k => A k b * C k a) (fun k => Dmat k b * A k a) (hCoeff a b) j
-
-/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof,
-for an arbitrary finite index set.
-
-Assume
-\[
-  A_b C_a=D_b A_a
-\]
-for all indices \(a,b\), and assume the right normalization
-\[
-  \sum_a A_aA_a^\dagger=I.
-\]
-Then, with \(E=\sum_a C_aA_a^\dagger\),
-\[
-  D_b=A_bE,\qquad A_bC_a=A_bEA_a.
-\]
--/
-theorem pgvwc07_boundary_matrix_identities_of_indexed_compatibility
-    {ι : Type*} [Fintype ι]
-    (A : ι → Matrix (Fin D) (Fin D) ℂ)
-    (C Dmat : ι → Matrix (Fin D) (Fin D) ℂ)
-    (hUnital : ∑ a : ι, A a * (A a)ᴴ = 1)
-    (hCompat : ∀ a b : ι, A b * C a = Dmat b * A a) :
-    (∀ b : ι, Dmat b = A b * (∑ a : ι, C a * (A a)ᴴ)) ∧
-      (∀ a b : ι,
-        A b * C a = A b * (∑ c : ι, C c * (A c)ᴴ) * A a) := by
-  classical
-  have hD : ∀ b : ι, Dmat b = A b * (∑ a : ι, C a * (A a)ᴴ) := by
-    intro b
-    calc
-      Dmat b = Dmat b * 1 := by simp
-      _ = Dmat b * (∑ a : ι, A a * (A a)ᴴ) := by rw [hUnital]
-      _ = ∑ a : ι, Dmat b * (A a * (A a)ᴴ) := by
-            rw [Matrix.mul_sum]
-      _ = ∑ a : ι, (Dmat b * A a) * (A a)ᴴ := by
-            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
-      _ = ∑ a : ι, (A b * C a) * (A a)ᴴ := by
-            exact Finset.sum_congr rfl fun a _ => by rw [← hCompat a b]
-      _ = ∑ a : ι, A b * (C a * (A a)ᴴ) := by
-            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
-      _ = A b * (∑ a : ι, C a * (A a)ᴴ) := by
-            rw [Matrix.mul_sum]
-  refine ⟨hD, ?_⟩
-  intro a b
-  calc
-    A b * C a = Dmat b * A a := hCompat a b
-    _ = A b * (∑ c : ι, C c * (A c)ᴴ) * A a := by rw [hD b]
-
-/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof. -/
-theorem pgvwc07_boundary_matrix_identities_of_compatibility
-    (A : MPSTensor d D)
-    (C Dmat : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (hUnital : ∑ a : Fin d, A a * (A a)ᴴ = 1)
-    (hCompat : ∀ a b : Fin d, A b * C a = Dmat b * A a) :
-    (∀ b : Fin d, Dmat b = A b * (∑ a : Fin d, C a * (A a)ᴴ)) ∧
-      (∀ a b : Fin d,
-        A b * C a = A b * (∑ c : Fin d, C c * (A c)ᴴ) * A a) := by
-  exact pgvwc07_boundary_matrix_identities_of_indexed_compatibility
-    A C Dmat hUnital hCompat
-
-/-- Word-indexed boundary-matrix identities in the PGVWC boundary comparison.
-
-This is the same normalized matrix calculation with the finite index set taken
-to be words of a fixed length:
-\[
-  A_\beta=A_{\beta_1}\cdots A_{\beta_K}.
-\]
-It is the algebraic form needed before the complementary-word boundary identity
-in the periodic block-diagonal argument. -/
-theorem pgvwc07_boundary_word_matrix_identities_of_compatibility
-    (A : MPSTensor d D) {K : ℕ}
-    (C Dmat : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ)
-    (hUnital :
-      ∑ β : Fin K → Fin d,
-        evalWord A (List.ofFn β) * (evalWord A (List.ofFn β))ᴴ = 1)
-    (hCompat : ∀ α β : Fin K → Fin d,
-      evalWord A (List.ofFn β) * C α = Dmat β * evalWord A (List.ofFn α)) :
-    (∀ β : Fin K → Fin d,
-      Dmat β =
-        evalWord A (List.ofFn β) *
-          (∑ α : Fin K → Fin d, C α * (evalWord A (List.ofFn α))ᴴ)) ∧
-      (∀ α β : Fin K → Fin d,
-        evalWord A (List.ofFn β) * C α =
-          evalWord A (List.ofFn β) *
-            (∑ γ : Fin K → Fin d, C γ * (evalWord A (List.ofFn γ))ᴴ) *
-              evalWord A (List.ofFn α)) := by
-  exact pgvwc07_boundary_matrix_identities_of_indexed_compatibility
-    (fun β : Fin K → Fin d => evalWord A (List.ofFn β)) C Dmat hUnital hCompat
 
 /-- The composed PGVWC open-segment step from the trace decompositions to
 membership in the supremum of block ground spaces.

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+
+/-!
+# Boundary matrix identities
+
+This file records the normalized matrix calculation used in the PGVWC
+block-diagonal intersection proof.
+
+## References
+
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2, proof around
+  \(A_b C_a=D_b A_a\) and \(E=\sum_a C_a A_a^\dagger\).
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Two-index boundary-matrix identities in the PGVWC boundary comparison.
+
+This abstracts the normalized matrix calculation in PGVWC07,
+`MPSarchive.tex` lines 1446-1451.
+
+This is the same normalized calculation when the right-normalized family is
+indexed by a finite set and the left family is indexed by an arbitrary set:
+\[
+  A_b C_a=D_b B_a,\qquad \sum_a B_aB_a^\dagger=I.
+\]
+Then, with \(E=\sum_a C_aB_a^\dagger\),
+\[
+  D_b=A_bE,\qquad A_bC_a=A_bEB_a.
+\]
+-/
+theorem pgvwc07_boundary_matrix_identities_of_two_index_compatibility
+    {ι κ : Type*} [Fintype κ]
+    (A : ι → Matrix (Fin D) (Fin D) ℂ)
+    (B C : κ → Matrix (Fin D) (Fin D) ℂ)
+    (Dmat : ι → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital : ∑ a : κ, B a * (B a)ᴴ = 1)
+    (hCompat : ∀ a : κ, ∀ b : ι, A b * C a = Dmat b * B a) :
+    (∀ b : ι, Dmat b = A b * (∑ a : κ, C a * (B a)ᴴ)) ∧
+      (∀ a : κ, ∀ b : ι,
+        A b * C a = A b * (∑ c : κ, C c * (B c)ᴴ) * B a) := by
+  classical
+  have hD : ∀ b : ι, Dmat b = A b * (∑ a : κ, C a * (B a)ᴴ) := by
+    intro b
+    calc
+      Dmat b = Dmat b * 1 := by simp
+      _ = Dmat b * (∑ a : κ, B a * (B a)ᴴ) := by rw [hUnital]
+      _ = ∑ a : κ, Dmat b * (B a * (B a)ᴴ) := by
+            rw [Matrix.mul_sum]
+      _ = ∑ a : κ, (Dmat b * B a) * (B a)ᴴ := by
+            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
+      _ = ∑ a : κ, (A b * C a) * (B a)ᴴ := by
+            exact Finset.sum_congr rfl fun a _ => by rw [← hCompat a b]
+      _ = ∑ a : κ, A b * (C a * (B a)ᴴ) := by
+            exact Finset.sum_congr rfl fun a _ => by rw [Matrix.mul_assoc]
+      _ = A b * (∑ a : κ, C a * (B a)ᴴ) := by
+            rw [Matrix.mul_sum]
+  refine ⟨hD, ?_⟩
+  intro a b
+  calc
+    A b * C a = Dmat b * B a := hCompat a b
+    _ = A b * (∑ c : κ, C c * (B c)ᴴ) * B a := by rw [hD b]
+
+/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof,
+for an arbitrary finite index set.
+
+Assume
+\[
+  A_b C_a=D_b A_a
+\]
+for all indices \(a,b\), and assume the right normalization
+\[
+  \sum_a A_aA_a^\dagger=I.
+\]
+Then, with \(E=\sum_a C_aA_a^\dagger\),
+\[
+  D_b=A_bE,\qquad A_bC_a=A_bEA_a.
+\]
+-/
+theorem pgvwc07_boundary_matrix_identities_of_indexed_compatibility
+    {ι : Type*} [Fintype ι]
+    (A : ι → Matrix (Fin D) (Fin D) ℂ)
+    (C Dmat : ι → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital : ∑ a : ι, A a * (A a)ᴴ = 1)
+    (hCompat : ∀ a b : ι, A b * C a = Dmat b * A a) :
+    (∀ b : ι, Dmat b = A b * (∑ a : ι, C a * (A a)ᴴ)) ∧
+      (∀ a b : ι,
+        A b * C a = A b * (∑ c : ι, C c * (A c)ᴴ) * A a) := by
+  exact pgvwc07_boundary_matrix_identities_of_two_index_compatibility
+    A A C Dmat hUnital hCompat
+
+/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof. -/
+theorem pgvwc07_boundary_matrix_identities_of_compatibility
+    (A : MPSTensor d D)
+    (C Dmat : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital : ∑ a : Fin d, A a * (A a)ᴴ = 1)
+    (hCompat : ∀ a b : Fin d, A b * C a = Dmat b * A a) :
+    (∀ b : Fin d, Dmat b = A b * (∑ a : Fin d, C a * (A a)ᴴ)) ∧
+      (∀ a b : Fin d,
+        A b * C a = A b * (∑ c : Fin d, C c * (A c)ᴴ) * A a) := by
+  exact pgvwc07_boundary_matrix_identities_of_indexed_compatibility
+    A C Dmat hUnital hCompat
+
+/-- Word-indexed boundary-matrix identities in the PGVWC boundary comparison.
+
+This is the same normalized matrix calculation with the finite index set taken
+to be words of a fixed length:
+\[
+  A_\beta=A_{\beta_1}\cdots A_{\beta_K}.
+\]
+It is the algebraic form needed before the complementary-word boundary identity
+in the periodic block-diagonal argument. -/
+theorem pgvwc07_boundary_word_matrix_identities_of_compatibility
+    (A : MPSTensor d D) {K : ℕ}
+    (C Dmat : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital :
+      ∑ β : Fin K → Fin d,
+        evalWord A (List.ofFn β) * (evalWord A (List.ofFn β))ᴴ = 1)
+    (hCompat : ∀ α β : Fin K → Fin d,
+      evalWord A (List.ofFn β) * C α = Dmat β * evalWord A (List.ofFn α)) :
+    (∀ β : Fin K → Fin d,
+      Dmat β =
+        evalWord A (List.ofFn β) *
+          (∑ α : Fin K → Fin d, C α * (evalWord A (List.ofFn α))ᴴ)) ∧
+      (∀ α β : Fin K → Fin d,
+        evalWord A (List.ofFn β) * C α =
+          evalWord A (List.ofFn β) *
+            (∑ γ : Fin K → Fin d, C γ * (evalWord A (List.ofFn γ))ᴴ) *
+              evalWord A (List.ofFn α)) := by
+  exact pgvwc07_boundary_matrix_identities_of_indexed_compatibility
+    (fun β : Fin K → Fin d => evalWord A (List.ofFn β)) C Dmat hUnital hCompat
+
+/-- Two-length word-indexed boundary-matrix identities.
+
+This is the word-alphabet form of the PGVWC07 calculation in
+`MPSarchive.tex` lines 1446-1451.
+
+The two index sets are words of lengths \(K\) and \(M\):
+\[
+  A_\beta C_\rho=D_\beta B_\rho,\qquad
+  \sum_\rho B_\rho B_\rho^\dagger=I.
+\]
+This is the word form needed when a boundary-crossing cyclic interval has a
+wrapped word and a complementary word of different lengths. -/
+theorem pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
+    (A : MPSTensor d D) {K M : ℕ}
+    (C : (Fin M → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (Dmat : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital :
+      ∑ ρ : Fin M → Fin d,
+        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ = 1)
+    (hCompat : ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      evalWord A (List.ofFn β) * C ρ =
+        Dmat β * evalWord A (List.ofFn ρ)) :
+    (∀ β : Fin K → Fin d,
+      Dmat β =
+        evalWord A (List.ofFn β) *
+          (∑ ρ : Fin M → Fin d, C ρ * (evalWord A (List.ofFn ρ))ᴴ)) ∧
+      (∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+        evalWord A (List.ofFn β) * C ρ =
+          evalWord A (List.ofFn β) *
+            (∑ γ : Fin M → Fin d, C γ * (evalWord A (List.ofFn γ))ᴴ) *
+              evalWord A (List.ofFn ρ)) := by
+  exact pgvwc07_boundary_matrix_identities_of_two_index_compatibility
+    (fun β : Fin K → Fin d => evalWord A (List.ofFn β))
+    (fun ρ : Fin M → Fin d => evalWord A (List.ofFn ρ))
+    C Dmat hUnital hCompat
+
+/-- Complementary-word boundary identities from a two-length PGVWC comparison.
+
+This is the boundary-crossing form of the PGVWC07 calculation in
+`MPSarchive.tex` lines 1446-1451.
+
+Assume that for every complementary word \(\rho\) and wrapped word \(\beta\),
+\[
+  A_\beta C_\rho=(X A_\beta)A_\rho,
+\]
+and that the complementary-word products are right-normalized. Then for every
+\(\rho\) there is a matrix \(E_\rho\) such that
+\[
+  (X A_\beta)A_\rho=A_\beta E_\rho
+\]
+for every wrapped word \(\beta\). -/
+theorem pgvwc07_complementary_word_boundary_identities_of_compatibility
+    (A : MPSTensor d D) {K M : ℕ}
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (C : (Fin M → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital :
+      ∑ ρ : Fin M → Fin d,
+        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ = 1)
+    (hCompat : ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      evalWord A (List.ofFn β) * C ρ =
+        (X * evalWord A (List.ofFn β)) * evalWord A (List.ofFn ρ)) :
+    ∀ ρ : Fin M → Fin d,
+      ∃ E : Matrix (Fin D) (Fin D) ℂ,
+        ∀ β : Fin K → Fin d,
+          (X * evalWord A (List.ofFn β)) * evalWord A (List.ofFn ρ) =
+            evalWord A (List.ofFn β) * E := by
+  classical
+  intro ρ
+  let E₀ : Matrix (Fin D) (Fin D) ℂ :=
+    ∑ γ : Fin M → Fin d, C γ * (evalWord A (List.ofFn γ))ᴴ
+  refine ⟨E₀ * evalWord A (List.ofFn ρ), ?_⟩
+  intro β
+  have hRect :
+      evalWord A (List.ofFn β) * C ρ =
+        evalWord A (List.ofFn β) * E₀ * evalWord A (List.ofFn ρ) :=
+    (pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
+      (A := A) (C := C)
+      (Dmat := fun β : Fin K → Fin d => X * evalWord A (List.ofFn β))
+      hUnital hCompat).2 ρ β
+  calc
+    (X * evalWord A (List.ofFn β)) * evalWord A (List.ofFn ρ)
+        = evalWord A (List.ofFn β) * C ρ := (hCompat ρ β).symm
+    _ = evalWord A (List.ofFn β) * E₀ * evalWord A (List.ofFn ρ) := hRect
+    _ = evalWord A (List.ofFn β) * (E₀ * evalWord A (List.ofFn ρ)) := by
+          rw [Matrix.mul_assoc]
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -183,12 +183,12 @@ Assume that for every complementary word \(\rho\) and wrapped word \(\beta\),
 \[
   A_\beta C_\rho=(X A_\beta)A_\rho,
 \]
-and that the complementary-word products are right-normalized. Then for every
-\(\rho\) there is a matrix \(E_\rho\) such that
+and that the complementary-word products are right-normalized. Then, for every
+complementary word \(\rho\), there is a matrix \(E_\rho\) such that for every
+wrapped word \(\beta\),
 \[
   (X A_\beta)A_\rho=A_\beta E_\rho
-\]
-for every wrapped word \(\beta\). -/
+\]. -/
 theorem pgvwc07_complementary_word_boundary_identities_of_compatibility
     (A : MPSTensor d D) {K M : ℕ}
     (X : Matrix (Fin D) (Fin D) ℂ)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -179,7 +179,8 @@ theorem pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
 This is the boundary-crossing form of the PGVWC07 calculation in
 `MPSarchive.tex` lines 1446-1451.
 
-Assume that for every complementary word \(\rho\) and wrapped word \(\beta\),
+Let \(X\in M_D(\mathbb C)\) be a matrix. Assume that for every complementary
+word \(\rho\) and wrapped word \(\beta\),
 \[
   A_\beta C_\rho=(X A_\beta)A_\rho,
 \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -185,6 +185,8 @@
     \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_indexed_compatibility}
     \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_compatibility}
     \lean{MPSTensor.pgvwc07_boundary_word_matrix_identities_of_compatibility}
+    \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_two_index_compatibility}
+    \lean{MPSTensor.pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility}
     \leanok
     Let $(A_a)_{a\in I}$, $(C_a)_{a\in I}$, and $(D_b)_{b\in I}$ be matrices in
     $M_D(\mathbb C)$, indexed by a finite alphabet. If
@@ -208,6 +210,28 @@
     In particular, the same calculation applies when the alphabet is the finite
     set of words of a fixed length and $A_\beta$ denotes
     $A_{\beta_1}\cdots A_{\beta_K}$.
+
+    The same argument also applies when the normalized family is indexed by a
+    finite set $J$, while $(A_b)_{b\in I}$ and $(D_b)_{b\in I}$ are indexed by
+    a set $I$. If $(B_a)_{a\in J}$ and $(C_a)_{a\in J}$ are indexed by $J$,
+    and
+    \[
+        \sum_a B_aB_a^\dagger=\Id,
+        \qquad
+        A_bC_a=D_bB_a
+    \]
+    for all $a\in J$ and $b\in I$, then with
+    \[
+        E=\sum_a C_aB_a^\dagger
+    \]
+    one has
+    \[
+        D_b=A_bE,
+        \qquad
+        A_bC_a=A_bEB_a.
+    \]
+    This includes the case where $I$ and $J$ are word sets of different
+    lengths.
 \end{lemma}
 
 \begin{proof}
@@ -226,6 +250,56 @@
     \]
     Substituting this in $A_bC_a=D_bA_a$ gives
     $A_bC_a=A_bEA_a$.
+    For two alphabets, the corresponding step is
+    \[
+        D_b
+        =
+        D_b\sum_a B_aB_a^\dagger
+        =
+        \sum_a D_bB_aB_a^\dagger
+        =
+        \sum_a A_bC_aB_a^\dagger
+        =
+        A_bE ,
+    \]
+    where $E=\sum_a C_aB_a^\dagger$.  Substituting this in
+    $A_bC_a=D_bB_a$ gives $A_bC_a=A_bEB_a$.
+\end{proof}
+
+\begin{lemma}[Complementary-word boundary identities from the PGVWC comparison]
+    \label{lem:complementary_word_boundary_identities_from_pgvwc}
+    \lean{MPSTensor.pgvwc07_complementary_word_boundary_identities_of_compatibility}
+    \leanok
+    \uses{lem:normalized_boundary_matrix_identities}
+    Let $A_\beta$ be the products over wrapped words of length $K$, and let
+    $A_\rho$ be the products over complementary words of length $M$. Suppose
+    that the complementary-word products satisfy
+    \[
+        \sum_\rho A_\rho A_\rho^\dagger=\Id
+    \]
+    and that there are matrices $C_\rho$, indexed by complementary words, such
+    that for every wrapped word $\beta$ and complementary word $\rho$,
+    \[
+        A_\beta C_\rho=(X A_\beta)A_\rho.
+    \]
+    Then, for every complementary word $\rho$, there is a matrix $E_\rho$ such
+    that for every wrapped word $\beta$,
+    \[
+        (X A_\beta)A_\rho=A_\beta E_\rho.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:normalized_boundary_matrix_identities}
+    Apply Lemma~\ref{lem:normalized_boundary_matrix_identities} with
+    $D_\beta=X A_\beta$. It gives
+    \[
+        A_\beta C_\rho=A_\beta E A_\rho
+    \]
+    for $E=\sum_\gamma C_\gamma A_\gamma^\dagger$. Combining this with
+    $A_\beta C_\rho=(X A_\beta)A_\rho$ and setting
+    $E_\rho=EA_\rho$ gives the required identity.
 \end{proof}
 
 \begin{lemma}[A left-boundary summand is a ground-space vector]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -271,9 +271,10 @@
     \lean{MPSTensor.pgvwc07_complementary_word_boundary_identities_of_compatibility}
     \leanok
     \uses{lem:normalized_boundary_matrix_identities}
-    Let $A_\beta$ be the products over wrapped words of length $K$, and let
-    $A_\rho$ be the products over complementary words of length $M$. Suppose
-    that the complementary-word products satisfy
+    Let $A_\beta$ be the products over wrapped words of length $K$, let
+    $A_\rho$ be the products over complementary words of length $M$, and let
+    $X\in M_D(\mathbb C)$ be a matrix.  Suppose that the complementary-word
+    products satisfy
     \[
         \sum_\rho A_\rho A_\rho^\dagger=\Id
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -214,13 +214,13 @@
     The same argument also applies when the normalized family is indexed by a
     finite set $J$, while $(A_b)_{b\in I}$ and $(D_b)_{b\in I}$ are indexed by
     a set $I$. If $(B_a)_{a\in J}$ and $(C_a)_{a\in J}$ are indexed by $J$,
-    and
+    and if for all $a\in J$ and $b\in I$,
     \[
         \sum_a B_aB_a^\dagger=\Id,
         \qquad
         A_bC_a=D_bB_a
     \]
-    for all $a\in J$ and $b\in I$, then with
+    then with
     \[
         E=\sum_a C_aB_a^\dagger
     \]
@@ -297,9 +297,14 @@
     \[
         A_\beta C_\rho=A_\beta E A_\rho
     \]
-    for $E=\sum_\gamma C_\gamma A_\gamma^\dagger$. Combining this with
-    $A_\beta C_\rho=(X A_\beta)A_\rho$ and setting
-    $E_\rho=EA_\rho$ gives the required identity.
+    for $E=\sum_\gamma C_\gamma A_\gamma^\dagger$. With $E_\rho=EA_\rho$,
+    the compatibility hypothesis gives
+    \[
+        (X A_\beta)A_\rho
+        = A_\beta C_\rho
+        = A_\beta E A_\rho
+        = A_\beta E_\rho.
+    \]
 \end{proof}
 
 \begin{lemma}[A left-boundary summand is a ground-space vector]


### PR DESCRIPTION
### Motivation
- The next boundary-crossing step for #2651 needs the PGVWC comparison in the case where the wrapped word and complementary word have different lengths.
- PGVWC07, `Papers/quant-ph_0608197/MPSarchive.tex:1436--1452`, compares two boundary descriptions, obtains `A_b C_a = D_b A_a`, and uses right normalization to set `E = \sum_a C_a A_a^\dagger`, giving `D_b = A_b E` and `A_b C_a = A_b E A_a`.
- In the cyclic boundary-crossing window, the same calculation naturally has two word alphabets, so this PR records that form before feeding it into `hIdentity` in the block-diagonal crossing theorem.

### Description
- Factor the normalized PGVWC boundary calculation into `TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean`, keeping `BlockIntersectionProperty.lean` below the 1000-line Lean file guard.
- Add `pgvwc07_boundary_matrix_identities_of_two_index_compatibility`, the two-index normalized boundary calculation.
- Add `pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility`, the word-indexed specialization for lengths `K` and `M`.
- Add `pgvwc07_complementary_word_boundary_identities_of_compatibility`, giving, for each complementary word `ρ`, a matrix `E_ρ` with `(X A_β) A_ρ = A_β E_ρ` for all wrapped words `β`.
- Update the block-intersection trace blueprint with the same two-alphabet calculation and the complementary-word consequence.

### Scope
- This is preparatory for #2651. It does not yet derive the matrices `C_ρ` from the chain intersection hypotheses or apply the result to `blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities`.

### Testing
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing -q --log-level=info` (passes; reports the pre-existing `sorry` warning in `BoundaryClosingStripping.lean`)
- `lake build TNLean -q --log-level=info` (passes; reports pre-existing warnings outside this PR)
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- `cd blueprint/src && chktex -q -l ../.chktexrc chapter/ch14_parent_hamiltonian_block_intersection_trace.tex`
- `latexindent -k -s -l blueprint/latexindent.yaml blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean` (no matches)

Refs #2651
Refs #190
Refs #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure algebraic refactoring plus new lemmas in the parent-Hamiltonian proof layer; no auth, runtime, or data-path changes, and existing theorems are preserved via the new module.
> 
> **Overview**
> Moves the PGVWC normalized boundary matrix calculation out of `BlockIntersectionProperty.lean` into **`BoundaryMatrixIdentities.lean`**, with root and block-intersection imports updated so the large file stays under the line guard.
> 
> The new module generalizes the single-alphabet argument to **two index sets** (`pgvwc07_boundary_matrix_identities_of_two_index_compatibility`) and to **word alphabets of lengths K and M** (`pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility`). It adds **`pgvwc07_complementary_word_boundary_identities_of_compatibility`**, which produces per-complementary-word matrices `E_ρ` with `(X A_β) A_ρ = A_β E_ρ` for cyclic boundary crossing when wrapped and complementary words differ in length.
> 
> The block-intersection trace blueprint is extended with the two-alphabet normalized identities and the complementary-word lemma, linked to the new Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bd57ebf3c2fc831832aa4373eadabc040f1dccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->