### PR TITLE
feat(PEPS): closed-chain MPS corollaries at n >= 2L+1 via Lemma 5 overlapping windows

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -627,3 +627,6 @@ import TNLean.PEPS.CycleMPSTranslationInvariant
 -- Word-span extension and word transport for block-injective matrix tensors,
 -- the linear-algebraic inputs of the overlapping-window route.
 import TNLean.PEPS.CycleMPSWordTransport
+-- Lemma 5 of arXiv:1804.04964 for matrix tensors: bond-operator extraction
+-- from overlapping injective windows on the closed chain.
+import TNLean.PEPS.CycleMPSOverlapWindow

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -633,3 +633,6 @@ import TNLean.PEPS.CycleMPSOverlapWindow
 -- The insertion correspondence: same closed-chain state at one length
 -- n ≥ 2L+1 gives conjugate word products at that length.
 import TNLean.PEPS.CycleMPSOverlapInsertion
+-- The closed-chain corollaries at n ≥ 2L+1: single-gauge and per-bond
+-- forms of the Fundamental Theorem via the overlapping-window route.
+import TNLean.PEPS.CycleMPSOverlapCapstone

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -624,3 +624,6 @@ import TNLean.PEPS.CycleMPSFundamentalTheorem
 -- The single-gauge form of the closed-chain corollary: one gauge `Z` and a
 -- constant `λ` with `λ^n = 1`, with uniqueness of `Z` up to a constant.
 import TNLean.PEPS.CycleMPSTranslationInvariant
+-- Word-span extension and word transport for block-injective matrix tensors,
+-- the linear-algebraic inputs of the overlapping-window route.
+import TNLean.PEPS.CycleMPSWordTransport

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -630,3 +630,6 @@ import TNLean.PEPS.CycleMPSWordTransport
 -- Lemma 5 of arXiv:1804.04964 for matrix tensors: bond-operator extraction
 -- from overlapping injective windows on the closed chain.
 import TNLean.PEPS.CycleMPSOverlapWindow
+-- The insertion correspondence: same closed-chain state at one length
+-- n ≥ 2L+1 gives conjugate word products at that length.
+import TNLean.PEPS.CycleMPSOverlapInsertion

--- a/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
+++ b/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
@@ -18,7 +18,7 @@ multiplicative constant (`fundamentalTheorem_normalMPS_gauge_unique`).
 The statement is the source corollary's conclusion — a family of per-bond
 gauges — with the source's site-dependent families `{A_i}`, `{B_i}`
 specialized to a single repeated tensor; the source's translation-invariant
-corollary (lines 1633--1668: a single gauge `Z` and a constant `λ` with
+corollary (lines 1624--1661: a single gauge `Z` and a constant `λ` with
 `λ^n = 1`) refines this output and is not delivered here.
 
 The derivation goes through the cycle-graph corollary
@@ -420,7 +420,7 @@ closed-chain state at the single size `n`, are related by invertible matrices
 The conclusion is the source corollary's per-bond gauge family.  The source
 states the corollary for site-dependent families `{A_i}`, `{B_i}`; this
 statement is its specialization to one repeated tensor, and the source's
-translation-invariant corollary (lines 1633--1668, a single gauge `Z` with a
+translation-invariant corollary (lines 1624--1661, a single gauge `Z` with a
 constant `λ`, `λ^n = 1`) is the follow-up refinement, not delivered here.
 
 Source: arXiv:1804.04964, Section 3, first corollary after the theorem

--- a/TNLean/PEPS/CycleMPSOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSOverlapCapstone.lean
@@ -1,0 +1,465 @@
+import TNLean.PEPS.CycleMPSOverlapInsertion
+import TNLean.PEPS.CycleMPSFundamentalTheorem
+
+/-!
+# The closed-chain corollaries at `n ≥ 2L + 1` via overlapping windows
+
+This file delivers the strengthened closed-chain corollaries of the
+Fundamental Theorem for normal PEPS announced in arXiv:1804.04964 at line
+1623 and proved in its Section `normal_alt` (the corollary after Lemma 5,
+lines 2256--2295 of `Papers/1804.04964/paper_normal.tex`): two normal
+translation-invariant MPS on `n ≥ 2L + 1` sites — two matrix tensors, each
+`L`-block injective — generating the same closed-chain state are related by
+
+* a single gauge `Z` and a constant `λ` with `λ^n = 1` and
+  `B^i = λ · Z⁻¹ A^i Z`
+  (`fundamentalTheorem_normalMPS_translationInvariant_of_overlap`), and
+* equivalently a per-bond gauge family `Z_v` with `B^i = Z_v⁻¹ A^i Z_{v+1}`
+  (`fundamentalTheorem_normalMPS_of_overlap`), the form delivered at
+  `n ≥ 3L` by `fundamentalTheorem_normalMPS` through the three-arc cover.
+
+The uniqueness clause of the source corollary — the gauge `Z` is unique up
+to a multiplicative constant — needs no system size and is already delivered
+by `fundamentalTheorem_normalMPS_translationInvariant_gauge_unique`.
+
+The route consumes the insertion correspondence built from Lemma 5
+(`MPSTensor.exists_conjugation_of_mpv_eq`): the two networks have conjugate
+word products at length `n`, `B^w = Z ⬝ A^w ⬝ Z⁻¹`.  The remaining step is a
+rigidity lemma (`MPSTensor.proportional_of_evalWord_eq`): two `L`-block
+injective tensors with *equal* word products at one length `n ≥ 2L + 1` are
+proportional letterwise, `C^i = λ A^i` with `λ^n = 1`.  Its proof transports
+words of intermediate lengths between the two networks, shows the transport
+of the identity is a nonzero scalar — it commutes with every letter of `C`
+by comparing the two one-letter extensions — and peels one letter off the
+full-length equality through the spanning windows.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section `normal_alt`, the corollary after Lemma 5, lines 2256--2295 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Rigidity: equal word products at one length force proportional letters -/
+
+/-- A nonzero-size identity matrix is nonzero. -/
+private theorem matrix_one_ne_zero' (hD : 0 < D) :
+    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
+  intro h
+  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
+  rw [Matrix.one_apply_eq] at hentry
+  exact one_ne_zero hentry
+
+/-- **The transport of the identity is a nonzero scalar.**  For two tensors
+with matched word transports at lengths `k` and `k + 1`, the transported
+identity commutes with every letter of `C` — its two one-letter extensions
+agree — hence with the full matrix algebra by block injectivity, so it is a
+scalar; surjectivity of the transport makes the scalar nonzero.
+
+This is the mechanism by which the source's Lemma 5 route pins the inserted
+identity (arXiv:1804.04964, lines 2045--2255 of
+`Papers/1804.04964/paper_normal.tex`, applied to the gauge-absorbed pair). -/
+private theorem transport_one_eq_smul_one {A C : MPSTensor d D} {L k : ℕ}
+    (hD : 0 < D)
+    (hAk : IsNBlkInjective A k) (hCk : IsNBlkInjective C k)
+    (hCL : IsNBlkInjective C L)
+    {Λk Λk1 : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hΛk : ∀ τ : Fin k → Fin d,
+      Λk (evalWord A (List.ofFn τ)) = evalWord C (List.ofFn τ))
+    (hΛk1 : ∀ τ : Fin (k + 1) → Fin d,
+      Λk1 (evalWord A (List.ofFn τ)) = evalWord C (List.ofFn τ)) :
+    ∃ c : ℂ, c ≠ 0 ∧ Λk 1 = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  -- The two one-letter extension relations.
+  have hR1 : ∀ (i : Fin d) (M : Matrix (Fin D) (Fin D) ℂ),
+      Λk1 (A i * M) = C i * Λk M := by
+    intro i
+    have hext := LinearMap.ext_on_range
+      (v := fun τ : Fin k → Fin d => evalWord A (List.ofFn τ)) (hv := hAk)
+      (f := Λk1 ∘ₗ LinearMap.mulLeft ℂ (A i))
+      (g := (LinearMap.mulLeft ℂ (C i)) ∘ₗ Λk)
+      (fun τ => by
+        simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply]
+        rw [← evalWord_ofFn_cons, hΛk1 (Fin.cons i τ), evalWord_ofFn_cons, hΛk τ])
+    intro M
+    have := congrArg (· M) hext
+    simpa only [LinearMap.comp_apply, LinearMap.mulLeft_apply] using this
+  have hR2 : ∀ (i : Fin d) (M : Matrix (Fin D) (Fin D) ℂ),
+      Λk1 (M * A i) = Λk M * C i := by
+    intro i
+    have hext := LinearMap.ext_on_range
+      (v := fun τ : Fin k → Fin d => evalWord A (List.ofFn τ)) (hv := hAk)
+      (f := Λk1 ∘ₗ LinearMap.mulRight ℂ (A i))
+      (g := (LinearMap.mulRight ℂ (C i)) ∘ₗ Λk)
+      (fun τ => by
+        simp only [LinearMap.comp_apply, LinearMap.mulRight_apply]
+        rw [← evalWord_ofFn_snoc, hΛk1 (Fin.snoc τ i), evalWord_ofFn_snoc, hΛk τ])
+    intro M
+    have := congrArg (· M) hext
+    simpa only [LinearMap.comp_apply, LinearMap.mulRight_apply] using this
+  -- The transported identity commutes with every letter of `C`.
+  have hcomm_letter : ∀ i : Fin d, Commute (C i) (Λk 1) := by
+    intro i
+    have h1 : C i * Λk 1 = Λk1 (A i) := by
+      rw [← hR1 i 1, Matrix.mul_one]
+    have h2 : Λk 1 * C i = Λk1 (A i) := by
+      rw [← hR2 i 1, Matrix.one_mul]
+    exact h1.trans h2.symm
+  -- Hence with every word product, hence with the full matrix algebra.
+  have hcomm_word : ∀ w : List (Fin d), Commute (evalWord C w) (Λk 1) := by
+    intro w
+    induction w with
+    | nil => exact Commute.one_left (Λk 1)
+    | cons i w ih => exact (hcomm_letter i).mul_left ih
+  have hcomm : ∀ M : Matrix (Fin D) (Fin D) ℂ, Commute M (Λk 1) := by
+    intro M
+    have hM : M ∈ Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+        evalWord C (List.ofFn τ)) := by
+      have hspan : Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+          evalWord C (List.ofFn τ)) = ⊤ := hCL
+      rw [hspan]
+      exact Submodule.mem_top
+    induction hM using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨τ, rfl⟩ := hx
+        exact hcomm_word (List.ofFn τ)
+    | zero => exact Commute.zero_left _
+    | add x y _ _ hx hy => exact Commute.add_left hx hy
+    | smul a x _ hx => exact Commute.smul_left hx a
+  -- A matrix commuting with everything is a scalar.
+  obtain ⟨c, hc⟩ := Matrix.mem_range_scalar_iff_commute_single'.mpr
+    (fun i j => hcomm (Matrix.single i j 1))
+  have hV : Λk 1 = c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [← hc, Matrix.scalar_apply, Matrix.smul_one_eq_diagonal]
+  -- The transport is surjective, hence injective, so the scalar is nonzero.
+  have hsurj : Function.Surjective Λk := by
+    rw [← LinearMap.range_eq_top, eq_top_iff]
+    calc (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ))
+        = Submodule.span ℂ (Set.range fun τ : Fin k → Fin d =>
+            evalWord C (List.ofFn τ)) := hCk.symm
+      _ ≤ LinearMap.range Λk := by
+          rw [Submodule.span_le]
+          rintro _ ⟨τ, rfl⟩
+          exact ⟨evalWord A (List.ofFn τ), hΛk τ⟩
+  have hinj : Function.Injective Λk := LinearMap.injective_iff_surjective.mpr hsurj
+  refine ⟨c, fun hc0 => ?_, hV⟩
+  apply matrix_one_ne_zero' hD
+  apply hinj
+  rw [hV, hc0, zero_smul, map_zero]
+
+/-- Some length-`n` word product of a block-injective tensor is nonzero. -/
+private theorem exists_evalWord_ne_zero {A : MPSTensor d D} {L n : ℕ}
+    (hL : 0 < L) (hD : 0 < D) (hA : IsNBlkInjective A L) (hn : L ≤ n) :
+    ∃ σ : Fin n → Fin d, evalWord A (List.ofFn σ) ≠ 0 := by
+  by_contra hall
+  push Not at hall
+  have hspan : Submodule.span ℂ (Set.range fun σ : Fin n → Fin d =>
+      evalWord A (List.ofFn σ)) = ⊤ := isNBlkInjective_of_le hL hA hn
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
+      (Set.range fun σ : Fin n → Fin d => evalWord A (List.ofFn σ)) :=
+    hspan ▸ Submodule.mem_top
+  obtain ⟨c, hc⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+  apply matrix_one_ne_zero' hD
+  rw [← hc]
+  exact Finset.sum_eq_zero fun σ _ => by rw [hall σ, smul_zero]
+
+/-- **Rigidity of word products at one length** (arXiv:1804.04964, the
+endgame of the corollary after Lemma 5, lines 2256--2295 of
+`Papers/1804.04964/paper_normal.tex`, after the gauge is absorbed).
+
+Two `L`-block injective tensors with *equal* word products at one length
+`n ≥ 2L + 1` are proportional letterwise: `C^i = λ A^i` with `λ^n = 1`.
+The transports of the identity at window length `L` and at the complementary
+length `n - 1 - L` are nonzero scalars; peeling one letter off the
+full-length equality through the two spanning windows leaves
+`C^i = (c_L c_{n-1-L})⁻¹ A^i`. -/
+theorem proportional_of_evalWord_eq {A C : MPSTensor d D} {n L : ℕ}
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hD : 0 < D)
+    (hA : IsNBlkInjective A L) (hC : IsNBlkInjective C L)
+    (hw : ∀ w : List (Fin d), w.length = n → evalWord C w = evalWord A w) :
+    ∃ lam : ℂ, lam ^ n = 1 ∧ ∀ i : Fin d, C i = lam • A i := by
+  classical
+  -- The window transports at length `L` and at the complementary length.
+  set k₁ : ℕ := n - 1 - L with hk₁def
+  have hk₁L : L ≤ k₁ := by omega
+  obtain ⟨ΛL, hΛL⟩ := exists_evalWordTransport (k := L) (q := n - L) (by omega)
+    hA (isNBlkInjective_of_le hL hA (by omega)) hw
+  obtain ⟨ΛL1, hΛL1⟩ := exists_evalWordTransport (k := L + 1) (q := n - (L + 1))
+    (by omega) (isNBlkInjective_of_le hL hA (by omega))
+    (isNBlkInjective_of_le hL hA (by omega)) hw
+  obtain ⟨Λk, hΛk⟩ := exists_evalWordTransport (k := k₁) (q := n - k₁) (by omega)
+    (isNBlkInjective_of_le hL hA hk₁L) (isNBlkInjective_of_le hL hA (by omega)) hw
+  obtain ⟨Λk1, hΛk1⟩ := exists_evalWordTransport (k := k₁ + 1) (q := n - (k₁ + 1))
+    (by omega) (isNBlkInjective_of_le hL hA (by omega))
+    (isNBlkInjective_of_le hL hA (by omega)) hw
+  -- The transported identities are nonzero scalars.
+  obtain ⟨cL, hcL0, hcL⟩ := transport_one_eq_smul_one hD hA
+    (isNBlkInjective_of_le hL hC le_rfl) hC hΛL hΛL1
+  obtain ⟨ck, hck0, hck⟩ := transport_one_eq_smul_one hD
+    (isNBlkInjective_of_le hL hA hk₁L) (isNBlkInjective_of_le hL hC hk₁L) hC
+    hΛk hΛk1
+  -- Peel one letter off the full-length equality.
+  have hc0 : ∀ (i : Fin d) (v : Fin k₁ → Fin d) (w : Fin L → Fin d),
+      C i * evalWord C (List.ofFn v) * evalWord C (List.ofFn w) =
+        A i * evalWord A (List.ofFn v) * evalWord A (List.ofFn w) := by
+    intro i v w
+    have hword := hw (i :: (List.ofFn v ++ List.ofFn w)) (by simp; omega)
+    rw [evalWord_cons, evalWord_cons, evalWord_append, evalWord_append] at hword
+    rw [Matrix.mul_assoc, Matrix.mul_assoc]
+    exact hword
+  -- Linearize the trailing window through `Λ_L`.
+  have hΛL_inv : ΛL (cL⁻¹ • (1 : Matrix (Fin D) (Fin D) ℂ)) = 1 := by
+    rw [map_smul, hcL, smul_smul, inv_mul_cancel₀ hcL0, one_smul]
+  have hc2 : ∀ (i : Fin d) (v : Fin k₁ → Fin d),
+      C i * evalWord C (List.ofFn v) = cL⁻¹ • (A i * evalWord A (List.ofFn v)) := by
+    intro i v
+    have hext := LinearMap.ext_on_range
+      (v := fun w : Fin L → Fin d => evalWord A (List.ofFn w)) (hv := hA)
+      (f := (LinearMap.mulLeft ℂ (C i * evalWord C (List.ofFn v))) ∘ₗ ΛL)
+      (g := LinearMap.mulLeft ℂ (A i * evalWord A (List.ofFn v)))
+      (fun w => by
+        simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply]
+        rw [hΛL w]
+        exact hc0 i v w)
+    have happ := congrArg (· (cL⁻¹ • (1 : Matrix (Fin D) (Fin D) ℂ))) hext
+    simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply, hΛL_inv] at happ
+    rw [Matrix.mul_one] at happ
+    rw [happ, Matrix.mul_smul, Matrix.mul_one]
+  -- Linearize the remaining window through `Λ_{k₁}`.
+  have hΛk_inv : Λk (ck⁻¹ • (1 : Matrix (Fin D) (Fin D) ℂ)) = 1 := by
+    rw [map_smul, hck, smul_smul, inv_mul_cancel₀ hck0, one_smul]
+  have hc4 : ∀ i : Fin d, C i = (cL⁻¹ * ck⁻¹) • A i := by
+    intro i
+    have hext := LinearMap.ext_on_range
+      (v := fun v : Fin k₁ → Fin d => evalWord A (List.ofFn v))
+      (hv := isNBlkInjective_of_le hL hA hk₁L)
+      (f := (LinearMap.mulLeft ℂ (C i)) ∘ₗ Λk)
+      (g := cL⁻¹ • LinearMap.mulLeft ℂ (A i))
+      (fun v => by
+        simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
+          LinearMap.smul_apply]
+        rw [hΛk v]
+        exact hc2 i v)
+    have happ := congrArg (· (ck⁻¹ • (1 : Matrix (Fin D) (Fin D) ℂ))) hext
+    simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
+      LinearMap.smul_apply, hΛk_inv] at happ
+    rw [Matrix.mul_one] at happ
+    rw [happ, Matrix.mul_smul, smul_smul, Matrix.mul_one]
+  -- The scalar is an `n`-th root of unity.
+  set lam : ℂ := cL⁻¹ * ck⁻¹ with hlam
+  have hCfam : C = fun i => lam • A i := funext fun i => hc4 i
+  obtain ⟨σ, hσ⟩ := exists_evalWord_ne_zero hL hD hA (by omega : L ≤ n)
+  have hlamn : lam ^ n = 1 := by
+    have hCw : evalWord C (List.ofFn σ) = lam ^ n • evalWord A (List.ofFn σ) := by
+      rw [hCfam]
+      have := evalWord_smul lam A (List.ofFn σ)
+      simpa using this
+    have heq := hw (List.ofFn σ) (by simp)
+    rw [hCw] at heq
+    have hzero : (lam ^ n - 1) • evalWord A (List.ofFn σ) = 0 := by
+      rw [sub_smul, one_smul, heq, sub_self]
+    rcases smul_eq_zero.mp hzero with h | h
+    · exact sub_eq_zero.mp h
+    · exact absurd h hσ
+  exact ⟨lam, hlamn, hc4⟩
+
+/-- Block injectivity is preserved by conjugation. -/
+private theorem isNBlkInjective_conj {B : MPSTensor d D} {L : ℕ}
+    (hB : IsNBlkInjective B L) (Q : GL (Fin D) ℂ) :
+    IsNBlkInjective (fun i => (Q : Matrix (Fin D) (Fin D) ℂ) * B i *
+      ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) L := by
+  set C : MPSTensor d D := fun i => (Q : Matrix (Fin D) (Fin D) ℂ) * B i *
+    ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) with hCdef
+  have hCw : ∀ w : List (Fin d), evalWord C w =
+      (Q : Matrix (Fin D) (Fin D) ℂ) * evalWord B w *
+        ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
+    evalWord_gauge Q (fun i => rfl)
+  have hmem : ∀ N ∈ Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+      evalWord B (List.ofFn τ)),
+      (Q : Matrix (Fin D) (Fin D) ℂ) * N *
+          ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) ∈
+        Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+          evalWord C (List.ofFn τ)) := by
+    intro N hN
+    induction hN using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨τ, rfl⟩ := hx
+        exact Submodule.subset_span ⟨τ, hCw (List.ofFn τ)⟩
+    | zero =>
+        rw [Matrix.mul_zero, Matrix.zero_mul]
+        exact Submodule.zero_mem _
+    | add x y _ _ hx hy =>
+        rw [Matrix.mul_add, Matrix.add_mul]
+        exact Submodule.add_mem _ hx hy
+    | smul a x _ hx =>
+        rw [Matrix.mul_smul, Matrix.smul_mul]
+        exact Submodule.smul_mem _ a hx
+  rw [IsNBlkInjective, eq_top_iff]
+  intro M _
+  have hQQ : (Q : Matrix (Fin D) (Fin D) ℂ) *
+      ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) = 1 := by
+    rw [← Units.val_mul, mul_inv_cancel, Units.val_one]
+  have hMrep : M = (Q : Matrix (Fin D) (Fin D) ℂ) *
+      (((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
+        (Q : Matrix (Fin D) (Fin D) ℂ)) *
+      ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    calc M = 1 * M * 1 := by rw [Matrix.one_mul, Matrix.mul_one]
+      _ = ((Q : Matrix (Fin D) (Fin D) ℂ) *
+            ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) * M *
+          ((Q : Matrix (Fin D) (Fin D) ℂ) *
+            ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by rw [hQQ]
+      _ = (Q : Matrix (Fin D) (Fin D) ℂ) *
+            (((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * M *
+              (Q : Matrix (Fin D) (Fin D) ℂ)) *
+          ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+        simp only [Matrix.mul_assoc]
+  rw [hMrep]
+  apply hmem
+  rw [show Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+    evalWord B (List.ofFn τ)) = ⊤ from hB]
+  exact Submodule.mem_top
+
+end MPSTensor
+
+namespace TNLean
+namespace PEPS
+
+/-! ### The strengthened closed-chain corollaries -/
+
+/-- **Fundamental Theorem for translation-invariant normal MPS at
+`n ≥ 2L + 1`, single-gauge form** (arXiv:1804.04964, Section `normal_alt`,
+the corollary after Lemma 5, lines 2256--2295 of
+`Papers/1804.04964/paper_normal.tex`).
+
+Two matrix tensors `A` and `B` on `n ≥ 2L + 1` sites, each `L`-block
+injective — the matrix form of "blocking `L` consecutive sites results in an
+injective tensor" — generating the same closed-chain state at the single
+size `n`, are related by one invertible matrix `Z` and a constant `λ` with
+`λ^n = 1` through `B^i = λ · Z⁻¹ A^i Z` for every `i`.
+
+This strengthens `fundamentalTheorem_normalMPS_translationInvariant` from
+`n ≥ 3L` to the source's `n ≥ 2L + 1` by replacing the three-arc cover with
+the overlapping-window route: the insertion correspondence of Lemma 5 gives
+conjugate word products at length `n`
+(`MPSTensor.exists_conjugation_of_mpv_eq`), and the rigidity of word
+products at one length (`MPSTensor.proportional_of_evalWord_eq`) turns the
+conjugation into the letterwise gauge relation.  The uniqueness clause of
+the source corollary needs no system size and is
+`fundamentalTheorem_normalMPS_translationInvariant_gauge_unique`.
+
+Source: arXiv:1804.04964, Section `normal_alt`, the corollary after Lemma 5,
+lines 2256--2295 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalMPS_translationInvariant_of_overlap
+    {n L d D : ℕ} (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (A B : MPSTensor d D)
+    (hA : MPSTensor.IsNBlkInjective A L) (hB : MPSTensor.IsNBlkInjective B L)
+    (hAB : ∀ σ : Fin n → Fin d, MPSTensor.mpv A σ = MPSTensor.mpv B σ) :
+    ∃ (Z : GL (Fin D) ℂ) (lam : ℂ), lam ^ n = 1 ∧
+      ∀ i : Fin d, B i = lam • ((Z⁻¹ : GL (Fin D) ℂ) * A i * (Z : GL (Fin D) ℂ)) := by
+  rcases Nat.eq_zero_or_pos D with hD0 | hD
+  · subst hD0
+    refine ⟨1, 1, one_pow n, fun i => ?_⟩
+    apply Matrix.ext
+    intro a b
+    exact a.elim0
+  -- The conjugation at length `n` from the insertion correspondence.
+  obtain ⟨P, hP⟩ := MPSTensor.exists_conjugation_of_mpv_eq hL hn A B hA hB hAB
+  -- Absorb the gauge: the conjugated `B` has equal word products with `A`.
+  set Q : GL (Fin D) ℂ := P⁻¹ with hQdef
+  set C : MPSTensor d D := fun i => (Q : Matrix (Fin D) (Fin D) ℂ) * B i *
+    ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) with hCdef
+  have hCw : ∀ w : List (Fin d), MPSTensor.evalWord C w =
+      (Q : Matrix (Fin D) (Fin D) ℂ) * MPSTensor.evalWord B w *
+        ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
+    MPSTensor.evalWord_gauge Q (fun i => rfl)
+  have hCA : ∀ w : List (Fin d), w.length = n →
+      MPSTensor.evalWord C w = MPSTensor.evalWord A w := by
+    intro w hwlen
+    rw [hCw w, hP w hwlen, hQdef]
+    rw [inv_inv]
+    rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, ← Units.val_mul,
+      inv_mul_cancel, Units.val_one, Matrix.one_mul, Matrix.mul_assoc,
+      ← Units.val_mul, inv_mul_cancel, Units.val_one, Matrix.mul_one]
+  have hC : MPSTensor.IsNBlkInjective C L := MPSTensor.isNBlkInjective_conj hB Q
+  -- Rigidity: the conjugated `B` is proportional to `A`.
+  obtain ⟨lam, hlamn, hCi⟩ :=
+    MPSTensor.proportional_of_evalWord_eq hL hn hD hA hC hCA
+  refine ⟨Q, lam, hlamn, fun i => ?_⟩
+  -- Reassemble: `B^i = λ · Q⁻¹ A^i Q`.
+  have hBi : B i = ((Q⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * C i *
+      (Q : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [hCdef]
+    rw [← Matrix.mul_assoc, ← Matrix.mul_assoc, ← Units.val_mul,
+      inv_mul_cancel, Units.val_one, Matrix.one_mul, Matrix.mul_assoc,
+      ← Units.val_mul, inv_mul_cancel, Units.val_one, Matrix.mul_one]
+  rw [hBi, hCi i, Matrix.mul_smul, Matrix.smul_mul]
+
+/-- **Fundamental Theorem for translation-invariant normal MPS on a closed
+chain at `n ≥ 2L + 1`, per-bond form** (arXiv:1804.04964, Section
+`normal_alt`, the corollary after Lemma 5, lines 2256--2295 of
+`Papers/1804.04964/paper_normal.tex`).
+
+The per-bond gauge family delivered by `fundamentalTheorem_normalMPS` at
+`n ≥ 3L` exists already at the source's `n ≥ 2L + 1`: invertible matrices
+`Z_v`, one per bond of the closed chain, with `B^i = Z_v⁻¹ A^i Z_{v+1}` at
+every site.  The family dresses the single gauge of the strengthened
+translation-invariant corollary with powers of its root of unity,
+`Z_v = λ^v Z`; conversely the matrix-level collapse
+(`fundamentalTheorem_normalMPS_translationInvariant`) recovers the single
+gauge from any such family, so the two forms agree.
+
+Source: arXiv:1804.04964, Section `normal_alt`, the corollary after Lemma 5,
+lines 2256--2295 of `Papers/1804.04964/paper_normal.tex`. -/
+theorem fundamentalTheorem_normalMPS_of_overlap {n L d D : ℕ} [NeZero n]
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (A B : MPSTensor d D)
+    (hA : MPSTensor.IsNBlkInjective A L) (hB : MPSTensor.IsNBlkInjective B L)
+    (hAB : ∀ σ : Fin n → Fin d, MPSTensor.mpv A σ = MPSTensor.mpv B σ) :
+    ∃ Z : Fin n → GL (Fin D) ℂ, ∀ (v : Fin n) (i : Fin d),
+      B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ) := by
+  obtain ⟨Z₀, lam, hlamn, hZ₀⟩ :=
+    fundamentalTheorem_normalMPS_translationInvariant_of_overlap hL hn A B hA hB hAB
+  have hlam0 : lam ≠ 0 := by
+    intro h0
+    rw [h0, zero_pow (by omega : n ≠ 0)] at hlamn
+    exact zero_ne_one hlamn
+  have hpow0 : ∀ m : ℕ, lam ^ m ≠ 0 := fun m => pow_ne_zero m hlam0
+  -- The per-bond gauges: powers of the root of unity dress the single gauge.
+  refine ⟨fun v => Units.mk (lam ^ v.val • (Z₀ : Matrix (Fin D) (Fin D) ℂ))
+    ((lam ^ v.val)⁻¹ • ((Z₀⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))
+    (by rw [smul_mul_smul_comm, mul_inv_cancel₀ (hpow0 v.val), ← Units.val_mul,
+      mul_inv_cancel, Units.val_one, one_smul])
+    (by rw [smul_mul_smul_comm, inv_mul_cancel₀ (hpow0 v.val), ← Units.val_mul,
+      inv_mul_cancel, Units.val_one, one_smul]), fun v i => ?_⟩
+  rw [Units.inv_mk]
+  show B i = ((lam ^ v.val)⁻¹ •
+      ((Z₀⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) * A i *
+    (lam ^ (v + 1).val • (Z₀ : Matrix (Fin D) (Fin D) ℂ))
+  rw [Matrix.smul_mul, Matrix.mul_smul, Matrix.smul_mul, smul_smul]
+  -- The scalar collected around the bond is `λ`, including across the seam.
+  have hscal : (lam ^ v.val)⁻¹ * lam ^ (v + 1).val = lam := by
+    have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
+    rw [Fin.val_add_eq_ite, h1]
+    have hv := v.isLt
+    by_cases hwrap : n ≤ v.val + 1
+    · rw [if_pos hwrap]
+      have hv' : v.val = n - 1 := by omega
+      have hexp : v.val + 1 - n = 0 := by omega
+      rw [hexp, pow_zero, mul_one, hv']
+      -- `(λ^(n-1))⁻¹ = λ` because `λ · λ^(n-1) = λ^n = 1`.
+      have hmul : lam * lam ^ (n - 1) = 1 := by
+        rw [← pow_succ', show n - 1 + 1 = n by omega, hlamn]
+      field_simp
+      rw [← hmul]
+      ring
+    · rw [if_neg hwrap, pow_succ]
+      rw [← mul_assoc, inv_mul_cancel₀ (hpow0 v.val), one_mul]
+  rw [mul_comm (lam ^ ((v + 1 : Fin n) : ℕ)) ((lam ^ (v : ℕ))⁻¹), hscal]
+  exact hZ₀ i
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/CycleMPSOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSOverlapCapstone.lean
@@ -436,7 +436,7 @@ theorem fundamentalTheorem_normalMPS_of_overlap {n L d D : ℕ} [NeZero n]
     (by rw [smul_mul_smul_comm, inv_mul_cancel₀ (hpow0 v.val), ← Units.val_mul,
       inv_mul_cancel, Units.val_one, one_smul]), fun v i => ?_⟩
   rw [Units.inv_mk]
-  show B i = ((lam ^ v.val)⁻¹ •
+  change B i = ((lam ^ v.val)⁻¹ •
       ((Z₀⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) * A i *
     (lam ^ (v + 1).val • (Z₀ : Matrix (Fin D) (Fin D) ℂ))
   rw [Matrix.smul_mul, Matrix.mul_smul, Matrix.smul_mul, smul_smul]

--- a/TNLean/PEPS/CycleMPSOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSOverlapInsertion.lean
@@ -1,0 +1,467 @@
+import TNLean.PEPS.CycleMPSOverlapWindow
+import TNLean.Algebra.SkolemNoether
+
+/-!
+# The insertion correspondence of the overlapping-window route
+
+This file applies the bond-operator extraction of
+`TNLean/PEPS/CycleMPSOverlapWindow.lean` — the matrix-tensor form of Lemma 5
+of arXiv:1804.04964 (lines 2045--2255 of
+`Papers/1804.04964/paper_normal.tex`) — to two `L`-block-injective tensors
+`A`, `B` generating the same closed-chain state on `n ≥ 2L + 1` sites, and
+delivers the conjugation between the two networks at length `n`
+(`MPSTensor.exists_conjugation_of_mpv_eq`):
+an invertible matrix `Z` with `B^w = Z ⬝ A^w ⬝ Z⁻¹` for every word `w` of
+length `n`.
+
+The route follows the source's derivation of the `n ≥ 2L + 1` corollary from
+Lemma 5 (lines 1961--2043 for the forward realization, lines 2045--2295 for
+the converse and the corollary):
+
+1. A virtual insertion `X` on a bond of the `A`-network is realized on each
+   of the `L + 1` overlapping windows around the bond
+   (`eq:normal_resonate`, lines 1961--2043): the deformed window tensor at
+   position `j` places `X` after the first `L - j` letters of the window.
+2. The deformed window tensors are transported to the `B`-network by the word
+   transport `Λ` of `TNLean/PEPS/CycleMPSWordTransport.lean`; the same-state
+   hypothesis makes the transported deformations generate one common state.
+3. Lemma 5 for the `B`-network extracts a bond operator `Y = Φ X`, with
+   `Λ (A^a ⬝ X) = B^a ⬝ Φ X` and `Λ (X ⬝ A^b) = Φ X ⬝ B^b` on all window
+   words.  Uniqueness of the bond operator makes `X ↦ Φ X` linear, unital and
+   multiplicative — the source's algebra-homomorphism clause for
+   `O_1 ↦ X` and `O_3^T ↦ X` (line 2253).
+4. A unital multiplicative endomorphism of a full matrix algebra is an
+   automorphism, and by Skolem--Noether it is inner: `Φ X = Z⁻¹ ⬝ X ⬝ Z`
+   (the source's `Y = Z⁻¹ X Z`, lines 582--584 in the injective case).
+   Pairing the insertions against all closed-chain words turns the relation
+   `⟨X, A^w⟩ = ⟨Φ X, B^w⟩` into the conjugation `B^w = Z ⬝ A^w ⬝ Z⁻¹` at
+   length `n`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section `normal_alt`, lines 1915--2295 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Words with one insertion -/
+
+/-- The word product with a matrix inserted after the first `p` letters: the
+matrix-tensor form of the deformed window tensors of arXiv:1804.04964,
+`eq:X->O` (line 333) and the windows of `eq:normal_resonate` (lines
+1961--2043 of `Papers/1804.04964/paper_normal.tex`). -/
+private noncomputable def insertedWord (A : MPSTensor d D) (X : Matrix (Fin D) (Fin D) ℂ)
+    (p : ℕ) (w : List (Fin d)) : Matrix (Fin D) (Fin D) ℂ :=
+  evalWord A (w.take p) * X * evalWord A (w.drop p)
+
+private theorem insertedWord_length (A : MPSTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) {w : List (Fin d)} {p : ℕ} (hp : w.length ≤ p) :
+    insertedWord A X p w = evalWord A w * X := by
+  rw [insertedWord, List.take_of_length_le hp, List.drop_of_length_le hp,
+    evalWord_nil, Matrix.mul_one]
+
+private theorem insertedWord_zero (A : MPSTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d)) :
+    insertedWord A X 0 w = X * evalWord A w := by
+  rw [insertedWord, List.take_zero, List.drop_zero, evalWord_nil, Matrix.one_mul]
+
+/-- Appending a letter beyond the insertion point. -/
+private theorem insertedWord_append_letter (A : MPSTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) {p : ℕ} {w : List (Fin d)} (hp : p ≤ w.length)
+    (i : Fin d) :
+    insertedWord A X p w * A i = insertedWord A X p (w ++ [i]) := by
+  rw [insertedWord, insertedWord, List.take_append_of_le_length hp,
+    List.drop_append_of_le_length hp, evalWord_append]
+  simp only [evalWord_cons, evalWord_nil, Matrix.mul_one, Matrix.mul_assoc]
+
+/-- Prepending a letter before the insertion point. -/
+private theorem insertedWord_cons_letter (A : MPSTensor d D)
+    (X : Matrix (Fin D) (Fin D) ℂ) (p : ℕ) (w : List (Fin d)) (i : Fin d) :
+    A i * insertedWord A X p w = insertedWord A X (p + 1) (i :: w) := by
+  rw [insertedWord, insertedWord, List.take_succ_cons, List.drop_succ_cons,
+    evalWord_cons]
+  simp only [Matrix.mul_assoc]
+
+/-! ### The transported deformation generates the inserted state -/
+
+/-- **The transport intertwines the closed-chain pairings**
+(arXiv:1804.04964, the mechanism of Lemma 5, lines 2045--2255 of
+`Papers/1804.04964/paper_normal.tex`): expanding any matrix `M` over the
+window products of `A` and re-reading the expansion in the `B`-network leaves
+every closed-chain coefficient of total length `n` unchanged. -/
+private theorem trace_transport_sandwich {A B : MPSTensor d D} {n L : ℕ}
+    (hA : IsNBlkInjective A L)
+    (hAB : ∀ σ : Fin n → Fin d, mpv A σ = mpv B σ)
+    {Λ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hΛ : ∀ τ : Fin L → Fin d,
+      Λ (evalWord A (List.ofFn τ)) = evalWord B (List.ofFn τ))
+    (M : Matrix (Fin D) (Fin D) ℂ) (pre post : List (Fin d))
+    (hlen : pre.length + L + post.length = n) :
+    Matrix.trace (evalWord B pre * Λ M * evalWord B post) =
+      Matrix.trace (evalWord A pre * M * evalWord A post) := by
+  classical
+  have hspan : Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+      evalWord A (List.ofFn τ)) = ⊤ := hA
+  have hM : M ∈ Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+      evalWord A (List.ofFn τ)) := hspan ▸ Submodule.mem_top
+  obtain ⟨c, hc⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp hM
+  have hΛM : Λ M = ∑ τ : Fin L → Fin d, c τ • evalWord B (List.ofFn τ) := by
+    rw [← hc, map_sum]
+    exact Finset.sum_congr rfl fun τ _ => by rw [map_smul, hΛ τ]
+  have decomp : ∀ (T : MPSTensor d D) (N : Matrix (Fin D) (Fin D) ℂ),
+      N = (∑ τ : Fin L → Fin d, c τ • evalWord T (List.ofFn τ)) →
+      Matrix.trace (evalWord T pre * N * evalWord T post) =
+        ∑ τ : Fin L → Fin d,
+          c τ * Matrix.trace (evalWord T (pre ++ (List.ofFn τ ++ post))) := by
+    intro T N hN
+    rw [hN, Finset.mul_sum, Finset.sum_mul, Matrix.trace_sum]
+    refine Finset.sum_congr rfl fun τ _ => ?_
+    rw [mul_smul_comm, smul_mul_assoc, Matrix.trace_smul, smul_eq_mul]
+    congr 1
+    rw [evalWord_append, evalWord_append, Matrix.mul_assoc]
+  rw [decomp B (Λ M) hΛM, decomp A M hc.symm]
+  refine Finset.sum_congr rfl fun τ _ => ?_
+  congr 1
+  exact (trace_evalWord_eq_of_mpv_eq hAB (by simp; omega)).symm
+
+/-! ### The insertion correspondence -/
+
+/-- **The insertion correspondence at one bond** (arXiv:1804.04964, Lemma 5
+applied to the deformations realizing a virtual insertion, lines 1961--2255
+of `Papers/1804.04964/paper_normal.tex`): for every insertion `X` on the
+`A`-network there is a unique `Y` on the `B`-network with
+`Λ (A^a ⬝ X) = B^a ⬝ Y` and `Λ (X ⬝ A^b) = Y ⬝ B^b` on all window words. -/
+private theorem exists_insertion_image {A B : MPSTensor d D} {n L : ℕ}
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n)
+    (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hAB : ∀ σ : Fin n → Fin d, mpv A σ = mpv B σ)
+    {Λ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hΛ : ∀ τ : Fin L → Fin d,
+      Λ (evalWord A (List.ofFn τ)) = evalWord B (List.ofFn τ))
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      (∀ a : Fin L → Fin d,
+        Λ (evalWord A (List.ofFn a) * X) = evalWord B (List.ofFn a) * Y) ∧
+        (∀ b : Fin L → Fin d,
+          Λ (X * evalWord A (List.ofFn b)) = Y * evalWord B (List.ofFn b)) := by
+  classical
+  -- The deformed window tensors transported to the `B`-network.
+  set C : ℕ → (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+    fun j s => Λ (insertedWord A X (L - j) (List.ofFn s)) with hC
+  -- All transported deformations generate the same state: each one matches
+  -- the `A`-state with `X` inserted on the bond.
+  have hstate : ∀ j, j < L → ∀ {q : ℕ}, j + (L + 1) + q = n →
+      ∀ (pre : Fin j → Fin d) (u : Fin (L + 1) → Fin d) (post : Fin q → Fin d),
+      Matrix.trace (evalWord B (List.ofFn pre) *
+          (C j (Fin.init u) * B (u (Fin.last L))) * evalWord B (List.ofFn post)) =
+        Matrix.trace (evalWord B (List.ofFn pre) *
+          (B (u 0) * C (j + 1) (Fin.tail u)) * evalWord B (List.ofFn post)) := by
+    intro j hj q hq pre u post
+    have hlen_init : (List.ofFn (Fin.init u)).length = L := by simp
+    have hlen_tail : (List.ofFn (Fin.tail u)).length = L := by simp
+    -- The left side: absorb the trailing letter into the suffix, transport,
+    -- and push the letter back into the deformed word.
+    have hleft : Matrix.trace (evalWord B (List.ofFn pre) *
+        (C j (Fin.init u) * B (u (Fin.last L))) * evalWord B (List.ofFn post)) =
+        Matrix.trace (evalWord A (List.ofFn pre) *
+          insertedWord A X (L - j) (List.ofFn u) * evalWord A (List.ofFn post)) := by
+      have e1 : evalWord B (List.ofFn pre) *
+          (C j (Fin.init u) * B (u (Fin.last L))) * evalWord B (List.ofFn post) =
+          evalWord B (List.ofFn pre) * C j (Fin.init u) *
+            evalWord B (u (Fin.last L) :: List.ofFn post) := by
+        rw [evalWord_cons]
+        simp only [Matrix.mul_assoc]
+      rw [e1, hC]
+      rw [trace_transport_sandwich hA hAB hΛ _ (List.ofFn pre)
+        (u (Fin.last L) :: List.ofFn post) (by simp; omega)]
+      have e2 : evalWord A (List.ofFn pre) *
+          insertedWord A X (L - j) (List.ofFn (Fin.init u)) *
+            evalWord A (u (Fin.last L) :: List.ofFn post) =
+          evalWord A (List.ofFn pre) *
+            (insertedWord A X (L - j) (List.ofFn (Fin.init u)) * A (u (Fin.last L))) *
+              evalWord A (List.ofFn post) := by
+        rw [evalWord_cons]
+        simp only [Matrix.mul_assoc]
+      rw [e2, insertedWord_append_letter A X (by omega : L - j ≤
+        (List.ofFn (Fin.init u)).length) (u (Fin.last L))]
+      have e3 : List.ofFn (Fin.init u) ++ [u (Fin.last L)] = List.ofFn u := by
+        rw [List.ofFn_succ' u, List.concat_eq_append]
+        rfl
+      rw [e3]
+    -- The right side: absorb the leading letter into the prefix, transport,
+    -- and push the letter back into the deformed word.
+    have hright : Matrix.trace (evalWord B (List.ofFn pre) *
+        (B (u 0) * C (j + 1) (Fin.tail u)) * evalWord B (List.ofFn post)) =
+        Matrix.trace (evalWord A (List.ofFn pre) *
+          insertedWord A X (L - j) (List.ofFn u) * evalWord A (List.ofFn post)) := by
+      have e1 : evalWord B (List.ofFn pre) *
+          (B (u 0) * C (j + 1) (Fin.tail u)) * evalWord B (List.ofFn post) =
+          evalWord B (List.ofFn pre ++ [u 0]) * C (j + 1) (Fin.tail u) *
+            evalWord B (List.ofFn post) := by
+        rw [evalWord_append]
+        simp only [evalWord_cons, evalWord_nil, Matrix.mul_one, Matrix.mul_assoc]
+      rw [e1, hC]
+      rw [trace_transport_sandwich hA hAB hΛ _ (List.ofFn pre ++ [u 0])
+        (List.ofFn post) (by simp; omega)]
+      have e2 : evalWord A (List.ofFn pre ++ [u 0]) *
+          insertedWord A X (L - (j + 1)) (List.ofFn (Fin.tail u)) *
+            evalWord A (List.ofFn post) =
+          evalWord A (List.ofFn pre) *
+            (A (u 0) * insertedWord A X (L - (j + 1)) (List.ofFn (Fin.tail u))) *
+              evalWord A (List.ofFn post) := by
+        rw [evalWord_append]
+        simp only [evalWord_cons, evalWord_nil, Matrix.mul_one, Matrix.mul_assoc]
+      rw [e2, insertedWord_cons_letter A X (L - (j + 1)) (List.ofFn (Fin.tail u))
+        (u 0)]
+      have e3 : u 0 :: List.ofFn (Fin.tail u) = List.ofFn u := by
+        rw [List.ofFn_succ (f := u)]
+        rfl
+      have e4 : L - (j + 1) + 1 = L - j := by omega
+      rw [e3, e4]
+    rw [hleft, hright]
+  -- Lemma 5 extracts the bond operator.
+  obtain ⟨Y, hY1, hY2⟩ := overlapWindow_exists_bondOperator hL hn hB C hstate
+  refine ⟨Y, fun a => ?_, fun b => ?_⟩
+  · have h0 := hY1 a
+    simp only [hC, Nat.sub_zero] at h0
+    rw [← insertedWord_length A X (p := L) (by simp : (List.ofFn a).length ≤ L)]
+    exact h0
+  · have hL0 := hY2 b
+    simp only [hC, Nat.sub_self, insertedWord_zero] at hL0
+    exact hL0
+
+/-! ### Assembling the conjugation -/
+
+/-- A nonzero-size identity matrix is nonzero. -/
+private theorem matrix_one_ne_zero (hD : 0 < D) :
+    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
+  intro h
+  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
+  rw [Matrix.one_apply_eq] at hentry
+  exact one_ne_zero hentry
+
+/-- Two matrices with equal trace pairings against every matrix on the left
+are equal. -/
+private theorem eq_of_trace_mul_left_eq {M N : Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace (X * M) = Matrix.trace (X * N)) : M = N := by
+  have h0 : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace ((M - N) * X) = 0 := by
+    intro X
+    rw [Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_mul_comm M X,
+      Matrix.trace_mul_comm N X, h X, sub_self]
+  exact sub_eq_zero.mp (trace_mul_right_eq_zero h0)
+
+/-- Any list of declared length is the word of a tuple. -/
+private theorem exists_ofFn_of_length {l : List (Fin d)} {k : ℕ}
+    (hl : l.length = k) : ∃ a : Fin k → Fin d, List.ofFn a = l := by
+  subst hl
+  exact ⟨l.get, List.ofFn_get l⟩
+
+/-- **The conjugation between two same-state networks at length `n ≥ 2L + 1`**
+(arXiv:1804.04964, Lemma 5 and the first half of the closed-chain corollary
+of Section `normal_alt`, lines 1961--2295 of
+`Papers/1804.04964/paper_normal.tex`, specialized to one site-independent
+tensor).
+
+Two `L`-block-injective tensors with the same closed-chain coefficients at
+one length `n ≥ 2L + 1` have conjugate word products at length `n`: there is
+an invertible `Z` with `B^w = Z ⬝ A^w ⬝ Z⁻¹` for every word `w` of length
+`n`.  The insertion correspondence `X ↦ Y` built from Lemma 5 is linear by
+uniqueness of the bond operator, unital and multiplicative — the source's
+algebra-homomorphism clause (line 2253) — hence an automorphism of the full
+matrix algebra, and by Skolem--Noether (the source's argument at lines
+582--584) it is conjugation by some `Z`; pairing insertions against all
+closed-chain words of length `n` transfers the conjugation to the word
+products. -/
+theorem exists_conjugation_of_mpv_eq {n L : ℕ} (hL : 0 < L) (hn : 2 * L + 1 ≤ n)
+    (A B : MPSTensor d D) (hA : IsNBlkInjective A L) (hB : IsNBlkInjective B L)
+    (hAB : ∀ σ : Fin n → Fin d, mpv A σ = mpv B σ) :
+    ∃ Z : GL (Fin D) ℂ, ∀ w : List (Fin d), w.length = n →
+      evalWord B w = (Z : Matrix (Fin D) (Fin D) ℂ) * evalWord A w *
+        ((Z⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+  classical
+  rcases Nat.eq_zero_or_pos D with hD0 | hD
+  · -- All `0 × 0` matrices are equal.
+    subst hD0
+    refine ⟨1, fun w hw => ?_⟩
+    apply Matrix.ext
+    intro a b
+    exact a.elim0
+  -- The word transport from the same-state hypothesis.
+  obtain ⟨Λ, hΛ⟩ := exists_mpvTransport (k := L) (q := n - L) (by omega) hA
+    (isNBlkInjective_of_le hL hA (by omega)) hAB
+  -- The insertion correspondence, with its defining identities.
+  have hins := exists_insertion_image hL hn hA hB hAB hΛ
+  -- The identity decomposition over the `B`-window products.
+  have hspanB : Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+      evalWord B (List.ofFn τ)) = ⊤ := hB
+  have h1B : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
+      (Set.range fun τ : Fin L → Fin d => evalWord B (List.ofFn τ)) :=
+    hspanB ▸ Submodule.mem_top
+  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1B
+  -- The correspondence as a linear map.
+  set Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+    ∑ b : Fin L → Fin d, α b •
+      (Λ ∘ₗ LinearMap.mulRight ℂ (evalWord A (List.ofFn b))) with hΦdef
+  have hΦ_apply : ∀ X, Φ X = ∑ b : Fin L → Fin d,
+      α b • Λ (X * evalWord A (List.ofFn b)) := by
+    intro X
+    rw [hΦdef]
+    simp only [LinearMap.sum_apply, LinearMap.smul_apply, LinearMap.comp_apply,
+      LinearMap.mulRight_apply]
+  -- `Φ X` is the bond operator of `X`.
+  have hΦY : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      (∀ a : Fin L → Fin d,
+        Λ (evalWord A (List.ofFn a) * X) = evalWord B (List.ofFn a) * Φ X) ∧
+        (∀ b : Fin L → Fin d,
+          Λ (X * evalWord A (List.ofFn b)) = Φ X * evalWord B (List.ofFn b)) := by
+    intro X
+    obtain ⟨Y, hY1, hY2⟩ := hins X
+    have hYΦ : Φ X = Y := by
+      rw [hΦ_apply]
+      calc (∑ b : Fin L → Fin d, α b • Λ (X * evalWord A (List.ofFn b)))
+          = ∑ b : Fin L → Fin d, α b • (Y * evalWord B (List.ofFn b)) :=
+            Finset.sum_congr rfl fun b _ => by rw [hY2 b]
+        _ = ∑ b : Fin L → Fin d, Y * (α b • evalWord B (List.ofFn b)) :=
+            Finset.sum_congr rfl fun b _ =>
+              (mul_smul_comm (α b) Y (evalWord B (List.ofFn b))).symm
+        _ = Y * ∑ b : Fin L → Fin d, α b • evalWord B (List.ofFn b) := by
+            rw [← Finset.mul_sum]
+        _ = Y := by rw [hα, Matrix.mul_one]
+    rw [hYΦ]
+    exact ⟨hY1, hY2⟩
+  have hΦ1 : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (a : Fin L → Fin d),
+      Λ (evalWord A (List.ofFn a) * X) = evalWord B (List.ofFn a) * Φ X :=
+    fun X => (hΦY X).1
+  have hΦ2 : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (b : Fin L → Fin d),
+      Λ (X * evalWord A (List.ofFn b)) = Φ X * evalWord B (List.ofFn b) :=
+    fun X => (hΦY X).2
+  -- The right-multiplication relation extends from window products to all
+  -- matrices, making `Φ` multiplicative.
+  have hΛr : ∀ (X M : Matrix (Fin D) (Fin D) ℂ), Λ (M * X) = Λ M * Φ X := by
+    intro X
+    have hext := LinearMap.ext_on_range
+      (v := fun a : Fin L → Fin d => evalWord A (List.ofFn a)) (hv := hA)
+      (f := Λ ∘ₗ LinearMap.mulRight ℂ X)
+      (g := (LinearMap.mulRight ℂ (Φ X)) ∘ₗ Λ)
+      (fun a => by
+        simp only [LinearMap.comp_apply, LinearMap.mulRight_apply]
+        rw [hΦ1 X a, hΛ a])
+    intro M
+    have := congrArg (· M) hext
+    simpa only [LinearMap.comp_apply, LinearMap.mulRight_apply] using this
+  have hΦmul : ∀ M N : Matrix (Fin D) (Fin D) ℂ, Φ (M * N) = Φ M * Φ N := by
+    intro M N
+    apply bondOperator_unique hB
+    intro a
+    calc evalWord B (List.ofFn a) * Φ (M * N)
+        = Λ (evalWord A (List.ofFn a) * (M * N)) := (hΦ1 (M * N) a).symm
+      _ = Λ ((evalWord A (List.ofFn a) * M) * N) := by rw [Matrix.mul_assoc]
+      _ = Λ (evalWord A (List.ofFn a) * M) * Φ N := hΛr N _
+      _ = (evalWord B (List.ofFn a) * Φ M) * Φ N := by rw [hΦ1 M a]
+      _ = evalWord B (List.ofFn a) * (Φ M * Φ N) := Matrix.mul_assoc _ _ _
+  -- `Φ` is unital, hence nonzero, hence an automorphism.
+  have hΦone : Φ 1 = 1 := by
+    apply bondOperator_unique hB (X := Φ 1) (X' := 1)
+    intro a
+    calc evalWord B (List.ofFn a) * Φ 1
+        = Λ (evalWord A (List.ofFn a) * 1) := (hΦ1 1 a).symm
+      _ = Λ (evalWord A (List.ofFn a)) := by rw [Matrix.mul_one]
+      _ = evalWord B (List.ofFn a) := hΛ a
+      _ = evalWord B (List.ofFn a) * 1 := (Matrix.mul_one _).symm
+  have hΦne : Φ ≠ 0 := by
+    intro h0
+    apply matrix_one_ne_zero hD
+    rw [← hΦone, h0]
+    rfl
+  have hBij := linear_mul_endomorphism_bijective Φ hΦmul hΦne
+  let fHom := linearMapToAlgHom Φ hΦmul hBij.surjective
+  let f := AlgEquiv.ofBijective fHom hBij
+  obtain ⟨P, hP⟩ := skolemNoether_matrix f
+  have hΦP : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      Φ X = (P : Matrix (Fin D) (Fin D) ℂ) * X *
+        ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    intro X
+    have : f X = Φ X := rfl
+    rw [← this]
+    exact hP X
+  -- The closed-chain pairing of insertions, in cyclic form.
+  have hpair : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d)),
+      w.length = n →
+      Matrix.trace (X * evalWord A w) = Matrix.trace (Φ X * evalWord B w) := by
+    intro X w hw
+    -- Split the word into its head of length `n - L` and tail window.
+    have hdrop : (w.drop (n - L)).length = L := by
+      rw [List.length_drop]
+      omega
+    obtain ⟨a, ha⟩ := exists_ofFn_of_length hdrop
+    have hsplit : w = w.take (n - L) ++ List.ofFn a := by
+      rw [ha, List.take_append_drop]
+    have htake : (w.take (n - L)).length = n - L := by
+      rw [List.length_take]
+      omega
+    -- The sandwich relation at the window, from the transport bridge.
+    have hsand : Matrix.trace (Λ (evalWord A (List.ofFn a) * X) *
+        evalWord B (w.take (n - L))) =
+        Matrix.trace (evalWord A (List.ofFn a) * X * evalWord A (w.take (n - L))) := by
+      have hb := trace_transport_sandwich hA hAB hΛ
+        (evalWord A (List.ofFn a) * X) [] (w.take (n - L)) (by simp [htake]; omega)
+      simpa only [evalWord_nil, Matrix.one_mul] using hb
+    calc Matrix.trace (X * evalWord A w)
+        = Matrix.trace (X * (evalWord A (w.take (n - L)) *
+            evalWord A (List.ofFn a))) := by
+          rw [← evalWord_append, ← hsplit]
+      _ = Matrix.trace (evalWord A (List.ofFn a) * (X *
+            evalWord A (w.take (n - L)))) := by
+          rw [← Matrix.mul_assoc, Matrix.trace_mul_comm]
+      _ = Matrix.trace (evalWord A (List.ofFn a) * X *
+            evalWord A (w.take (n - L))) := by rw [Matrix.mul_assoc]
+      _ = Matrix.trace (Λ (evalWord A (List.ofFn a) * X) *
+            evalWord B (w.take (n - L))) := hsand.symm
+      _ = Matrix.trace (evalWord B (List.ofFn a) * Φ X *
+            evalWord B (w.take (n - L))) := by rw [hΦ1 X a]
+      _ = Matrix.trace (Φ X * (evalWord B (w.take (n - L)) *
+            evalWord B (List.ofFn a))) := by
+          rw [Matrix.mul_assoc, Matrix.trace_mul_comm, ← Matrix.mul_assoc,
+            Matrix.mul_assoc]
+      _ = Matrix.trace (Φ X * evalWord B w) := by
+          rw [← evalWord_append, ← hsplit]
+  -- Strip the insertions: the word products are conjugate.
+  refine ⟨P, fun w hw => ?_⟩
+  have hAw : evalWord A w =
+      ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * evalWord B w *
+        (P : Matrix (Fin D) (Fin D) ℂ) := by
+    apply eq_of_trace_mul_left_eq
+    intro X
+    calc Matrix.trace (X * evalWord A w)
+        = Matrix.trace (Φ X * evalWord B w) := hpair X w hw
+      _ = Matrix.trace ((P : Matrix (Fin D) (Fin D) ℂ) * X *
+            ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+              evalWord B w) := by rw [hΦP X]
+      _ = Matrix.trace (X * (((P⁻¹ : GL (Fin D) ℂ) :
+            Matrix (Fin D) (Fin D) ℂ) * evalWord B w *
+              (P : Matrix (Fin D) (Fin D) ℂ))) := by
+          rw [Matrix.mul_assoc, Matrix.mul_assoc, Matrix.trace_mul_comm,
+            Matrix.mul_assoc, Matrix.mul_assoc]
+  calc evalWord B w
+      = ((P * P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * evalWord B w *
+          ((P * P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+        rw [mul_inv_cancel, Units.val_one, Matrix.one_mul, Matrix.mul_one]
+    _ = (P : Matrix (Fin D) (Fin D) ℂ) *
+          (((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * evalWord B w *
+            (P : Matrix (Fin D) (Fin D) ℂ)) *
+          ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+        rw [Units.val_mul]
+        simp only [Matrix.mul_assoc]
+    _ = (P : Matrix (Fin D) (Fin D) ℂ) * evalWord A w *
+          ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by rw [← hAw]
+
+end MPSTensor

--- a/TNLean/PEPS/CycleMPSOverlapWindow.lean
+++ b/TNLean/PEPS/CycleMPSOverlapWindow.lean
@@ -140,7 +140,7 @@ private theorem tail_snoc_shiftWindow {L' k : ℕ} (hk : k ≤ L') (hk' : k ≤ 
   funext i
   induction i using Fin.lastCases with
   | last =>
-      show Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
+      change Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
           (b ⟨k, by omega⟩) (Fin.last L').succ = shiftWindow (k + 1) hk1 a b (Fin.last L')
       rw [Fin.succ_last, Fin.snoc_last]
       have hlast : (Fin.last L').val = L' := rfl
@@ -149,7 +149,7 @@ private theorem tail_snoc_shiftWindow {L' k : ℕ} (hk : k ≤ L') (hk' : k ≤ 
       exact congrArg b
         (Fin.ext (show k = (Fin.last L').val + (k + 1) - (L' + 1) by omega))
   | cast i =>
-      show Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
+      change Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
           (b ⟨k, by omega⟩) i.castSucc.succ = shiftWindow (k + 1) hk1 a b i.castSucc
       rw [Fin.succ_castSucc, Fin.snoc_castSucc]
       have hsucc : (i.succ : Fin (L' + 1)).val = i.val + 1 := Fin.val_succ i

--- a/TNLean/PEPS/CycleMPSOverlapWindow.lean
+++ b/TNLean/PEPS/CycleMPSOverlapWindow.lean
@@ -1,0 +1,390 @@
+import TNLean.PEPS.CycleMPSWordTransport
+
+/-!
+# Bond-operator extraction from overlapping windows on the closed chain
+
+This file proves the matrix-tensor form of Lemma 5 of arXiv:1804.04964
+(lines 2045--2255 of `Papers/1804.04964/paper_normal.tex`), specialized to
+one site-independent tensor: if a deformation of a closed-chain state of a
+block-injective tensor `B` is realized by operators on each of the `L + 1`
+overlapping length-`L` windows around a bond — equivalently, by deformed
+window tensors `C 0, …, C L`, where `C j` replaces the blocked tensor of the
+window starting `j` sites left of the bond — then the deformation is a
+single virtual operation `X` on the bond:
+
+* `C 0` factors as the window product times `X` on the right, and `C L` as
+  `X` on the left of the window product
+  (`MPSTensor.overlapWindow_exists_bondOperator`), and
+* `X` is unique (`MPSTensor.bondOperator_unique`).
+
+The proof follows the source.  Comparing the windows at `j` and `j + 1`
+through the rest of the chain — an arc of `n - L - 1 ≥ L` sites, injective by
+the span-extension lemma — strips the state equality to a letter-level
+relation `C j (w) ⬝ B = B ⬝ C (j+1) (w shifted)` (the source's
+`eq:normal_act_123` and `eq:normal_act_234`, lines 2140--2210).  Chaining the
+`L` relations along a window of `2L` sites turns the leftmost window into the
+rightmost one (the source's plugging of `A_4` and `A_1`, lines 2168--2210),
+and the two ends are compared as in `eq:inj_O->X_argument` (line 377): a
+combination of window products representing the identity extracts the bond
+operator from either side, and the two extractions agree.
+
+The source states Lemma 5 for site-dependent tensors on five sites with
+`L = 2`; this file proves the statement for one site-independent tensor,
+arbitrary `L > 0`, and any chain length `n ≥ 2L + 1`, which is the form the
+closed-chain corollaries of Section `normal_alt` consume.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Lemma 5 of Section `normal_alt`, lines 2045--2255 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Stripping the state equality to the letter level -/
+
+/-- **Window comparison through the complementary arc** (arXiv:1804.04964,
+Lemma 5, the inversions producing `eq:normal_act_123` and
+`eq:normal_act_234`, lines 2140--2167 of
+`Papers/1804.04964/paper_normal.tex`).
+
+If the states obtained by applying the deformed window tensors `C` at
+position `j` and `C'` at position `j + 1` agree, then comparing through the
+remaining `n - L - 1 ≥ L` sites — whose word products span by the extension
+lemma — strips the equality to the letter level: on every window of `L + 1`
+sites, `C` contracted with a trailing letter equals a leading letter
+contracted with `C'`. -/
+private theorem window_letter_step {B : MPSTensor d D} {n L : ℕ}
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hB : IsNBlkInjective B L)
+    {j q : ℕ} (hq : j + (L + 1) + q = n)
+    {C C' : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ}
+    (hstate : ∀ (pre : Fin j → Fin d) (u : Fin (L + 1) → Fin d)
+      (post : Fin q → Fin d),
+      Matrix.trace (evalWord B (List.ofFn pre) *
+          (C (Fin.init u) * B (u (Fin.last L))) * evalWord B (List.ofFn post)) =
+        Matrix.trace (evalWord B (List.ofFn pre) *
+          (B (u 0) * C' (Fin.tail u)) * evalWord B (List.ofFn post)))
+    (u : Fin (L + 1) → Fin d) :
+    C (Fin.init u) * B (u (Fin.last L)) = B (u 0) * C' (Fin.tail u) := by
+  apply eq_of_trace_mul_evalWord_eq (m := q + j)
+    (isNBlkInjective_of_le hL hB (by omega))
+  intro ρ
+  -- Split the complementary arc into the suffix and the prefix of the chain.
+  set post : Fin q → Fin d := fun i => ρ (Fin.castLE (by omega) i) with hpost
+  set pre : Fin j → Fin d := fun i => ρ (Fin.natAdd q i) with hpre
+  have hρ : List.ofFn post ++ List.ofFn pre = List.ofFn ρ := (List.ofFn_add (f := ρ)).symm
+  have key : ∀ M : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace (evalWord B (List.ofFn pre) * M * evalWord B (List.ofFn post)) =
+        Matrix.trace (M * evalWord B (List.ofFn ρ)) := by
+    intro M
+    calc Matrix.trace (evalWord B (List.ofFn pre) * M * evalWord B (List.ofFn post))
+        = Matrix.trace (evalWord B (List.ofFn post) *
+            (evalWord B (List.ofFn pre) * M)) :=
+          Matrix.trace_mul_comm _ _
+      _ = Matrix.trace (M * (evalWord B (List.ofFn post) *
+            evalWord B (List.ofFn pre))) := by
+          rw [← Matrix.mul_assoc]
+          exact Matrix.trace_mul_comm _ _
+      _ = Matrix.trace (M * evalWord B (List.ofFn ρ)) := by
+          rw [← evalWord_append, hρ]
+  rw [← key, ← key]
+  exact hstate pre u post
+
+/-! ### Chaining the windows across the bond -/
+
+/-- The deformed window shifted `k` sites: the first `L - k` letters are
+read from the tail of `a`, the remaining `k` letters from the head of
+`b`. -/
+private def shiftWindow {L : ℕ} (k : ℕ) (hk : k ≤ L) (a b : Fin L → Fin d) :
+    Fin L → Fin d := fun i =>
+  if h : i.val + k < L then a ⟨i.val + k, h⟩
+  else b ⟨i.val + k - L, by have := i.isLt; omega⟩
+
+private theorem shiftWindow_zero {L : ℕ} (hk : 0 ≤ L) (a b : Fin L → Fin d) :
+    shiftWindow 0 hk a b = a := by
+  funext i
+  have hi := i.isLt
+  simp only [shiftWindow]
+  rw [dif_pos (show i.val + 0 < L by omega)]
+  exact congrArg a (Fin.ext (show i.val + 0 = i.val by omega))
+
+private theorem shiftWindow_self {L : ℕ} (hk : L ≤ L) (a b : Fin L → Fin d) :
+    shiftWindow L hk a b = b := by
+  funext i
+  have hi := i.isLt
+  simp only [shiftWindow]
+  rw [dif_neg (show ¬ i.val + L < L by omega)]
+  exact congrArg b (Fin.ext (show i.val + L - L = i.val by omega))
+
+private theorem shiftWindow_apply_zero {L' k : ℕ} (hk : k ≤ L') (hk' : k ≤ L' + 1)
+    (a b : Fin (L' + 1) → Fin d) :
+    shiftWindow k hk' a b 0 = a ⟨k, by omega⟩ := by
+  have h0 : (0 : Fin (L' + 1)).val = 0 := rfl
+  simp only [shiftWindow]
+  rw [dif_pos (show (0 : Fin (L' + 1)).val + k < L' + 1 by omega)]
+  exact congrArg a (Fin.ext (show (0 : Fin (L' + 1)).val + k = k by omega))
+
+/-- Shifting the deformed window by one site: popping the leading letter and
+appending the next letter of `b`. -/
+private theorem tail_snoc_shiftWindow {L' k : ℕ} (hk : k ≤ L') (hk' : k ≤ L' + 1)
+    (hk1 : k + 1 ≤ L' + 1) (a b : Fin (L' + 1) → Fin d) :
+    Fin.tail (α := fun _ => Fin d)
+        (Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b) (b ⟨k, by omega⟩)) =
+      shiftWindow (k + 1) hk1 a b := by
+  funext i
+  induction i using Fin.lastCases with
+  | last =>
+      show Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
+          (b ⟨k, by omega⟩) (Fin.last L').succ = shiftWindow (k + 1) hk1 a b (Fin.last L')
+      rw [Fin.succ_last, Fin.snoc_last]
+      have hlast : (Fin.last L').val = L' := rfl
+      simp only [shiftWindow]
+      rw [dif_neg (show ¬ (Fin.last L').val + (k + 1) < L' + 1 by omega)]
+      exact congrArg b
+        (Fin.ext (show k = (Fin.last L').val + (k + 1) - (L' + 1) by omega))
+  | cast i =>
+      show Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
+          (b ⟨k, by omega⟩) i.castSucc.succ = shiftWindow (k + 1) hk1 a b i.castSucc
+      rw [Fin.succ_castSucc, Fin.snoc_castSucc]
+      have hsucc : (i.succ : Fin (L' + 1)).val = i.val + 1 := Fin.val_succ i
+      have hcast : (i.castSucc : Fin (L' + 1)).val = i.val := Fin.val_castSucc i
+      have hi := i.isLt
+      simp only [shiftWindow]
+      by_cases h2 : i.val + 1 + k < L' + 1
+      · rw [dif_pos (show (i.succ : Fin (L' + 1)).val + k < L' + 1 by omega),
+          dif_pos (show (i.castSucc : Fin (L' + 1)).val + (k + 1) < L' + 1 by omega)]
+        exact congrArg a (Fin.ext
+          (show (i.succ : Fin (L' + 1)).val + k =
+            (i.castSucc : Fin (L' + 1)).val + (k + 1) by omega))
+      · rw [dif_neg (show ¬ (i.succ : Fin (L' + 1)).val + k < L' + 1 by omega),
+          dif_neg (show ¬ (i.castSucc : Fin (L' + 1)).val + (k + 1) < L' + 1 by omega)]
+        exact congrArg b (Fin.ext
+          (show (i.succ : Fin (L' + 1)).val + k - (L' + 1) =
+            (i.castSucc : Fin (L' + 1)).val + (k + 1) - (L' + 1) by omega))
+
+/-- The word product of the first `k + 1` letters peels its last letter. -/
+private theorem evalWord_take_succ {B : MPSTensor d D} {L k : ℕ}
+    (hk : k + 1 ≤ L) (f : Fin L → Fin d) :
+    evalWord B (List.ofFn fun i : Fin (k + 1) => f (Fin.castLE hk i)) =
+      evalWord B (List.ofFn fun i : Fin k => f (Fin.castLE (by omega) i)) *
+        B (f ⟨k, by omega⟩) := by
+  have hsnoc : (fun i : Fin (k + 1) => f (Fin.castLE hk i)) =
+      Fin.snoc (α := fun _ => Fin d)
+        (fun i : Fin k => f (Fin.castLE (by omega) i)) (f ⟨k, by omega⟩) := by
+    funext i
+    induction i using Fin.lastCases with
+    | last =>
+        rw [Fin.snoc_last]
+        exact congrArg f (Fin.ext
+          (show (Fin.castLE hk (Fin.last k)).val = k from rfl))
+    | cast i =>
+        rw [Fin.snoc_castSucc]
+        exact congrArg f (Fin.ext
+          (show (Fin.castLE hk i.castSucc).val = (Fin.castLE (by omega) i).val from rfl))
+  rw [hsnoc, evalWord_ofFn_snoc]
+
+/-- **Chaining the overlapping windows across the bond** (arXiv:1804.04964,
+Lemma 5, the step plugging `A_4` and `A_1` into `eq:normal_act_123` and
+`eq:normal_act_234`, lines 2168--2210 of
+`Papers/1804.04964/paper_normal.tex`).
+
+Iterating the letter-level relation `L` times along a window of `2L` sites
+moves the deformed window from the left of the bond to the right: the
+leftmost deformed window contracted with the right block equals the left
+block contracted with the rightmost deformed window. -/
+private theorem chain_windows {B : MPSTensor d D} {L : ℕ} (hL : 0 < L)
+    (C : ℕ → (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hstep : ∀ k, k < L → ∀ u : Fin (L + 1) → Fin d,
+      C k (Fin.init u) * B (u (Fin.last L)) = B (u 0) * C (k + 1) (Fin.tail u))
+    (a b : Fin L → Fin d) :
+    C 0 a * evalWord B (List.ofFn b) = evalWord B (List.ofFn a) * C L b := by
+  obtain ⟨L', rfl⟩ : ∃ L', L = L' + 1 := ⟨L - 1, by omega⟩
+  have S : ∀ k, ∀ hk : k ≤ L' + 1,
+      C 0 a * evalWord B (List.ofFn fun i : Fin k => b (Fin.castLE hk i)) =
+        evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE hk i)) *
+          C k (shiftWindow k hk a b) := by
+    intro k
+    induction k with
+    | zero =>
+        intro hk
+        simp only [List.ofFn_zero, evalWord_nil, Matrix.mul_one, Matrix.one_mul]
+        rw [shiftWindow_zero hk a b]
+    | succ k IH =>
+        intro hk1
+        have hk : k ≤ L' := by omega
+        set u : Fin (L' + 1 + 1) → Fin d :=
+          Fin.snoc (α := fun _ => Fin d) (shiftWindow k (by omega) a b)
+            (b ⟨k, by omega⟩) with hu
+        have hinit : Fin.init u = shiftWindow k (by omega) a b := Fin.init_snoc _ _
+        have hlast : u (Fin.last (L' + 1)) = b ⟨k, by omega⟩ := Fin.snoc_last _ _
+        have hzero : u 0 = a ⟨k, by omega⟩ := by
+          rw [hu, show (0 : Fin (L' + 1 + 1)) = Fin.castSucc 0 from
+            Fin.castSucc_zero.symm, Fin.snoc_castSucc]
+          exact shiftWindow_apply_zero hk (by omega) a b
+        have htail : Fin.tail u = shiftWindow (k + 1) hk1 a b :=
+          tail_snoc_shiftWindow hk (by omega) hk1 a b
+        calc C 0 a *
+              evalWord B (List.ofFn fun i : Fin (k + 1) => b (Fin.castLE hk1 i))
+            = C 0 a * (evalWord B (List.ofFn fun i : Fin k =>
+                b (Fin.castLE (by omega) i)) * B (b ⟨k, by omega⟩)) := by
+              rw [evalWord_take_succ hk1 b]
+          _ = (C 0 a * evalWord B (List.ofFn fun i : Fin k =>
+                b (Fin.castLE (by omega) i))) * B (b ⟨k, by omega⟩) := by
+              rw [Matrix.mul_assoc]
+          _ = (evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
+                C k (shiftWindow k (by omega) a b)) * B (b ⟨k, by omega⟩) := by
+              rw [IH (by omega)]
+          _ = evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
+                (C k (Fin.init u) * B (u (Fin.last (L' + 1)))) := by
+              rw [hinit, hlast, Matrix.mul_assoc]
+          _ = evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
+                (B (u 0) * C (k + 1) (Fin.tail u)) := by
+              rw [hstep k (by omega) u]
+          _ = (evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
+                B (a ⟨k, by omega⟩)) * C (k + 1) (shiftWindow (k + 1) hk1 a b) := by
+              rw [hzero, htail, Matrix.mul_assoc]
+          _ = evalWord B (List.ofFn fun i : Fin (k + 1) => a (Fin.castLE hk1 i)) *
+                C (k + 1) (shiftWindow (k + 1) hk1 a b) := by
+              rw [evalWord_take_succ hk1 a]
+  have hfull := S (L' + 1) le_rfl
+  have hcast : ∀ f : Fin (L' + 1) → Fin d,
+      (fun i : Fin (L' + 1) => f (Fin.castLE le_rfl i)) = f := by
+    intro f
+    funext i
+    exact congrArg f (Fin.ext rfl)
+  rw [hcast a, hcast b, shiftWindow_self le_rfl a b] at hfull
+  exact hfull
+
+/-! ### Extracting the bond operator from the two ends -/
+
+/-- **Uniqueness of the bond operator** (arXiv:1804.04964, Lemma 5: the maps
+to `X` "are uniquely defined", lines 2045--2255 of
+`Papers/1804.04964/paper_normal.tex`; the mechanism is the insertion
+uniqueness of lines 1940--1960).
+
+Two matrices multiplying every spanning word product to the same family on
+the right are equal. -/
+theorem bondOperator_unique {B : MPSTensor d D} {L : ℕ}
+    (hB : IsNBlkInjective B L) {X X' : Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ a : Fin L → Fin d,
+      evalWord B (List.ofFn a) * X = evalWord B (List.ofFn a) * X') : X = X' := by
+  have hspan : Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+      evalWord B (List.ofFn τ)) = ⊤ := hB
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
+      (Set.range fun τ : Fin L → Fin d => evalWord B (List.ofFn τ)) :=
+    hspan ▸ Submodule.mem_top
+  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+  calc X = (1 : Matrix (Fin D) (Fin D) ℂ) * X := (Matrix.one_mul _).symm
+    _ = (∑ τ : Fin L → Fin d, α τ • evalWord B (List.ofFn τ)) * X := by rw [hα]
+    _ = ∑ τ : Fin L → Fin d, α τ • (evalWord B (List.ofFn τ) * X) := by
+        rw [Finset.sum_mul]
+        exact Finset.sum_congr rfl fun τ _ =>
+          smul_mul_assoc (α τ) (evalWord B (List.ofFn τ)) X
+    _ = ∑ τ : Fin L → Fin d, α τ • (evalWord B (List.ofFn τ) * X') :=
+        Finset.sum_congr rfl fun τ _ => by rw [h τ]
+    _ = (∑ τ : Fin L → Fin d, α τ • evalWord B (List.ofFn τ)) * X' := by
+        rw [Finset.sum_mul]
+        exact Finset.sum_congr rfl fun τ _ =>
+          (smul_mul_assoc (α τ) (evalWord B (List.ofFn τ)) X').symm
+    _ = X' := by rw [hα, Matrix.one_mul]
+
+/-- **Bond-operator extraction from an intertwining pair** (arXiv:1804.04964,
+Lemma 5, the comparison of the two ends, lines 2211--2255 of
+`Papers/1804.04964/paper_normal.tex`, after the model of
+`eq:inj_O->X_argument`, line 377).
+
+If `F a ⬝ B^b = B^a ⬝ G b` for all length-`L` words `a`, `b`, with the word
+products of `B` spanning, then a single matrix `X` factors both families:
+`F` is the word products times `X` on the right, `G` is `X` times the word
+products.  `X` is the combination of the `G`-family by coefficients
+representing the identity, and the two factorizations agree because the
+mirrored combination of the `F`-family collapses onto the same matrix. -/
+theorem exists_bondOperator_of_intertwine {B : MPSTensor d D} {L : ℕ}
+    (hB : IsNBlkInjective B L)
+    (F G : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (h : ∀ a b : Fin L → Fin d,
+      F a * evalWord B (List.ofFn b) = evalWord B (List.ofFn a) * G b) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      (∀ a, F a = evalWord B (List.ofFn a) * X) ∧
+        (∀ b, G b = X * evalWord B (List.ofFn b)) := by
+  have hspan : Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+      evalWord B (List.ofFn τ)) = ⊤ := hB
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
+      (Set.range fun τ : Fin L → Fin d => evalWord B (List.ofFn τ)) :=
+    hspan ▸ Submodule.mem_top
+  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+  set X₀ : Matrix (Fin D) (Fin D) ℂ := ∑ τ : Fin L → Fin d, α τ • G τ with hX₀
+  have hF : ∀ a, F a = evalWord B (List.ofFn a) * X₀ := by
+    intro a
+    calc F a = F a * (1 : Matrix (Fin D) (Fin D) ℂ) := (Matrix.mul_one _).symm
+      _ = F a * ∑ τ : Fin L → Fin d, α τ • evalWord B (List.ofFn τ) := by rw [hα]
+      _ = ∑ τ : Fin L → Fin d, α τ • (F a * evalWord B (List.ofFn τ)) := by
+          rw [Finset.mul_sum]
+          exact Finset.sum_congr rfl fun τ _ =>
+            mul_smul_comm (α τ) (F a) (evalWord B (List.ofFn τ))
+      _ = ∑ τ : Fin L → Fin d, α τ • (evalWord B (List.ofFn a) * G τ) :=
+          Finset.sum_congr rfl fun τ _ => by rw [h a τ]
+      _ = ∑ τ : Fin L → Fin d, evalWord B (List.ofFn a) * (α τ • G τ) :=
+          Finset.sum_congr rfl fun τ _ =>
+            (mul_smul_comm (α τ) (evalWord B (List.ofFn a)) (G τ)).symm
+      _ = evalWord B (List.ofFn a) * X₀ := by rw [← Finset.mul_sum, hX₀]
+  refine ⟨X₀, hF, fun b => ?_⟩
+  -- The left factorization of `G`: compare against the right factorization
+  -- through the intertwining relation and strip the spanning word products.
+  apply bondOperator_unique hB (X := G b) (X' := X₀ * evalWord B (List.ofFn b))
+  intro a
+  calc evalWord B (List.ofFn a) * G b
+      = F a * evalWord B (List.ofFn b) := (h a b).symm
+    _ = (evalWord B (List.ofFn a) * X₀) * evalWord B (List.ofFn b) := by rw [hF a]
+    _ = evalWord B (List.ofFn a) * (X₀ * evalWord B (List.ofFn b)) :=
+        Matrix.mul_assoc _ _ _
+
+/-! ### The bond-operator extraction theorem -/
+
+/-- **Lemma 5 of arXiv:1804.04964 for matrix tensors** (lines 2045--2255 of
+`Papers/1804.04964/paper_normal.tex`, specialized to one site-independent
+tensor).
+
+Let `B` be `L`-block injective on a closed chain of `n ≥ 2L + 1` sites, and
+let `C 0, …, C L` be deformed window tensors — `C j` replaces the blocked
+tensor of the `L`-site window starting `j` sites left of a fixed bond; in the
+source, `C j` is the physical operator `O_{j+1}` contracted with the blocked
+window it acts on.  If the deformed states agree for consecutive window
+positions — the hypothesis quantifies the closed-chain coefficient over a
+common refinement: a prefix of `j` sites, the `L + 1` sites covered by the
+two windows, and the remaining sites — then the deformation is a virtual
+operation on the bond: a single matrix `X` with `C 0` the window products
+times `X` on the right and `C L` equal to `X` times the window products.
+
+Together with `MPSTensor.bondOperator_unique`, the assignments `C 0 ↦ X` and
+`C L ↦ X` are uniquely defined; their algebra-homomorphism property (the
+source's maps `O_1 ↦ X` and `O_3^T ↦ X`) is established for the insertion
+correspondence in `TNLean/PEPS/CycleMPSOverlapInsertion.lean`, where the
+deformed window tensors carry the algebra structure transported from the
+deforming network. -/
+theorem overlapWindow_exists_bondOperator {B : MPSTensor d D} {n L : ℕ}
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hB : IsNBlkInjective B L)
+    (C : ℕ → (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hstate : ∀ j, j < L → ∀ {q : ℕ}, j + (L + 1) + q = n →
+      ∀ (pre : Fin j → Fin d) (u : Fin (L + 1) → Fin d) (post : Fin q → Fin d),
+      Matrix.trace (evalWord B (List.ofFn pre) *
+          (C j (Fin.init u) * B (u (Fin.last L))) * evalWord B (List.ofFn post)) =
+        Matrix.trace (evalWord B (List.ofFn pre) *
+          (B (u 0) * C (j + 1) (Fin.tail u)) * evalWord B (List.ofFn post))) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      (∀ a, C 0 a = evalWord B (List.ofFn a) * X) ∧
+        (∀ b, C L b = X * evalWord B (List.ofFn b)) := by
+  have hstep : ∀ k, k < L → ∀ u : Fin (L + 1) → Fin d,
+      C k (Fin.init u) * B (u (Fin.last L)) = B (u 0) * C (k + 1) (Fin.tail u) := by
+    intro k hk u
+    exact window_letter_step hL hn hB (q := n - (k + (L + 1))) (by omega)
+      (fun pre u' post => hstate k hk (by omega) pre u' post) u
+  exact exists_bondOperator_of_intertwine hB (C 0) (C L) (chain_windows hL C hstep)
+
+end MPSTensor

--- a/TNLean/PEPS/CycleMPSWordTransport.lean
+++ b/TNLean/PEPS/CycleMPSWordTransport.lean
@@ -153,7 +153,7 @@ that `ΨA` is injective and `ΨA (F i) = ΨB (G i)` for every index, there is a
 linear map of the matrix algebra carrying each `F i` to `G i`.  This is the
 left-inverse construction of the linear extension for the single-block
 Fundamental Theorem (`TNLean/MPS/Structure/LinearExtension.lean`). -/
-private theorem exists_linearMap_apply_eq {ι : Type*} [Fintype ι]
+private theorem exists_linearMap_apply_eq {ι : Type*} [Finite ι]
     {V : Type*} [AddCommGroup V] [Module ℂ V]
     (F G : ι → Matrix (Fin D) (Fin D) ℂ)
     (ΨA ΨB : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] V)
@@ -163,6 +163,7 @@ private theorem exists_linearMap_apply_eq {ι : Type*} [Fintype ι]
     ∃ Λ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
       ∀ i, Λ (F i) = G i := by
   classical
+  cases nonempty_fintype ι
   let lcF := Fintype.linearCombination ℂ F
   let lcG := Fintype.linearCombination ℂ G
   have hsurj : Function.Surjective lcF := by

--- a/TNLean/PEPS/CycleMPSWordTransport.lean
+++ b/TNLean/PEPS/CycleMPSWordTransport.lean
@@ -1,0 +1,318 @@
+import TNLean.MPS.ParentHamiltonian.IntersectionProperty
+
+/-!
+# Word-span extension and word transport for block-injective matrix tensors
+
+This file provides the linear-algebraic inputs of the overlapping-window route
+to the closed-chain corollaries of the Fundamental Theorem for normal PEPS
+(arXiv:1804.04964, Section `normal_alt`, lines 1915--2295 of
+`Papers/1804.04964/paper_normal.tex`), at the matrix-tensor level:
+
+* `MPSTensor.isNBlkInjective_of_le`: block injectivity at length `L > 0`
+  extends to every length `m ≥ L` — the chain form of "any region of at least
+  size [`L`] is also injective" (arXiv:1804.04964, line 1940, after the union
+  lemma `lem:injective_union`, lines 1324--1417).
+* `MPSTensor.eq_of_trace_mul_evalWord_eq`: two matrices with the same trace
+  pairing against a spanning family of word products are equal — the
+  uniqueness of virtual insertions (arXiv:1804.04964, lines 1940--1960: equal
+  states with insertions `X` and `Y` on the same bond force `X = Y`).
+* `MPSTensor.exists_mpvTransport`: for two tensors with the same closed-chain
+  coefficients at one length `n = k + q` and word products of lengths `k`, `q`
+  spanning, a linear map of the matrix algebra carries each length-`k` word
+  product of the first tensor to that of the second.  This is the
+  operator-transport mechanism underlying the source's Lemma 5 (lines
+  2045--2255): a physical operator is expanded over the window products of one
+  network and re-read in the other.
+* `MPSTensor.exists_evalWordTransport`: the same transport when the two
+  tensors have *equal* (not just equal-trace) word products at length `n`,
+  with the pairing taken in the matrix algebra.
+
+The transports are produced by the left-inverse construction used for the
+linear extension of the single-block Fundamental Theorem
+(`TNLean/MPS/Structure/LinearExtension.lean`): the pairing of the matrix
+algebra against the complementary word products is injective on the first
+tensor's side by spanning and nondegeneracy, the same-state hypothesis
+matches the two pairings on the spanning family, and a left inverse of the
+second pairing assembles the transport.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section `normal_alt`, lines 1915--2295 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Block injectivity extends to longer blocks -/
+
+/-- Left multiplication by a letter maps the full length-`m` word span into
+the length-`(m+1)` word span. -/
+private theorem mul_left_letter_mem_span {A : MPSTensor d D} {m : ℕ}
+    (hm : Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
+      evalWord A (List.ofFn u)) = ⊤)
+    (i : Fin d) (Q : Matrix (Fin D) (Fin D) ℂ) :
+    A i * Q ∈ Submodule.span ℂ (Set.range fun w : Fin (m + 1) → Fin d =>
+      evalWord A (List.ofFn w)) := by
+  have hQ : Q ∈ Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
+      evalWord A (List.ofFn u)) := hm ▸ Submodule.mem_top
+  induction hQ using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨u, rfl⟩ := hx
+      rw [← evalWord_ofFn_cons]
+      exact Submodule.subset_span ⟨Fin.cons i u, rfl⟩
+  | zero => rw [Matrix.mul_zero]; exact Submodule.zero_mem _
+  | add x y _ _ hx hy => rw [Matrix.mul_add]; exact Submodule.add_mem _ hx hy
+  | smul c x _ hx => rw [mul_smul_comm]; exact Submodule.smul_mem _ c hx
+
+/-- **Block injectivity extends to longer blocks.**  If the word products of
+length `L > 0` span the full matrix algebra, so do the word products of any
+length `m ≥ L`: write the identity as a combination of length-`L` products,
+peel the leading letter of each, and absorb the remainder into the spanning
+products one length below.
+
+Source: arXiv:1804.04964, line 1940 of `Papers/1804.04964/paper_normal.tex`
+("any region of at least size two is also injective", after the union lemma
+`lem:injective_union`, lines 1324--1417), specialized to the closed chain
+with one site-independent tensor. -/
+theorem isNBlkInjective_of_le {A : MPSTensor d D} {L : ℕ} (hL : 0 < L)
+    (hA : IsNBlkInjective A L) {m : ℕ} (hm : L ≤ m) : IsNBlkInjective A m := by
+  induction m, hm using Nat.le_induction with
+  | base => exact hA
+  | succ m hLm IH =>
+      obtain ⟨L', rfl⟩ : ∃ L', L = L' + 1 := ⟨L - 1, by omega⟩
+      have hspanL : Submodule.span ℂ (Set.range fun v : Fin (L' + 1) → Fin d =>
+          evalWord A (List.ofFn v)) = ⊤ := hA
+      have hspanm : Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
+          evalWord A (List.ofFn u)) = ⊤ := IH
+      rw [IsNBlkInjective, eq_top_iff]
+      intro P _
+      have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+          Submodule.span ℂ (Set.range fun v : Fin (L' + 1) → Fin d =>
+            evalWord A (List.ofFn v)) := hspanL ▸ Submodule.mem_top
+      obtain ⟨c, hc⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+      have hP : P = ∑ v : Fin (L' + 1) → Fin d,
+          c v • (evalWord A (List.ofFn v) * P) := by
+        calc P = (1 : Matrix (Fin D) (Fin D) ℂ) * P := (one_mul P).symm
+          _ = (∑ v : Fin (L' + 1) → Fin d, c v • evalWord A (List.ofFn v)) * P := by
+              rw [hc]
+          _ = ∑ v : Fin (L' + 1) → Fin d, c v • (evalWord A (List.ofFn v) * P) := by
+              rw [Finset.sum_mul]
+              exact Finset.sum_congr rfl fun v _ => smul_mul_assoc _ _ _
+      rw [hP]
+      refine Submodule.sum_mem _ fun v _ => Submodule.smul_mem _ _ ?_
+      have hsplit : evalWord A (List.ofFn v) * P =
+          A (v 0) * (evalWord A (List.ofFn (Fin.tail v)) * P) := by
+        rw [show v = Fin.cons (v 0) (Fin.tail v) from (Fin.cons_self_tail v).symm,
+          evalWord_ofFn_cons, Matrix.mul_assoc, Fin.cons_zero, Fin.tail_cons]
+      rw [hsplit]
+      exact mul_left_letter_mem_span hspanm (v 0) _
+
+/-! ### Trace stripping against a spanning word family -/
+
+/-- **Uniqueness of virtual insertions.**  Two matrices with the same trace
+pairing against a spanning family of word products are equal.
+
+Source: arXiv:1804.04964, lines 1940--1960 of
+`Papers/1804.04964/paper_normal.tex`: two insertions `X`, `Y` on the same
+bond generating the same state are equal, by injectivity of the rest of the
+chain. -/
+theorem eq_of_trace_mul_evalWord_eq {B : MPSTensor d D} {m : ℕ}
+    (hspan : Submodule.span ℂ (Set.range fun ρ : Fin m → Fin d =>
+      evalWord B (List.ofFn ρ)) = ⊤)
+    {M N : Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ ρ : Fin m → Fin d,
+      Matrix.trace (M * evalWord B (List.ofFn ρ)) =
+        Matrix.trace (N * evalWord B (List.ofFn ρ))) : M = N := by
+  have hzero : ∀ Q : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace ((M - N) * Q) = 0 := by
+    intro Q
+    have hQ : Q ∈ Submodule.span ℂ (Set.range fun ρ : Fin m → Fin d =>
+        evalWord B (List.ofFn ρ)) := hspan ▸ Submodule.mem_top
+    induction hQ using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨ρ, rfl⟩ := hx
+        rw [Matrix.sub_mul, Matrix.trace_sub, h ρ, sub_self]
+    | zero => rw [Matrix.mul_zero, Matrix.trace_zero]
+    | add x y _ _ hx hy => rw [Matrix.mul_add, Matrix.trace_add, hx, hy, add_zero]
+    | smul c x _ hx => rw [Matrix.mul_smul, Matrix.trace_smul, hx, smul_zero]
+  have hMN : M - N = 0 := trace_mul_right_eq_zero hzero
+  exact sub_eq_zero.mp hMN
+
+/-! ### The generic transport construction -/
+
+/-- **Transport through a pair of matched pairings.**  Given two families
+`F`, `G` of matrices indexed by the same finite type, with `F` spanning, and
+two linear pairings `ΨA`, `ΨB` of the matrix algebra into a common space such
+that `ΨA` is injective and `ΨA (F i) = ΨB (G i)` for every index, there is a
+linear map of the matrix algebra carrying each `F i` to `G i`.  This is the
+left-inverse construction of the linear extension for the single-block
+Fundamental Theorem (`TNLean/MPS/Structure/LinearExtension.lean`). -/
+private theorem exists_linearMap_apply_eq {ι : Type*} [Fintype ι]
+    {V : Type*} [AddCommGroup V] [Module ℂ V]
+    (F G : ι → Matrix (Fin D) (Fin D) ℂ)
+    (ΨA ΨB : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] V)
+    (hspan : Submodule.span ℂ (Set.range F) = ⊤)
+    (hker : LinearMap.ker ΨA = ⊥)
+    (hpair : ∀ i, ΨA (F i) = ΨB (G i)) :
+    ∃ Λ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+      ∀ i, Λ (F i) = G i := by
+  classical
+  let lcF := Fintype.linearCombination ℂ F
+  let lcG := Fintype.linearCombination ℂ G
+  have hsurj : Function.Surjective lcF := by
+    rw [← LinearMap.range_eq_top, Fintype.range_linearCombination]
+    exact hspan
+  have hcomp : ΨA ∘ₗ lcF = ΨB ∘ₗ lcG := by
+    apply LinearMap.ext
+    intro c
+    simp only [LinearMap.comp_apply, lcF, lcG, Fintype.linearCombination_apply,
+      map_sum, map_smul]
+    exact Finset.sum_congr rfl fun i _ => by rw [hpair i]
+  have hrange : LinearMap.range ΨA ≤ LinearMap.range ΨB := by
+    rw [show LinearMap.range ΨA = LinearMap.range (ΨA ∘ₗ lcF) from by
+      simp [LinearMap.range_comp, LinearMap.range_eq_top.2 hsurj], hcomp]
+    exact LinearMap.range_comp_le_range lcG ΨB
+  have hkerB : LinearMap.ker ΨB = ⊥ := ker_bot_of_range_le ΨA ΨB hker hrange
+  obtain ⟨g, hg⟩ := ΨB.exists_leftInverse_of_injective hkerB
+  refine ⟨g ∘ₗ ΨA, fun i => ?_⟩
+  rw [LinearMap.comp_apply, hpair i]
+  simpa using congrArg (· (G i)) hg
+
+/-! ### Bridging closed-chain coefficients and word lists -/
+
+/-- Equality of the closed-chain coefficients at length `n`, read on word
+lists of length `n`. -/
+theorem trace_evalWord_eq_of_mpv_eq {A B : MPSTensor d D} {n : ℕ}
+    (hAB : ∀ σ : Fin n → Fin d, mpv A σ = mpv B σ)
+    {w : List (Fin d)} (hw : w.length = n) :
+    Matrix.trace (evalWord A w) = Matrix.trace (evalWord B w) := by
+  subst hw
+  simpa [mpv, coeff, List.ofFn_get] using hAB w.get
+
+/-- Equality of the word products at length `n`, read on word lists of
+length `n`. -/
+theorem evalWord_eq_of_forall_fin_eq {A C : MPSTensor d D} {n : ℕ}
+    (hAC : ∀ σ : Fin n → Fin d,
+      evalWord C (List.ofFn σ) = evalWord A (List.ofFn σ))
+    {w : List (Fin d)} (hw : w.length = n) :
+    evalWord C w = evalWord A w := by
+  subst hw
+  simpa [List.ofFn_get] using hAC w.get
+
+/-! ### The two transports -/
+
+/-- **Word transport from equal closed-chain coefficients** (the mechanism of
+arXiv:1804.04964, Lemma 5, lines 2045--2255 of
+`Papers/1804.04964/paper_normal.tex`).
+
+If `A` and `B` have the same closed-chain coefficients at one length
+`n = k + q`, and the length-`k` and length-`q` word products of `A` span the
+matrix algebra, then a linear map `Λ` of the matrix algebra carries every
+length-`k` word product of `A` to the corresponding word product of `B`.
+This is the matrix-level form of expanding a physical operator over the
+window products of one network and re-reading the expansion in the other:
+the pairing against the complementary length-`q` products is injective for
+`A` by spanning and trace nondegeneracy, and the same-state hypothesis
+matches the `A`- and `B`-pairings on the spanning window family. -/
+theorem exists_mpvTransport {A B : MPSTensor d D} {n k q : ℕ} (hkq : k + q = n)
+    (hAk : Submodule.span ℂ (Set.range fun τ : Fin k → Fin d =>
+      evalWord A (List.ofFn τ)) = ⊤)
+    (hAq : Submodule.span ℂ (Set.range fun ρ : Fin q → Fin d =>
+      evalWord A (List.ofFn ρ)) = ⊤)
+    (hAB : ∀ σ : Fin n → Fin d, mpv A σ = mpv B σ) :
+    ∃ Λ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+      ∀ τ : Fin k → Fin d,
+        Λ (evalWord A (List.ofFn τ)) = evalWord B (List.ofFn τ) := by
+  classical
+  set ΨA : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ((Fin q → Fin d) → ℂ) :=
+    LinearMap.pi fun ρ => (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
+      (LinearMap.mulRight ℂ (evalWord A (List.ofFn ρ))) with hΨA
+  set ΨB : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ((Fin q → Fin d) → ℂ) :=
+    LinearMap.pi fun ρ => (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
+      (LinearMap.mulRight ℂ (evalWord B (List.ofFn ρ))) with hΨB
+  have hΨA_apply : ∀ (M : Matrix (Fin D) (Fin D) ℂ) (ρ : Fin q → Fin d),
+      ΨA M ρ = Matrix.trace (M * evalWord A (List.ofFn ρ)) := fun M ρ => rfl
+  have hΨB_apply : ∀ (M : Matrix (Fin D) (Fin D) ℂ) (ρ : Fin q → Fin d),
+      ΨB M ρ = Matrix.trace (M * evalWord B (List.ofFn ρ)) := fun M ρ => rfl
+  refine exists_linearMap_apply_eq _ _ ΨA ΨB hAk ?_ ?_
+  · -- Injectivity of the `A`-pairing: spanning at length `q` plus trace
+    -- nondegeneracy.
+    rw [LinearMap.ker_eq_bot']
+    intro M hM
+    have h : ∀ ρ : Fin q → Fin d,
+        Matrix.trace (M * evalWord A (List.ofFn ρ)) =
+          Matrix.trace ((0 : Matrix (Fin D) (Fin D) ℂ) * evalWord A (List.ofFn ρ)) := by
+      intro ρ
+      rw [Matrix.zero_mul, Matrix.trace_zero, ← hΨA_apply]
+      exact congrArg (· ρ) hM
+    exact eq_of_trace_mul_evalWord_eq hAq h
+  · -- The two pairings match on the spanning window family: both compute the
+    -- closed-chain coefficient of the concatenated word, equal at length `n`.
+    intro τ
+    funext ρ
+    rw [hΨA_apply, hΨB_apply, ← evalWord_append, ← evalWord_append]
+    exact trace_evalWord_eq_of_mpv_eq hAB (by simp [hkq])
+
+/-- **Word transport from equal word products.**  If `C` and `A` have equal
+word products at one length `n = k + q` — not only equal traces — and the
+length-`k` and length-`q` word products of `A` span, then a linear map `Λ`
+carries every length-`k` word product of `A` to that of `C`.  The pairing is
+taken in the matrix algebra rather than through the trace.
+
+This is the transport used after the gauge of arXiv:1804.04964 Lemma 5
+(lines 2045--2255 of `Papers/1804.04964/paper_normal.tex`) has been absorbed,
+when the two closed chains have matching matrix products at length `n`. -/
+theorem exists_evalWordTransport {A C : MPSTensor d D} {n k q : ℕ} (hkq : k + q = n)
+    (hAk : Submodule.span ℂ (Set.range fun τ : Fin k → Fin d =>
+      evalWord A (List.ofFn τ)) = ⊤)
+    (hAq : Submodule.span ℂ (Set.range fun ρ : Fin q → Fin d =>
+      evalWord A (List.ofFn ρ)) = ⊤)
+    (hAC : ∀ w : List (Fin d), w.length = n → evalWord C w = evalWord A w) :
+    ∃ Λ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+      ∀ τ : Fin k → Fin d,
+        Λ (evalWord A (List.ofFn τ)) = evalWord C (List.ofFn τ) := by
+  classical
+  set ΨA : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      ((Fin q → Fin d) → Matrix (Fin D) (Fin D) ℂ) :=
+    LinearMap.pi fun ρ => LinearMap.mulRight ℂ (evalWord A (List.ofFn ρ)) with hΨA
+  set ΨC : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      ((Fin q → Fin d) → Matrix (Fin D) (Fin D) ℂ) :=
+    LinearMap.pi fun ρ => LinearMap.mulRight ℂ (evalWord C (List.ofFn ρ)) with hΨC
+  have hΨA_apply : ∀ (M : Matrix (Fin D) (Fin D) ℂ) (ρ : Fin q → Fin d),
+      ΨA M ρ = M * evalWord A (List.ofFn ρ) := fun M ρ => rfl
+  have hΨC_apply : ∀ (M : Matrix (Fin D) (Fin D) ℂ) (ρ : Fin q → Fin d),
+      ΨC M ρ = M * evalWord C (List.ofFn ρ) := fun M ρ => rfl
+  refine exists_linearMap_apply_eq _ _ ΨA ΨC hAk ?_ ?_
+  · -- Injectivity of the `A`-pairing: a matrix annihilating a spanning
+    -- family on the right annihilates the identity.
+    rw [LinearMap.ker_eq_bot']
+    intro M hM
+    have hQ : ∀ Q : Matrix (Fin D) (Fin D) ℂ, M * Q = 0 := by
+      intro Q
+      have hQmem : Q ∈ Submodule.span ℂ (Set.range fun ρ : Fin q → Fin d =>
+          evalWord A (List.ofFn ρ)) := hAq ▸ Submodule.mem_top
+      induction hQmem using Submodule.span_induction with
+      | mem x hx =>
+          obtain ⟨ρ, rfl⟩ := hx
+          rw [← hΨA_apply]
+          exact congrArg (· ρ) hM
+      | zero => rw [Matrix.mul_zero]
+      | add x y _ _ hx hy => rw [Matrix.mul_add, hx, hy, add_zero]
+      | smul c x _ hx => rw [Matrix.mul_smul, hx, smul_zero]
+    calc M = M * 1 := (Matrix.mul_one M).symm
+      _ = 0 := hQ 1
+  · -- The two pairings match on the spanning window family: both compute the
+    -- length-`n` matrix product of the concatenated word.
+    intro τ
+    funext ρ
+    rw [hΨA_apply, hΨC_apply, ← evalWord_append, ← evalWord_append]
+    exact (evalWord_eq_of_forall_fin_eq (n := n)
+      (fun σ => hAC (List.ofFn σ) (by simp)) (by simp [hkq])).symm
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
@@ -623,6 +623,261 @@
     scalar.
 \end{proof}
 
+\begin{lemma}[Block injectivity extends to longer blocks]%
+    \label{lem:isNBlkInjective_of_le}
+    \lean{MPSTensor.isNBlkInjective_of_le}
+    \leanok
+    \uses{def:l_blk_injective}
+    Let $A$ be a tensor of $D \times D$ matrices over physical dimension
+    $d$, $L$-block injective with $0 < L$.  Then $A$ is $m$-block injective
+    for every $m \ge L$.  This is the chain form of the statement that any
+    region of at least the blocking size is injective, derived in the
+    closing section of \cite{Molnar2018NormalPEPS} (``Normal MPS:
+    alternative proof'') from its union lemma.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:eval_word}
+    It suffices to pass from length $m$ to $m + 1$.  Write the identity as
+    a combination of length-$L$ word products and peel the leading letter
+    of each: any matrix $P$ becomes a combination of terms
+    $A^{i}\,(W P)$ with $W$ a word product of length $L - 1$.  Each factor
+    $W P$ is a combination of length-$m$ word products by the induction
+    hypothesis, so each term is a combination of length-$(m+1)$ word
+    products.
+\end{proof}
+
+\begin{lemma}[Word transport between same-state networks]%
+    \label{lem:exists_mpvTransport}
+    \lean{MPSTensor.exists_mpvTransport}
+    \lean{MPSTensor.exists_evalWordTransport}
+    \leanok
+    \uses{def:l_blk_injective, def:mpv, def:eval_word}
+    Let $A$ and $B$ be tensors of $D \times D$ matrices over physical
+    dimension $d$, let $n = k + q$, and suppose the length-$k$ and
+    length-$q$ word products of $A$ each span the full matrix algebra.  If
+    the matrix product vectors of $A$ and $B$ agree at system size $n$,
+    then there is a linear map $\Lambda$ of the matrix algebra with
+    $\Lambda(A^{x_1} \cdots A^{x_k}) = B^{x_1} \cdots B^{x_k}$ for every
+    word $x$ of length $k$.  The same holds when, instead of the traces,
+    the word products of the two tensors are themselves equal at length
+    $n$.  This is the operator-transport mechanism underlying Lemma~5 of
+    \cite{Molnar2018NormalPEPS}: an operator expanded over the window
+    products of one network is re-read in the other.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:mpv, def:eval_word}
+    Pair the matrix algebra against the complementary word products: let
+    $\Psi_A(M)$ be the family of traces
+    $\tr(M\,A^{y_1} \cdots A^{y_q})$ over the length-$q$ words $y$, and
+    $\Psi_B$ its $B$-analogue.  $\Psi_A$ is injective because the length-$q$
+    products span and the trace pairing is nondegenerate.  On the spanning
+    family of length-$k$ products the two pairings match:
+    $\Psi_A(A^{x}) = \Psi_B(B^{x})$, since both compute closed-chain
+    coefficients of total length $n$, equal by hypothesis.  Hence the range
+    of $\Psi_A$ lies in that of $\Psi_B$, forcing $\Psi_B$ to be injective
+    by dimension count, and a left inverse of $\Psi_B$ composed with
+    $\Psi_A$ is the transport.  For the matrix-product version replace the
+    traces by the products themselves.
+\end{proof}
+
+\begin{lemma}[Bond-operator extraction from overlapping windows]%
+    \label{lem:overlapWindow_exists_bondOperator}
+    \lean{MPSTensor.overlapWindow_exists_bondOperator}
+    \lean{MPSTensor.bondOperator_unique}
+    \leanok
+    \uses{def:l_blk_injective, def:eval_word}
+    Let $0 < L$ with $2L + 1 \le n$, let $B$ be a tensor of $D \times D$
+    matrices over physical dimension $d$, $L$-block injective, and let
+    $C_0, \ldots, C_L$ be deformed window tensors: each $C_j$ assigns a
+    matrix to every word of length $L$, read as replacing the blocked
+    tensor of the $L$-site window starting $j$ sites left of a fixed bond
+    of the closed chain on $n$ sites.  Suppose the deformed states agree
+    for consecutive window positions: for every $j < L$, every prefix $p$
+    of $j$ sites, every assignment $u$ on the $L + 1$ sites covered by the
+    two windows, and every suffix $s$ on the remaining sites,
+    \[
+        \tr\bigl(B^{p}\, C_j(u_1 \cdots u_L)\, B^{u_{L+1}}\, B^{s}\bigr)
+        = \tr\bigl(B^{p}\, B^{u_1}\, C_{j+1}(u_2 \cdots u_{L+1})\,
+            B^{s}\bigr),
+    \]
+    where $B^{p}$ and $B^{s}$ denote the word products over the prefix and
+    suffix.  Then the deformation is a virtual operation on the bond: there
+    is a matrix $X$ with
+    \[
+        C_0(a) = B^{a_1} \cdots B^{a_L}\, X
+        \quad\text{and}\quad
+        C_L(b) = X\, B^{b_1} \cdots B^{b_L}
+    \]
+    for all length-$L$ words $a$, $b$, and $X$ is unique.  This is Lemma~5
+    of \cite{Molnar2018NormalPEPS} (its closing section, ``Normal MPS:
+    alternative proof''), specialized to one site-independent tensor; the
+    source states it for site-dependent tensors on five sites with $L = 2$,
+    with the deformed window tensors arising as physical operators
+    contracted with the blocked windows they act on.  The
+    algebra-homomorphism clause of the source lemma is established with the
+    insertion correspondence in
+    Lemma~\ref{lem:exists_conjugation_of_mpv_eq}.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:isNBlkInjective_of_le, def:eval_word}
+    Comparing the windows at $j$ and $j + 1$ through the rest of the chain
+    — an arc of $n - L - 1 \ge L$ sites, whose word products span by
+    Lemma~\ref{lem:isNBlkInjective_of_le} — strips the state equality to
+    the letter level:
+    $C_j(u_1 \cdots u_L)\,B^{u_{L+1}} = B^{u_1}\,C_{j+1}(u_2 \cdots
+    u_{L+1})$ on every window of $L + 1$ sites.  Chaining the $L$ relations
+    along a window of $2L$ sites turns the leftmost window into the
+    rightmost one:
+    $C_0(a)\,B^{b} = B^{a}\,C_L(b)$ for all length-$L$ words.  Writing the
+    identity as a combination $\sum_b \alpha_b B^{b} = I$, the matrix
+    $X := \sum_b \alpha_b\,C_L(b)$ satisfies $B^{a} X = C_0(a)$; the
+    mirrored combination of the $C_0$-family collapses onto the same
+    matrix, giving $X\,B^{b} = C_L(b)$, and stripping the spanning factors
+    makes $X$ unique.
+\end{proof}
+
+\begin{lemma}[Conjugate word products at one length from Lemma~5]%
+    \label{lem:exists_conjugation_of_mpv_eq}
+    \lean{MPSTensor.exists_conjugation_of_mpv_eq}
+    \leanok
+    \uses{def:l_blk_injective, def:mpv, def:eval_word}
+    Let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$ be tensors of
+    $D \times D$ matrices over physical dimension $d$, each $L$-block
+    injective, whose matrix product vectors agree at system size $n$.
+    Then there is an invertible matrix $Z$ with
+    \[
+        B^{w_1} \cdots B^{w_n} = Z\, A^{w_1} \cdots A^{w_n}\, Z^{-1}
+    \]
+    for every word $w$ of length $n$.  This captures the insertion
+    correspondence of Lemma~5 of \cite{Molnar2018NormalPEPS} and its
+    algebra-homomorphism clause for one site-independent tensor: the map
+    sending an insertion on one network to the corresponding insertion on
+    the other is an automorphism of the matrix algebra, hence inner.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:exists_mpvTransport, lem:overlapWindow_exists_bondOperator,
+        lem:isNBlkInjective_of_le, thm:skolem_noether}
+    A virtual insertion $X$ on a bond of the $A$-network is realized on
+    each of the $L + 1$ overlapping windows around the bond by deformed
+    window tensors placing $X$ after the first $L - j$ letters.
+    Transporting them to the $B$-network by the word transport
+    (Lemma~\ref{lem:exists_mpvTransport}) preserves all closed-chain
+    coefficients, so the transported deformations generate one common
+    state, and the bond-operator extraction
+    (Lemma~\ref{lem:overlapWindow_exists_bondOperator}) produces
+    $Y = \Phi(X)$ with $\Lambda(A^{a} X) = B^{a}\,\Phi(X)$ and
+    $\Lambda(X A^{b}) = \Phi(X)\,B^{b}$ on all window words.  Uniqueness
+    of the bond operator makes $\Phi$ linear, unital and multiplicative,
+    hence an automorphism of the full matrix algebra, and by
+    Skolem--Noether (Theorem~\ref{thm:skolem_noether})
+    $\Phi(X) = Z X Z^{-1}$ for an invertible $Z$.  Pairing the insertions
+    against all closed-chain words of length $n$ and using nondegeneracy of
+    the trace pairing transfers the conjugation to the word products.
+\end{proof}
+
+\begin{lemma}[Rigidity of word products at one length]%
+    \label{lem:proportional_of_evalWord_eq}
+    \lean{MPSTensor.proportional_of_evalWord_eq}
+    \leanok
+    \uses{def:l_blk_injective, def:eval_word}
+    Let $0 < L$ with $2L + 1 \le n$ and $0 < D$, and let $A$ and $C$ be
+    tensors of $D \times D$ matrices over physical dimension $d$, each
+    $L$-block injective, with equal word products at length $n$:
+    $C^{w_1} \cdots C^{w_n} = A^{w_1} \cdots A^{w_n}$ for every word $w$ of
+    length $n$.  Then there is a constant $\lambda$ with $\lambda^n = 1$
+    and $C^i = \lambda A^i$ for every $i$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:exists_mpvTransport, lem:isNBlkInjective_of_le,
+        def:eval_word}
+    Transport word products of $A$ to those of $C$ at the window length
+    $L$, at $L + 1$, at the complementary length $n - 1 - L$, and at
+    $n - L$ (Lemma~\ref{lem:exists_mpvTransport}, matrix-product version;
+    the lengths lie between $L$ and $n - L$ by $2L + 1 \le n$).  For a
+    transport pair at lengths $k$ and $k + 1$, the transported identity
+    $\Lambda_k(I)$ commutes with every letter of $C$ — its two one-letter
+    extensions agree, $C^i\,\Lambda_k(I) = \Lambda_{k+1}(A^i) =
+    \Lambda_k(I)\,C^i$ — hence with the full matrix algebra by block
+    injectivity, so it is a scalar $c_k I$, nonzero because the transport
+    is surjective onto the spanning word products, hence bijective.
+    Peeling one letter off the full-length equality through the spanning
+    windows of lengths $L$ and $n - 1 - L$ then leaves
+    $C^i = (c_L\,c_{n-1-L})^{-1} A^i =: \lambda A^i$; evaluating any
+    nonzero length-$n$ word product gives $\lambda^n = 1$.
+\end{proof}
+
+\begin{corollary}[Fundamental Theorem for translation-invariant normal MPS
+    at $n \ge 2L + 1$, single-gauge form]%
+    \label{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
+    \leanok
+    \uses{def:l_blk_injective, def:mpv}
+    Let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$ be tensors of
+    $D \times D$ matrices over physical dimension $d$, each $L$-block
+    injective, whose matrix product vectors agree at system size $n$:
+    $V^{(n)}(A)_\sigma = V^{(n)}(B)_\sigma$ for every configuration
+    $\sigma$.  Then there are an invertible matrix $Z$ and a constant
+    $\lambda$ with $\lambda^n = 1$ such that
+    \[
+        B^i = \lambda\, Z^{-1} A^i Z \qquad\text{for every } i .
+    \]
+    This is the strengthened closed-chain corollary of
+    \cite{Molnar2018NormalPEPS} (the corollary after Lemma~5 in its closing
+    section ``Normal MPS: alternative proof''), improving the system-size
+    bound of
+    Corollary~\ref{cor:fundamentalTheorem_normalMPS_translationInvariant}
+    from $n \ge 3L$ to $n \ge 2L + 1$.  The uniqueness clause of the source
+    corollary — the gauge $Z$ is unique up to a multiplicative constant —
+    needs no system size and is
+    Corollary~\ref{cor:fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}.
+    Positivity of the bond dimension is not assumed: a vanishing bond
+    dimension makes the conclusion trivial.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{lem:exists_conjugation_of_mpv_eq, lem:proportional_of_evalWord_eq}
+    By Lemma~\ref{lem:exists_conjugation_of_mpv_eq} the word products of
+    $B$ at length $n$ are those of $A$ conjugated by an invertible matrix.
+    Absorbing the conjugation into $B$ — which preserves $L$-block
+    injectivity — leaves two tensors with equal word products at length
+    $n$, and Lemma~\ref{lem:proportional_of_evalWord_eq} makes them
+    proportional letterwise by an $n$-th root of unity.  Undoing the
+    absorption gives $B^i = \lambda\, Z^{-1} A^i Z$.
+\end{proof}
+
+\begin{corollary}[Fundamental Theorem for translation-invariant normal MPS
+    at $n \ge 2L + 1$, per-bond form]%
+    \label{cor:fundamentalTheorem_normalMPS_of_overlap}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_of_overlap}
+    \leanok
+    \uses{def:l_blk_injective, def:mpv}
+    Let $n$ be positive, let $0 < L$ with $2L + 1 \le n$, and let $A$ and
+    $B$ be tensors of $D \times D$ matrices over physical dimension $d$,
+    each $L$-block injective, whose matrix product vectors agree at system
+    size $n$.  Then there are invertible matrices $Z_v$, one per bond of
+    the closed chain ($v = 1, \ldots, n$, $n + 1 \equiv 1$), with
+    \[
+        B^i = Z_v^{-1}\, A^i\, Z_{v+1}
+        \qquad\text{for every site } v \text{ and every } i .
+    \]
+    This is the per-bond gauge family of
+    Corollary~\ref{cor:fundamentalTheorem_normalMPS}, delivered at the
+    source's strengthened bound $n \ge 2L + 1$ in place of $n \ge 3L$
+    (\cite{Molnar2018NormalPEPS}, the corollary after Lemma~5 in its
+    closing section ``Normal MPS: alternative proof'').
+\end{corollary}
+\begin{proof}\leanok
+    \uses{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
+    The single-gauge form
+    (Corollary~\ref{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap})
+    gives $Z$ and $\lambda$ with $\lambda^n = 1$ and
+    $B^i = \lambda\,Z^{-1} A^i Z$.  The family $Z_v := \lambda^{v} Z$
+    dresses the gauge with powers of the root of unity: away from the seam
+    the consecutive powers contribute the factor $\lambda$, and across the
+    seam the wraparound contributes $\lambda^{1-n} = \lambda$ because
+    $\lambda^n = 1$, so $B^i = Z_v^{-1} A^i Z_{v+1}$ at every site.
+\end{proof}
+
+
 \begin{theorem}[Fundamental Theorem for normal PEPS, vertex-injective case]%
     \label{thm:fundamentalTheorem_normalPEPS_of_vertexInjective}
     \lean{TNLean.PEPS.fundamentalTheorem_normalPEPS_of_vertexInjective}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2658,9 +2658,9 @@ physical dimension contradicts block injectivity, so the
 counterexample-backed positivity corrections of the graph-level corollary
 are discharged rather than assumed.  The statements specialize the source's
 site-dependent families to one repeated tensor; the source's
-translation-invariant corollary (lines 1633--1668: a single gauge $Z$ and a
+translation-invariant corollary (lines 1624--1661: a single gauge $Z$ and a
 constant $\lambda$ with $\lambda^n = 1$) remains the follow-up refinement,
-as does the strengthening to $n \ge 2L + 1$ (line 1632, proved in the
+as does the strengthening to $n \ge 2L + 1$ (line 1623, proved in the
 source's Section \path{normal_alt}).
 
 \section*{The translation-invariant corollary in single-gauge form}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2711,6 +2711,94 @@ $n \ge 2L + 1$ sites from it, and reuse the matrix-level collapse above
 verbatim — the collapse itself nowhere uses $3L \le n$ beyond consuming the
 per-bond family.
 
+\section*{The strengthening to $n \ge 2L+1$ via overlapping windows}
+
+The plan recorded in the previous section is carried out: the source's
+Lemma~5 (lines 2045--2255) is formalized for matrix tensors, and the
+closed-chain corollaries now hold at the source's bound $n \ge 2L + 1$.
+The development stays at the matrix-tensor level throughout; no graph-level
+input beyond Skolem--Noether enters.
+
+Four layers deliver the result.  First, the linear-algebraic inputs:
+block injectivity extends to every longer block
+(\leanid{MPSTensor.isNBlkInjective_of_le}, the chain form of the source's
+remark at line 1940), and a word transport carries the length-$k$ word
+products of one tensor to those of the other whenever the two closed-chain
+states agree at one length $n = k + q$ with both window lengths spanning
+(\leanid{MPSTensor.exists_mpvTransport}; the variant
+\leanid{MPSTensor.exists_evalWordTransport} starts from equal word products
+instead of equal traces).  The transport is built by the left-inverse
+construction of the single-block linear extension: the pairing against the
+complementary word products is injective on one side by spanning and trace
+nondegeneracy, and the same-state hypothesis matches the two pairings on
+the window family.
+
+Second, Lemma~5 itself
+(\leanid{MPSTensor.overlapWindow_exists_bondOperator}, uniqueness
+\leanid{MPSTensor.bondOperator_unique}, blueprint
+\path{lem:overlapWindow_exists_bondOperator}): deformed window tensors
+$C_0, \ldots, C_L$ on the $L+1$ overlapping windows around a bond that
+generate one common state on $n \ge 2L+1$ sites come from a single virtual
+operation $X$ on the bond, with $C_0(a) = B^a X$ and $C_L(b) = X B^b$.  The
+proof follows the source: comparing consecutive windows through the
+complementary arc of $n - L - 1 \ge L$ sites strips the state equality to
+the letter level (the inversions of lines 2140--2167), chaining the $L$
+letter relations along a window of $2L$ sites moves the deformation across
+the bond (the plugging of lines 2168--2210), and a combination of window
+products representing the identity extracts $X$ from the two ends (lines
+2211--2255, after the model of \path{eq:inj_O->X_argument}).  The deformed
+window tensors play the role of the source's physical operators contracted
+with the blocked windows they act on; the statement is specialized to one
+site-independent tensor, matching the landed corollary surface, while the
+source states it for site-dependent tensors on five sites with $L = 2$.
+
+Third, the insertion correspondence
+(\leanid{MPSTensor.exists_conjugation_of_mpv_eq}): for two
+$L$-block-injective tensors with the same state at one length
+$n \ge 2L+1$, a virtual insertion $X$ on the first network, realized on the
+overlapping windows and transported to the second, is extracted there as a
+bond operator $\Phi(X)$.  Uniqueness of the bond operator makes $\Phi$
+linear, unital and multiplicative --- the source's algebra-homomorphism
+clause for $O_1 \mapsto X$ and $O_3^T \mapsto X$ (line 2253) --- hence an
+automorphism of the matrix algebra, inner by Skolem--Noether; pairing
+insertions against all closed-chain words turns the conjugation of
+insertions into the conjugation of word products at length $n$,
+$B^w = Z A^w Z^{-1}$.
+
+Fourth, a rigidity step the source leaves implicit in ``similar to the
+injective case, this leads to'' (line 2256): two $L$-block-injective
+tensors with \emph{equal} word products at one length $n \ge 2L+1$ are
+proportional letterwise by an $n$-th root of unity
+(\leanid{MPSTensor.proportional_of_evalWord_eq}).  The transports of the
+identity at the window length and at the complementary length $n - 1 - L$
+commute with every letter --- their two one-letter extensions agree ---
+hence are nonzero scalars, and peeling one letter off the full-length
+equality through the two spanning windows leaves $C^i = \lambda A^i$; both
+window lengths fit inside $n$ exactly when $n \ge 2L + 1$, which is where
+the source's bound enters.
+
+The capstones combine the layers: the translationally invariant corollary
+at $n \ge 2L+1$ in single-gauge form, $B^i = \lambda Z^{-1} A^i Z$ with
+$\lambda^n = 1$
+(\leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_of_overlap},
+blueprint
+\path{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}),
+and the per-bond family $B^i = Z_v^{-1} A^i Z_{v+1}$ at $n \ge 2L+1$
+(\leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_of_overlap}, blueprint
+\path{cor:fundamentalTheorem_normalMPS_of_overlap}), obtained by dressing
+the single gauge with powers of the root of unity, $Z_v = \lambda^v Z$.
+The single-gauge form arrives directly, so the matrix-level collapse of the
+per-bond family recorded in the previous sections is not needed on this
+route; the landed $n \ge 3L$ statements remain in place unchanged.  The
+uniqueness clause of the source corollary needs no system size and was
+already delivered by
+\leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}.
+With this, every numbered claim of the source's Section \path{normal_alt}
+for matrix-product states is formalized for one site-independent tensor;
+the site-dependent form of Lemma~5 and the $2L+1$ strengthening for
+two-dimensional tensor networks (the corollary at lines 2297--2318) remain
+open.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## Summary

Formalizes the last substantive unformalized item of the arXiv:1804.04964 normal program for matrix-product states: the strengthening of the closed-chain corollaries from `n >= 3L` to the source's `n >= 2L+1`, through **Lemma 5** of the source's Section `normal_alt` (lines 2045--2255 of `Papers/1804.04964/paper_normal.tex`) — operator pushing through *overlapping* injective windows, replacing the three-disjoint-arc cover.

All new theorems are sorry-free; `#print axioms` on each of the 11 public results reports exactly `[propext, Classical.choice, Quot.sound]`.

## New files (all in matrix-tensor language, one site-independent tensor)

- `TNLean/PEPS/CycleMPSWordTransport.lean` — block injectivity extends to longer blocks (`MPSTensor.isNBlkInjective_of_le`, source line 1940); trace stripping (`eq_of_trace_mul_evalWord_eq`, lines 1940--1960); the word transports from equal closed-chain data at one length (`exists_mpvTransport`, `exists_evalWordTransport`), built by the left-inverse construction of the single-block linear extension.
- `TNLean/PEPS/CycleMPSOverlapWindow.lean` — **Lemma 5 in matrix form** (`MPSTensor.overlapWindow_exists_bondOperator` + `bondOperator_unique`): deformed window tensors on the L+1 overlapping windows around a bond generating one common state on `n >= 2L+1` sites come from a single virtual bond operation X, factoring the outer windows on the right and left. Proof per the source: strip through the complementary arc (lines 2140--2167), chain the letter relations across the bond (2168--2210), extract X from the two ends (2211--2255).
- `TNLean/PEPS/CycleMPSOverlapInsertion.lean` — the insertion correspondence `X ↦ Φ(X)`: linear, unital, multiplicative (the source's algebra-homomorphism clause, line 2253), hence inner by Skolem--Noether; conclusion `MPSTensor.exists_conjugation_of_mpv_eq`: conjugate word products at length n.
- `TNLean/PEPS/CycleMPSOverlapCapstone.lean` — rigidity of equal word products at one length (`MPSTensor.proportional_of_evalWord_eq`: `C^i = λ A^i`, `λ^n = 1`) and the two capstones:
  - `fundamentalTheorem_normalMPS_translationInvariant_of_overlap` — the source's corollary after Lemma 5 (lines 2256--2295): single gauge Z, `λ^n = 1`, `B^i = λ Z^{-1} A^i Z` at `n >= 2L+1`;
  - `fundamentalTheorem_normalMPS_of_overlap` — the per-bond family `B^i = Z_v^{-1} A^i Z_{v+1}` at `n >= 2L+1` (`Z_v = λ^v Z`), strengthening the landed `fundamentalTheorem_normalMPS` bound; the `3L` statements remain in place.

The uniqueness clause of the source corollary needs no system size and is the landed `fundamentalTheorem_normalMPS_translationInvariant_gauge_unique`; the landed per-bond collapse is not needed on this route since the single-gauge form arrives directly.

## Scope

As with the landed closed-chain corollaries, the statements specialize the source's site-dependent tensors to one repeated tensor (recorded in the blueprint entries and the route note). The source's Lemma 5 is stated for five sites with L = 2; the formalization handles arbitrary `L > 0` and `n >= 2L+1`, the form its corollary consumes.

## Warm-up

First commit corrects the TI-corollary citation range `1633--1668` → `1624--1661` (and `1632` → `1623`) in `CycleMPSFundamentalTheorem.lean` and the recently appended route-note sections.

## Docs

- Blueprint: seven new entries in `blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex` (`leanblueprint checkdecls` exit 0; chktex clean; `leanblueprint web` has no ERROR lines).
- Route note: appended section in `docs/paper-gaps/peps_normal_ft_section3_route.tex` recording the delivery and the remaining open items (site-dependent Lemma 5; the 2D `(2L+1)×(2K+1)` corollary, lines 2297--2318).

Full `lake build` green; `lake exe lint-style` exit 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal proofs and documentation only; no changes to runtime services or the existing n ≥ 3L API beyond new theorems and imports.
> 
> **Overview**
> Adds a **sorry-free** Lean formalization of arXiv:1804.04964’s `normal_alt` route: closed-chain fundamental-theorem corollaries for translation-invariant normal MPS at **`n ≥ 2L + 1`**, down from the existing **`n ≥ 3L`** three-arc proof.
> 
> Four new modules build the chain in matrix-tensor form (one repeated tensor): **word transport** and extended block injectivity (`CycleMPSWordTransport`), **Lemma 5** bond-operator extraction from overlapping windows (`CycleMPSOverlapWindow`), **insertion correspondence** → conjugate length-`n` word products (`CycleMPSOverlapInsertion`), then **rigidity** plus capstones **`fundamentalTheorem_normalMPS_translationInvariant_of_overlap`** and **`fundamentalTheorem_normalMPS_of_overlap`** (`CycleMPSOverlapCapstone`). They are wired into the root import surface in `TNLean.lean`.
> 
> Docs: seven blueprint lemmas/corollaries in `ch13a_peps_ft_normal_capstone.tex` and an updated route note; citation line ranges for the TI corollary are corrected in `CycleMPSFundamentalTheorem.lean` (1624–1661). Existing **`n ≥ 3L`** theorems are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d806e4c0f50f7083131d6ac72726bd7c4a8ed75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->