### PR TITLE
style(blueprint): apply latexindent to failing files

### DIFF
--- a/blueprint/src/chapter/ch02b_mpdo.tex
+++ b/blueprint/src/chapter/ch02b_mpdo.tex
@@ -401,7 +401,7 @@ legs cyclically and taking the resulting trace.
     \lean{IsKrausCPTP}
     \leanok
     A linear map $\mathcal{S}$ between matrix algebras is \emph{trace-preserving
-    completely positive} if it has a Kraus form
+        completely positive} if it has a Kraus form
     $\mathcal{S}(X) = \sum_{i} A_i X A_i^\dagger$ with $\sum_i A_i^\dagger A_i = I$.
     The Kraus operators may be rectangular, so the input and output dimensions
     need not agree.
@@ -983,7 +983,7 @@ strong subadditivity for a normalized three-site reduced state.
     $k\mapsto(\sigma_k,\sigma_k)$:
     \[
         V^{(N)}\bigl(i\mapsto M^{ii}\bigr)(\sigma)
-            = V^{(N)}\bigl(\widehat{M}\bigr)\bigl(k\mapsto(\sigma_k,\sigma_k)\bigr).
+        = V^{(N)}\bigl(\widehat{M}\bigr)\bigl(k\mapsto(\sigma_k,\sigma_k)\bigr).
     \]
 \end{lemma}
 \begin{proof}\leanok
@@ -1011,7 +1011,7 @@ strong subadditivity for a normalized three-site reduced state.
     $A_k^{\mathrm{diag}}(i) = A_k(i,i)$ is the diagonal restriction of each block:
     \[
         V^{(N)}\bigl(i\mapsto M^{ii}\bigr)(\sigma)
-            = V^{(N)}\Bigl(\textstyle\bigoplus_k \mu_k\, A_k^{\mathrm{diag}}\Bigr)(\sigma).
+        = V^{(N)}\Bigl(\textstyle\bigoplus_k \mu_k\, A_k^{\mathrm{diag}}\Bigr)(\sigma).
     \]
 \end{lemma}
 \begin{proof}\leanok
@@ -1046,10 +1046,10 @@ strong subadditivity for a normalized three-site reduced state.
     the diagonal tensor equals the diagonal entry of the generated operator,
     \[
         V^{(N)}\bigl(i\mapsto M^{ii}\bigr)(\sigma)
-            = \bigl\langle\sigma\,\big|\,\rho^{(N)}(M)\,\big|\,\sigma\bigr\rangle,
+        = \bigl\langle\sigma\,\big|\,\rho^{(N)}(M)\,\big|\,\sigma\bigr\rangle,
     \]
     since both equal $\operatorname{tr}\bigl(M^{\sigma_1\sigma_1}\cdots
-    M^{\sigma_N\sigma_N}\bigr)$.
+        M^{\sigma_N\sigma_N}\bigr)$.
 \end{lemma}
 \begin{proof}\leanok
     \uses{lem:eval_word_diagonal_tensor}
@@ -1086,8 +1086,8 @@ strong subadditivity for a normalized three-site reduced state.
     vector decomposes as
     \[
         V^{(N)}\Bigl(\textstyle\bigoplus_\alpha\bigoplus_j
-            \omega_{\alpha j}\, A_\alpha\Bigr)(\sigma)
-            = \sum_{\alpha}\sum_{j} (\omega_{\alpha j})^N\, V^{(N)}(A_\alpha)(\sigma).
+        \omega_{\alpha j}\, A_\alpha\Bigr)(\sigma)
+        = \sum_{\alpha}\sum_{j} (\omega_{\alpha j})^N\, V^{(N)}(A_\alpha)(\sigma).
     \]
 \end{lemma}
 \begin{proof}\leanok
@@ -1098,12 +1098,12 @@ strong subadditivity for a normalized three-site reduced state.
     (Theorem~\ref{thm:mpv_decomposition}),
     \[
         V^{(N)}\bigl(\text{assembly}\bigr)(\sigma)
-            = \sum_{q} (\widetilde\omega_q)^N\, V^{(N)}(\widetilde A_q)(\sigma).
+        = \sum_{q} (\widetilde\omega_q)^N\, V^{(N)}(\widetilde A_q)(\sigma).
     \]
     The flattening identifies $q$ with the pair $(\alpha, j)$ via the bijection
     $\bigl(\{1,\dots,g\}\times\{1,\dots,\mult_\alpha\}\bigr)\simeq
-    \{1,\dots,\sum_\alpha\mult_\alpha\}$, under which $\widetilde\omega_q=
-    \omega_{\alpha j}$ and $\widetilde A_q = A_\alpha$. Reindexing the sum along
+        \{1,\dots,\sum_\alpha\mult_\alpha\}$, under which $\widetilde\omega_q=
+        \omega_{\alpha j}$ and $\widetilde A_q = A_\alpha$. Reindexing the sum along
     this bijection yields the double sum over $(\alpha, j)$.
 \end{proof}
 
@@ -3350,7 +3350,7 @@ the elementary trace-power identity for diagonal matrices.
     reduced state of the first $L$ spins of
     \[
         \sigma^{(N)}(A)
-          =
+        =
         \frac{\ketbra{V^{(N)}(A)}{V^{(N)}(A)}}{\|V^{(N)}(A)\|^2}.
     \]
     The tensor saturates the area law if
@@ -3412,31 +3412,31 @@ the elementary trace-power identity for diagonal matrices.
     $\rho^{(N)}(M) = \ketbra{V^{(N)}(A)}{V^{(N)}(A)}$, hence
     \[
         \sigma^{(N)}(M)
-          =
+        =
         \frac{\rho^{(N)}(M)}{\tr[\rho^{(N)}(M)]}
-          =
+        =
         \frac{\ketbra{V^{(N)}(A)}{V^{(N)}(A)}}{\|V^{(N)}(A)\|^2}
-          =
+        =
         \sigma^{(N)}(A).
     \]
     Therefore the reduced block states agree:
     \[
         \rho_L^{(N)}(M)
-          =
+        =
         \tr_{N\setminus L}\!\bigl[\sigma^{(N)}(M)\bigr]
-          =
+        =
         \tr_{N\setminus L}\!\bigl[\sigma^{(N)}(A)\bigr]
-          =
+        =
         \rho_L^{(N)}(A).
     \]
     Thus
     \[
         S_L^{(N)}(M)
-          =
+        =
         S\bigl(\rho_L^{(N)}(M)\bigr)
-          =
+        =
         S\bigl(\rho_L^{(N)}(A)\bigr)
-          =
+        =
         S_L^{(N)}(A).
     \]
 \end{proof}
@@ -3490,11 +3490,11 @@ the elementary trace-power identity for diagonal matrices.
 \begin{proof}\leanok
     The reduced state is $\rho_L \propto W W^\dagger$, where the amplitude matrix
     $W(u, w) = \langle u\,w\,|\,V^{(N)}(A)\rangle = \operatorname{tr}
-    \bigl(A^{u_1}\cdots A^{u_L}\, A^{w_1}\cdots A^{w_{N-L}}\bigr)$ factors through
+        \bigl(A^{u_1}\cdots A^{u_L}\, A^{w_1}\cdots A^{w_{N-L}}\bigr)$ factors through
     the two bond pairs cut by the block boundary. Writing the trace as a sum over
     the bond index pair $(a, b)\in\{1,\dots,D\}^2$ exhibits $W = L'R'$ with $L'$
     having $D^2$ columns, so $\operatorname{rank}\rho_L \le \operatorname{rank} W
-    \le D^2$.
+        \le D^2$.
 \end{proof}
 
 \begin{lemma}[The reduced pure block state is a density matrix]
@@ -3565,7 +3565,7 @@ the elementary trace-power identity for diagonal matrices.
     The normalized operator is the rank-one pure state
     \[
         \frac{\ket{V^{(N)}(A)}\bra{V^{(N)}(A)}}
-             {\langle V^{(N)}(A), V^{(N)}(A)\rangle} ,
+        {\langle V^{(N)}(A), V^{(N)}(A)\rangle} ,
     \]
     after reindexing the full block. A pure state has von Neumann entropy zero.
 \end{proof}

--- a/blueprint/src/chapter/ch04a_channel_representations.tex
+++ b/blueprint/src/chapter/ch04a_channel_representations.tex
@@ -1416,10 +1416,10 @@ This section states the existence theorems from
     \[
         \widehat{T'} =
         \begin{pmatrix}
-            1   &0          &0          &0\\
-            0   &x/\sqrt{3} &0          &0\\
-            0   &0          &x/\sqrt{3} &0\\
-            2/3 &0          &0          &1/3
+            1   & 0          & 0          & 0   \\
+            0   & x/\sqrt{3} & 0          & 0   \\
+            0   & 0          & x/\sqrt{3} & 0   \\
+            2/3 & 0          & 0          & 1/3
         \end{pmatrix}.
     \]
     Trace preservation supplies the first row of the displayed matrix.
@@ -1433,10 +1433,10 @@ This section states the existence theorems from
     \[
         \widehat{T'} =
         \begin{pmatrix}
-            1 &0 &0 &0\\
-            0 &0 &0 &0\\
-            0 &0 &0 &0\\
-            1 &0 &0 &0
+            1 & 0 & 0 & 0 \\
+            0 & 0 & 0 & 0 \\
+            0 & 0 & 0 & 0 \\
+            1 & 0 & 0 & 0
         \end{pmatrix},
     \]
     equivalently, every input state is mapped to $(1+\sigma_{3})/2$.

--- a/blueprint/src/chapter/ch04b_entropy.tex
+++ b/blueprint/src/chapter/ch04b_entropy.tex
@@ -103,7 +103,7 @@ finite-dimensional quantum systems.
     real parts of the roots of its characteristic polynomial $\chi_\rho$:
     \[
         S(\rho) = \sum_{\lambda \in \mathrm{roots}(\chi_\rho)}
-            \bigl({-}\operatorname{Re}(\lambda)\, \log \operatorname{Re}(\lambda)\bigr).
+        \bigl({-}\operatorname{Re}(\lambda)\, \log \operatorname{Re}(\lambda)\bigr).
     \]
 \end{lemma}
 

--- a/blueprint/src/chapter/ch05_qpf.tex
+++ b/blueprint/src/chapter/ch05_qpf.tex
@@ -656,9 +656,9 @@ The TP-gauge application follows~\cite[Appendix~A]{Cirac2016MPDO_arXiv}.
     If a nonzero vector $v$ annihilated this quadratic form, then every term
     $E^k(A)$ with $0 \le k \le D-1$ would annihilate $v$.
     The growth theorem for irreducible CP maps
-        (that is, $(\Id + E)^{D-1}(A) > 0$ for irreducible $E$ and nonzero
-        PSD $A$, as established in the proof of
-        Theorem~\ref{thm:orthogonal_trace_cond}) then forces
+    (that is, $(\Id + E)^{D-1}(A) > 0$ for irreducible $E$ and nonzero
+    PSD $A$, as established in the proof of
+    Theorem~\ref{thm:orthogonal_trace_cond}) then forces
     $(\Id + E)^{D-1}(A)$ to annihilate $v$, contradicting its positive
     definiteness.
 \end{proof}

--- a/blueprint/src/chapter/ch06_spectral.tex
+++ b/blueprint/src/chapter/ch06_spectral.tex
@@ -361,7 +361,7 @@ a block embedding of a mixed-transfer eigenvector.
 
     \emph{Step~2 (Block Kraus family and off-diagonal embedding).}
     Form the block Kraus operators $C^i = \bigl(\begin{smallmatrix}
-            A'^i & 0 \\ 0 & B'^i\end{smallmatrix}\bigr)$.
+                A'^i & 0 \\ 0 & B'^i\end{smallmatrix}\bigr)$.
     These constitute a unital Kraus family on $\MN{2D}$.
     The off-diagonal matrix
     $Y = (\begin{smallmatrix} 0 & X' \\ 0 & 0\end{smallmatrix})$

--- a/blueprint/src/chapter/ch08_canonical.tex
+++ b/blueprint/src/chapter/ch08_canonical.tex
@@ -232,8 +232,8 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \[
         B^i =
         \begin{pmatrix}
-            A_1^i &*\\
-            0     &A_2^i
+            A_1^i & *     \\
+            0     & A_2^i
         \end{pmatrix}
     \]
     for the conjugated letters in this split basis. Since

--- a/blueprint/src/chapter/ch11b_periodic_ft.tex
+++ b/blueprint/src/chapter/ch11b_periodic_ft.tex
@@ -971,7 +971,7 @@ unconditional result.
         G_N(j,k)
         =
         \left\langle
-            V^{(pN)}(A_j),V^{(pN)}(A_k)
+        V^{(pN)}(A_j),V^{(pN)}(A_k)
         \right\rangle
     \]
     be the Gram matrix of the periodic vectors.  The diagonal entries have

--- a/blueprint/src/chapter/ch13_algebraic_ft.tex
+++ b/blueprint/src/chapter/ch13_algebraic_ft.tex
@@ -374,10 +374,10 @@ shows that this agreement forces the local tensors to be proportional.
     all $Y \in \MN{D}$ (on the external bond), and all physical indices $i,j$,
     \begin{align}
         \tr(A_1^{i}\, X\, A_2^{j})
-         &= \tr(B_1^{i}\, X\, B_2^{j})
-        \label{eq:internal_bond}\\
+         & = \tr(B_1^{i}\, X\, B_2^{j})
+        \label{eq:internal_bond}        \\
         \tr(A_2^{j}\, Y\, A_1^{i})
-         &= \tr(B_2^{j}\, Y\, B_1^{i})
+         & = \tr(B_2^{j}\, Y\, B_1^{i})
         \label{eq:external_bond}
     \end{align}
     Diagrammatically, inserting $X$ on the bond between the two sites
@@ -410,7 +410,7 @@ shows that this agreement forces the local tensors to be proportional.
     the conditions in Equations~(\ref{eq:internal_bond}) and~(\ref{eq:external_bond})
     give, for all physical indices $i,j$,
     \begin{align}
-        A_2^{j} A_1^{i} & = B_2^{j} B_1^{i}, \label{eq:aft_product_identities_a}\\
+        A_2^{j} A_1^{i} & = B_2^{j} B_1^{i}, \label{eq:aft_product_identities_a} \\
         A_1^{i} A_2^{j} & = B_1^{i} B_2^{j}. \label{eq:aft_product_identities_b}
     \end{align}
     Write $\Id_D = \sum_j c_j A_2^j$ using the decomposition map

--- a/blueprint/src/chapter/ch13a_peps_ft_edge_kernel_gauges.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_edge_kernel_gauges.tex
@@ -401,14 +401,14 @@
     $\sigma$,
     \[
         \sum_{\beta}
-            O_1(B_u(\beta_u))_{\sigma_u}\,
-            C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
-            (B_v(\beta_v))_{\sigma_v}
+        O_1(B_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        (B_v(\beta_v))_{\sigma_v}
         =
         \sum_{\beta}
-            (B_u(\beta_u))_{\sigma_u}\,
-            C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
-            O_2(B_v(\beta_v))_{\sigma_v}.
+        (B_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        O_2(B_v(\beta_v))_{\sigma_v}.
     \]
     Theorem~\ref{thm:peps_physical_to_virtual_insertion} gives a single virtual
     matrix realizing both endpoint operators.  Endpoint uniqueness then
@@ -471,40 +471,40 @@
         C_A(e,\sigma,X)
         =
         \sum_{\beta}
-            O_1(A_u(\beta_u))_{\sigma_u}\,
-            C_{\mathrm{mid}}^A(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
-            (A_v(\beta_v))_{\sigma_v}
+        O_1(A_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}^A(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        (A_v(\beta_v))_{\sigma_v}
         =
         \sum_{\beta}
-            O_1(B_u(\beta_u))_{\sigma_u}\,
-            C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
-            (B_v(\beta_v))_{\sigma_v}
+        O_1(B_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        (B_v(\beta_v))_{\sigma_v}
     \]
     and
     \[
         C_A(e,\sigma,X)
         =
         \sum_{\beta}
-            (A_u(\beta_u))_{\sigma_u}\,
-            C_{\mathrm{mid}}^A(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
-            O_2(A_v(\beta_v))_{\sigma_v}
+        (A_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}^A(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        O_2(A_v(\beta_v))_{\sigma_v}
         =
         \sum_{\beta}
-            (B_u(\beta_u))_{\sigma_u}\,
-            C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
-            O_2(B_v(\beta_v))_{\sigma_v}.
+        (B_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        O_2(B_v(\beta_v))_{\sigma_v}.
     \]
     Therefore, for every physical configuration $\sigma$,
     \[
         \sum_{\beta}
-            O_1(B_u(\beta_u))_{\sigma_u}\,
-            C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
-            (B_v(\beta_v))_{\sigma_v}
+        O_1(B_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        (B_v(\beta_v))_{\sigma_v}
         =
         \sum_{\beta}
-            (B_u(\beta_u))_{\sigma_u}\,
-            C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
-            O_2(B_v(\beta_v))_{\sigma_v}.
+        (B_u(\beta_u))_{\sigma_u}\,
+        C_{\mathrm{mid}}^B(\sigma;\beta_{\mathrm{L}},\beta_{\mathrm{R}})\,
+        O_2(B_v(\beta_v))_{\sigma_v}.
     \]
     The positive-bond physical-to-virtual recovery applied to the second
     edge-blocked chain gives a matrix $Y\in\MN{D_B(e)}$ such that, for every
@@ -515,15 +515,15 @@
     Thus $X\mapsto Y$ gives the required coefficient correspondence.  Denote
     this correspondence by $T$.  For every physical configuration $\sigma$,
     \[
-    \begin{aligned}
-        C_B(e,\sigma,T(X+X'))
-        &=
-        C_A(e,\sigma,X+X')
-         =
-        C_A(e,\sigma,X)+C_A(e,\sigma,X')\\
-        &=
-        C_B(e,\sigma,T(X)+T(X')),
-    \end{aligned}
+        \begin{aligned}
+            C_B(e,\sigma,T(X+X'))
+             & =
+            C_A(e,\sigma,X+X')
+            =
+            C_A(e,\sigma,X)+C_A(e,\sigma,X') \\
+             & =
+            C_B(e,\sigma,T(X)+T(X')),
+        \end{aligned}
     \]
     and similarly \(T(cX)=cT(X)\).  The multiplicative identity is read from
     the inserted two-endpoint realization:
@@ -1195,8 +1195,8 @@
         C_{A_1,A_2}(b,X;\eta_1,\eta_2,\sigma_1,\sigma_2)
         =
         \sum_{\substack{\mu,\nu\\
-                \mu|_{\mathcal B\setminus\{b\}}
-                =\nu|_{\mathcal B\setminus\{b\}}}}
+        \mu|_{\mathcal B\setminus\{b\}}
+        =\nu|_{\mathcal B\setminus\{b\}}}}
         X_{\mu_b,\nu_b}
         A_1(\eta_1,\mu,\sigma_1)A_2(\eta_2,\nu,\sigma_2).
     \]

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
@@ -445,7 +445,7 @@
 \end{proof}
 
 \begin{corollary}[Fundamental Theorem for translation-invariant normal MPS
-    on a closed chain, matrix form]%
+        on a closed chain, matrix form]%
     \label{cor:fundamentalTheorem_normalMPS}
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS}
     \leanok
@@ -493,7 +493,7 @@
 \end{proof}
 
 \begin{corollary}[Uniqueness of the per-bond gauges up to one constant,
-    matrix form]%
+        matrix form]%
     \label{cor:fundamentalTheorem_normalMPS_gauge_unique}
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_gauge_unique}
     \leanok
@@ -552,7 +552,7 @@
 \end{proof}
 
 \begin{corollary}[Fundamental Theorem for translation-invariant normal MPS
-    on a closed chain, single-gauge form]%
+        on a closed chain, single-gauge form]%
     \label{cor:fundamentalTheorem_normalMPS_translationInvariant}
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant}
     \leanok
@@ -592,7 +592,7 @@
 \end{proof}
 
 \begin{corollary}[Uniqueness of the translation-invariant gauge up to a
-    constant]%
+        constant]%
     \label{cor:fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}
     \leanok
@@ -698,7 +698,7 @@
     \[
         \tr\bigl(B^{p}\, C_j(u_1 \cdots u_L)\, B^{u_{L+1}}\, B^{s}\bigr)
         = \tr\bigl(B^{p}\, B^{u_1}\, C_{j+1}(u_2 \cdots u_{L+1})\,
-            B^{s}\bigr),
+        B^{s}\bigr),
     \]
     where $B^{p}$ and $B^{s}$ denote the word products over the prefix and
     suffix.  Then the deformation is a virtual operation on the bond: there
@@ -725,7 +725,7 @@
     Lemma~\ref{lem:isNBlkInjective_of_le} — strips the state equality to
     the letter level:
     $C_j(u_1 \cdots u_L)\,B^{u_{L+1}} = B^{u_1}\,C_{j+1}(u_2 \cdots
-    u_{L+1})$ on every window of $L + 1$ sites.  Chaining the $L$ relations
+        u_{L+1})$ on every window of $L + 1$ sites.  Chaining the $L$ relations
     along a window of $2L$ sites turns the leftmost window into the
     rightmost one:
     $C_0(a)\,B^{b} = B^{a}\,C_L(b)$ for all length-$L$ words.  Writing the
@@ -797,7 +797,7 @@
     transport pair at lengths $k$ and $k + 1$, the transported identity
     $\Lambda_k(I)$ commutes with every letter of $C$ — its two one-letter
     extensions agree, $C^i\,\Lambda_k(I) = \Lambda_{k+1}(A^i) =
-    \Lambda_k(I)\,C^i$ — hence with the full matrix algebra by block
+        \Lambda_k(I)\,C^i$ — hence with the full matrix algebra by block
     injectivity, so it is a scalar $c_k I$, nonzero because the transport
     is surjective onto the spanning word products, hence bijective.
     Peeling one letter off the full-length equality through the spanning
@@ -807,7 +807,7 @@
 \end{proof}
 
 \begin{corollary}[Fundamental Theorem for translation-invariant normal MPS
-    at $n \ge 2L + 1$, single-gauge form]%
+        at $n \ge 2L + 1$, single-gauge form]%
     \label{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
     \leanok
@@ -845,7 +845,7 @@
 \end{proof}
 
 \begin{corollary}[Fundamental Theorem for translation-invariant normal MPS
-    at $n \ge 2L + 1$, per-bond form]%
+        at $n \ge 2L + 1$, per-bond form]%
     \label{cor:fundamentalTheorem_normalMPS_of_overlap}
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_of_overlap}
     \leanok

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_square.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_square.tex
@@ -1084,7 +1084,7 @@
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal square-lattice PEPS,
-    interior-window form]%
+        interior-window form]%
     \label{thm:fundamentalTheorem_normalSquarePEPS_unconditional}
     \lean{TNLean.PEPS.fundamentalTheorem_normalSquarePEPS_unconditional}
     \leanok
@@ -1100,16 +1100,16 @@
     edge, such that:
     \begin{enumerate}
         \item at every edge with interior margins (for a horizontal edge with
-            left endpoint $(x,y)$: $3\le x$, $x+7\le n$, $4\le y$,
-            $y+6\le m$; for a vertical edge the mirrored margins), inserting
-            any matrix on the edge of $A$ gives the same coefficient as
-            inserting it on the corresponding edge of the gauge-absorbed $B$,
-            for every physical configuration; and
+              left endpoint $(x,y)$: $3\le x$, $x+7\le n$, $4\le y$,
+              $y+6\le m$; for a vertical edge the mirrored margins), inserting
+              any matrix on the edge of $A$ gives the same coefficient as
+              inserting it on the corresponding edge of the gauge-absorbed $B$,
+              for every physical configuration; and
         \item every vertex $v=(x,y)$ of the interior comparison window
-            $4\le x\le n-9$, $4\le y\le m-9$ carries a nonzero scalar
-            $\lambda_v$ such that $A_v$ equals $\lambda_v$ times the gauge
-            action of the family on $B$ at $v$, on every virtual configuration
-            of the incident edges and every physical index.
+              $4\le x\le n-9$, $4\le y\le m-9$ carries a nonzero scalar
+              $\lambda_v$ such that $A_v$ equals $\lambda_v$ times the gauge
+              action of the family on $B$ at $v$, on every virtual configuration
+              of the incident edges and every physical index.
     \end{enumerate}
     This is the open-lattice form of \cite[Theorem~3]{Molnar2018NormalPEPS},
     restricted in two ways. First, the conclusion reaches only the interior:

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_union.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_union.tex
@@ -374,7 +374,7 @@
         =
         \sum_{\zeta}
         \left(
-          \prod_{f\in\partial R}G_f^X(\mu_f,\zeta_f)
+        \prod_{f\in\partial R}G_f^X(\mu_f,\zeta_f)
         \right)
         \prod_{v\in R}B_v(\zeta|_{\operatorname{inc}(v)},\tau_v),
     \]
@@ -446,7 +446,7 @@
         \sum_{\nu}K_R^X(\mu,\nu)\,(K_R^X)^{-1}(\nu,\rho)
         =
         \begin{cases}
-            1, & \mu=\rho,\\
+            1, & \mu=\rho,    \\
             0, & \mu\neq\rho.
         \end{cases}
     \]

--- a/blueprint/src/chapter/ch13a_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_region_transfer.tex
@@ -76,8 +76,8 @@
         C_A(R,f,M;\sigma,\tau)
         =
         \sum_{\substack{\mu,\nu\\
-                \mu|_{\partial R\setminus\{f\}}
-                =\nu|_{\partial R\setminus\{f\}}}}
+        \mu|_{\partial R\setminus\{f\}}
+        =\nu|_{\partial R\setminus\{f\}}}}
         M_{\mu_f,\nu_f}\,
         T_{A,R}^{\mu}(\sigma)\,
         T_{A,V\setminus R}^{\nu^c}(\tau).
@@ -609,9 +609,9 @@
         v_X^\sigma(\nu)
         =
         \left[
-          O_{A,R,f}(X^T)\,
-          T_{B,R}^{\tilde\nu}(\sigma)
-        \right]_{\sigma(v_f)},
+            O_{A,R,f}(X^T)\,
+            T_{B,R}^{\tilde\nu}(\sigma)
+            \right]_{\sigma(v_f)},
     \]
     where \(\tilde\nu\) is the \(R\)-boundary configuration corresponding to the
     \(R^c\)-boundary configuration \(\nu\), and \(v_f\) is the endpoint of \(f\)
@@ -628,7 +628,7 @@
     If \(K_X\) has the incident form
     \[
         K_X(\mu,\nu)=\mathbf 1_{\mu|_{\partial R\setminus\{f\}}
-          =\nu|_{\partial R\setminus\{f\}}}\,Y_{\mu_f,\nu_f},
+        =\nu|_{\partial R\setminus\{f\}}}\,Y_{\mu_f,\nu_f},
     \]
     then \(C_A(R,f,X;\sigma,\tau)=C_B(R,f,Y;\sigma,\tau)\).
 \end{theorem}
@@ -659,7 +659,7 @@
     incident form determined by \(Y\):
     \[
         K_X(\mu,\nu)=\mathbf 1_{\mu|_{\partial R\setminus\{f\}}
-          =\nu|_{\partial R\setminus\{f\}}}\,Y_{\mu_f,\nu_f}.
+        =\nu|_{\partial R\setminus\{f\}}}\,Y_{\mu_f,\nu_f}.
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -802,10 +802,10 @@
     positivity of all virtual bonds of \(B\), gives
     \[
         \left(
-          \forall\sigma,\tau,\,
-          C_B(R,f,T_1(M);\sigma,\tau)
-          =
-          C_B(R,f,T_2(M);\sigma,\tau)
+        \forall\sigma,\tau,\,
+        C_B(R,f,T_1(M);\sigma,\tau)
+        =
+        C_B(R,f,T_2(M);\sigma,\tau)
         \right)
         \Longrightarrow
         T_1(M)=T_2(M).
@@ -942,8 +942,8 @@
     \[
         \sum_{\zeta}
         \mathbf 1[
-            \zeta_f=\zeta_{0,f}\text{ for every edge }f
-            \text{ whose endpoints are outside }S]\,
+                \zeta_f=\zeta_{0,f}\text{ for every edge }f
+                \text{ whose endpoints are outside }S]\,
         c_{\zeta|_{\operatorname{Star}(v)}}
         \prod_{w\in S} A_w(\zeta|_{\operatorname{Star}(w)},\tau_w)=0 .
     \]

--- a/blueprint/src/chapter/ch13a_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_torus.tex
@@ -220,7 +220,7 @@
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus,
-    translation-covariant form]%
+        translation-covariant form]%
     \label{thm:fundamentalTheorem_normalTorusPEPS_unconditional}
     \lean{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}
     \leanok

--- a/blueprint/src/chapter/ch13b_symmetry.tex
+++ b/blueprint/src/chapter/ch13b_symmetry.tex
@@ -486,7 +486,7 @@ non-triviality.
     \[
         \beta_{\omega_1}(g,h)
         = \frac{\varphi(g)\varphi(h)\varphi(gh)^{-1}\,\omega_2(g,h)}
-               {\varphi(h)\varphi(g)\varphi(hg)^{-1}\,\omega_2(h,g)}
+        {\varphi(h)\varphi(g)\varphi(hg)^{-1}\,\omega_2(h,g)}
         = \frac{\omega_2(g,h)}{\omega_2(h,g)}
         = \beta_{\omega_2}(g,h),
     \]
@@ -513,7 +513,7 @@ non-triviality.
     The trivial cocycle has commutator phase $1$ at every pair, so by
     Theorem~\ref{thm:comm_phase_invariant} any cocycle cohomologous to it has
     $\beta = 1$ at every commuting pair.  Contrapositively, $\beta_\omega(g,h)\neq
-    1$ for one commuting pair forces $\omega$ to be non-cohomologous to the
+        1$ for one commuting pair forces $\omega$ to be non-cohomologous to the
     trivial cocycle.
 \end{proof}
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_basic_local_parent.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_basic_local_parent.tex
@@ -215,7 +215,7 @@ orthogonal projector is the canonical representative used here.
         =
         \begin{cases}
             \tau(r),
-                & k\equiv i+r \pmod N\text{ for some }0\le r<L,\\
+                       & k\equiv i+r \pmod N\text{ for some }0\le r<L, \\
             \sigma(k), & \text{otherwise}.
         \end{cases}
     \]
@@ -262,12 +262,12 @@ translated copies of the local interaction.
         (h_i\psi)(\sigma)
         =
         \begin{cases}
-        \left[
-            h_L(A)
-            \bigl(\tau\mapsto
+            \left[
+                h_L(A)
+                \bigl(\tau\mapsto
                 \psi(\sigma^{[i,i+L-1]\leftarrow\tau})\bigr)
-        \right]\!\bigl(\sigma|_{[i,i+L-1]}\bigr), & L \le N,\\
-        0, & L > N.
+            \right]\!\bigl(\sigma|_{[i,i+L-1]}\bigr), & L \le N, \\
+            0,                                        & L > N.
         \end{cases}
     \]
 \end{definition}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_closing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_closing.tex
@@ -301,10 +301,10 @@
         \prod_j M_{D_j}(\mathbb C)
         \quad\Longrightarrow\quad
         \ker\!\left(
-            \bigoplus_{j=1}^g G_N(A_j)
-            \longrightarrow (\mathbb C^d)^{\otimes N},
-            \quad
-            (\phi_j)_j\longmapsto \sum_j\phi_j
+        \bigoplus_{j=1}^g G_N(A_j)
+        \longrightarrow (\mathbb C^d)^{\otimes N},
+        \quad
+        (\phi_j)_j\longmapsto \sum_j\phi_j
         \right)=0.
     \]
 \end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -10,7 +10,7 @@
     \(N\) sites to \(L\) sites,
     \[
         R_{i,\tau}\!\left(
-            \Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right)
+        \Gamma_N^B\!\left(\bigoplus_{j=1}^gX_j\right)
         \right)
         =
         \sum_{j=1}^g

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -243,8 +243,8 @@
         \alpha(\sigma)
         =
         \operatorname{tr}\!\left(
-            A_{\sigma_{n+2}} C_{\sigma_1}
-            A_{\sigma_2}\cdots A_{\sigma_{n+1}}
+        A_{\sigma_{n+2}} C_{\sigma_1}
+        A_{\sigma_2}\cdots A_{\sigma_{n+1}}
         \right).
     \]
     Then \(\alpha\in G_{n+2}(A)\).
@@ -263,7 +263,7 @@
         \alpha(\sigma)
         =
         \operatorname{tr}\!\left(
-            A_{\sigma_1}A_{\sigma_2}\cdots A_{\sigma_{n+2}}E
+        A_{\sigma_1}A_{\sigma_2}\cdots A_{\sigma_{n+2}}E
         \right),
     \]
     which is the ground-space parametrization of \(E\).
@@ -285,8 +285,8 @@
         \alpha_j(\sigma)
         =
         \operatorname{tr}\!\left(
-            A^j_{\sigma_{n+2}} C^j_{\sigma_1}
-            A^j_{\sigma_2}\cdots A^j_{\sigma_{n+1}}
+        A^j_{\sigma_{n+2}} C^j_{\sigma_1}
+        A^j_{\sigma_2}\cdots A^j_{\sigma_{n+1}}
         \right).
     \]
     Then
@@ -304,13 +304,13 @@
     trace,
     \[
         \operatorname{tr}\!\left(
-            A^j_{\sigma_{n+2}} C^j_{\sigma_1}
-            A^j_{\sigma_2}\cdots A^j_{\sigma_{n+1}}
+        A^j_{\sigma_{n+2}} C^j_{\sigma_1}
+        A^j_{\sigma_2}\cdots A^j_{\sigma_{n+1}}
         \right)
         =
         \operatorname{tr}\!\left(
-            A^j_{\sigma_1}A^j_{\sigma_2}\cdots
-            A^j_{\sigma_{n+2}}E^j
+        A^j_{\sigma_1}A^j_{\sigma_2}\cdots
+        A^j_{\sigma_{n+2}}E^j
         \right).
     \]
     Thus \(\alpha_j\) is the image of \(E^j\) under the parametrization
@@ -336,20 +336,20 @@
         \alpha_j(i_1,\ldots,i_{n+2})
         =
         \operatorname{tr}\!\left(
-            A^j_{i_{n+2}} C^j_{i_1}
-            A^j_{i_2}\cdots A^j_{i_{n+1}}
+        A^j_{i_{n+2}} C^j_{i_1}
+        A^j_{i_2}\cdots A^j_{i_{n+1}}
         \right),
     \]
     and suppose that the two trace decompositions agree for every middle word:
     \[
         \sum_j
         \operatorname{tr}\!\left(
-            A^j_b C^j_a A^j_w
+        A^j_b C^j_a A^j_w
         \right)
         =
         \sum_j
         \operatorname{tr}\!\left(
-            D^j_b A^j_a A^j_w
+        D^j_b A^j_a A^j_w
         \right).
     \]
     Then
@@ -413,7 +413,7 @@
         =
         \sum_j
         \operatorname{tr}\!\left(
-            A^j_{i_2}\cdots A^j_{i_{n+2}}C^j_a
+        A^j_{i_2}\cdots A^j_{i_{n+2}}C^j_a
         \right),
     \]
     and
@@ -422,7 +422,7 @@
         =
         \sum_j
         \operatorname{tr}\!\left(
-            A^j_{i_1}\cdots A^j_{i_{n+1}}D^j_b
+        A^j_{i_1}\cdots A^j_{i_{n+1}}D^j_b
         \right).
     \]
     Evaluating these two decompositions on
@@ -438,8 +438,8 @@
         \alpha_j(i_1,\ldots,i_{n+2})
         =
         \operatorname{tr}\!\left(
-            A^j_{i_{n+2}}C^j_{i_1}
-            A^j_{i_2}\cdots A^j_{i_{n+1}}
+        A^j_{i_{n+2}}C^j_{i_1}
+        A^j_{i_2}\cdots A^j_{i_{n+1}}
         \right).
     \]
     Lemma~\ref{lem:left_boundary_trace_decomposition_mem_block_ground_spaces}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_separation_and_intersection.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_separation_and_intersection.tex
@@ -88,7 +88,7 @@
         \sum_{|\omega|=S} c_\omega A_\ell^\omega
         =
         \begin{cases}
-            I, & \ell=k,\\
+            I, & \ell=k,    \\
             0, & \ell\in T.
         \end{cases}
     \]
@@ -256,9 +256,9 @@
     of blocks, the trace-separation conclusion has the form
     \[
         \left[
-        \forall |\omega|=S,\;
-        \tr(\Delta_A A^\omega)+\tr(\Delta_B B^\omega)=0
-        \right]
+            \forall |\omega|=S,\;
+            \tr(\Delta_A A^\omega)+\tr(\Delta_B B^\omega)=0
+            \right]
         \Longrightarrow
         \Delta_A=\Delta_B=0.
     \]
@@ -487,7 +487,7 @@
         \sum_{|\omega|=(g-1)S} c_\omega^{(k)} A_j^\omega
         =
         \begin{cases}
-            I, & j=k,\\
+            I, & j=k,    \\
             0, & j\ne k.
         \end{cases}
     \]
@@ -592,7 +592,7 @@
         \sum_{|\omega|=S} c_\omega^{(k)} A_j^\omega
         =
         \begin{cases}
-            I, & j=k,\\
+            I, & j=k,    \\
             0, & j\ne k.
         \end{cases}
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_bnt_span_consequences.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_bnt_span_consequences.tex
@@ -87,8 +87,8 @@
         =
         \sum_{i_1,\ldots,i_{m+1}}
         \tr\!\left(
-            A^j_{i_{m+1}} C^j_{i_1}
-            A^j_{i_2}\cdots A^j_{i_m}
+        A^j_{i_{m+1}} C^j_{i_1}
+        A^j_{i_2}\cdots A^j_{i_m}
         \right)
         |i_1\cdots i_{m+1}\rangle,
     \]
@@ -97,8 +97,8 @@
         =
         \sum_{i_1,\ldots,i_{m+1}}
         \tr\!\left(
-            D^j_{i_{m+1}}
-            A^j_{i_1} A^j_{i_2}\cdots A^j_{i_m}
+        D^j_{i_{m+1}}
+        A^j_{i_1} A^j_{i_2}\cdots A^j_{i_m}
         \right)
         |i_1\cdots i_{m+1}\rangle.
     \]
@@ -138,7 +138,7 @@
         =
         \sum_{i_1,\ldots,i_{m+1}}
         \tr\!\left(A^j_{i_1}\cdots A^j_{i_m}
-                  A^j_{i_{m+1}}E^j\right)
+        A^j_{i_{m+1}}E^j\right)
         |i_1\cdots i_{m+1}\rangle
         =
         \Gamma_{m+1}^{A_j}(E^j)
@@ -328,7 +328,7 @@
         \sum_{|\omega|=S} c_\omega^{(k)} A_j^\omega
         =
         \begin{cases}
-            I, & j=k,\\
+            I, & j=k,    \\
             0, & j\ne k.
         \end{cases}
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_normal_boundary_closing_reverse.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_normal_boundary_closing_reverse.tex
@@ -203,14 +203,14 @@
     \]
     Fixing the first physical letter in the two length-$(L_0+1)$ windows gives
     \[
-    \begin{aligned}
-        R_j\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
-        &=
-        \Gamma_{L_0}\!\left(Y_M(\tau^+_\eta(\mu))A^j\right),\\
-        R_j\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)
-        &=
-        \Gamma_{L_0}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\right).
-    \end{aligned}
+        \begin{aligned}
+            R_j\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+             & =
+            \Gamma_{L_0}\!\left(Y_M(\tau^+_\eta(\mu))A^j\right), \\
+            R_j\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)
+             & =
+            \Gamma_{L_0}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\right).
+        \end{aligned}
     \]
     The two restrictions are therefore equal.
 \end{proof}
@@ -403,13 +403,13 @@
     \[
         \tau^{+}_{\eta}(\mu)_i =
         \begin{cases}
-            \mu_{i-L_0}, & L_0\le i<N-1,\\
+            \mu_{i-L_0}, & L_0\le i<N-1,     \\
             \eta,        & \text{otherwise},
         \end{cases}
         \qquad
         \tau^{-}_{\eta}(\mu)_i =
         \begin{cases}
-            \mu_{i-1}, & 1\le i<N-L_0,\\
+            \mu_{i-1}, & 1\le i<N-L_0,     \\
             \eta,      & \text{otherwise}.
         \end{cases}
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_open_chain_intersection.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_open_chain_intersection.tex
@@ -222,7 +222,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     \]
     equivalently
     $\psi \in G_{L+1}(A) \iff
-      \psi \in G_L^{\mathrm{left}} \cap G_L^{\mathrm{right}}$.
+        \psi \in G_L^{\mathrm{left}} \cap G_L^{\mathrm{right}}$.
 \end{theorem}
 
 \begin{proof}
@@ -277,8 +277,8 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
         \rho^{\mathrm{cyc}}_{i,L,\omega}(k)
         :=
         \begin{cases}
-        \omega(\delta_i(k)), & \delta_i(k)<L,\\
-        \rho(k), & \delta_i(k)\ge L.
+            \omega(\delta_i(k)), & \delta_i(k)<L,    \\
+            \rho(k),             & \delta_i(k)\ge L.
         \end{cases}
     \]
     The restriction to the cyclic interval beginning at $i$ is

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_periodic_unique_ground_state.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_periodic_unique_ground_state.tex
@@ -57,7 +57,7 @@
     \leanok
     \uses{def:ground_space_parent}
     For $N > 0$ and $L \le N$, define the \emph{periodic parent-Hamiltonian
-    ground space}
+        ground space}
     \[
         \mathcal{G}_{N,L}(A) := \bigl\{\psi \in (\{0,\ldots,d{-}1\}^N \to \C)
         : \forall i \in \{0,\ldots,N{-}1\},\

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap.tex
@@ -10,7 +10,7 @@ and in the later formulation of Kastoryano and
 Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{definition}[Parent ground space in the Hilbert-space realization]
-\label{def:parent_ground_space_es}
+    \label{def:parent_ground_space_es}
     \lean{MPSTensor.parentHamiltonianGroundSpaceES}
     \leanok
     \uses{def:parent_hamiltonian, def:nsite_space_parent}
@@ -20,7 +20,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
 \end{definition}
 
 \begin{definition}[Parent Hamiltonian in the Hilbert-space realization]
-\label{def:parent_hamiltonian_es}
+    \label{def:parent_hamiltonian_es}
     \lean{MPSTensor.parentHamiltonianES}
     \leanok
     \uses{def:parent_hamiltonian, def:nsite_space_parent}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
@@ -117,7 +117,7 @@
     cyclic distance $d_N(i,j)$.
     Then
     $\sum_{\substack{j\ne i\\ \{i,j\}\text{ overlapping}}}c_{\{i,j\}}
-    \le 2(L-1)\cdot\tfrac{1}{2(L-1)} = 1$,
+        \le 2(L-1)\cdot\tfrac{1}{2(L-1)} = 1$,
     satisfying the row-sum hypothesis of
     Theorem~\ref{thm:martingale_criterion}.
 
@@ -144,7 +144,7 @@
     overlapping-window estimate with the displayed coefficient. Thus the
     remaining comparison is whether the principal-angle estimates cited in
     \cite{Fannes1992Finitely, Nachtergaele1996Spectral,
-    Kastoryano2018Martingale} supply this cyclic-window inequality, with
+        Kastoryano2018Martingale} supply this cyclic-window inequality, with
     constants independent of $N$, under the convention used here.
     % Paper-gap note: docs/paper-gaps/cpgsv21_martingale_overlap.tex.
 \end{proof}

--- a/blueprint/src/chapter/ch15_correlations.tex
+++ b/blueprint/src/chapter/ch15_correlations.tex
@@ -485,7 +485,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \leanok
     \uses{def:is_locally_orthogonal, def:is_cid}
     In the single-block convention, an MPS tensor has \emph{zero correlation
-    length} when
+        length} when
     \[
         \E_A^2=\E_A
         \qquad\text{and}\qquad

--- a/blueprint/src/chapter/ch16_examples.tex
+++ b/blueprint/src/chapter/ch16_examples.tex
@@ -52,7 +52,7 @@ non-injective, renormalization-fixed-point MPS.
         \ket{a}^{\otimes N}(\sigma_1,\ldots,\sigma_N)
         =
         \begin{cases}
-            1, & (\sigma_1,\ldots,\sigma_N)=(a,\ldots,a),\\
+            1, & (\sigma_1,\ldots,\sigma_N)=(a,\ldots,a), \\
             0, & \text{otherwise}.
         \end{cases}
     \]
@@ -311,7 +311,7 @@ symmetry-protected topological (SPT) order.
     $\mathrm{SU}(2)$ generator:
     $\diag(e^{-i\theta/2}, e^{i\theta/2}) \mapsto R_z(\theta)$ and
     $\bigl(\begin{smallmatrix}\cos\frac\beta2 & -i\sin\frac\beta2 \\
-    -i\sin\frac\beta2 & \cos\frac\beta2\end{smallmatrix}\bigr) \mapsto R_x(\beta)$.
+                -i\sin\frac\beta2 & \cos\frac\beta2\end{smallmatrix}\bigr) \mapsto R_x(\beta)$.
 \end{theorem}
 
 \begin{theorem}[$\mathrm{SO}(3)$ on-site symmetry of the AKLT tensor]\label{thm:aklt_so3_symmetric}
@@ -481,7 +481,7 @@ computation and provides another example of a non-trivial SPT phase.
 \begin{proof}
     \leanok
     \uses{thm:has_string_order_of_symmetric_injective, thm:cluster_z2z2_symmetric,
-      rem:cluster_injective_blocked}
+        rem:cluster_injective_blocked}
     The blocked tensor is injective (Remark~\ref{rem:cluster_injective_blocked})
     and on-site symmetric under $\Z_2 \times \Z_2$
     (Theorem~\ref{thm:cluster_z2z2_symmetric}), and each group element acts by a
@@ -506,10 +506,10 @@ is recorded here in the form
 \[
     \mathcal G_L(A)=
     \left\{
-        \sum_{i_1,\ldots,i_L}
-        \tr(A^{i_1}\cdots A^{i_L}X)
-        \ket{i_1\cdots i_L}
-        : X\in \MN{D}
+    \sum_{i_1,\ldots,i_L}
+    \tr(A^{i_1}\cdots A^{i_L}X)
+    \ket{i_1\cdots i_L}
+    : X\in \MN{D}
     \right\}.
 \]
 Thus
@@ -613,8 +613,8 @@ for the ground eigenspace.
         \mathcal G_{N,2}(A_{\mathrm{GHZ}})
         =
         \spn_{\C}\{
-            \ket{0}^{\otimes N},
-            \ket{1}^{\otimes N}
+        \ket{0}^{\otimes N},
+        \ket{1}^{\otimes N}
         \}.
     \]
     This is the cyclic-window form of the two-fold degeneracy in
@@ -755,8 +755,8 @@ for the ground eigenspace.
         =
         \sum_i
         \left(
-            \vec S_i\cdot\vec S_{i+1}
-            +\frac13(\vec S_i\cdot\vec S_{i+1})^2
+        \vec S_i\cdot\vec S_{i+1}
+        +\frac13(\vec S_i\cdot\vec S_{i+1})^2
         \right),
     \]
     up to an additive constant
@@ -768,9 +768,9 @@ for the ground eigenspace.
         =
         \frac12
         \left(
-            \vec S_i\cdot\vec S_{i+1}
-            +\frac13(\vec S_i\cdot\vec S_{i+1})^2
-            +\frac23 I
+        \vec S_i\cdot\vec S_{i+1}
+        +\frac13(\vec S_i\cdot\vec S_{i+1})^2
+        +\frac23 I
         \right)
     \]
     for two spin-$1$ particles.  For open boundary conditions,
@@ -778,7 +778,7 @@ for the ground eigenspace.
         \dim \operatorname{GS}(H_{\mathrm{AKLT},N}^{\mathrm{open}})=4,
         \qquad
         \dim\bigl(\operatorname{GS}(H_{\mathrm{AKLT},N}^{\mathrm{open}})
-            \cap \mathcal H_{S=0}\bigr)=1
+        \cap \mathcal H_{S=0}\bigr)=1
     \]
     \cite[lines~1169--1174]{Cirac2021Matrix}.
 \end{remark}

--- a/blueprint/src/macros/print.tex
+++ b/blueprint/src/macros/print.tex
@@ -26,21 +26,21 @@
 \AddToHook{env/proof/end}{\tnleanInProoffalse}
 
 \newcommand{\tnleanStatusBadge}[3]{%
-  \leavevmode\unskip
-  \penalty0\hspace{0.3em plus 0.15em minus 0.05em}%
-  \begingroup
-  \setlength{\fboxsep}{1.4pt}%
-  \fcolorbox{#1}{#2!8}{%
-    \textcolor{#1}{\sffamily\scriptsize\bfseries #3}%
-  }%
-  \endgroup
-  \penalty0\hspace{0.2em plus 0.1em minus 0.05em}%
-  \ignorespaces
+    \leavevmode\unskip
+    \penalty0\hspace{0.3em plus 0.15em minus 0.05em}%
+    \begingroup
+    \setlength{\fboxsep}{1.4pt}%
+    \fcolorbox{#1}{#2!8}{%
+        \textcolor{#1}{\sffamily\scriptsize\bfseries #3}%
+    }%
+    \endgroup
+    \penalty0\hspace{0.2em plus 0.1em minus 0.05em}%
+    \ignorespaces
 }
 
 \ExplSyntaxOn
 \cs_new_protected:Npn \tnlean_decl_badge:n #1
-  {
+{
     \tl_set:Nn \l_tmpa_tl {#1}
     \tl_trim_spaces:N \l_tmpa_tl
     \seq_set_split:NnV \l_tmpa_seq {.} \l_tmpa_tl
@@ -57,49 +57,49 @@
     \tl_replace_all:Nnn \l_tmpb_tl {₉} {9}
     \tl_replace_all:Nnn \l_tmpb_tl {ₗ} {l}
     \href{\tnleanDocHome/find/\#doc/\tl_use:N \l_tmpa_tl}
-      {
+    {
         \tnleanStatusBadge{tnleanStatusBlue}{tnleanStatusBlue}
-          {Lean}
-      }
-  }
+        {Lean}
+    }
+}
 \NewDocumentCommand{\lean}{m}
-  {
+{
     \clist_map_inline:nn {#1} {\tnlean_decl_badge:n {##1}}
-  }
+}
 \ExplSyntaxOff
 
 \newcommand{\discussion}[1]{%
-  \tnleanStatusBadge{tnleanStatusGrey}{tnleanStatusGrey}{Discussion: \##1}%
+    \tnleanStatusBadge{tnleanStatusGrey}{tnleanStatusGrey}{Discussion: \##1}%
 }
 \newcommand{\leanok}{%
-  \iftnleanInProof
-    \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
-      {\ensuremath{\checkmark}\ Proof}%
-  \else
-    \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
-      {\ensuremath{\checkmark}\ Stmt}%
-  \fi
+    \iftnleanInProof
+        \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
+        {\ensuremath{\checkmark}\ Proof}%
+    \else
+        \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
+        {\ensuremath{\checkmark}\ Stmt}%
+    \fi
 }
 \newcommand{\mathlibok}{%
-  \iftnleanInProof
-    \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
-      {\ensuremath{\checkmark}\ ML proof}%
-  \else
-    \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
-      {\ensuremath{\checkmark}\ ML stmt}%
-  \fi
+    \iftnleanInProof
+        \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
+        {\ensuremath{\checkmark}\ ML proof}%
+    \else
+        \tnleanStatusBadge{tnleanStatusGreen}{tnleanStatusGreen}
+        {\ensuremath{\checkmark}\ ML stmt}%
+    \fi
 }
 \newcommand{\notready}{%
-  \tnleanStatusBadge{tnleanStatusOrange}{tnleanStatusOrange}{Not ready}%
+    \tnleanStatusBadge{tnleanStatusOrange}{tnleanStatusOrange}{Not ready}%
 }
 % Make sure that arguments of \uses and \proves are real labels, by using invisible refs:
 % latex prints a warning if the label is not defined, but nothing is shown in the pdf file.
 % It uses LaTeX3 programming, this is why we use the expl3 package.
 \ExplSyntaxOn
 \NewDocumentCommand{\uses}{m}
- {\clist_map_inline:nn{#1}{\vphantom{\ref{##1}}}%
-  \ignorespaces}
+{\clist_map_inline:nn{#1}{\vphantom{\ref{##1}}}%
+    \ignorespaces}
 \NewDocumentCommand{\proves}{m}
- {\clist_map_inline:nn{#1}{\vphantom{\ref{##1}}}%
-  \ignorespaces}
+{\clist_map_inline:nn{#1}{\vphantom{\ref{##1}}}%
+    \ignorespaces}
 \ExplSyntaxOff

--- a/blueprint/src/macros/tn_core.tex
+++ b/blueprint/src/macros/tn_core.tex
@@ -6,23 +6,23 @@
 \usetikzlibrary{calc}
 
 \tikzset{
-  tn picture/.style={
-    baseline=-0.1cm,
-    transform shape,
-    font=\scriptsize
-  },
-  tn tensor dot/.style={
-    draw,
-    fill,
-    shape=circle,
-    inner sep=0.055cm
-  },
-  tn operator dot/.style={
-    tn tensor dot,
-    red
-  },
-  tn leg/.style={line width=0.4pt},
-  tn phys leg/.style={line width=0.7pt}
+    tn picture/.style={
+            baseline=-0.1cm,
+            transform shape,
+            font=\scriptsize
+        },
+    tn tensor dot/.style={
+            draw,
+            fill,
+            shape=circle,
+            inner sep=0.055cm
+        },
+    tn operator dot/.style={
+            tn tensor dot,
+            red
+        },
+    tn leg/.style={line width=0.4pt},
+    tn phys leg/.style={line width=0.7pt}
 }
 
 \makeatletter
@@ -37,202 +37,202 @@
 % ---------- Atomic drawing commands ----------
 
 \newcommand{\TN@tensordot}[2]{%
-  \node[tn tensor dot] (#1) at #2 {};%
+    \node[tn tensor dot] (#1) at #2 {};%
 }
 
 \newcommand{\TN@opdot}[2]{%
-  \node[tn operator dot] (#1) at #2 {};%
+    \node[tn operator dot] (#1) at #2 {};%
 }
 
 \newcommand{\TN@opdotabove}[3]{%
-  \node[tn operator dot, label=above:$#3$] (#1) at #2 {};%
+    \node[tn operator dot, label=above:$#3$] (#1) at #2 {};%
 }
 
 \newcommand{\TN@opdotbelow}[3]{%
-  \node[tn operator dot, label=below:$#3$] (#1) at #2 {};%
+    \node[tn operator dot, label=below:$#3$] (#1) at #2 {};%
 }
 
 \newcommand{\TN@opdotleft}[3]{%
-  \node[tn operator dot, label=left:$#3$] (#1) at #2 {};%
+    \node[tn operator dot, label=left:$#3$] (#1) at #2 {};%
 }
 
 \newcommand{\TN@opdotright}[3]{%
-  \node[tn operator dot, label=right:$#3$] (#1) at #2 {};%
+    \node[tn operator dot, label=right:$#3$] (#1) at #2 {};%
 }
 
 \newcommand{\TN@leftleg}[2]{%
-  \draw[tn leg] (#1.west) -- ++(-#2,0);%
+    \draw[tn leg] (#1.west) -- ++(-#2,0);%
 }
 
 \newcommand{\TN@rightleg}[2]{%
-  \draw[tn leg] (#1.east) -- ++(#2,0);%
+    \draw[tn leg] (#1.east) -- ++(#2,0);%
 }
 
 \newcommand{\TN@upleg}[2]{%
-  \draw[tn phys leg] (#1.north) -- ++(0,#2);%
+    \draw[tn phys leg] (#1.north) -- ++(0,#2);%
 }
 
 \newcommand{\TN@downleg}[2]{%
-  \draw[tn phys leg] (#1.south) -- ++(0,-#2);%
+    \draw[tn phys leg] (#1.south) -- ++(0,-#2);%
 }
 
 \newcommand{\TN@uplabel}[3]{%
-  \node at ($(#1.north)+(0,#2)$) {$#3$};%
+    \node at ($(#1.north)+(0,#2)$) {$#3$};%
 }
 
 \newcommand{\TN@downlabel}[3]{%
-  \node at ($(#1.south)+(0,-#2)$) {$#3$};%
+    \node at ($(#1.south)+(0,-#2)$) {$#3$};%
 }
 
 % ---------- Layout commands ----------
 
 \newcommand{\TN@openMPSword}[4]{%
-  \TN@tensordot{#1L}{(0,0)}
-  \TN@tensordot{#1M}{(\TN@chainsep,0)}
-  \TN@tensordot{#1R}{(\TN@chainright,0)}
-  \TN@upleg{#1L}{\TN@physleglen}
-  \TN@upleg{#1M}{\TN@physleglen}
-  \TN@upleg{#1R}{\TN@physleglen}
-  \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
-  \TN@uplabel{#1R}{\TN@physlabeloff}{#3}
-  \TN@leftleg{#1L}{0.8}
-  \draw[tn leg] (#1L.east) -- (#1M.west);
-  \draw[tn leg] (#1M.east) -- ++(0.62,0);
-  \draw[tn leg] ($(#1R.west)+(-0.62,0)$) -- (#1R.west);
-  \TN@rightleg{#1R}{0.8}
-  \node at (\TN@chainellipsisx,0) {$\cdots$};
-  \node at (\TN@chainellipsisx,-0.56) {$#4$};%
+    \TN@tensordot{#1L}{(0,0)}
+    \TN@tensordot{#1M}{(\TN@chainsep,0)}
+    \TN@tensordot{#1R}{(\TN@chainright,0)}
+    \TN@upleg{#1L}{\TN@physleglen}
+    \TN@upleg{#1M}{\TN@physleglen}
+    \TN@upleg{#1R}{\TN@physleglen}
+    \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
+    \TN@uplabel{#1R}{\TN@physlabeloff}{#3}
+    \TN@leftleg{#1L}{0.8}
+    \draw[tn leg] (#1L.east) -- (#1M.west);
+    \draw[tn leg] (#1M.east) -- ++(0.62,0);
+    \draw[tn leg] ($(#1R.west)+(-0.62,0)$) -- (#1R.west);
+    \TN@rightleg{#1R}{0.8}
+    \node at (\TN@chainellipsisx,0) {$\cdots$};
+    \node at (\TN@chainellipsisx,-0.56) {$#4$};%
 }
 
 \newcommand{\TN@blockedMPSword}[3]{%
-  \TN@tensordot{#1L}{(0,0)}
-  \TN@tensordot{#1M}{(\TN@chainsep,0)}
-  \TN@tensordot{#1R}{(\TN@chainright,0)}
-  \TN@upleg{#1L}{\TN@physleglen}
-  \TN@upleg{#1M}{\TN@physleglen}
-  \TN@upleg{#1R}{\TN@physleglen}
-  \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
-  \TN@uplabel{#1R}{\TN@physlabeloff}{#3}
-  \draw[tn leg] (-0.48,0) rectangle (4.68,-0.44);
-  \node at (\TN@chainellipsisx,0) {$\cdots$};%
+    \TN@tensordot{#1L}{(0,0)}
+    \TN@tensordot{#1M}{(\TN@chainsep,0)}
+    \TN@tensordot{#1R}{(\TN@chainright,0)}
+    \TN@upleg{#1L}{\TN@physleglen}
+    \TN@upleg{#1M}{\TN@physleglen}
+    \TN@upleg{#1R}{\TN@physleglen}
+    \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
+    \TN@uplabel{#1R}{\TN@physlabeloff}{#3}
+    \draw[tn leg] (-0.48,0) rectangle (4.68,-0.44);
+    \node at (\TN@chainellipsisx,0) {$\cdots$};%
 }
 
 \newcommand{\TN@openMPOword}[6]{%
-  \TN@tensordot{#1L}{(0,0)}
-  \TN@tensordot{#1M}{(\TN@chainsep,0)}
-  \TN@tensordot{#1R}{(\TN@chainright,0)}
-  \TN@upleg{#1L}{\TN@physleglen}
-  \TN@downleg{#1L}{\TN@physleglen}
-  \TN@upleg{#1M}{\TN@physleglen}
-  \TN@downleg{#1M}{\TN@physleglen}
-  \TN@upleg{#1R}{\TN@physleglen}
-  \TN@downleg{#1R}{\TN@physleglen}
-  \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
-  \TN@downlabel{#1L}{\TN@physlabeloff}{#3}
-  \TN@uplabel{#1R}{\TN@physlabeloff}{#4}
-  \TN@downlabel{#1R}{\TN@physlabeloff}{#5}
-  \TN@leftleg{#1L}{0.8}
-  \draw[tn leg] (#1L.east) -- (#1M.west);
-  \draw[tn leg] (#1M.east) -- ++(0.62,0);
-  \draw[tn leg] ($(#1R.west)+(-0.62,0)$) -- (#1R.west);
-  \TN@rightleg{#1R}{0.8}
-  \node at (\TN@chainellipsisx,0) {$\cdots$};
-  \node at (\TN@chainellipsisx,-1.02) {$#6$};%
+    \TN@tensordot{#1L}{(0,0)}
+    \TN@tensordot{#1M}{(\TN@chainsep,0)}
+    \TN@tensordot{#1R}{(\TN@chainright,0)}
+    \TN@upleg{#1L}{\TN@physleglen}
+    \TN@downleg{#1L}{\TN@physleglen}
+    \TN@upleg{#1M}{\TN@physleglen}
+    \TN@downleg{#1M}{\TN@physleglen}
+    \TN@upleg{#1R}{\TN@physleglen}
+    \TN@downleg{#1R}{\TN@physleglen}
+    \TN@uplabel{#1L}{\TN@physlabeloff}{#2}
+    \TN@downlabel{#1L}{\TN@physlabeloff}{#3}
+    \TN@uplabel{#1R}{\TN@physlabeloff}{#4}
+    \TN@downlabel{#1R}{\TN@physlabeloff}{#5}
+    \TN@leftleg{#1L}{0.8}
+    \draw[tn leg] (#1L.east) -- (#1M.west);
+    \draw[tn leg] (#1M.east) -- ++(0.62,0);
+    \draw[tn leg] ($(#1R.west)+(-0.62,0)$) -- (#1R.west);
+    \TN@rightleg{#1R}{0.8}
+    \node at (\TN@chainellipsisx,0) {$\cdots$};
+    \node at (\TN@chainellipsisx,-1.02) {$#6$};%
 }
 
 \newcommand{\TN@boxedThreeSiteChain}[4]{%
-  \draw[tn leg] (0.40,0) rectangle (3.50,-0.46);
-  \TN@tensordot{#1one}{(1.00,0)}
-  \TN@tensordot{#1two}{(2.00,0)}
-  \TN@tensordot{#1three}{(3.00,0)}
-  \foreach \n in {#1one,#1two,#1three} {
-    \TN@upleg{\n}{0.46}
-  }
-  \node at ($(#1one.south)+(0,-0.30)$) {$#2$};
-  \node at ($(#1two.south)+(0,-0.30)$) {$#3$};
-  \node at ($(#1three.south)+(0,-0.30)$) {$#4$};%
+    \draw[tn leg] (0.40,0) rectangle (3.50,-0.46);
+    \TN@tensordot{#1one}{(1.00,0)}
+    \TN@tensordot{#1two}{(2.00,0)}
+    \TN@tensordot{#1three}{(3.00,0)}
+    \foreach \n in {#1one,#1two,#1three} {
+            \TN@upleg{\n}{0.46}
+        }
+    \node at ($(#1one.south)+(0,-0.30)$) {$#2$};
+    \node at ($(#1two.south)+(0,-0.30)$) {$#3$};
+    \node at ($(#1three.south)+(0,-0.30)$) {$#4$};%
 }
 
 \newcommand{\TN@boxedThreeSiteInsertion}[5]{%
-  \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
-  \TN@opdotabove{#1X}{(1.50,0)}{#5}%
+    \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
+    \TN@opdotabove{#1X}{(1.50,0)}{#5}%
 }
 
 \newcommand{\TN@boxedThreeSitePhysicalOne}[5]{%
-  \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
-  \TN@opdotleft{#1O}{(1.00,0.72)}{#5}
-  \draw[tn phys leg] (#1one.north) -- (#1O.south);
-  \draw[tn phys leg, red] (#1O.north) -- ++(0,0.36);%
+    \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
+    \TN@opdotleft{#1O}{(1.00,0.72)}{#5}
+    \draw[tn phys leg] (#1one.north) -- (#1O.south);
+    \draw[tn phys leg, red] (#1O.north) -- ++(0,0.36);%
 }
 
 \newcommand{\TN@boxedThreeSitePhysicalTwo}[5]{%
-  \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
-  \TN@opdotleft{#1O}{(2.00,0.72)}{#5}
-  \draw[tn phys leg] (#1two.north) -- (#1O.south);
-  \draw[tn phys leg, red] (#1O.north) -- ++(0,0.36);%
+    \TN@boxedThreeSiteChain{#1}{#2}{#3}{#4}
+    \TN@opdotleft{#1O}{(2.00,0.72)}{#5}
+    \draw[tn phys leg] (#1two.north) -- (#1O.south);
+    \draw[tn phys leg, red] (#1O.north) -- ++(0,0.36);%
 }
 
 \newcommand{\TN@pepsFiveSitePatch}[1]{%
-  \TN@tensordot{#1one}{(0,0)}
-  \TN@tensordot{#1two}{(1.00,0)}
-  \TN@tensordot{#1three}{(1.50,1.00)}
-  \TN@tensordot{#1four}{(0.60,1.50)}
-  \TN@tensordot{#1five}{(-0.60,1.50)}
-  \foreach \n in {#1one,#1two,#1three,#1four,#1five} {
-    \TN@upleg{\n}{0.50}
-  }
-  \draw[tn leg] (#1one) -- (#1two) -- (#1three) --
+    \TN@tensordot{#1one}{(0,0)}
+    \TN@tensordot{#1two}{(1.00,0)}
+    \TN@tensordot{#1three}{(1.50,1.00)}
+    \TN@tensordot{#1four}{(0.60,1.50)}
+    \TN@tensordot{#1five}{(-0.60,1.50)}
+    \foreach \n in {#1one,#1two,#1three,#1four,#1five} {
+            \TN@upleg{\n}{0.50}
+        }
+    \draw[tn leg] (#1one) -- (#1two) -- (#1three) --
     (#1four) -- (#1five) -- (#1one);
-  \draw[tn leg] (#1two) -- (#1five);%
+    \draw[tn leg] (#1two) -- (#1five);%
 }
 
 \newcommand{\TN@pepsFiveSitePatchLabels}[6]{%
-  \node at ($(#1one.south)+(0,-0.25)$) {$#2$};
-  \node at ($(#1two.south)+(0,-0.25)$) {$#3$};
-  \node at ($(#1three.south)+(0,-0.25)$) {$#4$};
-  \node at ($(#1four.south)+(0,-0.25)$) {$#5$};
-  \node at ($(#1five.south)+(0,-0.25)$) {$#6$};%
+    \node at ($(#1one.south)+(0,-0.25)$) {$#2$};
+    \node at ($(#1two.south)+(0,-0.25)$) {$#3$};
+    \node at ($(#1three.south)+(0,-0.25)$) {$#4$};
+    \node at ($(#1four.south)+(0,-0.25)$) {$#5$};
+    \node at ($(#1five.south)+(0,-0.25)$) {$#6$};%
 }
 
 \newcommand{\TN@twoInjectiveInsertionPair}[4]{%
-  \TN@tensordot{#1one}{(0,0)}
-  \TN@tensordot{#1two}{(2.50,0)}
-  \TN@upleg{#1one}{0.42}
-  \TN@upleg{#1two}{0.42}
-  \TN@opdotabove{#1X}{(1.25,0.45)}{#4}
-  \draw[tn leg] (#1one) to[out=30,in=180] (#1X.west);
-  \draw[tn leg] (#1X.east) to[out=0,in=150] (#1two);
-  \draw[tn leg] (#1one) to[bend right=12] (#1two);
-  \draw[tn leg] (#1one) to[bend right=38] (#1two);
-  \node at (1.25,-0.08) {$\vdots$};
-  \node at ($(#1one.south)+(0,-0.30)$) {$#2$};
-  \node at ($(#1two.south)+(0,-0.30)$) {$#3$};%
+    \TN@tensordot{#1one}{(0,0)}
+    \TN@tensordot{#1two}{(2.50,0)}
+    \TN@upleg{#1one}{0.42}
+    \TN@upleg{#1two}{0.42}
+    \TN@opdotabove{#1X}{(1.25,0.45)}{#4}
+    \draw[tn leg] (#1one) to[out=30,in=180] (#1X.west);
+    \draw[tn leg] (#1X.east) to[out=0,in=150] (#1two);
+    \draw[tn leg] (#1one) to[bend right=12] (#1two);
+    \draw[tn leg] (#1one) to[bend right=38] (#1two);
+    \node at (1.25,-0.08) {$\vdots$};
+    \node at ($(#1one.south)+(0,-0.30)$) {$#2$};
+    \node at ($(#1two.south)+(0,-0.30)$) {$#3$};%
 }
 
 \newcommand{\TN@threeLegTensorFan}[2]{%
-  \TN@tensordot{#1}{(0,0)}
-  \TN@upleg{#1}{0.42}
-  \draw[tn leg] (#1) -- ++(0.75,0.45);
-  \draw[tn leg] (#1) -- ++(0.78,-0.05);
-  \draw[tn leg] (#1) -- ++(0.65,-0.55);
-  \node at ($(#1.south)+(0,-0.30)$) {$#2$};%
+    \TN@tensordot{#1}{(0,0)}
+    \TN@upleg{#1}{0.42}
+    \draw[tn leg] (#1) -- ++(0.75,0.45);
+    \draw[tn leg] (#1) -- ++(0.78,-0.05);
+    \draw[tn leg] (#1) -- ++(0.65,-0.55);
+    \node at ($(#1.south)+(0,-0.30)$) {$#2$};%
 }
 
 \newcommand{\TN@normalPepsGridLines}{%
-  \draw[step=0.5, tn leg] (-1,-1) grid (4,4);%
+    \draw[step=0.5, tn leg] (-1,-1) grid (4,4);%
 }
 
 \newcommand{\TN@normalPepsGridDots}{%
-  \foreach \x in {0,0.5,1,1.5,2,2.5,3} {
-    \foreach \y in {0,0.5,1,1.5,2,2.5,3} {
-      \node[tn tensor dot] at (\x,\y) {};
-    }
-  }%
+    \foreach \x in {0,0.5,1,1.5,2,2.5,3} {
+            \foreach \y in {0,0.5,1,1.5,2,2.5,3} {
+                    \node[tn tensor dot] at (\x,\y) {};
+                }
+        }%
 }
 
 \newcommand{\TN@normalPepsGrid}{%
-  \TN@normalPepsGridLines
-  \TN@normalPepsGridDots
+    \TN@normalPepsGridLines
+    \TN@normalPepsGridDots
 }
 
 \makeatother

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -18,1090 +18,1090 @@
 \newcommand{\TNTikZDiagram}[2]{#2}
 
 \newcommand{\TNMPSLocal}[2]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnA}{(0,0)}
-    \TN@leftleg{tnA}{0.8}
-    \TN@rightleg{tnA}{0.8}
-    \TN@upleg{tnA}{\TN@physleglen}
-    \TN@uplabel{tnA}{\TN@physlabeloff}{#2}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnA}{(0,0)}
+        \TN@leftleg{tnA}{0.8}
+        \TN@rightleg{tnA}{0.8}
+        \TN@upleg{tnA}{\TN@physleglen}
+        \TN@uplabel{tnA}{\TN@physlabeloff}{#2}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNMPSWord}[4]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@openMPSword{tn}{#2}{#3}{#4}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@openMPSword{tn}{#2}{#3}{#4}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNMPV}[4]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@blockedMPSword{tn}{#2}{#3}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@blockedMPSword{tn}{#2}{#3}
+    \end{tikzpicture}%
 }
 
 % Blocking: L neighbouring local tensors grouped (dashed box) into one
 % blocked tensor; physical legs poke out the top, the outer virtual legs
 % become the blocked bond.
 \newcommand{\TNBlocking}[4]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@openMPSword{tn}{#2}{#3}{#4}
-    \draw[densely dashed, rounded corners]
-      ($(tnL.west)+(-0.30,0.22)$) rectangle ($(tnR.east)+(0.30,-0.34)$);
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@openMPSword{tn}{#2}{#3}{#4}
+        \draw[densely dashed, rounded corners]
+        ($(tnL.west)+(-0.30,0.22)$) rectangle ($(tnR.east)+(0.30,-0.34)$);
+    \end{tikzpicture}%
 }
 
 % MPV overlap: the top row carries copies of #1, the bottom row the conjugate
 % copies of #2; the shared physical indices are contracted between the rows and
 % both virtual rings are closed by the trace (the boxes above and below).
 \newcommand{\TNMPVOverlap}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{ovuL}{(0,0.42)}
-    \TN@tensordot{ovuM}{(\TN@chainsep,0.42)}
-    \TN@tensordot{ovuR}{(\TN@chainright,0.42)}
-    \draw[tn leg] (-0.48,0.42) rectangle (4.68,0.74);
-    \TN@tensordot{ovdL}{(0,-0.42)}
-    \TN@tensordot{ovdM}{(\TN@chainsep,-0.42)}
-    \TN@tensordot{ovdR}{(\TN@chainright,-0.42)}
-    \draw[tn leg] (-0.48,-0.42) rectangle (4.68,-0.74);
-    \draw[tn phys leg] (ovuL.south) -- (ovdL.north);
-    \draw[tn phys leg] (ovuM.south) -- (ovdM.north);
-    \draw[tn phys leg] (ovuR.south) -- (ovdR.north);
-    % single centred ellipsis in the omitted-site column (no line crosses it)
-    \node at (\TN@chainellipsisx,0) {$\cdots$};
-    \node[anchor=east] at (-0.85,0.42) {$#1$};
-    \node[anchor=east] at (-0.85,-0.42) {$\overline{#2}$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{ovuL}{(0,0.42)}
+        \TN@tensordot{ovuM}{(\TN@chainsep,0.42)}
+        \TN@tensordot{ovuR}{(\TN@chainright,0.42)}
+        \draw[tn leg] (-0.48,0.42) rectangle (4.68,0.74);
+        \TN@tensordot{ovdL}{(0,-0.42)}
+        \TN@tensordot{ovdM}{(\TN@chainsep,-0.42)}
+        \TN@tensordot{ovdR}{(\TN@chainright,-0.42)}
+        \draw[tn leg] (-0.48,-0.42) rectangle (4.68,-0.74);
+        \draw[tn phys leg] (ovuL.south) -- (ovdL.north);
+        \draw[tn phys leg] (ovuM.south) -- (ovdM.north);
+        \draw[tn phys leg] (ovuR.south) -- (ovdR.north);
+        % single centred ellipsis in the omitted-site column (no line crosses it)
+        \node at (\TN@chainellipsisx,0) {$\cdots$};
+        \node[anchor=east] at (-0.85,0.42) {$#1$};
+        \node[anchor=east] at (-0.85,-0.42) {$\overline{#2}$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNTransferMap}[1]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnUp}{(0,0.44)}
-    \TN@tensordot{tnDn}{(0,-0.44)}
-    \draw[tn leg] ($(tnUp.west)+(-0.75,0)$) -- (tnUp.west);
-    \draw[tn leg] ($(tnDn.west)+(-0.75,0)$) -- (tnDn.west);
-    \draw[tn leg] (tnUp.east) -- ++(0.75,0);
-    \draw[tn leg] (tnDn.east) -- ++(0.75,0);
-    \draw[tn phys leg] (tnUp.south) -- (tnDn.north);
-    \node at (-1.18,0) {$X$};
-    \node at (1.36,0) {$\E_{#1}(X)$};
-    \node at ($(tnUp.south)!0.5!(tnDn.north)+(0.24,0)$) {$i$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnUp}{(0,0.44)}
+        \TN@tensordot{tnDn}{(0,-0.44)}
+        \draw[tn leg] ($(tnUp.west)+(-0.75,0)$) -- (tnUp.west);
+        \draw[tn leg] ($(tnDn.west)+(-0.75,0)$) -- (tnDn.west);
+        \draw[tn leg] (tnUp.east) -- ++(0.75,0);
+        \draw[tn leg] (tnDn.east) -- ++(0.75,0);
+        \draw[tn phys leg] (tnUp.south) -- (tnDn.north);
+        \node at (-1.18,0) {$X$};
+        \node at (1.36,0) {$\E_{#1}(X)$};
+        \node at ($(tnUp.south)!0.5!(tnDn.north)+(0.24,0)$) {$i$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNMPOCell}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnM}{(0,0)}
-    \TN@leftleg{tnM}{0.8}
-    \TN@rightleg{tnM}{0.8}
-    \TN@upleg{tnM}{\TN@physleglen}
-    \TN@downleg{tnM}{\TN@physleglen}
-    \TN@uplabel{tnM}{\TN@physlabeloff}{#2}
-    \TN@downlabel{tnM}{\TN@physlabeloff}{#3}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnM}{(0,0)}
+        \TN@leftleg{tnM}{0.8}
+        \TN@rightleg{tnM}{0.8}
+        \TN@upleg{tnM}{\TN@physleglen}
+        \TN@downleg{tnM}{\TN@physleglen}
+        \TN@uplabel{tnM}{\TN@physlabeloff}{#2}
+        \TN@downlabel{tnM}{\TN@physlabeloff}{#3}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNMPOChain}[6]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@openMPOword{tn}{#2}{#3}{#4}{#5}{#6}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@openMPOword{tn}{#2}{#3}{#4}{#5}{#6}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNGaugeConjugation}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@opdotabove{tnXl}{(-1.10,0)}{#1}
-    \TN@tensordot{tnA}{(0,0)}
-    \TN@opdotabove{tnXr}{(1.10,0)}{#3}
-    \draw[tn leg] (tnXl.west) -- ++(-0.55,0);
-    \draw[tn leg] (tnXl.east) -- (tnA.west);
-    \draw[tn leg] (tnA.east) -- (tnXr.west);
-    \draw[tn leg] (tnXr.east) -- ++(0.55,0);
-    \TN@upleg{tnA}{\TN@physleglen}
-    \TN@uplabel{tnA}{\TN@physlabeloff}{#2}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@opdotabove{tnXl}{(-1.10,0)}{#1}
+        \TN@tensordot{tnA}{(0,0)}
+        \TN@opdotabove{tnXr}{(1.10,0)}{#3}
+        \draw[tn leg] (tnXl.west) -- ++(-0.55,0);
+        \draw[tn leg] (tnXl.east) -- (tnA.west);
+        \draw[tn leg] (tnA.east) -- (tnXr.west);
+        \draw[tn leg] (tnXr.east) -- ++(0.55,0);
+        \TN@upleg{tnA}{\TN@physleglen}
+        \TN@uplabel{tnA}{\TN@physlabeloff}{#2}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPhysicalRealization}[2]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnA1}{(0,0)}
-    \draw[tn leg] (tnA1.west) -- ++(-0.65,0);
-    \TN@upleg{tnA1}{\TN@physleglen}
-    \TN@opdotabove{tnX}{(0.78,0)}{#1}
-    \draw[tn leg] (tnA1.east) -- (tnX.west);
-    \draw[tn leg] (tnX.east) -- ++(0.22,0);
-    \node at (1.78,0) {$=$};
-    \TN@tensordot{tnA2}{(2.65,0)}
-    \draw[tn leg] (tnA2.west) -- ++(-0.65,0);
-    \draw[tn leg] (tnA2.east) -- ++(0.65,0);
-    \TN@opdotleft{tnO}{(2.65,0.74)}{#2}
-    \draw[tn phys leg] (tnA2.north) -- (tnO.south);
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnA1}{(0,0)}
+        \draw[tn leg] (tnA1.west) -- ++(-0.65,0);
+        \TN@upleg{tnA1}{\TN@physleglen}
+        \TN@opdotabove{tnX}{(0.78,0)}{#1}
+        \draw[tn leg] (tnA1.east) -- (tnX.west);
+        \draw[tn leg] (tnX.east) -- ++(0.22,0);
+        \node at (1.78,0) {$=$};
+        \TN@tensordot{tnA2}{(2.65,0)}
+        \draw[tn leg] (tnA2.west) -- ++(-0.65,0);
+        \draw[tn leg] (tnA2.east) -- ++(0.65,0);
+        \TN@opdotleft{tnO}{(2.65,0.74)}{#2}
+        \draw[tn phys leg] (tnA2.north) -- (tnO.south);
+    \end{tikzpicture}%
 }
 
 % Fix (#401): use a dedicated physical-leg operator insertion for
 % general linear twists, and keep permutation twists for index relabellings.
 \newcommand{\TNLinearTwist}[2]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnA}{(0,0)}
-    \TN@leftleg{tnA}{0.65}
-    \TN@rightleg{tnA}{0.65}
-    \TN@opdotleft{tnu}{(0,0.64)}{#1}
-    \draw[tn phys leg] (tnA.north) -- (tnu.south);
-    \node at ($(tnu.north)+(0,0.18)$) {$#2$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnA}{(0,0)}
+        \TN@leftleg{tnA}{0.65}
+        \TN@rightleg{tnA}{0.65}
+        \TN@opdotleft{tnu}{(0,0.64)}{#1}
+        \draw[tn phys leg] (tnA.north) -- (tnu.south);
+        \node at ($(tnu.north)+(0,0.18)$) {$#2$};
+    \end{tikzpicture}%
 }
 
 % Fix (#401): make the relabelling arrow explicit so multi-step
 % permutation diagrams can distinguish \sigma_h from \sigma_g.
 \newcommand{\TNPermutationTwistLabeled}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnL}{(0,0)}
-    \TN@leftleg{tnL}{0.65}
-    \TN@rightleg{tnL}{0.65}
-    \TN@upleg{tnL}{\TN@physleglen}
-    \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
-    \node at (1.55,0) {$\xrightarrow{\ #3\ }$};
-    \TN@tensordot{tnR}{(3.30,0)}
-    \TN@leftleg{tnR}{0.65}
-    \TN@rightleg{tnR}{0.65}
-    \TN@upleg{tnR}{\TN@physleglen}
-    \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnL}{(0,0)}
+        \TN@leftleg{tnL}{0.65}
+        \TN@rightleg{tnL}{0.65}
+        \TN@upleg{tnL}{\TN@physleglen}
+        \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
+        \node at (1.55,0) {$\xrightarrow{\ #3\ }$};
+        \TN@tensordot{tnR}{(3.30,0)}
+        \TN@leftleg{tnR}{0.65}
+        \TN@rightleg{tnR}{0.65}
+        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPermutationTwist}[2]{%
-  \TNPermutationTwistLabeled{#1}{#2}{\sigma_g}%
+    \TNPermutationTwistLabeled{#1}{#2}{\sigma_g}%
 }
 
 \newcommand{\TNTwistedTransfer}[1]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnUp}{(0,\TN@doublelayersep)}
-    \TN@tensordot{tnDn}{(0,-\TN@doublelayersep)}
-    \draw[tn leg] ($(tnUp.west)+(-0.80,0)$) -- (tnUp.west);
-    \draw[tn leg] ($(tnDn.west)+(-0.80,0)$) -- (tnDn.west);
-    \draw[tn leg] (tnUp.east) -- ++(0.80,0);
-    \draw[tn leg] (tnDn.east) -- ++(0.80,0);
-    \TN@opdotleft{tnu}{(0,0)}{#1}
-    \draw[tn phys leg] (tnUp.south) -- (tnu.north);
-    \draw[tn phys leg] (tnu.south) -- (tnDn.north);
-    \node at (-1.25,0) {$X$};
-    \node at (1.52,0) {$\E_{#1}(X)$};
-    \node at ($(tnUp.north)+(0,0.28)$) {$n$};
-    \node at ($(tnDn.south)+(0,-0.28)$) {$n'$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnUp}{(0,\TN@doublelayersep)}
+        \TN@tensordot{tnDn}{(0,-\TN@doublelayersep)}
+        \draw[tn leg] ($(tnUp.west)+(-0.80,0)$) -- (tnUp.west);
+        \draw[tn leg] ($(tnDn.west)+(-0.80,0)$) -- (tnDn.west);
+        \draw[tn leg] (tnUp.east) -- ++(0.80,0);
+        \draw[tn leg] (tnDn.east) -- ++(0.80,0);
+        \TN@opdotleft{tnu}{(0,0)}{#1}
+        \draw[tn phys leg] (tnUp.south) -- (tnu.north);
+        \draw[tn phys leg] (tnu.south) -- (tnDn.north);
+        \node at (-1.25,0) {$X$};
+        \node at (1.52,0) {$\E_{#1}(X)$};
+        \node at ($(tnUp.north)+(0,0.28)$) {$n$};
+        \node at ($(tnDn.south)+(0,-0.28)$) {$n'$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNCondCOne}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnL}{(0,0)}
-    \TN@leftleg{tnL}{0.65}
-    \TN@rightleg{tnL}{0.65}
-    \TN@upleg{tnL}{0.26}
-    \TN@opdotleft{tnu}{(0,0.64)}{#1}
-    \draw[tn phys leg] (tnL.north) -- (tnu.south);
-    \node at ($(tnu.north)+(0,0.18)$) {$#3$};
-    \node at (1.65,0) {$=$};
-    \TN@opdotabove{tnXl}{(3.15,0)}{#2}
-    \TN@tensordot{tnA}{(4.20,0)}
-    \TN@opdotabove{tnXr}{(5.25,0)}{#2^\dagger}
-    \draw[tn leg] (tnXl.west) -- ++(-0.55,0);
-    \draw[tn leg] (tnXl.east) -- (tnA.west);
-    \draw[tn leg] (tnA.east) -- (tnXr.west);
-    \draw[tn leg] (tnXr.east) -- ++(0.55,0);
-    \TN@upleg{tnA}{\TN@physleglen}
-    \TN@uplabel{tnA}{\TN@physlabeloff}{#3}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnL}{(0,0)}
+        \TN@leftleg{tnL}{0.65}
+        \TN@rightleg{tnL}{0.65}
+        \TN@upleg{tnL}{0.26}
+        \TN@opdotleft{tnu}{(0,0.64)}{#1}
+        \draw[tn phys leg] (tnL.north) -- (tnu.south);
+        \node at ($(tnu.north)+(0,0.18)$) {$#3$};
+        \node at (1.65,0) {$=$};
+        \TN@opdotabove{tnXl}{(3.15,0)}{#2}
+        \TN@tensordot{tnA}{(4.20,0)}
+        \TN@opdotabove{tnXr}{(5.25,0)}{#2^\dagger}
+        \draw[tn leg] (tnXl.west) -- ++(-0.55,0);
+        \draw[tn leg] (tnXl.east) -- (tnA.west);
+        \draw[tn leg] (tnA.east) -- (tnXr.west);
+        \draw[tn leg] (tnXr.east) -- ++(0.55,0);
+        \TN@upleg{tnA}{\TN@physleglen}
+        \TN@uplabel{tnA}{\TN@physlabeloff}{#3}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNCondCTwo}[1]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@opdotabove{tnVL}{(-1.15,0.48)}{#1}
-    \TN@opdotbelow{tnVdL}{(-1.15,-0.48)}{#1^\dagger}
-    \TN@tensordot{tnLUp}{(0,0.48)}
-    \TN@tensordot{tnLDn}{(0,-0.48)}
-    \draw[tn leg] (tnVL.west) -- ++(-0.45,0);
-    \draw[tn leg] (tnVdL.west) -- ++(-0.45,0);
-    \draw[tn leg] (tnVL.east) -- (tnLUp.west);
-    \draw[tn leg] (tnVdL.east) -- (tnLDn.west);
-    \draw[tn leg] (tnLUp.east) -- ++(0.55,0);
-    \draw[tn leg] (tnLDn.east) -- ++(0.55,0);
-    \draw[tn phys leg] (tnLUp.south) -- (tnLDn.north);
-    \node at (1.55,0) {$=$};
-    \TN@tensordot{tnRUp}{(3.10,0.48)}
-    \TN@tensordot{tnRDn}{(3.10,-0.48)}
-    \TN@opdotabove{tnVR}{(4.25,0.48)}{#1}
-    \TN@opdotbelow{tnVdR}{(4.25,-0.48)}{#1^\dagger}
-    \draw[tn leg] (tnRUp.west) -- ++(-0.55,0);
-    \draw[tn leg] (tnRDn.west) -- ++(-0.55,0);
-    \draw[tn leg] (tnRUp.east) -- (tnVR.west);
-    \draw[tn leg] (tnRDn.east) -- (tnVdR.west);
-    \draw[tn leg] (tnVR.east) -- ++(0.45,0);
-    \draw[tn leg] (tnVdR.east) -- ++(0.45,0);
-    \draw[tn phys leg] (tnRUp.south) -- (tnRDn.north);
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@opdotabove{tnVL}{(-1.15,0.48)}{#1}
+        \TN@opdotbelow{tnVdL}{(-1.15,-0.48)}{#1^\dagger}
+        \TN@tensordot{tnLUp}{(0,0.48)}
+        \TN@tensordot{tnLDn}{(0,-0.48)}
+        \draw[tn leg] (tnVL.west) -- ++(-0.45,0);
+        \draw[tn leg] (tnVdL.west) -- ++(-0.45,0);
+        \draw[tn leg] (tnVL.east) -- (tnLUp.west);
+        \draw[tn leg] (tnVdL.east) -- (tnLDn.west);
+        \draw[tn leg] (tnLUp.east) -- ++(0.55,0);
+        \draw[tn leg] (tnLDn.east) -- ++(0.55,0);
+        \draw[tn phys leg] (tnLUp.south) -- (tnLDn.north);
+        \node at (1.55,0) {$=$};
+        \TN@tensordot{tnRUp}{(3.10,0.48)}
+        \TN@tensordot{tnRDn}{(3.10,-0.48)}
+        \TN@opdotabove{tnVR}{(4.25,0.48)}{#1}
+        \TN@opdotbelow{tnVdR}{(4.25,-0.48)}{#1^\dagger}
+        \draw[tn leg] (tnRUp.west) -- ++(-0.55,0);
+        \draw[tn leg] (tnRDn.west) -- ++(-0.55,0);
+        \draw[tn leg] (tnRUp.east) -- (tnVR.west);
+        \draw[tn leg] (tnRDn.east) -- (tnVdR.west);
+        \draw[tn leg] (tnVR.east) -- ++(0.45,0);
+        \draw[tn leg] (tnVdR.east) -- ++(0.45,0);
+        \draw[tn phys leg] (tnRUp.south) -- (tnRDn.north);
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNStringOrderParameter}[2]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnLam}{(-1.15,0)}
-    \node at ($(tnLam.south)+(0,-0.28)$) {$\Lambda$};
-    \TN@tensordot{tnU1}{(0,\TN@doublelayersep)}
-    \TN@tensordot{tnD1}{(0,-\TN@doublelayersep)}
-    \TN@tensordot{tnU2}{(1.55,\TN@doublelayersep)}
-    \TN@tensordot{tnD2}{(1.55,-\TN@doublelayersep)}
-    \TN@tensordot{tnU3}{(4.30,\TN@doublelayersep)}
-    \TN@tensordot{tnD3}{(4.30,-\TN@doublelayersep)}
-    \TN@opdotleft{tnuA}{(0,0)}{#1}
-    \TN@opdotleft{tnuB}{(1.55,0)}{#1}
-    \TN@opdotleft{tnuC}{(4.30,0)}{#1}
-    \draw[tn leg] (tnLam.east) -- (tnU1.west);
-    \draw[tn leg] (tnLam.east) -- (tnD1.west);
-    \draw[tn leg] (tnU1.east) -- (tnU2.west);
-    \draw[tn leg] (tnD1.east) -- (tnD2.west);
-    \draw[tn leg] (tnU2.east) -- ++(0.62,0);
-    \draw[tn leg] (tnD2.east) -- ++(0.62,0);
-    \draw[tn leg] ($(tnU3.west)+(-0.62,0)$) -- (tnU3.west);
-    \draw[tn leg] ($(tnD3.west)+(-0.62,0)$) -- (tnD3.west);
-    \draw[tn leg] (tnU3.east) -- ++(0.70,0);
-    \draw[tn leg] (tnD3.east) -- ++(0.70,0);
-    \draw[tn phys leg] (tnU1.south) -- (tnuA.north);
-    \draw[tn phys leg] (tnuA.south) -- (tnD1.north);
-    \draw[tn phys leg] (tnU2.south) -- (tnuB.north);
-    \draw[tn phys leg] (tnuB.south) -- (tnD2.north);
-    \draw[tn phys leg] (tnU3.south) -- (tnuC.north);
-    \draw[tn phys leg] (tnuC.south) -- (tnD3.north);
-    \node at (2.92,\TN@doublelayersep) {$\cdots$};
-    \node at (2.92,-\TN@doublelayersep) {$\cdots$};
-    \node at (5.55,0) {$\operatorname{tr}$};
-    \node at (2.92,-1.02) {$#2$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnLam}{(-1.15,0)}
+        \node at ($(tnLam.south)+(0,-0.28)$) {$\Lambda$};
+        \TN@tensordot{tnU1}{(0,\TN@doublelayersep)}
+        \TN@tensordot{tnD1}{(0,-\TN@doublelayersep)}
+        \TN@tensordot{tnU2}{(1.55,\TN@doublelayersep)}
+        \TN@tensordot{tnD2}{(1.55,-\TN@doublelayersep)}
+        \TN@tensordot{tnU3}{(4.30,\TN@doublelayersep)}
+        \TN@tensordot{tnD3}{(4.30,-\TN@doublelayersep)}
+        \TN@opdotleft{tnuA}{(0,0)}{#1}
+        \TN@opdotleft{tnuB}{(1.55,0)}{#1}
+        \TN@opdotleft{tnuC}{(4.30,0)}{#1}
+        \draw[tn leg] (tnLam.east) -- (tnU1.west);
+        \draw[tn leg] (tnLam.east) -- (tnD1.west);
+        \draw[tn leg] (tnU1.east) -- (tnU2.west);
+        \draw[tn leg] (tnD1.east) -- (tnD2.west);
+        \draw[tn leg] (tnU2.east) -- ++(0.62,0);
+        \draw[tn leg] (tnD2.east) -- ++(0.62,0);
+        \draw[tn leg] ($(tnU3.west)+(-0.62,0)$) -- (tnU3.west);
+        \draw[tn leg] ($(tnD3.west)+(-0.62,0)$) -- (tnD3.west);
+        \draw[tn leg] (tnU3.east) -- ++(0.70,0);
+        \draw[tn leg] (tnD3.east) -- ++(0.70,0);
+        \draw[tn phys leg] (tnU1.south) -- (tnuA.north);
+        \draw[tn phys leg] (tnuA.south) -- (tnD1.north);
+        \draw[tn phys leg] (tnU2.south) -- (tnuB.north);
+        \draw[tn phys leg] (tnuB.south) -- (tnD2.north);
+        \draw[tn phys leg] (tnU3.south) -- (tnuC.north);
+        \draw[tn phys leg] (tnuC.south) -- (tnD3.north);
+        \node at (2.92,\TN@doublelayersep) {$\cdots$};
+        \node at (2.92,-\TN@doublelayersep) {$\cdots$};
+        \node at (5.55,0) {$\operatorname{tr}$};
+        \node at (2.92,-1.02) {$#2$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNVirtualInsertion}[4]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnL}{(0,0)}
-    \TN@tensordot{tnM}{(1.45,0)}
-    \TN@tensordot{tnR}{(2.90,0)}
-    \TN@upleg{tnL}{\TN@physleglen}
-    \TN@upleg{tnM}{\TN@physleglen}
-    \TN@upleg{tnR}{\TN@physleglen}
-    \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
-    \TN@uplabel{tnM}{\TN@physlabeloff}{#2}
-    \TN@uplabel{tnR}{\TN@physlabeloff}{#3}
-    \draw[tn leg] (tnL.west) -- ++(-0.65,0);
-    \draw[tn leg] (tnL.east) -- (tnM.west);
-    \draw[tn leg] (tnM.east) -- (tnR.west);
-    \draw[tn leg] (tnR.east) -- ++(0.65,0);
-    \TN@opdotabove{tnX}{(0.72,0)}{#4}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnL}{(0,0)}
+        \TN@tensordot{tnM}{(1.45,0)}
+        \TN@tensordot{tnR}{(2.90,0)}
+        \TN@upleg{tnL}{\TN@physleglen}
+        \TN@upleg{tnM}{\TN@physleglen}
+        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
+        \TN@uplabel{tnM}{\TN@physlabeloff}{#2}
+        \TN@uplabel{tnR}{\TN@physlabeloff}{#3}
+        \draw[tn leg] (tnL.west) -- ++(-0.65,0);
+        \draw[tn leg] (tnL.east) -- (tnM.west);
+        \draw[tn leg] (tnM.east) -- (tnR.west);
+        \draw[tn leg] (tnR.east) -- ++(0.65,0);
+        \TN@opdotabove{tnX}{(0.72,0)}{#4}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNInternalTraceInsertion}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnL}{(0,0)}
-    \TN@opdotabove{tnX}{(0.80,0)}{#3}
-    \TN@tensordot{tnR}{(1.60,0)}
-    \TN@upleg{tnL}{\TN@physleglen}
-    \TN@upleg{tnR}{\TN@physleglen}
-    \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
-    \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
-    \draw[tn leg] (tnL.east) -- (tnX.west);
-    \draw[tn leg] (tnX.east) -- (tnR.west);
-    \draw[tn leg] (tnL.west) -- ++(-0.15,0) -- ++(0,-0.78)
-                  -- ++(1.90,0) -- ++(0,0.78) -- (tnR.east);
-    \node at (0.80,-0.88) {$\operatorname{Tr}$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnL}{(0,0)}
+        \TN@opdotabove{tnX}{(0.80,0)}{#3}
+        \TN@tensordot{tnR}{(1.60,0)}
+        \TN@upleg{tnL}{\TN@physleglen}
+        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
+        \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
+        \draw[tn leg] (tnL.east) -- (tnX.west);
+        \draw[tn leg] (tnX.east) -- (tnR.west);
+        \draw[tn leg] (tnL.west) -- ++(-0.15,0) -- ++(0,-0.78)
+        -- ++(1.90,0) -- ++(0,0.78) -- (tnR.east);
+        \node at (0.80,-0.88) {$\operatorname{Tr}$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNExternalTraceInsertion}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnL}{(0,0)}
-    \TN@tensordot{tnR}{(1.60,0)}
-    \TN@opdotbelow{tnY}{(0.80,-0.78)}{#3}
-    \TN@upleg{tnL}{\TN@physleglen}
-    \TN@upleg{tnR}{\TN@physleglen}
-    \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
-    \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
-    \draw[tn leg] (tnL.east) -- (tnR.west);
-    \draw[tn leg] (tnL.west) -- ++(-0.15,0) -- ++(0,-0.55) -- (tnY.west);
-    \draw[tn leg] (tnY.east) -- (1.75,-0.55) -- (1.75,0) -- (tnR.east);
-    \node at (0.80,-1.00) {$\operatorname{Tr}$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnL}{(0,0)}
+        \TN@tensordot{tnR}{(1.60,0)}
+        \TN@opdotbelow{tnY}{(0.80,-0.78)}{#3}
+        \TN@upleg{tnL}{\TN@physleglen}
+        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@uplabel{tnL}{\TN@physlabeloff}{#1}
+        \TN@uplabel{tnR}{\TN@physlabeloff}{#2}
+        \draw[tn leg] (tnL.east) -- (tnR.west);
+        \draw[tn leg] (tnL.west) -- ++(-0.15,0) -- ++(0,-0.55) -- (tnY.west);
+        \draw[tn leg] (tnY.east) -- (1.75,-0.55) -- (1.75,0) -- (tnR.east);
+        \node at (0.80,-1.00) {$\operatorname{Tr}$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNBoundaryRegrow}[4]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{rA}{(0,0)}
-    \TN@tensordot{rB}{(1.05,0)}
-    \TN@tensordot{rC}{(2.10,0)}
-    \TN@opdotabove{rX}{(3.55,0)}{#1}
-    \foreach \n in {rA,rB,rC} {
-      \TN@upleg{\n}{0.44}
-    }
-    \TN@uplabel{rA}{0.66}{#2}
-    \TN@uplabel{rC}{0.66}{#3}
-    \draw[tn leg] (rA.west) -- ++(-0.50,0);
-    \draw[tn leg] (rA.east) -- (rB.west);
-    \draw[tn leg] (rB.east) -- (rC.west);
-    \draw[tn leg] (rC.east) -- (rX.west);
-    \draw[tn leg] (rX.east) -- ++(0.45,0);
-    \node at (1.78,-0.58) {$#4$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{rA}{(0,0)}
+        \TN@tensordot{rB}{(1.05,0)}
+        \TN@tensordot{rC}{(2.10,0)}
+        \TN@opdotabove{rX}{(3.55,0)}{#1}
+        \foreach \n in {rA,rB,rC} {
+                \TN@upleg{\n}{0.44}
+            }
+        \TN@uplabel{rA}{0.66}{#2}
+        \TN@uplabel{rC}{0.66}{#3}
+        \draw[tn leg] (rA.west) -- ++(-0.50,0);
+        \draw[tn leg] (rA.east) -- (rB.west);
+        \draw[tn leg] (rB.east) -- (rC.west);
+        \draw[tn leg] (rC.east) -- (rX.west);
+        \draw[tn leg] (rX.east) -- ++(0.45,0);
+        \node at (1.78,-0.58) {$#4$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNLocalEqualityStep}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{lA}{(0,0)}
-    \TN@opdotabove{lX}{(0.82,0)}{#1}
-    \TN@tensordot{lB}{(1.65,0)}
-    \TN@upleg{lB}{0.44}
-    \TN@uplabel{lB}{0.66}{#3}
-    \draw[tn leg] (lA.west) -- ++(-0.50,0);
-    \draw[tn leg] (lA.east) -- (lX.west);
-    \draw[tn leg] (lX.east) -- (lB.west);
-    \draw[tn leg] (lB.east) -- ++(0.50,0);
-    \node at (2.85,0) {$=$};
-    \TN@tensordot{rA}{(4.10,0)}
-    \TN@opdotabove{rX}{(4.92,0)}{#2}
-    \TN@tensordot{rB}{(5.75,0)}
-    \TN@upleg{rB}{0.44}
-    \TN@uplabel{rB}{0.66}{#3}
-    \draw[tn leg] (rA.west) -- ++(-0.50,0);
-    \draw[tn leg] (rA.east) -- (rX.west);
-    \draw[tn leg] (rX.east) -- (rB.west);
-    \draw[tn leg] (rB.east) -- ++(0.50,0);
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{lA}{(0,0)}
+        \TN@opdotabove{lX}{(0.82,0)}{#1}
+        \TN@tensordot{lB}{(1.65,0)}
+        \TN@upleg{lB}{0.44}
+        \TN@uplabel{lB}{0.66}{#3}
+        \draw[tn leg] (lA.west) -- ++(-0.50,0);
+        \draw[tn leg] (lA.east) -- (lX.west);
+        \draw[tn leg] (lX.east) -- (lB.west);
+        \draw[tn leg] (lB.east) -- ++(0.50,0);
+        \node at (2.85,0) {$=$};
+        \TN@tensordot{rA}{(4.10,0)}
+        \TN@opdotabove{rX}{(4.92,0)}{#2}
+        \TN@tensordot{rB}{(5.75,0)}
+        \TN@upleg{rB}{0.44}
+        \TN@uplabel{rB}{0.66}{#3}
+        \draw[tn leg] (rA.west) -- ++(-0.50,0);
+        \draw[tn leg] (rA.east) -- (rX.west);
+        \draw[tn leg] (rX.east) -- (rB.west);
+        \draw[tn leg] (rB.east) -- ++(0.50,0);
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPeriodicGauge}[3]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{pA}{(0,0)}
-    \TN@tensordot{pB}{(1.10,0)}
-    \TN@opdotbelow{pZ}{(0.55,-0.72)}{#2}
-    \draw[tn leg] (-0.45,0) -- (1.55,0);
-    \TN@upleg{pA}{0.38}
-    \TN@upleg{pB}{0.38}
-    \draw[tn leg] (-0.45,0) -- (-0.45,-0.72) -- (pZ.west);
-    \draw[tn leg] (pZ.east) -- (1.55,-0.72) -- (1.55,0);
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{pA}{(0,0)}
+        \TN@tensordot{pB}{(1.10,0)}
+        \TN@opdotbelow{pZ}{(0.55,-0.72)}{#2}
+        \draw[tn leg] (-0.45,0) -- (1.55,0);
+        \TN@upleg{pA}{0.38}
+        \TN@upleg{pB}{0.38}
+        \draw[tn leg] (-0.45,0) -- (-0.45,-0.72) -- (pZ.west);
+        \draw[tn leg] (pZ.east) -- (1.55,-0.72) -- (1.55,0);
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNGroundSpaceMap}[5]{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnL}{(0,0)}
-    \TN@tensordot{tnM}{(1.15,0)}
-    \TN@tensordot{tnR}{(2.95,0)}
-    \TN@upleg{tnL}{\TN@physleglen}
-    \TN@upleg{tnM}{\TN@physleglen}
-    \TN@upleg{tnR}{\TN@physleglen}
-    \TN@uplabel{tnL}{\TN@physlabeloff}{#2}
-    \TN@uplabel{tnR}{\TN@physlabeloff}{#3}
-    \draw[tn leg] (-0.45,0) -- (3.40,0);
-    \node at (2.05,0) {$\cdots$};
-    \TN@opdotbelow{tnX}{(1.48,-0.82)}{#5}
-    \draw[tn leg] (-0.45,0) -- (-0.45,-0.82) -- (tnX.west);
-    \draw[tn leg] (tnX.east) -- (3.40,-0.82) -- (3.40,0);
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnL}{(0,0)}
+        \TN@tensordot{tnM}{(1.15,0)}
+        \TN@tensordot{tnR}{(2.95,0)}
+        \TN@upleg{tnL}{\TN@physleglen}
+        \TN@upleg{tnM}{\TN@physleglen}
+        \TN@upleg{tnR}{\TN@physleglen}
+        \TN@uplabel{tnL}{\TN@physlabeloff}{#2}
+        \TN@uplabel{tnR}{\TN@physlabeloff}{#3}
+        \draw[tn leg] (-0.45,0) -- (3.40,0);
+        \node at (2.05,0) {$\cdots$};
+        \TN@opdotbelow{tnX}{(1.48,-0.82)}{#5}
+        \draw[tn leg] (-0.45,0) -- (-0.45,-0.82) -- (tnX.west);
+        \draw[tn leg] (tnX.east) -- (3.40,-0.82) -- (3.40,0);
+    \end{tikzpicture}%
 }
 
 % ---------- PEPS diagrams ----------
 
 \newcommand{\TNPEPSEdgeBlockingReduction}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@pepsFiveSitePatch{blockC}
-      \draw[red, line width=0.45pt] (blockCone) circle (0.30cm);
-      \draw[red, line width=0.45pt] (blockCfive) circle (0.30cm);
-      \draw[red, rounded corners=2mm, line width=0.45pt]
-        (0.40,-0.20) rectangle (1.70,1.70);
-      \node[red] at (-0.45,-0.35) {$A'_2$};
-      \node[red] at (-1.10,1.80) {$A'_1$};
-      \node[red] at (1.70,1.80) {$A'_3$};
-    \end{scope}
-    \node at (2.70,0.70) {$\rightsquigarrow$};
-    \begin{scope}[xshift=3.75cm,yshift=0.70cm]
-      \draw[tn leg] (0.20,0) rectangle (4.00,-0.46);
-      \TN@tensordot{blkL}{(0.80,0)}
-      \TN@tensordot{blkM}{(2.10,0)}
-      \TN@tensordot{blkR}{(3.40,0)}
-      \foreach \n in {blkL,blkM,blkR} {
-        \TN@upleg{\n}{0.46}
-      }
-      \node at ($(blkL.south)+(0,-0.30)$) {$A'_1$};
-      \node at ($(blkM.south)+(0,-0.30)$) {$A'_3$};
-      \node at ($(blkR.south)+(0,-0.30)$) {$A'_2$};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@pepsFiveSitePatch{blockC}
+            \draw[red, line width=0.45pt] (blockCone) circle (0.30cm);
+            \draw[red, line width=0.45pt] (blockCfive) circle (0.30cm);
+            \draw[red, rounded corners=2mm, line width=0.45pt]
+            (0.40,-0.20) rectangle (1.70,1.70);
+            \node[red] at (-0.45,-0.35) {$A'_2$};
+            \node[red] at (-1.10,1.80) {$A'_1$};
+            \node[red] at (1.70,1.80) {$A'_3$};
+        \end{scope}
+        \node at (2.70,0.70) {$\rightsquigarrow$};
+        \begin{scope}[xshift=3.75cm,yshift=0.70cm]
+            \draw[tn leg] (0.20,0) rectangle (4.00,-0.46);
+            \TN@tensordot{blkL}{(0.80,0)}
+            \TN@tensordot{blkM}{(2.10,0)}
+            \TN@tensordot{blkR}{(3.40,0)}
+            \foreach \n in {blkL,blkM,blkR} {
+                    \TN@upleg{\n}{0.46}
+                }
+            \node at ($(blkL.south)+(0,-0.30)$) {$A'_1$};
+            \node at ($(blkM.south)+(0,-0.30)$) {$A'_3$};
+            \node at ($(blkR.south)+(0,-0.30)$) {$A'_2$};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSEdgeInsertedCoeff}{%
-  \begin{tikzpicture}[tn picture]
-    \TN@boxedThreeSiteInsertion{edgeCoeff}{A'_1}{A'_3}{A'_2}{X}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@boxedThreeSiteInsertion{edgeCoeff}{A'_1}{A'_3}{A'_2}{X}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSThreeSiteInsertionComparison}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@boxedThreeSiteInsertion{insA}{A_1}{A_2}{A_3}{X}
-    \end{scope}
-    \node at (4.20,0) {$=$};
-    \begin{scope}[xshift=4.90cm]
-      \TN@boxedThreeSiteInsertion{insB}{B_1}{B_2}{B_3}{Y}
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@boxedThreeSiteInsertion{insA}{A_1}{A_2}{A_3}{X}
+        \end{scope}
+        \node at (4.20,0) {$=$};
+        \begin{scope}[xshift=4.90cm]
+            \TN@boxedThreeSiteInsertion{insB}{B_1}{B_2}{B_3}{Y}
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSInsertionPhysicalRealization}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@tensordot{realLeftA}{(0,0)}
-      \TN@upleg{realLeftA}{0.50}
-      \draw[tn leg] (realLeftA.east) -- ++(0.70,0);
-      \draw[tn leg] (realLeftA.south) -- ++(0,-0.58);
-      \TN@opdotabove{realLeftM}{(-0.56,0)}{M}
-      \draw[tn leg, red] (realLeftM.west) -- ++(-0.42,0);
-      \draw[tn leg] (realLeftM.east) -- (realLeftA.west);
-      \node at ($(realLeftA.south)+(0,-0.30)$) {$A_u$};
-      \node at (-0.56,-0.35) {$e$};
-      \node at (0.72,-0.36) {$\eta_{\widehat e}$};
-      \node at ($(realLeftA.north)+(0,0.73)$) {$i$};
-    \end{scope}
-    \node at (1.80,0) {$=$};
-    \begin{scope}[xshift=3.20cm]
-      \TN@tensordot{realRightA}{(0,0)}
-      \TN@upleg{realRightA}{0.30}
-      \TN@opdotleft{realRightO}{(0,0.62)}{O}
-      \draw[tn phys leg] (realRightA.north) -- (realRightO.south);
-      \draw[tn phys leg, red] (realRightO.north) -- ++(0,0.28);
-      \draw[tn leg] (realRightA.west) -- ++(-0.70,0);
-      \draw[tn leg] (realRightA.east) -- ++(0.70,0);
-      \draw[tn leg] (realRightA.south) -- ++(0,-0.58);
-      \node at ($(realRightA.south)+(0,-0.30)$) {$A_u$};
-      \node at (-0.72,-0.36) {$\eta_e$};
-      \node at (0.72,-0.36) {$\eta_{\widehat e}$};
-      \node at ($(realRightO.north)+(0,0.55)$) {$O(A_u(\eta_e,\eta_{\widehat e}))$};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@tensordot{realLeftA}{(0,0)}
+            \TN@upleg{realLeftA}{0.50}
+            \draw[tn leg] (realLeftA.east) -- ++(0.70,0);
+            \draw[tn leg] (realLeftA.south) -- ++(0,-0.58);
+            \TN@opdotabove{realLeftM}{(-0.56,0)}{M}
+            \draw[tn leg, red] (realLeftM.west) -- ++(-0.42,0);
+            \draw[tn leg] (realLeftM.east) -- (realLeftA.west);
+            \node at ($(realLeftA.south)+(0,-0.30)$) {$A_u$};
+            \node at (-0.56,-0.35) {$e$};
+            \node at (0.72,-0.36) {$\eta_{\widehat e}$};
+            \node at ($(realLeftA.north)+(0,0.73)$) {$i$};
+        \end{scope}
+        \node at (1.80,0) {$=$};
+        \begin{scope}[xshift=3.20cm]
+            \TN@tensordot{realRightA}{(0,0)}
+            \TN@upleg{realRightA}{0.30}
+            \TN@opdotleft{realRightO}{(0,0.62)}{O}
+            \draw[tn phys leg] (realRightA.north) -- (realRightO.south);
+            \draw[tn phys leg, red] (realRightO.north) -- ++(0,0.28);
+            \draw[tn leg] (realRightA.west) -- ++(-0.70,0);
+            \draw[tn leg] (realRightA.east) -- ++(0.70,0);
+            \draw[tn leg] (realRightA.south) -- ++(0,-0.58);
+            \node at ($(realRightA.south)+(0,-0.30)$) {$A_u$};
+            \node at (-0.72,-0.36) {$\eta_e$};
+            \node at (0.72,-0.36) {$\eta_{\widehat e}$};
+            \node at ($(realRightO.north)+(0,0.55)$) {$O(A_u(\eta_e,\eta_{\widehat e}))$};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSPhysicalToVirtualInsertion}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@boxedThreeSitePhysicalOne{physVirtL}{B_1}{B_2}{B_3}{O_1}
-    \end{scope}
-    \node at (3.75,0) {$=$};
-    \begin{scope}[xshift=4.15cm]
-      \TN@boxedThreeSitePhysicalTwo{physVirtR}{B_1}{B_2}{B_3}{O_2}
-    \end{scope}
-    \node at (7.95,0) {$\Longrightarrow$};
-    \begin{scope}[xshift=8.40cm]
-      \TN@boxedThreeSiteInsertion{physVirtW}{B_1}{B_2}{B_3}{W}
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@boxedThreeSitePhysicalOne{physVirtL}{B_1}{B_2}{B_3}{O_1}
+        \end{scope}
+        \node at (3.75,0) {$=$};
+        \begin{scope}[xshift=4.15cm]
+            \TN@boxedThreeSitePhysicalTwo{physVirtR}{B_1}{B_2}{B_3}{O_2}
+        \end{scope}
+        \node at (7.95,0) {$\Longrightarrow$};
+        \begin{scope}[xshift=8.40cm]
+            \TN@boxedThreeSiteInsertion{physVirtW}{B_1}{B_2}{B_3}{W}
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSEdgeInsertionEquality}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@pepsFiveSitePatch{edgeEqA}
-      \TN@pepsFiveSitePatchLabels{edgeEqA}{A_1}{A_2}{A_3}{A_4}{A_5}
-      \TN@opdotright{edgeInsA}{($(edgeEqAtwo)!0.50!(edgeEqAfive)$)}{X}
-    \end{scope}
-    \node at (2.75,0.70) {$=$};
-    \begin{scope}[xshift=4.15cm]
-      \TN@pepsFiveSitePatch{edgeEqB}
-      \TN@pepsFiveSitePatchLabels{edgeEqB}
-        {\widetilde B_1}{\widetilde B_2}{\widetilde B_3}
-        {\widetilde B_4}{\widetilde B_5}
-      \TN@opdotright{edgeInsB}{($(edgeEqBtwo)!0.50!(edgeEqBfive)$)}{X}
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@pepsFiveSitePatch{edgeEqA}
+            \TN@pepsFiveSitePatchLabels{edgeEqA}{A_1}{A_2}{A_3}{A_4}{A_5}
+            \TN@opdotright{edgeInsA}{($(edgeEqAtwo)!0.50!(edgeEqAfive)$)}{X}
+        \end{scope}
+        \node at (2.75,0.70) {$=$};
+        \begin{scope}[xshift=4.15cm]
+            \TN@pepsFiveSitePatch{edgeEqB}
+            \TN@pepsFiveSitePatchLabels{edgeEqB}
+            {\widetilde B_1}{\widetilde B_2}{\widetilde B_3}
+            {\widetilde B_4}{\widetilde B_5}
+            \TN@opdotright{edgeInsB}{($(edgeEqBtwo)!0.50!(edgeEqBfive)$)}{X}
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSEdgeGaugeAbsorption}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@tensordot{absB}{(0,0)}
-      \TN@upleg{absB}{0.44}
-      \draw[tn leg] (absB.west) -- ++(-0.62,0);
-      \draw[tn leg] (absB.east) -- ++(0.62,0);
-      \draw[tn leg] ($(absB.south)-(0.18,0)$) -- ++(-0.50,-0.58);
-      \draw[tn leg] ($(absB.south)+(0.18,0)$) -- ++(0.50,-0.58);
-      \node at ($(absB.south)+(0,-0.95)$) {$B_v$};
-    \end{scope}
-    \node at (1.15,0) {$\longmapsto$};
-    \begin{scope}[xshift=2.30cm]
-      \TN@tensordot{absBt}{(0,0)}
-      \TN@upleg{absBt}{0.44}
-      \TN@opdotleft{absL}{(-0.70,0)}{Z_{e_1}^{\pm1}}
-      \TN@opdotright{absR}{(0.70,0)}{Z_{e_2}^{\pm1}}
-      \TN@opdotbelow{absDL}{(-0.48,-0.60)}{Z_{e_3}^{\pm1}}
-      \TN@opdotbelow{absDR}{(0.48,-0.60)}{Z_{e_4}^{\pm1}}
-      \draw[tn leg] (absL.west) -- ++(-0.28,0);
-      \draw[tn leg] (absL.east) -- (absBt.west);
-      \draw[tn leg] (absBt.east) -- (absR.west);
-      \draw[tn leg] (absR.east) -- ++(0.28,0);
-      \draw[tn leg] ($(absBt.south)-(0.18,0)$) -- (absDL.north);
-      \draw[tn leg] ($(absBt.south)+(0.18,0)$) -- (absDR.north);
-      \draw[tn leg] (absDL.south) -- ++(-0.20,-0.28);
-      \draw[tn leg] (absDR.south) -- ++(0.20,-0.28);
-      \node at ($(absBt.south)+(0,-1.10)$) {$\widetilde B_v$};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@tensordot{absB}{(0,0)}
+            \TN@upleg{absB}{0.44}
+            \draw[tn leg] (absB.west) -- ++(-0.62,0);
+            \draw[tn leg] (absB.east) -- ++(0.62,0);
+            \draw[tn leg] ($(absB.south)-(0.18,0)$) -- ++(-0.50,-0.58);
+            \draw[tn leg] ($(absB.south)+(0.18,0)$) -- ++(0.50,-0.58);
+            \node at ($(absB.south)+(0,-0.95)$) {$B_v$};
+        \end{scope}
+        \node at (1.15,0) {$\longmapsto$};
+        \begin{scope}[xshift=2.30cm]
+            \TN@tensordot{absBt}{(0,0)}
+            \TN@upleg{absBt}{0.44}
+            \TN@opdotleft{absL}{(-0.70,0)}{Z_{e_1}^{\pm1}}
+            \TN@opdotright{absR}{(0.70,0)}{Z_{e_2}^{\pm1}}
+            \TN@opdotbelow{absDL}{(-0.48,-0.60)}{Z_{e_3}^{\pm1}}
+            \TN@opdotbelow{absDR}{(0.48,-0.60)}{Z_{e_4}^{\pm1}}
+            \draw[tn leg] (absL.west) -- ++(-0.28,0);
+            \draw[tn leg] (absL.east) -- (absBt.west);
+            \draw[tn leg] (absBt.east) -- (absR.west);
+            \draw[tn leg] (absR.east) -- ++(0.28,0);
+            \draw[tn leg] ($(absBt.south)-(0.18,0)$) -- (absDL.north);
+            \draw[tn leg] ($(absBt.south)+(0.18,0)$) -- (absDR.north);
+            \draw[tn leg] (absDL.south) -- ++(-0.20,-0.28);
+            \draw[tn leg] (absDR.south) -- ++(0.20,-0.28);
+            \node at ($(absBt.south)+(0,-1.10)$) {$\widetilde B_v$};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSTwoInjectiveTensorInsertionComparison}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@twoInjectiveInsertionPair{twoInjA}{A_1}{A_2}{X}
-    \end{scope}
-    \node at (3.20,0) {$=$};
-    \begin{scope}[xshift=3.90cm]
-      \TN@twoInjectiveInsertionPair{twoInjB}{B_1}{B_2}{X}
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@twoInjectiveInsertionPair{twoInjA}{A_1}{A_2}{X}
+        \end{scope}
+        \node at (3.20,0) {$=$};
+        \begin{scope}[xshift=3.90cm]
+            \TN@twoInjectiveInsertionPair{twoInjB}{B_1}{B_2}{X}
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSTwoInjectiveGaugeScalarReduction}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@threeLegTensorFan{gaugeRedA}{A_1}
-    \end{scope}
-    \node at (1.25,0) {$=$};
-    \begin{scope}[xshift=2.05cm]
-      \TN@threeLegTensorFan{gaugeRedBZ}{B_1}
-      \draw[red, line width=0.9pt] (0.35,-0.46) arc (-55:5:0.55);
-      \node[red] at (0.70,-0.24) {$Z$};
-    \end{scope}
-    \node at (3.30,0) {$=$};
-    \begin{scope}[xshift=4.10cm]
-      \TN@threeLegTensorFan{gaugeRedBU}{B_1}
-      \draw[red, line width=0.9pt] (0.35,-0.06) arc (-10:45:0.55);
-      \node[red] at (0.72,0.24) {$U$};
-    \end{scope}
-    \node at (5.35,0) {$=$};
-    \begin{scope}[xshift=6.15cm]
-      \TN@tensordot{gaugeRedBW}{(0,0)}
-      \TN@upleg{gaugeRedBW}{0.42}
-      \draw[tn leg] (gaugeRedBW) -- ++(0.75,0.45);
-      \draw[tn leg] (gaugeRedBW) -- ++(0.40,-0.07);
-      \draw[tn leg] (gaugeRedBW) -- ++(0.65,-0.55);
-      \draw[red, line width=0.9pt] (0.35,-0.46) arc (-55:45:0.55);
-      \node[red] at (0.79,0.00) {$W$};
-      \node at ($(gaugeRedBW.south)+(0,-0.30)$) {$B_1$};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@threeLegTensorFan{gaugeRedA}{A_1}
+        \end{scope}
+        \node at (1.25,0) {$=$};
+        \begin{scope}[xshift=2.05cm]
+            \TN@threeLegTensorFan{gaugeRedBZ}{B_1}
+            \draw[red, line width=0.9pt] (0.35,-0.46) arc (-55:5:0.55);
+            \node[red] at (0.70,-0.24) {$Z$};
+        \end{scope}
+        \node at (3.30,0) {$=$};
+        \begin{scope}[xshift=4.10cm]
+            \TN@threeLegTensorFan{gaugeRedBU}{B_1}
+            \draw[red, line width=0.9pt] (0.35,-0.06) arc (-10:45:0.55);
+            \node[red] at (0.72,0.24) {$U$};
+        \end{scope}
+        \node at (5.35,0) {$=$};
+        \begin{scope}[xshift=6.15cm]
+            \TN@tensordot{gaugeRedBW}{(0,0)}
+            \TN@upleg{gaugeRedBW}{0.42}
+            \draw[tn leg] (gaugeRedBW) -- ++(0.75,0.45);
+            \draw[tn leg] (gaugeRedBW) -- ++(0.40,-0.07);
+            \draw[tn leg] (gaugeRedBW) -- ++(0.65,-0.55);
+            \draw[red, line width=0.9pt] (0.35,-0.46) arc (-55:45:0.55);
+            \node[red] at (0.79,0.00) {$W$};
+            \node at ($(gaugeRedBW.south)+(0,-0.30)$) {$B_1$};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSOneVertexComplementComparison}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \TN@tensordot{oneSiteAR}{(1.00,0)}
-      \TN@tensordot{oneSiteA}{(2.00,0)}
-      \TN@upleg{oneSiteAR}{0.42}
-      \TN@upleg{oneSiteA}{0.42}
-      \draw[tn leg] (0.50,0) -- (oneSiteAR) -- (oneSiteA) -- (2.50,0);
-      \node at ($(oneSiteAR.south)+(0,-0.30)$) {$A_R$};
-      \node at ($(oneSiteA.south)+(0,-0.30)$) {$A_v$};
-    \end{scope}
-    \node at (3.12,0) {$=$};
-    \begin{scope}[xshift=3.55cm]
-      \TN@tensordot{oneSiteAS}{(1.00,0)}
-      \TN@upleg{oneSiteAS}{0.42}
-      \draw[tn leg] (0.50,0) -- (oneSiteAS) -- (1.50,0);
-      \node at ($(oneSiteAS.south)+(0,-0.30)$) {$A_S$};
-    \end{scope}
-    \node at (5.42,0) {$\propto$};
-    \begin{scope}[xshift=5.95cm]
-      \TN@tensordot{oneSiteBS}{(1.00,0)}
-      \TN@upleg{oneSiteBS}{0.42}
-      \draw[tn leg] (0.50,0) -- (oneSiteBS) -- (1.50,0);
-      \node at ($(oneSiteBS.south)+(0,-0.30)$) {$\widetilde B_S$};
-    \end{scope}
-    \node at (7.82,0) {$=$};
-    \begin{scope}[xshift=8.25cm]
-      \TN@tensordot{oneSiteBR}{(1.00,0)}
-      \TN@tensordot{oneSiteB}{(2.00,0)}
-      \TN@upleg{oneSiteBR}{0.42}
-      \TN@upleg{oneSiteB}{0.42}
-      \draw[tn leg] (0.50,0) -- (oneSiteBR) -- (oneSiteB) -- (2.50,0);
-      \node at ($(oneSiteBR.south)+(0,-0.30)$) {$\widetilde B_R$};
-      \node at ($(oneSiteB.south)+(0,-0.30)$) {$\widetilde B_v$};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \TN@tensordot{oneSiteAR}{(1.00,0)}
+            \TN@tensordot{oneSiteA}{(2.00,0)}
+            \TN@upleg{oneSiteAR}{0.42}
+            \TN@upleg{oneSiteA}{0.42}
+            \draw[tn leg] (0.50,0) -- (oneSiteAR) -- (oneSiteA) -- (2.50,0);
+            \node at ($(oneSiteAR.south)+(0,-0.30)$) {$A_R$};
+            \node at ($(oneSiteA.south)+(0,-0.30)$) {$A_v$};
+        \end{scope}
+        \node at (3.12,0) {$=$};
+        \begin{scope}[xshift=3.55cm]
+            \TN@tensordot{oneSiteAS}{(1.00,0)}
+            \TN@upleg{oneSiteAS}{0.42}
+            \draw[tn leg] (0.50,0) -- (oneSiteAS) -- (1.50,0);
+            \node at ($(oneSiteAS.south)+(0,-0.30)$) {$A_S$};
+        \end{scope}
+        \node at (5.42,0) {$\propto$};
+        \begin{scope}[xshift=5.95cm]
+            \TN@tensordot{oneSiteBS}{(1.00,0)}
+            \TN@upleg{oneSiteBS}{0.42}
+            \draw[tn leg] (0.50,0) -- (oneSiteBS) -- (1.50,0);
+            \node at ($(oneSiteBS.south)+(0,-0.30)$) {$\widetilde B_S$};
+        \end{scope}
+        \node at (7.82,0) {$=$};
+        \begin{scope}[xshift=8.25cm]
+            \TN@tensordot{oneSiteBR}{(1.00,0)}
+            \TN@tensordot{oneSiteB}{(2.00,0)}
+            \TN@upleg{oneSiteBR}{0.42}
+            \TN@upleg{oneSiteB}{0.42}
+            \draw[tn leg] (0.50,0) -- (oneSiteBR) -- (oneSiteB) -- (2.50,0);
+            \node at ($(oneSiteBR.south)+(0,-0.30)$) {$\widetilde B_R$};
+            \node at ($(oneSiteB.south)+(0,-0.30)$) {$\widetilde B_v$};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\pepsNormalSquareLattice}{%
-  \TN@normalPepsGrid%
+    \TN@normalPepsGrid%
 }
 
 \newcommand{\pepsNormalSquareLatticeLines}{%
-  \TN@normalPepsGridLines%
+    \TN@normalPepsGridLines%
 }
 
 \newcommand{\pepsNormalSquareLatticeDots}{%
-  \TN@normalPepsGridDots%
+    \TN@normalPepsGridDots%
 }
 
 \newcommand{\pepsNormalRegionR}{%
-  \draw[red, fill=red!35, thick, rounded corners=1mm]
+    \draw[red, fill=red!35, thick, rounded corners=1mm]
     (0.3,1.3) -- (1.2,1.3) -- (1.2,1.8) -- (1.7,1.8) --
     (1.7,2.7) -- (0.3,2.7) -- cycle;
-  \node at (0.75,2.0) {$R$};%
+    \node at (0.75,2.0) {$R$};%
 }
 
 \newcommand{\pepsNormalRegionS}{%
-  \draw[red, fill=red!35, thick, rounded corners=1mm]
+    \draw[red, fill=red!35, thick, rounded corners=1mm]
     (0.3,1.3) rectangle (1.7,2.7);
-  \node at (1.00,2.00) {$S$};%
+    \node at (1.00,2.00) {$S$};%
 }
 
 \newcommand{\pepsNormalRegionT}{%
-  \filldraw[draw=red, fill=red!35, thick, rounded corners=1mm,
-    even odd rule]
+    \filldraw[draw=red, fill=red!35, thick, rounded corners=1mm,
+        even odd rule]
     (0.3,2.7) -- (1.2,2.7) -- (1.2,1.7) -- (2.7,1.7) --
     (2.7,0.8) -- (1.3,0.8) -- (1.3,1.3) -- (0.3,1.3) -- cycle
     (-0.25,0.25) rectangle (3.25,3.25);
-  \node at (2.0,2.3) {$T$};%
+    \node at (2.0,2.3) {$T$};%
 }
 
 \newcommand{\pepsNormalSingleSiteDifference}{%
-  \filldraw[yellow!75!white, draw=black!65, thick]
+    \filldraw[yellow!75!white, draw=black!65, thick]
     (1.5,1.5) circle (0.16cm);
-  \node[black] at (1.5,1.5) {\scriptsize $v$};%
+    \node[black] at (1.5,1.5) {\scriptsize $v$};%
 }
 
 \newcommand{\pepsNormalDistinguishedEdge}{%
-  \draw[line width=0.6mm, green!65!black] (1,1.5) -- (1.5,1.5);%
+    \draw[line width=0.6mm, green!65!black] (1,1.5) -- (1.5,1.5);%
 }
 
 \newcommand{\pepsNormalRedBlock}{%
-  \draw[red, thick, rounded corners=1mm] (0.3,1.3) rectangle (1.2,2.7);%
+    \draw[red, thick, rounded corners=1mm] (0.3,1.3) rectangle (1.2,2.7);%
 }
 
 \newcommand{\pepsNormalBlueBlock}{%
-  \draw[blue, thick, rounded corners=1mm] (1.3,1.7) rectangle (2.7,0.8);%
+    \draw[blue, thick, rounded corners=1mm] (1.3,1.7) rectangle (2.7,0.8);%
 }
 
 \newcommand{\pepsNormalComplementBlock}{%
-  \filldraw[draw=black!55, fill=black!8, dashed, thick, rounded corners=1mm,
-    even odd rule]
+    \filldraw[draw=black!55, fill=black!8, dashed, thick, rounded corners=1mm,
+        even odd rule]
     (-0.15,-0.15) rectangle (3.15,3.15)
     (0.3,1.3) rectangle (1.2,2.7)
     (1.3,0.8) rectangle (2.7,1.7);
-  \node[black!65] at (2.38,2.45) {$A_3$};%
+    \node[black!65] at (2.38,2.45) {$A_3$};%
 }
 
 \newcommand{\pepsBlockedNormalChain}{%
-  \draw[tn leg] (0.50,0) rectangle (3.50,-0.46);
-  \draw[line width=0.6mm, green!65!black] (1.00,0) -- (2.00,0);
-  \foreach \x/\c/\lab in {1/red/A_1,2/blue/A_2,3/black/A_3} {
-    \TN@tensordot{normalBlock\x}{(\x,0)}
-    \TN@upleg{normalBlock\x}{0.46}
-    \node[\c] at ($(normalBlock\x.south)+(0,-0.30)$) {$\lab$};
-  }%
+    \draw[tn leg] (0.50,0) rectangle (3.50,-0.46);
+    \draw[line width=0.6mm, green!65!black] (1.00,0) -- (2.00,0);
+    \foreach \x/\c/\lab in {1/red/A_1,2/blue/A_2,3/black/A_3} {
+            \TN@tensordot{normalBlock\x}{(\x,0)}
+            \TN@upleg{normalBlock\x}{0.46}
+            \node[\c] at ($(normalBlock\x.south)+(0,-0.30)$) {$\lab$};
+        }%
 }
 
 \newcommand{\pepsSquareTensor}[2]{%
-  \TN@tensordot{#1}{#2}
-  \TN@upleg{#1}{0.46}
-  \draw[tn leg] (#1.west) -- ++(-0.60,0);
-  \draw[tn leg] (#1.east) -- ++(0.60,0);
-  \draw[tn leg] (#1.south) -- ++(0,-0.60);
-  \draw[tn leg] (#1.north) -- ++(0,0.38);%
+    \TN@tensordot{#1}{#2}
+    \TN@upleg{#1}{0.46}
+    \draw[tn leg] (#1.west) -- ++(-0.60,0);
+    \draw[tn leg] (#1.east) -- ++(0.60,0);
+    \draw[tn leg] (#1.south) -- ++(0,-0.60);
+    \draw[tn leg] (#1.north) -- ++(0,0.38);%
 }
 
 \newcommand{\TNPEPSInjectiveRegionUnion}{%
-  \begin{tikzpicture}[tn picture]
-    \node[tn tensor dot] (unionAB) at (0,0) {};
-    \node[tn tensor dot] (unionI) at (0.70,0.70) {};
-    \node[tn tensor dot] (unionBA) at (2.00,0) {};
-    \node[tn tensor dot] (unionC) at (1.30,-0.70) {};
-    \foreach \n in {unionAB,unionI,unionBA,unionC} {
-      \draw[tn phys leg] (\n.north) -- ++(0,0.42);
-    }
-    \draw[tn leg] (unionAB) -- (unionI) -- (unionBA) -- (unionC) --
-      (unionAB) -- (unionBA);
-    \draw[tn leg] (unionI) -- (unionC);
-    \node[anchor=east] at ($(unionAB)+(-0.12,-0.20)$) {$A\setminus B$};
-    \node[anchor=west] at ($(unionI)+(0.12,0.02)$) {$A\cap B$};
-    \node[anchor=west] at ($(unionBA)+(0.12,-0.20)$) {$B\setminus A$};
-    \node at ($(unionC)+(0,-0.38)$) {$(A\cup B)^c$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \node[tn tensor dot] (unionAB) at (0,0) {};
+        \node[tn tensor dot] (unionI) at (0.70,0.70) {};
+        \node[tn tensor dot] (unionBA) at (2.00,0) {};
+        \node[tn tensor dot] (unionC) at (1.30,-0.70) {};
+        \foreach \n in {unionAB,unionI,unionBA,unionC} {
+                \draw[tn phys leg] (\n.north) -- ++(0,0.42);
+            }
+        \draw[tn leg] (unionAB) -- (unionI) -- (unionBA) -- (unionC) --
+        (unionAB) -- (unionBA);
+        \draw[tn leg] (unionI) -- (unionC);
+        \node[anchor=east] at ($(unionAB)+(-0.12,-0.20)$) {$A\setminus B$};
+        \node[anchor=west] at ($(unionI)+(0.12,0.02)$) {$A\cap B$};
+        \node[anchor=west] at ($(unionBA)+(0.12,-0.20)$) {$B\setminus A$};
+        \node at ($(unionC)+(0,-0.38)$) {$(A\cup B)^c$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSInjectiveRegionUnionProof}{%
-  \begin{tikzpicture}[tn picture, scale=0.82]
-    \begin{scope}
-      \node[tn tensor dot] (proofAB) at (0,0) {};
-      \node[tn tensor dot] (proofI) at (0.70,0.70) {};
-      \node[tn tensor dot] (proofBA) at (2.00,0) {};
-      \node[tn tensor dot] (proofX) at (1.30,-0.70) {};
-      \foreach \n in {proofAB,proofI,proofBA} {
-        \draw[tn phys leg] (\n.north) -- ++(0,0.36);
-      }
-      \draw[tn leg] (proofAB) -- (proofI) -- (proofBA) -- (proofX) --
-        (proofAB) -- (proofBA);
-      \draw[tn leg] (proofI) -- (proofX);
-      \node at ($(proofX)+(0,-0.34)$) {$X$};
-      \node at (1.00,-1.18) {$=0$};
-    \end{scope}
-    \draw[->, thick] (2.60,0.00) -- (3.20,0.00)
-      node[midway, above] {$A^{-1}$};
-    \begin{scope}[xshift=3.80cm]
-      \coordinate (proofAone) at (0,0);
-      \coordinate (proofItwo) at (0.70,0.70);
-      \node[tn tensor dot] (proofBAone) at (2.00,0) {};
-      \node[tn tensor dot] (proofXone) at (1.30,-0.70) {};
-      \draw[tn phys leg] (proofBAone.north) -- ++(0,0.36);
-      \draw[tn leg] (proofBAone) -- (proofXone);
-      \draw[tn leg] (proofXone) -- ($(proofXone)!0.34!(proofAone)$);
-      \draw[tn leg] (proofXone) -- ($(proofXone)!0.34!(proofItwo)$);
-      \draw[tn leg] (proofBAone) -- ($(proofBAone)!0.34!(proofAone)$);
-      \draw[tn leg] (proofBAone) -- ($(proofBAone)!0.34!(proofItwo)$);
-      \node at ($(proofXone)+(0,-0.34)$) {$X$};
-      \node at (1.00,-1.18) {$=0$};
-    \end{scope}
-    \draw[->, thick] (6.45,0.00) -- (7.05,0.00)
-      node[midway, above] {$A\cap B$};
-    \begin{scope}[xshift=7.70cm]
-      \coordinate (proofAtwo) at (0,0);
-      \node[tn tensor dot] (proofItwoNode) at (0.70,0.70) {};
-      \node[tn tensor dot] (proofBAtwo) at (2.00,0) {};
-      \node[tn tensor dot] (proofXtwo) at (1.30,-0.70) {};
-      \foreach \n in {proofItwoNode,proofBAtwo} {
-        \draw[tn phys leg] (\n.north) -- ++(0,0.36);
-      }
-      \draw[tn leg] (proofBAtwo) -- (proofXtwo) -- (proofItwoNode) --
-        (proofBAtwo);
-      \draw[tn leg] (proofXtwo) -- ($(proofXtwo)!0.34!(proofAtwo)$);
-      \draw[tn leg] (proofBAtwo) -- ($(proofBAtwo)!0.34!(proofAtwo)$);
-      \draw[tn leg] (proofItwoNode) -- ($(proofItwoNode)!0.34!(proofAtwo)$);
-      \node at ($(proofXtwo)+(0,-0.34)$) {$X$};
-      \node at (1.00,-1.18) {$=0$};
-    \end{scope}
-    \draw[->, thick] (10.35,0.00) -- (10.95,0.00)
-      node[midway, above] {$B^{-1}$};
-    \begin{scope}[xshift=11.55cm]
-      \coordinate (proofAthree) at (0,0);
-      \coordinate (proofIthree) at (0.70,0.70);
-      \coordinate (proofBAthree) at (2.00,0);
-      \node[tn tensor dot] (proofXthree) at (1.30,-0.70) {};
-      \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofAthree)$);
-      \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofIthree)$);
-      \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofBAthree)$);
-      \node at ($(proofXthree)+(0,-0.34)$) {$X=0$};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.82]
+        \begin{scope}
+            \node[tn tensor dot] (proofAB) at (0,0) {};
+            \node[tn tensor dot] (proofI) at (0.70,0.70) {};
+            \node[tn tensor dot] (proofBA) at (2.00,0) {};
+            \node[tn tensor dot] (proofX) at (1.30,-0.70) {};
+            \foreach \n in {proofAB,proofI,proofBA} {
+                    \draw[tn phys leg] (\n.north) -- ++(0,0.36);
+                }
+            \draw[tn leg] (proofAB) -- (proofI) -- (proofBA) -- (proofX) --
+            (proofAB) -- (proofBA);
+            \draw[tn leg] (proofI) -- (proofX);
+            \node at ($(proofX)+(0,-0.34)$) {$X$};
+            \node at (1.00,-1.18) {$=0$};
+        \end{scope}
+        \draw[->, thick] (2.60,0.00) -- (3.20,0.00)
+        node[midway, above] {$A^{-1}$};
+        \begin{scope}[xshift=3.80cm]
+            \coordinate (proofAone) at (0,0);
+            \coordinate (proofItwo) at (0.70,0.70);
+            \node[tn tensor dot] (proofBAone) at (2.00,0) {};
+            \node[tn tensor dot] (proofXone) at (1.30,-0.70) {};
+            \draw[tn phys leg] (proofBAone.north) -- ++(0,0.36);
+            \draw[tn leg] (proofBAone) -- (proofXone);
+            \draw[tn leg] (proofXone) -- ($(proofXone)!0.34!(proofAone)$);
+            \draw[tn leg] (proofXone) -- ($(proofXone)!0.34!(proofItwo)$);
+            \draw[tn leg] (proofBAone) -- ($(proofBAone)!0.34!(proofAone)$);
+            \draw[tn leg] (proofBAone) -- ($(proofBAone)!0.34!(proofItwo)$);
+            \node at ($(proofXone)+(0,-0.34)$) {$X$};
+            \node at (1.00,-1.18) {$=0$};
+        \end{scope}
+        \draw[->, thick] (6.45,0.00) -- (7.05,0.00)
+        node[midway, above] {$A\cap B$};
+        \begin{scope}[xshift=7.70cm]
+            \coordinate (proofAtwo) at (0,0);
+            \node[tn tensor dot] (proofItwoNode) at (0.70,0.70) {};
+            \node[tn tensor dot] (proofBAtwo) at (2.00,0) {};
+            \node[tn tensor dot] (proofXtwo) at (1.30,-0.70) {};
+            \foreach \n in {proofItwoNode,proofBAtwo} {
+                    \draw[tn phys leg] (\n.north) -- ++(0,0.36);
+                }
+            \draw[tn leg] (proofBAtwo) -- (proofXtwo) -- (proofItwoNode) --
+            (proofBAtwo);
+            \draw[tn leg] (proofXtwo) -- ($(proofXtwo)!0.34!(proofAtwo)$);
+            \draw[tn leg] (proofBAtwo) -- ($(proofBAtwo)!0.34!(proofAtwo)$);
+            \draw[tn leg] (proofItwoNode) -- ($(proofItwoNode)!0.34!(proofAtwo)$);
+            \node at ($(proofXtwo)+(0,-0.34)$) {$X$};
+            \node at (1.00,-1.18) {$=0$};
+        \end{scope}
+        \draw[->, thick] (10.35,0.00) -- (10.95,0.00)
+        node[midway, above] {$B^{-1}$};
+        \begin{scope}[xshift=11.55cm]
+            \coordinate (proofAthree) at (0,0);
+            \coordinate (proofIthree) at (0.70,0.70);
+            \coordinate (proofBAthree) at (2.00,0);
+            \node[tn tensor dot] (proofXthree) at (1.30,-0.70) {};
+            \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofAthree)$);
+            \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofIthree)$);
+            \draw[tn leg] (proofXthree) -- ($(proofXthree)!0.34!(proofBAthree)$);
+            \node at ($(proofXthree)+(0,-0.34)$) {$X=0$};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalRegionsRS}{%
-  \begin{tikzpicture}[tn picture, scale=0.90]
-    \begin{scope}
-      \clip (-0.25,0.75) rectangle (2.25,3.25);
-      \pepsNormalSquareLattice
-      \pepsNormalRegionR
-    \end{scope}
-    \node at (2.85,2.00) {and};
-    \begin{scope}[xshift=3.55cm]
-      \clip (-0.25,0.75) rectangle (2.25,3.25);
-      \pepsNormalSquareLattice
-      \pepsNormalRegionS
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.90]
+        \begin{scope}
+            \clip (-0.25,0.75) rectangle (2.25,3.25);
+            \pepsNormalSquareLattice
+            \pepsNormalRegionR
+        \end{scope}
+        \node at (2.85,2.00) {and};
+        \begin{scope}[xshift=3.55cm]
+            \clip (-0.25,0.75) rectangle (2.25,3.25);
+            \pepsNormalSquareLattice
+            \pepsNormalRegionS
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalRegionT}{%
-  \begin{tikzpicture}[tn picture, scale=0.90]
-    \clip (-0.25,0.25) rectangle (3.25,3.25);
-    \pepsNormalSquareLattice
-    \pepsNormalRegionT
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.90]
+        \clip (-0.25,0.25) rectangle (3.25,3.25);
+        \pepsNormalSquareLattice
+        \pepsNormalRegionT
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalRectangleCover}{%
-  \begin{tikzpicture}[tn picture, scale=0.78]
-    \draw[step=0.5, tn leg, black!30] (-0.25,-0.25) grid (2.35,2.35);
-    \draw[red!75!black, fill=red!28, thick, rounded corners=1mm]
-      (0.3,0.3) rectangle (1.2,1.7);
-    \draw[blue!75!black, fill=blue!24, thick, rounded corners=1mm]
-      (0.3,0.8) rectangle (1.7,1.7);
-    \draw[black!70, dashed, thick, rounded corners=1mm]
-      (0.3,0.3) -- (1.2,0.3) -- (1.2,0.8) -- (1.7,0.8) --
-      (1.7,1.7) -- (0.3,1.7) -- cycle;
-    \foreach \x in {0,0.5,1,1.5,2} {
-      \foreach \y in {0,0.5,1,1.5,2} {
-        \node[tn tensor dot] at (\x,\y) {};
-      }
-    }
-    \node[black!70] at (1.48,1.35) {$U$};
-    \node[red!75!black] at (0.75,0.55) {$2\times3$};
-    \node[blue!75!black] at (1.20,1.25) {$3\times2$};
-    \node at (0.98,-0.55)
-      {$U=\bigcup_j C_j,\quad C_j\cong 2\times3\ \mathrm{or}\ 3\times2$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.78]
+        \draw[step=0.5, tn leg, black!30] (-0.25,-0.25) grid (2.35,2.35);
+        \draw[red!75!black, fill=red!28, thick, rounded corners=1mm]
+        (0.3,0.3) rectangle (1.2,1.7);
+        \draw[blue!75!black, fill=blue!24, thick, rounded corners=1mm]
+        (0.3,0.8) rectangle (1.7,1.7);
+        \draw[black!70, dashed, thick, rounded corners=1mm]
+        (0.3,0.3) -- (1.2,0.3) -- (1.2,0.8) -- (1.7,0.8) --
+        (1.7,1.7) -- (0.3,1.7) -- cycle;
+        \foreach \x in {0,0.5,1,1.5,2} {
+                \foreach \y in {0,0.5,1,1.5,2} {
+                        \node[tn tensor dot] at (\x,\y) {};
+                    }
+            }
+        \node[black!70] at (1.48,1.35) {$U$};
+        \node[red!75!black] at (0.75,0.55) {$2\times3$};
+        \node[blue!75!black] at (1.20,1.25) {$3\times2$};
+        \node at (0.98,-0.55)
+        {$U=\bigcup_j C_j,\quad C_j\cong 2\times3\ \mathrm{or}\ 3\times2$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalEdgeComplementTopCollar}{%
-  \begin{tikzpicture}[tn picture, scale=0.90]
-    \begin{scope}
-      \clip (-0.25,-0.25) rectangle (3.25,3.25);
-      \pepsNormalSquareLatticeLines
-      \pepsNormalRegionT
-      \draw[purple!70!black, fill=purple!18, thick, rounded corners=1mm]
-        (0.3,2.55) rectangle (1.7,3.18);
-      \draw[purple!70!black, fill=purple!18, thick, rounded corners=1mm]
-        (1.3,2.55) rectangle (2.7,3.18);
-      \pepsNormalSquareLatticeDots
-      \node[red!75!black] at (2.05,1.45) {$T$};
-      \node[purple!70!black] at (1.50,2.88) {top collar};
-    \end{scope}
-    \node at (3.72,1.48) {$=$};
-    \begin{scope}[xshift=4.35cm]
-      \clip (-0.25,-0.25) rectangle (3.25,3.25);
-      \pepsNormalComplementBlock
-      \pepsNormalSquareLatticeLines
-      \pepsNormalSquareLatticeDots
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.90]
+        \begin{scope}
+            \clip (-0.25,-0.25) rectangle (3.25,3.25);
+            \pepsNormalSquareLatticeLines
+            \pepsNormalRegionT
+            \draw[purple!70!black, fill=purple!18, thick, rounded corners=1mm]
+            (0.3,2.55) rectangle (1.7,3.18);
+            \draw[purple!70!black, fill=purple!18, thick, rounded corners=1mm]
+            (1.3,2.55) rectangle (2.7,3.18);
+            \pepsNormalSquareLatticeDots
+            \node[red!75!black] at (2.05,1.45) {$T$};
+            \node[purple!70!black] at (1.50,2.88) {top collar};
+        \end{scope}
+        \node at (3.72,1.48) {$=$};
+        \begin{scope}[xshift=4.35cm]
+            \clip (-0.25,-0.25) rectangle (3.25,3.25);
+            \pepsNormalComplementBlock
+            \pepsNormalSquareLatticeLines
+            \pepsNormalSquareLatticeDots
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalOneSiteSeparation}{%
-  \begin{tikzpicture}[tn picture, scale=0.90]
-    \begin{scope}
-      \clip (-0.25,0.75) rectangle (2.25,3.25);
-      \pepsNormalSquareLattice
-      \pepsNormalRegionR
-      \pepsNormalSingleSiteDifference
-      \node at (1.00,0.98) {$R$};
-    \end{scope}
-    \node at (2.85,2.00) {$\subset$};
-    \begin{scope}[xshift=3.55cm]
-      \clip (-0.25,0.75) rectangle (2.25,3.25);
-      \pepsNormalSquareLattice
-      \pepsNormalRegionS
-      \pepsNormalSingleSiteDifference
-      \node at (1.00,0.98) {$S=R\cup\{v\}$};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.90]
+        \begin{scope}
+            \clip (-0.25,0.75) rectangle (2.25,3.25);
+            \pepsNormalSquareLattice
+            \pepsNormalRegionR
+            \pepsNormalSingleSiteDifference
+            \node at (1.00,0.98) {$R$};
+        \end{scope}
+        \node at (2.85,2.00) {$\subset$};
+        \begin{scope}[xshift=3.55cm]
+            \clip (-0.25,0.75) rectangle (2.25,3.25);
+            \pepsNormalSquareLattice
+            \pepsNormalRegionS
+            \pepsNormalSingleSiteDifference
+            \node at (1.00,0.98) {$S=R\cup\{v\}$};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalEdgeBlockingReduction}{%
-  \begin{tikzpicture}[tn picture, scale=0.90]
-    \begin{scope}
-      \clip (-0.25,-0.25) rectangle (3.25,3.25);
-      \pepsNormalComplementBlock
-      \pepsNormalSquareLatticeLines
-      \pepsNormalDistinguishedEdge
-      \pepsNormalSquareLatticeDots
-      \pepsNormalRedBlock
-      \pepsNormalBlueBlock
-    \end{scope}
-    \node at (3.75,1.45) {$\Rightarrow$};
-    \begin{scope}[xshift=4.45cm,yshift=1.50cm]
-      \pepsBlockedNormalChain
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.90]
+        \begin{scope}
+            \clip (-0.25,-0.25) rectangle (3.25,3.25);
+            \pepsNormalComplementBlock
+            \pepsNormalSquareLatticeLines
+            \pepsNormalDistinguishedEdge
+            \pepsNormalSquareLatticeDots
+            \pepsNormalRedBlock
+            \pepsNormalBlueBlock
+        \end{scope}
+        \node at (3.75,1.45) {$\Rightarrow$};
+        \begin{scope}[xshift=4.45cm,yshift=1.50cm]
+            \pepsBlockedNormalChain
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalEdgeBlockingHypotheses}{%
-  \begin{tikzpicture}[tn picture, scale=0.90]
-    \clip (-0.25,-0.25) rectangle (3.25,3.25);
-    \pepsNormalComplementBlock
-    \pepsNormalSquareLatticeLines
-    \pepsNormalDistinguishedEdge
-    \pepsNormalSquareLatticeDots
-    \pepsNormalRedBlock
-    \pepsNormalBlueBlock
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.90]
+        \clip (-0.25,-0.25) rectangle (3.25,3.25);
+        \pepsNormalComplementBlock
+        \pepsNormalSquareLatticeLines
+        \pepsNormalDistinguishedEdge
+        \pepsNormalSquareLatticeDots
+        \pepsNormalRedBlock
+        \pepsNormalBlueBlock
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSNormalBlockingHypotheses}{%
-  \begin{tikzpicture}[tn picture, scale=0.72]
-    \begin{scope}
-      \clip (-0.25,-0.25) rectangle (3.25,3.25);
-      \pepsNormalComplementBlock
-      \pepsNormalSquareLatticeLines
-      \pepsNormalDistinguishedEdge
-      \pepsNormalSquareLatticeDots
-      \pepsNormalRedBlock
-      \pepsNormalBlueBlock
-    \end{scope}
-    \node at (1.50,-0.58) {edge blocking};
-    \node at (3.75,1.45) {and};
-    \begin{scope}[xshift=4.60cm,yshift=-0.20cm]
-      \begin{scope}
-        \clip (-0.25,0.75) rectangle (2.25,3.25);
-        \pepsNormalSquareLattice
-        \pepsNormalRegionR
-        \pepsNormalSingleSiteDifference
-        \node at (1.00,0.98) {$R$};
-      \end{scope}
-      \node at (2.85,2.00) {$\subset$};
-      \begin{scope}[xshift=3.55cm]
-        \clip (-0.25,0.75) rectangle (2.25,3.25);
-        \pepsNormalSquareLattice
-        \pepsNormalRegionS
-        \pepsNormalSingleSiteDifference
-        \node at (1.00,0.98) {$S=R\cup\{v\}$};
-      \end{scope}
-      \node at (2.85,0.98) {one-site comparison};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture, scale=0.72]
+        \begin{scope}
+            \clip (-0.25,-0.25) rectangle (3.25,3.25);
+            \pepsNormalComplementBlock
+            \pepsNormalSquareLatticeLines
+            \pepsNormalDistinguishedEdge
+            \pepsNormalSquareLatticeDots
+            \pepsNormalRedBlock
+            \pepsNormalBlueBlock
+        \end{scope}
+        \node at (1.50,-0.58) {edge blocking};
+        \node at (3.75,1.45) {and};
+        \begin{scope}[xshift=4.60cm,yshift=-0.20cm]
+            \begin{scope}
+                \clip (-0.25,0.75) rectangle (2.25,3.25);
+                \pepsNormalSquareLattice
+                \pepsNormalRegionR
+                \pepsNormalSingleSiteDifference
+                \node at (1.00,0.98) {$R$};
+            \end{scope}
+            \node at (2.85,2.00) {$\subset$};
+            \begin{scope}[xshift=3.55cm]
+                \clip (-0.25,0.75) rectangle (2.25,3.25);
+                \pepsNormalSquareLattice
+                \pepsNormalRegionS
+                \pepsNormalSingleSiteDifference
+                \node at (1.00,0.98) {$S=R\cup\{v\}$};
+            \end{scope}
+            \node at (2.85,0.98) {one-site comparison};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSTINormalGaugeAbsorption}{%
-  \begin{tikzpicture}[tn picture]
-    \begin{scope}
-      \pepsSquareTensor{tiB}{(0,0)}
-      \node at ($(tiB.south)+(0,-0.88)$) {$B$};
-    \end{scope}
-    \node at (1.25,0) {$=$};
-    \begin{scope}[xshift=2.35cm]
-      \node[tn tensor dot] (tiA) at (0,0) {};
-      \node[tn operator dot, label=left:$X$] (tiXL) at (-0.76,0) {};
-      \node[tn operator dot, label=right:$X^{-1}$] (tiXR) at (0.76,0) {};
-      \node[tn operator dot, label=below:$Y$] (tiYD) at (0,-0.76) {};
-      \node[tn operator dot, label=above:$Y^{-1}$] (tiYU) at (0,0.76) {};
-      \draw[tn phys leg] (tiA.north) -- ++(0,0.46);
-      \draw[tn leg] (tiXL.west) -- ++(-0.24,0);
-      \draw[tn leg] (tiXL.east) -- (tiA.west);
-      \draw[tn leg] (tiA.east) -- (tiXR.west);
-      \draw[tn leg] (tiXR.east) -- ++(0.24,0);
-      \draw[tn leg] (tiYD.south) -- ++(0,-0.24);
-      \draw[tn leg] (tiYD.north) -- (tiA.south);
-      \draw[tn leg] (tiA.north) -- (tiYU.south);
-      \draw[tn leg] (tiYU.north) -- ++(0,0.24);
-      \node at ($(tiA.south)+(0,-1.20)$) {$\lambda A$};
-    \end{scope}
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \begin{scope}
+            \pepsSquareTensor{tiB}{(0,0)}
+            \node at ($(tiB.south)+(0,-0.88)$) {$B$};
+        \end{scope}
+        \node at (1.25,0) {$=$};
+        \begin{scope}[xshift=2.35cm]
+            \node[tn tensor dot] (tiA) at (0,0) {};
+            \node[tn operator dot, label=left:$X$] (tiXL) at (-0.76,0) {};
+            \node[tn operator dot, label=right:$X^{-1}$] (tiXR) at (0.76,0) {};
+            \node[tn operator dot, label=below:$Y$] (tiYD) at (0,-0.76) {};
+            \node[tn operator dot, label=above:$Y^{-1}$] (tiYU) at (0,0.76) {};
+            \draw[tn phys leg] (tiA.north) -- ++(0,0.46);
+            \draw[tn leg] (tiXL.west) -- ++(-0.24,0);
+            \draw[tn leg] (tiXL.east) -- (tiA.west);
+            \draw[tn leg] (tiA.east) -- (tiXR.west);
+            \draw[tn leg] (tiXR.east) -- ++(0.24,0);
+            \draw[tn leg] (tiYD.south) -- ++(0,-0.24);
+            \draw[tn leg] (tiYD.north) -- (tiA.south);
+            \draw[tn leg] (tiA.north) -- (tiYU.south);
+            \draw[tn leg] (tiYU.north) -- ++(0,0.24);
+            \node at ($(tiA.south)+(0,-1.20)$) {$\lambda A$};
+        \end{scope}
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSEdgeGaugeOrientation}{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnU}{(0,0)}
-    \TN@tensordot{tnW}{(3.30,0)}
-    \TN@opdotabove{tnXl}{(1.00,0)}{X_e}
-    \TN@opdotabove{tnXr}{(2.30,0)}{(X_e^{-1})^\top}
-    \draw[tn leg] (tnU.east) -- (tnXl.west);
-    \draw[tn leg] (tnXl.east) -- (tnXr.west);
-    \draw[tn leg] (tnXr.east) -- (tnW.west);
-    \node at (1.65,0.72) {$e = (u,w)$};
-    \node at ($(tnU.south)+(0,-0.28)$) {$u$};
-    \node at ($(tnW.south)+(0,-0.28)$) {$w$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnU}{(0,0)}
+        \TN@tensordot{tnW}{(3.30,0)}
+        \TN@opdotabove{tnXl}{(1.00,0)}{X_e}
+        \TN@opdotabove{tnXr}{(2.30,0)}{(X_e^{-1})^\top}
+        \draw[tn leg] (tnU.east) -- (tnXl.west);
+        \draw[tn leg] (tnXl.east) -- (tnXr.west);
+        \draw[tn leg] (tnXr.east) -- (tnW.west);
+        \node at (1.65,0.72) {$e = (u,w)$};
+        \node at ($(tnU.south)+(0,-0.28)$) {$u$};
+        \node at ($(tnW.south)+(0,-0.28)$) {$w$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSGaugeVertexAction}{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnV}{(0,0)}
-    \TN@opdotleft{tnL}{(-1.05,0)}{M_{ve_1}}
-    \TN@opdotright{tnR}{(1.05,0)}{M_{ve_2}}
-    \TN@opdotbelow{tnDL}{(-0.78,-0.92)}{M_{ve_3}}
-    \TN@opdotbelow{tnDR}{(0.78,-0.92)}{M_{ve_4}}
-    \draw[tn leg] (tnL.east) -- (tnV.west);
-    \draw[tn leg] (tnV.east) -- (tnR.west);
-    \draw[tn leg] ($(tnV.south)-(0.2,0)$) -- (tnDL.north);
-    \draw[tn leg] ($(tnV.south)+(0.2,0)$) -- (tnDR.north);
-    \draw[tn leg] (tnL.west) -- ++(-0.42,0);
-    \draw[tn leg] (tnR.east) -- ++(0.42,0);
-    \draw[tn leg] (tnDL.south) -- ++(-0.30,-0.42);
-    \draw[tn leg] (tnDR.south) -- ++(0.30,-0.42);
-    \TN@upleg{tnV}{0.54}
-    \TN@uplabel{tnV}{0.80}{\sigma}
-    \node at ($(tnV.south)+(0,-1.45)$) {$A_v \mapsto A_v^X$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnV}{(0,0)}
+        \TN@opdotleft{tnL}{(-1.05,0)}{M_{ve_1}}
+        \TN@opdotright{tnR}{(1.05,0)}{M_{ve_2}}
+        \TN@opdotbelow{tnDL}{(-0.78,-0.92)}{M_{ve_3}}
+        \TN@opdotbelow{tnDR}{(0.78,-0.92)}{M_{ve_4}}
+        \draw[tn leg] (tnL.east) -- (tnV.west);
+        \draw[tn leg] (tnV.east) -- (tnR.west);
+        \draw[tn leg] ($(tnV.south)-(0.2,0)$) -- (tnDL.north);
+        \draw[tn leg] ($(tnV.south)+(0.2,0)$) -- (tnDR.north);
+        \draw[tn leg] (tnL.west) -- ++(-0.42,0);
+        \draw[tn leg] (tnR.east) -- ++(0.42,0);
+        \draw[tn leg] (tnDL.south) -- ++(-0.30,-0.42);
+        \draw[tn leg] (tnDR.south) -- ++(0.30,-0.42);
+        \TN@upleg{tnV}{0.54}
+        \TN@uplabel{tnV}{0.80}{\sigma}
+        \node at ($(tnV.south)+(0,-1.45)$) {$A_v \mapsto A_v^X$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSGaugeCancellation}{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnL}{(0,0)}
-    \TN@opdot{tnX}{(0.92,0)}
-    \TN@opdot{tnXt}{(2.18,0)}
-    \TN@tensordot{tnR}{(3.10,0)}
-    \draw[tn leg] (tnL.east) -- (tnX.west);
-    \draw[tn leg] (tnX.east) -- (tnXt.west);
-    \draw[tn leg] (tnXt.east) -- (tnR.west);
-    \node at ($(tnX.north)+(0,0.28)$) {$X_e(j,i)$};
-    \node at ($(tnXt.north)+(0,0.28)$) {$((X_e^{-1})^\top)(j,k)$};
-    \node at (4.20,0) {$=$};
-    \TN@tensordot{tnL2}{(5.15,0)}
-    \TN@tensordot{tnR2}{(6.65,0)}
-    \draw[tn leg] (tnL2.east) -- (tnR2.west);
-    \node at (5.90,0.54) {$\sum_j X_e(j,i)\,((X_e^{-1})^\top)(j,k) = \delta(i,k)$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnL}{(0,0)}
+        \TN@opdot{tnX}{(0.92,0)}
+        \TN@opdot{tnXt}{(2.18,0)}
+        \TN@tensordot{tnR}{(3.10,0)}
+        \draw[tn leg] (tnL.east) -- (tnX.west);
+        \draw[tn leg] (tnX.east) -- (tnXt.west);
+        \draw[tn leg] (tnXt.east) -- (tnR.west);
+        \node at ($(tnX.north)+(0,0.28)$) {$X_e(j,i)$};
+        \node at ($(tnXt.north)+(0,0.28)$) {$((X_e^{-1})^\top)(j,k)$};
+        \node at (4.20,0) {$=$};
+        \TN@tensordot{tnL2}{(5.15,0)}
+        \TN@tensordot{tnR2}{(6.65,0)}
+        \draw[tn leg] (tnL2.east) -- (tnR2.west);
+        \node at (5.90,0.54) {$\sum_j X_e(j,i)\,((X_e^{-1})^\top)(j,k) = \delta(i,k)$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSBlockedMiddleLocalGaugeFormula}{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{bmA}{(0,0)}
-    \TN@tensordot{bmB}{(2.55,0)}
-    \draw[tn leg] (bmA) -- ++(40:0.55);
-    \draw[tn leg] (bmA) -- ++(100:0.55);
-    \draw[tn leg] (bmA) -- ++(160:0.55);
-    \draw[tn leg] (bmA) -- ++(220:0.55);
-    \draw[tn leg] (bmA) -- ++(300:0.55);
-    \draw[tn leg] (bmB) -- ++(40:0.55);
-    \draw[tn leg] (bmB) -- ++(100:0.55);
-    \draw[tn leg] (bmB) -- ++(160:0.55);
-    \draw[tn leg] (bmB) -- ++(220:0.55);
-    \draw[tn leg] (bmB) -- ++(300:0.55);
-    \draw[tn phys leg] (bmA.north) -- ++(0,0.62);
-    \draw[tn phys leg] (bmB.north) -- ++(0,0.62);
-    \node at ($(bmA)+(0,-0.62)$) {$A_v$};
-    \node at ($(bmB)+(0,-0.62)$) {$B_v$};
-    \node at (1.28,0.25) {$\prod_{e\ni v}X_e$};
-    \draw[->,tn leg] (0.62,0) -- (1.93,0);
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{bmA}{(0,0)}
+        \TN@tensordot{bmB}{(2.55,0)}
+        \draw[tn leg] (bmA) -- ++(40:0.55);
+        \draw[tn leg] (bmA) -- ++(100:0.55);
+        \draw[tn leg] (bmA) -- ++(160:0.55);
+        \draw[tn leg] (bmA) -- ++(220:0.55);
+        \draw[tn leg] (bmA) -- ++(300:0.55);
+        \draw[tn leg] (bmB) -- ++(40:0.55);
+        \draw[tn leg] (bmB) -- ++(100:0.55);
+        \draw[tn leg] (bmB) -- ++(160:0.55);
+        \draw[tn leg] (bmB) -- ++(220:0.55);
+        \draw[tn leg] (bmB) -- ++(300:0.55);
+        \draw[tn phys leg] (bmA.north) -- ++(0,0.62);
+        \draw[tn phys leg] (bmB.north) -- ++(0,0.62);
+        \node at ($(bmA)+(0,-0.62)$) {$A_v$};
+        \node at ($(bmB)+(0,-0.62)$) {$B_v$};
+        \node at (1.28,0.25) {$\prod_{e\ni v}X_e$};
+        \draw[->,tn leg] (0.62,0) -- (1.93,0);
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSLocalGaugeExtraction}{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnLv}{(0,0)}
-    \TN@upleg{tnLv}{0.50}
-    \TN@uplabel{tnLv}{0.76}{\sigma}
-    \draw[tn leg] (tnLv.west) -- ++(-0.90,0);
-    \draw[tn leg] (tnLv.east) -- ++(0.90,0);
-    \draw[tn leg] ($(tnLv.south)-(0.2,0)$) -- ++(-0.72,-0.82);
-    \draw[tn leg] ($(tnLv.south)+(0.2,0)$) -- ++(0.72,-0.82);
-    \node at (0,-1.42) {$\mathrm{star}(v)$};
-    \node at (2.85,0) {$\xrightarrow[\text{left inverse}]{\text{injective}}$};
-    \TN@tensordot{tnRv}{(5.70,0)}
-    \TN@upleg{tnRv}{0.50}
-    \TN@uplabel{tnRv}{0.76}{\sigma}
-    \TN@opdot{tnRl}{(4.62,0)}
-    \TN@opdot{tnRr}{(6.78,0)}
-    \TN@opdot{tnRdl}{(4.95,-0.86)}
-    \TN@opdot{tnRdr}{(6.45,-0.86)}
-    \draw[tn leg] (tnRl.west) -- ++(-0.42,0);
-    \draw[tn leg] (tnRl.east) -- (tnRv.west);
-    \draw[tn leg] (tnRv.east) -- (tnRr.west);
-    \draw[tn leg] (tnRr.east) -- ++(0.42,0);
-    \draw[tn leg] ($(tnRv.south)-(0.2,0)$) -- (tnRdl.north);
-    \draw[tn leg] ($(tnRv.south)+(0.2,0)$) -- (tnRdr.north);
-    \node at (5.70,-1.42) {$\text{local edge gauges}$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnLv}{(0,0)}
+        \TN@upleg{tnLv}{0.50}
+        \TN@uplabel{tnLv}{0.76}{\sigma}
+        \draw[tn leg] (tnLv.west) -- ++(-0.90,0);
+        \draw[tn leg] (tnLv.east) -- ++(0.90,0);
+        \draw[tn leg] ($(tnLv.south)-(0.2,0)$) -- ++(-0.72,-0.82);
+        \draw[tn leg] ($(tnLv.south)+(0.2,0)$) -- ++(0.72,-0.82);
+        \node at (0,-1.42) {$\mathrm{star}(v)$};
+        \node at (2.85,0) {$\xrightarrow[\text{left inverse}]{\text{injective}}$};
+        \TN@tensordot{tnRv}{(5.70,0)}
+        \TN@upleg{tnRv}{0.50}
+        \TN@uplabel{tnRv}{0.76}{\sigma}
+        \TN@opdot{tnRl}{(4.62,0)}
+        \TN@opdot{tnRr}{(6.78,0)}
+        \TN@opdot{tnRdl}{(4.95,-0.86)}
+        \TN@opdot{tnRdr}{(6.45,-0.86)}
+        \draw[tn leg] (tnRl.west) -- ++(-0.42,0);
+        \draw[tn leg] (tnRl.east) -- (tnRv.west);
+        \draw[tn leg] (tnRv.east) -- (tnRr.west);
+        \draw[tn leg] (tnRr.east) -- ++(0.42,0);
+        \draw[tn leg] ($(tnRv.south)-(0.2,0)$) -- (tnRdl.north);
+        \draw[tn leg] ($(tnRv.south)+(0.2,0)$) -- (tnRdr.north);
+        \node at (5.70,-1.42) {$\text{local edge gauges}$};
+    \end{tikzpicture}%
 }
 
 \newcommand{\TNPEPSGlobalConsistency}{%
-  \begin{tikzpicture}[tn picture]
-    \TN@tensordot{tnU}{(0,0)}
-    \TN@tensordot{tnW}{(3.35,0)}
-    \TN@upleg{tnU}{0.44}
-    \TN@upleg{tnW}{0.44}
-    \draw[tn leg] (tnU.west) -- ++(-0.70,0);
-    \draw[tn leg] (tnW.east) -- ++(0.70,0);
-    \draw[tn leg] (tnU.south) -- ++(-0.55,-0.68);
-    \draw[tn leg] (tnW.south) -- ++(0.55,-0.68);
-    \TN@opdotabove{tnXl}{(1.02,0)}{X_e}
-    \TN@opdotabove{tnXr}{(2.33,0)}{(X_e^{-1})^\top}
-    \draw[tn leg] (tnU.east) -- (tnXl.west);
-    \draw[tn leg] (tnXl.east) -- (tnXr.west);
-    \draw[tn leg] (tnXr.east) -- (tnW.west);
-    \node at (1.67,0.78) {$\text{shared edge } e$};
-    \node at ($(tnU.south)+(0,-0.28)$) {$u$};
-    \node at ($(tnW.south)+(0,-0.28)$) {$w$};
-  \end{tikzpicture}%
+    \begin{tikzpicture}[tn picture]
+        \TN@tensordot{tnU}{(0,0)}
+        \TN@tensordot{tnW}{(3.35,0)}
+        \TN@upleg{tnU}{0.44}
+        \TN@upleg{tnW}{0.44}
+        \draw[tn leg] (tnU.west) -- ++(-0.70,0);
+        \draw[tn leg] (tnW.east) -- ++(0.70,0);
+        \draw[tn leg] (tnU.south) -- ++(-0.55,-0.68);
+        \draw[tn leg] (tnW.south) -- ++(0.55,-0.68);
+        \TN@opdotabove{tnXl}{(1.02,0)}{X_e}
+        \TN@opdotabove{tnXr}{(2.33,0)}{(X_e^{-1})^\top}
+        \draw[tn leg] (tnU.east) -- (tnXl.west);
+        \draw[tn leg] (tnXl.east) -- (tnXr.west);
+        \draw[tn leg] (tnXr.east) -- (tnW.west);
+        \node at (1.67,0.78) {$\text{shared edge } e$};
+        \node at ($(tnU.south)+(0,-0.28)$) {$u$};
+        \node at ($(tnW.south)+(0,-0.28)$) {$w$};
+    \end{tikzpicture}%
 }
 
 \makeatother


### PR DESCRIPTION
### Motivation
- The standalone `Check blueprint compiles without errors` workflow currently fails on `main` during its repository-wide `latexindent` step.
- PR #2717 is approved and green except for that inherited formatter gate, so this PR isolates the mechanical formatting cleanup rather than mixing it into a mathematical parent-Hamiltonian change.

### Description
- Run `latexindent -l blueprint/latexindent.yaml -w -s` on the 29 `.tex` files that failed the current `latexindent -k` gate.
- The diff is whitespace-only under `git diff -w`.
- No Lean files, theorem statements, blueprint labels, or mathematical prose are intentionally changed.

### Testing
- Repository-wide latexindent gate:
  ```sh
  set -e
  bad=0
  while IFS= read -r f; do
    if ! latexindent -k -s -l blueprint/latexindent.yaml "$f" > /dev/null; then
      printf '%s\n' "$f"
      bad=1
    fi
  done < <(find blueprint/src -name '*.tex' -not -path '*/Packages/*')
  exit $bad
  ```
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint/src && find . -name '*.tex' -not -path '*/Packages/*' -print0 | xargs -0 -r chktex -q -l ../.chktexrc`
- `git diff --check`
- `cd blueprint && leanblueprint web` (exit code 0 locally; local Python/plasTeX environment emits pre-existing warning noise)

Refs #2717

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic LaTeX formatting with no logic or proof-content changes; risk is limited to accidental non-whitespace edits, which the PR explicitly avoids.
> 
> **Overview**
> Runs **`latexindent`** (with `blueprint/latexindent.yaml`) on **29 blueprint chapter/macro `.tex` files** that failed the repo-wide **`latexindent -k`** check, unblocking the standalone blueprint compile workflow.
> 
> The diff is **whitespace and layout only** (`git diff -w` is empty): wrapped equation continuations, matrix/cases alignment, `align`/`aligned` spacing, and re-indented TikZ/macro bodies in `print.tex`, `tn_core.tex`, and `tn_print.tex`. **No** Lean, labels, theorem statements, or intentional prose edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce3ca502bb4b0c2d8395e74b0aa6b728922f21b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->