### PR TITLE
feat(PEPS): Lemma 5 in its site-dependent form and the site-dependent closed-chain corollary

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -640,6 +640,9 @@ import TNLean.PEPS.CycleMPSOverlapWindow
 -- The site-dependent insertion correspondence: the algebra homomorphism of
 -- Lemma 5 and the per-bond conjugation between same-state chains.
 import TNLean.PEPS.CycleMPSChainOverlapInsertion
+-- The site-dependent closed-chain corollary at n ≥ 2L+1: same-state
+-- window-injective chains are gauge equivalent, one gauge per bond.
+import TNLean.PEPS.CycleMPSChainOverlapCapstone
 -- The insertion correspondence: same closed-chain state at one length
 -- n ≥ 2L+1 gives conjugate word products at that length.
 import TNLean.PEPS.CycleMPSOverlapInsertion

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -627,6 +627,10 @@ import TNLean.PEPS.CycleMPSTranslationInvariant
 -- Word-span extension and word transport for block-injective matrix tensors,
 -- the linear-algebraic inputs of the overlapping-window route.
 import TNLean.PEPS.CycleMPSWordTransport
+-- Arc products, window injectivity and rotated-state reading for
+-- site-dependent closed chains, the vocabulary of the site-dependent
+-- overlapping-window route.
+import TNLean.PEPS.CycleMPSChainArc
 -- Lemma 5 of arXiv:1804.04964 for matrix tensors: bond-operator extraction
 -- from overlapping injective windows on the closed chain.
 import TNLean.PEPS.CycleMPSOverlapWindow

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -631,6 +631,9 @@ import TNLean.PEPS.CycleMPSWordTransport
 -- site-dependent closed chains, the vocabulary of the site-dependent
 -- overlapping-window route.
 import TNLean.PEPS.CycleMPSChainArc
+-- Lemma 5 of arXiv:1804.04964 for site-dependent matrix tensors:
+-- bond-operator extraction from overlapping injective windows.
+import TNLean.PEPS.CycleMPSChainOverlapWindow
 -- Lemma 5 of arXiv:1804.04964 for matrix tensors: bond-operator extraction
 -- from overlapping injective windows on the closed chain.
 import TNLean.PEPS.CycleMPSOverlapWindow

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -637,6 +637,9 @@ import TNLean.PEPS.CycleMPSChainOverlapWindow
 -- Lemma 5 of arXiv:1804.04964 for matrix tensors: bond-operator extraction
 -- from overlapping injective windows on the closed chain.
 import TNLean.PEPS.CycleMPSOverlapWindow
+-- The site-dependent insertion correspondence: the algebra homomorphism of
+-- Lemma 5 and the per-bond conjugation between same-state chains.
+import TNLean.PEPS.CycleMPSChainOverlapInsertion
 -- The insertion correspondence: same closed-chain state at one length
 -- n ≥ 2L+1 gives conjugate word products at that length.
 import TNLean.PEPS.CycleMPSOverlapInsertion

--- a/TNLean/PEPS/CycleMPSChainArc.lean
+++ b/TNLean/PEPS/CycleMPSChainArc.lean
@@ -1,0 +1,379 @@
+import TNLean.MPS.Chain.Defs
+import TNLean.Algebra.TracePairing
+
+/-!
+# Arc products and window injectivity for site-dependent closed chains
+
+This file provides the site-dependent vocabulary for the overlapping-window
+route to the closed-chain corollaries of the Fundamental Theorem for normal
+PEPS (arXiv:1804.04964, Section `normal_alt`, lines 1915--2295 of
+`Papers/1804.04964/paper_normal.tex`).  The source states its Lemma 5 (lines
+2045--2255) for site-dependent tensors `A_1, …, A_5` on five sites whose
+two-site windows are injective; the previously landed development
+(`TNLean/PEPS/CycleMPSOverlapWindow.lean` and its consumers) specializes to
+one site-independent tensor.  Here the closed chain carries a family of
+tensors, one per site (`MPSChainTensor d D n`), and the basic objects are
+
+* `MPSChainTensor.arcEval`: the ordered product of the letters of a word
+  along an arc of consecutive sites, starting at a given site of the closed
+  chain; site indices wrap around the chain.
+* `MPSChainTensor.IsWindowInjective`: every window of `L` consecutive sites
+  is injective — the word products of the window span the full matrix
+  algebra (the source's "the blocking of any two consecutive tensors is
+  injective", lines 1928--1940, for the general window length `L`).
+* `MPSChainTensor.IsWindowInjective.arc_span`: every arc of at least `L`
+  sites is then injective as well — the site-dependent form of "any region
+  of at least size two is also injective" (line 1940).
+* `MPSChainTensor.SameState.trace_arcEval_eq`: equality of the closed-chain
+  states read on words based at an arbitrary site, by rotating the trace
+  once around the chain.
+
+The file also records the spanning-family forms of the trace-stripping and
+factor-uniqueness arguments used by the route
+(`eq_of_trace_pairing_span`, `eq_of_span_mul_left`, `eq_of_mul_span_right`),
+stated for an arbitrary spanning family of matrices so that both the
+site-independent word products and the site-dependent arc products feed
+them.
+
+**Scope restriction (uniform physical and bond dimensions):** the source
+poses no restriction on the local dimensions of the site-dependent tensors,
+while here all sites share one physical dimension `d` and all bonds one bond
+dimension `D`, matching the chain vocabulary of `TNLean/MPS/Chain/Defs.lean`.
+Documented in `docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section `normal_alt`, lines 1915--2295 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+open scoped Fin.NatCast
+
+namespace MPSChainTensor
+
+variable {d D n : ℕ}
+
+/-! ### Arc products along the closed chain -/
+
+/-- **The arc product of a site-dependent chain** (arXiv:1804.04964, the
+site-dependent windows of Section `normal_alt`, lines 1915--2255 of
+`Papers/1804.04964/paper_normal.tex`).  The word `w` is read on the arc of
+consecutive sites starting at site `s` of the closed chain: the first letter
+is contracted with the tensor at site `s`, the second with the tensor at
+site `s + 1`, and so on, indices wrapping around the chain. -/
+def arcEval [NeZero n] (A : MPSChainTensor d D n) :
+    ℕ → List (Fin d) → Matrix (Fin D) (Fin D) ℂ
+  | _, [] => 1
+  | s, i :: w => A (s : Fin n) i * arcEval A (s + 1) w
+
+@[simp] lemma arcEval_nil [NeZero n] (A : MPSChainTensor d D n) (s : ℕ) :
+    arcEval A s [] = 1 := rfl
+
+@[simp] lemma arcEval_cons [NeZero n] (A : MPSChainTensor d D n) (s : ℕ)
+    (i : Fin d) (w : List (Fin d)) :
+    arcEval A s (i :: w) = A (s : Fin n) i * arcEval A (s + 1) w := rfl
+
+/-- Concatenation splits the arc product at the matching intermediate
+site. -/
+lemma arcEval_append [NeZero n] (A : MPSChainTensor d D n) (s : ℕ)
+    (w₁ w₂ : List (Fin d)) :
+    arcEval A s (w₁ ++ w₂) = arcEval A s w₁ * arcEval A (s + w₁.length) w₂ := by
+  induction w₁ generalizing s with
+  | nil => simp
+  | cons i w₁ ih =>
+      rw [List.cons_append, arcEval_cons, arcEval_cons, ih (s + 1),
+        Matrix.mul_assoc, List.length_cons,
+        show s + (w₁.length + 1) = s + 1 + w₁.length by omega]
+
+/-- The arc product depends on its starting site only through its residue on
+the closed chain. -/
+lemma arcEval_add_n [NeZero n] (A : MPSChainTensor d D n) (s : ℕ)
+    (w : List (Fin d)) : arcEval A (s + n) w = arcEval A s w := by
+  induction w generalizing s with
+  | nil => simp
+  | cons i w ih =>
+      rw [arcEval_cons, arcEval_cons, show s + n + 1 = s + 1 + n by omega, ih,
+        Nat.cast_add, Fin.natCast_self, add_zero]
+
+/-- The arc product depends on its starting site only modulo the chain
+length. -/
+lemma arcEval_mod [NeZero n] (A : MPSChainTensor d D n) (s : ℕ)
+    (w : List (Fin d)) : arcEval A (s % n) w = arcEval A s w := by
+  have hn : 0 < n := Nat.pos_of_ne_zero (NeZero.ne n)
+  induction s using Nat.strong_induction_on with
+  | _ s ih =>
+      rcases lt_or_ge s n with hs | hs
+      · rw [Nat.mod_eq_of_lt hs]
+      · conv_rhs => rw [show s = s - n + n by omega]
+        rw [arcEval_add_n, Nat.mod_eq_sub_mod hs]
+        exact ih (s - n) (by omega)
+
+/-- On the constant chain the arc product is the word product of the
+repeated tensor. -/
+lemma arcEval_const [NeZero n] (B : MPSTensor d D) (s : ℕ) (w : List (Fin d)) :
+    arcEval (fun _ : Fin n => B) s w = MPSTensor.evalWord B w := by
+  induction w generalizing s with
+  | nil => rfl
+  | cons i w ih => rw [arcEval_cons, MPSTensor.evalWord_cons, ih (s + 1)]
+
+/-- The arc product of the word of the first `k + 1` letters of a tuple
+peels its last letter at the matching site. -/
+lemma arcEval_take_succ [NeZero n] (A : MPSChainTensor d D n) (s : ℕ)
+    {L k : ℕ} (hk : k + 1 ≤ L) (f : Fin L → Fin d) :
+    arcEval A s (List.ofFn fun i : Fin (k + 1) => f (Fin.castLE hk i)) =
+      arcEval A s (List.ofFn fun i : Fin k => f (Fin.castLE (by omega) i)) *
+        A ((s + k : ℕ) : Fin n) (f ⟨k, by omega⟩) := by
+  have hsnoc : (List.ofFn fun i : Fin (k + 1) => f (Fin.castLE hk i)) =
+      (List.ofFn fun i : Fin k => f (Fin.castLE (by omega) i)) ++ [f ⟨k, by omega⟩] := by
+    rw [List.ofFn_succ' fun i : Fin (k + 1) => f (Fin.castLE hk i),
+      List.concat_eq_append]
+    congr 1
+  rw [hsnoc, arcEval_append, List.length_ofFn, arcEval_cons, arcEval_nil,
+    Matrix.mul_one]
+
+/-! ### Window injectivity and arc spanning -/
+
+/-- **Window injectivity of a site-dependent chain** (arXiv:1804.04964,
+Section `normal_alt`: "the blocking of any two consecutive tensors … is
+injective", lines 1928--1940 of `Papers/1804.04964/paper_normal.tex`, for a
+general window length `L`).  Every window of `L` consecutive sites of the
+closed chain is injective: the arc products of the window span the full
+matrix algebra.  The starting site ranges over `ℕ`; by
+`MPSChainTensor.arcEval_mod` this quantifies exactly over the `n` windows of
+the chain. -/
+def IsWindowInjective [NeZero n] (A : MPSChainTensor d D n) (L : ℕ) : Prop :=
+  ∀ s : ℕ, Submodule.span ℂ (Set.range fun a : Fin L → Fin d =>
+    arcEval A s (List.ofFn a)) = ⊤
+
+/-- A site-independent block-injective tensor is window injective as a
+constant chain. -/
+theorem isWindowInjective_const [NeZero n] {B : MPSTensor d D} {L : ℕ}
+    (hB : MPSTensor.IsNBlkInjective B L) :
+    IsWindowInjective (fun _ : Fin n => B) L := by
+  intro s
+  have hcast : (fun a : Fin L → Fin d =>
+      arcEval (fun _ : Fin n => B) s (List.ofFn a)) =
+      fun a : Fin L → Fin d => MPSTensor.evalWord B (List.ofFn a) := by
+    funext a
+    exact arcEval_const B s (List.ofFn a)
+  rw [hcast]
+  exact hB
+
+/-- Left multiplication by the letter at the preceding site maps the full
+arc span one site downstream into the arc span one letter longer. -/
+private theorem mul_left_letter_mem_arc_span [NeZero n]
+    {A : MPSChainTensor d D n} {m s : ℕ}
+    (hm : Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
+      arcEval A (s + 1) (List.ofFn u)) = ⊤)
+    (i : Fin d) (Q : Matrix (Fin D) (Fin D) ℂ) :
+    A (s : Fin n) i * Q ∈ Submodule.span ℂ
+      (Set.range fun w : Fin (m + 1) → Fin d => arcEval A s (List.ofFn w)) := by
+  have hQ : Q ∈ Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
+      arcEval A (s + 1) (List.ofFn u)) := hm ▸ Submodule.mem_top
+  induction hQ using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨u, rfl⟩ := hx
+      show A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) ∈ _
+      have hcons : arcEval A s (List.ofFn (Fin.cons i u)) =
+          A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) := by
+        rw [List.ofFn_succ, arcEval_cons, Fin.cons_zero]
+        simp only [Fin.cons_succ]
+      exact Submodule.subset_span ⟨Fin.cons i u, hcons⟩
+  | zero => rw [Matrix.mul_zero]; exact Submodule.zero_mem _
+  | add x y _ _ hx hy => rw [Matrix.mul_add]; exact Submodule.add_mem _ hx hy
+  | smul c x _ hx => rw [mul_smul_comm]; exact Submodule.smul_mem _ c hx
+
+/-- **Arc spanning from window injectivity** (arXiv:1804.04964, Section
+`normal_alt`, line 1940 of `Papers/1804.04964/paper_normal.tex`: "any region
+of at least size two is also injective", site-dependent form for a general
+window length `L`).  If every window of `L > 0` consecutive sites is
+injective, then the arc products of any length `m ≥ L`, starting at any
+site, span the full matrix algebra: write the identity as a combination of
+window products at the starting site, peel the leading letter of each, and
+absorb the remainder into the spanning arcs one site downstream and one
+letter shorter. -/
+theorem IsWindowInjective.arc_span [NeZero n] {A : MPSChainTensor d D n}
+    {L : ℕ} (hL : 0 < L) (hA : IsWindowInjective A L) {m : ℕ} (hm : L ≤ m)
+    (s : ℕ) :
+    Submodule.span ℂ (Set.range fun ρ : Fin m → Fin d =>
+      arcEval A s (List.ofFn ρ)) = ⊤ := by
+  induction m, hm using Nat.le_induction generalizing s with
+  | base => exact hA s
+  | succ m hLm IH =>
+      obtain ⟨L', rfl⟩ : ∃ L', L = L' + 1 := ⟨L - 1, by omega⟩
+      rw [eq_top_iff]
+      intro P _
+      have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+          Submodule.span ℂ (Set.range fun v : Fin (L' + 1) → Fin d =>
+            arcEval A s (List.ofFn v)) := (hA s) ▸ Submodule.mem_top
+      obtain ⟨c, hc⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+      have hP : P = ∑ v : Fin (L' + 1) → Fin d,
+          c v • (arcEval A s (List.ofFn v) * P) := by
+        calc P = (1 : Matrix (Fin D) (Fin D) ℂ) * P := (one_mul P).symm
+          _ = (∑ v : Fin (L' + 1) → Fin d,
+                c v • arcEval A s (List.ofFn v)) * P := by rw [hc]
+          _ = ∑ v : Fin (L' + 1) → Fin d,
+                c v • (arcEval A s (List.ofFn v) * P) := by
+              rw [Finset.sum_mul]
+              exact Finset.sum_congr rfl fun v _ => smul_mul_assoc _ _ _
+      rw [hP]
+      refine Submodule.sum_mem _ fun v _ => Submodule.smul_mem _ _ ?_
+      have hsplit : arcEval A s (List.ofFn v) * P =
+          A (s : Fin n) (v 0) * (arcEval A (s + 1) (List.ofFn (Fin.tail v)) * P) := by
+        rw [List.ofFn_succ, arcEval_cons, Matrix.mul_assoc]
+        rfl
+      rw [hsplit]
+      exact mul_left_letter_mem_arc_span (IH (s + 1)) (v 0) _
+
+/-! ### Reading the closed-chain state on rotated arcs -/
+
+/-- The arc product of a word of tuple letters is the ordered product of the
+matrices selected at the rebased sites. -/
+private theorem arcEval_ofFn_eq_prod [NeZero n] (A : MPSChainTensor d D n) :
+    ∀ {m : ℕ} (g : Fin m → Fin n) (τ : Fin m → Fin d) (s : ℕ),
+      (∀ k : Fin m, ((s + k.val : ℕ) : Fin n) = g k) →
+      arcEval A s (List.ofFn τ) = Fin.prod fun k => A (g k) (τ k) := by
+  intro m
+  induction m with
+  | zero =>
+      intro g τ s hg
+      rw [List.ofFn_zero, arcEval_nil, Fin.prod_zero]
+  | succ m ih =>
+      intro g τ s hg
+      rw [List.ofFn_succ, arcEval_cons,
+        Fin.prod_succ fun k => A (g k) (τ k)]
+      congr 1
+      · rw [← hg 0]
+        norm_num
+      · exact ih (fun k => g k.succ) (fun k => τ k.succ) (s + 1) fun k => by
+          show ((s + 1 + k.val : ℕ) : Fin n) = g k.succ
+          rw [← hg k.succ]
+          congr 1
+          rw [Fin.val_succ]
+          omega
+
+/-- The closed-chain coefficient is the trace of the arc product based at
+site `0`. -/
+lemma coeff_eq_trace_arcEval [NeZero n] (A : MPSChainTensor d D n)
+    (σ : Fin n → Fin d) :
+    coeff A σ = Matrix.trace (arcEval A 0 (List.ofFn σ)) := by
+  rw [coeff_eq]
+  congr 1
+  rw [arcEval_ofFn_eq_prod A (fun k => k) σ 0 fun k => by
+    rw [Nat.zero_add, Fin.cast_val_eq_self]]
+  rfl
+
+/-- Rotating the closed trace one site forward: the leading letter moves to
+the end of the word, and the arc rebases one site downstream. -/
+private theorem trace_arcEval_rotate_one [NeZero n] (A : MPSChainTensor d D n)
+    (s : ℕ) (i : Fin d) {w : List (Fin d)} (hw : (i :: w).length = n) :
+    Matrix.trace (arcEval A s (i :: w)) =
+      Matrix.trace (arcEval A (s + 1) (w ++ [i])) := by
+  rw [arcEval_cons, Matrix.trace_mul_comm, arcEval_append, arcEval_cons,
+    arcEval_nil, Matrix.mul_one]
+  congr 2
+  have hlen : s + 1 + w.length = s + n := by
+    simp only [List.length_cons] at hw
+    omega
+  rw [hlen, Nat.cast_add, Fin.natCast_self, add_zero]
+
+/-- **The closed-chain state read on rotated arcs.**  Two site-dependent
+chains generating the same state have equal traces on full-length words
+based at every site, not only at site `0`: rotate the trace once around the
+chain (arXiv:1804.04964, the cyclic reading of the closed-chain state used
+throughout Section `normal_alt`, lines 1915--2295 of
+`Papers/1804.04964/paper_normal.tex`). -/
+theorem SameState.trace_arcEval_eq [NeZero n] {A B : MPSChainTensor d D n}
+    (hAB : SameState A B) (s : ℕ) {w : List (Fin d)} (hw : w.length = n) :
+    Matrix.trace (arcEval A s w) = Matrix.trace (arcEval B s w) := by
+  induction s generalizing w with
+  | zero =>
+      obtain ⟨σ, rfl⟩ : ∃ σ : Fin n → Fin d, List.ofFn σ = w := by
+        subst hw
+        exact ⟨w.get, List.ofFn_get w⟩
+      rw [← coeff_eq_trace_arcEval, ← coeff_eq_trace_arcEval]
+      exact hAB σ
+  | succ s ih =>
+      rcases w.eq_nil_or_concat' with rfl | ⟨u, j, rfl⟩
+      · rw [List.length_nil] at hw
+        exact absurd hw.symm (NeZero.ne n)
+      · have hlen : (j :: u).length = n := by
+          simpa using hw
+        rw [← trace_arcEval_rotate_one A s j hlen,
+          ← trace_arcEval_rotate_one B s j hlen]
+        exact ih hlen
+
+/-! ### Spanning-family stripping lemmas -/
+
+/-- **Trace stripping against a spanning family.**  Two matrices with the
+same trace pairing against a spanning family of matrices are equal — the
+spanning-family form of the uniqueness of virtual insertions
+(arXiv:1804.04964, lines 1940--1960 of
+`Papers/1804.04964/paper_normal.tex`). -/
+theorem eq_of_trace_pairing_span {ι : Sort*} {F : ι → Matrix (Fin D) (Fin D) ℂ}
+    (hspan : Submodule.span ℂ (Set.range F) = ⊤)
+    {M N : Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ i, Matrix.trace (M * F i) = Matrix.trace (N * F i)) : M = N := by
+  have hzero : ∀ Q : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace ((M - N) * Q) = 0 := by
+    intro Q
+    have hQ : Q ∈ Submodule.span ℂ (Set.range F) := hspan ▸ Submodule.mem_top
+    induction hQ using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨i, rfl⟩ := hx
+        rw [Matrix.sub_mul, Matrix.trace_sub, h i, sub_self]
+    | zero => rw [Matrix.mul_zero, Matrix.trace_zero]
+    | add x y _ _ hx hy => rw [Matrix.mul_add, Matrix.trace_add, hx, hy, add_zero]
+    | smul c x _ hx => rw [Matrix.mul_smul, Matrix.trace_smul, hx, smul_zero]
+  exact sub_eq_zero.mp (MPSTensor.trace_mul_right_eq_zero hzero)
+
+/-- **Uniqueness of a right factor against a spanning family** — the
+spanning-family form of the uniqueness of the bond operator
+(arXiv:1804.04964, Lemma 5: the maps to `X` "are uniquely defined", lines
+2045--2255 of `Papers/1804.04964/paper_normal.tex`).  Two matrices
+multiplying every member of a spanning family to the same product on the
+right are equal. -/
+theorem eq_of_span_mul_left {ι : Type*} [Fintype ι]
+    {W : ι → Matrix (Fin D) (Fin D) ℂ}
+    (hspan : Submodule.span ℂ (Set.range W) = ⊤)
+    {X X' : Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ i, W i * X = W i * X') : X = X' := by
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+      Submodule.span ℂ (Set.range W) := hspan ▸ Submodule.mem_top
+  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+  calc X = (1 : Matrix (Fin D) (Fin D) ℂ) * X := (Matrix.one_mul _).symm
+    _ = (∑ i, α i • W i) * X := by rw [hα]
+    _ = ∑ i, α i • (W i * X) := by
+        rw [Finset.sum_mul]
+        exact Finset.sum_congr rfl fun i _ => smul_mul_assoc _ _ _
+    _ = ∑ i, α i • (W i * X') := Finset.sum_congr rfl fun i _ => by rw [h i]
+    _ = (∑ i, α i • W i) * X' := by
+        rw [Finset.sum_mul]
+        exact Finset.sum_congr rfl fun i _ => (smul_mul_assoc _ _ _).symm
+    _ = X' := by rw [hα, Matrix.one_mul]
+
+/-- **Uniqueness of a left factor against a spanning family** — the mirror
+of `MPSChainTensor.eq_of_span_mul_left`. -/
+theorem eq_of_mul_span_right {ι : Type*} [Fintype ι]
+    {W : ι → Matrix (Fin D) (Fin D) ℂ}
+    (hspan : Submodule.span ℂ (Set.range W) = ⊤)
+    {X X' : Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ i, X * W i = X' * W i) : X = X' := by
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+      Submodule.span ℂ (Set.range W) := hspan ▸ Submodule.mem_top
+  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+  calc X = X * (1 : Matrix (Fin D) (Fin D) ℂ) := (Matrix.mul_one _).symm
+    _ = X * ∑ i, α i • W i := by rw [hα]
+    _ = ∑ i, α i • (X * W i) := by
+        rw [Finset.mul_sum]
+        exact Finset.sum_congr rfl fun i _ => mul_smul_comm _ _ _
+    _ = ∑ i, α i • (X' * W i) := Finset.sum_congr rfl fun i _ => by rw [h i]
+    _ = X' * ∑ i, α i • W i := by
+        rw [Finset.mul_sum]
+        exact Finset.sum_congr rfl fun i _ => (mul_smul_comm _ _ _).symm
+    _ = X' := by rw [hα, Matrix.mul_one]
+
+end MPSChainTensor

--- a/TNLean/PEPS/CycleMPSChainArc.lean
+++ b/TNLean/PEPS/CycleMPSChainArc.lean
@@ -176,7 +176,7 @@ private theorem mul_left_letter_mem_arc_span [NeZero n]
   induction hQ using Submodule.span_induction with
   | mem x hx =>
       obtain ⟨u, rfl⟩ := hx
-      show A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) ∈ _
+      change A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) ∈ _
       have hcons : arcEval A s (List.ofFn (Fin.cons i u)) =
           A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) := by
         rw [List.ofFn_succ, arcEval_cons, Fin.cons_zero]
@@ -249,7 +249,7 @@ private theorem arcEval_ofFn_eq_prod [NeZero n] (A : MPSChainTensor d D n) :
       · rw [← hg 0]
         norm_num
       · exact ih (fun k => g k.succ) (fun k => τ k.succ) (s + 1) fun k => by
-          show ((s + 1 + k.val : ℕ) : Fin n) = g k.succ
+          change ((s + 1 + k.val : ℕ) : Fin n) = g k.succ
           rw [← hg k.succ]
           congr 1
           rw [Fin.val_succ]
@@ -336,11 +336,12 @@ spanning-family form of the uniqueness of the bond operator
 2045--2255 of `Papers/1804.04964/paper_normal.tex`).  Two matrices
 multiplying every member of a spanning family to the same product on the
 right are equal. -/
-theorem eq_of_span_mul_left {ι : Type*} [Fintype ι]
+theorem eq_of_span_mul_left {ι : Type*} [Finite ι]
     {W : ι → Matrix (Fin D) (Fin D) ℂ}
     (hspan : Submodule.span ℂ (Set.range W) = ⊤)
     {X X' : Matrix (Fin D) (Fin D) ℂ}
     (h : ∀ i, W i * X = W i * X') : X = X' := by
+  cases nonempty_fintype ι
   have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
       Submodule.span ℂ (Set.range W) := hspan ▸ Submodule.mem_top
   obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
@@ -357,11 +358,12 @@ theorem eq_of_span_mul_left {ι : Type*} [Fintype ι]
 
 /-- **Uniqueness of a left factor against a spanning family** — the mirror
 of `MPSChainTensor.eq_of_span_mul_left`. -/
-theorem eq_of_mul_span_right {ι : Type*} [Fintype ι]
+theorem eq_of_mul_span_right {ι : Type*} [Finite ι]
     {W : ι → Matrix (Fin D) (Fin D) ℂ}
     (hspan : Submodule.span ℂ (Set.range W) = ⊤)
     {X X' : Matrix (Fin D) (Fin D) ℂ}
     (h : ∀ i, X * W i = X' * W i) : X = X' := by
+  cases nonempty_fintype ι
   have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
       Submodule.span ℂ (Set.range W) := hspan ▸ Submodule.mem_top
   obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1

--- a/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
@@ -1,0 +1,694 @@
+import TNLean.PEPS.CycleMPSChainOverlapInsertion
+
+/-!
+# The site-dependent closed-chain corollary at `n ≥ 2L + 1`
+
+This file assembles the site-dependent overlapping-window route of
+arXiv:1804.04964, Section `normal_alt` (lines 1915--2295 of
+`Papers/1804.04964/paper_normal.tex`) into the closed-chain corollary for
+site-dependent chains: two window-injective chains on `n ≥ 2L + 1` sites
+generating the same state are gauge equivalent — there are invertible
+matrices `Z_v`, one per bond, with `B_v^i = Z_v ⬝ A_v^i ⬝ Z_{v+1}⁻¹` at
+every site (`TNLean.PEPS.fundamentalTheorem_normalMPSChain_of_overlap`,
+concluding `MPSChainTensor.GaugeEquiv`).  The source displays the corollary
+after Lemma 5 for translation-invariant tensors; the site-dependent form
+combines the same Lemma 5 apparatus, which the source states for
+site-dependent tensors, at every bond of the chain.
+
+The assembly has three steps beyond the per-bond conjugation of
+`MPSChainTensor.exists_conjugation_of_sameState`:
+
+1. *Window covariance with a scalar*: from the conjugations at the two ends
+   of an arc of `m` sites (`L ≤ m`, `m + L ≤ n`), the `B`-arc products are a
+   nonzero scalar times the gauged `A`-arc products,
+   `B`-arc `= c • (Z_p ⬝ A`-arc`⬝ Z_{p+m}⁻¹)`.  The two conjugations
+   intertwine the arc products on the two sides, the bond-operator
+   extraction of Lemma 5 produces the connecting matrix, and comparing it
+   with the conjugation at the far bond pins it to a scalar multiple of the
+   gauge there, by the centralizer of the full matrix algebra.
+2. *Letterwise gauge relation*: comparing the covariance on windows of
+   lengths `L + 1` and `L` through the spanning window products leaves
+   `B_v^i = μ_v • (Z_v ⬝ A_v^i ⬝ Z_{v+1}⁻¹)` with nonzero scalars `μ_v`.
+3. *Absorbing the scalars*: iterating the letterwise relation once around
+   the closed chain forces `∏_v μ_v = 1`, so dressing the gauges with the
+   partial products absorbs every scalar, including across the seam.
+
+**Scope restriction (uniform physical and bond dimensions):** the source
+poses no restriction on the local dimensions of the site-dependent tensors,
+while here all sites share one physical dimension `d` and all bonds one
+bond dimension `D`.  Documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section `normal_alt`, lines 1915--2295 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+open scoped Fin.NatCast
+
+namespace MPSChainTensor
+
+variable {d D n : ℕ}
+
+/-! ### Spanning helpers -/
+
+/-- A nonzero-size identity matrix is nonzero. -/
+private theorem matrix_one_ne_zero' (hD : 0 < D) :
+    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
+  intro h
+  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
+  rw [Matrix.one_apply_eq] at hentry
+  exact one_ne_zero hentry
+
+/-- Right multiplication by an invertible matrix preserves spanning. -/
+private theorem span_range_mul_right_unit {ι : Type*}
+    {W : ι → Matrix (Fin D) (Fin D) ℂ}
+    (hW : Submodule.span ℂ (Set.range W) = ⊤) (U : GL (Fin D) ℂ) :
+    Submodule.span ℂ (Set.range fun i =>
+      W i * (U : Matrix (Fin D) (Fin D) ℂ)) = ⊤ := by
+  rw [eq_top_iff]
+  intro M _
+  have key : ∀ N ∈ Submodule.span ℂ (Set.range W),
+      N * (U : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
+        (Set.range fun i => W i * (U : Matrix (Fin D) (Fin D) ℂ)) := by
+    intro N hN
+    induction hN using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨i, rfl⟩ := hx
+        exact Submodule.subset_span ⟨i, rfl⟩
+    | zero => rw [Matrix.zero_mul]; exact Submodule.zero_mem _
+    | add x y _ _ hx hy => rw [Matrix.add_mul]; exact Submodule.add_mem _ hx hy
+    | smul c x _ hx => rw [Matrix.smul_mul]; exact Submodule.smul_mem _ c hx
+  have hM : M * ((U⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) ∈
+      Submodule.span ℂ (Set.range W) := hW ▸ Submodule.mem_top
+  have := key _ hM
+  rwa [Matrix.mul_assoc, ← Units.val_mul, inv_mul_cancel, Units.val_one,
+    Matrix.mul_one] at this
+
+/-- A matrix whose left multiples of some family span the matrix algebra is
+invertible. -/
+private theorem isUnit_of_mul_span {ι : Type*} {X : Matrix (Fin D) (Fin D) ℂ}
+    {G : ι → Matrix (Fin D) (Fin D) ℂ}
+    (hspan : Submodule.span ℂ (Set.range fun v => X * G v) = ⊤) :
+    IsUnit X := by
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+      Submodule.span ℂ (Set.range fun v => X * G v) :=
+    hspan ▸ Submodule.mem_top
+  have key : ∀ N ∈ Submodule.span ℂ (Set.range fun v => X * G v),
+      ∃ M, N = X * M := by
+    intro N hN
+    induction hN using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨v, rfl⟩ := hx
+        exact ⟨G v, rfl⟩
+    | zero => exact ⟨0, (Matrix.mul_zero X).symm⟩
+    | add x y _ _ hx hy =>
+        obtain ⟨Mx, rfl⟩ := hx
+        obtain ⟨My, rfl⟩ := hy
+        exact ⟨Mx + My, (Matrix.mul_add X Mx My).symm⟩
+    | smul c x _ hx =>
+        obtain ⟨Mx, rfl⟩ := hx
+        exact ⟨c • Mx, (Matrix.mul_smul X c Mx).symm⟩
+  obtain ⟨M, hM⟩ := key 1 h1
+  exact IsUnit.of_mul_eq_one M hM.symm
+
+/-- Products of two spanning families span. -/
+private theorem span_range_mul_pair {ι κ : Type*}
+    {V : ι → Matrix (Fin D) (Fin D) ℂ} {U : κ → Matrix (Fin D) (Fin D) ℂ}
+    (hV : Submodule.span ℂ (Set.range V) = ⊤)
+    (hU : Submodule.span ℂ (Set.range U) = ⊤) :
+    Submodule.span ℂ (Set.range fun vu : ι × κ => V vu.1 * U vu.2) = ⊤ := by
+  rw [eq_top_iff]
+  intro M _
+  have step1 : ∀ (w : κ), ∀ N ∈ Submodule.span ℂ (Set.range V),
+      N * U w ∈ Submodule.span ℂ
+        (Set.range fun vu : ι × κ => V vu.1 * U vu.2) := by
+    intro w N hN
+    induction hN using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨v, rfl⟩ := hx
+        exact Submodule.subset_span ⟨(v, w), rfl⟩
+    | zero => rw [Matrix.zero_mul]; exact Submodule.zero_mem _
+    | add x y _ _ hx hy => rw [Matrix.add_mul]; exact Submodule.add_mem _ hx hy
+    | smul c x _ hx => rw [Matrix.smul_mul]; exact Submodule.smul_mem _ c hx
+  have step2 : ∀ N ∈ Submodule.span ℂ (Set.range V),
+      ∀ W ∈ Submodule.span ℂ (Set.range U),
+      N * W ∈ Submodule.span ℂ
+        (Set.range fun vu : ι × κ => V vu.1 * U vu.2) := by
+    intro N hN W hW
+    induction hW using Submodule.span_induction with
+    | mem x hx =>
+        obtain ⟨w, rfl⟩ := hx
+        exact step1 w N hN
+    | zero => rw [Matrix.mul_zero]; exact Submodule.zero_mem _
+    | add x y _ _ hx hy => rw [Matrix.mul_add]; exact Submodule.add_mem _ hx hy
+    | smul c x _ hx => rw [Matrix.mul_smul]; exact Submodule.smul_mem _ c hx
+  have := step2 M (hV ▸ Submodule.mem_top) 1 (hU ▸ Submodule.mem_top)
+  rwa [Matrix.mul_one] at this
+
+/-- Two two-sided multiplications agreeing on a spanning family agree on
+every matrix. -/
+private theorem conj_eq_conj_of_span_range {ι : Sort*}
+    {F : ι → Matrix (Fin D) (Fin D) ℂ}
+    (hF : Submodule.span ℂ (Set.range F) = ⊤)
+    {P Q P' Q' : Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ i, P * F i * Q = P' * F i * Q') (M : Matrix (Fin D) (Fin D) ℂ) :
+    P * M * Q = P' * M * Q' := by
+  have hM : M ∈ Submodule.span ℂ (Set.range F) := hF ▸ Submodule.mem_top
+  induction hM using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨i, rfl⟩ := hx
+      exact h i
+  | zero => simp only [Matrix.mul_zero, Matrix.zero_mul]
+  | add x y _ _ hx hy =>
+      rw [Matrix.mul_add, Matrix.add_mul, Matrix.mul_add, Matrix.add_mul,
+        hx, hy]
+  | smul c x _ hx =>
+      rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_smul, Matrix.smul_mul,
+        hx]
+
+/-- Some arc product of a spanning arc family is nonzero. -/
+private theorem exists_arcEval_ne_zero [NeZero n] {A : MPSChainTensor d D n}
+    {m : ℕ} (hD : 0 < D) {s : ℕ}
+    (hspan : Submodule.span ℂ (Set.range fun ρ : Fin m → Fin d =>
+      arcEval A s (List.ofFn ρ)) = ⊤) :
+    ∃ ρ : Fin m → Fin d, arcEval A s (List.ofFn ρ) ≠ 0 := by
+  by_contra hall
+  push Not at hall
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
+      (Set.range fun ρ : Fin m → Fin d => arcEval A s (List.ofFn ρ)) :=
+    hspan ▸ Submodule.mem_top
+  obtain ⟨c, hc⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+  apply matrix_one_ne_zero' hD
+  rw [← hc]
+  exact Finset.sum_eq_zero fun ρ _ => by rw [hall ρ, smul_zero]
+
+/-! ### Window covariance from the per-bond conjugations -/
+
+/-- **Window covariance with a scalar** (arXiv:1804.04964, Section
+`normal_alt`, lines 1915--2295 of `Papers/1804.04964/paper_normal.tex` —
+the step combining Lemma 5's bond operators at the two ends of an arc).
+
+If at every site the full-length `B`-arc products are the `A`-arc products
+conjugated by a gauge `Z`, then on every arc of `m` sites with
+`L ≤ m` and `m + L ≤ n` the `B`-arc products are a nonzero scalar times the
+`A`-arc products gauged by `Z` at the two ends.  The conjugation at the
+near end intertwines the arc products of the two chains across the far
+bond, the bond-operator extraction produces the connecting matrix, and the
+conjugation at the far end pins it to a scalar multiple of the gauge there
+through the centralizer of the full matrix algebra. -/
+private theorem exists_window_covariance [NeZero n] {A B : MPSChainTensor d D n}
+    {L : ℕ} (hL : 0 < L) (hD : 0 < D)
+    (hA : IsWindowInjective A L) (hB : IsWindowInjective B L)
+    {Z : ℕ → GL (Fin D) ℂ}
+    (hZ : ∀ (p : ℕ) (w : List (Fin d)), w.length = n →
+      arcEval B p w = (Z p : Matrix (Fin D) (Fin D) ℂ) * arcEval A p w *
+        (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))
+    {m : ℕ} (hm : L ≤ m) (hmn : m + L ≤ n) (p : ℕ) :
+    ∃ c : ℂ, c ≠ 0 ∧ ∀ u : Fin m → Fin d,
+      arcEval B p (List.ofFn u) =
+        c • ((Z p : Matrix (Fin D) (Fin D) ℂ) * arcEval A p (List.ofFn u) *
+          (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
+  classical
+  have hq : L ≤ n - m := by omega
+  -- The conjugation at the near end intertwines the two chains across the
+  -- far bond.
+  have hinter : ∀ (u : Fin m → Fin d) (v : Fin (n - m) → Fin d),
+      ((((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+          arcEval B p (List.ofFn u)) *
+        (arcEval B (p + m) (List.ofFn v) * (Z p : Matrix (Fin D) (Fin D) ℂ)) =
+        arcEval A p (List.ofFn u) * arcEval A (p + m) (List.ofFn v) := by
+    intro u v
+    have hword := hZ p (List.ofFn u ++ List.ofFn v) (by simp; omega)
+    rw [arcEval_append, arcEval_append, List.length_ofFn] at hword
+    have hcancel : (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+        ((Z p : Matrix (Fin D) (Fin D) ℂ) *
+          (arcEval A p (List.ofFn u) * arcEval A (p + m) (List.ofFn v)) *
+          (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) *
+        (Z p : Matrix (Fin D) (Fin D) ℂ) =
+        arcEval A p (List.ofFn u) * arcEval A (p + m) (List.ofFn v) := by
+      simp only [← Matrix.mul_assoc]
+      rw [← Units.val_mul, inv_mul_cancel, Units.val_one, Matrix.one_mul,
+        Matrix.mul_assoc, ← Units.val_mul, inv_mul_cancel, Units.val_one,
+        Matrix.mul_one]
+    calc ((((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+            arcEval B p (List.ofFn u)) *
+          (arcEval B (p + m) (List.ofFn v) * (Z p : Matrix (Fin D) (Fin D) ℂ))
+        = (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+            (arcEval B p (List.ofFn u) * arcEval B (p + m) (List.ofFn v)) *
+            (Z p : Matrix (Fin D) (Fin D) ℂ) := by
+          simp only [Matrix.mul_assoc]
+      _ = arcEval A p (List.ofFn u) * arcEval A (p + m) (List.ofFn v) := by
+          rw [hword, hcancel]
+  -- The bond operator at the far end.
+  obtain ⟨X, hX1, hX2⟩ := exists_bondOperator_of_intertwine_span
+    (hA.arc_span hL hm p)
+    (span_range_mul_right_unit (hB.arc_span hL hq (p + m)) (Z p))
+    (fun u : Fin m → Fin d =>
+      (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+        arcEval B p (List.ofFn u))
+    (fun v : Fin (n - m) → Fin d => arcEval A (p + m) (List.ofFn v))
+    hinter
+  -- The bond operator is invertible.
+  have hXunit : IsUnit X := by
+    apply isUnit_of_mul_span (G := fun v : Fin (n - m) → Fin d =>
+      arcEval B (p + m) (List.ofFn v) * (Z p : Matrix (Fin D) (Fin D) ℂ))
+    have hcongr : (fun v : Fin (n - m) → Fin d =>
+        X * (arcEval B (p + m) (List.ofFn v) *
+          (Z p : Matrix (Fin D) (Fin D) ℂ))) =
+        fun v : Fin (n - m) → Fin d => arcEval A (p + m) (List.ofFn v) := by
+      funext v
+      exact (hX2 v).symm
+    rw [hcongr]
+    exact hA.arc_span hL hq (p + m)
+  obtain ⟨Xu, rfl⟩ := hXunit
+  -- The two halves of the conjugation, with the bond operator in place.
+  have hBv : ∀ v : Fin (n - m) → Fin d,
+      arcEval B (p + m) (List.ofFn v) =
+        ((Xu⁻¹ : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+          arcEval A (p + m) (List.ofFn v) *
+          (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    intro v
+    rw [hX2 v]
+    simp only [← Matrix.mul_assoc]
+    rw [← Units.val_mul, inv_mul_cancel, Units.val_one, Matrix.one_mul,
+      Matrix.mul_assoc, ← Units.val_mul, mul_inv_cancel, Units.val_one,
+      Matrix.mul_one]
+  have hBu : ∀ u : Fin m → Fin d,
+      arcEval B p (List.ofFn u) = (Z p : Matrix (Fin D) (Fin D) ℂ) *
+        (arcEval A p (List.ofFn u) *
+          ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ)) := by
+    intro u
+    calc arcEval B p (List.ofFn u)
+        = (Z p : Matrix (Fin D) (Fin D) ℂ) *
+            ((((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+              arcEval B p (List.ofFn u)) := by
+          rw [← Matrix.mul_assoc, ← Units.val_mul, mul_inv_cancel,
+            Units.val_one, Matrix.one_mul]
+      _ = (Z p : Matrix (Fin D) (Fin D) ℂ) *
+            (arcEval A p (List.ofFn u) *
+              ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ)) := by
+          rw [hX1 u]
+  -- The conjugation at the far end agrees with conjugation by the bond
+  -- operator on a spanning family.
+  have hconj_fam : ∀ (v : Fin (n - m) → Fin d) (u : Fin m → Fin d),
+      ((Xu⁻¹ : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+          (arcEval A (p + m) (List.ofFn v) * arcEval A p (List.ofFn u)) *
+          ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) =
+        (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) *
+          (arcEval A (p + m) (List.ofFn v) * arcEval A p (List.ofFn u)) *
+          (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    intro v u
+    have hword := hZ (p + m) (List.ofFn v ++ List.ofFn u) (by simp; omega)
+    rw [arcEval_append, arcEval_append, List.length_ofFn,
+      show p + m + (n - m) = p + n by omega, arcEval_add_n,
+      arcEval_add_n] at hword
+    have hcancel : (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+        ((Z p : Matrix (Fin D) (Fin D) ℂ) *
+          (arcEval A p (List.ofFn u) *
+            ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ))) =
+        arcEval A p (List.ofFn u) *
+          ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) := by
+      rw [← Matrix.mul_assoc, ← Units.val_mul, inv_mul_cancel, Units.val_one,
+        Matrix.one_mul]
+    calc ((Xu⁻¹ : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+            (arcEval A (p + m) (List.ofFn v) * arcEval A p (List.ofFn u)) *
+            ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ)
+        = (((Xu⁻¹ : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+            arcEval A (p + m) (List.ofFn v) *
+            (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) *
+            ((Z p : Matrix (Fin D) (Fin D) ℂ) *
+              (arcEval A p (List.ofFn u) *
+                ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ))) := by
+          simp only [Matrix.mul_assoc]
+          rw [hcancel]
+      _ = arcEval B (p + m) (List.ofFn v) * arcEval B p (List.ofFn u) := by
+          rw [← hBv v, ← hBu u]
+      _ = (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) *
+            (arcEval A (p + m) (List.ofFn v) * arcEval A p (List.ofFn u)) *
+            (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := hword
+  have hconj : ∀ M : Matrix (Fin D) (Fin D) ℂ,
+      ((Xu⁻¹ : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) * M *
+          ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) =
+        (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) * M *
+          (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
+    conj_eq_conj_of_span_range
+      (span_range_mul_pair (hA.arc_span hL hq (p + m)) (hA.arc_span hL hm p))
+      (fun vu => hconj_fam vu.1 vu.2)
+  -- The bond operator times the far gauge is central, hence a scalar.
+  have hcomm : ∀ M : Matrix (Fin D) (Fin D) ℂ,
+      Commute M (((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+        (Z (p + m) : Matrix (Fin D) (Fin D) ℂ)) := by
+    intro M
+    have h1 : ((Xu⁻¹ : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+        M * ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+        (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) =
+        (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) * M := by
+      rw [hconj M, Matrix.mul_assoc, ← Units.val_mul, inv_mul_cancel,
+        Units.val_one, Matrix.mul_one]
+    have h2 : M * (((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+        (Z (p + m) : Matrix (Fin D) (Fin D) ℂ)) =
+        ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+          (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) * M := by
+      calc M * (((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+              (Z (p + m) : Matrix (Fin D) (Fin D) ℂ))
+          = ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+              ((((Xu⁻¹ : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+                M * ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ)) *
+              (Z (p + m) : Matrix (Fin D) (Fin D) ℂ)) := by
+            simp only [← Matrix.mul_assoc]
+            rw [← Units.val_mul, mul_inv_cancel, Units.val_one, Matrix.one_mul]
+        _ = ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+              ((Z (p + m) : Matrix (Fin D) (Fin D) ℂ) * M) := by
+            rw [h1]
+        _ = ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+              (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) * M := by
+            rw [Matrix.mul_assoc]
+    exact h2
+  obtain ⟨c, hc⟩ := Matrix.mem_range_scalar_iff_commute_single'.mpr
+    (fun i j => hcomm (Matrix.single i j 1))
+  have hXZ : ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+      (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) =
+      c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+    rw [← hc, Matrix.scalar_apply, Matrix.smul_one_eq_diagonal]
+  have hc0 : c ≠ 0 := by
+    intro h0
+    apply matrix_one_ne_zero' hD
+    have hzero : ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+        (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) = 0 := by
+      rw [hXZ, h0, zero_smul]
+    calc (1 : Matrix (Fin D) (Fin D) ℂ)
+        = ((Xu⁻¹ : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+            (((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+              (Z (p + m) : Matrix (Fin D) (Fin D) ℂ)) *
+            (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+          simp only [← Matrix.mul_assoc]
+          rw [← Units.val_mul, inv_mul_cancel, Units.val_one, Matrix.one_mul,
+            ← Units.val_mul, mul_inv_cancel, Units.val_one]
+      _ = 0 := by rw [hzero, Matrix.mul_zero, Matrix.zero_mul]
+  have hXval : ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) =
+      c • (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    calc ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ)
+        = ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
+            (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) *
+            (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+          rw [Matrix.mul_assoc, ← Units.val_mul, mul_inv_cancel, Units.val_one,
+            Matrix.mul_one]
+      _ = (c • (1 : Matrix (Fin D) (Fin D) ℂ)) *
+            (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+          rw [hXZ]
+      _ = c • (((Z (p + m))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+          rw [Matrix.smul_mul, Matrix.one_mul]
+  refine ⟨c, hc0, fun u => ?_⟩
+  rw [hBu u, hXval, Matrix.mul_smul, Matrix.mul_smul, ← Matrix.mul_assoc]
+
+/-! ### The letterwise gauge relation and the scalar absorption -/
+
+/-- **Iterating the letterwise relation along an arc.**  A letterwise
+relation `B_p^i = μ_p • (Z_p ⬝ A_p^i ⬝ Z_{p+1}⁻¹)` propagates to every arc:
+the scalars multiply and the inner gauges cancel telescopically. -/
+private theorem arcEval_eq_smul_conj_of_letter [NeZero n]
+    {A B : MPSChainTensor d D n} {Z : ℕ → GL (Fin D) ℂ} {μ : ℕ → ℂ}
+    (hrel : ∀ (p : ℕ) (i : Fin d), B ((p : ℕ) : Fin n) i =
+      μ p • ((Z p : Matrix (Fin D) (Fin D) ℂ) * A ((p : ℕ) : Fin n) i *
+        (((Z (p + 1))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)))
+    (w : List (Fin d)) (s : ℕ) :
+    arcEval B s w = (∏ k ∈ Finset.range w.length, μ (s + k)) •
+      ((Z s : Matrix (Fin D) (Fin D) ℂ) * arcEval A s w *
+        (((Z (s + w.length))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
+  induction w generalizing s with
+  | nil =>
+      simp only [arcEval_nil, List.length_nil, Finset.range_zero,
+        Finset.prod_empty, one_smul, Nat.add_zero, Matrix.mul_one]
+      rw [← Units.val_mul, mul_inv_cancel, Units.val_one]
+  | cons i w ih =>
+      have hidx : s + 1 + w.length = s + (i :: w).length := by
+        rw [List.length_cons]
+        omega
+      have hprod : μ s * ∏ k ∈ Finset.range w.length, μ (s + 1 + k) =
+          ∏ k ∈ Finset.range (i :: w).length, μ (s + k) := by
+        rw [List.length_cons, Finset.prod_range_succ' (fun k => μ (s + k))
+          w.length, Nat.add_zero, mul_comm]
+        congr 1
+        exact Finset.prod_congr rfl fun k _ => congrArg μ (by omega)
+      rw [arcEval_cons, arcEval_cons, hrel s i, ih (s + 1)]
+      rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul, hidx, hprod]
+      congr 1
+      have hcancel : (((Z (s + 1))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+          ((Z (s + 1) : Matrix (Fin D) (Fin D) ℂ) *
+            (arcEval A (s + 1) w *
+              (((Z (s + (i :: w).length))⁻¹ : GL (Fin D) ℂ) :
+                Matrix (Fin D) (Fin D) ℂ))) =
+          arcEval A (s + 1) w *
+            (((Z (s + (i :: w).length))⁻¹ : GL (Fin D) ℂ) :
+              Matrix (Fin D) (Fin D) ℂ) := by
+        rw [← Matrix.mul_assoc, ← Units.val_mul, inv_mul_cancel, Units.val_one,
+          Matrix.one_mul]
+      simp only [Matrix.mul_assoc]
+      rw [hcancel]
+
+end MPSChainTensor
+
+namespace TNLean
+namespace PEPS
+
+open MPSChainTensor
+
+/-! ### The site-dependent closed-chain corollary -/
+
+/-- **Fundamental Theorem for site-dependent normal closed chains at
+`n ≥ 2L + 1`** (arXiv:1804.04964, Section `normal_alt`, lines 1915--2295 of
+`Papers/1804.04964/paper_normal.tex`: the closed-chain corollary after
+Lemma 5, assembled from the site-dependent Lemma 5 apparatus at every bond
+of the chain; the source displays the corollary for translation-invariant
+tensors, with the site-dependent Lemma 5 as its engine).
+
+Two site-dependent chains on `n ≥ 2L + 1` sites, each with every window of
+`L` consecutive sites injective, generating the same closed-chain state,
+are gauge equivalent: there are invertible matrices `Z_v`, one per bond,
+with `B_v^i = Z_v ⬝ A_v^i ⬝ Z_{v+1}⁻¹` at every site, indices cyclic.
+
+The per-bond conjugations of the insertion correspondence give window
+covariance with nonzero scalars; comparing windows of lengths `L + 1` and
+`L` makes the relation letterwise, `B_v^i = μ_v • (Z_v A_v^i Z_{v+1}⁻¹)`;
+one circuit of the chain forces `∏_v μ_v = 1`, and dressing the gauges with
+the partial products absorbs the scalars, including across the seam.
+
+**Scope restriction (uniform physical and bond dimensions):** the source
+poses no restriction on the local dimensions of the site-dependent tensors,
+while here all sites share one physical dimension `d` and all bonds one
+bond dimension `D`.  Documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+theorem fundamentalTheorem_normalMPSChain_of_overlap {n L d D : ℕ} [NeZero n]
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (A B : MPSChainTensor d D n)
+    (hA : IsWindowInjective A L) (hB : IsWindowInjective B L)
+    (hAB : SameState A B) : GaugeEquiv A B := by
+  classical
+  rcases Nat.eq_zero_or_pos D with hD0 | hD
+  · -- All `0 × 0` matrices are equal.
+    subst hD0
+    exact ⟨fun _ => 1, fun k i => by
+      apply Matrix.ext
+      intro a b
+      exact a.elim0⟩
+  obtain ⟨m', rfl⟩ : ∃ m', n = m' + 1 := ⟨n - 1, by omega⟩
+  -- The per-bond conjugations, chosen once per site of the chain and read
+  -- at arbitrary starting sites through the residue of the chain length.
+  have hZc : ∀ v : Fin (m' + 1), ∃ Zv : GL (Fin D) ℂ,
+      ∀ w : List (Fin d), w.length = m' + 1 →
+      arcEval B v.val w = (Zv : Matrix (Fin D) (Fin D) ℂ) * arcEval A v.val w *
+        ((Zv⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
+    fun v => exists_conjugation_of_sameState hL hn A B hA hB hAB v.val
+  choose Z₀ hZ₀ using hZc
+  set Z : ℕ → GL (Fin D) ℂ := fun p => Z₀ ((p : ℕ) : Fin (m' + 1)) with hZdef
+  have hZ : ∀ (p : ℕ) (w : List (Fin d)), w.length = m' + 1 →
+      arcEval B p w = (Z p : Matrix (Fin D) (Fin D) ℂ) * arcEval A p w *
+        (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    intro p w hw
+    have hmod : ∀ T : MPSChainTensor d D (m' + 1),
+        arcEval T (((p : ℕ) : Fin (m' + 1))).val w = arcEval T p w := by
+      intro T
+      rw [Fin.val_natCast, arcEval_mod]
+    have h := hZ₀ ((p : ℕ) : Fin (m' + 1)) w hw
+    rw [hmod A, hmod B] at h
+    exact h
+  -- The window covariances at lengths `L + 1` and `L`.
+  have hcov1 : ∀ p : ℕ, ∃ c : ℂ, c ≠ 0 ∧ ∀ u : Fin (L + 1) → Fin d,
+      arcEval B p (List.ofFn u) =
+        c • ((Z p : Matrix (Fin D) (Fin D) ℂ) * arcEval A p (List.ofFn u) *
+          (((Z (p + (L + 1)))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) :=
+    fun p => exists_window_covariance hL hD hA hB hZ (by omega) (by omega) p
+  have hcov2 : ∀ p : ℕ, ∃ c : ℂ, c ≠ 0 ∧ ∀ u : Fin L → Fin d,
+      arcEval B p (List.ofFn u) =
+        c • ((Z p : Matrix (Fin D) (Fin D) ℂ) * arcEval A p (List.ofFn u) *
+          (((Z (p + L))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) :=
+    fun p => exists_window_covariance hL hD hA hB hZ le_rfl (by omega) p
+  choose c₁ hc₁0 hc₁ using hcov1
+  choose c₂ hc₂0 hc₂ using hcov2
+  -- The letterwise gauge relation with scalars.
+  have hrel : ∀ (p : ℕ) (i : Fin d), B ((p : ℕ) : Fin (m' + 1)) i =
+      (c₁ p / c₂ (p + 1)) •
+        ((Z p : Matrix (Fin D) (Fin D) ℂ) * A ((p : ℕ) : Fin (m' + 1)) i *
+          (((Z (p + 1))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
+    intro p i
+    have key : ∀ w : Fin L → Fin d,
+        (c₂ (p + 1) • (B ((p : ℕ) : Fin (m' + 1)) i *
+            (Z (p + 1) : Matrix (Fin D) (Fin D) ℂ))) *
+          arcEval A (p + 1) (List.ofFn w) =
+        (c₁ p • ((Z p : Matrix (Fin D) (Fin D) ℂ) *
+            A ((p : ℕ) : Fin (m' + 1)) i)) *
+          arcEval A (p + 1) (List.ofFn w) := by
+      intro w
+      have hcons : List.ofFn (Fin.cons i w) = i :: List.ofFn w := by
+        rw [List.ofFn_succ]
+        simp only [Fin.cons_zero, Fin.cons_succ]
+      have h1 := hc₁ p (Fin.cons i w)
+      rw [hcons, arcEval_cons, arcEval_cons] at h1
+      have h2 := hc₂ (p + 1) w
+      rw [show p + 1 + L = p + (L + 1) by omega] at h2
+      rw [h2] at h1
+      have h3 := congrArg
+        (fun M => M * (Z (p + (L + 1)) : Matrix (Fin D) (Fin D) ℂ)) h1
+      simp only at h3
+      have hQcancel : (((Z (p + (L + 1)))⁻¹ : GL (Fin D) ℂ) :
+          Matrix (Fin D) (Fin D) ℂ) *
+          (Z (p + (L + 1)) : Matrix (Fin D) (Fin D) ℂ) = 1 := by
+        rw [← Units.val_mul, inv_mul_cancel, Units.val_one]
+      rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.smul_mul] at h3
+      simp only [Matrix.mul_assoc] at h3
+      simp only [hQcancel, Matrix.mul_one] at h3
+      rw [smul_mul_assoc, smul_mul_assoc]
+      simp only [Matrix.mul_assoc]
+      exact h3
+    have hstrip := eq_of_mul_span_right
+      (W := fun w : Fin L → Fin d => arcEval A (p + 1) (List.ofFn w))
+      (hA (p + 1)) key
+    have h4 : B ((p : ℕ) : Fin (m' + 1)) i *
+        (Z (p + 1) : Matrix (Fin D) (Fin D) ℂ) =
+        (c₁ p / c₂ (p + 1)) • ((Z p : Matrix (Fin D) (Fin D) ℂ) *
+          A ((p : ℕ) : Fin (m' + 1)) i) := by
+      have h5 := congrArg (fun M => (c₂ (p + 1))⁻¹ • M) hstrip
+      simp only [smul_smul] at h5
+      rw [inv_mul_cancel₀ (hc₂0 (p + 1)), one_smul] at h5
+      rw [div_eq_mul_inv, mul_comm (c₁ p) (c₂ (p + 1))⁻¹]
+      exact h5
+    calc B ((p : ℕ) : Fin (m' + 1)) i
+        = B ((p : ℕ) : Fin (m' + 1)) i *
+            (Z (p + 1) : Matrix (Fin D) (Fin D) ℂ) *
+            (((Z (p + 1))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+          rw [Matrix.mul_assoc, ← Units.val_mul, mul_inv_cancel, Units.val_one,
+            Matrix.mul_one]
+      _ = ((c₁ p / c₂ (p + 1)) • ((Z p : Matrix (Fin D) (Fin D) ℂ) *
+            A ((p : ℕ) : Fin (m' + 1)) i)) *
+            (((Z (p + 1))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+          rw [h4]
+      _ = (c₁ p / c₂ (p + 1)) • ((Z p : Matrix (Fin D) (Fin D) ℂ) *
+            A ((p : ℕ) : Fin (m' + 1)) i *
+            (((Z (p + 1))⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) :=
+          smul_mul_assoc _ _ _
+  set μ : ℕ → ℂ := fun p => c₁ p / c₂ (p + 1) with hμdef
+  have hμ0 : ∀ p, μ p ≠ 0 := fun p => div_ne_zero (hc₁0 p) (hc₂0 (p + 1))
+  -- One circuit of the chain forces the product of the scalars to one.
+  have hiter := arcEval_eq_smul_conj_of_letter (A := A) (B := B) (Z := Z)
+    (μ := μ) hrel
+  obtain ⟨ρ₀, hρ₀⟩ := exists_arcEval_ne_zero (A := A) hD
+    (hA.arc_span hL (by omega : L ≤ m' + 1) 0)
+  have hprod1 : (∏ k ∈ Finset.range (m' + 1), μ k) = 1 := by
+    have h1 := hiter (List.ofFn ρ₀) 0
+    have h2 := hZ 0 (List.ofFn ρ₀) (by simp)
+    rw [List.length_ofFn] at h1
+    have hZ0n : Z (0 + (m' + 1)) = Z 0 := by
+      simp only [hZdef]
+      have hcast : ((0 + (m' + 1) : ℕ) : Fin (m' + 1)) =
+          ((0 : ℕ) : Fin (m' + 1)) := by
+        rw [Nat.zero_add, Fin.natCast_self, Nat.cast_zero]
+      rw [hcast]
+    have hμshift : ∏ k ∈ Finset.range (m' + 1), μ (0 + k) =
+        ∏ k ∈ Finset.range (m' + 1), μ k :=
+      Finset.prod_congr rfl fun k _ => congrArg μ (Nat.zero_add k)
+    rw [hZ0n, hμshift, h2] at h1
+    by_contra hne
+    have hV : (Z 0 : Matrix (Fin D) (Fin D) ℂ) *
+        arcEval A 0 (List.ofFn ρ₀) *
+        (((Z 0)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
+      intro h0
+      apply hρ₀
+      calc arcEval A 0 (List.ofFn ρ₀)
+          = (((Z 0)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+              ((Z 0 : Matrix (Fin D) (Fin D) ℂ) *
+                arcEval A 0 (List.ofFn ρ₀) *
+                (((Z 0)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) *
+              (Z 0 : Matrix (Fin D) (Fin D) ℂ) := by
+            simp only [← Matrix.mul_assoc]
+            rw [← Units.val_mul, inv_mul_cancel, Units.val_one, Matrix.one_mul,
+              Matrix.mul_assoc, ← Units.val_mul, inv_mul_cancel, Units.val_one,
+              Matrix.mul_one]
+        _ = 0 := by rw [h0, Matrix.mul_zero, Matrix.zero_mul]
+    have hzero : ((∏ k ∈ Finset.range (m' + 1), μ k) - 1) •
+        ((Z 0 : Matrix (Fin D) (Fin D) ℂ) * arcEval A 0 (List.ofFn ρ₀) *
+          (((Z 0)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) = 0 := by
+      rw [sub_smul, one_smul, ← h1, sub_self]
+    rcases smul_eq_zero.mp hzero with h | h
+    · exact hne (sub_eq_zero.mp h)
+    · exact hV h
+  have hν0 : ∀ p : ℕ, (∏ k ∈ Finset.range p, μ k) ≠ 0 := by
+    intro p
+    induction p with
+    | zero => simp
+    | succ p ih =>
+        rw [Finset.prod_range_succ]
+        exact mul_ne_zero ih (hμ0 p)
+  -- Dress the gauges with the partial products of the scalars.
+  refine ⟨fun v => Units.mk
+      ((∏ k ∈ Finset.range v.val, μ k)⁻¹ • (Z v.val : Matrix (Fin D) (Fin D) ℂ))
+      ((∏ k ∈ Finset.range v.val, μ k) •
+        (((Z v.val)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))
+      (by rw [smul_mul_smul_comm, inv_mul_cancel₀ (hν0 v.val),
+        ← Units.val_mul, mul_inv_cancel, Units.val_one, one_smul])
+      (by rw [smul_mul_smul_comm, mul_inv_cancel₀ (hν0 v.val),
+        ← Units.val_mul, inv_mul_cancel, Units.val_one, one_smul]),
+    fun v i => ?_⟩
+  rw [Units.inv_mk]
+  change B v i =
+    ((∏ k ∈ Finset.range v.val, μ k)⁻¹ •
+      (Z v.val : Matrix (Fin D) (Fin D) ℂ)) * A v i *
+    ((∏ k ∈ Finset.range (cyclicSucc v).val, μ k) •
+      (((Z (cyclicSucc v).val)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))
+  rw [Matrix.smul_mul, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
+  -- The gauge at the cyclic successor is the gauge one bond downstream.
+  have hZsucc : Z (v.val + 1) = Z ((cyclicSucc v).val) := by
+    simp only [hZdef]
+    have hcast : ((v.val + 1 : ℕ) : Fin (m' + 1)) =
+        (((cyclicSucc v).val : ℕ) : Fin (m' + 1)) := by
+      apply Fin.ext
+      rw [Fin.val_natCast, Fin.val_natCast, cyclicSucc_val]
+      exact (Nat.mod_mod_of_dvd _ dvd_rfl).symm
+    rw [hcast]
+  -- The collected scalar is the letterwise scalar, including at the seam.
+  have hscal : (∏ k ∈ Finset.range v.val, μ k)⁻¹ *
+      (∏ k ∈ Finset.range ((cyclicSucc v).val), μ k) = μ v.val := by
+    rw [cyclicSucc_val]
+    have hv := v.isLt
+    by_cases hwrap : v.val + 1 < m' + 1
+    · rw [Nat.mod_eq_of_lt hwrap, Finset.prod_range_succ]
+      rw [inv_mul_cancel_left₀ (hν0 v.val)]
+    · have hv' : v.val = m' := by omega
+      have hmod0 : (v.val + 1) % (m' + 1) = 0 := by
+        rw [hv']
+        exact Nat.mod_self (m' + 1)
+      rw [hmod0, Finset.prod_range_zero, mul_one, hv']
+      have hfull : (∏ k ∈ Finset.range m', μ k) * μ m' = 1 := by
+        rw [← Finset.prod_range_succ]
+        exact hprod1
+      rw [eq_inv_of_mul_eq_one_left hfull, inv_inv]
+  rw [hscal, ← hZsucc]
+  have hr := hrel v.val i
+  rw [Fin.cast_val_eq_self] at hr
+  exact hr
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
@@ -1,0 +1,649 @@
+import TNLean.PEPS.CycleMPSChainOverlapWindow
+import TNLean.PEPS.CycleMPSWordTransport
+import TNLean.Algebra.SkolemNoether
+
+/-!
+# The site-dependent insertion correspondence of the overlapping-window route
+
+This file applies the site-dependent bond-operator extraction of
+`TNLean/PEPS/CycleMPSChainOverlapWindow.lean` — Lemma 5 of arXiv:1804.04964
+(lines 2045--2255 of `Papers/1804.04964/paper_normal.tex`) — to two
+window-injective site-dependent chains `A`, `B` generating the same
+closed-chain state on `n ≥ 2L + 1` sites, and delivers
+
+* the insertion correspondence at each bond as an algebra homomorphism
+  (`MPSChainTensor.exists_insertionHom`): a linear map `Φ` of the matrix
+  algebra, unital and multiplicative — the source's clause that the maps
+  `O_1 ↦ X` and `O_3^T ↦ X` "are uniquely defined and are
+  algebra-homomorphisms" (line 2253) — pairing every insertion `X` on the
+  `A`-chain with `Φ X` on the `B`-chain against all closed-chain words;
+* its uniqueness (`MPSChainTensor.insertionHom_unique`); and
+* the conjugation between the two chains at length `n`
+  (`MPSChainTensor.exists_conjugation_of_sameState`): at every bond an
+  invertible matrix `Z` with `B`-arc products of full length conjugate to
+  the `A`-arc products, the site-dependent analogue of
+  `MPSTensor.exists_conjugation_of_mpv_eq`.
+
+The route mirrors the site-independent file
+`TNLean/PEPS/CycleMPSOverlapInsertion.lean`, with one transport per window
+start: a virtual insertion `X` on a bond of the `A`-chain is realized on
+each of the `L + 1` overlapping windows around the bond
+(`eq:normal_resonate`, lines 1961--2043), each deformed window is
+transported to the `B`-chain by the arc transport at its own starting site
+(`MPSChainTensor.exists_arcTransport`), the same-state hypothesis makes the
+transported deformations generate one common state, and Lemma 5 for the
+`B`-chain extracts the bond operator `Φ X`.  Uniqueness of the bond
+operator makes `Φ` linear, unital and multiplicative; Skolem--Noether makes
+it inner, and pairing insertions against all closed-chain words turns the
+conjugation of insertions into the conjugation of arc products.
+
+**Scope restriction (uniform physical and bond dimensions):** the source
+poses no restriction on the local dimensions of the site-dependent tensors,
+while here all sites share one physical dimension `d` and all bonds one
+bond dimension `D`.  Documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Section `normal_alt`, lines 1915--2295 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+open scoped Fin.NatCast
+
+namespace MPSChainTensor
+
+variable {d D n : ℕ}
+
+/-! ### The arc transport between same-state chains -/
+
+/-- Concatenating a tuple word with a list splits the arc product at the
+declared intermediate site. -/
+private theorem arcEval_ofFn_mul [NeZero n] (A : MPSChainTensor d D n)
+    {k : ℕ} (s : ℕ) (τ : Fin k → Fin d) (w : List (Fin d)) :
+    arcEval A s (List.ofFn τ) * arcEval A (s + k) w =
+      arcEval A s (List.ofFn τ ++ w) := by
+  rw [arcEval_append, List.length_ofFn]
+
+/-- **Arc transport between same-state chains** (the site-dependent form of
+the operator-transport mechanism of arXiv:1804.04964, Lemma 5, lines
+2045--2255 of `Papers/1804.04964/paper_normal.tex`).
+
+If the chains `A` and `B` generate the same closed-chain state, and the
+`A`-arc products of length `k` starting at site `s` and of the
+complementary length `n - k` starting at site `s + k` both span the matrix
+algebra, then a linear map `Λ` of the matrix algebra carries every
+length-`k` arc product of `A` at site `s` to the corresponding arc product
+of `B`.  The pairing against the complementary arc products is injective by
+spanning and trace nondegeneracy, and the rotated same-state reading
+matches the `A`- and `B`-pairings on the spanning arc family. -/
+theorem exists_arcTransport [NeZero n] {A B : MPSChainTensor d D n}
+    {s k q : ℕ} (hkq : k + q = n)
+    (hAk : Submodule.span ℂ (Set.range fun τ : Fin k → Fin d =>
+      arcEval A s (List.ofFn τ)) = ⊤)
+    (hAq : Submodule.span ℂ (Set.range fun ρ : Fin q → Fin d =>
+      arcEval A (s + k) (List.ofFn ρ)) = ⊤)
+    (hAB : SameState A B) :
+    ∃ Λ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+      ∀ τ : Fin k → Fin d,
+        Λ (arcEval A s (List.ofFn τ)) = arcEval B s (List.ofFn τ) := by
+  classical
+  set ΨA : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ((Fin q → Fin d) → ℂ) :=
+    LinearMap.pi fun ρ => (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
+      (LinearMap.mulRight ℂ (arcEval A (s + k) (List.ofFn ρ))) with hΨA
+  set ΨB : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ((Fin q → Fin d) → ℂ) :=
+    LinearMap.pi fun ρ => (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
+      (LinearMap.mulRight ℂ (arcEval B (s + k) (List.ofFn ρ))) with hΨB
+  have hΨA_apply : ∀ (M : Matrix (Fin D) (Fin D) ℂ) (ρ : Fin q → Fin d),
+      ΨA M ρ = Matrix.trace (M * arcEval A (s + k) (List.ofFn ρ)) :=
+    fun M ρ => rfl
+  have hΨB_apply : ∀ (M : Matrix (Fin D) (Fin D) ℂ) (ρ : Fin q → Fin d),
+      ΨB M ρ = Matrix.trace (M * arcEval B (s + k) (List.ofFn ρ)) :=
+    fun M ρ => rfl
+  refine MPSTensor.exists_linearMap_apply_eq _ _ ΨA ΨB hAk ?_ ?_
+  · -- Injectivity of the `A`-pairing: spanning at the complementary length
+    -- plus trace nondegeneracy.
+    rw [LinearMap.ker_eq_bot']
+    intro M hM
+    refine eq_of_trace_pairing_span (F := fun ρ : Fin q → Fin d =>
+      arcEval A (s + k) (List.ofFn ρ)) hAq (N := 0) fun ρ => ?_
+    rw [Matrix.zero_mul, Matrix.trace_zero, ← hΨA_apply]
+    exact congrArg (· ρ) hM
+  · -- The two pairings match on the spanning arc family: both compute the
+    -- closed-chain coefficient of the concatenated word, equal at length
+    -- `n` by the rotated same-state reading.
+    intro τ
+    funext ρ
+    rw [hΨA_apply, hΨB_apply, arcEval_ofFn_mul, arcEval_ofFn_mul]
+    exact hAB.trace_arcEval_eq s (by simp [hkq])
+
+/-! ### The transported deformation generates the inserted state -/
+
+/-- **The transport intertwines the closed-chain pairings**
+(arXiv:1804.04964, the mechanism of Lemma 5, lines 2045--2255 of
+`Papers/1804.04964/paper_normal.tex`, site-dependent form): expanding any
+matrix `M` over the window products of `A` at the window start `s` and
+re-reading the expansion in the `B`-chain leaves every closed-chain
+coefficient of total length `n` unchanged. -/
+private theorem trace_transport_sandwich [NeZero n] {A B : MPSChainTensor d D n}
+    {L : ℕ} (hA : IsWindowInjective A L) (hAB : SameState A B) {s : ℕ}
+    {Λ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hΛ : ∀ τ : Fin L → Fin d,
+      Λ (arcEval A s (List.ofFn τ)) = arcEval B s (List.ofFn τ))
+    (M : Matrix (Fin D) (Fin D) ℂ) {s₀ : ℕ} (pre post : List (Fin d))
+    (hs : s₀ + pre.length = s) (hlen : pre.length + L + post.length = n) :
+    Matrix.trace (arcEval B s₀ pre * Λ M * arcEval B (s + L) post) =
+      Matrix.trace (arcEval A s₀ pre * M * arcEval A (s + L) post) := by
+  classical
+  have hM : M ∈ Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
+      arcEval A s (List.ofFn τ)) := (hA s) ▸ Submodule.mem_top
+  obtain ⟨c, hc⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp hM
+  have hΛM : Λ M = ∑ τ : Fin L → Fin d, c τ • arcEval B s (List.ofFn τ) := by
+    rw [← hc, map_sum]
+    exact Finset.sum_congr rfl fun τ _ => by rw [map_smul, hΛ τ]
+  have decomp : ∀ (T : MPSChainTensor d D n) (N : Matrix (Fin D) (Fin D) ℂ),
+      N = (∑ τ : Fin L → Fin d, c τ • arcEval T s (List.ofFn τ)) →
+      Matrix.trace (arcEval T s₀ pre * N * arcEval T (s + L) post) =
+        ∑ τ : Fin L → Fin d,
+          c τ * Matrix.trace (arcEval T s₀ (pre ++ (List.ofFn τ ++ post))) := by
+    intro T N hN
+    rw [hN, Finset.mul_sum, Finset.sum_mul, Matrix.trace_sum]
+    refine Finset.sum_congr rfl fun τ _ => ?_
+    rw [mul_smul_comm, smul_mul_assoc, Matrix.trace_smul, smul_eq_mul]
+    congr 1
+    rw [arcEval_append, arcEval_append, List.length_ofFn, hs, Matrix.mul_assoc]
+  rw [decomp B (Λ M) hΛM, decomp A M hc.symm]
+  refine Finset.sum_congr rfl fun τ _ => ?_
+  congr 1
+  exact (hAB.trace_arcEval_eq s₀ (by simp; omega)).symm
+
+/-! ### Arcs with one insertion -/
+
+/-- The arc product with a matrix inserted after the first `p` letters: the
+site-dependent form of the deformed window tensors of arXiv:1804.04964,
+`eq:X->O` (line 333) and the windows of `eq:normal_resonate` (lines
+1961--2043 of `Papers/1804.04964/paper_normal.tex`). -/
+private noncomputable def insertedArc [NeZero n] (A : MPSChainTensor d D n)
+    (X : Matrix (Fin D) (Fin D) ℂ) (s p : ℕ) (w : List (Fin d)) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  arcEval A s (w.take p) * X * arcEval A (s + p) (w.drop p)
+
+private theorem insertedArc_length [NeZero n] (A : MPSChainTensor d D n)
+    (X : Matrix (Fin D) (Fin D) ℂ) {s p : ℕ} {w : List (Fin d)}
+    (hp : w.length ≤ p) : insertedArc A X s p w = arcEval A s w * X := by
+  rw [insertedArc, List.take_of_length_le hp, List.drop_of_length_le hp,
+    arcEval_nil, Matrix.mul_one]
+
+private theorem insertedArc_zero [NeZero n] (A : MPSChainTensor d D n)
+    (X : Matrix (Fin D) (Fin D) ℂ) (s : ℕ) (w : List (Fin d)) :
+    insertedArc A X s 0 w = X * arcEval A s w := by
+  rw [insertedArc, List.take_zero, List.drop_zero, arcEval_nil,
+    Matrix.one_mul, Nat.add_zero]
+
+/-- Appending a letter beyond the insertion point, at the site following the
+arc. -/
+private theorem insertedArc_append_letter [NeZero n] (A : MPSChainTensor d D n)
+    (X : Matrix (Fin D) (Fin D) ℂ) {s p t : ℕ} {w : List (Fin d)}
+    (hp : p ≤ w.length) (ht : t = s + w.length) (i : Fin d) :
+    insertedArc A X s p w * A ((t : ℕ) : Fin n) i =
+      insertedArc A X s p (w ++ [i]) := by
+  subst ht
+  rw [insertedArc, insertedArc, List.take_append_of_le_length hp,
+    List.drop_append_of_le_length hp, arcEval_append, List.length_drop,
+    show s + p + (w.length - p) = s + w.length by omega, arcEval_cons,
+    arcEval_nil, Matrix.mul_one]
+  simp only [Matrix.mul_assoc]
+
+/-- Prepending a letter before the insertion point, at the site preceding
+the arc. -/
+private theorem insertedArc_cons_letter [NeZero n] (A : MPSChainTensor d D n)
+    (X : Matrix (Fin D) (Fin D) ℂ) (s p : ℕ) (w : List (Fin d)) (i : Fin d) :
+    A ((s : ℕ) : Fin n) i * insertedArc A X (s + 1) p w =
+      insertedArc A X s (p + 1) (i :: w) := by
+  rw [insertedArc, insertedArc, List.take_succ_cons, List.drop_succ_cons,
+    arcEval_cons, show s + (p + 1) = s + 1 + p by omega]
+  simp only [Matrix.mul_assoc]
+
+/-! ### The insertion correspondence at one bond -/
+
+/-- **The insertion correspondence at one bond** (arXiv:1804.04964, Lemma 5
+applied to the deformations realizing a virtual insertion, lines 1961--2255
+of `Papers/1804.04964/paper_normal.tex`, site-dependent form): for every
+insertion `X` on the bond `(r + L - 1, r + L)` of the `A`-chain there is a
+`Y` on the same bond of the `B`-chain with
+`Λ 0 (A`-window`⬝ X) = B`-window`⬝ Y` on the window ending at the bond and
+`Λ L (X ⬝ A`-window`) = Y ⬝ B`-window on the window starting at the bond,
+where `Λ j` is the arc transport at the window start `r + j`. -/
+private theorem exists_insertion_image [NeZero n] {A B : MPSChainTensor d D n}
+    {L : ℕ} (hL : 0 < L) (hn : 2 * L + 1 ≤ n)
+    (hA : IsWindowInjective A L) (hB : IsWindowInjective B L)
+    (hAB : SameState A B) (r : ℕ)
+    {Λ : ℕ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hΛ : ∀ (j : ℕ) (τ : Fin L → Fin d),
+      Λ j (arcEval A (r + j) (List.ofFn τ)) = arcEval B (r + j) (List.ofFn τ))
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+      (∀ a : Fin L → Fin d,
+        Λ 0 (arcEval A r (List.ofFn a) * X) = arcEval B r (List.ofFn a) * Y) ∧
+        (∀ b : Fin L → Fin d,
+          Λ L (X * arcEval A (r + L) (List.ofFn b)) =
+            Y * arcEval B (r + L) (List.ofFn b)) := by
+  classical
+  -- The deformed window tensors transported to the `B`-chain, one transport
+  -- per window start.
+  set C : ℕ → (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+    fun j s' => Λ j (insertedArc A X (r + j) (L - j) (List.ofFn s')) with hC
+  -- All transported deformations generate the same state: each one matches
+  -- the `A`-state with `X` inserted on the bond.
+  have hstate : ∀ j, j < L → ∀ {q : ℕ}, j + (L + 1) + q = n →
+      ∀ (pre : Fin j → Fin d) (u : Fin (L + 1) → Fin d) (post : Fin q → Fin d),
+      Matrix.trace (arcEval B r (List.ofFn pre) *
+          (C j (Fin.init u) * B ((r + j + L : ℕ) : Fin n) (u (Fin.last L))) *
+          arcEval B (r + j + L + 1) (List.ofFn post)) =
+        Matrix.trace (arcEval B r (List.ofFn pre) *
+          (B ((r + j : ℕ) : Fin n) (u 0) * C (j + 1) (Fin.tail u)) *
+          arcEval B (r + j + L + 1) (List.ofFn post)) := by
+    intro j hj q hq pre u post
+    -- The left side: absorb the trailing letter into the suffix, transport,
+    -- and push the letter back into the deformed arc.
+    have hleft : Matrix.trace (arcEval B r (List.ofFn pre) *
+        (C j (Fin.init u) * B ((r + j + L : ℕ) : Fin n) (u (Fin.last L))) *
+        arcEval B (r + j + L + 1) (List.ofFn post)) =
+        Matrix.trace (arcEval A r (List.ofFn pre) *
+          insertedArc A X (r + j) (L - j) (List.ofFn u) *
+          arcEval A (r + j + L + 1) (List.ofFn post)) := by
+      have e1 : arcEval B r (List.ofFn pre) *
+          (C j (Fin.init u) * B ((r + j + L : ℕ) : Fin n) (u (Fin.last L))) *
+          arcEval B (r + j + L + 1) (List.ofFn post) =
+          arcEval B r (List.ofFn pre) * C j (Fin.init u) *
+            arcEval B (r + j + L) (u (Fin.last L) :: List.ofFn post) := by
+        rw [arcEval_cons]
+        simp only [Matrix.mul_assoc]
+      rw [e1]
+      simp only [hC]
+      rw [trace_transport_sandwich hA hAB (hΛ j) _ (List.ofFn pre)
+        (u (Fin.last L) :: List.ofFn post) (by simp)
+        (by simp; omega)]
+      have e2 : arcEval A r (List.ofFn pre) *
+          insertedArc A X (r + j) (L - j) (List.ofFn (Fin.init u)) *
+            arcEval A (r + j + L) (u (Fin.last L) :: List.ofFn post) =
+          arcEval A r (List.ofFn pre) *
+            (insertedArc A X (r + j) (L - j) (List.ofFn (Fin.init u)) *
+              A ((r + j + L : ℕ) : Fin n) (u (Fin.last L))) *
+              arcEval A (r + j + L + 1) (List.ofFn post) := by
+        rw [arcEval_cons]
+        simp only [Matrix.mul_assoc]
+      rw [e2, insertedArc_append_letter A X
+        (by simp : L - j ≤ (List.ofFn (Fin.init u)).length)
+        (by simp : r + j + L = r + j + (List.ofFn (Fin.init u)).length)
+        (u (Fin.last L))]
+      have e3 : List.ofFn (Fin.init u) ++ [u (Fin.last L)] = List.ofFn u := by
+        rw [List.ofFn_succ' u, List.concat_eq_append]
+        rfl
+      rw [e3]
+    -- The right side: absorb the leading letter into the prefix, transport,
+    -- and push the letter back into the deformed arc.
+    have hright : Matrix.trace (arcEval B r (List.ofFn pre) *
+        (B ((r + j : ℕ) : Fin n) (u 0) * C (j + 1) (Fin.tail u)) *
+        arcEval B (r + j + L + 1) (List.ofFn post)) =
+        Matrix.trace (arcEval A r (List.ofFn pre) *
+          insertedArc A X (r + j) (L - j) (List.ofFn u) *
+          arcEval A (r + j + L + 1) (List.ofFn post)) := by
+      have e1 : arcEval B r (List.ofFn pre) *
+          (B ((r + j : ℕ) : Fin n) (u 0) * C (j + 1) (Fin.tail u)) *
+          arcEval B (r + j + L + 1) (List.ofFn post) =
+          arcEval B r (List.ofFn pre ++ [u 0]) * C (j + 1) (Fin.tail u) *
+            arcEval B (r + j + L + 1) (List.ofFn post) := by
+        rw [arcEval_append, List.length_ofFn, arcEval_cons, arcEval_nil,
+          Matrix.mul_one]
+        simp only [Matrix.mul_assoc]
+      have hΛ1 : ∀ τ : Fin L → Fin d,
+          Λ (j + 1) (arcEval A (r + j + 1) (List.ofFn τ)) =
+            arcEval B (r + j + 1) (List.ofFn τ) := by
+        intro τ
+        have h := hΛ (j + 1) τ
+        rwa [← Nat.add_assoc r j 1] at h
+      rw [e1]
+      simp only [hC]
+      rw [← Nat.add_assoc r j 1, show r + j + L + 1 = r + j + 1 + L by omega]
+      rw [trace_transport_sandwich hA hAB hΛ1 _
+        (List.ofFn pre ++ [u 0]) (List.ofFn post)
+        (by simp; omega) (by simp; omega)]
+      have e2 : arcEval A r (List.ofFn pre ++ [u 0]) *
+          insertedArc A X (r + j + 1) (L - (j + 1)) (List.ofFn (Fin.tail u)) *
+            arcEval A (r + j + 1 + L) (List.ofFn post) =
+          arcEval A r (List.ofFn pre) *
+            (A ((r + j : ℕ) : Fin n) (u 0) *
+              insertedArc A X (r + j + 1) (L - (j + 1)) (List.ofFn (Fin.tail u))) *
+              arcEval A (r + j + 1 + L) (List.ofFn post) := by
+        rw [arcEval_append, List.length_ofFn, arcEval_cons, arcEval_nil,
+          Matrix.mul_one]
+        simp only [Matrix.mul_assoc]
+      rw [e2]
+      have e4 : A ((r + j : ℕ) : Fin n) (u 0) *
+          insertedArc A X (r + j + 1) (L - (j + 1)) (List.ofFn (Fin.tail u)) =
+          insertedArc A X (r + j) (L - j) (List.ofFn u) := by
+        rw [insertedArc_cons_letter A X (r + j) (L - (j + 1))
+          (List.ofFn (Fin.tail u)) (u 0),
+          show L - (j + 1) + 1 = L - j by omega]
+        congr 1
+        rw [List.ofFn_succ (f := u)]
+        rfl
+      rw [e4, show r + j + 1 + L = r + j + L + 1 by omega]
+    rw [hleft, hright]
+  -- Lemma 5 extracts the bond operator on the `B`-chain.
+  obtain ⟨Y, hY1, hY2⟩ := overlapWindow_exists_bondOperator hL hn hB r C hstate
+  refine ⟨Y, fun a => ?_, fun b => ?_⟩
+  · have h0 := hY1 a
+    simp only [hC, Nat.sub_zero] at h0
+    rw [← insertedArc_length A X (s := r) (p := L)
+      (by simp : (List.ofFn a).length ≤ L)]
+    exact h0
+  · have hL0 := hY2 b
+    simp only [hC, Nat.sub_self, insertedArc_zero] at hL0
+    exact hL0
+
+/-! ### The insertion correspondence as an algebra homomorphism -/
+
+/-- Any list of declared length is the word of a tuple. -/
+private theorem exists_ofFn_of_length {l : List (Fin d)} {k : ℕ}
+    (hl : l.length = k) : ∃ a : Fin k → Fin d, List.ofFn a = l := by
+  subst hl
+  exact ⟨l.get, List.ofFn_get l⟩
+
+/-- A nonzero-size identity matrix is nonzero. -/
+private theorem matrix_one_ne_zero (hD : 0 < D) :
+    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
+  intro h
+  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
+  rw [Matrix.one_apply_eq] at hentry
+  exact one_ne_zero hentry
+
+/-- **The insertion correspondence is an algebra homomorphism**
+(arXiv:1804.04964, Lemma 5, the closing clause at line 2253 of
+`Papers/1804.04964/paper_normal.tex`: the maps `O_1 ↦ X` and `O_3^T ↦ X`
+"are uniquely defined and are algebra-homomorphisms", site-dependent form).
+
+For two window-injective site-dependent chains generating the same
+closed-chain state on `n ≥ 2L + 1` sites, the correspondence sending an
+insertion `X` on the bond `(r + L - 1, r + L)` of the `A`-chain to the bond
+operator extracted by Lemma 5 on the `B`-chain is a linear, unital and
+multiplicative map `Φ` of the matrix algebra; it pairs the two chains
+against every closed-chain word read from the bond.  Uniqueness is
+`MPSChainTensor.insertionHom_unique`.
+
+**Scope restriction (uniform physical and bond dimensions):** the source
+poses no restriction on the local dimensions of the site-dependent tensors,
+while here all sites share one physical dimension `d` and all bonds one
+bond dimension `D`.  Documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+theorem exists_insertionHom [NeZero n] {L : ℕ} (hL : 0 < L)
+    (hn : 2 * L + 1 ≤ n) (A B : MPSChainTensor d D n)
+    (hA : IsWindowInjective A L) (hB : IsWindowInjective B L)
+    (hAB : SameState A B) (r : ℕ) :
+    ∃ Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+      Φ 1 = 1 ∧ (∀ M N, Φ (M * N) = Φ M * Φ N) ∧
+        ∀ (X : Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d)), w.length = n →
+          Matrix.trace (X * arcEval A (r + L) w) =
+            Matrix.trace (Φ X * arcEval B (r + L) w) := by
+  classical
+  -- One arc transport per window start.
+  have hch : ∀ j : ℕ, ∃ Λj : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+      Matrix (Fin D) (Fin D) ℂ,
+      ∀ τ : Fin L → Fin d,
+        Λj (arcEval A (r + j) (List.ofFn τ)) = arcEval B (r + j) (List.ofFn τ) :=
+    fun j => exists_arcTransport (k := L) (q := n - L) (by omega)
+      (hA.arc_span hL le_rfl _) (hA.arc_span hL (by omega) _) hAB
+  choose Λ hΛ using hch
+  have hΛ0 : ∀ τ : Fin L → Fin d,
+      Λ 0 (arcEval A r (List.ofFn τ)) = arcEval B r (List.ofFn τ) := by
+    intro τ
+    have h := hΛ 0 τ
+    rwa [Nat.add_zero] at h
+  have hins := exists_insertion_image hL hn hA hB hAB r hΛ
+  -- The identity decomposition over the `B`-window products at the bond.
+  have h1B : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
+      (Set.range fun b : Fin L → Fin d => arcEval B (r + L) (List.ofFn b)) :=
+    (hB (r + L)) ▸ Submodule.mem_top
+  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1B
+  -- The correspondence as a linear map.
+  set Φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+    ∑ b : Fin L → Fin d, α b •
+      (Λ L ∘ₗ LinearMap.mulRight ℂ (arcEval A (r + L) (List.ofFn b))) with hΦdef
+  have hΦ_apply : ∀ X, Φ X = ∑ b : Fin L → Fin d,
+      α b • Λ L (X * arcEval A (r + L) (List.ofFn b)) := by
+    intro X
+    rw [hΦdef]
+    simp only [LinearMap.sum_apply, LinearMap.smul_apply, LinearMap.comp_apply,
+      LinearMap.mulRight_apply]
+  -- `Φ X` is the bond operator of `X`.
+  have hΦY : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      (∀ a : Fin L → Fin d,
+        Λ 0 (arcEval A r (List.ofFn a) * X) = arcEval B r (List.ofFn a) * Φ X) ∧
+        (∀ b : Fin L → Fin d,
+          Λ L (X * arcEval A (r + L) (List.ofFn b)) =
+            Φ X * arcEval B (r + L) (List.ofFn b)) := by
+    intro X
+    obtain ⟨Y, hY1, hY2⟩ := hins X
+    have hYΦ : Φ X = Y := by
+      rw [hΦ_apply]
+      calc (∑ b : Fin L → Fin d, α b • Λ L (X * arcEval A (r + L) (List.ofFn b)))
+          = ∑ b : Fin L → Fin d, α b • (Y * arcEval B (r + L) (List.ofFn b)) :=
+            Finset.sum_congr rfl fun b _ => by rw [hY2 b]
+        _ = ∑ b : Fin L → Fin d, Y * (α b • arcEval B (r + L) (List.ofFn b)) :=
+            Finset.sum_congr rfl fun b _ => (mul_smul_comm _ _ _).symm
+        _ = Y * ∑ b : Fin L → Fin d, α b • arcEval B (r + L) (List.ofFn b) := by
+            rw [← Finset.mul_sum]
+        _ = Y := by rw [hα, Matrix.mul_one]
+    rw [hYΦ]
+    exact ⟨hY1, hY2⟩
+  have hΦ1 : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (a : Fin L → Fin d),
+      Λ 0 (arcEval A r (List.ofFn a) * X) = arcEval B r (List.ofFn a) * Φ X :=
+    fun X => (hΦY X).1
+  -- The right-multiplication relation extends from window products to all
+  -- matrices, making `Φ` multiplicative.
+  have hΛr : ∀ (X M : Matrix (Fin D) (Fin D) ℂ),
+      Λ 0 (M * X) = Λ 0 M * Φ X := by
+    intro X
+    have hext := LinearMap.ext_on_range
+      (v := fun a : Fin L → Fin d => arcEval A r (List.ofFn a)) (hv := hA r)
+      (f := Λ 0 ∘ₗ LinearMap.mulRight ℂ X)
+      (g := (LinearMap.mulRight ℂ (Φ X)) ∘ₗ Λ 0)
+      (fun a => by
+        simp only [LinearMap.comp_apply, LinearMap.mulRight_apply]
+        rw [hΦ1 X a, hΛ0 a])
+    intro M
+    have := congrArg (· M) hext
+    simpa only [LinearMap.comp_apply, LinearMap.mulRight_apply] using this
+  have hΦmul : ∀ M N : Matrix (Fin D) (Fin D) ℂ, Φ (M * N) = Φ M * Φ N := by
+    intro M N
+    apply eq_of_span_mul_left (W := fun a : Fin L → Fin d =>
+      arcEval B r (List.ofFn a)) (hB r)
+    intro a
+    calc arcEval B r (List.ofFn a) * Φ (M * N)
+        = Λ 0 (arcEval A r (List.ofFn a) * (M * N)) := (hΦ1 (M * N) a).symm
+      _ = Λ 0 ((arcEval A r (List.ofFn a) * M) * N) := by rw [Matrix.mul_assoc]
+      _ = Λ 0 (arcEval A r (List.ofFn a) * M) * Φ N := hΛr N _
+      _ = (arcEval B r (List.ofFn a) * Φ M) * Φ N := by rw [hΦ1 M a]
+      _ = arcEval B r (List.ofFn a) * (Φ M * Φ N) := Matrix.mul_assoc _ _ _
+  have hΦone : Φ 1 = 1 := by
+    apply eq_of_span_mul_left (W := fun a : Fin L → Fin d =>
+      arcEval B r (List.ofFn a)) (hB r)
+    intro a
+    calc arcEval B r (List.ofFn a) * Φ 1
+        = Λ 0 (arcEval A r (List.ofFn a) * 1) := (hΦ1 1 a).symm
+      _ = Λ 0 (arcEval A r (List.ofFn a)) := by rw [Matrix.mul_one]
+      _ = arcEval B r (List.ofFn a) := hΛ0 a
+      _ = arcEval B r (List.ofFn a) * 1 := (Matrix.mul_one _).symm
+  refine ⟨Φ, hΦone, hΦmul, fun X w hw => ?_⟩
+  -- The closed-chain pairing of insertions, read from the bond.
+  have hdrop : (w.drop (n - L)).length = L := by
+    rw [List.length_drop]
+    omega
+  obtain ⟨a, ha⟩ := exists_ofFn_of_length hdrop
+  have htake : (w.take (n - L)).length = n - L := by
+    rw [List.length_take]
+    omega
+  have hsplit : w = w.take (n - L) ++ List.ofFn a := by
+    rw [ha, List.take_append_drop]
+  -- The sandwich relation at the window, from the transport bridge.
+  have hsand : Matrix.trace (Λ 0 (arcEval A r (List.ofFn a) * X) *
+      arcEval B (r + L) (w.take (n - L))) =
+      Matrix.trace (arcEval A r (List.ofFn a) * X *
+        arcEval A (r + L) (w.take (n - L))) := by
+    have hb := trace_transport_sandwich hA hAB hΛ0
+      (arcEval A r (List.ofFn a) * X) (s₀ := r) [] (w.take (n - L))
+      (by simp) (by simp [htake]; omega)
+    simpa only [arcEval_nil, Matrix.one_mul] using hb
+  -- Fold the rotated word on each chain.
+  have hfold : ∀ T : MPSChainTensor d D n,
+      arcEval T (r + L) (w.take (n - L)) * arcEval T r (List.ofFn a) =
+        arcEval T (r + L) w := by
+    intro T
+    conv_rhs => rw [hsplit]
+    rw [arcEval_append, htake, show r + L + (n - L) = r + n by omega,
+      arcEval_add_n]
+  calc Matrix.trace (X * arcEval A (r + L) w)
+      = Matrix.trace (X * (arcEval A (r + L) (w.take (n - L)) *
+          arcEval A r (List.ofFn a))) := by rw [hfold A]
+    _ = Matrix.trace (arcEval A r (List.ofFn a) * X *
+          arcEval A (r + L) (w.take (n - L))) := by
+        rw [← Matrix.mul_assoc, Matrix.trace_mul_comm, Matrix.mul_assoc]
+    _ = Matrix.trace (Λ 0 (arcEval A r (List.ofFn a) * X) *
+          arcEval B (r + L) (w.take (n - L))) := hsand.symm
+    _ = Matrix.trace (arcEval B r (List.ofFn a) * Φ X *
+          arcEval B (r + L) (w.take (n - L))) := by rw [hΦ1 X a]
+    _ = Matrix.trace (Φ X * (arcEval B (r + L) (w.take (n - L)) *
+          arcEval B r (List.ofFn a))) := by
+        rw [Matrix.mul_assoc, Matrix.trace_mul_comm, ← Matrix.mul_assoc,
+          Matrix.mul_assoc]
+    _ = Matrix.trace (Φ X * arcEval B (r + L) w) := by rw [hfold B]
+
+/-- **Uniqueness of the insertion correspondence** (arXiv:1804.04964,
+Lemma 5, line 2253 of `Papers/1804.04964/paper_normal.tex`: the maps
+"are uniquely defined", site-dependent form).  Two linear maps pairing
+identically against all closed-chain words of the window-injective `B`-chain
+are equal. -/
+theorem insertionHom_unique [NeZero n] {B : MPSChainTensor d D n} {L : ℕ}
+    (hL : 0 < L) (hn : L ≤ n) (hB : IsWindowInjective B L) (p : ℕ)
+    {Φ Φ' : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d)), w.length = n →
+      Matrix.trace (Φ X * arcEval B p w) = Matrix.trace (Φ' X * arcEval B p w)) :
+    Φ = Φ' := by
+  refine LinearMap.ext fun X => ?_
+  refine eq_of_trace_pairing_span (F := fun ρ : Fin n → Fin d =>
+    arcEval B p (List.ofFn ρ)) (hB.arc_span hL hn p) fun ρ => ?_
+  exact h X (List.ofFn ρ) (by simp)
+
+/-! ### The conjugation between same-state chains -/
+
+/-- Two matrices with equal trace pairings against every matrix on the left
+are equal. -/
+private theorem eq_of_trace_mul_left_eq {M N : Matrix (Fin D) (Fin D) ℂ}
+    (h : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace (X * M) = Matrix.trace (X * N)) : M = N := by
+  have h0 : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace ((M - N) * X) = 0 := by
+    intro X
+    rw [Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_mul_comm M X,
+      Matrix.trace_mul_comm N X, h X, sub_self]
+  exact sub_eq_zero.mp (MPSTensor.trace_mul_right_eq_zero h0)
+
+/-- **The conjugation between two same-state site-dependent chains at length
+`n ≥ 2L + 1`** (arXiv:1804.04964, Lemma 5 and the closed-chain corollary of
+Section `normal_alt`, lines 1961--2295 of
+`Papers/1804.04964/paper_normal.tex`, site-dependent form; the
+site-independent specialization is
+`MPSTensor.exists_conjugation_of_mpv_eq`).
+
+Two window-injective site-dependent chains generating the same closed-chain
+state on `n ≥ 2L + 1` sites have conjugate arc products of full length at
+every bond: for each site `p` there is an invertible `Z` with
+`B`-arc `= Z ⬝ A`-arc `⬝ Z⁻¹` for every word of length `n` read from site
+`p`.  The insertion correspondence at the bond is an algebra automorphism
+of the full matrix algebra, by Skolem--Noether inner; pairing insertions
+against all closed-chain words transfers the conjugation to the arc
+products.
+
+**Scope restriction (uniform physical and bond dimensions):** the source
+poses no restriction on the local dimensions of the site-dependent tensors,
+while here all sites share one physical dimension `d` and all bonds one
+bond dimension `D`.  Documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+theorem exists_conjugation_of_sameState [NeZero n] {L : ℕ} (hL : 0 < L)
+    (hn : 2 * L + 1 ≤ n) (A B : MPSChainTensor d D n)
+    (hA : IsWindowInjective A L) (hB : IsWindowInjective B L)
+    (hAB : SameState A B) (p : ℕ) :
+    ∃ Z : GL (Fin D) ℂ, ∀ w : List (Fin d), w.length = n →
+      arcEval B p w = (Z : Matrix (Fin D) (Fin D) ℂ) * arcEval A p w *
+        ((Z⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+  classical
+  rcases Nat.eq_zero_or_pos D with hD0 | hD
+  · -- All `0 × 0` matrices are equal.
+    subst hD0
+    refine ⟨1, fun w hw => ?_⟩
+    apply Matrix.ext
+    intro a b
+    exact a.elim0
+  -- The insertion correspondence at the bond `(p - 1, p)`, reading the
+  -- chain from the window start `p + (n - L)`.
+  obtain ⟨Φ, hΦone, hΦmul, hpair⟩ :=
+    exists_insertionHom hL hn A B hA hB hAB (p + (n - L))
+  have hpair' : ∀ (X : Matrix (Fin D) (Fin D) ℂ) (w : List (Fin d)),
+      w.length = n →
+      Matrix.trace (X * arcEval A p w) = Matrix.trace (Φ X * arcEval B p w) := by
+    intro X w hw
+    have h := hpair X w hw
+    rwa [show p + (n - L) + L = p + n by omega, arcEval_add_n,
+      arcEval_add_n] at h
+  -- `Φ` is unital, hence nonzero, hence an automorphism, hence inner.
+  have hΦne : Φ ≠ 0 := by
+    intro h0
+    apply matrix_one_ne_zero hD
+    rw [← hΦone, h0]
+    rfl
+  have hBij := MPSTensor.linear_mul_endomorphism_bijective Φ hΦmul hΦne
+  let fHom := MPSTensor.linearMapToAlgHom Φ hΦmul hBij.surjective
+  let f := AlgEquiv.ofBijective fHom hBij
+  obtain ⟨P, hP⟩ := MPSTensor.skolemNoether_matrix f
+  have hΦP : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      Φ X = (P : Matrix (Fin D) (Fin D) ℂ) * X *
+        ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+    intro X
+    have : f X = Φ X := rfl
+    rw [← this]
+    exact hP X
+  -- Strip the insertions: the arc products are conjugate.
+  refine ⟨P, fun w hw => ?_⟩
+  have hAw : arcEval A p w =
+      ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * arcEval B p w *
+        (P : Matrix (Fin D) (Fin D) ℂ) := by
+    apply eq_of_trace_mul_left_eq
+    intro X
+    calc Matrix.trace (X * arcEval A p w)
+        = Matrix.trace (Φ X * arcEval B p w) := hpair' X w hw
+      _ = Matrix.trace ((P : Matrix (Fin D) (Fin D) ℂ) * X *
+            ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+              arcEval B p w) := by rw [hΦP X]
+      _ = Matrix.trace (X * (((P⁻¹ : GL (Fin D) ℂ) :
+            Matrix (Fin D) (Fin D) ℂ) * arcEval B p w *
+              (P : Matrix (Fin D) (Fin D) ℂ))) := by
+          rw [Matrix.mul_assoc, Matrix.mul_assoc, Matrix.trace_mul_comm,
+            Matrix.mul_assoc, Matrix.mul_assoc]
+  calc arcEval B p w
+      = ((P * P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * arcEval B p w *
+          ((P * P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+        rw [mul_inv_cancel, Units.val_one, Matrix.one_mul, Matrix.mul_one]
+    _ = (P : Matrix (Fin D) (Fin D) ℂ) *
+          (((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * arcEval B p w *
+            (P : Matrix (Fin D) (Fin D) ℂ)) *
+          ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by
+        rw [Units.val_mul]
+        simp only [Matrix.mul_assoc]
+    _ = (P : Matrix (Fin D) (Fin D) ℂ) * arcEval A p w *
+          ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) := by rw [← hAw]
+
+end MPSChainTensor

--- a/TNLean/PEPS/CycleMPSChainOverlapWindow.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapWindow.lean
@@ -1,0 +1,380 @@
+import TNLean.PEPS.CycleMPSChainArc
+
+/-!
+# Bond-operator extraction from overlapping windows, site-dependent form
+
+This file proves the matrix-tensor form of Lemma 5 of arXiv:1804.04964
+(lines 2045--2255 of `Papers/1804.04964/paper_normal.tex`) for
+site-dependent tensors, the setting in which the source states it: a closed
+chain carries one tensor per site (`A_1, …, A_5` on five sites in the
+source's display, with `L = 2`), every window of `L` consecutive sites is
+injective, and a deformation of the closed-chain state is realized by
+operators on each of the `L + 1` overlapping length-`L` windows around a
+bond.  Then the deformation is a single virtual operation `X` on the bond:
+
+* the deformed window left of the bond factors as the window product times
+  `X` on the right, and the deformed window right of the bond as `X` times
+  the window product
+  (`MPSChainTensor.overlapWindow_exists_bondOperator`), and
+* `X` is unique (`MPSChainTensor.eq_of_span_mul_left` applied to either
+  spanning window).
+
+The proof follows the source.  Comparing the windows at positions `j` and
+`j + 1` through the rest of the chain — an arc of `n - L - 1 ≥ L` sites,
+injective by the arc-spanning lemma — strips the state equality to a
+letter-level relation (the source's `eq:normal_act_123` and
+`eq:normal_act_234`, lines 2140--2167).  Chaining the `L` relations along
+the `2L` sites flanking the bond turns the leftmost window into the
+rightmost one (the source's plugging of `A_4` and `A_1`, lines 2168--2210),
+and the two ends are compared as in `eq:inj_O->X_argument` (line 377): a
+combination of window products representing the identity extracts the bond
+operator from either side, and the two extractions agree
+(`MPSChainTensor.exists_bondOperator_of_intertwine_span`).
+
+The previously landed `TNLean/PEPS/CycleMPSOverlapWindow.lean` proves the
+same statement for one site-independent tensor; it now delegates to this
+file through the constant chain.
+
+**Scope restriction (uniform physical and bond dimensions):** the source
+poses no restriction on the local dimensions of the site-dependent tensors,
+while here all sites share one physical dimension `d` and all bonds one bond
+dimension `D`.  Documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected
+  entangled pair states generating the same state*, arXiv:1804.04964,
+  Lemma 5 of Section `normal_alt`, lines 2045--2255 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964)
+-/
+
+open scoped Matrix
+open scoped Fin.NatCast
+
+namespace MPSChainTensor
+
+variable {d D n : ℕ}
+
+/-! ### Extracting the bond operator from the two ends -/
+
+/-- **Bond-operator extraction from an intertwining pair, spanning-family
+form** (arXiv:1804.04964, Lemma 5, the comparison of the two ends, lines
+2211--2255 of `Papers/1804.04964/paper_normal.tex`, after the model of
+`eq:inj_O->X_argument`, line 377).
+
+If `F a ⬝ W₂ b = W₁ a ⬝ G b` for two spanning families `W₁`, `W₂` of the
+matrix algebra — on the chain, the products of the windows on the two sides
+of the bond — then a single matrix `X` factors both deforming families:
+`F` is the first family times `X` on the right, `G` is `X` times the second
+family.  `X` is the combination of the `G`-family by coefficients
+representing the identity over `W₂`, and the two factorizations agree
+because the mirrored combination of the `F`-family collapses onto the same
+matrix. -/
+theorem exists_bondOperator_of_intertwine_span {ι κ : Type*}
+    [Finite ι] [Finite κ]
+    {W₁ : ι → Matrix (Fin D) (Fin D) ℂ} {W₂ : κ → Matrix (Fin D) (Fin D) ℂ}
+    (hW₁ : Submodule.span ℂ (Set.range W₁) = ⊤)
+    (hW₂ : Submodule.span ℂ (Set.range W₂) = ⊤)
+    (F : ι → Matrix (Fin D) (Fin D) ℂ) (G : κ → Matrix (Fin D) (Fin D) ℂ)
+    (h : ∀ a b, F a * W₂ b = W₁ a * G b) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      (∀ a, F a = W₁ a * X) ∧ (∀ b, G b = X * W₂ b) := by
+  cases nonempty_fintype κ
+  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+      Submodule.span ℂ (Set.range W₂) := hW₂ ▸ Submodule.mem_top
+  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
+  set X₀ : Matrix (Fin D) (Fin D) ℂ := ∑ b, α b • G b with hX₀
+  have hF : ∀ a, F a = W₁ a * X₀ := by
+    intro a
+    calc F a = F a * (1 : Matrix (Fin D) (Fin D) ℂ) := (Matrix.mul_one _).symm
+      _ = F a * ∑ b, α b • W₂ b := by rw [hα]
+      _ = ∑ b, α b • (F a * W₂ b) := by
+          rw [Finset.mul_sum]
+          exact Finset.sum_congr rfl fun b _ => mul_smul_comm _ _ _
+      _ = ∑ b, α b • (W₁ a * G b) := Finset.sum_congr rfl fun b _ => by rw [h a b]
+      _ = ∑ b, W₁ a * (α b • G b) := Finset.sum_congr rfl fun b _ =>
+          (mul_smul_comm _ _ _).symm
+      _ = W₁ a * X₀ := by rw [← Finset.mul_sum, hX₀]
+  refine ⟨X₀, hF, fun b => ?_⟩
+  -- The left factorization of `G`: compare against the right factorization
+  -- through the intertwining relation and strip the spanning first family.
+  apply eq_of_span_mul_left hW₁ (X := G b) (X' := X₀ * W₂ b)
+  intro a
+  calc W₁ a * G b = F a * W₂ b := (h a b).symm
+    _ = (W₁ a * X₀) * W₂ b := by rw [hF a]
+    _ = W₁ a * (X₀ * W₂ b) := Matrix.mul_assoc _ _ _
+
+/-! ### Stripping the state equality to the letter level -/
+
+/-- **Window comparison through the complementary arc** (arXiv:1804.04964,
+Lemma 5, the inversions producing `eq:normal_act_123` and
+`eq:normal_act_234`, lines 2140--2167 of
+`Papers/1804.04964/paper_normal.tex`, site-dependent form).
+
+If the states obtained by applying the deformed window tensors `C` at
+position `j` and `C'` at position `j + 1` — windows starting at sites
+`r + j` and `r + j + 1` of the closed chain — agree, then comparing through
+the remaining `n - L - 1 ≥ L` sites, whose arc products span by the
+arc-spanning lemma, strips the equality to the letter level: on every
+window of `L + 1` sites, `C` contracted with the trailing letter at site
+`r + j + L` equals the leading letter at site `r + j` contracted with
+`C'`. -/
+private theorem window_letter_step [NeZero n] {A : MPSChainTensor d D n}
+    {L : ℕ} (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hA : IsWindowInjective A L)
+    {r j q : ℕ} (hq : j + (L + 1) + q = n)
+    {C C' : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ}
+    (hstate : ∀ (pre : Fin j → Fin d) (u : Fin (L + 1) → Fin d)
+      (post : Fin q → Fin d),
+      Matrix.trace (arcEval A r (List.ofFn pre) *
+          (C (Fin.init u) * A ((r + j + L : ℕ) : Fin n) (u (Fin.last L))) *
+          arcEval A (r + j + L + 1) (List.ofFn post)) =
+        Matrix.trace (arcEval A r (List.ofFn pre) *
+          (A ((r + j : ℕ) : Fin n) (u 0) * C' (Fin.tail u)) *
+          arcEval A (r + j + L + 1) (List.ofFn post)))
+    (u : Fin (L + 1) → Fin d) :
+    C (Fin.init u) * A ((r + j + L : ℕ) : Fin n) (u (Fin.last L)) =
+      A ((r + j : ℕ) : Fin n) (u 0) * C' (Fin.tail u) := by
+  apply eq_of_trace_pairing_span (F := fun ρ : Fin (q + j) → Fin d =>
+    arcEval A (r + j + L + 1) (List.ofFn ρ)) (hA.arc_span hL (by omega) _)
+  intro ρ
+  -- Split the complementary arc into the suffix and the prefix of the
+  -- chain, both read from the bond outward.
+  set post : Fin q → Fin d := fun i => ρ (Fin.castLE (by omega) i) with hpost
+  set pre : Fin j → Fin d := fun i => ρ (Fin.natAdd q i) with hpre
+  have hρ : List.ofFn post ++ List.ofFn pre = List.ofFn ρ :=
+    (List.ofFn_add (f := ρ)).symm
+  have key : ∀ M : Matrix (Fin D) (Fin D) ℂ,
+      Matrix.trace (arcEval A r (List.ofFn pre) * M *
+          arcEval A (r + j + L + 1) (List.ofFn post)) =
+        Matrix.trace (M * arcEval A (r + j + L + 1) (List.ofFn ρ)) := by
+    intro M
+    calc Matrix.trace (arcEval A r (List.ofFn pre) * M *
+            arcEval A (r + j + L + 1) (List.ofFn post))
+        = Matrix.trace (arcEval A (r + j + L + 1) (List.ofFn post) *
+            (arcEval A r (List.ofFn pre) * M)) := Matrix.trace_mul_comm _ _
+      _ = Matrix.trace (M * (arcEval A (r + j + L + 1) (List.ofFn post) *
+            arcEval A r (List.ofFn pre))) := by
+          rw [← Matrix.mul_assoc]
+          exact Matrix.trace_mul_comm _ _
+      _ = Matrix.trace (M * arcEval A (r + j + L + 1) (List.ofFn ρ)) := by
+          rw [← hρ, arcEval_append, List.length_ofFn,
+            show r + j + L + 1 + q = r + n by omega, arcEval_add_n]
+  rw [← key, ← key]
+  exact hstate pre u post
+
+/-! ### Chaining the windows across the bond -/
+
+/-- The deformed window shifted `k` sites: the first `L - k` letters are
+read from the tail of `a`, the remaining `k` letters from the head of
+`b`. -/
+private def shiftWindow {L : ℕ} (k : ℕ) (hk : k ≤ L) (a b : Fin L → Fin d) :
+    Fin L → Fin d := fun i =>
+  if h : i.val + k < L then a ⟨i.val + k, h⟩
+  else b ⟨i.val + k - L, by have := i.isLt; omega⟩
+
+private theorem shiftWindow_zero {L : ℕ} (hk : 0 ≤ L) (a b : Fin L → Fin d) :
+    shiftWindow 0 hk a b = a := by
+  funext i
+  have hi := i.isLt
+  simp only [shiftWindow]
+  rw [dif_pos (show i.val + 0 < L by omega)]
+  exact congrArg a (Fin.ext (show i.val + 0 = i.val by omega))
+
+private theorem shiftWindow_self {L : ℕ} (hk : L ≤ L) (a b : Fin L → Fin d) :
+    shiftWindow L hk a b = b := by
+  funext i
+  have hi := i.isLt
+  simp only [shiftWindow]
+  rw [dif_neg (show ¬ i.val + L < L by omega)]
+  exact congrArg b (Fin.ext (show i.val + L - L = i.val by omega))
+
+private theorem shiftWindow_apply_zero {L' k : ℕ} (hk : k ≤ L')
+    (hk' : k ≤ L' + 1) (a b : Fin (L' + 1) → Fin d) :
+    shiftWindow k hk' a b 0 = a ⟨k, by omega⟩ := by
+  have h0 : (0 : Fin (L' + 1)).val = 0 := rfl
+  simp only [shiftWindow]
+  rw [dif_pos (show (0 : Fin (L' + 1)).val + k < L' + 1 by omega)]
+  exact congrArg a (Fin.ext (show (0 : Fin (L' + 1)).val + k = k by omega))
+
+/-- Shifting the deformed window by one site: popping the leading letter and
+appending the next letter of `b`. -/
+private theorem tail_snoc_shiftWindow {L' k : ℕ} (hk : k ≤ L')
+    (hk' : k ≤ L' + 1) (hk1 : k + 1 ≤ L' + 1) (a b : Fin (L' + 1) → Fin d) :
+    Fin.tail (α := fun _ => Fin d)
+        (Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
+          (b ⟨k, by omega⟩)) =
+      shiftWindow (k + 1) hk1 a b := by
+  funext i
+  induction i using Fin.lastCases with
+  | last =>
+      change Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
+          (b ⟨k, by omega⟩) (Fin.last L').succ =
+        shiftWindow (k + 1) hk1 a b (Fin.last L')
+      rw [Fin.succ_last, Fin.snoc_last]
+      have hlast : (Fin.last L').val = L' := rfl
+      simp only [shiftWindow]
+      rw [dif_neg (show ¬ (Fin.last L').val + (k + 1) < L' + 1 by omega)]
+      exact congrArg b
+        (Fin.ext (show k = (Fin.last L').val + (k + 1) - (L' + 1) by omega))
+  | cast i =>
+      change Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
+          (b ⟨k, by omega⟩) i.castSucc.succ =
+        shiftWindow (k + 1) hk1 a b i.castSucc
+      rw [Fin.succ_castSucc, Fin.snoc_castSucc]
+      have hsucc : (i.succ : Fin (L' + 1)).val = i.val + 1 := Fin.val_succ i
+      have hcast : (i.castSucc : Fin (L' + 1)).val = i.val := Fin.val_castSucc i
+      have hi := i.isLt
+      simp only [shiftWindow]
+      by_cases h2 : i.val + 1 + k < L' + 1
+      · rw [dif_pos (show (i.succ : Fin (L' + 1)).val + k < L' + 1 by omega),
+          dif_pos (show (i.castSucc : Fin (L' + 1)).val + (k + 1) < L' + 1 by
+            omega)]
+        exact congrArg a (Fin.ext
+          (show (i.succ : Fin (L' + 1)).val + k =
+            (i.castSucc : Fin (L' + 1)).val + (k + 1) by omega))
+      · rw [dif_neg (show ¬ (i.succ : Fin (L' + 1)).val + k < L' + 1 by omega),
+          dif_neg (show ¬ (i.castSucc : Fin (L' + 1)).val + (k + 1) < L' + 1 by
+            omega)]
+        exact congrArg b (Fin.ext
+          (show (i.succ : Fin (L' + 1)).val + k - (L' + 1) =
+            (i.castSucc : Fin (L' + 1)).val + (k + 1) - (L' + 1) by omega))
+
+/-- **Chaining the overlapping windows across the bond** (arXiv:1804.04964,
+Lemma 5, the step plugging `A_4` and `A_1` into `eq:normal_act_123` and
+`eq:normal_act_234`, lines 2168--2210 of
+`Papers/1804.04964/paper_normal.tex`, site-dependent form).
+
+Iterating the letter-level relation `L` times along the `2L` sites flanking
+the bond moves the deformed window from the left of the bond to the right:
+the leftmost deformed window contracted with the right block equals the
+left block contracted with the rightmost deformed window. -/
+private theorem chain_windows [NeZero n] {A : MPSChainTensor d D n} {L : ℕ}
+    (hL : 0 < L) (r : ℕ)
+    (C : ℕ → (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hstep : ∀ k, k < L → ∀ u : Fin (L + 1) → Fin d,
+      C k (Fin.init u) * A ((r + k + L : ℕ) : Fin n) (u (Fin.last L)) =
+        A ((r + k : ℕ) : Fin n) (u 0) * C (k + 1) (Fin.tail u))
+    (a b : Fin L → Fin d) :
+    C 0 a * arcEval A (r + L) (List.ofFn b) =
+      arcEval A r (List.ofFn a) * C L b := by
+  obtain ⟨L', rfl⟩ : ∃ L', L = L' + 1 := ⟨L - 1, by omega⟩
+  have S : ∀ k, ∀ hk : k ≤ L' + 1,
+      C 0 a * arcEval A (r + (L' + 1))
+          (List.ofFn fun i : Fin k => b (Fin.castLE hk i)) =
+        arcEval A r (List.ofFn fun i : Fin k => a (Fin.castLE hk i)) *
+          C k (shiftWindow k hk a b) := by
+    intro k
+    induction k with
+    | zero =>
+        intro hk
+        simp only [List.ofFn_zero, arcEval_nil, Matrix.mul_one, Matrix.one_mul]
+        rw [shiftWindow_zero hk a b]
+    | succ k IH =>
+        intro hk1
+        have hk : k ≤ L' := by omega
+        set u : Fin (L' + 1 + 1) → Fin d :=
+          Fin.snoc (α := fun _ => Fin d) (shiftWindow k (by omega) a b)
+            (b ⟨k, by omega⟩) with hu
+        have hinit : Fin.init u = shiftWindow k (by omega) a b :=
+          Fin.init_snoc _ _
+        have hlast : u (Fin.last (L' + 1)) = b ⟨k, by omega⟩ := Fin.snoc_last _ _
+        have hzero : u 0 = a ⟨k, by omega⟩ := by
+          rw [hu, show (0 : Fin (L' + 1 + 1)) = Fin.castSucc 0 from
+            Fin.castSucc_zero.symm, Fin.snoc_castSucc]
+          exact shiftWindow_apply_zero hk (by omega) a b
+        have htail : Fin.tail u = shiftWindow (k + 1) hk1 a b :=
+          tail_snoc_shiftWindow hk (by omega) hk1 a b
+        calc C 0 a * arcEval A (r + (L' + 1))
+              (List.ofFn fun i : Fin (k + 1) => b (Fin.castLE hk1 i))
+            = C 0 a * (arcEval A (r + (L' + 1))
+                (List.ofFn fun i : Fin k => b (Fin.castLE (by omega) i)) *
+                A ((r + (L' + 1) + k : ℕ) : Fin n) (b ⟨k, by omega⟩)) := by
+              rw [arcEval_take_succ A (r + (L' + 1)) hk1 b]
+          _ = (C 0 a * arcEval A (r + (L' + 1))
+                (List.ofFn fun i : Fin k => b (Fin.castLE (by omega) i))) *
+                A ((r + (L' + 1) + k : ℕ) : Fin n) (b ⟨k, by omega⟩) := by
+              rw [Matrix.mul_assoc]
+          _ = (arcEval A r (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
+                C k (shiftWindow k (by omega) a b)) *
+                A ((r + (L' + 1) + k : ℕ) : Fin n) (b ⟨k, by omega⟩) := by
+              rw [IH (by omega)]
+          _ = arcEval A r (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
+                (C k (Fin.init u) *
+                  A ((r + k + (L' + 1) : ℕ) : Fin n) (u (Fin.last (L' + 1)))) := by
+              rw [hinit, hlast, Matrix.mul_assoc,
+                show r + (L' + 1) + k = r + k + (L' + 1) by omega]
+          _ = arcEval A r (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
+                (A ((r + k : ℕ) : Fin n) (u 0) * C (k + 1) (Fin.tail u)) := by
+              rw [hstep k (by omega) u]
+          _ = (arcEval A r (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
+                A ((r + k : ℕ) : Fin n) (a ⟨k, by omega⟩)) *
+                C (k + 1) (shiftWindow (k + 1) hk1 a b) := by
+              rw [hzero, htail, Matrix.mul_assoc]
+          _ = arcEval A r (List.ofFn fun i : Fin (k + 1) => a (Fin.castLE hk1 i)) *
+                C (k + 1) (shiftWindow (k + 1) hk1 a b) := by
+              rw [arcEval_take_succ A r hk1 a]
+  have hfull := S (L' + 1) le_rfl
+  have hcast : ∀ f : Fin (L' + 1) → Fin d,
+      (fun i : Fin (L' + 1) => f (Fin.castLE le_rfl i)) = f := by
+    intro f
+    funext i
+    exact congrArg f (Fin.ext rfl)
+  rw [hcast a, hcast b, shiftWindow_self le_rfl a b] at hfull
+  exact hfull
+
+/-! ### The site-dependent bond-operator extraction theorem -/
+
+/-- **Lemma 5 of arXiv:1804.04964 for site-dependent matrix tensors**
+(lines 2045--2255 of `Papers/1804.04964/paper_normal.tex`).
+
+Let the closed chain on `n ≥ 2L + 1` sites carry one tensor per site, every
+window of `L > 0` consecutive sites injective, and let `C 0, …, C L` be
+deformed window tensors around the bond `(r + L - 1, r + L)`: `C j`
+replaces the blocked tensor of the `L`-site window starting at site
+`r + j`.  In the source's five-site display (`L = 2`, bond `(2, 3)`), `C j`
+is the physical operator `O_{j+1}` contracted with the blocked window it
+acts on.  If the deformed states agree for consecutive window positions —
+the hypothesis quantifies the closed-chain coefficient over a common
+refinement: a prefix of `j` sites starting at site `r`, the `L + 1` sites
+covered by the two windows, and the remaining sites — then the deformation
+is a virtual operation on the bond: a single matrix `X` with `C 0` the
+window products starting at site `r` times `X` on the right, and `C L`
+equal to `X` times the window products starting at site `r + L`.
+
+`X` is unique by `MPSChainTensor.eq_of_span_mul_left` applied to the
+spanning window starting at `r`; the algebra-homomorphism clause of the
+source lemma (its final sentence, the maps `O_1 ↦ X` and `O_3^T ↦ X`) is
+established with the site-dependent insertion correspondence in
+`TNLean/PEPS/CycleMPSChainOverlapInsertion.lean`.
+
+**Scope restriction (uniform physical and bond dimensions):** the source
+poses no restriction on the local dimensions of the site-dependent tensors,
+while here all sites share one physical dimension `d` and all bonds one
+bond dimension `D`.  Documented in
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`. -/
+theorem overlapWindow_exists_bondOperator [NeZero n] {A : MPSChainTensor d D n}
+    {L : ℕ} (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hA : IsWindowInjective A L)
+    (r : ℕ) (C : ℕ → (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hstate : ∀ j, j < L → ∀ {q : ℕ}, j + (L + 1) + q = n →
+      ∀ (pre : Fin j → Fin d) (u : Fin (L + 1) → Fin d) (post : Fin q → Fin d),
+      Matrix.trace (arcEval A r (List.ofFn pre) *
+          (C j (Fin.init u) * A ((r + j + L : ℕ) : Fin n) (u (Fin.last L))) *
+          arcEval A (r + j + L + 1) (List.ofFn post)) =
+        Matrix.trace (arcEval A r (List.ofFn pre) *
+          (A ((r + j : ℕ) : Fin n) (u 0) * C (j + 1) (Fin.tail u)) *
+          arcEval A (r + j + L + 1) (List.ofFn post))) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      (∀ a, C 0 a = arcEval A r (List.ofFn a) * X) ∧
+        (∀ b, C L b = X * arcEval A (r + L) (List.ofFn b)) := by
+  have hstep : ∀ k, k < L → ∀ u : Fin (L + 1) → Fin d,
+      C k (Fin.init u) * A ((r + k + L : ℕ) : Fin n) (u (Fin.last L)) =
+        A ((r + k : ℕ) : Fin n) (u 0) * C (k + 1) (Fin.tail u) := by
+    intro k hk u
+    exact window_letter_step hL hn hA (r := r) (j := k)
+      (q := n - (k + (L + 1))) (by omega)
+      (fun pre u' post => hstate k hk (by omega) pre u' post) u
+  exact exists_bondOperator_of_intertwine_span (hA r) (hA (r + L)) (C 0) (C L)
+    (chain_windows hL r C hstep)
+
+end MPSChainTensor

--- a/TNLean/PEPS/CycleMPSOverlapWindow.lean
+++ b/TNLean/PEPS/CycleMPSOverlapWindow.lean
@@ -1,9 +1,10 @@
 import TNLean.PEPS.CycleMPSWordTransport
+import TNLean.PEPS.CycleMPSChainOverlapWindow
 
 /-!
 # Bond-operator extraction from overlapping windows on the closed chain
 
-This file proves the matrix-tensor form of Lemma 5 of arXiv:1804.04964
+This file states the matrix-tensor form of Lemma 5 of arXiv:1804.04964
 (lines 2045--2255 of `Papers/1804.04964/paper_normal.tex`), specialized to
 one site-independent tensor: if a deformation of a closed-chain state of a
 block-injective tensor `B` is realized by operators on each of the `L + 1`
@@ -17,21 +18,13 @@ single virtual operation `X` on the bond:
   (`MPSTensor.overlapWindow_exists_bondOperator`), and
 * `X` is unique (`MPSTensor.bondOperator_unique`).
 
-The proof follows the source.  Comparing the windows at `j` and `j + 1`
-through the rest of the chain — an arc of `n - L - 1 ≥ L` sites, injective by
-the span-extension lemma — strips the state equality to a letter-level
-relation `C j (w) ⬝ B = B ⬝ C (j+1) (w shifted)` (the source's
-`eq:normal_act_123` and `eq:normal_act_234`, lines 2140--2210).  Chaining the
-`L` relations along a window of `2L` sites turns the leftmost window into the
-rightmost one (the source's plugging of `A_4` and `A_1`, lines 2168--2210),
-and the two ends are compared as in `eq:inj_O->X_argument` (line 377): a
-combination of window products representing the identity extracts the bond
-operator from either side, and the two extractions agree.
-
-The source states Lemma 5 for site-dependent tensors on five sites with
-`L = 2`; this file proves the statement for one site-independent tensor,
-arbitrary `L > 0`, and any chain length `n ≥ 2L + 1`, which is the form the
-closed-chain corollaries of Section `normal_alt` consume.
+The proofs specialize the site-dependent form of Lemma 5
+(`TNLean/PEPS/CycleMPSChainOverlapWindow.lean`), which is the setting in
+which the source states the lemma, through the constant chain placing `B`
+at every site: the arc products of the constant chain are the word products
+of `B`, and block injectivity of `B` is window injectivity of the constant
+chain.  This specialized form is the one consumed by the closed-chain
+corollaries of Section `normal_alt` for one repeated tensor.
 
 ## References
 
@@ -47,221 +40,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ### Stripping the state equality to the letter level -/
-
-/-- **Window comparison through the complementary arc** (arXiv:1804.04964,
-Lemma 5, the inversions producing `eq:normal_act_123` and
-`eq:normal_act_234`, lines 2140--2167 of
-`Papers/1804.04964/paper_normal.tex`).
-
-If the states obtained by applying the deformed window tensors `C` at
-position `j` and `C'` at position `j + 1` agree, then comparing through the
-remaining `n - L - 1 ≥ L` sites — whose word products span by the extension
-lemma — strips the equality to the letter level: on every window of `L + 1`
-sites, `C` contracted with a trailing letter equals a leading letter
-contracted with `C'`. -/
-private theorem window_letter_step {B : MPSTensor d D} {n L : ℕ}
-    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hB : IsNBlkInjective B L)
-    {j q : ℕ} (hq : j + (L + 1) + q = n)
-    {C C' : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ}
-    (hstate : ∀ (pre : Fin j → Fin d) (u : Fin (L + 1) → Fin d)
-      (post : Fin q → Fin d),
-      Matrix.trace (evalWord B (List.ofFn pre) *
-          (C (Fin.init u) * B (u (Fin.last L))) * evalWord B (List.ofFn post)) =
-        Matrix.trace (evalWord B (List.ofFn pre) *
-          (B (u 0) * C' (Fin.tail u)) * evalWord B (List.ofFn post)))
-    (u : Fin (L + 1) → Fin d) :
-    C (Fin.init u) * B (u (Fin.last L)) = B (u 0) * C' (Fin.tail u) := by
-  apply eq_of_trace_mul_evalWord_eq (m := q + j)
-    (isNBlkInjective_of_le hL hB (by omega))
-  intro ρ
-  -- Split the complementary arc into the suffix and the prefix of the chain.
-  set post : Fin q → Fin d := fun i => ρ (Fin.castLE (by omega) i) with hpost
-  set pre : Fin j → Fin d := fun i => ρ (Fin.natAdd q i) with hpre
-  have hρ : List.ofFn post ++ List.ofFn pre = List.ofFn ρ := (List.ofFn_add (f := ρ)).symm
-  have key : ∀ M : Matrix (Fin D) (Fin D) ℂ,
-      Matrix.trace (evalWord B (List.ofFn pre) * M * evalWord B (List.ofFn post)) =
-        Matrix.trace (M * evalWord B (List.ofFn ρ)) := by
-    intro M
-    calc Matrix.trace (evalWord B (List.ofFn pre) * M * evalWord B (List.ofFn post))
-        = Matrix.trace (evalWord B (List.ofFn post) *
-            (evalWord B (List.ofFn pre) * M)) :=
-          Matrix.trace_mul_comm _ _
-      _ = Matrix.trace (M * (evalWord B (List.ofFn post) *
-            evalWord B (List.ofFn pre))) := by
-          rw [← Matrix.mul_assoc]
-          exact Matrix.trace_mul_comm _ _
-      _ = Matrix.trace (M * evalWord B (List.ofFn ρ)) := by
-          rw [← evalWord_append, hρ]
-  rw [← key, ← key]
-  exact hstate pre u post
-
-/-! ### Chaining the windows across the bond -/
-
-/-- The deformed window shifted `k` sites: the first `L - k` letters are
-read from the tail of `a`, the remaining `k` letters from the head of
-`b`. -/
-private def shiftWindow {L : ℕ} (k : ℕ) (hk : k ≤ L) (a b : Fin L → Fin d) :
-    Fin L → Fin d := fun i =>
-  if h : i.val + k < L then a ⟨i.val + k, h⟩
-  else b ⟨i.val + k - L, by have := i.isLt; omega⟩
-
-private theorem shiftWindow_zero {L : ℕ} (hk : 0 ≤ L) (a b : Fin L → Fin d) :
-    shiftWindow 0 hk a b = a := by
-  funext i
-  have hi := i.isLt
-  simp only [shiftWindow]
-  rw [dif_pos (show i.val + 0 < L by omega)]
-  exact congrArg a (Fin.ext (show i.val + 0 = i.val by omega))
-
-private theorem shiftWindow_self {L : ℕ} (hk : L ≤ L) (a b : Fin L → Fin d) :
-    shiftWindow L hk a b = b := by
-  funext i
-  have hi := i.isLt
-  simp only [shiftWindow]
-  rw [dif_neg (show ¬ i.val + L < L by omega)]
-  exact congrArg b (Fin.ext (show i.val + L - L = i.val by omega))
-
-private theorem shiftWindow_apply_zero {L' k : ℕ} (hk : k ≤ L') (hk' : k ≤ L' + 1)
-    (a b : Fin (L' + 1) → Fin d) :
-    shiftWindow k hk' a b 0 = a ⟨k, by omega⟩ := by
-  have h0 : (0 : Fin (L' + 1)).val = 0 := rfl
-  simp only [shiftWindow]
-  rw [dif_pos (show (0 : Fin (L' + 1)).val + k < L' + 1 by omega)]
-  exact congrArg a (Fin.ext (show (0 : Fin (L' + 1)).val + k = k by omega))
-
-/-- Shifting the deformed window by one site: popping the leading letter and
-appending the next letter of `b`. -/
-private theorem tail_snoc_shiftWindow {L' k : ℕ} (hk : k ≤ L') (hk' : k ≤ L' + 1)
-    (hk1 : k + 1 ≤ L' + 1) (a b : Fin (L' + 1) → Fin d) :
-    Fin.tail (α := fun _ => Fin d)
-        (Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b) (b ⟨k, by omega⟩)) =
-      shiftWindow (k + 1) hk1 a b := by
-  funext i
-  induction i using Fin.lastCases with
-  | last =>
-      change Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
-          (b ⟨k, by omega⟩) (Fin.last L').succ = shiftWindow (k + 1) hk1 a b (Fin.last L')
-      rw [Fin.succ_last, Fin.snoc_last]
-      have hlast : (Fin.last L').val = L' := rfl
-      simp only [shiftWindow]
-      rw [dif_neg (show ¬ (Fin.last L').val + (k + 1) < L' + 1 by omega)]
-      exact congrArg b
-        (Fin.ext (show k = (Fin.last L').val + (k + 1) - (L' + 1) by omega))
-  | cast i =>
-      change Fin.snoc (α := fun _ => Fin d) (shiftWindow k hk' a b)
-          (b ⟨k, by omega⟩) i.castSucc.succ = shiftWindow (k + 1) hk1 a b i.castSucc
-      rw [Fin.succ_castSucc, Fin.snoc_castSucc]
-      have hsucc : (i.succ : Fin (L' + 1)).val = i.val + 1 := Fin.val_succ i
-      have hcast : (i.castSucc : Fin (L' + 1)).val = i.val := Fin.val_castSucc i
-      have hi := i.isLt
-      simp only [shiftWindow]
-      by_cases h2 : i.val + 1 + k < L' + 1
-      · rw [dif_pos (show (i.succ : Fin (L' + 1)).val + k < L' + 1 by omega),
-          dif_pos (show (i.castSucc : Fin (L' + 1)).val + (k + 1) < L' + 1 by omega)]
-        exact congrArg a (Fin.ext
-          (show (i.succ : Fin (L' + 1)).val + k =
-            (i.castSucc : Fin (L' + 1)).val + (k + 1) by omega))
-      · rw [dif_neg (show ¬ (i.succ : Fin (L' + 1)).val + k < L' + 1 by omega),
-          dif_neg (show ¬ (i.castSucc : Fin (L' + 1)).val + (k + 1) < L' + 1 by omega)]
-        exact congrArg b (Fin.ext
-          (show (i.succ : Fin (L' + 1)).val + k - (L' + 1) =
-            (i.castSucc : Fin (L' + 1)).val + (k + 1) - (L' + 1) by omega))
-
-/-- The word product of the first `k + 1` letters peels its last letter. -/
-private theorem evalWord_take_succ {B : MPSTensor d D} {L k : ℕ}
-    (hk : k + 1 ≤ L) (f : Fin L → Fin d) :
-    evalWord B (List.ofFn fun i : Fin (k + 1) => f (Fin.castLE hk i)) =
-      evalWord B (List.ofFn fun i : Fin k => f (Fin.castLE (by omega) i)) *
-        B (f ⟨k, by omega⟩) := by
-  have hsnoc : (fun i : Fin (k + 1) => f (Fin.castLE hk i)) =
-      Fin.snoc (α := fun _ => Fin d)
-        (fun i : Fin k => f (Fin.castLE (by omega) i)) (f ⟨k, by omega⟩) := by
-    funext i
-    induction i using Fin.lastCases with
-    | last =>
-        rw [Fin.snoc_last]
-        exact congrArg f (Fin.ext
-          (show (Fin.castLE hk (Fin.last k)).val = k from rfl))
-    | cast i =>
-        rw [Fin.snoc_castSucc]
-        exact congrArg f (Fin.ext
-          (show (Fin.castLE hk i.castSucc).val = (Fin.castLE (by omega) i).val from rfl))
-  rw [hsnoc, evalWord_ofFn_snoc]
-
-/-- **Chaining the overlapping windows across the bond** (arXiv:1804.04964,
-Lemma 5, the step plugging `A_4` and `A_1` into `eq:normal_act_123` and
-`eq:normal_act_234`, lines 2168--2210 of
-`Papers/1804.04964/paper_normal.tex`).
-
-Iterating the letter-level relation `L` times along a window of `2L` sites
-moves the deformed window from the left of the bond to the right: the
-leftmost deformed window contracted with the right block equals the left
-block contracted with the rightmost deformed window. -/
-private theorem chain_windows {B : MPSTensor d D} {L : ℕ} (hL : 0 < L)
-    (C : ℕ → (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
-    (hstep : ∀ k, k < L → ∀ u : Fin (L + 1) → Fin d,
-      C k (Fin.init u) * B (u (Fin.last L)) = B (u 0) * C (k + 1) (Fin.tail u))
-    (a b : Fin L → Fin d) :
-    C 0 a * evalWord B (List.ofFn b) = evalWord B (List.ofFn a) * C L b := by
-  obtain ⟨L', rfl⟩ : ∃ L', L = L' + 1 := ⟨L - 1, by omega⟩
-  have S : ∀ k, ∀ hk : k ≤ L' + 1,
-      C 0 a * evalWord B (List.ofFn fun i : Fin k => b (Fin.castLE hk i)) =
-        evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE hk i)) *
-          C k (shiftWindow k hk a b) := by
-    intro k
-    induction k with
-    | zero =>
-        intro hk
-        simp only [List.ofFn_zero, evalWord_nil, Matrix.mul_one, Matrix.one_mul]
-        rw [shiftWindow_zero hk a b]
-    | succ k IH =>
-        intro hk1
-        have hk : k ≤ L' := by omega
-        set u : Fin (L' + 1 + 1) → Fin d :=
-          Fin.snoc (α := fun _ => Fin d) (shiftWindow k (by omega) a b)
-            (b ⟨k, by omega⟩) with hu
-        have hinit : Fin.init u = shiftWindow k (by omega) a b := Fin.init_snoc _ _
-        have hlast : u (Fin.last (L' + 1)) = b ⟨k, by omega⟩ := Fin.snoc_last _ _
-        have hzero : u 0 = a ⟨k, by omega⟩ := by
-          rw [hu, show (0 : Fin (L' + 1 + 1)) = Fin.castSucc 0 from
-            Fin.castSucc_zero.symm, Fin.snoc_castSucc]
-          exact shiftWindow_apply_zero hk (by omega) a b
-        have htail : Fin.tail u = shiftWindow (k + 1) hk1 a b :=
-          tail_snoc_shiftWindow hk (by omega) hk1 a b
-        calc C 0 a *
-              evalWord B (List.ofFn fun i : Fin (k + 1) => b (Fin.castLE hk1 i))
-            = C 0 a * (evalWord B (List.ofFn fun i : Fin k =>
-                b (Fin.castLE (by omega) i)) * B (b ⟨k, by omega⟩)) := by
-              rw [evalWord_take_succ hk1 b]
-          _ = (C 0 a * evalWord B (List.ofFn fun i : Fin k =>
-                b (Fin.castLE (by omega) i))) * B (b ⟨k, by omega⟩) := by
-              rw [Matrix.mul_assoc]
-          _ = (evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
-                C k (shiftWindow k (by omega) a b)) * B (b ⟨k, by omega⟩) := by
-              rw [IH (by omega)]
-          _ = evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
-                (C k (Fin.init u) * B (u (Fin.last (L' + 1)))) := by
-              rw [hinit, hlast, Matrix.mul_assoc]
-          _ = evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
-                (B (u 0) * C (k + 1) (Fin.tail u)) := by
-              rw [hstep k (by omega) u]
-          _ = (evalWord B (List.ofFn fun i : Fin k => a (Fin.castLE (by omega) i)) *
-                B (a ⟨k, by omega⟩)) * C (k + 1) (shiftWindow (k + 1) hk1 a b) := by
-              rw [hzero, htail, Matrix.mul_assoc]
-          _ = evalWord B (List.ofFn fun i : Fin (k + 1) => a (Fin.castLE hk1 i)) *
-                C (k + 1) (shiftWindow (k + 1) hk1 a b) := by
-              rw [evalWord_take_succ hk1 a]
-  have hfull := S (L' + 1) le_rfl
-  have hcast : ∀ f : Fin (L' + 1) → Fin d,
-      (fun i : Fin (L' + 1) => f (Fin.castLE le_rfl i)) = f := by
-    intro f
-    funext i
-    exact congrArg f (Fin.ext rfl)
-  rw [hcast a, hcast b, shiftWindow_self le_rfl a b] at hfull
-  exact hfull
-
-/-! ### Extracting the bond operator from the two ends -/
+/-! ### Uniqueness of the bond operator -/
 
 /-- **Uniqueness of the bond operator** (arXiv:1804.04964, Lemma 5: the maps
 to `X` "are uniquely defined", lines 2045--2255 of
@@ -269,30 +48,17 @@ to `X` "are uniquely defined", lines 2045--2255 of
 uniqueness of lines 1940--1960).
 
 Two matrices multiplying every spanning word product to the same family on
-the right are equal. -/
+the right are equal.  This is the spanning-family uniqueness
+`MPSChainTensor.eq_of_span_mul_left` read on the word products of one
+block-injective tensor. -/
 theorem bondOperator_unique {B : MPSTensor d D} {L : ℕ}
     (hB : IsNBlkInjective B L) {X X' : Matrix (Fin D) (Fin D) ℂ}
     (h : ∀ a : Fin L → Fin d,
-      evalWord B (List.ofFn a) * X = evalWord B (List.ofFn a) * X') : X = X' := by
-  have hspan : Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
-      evalWord B (List.ofFn τ)) = ⊤ := hB
-  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
-      (Set.range fun τ : Fin L → Fin d => evalWord B (List.ofFn τ)) :=
-    hspan ▸ Submodule.mem_top
-  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
-  calc X = (1 : Matrix (Fin D) (Fin D) ℂ) * X := (Matrix.one_mul _).symm
-    _ = (∑ τ : Fin L → Fin d, α τ • evalWord B (List.ofFn τ)) * X := by rw [hα]
-    _ = ∑ τ : Fin L → Fin d, α τ • (evalWord B (List.ofFn τ) * X) := by
-        rw [Finset.sum_mul]
-        exact Finset.sum_congr rfl fun τ _ =>
-          smul_mul_assoc (α τ) (evalWord B (List.ofFn τ)) X
-    _ = ∑ τ : Fin L → Fin d, α τ • (evalWord B (List.ofFn τ) * X') :=
-        Finset.sum_congr rfl fun τ _ => by rw [h τ]
-    _ = (∑ τ : Fin L → Fin d, α τ • evalWord B (List.ofFn τ)) * X' := by
-        rw [Finset.sum_mul]
-        exact Finset.sum_congr rfl fun τ _ =>
-          (smul_mul_assoc (α τ) (evalWord B (List.ofFn τ)) X').symm
-    _ = X' := by rw [hα, Matrix.one_mul]
+      evalWord B (List.ofFn a) * X = evalWord B (List.ofFn a) * X') : X = X' :=
+  MPSChainTensor.eq_of_span_mul_left
+    (W := fun a : Fin L → Fin d => evalWord B (List.ofFn a)) hB h
+
+/-! ### Extracting the bond operator from the two ends -/
 
 /-- **Bond-operator extraction from an intertwining pair** (arXiv:1804.04964,
 Lemma 5, the comparison of the two ends, lines 2211--2255 of
@@ -302,9 +68,9 @@ Lemma 5, the comparison of the two ends, lines 2211--2255 of
 If `F a ⬝ B^b = B^a ⬝ G b` for all length-`L` words `a`, `b`, with the word
 products of `B` spanning, then a single matrix `X` factors both families:
 `F` is the word products times `X` on the right, `G` is `X` times the word
-products.  `X` is the combination of the `G`-family by coefficients
-representing the identity, and the two factorizations agree because the
-mirrored combination of the `F`-family collapses onto the same matrix. -/
+products.  This is the spanning-family extraction
+`MPSChainTensor.exists_bondOperator_of_intertwine_span` with both spanning
+families the word products of `B`. -/
 theorem exists_bondOperator_of_intertwine {B : MPSTensor d D} {L : ℕ}
     (hB : IsNBlkInjective B L)
     (F G : (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
@@ -312,38 +78,10 @@ theorem exists_bondOperator_of_intertwine {B : MPSTensor d D} {L : ℕ}
       F a * evalWord B (List.ofFn b) = evalWord B (List.ofFn a) * G b) :
     ∃ X : Matrix (Fin D) (Fin D) ℂ,
       (∀ a, F a = evalWord B (List.ofFn a) * X) ∧
-        (∀ b, G b = X * evalWord B (List.ofFn b)) := by
-  have hspan : Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
-      evalWord B (List.ofFn τ)) = ⊤ := hB
-  have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
-      (Set.range fun τ : Fin L → Fin d => evalWord B (List.ofFn τ)) :=
-    hspan ▸ Submodule.mem_top
-  obtain ⟨α, hα⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
-  set X₀ : Matrix (Fin D) (Fin D) ℂ := ∑ τ : Fin L → Fin d, α τ • G τ with hX₀
-  have hF : ∀ a, F a = evalWord B (List.ofFn a) * X₀ := by
-    intro a
-    calc F a = F a * (1 : Matrix (Fin D) (Fin D) ℂ) := (Matrix.mul_one _).symm
-      _ = F a * ∑ τ : Fin L → Fin d, α τ • evalWord B (List.ofFn τ) := by rw [hα]
-      _ = ∑ τ : Fin L → Fin d, α τ • (F a * evalWord B (List.ofFn τ)) := by
-          rw [Finset.mul_sum]
-          exact Finset.sum_congr rfl fun τ _ =>
-            mul_smul_comm (α τ) (F a) (evalWord B (List.ofFn τ))
-      _ = ∑ τ : Fin L → Fin d, α τ • (evalWord B (List.ofFn a) * G τ) :=
-          Finset.sum_congr rfl fun τ _ => by rw [h a τ]
-      _ = ∑ τ : Fin L → Fin d, evalWord B (List.ofFn a) * (α τ • G τ) :=
-          Finset.sum_congr rfl fun τ _ =>
-            (mul_smul_comm (α τ) (evalWord B (List.ofFn a)) (G τ)).symm
-      _ = evalWord B (List.ofFn a) * X₀ := by rw [← Finset.mul_sum, hX₀]
-  refine ⟨X₀, hF, fun b => ?_⟩
-  -- The left factorization of `G`: compare against the right factorization
-  -- through the intertwining relation and strip the spanning word products.
-  apply bondOperator_unique hB (X := G b) (X' := X₀ * evalWord B (List.ofFn b))
-  intro a
-  calc evalWord B (List.ofFn a) * G b
-      = F a * evalWord B (List.ofFn b) := (h a b).symm
-    _ = (evalWord B (List.ofFn a) * X₀) * evalWord B (List.ofFn b) := by rw [hF a]
-    _ = evalWord B (List.ofFn a) * (X₀ * evalWord B (List.ofFn b)) :=
-        Matrix.mul_assoc _ _ _
+        (∀ b, G b = X * evalWord B (List.ofFn b)) :=
+  MPSChainTensor.exists_bondOperator_of_intertwine_span
+    (W₁ := fun a : Fin L → Fin d => evalWord B (List.ofFn a))
+    (W₂ := fun b : Fin L → Fin d => evalWord B (List.ofFn b)) hB hB F G h
 
 /-! ### The bond-operator extraction theorem -/
 
@@ -367,7 +105,11 @@ Together with `MPSTensor.bondOperator_unique`, the assignments `C 0 ↦ X` and
 source's maps `O_1 ↦ X` and `O_3^T ↦ X`) is established for the insertion
 correspondence in `TNLean/PEPS/CycleMPSOverlapInsertion.lean`, where the
 deformed window tensors carry the algebra structure transported from the
-deforming network. -/
+deforming network.
+
+The proof places `B` at every site of the site-dependent form
+(`MPSChainTensor.overlapWindow_exists_bondOperator`), which is the setting
+in which the source states Lemma 5. -/
 theorem overlapWindow_exists_bondOperator {B : MPSTensor d D} {n L : ℕ}
     (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (hB : IsNBlkInjective B L)
     (C : ℕ → (Fin L → Fin d) → Matrix (Fin D) (Fin D) ℂ)
@@ -380,11 +122,14 @@ theorem overlapWindow_exists_bondOperator {B : MPSTensor d D} {n L : ℕ}
     ∃ X : Matrix (Fin D) (Fin D) ℂ,
       (∀ a, C 0 a = evalWord B (List.ofFn a) * X) ∧
         (∀ b, C L b = X * evalWord B (List.ofFn b)) := by
-  have hstep : ∀ k, k < L → ∀ u : Fin (L + 1) → Fin d,
-      C k (Fin.init u) * B (u (Fin.last L)) = B (u 0) * C (k + 1) (Fin.tail u) := by
-    intro k hk u
-    exact window_letter_step hL hn hB (q := n - (k + (L + 1))) (by omega)
-      (fun pre u' post => hstate k hk (by omega) pre u' post) u
-  exact exists_bondOperator_of_intertwine hB (C 0) (C L) (chain_windows hL C hstep)
+  haveI : NeZero n := ⟨by omega⟩
+  obtain ⟨X, hX0, hXL⟩ := MPSChainTensor.overlapWindow_exists_bondOperator
+    (A := fun _ : Fin n => B) hL hn
+    (MPSChainTensor.isWindowInjective_const hB) 0 C
+    (fun j hj {q} hq pre u post => by
+      simpa only [MPSChainTensor.arcEval_const] using hstate j hj hq pre u post)
+  refine ⟨X, fun a => ?_, fun b => ?_⟩
+  · rw [hX0 a, MPSChainTensor.arcEval_const]
+  · rw [hXL b, MPSChainTensor.arcEval_const]
 
 end MPSTensor

--- a/TNLean/PEPS/CycleMPSWordTransport.lean
+++ b/TNLean/PEPS/CycleMPSWordTransport.lean
@@ -152,8 +152,10 @@ two linear pairings `ΨA`, `ΨB` of the matrix algebra into a common space such
 that `ΨA` is injective and `ΨA (F i) = ΨB (G i)` for every index, there is a
 linear map of the matrix algebra carrying each `F i` to `G i`.  This is the
 left-inverse construction of the linear extension for the single-block
-Fundamental Theorem (`TNLean/MPS/Structure/LinearExtension.lean`). -/
-private theorem exists_linearMap_apply_eq {ι : Type*} [Finite ι]
+Fundamental Theorem (`TNLean/MPS/Structure/LinearExtension.lean`).  The
+site-dependent arc transports of
+`TNLean/PEPS/CycleMPSChainOverlapInsertion.lean` consume it as well. -/
+theorem exists_linearMap_apply_eq {ι : Type*} [Finite ι]
     {V : Type*} [AddCommGroup V] [Module ℂ V]
     (F G : ι → Matrix (Fin D) (Fin D) ℂ)
     (ΨA ΨB : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] V)

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
@@ -713,27 +713,21 @@
     alternative proof''), specialized to one site-independent tensor; the
     source states it for site-dependent tensors on five sites with $L = 2$,
     with the deformed window tensors arising as physical operators
-    contracted with the blocked windows they act on.  The
+    contracted with the blocked windows they act on; the site-dependent
+    form, in the setting in which the source states the lemma, is
+    Lemma~\ref{lem:chain_overlapWindow_exists_bondOperator}, and this
+    statement is its constant specialization.  The
     algebra-homomorphism clause of the source lemma is established with the
     insertion correspondence in
     Lemma~\ref{lem:exists_conjugation_of_mpv_eq}.
 \end{lemma}
 \begin{proof}\leanok
-    \uses{lem:isNBlkInjective_of_le, def:eval_word}
-    Comparing the windows at $j$ and $j + 1$ through the rest of the chain
-    — an arc of $n - L - 1 \ge L$ sites, whose word products span by
-    Lemma~\ref{lem:isNBlkInjective_of_le} — strips the state equality to
-    the letter level:
-    $C_j(u_1 \cdots u_L)\,B^{u_{L+1}} = B^{u_1}\,C_{j+1}(u_2 \cdots
-    u_{L+1})$ on every window of $L + 1$ sites.  Chaining the $L$ relations
-    along a window of $2L$ sites turns the leftmost window into the
-    rightmost one:
-    $C_0(a)\,B^{b} = B^{a}\,C_L(b)$ for all length-$L$ words.  Writing the
-    identity as a combination $\sum_b \alpha_b B^{b} = I$, the matrix
-    $X := \sum_b \alpha_b\,C_L(b)$ satisfies $B^{a} X = C_0(a)$; the
-    mirrored combination of the $C_0$-family collapses onto the same
-    matrix, giving $X\,B^{b} = C_L(b)$, and stripping the spanning factors
-    makes $X$ unique.
+    \uses{lem:chain_overlapWindow_exists_bondOperator, def:eval_word}
+    Place the tensor at every site of the site-dependent form
+    (Lemma~\ref{lem:chain_overlapWindow_exists_bondOperator}): the arc
+    products of the constant chain are the word products of the repeated
+    tensor, and $L$-block injectivity of the tensor is window injectivity
+    of the constant chain.
 \end{proof}
 
 \begin{lemma}[Conjugate word products at one length from Lemma~5]%
@@ -875,6 +869,263 @@
     the consecutive powers contribute the factor $\lambda$, and across the
     seam the wraparound contributes $\lambda^{1-n} = \lambda$ because
     $\lambda^n = 1$, so $B^i = Z_v^{-1} A^i Z_{v+1}$ at every site.
+\end{proof}
+
+
+The source states its Lemma~5 for site-dependent tensors: five sites
+carrying tensors $A_1, \ldots, A_5$ whose two-site windows are injective.
+The entries above specialize to one repeated tensor; the remaining entries
+of this section formalize the site-dependent setting itself.  A closed
+chain carries one tensor per site, windows are arcs of consecutive sites,
+and the closed-chain corollary delivers one gauge per bond.  Throughout,
+all sites share one physical dimension $d$ and all bonds one bond
+dimension $D$; the source poses no restriction on the local dimensions of
+the site-dependent tensors, and the uniform-dimension restriction is
+recorded in the route note
+(\path{docs/paper-gaps/peps_normal_ft_section3_route.tex}).
+
+\begin{definition}[Arc products and window injectivity of a site-dependent
+    chain]%
+    \label{def:chain_arc_window_injective}
+    \lean{MPSChainTensor.arcEval}
+    \lean{MPSChainTensor.IsWindowInjective}
+    \leanok
+    \uses{def:non_ti_chain}
+    Let a closed chain on $n \ge 1$ sites carry one tensor of $D \times D$
+    matrices over physical dimension $d$ per site, $A_0, \dots, A_{n-1}$.
+    The \emph{arc product} of a word $x = x_1 \cdots x_\ell$ read from
+    site $s$ is
+    \[
+        A_{(s)}^{x} = A_{s}^{x_1}\, A_{s+1}^{x_2} \cdots
+            A_{s+\ell-1}^{x_\ell},
+    \]
+    site indices cyclic.  The chain is \emph{window injective at length
+    $L$} when, for every site $s$, the arc products of the length-$L$
+    words read from $s$ span the full matrix algebra.  This is the
+    site-dependent setting of the closing section of
+    \cite{Molnar2018NormalPEPS} (``Normal MPS: alternative proof''): an
+    MPS on five sites in which the blocking of any two consecutive tensors
+    is injective, for a general window length $L$.
+\end{definition}
+
+\begin{lemma}[Arc spanning from window injectivity]%
+    \label{lem:isWindowInjective_arc_span}
+    \lean{MPSChainTensor.IsWindowInjective.arc_span}
+    \leanok
+    \uses{def:chain_arc_window_injective}
+    Let a site-dependent chain on $n \ge 1$ sites be window injective at
+    length $L$ with $0 < L$.  Then for every $m \ge L$ and every site $s$,
+    the arc products of the length-$m$ words read from $s$ span the full
+    matrix algebra.  This is the site-dependent form of the remark that
+    any region of at least the blocking size is injective
+    (\cite{Molnar2018NormalPEPS}, closing section,
+    cf.\ Lemma~\ref{lem:isNBlkInjective_of_le}).
+\end{lemma}
+\begin{proof}\leanok
+    \uses{def:chain_arc_window_injective}
+    Write the identity as a combination of window products at the starting
+    site and peel the leading letter of each: any matrix becomes a
+    combination of terms $A_s^{i}\,(W P)$ with $W$ an arc product of
+    length $L - 1$ read from $s + 1$.  Each factor $W P$ is a combination
+    of length-$m$ arc products read from $s + 1$ by induction, so each
+    term is a combination of length-$(m+1)$ arc products read from $s$.
+\end{proof}
+
+\begin{lemma}[Bond-operator extraction from overlapping windows,
+    site-dependent form]%
+    \label{lem:chain_overlapWindow_exists_bondOperator}
+    \lean{MPSChainTensor.overlapWindow_exists_bondOperator}
+    \lean{MPSChainTensor.eq_of_span_mul_left}
+    \leanok
+    \uses{def:chain_arc_window_injective}
+    Let $0 < L$ with $2L + 1 \le n$, let the closed chain on $n$ sites
+    carry one tensor of $D \times D$ matrices per site, window injective
+    at length $L$, and fix a site $r$.  Let $C_0, \ldots, C_L$ be deformed
+    window tensors around the bond $(r+L-1,\, r+L)$: each $C_j$ assigns a
+    matrix to every word of length $L$, read as replacing the blocked
+    tensor of the $L$-site window starting at site $r + j$.  Suppose the
+    deformed states agree for consecutive window positions: for every
+    $j < L$, every prefix $p$ of $j$ sites read from $r$, every assignment
+    $u$ on the $L + 1$ sites covered by the two windows, and every suffix
+    $s$ on the remaining sites,
+    \[
+        \tr\bigl(A_{(r)}^{p}\, C_j(u_1 \cdots u_L)\,
+            A_{r+j+L}^{u_{L+1}}\, A_{(r+j+L+1)}^{s}\bigr)
+        = \tr\bigl(A_{(r)}^{p}\, A_{r+j}^{u_1}\,
+            C_{j+1}(u_2 \cdots u_{L+1})\, A_{(r+j+L+1)}^{s}\bigr).
+    \]
+    Then the deformation is a virtual operation on the bond: there is a
+    matrix $X$ with
+    \[
+        C_0(a) = A_{(r)}^{a}\, X
+        \quad\text{and}\quad
+        C_L(b) = X\, A_{(r+L)}^{b}
+    \]
+    for all length-$L$ words $a$, $b$, and $X$ is unique.  This is
+    Lemma~5 of \cite{Molnar2018NormalPEPS} in the site-dependent setting
+    in which the source states it, with the deformed window tensors
+    arising as physical operators contracted with the blocked windows
+    they act on; Lemma~\ref{lem:overlapWindow_exists_bondOperator} is its
+    constant specialization.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:isWindowInjective_arc_span, def:chain_arc_window_injective}
+    Comparing the windows at $j$ and $j + 1$ through the complementary
+    arc of $n - L - 1 \ge L$ sites, whose arc products span by
+    Lemma~\ref{lem:isWindowInjective_arc_span}, strips the state equality
+    to the letter level:
+    $C_j(u_1 \cdots u_L)\,A_{r+j+L}^{u_{L+1}} =
+    A_{r+j}^{u_1}\,C_{j+1}(u_2 \cdots u_{L+1})$ on every window of
+    $L + 1$ sites.  Chaining the $L$ relations along the $2L$ sites
+    flanking the bond turns the leftmost window into the rightmost one:
+    $C_0(a)\,A_{(r+L)}^{b} = A_{(r)}^{a}\,C_L(b)$ for all length-$L$
+    words.  Writing the identity as a combination
+    $\sum_b \alpha_b A_{(r+L)}^{b} = I$, the matrix
+    $X := \sum_b \alpha_b\,C_L(b)$ satisfies $A_{(r)}^{a} X = C_0(a)$;
+    the mirrored combination of the $C_0$-family collapses onto the same
+    matrix, giving $X\,A_{(r+L)}^{b} = C_L(b)$, and stripping the
+    spanning factors makes $X$ unique.
+\end{proof}
+
+\begin{lemma}[Arc transport between same-state chains]%
+    \label{lem:exists_arcTransport}
+    \lean{MPSChainTensor.exists_arcTransport}
+    \leanok
+    \uses{def:chain_arc_window_injective, def:non_ti_chain}
+    Let two site-dependent chains $A$, $B$ on $n$ sites generate the same
+    closed-chain state, let $k + q = n$, and suppose the $A$-arc products
+    of length $k$ read from a site $s$ and of length $q$ read from
+    $s + k$ each span the full matrix algebra.  Then there is a linear
+    map $\Lambda$ of the matrix algebra with
+    $\Lambda(A_{(s)}^{x}) = B_{(s)}^{x}$ for every word $x$ of length
+    $k$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:exists_mpvTransport, def:chain_arc_window_injective}
+    As for one repeated tensor (Lemma~\ref{lem:exists_mpvTransport}):
+    pair the matrix algebra against the complementary arc products.  The
+    pairing is injective on the $A$-side by spanning and trace
+    nondegeneracy, and the two pairings match on the spanning arc family
+    because both compute closed-chain coefficients of total length $n$,
+    equal after rotating the trace of the closed chain to the starting
+    site $s$.
+\end{proof}
+
+\begin{lemma}[The insertion correspondence is an algebra homomorphism,
+    site-dependent form]%
+    \label{lem:chain_exists_insertionHom}
+    \lean{MPSChainTensor.exists_insertionHom}
+    \lean{MPSChainTensor.insertionHom_unique}
+    \leanok
+    \uses{def:chain_arc_window_injective, def:non_ti_chain}
+    Let $0 < L$ with $2L + 1 \le n$, let $A$ and $B$ be site-dependent
+    chains on $n$ sites, each window injective at length $L$, generating
+    the same closed-chain state, and fix a site $r$.  Then there is a
+    linear map $\Phi$ of the matrix algebra, unital and multiplicative,
+    such that for every matrix $X$ and every word $w$ of length $n$,
+    \[
+        \tr\bigl(X\, A_{(r+L)}^{w}\bigr)
+            = \tr\bigl(\Phi(X)\, B_{(r+L)}^{w}\bigr),
+    \]
+    and $\Phi$ is the unique linear map with this pairing property.  This
+    is the closing clause of Lemma~5 of \cite{Molnar2018NormalPEPS} — the
+    maps $O_1 \mapsto X$ and $O_3^T \mapsto X$ are uniquely defined and
+    are algebra homomorphisms — in the site-dependent setting of the
+    source, with the algebra structure carried by the insertions: $\Phi$
+    sends an insertion on the bond $(r+L-1,\, r+L)$ of the first chain to
+    the bond operator extracted on the second.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:chain_overlapWindow_exists_bondOperator,
+        lem:exists_arcTransport, lem:isWindowInjective_arc_span}
+    A virtual insertion $X$ on the bond is realized on each of the
+    $L + 1$ overlapping windows around it by deformed window tensors
+    placing $X$ after the first $L - j$ letters of the window starting at
+    site $r + j$.  Each deformation is transported to the second chain by
+    the arc transport at its own starting site
+    (Lemma~\ref{lem:exists_arcTransport}); the same-state hypothesis
+    makes the transported deformations generate one common state, and the
+    bond-operator extraction
+    (Lemma~\ref{lem:chain_overlapWindow_exists_bondOperator}) produces
+    $\Phi(X)$.  Uniqueness of the bond operator makes $\Phi$ linear,
+    unital and multiplicative; the pairing against all closed-chain words
+    follows by expanding the insertion over the window products, and pins
+    $\Phi$ through the spanning arcs of length $n$
+    (Lemma~\ref{lem:isWindowInjective_arc_span}) and nondegeneracy of the
+    trace pairing.
+\end{proof}
+
+\begin{lemma}[Conjugate arc products at every bond, site-dependent form]%
+    \label{lem:chain_exists_conjugation_of_sameState}
+    \lean{MPSChainTensor.exists_conjugation_of_sameState}
+    \leanok
+    \uses{def:chain_arc_window_injective, def:non_ti_chain}
+    Let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$ be
+    site-dependent chains on $n$ sites, each window injective at length
+    $L$, generating the same closed-chain state.  Then for every site $p$
+    there is an invertible matrix $Z$ with
+    \[
+        B_{(p)}^{w} = Z\, A_{(p)}^{w}\, Z^{-1}
+    \]
+    for every word $w$ of length $n$.  The statement for one repeated
+    tensor is Lemma~\ref{lem:exists_conjugation_of_mpv_eq}.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:chain_exists_insertionHom, thm:skolem_noether}
+    The insertion correspondence at the bond
+    (Lemma~\ref{lem:chain_exists_insertionHom}) is unital and nonzero,
+    hence an automorphism of the full matrix algebra, and by
+    Skolem--Noether (Theorem~\ref{thm:skolem_noether}) it is conjugation
+    by an invertible $Z$; pairing insertions against all closed-chain
+    words read from $p$ and using nondegeneracy of the trace pairing
+    transfers the conjugation to the arc products.
+\end{proof}
+
+\begin{corollary}[Fundamental Theorem for site-dependent normal closed
+    chains at $n \ge 2L + 1$]%
+    \label{cor:fundamentalTheorem_normalMPSChain_of_overlap}
+    \lean{TNLean.PEPS.fundamentalTheorem_normalMPSChain_of_overlap}
+    \leanok
+    \uses{def:chain_arc_window_injective, def:non_ti_chain}
+    Let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$ be
+    site-dependent chains on $n$ sites, each window injective at length
+    $L$, generating the same closed-chain state.  Then the chains are
+    gauge equivalent: there are invertible matrices $Z_v$, one per bond
+    of the closed chain, with
+    \[
+        B_v^i = Z_v\, A_v^i\, Z_{v+1}^{-1}
+    \]
+    for every site $v$ and every $i$, indices cyclic.  This is the
+    closed-chain corollary of the closing section of
+    \cite{Molnar2018NormalPEPS} assembled from its site-dependent
+    Lemma~5 at every bond; the source displays the corollary for
+    translation-invariant tensors
+    (Corollary~\ref{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}),
+    with the site-dependent Lemma~5 as its engine.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{lem:chain_exists_conjugation_of_sameState,
+        lem:chain_overlapWindow_exists_bondOperator,
+        lem:isWindowInjective_arc_span}
+    For a vanishing bond dimension the conclusion is trivial.  Otherwise
+    the per-bond conjugations
+    (Lemma~\ref{lem:chain_exists_conjugation_of_sameState}) give window
+    covariance with nonzero scalars: on every arc of $m$ sites with
+    $L \le m$ and $m + L \le n$, the conjugation at the near end
+    intertwines the arc products of the two chains across the far bond,
+    the bond-operator extraction
+    (Lemma~\ref{lem:chain_overlapWindow_exists_bondOperator}) produces
+    the connecting matrix, and the conjugation at the far end pins it to
+    a nonzero scalar multiple of the gauge there through the centralizer
+    of the full matrix algebra, so
+    $B_{(p)}^{u} = c_{p,m} \cdot Z_p\, A_{(p)}^{u}\, Z_{p+m}^{-1}$ on all
+    length-$m$ words $u$.  Comparing the covariance on windows of lengths
+    $L + 1$ and $L$ through the spanning window products leaves the
+    letterwise relation $B_v^i = \mu_v\, Z_v\, A_v^i\, Z_{v+1}^{-1}$ with
+    nonzero scalars $\mu_v$; iterating it once around the closed chain
+    against a nonzero arc product forces $\prod_v \mu_v = 1$, and
+    dressing the gauges with the partial products of the scalars absorbs
+    them, including across the seam.
 \end{proof}
 
 

--- a/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex
@@ -885,7 +885,7 @@ recorded in the route note
 (\path{docs/paper-gaps/peps_normal_ft_section3_route.tex}).
 
 \begin{definition}[Arc products and window injectivity of a site-dependent
-    chain]%
+        chain]%
     \label{def:chain_arc_window_injective}
     \lean{MPSChainTensor.arcEval}
     \lean{MPSChainTensor.IsWindowInjective}
@@ -897,10 +897,10 @@ recorded in the route note
     site $s$ is
     \[
         A_{(s)}^{x} = A_{s}^{x_1}\, A_{s+1}^{x_2} \cdots
-            A_{s+\ell-1}^{x_\ell},
+        A_{s+\ell-1}^{x_\ell},
     \]
     site indices cyclic.  The chain is \emph{window injective at length
-    $L$} when, for every site $s$, the arc products of the length-$L$
+        $L$} when, for every site $s$, the arc products of the length-$L$
     words read from $s$ span the full matrix algebra.  This is the
     site-dependent setting of the closing section of
     \cite{Molnar2018NormalPEPS} (``Normal MPS: alternative proof''): an
@@ -932,7 +932,7 @@ recorded in the route note
 \end{proof}
 
 \begin{lemma}[Bond-operator extraction from overlapping windows,
-    site-dependent form]%
+        site-dependent form]%
     \label{lem:chain_overlapWindow_exists_bondOperator}
     \lean{MPSChainTensor.overlapWindow_exists_bondOperator}
     \lean{MPSChainTensor.eq_of_span_mul_left}
@@ -950,9 +950,9 @@ recorded in the route note
     $s$ on the remaining sites,
     \[
         \tr\bigl(A_{(r)}^{p}\, C_j(u_1 \cdots u_L)\,
-            A_{r+j+L}^{u_{L+1}}\, A_{(r+j+L+1)}^{s}\bigr)
+        A_{r+j+L}^{u_{L+1}}\, A_{(r+j+L+1)}^{s}\bigr)
         = \tr\bigl(A_{(r)}^{p}\, A_{r+j}^{u_1}\,
-            C_{j+1}(u_2 \cdots u_{L+1})\, A_{(r+j+L+1)}^{s}\bigr).
+        C_{j+1}(u_2 \cdots u_{L+1})\, A_{(r+j+L+1)}^{s}\bigr).
     \]
     Then the deformation is a virtual operation on the bond: there is a
     matrix $X$ with
@@ -975,7 +975,7 @@ recorded in the route note
     Lemma~\ref{lem:isWindowInjective_arc_span}, strips the state equality
     to the letter level:
     $C_j(u_1 \cdots u_L)\,A_{r+j+L}^{u_{L+1}} =
-    A_{r+j}^{u_1}\,C_{j+1}(u_2 \cdots u_{L+1})$ on every window of
+        A_{r+j}^{u_1}\,C_{j+1}(u_2 \cdots u_{L+1})$ on every window of
     $L + 1$ sites.  Chaining the $L$ relations along the $2L$ sites
     flanking the bond turns the leftmost window into the rightmost one:
     $C_0(a)\,A_{(r+L)}^{b} = A_{(r)}^{a}\,C_L(b)$ for all length-$L$
@@ -1012,7 +1012,7 @@ recorded in the route note
 \end{proof}
 
 \begin{lemma}[The insertion correspondence is an algebra homomorphism,
-    site-dependent form]%
+        site-dependent form]%
     \label{lem:chain_exists_insertionHom}
     \lean{MPSChainTensor.exists_insertionHom}
     \lean{MPSChainTensor.insertionHom_unique}
@@ -1025,7 +1025,7 @@ recorded in the route note
     such that for every matrix $X$ and every word $w$ of length $n$,
     \[
         \tr\bigl(X\, A_{(r+L)}^{w}\bigr)
-            = \tr\bigl(\Phi(X)\, B_{(r+L)}^{w}\bigr),
+        = \tr\bigl(\Phi(X)\, B_{(r+L)}^{w}\bigr),
     \]
     and $\Phi$ is the unique linear map with this pairing property.  This
     is the closing clause of Lemma~5 of \cite{Molnar2018NormalPEPS} — the
@@ -1082,7 +1082,7 @@ recorded in the route note
 \end{proof}
 
 \begin{corollary}[Fundamental Theorem for site-dependent normal closed
-    chains at $n \ge 2L + 1$]%
+        chains at $n \ge 2L + 1$]%
     \label{cor:fundamentalTheorem_normalMPSChain_of_overlap}
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPSChain_of_overlap}
     \leanok

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2799,6 +2799,94 @@ the site-dependent form of Lemma~5 and the $2L+1$ strengthening for
 two-dimensional tensor networks (the corollary at lines 2297--2318) remain
 open.
 
+\section*{The site-dependent form of Lemma 5}
+
+The site-dependent form of Lemma~5, recorded as open at the end of the
+previous section, is now formalized, and the site-independent statements
+landed there are its constant specializations.  The development works with
+the existing site-dependent chains (\leanid{MPSChainTensor}, one tensor per
+site of the closed chain, \path{TNLean/MPS/Chain/Defs.lean}) and adds the
+arc vocabulary: the ordered product of a word along an arc of consecutive
+sites, starting anywhere on the chain and wrapping cyclically
+(\leanid{MPSChainTensor.arcEval}), and the source's hypothesis that every
+window of $L$ consecutive sites is injective
+(\leanid{MPSChainTensor.IsWindowInjective}, the general-$L$ form of ``the
+blocking of any two consecutive tensors is injective'', lines 1928--1940),
+with the spanning of all longer arcs derived from it
+(\leanid{MPSChainTensor.IsWindowInjective.arc_span}, blueprint
+\path{def:chain_arc_window_injective},
+\path{lem:isWindowInjective_arc_span}).
+
+Lemma~5 itself is restated and proved for site-dependent chains
+(\leanid{MPSChainTensor.overlapWindow_exists_bondOperator}, blueprint
+\path{lem:chain_overlapWindow_exists_bondOperator}): deformed window
+tensors on the $L+1$ overlapping windows around a bond of a
+window-injective chain that generate one common state on $n \ge 2L+1$
+sites come from a single virtual operation $X$ on the bond, with the
+factorizations through the windows on the two sides and uniqueness of $X$
+(\leanid{MPSChainTensor.eq_of_span_mul_left}).  The proof is the source's,
+with one bookkeeping change against the site-independent version: the
+letter-level stripping, the window chaining, and the two-ends extraction
+all track the starting site of every arc, and the two spanning families at
+the two sides of the bond are now distinct.  The previously landed
+site-independent theorems (\leanid{MPSTensor.overlapWindow_exists_bondOperator},
+\leanid{MPSTensor.bondOperator_unique},
+\leanid{MPSTensor.exists_bondOperator_of_intertwine}) now delegate to the
+site-dependent ones through the constant chain
+(\leanid{MPSChainTensor.isWindowInjective_const},
+\leanid{MPSChainTensor.arcEval_const}); their statements and the
+downstream corollaries are unchanged.
+
+The algebra-homomorphism clause of the source lemma (line 2253) is
+delivered in the site-dependent setting by the insertion correspondence:
+one arc transport per window start
+(\leanid{MPSChainTensor.exists_arcTransport}; the rotated reading of the
+closed-chain state at every starting site is
+\leanid{MPSChainTensor.SameState.trace_arcEval_eq}), the correspondence
+$\Phi$ at each bond, linear, unital and multiplicative, pairing every
+insertion on the first chain with its bond operator on the second against
+all closed-chain words, with uniqueness
+(\leanid{MPSChainTensor.exists_insertionHom},
+\leanid{MPSChainTensor.insertionHom_unique}, blueprint
+\path{lem:chain_exists_insertionHom}), and by Skolem--Noether the per-bond
+conjugation of full-length arc products
+(\leanid{MPSChainTensor.exists_conjugation_of_sameState}, blueprint
+\path{lem:chain_exists_conjugation_of_sameState}).
+
+The capstone is the site-dependent closed-chain corollary at the source's
+bound: two window-injective site-dependent chains on $n \ge 2L+1$ sites
+generating the same state are gauge equivalent, one invertible gauge per
+bond, concluding the existing cyclic gauge-equivalence predicate
+(\leanid{TNLean.PEPS.fundamentalTheorem_normalMPSChain_of_overlap} with
+\leanid{MPSChainTensor.GaugeEquiv}, blueprint
+\path{cor:fundamentalTheorem_normalMPSChain_of_overlap}).  The source
+displays the corollary only for translation-invariant tensors; the
+site-dependent assembly needs two steps the translation-invariant collapse
+does not: a window covariance derived from the conjugations at the two
+ends of an arc — the connecting matrix produced by the two-ends extraction
+is pinned to a nonzero scalar multiple of the far gauge through the
+centralizer of the matrix algebra — and a scalar absorption, where one
+circuit of the chain forces the product of the letterwise scalars to one
+so that the partial products dress the gauges consistently across the
+seam.  These two steps are new mathematics relative to the
+translation-invariant route, not reindexing; everything else in the
+site-dependent development is the source's argument with arcs in place of
+word products.
+
+One scope restriction remains, marked in the sources:
+all sites share one physical dimension $d$ and all bonds one bond
+dimension $D$, the dimensions of the chain vocabulary of
+\path{TNLean/MPS/Chain/Defs.lean}, while the source poses no restriction
+on the local dimensions of the site-dependent tensors.  The
+per-bond-dimension generality would replace the matrix algebra by
+rectangular matrix spaces with dimensions varying around the chain, and
+with it every spanning, trace-pairing and Skolem--Noether ingredient of
+the route; it remains a follow-up.  With this, of the two items recorded
+as open at the end of the previous section, the site-dependent form of
+Lemma~5 is formalized up to the uniform-dimension restriction, and the
+$2L+1$ strengthening for two-dimensional tensor networks (the corollary at
+lines 2297--2318) remains open.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## Summary

Formalizes **Lemma 5 of arXiv:1804.04964 in its site-dependent form** (`Papers/1804.04964/paper_normal.tex`, lines 2045–2255) — the setting in which the source states it (five sites carrying tensors `A₁,…,A₅` with injective two-site windows, general window length `L`) — and derives the site-dependent closed-chain corollary at the source's bound `n ≥ 2L+1`. The repeated-tensor statements landed in #2718 now delegate to the site-dependent theorems through the constant chain; their signatures and every downstream consumer (`fundamentalTheorem_normalMPS*` family) are unchanged.

## New theorems (all sorry-free, axioms exactly `[propext, Classical.choice, Quot.sound]`)

- `TNLean/PEPS/CycleMPSChainArc.lean` — arc products along the closed chain (`MPSChainTensor.arcEval`), the window-injectivity predicate (`MPSChainTensor.IsWindowInjective`, the source's "blocking of any two consecutive tensors is injective" at general `L`), arc spanning (`IsWindowInjective.arc_span`), the rotated reading of the closed-chain state (`SameState.trace_arcEval_eq`), and spanning-family stripping lemmas.
- `TNLean/PEPS/CycleMPSChainOverlapWindow.lean` — **Lemma 5, site-dependent form** (`MPSChainTensor.overlapWindow_exists_bondOperator`): deformed window tensors on the `L+1` overlapping windows around a bond come from a single virtual operation `X` on the bond; uniqueness via `eq_of_span_mul_left`; the two-ends extraction for two distinct spanning families (`exists_bondOperator_of_intertwine_span`).
- `TNLean/PEPS/CycleMPSChainOverlapInsertion.lean` — the **algebra-homomorphism clause** (source line 2253): arc transports per window start (`exists_arcTransport`), the insertion correspondence `Φ` at each bond, linear/unital/multiplicative with the closed-chain pairing (`exists_insertionHom`) and uniqueness (`insertionHom_unique`), and the per-bond conjugation of full-length arc products via Skolem–Noether (`exists_conjugation_of_sameState`).
- `TNLean/PEPS/CycleMPSChainOverlapCapstone.lean` — the **site-dependent closed-chain corollary at `n ≥ 2L+1`** (`TNLean.PEPS.fundamentalTheorem_normalMPSChain_of_overlap`): two same-state window-injective site-dependent chains are gauge equivalent, concluding the existing `MPSChainTensor.GaugeEquiv` (one gauge per bond).

## Refactor of the landed surface

`TNLean/PEPS/CycleMPSOverlapWindow.lean` keeps its three public theorems with identical signatures; proofs now specialize the site-dependent file via `isWindowInjective_const`/`arcEval_const` (~250 lines of private machinery moved to the general file). `CycleMPSWordTransport.exists_linearMap_apply_eq` is made public for reuse. `CycleMPSOverlapInsertion`/`CycleMPSOverlapCapstone` are untouched and rebuild unchanged.

## Which steps needed new mathematics vs reindexing

- Reindexing (the source's argument with arcs in place of word products): letter-level stripping, window chaining, two-ends extraction, arc transports, insertion correspondence, per-bond conjugation. One real bookkeeping change: each step tracks the starting site of every arc, and the two windows flanking the bond carry distinct spanning families.
- New mathematics (beyond the source's displayed TI corollary): the capstone's *window covariance* (the connecting matrix from the two-ends extraction at one bond is pinned to a nonzero scalar multiple of the far gauge through the centralizer) and the *scalar absorption* (one circuit of the chain forces `∏ μ_v = 1`, so partial products dress the gauges consistently across the seam).

## Scope restriction

All sites share one physical dimension `d` and all bonds one bond dimension `D` (the chain vocabulary of `TNLean/MPS/Chain/Defs.lean`); the source poses no restriction on local dimensions. Marked with `**Scope restriction (...):**` in the four new files and documented in the appended section of `docs/paper-gaps/peps_normal_ft_section3_route.tex`. Per-bond dimensions would require a rectangular-matrix rebuild of the spanning/trace/Skolem–Noether toolchain and remain a follow-up, as does the `2L+1` strengthening for two-dimensional tensor networks (source lines 2297–2318).

## Blueprint

New entries in `blueprint/src/chapter/ch13a_peps_ft_normal_capstone.tex` (`def:chain_arc_window_injective`, `lem:isWindowInjective_arc_span`, `lem:chain_overlapWindow_exists_bondOperator`, `lem:exists_arcTransport`, `lem:chain_exists_insertionHom`, `lem:chain_exists_conjugation_of_sameState`, `cor:fundamentalTheorem_normalMPSChain_of_overlap`); the existing `lem:overlapWindow_exists_bondOperator` entry and proof now record the delegation. Route note appended (append-only). chktex clean; `leanblueprint checkdecls` clean; full `lake build` + `lake exe lint-style` green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new proof surface on the PEPS fundamental-theorem path; regressions would be subtle, though public repeated-tensor theorem statements are preserved and the change is mostly additive delegation.
> 
> **Overview**
> Formalizes **arXiv:1804.04964 Lemma 5 and the closed-chain corollary for site-dependent MPS chains** (`MPSChainTensor`): arc products and window injectivity (`CycleMPSChainArc`), bond-operator extraction from overlapping windows (`CycleMPSChainOverlapWindow`), arc transport / insertion homomorphism / per-bond conjugation (`CycleMPSChainOverlapInsertion`), and **`TNLean.PEPS.fundamentalTheorem_normalMPSChain_of_overlap`** concluding `MPSChainTensor.GaugeEquiv` at `n ≥ 2L+1` (`CycleMPSChainOverlapCapstone`), including window covariance with scalars and a one-circuit scalar absorption step.
> 
> The existing **site-independent** `MPSTensor.overlapWindow_exists_bondOperator` API is unchanged in signature; its proof now specializes the site-dependent theorem via `isWindowInjective_const` / `arcEval_const`. `exists_linearMap_apply_eq` in `CycleMPSWordTransport` is exported for reuse. Root imports, blueprint (`ch13a_peps_ft_normal_capstone.tex`), and the route note document the new lemmas and the uniform `(d, D)` dimension restriction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3df4652a4efda8b9ff591af7a2a7e57e8b45384. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->