### PR TITLE
feat(MPS/ParentHamiltonian): prove PGVWC boundary-crossing complementary-word identities

### DIFF
--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -128,6 +128,31 @@ lemma length_flattenBlockedWord (d L : ℕ) :
       simp [flattenBlockedWord_cons, ih, length_wordOfBlock,
         Nat.succ_mul, Nat.add_comm]
 
+private theorem list_ofFn_comp_fin_rev {L : ℕ} {α : Type*} (σ : Fin L → α) :
+    List.ofFn (σ ∘ Fin.rev) = (List.ofFn σ).reverse := by
+  calc
+    List.ofFn (σ ∘ Fin.rev)
+        = List.map (σ ∘ Fin.rev) (List.finRange L) := by
+          simp [List.ofFn_eq_map]
+    _ = List.map σ (List.map Fin.rev (List.finRange L)) := by
+          simp [List.map_map, Function.comp_def]
+    _ = List.map σ (List.finRange L).reverse := by
+          simp [List.finRange_reverse]
+    _ = (List.map σ (List.finRange L)).reverse := by
+          simp [List.map_reverse]
+    _ = (List.ofFn σ).reverse := by
+          simp [List.ofFn_eq_map]
+
+private theorem evalWord_pointwise_conjTranspose_reverse (A : MPSTensor d D) :
+    ∀ w : List (Fin d), (evalWord (fun i => (A i)ᴴ) w)ᴴ = evalWord A w.reverse := by
+  intro w
+  induction w with
+  | nil =>
+      simp [evalWord]
+  | cons i w ih =>
+      simp [evalWord, Matrix.conjTranspose_mul, ih, evalWord_append, List.reverse_cons,
+        Matrix.conjTranspose_conjTranspose]
+
 private theorem sum_evalWord_conjTranspose_mul_evalWord
     (A : MPSTensor d D)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
@@ -211,6 +236,73 @@ private theorem sum_evalWord_conjTranspose_mul_evalWord
                           simp
                 simpa [e] using hτ
         _ = 1 := ih
+
+/-- Right-canonical normalization propagates from letters to words of any fixed length.
+
+If
+\[
+  \sum_a A_aA_a^\dagger=I,
+\]
+then the same equation holds after replacing letters by words of length \(L\):
+\[
+  \sum_\rho A_\rho A_\rho^\dagger=I.
+\]
+This is the iterated form of the normalization used in arXiv:quant-ph/0608197,
+Theorem 2blocks.2, proof line 1450. -/
+theorem sum_evalWord_mul_conjTranspose_evalWord
+    (A : MPSTensor d D)
+    (hRight : ∑ i : Fin d, A i * (A i)ᴴ = 1) :
+    ∀ L : ℕ,
+      ∑ ρ : Fin L → Fin d,
+        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ = 1 := by
+  classical
+  intro L
+  let Aadj : MPSTensor d D := fun i => (A i)ᴴ
+  have hLeft : ∑ i : Fin d, (Aadj i)ᴴ * Aadj i = 1 := by
+    simpa [Aadj] using hRight
+  let revEquiv : (Fin L → Fin d) ≃ (Fin L → Fin d) :=
+    { toFun := fun ρ => ρ ∘ Fin.rev
+      invFun := fun ρ => ρ ∘ Fin.rev
+      left_inv := by
+        intro ρ
+        ext i
+        simp [Function.comp_def]
+      right_inv := by
+        intro ρ
+        ext i
+        simp [Function.comp_def] }
+  calc
+    ∑ ρ : Fin L → Fin d,
+        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ
+      = ∑ ρ : Fin L → Fin d,
+          (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ *
+            evalWord Aadj (List.ofFn (revEquiv ρ)) := by
+            refine Finset.sum_congr rfl ?_
+            intro ρ _
+            have hword :
+                List.ofFn (revEquiv ρ) = (List.ofFn ρ).reverse := by
+              simpa [revEquiv] using list_ofFn_comp_fin_rev (σ := ρ)
+            have hAdjEval :
+                (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ =
+                  evalWord A (List.ofFn ρ) := by
+              simpa [Aadj, hword] using
+                evalWord_pointwise_conjTranspose_reverse (A := A) (List.ofFn (revEquiv ρ))
+            have hEvalAdj :
+                evalWord Aadj (List.ofFn (revEquiv ρ)) =
+                  (evalWord A (List.ofFn ρ))ᴴ := by
+              simpa using congrArg Matrix.conjTranspose hAdjEval
+            rw [hAdjEval, hEvalAdj]
+    _ = ∑ ρ : Fin L → Fin d,
+          (evalWord Aadj (List.ofFn ρ))ᴴ * evalWord Aadj (List.ofFn ρ) := by
+          simpa [revEquiv] using
+            (Fintype.sum_equiv revEquiv
+              (f := fun ρ : Fin L → Fin d =>
+                (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ *
+                  evalWord Aadj (List.ofFn (revEquiv ρ)))
+              (g := fun ρ : Fin L → Fin d =>
+                (evalWord Aadj (List.ofFn ρ))ᴴ * evalWord Aadj (List.ofFn ρ))
+              (by intro ρ; rfl))
+    _ = 1 := sum_evalWord_conjTranspose_mul_evalWord (A := Aadj) hLeft L
 
 /-- Left-canonical normalization is preserved by physical blocking. -/
 theorem leftCanonical_blockTensor

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
+import TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities
 import TNLean.MPS.ParentHamiltonian.BlockStrip
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
 
@@ -678,6 +679,51 @@ theorem
   intro j
   exact wordSpan_eq_top_of_ge_of_unital (A j) (hUnital j)
     ((wordSpan_eq_top_iff_isNBlkInjective (A j) L₀).mpr (hBlk j)) (by omega)
+
+/-- PGVWC complementary-word comparisons give the componentwise periodic
+constraints under block injectivity.
+
+For each boundary-crossing interval beginning at \(i\), assume there are
+matrices \(C^j_{i,\rho}\) indexed by complementary words such that, for every
+wrapped word \(\beta\),
+\[
+  A^j_\beta C^j_{i,\rho}
+  =
+  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+\]
+The normalized PGVWC boundary calculation gives the complementary-word
+identities used in the injective componentwise periodic-chain theorem.
+This is the boundary-closing comparison in `MPSarchive.tex` lines 1446-1451,
+followed by the periodic conclusion in lines 1454-1456.
+-/
+theorem
+    blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L₀ L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hBlk : ∀ j : Fin r, IsNBlkInjective (A j) L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hNlarge : L + L₀ ≤ N)
+    (C : ∀ (j : Fin r) (_ : Fin N),
+      (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hCompat : ∀ (j : Fin r) (i : Fin N),
+      N < i.val + L →
+        ∀ ρ : Fin (N - L) → Fin d, ∀ β : Fin (i.val + L - N) → Fin d,
+          evalWord (A j) (List.ofFn β) * C j i ρ =
+            (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+              evalWord (A j) (List.ofFn ρ)) :
+    ∀ j : Fin r,
+      groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  refine
+    blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective
+      μ A hN hLN X hBlk hUnital hNlarge ?_
+  intro j i hi ρ
+  exact pgvwc07_complementary_word_boundary_identities_of_compatibility
+    (A := A j) (K := i.val + L - N) (M := N - L)
+    (X := ((μ j) ^ N • X j)) (C := C j i)
+    (sum_evalWord_mul_conjTranspose_evalWord (A j) (hUnital j) (N - L))
+    (hCompat j i hi) ρ
 
 /-- Complementary-word identities upgrade the block-diagonal boundary
 representation to periodic block components.

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -693,8 +693,9 @@ wrapped word \(\beta\),
 \]
 The normalized PGVWC boundary calculation gives the complementary-word
 identities used in the injective componentwise periodic-chain theorem.
-This is the boundary-closing comparison in `MPSarchive.tex` lines 1446-1451,
-followed by the periodic conclusion in lines 1454-1456.
+This is the boundary-closing comparison in arXiv:quant-ph/0608197, Theorem
+2blocks.2, proof lines 1446--1451, followed by the periodic conclusion in
+lines 1454--1456.
 -/
 theorem
     blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -22,6 +22,112 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+/-- Right normalization propagates from letters to words of any fixed length.
+
+If
+\[
+  \sum_a A_aA_a^\dagger=I,
+\]
+then the same equation holds after replacing the letters by all words of
+length \(L\):
+\[
+  \sum_\rho A_\rho A_\rho^\dagger=I.
+\]
+This is the iterated form of the normalization used in `MPSarchive.tex` line
+1450. -/
+theorem sum_evalWord_mul_conjTranspose_evalWord
+    (A : MPSTensor d D)
+    (hRight : ∑ i : Fin d, A i * (A i)ᴴ = 1) :
+    ∀ L : ℕ,
+      ∑ ρ : Fin L → Fin d,
+        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ = 1 := by
+  intro L
+  induction L with
+  | zero =>
+      simp
+  | succ L ih =>
+      let e : Fin d × (Fin L → Fin d) ≃ (Fin (L + 1) → Fin d) :=
+        Fin.consEquiv (fun _ => Fin d)
+      calc
+        ∑ ρ : Fin (L + 1) → Fin d,
+            evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ
+          = ∑ p : Fin d × (Fin L → Fin d),
+              evalWord A (List.ofFn (e p)) * (evalWord A (List.ofFn (e p)))ᴴ := by
+                simpa [e] using
+                  (Fintype.sum_equiv e
+                    (f := fun p : Fin d × (Fin L → Fin d) =>
+                      evalWord A (List.ofFn (e p)) *
+                        (evalWord A (List.ofFn (e p)))ᴴ)
+                    (g := fun ρ : Fin (L + 1) → Fin d =>
+                      evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ)
+                    (by intro p; rfl)).symm
+        _ = ∑ i : Fin d, ∑ τ : Fin L → Fin d,
+              evalWord A (List.ofFn (e (i, τ))) *
+                (evalWord A (List.ofFn (e (i, τ))))ᴴ := by
+                rw [Fintype.sum_prod_type]
+        _ = ∑ i : Fin d, A i * (A i)ᴴ := by
+                refine Finset.sum_congr rfl ?_
+                intro i _
+                calc
+                  ∑ τ : Fin L → Fin d,
+                      evalWord A (List.ofFn (e (i, τ))) *
+                        (evalWord A (List.ofFn (e (i, τ))))ᴴ
+                    =
+                  ∑ τ : Fin L → Fin d,
+                      A i *
+                        (evalWord A (List.ofFn τ) *
+                          (evalWord A (List.ofFn τ))ᴴ) *
+                        (A i)ᴴ := by
+                        refine Finset.sum_congr rfl ?_
+                        intro τ _
+                        simp [e, Matrix.conjTranspose_mul, Matrix.mul_assoc]
+                  _ =
+                    A i *
+                      (∑ τ : Fin L → Fin d,
+                        evalWord A (List.ofFn τ) * (evalWord A (List.ofFn τ))ᴴ) *
+                      (A i)ᴴ := by
+                        have hsum_right :
+                            ∑ τ : Fin L → Fin d,
+                                A i *
+                                  (evalWord A (List.ofFn τ) *
+                                    (evalWord A (List.ofFn τ))ᴴ) *
+                                  (A i)ᴴ
+                              =
+                            (∑ τ : Fin L → Fin d,
+                                A i *
+                                  (evalWord A (List.ofFn τ) *
+                                    (evalWord A (List.ofFn τ))ᴴ)) *
+                              (A i)ᴴ := by
+                              simpa [Matrix.mul_assoc] using
+                                (Finset.sum_mul
+                                  (s := (Finset.univ : Finset (Fin L → Fin d)))
+                                  (f := fun τ : Fin L → Fin d =>
+                                    A i *
+                                      (evalWord A (List.ofFn τ) *
+                                        (evalWord A (List.ofFn τ))ᴴ))
+                                  (a := (A i)ᴴ)).symm
+                        have hsum_left :
+                            ∑ τ : Fin L → Fin d,
+                                A i *
+                                  (evalWord A (List.ofFn τ) *
+                                    (evalWord A (List.ofFn τ))ᴴ)
+                              =
+                            A i *
+                              ∑ τ : Fin L → Fin d,
+                                evalWord A (List.ofFn τ) * (evalWord A (List.ofFn τ))ᴴ := by
+                              simpa [Matrix.mul_assoc] using
+                                (Finset.mul_sum
+                                  (s := (Finset.univ : Finset (Fin L → Fin d)))
+                                  (a := A i)
+                                  (f := fun τ : Fin L → Fin d =>
+                                    evalWord A (List.ofFn τ) *
+                                      (evalWord A (List.ofFn τ))ᴴ)).symm
+                        rw [hsum_right, hsum_left]
+                  _ = A i * (A i)ᴴ := by
+                        rw [ih]
+                        simp
+        _ = 1 := hRight
+
 /-- Two-index boundary-matrix identities in the PGVWC boundary comparison.
 
 This abstracts the normalized matrix calculation in PGVWC07,

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.MPS.Core.Blocking
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 
 /-!
@@ -21,112 +22,6 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-- Right normalization propagates from letters to words of any fixed length.
-
-If
-\[
-  \sum_a A_aA_a^\dagger=I,
-\]
-then the same equation holds after replacing the letters by all words of
-length \(L\):
-\[
-  \sum_\rho A_\rho A_\rho^\dagger=I.
-\]
-This is the iterated form of the normalization used in arXiv:quant-ph/0608197,
-Theorem 2blocks.2, proof line 1450. -/
-theorem sum_evalWord_mul_conjTranspose_evalWord
-    (A : MPSTensor d D)
-    (hRight : ∑ i : Fin d, A i * (A i)ᴴ = 1) :
-    ∀ L : ℕ,
-      ∑ ρ : Fin L → Fin d,
-        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ = 1 := by
-  intro L
-  induction L with
-  | zero =>
-      simp
-  | succ L ih =>
-      let e : Fin d × (Fin L → Fin d) ≃ (Fin (L + 1) → Fin d) :=
-        Fin.consEquiv (fun _ => Fin d)
-      calc
-        ∑ ρ : Fin (L + 1) → Fin d,
-            evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ
-          = ∑ p : Fin d × (Fin L → Fin d),
-              evalWord A (List.ofFn (e p)) * (evalWord A (List.ofFn (e p)))ᴴ := by
-                simpa [e] using
-                  (Fintype.sum_equiv e
-                    (f := fun p : Fin d × (Fin L → Fin d) =>
-                      evalWord A (List.ofFn (e p)) *
-                        (evalWord A (List.ofFn (e p)))ᴴ)
-                    (g := fun ρ : Fin (L + 1) → Fin d =>
-                      evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ)
-                    (by intro p; rfl)).symm
-        _ = ∑ i : Fin d, ∑ τ : Fin L → Fin d,
-              evalWord A (List.ofFn (e (i, τ))) *
-                (evalWord A (List.ofFn (e (i, τ))))ᴴ := by
-                rw [Fintype.sum_prod_type]
-        _ = ∑ i : Fin d, A i * (A i)ᴴ := by
-                refine Finset.sum_congr rfl ?_
-                intro i _
-                calc
-                  ∑ τ : Fin L → Fin d,
-                      evalWord A (List.ofFn (e (i, τ))) *
-                        (evalWord A (List.ofFn (e (i, τ))))ᴴ
-                    =
-                  ∑ τ : Fin L → Fin d,
-                      A i *
-                        (evalWord A (List.ofFn τ) *
-                          (evalWord A (List.ofFn τ))ᴴ) *
-                        (A i)ᴴ := by
-                        refine Finset.sum_congr rfl ?_
-                        intro τ _
-                        simp [e, Matrix.conjTranspose_mul, Matrix.mul_assoc]
-                  _ =
-                    A i *
-                      (∑ τ : Fin L → Fin d,
-                        evalWord A (List.ofFn τ) * (evalWord A (List.ofFn τ))ᴴ) *
-                      (A i)ᴴ := by
-                        have hsum_right :
-                            ∑ τ : Fin L → Fin d,
-                                A i *
-                                  (evalWord A (List.ofFn τ) *
-                                    (evalWord A (List.ofFn τ))ᴴ) *
-                                  (A i)ᴴ
-                              =
-                            (∑ τ : Fin L → Fin d,
-                                A i *
-                                  (evalWord A (List.ofFn τ) *
-                                    (evalWord A (List.ofFn τ))ᴴ)) *
-                              (A i)ᴴ := by
-                              simpa [Matrix.mul_assoc] using
-                                (Finset.sum_mul
-                                  (s := (Finset.univ : Finset (Fin L → Fin d)))
-                                  (f := fun τ : Fin L → Fin d =>
-                                    A i *
-                                      (evalWord A (List.ofFn τ) *
-                                        (evalWord A (List.ofFn τ))ᴴ))
-                                  (a := (A i)ᴴ)).symm
-                        have hsum_left :
-                            ∑ τ : Fin L → Fin d,
-                                A i *
-                                  (evalWord A (List.ofFn τ) *
-                                    (evalWord A (List.ofFn τ))ᴴ)
-                              =
-                            A i *
-                              ∑ τ : Fin L → Fin d,
-                                evalWord A (List.ofFn τ) * (evalWord A (List.ofFn τ))ᴴ := by
-                              simpa [Matrix.mul_assoc] using
-                                (Finset.mul_sum
-                                  (s := (Finset.univ : Finset (Fin L → Fin d)))
-                                  (a := A i)
-                                  (f := fun τ : Fin L → Fin d =>
-                                    evalWord A (List.ofFn τ) *
-                                      (evalWord A (List.ofFn τ))ᴴ)).symm
-                        rw [hsum_right, hsum_left]
-                  _ = A i * (A i)ᴴ := by
-                        rw [ih]
-                        simp
-        _ = 1 := hRight
 
 /-- Two-index boundary-matrix identities in the PGVWC boundary comparison.
 

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -33,8 +33,8 @@ length \(L\):
 \[
   \sum_\rho A_\rho A_\rho^\dagger=I.
 \]
-This is the iterated form of the normalization used in `MPSarchive.tex` line
-1450. -/
+This is the iterated form of the normalization used in arXiv:quant-ph/0608197,
+Theorem 2blocks.2, proof line 1450. -/
 theorem sum_evalWord_mul_conjTranspose_evalWord
     (A : MPSTensor d D)
     (hRight : ∑ i : Fin d, A i * (A i)ᴴ = 1) :
@@ -130,8 +130,8 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
 
 /-- Two-index boundary-matrix identities in the PGVWC boundary comparison.
 
-This abstracts the normalized matrix calculation in PGVWC07,
-`MPSarchive.tex` lines 1446-1451.
+This abstracts the normalized matrix calculation in arXiv:quant-ph/0608197,
+Theorem 2blocks.2, proof lines 1446--1451.
 
 This is the same normalized calculation when the right-normalized family is
 indexed by a finite set and the left family is indexed by an arbitrary set:
@@ -247,7 +247,7 @@ theorem pgvwc07_boundary_word_matrix_identities_of_compatibility
 /-- Two-length word-indexed boundary-matrix identities.
 
 This is the word-alphabet form of the PGVWC07 calculation in
-`MPSarchive.tex` lines 1446-1451.
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451.
 
 The two index sets are words of lengths \(K\) and \(M\):
 \[
@@ -283,7 +283,7 @@ theorem pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
 /-- Complementary-word boundary identities from a two-length PGVWC comparison.
 
 This is the boundary-crossing form of the PGVWC07 calculation in
-`MPSarchive.tex` lines 1446-1451.
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451.
 
 Let \(X\in M_D(\mathbb C)\) be a matrix. Assume that for every complementary
 word \(\rho\) and wrapped word \(\beta\),

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -559,6 +559,53 @@
     Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities}.
 \end{proof}
 
+\begin{lemma}[PGVWC comparison under block injectivity gives componentwise constraints]
+    \label{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective}
+    \leanok
+    \uses{lem:complementary_word_boundary_identities_from_pgvwc,
+        lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    Assume \(0<N\), \(L\le N\), and \(L+L_0\le N\). Suppose each block \(A_j\)
+    is \(L_0\)-block-injective and satisfies
+    \[
+        \sum_a A^j_aA^{j\dagger}_a=I .
+    \]
+    Fix block-diagonal boundary conditions \(X_j\). For every boundary-crossing
+    interval beginning at \(i\), suppose there are matrices \(C^j_{i,\rho}\),
+    indexed by complementary words \(\rho\) of length \(N-L\), such that for
+    every wrapped word \(\beta\) of length \(i+L-N\),
+    \[
+        A^j_\beta C^j_{i,\rho}
+        =
+        \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+    \]
+    Then, for every block \(j\),
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:complementary_word_boundary_identities_from_pgvwc,
+        lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    The normalization equation gives, by induction on word length,
+    \[
+        \sum_\rho A^j_\rho A^{j\dagger}_\rho=I
+    \]
+    for words \(\rho\) of length \(N-L\). Applying
+    Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc} with
+    \(X=\mu_j^NX_j\) gives, for every complementary word \(\rho\), a matrix
+    \(E_{j,i,\rho}\) such that for every wrapped word \(\beta\),
+    \[
+        \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho
+        =
+        A^j_\beta E_{j,i,\rho}.
+    \]
+    Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    then gives the componentwise periodic-chain constraint.
+\end{proof}
+
 \begin{lemma}[Complementary identities give periodic block components]
     \label{lem:block_diagonal_boundary_periodic_components_from_complementary_identities}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -559,11 +559,46 @@
     Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities}.
 \end{proof}
 
+\begin{lemma}[Normalization for words]
+    \label{lem:sum_evalWord_mul_conjTranspose_evalWord}
+    \lean{MPSTensor.sum_evalWord_mul_conjTranspose_evalWord}
+    \leanok
+    \uses{}
+    If
+    \[
+        \sum_a A_aA_a^\dagger=I ,
+    \]
+    then, for every length \(M\),
+    \[
+        \sum_\rho A_\rho A_\rho^\dagger=I ,
+    \]
+    where \(\rho\) ranges over all words of length \(M\).
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{}
+    The case \(M=0\) is the identity matrix.  For the induction step, write a
+    word of length \(M+1\) as \(a\rho\).  Since \(A_{a\rho}=A_aA_\rho\),
+    \[
+        \sum_{a,\rho} A_aA_\rho A_\rho^\dagger A_a^\dagger
+        =
+        \sum_a A_a
+        \left(\sum_\rho A_\rho A_\rho^\dagger\right)
+        A_a^\dagger
+        =
+        \sum_a A_aA_a^\dagger
+        =
+        I .
+    \]
+\end{proof}
+
 \begin{lemma}[PGVWC comparison under block injectivity gives componentwise constraints]
     \label{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective}
     \leanok
-    \uses{lem:complementary_word_boundary_identities_from_pgvwc,
+    \uses{lem:sum_evalWord_mul_conjTranspose_evalWord,
+        lem:complementary_word_boundary_identities_from_pgvwc,
         lem:block_diagonal_boundary_component_complementary_word_identities_injective}
     Assume \(0<N\), \(L\le N\), and \(L+L_0\le N\). Suppose each block \(A_j\)
     is \(L_0\)-block-injective and satisfies
@@ -587,7 +622,8 @@
 
 \begin{proof}
     \leanok
-    \uses{lem:complementary_word_boundary_identities_from_pgvwc,
+    \uses{lem:sum_evalWord_mul_conjTranspose_evalWord,
+        lem:complementary_word_boundary_identities_from_pgvwc,
         lem:block_diagonal_boundary_component_complementary_word_identities_injective}
     The normalization equation gives, by induction on word length,
     \[


### PR DESCRIPTION
### Motivation

- Follows #2644, which produced block-diagonal boundary matrices $X_j$ satisfying the open-boundary ground-space condition but not the periodic-chain membership $\Gamma_N^{A_j}(\mu_j^N X_j) \in \mathcal{G}_{N,L}(A_j)$; see issue #2651.
- The PGVWC comparison identity $A^j_\beta C^j_{i,\rho} = ((\mu_j^N X_j)A^j_\beta)A^j_\rho$ implies the complementary-word boundary identities, discharging the `hBoundary` hypothesis in `chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap` and completing the periodic ground-space decomposition needed for #460.
- Source: arXiv:quant-ph/0608197 (Pérez-García–Verstraete–Wolf–Cirac), Theorem 2blocks.2, proof lines 1454–1456; arXiv:2011.12127 (Cirac–Pérez-García–Schuch–Verstraete), §IV.C, lines 2126–2128.

### Description

- `TNLean/MPS/Core/Blocking.lean`: proves `sum_evalWord_mul_conjTranspose_evalWord` from the existing left-normalization theorem by passing to the pointwise adjoint tensor and reversing words.
- `TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean`: imports the blocking normalization result for the PGVWC boundary-matrix calculation.
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`: adds `blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective`, showing the PGVWC comparison identity implies the complementary-word boundary identities handled by the existing injective component theorem.
- `blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex`: records the corresponding lemma with a proof sketch (normalization → PGVWC complementary identities → injective component theorem).

### Testing

- `lake build TNLean.MPS.Core.Blocking TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/Core/Blocking.lean TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `cd blueprint && chktex -q -l .chktexrc src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex`
- `leanblueprint web` (completed; local renderer/bibliography warnings only)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`

Known pre-existing warnings: `BoundaryClosingStripping.lean:283`, periodic-overlap `sorry`s, and existing PEPS/MPDO linter warnings.

---
Closes #2651
Refs #190
Refs #460


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Localized formal proofs in the parent-Hamiltonian chain; a mistake could break downstream block-diagonal ground-space arguments, with no runtime or security impact.
> 
> **Overview**
> Adds **`sum_evalWord_mul_conjTranspose_evalWord`** in `Blocking.lean`: from per-letter right normalization \(\sum_a A_a A_a^\dagger = I\), it proves the same identity for all length-\(L\) MPS words, by reducing to the existing left-normalization lemma on the adjoint tensor and reindexing words with **`Fin.rev`**.
> 
> **`blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective`** in `BNTBlockDiagonalCrossing.lean` shows the PGVWC comparison \(A^j_\beta C^j_{i,\rho} = ((\mu_j^N X_j)A^j_\beta)A^j_\rho\) yields the complementary-word identities needed for periodic chain ground-space membership, using word-length normalization and **`pgvwc07_complementary_word_boundary_identities_of_compatibility`**. `BoundaryMatrixIdentities.lean` now imports blocking for that normalization; blueprint **ch14** records the normalization lemma and the PGVWC comparison lemma with proof sketches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 793027fffe7a9ff2128bbd5b3bb649265b10bdb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


