### PR TITLE
doc(parent): clarify conditional boundary comparison status

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -14,7 +14,7 @@ one-step identity from arXiv:quant-ph/0608197
   \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1},
   \qquad S_M=\bigvee_jG_M(A_j),
 \]
-as used in Theorem 2blocks.2 of arXiv:quant-ph/0608197. The later periodic
+as used in Theorem 2blocks.2 of arXiv:quant-ph/0608197. The separate periodic
 step is the boundary-closing comparison with block-diagonal boundary
 conditions, as in the closing-boundary sentence of arXiv:2011.12127,
 Section IV.C.
@@ -148,7 +148,8 @@ At the lengths used in Theorem 2blocks.2 of arXiv:quant-ph/0608197
   \mathcal G_{N,L}(B)\subseteq S_N,
 \]
 and the summands \(G_N(A_j)\) form an internal direct sum. This does not assert
-the later step closing the boundaries with block-diagonal boundary conditions. -/
+the separate step closing the boundaries with block-diagonal boundary
+conditions. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -214,9 +215,10 @@ length. Then every
 \[
   \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).
 \]
-This is still an open-boundary decomposition. The remaining boundary step in
-arXiv:quant-ph/0608197, Theorem 2blocks.2, is to prove
-\(\psi_j\in\mathcal G_{N,L}(A_j)\). -/
+This is an open-boundary decomposition. The periodic upgrade in
+arXiv:quant-ph/0608197, Theorem 2blocks.2, is a separate boundary-condition
+comparison: one must prove \(\psi_j\in\mathcal G_{N,L}(A_j)\) for the
+block components produced here. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -280,14 +282,14 @@ lies in the open-boundary ground space \(G_N(A_j)\).
 
 The latter membership is the defining open-boundary range property of the
 displayed boundary matrix. The substantive assertion is the block-diagonal
-representation of \(\psi\), and the later periodic-chain upgrade remains
-separate.
+representation of \(\psi\). The periodic-chain upgrade is the separate
+boundary-condition comparison for the cyclic windows crossing the chosen cut.
 
-This proves the displayed statement. The remaining
+This proves the displayed statement. The
 Pérez-García--Verstraete--Wolf--Cirac boundary-condition comparison
 (arXiv:quant-ph/0608197, proof lines 1454--1456; arXiv:2011.12127, lines
-2126--2128) is to show that these same component vectors lie in
-\(\mathcal G_{N,L}(A_j)\). -/
+2126--2128) shows, under the comparison identities, that these same component
+vectors lie in \(\mathcal G_{N,L}(A_j)\). -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -350,8 +352,8 @@ range,
   \subseteq
   \bigvee_j G_N(A_j),
 \]
-and the right-hand local block sum is internal. The remaining boundary-closing
-step from arXiv:quant-ph/0608197, with block-diagonal boundary conditions,
+and the right-hand local block sum is internal. The boundary-closing comparison
+from arXiv:quant-ph/0608197, with block-diagonal boundary conditions,
 replaces \(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\). -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -394,7 +396,7 @@ finite injectivity range,
   \subseteq
   \bigvee_j G_N(A_j),
 \]
-and the right-hand local block sum is internal. The remaining step from
+and the right-hand local block sum is internal. The separate step from
 arXiv:quant-ph/0608197 is
 to close the boundaries with block-diagonal boundary conditions. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
@@ -636,8 +638,8 @@ The boundary matrix remains outside the window, so the restricted vector is
   \Gamma_L^{A_j}(A_{\mathrm{right}}\mu_j^NX_jA_{\mathrm{left}}).
 \]
 If the cyclic window crosses the chosen cut, the boundary matrix lies between
-the two pieces of the window after trace rotation.  The remaining
-block-diagonal boundary-closing input is the matrix identity
+the two pieces of the window after trace rotation.  The block-diagonal
+boundary-closing input is the matrix identity
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
 \]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -15,9 +15,10 @@ interval crosses the boundary cut.  The input is the blockwise matrix identity
 appearing in the boundary-closing part of arXiv:quant-ph/0608197, Theorem
 2blocks.2.
 
-The final theorems here still assume the complementary-word identity obtained
-from the source \(C^j,D^j,E^j\) comparison. The remaining derivation is recorded
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+The equality theorem here is conditional on the complementary-word identities
+obtained from the source \(C^j,D^j,E^j\) comparison. The PGVWC comparison theorem
+below proves the componentwise periodic-chain conclusion once those identities
+are in the boundary-crossing form used in Theorem 2blocks.2.
 -/
 
 open scoped Matrix BigOperators
@@ -744,9 +745,9 @@ then the component vectors
 \]
 belong to \(\mathcal G_{N,L}(A_j)\).
 
-The complementary-word identities are assumptions of this theorem; deriving
-them from the source comparison is the remaining step documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+The complementary-word identities are assumptions of this theorem. The PGVWC
+comparison theorem below gives the componentwise conclusion from the source
+boundary-crossing form of these identities.
 
 This result follows the block-diagonal boundary conditions of arXiv:2011.12127,
 lines 2126--2128, and precedes the final equality in
@@ -803,8 +804,8 @@ This theorem combines two steps of the source boundary-closing argument:
 first obtain block-diagonal boundary conditions, then use the
 Pérez-García--Verstraete--Wolf--Cirac complementary-word identities to put
 each component vector in the corresponding periodic block chain space. The
-hypothesis is exactly the still-separate \(C,D,E\) comparison for every
-boundary-crossing interval; the theorem does not assert that comparison. -/
+hypothesis is the \(C,D,E\) comparison for every boundary-crossing interval; the
+theorem does not assert that comparison. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -16,9 +16,10 @@ appearing in the boundary-closing part of arXiv:quant-ph/0608197, Theorem
 2blocks.2.
 
 The equality theorem here is conditional on the complementary-word identities
-obtained from the source \(C^j,D^j,E^j\) comparison. The PGVWC comparison theorem
-below proves the componentwise periodic-chain conclusion once those identities
-are in the boundary-crossing form used in Theorem 2blocks.2.
+obtained from the source \(C^j,D^j,E^j\) comparison. The
+Pérez-García--Verstraete--Wolf--Cirac (PGVWC) comparison theorem below proves
+the componentwise periodic-chain conclusion once those identities are in the
+boundary-crossing form used in Theorem 2blocks.2.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -19,7 +19,9 @@ The equality theorem here is conditional on the complementary-word identities
 obtained from the source \(C^j,D^j,E^j\) comparison. The
 Pérez-García--Verstraete--Wolf--Cirac (PGVWC) comparison theorem below proves
 the componentwise periodic-chain conclusion once those identities are in the
-boundary-crossing form used in Theorem 2blocks.2.
+boundary-crossing form used in Theorem 2blocks.2. Deriving these identities
+from the source comparison is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
 
 open scoped Matrix BigOperators
@@ -748,7 +750,9 @@ belong to \(\mathcal G_{N,L}(A_j)\).
 
 The complementary-word identities are assumptions of this theorem. The PGVWC
 comparison theorem below gives the componentwise conclusion from the source
-boundary-crossing form of these identities.
+boundary-crossing form of these identities. Deriving these identities from the
+source comparison is documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
 This result follows the block-diagonal boundary conditions of arXiv:2011.12127,
 lines 2126--2128, and precedes the final equality in

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_closing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_closing.tex
@@ -348,13 +348,6 @@
     Thus every
     \(\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)\) has a unique
     decomposition \(\psi=\sum_j\psi_j\) with \(\psi_j\in G_N(A_j)\).
-    The boundary-crossing comparison in
-    \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix} proves
-    \[
-        \psi_j\in\mathcal G_{N,L}(A_j)
-    \]
-    for each \(j\), by closing the periodic boundary with block-diagonal
-    boundary conditions.
 \end{proof}
 
 \begin{lemma}[Block-diagonal boundary conditions for periodic chain vectors]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_closing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_closing.tex
@@ -348,8 +348,8 @@
     Thus every
     \(\psi\in\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)\) has a unique
     decomposition \(\psi=\sum_j\psi_j\) with \(\psi_j\in G_N(A_j)\).
-    The remaining boundary step in \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}
-    is to prove
+    The boundary-crossing comparison in
+    \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix} proves
     \[
         \psi_j\in\mathcal G_{N,L}(A_j)
     \]
@@ -404,8 +404,10 @@
     This proves the displayed statement.
 \end{proof}
 
-The lemma gives membership in the open-boundary space \(G_N(A_j)\). The later
-boundary-closing step concerns the separate assertion
+The lemma gives membership in the open-boundary space \(G_N(A_j)\). The
+boundary-crossing comparison of
+Lemma~\ref{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+concerns the separate assertion
 \[
     \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
 \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_bnt_span_consequences.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_bnt_span_consequences.tex
@@ -403,8 +403,9 @@
     \cite[Theorem~2blocks.2]{PerezGarcia2007Matrix}. The shorter range stated in
     \cite[lines~2126--2128]{Cirac2021Matrix} requires the strengthened
     block-diagonal re-growing step. These hypotheses do not by themselves give
-    the displayed cyclic boundary-closing inclusion; that inclusion is the
-    remaining periodic step for windows crossing the chosen cut. Since $g\ge2$
+    the displayed cyclic boundary-closing inclusion. That inclusion follows only
+    after the block-diagonal boundary conditions have been compared across the
+    cyclic windows crossing the chosen cut. Since $g\ge2$
     and $L_0\ge1$,
     \[
         L\ge 3(g-1)(L_0+1)+1 \ge 3L_0+4 > L_0,

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -55,13 +55,15 @@ canonical form notation, while $b$ follows PGVWC07's notation around Theorem
 Cirac et al. describe the degenerate parent-Hamiltonian ground space for a
 matrix product state with more than one block in canonical form in Section~IV.C
 of \cite{Cirac2021Matrix}.\footnote{For
-traceability, the periodic block-component comparison was tracked by
-\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} and is
-recorded on the main branch by pull request~\#2724. Earlier reductions were tracked by
-\href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641},
-\href{https://github.com/LionSR/TNLean/issues/905}{issue \#905}, and
-\href{https://github.com/LionSR/TNLean/issues/870}{issue \#870}. The relevant
-source lines are \path{Papers/2011.12127/TN-Review-main.tex}:2112--2128.}
+	traceability, the periodic block-component comparison was tracked by
+	\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}. Pull
+	request~\#2724 records the conditional reduction on the main branch, reducing
+	the unconditional target to the boundary-crossing comparison identities.
+	Earlier reductions were tracked by
+	\href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641},
+	\href{https://github.com/LionSR/TNLean/issues/905}{issue \#905}, and
+	\href{https://github.com/LionSR/TNLean/issues/870}{issue \#870}. The relevant
+	source lines are \path{Papers/2011.12127/TN-Review-main.tex}:2112--2128.}
 The source's block-injective canonical form is a block-diagonal
 physical--virtual correspondence. If
 \begin{align}
@@ -262,8 +264,7 @@ periodic component theorem proves the displayed conclusion from these
 complementary-word identities. The remaining source-level work in this note is
 to present the \(C^j,D^j,E^j\) comparison from
 \cite[Theorem~\emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}
-as an unconditional hypothesis-free equality theorem in the source range.
-\footnote{Formal declarations:
+as an unconditional hypothesis-free equality theorem in the source range.\footnote{Formal declarations:
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities},
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective},
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective},
@@ -426,44 +427,24 @@ The composition gives
 
 \section{Conclusion}
 
-This is not a source-error claim. The PGVWC07 propagation step now proved in
-Lean gives
+This is not a source-error claim. The formal development has proved the
+surrounding block-diagonal reductions and a conditional propagation step. In the
+finite-Condition-C1 Lean range
 \begin{align}
-  \mathcal K_{N,L}(\widehat A)\subseteq
-  S_N:=\bigvee_{j=1}^b\mathcal G_N^{A_j},
+  L\ge (L_0+1)+3(b-1)(L_0+1)+1,
 \end{align}
-in the finite-Condition-C1 Lean range
-\begin{align}
-  L\ge (L_0+1)+3(b-1)(L_0+1)+1.
-\end{align}
-The sum defining $S_N$ is internal.  Thus every
-$\psi\in\mathcal K_{N,L}(\widehat A)$ has a unique vector decomposition
-\begin{align}
-  \psi=\sum_{j=1}^b\phi_j,
-  \qquad
-  \phi_j\in\mathcal G_N^{A_j}.
-\end{align}
-Since $\mu_j\ne0$, write
-\begin{align}
-  \phi_j=\Gamma_N^{A_j}(\mu_j^NX_j).
-\end{align}
-Equivalently,
-\begin{align}
-  \psi
-  =
-  \Gamma_N^{\widehat A}\!\left(\bigoplus_{j=1}^bX_j\right)
-\end{align}
-with open-boundary block components.  The boundary-crossing comparison gives, for
-every $j$,
+assume the complementary-word comparison identities displayed above for the
+boundary-crossing windows. Then, for every block $j$,
 \begin{align}
   \psi\in\mathcal K_{N,L}(\widehat A)
   \quad\Longrightarrow\quad
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
-This was the assertion recorded in
-\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}. The remaining
-source-level task is to combine this comparison with the surrounding
-block-diagonal reductions in the source range
+This is the conditional reduction recorded by pull request~\#2724. The
+unconditional target of
+\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} is reduced to
+deriving those comparison identities from the PGVWC07
+\(C^j,D^j,E^j\) comparison in the source range
 \begin{align}
   b\ge2,
   \qquad

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -55,9 +55,9 @@ canonical form notation, while $b$ follows PGVWC07's notation around Theorem
 Cirac et al. describe the degenerate parent-Hamiltonian ground space for a
 matrix product state with more than one block in canonical form in Section~IV.C
 of \cite{Cirac2021Matrix}.\footnote{For
-traceability, the remaining boundary-condition comparison is tracked by
-\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}. Earlier
-reductions were tracked by
+traceability, the periodic block-component comparison was tracked by
+\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} and is
+recorded on the main branch by pull request~\#2724. Earlier reductions were tracked by
 \href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641},
 \href{https://github.com/LionSR/TNLean/issues/905}{issue \#905}, and
 \href{https://github.com/LionSR/TNLean/issues/870}{issue \#870}. The relevant
@@ -257,13 +257,16 @@ implies
   \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal K_{N,L}(A_j)
   \qquad (1\le j\le b).
 \end{align}
-Thus the remaining problem is no longer the open-boundary representation of
-\(\psi\), but the derivation of the displayed complementary-word identity from
-the \(C^j,D^j,E^j\) comparison in
-\cite[Theorem~\emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}.
+Thus the open-boundary representation of \(\psi\) is not the obstruction. The
+periodic component theorem proves the displayed conclusion from these
+complementary-word identities. The remaining source-level work in this note is
+to present the \(C^j,D^j,E^j\) comparison from
+\cite[Theorem~\emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}
+as an unconditional hypothesis-free equality theorem in the source range.
 \footnote{Formal declarations:
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities},
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective},
+\leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective},
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1}, and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}.}
 
@@ -285,7 +288,8 @@ containment, and \path{thm:gs_eq_bnt_span} for the final span statement in
     \psi_j\in\mathcal K_{N,L}(A_j)
   \right\}.
 \end{align}
-The missing source-level boundary-condition statement is then
+The source-level boundary-condition statement not yet stated without the
+complementary-word identity as an external hypothesis is
 \begin{align}
   \left[
     b\ge2
@@ -352,18 +356,18 @@ in the more conservative range
 \begin{align}
   L\ge (L_0+1)+3(b-1)(L_0+1)+1.
 \end{align}
-The later boundary-closing reductions are conditional: they assume either a
-decomposition into periodic block-chain vectors or a block-diagonal boundary
-representation whose components already belong to the periodic block-chain
-spaces.\footnote{Lean declarations:
+The boundary-closing reductions now separate into three forms: a decomposition
+into periodic block-chain vectors, a block-diagonal boundary representation whose
+components already belong to the periodic block-chain spaces, and the
+complementary-word formulation displayed above.\footnote{Lean declarations:
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition},
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap},
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition},
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary},
 and
-\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary}.}
-Those conditional reductions are not the source theorem: the last of them proves
-the equality only after the block-diagonal boundary representation has already
-been supplied.
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}.}
+These reductions do not yet state the source theorem without the
+boundary-crossing comparison as an external hypothesis.
 For
 \begin{align}
   X=\bigoplus_j X_j,
@@ -449,16 +453,17 @@ Equivalently,
   =
   \Gamma_N^{\widehat A}\!\left(\bigoplus_{j=1}^bX_j\right)
 \end{align}
-with open-boundary block components.  The present gap is the boundary-condition
-comparison: for every $j$,
+with open-boundary block components.  The boundary-crossing comparison gives, for
+every $j$,
 \begin{align}
   \psi\in\mathcal K_{N,L}(\widehat A)
   \quad\Longrightarrow\quad
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
-This is the missing assertion recorded in
-\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}. It is the
-block-diagonal boundary representation needed in the source range
+This was the assertion recorded in
+\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}. The remaining
+source-level task is to combine this comparison with the surrounding
+block-diagonal reductions in the source range
 \begin{align}
   b\ge2,
   \qquad


### PR DESCRIPTION
### Motivation

PR #2724 recorded the periodic block-component membership reduction tracked by #2651, but the surrounding documentation needed to distinguish the conditional Lean reduction from the still-open source-level comparison. This PR updates the surrounding text so the current frontier is stated accurately: the componentwise periodic-chain conclusion follows under the PGVWC boundary-crossing/complementary-word comparison identities, while the unconditional source-level comparison remains to be derived and the remaining spectral-gap leaf is #952.

### Description

- Restates the open-boundary decomposition docstrings in `BNTBlockDiagonalChain.lean` as separate from, rather than prior to, the cyclic boundary-condition comparison.
- Updates `BNTBlockDiagonalCrossing.lean` docstrings to distinguish the conditional complementary-word equality theorem from the PGVWC component theorem.
- Aligns the Chapter 14 blueprint prose with the post-#2724 conditional boundary-comparison status.
- Updates `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` so the #2651 target is described as reduced to the unconditional PGVWC comparison identities, not completed outright.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`
- `cd blueprint && chktex -q -l .chktexrc src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_closing.tex src/chapter/ch14_parent_hamiltonian_bnt_span_consequences.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `cd docs/paper-gaps && chktex -q -l ../../blueprint/.chktexrc cpgsv21_block_diagonal_parent_ground_space.tex`
- `cd docs/paper-gaps && TEXINPUTS=.: pdflatex -interaction=nonstopmode -halt-on-error cpgsv21_block_diagonal_parent_ground_space.tex`

Known pre-existing warnings: `BoundaryClosingStripping.lean:283`, periodic-overlap `sorry`s, and existing PEPS/MPDO linter warnings. The standalone paper-gap LaTeX run succeeds with first-pass citation/reference warnings only.

---
Refs #2651
Refs #190
Refs #460
Refs #952

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation edits only; no executable logic, APIs, or proof changes.
> 
> **Overview**
> **Documentation-only** alignment after PR #2724: no Lean proofs or theorem statements change—only module docstrings and reader-facing prose.
> 
> Lean comments in `BNTBlockDiagonalChain.lean` and `BNTBlockDiagonalCrossing.lean` now separate **open-boundary** block decomposition from the **cyclic boundary-closing** step, and spell out that periodic block-component membership is **conditional** on complementary-word / PGVWC boundary-crossing identities (with derivation of those identities still documented in the paper-gap note).
> 
> Chapter 14 blueprint text and `cpgsv21_block_diagonal_parent_ground_space.tex` match that frontier: issue **#2651** is framed as reduced to deriving the unconditional PGVWC \(C^j,D^j,E^j\) comparison, not as already closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2a45eeb1516f4e8371fbb6ce8794020a7687fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->