### PR TITLE
feat(MPS/ParentHamiltonian): add word boundary trace compatibility

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -464,6 +464,87 @@ theorem pgvwc07_blockwise_compatibility_of_trace_decomposition
   exact block_matrices_eq_of_wordTupleSpanTop_trace A hSpan
     (fun k => A k b * C k a) (fun k => Dmat k b * A k a) (hCoeff a b) j
 
+/-- Word-valued boundary-matrix compatibility from equality of the two
+coefficient decompositions in the Perez-Garcia--Verstraete--Wolf--Cirac
+block-diagonal intersection proof.
+
+This is the same extraction as
+`pgvwc07_blockwise_compatibility_of_trace_decomposition`, with the boundary
+letters replaced by words.  If, for every wrapped word \(\beta\), complementary
+word \(\rho\), and middle word \(w\), the two trace decompositions agree,
+then the blockwise matrices satisfy
+\[
+  A^j_\beta C^j_\rho=D^j_\beta A^j_\rho .
+\]
+This is the word form needed for the boundary-crossing comparison in
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451. -/
+theorem pgvwc07_blockwise_word_compatibility_of_trace_decomposition
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {m K M : ℕ} (hSpan : WordTupleSpanTop A m)
+    (C : (j : Fin r) → (Fin M → Fin d) →
+      Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (Dmat : (j : Fin r) → (Fin K → Fin d) →
+      Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hCoeff : ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      ∀ w : Fin m → Fin d,
+        (∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) (List.ofFn β) * C j ρ) *
+              evalWord (A j) (List.ofFn w))) =
+        (∑ j : Fin r,
+          Matrix.trace
+            ((Dmat j β * evalWord (A j) (List.ofFn ρ)) *
+              evalWord (A j) (List.ofFn w)))) :
+    ∀ j : Fin r, ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      evalWord (A j) (List.ofFn β) * C j ρ =
+        Dmat j β * evalWord (A j) (List.ofFn ρ) := by
+  intro j ρ β
+  exact block_matrices_eq_of_wordTupleSpanTop_trace A hSpan
+    (fun k => evalWord (A k) (List.ofFn β) * C k ρ)
+    (fun k => Dmat k β * evalWord (A k) (List.ofFn ρ))
+    (hCoeff ρ β) j
+
+/-- Word-valued compatibility for a block-diagonal boundary matrix.
+
+Assume the right trace decomposition has
+\[
+  D^j_\beta=(X_jA^j_\beta).
+\]
+Then the word-valued trace comparison gives
+\[
+  A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho .
+\]
+This is the exact compatibility hypothesis used by the complementary-word
+boundary theorem, following the boundary-crossing comparison in
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451. -/
+theorem pgvwc07_complementary_word_compatibility_of_trace_decomposition
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {m K M : ℕ} (hSpan : WordTupleSpanTop A m)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (C : (j : Fin r) → (Fin M → Fin d) →
+      Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hCoeff : ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      ∀ w : Fin m → Fin d,
+        (∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) (List.ofFn β) * C j ρ) *
+              evalWord (A j) (List.ofFn w))) =
+        (∑ j : Fin r,
+          Matrix.trace
+            (((X j * evalWord (A j) (List.ofFn β)) *
+                evalWord (A j) (List.ofFn ρ)) *
+              evalWord (A j) (List.ofFn w)))) :
+    ∀ j : Fin r, ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      evalWord (A j) (List.ofFn β) * C j ρ =
+        (X j * evalWord (A j) (List.ofFn β)) *
+          evalWord (A j) (List.ofFn ρ) := by
+  exact
+    pgvwc07_blockwise_word_compatibility_of_trace_decomposition
+      (A := A) (m := m) (K := K) (M := M) hSpan C
+      (fun j β => X j * evalWord (A j) (List.ofFn β)) hCoeff
+
 /-- The composed PGVWC open-segment step from the trace decompositions to
 membership in the supremum of block ground spaces.
 

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -180,6 +180,51 @@
     pairing is nondegenerate and hence every \(\Delta_j\) is zero.
 \end{proof}
 
+\begin{lemma}[Word-valued boundary compatibility from traces]
+    \label{lem:blockwise_word_boundary_compatibility_from_traces}
+    \lean{MPSTensor.pgvwc07_blockwise_word_compatibility_of_trace_decomposition,
+        MPSTensor.pgvwc07_complementary_word_compatibility_of_trace_decomposition}
+    \leanok
+    \uses{lem:block_matrices_equal_from_trace_pairings}
+    Let \(A^1,\ldots,A^g\) be block tensors with the common word-span property
+    at length \(m\). Suppose that the boundary letters in
+    Lemma~\ref{lem:blockwise_boundary_compatibility_from_traces} are replaced by
+    words \(\beta\) and \(\rho\). If, for every middle word \(w\) of length
+    \(m\),
+    \[
+        \sum_j\operatorname{tr}\!\left(A^j_\beta C^j_\rho A^j_w\right)
+        =
+        \sum_j\operatorname{tr}\!\left(D^j_\beta A^j_\rho A^j_w\right),
+    \]
+    then
+    \[
+        A^j_\beta C^j_\rho=D^j_\beta A^j_\rho
+    \]
+    for every block \(j\).  In particular, taking
+    \(D^j_\beta=X_jA^j_\beta\) gives
+    \[
+        A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_matrices_equal_from_trace_pairings}
+    Fix \(\beta\) and \(\rho\), and set
+    \[
+        \Delta_j=A^j_\beta C^j_\rho-D^j_\beta A^j_\rho .
+    \]
+    The trace equality says that
+    \[
+        \sum_j\operatorname{tr}(\Delta_jA^j_w)=0
+    \]
+    for every word \(w\) of length \(m\).  The same nondegenerate product
+    trace-pairing argument as in
+    Lemma~\ref{lem:blockwise_boundary_compatibility_from_traces} gives
+    \(\Delta_j=0\) for every \(j\).  The specialization
+    \(D^j_\beta=X_jA^j_\beta\) is immediate.
+\end{proof}
+
 \begin{lemma}[Normalized boundary matrix identities]
     \label{lem:normalized_boundary_matrix_identities}
     \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_indexed_compatibility}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -187,10 +187,11 @@
     \leanok
     \uses{lem:block_matrices_equal_from_trace_pairings}
     Let \(A^1,\ldots,A^g\) be block tensors with the common word-span property
-    at length \(m\). Suppose that the boundary letters in
-    Lemma~\ref{lem:blockwise_boundary_compatibility_from_traces} are replaced by
-    words \(\beta\) and \(\rho\). If, for every middle word \(w\) of length
-    \(m\),
+    at length \(m\). Suppose that \(C^j_\rho \in M_{D_j}(\mathbb C)\) is
+    indexed by a block \(j\) and a word \(\rho\) of some fixed length \(M\),
+    and that \(D^j_\beta \in M_{D_j}(\mathbb C)\) is indexed by a block
+    \(j\) and a word \(\beta\) of some fixed length \(K\). If, for every
+    middle word \(w\) of length \(m\),
     \[
         \sum_j\operatorname{tr}\!\left(A^j_\beta C^j_\rho A^j_w\right)
         =
@@ -200,7 +201,7 @@
     \[
         A^j_\beta C^j_\rho=D^j_\beta A^j_\rho
     \]
-    for every block \(j\).  In particular, taking
+    for every block \(j\) and all words \(\beta,\rho\).  In particular, taking
     \(D^j_\beta=X_jA^j_\beta\) gives
     \[
         A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho .

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -191,7 +191,8 @@
     indexed by a block \(j\) and a word \(\rho\) of some fixed length \(M\),
     and that \(D^j_\beta \in M_{D_j}(\mathbb C)\) is indexed by a block
     \(j\) and a word \(\beta\) of some fixed length \(K\). If, for every
-    middle word \(w\) of length \(m\),
+    word \(\rho\) of length \(M\), every word \(\beta\) of length \(K\), and
+    every middle word \(w\) of length \(m\),
     \[
         \sum_j\operatorname{tr}\!\left(A^j_\beta C^j_\rho A^j_w\right)
         =


### PR DESCRIPTION
### Motivation

- The block-diagonal intersection argument of Pérez-García, Verstraete, Wolf, and Cirac (arXiv:quant-ph/0608197, Theorem 2blocks.2) uses equality of two summed trace decompositions for every middle word to obtain a blockwise matrix equality.
- This PR extends the existing single-letter compatibility lemma to the word-valued setting needed by the complementary-word boundary comparison.
- The result is an algebraic step toward the degenerate ground-space decomposition in the parent-Hamiltonian chapter; it does not yet discharge the full source-level comparison required by #2651.

### Description

- `TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean` adds two lemmas:
  - `pgvwc07_blockwise_word_compatibility_of_trace_decomposition`: if the two summed trace decompositions agree for every middle word `w`, boundary word `β`, and complementary word `ρ`, then blockwise `A^j_β C^j_ρ = D^j_β A^j_ρ`.
  - `pgvwc07_complementary_word_compatibility_of_trace_decomposition`: the specialization `D^j_β = X_j A^j_β`, matching the hypothesis shape for the complementary-word boundary step.
- `blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex` adds the corresponding lemma, “Word-valued boundary compatibility from traces”, with `\lean` links to both new theorems.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && chktex -q -l .chktexrc src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex`
- Lean CI (`lean_action_ci.yml`) validates the full build on push.

---
Refs #2651
Refs #190
Refs #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and documentation in the parent-Hamiltonian block-intersection layer; no auth, I/O, or behavioral runtime changes.
> 
> **Overview**
> Extends the PGVWC block-intersection trace step from **single-letter** boundary indices to **word-valued** boundary matrices, for the complementary-word comparison in Theorem 2blocks.2.
> 
> In `BlockIntersectionProperty.lean`, **`pgvwc07_blockwise_word_compatibility_of_trace_decomposition`** shows that if summed traces agree for every middle word `w`, boundary word `β`, and complementary word `ρ`, then blockwise `evalWord(A^j, β) * C^j ρ = D^j β * evalWord(A^j, ρ)`. **`pgvwc07_complementary_word_compatibility_of_trace_decomposition`** is the case `D^j β = X_j * evalWord(A^j, β)`. Both proofs reuse **`block_matrices_eq_of_wordTupleSpanTop_trace`**, mirroring the existing letter-indexed lemma.
> 
> The blueprint chapter adds **“Word-valued boundary compatibility from traces”** with `\lean` links to both theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52e5f4694a3aa126464fdc688a93a4860a591d94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->