### PR TITLE
doc(MPS/ParentHamiltonian/Martingale): align martingale estimate terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 # Uniform spectral gap for the MPS parent Hamiltonian
 
 **Root-only.** This file contains the final conditional spectral-gap theorems
-for the MPS parent Hamiltonian. The overlapping-window Friedrichs-angle
+for the MPS parent Hamiltonian. The overlapping-window principal-angle
 estimate remains an explicit hypothesis.
 
 ## Main results
@@ -18,7 +18,7 @@ estimate remains an explicit hypothesis.
 * `parentHamiltonianES_gap_bound_of_overlap_norm_constant` — the corresponding
   positive-gap bound from a strict uniform compression coefficient.
 * `parentHamiltonian_gapped` — conditional uniform spectral gap for MPS parent
-  Hamiltonians on injective tensors, under the same Friedrichs input.
+  Hamiltonians on injective tensors, under the same principal-angle input.
 * `parentHamiltonian_gapped_of_overlap_norm_constant` — the corresponding
   uniform spectral gap from a strict uniform compression coefficient.
 -/
@@ -31,7 +31,7 @@ variable {d D : ℕ}
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
-/-- Gap bound from the overlapping cyclic-window Friedrichs estimate for the
+/-- Gap bound from the overlapping cyclic-window principal-angle estimate for the
 MPS parent Hamiltonian.
 
 The hypothesis is the precise norm-compression estimate for overlapping
@@ -111,7 +111,7 @@ projectors (`parentHamiltonian_frustrationFree`). The intersection property
     `ker h_left ∩ ker h_right ⊆ ker h`
 
 where `h_left` and `h_right` are the two overlapping length-`L` projectors and
-`h` is the length-`L+1` projector. The remaining Friedrichs-angle estimate
+`h` is the length-`L+1` projector. The remaining principal-angle estimate
 supplies the martingale operator inequality
 
     `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 
 **Root-only.** This file contains the reduction theorems that convert
 explicit local-projection bounds into the quadratic-form inequality
-`H² ≥ γ H` for the transported parent Hamiltonian `parentHamiltonianES`
+`H² ≥ γ H` for the Euclidean-space representative `parentHamiltonianES`
 and then into the norm lower bound `γ ‖v‖ ≤ ‖H_ES v‖` on the orthogonal
 complement of the ground space.
 
@@ -20,7 +20,7 @@ concrete cyclic-window overlap predicate and its row-cardinality bound
 `2 * (L - 1)`. The final reduction theorems (`*_gap_bound_of_cyclic_window_*`)
 supply all the already-proved structural input (local projection,
 non-overlap positivity, and row cardinality) and leave only the
-Friedrichs-angle estimate as a remaining hypothesis.
+principal-angle estimate as a remaining hypothesis.
 
 The abstract spectral-theorem step (`FrustrationFree.spectralGap_of_martingale`)
 and the projection-geometry lemmas (`ProjectionGeometry.quadraticForm_sum_*`)
@@ -36,13 +36,13 @@ variable {d D : ℕ}
 
 /-! ### Martingale quadratic-form reduction -/
 
-/-- A uniform quadratic-form estimate for the transported parent Hamiltonians
+/-- A uniform quadratic-form estimate for the Euclidean-space parent Hamiltonians
 implies the corresponding norm lower bound on the orthogonal complement of the
-transported ground space.
+Euclidean-space ground space.
 
 This theorem isolates the operator-theoretic part of the remaining
-Friedrichs-angle estimate. The hypotheses already include the quantitative
-martingale/Friedrichs estimate
+principal-angle estimate. The hypotheses already include the quantitative
+martingale estimate
 
 `γ * re ⟪H_N v, v⟫ ≤ re ⟪H_N v, H_N v⟫`,
 
@@ -72,7 +72,7 @@ theorem parentHamiltonianES_norm_bound_of_quadratic_form
 uniform quadratic-form estimate with constant `1 / (4 * L)`.
 
 Thus the remaining MPS-specific content is precisely to prove the hypothesis
-`hQuad` from the Friedrichs-angle / anti-commutator estimate and the finite
+`hQuad` from the principal-angle / anti-commutator estimate and the finite
 row-sum bound; the positivity, kernel transport, and spectral-theorem conversion
 are already available here. -/
 theorem parentHamiltonianES_gap_bound_of_quadratic_form
@@ -105,8 +105,8 @@ its hypotheses are only the ordered row-summable cross-term bounds
 
 `Re ⟪hᵢ v, hⱼ v⟫ ≥ -(1 - γ) cᵢⱼ Re ⟪hᵢ v, v⟫`.
 
-Under these hypotheses the transported Hamiltonian satisfies `H² ≥ γ H` as a
-quadratic form, exactly in the shape consumed by
+Under these hypotheses the Euclidean-space Hamiltonian satisfies `H² ≥ γ H`
+as a quadratic form, exactly in the shape consumed by
 `parentHamiltonianES_norm_bound_of_quadratic_form`. -/
 theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
     (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
@@ -130,11 +130,11 @@ theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
 /-- Uniform explicit gap-bound reduction from ordered local cross-term row
 bounds.
 
-For every chain length `N ≥ 2L`, assume the transported local terms satisfy the
-ordered row-summable cross-term estimate with constant `γ = 1 / (4L)`. The local
+For every chain length `N ≥ 2L`, assume the Euclidean-space local terms satisfy
+the ordered row-summable cross-term estimate with constant `γ = 1 / (4L)`. The local
 symmetric-projection input is already supplied by `localTermES_isSymmetricProjection`.
 Then the existing quadratic-form-to-gap theorem applies and yields the explicit
-norm lower bound. This exact reduction leaves proving the Friedrichs/row-sum
+norm lower bound. This exact reduction leaves proving the principal-angle/row-sum
 hypotheses for the concrete MPS local terms as the model-specific analytic task. -/
 theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
@@ -166,14 +166,14 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
     A L N hγle (c N) (hRow N hLN) (hCross N hLN) v
 
 /-- Fixed-chain martingale quadratic-form estimate from finite-overlap
-Friedrichs-angle hypotheses.
+principal-angle hypotheses.
 
 This is the local-window specialization of
 `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap`.  The
-predicate `overlaps i j` marks the off-diagonal pairs for which a Friedrichs-angle
+predicate `overlaps i j` marks the off-diagonal pairs for which a principal-angle
 estimate is needed.  If each row has at most `m` such pairs, the non-overlap
 cross terms are nonnegative, and every overlap obeys the ordered estimate with
-coefficient `1 / m`, then the transported parent Hamiltonian satisfies
+coefficient `1 / m`, then the Euclidean-space parent Hamiltonian satisfies
 `H² ≥ γ H` as a quadratic form. -/
 theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
     (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
@@ -200,7 +200,7 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
       hFriedrichs v)
 
 /-- Fixed-chain martingale quadratic-form estimate from finite-overlap
-norm-compression Friedrichs-angle hypotheses.
+norm-compression principal-angle hypotheses.
 
 For each overlapping pair, it is enough to bound the compressed product
 `‖hᵢ (hⱼ v)‖` by `(1 - γ) / m` times `‖hᵢ v‖`.  The abstract projection-geometry
@@ -262,14 +262,14 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le
       (fun i : Fin N => localTermES_isSymmetricProjection A L i) overlaps hm hCard
       hDisjoint hηle hOverlapNorm v)
 
-/-- Uniform explicit gap-bound reduction from finite-overlap Friedrichs-angle
+/-- Uniform explicit gap-bound reduction from finite-overlap principal-angle
 hypotheses.
 
 For parent-Hamiltonian windows of length `L`, the expected finite-range bound is
 `m = 2 * (L - 1)`: each local term overlaps at most that many other cyclic
-translates when `N ≥ 2L`.  This theorem leaves the transported local projection
+translates when `N ≥ 2L`.  This theorem leaves the Euclidean-space local projection
 structure, the cyclic-window overlap predicate, non-overlap positivity, and the
-Friedrichs-angle estimate as explicit hypotheses. It only performs the finite-overlap
+principal-angle estimate as explicit hypotheses. It only performs the finite-overlap
 row-sum reduction and the existing quadratic-form-to-gap conversion. -/
 theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
@@ -321,7 +321,7 @@ to the martingale method.  The row-cardinality estimate is supplied by
 `cyclicWindowsOverlap_card_le`, local projection structure is supplied by
 `localTermES_isSymmetricProjection`, and non-overlap positivity is supplied by
 `localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap`.  Consequently the
-only remaining local hypothesis is the Friedrichs-angle estimate for pairs
+only remaining local hypothesis is the principal-angle estimate for pairs
 marked by `cyclicWindowsOverlap`. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -17,12 +17,12 @@ method:
   projector on the Hilbert-space model `EuclideanSpace ℂ (Cfg d L)`;
 * `cyclicRestrictES` and `localTermESSummand` — cyclic-window restriction
   and the conjugated `Rᵢ,τ† P_L Rᵢ,τ` summands;
-* `localTermES` and `parentHamiltonianES` — transported local terms and the
-  full transported parent Hamiltonian on `EuclideanSpace`;
+* `localTermES` and `parentHamiltonianES` — Euclidean-space representatives of
+  the local terms and the full parent Hamiltonian;
 * positivity, idempotence, and symmetric-projection structure of the
-  transported local terms;
+  Euclidean-space local terms;
 * commutation and non-overlap positivity for disjoint cyclic windows;
-* kernel identification: the transported ground space equals `ker(H_ES)`.
+* kernel identification: the Euclidean-space ground space equals `ker(H_ES)`.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -146,14 +146,14 @@ noncomputable def parentHamiltonianGroundSpaceES (A : MPSTensor d D)
   (LinearMap.ker (parentHamiltonian A L N)).map
     (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm.toLinearMap
 
-/-- The parent Hamiltonian transported to `EuclideanSpace`. -/
+/-- The Euclidean-space representative of the parent Hamiltonian. -/
 noncomputable def parentHamiltonianES (A : MPSTensor d D) (L N : ℕ) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((parentHamiltonian A L N).comp e.toLinearMap)
 
-/-- The transported parent Hamiltonian is the sum of the transported local
-terms. -/
+/-- The Euclidean-space parent Hamiltonian is the sum of its Euclidean-space
+local terms. -/
 theorem parentHamiltonianES_eq_sum_localTermES (A : MPSTensor d D) (L N : ℕ) :
     parentHamiltonianES A L N = ∑ i : Fin N, localTermES A L i := by
   ext v σ
@@ -465,13 +465,13 @@ private theorem restrictFirst_eq_cyclicRestrictES_one {L : ℕ} (hL : 0 < L)
       exact Nat.mod_eq_of_lt (by omega)
     simp [cyclicCfg, hOneNat, hmod]
 
-/-- Forward local intersection property for adjacent transported local terms.
+/-- Forward local intersection property for adjacent Euclidean-space local terms.
 
 On an `(L+1)`-site chain, if the two overlapping `L`-site local terms based at
 `0` and `1` both annihilate a vector, then the vector lies in the `(L+1)`-site
 MPS ground space.  This is the Euclidean/local-projector form of the
 open-chain intersection property `groundSpace_intersection`; it is a structural
-predecessor to the quantitative Friedrichs-angle estimate for overlapping
+predecessor to the quantitative principal-angle estimate for overlapping
 windows. -/
 theorem mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero {A : MPSTensor d D}
     (hA : IsInjective A) {L : ℕ} (hL : 1 < L)
@@ -502,7 +502,7 @@ theorem mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero {A : MPSTensor d 
   exact (mem_groundSpaceES_iff A (L + 1) v).2 hψ
 
 /-- Vectors in the `(L+1)`-site MPS ground space are killed by the two adjacent
-`L`-site transported local terms. -/
+`L`-site Euclidean-space local terms. -/
 theorem adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ
     (A : MPSTensor d D) {L : ℕ} (hL : 0 < L)
     {v : EuclideanSpace ℂ (Cfg d (L + 1))} (hv : v ∈ groundSpaceES A (L + 1)) :
@@ -758,10 +758,10 @@ theorem localTermES_commute_of_cyclic_windows_disjoint {N : ℕ} (A : MPSTensor 
   simpa [P] using separateLinearMap_apply_commute P P F (extractWindow L i σ)
     (extractWindow L j σ)
 
-/-- Non-overlap positivity for transported local terms on disjoint cyclic windows.
+/-- Non-overlap positivity for Euclidean-space local terms on disjoint cyclic windows.
 
 For `L ≤ N`, if the cyclic windows based at `i` and `j` have no common site, then
-the ordered cross term of the corresponding transported local ES projections is
+the ordered cross term of the corresponding Euclidean-space local projections is
 nonnegative: `0 ≤ Re ⟪h_i v, h_j v⟫`. -/
 theorem localTermES_re_inner_nonneg_of_cyclic_windows_disjoint {N : ℕ}
     (A : MPSTensor d D) {L : ℕ} (hLN : L ≤ N) {i j : Fin N}
@@ -775,7 +775,7 @@ theorem localTermES_re_inner_nonneg_of_cyclic_windows_disjoint {N : ℕ}
 /-- Non-overlap positivity for the concrete cyclic-window overlap predicate.
 
 When `cyclicWindowsOverlap N L i j` fails and `L ≤ N`, the two windows are
-site-disjoint, so the transported local terms commute and have nonnegative ordered
+site-disjoint, so the Euclidean-space local terms commute and have nonnegative ordered
 cross term. -/
 theorem localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap {N : ℕ}
     (A : MPSTensor d D) {L : ℕ} (hLN : L ≤ N) {i j : Fin N}
@@ -784,15 +784,15 @@ theorem localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap {N : ℕ}
   localTermES_re_inner_nonneg_of_cyclic_windows_disjoint A hLN
     (CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap hij) v
 
-/-- The full transported parent Hamiltonian is positive because it is a finite
-sum of positive transported local terms. -/
+/-- The Euclidean-space parent Hamiltonian is positive because it is a finite
+sum of positive Euclidean-space local terms. -/
 theorem parentHamiltonianES_isPositive (A : MPSTensor d D) (L N : ℕ) :
     (parentHamiltonianES A L N).IsPositive := by
   rw [parentHamiltonianES_eq_sum_localTermES]
   exact LinearMap.isPositive_sum _ fun i _ => localTermES_isPositive A L i
 
-/-- The transported parent-Hamiltonian ground space is exactly the kernel of the
-transported parent Hamiltonian. -/
+/-- The Euclidean-space parent-Hamiltonian ground space is exactly the kernel of
+the Euclidean-space parent Hamiltonian. -/
 theorem parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES
     (A : MPSTensor d D) (L N : ℕ) :
     parentHamiltonianGroundSpaceES A L N =

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap.tex
@@ -90,15 +90,15 @@ Lucia~\cite{Kastoryano2018Martingale}.
     positivity, and finite sums of positive operators remain positive.
 \end{proof}
 
-\begin{lemma}[Cyclic averaging for the transported ES local terms]
+\begin{lemma}[Cyclic averaging for the Euclidean-space local terms]
     \label{lem:local_term_es_average}
     \lean{MPSTensor.parentHamiltonianES_eq_sum_localTermES}
     \lean{MPSTensor.localTermES_eq_average_localTermESSummand}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients, lem:euclidean_local_projector_positive}
-    The transported parent Hamiltonian is the sum of the transported local terms
-    $H_{N,\mathrm{ES}} = \sum_i h_{i,\mathrm{ES}}$, and each transported local term admits
-    the exact cyclic-averaging formula
+    The Euclidean-space parent Hamiltonian is the sum of the Euclidean-space
+    local terms $H_{N,\mathrm{ES}} = \sum_i h_{i,\mathrm{ES}}$, and each local
+    term admits the exact cyclic-averaging formula
     \begin{equation}\label{eq:ph_cyclic_averaging}
         h_{i,\mathrm{ES}}
         = d^{-L} \sum_{\tau} R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}.
@@ -107,19 +107,20 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    Unfold the transported local term and compare it configuration-by-configuration
-    with the cyclic restrictions. The $d^{-L}$ factor compensates for the $d^L$
-    choices of the window coordinates in the ambient configuration parameter $\tau$.
+    Unfold the Euclidean-space local term and compare it
+    configuration-by-configuration with the cyclic restrictions. The $d^{-L}$
+    factor compensates for the $d^L$ choices of the window coordinates in the
+    ambient configuration parameter $\tau$.
 \end{proof}
 
-\begin{lemma}[Positivity of the transported ES Hamiltonian]
+\begin{lemma}[Positivity of the Euclidean-space Hamiltonian]
     \label{lem:transported_es_positive}
     \lean{MPSTensor.localTermES_isPositive}
     \lean{MPSTensor.parentHamiltonianES_isPositive}
     \leanok
     \uses{lem:local_term_es_average}
-    Each transported local term $h_{i,\mathrm{ES}}$ is positive, hence the full
-    transported parent Hamiltonian $H_{N,\mathrm{ES}}$ is positive.
+    Each Euclidean-space local term $h_{i,\mathrm{ES}}$ is positive, hence the
+    full Euclidean-space parent Hamiltonian $H_{N,\mathrm{ES}}$ is positive.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex
@@ -87,14 +87,14 @@
     the $L-1$ clockwise starts or the $L-1$ counterclockwise starts.
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian gap from finite-overlap Friedrichs data]
+\begin{lemma}[Parent-Hamiltonian gap from a finite-overlap martingale estimate]
     \label{lem:parent_hamiltonian_finite_overlap_friedrichs_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs}
     \leanok
     \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic,
         lem:parent_hamiltonian_es_quadratic_reduction}
     Fix $L>1$ and set $m=2(L-1)$. Suppose uniformly for every $N\ge2L$ that
-    the hypotheses of the fixed-chain finite-overlap Friedrichs reduction hold
+    the hypotheses of the fixed-chain finite-overlap martingale reduction hold
     with $\gamma=1/(4L)$ and this value of $m$. Then $1/(4L)>0$, and the
     explicit norm lower bound with constant $1/(4L)$ follows for vectors in
     $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
@@ -107,7 +107,7 @@
     converts that estimate to the norm lower bound.
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian gap from cyclic-window Friedrichs data]
+\begin{lemma}[Parent-Hamiltonian gap from a cyclic-window martingale estimate]
     \label{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs}
     \leanok
@@ -143,7 +143,7 @@
     facts and the overlapping-window estimate~(\ref{eq:ph_cyclic_window_overlap_estimate}).
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian gap from overlapping cyclic Friedrichs data]
+\begin{lemma}[Parent-Hamiltonian gap from an overlapping cyclic martingale estimate]
     \label{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs}
     \leanok
@@ -237,4 +237,3 @@
     quadratic-form criterion converts it to the norm lower bound. The strict form
     is the same statement with $\gamma=1-\eta m$.
 \end{proof}
-

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
@@ -139,7 +139,7 @@
         \le
         \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}\|h_i v\|.
     \]
-    The qualitative Friedrichs-angle conclusion $\alpha<1$ does not by itself
+    The qualitative principal-angle conclusion $\alpha<1$ does not by itself
     imply this numerical bound; the missing step is the uniform
     overlapping-window estimate with the displayed coefficient. Thus the
     remaining comparison is whether the principal-angle estimates cited in
@@ -208,7 +208,7 @@
     row-cardinality bound.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap} combines
     these ingredients with the finite-overlap reduction, so the only additional
-    input is the Friedrichs-angle estimate for overlapping cyclic windows.
+    input is the principal-angle estimate for overlapping cyclic windows.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} states the
     same overlap-only formulation, and
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} states a sufficient

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_rowsum.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_rowsum.tex
@@ -7,8 +7,9 @@
     \leanok
     \uses{lem:transported_es_positive, thm:parent_ground_space_es_kernel,
         lem:quadratic_form_to_norm_bound}
-    Let $H_{N,L}^{\mathrm{ES}}(A)$ be the transported parent Hamiltonian. If a
-    constant $\gamma > 0$ satisfies the uniform quadratic-form estimate
+    Let $H_{N,L}^{\mathrm{ES}}(A)$ be the Euclidean-space representative of the
+    parent Hamiltonian. If a constant $\gamma > 0$ satisfies the uniform
+    quadratic-form estimate
     \begin{equation}\label{eq:ph_uniform_quadratic_form}
         \gamma\,\operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}(A)v, v\rangle
         \le
@@ -26,10 +27,10 @@
 
 \begin{proof}
     \leanok
-    The transported Hamiltonian is positive by
-    Lemma~\ref{lem:transported_es_positive}, and its transported ground space is
-    its kernel by Theorem~\ref{thm:parent_ground_space_es_kernel}. Therefore the
-    abstract spectral-theorem conversion of
+    The Euclidean-space Hamiltonian is positive by
+    Lemma~\ref{lem:transported_es_positive}, and its Euclidean-space ground
+    space is its kernel by Theorem~\ref{thm:parent_ground_space_es_kernel}.
+    Therefore the abstract spectral-theorem conversion of
     Lemma~\ref{lem:quadratic_form_to_norm_bound} applies directly. The
     explicit constant is positive because $L>1$ implies $4L>0$.
 \end{proof}
@@ -148,15 +149,15 @@
     \leanok
     \uses{lem:ordered_projection_rowsum_reduction, def:parent_hamiltonian_es,
         rem:euclidean_local_projector_ingredients, lem:transported_es_local_projections}
-    For a fixed chain length $N$, suppose the transported local terms
+    For a fixed chain length $N$, suppose the Euclidean-space local terms
     $h_{i,\mathrm{ES}}$ satisfy the ordered row-sum estimate
     \begin{equation}\label{eq:ph_ordered_rowsum_estimate}
         \operatorname{Re}\langle h_{i,\mathrm{ES}} v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\gamma)c_{ij}\operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle
         \qquad (i\ne j),
     \end{equation}
-    with $\sum_{j\ne i}c_{ij}\le1$ and $\gamma\le1$. Then the transported
-    parent Hamiltonian satisfies
+    with $\sum_{j\ne i}c_{ij}\le1$ and $\gamma\le1$. Then the
+    Euclidean-space parent Hamiltonian satisfies
     \[
         \gamma\operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}v,v\rangle
         \le
@@ -181,8 +182,9 @@
     \leanok
     \uses{lem:parent_hamiltonian_ordered_rowsum_quadratic,
         lem:parent_hamiltonian_es_quadratic_reduction, lem:transported_es_local_projections}
-    Assume uniformly for every $N\ge2L$ that the transported local terms satisfy
-    the ordered row-sum estimate~(\ref{eq:ph_ordered_rowsum_estimate}) with $\gamma=1/(4L)$. If $L>1$, then
+    Assume uniformly for every $N\ge2L$ that the Euclidean-space local terms
+    satisfy the ordered row-sum estimate~(\ref{eq:ph_ordered_rowsum_estimate})
+    with $\gamma=1/(4L)$. If $L>1$, then
     $1/(4L)>0$ and, for every
     $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
     \[
@@ -197,13 +199,13 @@
         lem:parent_hamiltonian_es_quadratic_reduction}
     The fixed-chain row-sum reduction supplies the quadratic-form estimate with
     $\gamma=1/(4L)$ for every admissible $N$. The positivity and kernel
-    identification of the transported Hamiltonian then allow
+    identification of the Euclidean-space Hamiltonian then allow
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} to convert this
     quadratic-form estimate into the norm lower bound on the orthogonal
     complement of the ground space.
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian finite-overlap Friedrichs quadratic reduction]
+\begin{lemma}[Parent-Hamiltonian finite-overlap martingale quadratic reduction]
     \label{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
     \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs}
     \leanok
@@ -211,15 +213,15 @@
     For a fixed chain length $N$, let $m$ be a positive integer and let
     $\gamma\le1$. Suppose an overlap predicate on local windows has at most $m$
     overlapping off-diagonal windows in each row. If non-overlapping local terms
-    have non-negative ordered cross terms, overlapping local terms satisfy the
-    finite-overlap Friedrichs estimate
+    have non-negative ordered cross terms, and overlapping local terms satisfy
+    the finite-overlap principal-angle estimate
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\gamma)\frac{1}{m}
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle,
     \]
-    and the transported local terms are symmetric projections, then the
-    transported Hamiltonian satisfies $H_{N,L}^{\mathrm{ES}}{}^2\ge
+    and the Euclidean-space local terms are symmetric projections, then the
+    Euclidean-space Hamiltonian satisfies $H_{N,L}^{\mathrm{ES}}{}^2\ge
         \gamma H_{N,L}^{\mathrm{ES}}$ as a quadratic form.
 \end{lemma}
 
@@ -257,4 +259,3 @@
     $P_i=h_{i,\mathrm{ES}}$. If a separate coefficient $\eta$ is used, first weaken
     the compression estimate using $\eta\le(1-\gamma)/m$.
 \end{proof}
-


### PR DESCRIPTION
### Motivation

- The parent-Hamiltonian spectral-gap reduction follows the martingale/principal-angle route described in arXiv:2011.12127 §IV.C. Reader-facing prose in the blueprint and Lean docstrings still foregrounded local formalization terminology such as "Friedrichs data" and "transported parent Hamiltonian".
- This PR makes the prose describe what the mathematical argument does: passing to Euclidean-space representatives and leaving a principal-angle estimate as the remaining analytic input.
- Continues formalization of arXiv:2011.12127 §IV.C parent Hamiltonian spectral-gap theory; see #190.

### Description

- Replaces reader-facing "Friedrichs data" theorem titles in the cyclic-overlap blueprint by "martingale estimate" (`ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex`, `ch14_parent_hamiltonian_spectral_gap_martingale.tex`, `ch14_parent_hamiltonian_spectral_gap_rowsum.tex`, `ch14_parent_hamiltonian_spectral_gap.tex`).
- Rewords `Martingale.{Gap,Reduction,Transport}` docstrings from "transported Hamiltonian/local terms" to "Euclidean-space representative/local terms", clarifying that `parentHamiltonianES` is the Hilbert-space model of the parent Hamiltonian (not a separate transported object).
- Uses "principal-angle estimate" for the remaining analytic input, matching #952 and arXiv:2011.12127 §IV.C, while preserving Lean declaration names containing `friedrichs` for API stability.
- Notes that PR #2727 did not prove the principal-angle or norm-compression estimate; #952 remains open.
- No proof, definition, or public theorem signature changes.

### Testing

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean`
- `cd blueprint && chktex -q -l .chktexrc src/chapter/ch14_parent_hamiltonian_spectral_gap.tex src/chapter/ch14_parent_hamiltonian_spectral_gap_rowsum.tex src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex`
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Gap -q --log-level=info`

---
Refs #190
Refs #460
Refs #952

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX-only edits; no changes to proofs, definitions, or public theorem signatures.
> 
> **Overview**
> Aligns **reader-facing** spectral-gap prose with the martingale / principal-angle story in arXiv:2011.12127 §IV.C, while **keeping** formal `ES` notation and Lean names such as `*_friedrichs` unchanged.
> 
> In **Lean** (`Martingale/Gap`, `Reduction`, `Transport`), module and theorem docstrings now describe `parentHamiltonianES` and local terms as **Euclidean-space representatives** of the parent Hamiltonian (not a separate "transported" object), and frame the remaining analytic input as a **principal-angle** (or norm-compression) estimate rather than a Friedrichs-angle hypothesis. No proof or type changes.
> 
> In the **blueprint** (ch14 row-sum, cyclic-overlap, martingale, and main spectral-gap sections), wording is updated similarly: parent Hamiltonian as Euclidean-space representative, **martingale estimate** in several lemma titles that previously said "Friedrichs data," and principal-angle language where the gap argument is explained. One trailing blank line is removed in a cyclic-overlap proof block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dda89cbdc223aa51aebfa83ccd19cb439536e8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->