### PR TITLE
feat(MPS/ParentHamiltonian): derive boundary identities from trace decompositions

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -730,6 +730,65 @@ theorem
     (sum_evalWord_mul_conjTranspose_evalWord (A j) (hUnital j) (N - L))
     (hCompat j i hi) ρ
 
+/-- PGVWC trace decompositions give the componentwise periodic constraints under
+block injectivity.
+
+For each boundary-crossing interval beginning at \(i\), assume there are
+matrices \(C^j_{i,\rho}\) indexed by complementary words such that the two
+trace decompositions agree for every wrapped word \(\beta\), complementary word
+\(\rho\), and middle word \(w\):
+\[
+  \sum_j\operatorname{tr}(A^j_\beta C^j_{i,\rho}A^j_w)
+  =
+  \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr).
+\]
+The product-span comparison extracts the blockwise identity
+\[
+  A^j_\beta C^j_{i,\rho}=((\mu_j^NX_j)A^j_\beta)A^j_\rho .
+\]
+The normalized PGVWC boundary calculation then gives the complementary-word
+identities used to prove
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+\]
+This is the boundary-crossing trace-decomposition form of
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1456. -/
+theorem
+    blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {m L₀ L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hTraceSpan : WordTupleSpanTop A m)
+    (hBlk : ∀ j : Fin r, IsNBlkInjective (A j) L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hNlarge : L + L₀ ≤ N)
+    (C : ∀ (j : Fin r) (_ : Fin N),
+      (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hCoeff : ∀ i : Fin N,
+      N < i.val + L →
+        ∀ ρ : Fin (N - L) → Fin d, ∀ β : Fin (i.val + L - N) → Fin d,
+          ∀ w : Fin m → Fin d,
+            (∑ j : Fin r,
+              Matrix.trace
+                ((evalWord (A j) (List.ofFn β) * C j i ρ) *
+                  evalWord (A j) (List.ofFn w))) =
+            (∑ j : Fin r,
+              Matrix.trace
+                ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                    evalWord (A j) (List.ofFn ρ)) *
+                  evalWord (A j) (List.ofFn w)))) :
+    ∀ j : Fin r,
+      groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  refine
+    blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities_of_injective
+      μ A hN hLN X hBlk hUnital hNlarge ?_
+  intro j i hi ρ
+  exact pgvwc07_complementary_word_boundary_identities_of_trace_decomposition
+    (A := A) (m := m) (K := i.val + L - N) (M := N - L) hTraceSpan
+    (fun k => (μ k) ^ N • X k) (fun k => C k i) hUnital
+    (hCoeff i hi) j ρ
+
 /-- Complementary-word identities upgrade the block-diagonal boundary
 representation to periodic block components.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -761,7 +761,13 @@ These complementary-word identities give
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
 \]
 This is the boundary-crossing trace-decomposition form of
-arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1456. -/
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1456.
+
+**Local fix (adjoint correction):** The complementary-word identity used here
+replaces the source's \(E^j=\sum_k C^j_kA^j_k\) by
+\(E^j=\sum_k C^j_kA^{j\dagger}_k\), since the normalization is
+\(\sum_k A^j_kA^{j\dagger}_k=I\). This is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
     {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -742,12 +742,19 @@ trace decompositions agree for every wrapped word \(\beta\), complementary word
   =
   \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr).
 \]
-The trace-separation hypothesis for products of length \(m\) extracts the blockwise identity
+Since the word tuples \((A^1_w,\ldots,A^r_w)\) span the full product algebra
+\(\prod_j M_{D_j}(\mathbb C)\) at length \(m\), the trace equality implies
+the blockwise identity
 \[
   A^j_\beta C^j_{i,\rho}=((\mu_j^NX_j)A^j_\beta)A^j_\rho .
 \]
-The normalized PGVWC boundary calculation then gives the complementary-word
-identities used to prove
+The normalized PGVWC boundary calculation then gives, for each block \(j\),
+interval \(i\), and complementary word \(\rho\), a matrix \(E_{j,i,\rho}\)
+such that, for every wrapped word \(\beta\),
+\[
+  ((\mu_j^NX_j)A^j_\beta)A^j_\rho=A^j_\beta E_{j,i,\rho}.
+\]
+These complementary-word identities give
 \[
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
 \]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -695,8 +695,9 @@ wrapped word \(\beta\),
   =
   \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
 \]
-The normalized PGVWC boundary calculation gives the complementary-word
-identities used in the injective componentwise periodic-chain theorem.
+The normalization \(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) and these
+compatibility identities give the complementary-word identities used in the
+injective componentwise periodic-chain theorem.
 This is the boundary-closing comparison in arXiv:quant-ph/0608197, Theorem
 2blocks.2, proof lines 1446--1451, followed by the periodic conclusion in
 lines 1454--1456.
@@ -748,7 +749,8 @@ the blockwise identity
 \[
   A^j_\beta C^j_{i,\rho}=((\mu_j^NX_j)A^j_\beta)A^j_\rho .
 \]
-The normalized PGVWC boundary calculation then gives, for each block \(j\),
+The normalization \(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) and the
+complementary-word compatibility identity then give, for each block \(j\),
 interval \(i\), and complementary word \(\rho\), a matrix \(E_{j,i,\rho}\)
 such that, for every wrapped word \(\beta\),
 \[

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -742,7 +742,7 @@ trace decompositions agree for every wrapped word \(\beta\), complementary word
   =
   \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr).
 \]
-The product-span comparison extracts the blockwise identity
+The trace-separation hypothesis for products of length \(m\) extracts the blockwise identity
 \[
   A^j_\beta C^j_{i,\rho}=((\mu_j^NX_j)A^j_\beta)A^j_\rho .
 \]

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -545,6 +545,54 @@ theorem pgvwc07_complementary_word_compatibility_of_trace_decomposition
       (A := A) (m := m) (K := K) (M := M) hSpan C
       (fun j β => X j * evalWord (A j) (List.ofFn β)) hCoeff
 
+/-- Complementary-word boundary identities from the PGVWC trace decompositions.
+
+Assume the right trace decomposition has
+\[
+  D^j_\beta=X_jA^j_\beta .
+\]
+If the two trace decompositions agree for every wrapped word \(\beta\),
+complementary word \(\rho\), and middle word \(w\), then the normalized PGVWC
+boundary calculation gives, for every block \(j\) and complementary word
+\(\rho\), a matrix \(E_{j,\rho}\) such that
+\[
+  (X_jA^j_\beta)A^j_\rho=A^j_\beta E_{j,\rho}.
+\]
+This is the word-valued form of arXiv:quant-ph/0608197, Theorem 2blocks.2,
+proof lines 1446--1451. -/
+theorem pgvwc07_complementary_word_boundary_identities_of_trace_decomposition
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {m K M : ℕ} (hSpan : WordTupleSpanTop A m)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (C : (j : Fin r) → (Fin M → Fin d) →
+      Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hCoeff : ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      ∀ w : Fin m → Fin d,
+        (∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) (List.ofFn β) * C j ρ) *
+              evalWord (A j) (List.ofFn w))) =
+        (∑ j : Fin r,
+          Matrix.trace
+            (((X j * evalWord (A j) (List.ofFn β)) *
+                evalWord (A j) (List.ofFn ρ)) *
+              evalWord (A j) (List.ofFn w)))) :
+    ∀ j : Fin r, ∀ ρ : Fin M → Fin d,
+      ∃ E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ∀ β : Fin K → Fin d,
+          (X j * evalWord (A j) (List.ofFn β)) *
+              evalWord (A j) (List.ofFn ρ) =
+            evalWord (A j) (List.ofFn β) * E := by
+  intro j ρ
+  exact pgvwc07_complementary_word_boundary_identities_of_compatibility
+    (A := A j) (K := K) (M := M) (X := X j) (C := C j)
+    (sum_evalWord_mul_conjTranspose_evalWord (A j) (hUnital j) M)
+    ((pgvwc07_complementary_word_compatibility_of_trace_decomposition
+      (A := A) (m := m) (K := K) (M := M) hSpan X C hCoeff) j)
+    ρ
+
 /-- The composed PGVWC open-segment step from the trace decompositions to
 membership in the supremum of block ground spaces.
 

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -559,7 +559,13 @@ boundary calculation gives, for every block \(j\) and complementary word
   (X_jA^j_\beta)A^j_\rho=A^j_\beta E_{j,\rho}.
 \]
 This is the word-valued form of arXiv:quant-ph/0608197, Theorem 2blocks.2,
-proof lines 1446--1451. -/
+proof lines 1446--1451.
+
+**Local fix (adjoint correction):** The source line writes
+\(E^j=\sum_k C^j_kA^j_k\), while the normalization step uses
+\(\sum_k A^j_kA^{j\dagger}_k=I\). The formal statement uses the adjointed
+matrix \(E^j=\sum_k C^j_kA^{j\dagger}_k\), as recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem pgvwc07_complementary_word_boundary_identities_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -552,9 +552,10 @@ Assume the right trace decomposition has
   D^j_\beta=X_jA^j_\beta .
 \]
 If the two trace decompositions agree for every wrapped word \(\beta\),
-complementary word \(\rho\), and middle word \(w\), then the normalized PGVWC
-boundary calculation gives, for every block \(j\) and complementary word
-\(\rho\), a matrix \(E_{j,\rho}\) such that
+complementary word \(\rho\), and middle word \(w\), then the normalization
+\(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) and the compatibility identity give,
+for every block \(j\) and complementary word \(\rho\), a matrix \(E_{j,\rho}\)
+such that
 \[
   (X_jA^j_\beta)A^j_\rho=A^j_\beta E_{j,\rho}.
 \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -605,6 +605,9 @@
     \[
         \sum_a A^j_aA^{j\dagger}_a=I .
     \]
+    Assume also that the simultaneous tuples \(w\mapsto(A^1_w,\ldots,A^g_w)\)
+    at the middle-word length \(m\) span the full product algebra
+    \(\prod_jM_{D_j}(\mathbb C)\).
     Fix block-diagonal boundary conditions \(X_j\). For every boundary-crossing
     interval beginning at \(i\), suppose there are matrices \(C^j_{i,\rho}\),
     indexed by complementary words \(\rho\) of length \(N-L\), such that for

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -593,7 +593,7 @@
     \]
 \end{proof}
 
-\begin{lemma}[PGVWC comparison under block injectivity gives componentwise constraints]
+\begin{lemma}[Compatibility hypotheses under block injectivity give componentwise constraints]
     \label{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective}
     \leanok
@@ -640,6 +640,50 @@
     \]
     Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities_injective}
     then gives the componentwise periodic-chain constraint.
+\end{proof}
+
+\begin{lemma}[Trace decompositions under block injectivity give componentwise constraints]
+    \label{lem:block_diagonal_boundary_component_trace_decomposition_injective}
+    \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}
+    \leanok
+    \uses{lem:complementary_word_boundary_identities_from_trace_decompositions,
+        lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    Assume \(0<N\), \(L\le N\), and \(L+L_0\le N\). Suppose each block \(A_j\)
+    is \(L_0\)-block-injective and satisfies
+    \[
+        \sum_a A^j_aA^{j\dagger}_a=I .
+    \]
+    Fix block-diagonal boundary conditions \(X_j\). For every boundary-crossing
+    interval beginning at \(i\), suppose there are matrices \(C^j_{i,\rho}\),
+    indexed by complementary words \(\rho\) of length \(N-L\), such that for
+    every wrapped word \(\beta\), complementary word \(\rho\), and middle word
+    \(w\),
+    \[
+        \sum_j\operatorname{tr}\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \sum_j
+        \operatorname{tr}\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    Then, for every block \(j\),
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:complementary_word_boundary_identities_from_trace_decompositions,
+        lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    Lemma~\ref{lem:complementary_word_boundary_identities_from_trace_decompositions}
+    gives, for every block \(j\), every boundary-crossing interval \(i\), and
+    every complementary word \(\rho\), a matrix \(E_{j,i,\rho}\) such that
+    \[
+        ((\mu_j^NX_j)A^j_\beta)A^j_\rho=A^j_\beta E_{j,i,\rho}
+    \]
+    for every wrapped word \(\beta\).  These are precisely the complementary-word
+    identities of
+    Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities_injective},
+    which gives the periodic-chain constraint for each block.
 \end{proof}
 
 \begin{lemma}[Complementary identities give periodic block components]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -681,11 +681,12 @@
     Lemma~\ref{lem:complementary_word_boundary_identities_from_trace_decompositions}
     with \(X_j\) replaced by \(\mu_j^NX_j\), for every block \(j\), every
     boundary-crossing interval \(i\), and every complementary word \(\rho\),
-    this gives a matrix \(E_{j,i,\rho}\) such that
+    this gives a matrix \(E_{j,i,\rho}\) such that, for every wrapped word
+    \(\beta\),
     \[
         ((\mu_j^NX_j)A^j_\beta)A^j_\rho=A^j_\beta E_{j,i,\rho}
-    \]
-    for every wrapped word \(\beta\).  These are precisely the complementary-word
+    \].
+    These are precisely the complementary-word
     identities of
     Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities_injective},
     which gives the periodic-chain constraint for each block.

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -677,9 +677,11 @@
     \leanok
     \uses{lem:complementary_word_boundary_identities_from_trace_decompositions,
         lem:block_diagonal_boundary_component_complementary_word_identities_injective}
+    Applying
     Lemma~\ref{lem:complementary_word_boundary_identities_from_trace_decompositions}
-    gives, for every block \(j\), every boundary-crossing interval \(i\), and
-    every complementary word \(\rho\), a matrix \(E_{j,i,\rho}\) such that
+    with \(X_j\) replaced by \(\mu_j^NX_j\), for every block \(j\), every
+    boundary-crossing interval \(i\), and every complementary word \(\rho\),
+    this gives a matrix \(E_{j,i,\rho}\) such that
     \[
         ((\mu_j^NX_j)A^j_\beta)A^j_\rho=A^j_\beta E_{j,i,\rho}
     \]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -656,11 +656,11 @@
     Assume also that the simultaneous tuples \(w\mapsto(A^1_w,\ldots,A^g_w)\)
     at the middle-word length \(m\) span the full product algebra
     \(\prod_jM_{D_j}(\mathbb C)\).
-    Fix block-diagonal boundary conditions \(X_j\). For every boundary-crossing
-    interval beginning at \(i\), suppose there are matrices \(C^j_{i,\rho}\),
-    indexed by complementary words \(\rho\) of length \(N-L\), such that for
-    every wrapped word \(\beta\), complementary word \(\rho\), and middle word
-    \(w\),
+    Fix complex numbers \(\mu_j\) and block-diagonal boundary conditions
+    \(X_j\). For every boundary-crossing interval beginning at \(i\), suppose
+    there are matrices \(C^j_{i,\rho}\), indexed by complementary words
+    \(\rho\) of length \(N-L\), such that for every wrapped word \(\beta\),
+    complementary word \(\rho\), and middle word \(w\),
     \[
         \sum_j\operatorname{tr}\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
         =

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -605,9 +605,6 @@
     \[
         \sum_a A^j_aA^{j\dagger}_a=I .
     \]
-    Assume also that the simultaneous tuples \(w\mapsto(A^1_w,\ldots,A^g_w)\)
-    at the middle-word length \(m\) span the full product algebra
-    \(\prod_jM_{D_j}(\mathbb C)\).
     Fix block-diagonal boundary conditions \(X_j\). For every boundary-crossing
     interval beginning at \(i\), suppose there are matrices \(C^j_{i,\rho}\),
     indexed by complementary words \(\rho\) of length \(N-L\), such that for
@@ -656,6 +653,9 @@
     \[
         \sum_a A^j_aA^{j\dagger}_a=I .
     \]
+    Assume also that the simultaneous tuples \(w\mapsto(A^1_w,\ldots,A^g_w)\)
+    at the middle-word length \(m\) span the full product algebra
+    \(\prod_jM_{D_j}(\mathbb C)\).
     Fix block-diagonal boundary conditions \(X_j\). For every boundary-crossing
     interval beginning at \(i\), suppose there are matrices \(C^j_{i,\rho}\),
     indexed by complementary words \(\rho\) of length \(N-L\), such that for

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -391,11 +391,10 @@
     \[
         A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho.
     \]
-    The normalization equation implies
+    The normalization equation for words of length \(M\) implies
     \[
         \sum_\rho A^j_\rho A^{j\dagger}_\rho=I
-    \]
-    for words \(\rho\) of length \(M\).
+    \].
     Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc} gives the
     matrices \(E_{j,\rho}\).
 \end{proof}

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -393,7 +393,8 @@
     \[
         A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho.
     \]
-    The normalization equation for words of length \(M\) implies
+    The hypothesis \(\sum_a A^j_a A^{j\dagger}_a=I\) extends to words of
+    length \(M\):
     \[
         \sum_\rho A^j_\rho A^{j\dagger}_\rho=I
     \].

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -359,7 +359,8 @@
     \label{lem:complementary_word_boundary_identities_from_trace_decompositions}
     \lean{MPSTensor.pgvwc07_complementary_word_boundary_identities_of_trace_decomposition}
     \leanok
-    \uses{lem:blockwise_word_boundary_compatibility_from_traces,
+    \uses{lem:sum_evalWord_mul_conjTranspose_evalWord,
+        lem:blockwise_word_boundary_compatibility_from_traces,
         lem:complementary_word_boundary_identities_from_pgvwc}
     Let \(A^1,\ldots,A^g\) be block tensors with the common word-span property
     at length \(m\). Fix matrices \(X_j\). Suppose that \(C^j_\rho\) is indexed
@@ -384,7 +385,8 @@
 
 \begin{proof}
     \leanok
-    \uses{lem:blockwise_word_boundary_compatibility_from_traces,
+    \uses{lem:sum_evalWord_mul_conjTranspose_evalWord,
+        lem:blockwise_word_boundary_compatibility_from_traces,
         lem:complementary_word_boundary_identities_from_pgvwc}
     Lemma~\ref{lem:blockwise_word_boundary_compatibility_from_traces} applied
     with \(D^j_\beta=X_jA^j_\beta\) gives

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_block_intersection_trace.tex
@@ -313,7 +313,7 @@
     $A_bC_a=D_bB_a$ gives $A_bC_a=A_bEB_a$.
 \end{proof}
 
-\begin{lemma}[Complementary-word boundary identities from the PGVWC comparison]
+\begin{lemma}[Complementary-word boundary identities from a compatibility hypothesis]
     \label{lem:complementary_word_boundary_identities_from_pgvwc}
     \lean{MPSTensor.pgvwc07_complementary_word_boundary_identities_of_compatibility}
     \leanok
@@ -353,6 +353,51 @@
         = A_\beta E A_\rho
         = A_\beta E_\rho.
     \]
+\end{proof}
+
+\begin{lemma}[Complementary-word boundary identities from trace decompositions]
+    \label{lem:complementary_word_boundary_identities_from_trace_decompositions}
+    \lean{MPSTensor.pgvwc07_complementary_word_boundary_identities_of_trace_decomposition}
+    \leanok
+    \uses{lem:blockwise_word_boundary_compatibility_from_traces,
+        lem:complementary_word_boundary_identities_from_pgvwc}
+    Let \(A^1,\ldots,A^g\) be block tensors with the common word-span property
+    at length \(m\). Fix matrices \(X_j\). Suppose that \(C^j_\rho\) is indexed
+    by a block \(j\) and a complementary word \(\rho\) of length \(M\). Assume
+    that, for every wrapped word \(\beta\) of length \(K\), every complementary
+    word \(\rho\), and every middle word \(w\) of length \(m\),
+    \[
+        \sum_j\operatorname{tr}\!\left(A^j_\beta C^j_\rho A^j_w\right)
+        =
+        \sum_j\operatorname{tr}\!\left((X_jA^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    If each block satisfies
+    \[
+        \sum_a A^j_aA^{j\dagger}_a=I,
+    \]
+    then, for every block \(j\) and every complementary word \(\rho\), there is
+    a matrix \(E_{j,\rho}\) such that, for every wrapped word \(\beta\),
+    \[
+        (X_jA^j_\beta)A^j_\rho=A^j_\beta E_{j,\rho}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:blockwise_word_boundary_compatibility_from_traces,
+        lem:complementary_word_boundary_identities_from_pgvwc}
+    Lemma~\ref{lem:blockwise_word_boundary_compatibility_from_traces} applied
+    with \(D^j_\beta=X_jA^j_\beta\) gives
+    \[
+        A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho.
+    \]
+    The normalization equation implies
+    \[
+        \sum_\rho A^j_\rho A^{j\dagger}_\rho=I
+    \]
+    for words \(\rho\) of length \(M\).
+    Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc} gives the
+    matrices \(E_{j,\rho}\).
 \end{proof}
 
 \begin{lemma}[A left-boundary summand is a ground-space vector]

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -160,7 +160,10 @@ for every $j,i_1,i_{m+1}$,
   =
   D^j_{i_{m+1}} A^j_{i_1}.
 \end{align}
-The source defines the matrix
+The source line writes \(E^j=\sum_k C^j_kA^j_k\), without an adjoint on the
+second factor. The normalization used in the next line is
+\(\sum_kA^j_kA^{j\dagger}_k=I\), so the calculation requires the adjointed
+matrix
 \begin{align}
   E^j=\sum_{k} C^j_{k}A^{j\dagger}_{k}.
 \end{align}
@@ -440,9 +443,11 @@ boundary-crossing windows. Then, for every block $j$,
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
 This is the conditional reduction recorded by pull request~\#2724.  The
-formal trace-decomposition step now records the following implication.  If, for
-every boundary-crossing interval, wrapped word $\beta$, complementary word
-$\rho$, and middle word $w$, the two PGVWC07 trace decompositions satisfy
+formal trace-decomposition step now records the following implication.  Assume
+the common word-span property for the middle-word length \(m\). If, for every
+boundary-crossing interval, wrapped word $\beta$, complementary word $\rho$,
+and middle word $w$ of length \(m\), the two PGVWC07 trace decompositions
+satisfy
 \begin{align}
   \sum_j\tr\!\left(A^j_\beta C^j_\rho A^j_w\right)
   =

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -160,8 +160,7 @@ for every $j,i_1,i_{m+1}$,
   =
   D^j_{i_{m+1}} A^j_{i_1}.
 \end{align}
-The source line defines $E^j$ without an adjoint. The following calculation
-uses instead the matrix
+The source defines the matrix
 \begin{align}
   E^j=\sum_{k} C^j_{k}A^{j\dagger}_{k}.
 \end{align}
@@ -440,10 +439,24 @@ boundary-crossing windows. Then, for every block $j$,
   \quad\Longrightarrow\quad
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
-This is the conditional reduction recorded by pull request~\#2724. The
-unconditional target of
+This is the conditional reduction recorded by pull request~\#2724.  The
+formal trace-decomposition step now records the following implication.  If, for
+every boundary-crossing interval, wrapped word $\beta$, complementary word
+$\rho$, and middle word $w$, the two PGVWC07 trace decompositions satisfy
+\begin{align}
+  \sum_j\tr\!\left(A^j_\beta C^j_\rho A^j_w\right)
+  =
+  \sum_j\tr\!\left((\mu_j^NX_jA^j_\beta)A^j_\rho A^j_w\right),
+\end{align}
+then
+\begin{align}
+  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j)
+\end{align}
+for every block $j$ in the block-injective range.\footnote{Lean declaration:
+\leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}.}
+The unconditional target of
 \href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} is reduced to
-deriving those comparison identities from the PGVWC07
+deriving those trace-decomposition equalities from the PGVWC07
 \(C^j,D^j,E^j\) comparison in the source range
 \begin{align}
   b\ge2,


### PR DESCRIPTION
### Motivation

- Continues the PGVWC07 boundary-closing formalization for the block-diagonal parent-Hamiltonian ground-space argument (see #2651, tracking #190, capstone #460).
- The prior conditional reduction (PR #2724) required an external comparison hypothesis; this PR derives that hypothesis from trace-decomposition equalities directly.
- Source: `Papers/quant-ph_0608197/MPSarchive.tex`, Theorem `2blocks.2`, proof lines 1454--1456 (arXiv:quant-ph/0608197, Perez-Garcia--Verstraete--Wolf--Cirac 2007); see also `Papers/2011.12127/TN-Review-main.tex`, §IV.C, lines 2126--2128 (arXiv:2011.12127).

### Description

- `TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`: adds `pgvwc07_complementary_word_boundary_identities_of_trace_decomposition`. From equality of the two trace expansions for every wrapped word, complementary word, and middle word, the word tuples spanning the product algebra give the blockwise compatibility identity; the normalization \(\sum_a A^j_aA^{j\dagger}_a=I\), extended to words, then gives matrices \(E_{j,\rho}\) satisfying \((X_j A^j_\beta)A^j_\rho = A^j_\beta E_{j,\rho}\).
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`: adds `blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective`, applying that identity in the block-injective boundary-closing theorem to conclude \(\Gamma_N^{A_j}(\mu_j^N X_j) \in \mathcal{G}_{N,L}(A_j)\) from the trace decompositions alone.
- `blueprint/src/chapter/ch14_parent_hamiltonian_block_diagonal_boundary_crossing.tex` and `ch14_parent_hamiltonian_block_intersection_trace.tex`: distinguish direct compatibility hypotheses from trace-decomposition comparisons.
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: records that PGVWC07 writes \(E^j\) without the adjoint, while the formal calculation requires \(E^j = \sum_k C^j_k A^{j\dagger}_k\).

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing -q --log-level=info`
- `lake build TNLean -q --log-level=info` succeeded with pre-existing warnings outside this PR's files
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `rg -n "\bsorry\b|\badmit\b|\baxiom\b|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`

---
Refs #2651
Refs #190
Refs #460