### PR TITLE
doc(parent): align martingale overlap terminology

### DIFF
--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap.tex
@@ -55,7 +55,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     parent Hamiltonian annihilates it.
 \end{lemma}
 
-\begin{remark}[Euclidean local projector ingredients]
+\begin{remark}[Euclidean local projectors]
     \label{rem:euclidean_local_projector_ingredients}
     \lean{MPSTensor.parentInteractionES}
     \lean{MPSTensor.cyclicRestrictES}
@@ -65,9 +65,10 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{def:ground_space_es, rem:cyclic_window_operators}
     Let $P_L^{\mathrm{ES}}(A)$ denote the orthogonal projector onto
     $(G_L^{\mathrm{ES}}(A))^\perp$ on the Euclidean $L$-site space. For a cyclic
-    window starting at $i$ and an outside configuration $\tau$, the transported
-    restriction map $R_{i,\tau}$ evaluates an $N$-site Euclidean vector on that
-    window. The transported local term $h_{i,\mathrm{ES}}$ is the corresponding
+    window starting at $i$ and an outside configuration $\tau$, the
+    boundary-filled restriction map $R_{i,\tau}$ evaluates an $N$-site
+    Euclidean vector on that window. The Euclidean local term
+    $h_{i,\mathrm{ES}}$ is the corresponding
     $N$-site local projector, and $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is
     the basic positive summand in its cyclic-averaging formula.
 \end{remark}
@@ -130,14 +131,14 @@ Lucia~\cite{Kastoryano2018Martingale}.
     itself positive. Summing over $i$ yields positivity of $H_{N,\mathrm{ES}}$.
 \end{proof}
 
-\begin{lemma}[Symmetric-projection structure of transported ES local terms]
+\begin{lemma}[Euclidean local terms are symmetric projections]
     \label{lem:transported_es_local_projections}
     \lean{MPSTensor.parentInteractionES_isSymmetricProjection}
     \lean{MPSTensor.localTermES_isSymmetricProjection}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients, lem:transported_es_positive}
     The Euclidean local projector $P_L^{\mathrm{ES}}(A)$ is a symmetric projection, and
-    every transported local term $h_{i,\mathrm{ES}}$ on the $N$-site chain is a
+    every Euclidean local term $h_{i,\mathrm{ES}}$ on the $N$-site chain is a
     symmetric projection.
 \end{lemma}
 
@@ -178,7 +179,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \lean{MPSTensor.cyclicRestrictES_mem_groundSpaceES_of_localTermES_eq_zero}
     \leanok
     \uses{lem:parent_interaction_es_kernel, rem:euclidean_local_projector_ingredients}
-    For $L\le N$, a transported local term $h_{i,\mathrm{ES}}$ annihilates a vector
+    For $L\le N$, a Euclidean local term $h_{i,\mathrm{ES}}$ annihilates a vector
     $v$ iff every boundary-filled restriction of $v$ to the cyclic $L$-window
     starting at $i$ lies in $G_L^{\mathrm{ES}}(A)$.
 \end{lemma}
@@ -200,8 +201,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{thm:ground_space_intersection, lem:local_term_es_kernel_restrictions,
         lem:mem_ground_space_es}
     If $A$ is injective and $L\ge2$, then on an $(L+1)$-site chain the kernels of
-    the two adjacent transported $L$-site local terms are exactly the transported
-    $(L+1)$-site MPS ground space:
+    the two adjacent Euclidean $L$-site local terms have common kernel equal to
+    the Euclidean $(L+1)$-site MPS ground space:
     \[
         h_{0,\mathrm{ES}}v=0\ \text{ and }\ h_{1,\mathrm{ES}}v=0
         \quad\Longleftrightarrow\quad
@@ -221,7 +222,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     the same kernel--restriction characterization.
 \end{proof}
 
-\begin{lemma}[Non-overlap positivity for transported ES local terms]
+\begin{lemma}[Non-overlap positivity for Euclidean local terms]
     \label{lem:transported_es_nonoverlap_positive}
     \lean{MPSTensor.CyclicWindowsDisjoint}
     \lean{MPSTensor.CyclicWindowsDisjoint.symm}
@@ -230,7 +231,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \lean{MPSTensor.localTermES_re_inner_nonneg_of_cyclic_windows_disjoint}
     \leanok
     \uses{lem:transported_es_local_projections, rem:projection_geometry_rowsum_identities}
-    Let $L\le N$ and let $h_{i,\mathrm{ES}},h_{j,\mathrm{ES}}$ be transported local
+    Let $L\le N$ and let $h_{i,\mathrm{ES}},h_{j,\mathrm{ES}}$ be Euclidean local
     terms whose cyclic $L$-windows are site-disjoint: no site of the periodic chain
     has cyclic offset $<L$ from both $i$ and $j$. Then the terms commute pointwise:
     for every vector $v$,

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex
@@ -50,7 +50,7 @@
     \uses{lem:cyclic_window_support_offsets, def:cyclic_windows_overlap,
         lem:transported_es_nonoverlap_positive}
     If $L\le N$ and the cyclic supports $S_i$ and $S_j$ do not meet, then the
-    transported local ES terms have non-negative ordered cross term:
+    Euclidean local terms have non-negative ordered cross term:
     \[
         0\le\operatorname{Re}\langle h_{i,\mathrm{ES}}v,
         h_{j,\mathrm{ES}}v\rangle.
@@ -135,7 +135,7 @@
     bound $m=2(L-1)$ for the overlap relation among length-$L$ local windows,
     and
     Lemma~\ref{lem:transported_es_local_projections} supplies the symmetric
-    projection structure of each transported local term. If two cyclic supports
+    projection structure of each Euclidean local term. If two cyclic supports
     do not meet, the corresponding windows are site-disjoint, so
     Lemma~\ref{lem:cyclic_window_nonoverlap_positive} gives the required
     non-negative ordered cross term. Apply
@@ -170,7 +170,7 @@
     cross-term condition.
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian gap from overlapping cyclic norm-compression data]
+\begin{lemma}[Parent-Hamiltonian gap from an overlapping cyclic norm-compression estimate]
     \label{lem:parent_hamiltonian_cyclic_overlap_norm_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound}
     \leanok
@@ -191,9 +191,9 @@
     \leanok
     \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
         rem:projection_geometry_rowsum_identities}
-    The norm-compression condition is converted to the ordered Friedrichs lower
-    bound by the projection-geometry Cauchy--Schwarz lemma. The preceding
-    overlapping-cyclic Friedrichs reduction then gives the norm lower bound.
+    The norm-compression condition is converted to the ordered principal-angle
+    lower bound by the projection-geometry Cauchy--Schwarz lemma. The preceding
+    overlapping-cyclic martingale reduction then gives the norm lower bound.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian gap from a cyclic overlap compression constant]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex
@@ -191,9 +191,27 @@
     \leanok
     \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
         rem:projection_geometry_rowsum_identities}
-    The norm-compression condition is converted to the ordered principal-angle
-    lower bound by the projection-geometry Cauchy--Schwarz lemma. The preceding
-    overlapping-cyclic martingale reduction then gives the norm lower bound.
+    For an overlapping pair, Cauchy--Schwarz and \(h_{i,\mathrm{ES}}^2
+    =h_{i,\mathrm{ES}}\) give
+    \[
+        \begin{aligned}
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+        &=
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,
+            h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}v\rangle\\
+        &\ge
+        -\|h_{i,\mathrm{ES}}v\|\,
+            \|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}v\|\\
+        &\ge
+        -\Bigl(1-\frac{1}{4L}\Bigr)\frac{1}{2(L-1)}
+            \|h_{i,\mathrm{ES}}v\|^2\\
+        &=
+        -\Bigl(1-\frac{1}{4L}\Bigr)\frac{1}{2(L-1)}
+            \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle .
+        \end{aligned}
+    \]
+    This is the ordered lower bound used by the preceding overlapping-cyclic
+    martingale reduction.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian gap from a cyclic overlap compression constant]

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex
@@ -191,8 +191,8 @@
     \leanok
     \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
         rem:projection_geometry_rowsum_identities}
-    For an overlapping pair, Cauchy--Schwarz and \(h_{i,\mathrm{ES}}^2
-    =h_{i,\mathrm{ES}}\) give
+    For an overlapping pair, Cauchy--Schwarz and $h_{i,\mathrm{ES}}^2
+    =h_{i,\mathrm{ES}}$ give
     \[
         \begin{aligned}
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
@@ -101,13 +101,13 @@
     The intersection identity shows that $\ker(h_i) \cap \ker(h_j)$ is
     exactly $G_{[i,j+L-1]}(A)$; in particular there is no non-trivial
     vector in one kernel that is orthogonal to the other yet lies in both.
-    Hence the principal angle $\theta_{d_N(i,j)}$ between $\ker(h_i)$ and
-    $\ker(h_j)$ is strictly positive (for the fixed injective tensor
-    $A$). Because the angle depends only on the overlap pattern
+    Hence the smallest non-zero principal angle $\theta_{d_N(i,j)}$ between
+    $\ker(h_i)$ and $\ker(h_j)$ is strictly positive (for the fixed injective
+    tensor $A$). Because the angle depends only on the overlap pattern
     $d_N(i,j) \in \{1,\ldots,L-1\}$ and not on the absolute position,
     the number of distinct angles is at most $L-1$.
     Let $\alpha := \max_{1 \le s < L} \cos\theta_s < 1$ be the
-    worst-case cosine of these principal angles.
+    worst-case cosine of these smallest non-zero principal angles.
 
     \emph{Row-sum bound.}
     Since $L \ge 2$, each site $i$ overlaps with at most $2(L-1)$
@@ -139,9 +139,9 @@
         \le
         \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}\|h_i v\|.
     \]
-    The qualitative principal-angle conclusion $\alpha<1$ does not by itself
-    imply this numerical bound; the missing step is the uniform
-    overlapping-window estimate with the displayed coefficient. Thus the
+    The qualitative smallest-non-zero-principal-angle conclusion $\alpha<1$
+    does not by itself imply this numerical bound; the missing step is the
+    uniform overlapping-window estimate with the displayed coefficient. Thus the
     remaining comparison is whether the principal-angle estimates cited in
     \cite{Fannes1992Finitely, Nachtergaele1996Spectral,
         Kastoryano2018Martingale} supply this cyclic-window inequality, with

--- a/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex
@@ -101,13 +101,13 @@
     The intersection identity shows that $\ker(h_i) \cap \ker(h_j)$ is
     exactly $G_{[i,j+L-1]}(A)$; in particular there is no non-trivial
     vector in one kernel that is orthogonal to the other yet lies in both.
-    Hence the Friedrichs angle $\theta_{d_N(i,j)}$ between $\ker(h_i)$ and
+    Hence the principal angle $\theta_{d_N(i,j)}$ between $\ker(h_i)$ and
     $\ker(h_j)$ is strictly positive (for the fixed injective tensor
     $A$). Because the angle depends only on the overlap pattern
     $d_N(i,j) \in \{1,\ldots,L-1\}$ and not on the absolute position,
     the number of distinct angles is at most $L-1$.
     Let $\alpha := \max_{1 \le s < L} \cos\theta_s < 1$ be the
-    worst-case cosine of the Friedrichs angles.
+    worst-case cosine of these principal angles.
 
     \emph{Row-sum bound.}
     Since $L \ge 2$, each site $i$ overlaps with at most $2(L-1)$
@@ -199,7 +199,7 @@
     establishes the finite-sum algebra from ordered cross-term row bounds, and
     Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
     and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} state the
-    common finite-overlap specialization with $m=2(L-1)$.
+    common finite-overlap principal-angle specialization with $m=2(L-1)$.
     Lemma~\ref{lem:transported_es_nonoverlap_positive} supplies the non-overlap
     positivity statement for site-disjoint windows, and
     Lemma~\ref{lem:cyclic_window_nonoverlap_positive} translates this to the
@@ -207,7 +207,7 @@
     Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the finite-overlap
     row-cardinality bound.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap} combines
-    these ingredients with the finite-overlap reduction, so the only additional
+    these results with the finite-overlap reduction, so the only additional
     input is the principal-angle estimate for overlapping cyclic windows.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} states the
     same overlap-only formulation, and

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -194,8 +194,9 @@ replacement input than the review text states explicitly.
 \section{Relation to the blueprint}
 
 The blueprint item labelled \path{lem:martingale_mps} in
-\path{blueprint/src/chapter/ch14_parent_hamiltonian.tex} now separates the
-finite-row martingale reduction from the still-open quantitative estimate.
+\path{blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap_martingale.tex}
+separates the finite-row martingale reduction from the still-open quantitative
+estimate.
 It does not assert that the displayed all-$L>1$ cyclic-window bound has already
 been obtained from the cited principal-angle estimates. Instead, it states that
 bound as the hypothesis of Theorem \path{thm:friedrichs_gap_bound}.


### PR DESCRIPTION
### Motivation

- The reader-facing spectral-gap blueprint uses project-local phrases ("transported" local terms, "Friedrichs angles") that diverge from the terminology in arXiv:2011.12127 §IV.C; aligning to standard Euclidean local-term and principal-angle language makes the blueprint readable without project context.
- After the spectral-gap chapter was split into separate files, the paper-gap note `docs/paper-gaps/cpgsv21_martingale_overlap.tex` retained a cross-reference to the now-superseded monolithic `ch14_parent_hamiltonian.tex`; that stale pointer is corrected here.
- This is a prose cleanup only; it does not prove the missing principal-angle or norm-compression estimate needed for the martingale gap argument (arXiv:2011.12127 §IV.C, eq. martingale-2). See #952 and related #190, #460.

### Description

- `blueprint/src/chapter/ch14_parent_hamiltonian_spectral_gap.tex`, `ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex`, `ch14_parent_hamiltonian_spectral_gap_martingale.tex`: replace "transported" local-term and "Friedrichs-angle" phrasing with Euclidean local terms, boundary-filled restriction ($R_{i,\tau}$), and principal-angle / martingale language in lemma titles and proof sketches. Lean declaration names (e.g. `friedrichs_gap_bound`) are unchanged.
- `docs/paper-gaps/cpgsv21_martingale_overlap.tex`: update the blueprint cross-reference for `lem:martingale_mps` from `ch14_parent_hamiltonian.tex` to `ch14_parent_hamiltonian_spectral_gap_martingale.tex`.
- The quantitative overlapping-window principal-angle / norm-compression input remains open and is left explicit in the prose.

### Testing

- Blueprint and paper-gap prose cleanup only; no Lean changes. Lean CI is not triggered by these files.
- Verified: `lake exe cache get && lake build TNLean -q` and `cd blueprint && leanblueprint checkdecls`.
- Reader-facing prose reviewed with `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`.
- `git diff --check` clean.

---
Addresses #952

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint and paper-gap prose only; no Lean or runtime behavior changes.
> 
> **Overview**
> **Documentation-only** alignment of the spectral-gap blueprint and a paper-gap note with standard **Euclidean local-term** and **principal-angle / martingale** language (replacing project-specific “transported” and “Friedrichs angle” phrasing). Lean declaration names are unchanged.
> 
> In `ch14_parent_hamiltonian_spectral_gap*.tex`, remark and lemma titles and statements now say **boundary-filled restriction** \(R_{i,\tau}\), **Euclidean local terms** \(h_{i,\mathrm{ES}}\), and clearer adjacent-kernel wording. The martingale subsection renames angles to **smallest non-zero principal angles** and reframes finite-overlap reductions as **principal-angle** specializations.
> 
> `ch14_parent_hamiltonian_spectral_gap_cyclic_overlap.tex` expands the proof of the norm-compression → ordered cross-term lemma with an explicit **Cauchy–Schwarz** chain (instead of a one-line projection-geometry reference) and retitles that lemma around an **overlapping cyclic norm-compression estimate**.
> 
> `docs/paper-gaps/cpgsv21_martingale_overlap.tex` points `lem:martingale_mps` at **`ch14_parent_hamiltonian_spectral_gap_martingale.tex`** after the chapter split. The open quantitative overlapping-window input is still stated explicitly; no proofs or Lean changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdcb4ffac2d55cccb36df015032c01120168e72f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->