### PR TITLE
doc(parent): record martingale delta formulation

### DIFF
--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -71,7 +71,7 @@ $\ker h_i\cap\ker h_j=\ker(h_i+h_j)$, and $\ell$ is the size of the
 overlap region. The review writes the displayed product with the symbols
 $h_i,h_j$; in the convention fixed above, those symbols must be read as the
 ground-space projectors $q_i,q_j$, not as the excitation projections $h_i$ used
-in \eqref{eq:4:martingale-2}. If one inserted the excitation projections into
+in \path{eq:4:martingale-2}. If one inserted the excitation projections into
 $\|h_ih_j-P\|$, the norm would be at least one on the common ground space. With
 the ground-space projectors, the cited result states that $\delta(\ell)$ decays
 exponentially with universal constants whenever the frustration-free

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -53,13 +53,22 @@ row add up to one. The formal row-sum algebra uses the slightly more flexible
 condition that, for each fixed $i$, the sum of the coefficients attached to
 terms overlapping $h_i$ is at most one.
 
-The same paragraph interprets this estimate as a lower bound on the smallest
-non-zero principal angle between the local ground spaces of overlapping terms.
-It then cites the martingale method and the MPS parent-Hamiltonian results of
+The same paragraph interprets this estimate as a lower bound on the minimum
+non-zero angle between the ground spaces of overlapping regions. It then cites
+the martingale method and the MPS parent-Hamiltonian results of
 Fannes--Nachtergaele--Werner and Nachtergaele, together with the later
 Kastoryano--Lucia formulation, for the conclusion that MPS parent Hamiltonians
 have a uniform positive spectral gap after a suitable blocking
 \cite{Fannes1992Finitely,Nachtergaele1996Spectral,Kastoryano2018Martingale}.
+The later formulation is described in terms of
+\begin{align}
+    \delta(\ell):=\|h_i h_j-P\|,
+\end{align}
+where $P$ is the projector onto $\ker(h_i+h_j)$ and $\ell$ is the size of the
+overlap region. The review states that $\delta(\ell)$ decays exponentially with
+universal constants whenever the frustration-free Hamiltonian is gapped, and
+that this implies the martingale condition because both quantities depend only
+on the principal angles between $\ker h_i$ and $\ker h_j$.
 The review text does not spell out the numerical constants or the precise
 finite cyclic blocking convention needed for the formal statement below.
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -60,15 +60,24 @@ Fannes--Nachtergaele--Werner and Nachtergaele, together with the later
 Kastoryano--Lucia formulation, for the conclusion that MPS parent Hamiltonians
 have a uniform positive spectral gap after a suitable blocking
 \cite{Fannes1992Finitely,Nachtergaele1996Spectral,Kastoryano2018Martingale}.
-The later formulation is described in terms of
+In the convention of this note, the Kastoryano--Lucia formulation cited there
+is the estimate for
 \begin{align}
-    \delta(\ell):=\|h_i h_j-P\|,
+    \delta(\ell):=\|q_i q_j-P\|,
 \end{align}
-where $P$ is the projector onto $\ker(h_i+h_j)$ and $\ell$ is the size of the
-overlap region. The review states that $\delta(\ell)$ decays exponentially with
-universal constants whenever the frustration-free Hamiltonian is gapped, and
-that this implies the martingale condition because both quantities depend only
-on the principal angles between $\ker h_i$ and $\ker h_j$.
+where $q_i$ and $q_j$ are the projectors onto the ground spaces
+$\ker h_i$ and $\ker h_j$, $P$ is the projector onto
+$\ker h_i\cap\ker h_j=\ker(h_i+h_j)$, and $\ell$ is the size of the
+overlap region. The review writes the displayed product with the symbols
+$h_i,h_j$; in the convention fixed above, those symbols must be read as the
+ground-space projectors $q_i,q_j$, not as the excitation projections $h_i$ used
+in \eqref{eq:4:martingale-2}. If one inserted the excitation projections into
+$\|h_ih_j-P\|$, the norm would be at least one on the common ground space. With
+the ground-space projectors, the cited result states that $\delta(\ell)$ decays
+exponentially with universal constants whenever the frustration-free
+Hamiltonian is gapped, and that this implies the martingale condition because
+both quantities depend only on the principal angles between
+$\ker h_i$ and $\ker h_j$.
 The review text does not spell out the numerical constants or the precise
 finite cyclic blocking convention needed for the formal statement below.
 


### PR DESCRIPTION
### Motivation

The #952 paper-gap note should track the language of arXiv:2011.12127 §IV.C while making the projector convention unambiguous. The review paragraph states the martingale estimate through the minimum non-zero angle between overlapping ground spaces and cites the Kastoryano--Lucia quantity written there as \(\delta(\ell)=\|h_i h_j-P\|\), where \(P\) projects onto \(\ker(h_i+h_j)\).

### Description

- Records the source's minimum-nonzero-angle wording.
- Rewrites the Kastoryano--Lucia quantity in the convention of the note as \(\delta(\ell)=\|q_i q_j-P\|\), where \(q_i,q_j\) project onto \(\ker h_i,\ker h_j\).
- Explains that the source symbols \(h_i,h_j\) in this norm must be read as ground-space projectors; using the excitation projections from the martingale inequality would make \(\|h_i h_j-P\|\ge 1\) on the common ground space.
- Keeps the note's conclusion that the formal cyclic-window norm-compression constant still has to be compared with the cited estimates.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `TEXINPUTS=.: pdflatex -interaction=nonstopmode -halt-on-error -output-directory=/tmp/tnlean-paper-gap-build-2735 cpgsv21_martingale_overlap.tex`

---
Refs #952
Refs #190
Refs #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX documentation only; no runtime, auth, or formal proof code changes.
> 
> **Overview**
> The martingale overlap paper-gap note (**#952**) now aligns its wording with the Cirac et al. review on **minimum non-zero angle** between overlapping ground spaces, and spells out how the cited **Kastoryano–Lucia** quantity should be read in this note’s notation.
> 
> It defines **δ(ℓ) = ‖q_i q_j − P‖** with **q_i, q_j** ground-space projectors and **P** onto **ker(h_i + h_j)**, and explains that the source’s **h_i, h_j** in that norm are those projectors—not the **excitation** projections **h_i** from the martingale inequality (which would force **‖h_i h_j − P‖ ≥ 1** on the common ground space). It also records that **δ(ℓ)** decays exponentially under a gap and ties to the martingale condition via principal angles between **ker h_i** and **ker h_j**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b772bf5bf4379c9969f7e5cb96eabc8c1b9d2f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->