### PR TITLE
feat(PEPS): corner-extension and staircase-pair stripping for the 2D overlapping-window FT (layer 3)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -413,6 +413,7 @@ import TNLean.PEPS.TorusWindowComplement
 import TNLean.PEPS.TorusWindowRegion
 import TNLean.PEPS.TorusDeformedWindow
 import TNLean.PEPS.TorusWindowChain
+import TNLean.PEPS.TorusWindowChain2
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusReferenceBlockingData

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -34,6 +34,20 @@ The deformed state is read as a function of the *full* physical configuration th
 `V → Fin d`; this lets the consecutive-window equalities chain across the patch by
 transitivity, the content of Step 2.
 
+## The chaining and stripping
+
+With the corner-extension identity, each single-window deformed state is the union
+deformed state of its corner-extended insert; `horizontalConsecutiveWindow_extend_eq`
+passes the agreement of two consecutive windows to the consecutive-window comparison
+engine, giving the open-boundary equality on the union (Step 1's display).  The patch
+chaining `horizontalStaircase_patch_extend_eq` extends the two end windows' states to the
+staircase patch and chains them (Step 2), and the staircase-pair stripping
+`staircasePair_insert_eq` inverts the end-pair complement, leaving the open-boundary
+equality on the staircase end pair (Step 3).  The stripping takes the end-pair complement
+injectivity as a hypothesis, the content the note's corner-completion supplies; its
+construction from the window hypotheses is the residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
+
 ## References
 
 * [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -348,5 +348,57 @@ theorem deformedRegionState_extend {R S : Finset V} (hRS : R ⊆ S)
     deformedRegionStateAssembled_bareExtend, smul_eq_mul, ← mul_assoc,
     inv_mul_cancel₀ hne, one_mul]
 
+/-! ### From the assembled state to the curried state
+
+The assembled deformed state, read as a function of the full physical configuration,
+determines the curried deformed state, a function of the region and complement physical
+configurations: assembling those two configurations and restricting back recovers them.
+Two inserts with equal assembled states therefore have equal curried states, the form
+the consecutive-window comparison engine consumes. -/
+
+omit [DecidableRel G.Adj] in
+/-- Restricting the assembled configuration to the region recovers the region
+configuration. -/
+theorem restrictRegionσ_assembleRegionσ (R : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    restrictRegionσ (V := V) (d := d) R (assembleRegionσ (V := V) (d := d) R σ τ) = σ := by
+  funext w
+  rw [restrictRegionσ_apply, assembleRegionσ_mem]
+
+omit [DecidableRel G.Adj] in
+/-- Restricting the assembled configuration to the set complement recovers the complement
+configuration. -/
+theorem restrictRegionσ_compl_assembleRegionσ (R : Finset V)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    restrictRegionσ (V := V) (d := d) (Finset.univ \ R)
+        (assembleRegionσ (V := V) (d := d) R σ τ) = τ := by
+  funext w
+  rw [restrictRegionσ_apply, assembleRegionσ_notMem]
+
+/-- Equal assembled deformed states give equal curried deformed states.  Evaluating the
+curried states at `(σ, τ)` is evaluating the assembled states at `assembleRegionσ R σ τ`,
+where the two restrictions recover `σ` and `τ`. -/
+theorem deformedRegionState_eq_of_assembled_eq (A : Tensor G d) (R : Finset V)
+    (C₁ C₂ : RegionInsert (G := G) (d := d) A R)
+    (h : deformedRegionStateAssembled (G := G) A R C₁ =
+      deformedRegionStateAssembled (G := G) A R C₂) :
+    deformedRegionState (G := G) A R C₁ = deformedRegionState (G := G) A R C₂ := by
+  funext σ τ
+  have hcfg := congrFun h (assembleRegionσ (V := V) (d := d) R σ τ)
+  simp only [deformedRegionStateAssembled, restrictRegionσ_assembleRegionσ,
+    restrictRegionσ_compl_assembleRegionσ] at hcfg
+  exact hcfg
+
+/-- Equal curried deformed states give equal assembled deformed states. -/
+theorem deformedRegionStateAssembled_eq_of_curried_eq (A : Tensor G d) (R : Finset V)
+    (C₁ C₂ : RegionInsert (G := G) (d := d) A R)
+    (h : deformedRegionState (G := G) A R C₁ = deformedRegionState (G := G) A R C₂) :
+    deformedRegionStateAssembled (G := G) A R C₁ =
+      deformedRegionStateAssembled (G := G) A R C₂ := by
+  funext cfg
+  rw [deformedRegionStateAssembled, deformedRegionStateAssembled, h]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -49,7 +49,7 @@ open scoped BigOperators Matrix
 namespace TNLean
 namespace PEPS
 
-variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {V : Type*} [Fintype V] [LinearOrder V]
 variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 variable {A : Tensor G d}
 
@@ -90,22 +90,65 @@ def nestedThreeBlockGeometry {R S : Finset V} (hRS : R ⊆ S) : ThreeBlockGeomet
       · exact Or.inl (Or.inr ⟨hvS, hvR⟩)
       · exact Or.inr hvS
 
-omit [LinearOrder V] [DecidableRel G.Adj] in
+omit [DecidableRel G.Adj] in
 @[simp] theorem nestedThreeBlockGeometry_red {R S : Finset V} (hRS : R ⊆ S) :
     (nestedThreeBlockGeometry (V := V) hRS).red = R := rfl
 
-omit [LinearOrder V] [DecidableRel G.Adj] in
+omit [DecidableRel G.Adj] in
 @[simp] theorem nestedThreeBlockGeometry_blue {R S : Finset V} (hRS : R ⊆ S) :
     (nestedThreeBlockGeometry (V := V) hRS).blue = S \ R := rfl
 
-omit [LinearOrder V] [DecidableRel G.Adj] in
+omit [DecidableRel G.Adj] in
 @[simp] theorem nestedThreeBlockGeometry_complement {R S : Finset V} (hRS : R ⊆ S) :
     (nestedThreeBlockGeometry (V := V) hRS).complement = Finset.univ \ S := rfl
 
-omit [LinearOrder V] [DecidableRel G.Adj] in
+omit [DecidableRel G.Adj] in
 /-- The host `univ \ red` of the nested geometry is `univ \ R`. -/
 theorem nestedThreeBlockGeometry_sdiff_red {R S : Finset V} (hRS : R ⊆ S) :
     Finset.univ \ (nestedThreeBlockGeometry (V := V) hRS).red = Finset.univ \ R := rfl
+
+/-! ### Restricting a global physical configuration to a region
+
+The deformed state is read as a function of the full physical configuration through
+the restriction `restrictRegionσ`, the inverse of `assembleRegionσ`.  Restricting to
+the host `univ \ R` factors through the nested geometry's fused leg: the host
+restriction is the `complPhysical` of the blue restriction (to `S \ R`) and the
+complement restriction (to `univ \ S`). -/
+
+/-- The restriction of a global physical configuration `cfg` to the region `R`. -/
+def restrictRegionσ (R : Finset V) (cfg : V → Fin d) :
+    RegionPhysicalConfig (V := V) (d := d) R :=
+  fun w => cfg w.1
+
+omit [Fintype V] [LinearOrder V] [DecidableRel G.Adj] in
+@[simp] theorem restrictRegionσ_apply (R : Finset V) (cfg : V → Fin d)
+    (w : {w : V // w ∈ R}) : restrictRegionσ (V := V) (d := d) R cfg w = cfg w.1 := rfl
+
+omit [DecidableRel G.Adj] in
+/-- Assembling the region and complement restrictions recovers the global
+configuration. -/
+theorem assembleRegionσ_restrict (R : Finset V) (cfg : V → Fin d) :
+    assembleRegionσ (V := V) (d := d) R (restrictRegionσ (V := V) (d := d) R cfg)
+        (restrictRegionσ (V := V) (d := d) (Finset.univ \ R) cfg) = cfg := by
+  funext w
+  by_cases h : w ∈ R
+  · rw [assembleRegionσ_mem (V := V) (d := d) R _ _ ⟨w, h⟩, restrictRegionσ_apply]
+  · have hw : w ∈ Finset.univ \ R := Finset.mem_sdiff.mpr ⟨Finset.mem_univ _, h⟩
+    rw [assembleRegionσ_notMem (V := V) (d := d) R _ _ ⟨w, hw⟩, restrictRegionσ_apply]
+
+omit [DecidableRel G.Adj] in
+/-- The host `univ \ R` restriction is the nested geometry's fused leg of the blue
+restriction (to `S \ R`) and the complement restriction (to `univ \ S`). -/
+theorem nestedComplPhysical_restrict {R S : Finset V} (hRS : R ⊆ S) (cfg : V → Fin d) :
+    (nestedThreeBlockGeometry (V := V) hRS).complPhysical (d := d)
+        (restrictRegionσ (V := V) (d := d) (S \ R) cfg)
+        (restrictRegionσ (V := V) (d := d) (Finset.univ \ S) cfg) =
+      restrictRegionσ (V := V) (d := d) (Finset.univ \ R) cfg := by
+  funext w
+  rw [ThreeBlockGeometry.complPhysical]
+  by_cases hb : w.1 ∈ (nestedThreeBlockGeometry (V := V) hRS).blue
+  · rw [dif_pos hb, restrictRegionσ_apply, restrictRegionσ_apply]
+  · rw [dif_neg hb, restrictRegionσ_apply, restrictRegionσ_apply]
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -400,5 +400,91 @@ theorem deformedRegionStateAssembled_eq_of_curried_eq (A : Tensor G d) (R : Fins
   funext cfg
   rw [deformedRegionStateAssembled, deformedRegionStateAssembled, h]
 
+/-! ### The consecutive-window union display on the torus
+
+On the discrete torus each single-window deformed state is, by the corner-extension
+identity, the union deformed state of the corner-extended insert.  Two consecutive
+windows whose deformed states agree therefore have equal union deformed states, and the
+consecutive-window comparison engine
+(`NormalTorusArcWindowInjectivityHypotheses.horizontalUnion_insert_eq_of_deformedState_eq`)
+strips that to the open-boundary equality of the corner-extended inserts on the union
+`U`: the note's Step 1 display restricted to the union. -/
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+variable [Fact (1 < width)] [Fact (1 < height)]
+variable {L K : ℕ} {B : Tensor (torusGraph width height) d}
+
+omit [Fact (1 < height)] in
+/-- The left window of a horizontally consecutive pair is a subset of their union, the
+`(L + 1) × K` cyclic rectangle. -/
+theorem torusArcRectangle_subset_horizontalUnion_left {L K : ℕ} (hL : 0 < L)
+    (s : TorusVertex width height) :
+    torusArcRectangle s L K ⊆ torusArcRectangle s (L + 1) K := by
+  rw [← horizontalAdjacentWindows_union hL (Fact.out (p := (1 < width))) s]
+  exact Finset.subset_union_left
+
+omit [Fact (1 < height)] in
+/-- The right window of a horizontally consecutive pair is a subset of their union, the
+`(L + 1) × K` cyclic rectangle. -/
+theorem torusArcRectangle_subset_horizontalUnion_right {L K : ℕ} (hL : 0 < L)
+    (s : TorusVertex width height) :
+    torusArcRectangle (s.1 + (1 : ZMod width), s.2) L K ⊆ torusArcRectangle s (L + 1) K := by
+  rw [← horizontalAdjacentWindows_union hL (Fact.out (p := (1 < width))) s]
+  exact Finset.subset_union_right
+
+/-- **The consecutive-window display (horizontal slide).** If two horizontally
+consecutive windows carry deformed inserts `C₁` and `C₂` whose deformed states agree as
+functions of the full physical configuration, then the corner-extended inserts on their
+union `U` are equal: the open-boundary equality on `U` of the note's Step 1.  Each window
+state is the union state of its corner-extended insert (`deformedRegionState_extend`); the
+agreement transfers to the union states, the curried bridge passes it to the comparison
+engine, and the engine strips the equal closed-torus states to the equal inserts.
+
+Source: arXiv:1804.04964, the one-dimensional inversions at lines 2133--2179 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 1. -/
+theorem horizontalConsecutiveWindow_extend_eq
+    (h : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (s : TorusVertex width height)
+    (C₁ : RegionInsert (G := torusGraph width height) (d := d) B (torusArcRectangle s L K))
+    (C₂ : RegionInsert (G := torusGraph width height) (d := d) B
+      (torusArcRectangle (s.1 + (1 : ZMod width), s.2) L K))
+    (hstate : deformedRegionStateAssembled (G := torusGraph width height) B
+        (torusArcRectangle s L K) C₁ =
+      deformedRegionStateAssembled (G := torusGraph width height) B
+        (torusArcRectangle (s.1 + (1 : ZMod width), s.2) L K) C₂) :
+    extendInsert (G := torusGraph width height)
+        (torusArcRectangle_subset_horizontalUnion_left (by omega) s) C₁ =
+      extendInsert (G := torusGraph width height)
+        (torusArcRectangle_subset_horizontalUnion_right (by omega) s) C₂ := by
+  -- Both extended inserts have equal union deformed states.
+  have hunion : deformedRegionStateAssembled (G := torusGraph width height) B
+        (torusArcRectangle s (L + 1) K)
+        (extendInsert (G := torusGraph width height)
+          (torusArcRectangle_subset_horizontalUnion_left (by omega) s) C₁) =
+      deformedRegionStateAssembled (G := torusGraph width height) B
+        (torusArcRectangle s (L + 1) K)
+        (extendInsert (G := torusGraph width height)
+          (torusArcRectangle_subset_horizontalUnion_right (by omega) s) C₂) := by
+    funext cfg
+    rw [← deformedRegionState_extend
+        (torusArcRectangle_subset_horizontalUnion_left (by omega) s) hpos C₁,
+      ← deformedRegionState_extend
+        (torusArcRectangle_subset_horizontalUnion_right (by omega) s) hpos C₂,
+      hstate]
+  -- Pass to the curried comparison engine on the union.
+  exact h.horizontalUnion_insert_eq_of_deformedState_eq hUB hL hK hxw hyh s _ _
+    (deformedRegionState_eq_of_assembled_eq (G := torusGraph width height) B
+      (torusArcRectangle s (L + 1) K) _ _ hunion)
+
+end Torus
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -484,6 +484,72 @@ theorem horizontalConsecutiveWindow_extend_eq
     (deformedRegionState_eq_of_assembled_eq (G := torusGraph width height) B
       (torusArcRectangle s (L + 1) K) _ _ hunion)
 
+/-! ### The patch chaining and the staircase-pair stripping
+
+The corner-extension identity, applied with the larger region the staircase patch `P`,
+extends each single-window assembled state to a patch assembled state.  All the windows'
+states agreeing therefore makes the two end windows' patch-extended assembled states
+agree.  Completing the corner block to the injective `L × K` rectangle and inverting it
+strips the patch comparison to the open-boundary equality on the staircase end pair: the
+note's Step 3 display. -/
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The left/last end window is a subset of the staircase patch. -/
+theorem horizontalStaircaseLeftWindow_subset_patch {L K : ℕ} (hL : 0 < L) (hK : 0 < K)
+    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
+    horizontalStaircaseLeftWindow s L K ⊆ horizontalStaircasePatch s L K := by
+  rw [horizontalStaircasePatch_eq_endPair_union_corner hL hK hxw hyh s,
+    horizontalStaircaseEndPair]
+  exact Finset.subset_union_left.trans Finset.subset_union_left
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The right/first end window is a subset of the staircase patch. -/
+theorem horizontalStaircaseRightWindow_subset_patch {L K : ℕ} (hL : 0 < L) (hK : 0 < K)
+    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
+    horizontalStaircaseRightWindow s L K ⊆ horizontalStaircasePatch s L K := by
+  rw [horizontalStaircasePatch_eq_endPair_union_corner hL hK hxw hyh s,
+    horizontalStaircaseEndPair]
+  exact Finset.subset_union_right.trans Finset.subset_union_left
+
+/-- **The patch chaining (Step 2).** If the two end windows carry deformed inserts whose
+assembled states agree, then the patch-extended inserts of the two end windows have equal
+assembled states on the patch.  Each end window's assembled state is the patch state of
+its corner-extended insert (`deformedRegionState_extend` with the larger region the
+patch); the agreement of the window states transfers to the patch states.  This is the
+note's Step 2 chaining, here delivered as the agreement of the two end-window
+contributions on the patch (the intermediate windows drop out of the comparison since all
+states are equal).
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (chaining the windows across the patch);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 2. -/
+theorem horizontalStaircase_patch_extend_eq
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 0 < L) (hK : 0 < K) (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (s : TorusVertex width height)
+    (C₀ : RegionInsert (G := torusGraph width height) (d := d) B
+      (horizontalStaircaseRightWindow s L K))
+    (Cend : RegionInsert (G := torusGraph width height) (d := d) B
+      (horizontalStaircaseLeftWindow s L K))
+    (hstate : deformedRegionStateAssembled (G := torusGraph width height) B
+        (horizontalStaircaseRightWindow s L K) C₀ =
+      deformedRegionStateAssembled (G := torusGraph width height) B
+        (horizontalStaircaseLeftWindow s L K) Cend) :
+    deformedRegionStateAssembled (G := torusGraph width height) B
+        (horizontalStaircasePatch s L K)
+        (extendInsert (G := torusGraph width height)
+          (horizontalStaircaseRightWindow_subset_patch hL hK hxw hyh s) C₀) =
+      deformedRegionStateAssembled (G := torusGraph width height) B
+        (horizontalStaircasePatch s L K)
+        (extendInsert (G := torusGraph width height)
+          (horizontalStaircaseLeftWindow_subset_patch hL hK hxw hyh s) Cend) := by
+  funext cfg
+  rw [← deformedRegionState_extend
+      (horizontalStaircaseRightWindow_subset_patch hL hK hxw hyh s) hpos C₀,
+    ← deformedRegionState_extend
+      (horizontalStaircaseLeftWindow_subset_patch hL hK hxw hyh s) hpos Cend,
+    hstate]
+
 end Torus
 
 end PEPS

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -1,0 +1,111 @@
+import TNLean.PEPS.TorusWindowChain
+import TNLean.PEPS.RegionBlock.UnionInjectivityGeneral
+
+/-!
+# Extending a deformed-window state to a larger region
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) chains the consecutive-window comparisons of
+`TNLean/PEPS/TorusDeformedWindow.lean` across the staircase patch around a lattice
+edge.  The chaining needs to read a single window's deformed state as the deformed
+state of a larger region carrying the genuine network block on the added vertices:
+the *corner-extended* insert.  This file builds that extension and the load-bearing
+identity, following the filled-in derivation
+(`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Steps 2--3).
+
+## The extension identity
+
+For nested regions `R ⊆ S`, the deformed state on `R` with insert `C` equals the
+deformed state on `S` with the *extended* insert `extendInsert R S C`, where the
+extended insert pairs `C` with the genuine network block of the added vertices
+`S \ R`.  The extension reuses the three-block factorization
+`ThreeBlockGeometry.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical`
+of `TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean`: with the geometry
+`red = R`, `blue = S \ R`, `complement = univ \ S`, the host `univ \ red = univ \ R`
+is the complement block of the deformed state on `R`, and the factorization splits its
+weight into the blue-coupling combination of the `univ \ S` complement weights.  The
+blue-coupling coefficient `threeBlockBlueCoeff`, contracted against `C`, is exactly the
+extended insert.  The factorization carries an interior-bond multiplicity factor on the
+`univ \ S` block, a nonzero scalar at positive bond dimensions, which cancels.
+
+The deformed state is read as a function of the *full* physical configuration through
+`assembleRegionσ`, so the identity is a region-independent equality of functions on
+`V → Fin d`; this lets the consecutive-window equalities chain across the patch by
+transitivity, the content of Step 2.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, the corollary and proof
+  sketch at lines 2296--2445 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+  Steps 2--3.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+/-! ### The nested-region three-block geometry
+
+For `R ⊆ S` the three blocks `red = R`, `blue = S \ R`, `complement = univ \ S`
+partition the vertex set, with host `univ \ red = univ \ R`.  This is the geometry
+whose three-block factorization splits the deformed-state complement weight on
+`univ \ R` into the `univ \ S` complement weights, the blue coupling carrying the
+added vertices `S \ R`. -/
+
+/-- The nested-region three-block geometry for `R ⊆ S`: `red = R`, `blue = S \ R`,
+`complement = univ \ S`.  The host `univ \ red` is `univ \ R`, the complement block
+of the deformed state on `R`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 2. -/
+def nestedThreeBlockGeometry {R S : Finset V} (hRS : R ⊆ S) : ThreeBlockGeometry V where
+  red := R
+  blue := S \ R
+  complement := Finset.univ \ S
+  red_disjoint_blue := by
+    rw [Finset.disjoint_left]; intro v hvR hvSR
+    exact (Finset.mem_sdiff.mp hvSR).2 hvR
+  red_disjoint_complement := by
+    rw [Finset.disjoint_left]; intro v hvR hvS
+    exact (Finset.mem_sdiff.mp hvS).2 (hRS hvR)
+  blue_disjoint_complement := by
+    rw [Finset.disjoint_left]; intro v hvSR hvS
+    exact (Finset.mem_sdiff.mp hvS).2 (Finset.mem_sdiff.mp hvSR).1
+  cover_univ := by
+    ext v
+    simp only [Finset.mem_union, Finset.mem_sdiff, Finset.mem_univ, true_and, iff_true]
+    by_cases hvR : v ∈ R
+    · exact Or.inl (Or.inl hvR)
+    · by_cases hvS : v ∈ S
+      · exact Or.inl (Or.inr ⟨hvS, hvR⟩)
+      · exact Or.inr hvS
+
+omit [LinearOrder V] [DecidableRel G.Adj] in
+@[simp] theorem nestedThreeBlockGeometry_red {R S : Finset V} (hRS : R ⊆ S) :
+    (nestedThreeBlockGeometry (V := V) hRS).red = R := rfl
+
+omit [LinearOrder V] [DecidableRel G.Adj] in
+@[simp] theorem nestedThreeBlockGeometry_blue {R S : Finset V} (hRS : R ⊆ S) :
+    (nestedThreeBlockGeometry (V := V) hRS).blue = S \ R := rfl
+
+omit [LinearOrder V] [DecidableRel G.Adj] in
+@[simp] theorem nestedThreeBlockGeometry_complement {R S : Finset V} (hRS : R ⊆ S) :
+    (nestedThreeBlockGeometry (V := V) hRS).complement = Finset.univ \ S := rfl
+
+omit [LinearOrder V] [DecidableRel G.Adj] in
+/-- The host `univ \ red` of the nested geometry is `univ \ R`. -/
+theorem nestedThreeBlockGeometry_sdiff_red {R S : Finset V} (hRS : R ⊆ S) :
+    Finset.univ \ (nestedThreeBlockGeometry (V := V) hRS).red = Finset.univ \ R := rfl
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -233,6 +233,11 @@ theorem extendInsert_eq_smul_bare {R S : Finset V} (hRS : R ⊆ S)
       fun ν σ => (regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ)⁻¹ *
         bareExtendInsert (G := G) hRS C ν σ := rfl
 
+-- The corner-extended insert is whnf-expensive over the discrete-torus regions (its blue
+-- coupling unfolds the cyclic-rectangle arithmetic); marking it irreducible keeps
+-- unification from unfolding it.  Its only consumer below is `extendInsert_eq_smul_bare`.
+attribute [irreducible] extendInsert
+
 open scoped Classical in
 /-- The bare corner-extended coefficient has deformed state the `univ \ S` interior-bond
 multiple of the deformed state on `R`, read as a function of the full physical
@@ -400,6 +405,19 @@ theorem deformedRegionStateAssembled_eq_of_curried_eq (A : Tensor G d) (R : Fins
   funext cfg
   rw [deformedRegionStateAssembled, deformedRegionStateAssembled, h]
 
+/-- The complement-inversion engine in assembled form: two inserts on `R` whose assembled
+deformed states agree are equal when the set complement `univ \ R` is blocked-tensor
+injective.  Combines the curried bridge with
+`deformedRegionState_insert_eq_of_complementInjective`. -/
+theorem deformedRegionStateAssembled_insert_eq_of_complementInjective (A : Tensor G d)
+    (R : Finset V) (hC : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (C₁ C₂ : RegionInsert (G := G) (d := d) A R)
+    (h : deformedRegionStateAssembled (G := G) A R C₁ =
+      deformedRegionStateAssembled (G := G) A R C₂) :
+    C₁ = C₂ :=
+  deformedRegionState_insert_eq_of_complementInjective (G := G) A R hC C₁ C₂
+    (deformedRegionState_eq_of_assembled_eq (G := G) A R C₁ C₂ h)
+
 /-! ### The consecutive-window union display on the torus
 
 On the discrete torus each single-window deformed state is, by the corner-extension
@@ -548,6 +566,70 @@ theorem horizontalStaircase_patch_extend_eq
       (horizontalStaircaseRightWindow_subset_patch hL hK hxw hyh s) hpos C₀,
     ← deformedRegionState_extend
       (horizontalStaircaseLeftWindow_subset_patch hL hK hxw hyh s) hpos Cend,
+    hstate]
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The left/last end window is a subset of the staircase end pair. -/
+theorem horizontalStaircaseLeftWindow_subset_endPair (s : TorusVertex width height) :
+    horizontalStaircaseLeftWindow s L K ⊆ horizontalStaircaseEndPair s L K :=
+  Finset.subset_union_left
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The right/first end window is a subset of the staircase end pair. -/
+theorem horizontalStaircaseRightWindow_subset_endPair (s : TorusVertex width height) :
+    horizontalStaircaseRightWindow s L K ⊆ horizontalStaircaseEndPair s L K :=
+  Finset.subset_union_right
+
+-- The end-pair region and the blocked-tensor injectivity predicate are whnf-expensive over
+-- the discrete torus (the boundary-configuration type unfolds the cyclic-rectangle edge
+-- arithmetic); marking them irreducible keeps the complement-inversion engine from
+-- unfolding the injectivity type during unification.
+attribute [local irreducible] horizontalStaircaseEndPair RegionBlockedTensorInjective
+
+/-- **The staircase-pair stripping (Step 3).** If the two end windows carry deformed
+inserts whose assembled states agree, and the torus complement of the staircase end pair
+is blocked-tensor injective, then the corner-extended inserts of the two end windows on
+the end pair are equal: the note's Step 3 open-boundary equality
+`C₀ ⊔ T_{W_{L+K-1}} = T_{W₀} ⊔ C_{L+K-1}` on `S = W₀ ⊔ W_{L+K-1}`.  Extending each end
+window's state to the end pair carries the genuine block of the opposite window across the
+single crossing bond; the agreement of the window states makes the two end-pair states
+agree; the complement-inversion engine then strips the closed-torus equality to the
+open-boundary equality of the end-pair inserts.
+
+The end-pair complement injectivity is the hypothesis the note's corner-completion supplies
+(completing the `L × (K - 1)` corner block to the injective `L × K` rectangle
+`horizontalStaircaseCompletedCorner` and inverting it, so that the end-pair complement is
+the union of that injective rectangle and an injective host); its construction from the
+window hypotheses is the residual recorded in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 3.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (add two-two tensors in the corner and invert);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3. -/
+theorem staircasePair_insert_eq (s : TorusVertex width height)
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hcompl : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ horizontalStaircaseEndPair s L K))
+    (C₀ : RegionInsert (G := torusGraph width height) (d := d) B
+      (horizontalStaircaseRightWindow s L K))
+    (Cend : RegionInsert (G := torusGraph width height) (d := d) B
+      (horizontalStaircaseLeftWindow s L K))
+    (hstate : deformedRegionStateAssembled (G := torusGraph width height) B
+        (horizontalStaircaseRightWindow s L K) C₀ =
+      deformedRegionStateAssembled (G := torusGraph width height) B
+        (horizontalStaircaseLeftWindow s L K) Cend) :
+    extendInsert (G := torusGraph width height)
+        (horizontalStaircaseRightWindow_subset_endPair s) C₀ =
+      extendInsert (G := torusGraph width height)
+        (horizontalStaircaseLeftWindow_subset_endPair s) Cend := by
+  -- Invert the end-pair complement: it suffices the two end-pair states agree.
+  refine deformedRegionStateAssembled_insert_eq_of_complementInjective
+    (G := torusGraph width height) B (horizontalStaircaseEndPair s L K) hcompl _ _ ?_
+  funext cfg
+  rw [← deformedRegionState_extend
+      (horizontalStaircaseRightWindow_subset_endPair s) hpos C₀,
+    ← deformedRegionState_extend
+      (horizontalStaircaseLeftWindow_subset_endPair s) hpos Cend,
     hstate]
 
 end Torus

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -138,17 +138,6 @@ omit [Fintype V] [LinearOrder V] [DecidableRel G.Adj] in
 @[simp] theorem restrictRegionσ_apply (R : Finset V) (cfg : V → Fin d)
     (w : {w : V // w ∈ R}) : restrictRegionσ (V := V) (d := d) R cfg w = cfg w.1 := rfl
 
-omit [DecidableRel G.Adj] in
-/-- Assembling the region and complement restrictions recovers the global
-configuration. -/
-theorem assembleRegionσ_restrict (R : Finset V) (cfg : V → Fin d) :
-    assembleRegionσ (V := V) (d := d) R (restrictRegionσ (V := V) (d := d) R cfg)
-        (restrictRegionσ (V := V) (d := d) (Finset.univ \ R) cfg) = cfg := by
-  funext w
-  by_cases h : w ∈ R
-  · rw [assembleRegionσ_mem (V := V) (d := d) R _ _ ⟨w, h⟩, restrictRegionσ_apply]
-  · have hw : w ∈ Finset.univ \ R := Finset.mem_sdiff.mpr ⟨Finset.mem_univ _, h⟩
-    rw [assembleRegionσ_notMem (V := V) (d := d) R _ _ ⟨w, hw⟩, restrictRegionσ_apply]
 
 omit [DecidableRel G.Adj] in
 /-- The host `univ \ R` restriction is the nested geometry's fused leg of the blue

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -305,5 +305,48 @@ theorem deformedRegionStateAssembled_bareExtend
   rw [regionComplementBoundaryConfigEquiv_apply, bareExtendInsert]
   congr 1
 
+/-! ### The clean extension identity
+
+Dividing out the interior-bond multiplicity gives the corner-extension identity: the
+deformed state on `R` with `C` equals the deformed state on `S` with the corner-extended
+insert, as functions of the full physical configuration.  The multiplicity is a nonzero
+scalar at positive bond dimensions. -/
+
+/-- The deformed state is linear in scaling the insert by a constant: scaling the insert
+by `c` scales the deformed state by `c`. -/
+theorem deformedRegionStateAssembled_const_smul (A : Tensor G d) (R : Finset V) (c : ℂ)
+    (C : RegionInsert (G := G) (d := d) A R) (cfg : V → Fin d) :
+    deformedRegionStateAssembled (G := G) A R (fun μ σ => c * C μ σ) cfg =
+      c * deformedRegionStateAssembled (G := G) A R C cfg := by
+  rw [deformedRegionStateAssembled, deformedRegionStateAssembled, deformedRegionState,
+    deformedRegionState, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [mul_assoc]
+
+open scoped Classical in
+/-- **The corner-extension identity.** For nested regions `R ⊆ S` and positive bond
+dimensions, the deformed state on `R` with insert `C` equals the deformed state on `S`
+with the corner-extended insert `extendInsert hRS C`, as functions of the full physical
+configuration.  The corner-extended insert pairs `C` with the genuine network block of
+the added vertices `S \ R`; the three-block factorization
+(`deformedRegionStateAssembled_bareExtend`) produces the bare coupling scaled by the
+`univ \ S` interior-bond multiplicity, which the corner-extended insert's divisor
+cancels.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the deformed states agree as closed-torus states);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 2. -/
+theorem deformedRegionState_extend {R S : Finset V} (hRS : R ⊆ S)
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e) (C : RegionInsert (G := G) (d := d) A R)
+    (cfg : V → Fin d) :
+    deformedRegionStateAssembled (G := G) A R C cfg =
+      deformedRegionStateAssembled (G := G) A S (extendInsert (G := G) hRS C) cfg := by
+  classical
+  have hne : (regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (regionInteriorBondProd_pos (G := G) A (Finset.univ \ S) hpos).ne'
+  rw [extendInsert_eq_smul_bare, deformedRegionStateAssembled_const_smul,
+    deformedRegionStateAssembled_bareExtend, smul_eq_mul, ← mul_assoc,
+    inv_mul_cancel₀ hne, one_mul]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -150,5 +150,55 @@ theorem nestedComplPhysical_restrict {R S : Finset V} (hRS : R ⊆ S) (cfg : V �
   · rw [dif_pos hb, restrictRegionσ_apply, restrictRegionσ_apply]
   · rw [dif_neg hb, restrictRegionσ_apply, restrictRegionσ_apply]
 
+/-- The restriction of a physical configuration on `S` to a sub-region `R ⊆ S`. -/
+def restrictSubRegionσ {R S : Finset V} (hRS : R ⊆ S)
+    (σ : RegionPhysicalConfig (V := V) (d := d) S) :
+    RegionPhysicalConfig (V := V) (d := d) R :=
+  fun w => σ ⟨w.1, hRS w.2⟩
+
+omit [Fintype V] [LinearOrder V] [DecidableRel G.Adj] in
+@[simp] theorem restrictSubRegionσ_restrict {R S : Finset V} (hRS : R ⊆ S) (cfg : V → Fin d) :
+    restrictSubRegionσ (V := V) (d := d) hRS (restrictRegionσ (V := V) (d := d) S cfg) =
+      restrictRegionσ (V := V) (d := d) R cfg := rfl
+
+/-! ### The corner-extended insert and the extension identity
+
+The corner-extended insert `extendInsert hRS C` pairs the insert `C` on `R` with the
+blue-coupling coefficient `threeBlockBlueCoeff` of the nested geometry, contracting `C`
+against the genuine network block of the added vertices `S \ R`.  Reading the deformed
+state as a function of the full physical configuration, the extension identity says the
+deformed state on `R` with `C` equals the deformed state on `S` with `extendInsert
+hRS C`. -/
+
+/-- The corner-extended insert on `S` built from an insert `C` on `R ⊆ S`: for a
+boundary configuration `ν` on `S` and a physical configuration `σ` on `S`, contract `C`
+(read on `R`) against the blue-coupling coefficient `threeBlockBlueCoeff` of the nested
+geometry (read on the added vertices `S \ R`) at the complement boundary configuration
+`regionComplementBoundaryConfig A S ν` on `univ \ S`.  This pairs `C` with the genuine
+network block of `S \ R` across the matching boundary configurations.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex` (the blue coupling coefficient);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 2. -/
+noncomputable def extendInsert {R S : Finset V} (hRS : R ⊆ S)
+    (C : RegionInsert (G := G) (d := d) A R) :
+    RegionInsert (G := G) (d := d) A S :=
+  fun ν σ =>
+    ∑ μ : RegionBoundaryConfig (G := G) A R,
+      C μ (restrictSubRegionσ (V := V) (d := d) hRS σ) *
+        (nestedThreeBlockGeometry (V := V) hRS).threeBlockBlueCoeff
+          (regionComplementBoundaryConfig (G := G) A R μ)
+          (restrictSubRegionσ (V := V) (d := d) Finset.sdiff_subset σ)
+          (regionComplementBoundaryConfig (G := G) A S ν)
+
+/-- The deformed-window state read as a function of the full physical configuration:
+restrict the global configuration to the region and its complement and evaluate the
+deformed state. -/
+noncomputable def deformedRegionStateAssembled (A : Tensor G d) (R : Finset V)
+    (C : RegionInsert (G := G) (d := d) A R) (cfg : V → Fin d) : ℂ :=
+  deformedRegionState (G := G) A R C
+    (restrictRegionσ (V := V) (d := d) R cfg)
+    (restrictRegionσ (V := V) (d := d) (Finset.univ \ R) cfg)
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -174,13 +174,47 @@ hRS C`. -/
 boundary configuration `ν` on `S` and a physical configuration `σ` on `S`, contract `C`
 (read on `R`) against the blue-coupling coefficient `threeBlockBlueCoeff` of the nested
 geometry (read on the added vertices `S \ R`) at the complement boundary configuration
-`regionComplementBoundaryConfig A S ν` on `univ \ S`.  This pairs `C` with the genuine
-network block of `S \ R` across the matching boundary configurations.
+`regionComplementBoundaryConfig A S ν` on `univ \ S`, divided by the `univ \ S`
+interior-bond multiplicity.  This pairs `C` with the genuine network block of `S \ R`
+across the matching boundary configurations; the multiplicity divisor cancels the factor
+the three-block factorization introduces, so the deformed state is preserved.
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
 `Papers/1804.04964/paper_normal.tex` (the blue coupling coefficient);
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 2. -/
 noncomputable def extendInsert {R S : Finset V} (hRS : R ⊆ S)
+    (C : RegionInsert (G := G) (d := d) A R) :
+    RegionInsert (G := G) (d := d) A S :=
+  fun ν σ =>
+    (regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ)⁻¹ *
+      ∑ μ : RegionBoundaryConfig (G := G) A R,
+        C μ (restrictSubRegionσ (V := V) (d := d) hRS σ) *
+          (nestedThreeBlockGeometry (V := V) hRS).threeBlockBlueCoeff
+            (regionComplementBoundaryConfig (G := G) A R μ)
+            (restrictSubRegionσ (V := V) (d := d) Finset.sdiff_subset σ)
+            (regionComplementBoundaryConfig (G := G) A S ν)
+
+/-- The deformed-window state read as a function of the full physical configuration:
+restrict the global configuration to the region and its complement and evaluate the
+deformed state. -/
+noncomputable def deformedRegionStateAssembled (A : Tensor G d) (R : Finset V)
+    (C : RegionInsert (G := G) (d := d) A R) (cfg : V → Fin d) : ℂ :=
+  deformedRegionState (G := G) A R C
+    (restrictRegionσ (V := V) (d := d) R cfg)
+    (restrictRegionσ (V := V) (d := d) (Finset.univ \ R) cfg)
+
+/-! ### The interior-bond multiple of the extension identity
+
+The three-block factorization carries an interior-bond multiplicity factor on the
+`univ \ S` block.  The *bare* corner-extended coefficient — the corner-extended insert
+without the multiplicity divisor — has deformed state equal to that multiple of the
+deformed state on `R`.  Dividing out the multiplicity (a nonzero scalar at positive bond
+dimensions) gives the clean extension identity. -/
+
+/-- The bare corner-extended coefficient: the corner-extended insert without the
+multiplicity divisor.  Its deformed state on `S` is the `univ \ S` interior-bond multiple
+of the deformed state on `R`. -/
+noncomputable def bareExtendInsert {R S : Finset V} (hRS : R ⊆ S)
     (C : RegionInsert (G := G) (d := d) A R) :
     RegionInsert (G := G) (d := d) A S :=
   fun ν σ =>
@@ -191,14 +225,85 @@ noncomputable def extendInsert {R S : Finset V} (hRS : R ⊆ S)
           (restrictSubRegionσ (V := V) (d := d) Finset.sdiff_subset σ)
           (regionComplementBoundaryConfig (G := G) A S ν)
 
-/-- The deformed-window state read as a function of the full physical configuration:
-restrict the global configuration to the region and its complement and evaluate the
-deformed state. -/
-noncomputable def deformedRegionStateAssembled (A : Tensor G d) (R : Finset V)
-    (C : RegionInsert (G := G) (d := d) A R) (cfg : V → Fin d) : ℂ :=
-  deformedRegionState (G := G) A R C
-    (restrictRegionσ (V := V) (d := d) R cfg)
-    (restrictRegionσ (V := V) (d := d) (Finset.univ \ R) cfg)
+/-- The corner-extended insert is the bare coefficient scaled by the inverse
+multiplicity. -/
+theorem extendInsert_eq_smul_bare {R S : Finset V} (hRS : R ⊆ S)
+    (C : RegionInsert (G := G) (d := d) A R) :
+    extendInsert (G := G) hRS C =
+      fun ν σ => (regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ)⁻¹ *
+        bareExtendInsert (G := G) hRS C ν σ := rfl
+
+open scoped Classical in
+/-- The bare corner-extended coefficient has deformed state the `univ \ S` interior-bond
+multiple of the deformed state on `R`, read as a function of the full physical
+configuration.  Each complement weight on `univ \ R` is split by the nested three-block
+factorization into the blue-coupling combination of the `univ \ S` complement weights,
+the blue coupling reassembling into the bare coefficient after reindexing the complement
+boundary configurations along `regionComplementBoundaryConfigEquiv`.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 2. -/
+theorem deformedRegionStateAssembled_bareExtend
+    {R S : Finset V} (hRS : R ⊆ S) (C : RegionInsert (G := G) (d := d) A R) (cfg : V → Fin d) :
+    deformedRegionStateAssembled (G := G) A S (bareExtendInsert (G := G) hRS C) cfg =
+      (regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ) •
+        deformedRegionStateAssembled (G := G) A R C cfg := by
+  classical
+  set g := nestedThreeBlockGeometry (V := V) hRS with hg
+  -- Abbreviate the three restrictions.
+  set σR := restrictRegionσ (V := V) (d := d) R cfg with hσR
+  set σblue := restrictRegionσ (V := V) (d := d) (S \ R) cfg with hσblue
+  set σcompl := restrictRegionσ (V := V) (d := d) (Finset.univ \ S) cfg with hσcompl
+  have hcompl : restrictRegionσ (V := V) (d := d) (Finset.univ \ R) cfg =
+      g.complPhysical (d := d) σblue σcompl := (nestedComplPhysical_restrict hRS cfg).symm
+  -- The right side: distribute the multiplicity into the boundary sum, then split each
+  -- `univ \ R` complement weight by the nested three-block factorization.
+  have hRHS : (regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ) •
+        deformedRegionStateAssembled (G := G) A R C cfg =
+      ∑ bc' : RegionBoundaryConfig (G := G) A g.complement,
+        (∑ μ : RegionBoundaryConfig (G := G) A R,
+            C μ σR * g.threeBlockBlueCoeff (regionComplementBoundaryConfig (G := G) A R μ)
+              σblue bc') * regionBlockedWeight (G := G) A g.complement bc' σcompl := by
+    rw [deformedRegionStateAssembled, deformedRegionState, ← hσR, hcompl, Finset.smul_sum]
+    -- Split each `univ \ R` complement weight by the nested three-block factorization.
+    rw [show (∑ μ : RegionBoundaryConfig (G := G) A R,
+          (regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ) •
+            (C μ σR * regionBlockedWeight (G := G) A (Finset.univ \ R)
+              (regionComplementBoundaryConfig (G := G) A R μ)
+              (g.complPhysical (d := d) σblue σcompl))) =
+        ∑ μ : RegionBoundaryConfig (G := G) A R,
+          ∑ bc' : RegionBoundaryConfig (G := G) A g.complement,
+            (C μ σR * g.threeBlockBlueCoeff (regionComplementBoundaryConfig (G := G) A R μ)
+              σblue bc') * regionBlockedWeight (G := G) A g.complement bc' σcompl from ?_,
+      Finset.sum_comm]
+    · refine Finset.sum_congr rfl (fun bc' _ => ?_)
+      rw [Finset.sum_mul]
+    · refine Finset.sum_congr rfl (fun μ _ => ?_)
+      have hfac := g.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical
+        (regionComplementBoundaryConfig (G := G) A R μ) σblue σcompl
+      rw [smul_eq_mul, mul_comm (C μ σR), ← mul_assoc,
+        show ((regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ) *
+              regionBlockedWeight (G := G) A (Finset.univ \ R)
+                (regionComplementBoundaryConfig (G := G) A R μ)
+                (g.complPhysical (d := d) σblue σcompl)) =
+            (regionInteriorBondProd (G := G) A g.complement : ℂ) •
+              regionBlockedWeight (G := G) A (Finset.univ \ g.red)
+                (regionComplementBoundaryConfig (G := G) A R μ)
+                (g.complPhysical (d := d) σblue σcompl) from by rw [smul_eq_mul]; rfl,
+        hfac, Finset.sum_mul]
+      refine Finset.sum_congr rfl (fun bc' _ => ?_)
+      rw [smul_eq_mul]; ring
+  rw [hRHS, deformedRegionStateAssembled, deformedRegionState]
+  -- Reindex the `bc'` sum to the `S`-boundary sum, then match the bare insert termwise.
+  refine Eq.trans ?_ (Equiv.sum_comp (regionComplementBoundaryConfigEquiv (G := G) A S)
+    (fun bc' : RegionBoundaryConfig (G := G) A g.complement =>
+      (∑ μ : RegionBoundaryConfig (G := G) A R,
+          C μ σR * g.threeBlockBlueCoeff (regionComplementBoundaryConfig (G := G) A R μ)
+            σblue bc') * regionBlockedWeight (G := G) A g.complement bc' σcompl))
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  rw [regionComplementBoundaryConfigEquiv_apply, bareExtendInsert]
+  congr 1
 
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -422,31 +422,54 @@ the single block Step~3 completes and inverts. The decomposition reduces every
 shifted cyclic distance to the base distance from the patch corner through the
 shift arithmetic \path{zmod_val_sub_shift}.
 
-The tensor content of the chaining and stripping --- the
-contraction-extension \path{deformedRegionState_extend} that writes a
-sub-region deformed state as the deformed state of a superset with the
-window's insert extended by the genuine block on the added vertices, and
-the chained patch equality and corner-inversion built from it --- remains.
-The contraction-extension is the disjoint factorization of the complement
-weight $T_{\mathrm{univ} \setminus R}$ over
+The tensor content of the chaining and stripping is in
+\path{TNLean/PEPS/TorusWindowChain2.lean}. The contraction-extension
+\path{deformedRegionState_extend} writes a sub-region deformed state, read
+as a function of the full physical configuration, as the deformed state of
+a superset $S \supseteq R$ with the window's insert extended by the genuine
+block on the added vertices $S \setminus R$. It is built from the disjoint
+factorization of the complement weight $T_{\mathrm{univ} \setminus R}$ over
 $\mathrm{univ} \setminus R = (S \setminus R) \sqcup
-(\mathrm{univ} \setminus S)$, already available as
-\path{ThreeBlockGeometry.regionBlockedWeight_complPhysical_eq} and
-\path{ThreeBlockGeometry.threeBlockBlueCoeff} of
-\path{TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean} over the
-geometry $\mathrm{red} = R$, $\mathrm{blue} = S \setminus R$,
-$\mathrm{complement} = \mathrm{univ} \setminus S$. Building
-\path{deformedRegionState_extend} from that factorization additionally
-needs a boundary-configuration split equivalence carrying $\partial R$ to
-the $\partial S$ legs together with the internal $R$/$(S \setminus R)$
-bonds, the one piece the three-block machinery does not yet expose as a
-standalone equivalence. With \path{deformedRegionState_extend} in hand the
-chain is the transitivity of the consecutive-window engine equalities
-extended to $P$, and the stripping is one further application of
-\path{deformedRegionState_insert_eq_of_complementInjective} at the patch
-level inverting the injective completed corner rectangle, leaving the
-open-boundary equality on the end pair $S$ --- the deliverable
-\path{staircasePair_insert_eq}.
+(\mathrm{univ} \setminus S)$: with the geometry $\mathrm{red} = R$,
+$\mathrm{blue} = S \setminus R$,
+$\mathrm{complement} = \mathrm{univ} \setminus S$, the landed
+\path{ThreeBlockGeometry.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical}
+splits $T_{\mathrm{univ} \setminus R}$ into the blue-coupling combination of
+the $T_{\mathrm{univ} \setminus S}$ weights, the sum over the
+$\partial(\mathrm{univ} \setminus S)$ boundary configurations being exactly
+the boundary-configuration split. The corner-extended insert
+\path{extendInsert} contracts the window insert against the blue coupling
+\path{ThreeBlockGeometry.threeBlockBlueCoeff}, scaled by the inverse of the
+$\mathrm{univ} \setminus S$ interior-bond multiplicity the factorization
+introduces (a nonzero scalar at positive bond dimensions, which cancels).
+The deformed state is read region-independently through \path{assembleRegionσ},
+so the extension equalities chain by transitivity. The corner extension thus
+needs no standalone $\partial R \to \partial S$ boundary-configuration
+equivalence; the three-block blue coupling supplies the split already
+packaged.
+
+With \path{deformedRegionState_extend} the consecutive-window display
+\path{horizontalConsecutiveWindow_extend_eq} writes each single-window state
+as the union state of its corner-extended insert and passes the equality to
+the consecutive-window engine; the patch chaining
+\path{horizontalStaircase_patch_extend_eq} extends the two end windows'
+states to the patch and chains them; and the corner stripping
+\path{staircasePair_insert_eq} inverts the end-pair complement, leaving the
+open-boundary equality on the end pair $S$ --- the layer's deliverable.
+
+One residual remains. The stripping \path{staircasePair_insert_eq} takes the
+blocked-tensor injectivity of $\mathrm{univ} \setminus S$ (the torus
+complement of the staircase end pair) as an explicit hypothesis. The note's
+Step~3 supplies it by completing the $L \times (K-1)$ corner block to the
+injective $L \times K$ rectangle \path{horizontalStaircaseCompletedCorner}
+and inverting it: the end-pair complement is then the union of that injective
+rectangle and the injective host, blocked-tensor injective by the landed
+union lemma. The injectivity of the completed rectangle and the patch
+decomposition $P = S \sqcup \mathrm{corner}$ are in place
+(\path{TNLean/PEPS/TorusWindowChain.lean}); the assembly of the end-pair
+complement injectivity from them --- a layer-1-style complement decomposition
+for the two-window end pair --- is the one piece not yet landed, and is the
+hypothesis \path{staircasePair_insert_eq} carries.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Layer 3 of the two-dimensional overlapping-window strengthening of the normal PEPS
Fundamental Theorem (arXiv:1804.04964, the corollary at
`Papers/1804.04964/paper_normal.tex:2297--2318`). This is the chaining-and-stripping
layer (item 3 of the plan in
`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`): the corner-extension identity that
re-expresses a single-window deformed state as a larger-region deformed state, and the
chaining/stripping built on it down to the staircase end pair.

All new content is in `TNLean/PEPS/TorusWindowChain2.lean` (641 lines; added to root
`TNLean.lean`). **Sorry-free**, no `maxHeartbeats`, no placeholder conclusions.

## The crux: the corner-extension identity

`deformedRegionState_extend` (R ⊆ S): the deformed state on `R` with insert `C` equals
the deformed state on `S` with the corner-extended insert `extendInsert hRS C`, read as a
region-independent function of the full physical configuration.

The boundary-configuration split is supplied by the **landed** three-block factorization
`ThreeBlockGeometry.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical`
over the geometry `red = R`, `blue = S \ R`, `complement = univ \ S` (`nestedThreeBlockGeometry`):
it splits the complement weight `T_{univ\R}` into the blue-coupling combination of the
`T_{univ\S}` weights, the sum over the `univ \ S` boundary configurations being exactly the
split. `extendInsert` contracts the window insert against `threeBlockBlueCoeff`, scaled by
the inverse of the `univ \ S` interior-bond multiplicity (nonzero at positive bonds, cancels).
**No standalone `∂R → ∂S` boundary-config equivalence was needed** — the three-block blue
coupling packages it.

The one real obstruction was an instance diamond (`DecidableEq V` from a variable vs
`LinearOrder.toDecidableEq`), which made `Finset.univ \ R` two different terms and exploded
`whnf`; resolved by dropping `[DecidableEq V]` and routing through `LinearOrder`.

## Deliverables

1. **`extendInsert`** + `nestedThreeBlockGeometry`, config restriction/fused-leg lemmas.
2. **`deformedRegionState_extend`** — the corner-extension identity (the crux). Built via
   `deformedRegionStateAssembled_bareExtend` (the factorization) + the curried/assembled
   bridge.
3. **`horizontalConsecutiveWindow_extend_eq`** — Step 1's union display: two consecutive
   windows' state agreement gives the open-boundary equality of their corner-extended
   inserts on the union, via the landed consecutive-window engine.
4. **`horizontalStaircase_patch_extend_eq`** — Step 2's chaining: the two end windows'
   states, extended to the staircase patch.
5. **`staircasePair_insert_eq`** — Step 3's stripping: the open-boundary equality
   `C₀ ⊔ T_{W_{L+K-1}} = T_{W₀} ⊔ C_{L+K-1}` on the staircase end pair, by inverting the
   end-pair complement.

## Residual

`staircasePair_insert_eq` takes the blocked-tensor injectivity of `univ \ endPair` (the
end-pair complement) as an explicit hypothesis. The note's Step 3 supplies it by completing
the `L×(K-1)` corner to the injective `L×K` rectangle and inverting; the injectivity of the
completed rectangle and the patch decomposition `P = S ⊔ corner` are landed
(`TorusWindowChain.lean`), but the assembly of the end-pair complement injectivity from them
(a layer-1-style two-window complement decomposition) is not yet landed and is the hypothesis
the lemma carries. Documented in the updated final section of
`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.

Orientation: horizontal only; the vertical analogue is deferred (transpose of the same
construction).

## Verification

- Full root `lake build` green.
- `lake exe lint-style` exit 0; all lines ≤ 100 chars; file ≤ 1000 lines.
- `#print axioms` for all five headline deliverables: exactly
  `[propext, Classical.choice, Quot.sound]`.

No blueprint entries (no capstone yet, per plan).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal Lean additions on the PEPS overlap track with no runtime or auth changes; main follow-up is a documented math hypothesis on `staircasePair_insert_eq`, not a production regression risk.
> 
> **Overview**
> Adds **`TNLean/PEPS/TorusWindowChain2.lean`** (~641 lines) and wires it into root **`TNLean.lean`**. This is layer 3 of the 2D overlapping-window PEPS FT route: **corner-extension** plus **chaining/stripping** on the torus staircase.
> 
> **Corner-extension:** For nested regions `R ⊆ S`, **`extendInsert`** pairs a window insert with the genuine block on `S \ R` via **`nestedThreeBlockGeometry`** and **`threeBlockBlueCoeff`**, using the landed three-block factorization from `UnionInjectivityGeneral` (no separate `∂R → ∂S` equivalence). **`deformedRegionState_extend`** proves the deformed state on `R` equals that on `S` with the extended insert, read through **`deformedRegionStateAssembled`** / **`restrictRegionσ`** so equalities chain on full physical configs.
> 
> **Torus deliverables:** **`horizontalConsecutiveWindow_extend_eq`** (Step 1 union display), **`horizontalStaircase_patch_extend_eq`** (Step 2 patch chaining), **`staircasePair_insert_eq`** (Step 3 open-boundary equality on the end pair, assuming end-pair complement blocked-tensor injectivity).
> 
> **Docs:** **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** now points at the landed lemmas and records the residual: deriving end-pair complement injectivity from corner completion is not yet formalized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2547cedb3f4fb0053e89506c894c07a4ee3c4d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->