### PR TITLE
doc(PEPS): correct the Step 3 end-pair complement obstruction (2D overlap layer 4)

### DIFF
--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -599,12 +599,19 @@ single crossing bond; the agreement of the window states makes the two end-pair 
 agree; the complement-inversion engine then strips the closed-torus equality to the
 open-boundary equality of the end-pair inserts.
 
-The end-pair complement injectivity is the hypothesis the note's corner-completion supplies
-(completing the `L × (K - 1)` corner block to the injective `L × K` rectangle
-`horizontalStaircaseCompletedCorner` and inverting it, so that the end-pair complement is
-the union of that injective rectangle and an injective host); its construction from the
-window hypotheses is the residual recorded in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-Step 3.
+The end-pair complement injectivity is taken here as an explicit hypothesis.  This is the
+wrong engine for the source's Step 3: at the corollary's minimal size `2 * L + 1 ≤ width`,
+`2 * K + 1 ≤ height` the torus complement `univ \ S` is *not* blocked-tensor injective under
+the one-orientation window hypotheses, so `hcompl` is not derivable.  At the row `y + K - 1`
+the two end windows together occupy all columns `[x - L + 1, x + L]`, leaving a complement
+band of width `width - 2 * L`, which is `1` at the minimal width and below `L` whenever
+`width < 3 * L`; no injective `L × K` window translate fits through that row, so `univ \ S`
+is not a union of injective window translates.  The faithful Step 3 instead cancels the
+*shared* injective completed corner `horizontalStaircaseCompletedCorner` (an `L × K` window,
+injective by hypothesis) common to both sides of the patch equality, never asserting
+injectivity of `univ \ S`.  Replacing this full-complement inversion by a
+shared-injective-block cancellation engine is the residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3, and tracked in issue #2745.
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex` (add two-two tensors in the corner and invert);

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -611,7 +611,7 @@ is not a union of injective window translates.  The faithful Step 3 instead canc
 injective by hypothesis) common to both sides of the patch equality, never asserting
 injectivity of `univ \ S`.  Replacing this full-complement inversion by a
 shared-injective-block cancellation engine is the residual recorded in
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3, and tracked in issue #2745.
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex` (add two-two tensors in the corner and invert);

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -203,6 +203,59 @@ result is the open-boundary equality on the staircase pair:
   \qquad\text{on } S .
 \]
 
+The inversion in this step cancels a \emph{shared} injective block. Both
+sides of the patch equality carry the genuine network block on the
+completed rectangle $Q = [x-L+1,x] \times [y+1,y+K]$ once the added row
+is contracted in; they differ only on $S$. Injectivity of $Q$ then
+cancels the common $Q$-block from both sides and leaves the equality on
+$S$. This is a different inversion from the consecutive-window step of
+Step~1, where the inverted region is the entire torus complement of the
+compared region and the two sides differ across that whole complement.
+
+\medskip
+\noindent\textbf{The complement of the end pair is not injective at the
+minimal size.} A natural but incorrect reading of the corner completion
+is that it makes the torus complement $\mathrm{univ} \setminus S$
+injective, so that the consecutive-window engine of Step~1 (which inverts
+the full complement of the compared region) applies with the compared
+region taken to be $S$ itself. This fails at the corollary's minimal
+size. Read the cyclic columns and rows from the lower-left corner of the
+left end window. The left window occupies columns $[0,L)$ at rows
+$[0,K)$ and the right window occupies columns $[L,2L)$ at rows
+$[K-1,2K-1)$, so at the single row $K-1$ the pair occupies \emph{all}
+columns $[0,2L)$. The complement of $S$ in that row is the column band
+$[2L, \mathrm{width})$, of width $\mathrm{width} - 2L$, which is exactly
+$1$ at $\mathrm{width} = 2L+1$ and in general below $L$ whenever
+$\mathrm{width} < 3L$. Every contiguous $L \times K$ window (or wider) that
+contains a complement vertex at row $K-1$ must include a column in
+$[0,2L)$ at that row, and every such column lies in $S$. So no injective
+$L \times K$ translate fits through row $K-1$ of the complement, and
+$\mathrm{univ} \setminus S$ is not a union of injective window translates;
+its blocked tensor is not injective under the one-orientation window
+hypotheses alone at this size. (For $\mathrm{width} \geq 3L$ and
+$\mathrm{height} \geq 3K$ the full-width and full-height gaps both reach
+$L$ and $K$, and $\mathrm{univ} \setminus S$ does decompose; the corollary
+needs the minimal size where it does not.) The same obstruction rules out
+the variant $\mathrm{univ} \setminus S = (\mathrm{univ} \setminus P) \cup
+\mathrm{corner}$: the patch $P$ also occupies all columns $[0,2L)$ at row
+$K-1$, so $\mathrm{univ} \setminus P$ has the same sub-$L$ band there.
+
+The faithful step is therefore the shared-block cancellation above, which
+needs only injectivity of the completed rectangle $Q$ (an $L \times K$
+window, injective by hypothesis) and never asserts injectivity of
+$\mathrm{univ} \setminus S$. The Lean stripping
+\leanid{staircasePair_insert_eq} currently discharges Step~3 with the
+full-complement engine
+\leanid{deformedRegionStateAssembled_insert_eq_of_complementInjective}
+and so carries
+\leanid{RegionBlockedTensorInjective}~$B\;(\mathrm{univ} \setminus
+\text{\leanid{horizontalStaircaseEndPair}}\;s\,L\,K)$ as an explicit
+hypothesis. That hypothesis is not derivable at the minimal size, by the
+argument above; the eliminating step is to replace the full-complement
+engine by a shared-injective-block cancellation engine for $Q$, which
+inverts the common completed-corner block rather than the whole
+complement.
+
 \subsection{Step 4: the single-crossing extraction}
 
 The two end windows are diagonally offset copies of the $L \times K$


### PR DESCRIPTION
## Summary

Layer-4 investigation of the 2D overlapping-window route (arXiv:1804.04964
corollary, lines 2297–2318; plan `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`).
This PR is **documentation only**: it corrects a geometric claim that turns out
to be false at the corollary's minimal torus size, recording the precise
obstruction and the faithful eliminating route. No theorem statements or proofs
change; `staircasePair_insert_eq` keeps its `hcompl` hypothesis.

## The finding

Issue #2745 proposed discharging
`hcompl : RegionBlockedTensorInjective B (univ \ horizontalStaircaseEndPair s L K)`
by the decomposition `univ \ S = (univ \ P) ∪ corner` with `univ \ P` injective.
**This is impossible at the minimal size `2L+1 × 2K+1`.**

Read cyclic columns/rows from the left end window's lower-left corner. The left
window occupies columns `[0,L)` at rows `[0,K)`; the right window occupies
columns `[L,2L)` at rows `[K-1,2K-1)`. At the single row `K-1` the two windows
together occupy **all** columns `[0,2L)`, so the complement of `S` in that row is
the column band `[2L, width)` of width `width - 2L`, which is `1` at
`width = 2L+1` and below `L` whenever `width < 3L`. Any contiguous `L × K` (or
wider) window through a complement vertex at row `K-1` must include a column in
`[0,2L)` at that row, and every such column lies in `S`. So no injective window
translate fits through that row, and `univ \ S` is not a union of injective
window translates; its blocked tensor is not injective under the one-orientation
window hypotheses at this size (the same band kills `univ \ P`).

This is consistent with the gap note's existing section "Why the formalized
three-block route cannot reach the corollary's sizes" — and indeed
`NormalEdgeBlockingData.complement_injective` shows the landed three-block
per-edge gauge engine (`exists_regionEdgeGauge_torus`) carries the same host
requirement and so also cannot be applied to the staircase pair at minimal size.

## The faithful route (recorded, not yet built)

The source's Step 3 cancels a **shared** injective block: both sides of the patch
equality carry the genuine network block on the completed corner
`Q = horizontalStaircaseCompletedCorner` (an `L × K` window, injective by
hypothesis — `horizontalStaircaseCompletedCorner_injective` is landed) and differ
only on `S`. Injectivity of `Q` cancels the common `Q`-block and leaves the
equality on `S`, never asserting injectivity of `univ \ S`. The eliminating step
is therefore a **shared-injective-block cancellation engine** for `Q`, replacing
the full-complement engine
`deformedRegionStateAssembled_insert_eq_of_complementInjective` used in the
current `staircasePair_insert_eq`.

## Why deliverable (B) is also blocked here

Step 4's single-crossing extraction needs the staircase end-pair equality cast
into the intertwining form `F a * W₂ b = W₁ a * G b` with `W₁, W₂` matrix
families on `Fin (bondDim e)` that **span** the full matrix algebra, then
`MPSChainTensor.exists_bondOperator_of_intertwine_span`. The bridge "read a
window's blocked tensor (with many open boundary legs) as a spanning matrix
family on the single e-bond, fixing the external legs matched by the pairing"
does not exist for the torus and is not a standalone window lemma; it is tied to
the single-crossing pairing structure. The landed torus per-edge route instead
goes through `NormalEdgeBlockingData` and never builds an e-bond spanning matrix
family. Building this bridge is the genuine remaining work for Step 4.

## Changes
- `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`: Step 3 gains the minimal-size
  obstruction analysis and the shared-block-cancellation faithful route.
- `TNLean/PEPS/TorusWindowChain2.lean`: `staircasePair_insert_eq` docstring
  corrected to record that `hcompl` is not derivable at minimal size and to point
  at the cancellation engine as the eliminating route.

## Verification
- `lake build TNLean.PEPS.TorusWindowChain2` green (docstring-only change).
- `lake exe lint-style` flags nothing for the changed file.
- Gap note compiles under `pdflatex` (`TEXINPUTS=.:`), no new errors.
- No `sorry`/`axiom`/`native_decide`.

Refs #2745, #2738; arXiv:1804.04964 lines 2320–2445.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX gap-note edits only; no Lean proof or API changes.
> 
> **Overview**
> **Documentation-only** correction for PEPS 2D overlap **Step 3**: the prior story that corner completion makes the torus complement `univ \ S` blocked-tensor injective—and thus discharges `hcompl` in `staircasePair_insert_eq`—is **false** at the corollary’s minimal size `(2L+1) × (2K+1)`.
> 
> The gap note now explains that at row `K-1` the two end windows cover all columns `[0, 2L)`, so the complement band has width `width - 2L` (often `1` or `< L`), and no injective `L × K` window fits through that row under one-orientation hypotheses. It contrasts **full-complement inversion** (what Lean uses today via `deformedRegionStateAssembled_insert_eq_of_complementInjective`) with the **faithful** route: cancel the **shared** injective completed corner `Q` (`horizontalStaircaseCompletedCorner`), which both patch sides carry, without claiming injectivity of `univ \ S`.
> 
> The `staircasePair_insert_eq` docstring is updated to match: `hcompl` stays an explicit hypothesis; the eliminating work is a future **shared-injective-block cancellation** engine. **No theorem statements or proofs change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad6d9d1e305f8605636589cfaa51884779a8beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->