### PR TITLE
feat(PEPS): record the superset closed-state collapse blocking the staircase-pair stripping

### DIFF
--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -421,6 +421,71 @@ theorem deformedRegionStateAssembled_insert_eq_of_complementInjective (A : Tenso
   deformedRegionState_insert_eq_of_complementInjective (G := G) A R hC C₁ C₂
     (deformedRegionState_eq_of_assembled_eq (G := G) A R C₁ C₂ h)
 
+/-! ### The superset closed-state route collapses to the sub-region complement
+
+The corner-extension identity `deformedRegionState_extend` reads in both directions: the
+assembled state on a superset `S ⊆ P'` with the corner-extended insert is the assembled
+state on `R = S`'s sub-region with the original insert.  This subsection records the
+consequence that governs the staircase-pair stripping of Step 3: extending an insert
+through a superset never changes the assembled state, so inverting the superset closed
+state recovers the sub-region insert *only* when the sub-region's torus complement is
+blocked-tensor injective.  Injectivity of the added block `P' \ R` plays no role in the
+closed-state route; it enters only an open-boundary cancellation, which the closed state
+does not provide.  This is the obstruction recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3. -/
+
+/-- **The superset closed-state collapse.** For nested regions `R ⊆ P'` and positive bond
+dimensions, the assembled state on the superset `P'` with the corner-extended insert
+`extendInsert hRP' C` is the assembled state on `R` with the original insert `C`.  This is
+`deformedRegionState_extend` read with the larger region named, isolating the structural
+fact that extending an insert through a superset leaves the closed-torus state unchanged.
+
+The collapse is the reason the staircase-pair stripping cannot strip a closed-state patch
+equality to an open-boundary equality on the end pair by enlarging the compared region:
+enlarging from the end pair `S` to any superset `P'` (the patch, or the patch with the
+corner completed) leaves the assembled state equal to the one on `S`, so inverting it
+requires the same sub-region complement `univ \ S`, never the added block `P' \ S`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 3. -/
+theorem deformedRegionStateAssembled_extendInsert_eq {R P' : Finset V} (hRP' : R ⊆ P')
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e) (C : RegionInsert (G := G) (d := d) A R)
+    (cfg : V → Fin d) :
+    deformedRegionStateAssembled (G := G) A P' (extendInsert (G := G) hRP' C) cfg =
+      deformedRegionStateAssembled (G := G) A R C cfg :=
+  (deformedRegionState_extend (G := G) hRP' hpos C cfg).symm
+
+/-- **The superset closed-state route still needs the sub-region complement.** If two
+inserts `C₁` and `C₂` on `R` have corner-extended inserts on a superset `R ⊆ P'` with
+equal assembled states, and the sub-region complement `univ \ R` is blocked-tensor
+injective, then `C₁ = C₂`.  The proof collapses the superset assembled states to the
+`R`-assembled states (`deformedRegionStateAssembled_extendInsert_eq`) and inverts the
+`R`-complement.
+
+The hypothesis is `univ \ R` injective, never injectivity of the added block `P' \ R`:
+the closed-state route through any superset reduces to inverting `univ \ R`.  At the
+corollary's minimal size the staircase end pair `R = S` has non-injective `univ \ S`, so
+this route is unavailable and the faithful Step 3 cancels the shared injective completed
+corner at the open-boundary level instead.  Documented in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 3. -/
+theorem deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective
+    {R P' : Finset V} (hRP' : R ⊆ P')
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e)
+    (hC : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (C₁ C₂ : RegionInsert (G := G) (d := d) A R)
+    (h : deformedRegionStateAssembled (G := G) A P' (extendInsert (G := G) hRP' C₁) =
+      deformedRegionStateAssembled (G := G) A P' (extendInsert (G := G) hRP' C₂)) :
+    C₁ = C₂ := by
+  refine deformedRegionStateAssembled_insert_eq_of_complementInjective (G := G) A R hC C₁ C₂ ?_
+  funext cfg
+  rw [← deformedRegionStateAssembled_extendInsert_eq hRP' hpos C₁ cfg,
+    ← deformedRegionStateAssembled_extendInsert_eq hRP' hpos C₂ cfg, congrFun h cfg]
+
 /-! ### The consecutive-window union display on the torus
 
 On the discrete torus each single-window deformed state is, by the corner-extension
@@ -609,8 +674,23 @@ band of width `width - 2 * L`, which is `1` at the minimal width and below `L` w
 is not a union of injective window translates.  The faithful Step 3 instead cancels the
 *shared* injective completed corner `horizontalStaircaseCompletedCorner` (an `L × K` window,
 injective by hypothesis) common to both sides of the patch equality, never asserting
-injectivity of `univ \ S`.  Replacing this full-complement inversion by a
-shared-injective-block cancellation engine is the residual recorded in
+injectivity of `univ \ S`.
+
+The shared-corner cancellation cannot be run on the *closed-torus* patch equality
+`horizontalStaircase_patch_extend_eq`.  Enlarging the compared region from the end pair `S`
+to any superset `P'` (the patch, or the patch with the corner completed) leaves the
+assembled state unchanged: by `deformedRegionStateAssembled_extendInsert_eq` the assembled
+state on `P'` with `extendInsert (hS : S ⊆ P') C` is the assembled state on `S` with `C`,
+since `univ \ S = (P' \ S) ⊔ (univ \ P')` and the closed state has already contracted the
+`univ \ P'` boundary.  Inverting the closed state on `P'` therefore reduces to inverting
+`univ \ S` (`deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective`),
+which fails at the minimal size for every `P'`; injectivity of the added completed corner
+`P' \ S` plays no role.  The shared-corner cancellation is an open-boundary operation: it
+needs an equality of inserts on `P'` as tensors, which the closed-torus patch equality does
+not provide.  The faithful Step 3 therefore requires re-deriving the patch chaining of
+Step 2 at the open-boundary (tensor-on-region) level — chaining the consecutive-window
+open-boundary equalities `horizontalConsecutiveWindow_extend_eq` across the patch — so that
+the completed corner can be cancelled locally.  This is the residual recorded in
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -504,25 +504,45 @@ packaged.
 With \path{deformedRegionState_extend} the consecutive-window display
 \path{horizontalConsecutiveWindow_extend_eq} writes each single-window state
 as the union state of its corner-extended insert and passes the equality to
-the consecutive-window engine; the patch chaining
+the consecutive-window engine, leaving an open-boundary equality of inserts
+on each consecutive-window union. The patch chaining
 \path{horizontalStaircase_patch_extend_eq} extends the two end windows'
-states to the patch and chains them; and the corner stripping
+states to the patch and chains them at the \emph{closed-torus} level, giving
+an equality of the two patch assembled states; and the stripping
 \path{staircasePair_insert_eq} inverts the end-pair complement, leaving the
-open-boundary equality on the end pair $S$ --- the layer's deliverable.
+open-boundary equality on the end pair $S$ --- under an explicit hypothesis
+that is not derivable at the minimal size.
 
-One residual remains. The stripping \path{staircasePair_insert_eq} takes the
+One residual remains, and the route to it is the open-boundary chaining, not
+a complement assembly. The stripping \path{staircasePair_insert_eq} takes the
 blocked-tensor injectivity of $\mathrm{univ} \setminus S$ (the torus
-complement of the staircase end pair) as an explicit hypothesis. The note's
-Step~3 supplies it by completing the $L \times (K-1)$ corner block to the
-injective $L \times K$ rectangle \path{horizontalStaircaseCompletedCorner}
-and inverting it: the end-pair complement is then the union of that injective
-rectangle and the injective host, blocked-tensor injective by the landed
-union lemma. The injectivity of the completed rectangle and the patch
-decomposition $P = S \sqcup \mathrm{corner}$ are in place
-(\path{TNLean/PEPS/TorusWindowChain.lean}); the assembly of the end-pair
-complement injectivity from them --- a layer-1-style complement decomposition
-for the two-window end pair --- is the one piece not yet landed, and is the
-hypothesis \path{staircasePair_insert_eq} carries.
+complement of the staircase end pair) as an explicit hypothesis. As Step~3
+records, that hypothesis is \emph{not} derivable at the corollary's minimal
+size: $\mathrm{univ} \setminus S$ is not a union of injective window
+translates, because the end pair occupies all columns of one row and the
+complement band there has width below $L$. Completing the corner does not
+repair this: enlarging the compared region from $S$ to the patch (or to the
+patch with the corner completed) leaves the closed-torus state unchanged, so
+inverting the closed state on any superset $P' \supseteq S$ reduces to
+inverting $\mathrm{univ} \setminus S$ rather than the added block $P'
+\setminus S$. This collapse is recorded as
+\path{deformedRegionStateAssembled_extendInsert_eq} and its inversion form
+\path{deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective}
+in \path{TNLean/PEPS/TorusWindowChain2.lean}: the superset closed-state route
+consumes $\mathrm{univ} \setminus S$ injectivity and never the completed
+corner's. The shared-corner cancellation of Step~3 is an open-boundary
+operation, cancelling the injective completed rectangle
+\path{horizontalStaircaseCompletedCorner} from an equality of inserts on the
+completed region as tensors. The remaining work is therefore to re-derive the
+patch chaining of Step~2 at the open-boundary level --- chaining the
+consecutive-window open-boundary equalities
+\path{horizontalConsecutiveWindow_extend_eq} across the patch by contraction
+and transitivity, rather than collapsing to the patch closed state --- after
+which the completed corner cancels locally by its injectivity alone. The
+injectivity of the completed rectangle and the patch decomposition $P = S
+\sqcup \mathrm{corner}$ are in place
+(\path{TNLean/PEPS/TorusWindowChain.lean}); the open-boundary patch chaining
+and the corner cancellation engine are the pieces not yet landed.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Phase-0 finding (layer 4a of the 2D overlapping-window campaign)

The adversarial review of #2748 found that `staircasePair_insert_eq`
(`TNLean/PEPS/TorusWindowChain2.lean`) carries an `hcompl` hypothesis —
blocked-tensor injectivity of `univ \ S` for the staircase end pair `S` —
that is **undischargeable at the corollary's minimal size** (the end pair
fills all columns of one row, leaving a complement band of width below `L`).
This PR resolves the Phase-0 scoping question: **which cancellation mechanism
strips the closed-torus patch equality to the open-boundary end-pair equality.**

### Verdict: route (ii) is forced; the closed-state route (i) is impossible.

The hoped-for route (i) — cancel the shared injective completed corner `Q`
from the *closed-state* patch equality using `Q`-injectivity alone — does not
exist. Enlarging the compared region from `S` to any superset `P' ⊇ S`
(the patch, or the patch with the corner completed) **leaves the closed-torus
assembled state unchanged**: since `univ \ S = (P' \ S) ⊔ (univ \ P')` and the
closed state has already contracted the `univ \ P'` boundary, the assembled
state on `P'` through `extendInsert (S ⊆ P')` is definitionally the assembled
state on `S`. Inverting the closed state on any `P'` therefore reduces to
inverting `univ \ S`, never the added block `P' \ S`. The `threeBlockBlueCoeff`
split of `T_{univ\S}` strips the blue=`Q` block but leaves the `univ \ P'`
factor un-inverted, and that factor is what the closed state has summed over.
The shared-corner cancellation is intrinsically an **open-boundary** operation,
so the faithful Step 3 requires re-deriving the patch chaining of Step 2 at the
tensor-on-region (open-boundary) level — chaining the consecutive-window
open-boundary equalities across the patch — which is a substantial follow-up
(route ii). Building the open-boundary corner-cancellation engine and
`extendInsert` transitivity each need new `threeBlockBlueCoeff`-composition
infrastructure not present in the repo; landing them sorry-free was out of
scope for this PR.

### Landed (sorry-free)

- `deformedRegionStateAssembled_extendInsert_eq` — the superset closed-state
  collapse, making the wall mechanical.
- `deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective` —
  the inversion form, visibly consuming `univ \ S` injectivity and never the
  added block's, so the closed-state route's dependence is auditable.

Both have axioms `[propext, Classical.choice, Quot.sound]`.

`staircasePair_insert_eq` is unchanged in signature (still carries `hcompl`);
its docstring and the paper-gap note now record that the route to discharging
`hcompl` is the open-boundary patch chaining, not a closed-state complement
assembly. Nothing imports `staircasePair_insert_eq` yet, so no downstream
cascade.

### Checks
- Full root `lake build`: green.
- `lake exe lint-style`: exit 0, no findings.

Ref: arXiv:1804.04964 lines 2320–2445;
`docs/paper-gaps/peps_normal_ft_2d_overlap.tex` Step 3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and thin rewrites of existing `deformedRegionState_extend` machinery; no API or proof changes to `staircasePair_insert_eq` and no new consumers.
> 
> **Overview**
> Formalizes why **enlarging a region cannot strip a closed-torus patch equality** to an open-boundary end-pair equality: extending an insert through a superset leaves **`deformedRegionStateAssembled` unchanged**, so any inversion on a patch-sized region still needs **`univ \ S` injectivity**, not injectivity of the added corner block.
> 
> Adds **`deformedRegionStateAssembled_extendInsert_eq`** (symmetry of `deformedRegionState_extend`) and **`deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective`** (superset assembled-state equality implies insert equality only when the **sub-region** complement is injective). **`staircasePair_insert_eq`** is unchanged in signature; its docstring and **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** now state that faithful Step 3 must use **open-boundary patch chaining** (`horizontalConsecutiveWindow_extend_eq`) plus shared-corner cancellation, not a closed-state complement route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed62d04161428e9f69ae75f1464e095c09c0a8c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->