### PR TITLE
feat(PEPS): corner-extension linearity for the open-boundary staircase Step 3

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -414,6 +414,7 @@ import TNLean.PEPS.TorusWindowRegion
 import TNLean.PEPS.TorusDeformedWindow
 import TNLean.PEPS.TorusWindowChain
 import TNLean.PEPS.TorusWindowChain2
+import TNLean.PEPS.TorusWindowChain3
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusReferenceBlockingData

--- a/TNLean/PEPS/TorusWindowChain3.lean
+++ b/TNLean/PEPS/TorusWindowChain3.lean
@@ -2,35 +2,26 @@ import TNLean.PEPS.TorusWindowChain2
 import TNLean.PEPS.RegionBlock.UnionInjectivityGeneralBlue
 
 /-!
-# Open-boundary chaining and the shared-corner cancellation for the staircase pair
+# Linearity of the corner extension for the open-boundary staircase chaining
 
 The two-dimensional strengthening of the normal PEPS Fundamental Theorem
 (arXiv:1804.04964, the corollary at lines 2297--2318 of
 `Papers/1804.04964/paper_normal.tex`) closes Step 3 of its proof sketch with an
 *open-boundary* cancellation: from the open-boundary equality of inserts on the
 staircase patch `P` it cancels the shared injective completed corner to leave the
-equality on the staircase end pair `S`.  This file builds the two reusable pieces the
-faithful Step 3 needs and assembles them, never inverting the non-injective torus
+equality on the staircase end pair `S`, never inverting the non-injective torus
 complement `univ \ S` (the obstruction recorded in
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3).
 
-## The corner-extension composition
-
-`extendInsert` composes across nested regions: extending an insert from `R` to `S`
-and then from `S` to `P` is extending it directly from `R` to `P`
-(`extendInsert_trans`).  The composition is the workhorse of the open-boundary patch
-chaining: each consecutive-window open-boundary equality
-(`horizontalConsecutiveWindow_extend_eq`, on the union `U`) is extended to the patch
-`P` and chained by transitivity into one patch-level insert equality.
-
-## The shared-corner cancellation
-
-`extendInsert (S ⊆ R)` is injective when the added block `R \ S` is blocked-tensor
-injective (`extendInsert_injective_of_blueInjective`): the blue-coupling combination
-of the added block's blocked weights is inverted by the added block's left inverse,
-which needs only the added block's injectivity, never `univ \ S`.  Cancelling the
-shared completed corner from the patch equality through this injectivity yields the
-end-pair insert equality, the faithful Step 3.
+This file collects the geometry-free algebraic facts that route feeds on: the corner
+extension `extendInsert` of `TNLean/PEPS/TorusWindowChain2.lean` is linear in its
+insert (`bareExtendInsert_const_smul`, `extendInsert_const_smul`), and the sub-region
+restriction composes (`restrictSubRegionσ_restrictSubRegionσ`), the leg identity
+behind the corner-extension composition.  The two fiber-gluing engines the route still
+needs — the corner-extension composition `extendInsert (S ⊆ P) (extendInsert (R ⊆ S)
+C) = extendInsert (R ⊆ P) C` and the shared-corner cancellation (injectivity of
+`extendInsert (S ⊆ R)` from injectivity of the added block `R \ S` alone) — are
+stated and scoped in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
 
 ## References
 
@@ -66,6 +57,29 @@ theorem bareExtendInsert_const_smul {R S : Finset V} (hRS : R ⊆ S) (c : ℂ)
   rw [bareExtendInsert, bareExtendInsert, Finset.mul_sum]
   refine Finset.sum_congr rfl (fun μ _ => ?_)
   rw [mul_assoc]
+
+omit [DecidableEq V] in
+/-- The corner-extended insert scales with the insert: pulling a constant out of `C`
+pulls it out of `extendInsert hRS C`.  Used to commute the bare/clean rescaling through
+the composition. -/
+theorem extendInsert_const_smul {R S : Finset V} (hRS : R ⊆ S) (c : ℂ)
+    (C : RegionInsert (G := G) (d := d) A R) :
+    extendInsert (G := G) hRS (fun μ σ => c * C μ σ) =
+      fun ν σ => c * extendInsert (G := G) hRS C ν σ := by
+  funext ν σ
+  rw [extendInsert_eq_smul_bare, extendInsert_eq_smul_bare, bareExtendInsert_const_smul]
+  ring
+
+omit [Fintype V] [LinearOrder V] [DecidableEq V] in
+/-- The restriction to a sub-region composes: restricting from `S` to `R ⊆ S` after
+restricting from `P` to `S` is restricting directly from `P` to `R`.  This is the leg
+identity behind the corner-extension composition: the inner extension reads the same
+`R`-physical leg whether through `S` or directly. -/
+theorem restrictSubRegionσ_restrictSubRegionσ {R S P : Finset V} (hRS : R ⊆ S) (hSP : S ⊆ P)
+    (σ : RegionPhysicalConfig (V := V) (d := d) P) :
+    restrictSubRegionσ (V := V) (d := d) hRS
+        (restrictSubRegionσ (V := V) (d := d) hSP σ) =
+      restrictSubRegionσ (V := V) (d := d) (hRS.trans hSP) σ := rfl
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowChain3.lean
+++ b/TNLean/PEPS/TorusWindowChain3.lean
@@ -1,0 +1,71 @@
+import TNLean.PEPS.TorusWindowChain2
+import TNLean.PEPS.RegionBlock.UnionInjectivityGeneralBlue
+
+/-!
+# Open-boundary chaining and the shared-corner cancellation for the staircase pair
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) closes Step 3 of its proof sketch with an
+*open-boundary* cancellation: from the open-boundary equality of inserts on the
+staircase patch `P` it cancels the shared injective completed corner to leave the
+equality on the staircase end pair `S`.  This file builds the two reusable pieces the
+faithful Step 3 needs and assembles them, never inverting the non-injective torus
+complement `univ \ S` (the obstruction recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3).
+
+## The corner-extension composition
+
+`extendInsert` composes across nested regions: extending an insert from `R` to `S`
+and then from `S` to `P` is extending it directly from `R` to `P`
+(`extendInsert_trans`).  The composition is the workhorse of the open-boundary patch
+chaining: each consecutive-window open-boundary equality
+(`horizontalConsecutiveWindow_extend_eq`, on the union `U`) is extended to the patch
+`P` and chained by transitivity into one patch-level insert equality.
+
+## The shared-corner cancellation
+
+`extendInsert (S ⊆ R)` is injective when the added block `R \ S` is blocked-tensor
+injective (`extendInsert_injective_of_blueInjective`): the blue-coupling combination
+of the added block's blocked weights is inverted by the added block's left inverse,
+which needs only the added block's injectivity, never `univ \ S`.  Cancelling the
+shared completed corner from the patch equality through this injectivity yields the
+end-pair insert equality, the faithful Step 3.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, the corollary and proof
+  sketch at lines 2296--2445 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [DecidableEq V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+/-! ### Linearity of the bare corner-extended coefficient
+
+The bare corner-extended coefficient `bareExtendInsert hRS C` is linear in the insert
+`C`: it contracts `C` against the fixed blue-coupling coefficient, so scaling `C` by a
+constant scales the bare coefficient, and adding inserts adds the bare coefficients. -/
+
+omit [DecidableEq V] in
+/-- The bare corner-extended coefficient scales with the insert. -/
+theorem bareExtendInsert_const_smul {R S : Finset V} (hRS : R ⊆ S) (c : ℂ)
+    (C : RegionInsert (G := G) (d := d) A R) :
+    bareExtendInsert (G := G) hRS (fun μ σ => c * C μ σ) =
+      fun ν σ => c * bareExtendInsert (G := G) hRS C ν σ := by
+  funext ν σ
+  rw [bareExtendInsert, bareExtendInsert, Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [mul_assoc]
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -538,11 +538,81 @@ patch chaining of Step~2 at the open-boundary level --- chaining the
 consecutive-window open-boundary equalities
 \path{horizontalConsecutiveWindow_extend_eq} across the patch by contraction
 and transitivity, rather than collapsing to the patch closed state --- after
-which the completed corner cancels locally by its injectivity alone. The
+which the completed corner cancels locally by its injectivity alone.
+
+The open-boundary route factors into two engines, neither of which inverts
+$\mathrm{univ} \setminus S$. They are stated here with the machinery each needs.
+
+\emph{The corner-extension composition.} The open-boundary chaining needs the
+transitivity of the corner extension: for nested regions $R \subseteq S
+\subseteq P$ and an insert $C$ on $R$,
+\[
+  \path{extendInsert} (S \subseteq P)\,\bigl(\path{extendInsert} (R \subseteq
+  S)\, C\bigr) \;=\; \path{extendInsert} (R \subseteq P)\, C
+  \qquad\text{as inserts on } P.
+\]
+Each consecutive-window open-boundary equality lives on the union $U_j$;
+extending both sides through $\path{extendInsert}(U_j \subseteq P)$ and
+collapsing the composition by this transitivity chains the equalities into one
+patch-level insert equality. The identity is \emph{not} reducible to the
+assembled-state collapse \path{deformedRegionState_extend}: both sides have the
+same assembled state on $P$, but equal assembled states determine equal inserts
+only when $\mathrm{univ} \setminus P$ is injective, which fails at the minimal
+size. Stripping the inverse interior-bond multiplicities (the lemma
+\path{extendInsert_const_smul} commutes the rescaling through), the identity
+reduces to the \emph{bare} composition law
+\[
+  \path{bareExtendInsert} (S \subseteq P)\,\bigl(\path{bareExtendInsert} (R
+  \subseteq S)\, C\bigr) \;=\; \mathrm{ribp}(\mathrm{univ} \setminus S)\cdot
+  \path{bareExtendInsert} (R \subseteq P)\, C ,
+\]
+which is the blue-coupling composition of \path{ThreeBlockGeometry.threeBlockBlueCoeff}
+across the two nested geometries, glued along the $\mathrm{univ} \setminus S$
+cut. The product $\prod_{P \setminus R}$ splits as $\prod_{S \setminus R}
+\cdot \prod_{P \setminus S}$, and the intermediate sum over
+$\partial S$ glues the two global-configuration constrained sums along their
+agreeing $\mathrm{univ} \setminus S$ boundary, with fiber multiplicity
+$\mathrm{ribp}(\mathrm{univ} \setminus S)$. This is a four-block ($R$,
+$S \setminus R$, $P \setminus S$, $\mathrm{univ} \setminus P$) merge-and-count,
+beyond the existing three-block fiber tooling of
+\path{TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean}; it is the residual
+piece of the chaining.
+
+\emph{The shared-corner cancellation.} With the patch equality
+$\path{extendInsert} (W_0 \subseteq P)\, C_0 = \path{extendInsert} (W_{L+K-1}
+\subseteq P)\, C_{L+K-1}$ in hand, the corner cancellation is the injectivity of
+$\path{extendInsert} (S \subseteq R)$ on inserts on $S$, where $R = S \sqcup Q$
+and $Q = \path{horizontalStaircaseCompletedCorner}$ is the injective completed
+rectangle: extending the patch equality to $R$ (one more transitivity step
+through $P \subseteq R$, since $R = P \sqcup \text{added row}$) and cancelling
+the shared $Q$-block gives the end-pair equality. The cancellation needs
+\emph{only} $Q$ injective, never $\mathrm{univ} \setminus S$. For the nested
+geometry $\mathrm{red} = S$, $\mathrm{blue} = R \setminus S = Q$,
+$\mathrm{complement} = \mathrm{univ} \setminus R$, the corner-extended insert
+contracts the $S$-insert against $\path{ThreeBlockGeometry.threeBlockBlueCoeff}$;
+its $\sigma_{\mathrm{blue}}$-dependence is a combination of the $Q$ blocked
+weights, so $Q$ injectivity (the chosen left inverse
+\path{regionBlockedTensorMap_injective_of_injective} of the $Q$ block) reads off
+the coupling rows, and the host-boundary decomposition $\partial(\mathrm{univ}
+\setminus S) \hookrightarrow \partial Q \times \partial(\mathrm{univ}\setminus R)$
+extracts the $S$-insert coefficients. This is the dual of the blue-strip
+inversion \path{ThreeBlockGeometry.complCoeff_combination_eq_zero}: that lemma
+pushes a host annihilation through the blue block to a complement-coupling
+annihilation using $\mathrm{blue}$ injectivity; the cancellation here inverts in
+the host index using $Q$ injectivity alone, the weaker hypothesis the union
+lemma's two-step does not isolate. It needs the host-boundary-edge embedding and
+the $Q$-weight span lemma, neither yet landed.
+
+The mechanical, geometry-free pieces of the open-boundary route are in place:
+the linearity \path{bareExtendInsert_const_smul} and \path{extendInsert_const_smul}
+of the corner extension in its insert, and the sub-region restriction
+composition \path{restrictSubRegionσ_restrictSubRegionσ}, the leg identity behind
+the composition. They are in \path{TNLean/PEPS/TorusWindowChain3.lean}. The
 injectivity of the completed rectangle and the patch decomposition $P = S
 \sqcup \mathrm{corner}$ are in place
-(\path{TNLean/PEPS/TorusWindowChain.lean}); the open-boundary patch chaining
-and the corner cancellation engine are the pieces not yet landed.
+(\path{TNLean/PEPS/TorusWindowChain.lean}). The two fiber-gluing engines above ---
+the corner-extension composition and the shared-corner cancellation --- are the
+pieces not yet landed.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Faithful Step 3 of the 2D overlapping-window campaign (arXiv:1804.04964, the
corollary at lines 2297–2318). The closed-state route to the staircase end-pair
equality inherently needs `univ \ S` injectivity, which is false at minimal torus
size (PR #2751 verdict). The faithful route is open-boundary: cancel the shared
injective completed corner from an equality of inserts on the patch, never inverting
`univ \ S`.

This PR lands the geometry-free algebraic facts that route feeds on, and records the
two remaining fiber-gluing engines with precise statements and machinery requirements.

## What landed (`TNLean/PEPS/TorusWindowChain3.lean`, sorry-free)

- `bareExtendInsert_const_smul`, `extendInsert_const_smul` — linearity of the corner
  extension in its insert (commutes the bare/clean rescaling through any composition).
- `restrictSubRegionσ_restrictSubRegionσ` — the sub-region restriction composes, the
  leg identity behind the corner-extension composition.

`#print axioms`: `[propext, Classical.choice, Quot.sound]` (the restriction-composition
lemma needs only `[propext, Quot.sound]`).

## What did not land, and why (recorded in `peps_normal_ft_2d_overlap.tex`, Step 3)

Both open-boundary engines require new fiber machinery comparable to an entire
`UnionInjectivity*` file, beyond the existing three-block tooling:

1. **Corner-extension composition** `extendInsert (S⊆P) (extendInsert (R⊆S) C) =
   extendInsert (R⊆P) C`. The workhorse of the open-boundary patch chaining. It is
   *not* reducible to the assembled-state collapse `deformedRegionState_extend`: both
   sides have the same assembled state on `P`, but equal assembled states determine
   equal inserts only when `univ \ P` is injective (false at minimal size). Reduces to
   the bare blue-coupling composition law glued along the `univ \ S` cut — a four-block
   (`R`, `S\R`, `P\S`, `univ\P`) merge-and-count.

2. **Shared-corner cancellation** — injectivity of `extendInsert (S⊆R)` from injectivity
   of the added block `R\S = Q` alone (never `univ \ S`). The dual of
   `complCoeff_combination_eq_zero`: that lemma pushes a host annihilation through the
   blue block using blue injectivity; the cancellation inverts in the host index using
   `Q` injectivity alone, the weaker hypothesis the union lemma's two-step does not
   isolate. Needs the host-boundary-edge embedding and the `Q`-weight span lemma.

No `RegionBlockedTensorInjective (univ \ S)` hypothesis appears anywhere in the landed
work; the existing `staircasePair_insert_eq` (with that hypothesis) is unchanged.

## Checks

- Full root `lake build` green; `lake exe lint-style` exit 0.
- No blueprint entries. No sorry/axiom/maxHeartbeats. 100-char lines; file ≤ 1000 lines.

Documented in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3. Do not merge
without review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and small, local PEPS lemmas with no changes to authentication, data paths, or existing capstone APIs; `staircasePair_insert_eq` and complement-injectivity hypotheses are unchanged.
> 
> **Overview**
> Adds **`TNLean/PEPS/TorusWindowChain3.lean`** (wired into **`TNLean.lean`**) with sorry-free algebra for the faithful open-boundary Step 3 route: **`bareExtendInsert_const_smul`**, **`extendInsert_const_smul`**, and **`restrictSubRegionσ_restrictSubRegionσ`**.
> 
> **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** (Step 3) now spells out the two still-missing fiber engines—**corner-extension composition** and **shared-corner cancellation**—and points to the new file for the geometry-free pieces already in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9ea4dc6872a9f5047038e7ad223ba16ae47a4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->