### PR TITLE
feat(PEPS): corner-Q cancellation engine for the 2D staircase

### DIFF
--- a/TNLean/PEPS/TorusWindowChain5.lean
+++ b/TNLean/PEPS/TorusWindowChain5.lean
@@ -566,5 +566,117 @@ theorem extendInsert_cancel_addedInjective {R S : Finset V} (hRS : R ⊆ S)
   extendInsert_injective_of_kernel_trivial hRS
     (fun D hD => extendInsert_kernel_trivial_of_addedInjective hRS hadd hpos D hD) C₁ C₂ h
 
+/-! ### The staircase specialization
+
+On the discrete torus the staircase end pair `S` is completed to the region
+`R = S ∪ Q`, with `Q = horizontalStaircaseCompletedCorner` the injective `L × K` completed
+rectangle.  The completed corner is disjoint from the end pair (the left end window is below
+it by rows, the right end window beside it by columns), so `R \ S = Q`.  Cancelling the shared
+injective `Q` from an open-boundary equality of inserts on `R` therefore leaves the
+open-boundary equality on `S`, the note's Step 3 display.  The cancellation needs only
+injectivity of the completed corner, supplied by the window hypotheses.
+
+The open-boundary equality on `R` is taken as a hypothesis: it is produced by re-deriving the
+patch chaining of Step 2 at the open-boundary level (chaining the consecutive-window
+open-boundary equalities by `extendInsert_trans`), the separate residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.  This lemma is the cancellation that
+consumes that equality. -/
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+variable [Fact (1 < width)] [Fact (1 < height)]
+variable {L K : ℕ} {B : Tensor (torusGraph width height) d}
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The staircase end pair is disjoint from the completed corner rectangle: the left end
+window occupies the cyclic rows `[b, b + K)` below the corner's `[b + K, b + 2K)`, and the
+right end window the cyclic columns `[a + L, a + 2L)` beside the corner's `[a, a + L)`, all
+clear of the seam at `2L ≤ width`, `2K ≤ height`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 3. -/
+theorem horizontalStaircaseEndPair_disjoint_completedCorner {L K : ℕ}
+    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
+    Disjoint (horizontalStaircaseEndPair s L K)
+      (horizontalStaircaseCompletedCorner s L K) := by
+  rw [Finset.disjoint_left]
+  intro v hvS hvC
+  rw [horizontalStaircaseCompletedCorner, mem_torusArcRectangle] at hvC
+  simp only at hvC
+  obtain ⟨hvCx, hvCy⟩ := hvC
+  -- The completed corner's row distance shifts `s.2`'s by `K`.
+  rw [show (K : ZMod height) = ((K : ℕ) : ZMod height) by norm_cast,
+    zmod_val_sub_shift height v.2 s.2 K (by omega)] at hvCy
+  have hdy := ZMod.val_lt (v.2 - s.2)
+  rw [horizontalStaircaseEndPair, Finset.mem_union] at hvS
+  rcases hvS with hvL | hvR
+  · rw [horizontalStaircaseLeftWindow, mem_torusArcRectangle] at hvL
+    obtain ⟨_, hvLy⟩ := hvL
+    -- The left window has row distance `< K`; the completed corner's wraps and reaches `K`.
+    rw [if_pos (by omega : (v.2 - s.2).val < K)] at hvCy
+    omega
+  · rw [horizontalStaircaseRightWindow, mem_torusArcRectangle] at hvR
+    obtain ⟨hvRx, _⟩ := hvR
+    -- The right window has column distance `≥ L`; the completed corner has `< L`.
+    rw [show (L : ZMod width) = ((L : ℕ) : ZMod width) by norm_cast,
+      zmod_val_sub_shift width v.1 s.1 L (by omega)] at hvRx
+    have hdx := ZMod.val_lt (v.1 - s.1)
+    rw [if_pos (by omega : (v.1 - s.1).val < L)] at hvRx
+    omega
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The end pair is a subset of the completed region `S ∪ Q`. -/
+theorem horizontalStaircaseEndPair_subset_completedUnion (s : TorusVertex width height) :
+    horizontalStaircaseEndPair s L K ⊆
+      horizontalStaircaseEndPair s L K ∪ horizontalStaircaseCompletedCorner s L K :=
+  Finset.subset_union_left
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The added block of the completed region is the completed corner: `(S ∪ Q) \ S = Q`. -/
+theorem horizontalStaircaseCompletedUnion_sdiff_endPair {L K : ℕ}
+    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height) (s : TorusVertex width height) :
+    (horizontalStaircaseEndPair s L K ∪ horizontalStaircaseCompletedCorner s L K) \
+        horizontalStaircaseEndPair s L K =
+      horizontalStaircaseCompletedCorner s L K := by
+  rw [Finset.union_sdiff_left, Finset.sdiff_eq_self_of_disjoint
+    (horizontalStaircaseEndPair_disjoint_completedCorner hxw hyh s).symm]
+
+/-- **The staircase-pair cancellation (Step 3).**  Given the open-boundary equality of two
+inserts on the completed region `R = S ∪ Q` — extending the right and left end-window inserts
+through the completed corner — and the injectivity of the completed corner `Q`, the two
+corner-extended inserts agree already on the end pair `S`.  The completed corner is disjoint
+from the end pair (`horizontalStaircaseEndPair_disjoint_completedCorner`), so `R \ S = Q`; the
+shared-corner cancellation `extendInsert_cancel_addedInjective` then cancels the injective `Q`,
+needing only its injectivity and never that of `univ \ S`.
+
+The open-boundary equality on `R` is the hypothesis the open-boundary patch chaining of Step 2
+supplies (chaining the consecutive-window open-boundary equalities across the patch by
+`extendInsert_trans` and one more transitivity step through the completed corner), the residual
+recorded in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (add two-two tensors in the corner and invert);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3. -/
+theorem staircasePair_cancel {L K : ℕ} (s : TorusVertex width height)
+    (hxw : 2 * L ≤ width) (hyh : 2 * K ≤ height)
+    (hpos : ∀ eg : Edge (torusGraph width height), 0 < B.bondDim eg)
+    (hQ : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (horizontalStaircaseCompletedCorner s L K))
+    (X Y : RegionInsert (G := torusGraph width height) (d := d) B
+      (horizontalStaircaseEndPair s L K))
+    (h : extendInsert (G := torusGraph width height)
+        (horizontalStaircaseEndPair_subset_completedUnion (L := L) (K := K) s) X =
+      extendInsert (G := torusGraph width height)
+        (horizontalStaircaseEndPair_subset_completedUnion (L := L) (K := K) s) Y) :
+    X = Y :=
+  extendInsert_cancel_addedInjective
+    (horizontalStaircaseEndPair_subset_completedUnion (L := L) (K := K) s)
+    (by rw [horizontalStaircaseCompletedUnion_sdiff_endPair hxw hyh s]; exact hQ)
+    hpos X Y h
+
+end Torus
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowChain5.lean
+++ b/TNLean/PEPS/TorusWindowChain5.lean
@@ -23,11 +23,16 @@ the insert (on top of the homogeneity `extendInsert_const_smul` of
 `TNLean/PEPS/TorusWindowChain3.lean`); subtracting the two extensions of equal-extension
 inserts reduces the cancellation to the kernel of the corner extension.
 
-The remaining fiber-gluing engine the cancellation needs — that the corner extension's kernel
-is trivial when the added block `R \ S` is blocked-tensor injective, the *shared-corner
-cancellation* proper — is stated and scoped in
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3 (the `Q`-weight span lemma and the
-host-boundary-edge embedding).
+The fiber-gluing engine the cancellation needs — that the corner extension's kernel is
+trivial when the added block `R \ S` is blocked-tensor injective, the *shared-corner
+cancellation* proper — is the genuinely new content of this file.  Its `Q`-weight span half
+(the blue coupling, read on the `Q`-leg, lies in the range of the `Q` block) is combined with
+the `S ⊔ Q` assembly bridge (an insert on `R` reads its `S`- and `Q`-legs independently) and
+the host-boundary-edge embedding `regionBoundaryLabel_host_eq_hostLabelFrom` of
+`TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean` (a global configuration's host residual
+is determined by its `Q` and `univ \ R` residuals).  The result is the kernel triviality
+`extendInsert_kernel_trivial_of_addedInjective` and the cancellation
+`extendInsert_cancel_addedInjective`, needing only injectivity of `Q = R \ S`.
 
 ## References
 
@@ -264,6 +269,302 @@ theorem ThreeBlockGeometry.crossingBondProd_smul_threeBlockBlueCoeff_eq
     g.swapBlueComplement.blueRedCrossingBondProd_smul_threeBlockComplCoeff_eq
       bdry bc' σblue]
   rfl
+
+/-! ### The `S ⊔ Q` assembly bridge
+
+The corner extension `bareExtendInsert (R ⊆ S)` reads the insert's `R`-leg and the added
+block's `S \ R`-leg as the two restrictions `restrictSubRegionσ` of a physical configuration on
+`S`.  As that configuration ranges over `RegionPhysicalConfig S`, the pair of restricted legs
+ranges over all of `RegionPhysicalConfig R × RegionPhysicalConfig (S \ R)`, since `S` is the
+disjoint union of `R` and `S \ R`.  The assembly `assembleSubRegionσ` builds the joint
+configuration from the two independent legs; restricting it back recovers each leg.  This is
+the assembly bridge the kernel triviality consumes: it lets the `R`-leg and the added-block leg
+be fixed independently when reading off the corner extension. -/
+
+/-- The physical configuration on `S` assembled from an `R`-leg and a `(S \ R)`-leg, for
+`R ⊆ S`: a vertex of `S` lies in `R` (read the `R`-leg) or in `S \ R` (read the added-block
+leg).
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 3. -/
+def assembleSubRegionσ {R S : Finset V}
+    (σR : RegionPhysicalConfig (V := V) (d := d) R)
+    (σQ : RegionPhysicalConfig (V := V) (d := d) (S \ R)) :
+    RegionPhysicalConfig (V := V) (d := d) S :=
+  fun w => if hr : w.1 ∈ R then σR ⟨w.1, hr⟩ else σQ ⟨w.1, Finset.mem_sdiff.mpr ⟨w.2, hr⟩⟩
+
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- Restricting the assembled configuration to the sub-region `R` recovers the `R`-leg. -/
+@[simp] theorem restrictSubRegionσ_assembleSubRegionσ {R S : Finset V} (hRS : R ⊆ S)
+    (σR : RegionPhysicalConfig (V := V) (d := d) R)
+    (σQ : RegionPhysicalConfig (V := V) (d := d) (S \ R)) :
+    restrictSubRegionσ (V := V) (d := d) hRS (assembleSubRegionσ (V := V) σR σQ) = σR := by
+  funext w
+  rw [restrictSubRegionσ, assembleSubRegionσ, dif_pos w.2]
+
+omit [Fintype V] [DecidableRel G.Adj] in
+/-- Restricting the assembled configuration to the added block `S \ R` recovers the
+added-block leg.  Stated for an arbitrary `S \ R ⊆ S` subset witness so it matches the witness
+the corner extension carries. -/
+@[simp] theorem restrictSubRegionσ_sdiff_assembleSubRegionσ {R S : Finset V}
+    (hQS : S \ R ⊆ S)
+    (σR : RegionPhysicalConfig (V := V) (d := d) R)
+    (σQ : RegionPhysicalConfig (V := V) (d := d) (S \ R)) :
+    restrictSubRegionσ (V := V) (d := d) hQS
+        (assembleSubRegionσ (V := V) σR σQ) = σQ := by
+  funext w
+  have hnotR : w.1 ∉ R := (Finset.mem_sdiff.mp w.2).2
+  rw [restrictSubRegionσ, assembleSubRegionσ, dif_neg hnotR]
+
+/-! ### The kernel triviality of the corner extension from injectivity of the added block
+
+The genuinely new content: when the added block `S \ R = Q` is blocked-tensor injective, the
+corner extension `extendInsert (R ⊆ S)` has trivial kernel.  The argument is the source's
+two-step inverse application of Lemma `injective_union`, read with the inverted block taken to
+be `Q` in the host index, rather than the complement in the complement index.
+
+Fix the `R`-physical leg `σR`.  The kernel hypothesis, read through the assembly bridge at the
+joint configuration of `σR` and an arbitrary `Q`-leg `σblue`, makes the `c`-weighted blue
+coupling vanish for every `σblue` and every complement boundary configuration `bc'`, where
+`c bdry = C ((complement boundary equivalence).symm bdry) σR`.  The `Q`-weight span
+`crossingBondProd_smul_threeBlockBlueCoeff_eq` reads the blue coupling, on the `Q`-leg, as a
+combination of the `Q` blocked-region weights; injectivity of `Q` (the chosen left inverse of
+the `Q` block) then forces the `c`-weighted coupling indicators to vanish for every blue
+boundary configuration `bβ` and `bc'`.  Host-label surjectivity at positive bond dimensions and
+the host-residual identity `regionBoundaryLabel_host_eq_hostLabelFrom` extract `c bdry = 0` at
+every host residual realized by a global configuration, hence `C μ σR = 0` for every `μ`. -/
+
+open scoped Classical in
+/-- The kernel hypothesis, read through the assembly bridge at a fixed `R`-leg `σR`, makes the
+`c`-weighted blue coupling of the nested geometry vanish for every added-block leg `σblue` and
+every complement boundary configuration `bc'`.  Here `c bdry` is the insert coefficient at the
+`R`-boundary configuration that the complement boundary equivalence sends to `bdry`.
+
+The nested geometry's host `univ \ R = univ \ g.red` carries `bdry`, and reindexing the insert
+sum along the complement boundary equivalence presents the corner extension as the
+`c`-combination of the blue coupling.
+
+Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 3. -/
+theorem blueCoeff_combination_eq_zero_of_extendInsert_zero {R S : Finset V} (hRS : R ⊆ S)
+    (C : RegionInsert (G := G) (d := d) A R)
+    (hker : bareExtendInsert (G := G) hRS C = 0)
+    (σR : RegionPhysicalConfig (V := V) (d := d) R)
+    (σblue : RegionPhysicalConfig (V := V) (d := d) (S \ R))
+    (bc' : RegionBoundaryConfig (G := G) A (Finset.univ \ S)) :
+    ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ R),
+        C (regionComplementBoundaryConfigEquiv (G := G) A R |>.symm bdry) σR •
+          (nestedThreeBlockGeometry (V := V) hRS).threeBlockBlueCoeff bdry σblue bc' = 0 := by
+  classical
+  -- Read the kernel hypothesis at the assembled configuration and the complement boundary
+  -- configuration that the equivalence reaches.
+  have hval := congrFun (congrFun hker
+    (regionComplementBoundaryConfigEquiv (G := G) A S |>.symm bc'))
+    (assembleSubRegionσ (V := V) σR σblue)
+  rw [Pi.zero_apply, Pi.zero_apply, bareExtendInsert] at hval
+  -- The complement boundary configuration of `S` at the reached argument is `bc'`.
+  have hbc : regionComplementBoundaryConfig (G := G) A S
+      (regionComplementBoundaryConfigEquiv (G := G) A S |>.symm bc') = bc' := by
+    rw [← regionComplementBoundaryConfigEquiv_apply, Equiv.apply_symm_apply]
+  -- Reindex the `μ`-sum (over `∂R`) along the complement boundary equivalence to a `bdry`-sum,
+  -- then match each summand to the corresponding `hval` summand: the assembled legs restrict
+  -- back to `σR` and `σblue`, and the reached complement boundary is `bc'`.
+  rw [← Equiv.sum_comp (regionComplementBoundaryConfigEquiv (G := G) A R)
+      (fun bdry => C (regionComplementBoundaryConfigEquiv (G := G) A R |>.symm bdry) σR •
+        (nestedThreeBlockGeometry (V := V) hRS).threeBlockBlueCoeff bdry σblue bc')]
+  rw [← hval]
+  refine Finset.sum_congr rfl (fun μ _ => ?_)
+  rw [Equiv.symm_apply_apply, smul_eq_mul, hbc, regionComplementBoundaryConfigEquiv_apply]
+  -- The assembled legs restrict back to `σR` and `σblue`; the boundary residual matches.
+  have hlegR : restrictSubRegionσ (V := V) (d := d) hRS
+      (assembleSubRegionσ (V := V) σR σblue) = σR :=
+    restrictSubRegionσ_assembleSubRegionσ hRS σR σblue
+  have hlegQ : ∀ hQS : S \ R ⊆ S,
+      restrictSubRegionσ (V := V) (d := d) hQS
+        (assembleSubRegionσ (V := V) σR σblue) = σblue := by
+    intro hQS; funext w
+    have hnotR : w.1 ∉ R := (Finset.mem_sdiff.mp w.2).2
+    rw [restrictSubRegionσ, assembleSubRegionσ, dif_neg hnotR]
+  rw [hlegR]
+  congr 2
+  exact (hlegQ _).symm
+
+open scoped Classical in
+/-- **The kernel triviality of the corner extension.**  For nested regions `R ⊆ S`, if the
+added block `S \ R` is blocked-tensor injective and the bond dimensions are positive, then the
+only insert on `R` whose corner extension on `S` vanishes is the zero insert.
+
+Fixing the `R`-leg `σR`, the kernel makes the `c`-weighted blue coupling vanish for every
+`Q`-leg and complement boundary configuration
+(`blueCoeff_combination_eq_zero_of_extendInsert_zero`).
+The `Q`-weight span `crossingBondProd_smul_threeBlockBlueCoeff_eq` reads the blue coupling on
+the `Q`-leg as a `Q`-blocked combination; injectivity of `Q = g.blue` forces, for every blue and
+complement boundary configuration, the `c`-weighted realization indicator to vanish.  Host-label
+surjectivity (`exists_regionBoundaryLabel_host_eq`) and the host-residual identity
+(`regionBoundaryLabel_host_eq_hostLabelFrom`) then extract `c bdry = 0` at every realized host
+residual, so `C μ σR = 0` for every `μ`.  This needs only injectivity of `Q`, never of
+`univ \ R`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (add two-two tensors in the corner and invert);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3. -/
+theorem extendInsert_kernel_trivial_of_addedInjective {R S : Finset V} (hRS : R ⊆ S)
+    (hadd : RegionBlockedTensorInjective (G := G) A (S \ R))
+    (hpos : ∀ eg : Edge G, 0 < A.bondDim eg)
+    (C : RegionInsert (G := G) (d := d) A R)
+    (h : extendInsert (G := G) hRS C = 0) :
+    C = 0 := by
+  classical
+  set g := nestedThreeBlockGeometry (V := V) hRS with hg
+  -- The corner extension vanishes iff the bare extension vanishes (nonzero divisor).
+  have hbare : bareExtendInsert (G := G) hRS C = 0 := by
+    have hne : (regionInteriorBondProd (G := G) A (Finset.univ \ S) : ℂ) ≠ 0 :=
+      Nat.cast_ne_zero.mpr (regionInteriorBondProd_pos (G := G) A (Finset.univ \ S) hpos).ne'
+    funext ν σ
+    have := congrFun (congrFun h ν) σ
+    rw [Pi.zero_apply, Pi.zero_apply, extendInsert_eq_smul_bare, mul_eq_zero] at this
+    rw [Pi.zero_apply, Pi.zero_apply]
+    rcases this with hz | hz
+    · exact absurd (inv_eq_zero.mp hz) hne
+    · exact hz
+  -- Fix the `R`-leg; show the insert coefficient family at that leg is zero.
+  funext μ σR
+  rw [Pi.zero_apply, Pi.zero_apply]
+  -- The `c`-coefficient family indexed by the host residual of `g`.
+  set c : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red) → ℂ :=
+    fun bdry => C (regionComplementBoundaryConfigEquiv (G := G) A R |>.symm bdry) σR with hc
+  -- The blue coupling combination of `c` vanishes for every `Q`-leg and complement boundary.
+  have hblue : ∀ (σblue : RegionPhysicalConfig (V := V) (d := d) g.blue)
+      (bc' : RegionBoundaryConfig (G := G) A g.complement),
+      ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red),
+          c bdry • g.threeBlockBlueCoeff bdry σblue bc' = 0 := fun σblue bc' =>
+    blueCoeff_combination_eq_zero_of_extendInsert_zero hRS C hbare σR σblue bc'
+  -- The `Q`-weight span strips the blue block: for every blue boundary `bβ` and complement
+  -- boundary `bc'`, the `c`-weighted realization indicator vanishes.
+  have hrow : ∀ (bβ : RegionBoundaryConfig (G := G) A g.blue)
+      (bc' : RegionBoundaryConfig (G := G) A g.complement),
+      ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red),
+          c bdry •
+            (if ∃ q : VirtualConfig A,
+                regionBoundaryLabel (G := G) A (Finset.univ \ g.red) q = bdry ∧
+                  regionBoundaryLabel (G := G) A g.complement q = bc' ∧
+                    regionBoundaryLabel (G := G) A g.blue q = bβ
+              then (1 : ℂ) else 0) = 0 := by
+    intro bβ bc'
+    -- The `Q`-blocked map of the `c`-weighted indicator row is the crossing multiple of the
+    -- `c`-weighted blue coupling, which vanishes.
+    have hmap : regionBlockedTensorMap (G := G) A g.blue
+        (fun bβ' => ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red),
+          c bdry •
+            (if ∃ q : VirtualConfig A,
+                regionBoundaryLabel (G := G) A (Finset.univ \ g.red) q = bdry ∧
+                  regionBoundaryLabel (G := G) A g.complement q = bc' ∧
+                    regionBoundaryLabel (G := G) A g.blue q = bβ'
+              then (1 : ℂ) else 0)) = 0 := by
+      funext σblue
+      rw [regionBlockedTensorMap_apply, Pi.zero_apply]
+      -- Distribute each coefficient sum over the weight, then swap the summation order.
+      rw [Finset.sum_congr rfl (g := fun bβ' =>
+            ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red),
+              (c bdry •
+                  (if ∃ q : VirtualConfig A,
+                      regionBoundaryLabel (G := G) A (Finset.univ \ g.red) q = bdry ∧
+                        regionBoundaryLabel (G := G) A g.complement q = bc' ∧
+                          regionBoundaryLabel (G := G) A g.blue q = bβ'
+                    then (1 : ℂ) else 0)) •
+                regionBlockedWeight (G := G) A g.blue bβ' σblue)
+          (fun bβ' _ => Finset.sum_smul)]
+      rw [Finset.sum_comm]
+      rw [show (∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red),
+            ∑ bβ' : RegionBoundaryConfig (G := G) A g.blue,
+              (c bdry •
+                  (if ∃ q : VirtualConfig A,
+                      regionBoundaryLabel (G := G) A (Finset.univ \ g.red) q = bdry ∧
+                        regionBoundaryLabel (G := G) A g.complement q = bc' ∧
+                          regionBoundaryLabel (G := G) A g.blue q = bβ'
+                    then (1 : ℂ) else 0)) •
+                regionBlockedWeight (G := G) A g.blue bβ' σblue) =
+          ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red),
+            c bdry •
+              ((g.swapBlueComplement.blueRedCrossingBondProd A : ℂ) •
+                g.threeBlockBlueCoeff bdry σblue bc') from ?_]
+      · -- The `c`-combination of the crossing multiples of the blue coupling vanishes.
+        rw [Finset.sum_congr rfl (g := fun bdry =>
+              (g.swapBlueComplement.blueRedCrossingBondProd A : ℂ) •
+                (c bdry • g.threeBlockBlueCoeff bdry σblue bc'))
+            (fun bdry _ => smul_comm _ _ _),
+          ← Finset.smul_sum, hblue σblue bc', smul_zero]
+      · refine Finset.sum_congr rfl (fun bdry _ => ?_)
+        rw [g.crossingBondProd_smul_threeBlockBlueCoeff_eq bdry bc' σblue, Finset.smul_sum]
+        refine Finset.sum_congr rfl (fun bβ' _ => ?_)
+        rw [smul_assoc]
+    have := regionBlockedTensorMap_injective_of_injective (G := G) A g.blue hadd
+      (a₁ := fun bβ' => ∑ bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red),
+        c bdry •
+          (if ∃ q : VirtualConfig A,
+              regionBoundaryLabel (G := G) A (Finset.univ \ g.red) q = bdry ∧
+                regionBoundaryLabel (G := G) A g.complement q = bc' ∧
+                  regionBoundaryLabel (G := G) A g.blue q = bβ'
+            then (1 : ℂ) else 0))
+      (a₂ := 0) (by rw [hmap, map_zero])
+    exact congrFun this bβ
+  -- Extract `c` at the host residual realized by a global configuration carrying `μ`.
+  have hμ : c (regionComplementBoundaryConfig (G := G) A R μ) = C μ σR := by
+    rw [hc, ← regionComplementBoundaryConfigEquiv_apply]
+    simp only [Equiv.symm_apply_apply]
+  rw [← hμ]
+  -- Realize the host residual `complBdry R μ` by a global configuration `q`.
+  obtain ⟨q, hq⟩ := g.exists_regionBoundaryLabel_host_eq
+    (regionComplementBoundaryConfig (G := G) A R μ) hpos
+  -- Apply the vanishing indicator row at the blue and complement labels of `q`.
+  have hq0 := hrow (regionBoundaryLabel (G := G) A g.blue q)
+    (regionBoundaryLabel (G := G) A g.complement q)
+  rw [Finset.sum_eq_single (regionBoundaryLabel (G := G) A (Finset.univ \ g.red) q)] at hq0
+  · rw [if_pos ⟨q, rfl, rfl, rfl⟩, smul_eq_mul, mul_one] at hq0
+    rw [hq] at hq0; exact hq0
+  · intro bdry' _ hne
+    -- Any global configuration realizing `q`'s blue and complement labels has host residual
+    -- `host q`, so the indicator at `bdry' ≠ host q` is zero.
+    rw [if_neg ?_, smul_zero]
+    rintro ⟨q', hh', hc', hb'⟩
+    apply hne
+    have e1 := g.regionBoundaryLabel_host_eq_hostLabelFrom q'
+    have e2 := g.regionBoundaryLabel_host_eq_hostLabelFrom q
+    rw [hh', hb', hc'] at e1
+    rw [e2, ← e1]
+  · intro h'; exact absurd (Finset.mem_univ _) h'
+
+/-! ### The shared-corner cancellation
+
+With the kernel triviality and the additivity of the corner extension, two inserts on `R` whose
+corner extensions on `S` agree are equal, provided the added block `S \ R` is injective.  This
+is the open-boundary cancellation of Step 3 in its reusable generic form: cancel the injective
+added block from an equality of corner extensions, needing only that block's injectivity. -/
+
+/-- **The shared-corner cancellation.**  For nested regions `R ⊆ S` with the added block
+`S \ R` blocked-tensor injective and positive bond dimensions, two inserts on `R` whose corner
+extensions on `S` agree are equal.  The kernel triviality
+`extendInsert_kernel_trivial_of_addedInjective` and the difference law `extendInsert_sub` feed
+the kernel reduction `extendInsert_injective_of_kernel_trivial`.
+
+This cancels the injective added block `S \ R = Q` from an open-boundary equality of inserts,
+needing only injectivity of `Q` and never of `univ \ R`.  It is the reusable engine of Step 3's
+shared-corner cancellation, the obstruction recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (add two-two tensors in the corner and invert);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3. -/
+theorem extendInsert_cancel_addedInjective {R S : Finset V} (hRS : R ⊆ S)
+    (hadd : RegionBlockedTensorInjective (G := G) A (S \ R))
+    (hpos : ∀ eg : Edge G, 0 < A.bondDim eg)
+    (C₁ C₂ : RegionInsert (G := G) (d := d) A R)
+    (h : extendInsert (G := G) hRS C₁ = extendInsert (G := G) hRS C₂) :
+    C₁ = C₂ :=
+  extendInsert_injective_of_kernel_trivial hRS
+    (fun D hD => extendInsert_kernel_trivial_of_addedInjective hRS hadd hpos D hD) C₁ C₂ h
 
 end PEPS
 end TNLean

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -647,6 +647,31 @@ fiber-gluing engines above, the corner-extension composition is landed
 the single kernel-triviality identity --- whose $Q$-weight span half is landed, leaving
 the $S \sqcup Q$ assembly bridge and the host-boundary-edge embedding as the residual.
 
+The shared-corner cancellation is now landed in
+\path{TNLean/PEPS/TorusWindowChain5.lean}. The $S \sqcup Q$ assembly bridge is
+\path{assembleSubRegionσ} with its leg restrictions
+\path{restrictSubRegionσ_assembleSubRegionσ} and
+\path{restrictSubRegionσ_sdiff_assembleSubRegionσ}: a physical configuration on
+$R = S \sqcup Q$ reads its $S$- and $Q$-legs independently, so the corner extension's
+$S$-leg and $Q$-leg can be fixed independently. The host-boundary-edge embedding is the
+landed host-residual identity \path{ThreeBlockGeometry.regionBoundaryLabel_host_eq_hostLabelFrom},
+which determines a global configuration's host residual from its $Q$ and
+$\mathrm{univ} \setminus R$ residuals. The kernel triviality
+\path{extendInsert_kernel_trivial_of_addedInjective} fixes the $S$-leg, reads the kernel
+through the assembly bridge to make the host-residual-weighted blue coupling vanish at
+every $Q$-leg and complement boundary, strips the blue ($=Q$) block by the $Q$-weight span
+and $Q$ injectivity, and extracts the $S$-insert coefficients by host-label surjectivity at
+positive bond dimensions. The shared-corner cancellation is
+\path{extendInsert_cancel_addedInjective}: it cancels the injective added block $S \setminus R$
+from an equality of corner extensions, needing only that block's injectivity and never that
+of $\mathrm{univ} \setminus S$. Its staircase specialization \path{staircasePair_cancel}
+completes the end pair to $S \sqcup Q$ with $Q$ the completed corner (disjoint from the end
+pair by \path{horizontalStaircaseEndPair_disjoint_completedCorner}, so $R \setminus S = Q$)
+and consumes an open-boundary equality of the two end-window inserts on the completed region.
+That open-boundary equality --- re-deriving the patch chaining of Step~2 at the open-boundary
+level by chaining the consecutive-window equalities through \path{extendInsert_trans} ---
+remains the single residual of Step~3.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## Summary

Completes the **corner-Q cancellation engine** of the 2D overlapping-window campaign
(arXiv:1804.04964, the corollary at lines 2297–2318; gap note Step 3): cancelling an
injective *added* block `Q` from a corner-extension insert equality, needing **only**
`Q`'s injectivity, never `univ \ S` (which fails at the minimal torus size).

This discharges the residual recorded in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
Step 3 — the `S ⊔ Q` assembly bridge and the host-boundary-edge embedding — using the
already-landed `Q`-weight span and the host-residual identity of the union-injectivity layer.

All work is in `TNLean/PEPS/TorusWindowChain5.lean` (extended, 682 lines, under the cap) and
an append-only paragraph in the shared gap note.

## What lands

**The assembly bridge (a):** `assembleSubRegionσ` with leg restrictions
`restrictSubRegionσ_assembleSubRegionσ` and `restrictSubRegionσ_sdiff_assembleSubRegionσ` —
a physical configuration on `R = S ⊔ Q` reads its `S`- and `Q`-legs independently.

**The kernel triviality (the crux):** `extendInsert_kernel_trivial_of_addedInjective` —
when `Q = S \ R` is blocked-tensor injective, the only insert whose corner extension vanishes
is the zero insert. The proof fixes the `R`-leg, reads the kernel through the assembly bridge
to make the host-residual-weighted blue coupling vanish at every `Q`-leg and complement
boundary, strips the blue (= `Q`) block by the `Q`-weight span
`crossingBondProd_smul_threeBlockBlueCoeff_eq` and `Q` injectivity, and extracts the `S`-insert
coefficients via host-label surjectivity and the host-residual identity
`regionBoundaryLabel_host_eq_hostLabelFrom` — the host-boundary-edge embedding (b). This is the
source's two-step inverse application of Lemma `injective_union`, read with the inverted block
taken as `Q` in the host index rather than the complement in the complement index.

**The generic cancellation:** `extendInsert_cancel_addedInjective` — cancels the injective added
block from an open-boundary equality of corner extensions, via `extendInsert_sub` and the kernel
reduction. The reusable engine.

**The staircase specialization:** `staircasePair_cancel` — completes the end pair to `S ⊔ Q`
with `Q` the completed corner (disjoint from the end pair by
`horizontalStaircaseEndPair_disjoint_completedCorner`, so `R \ S = Q`) and cancels the injective
`Q` from an open-boundary equality of the two end-window inserts on the completed region.

## Residual

The open-boundary equality on `R` that `staircasePair_cancel` consumes — re-deriving the patch
chaining of Step 2 at the open-boundary level by chaining the consecutive-window equalities
through `extendInsert_trans` — remains the single residual of Step 3, recorded in the gap note.

## Integrity

- Sorry-free; no `maxHeartbeats`; no placeholder conclusions.
- `#print axioms extendInsert_cancel_addedInjective` (and the kernel triviality, the staircase
  specialization, the disjointness): `[propext, Classical.choice, Quot.sound]`.
- Full root `lake build` green (8915 jobs); `lake exe lint-style` exit 0.

Do not merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof surface (~400 new lines) in critical PEPS injectivity/cancellation logic; errors would undermine the 2D overlap campaign, though changes are sorry-free and build on existing lemmas.
> 
> **Overview**
> **Lands the shared-corner cancellation** for PEPS Step 3 in `TorusWindowChain5.lean`: when the added block `Q = S \ R` is blocked-tensor injective, equal corner extensions imply equal inserts, without assuming injectivity of `univ \ S`.
> 
> Adds **`assembleSubRegionσ`** and restriction lemmas so configurations on `R = S ⊔ Q` split into independent `S`- and `Q`-legs; **`blueCoeff_combination_eq_zero_of_extendInsert_zero`** feeds the kernel into vanishing blue-coupling combinations; **`extendInsert_kernel_trivial_of_addedInjective`** (via `Q`-weight span and `regionBoundaryLabel_host_eq_hostLabelFrom`) shows only the zero insert has vanishing corner extension; **`extendInsert_cancel_addedInjective`** is the reusable cancellation; on the torus, **`staircasePair_cancel`** plus disjointness/`(S∪Q)\S = Q` lemmas specialize to the completed corner.
> 
> The module header and **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** now record this engine as landed; **open-boundary patch chaining** on the completed region (Step 2 at insert level via `extendInsert_trans`) remains the sole Step 3 residual.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b882eddd751b58a1a10e83d1caab9a7f8183dbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->