### PR TITLE
feat(PEPS): single-crossing geometry of the staircase end pair

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -419,6 +419,7 @@ import TNLean.PEPS.TorusWindowChain3
 import TNLean.PEPS.TorusWindowChain4
 import TNLean.PEPS.TorusWindowChain5
 import TNLean.PEPS.TorusWindowChain6
+import TNLean.PEPS.TorusWindowExtraction
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusReferenceBlockingData

--- a/TNLean/PEPS/TorusWindowExtraction.lean
+++ b/TNLean/PEPS/TorusWindowExtraction.lean
@@ -229,6 +229,119 @@ theorem not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge
   · exact hout (hsubR hin2)
   · exact hout (hsubL hin1)
 
+/-! ### The boundary of the end pair splits into the windows' external legs
+
+Every boundary edge of an end window other than the reference edge `e` is a boundary edge of the
+end pair `S`.  Combined with the interiority of `e`, this exhibits the boundary `∂S` as the
+disjoint union of the external legs of the two windows, with `e` the single interior bond — the
+shared virtual leg the bond operator lives on.  The argument: a boundary edge `f ≠ e` of one
+window has its out-of-window endpoint outside the other window (else `f` would cross between the
+two windows, forcing `f = e` by the single-crossing characterization), hence outside `S`. -/
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The end pair contains the left window, so a vertex of the left window lies in `S`. -/
+private theorem mem_endPair_of_mem_leftWindow {L K : ℕ} {s : TorusVertex width height}
+    {v : TorusVertex width height} (hv : v ∈ horizontalStaircaseLeftWindow s L K) :
+    v ∈ horizontalStaircaseEndPair s L K :=
+  horizontalStaircaseLeftWindow_subset_endPair s hv
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The end pair contains the right window, so a vertex of the right window lies in `S`. -/
+private theorem mem_endPair_of_mem_rightWindow {L K : ℕ} {s : TorusVertex width height}
+    {v : TorusVertex width height} (hv : v ∈ horizontalStaircaseRightWindow s L K) :
+    v ∈ horizontalStaircaseEndPair s L K :=
+  horizontalStaircaseRightWindow_subset_endPair s hv
+
+/-- **A non-reference boundary edge of the left window is a boundary edge of the end pair.**
+
+A boundary edge `f` of the left end window with `f ≠ e` is a boundary edge of the end pair
+`S = W_0 ⊔ W_{L+K-1}`: its in-endpoint lies in the left window, hence in `S`, while its
+out-endpoint lies outside the left window and outside the right window — were it in the right
+window, `f` would cross between the two end windows and so equal `e` by
+`isCrossingEdge_horizontalStaircaseEndWindows`.  Thus the out-endpoint is outside `S`, and `f`
+is a boundary edge of `S`.  The left and right windows are disjoint at `2 * L ≤ width`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the external legs of the two windows are the boundary of
+the end pair); `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+theorem isRegionBoundaryEdge_endPair_of_leftWindow
+    (A : Tensor (torusGraph width height) d) {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    {f : Edge (torusGraph width height)}
+    (hf : IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) f)
+    (hfe : f ≠ horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseEndPair ((a : ZMod width), (b : ZMod height)) L K) f := by
+  -- `f` does not cross between the two end windows, since the unique crossing edge is `e`.
+  have hnotcross : ¬ IsCrossingEdge (G := torusGraph width height) A
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+      (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) f := fun hcross =>
+    hfe ((isCrossingEdge_horizontalStaircaseEndWindows A hL hK ha0 haw hbh f).mp hcross)
+  -- Hence `f` is not a boundary edge of the right window.
+  have hnotR : ¬ IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) f :=
+    fun hR => hnotcross ⟨hf, hR⟩
+  -- The two windows are disjoint.
+  have hdisj := horizontalStaircaseEndPair_disjoint (width := width) (height := height)
+    (L := L) (K := K) (by omega) ((a : ZMod width), (b : ZMod height))
+  rw [Finset.disjoint_left] at hdisj
+  rw [IsRegionBoundaryEdge] at hnotR
+  -- The in-endpoint of `f` lies in `S`; the out-endpoint lies outside both windows, so outside `S`.
+  rcases hf with ⟨hin, hout⟩ | ⟨hout, hin⟩
+  · -- `f.1.1 ∈ left ⊆ S`; `f.1.2 ∉ left`, and ∉ right else `f` crosses the windows.
+    refine Or.inl ⟨mem_endPair_of_mem_leftWindow hin, ?_⟩
+    rw [horizontalStaircaseEndPair, Finset.mem_union, not_or]
+    -- `f.1.1 ∉ right` by disjointness with the left window.
+    exact ⟨hout, fun hR => hnotR (Or.inr ⟨fun hc => hdisj hin hc, hR⟩)⟩
+  · -- `f.1.2 ∈ left ⊆ S`; `f.1.1 ∉ left`, and ∉ right by the same single-crossing argument.
+    refine Or.inr ⟨?_, mem_endPair_of_mem_leftWindow hin⟩
+    rw [horizontalStaircaseEndPair, Finset.mem_union, not_or]
+    exact ⟨hout, fun hR => hnotR (Or.inl ⟨hR, fun hc => hdisj hin hc⟩)⟩
+
+/-- **A non-reference boundary edge of the right window is a boundary edge of the end pair.**
+
+The transpose of `isRegionBoundaryEdge_endPair_of_leftWindow` with the roles of the two end
+windows exchanged: a boundary edge `f ≠ e` of the right end window is a boundary edge of the end
+pair, its out-endpoint lying outside the left window (else `f` would cross between the windows
+and equal `e`).
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 4. -/
+theorem isRegionBoundaryEdge_endPair_of_rightWindow
+    (A : Tensor (torusGraph width height) d) {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    {f : Edge (torusGraph width height)}
+    (hf : IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) f)
+    (hfe : f ≠ horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseEndPair ((a : ZMod width), (b : ZMod height)) L K) f := by
+  -- `f` does not cross between the two end windows, since the unique crossing edge is `e`.
+  have hnotcross : ¬ IsCrossingEdge (G := torusGraph width height) A
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+      (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) f := fun hcross =>
+    hfe ((isCrossingEdge_horizontalStaircaseEndWindows A hL hK ha0 haw hbh f).mp hcross)
+  -- Hence `f` is not a boundary edge of the left window.
+  have hnotL : ¬ IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) f :=
+    fun hLeft => hnotcross ⟨hLeft, hf⟩
+  -- The two windows are disjoint.
+  have hdisj := horizontalStaircaseEndPair_disjoint (width := width) (height := height)
+    (L := L) (K := K) (by omega) ((a : ZMod width), (b : ZMod height))
+  rw [Finset.disjoint_left] at hdisj
+  rw [IsRegionBoundaryEdge] at hnotL
+  rcases hf with ⟨hin, hout⟩ | ⟨hout, hin⟩
+  · refine Or.inl ⟨mem_endPair_of_mem_rightWindow hin, ?_⟩
+    rw [horizontalStaircaseEndPair, Finset.mem_union, not_or]
+    exact ⟨fun hL' => hnotL (Or.inr ⟨fun hc => hdisj hc hin, hL'⟩), hout⟩
+  · refine Or.inr ⟨?_, mem_endPair_of_mem_rightWindow hin⟩
+    rw [horizontalStaircaseEndPair, Finset.mem_union, not_or]
+    exact ⟨fun hL' => hnotL (Or.inl ⟨hL', fun hc => hdisj hc hin⟩), hout⟩
+
 end Torus
 
 end PEPS

--- a/TNLean/PEPS/TorusWindowExtraction.lean
+++ b/TNLean/PEPS/TorusWindowExtraction.lean
@@ -1,0 +1,235 @@
+import TNLean.PEPS.TorusWindowChain6
+
+/-!
+# The single-crossing geometry of the staircase end pair
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) closes its proof sketch with the single-crossing
+extraction (Step 4): the two end windows of the overlapping-window chain around a horizontal
+edge are diagonally offset `L × K` rectangles whose column ranges are disjoint and whose row
+ranges meet only at one row, so the *only* lattice edge joining them is the distinguished edge
+`e`.  The open-boundary end-pair equality `staircasePair_insert_eq_open` of
+`TNLean/PEPS/TorusWindowChain6.lean` is therefore a pairing of two injective tensors across the
+single bond `e`, the geometry that makes the extracted bond operator live on one edge.
+
+This file lifts the single-crossing characterization `isCrossingEdge_horizontalStaircase` of
+`TNLean/PEPS/TorusWindowRegion.lean` from the abstract coordinate rectangles to the actual end
+windows of the staircase family — `horizontalStaircaseLeftWindow` (the last window
+`W_{L+K-1}`) and `horizontalStaircaseRightWindow` (the first window `W_0`) — and records the
+two boundary facts the extraction rests on:
+
+* the distinguished edge `e = horizontalStaircaseReferenceEdge` is the unique crossing edge
+  between the two end windows (`isCrossingEdge_horizontalStaircaseEndWindows`), hence a boundary
+  edge of each (`isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge`,
+  `isRegionBoundaryEdge_horizontalStaircaseRightWindow_referenceEdge`);
+* `e` is *not* a boundary edge of the end pair `S = W_0 ⊔ W_{L+K-1}`
+  (`not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge`): both its endpoints lie
+  in `S`, one in each window, so `e` is the single interior bond of `S` summed over when the
+  two windows are contracted together.
+
+The single crossing means that in the end-pair contraction the bond `e` is the only virtual
+leg shared by the two windows; every other open leg of each window crosses the boundary of `S`.
+This is the geometric content of the source's "the comparison of the first and the last window"
+and the reason the matrix extracted by the standard two-sided argument lives on the one bond
+`e` (arXiv:1804.04964, the matrix-level extraction
+`MPSChainTensor.exists_bondOperator_of_intertwine_span` after `eq:inj_O->X_argument`, line 377
+of `Papers/1804.04964/paper_normal.tex`).
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
+  2296--2445 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+variable [Fact (1 < width)] [Fact (1 < height)]
+variable {d : ℕ}
+
+/-! ### The distinguished edge of the staircase end pair
+
+The reference edge of the horizontal staircase is the right edge at the top-right corner of the
+left end window, equivalently the bottom-left corner of the right end window: the unique lattice
+edge joining the two end windows. -/
+
+/-- The distinguished edge `e` of the horizontal staircase end pair around the staircase corner
+`s = (a, b)`: the right edge at `(a + L - 1, b + K - 1)`, joining the left end window
+`[a, a + L) × [b, b + K)` to the right end window `[a + L, a + 2L) × [b + K - 1, b + 2K - 1)`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the highlighted edge of the window chain);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+def horizontalStaircaseReferenceEdge (s : TorusVertex width height) (L K : ℕ) :
+    Edge (torusGraph width height) :=
+  torusRightEdge ((s.1 + ((L - 1 : ℕ) : ZMod width)), (s.2 + ((K - 1 : ℕ) : ZMod height)))
+
+/-! ### The single crossing of the end windows
+
+The left and right end windows are the coordinate rectangles of
+`isCrossingEdge_horizontalStaircase` once the staircase corner is read with natural-number
+coordinates and the no-wraparound bounds hold.  The lift identifies the two `torusArcRectangle`
+windows with the lemma's `torusContiguousRectangle` rectangles and the reference edge with the
+lemma's distinguished edge. -/
+
+/-- **The single crossing of the staircase end windows.**
+
+For a staircase corner `s = ((a : ZMod width), (b : ZMod height))` with `1 ≤ a` and the
+no-wraparound bounds `a + 2 * L ≤ width`, `b + 2 * K - 1 ≤ height`, the only lattice edge
+joining the left end window `horizontalStaircaseLeftWindow` and the right end window
+`horizontalStaircaseRightWindow` is the reference edge `horizontalStaircaseReferenceEdge`.  This
+is `isCrossingEdge_horizontalStaircase` of `TNLean/PEPS/TorusWindowRegion.lean` read on the
+actual end windows: the two `torusArcRectangle` windows are the lemma's coordinate rectangles
+(`torusArcRectangle_eq_torusContiguousRectangle`), and the reference edge is the lemma's
+distinguished edge.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the comparison of the first and the last window);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+theorem isCrossingEdge_horizontalStaircaseEndWindows
+    (A : Tensor (torusGraph width height) d) {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (g : Edge (torusGraph width height)) :
+    IsCrossingEdge (G := torusGraph width height) A
+        (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+        (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) g ↔
+      g = horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K := by
+  -- Identify the two end windows with the lemma's coordinate rectangles.
+  have hleft : horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K =
+      torusContiguousRectangle a b L K := by
+    rw [horizontalStaircaseLeftWindow,
+      torusArcRectangle_eq_torusContiguousRectangle a b L K hL hK (by omega) (by omega)]
+  have hright : horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K =
+      torusContiguousRectangle (a + L) (b + K - 1) L K := by
+    rw [horizontalStaircaseRightWindow]
+    -- The right window start is the cast of the natural-number coordinates `(a + L, b + K - 1)`.
+    have hx : ((a : ZMod width) + (L : ZMod width)) = ((a + L : ℕ) : ZMod width) := by
+      push_cast; ring
+    have hy : ((b : ZMod height) + ((K - 1 : ℕ) : ZMod height)) =
+        ((b + K - 1 : ℕ) : ZMod height) := by
+      rw [show b + K - 1 = b + (K - 1) by omega]; push_cast; ring
+    simp only at hx hy ⊢
+    rw [hx, hy,
+      torusArcRectangle_eq_torusContiguousRectangle (a + L) (b + K - 1) L K hL hK
+        (by omega) (by omega)]
+  -- Identify the reference edge with the lemma's distinguished edge.
+  have hedge : horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K =
+      torusRightEdge (((a + L - 1 : ℕ) : ZMod width), ((b + K - 1 : ℕ) : ZMod height)) := by
+    rw [horizontalStaircaseReferenceEdge]
+    congr 2
+    · rw [show a + L - 1 = a + (L - 1) by omega]; push_cast; ring
+    · rw [show b + K - 1 = b + (K - 1) by omega]; push_cast; ring
+  rw [hleft, hright, hedge]
+  exact isCrossingEdge_horizontalStaircase A hL hK ha0 haw hbh g
+
+/-- The reference edge is a boundary edge of the left end window: it is the unique crossing edge
+of the two end windows, hence a boundary edge of the left window.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 4. -/
+theorem isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge
+    (A : Tensor (torusGraph width height) d) {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) :=
+  ((isCrossingEdge_horizontalStaircaseEndWindows A hL hK ha0 haw hbh _).mpr rfl).1
+
+/-- The reference edge is a boundary edge of the right end window.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 4. -/
+theorem isRegionBoundaryEdge_horizontalStaircaseRightWindow_referenceEdge
+    (A : Tensor (torusGraph width height) d) {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K)
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) :=
+  ((isCrossingEdge_horizontalStaircaseEndWindows A hL hK ha0 haw hbh _).mpr rfl).2
+
+/-! ### The reference edge is interior to the end pair
+
+The reference edge has one endpoint in each end window, so both endpoints lie in the end pair
+`S = W_0 ⊔ W_{L+K-1}`.  An edge with both endpoints in a region is not a boundary edge of that
+region: `e` is the single interior bond of `S`, the bond summed over when the two windows are
+contracted together.  This is what distinguishes the single-crossing pairing from the
+complement inversions of the earlier steps — the only virtual leg shared by the two windows is
+`e`, every other open leg crossing the boundary of `S`. -/
+
+/-- **The reference edge is interior to the end pair.**
+
+The reference edge `e` is *not* a boundary edge of the staircase end pair
+`S = horizontalStaircaseEndPair`: it crosses between the two end windows
+(`isCrossingEdge_horizontalStaircaseEndWindows`), so each endpoint lies in one of the windows,
+hence in `S`.  An edge with both endpoints in `S` is not a boundary edge of `S`.  Thus `e` is
+the single interior bond of `S`, summed over in the end-pair contraction.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the single bond `e` joining the two windows);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+theorem not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge
+    {L K a b : ℕ} (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height) :
+    ¬ IsRegionBoundaryEdge (G := torusGraph width height)
+        (horizontalStaircaseEndPair ((a : ZMod width), (b : ZMod height)) L K)
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) := by
+  set e := horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K with he
+  -- The end pair contains each end window.
+  have hsubL : horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K ⊆
+      horizontalStaircaseEndPair ((a : ZMod width), (b : ZMod height)) L K :=
+    horizontalStaircaseLeftWindow_subset_endPair _
+  have hsubR : horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K ⊆
+      horizontalStaircaseEndPair ((a : ZMod width), (b : ZMod height)) L K :=
+    horizontalStaircaseRightWindow_subset_endPair _
+  -- The two endpoints of `e`: the lower one in the left window, the upper one in the right.
+  have hep := torusRightEdge_endpoints_of_lt
+    (p := ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width), (b : ZMod height) +
+      ((K - 1 : ℕ) : ZMod height)))
+    (width := width) (height := height)
+    (by rw [show (a : ZMod width) + ((L - 1 : ℕ) : ZMod width) = ((a + L - 1 : ℕ) : ZMod width)
+          by rw [show a + L - 1 = a + (L - 1) by omega]; push_cast; ring,
+        ZMod.val_natCast_of_lt (by omega)]; omega)
+  -- The lower endpoint `e.1.1 = (a + L - 1, b + K - 1)` lies in the left window.
+  have hin1 : e.1.1 ∈ horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K := by
+    rw [he, horizontalStaircaseReferenceEdge, hep.1, horizontalStaircaseLeftWindow,
+      mem_torusArcRectangle]
+    refine ⟨?_, ?_⟩
+    · rw [add_sub_cancel_left, ZMod.val_natCast_of_lt (by omega)]; omega
+    · rw [add_sub_cancel_left, ZMod.val_natCast_of_lt (by omega)]; omega
+  -- The upper endpoint `e.1.2 = (a + L, b + K - 1)` lies in the right window.
+  have hin2 : e.1.2 ∈ horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K := by
+    rw [he, horizontalStaircaseReferenceEdge, hep.2, horizontalStaircaseRightWindow,
+      mem_torusArcRectangle]
+    refine ⟨?_, ?_⟩
+    · -- The horizontal distance from the right window's start `a + L` is `0`.
+      have hLcast : ((L - 1 : ℕ) : ZMod width) + 1 = (L : ZMod width) := by
+        rw [show (L : ZMod width) = ((L - 1 + 1 : ℕ) : ZMod width) by congr 1; omega]
+        push_cast; ring
+      rw [show ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width) + 1) - ((a : ZMod width) +
+            (L : ZMod width)) = (0 : ZMod width) by rw [← hLcast]; ring,
+        ZMod.val_zero]; omega
+    · -- The vertical distance from the right window's start `b + K - 1` is `0`.
+      rw [show ((b : ZMod height) + ((K - 1 : ℕ) : ZMod height)) - ((b : ZMod height) +
+            ((K - 1 : ℕ) : ZMod height)) = (0 : ZMod height) by ring, ZMod.val_zero]; omega
+  -- An edge with both endpoints in `S` is not a boundary edge of `S`.
+  rintro (⟨_, hout⟩ | ⟨hout, _⟩)
+  · exact hout (hsubR hin2)
+  · exact hout (hsubL hin1)
+
+end Torus
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -280,6 +280,69 @@ produces the unique matrix $X$ on $e$ with the two factorizations. This
 single-crossing geometry is the reason the extracted operator lives on
 one edge: no multi-edge cut is ever inverted across.
 
+\medskip
+\noindent\textbf{The single-crossing geometry, formalized at the end-pair
+boundary level.} The geometric core of Step~4 is in
+\path{TNLean/PEPS/TorusWindowExtraction.lean}: the reference edge $e$ is the
+unique lattice edge joining the two end windows
+(\path{isCrossingEdge_horizontalStaircaseEndWindows}, lifting the abstract
+\path{isCrossingEdge_horizontalStaircase} to the actual
+\path{horizontalStaircaseLeftWindow} and \path{horizontalStaircaseRightWindow}),
+hence a boundary edge of each window
+(\path{isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge} and
+its right counterpart) but \emph{not} of the end pair
+$S = W_0 \sqcup W_{L+K-1}$
+(\path{not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge}):
+both endpoints of $e$ lie in $S$, one in each window, so $e$ is the single
+interior bond of $S$. Every other boundary edge of either window is a boundary
+edge of $S$
+(\path{isRegionBoundaryEdge_endPair_of_leftWindow} and its right counterpart),
+so the boundary $\partial S$ is the disjoint union of the two windows' external
+legs with $e$ the only shared interior bond. This is the geometric data the
+bond-operator extraction consumes.
+
+\medskip
+\noindent\textbf{The matrix-intertwining route does not apply per window in
+two dimensions.} The footnoted matrix-level form
+\leanid{MPSChainTensor.exists_bondOperator_of_intertwine_span} extracts $X$
+from spanning families $W_1, W_2$ of \emph{square} matrices
+$\mathrm{Mat}_{D}$ with $F\,a \cdot W_2\,b = W_1\,a \cdot G\,b$. In the
+one-dimensional chain it applies directly because a length-$L$ window has two
+virtual legs --- a left bond and a right bond, both of dimension $D$ --- so the
+window product $\path{arcEval}\,A\,r\,(\mathrm{ofFn}\,a)$ and the deformed
+window $C\,0\,a$ are themselves $D \times D$ matrices. In two dimensions a
+single end window touches the bond $e$ with \emph{one} endpoint, so the
+$e$-leg is a single $\mathrm{Fin}(\mathrm{bondDim}\,e)$ index, not a pair: a
+window block read at fixed external legs and physical configuration is a
+\emph{vector} on $\mathrm{Fin}(\mathrm{bondDim}\,e)$, not a square matrix. The
+two indices of the extracted $X(i,j)$ are the $e$-leg of $W_0$ (one) and the
+$e$-leg of $W_{L+K-1}$ (the other); neither window alone supplies a square
+matrix family, and folding a window's external perimeter into a second
+$\mathrm{Fin}(\mathrm{bondDim}\,e)$ index would require
+$\prod_{\text{external legs}} \mathrm{bondDim} = \mathrm{bondDim}\,e$, false in
+general. So \path{exists_bondOperator_of_intertwine_span} cannot be fed from
+per-window blocks.
+
+The faithful two-dimensional extraction is the single-crossing
+algebra-isomorphism route the torus Theorem~3 development already uses
+(\path{exists_regionEdgeGauge_of_blockingData} of
+\path{TNLean/PEPS/CoherentFrameInstance2.lean}): the region-inserted
+coefficient \path{regionInsertedCoeff} inserts a matrix on the single boundary
+edge $e$ and contracts the red block against the host, and Skolem--Noether
+(\path{edgeGaugeFromInsertionAlgebraIsomorphism}) turns the resulting algebra
+isomorphism into conjugation by an invertible edge matrix $Z$. The Theorem~3
+engine inverts the \emph{host} $\mathrm{univ} \setminus \mathrm{red}$ (its
+hypothesis \path{hCB}), which the corollary's minimal size does not provide; the
+overlapping-window replacement plays the second end window $W_{L+K-1}$ in the
+host's role, inverting only the two injective windows. Reaching $X$ from the
+end-pair equality \path{staircasePair_insert_eq_open} therefore needs the
+$\path{extendInsert}\,(W_0 \subseteq S)$-to-single-bond-$e$ peeling: reading the
+corner extension on $S$ as a $\path{regionInsertedCoeff}$-style contraction of
+$C_0$ against the genuine $W_{L+K-1}$ block across $e$. That peeling is the
+host-boundary-edge embedding and the $Q$-weight span lemma recorded as the
+unbuilt residual at the close of the previous section; the single-crossing
+geometry above is the prerequisite it consumes, and is now in place.
+
 \subsection{Step 5: the rest of the proof}
 
 With the per-edge extraction in place, the remainder is, as the source


### PR DESCRIPTION
## Summary

Layer 4b of the 2D overlapping-window campaign (arXiv:1804.04964 corollary, lines 2297–2318): the single-crossing geometry that underlies the Step-4 bond extraction. This lands the geometric foundation of the extraction and records the precise structural scoping of the bond-operator step in the gap note.

Input: the hcompl-free open-boundary end-pair equality `staircasePair_insert_eq_open` (TorusWindowChain6, #2765), an equality of `RegionInsert` objects on the staircase end pair `S = W₀ ⊔ W_{L+K-1}`.

## What lands (`TNLean/PEPS/TorusWindowExtraction.lean`, sorry-free)

The single-crossing structure of the end pair, lifted from the abstract `isCrossingEdge_horizontalStaircase` to the actual end windows:

- `isCrossingEdge_horizontalStaircaseEndWindows` — the reference edge `e` is the unique lattice edge joining `horizontalStaircaseLeftWindow` and `horizontalStaircaseRightWindow`.
- `isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge` / `…RightWindow…` — `e` is a boundary edge of each end window.
- `not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge` — `e` is **not** a boundary edge of `S`: both its endpoints lie in `S`, one per window, so `e` is the single interior bond of `S`.
- `isRegionBoundaryEdge_endPair_of_leftWindow` / `…rightWindow…` — every boundary edge of an end window other than `e` is a boundary edge of `S`. So `∂S` is the disjoint union of the two windows' external legs with `e` the only shared interior bond.

All depend exactly on `[propext, Classical.choice, Quot.sound]`.

## Phase-0 scoping (recorded in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4)

The bond-operator extraction `exists_bondOperator_of_intertwine_span` (the footnoted matrix-level form) does **not** apply per window in 2D. In 1D a window has two virtual legs (left/right bond), so its product is a square `D×D` matrix and the lemma applies directly. In 2D a single end window touches the bond `e` with one endpoint, so the `e`-leg is a single index: a window block at fixed external legs is a *vector* on `Fin (bondDim e)`, not a square matrix. The two indices of the extracted `X(i,j)` are the `e`-leg of `W₀` and the `e`-leg of `W_{L+K-1}`; neither window alone supplies a square matrix family.

The faithful 2D route is the single-crossing algebra-isomorphism route the torus Theorem-3 development already uses (`exists_regionEdgeGauge_of_blockingData` + Skolem–Noether `edgeGaugeFromInsertionAlgebraIsomorphism`), with the second end window playing the host's role (the Theorem-3 engine's host injectivity `hCB` is exactly what the minimal size denies). Reaching `X` from `staircasePair_insert_eq_open` needs the `extendInsert (W₀ ⊆ S)`→single-bond-`e` peeling — the host-boundary-edge embedding and `Q`-weight span lemma already recorded as the unbuilt residual. The single-crossing geometry landed here is the prerequisite that peeling consumes.

`exists_staircaseBondOperator` is therefore **not** closed in this PR; the geometric foundation it rests on is, and the wall is documented in mathematical terms.

## Checks
- Full root `lake build` green.
- `lake exe lint-style` exit 0.
- No blueprint entries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New sorry-free PEPS geometry lemmas and documentation only; no changes to auth, runtime behavior, or existing theorem APIs beyond a new public import.
> 
> **Overview**
> Adds **`TNLean/PEPS/TorusWindowExtraction.lean`** (wired into the root import list) and formalizes Step 4’s **single-crossing** picture for the horizontal staircase end pair **S = W₀ ⊔ W_{L+K−1}**.
> 
> The new module defines **`horizontalStaircaseReferenceEdge`** and proves that **`e`** is the **only** edge between the left/right end windows (**`isCrossingEdge_horizontalStaircaseEndWindows`**, by lifting **`isCrossingEdge_horizontalStaircase`**), is a **boundary** edge of each window but **not** of **S** (**`not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge`**), and that every other window boundary edge lies on **∂S** (**`isRegionBoundaryEdge_endPair_of_leftWindow`** / right). That pins **`e`** as the sole interior bond for end-pair contraction.
> 
> **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** (Step 4) now points at these lemmas and records that **`exists_bondOperator_of_intertwine_span`** does not apply per-window in 2D; the intended route is the existing region insertion / Skolem–Noether machinery, with bond extraction still downstream of **`staircasePair_insert_eq_open`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47aa338bdb1c7d8f8d6421c9c7b005c60f81931c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->