### PR TITLE
doc(peps): record corner cancellation blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -448,7 +448,6 @@
     \label{def:peps_corner_extension}
     \lean{TNLean.PEPS.bareExtendInsert}
     \lean{TNLean.PEPS.extendInsert}
-    \lean{TNLean.PEPS.deformedRegionState_extend}
     \leanok
     \uses{def:peps_regionInjectivityData}
     Let $R\subseteq S$ be regions in a finite graph, and let $C$ be a region
@@ -465,17 +464,24 @@
         \Phi_{R,S}\bigl(\mu,\sigma|_{S\setminus R},\nu\bigr),
     \]
     where $P_{V\setminus S}$ is the product of interior bond dimensions in
-    $V\setminus S$.  At positive bond dimensions, this extension preserves the
-    deformed region state:
+    $V\setminus S$.  This is the open-boundary form of the extension used in
+    the overlapping-window proof sketch of
+    \cite[Section~3]{Molnar2018NormalPEPS}.
+\end{definition}
+
+\begin{lemma}[State preservation under corner extension]
+    \label{lem:peps_corner_extension_state_preserves}
+    \lean{TNLean.PEPS.deformedRegionState_extend}
+    \leanok
+    \uses{def:peps_corner_extension}
+    If all bond dimensions are positive, then corner extension from
+    $R\subseteq S$ preserves the deformed region state:
     \[
         \Psi_{A,R,C}
         =
         \Psi_{A,S,\operatorname{Ext}_{R\subseteq S}(C)}.
     \]
-    This is the open-boundary form of the extension used in the
-    overlapping-window proof sketch of
-    \cite[Section~3]{Molnar2018NormalPEPS}.
-\end{definition}
+\end{lemma}
 
 \begin{lemma}[Linearity and transitivity of corner extension]
     \label{lem:peps_corner_extension_linear_transitive}
@@ -529,8 +535,6 @@
 \begin{definition}[Assembly of subregion physical configurations]
     \label{def:peps_assemble_subregion_physical_config}
     \lean{TNLean.PEPS.assembleSubRegionσ}
-    \lean{TNLean.PEPS.restrictSubRegionσ_assembleSubRegionσ}
-    \lean{TNLean.PEPS.restrictSubRegionσ_sdiff_assembleSubRegionσ}
     \leanok
     If $R\subseteq S$, a physical configuration on $R$ and a physical
     configuration on $S\setminus R$ assemble to a physical configuration on
@@ -543,20 +547,29 @@
         \sigma_Q(v), & v\in S\setminus R.
         \end{cases}
     \]
+\end{definition}
+
+\begin{lemma}[Restrictions of assembled subregion configurations]
+    \label{lem:peps_assemble_subregion_physical_config_restricts}
+    \lean{TNLean.PEPS.restrictSubRegionσ_assembleSubRegionσ}
+    \lean{TNLean.PEPS.restrictSubRegionσ_sdiff_assembleSubRegionσ}
+    \leanok
+    \uses{def:peps_assemble_subregion_physical_config}
     The two restrictions recover the original configurations:
     \[
         \operatorname{As}_{R,S}(\sigma_R,\sigma_Q)|_R=\sigma_R,
         \qquad
         \operatorname{As}_{R,S}(\sigma_R,\sigma_Q)|_{S\setminus R}=\sigma_Q.
     \]
-\end{definition}
+\end{lemma}
 
 \begin{theorem}[Kernel triviality of corner extension from the added block]
     \label{thm:peps_extend_insert_kernel_trivial_added_injective}
     \lean{TNLean.PEPS.extendInsert_kernel_trivial_of_addedInjective}
     \leanok
     \uses{def:peps_corner_extension,
-        def:peps_assemble_subregion_physical_config}
+        def:peps_assemble_subregion_physical_config,
+        lem:peps_assemble_subregion_physical_config_restricts}
     Let $R\subseteq S$ be finite regions.  Suppose that all bond dimensions are
     positive and that the added block $Q=S\setminus R$ is blocked-tensor
     injective.  If a region insert $C$ on $R$ has zero corner extension,
@@ -575,11 +588,14 @@
         \sum_{\mu\in\partial R}
         c_\mu\,\Phi_{R,S}(\mu,\sigma_Q,\nu)=0.
     \]
-    The coefficient $\Phi_{R,S}$ is a linear combination of blocked weights of
-    $Q$.  Since $Q$ is injective, applying a left inverse for its blocked tensor
-    forces the corresponding boundary coefficients to vanish.  Positivity of
-    bond dimensions realizes every host boundary configuration, so
-    $c_\mu=0$ for every $\mu$.  Since $\sigma_R$ was arbitrary, $C=0$.
+    For each boundary value $\nu$, let $f_\nu$ be the coefficient row obtained
+    from the left-hand side as a function of the boundary of $Q$.  The blocked
+    tensor of $Q$ sends this row to zero, so injectivity gives
+    \[
+        T_Q(f_\nu)=0 \Longrightarrow f_\nu=0.
+    \]
+    Positivity of bond dimensions realizes every host boundary configuration,
+    hence $c_\mu=0$ for every $\mu$.  Since $\sigma_R$ was arbitrary, $C=0$.
 \end{proof}
 
 \begin{theorem}[Cancellation of a shared injective corner]
@@ -614,12 +630,14 @@
     \lean{TNLean.PEPS.staircasePair_cancel}
     \leanok
     \uses{thm:peps_extend_insert_cancel_added_injective}
-    Let $S$ be the staircase end pair around a horizontal edge of the torus,
-    and let $Q$ be the completed corner rectangle.  Assume that $Q$ is
-    blocked-tensor injective, all bond dimensions are positive, and
+    Let the torus have width $W$ and height $H$.  Let $S$ be the staircase end
+    pair around a horizontal edge, with seam dimensions $L$ and $K$, and let
+    $Q$ be the completed corner rectangle.  Assume the size bounds
     \[
-        (S\cup Q)\setminus S=Q.
+        2L\le W,\qquad 2K\le H,
     \]
+    that $Q$ is blocked-tensor injective, and that all bond dimensions are
+    positive.
     If two inserts $X$ and $Y$ on $S$ have equal extensions to $S\cup Q$,
     \[
         \operatorname{Ext}_{S\subseteq S\cup Q}(X)
@@ -632,8 +650,12 @@
 \end{theorem}
 \begin{proof}
     \leanok
-    The staircase end pair is disjoint from the completed corner at the
-    required torus sizes, so $(S\cup Q)\setminus S=Q$.  The claimed equality is
-    exactly Theorem~\ref{thm:peps_extend_insert_cancel_added_injective} applied
-    to the inclusion $S\subseteq S\cup Q$.
+    The size bounds imply that the staircase end pair is disjoint from the
+    completed corner, and therefore
+    \[
+        (S\cup Q)\setminus S=Q.
+    \]
+    The claimed equality is exactly
+    Theorem~\ref{thm:peps_extend_insert_cancel_added_injective} applied to the
+    inclusion $S\subseteq S\cup Q$.
 \end{proof}

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -453,8 +453,15 @@
     Let $R\subseteq S$ be regions in a finite graph, and let $C$ be a region
     insert on $R$.  Write $\Phi_{R,S}$ for the coefficient obtained by
     contracting the added block $S\setminus R$ between the boundary of $R$ and
-    the boundary of $S$.  The corner extension of $C$ from $R$ to $S$ is the
-    region insert
+    the boundary of $S$.  The bare corner extension is
+    \[
+        \overline{\operatorname{Ext}}_{R\subseteq S}(C)_{\nu,\sigma}
+        =
+        \sum_{\mu\in \partial R}
+        C_{\mu,\sigma|_R}\,
+        \Phi_{R,S}\bigl(\mu,\sigma|_{S\setminus R},\nu\bigr).
+    \]
+    The normalized corner extension of $C$ from $R$ to $S$ is the region insert
     \[
         \operatorname{Ext}_{R\subseteq S}(C)_{\nu,\sigma}
         =
@@ -469,8 +476,8 @@
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
-\begin{lemma}[State preservation under corner extension]
-    \label{lem:peps_corner_extension_state_preserves}
+\begin{theorem}[State preservation under corner extension]
+    \label{thm:peps_corner_extension_state_preserves}
     \lean{TNLean.PEPS.deformedRegionState_extend}
     \leanok
     \uses{def:peps_corner_extension}
@@ -481,10 +488,10 @@
         =
         \Psi_{A,S,\operatorname{Ext}_{R\subseteq S}(C)}.
     \]
-\end{lemma}
+\end{theorem}
 
-\begin{lemma}[Linearity and transitivity of corner extension]
-    \label{lem:peps_corner_extension_linear_transitive}
+\begin{theorem}[Linearity and transitivity of corner extension]
+    \label{thm:peps_corner_extension_linear_transitive}
     \lean{TNLean.PEPS.bareExtendInsert_const_smul}
     \lean{TNLean.PEPS.extendInsert_const_smul}
     \lean{TNLean.PEPS.extendInsert_add}
@@ -512,7 +519,7 @@
         P_{V\setminus S}\,
         \overline{\operatorname{Ext}}_{R\subseteq P}(C).
     \]
-\end{lemma}
+\end{theorem}
 \begin{proof}
     \leanok
     The scalar and additive laws follow from the defining sum.  For
@@ -549,8 +556,8 @@
     \]
 \end{definition}
 
-\begin{lemma}[Restrictions of assembled subregion configurations]
-    \label{lem:peps_assemble_subregion_physical_config_restricts}
+\begin{theorem}[Restrictions of assembled subregion configurations]
+    \label{thm:peps_assemble_subregion_physical_config_restricts}
     \lean{TNLean.PEPS.restrictSubRegionσ_assembleSubRegionσ}
     \lean{TNLean.PEPS.restrictSubRegionσ_sdiff_assembleSubRegionσ}
     \leanok
@@ -561,7 +568,7 @@
         \qquad
         \operatorname{As}_{R,S}(\sigma_R,\sigma_Q)|_{S\setminus R}=\sigma_Q.
     \]
-\end{lemma}
+\end{theorem}
 
 \begin{theorem}[Kernel triviality of corner extension from the added block]
     \label{thm:peps_extend_insert_kernel_trivial_added_injective}
@@ -569,7 +576,7 @@
     \leanok
     \uses{def:peps_corner_extension,
         def:peps_assemble_subregion_physical_config,
-        lem:peps_assemble_subregion_physical_config_restricts}
+        thm:peps_assemble_subregion_physical_config_restricts}
     Let $R\subseteq S$ be finite regions.  Suppose that all bond dimensions are
     positive and that the added block $Q=S\setminus R$ is blocked-tensor
     injective.  If a region insert $C$ on $R$ has zero corner extension,
@@ -588,9 +595,28 @@
         \sum_{\mu\in\partial R}
         c_\mu\,\Phi_{R,S}(\mu,\sigma_Q,\nu)=0.
     \]
-    For each boundary value $\nu$, let $f_\nu$ be the coefficient row obtained
-    from the left-hand side as a function of the boundary of $Q$.  The blocked
-    tensor of $Q$ sends this row to zero, so injectivity gives
+    For each outer boundary value $\nu$ and each boundary value $\beta$ of $Q$,
+    define
+    \[
+        f_\nu(\beta)
+        =
+        \sum_{\eta\in\partial(V\setminus R)}
+        c_\eta\,
+        \mathbf 1_{\{\exists q:\,
+            \partial_{V\setminus R}q=\eta,\,
+            \partial_{V\setminus S}q=\nu,\,
+            \partial_Qq=\beta\}}.
+    \]
+    Here $c_\eta$ is the coefficient $C_{\mu,\sigma_R}$ under the complement
+    boundary identification.  The preceding display says exactly that
+    \[
+        (T_Q f_\nu)(\sigma_Q)
+        =
+        \sum_{\beta\in\partial Q} f_\nu(\beta)\,W_Q(\beta,\sigma_Q)
+        =
+        0
+    \]
+    for every $\sigma_Q$.  Injectivity of the blocked tensor of $Q$ gives
     \[
         T_Q(f_\nu)=0 \Longrightarrow f_\nu=0.
     \]
@@ -602,7 +628,7 @@
     \label{thm:peps_extend_insert_cancel_added_injective}
     \lean{TNLean.PEPS.extendInsert_cancel_addedInjective}
     \leanok
-    \uses{lem:peps_corner_extension_linear_transitive,
+    \uses{thm:peps_corner_extension_linear_transitive,
         thm:peps_extend_insert_kernel_trivial_added_injective}
     Let $R\subseteq S$, and suppose that all bond dimensions are positive and
     that $S\setminus R$ is blocked-tensor injective.  If two inserts on $R$

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -440,3 +440,200 @@
         proportionality at each edge.
     \end{proof}
 \end{theorem}
+
+\subsection{Overlapping-window corner cancellation}
+\label{subsec:peps_torus_overlap_corner_cancellation}
+
+\begin{definition}[Corner extension of a region insert]
+    \label{def:peps_corner_extension}
+    \lean{TNLean.PEPS.bareExtendInsert}
+    \lean{TNLean.PEPS.extendInsert}
+    \lean{TNLean.PEPS.deformedRegionState_extend}
+    \leanok
+    \uses{def:peps_regionInjectivityData}
+    Let $R\subseteq S$ be regions in a finite graph, and let $C$ be a region
+    insert on $R$.  Write $\Phi_{R,S}$ for the coefficient obtained by
+    contracting the added block $S\setminus R$ between the boundary of $R$ and
+    the boundary of $S$.  The corner extension of $C$ from $R$ to $S$ is the
+    region insert
+    \[
+        \operatorname{Ext}_{R\subseteq S}(C)_{\nu,\sigma}
+        =
+        P_{V\setminus S}^{-1}
+        \sum_{\mu\in \partial R}
+        C_{\mu,\sigma|_R}\,
+        \Phi_{R,S}\bigl(\mu,\sigma|_{S\setminus R},\nu\bigr),
+    \]
+    where $P_{V\setminus S}$ is the product of interior bond dimensions in
+    $V\setminus S$.  At positive bond dimensions, this extension preserves the
+    deformed region state:
+    \[
+        \Psi_{A,R,C}
+        =
+        \Psi_{A,S,\operatorname{Ext}_{R\subseteq S}(C)}.
+    \]
+    This is the open-boundary form of the extension used in the
+    overlapping-window proof sketch of
+    \cite[Section~3]{Molnar2018NormalPEPS}.
+\end{definition}
+
+\begin{lemma}[Linearity and transitivity of corner extension]
+    \label{lem:peps_corner_extension_linear_transitive}
+    \lean{TNLean.PEPS.bareExtendInsert_const_smul}
+    \lean{TNLean.PEPS.extendInsert_const_smul}
+    \lean{TNLean.PEPS.extendInsert_add}
+    \lean{TNLean.PEPS.extendInsert_sub}
+    \lean{TNLean.PEPS.threeBlockBlueCoeff_comp}
+    \lean{TNLean.PEPS.bareExtendInsert_trans}
+    \lean{TNLean.PEPS.extendInsert_trans}
+    \leanok
+    \uses{def:peps_corner_extension}
+    The corner extension is linear in the inserted boundary coefficients.  For
+    nested regions $R\subseteq S\subseteq P$ and positive bond dimensions, it is
+    also transitive:
+    \[
+        \operatorname{Ext}_{S\subseteq P}
+        \bigl(\operatorname{Ext}_{R\subseteq S}(C)\bigr)
+        =
+        \operatorname{Ext}_{R\subseteq P}(C).
+    \]
+    Before dividing by the interior-bond products, the corresponding bare
+    extension satisfies
+    \[
+        \overline{\operatorname{Ext}}_{S\subseteq P}
+        \bigl(\overline{\operatorname{Ext}}_{R\subseteq S}(C)\bigr)
+        =
+        P_{V\setminus S}\,
+        \overline{\operatorname{Ext}}_{R\subseteq P}(C).
+    \]
+\end{lemma}
+\begin{proof}
+    \leanok
+    The scalar and additive laws follow from the defining sum.  For
+    transitivity, one first composes the two coefficient kernels
+    $\Phi_{R,S}$ and $\Phi_{S,P}$ over the shared boundary of $S$:
+    \[
+        \sum_{\nu\in\partial S}
+        \Phi_{R,S}\bigl(\mu,\sigma|_{S\setminus R},\nu\bigr)
+        \Phi_{S,P}\bigl(\nu,\sigma|_{P\setminus S},\omega\bigr)
+        =
+        P_{V\setminus S}\,
+        \Phi_{R,P}\bigl(\mu,\sigma|_{P\setminus R},\omega\bigr).
+    \]
+    This is the two-block merge collapse in the proof of
+    \cite[Section~3]{Molnar2018NormalPEPS}.  Substitution into the defining
+    sum gives the bare formula, and the factors $P_{V\setminus S}$ cancel in
+    the normalized extension.
+\end{proof}
+
+\begin{definition}[Assembly of subregion physical configurations]
+    \label{def:peps_assemble_subregion_physical_config}
+    \lean{TNLean.PEPS.assembleSubRegionσ}
+    \lean{TNLean.PEPS.restrictSubRegionσ_assembleSubRegionσ}
+    \lean{TNLean.PEPS.restrictSubRegionσ_sdiff_assembleSubRegionσ}
+    \leanok
+    If $R\subseteq S$, a physical configuration on $R$ and a physical
+    configuration on $S\setminus R$ assemble to a physical configuration on
+    $S$:
+    \[
+        \operatorname{As}_{R,S}(\sigma_R,\sigma_Q)(v)
+        =
+        \begin{cases}
+        \sigma_R(v), & v\in R,\\
+        \sigma_Q(v), & v\in S\setminus R.
+        \end{cases}
+    \]
+    The two restrictions recover the original configurations:
+    \[
+        \operatorname{As}_{R,S}(\sigma_R,\sigma_Q)|_R=\sigma_R,
+        \qquad
+        \operatorname{As}_{R,S}(\sigma_R,\sigma_Q)|_{S\setminus R}=\sigma_Q.
+    \]
+\end{definition}
+
+\begin{theorem}[Kernel triviality of corner extension from the added block]
+    \label{thm:peps_extend_insert_kernel_trivial_added_injective}
+    \lean{TNLean.PEPS.extendInsert_kernel_trivial_of_addedInjective}
+    \leanok
+    \uses{def:peps_corner_extension,
+        def:peps_assemble_subregion_physical_config}
+    Let $R\subseteq S$ be finite regions.  Suppose that all bond dimensions are
+    positive and that the added block $Q=S\setminus R$ is blocked-tensor
+    injective.  If a region insert $C$ on $R$ has zero corner extension,
+    \[
+        \operatorname{Ext}_{R\subseteq S}(C)=0,
+    \]
+    then $C=0$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Fix the $R$-leg $\sigma_R$ and write
+    $c_\mu=C_{\mu,\sigma_R}$.  Evaluating the zero extension at the assembled
+    configuration $\operatorname{As}_{R,S}(\sigma_R,\sigma_Q)$ gives, for
+    every added-block leg $\sigma_Q$ and every boundary value $\nu$ of $S$,
+    \[
+        \sum_{\mu\in\partial R}
+        c_\mu\,\Phi_{R,S}(\mu,\sigma_Q,\nu)=0.
+    \]
+    The coefficient $\Phi_{R,S}$ is a linear combination of blocked weights of
+    $Q$.  Since $Q$ is injective, applying a left inverse for its blocked tensor
+    forces the corresponding boundary coefficients to vanish.  Positivity of
+    bond dimensions realizes every host boundary configuration, so
+    $c_\mu=0$ for every $\mu$.  Since $\sigma_R$ was arbitrary, $C=0$.
+\end{proof}
+
+\begin{theorem}[Cancellation of a shared injective corner]
+    \label{thm:peps_extend_insert_cancel_added_injective}
+    \lean{TNLean.PEPS.extendInsert_cancel_addedInjective}
+    \leanok
+    \uses{lem:peps_corner_extension_linear_transitive,
+        thm:peps_extend_insert_kernel_trivial_added_injective}
+    Let $R\subseteq S$, and suppose that all bond dimensions are positive and
+    that $S\setminus R$ is blocked-tensor injective.  If two inserts on $R$
+    have the same corner extension to $S$,
+    \[
+        \operatorname{Ext}_{R\subseteq S}(C_1)
+        =
+        \operatorname{Ext}_{R\subseteq S}(C_2),
+    \]
+    then $C_1=C_2$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    By linearity,
+    \[
+        \operatorname{Ext}_{R\subseteq S}(C_1-C_2)=0.
+    \]
+    Theorem~\ref{thm:peps_extend_insert_kernel_trivial_added_injective}
+    applied to the added block $S\setminus R$ gives $C_1-C_2=0$, hence
+    $C_1=C_2$.
+\end{proof}
+
+\begin{theorem}[Staircase-pair cancellation on the torus]
+    \label{thm:peps_staircase_pair_cancel}
+    \lean{TNLean.PEPS.staircasePair_cancel}
+    \leanok
+    \uses{thm:peps_extend_insert_cancel_added_injective}
+    Let $S$ be the staircase end pair around a horizontal edge of the torus,
+    and let $Q$ be the completed corner rectangle.  Assume that $Q$ is
+    blocked-tensor injective, all bond dimensions are positive, and
+    \[
+        (S\cup Q)\setminus S=Q.
+    \]
+    If two inserts $X$ and $Y$ on $S$ have equal extensions to $S\cup Q$,
+    \[
+        \operatorname{Ext}_{S\subseteq S\cup Q}(X)
+        =
+        \operatorname{Ext}_{S\subseteq S\cup Q}(Y),
+    \]
+    then $X=Y$.  Thus the injective completed corner can be cancelled from an
+    open-boundary equality, without assuming injectivity of the torus
+    complement of $S$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The staircase end pair is disjoint from the completed corner at the
+    required torus sizes, so $(S\cup Q)\setminus S=Q$.  The claimed equality is
+    exactly Theorem~\ref{thm:peps_extend_insert_cancel_added_injective} applied
+    to the inclusion $S\subseteq S\cup Q$.
+\end{proof}

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -469,9 +469,9 @@
         C_{\mu,\sigma|_R}\,
         \Phi_{R,S}\bigl(\mu,\sigma|_{S\setminus R},\nu\bigr),
     \]
-    where $P_{V\setminus S}$ is the product of interior bond dimensions in
-    $V\setminus S$.  This is the open-boundary form of the extension used in
-    the overlapping-window proof sketch of
+    where $P_{V\setminus S}$ is the product of bond dimensions over the edges
+    not crossing the boundary of $V\setminus S$.  This is the open-boundary
+    form of the extension used in the overlapping-window proof sketch of
     \cite[Section~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
@@ -489,41 +489,13 @@
     \]
 \end{theorem}
 
-\begin{theorem}[Linearity and transitivity of corner extension]
-    \label{thm:peps_corner_extension_linear_transitive}
-    \lean{TNLean.PEPS.bareExtendInsert_const_smul}
-    \lean{TNLean.PEPS.extendInsert_const_smul}
-    \lean{TNLean.PEPS.extendInsert_add}
-    \lean{TNLean.PEPS.extendInsert_sub}
+\begin{theorem}[Composition of corner-extension coefficient kernels]
+    \label{thm:peps_corner_extension_coefficient_composition}
     \lean{TNLean.PEPS.threeBlockBlueCoeff_comp}
-    \lean{TNLean.PEPS.bareExtendInsert_trans}
-    \lean{TNLean.PEPS.extendInsert_trans}
     \leanok
     \uses{def:peps_corner_extension}
-    The corner extension is linear in the inserted boundary coefficients.  For
-    nested regions $R\subseteq S\subseteq P$ and positive bond dimensions, it is
-    also transitive:
-    \[
-        \operatorname{Ext}_{S\subseteq P}
-        \bigl(\operatorname{Ext}_{R\subseteq S}(C)\bigr)
-        =
-        \operatorname{Ext}_{R\subseteq P}(C).
-    \]
-    Before dividing by the interior-bond products, the corresponding bare
-    extension satisfies
-    \[
-        \overline{\operatorname{Ext}}_{S\subseteq P}
-        \bigl(\overline{\operatorname{Ext}}_{R\subseteq S}(C)\bigr)
-        =
-        P_{V\setminus S}\,
-        \overline{\operatorname{Ext}}_{R\subseteq P}(C).
-    \]
-\end{theorem}
-\begin{proof}
-    \leanok
-    The scalar and additive laws follow from the defining sum.  For
-    transitivity, one first composes the two coefficient kernels
-    $\Phi_{R,S}$ and $\Phi_{S,P}$ over the shared boundary of $S$:
+    For nested regions $R\subseteq S\subseteq P$, the coefficient kernels
+    satisfy
     \[
         \sum_{\nu\in\partial S}
         \Phi_{R,S}\bigl(\mu,\sigma|_{S\setminus R},\nu\bigr)
@@ -533,9 +505,45 @@
         \Phi_{R,P}\bigl(\mu,\sigma|_{P\setminus R},\omega\bigr).
     \]
     This is the two-block merge collapse in the proof of
-    \cite[Section~3]{Molnar2018NormalPEPS}.  Substitution into the defining
-    sum gives the bare formula, and the factors $P_{V\setminus S}$ cancel in
-    the normalized extension.
+    \cite[Section~3]{Molnar2018NormalPEPS}.
+\end{theorem}
+
+\begin{theorem}[Linearity and transitivity of corner extension]
+    \label{thm:peps_corner_extension_linear_transitive}
+    \lean{TNLean.PEPS.bareExtendInsert_const_smul}
+    \lean{TNLean.PEPS.extendInsert_const_smul}
+    \lean{TNLean.PEPS.extendInsert_add}
+    \lean{TNLean.PEPS.extendInsert_sub}
+    \lean{TNLean.PEPS.bareExtendInsert_trans}
+    \lean{TNLean.PEPS.extendInsert_trans}
+    \leanok
+    \uses{def:peps_corner_extension,
+        thm:peps_corner_extension_coefficient_composition}
+    The corner extension is linear in the inserted boundary coefficients.  For
+    nested regions $R\subseteq S\subseteq P$, the bare extension satisfies
+    \[
+        \overline{\operatorname{Ext}}_{S\subseteq P}
+        \bigl(\overline{\operatorname{Ext}}_{R\subseteq S}(C)\bigr)
+        =
+        P_{V\setminus S}\,
+        \overline{\operatorname{Ext}}_{R\subseteq P}(C)
+    \]
+    without a positivity assumption.  If all bond dimensions are positive, the
+    normalized corner extension is transitive:
+    \[
+        \operatorname{Ext}_{S\subseteq P}
+        \bigl(\operatorname{Ext}_{R\subseteq S}(C)\bigr)
+        =
+        \operatorname{Ext}_{R\subseteq P}(C).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    The scalar and additive laws follow from the defining sum.  For
+    transitivity, substitute
+    Theorem~\ref{thm:peps_corner_extension_coefficient_composition} into the
+    defining sum.  This gives the bare formula, and the factors
+    $P_{V\setminus S}$ cancel in the normalized extension.
 \end{proof}
 
 \begin{definition}[Assembly of subregion physical configurations]
@@ -592,39 +600,42 @@
     configuration $\sigma_R$ on $R$.  Let
     \[
         \rho:\partial R \simeq \partial(V\setminus R)
+        \qquad\text{and}\qquad
+        \tau:\partial S \simeq \partial(V\setminus S)
     \]
-    be the complement-boundary bijection, and define
+    be the complement-boundary bijections, and define
     \[
         c_\eta=C_{\rho^{-1}(\eta),\sigma_R}
         \qquad(\eta\in \partial(V\setminus R)).
     \]
     Evaluating the bare zero extension at
     $\operatorname{As}_{R,S}(\sigma_R,\sigma_Q)$ gives, for every added-block
-    configuration $\sigma_Q$ and every boundary value $\nu$ of $S$,
+    configuration $\sigma_Q$ and every boundary value
+    $\omega\in\partial(V\setminus S)$,
     \[
         \sum_{\eta\in\partial(V\setminus R)}
-        c_\eta\,\Phi_{R,S}(\rho^{-1}(\eta),\sigma_Q,\nu)=0.
+        c_\eta\,\Phi_{R,S}(\rho^{-1}(\eta),\sigma_Q,\tau^{-1}(\omega))=0.
     \]
-    For each outer boundary value $\nu$ and each boundary value $\beta$ of $Q$,
+    For each outer boundary value $\omega$ and each boundary value $\beta$ of $Q$,
     define
     \[
-        f_\nu(\beta)
+        f_\omega(\beta)
         =
         \sum_{\eta\in\partial(V\setminus R)}
         c_\eta\,
         \mathbf 1_{\{\exists q:\,
             \partial_{V\setminus R}q=\eta,\,
-            \partial_{V\setminus S}q=\nu,\,
+            \partial_{V\setminus S}q=\omega,\,
             \partial_Qq=\beta\}}.
     \]
-    Unfolding $\Phi_{R,S}$ as a sum over the blocked weights of $Q$ gives,
-    for every $\sigma_Q$,
+    Let $\Gamma$ be the product of bond dimensions on the crossing edges
+    separated when the $Q$-block is read first.  Unfolding $\Phi_{R,S}$ as a sum
+    over the blocked weights of $Q$ gives, for every $\sigma_Q$,
     \[
     \begin{aligned}
-        0
+        (T_Q f_\omega)(\sigma_Q)
         &=
-        \sum_{\eta\in\partial(V\setminus R)}
-        c_\eta\,\Phi_{R,S}(\rho^{-1}(\eta),\sigma_Q,\nu) \\
+        \sum_{\beta\in\partial Q} f_\omega(\beta)\,W_Q(\beta,\sigma_Q) \\
         &=
         \sum_{\beta\in\partial Q}
         \left(
@@ -632,32 +643,34 @@
         c_\eta\,
         \mathbf 1_{\{\exists q:\,
             \partial_{V\setminus R}q=\eta,\,
-            \partial_{V\setminus S}q=\nu,\,
+            \partial_{V\setminus S}q=\omega,\,
             \partial_Qq=\beta\}}
         \right) W_Q(\beta,\sigma_Q) \\
         &=
-        \sum_{\beta\in\partial Q} f_\nu(\beta)\,W_Q(\beta,\sigma_Q)
+        \Gamma
+        \sum_{\eta\in\partial(V\setminus R)}
+        c_\eta\,\Phi_{R,S}(\rho^{-1}(\eta),\sigma_Q,\tau^{-1}(\omega))
         =
-        (T_Q f_\nu)(\sigma_Q).
+        0.
     \end{aligned}
     \]
-    Hence $T_Q(f_\nu)=0$.  Injectivity of the blocked tensor of $Q$ gives
+    Hence $T_Q(f_\omega)=0$.  Injectivity of the blocked tensor of $Q$ gives
     \[
-        T_Q(f_\nu)=0 \Longrightarrow f_\nu=0.
+        T_Q(f_\omega)=0 \Longrightarrow f_\omega=0.
     \]
     Now fix $\mu\in\partial R$.  Positivity of bond dimensions gives a global
     virtual configuration $q$ whose residual boundary on $V\setminus R$ is
     $\rho(\mu)$.  Set
     \[
-        \nu=\partial_{V\setminus S}q,\qquad
+        \omega=\partial_{V\setminus S}q,\qquad
         \beta=\partial_Q q.
     \]
-    Evaluating $f_\nu=0$ at $\beta$, the residual-boundary uniqueness identity
+    Evaluating $f_\omega=0$ at $\beta$, the residual-boundary uniqueness identity
     leaves only the term $\eta=\rho(\mu)$:
     \[
         0
         =
-        f_\nu(\beta)
+        f_\omega(\beta)
         =
         c_{\rho(\mu)}\cdot 1
         =

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -607,16 +607,31 @@
             \partial_{V\setminus S}q=\nu,\,
             \partial_Qq=\beta\}}.
     \]
-    Here $c_\eta$ is the coefficient $C_{\mu,\sigma_R}$ under the complement
-    boundary identification.  The preceding display says exactly that
+    Unfolding $\Phi_{R,S}$ as a sum over the blocked weights of $Q$ gives,
+    for every $\sigma_Q$,
     \[
-        (T_Q f_\nu)(\sigma_Q)
-        =
+    \begin{aligned}
+        0
+        &=
+        \sum_{\mu\in\partial R}
+        c_\mu\,\Phi_{R,S}(\mu,\sigma_Q,\nu) \\
+        &=
+        \sum_{\beta\in\partial Q}
+        \left(
+        \sum_{\eta\in\partial(V\setminus R)}
+        c_\eta\,
+        \mathbf 1_{\{\exists q:\,
+            \partial_{V\setminus R}q=\eta,\,
+            \partial_{V\setminus S}q=\nu,\,
+            \partial_Qq=\beta\}}
+        \right) W_Q(\beta,\sigma_Q) \\
+        &=
         \sum_{\beta\in\partial Q} f_\nu(\beta)\,W_Q(\beta,\sigma_Q)
         =
-        0
+        (T_Q f_\nu)(\sigma_Q).
+    \end{aligned}
     \]
-    for every $\sigma_Q$.  Injectivity of the blocked tensor of $Q$ gives
+    Hence $T_Q(f_\nu)=0$.  Injectivity of the blocked tensor of $Q$ gives
     \[
         T_Q(f_\nu)=0 \Longrightarrow f_\nu=0.
     \]

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -449,7 +449,6 @@
     \lean{TNLean.PEPS.bareExtendInsert}
     \lean{TNLean.PEPS.extendInsert}
     \leanok
-    \uses{def:peps_regionInjectivityData}
     Let $R\subseteq S$ be regions in a finite graph, and let $C$ be a region
     insert on $R$.  Write $\Phi_{R,S}$ for the coefficient obtained by
     contracting the added block $S\setminus R$ between the boundary of $R$ and
@@ -587,13 +586,24 @@
 \end{theorem}
 \begin{proof}
     \leanok
-    Fix the $R$-leg $\sigma_R$ and write
-    $c_\mu=C_{\mu,\sigma_R}$.  Evaluating the zero extension at the assembled
-    configuration $\operatorname{As}_{R,S}(\sigma_R,\sigma_Q)$ gives, for
-    every added-block leg $\sigma_Q$ and every boundary value $\nu$ of $S$,
+    Since all bond dimensions are positive, $P_{V\setminus S}\ne 0$.
+    Thus $\operatorname{Ext}_{R\subseteq S}(C)=0$ is equivalent to
+    $\overline{\operatorname{Ext}}_{R\subseteq S}(C)=0$.  Fix the physical
+    configuration $\sigma_R$ on $R$.  Let
     \[
-        \sum_{\mu\in\partial R}
-        c_\mu\,\Phi_{R,S}(\mu,\sigma_Q,\nu)=0.
+        \rho:\partial R \simeq \partial(V\setminus R)
+    \]
+    be the complement-boundary bijection, and define
+    \[
+        c_\eta=C_{\rho^{-1}(\eta),\sigma_R}
+        \qquad(\eta\in \partial(V\setminus R)).
+    \]
+    Evaluating the bare zero extension at
+    $\operatorname{As}_{R,S}(\sigma_R,\sigma_Q)$ gives, for every added-block
+    configuration $\sigma_Q$ and every boundary value $\nu$ of $S$,
+    \[
+        \sum_{\eta\in\partial(V\setminus R)}
+        c_\eta\,\Phi_{R,S}(\rho^{-1}(\eta),\sigma_Q,\nu)=0.
     \]
     For each outer boundary value $\nu$ and each boundary value $\beta$ of $Q$,
     define
@@ -613,8 +623,8 @@
     \begin{aligned}
         0
         &=
-        \sum_{\mu\in\partial R}
-        c_\mu\,\Phi_{R,S}(\mu,\sigma_Q,\nu) \\
+        \sum_{\eta\in\partial(V\setminus R)}
+        c_\eta\,\Phi_{R,S}(\rho^{-1}(\eta),\sigma_Q,\nu) \\
         &=
         \sum_{\beta\in\partial Q}
         \left(
@@ -635,8 +645,25 @@
     \[
         T_Q(f_\nu)=0 \Longrightarrow f_\nu=0.
     \]
-    Positivity of bond dimensions realizes every host boundary configuration,
-    hence $c_\mu=0$ for every $\mu$.  Since $\sigma_R$ was arbitrary, $C=0$.
+    Now fix $\mu\in\partial R$.  Positivity of bond dimensions gives a global
+    virtual configuration $q$ whose residual boundary on $V\setminus R$ is
+    $\rho(\mu)$.  Set
+    \[
+        \nu=\partial_{V\setminus S}q,\qquad
+        \beta=\partial_Q q.
+    \]
+    Evaluating $f_\nu=0$ at $\beta$, the residual-boundary uniqueness identity
+    leaves only the term $\eta=\rho(\mu)$:
+    \[
+        0
+        =
+        f_\nu(\beta)
+        =
+        c_{\rho(\mu)}\cdot 1
+        =
+        C_{\mu,\sigma_R}.
+    \]
+    Since $\sigma_R$ and $\mu$ were arbitrary, $C=0$.
 \end{proof}
 
 \begin{theorem}[Cancellation of a shared injective corner]
@@ -671,9 +698,10 @@
     \lean{TNLean.PEPS.staircasePair_cancel}
     \leanok
     \uses{thm:peps_extend_insert_cancel_added_injective}
-    Let the torus have width $W$ and height $H$.  Let $S$ be the staircase end
-    pair around a horizontal edge, with seam dimensions $L$ and $K$, and let
-    $Q$ be the completed corner rectangle.  Assume the size bounds
+    Let the torus have width $W$ and height $H$, with $1<W$ and $1<H$.
+    Let $S$ be the staircase end pair around a horizontal edge, with seam
+    dimensions $L$ and $K$, and let $Q$ be the completed corner rectangle.
+    Assume the size bounds
     \[
         2L\le W,\qquad 2K\le H,
     \]


### PR DESCRIPTION
### Motivation

- Blueprint entries are missing for the two principal theorems of Step 3 of the 2D overlapping-window campaign (arXiv:1804.04964, §3, Lemma `injective_union`, lines 2320–2445): `extendInsert_kernel_trivial_of_addedInjective` and `extendInsert_cancel_addedInjective` were recorded as landed in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex` by PR #2761 but lacked `\begin{theorem}...\lean{...}\leanok` entries in any `blueprint/src/chapter/` file.
- These results and two supporting constructions (`assembleSubRegionσ`, `staircasePair_cancel`) complete a named campaign step and are substantive enough to warrant blueprint entries rather than gap-note-only recording, per #2764.

### Description

- Modified `blueprint/src/chapter/ch24_peps_ft_torus.tex` (+197 lines): added subsection **Overlapping-window corner cancellation** with:
  - Corner extension formula $\operatorname{Ext}_{R\subseteq S}(C)_{\nu,\sigma} = P_{V\setminus S}^{-1}\sum_{\mu\in\partial R} C_{\mu,\sigma|_R}\,\Phi_{R,S}(\mu,\sigma|_{S\setminus R},\nu)$ with linearity and transitivity lemma.
  - Assembly of physical configurations on $R$ and $S\setminus R$ (`\lean{assembleSubRegionσ}`, `TNLean/PEPS/TorusWindowChain5.lean` line 287).
  - Kernel triviality: if $S\setminus R$ is blocked-tensor injective and bond dimensions are positive, the corner extension $\mathrm{extendInsert}(R\subseteq S)$ has trivial kernel (`\lean{extendInsert_kernel_trivial_of_addedInjective}`, line 413).
  - Shared-corner cancellation: two inserts on $R$ whose corner extensions on $S$ agree are equal, whenever $S\setminus R$ is blocked-tensor injective (`\lean{extendInsert_cancel_addedInjective}`, line 560).
  - Staircase-pair cancellation corollary on the torus (`\lean{staircasePair_cancel}`, line 610).
  - `\uses{}` references to predecessor results in `TorusWindowChain3` and `TorusWindowChain4`.

### Testing

- `git diff --check origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`

---
Closes #2764

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX/blueprint sync; no runtime or proof logic changes in this diff.
> 
> **Overview**
> Adds subsection **Overlapping-window corner cancellation** to the torus normal PEPS blueprint chapter, wiring the overlapping-window Step 3 from Molnár et al. to existing `TNLean.PEPS` declarations via `\lean{...}` / `\leanok` tags.
> 
> The new material defines **corner extension** of region inserts (`Ext_{R⊆S}`), a lemma on linearity and transitivity, assembly of physical configs on subregions, then three theorems: kernel triviality when the added block is injective, cancellation of equal extensions through an injective corner, and the **staircase-pair** torus corollary that cancels the completed corner without injectivity of the full complement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d387660b583f803275f8f40bfb5deeb76584a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX blueprint documentation and Lean name sync only; no changes to proofs or application code in this diff.
> 
> **Overview**
> Adds subsection **Overlapping-window corner cancellation** to `ch24_peps_ft_torus.tex`, linking Molnár et al. §3 Step 3 to existing `TNLean.PEPS` results via `\lean{...}` / `\leanok`.
> 
> The new material defines **corner extension** `Ext_{R⊆S}` (bare and normalized), records composition/linearity/transitivity, and **`assembleSubRegionσ`** for gluing physical configs on `R` and `S\setminus R`. It then states kernel triviality when the added block is blocked-tensor injective, **shared-corner cancellation** (equal extensions imply equal inserts), and the **staircase-pair** torus corollary that cancels the completed corner without injectivity of the full complement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa5bd54468ae5d24bb5f9846b28d408e0bd4dd18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->