### PR TITLE
refactor(MPS/MPDO): lint, docstring, and dead-code cleanup

### DIFF
--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -102,6 +102,8 @@ noncomputable def schmidtMat (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     Matrix (Fin L → Fin d) (Fin (N - L) → Fin d) ℂ :=
   fun u w => MPSTensor.mpv A ((MPOTensor.blockReindexEquiv d N L hL).symm (Fin.append u w))
 
+/-- The reduced pure-state block density matrix is the normalized Gram matrix
+`(tr V^{(N)})⁻¹ • (W * Wᴴ)` of the Schmidt matrix `W = schmidtMat A N L`. -/
 theorem reducedPureBlockState_eq_gram (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     MPSTensor.reducedPureBlockState A N L hL
       = (Matrix.trace (MPSTensor.pureState A N))⁻¹ •
@@ -140,6 +142,8 @@ theorem mpv_comp_finRotate_pow (A : MPSTensor d D) {N : ℕ} (p : ℕ) (σ : Fin
     rw [Function.iterate_succ, ← Function.comp_assoc, mpv_comp_finRotate, ih]
 
 
+/-- The inverse block-reindexing equivalence acts by precomposition with the
+length cast `N = L + (N - L)`. -/
 theorem blockReindexEquiv_symm_apply {N L : ℕ} (hL : L ≤ N) (c : Fin (L + (N - L)) → Fin d) :
     (MPOTensor.blockReindexEquiv d N L hL).symm c
       = c ∘ Fin.cast (by omega : N = L + (N - L)) := by
@@ -184,6 +188,8 @@ theorem schmidt_swap (A : MPSTensor d D) {N L : ℕ} (hL : L ≤ N)
       congr 1
   rw [hcfg, mpv_comp_finRotate_pow]
 
+/-- The complement-block Gram matrix `W_{N-L} * W_{N-L}ᴴ` is the entrywise
+conjugate of the kept-block Gram matrix `W_Lᴴ * W_L`. -/
 theorem gram_complement (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     schmidtMat A N (N - L) (Nat.sub_le N L) * (schmidtMat A N (N - L) (Nat.sub_le N L))ᴴ
       = ((schmidtMat A N L hL)ᴴ * schmidtMat A N L hL).map (starRingEnd ℂ) := by
@@ -202,6 +208,7 @@ theorem gram_complement (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     rw [schmidtMat, schmidtMat, schmidt_swap A hL w' (e u), hcast]
   rw [h1, h2]
 
+/-- The trace of the pure state is real: conjugating it leaves it unchanged. -/
 theorem trace_pureState_conj (A : MPSTensor d D) (N : ℕ) :
     starRingEnd ℂ (Matrix.trace (MPSTensor.pureState A N)) = Matrix.trace (MPSTensor.pureState A N) := by
   have h := Matrix.trace_conjTranspose (MPSTensor.pureState A N)
@@ -315,6 +322,8 @@ theorem append_zero_eq {α : Type*} {L : ℕ} (u : Fin L → α) (g : Fin 0 → 
   refine Fin.addCases (fun j => ?_) (fun j => j.elim0) i
   rw [Fin.append_left]; congr 1
 
+/-- With an empty right block, the block-reduced state is `Z` reindexed along
+the trivial length identity `L + 0 = L`. -/
 theorem blockReducedState_zero {L : ℕ} (Z : Matrix (Fin (L + 0) → Fin d) (Fin (L + 0) → Fin d) ℂ) :
     blockReducedState d L 0 Z
       = Z.submatrix (Equiv.arrowCongr (finCongr (Nat.add_zero L).symm) (Equiv.refl (Fin d)))
@@ -324,6 +333,8 @@ theorem blockReducedState_zero {L : ℕ} (Z : Matrix (Fin (L + 0) → Fin d) (Fi
     blockSplitEquiv_symm_apply, Fintype.sum_unique, append_zero_eq]
   rfl
 
+/-- The full-system pure block entropy vanishes: the whole-chain reduced state
+is pure, so `S_N = 0`. See arXiv:1606.00608, Section 3 (line 599). -/
 theorem pureBlockEntropy_full (A : MPSTensor d D) (N : ℕ)
     (htr : Matrix.trace (MPSTensor.pureState A N) ≠ 0) :
     MPSTensor.pureBlockEntropy A N N (le_refl N) = 0 := by
@@ -362,6 +373,8 @@ theorem mutualInfoChain_doubledTensor (A : MPSTensor d D) (N L : ℕ) (hL : L �
 
 namespace MPSTensor
 
+/-- Listing the block-reindexed configuration concatenates the two sub-block
+listings: `ofFn ((blockReindexEquiv).symm (u ++ w)) = ofFn u ++ ofFn w`. -/
 theorem ofFn_blockReindex {N L : ℕ} (hL : L ≤ N) (u : Fin L → Fin d)
     (w : Fin (N - L) → Fin d) :
     List.ofFn ((MPOTensor.blockReindexEquiv d N L hL).symm (Fin.append u w))

--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -102,8 +102,9 @@ noncomputable def schmidtMat (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     Matrix (Fin L → Fin d) (Fin (N - L) → Fin d) ℂ :=
   fun u w => MPSTensor.mpv A ((MPOTensor.blockReindexEquiv d N L hL).symm (Fin.append u w))
 
-/-- The reduced pure-state block density matrix is the normalized Gram matrix
-`(tr V^{(N)})⁻¹ • (W * Wᴴ)` of the Schmidt matrix `W = schmidtMat A N L`. -/
+/-- The reduced pure-state block density matrix is the trace-normalized Gram
+matrix of the Schmidt matrix `schmidtMat A N L`: the inverse pure-state trace
+times the Schmidt matrix composed with its conjugate transpose. -/
 theorem reducedPureBlockState_eq_gram (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     MPSTensor.reducedPureBlockState A N L hL
       = (Matrix.trace (MPSTensor.pureState A N))⁻¹ •
@@ -143,7 +144,7 @@ theorem mpv_comp_finRotate_pow (A : MPSTensor d D) {N : ℕ} (p : ℕ) (σ : Fin
 
 
 /-- The inverse block-reindexing equivalence acts by precomposition with the
-length cast `N = L + (N - L)`. -/
+length cast identifying N with L + (N - L). -/
 theorem blockReindexEquiv_symm_apply {N L : ℕ} (hL : L ≤ N) (c : Fin (L + (N - L)) → Fin d) :
     (MPOTensor.blockReindexEquiv d N L hL).symm c
       = c ∘ Fin.cast (by omega : N = L + (N - L)) := by
@@ -188,8 +189,8 @@ theorem schmidt_swap (A : MPSTensor d D) {N L : ℕ} (hL : L ≤ N)
       congr 1
   rw [hcfg, mpv_comp_finRotate_pow]
 
-/-- The complement-block Gram matrix `W_{N-L} * W_{N-L}ᴴ` is the entrywise
-conjugate of the kept-block Gram matrix `W_Lᴴ * W_L`. -/
+/-- The complement-block Gram matrix is the entrywise conjugate of the
+kept-block Gram matrix of `schmidtMat A N L`. -/
 theorem gram_complement (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     schmidtMat A N (N - L) (Nat.sub_le N L) * (schmidtMat A N (N - L) (Nat.sub_le N L))ᴴ
       = ((schmidtMat A N L hL)ᴴ * schmidtMat A N L hL).map (starRingEnd ℂ) := by
@@ -322,8 +323,8 @@ theorem append_zero_eq {α : Type*} {L : ℕ} (u : Fin L → α) (g : Fin 0 → 
   refine Fin.addCases (fun j => ?_) (fun j => j.elim0) i
   rw [Fin.append_left]; congr 1
 
-/-- With an empty right block, the block-reduced state is `Z` reindexed along
-the trivial length identity `L + 0 = L`. -/
+/-- With an empty right block, the block-reduced state is the input matrix
+reindexed along the trivial length identity L + 0 = L. -/
 theorem blockReducedState_zero {L : ℕ} (Z : Matrix (Fin (L + 0) → Fin d) (Fin (L + 0) → Fin d) ℂ) :
     blockReducedState d L 0 Z
       = Z.submatrix (Equiv.arrowCongr (finCongr (Nat.add_zero L).symm) (Equiv.refl (Fin d)))
@@ -334,7 +335,8 @@ theorem blockReducedState_zero {L : ℕ} (Z : Matrix (Fin (L + 0) → Fin d) (Fi
   rfl
 
 /-- The full-system pure block entropy vanishes: the whole-chain reduced state
-is pure, so `S_N = 0`. See arXiv:1606.00608, Section 3 (line 599). -/
+is pure, so its von Neumann entropy is zero. See arXiv:1606.00608, Section 3
+(line 599). -/
 theorem pureBlockEntropy_full (A : MPSTensor d D) (N : ℕ)
     (htr : Matrix.trace (MPSTensor.pureState A N) ≠ 0) :
     MPSTensor.pureBlockEntropy A N N (le_refl N) = 0 := by
@@ -373,8 +375,8 @@ theorem mutualInfoChain_doubledTensor (A : MPSTensor d D) (N L : ℕ) (hL : L �
 
 namespace MPSTensor
 
-/-- Listing the block-reindexed configuration concatenates the two sub-block
-listings: `ofFn ((blockReindexEquiv).symm (u ++ w)) = ofFn u ++ ofFn w`. -/
+/-- Listing the block-reindexed configuration concatenates the listings of the
+two sub-blocks, via `List.ofFn_fin_append`. -/
 theorem ofFn_blockReindex {N L : ℕ} (hL : L ≤ N) (u : Fin L → Fin d)
     (w : Fin (N - L) → Fin d) :
     List.ofFn ((MPOTensor.blockReindexEquiv d N L hL).symm (Fin.append u w))

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/

--- a/TNLean/MPS/RFP/Decorrelation.lean
+++ b/TNLean/MPS/RFP/Decorrelation.lean
@@ -63,7 +63,7 @@ All results are fully proved (no `sorry`).
 ### Commuting idempotent product algebra
 
 Algebraic lemmas for pairs of commuting idempotent endomorphisms.
-These are the workhorses behind `HasCommutingParentHam`.
+These support the `HasCommutingParentHam` properties below.
 -/
 
 section CommutingIdempotentAlgebra

--- a/TNLean/MPS/RFP/Defs.lean
+++ b/TNLean/MPS/RFP/Defs.lean
@@ -32,11 +32,6 @@ See arXiv:1606.00608, Definition 3.2. -/
 def IsRFP (A : MPSTensor d D) : Prop :=
   transferMap A ∘ₗ transferMap A = transferMap A
 
-/-- The idempotence equation expressed as a projection lemma. -/
-theorem IsRFP.idempotent {A : MPSTensor d D} (h : IsRFP A) :
-    transferMap A ∘ₗ transferMap A = transferMap A :=
-  h
-
 /-- The backward direction of the RFP ↔ Kraus-isometry characterisation
 (arXiv:1606.00608, Theorem 3.1): if the Kraus operators of an MPS tensor
 decompose via a rectangular isometry `V` (with `V†V = 1`), then the

--- a/scripts/nolints-style.txt
+++ b/scripts/nolints-style.txt
@@ -9,10 +9,6 @@ TNLean/MPS/ParentHamiltonian/Commuting.lean : line 1 : ERR_TWS : This line ends 
 TNLean/MPS/SharedInfra/GaugePhase.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
 TNLean/MPS/SharedInfra/SectorDecomposition.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
 TNLean/MPS/SharedInfra/KrausAdjointSetup.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-TNLean/MPS/MPDO/ZCL.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-TNLean/MPS/MPDO/VerticalCF.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-TNLean/MPS/MPDO/RFP.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-TNLean/MPS/MPDO/PRFP.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
 TNLean/Algebra/LinearMapAux.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
 
 -- ERR_UNICODE: the combining tilde U+0303 ("B" with a tilde) appears in the


### PR DESCRIPTION
## Summary
Surgical, CI-verifiable cleanup of the MPDO/RFP modules. **No proof or theorem-statement semantics changed**; every touched file elaborates (`lake env lean` verified locally).

- **Lint**: fixed the line-1 trailing whitespace on `MPDO/RFP.lean`, `MPDO/ZCL.lean`, `MPDO/VerticalCF.lean` and dropped their now-stale `nolints-style.txt` entries; also removed the **dead** nolint entry for `TNLean/MPS/MPDO/PRFP.lean` — a file that no longer exists.
- **Dead code**: deleted the no-op accessor `IsRFP.idempotent` (`RFP/Defs.lean`); its conclusion is definitionally `IsRFP A` and its proof is the hypothesis `h`, with zero call sites in `TNLean/` or `blueprint/`.
- **Docstrings**: added docstrings to seven undocumented helper lemmas in `PureAreaLaw.lean` (Gram-factorization / Schmidt-symmetry plumbing), plus a source label (arXiv:1606.00608, Section 3) on the blueprint-cited `pureBlockEntropy_full`.
- **Prose**: replaced the informal "workhorses" phrasing in `RFP/Decorrelation.lean` with neutral wording (`docs/prose_style.md`).

## Notes
- An audit-flagged "~13 over-length lines" finding was **investigated and dropped**: `awk` counts bytes, but Mathlib's `lint-style` counts codepoints. Only 4 lines actually exceed 100 codepoints, and those are unchanged on `main` (which is green on the lint-style gate), so the linter already tolerates them — wrapping them would be unnecessary churn with elaboration-breakage risk.
- The `erw → simp only` swap in `Defs.lean` and the von-Neumann-entropy-lemma relocation were deferred (they carry real proof-breakage risk and belong in a focused follow-up).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, whitespace, and removal of an unused definitional accessor only; mathematical content is unchanged.
> 
> **Overview**
> CI/style hygiene and documentation only—**no theorem statements or proof logic change**.
> 
> **Style gate:** Line-1 trailing whitespace is fixed on `MPDO/RFP.lean`, `MPDO/ZCL.lean`, and `MPDO/VerticalCF.lean` (opening `/-` comment). Matching `scripts/nolints-style.txt` exemptions are removed, including a stale entry for deleted `MPDO/PRFP.lean`.
> 
> **Dead code:** `IsRFP.idempotent` is removed from `RFP/Defs.lean` (it only restated `IsRFP` from the hypothesis; no references remain).
> 
> **Docstrings:** Seven previously undocumented helper lemmas in `PureAreaLaw.lean` (Gram/Schmidt/block-reindex plumbing) get docstrings; `pureBlockEntropy_full` is tagged with arXiv:1606.00608 §3.
> 
> **Prose:** In `RFP/Decorrelation.lean`, informal “workhorses” wording is replaced with neutral phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a26df03a396246e7406d1ff1a496f6649c531c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->