### PR TITLE
doc(blueprint): add the renormalization-flow RFP characterization

### DIFF
--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -310,16 +310,19 @@ and rates for the single-tensor transfer map $\E_A$.
         A^{i_1} A^{i_2} = \sum_{j=0}^{d-1} V_{(i_1,i_2),j} A^j
     \end{equation}
     for all $i_1,i_2 \in \{0,\ldots,d-1\}$.
-    This is \cite[Theorem~3.1]{Cirac2016MPDO_arXiv}; equivalently, $A$ arises as a
-    limit of the renormalization flow $\E \mapsto \E^2$.
+    This is \cite[Theorem~3.1]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:kraus_isometry_implies_rfp}
+    \uses{thm:kraus_isometry_implies_rfp, thm:kraus_rectangular_freedom'}
     The backward implication is
     Theorem~\ref{thm:kraus_isometry_implies_rfp}. For the forward implication,
-    $\E_A^2 = \E_A$ says the product Kraus family $\{A^{i_1} A^{i_2}\}$ and the
-    single family $\{A^j\}$ define the same completely positive map; rectangular
-    Kraus freedom (Wolf Theorem~2.1(4)) supplies the isometry $V$ relating them.
+    expanding $\E_A^2 = \E_A$ as a Kraus sum gives, for every $X$,
+    \[
+        \sum_{i_1,i_2}(A^{i_1} A^{i_2})\,X\,(A^{i_1} A^{i_2})^\dagger
+        = \sum_j A^j\,X\,(A^j)^\dagger .
+    \]
+    Theorem~\ref{thm:kraus_rectangular_freedom'} then supplies the isometry $V$
+    relating the two Kraus families.
 \end{proof}
 
 \begin{definition}[Single-block local orthogonality convention]%

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -298,6 +298,30 @@ and rates for the single-tensor transfer map $\E_A$.
     $\{A^j\}$, hence $\E_A^2 = \E_A$.
 \end{proof}
 
+\begin{theorem}[Renormalization-fixed-point characterization]%
+    \label{thm:renormalization_flow}
+    \lean{MPSTensor.isRFP_iff_kraus_isometry}
+    \leanok
+    \uses{def:is_rfp, thm:kraus_isometry_implies_rfp}
+    An MPS tensor $A$ is a renormalization fixed point if and only if there
+    exists an isometry $V : \C^d \to \C^{d^2}$, written as coefficients
+    $V_{(i_1,i_2),j}$ with $V^\dagger V = 1$, such that
+    \begin{equation}\label{eq:corr_AA_isometry}
+        A^{i_1} A^{i_2} = \sum_{j=0}^{d-1} V_{(i_1,i_2),j} A^j
+    \end{equation}
+    for all $i_1,i_2 \in \{0,\ldots,d-1\}$.
+    This is \cite[Theorem~3.1]{Cirac2016MPDO_arXiv}; equivalently, $A$ arises as a
+    limit of the renormalization flow $\E \mapsto \E^2$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:kraus_isometry_implies_rfp}
+    The backward implication is
+    Theorem~\ref{thm:kraus_isometry_implies_rfp}. For the forward implication,
+    $\E_A^2 = \E_A$ says the product Kraus family $\{A^{i_1} A^{i_2}\}$ and the
+    single family $\{A^j\}$ define the same completely positive map; rectangular
+    Kraus freedom (Wolf Theorem~2.1(4)) supplies the isometry $V$ relating them.
+\end{proof}
+
 \begin{definition}[Single-block local orthogonality convention]%
     \label{def:is_locally_orthogonal}
     \lean{MPSTensor.IsLocallyOrthogonal}


### PR DESCRIPTION
## Summary
Surfaces an **already-proven** result that the blueprint was only partially recording, addressing the #2632 coverage gap.

The pure-state renormalization-flow theorem (arXiv:1606.00608, `thm:renormalization-flow` / Theorem 3.1) characterizes renormalization fixed points by the isometric relation
$$ A^{i_1} A^{i_2} = \sum_j V_{(i_1,i_2),j}\, A^j, \qquad V^\dagger V = 1. $$

The **full biconditional** is already formalized as `MPSTensor.isRFP_iff_kraus_isometry` (`TNLean/MPS/RFP/Defs.lean`), but `ch14_correlations.tex` carried only the **backward** direction (`thm:kraus_isometry_implies_rfp`, `\lean{MPSTensor.isRFP_of_kraus_isometry}`).

This PR adds the full-iff blueprint entry (`thm:renormalization_flow`) with statement- and proof-level `\leanok`, `\lean{MPSTensor.isRFP_iff_kraus_isometry}`, restating the characterization in the paper's `eq:AA=A` form and citing Theorem 3.1 (consistent with the existing sibling entry).

## Faithfulness
The Lean statement is a clean `IsRFP A ↔ ∃ V …` with **no hypotheses absent from the source** theorem. The identification of `IsRFP` ($\E^2=\E$) with the renormalization-flow limit is the paper's own (it defines RFP via this relation and identifies the flow step with $\E\mapsto\E^2$).

## Verification
No Lean changed; the `\lean` target is an existing public theorem. CI regenerates `lean_decls` and runs `checkdecls` + the blueprint compile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition to the blueprint TeX; no Lean or application logic is modified.
> 
> **Overview**
> Adds a new blueprint theorem **`thm:renormalization_flow`** in `ch14_correlations.tex` so Chapter 14 records the **full biconditional** RFP ↔ Kraus-isometry relation (Cirac et al., Theorem 3.1), not only the backward direction in `thm:kraus_isometry_implies_rfp`.
> 
> The entry states \(A^{i_1}A^{i_2}=\sum_j V_{(i_1,i_2),j}A^j\) with \(V^\dagger V=1\), labels **`eq:corr_AA_isometry`**, and wires statement and proof to existing Lean via `\lean{MPSTensor.isRFP_iff_kraus_isometry}` and `\leanok`. The proof sketch cites the existing backward theorem and **`thm:kraus_rectangular_freedom'`** for the forward direction from \(\mathcal{E}_A^2=\mathcal{E}_A\).
> 
> No Lean or runtime code changes—documentation/blueprint coverage only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5922818223bf4ed5011649f32bec5793eb823563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->