### PR TITLE
feat(PEPS): the staircase end-pair boundary peeling and the back-half host-injectivity scope verdict

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -420,6 +420,7 @@ import TNLean.PEPS.TorusWindowChain4
 import TNLean.PEPS.TorusWindowChain5
 import TNLean.PEPS.TorusWindowChain6
 import TNLean.PEPS.TorusWindowExtraction
+import TNLean.PEPS.TorusWindowPeel
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusReferenceBlockingData

--- a/TNLean/PEPS/TorusWindowPeel.lean
+++ b/TNLean/PEPS/TorusWindowPeel.lean
@@ -234,6 +234,76 @@ theorem isRegionBoundaryEdge_endPair_exactlyOne_window {L K a b : ℕ}
   · refine Or.inr ⟨fun hfL => hne ?_, hfR⟩
     exact eq_referenceEdge_of_isRegionBoundaryEdge_both_endWindows A hL hK ha0 haw hbh hfL hfR
 
+/-! ### The complement of one window is the opposite window and the rest
+
+The complement of one end window splits as the opposite end window joined with the complement of
+the whole end pair: $\mathrm{univ}\setminus W_0 = W_{L+K-1}\sqcup(\mathrm{univ}\setminus S)$.  This
+is the geometric fact behind the bond-$e$ coefficient identity: contracting one window against its
+complement factors the contraction into the genuine block of the opposite window (the window the
+bond $e$ joins to) and the rest of the torus.  Both windows being subsets of $S$, the splits hold
+for either window, with the opposite window the difference $S\setminus W$. -/
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The difference of the end pair and the left window is the right window: at `2 * L ≤ width` the
+two windows are disjoint, so removing the left window from `S = W_0 ∪ W_{L+K-1}` leaves the right
+window. -/
+theorem horizontalStaircaseEndPair_sdiff_leftWindow {L K : ℕ} (hxw : 2 * L ≤ width)
+    (s : TorusVertex width height) :
+    horizontalStaircaseEndPair s L K \ horizontalStaircaseLeftWindow s L K =
+      horizontalStaircaseRightWindow s L K := by
+  rw [horizontalStaircaseEndPair, Finset.union_sdiff_left,
+    Finset.sdiff_eq_self_of_disjoint
+      (horizontalStaircaseEndPair_disjoint hxw s).symm]
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- The difference of the end pair and the right window is the left window. -/
+theorem horizontalStaircaseEndPair_sdiff_rightWindow {L K : ℕ} (hxw : 2 * L ≤ width)
+    (s : TorusVertex width height) :
+    horizontalStaircaseEndPair s L K \ horizontalStaircaseRightWindow s L K =
+      horizontalStaircaseLeftWindow s L K := by
+  rw [horizontalStaircaseEndPair, Finset.union_sdiff_right,
+    Finset.sdiff_eq_self_of_disjoint (horizontalStaircaseEndPair_disjoint hxw s)]
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- **The complement of the left window splits into the right window and the rest.**
+
+The torus complement of the left end window is the disjoint union of the right end window (the
+window the bond `e` joins to) and the complement of the end pair `S`:
+`univ \ W_0 = W_{L+K-1} ∪ (univ \ S)`.  Since `W_0 ⊆ S`, the host `univ \ W_0` is
+`(S \ W_0) ∪ (univ \ S)`, and `S \ W_0 = W_{L+K-1}` at `2 * L ≤ width`.  This is the geometric
+content of the bond-`e` contraction: pairing the left window against its complement reads the
+opposite window's genuine block across `e` and the rest of the torus separately.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the bond `e` joins the two windows);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+theorem compl_leftWindow_eq_rightWindow_union_complEndPair {L K : ℕ} (hxw : 2 * L ≤ width)
+    (s : TorusVertex width height) :
+    Finset.univ \ horizontalStaircaseLeftWindow s L K =
+      horizontalStaircaseRightWindow s L K ∪
+        (Finset.univ \ horizontalStaircaseEndPair s L K) := by
+  rw [← horizontalStaircaseEndPair_sdiff_leftWindow hxw s, Finset.union_comm,
+    Finset.sdiff_union_sdiff_cancel (Finset.subset_univ _)
+      (horizontalStaircaseLeftWindow_subset_endPair s)]
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- **The complement of the right window splits into the left window and the rest.**
+
+The transpose of `compl_leftWindow_eq_rightWindow_union_complEndPair`:
+`univ \ W_{L+K-1} = W_0 ∪ (univ \ S)`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 4. -/
+theorem compl_rightWindow_eq_leftWindow_union_complEndPair {L K : ℕ} (hxw : 2 * L ≤ width)
+    (s : TorusVertex width height) :
+    Finset.univ \ horizontalStaircaseRightWindow s L K =
+      horizontalStaircaseLeftWindow s L K ∪
+        (Finset.univ \ horizontalStaircaseEndPair s L K) := by
+  rw [← horizontalStaircaseEndPair_sdiff_rightWindow hxw s, Finset.union_comm,
+    Finset.sdiff_union_sdiff_cancel (Finset.subset_univ _)
+      (horizontalStaircaseRightWindow_subset_endPair s)]
+
 end Torus
 
 end PEPS

--- a/TNLean/PEPS/TorusWindowPeel.lean
+++ b/TNLean/PEPS/TorusWindowPeel.lean
@@ -1,0 +1,240 @@
+import TNLean.PEPS.TorusWindowExtraction
+
+/-!
+# The boundary of the staircase end pair is the windows' external legs
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) extracts the bond operator on the distinguished edge `e`
+from the open-boundary end-pair equality `staircasePair_insert_eq_open` of
+`TNLean/PEPS/TorusWindowChain6.lean` (Step 4 of the proof sketch).  The extraction rests on the
+*single-crossing* geometry: `e` is the only lattice edge joining the two end windows, hence the
+only interior bond of the end pair `S = W_0 ⊔ W_{L+K-1}`, with every other open leg of each
+window crossing the boundary of `S`.
+
+The landed single-crossing lemmas of `TNLean/PEPS/TorusWindowExtraction.lean` supply one
+direction: a boundary edge of an end window other than `e` is a boundary edge of `S`
+(`isRegionBoundaryEdge_endPair_of_leftWindow`, `isRegionBoundaryEdge_endPair_of_rightWindow`).
+This file supplies the converse and assembles the complete characterization: every boundary edge
+of `S` is a boundary edge of exactly one of the two windows and is not `e`.  Together with the
+interiority of `e` (`not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge`), this
+exhibits the boundary `∂S` as the disjoint union of the two windows' external legs with `e` the
+single interior bond.  This characterization is the geometric peeling that turns the end-pair
+`RegionInsert` equality into a relation across the single bond `e`: the open legs of `S` are
+partitioned into the left window's external legs and the right window's external legs, and the
+only leg the two windows share is `e`, summed over in the end-pair contraction.
+
+The window the boundary edge of `S` belongs to is read off the in-region endpoint: the endpoint
+of `f` that lies in `S` lies in exactly one window (the two end windows are disjoint at
+`2 * L ≤ width`), and the out-of-`S` endpoint lies outside that window since it lies outside all
+of `S`.  The two windows being disjoint, no boundary edge of `S` is a boundary edge of both
+windows, so the partition is genuine.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
+  2296--2445 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+variable [Fact (1 < width)] [Fact (1 < height)]
+variable {d : ℕ}
+
+/-! ### A boundary edge of the end pair belongs to one window
+
+The in-region endpoint of a boundary edge of `S` lies in one of the two end windows; the
+out-of-region endpoint lies outside that window since it lies outside all of `S`.  This makes the
+edge a boundary edge of that window. -/
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- A vertex outside the end pair is outside the left end window. -/
+private theorem notMem_leftWindow_of_notMem_endPair {L K : ℕ} {s : TorusVertex width height}
+    {v : TorusVertex width height} (hv : v ∉ horizontalStaircaseEndPair s L K) :
+    v ∉ horizontalStaircaseLeftWindow s L K :=
+  fun hL => hv (horizontalStaircaseLeftWindow_subset_endPair s hL)
+
+omit [Fact (1 < width)] [Fact (1 < height)] in
+/-- A vertex outside the end pair is outside the right end window. -/
+private theorem notMem_rightWindow_of_notMem_endPair {L K : ℕ} {s : TorusVertex width height}
+    {v : TorusVertex width height} (hv : v ∉ horizontalStaircaseEndPair s L K) :
+    v ∉ horizontalStaircaseRightWindow s L K :=
+  fun hR => hv (horizontalStaircaseRightWindow_subset_endPair s hR)
+
+/-- **A boundary edge of the end pair is a boundary edge of one of the two windows.**
+
+A boundary edge `f` of the staircase end pair `S = W_0 ⊔ W_{L+K-1}` is a boundary edge of the
+left end window or of the right end window: the in-region endpoint of `f` lies in `S`, hence in
+one of the two windows, while the out-of-region endpoint lies outside all of `S`, hence outside
+that window.  This is the converse of the landed
+`isRegionBoundaryEdge_endPair_of_leftWindow` / `...rightWindow`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the external legs of the two windows are the boundary of the
+end pair); `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+theorem isRegionBoundaryEdge_window_of_endPair {L K : ℕ} {s : TorusVertex width height}
+    {f : Edge (torusGraph width height)}
+    (hf : IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseEndPair s L K) f) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+        (horizontalStaircaseLeftWindow s L K) f ∨
+      IsRegionBoundaryEdge (G := torusGraph width height)
+        (horizontalStaircaseRightWindow s L K) f := by
+  rcases hf with ⟨hin, hout⟩ | ⟨hout, hin⟩
+  · -- `f.1.1 ∈ S`, `f.1.2 ∉ S`.  Split on which window the in-endpoint lies in.
+    rw [horizontalStaircaseEndPair, Finset.mem_union] at hin
+    rcases hin with hinL | hinR
+    · exact Or.inl (Or.inl ⟨hinL, notMem_leftWindow_of_notMem_endPair hout⟩)
+    · exact Or.inr (Or.inl ⟨hinR, notMem_rightWindow_of_notMem_endPair hout⟩)
+  · -- `f.1.2 ∈ S`, `f.1.1 ∉ S`.
+    rw [horizontalStaircaseEndPair, Finset.mem_union] at hin
+    rcases hin with hinL | hinR
+    · exact Or.inl (Or.inr ⟨notMem_leftWindow_of_notMem_endPair hout, hinL⟩)
+    · exact Or.inr (Or.inr ⟨notMem_rightWindow_of_notMem_endPair hout, hinR⟩)
+
+/-! ### A boundary edge of the end pair is not the reference edge
+
+The reference edge `e` is interior to `S` (both endpoints in `S`, one per window), so it is not a
+boundary edge of `S`.  Hence every boundary edge of `S` differs from `e`. -/
+
+/-- **A boundary edge of the end pair is not the reference edge.**
+
+A boundary edge `f` of the staircase end pair `S` differs from the reference edge `e`: `e` has
+both endpoints in `S` (one in each window), so `e` is interior to `S`
+(`not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge`), while `f` is a boundary
+edge of `S`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the single bond `e` is the only interior bond);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+theorem ne_referenceEdge_of_isRegionBoundaryEdge_endPair {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    {f : Edge (torusGraph width height)}
+    (hf : IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseEndPair ((a : ZMod width), (b : ZMod height)) L K) f) :
+    f ≠ horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K := by
+  rintro rfl
+  exact not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge hL hK ha0 haw hbh hf
+
+/-! ### The complete characterization of the end pair's boundary
+
+The boundary edges of `S` are exactly the boundary edges of the two windows other than the
+reference edge `e`: an edge is a boundary edge of `S` if and only if it is a boundary edge of one
+of the two windows and is not `e`.  This is the partition of the open legs of `S` into the two
+windows' external legs, with `e` the single interior bond. -/
+
+/-- **The boundary of the end pair is the windows' external legs.**
+
+An edge `f` is a boundary edge of the staircase end pair `S = W_0 ⊔ W_{L+K-1}` if and only if it
+is a boundary edge of one of the two end windows and differs from the reference edge `e`.  The
+forward direction is `isRegionBoundaryEdge_window_of_endPair` together with
+`ne_referenceEdge_of_isRegionBoundaryEdge_endPair`; the backward direction is the landed
+`isRegionBoundaryEdge_endPair_of_leftWindow` / `...rightWindow`.  This exhibits `∂S` as the
+disjoint union of the external legs of the two windows, with `e` the single interior bond summed
+over in the end-pair contraction — the geometric peeling that turns the end-pair `RegionInsert`
+equality into a relation across the single bond `e`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex` (the external legs of the two windows are the boundary of the
+end pair, `e` the single bond joining them); `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 4. -/
+theorem isRegionBoundaryEdge_endPair_iff {L K a b : ℕ}
+    (A : Tensor (torusGraph width height) d)
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (f : Edge (torusGraph width height)) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+        (horizontalStaircaseEndPair ((a : ZMod width), (b : ZMod height)) L K) f ↔
+      (IsRegionBoundaryEdge (G := torusGraph width height)
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) f ∨
+          IsRegionBoundaryEdge (G := torusGraph width height)
+            (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) f) ∧
+        f ≠ horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K := by
+  constructor
+  · intro hf
+    exact ⟨isRegionBoundaryEdge_window_of_endPair hf,
+      ne_referenceEdge_of_isRegionBoundaryEdge_endPair hL hK ha0 haw hbh hf⟩
+  · rintro ⟨hwin | hwin, hne⟩
+    · exact isRegionBoundaryEdge_endPair_of_leftWindow A hL hK ha0 haw hbh hwin hne
+    · exact isRegionBoundaryEdge_endPair_of_rightWindow A hL hK ha0 haw hbh hwin hne
+
+/-! ### A boundary edge of the end pair lies on exactly one window
+
+The reference edge `e` is a boundary edge of *both* windows (it is the crossing edge), but it is
+*not* a boundary edge of `S`.  Every other edge that is a boundary edge of both windows is
+likewise `e` (the single crossing).  Hence a boundary edge of `S` — which excludes `e` — is a
+boundary edge of exactly one window: the partition of `∂S` into the two windows' external legs is
+disjoint. -/
+
+/-- **An edge that is a boundary edge of both end windows is the reference edge.**
+
+The only edge that is a boundary edge of both the left and the right end window is the reference
+edge `e`: a boundary edge of both is a crossing edge of the pair
+(`IsCrossingEdge`), and the unique crossing edge is `e`
+(`isCrossingEdge_horizontalStaircaseEndWindows`).  Conversely `e` is a boundary edge of each
+window.  So the two windows' external legs meet only along `e`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 4. -/
+theorem eq_referenceEdge_of_isRegionBoundaryEdge_both_endWindows {L K a b : ℕ}
+    (A : Tensor (torusGraph width height) d)
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    {f : Edge (torusGraph width height)}
+    (hfL : IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) f)
+    (hfR : IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) f) :
+    f = horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K :=
+  (isCrossingEdge_horizontalStaircaseEndWindows A hL hK ha0 haw hbh f).mp ⟨hfL, hfR⟩
+
+/-- **A boundary edge of the end pair lies on exactly one window.**
+
+A boundary edge `f` of the staircase end pair `S` is a boundary edge of exactly one of the two end
+windows: it is a boundary edge of one (`isRegionBoundaryEdge_window_of_endPair`), and it is not a
+boundary edge of both, since the only edge that is a boundary edge of both is the reference edge
+`e` (`eq_referenceEdge_of_isRegionBoundaryEdge_both_endWindows`), which is not a boundary edge of
+`S` (`ne_referenceEdge_of_isRegionBoundaryEdge_endPair`).  This is the disjointness of the
+partition of `∂S` into the two windows' external legs.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
+Step 4. -/
+theorem isRegionBoundaryEdge_endPair_exactlyOne_window {L K a b : ℕ}
+    (A : Tensor (torusGraph width height) d)
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    {f : Edge (torusGraph width height)}
+    (hf : IsRegionBoundaryEdge (G := torusGraph width height)
+      (horizontalStaircaseEndPair ((a : ZMod width), (b : ZMod height)) L K) f) :
+    (IsRegionBoundaryEdge (G := torusGraph width height)
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) f ∧
+        ¬ IsRegionBoundaryEdge (G := torusGraph width height)
+          (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) f) ∨
+      (¬ IsRegionBoundaryEdge (G := torusGraph width height)
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) f ∧
+        IsRegionBoundaryEdge (G := torusGraph width height)
+          (horizontalStaircaseRightWindow ((a : ZMod width), (b : ZMod height)) L K) f) := by
+  have hne : f ≠ horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K :=
+    ne_referenceEdge_of_isRegionBoundaryEdge_endPair hL hK ha0 haw hbh hf
+  -- `f` is a boundary edge of one window; were it a boundary edge of both, it would be `e`.
+  rcases isRegionBoundaryEdge_window_of_endPair hf with hfL | hfR
+  · refine Or.inl ⟨hfL, fun hfR => hne ?_⟩
+    exact eq_referenceEdge_of_isRegionBoundaryEdge_both_endWindows A hL hK ha0 haw hbh hfL hfR
+  · refine Or.inr ⟨fun hfL => hne ?_, hfR⟩
+    exact eq_referenceEdge_of_isRegionBoundaryEdge_both_endWindows A hL hK ha0 haw hbh hfL hfR
+
+end Torus
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -758,6 +758,126 @@ agree input; it carries no $\mathrm{univ} \setminus S$ injectivity hypothesis. T
 \path{univ} $\setminus S$ obstruction of Step~3 is therefore eliminated, and the back half of the
 overlapping-window campaign is unblocked.
 
+\section{The single-bond extraction and the host-injectivity scope of the
+back half}
+
+This section records two findings that follow the landing of the open-boundary
+end-pair equality \path{staircasePair_insert_eq_open} and the single-crossing
+geometry of Step~4: the geometric peeling of the end-pair equality onto the
+single bond $e$, and a precise scope verdict on what host injectivity the
+back-half of Theorem~3 (Step~5) actually needs.
+
+\subsection{The boundary of the end pair is the windows' external legs}
+
+Step~3 now delivers the open-boundary equality on the end pair $S = W_0 \sqcup
+W_{L+K-1}$ without inverting $\mathrm{univ}\setminus S$: the corner-extension
+composition $\path{extendInsert}(S\subseteq P)\circ\path{extendInsert}(R\subseteq
+S) = \path{extendInsert}(R\subseteq P)$ and the shared-corner cancellation
+$\path{staircasePair\_cancel}$ are landed, and the end-pair equality
+\[
+  \path{extendInsert}(W_0\subseteq S)\,C_0 \;=\;
+  \path{extendInsert}(W_{L+K-1}\subseteq S)\,C_{L+K-1}
+  \qquad\text{as inserts on } S
+\]
+is \path{staircasePair_insert_eq_open}, with no $\mathrm{univ}\setminus S$
+hypothesis. The single-crossing geometry of Step~4 shows $e$ is the only lattice
+edge joining the two end windows, hence the only interior bond of $S$.
+
+The geometric peeling of this equality onto the bond $e$ rests on the complete
+characterization of the boundary $\partial S$. The landed direction
+($\path{isRegionBoundaryEdge\_endPair\_of\_leftWindow}$ and its right-window
+counterpart) shows a boundary edge $f\neq e$ of one window is a boundary edge of
+$S$. The converse, supplying the partition, is
+$\path{isRegionBoundaryEdge\_window\_of\_endPair}$: a boundary edge of $S$ is a
+boundary edge of one of the two windows, read off the in-region endpoint, whose
+out-of-region endpoint lies outside that window since it lies outside all of $S$.
+Combined with $e$'s interiority, this gives
+$\path{isRegionBoundaryEdge\_endPair\_iff}$: $f$ is a boundary edge of $S$ iff it
+is a boundary edge of one window and $f\neq e$; and
+$\path{isRegionBoundaryEdge\_endPair\_exactlyOne\_window}$: each boundary edge of
+$S$ lies on \emph{exactly} one window, since the only edge on both windows is $e$
+($\path{eq\_referenceEdge\_of\_isRegionBoundaryEdge\_both\_endWindows}$), which is
+not a boundary edge of $S$. So $\partial S$ is the disjoint union of the two
+windows' external legs, with $e$ the single interior bond summed over in the
+end-pair contraction. This is the geometric content the bond-$e$ coefficient
+identity reads: the open legs of $S$ split into the left-window external legs and
+the right-window external legs, and the matrix on $e$ is the only datum the two
+windows share. These facts are in \path{TNLean/PEPS/TorusWindowPeel.lean}.
+
+\subsection{The back half transfers with a window as witness region}
+
+The torus back half of Theorem~3 consumes host injectivity in exactly two
+places, and at the corollary's minimal size $(2L+1)\times(2K+1)$ both are
+supplied by one-orientation $L\times K$ window translates --- the obstruction of
+Step~3 (that $\mathrm{univ}\setminus S$ is not injective at the minimal size) does
+not propagate to either.
+
+\emph{The witness region.} The per-edge interface
+$\path{EdgeCoeffIdentityWitness}$ bundles a region whose boundary contains $e$,
+the second tensor's region and host blocked-tensor injectivity, and the
+conjugation coefficient identities on $e$. Its host field
+$\path{hCB}:\path{RegionBlockedTensorInjective}\,B\,(\mathrm{univ}\setminus
+\path{region})$ is host injectivity of the \emph{witness} region, not of $S$. The
+rectangle route takes $\path{region}$ to be the reference rectangle's red block,
+host injective only at the three-block sizes ($\geq 7$, or the seam-touching
+$+5=\mathrm{width}$ special case). At the window route, $\path{region}$ may be a
+single end window $W$: $e$ is a boundary edge of each end window
+($\path{isRegionBoundaryEdge\_horizontalStaircaseLeftWindow\_referenceEdge}$ and
+its right counterpart), $W$ is region injective
+($\path{horizontalStaircaseLeftWindow\_injective}$), and crucially its host
+$\mathrm{univ}\setminus W$ \emph{is} injective at $(2L+1)\times(2K+1)$ --- this is
+the landed $\path{regionBlockedTensorInjective\_windowComplement}$, whose
+complement decomposition (a full-height band of $\mathrm{width}-L\geq L+1$ columns
+and an $L$-column band of $\mathrm{height}-K\geq K+1$ rows, each an $L\times K$
+window union) needs exactly $2L+1\leq\mathrm{width}$, $2K+1\leq\mathrm{height}$.
+So a single window is a valid $\path{EdgeCoeffIdentityWitness}$ region with host
+injectivity available at the minimal size, once the peeling of \S5.1 produces the
+bond-$e$ coefficient identity $\path{regionInsertedCoeff}\,A\,W\,\langle
+e\rangle\,M = \path{regionInsertedCoeff}\,B\,W\,\langle e\rangle\,(Z\,M\,Z^{-1})$
+with $W$ in place of the rectangle red block.
+
+\emph{The comparison regions.} The scalar extraction
+$\path{lambda\_pow\_card\_torus\_eq\_one}$ takes a single comparison region $R$
+with $R$ and $\mathrm{univ}\setminus R$ injective; the per-vertex relation
+$\path{component\_eq\_gaugeVertex\_of\_cornerProportional}$ compares $R$ against
+$\path{insert}\,v\,R$, needing both regions' hosts injective. The formalized $R$
+is $\path{cornerRegion}$ (the $3\times3$ square minus its corner) and
+$\path{insert}\,v\,R = \path{cornerSquare}$ (the $3\times3$ square), at offset
+$(2,2)$ with hardcoded $7\leq\mathrm{width}$, $7\leq\mathrm{height}$; their host
+decompositions ($\path{compl\_cornerRegion\_injective}$,
+$\path{compl\_cornerSquare\_injective}$) use both rectangle orientations
+($\path{rect23}$, $\path{rect32}$, $\path{wideRectangle}$, $\path{shortRectangle}$)
+and width-$2$/width-$(\mathrm{width}-5)$ bands tied to the $3\times3$ shape. These
+are the $L=K=2$ instance of the source's $(L+1)\times(K+1)$ comparison pair. The
+one-orientation replacement, as Step~5 of this note prescribes, is the
+$(L+1)\times(K+1)$ cyclic rectangle minus one corner vertex against the full
+$(L+1)\times(K+1)$ rectangle. Both are region injective with one orientation by
+$\path{arcRectangle\_injective}$ (a cyclic rectangle of width $\geq L$, height
+$\geq K$ is the union of the $L\times K$ windows sliding over it). Both hosts
+decompose at the minimal size: by $\path{compl\_torusArcRectangle}$ the complement
+of a $(L+1)\times(K+1)$ cyclic rectangle is a full-height band of
+$\mathrm{width}-(L+1)\geq L$ columns and an $(L+1)$-column band of
+$\mathrm{height}-(K+1)\geq K$ rows, each injective by
+$\path{arcRectangle\_injective}$; the band widths reach exactly $L$ and the
+heights exactly $K$ at $2L+1$, $2K+1$, which is why the corollary needs no larger
+size. The minus-corner region differs by one vertex and decomposes the same way
+with one extra corner rectangle, the transpose of the formalized
+$\path{cornerRegion}$ band decomposition.
+
+\emph{Verdict.} The back half transfers to the corollary's minimal size with the
+window as witness region and the $(L+1)\times(K+1)$-shaped comparison pair, both
+host-decomposable into one-orientation $L\times K$ window translates at $2L+1$,
+$2K+1$. No host injectivity genuinely fails at the minimal size for any region the
+back half inverts: the sole failure, $\mathrm{univ}\setminus S$, is confined to
+the Step~3 stripping, which the open-boundary route already circumvents. The
+capstone is therefore an \emph{assembly} of landed machinery --- the peeling of
+\S5.1 to the bond-$e$ coefficient identity (the one genuinely-new mechanical
+piece, whose geometric foundation is now landed), the window-region witness with
+its already-available host injectivity, and the re-anchored comparison pair built
+from $\path{arcRectangle\_injective}$ and $\path{compl\_torusArcRectangle}$ ---
+not further research. A host-free variant of the back-half engines is \emph{not}
+needed.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## Summary

The back half of the 2D overlapping-window campaign (arXiv:1804.04964, the
corollary at lines 2297–2318): the geometric peeling of the landed
hcompl-free end-pair equality onto the single bond `e`, plus a precise scope
verdict on the host injectivity the torus Theorem-3 back half needs at the
corollary's minimal size.

## Deliverable A — the peeling foundation

The end-pair equality `staircasePair_insert_eq_open` (#2765) is an equality of
`RegionInsert B S` on `S = W_0 ⊔ W_{L+K-1}`, with `e` the single interior bond
(#2766). The peeling onto `e` rests on the complete characterization of `∂S`,
landed in `TNLean/PEPS/TorusWindowPeel.lean`:

- `isRegionBoundaryEdge_window_of_endPair` — the converse of the #2766 single-
  crossing boundary lemmas: a boundary edge of `S` is a boundary edge of one of
  the two windows (read off the in-region endpoint).
- `isRegionBoundaryEdge_endPair_iff` — `f ∈ ∂S` iff `f` is a boundary edge of
  one window and `f ≠ e`.
- `isRegionBoundaryEdge_endPair_exactlyOne_window` — each boundary edge of `S`
  lies on exactly one window (the only edge on both is `e`, which is interior
  to `S`).
- `compl_leftWindow_eq_rightWindow_union_complEndPair` (and its right-window
  transpose) — `univ \ W_0 = W_{L+K-1} ∪ (univ \ S)`: pairing one window
  against its complement reads the opposite window's genuine block across `e`
  and the rest of the torus separately. This is the geometric fact the bond-`e`
  coefficient identity factors through.

Together these exhibit `∂S` as the disjoint union of the two windows' external
legs with `e` the single interior bond — the geometric peeling that turns the
end-pair `RegionInsert` equality into a relation across `e`. The residual to a
full bond-`e` `regionInsertedCoeff` identity is the index bookkeeping along the
`univ \ W = W' ⊔ (univ \ S)` split (the `M`-on-`e` insert against the opposite-
window block), recorded in the gap note §5.1.

## Deliverable B — the scope verdict (decisive)

Recorded in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex` §5.2.
**Verdict (a): the back half transfers with a window as witness region**; no
host-free variant is needed.

The back half consumes host injectivity in exactly two places, both supplied by
one-orientation `L×K` window translates at `(2L+1)×(2K+1)`:

1. **Witness region** (`EdgeCoeffIdentityWitness.hCB`): the rectangle route uses
   the reference rectangle's red block (host injective only at ≥7 / the
   `+5=width` special case). A single end window `W` is a valid replacement: `e`
   is a boundary edge of each window (#2766), `W` is region injective
   (`horizontalStaircaseLeftWindow_injective`), and its host is injective at the
   minimal size — landed `regionBlockedTensorInjective_windowComplement`.
2. **Comparison regions** (`lambda_pow_card_torus_eq_one`,
   `component_eq_gaugeVertex_of_cornerProportional`): the formalized
   `cornerRegion`/`cornerSquare` are the `L=K=2` instance (`3×3` minus corner /
   `3×3`), hardcoded at `7 ≤ width` with both rectangle orientations. The
   re-anchored `(L+1)×(K+1)`-shaped pair is region injective with one
   orientation (`arcRectangle_injective`) and its host decomposes at `2L+1`
   into a full-height band of width `width-(L+1) ≥ L` and an `(L+1)`-column band
   of height `height-(K+1) ≥ K` (`compl_torusArcRectangle`), both window unions.

The only host injectivity that fails at the minimal size is `univ \ S` for the
end pair — confined to the Step-3 stripping, which the open-boundary route
already circumvents. The capstone is therefore **assembly** of landed machinery
(the §5.1 peeling, the window-region witness, the re-anchored comparison pair),
not further research.

## Verification

- Sorry-free; no `maxHeartbeats`/`native_decide`/`axiom`.
- `#print axioms` on the new lemmas: `[propext, Classical.choice, Quot.sound]`.
- Full root `lake build` green; `lake exe lint-style` exit 0.
- No blueprint entries.

Source: arXiv:1804.04964 §Step 4–5; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sorry-free formal geometry and documentation only; no changes to auth, runtime, or existing theorem APIs beyond a new PEPS import.
> 
> **Overview**
> Adds **`TNLean/PEPS/TorusWindowPeel.lean`** (wired into the root import list) to finish the **Step 4 boundary geometry** for the horizontal staircase end pair `S`: converse lemmas that every `∂S` edge lies on one end window, iff/`≠ e` characterizations, **exactly-one-window** disjointness, and **`univ \ W = W' ⊔ (univ \ S)`** complement splits for bond-`e` contraction.
> 
> Updates **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** with **§5**: how that peeling supports the bond-`e` coefficient identity, and a **scope verdict** that Theorem 3’s back half at minimal `(2L+1)×(2K+1)` needs host injectivity only for a **single window witness** and **re-anchored `(L+1)×(K+1)` comparison regions**—not `univ \ S`, which Step 3’s open-boundary route already avoids.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ada09b70fdf0e5d2d97e430ce31f2ab1dc1a835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->