### PR TITLE
feat(PEPS): the single-bond peeling and window-region witness

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -421,6 +421,7 @@ import TNLean.PEPS.TorusWindowChain5
 import TNLean.PEPS.TorusWindowChain6
 import TNLean.PEPS.TorusWindowExtraction
 import TNLean.PEPS.TorusWindowPeel
+import TNLean.PEPS.TorusWindowPeel2
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusReferenceBlockingData

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -422,6 +422,7 @@ import TNLean.PEPS.TorusWindowChain6
 import TNLean.PEPS.TorusWindowExtraction
 import TNLean.PEPS.TorusWindowPeel
 import TNLean.PEPS.TorusWindowPeel2
+import TNLean.PEPS.TorusWindowWitness
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusReferenceBlockingData

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -422,6 +422,7 @@ import TNLean.PEPS.TorusWindowChain6
 import TNLean.PEPS.TorusWindowExtraction
 import TNLean.PEPS.TorusWindowPeel
 import TNLean.PEPS.TorusWindowPeel2
+import TNLean.PEPS.TorusWindowPeel3
 import TNLean.PEPS.TorusWindowWitness
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge

--- a/TNLean/PEPS/TorusWindowPeel2.lean
+++ b/TNLean/PEPS/TorusWindowPeel2.lean
@@ -1,0 +1,115 @@
+import TNLean.PEPS.TorusWindowPeel
+
+/-!
+# The bond insertion as a window deformed state
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) extracts the bond operator on the distinguished edge `e`
+from the open-boundary end-pair equality `staircasePair_insert_eq_open`.  That equality is stated
+for the *deformed-window* vocabulary — inserts on a region and their closed-torus deformed states —
+while the per-edge gauge of Step 5 is read off the *region-inserted coefficient*
+`regionInsertedCoeff`, which inserts a matrix on one crossing bond and contracts the region against
+its complement.  This file bridges the two: the deformed state of a window carrying the
+*bond-inserted* insert equals the region-inserted coefficient.
+
+## The bond-inserted insert
+
+For a region `R`, a boundary edge `f` of `R`, and a matrix `M` on `f`, the bond-inserted insert
+`bondInsertedRegionInsert A R f M` is the insert on `R` whose boundary configuration `ν` reads the
+combination of the genuine `R` block over all boundary configurations `μ` agreeing with `ν` away
+from `f`, with `M` coupling their `f`-legs.  Contracting this insert against the complement is the
+double-boundary-sum of `regionInsertedCoeff`: the inner `μ`-sum builds the bond-inserted insert,
+the outer `ν`-sum is the complement contraction of the deformed state.  This is the content of
+`deformedRegionState_bondInsertedRegionInsert`.
+
+The bridge lets the staircase end-pair equality, stated as an `extendInsert` equality of window
+inserts, drive a relation between region-inserted coefficients on a single window: taking the
+window inserts to be the bond-inserted inserts, the end-pair equality compares the genuine block of
+one window against the genuine block of the other across the single bond `e`, which is the peeling
+of the end-pair equality onto `e`.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
+  2296--2445 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Steps 4--5.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A : Tensor G d}
+
+/-! ### The bond-inserted insert on a region
+
+Inserting a matrix `M` on a boundary edge `f` of `R` is, at the level of inserts, the insert whose
+boundary configuration `ν` (read by the complement) carries the `M`-coupled combination of the
+genuine `R` block over the boundary configurations `μ` that agree with `ν` away from `f`.  Its
+deformed state recovers `regionInsertedCoeff`. -/
+
+open scoped Classical in
+/-- The bond-inserted insert on `R`: for a boundary configuration `ν` and physical configuration
+`σ` on `R`, the combination of the genuine `R` block `regionBlockedWeight A R μ σ` over the
+boundary configurations `μ` agreeing with `ν` away from `f`, weighted by `M (μ f) (ν f)`.
+
+Pairing this insert against the complement is the region-inserted coefficient: the boundary
+configuration `ν` of the insert is the one read by the complement contraction, and the inner
+`μ`-sum is the region side coupled to it by `M` across `f`.
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 of `Papers/1804.04964/paper_normal.tex` (one
+block against its complement, with a matrix inserted on the shared bond);
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+noncomputable def bondInsertedRegionInsert (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) :
+    RegionInsert (G := G) (d := d) A R :=
+  fun ν σ =>
+    ∑ μ : RegionBoundaryConfig (G := G) A R,
+      (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+        regionBlockedWeight (G := G) A R μ σ
+
+open scoped Classical in
+/-- **The bond insertion is the bond-inserted insert's deformed state.**
+
+The deformed state of `R` with the bond-inserted insert `bondInsertedRegionInsert A R f M` equals
+the region-inserted coefficient `regionInsertedCoeff A R f M`.  Both contract `R` against its
+complement with `M` inserted on `f`; the deformed state's single boundary sum over `ν` (read by the
+complement) carries the inner `μ`-sum of the bond-inserted insert, reproducing the double sum of
+`regionInsertedCoeff`.
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 of `Papers/1804.04964/paper_normal.tex`;
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+theorem deformedRegionState_bondInsertedRegionInsert (A : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+    (σ : RegionPhysicalConfig (V := V) (d := d) R)
+    (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)) :
+    deformedRegionState (G := G) A R (bondInsertedRegionInsert (G := G) A R f M) σ τ =
+      regionInsertedCoeff (G := G) A R f M σ τ := by
+  classical
+  rw [deformedRegionState, regionInsertedCoeff_eq]
+  -- The deformed state's `ν`-sum carries the bond-inserted insert's inner `μ`-sum.  Push the
+  -- complement weight into the `μ`-sum and swap the order of summation to match the `μ`-outer /
+  -- `ν`-inner double sum of `regionInsertedCoeff`.
+  rw [show (∑ ν : RegionBoundaryConfig (G := G) A R,
+        bondInsertedRegionInsert (G := G) A R f M ν σ *
+          regionBlockedWeight (G := G) A (Finset.univ \ R)
+            (regionComplementBoundaryConfig (G := G) A R ν) τ) =
+      ∑ ν : RegionBoundaryConfig (G := G) A R,
+        ∑ μ : RegionBoundaryConfig (G := G) A R,
+          (if SameAwayFromBond f μ ν then M (μ f) (ν f) else 0) *
+            regionBlockedWeight (G := G) A R μ σ *
+            regionBlockedWeight (G := G) A (Finset.univ \ R)
+              (regionComplementBoundaryConfig (G := G) A R ν) τ from ?_,
+    Finset.sum_comm]
+  refine Finset.sum_congr rfl (fun ν _ => ?_)
+  rw [bondInsertedRegionInsert, Finset.sum_mul]
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWindowPeel2.lean
+++ b/TNLean/PEPS/TorusWindowPeel2.lean
@@ -111,5 +111,38 @@ theorem deformedRegionState_bondInsertedRegionInsert (A : Tensor G d) (R : Finse
   refine Finset.sum_congr rfl (fun ν _ => ?_)
   rw [bondInsertedRegionInsert, Finset.sum_mul]
 
+/-! ### The bond insertion as the extended deformed state on a superset
+
+For a region `R ⊆ S`, the bond insertion on `R` (read off a global configuration through its `R`-
+and `univ \ R`-restrictions) equals the corner-extended deformed state on `S`: the deformed-state
+extension identity `deformedRegionState_extend` reads the bond-inserted deformed state on `R` as
+the deformed state on `S` of the corner-extended bond-inserted insert.  This is the form the
+staircase end-pair equality consumes, where `R = W` is a single end window and `S = W_0 ⊔ W_{L+K-1}`
+is the end pair: the genuine block of the *opposite* window the bond `e` joins to is carried by the
+corner extension `extendInsert (W ⊆ S)`. -/
+
+/-- **The bond insertion is the corner-extended deformed state on a superset.**
+
+For `R ⊆ S`, the region-inserted coefficient `regionInsertedCoeff A R f M` read off a global
+configuration `cfg` (restricted to `R` and to `univ \ R`) equals the assembled deformed state on `S`
+of the corner-extended bond-inserted insert `extendInsert (R ⊆ S) (bondInsertedRegionInsert A R f
+M)`.  The bridge `deformedRegionState_bondInsertedRegionInsert` writes the coefficient as the
+bond-inserted deformed state on `R`, and `deformedRegionState_extend` reads that as the deformed
+state on `S` of the corner extension.
+
+Source: arXiv:1804.04964, Section 3, lines 1205--1210 and the proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/
+theorem regionInsertedCoeff_eq_extendInsert_bondInserted {R S : Finset V} (hRS : R ⊆ S)
+    (hpos : ∀ e : Edge G, 0 < A.bondDim e)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ) (cfg : V → Fin d) :
+    regionInsertedCoeff (G := G) A R f M
+        (restrictRegionσ (V := V) (d := d) R cfg)
+        (restrictRegionσ (V := V) (d := d) (Finset.univ \ R) cfg) =
+      deformedRegionStateAssembled (G := G) A S
+        (extendInsert (G := G) hRS (bondInsertedRegionInsert (G := G) A R f M)) cfg := by
+  rw [← deformedRegionState_extend hRS hpos (bondInsertedRegionInsert (G := G) A R f M),
+    deformedRegionStateAssembled, deformedRegionState_bondInsertedRegionInsert]
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowPeel3.lean
+++ b/TNLean/PEPS/TorusWindowPeel3.lean
@@ -1,0 +1,156 @@
+import TNLean.PEPS.TorusWindowPeel2
+
+/-!
+# The single-bond peeling of the staircase end-pair equality
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) extracts the bond operator on the distinguished edge `e` from
+the open-boundary end-pair equality `staircasePair_insert_eq_open`.  This file performs the peeling
+of that equality onto the single bond `e`: when the staircase window inserts are the bond-inserted
+inserts on the two end windows (and arbitrary inserts on the intermediate windows) all sharing one
+deformed state, the end-pair equality reads as an equality of the two end windows' region-inserted
+coefficients across `e`.
+
+## The peeling
+
+The bridge `regionInsertedCoeff_eq_extendInsert_bondInserted` of `TNLean/PEPS/TorusWindowPeel2.lean`
+writes the region-inserted coefficient of an end window, with a matrix inserted on `e`, as the
+assembled deformed state of the corner-extended bond-inserted insert on the end pair `S`.  The
+end-pair equality `staircasePair_insert_eq_open` equates the two corner-extended inserts on `S`,
+hence their assembled deformed states.  Chaining the two bridge identities through the end-pair
+equality leaves the two end windows' region-inserted coefficients equal across `e`, read off any
+global physical configuration.  This is the single-tensor content of the peeling; the cross-tensor
+gauge is the algebra-isomorphism step that consumes this equality, the residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
+  2296--2445 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+variable [Fact (1 < width)] [Fact (1 < height)]
+variable {d : ℕ} {L K : ℕ} {B : Tensor (torusGraph width height) d}
+
+/-! ### The reference edge as a boundary edge of the first and last staircase windows
+
+The reference edge `e` is a boundary edge of the right end window `W_0` and the left end window
+`W_{L+K-1}`, hence of the first and last staircase windows `staircaseWindow s L K 0` and
+`staircaseWindow s L K (L+K-1)`, which are those two windows. -/
+
+/-- The reference edge is a boundary edge of the first staircase window `W_0` (the right end
+window).
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem isRegionBoundaryEdge_staircaseWindow_zero_referenceEdge
+    (A : Tensor (torusGraph width height) d) {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0)
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) := by
+  rw [staircaseWindow_zero]
+  exact isRegionBoundaryEdge_horizontalStaircaseRightWindow_referenceEdge A hL hK ha0 haw hbh
+
+/-- The reference edge is a boundary edge of the last staircase window `W_{L+K-1}` (the left end
+window).
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem isRegionBoundaryEdge_staircaseWindow_last_referenceEdge
+    (A : Tensor (torusGraph width height) d) {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K (L + K - 1))
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) := by
+  rw [staircaseWindow_last _ hL hK]
+  exact isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw hbh
+
+/-! ### The single-bond peeling
+
+The bond-inserted inserts on the two end windows, plugged into the end-pair equality, peel the
+equality onto the single bond `e`. -/
+
+/-- **The single-bond peeling of the staircase end-pair equality.**
+
+Given a family of inserts `C` on the staircase windows whose deformed states all equal one common
+state, with the first window's insert `C 0` the bond-inserted insert of a matrix `M` on the
+reference edge `e` and the last window's insert `C (L+K-1)` the bond-inserted insert of `M'`, the
+two end windows' region-inserted coefficients with `M` and `M'` inserted on `e` agree, read off any
+global physical configuration `cfg`.
+
+The bridge `regionInsertedCoeff_eq_extendInsert_bondInserted` writes each side as the assembled
+deformed state of the corner-extended bond-inserted insert on the end pair `S`; the end-pair
+equality `staircasePair_insert_eq_open` equates those two assembled states.  This is the
+single-tensor content of the peeling: the cross-tensor gauge `Z` and the conjugation identity are
+the algebra-isomorphism step that consumes this equality, the residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem regionInsertedCoeff_endWindows_eq_of_staircase {a b : ℕ}
+    (h : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (M M' : Matrix
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+      (Fin (B.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+      ℂ)
+    (C : ∀ j, RegionInsert (G := torusGraph width height) (d := d)
+      B (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j))
+    (common : (TorusVertex width height → Fin d) → ℂ)
+    (hagree : ∀ j, j < L + K →
+      deformedRegionStateAssembled (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j) (C j) = common)
+    (hC0 : C 0 = bondInsertedRegionInsert (G := torusGraph width height) B
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0)
+      ⟨_, isRegionBoundaryEdge_staircaseWindow_zero_referenceEdge B
+        (by omega) (by omega) ha0 haw hbh⟩ M)
+    (hClast : C (L + K - 1) = bondInsertedRegionInsert (G := torusGraph width height) B
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K (L + K - 1))
+      ⟨_, isRegionBoundaryEdge_staircaseWindow_last_referenceEdge B
+        (by omega) (by omega) ha0 haw hbh⟩ M')
+    (cfg : TorusVertex width height → Fin d) :
+    regionInsertedCoeff (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K 0)
+        ⟨_, isRegionBoundaryEdge_staircaseWindow_zero_referenceEdge B
+          (by omega) (by omega) ha0 haw hbh⟩ M
+        (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
+        (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg) =
+      regionInsertedCoeff (G := torusGraph width height) B
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K (L + K - 1))
+        ⟨_, isRegionBoundaryEdge_staircaseWindow_last_referenceEdge B
+          (by omega) (by omega) ha0 haw hbh⟩ M'
+        (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
+        (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg) := by
+  -- Bridge each side to the assembled deformed state of the corner-extended bond-inserted insert.
+  rw [regionInsertedCoeff_eq_extendInsert_bondInserted
+      (staircaseWindow_zero_subset_endPair _ L K) hpos, ← hC0,
+    regionInsertedCoeff_eq_extendInsert_bondInserted
+      (staircaseWindow_last_subset_endPair (by omega) (by omega) _) hpos, ← hClast]
+  -- The end-pair equality equates the two corner-extended inserts on `S`; equal inserts give equal
+  -- assembled deformed states.
+  rw [staircasePair_insert_eq_open h hUB hpos hL hK hxw hyh _ C common hagree]
+
+end Torus
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWindowWitness.lean
+++ b/TNLean/PEPS/TorusWindowWitness.lean
@@ -1,0 +1,155 @@
+import TNLean.PEPS.TorusWindowPeel2
+import TNLean.PEPS.TorusWindowComplement
+import TNLean.PEPS.TorusConjCovarianceFamily
+
+/-!
+# The window-region coefficient-identity witness
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) feeds the torus covariant-family machinery an
+`EdgeCoeffIdentityWitness` at one reference edge per orientation.  The rectangle route of
+Theorem 3 takes the witness region to be the reference rectangle's red block, whose host is
+injective only at the three-block sizes.  At the corollary's minimal size $(2L+1)\times(2K+1)$ the
+host of the rectangle red block is not a union of injective windows, but the host of a *single end
+window* is: this is the landed `regionBlockedTensorInjective_windowComplement`, whose complement
+decomposition needs exactly $2L+1\le\mathrm{width}$, $2K+1\le\mathrm{height}$.
+
+This file packages a window-region witness.  Every field except the conjugation coefficient
+identity is supplied at the minimal size by landed window geometry: the reference edge is a
+boundary edge of the left end window, the window is region injective, and its host is injective by
+`regionBlockedTensorInjective_windowComplement`.  The conjugation coefficient identity is the
+genuinely-new single-bond peeling of the staircase end-pair equality (the residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1), supplied here as a hypothesis: given the
+identity, the witness assembles unconditionally, which is the §5.2 packaging the note describes.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
+  2296--2445, and Section 3 proof of Theorem 3 at lines 1449--1572 of
+  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the filled-in
+  derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Steps 4--5.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **The window-region coefficient-identity witness.**
+
+For two torus tensors `A`, `B` with the left end window of the staircase around the reference edge
+`e` injective for `B` (`hRB`) and its host injective for `B` (`hCB`, available at the minimal size
+by `regionBlockedTensorInjective_windowComplement`), positive bonds for `B`, and the single-bond
+conjugation coefficient identity on `e` realized by a gauge `Z` (`hid`, the §5.1 peeling supplied
+as a hypothesis), the data assemble into an `EdgeCoeffIdentityWitness` whose region is the left end
+window.  The reference gauge is taken to be `Z` as well, so both witness identities are `hid`.
+
+This is the §5.2 packaging: the witness fields other than the conjugation identity are landed window
+geometry, host injectivity available at the minimal size; the identity itself is the genuinely-new
+peeling of `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.  The window region's host
+injectivity is what makes a single window a valid witness region at the corollary's minimal size,
+in place of the rectangle red block whose host fails there.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.2. -/
+noncomputable def windowEdgeCoeffIdentityWitness
+    {A B : Tensor (torusGraph width height) d} {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (Z : GL (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+    (hE : A.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) =
+      B.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (hid : ∀ (M : Matrix (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+        (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+          ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (Finset.univ \ horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)),
+      regionInsertedCoeff (G := torusGraph width height) A
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+          ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw hbh⟩
+          M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+          ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw hbh⟩
+          ((Z : Matrix _ _ ℂ) * Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+            (↑Z⁻¹ : Matrix _ _ ℂ)) σ τ) :
+    EdgeCoeffIdentityWitness A B
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) Z Z hE where
+  region := horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K
+  isBoundary := isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw hbh
+  hRB := hRB
+  hCB := hCB
+  hposB := hposB
+  hidZ := hid
+  hidZref := hid
+
+/-- **The window-region witness from the window injectivity hypotheses.**
+
+The assembled form of `windowEdgeCoeffIdentityWitness`: with `B` satisfying the one-orientation
+window injectivity hypotheses and union closure, the left end window's region injectivity (`hRB`)
+and host injectivity (`hCB`) are discharged from the hypotheses at the minimal size, so the only
+remaining input is the single-bond conjugation coefficient identity `hid` (the §5.1 peeling).  The
+host injectivity is the landed `regionBlockedTensorInjective_windowComplement`, available exactly at
+$2L+1\le\mathrm{width}$, $2K+1\le\mathrm{height}$.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.2. -/
+noncomputable def windowEdgeCoeffIdentityWitness_of_hypotheses
+    {A B : Tensor (torusGraph width height) d} {L K a b : ℕ}
+    (hB : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (Z : GL (Fin (B.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+    (hE : A.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) =
+      B.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (hid : ∀ (M : Matrix (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+        ((a : ZMod width), (b : ZMod height)) L K)))
+        (Fin (A.bondDim (horizontalStaircaseReferenceEdge
+          ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+        (Finset.univ \ horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)),
+      regionInsertedCoeff (G := torusGraph width height) A
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+          ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+            (by omega) ha0 haw hbh⟩ M σ τ =
+        regionInsertedCoeff (G := torusGraph width height) B
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+          ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+            (by omega) ha0 haw hbh⟩
+          ((Z : Matrix _ _ ℂ) * Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+            (↑Z⁻¹ : Matrix _ _ ℂ)) σ τ) :
+    EdgeCoeffIdentityWitness A B
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) Z Z hE :=
+  windowEdgeCoeffIdentityWitness (by omega) (by omega) ha0 haw hbh Z hE
+    (by
+      have hi := hB.horizontalStaircaseLeftWindow_injective ((a : ZMod width), (b : ZMod height))
+      rwa [regionInjectivityDataOf_isInjective] at hi)
+    (hB.regionBlockedTensorInjective_windowComplement hUB hL hK hxw hyh _)
+    hposB hid
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -878,6 +878,79 @@ from $\path{arcRectangle\_injective}$ and $\path{compl\_torusArcRectangle}$ ---
 not further research. A host-free variant of the back-half engines is \emph{not}
 needed.
 
+\subsection{The bond-insertion bridge and the single-bond peeling are landed}
+
+The peeling of \S5.1 onto the single bond $e$ rests on a bridge between the two
+vocabularies the back half mixes: the \emph{deformed-window} inserts the
+overlapping-window staircase produces, and the \emph{region-inserted coefficient}
+$\path{regionInsertedCoeff}$ the per-edge gauge of Step~5 reads.  These were two
+parallel developments with no connecting lemma.  The bridge is now in
+\path{TNLean/PEPS/TorusWindowPeel2.lean}.
+
+The bond-inserted insert $\path{bondInsertedRegionInsert}\,A\,R\,f\,M$ on a region
+$R$ is the insert whose boundary configuration $\nu$ (read by the complement
+contraction) carries the $M$-coupled combination of the genuine $R$ block over the
+boundary configurations agreeing with $\nu$ away from $f$.  Its deformed state is
+exactly the region-inserted coefficient:
+$\path{deformedRegionState\_bondInsertedRegionInsert}$ proves
+$\path{deformedRegionState}\,A\,R\,(\path{bondInsertedRegionInsert}\,A\,R\,f\,M) =
+\path{regionInsertedCoeff}\,A\,R\,f\,M$, the inner boundary sum of the insert
+reproducing the double boundary sum of the coefficient.  Composing with the
+corner-extension identity $\path{deformedRegionState\_extend}$ gives
+$\path{regionInsertedCoeff\_eq\_extendInsert\_bondInserted}$: the coefficient on $R$,
+read off a global configuration, equals the assembled deformed state on a superset
+$S$ of the corner-extended bond-inserted insert.  With $R$ an end window and $S$ the
+end pair, the genuine block of the \emph{opposite} window the bond $e$ joins to is
+carried by the corner extension --- the geometric content the
+$\mathrm{univ}\setminus W = W' \sqcup (\mathrm{univ}\setminus S)$ split of \S5.1
+describes, now realized through the landed corner extension rather than a bespoke
+contraction split.
+
+The single-bond peeling itself is
+$\path{regionInsertedCoeff\_endWindows\_eq\_of\_staircase}$ in
+\path{TNLean/PEPS/TorusWindowPeel3.lean}.  Feeding the end-pair equality
+$\path{staircasePair\_insert\_eq\_open}$ the bond-inserted inserts on the two end
+windows (and arbitrary inserts on the intermediate windows), all sharing one deformed
+state, and bridging both sides through
+$\path{regionInsertedCoeff\_eq\_extendInsert\_bondInserted}$, peels the equality onto
+$e$: the two end windows' region-inserted coefficients with $M$ and $M'$ on $e$ agree,
+read off any global configuration.  The reference edge is a boundary edge of each end
+window by the landed single-crossing geometry
+($\path{isRegionBoundaryEdge\_staircaseWindow\_zero\_referenceEdge}$ and its last-window
+counterpart), so $M$ and $M'$ live on the same bond.
+
+The window-region witness packaging of \S5.2 is
+$\path{windowEdgeCoeffIdentityWitness}$ (and its hypotheses form
+$\path{windowEdgeCoeffIdentityWitness\_of\_hypotheses}$) in
+\path{TNLean/PEPS/TorusWindowWitness.lean}: given the bond-$e$ conjugation coefficient
+identity, every other $\path{EdgeCoeffIdentityWitness}$ field with the left end window
+as region is discharged from the landed window geometry, the host injectivity supplied
+at the minimal size by $\path{regionBlockedTensorInjective\_windowComplement}$.  The
+witness is the reference-edge interface the torus covariant-family machinery consumes.
+
+\medskip
+\noindent\textbf{The residual.}  What remains of \S5.1 is the production of the
+bond-$e$ \emph{conjugation} coefficient identity the witness packaging consumes ---
+$\path{regionInsertedCoeff}\,A\,W\,\langle e\rangle\,M =
+\path{regionInsertedCoeff}\,B\,W\,\langle e\rangle\,(Z\,M\,Z^{-1})$.  Two pieces feed
+it.  First, the bond-inserted \emph{family} the single-bond peeling consumes: an insert
+on every staircase window all sharing one deformed state, with the two end windows
+carrying the bond-inserted inserts of $M$ and $M'$.  For the windows containing both
+endpoints of $e$ the bond is interior, so the insert is the $M$-on-interior-bond
+deformation of the genuine block, and the common state is the closed torus state with
+$M$ inserted on $e$ --- the ``a virtual operation on a given bond is a physical
+operation on any window containing an endpoint'' correspondence of the sketch, not yet
+built as an insert family.  Second, the cross-tensor gauge: the algebra-isomorphism
+step (insertion correspondence, Skolem--Noether) that turns the single-tensor end-window
+equality into conjugation by an invertible edge matrix $Z$.  The landed
+$\path{edgeGaugeFromInsertionAlgebraIsomorphism}$ performs the Skolem--Noether step from
+an algebra isomorphism, and the region-to-edge identity
+$\path{regionInsertedCoeff\_eq\_smul\_edgeInsertedCoeff}$ makes the coefficient
+region-independent; the multiplicative transfer the isomorphism needs is the piece the
+window route must supply from the staircase in place of the edge-middle injectivity
+($\mathrm{univ}\setminus\{u,v\}$ injective), which fails at the minimal size --- the
+same obstruction, at the edge, that $\mathrm{univ}\setminus S$ exhibits at the end pair.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 


### PR DESCRIPTION
## Summary

The next genuinely-new layer of the 2D overlapping-window campaign (arXiv:1804.04964,
the corollary at lines 2297--2318): bridge the staircase end-pair equality
`staircasePair_insert_eq_open` (#2772) to the single-bond `regionInsertedCoeff` of the
per-edge gauge, peel it onto the reference edge `e`, and package the window-region
`EdgeCoeffIdentityWitness`. Documented in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
§5.1--§5.2.

The overlapping-window staircase and the per-edge gauge were two parallel developments
with no connecting lemma: the staircase produces *deformed-window* inserts, while the
gauge reads the *region-inserted coefficient*. This PR builds the bridge between them and
peels the end-pair equality onto the single bond.

## What landed (all sorry-free, `#print axioms` = `[propext, Classical.choice, Quot.sound]`)

**`TNLean/PEPS/TorusWindowPeel2.lean`** — the bond-insertion bridge
- `bondInsertedRegionInsert` / `deformedRegionState_bondInsertedRegionInsert`: the
  deformed state of a region carrying the bond-inserted insert *is* `regionInsertedCoeff`.
- `regionInsertedCoeff_eq_extendInsert_bondInserted`: that coefficient, read off a global
  configuration, equals the assembled deformed state on a superset of the corner-extended
  bond-inserted insert — the staircase-consumable form, where the opposite window's
  genuine block across `e` is carried by `extendInsert (W ⊆ S)`.

**`TNLean/PEPS/TorusWindowPeel3.lean`** — the single-bond peeling
- `regionInsertedCoeff_endWindows_eq_of_staircase`: feeding `staircasePair_insert_eq_open`
  the bond-inserted inserts on the two end windows (sharing one deformed state) and
  bridging both sides peels the equality onto `e`: the two end windows' region-inserted
  coefficients with `M`, `M'` on `e` agree. Plus the boundary-edge helpers for the first
  and last staircase windows.

**`TNLean/PEPS/TorusWindowWitness.lean`** — the window-region witness (Deliverable 2)
- `windowEdgeCoeffIdentityWitness` / `windowEdgeCoeffIdentityWitness_of_hypotheses`:
  given the bond-`e` conjugation coefficient identity, assemble the
  `EdgeCoeffIdentityWitness` with `region := horizontalStaircaseLeftWindow`; every other
  field is landed window geometry, the host injective at the minimal size by
  `regionBlockedTensorInjective_windowComplement` (#2740). This is the reference-edge
  interface the torus covariant-family machinery consumes.

## Residual (the genuinely-hard remainder of §5.1)

Producing the bond-`e` *conjugation* identity the witness consumes needs two further
pieces, recorded in the gap note:
1. the bond-inserted *family* the peeling consumes (an insert on every staircase window
   sharing one deformed state, with the `M`-on-interior-bond deformation on the windows
   where `e` is interior — the virtual-operation/physical-deformation correspondence);
2. the cross-tensor gauge: the algebra-isomorphism (Skolem--Noether) step turning the
   single-tensor end-window equality into conjugation by `Z`, whose multiplicative
   transfer the window route must supply from the staircase in place of the edge-middle
   injectivity that fails at the minimal size.

No blueprint entries. Does not merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New sorry-free Lean proofs and documentation in the PEPS torus formalization path; no runtime, auth, or data-layer changes.
> 
> **Overview**
> Adds the missing link between **deformed-window** staircase inserts and **`regionInsertedCoeff`**, then peels the open-boundary end-pair equality onto the reference bond and packages a window **`EdgeCoeffIdentityWitness`**.
> 
> **`TorusWindowPeel2.lean`** introduces `bondInsertedRegionInsert` and proves its deformed state is `regionInsertedCoeff` (`deformedRegionState_bondInsertedRegionInsert`), plus `regionInsertedCoeff_eq_extendInsert_bondInserted` so coefficients match corner-extended assembled states on a superset (the form `staircasePair_insert_eq_open` uses).
> 
> **`TorusWindowPeel3.lean`** proves `regionInsertedCoeff_endWindows_eq_of_staircase`: with bond-inserted inserts on the first and last staircase windows and a shared deformed state, the two end windows’ region-inserted coefficients agree on `M` / `M'`. Includes lemmas that the reference edge is a boundary edge of those windows.
> 
> **`TorusWindowWitness.lean`** defines `windowEdgeCoeffIdentityWitness` and `windowEdgeCoeffIdentityWitness_of_hypotheses`, building an `EdgeCoeffIdentityWitness` on the left end window when the conjugation coefficient identity is assumed; other fields come from landed window injectivity and `regionBlockedTensorInjective_windowComplement` at minimal torus size.
> 
> Root **`TNLean.lean`** imports the three modules. **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** documents the landed bridge, peeling, witness, and what still remains (conjugation identity, bond-inserted family, cross-tensor gauge).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1a50141ce5b7d106eceb459024984744cd52574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->