### PR TITLE
doc(paper-gaps): faithful MPDO ZCL realignment design + Thm 4.9 conflation finding

### DIFF
--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -106,9 +106,10 @@ $\lambda=\tfrac12$ and is now classified as ZCL, whereas the literal condition
 wrongly excluded it.
 
 \paragraph{The correction is to ZCL, not to RFP.} Literal transfer-map
-idempotence remains the right object for the fusion/algebra characterization of
-Theorem~4.14, where the $n$-blocked transfer map must equal $E_M$; this fails for
-$\lambda\ne 1$, since $E_M^n=\lambda^{n-1}E_M$. So normalized idempotence replaces
+idempotence remains the right object for the canonical-form fusion/algebra
+characterization (the blocked transfer-map condition, in which the $n$-blocked
+transfer map must equal $E_M$); this fails for $\lambda\ne 1$, since
+$E_M^n=\lambda^{n-1}E_M$. So normalized idempotence replaces
 \emph{only} the zero-correlation-length notion, while literal idempotence is
 retained as the canonical-form ($\lambda=1$) notion and now \emph{implies}
 zero correlation length rather than coinciding with it. Every source-facing
@@ -122,22 +123,57 @@ artifact of the literal definition; under the faithful one it is a positive
 example showing that normalized ZCL captures the maximally mixed product state, as
 the source intends.
 
-\paragraph{Finding (classification: faithful local correction, not a source
-error).} The simple-MPDO direction of Theorem~4.9 is formalized by treating a
-zero-correlation-length hypothesis \emph{as if} it were literal idempotence, in
-order to build the blocked fusion isometry. This identification is valid only
-while the two notions coincide definitionally; under the faithful normalized ZCL
-it is no longer available. This is the correct behaviour: the source obtains the
-fusion structure from zero correlation length \emph{together with} the strong area
-law, through the simple-MPDO local structure of Lemmas~C.2--C.5. The normalized
-witness $E_M=\tfrac12\,\mathrm{id}$ shows that zero correlation length \emph{alone}
-does not force $\lambda=1$; whether the strong area law together with zero
-correlation length pins $\lambda=1$ and yields literal idempotence is exactly the
-content of the simple-MPDO direction of Theorem~4.9, which is not otherwise
-established here. The faithful statement therefore phrases that direction at the
-level of literal idempotence where it builds the fusion isometry, and records
-``strong area law and zero correlation length imply literal idempotence'' as an
-explicit obligation rather than a definitional identity.
+\paragraph{Finding (classification: unfaithful theorem).} The simple-MPDO
+direction of Theorem~4.9 (paper label \texttt{thm:main-simple},
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:851}; chain
+$\mathrm{(i)}\Rightarrow\mathrm{(ii)}\Leftrightarrow\mathrm{(iii)}
+\Rightarrow\mathrm{(iv)}\Rightarrow\mathrm{(v)}$ at line~892) is formalized by
+treating a zero-correlation-length hypothesis \emph{as if} it were literal
+idempotence $E_M^2=E_M$, in order to build the blocked fusion isometry. This
+identification is valid only while the two notions coincide definitionally;
+under the faithful normalized ZCL it is no longer available, and the source does
+not supply the missing step. Two facts pin this down.
+
+First, the source's conclusion is not literal transfer-map idempotence.
+Hypothesis (ii) is ``$K$ has ZCL and SAL'' (line~862), and the terminal
+conclusion (v) is ``$M$ is a RFP'' (line~890) in the mixed-state sense of
+Definition~4.1 (paper label \texttt{RFPMixedTS},
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:657}): the existence of two
+trace-preserving completely positive maps $\mathcal S,\mathcal T$ on the
+physical indices intertwining the one- and two-site operators. This is a
+structural reversibility condition, not $E_M\circ E_M=E_M$; the source notes
+(line~786) that for mixed states zero correlation length is strictly weaker than
+this fixed-point property.
+
+Second, the proposed bridge is false. The normalized witness
+$E_M=\tfrac12\,\mathrm{id}$ generates the maximally mixed product state
+$\rho^{(N)}\propto I$, which has vanishing mutual information at every length
+($I_1=I_2=\dots=0$), hence satisfies the strong area law
+(Definition~\texttt{def:area-law},
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:812}) as well as zero correlation
+length, yet $E_M\circ E_M=\tfrac14\,\mathrm{id}\neq E_M$. So the strong area law
+and zero correlation length together do \emph{not} imply literal idempotence;
+$\lambda=1$ is not pinned by the strong area law.
+
+The faithful obligation discharged by the simple-MPDO direction is therefore the
+structural fixed point of Definition~4.1, formalized as \texttt{IsRFPViaTS}
+(equivalently condition~(iv), the basis-of-normal-tensors fusion data of
+equations \texttt{UkU=rl}--\texttt{PsiPhi}), derived from zero correlation length
+\emph{together with} the strong area law; the fusion isometry is built at that
+structural level, not from literal idempotence. The residual passage from the
+structural fixed point to literal idempotence $E_M^2=E_M$ is available only after
+canonical normalization (the $\lambda=1$ reduction); as the witness above shows,
+it does not hold without that step.
+
+Accordingly, any Lean theorem that currently obtains literal idempotence
+(\texttt{IsRFP}) from a zero-correlation-length hypothesis by definitional
+coercion --- the pattern in the simple-MPDO chain that uses an
+\texttt{IsZCL} field directly as \texttt{IsRFP} --- relies on an intermediate the
+source does not provide, and is \emph{unfaithful} in the sense of the project's
+faithfulness policy. Under the realignment each such theorem must carry an
+in-source \texttt{**Unfaithful:**} marker pointing to this note and naming
+\texttt{IsRFPViaTS} (condition~(iv)) as the faithful intermediate that the
+realignment must instead establish.
 
 \paragraph{Sequencing.} The affected definition, the purification-witness
 statement, and the simple-MPDO chain hypotheses are presented in the chapter file

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -20,10 +20,18 @@ Cirac--Perez-Garcia--Schuch--Verstraete 2017}
 For mixed states, Definition~4.2 (local label \texttt{DefinitionZCL},
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:735--739}) defines a tensor $M$
 generating an MPDO to have \emph{zero correlation length} (ZCL) by a graphical
-equation displayed as the figure \texttt{MPDO\_ZCL.png}. The text states this is
-``the natural extension of the pure state case of Theorem~\ref{TheoremZCLPure}''
-and that correlation functions computed from an MPDO with ZCL are
-length-independent.
+equation displayed as the figure \texttt{MPDO\_ZCL.png}. The diagram closes the
+ket and bra physical legs of a single MPDO tensor and compares the resulting
+one-layer virtual transfer with its square. In formulas, if
+$M^{ij}$ denotes the bond matrix with ket index $i$ and bra index $j$, the
+object represented by the diagram is the physical-trace transfer
+\[
+  \mathcal T_M := \sum_i M^{ii},
+\]
+not the doubled-index completely positive map on bond matrices. The text states
+that this is ``the natural extension of the pure state case of
+Theorem~\ref{TheoremZCLPure}'' and that correlation functions computed from an
+MPDO with ZCL are length-independent.
 
 The pure-state case is made precise in the proof of Theorem~\ref{TheoremZCLPure}
 (\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1248}): ZCL ``is equivalent to the
@@ -38,17 +46,19 @@ peripheral (eigenvalue-$1$) subspace.
 
 \section{The gap}
 
-The Lean definition \texttt{MPOTensor.IsZCL} reads
+The Lean definition \texttt{MPOTensor.IsZCL} instead reads
 \[
-  E_M \circ E_M = E_M,
+  \mathcal E_M \circ \mathcal E_M = \mathcal E_M,
+  \qquad
+  \mathcal E_M(X)=\sum_{i,j} M^{ij}X(M^{ij})^\ast ,
 \]
-i.e. \emph{literal} idempotence of the transfer map $E_M$, with no normalization.
-This is faithful to the source only when $M$ is already in canonical form, i.e.
-when $E_M$ has leading eigenvalue exactly $1$. For a general (un-normalized)
-representative, $E_M\circ E_M=E_M$ is strictly stronger than the source's ZCL: it
-forces the leading eigenvalue to be exactly $1$, whereas the source's ZCL is the
-\emph{normalized} (peripheral) idempotence, invariant under rescaling $E_M\mapsto
-\lambda E_M$.
+i.e. \emph{literal} idempotence of the doubled-index CP transfer map
+$\mathcal E_M$. This is not the transfer drawn in Definition~4.2: the source
+contracts the two physical legs first and squares $\mathcal T_M=\sum_iM^{ii}$.
+Thus the current predicate is not merely an un-normalized version of the source
+condition; it is a condition on a different transfer object. Even after allowing
+a scalar normalization, idempotence of $\mathcal E_M$ would classify tensors by
+the doubled-index MPS transfer rather than by the MPDO ZCL diagram.
 
 This deviation is witnessed in the development by
 \texttt{MPOTensor.exists\_isLocalPurificationRFP\_not\_isZCL}. Take $d=d_K=2$,
@@ -56,72 +66,83 @@ $D'=D=1$, $A=[\tfrac{1}{\sqrt2},0,0,\tfrac{1}{\sqrt2}]$, which is an RFP MPS ten
 ($E_A=\mathrm{id}$). The induced MPDO tensor has scalar entries
 $M^{00}=M^{11}=\tfrac12$, off-diagonal $0$, so $\rho^{(N)}(M)=(\tfrac12)^N I$ is
 the (normalized) maximally mixed state --- manifestly length-independent
-correlations, hence ZCL in the source's sense. But $E_M=\tfrac12\,\mathrm{id}$,
-so $E_M\circ E_M=\tfrac14\,\mathrm{id}\neq E_M$: literal \texttt{IsZCL} fails. The
-trace contraction in the purification has dropped the leading eigenvalue from $1$
-to $\tfrac12$.
+correlations, hence ZCL in the source's sense. On the source transfer,
+\[
+  \mathcal T_M=M^{00}+M^{11}=1,
+\]
+so the graphical idempotence holds. On the Lean doubled-index CP transfer,
+$\mathcal E_M=\tfrac12\,\mathrm{id}$, so
+$\mathcal E_M\circ\mathcal E_M=\tfrac14\,\mathrm{id}\neq\mathcal E_M$ and literal
+\texttt{IsZCL} fails. The witness therefore exposes the wrong transfer object,
+not only a missing scalar normalization.
 
 \section{Consequence and elimination plan}
 
 The source's $\text{PRFP}\Rightarrow\text{ZCL}$ implication
 (\path{Papers/1606.00608/MPDO-22-12-17-2.tex:777}) is therefore not provable
-against \texttt{IsZCL} as literally stated: the purifying tensor $A$ must first be
-brought to canonical form (normalizing $E_M$) before the idempotence holds. Two
-faithful options:
+against \texttt{IsZCL} as literally stated: the source implication controls
+$\mathcal T_M$, whereas the Lean predicate controls $\mathcal E_M$. Two faithful
+options:
 
 \begin{enumerate}
-  \item \textbf{Normalized ZCL.} Replace \texttt{IsZCL} by peripheral
-  idempotence: $E_M$ restricted to (or rescaled onto) its leading eigenspace is a
-  projection. Equivalently, $E_M/r(E_M)$ is idempotent, where $r$ is the spectral
-  radius. This matches ``$\mathbb{E}^2=\mathbb{E}$ in CF'' and is rescaling
-  invariant.
-  \item \textbf{Canonical-form hypothesis.} Keep literal \texttt{IsZCL} but
-  restrict every source-labelled ZCL theorem to canonical-form tensors, and
-  derive the implication after a canonicalization step.
+  \item \textbf{Source ZCL transfer.} Introduce the physical-trace transfer
+  $\mathcal T_M=\sum_iM^{ii}$ and state ZCL as idempotence of this transfer,
+  with scalar normalization allowed before canonical form:
+  $\mathcal T_M\ne0$ and $\mathcal T_M^2=\lambda\mathcal T_M$ for some
+  $\lambda>0$. The canonical representative is the case $\lambda=1$.
+  \item \textbf{Canonical physical-trace hypothesis.} Keep exact idempotence
+  $\mathcal T_M^2=\mathcal T_M$ only for source-labelled theorems whose
+  hypotheses include the required canonical normalization. The doubled-index map
+  $\mathcal E_M$ remains a separate CP transfer used in the current formal
+  fusion and algebra statements, not the source's ZCL transfer.
 \end{enumerate}
 
-Until one of these is in place, \texttt{IsZCL} should be documented as the
-\emph{canonical-form} zero-correlation-length condition (faithful for normalized
-tensors), not the unrestricted source Definition~4.2. The
+Until one of these is in place, \texttt{IsZCL} should be documented as a
+doubled-index CP-transfer idempotence condition, not as the unrestricted source
+Definition~4.2. The
 $\text{PRFP}\Leftrightarrow\text{ZCL}$ equivalence remains open
 (issues \#2395, \#2421).
 
 \section{The faithful definition and its consequences}
 
-The faithful reading is Option~1 (normalized ZCL). Writing $E_M$ for the transfer
-map, the condition is normalized idempotence,
+The faithful reading is Option~1 (source ZCL transfer). Writing $\mathcal T_M$
+for the physical-trace transfer, the normalized condition is
 \[
-  \texttt{IsZCL}\ M\ :=\ E_M\ne 0\ \wedge\
+  \texttt{IsZCL}\ M\ :=\ \mathcal T_M\ne 0\ \wedge\
   \exists\, \lambda\in\mathbb R,\ 0<\lambda
-  \ \wedge\ E_M\circ E_M = \lambda\, E_M .
+  \ \wedge\ \mathcal T_M^2 = \lambda\, \mathcal T_M .
 \]
-The clause $E_M\ne 0$ excludes the degenerate zero tensor, which otherwise
-satisfies $E_M\circ E_M=\lambda E_M$ vacuously for every $\lambda$. No
-spectral-radius apparatus is required: if $E_M\circ E_M=\lambda E_M$ with
-$\lambda>0$ and $E_M\ne 0$, the minimal polynomial of $E_M$ divides $x(x-\lambda)$,
-so its eigenvalues lie in $\{0,\lambda\}$ and $\lambda$ is the leading eigenvalue.
-Literal idempotence $E_M^2=E_M$ is exactly the $\lambda=1$ case, the canonical-form
-representative. The maximally mixed witness $E_M=\tfrac12\,\mathrm{id}$ has
-$\lambda=\tfrac12$ and is now classified as ZCL, whereas the literal condition
-wrongly excluded it.
+The clause $\mathcal T_M\ne0$ excludes the degenerate zero tensor, which otherwise
+satisfies $\mathcal T_M^2=\lambda\mathcal T_M$ vacuously for every $\lambda$.
+No spectral-radius apparatus is required: if
+$\mathcal T_M^2=\lambda\mathcal T_M$ with $\lambda>0$ and
+$\mathcal T_M\ne0$, the minimal polynomial of $\mathcal T_M$ divides
+$x(x-\lambda)$, so its eigenvalues lie in $\{0,\lambda\}$ and $\lambda$ is the
+leading eigenvalue. Literal idempotence $\mathcal T_M^2=\mathcal T_M$ is exactly
+the $\lambda=1$ case, the canonical-form representative. The maximally mixed
+witness has $\mathcal T_M=1$ and is therefore classified as ZCL by the source
+transfer, whereas the current doubled-index condition wrongly excludes it.
 
-\paragraph{The correction is to ZCL, not to RFP.} Literal transfer-map
-idempotence remains the right object for the canonical-form fusion/algebra
-characterization (the blocked transfer-map condition, in which the $n$-blocked
-transfer map must equal $E_M$); this fails for $\lambda\ne 1$, since
-$E_M^n=\lambda^{n-1}E_M$. So normalized idempotence replaces
-\emph{only} the zero-correlation-length notion, while literal idempotence is
-retained as the canonical-form ($\lambda=1$) notion and now \emph{implies}
-zero correlation length rather than coinciding with it. Every source-facing
-description that calls the literal notion ``definitionally zero correlation
-length'' must be weakened to this one-directional implication.
+\paragraph{The correction is to ZCL, not to the doubled-index RFP predicate.}
+The doubled-index transfer map $\mathcal E_M$ remains the object used by the
+current Lean predicate \texttt{IsRFP} and by the transfer-map formulation of the
+fusion/algebra statements. It should no longer be identified with the source ZCL
+diagram. Literal idempotence of the physical-trace transfer
+$\mathcal T_M^2=\mathcal T_M$ implies normalized ZCL only together with the
+nonzero hypothesis $\mathcal T_M\ne0$ (or an equivalent generated-MPDO
+nondegeneracy assumption); without that clause, the zero transfer is idempotent
+but not ZCL under the definition above. Every source-facing description that
+calls the doubled-index literal notion ``definitionally zero correlation
+length'' must be weakened to a separate bridge, with the nonzero hypothesis
+stated explicitly.
 
 \paragraph{Effect on the purification witness.} The diagonal purification of
-Section~3 has $E_M=\tfrac12\,\mathrm{id}$, which \emph{is} normalized-idempotent.
+Section~3 has $\mathcal T_M=1$, hence satisfies the source ZCL equation already.
 The earlier reading, that this witness fails zero correlation length, was an
-artifact of the literal definition; under the faithful one it is a positive
-example showing that normalized ZCL captures the maximally mixed product state, as
-the source intends.
+artifact of using $\mathcal E_M=\tfrac12\,\mathrm{id}$ in place of the
+physical-trace transfer. Under the faithful reading it is a positive example
+showing that ZCL captures the maximally mixed product state, as the source
+intends.
 
 \paragraph{Finding (classification: unfaithful theorem).} The simple-MPDO
 direction of Theorem~4.9 (paper label \texttt{thm:main-simple},
@@ -129,10 +150,10 @@ direction of Theorem~4.9 (paper label \texttt{thm:main-simple},
 $\mathrm{(i)}\Rightarrow\mathrm{(ii)}\Leftrightarrow\mathrm{(iii)}
 \Rightarrow\mathrm{(iv)}\Rightarrow\mathrm{(v)}$ at line~892) is formalized by
 treating a zero-correlation-length hypothesis \emph{as if} it were literal
-idempotence $E_M^2=E_M$, in order to build the blocked fusion isometry. This
-identification is valid only while the two notions coincide definitionally;
-under the faithful normalized ZCL it is no longer available, and the source does
-not supply the missing step. Two facts pin this down.
+idempotence of the doubled-index transfer, in order to build the blocked fusion
+isometry. This identification is valid only while the two notions coincide
+definitionally; under the faithful physical-trace ZCL it is no longer available,
+and the source does not supply the missing step. Two facts pin this down.
 
 First, the source's conclusion is not literal transfer-map idempotence.
 Hypothesis (ii) is ``$K$ has ZCL and SAL'' (line~862), and the terminal
@@ -141,39 +162,42 @@ Definition~4.1 (paper label \texttt{RFPMixedTS},
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:657}): the existence of two
 trace-preserving completely positive maps $\mathcal S,\mathcal T$ on the
 physical indices intertwining the one- and two-site operators. This is a
-structural reversibility condition, not $E_M\circ E_M=E_M$; the source notes
-(line~786) that for mixed states zero correlation length is strictly weaker than
-this fixed-point property.
+structural reversibility condition, not
+$\mathcal E_M\circ\mathcal E_M=\mathcal E_M$; the source notes (line~786) that
+for mixed states zero correlation length is strictly weaker than this
+fixed-point property.
 
-Second, the proposed bridge is false. The normalized witness
-$E_M=\tfrac12\,\mathrm{id}$ generates the maximally mixed product state
-$\rho^{(N)}\propto I$, which has vanishing mutual information at every length
-($I_1=I_2=\dots=0$), hence satisfies the strong area law
-(Definition~\texttt{def:area-law},
+Second, the proposed bridge to doubled-index idempotence is false. The witness
+above generates the maximally mixed product state $\rho^{(N)}\propto I$, which
+has vanishing mutual information at every length ($I_1=I_2=\dots=0$), hence
+satisfies the strong area law (Definition~\texttt{def:area-law},
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:812}) as well as zero correlation
-length, yet $E_M\circ E_M=\tfrac14\,\mathrm{id}\neq E_M$. So the strong area law
-and zero correlation length together do \emph{not} imply literal idempotence;
-$\lambda=1$ is not pinned by the strong area law.
+length, yet $\mathcal E_M\circ\mathcal E_M=\tfrac14\,\mathrm{id}\neq\mathcal E_M$.
+So the strong area law and zero correlation length together do \emph{not} imply
+literal idempotence of the doubled-index transfer; the missing passage cannot be
+obtained by definitional coercion.
 
-The faithful obligation discharged by the simple-MPDO direction is therefore the
-structural fixed point of Definition~4.1, formalized as \texttt{IsRFPViaTS}
-(equivalently condition~(iv), the basis-of-normal-tensors fusion data of
-equations \texttt{UkU=rl}--\texttt{PsiPhi}), derived from zero correlation length
-\emph{together with} the strong area law; the fusion isometry is built at that
-structural level, not from literal idempotence. The residual passage from the
-structural fixed point to literal idempotence $E_M^2=E_M$ is available only after
-canonical normalization (the $\lambda=1$ reduction); as the witness above shows,
-it does not hold without that step.
+The faithful obligation discharged by the simple-MPDO direction is therefore:
+from zero correlation length \emph{together with} the strong area law, derive
+condition~(iv), the BNT support, positivity, and fusion data of equations
+\texttt{KxKy=0}--\texttt{PsiPhi}; then use the source implication
+$\mathrm{(iv)}\Rightarrow\mathrm{(v)}$ to obtain the structural fixed point of
+Definition~4.1, formalized as \texttt{IsRFPViaTS}. Condition~(iv) is an
+intermediate used to derive that target, not an equivalent name for the target
+itself. The residual passage from the structural fixed point to literal
+doubled-index idempotence $\mathcal E_M^2=\mathcal E_M$ is a separate
+canonical-normalization bridge; as the witness above shows, it does not hold
+for an arbitrary ZCL and SAL tensor.
 
-Accordingly, any Lean theorem that currently obtains literal idempotence
+Accordingly, any Lean theorem that currently obtains doubled-index idempotence
 (\texttt{IsRFP}) from a zero-correlation-length hypothesis by definitional
 coercion --- the pattern in the simple-MPDO chain that uses an
 \texttt{IsZCL} field directly as \texttt{IsRFP} --- relies on an intermediate the
 source does not provide, and is \emph{unfaithful} in the sense of the project's
 faithfulness policy. Under the realignment each such theorem must carry an
 in-source \texttt{**Unfaithful:**} marker pointing to this note and naming
-\texttt{IsRFPViaTS} (condition~(iv)) as the faithful intermediate that the
-realignment must instead establish.
+\texttt{IsRFPViaTS}, reached through condition~(iv), as the faithful target that
+the realignment must instead establish.
 
 \paragraph{Sequencing.} The affected definition, the purification-witness
 statement, and the simple-MPDO chain hypotheses are presented in the chapter file

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{Zero correlation length is canonical-form idempotence in
+\title{Zero correlation length uses the physical-trace transfer in
 Cirac--Perez-Garcia--Schuch--Verstraete 2017}
 \author{}
 \date{2026-06-08}
@@ -59,6 +59,11 @@ Thus the current predicate is not merely an un-normalized version of the source
 condition; it is a condition on a different transfer object. Even after allowing
 a scalar normalization, idempotence of $\mathcal E_M$ would classify tensors by
 the doubled-index MPS transfer rather than by the MPDO ZCL diagram.
+
+\paragraph{Classification.} This is a wrong-transfer-object gap: the current
+formal predicate records doubled-index CP-transfer idempotence, while the source
+definition uses the physical-trace transfer. Until the latter transfer is
+formalized, unrestricted source ZCL remains open.
 
 This deviation is witnessed in the development by
 \texttt{MPOTensor.exists\_isLocalPurificationRFP\_not\_isZCL}. Take $d=d_K=2$,

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -204,9 +204,4 @@ in-source \texttt{**Unfaithful:**} marker pointing to this note and naming
 \texttt{IsRFPViaTS}, reached through condition~(iv), as the faithful target that
 the realignment must instead establish.
 
-\paragraph{Sequencing.} The affected definition, the purification-witness
-statement, and the simple-MPDO chain hypotheses are presented in the chapter file
-currently being reorganized into per-section files, so the realignment is best
-carried out after that reorganization to avoid a move/edit conflict.
-
 \end{document}

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -86,67 +86,62 @@ tensors), not the unrestricted source Definition~4.2. The
 $\text{PRFP}\Leftrightarrow\text{ZCL}$ equivalence remains open
 (issues \#2395, \#2421).
 
-\section{Implementation decision and cascade map (2026-06-14)}
+\section{The faithful definition and its consequences}
 
-The author chose \textbf{Option~1 (Normalized ZCL)}: match the paper. The
-faithful definition is the existential normalized idempotence
+The faithful reading is Option~1 (normalized ZCL). Writing $E_M$ for the transfer
+map, the condition is normalized idempotence,
 \[
-  \texttt{IsZCL}\ M\ :=\ \exists\, \lambda\in\mathbb R,\ 0<\lambda
+  \texttt{IsZCL}\ M\ :=\ E_M\ne 0\ \wedge\
+  \exists\, \lambda\in\mathbb R,\ 0<\lambda
   \ \wedge\ E_M\circ E_M = \lambda\, E_M .
 \]
-This avoids any spectral-radius machinery (which is not wired into the
-tensor-level transfer map): if $E_M\circ E_M=\lambda E_M$ with $\lambda>0$ and
-$E_M\ne 0$, then the minimal polynomial of $E_M$ divides $x(x-\lambda)$, so its
-eigenvalues lie in $\{0,\lambda\}$ and $\lambda$ \emph{is} the leading eigenvalue.
-The literal $E_M^2=E_M$ is exactly the $\lambda=1$ canonical-form case. The
-diagonal witness $E_M=\tfrac12\,\mathrm{id}$ satisfies it with $\lambda=\tfrac12$,
-as it should (the maximally mixed reduced state is length-independent).
+The clause $E_M\ne 0$ excludes the degenerate zero tensor, which otherwise
+satisfies $E_M\circ E_M=\lambda E_M$ vacuously for every $\lambda$. No
+spectral-radius apparatus is required: if $E_M\circ E_M=\lambda E_M$ with
+$\lambda>0$ and $E_M\ne 0$, the minimal polynomial of $E_M$ divides $x(x-\lambda)$,
+so its eigenvalues lie in $\{0,\lambda\}$ and $\lambda$ is the leading eigenvalue.
+Literal idempotence $E_M^2=E_M$ is exactly the $\lambda=1$ case, the canonical-form
+representative. The maximally mixed witness $E_M=\tfrac12\,\mathrm{id}$ has
+$\lambda=\tfrac12$ and is now classified as ZCL, whereas the literal condition
+wrongly excluded it.
 
-\textbf{Scope: change \texttt{IsZCL} only, not \texttt{IsRFP}.} The fusion and
-algebra theory (Theorem~4.14 surface) consumes the MPO \texttt{IsRFP} (literal
-idempotence, the canonical-form/$\lambda=1$ notion), \emph{not} \texttt{IsZCL}.
-Redefining \texttt{IsRFP} as well breaks that whole theory (the blocked transfer
-map $E^n=\lambda^{n-1}E$ is no longer $E$), so \texttt{IsRFP} must stay literal.
-\texttt{IsRFP M} then \emph{implies} \texttt{IsZCL M} (the $\lambda=1$ case); the
-former \texttt{isRFP\_iff\_isZCL} (\texttt{Iff.rfl}) becomes the one-directional
-\texttt{IsRFP.isZCL}.
+\paragraph{The correction is to ZCL, not to RFP.} Literal transfer-map
+idempotence remains the right object for the fusion/algebra characterization of
+Theorem~4.14, where the $n$-blocked transfer map must equal $E_M$; this fails for
+$\lambda\ne 1$, since $E_M^n=\lambda^{n-1}E_M$. So normalized idempotence replaces
+\emph{only} the zero-correlation-length notion, while literal idempotence is
+retained as the canonical-form ($\lambda=1$) notion and now \emph{implies}
+zero correlation length rather than coinciding with it. Every source-facing
+description that calls the literal notion ``definitionally zero correlation
+length'' must be weakened to this one-directional implication.
 
-The contained Lean cascade was verified by build:
-\begin{itemize}
-  \item \path{ZCL.lean}: new \texttt{IsZCL}; the
-  \texttt{isZCL\_iff\_toMPSTensor\_isRFP} bridge restates to normalized
-  idempotence of $E_{A}$ for $A=M.\texttt{toMPSTensor}$ (compiles).
-  \item \path{RFP.lean}: drop the \texttt{Iff.rfl} \texttt{isRFP\_iff\_isZCL};
-  fix \texttt{IsRFP.isZCL} to $\langle 1, \texttt{one\_pos}, \ldots\rangle$;
-  \texttt{isRFP\_iff\_toMPSTensor\_isRFP} stays literal$\leftrightarrow$literal.
-  \item \path{LocalPurificationRFP.lean}: the now-\emph{false}
-  \texttt{exists\_isLocalPurificationRFP\_not\_isZCL} (the $\tfrac12\,\mathrm{id}$
-  witness \emph{is} normalized-idempotent) becomes a positive demonstration that
-  the faithful \texttt{IsZCL} correctly classifies it as ZCL.
-  \item \path{PureRecovery.lean}, \path{FusionIsometries.lean},
-  \path{CommutingFormBridge.lean}: unaffected (they use \texttt{IsRFP}).
-\end{itemize}
+\paragraph{Effect on the purification witness.} The diagonal purification of
+Section~3 has $E_M=\tfrac12\,\mathrm{id}$, which \emph{is} normalized-idempotent.
+The earlier reading, that this witness fails zero correlation length, was an
+artifact of the literal definition; under the faithful one it is a positive
+example showing that normalized ZCL captures the maximally mixed product state, as
+the source intends.
 
-\textbf{Finding: the Theorem~4.9 chain in \path{BlockedRFPConstruction.lean}
-silently conflates ZCL with literal idempotence.} The ``simple MPDO RFP chain''
-(\texttt{SimpleMPDOBlockedRFPData.zcl}, \texttt{structural\_implies\_rfp\_blocked},
-\texttt{isRFP\_via\_fusion}, \texttt{simple\_mpdo\_rfp\_chain}, and the
-\texttt{ofSALZCL*} constructors) repeatedly writes \texttt{show IsRFP K from hZCL},
-which is sound only while \texttt{IsZCL = IsRFP} definitionally. Under the faithful
-\texttt{IsZCL} this shortcut is rejected --- correctly, because the paper's
-Theorem~4.9 derives the fusion structure from ZCL \emph{together with} the strong
-area law (SAL), and it is precisely SAL that supplies the normalization
-($\lambda=1$) turning ZCL into literal idempotence. The conflation hid this SAL
-step. Faithful realignment therefore requires these chain theorems to take
-\texttt{IsRFP K} (literal) where they build the fusion isometry, with the
-``$\text{SAL}+\text{ZCL}\Rightarrow$ literal idempotence'' step made an explicit
-(currently unproved) Theorem~4.9 obligation rather than a definitional coercion.
+\paragraph{Finding (classification: faithful local correction, not a source
+error).} The simple-MPDO direction of Theorem~4.9 is formalized by treating a
+zero-correlation-length hypothesis \emph{as if} it were literal idempotence, in
+order to build the blocked fusion isometry. This identification is valid only
+while the two notions coincide definitionally; under the faithful normalized ZCL
+it is no longer available. This is the correct behaviour: the source obtains the
+fusion structure from zero correlation length \emph{together with} the strong area
+law, through the simple-MPDO local structure of Lemmas~C.2--C.5. The normalized
+witness $E_M=\tfrac12\,\mathrm{id}$ shows that zero correlation length \emph{alone}
+does not force $\lambda=1$; whether the strong area law together with zero
+correlation length pins $\lambda=1$ and yields literal idempotence is exactly the
+content of the simple-MPDO direction of Theorem~4.9, which is not otherwise
+established here. The faithful statement therefore phrases that direction at the
+level of literal idempotence where it builds the fusion isometry, and records
+``strong area law and zero correlation length imply literal idempotence'' as an
+explicit obligation rather than a definitional identity.
 
-\textbf{Sequencing.} The blueprint edits (\texttt{def:mpo\_is\_zcl} now normalized;
-\texttt{thm:local\_purification\_rfp\_not\_zcl} restated; the chain-theorem
-hypotheses) land in \path{blueprint/src/chapter/ch21_mpdo.tex}, which the split
-PR \#2769 is reorganizing. The realignment should follow \#2769 to avoid a
-file-move/edit conflict, then proceed as the contained Lean change above plus the
-Theorem~4.9 SAL-normalization obligation.
+\paragraph{Sequencing.} The affected definition, the purification-witness
+statement, and the simple-MPDO chain hypotheses are presented in the chapter file
+currently being reorganized into per-section files, so the realignment is best
+carried out after that reorganization to avoid a move/edit conflict.
 
 \end{document}

--- a/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
+++ b/docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex
@@ -86,4 +86,67 @@ tensors), not the unrestricted source Definition~4.2. The
 $\text{PRFP}\Leftrightarrow\text{ZCL}$ equivalence remains open
 (issues \#2395, \#2421).
 
+\section{Implementation decision and cascade map (2026-06-14)}
+
+The author chose \textbf{Option~1 (Normalized ZCL)}: match the paper. The
+faithful definition is the existential normalized idempotence
+\[
+  \texttt{IsZCL}\ M\ :=\ \exists\, \lambda\in\mathbb R,\ 0<\lambda
+  \ \wedge\ E_M\circ E_M = \lambda\, E_M .
+\]
+This avoids any spectral-radius machinery (which is not wired into the
+tensor-level transfer map): if $E_M\circ E_M=\lambda E_M$ with $\lambda>0$ and
+$E_M\ne 0$, then the minimal polynomial of $E_M$ divides $x(x-\lambda)$, so its
+eigenvalues lie in $\{0,\lambda\}$ and $\lambda$ \emph{is} the leading eigenvalue.
+The literal $E_M^2=E_M$ is exactly the $\lambda=1$ canonical-form case. The
+diagonal witness $E_M=\tfrac12\,\mathrm{id}$ satisfies it with $\lambda=\tfrac12$,
+as it should (the maximally mixed reduced state is length-independent).
+
+\textbf{Scope: change \texttt{IsZCL} only, not \texttt{IsRFP}.} The fusion and
+algebra theory (Theorem~4.14 surface) consumes the MPO \texttt{IsRFP} (literal
+idempotence, the canonical-form/$\lambda=1$ notion), \emph{not} \texttt{IsZCL}.
+Redefining \texttt{IsRFP} as well breaks that whole theory (the blocked transfer
+map $E^n=\lambda^{n-1}E$ is no longer $E$), so \texttt{IsRFP} must stay literal.
+\texttt{IsRFP M} then \emph{implies} \texttt{IsZCL M} (the $\lambda=1$ case); the
+former \texttt{isRFP\_iff\_isZCL} (\texttt{Iff.rfl}) becomes the one-directional
+\texttt{IsRFP.isZCL}.
+
+The contained Lean cascade was verified by build:
+\begin{itemize}
+  \item \path{ZCL.lean}: new \texttt{IsZCL}; the
+  \texttt{isZCL\_iff\_toMPSTensor\_isRFP} bridge restates to normalized
+  idempotence of $E_{A}$ for $A=M.\texttt{toMPSTensor}$ (compiles).
+  \item \path{RFP.lean}: drop the \texttt{Iff.rfl} \texttt{isRFP\_iff\_isZCL};
+  fix \texttt{IsRFP.isZCL} to $\langle 1, \texttt{one\_pos}, \ldots\rangle$;
+  \texttt{isRFP\_iff\_toMPSTensor\_isRFP} stays literal$\leftrightarrow$literal.
+  \item \path{LocalPurificationRFP.lean}: the now-\emph{false}
+  \texttt{exists\_isLocalPurificationRFP\_not\_isZCL} (the $\tfrac12\,\mathrm{id}$
+  witness \emph{is} normalized-idempotent) becomes a positive demonstration that
+  the faithful \texttt{IsZCL} correctly classifies it as ZCL.
+  \item \path{PureRecovery.lean}, \path{FusionIsometries.lean},
+  \path{CommutingFormBridge.lean}: unaffected (they use \texttt{IsRFP}).
+\end{itemize}
+
+\textbf{Finding: the Theorem~4.9 chain in \path{BlockedRFPConstruction.lean}
+silently conflates ZCL with literal idempotence.} The ``simple MPDO RFP chain''
+(\texttt{SimpleMPDOBlockedRFPData.zcl}, \texttt{structural\_implies\_rfp\_blocked},
+\texttt{isRFP\_via\_fusion}, \texttt{simple\_mpdo\_rfp\_chain}, and the
+\texttt{ofSALZCL*} constructors) repeatedly writes \texttt{show IsRFP K from hZCL},
+which is sound only while \texttt{IsZCL = IsRFP} definitionally. Under the faithful
+\texttt{IsZCL} this shortcut is rejected --- correctly, because the paper's
+Theorem~4.9 derives the fusion structure from ZCL \emph{together with} the strong
+area law (SAL), and it is precisely SAL that supplies the normalization
+($\lambda=1$) turning ZCL into literal idempotence. The conflation hid this SAL
+step. Faithful realignment therefore requires these chain theorems to take
+\texttt{IsRFP K} (literal) where they build the fusion isometry, with the
+``$\text{SAL}+\text{ZCL}\Rightarrow$ literal idempotence'' step made an explicit
+(currently unproved) Theorem~4.9 obligation rather than a definitional coercion.
+
+\textbf{Sequencing.} The blueprint edits (\texttt{def:mpo\_is\_zcl} now normalized;
+\texttt{thm:local\_purification\_rfp\_not\_zcl} restated; the chain-theorem
+hypotheses) land in \path{blueprint/src/chapter/ch21_mpdo.tex}, which the split
+PR \#2769 is reorganizing. The realignment should follow \#2769 to avoid a
+file-move/edit conflict, then proceed as the contained Lean change above plus the
+Theorem~4.9 SAL-normalization obligation.
+
 \end{document}


### PR DESCRIPTION
## Summary
Per your decision to **match the paper**, this records the design + verified findings for redefining MPDO `IsZCL` to the paper-faithful **normalized idempotence**, and documents a real unfaithfulness finding the deep-dive uncovered. (Design/doc only — the implementation is sequenced behind #2769; see below.)

### Faithful definition (verified to compile)
```
IsZCL M := ∃ λ : ℝ, 0 < λ ∧ E_M ∘ E_M = (λ:ℂ) • E_M
```
The existential avoids spectral-radius machinery: if `E²=λE` with `λ>0`, eigenvalues lie in `{0,λ}`, so `λ` *is* the leading eigenvalue. Literal `E²=E` is the `λ=1` (canonical-form) case. The ½·id purification witness satisfies it with `λ=½` — correctly ZCL.

### Scope: change `IsZCL` only, not `IsRFP`
The fusion/algebra (Thm 4.14) theory consumes literal `IsRFP`, not `IsZCL`. Redefining `IsRFP` too breaks it (blocked transfer map `E^n=λ^{n-1}E≠E`). So `IsRFP` stays literal and **implies** `IsZCL` (λ=1). I build-verified that with this scope the cascade is contained: `ZCL.lean`/`RFP.lean` bridges + the (now-positive) purification witness compile; `PureRecovery`/`FusionIsometries`/`CommutingFormBridge` are untouched.

### 🔍 Finding: the Theorem 4.9 chain conflates ZCL with literal idempotence
`BlockedRFPConstruction.lean`'s "simple MPDO RFP chain" repeatedly writes `show IsRFP K from hZCL` — sound only while `IsZCL = IsRFP` definitionally. Faithful ZCL rejects it **correctly**: the paper's Thm 4.9 derives the fusion structure from ZCL **+ SAL**, and SAL is exactly what supplies the normalization (λ=1) turning ZCL into literal idempotence. The conflation hid this SAL step. Faithful realignment makes `SAL+ZCL ⇒ literal idempotence` an explicit (currently unproved) Thm 4.9 obligation instead of a definitional coercion.

### Sequencing
The blueprint edits (`def:mpo_is_zcl`, the witness theorem, the chain-theorem hypotheses) land in `ch21_mpdo.tex`, which #2769 is splitting. **This realignment should follow #2769** to avoid a file-move/edit conflict, then proceed as the contained Lean change + the Thm 4.9 SAL-normalization obligation.

Full details in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex` (new "Implementation decision and cascade map" section).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a LaTeX gap note; no Lean or runtime code changes.
> 
> **Overview**
> **Reframes** the CPSV16 zero-correlation-length gap note: the paper’s Definition 4.2 uses the **physical-trace transfer** \(\mathcal T_M=\sum_i M^{ii}\), while Lean’s `IsZCL` is **doubled-index CP transfer** idempotence \(\mathcal E_M^2=\mathcal E_M\)—classified as a **wrong-transfer-object** gap, not merely missing normalization. The purification witness is reinterpreted as **source-ZCL positive** (\(\mathcal T_M=1\)) while current `IsZCL` still fails.
> 
> **Adds** a faithful target definition (\(\mathcal T_M\ne 0\) and \(\mathcal T_M^2=\lambda\mathcal T_M\)), scope guidance (**fix `IsZCL` only; keep `IsRFP` on \(\mathcal E_M\)**), and a **finding** that Theorem 4.9’s simple-MPDO chain is **unfaithful** when it treats ZCL as literal doubled-index idempotence (`show IsRFP K from hZCL`): paper (v) is structural `IsRFPViaTS`, and ZCL+SAL do **not** imply \(\mathcal E_M^2=\mathcal E_M\) (witness: maximally mixed). Faithful obligation is ZCL+SAL → condition (iv) → `IsRFPViaTS`, with **`**Unfaithful:**`** markers on coercion theorems.
> 
> **Updates** title, elimination plan (physical-trace options), and retires the earlier “canonical-form idempotence only” framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08442a226e8ff789f17330ce8f889adf64a0ef18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->