### PR TITLE
doc(PEPS): polish torus window blueprint entries

### DIFF
--- a/TNLean/PEPS/TorusWindowPeel2.lean
+++ b/TNLean/PEPS/TorusWindowPeel2.lean
@@ -7,11 +7,11 @@ The two-dimensional strengthening of the normal PEPS Fundamental Theorem
 (arXiv:1804.04964, the corollary at lines 2297--2318 of
 `Papers/1804.04964/paper_normal.tex`) extracts the bond operator on the distinguished edge `e`
 from the open-boundary end-pair equality `staircasePair_insert_eq_open`.  That equality is stated
-for the *deformed-window* vocabulary — inserts on a region and their closed-torus deformed states —
-while the per-edge gauge of Step 5 is read off the *region-inserted coefficient*
+for the *deformed-window* vocabulary — inserts on a region and their closed-torus deformed
+states — while the per-edge gauge of Step 5 is read off the *region-inserted coefficient*
 `regionInsertedCoeff`, which inserts a matrix on one crossing bond and contracts the region against
-its complement.  This file bridges the two: the deformed state of a window carrying the
-*bond-inserted* insert equals the region-inserted coefficient.
+its complement.  This file compares the two descriptions: the deformed state of a window carrying
+the *bond-inserted* insert equals the region-inserted coefficient.
 
 ## The bond-inserted insert
 
@@ -23,8 +23,8 @@ double-boundary-sum of `regionInsertedCoeff`: the inner `μ`-sum builds the bond
 the outer `ν`-sum is the complement contraction of the deformed state.  This is the content of
 `deformedRegionState_bondInsertedRegionInsert`.
 
-The bridge lets the staircase end-pair equality, stated as an `extendInsert` equality of window
-inserts, drive a relation between region-inserted coefficients on a single window: taking the
+This comparison lets the staircase end-pair equality, stated as an `extendInsert` equality of window
+inserts, determine a relation between region-inserted coefficients on a single window: taking the
 window inserts to be the bond-inserted inserts, the end-pair equality compares the genuine block of
 one window against the genuine block of the other across the single bond `e`, which is the peeling
 of the end-pair equality onto `e`.
@@ -116,19 +116,19 @@ theorem deformedRegionState_bondInsertedRegionInsert (A : Tensor G d) (R : Finse
 For a region `R ⊆ S`, the bond insertion on `R` (read off a global configuration through its `R`-
 and `univ \ R`-restrictions) equals the corner-extended deformed state on `S`: the deformed-state
 extension identity `deformedRegionState_extend` reads the bond-inserted deformed state on `R` as
-the deformed state on `S` of the corner-extended bond-inserted insert.  This is the form the
-staircase end-pair equality consumes, where `R = W` is a single end window and `S = W_0 ⊔ W_{L+K-1}`
-is the end pair: the genuine block of the *opposite* window the bond `e` joins to is carried by the
-corner extension `extendInsert (W ⊆ S)`. -/
+the deformed state on `S` of the corner-extended bond-inserted insert.  This is the form used in the
+staircase end-pair equality, where `R = W` is a single end window and `S = W_0 ⊔ W_{L+K-1}` is the
+end pair: the genuine block of the *opposite* window the bond `e` joins to is carried by the corner
+extension `extendInsert (W ⊆ S)`. -/
 
 /-- **The bond insertion is the corner-extended deformed state on a superset.**
 
 For `R ⊆ S`, the region-inserted coefficient `regionInsertedCoeff A R f M` read off a global
 configuration `cfg` (restricted to `R` and to `univ \ R`) equals the assembled deformed state on `S`
 of the corner-extended bond-inserted insert `extendInsert (R ⊆ S) (bondInsertedRegionInsert A R f
-M)`.  The bridge `deformedRegionState_bondInsertedRegionInsert` writes the coefficient as the
-bond-inserted deformed state on `R`, and `deformedRegionState_extend` reads that as the deformed
-state on `S` of the corner extension.
+M)`.  The theorem `deformedRegionState_bondInsertedRegionInsert` writes the coefficient as the
+bond-inserted deformed state on `R`, and `deformedRegionState_extend` reads that as the
+deformed state on `S` of the corner extension.
 
 Source: arXiv:1804.04964, Section 3, lines 1205--1210 and the proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 4. -/

--- a/TNLean/PEPS/TorusWindowPeel3.lean
+++ b/TNLean/PEPS/TorusWindowPeel3.lean
@@ -14,14 +14,15 @@ coefficients across `e`.
 
 ## The peeling
 
-The bridge `regionInsertedCoeff_eq_extendInsert_bondInserted` of `TNLean/PEPS/TorusWindowPeel2.lean`
-writes the region-inserted coefficient of an end window, with a matrix inserted on `e`, as the
-assembled deformed state of the corner-extended bond-inserted insert on the end pair `S`.  The
-end-pair equality `staircasePair_insert_eq_open` equates the two corner-extended inserts on `S`,
-hence their assembled deformed states.  Chaining the two bridge identities through the end-pair
-equality leaves the two end windows' region-inserted coefficients equal across `e`, read off any
-global physical configuration.  This is the single-tensor content of the peeling; the cross-tensor
-gauge is the algebra-isomorphism step that consumes this equality, the residual recorded in
+The theorem `regionInsertedCoeff_eq_extendInsert_bondInserted` of
+`TNLean/PEPS/TorusWindowPeel2.lean` writes the region-inserted coefficient of an end window, with a
+matrix inserted on `e`, as the assembled deformed state of the corner-extended bond-inserted insert
+on the end pair `S`.  The end-pair equality `staircasePair_insert_eq_open` equates the two
+corner-extended inserts on `S`, hence their assembled deformed states.  Chaining the two rewriting
+identities through the end-pair equality leaves the two end windows' region-inserted coefficients
+equal across `e`, read off any global physical configuration.  This is the single-tensor content of
+the peeling; the cross-tensor gauge is the algebra-isomorphism step that uses this equality, the
+residual recorded in
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
 
 ## References
@@ -92,11 +93,11 @@ reference edge `e` and the last window's insert `C (L+K-1)` the bond-inserted in
 two end windows' region-inserted coefficients with `M` and `M'` inserted on `e` agree, read off any
 global physical configuration `cfg`.
 
-The bridge `regionInsertedCoeff_eq_extendInsert_bondInserted` writes each side as the assembled
+The theorem `regionInsertedCoeff_eq_extendInsert_bondInserted` writes each side as the assembled
 deformed state of the corner-extended bond-inserted insert on the end pair `S`; the end-pair
 equality `staircasePair_insert_eq_open` equates those two assembled states.  This is the
 single-tensor content of the peeling: the cross-tensor gauge `Z` and the conjugation identity are
-the algebra-isomorphism step that consumes this equality, the residual recorded in
+the algebra-isomorphism step that uses this equality, the residual recorded in
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
@@ -141,7 +142,7 @@ theorem regionInsertedCoeff_endWindows_eq_of_staircase {a b : ℕ}
           (by omega) (by omega) ha0 haw hbh⟩ M'
         (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg)
         (restrictRegionσ (V := TorusVertex width height) (d := d) _ cfg) := by
-  -- Bridge each side to the assembled deformed state of the corner-extended bond-inserted insert.
+  -- Rewrite each side as the assembled deformed state of the corner-extended bond-inserted insert.
   rw [regionInsertedCoeff_eq_extendInsert_bondInserted
       (staircaseWindow_zero_subset_endPair _ L K) hpos, ← hC0,
     regionInsertedCoeff_eq_extendInsert_bondInserted

--- a/TNLean/PEPS/TorusWindowWitness.lean
+++ b/TNLean/PEPS/TorusWindowWitness.lean
@@ -7,21 +7,20 @@ import TNLean.PEPS.TorusConjCovarianceFamily
 
 The two-dimensional strengthening of the normal PEPS Fundamental Theorem
 (arXiv:1804.04964, the corollary at lines 2297--2318 of
-`Papers/1804.04964/paper_normal.tex`) feeds the torus covariant-family machinery an
+`Papers/1804.04964/paper_normal.tex`) provides the torus covariant-family construction with an
 `EdgeCoeffIdentityWitness` at one reference edge per orientation.  The rectangle route of
 Theorem 3 takes the witness region to be the reference rectangle's red block, whose host is
 injective only at the three-block sizes.  At the corollary's minimal size $(2L+1)\times(2K+1)$ the
 host of the rectangle red block is not a union of injective windows, but the host of a *single end
-window* is: this is the landed `regionBlockedTensorInjective_windowComplement`, whose complement
-decomposition needs exactly $2L+1\le\mathrm{width}$, $2K+1\le\mathrm{height}$.
+window* is: this is the theorem `regionBlockedTensorInjective_windowComplement`, whose complement
+decomposition needs exactly $2L+1\le\mathrm{width}$ and $2K+1\le\mathrm{height}$.
 
-This file packages a window-region witness.  Every field except the conjugation coefficient
-identity is supplied at the minimal size by landed window geometry: the reference edge is a
-boundary edge of the left end window, the window is region injective, and its host is injective by
+This file records a window-region witness.  Every field except the conjugation coefficient identity
+is supplied at the minimal size by the established window geometry: the reference edge is a boundary
+edge of the left end window, the window is region injective, and its host is injective by
 `regionBlockedTensorInjective_windowComplement`.  The conjugation coefficient identity is the
-genuinely-new single-bond peeling of the staircase end-pair equality (the residual recorded in
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1), supplied here as a hypothesis: given the
-identity, the witness assembles unconditionally, which is the §5.2 packaging the note describes.
+single-bond peeling of the staircase end-pair equality (the residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1), supplied here as a hypothesis.
 
 ## References
 
@@ -49,11 +48,11 @@ conjugation coefficient identity on `e` realized by a gauge `Z` (`hid`, the §5.
 as a hypothesis), the data assemble into an `EdgeCoeffIdentityWitness` whose region is the left end
 window.  The reference gauge is taken to be `Z` as well, so both witness identities are `hid`.
 
-This is the §5.2 packaging: the witness fields other than the conjugation identity are landed window
-geometry, host injectivity available at the minimal size; the identity itself is the genuinely-new
-peeling of `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.  The window region's host
-injectivity is what makes a single window a valid witness region at the corollary's minimal size,
-in place of the rectangle red block whose host fails there.
+This is the form described in §5.2 of the gap note: the witness fields other than the conjugation
+identity are the established window geometry and host injectivity at the minimal size; the identity
+itself is the single-bond peeling of `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.  The
+window region's host injectivity is what makes a single window a valid witness region at the
+corollary's minimal size, in place of the rectangle red block whose host fails there.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
 `Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;
@@ -100,12 +99,14 @@ noncomputable def windowEdgeCoeffIdentityWitness
 
 /-- **The window-region witness from the window injectivity hypotheses.**
 
-The assembled form of `windowEdgeCoeffIdentityWitness`: with `B` satisfying the one-orientation
-window injectivity hypotheses and union closure, the left end window's region injectivity (`hRB`)
-and host injectivity (`hCB`) are discharged from the hypotheses at the minimal size, so the only
-remaining input is the single-bond conjugation coefficient identity `hid` (the §5.1 peeling).  The
-host injectivity is the landed `regionBlockedTensorInjective_windowComplement`, available exactly at
-$2L+1\le\mathrm{width}$, $2K+1\le\mathrm{height}$.
+The specialization of `windowEdgeCoeffIdentityWitness` under the one-orientation window injectivity
+hypotheses for `B` and their union closure.  The declaration also assumes `2 ≤ L`, `2 ≤ K`, the
+placement bounds for the staircase, the minimal torus bounds
+$2L+1\le\mathrm{width}$ and $2K+1\le\mathrm{height}$, positive bond dimensions for `B`, an
+identification `hE` of the reference bond dimensions of `A` and `B`, and the single-bond
+conjugation coefficient identity `hid` (the §5.1 peeling).  The window and host injectivity
+conditions required by `windowEdgeCoeffIdentityWitness` then follow from the window hypotheses and
+`regionBlockedTensorInjective_windowComplement`.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
 `Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -142,9 +142,20 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
 \end{theorem}
 \begin{proof}
     \leanok
-    Expand the deformed state and substitute the definition of
-    $I_{A,R,f,M}$:
+    Expanding the deformed state gives
     \[
+        \Psi_{A,R,I_{A,R,f,M}}(\sigma,\tau)
+        =
+        \sum_{\nu\in\partial R}
+        I_{A,R,f,M}(\nu,\sigma)\,
+        T_{A,V\setminus R}^{\nu^c}(\tau).
+    \]
+    Substituting the definition of $I_{A,R,f,M}$ and exchanging the two finite
+    sums gives
+    \[
+    \begin{aligned}
+        \Psi_{A,R,I_{A,R,f,M}}(\sigma,\tau)
+        &=
         \sum_{\nu\in\partial R}
         \left(
         \sum_{\substack{\mu\in\partial R\\
@@ -152,10 +163,11 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         =\nu|_{\partial R\setminus\{f\}}}}
         M_{\mu_f,\nu_f}\,T_{A,R}^{\mu}(\sigma)
         \right)
-        T_{A,V\setminus R}^{\nu^c}(\tau).
+        T_{A,V\setminus R}^{\nu^c}(\tau)\\
+        &=
+        C_A(R,f,M;\sigma,\tau).
+    \end{aligned}
     \]
-    Exchanging the two finite sums gives exactly the defining double sum for
-    $C_A(R,f,M;\sigma,\tau)$.
 \end{proof}
 
 \begin{theorem}[Bond insertion through a corner extension]
@@ -177,14 +189,17 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
 \end{theorem}
 \begin{proof}
     \leanok
-    The preceding theorem rewrites the left-hand side as
-    $\Psi_{A,R,I_{A,R,f,M}}(\sigma)$.  The state-preservation theorem for
-    corner extension then gives
+    The preceding theorem and state preservation for corner extension give
     \[
-        \Psi_{A,R,I_{A,R,f,M}}(\sigma)
-        =
+    \begin{aligned}
+        C_A\bigl(R,f,M;\sigma|_R,\sigma|_{V\setminus R}\bigr)
+        &=
+        \Psi_{A,R,I_{A,R,f,M}}
+            (\sigma|_R,\sigma|_{V\setminus R})\\
+        &=
         \Psi_{A,S,
-        \operatorname{Ext}_{R\subseteq S}(I_{A,R,f,M})}(\sigma).
+            \operatorname{Ext}_{R\subseteq S}(I_{A,R,f,M})}(\sigma).
+    \end{aligned}
     \]
 \end{proof}
 


### PR DESCRIPTION
### Motivation
- After the PEPS blueprint restructuring on `main`, the torus-window entries are present, but the review of this branch identified two remaining reader-facing problems: some proof sketches should display the contraction identities rather than describe them only in words, and the Lean module prose should avoid local process terminology.
- The affected mathematics is the bond-inserted region insert and its corner-extension form in the overlapping-window argument of arXiv:1804.04964, Section 3.

### Description
- `blueprint/src/chapter/ch24_peps_ft_region_transfer.tex`: expand the proof sketches for `deformedRegionState_bondInsertedRegionInsert` and `regionInsertedCoeff_eq_extendInsert_bondInserted` into displayed identities:
  \[
  \Psi_{A,R,I_{A,R,f,M}}(\sigma,\tau)
  =\sum_{\nu} I_{A,R,f,M}(\nu,\sigma)T_{A,V\setminus R}^{\nu^c}(\tau)
  =C_A(R,f,M;\sigma,\tau),
  \]
  and
  \[
  C_A(R,f,M;\sigma|_R,\sigma|_{V\setminus R})
  =\Psi_{A,R,I_{A,R,f,M}}(\sigma|_R,\sigma|_{V\setminus R})
  =\Psi_{A,S,\operatorname{Ext}_{R\subseteq S}(I_{A,R,f,M})}(\sigma).
  \]
- `TNLean/PEPS/TorusWindowPeel2.lean`, `TorusWindowPeel3.lean`, and `TorusWindowWitness.lean`: replace informal labels such as “bridge” and “packaging” with direct mathematical descriptions, and make the hypotheses of `windowEdgeCoeffIdentityWitness_of_hypotheses` visible in the docstring.

### Testing
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

Closes #2779