### PR TITLE
feat(PEPS): classify reference edge across staircase window family

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -420,6 +420,7 @@ import TNLean.PEPS.TorusWindowChain4
 import TNLean.PEPS.TorusWindowChain5
 import TNLean.PEPS.TorusWindowChain6
 import TNLean.PEPS.TorusWindowExtraction
+import TNLean.PEPS.TorusWindowFamilyCrossing
 import TNLean.PEPS.TorusWindowPeel
 import TNLean.PEPS.TorusWindowPeel2
 import TNLean.PEPS.TorusWindowPeel3

--- a/TNLean/PEPS/TorusWindowFamilyCrossing.lean
+++ b/TNLean/PEPS/TorusWindowFamilyCrossing.lean
@@ -10,8 +10,9 @@ The two-dimensional strengthening of the normal PEPS Fundamental Theorem
 as a physical operation on any staircase window containing an endpoint of `e`.  The bond-inserted
 family the single-bond peeling `regionInsertedCoeff_endWindows_eq_of_staircase` consumes carries an
 insert on every staircase window: a bond-inserted insert on the windows where `e` is a boundary
-edge, and an interior-bond deformation on the windows where `e` is an interior bond.  Which
-construction applies to each window `W_j` is the geometric datum this file supplies.
+edge, and an interior-bond deformation on the windows where `e` is an interior bond.  The lemmas
+below classify the windows: those with `j = 0` or `L ≤ j` carry a boundary-edge insert, and those
+with `1 ≤ j < L` carry the interior-bond deformation of the genuine block.
 
 ## The classification
 
@@ -43,8 +44,6 @@ insert, the interior-bond windows the interior-bond deformation of the genuine b
   filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
 -/
 
-open scoped BigOperators Matrix
-
 namespace TNLean
 namespace PEPS
 
@@ -75,7 +74,6 @@ theorem referenceEdge_leftEndpoint_mem_staircaseWindow {L K a b j : ℕ}
     (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) :
     (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.1 ∈
         staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j ↔ 1 ≤ j := by
-  have hw0 : 0 < width := NeZero.pos width
   -- The reference edge avoids wraparound, so its ordered endpoints are explicit.
   have hp1lt :
       ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)).val + 1 < width := by
@@ -114,7 +112,6 @@ theorem referenceEdge_rightEndpoint_mem_staircaseWindow {L K a b j : ℕ}
     (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) :
     (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.2 ∈
         staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j ↔ j < L := by
-  have hw0 : 0 < width := NeZero.pos width
   have hp1lt :
       ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)).val + 1 < width := by
     rw [show (a : ZMod width) + ((L - 1 : ℕ) : ZMod width) = ((a + (L - 1) : ℕ) : ZMod width) by

--- a/TNLean/PEPS/TorusWindowFamilyCrossing.lean
+++ b/TNLean/PEPS/TorusWindowFamilyCrossing.lean
@@ -15,9 +15,9 @@ construction applies to each window `W_j` is the geometric datum this file suppl
 
 ## The classification
 
-The reference edge `e = horizontalStaircaseReferenceEdge s L K` has endpoints
-`e.1.1 = (a + L - 1, b + K - 1)` (the left endpoint `u`) and `e.1.2 = (a + L, b + K - 1)` (the
-right endpoint `w`), read off `torusRightEdge_endpoints_of_lt`.  Against the membership
+The reference edge `e = horizontalStaircaseReferenceEdge s L K` has the left endpoint
+$u = (a + L - 1, b + K - 1)$ and the right endpoint
+$w = (a + L, b + K - 1)$, read off `torusRightEdge_endpoints_of_lt`.  Against the membership
 characterization `mem_staircaseWindow`, in the staircase coordinates `s = (a, b)`:
 
 * the right endpoint `w` lies in `W_j` exactly for `j < L` (the sliding arm strictly before the
@@ -56,13 +56,13 @@ variable [Fact (1 < width)] [Fact (1 < height)]
 /-! ### Membership of the two endpoints of the reference edge
 
 The reference edge `e` of the horizontal staircase end pair is the right edge at
-`(a + L - 1, b + K - 1)`.  Its two endpoints are the left endpoint `u = e.1.1` and the right
-endpoint `w = e.1.2`; the two lemmas below read off, against `mem_staircaseWindow`, exactly which
-windows of the family contain each. -/
+`(a + L - 1, b + K - 1)`.  Its two endpoints are the left endpoint $u$ and the
+right endpoint $w$; the two lemmas below read off, against `mem_staircaseWindow`,
+exactly which windows of the family contain each. -/
 
 /-- **The left endpoint of the reference edge lies in `W_j` exactly for `1 ≤ j`.**
 
-The left endpoint `u = e.1.1 = (a + L - 1, b + K - 1)` of the reference edge has column distance
+The left endpoint $u = (a + L - 1, b + K - 1)$ of the reference edge has column distance
 `L - 1` and row distance `K - 1` from the staircase corner `s = (a, b)`.  Against the window
 membership characterization `mem_staircaseWindow`, the column distance `L - 1` lands in the
 window's column band exactly when the window has slid past the first one (`1 ≤ j`); the row
@@ -71,8 +71,8 @@ distance `K - 1` lands in every window's row band.
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
 theorem referenceEdge_leftEndpoint_mem_staircaseWindow {L K a b j : ℕ}
-    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
-    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) (hj : j < L + K) :
+    (hL : 0 < L) (hK : 0 < K)
+    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) :
     (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.1 ∈
         staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j ↔ 1 ≤ j := by
   have hw0 : 0 < width := NeZero.pos width
@@ -101,7 +101,7 @@ theorem referenceEdge_leftEndpoint_mem_staircaseWindow {L K a b j : ℕ}
 
 /-- **The right endpoint of the reference edge lies in `W_j` exactly for `j < L`.**
 
-The right endpoint `w = e.1.2 = (a + L, b + K - 1)` of the reference edge has column distance `L`
+The right endpoint $w = (a + L, b + K - 1)$ of the reference edge has column distance `L`
 and row distance `K - 1` from the staircase corner `s = (a, b)`.  Against the window membership
 characterization `mem_staircaseWindow`, the column distance `L` lands in the window's column band
 `[L - j, 2L - j)` exactly when the window is strictly before the corner (`j < L`); the row distance
@@ -110,7 +110,7 @@ characterization `mem_staircaseWindow`, the column distance `L` lands in the win
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
 theorem referenceEdge_rightEndpoint_mem_staircaseWindow {L K a b j : ℕ}
-    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (hL : 0 < L) (hK : 0 < K)
     (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) :
     (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.2 ∈
         staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j ↔ j < L := by
@@ -156,22 +156,22 @@ exactly one endpoint of `e` lies in `W_j`.
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
 theorem isRegionBoundaryEdge_staircaseWindow_referenceEdge {L K a b j : ℕ}
-    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
-    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) (hj : j < L + K)
+    (hL : 0 < L) (hK : 0 < K)
+    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height)
     (hjcase : j = 0 ∨ L ≤ j) :
     IsRegionBoundaryEdge (G := torusGraph width height)
       (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
       (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) := by
   have hlow := referenceEdge_leftEndpoint_mem_staircaseWindow (width := width) (height := height)
-    (b := b) hL hK ha0 haw hyh hj
+    (b := b) (j := j) hL hK haw hyh
   have hup := referenceEdge_rightEndpoint_mem_staircaseWindow (width := width) (height := height)
-    (b := b) (j := j) hL hK ha0 haw hyh
+    (b := b) (j := j) hL hK haw hyh
   rw [IsRegionBoundaryEdge]
   rcases hjcase with hj0 | hjL
-  · -- `j = 0`: only the right endpoint `e.1.2` lies in `W_0`.
+  · -- `j = 0`: only the right endpoint lies in `W_0`.
     subst hj0
     exact Or.inr ⟨fun h => absurd (hlow.mp h) (by omega), hup.mpr (by omega)⟩
-  · -- `L ≤ j`: only the left endpoint `e.1.1` lies in `W_j`.
+  · -- `L ≤ j`: only the left endpoint lies in `W_j`.
     exact Or.inl ⟨hlow.mpr (by omega), fun h => absurd (hup.mp h) (by omega)⟩
 
 /-- **Both endpoints of the reference edge lie in an interior-bond window.**
@@ -183,35 +183,35 @@ both the left endpoint (`1 ≤ j`) and the right endpoint (`j < L`).
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
 theorem referenceEdge_endpoints_mem_staircaseWindow_of_interior {L K a b j : ℕ}
-    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (hL : 0 < L) (hK : 0 < K)
     (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) (h1 : 1 ≤ j) (h2 : j < L) :
     (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.1 ∈
         staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j ∧
       (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.2 ∈
         staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j :=
   ⟨(referenceEdge_leftEndpoint_mem_staircaseWindow (width := width) (height := height)
-      (b := b) hL hK ha0 haw hyh (by omega)).mpr h1,
+      (b := b) (j := j) hL hK haw hyh).mpr h1,
     (referenceEdge_rightEndpoint_mem_staircaseWindow (width := width) (height := height)
-      (b := b) (j := j) hL hK ha0 haw hyh).mpr h2⟩
+      (b := b) (j := j) hL hK haw hyh).mpr h2⟩
 
 /-- **The reference edge is not a boundary edge of an interior-bond window.**
 
 For a window `W_j` of the staircase family with `1 ≤ j < L`, the reference edge `e` is *not* a
 boundary edge of `W_j`: both endpoints of `e` lie in `W_j`
-(`referenceEdge_endpoints_mem_staircaseWindow_of_interior`), so `e` is an interior bond of `W_j`.
+(the preceding theorem, for `1 ≤ j < L`), so `e` is an interior bond of `W_j`.
 This is the window on which the bond-inserted family carries the interior-bond deformation of the
 genuine block rather than a boundary-edge insert.
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
 theorem not_isRegionBoundaryEdge_staircaseWindow_referenceEdge_of_interior {L K a b j : ℕ}
-    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (hL : 0 < L) (hK : 0 < K)
     (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) (h1 : 1 ≤ j) (h2 : j < L) :
     ¬ IsRegionBoundaryEdge (G := torusGraph width height)
         (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
         (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) := by
   obtain ⟨hlow, hup⟩ := referenceEdge_endpoints_mem_staircaseWindow_of_interior
-    (width := width) (height := height) (b := b) hL hK ha0 haw hyh h1 h2
+    (width := width) (height := height) (b := b) hL hK haw hyh h1 h2
   rw [IsRegionBoundaryEdge]
   rintro (⟨_, hout⟩ | ⟨hout, _⟩)
   · exact hout hup

--- a/TNLean/PEPS/TorusWindowFamilyCrossing.lean
+++ b/TNLean/PEPS/TorusWindowFamilyCrossing.lean
@@ -1,0 +1,223 @@
+import TNLean.PEPS.TorusWindowExtraction
+import TNLean.PEPS.TorusWindowFamily
+
+/-!
+# The reference edge across the staircase window family
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) realizes a virtual operation on the distinguished bond `e`
+as a physical operation on any staircase window containing an endpoint of `e`.  The bond-inserted
+family the single-bond peeling `regionInsertedCoeff_endWindows_eq_of_staircase` consumes carries an
+insert on every staircase window: a bond-inserted insert on the windows where `e` is a boundary
+edge, and an interior-bond deformation on the windows where `e` is an interior bond.  Which
+construction applies to each window `W_j` is the geometric datum this file supplies.
+
+## The classification
+
+The reference edge `e = horizontalStaircaseReferenceEdge s L K` has endpoints
+`e.1.1 = (a + L - 1, b + K - 1)` (the left endpoint `u`) and `e.1.2 = (a + L, b + K - 1)` (the
+right endpoint `w`), read off `torusRightEdge_endpoints_of_lt`.  Against the membership
+characterization `mem_staircaseWindow`, in the staircase coordinates `s = (a, b)`:
+
+* the right endpoint `w` lies in `W_j` exactly for `j < L` (the sliding arm strictly before the
+  corner);
+* the left endpoint `u` lies in `W_j` exactly for `1 ≤ j` (every window but the first).
+
+Hence:
+
+* `W_0` (`j = 0`) contains only `w`, so `e` is a boundary edge;
+* `W_1, …, W_{L-1}` (`1 ≤ j < L`) contain both endpoints, so `e` is an interior bond;
+* `W_L, …, W_{L+K-1}` (`L ≤ j < L + K`) contain only `u`, so `e` is a boundary edge.
+
+This is the per-window split described in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1
+(residual piece 1) and the proof sketch's "a virtual operation on a given bond is a physical
+operation on any window containing an endpoint": the boundary-edge windows carry the bond-inserted
+insert, the interior-bond windows the interior-bond deformation of the genuine block.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
+  2296--2445 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+section Torus
+
+variable {width height : ℕ} [NeZero width] [NeZero height]
+variable [Fact (1 < width)] [Fact (1 < height)]
+
+/-! ### Membership of the two endpoints of the reference edge
+
+The reference edge `e` of the horizontal staircase end pair is the right edge at
+`(a + L - 1, b + K - 1)`.  Its two endpoints are the left endpoint `u = e.1.1` and the right
+endpoint `w = e.1.2`; the two lemmas below read off, against `mem_staircaseWindow`, exactly which
+windows of the family contain each. -/
+
+/-- **The left endpoint of the reference edge lies in `W_j` exactly for `1 ≤ j`.**
+
+The left endpoint `u = e.1.1 = (a + L - 1, b + K - 1)` of the reference edge has column distance
+`L - 1` and row distance `K - 1` from the staircase corner `s = (a, b)`.  Against the window
+membership characterization `mem_staircaseWindow`, the column distance `L - 1` lands in the
+window's column band exactly when the window has slid past the first one (`1 ≤ j`); the row
+distance `K - 1` lands in every window's row band.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem referenceEdge_leftEndpoint_mem_staircaseWindow {L K a b j : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) (hj : j < L + K) :
+    (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.1 ∈
+        staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j ↔ 1 ≤ j := by
+  have hw0 : 0 < width := NeZero.pos width
+  -- The reference edge avoids wraparound, so its ordered endpoints are explicit.
+  have hp1lt :
+      ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)).val + 1 < width := by
+    rw [show (a : ZMod width) + ((L - 1 : ℕ) : ZMod width) = ((a + (L - 1) : ℕ) : ZMod width) by
+        push_cast; ring, ZMod.val_natCast_of_lt (by omega)]
+    omega
+  have href : horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K =
+      torusRightEdge ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width),
+        (b : ZMod height) + ((K - 1 : ℕ) : ZMod height)) := rfl
+  have hep := torusRightEdge_endpoints_of_lt (width := width) (height := height)
+    (p := ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width),
+      (b : ZMod height) + ((K - 1 : ℕ) : ZMod height))) hp1lt
+  rw [href, hep.1, mem_staircaseWindow (by omega) hyh]
+  -- The two coordinate distances of `u` from the staircase corner.
+  have hd1 : (((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)) - (a : ZMod width)).val = L - 1 := by
+    rw [add_sub_cancel_left, ZMod.val_natCast_of_lt (by omega)]
+  have hd2 :
+      (((b : ZMod height) + ((K - 1 : ℕ) : ZMod height)) - (b : ZMod height)).val = K - 1 := by
+    rw [add_sub_cancel_left, ZMod.val_natCast_of_lt (by omega)]
+  dsimp only
+  rw [hd1, hd2]
+  omega
+
+/-- **The right endpoint of the reference edge lies in `W_j` exactly for `j < L`.**
+
+The right endpoint `w = e.1.2 = (a + L, b + K - 1)` of the reference edge has column distance `L`
+and row distance `K - 1` from the staircase corner `s = (a, b)`.  Against the window membership
+characterization `mem_staircaseWindow`, the column distance `L` lands in the window's column band
+`[L - j, 2L - j)` exactly when the window is strictly before the corner (`j < L`); the row distance
+`K - 1` lands in every window's row band.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem referenceEdge_rightEndpoint_mem_staircaseWindow {L K a b j : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) :
+    (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.2 ∈
+        staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j ↔ j < L := by
+  have hw0 : 0 < width := NeZero.pos width
+  have hp1lt :
+      ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)).val + 1 < width := by
+    rw [show (a : ZMod width) + ((L - 1 : ℕ) : ZMod width) = ((a + (L - 1) : ℕ) : ZMod width) by
+        push_cast; ring, ZMod.val_natCast_of_lt (by omega)]
+    omega
+  have href : horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K =
+      torusRightEdge ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width),
+        (b : ZMod height) + ((K - 1 : ℕ) : ZMod height)) := rfl
+  have hep := torusRightEdge_endpoints_of_lt (width := width) (height := height)
+    (p := ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width),
+      (b : ZMod height) + ((K - 1 : ℕ) : ZMod height))) hp1lt
+  rw [href, hep.2, mem_staircaseWindow (by omega) hyh]
+  -- The two coordinate distances of `w` from the staircase corner.
+  have hd1 :
+      ((((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)) + 1) - (a : ZMod width)).val = L := by
+    rw [show (((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)) + 1) - (a : ZMod width) =
+        ((L : ℕ) : ZMod width) by
+      rw [show ((L : ℕ) : ZMod width) = (((L - 1) + 1 : ℕ) : ZMod width) by congr 1; omega]
+      push_cast; ring]
+    rw [ZMod.val_natCast_of_lt (by omega)]
+  have hd2 :
+      (((b : ZMod height) + ((K - 1 : ℕ) : ZMod height)) - (b : ZMod height)).val = K - 1 := by
+    rw [add_sub_cancel_left, ZMod.val_natCast_of_lt (by omega)]
+  dsimp only
+  rw [hd1, hd2]
+  omega
+
+/-! ### The classification of the reference edge per window
+
+The two endpoint memberships split the family into boundary-edge windows (`j = 0` or `L ≤ j`) and
+interior-bond windows (`1 ≤ j < L`). -/
+
+/-- **The reference edge is a boundary edge of a single-endpoint window.**
+
+For a window `W_j` of the staircase family with `j = 0` (containing only the right endpoint) or
+`L ≤ j` (containing only the left endpoint), the reference edge `e` is a boundary edge of `W_j`:
+exactly one endpoint of `e` lies in `W_j`.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem isRegionBoundaryEdge_staircaseWindow_referenceEdge {L K a b j : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) (hj : j < L + K)
+    (hjcase : j = 0 ∨ L ≤ j) :
+    IsRegionBoundaryEdge (G := torusGraph width height)
+      (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) := by
+  have hlow := referenceEdge_leftEndpoint_mem_staircaseWindow (width := width) (height := height)
+    (b := b) hL hK ha0 haw hyh hj
+  have hup := referenceEdge_rightEndpoint_mem_staircaseWindow (width := width) (height := height)
+    (b := b) (j := j) hL hK ha0 haw hyh
+  rw [IsRegionBoundaryEdge]
+  rcases hjcase with hj0 | hjL
+  · -- `j = 0`: only the right endpoint `e.1.2` lies in `W_0`.
+    subst hj0
+    exact Or.inr ⟨fun h => absurd (hlow.mp h) (by omega), hup.mpr (by omega)⟩
+  · -- `L ≤ j`: only the left endpoint `e.1.1` lies in `W_j`.
+    exact Or.inl ⟨hlow.mpr (by omega), fun h => absurd (hup.mp h) (by omega)⟩
+
+/-- **Both endpoints of the reference edge lie in an interior-bond window.**
+
+For a window `W_j` of the staircase family with `1 ≤ j < L`, both endpoints of the reference edge
+`e` lie in `W_j`: the window has slid past the first one but not reached the corner, so it contains
+both the left endpoint (`1 ≤ j`) and the right endpoint (`j < L`).
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem referenceEdge_endpoints_mem_staircaseWindow_of_interior {L K a b j : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) (h1 : 1 ≤ j) (h2 : j < L) :
+    (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.1 ∈
+        staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j ∧
+      (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K).1.2 ∈
+        staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j :=
+  ⟨(referenceEdge_leftEndpoint_mem_staircaseWindow (width := width) (height := height)
+      (b := b) hL hK ha0 haw hyh (by omega)).mpr h1,
+    (referenceEdge_rightEndpoint_mem_staircaseWindow (width := width) (height := height)
+      (b := b) (j := j) hL hK ha0 haw hyh).mpr h2⟩
+
+/-- **The reference edge is not a boundary edge of an interior-bond window.**
+
+For a window `W_j` of the staircase family with `1 ≤ j < L`, the reference edge `e` is *not* a
+boundary edge of `W_j`: both endpoints of `e` lie in `W_j`
+(`referenceEdge_endpoints_mem_staircaseWindow_of_interior`), so `e` is an interior bond of `W_j`.
+This is the window on which the bond-inserted family carries the interior-bond deformation of the
+genuine block rather than a boundary-edge insert.
+
+Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem not_isRegionBoundaryEdge_staircaseWindow_referenceEdge_of_interior {L K a b j : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hyh : 2 * K ≤ height) (h1 : 1 ≤ j) (h2 : j < L) :
+    ¬ IsRegionBoundaryEdge (G := torusGraph width height)
+        (staircaseWindow ((a : ZMod width), (b : ZMod height)) L K j)
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) := by
+  obtain ⟨hlow, hup⟩ := referenceEdge_endpoints_mem_staircaseWindow_of_interior
+    (width := width) (height := height) (b := b) hL hK ha0 haw hyh h1 h2
+  rw [IsRegionBoundaryEdge]
+  rintro (⟨_, hout⟩ | ⟨hout, _⟩)
+  · exact hout hup
+  · exact hout hlow
+
+end Torus
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWindowFamilyCrossing.lean
+++ b/TNLean/PEPS/TorusWindowFamilyCrossing.lean
@@ -6,30 +6,32 @@ import TNLean.PEPS.TorusWindowFamily
 
 The two-dimensional strengthening of the normal PEPS Fundamental Theorem
 (arXiv:1804.04964, the corollary at lines 2297--2318 of
-`Papers/1804.04964/paper_normal.tex`) realizes a virtual operation on the distinguished bond `e`
-as a physical operation on any staircase window containing an endpoint of `e`.  The bond-inserted
+`Papers/1804.04964/paper_normal.tex`) realizes a virtual operation on the distinguished bond $e$
+as a physical operation on any staircase window containing an endpoint of $e$.  The bond-inserted
 family the single-bond peeling `regionInsertedCoeff_endWindows_eq_of_staircase` consumes carries an
-insert on every staircase window: a bond-inserted insert on the windows where `e` is a boundary
-edge, and an interior-bond deformation on the windows where `e` is an interior bond.  The lemmas
-below classify the windows: those with `j = 0` or `L ≤ j` carry a boundary-edge insert, and those
-with `1 ≤ j < L` carry the interior-bond deformation of the genuine block.
+insert on every staircase window: a bond-inserted insert on the windows where $e$ is a boundary
+edge, and an interior-bond deformation on the windows where $e$ is an interior bond.  The lemmas
+below classify the windows: those with $j = 0$ or $L \le j$ carry a boundary-edge insert, and those
+with $1 \le j < L$ carry the interior-bond deformation of the genuine block.
 
 ## The classification
 
-The reference edge `e = horizontalStaircaseReferenceEdge s L K` has the left endpoint
+The reference edge determined by the staircase corner $s$ and sizes $L,K$ has the left endpoint
 $u = (a + L - 1, b + K - 1)$ and the right endpoint
 $w = (a + L, b + K - 1)$, read off `torusRightEdge_endpoints_of_lt`.  Against the membership
-characterization `mem_staircaseWindow`, in the staircase coordinates `s = (a, b)`:
+characterization `mem_staircaseWindow`, in the staircase coordinates $s = (a, b)$:
 
-* the right endpoint `w` lies in `W_j` exactly for `j < L` (the sliding arm strictly before the
+* the right endpoint $w$ lies in $W_j$ exactly for $j < L$ (the sliding arm strictly before the
   corner);
-* the left endpoint `u` lies in `W_j` exactly for `1 ≤ j` (every window but the first).
+* the left endpoint $u$ lies in $W_j$ exactly for $1 \le j$ (every window but the first).
 
 Hence:
 
-* `W_0` (`j = 0`) contains only `w`, so `e` is a boundary edge;
-* `W_1, …, W_{L-1}` (`1 ≤ j < L`) contain both endpoints, so `e` is an interior bond;
-* `W_L, …, W_{L+K-1}` (`L ≤ j < L + K`) contain only `u`, so `e` is a boundary edge.
+* $W_0$ ($j = 0$) contains only $w$, so $e$ is a boundary edge;
+* $W_1,\ldots,W_{L-1}$ ($1 \le j < L$) contain both endpoints, so $e$ is an
+  interior bond;
+* $W_L,\ldots,W_{L+K-1}$ ($L \le j < L + K$) contain only $u$, so $e$ is a
+  boundary edge.
 
 This is the per-window split described in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1
 (residual piece 1) and the proof sketch's "a virtual operation on a given bond is a physical
@@ -54,18 +56,18 @@ variable [Fact (1 < width)] [Fact (1 < height)]
 
 /-! ### Membership of the two endpoints of the reference edge
 
-The reference edge `e` of the horizontal staircase end pair is the right edge at
-`(a + L - 1, b + K - 1)`.  Its two endpoints are the left endpoint $u$ and the
+The reference edge $e$ of the horizontal staircase end pair is the right edge at
+$(a + L - 1, b + K - 1)$.  Its two endpoints are the left endpoint $u$ and the
 right endpoint $w$; the two lemmas below read off, against `mem_staircaseWindow`,
 exactly which windows of the family contain each. -/
 
-/-- **The left endpoint of the reference edge lies in `W_j` exactly for `1 ≤ j`.**
+/-- **The left endpoint of the reference edge lies in $W_j$ exactly for $1 \le j$.**
 
 The left endpoint $u = (a + L - 1, b + K - 1)$ of the reference edge has column distance
-`L - 1` and row distance `K - 1` from the staircase corner `s = (a, b)`.  Against the window
-membership characterization `mem_staircaseWindow`, the column distance `L - 1` lands in the
-window's column band exactly when the window has slid past the first one (`1 ≤ j`); the row
-distance `K - 1` lands in every window's row band.
+$L - 1$ and row distance $K - 1$ from the staircase corner $s = (a, b)$.  Against the window
+membership characterization `mem_staircaseWindow`, the column distance $L - 1$ lands in the
+window's column band exactly when the window has slid past the first one ($1 \le j$); the row
+distance $K - 1$ lands in every window's row band.
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
@@ -87,8 +89,9 @@ theorem referenceEdge_leftEndpoint_mem_staircaseWindow {L K a b j : ℕ}
     (p := ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width),
       (b : ZMod height) + ((K - 1 : ℕ) : ZMod height))) hp1lt
   rw [href, hep.1, mem_staircaseWindow (by omega) hyh]
-  -- The two coordinate distances of `u` from the staircase corner.
-  have hd1 : (((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)) - (a : ZMod width)).val = L - 1 := by
+  -- The two coordinate distances of $u$ from the staircase corner.
+  have hd1 :
+      (((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)) - (a : ZMod width)).val = L - 1 := by
     rw [add_sub_cancel_left, ZMod.val_natCast_of_lt (by omega)]
   have hd2 :
       (((b : ZMod height) + ((K - 1 : ℕ) : ZMod height)) - (b : ZMod height)).val = K - 1 := by
@@ -97,13 +100,13 @@ theorem referenceEdge_leftEndpoint_mem_staircaseWindow {L K a b j : ℕ}
   rw [hd1, hd2]
   omega
 
-/-- **The right endpoint of the reference edge lies in `W_j` exactly for `j < L`.**
+/-- **The right endpoint of the reference edge lies in $W_j$ exactly for $j < L$.**
 
-The right endpoint $w = (a + L, b + K - 1)$ of the reference edge has column distance `L`
-and row distance `K - 1` from the staircase corner `s = (a, b)`.  Against the window membership
-characterization `mem_staircaseWindow`, the column distance `L` lands in the window's column band
-`[L - j, 2L - j)` exactly when the window is strictly before the corner (`j < L`); the row distance
-`K - 1` lands in every window's row band.
+The right endpoint $w = (a + L, b + K - 1)$ of the reference edge has column distance $L$
+and row distance $K - 1$ from the staircase corner $s = (a, b)$.  Against the window membership
+characterization `mem_staircaseWindow`, the column distance $L$ lands in the window's column band
+$[L - j, 2L - j)$ exactly when the window is strictly before the corner ($j < L$); the row distance
+$K - 1$ lands in every window's row band.
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
@@ -124,7 +127,7 @@ theorem referenceEdge_rightEndpoint_mem_staircaseWindow {L K a b j : ℕ}
     (p := ((a : ZMod width) + ((L - 1 : ℕ) : ZMod width),
       (b : ZMod height) + ((K - 1 : ℕ) : ZMod height))) hp1lt
   rw [href, hep.2, mem_staircaseWindow (by omega) hyh]
-  -- The two coordinate distances of `w` from the staircase corner.
+  -- The two coordinate distances of $w$ from the staircase corner.
   have hd1 :
       ((((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)) + 1) - (a : ZMod width)).val = L := by
     rw [show (((a : ZMod width) + ((L - 1 : ℕ) : ZMod width)) + 1) - (a : ZMod width) =
@@ -141,14 +144,14 @@ theorem referenceEdge_rightEndpoint_mem_staircaseWindow {L K a b j : ℕ}
 
 /-! ### The classification of the reference edge per window
 
-The two endpoint memberships split the family into boundary-edge windows (`j = 0` or `L ≤ j`) and
-interior-bond windows (`1 ≤ j < L`). -/
+The two endpoint memberships split the family into boundary-edge windows ($j = 0$ or $L \le j$)
+and interior-bond windows ($1 \le j < L$). -/
 
 /-- **The reference edge is a boundary edge of a single-endpoint window.**
 
-For a window `W_j` of the staircase family with `j = 0` (containing only the right endpoint) or
-`L ≤ j` (containing only the left endpoint), the reference edge `e` is a boundary edge of `W_j`:
-exactly one endpoint of `e` lies in `W_j`.
+For a window $W_j$ of the staircase family with $j = 0$ (containing only the right endpoint) or
+$L \le j$ (containing only the left endpoint), the reference edge $e$ is a boundary edge of $W_j$:
+exactly one endpoint of $e$ lies in $W_j$.
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
@@ -165,17 +168,17 @@ theorem isRegionBoundaryEdge_staircaseWindow_referenceEdge {L K a b j : ℕ}
     (b := b) (j := j) hL hK haw hyh
   rw [IsRegionBoundaryEdge]
   rcases hjcase with hj0 | hjL
-  · -- `j = 0`: only the right endpoint lies in `W_0`.
+  · -- $j = 0$: only the right endpoint lies in $W_0$.
     subst hj0
     exact Or.inr ⟨fun h => absurd (hlow.mp h) (by omega), hup.mpr (by omega)⟩
-  · -- `L ≤ j`: only the left endpoint lies in `W_j`.
+  · -- $L \le j$: only the left endpoint lies in $W_j$.
     exact Or.inl ⟨hlow.mpr (by omega), fun h => absurd (hup.mp h) (by omega)⟩
 
 /-- **Both endpoints of the reference edge lie in an interior-bond window.**
 
-For a window `W_j` of the staircase family with `1 ≤ j < L`, both endpoints of the reference edge
-`e` lie in `W_j`: the window has slid past the first one but not reached the corner, so it contains
-both the left endpoint (`1 ≤ j`) and the right endpoint (`j < L`).
+For a window $W_j$ of the staircase family with $1 \le j < L$, both endpoints of the reference edge
+$e$ lie in $W_j$: the window has slid past the first one but not reached the corner, so it contains
+both the left endpoint ($1 \le j$) and the right endpoint ($j < L$).
 
 Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
 `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
@@ -193,9 +196,9 @@ theorem referenceEdge_endpoints_mem_staircaseWindow_of_interior {L K a b j : ℕ
 
 /-- **The reference edge is not a boundary edge of an interior-bond window.**
 
-For a window `W_j` of the staircase family with `1 ≤ j < L`, the reference edge `e` is *not* a
-boundary edge of `W_j`: both endpoints of `e` lie in `W_j`
-(the preceding theorem, for `1 ≤ j < L`), so `e` is an interior bond of `W_j`.
+For a window $W_j$ of the staircase family with $1 \le j < L$, the reference edge $e$ is *not* a
+boundary edge of $W_j$: both endpoints of $e$ lie in $W_j$
+(the preceding theorem, for $1 \le j < L$), so $e$ is an interior bond of $W_j$.
 This is the window on which the bond-inserted family carries the interior-bond deformation of the
 genuine block rather than a boundary-edge insert.
 

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -195,6 +195,86 @@
     The same argument with the reference up edge gives $D_{f_v}=D_v$.
 \end{proof}
 
+\paragraph{Staircase-window geometry for a reference edge.}
+
+\begin{lemma}[Left endpoint of the staircase reference edge]%
+    \label{lem:peps_reference_edge_left_endpoint_staircase_window}
+    \lean{TNLean.PEPS.referenceEdge_leftEndpoint_mem_staircaseWindow}
+    \leanok
+    Let \(L,K>0\), let \(s=(a,b)\) be a staircase corner on the torus, and assume
+    \(a+2L\le n\) and \(2K\le m\). Let \(e\) be the horizontal reference edge
+    from \((a+L-1,b+K-1)\) to \((a+L,b+K-1)\), and let \(W_j\) be the \(j\)th
+    staircase window based at \(s\). Then the left endpoint
+    \[
+        u=(a+L-1,b+K-1)
+    \]
+    lies in \(W_j\) if and only if \(1\le j\).
+\end{lemma}
+\begin{proof}\leanok
+    The endpoint formula gives the two coordinate distances from the corner:
+    the column distance is \(L-1\) and the row distance is \(K-1\). Substituting
+    these distances into the staircase-window membership criterion gives exactly
+    \(1\le j\).
+\end{proof}
+
+\begin{lemma}[Right endpoint of the staircase reference edge]%
+    \label{lem:peps_reference_edge_right_endpoint_staircase_window}
+    \lean{TNLean.PEPS.referenceEdge_rightEndpoint_mem_staircaseWindow}
+    \leanok
+    In the same notation, the right endpoint
+    \[
+        w=(a+L,b+K-1)
+    \]
+    lies in \(W_j\) if and only if \(j<L\).
+\end{lemma}
+\begin{proof}\leanok
+    The right endpoint has column distance \(L\) and row distance \(K-1\) from
+    \(s\). The row condition is automatic, while the column band contains this
+    distance precisely for \(j<L\).
+\end{proof}
+
+\begin{lemma}[Boundary windows for the staircase reference edge]%
+    \label{lem:peps_reference_edge_boundary_windows}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_staircaseWindow_referenceEdge}
+    \leanok
+    \uses{lem:peps_reference_edge_left_endpoint_staircase_window,
+        lem:peps_reference_edge_right_endpoint_staircase_window}
+    If \(j=0\) or \(L\le j\), then the reference edge \(e\) is a boundary edge
+    of \(W_j\): exactly one of its two endpoints lies in the window.
+\end{lemma}
+\begin{proof}\leanok
+    For \(j=0\), Lemmas~\ref{lem:peps_reference_edge_left_endpoint_staircase_window}
+    and~\ref{lem:peps_reference_edge_right_endpoint_staircase_window} show that
+    only \(w\) lies in \(W_j\). For \(L\le j\), the same two endpoint tests show
+    that only \(u\) lies in \(W_j\).
+\end{proof}
+
+\begin{lemma}[Interior windows for the staircase reference edge]%
+    \label{lem:peps_reference_edge_interior_windows}
+    \lean{TNLean.PEPS.referenceEdge_endpoints_mem_staircaseWindow_of_interior}
+    \leanok
+    \uses{lem:peps_reference_edge_left_endpoint_staircase_window,
+        lem:peps_reference_edge_right_endpoint_staircase_window}
+    If \(1\le j<L\), then both endpoints of \(e\) lie in \(W_j\).
+\end{lemma}
+\begin{proof}\leanok
+    The left-endpoint criterion gives \(u\in W_j\) from \(1\le j\), and the
+    right-endpoint criterion gives \(w\in W_j\) from \(j<L\).
+\end{proof}
+
+\begin{lemma}[Interior windows are not boundary windows]%
+    \label{lem:peps_reference_edge_not_boundary_interior_windows}
+    \lean{TNLean.PEPS.not_isRegionBoundaryEdge_staircaseWindow_referenceEdge_of_interior}
+    \leanok
+    \uses{lem:peps_reference_edge_interior_windows}
+    If \(1\le j<L\), then \(e\) is not a boundary edge of \(W_j\).
+\end{lemma}
+\begin{proof}\leanok
+    By Lemma~\ref{lem:peps_reference_edge_interior_windows}, both endpoints of
+    \(e\) lie in \(W_j\). The definition of a boundary edge requires exactly one
+    endpoint in the region, so \(e\) is not a boundary edge of \(W_j\).
+\end{proof}
+
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus]%
     \label{thm:fundamentalTheorem_normalTorusPEPS}
     \notready

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -201,20 +201,20 @@
     \label{lem:peps_reference_edge_left_endpoint_staircase_window}
     \lean{TNLean.PEPS.referenceEdge_leftEndpoint_mem_staircaseWindow}
     \leanok
-    Let \(L,K>0\), let \(s=(a,b)\) be a staircase corner on the torus, and assume
-    \(a+2L\le n\) and \(2K\le m\). Let \(e\) be the horizontal reference edge
-    from \((a+L-1,b+K-1)\) to \((a+L,b+K-1)\), and let \(W_j\) be the \(j\)th
-    staircase window based at \(s\). Then the left endpoint
+    Let $L,K>0$, let $s=(a,b)$ be a staircase corner on the torus, and assume
+    $a+2L\le n$ and $2K\le m$. Let $e$ be the horizontal reference edge
+    from $(a+L-1,b+K-1)$ to $(a+L,b+K-1)$, and let $W_j$ be the $j$th
+    staircase window based at $s$. Then the left endpoint
     \[
         u=(a+L-1,b+K-1)
     \]
-    lies in \(W_j\) if and only if \(1\le j\).
+    lies in $W_j$ if and only if $1\le j$.
 \end{lemma}
 \begin{proof}\leanok
     The endpoint formula gives the two coordinate distances from the corner:
-    the column distance is \(L-1\) and the row distance is \(K-1\). Substituting
+    the column distance is $L-1$ and the row distance is $K-1$. Substituting
     these distances into the staircase-window membership criterion gives exactly
-    \(1\le j\).
+    $1\le j$.
 \end{proof}
 
 \begin{lemma}[Right endpoint of the staircase reference edge]%
@@ -225,12 +225,12 @@
     \[
         w=(a+L,b+K-1)
     \]
-    lies in \(W_j\) if and only if \(j<L\).
+    lies in $W_j$ if and only if $j<L$.
 \end{lemma}
 \begin{proof}\leanok
-    The right endpoint has column distance \(L\) and row distance \(K-1\) from
-    \(s\). The row condition is automatic, while the column band contains this
-    distance precisely for \(j<L\).
+    The right endpoint has column distance $L$ and row distance $K-1$ from
+    $s$. The row condition is automatic, while the column band contains this
+    distance precisely for $j<L$.
 \end{proof}
 
 \begin{lemma}[Boundary windows for the staircase reference edge]%
@@ -239,14 +239,14 @@
     \leanok
     \uses{lem:peps_reference_edge_left_endpoint_staircase_window,
         lem:peps_reference_edge_right_endpoint_staircase_window}
-    If \(j=0\) or \(L\le j\), then the reference edge \(e\) is a boundary edge
-    of \(W_j\): exactly one of its two endpoints lies in the window.
+    If $j=0$ or $L\le j$, then the reference edge $e$ is a boundary edge
+    of $W_j$: exactly one of its two endpoints lies in the window.
 \end{lemma}
 \begin{proof}\leanok
-    For \(j=0\), Lemmas~\ref{lem:peps_reference_edge_left_endpoint_staircase_window}
+    For $j=0$, Lemmas~\ref{lem:peps_reference_edge_left_endpoint_staircase_window}
     and~\ref{lem:peps_reference_edge_right_endpoint_staircase_window} show that
-    only \(w\) lies in \(W_j\). For \(L\le j\), the same two endpoint tests show
-    that only \(u\) lies in \(W_j\).
+    only $w$ lies in $W_j$. For $L\le j$, the same two endpoint tests show
+    that only $u$ lies in $W_j$.
 \end{proof}
 
 \begin{lemma}[Interior windows for the staircase reference edge]%
@@ -255,11 +255,11 @@
     \leanok
     \uses{lem:peps_reference_edge_left_endpoint_staircase_window,
         lem:peps_reference_edge_right_endpoint_staircase_window}
-    If \(1\le j<L\), then both endpoints of \(e\) lie in \(W_j\).
+    If $1\le j<L$, then both endpoints of $e$ lie in $W_j$.
 \end{lemma}
 \begin{proof}\leanok
-    The left-endpoint criterion gives \(u\in W_j\) from \(1\le j\), and the
-    right-endpoint criterion gives \(w\in W_j\) from \(j<L\).
+    The left-endpoint criterion gives $u\in W_j$ from $1\le j$, and the
+    right-endpoint criterion gives $w\in W_j$ from $j<L$.
 \end{proof}
 
 \begin{lemma}[Interior windows are not boundary windows]%
@@ -267,12 +267,12 @@
     \lean{TNLean.PEPS.not_isRegionBoundaryEdge_staircaseWindow_referenceEdge_of_interior}
     \leanok
     \uses{lem:peps_reference_edge_interior_windows}
-    If \(1\le j<L\), then \(e\) is not a boundary edge of \(W_j\).
+    If $1\le j<L$, then $e$ is not a boundary edge of $W_j$.
 \end{lemma}
 \begin{proof}\leanok
     By Lemma~\ref{lem:peps_reference_edge_interior_windows}, both endpoints of
-    \(e\) lie in \(W_j\). The definition of a boundary edge requires exactly one
-    endpoint in the region, so \(e\) is not a boundary edge of \(W_j\).
+    $e$ lie in $W_j$. The definition of a boundary edge requires exactly one
+    endpoint in the region, so $e$ is not a boundary edge of $W_j$.
 \end{proof}
 
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus]%


### PR DESCRIPTION
### Motivation

- Follow-up to #2776 (*feat(PEPS): single-bond peeling and window-region witness*), implementing formalization target 1 from §5.1 of arXiv:1804.04964 (`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1, residual piece 1).
- The bond-inserted family constructed here is the geometric input consumed by `regionInsertedCoeff_endWindows_eq_of_staircase` (from `TorusWindowPeel3.lean`, #2776). Each staircase window $W_j$ must be classified as having the reference edge $e$ either as a boundary edge (exactly one endpoint in $W_j$) or as an interior bond (both endpoints in $W_j$) to determine the correct type of insert.

### Description

- New file `TNLean/PEPS/TorusWindowFamilyCrossing.lean` (223 lines): classifies the horizontal reference edge $e$ across the staircase window family $W_0, \ldots, W_{L+K-1}$.
  - `referenceEdge_leftEndpoint_mem_staircaseWindow` — the left endpoint of $e$ lies in $W_j$ exactly for $1 \leq j$.
  - `referenceEdge_rightEndpoint_mem_staircaseWindow` — the right endpoint of $e$ lies in $W_j$ exactly for $j < L$.
  - `isRegionBoundaryEdge_staircaseWindow_referenceEdge` — $e$ is a boundary edge of $W_j$ for $j = 0$ and for $L \leq j$; proved using `mem_staircaseWindow` and `torusRightEdge_endpoints_of_lt`.
  - `referenceEdge_endpoints_mem_staircaseWindow_of_interior` and `not_isRegionBoundaryEdge_staircaseWindow_referenceEdge_of_interior` — $e$ is an interior bond of $W_j$ for $1 \leq j < L$.
- Modified `TNLean.lean`: adds import of `TorusWindowFamilyCrossing`.
- Source: arXiv:1804.04964, lines 2320–2445 of `Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses #2780

> [!NOTE]
> **Low Risk**
> Pure formal PEPS geometry lemmas and a root import line; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Adds **`TNLean/PEPS/TorusWindowFamilyCrossing.lean`** and registers it on the root import surface in **`TNLean.lean`**, supplying the per-window geometry for the horizontal staircase reference edge in the normal PEPS 2D overlap route (§5.1 / issue #2780).
> 
> The new file proves that each endpoint of `horizontalStaircaseReferenceEdge` lies in `staircaseWindow W_j` exactly when `1 ≤ j` (left) or `j < L` (right), using `mem_staircaseWindow` and `torusRightEdge_endpoints_of_lt`. From that it derives **`IsRegionBoundaryEdge`** for `j = 0` or `L ≤ j` (single endpoint in the window) and the negation for `1 ≤ j < L` (both endpoints inside, interior bond).
> 
> That split is the datum downstream bond-inserted peeling needs: boundary windows get bond-inserted inserts; interior windows get interior-bond deformations instead of boundary inserts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea8478a0e3dc1eab7371b071e6076ebf355b779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal PEPS/torus geometry and documentation; no runtime, auth, or data-path changes. Risk is limited to Lean build surface via one new root import.
> 
> **Overview**
> Adds **`TorusWindowFamilyCrossing.lean`** and wires it into the root import list, formalizing §5.1 (residual piece 1) of the normal PEPS 2D overlap route: for each staircase window \(W_j\), whether the horizontal reference edge is a **boundary edge** or an **interior bond**.
> 
> The file proves endpoint membership in `staircaseWindow` via `mem_staircaseWindow` and `torusRightEdge_endpoints_of_lt` (left endpoint iff \(1 \le j\), right iff \(j < L\)), then derives `IsRegionBoundaryEdge` for \(j = 0\) or \(L \le j\) and the negation for \(1 \le j < L\). That split is the geometric input for bond-inserted peeling: boundary windows get bond-inserted inserts; interior windows get interior-bond deformations.
> 
> **Blueprint** `ch24_peps_ft_torus.tex` gains a new paragraph and five `\leanok` lemmas linked to these theorems, placed before the torus Fundamental Theorem statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4195ecf7c80f6f6d434e638c95f904b7852fc7c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->