### PR TITLE
feat(MPS/RFP): per-block isometry canonical form (part of #2598)

### DIFF
--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -408,9 +408,12 @@ the isometry decomposition `A k i = X * diagonal Λ * U i * X⁻¹` with `X`
 invertible, `Λ` positive, and `U` a physical-index isometry.
 
 This is the blockwise application of `rfp_nt_structural_full` to a basis of normal
-tensors; it is the per-block content of arXiv:1606.00608, Corollary III.cor3
-(line 584). The source normalizes `tr(Λ_k) = 1`; here `Λ` is only required
-positive, since that trace normalization is a gauge convention absorbed into `X`.
+tensors; it is the per-block isometry form of arXiv:1606.00608, Corollary III.cor3
+(line 584). The source additionally imposes the normalization `tr(Λ_k) = 1`; the
+statement here gives positive `Λ_k` without it. The normalization is genuine, not
+a conjugation gauge: rescaling `Λ_k ↦ Λ_k / tr(Λ_k)` factors out as an overall
+scalar on `A_k` (conjugation by `X` preserves the scale), so this is the
+un-normalized isometry form rather than III_cor3 verbatim.
 Deriving the per-block normal/RFP/left-canonical hypotheses from a whole-tensor
 canonical-form fixed-point condition is a separate step. -/
 theorem rfp_nt_structural_full_blocks {r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -414,14 +414,15 @@ the statement here gives positive Λ_k without it. The normalization is genuine,
 not a conjugation gauge: rescaling Λ_k ↦ Λ_k / tr(Λ_k) factors out as an overall
 scalar on A_k, since conjugation by X preserves the scale.
 
-**Scope restriction (cross-block isometry):** Corollary III.cor3 also invokes
-the joint isometry condition from eq:III_isometry, lines 550--554, including
-the δ_{j,j'} orthogonality between distinct blocks. This theorem records only
-the separate per-block isometry condition ∑ i, (U i)ᴴ * U i = 1, and does not
-include the cross-block equations. This restriction is recorded in
-`docs/paper-gaps/cpsv16_rfp_isometry_cross_block_scope.tex`. Elimination:
-prove a joint BNT-family isometry form from whole-tensor canonical-form RFP
-data.
+**Scope restriction (source isometry):** Corollary III.cor3 also invokes the
+joint isometry condition from eq:III_isometry, lines 550--554. This theorem
+records only the contracted per-block condition ∑ i, (U i)ᴴ * U i = 1. It does
+not include the full diagonal pair-index orthonormality, with its source
+normalization, and it also omits the δ_{j,j'} orthogonality between distinct
+blocks. This restriction is recorded in
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. Elimination: strengthen the
+single-block statement to expose the pair-index isometry, then prove a joint
+BNT-family isometry form from whole-tensor canonical-form RFP data.
 
 Deriving the per-block normal/RFP/left-canonical hypotheses from a whole-tensor
 canonical-form fixed-point condition is a separate step. -/

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -407,8 +407,8 @@ tensor is a normal, left-canonical renormalization fixed point, that block admit
 the isometry decomposition `A k i = X * diagonal Λ * U i * X⁻¹` with `X`
 invertible, `Λ` positive, and `U` a physical-index isometry.
 
-This is the blockwise application of `rfp_nt_structural_full` to a basis of normal
-tensors; it is the per-block isometry form of arXiv:1606.00608, Corollary III.cor3
+This is the blockwise application of `rfp_nt_structural_full` to each normal-tensor
+block; it is the per-block isometry form of arXiv:1606.00608, Corollary III.cor3
 (line 584). The source additionally imposes the normalization `tr(Λ_k) = 1`; the
 statement here gives positive `Λ_k` without it. The normalization is genuine, not
 a conjugation gauge: rescaling `Λ_k ↦ Λ_k / tr(Λ_k)` factors out as an overall

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -401,4 +401,26 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
         rw [hB_fact i]
       _ = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹ := by
         simp [L, Matrix.mul_assoc]
+
+/-- **Per-block isometry canonical form.** When each block `A k` of a multi-block
+tensor is a normal, left-canonical renormalization fixed point, that block admits
+the isometry decomposition `A k i = X * diagonal Λ * U i * X⁻¹` with `X`
+invertible, `Λ` positive, and `U` a physical-index isometry.
+
+This is the blockwise application of `rfp_nt_structural_full` to a basis of normal
+tensors; it is the per-block content of arXiv:1606.00608, Corollary III.cor3
+(line 584). The source normalizes `tr(Λ_k) = 1`; here `Λ` is only required
+positive, since that trace normalization is a gauge convention absorbed into `X`.
+Deriving the per-block normal/RFP/left-canonical hypotheses from a whole-tensor
+canonical-form fixed-point condition is a separate step. -/
+theorem rfp_nt_structural_full_blocks {r : ℕ} {dim : Fin r → ℕ}
+    [∀ k, NeZero (dim k)] (A : (k : Fin r) → MPSTensor d (dim k))
+    (hNT : ∀ k, IsNormal (A k)) (hRFP : ∀ k, IsRFP (A k))
+    (hLeft : ∀ k, ∑ i : Fin d, (A k i)ᴴ * (A k i) = 1) :
+    ∀ k, ∃ (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) (Λ : Fin (dim k) → ℝ)
+      (U : MPSTensor d (dim k)),
+      X.det ≠ 0 ∧ (∀ j, 0 < Λ j) ∧ (∑ i : Fin d, (U i)ᴴ * U i = 1) ∧
+      (∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) * U i * X⁻¹) :=
+  fun k => rfp_nt_structural_full (A k) (hNT k) (hRFP k) (hLeft k)
+
 end MPSTensor

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -402,18 +402,27 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
       _ = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹ := by
         simp [L, Matrix.mul_assoc]
 
-/-- **Per-block isometry canonical form.** When each block `A k` of a multi-block
-tensor is a normal, left-canonical renormalization fixed point, that block admits
-the isometry decomposition `A k i = X * diagonal Λ * U i * X⁻¹` with `X`
-invertible, `Λ` positive, and `U` a physical-index isometry.
+/-- **Per-block isometry canonical form.** When each block of a multi-block tensor
+is a normal, left-canonical renormalization fixed point, that block admits an
+isometry decomposition A_k^i = X diag(Λ) U^i X⁻¹ with X invertible, Λ positive,
+and U a physical-index isometry.
 
-This is the blockwise application of `rfp_nt_structural_full` to each normal-tensor
-block; it is the per-block isometry form of arXiv:1606.00608, Corollary III.cor3
-(line 584). The source additionally imposes the normalization `tr(Λ_k) = 1`; the
-statement here gives positive `Λ_k` without it. The normalization is genuine, not
-a conjugation gauge: rescaling `Λ_k ↦ Λ_k / tr(Λ_k)` factors out as an overall
-scalar on `A_k` (conjugation by `X` preserves the scale), so this is the
-un-normalized isometry form rather than III_cor3 verbatim.
+This is the isometry canonical form applied separately to each normal-tensor
+block; it is a per-block form related to arXiv:1606.00608, Corollary III.cor3,
+lines 583--589. The source additionally imposes the normalization tr(Λ_k) = 1;
+the statement here gives positive Λ_k without it. The normalization is genuine,
+not a conjugation gauge: rescaling Λ_k ↦ Λ_k / tr(Λ_k) factors out as an overall
+scalar on A_k, since conjugation by X preserves the scale.
+
+**Scope restriction (cross-block isometry):** Corollary III.cor3 also invokes
+the joint isometry condition from eq:III_isometry, lines 550--554, including
+the δ_{j,j'} orthogonality between distinct blocks. This theorem records only
+the separate per-block isometry condition ∑ i, (U i)ᴴ * U i = 1, and does not
+include the cross-block equations. This restriction is recorded in
+`docs/paper-gaps/cpsv16_rfp_isometry_cross_block_scope.tex`. Elimination:
+prove a joint BNT-family isometry form from whole-tensor canonical-form RFP
+data.
+
 Deriving the per-block normal/RFP/left-canonical hypotheses from a whole-tensor
 canonical-form fixed-point condition is a separate step. -/
 theorem rfp_nt_structural_full_blocks {r : ℕ} {dim : Fin r → ℕ}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -431,8 +431,12 @@ and rates for the single-tensor transfer map $\E_A$.
     diagonal positive, and $U_k = (U_k^i)$ an isometry in the physical indices.
     This is the blockwise form of the isometry canonical form
     (Theorem~\ref{thm:rfp_nt_structural_full}); see
-    \cite[Section~3]{Cirac2016MPDO_arXiv}. The source's normalization
-    $\tr(\Lambda_k) = 1$ is a gauge convention absorbed into $X_k$.
+    \cite[Section~3]{Cirac2016MPDO_arXiv}. The source additionally imposes the
+    normalization $\tr(\Lambda_k) = 1$; the statement here gives positive
+    $\Lambda_k$ without it. That normalization is genuine rather than a
+    conjugation gauge, since rescaling $\Lambda_k \mapsto \Lambda_k/\tr(\Lambda_k)$
+    factors out as an overall scalar on $A_k^i$ (conjugation by $X_k$ preserves
+    the scale); the statement is thus the un-normalized isometry form.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp_nt_structural_full}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -438,7 +438,7 @@ and rates for the single-tensor transfer map $\E_A$.
     conjugation gauge, since rescaling $\Lambda_k \mapsto \Lambda_k/\tr(\Lambda_k)$
     factors out as an overall scalar on $A_k^i$ (conjugation by $X_k$ preserves
     the scale); the statement is thus the un-normalized isometry form.
-    \emph{Scope restriction (cross-block isometry).} Corollary~III.cor3 also
+    \emph{Scope restriction (source isometry).} Corollary~III.cor3 also
     invokes the joint isometry condition
     \[
         \sum_i (U_k^i)_{\alpha,\beta}\,
@@ -446,10 +446,11 @@ and rates for the single-tensor transfer map $\E_A$.
         =
         \delta_{k,\ell}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
-    The theorem above records only the diagonal per-block condition
-    $\sum_i (U_k^i)^\dagger U_k^i=I$ and does not include the cross-block
-    equations for $k\ne\ell$. This restriction is recorded in
-    \path{docs/paper-gaps/cpsv16_rfp_isometry_cross_block_scope.tex}.
+    The theorem above records only the contracted per-block condition
+    $\sum_i (U_k^i)^\dagger U_k^i=I$. It does not state the full diagonal
+    pair-index equality, with its source normalization, and it also does not
+    include the cross-block equations for $k\ne\ell$. This restriction is
+    recorded in \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp_nt_structural_full}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -438,6 +438,18 @@ and rates for the single-tensor transfer map $\E_A$.
     conjugation gauge, since rescaling $\Lambda_k \mapsto \Lambda_k/\tr(\Lambda_k)$
     factors out as an overall scalar on $A_k^i$ (conjugation by $X_k$ preserves
     the scale); the statement is thus the un-normalized isometry form.
+    \emph{Scope restriction (cross-block isometry).} Corollary~III.cor3 also
+    invokes the joint isometry condition
+    \[
+        \sum_i (U_k^i)_{\alpha,\beta}\,
+            \overline{(U_\ell^i)_{\alpha',\beta'}}
+        =
+        \delta_{k,\ell}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+    \]
+    The theorem above records only the diagonal per-block condition
+    $\sum_i (U_k^i)^\dagger U_k^i=I$ and does not include the cross-block
+    equations for $k\ne\ell$. This restriction is recorded in
+    \path{docs/paper-gaps/cpsv16_rfp_isometry_cross_block_scope.tex}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp_nt_structural_full}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -428,7 +428,8 @@ and rates for the single-tensor transfer map $\E_A$.
     When each block $A_k$ of a multi-block tensor is a normal, left-canonical
     renormalization fixed point, that block admits the isometry decomposition
     $A_k^i = X_k \Lambda_k U_k^i X_k^{-1}$, with $X_k$ invertible, $\Lambda_k$
-    diagonal positive, and $U_k = (U_k^i)$ an isometry in the physical indices.
+    diagonal positive, and $U_k = (U_k^i)$ a physical-index isometry,
+    $\sum_i (U_k^i)^\dagger U_k^i = I$.
     This is the blockwise form of the isometry canonical form
     (Theorem~\ref{thm:rfp_nt_structural_full}); see
     \cite[Section~3]{Cirac2016MPDO_arXiv}. The source additionally imposes the

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -420,6 +420,25 @@ and rates for the single-tensor transfer map $\E_A$.
     transports the decomposition back through the conjugation.
 \end{proof}
 
+\begin{theorem}[Per-block isometry canonical form]%
+    \label{thm:rfp_nt_structural_full_blocks}
+    \lean{MPSTensor.rfp_nt_structural_full_blocks}
+    \leanok
+    \uses{thm:rfp_nt_structural_full}
+    When each block $A_k$ of a multi-block tensor is a normal, left-canonical
+    renormalization fixed point, that block admits the isometry decomposition
+    $A_k^i = X_k \Lambda_k U_k^i X_k^{-1}$, with $X_k$ invertible, $\Lambda_k$
+    diagonal positive, and $U_k = (U_k^i)$ an isometry in the physical indices.
+    This is the blockwise form of the isometry canonical form
+    (Theorem~\ref{thm:rfp_nt_structural_full}); see
+    \cite[Section~3]{Cirac2016MPDO_arXiv}. The source's normalization
+    $\tr(\Lambda_k) = 1$ is a gauge convention absorbed into $X_k$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:rfp_nt_structural_full}
+    Apply Theorem~\ref{thm:rfp_nt_structural_full} to each block.
+\end{proof}
+
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}
     \leanok

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -47,9 +47,10 @@ For MPDO renormalization fixed points:
   pure-MPS ZCL theorem is a single-block idempotence/CID equivalence. The
   source theorem also includes the BNT-level local-orthogonality equations
   between distinct blocks.
-- `cpsv16_rfp_isometry_cross_block_scope.tex` records that the current
-  per-block RFP isometry theorem proves separate block isometries, while the
-  source's equation `III_isometry` also imposes cross-block orthogonality.
+- `cpsv16_rfp_isometry_scope.tex` records that the current per-block RFP
+  isometry theorem exposes only a contracted per-block isometry condition,
+  while the source's equation `III_isometry` imposes full pair-index
+  orthonormality and cross-block orthogonality.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -47,6 +47,9 @@ For MPDO renormalization fixed points:
   pure-MPS ZCL theorem is a single-block idempotence/CID equivalence. The
   source theorem also includes the BNT-level local-orthogonality equations
   between distinct blocks.
+- `cpsv16_rfp_isometry_cross_block_scope.tex` records that the current
+  per-block RFP isometry theorem proves separate block isometries, while the
+  source's equation `III_isometry` also imposes cross-block orthogonality.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/cpsv16_rfp_isometry_cross_block_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_cross_block_scope.tex
@@ -1,0 +1,98 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Per-block RFP Isometry Form and Cross-Block Orthogonality in CPSV16}
+\author{}
+\date{2026-06-14}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+The pure-state RFP characterization in Section~3 of
+\cite{Cirac2016MPDO_arXiv} writes a canonical-form RFP tensor as
+\begin{align}
+  A^i
+    =
+  \bigoplus_{j=1}^g\bigoplus_{q=1}^{r_j}
+  \mu_{j,q}X_{j,q}\Lambda_jU_j^iX_{j,q}^{-1},
+  \tag{\path{III_CFI_RFP}}
+\end{align}
+where the matrices $\Lambda_j$ are diagonal, positive, and trace-normalized.
+The same theorem requires a joint isometry condition
+\begin{align}
+  \sum_{i=1}^s
+  (U_j^i)_{\alpha,\beta}\,
+  \overline{(U_{j'}^i)_{\alpha',\beta'}}
+  =
+  \delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+  \tag{\path{eq:III_isometry}}
+\end{align}
+The factor $\delta_{j,j'}$ is a cross-block orthogonality condition: for
+$j\ne j'$, the physical-index isometries associated with the two normal-tensor
+blocks are mutually orthogonal.  Corollary~III.cor3 invokes this same isometry
+condition for the BNT elements.\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:543--554} and
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:583--589}.}
+
+\section{Formal boundary}
+
+The current formal theorem applies the single-block isometry form separately to
+each block of an indexed family.\footnote{Formal declaration:
+\leanid{MPSTensor.rfp_nt_structural_full_blocks} in
+\doclink{TNLean/MPS/RFP/StructuralFull}.  Introduced in \ghpr{2785}.}  For each
+block $k$ it gives
+\begin{align}
+  A_k^i
+    &=
+  X_k\Lambda_kU_k^iX_k^{-1},\\
+  \sum_i (U_k^i)^\dagger U_k^i
+    &= I.
+\end{align}
+There is no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus the
+formal theorem records a separate isometry condition for each block, but it does
+not record the cross-block equations
+\begin{align}
+  \sum_i
+  (U_k^i)_{\alpha,\beta}\,
+  \overline{(U_\ell^i)_{\alpha',\beta'}}
+  =
+  0
+  \qquad (k\ne \ell),
+\end{align}
+which are part of the source condition \path{eq:III_isometry}.
+
+\section{Elimination plan}
+
+A source-faithful version of Corollary~III.cor3 should be stated for a
+BNT-family or whole-tensor canonical-form datum, not merely for independent
+blocks.  Its conclusion should include a joint family $U$ satisfying
+\begin{align}
+  \sum_i
+  (U_k^i)_{\alpha,\beta}\,
+  \overline{(U_\ell^i)_{\alpha',\beta'}}
+  =
+  \delta_{k,\ell}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+\end{align}
+Such a statement must account for the common physical space into which all
+blocks embed; in particular, the joint isometry condition has the dimensional
+content that the block-pair spaces fit orthogonally inside the physical space.
+
+\section{Conclusion}
+
+The current theorem is a scope restriction.  It is a useful per-block
+consequence of the single-block RFP isometry form, but it is not the full
+isometry assertion of Corollary~III.cor3 because it omits the cross-block
+$\delta_{j,j'}$ orthogonality equations.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -7,7 +7,7 @@
 
 \input{command}
 
-\title{Per-block RFP Isometry Form and Cross-Block Orthogonality in CPSV16}
+\title{Per-block RFP Isometry Form and the Source Isometry Condition in CPSV16}
 \author{}
 \date{2026-06-14}
 
@@ -35,10 +35,12 @@ The same theorem requires a joint isometry condition
   \delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
   \tag{\path{eq:III_isometry}}
 \end{align}
-The factor $\delta_{j,j'}$ is a cross-block orthogonality condition: for
-$j\ne j'$, the physical-index isometries associated with the two normal-tensor
-blocks are mutually orthogonal.  Corollary~III.cor3 invokes this same isometry
-condition for the BNT elements.\footnote{Local source:
+The diagonal case $j=j'$ is a full pair-index orthonormality condition in the
+two virtual indices $(\alpha,\beta)$.  The factor $\delta_{j,j'}$ adds a
+cross-block orthogonality condition: for $j\ne j'$, the physical-index
+isometries associated with the two normal-tensor blocks are mutually
+orthogonal.  Corollary~III.cor3 invokes this same isometry condition for the
+BNT elements.\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:543--554} and
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:583--589}.}
 
@@ -56,9 +58,30 @@ block $k$ it gives
   \sum_i (U_k^i)^\dagger U_k^i
     &= I.
 \end{align}
-There is no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus the
-formal theorem records a separate isometry condition for each block, but it does
-not record the cross-block equations
+The second equation is the contracted identity
+\begin{align}
+  \sum_{i,\alpha}
+  \overline{(U_k^i)_{\alpha,\beta}}\,
+  (U_k^i)_{\alpha,\beta'}
+  =
+  \delta_{\beta,\beta'}.
+\end{align}
+It does not record the full diagonal pair-index equation
+\begin{align}
+  \sum_i
+  (U_k^i)_{\alpha,\beta}\,
+  \overline{(U_k^i)_{\alpha',\beta'}}
+  =
+  \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+\end{align}
+For the normalization exposed by the current theorem, a pair-index formula
+compatible with the contracted identity would also have to account for the
+corresponding $1/D_k$ scaling, where $D_k=\dim A_k$.  The theorem does not
+state such a pair-index formula.
+
+There is also no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus
+the formal theorem records only a contracted separate isometry condition for
+each block; it does not record the cross-block equations
 \begin{align}
   \sum_i
   (U_k^i)_{\alpha,\beta}\,
@@ -73,7 +96,9 @@ which are part of the source condition \path{eq:III_isometry}.
 
 A source-faithful version of Corollary~III.cor3 should be stated for a
 BNT-family or whole-tensor canonical-form datum, not merely for independent
-blocks.  Its conclusion should include a joint family $U$ satisfying
+blocks.  Its conclusion should first expose the full pair-index isometry for a
+single block, with the normalization compared to the source convention, and
+then include a joint family $U$ satisfying
 \begin{align}
   \sum_i
   (U_k^i)_{\alpha,\beta}\,
@@ -89,8 +114,10 @@ content that the block-pair spaces fit orthogonally inside the physical space.
 
 The current theorem is a scope restriction.  It is a useful per-block
 consequence of the single-block RFP isometry form, but it is not the full
-isometry assertion of Corollary~III.cor3 because it omits the cross-block
-$\delta_{j,j'}$ orthogonality equations.
+isometry assertion of Corollary~III.cor3.  It exposes only the contracted
+per-block identity $\sum_i (U_k^i)^\dagger U_k^i=I$, not the full diagonal
+pair-index orthonormality, and it also omits the cross-block $\delta_{j,j'}$
+orthogonality equations.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Adds `MPSTensor.rfp_nt_structural_full_blocks`, the per-block isometry canonical form: when each block `A_k` of a multi-block tensor is a normal, left-canonical renormalization fixed point, it admits
$$ A_k^i = X_k\,\mathrm{diag}(\Lambda_k)\,U_k^i\,X_k^{-1}, $$
with `X_k` invertible, `Λ_k` positive, and `U_k` satisfying the contracted per-block isometry condition. This is the blockwise application of the single-block isometry form and advances #2598 (charact-MPS characterization, sub-target b).

## Faithfulness

The source Corollary III.cor3 is stronger in several ways.

First, the source normalizes `tr(Λ_k) = 1`; this lemma only requires `Λ_k` to be positive. That normalization is genuine, not a conjugation gauge: rescaling `Λ_k` factors out as an overall scalar on `A_k`.

Second, Corollary III.cor3 invokes the joint isometry equation `III_isometry`. This PR exposes only the contracted per-block condition `∑ i, (U_k^i)ᴴ * U_k^i = I`; it does not state the full diagonal pair-index orthonormality with the source normalization, and it also does not prove cross-block `δ_{j,j'}` orthogonality. The scope restriction is recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` and in the blueprint entry.

Deriving the per-block normal/RFP/left-canonical hypotheses from a whole-tensor canonical-form fixed-point condition is also left for a later theorem.

## Verification

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New theorem is a direct per-index application of an existing result; changes are formal documentation and scope notes, not auth or runtime logic.
> 
> **Overview**
> Adds **`MPSTensor.rfp_nt_structural_full_blocks`**, which applies the existing single-block isometry canonical form (`rfp_nt_structural_full`) to each block of a multi-block family when every block is normal, left-canonical, and an RFP.
> 
> The blueprint gains a matching **per-block isometry canonical form** theorem, and a new paper-gap note **`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`** (linked from the README) records that this is weaker than CPSV16 Corollary III.cor3: only contracted per-block isometry \(\sum_i (U_k^i)^\dagger U_k^i = I\), not full pair-index orthonormality, \(\mathrm{tr}(\Lambda_k)=1\), or cross-block joint isometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3085b3d8673d46d0d821886bd48e125316158748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->