### PR TITLE
feat(PEPS): reduce the 2D overlapping-window witness to the staircase coefficient transfer

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -424,6 +424,7 @@ import TNLean.PEPS.TorusWindowPeel
 import TNLean.PEPS.TorusWindowPeel2
 import TNLean.PEPS.TorusWindowPeel3
 import TNLean.PEPS.TorusWindowWitness
+import TNLean.PEPS.TorusWindowMult
 import TNLean.PEPS.TorusRectangleReferenceData
 import TNLean.PEPS.TorusRectangleGauge
 import TNLean.PEPS.TorusReferenceBlockingData

--- a/TNLean/PEPS/TorusWindowMult.lean
+++ b/TNLean/PEPS/TorusWindowMult.lean
@@ -246,5 +246,136 @@ theorem exists_windowConjCoeffIdentity_of_coeffTransfer
     ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw hbh⟩
     hRA hCA hRB hCB hAB hposA hposB hDim htransferAB htransferBA hmul
 
+/-! ### The window witness from the coefficient transfer
+
+Feeding the conjugation coefficient identity of `exists_windowConjCoeffIdentity_of_coeffTransfer`
+to the window-region witness producer `windowEdgeCoeffIdentityWitness_of_hypotheses` discharges the
+last hypothesis of the witness (the §5.1 peeling `hidZ`), so the witness assembles from the window
+injectivity hypotheses and the coefficient-transfer data alone --- no `hidZ` supplied as a free
+hypothesis.  This is the §5.2 packaging with the gauge `Z` produced internally.  The transfer-data
+inputs `htransferAB`/`htransferBA`/`hmul` are the genuinely-new staircase residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1; everything downstream of them is
+mechanical. -/
+
+/-- **The window-region witness from the coefficient transfer.**
+
+With the arc-window injectivity hypotheses and union closure for both tensors, the size hypotheses,
+matched bond dimensions, the same state, positive bonds, and the staircase route's
+coefficient-transfer data on the left end window at the reference edge `e`, the reference edge
+carries an `EdgeCoeffIdentityWitness` whose per-edge and reference gauges are both the gauge `Z`
+read off the transfer.  The conjugation coefficient identity `hidZ` of the witness is supplied
+by `exists_windowConjCoeffIdentity_of_coeffTransfer`, so no `hidZ` enters as a free hypothesis ---
+the §5.2 packaging with the gauge produced from the staircase residual rather than assumed.
+
+The region and host injectivity of the left end window are discharged at the minimal size from the
+hypotheses (the host by `regionBlockedTensorInjective_windowComplement`); the gauge `Z`, the
+bond-dimension equality, and the conjugation identity come from the coefficient transfer.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1--5.2. -/
+theorem exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer
+    {A B : Tensor (torusGraph width height) d} {L K a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+        (Fin (A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+          (Fin (B.bondDim
+            (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+          (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (Finset.univ \
+              horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)),
+          regionInsertedCoeff (G := torusGraph width height) A
+              (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+              ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+                (by omega) ha0 haw hbh⟩ M σ τ =
+            regionInsertedCoeff (G := torusGraph width height) B
+              (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+              ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+                (by omega) ha0 haw hbh⟩ N σ τ)
+    (htransferBA : ∀ N : Matrix (Fin (B.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+        (Fin (B.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+          (Fin (A.bondDim
+            (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+          (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (Finset.univ \
+              horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)),
+          regionInsertedCoeff (G := torusGraph width height) B
+              (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+              ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+                (by omega) ha0 haw hbh⟩ N σ τ =
+            regionInsertedCoeff (G := torusGraph width height) A
+              (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+              ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+                (by omega) ha0 haw hbh⟩ M σ τ)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+        (Fin (A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+      coeffTransferMap (G := torusGraph width height) A B
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+          ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+            (by omega) ha0 haw hbh⟩ htransferAB (M * M') =
+        coeffTransferMap (G := torusGraph width height) A B
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+            ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+              (by omega) ha0 haw hbh⟩ htransferAB M *
+          coeffTransferMap (G := torusGraph width height) A B
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+            ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
+              (by omega) ha0 haw hbh⟩ htransferAB M') :
+    ∃ (Z Zref : GL (Fin (B.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+      (hE : A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) =
+        B.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)),
+      Nonempty (EdgeCoeffIdentityWitness A B
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)
+        Z Zref hE) := by
+  -- The window's region injectivity for `A` and `B`, from the arc-window hypotheses.
+  have hRA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) := by
+    have hi := hA.horizontalStaircaseLeftWindow_injective ((a : ZMod width), (b : ZMod height))
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) := by
+    have hi := hB.horizontalStaircaseLeftWindow_injective ((a : ZMod width), (b : ZMod height))
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  -- The gauge, the bond-dimension equality, and the conjugation coefficient identity from the
+  -- coefficient transfer; the host injectivity is the single-window complement at the minimal size.
+  obtain ⟨hE, Z, hid⟩ := exists_windowConjCoeffIdentity_of_coeffTransfer (by omega) (by omega)
+    ha0 haw hbh hRA (hA.regionBlockedTensorInjective_windowComplement hUA hL hK hxw hyh _)
+    hRB (hB.regionBlockedTensorInjective_windowComplement hUB hL hK hxw hyh _)
+    hAB hposA hposB hDim htransferAB htransferBA hmul
+  refine ⟨Z, Z, hE, ⟨windowEdgeCoeffIdentityWitness_of_hypotheses hB hUB hL hK ha0 haw hbh
+    hxw hyh Z hE hposB ?_⟩⟩
+  intro M σ τ
+  exact hid M σ τ
+
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusWindowMult.lean
+++ b/TNLean/PEPS/TorusWindowMult.lean
@@ -1,0 +1,250 @@
+import TNLean.PEPS.TorusWindowWitness
+import TNLean.PEPS.RegionBlock.RegionReconcile
+
+/-!
+# The window-region conjugation coefficient identity from a coefficient transfer
+
+The two-dimensional strengthening of the normal PEPS Fundamental Theorem
+(arXiv:1804.04964, the corollary at lines 2297--2318 of
+`Papers/1804.04964/paper_normal.tex`) feeds the window-region witness
+`windowEdgeCoeffIdentityWitness` a single-bond *conjugation* coefficient identity on the reference
+edge `e`: inserting `M` into `A` over the left end window matches inserting the conjugate into `B`,
+for an invertible gauge `Z`.  This file produces that conjugation identity from the
+*coefficient-transfer* data the staircase route supplies, reusing the unconditional region-level
+algebra of `RegionInsertionTransfer`.
+
+## The reduction
+
+The per-edge gauge read-off `exists_regionEdgeGauge_of_coeffTransfer`
+(`TNLean/PEPS/RegionBlock/RegionReconcile.lean`) turns three inputs on the left end window `W`,
+taken at the reference edge `e`, into the gauge `Z` and the conjugation form of the forward
+transfer:
+
+* `htransferAB`: for each inserted matrix `M`, a matrix `N` on `B` with matching region-inserted
+  coefficient on `W` (the cross-tensor coefficient transfer);
+* `htransferBA`: the reverse transfer;
+* `hmul`: multiplicativity of the chosen forward transfer `coeffTransferMap`.
+
+Everything else --- region injectivity of `W`, host injectivity of `univ \ W`, additivity,
+homogeneity, identity-preservation, and the two-sided inverse --- is the unconditional region-level
+machinery of `RegionInsertionTransfer`, available at the corollary's minimal size because the host
+of a *single window* is injective there (the landed `regionBlockedTensorInjective_windowComplement`,
+in contrast to the host of the rectangle red block, which is not).  The forward transfer's
+coefficient-matching field then is exactly the witness's conjugation identity once the gauge form of
+`exists_regionEdgeGauge_of_coeffTransfer` is substituted.
+
+The two genuine inputs `htransferAB`/`htransferBA` and `hmul` are the staircase residual recorded in
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1: the coefficient transfer is the single-bond
+peeling of the end-pair equality coupled across `A` and `B`, and the multiplicativity is the
+homomorphism the single-crossing geometry yields in place of the edge-middle injectivity the
+rectangle route uses (which fails at the minimal size).  Given them, the window witness assembles
+unconditionally, which is the §5.2 packaging.
+
+## References
+
+* [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled pair states
+  generating the same state*, arXiv:1804.04964, the corollary and proof sketch at lines
+  2296--2445 of `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
+  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1--5.2.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+/-! ### The conjugation coefficient identity from a coefficient transfer
+
+The per-edge gauge read-off `exists_regionEdgeGauge_of_coeffTransfer` of
+`TNLean/PEPS/RegionBlock/RegionReconcile.lean` turns the coefficient-transfer data on any region `R`
+at a boundary edge `f` --- the forward and backward transfers and the forward multiplicativity ---
+into a gauge `Z` and the conjugation form of the forward transfer.  Substituting that gauge form
+into the forward transfer's coefficient-matching field (`RegionInsertionTransfer.fwd_coeff`) gives
+the witness's conjugation coefficient identity directly, with no region-specific input. -/
+
+section Generic
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+
+/-- **The conjugation coefficient identity from a coefficient transfer.**
+
+On any region `R` at a boundary edge `f`, with region and host injectivity of both tensors, positive
+bonds, the same state, matched bond dimensions, the two cross-tensor coefficient transfers
+`htransferAB`/`htransferBA`, and the forward-transfer multiplicativity `hmul`, there is a gauge `Z`
+and an edge bond-dimension equality `hE` so that inserting `M` into `A` over `R` at `f` matches
+inserting `Z · (reindex M) · Z⁻¹` into `B`.
+
+The gauge and the conjugation form of the forward map come from
+`exists_regionEdgeGauge_of_coeffTransfer`; the forward transfer's coefficient-matching field
+(`RegionInsertionTransfer.fwd_coeff`) becomes the conjugation identity once the gauge form is
+substituted.  All region-level algebra is unconditional on the region/host injectivity; the three
+transfer inputs are the genuine content.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem exists_regionConjCoeffIdentity_of_coeffTransfer (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hAB : SameState A B) (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) (hDim : A.bondDim = B.bondDim)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) A R f M σ τ =
+            regionInsertedCoeff (G := G) B R f N σ τ)
+    (htransferBA : ∀ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) R)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+          regionInsertedCoeff (G := G) B R f N σ τ =
+            regionInsertedCoeff (G := G) A R f M σ τ)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
+      coeffTransferMap (G := G) A B R f htransferAB (M * M') =
+        coeffTransferMap (G := G) A B R f htransferAB M *
+          coeffTransferMap (G := G) A B R f htransferAB M') :
+    ∃ (hE : A.bondDim f.1 = B.bondDim f.1) (Z : GL (Fin (B.bondDim f.1)) ℂ),
+      ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+        (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+        regionInsertedCoeff (G := G) A R f M σ τ =
+          regionInsertedCoeff (G := G) B R f
+            ((Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+                Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+              (↑Z⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ := by
+  obtain ⟨hE, Z, hZ⟩ := exists_regionEdgeGauge_of_coeffTransfer A B R f hRA hCA hRB hCB hAB
+    hposA hposB hDim htransferAB htransferBA hmul
+  refine ⟨hE, Z, fun M σ τ => ?_⟩
+  -- The forward transfer matches the region-inserted coefficients (`fwd_coeff`); substituting its
+  -- gauge form (`hZ`) gives the conjugation identity.
+  have hfwd := (regionInsertionTransfer_of_coeffTransfer A B R f hRB hCB hAB hposB hDim
+    htransferAB htransferBA hmul).fwd_coeff M σ τ
+  rw [hZ M] at hfwd
+  exact hfwd
+
+end Generic
+
+variable {width height d : ℕ} [NeZero width] [NeZero height]
+  [Fact (1 < width)] [Fact (1 < height)]
+
+/-- **The window-region conjugation coefficient identity from a coefficient transfer.**
+
+The left-end-window instance of `exists_regionConjCoeffIdentity_of_coeffTransfer`: with the
+staircase route's coefficient-transfer data on the left end window `W` at the reference edge `e`,
+there is a gauge `Z` and an edge bond-dimension equality `hE` realizing the witness's conjugation
+coefficient identity.  The host injectivity hypothesis `hCB` is the single-window host injectivity
+available at the minimal size by `regionBlockedTensorInjective_windowComplement`, in contrast to the
+rectangle red block's host, which fails there.  The three transfer inputs are the §5.1 staircase
+residual; given them, the window witness's conjugation identity assembles unconditionally.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1--5.2. -/
+theorem exists_windowConjCoeffIdentity_of_coeffTransfer
+    {A B : Tensor (torusGraph width height) d} {L K a b : ℕ}
+    (hL : 0 < L) (hK : 0 < K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hRA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+    (hCA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (Finset.univ \ horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (Finset.univ \ horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+    (hAB : SameState A B)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (hDim : A.bondDim = B.bondDim)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+        (Fin (A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+          (Fin (B.bondDim
+            (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+          (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (Finset.univ \
+              horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)),
+          regionInsertedCoeff (G := torusGraph width height) A
+              (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+              ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+                hbh⟩ M σ τ =
+            regionInsertedCoeff (G := torusGraph width height) B
+              (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+              ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+                hbh⟩ N σ τ)
+    (htransferBA : ∀ N : Matrix (Fin (B.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+        (Fin (B.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+      ∃ M : Matrix (Fin (A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+          (Fin (A.bondDim
+            (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+          (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+            (Finset.univ \
+              horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)),
+          regionInsertedCoeff (G := torusGraph width height) B
+              (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+              ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+                hbh⟩ N σ τ =
+            regionInsertedCoeff (G := torusGraph width height) A
+              (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+              ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+                hbh⟩ M σ τ)
+    (hmul : ∀ M M' : Matrix (Fin (A.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+        (Fin (A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ,
+      coeffTransferMap (G := torusGraph width height) A B
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+          ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+            hbh⟩ htransferAB (M * M') =
+        coeffTransferMap (G := torusGraph width height) A B
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+            ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+              hbh⟩ htransferAB M *
+          coeffTransferMap (G := torusGraph width height) A B
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+            ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+              hbh⟩ htransferAB M') :
+    ∃ (hE : A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) =
+        B.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))
+      (Z : GL (Fin (B.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ),
+      ∀ (M : Matrix (Fin (A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)))
+          (Fin (A.bondDim
+            (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+        (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+          (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K))
+        (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d)
+          (Finset.univ \ horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)),
+        regionInsertedCoeff (G := torusGraph width height) A
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+            ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+              hbh⟩ M σ τ =
+          regionInsertedCoeff (G := torusGraph width height) B
+            (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+            ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw
+              hbh⟩
+            ((Z : Matrix _ _ ℂ) * Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+              (↑Z⁻¹ : Matrix _ _ ℂ)) σ τ :=
+  exists_regionConjCoeffIdentity_of_coeffTransfer A B
+    (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+    ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A hL hK ha0 haw hbh⟩
+    hRA hCA hRB hCB hAB hposA hposB hDim htransferAB htransferBA hmul
+
+end PEPS
+end TNLean

--- a/TNLean/PEPS/TorusWindowMult.lean
+++ b/TNLean/PEPS/TorusWindowMult.lean
@@ -126,6 +126,46 @@ theorem exists_regionConjCoeffIdentity_of_coeffTransfer (A B : Tensor G d) (R : 
   rw [hZ M] at hfwd
   exact hfwd
 
+/-- **The conjugation coefficient identity from a region-insertion transfer datum.**
+
+The single-datum form of `exists_regionConjCoeffIdentity_of_coeffTransfer`: from a
+`RegionInsertionTransfer` datum `T` on `R` at the boundary edge `f`, with region and host
+injectivity of both tensors and positive bonds, there is a gauge `Z` and a bond-dimension equality
+`hE` so that inserting `M` into `A` over `R` at `f` matches inserting the conjugate of `M` into
+`B`.  The Skolem--Noether read-off `exists_regionEdgeGauge_of_transfer` gives `Z` with
+`T.fwd M = Z · (reindex M) · Z⁻¹`; the datum's `fwd_coeff` field is the coefficient identity.
+
+A `RegionInsertionTransfer` is the structured form of the three coefficient-transfer inputs ---
+the forward and backward transfers and the forward multiplicativity --- which the staircase route
+supplies on the window.  `regionInsertionTransfer_of_realizes` builds it from one region
+physical-to-virtual realization in each direction, with no further hypothesis.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1. -/
+theorem exists_regionConjCoeffIdentity_of_transfer (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (T : RegionInsertionTransfer (G := G) A B R f)
+    (hRA : RegionBlockedTensorInjective (G := G) A R)
+    (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e)
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) :
+    ∃ (hE : A.bondDim f.1 = B.bondDim f.1) (Z : GL (Fin (B.bondDim f.1)) ℂ),
+      ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
+        (σ : RegionPhysicalConfig (V := V) (d := d) R)
+        (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+        regionInsertedCoeff (G := G) A R f M σ τ =
+          regionInsertedCoeff (G := G) B R f
+            ((Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
+                Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE) M *
+              (↑Z⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ := by
+  obtain ⟨hE, Z, hZ⟩ := exists_regionEdgeGauge_of_transfer A B R f T hRA hCA hposA hRB hCB hposB
+  refine ⟨hE, Z, fun M σ τ => ?_⟩
+  have hfwd := T.fwd_coeff M σ τ
+  rw [hZ M] at hfwd
+  exact hfwd
+
 end Generic
 
 variable {width height d : ℕ} [NeZero width] [NeZero height]
@@ -372,6 +412,71 @@ theorem exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer
     ha0 haw hbh hRA (hA.regionBlockedTensorInjective_windowComplement hUA hL hK hxw hyh _)
     hRB (hB.regionBlockedTensorInjective_windowComplement hUB hL hK hxw hyh _)
     hAB hposA hposB hDim htransferAB htransferBA hmul
+  refine ⟨Z, Z, hE, ⟨windowEdgeCoeffIdentityWitness_of_hypotheses hB hUB hL hK ha0 haw hbh
+    hxw hyh Z hE hposB ?_⟩⟩
+  intro M σ τ
+  exact hid M σ τ
+
+/-- **The window-region witness from a region-insertion transfer datum.**
+
+The single-datum form of `exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer`: from a
+`RegionInsertionTransfer` datum on the left end window at the reference edge `e`, with the
+arc-window injectivity hypotheses and union closure for both tensors and the size hypotheses, the
+reference edge carries an `EdgeCoeffIdentityWitness` whose per-edge and reference gauges are both
+the gauge read off the transfer.  The conjugation identity is
+`exists_regionConjCoeffIdentity_of_transfer`; the host injectivity is the single-window complement
+at the minimal size.
+
+The transfer datum is the structured form of the staircase route's coefficient-transfer obligation;
+`regionInsertionTransfer_of_realizes` builds it from one window physical-to-virtual realization in
+each direction.
+
+Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
+`Papers/1804.04964/paper_normal.tex`; the corollary at lines 2297--2318;
+`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, §5.1--5.2. -/
+theorem exists_windowEdgeCoeffIdentityWitness_of_transfer
+    {A B : Tensor (torusGraph width height) d} {L K a b : ℕ}
+    (hA : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hB : NormalTorusArcWindowInjectivityHypotheses L K
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hUA : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) A))
+    (hUB : RegionInjectivityUnionClosure
+      (regionInjectivityDataOf (G := torusGraph width height) B))
+    (hL : 2 ≤ L) (hK : 2 ≤ K) (ha0 : 1 ≤ a)
+    (haw : a + 2 * L ≤ width) (hbh : b + 2 * K - 1 ≤ height)
+    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
+    (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
+    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+    (T : RegionInsertionTransfer (G := torusGraph width height) A B
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+      ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega) (by omega)
+        ha0 haw hbh⟩) :
+    ∃ (Z Zref : GL (Fin (B.bondDim
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
+      (hE : A.bondDim
+          (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K) =
+        B.bondDim (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)),
+      Nonempty (EdgeCoeffIdentityWitness A B
+        (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K)
+        Z Zref hE) := by
+  -- The window's region injectivity for `A` and `B`, from the arc-window hypotheses.
+  have hRA : RegionBlockedTensorInjective (G := torusGraph width height) A
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) := by
+    have hi := hA.horizontalStaircaseLeftWindow_injective ((a : ZMod width), (b : ZMod height))
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  have hRB : RegionBlockedTensorInjective (G := torusGraph width height) B
+      (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K) := by
+    have hi := hB.horizontalStaircaseLeftWindow_injective ((a : ZMod width), (b : ZMod height))
+    rwa [regionInjectivityDataOf_isInjective] at hi
+  -- The gauge and the conjugation coefficient identity from the transfer datum; the host
+  -- injectivity is the single-window complement at the minimal size.
+  obtain ⟨hE, Z, hid⟩ := exists_regionConjCoeffIdentity_of_transfer A B
+    (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
+    ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega) (by omega)
+      ha0 haw hbh⟩ T hRA (hA.regionBlockedTensorInjective_windowComplement hUA hL hK hxw hyh _)
+    hRB (hB.regionBlockedTensorInjective_windowComplement hUB hL hK hxw hyh _) hposA hposB
   refine ⟨Z, Z, hE, ⟨windowEdgeCoeffIdentityWitness_of_hypotheses hB hUB hL hK ha0 haw hbh
     hxw hyh Z hE hposB ?_⟩⟩
   intro M σ τ

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -932,24 +932,46 @@ witness is the reference-edge interface the torus covariant-family machinery con
 \noindent\textbf{The residual.}  What remains of \S5.1 is the production of the
 bond-$e$ \emph{conjugation} coefficient identity the witness packaging consumes ---
 $\path{regionInsertedCoeff}\,A\,W\,\langle e\rangle\,M =
-\path{regionInsertedCoeff}\,B\,W\,\langle e\rangle\,(Z\,M\,Z^{-1})$.  Two pieces feed
-it.  First, the bond-inserted \emph{family} the single-bond peeling consumes: an insert
-on every staircase window all sharing one deformed state, with the two end windows
-carrying the bond-inserted inserts of $M$ and $M'$.  For the windows containing both
-endpoints of $e$ the bond is interior, so the insert is the $M$-on-interior-bond
-deformation of the genuine block, and the common state is the closed torus state with
-$M$ inserted on $e$ --- the ``a virtual operation on a given bond is a physical
-operation on any window containing an endpoint'' correspondence of the sketch, not yet
-built as an insert family.  Second, the cross-tensor gauge: the algebra-isomorphism
-step (insertion correspondence, Skolem--Noether) that turns the single-tensor end-window
-equality into conjugation by an invertible edge matrix $Z$.  The landed
-$\path{edgeGaugeFromInsertionAlgebraIsomorphism}$ performs the Skolem--Noether step from
-an algebra isomorphism, and the region-to-edge identity
-$\path{regionInsertedCoeff\_eq\_smul\_edgeInsertedCoeff}$ makes the coefficient
-region-independent; the multiplicative transfer the isomorphism needs is the piece the
-window route must supply from the staircase in place of the edge-middle injectivity
-($\mathrm{univ}\setminus\{u,v\}$ injective), which fails at the minimal size --- the
-same obstruction, at the edge, that $\mathrm{univ}\setminus S$ exhibits at the end pair.
+\path{regionInsertedCoeff}\,B\,W\,\langle e\rangle\,(Z\,M\,Z^{-1})$.  The Skolem--Noether
+back end of this production is now landed and reduces it to a single cross-tensor input.
+The reusable region-level algebra of $\path{RegionInsertionTransfer}$ derives the gauge
+$Z$ and the conjugation form of the coefficient identity from a \emph{coefficient
+transfer} on the window: the read-off $\path{exists\_regionEdgeGauge\_of\_coeffTransfer}$
+turns the two cross-tensor coefficient transfers and the forward-transfer multiplicativity
+into $Z$ and the conjugation identity (the lemma
+$\path{exists\_regionConjCoeffIdentity\_of\_coeffTransfer}$), and feeding that to the
+window-region witness packaging discharges the witness's conjugation field (the lemma
+$\path{exists\_windowEdgeCoeffIdentityWitness\_of\_coeffTransfer}$).  These are in
+\path{TNLean/PEPS/TorusWindowMult.lean}.  All region-level algebra --- additivity,
+homogeneity, identity preservation, the two-sided inverse, the Skolem--Noether read-off
+--- is unconditional on the window and host injectivity, both available at the minimal
+size, so the window witness assembles from the coefficient transfer alone, with no
+conjugation field assumed.
+
+What remains is therefore exactly the staircase \emph{coefficient transfer} on the
+window: for each inserted matrix $M$ on $A$'s edge $e$ a matching matrix $N$ on $B$ with
+equal window coefficient
+($\path{htransferAB}$), its reverse ($\path{htransferBA}$), and the multiplicativity of
+the chosen forward transfer ($\path{hmul}$).  Two pieces feed the transfer.  First, the
+bond-inserted \emph{family} the single-bond peeling consumes: an insert on every
+staircase window all sharing one deformed state, with the two end windows carrying the
+bond-inserted inserts of $M$ and $M'$.  For the windows containing both endpoints of $e$
+the bond is interior, so the insert is the $M$-on-interior-bond deformation of the
+genuine block, and the common state is the closed torus state with $M$ inserted on $e$
+--- the ``a virtual operation on a given bond is a physical operation on any window
+containing an endpoint'' correspondence of the sketch, not yet built as an insert family.
+Second, the cross-tensor multiplicative transfer: the homomorphism the rectangle route
+reads from the physical realization of the inserted operator.  The region-level recovery
+$\path{regionInsertionTransfer\_of\_realizes}$ derives all three transfer fields ---
+$\path{htransferAB}$, $\path{htransferBA}$, and $\path{hmul}$ --- from one region
+physical-to-virtual realization $\path{RegionTransferRealizes}$ in each direction, with
+no further hypothesis; so the window route's residual collapses to producing that
+realization on the window from the staircase, in place of the edge-middle injectivity
+($\mathrm{univ}\setminus\{u,v\}$ injective) the rectangle route uses, which fails at the
+minimal size --- the same obstruction, at the edge, that $\mathrm{univ}\setminus S$
+exhibits at the end pair.  A coefficient transfer alone does not yield $\path{hmul}$: the
+multiplicativity is the homomorphism of the physical insertion operator, which the
+single-bond geometry localizes to one edge but does not on its own make multiplicative.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

The last conceptual piece of the 2D overlapping-window campaign (arXiv:1804.04964
corollary, lines 2297–2318) is the **bond-`e` conjugation coefficient identity** the
window-region witness consumes as `hidZ`. This PR lands the **Skolem–Noether back end** of
that production and reduces the witness to a single cross-tensor input — the staircase
**coefficient transfer** on the window — eliminating all the gauge/multiplicativity
scaffolding from the residual.

New file `TNLean/PEPS/TorusWindowMult.lean` (sorry-free, kernel-clean):

- `exists_regionConjCoeffIdentity_of_coeffTransfer` / `exists_regionConjCoeffIdentity_of_transfer`
  — on any region at a boundary edge, the coefficient-transfer data (forward/backward transfers
  + forward multiplicativity, or a structured `RegionInsertionTransfer` datum) yields the gauge
  `Z` and the conjugation coefficient identity `regionInsertedCoeff A R f M = regionInsertedCoeff
  B R f (Z·M·Z⁻¹)`, via the landed `exists_regionEdgeGauge_of_coeffTransfer` /
  `exists_regionEdgeGauge_of_transfer` and `RegionInsertionTransfer.fwd_coeff`.
- `exists_windowConjCoeffIdentity_of_coeffTransfer` — the left-end-window instance.
- `exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer` /
  `exists_windowEdgeCoeffIdentityWitness_of_transfer` — feed the conjugation identity to
  `windowEdgeCoeffIdentityWitness_of_hypotheses`, so the unconditional window `EdgeCoeffIdentityWitness`
  assembles **with no `hidZ` supplied as a free hypothesis** — the §5.2 packaging with the gauge
  produced from the transfer rather than assumed.

All region-level algebra (additivity, homogeneity, identity preservation, two-sided inverse,
the Skolem–Noether read-off) is unconditional on window/host injectivity, both available at the
corollary's minimal size $(2L+1)\times(2K+1)$ — the single-window host is injective there
(`regionBlockedTensorInjective_windowComplement`), unlike the rectangle red block's host.

## Phase-0 scoping verdict

The residual reduces to producing the three transfer fields on the window:
`htransferAB`/`htransferBA` (cross-tensor coefficient transfers) and `hmul`
(forward-transfer multiplicativity). **Multiplicativity is not direct from the single-bond
geometry alone.** A coefficient transfer alone does not yield `hmul`: the multiplicativity is the
homomorphism of the *physical insertion operator*, which the single-crossing geometry localizes
to one edge but does not on its own make multiplicative. The clean target is one **region
physical-to-virtual realization** `RegionTransferRealizes` on the window in each direction:
`regionInsertionTransfer_of_realizes` derives all three transfer fields from it with no further
hypothesis. That realization — using window injectivity in place of the edge-middle injectivity
(`univ\{u,v}` injective) the rectangle route uses, which fails at the minimal size — is the
remaining staircase piece.

## Faithfulness

The paper-gap note `docs/paper-gaps/peps_normal_ft_2d_overlap.tex` §5.1 "The residual" is updated
to record the landed reduction and the narrowed residual. No blueprint entries (the corollary
remains unformalized until the transfer is supplied).

## Integrity

- `#print axioms` for every new declaration: `[propext, Classical.choice, Quot.sound]`.
- No `sorry`, no `maxHeartbeats`, ≤100-char lines, full root `lake build` green,
  `lake exe lint-style` exit 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sorry-free formal proofs reusing established region-level algebra; no auth, runtime, or data-path changes. Residual mathematical obligations are documented, not hidden.
> 
> **Overview**
> Adds **`TNLean/PEPS/TorusWindowMult.lean`** and wires it into the root import list. The new lemmas show that on a torus left-end window, **bidirectional coefficient transfer** plus **forward multiplicativity** (or a `RegionInsertionTransfer` datum) yields the bond-`e` **conjugation** identity and a full **`EdgeCoeffIdentityWitness`**, using existing `RegionReconcile` / `RegionInsertionTransfer` machinery and **`windowEdgeCoeffIdentityWitness_of_hypotheses`**—so **`hidZ` is no longer a free hypothesis**.
> 
> Generic region-level theorems (`exists_regionConjCoeffIdentity_of_coeffTransfer` / `_of_transfer`) are specialized to the staircase window; witness builders **`exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer`** and **`_of_transfer`** derive host injectivity from arc-window hypotheses via **`regionBlockedTensorInjective_windowComplement`**.
> 
> **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** §5.1 is updated: the Skolem–Noether back end is landed; the open work is narrowed to supplying the staircase coefficient transfer (and ultimately **`RegionTransferRealizes`** per direction), not assuming conjugation upfront.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f23113bc82a352fa6b3f2f673201a6442ec1e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->