### PR TITLE
doc(peps): add bond peeling blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -88,6 +88,90 @@
     between the region $R$ and its complement.
 \end{definition}
 
+\begin{definition}[Bond-inserted region insert]%
+    \label{def:peps_bond_inserted_region_insert}
+    \lean{TNLean.PEPS.bondInsertedRegionInsert}
+    \leanok
+    Let $f$ be an edge crossing the boundary of $R$, and let
+    $M\in\MN{D_f}$.  The bond-inserted region insert
+    $I_{A,R,f,M}$ is the insert on $R$ defined by
+    \[
+        (I_{A,R,f,M})_{\nu,\sigma}
+        =
+        \sum_{\substack{\mu\in\partial R\\
+        \mu|_{\partial R\setminus\{f\}}
+        =\nu|_{\partial R\setminus\{f\}}}}
+        M_{\mu_f,\nu_f}\,T_{A,R}^{\mu}(\sigma).
+    \]
+    Thus the complement boundary value $\nu$ is fixed away from $f$, while
+    the matrix $M$ couples the two $f$-labels.  This is the one-bond insertion
+    in the region/complement coefficient of
+    \cite[Section~3]{Molnar2018NormalPEPS}.
+\end{definition}
+
+\begin{theorem}[Bond insertion as a deformed region state]
+    \label{thm:peps_deformedRegionState_bondInsertedRegionInsert}
+    \lean{TNLean.PEPS.deformedRegionState_bondInsertedRegionInsert}
+    \leanok
+    \uses{def:peps_bond_inserted_region_insert,
+        def:peps_regionInsertedCoeff}
+    For every physical configuration $\sigma$ on $R$ and $\tau$ on
+    $V\setminus R$, the deformed state of the bond-inserted region insert is
+    the region insertion coefficient:
+    \[
+        \Psi_{A,R,I_{A,R,f,M}}(\sigma,\tau)
+        =
+        C_A(R,f,M;\sigma,\tau).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    Expand the deformed state and substitute the definition of
+    $I_{A,R,f,M}$:
+    \[
+        \sum_{\nu\in\partial R}
+        \left(
+        \sum_{\substack{\mu\in\partial R\\
+        \mu|_{\partial R\setminus\{f\}}
+        =\nu|_{\partial R\setminus\{f\}}}}
+        M_{\mu_f,\nu_f}\,T_{A,R}^{\mu}(\sigma)
+        \right)
+        T_{A,V\setminus R}^{\nu^c}(\tau).
+    \]
+    Exchanging the two finite sums gives exactly the defining double sum for
+    $C_A(R,f,M;\sigma,\tau)$.
+\end{proof}
+
+\begin{theorem}[Bond insertion through a corner extension]
+    \label{thm:peps_regionInsertedCoeff_eq_extendInsert_bondInserted}
+    \lean{TNLean.PEPS.regionInsertedCoeff_eq_extendInsert_bondInserted}
+    \leanok
+    \uses{thm:peps_deformedRegionState_bondInsertedRegionInsert,
+        thm:peps_corner_extension_state_preserves}
+    Let $R\subseteq S$, and suppose that all bond dimensions are positive.
+    For every global physical configuration $\sigma$,
+    \[
+        C_A\bigl(R,f,M;\sigma|_R,\sigma|_{V\setminus R}\bigr)
+        =
+        \Psi_{A,S,
+        \operatorname{Ext}_{R\subseteq S}(I_{A,R,f,M})}(\sigma).
+    \]
+    In particular, the one-bond insertion on $R$ may be read after extending
+    the corresponding insert to any larger region $S$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The preceding theorem rewrites the left-hand side as
+    $\Psi_{A,R,I_{A,R,f,M}}(\sigma)$.  The state-preservation theorem for
+    corner extension then gives
+    \[
+        \Psi_{A,R,I_{A,R,f,M}}(\sigma)
+        =
+        \Psi_{A,S,
+        \operatorname{Ext}_{R\subseteq S}(I_{A,R,f,M})}(\sigma).
+    \]
+\end{proof}
+
 \begin{theorem}[Region insertion as a two-block insertion]%
     \label{thm:peps_twoBlockInsertedCoeff_eq_regionInsertedCoeff}
     \lean{TNLean.PEPS.twoBlockInsertedCoeff_eq_regionInsertedCoeff}

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -741,3 +741,198 @@
     Theorem~\ref{thm:peps_extend_insert_cancel_added_injective} applied to the
     inclusion $S\subseteq S\cup Q$.
 \end{proof}
+
+\subsection{Single-bond peeling and the window witness}
+\label{subsec:peps_torus_single_bond_peeling_window_witness}
+
+\begin{theorem}[The reference edge bounds the two end windows]
+    \label{thm:peps_staircase_end_reference_edge_boundary}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_staircaseWindow_zero_referenceEdge}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_staircaseWindow_last_referenceEdge}
+    \leanok
+    Let the torus have width $W$ and height $H$, with $1<W$ and $1<H$.
+    Let $e$ be the horizontal reference edge of a staircase window family with
+    dimensions $L,K$ and lower-left coordinate $(a,b)$.  Suppose
+    \[
+        0<L,\qquad 0<K,\qquad 1\le a,\qquad
+        a+2L\le W,\qquad b+2K-1\le H.
+    \]
+    Then $e$ is a boundary edge of the first staircase window $W_0$ and of the
+    last staircase window $W_{L+K-1}$:
+    \[
+        e\in\partial W_0,
+        \qquad
+        e\in\partial W_{L+K-1}.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    The first staircase window is the right end window, and the last
+    staircase window is the left end window:
+    \[
+        W_0=W_{\mathrm{right}},
+        \qquad
+        W_{L+K-1}=W_{\mathrm{left}}.
+    \]
+    The reference edge is a boundary edge of these two end windows by their
+    defining geometry.
+\end{proof}
+
+\begin{theorem}[Open-boundary equality on the staircase end pair]
+    \label{thm:peps_staircase_pair_insert_eq_open}
+    \lean{TNLean.PEPS.staircasePair_insert_eq_open}
+    \leanok
+    \uses{thm:peps_staircase_pair_cancel,
+        thm:peps_corner_extension_linear_transitive}
+    Let $S=W_0\cup W_{L+K-1}$ be the staircase end pair.  Suppose that the
+    one-orientation $L\times K$ window injectivity hypotheses hold for a
+    tensor $B$, unions of injective regions are injective, all bond dimensions
+    of $B$ are positive, and
+    \[
+        2\le L,\qquad 2\le K,\qquad
+        2L+1\le W,\qquad 2K+1\le H.
+    \]
+    If $C_j$ are inserts on the staircase windows whose deformed states all
+    equal one common state, then the two end-window inserts have equal corner
+    extensions to $S$:
+    \[
+        \operatorname{Ext}_{W_0\subseteq S}(C_0)
+        =
+        \operatorname{Ext}_{W_{L+K-1}\subseteq S}(C_{L+K-1}).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    The consecutive-window equalities are composed across the staircase patch.
+    Both sides are then extended through the completed corner, and
+    transitivity of corner extension rewrites the two extension chains.  The
+    completed corner is an injective $L\times K$ window, so
+    Theorem~\ref{thm:peps_staircase_pair_cancel} cancels it and leaves the
+    equality on the end pair $S$.
+\end{proof}
+
+\begin{theorem}[Single-bond peeling of the staircase end equality]
+    \label{thm:peps_regionInsertedCoeff_endWindows_eq_of_staircase}
+    \lean{TNLean.PEPS.regionInsertedCoeff_endWindows_eq_of_staircase}
+    \leanok
+    \uses{def:peps_bond_inserted_region_insert,
+        thm:peps_regionInsertedCoeff_eq_extendInsert_bondInserted,
+        thm:peps_staircase_end_reference_edge_boundary,
+        thm:peps_staircase_pair_insert_eq_open}
+    Let the torus have width $W$ and height $H$, with $1<W$ and $1<H$.
+    Suppose that the one-orientation $L\times K$ window injectivity
+    hypotheses hold for a tensor $B$, unions of injective regions are
+    injective, and all bond dimensions of $B$ are positive.  Assume
+    \[
+        2\le L,\qquad 2\le K,\qquad 1\le a,\qquad
+        a+2L\le W,\qquad b+2K-1\le H,
+    \]
+    and
+    \[
+        2L+1\le W,\qquad 2K+1\le H.
+    \]
+    Let $C_j$ be inserts on the staircase windows $W_j$ whose deformed states
+    all equal one common state.  Suppose that
+    \[
+        C_0=I_{B,W_0,e,M},
+        \qquad
+        C_{L+K-1}=I_{B,W_{L+K-1},e,M'}.
+    \]
+    Then for every global physical configuration $\sigma$,
+    \[
+        C_B\bigl(W_0,e,M;\sigma|_{W_0},\sigma|_{V\setminus W_0}\bigr)
+        =
+        C_B\bigl(W_{L+K-1},e,M';
+            \sigma|_{W_{L+K-1}},\sigma|_{V\setminus W_{L+K-1}}\bigr).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_extendInsert_bondInserted}
+    rewrites the two displayed coefficients as the deformed states on the
+    staircase end pair of the two corner-extended inserts:
+    \[
+        C_B(W_0,e,M;\sigma|_{W_0},\sigma|_{V\setminus W_0})
+        =
+        \Psi_{B,S,\operatorname{Ext}_{W_0\subseteq S}(C_0)}(\sigma),
+    \]
+    and
+    \[
+        C_B(W_{L+K-1},e,M';
+            \sigma|_{W_{L+K-1}},\sigma|_{V\setminus W_{L+K-1}})
+        =
+        \Psi_{B,S,
+        \operatorname{Ext}_{W_{L+K-1}\subseteq S}(C_{L+K-1})}(\sigma).
+    \]
+    The open-boundary equality on the staircase end pair gives
+    \[
+        \operatorname{Ext}_{W_0\subseteq S}(C_0)
+        =
+        \operatorname{Ext}_{W_{L+K-1}\subseteq S}(C_{L+K-1}),
+    \]
+    and hence the two coefficients are equal.
+\end{proof}
+
+\begin{definition}[Window-region coefficient-identity witness]
+    \label{def:peps_window_edge_coeff_identity_witness}
+    \lean{TNLean.PEPS.windowEdgeCoeffIdentityWitness}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff,
+        thm:peps_staircase_end_reference_edge_boundary}
+    Let $W$ be the left end window of a horizontal staircase with parameters
+    $(L,K)$ and lower-left coordinate $(a,b)$, and let $e$ be its reference
+    edge.  Suppose that
+    \[
+        0<L,\qquad 0<K,\qquad
+        1\le a,\qquad
+        a+2L\le W_{\mathrm{torus}},\qquad
+        b+2K-1\le H_{\mathrm{torus}}.
+    \]
+    Then $e\in\partial W$.  Suppose also that the blocked tensors of $B$ on
+    $W$ and $V\setminus W$ are injective, that all bond dimensions of $B$ are
+    positive, and that the bond dimensions of $A$ and $B$ at $e$ are
+    identified by $\iota_e:\MN{D_A(e)}\simeq\MN{D_B(e)}$.  If
+    $Z\in\GL(D_B(e))$ satisfies, for every matrix $M$ and physical
+    configurations $\sigma,\tau$,
+    \[
+        C_A(W,e,M;\sigma,\tau)
+        =
+        C_B(W,e,Z\,\iota_e(M)\,Z^{-1};\sigma,\tau),
+    \]
+    then these objects form the coefficient-identity witness at $e$ with
+    witness region $W$ and with both gauge entries equal to $Z$.
+\end{definition}
+
+\begin{definition}[Window-region witness from window injectivity]
+    \label{def:peps_window_edge_coeff_identity_witness_of_hypotheses}
+    \lean{TNLean.PEPS.windowEdgeCoeffIdentityWitness_of_hypotheses}
+    \leanok
+    \uses{def:peps_window_edge_coeff_identity_witness}
+    Let $W$ be the left end window around the reference edge $e$, placed with
+    lower-left coordinate $(a,b)$.  Suppose that every cyclic $L\times K$
+    window of $B$ is blocked-tensor injective, unions of injective regions are
+    injective, all bond dimensions of $B$ are positive, and
+    \[
+        2\le L,\qquad 2\le K,\qquad
+        2L+1\le W_{\mathrm{torus}},\qquad
+        2K+1\le H_{\mathrm{torus}},
+    \]
+    with
+    \[
+        1\le a,\qquad
+        a+2L\le W_{\mathrm{torus}},\qquad
+        b+2K-1\le H_{\mathrm{torus}}.
+    \]
+    Suppose also that the bond dimensions of $A$ and $B$ at $e$ are
+    identified by $\iota_e:\MN{D_A(e)}\simeq\MN{D_B(e)}$, and let
+    $Z\in\GL(D_B(e))$.  If the conjugation identity
+    \[
+        C_A(W,e,M;\sigma,\tau)
+        =
+        C_B(W,e,Z\,\iota_e(M)\,Z^{-1};\sigma,\tau)
+    \]
+    holds for every $M,\sigma,\tau$, then the coefficient-identity witness of
+    Definition~\ref{def:peps_window_edge_coeff_identity_witness} is obtained
+    for the region $W$.  The hypotheses supply the injectivity of both $W$ and
+    its complement at the minimal torus size.
+\end{definition}


### PR DESCRIPTION
### Motivation

- Eight sorry-free declarations introduced in #2776 (`bondInsertedRegionInsert`, `deformedRegionState_bondInsertedRegionInsert`, `regionInsertedCoeff_eq_extendInsert_bondInserted`, two boundary-edge helpers, `regionInsertedCoeff_endWindows_eq_of_staircase`, and two coefficient-identity witnesses) have no blueprint entries, leaving the blueprint out of sync with the Lean code. See #2779.
- Source: arXiv:1804.04964, §5.1–§5.2 (single-bond peeling and window-region witnesses); `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Steps 4–5.

### Description

Changes to `blueprint/src/chapter/ch24_peps_ft_region_transfer.tex` (+84 lines):

- Adds a blueprint entry for `bondInsertedRegionInsert`: the insert on region $R$ whose boundary configuration $\nu$ carries the $M$-coupled combination of the genuine $R$ block over configurations agreeing with $\nu$ away from reference edge $f$.
- Adds entries for `deformedRegionState_bondInsertedRegionInsert` (the deformed state of the bond-inserted insert equals `regionInsertedCoeff`) and `regionInsertedCoeff_eq_extendInsert_bondInserted` (the coefficient identity is unchanged after corner extension to a larger region).

Changes to `blueprint/src/chapter/ch24_peps_ft_torus.tex` (+179 lines):

- Adds entries for `isRegionBoundaryEdge_staircaseWindow_zero_referenceEdge` and `isRegionBoundaryEdge_staircaseWindow_last_referenceEdge`: the reference edge bounds the first and last staircase end windows.
- Adds an entry for `regionInsertedCoeff_endWindows_eq_of_staircase` (single-bond peeling: equal deformed states along the staircase imply equal end-window region-insertion coefficients for bond inserts on the shared reference edge).
- Adds entries for `windowEdgeCoeffIdentityWitness` and `windowEdgeCoeffIdentityWitness_of_hypotheses`: witnesses packaging the conjugation coefficient identity $C_A(W,e,M) = C_B(W,e,Z\iota_e(M)Z^{-1})$, the latter built from cyclic-window injectivity hypotheses.

Coefficient identities are stated as displayed equations, not as Lean theorem names in prose. All eight declarations are sorry-free; `\leanok` applies immediately.

### Testing

- `git diff --check origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && (cd blueprint && leanblueprint checkdecls)`
- `lake build TNLean`

---
Closes #2779

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint additions with no Lean or runtime behavior changes.
> 
> **Overview**
> Brings the PEPS fundamental-theorem blueprint back in sync with eight declarations from #2776 that previously had no `\lean` entries.
> 
> In **`ch24_peps_ft_region_transfer.tex`**, documents **bond-inserted region inserts** \(I_{A,R,f,M}\), the identity **\(\Psi_{A,R,I}=\) `regionInsertedCoeff`**, and **corner extension** of that coefficient to a larger region \(S\).
> 
> In **`ch24_peps_ft_torus.tex`**, adds subsection *Single-bond peeling and the window witness*: reference edge on first/last staircase windows, open-boundary equality on the end pair, **single-bond peeling** (`regionInsertedCoeff` equality for bond inserts on end windows when staircase deformed states agree), and **window-region coefficient-identity witnesses** (conjugation \(C_A = C_B(\cdot, Z\iota_e(M)Z^{-1},\cdot)\), including a variant from cyclic-window injectivity hypotheses). All entries use `\leanok` and state math as displayed equations, not Lean names in prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50c6e71a3c9534f27d7e8dc73368a58d5d895c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->