### PR TITLE
doc(MPS/ParentHamiltonian): use math notation in docstrings

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -30,10 +30,10 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- The complementary word for the cyclic window of length `m+2` beginning at
-site `M` in a chain of length `M+1`.
+/-- The complementary word for the cyclic window of length \(m+2\) beginning at
+site \(M\) in a chain of length \(M+1\).
 
-For an outside configuration `τ`, this is
+For an outside configuration \(\tau\), this is
 \[
   \rho=\tau_{m+1}\cdots\tau_{M-1}.
 \] -/

--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -3,7 +3,7 @@ import TNLean.MPS.ParentHamiltonian.Defs
 /-!
 # Basic parent-Hamiltonian properties
 
-The parent interaction is the orthogonal projector onto `(groundSpace A L)ᗮ`.
+The parent interaction is the orthogonal projector onto \(G_L(A)^\perp\).
 It therefore annihilates any vector in the ground space. The periodic MPS vector
 `mpv A` lies in the ground space at every window, which gives
 frustration-freeness.
@@ -19,7 +19,7 @@ variable {d D : ℕ}
 
 /-- The parent interaction annihilates any vector in the ground space.
 This is the core property: `parentInteraction A L` is the orthogonal projector
-onto `(groundSpace A L)ᗮ`, so it kills everything in `groundSpace A L`. -/
+onto \(G_L(A)^\perp\), so it kills everything in `groundSpace A L`. -/
 lemma parentInteraction_apply_mem_groundSpace (A : MPSTensor d D) (L : ℕ)
     (v : NSiteSpace d L) (hv : v ∈ groundSpace A L) :
     parentInteraction A L v = 0 := by
@@ -48,12 +48,12 @@ private lemma trace_evalWord_append_comm (A : MPSTensor d D) (w₁ w₂ : List (
 
 /-! ### Periodic MPS vector window membership -/
 
-/-- The periodic MPS vector restricted to any window of `L` sites lies in
+/-- The periodic MPS vector restricted to any window of \(L\) sites lies in
 `groundSpace A L`.
 
-The witness is the "complement matrix": the product of `A`-matrices on sites
-outside the `L`-site window, cyclically ordered starting from `i + L`. The proof
-uses trace cyclicity to rotate the full `N`-site product so that the window
+The witness is the "complement matrix": the product of \(A\)-matrices on sites
+outside the \(L\)-site window, cyclically ordered starting from \(i + L\). The proof
+uses trace cyclicity to rotate the full \(N\)-site product so that the window
 indices come first, matching the `groundSpaceMap` definition. -/
 lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N)
     (i : Fin N) (σ : Cfg d N) :
@@ -118,7 +118,7 @@ lemma localTerm_annihilates_mpv (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) 
   rfl
 
 /-- The parent Hamiltonian annihilates the periodic MPS vector:
-`H_N V^{(N)}(A) = 0`. -/
+\(H_N V^{(N)}(A) = 0\). -/
 lemma parentHamiltonian_annihilates (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N) :
     parentHamiltonian A L N (mpv A) = 0 := by
   simp only [parentHamiltonian, LinearMap.sum_apply]

--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -24,16 +24,16 @@ parent-Hamiltonian closure argument for block-injective tensors.
 
 ## Mathematical content
 
-If words of a fixed length `L` span the full matrix algebra, then the trace map
+If words of a fixed length \(L\) span the full matrix algebra, then the trace map
 `groundSpaceMap A L` is injective. We use this to formulate a block-word
-compatibility argument: if a family indexed by length-`L₀` words satisfies a
-common right-factor relation after multiplying by every length-`K` suffix, then
-block injectivity at length `L₀` strips the suffix and produces a common right
-factor already at block length `L₀`.
+compatibility argument: if a family indexed by length-\(L₀\) words satisfies a
+common right-factor relation after multiplying by every length-\(K\) suffix, then
+block injectivity at length \(L₀\) strips the suffix and produces a common right
+factor already at block length \(L₀\).
 
 The final theorem applies this stripping mechanism to commutation relations:
-commutation with all words of length `m ≥ L₀` forces commutation with all block
-words of length `L₀`.
+commutation with all words of length \(m ≥ L₀\) forces commutation with all block
+words of length \(L₀\).
 
 ## References
 
@@ -47,7 +47,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- If words of length `L` span the full matrix algebra, then `groundSpaceMap A L`
+/-- If words of length \(L\) span the full matrix algebra, then `groundSpaceMap A L`
 has trivial kernel. -/
 theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D}
     {L : ℕ} (hWord : wordSpan A L = ⊤) :
@@ -71,15 +71,15 @@ theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D}
         _ = 0 := hNX
   exact LinearMap.ker_eq_bot.mp hker
 
-/-- Block injectivity at length `L₀` makes `groundSpaceMap A L₀` injective. -/
+/-- Block injectivity at length \(L₀\) makes the map \(Γ_{L₀}\) injective. -/
 theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D}
     {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) :
     Function.Injective (groundSpaceMap A L₀) := by
   apply groundSpaceMap_injective_of_wordSpan_eq_top
   exact (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
 
-/-- Letter compatibility extends to every nonempty word.  The left family `Z` and
-right family `F` can be indexed by any finite type; only the physical word lies
+/-- Letter compatibility extends to every nonempty word.  The left family \(Z\) and
+right family \(F\) can be indexed by any finite type; only the physical word lies
 in the MPS alphabet. -/
 private theorem exists_evalWord_factor_of_letter_compatibility
     {A : MPSTensor d D} {α : Type*} {F Z : α → Matrix (Fin D) (Fin D) ℂ}
@@ -101,9 +101,9 @@ private theorem exists_evalWord_factor_of_letter_compatibility
         _ = (F a * Y) * evalWord A w := by rw [hY a]
         _ = F a * (Y * evalWord A w) := by rw [Matrix.mul_assoc]
 
-/-- If a family indexed by length-`L₀` words is compatible with multiplication by
+/-- If a family indexed by length-\(L₀\) words is compatible with multiplication by
 single physical letters, then block injectivity strips the letter and produces a
-common right factor already at block length `L₀`. -/
+common right factor already at block length \(L₀\). -/
 private theorem exists_right_factor_of_block_letter_compatibility
     {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {Z : (Fin L₀ → Fin d) → Matrix (Fin D) (Fin D) ℂ}
@@ -149,7 +149,7 @@ private theorem exists_right_factor_of_block_letter_compatibility
     _ = evalWord A (List.ofFn σ) * X := by rfl
 
 /-- Block-word stripping theorem: compatibility with every suffix word of a fixed
-length `K` implies a common right factor already at block length `L₀`. -/
+length \(K\) implies a common right factor already at block length \(L₀\). -/
 theorem exists_right_factor_of_block_word_compatibility
     {A : MPSTensor d D} {K L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {Z : (Fin L₀ → Fin d) → Matrix (Fin D) (Fin D) ℂ}
@@ -224,8 +224,8 @@ theorem exists_common_boundary_matrix_of_word_identities_of_wordSpan_eq_top
   intro a
   simpa using hY a
 
-/-- If a matrix commutes with all words of some length `m ≥ L₀`, then it already
-commutes with every block word of length `L₀`. -/
+/-- If a matrix commutes with all words of some length \(m ≥ L₀\), then it already
+commutes with every block word of length \(L₀\). -/
 theorem commutes_block_words_of_commutes_long_words_of_isNBlkInjective
     {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     (hm : L₀ ≤ m) {X : Matrix (Fin D) (Fin D) ℂ}
@@ -282,7 +282,7 @@ theorem commutes_block_words_of_commutes_long_words_of_isNBlkInjective
   intro σ
   simpa [Z, hXR] using hR σ
 
-/-- If a matrix commutes with all words of some length `m ≥ L₀`, then block
+/-- If a matrix commutes with all words of some length \(m ≥ L₀\), then block
 injectivity forces it to commute with every matrix in the ambient algebra. -/
 theorem commutes_all_of_commutes_long_words_of_isNBlkInjective
     {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryOverlap.lean
@@ -21,9 +21,9 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- If a non-repeating cyclic `(L + 1)`-window is represented by the matrix `Y`,
-then fixing its first site to `j` represents the shifted length-`L` window by the
-matrix `Y * A j`. -/
+/-- If a non-repeating cyclic \((L + 1)\)-window is represented by the matrix \(Y\),
+then fixing its first site to \(j\) represents the shifted length-\(L\) window by the
+matrix \(Y A_j\). -/
 theorem cyclicRestrictₗ_restrictFirst_groundSpaceMap {A : MPSTensor d D}
     {N L : ℕ} (hN : 0 < N) (hLN : L + 1 ≤ N)
     (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N)
@@ -36,9 +36,9 @@ theorem cyclicRestrictₗ_restrictFirst_groundSpaceMap {A : MPSTensor d D}
   rw [← cyclicRestrictₗ_restrictFirst hN hLN i τ ψ j, hY,
     restrictFirst_groundSpaceMap]
 
-/-- If a cyclic `(L + 1)`-window is represented by the matrix `Y`, then fixing
-its last site to `j` represents the initial length-`L` window by the matrix
-`A j * Y`. -/
+/-- If a cyclic \((L + 1)\)-window is represented by the matrix \(Y\), then fixing
+its last site to \(j\) represents the initial length-\(L\) window by the matrix
+\(A_j Y\). -/
 theorem cyclicRestrictₗ_restrictLast_groundSpaceMap {A : MPSTensor d D}
     {N L : ℕ} (hN : 0 < N)
     (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N)
@@ -50,7 +50,7 @@ theorem cyclicRestrictₗ_restrictLast_groundSpaceMap {A : MPSTensor d D}
       groundSpaceMap A L (A j * Y) := by
   rw [← cyclicRestrictₗ_restrictLast hN i τ ψ j, hY, restrictLast_groundSpaceMap]
 
-/-- Adjacent cyclic windows have compatible matrices on their common length-`L`
+/-- Adjacent cyclic windows have compatible matrices on their common length-\(L\)
 overlap.
 
 The hypothesis `hτ` says that, after the first window is restricted at its first

--- a/TNLean/MPS/ParentHamiltonian/BoundaryStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryStripping.lean
@@ -18,8 +18,8 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- If every length-`k` word product annihilates `Z` on the left, and words of
-some longer length `n` span the full matrix algebra, then `Z = 0`. -/
+/-- If every length-\(k\) word product annihilates \(Z\) on the left, and words of
+some longer length \(n\) span the full matrix algebra, then \(Z = 0\). -/
 theorem eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
     {A : MPSTensor d D} {k n : ℕ} {Z : Matrix (Fin D) (Fin D) ℂ}
     (htop : wordSpan A n = ⊤) (hkn : k ≤ n)
@@ -62,9 +62,9 @@ theorem eq_zero_of_evalWord_mul_eq_zero_of_wordSpan_eq_top
 
 /-- Block-injective left-annihilation padding variant.
 
-If `A` is `L₀`-block-injective, then a relation \(A^wZ=0\) for every word
-`w` of length `k` already forces \(Z=0\) whenever `k` is bounded by a positive
-multiple of `L₀`. -/
+If \(A\) is \(L₀\)-block-injective, then a relation \(A^wZ=0\) for every word
+\(w\) of length \(k\) already forces \(Z=0\) whenever \(k\) is bounded by a positive
+multiple of \(L₀\). -/
 theorem eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul
     {A : MPSTensor d D} {L₀ k q : ℕ} (hInj : IsNBlkInjective A L₀)
     (hq : 1 ≤ q) (hkq : k ≤ q * L₀) {Z : Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -19,7 +19,7 @@ Hamiltonian part of arXiv:1606.00608.
 ## Main definitions
 
 * `MPSTensor.IsCommutingParentHam A L N` — the local terms of the parent
-  Hamiltonian on `N` sites with block length `L` mutually commute.
+  Hamiltonian on \(N\) sites with block length \(L\) mutually commute.
 * `MPSTensor.IsNNCPH A N` — length-two commutativity of the translated parent
   interaction terms.
 * `MPSTensor.IsNNCPHGroundState A N` — the nearest-neighbor local terms commute
@@ -30,18 +30,18 @@ Hamiltonian part of arXiv:1606.00608.
 * `MPSTensor.IsCommutingParentHam.ham_comm_localTerm` — if local terms commute,
   the full Hamiltonian commutes with each local term.
 * `MPSTensor.ProductPairBridge.isNNCPH` — if the two-site local terms are
-  projectors `pᵢ` with `pᵢpⱼ = pⱼpᵢ`, then the parent Hamiltonian satisfies
-  `hᵢhⱼ = hⱼhᵢ`.
+  projectors \(pᵢ\) with \(pᵢpⱼ = pⱼpᵢ\), then the parent Hamiltonian satisfies
+  \(hᵢhⱼ = hⱼhᵢ\).
 * `MPSTensor.rfp_implies_nncph_of_appendixBExtraction` — a conditional theorem
   deriving NNCPH from the Appendix B structural form
-  `Aᵢ = XΛUᵢX⁻¹`, the even-chain product-of-pairs factorization, and the
+  \(Aᵢ = XΛUᵢX⁻¹\), the even-chain product-of-pairs factorization, and the
   two-site projector identities, without invoking
   `Axioms.rfp_to_nncph_commute`.
-* `MPSTensor.rfp_implies_nncph` — construction for the RFP `⟹` NNCPH direction of
+* `MPSTensor.rfp_implies_nncph` — construction for the RFP \(\Longrightarrow\) NNCPH direction of
   Theorem 3.10.
 * `MPSTensor.rfp_implies_nncph_ground_state` — the same direction with the
   frustration-free ground-state condition for the MPS vector included.
-* `MPSTensor.nncph_implies_rfp` — construction for the NNCPH `⟹` RFP direction of
+* `MPSTensor.nncph_implies_rfp` — construction for the NNCPH \(\Longrightarrow\) RFP direction of
   Theorem 3.10.
 
 ## References
@@ -49,7 +49,7 @@ Hamiltonian part of arXiv:1606.00608.
 * arXiv:1606.00608, Section 3.3 Definition 3.9, Theorem 3.10
 * S. Beigi, *J. Phys. A: Math. Theor.* **45** (2012) 025306 —
   ground-space characterization for commuting nearest-neighbor
-  Hamiltonians in 1D (consumed only in the `NNCPH ⟹ RFP` direction)
+  Hamiltonians in 1D (consumed only in the NNCPH \(\Longrightarrow\) RFP direction)
 -/
 
 open scoped Matrix BigOperators
@@ -122,8 +122,8 @@ theorem IsNNCPH.isNNCPHGroundState {A : MPSTensor d D} {N : ℕ}
     IsNNCPHGroundState A N :=
   ⟨h, parentHamiltonian_frustrationFree A 2 N hN⟩
 
-/-- If the two-site parent terms are idempotents `pᵢ` with
-`pᵢpⱼ = pⱼpᵢ`, then the nearest-neighbor parent Hamiltonian is commuting on
+/-- If the two-site parent terms are idempotents \(pᵢ\) with
+\(pᵢpⱼ = pⱼpᵢ\), then the nearest-neighbor parent Hamiltonian is commuting on
 that finite chain. -/
 theorem HasProductPairLocalProjectors.isNNCPH {A : MPSTensor d D} {N : ℕ}
     (hPair : HasProductPairLocalProjectors A N) :
@@ -140,7 +140,7 @@ theorem ProductPairBridge.isNNCPH {A : MPSTensor d D} (hBridge : ProductPairBrid
 /-- Conditional internal theorem for Theorem 3.10(i)⟹(iii).
 
 A normal left-canonical RFP tensor has the Appendix B structural form
-`Aᵢ = XΛUᵢX⁻¹` by `AppendixBStructuralData.ofRFP`. If the associated two-site
+\(Aᵢ = XΛUᵢX⁻¹\) by `AppendixBStructuralData.ofRFP`. If the associated two-site
 amplitude gives the even-chain factorization and the two-site parent terms are
 identified with commuting idempotents, then the nearest-neighbor parent
 Hamiltonian is commuting on every finite chain.

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -18,7 +18,7 @@ cyclic windows of L consecutive sites on a periodic chain.
 * `MPSTensor.cyclicWindowSupport` and `MPSTensor.cyclicWindowsOverlap` — the
   support and overlap predicate for translated cyclic windows.
 * `MPSTensor.cyclicWindowsOverlap_card_le` — each cyclic window overlaps at most
-  `2 * (L - 1)` other cyclic windows when `2 * L ≤ N`.
+  \(2 * (L - 1)\) other cyclic windows when \(2 * L ≤ N\).
 -/
 
 open scoped Matrix BigOperators
@@ -29,15 +29,16 @@ variable {d D : ℕ}
 
 /-! ### Contiguous (non-wrapping) window extraction -/
 
-/-- Assemble an N-site configuration by placing window values `σ` at
-contiguous sites `[s, s+1, ..., s+M-1]` and using `τ` for the remaining sites. -/
+/-- Assemble an N-site configuration by placing the word \(\sigma\) at
+contiguous sites \([s, s+1, \ldots, s+M-1]\) and using \(\tau\) for the remaining
+sites. -/
 def contiguousCfg {N : ℕ} (s M : ℕ)
     (σ : Fin M → Fin d) (τ : Fin N → Fin d) : Fin N → Fin d :=
   fun k => if h : s ≤ k.val ∧ k.val < s + M
            then σ ⟨k.val - s, by omega⟩
            else τ k
 
-/-- Linear restriction to a contiguous block `[s, s+1, ..., s+M-1]`. -/
+/-- Linear restriction to a contiguous block \([s, s+1, \ldots, s+M-1]\). -/
 def contiguousRestrictₗ {N : ℕ} (s M : ℕ) (_hsM : s + M ≤ N)
     (τ : Fin N → Fin d) : NSiteSpace d N →ₗ[ℂ] NSiteSpace d M where
   toFun ψ σ := ψ (contiguousCfg s M σ τ)
@@ -56,7 +57,7 @@ theorem contiguousCfg_zero_full {N : ℕ} (σ : Fin N → Fin d) (τ : Fin N →
   simp only [contiguousCfg, Nat.zero_le, true_and]
   simp [hk]
 
-/-- Restricting the last site of a contiguous `(M+1)`-block peels off
+/-- Restricting the last site of a contiguous \((M+1)\)-block peels off
 the rightmost site and extends the outside config. -/
 theorem contiguousRestrictₗ_restrictLast {N : ℕ} (s M : ℕ) (hsM1 : s + (M + 1) ≤ N)
     (τ : Fin N → Fin d) (ψ : NSiteSpace d N) (j : Fin d) :
@@ -84,7 +85,7 @@ theorem contiguousRestrictₗ_restrictLast {N : ℕ} (s M : ℕ) (hsM1 : s + (M 
       rw [dif_neg (show ¬(s ≤ k ∧ k < s + (M + 1)) from by omega), dif_neg hwin]
       simp [Function.update, show ¬(k = s + M) from hbdy]
 
-/-- Restricting the first site of a contiguous `(M+1)`-block peels off
+/-- Restricting the first site of a contiguous \((M+1)\)-block peels off
 the leftmost site and shifts the window start. -/
 theorem contiguousRestrictₗ_restrictFirst {N : ℕ} (s M : ℕ) (hsM1 : s + (M + 1) ≤ N)
     (τ : Fin N → Fin d) (ψ : NSiteSpace d N) (i : Fin d) :
@@ -114,15 +115,15 @@ theorem contiguousRestrictₗ_restrictFirst {N : ℕ} (s M : ℕ) (hsM1 : s + (M
 
 /-! ### Iterated intersection: non-wrapping windows → open-chain membership -/
 
-/-- If an N-site state `ψ` satisfies the L-site ground condition at all
-non-wrapping contiguous positions `s` (meaning `s + L ≤ N`), then
-`ψ ∈ groundSpace A N` (the open-chain ground space).
+/-- If an \(N\)-site state \(ψ\) satisfies the \(L\)-site ground condition at all
+non-wrapping contiguous positions \(s\) (meaning \(s + L ≤ N\)), then
+\(ψ \in G_N(A)\) (the open-chain ground space).
 
-The proof works by induction on `k` from 0 to `N - L`: at each step, two
-adjacent windows of size `L + k` at positions `s` and `s + 1` are combined
-via the intersection property to form a window of size `L + k + 1`.
+The proof works by induction on \(k\) from \(0\) to \(N - L\): at each step, two
+adjacent windows of size \(L + k\) at positions \(s\) and \(s + 1\) are combined
+via the intersection property to form a window of size \(L + k + 1\).
 
-**Hypotheses:** `L ≥ 2` (from the intersection property) and `L ≤ N`. -/
+**Hypotheses:** \(L ≥ 2\) (from the intersection property) and \(L ≤ N\). -/
 theorem contiguous_mem_groundSpace {A : MPSTensor d D} (hA : IsInjective A)
     {L N : ℕ} (hL : 1 < L) (hLN : L ≤ N) [NeZero d]
     {ψ : NSiteSpace d N}
@@ -164,12 +165,12 @@ theorem contiguous_mem_groundSpace {A : MPSTensor d D} (hA : IsInjective A)
 
 /-- Open-chain iteration for a family of subspaces.
 
-If every length-`L` contiguous interval of an `N`-site state lies in `S L`, and
+If every length-\(L\) contiguous interval of an \(N\)-site state lies in \(S_L\), and
 the intersections
 \[
   \mathbb C^d\otimes S_M \cap S_M\otimes \mathbb C^d = S_{M+1}
 \]
-hold for all `M ≥ L`, then the state lies in `S N`. This is the open-segment
+hold for all \(M ≥ L\), then the state lies in \(S_N\). This is the open-segment
 iteration used in PGVWC07, Theorem 2blocks.2, before the periodic-chain
 boundary-closing step. -/
 theorem contiguous_mem_of_restriction_intersection_submodules
@@ -223,22 +224,22 @@ theorem contiguous_mem_of_restriction_intersection_submodules
 
 /-! ### Cyclic window extraction -/
 
-/-- The site obtained by moving `r` steps clockwise from `i` on the cyclic chain. -/
+/-- The site obtained by moving \(r\) steps clockwise from \(i\) on the cyclic chain. -/
 def cyclicForwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
   ⟨(i.val + r) % N, Nat.mod_lt _ (Fin.pos i)⟩
 
-/-- The site obtained by moving `r` steps counterclockwise from `i` on the cyclic chain. -/
+/-- The site obtained by moving \(r\) steps counterclockwise from \(i\) on the cyclic chain. -/
 def cyclicBackwardSite {N : ℕ} (i : Fin N) (r : ℕ) : Fin N :=
   ⟨(i.val + N - r % N) % N, Nat.mod_lt _ (Fin.pos i)⟩
 
-/-- The support of the length-`L` cyclic window starting at `i`, represented as the
-finite set of sites reached from `i` by offsets below `L`, modulo the chain
-length.  If `L` is larger than the chain length, repeated visits to a site are
-counted only once; the parent-Hamiltonian applications use `L ≤ N`. -/
+/-- The support of the length-\(L\) cyclic window starting at \(i\), represented as the
+finite set of sites reached from \(i\) by offsets below \(L\), modulo the chain
+length.  If \(L\) is larger than the chain length, repeated visits to a site are
+counted only once; the parent-Hamiltonian applications use \(L ≤ N\). -/
 def cyclicWindowSupport (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
   (Finset.range L).image fun r => cyclicForwardSite i r
 
-/-- Cyclic-window overlap predicate for length-`L` windows on `Fin N`.
+/-- Cyclic-window overlap predicate for length-\(L\) windows on `Fin N`.
 
 Two windows overlap when their cyclic supports share at least one site.  This is
 the locality relation for translated local terms at the two starting sites.  In
@@ -253,20 +254,21 @@ instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
   unfold cyclicWindowsOverlap
   exact Fintype.decidableExistsFintype
 
-/-- Clockwise neighbours of the cyclic window starting at `i` that can overlap it
+/-- Clockwise neighbours of the cyclic window starting at \(i\) that can overlap it
 properly. -/
 private def cyclicWindowClockwiseNeighbours (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
   (Finset.univ : Finset (Fin (L - 1))).image fun r => cyclicForwardSite i (r.val + 1)
 
-/-- Counterclockwise neighbours of the cyclic window starting at `i` that can
+/-- Counterclockwise neighbours of the cyclic window starting at \(i\) that can
 overlap it properly. -/
 private def cyclicWindowCounterclockwiseNeighbours (N L : ℕ) (i : Fin N) : Finset (Fin N) :=
   (Finset.univ : Finset (Fin (L - 1))).image fun r => cyclicBackwardSite i (r.val + 1)
 
-/-- Assemble an N-site configuration from a cyclic window at position `i`
-(covering sites `i, i+1, ..., i+L-1 mod N`) and outside values `τ`.
-Site `k` gets the window value `σ(offset)` where `offset = (k - i + N) % N`
-if `offset < L`, otherwise it gets `τ(k)`. -/
+/-- Assemble an N-site configuration from a cyclic window at position \(i\)
+(covering sites \(i, i+1, \ldots, i+L-1 \bmod N\)) and outside values \(\tau\).
+Site \(k\) gets the window value \(\sigma(\mathrm{offset})\), where
+\(\mathrm{offset} = (k - i + N) \bmod N\), if \(\mathrm{offset} < L\);
+otherwise it gets \(\tau(k)\). -/
 def cyclicCfg {N : ℕ} (_hN : 0 < N) (L : ℕ)
     (i : Fin N) (σ : Fin L → Fin d) (τ : Fin N → Fin d) : Fin N → Fin d :=
   fun k =>
@@ -274,8 +276,8 @@ def cyclicCfg {N : ℕ} (_hN : 0 < N) (L : ℕ)
     then σ ⟨(k.val + N - i.val) % N, h⟩
     else τ k
 
-/-- If a site has cyclic offset `r` from `i`, then it is the site `i + r` modulo
-`N`. -/
+/-- If a site has cyclic offset \(r\) from \(i\), then it is the site \(i + r\)
+modulo \(N\). -/
 theorem eq_cyclic_site_of_offset_eq {N : ℕ} (hN : 0 < N) {i k : Fin N} {r : ℕ}
     (h : (k.val + N - i.val) % N = r) :
     k = ⟨(i.val + r) % N, Nat.mod_lt _ hN⟩ := by
@@ -301,7 +303,7 @@ theorem eq_cyclic_site_of_offset_eq {N : ℕ} (hN : 0 < N) {i k : Fin N} {r : �
 
 /-- Membership in a cyclic-window support is equivalently the cyclic offset from
 the starting site being smaller than the window length, in the non-repeating regime
-`L ≤ N`. -/
+\(L ≤ N\). -/
 theorem mem_cyclicWindowSupport_iff {N L : ℕ} (hLN : L ≤ N) (i k : Fin N) :
     k ∈ cyclicWindowSupport N L i ↔ ((k.val + N - i.val) % N < L) := by
   constructor
@@ -350,9 +352,9 @@ private theorem cyclicForwardSite_eq_mod_eq {N : ℕ} (i : Fin N) {a b : ℕ}
 /-- Row-cardinality estimate for cyclic support overlap in the finite-overlap
 regime used by the martingale proof.
 
-If `2 * L ≤ N`, then every length-`L` cyclic window can meet only the `L - 1`
-clockwise starts and the `L - 1` counterclockwise starts.  Thus, after erasing
-the window itself, at most `2 * (L - 1)` translated local terms overlap it. -/
+If \(2L ≤ N\), then every length-\(L\) cyclic window can meet only the \(L - 1\)
+clockwise starts and the \(L - 1\) counterclockwise starts.  Thus, after erasing
+the window itself, at most \(2(L - 1)\) translated local terms overlap it. -/
 theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L)
     (i : Fin N) :
     ((Finset.univ.erase i).filter (fun j => cyclicWindowsOverlap N L i j)).card ≤
@@ -391,7 +393,7 @@ theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L
       rw [Nat.mod_eq_of_lt haN] at hmod
       exact hmod.symm
     by_cases hxb_lt : x + b < N
-    · -- No wraparound: the clockwise offset `x` is a positive distance below `L`.
+    · -- No wraparound: the clockwise offset \(x\) is a positive distance below \(L\).
       have hsum : x + b = a := by
         rw [Nat.mod_eq_of_lt hxb_lt] at hxb_mod
         exact hxb_mod
@@ -411,7 +413,7 @@ theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L
         simp
         omega
       simpa [hstep] using hjx.symm
-    · -- Wraparound: the equivalent counterclockwise distance is `b - a`, below `L`.
+    · -- Wraparound: the equivalent counterclockwise distance is \(b-a\), below \(L\).
       have hxb_ge : N ≤ x + b := Nat.le_of_not_gt hxb_lt
       have hxb_lt_two : x + b < 2 * N := by omega
       have hmod_sub : (x + b) % N = x + b - N := by
@@ -455,7 +457,7 @@ theorem cyclicWindowsOverlap_card_le {N L : ℕ} (hLN : 2 * L ≤ N) (hL : 1 < L
     _ ≤ (L - 1) + (L - 1) := Nat.add_le_add hcw_card hccw_card
     _ = 2 * (L - 1) := by omega
 
-/-- Linear restriction to a cyclic window at position `i`. -/
+/-- Linear restriction to a cyclic window at position \(i\). -/
 def cyclicRestrictₗ {N : ℕ} (hN : 0 < N) (L : ℕ)
     (i : Fin N) (τ : Fin N → Fin d) : NSiteSpace d N →ₗ[ℂ] NSiteSpace d L where
   toFun ψ σ := ψ (cyclicCfg hN L i σ τ)
@@ -511,8 +513,8 @@ theorem cyclicCfg_cyclicForwardSite {N L : ℕ} (hN : 0 < N) (hLN : L ≤ N)
     exact hoff
   rw [dif_pos (by rw [hoff]; exact r.isLt), hidx]
 
-/-- Restricting the final site of a cyclic `(L + 1)`-window peels off the site with
-cyclic offset `L` and stores its value in the outside configuration. -/
+/-- Restricting the final site of a cyclic \((L + 1)\)-window peels off the site with
+cyclic offset \(L\) and stores its value in the outside configuration. -/
 theorem cyclicRestrictₗ_restrictLast {N L : ℕ} (hN : 0 < N)
     (i : Fin N) (τ : Fin N → Fin d) (ψ : NSiteSpace d N) (j : Fin d) :
     restrictLast (cyclicRestrictₗ hN (L + 1) i τ ψ) j =
@@ -533,7 +535,7 @@ theorem cyclicRestrictₗ_restrictLast {N L : ℕ} (hN : 0 < N)
     · rw [dif_neg (by omega : ¬((k.val + N - i.val) % N < L + 1))]
       simp [hlast]
 
-/-- Restricting the first site of a non-repeating cyclic `(L + 1)`-window peels
+/-- Restricting the first site of a non-repeating cyclic \((L + 1)\)-window peels
 off the site with cyclic offset `0`, stores its value in the outside
 configuration, and moves the window start one site forward. -/
 theorem cyclicRestrictₗ_restrictFirst {N L : ℕ} (hN : 0 < N) (hLN : L + 1 ≤ N)
@@ -607,7 +609,7 @@ theorem cyclicRestrictₗ_restrictFirst {N L : ℕ} (hN : 0 < N) (hLN : L + 1 �
       rw [dif_neg hsmall, dif_neg hshiftLarge]
       simp [hzero]
 
-/-- For a non-wrapping window (`i + L ≤ N`), the cyclic config agrees with
+/-- For a non-wrapping window (\(i + L ≤ N\)), the cyclic config agrees with
 the contiguous config. -/
 theorem cyclicCfg_eq_contiguousCfg {N : ℕ} (hN : 0 < N) {L : ℕ} (hLN : L ≤ N)
     {i : Fin N} (hi : i.val + L ≤ N)

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -19,12 +19,13 @@ and is deferred.
 
 ## Main definitions
 
-* `Decorrelation.IsDecorrelated` — regions A and B are decorrelated w.r.t. a
-  subspace K when `P_K O_A (1 - P_K) O_B P_K = 0` for all observables
-  O_A, O_B on the respective regions.
-* `Decorrelation.HasCommutingParentHam` — a subspace K corresponds to a parent
+* `Decorrelation.IsDecorrelated` — regions \(A\) and \(B\) are decorrelated w.r.t. a
+  subspace \(K\) when \(P_K O_A (1 - P_K) O_B P_K = 0\) for all observables
+  \(O_A, O_B\) on the respective regions.
+* `Decorrelation.HasCommutingParentHam` — a subspace \(K\) corresponds to a parent
   commuting Hamiltonian, expressed as the intersection of two local kernels
-  `K_AX ⊗ H_B ∩ H_A ⊗ K_XB` where the corresponding projectors commute.
+  \(K_{AX} \otimes H_B \cap H_A \otimes K_{XB}\) where the corresponding
+  projectors commute.
 
 ## Main results
 
@@ -50,9 +51,9 @@ variable {E : Type*} [AddCommGroup E] [Module ℂ E]
 
 namespace LinearMap
 
-/-- For commuting idempotents, `Q ∘ (1 - P ∘ Q) ∘ P = 0`. This is the
+/-- For commuting idempotents, \(Q ∘ (1 - P ∘ Q) ∘ P = 0\). This is the
 key cancellation used in the "only if" direction of Prop D.3:
-`P_XB ∘ P_K^⊥ ∘ P_AX = 0`. -/
+\(P_{XB} \circ P_K^\perp \circ P_{AX} = 0\). -/
 theorem comp_complement_comm_zero
     {P Q : E →ₗ[ℂ] E}
     (hP : P ∘ₗ P = P)
@@ -88,7 +89,7 @@ end CommutingProjectors
 ### Abstract operator-algebraic formulation
 
 We work in an abstract setting with finite-dimensional Hilbert spaces
-`H_A`, `H_X`, `H_B` and a subspace `K ≤ H_A ⊗ H_X ⊗ H_B`.
+\(H_A\), \(H_X\), \(H_B\) and a subspace \(K ≤ H_A ⊗ H_X ⊗ H_B\).
 
 Since the full formalization of the tensor product of Hilbert spaces is
 not yet available in Mathlib, we state the main definitions and the
@@ -102,10 +103,10 @@ variable {E : Type*} [AddCommGroup E] [Module ℂ E]
 
 namespace Decorrelation
 
-/-- **Decorrelation**: given an idempotent endomorphism `P_K` (projecting onto a
-subspace K) and families of operators `O_A` and `O_B` representing observables
+/-- **Decorrelation**: given an idempotent endomorphism \(P_K\) (projecting onto a
+subspace K) and families of operators \(O_A\) and \(O_B\) representing observables
 on regions A and B, regions A and B are **decorrelated** w.r.t. K when
-`P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K = 0` for all observables `O_A`, `O_B`.
+\(P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K = 0\) for all observables \(O_A\), \(O_B\).
 
 See arXiv:1606.00608, Appendix D, Section D.2, Definition D.1. -/
 def IsDecorrelated (P_K : E →ₗ[ℂ] E)
@@ -114,45 +115,45 @@ def IsDecorrelated (P_K : E →ₗ[ℂ] E)
     P_K ∘ₗ O_A ∘ₗ (LinearMap.id - P_K) ∘ₗ O_B ∘ₗ P_K = 0
 
 /-- **Parent commuting Hamiltonian representation**: a subspace (given by its
-idempotent endomorphism `P_K`) corresponds to a parent commuting Hamiltonian if
-there exist idempotent endomorphisms `P_AX` and `P_XB` (acting on regions AX and
-XB respectively) that commute and whose intersection recovers `P_K`.
+idempotent endomorphism \(P_K\)) corresponds to a parent commuting Hamiltonian if
+there exist idempotent endomorphisms \(P_{AX}\) and \(P_{XB}\) (acting on regions AX and
+XB respectively) that commute and whose intersection recovers \(P_K\).
 
-Formally: `[Q_AX, Q_XB] = 0` where `Q = 1 - P`, and
-`K = (K_AX ⊗ H_B) ∩ (H_A ⊗ K_XB)`, which in projector language means
-`P_AX ∘ P_XB = P_K`.
+Formally: \([Q_{AX}, Q_{XB}] = 0\) where \(Q = 1 - P\), and
+\(K = (K_{AX} \otimes H_B) \cap (H_A \otimes K_{XB})\), which in projector
+language means \(P_{AX} \circ P_{XB} = P_K\).
 
 Note: this definition only requires idempotence and commutativity, not
-orthogonality / self-adjointness. Locality (that `P_AX` acts on the AX
-tensor factor and `P_XB` on XB) is not enforced in this abstract setting;
+orthogonality / self-adjointness. Locality (that \(P_{AX}\) acts on the AX
+tensor factor and \(P_{XB}\) on XB) is not enforced in this abstract setting;
 it will be added once tensor-product Hilbert space formulation is
-available. In particular, the trivial witness `P_AX = P_XB = P_K` always
-satisfies this predicate for any idempotent `P_K`; non-trivial content
+available. In particular, the trivial witness \(P_{AX} = P_{XB} = P_K\) always
+satisfies this predicate for any idempotent \(P_K\); non-trivial content
 arises only when combined with locality constraints (see
 `commutingHam_isDecorrelated`).
 
 See arXiv:1606.00608, Appendix D, Section D.2, Definition D.2.
 
-TODO(tensor-product): add locality constraints requiring `P_AX` to act on
-`H_A ⊗ H_X` and `P_XB` to act on `H_X ⊗ H_B`. Without these, the predicate
-is trivially satisfiable by `P_AX = P_XB = P_K`. -/
+TODO(tensor-product): add locality constraints requiring \(P_{AX}\) to act on
+\(H_A \otimes H_X\) and \(P_{XB}\) to act on \(H_X \otimes H_B\). Without these,
+the predicate is trivially satisfiable by \(P_{AX} = P_{XB} = P_K\). -/
 structure HasCommutingParentHam (P_K : E →ₗ[ℂ] E) where
   /-- Projector onto the AX region. -/
   P_AX : E →ₗ[ℂ] E
   /-- Projector onto the XB region. -/
   P_XB : E →ₗ[ℂ] E
-  /-- `P_AX` is idempotent. -/
+  /-- \(P_{AX}\) is idempotent. -/
   hAX_idem : P_AX ∘ₗ P_AX = P_AX
-  /-- `P_XB` is idempotent. -/
+  /-- \(P_{XB}\) is idempotent. -/
   hXB_idem : P_XB ∘ₗ P_XB = P_XB
-  /-- The projectors commute: `[P_AX, P_XB] = 0`. -/
+  /-- The projectors commute: \([P_{AX}, P_{XB}] = 0\). -/
   hcomm : P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX
-  /-- `P_K` is the intersection projector: `P_AX ∘ P_XB = P_K`. -/
+  /-- \(P_K\) is the intersection projector: \(P_{AX} \circ P_{XB} = P_K\). -/
   hK : P_AX ∘ₗ P_XB = P_K
 
 /-- In the current abstract setting, every idempotent endomorphism has a
 trivial `HasCommutingParentHam` witness obtained by taking
-`P_AX = P_XB = P_K`.
+\(P_{AX} = P_{XB} = P_K\).
 
 This definition is intentionally explicit: it explains why the forward
 direction of Proposition D.3 cannot be formalized meaningfully without
@@ -169,28 +170,30 @@ def HasCommutingParentHam.ofIdem
 
 /-- **Proposition D.3, backward direction** (arXiv:1606.00608, Appendix D, Section D.2):
 If a subspace K corresponds to a parent commuting Hamiltonian through
-`P_K = P_AX ∘ P_XB` with `[P_AX, P_XB] = 0`, and observables on region A
-commute with `P_XB` while observables on region B commute with `P_AX`, then
+\(P_K = P_{AX} \circ P_{XB}\) with \([P_{AX}, P_{XB}] = 0\), and observables on
+region A commute with \(P_{XB}\) while observables on region B commute with \(P_{AX}\), then
 regions A and B are decorrelated w.r.t. K.
 
 The commutation hypotheses are scoped to the *specific* witnessing projectors
-`P_AX` and `P_XB`, not all linear maps. This captures the locality structure:
+\(P_{AX}\) and \(P_{XB}\), not all linear maps. This captures the locality structure:
 A-observables commute with the XB-projector and vice versa.
 
 ## Proof outline
 
-The key identity is `P_XB ∘ (1 - P_AX ∘ P_XB) ∘ P_AX = 0` (see
+The key identity is
+\(P_{XB} \circ (1 - P_{AX} \circ P_{XB}) \circ P_{AX} = 0\) (see
 `LinearMap.comp_complement_comm_zero`). Using the commutation hypotheses to
-slide `O_A` past `P_XB` and `O_B` past `P_AX`, the five-fold composition
-`P_K ∘ O_A ∘ (1 - P_K) ∘ O_B ∘ P_K` factors as
-`P_AX ∘ O_A ∘ [P_XB ∘ (1 - P_AX ∘ P_XB) ∘ P_AX] ∘ O_B ∘ P_XB = 0`.
+slide \(O_A\) past \(P_{XB}\) and \(O_B\) past \(P_{AX}\), the five-fold
+composition \(P_K \circ O_A \circ (1 - P_K) \circ O_B \circ P_K\) factors as
+\(P_{AX} \circ O_A \circ [P_{XB} \circ (1 - P_{AX} \circ P_{XB}) \circ P_{AX}]
+\circ O_B \circ P_{XB} = 0\).
 
 ## Note on the forward direction
 
 The converse (IsDecorrelated → HasCommutingParentHam) requires constructing
-*local* projectors `P_AX` and `P_XB` on the AX and XB tensor factors.
+*local* projectors \(P_{AX}\) and \(P_{XB}\) on the AX and XB tensor factors.
 In this abstract (non-tensor-product) setting, `HasCommutingParentHam` is
-trivially satisfiable by `P_AX = P_XB = P_K`, so an abstract iff would be
+trivially satisfiable by \(P_{AX} = P_{XB} = P_K\), so an abstract iff would be
 vacuous. The forward direction is deferred to the tensor-product setting.
 
 See arXiv:1606.00608, Appendix D, Section D.2, Proposition D.3. -/
@@ -237,7 +240,7 @@ theorem commutingHam_isDecorrelated
 
 /-- Convenience form that accepts `HasCommutingParentHam` directly.
 
-The witnessing projectors `P_AX`, `P_XB` are extracted from the structure
+The witnessing projectors \(P_{AX}\), \(P_{XB}\) are extracted from the structure
 fields. See `commutingHam_isDecorrelated` for the version with explicit
 witnesses. -/
 theorem HasCommutingParentHam.isDecorrelated

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -11,23 +11,24 @@ and the finite-chain parent Hamiltonian.
 ## Main definitions
 
 * `MPSTensor.parentInteraction A L` — the canonical parent interaction
-  `1 - Π_{G_L(A)}`, represented as the orthogonal projector onto
-  `(groundSpace A L)ᗮ`. This positive operator has kernel `G_L(A)`.
+  \(1 - Π_{G_L(A)}\), represented as the orthogonal projector onto
+  \(G_L(A)^\perp\). This positive operator has kernel \(G_L(A)\).
 
-* `MPSTensor.extractWindow L i σ` — extracts `L` consecutive site values from an `N`-site
-  configuration `σ` starting at position `i` (with periodic boundary conditions).
+* `MPSTensor.extractWindow L i σ` — extracts \(L\) consecutive site values from an
+  \(N\)-site configuration \(\sigma\) starting at position \(i\) (with periodic
+  boundary conditions).
 
-* `MPSTensor.replaceWindow L i σ τ` — replaces the `L` consecutive site values in `σ`
-  starting at position `i` with values from `τ`.
+* `MPSTensor.replaceWindow L i σ τ` — replaces the \(L\) consecutive site values in
+  \(\sigma\) starting at position \(i\) with values from \(\tau\).
 
-* `MPSTensor.localTerm A L N i` — the parent interaction embedded at site `i` on the
-  `N`-site periodic chain, acting as `parentInteraction` on the window
-  `{i, i+1, …, i+L-1 mod N}` and as the identity on the complement.
+* `MPSTensor.localTerm A L N i` — the parent interaction embedded at site \(i\) on
+  the \(N\)-site periodic chain, acting as `parentInteraction` on the window
+  \(\{i, i+1, \ldots, i+L-1 \bmod N\}\) and as the identity on the complement.
 
-* `MPSTensor.parentHamiltonian A L N` — the parent Hamiltonian `H = ∑ᵢ hᵢ`.
+* `MPSTensor.parentHamiltonian A L N` — the parent Hamiltonian \(H = ∑ᵢ hᵢ\).
 
-* `MPSTensor.IsFrustrationFree A L N ψ` — the parent-Hamiltonian ground-state
-  condition `hᵢ ψ = 0` for every local term.
+* `MPSTensor.IsFrustrationFree` — the parent-Hamiltonian ground-state
+  condition \(hᵢ ψ = 0\) for every local term.
 -/
 
 open scoped BigOperators
@@ -38,14 +39,16 @@ variable {d D : ℕ}
 
 /-! ### Transport between `NSiteSpace` and `EuclideanSpace`
 
-`NSiteSpace d L = Cfg d L → ℂ` and `EuclideanSpace ℂ (Cfg d L)` is the same underlying
+`NSiteSpace d L` is the function space on length-\(L\) configurations with
+values in \(\mathbb C\), and
+`EuclideanSpace ℂ (Cfg d L)` is the same underlying
 function space equipped with the canonical ℓ² inner product via `WithLp 2`
 (concretely, `EuclideanSpace ℂ (Cfg d L) = WithLp 2 (Cfg d L → ℂ)`). We use
 `WithLp.linearEquiv` to view the local ground space in this ℓ² realization, where
 Mathlib provides `InnerProductSpace` and orthogonal projection. -/
 
 /-- The local ground space \(G_L(A)\) in the canonical ℓ² realization of the
-`L`-site configuration space. -/
+\(L\)-site configuration space. -/
 noncomputable def groundSpaceES (A : MPSTensor d D) (L : ℕ) :
     Submodule ℂ (EuclideanSpace ℂ (Cfg d L)) :=
   (groundSpace A L).map (WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm.toLinearMap
@@ -62,12 +65,12 @@ theorem mem_groundSpaceES_iff (A : MPSTensor d D) (L : ℕ)
 
 /-! ### Parent interaction -/
 
-/-- Canonical parent interaction on `L` consecutive sites: the orthogonal
-projector onto `(groundSpace A L)ᗮ` in the `L`-site Hilbert space.
+/-- Canonical parent interaction on \(L\) consecutive sites: the orthogonal
+projector onto \(G_L(A)^\perp\) in the \(L\)-site Hilbert space.
 
-Mathematically, `parentInteraction A L = 𝟙 - P_{G_L(A)}`, where `P_{G_L(A)}` is the
-orthogonal projector onto the ground space. This is a PSD operator with
-`ker(parentInteraction A L) = groundSpace A L`. -/
+Mathematically, \(h_L = 𝟙 - P_{G_L(A)}\), where \(P_{G_L(A)}\) is the
+orthogonal projector onto \(G_L(A)\). This is a PSD operator with
+\(\ker h_L = G_L(A)\). -/
 noncomputable def parentInteraction (A : MPSTensor d D) (L : ℕ) :
     NSiteSpace d L →ₗ[ℂ] NSiteSpace d L :=
   let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d L)
@@ -75,11 +78,11 @@ noncomputable def parentInteraction (A : MPSTensor d D) (L : ℕ) :
 
 /-! ### Window extraction and replacement (periodic boundary conditions) -/
 
-/-- Extract `L` consecutive values from an `N`-periodic sequence `σ`,
-starting at position `i` with periodic boundary conditions.
+/-- Extract \(L\) consecutive values from an \(N\)-periodic sequence \(\sigma\),
+starting at position \(i\) with periodic boundary conditions.
 
-Note: when `L > N`, indices wrap and may revisit the same positions. The
-intended use case is `L ≤ N` (e.g., the window size is at most the chain
+Note: when \(L > N\), indices wrap and may revisit the same positions. The
+intended use case is \(L ≤ N\) (e.g., the window size is at most the chain
 length). -/
 def extractWindow (L : ℕ) {N : ℕ} {α : Type*} (i : Fin N) (σ : Fin N → α) : Fin L → α :=
   have hN : 0 < N := i.val.zero_le.trans_lt i.isLt
@@ -87,13 +90,13 @@ def extractWindow (L : ℕ) {N : ℕ} {α : Type*} (i : Fin N) (σ : Fin N → �
 
 variable {N : ℕ}
 
-/-- Replace `L` consecutive values in an `N`-periodic sequence `σ`,
-starting at position `i`, with values from `τ` (periodic boundary conditions).
+/-- Replace \(L\) consecutive values in an \(N\)-periodic sequence \(\sigma\),
+starting at position \(i\), with values from \(\tau\) (periodic boundary conditions).
 
-Requires `L ≤ N` to ensure the `L`-site window is represented faithfully.
+Requires \(L ≤ N\) to ensure the \(L\)-site window is represented faithfully.
 
 Note: the offset logic mirrors `cyclicCfg` in `CyclicWindow.lean`, but this
-function is type-generic (`α` instead of `Fin d`) and *replaces* a window
+function is generic in the value type and *replaces* a window
 rather than *assembling* a configuration. -/
 def replaceWindow (L : ℕ) (_hLN : L ≤ N) {α : Type*}
     (i : Fin N) (σ : Fin N → α) (τ : Fin L → α) :
@@ -102,8 +105,8 @@ def replaceWindow (L : ℕ) (_hLN : L ≤ N) {α : Type*}
     let offset := (k.val + N - i.val) % N
     if h : offset < L then τ ⟨offset, h⟩ else σ k
 
-/-- If `a` and `b` are residues modulo `N`, then the cyclic offset of
-`a + b` from `a` is `b`. -/
+/-- If \(a\) and \(b\) are residues modulo \(N\), then the cyclic offset of
+\(a + b\) from \(a\) is \(b\). -/
 lemma offset_mod_eq {a b N : ℕ} (ha : a < N) (hb : b < N) :
     ((a + b) % N + N - a) % N = b := by
   rcases lt_or_ge (a + b) N with hab | hab
@@ -157,16 +160,16 @@ that configuration unchanged. -/
 
 /-! ### Local term (site embedding) -/
 
-/-- Translated local term on an `N`-site periodic chain: embeds
-`parentInteraction A L` at site `i`, acting on the window
-`{i, i+1, …, i+L-1 mod N}` and as identity on the complement.
+/-- Translated local term on an \(N\)-site periodic chain: embeds
+`parentInteraction A L` at site \(i\), acting on the window
+\(\{i, i+1, \ldots, i+L-1 \bmod N\}\) and as identity on the complement.
 
-**Important:** When `L > N` the definition returns `0`, which makes
+**Important:** When \(L > N\) the definition returns `0`, which makes
 `parentHamiltonian` trivially zero and `IsFrustrationFree` vacuously true.
-All meaningful lemmas in `Basic.lean` carry an explicit `hLN : L ≤ N`
+All meaningful lemmas in `Basic.lean` carry an explicit \(L ≤ N\)
 hypothesis, so this degenerate branch is never reached in verified results.
 
-For `f : NSiteSpace d N` and output configuration `σ`:
+For \(f\) and output configuration \(\sigma\):
 ```
 (localTerm A L N i f)(σ) = (parentInteraction A L (fun τ ↦ f (replaceWindow L i σ τ)))
                              (extractWindow L i σ)
@@ -181,7 +184,7 @@ noncomputable def localTerm (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
           (LinearMap.proj (replaceWindow L hLN i σ τ) : NSiteSpace d N →ₗ[ℂ] ℂ)))
   else 0
 
-/-- Parent Hamiltonian on an `N`-site periodic chain:
+/-- Parent Hamiltonian on an \(N\)-site periodic chain:
 sum of translated local interaction terms. -/
 noncomputable def parentHamiltonian (A : MPSTensor d D) (L N : ℕ) :
     NSiteSpace d N →ₗ[ℂ] NSiteSpace d N :=

--- a/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
+++ b/TNLean/MPS/ParentHamiltonian/ExtendRight.lean
@@ -102,8 +102,8 @@ private theorem exists_right_factor_of_letter_compatibility [NeZero D]
     _ = A j * X := by rfl
 
 /-- The positive-length case of the grow-back theorem.  Compatibility for words
-of length `K + 1` reduces to the single-letter case by stripping the first
-letter and applying the induction hypothesis to the matrices `Z j * A i`. -/
+of length \(K + 1\) reduces to the single-letter case by stripping the first
+letter and applying the induction hypothesis to the matrices \(Z_j A_i\). -/
 private theorem exists_right_factor_of_evalWord_compatibility_succ [NeZero D]
     {A : MPSTensor d D} {L₀ : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) :
@@ -140,7 +140,7 @@ private theorem exists_right_factor_of_evalWord_compatibility_succ [NeZero D]
       exists_right_factor_of_letter_compatibility hInj hL₀ hCompat1
 
 /-- Inverting step: if a family of boundary matrices satisfies the compatibility
-identity `Z j * A^σ = A j * Y_σ` for every length-`K` word `σ`, then all `Z j`
+identity \(Z_j A^σ = A_j Y_σ\) for every length-\(K\) word \(σ\), then all \(Z_j\)
 share a common right factor. -/
 theorem exists_right_factor_of_evalWord_compatibility [NeZero D]
     {A : MPSTensor d D} {K L₀ : ℕ}
@@ -160,7 +160,7 @@ theorem exists_right_factor_of_evalWord_compatibility [NeZero D]
       exact exists_right_factor_of_evalWord_compatibility_succ hInj hL₀ K hCompat
 
 /-- If two adjacent open-chain windows satisfy the ground-space condition at the
-injectivity length `L₀ + 1`, then the full `(K + L₀ + 1)`-site state is itself
+injectivity length \(L₀ + 1\), then the full \((K + L₀ + 1)\)-site state is itself
 in the open-chain ground space. -/
 theorem groundSpace_extend_right_of_isNBlkInjective
     [NeZero D] {A : MPSTensor d D} {K L₀ : ℕ} (hInj : IsNBlkInjective A L₀)

--- a/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
@@ -8,9 +8,9 @@ import Mathlib.LinearAlgebra.Pi
 /-!
 # Ground space for parent Hamiltonians
 
-For a tensor `A` and block length `L`, the local ground space is
-`G_L(A) = range Γ_L`, where
-`X ↦ (σ ↦ trace (evalWord A (List.ofFn σ) * X))`.
+For a tensor \(A\) and block length \(L\), the local ground space is
+\(G_L(A) = \operatorname{range} Γ_L\), where
+\(X ↦ (σ ↦ \operatorname{tr}(A^σ X))\).
 -/
 
 open scoped Matrix
@@ -19,11 +19,11 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- The local Hilbert space on `N` sites, written in the computational basis as
+/-- The local Hilbert space on \(N\) sites, written in the computational basis as
 functions on configurations `σ : Fin N → Fin d`. -/
 abbrev NSiteSpace (d N : ℕ) := Cfg d N → ℂ
 
-/-- The boundary-condition parametrization `Γ_L`; its image is the local MPS
+/-- The boundary-condition parametrization \(Γ_L\); its image is the local MPS
 ground space. -/
 noncomputable def groundSpaceMap (A : MPSTensor d D) (L : ℕ) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] NSiteSpace d L :=
@@ -36,8 +36,8 @@ noncomputable def groundSpaceMap (A : MPSTensor d D) (L : ℕ) :
     groundSpaceMap A L X σ = Matrix.trace (evalWord A (List.ofFn σ) * X) := by
   simp [groundSpaceMap, Matrix.traceLinearMap_apply]
 
-/-- Ground space on `L` consecutive sites:
-`G_L(A) = range Γ_L`. -/
+/-- Ground space on \(L\) consecutive sites:
+\(G_L(A) = \operatorname{range} Γ_L\). -/
 noncomputable def groundSpace (A : MPSTensor d D) (L : ℕ) :
     Submodule ℂ (NSiteSpace d L) :=
   (groundSpaceMap A L).range
@@ -51,7 +51,7 @@ lemma groundSpace_finrank_le (A : MPSTensor d D) (L : ℕ) :
     Matrix.finrank_matrix_fin_eq_sq D
   exact hRange.trans (by simp [hMatrix])
 
-/-- The ambient local space has dimension `d^L`. -/
+/-- The ambient local space has dimension \(d^L\). -/
 lemma nSiteSpace_finrank (d L : ℕ) :
     Module.finrank ℂ (NSiteSpace d L) = d ^ L := by
   calc
@@ -60,7 +60,7 @@ lemma nSiteSpace_finrank (d L : ℕ) :
             simp [NSiteSpace, Module.finrank_fintype_fun_eq_card]
     _ = d ^ L := by simp
 
-/-- If `d^L > D^2`, then `G_L(A)` is a proper subspace. -/
+/-- If \(d^L > D^2\), then \(G_L(A)\) is a proper subspace. -/
 lemma groundSpace_ne_top (A : MPSTensor d D) (L : ℕ) (hDim : d ^ L > D ^ 2) :
     groundSpace A L ≠ ⊤ := by
   intro hTop

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -10,18 +10,18 @@ import TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan
 /-!
 # Intersection property of MPS ground spaces
 
-For an injective MPS tensor `A`, we establish:
+For an injective MPS tensor \(A\), we establish:
 
-1. **Injectivity of the ground-space map**: `groundSpaceMap A L` is injective for `L ≥ 1`,
-   yielding `dim G_L(A) = D²`.
+1. **Injectivity of the ground-space map**: `groundSpaceMap A L` is injective for
+   \(L \geq 1\), yielding \(\dim G_L(A) = D^2\).
 
-2. **Restriction to ground spaces**: An element of `G_{L+1}(A)` restricts to elements of
-   `G_L(A)` on both the left `L`-site window (fixing the last index) and the right
-   `L`-site window (fixing the first index).
+2. **Restriction to ground spaces**: An element of \(G_{L+1}(A)\) restricts to elements of
+   \(G_L(A)\) on both the left \(L\)-site window (fixing the last index) and the right
+   \(L\)-site window (fixing the first index).
 
 3. **Intersection property** (the "inverting and growing back" step): conversely, a state
-   on `L+1` sites whose left and right restrictions both lie in `G_L(A)` is itself in
-   `G_{L+1}(A)`.
+   on \(L+1\) sites whose left and right restrictions both lie in \(G_L(A)\) is itself in
+   \(G_{L+1}(A)\).
 
 The intersection property is the key ingredient for proving uniqueness of the ground state
 of the parent Hamiltonian (see `UniqueGroundState.lean`).
@@ -31,7 +31,7 @@ of the parent Hamiltonian (see `UniqueGroundState.lean`).
 * `MPSTensor.groundSpace_inLeftGround` — forward direction, left window
 * `MPSTensor.groundSpace_inRightGround` — forward direction, right window
 * `MPSTensor.groundSpaceMap_injective` — injectivity for injective tensors
-* `MPSTensor.groundSpace_finrank_eq` — dimension equals `D²`
+* `MPSTensor.groundSpace_finrank_eq` — dimension equals \(D^2\)
 * `MPSTensor.groundSpace_intersection` — the intersection property
 
 ## References
@@ -48,13 +48,14 @@ This file imports `TNLean.Wielandt.SpanGrowth.CumulativeToWordSpan`, which suppl
 the connection from the cumulative Wielandt bound to a concrete word-span theorem:
 
 > **Cumulative-to-word-span connection (Wielandt chain, Lemma 2(b) of arXiv:0909.5347).**
-> The cumulative span `S_n(A)` is the linear span of all word products of length
-> `≤ n`.  `CumulativeToWordSpan` converts the statement "`S_n(A)` reaches the
-> full matrix algebra" into "`wordSpan A n = ⊤`" — i.e., the
-> word products of exactly length `n` (not just up to `n`) span `M_D(ℂ)`.
+> The cumulative span \(S_n(A)\) is the linear span of all word products of length
+> \(≤ n\).  `CumulativeToWordSpan` converts the statement "\(S_n(A)\) reaches the
+> full matrix algebra" into exact-length fullness, namely that the
+> word products of exactly length \(n\) (not just up to \(n\)) span \(M_D(ℂ)\).
 
 In the intersection property proof: the injectivity of `groundSpaceMap A L`
-(for `L ≥ 1`) requires that `wordSpan A L = ⊤`.  The Wielandt machinery
+(for \(L ≥ 1\)) requires the products \(A^\sigma\), with \(|\sigma| = L\), to
+span the full matrix algebra.  The Wielandt machinery
 supplies this conclusion from the injectivity hypothesis `IsInjective A`:
 injectivity at length 1 implies word-span fullness at all positive lengths
 via the cumulative span chain, and `CumulativeToWordSpan` upgrades the
@@ -111,8 +112,8 @@ theorem evalWord_ofFn_cons (A : MPSTensor d D) {L : ℕ}
 
 /-! ### Restriction maps between site spaces -/
 
-/-- Restrict an `(L+1)`-site state to the first `L` sites by fixing the last
-physical index to `j` (using `Fin.snoc`). -/
+/-- Restrict an \((L+1)\)-site state to the first \(L\) sites by fixing the last
+physical index to \(j\) (using `Fin.snoc`). -/
 def restrictLastₗ {d L : ℕ} (j : Fin d) : NSiteSpace d (L + 1) →ₗ[ℂ] NSiteSpace d L where
   toFun ψ := fun σ => ψ (Fin.snoc σ j)
   map_add' ψ₁ ψ₂ := by
@@ -122,14 +123,14 @@ def restrictLastₗ {d L : ℕ} (j : Fin d) : NSiteSpace d (L + 1) →ₗ[ℂ] N
     ext σ
     simp
 
-/-- Restrict an `(L+1)`-site state to the first `L` sites by fixing the last
-physical index to `j` (using `Fin.snoc`). -/
+/-- Restrict an \((L+1)\)-site state to the first \(L\) sites by fixing the last
+physical index to \(j\) (using `Fin.snoc`). -/
 noncomputable def restrictLast {d L : ℕ} (ψ : NSiteSpace d (L + 1)) (j : Fin d) :
     NSiteSpace d L :=
   restrictLastₗ j ψ
 
-/-- Restrict an `(L+1)`-site state to the last `L` sites by fixing the first
-physical index to `i` (using `Fin.cons`). -/
+/-- Restrict an \((L+1)\)-site state to the last \(L\) sites by fixing the first
+physical index to \(i\) (using `Fin.cons`). -/
 def restrictFirstₗ {d L : ℕ} (i : Fin d) : NSiteSpace d (L + 1) →ₗ[ℂ] NSiteSpace d L where
   toFun ψ := fun σ => ψ (Fin.cons i σ)
   map_add' ψ₁ ψ₂ := by
@@ -139,8 +140,8 @@ def restrictFirstₗ {d L : ℕ} (i : Fin d) : NSiteSpace d (L + 1) →ₗ[ℂ] 
     ext σ
     simp
 
-/-- Restrict an `(L+1)`-site state to the last `L` sites by fixing the first
-physical index to `i` (using `Fin.cons`). -/
+/-- Restrict an \((L+1)\)-site state to the last \(L\) sites by fixing the first
+physical index to \(i\) (using `Fin.cons`). -/
 noncomputable def restrictFirst {d L : ℕ} (ψ : NSiteSpace d (L + 1)) (i : Fin d) :
     NSiteSpace d L :=
   restrictFirstₗ i ψ
@@ -153,7 +154,7 @@ noncomputable def restrictFirst {d L : ℕ} (ψ : NSiteSpace d (L + 1)) (i : Fin
     (i : Fin d) (σ : Fin L → Fin d) :
     restrictFirst ψ i σ = ψ (Fin.cons i σ) := rfl
 
-/-- A vector on `L + 1` sites is determined by all restrictions obtained by
+/-- A vector on \(L + 1\) sites is determined by all restrictions obtained by
 fixing its first physical index. -/
 theorem eq_of_forall_restrictFirst_eq {d L : ℕ} {ψ φ : NSiteSpace d (L + 1)}
     (h : ∀ i : Fin d, restrictFirst ψ i = restrictFirst φ i) :
@@ -164,24 +165,26 @@ theorem eq_of_forall_restrictFirst_eq {d L : ℕ} {ψ φ : NSiteSpace d (L + 1)}
 
 /-! ### Ground space membership via restrictions -/
 
-/-- A state on `L+1` sites has its left restriction in `G_L(A)`: for each value of the
-last physical index, the resulting `L`-site state lies in the ground space. -/
+/-- A state on \(L+1\) sites has its left restriction in \(G_L(A)\): for each value of the
+last physical index, the resulting \(L\)-site state lies in the ground space. -/
 def InLeftGround (A : MPSTensor d D) (L : ℕ) (ψ : NSiteSpace d (L + 1)) : Prop :=
   ∀ j : Fin d, restrictLast ψ j ∈ groundSpace A L
 
-/-- A state on `L+1` sites has its right restriction in `G_L(A)`: for each value of the
-first physical index, the resulting `L`-site state lies in the ground space. -/
+/-- A state on \(L+1\) sites has its right restriction in \(G_L(A)\): for each value of the
+first physical index, the resulting \(L\)-site state lies in the ground space. -/
 def InRightGround (A : MPSTensor d D) (L : ℕ) (ψ : NSiteSpace d (L + 1)) : Prop :=
   ∀ i : Fin d, restrictFirst ψ i ∈ groundSpace A L
 
 /-! ### Forward direction: ground-space elements restrict to ground-space elements
 
-If `ψ ∈ G_{L+1}(A)`, i.e. `ψ(σ) = tr(A^σ · X)` for some boundary matrix `X`,
-then fixing the last index `j` gives `ψ(σ, j) = tr(A^σ · (A^j · X))`, which lies
-in `G_L(A)` with boundary matrix `A^j · X`. Similarly, fixing the first index `i`
-gives `ψ(i, σ) = tr(A^σ · (X · A^i))` by trace cyclicity. -/
+If \(\psi \in G_{L+1}(A)\), i.e.
+\(\psi(\sigma) = \operatorname{tr}(A^\sigma X)\) for some boundary matrix \(X\),
+then fixing the last index \(j\) gives
+\(\psi(\sigma, j) = \operatorname{tr}(A^\sigma A^j X)\), which lies in \(G_L(A)\)
+with boundary matrix \(A^j X\). Similarly, fixing the first index \(i\) gives
+\(\psi(i, \sigma) = \operatorname{tr}(A^\sigma X A^i)\) by trace cyclicity. -/
 
-/-- An element of `G_{L+1}(A)` restricts to `G_L(A)` on the first `L` sites
+/-- An element of \(G_{L+1}(A)\) restricts to \(G_L(A)\) on the first \(L\) sites
 (left window, fixing the last index). -/
 theorem groundSpace_inLeftGround (A : MPSTensor d D) (L : ℕ)
     {ψ : NSiteSpace d (L + 1)} (hψ : ψ ∈ groundSpace A (L + 1)) :
@@ -193,7 +196,7 @@ theorem groundSpace_inLeftGround (A : MPSTensor d D) (L : ℕ)
   ext σ
   simp only [restrictLast_apply, groundSpaceMap_apply, evalWord_ofFn_snoc, Matrix.mul_assoc]
 
-/-- An element of `G_{L+1}(A)` restricts to `G_L(A)` on the last `L` sites
+/-- An element of \(G_{L+1}(A)\) restricts to \(G_L(A)\) on the last \(L\) sites
 (right window, fixing the first index). -/
 theorem groundSpace_inRightGround (A : MPSTensor d D) (L : ℕ)
     {ψ : NSiteSpace d (L + 1)} (hψ : ψ ∈ groundSpace A (L + 1)) :
@@ -209,12 +212,12 @@ theorem groundSpace_inRightGround (A : MPSTensor d D) (L : ℕ)
 
 /-! ### Injectivity of the ground-space map -/
 
-/-- For an injective tensor, `groundSpaceMap A L` is injective for any `L ≥ 1`.
+/-- For an injective tensor, the ground-space map is injective for any \(L ≥ 1\).
 
-**Proof sketch**: It suffices to show `groundSpaceMap A L X = 0 → X = 0`.
-If `tr(A^σ · X) = 0` for all words `σ` of length `L`, and the set `{A^σ}`
-spans `M_D(ℂ)` (which holds for `L ≥ 1` by the injectivity hypothesis),
-then nondegeneracy of the trace pairing gives `X = 0`. -/
+**Proof sketch**: It suffices to show \(Γ_L(X)=0 → X=0\).
+If \(\operatorname{tr}(A^σ X) = 0\) for all words \(σ\) of length \(L\), and the set
+\(\{A^σ\}\) spans \(M_D(ℂ)\) (which holds for \(L ≥ 1\) by the injectivity hypothesis),
+then nondegeneracy of the trace pairing gives \(X = 0\). -/
 theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
     {L : ℕ} (hL : 0 < L) :
     Function.Injective (groundSpaceMap A L) := by
@@ -256,10 +259,12 @@ theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
         _ = 0 := hNX
   exact LinearMap.ker_eq_bot.mp hker
 
-/-- For an injective tensor, the ground space has dimension exactly `D²` for `L ≥ 1`.
+/-- For an injective tensor, the ground space has dimension exactly \(D^2\) for
+\(L \geq 1\).
 
-This follows from injectivity of `groundSpaceMap` (which has domain `M_D(ℂ)` of
-dimension `D²`) together with the dimension upper bound `dim G_L(A) ≤ D²`. -/
+This follows from injectivity of `groundSpaceMap` (which has domain \(M_D(ℂ)\) of
+dimension \(D^2\)) together with the dimension upper bound
+\(\dim G_L(A) \leq D^2\). -/
 theorem groundSpace_finrank_eq {A : MPSTensor d D} (hA : IsInjective A)
     {L : ℕ} (hL : 0 < L) :
     Module.finrank ℂ ↥(groundSpace A L) = D ^ 2 := by
@@ -277,22 +282,24 @@ theorem groundSpace_finrank_eq {A : MPSTensor d D} (hA : IsInjective A)
 /-! ### The intersection property -/
 
 /-- Nontrivial direction of the intersection property for injective MPS: a state
-on `L+1` sites that restricts to ground-space elements on both the left and right
-`L`-site windows is itself in `G_{L+1}(A)`.
+on \(L+1\) sites that restricts to ground-space elements on both the left and right
+\(L\)-site windows is itself in \(G_{L+1}(A)\).
 
 This is the "inverting and growing back" step. The proof proceeds as follows:
 
-1. From `InRightGround`: for each `i`, ∃ unique `Y_i` with `ψ(i, σ) = tr(A^σ · Y_i)`.
-2. From `InLeftGround`: for each `j`, ∃ unique `Z_j` with `ψ(σ, j) = tr(A^σ · Z_j)`.
+1. From `InRightGround`: for each \(i\), ∃ unique \(Y_i\) with
+   \(ψ(i, σ) = \operatorname{tr}(A^σ · Y_i)\).
+2. From `InLeftGround`: for each \(j\), ∃ unique \(Z_j\) with
+   \(ψ(σ, j) = \operatorname{tr}(A^σ · Z_j)\).
 3. Matching on the overlap and using trace-pairing nondegeneracy:
-   `A^j · Y_i = Z_j · A^i` for all `i, j`.
+   \(A^j · Y_i = Z_j · A^i\) for all \(i, j\).
 4. Apply the decomposition map (one-sided inverse from `OneSidedInverse.lean`):
-   sum over `i` with decomposition coefficients of the identity to get
-   `Y_i = X' · A^i` for a single matrix `X' = ∑ⱼ (Ψ(I))ⱼ · Z_j`.
-5. By trace cyclicity, `ψ(σ) = tr(A^σ · X')`, so `ψ ∈ G_{L+1}(A)`.
+   sum over \(i\) with decomposition coefficients of the identity to get
+   \(Y_i = X' · A^i\) for a single matrix \(X' = ∑ⱼ (Ψ(I))ⱼ · Z_j\).
+5. By trace cyclicity, \(ψ(σ) = \operatorname{tr}(A^σ · X')\), so \(ψ ∈ G_{L+1}(A)\).
 
-The formal overlap argument uses the `(L - 1)`-site intersection, so we state
-the theorem with the exact hypothesis `1 < L`. -/
+The formal overlap argument uses the \((L - 1)\)-site intersection, so we state
+the theorem with the exact hypothesis \(1 < L\). -/
 theorem groundSpace_intersection {A : MPSTensor d D} (hA : IsInjective A)
     {L : ℕ} (hL : 1 < L) {ψ : NSiteSpace d (L + 1)}
     (hLeft : InLeftGround A L ψ) (hRight : InRightGround A L ψ) :
@@ -401,8 +408,8 @@ theorem groundSpace_intersection {A : MPSTensor d D} (hA : IsInjective A)
     _ = ψ τ := by
           rw [Fin.cons_self_tail τ]
 
-/-- The ground space on `L+1` sites is characterized by the intersection property:
-`ψ ∈ G_{L+1}(A)` iff both the left and right `L`-site restrictions lie in `G_L(A)`. -/
+/-- The ground space on \(L+1\) sites is characterized by the intersection property:
+\(ψ ∈ G_{L+1}(A)\) iff both the left and right \(L\)-site restrictions lie in \(G_L(A)\). -/
 theorem groundSpace_iff_left_right {A : MPSTensor d D} (hA : IsInjective A)
     {L : ℕ} (hL : 1 < L) {ψ : NSiteSpace d (L + 1)} :
     ψ ∈ groundSpace A (L + 1) ↔ InLeftGround A L ψ ∧ InRightGround A L ψ :=

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -30,7 +30,7 @@ The four components are:
 1. **Frustration-freeness** (`parentHamiltonian_frustrationFree`): every local
    term annihilates the periodic MPS vector \(V^{(N)}(A)\).
 2. **Local projector structure** (`parentInteraction`/`localTerm`): each local
-   term is an orthogonal projector on its `L`-site window.
+   term is an orthogonal projector on its \(L\)-site window.
 3. **Intersection property** (`groundSpace_intersection`): for an injective
    MPS tensor, the kernel of the sum of two overlapping local terms equals
    the intersection of their kernels.
@@ -38,12 +38,12 @@ The four components are:
    kernels of overlapping local terms. The remaining quantitative input is the
    Friedrichs-angle estimate, equivalently the anticommutator bound
 
-        `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`
+        \(h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)\)
 
    with coefficients whose rows are summable uniformly in the chain length.
-5. **Row-sum bound** `∑_{j ≠ i} c_{ij} ≤ 1`: at most `2(L-1)` local terms
-   overlap a given length-`L` cyclic window under the convention used here.
-6. **Quadratic form ⟹ norm bound**: combining these estimates with `h_i^2 = h_i`
-   yields `H² ≥ γ H` as a quadratic form, which by the spectral theorem
-   gives `γ ‖v‖ ≤ ‖H v‖` for `v ⊥ ker H`.
+5. **Row-sum bound** \(∑_{j ≠ i} c_{ij} ≤ 1\): at most \(2(L-1)\) local terms
+   overlap a given length-\(L\) cyclic window under the convention used here.
+6. **Quadratic form ⟹ norm bound**: combining these estimates with \(h_i^2 = h_i\)
+   yields \(H² ≥ γ H\) as a quadratic form, which by the spectral theorem
+   gives \(γ ‖v‖ ≤ ‖H v‖\) for \(v \perp \ker H\).
 -/

--- a/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
@@ -8,9 +8,9 @@ import Mathlib.Analysis.InnerProductSpace.Spectrum
 /-!
 # Abstract martingale criterion (quadratic form → norm bound)
 
-For a positive operator `H` on a finite-dimensional complex Hilbert space, the
-quadratic-form inequality `H² ≥ γ H` (with `γ > 0`) implies the norm lower bound
-`γ ‖v‖ ≤ ‖H v‖` on the orthogonal complement of `ker H`. This is the
+For a positive operator \(H\) on a finite-dimensional complex Hilbert space, the
+quadratic-form inequality \(H² ≥ γ H\) (with \(γ > 0\)) implies the norm lower bound
+\(γ ‖v‖ ≤ ‖H v‖\) on the orthogonal complement of \(\ker H\). This is the
 operator-theoretic kernel of the Kastoryano–Lucia / Nachtergaele martingale
 method for spectral gaps; the MPS-specific instance is
 `MPSTensor.parentHamiltonian_gapped`.
@@ -23,29 +23,29 @@ namespace FrustrationFree
 /--
 **Abstract martingale criterion (quadratic form ⟹ norm bound).**
 
-Let `H` be a positive linear operator (in the sense of `LinearMap.IsPositive`:
-symmetric with `0 ≤ re ⟪H v, v⟫`) on a finite-dimensional complex Hilbert
-space satisfying the quadratic-form inequality
+Let \(H\) be a positive linear operator (in the sense of `LinearMap.IsPositive`:
+symmetric with \(0 ≤ \operatorname{Re}\langle H v, v\rangle\)) on a finite-dimensional
+complex Hilbert space satisfying the quadratic-form inequality
 
-    `γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` for all `v`,
+    \(γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩\) for all \(v\),
 
-i.e.\ `H² ≥ γ H` as a quadratic form. Then on the orthogonal complement
-of `ker H`, `H` is bounded below in norm by `γ`:
+i.e.\ \(H² ≥ γ H\) as a quadratic form. Then on the orthogonal complement
+of \(\ker H\), \(H\) is bounded below in norm by \(γ\):
 
-    `γ ‖v‖ ≤ ‖H v‖` for all `v ⊥ ker H`.
+    \(γ ‖v‖ ≤ ‖H v‖\) for all \(v \perp \ker H\).
 
 The positivity hypothesis is essential: it rules out negative eigenvalues of
-small magnitude (such as `H = -Id`, which otherwise satisfies
-`γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩` vacuously but fails the conclusion). For the MPS
-parent Hamiltonian this hypothesis is automatic because `H = ∑ᵢ hᵢ` is a
+small magnitude (such as \(H = -Id\), which otherwise satisfies
+\(γ ⟨v, H v⟩ ≤ ⟨H v, H v⟩\) vacuously but fails the conclusion). For the MPS
+parent Hamiltonian this hypothesis is automatic because \(H = ∑ᵢ hᵢ\) is a
 sum of orthogonal projectors.
 
 This is the operator-theoretic content of the Kastoryano–Lucia /
 Nachtergaele martingale method: once the MPS-specific projector
 geometry (Friedrichs angle on overlapping local ground spaces plus
-the row-sum bound) produces the operator inequality `H² ≥ γ H` for the
-PSD operator `H`, the norm lower bound — and hence the spectral gap
-for eigenvectors of `H` — follows by the spectral theorem. This lemma
+the row-sum bound) produces the operator inequality \(H² ≥ γ H\) for the
+PSD operator \(H\), the norm lower bound — and hence the spectral gap
+for eigenvectors of \(H\) — follows by the spectral theorem. This lemma
 provides the final spectral-theorem step; the remaining MPS-specific
 quadratic-form hypothesis is stated separately in
 `MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`. -/
@@ -66,7 +66,7 @@ theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 
     hSym.apply_eigenvectorBasis hn i
   have hbb : ∀ i j : Fin n, ⟪b i, b j⟫_ℂ = if i = j then (1 : ℂ) else 0 :=
     orthonormal_iff_ite.mp b.orthonormal
-  -- Apply the operator inequality to each eigenvector: `γ μᵢ ≤ μᵢ²`.
+  -- Apply the operator inequality to each eigenvector: \(γ μᵢ ≤ μᵢ²\).
   have hμ_ineq : ∀ i, γ * μ i ≤ μ i * μ i := by
     intro i
     have key := hOpIneq (b i)
@@ -79,7 +79,7 @@ theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 
           Complex.conj_ofReal, ← Complex.ofReal_mul, Complex.ofReal_re]
     rw [e1, e2] at key
     exact key
-  -- Combined with `μᵢ ≥ 0`, this gives `μᵢ = 0 ∨ γ ≤ μᵢ` for each `i`.
+  -- Combined with \(μᵢ ≥ 0\), this gives \(μᵢ = 0 ∨ γ ≤ μᵢ\) for each \(i\).
   have hμ_alt : ∀ i, μ i = 0 ∨ γ ≤ μ i := by
     intro i
     rcases (hμ_nn i).lt_or_eq with hpos | hzero
@@ -88,16 +88,16 @@ theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 
       have hpos' : 0 < μ i := hpos
       nlinarith
     · left; exact hzero.symm
-  -- Main argument on `v ∈ (ker H)ᗮ`.
+  -- Main argument on \(v ∈ (\ker H)^\perp\).
   intro v hv
-  -- Eigenvectors with zero eigenvalue lie in `ker H`, hence are orthogonal to `v`.
+  -- Eigenvectors with zero eigenvalue lie in \(\ker H\), hence are orthogonal to \(v\).
   have hker : ∀ i, μ i = 0 → b i ∈ LinearMap.ker H := by
     intro i hi
     rw [LinearMap.mem_ker, hHb i]
     simp [hi]
   have hv_perp : ∀ i, μ i = 0 → ⟪b i, v⟫_ℂ = 0 := fun i hi =>
     Submodule.inner_right_of_mem_orthogonal (hker i hi) hv
-  -- Express `‖v‖²` and `‖Hv‖²` through the eigenvector basis.
+  -- Express \(‖v‖²\) and \(‖Hv‖²\) through the eigenvector basis.
   have hv_sq : ‖v‖ ^ 2 = ∑ i, ‖(b.repr v) i‖ ^ 2 := by
     have hiso := b.repr.norm_map v
     rw [← hiso, EuclideanSpace.norm_sq_eq]
@@ -107,7 +107,7 @@ theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 
     refine Finset.sum_congr rfl (fun i _ => ?_)
     rw [hSym.eigenvectorBasis_apply_self_apply hn v i, norm_mul, mul_pow,
         RCLike.norm_ofReal, sq_abs]
-  -- The quadratic-form bound `γ² ‖v‖² ≤ ‖Hv‖²` is now term-by-term.
+  -- The quadratic-form bound \(γ² ‖v‖² ≤ ‖Hv‖²\) is now term-by-term.
   have h_sq : γ ^ 2 * ‖v‖ ^ 2 ≤ ‖H v‖ ^ 2 := by
     rw [hv_sq, hHv_sq, Finset.mul_sum]
     refine Finset.sum_le_sum (fun i _ => ?_)
@@ -121,7 +121,7 @@ theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 
         pow_le_pow_left₀ hγ.le hi 2
       have hnn : (0 : ℝ) ≤ ‖(b.repr v) i‖ ^ 2 := sq_nonneg _
       exact mul_le_mul_of_nonneg_right hγ_sq hnn
-  -- Take square roots to conclude `γ ‖v‖ ≤ ‖Hv‖`.
+  -- Take square roots to conclude \(γ ‖v‖ ≤ ‖Hv‖\).
   have h1 : (γ * ‖v‖) ^ 2 ≤ ‖H v‖ ^ 2 := by
     rw [mul_pow]; exact h_sq
   have h2 : 0 ≤ γ * ‖v‖ := mul_nonneg hγ.le (norm_nonneg v)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -67,10 +67,10 @@ assert the special coefficient used in
 `parentHamiltonianES_gap_bound_of_friedrichs`; instead, it says that any uniform
 bound
 
-`‖p_i p_j v‖ ≤ η ‖p_i v‖`
+\(‖p_i p_j v‖ ≤ η ‖p_i v‖\)
 
-with `η * 2(L-1) < 1` yields the positive gap constant
-`1 - η * 2(L-1)`.  The comparison between this flexible cyclic-window
+with \(η * 2(L-1) < 1\) yields the positive gap constant
+\(1 - η * 2(L-1)\).  The comparison between this flexible cyclic-window
 hypothesis and the cited FNW--Nachtergaele--Kastoryano principal-angle estimates
 is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_overlap_norm_constant
@@ -94,36 +94,37 @@ theorem parentHamiltonianES_gap_bound_of_overlap_norm_constant
 /--
 **Conditional spectral gap for MPS parent Hamiltonians.**
 
-For an injective MPS tensor `A` and interaction range `L > 1`, the
+For an injective MPS tensor \(A\) and interaction range \(L > 1\), the
 overlapping-window norm-compression estimate implies the existence of a uniform
-gap `γ > 0` (independent of system size `N`). For all `N ≥ 2L`, every vector
+gap \(γ > 0\) (independent of system size \(N\)). For all \(N ≥ 2L\), every vector
 in the orthogonal complement of the ground space satisfies
-`γ * ‖v‖ ≤ ‖H_ES v‖`.
+\(γ ‖v‖ ≤ ‖H_{\mathrm{ES}} v‖\).
 
 The orthogonal complement is computed in the `EuclideanSpace` structure
 on `NSiteSpace d N ≃ Cfg d N → ℂ`.
 
 **Proof strategy (Kastoryano–Lucia 2018 / Nachtergaele 1996).** The parent
-Hamiltonian `H_N = ∑ᵢ hᵢ` is a frustration-free sum of local orthogonal
+Hamiltonian \(H_N = ∑ᵢ hᵢ\) is a frustration-free sum of local orthogonal
 projectors (`parentHamiltonian_frustrationFree`). The intersection property
 `groundSpace_intersection` gives the local relation
 
-    `ker h_left ∩ ker h_right ⊆ ker h`
+    \(\ker h_{\mathrm{left}} \cap \ker h_{\mathrm{right}} \subseteq \ker h\)
 
-where `h_left` and `h_right` are the two overlapping length-`L` projectors and
-`h` is the length-`L+1` projector. The remaining principal-angle estimate
+where \(h_{\mathrm{left}}\) and \(h_{\mathrm{right}}\) are the two overlapping
+length-\(L\) projectors and \(h\) is the length-\(L+1\) projector. The remaining
+principal-angle estimate
 supplies the martingale operator inequality
 
-    `h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)`
+    \(h_i h_j + h_j h_i ≥ - c_{ij} (1 - γ) (h_i + h_j)\)
 
-with row-summable coefficients. At most `2(L-1)` local terms overlap a given
-length-`L` cyclic window, so the chosen coefficients have row sum at most one.
-Combined with `h_i^2 = h_i`, this yields the quadratic-form inequality
-`H² ≥ γ H`, which feeds into the abstract lemma
+with row-summable coefficients. At most \(2(L-1)\) local terms overlap a given
+length-\(L\) cyclic window, so the chosen coefficients have row sum at most one.
+Combined with \(h_i^2 = h_i\), this yields the quadratic-form inequality
+\(H² ≥ γ H\), which feeds into the abstract lemma
 `FrustrationFree.spectralGap_of_martingale` to produce the norm bound
-`γ ‖v‖ ≤ ‖H v‖` on `(ker H)ᗮ`. The `LinearMap.IsPositive` hypothesis required
+\(γ ‖v‖ ≤ ‖H v‖\) on \((\ker H)^\perp\). The `LinearMap.IsPositive` hypothesis required
 by `FrustrationFree.spectralGap_of_martingale` is automatic here because
-`H_N = ∑ᵢ hᵢ` is a sum of orthogonal projectors.
+\(H_N = ∑ᵢ hᵢ\) is a sum of orthogonal projectors.
 
 The proof below invokes
 `parentHamiltonianES_gap_bound_of_friedrichs`, which combines the already
@@ -148,16 +149,16 @@ theorem parentHamiltonian_gapped
 **Conditional spectral gap from a strict overlapping-window compression
 coefficient.**
 
-For an MPS tensor `A` and interaction range `L > 1`, any uniform
+For an MPS tensor \(A\) and interaction range \(L > 1\), any uniform
 overlapping cyclic-window estimate
-`‖p_i p_j v‖ ≤ η ‖p_i v‖` with `0 ≤ η` and `η * 2(L-1) < 1` gives a uniform
+\(‖p_i p_j v‖ ≤ η ‖p_i v‖\) with \(0 ≤ η\) and \(η * 2(L-1) < 1\) gives a uniform
 positive lower bound on the parent Hamiltonian, independent of the chain length.
 
 This is the version of `parentHamiltonian_gapped` with an arbitrary compression
 constant.  It is the appropriate target if the principal-angle estimates cited
 in arXiv:2011.12127, Section IV.C, first produce an unspecified positive
 compression constant rather than the explicit coefficient
-`(1 - 1/(4L)) / (2(L-1))`. -/
+\((1 - 1/(4L)) / (2(L-1))\). -/
 theorem parentHamiltonian_gapped_of_overlap_norm_constant
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -10,14 +10,14 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 
 **Root-only.** This file contains the reduction theorems that convert
 explicit local-projection bounds into the quadratic-form inequality
-`H² ≥ γ H` for the Euclidean-space representative `parentHamiltonianES`
-and then into the norm lower bound `γ ‖v‖ ≤ ‖H_ES v‖` on the orthogonal
+\(H² ≥ γ H\) for the Euclidean-space representative `parentHamiltonianES`
+and then into the norm lower bound \(γ ‖v‖ ≤ ‖H_{\mathrm{ES}} v‖\) on the orthogonal
 complement of the ground space.
 
 The chain proceeds from the most abstract (ordered row-sum of local
 cross-term bounds) through finite-overlap reductions down to the
 concrete cyclic-window overlap predicate and its row-cardinality bound
-`2 * (L - 1)`. The final reduction theorems (`*_gap_bound_of_cyclic_window_*`)
+\(2(L - 1)\). The final reduction theorems (`*_gap_bound_of_cyclic_window_*`)
 supply all the already-proved structural input (local projection,
 non-overlap positivity, and row cardinality) and leave only the
 principal-angle estimate as a remaining hypothesis.
@@ -44,7 +44,8 @@ This theorem isolates the operator-theoretic part of the remaining
 principal-angle estimate. The hypotheses already include the quantitative
 martingale estimate
 
-`γ * re ⟪H_N v, v⟫ ≤ re ⟪H_N v, H_N v⟫`,
+\(γ \operatorname{Re}\langle H_N v, v\rangle ≤
+\operatorname{Re}\langle H_N v, H_N v\rangle\),
 
 to be supplied later from the finite-overlap projection geometry. The proof
 uses the established positivity of `parentHamiltonianES`, the kernel
@@ -69,7 +70,7 @@ theorem parentHamiltonianES_norm_bound_of_quadratic_form
 
 /-- The exact explicit gap-bound reduction needed by
 `parentHamiltonianES_gap_bound_of_friedrichs` follows from the corresponding
-uniform quadratic-form estimate with constant `1 / (4 * L)`.
+uniform quadratic-form estimate with constant \(1 / (4 * L)\).
 
 Thus the remaining MPS-specific content is precisely to prove the hypothesis
 `hQuad` from the principal-angle / anti-commutator estimate and the finite
@@ -103,9 +104,10 @@ geometry in `ProjectionGeometry.quadraticForm_sum_projections_of_ordered_rowSum`
 The local projection input is supplied by `localTermES_isSymmetricProjection`, so
 its hypotheses are only the ordered row-summable cross-term bounds
 
-`Re ⟪hᵢ v, hⱼ v⟫ ≥ -(1 - γ) cᵢⱼ Re ⟪hᵢ v, v⟫`.
+\(\operatorname{Re}\langle h_i v, h_j v\rangle ≥
+-(1 - γ)c_{ij}\operatorname{Re}\langle h_i v, v\rangle\).
 
-Under these hypotheses the Euclidean-space Hamiltonian satisfies `H² ≥ γ H`
+Under these hypotheses the Euclidean-space Hamiltonian satisfies \(H² ≥ γ H\)
 as a quadratic form, exactly in the shape consumed by
 `parentHamiltonianES_norm_bound_of_quadratic_form`. -/
 theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
@@ -130,8 +132,8 @@ theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
 /-- Uniform explicit gap-bound reduction from ordered local cross-term row
 bounds.
 
-For every chain length `N ≥ 2L`, assume the Euclidean-space local terms satisfy
-the ordered row-summable cross-term estimate with constant `γ = 1 / (4L)`. The local
+For every chain length \(N ≥ 2L\), assume the Euclidean-space local terms satisfy
+the ordered row-summable cross-term estimate with constant \(γ = 1 / (4L)\). The local
 symmetric-projection input is already supplied by `localTermES_isSymmetricProjection`.
 Then the existing quadratic-form-to-gap theorem applies and yields the explicit
 norm lower bound. This exact reduction leaves proving the principal-angle/row-sum
@@ -171,10 +173,10 @@ principal-angle hypotheses.
 This is the local-window specialization of
 `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap`.  The
 predicate `overlaps i j` marks the off-diagonal pairs for which a principal-angle
-estimate is needed.  If each row has at most `m` such pairs, the non-overlap
+estimate is needed.  If each row has at most \(m\) such pairs, the non-overlap
 cross terms are nonnegative, and every overlap obeys the ordered estimate with
-coefficient `1 / m`, then the Euclidean-space parent Hamiltonian satisfies
-`H² ≥ γ H` as a quadratic form. -/
+coefficient \(1 / m\), then the Euclidean-space parent Hamiltonian satisfies
+\(H² ≥ γ H\) as a quadratic form. -/
 theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
     (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
     (overlaps : Fin N → Fin N → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
@@ -203,8 +205,8 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
 norm-compression principal-angle hypotheses.
 
 For each overlapping pair, it is enough to bound the compressed product
-`‖hᵢ (hⱼ v)‖` by `(1 - γ) / m` times `‖hᵢ v‖`.  The abstract projection-geometry
-lemma converts this principal-angle style norm estimate into the ordered
+\(‖hᵢ (hⱼ v)‖\) by \((1 - γ) / m\) times \(‖hᵢ v‖\).  The abstract
+projection-geometry lemma converts this principal-angle style norm estimate into the ordered
 cross-term bound consumed by the finite-overlap row-sum reduction. -/
 theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound
     (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
@@ -233,9 +235,9 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound
 /-- Fixed-chain finite-overlap quadratic-form estimate from a separate
 norm-compression coefficient.
 
-If the compressed products on overlapping pairs are bounded by `η`, and
-`η ≤ (1 - γ) / m`, then the fixed-chain martingale quadratic form follows with
-constant `γ`.  This version keeps the analytic overlap constant separate from the
+If the compressed products on overlapping pairs are bounded by \(η\), and
+\(η ≤ (1 - γ) / m\), then the fixed-chain martingale quadratic form follows with
+constant \(γ\).  This version keeps the analytic overlap constant separate from the
 gap parameter. -/
 theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le
     (A : MPSTensor d D) (L N : ℕ) {γ η : ℝ} (hγle : γ ≤ 1)
@@ -265,9 +267,9 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le
 /-- Uniform explicit gap-bound reduction from finite-overlap principal-angle
 hypotheses.
 
-For parent-Hamiltonian windows of length `L`, the expected finite-range bound is
-`m = 2 * (L - 1)`: each local term overlaps at most that many other cyclic
-translates when `N ≥ 2L`.  This theorem leaves the Euclidean-space local projection
+For parent-Hamiltonian windows of length \(L\), the expected finite-range bound is
+\(m = 2 * (L - 1)\): each local term overlaps at most that many other cyclic
+translates when \(N ≥ 2L\).  This theorem leaves the Euclidean-space local projection
 structure, the cyclic-window overlap predicate, non-overlap positivity, and the
 principal-angle estimate as explicit hypotheses. It only performs the finite-overlap
 row-sum reduction and the existing quadratic-form-to-gap conversion. -/
@@ -315,8 +317,8 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
 /-- Uniform explicit gap-bound reduction using the concrete cyclic-window overlap
 predicate.
 
-For chains with `N ≥ 2L`, the predicate `cyclicWindowsOverlap N L i j` marks the
-cyclic translates whose length-`L` windows have the finite-range overlap relevant
+For chains with \(N ≥ 2L\), the predicate `cyclicWindowsOverlap N L i j` marks the
+cyclic translates whose length-\(L\) windows have the finite-range overlap relevant
 to the martingale method.  The row-cardinality estimate is supplied by
 `cyclicWindowsOverlap_card_le`, local projection structure is supplied by
 `localTermES_isSymmetricProjection`, and non-overlap positivity is supplied by
@@ -375,7 +377,7 @@ overlapping-window Friedrichs estimate.
 
 It suffices to prove that for every overlapping off-diagonal pair the compressed
 product of transported local projections satisfies
-`‖hᵢ (hⱼ v)‖ ≤ (1 - 1/(4L)) / (2(L-1)) * ‖hᵢ v‖`.  The abstract projection
+\(‖hᵢ (hⱼ v)‖ ≤ (1 - 1/(4L)) / (2(L-1)) * ‖hᵢ v‖\).  The abstract projection
 geometry converts this principal-angle style condition into the ordered
 Friedrichs lower bound and then applies the finite-overlap martingale reduction. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound
@@ -407,9 +409,9 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound
 /-- Uniform gap-bound reduction from an overlap norm-compression estimate with a
 separate coefficient.
 
-For cyclic windows with at most `2 * (L - 1)` overlapping off-diagonal neighbours,
-a compression estimate with coefficient `η` gives any positive gap parameter `γ`
-satisfying `η ≤ (1 - γ) / (2 * (L - 1))`.  This is the constant-flexible form of
+For cyclic windows with at most \(2 * (L - 1)\) overlapping off-diagonal neighbours,
+a compression estimate with coefficient \(η\) gives any positive gap parameter \(γ\)
+satisfying \(η ≤ (1 - γ) / (2 * (L - 1))\).  This is the constant-flexible form of
 `parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound`. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {γ η : ℝ}
@@ -440,8 +442,8 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
 /-- Uniform gap-bound reduction from a strict overlap norm-compression constant.
 
 If every overlapping off-diagonal cyclic pair satisfies the compression estimate
-with coefficient `η`, and `η * (2 * (L - 1)) < 1`, then the transported parent
-Hamiltonians have gap constant `1 - η * (2 * (L - 1))`.  Thus any uniform
+with coefficient \(η\), and \(η * (2 * (L - 1)) < 1\), then the transported parent
+Hamiltonians have gap constant \(1 - η * (2 * (L - 1))\).  Thus any uniform
 compression constant strictly below the reciprocal of the cyclic overlap degree
 yields a positive gap. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -13,16 +13,16 @@ import TNLean.Analysis.ProjectionGeometry
 The `EuclideanSpace`-based formulation of the parent-Hamiltonian martingale
 method:
 
-* `parentInteractionES` — the `L`-site parent interaction as an orthogonal
+* `parentInteractionES` — the \(L\)-site parent interaction as an orthogonal
   projector on the Hilbert-space model `EuclideanSpace ℂ (Cfg d L)`;
 * `cyclicRestrictES` and `localTermESSummand` — cyclic-window restriction
-  and the conjugated `Rᵢ,τ† P_L Rᵢ,τ` summands;
+  and the conjugated \(R_{i,\tau}^\dagger P_L R_{i,\tau}\) summands;
 * `localTermES` and `parentHamiltonianES` — Euclidean-space representatives of
   the local terms and the full parent Hamiltonian;
 * positivity, idempotence, and symmetric-projection structure of the
   Euclidean-space local terms;
 * commutation and non-overlap positivity for disjoint cyclic windows;
-* kernel identification: the Euclidean-space ground space equals `ker(H_ES)`.
+* kernel identification: the Euclidean-space ground space equals \(\ker h_L\).
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -33,15 +33,15 @@ variable {d D : ℕ}
 
 /-! ### Euclidean local projector ingredients -/
 
-/-- The `L`-site parent interaction viewed directly on the Hilbert-space model
+/-- The \(L\)-site parent interaction viewed directly on the Hilbert-space model
 `EuclideanSpace ℂ (Cfg d L)`. Equivalently, this is the orthogonal projector
-onto `(groundSpaceES A L)ᗮ`. -/
+onto the orthogonal complement of the Euclidean realization of \(G_L(A)\). -/
 noncomputable def parentInteractionES (A : MPSTensor d D) (L : ℕ) :
     EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L) :=
   ((groundSpaceES A L)ᗮ.starProjection.toLinearMap)
 
 /-- The `EuclideanSpace` parent interaction is the symmetric projection onto
-`(groundSpaceES A L)ᗮ`. -/
+the orthogonal complement of the Euclidean realization of \(G_L(A)\). -/
 theorem parentInteractionES_isSymmetricProjection (A : MPSTensor d D) (L : ℕ) :
     (parentInteractionES A L).IsSymmetricProjection :=
   Submodule.isSymmetricProjection_starProjection ((groundSpaceES A L)ᗮ)
@@ -72,9 +72,8 @@ noncomputable def cyclicRestrictES {N : ℕ} (hN : 0 < N) (L : ℕ) (i : Fin N)
 /-- One positive summand in the future averaged `EuclideanSpace` formula for a
 local parent-Hamiltonian term.
 
-This is the conjugate `Rᵢ,τ† P_L Rᵢ,τ` of the local orthogonal projector
-`P_L = parentInteractionES A L` by the transported cyclic restriction map
-`Rᵢ,τ = cyclicRestrictES hN L i τ`. -/
+This is the conjugate \(R_{i,\tau}^\dagger P_L R_{i,\tau}\) of the local
+orthogonal projector \(P_L\) by the transported cyclic restriction map \(R_{i,\tau}\). -/
 noncomputable def localTermESSummand {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
     (L : ℕ) (i : Fin N) (τ : Fin N → Fin d) :
     EuclideanSpace ℂ (Cfg d N) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d N) :=
@@ -82,7 +81,8 @@ noncomputable def localTermESSummand {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
     parentInteractionES A L ∘ₗ
     cyclicRestrictES (d := d) hN L i τ
 
-/-- Each conjugated cyclic-restriction summand `Rᵢ,τ† P_L Rᵢ,τ` is positive. -/
+/-- Each conjugated cyclic-restriction summand \(R_{i,\tau}^\dagger P_L R_{i,\tau}\)
+is positive. -/
 theorem localTermESSummand_isPositive {N : ℕ} (A : MPSTensor d D) (hN : 0 < N)
     (L : ℕ) (i : Fin N) (τ : Fin N → Fin d) :
     (localTermESSummand A hN L i τ).IsPositive := by
@@ -107,10 +107,10 @@ noncomputable def localTermES {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N
   let e := (WithLp.linearEquiv 2 ℂ (NSiteSpace d N))
   e.symm.toLinearMap.comp ((localTerm A L N i).comp e.toLinearMap)
 
-/-- Site-disjointness for two cyclic `L`-windows on an `N`-site periodic chain.
+/-- Site-disjointness for two cyclic \(L\)-windows on an \(N\)-site periodic chain.
 
-The window starting at `i` contains exactly the sites whose cyclic offset from `i`
-is `< L`.  Thus `CyclicWindowsDisjoint L i j` says that no site has offset `< L`
+The window starting at \(i\) contains exactly the sites whose cyclic offset from \(i\)
+is \(< L\).  Thus `CyclicWindowsDisjoint L i j` says that no site has offset \(< L\)
 from both starting points.  This is the non-overlap condition used by the
 finite-overlap martingale reduction. -/
 def CyclicWindowsDisjoint {N : ℕ} (L : ℕ) (i j : Fin N) : Prop :=
@@ -401,7 +401,7 @@ private theorem cyclicRestrictES_localTermES {N : ℕ} (A : MPSTensor d D) {L : 
   rw [← hrestrict, hextract]
 
 /-- A transported local term vanishes exactly when every boundary-filled cyclic
-restriction to its window lies in the `L`-site MPS ground space. -/
+restriction to its window lies in the \(L\)-site MPS ground space. -/
 theorem localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES {N : ℕ}
     (A : MPSTensor d D) {L : ℕ} (hLN : L ≤ N) (i : Fin N)
     (v : EuclideanSpace ℂ (Cfg d N)) :
@@ -467,8 +467,8 @@ private theorem restrictFirst_eq_cyclicRestrictES_one {L : ℕ} (hL : 0 < L)
 
 /-- Forward local intersection property for adjacent Euclidean-space local terms.
 
-On an `(L+1)`-site chain, if the two overlapping `L`-site local terms based at
-`0` and `1` both annihilate a vector, then the vector lies in the `(L+1)`-site
+On an \((L+1)\)-site chain, if the two overlapping \(L\)-site local terms based at
+`0` and `1` both annihilate a vector, then the vector lies in the \((L+1)\)-site
 MPS ground space.  This is the Euclidean/local-projector form of the
 open-chain intersection property `groundSpace_intersection`; it is a structural
 predecessor to the quantitative principal-angle estimate for overlapping
@@ -501,8 +501,8 @@ theorem mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero {A : MPSTensor d 
     groundSpace_intersection hA hL hLeft hRight
   exact (mem_groundSpaceES_iff A (L + 1) v).2 hψ
 
-/-- Vectors in the `(L+1)`-site MPS ground space are killed by the two adjacent
-`L`-site Euclidean-space local terms. -/
+/-- Vectors in the \((L+1)\)-site MPS ground space are killed by the two adjacent
+\(L\)-site Euclidean-space local terms. -/
 theorem adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ
     (A : MPSTensor d D) {L : ℕ} (hL : 0 < L)
     {v : EuclideanSpace ℂ (Cfg d (L + 1))} (hv : v ∈ groundSpaceES A (L + 1)) :
@@ -525,7 +525,7 @@ theorem adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ
     rw [← restrictFirst_eq_cyclicRestrictES_one hL v τ]
     exact groundSpace_inRightGround A L hψ (τ 0)
 
-/-- Adjacent local kernels on an `(L+1)`-site chain intersect in the MPS ground
+/-- Adjacent local kernels on an \((L+1)\)-site chain intersect in the MPS ground
 space.  This restates the open-chain intersection property in the same
 Euclidean local-projector language used by the martingale proof. -/
 theorem adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ {A : MPSTensor d D}
@@ -583,7 +583,7 @@ private theorem sameOutsideWindow_card {N : ℕ} {L : ℕ} (hLN : L ≤ N)
     _ = d ^ L := by simp [Cfg]
 
 /-- The transported local term is the cyclic average of the positive Euclidean
-summands `Rᵢ,τ† P_L Rᵢ,τ`. -/
+summands \(R_{i,\tau}^\dagger P_L R_{i,\tau}\). -/
 theorem localTermES_eq_average_localTermESSummand {N : ℕ} (A : MPSTensor d D)
     {L : ℕ} (hLN : L ≤ N) (i : Fin N) :
     localTermES A L i =
@@ -656,7 +656,7 @@ private theorem isPositive_smul_of_real_re_nonneg {ι : Type*} [Fintype ι]
   exact mul_nonneg hc_re (hT.re_inner_nonneg_left x)
 
 /-- The transported local term is positive because it is a finite cyclic average
-of the positive summands `Rᵢ,τ† P_L Rᵢ,τ`. -/
+of the positive summands \(R_{i,\tau}^\dagger P_L R_{i,\tau}\). -/
 theorem localTermES_isPositive {N : ℕ} (A : MPSTensor d D) (L : ℕ) (i : Fin N) :
     (localTermES A L i).IsPositive := by
   by_cases hLN : L ≤ N
@@ -696,8 +696,8 @@ private theorem localTermES_isIdempotentElem {N : ℕ} (A : MPSTensor d D) (L : 
 
 This is the Euclidean-space version of the fact that the local term is the
 orthogonal projector onto the complement of the translated local ground space.
-For `L ≤ N`, idempotence follows by restricting to the cyclic window, applying
-the local projector `parentInteractionES`, and using `P_L^2 = P_L`; for `L > N`
+For \(L ≤ N\), idempotence follows by restricting to the cyclic window, applying
+the local projector `parentInteractionES`, and using \(P_L^2 = P_L\); for \(L > N\)
 the definition gives the zero projection. -/
 theorem localTermES_isSymmetricProjection {N : ℕ} (A : MPSTensor d D) (L : ℕ)
     (i : Fin N) : (localTermES A L i).IsSymmetricProjection :=
@@ -705,7 +705,7 @@ theorem localTermES_isSymmetricProjection {N : ℕ} (A : MPSTensor d D) (L : ℕ
 
 /-- Transported local terms on site-disjoint cyclic windows commute pointwise.
 
-If `L ≤ N` and no site belongs to both cyclic windows based at `i` and `j`, then
+If \(L ≤ N\) and no site belongs to both cyclic windows based at \(i\) and \(j\), then
 applying the two transported local ES terms in either order gives the same vector.
 This is the non-overlap commutation input for the finite-overlap martingale
 reduction. -/
@@ -760,9 +760,9 @@ theorem localTermES_commute_of_cyclic_windows_disjoint {N : ℕ} (A : MPSTensor 
 
 /-- Non-overlap positivity for Euclidean-space local terms on disjoint cyclic windows.
 
-For `L ≤ N`, if the cyclic windows based at `i` and `j` have no common site, then
+For \(L ≤ N\), if the cyclic windows based at \(i\) and \(j\) have no common site, then
 the ordered cross term of the corresponding Euclidean-space local projections is
-nonnegative: `0 ≤ Re ⟪h_i v, h_j v⟫`. -/
+nonnegative: \(0 ≤ \operatorname{Re}\langle h_i v, h_j v\rangle\). -/
 theorem localTermES_re_inner_nonneg_of_cyclic_windows_disjoint {N : ℕ}
     (A : MPSTensor d D) {L : ℕ} (hLN : L ≤ N) {i j : Fin N}
     (hij : CyclicWindowsDisjoint L i j) (v : EuclideanSpace ℂ (Cfg d N)) :
@@ -774,7 +774,7 @@ theorem localTermES_re_inner_nonneg_of_cyclic_windows_disjoint {N : ℕ}
 
 /-- Non-overlap positivity for the concrete cyclic-window overlap predicate.
 
-When `cyclicWindowsOverlap N L i j` fails and `L ≤ N`, the two windows are
+When `cyclicWindowsOverlap N L i j` fails and \(L ≤ N\), the two windows are
 site-disjoint, so the Euclidean-space local terms commute and have nonnegative ordered
 cross term. -/
 theorem localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap {N : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
@@ -16,11 +16,11 @@ open-chain restriction maps (`contiguousRestrictₗ`, `tailRestrictₗ`,
 aimed at the periodic-chain normal-form range-reduction argument
 (see [Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127,
 Section IV.C, lines 2049--2094]), where intermediate induction steps naturally produce
-states indexed by `K + 1 + L₀` that have to be viewed as states indexed by
-`K + (L₀ + 1)`, or states indexed by `N - (L₀ + 1) + (L₀ + 1)` that have to be
-viewed as states indexed by `N`.
+states indexed by \(K + 1 + L₀\) that have to be viewed as states indexed by
+\(K + (L₀ + 1)\), or states indexed by \(N - (L₀ + 1) + (L₀ + 1)\) that have to be
+viewed as states indexed by \(N\).
 
-Because `NSiteSpace d N = (Fin N → Fin d) → ℂ` depends definitionally on `N`,
+Because `NSiteSpace d N = (Fin N → Fin d) → ℂ` depends definitionally on \(N\),
 two states whose length-witnesses are propositionally but not definitionally
 equal cannot be compared directly. The canonical solution is to reindex via
 `Fin.cast`, which this file represents as a `LinearEquiv`.
@@ -28,19 +28,19 @@ equal cannot be compared directly. The canonical solution is to reindex via
 ## Main contents
 
 * `MPSTensor.reindexSites` — the linear equivalence
-  `NSiteSpace d M ≃ₗ[ℂ] NSiteSpace d N` induced by a proof `h : M = N`.
+  `NSiteSpace d M ≃ₗ[ℂ] NSiteSpace d N` induced by a proof \(h : M = N\).
 * `MPSTensor.reindexSites_groundSpaceMap` — reindexing commutes with
-  `groundSpaceMap`, so ground-space membership transports through `h`.
-* `MPSTensor.tailRestrictₗ_snoc` — pushing the last entry of a `(K+1)`-prefix
-  into the first suffix position, bridging `K + 1 + L` and `K + (L + 1)`.
+  `groundSpaceMap`, so ground-space membership transports through \(h\).
+* `MPSTensor.tailRestrictₗ_snoc` — pushing the last entry of a \((K+1)\)-prefix
+  into the first suffix position, bridging \(K + 1 + L\) and \(K + (L + 1)\).
 * `MPSTensor.tailRestrictₗ_reindex_prefix` /
   `MPSTensor.tailRestrictₗ_reindex_tail` — transport `tailRestrictₗ` under
   equalities of the prefix or tail length.
 * `MPSTensor.contiguousRestrictₗ_reindex_window` /
   `MPSTensor.contiguousRestrictₗ_reindex_total` — transport
   `contiguousRestrictₗ` under equalities of the window or total length.
-* `MPSTensor.tailRestrictₗ_reindex_of_le` — tail restriction of a state on `N`
-  sites through the identification `N = (N - L) + L`.
+* `MPSTensor.tailRestrictₗ_reindex_of_le` — tail restriction of a state on \(N\)
+  sites through the identification \(N = (N - L) + L\).
 
 ## References
 
@@ -57,7 +57,7 @@ variable {d D : ℕ}
 /-! ### Reindexing `NSiteSpace` along an equality of lengths -/
 
 /-- The linear equivalence between `NSiteSpace d M` and `NSiteSpace d N`
-induced by a proof `h : M = N`, reindexing configurations via `Fin.cast`. -/
+induced by a proof \(h : M = N\), reindexing configurations via `Fin.cast`. -/
 def reindexSites {d : ℕ} {M N : ℕ} (h : M = N) :
     NSiteSpace d M ≃ₗ[ℂ] NSiteSpace d N where
   toFun ψ σ := ψ (σ ∘ Fin.cast h)
@@ -104,12 +104,12 @@ theorem reindexSites_mem_groundSpace {A : MPSTensor d D} {M N : ℕ} (h : M = N)
 
 /-! ### Transport for `tailRestrictₗ` -/
 
-/-- Pushing the final entry of a `(K+1)`-prefix into the first suffix position.
-For `ψ : NSiteSpace d (K + 1 + L)`, the `(K+1)`-prefix `Fin.snoc u j` yields the
-same tail state as `restrictFirst` at `j` of the `K`-prefix `u` applied to the
-reindexed state in `NSiteSpace d (K + (L + 1))`.
+/-- Pushing the final entry of a \((K+1)\)-prefix into the first suffix position.
+For a state \(ψ\) on \(K + 1 + L\) sites, appending \(j\) to the prefix \(u\)
+yields the same tail state as `restrictFirst` at \(j\) of the \(K\)-prefix \(u\)
+applied to the reindexed state on \(K + (L + 1)\) sites.
 
-This is the key compatibility bridging `K + 1 + L₀` and `K + (L₀ + 1)` that
+This is the key compatibility bridging \(K + 1 + L₀\) and \(K + (L₀ + 1)\) that
 arises in the periodic normal-form range-reduction induction. -/
 theorem tailRestrictₗ_snoc {K L : ℕ} (u : Fin K → Fin d) (j : Fin d)
     (ψ : NSiteSpace d (K + 1 + L)) :
@@ -123,10 +123,9 @@ theorem tailRestrictₗ_snoc {K L : ℕ} (u : Fin K → Fin d) (j : Fin d)
   rw [Fin.append_right_cons]
   rfl
 
-/-- Transport `tailRestrictₗ` across an equality of prefix lengths `K = K'`:
-fixing the prefix `u : Fin K → Fin d` on a state in `NSiteSpace d (K + L)` is
-equivalent to fixing the pulled-back prefix on the reindexed state in
-`NSiteSpace d (K' + L)`. -/
+/-- Transport `tailRestrictₗ` across an equality of prefix lengths \(K = K'\):
+fixing the prefix `u : Fin K → Fin d` on a state with \(K + L\) sites is equivalent
+to fixing the pulled-back prefix on the reindexed state with \(K' + L\) sites. -/
 theorem tailRestrictₗ_reindex_prefix {K K' L : ℕ} (hK : K = K')
     (u : Fin K → Fin d) (ψ : NSiteSpace d (K + L)) :
     tailRestrictₗ u ψ =
@@ -134,7 +133,7 @@ theorem tailRestrictₗ_reindex_prefix {K K' L : ℕ} (hK : K = K')
         (reindexSites (congrArg (· + L) hK) ψ) := by
   subst hK; rfl
 
-/-- Transport `tailRestrictₗ` across an equality of tail lengths `L = L'`:
+/-- Transport `tailRestrictₗ` across an equality of tail lengths \(L = L'\):
 reindexing the target commutes with reindexing the source. -/
 theorem tailRestrictₗ_reindex_tail {K L L' : ℕ} (hL : L = L')
     (u : Fin K → Fin d) (ψ : NSiteSpace d (K + L)) :
@@ -143,8 +142,8 @@ theorem tailRestrictₗ_reindex_tail {K L L' : ℕ} (hL : L = L')
         (reindexSites (congrArg (K + ·) hL) ψ) := by
   subst hL; rfl
 
-/-- Tail restriction of a state on `N` sites through the identification
-`N = (N - L) + L`, which holds when `L ≤ N`. Useful when the periodic induction
+/-- Tail restriction of a state on \(N\) sites through the identification
+\(N = (N - L) + L\), which holds when \(L ≤ N\). Useful when the periodic induction
 splits a full chain at a boundary position and views what remains as a suffix
 window. -/
 theorem tailRestrictₗ_reindex_of_le {N L : ℕ} (hLN : L ≤ N)
@@ -159,7 +158,7 @@ theorem tailRestrictₗ_reindex_of_le {N L : ℕ} (hLN : L ≤ N)
 /-! ### Transport for `contiguousRestrictₗ` -/
 
 /-- Transport `contiguousRestrictₗ` across an equality of window lengths
-`M = M'`. -/
+\(M = M'\). -/
 theorem contiguousRestrictₗ_reindex_window
     {N : ℕ} {s M M' : ℕ} (hM : M = M') (hsM : s + M ≤ N) (hsM' : s + M' ≤ N)
     (τ : Fin N → Fin d) (ψ : NSiteSpace d N) :
@@ -168,7 +167,7 @@ theorem contiguousRestrictₗ_reindex_window
   subst hM; rfl
 
 /-- Transport `contiguousRestrictₗ` across an equality of total lengths
-`N = N'`: the state, the outside configuration, and both bounding proofs all
+\(N = N'\): the state, the outside configuration, and both bounding proofs all
 travel along `Fin.cast`. -/
 theorem contiguousRestrictₗ_reindex_total
     {N N' : ℕ} {s M : ℕ} (hN : N = N') (hsM : s + M ≤ N) (hsM' : s + M ≤ N')
@@ -178,8 +177,8 @@ theorem contiguousRestrictₗ_reindex_total
         (reindexSites hN ψ) := by
   subst hN; rfl
 
-/-- Fixing the first `K` sites of a contiguous `(K + L)`-window leaves the
-contiguous `L`-window that starts at `s + K`, with the fixed prefix inserted into
+/-- Fixing the first \(K\) sites of a contiguous \((K + L)\)-window leaves the
+contiguous \(L\)-window that starts at \(s + K\), with the fixed prefix inserted into
 the outside configuration. -/
 theorem tailRestrictₗ_contiguousRestrictₗ
     {N s K L : ℕ} (hsKL : s + (K + L) ≤ N)

--- a/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/SuffixWindow.lean
@@ -11,7 +11,7 @@ import Mathlib.Data.Fin.Tuple.Basic
 # Suffix-window restrictions for parent-Hamiltonian ground spaces
 
 This file introduces restriction maps obtained by fixing a prefix and reading the
-last `L` sites of a state on `K + L` sites. It states the resulting matrix
+last \(L\) sites of a state on \(K + L\) sites. It states the resulting matrix
 identities needed for the open-chain range-reduction argument in
 [Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127,
 Section IV.C, lines 2049--2094].
@@ -24,7 +24,7 @@ Section IV.C, lines 2049--2094].
 - `MPSTensor.groundSpace_inTailGround` — a ground-space state restricts to
   ground-space states on every suffix slice
 - `MPSTensor.exists_left_tail_compatibility` — extract matrices satisfying
-  `Z j * evalWord A (List.ofFn u) = A j * Y u`
+  \(Z_j A^u = A_j Y_u\)
 
 ## References
 
@@ -38,8 +38,8 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Suffix restriction: fixing a prefix `u : Fin K → Fin d` and keeping the last
-`L` sites of a state on `K + L` sites. -/
+/-- Suffix restriction: fixing a prefix \(u\) and keeping the last
+\(L\) sites of a state on \(K + L\) sites. -/
 def tailRestrictₗ {d K L : ℕ} (u : Fin K → Fin d) :
     NSiteSpace d (K + L) →ₗ[ℂ] NSiteSpace d L where
   toFun ψ := fun σ => ψ (Fin.append u σ)
@@ -64,8 +64,8 @@ restricting the last site and then fixing the prefix. -/
   simp only [restrictLast_apply, tailRestrictₗ_apply]
   rw [Fin.append_snoc]
 
-/-- Restricting a ground-space vector of length `L + 1` by fixing the last site
-produces the expected boundary matrix `A j * X`. -/
+/-- Restricting a ground-space vector of length \(L + 1\) by fixing the last site
+produces the expected boundary matrix \(A_j X\). -/
 @[simp] theorem restrictLast_groundSpaceMap (A : MPSTensor d D) {L : ℕ}
     (j : Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
     restrictLast (groundSpaceMap A (L + 1) X) j = groundSpaceMap A L (A j * X) := by
@@ -74,8 +74,8 @@ produces the expected boundary matrix `A j * X`. -/
   rw [evalWord_ofFn_snoc]
   simp [Matrix.mul_assoc]
 
-/-- Restricting a ground-space vector of length `L + 1` by fixing the first site
-produces the expected boundary matrix `X * A i`. -/
+/-- Restricting a ground-space vector of length \(L + 1\) by fixing the first site
+produces the expected boundary matrix \(X A_i\). -/
 @[simp] theorem restrictFirst_groundSpaceMap (A : MPSTensor d D) {L : ℕ}
     (i : Fin d) (X : Matrix (Fin D) (Fin D) ℂ) :
     restrictFirst (groundSpaceMap A (L + 1) X) i = groundSpaceMap A L (X * A i) := by
@@ -90,7 +90,7 @@ produces the expected boundary matrix `X * A i`. -/
     _ = Matrix.trace (evalWord A (List.ofFn σ) * (X * A i)) := by
           rw [Matrix.trace_mul_comm]
 
-/-- If the length-`L` word span is all of `M_D`, then `groundSpaceMap A L` is
+/-- If the length-\(L\) word span is all of \(M_D\), then `groundSpaceMap A L` is
 injective. -/
 theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ}
     (hwordL : wordSpan A L = ⊤) :
@@ -104,7 +104,7 @@ theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D} {L : ℕ
   have hXY' := congrArg (fun ψ => ψ (decodeBlock d L (σ 0))) hXY
   simpa [groundSpaceMap_apply, blockTensor, wordOfBlock, decodeBlock] using hXY'
 
-/-- Block injectivity at length `L` implies injectivity of `groundSpaceMap A L`. -/
+/-- Block injectivity at length \(L\) implies injectivity of `groundSpaceMap A L`. -/
 theorem groundSpaceMap_injective_of_isNBlkInjective {A : MPSTensor d D} {L : ℕ}
     (hInj : IsNBlkInjective A L) :
     Function.Injective (groundSpaceMap A L) :=
@@ -133,8 +133,8 @@ form, with the prefix word moved to the right boundary matrix by trace cyclicity
     _ = groundSpaceMap A L (X * evalWord A (List.ofFn u)) σ := by
           simp [groundSpaceMap_apply]
 
-/-- A state on `K + L` sites lies in the tail ground condition if every fixed
-prefix gives an `L`-site ground-space vector. -/
+/-- A state on \(K + L\) sites lies in the tail ground condition if every fixed
+prefix gives an \(L\)-site ground-space vector. -/
 def InTailGround (A : MPSTensor d D) (K L : ℕ) (ψ : NSiteSpace d (K + L)) : Prop :=
   ∀ u : Fin K → Fin d, tailRestrictₗ u ψ ∈ groundSpace A L
 
@@ -151,7 +151,7 @@ theorem groundSpace_inTailGround (A : MPSTensor d D) (K L : ℕ)
 
 /-- From the long left-window condition and the suffix-window condition, extract
 boundary matrices satisfying the common overlap identity
-`Z j * evalWord A (List.ofFn u) = A j * Y u`. -/
+\(Z_j A^u = A_j Y_u\). -/
 theorem exists_left_tail_compatibility {A : MPSTensor d D} {K L₀ : ℕ}
     (hInj : IsNBlkInjective A L₀) {ψ : NSiteSpace d (K + L₀ + 1)}
     (hLeft : InLeftGround A (K + L₀) ψ)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -12,9 +12,9 @@ import TNLean.MPS.ParentHamiltonian.RestrictTransport
 /-!
 # Unique ground state for injective MPS parent Hamiltonians
 
-For an injective MPS tensor `A` on a periodic chain, the expected parent-Hamiltonian
+For an injective MPS tensor \(A\) on a periodic chain, the expected parent-Hamiltonian
 ground space is spanned by the MPS vector
-`σ ↦ tr(A^{σ₀} ⋯ A^{σ_{N-1}})`.
+\(\sigma \mapsto \operatorname{tr}(A^{\sigma_0} \cdots A^{\sigma_{N-1}})\).
 
 ## Overview
 
@@ -79,10 +79,10 @@ variable {d D : ℕ}
 /-! ### The MPS submodule -/
 
 /-- The submodule spanned by the MPS vector.
-
-On the periodic chain, the MPS vector is `σ ↦ tr(A^{σ₀} ⋯ A^{σ_{N-1}})`,
+On the periodic chain, the MPS vector is
+\(\sigma \mapsto \operatorname{tr}(A^{\sigma_0} \cdots A^{\sigma_{N-1}})\),
 which corresponds to the ground-space map applied to the identity:
-`mpv A = groundSpaceMap A N 1`. -/
+\(V^{(N)}(A)=Γ_N(1)\). -/
 noncomputable def mpvSubmodule (A : MPSTensor d D) (N : ℕ) :
     Submodule ℂ (NSiteSpace d N) :=
   Submodule.span ℂ {mpv A}
@@ -93,7 +93,7 @@ theorem mpv_eq_groundSpaceMap_one (A : MPSTensor d D) (N : ℕ) :
   ext σ
   simp [mpv, coeff, groundSpaceMap_apply]
 
-/-- The MPS vector lies in the ground space `G_N(A)` for any `N`. -/
+/-- The MPS vector lies in the ground space \(G_N(A)\) for any \(N\). -/
 theorem mpv_mem_groundSpace (A : MPSTensor d D) (N : ℕ) :
     (mpv A : NSiteSpace d N) ∈ groundSpace A N := by
   rw [groundSpace, LinearMap.mem_range]
@@ -101,18 +101,18 @@ theorem mpv_mem_groundSpace (A : MPSTensor d D) (N : ℕ) :
 
 /-! ### Periodic chain ground space
 
-On a periodic chain of `N` sites, the ground space of the parent Hamiltonian
-is the set of states whose restriction to every cyclic window of `L` consecutive
-sites lies in `G_L(A)`.
+On a periodic chain of \(N\) sites, the ground space of the parent Hamiltonian
+is the set of states whose restriction to every cyclic window of \(L\) consecutive
+sites lies in \(G_L(A)\).
 
 For the nondegenerate regime used below, this is the intersection of all cyclic
 window constraints. The subsequent theorems state their nondegeneracy assumptions
 explicitly. -/
 
-/-- The periodic chain ground space: the set of states `ψ` on `N` sites such
-that every cyclic window of `L` consecutive sites restricts into `G_L(A)`.
+/-- The periodic chain ground space: the set of states \(ψ\) on \(N\) sites such
+that every cyclic window of \(L\) consecutive sites restricts into \(G_L(A)\).
 
-When `N = 0` or `L > N`, we return `⊤` as a degenerate convention. -/
+When \(N = 0\) or \(L > N\), we return \(\top\) as a degenerate convention. -/
 noncomputable def chainGroundSpace (A : MPSTensor d D) (L N : ℕ) :
     Submodule ℂ (NSiteSpace d N) :=
   if hN : 0 < N ∧ L ≤ N then
@@ -122,9 +122,9 @@ noncomputable def chainGroundSpace (A : MPSTensor d D) (L N : ℕ) :
 
 /-- The MPS vector is in the chain ground space.
 
-The proof uses trace cyclicity: for each cyclic window at position `i`, the
+The proof uses trace cyclicity: for each cyclic window at position \(i\), the
 restriction of the MPS vector to that window equals `groundSpaceMap A L X_τ` where
-`X_τ` is the product of `A`-matrices at outside positions. The cyclic list
+\(X_\tau\) is the product of \(A\)-matrices at outside positions. The cyclic list
 verification follows from the window-level membership calculation. -/
 theorem mpv_mem_chainGroundSpace (A : MPSTensor d D) (L N : ℕ)
     (hN : 0 < N) (hLN : L ≤ N) :
@@ -262,7 +262,7 @@ private theorem neZero_d_of_isNBlkInjective [NeZero D]
 
 /-- Open-chain intersection property for block-injective tensors.
 
-If all contiguous windows of size `L₀ + 1` lie in the corresponding MPS ground
+If all contiguous windows of size \(L₀ + 1\) lie in the corresponding MPS ground
 space, then the full open chain lies in `groundSpace A N`.  This is the
 chain-level iteration of the inverting and growing-back argument in
 arXiv:2011.12127, Section IV.C. -/
@@ -325,7 +325,7 @@ theorem contiguous_mem_groundSpace_of_isNBlkInjective
 block-injective tensors.
 
 This combines cyclic window monotonicity (peeling longer cyclic windows down to
-`L₀ + 1`), the non-wrapping cyclic/contiguous identification, and the open-chain
+\(L₀ + 1\)), the non-wrapping cyclic/contiguous identification, and the open-chain
 closure-property argument for block-injective tensors. It stops at open-chain
 membership; the boundary-closing scalarity step remains separate. -/
 theorem chainGroundSpace_le_groundSpace_of_isNBlkInjective
@@ -372,7 +372,7 @@ private theorem eq_zero_of_trace_evalWord_mul_eq_zero {A : MPSTensor d D}
 /-! ### Uniqueness theorems -/
 
 /-- On a periodic chain, the injective parent-Hamiltonian ground space
-coincides with `ℂ V^{(N)}(A)` when the window size satisfies `L ≥ 2`.
+coincides with \(ℂ V^{(N)}(A)\) when the window size satisfies \(L ≥ 2\).
 
 For injective tensors, the open-chain intersection argument requires only
 a window of at least `2` sites. -/
@@ -491,7 +491,7 @@ theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
   exact ⟨YAt wrapPos, YAt mirrorPos, hWrap, hMirror⟩
 
 /-- Long-word commutation is enough to place an open-chain boundary vector in
-`ℂ V^{(N)}(A)`.
+\(ℂ V^{(N)}(A)\).
 
 After the reduced cyclic-window compatibilities at the boundary have been converted into a
 family of identities \(XA^\omega=A^\omega X\) for one word length \(m \ge L₀\),

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -17,8 +17,8 @@ injective MPS tensor on a periodic chain.
 
 ## Proof strategy
 
-On a periodic chain of `N` sites with window size `L`, the boundary-crossing
-cyclic window starts at position `N-1` and contains the first `L-1` sites. The proof
+On a periodic chain of \(N\) sites with window size \(L\), the boundary-crossing
+cyclic window starts at position \(N-1\) and contains the first \(L-1\) sites. The proof
 proceeds as follows:
 
 1. At the boundary-crossing position \(N-1\), the cyclic configuration separates into
@@ -65,9 +65,9 @@ the spanning step used in the periodic boundary-closure argument:
 
 > **Vector-to-matrix spanning step (arXiv:0909.5347, Lemma 2(a) / Wolf Chapter 6).**
 > If the vector-valued images of Kraus word products span the full vector space
-> `ℂ^D`, then the matrix-valued word products span the full matrix
-> algebra `M_D(ℂ)`.  Concretely: `span{A_w v} = ℂ^D` for all `v ≠ 0` implies
-> `span{A_w} = M_D(ℂ)`.
+> \(ℂ^D\), then the matrix-valued word products span the full matrix
+> algebra \(M_D(ℂ)\).  Concretely: \(\operatorname{span}\{A_w v\} = \mathbb C^D\)
+> for all \(v \ne 0\) implies \(\operatorname{span}\{A_w\} = M_D(\mathbb C)\).
 
 In MPS notation after blocking: for an injective tensor \(A\), the Kraus word
 products of length \(L-1\) span \(M_D(\mathbb C)\).
@@ -84,10 +84,11 @@ variable {d D : ℕ}
 
 /-! ### Cyclic config decomposition at the wrapping position
 
-These lemmas analyze the structure of `cyclicCfg` at position `N-1`,
+These lemmas analyze the structure of `cyclicCfg` at position \(N-1\),
 where the window wraps from the last site back to the first sites. -/
 
-/-- At the wrapping position `N-1`, the cyclic config's last site is `σ_w 0`. -/
+/-- At the wrapping position \(N-1\), the cyclic config's last site is
+\(\sigma_w(0)\). -/
 private theorem cyclicCfg_last_eq {N L : ℕ} (hN : 2 ≤ N) (hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d) :
     cyclicCfg (by omega : 0 < N) L ⟨N - 1, by omega⟩ σ_w τ ⟨N - 1, by omega⟩ =
@@ -99,7 +100,8 @@ private theorem cyclicCfg_last_eq {N L : ℕ} (hN : 2 ≤ N) (hLN : L ≤ N) (hL
   rw [dif_pos (show ((N - 1) + N - (N - 1)) % N < L by rw [hoffset]; omega)]
   congr 1; ext; simp
 
-/-- At the wrapping position `N-1`, sites `0..L-2` get `σ_w(1)..σ_w(L-1)`. -/
+/-- At the wrapping position \(N-1\), sites \(0,\ldots,L-2\) get
+\(\sigma_w(1),\ldots,\sigma_w(L-1)\). -/
 private theorem cyclicCfg_window_site {N L : ℕ} (hN : 2 ≤ N) (_hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d)
     {k : ℕ} (hk : k < L - 1) :
@@ -112,7 +114,7 @@ private theorem cyclicCfg_window_site {N L : ℕ} (hN : 2 ≤ N) (_hLN : L ≤ N
   rw [dif_pos (show (k + N - (N - 1)) % N < L by rw [hoffset]; omega)]
   congr 1; ext; simp [hoffset]
 
-/-- At the wrapping position `N-1`, complement sites get τ values. -/
+/-- At the wrapping position \(N-1\), complement sites get \(\tau\) values. -/
 private theorem cyclicCfg_complement_site {N L : ℕ} (hN : 2 ≤ N) (_hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d)
     {k : ℕ} (hk1 : L - 1 ≤ k) (hk2 : k < N - 1) :
@@ -126,11 +128,12 @@ private theorem cyclicCfg_complement_site {N L : ℕ} (hN : 2 ≤ N) (_hLN : L �
 
 /-! ### Snoc factorization
 
-Factor the full cyclic config product as `evalWord(init) * A(σ_w(0))`,
-then split `init` into window-tail and complement parts. -/
+Factor the full cyclic configuration product as \(A^{\mathrm{init}} A_{\sigma_w(0)}\),
+then split \(\mathrm{init}\) into window-tail and complement parts. -/
 
-/-- The evalWord of the cyclic config at position `M` on `M+1` sites
-decomposes as `evalWord(init) * A(σ_w(0))` where `init` covers sites `0..M-1`. -/
+/-- The word product along the cyclic configuration at position \(M\) on \(M+1\) sites
+decomposes as \(A^{\mathrm{init}} A_{\sigma_w(0)}\), where \(\mathrm{init}\) covers
+sites \(0,\ldots,M-1\). -/
 theorem evalWord_cyclicCfg_snoc {A : MPSTensor d D}
     {M L : ℕ} (hM : 1 ≤ M) (hLN : L ≤ M + 1) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin (M + 1) → Fin d) :
@@ -184,7 +187,7 @@ theorem init_evalWord_split {A : MPSTensor d D}
       simp only [List.length_ofFn]
       have hcomp := cyclicCfg_complement_site (by omega : 2 ≤ M + 1) hLN hL σ_w τ
         (show L - 1 ≤ k from by omega) (show k < M from by omega)
-      -- hcomp is about cyclicCfg ... ⟨k, _⟩, we need it about Fin.castSucc ⟨k, _⟩
+      -- hcomp is about cyclicCfg at the original index; use Fin.castSucc ⟨k, _⟩.
       have : (Fin.castSucc (⟨k, by omega⟩ : Fin M) : Fin (M + 1)) =
           ⟨k, by omega⟩ := by ext; simp [Fin.castSucc]
       rw [this] at *
@@ -200,13 +203,13 @@ theorem init_evalWord_split {A : MPSTensor d D}
 
 /-! ### Mirror factorization at the opposite wrapped position
 
-At the wrapped position `N - L + 1`, the cyclic word starts with the last window
+At the wrapped position \(N - L + 1\), the cyclic word starts with the last window
 site, then runs through the complement, then finishes with the remaining
-`L - 1` window sites.  This yields the factorization needed for the mirror
+\(L - 1\) window sites.  This yields the factorization needed for the mirror
 block-injective extraction. -/
 
-/-- At the opposite wrapped position `N - L + 1`, site `0` carries the final
-window entry `σ_w(L-1)`. -/
+/-- At the opposite wrapped position \(N - L + 1\), site \(0\) carries the final
+window entry \(\sigma_w(L-1)\). -/
 private theorem cyclicCfg_mirror_zero_eq {N L : ℕ} (hN : 2 ≤ N) (hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d) :
     cyclicCfg (by omega : 0 < N) L ⟨N - L + 1, by omega⟩ σ_w τ ⟨0, by omega⟩ =
@@ -223,8 +226,8 @@ private theorem cyclicCfg_mirror_zero_eq {N L : ℕ} (hN : 2 ≤ N) (hLN : L ≤
   ext
   exact hoffset
 
-/-- At the opposite wrapped position `N - L + 1`, the complement sites
-`1, ..., N - L` keep their `τ` values. -/
+/-- At the opposite wrapped position \(N - L + 1\), the complement sites
+\(1,\ldots,N-L\) keep their \(\tau\) values. -/
 private theorem cyclicCfg_mirror_complement_site {N L : ℕ}
     (hN : 2 ≤ N) (_hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d)
@@ -237,8 +240,8 @@ private theorem cyclicCfg_mirror_complement_site {N L : ℕ}
     rw [this, Nat.mod_eq_of_lt (by omega)]
   rw [dif_neg (show ¬((k + N - (N - L + 1)) % N < L) by rw [hoffset]; omega)]
 
-/-- At the opposite wrapped position `N - L + 1`, the final `L - 1` physical
-sites carry the first `L - 1` entries of the window. -/
+/-- At the opposite wrapped position \(N - L + 1\), the final \(L - 1\) physical
+sites carry the first \(L - 1\) entries of the window. -/
 private theorem cyclicCfg_mirror_window_site {N L : ℕ}
     (hN : 2 ≤ N) (_hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d)
@@ -254,9 +257,9 @@ private theorem cyclicCfg_mirror_window_site {N L : ℕ}
   rw [dif_pos (show (N - L + 1 + k + N - (N - L + 1)) % N < L by rw [hoffset]; omega)]
   congr 1; ext; simp [hoffset]
 
-/-- At the opposite wrapped position `N - L + 1`, the cyclic word factors as
+/-- At the opposite wrapped position \(N - L + 1\), the cyclic word factors as
 the final window letter, then the complement word, then the remaining
-`L - 1`-site window head. -/
+\((L - 1)\)-site window head. -/
 private theorem evalWord_cyclicCfg_cons {A : MPSTensor d D}
     {M L : ℕ} (hM : 1 ≤ M) (hLN : L ≤ M + 1) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin (M + 1) → Fin d) :
@@ -316,7 +319,8 @@ private theorem evalWord_cyclicCfg_cons {A : MPSTensor d D}
 
 /-! ### Trace rotation and matrix equation extraction
 
-Use `tr(P * Q) = tr(Q * P)` to rotate across the periodic boundary,
+Use \(\operatorname{tr}(P \cdot Q) = \operatorname{tr}(Q \cdot P)\) to rotate
+across the periodic boundary,
 then extract a matrix equation via `groundSpaceMap_injective`. -/
 
 set_option maxHeartbeats 800000 in
@@ -396,7 +400,7 @@ private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
   exact key
 
 /-- Block injectivity strips the cyclic-window tail block at the boundary and
-yields the one-sided compatibility `C_τ * A j * X = Y_τ * A j`. The
+yields the one-sided compatibility \(C_τ A_j X = Y_τ A_j\). The
 complementary opposite cyclic-window comparison is the remaining local step
 needed for the two-sided relation. -/
 theorem wrapping_window_compatibility_of_isNBlkInjective
@@ -444,8 +448,8 @@ theorem wrapping_window_compatibility_of_isNBlkInjective
           simp [Matrix.mul_assoc]
 
 /-- The opposite cyclic position used in the closure property exposes the
-compatibility `X * A j * C_τ = A j * Y_τ` after block-injective stripping of the
-trailing `L₀`-site block. -/
+compatibility \(X A_j C_τ = A_j Y_τ\) after block-injective stripping of the
+trailing \(L₀\)-site block. -/
 theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -541,8 +545,8 @@ with the same word \(\mu\) on complementary sites and the same matrix
 word on the complementary sites.
 
 For the wrapped window at the last site, the complement occupies physical sites
-`L₀, ..., N - 2`.  This construction fills exactly those sites with `μ`; the
-remaining sites receive the letter `η` and do not affect the complement word
+\(L₀, \ldots, N - 2\).  This construction fills exactly those sites with \(\mu\); the
+remaining sites receive the letter \(\eta\) and do not affect the complement word
 extracted by the wrapped boundary identity. -/
 def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
@@ -556,8 +560,8 @@ def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
 word on the complementary sites.
 
 For the opposite wrapped window, the complement occupies physical sites
-`1, ..., N - L₀ - 1`.  This construction fills exactly those sites with `μ`; all
-other sites receive the letter `η`. -/
+\(1, \ldots, N - L₀ - 1\).  This construction fills exactly those sites with \(\mu\); all
+other sites receive the letter \(\eta\). -/
 def mirrorMiddleBackground (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
   fun i =>
@@ -638,9 +642,9 @@ with every word obtained by adjoining one physical letter on each side.
 
 This is the algebraic core of the remaining normal parent-Hamiltonian closure
 property: after the two cyclic windows have been compared so that their matrices
-agree on a shared complement `μ`, the identities `A^μ A^b X = Y_μ A^b` and
-`X A^a A^μ = A^a Y_μ` imply
-`X A^a A^μ A^b = A^a A^μ A^b X`. -/
+agree on a shared complement \(\mu\), the identities \(A^μ A^b X = Y_μ A^b\) and
+\(X A^a A^μ = A^a Y_μ\) imply
+\(X A^a A^μ A^b = A^a A^μ A^b X\). -/
 theorem commutes_words_of_two_sided_middle_compatibility
     {A : MPSTensor d D} {m : ℕ} {X : Matrix (Fin D) (Fin D) ℂ}
     (Y : (Fin m → Fin d) → Matrix (Fin D) (Fin D) ℂ)
@@ -675,7 +679,7 @@ theorem commutes_words_of_two_sided_middle_compatibility
 /-- If \(X\) commutes with all words of a fixed length \(m\), then it commutes
 with all words whose length is any multiple of \(m\).
 
-The proof chunks a list of length `q * m` into a length-`m` prefix and a shorter
+The proof chunks a list of length \(q * m\) into a length-\(m\) prefix and a shorter
 multiple-length suffix. This formalizes the amplification step that promotes
 fixed-length commutation to the long-word commutation hypothesis required by
 the block-injective boundary-contraction theorem. -/
@@ -734,7 +738,7 @@ theorem commutes_words_mul_of_commutes_words {A : MPSTensor d D}
 
 Extend from the boundary-crossing equation to full commutation via spanning. -/
 
-/-- If a boundary matrix commutes with all words of some length `m ≥ L₀`, then
+/-- If a boundary matrix commutes with all words of some length \(m ≥ L₀\), then
 block injectivity forces it to commute with every generator. -/
 theorem boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
     {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -746,12 +750,12 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
   exact commutes_all_of_commutes_long_words_of_isNBlkInjective
     (A := A) hInj hL₀ hm hComm (A j)
 
-/-- If left multiplication by `Z` annihilates every word product of length `k`,
-and words of some longer length `n` span the full matrix algebra, then `Z = 0`.
+/-- If left multiplication by \(Z\) annihilates every word product of length \(k\),
+and words of some longer length \(n\) span the full matrix algebra, then \(Z = 0\).
 
 This is the padding form needed in the normal boundary-closing argument: a
 zero-product relation obtained for a short complement word can be multiplied by
-all padding words up to any length whose exact word span is `⊤`. -/
+all padding words up to any length whose exact word span is \(\top\). -/
 theorem eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top
     {A : MPSTensor d D} {k n : ℕ} {Z : Matrix (Fin D) (Fin D) ℂ}
     (htop : wordSpan A n = ⊤) (hkn : k ≤ n)
@@ -792,9 +796,9 @@ theorem eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top
 /-- Block-injective padding variant of
 `eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top`.
 
-If `A` is `L₀`-block-injective, then every positive multiple of `L₀` has full
-word span. Hence a zero-product relation at length `k` already forces `Z = 0`
-as soon as `k` is bounded by such a multiple. -/
+If \(A\) is \(L₀\)-block-injective, then every positive multiple of \(L₀\) has full
+word span. Hence a zero-product relation at length \(k\) already forces \(Z = 0\)
+as soon as \(k\) is bounded by such a multiple. -/
 theorem eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
     {A : MPSTensor d D} {L₀ k q : ℕ} (hInj : IsNBlkInjective A L₀)
     (hq : 1 ≤ q) (hkq : k ≤ q * L₀) {Z : Matrix (Fin D) (Fin D) ℂ}
@@ -881,7 +885,7 @@ then \(X\) commutes with all generators \(A_j\).
 
 This is the key step in the periodic-chain uniqueness argument: the
 boundary-crossing local condition forces the boundary matrix into the center of
-the algebra generated by `{A_j}`. -/
+the algebra generated by \(\{A_j\}\). -/
 theorem boundary_matrix_commutes {A : MPSTensor d D} [NeZero D]
     (hA : IsInjective A) {L N : ℕ} (hN : 2 ≤ N) (hL : 1 < L) (hLN : L ≤ N)
     {X : Matrix (Fin D) (Fin D) ℂ}

--- a/docs/prose_style.md
+++ b/docs/prose_style.md
@@ -119,6 +119,9 @@ without opening the `.lean` files, the prose has failed.
 ### Allowed in Lean docstrings
 
 - Mathematical descriptions of what the declaration means.
+- In migrated docstring regions (currently `TNLean/MPS/ParentHamiltonian`),
+  inline mathematical expressions should use `\(...\)`, not backtick code spans.
+  Reserve backticks for genuine Lean references.
 - Backticks around genuine Lean references (e.g. ``` `Fin d` ```, ``` `evalWord` ```)
   when explaining how to use the API of *this* declaration. Use sparingly — prefer
   mathematical phrasing.

--- a/scripts/check_reader_facing_prose.py
+++ b/scripts/check_reader_facing_prose.py
@@ -16,6 +16,57 @@ ISSUE_REF_RE = re.compile(
     r"(?i)(?:issues?\s*)?#\d+(?:/#\d+)*|issues?\s*\\#\d+(?:/\\#\d+)*|"
     r"Issue~\\#\d+|https://github\.com/[^\s}]+/issues/\d+"
 )
+LEAN_CODE_SPAN_RE = re.compile(r"`([^`\n]+)`")
+LEAN_PATH_LIKE_CODE_SPAN_RE = re.compile(
+    r"^(?:\.?/)?(?:TNLean|docs|blueprint|scripts|Papers|Notes|\.github|\.lake)/"
+    r"|^(?!\d+\.\.)[\w./-]+\.[A-Za-z][\w-]*$"
+)
+LATEX_MATH_MACROS = (
+    r"le|ge|lt|gt|ne|sum|prod|ker|operatorname|mathrm|mathbb|mathcal|span|"
+    r"tr|alpha|beta|gamma|delta|epsilon|varepsilon|zeta|eta|theta|vartheta|"
+    r"iota|kappa|lambda|mu|nu|xi|pi|rho|sigma|tau|upsilon|phi|varphi|chi|"
+    r"psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega|"
+    r"partial|in|subset|otimes|perp|circ|top|bot|implies|to|iff"
+)
+LEAN_MATH_CODE_SPAN_TRIGGER_RE = re.compile(
+    r"[≤≥<>≠=+\-*/^²³¹⁻₀₁₂₃₄₅₆₇₈₉ᵢⱼᵏᵐⁿ∘⊗∑∏·"
+    r"αβγδεζηθικλμνξοπρστυφχψω"
+    r"ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ"
+    r"∂∈∉⊆⊂∪∩∖‖⟪⟫ᗮ⊤⊥⟹⇒→↔]"
+    rf"|\\(?:{LATEX_MATH_MACROS})\b"
+    r"|\b[A-Za-z]_[A-Za-z0-9α-ωΑ-Ω]"
+    r"|\b[A-Za-zα-ωΑ-Ω][A-Za-z0-9α-ωΑ-Ω]*_\{[A-Za-z0-9α-ωΑ-Ω]+\}"
+)
+LEAN_SYMBOLIC_SUBSCRIPT_TOKEN_RE = re.compile(
+    r"[A-Za-z]_(?:[A-Za-z0-9α-ωΑ-Ω]|[α-ωΑ-Ω][A-Za-z0-9α-ωΑ-Ω]*|[A-Z0-9]{2,})"
+)
+LEAN_SYMBOLIC_SCRIPT_TOKEN_RE = re.compile(
+    r"[A-Za-zα-ωΑ-Ω][₀₁₂₃₄₅₆₇₈₉ᵢⱼᵏᵐⁿ⁰¹²³⁴⁵⁶⁷⁸⁹¹²³⁻]+"
+)
+LEAN_IDENTIFIER = (
+    r"[A-Za-z_α-ωΑ-Ω]"
+    r"[A-Za-z0-9_'.α-ωΑ-Ω₀₁₂₃₄₅₆₇₈₉"
+    r"⁰¹²³⁴⁵⁶⁷⁸⁹ᵢⱼᵏᵐⁿ]*"
+)
+LEAN_NAMED_ARG_CONTENT_RE = re.compile(rf"{LEAN_IDENTIFIER}\s*:=\s*(?:{LEAN_IDENTIFIER}|\d+)")
+LEAN_NAMED_ARG = rf"\(\s*{LEAN_IDENTIFIER}\s*:=\s*(?:{LEAN_IDENTIFIER}|\d+)\s*\)"
+LEAN_PAREN_ARG = r"\([^=≤≥<>≠ᗮ⊤⊥]*\)"
+LEAN_APPLIED_REFERENCE_RE = re.compile(
+    rf"^{LEAN_IDENTIFIER}(?:\s+(?:{LEAN_IDENTIFIER}|\d+|{LEAN_NAMED_ARG}|"
+    rf"{LEAN_PAREN_ARG}))*$"
+)
+LEAN_PAREN_ARG_RE = re.compile(r"\(([^()]*)\)")
+LEAN_PAREN_FORMULA_TRIGGER_RE = re.compile(
+    r"[≤≥<>≠=+\-*/^∘⊗∑∏·∈∉⊆⊂∪∩∖‖⟪⟫ᗮ⊤⊥⟹⇒→↔]"
+    rf"|\\(?:{LATEX_MATH_MACROS})\b"
+)
+LEAN_TYPE_CONSTRUCTOR_RE = re.compile(
+    r"\b(?:NSiteSpace|EuclideanSpace|WithLp|Cfg|Fin|Matrix|Submodule|Type|Prop)\b"
+)
+LEAN_TYPE_ATOM = rf"(?:{LEAN_IDENTIFIER}|\([^()\n]+\))"
+LEAN_GENERIC_ARROW_TYPE_RE = re.compile(
+    rf"^{LEAN_TYPE_ATOM}(?:\s*(?:→ₗ\[[^\]\n]+\]|→)\s*{LEAN_TYPE_ATOM})+$"
+)
 BLUEPRINT_LABEL_TEXTTT_RE = re.compile(r"\\texttt\{(?:thm|lem|def|prop|cor|eq):[^}]*\}")
 IGNORED_TEX_MACRO_RE = re.compile(r"\\(?:label|ref|eqref|uses|lean)\{[^}]*\}")
 BLUEPRINT_ENTRYPOINTS = {
@@ -160,12 +211,70 @@ def normalized_tex_prose(text: str) -> str:
     return IGNORED_TEX_MACRO_RE.sub("", strip_tex_comment(text))
 
 
-def check_lean_line(path: Path, line_no: int, text: str) -> Finding | None:
+def is_backtick_math(span: str) -> bool:
+    """Whether a Lean comment code span is mathematical notation, not an identifier."""
+    if LEAN_PATH_LIKE_CODE_SPAN_RE.search(span):
+        return False
+    if span.startswith("*") or span.endswith("*"):
+        return False
+    has_math_trigger = LEAN_MATH_CODE_SPAN_TRIGGER_RE.search(span) is not None
+    if not has_math_trigger:
+        return False
+    if is_lean_type_expression_code_span(span):
+        return False
+    tokens = span.split()
+    applied_reference = LEAN_APPLIED_REFERENCE_RE.fullmatch(span) is not None
+    if len(tokens) > 1 and applied_reference:
+        if any(
+            not LEAN_NAMED_ARG_CONTENT_RE.fullmatch(arg.strip())
+            and LEAN_PAREN_FORMULA_TRIGGER_RE.search(arg)
+            for arg in LEAN_PAREN_ARG_RE.findall(span)
+        ):
+            return True
+        return False
+    if any(
+        LEAN_SYMBOLIC_SUBSCRIPT_TOKEN_RE.fullmatch(token)
+        or LEAN_SYMBOLIC_SCRIPT_TOKEN_RE.fullmatch(token)
+        for token in tokens
+    ):
+        return True
+    if applied_reference:
+        return False
+    return True
+
+
+def is_lean_type_expression_code_span(span: str) -> bool:
+    """Whether a code span is a Lean type expression rather than mathematical notation."""
+    if re.search(r"[{}]", span):
+        return False
+    if LEAN_GENERIC_ARROW_TYPE_RE.fullmatch(span):
+        return True
+    if LEAN_TYPE_CONSTRUCTOR_RE.search(span) is None:
+        return False
+    return re.search(r"(?:=|:|→|↔|≃)", span) is not None
+
+
+def check_lean_line(
+    path: Path,
+    line_no: int,
+    text: str,
+    *,
+    check_math_code_spans: bool = True,
+) -> Finding | None:
     if ISSUE_REF_RE.search(text):
         return Finding(
             path,
             line_no,
             "Lean docstrings and comments should cite the mathematical note, not an issue number.",
+            text,
+        )
+    if check_math_code_spans and any(
+        is_backtick_math(match.group(1)) for match in LEAN_CODE_SPAN_RE.finditer(text)
+    ):
+        return Finding(
+            path,
+            line_no,
+            "Lean comments should write mathematical expressions in \\(...\\), not backtick code spans.",
             text,
         )
     return None
@@ -205,6 +314,10 @@ def is_blueprint_prose_path(path: Path) -> bool:
     )
 
 
+def checks_lean_math_code_spans(path: Path) -> bool:
+    return path.parts[:3] == ("TNLean", "MPS", "ParentHamiltonian")
+
+
 def check_added_lines(lines: Iterable[AddedLine]) -> list[Finding]:
     findings: list[Finding] = []
     lean_comment_cache: dict[Path, set[int]] = {}
@@ -216,7 +329,12 @@ def check_added_lines(lines: Iterable[AddedLine]) -> list[Finding]:
                 added.path, lean_comment_lines(added.path)
             )
             if added.line_no in comment_lines:
-                finding = check_lean_line(added.path, added.line_no, added.text)
+                finding = check_lean_line(
+                    added.path,
+                    added.line_no,
+                    added.text,
+                    check_math_code_spans=checks_lean_math_code_spans(added.path),
+                )
                 if finding is not None:
                     findings.append(finding)
         elif added.path.suffix == ".tex" and is_blueprint_prose_path(added.path):
@@ -231,7 +349,12 @@ def check_all(root: Path) -> list[Finding]:
         comment_lines = lean_comment_lines(path)
         for line_no, text in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
             if line_no in comment_lines:
-                finding = check_lean_line(rel_path, line_no, text)
+                finding = check_lean_line(
+                    rel_path,
+                    line_no,
+                    text,
+                    check_math_code_spans=checks_lean_math_code_spans(rel_path),
+                )
                 if finding is not None:
                     findings.append(finding)
     for path in blueprint_files(root):


### PR DESCRIPTION
### Motivation

- Docstrings throughout `TNLean/MPS/ParentHamiltonian/` used backtick code spans for mathematical expressions (e.g., `` `H² ≥ γ H` ``, `` `G_{L+1}(A)` ``); `docs/prose_style.md` §1 reserves backticks for genuine Lean identifiers and requires `\(...\)` for mathematical expressions.
- This migration was deliberately deferred from the prose clarity pass in #2774 to avoid a partial, inconsistent conversion; #2783 tracks the full directory migration.

### Description

- All `.lean` files under `TNLean/MPS/ParentHamiltonian/` (21 files): backtick-wrapped mathematical expressions in docstrings and module comments converted to inline `\(...\)` notation; genuine Lean identifiers (`groundSpaceMap`, `Fin d`, declaration names) remain in backticks.
- `docs/prose_style.md`: convention documented explicitly.
- `scripts/check_reader_facing_prose.py`: extended to detect backtick spans that look mathematical (operators, Greek letters, sub/superscripts, equations) on comment lines under `TNLean/MPS/ParentHamiltonian/`; operates in both full-scan and `--diff-base` (CI diff) modes.
- No changes to definitions, proofs, or runtime behavior.

### Testing

- `python3 -m py_compile scripts/check_reader_facing_prose.py`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` (changed-line scan clean)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main`
- `lake exe cache get && lake build TNLean`

---
Closes #2783

> [!NOTE]
> **Low Risk**
> Comment and tooling-only changes with no effect on formalized mathematics or build artifacts beyond the existing prose check.
>
> **Overview**
> Standardizes **reader-facing math** in `TNLean/MPS/ParentHamiltonian`: docstrings and module comments that used backtick "code" for formulas (dimensions, ground spaces, Hamiltonian notation, inequalities) now use inline `\(...\)`. **Lean names** (e.g. `groundSpaceMap`, `Fin d`) stay in backticks where they are API references.
>
> **`docs/prose_style.md`** states that docstring math should use `\(...\)`, not backticks.
>
> **`scripts/check_reader_facing_prose.py`** detects backtick spans that look mathematical (symbols, subscripts, paths excluded) and reports them on comment lines under `TNLean/MPS/ParentHamiltonian` during full scans and on changed lines in diff mode.
>
> No changes to definitions, proofs, or runtime behavior—documentation and lint only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a21b09883fd18265a63571241fc01ab017048b3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and lint-only changes with no effect on formalized mathematics or build logic beyond the prose checker.
> 
> **Overview**
> Migrates **reader-facing math** in `TNLean/MPS/ParentHamiltonian` docstrings and module comments from backtick code spans to inline `\(...\)` notation (e.g. ground spaces, Hamiltonians, inequalities), while **keeping backticks** for real Lean API names like `groundSpaceMap` and `Fin d`.
> 
> **`docs/prose_style.md`** now states that migrated ParentHamiltonian docstrings should use `\(...\)` for math and reserve backticks for Lean references.
> 
> **`scripts/check_reader_facing_prose.py`** gains heuristics to flag mathematical backtick spans in Lean comments, scoped to `TNLean/MPS/ParentHamiltonian` in both full-repo and `--diff-base` CI scans, with exceptions for paths and type expressions.
> 
> No changes to definitions, proofs, or runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df6ac51e60c9efa6e2f64dedacb0a1c4c22d447a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->