### PR TITLE
feat(PEPS/RegionBlock): coarse-frame forward-transfer multiplicativity, and the 2D overlap verdict

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -597,6 +597,7 @@ import TNLean.PEPS.RegionBlock.CoarseThreeSite8
 import TNLean.PEPS.RegionBlock.CoarseThreeSite9
 import TNLean.PEPS.RegionBlock.CoarseThreeSite10
 import TNLean.PEPS.RegionBlock.CoarseThreeSite11
+import TNLean.PEPS.RegionBlock.CoarseThreeSiteMul
 import TNLean.PEPS.CoherentFrameInstance
 import TNLean.PEPS.CoherentFrameInstance2
 import TNLean.PEPS.NormalEdgeGaugeFamily

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean
@@ -96,7 +96,8 @@ theorem coeffTransferMap_mul_of_coherentFrames
               (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ)
     (M M' : Matrix (Fin (A.bondDim
         (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
-        (Fin (A.bondDim (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ) :
+        (Fin (A.bondDim
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ) :
     coeffTransferMap (G := G) A B F.frame.red
         (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) htransferAB (M * M') =
       coeffTransferMap (G := G) A B F.frame.red

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean
@@ -1,0 +1,115 @@
+import TNLean.PEPS.RegionBlock.CoarseThreeSite11
+
+/-!
+# The forward-transfer multiplicativity from two coherent coarse blocking frames
+
+The per-edge gauge construction of the normal-PEPS edge comparison consumes three
+inputs about the chosen forward transfer `coeffTransferMap` over the red block at the
+single boundary edge `e`: the two cross-tensor coefficient transfers and the
+multiplicativity of the chosen forward transfer.  The first two are produced by the
+single-region coefficient transfer; the third is the load-bearing one, since a
+coefficient transfer alone does not make the chosen forward map a homomorphism.
+
+This file isolates that multiplicativity field as a reusable theorem.  The proof inside
+`exists_regionEdgeGauge_of_coherentFrames` (`TNLean.PEPS.RegionBlock.CoarseThreeSite11`)
+discharges the multiplicativity through the concrete single-edge transfer
+`regionEdgeTransfer`: the bridge `coeffTransferMap_eq_regionEdgeTransfer` identifies the
+chosen forward map with the concrete one through `regionInsertedCoeff_injective`, and
+`regionEdgeTransfer_mul` is the concrete map's multiplicativity, itself the coarse
+three-site `edgeTransferMatrix_mul` conjugated by the two bond models.  That field was
+only ever available bundled inside the gauge assembly; exposing it standalone lets a
+consumer that already holds the coefficient transfer (the overlapping-window route, whose
+read-off side is unconditional on window and host injectivity) obtain the
+multiplicativity from a coherent coarse blocking frame over the red block, with the same
+three-block injectivity input and no single-vertex injectivity.
+
+The single mathematical content the multiplicativity rests on is the coarse three-site
+injectivity of the assembled coarse tensor at the distinguished super-bond, which the
+coherent frame supplies from the blocked-region injectivity of its three regions: the two
+endpoint super-sites are injective by the red and blue blocking injectivities, the middle
+super-site by the complement blocking injectivity.  The original tensor's single vertices
+play no role; the super-vertex injectivity stands in for the single-vertex spanning the
+vertex-injective route would use.
+
+## References
+
+- [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
+  pair states generating the same state*, arXiv:1804.04964, Section 3, Lemma
+  `inj_isomorph`, lines 254--586 of `Papers/1804.04964/paper_normal.tex`; the corollary at
+  lines 2297--2318](https://arxiv.org/abs/1804.04964)
+- `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, the residual of the overlapping-window
+  multiplicativity; `docs/paper-gaps/peps_normal_ft_section3_route.tex`, the coarse
+  three-site route that supplies it without single-vertex injectivity.
+-/
+
+open scoped BigOperators Matrix
+
+namespace TNLean
+namespace PEPS
+
+variable {V : Type*} [Fintype V] [LinearOrder V]
+variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
+variable {A B : Tensor G d}
+
+/-- **The forward-transfer multiplicativity from two coherent coarse blocking frames.**
+
+Two coherent coarse blocking frames over `A` and `B` sharing the three regions, the bond
+dimensions, and the single red-to-blue crossing edge `e`, with `A` and `B` generating the
+same state, make the chosen forward transfer `coeffTransferMap` over the red block at the
+single boundary edge `e` multiplicative: the transfer of a product is the product of the
+transfers.
+
+This is the `hmul` field of the per-edge gauge, extracted as a standalone statement.  The
+proof identifies the chosen forward map with the concrete single-edge transfer
+`regionEdgeTransfer` through `coeffTransferMap_eq_regionEdgeTransfer`, and applies the
+concrete transfer's multiplicativity `regionEdgeTransfer_mul`, the coarse
+`edgeTransferMatrix_mul` conjugated by the two bond models.  No single-vertex injectivity
+of `A` or `B` enters: the only injectivity input is the blocked-region injectivity of the
+three regions, carried by the coherent frames, which makes the assembled coarse tensor
+edge-blocked three-site injective at the distinguished super-bond.
+
+Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--586 of
+`Papers/1804.04964/paper_normal.tex`. -/
+theorem coeffTransferMap_mul_of_coherentFrames
+    (F : CoherentCoarseBlockingFrame (G := G) (d := d) A)
+    (F' : CoherentCoarseBlockingFrame (G := G) (d := d) B)
+    (hP : F.frame.IsPartition) (hP' : F'.frame.IsPartition)
+    (hred : F.frame.red = F'.frame.red) (hblue : F.frame.blue = F'.frame.blue)
+    (hcompl : F.frame.complement = F'.frame.complement)
+    (hbond : A.bondDim = B.bondDim) (hAB : SameState A B) (hd : 0 < d)
+    (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
+    (e : Edge G)
+    (hsingle : ∀ g : Edge G,
+      IsCrossingEdge (G := G) A F.frame.red F.frame.blue g ↔ g = e)
+    (htransferAB : ∀ M : Matrix (Fin (A.bondDim
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+        (Fin (A.bondDim (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+      ∃ N : Matrix (Fin (B.bondDim
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+          (Fin (B.bondDim
+            (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ,
+        ∀ (σ : RegionPhysicalConfig (V := V) (d := d) F.frame.red)
+          (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ F.frame.red)),
+          regionInsertedCoeff (G := G) A F.frame.red
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) M σ τ =
+            regionInsertedCoeff (G := G) B F.frame.red
+              (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) N σ τ)
+    (M M' : Matrix (Fin (A.bondDim
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1))
+        (Fin (A.bondDim (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle).1)) ℂ) :
+    coeffTransferMap (G := G) A B F.frame.red
+        (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) htransferAB (M * M') =
+      coeffTransferMap (G := G) A B F.frame.red
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) htransferAB M *
+        coeffTransferMap (G := G) A B F.frame.red
+          (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) htransferAB M' := by
+  rw [coeffTransferMap_eq_regionEdgeTransfer F F' hP hP' hred hblue hcompl hbond hAB hd hposA
+      hposB e hsingle htransferAB (M * M'),
+    coeffTransferMap_eq_regionEdgeTransfer F F' hP hP' hred hblue hcompl hbond hAB hd hposA
+      hposB e hsingle htransferAB M,
+    coeffTransferMap_eq_regionEdgeTransfer F F' hP hP' hred hblue hcompl hbond hAB hd hposA
+      hposB e hsingle htransferAB M']
+  exact regionEdgeTransfer_mul F F' hP hP' hred hblue hcompl hbond hAB e hsingle M M'
+
+end PEPS
+end TNLean

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -941,6 +941,123 @@ exhibits at the end pair.  A coefficient transfer alone does not yield $\path{hm
 multiplicativity is the homomorphism of the physical insertion operator, which the
 single-bond geometry localizes to one edge but does not on its own make multiplicative.
 
+\section{The multiplicativity verdict: it is the coarse three-site
+super-bond, not a single-window span}
+
+This section records the definitive resolution of the one residual question the
+overlapping-window corollary reduces to: whether the forward-transfer
+multiplicativity $\path{hmul}$ at the left end window is obtainable from window and
+host injectivity at the corollary's minimal size, or genuinely needs a block-level
+construction the landed single-window machinery does not provide.
+
+\subsection{The single-window span does not exist, and is not the mechanism}
+
+The natural reading of $\path{hmul}$ as a single-window fact is the question whether
+the reference-edge-restricted matrix family of the left end window $W$ --- the bond
+matrix on $e$ read off the window block at fixed external legs and physical
+configuration --- spans the full $\mathrm{Fin}(\mathrm{bondDim}\,e)$ algebra, the way
+a one-dimensional length-$L$ window product spans the full $D\times D$ algebra and
+feeds the homomorphism extraction $\path{exists\_insertionHom}$ through
+$\path{LinearMap.ext\_on\_range}$. It does not. A one-dimensional window has exactly
+two virtual legs, both of dimension $D$, so its product \emph{is} a square matrix on
+the bond and window injectivity is bond-algebra spanning directly. A two-dimensional
+$L\times K$ end window touches $e$ with \emph{one} endpoint, so its $e$-restricted
+family is a family of \emph{vectors} on $\mathrm{Fin}(\mathrm{bondDim}\,e)$, and the
+window's whole perimeter is open. Folding the perimeter into a second
+$\mathrm{Fin}(\mathrm{bondDim}\,e)$ index would require
+$\prod_{\text{external legs}}\mathrm{bondDim} = \mathrm{bondDim}\,e$, false in
+general; the full boundary-configuration family is linearly independent (window block
+injectivity), but its projection onto the $e$-leg at fixed external legs is not a
+square-matrix span. So the one-dimensional template port has no two-dimensional
+single-window analogue, and the homomorphism cannot be read from one window's block.
+
+\subsection{The faithful mechanism is the coarse super-bond, available without
+single-vertex injectivity, but obstructed for the single-window red block at the
+minimal size}
+
+The source supplies $\path{hmul}$ not from a single window but from the homomorphism
+of the physical insertion operator, which the formalization realizes through the
+\emph{coarse three-site} route already landed for the rectangle blocking: three
+blocked regions (a red block, a blue block meeting it only at $e$, and the
+complement) are assembled into a coarse tensor on a three-vertex graph, whose three
+super-sites are injective directly from the three blocked-region injectivities, with
+no single-vertex injectivity of the original tensor. The coarse tensor is
+edge-blocked three-site injective at the distinguished super-bond, so the
+single-vertex transfer-matrix multiplicativity $\path{edgeTransferMatrix\_mul}$
+applies \emph{at the super-bond}; conjugated by the two bond models this is
+$\path{regionEdgeTransfer\_mul}$, and through the identification of the chosen forward
+transfer with the concrete one ($\path{coeffTransferMap\_eq\_regionEdgeTransfer}$, by
+$\path{regionInsertedCoeff\_injective}$) it is exactly $\path{hmul}$ for the chosen
+transfer over the red block. The super-vertex injectivity stands in for the
+single-vertex spanning the vertex-injective route would use; this is why the route
+needs only blocked-region injectivity of the three regions.
+
+This mechanism applies to the window route iff the left end window $W$ can play the
+coarse red block, which requires a blue block making $e$ the single red-to-blue
+crossing and a complement $\mathrm{univ}\setminus(W\cup\mathrm{blue})$ injective. The
+single-crossing requirement is met canonically: the right end window $W'$ is the only
+block joined to $W$ by exactly the reference edge $e$
+($\path{isCrossingEdge\_horizontalStaircaseEndWindows}$). But that forces
+$W\cup\mathrm{blue} = W\cup W' = S$, the staircase end pair, so the complement is
+$\mathrm{univ}\setminus S$ --- the very region Step~3 proves is \emph{not} injective
+at the corollary's minimal size, because $S$ occupies all columns of one row and the
+complement band there has width below $L$. So the coarse three-site frame with
+$\mathrm{red}=W$ and the natural single-crossing partner is unbuildable at the minimal
+size: its $\path{complement\_injective}$ field is exactly the obstructed
+$\mathrm{univ}\setminus S$ injectivity, the same obstruction the open-boundary
+staircase route was built to circumvent at the \emph{state-equality} level, now
+reappearing at the \emph{multiplicativity} level. Any other blue block making $e$ a
+single crossing must still contain $e$'s out-of-$W$ endpoint, hence a vertex of the
+column band where the obstruction lives, so no choice of partner repairs the
+complement.
+
+\subsection{Verdict}
+
+The verdict is \textbf{(b)}: the $e$-bond multiplicativity at the minimal size is
+\emph{not} derivable from window and host injectivity of the single left end window.
+It is the coarse three-site super-bond multiplicativity, which needs a third injective
+block --- the complement of the red-blue pair --- and at the minimal size, with the
+red block a single window and the single-crossing partner forced to be the opposite
+window, that complement is $\mathrm{univ}\setminus S$, non-injective. The read-off
+side ($\path{htransferAB}$, $\path{htransferBA}$, and the whole region-level gauge
+algebra) \emph{is} powered by window and single-window-complement injectivity, both
+available at the minimal size; only the homomorphism is not.
+
+The block-level construction the staircase must supply is therefore precisely a
+coarse blocking frame around $e$ whose three regions are all injective at the minimal
+size and whose red-to-blue crossing is the singleton $\{e\}$ --- equivalently, a
+coefficient transfer on the window that is \emph{independently} known to be
+multiplicative, since the multiplicativity is the homomorphism of the physical
+insertion operator and no single-window read-off makes it one. The source's sketched
+overlapping-window realization is that the same virtual operation $M$ on $e$ is a
+physical operation on \emph{every} window of the staircase chain, all sharing one
+deformed state; the chain of consecutive-window inversions (landed at the
+state-equality level as $\path{staircasePair\_insert\_eq\_open}$, never inverting
+$\mathrm{univ}\setminus S$) transports $M$ around the corner, and the homomorphism
+$M\cdot M' \mapsto$ (transfer of $M$)\,(transfer of $M'$) is read from the composition
+of two such transports across the chain, not from any one window's block. Building
+that insert-family transport --- the ``a virtual operation on a given bond is a
+physical operation on any window containing an endpoint'' correspondence as an actual
+insert family with the composition law --- is the residual, and it is a
+\emph{block-level} (insert-family-and-chain) construction, not a single-window span.
+
+\subsection{The foundation that lands}
+
+The reusable multiplicativity is exposed as
+\leanid{TNLean.PEPS.coeffTransferMap\_mul\_of\_coherentFrames}
+(\path{TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean}): two coherent coarse blocking
+frames over the two tensors sharing the three regions, the bond dimensions, and the
+single-crossing edge make the chosen forward transfer over the red block
+multiplicative, with no single-vertex injectivity. This is the $\path{hmul}$ field
+extracted from the bundled gauge assembly
+\leanid{TNLean.PEPS.exists\_regionEdgeGauge\_of\_coherentFrames}, so a consumer holding
+only the coefficient transfer can obtain the multiplicativity from a frame. It makes
+the verdict auditable in Lean: the window route's $\path{hmul}$ is one application of
+this theorem with $\mathrm{red}=W$, and the unmet hypothesis is exactly the frame's
+$\path{complement\_injective}$ at $\mathrm{univ}\setminus S$, the documented
+obstruction. The remaining work is the insert-family transport that produces a
+multiplicative window coefficient transfer without a single-window red-block frame.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -1006,10 +1006,13 @@ $\mathrm{red}=W$ and the natural single-crossing partner is unbuildable at the m
 size: its $\path{complement\_injective}$ field is exactly the obstructed
 $\mathrm{univ}\setminus S$ injectivity, the same obstruction the open-boundary
 staircase route was built to circumvent at the \emph{state-equality} level, now
-reappearing at the \emph{multiplicativity} level. Any other blue block making $e$ a
-single crossing must still contain $e$'s out-of-$W$ endpoint, hence a vertex of the
-column band where the obstruction lives, so no choice of partner repairs the
-complement.
+reappearing at the \emph{multiplicativity} level. Enlarging the blue block beyond
+$W'$ cannot repair this within the single-window red frame: a blue block making $e$
+the sole red-to-blue crossing must contain $e$'s out-of-$W$ endpoint and avoid
+creating any second crossing of $\partial W$, and any such enlargement only shrinks
+$\mathrm{univ}\setminus(W\cup\mathrm{blue})$, making its injectivity no easier than for
+$\mathrm{univ}\setminus S$. The faithful repair is not a larger partner but a
+different mechanism, below.
 
 \subsection{Verdict}
 


### PR DESCRIPTION
## Summary

Definitive verdict (with a concrete derivation attempt) on the single irreducible
question the 2D overlapping-window corollary (arXiv:1804.04964, lines 2297–2318) now
reduces to: whether the forward-transfer multiplicativity `hmul` at the left end window
is derivable from window + single-window-host injectivity at the corollary's minimal
size.

**Verdict: (b) — not derivable from a single window.** The `e`-bond multiplicativity is
the coarse three-site **super-bond** multiplicativity, which needs a third injective
block (the complement of the red–blue pair). At the minimal size, with the red block a
single window `W` and the single-crossing partner forced to be the opposite end window
`W'` (`isCrossingEdge_horizontalStaircaseEndWindows`), the complement is exactly
`univ \ S` — the region Step 3 already proves non-injective at the minimal size. So the
natural coarse frame with `red = W` is unbuildable: its `complement_injective` field is
the documented obstruction.

The one-dimensional template has no two-dimensional single-window analogue: a 1D length-`L`
window product is a square `D×D` matrix (window injectivity = bond span directly), while a
2D `L×K` end window touches `e` with one endpoint, so its `e`-restricted family is vectors,
not a square-matrix span; folding the open perimeter into a second `e`-leg index would need
`∏(external bondDim) = bondDim e`, false in general.

## What lands

`coeffTransferMap_mul_of_coherentFrames` (`TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean`):
the `hmul` field extracted from the bundled gauge assembly
`exists_regionEdgeGauge_of_coherentFrames` as a reusable theorem. Two coherent coarse
blocking frames sharing the three regions, the bond dimensions, and the single-crossing
edge make the chosen forward transfer `coeffTransferMap` over the red block multiplicative,
with **no single-vertex injectivity**. This makes the verdict auditable in Lean: the window
route's `hmul` is one application with `red = W`, and the unmet hypothesis is exactly the
frame's `complement_injective` at `univ \ S`.

`#print axioms coeffTransferMap_mul_of_coherentFrames` → `[propext, Classical.choice,
Quot.sound]`. No sorry, no `maxHeartbeats`.

The verdict and the precise block-level construction the staircase must supply (an
insert-family transport making a multiplicative window coefficient transfer, without a
single-window red-block frame) are recorded in
`docs/paper-gaps/peps_normal_ft_2d_overlap.tex` §6.

## Checks

- Full root `lake build`: green (8927 jobs).
- Whole-repo `lake exe lint-style`: exit 0.

No blueprint entries (the corollary remains unformalized).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Lean theorem is a thin refactor of existing `CoarseThreeSite11` proofs plus documentation; no auth, I/O, or production runtime paths.
> 
> **Overview**
> **Adds** `coeffTransferMap_mul_of_coherentFrames` in `TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean` and wires it into the root import list. The theorem is the per-edge gauge **`hmul`** field pulled out of `exists_regionEdgeGauge_of_coherentFrames`: two coherent coarse blocking frames plus a coefficient transfer make `coeffTransferMap` multiplicative via `coeffTransferMap_eq_regionEdgeTransfer` and `regionEdgeTransfer_mul`, using only three-region blocked injectivity (no single-vertex injectivity).
> 
> **Documents** in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex` (new §6) the resolution of the overlapping-window residual: **`hmul` is not a single-window bond-algebra span** (2D end windows give vectors on `e`, not a `D×D` span). The faithful mechanism is **coarse three-site super-bond** multiplicativity; at minimal size with `red = W` and partner `W'`, complement injectivity is **`univ \ S`**, the same obstruction Step 3 already flags—so verdict **(b)**. Remaining work is an **insert-family transport** along the staircase chain, not enlarging the blue block.
> 
> Lean change is proof reuse (~15 lines); risk is low for runtime behavior, medium for proof-maintenance surface on the PEPS formalization track.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc12eda8df862875a7c184e686c67ebf8a79dd6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->