### PR TITLE
refactor(PEPS): consolidate the 2D overlapping-window campaign machinery

### DIFF
--- a/TNLean/PEPS/TorusWindowFamily.lean
+++ b/TNLean/PEPS/TorusWindowFamily.lean
@@ -188,42 +188,6 @@ theorem staircaseUnion_eq_verticalRectangle {L K : ℕ} (hh : 1 < height)
   exact verticalAdjacentWindows_union (by omega) hh
     (s.1, s.2 + ((K - 1 - ((j + 1) - L) : ℕ) : ZMod height))
 
-namespace NormalTorusArcWindowInjectivityHypotheses
-
-variable {L K : ℕ} {κ : RegionInjectivityData (TorusVertex width height)}
-
-/-- **A sliding-arm consecutive union is injective.** It is the `(L + 1) × K`
-cyclic rectangle of `staircaseUnion_eq_horizontalRectangle`.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-Step 1. -/
-theorem staircaseUnion_horizontal_injective
-    (h : NormalTorusArcWindowInjectivityHypotheses L K κ)
-    (hUnion : RegionInjectivityUnionClosure κ) (hL : 2 ≤ L) (hK : 2 ≤ K)
-    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
-    (s : TorusVertex width height) {j : ℕ} (hj : j < L) :
-    κ.IsInjective (staircaseUnion s L K j) := by
-  rw [staircaseUnion_eq_horizontalRectangle (by omega) s hj]
-  exact h.horizontalUnion_injective hUnion hL hK hxw hyh _
-
-/-- **A descending-arm consecutive union is injective.** It is the `L × (K + 1)`
-cyclic rectangle of `staircaseUnion_eq_verticalRectangle`.
-
-Source: arXiv:1804.04964, the proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex`; `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`,
-Step 1. -/
-theorem staircaseUnion_vertical_injective
-    (h : NormalTorusArcWindowInjectivityHypotheses L K κ)
-    (hUnion : RegionInjectivityUnionClosure κ) (hL : 2 ≤ L) (hK : 2 ≤ K)
-    (hxw : 2 * L + 1 ≤ width) (hyh : 2 * K + 1 ≤ height)
-    (s : TorusVertex width height) {j : ℕ} (hj : L ≤ j) (hjK : j + 1 < L + K) :
-    κ.IsInjective (staircaseUnion s L K j) := by
-  rw [staircaseUnion_eq_verticalRectangle (by omega) s hj hjK]
-  exact h.verticalUnion_injective hUnion hL hK hxw hyh _
-
-end NormalTorusArcWindowInjectivityHypotheses
-
 /-! ### Membership in the family
 
 The cyclic distances of a window vertex from the staircase corner `s`, read back

--- a/TNLean/PEPS/TorusWindowRegion.lean
+++ b/TNLean/PEPS/TorusWindowRegion.lean
@@ -11,12 +11,12 @@ the sizes `n ≥ 2L + 1` and `m ≥ 2K + 1`.  This file is the geometry layer of
 that route, scoped in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`:
 
 * the one-orientation window-injectivity hypotheses
-  (`NormalTorusWindowInjectivityHypotheses`), with every larger rectangle
-  injective by sliding unions of windows;
+  (`NormalTorusWindowInjectivityHypotheses`), with a larger rectangle exhibited
+  as a sliding union of windows (`contiguousRectangle_eq_biUnion_window`);
 * the staircase end pair of the overlapping-window chain around an edge: two
   diagonally offset `L × K` windows whose only joining lattice edge is the
   distinguished edge itself (`isCrossingEdge_horizontalStaircase`,
-  `isCrossingEdge_verticalStaircase`), together with their disjointness.
+  `isCrossingEdge_verticalStaircase`).
 
 The single-crossing geometry of the end pair is the reason the bond operator
 extracted by the window chain lives on one edge; it is consumed by the same
@@ -82,32 +82,6 @@ theorem contiguousRectangle_eq_biUnion_window {L K : ℕ} (hL : 0 < L) (hK : 0 <
   · rintro ⟨⟨p, q⟩, ⟨_, _⟩, hv⟩
     omega
 
-namespace NormalTorusWindowInjectivityHypotheses
-
-variable {L K : ℕ} {κ : RegionInjectivityData (TorusVertex width height)}
-
-/-- A contiguous torus rectangle of width at least `L` and height at least `K`
-is injective under the one-orientation window hypotheses: it is the union of
-the `L × K` windows sliding over it.
-
-Source: arXiv:1804.04964, Section 3, Lemma `injective_union` and the corollary
-at lines 2297--2318 of `Papers/1804.04964/paper_normal.tex`. -/
-theorem rectangle_injective (h : NormalTorusWindowInjectivityHypotheses L K κ)
-    (hUnion : RegionInjectivityUnionClosure κ) (hL : 0 < L) (hK : 0 < K)
-    {xStart yStart xLen yLen : ℕ} (hx : L ≤ xLen) (hy : K ≤ yLen)
-    (hxw : xStart + xLen ≤ width) (hyh : yStart + yLen ≤ height) :
-    κ.IsInjective
-      (torusContiguousRectangle xStart yStart xLen yLen :
-        Finset (TorusVertex width height)) := by
-  rw [contiguousRectangle_eq_biUnion_window hL hK xStart yStart xLen yLen hx hy]
-  refine hUnion.biUnion_injective ?_ _ ?_
-  · exact ⟨(0, 0), by simp [Finset.mem_product, Finset.mem_range]⟩
-  · rintro ⟨p, q⟩ hpq
-    simp only [Finset.mem_product, Finset.mem_range] at hpq
-    exact h.window_injective _ _ (by omega) (by omega)
-
-end NormalTorusWindowInjectivityHypotheses
-
 /-! ### The staircase end pair around a horizontal edge
 
 The overlapping-window chain around a horizontal edge ends on two diagonally
@@ -149,18 +123,6 @@ theorem horizontalStaircaseEdge_val {L K a b : ℕ} (hL : 0 < L)
       rw [← Nat.cast_add_one]; congr 1; omega]
     exact ZMod.val_cast_of_lt (by omega)
   · rw [href.2]; exact ZMod.val_cast_of_lt (by omega)
-
-omit [Fact (1 < width)] [Fact (1 < height)] in
-/-- The two windows of the horizontal staircase pair are disjoint: their column
-ranges are. -/
-theorem horizontalStaircase_disjoint {L K a b : ℕ} :
-    Disjoint
-      (torusContiguousRectangle a b L K : Finset (TorusVertex width height))
-      (torusContiguousRectangle (a + L) (b + K - 1) L K) := by
-  rw [Finset.disjoint_left]
-  intro v hv hv'
-  rw [mem_torusContiguousRectangle] at hv hv'
-  omega
 
 /-- **The single crossing of the horizontal staircase pair.**
 
@@ -294,18 +256,6 @@ theorem verticalStaircaseEdge_val {L K a b : ℕ} (hK : 0 < K)
     rw [show ((b + K - 1 : ℕ) : ZMod height) + 1 = ((b + K : ℕ) : ZMod height) from by
       rw [← Nat.cast_add_one]; congr 1; omega]
     exact ZMod.val_cast_of_lt (by omega)
-
-omit [Fact (1 < width)] [Fact (1 < height)] in
-/-- The two windows of the vertical staircase pair are disjoint: their row
-ranges are. -/
-theorem verticalStaircase_disjoint {L K a b : ℕ} :
-    Disjoint
-      (torusContiguousRectangle a b L K : Finset (TorusVertex width height))
-      (torusContiguousRectangle (a + L - 1) (b + K) L K) := by
-  rw [Finset.disjoint_left]
-  intro v hv hv'
-  rw [mem_torusContiguousRectangle] at hv hv'
-  omega
 
 /-- **The single crossing of the vertical staircase pair.**
 


### PR DESCRIPTION
## Summary

A conservative consolidation pass over the 2D overlapping-window campaign
(18 `TorusWindow*.lean` files + `TorusDeformedWindow` + the RegionBlock
reduction layers). This is a maintenance pass per the periodic-refactor
discipline: remove genuinely dead/superseded scaffolding only. The live
reduction chain feeding the open 2D corollary
(`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`) is left intact; no frontier
work, no behaviour change to surviving lemmas.

**Removed: 5 declarations, net -86 lines, 2 files.** Each is superseded by a
consumed seam-aware equivalent and has zero call sites tree-wide.

## What was removed (and why it is safe)

| Removed declaration | File | Superseded by (consumers) | Tree-wide uses |
|---|---|---|---|
| `rectangle_injective` | TorusWindowRegion | `arcRectangle_injective` (seam-wrapping general version, TorusWindowComplement) | 9 |
| `horizontalStaircase_disjoint` | TorusWindowRegion | `horizontalStaircaseEndPair_disjoint` (seam-aware `torusArcRectangle`, TorusWindowChain) | 5 |
| `verticalStaircase_disjoint` | TorusWindowRegion | same as above (vertical sibling) | 5 |
| `staircaseUnion_horizontal_injective` | TorusWindowFamily | direct use of `staircaseUnion_eq_horizontalRectangle` + `horizontalUnion_injective` | — |
| `staircaseUnion_vertical_injective` | TorusWindowFamily | direct use of `staircaseUnion_eq_verticalRectangle` + `verticalUnion_injective` | — |

Each removed declaration appeared exactly once in the whole `TNLean/` tree
(its own definition) and is referenced in no `docs/paper-gaps/*.tex` note. The
first three are the no-wraparound coordinate-rectangle versions of facts the
live chain restates on the seam-aware `torusArcRectangle`; the last two are
redundant packaged corollaries whose underlying lemmas the consumers call
directly. Two emptied namespace blocks are dropped. The host structures
(`NormalTorusWindowInjectivityHypotheses`,
`NormalTorusArcWindowInjectivityHypotheses`) and the live tiling lemma
`contiguousRectangle_eq_biUnion_window` are kept. The `TorusWindowRegion`
module docstring is adjusted to match the file's contents.

No deprecation aliases: these are internal scaffolding with no external
consumers (per `docs/CONTRIBUTING.md` for internal renames/removals).

## Audit: dead vs kept (consumer analysis)

Built the consumer graph by grepping every public 2D-campaign declaration
name across `origin/main`. Of 176 declarations in the 19 core files, 96 have
zero external-file consumers; 19 of those also have zero in-file uses. Each of
those 19 was classified:

**Removed (5):** the superseded duplicates above — demonstrably replaced by a
*consumed* equivalent, so they clear the bar that frontier inputs do not.

**Kept — frontier terminals of the open path** (mission-protected; consumed
only by the not-yet-built witness/capstone):
- `exists_windowEdgeCoeffIdentityWitness_of_bondLocal` (TorusWindowBondLocal),
  `..._of_realizes` (TorusWindowRealizes), and the `..._of_coeffTransfer`
  family (TorusWindowMult) — **three parallel reductions of the same window
  witness from different hypothesis bundles** (coeff-transfer vs bond-locality
  vs single-vertex realization). None supersedes another; each isolates the
  open residual from a different angle and is the documented frontier
  characterization in the gap note §5.1–5.2. Kept all three.
- `horizontalStaircaseConsecutiveWindow_bondTransport_extend_eq` and its
  vertical sibling (TorusWindowBondTransport, #2799) — the per-step bond
  transport through the injective overlap, the latest landed brick.

**Kept — peeling characterization for the open Step-4 extraction**
(mission names `TorusWindowPeel*` as must-survive): the assembled boundary
lemmas in TorusWindowPeel (`isRegionBoundaryEdge_endPair_iff`,
`..._exactlyOne_window`, `compl_rightWindow_eq_...`, etc.) feed
`regionInsertedCoeff_endWindows_eq_of_staircase`, which consumes the live
open-route `staircasePair_insert_eq_open`.

**Kept — documented obstruction marker:** `staircasePair_insert_eq`
(TorusWindowChain2) has zero call sites and is the superseded closed-state
stripping carrying the non-derivable `univ \ S` injectivity hypothesis. It is
explicitly referenced in the gap note §3 as the illustration of why the
open-boundary route is needed. Removing it would erase a documented wall and
force a gap-note reword, so it is kept and flagged here.

**Kept — foundational geometry plausibly feeding the open chaining**
(conservative, supersession not established): `biUnion_staircaseWindow_eq_patch`
(the patch = union-of-windows relation), `horizontalStaircaseRightWindow_injective`
(right half of a deliberate left/right injective pair), and the remaining
zero-use Chain/Peel helpers. Flagged but kept under the "when uncertain, keep"
rule.

**No dead files.** All four files with zero externally-consumed declarations
(TorusWindowPeel, TorusWindowBondLocal, TorusWindowBondTransport,
TorusWindowRealizes) are named live-frontier endpoints the mission protects.

## Verification

- Full root `lake build` green: **8928 jobs** (baseline ~8927).
- PEPS sorry-free (the only `sorry`/`admit` token matches in PEPS are the word
  "admit" in prose; the two touched files have none).
- `lake exe lint-style` exit 0.
- `#print axioms`:
  `fundamentalTheorem_normalTorusPEPS_unconditional` (landed capstone) and
  `staircasePair_insert_eq_open` (surviving open-route reduction) both
  `[propext, Classical.choice, Quot.sound]` — unchanged.
- No `.tex` touched; no blueprint entries exist for the 2D corollary
  (unformalized), so none to update.

Do not merge — opened for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure removal of uncalled internal lemmas and doc edits; consumers already use `arcRectangle_injective`, `horizontalStaircaseEndPair_disjoint`, and direct `staircaseUnion_eq_*` + union injectivity.
> 
> **Overview**
> This pass **deletes five Lean lemmas** that had no tree-wide callers and duplicate facts already stated on the seam-aware `torusArcRectangle` path: `rectangle_injective` and the horizontal/vertical `*Staircase_disjoint` lemmas in `TorusWindowRegion`, plus `staircaseUnion_horizontal_injective` / `staircaseUnion_vertical_injective` and their `NormalTorusArcWindowInjectivityHypotheses` namespace wrapper in `TorusWindowFamily`.
> 
> **`TorusWindowRegion`** module documentation is updated so injectivity is described via `contiguousRectangle_eq_biUnion_window` rather than “every larger rectangle injective by sliding unions,” and disjointness of the end pair is no longer claimed in the header (single-crossing lemmas remain).
> 
> Core structures (`NormalTorusWindowInjectivityHypotheses`, tiling lemma `contiguousRectangle_eq_biUnion_window`) and the rest of the staircase geometry in these files are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 873534bc718787ad14b6ea875f4b2690db42ec57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->