### PR TITLE
doc(MPS/ParentHamiltonian): normalize boundary-closing gap markers

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -63,7 +63,13 @@ Condition C1 at a finite length \(L_0\).
 PGVWC07, Lemma `lem:direct-sum`, first uses Condition C1 in each block at
 length \(L_0\), then compares the spaces \(\mathcal G_{L_0+1}^{A^j}\). This
 version follows that length convention and does not assume one-site
-injectivity. -/
+injectivity.
+
+**Unfaithful:** This proof relies on
+`groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -122,7 +128,13 @@ theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of
 
 /-- Same-dimension BNT-separated blocks give homogeneous pair trace separation
 at the PGVWC length \(3(L_0+1)\), assuming Condition C1 at \(L_0\) and the
-corresponding block injectivity at \(L_0+1\) and \(3(L_0+1)\). -/
+corresponding block injectivity at \(L_0+1\) and \(3(L_0+1)\).
+
+**Unfaithful:** This proof relies on
+`groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -189,7 +201,13 @@ Condition C1 at \(L_0\), without the one-site special case of Condition C1.
 
 The length is \(3(L_0+1)\), written as
 \((L_0+1)+((L_0+1)+(L_0+1))\) to match the formal concatenation of the three
-blocks in PGVWC07, Lemma `lem:direct-sum`. -/
+blocks in PGVWC07, Lemma `lem:direct-sum`.
+
+**Unfaithful:** This proof relies on
+`pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -245,7 +263,13 @@ theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEqu
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
 
 /-- Existential common-length form of
-`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`. -/
+`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`.
+
+**Unfaithful:** This proof relies on
+`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -287,7 +311,13 @@ theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
 
 /-- BNT-separated blocks give common pairwise block-separating equations at
-length \(3(L_0+1)\) from Condition C1 at \(L_0\). -/
+length \(3(L_0+1)\) from Condition C1 at \(L_0\).
+
+**Unfaithful:** This proof relies on
+`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -324,7 +354,13 @@ theorem propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum
     (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
 
-/-- Finite-C1 version of the BNT abstract block-injectivity selector datum. -/
+/-- Finite-C1 version of the BNT abstract block-injectivity selector datum.
+
+**Unfaithful:** This proof relies on
+`hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -376,7 +412,13 @@ The simultaneous block-word tuples span the full product algebra at
 \]
 The proof follows PGVWC07 by using Condition C1 at \(L_0\), the source
 comparison length \(L_0+1\), and the three-block separation length
-\(3(L_0+1)\). -/
+\(3(L_0+1)\).
+
+**Unfaithful:** This proof relies on
+`hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -415,7 +457,13 @@ theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
 
 /-- Existential form of
-`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`. -/
+`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`.
+
+**Unfaithful:** This proof relies on
+`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -106,7 +106,13 @@ PGVWC07, Lemma `lem:direct-sum`, uses Condition C1 at a length \(L_0\) and
 then compares the parent Hamiltonian whose local image space is
 \(\mathcal G_{L_0+1}\). This version uses the normal parent-Hamiltonian
 uniqueness theorem at range \(L_0+1\), rather than assuming the one-site span
-condition. -/
+condition.
+
+**Unfaithful:** This proof relies on `chainGroundSpace_eq_mpvSubmodule_normal`,
+whose proof transitively uses the boundary-closing coordinate comparison rather
+than deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the
+comparison. -/
 theorem not_bondDim_eq_and_groundSpace_succ_eq_of_mpvSubmodule_ne
     {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hB : IsNBlkInjective B L₀)
@@ -146,7 +152,13 @@ theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
 
 /-- Finite-C1 form of the same two-block directness statement.
 
-The source length is \(L_0+1\), where \(L_0\) is the Condition C1 length. -/
+The source length is \(L_0+1\), where \(L_0\) is the Condition C1 length.
+
+**Unfaithful:** This proof relies on
+`not_bondDim_eq_and_groundSpace_succ_eq_of_mpvSubmodule_ne`, which transitively
+uses the boundary-closing coordinate comparison rather than deriving it from
+arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
     {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
     {L₀ : ℕ}
@@ -188,7 +200,13 @@ theorem pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_
     hAblk3 hBblk3
 
 /-- Finite-C1 form of homogeneous pair trace separation at the PGVWC
-three-block length \(3(L_0+1)\). -/
+three-block length \(3(L_0+1)\).
+
+**Unfaithful:** This proof relies on
+`groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
     {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
     {L₀ : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -100,7 +100,13 @@ This is the inclusion into the linear span of block local ground spaces used in
 Theorem 2blocks.2 of arXiv:quant-ph/0608197 (proof lines
 1430--1456). The replacement of \(S_N\) by periodic block chain spaces is the
 separate step of closing the boundaries with block-diagonal boundary
-conditions. -/
+conditions.
+
+**Unfaithful:** This proof relies on
+`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -175,7 +181,13 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital (by omega)
 
 /-- Finite-length block injectivity gives the periodic-chain inclusion into
-\(S_N\), and \(S_N\) is an internal direct sum of local block ground spaces. -/
+\(S_N\), and \(S_N\) is an internal direct sum of local block ground spaces.
+
+**Unfaithful:** This proof relies on the finite-\(C_1\) inclusion and
+internal-direct-sum conclusions above, which transitively use the
+boundary-closing coordinate comparison rather than deriving it from
+arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -218,7 +230,13 @@ length. Then every
 This is an open-boundary decomposition. The periodic upgrade in
 arXiv:quant-ph/0608197, Theorem 2blocks.2, is a separate boundary-condition
 comparison: one must prove \(\psi_j\in\mathcal G_{N,L}(A_j)\) for the
-block components produced here. -/
+block components produced here.
+
+**Unfaithful:** This proof relies on
+`chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -289,7 +307,13 @@ This proves the displayed statement. The
 Pérez-García--Verstraete--Wolf--Cirac boundary-condition comparison
 (arXiv:quant-ph/0608197, proof lines 1454--1456; arXiv:2011.12127, lines
 2126--2128) shows, under the comparison identities, that these same component
-vectors lie in \(\mathcal G_{N,L}(A_j)\). -/
+vectors lie in \(\mathcal G_{N,L}(A_j)\).
+
+**Unfaithful:** This proof relies on
+`exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -398,7 +422,13 @@ finite injectivity range,
 \]
 and the right-hand local block sum is internal. The separate step from
 arXiv:quant-ph/0608197 is
-to close the boundaries with block-diagonal boundary conditions. -/
+to close the boundaries with block-diagonal boundary conditions.
+
+**Unfaithful:** This proof relies on
+`chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -803,7 +833,13 @@ The source boundary-closing step is to obtain the displayed block-diagonal
 boundary representation and the periodic constraints for each block from the
 inverting-and-re-growing argument in Perez-Garcia, Verstraete, Wolf, and Cirac
 (arXiv:quant-ph/0608197) and Cirac, Perez-Garcia, Schuch, and Verstraete
-(arXiv:2011.12127), with block-diagonal boundary conditions. -/
+(arXiv:2011.12127), with block-diagonal boundary conditions.
+
+**Unfaithful:** This proof relies on
+`chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -859,7 +895,13 @@ Then
 \[
   \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j),
 \]
-and the sum \(\bigvee_jG_N(A_j)\) is internal. -/
+and the sum \(\bigvee_jG_N(A_j)\) is internal.
+
+**Unfaithful:** This proof relies on
+`chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -829,7 +829,13 @@ form. Deriving this displayed form from the source comparison is documented in
 
 This result follows the block-diagonal boundary conditions of arXiv:2011.12127,
 lines 2126--2128, and precedes the final equality in
-arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1454--1456. -/
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1454--1456.
+
+**Unfaithful:** This proof relies on
+`exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -883,7 +889,13 @@ first obtain block-diagonal boundary conditions, then use the
 Pérez-García--Verstraete--Wolf--Cirac \(C,D,E\) comparison, in the displayed
 matrix form indexed by complementary words, to put each single-block vector in
 the corresponding periodic block chain space. The theorem assumes this matrix
-form for every boundary-crossing interval; it does not assert the comparison. -/
+form for every boundary-crossing interval; it does not assert the comparison.
+
+**Unfaithful:** This proof relies on
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -64,7 +64,13 @@ Writing \(S_m=\bigvee_j G_m(A_j)\), the identity is
   \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}.
 \]
 This is the equation used in PGVWC07, Theorem 2blocks.2, proof lines
-1430--1452. -/
+1430--1452.
+
+**Unfaithful:** This proof relies on
+`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -174,7 +180,13 @@ The normalization propagates Condition C1 from \(L_0\) to \(L_0+1\) and
 then gives the simultaneous product span for every
 \[
   n\ge (L_0+1)+(r-1)\,3(L_0+1).
-\] -/
+\]
+
+**Unfaithful:** This proof relies on
+`hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -231,7 +243,13 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
 
 /-- Condition-C1 form of the internal-direct-sum conclusion for the block local
-spaces. -/
+spaces.
+
+**Unfaithful:** This proof relies on
+`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, which transitively uses
+the boundary-closing coordinate comparison rather than deriving it from
+arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -290,7 +308,13 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
     hUnital
 
 /-- Condition-C1 form of the one-step block-intersection identity at every
-length above the BNT block-separation bound. -/
+length above the BNT block-separation bound.
+
+**Unfaithful:** This proof relies on
+`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, which transitively uses
+the boundary-closing coordinate comparison rather than deriving it from
+arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -363,7 +387,13 @@ theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn⟩
 
 /-- Condition-C1 form of the large-length block intersection as an internal
-direct sum. -/
+direct sum.
+
+**Unfaithful:** This proof relies on the finite-\(C_1\) internal-direct-sum and
+block-intersection conclusions above, which transitively use the boundary-closing
+coordinate comparison rather than deriving it from arXiv:2011.12127,
+Section IV.C, lines 2078--2079. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -489,7 +519,13 @@ theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital
     A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn
 
 /-- Condition-C1 form of the eventual block-intersection identity without a
-separate one-site injectivity assumption. -/
+separate one-site injectivity assumption.
+
+**Unfaithful:** This proof relies on
+`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, which
+transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -605,7 +605,7 @@ physical letter \(j\), their first-letter restrictions give
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
 \]
 **Scope restriction (boundary-closing restriction equality):** This lemma assumes this equality
-rather than deriving arXiv:2011.12127 IV.C 2078--2079; documented in
+rather than deriving arXiv:2011.12127, Section IV.C, lines 2078--2079; documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_boundary_first_products_of_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}
@@ -786,7 +786,7 @@ The source says that the same inverting and growing-back argument may be used
 when closing the boundary. In coordinates, the remaining comparison is the
 displayed restriction equality.
 **Scope restriction (boundary-closing restriction equality):** Assumes the displayed equality
-rather than deriving arXiv:2011.12127 IV.C 2078--2079; documented in
+rather than deriving arXiv:2011.12127, Section IV.C, lines 2078--2079; documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -604,11 +604,9 @@ physical letter \(j\), their first-letter restrictions give
   =
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
 \]
-
-**Scope restriction (boundary-closing restriction equality):** This lemma
-assumes the equality of the two boundary-closing restrictions rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Scope restriction (boundary-closing restriction equality):** This lemma assumes this equality
+rather than deriving arXiv:2011.12127 IV.C 2078--2079; documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_boundary_first_products_of_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -787,10 +785,8 @@ Then there are boundary conditions with the same complementary word and with
 The source says that the same inverting and growing-back argument may be used
 when closing the boundary. In coordinates, the remaining comparison is the
 displayed restriction equality.
-
-**Scope restriction (boundary-closing restriction equality):** This lemma
-assumes the displayed restriction equality rather than deriving it from
-arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
+**Scope restriction (boundary-closing restriction equality):** Assumes the displayed equality
+rather than deriving arXiv:2011.12127 IV.C 2078--2079; documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -605,8 +605,10 @@ physical letter \(j\), their first-letter restrictions give
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
 \]
 
-This boundary equality is isolated in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Scope restriction (boundary-closing restriction equality):** This lemma
+assumes the equality of the two boundary-closing restrictions rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_boundary_first_products_of_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -783,8 +785,12 @@ Then there are boundary conditions with the same complementary word and with
   Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
 \]
 The source says that the same inverting and growing-back argument may be used
-when closing the boundary.  In coordinates, the remaining comparison is the
-displayed restriction equality; it is recorded in
+when closing the boundary. In coordinates, the remaining comparison is the
+displayed restriction equality.
+
+**Scope restriction (boundary-closing restriction equality):** This lemma
+assumes the displayed restriction equality rather than deriving it from
+arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -285,7 +285,7 @@ the paper's diagrammatic boundary-closing argument with a local coordinate
 equality. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 boundary-closing coordinate comparison from the source's
-inverting-and-growing-back argument and remove the `sorry`; tracked in #2405. -/
+inverting-and-growing-back argument and remove the `sorry`; tracked in the paper-gap note. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -391,7 +391,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the boundary-closing coordinate comparison and reprove this
-theorem without the unfaithful comparison; tracked in #2405.
+theorem without the unfaithful comparison; tracked in the paper-gap note.
 
 The comparison is derived from the boundary-closing restriction equality
 \[
@@ -456,7 +456,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -517,7 +517,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -31,10 +31,10 @@ the right word \(\sigma\), the difference
 is killed by left multiplication by every length-\(L_0\) word product, then the
 difference is zero.
 
-**Open gap:** This is only a stripping reduction. It does not prove the
-left-multiplied coordinate equation; that equation is the remaining coordinate
-reconstruction used here for the boundary-closing sentence in arXiv:2011.12127,
-Section IV.C, lines 2078--2079. The interpretive step is documented in
+**Scope restriction (left-multiplied closing-boundary comparison):** This is
+only a stripping reduction. It assumes the left-multiplied coordinate equation
+rather than deriving it from arXiv:2011.12127, Section IV.C,
+lines 2078--2079. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_mirror_padded_products_of_left_word_products
     {A : MPSTensor d D} {L₀ M : ℕ}
@@ -90,10 +90,11 @@ every length-\(L_0\) word product:
 Then the auxiliary boundary conditions \(\rho^+_{j,\sigma}\) and
 \(\rho^-_{j,\sigma}\) satisfying the required product equation exist.
 
-**Open gap:** This is a reduction toward the coordinate reconstruction used here
-for the closing-boundary sentence in arXiv:2011.12127, Section IV.C,
-lines 2078--2079. The formula is not displayed in the source; it is
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Scope restriction (left-multiplied closing-boundary comparison):** This
+reduction assumes the left-multiplied coordinate equation rather than deriving
+it from arXiv:2011.12127, Section IV.C, lines 2078--2079. The formula is not
+displayed in the source. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -150,11 +151,10 @@ left-multiplied coordinate comparison
   A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr)
 \]
 
-**Open gap:** This theorem combines the preceding reductions in the
-closure-property argument. It does not prove the displayed left-multiplied
-comparison; that comparison is the coordinate reconstruction used here for the
-boundary-closing sentence in arXiv:2011.12127, Section IV.C, lines 2078--2079.
-The source does not display this formula. See
+**Scope restriction (left-multiplied closing-boundary comparison):** This theorem
+assumes the displayed left-multiplied comparison rather than deriving it from
+the boundary-closing sentence in arXiv:2011.12127, Section IV.C,
+lines 2078--2079. The source does not display this formula. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -211,9 +211,11 @@ then
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
 
-This theorem reduces the coordinate comparison to the closing-boundary equality
-in arXiv:2011.12127, Section IV.C, lines
-2078--2079. -/
+**Scope restriction (left-multiplied closing-boundary comparison):** This theorem
+assumes the displayed left-multiplied comparison rather than deriving it from
+the closing-boundary equality in arXiv:2011.12127, Section IV.C,
+lines 2078--2079. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -276,10 +278,14 @@ boundary product comparison
 \]
 for all boundary letters \(\eta\) and physical letters \(j\).
 
-**Open gap:** arXiv:2011.12127, Section IV.C, lines 2078--2079 states that
-the inverting-and-growing-back argument may also be applied when closing the
-boundary. The displayed equality is the local coordinate form recorded here.
-See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** This proof currently relies on the unproved coordinate
+comparison identifying the two boundary-closing cyclic restrictions, which
+deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by replacing
+the paper's diagrammatic boundary-closing argument with a local coordinate
+equality. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
+boundary-closing coordinate comparison from the source's
+inverting-and-growing-back argument and remove the `sorry`; tracked in #2405. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -327,8 +333,10 @@ If the two cyclic restrictions agree, then their first-letter restrictions give
 Multiplying this equality on the left by \(A^\alpha\) and on the right by
 \(A^\sigma\) gives the displayed coordinate comparison.
 
-This left-multiplied comparison is recorded in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Scope restriction (boundary-closing restriction equality):** This lemma
+assumes the equality of the two boundary-closing restrictions rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -376,8 +384,16 @@ boundary-closing comparison is
   A^\alpha\bigl(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\bigr).
 \]
 
-**Gap dependency:** This comparison is derived from the boundary-closing
-restriction equality
+**Unfaithful:** This proof currently relies on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`, whose proof
+contains the unproved boundary-closing coordinate comparison. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
+Elimination: prove the boundary-closing coordinate comparison and reprove this
+theorem without the unfaithful comparison; tracked in #2405.
+
+The comparison is derived from the boundary-closing restriction equality
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
   =
@@ -432,12 +448,15 @@ remaining boundary-closing comparison is
   A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr).
 \]
 
-**Gap dependency:** This theorem uses the displayed comparison between the two
-cyclic restrictions, together with the one-sided last-boundary equation. That
-restriction equality is the local coordinate form of the sentence in
-arXiv:2011.12127, Section IV.C, lines 2078--2079, that the
-inverting-and-growing-back argument may also be applied when closing the
-boundary. See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** This proof currently relies on
+`closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap`, which
+transitively uses the unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -490,10 +509,15 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
   Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
 \]
 
-**Gap dependency:** This theorem is conditional on the left-multiplied
-comparison above. That formula is not displayed in the source; it is the
-coordinate reconstruction used here for arXiv:2011.12127, Section IV.C,
-lines 2078--2079. -/
+**Unfaithful:** This proof currently relies on
+`closure_property_mirror_left_word_products_of_groundSpaceMap`, which
+transitively uses the unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -285,7 +285,7 @@ the paper's diagrammatic boundary-closing argument with a local coordinate
 equality. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 boundary-closing coordinate comparison from the source's
-inverting-and-growing-back argument and remove the `sorry`; tracked in the paper-gap note. -/
+inverting-and-growing-back argument and remove the `sorry`. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -391,7 +391,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the boundary-closing coordinate comparison and reprove this
-theorem without the unfaithful comparison; tracked in the paper-gap note.
+theorem without the unfaithful comparison.
 
 The comparison is derived from the boundary-closing restriction equality
 \[
@@ -456,7 +456,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+unfaithful comparison. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -517,7 +517,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+unfaithful comparison. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -716,7 +716,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -752,7 +752,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem closure_property_boundary_right_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -799,7 +799,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -844,7 +844,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -884,7 +884,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -938,7 +938,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -981,7 +981,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
@@ -1025,7 +1025,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) :
@@ -1050,7 +1050,7 @@ from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
 coordinate form recorded for the paper's boundary-closing argument. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in #2405. -/
+unfaithful comparison; tracked in the paper-gap note. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -708,10 +708,15 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
   =
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma .
 \]
-**Open gap:** This follows from the boundary-closing reductions. The only
-unproved input in this chain is now the equality of the two boundary-closing
-cyclic restrictions; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** This proof currently relies on
+`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`, which
+transitively uses the unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -739,8 +744,15 @@ theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
 /-- Matrix equality obtained from the product equality and block injectivity:
 \(Y_M(\tau^+_\eta(\mu))A^j
 =Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\).
-**Open gap:** Inherits the boundary-closing restriction equality through the
-product equality above; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** This proof currently relies on
+`closure_property_boundary_closing_product_eq_of_chainGroundSpace`, which
+transitively uses the unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem closure_property_boundary_right_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -777,9 +789,17 @@ theorem closure_property_boundary_right_products_eq_of_chainGroundSpace
 
 /-- First-letter restriction equality \(R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu}\),
 obtained by restricting the displayed matrix equation at the first physical
-index.  **Open gap:** Inherits the boundary-closing restriction equality
-through the one-site product equality above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+index.
+
+**Unfaithful:** This proof currently relies on
+`closure_property_boundary_right_products_eq_of_chainGroundSpace`, which
+transitively uses the unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -814,10 +834,17 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
   exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
 /-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) at the closed
-boundary, obtained from the first-letter family.  **Open gap:** This is the
-chain-ground-space form of the boundary-closing restriction equality now
-isolated as a ground-space-map comparison; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+boundary, obtained from the first-letter family.
+
+**Unfaithful:** This proof currently relies on
+`closure_property_boundary_right_products_eq_of_chainGroundSpace`, which
+transitively uses the unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -848,9 +875,16 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
 with every \(A^j\) agree:
 \(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j
 \Rightarrow Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
-**Open gap:** Inherits the boundary-closing restriction equality through the
-one-site product comparison above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+
+**Unfaithful:** This proof currently relies on
+`closure_property_boundary_right_products_eq_of_chainGroundSpace`, which
+transitively uses the unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -895,8 +929,16 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 \(\mathcal G_{N,L}(A) \subseteq \mathbb C\,V^{(N)}(A)\) for \(L>L₀\).
 The source names the closure-property step in arXiv:2011.12127, Section IV.C,
 lines 2078--2079, and states the resulting uniqueness theorem in lines 2087--2090.
-**Open gap:** Depends on the comparison at the closed boundary; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+
+**Unfaithful:** This proof currently relies on
+`wrapped_mirror_witness_agree_of_chainGroundSpace`, which transitively uses the
+unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -931,8 +973,15 @@ for every \(L>L₀\), by the intersection property and closure property of
 arXiv:2011.12127, Section IV.C, lines 2078--2079.  The resulting
 periodic-chain uniqueness theorem is stated there in lines 2087--2090.
 
-**Open gap:** The containment direction depends on the closure property; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** This proof currently relies on
+`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`, which transitively
+uses the unproved boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
@@ -968,8 +1017,15 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
 
 /-- Unique ground state for tensors injective after blocking at range \(2L₀\).
 
-**Open gap:** This uses the normal closure-property equality; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** This proof currently relies on
+`chainGroundSpace_eq_mpvSubmodule_normal`, which transitively uses the unproved
+boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) :
@@ -986,8 +1042,15 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
   \dim \mathcal G_{N,L₀+1}(A)=1.
 \]
 
-**Open gap:** This depends on the normal closure-property equality above; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** This proof currently relies on
+`chainGroundSpace_eq_mpvSubmodule_normal`, which transitively uses the unproved
+boundary-closing coordinate comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
+coordinate form recorded for the paper's boundary-closing argument. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
+the boundary-closing coordinate comparison and reprove this theorem without the
+unfaithful comparison; tracked in #2405. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -702,21 +702,13 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
   exact hfixed j
 
-/-- Product equality needed after closing the boundary:
-\[
-  Y_M(\tau^+_\eta(\mu))A^jA^\sigma
-  =
-  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma .
-\]
-**Unfaithful:** This proof currently relies on
-`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`, which
-transitively uses the unproved boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+/-- Product equality needed after closing the boundary,
+\(Y_M(\tau^+_\eta(\mu))A^jA^\sigma =
+Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\).
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -742,17 +734,11 @@ theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     (A := A) hInj hL₀ hM YAt hYAt η μ ρPlus ρMinus hρPlus hρMinus hProductEq
 
 /-- Matrix equality obtained from the product equality and block injectivity:
-\(Y_M(\tau^+_\eta(\mu))A^j
-=Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\).
-**Unfaithful:** This proof currently relies on
-`closure_property_boundary_closing_product_eq_of_chainGroundSpace`, which
-transitively uses the unproved boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+\(Y_M(\tau^+_\eta(\mu))A^j = Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\).
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem closure_property_boundary_right_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -788,18 +774,11 @@ theorem closure_property_boundary_right_products_eq_of_chainGroundSpace
   exact sub_eq_zero.mp hsub
 
 /-- First-letter restriction equality \(R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu}\),
-obtained by restricting the displayed matrix equation at the first physical
-index.
-
-**Unfaithful:** This proof currently relies on
-`closure_property_boundary_right_products_eq_of_chainGroundSpace`, which
-transitively uses the unproved boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+obtained by restricting the displayed matrix equation at the first physical index.
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -833,18 +812,12 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j
   exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
-/-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) at the closed
-boundary, obtained from the first-letter family.
-
-**Unfaithful:** This proof currently relies on
-`closure_property_boundary_right_products_eq_of_chainGroundSpace`, which
-transitively uses the unproved boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+/-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) at the closed boundary,
+obtained from the first-letter family.
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -873,18 +846,12 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
 
 /-- The two boundary-condition matrix families agree once their right-products
 with every \(A^j\) agree:
-\(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j
-\Rightarrow Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
-
-**Unfaithful:** This proof currently relies on
-`closure_property_boundary_right_products_eq_of_chainGroundSpace`, which
-transitively uses the unproved boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+\(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j \Rightarrow
+Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -929,16 +896,10 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 \(\mathcal G_{N,L}(A) \subseteq \mathbb C\,V^{(N)}(A)\) for \(L>L₀\).
 The source names the closure-property step in arXiv:2011.12127, Section IV.C,
 lines 2078--2079, and states the resulting uniqueness theorem in lines 2087--2090.
-
-**Unfaithful:** This proof currently relies on
-`wrapped_mirror_witness_agree_of_chainGroundSpace`, which transitively uses the
-unproved boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -965,23 +926,13 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_wrapped_witness_comparison
     (A := A) (L₀ := L₀) (N := N) hInj hL₀ η Ywrap Ymirror hWrap hMirror hCompare
 
-/-- On a periodic chain, the normal parent-Hamiltonian ground space satisfies
-\[
-  \mathcal G_{N,L}(A)=\mathbb C\,V^{(N)}(A)
-\]
-for every \(L>L₀\), by the intersection property and closure property of
-arXiv:2011.12127, Section IV.C, lines 2078--2079.  The resulting
-periodic-chain uniqueness theorem is stated there in lines 2087--2090.
-
-**Unfaithful:** This proof currently relies on
-`chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`, which transitively
-uses the unproved boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+/-- On a periodic chain, \(\mathcal G_{N,L}(A)=\mathbb C\,V^{(N)}(A)\) for every
+\(L>L₀\), by the intersection and closure properties in arXiv:2011.12127,
+Section IV.C, lines 2078--2090.
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N) :
@@ -1016,16 +967,10 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
   simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
 
 /-- Unique ground state for tensors injective after blocking at range \(2L₀\).
-
-**Unfaithful:** This proof currently relies on
-`chainGroundSpace_eq_mpvSubmodule_normal`, which transitively uses the unproved
-boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) :
@@ -1038,19 +983,11 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
   simpa [mpvSubmodule] using finrank_span_singleton (K := ℂ) hmpv
 
 /-- Unique ground state for normal tensors at range \(L₀+1\):
-\[
-  \dim \mathcal G_{N,L₀+1}(A)=1.
-\]
-
-**Unfaithful:** This proof currently relies on
-`chainGroundSpace_eq_mpvSubmodule_normal`, which transitively uses the unproved
-boundary-closing coordinate comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison; tracked in the paper-gap note. -/
+\(\dim \mathcal G_{N,L₀+1}(A)=1\).
+**Unfaithful:** This proof relies directly or transitively on
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
+form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 ≤ N) :


### PR DESCRIPTION
### Motivation

- The parent-Hamiltonian modules used non-standard `**Open gap:**` / `**Gap dependency:**` markers for the boundary-closing comparison.
- This PR aligns those markers with the `**Unfaithful:**` / `**Scope restriction (...):**` vocabulary required by `CLAUDE.md`.
- The mathematical gap remains documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; #2405 is the PR-level tracking issue for proving the boundary-closing coordinate comparison. Lean docstrings cite the paper-gap note rather than GitHub issue numbers, as required by the prose checker.

### Description

- `BoundaryClosing.lean`: marks lemmas that assume the boundary-closing restriction equality as `**Scope restriction (...):**`.
- `BoundaryClosingStripping.lean`: marks the boundary-closing comparison itself and its direct downstream consequences as `**Unfaithful:**`.
- `UniqueGroundState.lean`: marks the normal-range containment and uniqueness chain as transitively `**Unfaithful:**`.
- Keeps both touched large files at the 1000-line guard limit; no theorem statements or proof bodies are changed.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.UniqueGroundState`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check origin/main...HEAD`

---
Closes #2778

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only docstring edits with no changes to proofs or theorem statements; risk is limited to prose consistency and reviewer-facing clarity.
> 
> **Overview**
> This PR **only updates Lean docstrings**; theorem statements and proofs are unchanged.
> 
> It replaces ad hoc `**Open gap:**` / `**Gap dependency:**` notes with the repo-standard **`**Unfaithful:**`** and **`**Scope restriction (...):**`** labels from `CLAUDE.md`, so readers can see which results assume the boundary-closing coordinate comparison vs. which merely inherit it transitively.
> 
> **Parent-Hamiltonian boundary closing:** `BoundaryClosing.lean` and `BoundaryClosingStripping.lean` mark assumed restriction equalities and left-multiplied comparisons as scope restrictions; the main `closure_property_boundary_restrictions_eq_of_groundSpaceMap` chain and downstream lemmas are marked **Unfaithful** with pointers to `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and arXiv:2011.12127 IV.C (2078–2079). `UniqueGroundState.lean` tags the normal-range containment and uniqueness chain the same way.
> 
> **Downstream propagation:** The same **Unfaithful** boilerplate is added on finite-C1 BNT/direct-sum theorems in `BNTDirectSum.lean`, `DirectSumUniqueness.lean`, `BNTBlockIntersection.lean`, `BNTBlockDiagonalChain.lean`, and `BNTBlockDiagonalCrossing.lean`, citing the named lemma each proof depends on and the same paper-gap note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bce205a118e0e2c7f0472e58c22f84ae625a5a7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->