### PR TITLE
doc(README): refresh Wielandt theorem name and add SharedInfra to module table

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ modules.  A central current theorem is the cumulative $D^2$ bound for the
 project's normality predicate:
 
 ```lean
-theorem cumulative_wielandt_bound [NeZero D]
+theorem cumulativeSpan_eq_top_of_isNormal_bound [NeZero D]
     (A : MPSTensor d D) (hN : IsNormal A) :
     cumulativeSpan A (D ^ 2) = ⊤
 ```
@@ -158,6 +158,7 @@ import.  The main source tree is organized as follows.
 | `TNLean/MPS/FundamentalTheorem`, `TNLean/MPS/BNT`, `TNLean/MPS/CanonicalForm`, `TNLean/MPS/Periodic`, `TNLean/MPS/Structure` | Single-block, same-structure, BNT, periodic, and canonical-form Fundamental-Theorem material. |
 | `TNLean/MPS/Symmetry` | Gauge uniqueness, on-site symmetries, virtual representations, cocycle coboundaries, symmetric MPS, and string-order infrastructure. |
 | `TNLean/MPS/Irreducible` | Fixed-point projections, Form II reductions, scalar fixed points, adjoint irreducibility, and periodic-blocking infrastructure for irreducible blocks. |
+| `TNLean/MPS/SharedInfra` | Cross-cutting helpers reused across the canonical-form, irreducible, and Wielandt developments: block assembly and gauge data, gauge-phase normalization, Kraus-adjoint setup, scaling, and sector decomposition. |
 | `TNLean/MPS/ParentHamiltonian` | Parent Hamiltonians, local projectors, ground spaces, intersection and wrapping-window arguments, commuting cases, and martingale estimates. |
 | `TNLean/MPS/MPDO`, `TNLean/MPS/RFP` | MPDO/LPDO foundations, canonical-form and zero-correlation-length predicates, pure RFP structures, and structural bridges. |
 | `TNLean/MPS/Examples` | Example tensors and state families, including AKLT, even-parity, GHZ, and $\mathbb{Z}/2$ examples. |


### PR DESCRIPTION
### Motivation

- The README code example quoted `cumulative_wielandt_bound` as a central theorem, but that declaration was renamed to `cumulativeSpan_eq_top_of_isNormal_bound` in `TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean`; the stale name misleads readers about the current library interface.
- The module structure table omitted the `TNLean/MPS/SharedInfra` subtree, leaving a gap in the documented layout.

### Description

- `README.md`: updated the Wielandt bound code block to use the current declaration name `cumulativeSpan_eq_top_of_isNormal_bound` (was `cumulative_wielandt_bound`).
- `README.md`: added a row for `TNLean/MPS/SharedInfra` to the module structure table, describing cross-cutting helpers reused by the canonical-form, irreducible, and Wielandt developments: block assembly and gauge data, gauge-phase normalization, Kraus-adjoint setup, scaling, and sector decomposition.

### Testing

- No Lean code changed; documentation-only edits carry no build or runtime impact.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
No issue linked. The author should add an `Addresses #N` reference if a tracking issue exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no Lean code, build, or runtime impact.
>
> **Overview**
> Updates **README** documentation so it matches the current library layout and theorem names.
>
> The Quantum Wielandt example now quotes **`cumulativeSpan_eq_top_of_isNormal_bound`** instead of the retired **`cumulative_wielandt_bound`**, aligning the docs with `TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean`.
>
> The module structure table adds a row for **`TNLean/MPS/SharedInfra`**, describing cross-cutting helpers (block assembly, gauge normalization, Kraus-adjoint setup, scaling, sector decomposition) used by canonical-form, irreducible, and Wielandt work.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a20b7ccd53d4036540cc40a843a3ec3831ad45e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->