### PR TITLE
doc(PEPS): align Molnar normal theorem citations

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft.tex
+++ b/blueprint/src/chapter/ch24_peps_ft.tex
@@ -63,8 +63,14 @@ main results of the chapter make this precise.
     \item For a normal PEPS on a connected graph the same conclusion holds once
         the tensors become injective after blocking suitable regions
         (Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected}; the general
-        normal-PEPS theorem stated after \cite[Theorem~3]{Molnar2018NormalPEPS}).
+        normal-PEPS theorem in \cite[Section~4]{Molnar2018NormalPEPS}, following
+        its Theorem~3).
 \end{itemize}
+
+In the citations below, \cite[Theorem~3]{Molnar2018NormalPEPS} denotes only
+the translationally invariant square-lattice theorem. The connected-graph
+normal theorem and the normal-MPS corollaries are cited as results of
+\cite[Section~4]{Molnar2018NormalPEPS}.
 
 The chapter builds these results in stages.
 Section~\ref{sec:peps_foundations} fixes the tensors, the generated state, the

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -5,9 +5,9 @@ tensors are injective after blocking around every edge and that each site
 separates two injective regions whose complements are also injective, are what
 the injective theorem needs once union closure is in hand. The Fundamental
 Theorem for normal PEPS, Theorem~\ref{thm:fundamentalTheorem_normalPEPS_connected},
-follows on a connected graph; this is the general normal-PEPS theorem stated
-after \cite[Theorem~3]{Molnar2018NormalPEPS}, and its gauges are unique modulo
-balanced edge scalars.
+follows on a connected graph; this is the general normal-PEPS theorem in
+\cite[Section~4]{Molnar2018NormalPEPS}, following its Theorem~3, and its
+gauges are unique modulo balanced edge scalars.
 The corollaries specialize it to closed chains, translation-invariant matrix
 product states, and the square lattice.
 
@@ -80,8 +80,8 @@ product states, and the square lattice.
     two injective regions with injective complements that differ exactly at
     that site. Then their defining tensors are related by a local gauge, and
     the gauges are unique up to the scalar freedom allowed by the graph. This
-    is the general normal-PEPS theorem stated after
-    \cite[Theorem~3]{Molnar2018NormalPEPS}.
+    is the general normal-PEPS theorem in
+    \cite[Section~4]{Molnar2018NormalPEPS}, following its Theorem~3.
     A connected-graph form, with the blocking hypothesis stated as the
     source's proof uses it (one blocking shared by the two states, each
     distinguished edge the entire bond of its chain), is
@@ -179,8 +179,8 @@ product states, and the square lattice.
     defining tensors are related by a local gauge: there are invertible
     matrices, one on each edge, whose endpoint actions transform $A_v$ into
     $B_v$ at every vertex, with no leftover scalar.
-    This is the general normal-PEPS theorem stated after
-    \cite[Theorem~3]{Molnar2018NormalPEPS}
+    This is the general normal-PEPS theorem in
+    \cite[Section~4]{Molnar2018NormalPEPS}, following its Theorem~3
     (Theorem~\ref{thm:fundamentalTheorem_normalPEPS}), with the source's
     blocking hypothesis stated explicitly as its proof uses it, in two ways,
     neither of which restricts the source statement.  First, the blockings
@@ -196,10 +196,10 @@ product states, and the square lattice.
     In the source, blocking around an edge groups all vertices except the two
     endpoints of the edge, so the edge is the bond between the first two
     parties; the regions in the proof of
-    \cite[Theorem~3]{Molnar2018NormalPEPS} enlarge those parties to injective
-    blocks meeting only along the distinguished edge, and the gauge of the
-    isomorphism lemma lives on that edge of the original network. The
-    equality of the bond dimensions is not assumed; it is derived from the
+    \cite[Section~4, proof of Theorem~3]{Molnar2018NormalPEPS} enlarge those
+    parties to injective blocks meeting only along the distinguished edge,
+    and the gauge of the isomorphism lemma lives on that edge of the original
+    network. The equality of the bond dimensions is not assumed; it is derived from the
     blocking hypotheses
     (Theorem~\ref{thm:peps_bondDim_eq_of_normalBlocking}), as in the source's
     isomorphism lemma. The
@@ -258,9 +258,10 @@ product states, and the square lattice.
     the endpoint actions of the family transform $A_v$ into $B_v$.  Then the
     two families are proportional at every edge: $X'_e = c\cdot X_e$ for a
     nonzero scalar $c$ depending on the edge.  This is the uniqueness clause
-    of the general normal-PEPS theorem stated after
-    \cite[Theorem~3]{Molnar2018NormalPEPS}, read against the scalar-free
-    relation; neither equality of the two states nor connectivity is needed.
+    of the general normal-PEPS theorem in
+    \cite[Section~4]{Molnar2018NormalPEPS}, following its Theorem~3, read
+    against the scalar-free relation; neither equality of the two states nor
+    connectivity is needed.
     \begin{proof}
         \leanok
         \uses{thm:peps_gaugeConj_eq_of_coeffIdentities,
@@ -332,7 +333,7 @@ product states, and the square lattice.
     transform $A_i$ into $B_i$ at every site with no leftover scalar.  This
     is the source's family $Z_i$ ($i = 1, \dots, n$, $n + 1 \equiv 1$) with
     $B_i = Z_i^{-1} A_i Z_{i+1}$, the first corollary following the general
-    normal-PEPS theorem of \cite[Section~3]{Molnar2018NormalPEPS}, the
+    normal-PEPS theorem in \cite[Section~4]{Molnar2018NormalPEPS}, the
     statement for MPS without translation invariance at a fixed system size.
     The positive physical and bond dimensions are the counterexample-backed
     corrections carried over from the injective Fundamental Theorem
@@ -369,7 +370,7 @@ product states, and the square lattice.
     proportional at every bond: $Z'_i = c \cdot Z_i$ for a nonzero scalar
     $c$ depending on the bond.  This is the uniqueness clause of the first
     corollary following the general normal-PEPS theorem of
-    \cite[Section~3]{Molnar2018NormalPEPS}: the gauges $Z_i$ are unique up
+    \cite[Section~4]{Molnar2018NormalPEPS}: the gauges $Z_i$ are unique up
     to a multiplicative constant.  Neither equality of the two states nor
     connectivity is needed, as in the general uniqueness clause.
 \end{corollary}
@@ -474,7 +475,7 @@ product states, and the square lattice.
         \qquad\text{for every site } v \text{ and every } i .
     \]
     This is the first corollary following the general normal-PEPS theorem of
-    \cite[Section~3]{Molnar2018NormalPEPS} specialized to one
+    \cite[Section~4]{Molnar2018NormalPEPS} specialized to one
     site-independent tensor: the source states the corollary for
     site-dependent families, and its conclusion is the per-bond gauge family
     delivered here.  The source's translation-invariant corollary (a single
@@ -518,7 +519,7 @@ product states, and the square lattice.
     are proportional by a single constant: there is a nonzero scalar $c$
     with $Z'_v = c\,Z_v$ at every bond.  This is the uniqueness clause of
     the first corollary following the general normal-PEPS theorem of
-    \cite[Section~3]{Molnar2018NormalPEPS}, for one site-independent
+    \cite[Section~4]{Molnar2018NormalPEPS}, for one site-independent
     tensor.  Equality of the two states is not needed.
 \end{corollary}
 \begin{proof}\leanok
@@ -580,7 +581,7 @@ product states, and the square lattice.
         B^i = \lambda\, Z^{-1} A^i Z \qquad\text{for every } i .
     \]
     This is the translation-invariant corollary of
-    \cite[Section~3]{Molnar2018NormalPEPS}, the statement for TI MPS
+    \cite[Section~4]{Molnar2018NormalPEPS}, the statement for TI MPS
     following the first corollary after the general normal-PEPS theorem.
     Positivity of the bond dimension is not assumed: a vanishing bond
     dimension makes the conclusion trivial.
@@ -616,7 +617,7 @@ product states, and the square lattice.
     $B^i = \lambda\, Z^{-1} A^i Z$ and $B^i = \lambda'\, Z'^{-1} A^i Z'$ for
     every $i$, then there is a nonzero scalar $c$ with $Z' = c\,Z$.  This is
     the uniqueness clause of the translation-invariant corollary of
-    \cite[Section~3]{Molnar2018NormalPEPS} for TI MPS.  No system size
+    \cite[Section~4]{Molnar2018NormalPEPS} for TI MPS.  No system size
     enters the statement: equality of the two states is not needed, nor are
     the root-of-unity conditions on $\lambda$ and $\lambda'$.
 \end{corollary}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
@@ -130,8 +130,8 @@ every finite union of injective regions.
     \lean{TNLean.PEPS.InjectiveUnionContractionMaps}
     \leanok
     Let $K$, $E_{012}$, $E_2$, and $E_{12}$ be complex vector spaces. A
-    contraction-map family for the proof of
-    \cite[Section~3]{Molnar2018NormalPEPS} consists of three linear maps
+    contraction-map family for the union-injectivity lemma in
+    \cite[Section~4]{Molnar2018NormalPEPS} consists of three linear maps
     $\mathcal C_{\{0,1,2\}}:K\to E_{012}$,
     $\mathcal C_{\{2\}}:K\to E_2$, and
     $\mathcal C_{\{1,2\}}:K\to E_{12}$.
@@ -160,7 +160,8 @@ every finite union of injective regions.
     $\mathcal C_{\{0,1,2\}}:K\to E_{012}$,
     $\mathcal C_{\{2\}}:K\to E_2$, and
     $\mathcal C_{\{1,2\}}:K\to E_{12}$ be the three contraction maps in the
-    proof of \cite[Section~3]{Molnar2018NormalPEPS}. If
+    proof of the union-injectivity lemma in
+    \cite[Section~4]{Molnar2018NormalPEPS}. If
     \[
         \mathcal C_{\{0,1,2\}}(X)=0
         \Longrightarrow \mathcal C_{\{2\}}(X)=0,\qquad
@@ -196,8 +197,8 @@ every finite union of injective regions.
         \Longrightarrow
         \operatorname{inj}(A\cup B).
     \]
-    The proof in \cite[Section~3]{Molnar2018NormalPEPS} blocks the network into
-    four parts $A\setminus B$, $A\cap B$, $B\setminus A$, and
+    The union-injectivity proof in \cite[Section~4]{Molnar2018NormalPEPS}
+    blocks the network into four parts $A\setminus B$, $A\cap B$, $B\setminus A$, and
     $(A\cup B)^c$, and applies the two available left inverses in sequence:
     \begin{center}
         \TNPEPSInjectiveRegionUnion
@@ -435,7 +436,7 @@ every finite union of injective regions.
         \sum_{\nu}K_R^X(\mu,\nu)\,T_{B,R}^{\nu}(\tau).
     \]
     This is the gauge absorption of the blocked tensor in
-    \cite[Section~3, proof of Theorem~3]{Molnar2018NormalPEPS}.
+    \cite[Section~4, proof of Theorem~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 \begin{proof}\leanok
     Start from Theorem~\ref{thm:peps_regionBlockedWeight_applyGauge_eq_globalSum}

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -1141,7 +1141,7 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
 \end{proof}
 
 \begin{remark}[Normal-region form]
-    The normal-region application in \cite[Section~3]{Molnar2018NormalPEPS}
+    The normal-region application in \cite[Section~4]{Molnar2018NormalPEPS}
     uses the same scalar comparison after comparing two injective regions
     $R\subset S=R\cup\{v\}$. If the region comparisons give
     $A_R=\lambda_R\widetilde B_R$ and

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -486,7 +486,7 @@ site-independent tensor and produces the global phase of
     where $P_{V\setminus S}$ is the product of bond dimensions over the edges
     not crossing the boundary of $V\setminus S$.  This is the open-boundary
     form of the extension used in the overlapping-window proof sketch of
-    \cite[Section~3]{Molnar2018NormalPEPS}.
+    \cite[Section~4, proof of Theorem~3]{Molnar2018NormalPEPS}.
 \end{definition}
 
 \begin{theorem}[State preservation under corner extension]
@@ -519,7 +519,7 @@ site-independent tensor and produces the global phase of
         \Phi_{R,P}\bigl(\mu,\sigma|_{P\setminus R},\omega\bigr).
     \]
     This is the two-block merge collapse in the proof of
-    \cite[Section~3]{Molnar2018NormalPEPS}.
+    \cite[Section~4, proof of Theorem~3]{Molnar2018NormalPEPS}.
 \end{theorem}
 
 \begin{theorem}[Linearity and transitivity of corner extension]


### PR DESCRIPTION
### Motivation

- The PEPS chapter (`blueprint/src/chapter/ch24_peps_ft.tex` and subfiles) cited `\cite[Theorem~3]{Molnar2018NormalPEPS}` for both the translationally invariant square-lattice normal PEPS result (Theorem 3 of arXiv:1804.04964) and the more general connected-graph normal result (`thm:normal`, Section 4 of arXiv:1804.04964), diverging from the paper's own numbering.
- Aligns citations to the paper (resolution (A) from #2810): `\cite[Theorem~3]{Molnar2018NormalPEPS}` is reserved for the 2D TI square-lattice theorem; the general connected-graph normal result and its normal-MPS corollaries are cited as Section 4 results.

### Description

- `ch24_peps_ft.tex`: reserved `\cite[Theorem~3]{Molnar2018NormalPEPS}` for the translationally invariant square-lattice normal PEPS theorem (Theorem 3, Section 4 of arXiv:1804.04964) only.
- `ch24_peps_ft_normal_capstone.tex`: retargeted the connected-graph normal fundamental theorem, its uniqueness clauses, and normal-MPS corollaries from `\cite[Theorem~3]{...}` to `\cite[Section~4]{...}`.
- `ch24_peps_ft_normal_union.tex`: redirected normal-union references (union injectivity, contraction maps, gauge absorption) from Section 3 to Section 4.
- `ch24_peps_ft_region_transfer.tex`, `ch24_peps_ft_torus.tex`: moved torus-window and corner-extension proof-sketch references from Section 3 to Section 4; injective PEPS Section 3 citations are unchanged.
- No Lean source files modified; this is a blueprint-only citation correction.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- `cd blueprint && leanblueprint web` (exit 0; pre-existing bibliography/package warnings in local environment)

---
Closes #2810

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX citation and prose changes with no Lean or runtime behavior impact.
>
> **Overview**
> **Citation alignment** for `Molnar2018NormalPEPS` in the PEPS Fundamental Theorem blueprint: `\cite[Theorem~3]{Molnar2018NormalPEPS}` is documented as **only** the translationally invariant square-lattice normal PEPS theorem (torus / square-lattice entries unchanged in role).
>
> The **connected-graph normal fundamental theorem**, its uniqueness clauses, and **normal-MPS corollaries** are retargeted from Section 3 to **Section 4**, with wording such as "following its Theorem~3" where the general result sits after the square-lattice theorem in the source.
>
> **Normal-union** material (union injectivity, contraction maps, gauge absorption) and **torus** overlapping-window / corner-extension proof sketches that track the normal route are similarly moved from Section 3 to **Section 4** (often `\cite[Section~4, proof of Theorem~3]{...}`). **Injective PEPS** prose that still maps to the injective route continues to cite **Section 3** (e.g. region transfer, edge kernels).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01ac6b7b5e82b2c9476f3829472800f9e7d43223. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>