### PR TITLE
refactor(MPS/MPDO): relocate pure entropy lemma

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -594,3 +594,42 @@ def IsSAL (A : MPSTensor d D) : Prop :=
       = pureBlockEntropy A N (L + 1) (hL.trans_le (Nat.div_le_self N 2))
 
 end MPSTensor
+
+open Polynomial in
+/-- **The normalized global pure state has zero von Neumann entropy** (`S_N = 0`,
+arXiv:1606.00608, Section 3, line 599). The state `|V⟩⟨V| / ‖V‖²` is a rank-one
+projector, so its characteristic polynomial is `X^{n-1}(X - 1)` and the entropy
+sum over the eigenvalues of -λ log λ vanishes. -/
+theorem vonNeumannEntropy_normalizedPureState {d D : ℕ} (A : MPSTensor d D) (N : ℕ)
+    (htr : Matrix.trace (MPSTensor.pureState A N) ≠ 0) :
+    vonNeumannEntropy (MPSTensor.normalizedPureState A N)
+        (MPSTensor.normalizedPureState_isHermitian A N) = 0 := by
+  set n := Fintype.card (Fin N → Fin d) with hn
+  have hcard : 1 ≤ n := by
+    rw [hn, Nat.one_le_iff_ne_zero]; intro h0
+    haveI : IsEmpty (Fin N → Fin d) := Fintype.card_eq_zero_iff.mp h0
+    exact htr (by simp [Matrix.trace, Matrix.diag, Finset.univ_eq_empty])
+  have hdotEq : (fun σ : Fin N → Fin d => MPSTensor.mpv A σ) ⬝ᵥ
+      (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) =
+      Matrix.trace (MPSTensor.pureState A N) := by
+    rw [Matrix.trace]
+    simp only [Matrix.diag, MPSTensor.pureState, Matrix.vecMulVec_apply, dotProduct,
+      Pi.star_apply]
+  have hnp : MPSTensor.normalizedPureState A N
+      = Matrix.vecMulVec ((Matrix.trace (MPSTensor.pureState A N))⁻¹ •
+          (fun σ : Fin N → Fin d => MPSTensor.mpv A σ))
+          (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) := by
+    rw [Matrix.smul_vecMulVec]; rfl
+  have hdot : ((Matrix.trace (MPSTensor.pureState A N))⁻¹ •
+        (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) ⬝ᵥ
+        (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) = 1 := by
+    rw [smul_dotProduct, hdotEq, smul_eq_mul, inv_mul_cancel₀ htr]
+  rw [vonNeumannEntropy_eq_charpoly_roots, hnp, Matrix.charpoly_vecMulVec, hdot, one_smul, ← hn]
+  have hX1 : (X - 1 : ℂ[X]) ≠ 0 := by
+    rw [show (1 : ℂ[X]) = C 1 by simp]; exact X_sub_C_ne_zero 1
+  have hfact : (X ^ n - X ^ (n - 1) : ℂ[X]) = X ^ (n - 1) * (X - 1) := by
+    rw [mul_sub, mul_one, ← pow_succ, Nat.sub_add_cancel hcard]
+  rw [hfact, Polynomial.roots_mul (mul_ne_zero (pow_ne_zero _ X_ne_zero) hX1),
+    Polynomial.roots_pow, Polynomial.roots_X,
+    show (X - 1 : ℂ[X]) = X - C 1 by simp, Polynomial.roots_X_sub_C]
+  simp [Multiset.map_nsmul, Multiset.sum_nsmul, Real.negMulLog_zero, Real.negMulLog_one]

--- a/TNLean/MPS/MPDO/Defs.lean
+++ b/TNLean/MPS/MPDO/Defs.lean
@@ -302,8 +302,8 @@ theorem IsLPDO.isMPDO {M : MPOTensor d D} (h : IsLPDO M) : IsMPDO M := by
   simp_rw [Matrix.trace_kronecker]
   -- trace of entrywise conjugate = conjugate of trace: trace(A.map star) = star(trace A)
   simp_rw [← AddMonoidHom.map_trace (starRingEnd ℂ)]
-  -- Push σ τ application inside the sum on the RHS, expand vecMulVec
-  erw [Fintype.sum_apply σ, Fintype.sum_apply τ]; congr 1
+  -- Evaluate the entries of the finite sum of rank-one matrices.
+  simp only [Matrix.sum_apply, Matrix.vecMulVec_apply, Pi.star_apply, starRingEnd_apply]
 
 /-! ### MPDO renormalization fixed points -/
 

--- a/TNLean/MPS/MPDO/PureAreaLaw.lean
+++ b/TNLean/MPS/MPDO/PureAreaLaw.lean
@@ -211,7 +211,8 @@ theorem gram_complement (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
 
 /-- The trace of the pure state is real: conjugating it leaves it unchanged. -/
 theorem trace_pureState_conj (A : MPSTensor d D) (N : ℕ) :
-    starRingEnd ℂ (Matrix.trace (MPSTensor.pureState A N)) = Matrix.trace (MPSTensor.pureState A N) := by
+    starRingEnd ℂ (Matrix.trace (MPSTensor.pureState A N))
+      = Matrix.trace (MPSTensor.pureState A N) := by
   have h := Matrix.trace_conjTranspose (MPSTensor.pureState A N)
   rw [(MPSTensor.pureState_isHermitian A N)] at h
   rw [starRingEnd_apply]; exact h.symm
@@ -239,10 +240,12 @@ theorem pureBlockEntropy_complement (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ 
     rw [hc]
   have e3 : MPSTensor.reducedPureBlockState A N (N - L) (Nat.sub_le N L)
       = (c • (Wᴴ * W)).map (starRingEnd ℂ) := by
-    rw [reducedPureBlockState_eq_gram A N (N - L) (Nat.sub_le N L), gram_complement A N L hL, hmapsmul]
+    rw [reducedPureBlockState_eq_gram A N (N - L) (Nat.sub_le N L),
+      gram_complement A N L hL, hmapsmul]
   rw [MPSTensor.pureBlockEntropy, MPSTensor.pureBlockEntropy,
     vonNeumannEntropy_congr e1 (MPSTensor.reducedPureBlockState_isHermitian A N L hL) hcWW,
-    vonNeumannEntropy_congr e3 (MPSTensor.reducedPureBlockState_isHermitian A N (N - L) (Nat.sub_le N L)) hmapH,
+    vonNeumannEntropy_congr e3
+      (MPSTensor.reducedPureBlockState_isHermitian A N (N - L) (Nat.sub_le N L)) hmapH,
     vonNeumannEntropy_mul_comm (c • W) Wᴴ hcWW hWcW,
     vonNeumannEntropy_congr e2 hWcW hHWW,
     vonNeumannEntropy_map_conj (c • (Wᴴ * W)) hHWW]
@@ -274,46 +277,6 @@ theorem pureBlockEntropy_monotone (A : MPSTensor d D) {N L : ℕ} (hN : 2 * L + 
   rw [← blockEntropy_doubledTensor A N L (by omega),
     ← blockEntropy_doubledTensor A N (L + 1) (by omega)]
   linarith [key, s1, s2]
-
-/-! ## The global pure state has zero entropy (S_N = 0) -/
-
-open Polynomial in
-/-- **The normalized global pure state has zero von Neumann entropy** (`S_N = 0`,
-arXiv:1606.00608, Section 3, line 599). The state `|V⟩⟨V| / ‖V‖²` is a rank-one
-projector, so its characteristic polynomial is `X^{n-1}(X - 1)` and the entropy
-sum `∑ negMulLog(λ)` vanishes. -/
-theorem vonNeumannEntropy_normalizedPureState (A : MPSTensor d D) (N : ℕ)
-    (htr : Matrix.trace (MPSTensor.pureState A N) ≠ 0) :
-    vonNeumannEntropy (MPSTensor.normalizedPureState A N)
-        (MPSTensor.normalizedPureState_isHermitian A N) = 0 := by
-  set n := Fintype.card (Fin N → Fin d) with hn
-  have hcard : 1 ≤ n := by
-    rw [hn, Nat.one_le_iff_ne_zero]; intro h0
-    haveI : IsEmpty (Fin N → Fin d) := Fintype.card_eq_zero_iff.mp h0
-    exact htr (by simp [Matrix.trace, Matrix.diag, Finset.univ_eq_empty])
-  have hdotEq : (fun σ : Fin N → Fin d => MPSTensor.mpv A σ) ⬝ᵥ
-      (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) = Matrix.trace (MPSTensor.pureState A N) := by
-    rw [Matrix.trace]
-    simp only [Matrix.diag, MPSTensor.pureState, Matrix.vecMulVec_apply, dotProduct, Pi.star_apply]
-  have hnp : MPSTensor.normalizedPureState A N
-      = Matrix.vecMulVec ((Matrix.trace (MPSTensor.pureState A N))⁻¹ •
-          (fun σ : Fin N → Fin d => MPSTensor.mpv A σ))
-          (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) := by
-    rw [Matrix.smul_vecMulVec]; rfl
-  have hdot : ((Matrix.trace (MPSTensor.pureState A N))⁻¹ •
-        (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) ⬝ᵥ
-        (star (fun σ : Fin N → Fin d => MPSTensor.mpv A σ)) = 1 := by
-    rw [smul_dotProduct, hdotEq, smul_eq_mul, inv_mul_cancel₀ htr]
-  rw [vonNeumannEntropy_eq_charpoly_roots, hnp, Matrix.charpoly_vecMulVec, hdot, one_smul, ← hn]
-  have hX1 : (X - 1 : ℂ[X]) ≠ 0 := by
-    rw [show (1 : ℂ[X]) = C 1 by simp]; exact X_sub_C_ne_zero 1
-  have hfact : (X ^ n - X ^ (n - 1) : ℂ[X]) = X ^ (n - 1) * (X - 1) := by
-    rw [mul_sub, mul_one, ← pow_succ, Nat.sub_add_cancel hcard]
-  rw [hfact, Polynomial.roots_mul (mul_ne_zero (pow_ne_zero _ X_ne_zero) hX1),
-    Polynomial.roots_pow, Polynomial.roots_X,
-    show (X - 1 : ℂ[X]) = X - C 1 by simp, Polynomial.roots_X_sub_C]
-  simp [Multiset.map_nsmul, Multiset.sum_nsmul, Real.negMulLog_zero, Real.negMulLog_one]
-
 
 /-! ## S_N = 0 and the pure mutual information `I_L = 2 S_L` -/
 


### PR DESCRIPTION
### Motivation

- `vonNeumannEntropy_normalizedPureState` is placed in `PureAreaLaw.lean`, outside its natural home; it belongs in `AreaLaw.lean`, where `normalizedPureState` and related pure-state definitions are introduced. Follow-up to #2770.
- An `erw` tactic call in `IsLPDO.isMPDO` in `Defs.lean` should be replaced with `simp only` for alignment with Mathlib tactic style.

### Description

- Move `vonNeumannEntropy_normalizedPureState` (the zero-entropy theorem for normalized pure MPDO states) from `TNLean/MPS/MPDO/PureAreaLaw.lean` to `TNLean/MPS/MPDO/AreaLaw.lean`, with explicit `MPSTensor` namespace on the statement. `pureBlockEntropy_full` continues to reach it through the import chain (`PureAreaLaw` → `MutualInfoMonotone` → `AreaLaw`).
- Replace the `erw` on `Fintype.sum_apply` in `IsLPDO.isMPDO` (`TNLean/MPS/MPDO/Defs.lean`) with `simp only [Matrix.sum_apply]` and rank-one matrix entry lemmas.
- Wrap long lines in `TNLean/MPS/MPDO/PureAreaLaw.lean` around `trace_pureState_conj` and `pureBlockEntropy_complement`, exposed by the lemma removal.
- Note: `TNLean/MPS/RFP/Defs.lean` contains no `erw` occurrences on current `main`; the erw fix from issue item 1 was addressed via `MPDO/Defs.lean` instead.

### Testing

- `lake build TNLean.MPS.MPDO.Defs TNLean.MPS.MPDO.AreaLaw TNLean.MPS.MPDO.PureAreaLaw`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- `rg -n "\berw\b" TNLean/MPS/RFP/Defs.lean TNLean/MPS/MPDO/Defs.lean` (no matches)

---
Closes #2809

> [!NOTE]
> **Low Risk**
> Proof-only refactor and lemma relocation with no API or runtime behavior changes; import order already exposes the moved theorem to PureAreaLaw callers.
>
> **Overview**
> Moves **`vonNeumannEntropy_normalizedPureState`** from `PureAreaLaw.lean` into **`AreaLaw.lean`**, next to `normalizedPureState` and related pure-state definitions, with explicit `MPSTensor` namespaces on the statement. **`pureBlockEntropy_full`** still applies that theorem via the import chain (`PureAreaLaw` → `MutualInfoMonotone` → `AreaLaw`).
>
> In **`Defs.lean`**, the `IsLPDO.isMPDO` matrix-entry step no longer uses `erw` on `Fintype.sum_apply`; it finishes with **`simp only`** on `Matrix.sum_apply` and rank-one matrix entries.
>
> **`PureAreaLaw.lean`** drops the duplicated zero-entropy section and only has minor line-wrapping around `trace_pureState_conj` and `pureBlockEntropy_complement`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e55cffaecf8a819436e464cbd43d974cc1398a59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lemma relocation and tactic cleanup only; no API or runtime behavior changes, and downstream proofs keep the same theorem via imports.
> 
> **Overview**
> Proof-only refactor: **`vonNeumannEntropy_normalizedPureState`** moves from `PureAreaLaw.lean` into **`AreaLaw.lean`**, placed after the `MPSTensor` block next to `normalizedPureState` / `pureBlockEntropy`, with fully qualified `MPSTensor` names on the statement. The proof is unchanged; **`pureBlockEntropy_full`** still applies it through the existing import chain (`PureAreaLaw` → `MutualInfoMonotone` → `AreaLaw`).
> 
> In **`Defs.lean`**, the matrix-entry step in **`IsLPDO.isMPDO`** drops `erw` on `Fintype.sum_apply` and closes with **`simp only`** on `Matrix.sum_apply` and rank-one `vecMulVec` entries.
> 
> **`PureAreaLaw.lean`** removes the duplicate zero-entropy section and only adjusts line breaks around `trace_pureState_conj` and `pureBlockEntropy_complement`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b958099e227a8a9a1317456578e00d91c15a4576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->