### PR TITLE
doc(PEPS): remove redundant torus-size clauses

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -764,7 +764,7 @@ site-independent tensor and produces the global phase of
     \lean{TNLean.PEPS.isRegionBoundaryEdge_staircaseWindow_zero_referenceEdge}
     \lean{TNLean.PEPS.isRegionBoundaryEdge_staircaseWindow_last_referenceEdge}
     \leanok
-    Let the torus have width $W$ and height $H$, with $1<W$ and $1<H$.
+    Let the torus have width $W$ and height $H$, with $1<H$.
     Let $e$ be the horizontal reference edge of a staircase window family with
     dimensions $L,K$ and lower-left coordinate $(a,b)$.  Suppose
     \[
@@ -833,7 +833,7 @@ site-independent tensor and produces the global phase of
         thm:peps_regionInsertedCoeff_eq_extendInsert_bondInserted,
         thm:peps_staircase_end_reference_edge_boundary,
         thm:peps_staircase_pair_insert_eq_open}
-    Let the torus have width $W$ and height $H$, with $1<W$ and $1<H$.
+    Let the torus have width $W$ and height $H$.
     Suppose that the one-orientation $L\times K$ window injectivity
     hypotheses hold for a tensor $B$, unions of injective regions are
     injective, and all bond dimensions of $B$ are positive.  Assume


### PR DESCRIPTION
### Motivation

- In the boundary-edge entry, the width assumption $1<W$ is redundant: the displayed hypotheses $1\le a$, $0<L$, and $a+2L\le W$ already imply $W>1$. The height assumption $1<H$ is retained because it is still required by the corresponding Lean declarations through the torus graph.
- In the single-bond peeling entry, the whole clause "with $1<W$ and $1<H$" is redundant: the displayed hypotheses $2L+1\le W$ and $2K+1\le H$ with $2\le L,K$ imply both bounds.
- Continues the blueprint alignment from PR #2788, which added the bond-peeling subsection to `ch24_peps_ft_torus.tex`.

### Description

- In `blueprint/src/chapter/ch24_peps_ft_torus.tex`, replace the boundary-edge preamble by "Let the torus have width $W$ and height $H$, with $1<H$." This removes only the redundant width condition from `\label{thm:peps_staircase_end_reference_edge_boundary}`.
- Remove the full redundant clause from `\label{thm:peps_regionInsertedCoeff_endWindows_eq_of_staircase}`.
- Leave all displayed size constraints unchanged. No Lean files are modified.

### Testing

- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `leanblueprint web` (exited 0 with pre-existing package-loading and bibliography warnings)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` followed by `lake exe checkdecls blueprint/lean_decls` (generated file not committed as it is not tracked)

---
Closes #2793

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint prose-only edits with no Lean changes; mathematical hypotheses in the displayed inequalities are unchanged.
> 
> **Overview**
> Aligns two staircase **single-bond peeling** blueprint theorems in `ch24_peps_ft_torus.tex` with their Lean counterparts by dropping redundant torus-size wording from the opening line.
> 
> For **The reference edge bounds the two end windows** (`thm:peps_staircase_end_reference_edge_boundary`), the preamble no longer requires `1<W` alongside the existing window placement hypotheses (`a+2L\le W`, `b+2K-1\le H`, etc.); it now only states `1<H` where the diff leaves that clause. For **Single-bond peeling of the staircase end equality** (`thm:peps_regionInsertedCoeff_endWindows_eq_of_staircase`), the entire `with $1<W$ and $1<H$` phrase is removed so the statement starts at “Let the torus have width $W$ and height $H$” while all substantive size constraints are unchanged.
> 
> No Lean or proof logic changes—documentation sync only, continuing blueprint alignment from prior PEPS torus work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb39a746b63ebd043572d8e3dd9ff88d8e1b9f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->