### PR TITLE
feat(MPDO): renormalization fixed points saturate the pure-state area law

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -274,6 +274,7 @@ import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.MPDO.AreaLaw
 import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.MPDO.PureAreaLaw
+import TNLean.MPS.MPDO.PureRFPSAL
 import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -114,11 +114,11 @@ theorem vonNeumannEntropy_submatrix_equiv (e : m ≃ n) (ρ : Matrix n n ℂ)
   have hre : ρ.submatrix e e = reindex e.symm e.symm ρ := rfl
   rw [hre, charpoly_reindex]
 
-/-- **Cyclic invariance of the entropy charpoly-root sum.** The `negMulLog ∘ Re`
+/-- **Cyclic invariance of the entropy charpoly-root sum.** The negMulLog ∘ Re
 sum over the roots of the characteristic polynomial is unchanged under the cyclic
-swap `A * B ↦ B * A` of a (possibly rectangular) product. The two characteristic
-polynomials differ only by a power of `X`, i.e. by extra roots equal to `0`,
-which contribute `negMulLog 0 = 0`. This is the Hermitian-free core of
+swap AB ↦ BA of a (possibly rectangular) product. The two characteristic
+polynomials differ only by a power of X, i.e. by extra roots equal to 0,
+which contribute negMulLog 0 = 0. This is the Hermitian-free core of
 `vonNeumannEntropy_mul_comm`: it lets a block entropy be pushed onto a smaller
 factor even when the intermediate product (e.g. of two positive semidefinite
 Gram matrices) is not Hermitian. -/
@@ -140,10 +140,10 @@ theorem charpoly_roots_negMulLog_re_mul_comm (A : Matrix m n ℂ) (B : Matrix n 
     Multiset.map_singleton, Multiset.sum_singleton, hf0, smul_zero, zero_add] at key
   exact key
 
-/-- **Entropy of `A·B` equals entropy of `B·A`.** The von Neumann entropy is
+/-- **Entropy of A B equals entropy of B A.** The von Neumann entropy is
 unchanged under the cyclic swap of a (possibly rectangular) product: the
-characteristic polynomials of `A * B` and `B * A` differ only by a power of `X`,
-i.e. by extra eigenvalues equal to `0`, which contribute `negMulLog 0 = 0`. This
+characteristic polynomials of A B and B A differ only by a power of X,
+i.e. by extra eigenvalues equal to 0, which contribute negMulLog 0 = 0. This
 is the spectral form of the Schmidt symmetry of complementary reductions of a
 pure state. -/
 theorem vonNeumannEntropy_mul_comm (A : Matrix m n ℂ) (B : Matrix n m ℂ)

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -114,16 +114,17 @@ theorem vonNeumannEntropy_submatrix_equiv (e : m ≃ n) (ρ : Matrix n n ℂ)
   have hre : ρ.submatrix e e = reindex e.symm e.symm ρ := rfl
   rw [hre, charpoly_reindex]
 
-/-- **Entropy of `A·B` equals entropy of `B·A`.** The von Neumann entropy is
-unchanged under the cyclic swap of a (possibly rectangular) product: the
-characteristic polynomials of `A * B` and `B * A` differ only by a power of `X`,
-i.e. by extra eigenvalues equal to `0`, which contribute `negMulLog 0 = 0`. This
-is the spectral form of the Schmidt symmetry of complementary reductions of a
-pure state. -/
-theorem vonNeumannEntropy_mul_comm (A : Matrix m n ℂ) (B : Matrix n m ℂ)
-    (hAB : (A * B).IsHermitian) (hBA : (B * A).IsHermitian) :
-    vonNeumannEntropy (A * B) hAB = vonNeumannEntropy (B * A) hBA := by
-  rw [vonNeumannEntropy_eq_charpoly_roots, vonNeumannEntropy_eq_charpoly_roots]
+/-- **Cyclic invariance of the entropy charpoly-root sum.** The `negMulLog ∘ Re`
+sum over the roots of the characteristic polynomial is unchanged under the cyclic
+swap `A * B ↦ B * A` of a (possibly rectangular) product. The two characteristic
+polynomials differ only by a power of `X`, i.e. by extra roots equal to `0`,
+which contribute `negMulLog 0 = 0`. This is the Hermitian-free core of
+`vonNeumannEntropy_mul_comm`: it lets a block entropy be pushed onto a smaller
+factor even when the intermediate product (e.g. of two positive semidefinite
+Gram matrices) is not Hermitian. -/
+theorem charpoly_roots_negMulLog_re_mul_comm (A : Matrix m n ℂ) (B : Matrix n m ℂ) :
+    ((A * B).charpoly.roots.map (fun z : ℂ => Real.negMulLog z.re)).sum
+      = ((B * A).charpoly.roots.map (fun z : ℂ => Real.negMulLog z.re)).sum := by
   set f : ℂ → ℝ := fun z => Real.negMulLog z.re with hf
   have hroots : (Polynomial.X ^ Fintype.card n * (A * B).charpoly).roots
       = (Polynomial.X ^ Fintype.card m * (B * A).charpoly).roots := by
@@ -138,6 +139,18 @@ theorem vonNeumannEntropy_mul_comm (A : Matrix m n ℂ) (B : Matrix n m ℂ)
   simp only [Multiset.map_add, Multiset.sum_add, Multiset.map_nsmul, Multiset.sum_nsmul,
     Multiset.map_singleton, Multiset.sum_singleton, hf0, smul_zero, zero_add] at key
   exact key
+
+/-- **Entropy of `A·B` equals entropy of `B·A`.** The von Neumann entropy is
+unchanged under the cyclic swap of a (possibly rectangular) product: the
+characteristic polynomials of `A * B` and `B * A` differ only by a power of `X`,
+i.e. by extra eigenvalues equal to `0`, which contribute `negMulLog 0 = 0`. This
+is the spectral form of the Schmidt symmetry of complementary reductions of a
+pure state. -/
+theorem vonNeumannEntropy_mul_comm (A : Matrix m n ℂ) (B : Matrix n m ℂ)
+    (hAB : (A * B).IsHermitian) (hBA : (B * A).IsHermitian) :
+    vonNeumannEntropy (A * B) hAB = vonNeumannEntropy (B * A) hBA := by
+  rw [vonNeumannEntropy_eq_charpoly_roots, vonNeumannEntropy_eq_charpoly_roots]
+  exact charpoly_roots_negMulLog_re_mul_comm A B
 
 /-- For a Hermitian matrix, entrywise conjugation equals the transpose. -/
 theorem isHermitian_map_conj_eq_transpose {n : Type*} {ρ : Matrix n n ℂ}

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -34,7 +34,7 @@ noncomputable def schmidtLeft (A : MPSTensor d D) (L : ℕ) :
 
 /-- **Left Gram = transfer-map power on a matrix unit.** The `D² × D²` Gram matrix
 of the operator-Schmidt left factor collects the same length-`L` word sum as the
-`L`-fold transfer map evaluated on the matrix unit `single b₂ a₂ 1`. -/
+`L`-fold transfer map evaluated on the matrix unit e_{b₂,a₂}. -/
 theorem schmidtLeft_gram_apply (A : MPSTensor d D) (L : ℕ) (a b : Fin D × Fin D) :
     ((schmidtLeft A L)ᴴ * schmidtLeft A L) a b
       = ((transferMap A ^ L) (Matrix.single b.2 a.2 1)) b.1 a.1 := by
@@ -93,11 +93,11 @@ theorem schmidtMat_eq_schmidtLeft_mul_schmidtRight (A : MPSTensor d D) (N L : �
   schmidtMat_eq_mul A N L hL
 
 /-- **The block entropy is the entropy of the bond environment.** The pure block
-entropy `S_L` equals the `negMulLog ∘ Re` charpoly-root sum of the `D²×D²`
-*environment matrix* `c · (R Rᴴ)(Lᴴ L)`, where `R = schmidtRight A (N-L)`,
-`L = schmidtLeft A L`, and `c = (tr σ^{(N)})⁻¹`. Cyclicity of the spectrum
-(`charpoly_roots_negMulLog_re_mul_comm`) moves the `d^L`-dimensional reduced state
-onto this bond-indexed core. -/
+entropy S_L equals the negMulLog ∘ Re charpoly-root sum of the D²×D²
+*environment matrix* c · (R Rᴴ)(Lᴴ L), where R is the right Schmidt factor for
+N - L sites, L is the left Schmidt factor for L sites, and c = (tr σ^{(N)})⁻¹.
+Cyclicity of the spectrum (`charpoly_roots_negMulLog_re_mul_comm`) moves the
+d^L-dimensional reduced state onto this bond-indexed core. -/
 theorem pureBlockEntropy_eq_env_charpoly (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     pureBlockEntropy A N L hL
       = (((Matrix.trace (pureState A N))⁻¹ •

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.PureAreaLaw
+import TNLean.Spectral.MixedTransfer
+import TNLean.MPS.RFP.Defs
+
+/-!
+# Renormalization fixed points saturate the area law
+
+For a pure-state renormalization fixed point the transfer map is idempotent, so
+its powers collapse (`𝔼^L = 𝔼` for `L ≥ 1`). The operator-Schmidt Gram matrices
+of a block are therefore block-size independent, hence the block entropy is
+constant: the area law is saturated.
+
+See arXiv:1606.00608, Section 3 (pure-state area law, line 599).
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+/-- **Cyclic invariance of the entropy charpoly-root sum.** The `negMulLog ∘ Re`
+sum over the roots of the characteristic polynomial is unchanged under the cyclic
+swap `A * B ↦ B * A` of a (possibly rectangular) product. This is the
+Hermitian-free core of `vonNeumannEntropy_mul_comm`: the two characteristic
+polynomials differ only by a power of `X`, i.e. by extra roots equal to `0`,
+which contribute `negMulLog 0 = 0`. It lets the block entropy be pushed onto the
+`D²`-dimensional bond environment even though the intermediate product of two
+positive semidefinite Gram matrices is not Hermitian. -/
+theorem charpoly_roots_negMulLog_re_mul_comm {m n : Type*} [Fintype m] [DecidableEq m]
+    [Fintype n] [DecidableEq n] (A : Matrix m n ℂ) (B : Matrix n m ℂ) :
+    ((A * B).charpoly.roots.map (fun z : ℂ => Real.negMulLog z.re)).sum
+      = ((B * A).charpoly.roots.map (fun z : ℂ => Real.negMulLog z.re)).sum := by
+  set f : ℂ → ℝ := fun z => Real.negMulLog z.re with hf
+  have hroots : (Polynomial.X ^ Fintype.card n * (A * B).charpoly).roots
+      = (Polynomial.X ^ Fintype.card m * (B * A).charpoly).roots := by
+    rw [Matrix.charpoly_mul_comm']
+  rw [Polynomial.roots_mul
+        (mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero) (Matrix.charpoly_monic _).ne_zero),
+      Polynomial.roots_mul
+        (mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero) (Matrix.charpoly_monic _).ne_zero),
+      Polynomial.roots_pow, Polynomial.roots_pow, Polynomial.roots_X] at hroots
+  have hf0 : f 0 = 0 := by simp [hf]
+  have key := congrArg (fun s => (Multiset.map f s).sum) hroots
+  simp only [Multiset.map_add, Multiset.sum_add, Multiset.map_nsmul, Multiset.sum_nsmul,
+    Multiset.map_singleton, Multiset.sum_singleton, hf0, smul_zero, zero_add] at key
+  exact key
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The operator-Schmidt **left factor** of an `L`-spin block: the
+`(d^L) × D²` matrix whose row `u` records the bond-indexed entries of the word
+product `A^u`. It is the left factor in the wavefunction-matrix factorization
+`schmidtMat = schmidtLeft · (right factor)` of `schmidtMat_eq_mul`. -/
+noncomputable def schmidtLeft (A : MPSTensor d D) (L : ℕ) :
+    Matrix (Fin L → Fin d) (Fin D × Fin D) ℂ :=
+  Matrix.of (fun u p => (evalWord A (List.ofFn u)) p.1 p.2)
+
+/-- **Left Gram = transfer-map power on a matrix unit.** The `D² × D²` Gram matrix
+of the operator-Schmidt left factor collects the same length-`L` word sum as the
+`L`-fold transfer map evaluated on the matrix unit `single b₂ a₂ 1`. -/
+theorem schmidtLeft_gram_apply (A : MPSTensor d D) (L : ℕ) (a b : Fin D × Fin D) :
+    ((schmidtLeft A L)ᴴ * schmidtLeft A L) a b
+      = ((transferMap A ^ L) (Matrix.single b.2 a.2 1)) b.1 a.1 := by
+  rw [Matrix.mul_apply, transferMap_pow_apply', Matrix.sum_apply]
+  refine Finset.sum_congr rfl (fun σ _ => ?_)
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, schmidtLeft, Matrix.of_apply,
+    Matrix.single_apply, RCLike.star_def, mul_ite, mul_one, mul_zero, ite_and, ite_mul,
+    zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ite_true]
+  ring
+
+/-- **The left Gram is block-size independent for a renormalization fixed point.**
+Idempotence of `transferMap A` collapses its positive powers, so the
+operator-Schmidt left Gram of an `L`-block agrees with the single-site one for
+every `L ≥ 1`. This is the algebraic core of area-law saturation. -/
+theorem schmidtLeft_gram_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
+    {L : ℕ} (hL : 1 ≤ L) :
+    (schmidtLeft A L)ᴴ * schmidtLeft A L = (schmidtLeft A 1)ᴴ * schmidtLeft A 1 := by
+  have hIdem : IsIdempotentElem (transferMap A) := hRFP
+  ext a b
+  rw [schmidtLeft_gram_apply, schmidtLeft_gram_apply,
+    hIdem.pow_eq (by omega : L ≠ 0), pow_one]
+
+/-- The operator-Schmidt **right factor** of an `M`-spin complement block: the
+`D² × (d^M)` matrix recording the bond-indexed entries of `A^w` with the two
+bonds swapped, as in the wavefunction factorization `schmidtMat_eq_mul`. -/
+noncomputable def schmidtRight (A : MPSTensor d D) (M : ℕ) :
+    Matrix (Fin D × Fin D) (Fin M → Fin d) ℂ :=
+  Matrix.of (fun p w => (evalWord A (List.ofFn w)) p.2 p.1)
+
+/-- **Right Gram = transfer-map power on a matrix unit** (complement analogue of
+`schmidtLeft_gram_apply`). -/
+theorem schmidtRight_gram_apply (A : MPSTensor d D) (M : ℕ) (p q : Fin D × Fin D) :
+    (schmidtRight A M * (schmidtRight A M)ᴴ) p q
+      = ((transferMap A ^ M) (Matrix.single p.1 q.1 1)) p.2 q.2 := by
+  rw [Matrix.mul_apply, transferMap_pow_apply', Matrix.sum_apply]
+  refine Finset.sum_congr rfl (fun σ _ => ?_)
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, schmidtRight, Matrix.of_apply,
+    Matrix.single_apply, RCLike.star_def, mul_ite, mul_one, mul_zero, ite_and, ite_mul,
+    zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ite_true]
+
+/-- **The right Gram is block-size independent for a renormalization fixed point.**
+The complement analogue of `schmidtLeft_gram_eq_of_isRFP`. -/
+theorem schmidtRight_gram_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
+    {M : ℕ} (hM : 1 ≤ M) :
+    schmidtRight A M * (schmidtRight A M)ᴴ = schmidtRight A 1 * (schmidtRight A 1)ᴴ := by
+  have hIdem : IsIdempotentElem (transferMap A) := hRFP
+  ext p q
+  rw [schmidtRight_gram_apply, schmidtRight_gram_apply,
+    hIdem.pow_eq (by omega : M ≠ 0), pow_one]
+
+/-- The wavefunction matrix factors as `schmidtLeft · schmidtRight` through the
+`D × D` bond pair: the operator-Schmidt factorization of `schmidtMat_eq_mul`,
+phrased with the named left and right factors. -/
+theorem schmidtMat_eq_schmidtLeft_mul_schmidtRight (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
+    schmidtMat A N L hL = schmidtLeft A L * schmidtRight A (N - L) :=
+  schmidtMat_eq_mul A N L hL
+
+/-- **The block entropy is the entropy of the bond environment.** The pure block
+entropy `S_L` equals the `negMulLog ∘ Re` charpoly-root sum of the `D²×D²`
+*environment matrix* `c · (R Rᴴ)(Lᴴ L)`, where `R = schmidtRight A (N-L)`,
+`L = schmidtLeft A L`, and `c = (tr σ^{(N)})⁻¹`. Cyclicity of the spectrum
+(`charpoly_roots_negMulLog_re_mul_comm`) moves the `d^L`-dimensional reduced state
+onto this bond-indexed core. -/
+theorem pureBlockEntropy_eq_env_charpoly (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
+    pureBlockEntropy A N L hL
+      = (((Matrix.trace (pureState A N))⁻¹ •
+            ((schmidtRight A (N - L) * (schmidtRight A (N - L))ᴴ)
+              * ((schmidtLeft A L)ᴴ * schmidtLeft A L))).charpoly.roots.map
+          (fun z : ℂ => Real.negMulLog z.re)).sum := by
+  have hρ : reducedPureBlockState A N L hL
+      = ((Matrix.trace (pureState A N))⁻¹ • schmidtLeft A L)
+        * (schmidtRight A (N - L) * (schmidtRight A (N - L))ᴴ * (schmidtLeft A L)ᴴ) := by
+    rw [reducedPureBlockState_eq_gram, schmidtMat_eq_schmidtLeft_mul_schmidtRight A N L hL,
+      Matrix.conjTranspose_mul, Matrix.smul_mul]
+    congr 1
+    simp only [Matrix.mul_assoc]
+  have hcyc : (schmidtRight A (N - L) * (schmidtRight A (N - L))ᴴ * (schmidtLeft A L)ᴴ)
+        * ((Matrix.trace (pureState A N))⁻¹ • schmidtLeft A L)
+      = (Matrix.trace (pureState A N))⁻¹ •
+          ((schmidtRight A (N - L) * (schmidtRight A (N - L))ᴴ)
+            * ((schmidtLeft A L)ᴴ * schmidtLeft A L)) := by
+    rw [Matrix.mul_smul]
+    congr 1
+    simp only [Matrix.mul_assoc]
+  rw [pureBlockEntropy, vonNeumannEntropy_eq_charpoly_roots, hρ,
+    charpoly_roots_negMulLog_re_mul_comm, hcyc]
+
+/-- **A renormalization fixed point saturates the area law.** For a pure-state
+renormalization fixed point the operator-Schmidt Gram matrices collapse to their
+single-site values, so the `D²×D²` bond-environment matrix governing the block
+spectrum is block-size independent. The block entropy is therefore constant in
+the block size: the area law is saturated.
+
+Source: arXiv:1606.00608, Section 3 (pure-state area law, line 599);
+blueprint `thm:rfp-saturates-area-law`. -/
+theorem isSAL_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) : IsSAL A := by
+  intro N L hL1 hLlt
+  rw [pureBlockEntropy_eq_env_charpoly, pureBlockEntropy_eq_env_charpoly,
+    schmidtRight_gram_eq_of_isRFP A hRFP (show 1 ≤ N - L by omega),
+    schmidtLeft_gram_eq_of_isRFP A hRFP hL1,
+    schmidtRight_gram_eq_of_isRFP A hRFP (show 1 ≤ N - (L + 1) by omega),
+    schmidtLeft_gram_eq_of_isRFP A hRFP (show 1 ≤ L + 1 by omega)]
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.RFP.Defs
 # Renormalization fixed points saturate the area law
 
 For a pure-state renormalization fixed point the transfer map is idempotent, so
-its powers collapse (`𝔼^L = 𝔼` for `L ≥ 1`). The operator-Schmidt Gram matrices
+its powers collapse, 𝔼^L = 𝔼 for L ≥ 1. The operator-Schmidt Gram matrices
 of a block are therefore block-size independent, hence the block entropy is
 constant: the area law is saturated.
 
@@ -24,17 +24,17 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- The operator-Schmidt **left factor** of an `L`-spin block: the
-`(d^L) × D²` matrix whose row `u` records the bond-indexed entries of the word
-product `A^u`. It is the left factor in the wavefunction-matrix factorization
-`schmidtMat = schmidtLeft · (right factor)` of `schmidtMat_eq_mul`. -/
+/-- The operator-Schmidt **left factor** of an L-spin block: the
+(d^L) × D² matrix whose row u records the bond-indexed entries of the word
+product A^u. It is the left factor in the wavefunction-matrix factorization
+used by `schmidtMat_eq_mul`. -/
 noncomputable def schmidtLeft (A : MPSTensor d D) (L : ℕ) :
     Matrix (Fin L → Fin d) (Fin D × Fin D) ℂ :=
   Matrix.of (fun u p => (evalWord A (List.ofFn u)) p.1 p.2)
 
-/-- **Left Gram = transfer-map power on a matrix unit.** The `D² × D²` Gram matrix
-of the operator-Schmidt left factor collects the same length-`L` word sum as the
-`L`-fold transfer map evaluated on the matrix unit e_{b₂,a₂}. -/
+/-- **Left Gram = transfer-map power on a matrix unit.** The D² × D² Gram matrix
+of the operator-Schmidt left factor collects the same length-L word sum as the
+L-fold transfer map evaluated on the matrix unit e_{b₂,a₂}. -/
 theorem schmidtLeft_gram_apply (A : MPSTensor d D) (L : ℕ) (a b : Fin D × Fin D) :
     ((schmidtLeft A L)ᴴ * schmidtLeft A L) a b
       = ((transferMap A ^ L) (Matrix.single b.2 a.2 1)) b.1 a.1 := by
@@ -46,9 +46,9 @@ theorem schmidtLeft_gram_apply (A : MPSTensor d D) (L : ℕ) (a b : Fin D × Fin
   ring
 
 /-- **The left Gram is block-size independent for a renormalization fixed point.**
-Idempotence of `transferMap A` collapses its positive powers, so the
-operator-Schmidt left Gram of an `L`-block agrees with the single-site one for
-every `L ≥ 1`. This is the algebraic core of area-law saturation. -/
+Idempotence of the transfer map collapses its positive powers, so the
+operator-Schmidt left Gram of an L-block agrees with the single-site one for
+every L ≥ 1. This is the algebraic core of area-law saturation. -/
 theorem schmidtLeft_gram_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
     {L : ℕ} (hL : 1 ≤ L) :
     (schmidtLeft A L)ᴴ * schmidtLeft A L = (schmidtLeft A 1)ᴴ * schmidtLeft A 1 := by
@@ -57,8 +57,8 @@ theorem schmidtLeft_gram_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
   rw [schmidtLeft_gram_apply, schmidtLeft_gram_apply,
     hIdem.pow_eq (by omega : L ≠ 0), pow_one]
 
-/-- The operator-Schmidt **right factor** of an `M`-spin complement block: the
-`D² × (d^M)` matrix recording the bond-indexed entries of `A^w` with the two
+/-- The operator-Schmidt **right factor** of an M-spin complement block: the
+D² × (d^M) matrix recording the bond-indexed entries of A^w with the two
 bonds swapped, as in the wavefunction factorization `schmidtMat_eq_mul`. -/
 noncomputable def schmidtRight (A : MPSTensor d D) (M : ℕ) :
     Matrix (Fin D × Fin D) (Fin M → Fin d) ℂ :=
@@ -85,8 +85,8 @@ theorem schmidtRight_gram_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
   rw [schmidtRight_gram_apply, schmidtRight_gram_apply,
     hIdem.pow_eq (by omega : M ≠ 0), pow_one]
 
-/-- The wavefunction matrix factors as `schmidtLeft · schmidtRight` through the
-`D × D` bond pair: the operator-Schmidt factorization of `schmidtMat_eq_mul`,
+/-- The wavefunction matrix factors through the D × D bond pair: this is the
+operator-Schmidt factorization of `schmidtMat_eq_mul`,
 phrased with the named left and right factors. -/
 theorem schmidtMat_eq_schmidtLeft_mul_schmidtRight (A : MPSTensor d D) (N L : ℕ) (hL : L ≤ N) :
     schmidtMat A N L hL = schmidtLeft A L * schmidtRight A (N - L) :=
@@ -124,12 +124,12 @@ theorem pureBlockEntropy_eq_env_charpoly (A : MPSTensor d D) (N L : ℕ) (hL : L
 
 /-- **A renormalization fixed point saturates the area law.** For a pure-state
 renormalization fixed point the operator-Schmidt Gram matrices collapse to their
-single-site values, so the `D²×D²` bond-environment matrix governing the block
+single-site values, so the D²×D² bond-environment matrix governing the block
 spectrum is block-size independent. The block entropy is therefore constant in
 the block size: the area law is saturated.
 
 Source: arXiv:1606.00608, Section 3 (pure-state area law, line 599);
-blueprint `thm:rfp-saturates-area-law`. -/
+blueprint label thm:rfp-saturates-area-law. -/
 theorem isSAL_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) : IsSAL A := by
   intro N L hL1 hLlt
   rw [pureBlockEntropy_eq_env_charpoly, pureBlockEntropy_eq_env_charpoly,

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -20,33 +20,6 @@ See arXiv:1606.00608, Section 3 (pure-state area law, line 599).
 open scoped Matrix BigOperators
 open Matrix
 
-/-- **Cyclic invariance of the entropy charpoly-root sum.** The `negMulLog ∘ Re`
-sum over the roots of the characteristic polynomial is unchanged under the cyclic
-swap `A * B ↦ B * A` of a (possibly rectangular) product. This is the
-Hermitian-free core of `vonNeumannEntropy_mul_comm`: the two characteristic
-polynomials differ only by a power of `X`, i.e. by extra roots equal to `0`,
-which contribute `negMulLog 0 = 0`. It lets the block entropy be pushed onto the
-`D²`-dimensional bond environment even though the intermediate product of two
-positive semidefinite Gram matrices is not Hermitian. -/
-theorem charpoly_roots_negMulLog_re_mul_comm {m n : Type*} [Fintype m] [DecidableEq m]
-    [Fintype n] [DecidableEq n] (A : Matrix m n ℂ) (B : Matrix n m ℂ) :
-    ((A * B).charpoly.roots.map (fun z : ℂ => Real.negMulLog z.re)).sum
-      = ((B * A).charpoly.roots.map (fun z : ℂ => Real.negMulLog z.re)).sum := by
-  set f : ℂ → ℝ := fun z => Real.negMulLog z.re with hf
-  have hroots : (Polynomial.X ^ Fintype.card n * (A * B).charpoly).roots
-      = (Polynomial.X ^ Fintype.card m * (B * A).charpoly).roots := by
-    rw [Matrix.charpoly_mul_comm']
-  rw [Polynomial.roots_mul
-        (mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero) (Matrix.charpoly_monic _).ne_zero),
-      Polynomial.roots_mul
-        (mul_ne_zero (pow_ne_zero _ Polynomial.X_ne_zero) (Matrix.charpoly_monic _).ne_zero),
-      Polynomial.roots_pow, Polynomial.roots_pow, Polynomial.roots_X] at hroots
-  have hf0 : f 0 = 0 := by simp [hf]
-  have key := congrArg (fun s => (Multiset.map f s).sum) hroots
-  simp only [Multiset.map_add, Multiset.sum_add, Multiset.map_nsmul, Multiset.sum_nsmul,
-    Multiset.map_singleton, Multiset.sum_singleton, hf0, smul_zero, zero_add] at key
-  exact key
-
 namespace MPSTensor
 
 variable {d D : ℕ}

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -78,7 +78,7 @@ theorem schmidtRight_gram_apply (A : MPSTensor d D) (M : ℕ) (p q : Fin D × Fi
     zero_mul, Finset.sum_ite_eq, Finset.mem_univ, ite_true]
 
 /-- **The right Gram is block-size independent for a renormalization fixed point.**
-The complement analogue of `schmidtLeft_gram_eq_of_isRFP`. -/
+This is the complement analogue of the left-Gram collapse theorem. -/
 theorem schmidtRight_gram_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
     {M : ℕ} (hM : 1 ≤ M) :
     schmidtRight A M * (schmidtRight A M)ᴴ = schmidtRight A 1 * (schmidtRight A 1)ᴴ := by

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -14,7 +14,9 @@ its powers collapse, 𝔼^L = 𝔼 for L ≥ 1. The operator-Schmidt Gram matric
 of a block are therefore block-size independent, hence the block entropy is
 constant: the area law is saturated.
 
-See arXiv:1606.00608, Section 3 (pure-state area law, line 599).
+The result below strengthens arXiv:1606.00608, Proposition ZCLandSALpure,
+lines 606--608: the cited proposition assumes canonical form, while the proof
+uses only idempotence of the transfer map.
 -/
 
 open scoped Matrix BigOperators
@@ -128,8 +130,10 @@ single-site values, so the D²×D² bond-environment matrix governing the block
 spectrum is block-size independent. The block entropy is therefore constant in
 the block size: the area law is saturated.
 
-Source: arXiv:1606.00608, Section 3 (pure-state area law, line 599);
-blueprint label thm:rfp-saturates-area-law. -/
+Source: arXiv:1606.00608, Proposition ZCLandSALpure, lines 606--608. The
+cited proposition assumes canonical form; this statement proves the same
+implication from transfer-map idempotence alone, so the source proposition
+follows as a special case. -/
 theorem isSAL_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) : IsSAL A := by
   intro N L hL1 hLlt
   rw [pureBlockEntropy_eq_env_charpoly, pureBlockEntropy_eq_env_charpoly,

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -135,11 +135,38 @@ finite-dimensional quantum systems.
     and the entropies coincide.
 \end{proof}
 
+\begin{lemma}[Cyclic invariance of the charpoly-root entropy sum]
+    \label{lem:charpoly_root_entropy_cyclic_swap}
+    \lean{charpoly_roots_negMulLog_re_mul_comm}
+    \leanok
+    Let $A \in M_{m \times n}(\mathbb{C})$ and
+    $B \in M_{n \times m}(\mathbb{C})$. Then the charpoly-root entropy sum is
+    invariant under the cyclic swap $AB \mapsto BA$:
+    \[
+        \sum_{\lambda \in \mathrm{roots}(\chi_{AB})}
+        \bigl({-}\operatorname{Re}(\lambda)\log\operatorname{Re}(\lambda)\bigr)
+        =
+        \sum_{\mu \in \mathrm{roots}(\chi_{BA})}
+        \bigl({-}\operatorname{Re}(\mu)\log\operatorname{Re}(\mu)\bigr),
+    \]
+    with roots counted with algebraic multiplicity.
+\end{lemma}
+
+\begin{proof}\leanok
+    The rectangular characteristic-polynomial identity gives
+    \[
+        X^n \chi_{AB} = X^m \chi_{BA}.
+    \]
+    Thus the two characteristic polynomials have the same nonzero roots, with
+    multiplicity; the additional zero roots contribute nothing because
+    $0\log 0=0$.
+\end{proof}
+
 \begin{theorem}[Entropy of $AB$ equals entropy of $BA$]
     \label{thm:entropy_mul_comm}
     \lean{vonNeumannEntropy_mul_comm}
     \leanok
-    \uses{lem:entropy_charpoly_roots}
+    \uses{lem:entropy_charpoly_roots, lem:charpoly_root_entropy_cyclic_swap}
     For matrices $A \in M_{m \times n}(\mathbb{C})$ and
     $B \in M_{n \times m}(\mathbb{C})$ such that $AB$ and $BA$ are Hermitian,
     \[
@@ -148,14 +175,10 @@ finite-dimensional quantum systems.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{lem:entropy_charpoly_roots}
-    The rectangular characteristic-polynomial identity gives
-    \[
-        X^n \chi_{AB} = X^m \chi_{BA}.
-    \]
-    Hence $AB$ and $BA$ have the same nonzero eigenvalues, with multiplicity.
-    The roots at $0$ contribute nothing because $0 \log 0 = 0$, so
-    Lemma~\ref{lem:entropy_charpoly_roots} gives $S(AB) = S(BA)$.
+    \uses{lem:entropy_charpoly_roots, lem:charpoly_root_entropy_cyclic_swap}
+    By Lemma~\ref{lem:entropy_charpoly_roots}, the entropy of a Hermitian matrix
+    is its charpoly-root entropy sum. Lemma~\ref{lem:charpoly_root_entropy_cyclic_swap}
+    identifies these two sums for $AB$ and $BA$.
 \end{proof}
 
 \section{Tripartite partial traces}

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3545,7 +3545,7 @@ the elementary trace-power identity for diagonal matrices.
     \cite[Section~3, line~599]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{lem:schmidt_gram_transfer_power}
+    \uses{lem:schmidt_gram_transfer_power, lem:charpoly_root_entropy_cyclic_swap}
     Factor the block reduced state through the two bonds cut by the boundary:
     $\rho_L \propto L_L\,(R_m R_m^\dagger)\,L_L^\dagger$ with $m = N-L$, where
     $L_L$ and $R_m$ are the operator-Schmidt factors. Writing

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3483,12 +3483,20 @@ the elementary trace-power identity for diagonal matrices.
 
 \begin{lemma}[Operator-Schmidt Gram is a transfer-map power]
     \label{lem:schmidt_gram_transfer_power}
-    \lean{MPSTensor.schmidtLeft_gram_apply, MPSTensor.schmidtRight_gram_apply}
+    \lean{MPSTensor.schmidtLeft, MPSTensor.schmidtRight,
+        MPSTensor.schmidtLeft_gram_apply, MPSTensor.schmidtRight_gram_apply}
     \leanok
     \uses{def:transfer_map}
-    Let $A$ be an MPS tensor of bond dimension $D$. The $D^2\times D^2$ Gram matrix
-    of the operator-Schmidt left factor $L_\ell$ of an $\ell$-spin block equals the
-    $\ell$-fold transfer map evaluated on a matrix unit:
+    Let $A$ be an MPS tensor of bond dimension $D$. For a length-$\ell$
+    configuration $\sigma$ and a length-$m$ configuration $\tau$, write the
+    operator-Schmidt factors as
+    \[
+        (L_\ell)_{\sigma,(a_1,a_2)} = (A^\sigma)_{a_1a_2},
+        \qquad
+        (R_m)_{(p_1,p_2),\tau} = (A^\tau)_{p_2p_1}.
+    \]
+    The $D^2\times D^2$ Gram matrix of the left factor equals the $\ell$-fold
+    transfer map evaluated on a matrix unit:
     \[
         \bigl(L_\ell^\dagger L_\ell\bigr)_{(a_1,a_2),(b_1,b_2)}
             = \sum_{\sigma}\overline{(A^\sigma)_{a_1 a_2}}\,(A^\sigma)_{b_1 b_2}

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3529,11 +3529,67 @@ the elementary trace-power identity for diagonal matrices.
     $\mathbb{E}_A^{\,m}(\ketbra{p_1}{q_1})$.
 \end{proof}
 
+\begin{lemma}[RFP collapse of the operator-Schmidt Grams]
+    \label{lem:rfp_schmidt_gram_collapse}
+    \lean{MPSTensor.schmidtLeft_gram_eq_of_isRFP,
+        MPSTensor.schmidtRight_gram_eq_of_isRFP}
+    \leanok
+    \uses{def:is_rfp, lem:schmidt_gram_transfer_power}
+    Let $A$ be a renormalization fixed point. For every $L\ge 1$ and
+    $m\ge 1$, the operator-Schmidt Grams of the $L$-block and of the
+    $m$-site complement are the one-site Grams:
+    \[
+        L_L^\dagger L_L = L_1^\dagger L_1,
+        \qquad
+        R_mR_m^\dagger = R_1R_1^\dagger .
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    The RFP hypothesis says that the transfer map is idempotent. Hence
+    $\mathbb{E}_A^{\,k}=\mathbb{E}_A$ for every $k\ge 1$. Applying
+    Lemma~\ref{lem:schmidt_gram_transfer_power} to the left and right Gram
+    entries gives the two displayed identities.
+\end{proof}
+
+\begin{lemma}[Pure block entropy as a bond-environment charpoly sum]
+    \label{lem:pure_block_entropy_env_charpoly}
+    \lean{MPSTensor.pureBlockEntropy_eq_env_charpoly}
+    \leanok
+    \uses{lem:schmidt_gram_transfer_power, lem:charpoly_root_entropy_cyclic_swap}
+    Let $A$ be an MPS tensor, let $L\le N$, put $m=N-L$, and write
+    $c=(\tr\rho^{(N)})^{-1}$. Then the pure block entropy is the
+    charpoly-root entropy sum of the $D^2\times D^2$ bond environment:
+    \[
+        S_L^{(N)}(A)
+        =
+        \sum_{\lambda\in
+            \operatorname{roots}\chi_{c\,(R_mR_m^\dagger)(L_L^\dagger L_L)}}
+            -\operatorname{Re}(\lambda)\log\operatorname{Re}(\lambda),
+    \]
+    with roots counted with algebraic multiplicity.
+\end{lemma}
+\begin{proof}\leanok
+    The reduced block state has the exact factorization
+    \[
+        \rho_L^{(N)}(A)
+        =
+        c\,L_L(R_mR_m^\dagger)L_L^\dagger .
+    \]
+    Cyclic invariance of the charpoly-root entropy sum gives
+    \[
+        S\bigl(c\,L_L(R_mR_m^\dagger)L_L^\dagger\bigr)
+            =
+        S\bigl(c\,(R_mR_m^\dagger)(L_L^\dagger L_L)\bigr),
+    \]
+    which is the displayed formula.
+\end{proof}
+
 \begin{theorem}[A renormalization fixed point saturates the area law]
     \label{thm:rfp-saturates-area-law}
     \lean{MPSTensor.isSAL_of_isRFP}
     \leanok
-    \uses{def:is_rfp, def:pure_sal, lem:schmidt_gram_transfer_power}
+    \uses{def:is_rfp, def:pure_sal, lem:pure_block_entropy_env_charpoly,
+        lem:rfp_schmidt_gram_collapse}
     If an MPS tensor $A$ is a renormalization fixed point, then it saturates the
     area law: for every chain length $N$ and every block length
     $1\le L<\lfloor N/2\rfloor$, the pure-state block entropy is constant in the
@@ -3547,25 +3603,40 @@ the elementary trace-power identity for diagonal matrices.
     implication obtained from transfer-map idempotence alone.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{lem:schmidt_gram_transfer_power, lem:charpoly_root_entropy_cyclic_swap}
-    Factor the block reduced state through the two bonds cut by the boundary:
-    $\rho_L \propto L_L\,(R_m R_m^\dagger)\,L_L^\dagger$ with $m = N-L$, where
-    $L_L$ and $R_m$ are the operator-Schmidt factors. Writing
-    $c=(\tr\rho^{(N)})^{-1}$, the cyclic invariance of the charpoly-root entropy
+    \uses{lem:pure_block_entropy_env_charpoly, lem:rfp_schmidt_gram_collapse}
+    Write $c=(\tr\rho^{(N)})^{-1}$. Lemma~\ref{lem:pure_block_entropy_env_charpoly}
+    computes the entropy from the bond environment:
+    \[
+        S_L^{(N)}(A)
+        =
+        \sum_{\lambda\in
+            \operatorname{roots}\chi_{c\,(R_{N-L}R_{N-L}^\dagger)
+                (L_L^\dagger L_L)}}
+            -\operatorname{Re}(\lambda)\log\operatorname{Re}(\lambda).
+    \]
+    Since $1\le L<\lfloor N/2\rfloor$, the four lengths
+    $L$, $L+1$, $N-L$, and $N-(L+1)$ are positive. The RFP Gram-collapse lemma
     gives
     \[
-        S\bigl(c\,L_L(R_mR_m^\dagger)L_L^\dagger\bigr)
-            =
-        S\bigl(c\,(R_mR_m^\dagger)(L_L^\dagger L_L)\bigr).
+        L_L^\dagger L_L=L_1^\dagger L_1,\qquad
+        L_{L+1}^\dagger L_{L+1}=L_1^\dagger L_1,
     \]
-    Thus the entropy is computed by the $D^2\times D^2$ bond environment
-    $(R_m R_m^\dagger)(L_L^\dagger L_L)$, a product of two positive semidefinite
-    Gram matrices. For a renormalization fixed point the transfer map is
-    idempotent, so its positive powers collapse,
-    $\mathbb{E}_A^{\,k} = \mathbb{E}_A$ for $k\ge 1$; by
-    Lemma~\ref{lem:schmidt_gram_transfer_power} both Gram factors are therefore
-    independent of the block size. The environment matrix is thus the same for
-    block lengths $L$ and $L+1$, so the two block entropies coincide.
+    and
+    \[
+        R_{N-L}R_{N-L}^\dagger=R_1R_1^\dagger,\qquad
+        R_{N-(L+1)}R_{N-(L+1)}^\dagger=R_1R_1^\dagger .
+    \]
+    Therefore the two bond environments agree:
+    \[
+        (R_{N-L}R_{N-L}^\dagger)(L_L^\dagger L_L)
+        =
+        (R_1R_1^\dagger)(L_1^\dagger L_1)
+        =
+        (R_{N-(L+1)}R_{N-(L+1)}^\dagger)
+            (L_{L+1}^\dagger L_{L+1}).
+    \]
+    The scalar $c$ depends only on $N$, so the two charpoly-root entropy sums
+    are equal. Hence $S_L^{(N)}(A)=S_{L+1}^{(N)}(A)$.
 \end{proof}
 
 \begin{lemma}[Operator-Schmidt rank bound]\label{lem:operator_schmidt_rank}

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3541,8 +3541,10 @@ the elementary trace-power identity for diagonal matrices.
     \[
         S_L^{(N)}(A) = S_{L+1}^{(N)}(A).
     \]
-    This is the pure-state direction of
-    \cite[Proposition~ZCLandSALpure, lines~604--608]{Cirac2016MPDO_arXiv}.
+    The source statement is
+    \cite[Proposition~ZCLandSALpure, lines~606--608]{Cirac2016MPDO_arXiv}.
+    It assumes canonical form; the theorem above is the stronger pure-state
+    implication obtained from transfer-map idempotence alone.
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:schmidt_gram_transfer_power, lem:charpoly_root_entropy_cyclic_swap}

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3495,17 +3495,30 @@ the elementary trace-power identity for diagonal matrices.
             = \bigl(\mathbb{E}_A^{\,\ell}(\ketbra{b_2}{a_2})\bigr)_{b_1,a_1},
     \]
     the sum running over length-$\ell$ configurations $\sigma$. The Gram of the
-    right factor $R_m$ of an $m$-spin complement satisfies the analogous identity
-    with $\mathbb{E}_A^{\,m}$.
+    right factor $R_m$ of an $m$-spin complement satisfies the bond-swapped
+    identity
+    \[
+        \bigl(R_m R_m^\dagger\bigr)_{(p_1,p_2),(q_1,q_2)}
+            = \sum_{\tau}(A^\tau)_{p_2 p_1}\,
+                \overline{(A^\tau)_{q_2 q_1}}
+            = \bigl(\mathbb{E}_A^{\,m}(\ketbra{p_1}{q_1})\bigr)_{p_2,q_2},
+    \]
+    the sum running over length-$m$ configurations $\tau$.
 \end{lemma}
 \begin{proof}\leanok
-    The Gram entry is $\sum_\sigma \overline{(A^\sigma)_{a_1 a_2}}\,(A^\sigma)_{b_1 b_2}$
+    The left Gram entry is
+    $\sum_\sigma \overline{(A^\sigma)_{a_1 a_2}}\,(A^\sigma)_{b_1 b_2}$
     by definition of $L_\ell$. Expanding
     $\mathbb{E}_A^{\,\ell}(\ketbra{b_2}{a_2})
         = \sum_\sigma A^\sigma\,\ketbra{b_2}{a_2}\,(A^\sigma)^\dagger$
     and reading off the $(b_1,a_1)$ entry gives the same sum, since
     $\bigl(A^\sigma\,\ketbra{b_2}{a_2}\,(A^\sigma)^\dagger\bigr)_{b_1,a_1}
         = (A^\sigma)_{b_1 b_2}\,\overline{(A^\sigma)_{a_1 a_2}}$.
+    The right-factor formula is the same expansion with the two boundary bonds
+    interchanged: the $(p,q)$ entry of $R_mR_m^\dagger$ is
+    $\sum_\tau (A^\tau)_{p_2p_1}\overline{(A^\tau)_{q_2q_1}}$, which is the
+    $(p_2,q_2)$ entry of
+    $\mathbb{E}_A^{\,m}(\ketbra{p_1}{q_1})$.
 \end{proof}
 
 \begin{theorem}[A renormalization fixed point saturates the area law]
@@ -3514,8 +3527,9 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:is_rfp, def:pure_sal, lem:schmidt_gram_transfer_power}
     If an MPS tensor $A$ is a renormalization fixed point, then it saturates the
-    area law: for every block length $1\le L<\lfloor N/2\rfloor$ the pure-state
-    block entropy is constant in the block size,
+    area law: for every chain length $N$ and every block length
+    $1\le L<\lfloor N/2\rfloor$, the pure-state block entropy is constant in the
+    block size,
     \[
         S_L^{(N)}(A) = S_{L+1}^{(N)}(A).
     \]
@@ -3526,8 +3540,15 @@ the elementary trace-power identity for diagonal matrices.
     \uses{lem:schmidt_gram_transfer_power}
     Factor the block reduced state through the two bonds cut by the boundary:
     $\rho_L \propto L_L\,(R_m R_m^\dagger)\,L_L^\dagger$ with $m = N-L$, where
-    $L_L$ and $R_m$ are the operator-Schmidt factors. Cyclicity of the spectrum
-    moves the entropy onto the $D^2\times D^2$ bond environment
+    $L_L$ and $R_m$ are the operator-Schmidt factors. Writing
+    $c=(\tr\rho^{(N)})^{-1}$, the cyclic invariance of the charpoly-root entropy
+    gives
+    \[
+        S\bigl(c\,L_L(R_mR_m^\dagger)L_L^\dagger\bigr)
+            =
+        S\bigl(c\,(R_mR_m^\dagger)(L_L^\dagger L_L)\bigr).
+    \]
+    Thus the entropy is computed by the $D^2\times D^2$ bond environment
     $(R_m R_m^\dagger)(L_L^\dagger L_L)$, a product of two positive semidefinite
     Gram matrices. For a renormalization fixed point the transfer map is
     idempotent, so its positive powers collapse,

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3542,7 +3542,7 @@ the elementary trace-power identity for diagonal matrices.
         S_L^{(N)}(A) = S_{L+1}^{(N)}(A).
     \]
     This is the pure-state direction of
-    \cite[Section~3, line~599]{Cirac2016MPDO_arXiv}.
+    \cite[Proposition~ZCLandSALpure, lines~604--608]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:schmidt_gram_transfer_power, lem:charpoly_root_entropy_cyclic_swap}

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3488,18 +3488,24 @@ the elementary trace-power identity for diagonal matrices.
     \uses{def:transfer_map}
     Let $A$ be an MPS tensor of bond dimension $D$. The $D^2\times D^2$ Gram matrix
     of the operator-Schmidt left factor $L_\ell$ of an $\ell$-spin block equals the
-    $\ell$-fold transfer map evaluated on a matrix unit,
+    $\ell$-fold transfer map evaluated on a matrix unit:
     \[
-        \bigl(L_\ell^\dagger L_\ell\bigr)_{(b_1,a_1),(b_2,a_2)}
-            = \bigl(\mathbb{E}_A^{\,\ell}(\ketbra{a_2}{b_2})\bigr)_{b_1,a_1},
+        \bigl(L_\ell^\dagger L_\ell\bigr)_{(a_1,a_2),(b_1,b_2)}
+            = \sum_{\sigma}\overline{(A^\sigma)_{a_1 a_2}}\,(A^\sigma)_{b_1 b_2}
+            = \bigl(\mathbb{E}_A^{\,\ell}(\ketbra{b_2}{a_2})\bigr)_{b_1,a_1},
     \]
-    and the Gram of the right factor $R_m$ of an $m$-spin complement equals
-    $\mathbb{E}_A^{\,m}$ on the corresponding matrix unit.
+    the sum running over length-$\ell$ configurations $\sigma$. The Gram of the
+    right factor $R_m$ of an $m$-spin complement satisfies the analogous identity
+    with $\mathbb{E}_A^{\,m}$.
 \end{lemma}
 \begin{proof}\leanok
-    Both Grams collect the same length-$\ell$ (respectively $m$) word sum
-    $\sum_\sigma A^\sigma X (A^\sigma)^\dagger$ that defines the iterated transfer
-    map on a matrix unit.
+    The Gram entry is $\sum_\sigma \overline{(A^\sigma)_{a_1 a_2}}\,(A^\sigma)_{b_1 b_2}$
+    by definition of $L_\ell$. Expanding
+    $\mathbb{E}_A^{\,\ell}(\ketbra{b_2}{a_2})
+        = \sum_\sigma A^\sigma\,\ketbra{b_2}{a_2}\,(A^\sigma)^\dagger$
+    and reading off the $(b_1,a_1)$ entry gives the same sum, since
+    $\bigl(A^\sigma\,\ketbra{b_2}{a_2}\,(A^\sigma)^\dagger\bigr)_{b_1,a_1}
+        = (A^\sigma)_{b_1 b_2}\,\overline{(A^\sigma)_{a_1 a_2}}$.
 \end{proof}
 
 \begin{theorem}[A renormalization fixed point saturates the area law]
@@ -3508,16 +3514,16 @@ the elementary trace-power identity for diagonal matrices.
     \leanok
     \uses{def:is_rfp, def:pure_sal, lem:schmidt_gram_transfer_power}
     If an MPS tensor $A$ is a renormalization fixed point, then it saturates the
-    area law: the pure-state block entropy is constant in the block size,
+    area law: for every block length $1\le L<\lfloor N/2\rfloor$ the pure-state
+    block entropy is constant in the block size,
     \[
-        S_L^{(N)}(A) = S_{L+1}^{(N)}(A)
-        \qquad (1\le L<\lfloor N/2\rfloor) .
+        S_L^{(N)}(A) = S_{L+1}^{(N)}(A).
     \]
     This is the pure-state direction of
     \cite[Section~3, line~599]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{lem:schmidt_gram_transfer_power, lem:operator_schmidt_rank}
+    \uses{lem:schmidt_gram_transfer_power}
     Factor the block reduced state through the two bonds cut by the boundary:
     $\rho_L \propto L_L\,(R_m R_m^\dagger)\,L_L^\dagger$ with $m = N-L$, where
     $L_L$ and $R_m$ are the operator-Schmidt factors. Cyclicity of the spectrum

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3481,6 +3481,56 @@ the elementary trace-power identity for diagonal matrices.
     $S_L \le S_{L+1}$.
 \end{proof}
 
+\begin{lemma}[Operator-Schmidt Gram is a transfer-map power]
+    \label{lem:schmidt_gram_transfer_power}
+    \lean{MPSTensor.schmidtLeft_gram_apply, MPSTensor.schmidtRight_gram_apply}
+    \leanok
+    \uses{def:transfer_map}
+    Let $A$ be an MPS tensor of bond dimension $D$. The $D^2\times D^2$ Gram matrix
+    of the operator-Schmidt left factor $L_\ell$ of an $\ell$-spin block equals the
+    $\ell$-fold transfer map evaluated on a matrix unit,
+    \[
+        \bigl(L_\ell^\dagger L_\ell\bigr)_{(b_1,a_1),(b_2,a_2)}
+            = \bigl(\mathbb{E}_A^{\,\ell}(\ketbra{a_2}{b_2})\bigr)_{b_1,a_1},
+    \]
+    and the Gram of the right factor $R_m$ of an $m$-spin complement equals
+    $\mathbb{E}_A^{\,m}$ on the corresponding matrix unit.
+\end{lemma}
+\begin{proof}\leanok
+    Both Grams collect the same length-$\ell$ (respectively $m$) word sum
+    $\sum_\sigma A^\sigma X (A^\sigma)^\dagger$ that defines the iterated transfer
+    map on a matrix unit.
+\end{proof}
+
+\begin{theorem}[A renormalization fixed point saturates the area law]
+    \label{thm:rfp-saturates-area-law}
+    \lean{MPSTensor.isSAL_of_isRFP}
+    \leanok
+    \uses{def:is_rfp, def:pure_sal, lem:schmidt_gram_transfer_power}
+    If an MPS tensor $A$ is a renormalization fixed point, then it saturates the
+    area law: the pure-state block entropy is constant in the block size,
+    \[
+        S_L^{(N)}(A) = S_{L+1}^{(N)}(A)
+        \qquad (1\le L<\lfloor N/2\rfloor) .
+    \]
+    This is the pure-state direction of
+    \cite[Section~3, line~599]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:schmidt_gram_transfer_power, lem:operator_schmidt_rank}
+    Factor the block reduced state through the two bonds cut by the boundary:
+    $\rho_L \propto L_L\,(R_m R_m^\dagger)\,L_L^\dagger$ with $m = N-L$, where
+    $L_L$ and $R_m$ are the operator-Schmidt factors. Cyclicity of the spectrum
+    moves the entropy onto the $D^2\times D^2$ bond environment
+    $(R_m R_m^\dagger)(L_L^\dagger L_L)$, a product of two positive semidefinite
+    Gram matrices. For a renormalization fixed point the transfer map is
+    idempotent, so its positive powers collapse,
+    $\mathbb{E}_A^{\,k} = \mathbb{E}_A$ for $k\ge 1$; by
+    Lemma~\ref{lem:schmidt_gram_transfer_power} both Gram factors are therefore
+    independent of the block size. The environment matrix is thus the same for
+    block lengths $L$ and $L+1$, so the two block entropies coincide.
+\end{proof}
+
 \begin{lemma}[Operator-Schmidt rank bound]\label{lem:operator_schmidt_rank}
     \lean{MPSTensor.rank_reducedPureBlockState_le}
     \leanok


### PR DESCRIPTION
## Summary

Closes #2596: an MPS renormalization fixed point saturates the pure-state area law, so the block entropy is constant in the block size.

This proves a strengthening of arXiv:1606.00608, Proposition `ZCLandSALpure`, lines 606--608. The source proposition assumes canonical form; the formal theorem below uses only the RFP hypothesis, so the source proposition follows as a special case.

```lean
theorem isSAL_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) : IsSAL A
```

## Proof architecture

The block reduced state factors through the two bonds cut by the boundary,
`ρ_L ∝ L_L (R_m R_mᴴ) L_Lᴴ` with `m = N − L`. The argument moves the entropy onto the `D² × D²` bond environment `(R_m R_mᴴ)(L_Lᴴ L_L)` and shows that this matrix is block-size independent under RFP.

- `schmidtLeft` and `schmidtRight` are the operator-Schmidt factors; their `D² × D²` Gram matrices equal transfer-map powers on matrix units.
- Under RFP idempotence, positive powers collapse, so both Gram matrices are block-size independent.
- `charpoly_roots_negMulLog_re_mul_comm` is the Hermitian-free cyclic charpoly-root identity needed for the intermediate product `(R Rᴴ)(Lᴴ L)`.
- `pureBlockEntropy_eq_env_charpoly` identifies the block entropy with the entropy of the bond environment.
- `isSAL_of_isRFP` compares block lengths `L` and `L + 1` after both environments collapse to the same single-site expression.

## Blueprint

Added the corresponding blueprint theorem `thm:rfp-saturates-area-law`, the supporting operator-Schmidt Gram lemma, and the cyclic charpoly-root lemma in the entropy chapter, all with `\leanok`.

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- Remote Lean CI passed on the previous head; the current push only corrects citation/framing prose.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal mathematics and documentation only; no runtime, auth, or data-path changes. Risk is limited to proof maintenance and public API surface (new theorem and entropy lemma).
> 
> **Overview**
> Adds **`MPSTensor.isSAL_of_isRFP`**: transfer-map idempotence alone implies pure block entropies are constant in block size, strengthening the Cirac et al. statement that assumed canonical form.
> 
> The proof is new machinery in **`PureRFPSAL`**: named **`schmidtLeft` / `schmidtRight`** factors, lemmas that their **D²×D² Gram matrices equal transfer-map powers** on matrix units, and **RFP collapse** of those Grams to the one-site case. **`pureBlockEntropy_eq_env_charpoly`** rewrites block entropy as a charpoly-root sum on a **bond-environment** matrix; **`charpoly_roots_negMulLog_re_mul_comm`** (new in **`Entropy.lean`**) supplies the cyclic swap without requiring Hermiticity of the intermediate product.
> 
> **`vonNeumannEntropy_mul_comm`** now delegates to that lemma; blueprint chapters **19** and **21** document the cyclic charpoly-root lemma and the RFP saturates-area-law theorem. **`TNLean.lean`** imports **`PureRFPSAL`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10983d0150bf14e5f081d345f148cc9d3cf4faec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->