### PR TITLE
feat(MPDO): RFP gives the constant block-entropy chain S_1=⋯=S_{N/2}

### DIFF
--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -143,12 +143,11 @@ theorem isSAL_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) : IsSAL A := by
     schmidtLeft_gram_eq_of_isRFP A hRFP (show 1 ≤ L + 1 by omega)]
 
 /-- **A renormalization fixed point has a constant block-entropy chain.**
-Combining `isSAL_of_isRFP` with the telescoping of saturation
-(`pureBlockEntropy_eq_of_isSAL`), every pair of block entropies in the range
-`1 ≤ L, L' ≤ ⌊N/2⌋` of a renormalization fixed point coincides, i.e.
-`S_1 = S_2 = ⋯ = S_{⌊N/2⌋}`. This is the explicit constant-entropy chain of the
-area-law saturation (arXiv:1606.00608, Definition 3.13, line 600) under the
-fixed-point hypothesis. -/
+A renormalization fixed point saturates the area law, and for an
+area-law-saturating tensor the block entropy is independent of the block size.
+Hence every pair of block entropies with 1 ≤ L, L' ≤ ⌊N/2⌋ coincides, giving the
+constant chain S₁ = S₂ = ⋯ = S_{⌊N/2⌋}. This is the explicit constant-entropy
+form of the area-law saturation (arXiv:1606.00608, Definition 3.13, line 600). -/
 theorem pureBlockEntropy_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
     {N L L' : ℕ} (hL1 : 1 ≤ L) (hLN : L ≤ N / 2) (hL'1 : 1 ≤ L') (hL'N : L' ≤ N / 2) :
     pureBlockEntropy A N L (hLN.trans (Nat.div_le_self N 2)) =

--- a/TNLean/MPS/MPDO/PureRFPSAL.lean
+++ b/TNLean/MPS/MPDO/PureRFPSAL.lean
@@ -142,4 +142,17 @@ theorem isSAL_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) : IsSAL A := by
     schmidtRight_gram_eq_of_isRFP A hRFP (show 1 ≤ N - (L + 1) by omega),
     schmidtLeft_gram_eq_of_isRFP A hRFP (show 1 ≤ L + 1 by omega)]
 
+/-- **A renormalization fixed point has a constant block-entropy chain.**
+Combining `isSAL_of_isRFP` with the telescoping of saturation
+(`pureBlockEntropy_eq_of_isSAL`), every pair of block entropies in the range
+`1 ≤ L, L' ≤ ⌊N/2⌋` of a renormalization fixed point coincides, i.e.
+`S_1 = S_2 = ⋯ = S_{⌊N/2⌋}`. This is the explicit constant-entropy chain of the
+area-law saturation (arXiv:1606.00608, Definition 3.13, line 600) under the
+fixed-point hypothesis. -/
+theorem pureBlockEntropy_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
+    {N L L' : ℕ} (hL1 : 1 ≤ L) (hLN : L ≤ N / 2) (hL'1 : 1 ≤ L') (hL'N : L' ≤ N / 2) :
+    pureBlockEntropy A N L (hLN.trans (Nat.div_le_self N 2)) =
+      pureBlockEntropy A N L' (hL'N.trans (Nat.div_le_self N 2)) :=
+  pureBlockEntropy_eq_of_isSAL A (isSAL_of_isRFP A hRFP) hL1 hLN hL'1 hL'N
+
 end MPSTensor

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3639,8 +3639,8 @@ the elementary trace-power identity for diagonal matrices.
     are equal. Hence $S_L^{(N)}(A)=S_{L+1}^{(N)}(A)$.
 \end{proof}
 
-\begin{corollary}[A renormalization fixed point has a constant block-entropy chain]
-    \label{cor:rfp_constant_entropy}
+\begin{theorem}[A renormalization fixed point has a constant block-entropy chain]
+    \label{thm:rfp_constant_entropy}
     \lean{MPSTensor.pureBlockEntropy_eq_of_isRFP}
     \leanok
     \uses{thm:rfp-saturates-area-law, lem:pure_sal_const}
@@ -3652,13 +3652,16 @@ the elementary trace-power identity for diagonal matrices.
     This is the explicit constant-entropy chain of the area-law saturation
     \cite[Definition~3.13, line~600]{Cirac2016MPDO_arXiv}, under the fixed-point
     hypothesis.
-\end{corollary}
+\end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp-saturates-area-law, lem:pure_sal_const}
     The fixed point saturates the area law
     (Theorem~\ref{thm:rfp-saturates-area-law}), so by the telescoping of
-    saturation (Lemma~\ref{lem:pure_sal_const}) all block entropies in the range
-    coincide.
+    saturation (Lemma~\ref{lem:pure_sal_const}) the block entropies at any two
+    lengths $1\le L, L'\le\lfloor N/2\rfloor$ agree:
+    \[
+        S_L^{(N)}(A) = S_{L'}^{(N)}(A).
+    \]
 \end{proof}
 
 \begin{lemma}[Operator-Schmidt rank bound]\label{lem:operator_schmidt_rank}

--- a/blueprint/src/chapter/ch21_mpdo.tex
+++ b/blueprint/src/chapter/ch21_mpdo.tex
@@ -3639,6 +3639,28 @@ the elementary trace-power identity for diagonal matrices.
     are equal. Hence $S_L^{(N)}(A)=S_{L+1}^{(N)}(A)$.
 \end{proof}
 
+\begin{corollary}[A renormalization fixed point has a constant block-entropy chain]
+    \label{cor:rfp_constant_entropy}
+    \lean{MPSTensor.pureBlockEntropy_eq_of_isRFP}
+    \leanok
+    \uses{thm:rfp-saturates-area-law, lem:pure_sal_const}
+    If an MPS tensor $A$ is a renormalization fixed point, then all block entropies
+    in the range $1\le L\le\lfloor N/2\rfloor$ coincide:
+    \[
+        S_1^{(N)}(A) = S_2^{(N)}(A) = \cdots = S_{\lfloor N/2\rfloor}^{(N)}(A).
+    \]
+    This is the explicit constant-entropy chain of the area-law saturation
+    \cite[Definition~3.13, line~600]{Cirac2016MPDO_arXiv}, under the fixed-point
+    hypothesis.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{thm:rfp-saturates-area-law, lem:pure_sal_const}
+    The fixed point saturates the area law
+    (Theorem~\ref{thm:rfp-saturates-area-law}), so by the telescoping of
+    saturation (Lemma~\ref{lem:pure_sal_const}) all block entropies in the range
+    coincide.
+\end{proof}
+
 \begin{lemma}[Operator-Schmidt rank bound]\label{lem:operator_schmidt_rank}
     \lean{MPSTensor.rank_reducedPureBlockState_le}
     \leanok


### PR DESCRIPTION
## Summary

Follow-up to #2815. The paper (arXiv:1606.00608, Definition 3.13, line 600) defines area-law saturation as the **explicit chain** `S_1^{(N)} = S_2^{(N)} = ⋯ = S_{⌊N/2⌋}^{(N)}`. `isSAL_of_isRFP` (from #2815) proves the consecutive form `S_L = S_{L+1}`; this corollary composes it with `pureBlockEntropy_eq_of_isSAL` (the saturation-telescoping lemma) to give the explicit all-pairs constant chain under the fixed-point hypothesis — the form the paper actually writes.

```lean
theorem pureBlockEntropy_eq_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A)
    {N L L' : ℕ} (hL1 : 1 ≤ L) (hLN : L ≤ N / 2) (hL'1 : 1 ≤ L') (hL'N : L' ≤ N / 2) :
    pureBlockEntropy A N L _ = pureBlockEntropy A N L' _ :=
  pureBlockEntropy_eq_of_isSAL A (isSAL_of_isRFP A hRFP) hL1 hLN hL'1 hL'N
```

One-line composition, sorry-free.

## Faithfulness

Both ingredients are already on `main`: `isSAL_of_isRFP` (#2815) and `pureBlockEntropy_eq_of_isSAL` (#2581). The corollary's hypothesis set (`1 ≤ L, L' ≤ ⌊N/2⌋`) is exactly the range of the paper's chain. No new hypotheses.

## Blueprint

`cor:rfp_constant_entropy` added to ch21 right after `thm:rfp-saturates-area-law`, `\leanok`, `\uses{thm:rfp-saturates-area-law, lem:pure_sal_const}`.

## Verification

- `lake build TNLean.MPS.MPDO.PureRFPSAL` — exit 0, 3438/3438 jobs, no `sorry`/`axiom`.
- `check_reader_facing_prose.py --diff-base HEAD` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin composition of existing lemmas and blueprint prose only; no auth, runtime, or behavioral code changes.
> 
> **Overview**
> Adds the **paper-facing** constant block-entropy chain under a renormalization fixed point: for `1 ≤ L, L' ≤ ⌊N/2⌋`, `pureBlockEntropy` at `L` equals at `L'`, i.e. `S₁^{(N)} = ⋯ = S_{⌊N/2⌋}^{(N)}` (Cirac et al., Definition 3.13).
> 
> In Lean, new theorem `MPSTensor.pureBlockEntropy_eq_of_isRFP` is a one-line corollary: `isSAL_of_isRFP` plus existing telescoping `pureBlockEntropy_eq_of_isSAL`—no new analytic argument.
> 
> The blueprint gains `thm:rfp_constant_entropy` (`\leanok`) immediately after `thm:rfp-saturates-area-law`, with proof citing RFP area-law saturation and `lem:pure_sal_const`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0cec160566d4b07a7148611c0f355e0ced5c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->