### PR TITLE
style: remove trailing whitespace and clear ERR_TWS nolint exemptions

### DIFF
--- a/TNLean/Algebra/LinearMapAux.lean
+++ b/TNLean/Algebra/LinearMapAux.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/

--- a/TNLean/MPS/SharedInfra/KrausAdjointSetup.lean
+++ b/TNLean/MPS/SharedInfra/KrausAdjointSetup.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/

--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/

--- a/scripts/nolints-style.txt
+++ b/scripts/nolints-style.txt
@@ -6,10 +6,6 @@
 -- in a follow-up cleanup PR after the corresponding source lines are fixed.
 
 TNLean/MPS/ParentHamiltonian/Commuting.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-TNLean/MPS/SharedInfra/GaugePhase.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-TNLean/MPS/SharedInfra/SectorDecomposition.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-TNLean/MPS/SharedInfra/KrausAdjointSetup.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-TNLean/Algebra/LinearMapAux.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
 
 -- ERR_UNICODE: the combining tilde U+0303 ("B" with a tilde) appears in the
 -- docstrings of three PEPS files, matching the modified-tensor notation of the


### PR DESCRIPTION
## Summary

Mechanical main-health cleanup of lint debt. Line 1 of four files opened the copyright block with `/- ` (a trailing space), each exempted in `scripts/nolints-style.txt` to keep the whole-repo `lake exe lint-style` gate green. This strips the whitespace and drops the four now-unneeded `ERR_TWS` exemptions:

- `TNLean/Algebra/LinearMapAux.lean`
- `TNLean/MPS/SharedInfra/GaugePhase.lean`
- `TNLean/MPS/SharedInfra/KrausAdjointSetup.lean`
- `TNLean/MPS/SharedInfra/SectorDecomposition.lean`

**Whitespace-only** — `/- ` → `/-` on line 1 of each; no Lean declaration, statement, or proof changes, so the build is unaffected and the style gate stays green without the exemptions.

The remaining `ParentHamiltonian/Commuting.lean` `ERR_TWS` exemption is intentionally **left** for its owning stream, which is mid-refactor (a `parent-hamiltonian-marker-migration` branch is active). The `ERR_UNICODE` PEPS exemptions are also untouched (separate follow-up).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only edits on comment openers and lint config; no logic, proofs, or build behavior changes.
> 
> **Overview**
> Removes trailing whitespace on **line 1** of four Lean files (`/- ` → `/-` on the copyright block opener) and deletes the matching **`ERR_TWS`** rows from `scripts/nolints-style.txt` so `lake exe lint-style` no longer needs those exemptions.
> 
> **No** theorem, definition, or proof text changes—only the first character line of each file. The `ParentHamiltonian/Commuting.lean` `ERR_TWS` entry and PEPS `ERR_UNICODE` exemptions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92d59ce5dc06932406ad08050854c99e0a86a3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->