### PR TITLE
feat(MPS/ParentHamiltonian): block-injective boundary-matrix commutation (L2 of #2405)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -186,6 +186,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryStripping
 import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingCoordinate
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping
+import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
 import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.WrappingWindow
+
+/-!
+# Block-injective boundary-matrix commutation
+
+For a block-injective MPS tensor (injective after blocking `L₀` sites), a boundary
+matrix `X` whose length-`L₀` windowed products satisfy a single matrix equation
+commutes with every one-site matrix `A j`. This is the block-injective analogue of
+`boundary_matrix_commutes`, with the single-site spanning replaced by the
+length-`L₀` block span and the complement cancellation handled by the block
+annihilation lemma `eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`.
+
+This is the "L2" step of the boundary-closing decomposition for the normal
+range-reduction argument of arXiv:2011.12127, Section IV.C; it isolates the whole
+remaining obligation onto the block matrix equation hypothesis `hMatEq` (the "L1"
+keystone, not yet proved). See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- **Block-injective boundary-matrix commutation (L2).**
+
+Let `A` be block injective with injectivity length `L₀ > 0`. Suppose a boundary
+matrix `X` and a family `Y` of matrices indexed by length-`K` complement words
+satisfy the block matrix equation
+\[
+  X \cdot A^{\sigma_{\mathrm{tail}}} \cdot A^{\sigma_{\mathrm{comp}}}
+  = A^{\sigma_{\mathrm{tail}}} \cdot Y_{\sigma_{\mathrm{comp}}}
+\]
+for every length-`L₀` head word `σ_tail` and every length-`K` complement word
+`σ_comp`. Then `X` commutes with every one-site matrix `A j`.
+
+The length-`L₀` head span (`wordSpan A L₀ = ⊤`) promotes the equation to all
+matrices `M₁`, and the block annihilation lemma cancels the length-`K` complement.
+This isolates the whole boundary-closing gap onto `hMatEq`. -/
+theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
+    {A : MPSTensor d D} {L₀ K : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (Y : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hMatEq : ∀ (σ_tail : Fin L₀ → Fin d) (σ_comp : Fin K → Fin d),
+      X * evalWord A (List.ofFn σ_tail) * evalWord A (List.ofFn σ_comp)
+        = evalWord A (List.ofFn σ_tail) * Y σ_comp) :
+    ∀ j : Fin d, X * A j = A j * X := by
+  -- Step 1: span the length-`L₀` head to promote the equation to all matrices `M₁`.
+  have hStep1 : ∀ (M₁ : Matrix (Fin D) (Fin D) ℂ) (σ_comp : Fin K → Fin d),
+      X * M₁ * evalWord A (List.ofFn σ_comp) = M₁ * Y σ_comp := by
+    intro M₁ σ_comp
+    have hfg : (LinearMap.mulLeft ℂ X).comp
+        (LinearMap.mulRight ℂ (evalWord A (List.ofFn σ_comp)))
+        = LinearMap.mulRight ℂ (Y σ_comp) := by
+      apply LinearMap.ext_on_range
+        (v := fun σ : Fin L₀ → Fin d => evalWord A (List.ofFn σ))
+      · simpa [wordSpan] using (wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj
+      · intro σ_tail
+        simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
+          LinearMap.mulRight_apply]
+        rw [← Matrix.mul_assoc]
+        exact hMatEq σ_tail σ_comp
+    have hcong := congrArg (· M₁) hfg
+    simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
+      LinearMap.mulRight_apply] at hcong
+    rw [← Matrix.mul_assoc] at hcong
+    exact hcong
+  -- Step 2: identify `Y σ_comp = X · A^{σ_comp}` (take `M₁ = 1`).
+  have hY : ∀ σ_comp : Fin K → Fin d,
+      Y σ_comp = X * evalWord A (List.ofFn σ_comp) := by
+    intro σ_comp
+    have h := hStep1 1 σ_comp
+    simp only [mul_one, one_mul] at h
+    exact h.symm
+  -- Step 3: the commutator annihilates every length-`K` complement word.
+  intro j
+  have hB : ∀ σ_comp : Fin K → Fin d,
+      (X * A j - A j * X) * evalWord A (List.ofFn σ_comp) = 0 := by
+    intro σ_comp
+    have h1 := hStep1 (A j) σ_comp
+    rw [hY σ_comp, ← Matrix.mul_assoc] at h1
+    rw [sub_mul, sub_eq_zero]
+    exact h1
+  -- Step 4: block injectivity turns annihilation at length `K ≤ (K+1)·L₀` into `0`.
+  have hzero : X * A j - A j * X = 0 :=
+    eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul hInj
+      (q := K + 1) (Nat.succ_le_succ (Nat.zero_le K))
+      (le_trans (Nat.le_succ K) (Nat.le_mul_of_pos_right (K + 1) hL₀)) hB
+  exact sub_eq_zero.mp hzero
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
@@ -8,11 +8,11 @@ import TNLean.MPS.ParentHamiltonian.WrappingWindow
 /-!
 # Block-injective boundary-matrix commutation
 
-For a block-injective MPS tensor (injective after blocking `L₀` sites), a boundary
-matrix `X` whose length-`L₀` windowed products satisfy a single matrix equation
+For a block-injective MPS tensor (injective after blocking \(L_0\) sites), a boundary
+matrix `X` whose length-\(L_0\) windowed products satisfy a single matrix equation
 commutes with every one-site matrix `A j`. This is the block-injective analogue of
 `boundary_matrix_commutes`, with the single-site spanning replaced by the
-length-`L₀` block span and the complement cancellation handled by the block
+length-\(L_0\) block span and the complement cancellation handled by the block
 annihilation lemma `eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`.
 
 This is the "L2" step of the boundary-closing decomposition for the normal
@@ -29,18 +29,19 @@ variable {d D : ℕ}
 
 /-- **Block-injective boundary-matrix commutation (L2).**
 
-Let `A` be block injective with injectivity length `L₀ > 0`. Suppose a boundary
+Let `A` be block injective with injectivity length \(L_0 > 0\). Suppose a boundary
 matrix `X` and a family `Y` of matrices indexed by length-`K` complement words
 satisfy the block matrix equation
 \[
   X \cdot A^{\sigma_{\mathrm{tail}}} \cdot A^{\sigma_{\mathrm{comp}}}
   = A^{\sigma_{\mathrm{tail}}} \cdot Y_{\sigma_{\mathrm{comp}}}
 \]
-for every length-`L₀` head word `σ_tail` and every length-`K` complement word
+for every length-\(L_0\) head word `σ_tail` and every length-`K` complement word
 `σ_comp`. Then `X` commutes with every one-site matrix `A j`.
 
-The length-`L₀` head span (`wordSpan A L₀ = ⊤`) promotes the equation to all
-matrices `M₁`, and the block annihilation lemma cancels the length-`K` complement.
+The length-\(L_0\) head span exhausts the full matrix algebra, promoting the equation
+to all matrices \(M_1\), and the block annihilation lemma cancels the length-`K`
+complement.
 This isolates the whole boundary-closing gap onto `hMatEq`. -/
 theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
     {A : MPSTensor d D} {L₀ K : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -50,7 +51,7 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
       X * evalWord A (List.ofFn σ_tail) * evalWord A (List.ofFn σ_comp)
         = evalWord A (List.ofFn σ_tail) * Y σ_comp) :
     ∀ j : Fin d, X * A j = A j * X := by
-  -- Step 1: span the length-`L₀` head to promote the equation to all matrices `M₁`.
+  -- Step 1: span the length-\(L_0\) head to promote the equation to all matrices \(M_1\).
   have hStep1 : ∀ (M₁ : Matrix (Fin D) (Fin D) ℂ) (σ_comp : Fin K → Fin d),
       X * M₁ * evalWord A (List.ofFn σ_comp) = M₁ * Y σ_comp := by
     intro M₁ σ_comp
@@ -70,7 +71,7 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
       LinearMap.mulRight_apply] at hcong
     rw [← Matrix.mul_assoc] at hcong
     exact hcong
-  -- Step 2: identify `Y σ_comp = X · A^{σ_comp}` (take `M₁ = 1`).
+  -- Step 2: take \(M_1 = 1\) to identify \(Y_{\sigma} = X \cdot A^{\sigma}\) on the complement.
   have hY : ∀ σ_comp : Fin K → Fin d,
       Y σ_comp = X * evalWord A (List.ofFn σ_comp) := by
     intro σ_comp
@@ -86,7 +87,7 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
     rw [hY σ_comp, ← Matrix.mul_assoc] at h1
     rw [sub_mul, sub_eq_zero]
     exact h1
-  -- Step 4: block injectivity turns annihilation at length `K ≤ (K+1)·L₀` into `0`.
+  -- Step 4: block injectivity turns annihilation at length \(K \le (K+1)\cdot L_0\) into \(0\).
   have hzero : X * A j - A j * X = 0 :=
     eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul hInj
       (q := K + 1) (Nat.succ_le_succ (Nat.zero_le K))


### PR DESCRIPTION
## Summary

Adds `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` — the **block-injective analogue** of `boundary_matrix_commutes`. This is the **L2 step** of the decomposition for the live boundary-closing `sorry` tracked in **#2405** (`closure_property_boundary_restrictions_eq_of_groundSpaceMap`).

Given the block matrix equation
```
X · A^{σ_tail} · A^{σ_comp} = A^{σ_tail} · Y_{σ_comp}
```
for every length-`L₀` head `σ_tail` and length-`K` complement `σ_comp`, the lemma proves `X · A j = A j · X` for every one-site matrix.

## Why this resolves the spanning crux

The injective-case proof (`boundary_matrix_commutes`) spans the complement word at its literal length using full word-span at *every* length, which `IsInjective` provides but `IsNBlkInjective A L₀` does **not** (block span is full only at multiples of `L₀`). This lemma instead:

1. spans the length-`L₀` head via `(wordSpan_eq_top_iff_isNBlkInjective A L₀).mpr hInj` to promote the equation to all matrices `M₁`;
2. shows the commutator `X·A j − A j·X` annihilates every length-`K` complement word on the right;
3. applies `eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul` with `q = K+1` (so `K ≤ (K+1)·L₀`), which is exactly the block-injective annihilation tool — no full complement span needed.

This isolates the entire remaining boundary-closing obligation onto the block matrix equation hypothesis (`hMatEq`, the L1 keystone). See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` and #2405 for the full decomposition.

96-line new file; structurally mirrors the proven injective-case template. Statement-only consumer wiring (L1/L3) follows in subsequent PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proof module with no changes to runtime behavior, auth, or existing theorem statements; risk is limited to library build/import graph and downstream proof wiring.
> 
> **Overview**
> Adds **`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`**, the block-injective version of `boundary_matrix_commutes`, and exports it via **`TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean`** on the root import list.
> 
> From a **block matrix equation** on length-`L₀` head words and length-`K` complement words, the proof promotes the relation to all head matrices using **`wordSpan_eq_top_iff_isNBlkInjective`**, then uses **`eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`** so the commutator vanishes without spanning the full complement at every length. This is the **L2** step in the boundary-closing decomposition for normal range reduction; the remaining gap is proving the equation hypothesis (**L1** / `hMatEq`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd56435a41e071c8d0fe44e11a4f08f6b8cc1732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->