### PR TITLE
style: replace combining-tilde B̃ with B' in PEPS docstrings, clear ERR_UNICODE exemptions

### DIFF
--- a/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
+++ b/TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean
@@ -8,6 +8,9 @@ This file performs the orientation-reconciliation step of the normal PEPS Fundam
 final comparison (arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1519--1571 of
 `Papers/1804.04964/paper_normal.tex`).
 
+Throughout, `B'` abbreviates the gauged tensor `applyGauge B X`, which the source writes
+with a tilde over `B`; the `Source:` citations below use this notation.
+
 The region comparison `regionComplement_comparison` consumes, as its load-bearing hypothesis
 `hregion`, the *absorbed plain* region-inserted coefficient equality
 
@@ -24,7 +27,7 @@ holding at the *edge level* on every boundary edge of `R` --- the bare-edge stat
 no region --- multiplies back up to the region absorbed equality at `R`
 (`regionInsertedCoeff_eq_applyGauge_of_edge`), supplying `hregion` for *every* comparison region
 whose boundary edges all carry the edge-level absorbed equality.  Feeding it to
-`regionComplement_comparison` produces the region-block scalar proportionality `A_R ∝ B̃_R` that
+`regionComplement_comparison` produces the region-block scalar proportionality `A_R ∝ B'_R` that
 the inserted-site scalar extraction consumes.
 
 The single uniform `X` realizing the edge-level absorbed equality at every edge --- the
@@ -124,13 +127,13 @@ theorem regionAbsorbed_of_edgeAbsorbed (A B : Tensor G d)
 For a region `R` whose two block tensors over `A` and over the gauge-absorbed second tensor
 `applyGauge B X` are all two-block injective, if the edge-level absorbed equality against
 `applyGauge B X` holds at every edge of the graph, then the region blocks of `A` and of the
-reindexed `applyGauge B X` are scalar proportional: there is a nonzero `c` with `A_R = c · B̃_R`.
+reindexed `applyGauge B X` are scalar proportional: there is a nonzero `c` with `A_R = c · B'_R`.
 
 This is `regionComplement_comparison` fed the region absorbed equality of
 `regionAbsorbed_of_edgeAbsorbed`.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1544 of
-`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B̃_R`. -/
+`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B'_R`. -/
 theorem twoBlockProportional_of_edgeAbsorbed (A B : Tensor G d)
     (hbd : A.bondDim = B.bondDim)
     (X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
@@ -165,7 +168,7 @@ edges with interior margins, so the absorbed equality is available on the bounda
 comparison region placed in the interior window, not on every lattice edge.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1544 of
-`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B̃_R`. -/
+`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B'_R`. -/
 theorem twoBlockProportional_of_boundaryEdgeAbsorbed (A B : Tensor G d)
     (hbd : A.bondDim = B.bondDim)
     (X : (e : Edge G) → GL (Fin (B.bondDim e)) ℂ)
@@ -191,18 +194,18 @@ theorem twoBlockProportional_of_boundaryEdgeAbsorbed (A B : Tensor G d)
 
 /-! ### Uniqueness of the proportionality scalar
 
-The scalar `c` in a region-block proportionality `A_R = c · B̃_R` is determined by `A` and `B̃`
-once `B̃`'s blocked family is linearly independent: a linearly independent family has no zero
-member, so some blocked weight of `B̃` is nonzero, and the proportionality reads `c` off that
+The scalar `c` in a region-block proportionality `A_R = c · B'_R` is determined by `A` and `B'`
+once `B'`'s blocked family is linearly independent: a linearly independent family has no zero
+member, so some blocked weight of `B'` is nonzero, and the proportionality reads `c` off that
 nonzero entry.  This names the proportionality scalar canonically --- the translation-invariant
 common quotient the torus scalar condition consumes is the ratio of two such named scalars. -/
 
 /-- **Uniqueness of the region-block proportionality scalar.**
 
-If the reindexed comparison tensor `B̃ = reindexTensor Btilde hbd` has a linearly independent
+If the reindexed comparison tensor `B' = reindexTensor Btilde hbd` has a linearly independent
 blocked family over `R`, every bond dimension is positive, and both `c` and `c'` are
-proportionality scalars of `A_R` against `B̃_R`, then `c = c'`: positivity makes the boundary-label
-index nonempty, linear independence forbids a zero member there, so some blocked weight of `B̃` is
+proportionality scalars of `A_R` against `B'_R`, then `c = c'`: positivity makes the boundary-label
+index nonempty, linear independence forbids a zero member there, so some blocked weight of `B'` is
 nonzero and both scalars equal `A`'s weight divided by it.
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_equal_tensors_2`: the proportionality constant is
@@ -226,7 +229,7 @@ theorem twoBlockScalarProportional_unique (A Btilde : Tensor G d) (R : Finset V)
   have hNe : Nonempty (RegionBoundaryConfig (G := G) C R) :=
     ⟨fun f => ⟨0, hCpos f.1⟩⟩
   -- A linearly independent family has no zero member: pick a boundary label `b` and a physical
-  -- configuration `ρ` where `B̃`'s blocked weight is nonzero.
+  -- configuration `ρ` where `B'`'s blocked weight is nonzero.
   have hne : (regionBlockedTensorFamily (G := G) C R)
       (Classical.arbitrary (RegionBoundaryConfig (G := G) C R)) ≠ 0 :=
     hBinj.ne_zero _
@@ -236,7 +239,7 @@ theorem twoBlockScalarProportional_unique (A Btilde : Tensor G d) (R : Finset V)
     push Not at h
     exact hne (funext h)
   set b := Classical.arbitrary (RegionBoundaryConfig (G := G) C R) with hbdef
-  -- Both proportionalities read at `(b, ρ)` give `A_R = c · B̃_R` and `A_R = c' · B̃_R`.
+  -- Both proportionalities read at `(b, ρ)` give `A_R = c · B'_R` and `A_R = c' · B'_R`.
   have h1 := hc PUnit.unit b ρ
   have h2 := hc' PUnit.unit b ρ
   simp only [regionTwoBlock_apply] at h1 h2

--- a/TNLean/PEPS/RegionBlock/ScalarExtraction.lean
+++ b/TNLean/PEPS/RegionBlock/ScalarExtraction.lean
@@ -7,22 +7,25 @@ This file performs the scalar-extraction step of the normal PEPS Fundamental
 Theorem's final comparison (arXiv:1804.04964, Section 3, proof of Theorem 3,
 lines 1544--1571 of `Papers/1804.04964/paper_normal.tex`).
 
+Throughout, `B'` abbreviates the gauged tensor, which the source writes with a
+tilde over `B`.
+
 The region comparison `regionComplement_comparison` delivers, at a region `R` and
 at the one-site-larger region `insert v R`, the two scalar proportionalities
-`A_R = c_R · B̃_R` and `A_S = c_S · B̃_S` of the blocked weights.  Feeding both
+`A_R = c_R · B'_R` and `A_S = c_S · B'_S` of the blocked weights.  Feeding both
 through the landed inserted-site factorization
 `insertOuterBondProd_smul_regionBlockedWeight_insert` cancels the bond-only
 inserted-site multiplicity and leaves, at every inserted-site local configuration
 `η`, the inserted-site tensor of `A` against the bridge-label blocked weight of `R`
-matched with `c_S` against the inserted-site tensor of `B̃` against the same
+matched with `c_S` against the inserted-site tensor of `B'` against the same
 bridge-label weight, scaled by `c_R` after substituting the `R`-proportionality.
 
 The bridge labels of the *consistent* local configurations `η` at `v` are in
 bijection with `η` itself: a consistent `η` is determined by the bridge label on
 the `v`-incident edges that bound `R` and by `μ` on the `v`-incident edges that do
-not.  Linear independence of `B̃`'s `R`-blocked family therefore separates the
+not.  Linear independence of `B'`'s `R`-blocked family therefore separates the
 `η`-coefficients to a single term each, yielding the per-vertex relation
-`A.component v η = (c_S / c_R) · B̃.component v η` at every local configuration `η`.
+`A.component v η = (c_S / c_R) · B'.component v η` at every local configuration `η`.
 
 ## References
 

--- a/TNLean/PEPS/RegionComplementComparison.lean
+++ b/TNLean/PEPS/RegionComplementComparison.lean
@@ -11,9 +11,9 @@ Fundamental Theorem (arXiv:1804.04964, Section 3, proof of Theorem 3, lines
 
 After the per-edge gauges are absorbed into the second tensor, the source compares
 two one-site-different injective regions `R` and `S`, both with injective
-complements, against the modified tensor `B̃`:
-
-> *"by `lem:inj_equal_tensors_2`, `A_R ∝ B̃_R` and `A_S ∝ B̃_S`."* (line 1544)
+complements, against the modified tensor `B'` (written with a tilde over `B` in
+the source). At line 1544 the source applies its `lem:inj_equal_tensors_2` to
+conclude `A_R ∝ B'_R` and `A_S ∝ B'_S`.
 
 This is the region analogue of the one-vertex-versus-complement comparison
 `one_vertex_complement_comparison` used in the injective case. The single vertex is
@@ -22,11 +22,11 @@ complement `univ \ R`. The two blocks are wrapped as `regionTwoBlock A R` and
 `regionComplementTwoBlock A R`, both two-block injective for a vertex-injective PEPS
 with positive bonds (`regionBlockedTensorInjective_of_isVertexInjective`). The
 generalized two-injective comparison `two_injective_tensor_insertion_comparison`
-then gives scalar proportionality `A_R ∝ B̃_R`.
+then gives scalar proportionality `A_R ∝ B'_R`.
 
 ## The conditional structure
 
-The region-inserted-coefficient equality between `A` and `B̃` --- the source's
+The region-inserted-coefficient equality between `A` and `B'` --- the source's
 statement at line 1519 that "inserting a matrix `Z` on any bond of the first PEPS
 gives the same state as inserting the same matrix on the corresponding bond of the
 second PEPS" --- is taken as a hypothesis. It is the region form of the
@@ -54,17 +54,17 @@ variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 
 A region `R` and its set complement `univ \ R` form a two-block pair over the edges
 crossing the boundary of `R`. The region-inserted-coefficient equality between `A`
-and the modified tensor `B̃` (transported to `A`'s bonds) gives, via
+and the modified tensor `B'` (transported to `A`'s bonds) gives, via
 `sameTwoBlockInsertions_of_regionInsertedCoeff_eq` and the generalized two-injective
 comparison, scalar proportionality of the region block of `A` with the region block
-of `B̃`. -/
+of `B'`. -/
 
 /-- **Region-versus-complement scalar proportionality.**
 
-For a region `R` whose two block tensors over `A` and over the reindexed `B̃` are
-all two-block injective, if `A` and `B̃` have matched bond dimensions and equal
+For a region `R` whose two block tensors over `A` and over the reindexed `B'` are
+all two-block injective, if `A` and `B'` have matched bond dimensions and equal
 region-inserted coefficients on every boundary edge of `R`, then the region blocks
-are scalar proportional: there is a nonzero `c` with `A_R = c · B̃_R`.
+are scalar proportional: there is a nonzero `c` with `A_R = c · B'_R`.
 
 This is the region analogue of `one_vertex_complement_comparison`. The matched
 region-inserted coefficients are turned into equal one-bond two-block insertions by
@@ -75,7 +75,7 @@ The region-inserted-coefficient equality is the conditional kernel input; see th
 module docstring.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, line 1544 of
-`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B̃_R`. -/
+`Papers/1804.04964/paper_normal.tex`: `A_R ∝ B'_R`. -/
 theorem regionComplement_comparison (A Btilde : Tensor G d)
     (R : Finset V) (hbd : A.bondDim = Btilde.bondDim)
     [Nonempty {f : Edge G // IsRegionBoundaryEdge (G := G) R f}]
@@ -115,8 +115,8 @@ theorem regionComplement_comparison (A Btilde : Tensor G d)
 
 For vertex-injective `A` and `Btilde` with positive bond dimensions and matched
 bond dimensions, every region `R` with at least one boundary edge admits the
-region-block scalar proportionality `A_R ∝ B̃_R`, provided the region-inserted
-coefficients of `A` and `B̃` agree on every boundary edge of `R`.
+region-block scalar proportionality `A_R ∝ B'_R`, provided the region-inserted
+coefficients of `A` and `B'` agree on every boundary edge of `R`.
 
 The four two-block injectivity hypotheses are discharged uniformly from vertex
 injectivity by `regionBlockedTensorInjective_of_isVertexInjective`, so the region

--- a/scripts/nolints-style.txt
+++ b/scripts/nolints-style.txt
@@ -6,12 +6,3 @@
 -- in a follow-up cleanup PR after the corresponding source lines are fixed.
 
 TNLean/MPS/ParentHamiltonian/Commuting.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this
-
--- ERR_UNICODE: the combining tilde U+0303 ("B" with a tilde) appears in the
--- docstrings of three PEPS files, matching the modified-tensor notation of the
--- source paper arXiv:1804.04964. It is not on the Mathlib text linter allowlist.
--- Exempted here to keep the style gate green; replace with allowlist-safe prose in
--- a follow-up PEPS docstring cleanup.
-TNLean/PEPS/RegionComplementComparison.lean : line 1 : ERR_UNICODE : This line contains a unicode character that is not on the allowlist '̃' (U+0303). For adding new symbols see `Mathlib.Linter.TextBased.UnicodeLinter.othersInMathlib`.
-TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean : line 1 : ERR_UNICODE : This line contains a unicode character that is not on the allowlist '̃' (U+0303). For adding new symbols see `Mathlib.Linter.TextBased.UnicodeLinter.othersInMathlib`.
-TNLean/PEPS/RegionBlock/ScalarExtraction.lean : line 1 : ERR_UNICODE : This line contains a unicode character that is not on the allowlist '̃' (U+0303). For adding new symbols see `Mathlib.Linter.TextBased.UnicodeLinter.othersInMathlib`.


### PR DESCRIPTION
## Summary

Resolves the documented `ERR_UNICODE` lint debt in `scripts/nolints-style.txt`. The combining tilde **U+0303** (`B̃`) appeared only in the docstrings of three PEPS files as shorthand for the gauged/modified tensor (the Lean term `applyGauge B X`); it is off the Mathlib text-linter allowlist and was exempted to keep the style gate green, with a note asking for "a follow-up PEPS docstring cleanup".

This replaces the 32 occurrences with the allowlist-safe `B'` and removes the three `ERR_UNICODE` exemptions plus their now-obsolete comment block.

- `TNLean/PEPS/RegionComplementComparison.lean`
- `TNLean/PEPS/RegionBlock/ProportionalityFromAbsorbed.lean`
- `TNLean/PEPS/RegionBlock/ScalarExtraction.lean`

**Docstring-only** — `B̃` was never a Lean identifier (the code uses `applyGauge B X`), so there is no semantic or build change; the lint-style gate passes without the exemptions.

## Notation note for reviewers

I used `B'` because the docstrings already call it "the modified tensor" and `B'` reads cleanly in the inline-code notation (`A_R ∝ B'_R`, `A_R = c · B'_R`). The source paper (arXiv:1804.04964) writes it with a tilde, so one docstring quote now renders `B'` where the paper has `B̃`. If you'd prefer a different allowlist-safe rendering (e.g. spelling out "gauged B", or `$\widetilde{B}$` in math spans), say so and I'll switch — the load-bearing change is just removing U+0303.

The `ParentHamiltonian/Commuting.lean` `ERR_TWS` exemption is intentionally left for its owning stream (active refactor).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and lint-exception cleanup only; no Lean definitions, proofs, or runtime behavior change.
> 
> **Overview**
> Replaces **combining-tilde** gauged-tensor notation (`B̃`, U+0303) in PEPS module and theorem docstrings with allowlist-safe **`B'`**, and adds short notes that `B'` means `applyGauge B X` / the paper’s tilde-over-`B` notation.
> 
> **`scripts/nolints-style.txt`**: removes the three **`ERR_UNICODE`** exemptions (and their comment block) for `RegionComplementComparison.lean`, `ProportionalityFromAbsorbed.lean`, and `ScalarExtraction.lean` so the text style gate no longer needs those waivers.
> 
> Docstrings and lint config only — Lean identifiers and proofs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe1c902dedfbca87c43ec0f8bda3e9b63a9bea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->