### PR TITLE
feat(MPDO): physical-trace transfer and source-faithful zero correlation length

### DIFF
--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -13,6 +13,12 @@ networks, following arXiv:1606.00608, lines 736–741.
 
 ## Main definitions
 
+* `MPOTensor.physTraceTransfer`: the physical-trace transfer
+  `∑ i, M i i` obtained by closing the ket and bra physical legs of one tensor.
+* `MPOTensor.IsSourceZCL`: the source-faithful zero-correlation-length
+  condition for the physical-trace transfer.
+* `MPOTensor.isSourceZCL_of_physTraceTransfer_sq`: literal idempotence of the
+  physical-trace transfer gives source ZCL.
 * `MPOTensor.IsZCL`: the MPO transfer map is idempotent.
 * `MPOTensor.isZCL_iff_toMPSTensor_isRFP`: this condition is equivalent to the
   pure-state RFP condition for the doubled-index MPS tensor.

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -60,4 +60,41 @@ theorem isZCL_iff_toMPSTensor_isRFP (M : MPOTensor d D) :
     IsZCL M ↔ MPSTensor.IsRFP (M.toMPSTensor) := by
   simp [IsZCL, MPSTensor.IsRFP]
 
+/-- The **physical-trace transfer** `𝒯_M = ∑_i M^{ii}` of an MPO tensor: the
+single bond matrix obtained by closing the ket and bra physical legs of one
+tensor. This is the transfer object of the source zero-correlation-length
+condition (arXiv:1606.00608, Definition 4.2, lines 735–739), as identified in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. It is distinct
+from the doubled-index completely positive map `transferMap`, which sums
+`∑_{i,j} M^{ij} X (M^{ij})ᴴ` over both physical legs; the physical-trace transfer
+instead contracts the two legs of a single tensor. -/
+noncomputable def physTraceTransfer (M : MPOTensor d D) : Matrix (Fin D) (Fin D) ℂ :=
+  ∑ i : Fin d, M i i
+
+/-- **Source-faithful zero correlation length** (arXiv:1606.00608, Definition 4.2).
+An MPO tensor has zero correlation length when its physical-trace transfer
+`𝒯_M = ∑_i M^{ii}` is nonzero and idempotent up to a positive scalar:
+`𝒯_M * 𝒯_M = λ • 𝒯_M` for some `λ > 0`. The condition is invariant under the
+rescaling `M ↦ c M`, and literal idempotence `𝒯_M * 𝒯_M = 𝒯_M` is the `λ = 1`
+canonical-form representative. The nonzero clause excludes the degenerate zero
+transfer, which satisfies `𝒯_M * 𝒯_M = λ • 𝒯_M` vacuously for every `λ`.
+
+This is the Option 1 formalization of
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`: it uses the source
+transfer object `𝒯_M`, unlike `MPOTensor.IsZCL`, which records idempotence of the
+doubled-index map `transferMap`. -/
+def IsSourceZCL (M : MPOTensor d D) : Prop :=
+  physTraceTransfer M ≠ 0 ∧
+    ∃ lam : ℝ, 0 < lam ∧
+      physTraceTransfer M * physTraceTransfer M = (lam : ℂ) • physTraceTransfer M
+
+/-- Literal idempotence of the physical-trace transfer (the `λ = 1`
+canonical-form case) gives source zero correlation length, provided the transfer
+is nonzero. -/
+theorem isSourceZCL_of_physTraceTransfer_sq
+    (M : MPOTensor d D) (h0 : physTraceTransfer M ≠ 0)
+    (hidem : physTraceTransfer M * physTraceTransfer M = physTraceTransfer M) :
+    IsSourceZCL M :=
+  ⟨h0, 1, one_pos, by rw [hidem, Complex.ofReal_one, one_smul]⟩
+
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_blocked_rfp.tex
@@ -13,7 +13,7 @@
     rank-one criterion of Theorem~\ref{thm:sal_zcl_implies_rank_one_t}.
 \end{definition}
 
-\begin{theorem}[Local simple-MPDO structure from SAL--ZCL hypotheses]
+\begin{theorem}[Local simple-MPDO structure from entropy data and the rank-one criterion]
     \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCL}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef}
@@ -45,16 +45,20 @@
     argument for commuting form.
 \end{definition}
 
-\begin{theorem}[Blocked-RFP structure from SAL--ZCL and commuting form]
+\begin{theorem}[Blocked-RFP structure from local data and commuting form]
     \label{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_commuting_form}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndCommutingForm}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndCommutingFormOfPosSemidef}
     \leanok
     \uses{def:simple_mpdo_blocked_rfp_data,
         thm:simple_mpdo_local_structure_data_of_sal_zcl}
-    The SAL--ZCL hypotheses together with a commuting-form witness determine
-    the simple-MPDO blocked-RFP structure. In the PSD-corrected form, the
-    matrix input is $T\ge0$, $\operatorname{tr}(T)=1$, and
+    The local simple-MPDO structure, a commuting-form witness, and the
+    doubled-index transfer equation
+    \[
+        \E_K\circ\E_K=\E_K
+    \]
+    determine the simple-MPDO blocked-RFP structure. In the PSD-corrected form,
+    the matrix input is $T\ge0$, $\operatorname{tr}(T)=1$, and
     $\operatorname{tr}(T^m)=1$ for all $m>0$, rather than an abstract
     Perron--Frobenius rank-one assumption for $T$.
 \end{theorem}
@@ -79,7 +83,7 @@
     doubled-index transfer condition fill the other two fields.
 \end{proof}
 
-\begin{theorem}[Blocked-RFP structure from SAL--ZCL and $\eta$-local structure]
+\begin{theorem}[Blocked-RFP structure from local data and $\eta$-local structure]
     \label{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructure}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData.ofSALZCLAndEtaLocalStructureOfPosSemidef}
@@ -252,20 +256,24 @@
     \]
 \end{proof}
 
-\begin{theorem}[Simple-MPDO RFP chain from SAL--ZCL and $\eta$-local structure]
+\begin{theorem}[Simple-MPDO RFP chain from local data and $\eta$-local structure]
     \label{thm:simple_mpdo_rfp_chain_of_sal_zcl_and_eta_local_structure}
     \lean{MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure}
     \lean{MPOTensor.simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef}
     \leanok
     \uses{thm:simple_mpdo_blocked_rfp_data_of_sal_zcl_and_eta_local_structure,
         thm:simple_mpdo_rfp_chain_of_data}
-    Assume the local SAL--ZCL hypotheses of
+    Assume the local hypotheses of
     \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv} and the assembled
-    $\eta$-local product form, with the conditional rank-one criterion for $T$,
-    $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
-    $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$. Then
-    $K$ lies in the GSNNCH branch with doubled-index idempotence, admits a
-    blocked fusion-isometry witness at size $2$, and satisfies the
+    $\eta$-local product form, with the conditional rank-one criterion for $T$
+    and the doubled-index transfer equation
+    \[
+        \E_K\circ\E_K=\E_K.
+    \]
+    If $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
+    $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$, then $K$ lies in the
+    GSNNCH branch with doubled-index idempotence, admits a blocked
+    fusion-isometry witness at size $2$, and satisfies the
     transfer-map fusion formulation of idempotence. The
     PSD-corrected form uses $T\ge0$ together with
     $\operatorname{tr}(T^m)=1$ for all $m>0$ in place of the conditional
@@ -273,8 +281,8 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    Combine the local SAL--ZCL hypotheses and the $\eta$-local product form into the
-    blocked-RFP structure, then apply
+    Combine the local hypotheses, the doubled-index transfer equation, and the
+    $\eta$-local product form into the blocked-RFP structure, then apply
     Theorem~\ref{thm:simple_mpdo_rfp_chain_of_data}.
 \end{proof}
 
@@ -302,19 +310,20 @@
     condition, which is transfer-map idempotence.
 \end{proof}
 
-\begin{remark}[SAL--ZCL implication for the GSNNCH branch]
+\begin{remark}[Missing implication for the GSNNCH branch]
     \label{rem:simple_mpdo_rfp_chain_gap}
     \notready
     \uses{def:simple_mpdo_local_structure_data,
         def:simple_mpdo_blocked_rfp_data, thm:simple_mpdo_rfp_chain}
-    The implication from SAL and ZCL alone to the conclusion of
+    The implication from the source entropy and zero-correlation-length
+    hypotheses alone to the conclusion of
     \cite[Appendix~C.2]{Cirac2016MPDO_arXiv} requires a derivation of the
     commuting-form property from the local simple-MPDO structure of
     \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv}. Once that derivation
     is available,
     Theorem~\ref{thm:simple_mpdo_rfp_chain} gives the GSNNCH branch with the
     present doubled-index transfer condition and the blocked fusion-isometry
-    witness. This missing derivation is documented
-    in \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
+    witness.
+    % Gap documented in docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex.
     % issue #823
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_blocked_rfp.tex
@@ -29,16 +29,20 @@
     Theorem~\ref{thm:psd_trace_powers_rank_one_t}.
 \end{theorem}
 
-\begin{definition}[Simple-MPDO blocked-RFP structure]
+\begin{definition}[Simple-MPDO blocked doubled-index structure]
     \label{def:simple_mpdo_blocked_rfp_data}
     \lean{MPOTensor.SimpleMPDOBlockedRFPData}
     \leanok
     \uses{def:simple_mpdo_local_structure_data, def:mpdo_has_commuting_form,
         def:mpo_is_zcl}
     For an MPO tensor $K$, this records the local ingredients of
-    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}, the
-    commuting-form property, and zero correlation length. The local component
-    consists of the hypotheses used in the entropy-side argument for commuting form.
+    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}, the commuting-form property,
+    and the doubled-index transfer condition
+    \[
+        \E_K\circ\E_K=\E_K.
+    \]
+    The local component consists of the hypotheses used in the entropy-side
+    argument for commuting form.
 \end{definition}
 
 \begin{theorem}[Blocked-RFP structure from SAL--ZCL and commuting form]
@@ -62,17 +66,17 @@
     \uses{def:simple_mpdo_local_structure_data,
         def:simple_mpdo_blocked_rfp_data,
         def:mpdo_eta_local_structure_data}
-    Given the local data of \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}, ZCL, and
-    an $\eta$-local product
+    Given the local data of \cite[Appendix~C.2]{Cirac2016MPDO_arXiv}, the
+    doubled-index transfer condition, and an $\eta$-local product
     $\sigma^{(N)}(K)=c_N\prod_n B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge0$, and $[B_{i,i+1},B_{j,j+1}]=0$, one obtains the
     simple-MPDO blocked-RFP structure for $K$.
 \end{theorem}
 
 \begin{proof}\leanok
-    The $\eta$-local product gives the commuting-form property for $K$; the local
-    hypotheses of \cite[Appendix~C.2]{Cirac2016MPDO_arXiv} and ZCL fill the
-    other two fields.
+    The $\eta$-local product gives the commuting-form property for $K$; the
+    local hypotheses of \cite[Appendix~C.2]{Cirac2016MPDO_arXiv} and the
+    doubled-index transfer condition fill the other two fields.
 \end{proof}
 
 \begin{theorem}[Blocked-RFP structure from SAL--ZCL and $\eta$-local structure]
@@ -85,7 +89,7 @@
     Suppose \cite[Lemma~C.2]{Cirac2016MPDO_arXiv} gives the Markov decomposition,
     \cite[Lemma~C.4]{Cirac2016MPDO_arXiv} gives the
     local $\eta$-structure and a primitive matrix $T$ with
-    $\operatorname{tr}(T)=1$, and ZCL together with
+    $\operatorname{tr}(T)=1$, and the doubled-index transfer condition together with
     \cite[Lemma~C.5]{Cirac2016MPDO_arXiv} gives
     $\operatorname{tr}(T^m)$ independent of $m$ and the conditional rank-one
     criterion for $T$. Suppose also that the assembled $\eta$-local structure gives
@@ -103,24 +107,25 @@
     primitivity statement of \cite[Lemma~C.4]{Cirac2016MPDO_arXiv}, and the
     conditional rank-one criterion for $T$ of
     \cite[Lemma~C.5]{Cirac2016MPDO_arXiv}. The $\eta$-local product
-    formula supplies the commuting-form component, and ZCL supplies the
-    remaining component of the blocked-RFP structure.
+    formula supplies the commuting-form component, and the doubled-index
+    transfer condition supplies the remaining component of the blocked-RFP
+    structure.
 \end{proof}
 
-\begin{theorem}[Zero correlation length gives a blocked fusion-isometry witness]
+\begin{theorem}[Doubled-index idempotence gives a blocked fusion-isometry witness]
     \label{thm:structural_implies_rfp_blocked}
     \lean{MPOTensor.structural_implies_rfp_blocked}
     \leanok
     \uses{def:mpo_is_zcl, def:mpdo_fusion_isometry, def:mpdo_rfp_via_fusion,
         thm:mpdo_rfp_via_fusion_iff}
-    If an MPO tensor $K$ has zero correlation length, then it has a blocked
-    fusion-isometry witness at size $2$ in the sense of
+    If an MPO tensor $K$ satisfies the doubled-index transfer condition, then
+    it has a blocked fusion-isometry witness at size $2$ in the sense of
     Definition~\ref{def:mpdo_fusion_isometry}.
 \end{theorem}
 
 \begin{proof}\leanok
-    Zero correlation length is transfer-map idempotence.
-    Applying the converse direction of
+    The doubled-index transfer condition is transfer-map idempotence. Applying
+    the converse direction of
     Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to that RFP witness yields
     fusion-isometry data at every positive blocked size; evaluating it at size $2$
     produces the blocked witness.
@@ -136,8 +141,8 @@
 \end{theorem}
 
 \begin{proof}\leanok
-    Apply the zero-correlation-length theorem to the ZCL component of the
-    blocked-RFP data.
+    Apply the doubled-index idempotence theorem to the corresponding component
+    of the blocked-RFP data.
 \end{proof}
 
 \begin{lemma}[Blocked-RFP data give the fusion formulation]
@@ -152,7 +157,7 @@
 \begin{proof}\leanok
     The implication used here is
     \[
-        \operatorname{ZCL}(K)
+        \E_K\circ\E_K=\E_K
         \Longrightarrow \operatorname{RFP}(K)
         \Longrightarrow \operatorname{RFP}_{\mathrm{fusion}}(K).
     \]
@@ -166,14 +171,15 @@
         thm:structural_implies_rfp_blocked,
         lem:simple_mpdo_blocked_rfp_data_rfp_via_fusion}
     Given the blocked-RFP data for an MPO tensor $K$, one obtains the
-    GSNNCH-with-ZCL case, the blocked fusion-isometry witness at size $2$, and
-    the transfer-map fusion formulation of idempotence.
+    GSNNCH branch with doubled-index idempotence, the blocked fusion-isometry
+    witness at size $2$, and the transfer-map fusion formulation of
+    idempotence.
 \end{theorem}
 
 \begin{proof}\leanok
-    The commuting-form and zero-correlation-length assumptions give the
-    GSNNCH-with-ZCL case. Zero correlation length also gives the blocked
-    fusion-isometry witness and the transfer-map fusion formulation.
+    The commuting-form and doubled-index transfer assumptions give the GSNNCH
+    branch with doubled-index idempotence. The same transfer condition gives
+    the blocked fusion-isometry witness and the transfer-map fusion formulation.
 \end{proof}
 
 \begin{lemma}[Size-$2$ fusion witness from $\eta$-local structure]
@@ -183,14 +189,14 @@
     \uses{def:mpdo_eta_local_structure_data, def:mpo_is_zcl,
         thm:structural_implies_rfp_blocked}
     If the $\eta$-local structure has been constructed for an MPO tensor $K$,
-    then zero correlation length gives the blocked fusion-isometry witness at
-    size $2$.
+    then the doubled-index transfer condition gives the blocked
+    fusion-isometry witness at size $2$.
 \end{lemma}
 
 \begin{proof}\leanok
     The implication used here is
     \[
-        \operatorname{ZCL}(K)
+        \E_K\circ\E_K=\E_K
         \Longrightarrow \operatorname{RFP}(K)
         \Longrightarrow \operatorname{FusionWitness}_{2}(K).
     \]
@@ -203,14 +209,14 @@
     \uses{def:mpdo_eta_local_structure_data, def:mpo_is_zcl,
         def:mpdo_rfp_via_fusion}
     If the $\eta$-local structure has been constructed for an MPO tensor $K$,
-    then zero correlation length gives the transfer-map fusion formulation of
-    idempotence.
+    then the doubled-index transfer condition gives the transfer-map fusion
+    formulation of idempotence.
 \end{lemma}
 
 \begin{proof}\leanok
     This is the implication
     \[
-        \operatorname{ZCL}(K)
+        \E_K\circ\E_K=\E_K
         \Longrightarrow \operatorname{RFP}(K)
         \Longrightarrow \operatorname{RFP}_{\mathrm{fusion}}(K).
     \]
@@ -226,20 +232,21 @@
         lem:eta_local_structure_fusion_isometry_two,
         lem:eta_local_structure_rfp_via_fusion}
     If the $\eta$-local structure has been constructed for an
-    MPO tensor $K$, then zero correlation length gives the GSNNCH-with-ZCL
-    case, the blocked fusion-isometry witness at size $2$, and the
-    transfer-map fusion formulation of idempotence.
+    MPO tensor $K$, then the doubled-index transfer condition gives the
+    GSNNCH branch with doubled-index idempotence, the blocked fusion-isometry
+    witness at size $2$, and the transfer-map fusion formulation of
+    idempotence.
 \end{theorem}
 
 \begin{proof}\leanok
     The $\eta$-local structure supplies the commuting nearest-neighbor product
     form. The remaining two implications are
     \[
-        \operatorname{ZCL}(K) \Longrightarrow
+        \E_K\circ\E_K=\E_K \Longrightarrow
         \operatorname{RFP}(K) \Longrightarrow
         \operatorname{RFP}_{\mathrm{fusion}}(K)
         \quad\text{and}\quad
-        \operatorname{ZCL}(K) \Longrightarrow
+        \E_K\circ\E_K=\E_K \Longrightarrow
         \operatorname{RFP}(K) \Longrightarrow
         \operatorname{FusionWitness}_{2}(K).
     \]
@@ -257,8 +264,9 @@
     $\eta$-local product form, with the conditional rank-one criterion for $T$,
     $\sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}$ with $c_N>0$,
     $B_{n,n+1}\ge 0$, and $[B_{i,i+1},B_{j,j+1}]=0$. Then
-    $K$ is GSNNCH with ZCL, admits a blocked fusion-isometry witness at size
-    $2$, and satisfies the transfer-map fusion formulation of idempotence. The
+    $K$ lies in the GSNNCH branch with doubled-index idempotence, admits a
+    blocked fusion-isometry witness at size $2$, and satisfies the
+    transfer-map fusion formulation of idempotence. The
     PSD-corrected form uses $T\ge0$ together with
     $\operatorname{tr}(T^m)=1$ for all $m>0$ in place of the conditional
     matrix rank-one hypothesis.
@@ -270,7 +278,7 @@
     Theorem~\ref{thm:simple_mpdo_rfp_chain_of_data}.
 \end{proof}
 
-\begin{theorem}[Simple-MPDO RFP chain from commuting form and ZCL]
+\begin{theorem}[Simple-MPDO RFP chain from commuting form and doubled-index idempotence]
     \label{thm:simple_mpdo_rfp_chain}
     \lean{MPOTensor.simple_mpdo_rfp_chain}
     \leanok
@@ -278,22 +286,23 @@
         thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl,
         thm:structural_implies_rfp_blocked, def:mpdo_rfp_via_fusion,
         thm:mpdo_rfp_via_fusion_iff}
-    From the commuting-form property and zero correlation length one
-    simultaneously recovers the GSNNCH-with-ZCL criterion, the
-    blocked fusion-isometry witness at size $2$, and the transfer-map fusion
+    From the commuting-form property and the doubled-index transfer condition
+    one simultaneously recovers the corresponding GSNNCH criterion, the blocked
+    fusion-isometry witness at size $2$, and the transfer-map fusion
     formulation of idempotence.
 \end{theorem}
 
 \begin{proof}\leanok
-    The commuting-form and zero-correlation-length hypotheses give the GSNNCH--ZCL
-    branch via Theorem~\ref{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}.
+    The commuting-form and doubled-index transfer hypotheses give the GSNNCH
+    branch via
+    Theorem~\ref{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}.
     The blocked witness is Theorem~\ref{thm:structural_implies_rfp_blocked}. The
     full transfer-map fusion formulation follows by applying the converse direction
-    of Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to zero correlation length, which
-    is transfer-map idempotence.
+    of Theorem~\ref{thm:mpdo_rfp_via_fusion_iff} to the doubled-index transfer
+    condition, which is transfer-map idempotence.
 \end{proof}
 
-\begin{remark}[SAL--ZCL implication for the GSNNCH--ZCL criterion]
+\begin{remark}[SAL--ZCL implication for the GSNNCH branch]
     \label{rem:simple_mpdo_rfp_chain_gap}
     \notready
     \uses{def:simple_mpdo_local_structure_data,
@@ -303,8 +312,9 @@
     commuting-form property from the local simple-MPDO structure of
     \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv}. Once that derivation
     is available,
-    Theorem~\ref{thm:simple_mpdo_rfp_chain} gives the GSNNCH--ZCL branch and
-    the blocked fusion-isometry witness. This missing derivation is documented
+    Theorem~\ref{thm:simple_mpdo_rfp_chain} gives the GSNNCH branch with the
+    present doubled-index transfer condition and the blocked fusion-isometry
+    witness. This missing derivation is documented
     in \path{docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex}.
     % issue #823
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_commuting_form_gsnnch.tex
@@ -47,27 +47,34 @@
     witness, and every GSNNCH witness remembers its underlying commuting-form data.
 \end{proof}
 
-\begin{definition}[GSNNCH with zero correlation length]
+\begin{definition}[GSNNCH with doubled-index transfer idempotence]
     \label{def:mpdo_is_gsnnch_zcl}
     \lean{MPOTensor.IsGSNNCHWithZCL}
     \leanok
     \uses{def:mpdo_is_gsnnch, def:mpo_is_zcl}
-    This is the conjunction of the GSNNCH condition with MPO zero correlation
-    length, matching item~(iii) of the simple-MPDO equivalence in
-    \cite{Cirac2016MPDO_arXiv}.
+    This is the conjunction of the GSNNCH condition with the doubled-index
+    transfer condition
+    \[
+        \E_M\circ\E_M=\E_M.
+    \]
+    It is the currently formalized analogue of the ZCL clause in item~(iii) of
+    the simple-MPDO equivalence in \cite{Cirac2016MPDO_arXiv}; the
+    source physical-trace condition is Definition~\ref{def:mpo_source_zcl}.
 \end{definition}
 
-\begin{theorem}[GSNNCH--ZCL iff commuting form with ZCL]
+\begin{theorem}[GSNNCH with doubled-index idempotence iff commuting form with it]
     \label{thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
     \lean{MPOTensor.isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL}
     \leanok
     \uses{def:mpdo_is_gsnnch_zcl, thm:mpdo_is_gsnnch_iff_has_commuting_form}
-    The GSNNCH--ZCL branch is equivalent to the conjunction of the
-    commuting-form property with MPO zero correlation length.
+    The GSNNCH branch with doubled-index transfer idempotence is equivalent to
+    the conjunction of the commuting-form property with that same idempotence
+    condition.
 \end{theorem}
 
 \begin{proof}\leanok
-    Unfold the definition of GSNNCH with zero correlation length and apply
+    Unfold the definition of the GSNNCH branch with doubled-index transfer
+    idempotence and apply
     Theorem~\ref{thm:mpdo_is_gsnnch_iff_has_commuting_form}.
 \end{proof}
 
@@ -153,7 +160,7 @@
     Evaluate the local structure at each chain length $N \ge 2$.
 \end{proof}
 
-\begin{theorem}[$\eta$-local structure with ZCL gives GSNNCH--ZCL]
+\begin{theorem}[$\eta$-local structure with doubled-index idempotence]
     \label{thm:mpdo_eta_local_structure_is_gsnnch_zcl}
     \lean{MPOTensor.EtaLocalStructureData.isGSNNCHWithZCL}
     \lean{MPOTensor.isGSNNCHWithZCL_of_etaLocalStructure}
@@ -161,13 +168,13 @@
     \uses{thm:mpdo_eta_local_structure_has_commuting_form,
         thm:mpdo_is_gsnnch_zcl_iff_has_commuting_form_and_is_zcl}
     Once the $\eta$-local structure gives the commuting nearest-neighbor
-    product form, adding zero correlation length gives the GSNNCH--ZCL case
-    of the simple-MPDO equivalence.
+    product form, adding the doubled-index transfer condition gives the
+    corresponding GSNNCH branch.
 \end{theorem}
 
 \begin{proof}\leanok
     Use the commuting-form witness carried by the $\eta$-local structure and
-    combine it with the ZCL hypothesis.
+    combine it with the doubled-index transfer hypothesis.
 \end{proof}
 
 \begin{theorem}[$\eta$-local structure implies commuting form]
@@ -219,6 +226,6 @@
     (\ref{eq:mpdo_eta_bond_assembly}) and~(\ref{eq:mpdo_eta_product_form}) are
     exactly the $\eta$-local product hypothesis; after that,
     Theorem~\ref{thm:mpdo_has_commuting_form_of_eta_local_structure}
-    gives the commuting-form conclusion. Zero correlation length enters only in
-    the subsequent RFP and GSNNCH--ZCL conclusions.
+    gives the commuting-form conclusion. The doubled-index transfer condition
+    enters only in the subsequent RFP and GSNNCH branch conclusions.
 \end{remark}

--- a/blueprint/src/chapter/ch21_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_foundations.tex
@@ -387,7 +387,7 @@ legs cyclically and taking the resulting trace.
     follows from Theorem~\ref{thm:lpdo_is_mpdo}.
 \end{proof}
 
-\begin{theorem}[Local purification RFP does not imply zero correlation length]
+\begin{theorem}[Local purification RFP does not imply doubled-index idempotence]
     \label{thm:local_purification_rfp_not_zcl}
     \lean{MPOTensor.exists_isLocalPurificationRFP_not_isZCL}
     \leanok

--- a/blueprint/src/chapter/ch21_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_foundations.tex
@@ -221,10 +221,9 @@ legs cyclically and taking the resulting trace.
     \[
         \mathcal T_M=\sum_i M^{ii}.
     \]
+    % Gap documented in docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex.
     This is the transfer object appearing in the zero-correlation-length
-    condition of \cite[Definition~4.2, lines~736--741]{Cirac2016MPDO_arXiv};
-    see also the gap record
-    \texttt{docs/paper-gaps/cpsv16\_zcl\_canonical\_form\_normalization.tex}.
+    condition of \cite[Definition~4.2, lines~736--741]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{definition}[Source zero correlation length for MPO tensors]
@@ -232,15 +231,15 @@ legs cyclically and taking the resulting trace.
     \lean{MPOTensor.IsSourceZCL}
     \leanok
     \uses{def:mpo_physical_trace_transfer}
-    An MPO tensor has source zero correlation length when
+    An MPO tensor has source zero correlation length when, for some real number
+    $\lambda>0$,
     \[
         \mathcal T_M\ne 0
         \quad\text{and}\quad
         \mathcal T_M^2=\lambda\,\mathcal T_M
     \]
-    for some real number $\lambda>0$. The nonzero condition excludes the
-    degenerate zero transfer, and the positive scalar makes the condition
-    invariant under rescaling of $M$.
+    hold. The nonzero condition excludes the degenerate zero transfer, and the
+    positive scalar makes the condition invariant under rescaling of $M$.
 \end{definition}
 
 \begin{theorem}[Literal physical-trace idempotence gives source ZCL]
@@ -267,10 +266,9 @@ legs cyclically and taking the resulting trace.
     \[
         \E_M \circ \E_M = \E_M.
     \]
+    % Gap documented in docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex.
     This is the condition obtained from the doubled-index MPS view. It is not
-    the physical-trace condition of Definition~\ref{def:mpo_source_zcl}; the
-    distinction is recorded in
-    \texttt{docs/paper-gaps/cpsv16\_zcl\_canonical\_form\_normalization.tex}.
+    the physical-trace condition of Definition~\ref{def:mpo_source_zcl}.
 \end{definition}
 
 \begin{theorem}[Doubled-index transfer idempotence iff MPS RFP]%

--- a/blueprint/src/chapter/ch21_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_foundations.tex
@@ -211,29 +211,75 @@ legs cyclically and taking the resulting trace.
 
 \section{Zero correlation length}
 
-\begin{definition}[Zero correlation length for MPO tensors]%
+\begin{definition}[Physical-trace transfer]
+    \label{def:mpo_physical_trace_transfer}
+    \lean{MPOTensor.physTraceTransfer}
+    \leanok
+    \uses{def:mpo_tensor}
+    The physical-trace transfer of an MPO tensor $M$ is the virtual matrix
+    obtained by contracting the ket and bra physical legs of one tensor:
+    \[
+        \mathcal T_M=\sum_i M^{ii}.
+    \]
+    This is the transfer object appearing in the zero-correlation-length
+    condition of \cite[Definition~4.2, lines~736--741]{Cirac2016MPDO_arXiv};
+    see also the gap record
+    \texttt{docs/paper-gaps/cpsv16\_zcl\_canonical\_form\_normalization.tex}.
+\end{definition}
+
+\begin{definition}[Source zero correlation length for MPO tensors]
+    \label{def:mpo_source_zcl}
+    \lean{MPOTensor.IsSourceZCL}
+    \leanok
+    \uses{def:mpo_physical_trace_transfer}
+    An MPO tensor has source zero correlation length when
+    \[
+        \mathcal T_M\ne 0
+        \quad\text{and}\quad
+        \mathcal T_M^2=\lambda\,\mathcal T_M
+    \]
+    for some real number $\lambda>0$. The nonzero condition excludes the
+    degenerate zero transfer, and the positive scalar makes the condition
+    invariant under rescaling of $M$.
+\end{definition}
+
+\begin{theorem}[Literal physical-trace idempotence gives source ZCL]
+    \label{thm:mpo_source_zcl_of_physical_trace_idempotent}
+    \lean{MPOTensor.isSourceZCL_of_physTraceTransfer_sq}
+    \leanok
+    \uses{def:mpo_source_zcl, def:mpo_physical_trace_transfer}
+    If $\mathcal T_M\ne0$ and $\mathcal T_M^2=\mathcal T_M$, then $M$ has
+    source zero correlation length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    This is the preceding definition with $\lambda=1$.
+\end{proof}
+
+\begin{definition}[Doubled-index transfer idempotence for MPO tensors]%
     \label{def:mpo_is_zcl}
     \lean{MPOTensor.IsZCL}
     \leanok
     \uses{def:mpo_transfer_map}
-    An MPO tensor $M$ has \emph{zero correlation length} when its transfer map
-    is idempotent:
+    An MPO tensor $M$ satisfies the doubled-index transfer condition when its
+    completely positive transfer map is idempotent:
     \[
         \E_M \circ \E_M = \E_M.
     \]
-    This is the mixed-state analog of the renormalization fixed-point
-    condition for MPS tensors; see \cite[definition of MPDO zero correlation
-        length, lines~736--741]{Cirac2016MPDO_arXiv} and
-    \cite[Section~II.E.2, lines~937--939]{Cirac2021Matrix}.
+    This is the condition obtained from the doubled-index MPS view. It is not
+    the physical-trace condition of Definition~\ref{def:mpo_source_zcl}; the
+    distinction is recorded in
+    \texttt{docs/paper-gaps/cpsv16\_zcl\_canonical\_form\_normalization.tex}.
 \end{definition}
 
-\begin{theorem}[MPO ZCL iff doubled-index MPS RFP]%
+\begin{theorem}[Doubled-index transfer idempotence iff MPS RFP]%
     \label{thm:mpo_is_zcl_iff_to_mps_rfp}
     \lean{MPOTensor.isZCL_iff_toMPSTensor_isRFP}
     \leanok
     \uses{def:mpo_is_zcl, def:mpo_to_mps, def:is_rfp, lem:mpo_transfer_eq_mps}
-    An MPO tensor has zero correlation length if and only if its doubled-index
-    MPS view is a renormalization fixed point.
+    An MPO tensor satisfies the doubled-index transfer condition if and only if
+    its doubled-index MPS view is a renormalization fixed point.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_pure_state_recovery.tex
@@ -53,11 +53,13 @@
     This is \cite[Definition~4.1, line~657]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{theorem}[Transfer-map idempotence iff MPO ZCL]\label{thm:is_rfp_iff_is_zcl}
+\begin{theorem}[Transfer-map idempotence iff doubled-index condition]
+    \label{thm:is_rfp_iff_is_zcl}
     \lean{MPOTensor.isRFP_iff_isZCL}
     \leanok
     \uses{def:is_rfp_mpdo, def:mpo_is_zcl}
-    MPO transfer-map idempotence is exactly zero correlation length.
+    MPO transfer-map idempotence is exactly the doubled-index transfer
+    condition of Definition~\ref{def:mpo_is_zcl}.
 \end{theorem}
 
 \begin{proof}
@@ -79,8 +81,9 @@
 \begin{proof}
     \leanok
     \uses{thm:mpo_is_zcl_iff_to_mps_rfp}
-    Unfold transfer-map idempotence to its definitional equivalent, MPO ZCL,
-    then apply Theorem~\ref{thm:mpo_is_zcl_iff_to_mps_rfp}.
+    Unfold transfer-map idempotence to its definitional equivalent, the
+    doubled-index transfer condition, and apply
+    Theorem~\ref{thm:mpo_is_zcl_iff_to_mps_rfp}.
 \end{proof}
 
 \begin{definition}[Diagonal pure-state embedding as an MPO]\label{def:to_mpo_tensor}


### PR DESCRIPTION
## Summary

Introduces the **infrastructure** for the faithful zero-correlation-length realignment of arXiv:1606.00608, Definition 4.2, per the merged design note `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex` (#2777).

The merged note establishes that the source ZCL diagram closes the ket/bra physical legs of a *single* MPO tensor, giving the **physical-trace transfer** `𝒯_M = ∑ᵢ Mⁱⁱ` — a different transfer object than the doubled-index CP map `transferMap` (`∑ᵢⱼ Mⁱʲ X (Mⁱʲ)ᴴ`) that the current `MPOTensor.IsZCL` uses. This PR adds the source transfer and the source-faithful predicate as **new definitions**, laying the foundation without disturbing the existing predicate or its consumers.

```lean
noncomputable def physTraceTransfer (M : MPOTensor d D) : Matrix (Fin D) (Fin D) ℂ := ∑ i, M i i

def IsSourceZCL (M : MPOTensor d D) : Prop :=
  physTraceTransfer M ≠ 0 ∧ ∃ lam : ℝ, 0 < lam ∧
    physTraceTransfer M * physTraceTransfer M = (lam : ℂ) • physTraceTransfer M

theorem isSourceZCL_of_physTraceTransfer_sq (M) (h0 : physTraceTransfer M ≠ 0)
    (hidem : physTraceTransfer M * physTraceTransfer M = physTraceTransfer M) : IsSourceZCL M
```

`IsSourceZCL` is the note's **Option 1**: `𝒯_M ≠ 0` and `𝒯_M² = λ·𝒯_M` for some `λ > 0` (rescaling-invariant; literal idempotence is the `λ = 1` canonical-form case). It is the first **faithful** formalization of source Definition 4.2 (the existing `IsZCL` records the wrong transfer object, as documented in the note).

## Scope

**Additive only** — the existing `IsZCL`/`transferMap` and all their consumers (the BlockedRFP fusion/algebra chain, etc.) are untouched. No `sorry`, no cascade, no redefinition. This is deliberately the *foundation* step: the multi-stage realignment proper (mark the `ZCL→IsRFP` coercion sites `**Unfaithful:**`, then rework the Theorem 4.9 chain toward `IsRFPViaTS`) follows in separate, coordinated work.

## Verification

- `lake env lean TNLean/MPS/MPDO/ZCL.lean` — exit 0, no `sorry`/`axiom`.
- Diff is additions-only (no whitespace regression).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean definitions and documentation-only blueprint renames; no changes to `IsZCL` or downstream proof chains.
> 
> **Overview**
> Adds **source-faithful** zero correlation length infrastructure in Lean (`physTraceTransfer`, `IsSourceZCL`, and `isSourceZCL_of_physTraceTransfer_sq`) alongside unchanged `IsZCL` / `transferMap` consumers.
> 
> The blueprint is retitled and reworded so **source ZCL** (physical-trace \(\mathcal T_M=\sum_i M^{ii}\), rescaling-invariant \(\mathcal T_M^2=\lambda\mathcal T_M\)) is documented separately from the existing **doubled-index** idempotence \(\mathcal E_M\circ\mathcal E_M=\mathcal E_M\) (`MPOTensor.IsZCL`). Blocked-RFP, GSNNCH, and pure-state recovery chapters now refer to doubled-index transfer idempotence explicitly and point to the new source definitions where the paper’s Definition 4.2 applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee81c827b1ffd503a8cf839b0383602e3df47f01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Closes #2824.

