### PR TITLE
doc(mpdo): mark ZCL-to-RFP coercions unfaithful

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -350,7 +350,7 @@ the two predicates coincide. The source's Theorem 4.9 (`thm:main-simple`,
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in issues #2421 and #2824. -/
+tracked in the paper-gap note above. -/
 theorem isRFP (data : SimpleMPDOBlockedRFPData K) : IsRFP K :=
   data.zcl
 
@@ -363,7 +363,7 @@ structural fixed point `IsRFPViaTS`, through condition (iv), not literal
 doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
 replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-issues #2421 and #2824. -/
+the paper-gap note above. -/
 theorem isRFP_via_fusion (data : SimpleMPDOBlockedRFPData K) : IsRFP_MPDO_via_fusion K :=
   isRFP_MPDO_via_fusion_of_isRFP (M := K) data.isRFP
 
@@ -379,7 +379,7 @@ the two predicates coincide. The source's Theorem 4.9 (`thm:main-simple`,
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in issues #2421 and #2824. -/
+tracked in the paper-gap note above. -/
 theorem structural_implies_rfp_blocked {K : MPOTensor d D}
     (hZCL : IsZCL K) :
     Nonempty (FusionIsometryData K 2) :=
@@ -400,7 +400,7 @@ larger simple-MPDO statement.
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in issues #2421 and #2824. -/
+tracked in the paper-gap note above. -/
 theorem structural_implies_rfp_blocked_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     Nonempty (FusionIsometryData K 2) :=
@@ -422,7 +422,7 @@ followed by the ZCL/RFP implication in Theorem 4.9.
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in issues #2421 and #2824. -/
+tracked in the paper-gap note above. -/
 theorem fusion_isometry_data_two (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     Nonempty (FusionIsometryData K 2) :=
   structural_implies_rfp_blocked (K := K) hZCL
@@ -440,7 +440,7 @@ Theorem 4.9 (`thm:main-simple`,
 condition (iv), not literal doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
 replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-issues #2421 and #2824. -/
+the paper-gap note above. -/
 theorem isRFP_via_fusion (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsRFP_MPDO_via_fusion K :=
   isRFP_MPDO_via_fusion_of_isRFP (M := K) (show IsRFP K from hZCL)
@@ -458,7 +458,7 @@ idempotence from `IsZCL K` by definitional coercion. The source's Theorem 4.9
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in issues #2421 and #2824. -/
+tracked in the paper-gap note above. -/
 theorem simple_mpdo_rfp_chain (data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
       IsRFP_MPDO_via_fusion K :=
@@ -486,7 +486,7 @@ idempotence from `IsZCL K` by definitional coercion. The source's Theorem 4.9
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in issues #2421 and #2824. -/
+tracked in the paper-gap note above. -/
 theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -504,7 +504,7 @@ in the transfer-map fusion component. The source's Theorem 4.9
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
 Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in issues #2421 and #2824. -/
+tracked in the paper-gap note above. -/
 theorem simple_mpdo_rfp_chain {K : MPOTensor d D}
     (hCommuting : HasCommutingForm K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -528,7 +528,7 @@ The source's Theorem 4.9 (`thm:main-simple`,
 condition (iv), not literal doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
 replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-issues #2421 and #2824. -/
+the paper-gap note above. -/
 theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
     (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -556,12 +556,12 @@ conditional `hPF` shortcut absent from arXiv:1606.00608, Lemma C.5,
 lines 1484--1502. Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
 Elimination: use the PSD-corrected theorem
 `simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef`; tracked
-in issue #1041. The proof also calls `simple_mpdo_rfp_chain_of_data`, which
+in the paper-gap note above. The proof also calls `simple_mpdo_rfp_chain_of_data`, which
 obtains doubled-index idempotence from `IsZCL K` by definitional coercion;
 this second deviation is documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
 replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-issues #2421 and #2824. -/
+the paper-gap note above. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure {K : MPOTensor d D}
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -602,7 +602,7 @@ Theorem 4.9 (`thm:main-simple`,
 condition (iv), not literal doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
 replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-issues #2421 and #2824. -/
+the paper-gap note above. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef
     {K : MPOTensor d D} {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -349,8 +349,8 @@ the two predicates coincide. The source's Theorem 4.9 (`thm:main-simple`,
 `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches the structural fixed point
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
-Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in the paper-gap note above. -/
+Elimination: replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem isRFP (data : SimpleMPDOBlockedRFPData K) : IsRFP K :=
   data.zcl
 
@@ -362,8 +362,8 @@ theorem isRFP (data : SimpleMPDOBlockedRFPData K) : IsRFP K :=
 structural fixed point `IsRFPViaTS`, through condition (iv), not literal
 doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
-replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-the paper-gap note above. -/
+replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem isRFP_via_fusion (data : SimpleMPDOBlockedRFPData K) : IsRFP_MPDO_via_fusion K :=
   isRFP_MPDO_via_fusion_of_isRFP (M := K) data.isRFP
 
@@ -378,8 +378,8 @@ the two predicates coincide. The source's Theorem 4.9 (`thm:main-simple`,
 `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches the structural fixed point
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
-Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in the paper-gap note above. -/
+Elimination: replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem structural_implies_rfp_blocked {K : MPOTensor d D}
     (hZCL : IsZCL K) :
     Nonempty (FusionIsometryData K 2) :=
@@ -399,8 +399,8 @@ larger simple-MPDO statement.
 (`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
-Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in the paper-gap note above. -/
+Elimination: replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem structural_implies_rfp_blocked_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     Nonempty (FusionIsometryData K 2) :=
@@ -421,8 +421,8 @@ followed by the ZCL/RFP implication in Theorem 4.9.
 (`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
-Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in the paper-gap note above. -/
+Elimination: replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem fusion_isometry_data_two (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     Nonempty (FusionIsometryData K 2) :=
   structural_implies_rfp_blocked (K := K) hZCL
@@ -439,8 +439,8 @@ Theorem 4.9 (`thm:main-simple`,
 `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches `IsRFPViaTS`, through
 condition (iv), not literal doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
-replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-the paper-gap note above. -/
+replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem isRFP_via_fusion (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsRFP_MPDO_via_fusion K :=
   isRFP_MPDO_via_fusion_of_isRFP (M := K) (show IsRFP K from hZCL)
@@ -457,8 +457,8 @@ idempotence from `IsZCL K` by definitional coercion. The source's Theorem 4.9
 (`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
-Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in the paper-gap note above. -/
+Elimination: replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem simple_mpdo_rfp_chain (data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
       IsRFP_MPDO_via_fusion K :=
@@ -485,8 +485,8 @@ idempotence from `IsZCL K` by definitional coercion. The source's Theorem 4.9
 (`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
-Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in the paper-gap note above. -/
+Elimination: replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -503,8 +503,8 @@ in the transfer-map fusion component. The source's Theorem 4.9
 (`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
-Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
-tracked in the paper-gap note above. -/
+Elimination: replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem simple_mpdo_rfp_chain {K : MPOTensor d D}
     (hCommuting : HasCommutingForm K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -527,8 +527,8 @@ The source's Theorem 4.9 (`thm:main-simple`,
 `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches `IsRFPViaTS`, through
 condition (iv), not literal doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
-replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-the paper-gap note above. -/
+replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
     (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -555,13 +555,15 @@ constructions are tracked by issue #823.
 conditional `hPF` shortcut absent from arXiv:1606.00608, Lemma C.5,
 lines 1484--1502. Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
 Elimination: use the PSD-corrected theorem
-`simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef`; tracked
-in the paper-gap note above. The proof also calls `simple_mpdo_rfp_chain_of_data`, which
+`simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef`;
+this rank-one deviation is documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. The proof also calls
+`simple_mpdo_rfp_chain_of_data`, which
 obtains doubled-index idempotence from `IsZCL K` by definitional coercion;
 this second deviation is documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
-replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-the paper-gap note above. -/
+replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure {K : MPOTensor d D}
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -601,8 +603,8 @@ Theorem 4.9 (`thm:main-simple`,
 `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches `IsRFPViaTS`, through
 condition (iv), not literal doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
-replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
-the paper-gap note above. -/
+replace this step by the source's route from ZCL and SAL through
+condition (iv) to `IsRFPViaTS`, as described in the cited paper-gap note. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef
     {K : MPOTensor d D} {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -341,18 +341,45 @@ Theorem 4.9. -/
 theorem isGSNNCHWithZCL (data : SimpleMPDOBlockedRFPData K) : IsGSNNCHWithZCL K :=
   (isGSNNCHWithZCL_iff_hasCommutingForm_and_isZCL K).2 ⟨data.commutingForm, data.zcl⟩
 
-/-- The structure implies the current MPDO RFP predicate. -/
+/-- The structure implies the current MPDO RFP predicate.
+
+**Unfaithful:** This proof currently derives `IsRFP K` from `IsZCL K` by
+definitional coercion (`isRFP_iff_isZCL` is `Iff.rfl`). This is valid only while
+the two predicates coincide. The source's Theorem 4.9 (`thm:main-simple`,
+`Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches the structural fixed point
+`IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
+Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
+tracked in issues #2421 and #2824. -/
 theorem isRFP (data : SimpleMPDOBlockedRFPData K) : IsRFP K :=
   data.zcl
 
-/-- The structure implies the transfer-map fusion formulation of MPDO RFP. -/
+/-- The structure implies the transfer-map fusion formulation of MPDO RFP.
+
+**Unfaithful:** This proof calls `SimpleMPDOBlockedRFPData.isRFP`, which derives
+`IsRFP K` from `IsZCL K` by definitional coercion. The source's Theorem 4.9
+(`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches the
+structural fixed point `IsRFPViaTS`, through condition (iv), not literal
+doubled-index idempotence. Documented in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
+replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
+issues #2421 and #2824. -/
 theorem isRFP_via_fusion (data : SimpleMPDOBlockedRFPData K) : IsRFP_MPDO_via_fusion K :=
   isRFP_MPDO_via_fusion_of_isRFP (M := K) data.isRFP
 
 end SimpleMPDOBlockedRFPData
 
 /-- Under the current convention `IsRFP = IsZCL`, zero correlation length yields
-a blocked fusion-isometry witness at size `2`. -/
+a blocked fusion-isometry witness at size `2`.
+
+**Unfaithful:** This proof currently derives `IsRFP K` from `IsZCL K` by
+definitional coercion (`isRFP_iff_isZCL` is `Iff.rfl`). This is valid only while
+the two predicates coincide. The source's Theorem 4.9 (`thm:main-simple`,
+`Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches the structural fixed point
+`IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
+Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
+tracked in issues #2421 and #2824. -/
 theorem structural_implies_rfp_blocked {K : MPOTensor d D}
     (hZCL : IsZCL K) :
     Nonempty (FusionIsometryData K 2) :=
@@ -365,7 +392,15 @@ theorem structural_implies_rfp_blocked {K : MPOTensor d D}
 Relative to the current convention `IsRFP = IsZCL`, the present conclusion uses
 only `data.zcl`. The components `localData` and `commutingForm` record the local
 Appendix C structure and the global commuting-form conclusion used in the
-larger simple-MPDO statement. -/
+larger simple-MPDO statement.
+
+**Unfaithful:** This proof calls `structural_implies_rfp_blocked`, which derives
+`IsRFP K` from `IsZCL K` by definitional coercion. The source's Theorem 4.9
+(`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
+`IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
+Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
+tracked in issues #2421 and #2824. -/
 theorem structural_implies_rfp_blocked_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     Nonempty (FusionIsometryData K 2) :=
@@ -379,7 +414,15 @@ variable {K : MPOTensor d D}
 fusion-isometry witness at size `2`.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593,
-followed by the ZCL/RFP implication in Theorem 4.9. -/
+followed by the ZCL/RFP implication in Theorem 4.9.
+
+**Unfaithful:** This proof calls `structural_implies_rfp_blocked`, which derives
+`IsRFP K` from `IsZCL K` by definitional coercion. The source's Theorem 4.9
+(`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
+`IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
+Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
+tracked in issues #2421 and #2824. -/
 theorem fusion_isometry_data_two (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     Nonempty (FusionIsometryData K 2) :=
   structural_implies_rfp_blocked (K := K) hZCL
@@ -388,7 +431,16 @@ theorem fusion_isometry_data_two (_data : EtaLocalStructureData K) (hZCL : IsZCL
 fusion formulation of MPDO RFP.
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593,
-followed by the ZCL/RFP implication in Theorem 4.9. -/
+followed by the ZCL/RFP implication in Theorem 4.9.
+
+**Unfaithful:** This proof currently derives `IsRFP K` from `IsZCL K` by
+definitional coercion (`isRFP_iff_isZCL` is `Iff.rfl`). The source's
+Theorem 4.9 (`thm:main-simple`,
+`Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches `IsRFPViaTS`, through
+condition (iv), not literal doubled-index idempotence. Documented in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
+replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
+issues #2421 and #2824. -/
 theorem isRFP_via_fusion (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsRFP_MPDO_via_fusion K :=
   isRFP_MPDO_via_fusion_of_isRFP (M := K) (show IsRFP K from hZCL)
@@ -397,7 +449,16 @@ theorem isRFP_via_fusion (_data : EtaLocalStructureData K) (hZCL : IsZCL K) :
 
 Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 the η-local nearest-neighbor product gives the commuting-form side; adding ZCL
-gives the GSNNCH--ZCL and RFP consequences of Theorem 4.9. -/
+gives the GSNNCH--ZCL and RFP consequences of Theorem 4.9.
+
+**Unfaithful:** This proof calls `EtaLocalStructureData.fusion_isometry_data_two`
+and `EtaLocalStructureData.isRFP_via_fusion`, which obtain doubled-index
+idempotence from `IsZCL K` by definitional coercion. The source's Theorem 4.9
+(`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
+`IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
+Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
+tracked in issues #2421 and #2824. -/
 theorem simple_mpdo_rfp_chain (data : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
       IsRFP_MPDO_via_fusion K :=
@@ -416,7 +477,16 @@ From the explicit simple-MPDO hypotheses one simultaneously recovers:
 
 Relative to the current formalization, this is the construction layer after the
 local simple-MPDO structure, commuting form, and zero-correlation-length
-hypotheses have been supplied explicitly. -/
+hypotheses have been supplied explicitly.
+
+**Unfaithful:** This proof calls `structural_implies_rfp_blocked_of_data` and
+`SimpleMPDOBlockedRFPData.isRFP_via_fusion`, which obtain doubled-index
+idempotence from `IsZCL K` by definitional coercion. The source's Theorem 4.9
+(`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
+`IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
+Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
+tracked in issues #2421 and #2824. -/
 theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
     (data : SimpleMPDOBlockedRFPData K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -425,7 +495,16 @@ theorem simple_mpdo_rfp_chain_of_data {K : MPOTensor d D}
     data.isRFP_via_fusion⟩
 
 /-- Direct-argument form of Theorem 4.9 using only the hypotheses that enter the
-current theorem. -/
+current theorem.
+
+**Unfaithful:** This proof obtains doubled-index idempotence from `IsZCL K` by
+definitional coercion, both through `structural_implies_rfp_blocked` and directly
+in the transfer-map fusion component. The source's Theorem 4.9
+(`thm:main-simple`, `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches
+`IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
+Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
+Elimination: replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path;
+tracked in issues #2421 and #2824. -/
 theorem simple_mpdo_rfp_chain {K : MPOTensor d D}
     (hCommuting : HasCommutingForm K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -440,7 +519,16 @@ structure has been constructed.
 Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593:
 the neighboring `η_{k,h}` operators assemble into commuting two-site bonds
 whose product realizes the MPDO. The eta-local structure is precisely this
-assembled positive commuting-bond form. -/
+assembled positive commuting-bond form.
+
+**Unfaithful:** This proof calls `EtaLocalStructureData.simple_mpdo_rfp_chain`,
+which obtains doubled-index idempotence from `IsZCL K` by definitional coercion.
+The source's Theorem 4.9 (`thm:main-simple`,
+`Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches `IsRFPViaTS`, through
+condition (iv), not literal doubled-index idempotence. Documented in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
+replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
+issues #2421 and #2824. -/
 theorem simple_mpdo_rfp_chain_of_etaLocalStructure {K : MPOTensor d D}
     (hEta : EtaLocalStructureData K) (hZCL : IsZCL K) :
     IsGSNNCHWithZCL K ∧ Nonempty (FusionIsometryData K 2) ∧
@@ -468,7 +556,12 @@ conditional `hPF` shortcut absent from arXiv:1606.00608, Lemma C.5,
 lines 1484--1502. Documented in `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
 Elimination: use the PSD-corrected theorem
 `simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef`; tracked
-in issue #1041. -/
+in issue #1041. The proof also calls `simple_mpdo_rfp_chain_of_data`, which
+obtains doubled-index idempotence from `IsZCL K` by definitional coercion;
+this second deviation is documented in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
+replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
+issues #2421 and #2824. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure {K : MPOTensor d D}
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -500,7 +593,16 @@ construction is tracked by issue #823.
 
 **Local fix (PSD rank-one criterion):** it uses the positive-semidefinite
 replacement for the matrix step in Lemma C.5, documented in
-`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
+
+**Unfaithful:** This proof calls `simple_mpdo_rfp_chain_of_data`, which obtains
+doubled-index idempotence from `IsZCL K` by definitional coercion. The source's
+Theorem 4.9 (`thm:main-simple`,
+`Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches `IsRFPViaTS`, through
+condition (iv), not literal doubled-index idempotence. Documented in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:
+replace by the ZCL + SAL to condition (iv) to `IsRFPViaTS` path; tracked in
+issues #2421 and #2824. -/
 theorem simple_mpdo_rfp_chain_of_sal_zcl_and_etaLocalStructure_of_posSemidef
     {K : MPOTensor d D} {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -344,8 +344,8 @@ theorem isGSNNCHWithZCL (data : SimpleMPDOBlockedRFPData K) : IsGSNNCHWithZCL K 
 /-- The structure implies the current MPDO RFP predicate.
 
 **Unfaithful:** This proof currently derives `IsRFP K` from `IsZCL K` by
-definitional coercion (`isRFP_iff_isZCL` is `Iff.rfl`). This is valid only while
-the two predicates coincide. The source's Theorem 4.9 (`thm:main-simple`,
+definitional coercion. This is valid only while the two predicates coincide.
+The source's Theorem 4.9 (`thm:main-simple`,
 `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches the structural fixed point
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
@@ -373,8 +373,8 @@ end SimpleMPDOBlockedRFPData
 a blocked fusion-isometry witness at size `2`.
 
 **Unfaithful:** This proof currently derives `IsRFP K` from `IsZCL K` by
-definitional coercion (`isRFP_iff_isZCL` is `Iff.rfl`). This is valid only while
-the two predicates coincide. The source's Theorem 4.9 (`thm:main-simple`,
+definitional coercion. This is valid only while the two predicates coincide.
+The source's Theorem 4.9 (`thm:main-simple`,
 `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches the structural fixed point
 `IsRFPViaTS`, through condition (iv), not literal doubled-index idempotence.
 Documented in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
@@ -434,8 +434,7 @@ Source: arXiv:1606.00608, Appendix C.2, Proposition 3to4, lines 1571--1593,
 followed by the ZCL/RFP implication in Theorem 4.9.
 
 **Unfaithful:** This proof currently derives `IsRFP K` from `IsZCL K` by
-definitional coercion (`isRFP_iff_isZCL` is `Iff.rfl`). The source's
-Theorem 4.9 (`thm:main-simple`,
+definitional coercion. The source's Theorem 4.9 (`thm:main-simple`,
 `Papers/1606.00608/MPDO-22-12-17-2.tex:851`) reaches `IsRFPViaTS`, through
 condition (iv), not literal doubled-index idempotence. Documented in
 `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. Elimination:


### PR DESCRIPTION
## Summary
- Adds `**Unfaithful:**` markers to the MPDO Theorem 4.9 consequences whose proofs obtain `IsRFP K` from `IsZCL K` by definitional coercion.
- Records propagation through the blocked fusion-isometry and RFP-chain consequences, citing `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`.
- Leaves the mathematical statements unchanged; the source-faithful replacement remains tracked in #2421 and #2824.

Closes #2823

## Checks
- `lake build TNLean.MPS.MPDO.BlockedRFPConstruction`
- `lake env lean TNLean/MPS/MPDO/BlockedRFPConstruction.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes in one Lean file; no logic or API changes.
> 
> **Overview**
> Adds **`**Unfaithful:**`** docstring blocks across `BlockedRFPConstruction.lean` for theorems whose proofs still treat **`IsZCL K`** as **`IsRFP K`** under the current definitional identification, instead of the paper’s Theorem 4.9 route to **`IsRFPViaTS`** via condition (iv).
> 
> Coverage includes core steps (`isRFP`, `isRFP_via_fusion`, `structural_implies_rfp_blocked`) and propagated RFP-chain consequences (`EtaLocalStructureData.*`, `simple_mpdo_rfp_chain*`). Existing **`hPF`** unfaithfulness notes are extended where relevant (e.g. SAL+η-local chain) to also call out the ZCL coercion path, with pointers to `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`. **No Lean proofs or theorem statements change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ef1fe873049c75278460c169fe668624ffc890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->