### PR TITLE
style: remove the last trailing-whitespace nolint exemption (Commuting.lean)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/

--- a/scripts/nolints-style.txt
+++ b/scripts/nolints-style.txt
@@ -5,4 +5,3 @@
 -- touching mathematical Lean files in the lint-infrastructure PR; remove them
 -- in a follow-up cleanup PR after the corresponding source lines are fixed.
 
-TNLean/MPS/ParentHamiltonian/Commuting.lean : line 1 : ERR_TWS : This line ends with some whitespace: please remove this


### PR DESCRIPTION
## Summary

Completes the `scripts/nolints-style.txt` lint-debt cleanup. Strips the line-1 trailing space (`/- ` → `/-`) in `TNLean/MPS/ParentHamiltonian/Commuting.lean` and drops the final `ERR_TWS` exemption.

After #2818 (4 `ERR_TWS`) and #2821 (3 `ERR_UNICODE`), this was the last remaining exemption — I held it back while the ParentHamiltonian area was actively refactoring. That has settled (the marker-migration worktree is gone, no open PR touches `Commuting.lean`, it last changed 2 days ago), so it's now safe to clear.

**The exemption list is now empty** — the header comment is kept as a template for future entries. Whitespace-only; no Lean declaration or build change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace and lint-config only; no behavioral or mathematical Lean changes.
> 
> **Overview**
> Removes a trailing space on the opening `/-` line in `Commuting.lean` so the file passes the whitespace style linter, and deletes the corresponding `ERR_TWS` entry from `scripts/nolints-style.txt`.
> 
> **The manual style exemption list is now empty**; the nolints file header remains as a template for future exceptions. No Lean definitions, imports, or proof content change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a04701c0cad17d5dc7073632acb2ce8d67df1105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->