### PR TITLE
doc(blueprint): sync torus PEPS window geometry entries

### DIFF
--- a/TNLean/PEPS/TorusWindowChain4.lean
+++ b/TNLean/PEPS/TorusWindowChain4.lean
@@ -4,52 +4,60 @@ import TNLean.PEPS.TorusWindowChain3
 # Transitivity of the corner extension across nested regions
 
 The two-dimensional strengthening of the normal PEPS Fundamental Theorem
-(arXiv:1804.04964, the corollary at lines 2297--2318 of
-`Papers/1804.04964/paper_normal.tex`) chains consecutive-window comparisons across the
-staircase patch by extending each window's deformed-state insert through a tower of nested
-regions.  The open-boundary chaining of its Step 3 needs the *transitivity* of the corner
-extension: extending an insert over `R ⊆ S` and then over `S ⊆ P` agrees with extending it
-directly over `R ⊆ P`.  This file proves that transitivity for the corner extension
-`extendInsert` of `TNLean/PEPS/TorusWindowChain2.lean`.
+(arXiv:1804.04964, the corollary at lines 2297--2318) chains
+consecutive-window comparisons across the staircase patch.  The open-boundary
+chaining needs the transitivity of corner extension: for nested regions
+`R ⊆ S ⊆ P`,
 
-## The composition reduces to a blue-coupling law
+```
+Ext_{S⊆P}(Ext_{R⊆S}(C)) = Ext_{R⊆P}(C).
+```
 
-Stripping the interior-bond multiplicity divisors of the clean corner extension (using the
-linearity `bareExtendInsert_const_smul` and `extendInsert_const_smul` of
-`TNLean/PEPS/TorusWindowChain3.lean`), the transitivity reduces to a *bare* composition law
-`bareExtendInsert_trans`: composing the bare corner extensions over `R ⊆ S` and `S ⊆ P` is the
-`univ \ S` interior-bond multiple of the bare corner extension over `R ⊆ P`.  The bare
-extension contracts the insert against the blue-coupling coefficient `threeBlockBlueCoeff` of
-the nested three-block geometry, so the bare composition law is in turn the *blue-coupling
-composition law* `threeBlockBlueCoeff_comp`: the composition over the shared `univ \ S` rows of
-the blue couplings of `nested(R⊆S)` and `nested(S⊆P)` equals the `univ \ S` interior-bond
-multiple of the single blue coupling of `nested(R⊆P)`.
+Here `Ext` denotes the normalized corner extension of a region insert.  The
+unnormalized extension `Extbar` satisfies the stronger bookkeeping identity
 
-## The blue-coupling composition is a merge collapse
+```
+Extbar_{S⊆P}(Extbar_{R⊆S}(C))
+  = IB(V \ S) • Extbar_{R⊆P}(C),
+```
 
-The blue coupling `threeBlockBlueCoeff` is a sum over the global virtual configurations with a
-prescribed host label and complement boundary label, of the blue vertex product.  Composing the
-two nested couplings and summing over the shared `univ \ S` boundary configuration pairs two
-configurations agreeing on the `univ \ S` boundary, one carrying the `S \ R` product with the
-`univ \ R` host label, the other the `P \ S` product with the `univ \ P` host label.  This is a
-two-sub-block merge collapse over the region `univ \ S`: reading both products and both host
-labels through the merge `regionMerge A (univ \ S)`, the pair count over each merge fiber is the
-`univ \ S` interior-bond product (`regionFiber_card`), collapsing the double sum to the single
-sum over the merge.  The two host labels transfer to the merge through the boundary-edge
-embeddings `regionBoundaryLabel_regionMerge_compl_of_subset` (the `univ \ R` host, whose
-`R`-side endpoint lies outside `univ \ S`) and `regionBoundaryLabel_regionMerge_of_subset_left`
-(the `univ \ P` host, contained in `univ \ S`), and the products over `S \ R` and `P \ S`
-through `regionProd_p2_eq_merge_of_compl` and `regionProd_p1_eq_merge_of_subset`; the
-`P \ R = (S \ R) ⊔ (P \ S)` product split recombines the two merge products into the single
-blue coupling of `nested(R⊆P)`.
+where `IB(T)` is the product of the interior bond dimensions over the region
+`T`.  The normalized identity follows by cancelling this common multiplicity.
+
+## Blue-coupling composition
+
+Let `Φ_{R,S}` denote the blue coefficient for the nested three-block geometry
+`R ⊆ S`, with blue block `S \ R` and exterior `V \ S`.  The bare composition is
+equivalent to
+
+```
+Σ ν, Φ_{R,S}(β_R, σ_{S\R}, ν) Φ_{S,P}(ν, σ_{P\S}, β_P)
+  = IB(V \ S) • Φ_{R,P}(β_R, σ_{P\R}, β_P).
+```
+
+This is the coefficient identity used when two consecutive corner extensions
+are replaced by the direct extension over `R ⊆ P`.
+
+## Merge collapse
+
+The preceding blue-coupling law is proved by a two-sub-block merge collapse.
+Pairs of virtual configurations that agree on the boundary of `V \ S` are
+merged over `V \ S`.  Each merged configuration has exactly `IB(V \ S)`
+preimages, and the products over the two blue blocks recombine because
+
+```
+P \ R = (S \ R) ⊔ (P \ S).
+```
+
+Thus the boundary-agreeing double sum collapses to `IB(V \ S)` times the
+single sum over the merged configuration, which is the blue coefficient for
+`R ⊆ P`.
 
 ## References
 
 * [Molnár, Garre-Rubio, Pérez-García, Schuch, Cirac, *Normal projected entangled
   pair states generating the same state*, arXiv:1804.04964, the corollary and proof
-  sketch at lines 2296--2445 of
-  `Papers/1804.04964/paper_normal.tex`](https://arxiv.org/abs/1804.04964); the
-  filled-in derivation in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
+  sketch at lines 2296--2445](https://arxiv.org/abs/1804.04964).
 -/
 
 open scoped BigOperators Matrix

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -303,28 +303,32 @@ site-independent tensor and produces the global phase of
     \leanok
     \uses{def:peps_torus_geometry_translation}
     Fix a horizontal reference edge and write the staircase corner as
-    $s=(a,b)$.  The two end windows of the overlapping-window chain are
+    $s=(a,b)$.  For coordinate intervals write
     \[
-        W_{\mathrm{left}}=\left\lbrack a,a+L\right)\times\left\lbrack b,b+K\right),
+        I(u,v)=\{t\mid u\le t<v\}.
+    \]
+    The two end windows of the overlapping-window chain are
+    \[
+        W_{\mathrm{left}}=I(a,a+L)\times I(b,b+K),
         \qquad
         W_{\mathrm{right}}
-        =\left\lbrack a+L,a+2L\right)\times\left\lbrack b+K-1,b+2K-1\right).
+        =I(a+L,a+2L)\times I(b+K-1,b+2K-1).
     \]
     Their end pair is $S=W_{\mathrm{left}}\cup W_{\mathrm{right}}$.  The
     staircase patch is the union
     \[
         P=
-        \bigl(\left\lbrack a,a+2L\right)\times\left\lbrack b+K-1,b+2K-1\right)\bigr)
+        \bigl(I(a,a+2L)\times I(b+K-1,b+2K-1)\bigr)
         \cup
-        \bigl(\left\lbrack a,a+L\right)\times\left\lbrack b,b+2K-1\right)\bigr),
+        \bigl(I(a,a+L)\times I(b,b+2K-1)\bigr),
     \]
     and the corner cut out by the two end windows is
     \[
-        C=\left\lbrack a,a+L\right)\times\left\lbrack b+K,b+2K-1\right).
+        C=I(a,a+L)\times I(b+K,b+2K-1).
     \]
     Completing $C$ by one row gives the $L\times K$ rectangle
     \[
-        \widehat C=\left\lbrack a,a+L\right)\times\left\lbrack b+K,b+2K\right).
+        \widehat C=I(a,a+L)\times I(b+K,b+2K).
     \]
     These cyclic rectangles are the regions used in the staircase chaining and
     corner-stripping step of
@@ -344,8 +348,8 @@ site-independent tensor and produces the global phase of
 \end{lemma}
 \begin{proof}
     \leanok
-    Their horizontal coordinate intervals are $\left\lbrack a,a+L\right)$ and
-    $\left\lbrack a+L,a+2L\right)$.  The bound $2L\le W$ prevents wraparound overlap.
+    Their horizontal coordinate intervals are $I(a,a+L)$ and $I(a+L,a+2L)$.
+    The bound $2L\le W$ prevents wraparound overlap.
 \end{proof}
 
 \begin{lemma}[Injectivity of the staircase end windows and completed corner]

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -305,25 +305,26 @@ site-independent tensor and produces the global phase of
     Fix a horizontal reference edge and write the staircase corner as
     $s=(a,b)$.  The two end windows of the overlapping-window chain are
     \[
-        W_{\mathrm{left}}=[a,a+L)\times[b,b+K),
+        W_{\mathrm{left}}=\left[a,a+L\right)\times\left[b,b+K\right),
         \qquad
-        W_{\mathrm{right}}=[a+L,a+2L)\times[b+K-1,b+2K-1).
+        W_{\mathrm{right}}
+        =\left[a+L,a+2L\right)\times\left[b+K-1,b+2K-1\right).
     \]
     Their end pair is $S=W_{\mathrm{left}}\cup W_{\mathrm{right}}$.  The
     staircase patch is the union
     \[
         P=
-        \bigl([a,a+2L)\times[b+K-1,b+2K-1)\bigr)
+        \bigl(\left[a,a+2L\right)\times\left[b+K-1,b+2K-1\right)\bigr)
         \cup
-        \bigl([a,a+L)\times[b,b+2K-1)\bigr),
+        \bigl(\left[a,a+L\right)\times\left[b,b+2K-1\right)\bigr),
     \]
     and the corner cut out by the two end windows is
     \[
-        C=[a,a+L)\times[b+K,b+2K-1).
+        C=\left[a,a+L\right)\times\left[b+K,b+2K-1\right).
     \]
     Completing $C$ by one row gives the $L\times K$ rectangle
     \[
-        \widehat C=[a,a+L)\times[b+K,b+2K).
+        \widehat C=\left[a,a+L\right)\times\left[b+K,b+2K\right).
     \]
     These cyclic rectangles are the regions used in the staircase chaining and
     corner-stripping step of
@@ -343,8 +344,8 @@ site-independent tensor and produces the global phase of
 \end{lemma}
 \begin{proof}
     \leanok
-    Their horizontal coordinate intervals are $[a,a+L)$ and $[a+L,a+2L)$.
-    The bound $2L\le W$ prevents wraparound overlap.
+    Their horizontal coordinate intervals are $\left[a,a+L\right)$ and
+    $\left[a+L,a+2L\right)$.  The bound $2L\le W$ prevents wraparound overlap.
 \end{proof}
 
 \begin{lemma}[Injectivity of the staircase end windows and completed corner]

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -305,26 +305,26 @@ site-independent tensor and produces the global phase of
     Fix a horizontal reference edge and write the staircase corner as
     $s=(a,b)$.  The two end windows of the overlapping-window chain are
     \[
-        W_{\mathrm{left}}=\left[a,a+L\right)\times\left[b,b+K\right),
+        W_{\mathrm{left}}=\left\lbrack a,a+L\right)\times\left\lbrack b,b+K\right),
         \qquad
         W_{\mathrm{right}}
-        =\left[a+L,a+2L\right)\times\left[b+K-1,b+2K-1\right).
+        =\left\lbrack a+L,a+2L\right)\times\left\lbrack b+K-1,b+2K-1\right).
     \]
     Their end pair is $S=W_{\mathrm{left}}\cup W_{\mathrm{right}}$.  The
     staircase patch is the union
     \[
         P=
-        \bigl(\left[a,a+2L\right)\times\left[b+K-1,b+2K-1\right)\bigr)
+        \bigl(\left\lbrack a,a+2L\right)\times\left\lbrack b+K-1,b+2K-1\right)\bigr)
         \cup
-        \bigl(\left[a,a+L\right)\times\left[b,b+2K-1\right)\bigr),
+        \bigl(\left\lbrack a,a+L\right)\times\left\lbrack b,b+2K-1\right)\bigr),
     \]
     and the corner cut out by the two end windows is
     \[
-        C=\left[a,a+L\right)\times\left[b+K,b+2K-1\right).
+        C=\left\lbrack a,a+L\right)\times\left\lbrack b+K,b+2K-1\right).
     \]
     Completing $C$ by one row gives the $L\times K$ rectangle
     \[
-        \widehat C=\left[a,a+L\right)\times\left[b+K,b+2K\right).
+        \widehat C=\left\lbrack a,a+L\right)\times\left\lbrack b+K,b+2K\right).
     \]
     These cyclic rectangles are the regions used in the staircase chaining and
     corner-stripping step of
@@ -344,8 +344,8 @@ site-independent tensor and produces the global phase of
 \end{lemma}
 \begin{proof}
     \leanok
-    Their horizontal coordinate intervals are $\left[a,a+L\right)$ and
-    $\left[a+L,a+2L\right)$.  The bound $2L\le W$ prevents wraparound overlap.
+    Their horizontal coordinate intervals are $\left\lbrack a,a+L\right)$ and
+    $\left\lbrack a+L,a+2L\right)$.  The bound $2L\le W$ prevents wraparound overlap.
 \end{proof}
 
 \begin{lemma}[Injectivity of the staircase end windows and completed corner]

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -730,8 +730,27 @@ site-independent tensor and produces the global phase of
     \leanok
     Theorem~\ref{thm:peps_corner_extension_state_preserves} rewrites each
     single-window deformed state as the deformed state on $U$ with the
-    corresponding extended insert.  The union comparison then strips the
-    equal states to equality of the two inserts on $U$.
+    corresponding extended insert:
+    \[
+        \Psi_{A,U,\operatorname{Ext}_{W_1\subseteq U}(C_1)}
+        =
+        \Psi_{A,W_1,C_1}
+        =
+        \Psi_{A,W_2,C_2}
+        =
+        \Psi_{A,U,\operatorname{Ext}_{W_2\subseteq U}(C_2)}.
+    \]
+    Since $U$ is injective, equality of the two $U$-states implies equality
+    of the two inserts:
+    \[
+        \Psi_{A,U,\operatorname{Ext}_{W_1\subseteq U}(C_1)}
+        =
+        \Psi_{A,U,\operatorname{Ext}_{W_2\subseteq U}(C_2)}
+        \quad\Longrightarrow\quad
+        \operatorname{Ext}_{W_1\subseteq U}(C_1)
+        =
+        \operatorname{Ext}_{W_2\subseteq U}(C_2).
+    \]
 \end{proof}
 
 \begin{theorem}[Patch-extended equality of the staircase end windows]
@@ -754,10 +773,18 @@ site-independent tensor and produces the global phase of
 \end{theorem}
 \begin{proof}
     \leanok
-    Extend both end-window inserts to $P$ and use
-    Theorem~\ref{thm:peps_corner_extension_state_preserves} on each side.
-    The assumed equality of the end-window deformed states then gives the
-    displayed equality on $P$.
+    Applying Theorem~\ref{thm:peps_corner_extension_state_preserves} to each
+    end window gives
+    \[
+        \Psi_{A,P,\operatorname{Ext}_{W_{\mathrm{right}}\subseteq P}(C_0)}
+        =
+        \Psi_{A,W_{\mathrm{right}},C_0}
+        =
+        \Psi_{A,W_{\mathrm{left}},C_{\mathrm{end}}}
+        =
+        \Psi_{A,P,\operatorname{Ext}_{W_{\mathrm{left}}\subseteq P}(C_{\mathrm{end}})},
+    \]
+    where the middle equality is the hypothesis.
 \end{proof}
 
 \begin{theorem}[End-pair stripping under complement injectivity]
@@ -766,10 +793,10 @@ site-independent tensor and produces the global phase of
     \leanok
     \uses{def:peps_horizontal_staircase_patch,
         thm:peps_corner_extension_state_preserves}
-    Suppose all bond dimensions are positive and the torus complement
-    $V\setminus S$ of the staircase end pair is blocked-tensor injective.  If
-    the two end-window inserts have equal deformed states, then their extensions
-    to $S$ are equal:
+    Suppose $1<W$, $1<H$, all bond dimensions are positive, and the torus
+    complement $V\setminus S$ of the staircase end pair is blocked-tensor
+    injective.  If the two end-window inserts have equal deformed states, then
+    their extensions to $S$ are equal:
     \[
         \operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)
         =
@@ -780,9 +807,30 @@ site-independent tensor and produces the global phase of
 % source minimal-size argument.
 \begin{proof}
     \leanok
-    The state-preservation theorem moves the two end-window states to the
-    end pair $S$.  Injectivity of the complement $V\setminus S$ then allows
-    the end-pair comparison map to be inverted, giving equality of inserts.
+    The state-preservation theorem moves the two end-window states to the end
+    pair:
+    \[
+        \Psi_{A,S,\operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)}
+        =
+        \Psi_{A,W_{\mathrm{right}},C_0}
+        =
+        \Psi_{A,W_{\mathrm{left}},C_{\mathrm{end}}}
+        =
+        \Psi_{A,S,\operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}})}.
+    \]
+    Complement injectivity then gives
+    \[
+        \begin{gathered}
+        V\setminus S\text{ is blocked-tensor injective},\\
+        \Psi_{A,S,\operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)}
+        =
+        \Psi_{A,S,\operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}})}
+        \end{gathered}
+        \quad\Longrightarrow\quad
+        \operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)
+        =
+        \operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}}).
+    \]
 \end{proof}
 
 \begin{lemma}[Two-block merge collapse]
@@ -790,7 +838,14 @@ site-independent tensor and produces the global phase of
     \lean{TNLean.PEPS.mergeCollapse2}
     \leanok
     Let $B_1,K_1\subseteq V\setminus T$ and $B_2,H_2\subseteq T$.  Fix
-    boundary data $c_1$ on $V\setminus K_1$ and $c_2$ on $H_2$.  Then the
+    boundary data $c_1$ on $V\setminus K_1$ and $c_2$ on $H_2$, and physical
+    labels $\sigma_1$ on $B_1$ and $\sigma_2$ on $B_2$.  Set
+    \[
+        F_1(\xi)=\prod_{x\in B_1}A_x(\xi|_{\partial x},\sigma_1(x)),
+        \qquad
+        F_2(\xi)=\prod_{x\in B_2}A_x(\xi|_{\partial x},\sigma_2(x)).
+    \]
+    Then the
     boundary-compatible double sum collapses to the multiplicity of the
     interior bonds of $T$ times the single merged sum:
     \[
@@ -798,13 +853,13 @@ site-independent tensor and produces the global phase of
             \zeta_2|_{\partial(V\setminus K_1)}=c_1,\;
             \zeta_1|_{\partial H_2}=c_2\\
             \zeta_1|_{\partial T}=\zeta_2|_{\partial T}}}
-        F_1(\zeta_2|_{B_1})F_2(\zeta_1|_{B_2})
+        F_1(\zeta_2)F_2(\zeta_1)
         =
         P_T
         \sum_{\substack{
             \eta|_{\partial(V\setminus K_1)}=c_1,\;
             \eta|_{\partial H_2}=c_2}}
-        F_1(\eta|_{B_1})F_2(\eta|_{B_2}).
+        F_1(\eta)F_2(\eta).
     \]
 \end{lemma}
 \begin{proof}
@@ -1097,7 +1152,7 @@ site-independent tensor and produces the global phase of
         def:peps_horizontal_staircase_patch}
     Assume
     \[
-        0<L,\qquad 0<K,\qquad 1\le a,\qquad
+        1<W,\qquad 1<H,\qquad 0<L,\qquad 0<K,\qquad 1\le a,\qquad
         a+2L\le W,\qquad b+2K-1\le H.
     \]
     Then an edge crosses from the left end window to the right end window if
@@ -1128,7 +1183,7 @@ site-independent tensor and produces the global phase of
     \uses{thm:peps_horizontal_staircase_reference_edge_crossing}
     Under the bounds
     \[
-        0<L,\qquad 0<K,\qquad 1\le a,\qquad
+        1<W,\qquad 1<H,\qquad 0<L,\qquad 0<K,\qquad 1\le a,\qquad
         a+2L\le W,\qquad b+2K-1\le H,
     \]
     a boundary edge of the end pair is a boundary edge of one of the two end
@@ -1152,7 +1207,7 @@ site-independent tensor and produces the global phase of
     \uses{lem:peps_horizontal_staircase_end_pair_boundary_from_windows}
     Under the bounds
     \[
-        0<L,\qquad 0<K,\qquad 1\le a,\qquad
+        1<W,\qquad 1<H,\qquad 0<L,\qquad 0<K,\qquad 1\le a,\qquad
         a+2L\le W,\qquad b+2K-1\le H,
     \]
     an edge is a boundary edge of the staircase end pair $S$ if and only if it

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -289,6 +289,108 @@ site-independent tensor and produces the global phase of
     endpoint in the region, so $e$ is not a boundary edge of $W_j$.
 \end{proof}
 
+\subsection{Staircase patch geometry}
+\label{subsec:peps_torus_staircase_patch_geometry}
+
+\begin{definition}[Horizontal staircase patch and its corner]
+    \label{def:peps_horizontal_staircase_patch}
+    \lean{TNLean.PEPS.horizontalStaircasePatch}
+    \lean{TNLean.PEPS.horizontalStaircaseLeftWindow}
+    \lean{TNLean.PEPS.horizontalStaircaseRightWindow}
+    \lean{TNLean.PEPS.horizontalStaircaseEndPair}
+    \lean{TNLean.PEPS.horizontalStaircaseCorner}
+    \lean{TNLean.PEPS.horizontalStaircaseCompletedCorner}
+    \leanok
+    \uses{def:peps_torus_geometry_translation}
+    Fix a horizontal reference edge and write the staircase corner as
+    $s=(a,b)$.  The two end windows of the overlapping-window chain are
+    \[
+        W_{\mathrm{left}}=[a,a+L)\times[b,b+K),
+        \qquad
+        W_{\mathrm{right}}=[a+L,a+2L)\times[b+K-1,b+2K-1).
+    \]
+    Their end pair is $S=W_{\mathrm{left}}\cup W_{\mathrm{right}}$.  The
+    staircase patch is the union
+    \[
+        P=
+        \bigl([a,a+2L)\times[b+K-1,b+2K-1)\bigr)
+        \cup
+        \bigl([a,a+L)\times[b,b+2K-1)\bigr),
+    \]
+    and the corner cut out by the two end windows is
+    \[
+        C=[a,a+L)\times[b+K,b+2K-1).
+    \]
+    Completing $C$ by one row gives the $L\times K$ rectangle
+    \[
+        \widehat C=[a,a+L)\times[b+K,b+2K).
+    \]
+    These cyclic rectangles are the regions used in the staircase chaining and
+    corner-stripping step of
+    \cite[proof sketch, lines~2320--2445]{Molnar2018NormalPEPS}.
+\end{definition}
+
+\begin{lemma}[The staircase end windows are disjoint]
+    \label{lem:peps_horizontal_staircase_end_pair_disjoint}
+    \lean{TNLean.PEPS.horizontalStaircaseEndPair_disjoint}
+    \leanok
+    \uses{def:peps_horizontal_staircase_patch}
+    If $2L\le W$, then the two end windows of the horizontal staircase are
+    disjoint:
+    \[
+        W_{\mathrm{left}}\cap W_{\mathrm{right}}=\varnothing.
+    \]
+\end{lemma}
+\begin{proof}
+    \leanok
+    Their horizontal coordinate intervals are $[a,a+L)$ and $[a+L,a+2L)$.
+    The bound $2L\le W$ prevents wraparound overlap.
+\end{proof}
+
+\begin{lemma}[Injectivity of the staircase end windows and completed corner]
+    \label{lem:peps_horizontal_staircase_window_injectivity}
+    \lean{TNLean.PEPS.NormalTorusArcWindowInjectivityHypotheses.horizontalStaircaseLeftWindow_injective}
+    \lean{TNLean.PEPS.NormalTorusArcWindowInjectivityHypotheses.horizontalStaircaseRightWindow_injective}
+    \lean{TNLean.PEPS.NormalTorusArcWindowInjectivityHypotheses.horizontalStaircaseCompletedCorner_injective}
+    \leanok
+    \uses{def:peps_horizontal_staircase_patch}
+    Under the one-orientation $L\times K$ torus-window injectivity hypotheses,
+    the two end windows and the completed corner are injective regions:
+    \[
+        W_{\mathrm{left}},\quad W_{\mathrm{right}},\quad \widehat C
+        \quad\text{are injective.}
+    \]
+\end{lemma}
+\begin{proof}
+    \leanok
+    Each of the three regions is an $L\times K$ cyclic rectangle, so the
+    window-injectivity hypothesis applies directly.
+\end{proof}
+
+\begin{lemma}[Patch decomposition by the end pair and the corner]
+    \label{lem:peps_horizontal_staircase_patch_decomposition}
+    \lean{TNLean.PEPS.horizontalStaircaseCorner_disjoint_endPair}
+    \lean{TNLean.PEPS.horizontalStaircasePatch_eq_endPair_union_corner}
+    \lean{TNLean.PEPS.horizontalStaircasePatch_sdiff_endPair}
+    \leanok
+    \uses{def:peps_horizontal_staircase_patch,
+        lem:peps_horizontal_staircase_end_pair_disjoint}
+    If $L,K>0$, $2L\le W$, and $2K\le H$, then the corner is disjoint from
+    the end pair and the patch decomposes as
+    \[
+        P=S\cup C,
+        \qquad
+        P\setminus S=C.
+    \]
+\end{lemma}
+\begin{proof}
+    \leanok
+    In the no-wraparound rectangle, the rows and columns of the two end
+    windows and the corner are the displayed intervals above.  The interval
+    calculation gives the disjointness and identifies every point of $P$ with
+    either an end-window point or a corner point.
+\end{proof}
+
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus]%
     \label{thm:fundamentalTheorem_normalTorusPEPS}
     \notready
@@ -540,6 +642,7 @@ site-independent tensor and produces the global phase of
 
 \begin{definition}[Corner extension of a region insert]
     \label{def:peps_corner_extension}
+    \lean{TNLean.PEPS.nestedThreeBlockGeometry}
     \lean{TNLean.PEPS.bareExtendInsert}
     \lean{TNLean.PEPS.extendInsert}
     \leanok
@@ -582,9 +685,87 @@ site-independent tensor and produces the global phase of
         \Psi_{A,S,\operatorname{Ext}_{R\subseteq S}(C)}.
     \]
 \end{theorem}
+\begin{proof}
+    \leanok
+    Expanding the deformed state on $S$ separates the added block
+    $S\setminus R$ from the complement $V\setminus S$.  The corner-extension
+    sum contracts the added block first, and the factor $P_{V\setminus S}^{-1}$
+    cancels the multiplicity coming from the virtual indices wholly inside the
+    exterior.
+\end{proof}
+
+\begin{theorem}[Consecutive horizontal windows have equal corner extensions]
+    \label{thm:peps_horizontal_consecutive_window_extend_eq}
+    \lean{TNLean.PEPS.horizontalConsecutiveWindow_extend_eq}
+    \leanok
+    \uses{def:peps_corner_extension,
+        thm:peps_corner_extension_state_preserves}
+    Suppose two horizontally consecutive $L\times K$ windows carry inserts
+    $C_1$ and $C_2$ whose deformed states agree.  Let
+    $U$ be their $(L+1)\times K$ union.  Then their extensions to $U$ agree:
+    \[
+        \operatorname{Ext}_{W_1\subseteq U}(C_1)
+        =
+        \operatorname{Ext}_{W_2\subseteq U}(C_2).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:peps_corner_extension_state_preserves} rewrites each
+    single-window deformed state as the deformed state on $U$ with the
+    corresponding extended insert.  The union comparison then strips the
+    equal states to equality of the two inserts on $U$.
+\end{proof}
+
+\begin{theorem}[Patch-extended equality of the staircase end windows]
+    \label{thm:peps_horizontal_staircase_patch_extend_eq}
+    \lean{TNLean.PEPS.horizontalStaircase_patch_extend_eq}
+    \leanok
+    \uses{def:peps_horizontal_staircase_patch,
+        thm:peps_corner_extension_state_preserves}
+    If the deformed states of the two end-window inserts agree, then their
+    extensions to the staircase patch $P$ have equal deformed states:
+    \[
+        \Psi_{A,P,\operatorname{Ext}_{W_{\mathrm{right}}\subseteq P}(C_0)}
+        =
+        \Psi_{A,P,\operatorname{Ext}_{W_{\mathrm{left}}\subseteq P}(C_{\mathrm{end}})}.
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    Extend both end-window inserts to $P$ and use
+    Theorem~\ref{thm:peps_corner_extension_state_preserves} on each side.
+    The assumed equality of the end-window deformed states then gives the
+    displayed equality on $P$.
+\end{proof}
+
+\begin{theorem}[End-pair stripping under complement injectivity]
+    \label{thm:peps_staircase_pair_insert_eq_complement_injective}
+    \lean{TNLean.PEPS.staircasePair_insert_eq}
+    \leanok
+    \uses{def:peps_horizontal_staircase_patch,
+        thm:peps_corner_extension_state_preserves}
+    Suppose the torus complement $V\setminus S$ of the staircase end pair is
+    blocked-tensor injective.  If the two end-window inserts have equal
+    deformed states, then their extensions to $S$ are equal:
+    \[
+        \operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)
+        =
+        \operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}}).
+    \]
+    This is a complement-injectivity variant of the stripping step, not the
+    source minimal-size argument.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The state-preservation theorem moves the two end-window states to the
+    end pair $S$.  Injectivity of the complement $V\setminus S$ then allows
+    the end-pair comparison map to be inverted, giving equality of inserts.
+\end{proof}
 
 \begin{theorem}[Composition of corner-extension coefficient kernels]
     \label{thm:peps_corner_extension_coefficient_composition}
+    \lean{TNLean.PEPS.mergeCollapse2}
     \lean{TNLean.PEPS.threeBlockBlueCoeff_comp}
     \leanok
     \uses{def:peps_corner_extension}
@@ -838,6 +1019,126 @@ site-independent tensor and produces the global phase of
 
 \subsection{Single-bond peeling and the window witness}
 \label{subsec:peps_torus_single_bond_peeling_window_witness}
+
+\begin{definition}[Reference edge of the horizontal staircase]
+    \label{def:peps_horizontal_staircase_reference_edge}
+    \lean{TNLean.PEPS.horizontalStaircaseReferenceEdge}
+    \leanok
+    \uses{def:peps_horizontal_staircase_patch}
+    In the staircase coordinates $s=(a,b)$, the reference edge is the
+    horizontal edge joining
+    \[
+        (a+L-1,b+K-1)
+        \quad\text{to}\quad
+        (a+L,b+K-1).
+    \]
+    It is the edge between the left and right end windows.
+\end{definition}
+
+\begin{theorem}[The reference edge is the unique crossing of the two end windows]
+    \label{thm:peps_horizontal_staircase_reference_edge_crossing}
+    \lean{TNLean.PEPS.isCrossingEdge_horizontalStaircaseEndWindows}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_horizontalStaircaseRightWindow_referenceEdge}
+    \lean{TNLean.PEPS.not_isRegionBoundaryEdge_horizontalStaircaseEndPair_referenceEdge}
+    \leanok
+    \uses{def:peps_horizontal_staircase_reference_edge,
+        def:peps_horizontal_staircase_patch}
+    Under the no-wraparound bounds, an edge crosses from the left end window
+    to the right end window if and only if it is the reference edge $e$:
+    \[
+        f\in\partial W_{\mathrm{left}}\cap\partial W_{\mathrm{right}}
+        \quad\Longleftrightarrow\quad
+        f=e.
+    \]
+    Thus $e$ is a boundary edge of each end window, but both endpoints of $e$
+    lie in the end pair $S$, so $e\notin\partial S$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The endpoint calculation identifies $e$ with the unique horizontal edge
+    joining the two displayed rectangles.  Since one endpoint lies in
+    $W_{\mathrm{left}}$ and the other lies in $W_{\mathrm{right}}$, the same
+    edge is internal to their union $S$.
+\end{proof}
+
+\begin{lemma}[Boundary edges of the end pair come from the end windows]
+    \label{lem:peps_horizontal_staircase_end_pair_boundary_from_windows}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_endPair_of_leftWindow}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_endPair_of_rightWindow}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_window_of_endPair}
+    \lean{TNLean.PEPS.ne_referenceEdge_of_isRegionBoundaryEdge_endPair}
+    \leanok
+    \uses{thm:peps_horizontal_staircase_reference_edge_crossing}
+    A boundary edge of the end pair is a boundary edge of one of the two end
+    windows, and it is not the reference edge.  Conversely, any boundary edge
+    of one end window other than $e$ is a boundary edge of $S$.
+\end{lemma}
+\begin{proof}
+    \leanok
+    A boundary edge of $S$ has one endpoint in $S$; that endpoint lies in one
+    of the two end windows.  The other endpoint is outside $S$, hence outside
+    that window.  Conversely, a boundary edge of one window which is not $e$
+    cannot enter the other window, because $e$ is the unique crossing edge.
+\end{proof}
+
+\begin{theorem}[Boundary of the staircase end pair]
+    \label{thm:peps_horizontal_staircase_end_pair_boundary}
+    \lean{TNLean.PEPS.eq_referenceEdge_of_isRegionBoundaryEdge_both_endWindows}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_endPair_iff}
+    \lean{TNLean.PEPS.isRegionBoundaryEdge_endPair_exactlyOne_window}
+    \leanok
+    \uses{lem:peps_horizontal_staircase_end_pair_boundary_from_windows}
+    An edge is a boundary edge of the staircase end pair $S$ if and only if it
+    is a boundary edge of one of the two end windows and is not the reference
+    edge:
+    \[
+        f\in\partial S
+        \quad\Longleftrightarrow\quad
+        \bigl(f\in\partial W_{\mathrm{left}}
+        \quad\text{or}\quad
+        f\in\partial W_{\mathrm{right}}\bigr)
+        \ \text{and}\ f\ne e.
+    \]
+    Moreover each edge in $\partial S$ lies on exactly one of the two window
+    boundaries.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:peps_horizontal_staircase_end_pair_boundary_from_windows}
+    gives both implications.  If an edge lay on both end-window boundaries,
+    the unique-crossing theorem would identify it with $e$, which is not a
+    boundary edge of $S$.
+\end{proof}
+
+\begin{lemma}[Complement split for an end window]
+    \label{lem:peps_horizontal_staircase_end_window_complement_split}
+    \lean{TNLean.PEPS.horizontalStaircaseEndPair_sdiff_leftWindow}
+    \lean{TNLean.PEPS.horizontalStaircaseEndPair_sdiff_rightWindow}
+    \lean{TNLean.PEPS.compl_leftWindow_eq_rightWindow_union_complEndPair}
+    \lean{TNLean.PEPS.compl_rightWindow_eq_leftWindow_union_complEndPair}
+    \leanok
+    \uses{def:peps_horizontal_staircase_patch,
+        lem:peps_horizontal_staircase_end_pair_disjoint}
+    The complement of either end window splits as the opposite end window and
+    the complement of the end pair:
+    \[
+        V\setminus W_{\mathrm{left}}
+        =
+        W_{\mathrm{right}}\cup (V\setminus S),
+        \qquad
+        V\setminus W_{\mathrm{right}}
+        =
+        W_{\mathrm{left}}\cup (V\setminus S).
+    \]
+\end{lemma}
+\begin{proof}
+    \leanok
+    Since the two end windows are disjoint and
+    $S=W_{\mathrm{left}}\cup W_{\mathrm{right}}$, removing one window from
+    $S$ leaves the other.  Splitting $V\setminus W$ through the inclusion
+    $W\subseteq S$ gives the displayed decompositions.
+\end{proof}
 
 \begin{theorem}[The reference edge bounds the two end windows]
     \label{thm:peps_staircase_end_reference_edge_boundary}

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -789,21 +789,30 @@ site-independent tensor and produces the global phase of
     \label{lem:peps_two_block_merge_collapse}
     \lean{TNLean.PEPS.mergeCollapse2}
     \leanok
-    Suppose the two subblocks $B_1$ and $B_2$ are disjoint and lie in $T$.
-    Summing over pairs of virtual configurations that agree on the boundary of
-    $T$ collapses to the multiplicity of the interior bonds of $T$ times the
-    single merged sum:
+    Let $B_1,K_1\subseteq V\setminus T$ and $B_2,H_2\subseteq T$.  Fix
+    boundary data $c_1$ on $V\setminus K_1$ and $c_2$ on $H_2$.  Then the
+    boundary-compatible double sum collapses to the multiplicity of the
+    interior bonds of $T$ times the single merged sum:
     \[
-        \sum_{\zeta_1|_{V\setminus T}=\zeta_2|_{V\setminus T}}
-        F_1(\zeta_2)F_2(\zeta_1)
+        \sum_{\substack{
+            \zeta_2|_{\partial(V\setminus K_1)}=c_1,\;
+            \zeta_1|_{\partial H_2}=c_2\\
+            \zeta_1|_{\partial T}=\zeta_2|_{\partial T}}}
+        F_1(\zeta_2|_{B_1})F_2(\zeta_1|_{B_2})
         =
-        P_T\sum_{\eta}F_1(\eta)F_2(\eta).
+        P_T
+        \sum_{\substack{
+            \eta|_{\partial(V\setminus K_1)}=c_1,\;
+            \eta|_{\partial H_2}=c_2}}
+        F_1(\eta|_{B_1})F_2(\eta|_{B_2}).
     \]
 \end{lemma}
 \begin{proof}
     \leanok
-    Each merged configuration has exactly $P_T$ preimages, and the products on
-    the two disjoint subblocks are unchanged under the merge.
+    Each merged configuration has exactly $P_T$ preimages, indexed by the
+    virtual bonds strictly inside $T$.  Since $B_1$ and $K_1$ lie outside
+    $T$, while $B_2$ and $H_2$ lie inside $T$, the two products and the two
+    boundary conditions are unchanged under the merge.
 \end{proof}
 
 \begin{theorem}[Composition of corner-extension coefficient kernels]

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -690,9 +690,15 @@ site-independent tensor and produces the global phase of
     \leanok
     Expanding the deformed state on $S$ separates the added block
     $S\setminus R$ from the complement $V\setminus S$.  The corner-extension
-    sum contracts the added block first, and the factor $P_{V\setminus S}^{-1}$
-    cancels the multiplicity coming from the virtual indices wholly inside the
-    exterior.
+    sum contracts the added block first, giving the pointwise identity
+    \[
+        \Psi_{A,S,\operatorname{Ext}_{R\subseteq S}(C)}(\tau)
+        =
+        P_{V\setminus S}^{-1}\,P_{V\setminus S}\,
+        \Psi_{A,R,C}(\tau)
+        =
+        \Psi_{A,R,C}(\tau).
+    \]
 \end{proof}
 
 \begin{theorem}[Consecutive horizontal windows have equal corner extensions]
@@ -701,9 +707,15 @@ site-independent tensor and produces the global phase of
     \leanok
     \uses{def:peps_corner_extension,
         thm:peps_corner_extension_state_preserves}
+    Assume the one-orientation $L\times K$ window-injectivity hypotheses,
+    union closure for injective regions, positive bond dimensions, and the
+    bounds
+    \[
+        2\le L,\qquad 2\le K,\qquad 2L+1\le W,\qquad 2K+1\le H.
+    \]
     Suppose two horizontally consecutive $L\times K$ windows carry inserts
-    $C_1$ and $C_2$ whose deformed states agree.  Let
-    $U$ be their $(L+1)\times K$ union.  Then their extensions to $U$ agree:
+    $C_1$ and $C_2$ whose deformed states agree.  Let $U$ be their
+    $(L+1)\times K$ union.  Then their extensions to $U$ agree:
     \[
         \operatorname{Ext}_{W_1\subseteq U}(C_1)
         =
@@ -724,6 +736,10 @@ site-independent tensor and produces the global phase of
     \leanok
     \uses{def:peps_horizontal_staircase_patch,
         thm:peps_corner_extension_state_preserves}
+    Assume positive bond dimensions and the bounds
+    \[
+        0<L,\qquad 0<K,\qquad 2L\le W,\qquad 2K\le H.
+    \]
     If the deformed states of the two end-window inserts agree, then their
     extensions to the staircase patch $P$ have equal deformed states:
     \[
@@ -746,17 +762,18 @@ site-independent tensor and produces the global phase of
     \leanok
     \uses{def:peps_horizontal_staircase_patch,
         thm:peps_corner_extension_state_preserves}
-    Suppose the torus complement $V\setminus S$ of the staircase end pair is
-    blocked-tensor injective.  If the two end-window inserts have equal
-    deformed states, then their extensions to $S$ are equal:
+    Suppose all bond dimensions are positive and the torus complement
+    $V\setminus S$ of the staircase end pair is blocked-tensor injective.  If
+    the two end-window inserts have equal deformed states, then their extensions
+    to $S$ are equal:
     \[
         \operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)
         =
         \operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}}).
     \]
-    This is a complement-injectivity variant of the stripping step, not the
-    source minimal-size argument.
 \end{theorem}
+% This is a complement-injectivity variant of the stripping step, not the
+% source minimal-size argument.
 \begin{proof}
     \leanok
     The state-preservation theorem moves the two end-window states to the
@@ -764,12 +781,32 @@ site-independent tensor and produces the global phase of
     the end-pair comparison map to be inverted, giving equality of inserts.
 \end{proof}
 
+\begin{lemma}[Two-block merge collapse]
+    \label{lem:peps_two_block_merge_collapse}
+    \lean{TNLean.PEPS.mergeCollapse2}
+    \leanok
+    Suppose the two subblocks $B_1$ and $B_2$ are disjoint and lie in $T$.
+    Summing over pairs of virtual configurations that agree on the boundary of
+    $T$ collapses to the multiplicity of the interior bonds of $T$ times the
+    single merged sum:
+    \[
+        \sum_{\zeta_1|_{V\setminus T}=\zeta_2|_{V\setminus T}}
+        F_1(\zeta_2)F_2(\zeta_1)
+        =
+        P_T\sum_{\eta}F_1(\eta)F_2(\eta).
+    \]
+\end{lemma}
+\begin{proof}
+    \leanok
+    Each merged configuration has exactly $P_T$ preimages, and the products on
+    the two disjoint subblocks are unchanged under the merge.
+\end{proof}
+
 \begin{theorem}[Composition of corner-extension coefficient kernels]
     \label{thm:peps_corner_extension_coefficient_composition}
-    \lean{TNLean.PEPS.mergeCollapse2}
     \lean{TNLean.PEPS.threeBlockBlueCoeff_comp}
     \leanok
-    \uses{def:peps_corner_extension}
+    \uses{def:peps_corner_extension, lem:peps_two_block_merge_collapse}
     For nested regions $R\subseteq S\subseteq P$, the coefficient kernels
     satisfy
     \[
@@ -1045,8 +1082,13 @@ site-independent tensor and produces the global phase of
     \leanok
     \uses{def:peps_horizontal_staircase_reference_edge,
         def:peps_horizontal_staircase_patch}
-    Under the no-wraparound bounds, an edge crosses from the left end window
-    to the right end window if and only if it is the reference edge $e$:
+    Assume
+    \[
+        0<L,\qquad 0<K,\qquad 1\le a,\qquad
+        a+2L\le W,\qquad b+2K-1\le H.
+    \]
+    Then an edge crosses from the left end window to the right end window if
+    and only if it is the reference edge $e$:
     \[
         f\in\partial W_{\mathrm{left}}\cap\partial W_{\mathrm{right}}
         \quad\Longleftrightarrow\quad
@@ -1071,7 +1113,12 @@ site-independent tensor and produces the global phase of
     \lean{TNLean.PEPS.ne_referenceEdge_of_isRegionBoundaryEdge_endPair}
     \leanok
     \uses{thm:peps_horizontal_staircase_reference_edge_crossing}
-    A boundary edge of the end pair is a boundary edge of one of the two end
+    Under the bounds
+    \[
+        0<L,\qquad 0<K,\qquad 1\le a,\qquad
+        a+2L\le W,\qquad b+2K-1\le H,
+    \]
+    a boundary edge of the end pair is a boundary edge of one of the two end
     windows, and it is not the reference edge.  Conversely, any boundary edge
     of one end window other than $e$ is a boundary edge of $S$.
 \end{lemma}
@@ -1090,7 +1137,12 @@ site-independent tensor and produces the global phase of
     \lean{TNLean.PEPS.isRegionBoundaryEdge_endPair_exactlyOne_window}
     \leanok
     \uses{lem:peps_horizontal_staircase_end_pair_boundary_from_windows}
-    An edge is a boundary edge of the staircase end pair $S$ if and only if it
+    Under the bounds
+    \[
+        0<L,\qquad 0<K,\qquad 1\le a,\qquad
+        a+2L\le W,\qquad b+2K-1\le H,
+    \]
+    an edge is a boundary edge of the staircase end pair $S$ if and only if it
     is a boundary edge of one of the two end windows and is not the reference
     edge:
     \[
@@ -1121,8 +1173,8 @@ site-independent tensor and produces the global phase of
     \leanok
     \uses{def:peps_horizontal_staircase_patch,
         lem:peps_horizontal_staircase_end_pair_disjoint}
-    The complement of either end window splits as the opposite end window and
-    the complement of the end pair:
+    If $2L\le W$, the complement of either end window splits as the opposite
+    end window and the complement of the end pair:
     \[
         V\setminus W_{\mathrm{left}}
         =


### PR DESCRIPTION
## Summary

This PR synchronizes the torus PEPS blueprint with the recently landed window-geometry layers.

- Adds blueprint entries for the horizontal staircase patch, the two end windows, the end pair, the corner block, the completed corner, and their injectivity/decomposition lemmas.
- Adds the corner-extension, consecutive-window extension, staircase-patch extension, complement-injectivity stripping, blue-coupling composition, merge-collapse, and extension-transitivity entries.
- Rewrites the `TorusWindowChain4` module docstring around the displayed identities
  \[
  \operatorname{Ext}_{S\subseteq P}(\operatorname{Ext}_{R\subseteq S}(C))
  =\operatorname{Ext}_{R\subseteq P}(C)
  \]
  and
  \[
  \overline{\operatorname{Ext}}_{S\subseteq P}(\overline{\operatorname{Ext}}_{R\subseteq S}(C))
  = IB(V\setminus S)\,\overline{\operatorname{Ext}}_{R\subseteq P}(C).
  \]
- Adds the single-crossing reference-edge entries and the end-pair boundary/complement-split entries.

## Checks

- `lake build TNLean.PEPS.TorusWindowChain4` passed. It reported pre-existing linter warnings in surrounding PEPS support files, not in the changed declarations.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Closes #2743.
Closes #2746.
Closes #2757.
Closes #2767.
Closes #2775.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits (LaTeX blueprint and a Lean module docstring); no proof or API changes in the diff.
> 
> **Overview**
> **Blueprint (`ch24_peps_ft_torus.tex`)** gains a **staircase patch geometry** subsection (end windows, end pair, patch, corner, completed corner, disjointness, injectivity, and \(P=S\cup C\) decomposition) with `\lean{...}` links to the existing Lean names.
> 
> The **overlapping-window corner cancellation** subsection is expanded with blueprint statements and proofs for state preservation under corner extension, consecutive-window and staircase-patch extension equalities, complement-injectivity stripping on the end pair, the two-block **merge collapse** lemma, and updated `\uses` on blue-coupling composition. **Single-bond peeling** adds the horizontal staircase reference edge, unique crossing, end-pair boundary characterization, and complement splits for end windows.
> 
> **`TorusWindowChain4.lean`** only changes the module docstring: it now states normalized and bare corner-extension transitivity, the blue-coupling composition identity, and merge-collapse proof outline with explicit formulas, and trims internal file-path references in favor of the arXiv citation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 769ddfb83d9cac2c3ba8938a075e67a520cfb619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->