### PR TITLE
feat(MPDO): the maximally-mixed witness satisfies source ZCL

### DIFF
--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -235,7 +235,7 @@ purification tensor, which is the counterexample above to literal doubled-index
 idempotence, has physical-trace transfer equal to the identity. This transfer is
 nonzero and idempotent, hence the tensor has source zero correlation length. The
 example is recorded in
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`: the physical-trace
+docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex: the physical-trace
 transfer correctly classifies the maximally mixed product state as having zero
 correlation length, whereas the doubled-index condition wrongly excludes it. -/
 theorem isSourceZCL_witnessM : IsSourceZCL witnessM :=

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -216,4 +216,31 @@ theorem exists_isLocalPurificationRFP_not_isZCL :
     Matrix.smul_apply, Matrix.one_apply, ↓reduceIte] at hc
   norm_num at hc
 
+/-- The physical-trace transfer of the witness is the identity: closing the ket
+and bra legs gives `𝒯 = M^{00} + M^{11} = ½ + ½ = 1`. -/
+lemma physTraceTransfer_witnessM : physTraceTransfer witnessM = 1 := by
+  have hentry : physTraceTransfer witnessM 0 0 = 1 := by
+    rw [show physTraceTransfer witnessM = ∑ i : Fin 2, witnessM i i from rfl,
+      Matrix.sum_apply, Fin.sum_univ_two, witnessM_entry, witnessM_entry,
+      if_pos rfl, if_pos rfl]
+    norm_num
+  ext a b
+  obtain rfl : a = 0 := Subsingleton.elim a 0
+  obtain rfl : b = 0 := Subsingleton.elim b 0
+  rw [hentry, Matrix.one_apply_eq]
+
+/-- **The maximally mixed witness has source zero correlation length.** The
+ancilla-contracted tensor `witnessM` fails the literal doubled-index condition
+`IsZCL` (see `exists_isLocalPurificationRFP_not_isZCL`), yet its physical-trace
+transfer is `𝒯 = 1`, which is idempotent and nonzero, so it satisfies the
+source-faithful `IsSourceZCL`. This is the positive example of
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`: realigning to the
+physical-trace transfer correctly classifies the maximally mixed product state as
+having zero correlation length, where the doubled-index condition wrongly
+excludes it. -/
+theorem isSourceZCL_witnessM : IsSourceZCL witnessM :=
+  isSourceZCL_of_physTraceTransfer_sq witnessM
+    (by rw [physTraceTransfer_witnessM]; exact one_ne_zero)
+    (by rw [physTraceTransfer_witnessM, mul_one])
+
 end MPOTensor

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -216,8 +216,8 @@ theorem exists_isLocalPurificationRFP_not_isZCL :
     Matrix.smul_apply, Matrix.one_apply, ↓reduceIte] at hc
   norm_num at hc
 
-/-- The physical-trace transfer of the witness is the identity: closing the ket
-and bra legs gives `𝒯 = M^{00} + M^{11} = ½ + ½ = 1`. -/
+/-- The physical-trace transfer of the witness is the identity matrix: closing
+the ket and bra physical legs gives 𝒯 = M⁰⁰ + M¹¹ = ½ + ½ = 1. -/
 lemma physTraceTransfer_witnessM : physTraceTransfer witnessM = 1 := by
   have hentry : physTraceTransfer witnessM 0 0 = 1 := by
     rw [show physTraceTransfer witnessM = ∑ i : Fin 2, witnessM i i from rfl,
@@ -230,13 +230,13 @@ lemma physTraceTransfer_witnessM : physTraceTransfer witnessM = 1 := by
   rw [hentry, Matrix.one_apply_eq]
 
 /-- **The maximally mixed witness has source zero correlation length.** The
-ancilla-contracted tensor `witnessM` fails the literal doubled-index condition
-`IsZCL` (see `exists_isLocalPurificationRFP_not_isZCL`), yet its physical-trace
-transfer is `𝒯 = 1`, which is idempotent and nonzero, so it satisfies the
-source-faithful `IsSourceZCL`. This is the positive example of
-`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`: realigning to the
+maximally-mixed purification tensor — the counterexample above to literal
+doubled-index idempotence — has physical-trace transfer equal to the identity,
+which is nonzero and idempotent, so it satisfies `IsSourceZCL`. This is the
+positive example of the realignment design note
+(`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`): realigning to the
 physical-trace transfer correctly classifies the maximally mixed product state as
-having zero correlation length, where the doubled-index condition wrongly
+having zero correlation length, whereas the doubled-index condition wrongly
 excludes it. -/
 theorem isSourceZCL_witnessM : IsSourceZCL witnessM :=
   isSourceZCL_of_physTraceTransfer_sq witnessM

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -229,15 +229,15 @@ lemma physTraceTransfer_witnessM : physTraceTransfer witnessM = 1 := by
   obtain rfl : b = 0 := Subsingleton.elim b 0
   rw [hentry, Matrix.one_apply_eq]
 
-/-- **The maximally mixed witness has source zero correlation length.** The
-maximally-mixed purification tensor — the counterexample above to literal
-doubled-index idempotence — has physical-trace transfer equal to the identity,
-which is nonzero and idempotent, so it satisfies `IsSourceZCL`. This is the
-positive example of the realignment design note
-(`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`): realigning to the
-physical-trace transfer correctly classifies the maximally mixed product state as
-having zero correlation length, whereas the doubled-index condition wrongly
-excludes it. -/
+/-- **The maximally mixed witness has source zero correlation length**
+(arXiv:1606.00608, Definition 4.2, lines 735–739). The maximally mixed
+purification tensor, which is the counterexample above to literal doubled-index
+idempotence, has physical-trace transfer equal to the identity. This transfer is
+nonzero and idempotent, hence the tensor has source zero correlation length. The
+example is recorded in
+`docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`: the physical-trace
+transfer correctly classifies the maximally mixed product state as having zero
+correlation length, whereas the doubled-index condition wrongly excludes it. -/
 theorem isSourceZCL_witnessM : IsSourceZCL witnessM :=
   isSourceZCL_of_physTraceTransfer_sq witnessM
     (by rw [physTraceTransfer_witnessM]; exact one_ne_zero)

--- a/blueprint/src/chapter/ch21_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_foundations.tex
@@ -413,11 +413,37 @@ legs cyclically and taking the resulting trace.
     source's normalized one.
 \end{proof}
 
+\begin{lemma}[Physical-trace transfer of the maximally mixed witness]
+    \label{lem:phys_trace_transfer_witnessM}
+    \lean{MPOTensor.physTraceTransfer_witnessM}
+    \leanok
+    \uses{def:mpo_physical_trace_transfer, thm:local_purification_rfp_not_zcl}
+    For the diagonal-purification tensor of
+    Theorem~\ref{thm:local_purification_rfp_not_zcl}, closing the ket and bra
+    physical legs gives
+    \[
+        \mathcal T_M
+        =
+        M^{00}+M^{11}
+        =
+        \tfrac12+\tfrac12
+        =
+        1 .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is the direct computation of the two nonzero diagonal entries of the
+    witness tensor.
+\end{proof}
+
 \begin{theorem}[The maximally mixed witness has source zero correlation length]
     \label{thm:witness_source_zcl}
     \lean{MPOTensor.isSourceZCL_witnessM}
     \leanok
     \uses{def:mpo_source_zcl, thm:local_purification_rfp_not_zcl,
+        lem:phys_trace_transfer_witnessM,
         thm:mpo_source_zcl_of_physical_trace_idempotent}
     The same diagonal-purification tensor of
     Theorem~\ref{thm:local_purification_rfp_not_zcl} has source zero correlation
@@ -426,9 +452,9 @@ legs cyclically and taking the resulting trace.
     state, but the physical-trace condition correctly classifies it.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:mpo_source_zcl_of_physical_trace_idempotent}
-    Closing the ket and bra physical legs gives
-    $\mathcal T_M = M^{00} + M^{11} = \tfrac12 + \tfrac12 = 1$. The identity is
-    nonzero and idempotent, so source zero correlation length holds with
-    $\lambda = 1$.
+    \uses{lem:phys_trace_transfer_witnessM,
+        thm:mpo_source_zcl_of_physical_trace_idempotent}
+    Lemma~\ref{lem:phys_trace_transfer_witnessM} gives
+    $\mathcal T_M=1$. The identity is nonzero and idempotent, so source zero
+    correlation length holds with $\lambda = 1$.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_foundations.tex
@@ -412,3 +412,23 @@ legs cyclically and taking the resulting trace.
     zero-correlation-length condition is therefore strictly stronger than the
     source's normalized one.
 \end{proof}
+
+\begin{theorem}[The maximally mixed witness has source zero correlation length]
+    \label{thm:witness_source_zcl}
+    \lean{MPOTensor.isSourceZCL_witnessM}
+    \leanok
+    \uses{def:mpo_source_zcl, thm:local_purification_rfp_not_zcl,
+        thm:mpo_source_zcl_of_physical_trace_idempotent}
+    The same diagonal-purification tensor of
+    Theorem~\ref{thm:local_purification_rfp_not_zcl} has source zero correlation
+    length: its physical-trace transfer is the identity, hence nonzero and
+    idempotent. The doubled-index condition excludes this maximally mixed product
+    state, but the physical-trace condition correctly classifies it.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:mpo_source_zcl_of_physical_trace_idempotent}
+    Closing the ket and bra physical legs gives
+    $\mathcal T_M = M^{00} + M^{11} = \tfrac12 + \tfrac12 = 1$. The identity is
+    nonzero and idempotent, so source zero correlation length holds with
+    $\lambda = 1$.
+\end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_foundations.tex
@@ -417,9 +417,8 @@ legs cyclically and taking the resulting trace.
     \label{lem:phys_trace_transfer_witnessM}
     \lean{MPOTensor.physTraceTransfer_witnessM}
     \leanok
-    \uses{def:mpo_physical_trace_transfer, thm:local_purification_rfp_not_zcl}
-    For the diagonal-purification tensor of
-    Theorem~\ref{thm:local_purification_rfp_not_zcl}, closing the ket and bra
+    \uses{def:mpo_physical_trace_transfer}
+    For the maximally mixed witness $M_{\mathrm w}$, closing the ket and bra
     physical legs gives
     \[
         \mathcal T_M
@@ -442,19 +441,14 @@ legs cyclically and taking the resulting trace.
     \label{thm:witness_source_zcl}
     \lean{MPOTensor.isSourceZCL_witnessM}
     \leanok
-    \uses{def:mpo_source_zcl, thm:local_purification_rfp_not_zcl,
-        lem:phys_trace_transfer_witnessM,
-        thm:mpo_source_zcl_of_physical_trace_idempotent}
-    The same diagonal-purification tensor of
-    Theorem~\ref{thm:local_purification_rfp_not_zcl} has source zero correlation
-    length: its physical-trace transfer is the identity, hence nonzero and
-    idempotent. The doubled-index condition excludes this maximally mixed product
-    state, but the physical-trace condition correctly classifies it.
+    \uses{def:mpo_source_zcl, thm:local_purification_rfp_not_zcl}
+    The maximally mixed witness $M_{\mathrm w}$ has source zero correlation
+    length.
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:phys_trace_transfer_witnessM,
         thm:mpo_source_zcl_of_physical_trace_idempotent}
     Lemma~\ref{lem:phys_trace_transfer_witnessM} gives
-    $\mathcal T_M=1$. The identity is nonzero and idempotent, so source zero
-    correlation length holds with $\lambda = 1$.
+    $\mathcal T_{M_{\mathrm w}}=1$. The identity is nonzero and idempotent, so
+    source zero correlation length holds with $\lambda = 1$.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_foundations.tex
@@ -421,9 +421,9 @@ legs cyclically and taking the resulting trace.
     For the maximally mixed witness $M_{\mathrm w}$, closing the ket and bra
     physical legs gives
     \[
-        \mathcal T_M
+        \mathcal T_{M_{\mathrm w}}
         =
-        M^{00}+M^{11}
+        M_{\mathrm w}^{00}+M_{\mathrm w}^{11}
         =
         \tfrac12+\tfrac12
         =


### PR DESCRIPTION
## Summary

Builds on #2826. Makes precise the "positive witness" observation of `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`: the maximally-mixed purification witness `witnessM` — which *fails* the literal doubled-index `IsZCL` (`exists_isLocalPurificationRFP_not_isZCL`) — *satisfies* the source-faithful `IsSourceZCL`.

* `MPOTensor.physTraceTransfer_witnessM` — `𝒯_witnessM = M⁰⁰ + M¹¹ = ½ + ½ = 1`.
* `MPOTensor.isSourceZCL_witnessM` — hence `witnessM` satisfies `IsSourceZCL` (`𝒯 = 1` is nonzero and idempotent, λ = 1).

Together with the existing `exists_isLocalPurificationRFP_not_isZCL`, this is the formal contrast the note describes: the *same* tensor fails the doubled-index condition but satisfies the source-faithful one — confirming the realignment classifies the maximally mixed product state correctly. Additive, `sorry`-free.

## Note on verification

Opened as **draft**: my local checkout is far behind `main` and can't reliably build recent code, so I'm using CI as the proof verifier. The proof mirrors the existing witness-lemma style in the file (`Subsingleton.elim`, `Fin.sum_univ_two`, `witnessM_entry`). I'll mark ready once the `build` check is green (or fix if it surfaces a tactic-name issue).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and blueprint text only; no runtime or auth paths touched.
> 
> **Overview**
> Formalizes the **positive witness** for source-faithful zero correlation length: the same `witnessM` tensor that already **fails** doubled-index `IsZCL` (via `exists_isLocalPurificationRFP_not_isZCL`) is shown to **satisfy** `IsSourceZCL`.
> 
> Adds **`physTraceTransfer_witnessM`** (`𝒯 = M⁰⁰ + M¹¹ = ½ + ½ = 1` on the `1×1` bond) and **`isSourceZCL_witnessM`**, derived from `isSourceZCL_of_physTraceTransfer_sq` because the physical-trace transfer is the identity. Blueprint chapter 21 gains the matching lemma and theorem with `\leanok` links.
> 
> Together this pins the contrast in `cpsv16_zcl_canonical_form_normalization.tex`: physical-trace transfer classifies the maximally mixed product state as source ZCL; the doubled-index transfer map does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c00dd951b25815772dc0da5f6f5853d94971fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->