### PR TITLE
feat(MPDO): source ZCL normalizes the physical-trace transfer to a projection

### DIFF
--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -103,17 +103,18 @@ theorem isSourceZCL_of_physTraceTransfer_sq
     IsSourceZCL M :=
   ⟨h0, 1, one_pos, by rw [hidem, Complex.ofReal_one, one_smul]⟩
 
-/-- **Under source zero correlation length the physical-trace transfer is a scaled
-projection.** From `𝒯_M * 𝒯_M = λ • 𝒯_M` with `λ > 0`, the rescaled transfer
-`λ⁻¹ • 𝒯_M` is idempotent. Hence the eigenvalues of `𝒯_M` lie in `{0, λ}` and `λ`
-is its leading eigenvalue: after normalization, `𝒯_M` projects onto its
-leading-eigenvalue subspace. -/
+/-- **Normalized transfer is idempotent under source zero correlation length.**
+If the physical-trace transfer satisfies
+$\mathcal{T}_M^2 = \lambda\,\mathcal{T}_M$ with $\lambda > 0$, then
+$\lambda^{-1}\mathcal{T}_M$ is idempotent. Hence the eigenvalues of
+$\mathcal{T}_M$ lie in $\{0,\lambda\}$, and $\lambda$ is its leading
+eigenvalue. -/
 theorem IsSourceZCL.normalized_idempotent {M : MPOTensor d D} (h : IsSourceZCL M) :
     ∃ lam : ℝ, 0 < lam ∧ IsIdempotentElem ((lam : ℂ)⁻¹ • physTraceTransfer M) := by
   obtain ⟨_, lam, hlam, hidem⟩ := h
   have hlamC : (lam : ℂ) ≠ 0 := by exact_mod_cast ne_of_gt hlam
   refine ⟨lam, hlam, ?_⟩
-  show ((lam : ℂ)⁻¹ • physTraceTransfer M) * ((lam : ℂ)⁻¹ • physTraceTransfer M)
+  change ((lam : ℂ)⁻¹ • physTraceTransfer M) * ((lam : ℂ)⁻¹ • physTraceTransfer M)
     = (lam : ℂ)⁻¹ • physTraceTransfer M
   rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul, hidem, smul_smul]
   congr 1

--- a/TNLean/MPS/MPDO/ZCL.lean
+++ b/TNLean/MPS/MPDO/ZCL.lean
@@ -103,4 +103,20 @@ theorem isSourceZCL_of_physTraceTransfer_sq
     IsSourceZCL M :=
   ⟨h0, 1, one_pos, by rw [hidem, Complex.ofReal_one, one_smul]⟩
 
+/-- **Under source zero correlation length the physical-trace transfer is a scaled
+projection.** From `𝒯_M * 𝒯_M = λ • 𝒯_M` with `λ > 0`, the rescaled transfer
+`λ⁻¹ • 𝒯_M` is idempotent. Hence the eigenvalues of `𝒯_M` lie in `{0, λ}` and `λ`
+is its leading eigenvalue: after normalization, `𝒯_M` projects onto its
+leading-eigenvalue subspace. -/
+theorem IsSourceZCL.normalized_idempotent {M : MPOTensor d D} (h : IsSourceZCL M) :
+    ∃ lam : ℝ, 0 < lam ∧ IsIdempotentElem ((lam : ℂ)⁻¹ • physTraceTransfer M) := by
+  obtain ⟨_, lam, hlam, hidem⟩ := h
+  have hlamC : (lam : ℂ) ≠ 0 := by exact_mod_cast ne_of_gt hlam
+  refine ⟨lam, hlam, ?_⟩
+  show ((lam : ℂ)⁻¹ • physTraceTransfer M) * ((lam : ℂ)⁻¹ • physTraceTransfer M)
+    = (lam : ℂ)⁻¹ • physTraceTransfer M
+  rw [Matrix.smul_mul, Matrix.mul_smul, smul_smul, hidem, smul_smul]
+  congr 1
+  rw [mul_assoc, inv_mul_cancel₀ hlamC, mul_one]
+
 end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_foundations.tex
@@ -256,6 +256,28 @@ legs cyclically and taking the resulting trace.
     This is the preceding definition with $\lambda=1$.
 \end{proof}
 
+\begin{lemma}[Normalized transfer is idempotent under source zero correlation length]
+    \label{lem:mpo_source_zcl_normalized_idempotent}
+    \lean{MPOTensor.IsSourceZCL.normalized_idempotent}
+    \leanok
+    \uses{def:mpo_source_zcl}
+    If $M$ has source zero correlation length, then there exists $\lambda>0$
+    such that $\lambda^{-1}\mathcal T_M$ is idempotent.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    From source zero correlation length, choose $\lambda>0$ with
+    $\mathcal T_M^2=\lambda\,\mathcal T_M$. Then
+    \[
+        (\lambda^{-1}\mathcal T_M)^2
+        =
+        \lambda^{-2}\mathcal T_M^2
+        =
+        \lambda^{-1}\mathcal T_M .
+    \]
+\end{proof}
+
 \begin{definition}[Doubled-index transfer idempotence for MPO tensors]%
     \label{def:mpo_is_zcl}
     \lean{MPOTensor.IsZCL}


### PR DESCRIPTION
## Summary

Builds on #2826. Formalizes the spectral consequence recorded in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`: if `𝒯_M² = λ·𝒯_M` with `λ > 0`, then `λ⁻¹·𝒯_M` is idempotent, so the eigenvalues of `𝒯_M` lie in `{0, λ}` and `λ` is its leading eigenvalue — the canonical-form (peripheral-projection) reading the realignment relies on.

* `MPOTensor.IsSourceZCL.normalized_idempotent` — `IsSourceZCL M` yields `λ > 0` with `IsIdempotentElem (λ⁻¹ • physTraceTransfer M)`.

Additive, `sorry`-free.

## Note on verification

Opened as **draft**: my local checkout is far behind `main` and can't reliably build recent code, so CI is the proof verifier (as with #2830, whose build passed first try). The proof is a short scalar-algebra chain (`Matrix.smul_mul`/`mul_smul`/`smul_smul` + `inv_mul_cancel₀`). I'll mark ready once `build` is green, or fix a tactic name if it surfaces one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive formalization in MPDO ZCL with no changes to existing definitions or runtime behavior; proof is local matrix/scalar algebra only.
> 
> **Overview**
> Adds **`MPOTensor.IsSourceZCL.normalized_idempotent`**, showing that source zero correlation length (`𝒯_M² = λ·𝒯_M` with `λ > 0` and `𝒯_M ≠ 0`) yields **`λ⁻¹·𝒯_M` idempotent** via Mathlib’s `IsIdempotentElem`. The docstring records the spectral reading: eigenvalues of `𝒯_M` lie in `{0, λ}` and `λ` is the leading eigenvalue—the normalization step the canonical-form / peripheral-projection story depends on.
> 
> The blueprint chapter **`ch21_mpdo_foundations.tex`** gets the matching lemma **`lem:mpo_source_zcl_normalized_idempotent`** with a short scalar-algebra proof, wired to the Lean symbol.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d293b72a653b4728797c85a71946706f550ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->