### PR TITLE
doc(blueprint): add row-cut obstruction entries

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -209,6 +209,8 @@ site-independent tensor and produces the global phase of
     The same argument with the reference up edge gives $D_{f_v}=D_v$.
 \end{proof}
 
+\input{chapter/ch24_peps_ft_torus_row_cut_obstruction}
+
 \paragraph{Staircase-window geometry for a reference edge.}
 
 \begin{lemma}[Left endpoint of the staircase reference edge]%

--- a/blueprint/src/chapter/ch24_peps_ft_torus_row_cut_obstruction.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_row_cut_obstruction.tex
@@ -1,0 +1,140 @@
+\paragraph{Failure of the row-and-column reduction.}
+
+\begin{definition}[Per-edge product matrix on two vertical bonds]%
+    \label{def:peps_row_cut_per_edge_product}
+    \lean{TNLean.PEPS.RowColumnReductionObstruction.IsPerEdgeProduct}
+    \leanok
+    A matrix $M\in \MN{4}$ is a per-edge product on two collected vertical
+    bonds if, under the identification
+    \[
+        (r,s)\longmapsto 2r+s,\qquad \{0,1\}\times\{0,1\}\simeq \{0,1,2,3\},
+    \]
+    there are matrices $Y_0,Y_1\in \MN{2}$ such that, for all
+    $r,s,r',s'\in\{0,1\}$,
+    \[
+        M_{(r,s),(r',s')}=(Y_0)_{r,r'}(Y_1)_{s,s'}.
+    \]
+\end{definition}
+
+\begin{definition}[Per-edge factorization of the row-cut gauge]%
+    \label{def:peps_row_cut_gauge_factorizes}
+    \lean{TNLean.PEPS.RowColumnReductionObstruction.RowCutGaugeFactorizes}
+    \leanok
+    \uses{def:mps_tensor, def:l_blk_injective, def:same_mpv,
+        def:peps_row_cut_per_edge_product}
+    The row-cut factorization assertion is the following statement. Let $A$
+    and $B$ be MPS tensors with physical alphabet $\{0,\ldots,15\}$ and
+    bond space $\C^4$. If $A$ and $B$ are $1$-block injective and generate
+    the same MPV family, then there exist $Z\in \GL_4(\C)$ and
+    $\lambda\in\C$ such that $Z$ is a per-edge product matrix and, for all
+    physical indices $i\in\{0,\ldots,15\}$,
+    \[
+        B^i=\lambda\, Z^{-1}A^iZ.
+    \]
+    This is the additional product conclusion needed by a row-wise
+    one-dimensional reduction before it could imply the per-edge conclusion
+    of \cite[Theorem~3]{Molnar2018NormalPEPS}.
+\end{definition}
+
+\begin{theorem}[A row-cut gauge need not factor per edge]%
+    \label{thm:peps_row_cut_gauge_factorizes_false}
+    \lean{TNLean.PEPS.RowColumnReductionObstruction.rowCutGaugeFactorizes_false}
+    \leanok
+    \uses{def:peps_row_cut_gauge_factorizes}
+    The row-cut factorization assertion is false. Explicitly, let
+    $E_{ab}\in\MN{4}$ be the matrix units and set
+    \[
+        A^{(a,b)}=E_{ab},\qquad
+        G=
+        \begin{pmatrix}
+            1&0&1&0\\
+            0&1&0&0\\
+            0&0&1&0\\
+            0&0&0&1
+        \end{pmatrix},
+        \qquad
+        B^{(a,b)}=G^{-1}E_{ab}G.
+    \]
+    Then $A$ and $B$ are $1$-block injective and generate the same MPV
+    family, but there are no $Z\in\GL_4(\C)$ and $\lambda\in\C$ with
+    $Z$ a per-edge product matrix and
+    \[
+        B^{(a,b)}=\lambda\, Z^{-1}E_{ab}Z
+    \]
+    for all $a,b\in\{0,\ldots,3\}$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The matrix units span $\MN{4}$, hence $A$ is $1$-block injective; conjugation
+    by $G$ preserves this property for $B$. For every word
+    $w=((a_1,b_1),\ldots,(a_N,b_N))$,
+    \[
+        B^{w}
+        =
+        G^{-1}A^{w}G,
+        \qquad
+        \tr(B^{w})=\tr(A^{w}),
+    \]
+    so the two MPV families are equal.
+
+    Suppose that $Z$ and $\lambda$ satisfied the displayed conjugation
+    relation. With $W=ZG^{-1}$, multiplication by $Z$ on the left and by
+    $G^{-1}$ on the right gives, for every matrix unit $E_{ab}$,
+    \[
+        W E_{ab}=\lambda\, E_{ab}W.
+    \]
+    Taking the $(x,y)$ entry gives, for all $x,y,a,b\in\{0,\ldots,3\}$,
+    \[
+        W_{x,a}\delta_{b,y}
+        =
+        \lambda\,\delta_{x,a}W_{b,y}.
+    \]
+    With $y=b$ this gives
+    \[
+        x\ne a \Rightarrow W_{x,a}=0,
+        \qquad
+        W_{a,a}=\lambda W_{b,b}.
+    \]
+    Since $Z$ and $G$ are invertible, so is $W$. Thus the diagonal entries
+    cannot all vanish; the case $a=b$ gives $\lambda=1$, and then
+    $W_{a,a}=W_{b,b}$ for all $a,b$. Hence
+    \[
+        W=cI_4,\qquad \lambda=1
+    \]
+    with $c\ne0$. Thus $Z=cG$.
+
+    For a matrix $M\in\MN{4}$ write $M_{rr'}\in\MN{2}$ for the block
+    whose $(s,s')$ entry is $M_{(r,s),(r',s')}$. If $Z$ were a per-edge
+    product, then
+    \[
+        Z_{rr'}=(Y_0)_{r,r'}Y_1
+    \]
+    for some $Y_0,Y_1\in\MN{2}$. In particular,
+    \[
+        (Z_{00})_{s,s'}(Z_{01})_{1,1}
+        =
+        (Z_{01})_{s,s'}(Z_{00})_{1,1}.
+    \]
+    Since $Z=cG$ and $c\ne0$, the same identity holds for the corresponding
+    blocks of $G$:
+    \[
+        G_{00}=
+        \begin{pmatrix}
+            1&0\\
+            0&1
+        \end{pmatrix},
+        \qquad
+        G_{01}=
+        \begin{pmatrix}
+            1&0\\
+            0&0
+        \end{pmatrix}.
+    \]
+    Their proportionality identity gives
+    \[
+        (G_{00})_{00}(G_{01})_{11}
+        =
+        (G_{01})_{00}(G_{00})_{11},
+    \]
+    which reads $0=1$. Hence no per-edge product conjugator can exist.
+\end{proof}


### PR DESCRIPTION
## Summary

- Add blueprint entries for the per-edge product condition, the row-cut factorization assertion, and the explicit matrix-unit counterexample showing the assertion fails.
- Place the obstruction material in a small included torus subsection file, keeping `ch24_peps_ft_torus.tex` below 1500 lines.
- Link all three declarations with `\lean{}` and `\leanok` tags.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `chktex -q -l ../.chktexrc chapter/ch24_peps_ft_torus.tex chapter/ch24_peps_ft_torus_row_cut_obstruction.tex`
- `lake build TNLean.PEPS.TorusRowColumnReductionObstruction`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`

Closes #2807.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX with Lean sync tags; no runtime or proof logic changes in application code.
> 
> **Overview**
> Documents why a **row-and-column (row-cut) one-dimensional reduction** cannot assume a stronger **per-edge product** gauge conclusion on the way to Molnár’s per-edge normal PEPS theorem.
> 
> A new included subsection defines **per-edge product** matrices on two vertical bonds and the **row-cut factorization assertion** (same MPV + 1-block injectivity ⇒ conjugation by a per-edge product \(Z\)). It then proves that assertion is **false** via an explicit matrix-unit / conjugation-by-\(G\) counterexample, with a short proof that any would-be conjugator must be proportional to \(G\), which fails the product condition.
> 
> The material lives in `ch24_peps_ft_torus_row_cut_obstruction.tex` and is pulled into the torus chapter before the staircase-window geometry; all three declarations are wired with `\lean{}` / `\leanok` to `TNLean.PEPS.RowColumnReductionObstruction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c17bfb4628b0ffacffa5ec06722ca60cdcfccec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->