### PR TITLE
doc(blueprint): add torus window-realization entries

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -104,6 +104,34 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
     between the region $R$ and its complement.
 \end{definition}
 
+\begin{theorem}[Region insertion coefficients determine the inserted matrix]%
+    \label{thm:peps_regionInsertedCoeff_injective}
+    \lean{TNLean.PEPS.regionInsertedCoeff_injective}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff}
+    Suppose that the blocked tensor maps of $A$ on $R$ and on
+    $V\setminus R$ are injective, and that every bond dimension of $A$ is
+    positive.  If $f\in\partial R$ and
+    $M,M'\in\MN{D_A(f)}$ satisfy
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_A(R,f,M';\sigma,\tau)
+    \]
+    for every physical configuration $\sigma$ on $R$ and $\tau$ on
+    $V\setminus R$, then $M=M'$.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Subtracting the two coefficients gives
+    \[
+        C_A(R,f,M-M';\sigma,\tau)=0
+    \]
+    for every $\sigma,\tau$.  Injectivity of the region and complement
+    blocked tensor maps reads off every entry of $M-M'$ from configurations
+    agreeing away from $f$, so $M-M'=0$ and hence $M=M'$.
+\end{proof}
+
 \begin{definition}[Bond-inserted region insert]%
     \label{def:peps_bond_inserted_region_insert}
     \lean{TNLean.PEPS.bondInsertedRegionInsert}

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -1456,3 +1456,5 @@ site-independent tensor and produces the global phase of
     for the region $W$.  The hypotheses supply the injectivity of both $W$ and
     its complement at the minimal torus size.
 \end{definition}
+
+\input{chapter/ch24_peps_ft_torus_window_realizes}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_window_realizes.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_window_realizes.tex
@@ -1,0 +1,124 @@
+\paragraph{Window realization and witness read-off.}
+
+\begin{lemma}[Window-level edge-insertion injectivity]%
+    \label{lem:peps_windowRegionInsertedCoeff_injective}
+    \lean{TNLean.PEPS.windowRegionInsertedCoeff_injective}
+    \leanok
+    \uses{thm:peps_regionInsertedCoeff_injective,
+        lem:peps_horizontal_staircase_window_injectivity,
+        thm:peps_horizontal_staircase_reference_edge_crossing}
+    Let $B$ be a PEPS tensor on a torus whose periods $W,H$ satisfy
+    $1<W$ and $1<H$.  Assume the one-orientation $L\times K$
+    window-injectivity hypotheses for $B$, union closure for injective
+    regions, positive bond dimensions, and
+    \[
+        2\le L,\qquad 2\le K,\qquad 1\le a,\qquad
+        a+2L\le W,\qquad b+2K-1\le H,
+    \]
+    together with
+    \[
+        2L+1\le W,\qquad 2K+1\le H.
+    \]
+    Let $W_{\mathrm L}$ be the left end window and let $e$ be the reference
+    edge.  If $M,M'\in\MN{D_B(e)}$ satisfy
+    \[
+        C_B(W_{\mathrm L},e,M;\sigma,\tau)
+        =
+        C_B(W_{\mathrm L},e,M';\sigma,\tau)
+    \]
+    for every physical configuration $\sigma$ on $W_{\mathrm L}$ and $\tau$
+    on $V\setminus W_{\mathrm L}$, then $M=M'$.
+\end{lemma}
+\begin{proof}
+    \leanok
+    The window-injectivity hypotheses give injectivity of the blocked tensor
+    map on $W_{\mathrm L}$.  The single-window complement is also injective at
+    the displayed size.  Since $e\in\partial W_{\mathrm L}$,
+    Theorem~\ref{thm:peps_regionInsertedCoeff_injective} applied to the
+    region $W_{\mathrm L}$ gives $M=M'$.
+\end{proof}
+
+\begin{theorem}[Window witness from a region insertion transfer]%
+    \label{thm:peps_windowEdgeCoeffIdentityWitness_of_transfer}
+    \lean{TNLean.PEPS.exists_windowEdgeCoeffIdentityWitness_of_transfer}
+    \leanok
+    \uses{def:peps_region_insertion_transfer,
+        def:peps_window_edge_coeff_identity_witness,
+        def:peps_window_edge_coeff_identity_witness_of_hypotheses}
+    Let $A$ and $B$ be PEPS tensors on a torus whose periods $W,H$ satisfy
+    $1<W$ and $1<H$.  Assume the one-orientation $L\times K$
+    window-injectivity hypotheses for both tensors, union closure for
+    injective regions for both tensors, positive bond dimensions, and
+    \[
+        2\le L,\qquad 2\le K,\qquad 1\le a,\qquad
+        a+2L\le W,\qquad b+2K-1\le H,
+    \]
+    together with
+    \[
+        2L+1\le W,\qquad 2K+1\le H.
+    \]
+    Let $W_{\mathrm L}$ be the left end window and let $e$ be the reference
+    edge.  If $T_e:\MN{D_A(e)}\to\MN{D_B(e)}$ is a region insertion transfer
+    on $W_{\mathrm L}$ at $e$, then there exist
+    $Z,Z_{\mathrm{ref}}\in\GL(D_B(e))$ and a bond-dimension identification
+    $\iota_e:\MN{D_A(e)}\simeq\MN{D_B(e)}$ such that the coefficient-identity
+    witness at $e$ is nonempty.  The coefficient identity has the form
+    \[
+        C_A(W_{\mathrm L},e,M;\sigma,\tau)
+        =
+        C_B(W_{\mathrm L},e,Z\,\iota_e(M)\,Z^{-1};\sigma,\tau).
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    The transfer determines a gauge $Z$ by the region insertion algebra:
+    \[
+        T_e(M)=Z\,\iota_e(M)\,Z^{-1}.
+    \]
+    Its coefficient-matching property gives the displayed identity.  The
+    window and complement injectivity hypotheses are those required by
+    Definition~\ref{def:peps_window_edge_coeff_identity_witness_of_hypotheses},
+    which yields the witness with $Z_{\mathrm{ref}}=Z$.
+\end{proof}
+
+\begin{theorem}[Window witness from single-vertex realization]%
+    \label{thm:peps_windowEdgeCoeffIdentityWitness_of_realizes}
+    \lean{TNLean.PEPS.exists_windowEdgeCoeffIdentityWitness_of_realizes}
+    \leanok
+    \uses{def:peps_region_transfer_realizes,
+        def:peps_region_insertion_transfer_of_realizes,
+        thm:peps_windowEdgeCoeffIdentityWitness_of_transfer}
+    Let $A$ and $B$ be PEPS tensors on a torus whose periods $W,H$ satisfy
+    $1<W$ and $1<H$.  Assume the one-orientation $L\times K$
+    window-injectivity hypotheses for both tensors, union closure for
+    injective regions for both tensors, matched bond dimensions, equality of
+    the PEPS state, positive bond dimensions, and
+    \[
+        2\le L,\qquad 2\le K,\qquad 1\le a,\qquad
+        a+2L\le W,\qquad b+2K-1\le H,
+    \]
+    together with
+    \[
+        2L+1\le W,\qquad 2K+1\le H.
+    \]
+    Let $W_{\mathrm L}$ be the left end window and let $e$ be the reference
+    edge.  Suppose the endpoint tensor of each family at the in-region
+    endpoint of $e$ has linearly independent columns, and suppose the boundary
+    matrix transfer is realized on $W_{\mathrm L}$ in both directions.  Then
+    there exist $Z,Z_{\mathrm{ref}}\in\GL(D_B(e))$ and a bond-dimension
+    identification $\iota_e:\MN{D_A(e)}\simeq\MN{D_B(e)}$ such that the
+    coefficient-identity witness at $e$ is nonempty.
+\end{theorem}
+\begin{proof}
+    \leanok
+    The two realized boundary transfers determine a region insertion transfer:
+    \[
+        C_A(W_{\mathrm L},e,M;\sigma,\tau)
+        =
+        C_B(W_{\mathrm L},e,T_e(M);\sigma,\tau),
+        \qquad
+        T_e(MM')=T_e(M)T_e(M').
+    \]
+    Theorem~\ref{thm:peps_windowEdgeCoeffIdentityWitness_of_transfer} then
+    gives the two gauges and the nonempty coefficient-identity witness.
+\end{proof}


### PR DESCRIPTION
## Summary
- add the region-level injectivity statement for insertion coefficients used by the torus window argument
- add a torus-window realization fragment covering window insertion injectivity, witnesses from region insertion transfers, and witnesses from single-vertex realization
- include the fragment from the PEPS torus section without increasing `ch24_peps_ft_torus.tex` past 1500 lines

## Validation
- `lake build TNLean.PEPS.TorusWindowRealizes`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `chktex -q -l ../.chktexrc chapter/ch24_peps_ft_torus.tex chapter/ch24_peps_ft_torus_window_realizes.tex chapter/ch24_peps_ft_region_transfer.tex`
- `leanblueprint web` (completed with the repository's existing plasTeX package and bibliography warnings)

Closes #2797.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint/LaTeX and lean decl sync; no runtime or security-sensitive code changes.
> 
> **Overview**
> Documents the **region insertion coefficient injectivity** theorem in the region-transfer chapter and adds a **torus window-realization** fragment pulled into the torus section via `\input` so `ch24_peps_ft_torus.tex` stays under 1500 lines.
> 
> The new fragment states **window-level** edge-insertion injectivity (reducing to the region theorem), and shows how a **nonempty window edge coefficient-identity witness** follows from a **region insertion transfer** or from **bidirectional single-vertex boundary realization**, with Lean decl hooks (`TNLean.PEPS.*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e5522ce507eb1c9fdb062194955c2cccdcb69e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->