### PR TITLE
doc(blueprint): add torus window-peeling entries

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -203,8 +203,13 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
     \lean{TNLean.PEPS.regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
     \leanok
     \uses{def:peps_regionInsertedCoeff, def:peps_edgeInsertedCoeff}
-    Let $f$ be a boundary edge of $R$.  If $N\in\MN{D_B(f)}$, then
-    the region insertion coefficient factors through the edge-inserted
+    Let $f$ be a boundary edge of $R$, let $N\in\MN{D_B(f)}$, let $\sigma$
+    be a physical configuration on $R$, and let $\tau$ be a physical
+    configuration on $V\setminus R$.  Put
+    \[
+        p_B(R)=\prod_{g\notin\partial R}D_B(g).
+    \]
+    Then the region insertion coefficient factors through the edge-inserted
     coefficient:
     \[
         C_B(R,f,N;\sigma,\tau)
@@ -213,19 +218,39 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         E_B\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),
             \mathcal O_{R,f}(N)\bigr).
     \]
-    Here $p_B(R)$ is the product of the interior bond dimensions of $R$,
-    and $\mathcal O_{R,f}$ is the boundary-edge orientation, equal to the
+    Here $\mathcal O_{R,f}$ is the boundary-edge orientation, equal to the
     identity if the left endpoint of $f$ lies in $R$ and to transpose
     otherwise.
 \end{theorem}
 \begin{proof}
     \leanok
-    Expanding $C_B(R,f,N;\sigma,\tau)$ gives a sum over two boundary
-    configurations which agree away from $f$.  The common off-edge data is an
-    open-edge configuration, and the remaining free interior bonds contribute
-    exactly $p_B(R)$.  The surviving summand is the edge-inserted coefficient
-    of the assembled physical configuration, with the inserted matrix oriented
-    by $\mathcal O_{R,f}$.
+    Let $\mathcal C_{R,f}(\sigma,\tau)$ denote the open-edge configurations
+    compatible with the two physical configurations and with the two boundary
+    readings agreeing away from $f$.  For
+    $\xi\in\mathcal C_{R,f}(\sigma,\tau)$, let
+    $\operatorname{Fib}_{R,f}(\xi)$ be the corresponding fibre of agreeing
+    boundary readings.  Grouping the expansion of $C_B(R,f,N;\sigma,\tau)$ by
+    such an open-edge configuration $\xi$ gives
+    \[
+    \begin{aligned}
+        C_B(R,f,N;\sigma,\tau)
+        &=
+        \sum_{\xi\in\mathcal C_{R,f}(\sigma,\tau)}
+        \#\operatorname{Fib}_{R,f}(\xi)\,
+        N_{\xi_{R,f}^{(1)},\xi_{R,f}^{(2)}}
+        \prod_{v\in V}
+        B_v\bigl(\xi_v,\operatorname{Assemble}_R(\sigma,\tau)_v\bigr),\\
+        \#\operatorname{Fib}_{R,f}(\xi)
+        &=
+        \prod_{g\notin\partial R}D_B(g)
+        =
+        p_B(R).
+    \end{aligned}
+    \]
+    Thus the grouped contraction is $p_B(R)$ times the single-edge
+    contraction for the assembled physical configuration.  The only remaining
+    distinction is the orientation in which the boundary edge is read, and
+    this replaces $N$ by $\mathcal O_{R,f}(N)$.
 \end{proof}
 
 \begin{theorem}[Bond insertion through a corner extension]

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -247,10 +247,24 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         p_B(R).
     \end{aligned}
     \]
-    Thus the grouped contraction is $p_B(R)$ times the single-edge
-    contraction for the assembled physical configuration.  The only remaining
-    distinction is the orientation in which the boundary edge is read, and
-    this replaces $N$ by $\mathcal O_{R,f}(N)$.
+    Substituting this fibre cardinality gives
+    \[
+    \begin{aligned}
+        C_B(R,f,N;\sigma,\tau)
+        &=
+        p_B(R)
+        \sum_{\xi\in\mathcal C_{R,f}(\sigma,\tau)}
+        N_{\xi_{R,f}^{(1)},\xi_{R,f}^{(2)}}
+        \prod_{v\in V}
+        B_v\bigl(\xi_v,\operatorname{Assemble}_R(\sigma,\tau)_v\bigr)\\
+        &=
+        p_B(R)\,
+        E_B\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),
+            \mathcal O_{R,f}(N)\bigr).
+    \end{aligned}
+    \]
+    The second equality is the definition of the edge-inserted coefficient,
+    with the inserted matrix read in the boundary-edge orientation.
 \end{proof}
 
 \begin{theorem}[Bond insertion through a corner extension]

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -198,6 +198,36 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
     \]
 \end{proof}
 
+\begin{theorem}[Region insertion as an edge insertion]
+    \label{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
+    \lean{TNLean.PEPS.regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:peps_edgeInsertedCoeff}
+    Let $f$ be a boundary edge of $R$.  If $N\in\MN{D_B(f)}$, then
+    the region insertion coefficient factors through the edge-inserted
+    coefficient:
+    \[
+        C_B(R,f,N;\sigma,\tau)
+        =
+        p_B(R)\,
+        E_B\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),
+            \mathcal O_{R,f}(N)\bigr).
+    \]
+    Here $p_B(R)$ is the product of the interior bond dimensions of $R$,
+    and $\mathcal O_{R,f}$ is the boundary-edge orientation, equal to the
+    identity if the left endpoint of $f$ lies in $R$ and to transpose
+    otherwise.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Expanding $C_B(R,f,N;\sigma,\tau)$ gives a sum over two boundary
+    configurations which agree away from $f$.  The common off-edge data is an
+    open-edge configuration, and the remaining free interior bonds contribute
+    exactly $p_B(R)$.  The surviving summand is the edge-inserted coefficient
+    of the assembled physical configuration, with the inserted matrix oriented
+    by $\mathcal O_{R,f}$.
+\end{proof}
+
 \begin{theorem}[Bond insertion through a corner extension]
     \label{thm:peps_regionInsertedCoeff_eq_extendInsert_bondInserted}
     \lean{TNLean.PEPS.regionInsertedCoeff_eq_extendInsert_bondInserted}

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -1393,6 +1393,8 @@ site-independent tensor and produces the global phase of
     and hence the two coefficients are equal.
 \end{proof}
 
+\input{chapter/ch24_peps_ft_torus_window_peel4}
+
 \begin{definition}[Window-region coefficient-identity witness]
     \label{def:peps_window_edge_coeff_identity_witness}
     \lean{TNLean.PEPS.windowEdgeCoeffIdentityWitness}

--- a/blueprint/src/chapter/ch24_peps_ft_torus_window_peel4.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_window_peel4.tex
@@ -29,7 +29,7 @@
     Let $R$ be a region, let $f$ be a boundary edge of $R$, let
     $M\in\MN{D_B(f)}$, and let $\omega$ be a physical configuration on the
     full vertex set.  Then the assembled deformed state of the bond-inserted
-    region insert is the interior-bond multiple of the corresponding
+    region insert is the non-boundary bond product times the corresponding
     edge-inserted coefficient:
     \[
         \Psi^{\mathrm{as}}_{B,R,I_{B,R,f,M}}(\omega)
@@ -37,8 +37,8 @@
         p_B(R)\,
         E_B\bigl(f,\omega,\mathcal O_{R,f}(M)\bigr).
     \]
-    Here $p_B(R)$ is the product of the interior bond dimensions of $R$, and
-    $\mathcal O_{R,f}$ is the boundary-edge orientation.
+    Here $p_B(R)=\prod_{g\notin\partial R}D_B(g)$, and $\mathcal O_{R,f}$ is
+    the boundary-edge orientation.
 \end{theorem}
 \begin{proof}
     \leanok
@@ -84,12 +84,11 @@
     \leanok
     Applying
     Theorem~\ref{thm:peps_deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff}
-    to the two regions gives
+    to each of the two regions gives, for $i=1,2$,
     \[
         \Psi^{\mathrm{as}}_{B,R_i,I_{B,R_i,e,M_i}}(\omega)
         =
-        p_B(R_i)\,E_B(e,\omega,\mathcal O_{R_i,e}(M_i)),
-        \qquad i=1,2.
+        p_B(R_i)\,E_B(e,\omega,\mathcal O_{R_i,e}(M_i)).
     \]
     The oriented insertions are equal by hypothesis, so both sides of the
     claimed identity are

--- a/blueprint/src/chapter/ch24_peps_ft_torus_window_peel4.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus_window_peel4.tex
@@ -1,0 +1,99 @@
+\paragraph{Window-independence of the bond insertion.}
+
+\begin{lemma}[Restriction and reassembly of a physical configuration]
+    \label{lem:peps_assembleRegionSigma_restrict}
+    \lean{TNLean.PEPS.assembleRegionσ_restrict}
+    \leanok
+    Let $\omega$ be a physical configuration on the full vertex set.  If
+    $\omega_R$ and $\omega_{V\setminus R}$ are its restrictions to $R$ and
+    to the complement, then
+    \[
+        \operatorname{Assemble}_R(\omega_R,\omega_{V\setminus R})=\omega.
+    \]
+\end{lemma}
+\begin{proof}
+    \leanok
+    At a vertex in $R$ the assembled configuration reads $\omega_R$, and at a
+    vertex outside $R$ it reads $\omega_{V\setminus R}$.  These restrictions
+    are both inherited from $\omega$, so the two configurations agree at every
+    vertex.
+\end{proof}
+
+\begin{theorem}[Bond-inserted state as an edge insertion]
+    \label{thm:peps_deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff}
+    \lean{TNLean.PEPS.deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff}
+    \leanok
+    \uses{thm:peps_deformedRegionState_bondInsertedRegionInsert,
+        thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff,
+        lem:peps_assembleRegionSigma_restrict}
+    Let $R$ be a region, let $f$ be a boundary edge of $R$, let
+    $M\in\MN{D_B(f)}$, and let $\omega$ be a physical configuration on the
+    full vertex set.  Then the assembled deformed state of the bond-inserted
+    region insert is the interior-bond multiple of the corresponding
+    edge-inserted coefficient:
+    \[
+        \Psi^{\mathrm{as}}_{B,R,I_{B,R,f,M}}(\omega)
+        =
+        p_B(R)\,
+        E_B\bigl(f,\omega,\mathcal O_{R,f}(M)\bigr).
+    \]
+    Here $p_B(R)$ is the product of the interior bond dimensions of $R$, and
+    $\mathcal O_{R,f}$ is the boundary-edge orientation.
+\end{theorem}
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:peps_deformedRegionState_bondInsertedRegionInsert}
+    rewrites the assembled deformed state as
+    \[
+        C_B(R,f,M;\omega_R,\omega_{V\setminus R}).
+    \]
+    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
+    turns this coefficient into
+    \[
+        p_B(R)\,
+        E_B\bigl(f,\operatorname{Assemble}_R
+            (\omega_R,\omega_{V\setminus R}),\mathcal O_{R,f}(M)\bigr).
+    \]
+    Lemma~\ref{lem:peps_assembleRegionSigma_restrict} identifies the assembled
+    configuration with $\omega$.
+\end{proof}
+
+\begin{theorem}[Window-independence of a bond insertion]
+    \label{thm:peps_bondInserted_windowIndependent}
+    \lean{TNLean.PEPS.bondInserted_windowIndependent}
+    \leanok
+    \uses{thm:peps_deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff}
+    Let $R_1$ and $R_2$ be two regions for which the same edge $e$ is a
+    boundary edge.  Let $M_1,M_2\in\MN{D_B(e)}$, and suppose that the two
+    oriented insertions agree,
+    \[
+        \mathcal O_{R_1,e}(M_1)=\mathcal O_{R_2,e}(M_2).
+    \]
+    Then for every physical configuration $\omega$ on the full vertex set,
+    \[
+    \begin{aligned}
+        p_B(R_2)\,
+        \Psi^{\mathrm{as}}_{B,R_1,I_{B,R_1,e,M_1}}(\omega)
+        &=
+        p_B(R_1)\,
+        \Psi^{\mathrm{as}}_{B,R_2,I_{B,R_2,e,M_2}}(\omega).
+    \end{aligned}
+    \]
+\end{theorem}
+\begin{proof}
+    \leanok
+    Applying
+    Theorem~\ref{thm:peps_deformedRegionStateAssembled_bondInserted_eq_smul_edgeInsertedCoeff}
+    to the two regions gives
+    \[
+        \Psi^{\mathrm{as}}_{B,R_i,I_{B,R_i,e,M_i}}(\omega)
+        =
+        p_B(R_i)\,E_B(e,\omega,\mathcal O_{R_i,e}(M_i)),
+        \qquad i=1,2.
+    \]
+    The oriented insertions are equal by hypothesis, so both sides of the
+    claimed identity are
+    \[
+        p_B(R_1)p_B(R_2)\,E_B(e,\omega,\mathcal O_{R_1,e}(M_1)).
+    \]
+\end{proof}


### PR DESCRIPTION
## Summary
- add the region-to-edge coefficient identity used by the bond-insertion peeling argument
- add a torus-window peeling fragment for restriction reassembly, the assembled bond-inserted state, and window-independence of the bond insertion
- include the fragment inside the PEPS torus section while keeping `ch24_peps_ft_torus.tex` under 1500 lines

## Validation
- `lake build TNLean.PEPS.TorusWindowPeel4`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `chktex -q -l ../.chktexrc chapter/ch24_peps_ft_torus.tex chapter/ch24_peps_ft_torus_window_peel4.tex chapter/ch24_peps_ft_region_transfer.tex`
- `leanblueprint web` (completed with the repository's existing plasTeX package and bibliography warnings)

Closes #2795.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint/LaTeX and Lean declaration sync only; no runtime or security-sensitive code paths.
> 
> **Overview**
> Extends the PEPS blueprint with the **region insertion → edge insertion** identity (`C_B = p_B(R)·E_B`) and a new torus fragment on **window-independence of bond insertions**.
> 
> **Region transfer:** Adds Theorem `peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff` with a proof that groups the region coefficient by open-edge configurations and uses fibre cardinality `p_B(R)`.
> 
> **Torus peeling (`ch24_peps_ft_torus_window_peel4.tex`):** New `\input` before the window coefficient-identity witness. It proves restriction/reassembly of `Assemble_R`, rewrites the **assembled** bond-inserted deformed state as `p_B(R)·E_B` on the full lattice, and shows two regions sharing boundary edge `e` with the same oriented insertion satisfy `p_B(R₂)·Ψ^as_{R₁} = p_B(R₁)·Ψ^as_{R₂}` because the edge-inserted term is region-independent.
> 
> Keeps the main torus chapter under the line limit by splitting this peel step into its own file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ca4a6da42a07bf14a3cc7c590139b72406f9323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->