### PR TITLE
feat(RFP): expose pair-index isometry normalization

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -201,6 +201,11 @@ structure AppendixBStructuralData (A : MPSTensor d D) where
   hΛ_pos : ∀ k, 0 < Λ k
   /-- The residual tensor is left-canonical. -/
   hU_left : ∑ i : Fin d, (U i)ᴴ * U i = 1
+  /-- The residual tensor satisfies the pair-index orthonormality in the
+  normalization used by `rfp_nt_structural_full`. -/
+  hU_pair : ∀ p q : Fin D × Fin D,
+    ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+      if p = q then (D : ℂ)⁻¹ else 0
   /-- The original tensor has the Appendix B structural form. -/
   hA_eq : ∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹
 
@@ -210,7 +215,7 @@ theorem AppendixBStructuralData.exists_ofRFP (A : MPSTensor d D) [NeZero D]
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     Nonempty (AppendixBStructuralData A) := by
   classical
-  obtain ⟨X, Λ, U, hX_det, hΛ_pos, hU_left, hA_eq⟩ :=
+  obtain ⟨X, Λ, U, hX_det, hΛ_pos, hU_left, hU_pair, hA_eq⟩ :=
     rfp_nt_structural_full A hNT hRFP hLeft
   exact ⟨
     { X := X
@@ -219,6 +224,7 @@ theorem AppendixBStructuralData.exists_ofRFP (A : MPSTensor d D) [NeZero D]
       hX_det := hX_det
       hΛ_pos := hΛ_pos
       hU_left := hU_left
+      hU_pair := hU_pair
       hA_eq := hA_eq }⟩
 
 /-- Extract the bundled Appendix B structural form from the proved structural

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -15,7 +15,7 @@ renormalization fixed-point tensors (arXiv:1606.00608, Lemma B.1). The main
 result is `rfp_nt_structural_full`, which shows that a normal tensor in
 canonical form II and at a renormalization fixed point admits a decomposition
 `A i = X * diagonal Λ * U i * X⁻¹`, where `Λ` has positive diagonal entries
-and the family `U` is isometric in the physical index.
+and the family `U` is left-canonical with a scaled pair-index orthonormality.
 
 The proof is self-contained and contains the full appendix argument in the main
 `MPS/RFP` development.
@@ -83,14 +83,21 @@ private lemma matrixUnits_map (X : Mat) :
 
 /-- **Lemma B.1** (arXiv:1606.00608, Appendix B): a normal tensor in canonical
 form II that is an RFP admits the decomposition `A i = X * Λ * U i * X⁻¹`
-with diagonal positive `Λ` and a physical-index isometry `U`.
+with diagonal positive `Λ` and a residual tensor `U` satisfying the
+left-canonical equation and the scaled pair-index orthonormality
+\[
+  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+  =
+  D^{-1}\delta_{(\alpha,\beta),(\alpha',\beta')}.
+\]
 
 The proof combines the diagonal fixed-point reduction
 `rfp_nt_cfii_diagonal_fixedPoint`, the rank-one classification
 `transferMap_eq_fixedPointProj_of_isRFP_injective`, and an explicit Kraus
 realization of `fixedPointProj ρ`. Applying `kraus_rectangular_freedom'`
-identifies the physical-index family with an isometry and yields the witnesses
-`X * diag(Λ) * U i * X⁻¹`. -/
+identifies the physical-index coefficients with an isometry. The matrix units
+are normalized by $D^{-1/2}$, so the resulting matrix entries carry the
+displayed factor $D^{-1}$. -/
 theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
@@ -99,6 +106,9 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
       X.det ≠ 0 ∧
       (∀ k, 0 < Λ k) ∧
       (∑ i : Fin d, (U i)ᴴ * U i = 1) ∧
+      (∀ p q : Fin D × Fin D,
+        ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+          if p = q then (D : ℂ)⁻¹ else 0) ∧
       (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
   classical
   have hInjA : IsInjective A :=
@@ -341,6 +351,46 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     intro p q
     have h := congrFun (congrFun hV_iso p) q
     simpa [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] using h
+  have hU_entry : ∀ (i : Fin d) (p : Fin D × Fin D), U i p.1 p.2 = c * V i p := by
+    intro i p
+    simp only [U, E, Matrix.smul_single, smul_eq_mul, mul_one]
+    rw [Matrix.sum_apply]
+    rw [Finset.sum_eq_single p]
+    · simp [mul_comm]
+    · intro q _ hq
+      have hcoord : q.1 ≠ p.1 ∨ q.2 ≠ p.2 := by
+        by_cases h1 : q.1 = p.1
+        · right
+          intro h2
+          apply hq
+          exact Prod.ext h1 h2
+        · exact Or.inl h1
+      rcases hcoord with h1 | h2
+      · simp [h1]
+      · simp [h2]
+    · simp
+  have hc_norm' : star c * c = (D : ℂ)⁻¹ := by
+    rw [mul_comm, hc_norm]
+    simp [div_eq_mul_inv]
+  have hU_pair : ∀ p q : Fin D × Fin D,
+      ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+        if p = q then (D : ℂ)⁻¹ else 0 := by
+    intro p q
+    calc
+      ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2
+          = ∑ i : Fin d, (star c * c) * (star (V i p) * V i q) := by
+              refine Finset.sum_congr rfl ?_
+              intro i _
+              rw [hU_entry i p, hU_entry i q]
+              simp [mul_assoc, mul_left_comm, mul_comm]
+      _ = (star c * c) * ∑ i : Fin d, star (V i p) * V i q := by
+              rw [Finset.mul_sum]
+      _ = (star c * c) * (if p = q then 1 else 0) := by
+              rw [hV_entry p q]
+      _ = if p = q then (D : ℂ)⁻¹ else 0 := by
+              by_cases hpq : p = q
+              · simpa [hpq] using hc_norm'
+              · simp [hpq]
   have hU_left : ∑ i : Fin d, (U i)ᴴ * U i = 1 := by
     calc
       ∑ i : Fin d, (U i)ᴴ * U i
@@ -381,7 +431,7 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
             simp [Finset.mul_sum]
       _ = L * U i := by
             simp [U]
-  refine ⟨X, Λ, U, hX_det, ?_, hU_left, ?_⟩
+  refine ⟨X, Λ, U, hX_det, ?_, hU_left, hU_pair, ?_⟩
   · intro k
     apply Real.sqrt_pos.2
     have hk_pos : 0 < (ρ k k).re := by
@@ -415,14 +465,14 @@ not a conjugation gauge: rescaling Λ_k ↦ Λ_k / tr(Λ_k) factors out as an ov
 scalar on A_k, since conjugation by X preserves the scale.
 
 **Scope restriction (source isometry):** Corollary III.cor3 also invokes the
-joint isometry condition from eq:III_isometry, lines 550--554. This theorem
-records only the contracted per-block condition ∑ i, (U i)ᴴ * U i = 1. It does
-not include the full diagonal pair-index orthonormality, with its source
-normalization, and it also omits the δ_{j,j'} orthogonality between distinct
-blocks. This restriction is recorded in
+joint isometry condition from eq:III_isometry, lines 550--554. This theorem now
+records the diagonal pair-index equation for each block in the normalization used
+by `rfp_nt_structural_full`, where the right-hand side is multiplied by
+$(\dim k)^{-1}$. It still omits the source trace-normalization of $\Lambda_k$ and the
+δ_{j,j'} orthogonality between distinct blocks. This restriction is recorded in
 `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. Elimination: strengthen the
-single-block statement to expose the pair-index isometry, then prove a joint
-BNT-family isometry form from whole-tensor canonical-form RFP data.
+normalization comparison, then prove a joint BNT-family isometry form from
+whole-tensor canonical-form RFP data.
 
 Deriving the per-block normal/RFP/left-canonical hypotheses from a whole-tensor
 canonical-form fixed-point condition is a separate step. -/
@@ -433,6 +483,9 @@ theorem rfp_nt_structural_full_blocks {r : ℕ} {dim : Fin r → ℕ}
     ∀ k, ∃ (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ) (Λ : Fin (dim k) → ℝ)
       (U : MPSTensor d (dim k)),
       X.det ≠ 0 ∧ (∀ j, 0 < Λ j) ∧ (∑ i : Fin d, (U i)ᴴ * U i = 1) ∧
+      (∀ p q : Fin (dim k) × Fin (dim k),
+        ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+          if p = q then (dim k : ℂ)⁻¹ else 0) ∧
       (∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) * U i * X⁻¹) :=
   fun k => rfp_nt_structural_full (A k) (hNT k) (hRFP k) (hLeft k)
 

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -436,15 +436,21 @@ and rates for the single-tensor transfer map $\E_A$.
         thm:transferMap_eq_fixedPointProj_of_isRFP_injective}
     A normal tensor $A$ in canonical form~II that is a renormalization fixed
     point admits a decomposition $A^i = X \Lambda U^i X^{-1}$, where
-    $\Lambda$ is diagonal positive and the family $U = (U^i)$ is an
-    isometry in the physical indices.
+    $\Lambda$ is diagonal positive, $\sum_i (U^i)^\dagger U^i=I$, and
+    \[
+        \sum_i \overline{(U^i)_{\alpha,\beta}}\,
+        (U^i)_{\alpha',\beta'}
+        =
+        D^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Combine the diagonal fixed-point reduction with the rank-one
     classification of injective left-canonical RFP tensors. One then writes the
-    resulting rank-one projector in a canonical Kraus form, applies Kraus
-    freedom to identify the physical-index family with an isometry $U$, and
-    transports the decomposition back through the conjugation.
+    resulting rank-one projector in a normalized matrix-unit Kraus form,
+    applies Kraus freedom to identify the pair-index coefficients, and
+    transports the decomposition back through the conjugation. The matrix-unit
+    normalization contributes the factor $D^{-1}$ in the pair-index equation.
 \end{proof}
 
 \begin{theorem}[Per-block isometry canonical form]%

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -56,7 +56,12 @@ block $k$ it gives
     &=
   X_k\Lambda_kU_k^iX_k^{-1},\\
   \sum_i (U_k^i)^\dagger U_k^i
-    &= I.
+    &= I,\\
+  \sum_i
+  \overline{(U_k^i)_{\alpha,\beta}}\,
+  (U_k^i)_{\alpha',\beta'}
+    &=
+  D_k^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
 \end{align}
 The second equation is the contracted identity
 \begin{align}
@@ -66,21 +71,22 @@ The second equation is the contracted identity
   =
   \delta_{\beta,\beta'}.
 \end{align}
-It does not record the full diagonal pair-index equation
+The third equation records the diagonal pair-index orthonormality in the
+normalization used by the formal theorem.  Compared with the source convention,
+the entries of $U_k^i$ carry the normalized matrix-unit factor $D_k^{-1/2}$;
+therefore the compatible pair-index equation is
 \begin{align}
   \sum_i
-  (U_k^i)_{\alpha,\beta}\,
-  \overline{(U_k^i)_{\alpha',\beta'}}
+  \overline{(U_k^i)_{\alpha,\beta}}\,
+  (U_k^i)_{\alpha',\beta'}
   =
-  \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+  D_k^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
 \end{align}
-For the normalization exposed by the current theorem, a pair-index formula
-compatible with the contracted identity would also have to account for the
-corresponding $1/D_k$ scaling, where $D_k=\dim A_k$.  The theorem does not
-state such a pair-index formula.
+The remaining normalization comparison with the source equation
+\eqref{eq:III_isometry} is therefore explicit rather than hidden.
 
-There is also no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus
-the formal theorem records only a contracted separate isometry condition for
+There is still no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus
+the formal theorem records only a separate normalized isometry condition for
 each block; it does not record the cross-block equations
 \begin{align}
   \sum_i
@@ -114,9 +120,10 @@ content that the block-pair spaces fit orthogonally inside the physical space.
 
 The current theorem is a scope restriction.  It is a useful per-block
 consequence of the single-block RFP isometry form, but it is not the full
-isometry assertion of Corollary~III.cor3.  It exposes only the contracted
-per-block identity $\sum_i (U_k^i)^\dagger U_k^i=I$, not the full diagonal
-pair-index orthonormality, and it also omits the cross-block $\delta_{j,j'}$
+isometry assertion of Corollary~III.cor3.  It exposes the contracted
+per-block identity $\sum_i (U_k^i)^\dagger U_k^i=I$ and the diagonal
+pair-index orthonormality in the normalized single-block convention.  It still
+omits the source trace-normalization and the cross-block $\delta_{j,j'}$
 orthogonality equations.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
## Summary
- strengthen `MPSTensor.rfp_nt_structural_full` with the pair-index orthonormality carried by the normalized matrix-unit construction
- propagate the same identity through `MPSTensor.rfp_nt_structural_full_blocks` and `AppendixBStructuralData`
- update the blueprint and paper-gap note to record the normalized `D^{-1}` factor and the remaining source-level gaps

Closes #2819.

## Validation
- `lake build TNLean.MPS.RFP.CommutingBridge`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `chktex -q -l ../.chktexrc chapter/ch14_correlations.tex`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive Lean conclusions and doc sync on formalized math; no runtime or security surface, though downstream proofs must handle the new `hU_pair` field.
> 
> **Overview**
> **`rfp_nt_structural_full`** now concludes that the residual tensor **`U`** satisfies **scaled pair-index orthonormality**—\(\sum_i \overline{U^i_{\alpha,\beta}} U^i_{\alpha',\beta'} = D^{-1}\delta\) on diagonal pairs—alongside the existing left-canonical identity. The proof derives this from the **\(D^{-1/2}\)-normalized matrix-unit Kraus family** and the physical-index isometry **`V`** from Kraus freedom.
> 
> The same identity is threaded through **`rfp_nt_structural_full_blocks`**, the **`AppendixBStructuralData`** bundle (`hU_pair`), and **`exists_ofRFP`**. Blueprint **ch14** and **`cpsv16_rfp_isometry_scope.tex`** are updated to state the **\(D^{-1}\)** normalization explicitly and to narrow what still differs from the source (trace-normalized \(\Lambda\), cross-block orthogonality).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15c19a82e1c19f342b433b2bad263cbf9497c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->