### PR TITLE
feat(MPS/ParentHamiltonian): boundary-restriction equality from commutation (L3 of #2405)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
@@ -96,9 +96,9 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
 
 /-- **Boundary-restriction equality from commutation and the one-sided products (L3).**
 
-Suppose \(X\) commutes with every matrix (the conclusion of
-`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`), and the two
-boundary-crossing supports give the one-sided product equations
+Suppose \(X\) commutes with every one-site matrix \(A^j\), as in the
+block-window commutation lemma, and the two boundary-crossing supports give the
+one-sided product equations
 \[
   W_\eta \, A^j = A^\mu \, A^j \, X,
   \qquad
@@ -108,26 +108,54 @@ for the wrapped witness \(W_\eta\) and mirror witness \(V_\eta\). Then the two
 witnesses agree after right multiplication by each one-site matrix:
 \(W_\eta \, A^j = V_\eta \, A^j\).
 
-The mirror equation together with centrality of \(X\) forces \(V_\eta = A^\mu X\)
-by left witness uniqueness, and the wrapped equation then matches it. This is the
-"L3" step of the boundary-closing decomposition; see
+The mirror equation and the commutation relations give, for every \(k\),
+\[
+  A^k V_\eta
+  =
+  X A^k A^\mu
+  =
+  A^k X A^\mu
+  =
+  A^k A^\mu X .
+\]
+Left witness uniqueness therefore forces \(V_\eta=A^\mu X\). The wrapped
+equation then yields
+\[
+  W_\eta A^j
+  =
+  A^\mu A^jX
+  =
+  A^\mu X A^j
+  =
+  V_\eta A^j .
+\]
+This is the "L3" step of the boundary-closing decomposition; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem boundary_restrictions_eq_of_commutes_and_one_sided
     {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {X : Matrix (Fin D) (Fin D) ℂ}
     (W V : Fin d → Matrix (Fin D) (Fin D) ℂ) (μ : Fin m → Fin d)
-    (hComm : ∀ B : Matrix (Fin D) (Fin D) ℂ, X * B = B * X)
+    (hComm : ∀ j : Fin d, X * A j = A j * X)
     (hWrap : ∀ η j : Fin d,
       W η * A j = evalWord A (List.ofFn μ) * A j * X)
     (hMirror : ∀ η j : Fin d,
       X * A j * evalWord A (List.ofFn μ) = A j * V η) :
     ∀ η j : Fin d, W η * A j = V η * A j := by
+  -- Single-site commutation extends to commutation with every word.
+  have hCommWord : ∀ w : List (Fin d),
+      X * evalWord A w = evalWord A w * X := by
+    intro w
+    induction w with
+    | nil => simp [evalWord_nil]
+    | cons a rest ih =>
+      rw [evalWord_cons, ← Matrix.mul_assoc, hComm a, Matrix.mul_assoc, ih,
+        ← Matrix.mul_assoc]
   intro η j
   have hV : V η = evalWord A (List.ofFn μ) * X := by
     apply left_witness_unique_of_isNBlkInjective hInj hL₀
     intro k
     have h := hMirror η k
-    rw [← h, hComm (A k), Matrix.mul_assoc, hComm (evalWord A (List.ofFn μ))]
-  rw [hWrap η j, hV, Matrix.mul_assoc, ← hComm (A j), ← Matrix.mul_assoc]
+    rw [← h, hComm k, Matrix.mul_assoc, hCommWord (List.ofFn μ)]
+  rw [hWrap η j, hV, Matrix.mul_assoc, ← hComm j, ← Matrix.mul_assoc]
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
@@ -94,4 +94,40 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
       (le_trans (Nat.le_succ K) (Nat.le_mul_of_pos_right (K + 1) hL₀)) hB
   exact sub_eq_zero.mp hzero
 
+/-- **Boundary-restriction equality from commutation and the one-sided products (L3).**
+
+Suppose \(X\) commutes with every matrix (the conclusion of
+`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`), and the two
+boundary-crossing supports give the one-sided product equations
+\[
+  W_\eta \, A^j = A^\mu \, A^j \, X,
+  \qquad
+  X \, A^j \, A^\mu = A^j \, V_\eta,
+\]
+for the wrapped witness \(W_\eta\) and mirror witness \(V_\eta\). Then the two
+witnesses agree after right multiplication by each one-site matrix:
+`W η * A j = V η * A j`.
+
+The mirror equation together with centrality of \(X\) forces \(V_\eta = A^\mu X\)
+by left witness uniqueness, and the wrapped equation then matches it. This is the
+"L3" step of the boundary-closing decomposition; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+theorem boundary_restrictions_eq_of_commutes_and_one_sided
+    {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (W V : Fin d → Matrix (Fin D) (Fin D) ℂ) (μ : Fin m → Fin d)
+    (hComm : ∀ B : Matrix (Fin D) (Fin D) ℂ, X * B = B * X)
+    (hWrap : ∀ η j : Fin d,
+      W η * A j = evalWord A (List.ofFn μ) * A j * X)
+    (hMirror : ∀ η j : Fin d,
+      X * A j * evalWord A (List.ofFn μ) = A j * V η) :
+    ∀ η j : Fin d, W η * A j = V η * A j := by
+  intro η j
+  have hV : V η = evalWord A (List.ofFn μ) * X := by
+    apply left_witness_unique_of_isNBlkInjective hInj hL₀
+    intro k
+    have h := hMirror η k
+    rw [← h, hComm (A k), Matrix.mul_assoc, hComm (evalWord A (List.ofFn μ))]
+  rw [hWrap η j, hV, Matrix.mul_assoc, ← hComm (A j), ← Matrix.mul_assoc]
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
@@ -106,7 +106,7 @@ boundary-crossing supports give the one-sided product equations
 \]
 for the wrapped witness \(W_\eta\) and mirror witness \(V_\eta\). Then the two
 witnesses agree after right multiplication by each one-site matrix:
-`W η * A j = V η * A j`.
+\(W_\eta \, A^j = V_\eta \, A^j\).
 
 The mirror equation together with centrality of \(X\) forces \(V_\eta = A^\mu X\)
 by left witness uniqueness, and the wrapped equation then matches it. This is the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -55,6 +55,61 @@ that remains the open input.
     gives $X A^j-A^jX=0$.
 \end{proof}
 
+\begin{lemma}[Boundary restrictions from commutation and one-sided products]
+    \label{lem:boundary_restrictions_from_commutation_one_sided_products}
+    \lean{MPSTensor.boundary_restrictions_eq_of_commutes_and_one_sided}
+    \leanok
+    \uses{def:l_blk_injective, def:eval_word,
+        lem:one_sided_boundary_witness_unique}
+    Let $A$ be $L_0$-block-injective with $L_0>0$. Let $X$ be a boundary
+    matrix, let $W_\eta$ and $V_\eta$ be matrix families indexed by a physical
+    letter $\eta$, and let $\mu$ be a word. Suppose
+    \[
+        X A^j=A^jX
+    \]
+    for every physical letter $j$. Suppose also that, for every $\eta$ and
+    every $j$,
+    \[
+        W_\eta A^j = A^\mu A^jX,
+        \qquad
+        X A^jA^\mu = A^jV_\eta .
+    \]
+    Then, for every $\eta$ and every $j$,
+    \[
+        W_\eta A^j=V_\eta A^j.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:one_sided_boundary_witness_unique}
+    The commutation relation $X A^j=A^jX$ extends by induction to
+    \[
+        X A^w=A^wX
+    \]
+    for every word $w$. Hence the mirror equation gives, for every $k$,
+    \[
+        A^kV_\eta
+        =
+        X A^kA^\mu
+        =
+        A^kX A^\mu
+        =
+        A^kA^\mu X .
+    \]
+    Lemma~\ref{lem:one_sided_boundary_witness_unique} gives
+    $V_\eta=A^\mu X$. The wrapped equation then gives
+    \[
+        W_\eta A^j
+        =
+        A^\mu A^jX
+        =
+        A^\mu X A^j
+        =
+        V_\eta A^j .
+    \]
+\end{proof}
+
 \begin{lemma}[Products with one-site tensors determine the witness]
     \label{lem:wrapped_mirror_right_products_determine}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_right_products}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -63,11 +63,12 @@ that remains the open input.
         lem:one_sided_boundary_witness_unique}
     Let $A$ be $L_0$-block-injective with $L_0>0$. Let $X$ be a boundary
     matrix, let $W_\eta$ and $V_\eta$ be matrix families indexed by a physical
-    letter $\eta$, and let $\mu$ be a word. Suppose
+    letter $\eta$, and let $\mu$ be a word. Suppose that, for every physical
+    letter $j$,
     \[
         X A^j=A^jX
     \]
-    for every physical letter $j$. Suppose also that, for every $\eta$ and
+    Suppose also that, for every $\eta$ and
     every $j$,
     \[
         W_\eta A^j = A^\mu A^jX,
@@ -83,11 +84,12 @@ that remains the open input.
 \begin{proof}
     \leanok
     \uses{lem:one_sided_boundary_witness_unique}
-    The commutation relation $X A^j=A^jX$ extends by induction to
+    The commutation relation $X A^j=A^jX$ extends by induction: for every word
+    $w$,
     \[
         X A^w=A^wX
     \]
-    for every word $w$. Hence the mirror equation gives, for every $k$,
+    Hence the mirror equation gives, for every $k$,
     \[
         A^kV_\eta
         =


### PR DESCRIPTION
## Summary

Adds `MPSTensor.boundary_restrictions_eq_of_commutes_and_one_sided` — the **L3 step** of the boundary-closing decomposition (#2405), building on the merged L2 (`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`, #2820).

Given:
- `X` central (the conclusion of L2), and
- the two one-sided boundary products `W_η · A j = A^μ · A j · X` and `X · A j · A^μ = A j · V_η` (from `closure_property_boundary_one_sided_products_of_groundSpaceMap`),

it proves the boundary-restriction equality `W η · A j = V η · A j` — exactly the `hProd` goal sorried in `closure_property_boundary_restrictions_eq_of_groundSpaceMap`.

## The key step

The structural obstruction was that the mirror witness appears only *left*-multiplied (`A j · V`), never `V · A j`. The resolution: the mirror equation plus X-centrality gives `A k · V_η = A k · (A^μ · X)` for every `k`, so **`left_witness_unique_of_isNBlkInjective`** forces `V_η = A^μ · X`. (Crucially, that uniqueness lemma holds at single-site length `1 ≤ L₀` via `eq_zero_..._of_le_mul`, so no length-`L₀` word span is needed.) The wrapped equation then matches: `W η · A j = A^μ · A j · X = A^μ · X · A j = V η · A j`.

With L2 (merged) and L3, the **only remaining boundary-closing obligation is the block matrix equation (L1)** — the keystone — after which the live `sorry` in `closure_property_boundary_restrictions_eq_of_groundSpaceMap` can be eliminated by wiring L1 → L2 → L3.

~40-line addition to the existing `BoundaryMatrixBlock.lean`; definite proof strategy, no new axioms.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style proof extension and blueprint documentation; no runtime or API surface changes beyond new theorems.
> 
> **Overview**
> Adds **`MPSTensor.boundary_restrictions_eq_of_commutes_and_one_sided`** in `BoundaryMatrixBlock.lean` — the **L3** step of boundary-closing (#2405): from central `X`, wrapped products `W_η · A j = A^μ · A j · X`, and mirror products `X · A j · A^μ = A j · V_η`, it proves **`W_η · A j = V_η · A j`**.
> 
> The proof extends single-site commutation to all words, uses **`left_witness_unique_of_isNBlkInjective`** to get `V_η = A^μ · X` from the mirror side, then rewrites the wrapped equation.
> 
> The blueprint chapter **`ch13_parent_hamiltonian_normal_closing.tex`** gains the matching lemma (with `\leanok` proof) linked to that Lean name, citing one-sided witness uniqueness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87500807bbdca03895b739ea5f8139a8108f9b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->