### PR TITLE
feat(MPS/ParentHamiltonian): add trace-decomposition boundary reformulation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -218,6 +218,7 @@ import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
 import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition
 import TNLean.Algebra.BlockTriangularTrace
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.BNT.Basic

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
 
 /-!
-# Trace-decomposition wrappers for block-diagonal parent spaces
+# Finite-spanning versions of trace-decomposition results for block-diagonal parent spaces
 
 This file packages a finite-spanning form of the PGVWC trace-decomposition
 hypothesis into the block-diagonal boundary and finite-range equality
@@ -41,7 +41,7 @@ single-block vectors
 \]
 belong to \(\mathcal G_{N,L}(A_j)\).
 
-This is the finite-spanning wrapper for the trace-decomposition form of
+This is the finite-spanning reformulation of the trace-decomposition form of
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456, after the
 block-diagonal boundary conditions of arXiv:2011.12127, lines 2126--2128.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -1,0 +1,176 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
+
+/-!
+# Trace-decomposition wrappers for block-diagonal parent spaces
+
+This file packages a finite-spanning form of the PGVWC trace-decomposition
+hypothesis into the block-diagonal boundary and finite-range equality
+conclusions. The remaining source step is to derive that trace-decomposition
+equality from the \(C^j,D^j,E^j\) comparison in arXiv:quant-ph/0608197,
+Theorem 12.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- PGVWC trace decompositions upgrade the block-diagonal boundary
+representation to periodic single-block states.
+
+Under the normalized BNT hypotheses, every vector in the block-diagonal
+periodic chain space has block-diagonal boundary conditions \(X_j\). Assume
+also a length \(m\) at which the simultaneous block-word tuples span the
+full product algebra. If, for those same boundary conditions, the
+boundary-crossing trace decompositions
+\[
+  \sum_j\operatorname{tr}(A^j_\beta C^j_{i,\rho}A^j_w)
+  =
+  \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr)
+\]
+hold for every boundary-crossing interval \(i\), wrapped word \(\beta\),
+complementary word \(\rho\), and word \(w\) of length \(m\), then the
+single-block vectors
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)
+\]
+belong to \(\mathcal G_{N,L}(A_j)\).
+
+This is the finite-spanning wrapper for the trace-decomposition form of
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456, after the
+block-diagonal boundary conditions of arXiv:2011.12127, lines 2126--2128.
+
+**Unfaithful:** This proof relies on
+`exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+theorem
+    exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {m L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hTraceSpan : WordTupleSpanTop A m)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (hTrace :
+      ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+          ∃ C : ∀ (j : Fin r) (_ : Fin N),
+            (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+            ∀ i : Fin N,
+              N < i.val + L →
+                ∀ ρ : Fin (N - L) → Fin d,
+                  ∀ β : Fin (i.val + L - N) → Fin d,
+                    ∀ w : Fin m → Fin d,
+                      (∑ j : Fin r,
+                        Matrix.trace
+                          ((evalWord (A j) (List.ofFn β) * C j i ρ) *
+                            evalWord (A j) (List.ofFn w))) =
+                      (∑ j : Fin r,
+                        Matrix.trace
+                          ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                              evalWord (A j) (List.ofFn ρ)) *
+                            evalWord (A j) (List.ofFn w)))) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  classical
+  obtain ⟨X, hψX, _hOpen⟩ :=
+    exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
+  obtain ⟨C, hCoeff⟩ := hTrace X hψX
+  refine ⟨X, hψX, ?_⟩
+  exact
+    blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
+      μ A hN hLN X hTraceSpan hBlk hUnital hNlarge C hCoeff
+
+/-- PGVWC trace decompositions give the block-diagonal periodic-chain equality
+in the finite BNT range.
+
+This theorem combines the block-diagonal boundary representation with the
+trace-decomposition form of the Pérez-García--Verstraete--Wolf--Cirac
+boundary-crossing comparison. It assumes a finite simultaneous word-spanning
+length \(m\) and the trace equality at that length, for every
+boundary-crossing interval and every block-diagonal boundary representation.
+Deriving that equality from the source \(C^j,D^j,E^j\) comparison is the
+remaining step recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
+**Unfaithful:** This proof relies on
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,
+which transitively uses the boundary-closing coordinate comparison rather than
+deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
+in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+theorem
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {m L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hTraceSpan : WordTupleSpanTop A m)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hTrace :
+      ∀ {ψ : NSiteSpace d N},
+        ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+            ∃ C : ∀ (j : Fin r) (_ : Fin N),
+              (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+              ∀ i : Fin N,
+                N < i.val + L →
+                  ∀ ρ : Fin (N - L) → Fin d,
+                    ∀ β : Fin (i.val + L - N) → Fin d,
+                      ∀ w : Fin m → Fin d,
+                        (∑ j : Fin r,
+                          Matrix.trace
+                            ((evalWord (A j) (List.ofFn β) * C j i ρ) *
+                              evalWord (A j) (List.ofFn w))) =
+                        (∑ j : Fin r,
+                          Matrix.trace
+                            ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                                evalWord (A j) (List.ofFn ρ)) *
+                              evalWord (A j) (List.ofFn w)))) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  exact
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+      (fun ψ hψ =>
+        exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
+          μ A hμ hIrr hLeft hOverlap hBlocks hTraceSpan hBlk hL₀ hUnital hN hL hLN hRange
+          hNlarge hψ (fun X hψX => hTrace hψ X hψX))
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -1496,7 +1496,10 @@ membership for the single-block states.
         lem:bnt_block_diagonal_boundary_representation_equality}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
-    in addition that $L+L_0\le N$. Suppose that for every
+    in addition that $L+L_0\le N$. Assume also that, for some middle-word length
+    $m$, the simultaneous tuples $w\mapsto(A^1_w,\ldots,A^g_w)$ with
+    $w\in\Fin{d}^m$ span the full product algebra $\prod_j\MN{D_j}$. Suppose
+    that for every
     \[
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -1437,10 +1437,7 @@ membership for the single-block states.
         lem:bnt_block_diagonal_boundary_representation_equality}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
-    in addition that $L+L_0\le N$. Assume also that, for some middle-word length
-    $m$, the simultaneous tuples $w\mapsto(A^1_w,\ldots,A^g_w)$ with
-    $w\in\Fin{d}^m$ span the full product algebra $\prod_j\MN{D_j}$. Assume
-    further that, for every
+    in addition that $L+L_0\le N$. Assume further that, for every
     \[
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -1439,8 +1439,8 @@ membership for the single-block states.
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
     in addition that $L+L_0\le N$. Assume also that, for some middle-word length
     $m$, the simultaneous tuples $w\mapsto(A^1_w,\ldots,A^g_w)$ with
-    $w\in\Fin{d}^m$ span the full product algebra $\prod_j\MN{D_j}$. Suppose
-    that for every
+    $w\in\Fin{d}^m$ span the full product algebra $\prod_j\MN{D_j}$. Assume
+    further that, for every
     \[
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
@@ -1498,8 +1498,8 @@ membership for the single-block states.
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
     in addition that $L+L_0\le N$. Assume also that, for some middle-word length
     $m$, the simultaneous tuples $w\mapsto(A^1_w,\ldots,A^g_w)$ with
-    $w\in\Fin{d}^m$ span the full product algebra $\prod_j\MN{D_j}$. Suppose
-    that for every
+    $w\in\Fin{d}^m$ span the full product algebra $\prod_j\MN{D_j}$. Assume
+    further that, for every
     \[
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -1123,6 +1123,61 @@ in both cases.
     which gives the periodic-chain constraint for each block.
 \end{proof}
 
+\begin{lemma}[Trace decompositions give periodic single-block states]
+    \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:block_diagonal_boundary_component_trace_decomposition_injective}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
+    addition that $L+L_0\le N$. Assume also that, for some middle-word length
+    $m$, the simultaneous tuples $w\mapsto(A^1_w,\ldots,A^g_w)$ with
+    $w\in\Fin{d}^m$ span the full product algebra $\prod_j\MN{D_j}$. Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right).
+    \]
+    Suppose that whenever
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+    \]
+    there are matrices $C^j_{i,\rho}$ such that, for every
+    boundary-crossing interval $i$, every complementary word $\rho$, every
+    wrapped word $\beta$, and every word $w$ of length $m$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    Then there are block-diagonal boundary conditions $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:bnt_block_diagonal_open_boundary_matrices,
+        lem:block_diagonal_boundary_component_trace_decomposition_injective}
+    By Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices} there are
+    matrices $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
+    \]
+    For this representation, the assumed trace decompositions give matrices
+    $C^j_{i,\rho}$. Lemma~\ref{lem:block_diagonal_boundary_component_trace_decomposition_injective}
+    then gives, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{proof}
+
 \begin{lemma}[Matrix identities give periodic single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_complementary_identities}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1}
@@ -1382,7 +1437,10 @@ membership for the single-block states.
         lem:bnt_block_diagonal_boundary_representation_equality}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
-    in addition that $L+L_0\le N$. Suppose that for every
+    in addition that $L+L_0\le N$. Assume also that, for some middle-word length
+    $m$, the simultaneous tuples $w\mapsto(A^1_w,\ldots,A^g_w)$ with
+    $w\in\Fin{d}^m$ span the full product algebra $\prod_j\MN{D_j}$. Suppose
+    that for every
     \[
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
@@ -1419,6 +1477,66 @@ membership for the single-block states.
     and, for every $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
+    \]
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}
+    then gives
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =
+        \bigvee_j\mathcal G_{N,L}(A_j),
+    \]
+    and the internality of the sum of the $G_N(A_j)$.
+\end{proof}
+
+\begin{lemma}[Trace decompositions give equality in the finite range]
+    \label{lem:bnt_block_diagonal_trace_decomposition_equality}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition}
+    \leanok
+    \uses{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition,
+        lem:bnt_block_diagonal_boundary_representation_equality}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
+    in addition that $L+L_0\le N$. Suppose that for every
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+    \]
+    and every block-diagonal boundary representation
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+    \]
+    there are matrices $C^j_{i,\rho}$ such that, for every
+    boundary-crossing interval $i$, every complementary word $\rho$, every
+    wrapped word $\beta$, and every word $w$ of length $m$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    Then
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =
+        \bigvee_j\mathcal G_{N,L}(A_j),
+    \]
+    and the $N$-site ground spaces $G_N(A_j)=\mathcal G_{N,N}(A_j)$
+    have internal sum.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition,
+        lem:bnt_block_diagonal_boundary_representation_equality}
+    For each $\psi$,
+    Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
+    gives matrices $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
     \]
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}
     then gives


### PR DESCRIPTION
## Summary

- add a BNT boundary reformulation whose hypothesis is the PGVWC trace-decomposition equality for every boundary-crossing interval
- add the corresponding finite-range equality theorem from those trace decompositions
- add matching blueprint entries in the block-diagonal parent-Hamiltonian chapter

## Mathematical role

This does not derive the PGVWC trace equality. It packages the existing formal step showing that, once the trace decompositions

\[
  \sum_j \operatorname{tr}(A^j_\beta C^j_{i,\rho} A^j_w)
  =
  \sum_j \operatorname{tr}(((\mu_j^N X_j)A^j_\beta)A^j_\rho A^j_w)
\]

are available for each boundary-crossing interval, the corresponding block-diagonal boundary representation gives periodic single-block states and hence the finite-range equality.

This isolates the remaining source-faithful task for #2651: deriving those trace decompositions from the PGVWC07 \(C^j,D^j,E^j\) comparison in Theorem 12, proof lines 1436--1456.

Refs #2651.
Refs #190.
Refs #460.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

The affected Lean build reports the pre-existing `BoundaryClosingStripping.lean` sorry warning, not a new sorry in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation of an alternate hypothesis route; proofs delegate to existing lemmas and explicitly flag transitive unfaithful dependencies, with no runtime or security impact.
> 
> **Overview**
> Adds a **PGVWC trace-decomposition** route parallel to the existing complementary-word matrix-identity path for block-diagonal parent periodic ground spaces.
> 
> A new Lean module introduces two capstones: assuming the boundary-crossing **trace equalities** (with a finite word-span length `m`) for every block-diagonal boundary representation yields **periodic single-block membership** per block, and hence the finite-range equality \(\mathcal G_{N,L}(\bigoplus_j \mu_j A_j) = \bigvee_j \mathcal G_{N,L}(A_j)\) with internal \(N\)-site ground spaces. The proofs **compose** existing boundary and `blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective` lemmas; they **do not** derive the trace identity from PGVWC07 \(C^j,D^j,E^j\) (that gap is documented).
> 
> The root import list and blueprint chapter 13 gain matching lemmas (`lem:block_diagonal_boundary_periodic_components_from_trace_decomposition`, `lem:bnt_block_diagonal_trace_decomposition_equality`) with `\leanok` links to the new theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d04a2cd346d164d2ec95e71c1a30a99c9c15f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->