### PR TITLE
doc(blueprint): add the two-point correlator diagram to ch14

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -97,6 +97,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNPEPSStateContraction": "",
     "TNPEPSTorusGeometry": "",
     "TNPEPSVertexScalarBalance": "",
+    "TNTwoPointCorrelator": "",
 }
 
 

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -46,6 +46,9 @@ their spectral decomposition, and quantitative bounds on decay rates.
     \]
     Equivalently: insert $X$ at site $0$, propagate by $\E_A^n$, then insert
     $Y$ and take the trace.
+    \begin{center}
+        \TNTwoPointCorrelator
+    \end{center}
 \end{definition}
 
 \begin{definition}[Connected correlator]\label{def:connected_correlator}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1234,4 +1234,23 @@
     \end{tikzpicture}%
 }
 
+% Two-point correlator <X_0 Y_n> = tr(Y E_A^n(X rho^R)): on the transfer-map
+% (M_D) line, start from the fixed point rho^R, insert X, propagate by n copies
+% of the transfer map E_A, insert Y, and close the line by the trace.
+\newcommand{\TNTwoPointCorrelator}{%
+    \begin{tikzpicture}[tn picture]
+        \node[draw, fill=white, inner sep=1.6pt] (coR) at (0,0) {$\rho^R$};
+        \TN@opdot{coX}{(1.05,0)}
+        \node[draw, fill=white, inner sep=2pt] (coE) at (2.3,0) {$\E_A^n$};
+        \TN@opdot{coY}{(3.55,0)}
+        \draw[tn leg] (coR.east) -- (coX.west);
+        \draw[tn leg] (coX.east) -- (coE.west);
+        \draw[tn leg] (coE.east) -- (coY.west);
+        \node at (1.05,0.28) {$X$};
+        \node at (3.55,0.28) {$Y$};
+        \draw[tn leg] (coY.east) -- (4.1,0) -- (4.1,-0.85) -- (-0.55,-0.85) -- (-0.55,0) -- (coR.west);
+        \node at (1.8,-1.08) {$\tr$};
+    \end{tikzpicture}%
+}
+
 \makeatother

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -66,3 +66,6 @@ name: TNPEPSLatticeState TNPEPSLocalTensorStar TNPEPSVertexInjectivityMap
 
 name: TNPEPSStateContraction TNPEPSTorusGeometry TNPEPSVertexScalarBalance
 {{ obj.tn_svg_html }}
+
+name: TNTwoPointCorrelator
+{{ obj.tn_svg_html }}


### PR DESCRIPTION
## Summary

Chapter 14 (decay of correlations) defines the two-point expectation `⟨X₀Yₙ⟩ = tr(Y·E_A^n(Xρ^R))` and already describes its diagram in words ("insert X at site 0, propagate by E_A^n, then insert Y and take the trace") — but had no figure. This adds it: on the transfer-map line, the fixed point `ρ^R`, the `X` insertion, `n` copies of the transfer map `E_A`, the `Y` insertion, and the trace closure.

The macro is registered in `Packages/tn_diagrams.py` (`_DIAGRAM_ARGS`) and the jinja template so the arity-sync guard passes (59 registrations); the blueprint PDF builds clean. Independent of #2839 (channel figures); the two touch `macros/tn_print.tex` in the same trailing region, so whichever merges second may need a trivial keep-both resolution there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram plumbing only; no Lean or runtime behavior changes.
> 
> **Overview**
> Adds a **figure** for the two-point expectation ⟨X₀Yₙ⟩ = tr(Y E_A^n(Xρ^R)) in Chapter 14, matching the prose (“ρ^R → X → E_A^n → Y → trace” on the transfer-map line).
> 
> Introduces the zero-argument TikZ macro `\TNTwoPointCorrelator` in `macros/tn_print.tex`, registers it in `Packages/tn_diagrams.py` and `TensorNetworkDiagrams.jinja2s` so PDF and web blueprints stay in sync with the arity/template guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb9a47619346718df60410b3f43e7392fe591c3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->