### PR TITLE
feat(MPS/ParentHamiltonian): wire L2+L3 into the boundary-closing theorem (reduce sorry to hComm)

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -291,7 +291,8 @@ boundary-restriction equality lemma
 `boundary_restrictions_eq_of_commutes_and_one_sided` and the block-injective
 commutation lemma
 `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` reduce the whole
-boundary-closing step to this single commutation obligation. Documented in
+boundary-closing step to this single commutation obligation, which is the
+transitive dependency for the coordinate consequences below. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 block matrix equation (`wrapping_window_matEq_block`) and discharge `hComm` via
 the block-injective commutation lemma, as recorded in

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -295,7 +295,7 @@ boundary-closing step to this single commutation obligation. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 block matrix equation (`wrapping_window_matEq_block`) and discharge `hComm` via
 the block-injective commutation lemma, as recorded in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in issue #2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -412,7 +412,8 @@ open the block-window equation that should produce that commutation identity.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the block-window equation, discharge the one-site
 commutation identity by the block-injective commutation lemma, and reprove this
-theorem without the unfaithful dependency; tracked in issue #2405.
+theorem without the unfaithful dependency, as recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 
 The comparison is derived from the boundary-closing restriction equality
 \[
@@ -479,7 +480,8 @@ block-window equation that should produce that commutation identity. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the block-window equation, discharge the one-site commutation identity by the
 block-injective commutation lemma, and reprove this theorem without the
-unfaithful dependency; tracked in issue #2405. -/
+unfaithful dependency, as recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -542,7 +544,8 @@ block-window equation that should produce that commutation identity. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the block-window equation, discharge the one-site commutation identity by the
 block-injective commutation lemma, and reprove this theorem without the
-unfaithful dependency; tracked in issue #2405. -/
+unfaithful dependency, as recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -287,12 +287,15 @@ for all boundary letters \(\eta\) and physical letters \(j\).
 boundary matrix `X` commutes with every one-site matrix `A j`), which is the
 block matrix equation keystone for the boundary-closing argument of
 arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
-`boundary_restrictions_eq_of_commutes_and_one_sided` (L3) and
-`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (L2) reduce the
-whole boundary-closing step to this single `hComm` obligation. Documented in
+boundary-restriction equality lemma
+`boundary_restrictions_eq_of_commutes_and_one_sided` and the block-injective
+commutation lemma
+`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` reduce the whole
+boundary-closing step to this single commutation obligation. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 block matrix equation (`wrapping_window_matEq_block`) and discharge `hComm` via
-L2, as recorded in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+the block-injective commutation lemma, as recorded in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -328,8 +331,8 @@ theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
   obtain ⟨hWrap, hMirror⟩ :=
     closure_property_boundary_one_sided_products_of_groundSpaceMap
       hInj hL₀ hM hψX YAt hYAt μ
-  -- Remaining keystone (L1): X commutes with every one-site matrix `A j`. This is
-  -- discharged from `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (L2)
+  -- Remaining keystone: `X` commutes with every one-site matrix `A j`. This is
+  -- discharged from `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`
   -- once the block matrix equation is proved; see
   -- `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
   have hComm : ∀ k : Fin d, X * A k = A k * X := sorry

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -292,7 +292,7 @@ arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
 whole boundary-closing step to this single `hComm` obligation. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 block matrix equation (`wrapping_window_matEq_block`) and discharge `hComm` via
-L2; tracked in #2405. -/
+L2, as recorded in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -330,7 +330,8 @@ theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
       hInj hL₀ hM hψX YAt hYAt μ
   -- Remaining keystone (L1): X commutes with every one-site matrix `A j`. This is
   -- discharged from `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (L2)
-  -- once the block matrix equation is proved; see #2405.
+  -- once the block matrix equation is proved; see
+  -- `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
   have hComm : ∀ k : Fin d, X * A k = A k * X := sorry
   exact boundary_restrictions_eq_of_commutes_and_one_sided hInj hL₀
     (fun η => YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -295,7 +295,7 @@ boundary-closing step to this single commutation obligation, which is the
 transitive dependency for the coordinate consequences below. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 block matrix equation (`wrapping_window_matEq_block`) and discharge `hComm` via
-the block-injective commutation lemma; tracked in #2405. -/
+the block-injective commutation lemma; tracked in issue 2405. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -412,7 +412,7 @@ open the block-window equation that should produce that commutation identity.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the block-window equation, discharge the one-site
 commutation identity by the block-injective commutation lemma, and reprove this
-theorem without the unfaithful dependency; tracked in #2405.
+theorem without the unfaithful dependency; tracked in issue 2405.
 
 The comparison is derived from the boundary-closing restriction equality
 \[
@@ -479,7 +479,7 @@ block-window equation that should produce that commutation identity. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the block-window equation, discharge the one-site commutation identity by the
 block-injective commutation lemma, and reprove this theorem without the
-unfaithful dependency; tracked in #2405. -/
+unfaithful dependency; tracked in issue 2405. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -542,7 +542,7 @@ block-window equation that should produce that commutation identity. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the block-window equation, discharge the one-site commutation identity by the
 block-injective commutation lemma, and reprove this theorem without the
-unfaithful dependency; tracked in #2405. -/
+unfaithful dependency; tracked in issue 2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -295,7 +295,7 @@ boundary-closing step to this single commutation obligation. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 block matrix equation (`wrapping_window_matEq_block`) and discharge `hComm` via
 the block-injective commutation lemma, as recorded in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in issue #2405. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -406,12 +406,13 @@ boundary-closing comparison is
 
 **Unfaithful:** This proof currently relies on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`, whose proof
-contains the unproved boundary-closing coordinate comparison. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument.
+depends on the unproved one-site commutation identity for the boundary matrix.
+This deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving
+open the block-window equation that should produce that commutation identity.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the boundary-closing coordinate comparison and reprove this
-theorem without the unfaithful comparison.
+Elimination: prove the block-window equation, discharge the one-site
+commutation identity by the block-injective commutation lemma, and reprove this
+theorem without the unfaithful dependency; tracked in issue #2405.
 
 The comparison is derived from the boundary-closing restriction equality
 \[
@@ -470,13 +471,15 @@ remaining boundary-closing comparison is
 
 **Unfaithful:** This proof currently relies on
 `closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap`, which
-transitively uses the unproved boundary-closing coordinate comparison in
+transitively depends on the unproved one-site commutation identity for the
+boundary matrix in
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open the
+block-window equation that should produce that commutation identity. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison. -/
+the block-window equation, discharge the one-site commutation identity by the
+block-injective commutation lemma, and reprove this theorem without the
+unfaithful dependency; tracked in issue #2405. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -531,13 +534,15 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
 
 **Unfaithful:** This proof currently relies on
 `closure_property_mirror_left_word_products_of_groundSpaceMap`, which
-transitively uses the unproved boundary-closing coordinate comparison in
+transitively depends on the unproved one-site commutation identity for the
+boundary matrix in
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates
-from arXiv:2011.12127, Section IV.C, lines 2078--2079 by using the local
-coordinate form recorded for the paper's boundary-closing argument. Documented
+from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open the
+block-window equation that should produce that commutation identity. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
-the boundary-closing coordinate comparison and reprove this theorem without the
-unfaithful comparison. -/
+the block-window equation, discharge the one-site commutation identity by the
+block-injective commutation lemma, and reprove this theorem without the
+unfaithful dependency; tracked in issue #2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -295,8 +295,7 @@ boundary-closing step to this single commutation obligation, which is the
 transitive dependency for the coordinate consequences below. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 block matrix equation (`wrapping_window_matEq_block`) and discharge `hComm` via
-the block-injective commutation lemma, as recorded in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+the block-injective commutation lemma; tracked in #2405. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -413,8 +412,7 @@ open the block-window equation that should produce that commutation identity.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the block-window equation, discharge the one-site
 commutation identity by the block-injective commutation lemma, and reprove this
-theorem without the unfaithful dependency, as recorded in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
+theorem without the unfaithful dependency; tracked in #2405.
 
 The comparison is derived from the boundary-closing restriction equality
 \[
@@ -481,8 +479,7 @@ block-window equation that should produce that commutation identity. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the block-window equation, discharge the one-site commutation identity by the
 block-injective commutation lemma, and reprove this theorem without the
-unfaithful dependency, as recorded in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+unfaithful dependency; tracked in #2405. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -545,8 +542,7 @@ block-window equation that should produce that commutation identity. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove
 the block-window equation, discharge the one-site commutation identity by the
 block-injective commutation lemma, and reprove this theorem without the
-unfaithful dependency, as recorded in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+unfaithful dependency; tracked in #2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -471,8 +471,8 @@ remaining boundary-closing comparison is
   A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr).
 \]
 
-**Unfaithful:** This proof currently relies on
-`closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap`, which
+**Unfaithful:** This proof uses
+`closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap`; that theorem
 transitively depends on the unproved one-site commutation identity for the
 boundary matrix in
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This deviates

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 import TNLean.MPS.ParentHamiltonian.BoundaryStripping
+import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
 
 /-!
 # Stripping reductions for the closing boundary
@@ -282,14 +283,16 @@ boundary product comparison
 \]
 for all boundary letters \(\eta\) and physical letters \(j\).
 
-**Unfaithful:** This proof currently relies on the unproved coordinate
-comparison identifying the two boundary-closing cyclic restrictions, which
-deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by replacing
-the paper's diagrammatic boundary-closing argument with a local coordinate
-equality. Documented in
+**Unfaithful:** This proof relies on the unproved commutation `hComm` (the
+boundary matrix `X` commutes with every one-site matrix `A j`), which is the
+block matrix equation keystone for the boundary-closing argument of
+arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
+`boundary_restrictions_eq_of_commutes_and_one_sided` (L3) and
+`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (L2) reduce the
+whole boundary-closing step to this single `hComm` obligation. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
-boundary-closing coordinate comparison from the source's
-inverting-and-growing-back argument and remove the `sorry`. -/
+block matrix equation (`wrapping_window_matEq_block`) and discharge `hComm` via
+L2; tracked in #2405. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -322,8 +325,17 @@ theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
           (mirrorMiddleBackground L₀ (M + 1) η μ) * A j by
     exact closure_property_boundary_restrictions_eq_of_first_products
       (A := A) hL₀ hM YAt hYAt μ hProd
-  intro η j
-  sorry
+  obtain ⟨hWrap, hMirror⟩ :=
+    closure_property_boundary_one_sided_products_of_groundSpaceMap
+      hInj hL₀ hM hψX YAt hYAt μ
+  -- Remaining keystone (L1): X commutes with every one-site matrix `A j`. This is
+  -- discharged from `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (L2)
+  -- once the block matrix equation is proved; see #2405.
+  have hComm : ∀ k : Fin d, X * A k = A k * X := sorry
+  exact boundary_restrictions_eq_of_commutes_and_one_sided hInj hL₀
+    (fun η => YAt ⟨M, by omega⟩ (wrappedMiddleBackground L₀ (M + 1) η μ))
+    (fun η => YAt ⟨M + 1 - L₀, by omega⟩ (mirrorMiddleBackground L₀ (M + 1) η μ))
+    μ hComm hWrap hMirror
 
 /-- Left-multiplied comparison of the two cyclic restriction coordinates from
 equality of the two boundary-closing restrictions.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -5,13 +5,9 @@ The results here compare the two boundary-crossing cyclic restrictions
 $\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)$ and
 $\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)$ of a chain ground
 state. Once the one-sided boundary products are known, equality of the two
-restrictions follows from the following commutation identity: for every physical
-letter $j$,
-\[
-    X A^j=A^jX.
-\]
-The remaining boundary-closing step is to derive
-these identities from the block-window equation.
+restrictions follows from the commutation identity $XA^j=A^jX$ for every
+physical letter $j$. The remaining boundary-closing step is to derive these
+identities from the block-window equation.
 
 \begin{lemma}[Boundary matrix commutation from a block-window equation]
     \label{lem:boundary_matrix_commutes_block_window}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -5,11 +5,12 @@ The results here compare the two boundary-crossing cyclic restrictions
 $\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)$ and
 $\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)$ of a chain ground
 state. Once the one-sided boundary products are known, equality of the two
-restrictions follows from the commutation identities
+restrictions follows from the following commutation identity: for every physical
+letter $j$,
 \[
     X A^j=A^jX
 \]
-for all physical letters $j$. The remaining boundary-closing step is to derive
+The remaining boundary-closing step is to derive
 these identities from the block-window equation.
 
 \begin{lemma}[Boundary matrix commutation from a block-window equation]
@@ -804,11 +805,12 @@ these identities from the block-window equation.
         \qquad
         XA^jA^\mu=A^jY_{M+1-L_0}(\tau^-_\eta(\mu)).
     \]
-    The remaining obligation is the commutation identity
+    The remaining obligation is, for every physical letter $k$, the commutation
+    identity
     \[
         XA^k=A^kX
     \]
-    for every physical letter $k$. Assuming this identity,
+    Assuming this identity,
     Lemma~\ref{lem:boundary_restrictions_from_commutation_one_sided_products}
     gives
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -4,9 +4,13 @@
 The results here compare the two boundary-crossing cyclic restrictions
 $\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)$ and
 $\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)$ of a chain ground
-state, reducing their agreement, the boundary-closing step that identifies the
-two boundary witnesses $Y^+$ and $Y^-$, to a single padded coordinate comparison
-that remains the open input.
+state. Once the one-sided boundary products are known, equality of the two
+restrictions follows from the commutation identities
+\[
+    X A^j=A^jX
+\]
+for all physical letters $j$. The remaining boundary-closing step is to derive
+these identities from the block-window equation.
 
 \begin{lemma}[Boundary matrix commutation from a block-window equation]
     \label{lem:boundary_matrix_commutes_block_window}
@@ -760,10 +764,8 @@ that remains the open input.
     \leanok
     \uses{def:ground_space_map, rem:cyclic_window_operators,
         lem:closure_property_boundary_one_sided_products_ground_space_map,
-        lem:closure_property_opposite_boundary_comparison_from_left_words,
-        lem:closure_property_opposite_boundary_comparison_from_right_words,
-        lem:closed_boundary_restrictions_from_first_letter_products,
-        thm:closure_property_boundary_restrictions_ground_space_map_left_words}
+        lem:boundary_restrictions_from_commutation_one_sided_products,
+        lem:closed_boundary_restrictions_from_first_letter_products}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0\le M$, and
     $D\ge1$. Let
     \[
@@ -795,21 +797,31 @@ that remains the open input.
 \begin{proof}
     \notready
     Choose matrices $Y_i(\tau)$ representing the length-$(L_0+1)$
-    restrictions. It remains to establish the following coordinate comparison:
-    for every boundary letter $\eta$, physical letter $j$, and length-$L_0$
-    words $\alpha,\sigma$,
+    restrictions. The one-sided boundary-product lemma gives, for every
+    boundary letter $\eta$ and physical letter $j$,
     \[
-        A^\alpha
-        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
-        =
-        A^\alpha
-        \left(A^\mu A^jXA^\sigma\right).
+        Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX,
+        \qquad
+        XA^jA^\mu=A^jY_{M+1-L_0}(\tau^-_\eta(\mu)).
     \]
-    Theorem~\ref{thm:closure_property_boundary_restrictions_ground_space_map_left_words}
-    records that these equations imply the equality of the two restrictions.
-    The displayed left-multiplied family is the coordinate form of the
-    boundary-closing sentence in \cite[lines~2078--2079]{Cirac2021Matrix}.
-    The remaining mathematical gap is recorded in
+    The remaining obligation is the commutation identity
+    \[
+        XA^k=A^kX
+    \]
+    for every physical letter $k$. Assuming this identity,
+    Lemma~\ref{lem:boundary_restrictions_from_commutation_one_sided_products}
+    gives
+    \[
+        Y_M(\tau^+_\eta(\mu))A^j
+        =
+        Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
+    \]
+    Lemma~\ref{lem:closed_boundary_restrictions_from_first_letter_products}
+    then identifies the two cyclic restrictions. Thus the full boundary
+    restriction conclusion has been reduced to the commutation identity. The
+    derivation of that identity from the closing-boundary block equation is the
+    remaining part of the boundary-closing sentence in
+    \cite[lines~2078--2079]{Cirac2021Matrix}; it is recorded in
     \path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -8,7 +8,7 @@ state. Once the one-sided boundary products are known, equality of the two
 restrictions follows from the following commutation identity: for every physical
 letter $j$,
 \[
-    X A^j=A^jX
+    X A^j=A^jX.
 \]
 The remaining boundary-closing step is to derive
 these identities from the block-window equation.
@@ -808,7 +808,7 @@ these identities from the block-window equation.
     The remaining obligation is, for every physical letter $k$, the commutation
     identity
     \[
-        XA^k=A^kX
+        XA^k=A^kX.
     \]
     Assuming this identity,
     Lemma~\ref{lem:boundary_restrictions_from_commutation_one_sided_products}

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -175,16 +175,18 @@ and
 \path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:329 for the
 use of
 \path{MPSTensor.closure_property_boundary_one_sided_products_of_groundSpaceMap}.}
-The remaining hypothesis in this theorem is the commutation identity
+The remaining hypothesis in this theorem is the following commutation identity:
+for every physical letter \(k\),
 \[
   XA^k=A^kX
 \]
-for every physical letter \(k\). In the proof this hypothesis is named
-\path{hComm}; in the L1--L3 decomposition of the boundary-closing argument it
-is the L1 obligation.
+This is the one-site commutation step in the boundary-closing argument.
+\footnote{In the formal proof of
+\leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}
+this local hypothesis is named \texttt{hComm}.}
 
-Once this identity is available, the L3 lemma proves that the two witnesses have
-the same first-letter products:
+Once this identity is available, the boundary-restriction equality lemma proves
+that the two witnesses have the same first-letter products:
 \[
   W_\eta A^j=V_\eta A^j
 \]
@@ -198,31 +200,33 @@ the two cyclic restrictions
 Thus the equality of boundary restrictions is no longer the primitive open
 comparison: it is a checked consequence of the one-sided products and the
 commutation identity.\footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:105 for
-\path{MPSTensor.boundary_restrictions_eq_of_commutes_and_one_sided}, and
+\path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:134 for
+\leanid{MPSTensor.boundary_restrictions_eq_of_commutes_and_one_sided}, and
 \path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:336 for its
 use in
-\path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}.}
+\leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}.}
 
-The L2 lemma reduces the commutation identity itself to a block-window matrix
-equation. It states that, if \(A\) is \(L_0\)-block-injective and there are
-matrices \(Y_\nu\) such that, for every length-\(L_0\) word \(\alpha\) and
-every complementary word \(\nu\),
+The block-injective commutation lemma reduces the commutation identity itself
+to a block-window matrix equation. It states that, if \(A\) is
+\(L_0\)-block-injective and there are matrices \(Y_\nu\) such that, for every
+length-\(L_0\) word \(\alpha\) and every complementary word \(\nu\),
 \[
   XA^\alpha A^\nu=A^\alpha Y_\nu,
 \]
 then \(XA^k=A^kX\) for every physical letter \(k\).\footnote{Formal location:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:46 for
-\path{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}.}
+\leanid{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}.}
 The remaining mathematical task is therefore to derive this block-window
-equation from the closing-boundary local constraints. This is the object
-referred to in the Lean marker as \path{wrapping_window_matEq_block}. After that
-equation is proved, L2 supplies \path{hComm}, L3 supplies the equality of the
-two boundary restrictions, and the boundary-closing step follows.
+equation from the closing-boundary local constraints. After that equation is
+proved, the block-injective commutation lemma supplies the one-site commutation
+identity, the boundary-restriction equality lemma supplies the equality of the
+two boundary restrictions, and the boundary-closing step follows.\footnote{The
+Lean marker currently refers to the planned block-window equation as
+\texttt{wrapping\_window\_matEq\_block}.}
 
-The older coordinate comparison is still a useful way to recognize the same
-boundary phenomenon. For an \(N\)-site vector \(\psi\), the two restrictions are
-obtained from the two boundary-crossing words
+Equivalently, the same boundary phenomenon can be recognized in coordinate
+terms. For an \(N\)-site vector \(\psi\), the two restrictions are obtained from
+the two boundary-crossing words
 \[
   \tau^{+}_{\eta}(\mu)_i =
   \begin{cases}
@@ -236,11 +240,9 @@ obtained from the two boundary-crossing words
     \eta,      & \text{otherwise}.
   \end{cases}
 \]
-Earlier versions of this note described the missing step as a direct comparison
-of the two restrictions, or equivalently as a left-multiplied coordinate
-comparison after taking first-letter restrictions. That description is now
-superseded by the L2--L3 reduction above: the restriction comparison is a
-consequence once the L1 commutation identity \(XA^k=A^kX\) has been proved.
+The direct comparison of these two restrictions, and the left-multiplied
+coordinate comparison obtained after taking first-letter restrictions, are
+consequences of the one-site commutation identity \(XA^k=A^kX\).
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -177,17 +177,23 @@ and
 The remaining hypothesis in this theorem is the following commutation identity:
 for every physical letter \(k\),
 \[
-  XA^k=A^kX
+  XA^k=A^kX.
 \]
 This is the one-site commutation step in the boundary-closing argument.
 \footnote{In the formal proof of
 \leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}
 this local hypothesis is named \texttt{hComm}.}
 
+For an \(N\)-site vector \(\psi\),
+\(\operatorname{Res}^{\tau}_{i,L}(\psi)\) denotes the \(L\)-site vector whose
+\(\sigma\)-coordinate is the coordinate of \(\psi\) obtained by placing
+\(\sigma\) in the cyclic window of length \(L\) beginning at \(i\), and by
+using \(\tau\) on the remaining sites.
+
 Once this identity is available, the boundary-restriction equality lemma proves
 that the two witnesses have the same first-letter products:
 \[
-  W_\eta A^j=V_\eta A^j
+  W_\eta A^j=V_\eta A^j,
 \]
 for every \(\eta\) and \(j\). The first-letter restriction lemma then identifies
 the two cyclic restrictions

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -169,10 +169,10 @@ one-sided boundary-product lemma gives, for every physical letter \(j\),
 Here \(W_\eta\) is the witness for the last-site boundary restriction and
 \(V_\eta\) is the witness for the opposite boundary-crossing restriction.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:296 for
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:299 for
 \path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
 and
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:329 for the
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:332 for the
 use of
 \path{MPSTensor.closure_property_boundary_one_sided_products_of_groundSpaceMap}.}
 The remaining hypothesis in this theorem is the following commutation identity:
@@ -202,7 +202,7 @@ comparison: it is a checked consequence of the one-sided products and the
 commutation identity.\footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:134 for
 \leanid{MPSTensor.boundary_restrictions_eq_of_commutes_and_one_sided}, and
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:336 for its
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:339 for its
 use in
 \leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}.}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -172,8 +172,7 @@ Here \(W_\eta\) is the witness for the last-site boundary restriction and
 \path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:299 for
 \path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
 and
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:332 for the
-use of
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:332 for the use of
 \path{MPSTensor.closure_property_boundary_one_sided_products_of_groundSpaceMap}.}
 The remaining hypothesis in this theorem is the following commutation identity:
 for every physical letter \(k\),

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -129,40 +129,18 @@ through the older single-site intersection lemma.
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:328 for
 \path{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}.}
 
-\section{The remaining comparison}
+\section{The remaining commutation identity}
 
 After the open-chain step, a periodic-chain ground state can be written with an
 open-chain boundary matrix $X$. The point left to prove is that the cyclic
-length-$L_0+1$ constraints force $X$ to be scalar, and hence that the state is
-in \(\mathbb C\,\Omega_N(A)\). The current formalization records the two one-sided
-cyclic-window compatibilities at the boundary. In schematic notation, the
-last-site cyclic window used in closing the boundary gives
-\[
-  C^+_{\tau} A_j X = Y^+_{\tau} A_j,
-\]
-while the opposite cyclic window used in closing the boundary gives
-\[
-  X A_j C^-_{\tau} = A_j Y^-_{\tau}.
-\]
-Here $\tau$ denotes the complementary boundary word exposed by such a cyclic
-window, equivalently the physical labels outside the open middle interval. The
-cyclic-window lemmas in the formalization produce analogous complement-word products,
-written schematically as $C^+_{\tau}$ and $C^-_{\tau}$, but the two products are
-obtained with different orientations and indexings. The two formulas are both
-valid; what is missing is a comparison that identifies the two boundary
-matrices after the complementary sites have been indexed by the same word.
-\footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:441 for
-\path{MPSTensor.chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective},
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:402 for the wrapped
-compatibility, and
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:450 for the mirror
-compatibility.}
+length-$L_0+1$ constraints force $X$ to commute with the one-site matrices of
+$A$; block injectivity then forces $X$ to be scalar, and hence the state lies in
+\(\mathbb C\,\Omega_N(A)\).
 
-This is why the open-chain containment cannot simply be reversed.  Let
+This is why the open-chain containment cannot simply be reversed. Let
 \(\Gamma_N(X)\) denote the length-\(N\) open-chain vector
-\(\Gamma_N(X)_\omega=\tr(A^\omega X)\).  A vector
-\(\Gamma_N(X)\in G_N(A)\) need not lie in the cyclic-chain ground space.  For a
+\(\Gamma_N(X)_\omega=\tr(A^\omega X)\). A vector
+\(\Gamma_N(X)\in G_N(A)\) need not lie in the cyclic-chain ground space. For a
 boundary-crossing window, the restriction has trace coefficients with \(X\)
 between the two parts of the window word,
 \begin{align}
@@ -176,39 +154,75 @@ written as
     A^{\omega_{\mathrm{head}}}Y_\rho\right)
 \end{align}
 for a matrix \(Y_\rho\) depending only on the complementary boundary condition.
-The closure-property comparison is precisely what supplies this missing
-movement of \(X\) through the boundary-crossing word.
+The closure-property comparison supplies the missing movement of \(X\) through
+the boundary-crossing word.
 
-The last algebraic step needs the two one-sided identities to use the same matrix.
-There should be a word $\mu$ on the complementary sites and matrices $Y_\mu$
-such that, for every physical letter $j$,
+The current formal reduction isolates this movement as the one-site commutation
+identity. Fix a complementary word \(\mu\) and a boundary letter \(\eta\). After
+choosing witnesses for the two boundary-crossing restrictions, the verified
+one-sided boundary-product lemma gives, for every physical letter \(j\),
 \[
-  A^\mu A_j X = Y_\mu A_j,
+  W_\eta A^j=A^\mu A^jX,
   \qquad
-  X A_j A^\mu = A_j Y_\mu.
+  XA^jA^\mu=A^jV_\eta .
 \]
-Once these two identities use the same complementary-site word $\mu$ and the
-same matrix $Y_\mu$, the algebraic lemma in the formalization proves that $X$
-commutes with all
-words of a fixed positive length; block injectivity then promotes this to
-commutation with the full matrix algebra, so $X$ is scalar.
+Here \(W_\eta\) is the witness for the last-site boundary restriction and
+\(V_\eta\) is the witness for the opposite boundary-crossing restriction.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/WrappingWindow.lean}:645 for
-\path{MPSTensor.commutes_words_of_two_sided_middle_compatibility}, and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:554 for
-\path{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_compatibility}.}
-The remaining point is the comparison between the two boundary-crossing
-outputs: one must reindex their complementary words in the same way and identify
-the two boundary matrices as the same matrix $Y_\mu$. For an $N$-site vector
-$\psi$, write
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:296 for
+\path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
+and
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:329 for the
+use of
+\path{MPSTensor.closure_property_boundary_one_sided_products_of_groundSpaceMap}.}
+The remaining hypothesis in this theorem is the commutation identity
 \[
-  \operatorname{Res}^{\tau}_{i,L}(\psi)(\sigma)
-  =
-  \psi\!\left(\operatorname{replaceWindow}_{L,i}(\sigma,\tau)\right),
+  XA^k=A^kX
 \]
-where the cyclic window of length $L$ beginning at $i$ is fixed to the word
-$\tau$, and $\sigma$ labels the remaining $N-L$ sites. With $N=M+1$, the two
-boundary-crossing words are
+for every physical letter \(k\). In the proof this hypothesis is named
+\path{hComm}; in the L1--L3 decomposition of the boundary-closing argument it
+is the L1 obligation.
+
+Once this identity is available, the L3 lemma proves that the two witnesses have
+the same first-letter products:
+\[
+  W_\eta A^j=V_\eta A^j
+\]
+for every \(\eta\) and \(j\). The first-letter restriction lemma then identifies
+the two cyclic restrictions
+\[
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
+  =
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
+\]
+Thus the equality of boundary restrictions is no longer the primitive open
+comparison: it is a checked consequence of the one-sided products and the
+commutation identity.\footnote{Formal locations:
+\path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:105 for
+\path{MPSTensor.boundary_restrictions_eq_of_commutes_and_one_sided}, and
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:336 for its
+use in
+\path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}.}
+
+The L2 lemma reduces the commutation identity itself to a block-window matrix
+equation. It states that, if \(A\) is \(L_0\)-block-injective and there are
+matrices \(Y_\nu\) such that, for every length-\(L_0\) word \(\alpha\) and
+every complementary word \(\nu\),
+\[
+  XA^\alpha A^\nu=A^\alpha Y_\nu,
+\]
+then \(XA^k=A^kX\) for every physical letter \(k\).\footnote{Formal location:
+\path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:46 for
+\path{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}.}
+The remaining mathematical task is therefore to derive this block-window
+equation from the closing-boundary local constraints. This is the object
+referred to in the Lean marker as \path{wrapping_window_matEq_block}. After that
+equation is proved, L2 supplies \path{hComm}, L3 supplies the equality of the
+two boundary restrictions, and the boundary-closing step follows.
+
+The older coordinate comparison is still a useful way to recognize the same
+boundary phenomenon. For an \(N\)-site vector \(\psi\), the two restrictions are
+obtained from the two boundary-crossing words
 \[
   \tau^{+}_{\eta}(\mu)_i =
   \begin{cases}
@@ -222,106 +236,11 @@ boundary-crossing words are
     \eta,      & \text{otherwise}.
   \end{cases}
 \]
-Equivalently, when closing the boundaries, the closure property should identify
-the two restrictions
-\[
-  \operatorname{Res}^{\tau^+_{\eta}(\mu)}_{M,L_0+1}(\psi)
-  =
-  \operatorname{Res}^{\tau^-_{\eta}(\mu)}_{M+1-L_0,L_0+1}(\psi),
-\]
-before taking the first-site restriction $\sigma_1=j$.\footnote{For
-traceability, this is the mathematical content recorded in
-\href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}.}
-
-The present reduction isolates a smaller coordinate identity. Here
-\(\Gamma_L(Y)\) denotes the length-\(L\) open-chain MPS vector with boundary
-matrix \(Y\), namely
-\(\Gamma_L(Y)_\omega=\operatorname{tr}(A^\omega Y)\). Let
-\[
-  \begin{aligned}
-    \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
-    &=
-    \Gamma_{L_0+1}\!\left(Y_M(\tau^+_\eta(\mu))\right),\\
-    \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)
-    &=
-    \Gamma_{L_0+1}\!\left(Y_{M+1-L_0}(\tau^-_\eta(\mu))\right).
-  \end{aligned}
-\]
-The last-site boundary gives the one-sided equation
-\[
-  Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
-\]
-The cyclic local ground-space conditions are that for all \(i\) and \(\tau\),
-\[
-  \operatorname{Res}^{\tau}_{i,L_0+1}(\psi)\in G_{L_0+1}(A),
-\]
-and the boundary-closing step is reduced to equality of the two cyclic
-restrictions:
-\[
-  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
-  =
-  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
-\]
-The source does not display this equality. It is the current remaining
-comparison in
-\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}.\footnote{Formal
-declaration:
-\leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}
-in \doclink{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping}.} Taking
-first-letter restrictions gives, for every physical letter \(j\),
-\[
-  Y_M(\tau^+_\eta(\mu))A^j
-  =
-  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
-\]
-Multiplying on the left by \(A^\alpha\) and on the right by \(A^\sigma\)
-then gives, for words \(\alpha,\sigma\) of length \(L_0\),
-\[
-  A^\alpha
-  \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
-  =
-  A^\alpha
-  \left(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\right).
-\]
-After substituting the one-sided equation above, this gives the previously
-isolated left-multiplied family
-\[
-  A^\alpha
-  \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
-  =
-  A^\alpha
-  \left(A^\mu A^jX A^\sigma\right).
-\]
-The converse implication needed by the formal proof is also recorded: if this
-left-multiplied family holds for all \(\eta,j,\alpha,\sigma\), then the
-restriction comparison follows.\footnote{Formal declaration:
-\leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words}
-in \doclink{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping}.}
-Equivalently, after block-injective cancellation this yields, for every word
-\(\sigma\) of length \(L_0\),
-\[
-  Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
-  =
-  A^\mu A^jX A^\sigma .
-\]
-The same comparison gives the auxiliary boundary conditions used later in the
-boundary-closing argument: for every \(j\) and \(\sigma\), there are
-\(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) satisfying, for every
-complementary position \(k\),
-\[
-  \rho^+_{j,\sigma}(k+L_0)=\mu_k,
-  \qquad
-  \rho^-_{j,\sigma}(k+1)=\mu_k,
-\]
-and
-\[
-  Y_M(\rho^+_{j,\sigma})A^jA^\sigma
-  =
-  Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
-\]
-Thus the older right-multiplied identity is no longer the residual formal
-statement; it follows from the comparison of the two cyclic restrictions and
-the last-site one-sided equation.
+Earlier versions of this note described the missing step as a direct comparison
+of the two restrictions, or equivalently as a left-multiplied coordinate
+comparison after taking first-letter restrictions. That description is now
+superseded by the L2--L3 reduction above: the restriction comparison is a
+consequence once the L1 commutation identity \(XA^k=A^kX\) has been proved.
 
 \section{Conclusion}
 
@@ -330,19 +249,17 @@ compressed source proof and the available formal lemmas; it is not a
 source-error claim. The cited Cirac--Perez-Garcia--Schuch--Verstraete 2021
 argument is not refuted. The source compresses two mathematical steps which the
 formalization must keep separate: the $B$-region inverting and growing-back
-open-chain range reduction, and the comparison of the boundary matrices arising
-from the two boundary-crossing supports used in closing the boundary. The
-current open form of the latter comparison is the displayed equality of the two
-boundary-closing cyclic restrictions. The left-multiplied matrix comparison and
-the right-multiplied identity with \(A^\mu A^jX\) are derived consequences once
-that equality is available.
+open-chain range reduction, and the movement of the open-chain boundary matrix
+through the boundary-crossing word when closing the periodic boundary.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.
-The last mathematical point is the comparison of the two boundary matrices at
-the periodic boundary. If that comparison is proved, the difference is only expository. If it
-reveals an additional mathematical obstruction, the conclusion should be revised
-accordingly.
+The last mathematical point is the commutation identity \(XA^k=A^kX\) for every
+physical letter \(k\). The present formalization proves that the full
+boundary-restriction equality follows from this identity and the one-sided
+boundary products. If the block-window equation proves the commutation identity,
+the remaining difference is only expository. If it reveals an additional
+mathematical obstruction, the conclusion should be revised accordingly.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Stacked on #2840 (L3). Wires the two verified bridge lemmas into the actual boundary-closing theorem `closure_property_boundary_restrictions_eq_of_groundSpaceMap`, **collapsing its `sorry` from the geometric `hProd` down to a single clean commutation obligation `hComm`**.

The `hProd` sorry is replaced by `boundary_restrictions_eq_of_commutes_and_one_sided` (L3) applied to the existing `closure_property_boundary_one_sided_products_of_groundSpaceMap` (which supplies `hWrap`/`hMirror`). The only remaining `sorry` is now:
```
hComm : ∀ k : Fin d, X * A k = A k * X
```
— X commutes with every one-site matrix, i.e. the **block matrix equation keystone (L1)**, which `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (L2, merged in #2820) discharges once L1 is proved.

## Effect

- The sorry count is unchanged (still 1) but it now sits at the precise, clean X-commutation statement rather than the opaque boundary-restriction equality, with L2 and L3 (both CI-verified) connecting it to the conclusion.
- The theorem's `**Unfaithful:**` marker is updated to name `hComm`/L1 as the deviation and adds the `tracked in #2405` handle.
- Adds `import BoundaryMatrixBlock` (no import cycle: that file only imports `WrappingWindow`).

The remaining work to eliminate the sorry entirely is L1 (`wrapping_window_matEq_block`), fully specified on #2405.

Note: stacked on #2840; will retarget to `main` automatically once #2840 merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure and documentation only; no auth, runtime, or API surface changes beyond Lean imports and docstrings.
> 
> **Overview**
> **Boundary-closing theorem** `closure_property_boundary_restrictions_eq_of_groundSpaceMap` now routes through **`BoundaryMatrixBlock`**: it imports that module, pulls **one-sided** boundary products from `closure_property_boundary_one_sided_products_of_groundSpaceMap`, and closes the restriction step with **`boundary_restrictions_eq_of_commutes_and_one_sided`** instead of a direct `sorry` on the first-letter product `hProd`.
> 
> The lone remaining proof hole is **`hComm`** (`∀ k, X * A k = A k * X`), documented as the block-window / L1 keystone (issue 2405). **Unfaithful** markers and downstream theorems are retargeted from “unproved restriction equality” to this **one-site commutation** dependency.
> 
> **Blueprint** (`ch13_parent_hamiltonian_normal_closing.tex`) and **`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`** are rewritten so the open gap is **commutation** (and deriving it from the block-window equation), not equality of the two cyclic restrictions as the primitive comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f8f9197e5d3fc024d37fed6e9d4e8b3dfaed68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->