### PR TITLE
feat(MPDO): tp-CP map API — identity and composition are Kraus-CPTP

### DIFF
--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -62,6 +62,45 @@ def IsKrausCPTP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [Deci
   ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
     (∀ X, S X = ∑ i, A i * X * (A i)ᴴ) ∧ (∑ i, (A i)ᴴ * A i = (1 : Matrix α α ℂ))
 
+/-- The identity map is trace-preserving completely positive (the single Kraus
+operator is the identity matrix). -/
+theorem isKrausCPTP_id {α : Type*} [Fintype α] [DecidableEq α] :
+    IsKrausCPTP (LinearMap.id : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) := by
+  refine ⟨1, fun _ => 1, ?_, ?_⟩
+  · intro X; simp
+  · simp
+
+/-- **Composition of trace-preserving completely positive maps is again
+trace-preserving completely positive.** If `T` has Kraus operators `Bⱼ` and `S`
+has Kraus operators `Aᵢ`, then `S ∘ T` has Kraus operators `Aᵢ Bⱼ`, and the
+resolution of identity for the composite follows from those of `S` and `T`:
+`∑ᵢⱼ (AᵢBⱼ)† (AᵢBⱼ) = ∑ⱼ Bⱼ† (∑ᵢ Aᵢ† Aᵢ) Bⱼ = ∑ⱼ Bⱼ† Bⱼ = I`. -/
+theorem isKrausCPTP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Fintype β]
+    [DecidableEq β] [Fintype γ] [DecidableEq γ]
+    {T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} {S : Matrix β β ℂ →ₗ[ℂ] Matrix γ γ ℂ}
+    (hT : IsKrausCPTP T) (hS : IsKrausCPTP S) : IsKrausCPTP (S ∘ₗ T) := by
+  obtain ⟨r, A, hA_form, hA_tp⟩ := hS
+  obtain ⟨s, B, hB_form, hB_tp⟩ := hT
+  refine ⟨r * s, fun k => A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2, ?_, ?_⟩
+  · intro X
+    rw [LinearMap.comp_apply, hB_form X, hA_form,
+      ← finProdFinEquiv.sum_comp (fun k => (A (finProdFinEquiv.symm k).1 *
+          B (finProdFinEquiv.symm k).2) * X *
+        (A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2)ᴴ)]
+    simp only [Equiv.symm_apply_apply, Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.conjTranspose_mul, Matrix.mul_assoc]
+  · rw [← finProdFinEquiv.sum_comp (fun k => (A (finProdFinEquiv.symm k).1 *
+        B (finProdFinEquiv.symm k).2)ᴴ *
+      (A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2))]
+    simp only [Equiv.symm_apply_apply, Fintype.sum_prod_type, Matrix.conjTranspose_mul]
+    rw [Finset.sum_comm, ← hB_tp]
+    refine Finset.sum_congr rfl (fun j _ => ?_)
+    have step : ∑ i : Fin r, (B j)ᴴ * (A i)ᴴ * (A i * B j)
+        = (B j)ᴴ * ((∑ i : Fin r, (A i)ᴴ * A i) * B j) := by
+      simp only [Matrix.sum_mul, Matrix.mul_sum, Matrix.mul_assoc]
+    rw [step, hA_tp, Matrix.one_mul]
+
 namespace MPOTensor
 
 variable {d D : ℕ}

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -74,7 +74,7 @@ theorem isKrausCPTP_id {α : Type*} [Fintype α] [DecidableEq α] :
 trace-preserving completely positive.** If `T` has Kraus operators `Bⱼ` and `S`
 has Kraus operators `Aᵢ`, then `S ∘ T` has Kraus operators `Aᵢ Bⱼ`, and the
 resolution of identity for the composite follows from those of `S` and `T`:
-`∑ᵢⱼ (AᵢBⱼ)† (AᵢBⱼ) = ∑ⱼ Bⱼ† (∑ᵢ Aᵢ† Aᵢ) Bⱼ = ∑ⱼ Bⱼ† Bⱼ = I`. -/
+∑ᵢⱼ (AᵢBⱼ)† (AᵢBⱼ) = ∑ⱼ Bⱼ† (∑ᵢ Aᵢ† Aᵢ) Bⱼ = ∑ⱼ Bⱼ† Bⱼ = I. -/
 theorem isKrausCPTP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Fintype β]
     [DecidableEq β] [Fintype γ] [DecidableEq γ]
     {T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} {S : Matrix β β ℂ →ₗ[ℂ] Matrix γ γ ℂ}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -24,6 +24,43 @@
     need not agree.
 \end{definition}
 
+\begin{lemma}[Identity map is trace-preserving completely positive]
+    \label{lem:is_kraus_cptp_id}
+    \lean{isKrausCPTP_id}
+    \leanok
+    \uses{def:is_kraus_cptp}
+    The identity map $\mathrm{id}(X) = X$ is trace-preserving completely positive,
+    with single Kraus operator $A_0 = I$.
+\end{lemma}
+\begin{proof}
+    \leanok
+    Take $r = 1$, $A_0 = I$; then $\mathrm{id}(X) = I X I^\dagger = X$ and
+    $A_0^\dagger A_0 = I$.
+\end{proof}
+
+\begin{lemma}[Composition of trace-preserving completely positive maps]
+    \label{lem:is_kraus_cptp_comp}
+    \lean{isKrausCPTP_comp}
+    \leanok
+    \uses{def:is_kraus_cptp, lem:is_kraus_cptp_id}
+    The composition of two trace-preserving completely positive maps is again
+    trace-preserving completely positive. If $\mathcal{S}$ has Kraus operators
+    $A_i$ and $\mathcal{T}$ has Kraus operators $B_j$, then $\mathcal{S} \circ
+    \mathcal{T}$ has Kraus operators $A_i B_j$.
+\end{lemma}
+\begin{proof}
+    \leanok
+    The Kraus form of the composite is
+    $(\mathcal{S} \circ \mathcal{T})(X) = \sum_{i,j} (A_i B_j) X (A_i B_j)^\dagger$,
+    and the resolution of identity follows from those of $\mathcal{S}$ and
+    $\mathcal{T}$:
+    \[
+        \sum_{i,j} (A_i B_j)^\dagger (A_i B_j)
+        = \sum_{j} B_j^\dagger \Bigl( \sum_{i} A_i^\dagger A_i \Bigr) B_j
+        = \sum_{j} B_j^\dagger B_j = I.
+    \]
+\end{proof}
+
 \begin{definition}[One- and two-site physical closure maps]
     \label{def:phys_close}
     \lean{MPOTensor.physClose1, MPOTensor.physClose2}


### PR DESCRIPTION
## Summary

First infrastructure toward the faithful Theorem 4.9 → `IsRFPViaTS` migration (scoped in `docs/paper-gaps/cpsv16_zcl_canonical_form_normalization.tex`). The `IsRFPViaTS` closure-map construction builds and composes trace-preserving completely positive maps; these are the two foundational closure properties, reusable across the channel/RFP development:

* `isKrausCPTP_id` — the identity map is tp-CP (single Kraus operator = `I`).
* `isKrausCPTP_comp` — `IsKrausCPTP T → IsKrausCPTP S → IsKrausCPTP (S ∘ₗ T)`. Composite Kraus operators are `Aᵢ Bⱼ`; the resolution of identity follows: `∑ᵢⱼ (AᵢBⱼ)†(AᵢBⱼ) = ∑ⱼ Bⱼ†(∑ᵢ Aᵢ†Aᵢ)Bⱼ = ∑ⱼ Bⱼ†Bⱼ = I`.

Additive, `sorry`-free; leaves all existing code untouched.

## Verification

Verified locally against the exact `IsKrausCPTP` definition and mathlib in a standalone file under the file's `open scoped Matrix BigOperators` context (`lake env lean`, exit 0). Note: matrix multiplication across dimensions needs the matrix-specific `Matrix.sum_mul`/`Matrix.mul_sum` (not the generic `Finset.*`), which the proof uses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and blueprint text only; no behavior changes outside new lemmas on matrix linear maps.
> 
> **Overview**
> Adds foundational **Kraus tp-CP** closure lemmas next to `IsKrausCPTP` in `RFPViaTS.lean`, aimed at later `IsRFPViaTS` / Theorem 4.9 work.
> 
> **`isKrausCPTP_id`** shows `LinearMap.id` is Kraus-CPTP with a single Kraus operator `I`. **`isKrausCPTP_comp`** shows Kraus-CPTP is closed under `∘ₗ`: composite Kraus operators are `Aᵢ Bⱼ`, with trace preservation from the factor resolutions of identity. The blueprint chapter gains matching lemmas `lem:is_kraus_cptp_id` and `lem:is_kraus_cptp_comp` linked to the Lean proofs.
> 
> Existing definitions and downstream code are unchanged; proofs are complete (no `sorry`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c6feb2ab8d635311552ef36233991b7acb8b833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->