### PR TITLE
doc(blueprint): illustrate the single-block gauge conjugation in ch03

### DIFF
--- a/blueprint/src/chapter/ch03_single.tex
+++ b/blueprint/src/chapter/ch03_single.tex
@@ -220,7 +220,12 @@ nonvanishing of~$T$, which the final theorem combines into the gauge~$X$.
     \uses{def:injective, def:same_mpv, def:gauge_equiv}
     Let $A$ be an injective MPS tensor and $B$ a tensor of the same bond
     dimension. If $A$ and $B$ generate the same matrix-product vectors, then
-    there is $X \in \GL_{D}(\C)$ with $B^i = X A^i X^{-1}$ for all~$i$.
+    there is $X \in \GL_{D}(\C)$ with $B^i = X A^i X^{-1}$ for all~$i$. In
+    tensor-network notation the gauge conjugates the local tensor on its virtual
+    legs, with the physical index~$i$ on the upper leg:
+    \begin{center}
+        \TNGaugeConjugation{X}{i}{X^{-1}}
+    \end{center}
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
Chapter 3 (single-block Fundamental Theorem) concludes `B^i = X A^i X⁻¹` but had no figure. This adds the existing `\TNGaugeConjugation` diagram showing the gauge acting by conjugation on each local tensor.

Reuses an already-registered macro, so this touches only `ch03_single.tex` — independent of the in-flight figure PRs #2839/#2844 (no `tn_print.tex` change). Blueprint PDF builds clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX in the blueprint chapter; reuses an existing diagram macro with no logic or build-pipeline changes.
> 
> **Overview**
> The **Single-block Fundamental Theorem** in Chapter 3 now matches the narrative in Chapter 2: after stating \(B^i = X A^i X^{-1}\), the theorem text explains that in tensor-network notation the gauge acts by conjugation on the virtual legs (physical index \(i\) on the upper leg) and embeds the existing `\TNGaugeConjugation{X}{i}{X^{-1}}` figure.
> 
> Only `ch03_single.tex` is edited; no new macros or `tn_print` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05526e2e3929cb3fc4c6a138a0eb57bb87998e6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->