### PR TITLE
doc(blueprint): section normal MPS PEPS corollaries

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft.tex
+++ b/blueprint/src/chapter/ch24_peps_ft.tex
@@ -88,8 +88,9 @@ normal PEPS requires.
 Sections~\ref{sec:peps_normal_square} and~\ref{sec:peps_torus} supply the
 square-lattice and torus geometries.
 Section~\ref{sec:peps_normal_capstone} proves the Fundamental Theorem for
-normal PEPS, and Section~\ref{sec:peps_balanced_edge_scalars} records the scalar
-freedom that remains in the edge gauges.
+normal PEPS, Section~\ref{sec:peps_normal_mps} specializes it to matrix product
+states on the closed chain, and Section~\ref{sec:peps_balanced_edge_scalars}
+records the scalar freedom that remains in the edge gauges.
 
 \input{chapter/ch24_peps_ft_foundations}
 \input{chapter/ch24_peps_ft_edge_middle}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1228,18 +1228,19 @@ recorded in the route note
 \end{proof}
 
 Two remarks place these statements against \cite{Molnar2018NormalPEPS}.  The
-injective matrix product states of the source's opening section are the case
-$L = 1$, in which a single tensor already spans the matrix algebra; the
-corollaries above contain them at $n \ge 3$, with no separate argument needed.
-And the site-dependent results are stated for one physical dimension $d$ and one
-bond dimension $D$ around the chain, while the source places no restriction on
-the local dimensions; this uniform-dimension restriction is the only narrowing,
-recorded in the route note
-(\path{docs/paper-gaps/peps_normal_ft_section3_route.tex}).  The source's
-translation-symmetry corollary, that a non-translation-invariant injective chain
-whose state is translation invariant admits a translation-invariant description
-with the same bond dimension, is a statement about a single chain rather than a
-comparison of two, and is not part of this section.
+injective matrix product states of the opening section of
+\cite{Molnar2018NormalPEPS} are the case $L = 1$, in which a single tensor
+already spans the matrix algebra; the corollaries above contain them at
+$n \ge 3$, with no separate argument needed.  The site-dependent results are
+stated for one physical dimension $d$ and one bond dimension $D$ around the
+chain, while \cite{Molnar2018NormalPEPS} places no restriction on the local
+dimensions; this uniform-dimension restriction is the only narrowing.
+% Paper-gap note: docs/paper-gaps/peps_normal_ft_section3_route.tex
+The translation-symmetry corollary in \cite{Molnar2018NormalPEPS}, that a
+non-translation-invariant injective chain whose state is translation invariant
+admits a translation-invariant description with the same bond dimension, is a
+statement about a single chain rather than a comparison of two, and is not part
+of this section.
 
 \section{The vertex-injective case and the residual edge scalars}
 

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -293,19 +293,35 @@ $\tr(A^{i_1} \cdots A^{i_n})$.  The Fundamental Theorem for normal PEPS
 therefore specializes to matrix product states once its blocking hypotheses are
 read off the chain, and this section records the resulting statements,
 following the matrix-product-state corollaries of
-\cite[Section~3]{Molnar2018NormalPEPS} and the sharper system-size bound of its
-closing section \emph{Normal MPS: alternative proof}.
+\cite[Section~4]{Molnar2018NormalPEPS} and the sharper system-size bound in its
+closing part \emph{Normal MPS: alternative proof}.
 
 The development proceeds in four steps.  The closed chain is first identified
 with a cycle of tensors, and the normal blocking hypotheses are obtained from
 the injectivity of every arc of $L$ consecutive sites, giving the Fundamental
 Theorem for normal matrix product states on a ring of $n \ge 3L$ sites with one
 invertible gauge per bond.  The translation-invariant case then collapses the
-per-bond gauges to a single gauge $Z$ and a constant $\lambda$ with
-$\lambda^n = 1$.  An overlapping-window argument, the matrix-product-state form
-of the source's Lemma~5, lowers the system size from $n \ge 3L$ to the optimal
-$n \ge 2L + 1$.  Finally the same argument is run for site-dependent chains,
-one tensor per site, which is the setting in which the source states Lemma~5.
+per-bond gauges to one gauge $Z$ and one scalar $\lambda$, with the length-$n$
+trace identity forcing $\lambda^n = 1$.
+
+For the sharper bound, the matrix-product-state form of
+\cite[Lemma~5]{Molnar2018NormalPEPS} compares the $L + 1$ overlapping
+windows around a fixed bond.  If $C_j$ is the deformation of the $j$-th
+window, then for length-$L$ words $a$ and $b$ the family of
+consecutive-window trace identities strips to
+\[
+    C_0(a)\,B^b = B^a\,C_L(b),
+\]
+and hence to
+\[
+    C_0(a) = B^a X,
+    \qquad
+    C_L(b) = X B^b .
+\]
+This is the step that lowers the system size from $n \ge 3L$ to
+$n \ge 2L + 1$.  Finally the same argument is run for site-dependent
+chains, one tensor per site, which is the setting of
+\cite[Lemma~5]{Molnar2018NormalPEPS}.
 
 \subsection{Matrix product states on the closed chain}
 
@@ -487,10 +503,17 @@ one tensor per site, which is the setting in which the source states Lemma~5.
 \subsection{Translation-invariant matrix product states}
 
 When the same tensor sits at every site, the closed chain ties the per-bond
-gauges together: consecutive bonds carry proportional gauges, and going once
-around the chain forces the common ratio to be an $n$-th root of unity.  A single
-gauge $Z$ and a constant $\lambda$ with $\lambda^n = 1$ then capture all the
-freedom, which is the form in which the source states the corollary.
+gauges together.  If one gauge $Z$ and one scalar $\lambda$ satisfy
+$B^i = \lambda\,Z^{-1}A^iZ$ for every physical index $i$, then for a
+configuration $\sigma=(i_1,\ldots,i_n)$,
+\[
+    \tr(B^{i_1}\cdots B^{i_n})
+    = \lambda^n\,\tr(Z^{-1}A^{i_1}\cdots A^{i_n}Z)
+    = \lambda^n\,\tr(A^{i_1}\cdots A^{i_n}).
+\]
+Equality of the matrix product states therefore forces $\lambda^n = 1$.
+Thus $Z$ and $\lambda$ capture precisely the freedom in the
+translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
 
 \begin{corollary}[Fundamental Theorem for translation-invariant normal MPS
         on a closed chain, matrix form]%
@@ -674,12 +697,28 @@ freedom, which is the form in which the source states the corollary.
 \subsection{\texorpdfstring{The optimal system size $n \ge 2L + 1$}{The optimal system size n >= 2L+1}}
 
 The bound $n \ge 3L$ is not optimal.  A bond of the closed chain is straddled by
-the $L + 1$ overlapping windows of $L$ sites around it, and matching the
-deformations these windows carry already pins the virtual operation on the
-bond — the matrix-product-state form of the source's Lemma~5.  The lemmas below
-assemble that argument: block injectivity extends to every length, word products
-transport between equal-state chains, and the bond operator is extracted and
-shown to act by conjugation, lowering the system size to $n \ge 2L + 1$.
+the $L + 1$ overlapping windows of $L$ sites around it.  For consecutive
+windows, the deformed closed-chain coefficients have the form
+\[
+    \tr\bigl(B^{p}\, C_j(u_1 \cdots u_L)\, B^{u_{L+1}}\, B^{s}\bigr)
+    =
+    \tr\bigl(B^{p}\, B^{u_1}\, C_{j+1}(u_2 \cdots u_{L+1})\, B^{s}\bigr).
+\]
+Injectivity on the complementary arc strips these identities to
+\[
+    C_j(u_1 \cdots u_L)\,B^{u_{L+1}}
+    =
+    B^{u_1}\,C_{j+1}(u_2 \cdots u_{L+1}),
+\]
+and chaining the relations across the $L + 1$ windows gives
+\[
+    C_0(a)\,B^b = B^a\,C_L(b).
+\]
+This is the overlap mechanism in \cite[Lemma~5]{Molnar2018NormalPEPS}.
+The lemmas below assemble that argument: block injectivity extends to every
+length, word products transport between equal-state chains, and the bond
+operator is extracted and shown to act by conjugation, lowering the system size
+to $n \ge 2L + 1$.
 
 \begin{lemma}[Block injectivity extends to longer blocks]%
     \label{lem:isNBlkInjective_of_le}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -283,6 +283,32 @@ product states, and the square lattice.
     \end{proof}
 \end{theorem}
 
+\section{Fundamental Theorem for normal matrix product states}%
+\label{sec:peps_normal_mps}
+
+The closed chain is the one-dimensional PEPS: the cycle graph on $n$ vertices
+carrying one tensor of $D \times D$ matrices per site, so that a physical
+configuration $\sigma = (i_1, \ldots, i_n)$ receives the amplitude
+$\tr(A^{i_1} \cdots A^{i_n})$.  The Fundamental Theorem for normal PEPS
+therefore specializes to matrix product states once its blocking hypotheses are
+read off the chain, and this section records the resulting statements,
+following the matrix-product-state corollaries of
+\cite[Section~3]{Molnar2018NormalPEPS} and the sharper system-size bound of its
+closing section \emph{Normal MPS: alternative proof}.
+
+The development proceeds in four steps.  The closed chain is first identified
+with a cycle of tensors, and the normal blocking hypotheses are obtained from
+the injectivity of every arc of $L$ consecutive sites, giving the Fundamental
+Theorem for normal matrix product states on a ring of $n \ge 3L$ sites with one
+invertible gauge per bond.  The translation-invariant case then collapses the
+per-bond gauges to a single gauge $Z$ and a constant $\lambda$ with
+$\lambda^n = 1$.  An overlapping-window argument, the matrix-product-state form
+of the source's Lemma~5, lowers the system size from $n \ge 3L$ to the optimal
+$n \ge 2L + 1$.  Finally the same argument is run for site-dependent chains,
+one tensor per site, which is the setting in which the source states Lemma~5.
+
+\subsection{Matrix product states on the closed chain}
+
 \begin{theorem}[Cycle blocking hypotheses from arc injectivity]%
     \label{thm:peps_cycleNormalPEPSBlockingHypotheses}
     \lean{TNLean.PEPS.cycleArcFrom}
@@ -457,6 +483,14 @@ product states, and the square lattice.
     $L$-block injectivity, and the trace pairing is nondegenerate, so
     $C = 0$.
 \end{proof}
+
+\subsection{Translation-invariant matrix product states}
+
+When the same tensor sits at every site, the closed chain ties the per-bond
+gauges together: consecutive bonds carry proportional gauges, and going once
+around the chain forces the common ratio to be an $n$-th root of unity.  A single
+gauge $Z$ and a constant $\lambda$ with $\lambda^n = 1$ then capture all the
+freedom, which is the form in which the source states the corollary.
 
 \begin{corollary}[Fundamental Theorem for translation-invariant normal MPS
         on a closed chain, matrix form]%
@@ -636,6 +670,16 @@ product states, and the square lattice.
     $Z' Z^{-1}$ commutes with the full matrix algebra, hence is a nonzero
     scalar.
 \end{proof}
+
+\subsection{\texorpdfstring{The optimal system size $n \ge 2L + 1$}{The optimal system size n >= 2L+1}}
+
+The bound $n \ge 3L$ is not optimal.  A bond of the closed chain is straddled by
+the $L + 1$ overlapping windows of $L$ sites around it, and matching the
+deformations these windows carry already pins the virtual operation on the
+bond — the matrix-product-state form of the source's Lemma~5.  The lemmas below
+assemble that argument: block injectivity extends to every length, word products
+transport between equal-state chains, and the bond operator is extracted and
+shown to act by conjugation, lowering the system size to $n \ge 2L + 1$.
 
 \begin{lemma}[Block injectivity extends to longer blocks]%
     \label{lem:isNBlkInjective_of_le}
@@ -885,6 +929,8 @@ product states, and the square lattice.
     $\lambda^n = 1$, so $B^i = Z_v^{-1} A^i Z_{v+1}$ at every site.
 \end{proof}
 
+
+\subsection{Site-dependent chains}
 
 The source states its Lemma~5 for site-dependent tensors: five sites
 carrying tensors $A_1, \ldots, A_5$ whose two-site windows are injective.
@@ -1142,6 +1188,21 @@ recorded in the route note
     them, including across the seam.
 \end{proof}
 
+Two remarks place these statements against \cite{Molnar2018NormalPEPS}.  The
+injective matrix product states of the source's opening section are the case
+$L = 1$, in which a single tensor already spans the matrix algebra; the
+corollaries above contain them at $n \ge 3$, with no separate argument needed.
+And the site-dependent results are stated for one physical dimension $d$ and one
+bond dimension $D$ around the chain, while the source places no restriction on
+the local dimensions; this uniform-dimension restriction is the only narrowing,
+recorded in the route note
+(\path{docs/paper-gaps/peps_normal_ft_section3_route.tex}).  The source's
+translation-symmetry corollary, that a non-translation-invariant injective chain
+whose state is translation invariant admits a translation-invariant description
+with the same bond dimension, is a statement about a single chain rather than a
+comparison of two, and is not part of this section.
+
+\section{The vertex-injective case and the residual edge scalars}
 
 \begin{theorem}[Fundamental Theorem for normal PEPS, vertex-injective case]%
     \label{thm:fundamentalTheorem_normalPEPS_of_vertexInjective}


### PR DESCRIPTION
## Summary
- preserve the useful local PEPS change by giving the normal-MPS corollaries their own section
- add short subsection introductions for the closed-chain, translation-invariant, optimal-size, and site-dependent statements
- keep upstream PEPS overview and diagram wording after rebasing onto current main

## Validation
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- python3 scripts/blueprint_lean_sync.py --root . --ci
- git diff --check origin/main..HEAD
- cd blueprint && leanblueprint web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX documentation and reader-facing structure only; existing theorems and Lean labels are preserved, with no runtime or formal proof changes in the diff.
> 
> **Overview**
> Reorganizes the blueprint’s **normal matrix product state** corollaries into a dedicated section (`sec:peps_normal_mps`) instead of burying them only inside the normal-PEPS capstone narrative.
> 
> The chapter roadmap in `ch24_peps_ft.tex` now points readers to that section (closed chain specialization) before the balanced edge-scalars section. In `ch24_peps_ft_normal_capstone.tex`, new **section-level** prose frames the four-part development (closed chain / translation invariance / sharper `n ≥ 2L+1` overlap argument / site-dependent chains) with citations to Molnar2018.
> 
> **Subsection headers and short introductions** were added for the closed-chain blocking corollaries, translation-invariant gauge collapse (`λ^n = 1`), the optimal-size overlap mechanism, and site-dependent chains; closing **remarks** clarify how this relates to injective `L = 1`, uniform bond/physical dimensions vs. the paper, and what is intentionally omitted. The vertex-injective normal-PEPS material is pulled under its own section title at the end of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce9f7b710eef8204c8c9350693fa06c786c2c5e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->