### PR TITLE
doc(Channel): accurate Mathlib map for the Lorentz infimum_is_attained gap

### DIFF
--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -168,17 +168,19 @@ so we may restrict to a bounded subset `{S_i | ‖S_i‖ ≤ C}` inside
 `{S | det S = 1}`.  In finite dimensions this set is compact, and the
 continuous trace functional attains its infimum by the extreme value theorem.
 
-**Missing Mathlib facts:**
-- Compactness of the set `{S : Matrix n n ℂ | det S = 1 ∧ ‖S‖ ≤ C}`.
-  This needs: (a) the determinant condition `det S = 1` defines a closed set
-  (it is a polynomial equation), and (b) the spectral-norm ball `‖S‖ ≤ C` is
-  compact (finite-dimensional Heine–Borel).
-- The extreme value theorem for the continuous map
-  `(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
-  on this compact product set.
-Both should be obtainable from `Mathlib.Topology.Instances.Matrix` and
-`Mathlib.Topology.Algebra.Module.FiniteDimension`, but the connecting results
-are not yet in Mathlib. -/
+**Available Mathlib facts:** the extreme value theorem is
+`IsCompact.exists_isMinOn` (`Mathlib.Topology.Order.Compact`); finite-dimensional
+Heine–Borel is `Metric.isCompact_of_isClosed_isBounded` (the matrix space is a
+proper space); and `det S = 1` is closed as the preimage of `{1}` under the
+continuous determinant.
+
+**Remaining gap:** the **coercivity bound** that reduces the unbounded
+minimisation over `det = 1` to a compact sublevel set, namely
+`tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] ≥ λ_min(τ) · ‖S₂ ⊗ₖ S₁‖²` together with
+`‖S₂ ⊗ₖ S₁‖² = ‖S₂‖² · ‖S₁‖²` and `det S = 1 ⟹ ‖S‖² ≥ n` (so the value tends to
+`∞` with `‖S‖`).  These rest on `tr(P · Q) ≥ 0` for positive semidefinite
+`P, Q` and the `PosDef` smallest-eigenvalue bound, neither of which is currently
+in Mathlib. -/
 lemma infimum_is_attained
     {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
     (_hτ_posDef : τ.PosDef) :

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -162,7 +162,9 @@ is attained.  That is, the continuous function
 `(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
 achieves its minimum on the domain of SL(n, ℂ) × SL(n, ℂ).
 
-**Proof sketch** (Wolf Section 2.3).  There exist bounds
+**Proof sketch** (Wolf Section 2.3).  Throughout, `‖·‖` denotes the Frobenius
+(Hilbert–Schmidt) norm `‖M‖² = tr[M M†]`; the coercivity bounds below are false
+for the operator norm (e.g. `‖I‖_op² = 1 < n`).  There exist bounds
   `0 < λ_min(τ) · ‖S₂ ⊗ₖ S₁‖² ≤ tr[τ'] ≤ tr[τ]`,
 so we may restrict to a bounded subset `{S_i | ‖S_i‖ ≤ C}` inside
 `{S | det S = 1}`.  In finite dimensions this set is compact, and the
@@ -176,8 +178,10 @@ continuous determinant.
 
 **Remaining gap:** the **coercivity bound** that reduces the unbounded
 minimisation over `det = 1` to a compact sublevel set, namely
-`tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] ≥ λ_min(τ) · ‖S₂ ⊗ₖ S₁‖²` together with
-`‖S₂ ⊗ₖ S₁‖² = ‖S₂‖² · ‖S₁‖²` and `det S = 1 ⟹ ‖S‖² ≥ n` (so the value tends to
+`tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] ≥ λ_min(τ) · ‖S₂ ⊗ₖ S₁‖²` together with the
+Hilbert–Schmidt multiplicativity `‖S₂ ⊗ₖ S₁‖² = ‖S₂‖² · ‖S₁‖²` and the AM–GM
+determinant bound `det S = 1 ⟹ ‖S‖² ≥ n` (singular values of `S` have product
+`|det S| = 1`, so their squares average at least `1`; hence the value tends to
 `∞` with `‖S‖`).  These rest on `tr(P · Q) ≥ 0` for positive semidefinite
 `P, Q` and the `PosDef` smallest-eigenvalue bound, neither of which is currently
 in Mathlib. -/


### PR DESCRIPTION
The `infimum_is_attained` docstring claimed the extreme value theorem and finite-dimensional compactness are "not yet in Mathlib" — but both exist (`IsCompact.exists_isMinOn`, `Metric.isCompact_of_isClosed_isBounded`). This corrects the note so whoever closes the sorry has an accurate map: the real remaining gap is the **coercivity bound** `tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] ≥ λ_min(τ)·‖S₂ ⊗ₖ S₁‖²`, which rests on `tr(P·Q) ≥ 0` for PSD `P,Q` and the `PosDef` smallest-eigenvalue bound — neither currently in Mathlib.

Docstring-only; the `sorry` is unchanged. Verified the file still compiles locally (`lake env lean`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edit to a docstring; no executable logic or proofs changed.
> 
> **Overview**
> Updates the **`infimum_is_attained`** docstring so the proof roadmap matches Mathlib: compactness and the extreme value theorem are **available** (`IsCompact.exists_isMinOn`, `Metric.isCompact_of_isClosed_isBounded`, closed `det = 1`), not missing.
> 
> The note now states that norms in the coercivity sketch are **Frobenius / Hilbert–Schmidt** (operator norm would break the bounds), and isolates the real blocker: the **coercivity / sublevel-set** chain (`λ_min(τ)` trace lower bound, Kronecker HS norm, AM–GM on `det S = 1`), which still needs `tr(P·Q) ≥ 0` for PSD matrices and a **`PosDef` smallest-eigenvalue** bound.
> 
> No Lean proof changes; the lemma remains `sorry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25984558bd22eb3c60c9daa711c5a65c9445f36c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->