### PR TITLE
feat(MPS/ParentHamiltonian): block-to-letter translation of boundary block matrix equation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -187,6 +187,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingCoordinate
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
+import TNLean.MPS.ParentHamiltonian.BoundaryBlockMatEq
 import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation

--- a/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
@@ -22,7 +22,7 @@ length-\(L_0 K\) words of `A`.
   =
   A^{w(b)} \, Y_{c_b},
 \]
-where `b` is a single block letter and `c_b` is an iterated block index of the
+where \(b\) is a single block letter and \(c_b\) is an iterated block index of the
 complement, and produces the block matrix equation in the shape consumed by
 `MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (the "L2"
 step), with the head ranging over every length-\(L_0\) word and the complement

--- a/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
@@ -28,10 +28,10 @@ by the boundary-matrix commutation lemma (Boundary matrix commutation from a
 block-window equation), with the head ranging over every length-L₀ word and the
 complement over every length-L₀K word.
 
-The proof sends each length-L₀ word `s` to its canonical block letter in
-`Fin (dᴸ⁰)` and regroups each length-L₀K complement word `c` through the
-isomorphism `Fin (d^(L₀K)) ≅ (Fin (dᴸ⁰))^K`, both invertible by the blocking
-round-trip lemmas.
+The proof sends each length-\(L_0\) word \(s\) to its canonical block letter in
+\(\mathrm{Fin}(d^{L_0})\) and regroups each length-\(L_0 K\) complement word \(c\)
+through the isomorphism \(\mathrm{Fin}(d^{L_0 K}) \cong (\mathrm{Fin}(d^{L_0}))^K\),
+both invertible by the blocking round-trip lemmas.
 
 This is a step of the boundary-closing decomposition for the normal
 range-reduction argument; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`

--- a/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
@@ -16,21 +16,22 @@ single-site windowed matrix equation already proved for the blocked tensor
 equation back into a statement about ordinary length-\(L_0\) and
 length-\(L_0 K\) words of `A`.
 
-`MPSTensor.block_matEq_of_blocked_matEq` takes the blocked matrix equation
+Starting from the blocked matrix equation
 \[
   X \, A^{w(b)} \, A^{\mathrm{flatten}(w(c_b))}
   =
   A^{w(b)} \, Y_{c_b},
 \]
 where \(b\) is a single block letter and \(c_b\) is an iterated block index of the
-complement, and produces the block matrix equation in the shape consumed by
-`MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (the "L2"
-step), with the head ranging over every length-\(L_0\) word and the complement
-over every length-\(L_0 K\) word.
+complement, the result produces the block matrix equation in the shape consumed
+by the boundary-matrix commutation lemma (Boundary matrix commutation from a
+block-window equation), with the head ranging over every length-L₀ word and the
+complement over every length-L₀K word.
 
-The head realization uses `blockIndexOfList` / `wordOfBlock_blockIndexOfList`;
-the complement grouping uses `directToIteratedBlockIndex` /
-`flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex`.
+The proof sends each length-L₀ word `s` to its canonical block letter in
+`Fin (dᴸ⁰)` and regroups each length-L₀K complement word `c` through the
+isomorphism `Fin (d^(L₀K)) ≅ (Fin (dᴸ⁰))^K`, both invertible by the blocking
+round-trip lemmas.
 
 This is a step of the boundary-closing decomposition for the normal
 range-reduction argument; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`
@@ -65,11 +66,8 @@ for which the block matrix equation
 holds for *every* length-\(L_0\) head word `σ_tail` and *every* length-\(L_0 K\)
 complement word `σ_comp`.
 
-The head word is realized as a single block letter through `blockIndexOfList`, and
-the complement word is grouped into `K` blocks through `directToIteratedBlockIndex`;
-both round-trip through `wordOfBlock`/`flattenBlockedWord`.  The resulting equation
-is in the exact shape consumed by
-`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`. -/
+The conclusion is the block matrix equation consumed by the boundary-matrix
+commutation step. -/
 theorem block_matEq_of_blocked_matEq
     {A : MPSTensor d D} {L₀ Kb : ℕ}
     {X : Matrix (Fin D) (Fin D) ℂ}

--- a/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
@@ -56,15 +56,16 @@ iterated block index `cb` of the complement,
 \[
   X \, A^{w(b)} \, A^{\mathrm{flatten}(w(c_b))} = A^{w(b)} \, Y_{c_b},
 \]
-where `w(b)` is the length-\(L_0\) word of `b` and `flatten (w(cb))` is the
-length-\(L_0 K\) complement word.  Then there is a complement-indexed family `Y`
+where \(w(b)\) is the length-\(L_0\) word of \(b\) and \(\widetilde{w(c_b)}\) is the
+length-\(L_0 K\) complement word obtained by concatenating the blocks of \(c_b\).
+Then there is a complement-indexed family \(Y\)
 for which the block matrix equation
 \[
   X \, A^{\sigma_{\mathrm{tail}}} \, A^{\sigma_{\mathrm{comp}}}
   = A^{\sigma_{\mathrm{tail}}} \, Y_{\sigma_{\mathrm{comp}}}
 \]
-holds for *every* length-\(L_0\) head word `σ_tail` and *every* length-\(L_0 K\)
-complement word `σ_comp`.
+holds for *every* length-\(L_0\) head word \(\sigma_{\mathrm{tail}}\) and *every*
+length-\(L_0 K\) complement word \(\sigma_{\mathrm{comp}}\).
 
 The conclusion is the block matrix equation consumed by the boundary-matrix
 commutation step. -/

--- a/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
@@ -1,0 +1,108 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Core.BlockingInfrastructure
+
+/-!
+# Block-to-letter translation of the boundary block matrix equation
+
+The boundary-closing argument of
+[Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127, Section IV.C,
+lines 2078--2079] reduces, after blocking \(L_0\) sites into one, to the
+single-site windowed matrix equation already proved for the blocked tensor
+`blockTensor A L₀`.  This file supplies the bookkeeping that turns that blocked
+equation back into a statement about ordinary length-\(L_0\) and
+length-\(L_0 K\) words of `A`.
+
+`MPSTensor.block_matEq_of_blocked_matEq` takes the blocked matrix equation
+\[
+  X \, A^{w(b)} \, A^{\mathrm{flatten}(w(c_b))}
+  =
+  A^{w(b)} \, Y_{c_b},
+\]
+where `b` is a single block letter and `c_b` is an iterated block index of the
+complement, and produces the block matrix equation in the shape consumed by
+`MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` (the "L2"
+step), with the head ranging over every length-\(L_0\) word and the complement
+over every length-\(L_0 K\) word.
+
+The head realization uses `blockIndexOfList` / `wordOfBlock_blockIndexOfList`;
+the complement grouping uses `directToIteratedBlockIndex` /
+`flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex`.
+
+This is a step of the boundary-closing decomposition for the normal
+range-reduction argument; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`
+and the tracking issue for the remaining boundary-closing obligation.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
+  Section IV.C, lines 2078--2079
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- **Block-to-letter translation of the boundary block matrix equation.**
+
+Suppose the blocked tensor satisfies, for every single block letter `b` and every
+iterated block index `cb` of the complement,
+\[
+  X \, A^{w(b)} \, A^{\mathrm{flatten}(w(c_b))} = A^{w(b)} \, Y_{c_b},
+\]
+where `w(b)` is the length-\(L_0\) word of `b` and `flatten (w(cb))` is the
+length-\(L_0 K\) complement word.  Then there is a complement-indexed family `Y`
+for which the block matrix equation
+\[
+  X \, A^{\sigma_{\mathrm{tail}}} \, A^{\sigma_{\mathrm{comp}}}
+  = A^{\sigma_{\mathrm{tail}}} \, Y_{\sigma_{\mathrm{comp}}}
+\]
+holds for *every* length-\(L_0\) head word `σ_tail` and *every* length-\(L_0 K\)
+complement word `σ_comp`.
+
+The head word is realized as a single block letter through `blockIndexOfList`, and
+the complement word is grouped into `K` blocks through `directToIteratedBlockIndex`;
+both round-trip through `wordOfBlock`/`flattenBlockedWord`.  The resulting equation
+is in the exact shape consumed by
+`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`. -/
+theorem block_matEq_of_blocked_matEq
+    {A : MPSTensor d D} {L₀ Kb : ℕ}
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (YB : Fin (blockPhysDim (blockPhysDim d L₀) Kb) → Matrix (Fin D) (Fin D) ℂ)
+    (hBlk : ∀ (b : Fin (blockPhysDim d L₀))
+        (cb : Fin (blockPhysDim (blockPhysDim d L₀) Kb)),
+      X * evalWord A (wordOfBlock d L₀ b)
+          * evalWord A (flattenBlockedWord d L₀ (wordOfBlock (blockPhysDim d L₀) Kb cb))
+        = evalWord A (wordOfBlock d L₀ b) * YB cb) :
+    ∃ Y : (Fin (L₀ * Kb) → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+      ∀ (s : Fin L₀ → Fin d) (c : Fin (L₀ * Kb) → Fin d),
+        X * evalWord A (List.ofFn s) * evalWord A (List.ofFn c)
+          = evalWord A (List.ofFn s) * Y c := by
+  refine ⟨fun c =>
+    YB (directToIteratedBlockIndex d L₀ Kb
+      (blockIndexOfList d (L₀ * Kb) (List.ofFn c) (by simp))), ?_⟩
+  intro s c
+  -- Realize the head `s` as a single block letter `b`.
+  set b : Fin (blockPhysDim d L₀) :=
+    blockIndexOfList d L₀ (List.ofFn s) (by simp) with hb
+  have hbword : wordOfBlock d L₀ b = List.ofFn s := by
+    rw [hb]; exact wordOfBlock_blockIndexOfList d L₀ (List.ofFn s) (by simp)
+  -- Realize the complement `c` as a grouped iterated block index `cb`.
+  set i : Fin (blockPhysDim d (L₀ * Kb)) :=
+    blockIndexOfList d (L₀ * Kb) (List.ofFn c) (by simp) with hi
+  set cb : Fin (blockPhysDim (blockPhysDim d L₀) Kb) :=
+    directToIteratedBlockIndex d L₀ Kb i with hcb
+  have hcword :
+      flattenBlockedWord d L₀ (wordOfBlock (blockPhysDim d L₀) Kb cb) = List.ofFn c := by
+    rw [hcb, flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex, hi]
+    exact wordOfBlock_blockIndexOfList d (L₀ * Kb) (List.ofFn c) (by simp)
+  have hmain := hBlk b cb
+  rw [hbword, hcword] at hmain
+  simpa [hb, hi, hcb] using hmain
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -9,12 +9,44 @@ restrictions follows from the commutation identity $XA^j=A^jX$ for every
 physical letter $j$. The remaining boundary-closing step is to derive these
 identities from the block-window equation.
 
+\begin{lemma}[Block-to-letter translation of the boundary block matrix equation]
+    \label{lem:block_mateq_of_blocked_mateq}
+    \lean{MPSTensor.block_matEq_of_blocked_matEq}
+    \leanok
+    \uses{def:eval_word, def:blocked_tensor, lem:eval_word_block}
+    Let $A$ be an MPS tensor and let $L_0,K\ge 0$. Let $X$ be a matrix, and let
+    $Y_{c_b}$ be a matrix for each iterated block index $c_b$ of the complement.
+    Suppose that, for every block letter $b$ of the alphabet
+    $\{0,\ldots,d{-}1\}^{L_0}$ and every iterated block index $c_b$ of the
+    complement, with $w(b)$ the length-$L_0$ word of $b$ and
+    $\widetilde{w(c_b)}$ the length-$L_0K$ complement word obtained by
+    concatenating the blocks of $c_b$,
+    \[
+        X A^{w(b)} A^{\widetilde{w(c_b)}} = A^{w(b)} Y_{c_b} .
+    \]
+    Then there is a family $Y'_c$, indexed by the length-$L_0K$ words $c$, with
+    \[
+        X A^s A^c = A^s Y'_c
+    \]
+    for every length-$L_0$ word $s$ and every length-$L_0K$ word $c$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Each length-$L_0$ word $s$ is the word $w(b)$ of its block letter $b$,
+    and each length-$L_0K$ word $c$ regroups into $K$ blocks, recovering it as
+    the concatenated complement word $\widetilde{w(c_b)}$ of an iterated block
+    index $c_b$; both identifications are bijective. Substituting these
+    representations into the hypothesis and setting $Y'_c=Y_{c_b}$ gives the
+    asserted equation for every $s$ and $c$.
+\end{proof}
+
 \begin{lemma}[Boundary matrix commutation from a block-window equation]
     \label{lem:boundary_matrix_commutes_block_window}
     \lean{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}
     \leanok
     \uses{def:l_blk_injective, def:eval_word, lem:wordspan_blk_inj,
-        lem:padded_complement_annihilation}
+        lem:padded_complement_annihilation, lem:block_mateq_of_blocked_mateq}
     Let $A$ be $L_0$-block-injective with $L_0>0$. Let $X$ be a boundary
     matrix, and let $Y_v$ be a matrix for each complementary word $v$ of
     length $K$. Suppose that, for every word $u$ of length $L_0$ and every


### PR DESCRIPTION
## Summary

Adds `MPSTensor.block_matEq_of_blocked_matEq` (new file `BoundaryBlockMatEq.lean`), the block-to-letter bookkeeping core of the **blocking route** for the boundary-closing step of the normal range-reduction argument (arXiv:2011.12127, Section IV.C, lines 2078–2079).

Given the single-site windowed matrix equation on the blocked tensor `blockTensor A L₀` (the shape `wrapping_window_matEq` produces, after `evalWord_blockTensor`), it produces the block matrix equation in the **exact shape consumed by the L2 commutation lemma** `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`:

```
X * A^σ_tail * A^σ_comp = A^σ_tail * Y σ_comp
```

with the head `σ_tail` ranging over *every* length-$L_0$ word and the complement `σ_comp` over *every* length-$L_0 K$ word.

## Why

This is the verified core of the path to discharge the single remaining `hComm : ∀ k, X * A k = A k * X` sorry in `closure_property_boundary_restrictions_eq_of_groundSpaceMap` (the boundary-closing keystone left after #2820 / #2840 / #2846). The blocking route reduces that obligation to the already-proved single-site `wrapping_window_matEq` applied to `blockTensor A L₀` with a two-letter window, where the single-site boundary peel handles the $L_0$-block automatically — no new `cyclicCfg` index machinery.

The head realization uses `blockIndexOfList` / `wordOfBlock_blockIndexOfList`; the complement grouping uses `directToIteratedBlockIndex` / `flattenBlockedWord_wordOfBlock_directToIteratedBlockIndex`.

## Notes

- Pure blocking bookkeeping — no injectivity hypothesis, no `sorry`, no new axioms.
- Builds on existing `Core.BlockingInfrastructure` helpers only (light leaf import).
- Toward #2405 (the wrapping of `wrapping_window_matEq` on the blocked tensor and the call-site trace-identity reconstruction are the remaining steps).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal bookkeeping on existing blocking infrastructure; no auth, runtime, or behavioral changes.
> 
> **Overview**
> Adds **`MPSTensor.block_matEq_of_blocked_matEq`** in `BoundaryBlockMatEq.lean` and wires it into the root import list.
> 
> The theorem reindexes a **single block-letter** matrix equation (head `wordOfBlock`, complement via `flattenBlockedWord` / iterated block indices) into the **word-indexed** form `X * A^s * A^c = A^s * Y c` for all length-`L₀` heads and length-`L₀ K` complements—the input shape of **`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq`**. The proof is blocking round-trips (`blockIndexOfList`, `directToIteratedBlockIndex`) only; no injectivity and no `sorry`.
> 
> The blueprint chapter **normal boundary closing** gains Lemma `block_mateq_of_blocked_mateq` (`\leanok`) and lists it in the `\uses` of the boundary-matrix commutation lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff779fc03833275d419be2947491553feb28fd4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->