### PR TITLE
doc(blueprint): revise boundary proof wording

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -79,8 +79,8 @@ identities from the block-window equation.
     \notready
     This is the coordinate form of the boundary-closing part of the
     inverting-and-growing-back argument in
-    \cite[Section~IV.C, lines~2078--2079]{Cirac2021Matrix}. The formal proof
-    still has to derive the displayed equation from the closing-boundary local
+    \cite[Section~IV.C, lines~2078--2079]{Cirac2021Matrix}. A complete proof
+    must derive the displayed equation from the closing-boundary local
     constraints recorded above.
 \end{proof}
 


### PR DESCRIPTION
Post-merge response to the nonblocking review note on #2850: replace the phrase "formal proof" in a blueprint proof block with "complete proof".

Checks run locally:
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`

No issue closure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording in a blueprint proof block; no logic, Lean, or runtime behavior changes.
> 
> **Overview**
> In **`ch13_parent_hamiltonian_normal_closing.tex`**, the stub proof for the block-window equation at the closing boundary (`\notready`) updates reader-facing wording: **“The formal proof still has to derive…”** becomes **“A complete proof must derive…”** the displayed equation from the closing-boundary local constraints.
> 
> This is a follow-up to review feedback on #2850 and does not change mathematical claims or Lean linkage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e92ce9280f8e77f840d8e861cfb12ce8dd976f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->