### PR TITLE
doc(blueprint): add AbsorbedEquality theorem entries to ch24

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_edge_middle.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_middle.tex
@@ -720,3 +720,180 @@ Section~\ref{sec:peps_edge_kernel_gauges}.
     gives $V\setminus\{u,v\}\ne\varnothing$. Apply the preceding all-edge
     singleton theorem.
 \end{proof}
+
+\subsection{From the conjugation identity to the absorbed equality}%
+\label{subsec:peps_absorbed_equality}
+
+% Companion to issue tracked in docs/paper-gaps/peps_normal_ft_section3_route.tex.
+The per-edge gauge engine produces, at a region $R$ with single boundary edge
+$f$, the \emph{conjugation} form
+\[
+    C_A(R,f,M;\sigma,\tau)
+    =
+    C_B\bigl(R,f,Z\,\phi_{h_f}(M)\,Z^{-1};\sigma,\tau\bigr),
+\]
+where $Z$ is the invertible bond matrix on $f$ and $\phi_{h_f}$ is the
+matrix-algebra transport induced by $h_f:D_A(f)=D_B(f)$. The region comparison
+of \cite[Section~3]{Molnar2018NormalPEPS} instead consumes the \emph{absorbed}
+form: the gauge is absorbed into the second tensor, and the \emph{same} matrix
+$\phi_{h_f}(M)$ is inserted on both sides. The conversion is the content of the
+present subsection.
+
+\begin{definition}[Orientation-adapted absorbing gauge]%
+    \label{def:peps_absorbedBoundaryGauge}
+    \lean{TNLean.PEPS.absorbedBoundaryGauge}
+    \leanok
+    Let $f$ be a boundary edge of $R$ and let $Z$ be an invertible matrix on the
+    bond space of $f$. The orientation-adapted absorbing gauge is
+    \[
+        X_f
+        =
+        \begin{cases}
+            Z^{\mathsf T} & \text{if the left endpoint of $f$ lies in $R$,}\\
+            Z^{-1} & \text{otherwise.}
+        \end{cases}
+    \]
+    It is the absorbing matrix on $f$ for which the gauge action of the region
+    insertion reproduces the engine's conjugation by $Z$.
+\end{definition}
+
+\begin{lemma}[Matrix reconciliation for the absorbing gauge]%
+    \label{lem:peps_regionEdgeOrient_absorbedBoundaryGauge}
+    \lean{TNLean.PEPS.regionEdgeOrient_absorbedBoundaryGauge}
+    \leanok
+    \uses{def:peps_absorbedBoundaryGauge}
+    With $X_f$ the orientation-adapted absorbing gauge of $Z$ and
+    $\mathcal O_{R,f}$ the boundary-edge orientation, for every matrix $N$ on the
+    bond space of $f$,
+    \[
+        \mathcal O_{R,f}\bigl(
+            X_f^{\mathsf T}\,\mathcal O_{R,f}(N)\,(X_f^{-1})^{\mathsf T}
+        \bigr)
+        =
+        Z\,N\,Z^{-1}.
+    \]
+    The conjugation by $X_f^{\mathsf T}\cdot(\cdot)\cdot(X_f^{-1})^{\mathsf T}$
+    carried by the region gauge action thus reproduces the engine's conjugation
+    by $Z$.
+\end{lemma}
+\begin{proof}\leanok
+    When the left endpoint of $f$ lies in $R$, the orientation is the identity
+    and $X_f=Z^{\mathsf T}$, so $X_f^{\mathsf T}=Z$ and
+    $(X_f^{-1})^{\mathsf T}=Z^{-1}$. Otherwise the orientation is transpose and
+    $X_f=Z^{-1}$, so the outer transposes flip the conjugation onto the same
+    form. Both cases give $Z\,N\,Z^{-1}$.
+\end{proof}
+
+\begin{theorem}[Region absorbed equality from the conjugation identity]%
+    \label{thm:peps_regionInsertedCoeff_eq_applyGauge_of_conjIdentity}
+    \lean{TNLean.PEPS.regionInsertedCoeff_eq_applyGauge_of_conjIdentity}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:applyGauge,
+        def:peps_absorbedBoundaryGauge,
+        lem:peps_regionEdgeOrient_absorbedBoundaryGauge}
+    Let $R$ be a region with single boundary edge $f$ and assume the
+    bond-dimension equality $h:D_A=D_B$. Suppose the per-edge gauge $Z$ realizes
+    the conjugation-form region-insertion identity at $f$: for every matrix $M$
+    on the bond space of $f$ and all physical configurations $\sigma$ on $R$ and
+    $\tau$ on $V\setminus R$,
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_B\bigl(R,f,Z\,\phi_{h_f}(M)\,Z^{-1};\sigma,\tau\bigr).
+    \]
+    Let $X$ be an edge-gauge family whose value on $f$ is the orientation-adapted
+    absorbing gauge $X_f$ of $Z$. Then $A$ inserting $M$ matches the absorbed
+    tensor $B^X$ inserting the same transported matrix:
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_{B^X}\bigl(R,f,\phi_{h_f}(M);\sigma,\tau\bigr).
+    \]
+    This is the region analogue of
+    Theorem~\ref{thm:peps_postAbsorptionEdgeInsertionEquality}: the
+    conjugation-form coefficient identity becomes the absorbed plain equality.
+\end{theorem}
+\begin{proof}\leanok
+    The region gauge action conjugates the inserted matrix by
+    $X_f^{\mathsf T}\cdot\mathcal O_{R,f}(\cdot)\cdot(X_f^{-1})^{\mathsf T}$ and
+    cancels every interior gauge of the region and of its complement, so the
+    right-hand coefficient over $B^X$ equals the coefficient over $B$ with the
+    transported matrix conjugated by that gauge. Substituting the engine identity
+    on the left and the matrix reconciliation
+    Lemma~\ref{lem:peps_regionEdgeOrient_absorbedBoundaryGauge} matches the two
+    conjugation forms.
+\end{proof}
+
+\begin{theorem}[Edge absorbed equality from the region absorbed equality]%
+    \label{thm:peps_edgeInsertedCoeff_eq_applyGauge_of_region}
+    \lean{TNLean.PEPS.edgeInsertedCoeff_eq_applyGauge_of_region}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:peps_edgeInsertedCoeff,
+        def:applyGauge,
+        thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
+    Let $R$ be a region with boundary edge $f$, assume the bond-dimension
+    equality $h:D_A=D_B$ and that every bond dimension of $A$ is positive, and
+    suppose the absorbed region equality holds: for every matrix $M$ on the bond
+    space of $f$ and all physical configurations $\sigma$ on $R$ and $\tau$ on
+    $V\setminus R$,
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_{B^X}\bigl(R,f,\phi_{h_f}(M);\sigma,\tau\bigr).
+    \]
+    Then the edge-level absorbed equality holds at $f$: for every global physical
+    configuration $\sigma$ and every matrix $N$ on the bond space of $f$,
+    \[
+        E_A(f,\sigma,N)
+        =
+        E_{B^X}\bigl(f,\sigma,\phi_{h_f}(N)\bigr).
+    \]
+    The edge-level identity no longer mentions the region.
+\end{theorem}
+\begin{proof}\leanok
+    The interior bond multiplicity $p_A(R)=\prod_{g\notin\partial R}D_A(g)$ is a
+    positive integer, and it is shared by $A$ and $B^X$ because the gauge
+    preserves bond dimensions and $D_A=D_B$. Reading both region coefficients
+    through the region-to-edge identity
+    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}, using
+    that the orientation $\mathcal O_{R,f}$ is an involution and commutes with the
+    transport, expresses each side as $p_A(R)$ times the edge-inserted
+    coefficient of the assembled configuration. Cancelling the shared positive
+    multiplicity gives the edge-level identity.
+\end{proof}
+
+\begin{theorem}[Region absorbed equality from the edge absorbed equality]%
+    \label{thm:peps_regionInsertedCoeff_eq_applyGauge_of_edge}
+    \lean{TNLean.PEPS.regionInsertedCoeff_eq_applyGauge_of_edge}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:peps_edgeInsertedCoeff,
+        def:applyGauge,
+        thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
+    Assume the bond-dimension equality $h:D_A=D_B$ and suppose the edge-level
+    absorbed equality holds at an edge $e$: for every global physical
+    configuration $\sigma$ and every matrix $N$ on the bond space of $e$,
+    \[
+        E_A(e,\sigma,N)
+        =
+        E_{B^X}\bigl(e,\sigma,\phi_{h_e}(N)\bigr).
+    \]
+    Then the region absorbed equality holds at every region $R$ having $e$ as a
+    boundary edge: for every matrix $M$ on the bond space of $e$ and all physical
+    configurations $\sigma$ on $R$ and $\tau$ on $V\setminus R$,
+    \[
+        C_A(R,e,M;\sigma,\tau)
+        =
+        C_{B^X}\bigl(R,e,\phi_{h_e}(M);\sigma,\tau\bigr).
+    \]
+    Together with the preceding theorem this expresses region-independence: the
+    absorbed plain equality over any comparison region follows from the single
+    edge-level identity at the boundary edge.
+\end{theorem}
+\begin{proof}\leanok
+    Read both region coefficients through the region-to-edge identity
+    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}. The
+    interior multiplicities agree because the gauge preserves bond dimensions and
+    $D_A=D_B$, and the orientation $\mathcal O_{R,e}$ commutes with the transport,
+    so the region equality reduces to the edge-level equality of the assembled
+    configuration, which is the hypothesis.
+\end{proof}


### PR DESCRIPTION
Resolves the blueprint-sync follow-up: the three sorry-free theorems of
`TNLean/PEPS/RegionBlock/AbsorbedEquality.lean` (added in #2638) had no
`\begin{theorem}` entries in the PEPS Fundamental Theorem chapter, although the
route note `docs/paper-gaps/peps_normal_ft_section3_route.tex` already cites
them. This adds a new subsection "From the conjugation identity to the absorbed
equality" to `blueprint/src/chapter/ch24_peps_ft_edge_middle.tex` at the
granularity of the analogous edge-level entry
`thm:peps_postAbsorptionEdgeInsertionEquality`.

## Entries added (all sorry-free, `\leanok` at statement and proof)

| `\lean{}` declaration | `\label{}` |
|---|---|
| `TNLean.PEPS.absorbedBoundaryGauge` | `def:peps_absorbedBoundaryGauge` |
| `TNLean.PEPS.regionEdgeOrient_absorbedBoundaryGauge` | `lem:peps_regionEdgeOrient_absorbedBoundaryGauge` |
| `TNLean.PEPS.regionInsertedCoeff_eq_applyGauge_of_conjIdentity` | `thm:peps_regionInsertedCoeff_eq_applyGauge_of_conjIdentity` |
| `TNLean.PEPS.edgeInsertedCoeff_eq_applyGauge_of_region` | `thm:peps_edgeInsertedCoeff_eq_applyGauge_of_region` |
| `TNLean.PEPS.regionInsertedCoeff_eq_applyGauge_of_edge` | `thm:peps_regionInsertedCoeff_eq_applyGauge_of_edge` |

The three headline theorems are the issue's targets; `absorbedBoundaryGauge`
(orientation-adapted absorbing gauge) and `regionEdgeOrient_absorbedBoundaryGauge`
(matrix reconciliation) are the supporting definition/lemma the issue notes may
appear, and are needed as real `\uses` targets. The restoration helper
`assembleRegionσ_restrict` is omitted, as the issue allows.

## `\uses` wiring

Every cited label exists exactly once: `def:peps_regionInsertedCoeff`,
`def:peps_edgeInsertedCoeff`, `def:applyGauge`,
`thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff`, and
`thm:peps_postAbsorptionEdgeInsertionEquality`. The issue suggested
`thm:peps_regionInsertedCoeff_applyGauge`, but no such blueprint label exists
(the bridge `regionInsertedCoeff_applyGauge` has no entry), so it is omitted per
the convention "cite real labels only"; its content is described inline in the
proof prose instead.

## Notation

Mirrors the neighboring ch24 entries: $C_A(R,f,M;\sigma,\tau)$ for the region
insertion, $E_A(f,\sigma,N)$ for the edge insertion, $B^X$ for the gauged
tensor, $\phi_{h_f}$ for the bond-dimension transport, $\mathcal O_{R,f}$ for the
boundary-edge orientation, and $p_A(R)$ for the interior bond multiplicity. The
absorbing gauge is $Z^{\mathsf T}$ or $Z^{-1}$ per the orientation, as in the
route note.

## Verification

- All five `\lean{}` names resolve to the real `TNLean.PEPS` declarations.
- All `\label`/`\ref`/`\uses` labels exist exactly once.
- No git conflict markers.
- Reader-facing prose check passes (`scripts/check_reader_facing_prose.py --ci`):
  no Lean identifiers in statement/proof prose, no em-dashes, no software
  jargon, no issue numbers in reader-facing text (a `% comment` records the
  paper-gap companion).

Closes #2639

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX/blueprint sync with no runtime or proof changes beyond published theorem entries.
> 
> **Overview**
> Adds subsection **From the conjugation identity to the absorbed equality** to `ch24_peps_ft_edge_middle.tex`, wiring the sorry-free `TNLean.PEPS` results from `AbsorbedEquality.lean` into the PEPS Fundamental Theorem blueprint (closing the gap noted in the paper-route doc).
> 
> The new material defines the **orientation-adapted absorbing gauge** and a **matrix reconciliation** lemma, then states three linked theorems: conjugation-form region insertion implies the **absorbed** region equality against gauged $B^X$; region absorbed equality implies **edge-level** absorbed equality (via interior multiplicity and the region-to-edge bridge); and edge absorbed equality implies region absorbed equality for any region with that boundary edge (**region-independence**). Entries use `\lean{}`, `\leanok`, and `\uses` pointing at existing region/edge coefficient and gauge labels, paralleling the edge post-absorption theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b60bb6a2de28564287f3bba59ad561bff40231f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->