### PR TITLE
doc(blueprint): add translated-edge per-edge gauge entries to ch24

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
@@ -707,8 +707,16 @@ produces the global gauge family that relates the two tensors.
 \end{theorem}
 
 \begin{proof}\leanok
-    Identical to the horizontal case after rotating the frame by a quarter turn,
-    using the vertical translated frame's one-edge interior blocking datum.
+    The vertical translated frame, the horizontal frame rotated by a quarter
+    turn, likewise supplies for both $A$ and $B$ the shared one-edge interior
+    blocking datum,
+    \[
+        R_A = R_B,\qquad B_A = B_B,\qquad C_A = C_B,
+    \]
+    with the distinguished vertical edge $e$ as the unique crossing edge of the
+    red and blue blocks. Applying the per-edge gauge construction from a one-edge
+    blocking datum to the two blocking data yields the bond-dimension equality on
+    $e$ and the conjugating gauge $Z$.
 \end{proof}
 
 \begin{definition}[Factorized local gauge datum]%

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
@@ -696,7 +696,8 @@ produces the global gauge family that relates the two tensors.
     The rotated counterpart of
     Theorem~\ref{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}.
     Under the same hypotheses on $A$ and $B$, for a translated vertical interior
-    frame with two rows and two columns of margin and distinguished vertical
+    frame with two rows and two columns of margin, that is $2\le x_0$,
+    $2\le y_0$, $x_0+8\le W$, and $y_0+8\le H$, with distinguished vertical
     edge $e$, the bond dimensions agree on $e$, $D_A(e)=D_B(e)$, and there are an
     invertible edge matrix $Z\in\GL(D_B(e))$ and a forward map $\mathrm{fwd}$
     given by the conjugation

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
@@ -648,6 +648,63 @@ produces the global gauge family that relates the two tensors.
     conjugating matrix to the $A$-side bond.
 \end{proof}
 
+% Specializations of the per-edge gauge to the translated interior edges of the
+% open square lattice, where the gauge comes from a one-edge blocking datum.
+
+\begin{theorem}[Per-edge gauge at a translated horizontal interior edge]%
+    \label{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}
+    \lean{TNLean.PEPS.exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}
+    \leanok
+    \uses{lem:peps_normalSquareHorizontalTranslatedEdge_blockingData}
+    Let $A$ and $B$ be normal PEPS on the open $W\times H$ square lattice that
+    satisfy the rectangular-injectivity hypotheses with union closure, have equal
+    and everywhere-positive virtual bond dimensions, and define the same PEPS
+    state. Fix a translated horizontal interior frame with two rows and two
+    columns of margin, that is $2\le x_0$, $2\le y_0$, $x_0+8\le W$, and
+    $y_0+8\le H$, and let $e$ be the distinguished horizontal edge of that frame.
+    Then the bond dimensions agree on $e$, $D_A(e)=D_B(e)$, and there is an
+    invertible edge matrix $Z\in\GL(D_B(e))$ for which the forward
+    region-insertion transfer is the conjugation
+    \[
+        \mathrm{fwd}(M)=Z\,\phi_{h_e}(M)\,Z^{-1},
+    \]
+    where $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_B(e)}$ is the reindexing induced by the
+    bond-dimension equality on $e$. No single-vertex injectivity is used; the
+    only injectivity inputs are the blocked-region injectivities of the interior
+    blocking data and the red and host injectivities of $B$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The translated horizontal frame supplies, for both $A$ and $B$, the one-edge
+    interior blocking datum whose red, blue, and complementary blocks are
+    coordinate regions and therefore shared. The distinguished edge is the unique
+    crossing edge of the red and blue blocks. Feeding the two blocking data to
+    the per-edge gauge construction from a one-edge blocking datum yields the
+    bond-dimension equality on $e$ and the conjugating gauge $Z$.
+\end{proof}
+
+\begin{theorem}[Per-edge gauge at a translated vertical interior edge]%
+    \label{thm:peps_exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge}
+    \lean{TNLean.PEPS.exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge}
+    \leanok
+    \uses{lem:peps_normalSquareVerticalTranslatedEdge_blockingData}
+    The rotated counterpart of
+    Theorem~\ref{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}.
+    Under the same hypotheses on $A$ and $B$, for a translated vertical interior
+    frame with two rows and two columns of margin and distinguished vertical
+    edge $e$, the bond dimensions agree on $e$, $D_A(e)=D_B(e)$, and there is an
+    invertible edge matrix $Z\in\GL(D_B(e))$ for which the forward
+    region-insertion transfer is the conjugation
+    $\mathrm{fwd}(M)=Z\,\phi_{h_e}(M)\,Z^{-1}$, with
+    $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_B(e)}$ the reindexing induced by the
+    bond-dimension equality on $e$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Identical to the horizontal case after rotating the frame by a quarter turn,
+    using the vertical translated frame's one-edge interior blocking datum.
+\end{proof}
+
 \begin{definition}[Factorized local gauge datum]%
     \label{def:peps_hasFactorizedLocalGauge}
     \lean{TNLean.PEPS.HasFactorizedLocalGauge}

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
@@ -657,9 +657,10 @@ produces the global gauge family that relates the two tensors.
     \leanok
     \uses{lem:peps_normalSquareHorizontalTranslatedEdge_blockingData}
     Let $A$ and $B$ be normal PEPS on the open $W\times H$ square lattice that
-    satisfy the rectangular-injectivity hypotheses with union closure, have equal
-    and everywhere-positive virtual bond dimensions, and define the same PEPS
-    state. Fix a translated horizontal interior frame with two rows and two
+    satisfy the rectangular-injectivity hypotheses with union closure, have
+    positive physical dimension $d>0$, have equal and everywhere-positive virtual
+    bond dimensions, and define the same PEPS state. Fix a translated horizontal
+    interior frame with two rows and two
     columns of margin, that is $2\le x_0$, $2\le y_0$, $x_0+8\le W$, and
     $y_0+8\le H$, and let $e$ be the distinguished horizontal edge of that frame.
     Then the bond dimensions agree on $e$, $D_A(e)=D_B(e)$, and there is an
@@ -670,17 +671,21 @@ produces the global gauge family that relates the two tensors.
     \]
     where $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_B(e)}$ is the reindexing induced by the
     bond-dimension equality on $e$. No single-vertex injectivity is used; the
-    only injectivity inputs are the blocked-region injectivities of the interior
-    blocking data and the red and host injectivities of $B$.
+    only injectivity hypotheses are the blocked-region injectivities of the
+    interior blocking data and the red and host injectivities of $B$.
 \end{theorem}
 
 \begin{proof}\leanok
     The translated horizontal frame supplies, for both $A$ and $B$, the one-edge
-    interior blocking datum whose red, blue, and complementary blocks are
-    coordinate regions and therefore shared. The distinguished edge is the unique
-    crossing edge of the red and blue blocks. Feeding the two blocking data to
-    the per-edge gauge construction from a one-edge blocking datum yields the
-    bond-dimension equality on $e$ and the conjugating gauge $Z$.
+    interior blocking datum. Because the red, blue, and complementary blocks are
+    coordinate regions, independent of the tensor, the two data share them,
+    \[
+        R_A = R_B,\qquad B_A = B_B,\qquad C_A = C_B,
+    \]
+    and the distinguished edge $e$ is the unique crossing edge of the red and
+    blue blocks. Applying the per-edge gauge construction from a one-edge
+    blocking datum to the two blocking data yields the bond-dimension equality on
+    $e$ and the conjugating gauge $Z$.
 \end{proof}
 
 \begin{theorem}[Per-edge gauge at a translated vertical interior edge]%

--- a/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex
@@ -663,9 +663,9 @@ produces the global gauge family that relates the two tensors.
     interior frame with two rows and two
     columns of margin, that is $2\le x_0$, $2\le y_0$, $x_0+8\le W$, and
     $y_0+8\le H$, and let $e$ be the distinguished horizontal edge of that frame.
-    Then the bond dimensions agree on $e$, $D_A(e)=D_B(e)$, and there is an
-    invertible edge matrix $Z\in\GL(D_B(e))$ for which the forward
-    region-insertion transfer is the conjugation
+    Then the bond dimensions agree on $e$, $D_A(e)=D_B(e)$, and there are an
+    invertible edge matrix $Z\in\GL(D_B(e))$ and a forward map $\mathrm{fwd}$
+    given by the conjugation
     \[
         \mathrm{fwd}(M)=Z\,\phi_{h_e}(M)\,Z^{-1},
     \]
@@ -697,9 +697,9 @@ produces the global gauge family that relates the two tensors.
     Theorem~\ref{thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge}.
     Under the same hypotheses on $A$ and $B$, for a translated vertical interior
     frame with two rows and two columns of margin and distinguished vertical
-    edge $e$, the bond dimensions agree on $e$, $D_A(e)=D_B(e)$, and there is an
-    invertible edge matrix $Z\in\GL(D_B(e))$ for which the forward
-    region-insertion transfer is the conjugation
+    edge $e$, the bond dimensions agree on $e$, $D_A(e)=D_B(e)$, and there are an
+    invertible edge matrix $Z\in\GL(D_B(e))$ and a forward map $\mathrm{fwd}$
+    given by the conjugation
     $\mathrm{fwd}(M)=Z\,\phi_{h_e}(M)\,Z^{-1}$, with
     $\phi_{h_e}:\MN{D_A(e)}\to\MN{D_B(e)}$ the reindexing induced by the
     bond-dimension equality on $e$.


### PR DESCRIPTION
Resolves the §13a→ch24 blueprint-sync follow-up for the per-edge gauge family at translated interior square-lattice edges.

Adds two `\begin{theorem}` entries to `blueprint/src/chapter/ch24_peps_ft_edge_kernel_gauges.tex`, placed right after `thm:peps_exists_edgeGaugeFamily`:

| `\lean{}` | `\label{}` |
|---|---|
| `TNLean.PEPS.exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge` | `thm:peps_exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge` |
| `TNLean.PEPS.exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge` | `thm:peps_exists_regionEdgeGauge_normalSquareVerticalTranslatedEdge` |

Both source theorems (`TNLean/PEPS/NormalEdgeGaugeFamily.lean`) are sorry-free; entries carry `\leanok` at statement and proof level.

`\uses` wiring cites only pre-existing labels — the translated-edge blocking-datum lemmas `lem:peps_normalSquareHorizontalTranslatedEdge_blockingData` / `lem:peps_normalSquareVerticalTranslatedEdge_blockingData`. The per-edge gauge construction from a one-edge blocking datum (`exists_regionEdgeGauge_of_blockingData`) is not separately blueprinted, so it is described inline in the proofs rather than cited by an invented label.

Notation matches the neighboring edge-gauge entries (`D_A(e)`, `\GL`, `\phi_{h_e}`, `\MN{}`, conjugation `Z M Z^{-1}`). Source: arXiv:1804.04964, Section 3, proof of Theorem 3 (lines 1449–1500).

Reader-facing prose check passes; both new labels unique; both `\lean{}` names resolve.

Closes #2605

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX additions with no Lean or runtime changes; mathematical content mirrors already-proved theorems in `NormalEdgeGaugeFamily.lean`.
> 
> **Overview**
> Adds two blueprint theorem entries in `ch24_peps_ft_edge_kernel_gauges.tex` immediately after `thm:peps_exists_edgeGaugeFamily`, specializing the per-edge gauge story to **translated horizontal and vertical interior edges** on the open square lattice.
> 
> Each entry wires to sorry-free Lean (`exists_regionEdgeGauge_normalSquareHorizontalTranslatedEdge` / `…VerticalTranslatedEdge`), cites the existing translated-edge blocking-datum lemmas via `\uses`, and states bond-dimension equality on the distinguished edge plus a conjugating gauge `Z` with forward map `fwd(M)=Z φ_{h_e}(M) Z^{-1}`. Proofs are short: shared red/blue/complement blocks from the one-edge interior datum, then the one-edge blocking construction (described inline because it has no separate blueprint label). The horizontal theorem notes weaker injectivity than vertex-wise assumptions; the vertical one is the rotated counterpart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e48efe301f1ec7b688fdedc879f2785e6ef537e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->