### PR TITLE
doc(blueprint): add ScalarExtraction and torus-λ entries to ch24

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
@@ -351,9 +351,12 @@ consistency these two pieces of data determine $\eta$ completely.
     \uses{thm:peps_component_eq_of_regionProportional, def:peps_regionTwoBlock,
         def:applyGauge, def:gaugeVertex,
         thm:peps_twoInjectiveTensorInsertionComparison}
-    When the comparison tensor is the gauge-absorbed second tensor, the two two-block
-    scalar proportionalities of the blocked weights over $R$ and over
-    $S=R\cup\{v\}$, with ratios $c_R$ and $c_S$ and with $c_R\ne 0$, yield the
+    Suppose $A$ and $B$ have equal, everywhere-positive bond dimensions, and let
+    the comparison tensor be the gauge-absorbed second tensor (the gauge action of
+    $X$ on $B$, reindexed along the bond-dimension equality). Assume the
+    $R$-blocked family of that comparison tensor is linearly independent. If the
+    two two-block scalar proportionalities of the blocked weights over $R$ and over
+    $S=R\cup\{v\}$ hold, with ratios $c_R$ and $c_S$ and with $c_R\ne 0$, then the
     per-vertex gauge relation
     \[
         A_v(\eta,\sigma)

--- a/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
@@ -269,3 +269,92 @@ constant.
     comparison with the corresponding three-site injective chain. The corrected
     uniqueness statement is a quotient by balanced edge scalars.
 \end{remark}
+
+\subsection{Inserted-site scalar extraction}
+\label{subsec:peps_inserted_site_scalar_extraction}
+
+The final comparison of \cite[Section~3, proof of Theorem~3]{Molnar2018NormalPEPS}
+turns two region proportionalities into a single scalar at one site. Fix a finite
+region $R$ and a site $v\notin R$, and write $S=R\cup\{v\}$ for the
+region with $v$ adjoined. A local configuration $\eta$ at $v$ assigns a virtual
+index to every edge incident to $v$. Its bridge label reads $\eta$ on the
+$v$-incident edges that bound $R$, while the base boundary label $\mu$ fixes the
+remaining $v$-incident edges. Under inserted-site consistency these two pieces of
+data determine $\eta$ completely.
+
+\begin{lemma}[Inserted-site consistency pins a local configuration to its bridge label]%
+    \label{lem:peps_localConfig_eq_of_insertConsistent}
+    \lean{TNLean.PEPS.localConfig_eq_of_insertConsistent}
+    \leanok
+    Fix a region $R$ and a site $v\notin R$, and let $\mu$ be a boundary label of
+    $S=R\cup\{v\}$. Two local configurations at $v$ that are both
+    consistent with $\mu$ and carry the same bridge label coincide.
+\end{lemma}
+\begin{proof}\leanok
+    Read both configurations on each $v$-incident edge. On a $v$-incident edge
+    that bounds $R$ the value is the shared bridge label. On a $v$-incident edge
+    that does not bound $R$, the edge runs from $v$ to a site outside $S$, and
+    inserted-site consistency reads the value from $\mu$. Both readings agree edge
+    by edge, so the two configurations are equal.
+\end{proof}
+
+\begin{theorem}[Inserted-site scalar extraction from two region proportionalities]%
+    \label{thm:peps_component_eq_of_regionProportional}
+    \lean{TNLean.PEPS.component_eq_of_regionProportional}
+    \leanok
+    \uses{lem:peps_localConfig_eq_of_insertConsistent}
+    Let $A$ and a comparison tensor $C$ share their bond dimensions and have
+    positive bond dimensions, and suppose the $R$-blocked family of $C$ is linearly
+    independent. If the blocked weights satisfy the two region proportionalities
+    \[
+        A_R = c_R\,C_R,
+        \qquad
+        A_S = c_S\,C_S
+    \]
+    over $R$ and over $S=R\cup\{v\}$, with $c_R\ne 0$, then the
+    inserted-site tensors are proportional with ratio $c_S/c_R$ at every local
+    configuration $\eta$ at $v$ and every physical index $\sigma$:
+    \[
+        A_v(\eta,\sigma) = \frac{c_S}{c_R}\,C_v(\eta,\sigma).
+    \]
+\end{theorem}
+\begin{proof}\leanok
+    The inserted-site factorization reads each blocked weight of $S$ as the
+    inserted-site tensor summed against the bridge-label blocked weight of $R$ over
+    the local configurations consistent with $\mu$. Feeding both proportionalities
+    through this factorization, cancelling the nonzero bond-only inserted-site
+    multiplicity, and substituting the $R$-proportionality leaves, for every base
+    label $\mu$, a vanishing combination of the $R$-blocked family of $C$ with
+    coefficient $c_R\,A_v(\eta)-c_S\,C_v(\eta)$ summed over the consistent local
+    configurations. By
+    Lemma~\ref{lem:peps_localConfig_eq_of_insertConsistent} the consistent
+    configurations inject into their bridge labels, so linear independence of the
+    $R$-blocked family separates the combination to one term, forcing
+    $c_R\,A_v(\eta,\sigma)=c_S\,C_v(\eta,\sigma)$ and hence the displayed ratio.
+\end{proof}
+
+\begin{corollary}[Per-vertex gauge relation from two two-block proportionalities]%
+    \label{cor:peps_component_eq_gaugeVertex_of_twoBlockProportional}
+    \lean{TNLean.PEPS.component_eq_gaugeVertex_of_twoBlockProportional}
+    \leanok
+    \uses{thm:peps_component_eq_of_regionProportional, def:peps_regionTwoBlock,
+        def:applyGauge, def:gaugeVertex,
+        thm:peps_twoInjectiveTensorInsertionComparison}
+    When the comparison tensor is the gauge-absorbed second tensor, the two two-block
+    scalar proportionalities of the blocked weights over $R$ and over
+    $S=R\cup\{v\}$, with nonzero ratios $c_R$ and $c_S$, yield the
+    per-vertex gauge relation
+    \[
+        A_v(\eta,\sigma)
+        =
+        \frac{c_S}{c_R}\,(\text{gauge action of }X\text{ on }B)_v(\eta,\sigma)
+    \]
+    at every local configuration $\eta$ at $v$ and every physical index $\sigma$.
+\end{corollary}
+\begin{proof}\leanok
+    The two-block proportionalities are exactly the region proportionalities of
+    Theorem~\ref{thm:peps_component_eq_of_regionProportional} for the gauge-absorbed
+    comparison tensor. The reindexed inserted-site tensor of that comparison tensor
+    is the gauge action of $X$ on $B$ at $v$, so the extraction reads as the
+    displayed gauge relation.
+\end{proof}

--- a/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
@@ -277,23 +277,23 @@ The final comparison of \cite[Section~3, proof of Theorem~3]{Molnar2018NormalPEP
 turns two region proportionalities into a single scalar at one site. Fix a finite
 region $R$ and a site $v\notin R$, and write $S=R\cup\{v\}$ for the
 region with $v$ adjoined. A local configuration $\eta$ at $v$ assigns a virtual
-index to every edge incident to $v$. Its bridge label reads $\eta$ on the
-$v$-incident edges that bound $R$, while the base boundary label $\mu$ fixes the
-remaining $v$-incident edges. Under inserted-site consistency these two pieces of
-data determine $\eta$ completely.
+index to every edge incident to $v$. The label on its $v$-incident $R$-boundary
+edges reads $\eta$ on the $v$-incident edges that bound $R$, while the base
+boundary label $\mu$ fixes the remaining $v$-incident edges. Under inserted-site
+consistency these two pieces of data determine $\eta$ completely.
 
-\begin{lemma}[Inserted-site consistency pins a local configuration to its bridge label]%
+\begin{lemma}[Inserted-site consistency pins a local configuration to its $R$-boundary label]%
     \label{lem:peps_localConfig_eq_of_insertConsistent}
     \lean{TNLean.PEPS.localConfig_eq_of_insertConsistent}
     \leanok
     Fix a region $R$ and a site $v\notin R$, and let $\mu$ be a boundary label of
     $S=R\cup\{v\}$. Two local configurations at $v$ that are both
-    consistent with $\mu$ and carry the same bridge label coincide.
+    consistent with $\mu$ and carry the same $R$-boundary label coincide.
 \end{lemma}
 \begin{proof}\leanok
     Read both configurations on each $v$-incident edge. On a $v$-incident edge
-    that bounds $R$ the value is the shared bridge label. On a $v$-incident edge
-    that does not bound $R$, the edge runs from $v$ to a site outside $S$, and
+    that bounds $R$ the value is the shared $R$-boundary label. On a $v$-incident
+    edge that does not bound $R$, the edge runs from $v$ to a site outside $S$, and
     inserted-site consistency reads the value from $\mu$. Both readings agree edge
     by edge, so the two configurations are equal.
 \end{proof}
@@ -319,17 +319,28 @@ data determine $\eta$ completely.
     \]
 \end{theorem}
 \begin{proof}\leanok
-    The inserted-site factorization reads each blocked weight of $S$ as the
-    inserted-site tensor summed against the bridge-label blocked weight of $R$ over
-    the local configurations consistent with $\mu$. Feeding both proportionalities
-    through this factorization, cancelling the nonzero bond-only inserted-site
-    multiplicity, and substituting the $R$-proportionality leaves, for every base
-    label $\mu$, a vanishing combination of the $R$-blocked family of $C$ with
-    coefficient $c_R\,A_v(\eta)-c_S\,C_v(\eta)$ summed over the consistent local
+    Write $b(\mu,\eta)$ for the label that a local configuration $\eta$ at $v$,
+    consistent with the base boundary label $\mu$, induces on the $v$-incident
+    edges that bound $R$. With $m$ the bond-only inserted-site multiplicity, the
+    inserted-site factorization reads each blocked weight of $S$ as the
+    inserted-site tensor summed against the $R$-boundary-label blocked weight of
+    $R$ over the local configurations consistent with $\mu$:
+    \[
+        m\,A_S(\mu,\sigma)
+        =
+        \sum_{\eta\ \text{consistent with}\ \mu}
+        A_v\bigl(\eta,\sigma(v)\bigr)\,
+        A_R\bigl(b(\mu,\eta),\sigma|_R\bigr),
+    \]
+    and likewise for $C$. Feeding both proportionalities through this
+    factorization, cancelling the nonzero $m$, and substituting the
+    $R$-proportionality leaves, for every base label $\mu$, a vanishing
+    combination of the $R$-blocked family of $C$ with coefficient
+    $c_R\,A_v(\eta)-c_S\,C_v(\eta)$ summed over the consistent local
     configurations. By
     Lemma~\ref{lem:peps_localConfig_eq_of_insertConsistent} the consistent
-    configurations inject into their bridge labels, so linear independence of the
-    $R$-blocked family separates the combination to one term, forcing
+    configurations inject into their $R$-boundary labels, so linear independence
+    of the $R$-blocked family separates the combination to one term, forcing
     $c_R\,A_v(\eta,\sigma)=c_S\,C_v(\eta,\sigma)$ and hence the displayed ratio.
 \end{proof}
 
@@ -342,7 +353,7 @@ data determine $\eta$ completely.
         thm:peps_twoInjectiveTensorInsertionComparison}
     When the comparison tensor is the gauge-absorbed second tensor, the two two-block
     scalar proportionalities of the blocked weights over $R$ and over
-    $S=R\cup\{v\}$, with nonzero ratios $c_R$ and $c_S$, yield the
+    $S=R\cup\{v\}$, with ratios $c_R$ and $c_S$ and with $c_R\ne 0$, yield the
     per-vertex gauge relation
     \[
         A_v(\eta,\sigma)

--- a/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
@@ -280,7 +280,8 @@ region with $v$ adjoined. A local configuration $\eta$ at $v$ assigns a virtual
 index to every edge incident to $v$. The label on its $v$-incident $R$-boundary
 edges reads $\eta$ on the $v$-incident edges that bound $R$, while the base
 boundary label $\mu$ fixes the remaining $v$-incident edges. Under inserted-site
-consistency these two pieces of data determine $\eta$ completely.
+consistency, the $R$-boundary label and the values fixed by $\mu$ on the
+remaining $v$-incident edges determine $\eta$ completely.
 
 \begin{lemma}[Inserted-site consistency pins a local configuration to its $R$-boundary label]%
     \label{lem:peps_localConfig_eq_of_insertConsistent}
@@ -349,8 +350,7 @@ consistency these two pieces of data determine $\eta$ completely.
     \lean{TNLean.PEPS.component_eq_gaugeVertex_of_twoBlockProportional}
     \leanok
     \uses{thm:peps_component_eq_of_regionProportional, def:peps_regionTwoBlock,
-        def:applyGauge, def:gaugeVertex,
-        thm:peps_twoInjectiveTensorInsertionComparison}
+        def:applyGauge, def:gaugeVertex}
     Suppose $A$ and $B$ have the same bond dimension on every edge, and that these
     bond dimensions are positive. Let $C$ be the gauge action of $X$ on $B$,
     reindexed along this bond-dimension equality, and assume that the $R$-blocked
@@ -361,7 +361,7 @@ consistency these two pieces of data determine $\eta$ completely.
     \[
         A_v(\eta,\sigma)
         =
-        \frac{c_S}{c_R}\,(\text{gauge action of }X\text{ on }B)_v(\eta,\sigma)
+        \frac{c_S}{c_R}\,C_v(\eta,\sigma)
     \]
     holds at every local configuration $\eta$ at $v$ and every physical index $\sigma$.
 \end{corollary}

--- a/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex
@@ -351,11 +351,11 @@ consistency these two pieces of data determine $\eta$ completely.
     \uses{thm:peps_component_eq_of_regionProportional, def:peps_regionTwoBlock,
         def:applyGauge, def:gaugeVertex,
         thm:peps_twoInjectiveTensorInsertionComparison}
-    Suppose $A$ and $B$ have equal, everywhere-positive bond dimensions, and let
-    the comparison tensor be the gauge-absorbed second tensor (the gauge action of
-    $X$ on $B$, reindexed along the bond-dimension equality). Assume the
-    $R$-blocked family of that comparison tensor is linearly independent. If the
-    two two-block scalar proportionalities of the blocked weights over $R$ and over
+    Suppose $A$ and $B$ have the same bond dimension on every edge, and that these
+    bond dimensions are positive. Let $C$ be the gauge action of $X$ on $B$,
+    reindexed along this bond-dimension equality, and assume that the $R$-blocked
+    family of $C$ is linearly independent. If the two two-block scalar
+    proportionalities of the blocked weights of $A$ and $C$ over $R$ and over
     $S=R\cup\{v\}$ hold, with ratios $c_R$ and $c_S$ and with $c_R\ne 0$, then the
     per-vertex gauge relation
     \[
@@ -363,7 +363,7 @@ consistency these two pieces of data determine $\eta$ completely.
         =
         \frac{c_S}{c_R}\,(\text{gauge action of }X\text{ on }B)_v(\eta,\sigma)
     \]
-    at every local configuration $\eta$ at $v$ and every physical index $\sigma$.
+    holds at every local configuration $\eta$ at $v$ and every physical index $\sigma$.
 \end{corollary}
 \begin{proof}\leanok
     The two-block proportionalities are exactly the region proportionalities of

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -501,6 +501,35 @@ site-independent tensor and produces the global phase of
     \end{proof}
 \end{theorem}
 
+\begin{corollary}[Torus scalar condition from the per-vertex two-block proportionalities]%
+    \label{cor:peps_lambda_pow_card_torus_eq_one_of_twoBlockProportional}
+    \lean{TNLean.PEPS.lambda_pow_card_torus_eq_one_of_twoBlockProportional}
+    \leanok
+    \uses{cor:peps_component_eq_gaugeVertex_of_twoBlockProportional}
+    Let $A$ and $B$ be PEPS tensors on the discrete $n\times m$ torus with positive
+    bond dimensions, generating the same state, and let $X$ be a family of invertible
+    matrices, one on each edge. Suppose that at every site $v$ a region $R_v$ not
+    containing $v$ is supplied together with the two two-block scalar
+    proportionalities of the blocked weights of $A$ and of the gauge-absorbed second
+    tensor over $R_v$ and over $R_v\cup\{v\}$, with nonzero ratios
+    $c_R(v)$ and $c_S(v)$ whose quotient is a single scalar $\lambda$, and with the
+    gauge-absorbed region block linearly independent. If, in addition, a single
+    comparison region whose block and complement block are both blocked-tensor
+    injective is supplied, then $\lambda$ raised to the number of torus sites is one:
+    \[
+        \lambda^{nm}=1.
+    \]
+\end{corollary}
+\begin{proof}\leanok
+    At each site the inserted-site scalar extraction of
+    Corollary~\ref{cor:peps_component_eq_gaugeVertex_of_twoBlockProportional} turns
+    the two two-block proportionalities into the per-vertex gauge relation
+    $A_v=\lambda\,(\text{gauge action of }X\text{ on }B)_v$. The single comparison
+    region and its complement being injective forces the product of the per-vertex
+    scalars over the torus to one, and translation gives the same scalar $\lambda$ at
+    every site, so that product is $\lambda^{nm}$, yielding $\lambda^{nm}=1$.
+\end{proof}
+
 \begin{theorem}[Per-edge uniqueness of the torus gauge up to a constant]%
     \label{thm:torusAbsorbedGauge_unique_scalar}
     \lean{TNLean.PEPS.torusAbsorbedGauge_unique_scalar}

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -540,8 +540,9 @@ site-independent tensor and produces the global phase of
         \lambda^{nm}\,\langle \widetilde B\rangle_{\mathrm{torus}}.
     \]
     The single comparison region and its complement being injective makes this
-    common torus contraction nonzero, and translation gives the same scalar
-    $\lambda$ at every site, so $\lambda^{nm}=1$.
+    common torus contraction nonzero; by hypothesis the quotient
+    $c_S(v)/c_R(v)$ is the same scalar $\lambda$ at every site, so
+    $\lambda^{nm}=1$.
 \end{proof}
 
 \begin{theorem}[Per-edge uniqueness of the torus gauge up to a constant]%

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -506,13 +506,14 @@ site-independent tensor and produces the global phase of
     \lean{TNLean.PEPS.lambda_pow_card_torus_eq_one_of_twoBlockProportional}
     \leanok
     \uses{cor:peps_component_eq_gaugeVertex_of_twoBlockProportional}
-    Let $A$ and $B$ be PEPS tensors on the discrete $n\times m$ torus with positive
-    bond dimensions, generating the same state, and let $X$ be a family of invertible
-    matrices, one on each edge. Suppose that at every site $v$ a region $R_v$ not
-    containing $v$ is supplied together with the two two-block scalar
-    proportionalities of the blocked weights of $A$ and of the gauge-absorbed second
-    tensor over $R_v$ and over $R_v\cup\{v\}$, with nonzero ratios
-    $c_R(v)$ and $c_S(v)$ whose quotient is a single scalar $\lambda$, and with the
+    Let $A$ and $B$ be PEPS tensors on the discrete $n\times m$ torus with $n,m>1$,
+    with equal bond dimensions and positive bond dimensions, generating the same
+    state, and let $X$ be a family of invertible matrices, one on each edge. Suppose
+    that at every site $v$ a region $R_v$ not containing $v$ is supplied together with
+    the two two-block scalar proportionalities of the blocked weights of $A$ and of
+    the gauge-absorbed second tensor over $R_v$ and over $R_v\cup\{v\}$, with ratios
+    $c_R(v)$ and $c_S(v)$ satisfying $c_R(v)\ne 0$ and whose quotient
+    $c_S(v)/c_R(v)$ is a single scalar $\lambda$ independent of $v$, and with the
     gauge-absorbed region block linearly independent. If, in addition, a single
     comparison region whose block and complement block are both blocked-tensor
     injective is supplied, then $\lambda$ raised to the number of torus sites is one:
@@ -521,13 +522,26 @@ site-independent tensor and produces the global phase of
     \]
 \end{corollary}
 \begin{proof}\leanok
-    At each site the inserted-site scalar extraction of
+    At each of the $nm$ sites $v$ the inserted-site scalar extraction of
     Corollary~\ref{cor:peps_component_eq_gaugeVertex_of_twoBlockProportional} turns
     the two two-block proportionalities into the per-vertex gauge relation
-    $A_v=\lambda\,(\text{gauge action of }X\text{ on }B)_v$. The single comparison
-    region and its complement being injective forces the product of the per-vertex
-    scalars over the torus to one, and translation gives the same scalar $\lambda$ at
-    every site, so that product is $\lambda^{nm}$, yielding $\lambda^{nm}=1$.
+    \[
+        A_v(\eta,\sigma)
+        =
+        \lambda\,\widetilde B_v(\eta,\sigma),
+    \]
+    where $\widetilde B_v$ is the gauge action of $X$ on $B$ at $v$. Contracting
+    both sides over the whole torus pulls one factor of $\lambda$ out of each of
+    the $nm$ sites, so the closed torus contractions of $A$ and of $\widetilde B$
+    satisfy
+    \[
+        \langle A\rangle_{\mathrm{torus}}
+        =
+        \lambda^{nm}\,\langle \widetilde B\rangle_{\mathrm{torus}}.
+    \]
+    The single comparison region and its complement being injective makes this
+    common torus contraction nonzero, and translation gives the same scalar
+    $\lambda$ at every site, so $\lambda^{nm}=1$.
 \end{proof}
 
 \begin{theorem}[Per-edge uniqueness of the torus gauge up to a constant]%


### PR DESCRIPTION
Resolves #2649.

Adds blueprint entries for the inserted-site scalar-extraction theorems and the
torus scalar-condition corollary, the completed steps on the critical path to
arXiv:1804.04964 Theorem 3 named in the route document
`docs/paper-gaps/peps_normal_ft_section3_route.tex` that had no `\begin{...}`
block in the blueprint.

## New entries

In `blueprint/src/chapter/ch24_peps_ft_balanced_edge_scalars.tex`
(new subsection *Inserted-site scalar extraction*):

- `\lean{TNLean.PEPS.localConfig_eq_of_insertConsistent}` —
  `\label{lem:peps_localConfig_eq_of_insertConsistent}` (lemma);
  `\uses{}` none.
- `\lean{TNLean.PEPS.component_eq_of_regionProportional}` —
  `\label{thm:peps_component_eq_of_regionProportional}` (theorem);
  `\uses{lem:peps_localConfig_eq_of_insertConsistent}`.
- `\lean{TNLean.PEPS.component_eq_gaugeVertex_of_twoBlockProportional}` —
  `\label{cor:peps_component_eq_gaugeVertex_of_twoBlockProportional}` (corollary);
  `\uses{thm:peps_component_eq_of_regionProportional, def:peps_regionTwoBlock,
  def:applyGauge, def:gaugeVertex, thm:peps_twoInjectiveTensorInsertionComparison}`.

In `blueprint/src/chapter/ch24_peps_ft_torus.tex`
(after the translation-covariant torus Fundamental Theorem):

- `\lean{TNLean.PEPS.lambda_pow_card_torus_eq_one_of_twoBlockProportional}` —
  `\label{cor:peps_lambda_pow_card_torus_eq_one_of_twoBlockProportional}` (corollary);
  `\uses{cor:peps_component_eq_gaugeVertex_of_twoBlockProportional}`.

## Notes

- All four declarations are sorry-free and axiom-clean
  (`TNLean/PEPS/RegionBlock/ScalarExtraction.lean`,
  `TNLean/PEPS/TorusFundamentalTheorem.lean`); every entry carries
  statement-level and proof-level `\leanok`.
- `\uses{}` cites only labels that already exist exactly once; the
  no-blueprint-label dependencies (the bridge factorization, inserted-site
  consistency predicate, region-injectivity wrappers) are omitted rather than
  invented.
- Notation follows the route document: region proportionalities
  $A_R=c_R\,C_R$, $A_S=c_S\,C_S$ over $R$ and $R\cup\{v\}$, ratio $c_S/c_R$,
  per-vertex gauge relation, and the torus condition $\lambda^{nm}=1$.
- Reader-facing prose check passes
  (`scripts/check_reader_facing_prose.py --diff-base origin/main --ci`): no
  violations.

Closes #2649

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX blueprint additions with no runtime or proof-code changes in the diff; low risk aside from possible `\uses` / label cross-reference typos in the blueprint graph.
> 
> **Overview**
> Documents previously missing blueprint steps on the **normal PEPS Fundamental Theorem** route (issue #2649): turning paired region two-block proportionalities into a single inserted-site scalar and deriving the torus global phase constraint.
> 
> In **`ch24_peps_ft_balanced_edge_scalars.tex`**, a new subsection **Inserted-site scalar extraction** adds a lemma that inserted-site consistency fixes the local virtual configuration from the \(R\)-boundary label, a theorem that \(A_R=c_R C_R\) and \(A_S=c_S C_S\) force \(A_v=(c_S/c_R)C_v\) at the inserted site, and a corollary packaging the same as the **per-vertex gauge relation** from two-block proportionalities. Each block has `\lean{…}` / `\leanok` ties to `TNLean.PEPS.*` in `ScalarExtraction.lean`, with `\uses{}` only on existing labels.
> 
> In **`ch24_peps_ft_torus.tex`**, a corollary after the translation-covariant torus Fundamental Theorem states that site-wise two-block ratios with a common \(\lambda\) and a nonzero injective comparison region imply **\(\lambda^{nm}=1\)**, wired to `TNLean.PEPS.lambda_pow_card_torus_eq_one_of_twoBlockProportional` and the gauge-vertex corollary above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2631b83d177c9367c3b16c89209fefc8dee231e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->