### PR TITLE
doc(blueprint): relocate absorbed-equality entries to region-transfer and clean prose

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -198,6 +198,17 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
     \]
 \end{proof}
 
+For a region $R$, a physical configuration $\sigma$ on $R$, and a physical
+configuration $\tau$ on $V\setminus R$, write $\omega_{R,\sigma,\tau}$ for the
+physical configuration on $V$ with
+\[
+    \omega_{R,\sigma,\tau}(v)=
+    \begin{cases}
+        \sigma(v),& v\in R,\\
+        \tau(v),& v\notin R.
+    \end{cases}
+\]
+
 \begin{theorem}[Region insertion as an edge insertion]
     \label{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
     \lean{TNLean.PEPS.regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
@@ -215,14 +226,10 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         C_B(R,f,N;\sigma,\tau)
         =
         p_B(R)\,
-        E_B\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),
-            \mathcal O_{R,f}(N)\bigr).
+        E_B\bigl(f,\omega_{R,\sigma,\tau},\mathcal O_{R,f}(N)\bigr).
     \]
-    Here $\operatorname{Assemble}_R(\sigma,\tau)$ denotes the physical
-    configuration on $V$ that restricts to $\sigma$ on $R$ and to $\tau$ on
-    $V\setminus R$, and $\mathcal O_{R,f}$ is the boundary-edge orientation, equal
-    to the identity if the left endpoint of $f$ lies in $R$ and to transpose
-    otherwise.
+    Here $\mathcal O_{R,f}$ is the boundary-edge orientation, equal to the
+    identity if the left endpoint of $f$ lies in $R$ and to transpose otherwise.
 \end{theorem}
 \begin{proof}
     \leanok
@@ -241,7 +248,7 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         \#\operatorname{Fib}_{R,f}(\xi)\,
         N_{\xi_{R,f}^{(1)},\xi_{R,f}^{(2)}}
         \prod_{v\in V}
-        B_v\bigl(\xi_v,\operatorname{Assemble}_R(\sigma,\tau)_v\bigr),\\
+        B_v\bigl(\xi_v,\omega_{R,\sigma,\tau}(v)\bigr),\\
         \#\operatorname{Fib}_{R,f}(\xi)
         &=
         \prod_{g\notin\partial R}D_B(g)
@@ -258,11 +265,10 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         \sum_{\xi\in\mathcal C_{R,f}(\sigma,\tau)}
         N_{\xi_{R,f}^{(1)},\xi_{R,f}^{(2)}}
         \prod_{v\in V}
-        B_v\bigl(\xi_v,\operatorname{Assemble}_R(\sigma,\tau)_v\bigr)\\
+        B_v\bigl(\xi_v,\omega_{R,\sigma,\tau}(v)\bigr)\\
         &=
         p_B(R)\,
-        E_B\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),
-            \mathcal O_{R,f}(N)\bigr).
+        E_B\bigl(f,\omega_{R,\sigma,\tau},\mathcal O_{R,f}(N)\bigr).
     \end{aligned}
     \]
     The second equality is the definition of the edge-inserted coefficient,
@@ -1225,9 +1231,9 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
     endpoint gauges conjugate the oriented matrix
     $N=\mathcal O_{R,f}(M)$ by the transpose of $X_f$ and its inverse:
     \[
-        E_{B^X}\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),N\bigr)
+        E_{B^X}\bigl(f,\omega_{R,\sigma,\tau},N\bigr)
         =
-        E_B\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),
+        E_B\bigl(f,\omega_{R,\sigma,\tau},
             X_f^{\mathsf T}\,N\,(X_f^{-1})^{\mathsf T}\bigr).
     \]
     Transporting this back through

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -1162,10 +1162,11 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
     \uses{thm:peps_isRegionBoundaryEdge_insert_of_not_incident}
     Let $v\notin R$.  Given a crossing-edge label $\mu$ for $R\cup\{v\}$ and a
     local virtual configuration $\eta$ on the edges incident to $v$, the
-    crossing-edge label of $R$ is read off these two data: a crossing edge of $R$
-    incident to $v$ has become internal to $R\cup\{v\}$, so its label is taken
-    from $\eta$; a crossing edge of $R$ not incident to $v$ is also a crossing
-    edge of $R\cup\{v\}$, so its label is taken from $\mu$.
+    crossing-edge label $\beta(\mu,\eta)$ of $R$ is read off these two
+    configurations: a crossing edge of $R$ incident to $v$ has become internal to
+    $R\cup\{v\}$, so its label is taken from $\eta$; a crossing edge of $R$ not
+    incident to $v$ is also a crossing edge of $R\cup\{v\}$, so its label is taken
+    from $\mu$.
 \end{definition}
 
 \begin{theorem}[Boundary-label fiber identity across an inserted site]%
@@ -1175,8 +1176,9 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
     \uses{def:peps_boundaryLabelOfInsert}
     Let $v\notin R$.  If a global virtual configuration $\zeta$ restricts to $\mu$
     on the crossing edges of $R\cup\{v\}$ and to $\eta$ on the edges incident to
-    $v$, then the crossing-edge label of $R$ read from $\zeta$ is exactly the
-    bridge label of $\mu$ and $\eta$.
+    $v$, then the crossing-edge label of $R$ read from $\zeta$ is exactly
+    $\beta(\mu,\eta)$ of
+    Definition~\ref{def:peps_boundaryLabelOfInsert}.
 \end{theorem}
 \begin{proof}\leanok
     The two labels are compared edge by edge.  On a crossing edge of $R$
@@ -1186,7 +1188,7 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
 \end{proof}
 
 %======================================================================
-% Gauge-absorption bridge at region granularity
+% Gauge absorption at region granularity
 %======================================================================
 
 \begin{theorem}[Region gauge absorption]%
@@ -1215,12 +1217,201 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
 \begin{proof}\leanok
     By Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff} the
     region/complement contraction is the single-bond cut at $f$ up to the
-    interior-bond multiplicity, which is unchanged by a gauge.  At the edge
-    granularity every interior edge and every crossing edge other than $f$
-    cancels its gauge pairwise, while the two endpoint gauges on $f$ conjugate
-    the inserted matrix.  Transporting the cancelled identity back through the
-    region-to-edge identity, and using that the boundary-edge orientation is an
-    involution, gives the displayed equality.
+    interior-bond multiplicity $p_B(R)=\prod_{g\notin\partial R}D_B(g)$, which is
+    unchanged by a gauge.  At the edge granularity every interior edge and every
+    crossing edge other than $f$ cancels its gauge pairwise, while on $f$ the
+    endpoint gauges conjugate the oriented matrix
+    $N=\mathcal O_{R,f}(M)$ by the transpose of $X_f$ and its inverse:
+    \[
+        E_{B^X}\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),N\bigr)
+        =
+        E_B\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),
+            X_f^{\mathsf T}\,N\,(X_f^{-1})^{\mathsf T}\bigr).
+    \]
+    Transporting this back through
+    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff} on $B$,
+    and using that the boundary-edge orientation is an involution
+    ($\mathcal O_{R,f}\circ\mathcal O_{R,f}=\operatorname{id}$), gives the
+    displayed equality.
+\end{proof}
+
+\subsection{From the conjugation identity to the absorbed equality}%
+\label{subsec:peps_absorbed_equality}
+
+% Companion to docs/paper-gaps/peps_normal_ft_section3_route.tex.
+The per-edge gauge engine produces, at a region $R$ with single boundary edge
+$f$, the \emph{conjugation} form
+\[
+    C_A(R,f,M;\sigma,\tau)
+    =
+    C_B\bigl(R,f,Z\,\phi_{h_f}(M)\,Z^{-1};\sigma,\tau\bigr),
+\]
+where $Z$ is the invertible bond matrix on $f$ and $\phi_{h_f}$ is the
+matrix-algebra transport induced by $h_f:D_A(f)=D_B(f)$. The region comparison
+of \cite[Section~3]{Molnar2018NormalPEPS} instead consumes the \emph{absorbed}
+form: the gauge is absorbed into the second tensor, and the \emph{same} matrix
+$\phi_{h_f}(M)$ is inserted on both sides. The conversion is the content of the
+present subsection.
+
+\begin{definition}[Orientation-adapted absorbing gauge]%
+    \label{def:peps_absorbedBoundaryGauge}
+    \lean{TNLean.PEPS.absorbedBoundaryGauge}
+    \leanok
+    Let $f$ be a boundary edge of $R$ and let $Z$ be an invertible matrix on the
+    bond space of $f$. The orientation-adapted absorbing gauge is
+    \[
+        X_f
+        =
+        \begin{cases}
+            Z^{\mathsf T} & \text{if the left endpoint of $f$ lies in $R$,}\\
+            Z^{-1} & \text{otherwise.}
+        \end{cases}
+    \]
+    It is the absorbing matrix on $f$ for which the gauge action of the region
+    insertion reproduces the engine's conjugation by $Z$.
+\end{definition}
+
+\begin{lemma}[Matrix reconciliation for the absorbing gauge]%
+    \label{lem:peps_regionEdgeOrient_absorbedBoundaryGauge}
+    \lean{TNLean.PEPS.regionEdgeOrient_absorbedBoundaryGauge}
+    \leanok
+    \uses{def:peps_absorbedBoundaryGauge}
+    With $X_f$ the orientation-adapted absorbing gauge of $Z$ and
+    $\mathcal O_{R,f}$ the boundary-edge orientation, for every matrix $N$ on the
+    bond space of $f$,
+    \[
+        \mathcal O_{R,f}\bigl(
+            X_f^{\mathsf T}\,\mathcal O_{R,f}(N)\,(X_f^{-1})^{\mathsf T}
+        \bigr)
+        =
+        Z\,N\,Z^{-1}.
+    \]
+    The conjugation by $X_f^{\mathsf T}\cdot(\cdot)\cdot(X_f^{-1})^{\mathsf T}$
+    carried by the region gauge action thus reproduces the engine's conjugation
+    by $Z$.
+\end{lemma}
+\begin{proof}\leanok
+    When the left endpoint of $f$ lies in $R$, the orientation is the identity
+    and $X_f=Z^{\mathsf T}$, so $X_f^{\mathsf T}=Z$ and
+    $(X_f^{-1})^{\mathsf T}=Z^{-1}$. Otherwise the orientation is transpose and
+    $X_f=Z^{-1}$, so the outer transposes flip the conjugation onto the same
+    form. Both cases give $Z\,N\,Z^{-1}$.
+\end{proof}
+
+\begin{theorem}[Region absorbed equality from the conjugation identity]%
+    \label{thm:peps_regionInsertedCoeff_eq_applyGauge_of_conjIdentity}
+    \lean{TNLean.PEPS.regionInsertedCoeff_eq_applyGauge_of_conjIdentity}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:applyGauge,
+        def:peps_absorbedBoundaryGauge,
+        lem:peps_regionEdgeOrient_absorbedBoundaryGauge,
+        thm:peps_regionInsertedCoeff_applyGauge}
+    Let $R$ be a region with single boundary edge $f$ and assume the
+    bond-dimension equality $h:D_A=D_B$. Suppose the per-edge gauge $Z$ realizes
+    the conjugation-form region-insertion identity at $f$: for every matrix $M$
+    on the bond space of $f$ and all physical configurations $\sigma$ on $R$ and
+    $\tau$ on $V\setminus R$,
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_B\bigl(R,f,Z\,\phi_{h_f}(M)\,Z^{-1};\sigma,\tau\bigr).
+    \]
+    Let $X$ be an edge-gauge family whose value on $f$ is the orientation-adapted
+    absorbing gauge $X_f$ of $Z$. Then $A$ inserting $M$ matches the absorbed
+    tensor $B^X$ inserting the same transported matrix:
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_{B^X}\bigl(R,f,\phi_{h_f}(M);\sigma,\tau\bigr).
+    \]
+    This is the region analogue of
+    Theorem~\ref{thm:peps_postAbsorptionEdgeInsertionEquality}: the
+    conjugation-form coefficient identity becomes the absorbed plain equality.
+\end{theorem}
+\begin{proof}\leanok
+    By Theorem~\ref{thm:peps_regionInsertedCoeff_applyGauge} the region gauge
+    action conjugates the inserted matrix by
+    $X_f^{\mathsf T}\cdot\mathcal O_{R,f}(\cdot)\cdot(X_f^{-1})^{\mathsf T}$ and
+    cancels every interior gauge of the region and of its complement, so the
+    right-hand coefficient over $B^X$ equals the coefficient over $B$ with the
+    transported matrix conjugated by that gauge. Substituting the engine identity
+    on the left and the matrix reconciliation
+    Lemma~\ref{lem:peps_regionEdgeOrient_absorbedBoundaryGauge} matches the two
+    conjugation forms.
+\end{proof}
+
+\begin{theorem}[Edge absorbed equality from the region absorbed equality]%
+    \label{thm:peps_edgeInsertedCoeff_eq_applyGauge_of_region}
+    \lean{TNLean.PEPS.edgeInsertedCoeff_eq_applyGauge_of_region}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:peps_edgeInsertedCoeff,
+        def:applyGauge,
+        thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
+    Let $R$ be a region with boundary edge $f$, assume the bond-dimension
+    equality $h:D_A=D_B$ and that every bond dimension of $A$ is positive, and
+    suppose the absorbed region equality holds: for every matrix $M$ on the bond
+    space of $f$ and all physical configurations $\sigma$ on $R$ and $\tau$ on
+    $V\setminus R$,
+    \[
+        C_A(R,f,M;\sigma,\tau)
+        =
+        C_{B^X}\bigl(R,f,\phi_{h_f}(M);\sigma,\tau\bigr).
+    \]
+    Then the edge-level absorbed equality holds at $f$: for every global physical
+    configuration $\sigma$ and every matrix $N$ on the bond space of $f$,
+    \[
+        E_A(f,\sigma,N)
+        =
+        E_{B^X}\bigl(f,\sigma,\phi_{h_f}(N)\bigr).
+    \]
+    The edge-level identity no longer mentions the region.
+\end{theorem}
+\begin{proof}\leanok
+    The interior bond multiplicity $p_A(R)=\prod_{g\notin\partial R}D_A(g)$ is a
+    positive integer, and it is shared by $A$ and $B^X$ because the gauge
+    preserves bond dimensions and $D_A=D_B$. Reading both region coefficients
+    through the region-to-edge identity
+    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}, using
+    that the orientation $\mathcal O_{R,f}$ is an involution and commutes with the
+    transport, expresses each side as $p_A(R)$ times the edge-inserted
+    coefficient of the assembled configuration. Cancelling the shared positive
+    multiplicity gives the edge-level identity.
+\end{proof}
+
+\begin{theorem}[Region absorbed equality from the edge absorbed equality]%
+    \label{thm:peps_regionInsertedCoeff_eq_applyGauge_of_edge}
+    \lean{TNLean.PEPS.regionInsertedCoeff_eq_applyGauge_of_edge}
+    \leanok
+    \uses{def:peps_regionInsertedCoeff, def:peps_edgeInsertedCoeff,
+        def:applyGauge,
+        thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}
+    Assume the bond-dimension equality $h:D_A=D_B$ and suppose the edge-level
+    absorbed equality holds at an edge $e$: for every global physical
+    configuration $\sigma$ and every matrix $N$ on the bond space of $e$,
+    \[
+        E_A(e,\sigma,N)
+        =
+        E_{B^X}\bigl(e,\sigma,\phi_{h_e}(N)\bigr).
+    \]
+    Then the region absorbed equality holds at every region $R$ having $e$ as a
+    boundary edge: for every matrix $M$ on the bond space of $e$ and all physical
+    configurations $\sigma$ on $R$ and $\tau$ on $V\setminus R$,
+    \[
+        C_A(R,e,M;\sigma,\tau)
+        =
+        C_{B^X}\bigl(R,e,\phi_{h_e}(M);\sigma,\tau\bigr).
+    \]
+    Together with the preceding theorem this expresses region-independence: the
+    absorbed plain equality over any comparison region follows from the single
+    edge-level identity at the boundary edge.
+\end{theorem}
+\begin{proof}\leanok
+    Read both region coefficients through the region-to-edge identity
+    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}. The
+    interior multiplicities agree because the gauge preserves bond dimensions and
+    $D_A=D_B$, and the orientation $\mathcal O_{R,e}$ commutes with the transport,
+    so the region equality reduces to the edge-level equality of the assembled
+    configuration, which is the hypothesis.
 \end{proof}
 
 %======================================================================
@@ -1310,8 +1501,8 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         =
         C_{A_2}\bigl(R,f,\psi M;\sigma,\tau\bigr).
     \]
-    This bridges the literal tensor of a translation-invariant PEPS with its
-    transported copy.
+    This connects the literal tensor of a translation-invariant PEPS with its
+    transported copy through the definitional equality $A_1=A_2$.
 \end{theorem}
 \begin{proof}\leanok
     Substituting the equality of tensors identifies the two coefficients, and the
@@ -1326,11 +1517,11 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
     \uses{def:peps_torus_translation_invariant,
         def:peps_torus_geometry_translation}
     Let $A$ be translation invariant on the discrete torus, let $f$ be a crossing
-    edge of $R$, and let $\tau_{a,b}$ be a translation.  The bond dimension of $A$
+    edge of $R$, and let $T_{a,b}$ be a translation.  The bond dimension of $A$
     at the translated crossing edge equals its bond dimension at the reference
     crossing edge:
     \[
-        D_A\bigl(\tau_{a,b}(f)\bigr)=D_A(f).
+        D_A\bigl(T_{a,b}(f)\bigr)=D_A(f).
     \]
 \end{theorem}
 \begin{proof}\leanok
@@ -1355,16 +1546,16 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         =
         C_B\bigl(R,f,g(M);\sigma,\tau\bigr).
     \]
-    Then, for every translation $\tau_{a,b}$, the same identity holds at the
+    Then, for every translation $T_{a,b}$, the same identity holds at the
     translated crossing edge of the translated region, with the inserted matrix
     carried between the translated and reference bonds:
     \[
-        C_A\bigl(\tau_{a,b}(R),\tau_{a,b}(f),M';
-            \tau_{a,b}\cdot\sigma,\tau_{a,b}\cdot\tau\bigr)
+        C_A\bigl(T_{a,b}(R),T_{a,b}(f),M';
+            T_{a,b}\cdot\sigma,T_{a,b}\cdot\tau\bigr)
         =
-        C_B\bigl(\tau_{a,b}(R),\tau_{a,b}(f),
+        C_B\bigl(T_{a,b}(R),T_{a,b}(f),
             \widehat{g}(M');
-            \tau_{a,b}\cdot\sigma,\tau_{a,b}\cdot\tau\bigr),
+            T_{a,b}\cdot\sigma,T_{a,b}\cdot\tau\bigr),
     \]
     where $\widehat{g}$ applies $g$ to the reference-bond reindex of $M'$ and
     carries the result back to the translated bond.

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -1427,7 +1427,8 @@ $\phi_{h_f}(M)$ is inserted on both sides.
             \phi_{h_e}(\mathcal O_{R,e}(M))\bigr).
     \]
     The edge-level hypothesis at $\omega_{R,\sigma,\tau}$ equates these
-    coefficients; cancelling $p_A(R)$ gives the region equality.
+    coefficients; multiplying by the common factor $p_A(R)$ gives the region
+    equality.
 \end{proof}
 
 %======================================================================
@@ -1517,8 +1518,8 @@ $\phi_{h_f}(M)$ is inserted on both sides.
         =
         C_{A_2}\bigl(R,f,\psi M;\sigma,\tau\bigr).
     \]
-    This connects the literal tensor of a translation-invariant PEPS with its
-    transported copy through the definitional equality $A_1=A_2$.
+    This applies to any tensor equality $A_1=A_2$, including the equality between
+    a translation-invariant tensor and its transported copy.
 \end{theorem}
 \begin{proof}\leanok
     Substituting the equality of tensors identifies the two coefficients, and the

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -1300,8 +1300,18 @@ $\phi_{h_f}(M)$ is inserted on both sides.
     When the left endpoint of $f$ lies in $R$, the orientation is the identity
     and $X_f=Z^{\mathsf T}$, so $X_f^{\mathsf T}=Z$ and
     $(X_f^{-1})^{\mathsf T}=Z^{-1}$. Otherwise the orientation is transpose and
-    $X_f=Z^{-1}$, so the outer transposes flip the conjugation onto the same
-    form. Both cases give $Z\,N\,Z^{-1}$.
+    $X_f=Z^{-1}$, so $X_f^{\mathsf T}=(Z^{-1})^{\mathsf T}$ and
+    $(X_f^{-1})^{\mathsf T}=Z^{\mathsf T}$, giving
+    \[
+        X_f^{\mathsf T}\,\mathcal O_{R,f}(N)\,(X_f^{-1})^{\mathsf T}
+        =
+        (Z^{-1})^{\mathsf T}\,N^{\mathsf T}\,Z^{\mathsf T}
+        =
+        (Z\,N\,Z^{-1})^{\mathsf T}.
+    \]
+    Applying the outer transpose orientation gives
+    $\mathcal O_{R,f}((Z\,N\,Z^{-1})^{\mathsf T})=Z\,N\,Z^{-1}$.
+    Both cases give $Z\,N\,Z^{-1}$.
 \end{proof}
 
 \begin{theorem}[Region absorbed equality from the conjugation identity]%

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -1278,8 +1278,8 @@ $\phi_{h_f}(M)$ is inserted on both sides.
     coefficient reproduces the conjugation $Z\,(\cdot)\,Z^{-1}$.
 \end{definition}
 
-\begin{lemma}[Matrix reconciliation for the absorbing gauge]%
-    \label{lem:peps_regionEdgeOrient_absorbedBoundaryGauge}
+\begin{theorem}[Matrix reconciliation for the absorbing gauge]%
+    \label{thm:peps_regionEdgeOrient_absorbedBoundaryGauge}
     \lean{TNLean.PEPS.regionEdgeOrient_absorbedBoundaryGauge}
     \leanok
     \uses{def:peps_absorbedBoundaryGauge}
@@ -1295,7 +1295,7 @@ $\phi_{h_f}(M)$ is inserted on both sides.
     \]
     The conjugation by $X_f^{\mathsf T}\cdot(\cdot)\cdot(X_f^{-1})^{\mathsf T}$
     carried by the region gauge action thus equals $Z\,(\cdot)\,Z^{-1}$.
-\end{lemma}
+\end{theorem}
 \begin{proof}\leanok
     When the left endpoint of $f$ lies in $R$, the orientation is the identity
     and $X_f=Z^{\mathsf T}$, so $X_f^{\mathsf T}=Z$ and
@@ -1310,7 +1310,7 @@ $\phi_{h_f}(M)$ is inserted on both sides.
     \leanok
     \uses{def:peps_regionInsertedCoeff, def:applyGauge,
         def:peps_absorbedBoundaryGauge,
-        lem:peps_regionEdgeOrient_absorbedBoundaryGauge,
+        thm:peps_regionEdgeOrient_absorbedBoundaryGauge,
         thm:peps_regionInsertedCoeff_applyGauge}
     Let $R$ be a region with boundary edge $f$ and assume the
     bond-dimension equality $h:D_A=D_B$. Suppose the per-edge gauge $Z$ realizes
@@ -1342,7 +1342,7 @@ $\phi_{h_f}(M)$ is inserted on both sides.
     right-hand coefficient over $B^X$ equals the coefficient over $B$ with the
     transported matrix conjugated by that gauge. Substituting the conjugation
     hypothesis on the left and the matrix reconciliation
-    Lemma~\ref{lem:peps_regionEdgeOrient_absorbedBoundaryGauge} matches the two
+    Theorem~\ref{thm:peps_regionEdgeOrient_absorbedBoundaryGauge} matches the two
     conjugation forms.
 \end{proof}
 
@@ -1375,16 +1375,40 @@ $\phi_{h_f}(M)$ is inserted on both sides.
 \begin{proof}\leanok
     The interior bond multiplicity $p_A(R)=\prod_{g\notin\partial R}D_A(g)$ is a
     positive integer, and it is shared by $A$ and $B^X$ because the gauge
-    preserves bond dimensions and $D_A=D_B$. Reading both region coefficients
-    through the region-to-edge identity
+    preserves bond dimensions and $D_A=D_B$. Apply
     Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff} with the
-    orientation-corrected matrix $\mathcal O_{R,f}(N)$ and the configurations
-    $(\sigma|_R,\sigma|_{V\setminus R})$. Using the involution
+    inserted matrix $\mathcal O_{R,f}(N)$ and with configurations
+    $(\sigma|_R,\sigma|_{V\setminus R})$. On the left-hand side,
+    \[
+        C_A\bigl(R,f,\mathcal O_{R,f}(N);
+            \sigma|_R,\sigma|_{V\setminus R}\bigr)
+        =
+        p_A(R)\,
+        E_A\bigl(f,\sigma,
+            \mathcal O_{R,f}(\mathcal O_{R,f}(N))\bigr)
+        =
+        p_A(R)\,E_A(f,\sigma,N).
+    \]
+    On the right-hand side of the assumed region equality,
+    \[
+    \begin{aligned}
+        C_{B^X}\bigl(R,f,\phi_{h_f}(\mathcal O_{R,f}(N));
+            \sigma|_R,\sigma|_{V\setminus R}\bigr)
+        &=
+        p_A(R)\,
+        E_{B^X}\bigl(f,\sigma,
+            \mathcal O_{R,f}(\phi_{h_f}(\mathcal O_{R,f}(N)))\bigr)\\
+        &=
+        p_A(R)\,
+        E_{B^X}\bigl(f,\sigma,\phi_{h_f}(N)\bigr).
+    \end{aligned}
+    \]
+    The displayed equalities also use
     $\mathcal O_{R,f}\circ\mathcal O_{R,f}=\operatorname{id}$, the compatibility
     of $\mathcal O_{R,f}$ with transport, and
-    $\omega_{R,\sigma|_R,\sigma|_{V\setminus R}}=\sigma$, each side becomes
-    $p_A(R)$ times the corresponding edge-inserted coefficient. Cancelling the
-    shared positive multiplicity gives the edge-level identity.
+    $\omega_{R,\sigma|_R,\sigma|_{V\setminus R}}=\sigma$. Substituting these two
+    identities into the assumed region equality and cancelling the shared
+    positive multiplicity gives the edge-level identity.
 \end{proof}
 
 \begin{theorem}[Region absorbed equality from the edge absorbed equality]%

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -218,8 +218,10 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
         E_B\bigl(f,\operatorname{Assemble}_R(\sigma,\tau),
             \mathcal O_{R,f}(N)\bigr).
     \]
-    Here $\mathcal O_{R,f}$ is the boundary-edge orientation, equal to the
-    identity if the left endpoint of $f$ lies in $R$ and to transpose
+    Here $\operatorname{Assemble}_R(\sigma,\tau)$ denotes the physical
+    configuration on $V$ that restricts to $\sigma$ on $R$ and to $\tau$ on
+    $V\setminus R$, and $\mathcal O_{R,f}$ is the boundary-edge orientation, equal
+    to the identity if the left endpoint of $f$ lies in $R$ and to transpose
     otherwise.
 \end{theorem}
 \begin{proof}
@@ -1250,8 +1252,7 @@ where $Z$ is the invertible bond matrix on $f$ and $\phi_{h_f}$ is the
 matrix-algebra transport induced by $h_f:D_A(f)=D_B(f)$. The region comparison
 of \cite[Section~3]{Molnar2018NormalPEPS} instead consumes the \emph{absorbed}
 form: the gauge is absorbed into the second tensor, and the \emph{same} matrix
-$\phi_{h_f}(M)$ is inserted on both sides. The conversion is the content of the
-present subsection.
+$\phi_{h_f}(M)$ is inserted on both sides.
 
 \begin{definition}[Orientation-adapted absorbing gauge]%
     \label{def:peps_absorbedBoundaryGauge}

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -1239,7 +1239,7 @@ injective PEPS, Theorem~\ref{thm:fundamentalTheorem_PEPS}, the formalization of
 \label{subsec:peps_absorbed_equality}
 
 % Companion to docs/paper-gaps/peps_normal_ft_section3_route.tex.
-The per-edge gauge engine produces, at a region $R$ with single boundary edge
+The per-edge gauge engine produces, at a region $R$ with boundary edge
 $f$, the \emph{conjugation} form
 \[
     C_A(R,f,M;\sigma,\tau)
@@ -1306,7 +1306,7 @@ present subsection.
         def:peps_absorbedBoundaryGauge,
         lem:peps_regionEdgeOrient_absorbedBoundaryGauge,
         thm:peps_regionInsertedCoeff_applyGauge}
-    Let $R$ be a region with single boundary edge $f$ and assume the
+    Let $R$ be a region with boundary edge $f$ and assume the
     bond-dimension equality $h:D_A=D_B$. Suppose the per-edge gauge $Z$ realizes
     the conjugation-form region-insertion identity at $f$: for every matrix $M$
     on the bond space of $f$ and all physical configurations $\sigma$ on $R$ and

--- a/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_region_transfer.tex
@@ -1247,8 +1247,8 @@ physical configuration on $V$ with
 \label{subsec:peps_absorbed_equality}
 
 % Companion to docs/paper-gaps/peps_normal_ft_section3_route.tex.
-The per-edge gauge engine produces, at a region $R$ with boundary edge
-$f$, the \emph{conjugation} form
+At a region $R$ with boundary edge $f$, the per-edge gauge identity takes
+the \emph{conjugation} form
 \[
     C_A(R,f,M;\sigma,\tau)
     =
@@ -1274,8 +1274,8 @@ $\phi_{h_f}(M)$ is inserted on both sides.
             Z^{-1} & \text{otherwise.}
         \end{cases}
     \]
-    It is the absorbing matrix on $f$ for which the gauge action of the region
-    insertion reproduces the engine's conjugation by $Z$.
+    It is the absorbing matrix on $f$ for which the gauge action on the region
+    coefficient reproduces the conjugation $Z\,(\cdot)\,Z^{-1}$.
 \end{definition}
 
 \begin{lemma}[Matrix reconciliation for the absorbing gauge]%
@@ -1294,8 +1294,7 @@ $\phi_{h_f}(M)$ is inserted on both sides.
         Z\,N\,Z^{-1}.
     \]
     The conjugation by $X_f^{\mathsf T}\cdot(\cdot)\cdot(X_f^{-1})^{\mathsf T}$
-    carried by the region gauge action thus reproduces the engine's conjugation
-    by $Z$.
+    carried by the region gauge action thus equals $Z\,(\cdot)\,Z^{-1}$.
 \end{lemma}
 \begin{proof}\leanok
     When the left endpoint of $f$ lies in $R$, the orientation is the identity
@@ -1341,8 +1340,8 @@ $\phi_{h_f}(M)$ is inserted on both sides.
     $X_f^{\mathsf T}\cdot\mathcal O_{R,f}(\cdot)\cdot(X_f^{-1})^{\mathsf T}$ and
     cancels every interior gauge of the region and of its complement, so the
     right-hand coefficient over $B^X$ equals the coefficient over $B$ with the
-    transported matrix conjugated by that gauge. Substituting the engine identity
-    on the left and the matrix reconciliation
+    transported matrix conjugated by that gauge. Substituting the conjugation
+    hypothesis on the left and the matrix reconciliation
     Lemma~\ref{lem:peps_regionEdgeOrient_absorbedBoundaryGauge} matches the two
     conjugation forms.
 \end{proof}
@@ -1378,11 +1377,14 @@ $\phi_{h_f}(M)$ is inserted on both sides.
     positive integer, and it is shared by $A$ and $B^X$ because the gauge
     preserves bond dimensions and $D_A=D_B$. Reading both region coefficients
     through the region-to-edge identity
-    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}, using
-    that the orientation $\mathcal O_{R,f}$ is an involution and commutes with the
-    transport, expresses each side as $p_A(R)$ times the edge-inserted
-    coefficient of the assembled configuration. Cancelling the shared positive
-    multiplicity gives the edge-level identity.
+    Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff} with the
+    orientation-corrected matrix $\mathcal O_{R,f}(N)$ and the configurations
+    $(\sigma|_R,\sigma|_{V\setminus R})$. Using the involution
+    $\mathcal O_{R,f}\circ\mathcal O_{R,f}=\operatorname{id}$, the compatibility
+    of $\mathcal O_{R,f}$ with transport, and
+    $\omega_{R,\sigma|_R,\sigma|_{V\setminus R}}=\sigma$, each side becomes
+    $p_A(R)$ times the corresponding edge-inserted coefficient. Cancelling the
+    shared positive multiplicity gives the edge-level identity.
 \end{proof}
 
 \begin{theorem}[Region absorbed equality from the edge absorbed equality]%
@@ -1416,9 +1418,16 @@ $\phi_{h_f}(M)$ is inserted on both sides.
     Read both region coefficients through the region-to-edge identity
     Theorem~\ref{thm:peps_regionInsertedCoeff_eq_smul_edgeInsertedCoeff}. The
     interior multiplicities agree because the gauge preserves bond dimensions and
-    $D_A=D_B$, and the orientation $\mathcal O_{R,e}$ commutes with the transport,
-    so the region equality reduces to the edge-level equality of the assembled
-    configuration, which is the hypothesis.
+    $D_A=D_B$, and the orientation $\mathcal O_{R,e}$ commutes with the transport.
+    Hence the two sides are $p_A(R)$ times the edge coefficients
+    \[
+        E_A(e,\omega_{R,\sigma,\tau},\mathcal O_{R,e}(M))
+        \quad\text{and}\quad
+        E_{B^X}\bigl(e,\omega_{R,\sigma,\tau},
+            \phi_{h_e}(\mathcal O_{R,e}(M))\bigr).
+    \]
+    The edge-level hypothesis at $\omega_{R,\sigma,\tau}$ equates these
+    coefficients; cancelling $p_A(R)$ gives the region equality.
 \end{proof}
 
 %======================================================================


### PR DESCRIPTION
## Summary

A blueprint-only follow-up to merged PR #2860, touching a single file
(`blueprint/src/chapter/ch24_peps_ft_region_transfer.tex`). It does two things.

### (a) Addresses PR #2860's Category B review

1. **Banned term "bridge label".** In the boundary-label fiber identity the
   crossing-edge label is now named by its mathematical content: the definition
   `def:peps_boundaryLabelOfInsert` introduces the symbol $\beta(\mu,\eta)$, and
   the theorem cites $\beta(\mu,\eta)$ instead of "bridge label".
2. **Banned term "bridges".** The covariance theorem now reads "This connects the
   literal tensor of a translation-invariant PEPS with its transported copy
   through the definitional equality $A_1=A_2$." The section comment "Gauge-absorption
   bridge" is reworded to "Gauge absorption at region granularity".
3. **Notation collision $\tau$.** In the translation-covariance theorem the
   translation symbol $\tau_{a,b}$ collided with the physical configuration $\tau$
   in $C_A(R,f,M;\sigma,\tau)$, producing $\tau_{a,b}\cdot\tau$. The translation is
   renamed $T_{a,b}$ throughout that theorem and its proof (and the adjacent
   bond-dimension theorem), leaving $\tau$ for the physical configuration.
4. **Word-only proof sketch.** The Region gauge absorption proof now anchors the
   gauge cancellation to a displayed edge-level identity
   $E_{B^X}(f,\cdot,N)=E_B(f,\cdot,X_f^{\mathsf T}\,N\,(X_f^{-1})^{\mathsf T})$ with
   $N=\mathcal O_{R,f}(M)$, faithful to `regionInsertedCoeff_applyGauge`, and states
   the orientation involution explicitly.

### (b) Relocates the absorbed-equality entries from edge_middle to region_transfer

The "From the conjugation identity to the absorbed equality" subsection (one
definition, one lemma, three theorems: `absorbedBoundaryGauge`,
`regionEdgeOrient_absorbedBoundaryGauge`,
`regionInsertedCoeff_eq_applyGauge_of_conjIdentity`,
`edgeInsertedCoeff_eq_applyGauge_of_region`,
`regionInsertedCoeff_eq_applyGauge_of_edge`) is moved into
`ch24_peps_ft_region_transfer.tex`, placed immediately after the Region gauge
absorption theorem, where its dependency `def:peps_regionInsertedCoeff` is already
defined. The chapter includes `region_transfer` after `edge_middle`, so the prior
placement referenced `def:peps_regionInsertedCoeff` before definition; this fixes
the ordering.

Labels, `\lean{}`, `\leanok`, and statements are unchanged. The
`regionInsertedCoeff_eq_applyGauge_of_conjIdentity` proof now wires
`\uses{thm:peps_regionInsertedCoeff_applyGauge}` (added by #2860, now in this file)
and cites it directly instead of describing the region gauge action inline.

`Closes #2639`. This PR supersedes PR #2857, which added the same entries to the
wrong file (`ch24_peps_ft_edge_middle.tex`).

## Verification

- All `\lean{}` decls in the file resolve under `TNLean/PEPS/`.
- All relocated `\label`s are unique; all `\uses`/`\ref` resolve.
- No conflict markers, no em-dashes, no banned terms, no issue numbers in prose.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`: no violations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and LaTeX ordering/prose only; no runtime code or formal proof logic changes beyond relocated blueprint text.
> 
> **Overview**
> Blueprint-only edits to `ch24_peps_ft_region_transfer.tex`: the **absorbed-equality** block (orientation-adapted gauge, matrix reconciliation, and region/edge absorbed identities) is placed **after** region gauge absorption so it follows `def:peps_regionInsertedCoeff` instead of appearing earlier in `edge_middle`.
> 
> The region-to-edge factorization now uses global physical configuration **`ω_{R,σ,τ}`** in place of **`Assemble_R(σ,τ)`**, and the **region gauge absorption** proof cites an explicit edge-level conjugation identity before invoking the orientation involution.
> 
> Reader-facing cleanup from prior review: boundary labels are **`β(μ,η)`** (not “bridge label”), section wording drops “bridge,” torus **translations are `T_{a,b}`** so physical **`τ`** is unambiguous, and the tensor-congruence remark no longer uses “bridges” phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd3205e627ff253cc0a4ad9bd9b30c45d7470fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->