### PR TITLE
doc(MPS/RFP): sync per-block isometry blueprint

### DIFF
--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -490,8 +490,10 @@ and rates for the single-tensor transfer map $\E_A$.
         \delta_{k,\ell}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
     The theorem above records the contracted per-block condition
-    $\sum_i (U_k^i)^\dagger U_k^i=I$ and the diagonal pair-index equation in
-    the single-block normalization. It does not impose the trace-normalization
+    $\sum_i (U_k^i)^\dagger U_k^i=I$ and the diagonal pair-index equation with
+    right-hand side
+    $D_k^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}$. It does not impose
+    the trace-normalization
     $\tr(\Lambda_k)=1$, and it does not include the cross-block equations for
     $k\ne\ell$. This restriction is recorded in
     \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -464,8 +464,15 @@ and rates for the single-tensor transfer map $\E_A$.
     When each block $A_k$ of a multi-block tensor is a normal, left-canonical
     renormalization fixed point, that block admits the isometry decomposition
     $A_k^i = X_k \Lambda_k U_k^i X_k^{-1}$, with $X_k$ invertible, $\Lambda_k$
-    diagonal positive, and $U_k = (U_k^i)$ a physical-index isometry,
-    $\sum_i (U_k^i)^\dagger U_k^i = I$.
+    diagonal positive, and $U_k = (U_k^i)$ satisfies
+    $\sum_i (U_k^i)^\dagger U_k^i = I$ and the pair-index orthonormality
+    condition
+    \[
+        \sum_i \overline{(U_k^i)_{\alpha,\beta}}\,
+        (U_k^i)_{\alpha',\beta'}
+        =
+        D_k^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
+    \]
     This is the blockwise form of the isometry canonical form
     (Theorem~\ref{thm:rfp_nt_structural_full}); see
     \cite[Section~3]{Cirac2016MPDO_arXiv}. The source additionally imposes the
@@ -482,11 +489,12 @@ and rates for the single-tensor transfer map $\E_A$.
         =
         \delta_{k,\ell}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
-    The theorem above records only the contracted per-block condition
-    $\sum_i (U_k^i)^\dagger U_k^i=I$. It does not state the full diagonal
-    pair-index equality, with its source normalization, and it also does not
-    include the cross-block equations for $k\ne\ell$. This restriction is
-    recorded in \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+    The theorem above records the contracted per-block condition
+    $\sum_i (U_k^i)^\dagger U_k^i=I$ and the diagonal pair-index equation in
+    the single-block normalization. It does not impose the trace-normalization
+    $\tr(\Lambda_k)=1$, and it does not include the cross-block equations for
+    $k\ne\ell$. This restriction is recorded in
+    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp_nt_structural_full}


### PR DESCRIPTION
### Motivation
- The blueprint entry `thm:rfp_nt_structural_full_blocks` omitted the diagonal pair-index orthonormality now present in the Lean theorem.
- The source comparison is arXiv:1606.00608, equation `eq:III_isometry`, in `Papers/1606.00608/MPDO-22-12-17-2.tex:550--554`.
- The remaining restriction is recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`: the source trace-normalization of `Λ_k` and the cross-block `δ_{j,j'}` orthogonality are not part of the per-block formal theorem.

### Description
- Added the pair-index equation
  `Σ_i overline((U_k^i)_{α,β}) (U_k^i)_{α',β'} = D_k^{-1} δ_{α,α'} δ_{β,β'}`
  to the blueprint statement of `thm:rfp_nt_structural_full_blocks`.
- Replaced the obsolete scope prose saying that the diagonal pair-index equation was absent.
- Kept the scope restriction focused on the two remaining differences from the source statement: `tr(Λ_k)=1` and the cross-block equations for `k ≠ ℓ`.

### Testing
- `git diff --check`
- `lake build`
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main`

---
Closes #2838

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in blueprint LaTeX; no Lean or runtime code modified.
> 
> **Overview**
> Updates the blueprint statement of **`thm:rfp_nt_structural_full_blocks`** so it matches the Lean theorem **`MPSTensor.rfp_nt_structural_full_blocks`**, which already includes the per-block diagonal pair-index orthonormality equation with right-hand side **\(D_k^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\)**.
> 
> The scope note no longer claims that diagonal pair-index condition is missing; it now states explicitly that the formal result still differs from the Cirac–Pérez–Schuch–Verstraete source only on **\(\tr(\Lambda_k)=1\)** and the **cross-block** isometry equations for **\(k\neq\ell\)**, with the gap still documented in **`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fe739a2b7c524f47dbd2f655496950d92a8a161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->