### PR TITLE
doc(parent): use closure-property boundary terminology

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -7,7 +7,7 @@ $\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)$ of a chain ground
 state. Once the one-sided boundary products are known, equality of the two
 restrictions follows from the commutation identity $XA^j=A^jX$ for every
 physical letter $j$. The remaining boundary-closing step is to derive these
-identities from the block-window equation.
+identities from the boundary matrix identity in the closure-property comparison.
 
 \begin{lemma}[Block-to-letter translation of the boundary block matrix equation]
     \label{lem:block_mateq_of_blocked_mateq}
@@ -41,7 +41,7 @@ identities from the block-window equation.
     asserted equation for every $s$ and $c$.
 \end{proof}
 
-\begin{lemma}[Boundary matrix commutation from a block-window equation]
+\begin{lemma}[Boundary matrix commutation from the closure-property identity]
     \label{lem:boundary_matrix_commutes_block_window}
     \lean{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}
     \leanok
@@ -88,7 +88,7 @@ identities from the block-window equation.
     gives $X A^j-A^jX=0$.
 \end{proof}
 
-\begin{lemma}[Block-window equation at the closing boundary]
+\begin{lemma}[Boundary matrix identity at the closing boundary]
     \label{lem:closure_property_boundary_block_window_equation_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}
     \leanok
@@ -173,7 +173,7 @@ identities from the block-window equation.
     \]
 \end{proof}
 
-\begin{lemma}[Products with one-site tensors determine the witness]
+\begin{lemma}[Products with one-site tensors determine the boundary matrix]
     \label{lem:wrapped_mirror_right_products_determine}
     \lean{MPSTensor.wrapped_mirror_witness_agree_of_right_products}
     \leanok
@@ -219,9 +219,9 @@ identities from the block-window equation.
     \[
         Y_\rho=Y_{\tau^-_\eta(\mu)}.
     \]
-    This is the witness-independence step used to choose one representative
-    outside configuration for each outside word in the open block-window matrix
-    comparison.
+    This is the boundary-matrix independence step used to choose one
+    representative outside configuration for each outside word in the
+    closure-property matrix comparison.
 \end{lemma}
 
 \begin{proof}
@@ -917,8 +917,9 @@ identities from the block-window equation.
     \]
     Lemma~\ref{lem:closed_boundary_restrictions_from_first_letter_products}
     then identifies the two cyclic restrictions. Thus the full boundary
-    restriction conclusion has been reduced to the block-window equation. The
-    derivation of that equation from the closing-boundary local constraints is
+    restriction conclusion has been reduced to the boundary matrix identity in
+    the closure-property comparison. The derivation of that identity from the
+    closing-boundary local constraints is
     the remaining part of the boundary-closing sentence in
     \cite[lines~2078--2079]{Cirac2021Matrix}; it is recorded in
     \path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex}.

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -67,15 +67,15 @@ boundary-closing sentence, and
 
 The corresponding formal statement keeps the intended hypotheses. In
 mathematical terms, it assumes that $A$ is normal, that $A$ is injective
-after blocking a positive number $L_0$ of sites, and that the periodic
-chain has length $N\ge 2$ with an interaction range $L$ satisfying
-$L_0<L\le N$. The desired conclusion is that the
-periodic-chain ground space is the line spanned by the periodic MPS vector
+after blocking a positive number $L_0$ of sites, and that the ring has length
+$N\ge 2$ with an interaction range $L$ satisfying $L_0<L\le N$. The desired
+conclusion is that the periodic-boundary ground space is the line spanned by
+the periodic MPS vector
 $\Omega_N(A)$:
 \[
   \mathcal G_{N,L}(A)=\mathbb C\,\Omega_N(A).
 \]
-In the formal statement this is the equality between the cyclic chain ground
+In the formal statement this is the equality between the periodic-boundary ground
 space and the subspace \(\mathbb C\,\Omega_N(A)\). The hard inclusion into
 \(\mathbb C\,\Omega_N(A)\) is the remaining range-reduction lemma.
 \footnote{Formal locations:
@@ -132,17 +132,17 @@ through the older single-site intersection lemma.
 
 \section{The remaining commutation identity}
 
-After the open-chain step, a periodic-chain ground state can be written with an
-open-chain boundary matrix $X$. The point left to prove is that the cyclic
-length-$L_0+1$ constraints force $X$ to commute with the one-site matrices of
-$A$; block injectivity then forces $X$ to be scalar, and hence the state lies in
-\(\mathbb C\,\Omega_N(A)\).
+After the open-boundary range reduction, a periodic-boundary ground state can
+be written in trace form with a matrix $X$. The point left to prove is that the
+cyclic length-$L_0+1$ constraints force $X$ to commute with the one-site
+matrices of $A$; block injectivity then forces $X$ to be scalar, and hence the
+state lies in \(\mathbb C\,\Omega_N(A)\).
 
 This is why the open-chain containment cannot simply be reversed. Let
-\(\Gamma_N(X)\) denote the length-\(N\) open-chain vector
+\(\Gamma_N(X)\) denote the length-\(N\) trace-form vector
 \(\Gamma_N(X)_\omega=\tr(A^\omega X)\). A vector
-\(\Gamma_N(X)\in G_N(A)\) need not lie in the cyclic-chain ground space. For a
-boundary-crossing window, the restriction has trace coefficients with \(X\)
+\(\Gamma_N(X)\in G_N(A)\) need not lie in the periodic-boundary ground space.
+For a boundary-crossing window, the restriction has trace coefficients with \(X\)
 between the two parts of the window word,
 \begin{align}
   \tr\!\left(A^{\omega_{\mathrm{tail}}}X
@@ -162,18 +162,19 @@ In the coordinate form used here, \(\mu\) denotes the nonempty word placed on
 the sites outside the two cyclic windows and \(\eta\) is the letter used on the
 remaining outside sites. This is a coordinate form of the boundary-closing
 sentence in Section~IV.C, lines 2078--2079. The reduction isolates the movement
-of \(X\) as a boundary matrix identity in the closure-property comparison, which
-implies the one-site commutation identity. After choosing boundary matrices for
-the two boundary-crossing restrictions, the verified one-sided boundary-product
-lemma gives, for every physical letter \(j\),
+of \(X\) as an identity between boundary-restriction matrices in the
+closure-property comparison, which implies the one-site commutation identity.
+After choosing boundary-restriction matrices for the two boundary-crossing
+restrictions, the verified one-sided boundary-product lemma gives, for every
+physical letter \(j\),
 \[
   W_\eta A^j=A^\mu A^jX,
   \qquad
   XA^jA^\mu=A^jV_\eta .
 \]
-Here \(W_\eta\) is the boundary matrix for the last-site boundary restriction
-and \(V_\eta\) is the boundary matrix for the opposite boundary-crossing
-restriction.
+Here \(W_\eta\) is the boundary-restriction matrix for the last-site boundary
+restriction and \(V_\eta\) is the boundary-restriction matrix for the opposite
+boundary-crossing restriction.
 \footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:338 for
 \path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
@@ -198,7 +199,7 @@ For an \(N\)-site vector \(\psi\),
 using \(\tau\) on the remaining sites.
 
 Once this identity is available, the boundary-restriction equality lemma proves
-that the two witnesses have the same first-letter products:
+that the two boundary-restriction matrices have the same first-letter products:
 \[
   W_\eta A^j=V_\eta A^j,
 \]
@@ -263,7 +264,7 @@ compressed source proof and the available formal lemmas; it is not a
 source-error claim. The cited Cirac--Perez-Garcia--Schuch--Verstraete 2021
 argument is not refuted. The source compresses two mathematical steps which the
 formalization must keep separate: the $B$-region inverting and growing-back
-open-chain range reduction, and the movement of the open-chain boundary matrix
+open-chain range reduction, and the movement of the trace-form matrix \(X\)
 through the boundary-crossing word when closing the periodic boundary.
 
 The open-chain part has been proved under the intended block-injective

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -158,22 +158,22 @@ for a matrix \(Y_\rho\) depending only on the labels outside the window.
 The closure-property comparison supplies the missing movement of \(X\) through
 the boundary-crossing word.
 
-In the formal coordinate notation, \(\mu\) denotes the nonempty word placed on
+In the coordinate form used here, \(\mu\) denotes the nonempty word placed on
 the sites outside the two cyclic windows and \(\eta\) is the letter used on the
-remaining outside sites. The source does not use this notation; it is a
-coordinate form of the boundary-closing sentence in Section~IV.C,
-lines 2078--2079. The current formal reduction isolates the movement of \(X\)
-as a local matrix comparison, called the block-window equation in the Lean
-development, which implies the one-site commutation identity. After choosing
-witnesses for the two boundary-crossing restrictions, the verified one-sided
-boundary-product lemma gives, for every physical letter \(j\),
+remaining outside sites. This is a coordinate form of the boundary-closing
+sentence in Section~IV.C, lines 2078--2079. The reduction isolates the movement
+of \(X\) as a boundary matrix identity in the closure-property comparison, which
+implies the one-site commutation identity. After choosing boundary matrices for
+the two boundary-crossing restrictions, the verified one-sided boundary-product
+lemma gives, for every physical letter \(j\),
 \[
   W_\eta A^j=A^\mu A^jX,
   \qquad
   XA^jA^\mu=A^jV_\eta .
 \]
-Here \(W_\eta\) is the witness for the last-site boundary restriction and
-\(V_\eta\) is the witness for the opposite boundary-crossing restriction.
+Here \(W_\eta\) is the boundary matrix for the last-site boundary restriction
+and \(V_\eta\) is the boundary matrix for the opposite boundary-crossing
+restriction.
 \footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:338 for
 \path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
@@ -233,7 +233,7 @@ from the closing-boundary local constraints. After that equation is
 proved, the block-injective commutation lemma supplies the one-site commutation
 identity, the boundary-restriction equality lemma supplies the equality of the
 two boundary restrictions, and the boundary-closing step follows.\footnote{The
-formal placeholder for this step is
+present source-labelled statement for this step is
 \leanid{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}.}
 
 Equivalently, the same boundary phenomenon can be recognized in coordinate


### PR DESCRIPTION
## Summary
- replace reader-facing “block-window equation” prose in the normal boundary-closing section by “boundary matrix identity in the closure-property comparison”
- refer to \(W_\eta\) and \(V_\eta\) as boundary matrices for the two boundary-crossing restrictions
- align the paper-gap note with the Cirac Section IV.C boundary-closing sentence rather than local formalization terminology

## Scope
This is a prose/source-alignment cleanup only. It changes no Lean statement, blueprint label, or mathematical dependency.

Refs #2405.
Refs #190.

## Validation
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and exposition only; no code or formal proof artifacts are modified.
> 
> **Overview**
> **Documentation-only** terminology cleanup in the normal boundary-closing blueprint chapter and the `cpgsv21_normal_range_reduction` paper-gap note. No Lean statements, blueprint labels, or proof dependencies change.
> 
> Reader-facing prose now describes the remaining boundary-closing step as deriving commutation from the **boundary matrix identity in the closure-property comparison**, instead of the informal **block-window equation**. Lemma titles and narrative use **boundary matrix** / **closure-property identity** wording; **witness** is replaced by **boundary-restriction matrix** where \(W_\eta\) and \(V_\eta\) are discussed.
> 
> The gap note is aligned with Cirac Section IV.C: **periodic-boundary** / **ring** / **trace-form** language replaces open-chain-centric phrasing, and the open mathematical task is framed as a **closure-property matrix comparison** rather than Lean-local jargon (e.g. “placeholder” → “present source-labelled statement”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90add9e99d0c21994b98d39c83521687a2afe123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->