### PR TITLE
doc(parent): use periodic-boundary ground-space terminology

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -27,10 +27,10 @@ The parent-Hamiltonian theorem in \cite[Theorem~IV.16, lines~2121--2128]{Cirac20
     \quad\Longrightarrow\quad
     \ker H_N=\spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
 \]
-The statements below record the corresponding cyclic-chain ground-space
+The statements below record the corresponding periodic-boundary ground-space
 formulation; the passage to $\ker H_N$ is kept separate.
 
-\begin{definition}[Chain ground space for the block-diagonal tensor]
+\begin{definition}[Periodic-boundary ground space for the block-diagonal tensor]
     \label{def:parent_hamiltonian_ground_space_bnt}
     \notready
     \uses{def:chain_ground_space}
@@ -39,13 +39,13 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \[
         B := \bigoplus_{j=1}^g \mu_j A_j .
     \]
-    The periodic chain ground space considered in this section is
+    The ground space on the \(N\)-site ring considered in this section is
     \[
         \mathcal G_{N,L}(B).
     \]
 \end{definition}
 
-\begin{lemma}[Block-diagonal chain ground space]
+\begin{lemma}[Block-diagonal periodic-boundary ground space]
     \label{lem:parent_hamiltonian_ground_space_eq}
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt}
@@ -92,7 +92,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \cite[lines~2113--2117]{Cirac2021Matrix}.
 \end{definition}
 
-\begin{lemma}[Each normal-tensor vector lies in the chain ground space]
+\begin{lemma}[Each normal-tensor vector lies in the periodic-boundary ground space]
     \label{lem:bnt_mpv_mem_ground_space}
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, lem:mpv_mem_chain_ground_space}
@@ -122,8 +122,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \leanok
     \uses{def:chain_ground_space, lem:local_ground_space_block_le_assembled}
     For each block index $j$ with $\mu_{j} \neq 0$, and whenever $0<N$ and
-    $L\le N$, the chain ground space of the block $A_j$ embeds into the chain
-    ground space of the direct-sum tensor:
+    $L\le N$, the periodic-boundary ground space of the block $A_j$ embeds
+    into the corresponding ground space of the direct-sum tensor:
     \[
         \mathcal G_{N,L}(A_{j})
         \subseteq
@@ -133,9 +133,9 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
-    The cyclic-window definition of the chain ground space reduces the inclusion to
+    The definition by length-\(L\) windows on the ring reduces the inclusion to
     the local block-embedding statement that each ground vector of $A_j$ on the
-    window of length $L$ lifts to the direct sum by the identity
+    window lifts to the direct sum by the identity
     \[
         \Gamma_L^{\oplus_k\mu_k A_k}\!\left(\iota_j(\mu_j^{-L}X)\right)
         =
@@ -152,8 +152,9 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \leanok
     \uses{def:chain_ground_space, lem:chain_ground_space_block_le_assembled}
     Assume $\mu_{j} \neq 0$ for every block index $j$. Whenever $0<N$ and
-    $L\le N$, the linear sum of the blockwise periodic-chain ground spaces is
-    contained in the direct-sum tensor's periodic-chain ground space:
+    $L\le N$, the linear sum of the blockwise ground spaces with periodic
+    boundary conditions is contained in the direct-sum tensor's ground space
+    with periodic boundary conditions:
     \[
         \sum_{j} \mathcal G_{N,L}(A_{j})
         \subseteq
@@ -180,8 +181,8 @@ formulation; the passage to $\ker H_N$ is kept separate.
         lem:isup_chain_ground_space_block_le_assembled}
     Let $A^i=\bigoplus_j\mu_j A_j^i$ be in block-injective canonical form,
     where $A_1,\ldots,A_g$ is a basis of normal tensors.  The linear sum of the
-    blockwise periodic-chain ground spaces is contained in the periodic chain
-    ground space of the block-diagonal tensor:
+    blockwise ground spaces with periodic boundary conditions is contained in
+    the ground space of the block-diagonal tensor on the \(N\)-site ring:
     \[
         \sum_{j} \mathcal G_{N,L}(A_{j})
         \subseteq
@@ -192,7 +193,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 \begin{proof}
     \notready
     The block-injective canonical-form hypothesis supplies $\mu_{j} \neq 0$ for
-    every $j$, and the block-diagonal chain ground space is
+    every $j$, and the block-diagonal periodic-boundary ground space is
     $\mathcal G_{N,L}(\bigoplus_j \mu_j A_j)$ by definition.
 \end{proof}
 
@@ -477,8 +478,8 @@ parent-Hamiltonian ground space.
         \Longrightarrow
         \C\,V^{(N)}(A)=\C\,V^{(N)}(B),
     \]
-    by equality of the periodic-chain constraint spaces and injective
-    uniqueness. For same-dimensional separated BNT blocks, the
+    by equality of the periodic-boundary constraint spaces, followed by
+    injective uniqueness. For same-dimensional separated BNT blocks, the
     non-equivalence condition supplies this non-proportionality at arbitrarily
     large chain lengths; the direct-sum injectivity hypotheses remain
     explicit. Combining the equal-dimension and unequal-dimension branches
@@ -547,7 +548,7 @@ parent-Hamiltonian ground space.
     The dimension step applied to this homogeneous three-block trace
     relation gives $D_A^2\le D_B^2$, contradicting $D_B<D_A$ in the
     strict-size branch. In the equal-size branch, equal local spaces impose
-    the same cyclic local constraints on a periodic chain:
+    the same length-\(L\) constraints on the \(N\)-site ring:
     \[
         \mathcal G_L^A=\mathcal G_L^B
         \Longrightarrow

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -39,7 +39,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \[
         B := \bigoplus_{j=1}^g \mu_j A_j .
     \]
-    The ground space on the \(N\)-site ring considered in this section is
+    The ground space on the $N$-site ring considered in this section is
     \[
         \mathcal G_{N,L}(B).
     \]
@@ -133,7 +133,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
 
 \begin{proof}
     \leanok
-    The definition by length-\(L\) windows on the ring reduces the inclusion to
+    The definition by length-$L$ windows on the ring reduces the inclusion to
     the local block-embedding statement that each ground vector of $A_j$ on the
     window lifts to the direct sum by the identity
     \[
@@ -182,7 +182,7 @@ formulation; the passage to $\ker H_N$ is kept separate.
     Let $A^i=\bigoplus_j\mu_j A_j^i$ be in block-injective canonical form,
     where $A_1,\ldots,A_g$ is a basis of normal tensors.  The linear sum of the
     blockwise ground spaces with periodic boundary conditions is contained in
-    the ground space of the block-diagonal tensor on the \(N\)-site ring:
+    the ground space of the block-diagonal tensor on the $N$-site ring:
     \[
         \sum_{j} \mathcal G_{N,L}(A_{j})
         \subseteq
@@ -548,7 +548,7 @@ parent-Hamiltonian ground space.
     The dimension step applied to this homogeneous three-block trace
     relation gives $D_A^2\le D_B^2$, contradicting $D_B<D_A$ in the
     strict-size branch. In the equal-size branch, equal local spaces impose
-    the same length-\(L\) constraints on the \(N\)-site ring:
+    the same length-$L$ constraints on the $N$-site ring:
     \[
         \mathcal G_L^A=\mathcal G_L^B
         \Longrightarrow

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -6,7 +6,7 @@ relates three ground spaces. Each block $A_j$ has a local parent-Hamiltonian
 ground space $G_m(A_j)$ on an open length-$m$ segment, and we write
 $S_m:=\sum_{j=1}^g G_m(A_j)$ for their linear sum; internal directness is proved
 only under the BNT separation hypotheses and the stated length ranges. On the
-\(N\)-site ring the parent Hamiltonian has the periodic-boundary ground space
+$N$-site ring the parent Hamiltonian has the periodic-boundary ground space
 $\mathcal G_{N,L}(\bigoplus_j\mu_j A_j)$. The results below establish the
 open-segment recursion
 $\C^d\otimes S_m\cap S_m\otimes\C^d=S_{m+1}$ and, conditional on the
@@ -185,7 +185,7 @@ vectors.
     In the range where the sums $\bigvee_jG_m(A_j)$ are direct, this identifies
     $G_L(B)$ with the subspace denoted in the source by
     $S=\bigoplus_j\mathcal G_L^{A^j}$.
-    The passage from the open-segment recursion to the \(N\)-site ring is the
+    The passage from the open-segment recursion to the $N$-site ring is the
     separate closure-property step at the periodic boundary in
     \cite[Theorem~12]{PerezGarcia2007Matrix}.
     % This closure-property step is not the inclusion

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -1,4 +1,4 @@
-\section{Cyclic-chain ground space as the basis-of-normal-tensors span}
+\section{Periodic-boundary ground space as the basis-of-normal-tensors span}
 \label{sec:bnt_span_consequences}
 
 For a block-diagonal tensor $\bigoplus_j\mu_j A_j$ with $\mu_j\ne0$, this section
@@ -6,15 +6,16 @@ relates three ground spaces. Each block $A_j$ has a local parent-Hamiltonian
 ground space $G_m(A_j)$ on an open length-$m$ segment, and we write
 $S_m:=\sum_{j=1}^g G_m(A_j)$ for their linear sum; internal directness is proved
 only under the BNT separation hypotheses and the stated length ranges. On the
-cyclic chain the parent Hamiltonian has the periodic ground space
+\(N\)-site ring the parent Hamiltonian has the periodic-boundary ground space
 $\mathcal G_{N,L}(\bigoplus_j\mu_j A_j)$. The results below establish the
 open-segment recursion
-$\C^d\otimes S_m\cap S_m\otimes\C^d=S_{m+1}$ and, conditional on the cyclic
-boundary-closing inclusion, reduce the cyclic-chain ground space to the span
+$\C^d\otimes S_m\cap S_m\otimes\C^d=S_{m+1}$ and, conditional on the
+closure-property inclusion at the periodic boundary, reduce the
+periodic-boundary ground space to the span
 $\spn\{V^{(N)}(A_j):j=1,\ldots,g\}$ of the basis-of-normal-tensors component
 vectors.
 
-\begin{theorem}[Block-diagonal local recursion and boundary closing]
+\begin{theorem}[Block-diagonal local recursion and periodic-boundary closure]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
     \uses{def:ground_space_parent, def:chain_ground_space, def:l_blk_injective,
@@ -184,10 +185,10 @@ vectors.
     In the range where the sums $\bigvee_jG_m(A_j)$ are direct, this identifies
     $G_L(B)$ with the subspace denoted in the source by
     $S=\bigoplus_j\mathcal G_L^{A^j}$.
-    The passage from the open-segment recursion to the periodic chain is the
-    separate boundary-closing step in
+    The passage from the open-segment recursion to the \(N\)-site ring is the
+    separate closure-property step at the periodic boundary in
     \cite[Theorem~12]{PerezGarcia2007Matrix}.
-    % This boundary-closing step is not the inclusion
+    % This closure-property step is not the inclusion
     % $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails for a general
     % open-boundary matrix crossing the periodic boundary.
     The source boundary-closing conclusion is
@@ -349,7 +350,7 @@ vectors.
     equality follows after adding the forward inclusion.
 \end{proof}
 
-\begin{theorem}[Cyclic-chain containment in the BNT span]
+\begin{theorem}[Periodic-boundary containment in the BNT span]
     \label{thm:parent_ground_space_le_bnt_span}
     \notready
     \uses{def:parent_hamiltonian_ground_space_bnt, def:bnt_span,
@@ -365,7 +366,7 @@ vectors.
         \qquad
         N\ge L+L_0,
     \]
-    and assume the cyclic boundary-closing inclusion
+    and assume the closure-property inclusion at the periodic boundary
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
         \subseteq
@@ -386,9 +387,10 @@ vectors.
     \cite[Theorem~12]{PerezGarcia2007Matrix}. The shorter range stated in
     \cite[lines~2126--2128]{Cirac2021Matrix} requires the strengthened
     block-diagonal re-growing step. These hypotheses do not by themselves give
-    the displayed cyclic boundary-closing inclusion. That inclusion follows only
+    the displayed closure-property inclusion at the periodic boundary. That
+    inclusion follows only
     after the block-diagonal boundary conditions have been compared across the
-    cyclic windows crossing the chosen cut. Since $g\ge2$
+    windows crossing the chosen periodic-boundary cut. Since $g\ge2$
     and $L_0\ge1$,
     \[
         L\ge 3(g-1)(L_0+1)+1 \ge 3L_0+4 > L_0,
@@ -402,7 +404,7 @@ vectors.
         \quad\Longrightarrow\quad
         \exists n\ge1,\; V^{(n)}(A_j)\ne V^{(n)}(A_k).
     \]
-    By the assumed cyclic boundary-closing inclusion,
+    By the assumed closure-property inclusion at the periodic boundary,
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
         \subseteq
@@ -418,14 +420,15 @@ vectors.
     the displayed containment.
 \end{proof}
 
-\begin{theorem}[Cyclic-chain equality with the BNT span]
+\begin{theorem}[Periodic-boundary equality with the BNT span]
     \label{thm:gs_eq_bnt_span}
     \notready
     \uses{thm:parent_ground_space_le_bnt_span, lem:bnt_mpv_mem_ground_space,
         def:parent_hamiltonian_ground_space_bnt, def:bnt_span}
     Under the hypotheses of
-    Theorem~\ref{thm:parent_ground_space_le_bnt_span}, the corresponding cyclic
-    chain ground space is exactly the span of the BNT component vectors:
+    Theorem~\ref{thm:parent_ground_space_le_bnt_span}, the corresponding
+    periodic-boundary ground space is exactly the span of the BNT component
+    vectors:
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
         =
@@ -445,8 +448,8 @@ vectors.
     is exactly Theorem~\ref{thm:parent_ground_space_le_bnt_span}. For the reverse inclusion,
     the nonzero-weight hypothesis and Lemma~\ref{lem:bnt_mpv_mem_ground_space}
     show that each vector $V^{(N)}(A_j)$ lies in
-    $\mathcal G_{N,L}(\bigoplus_j \mu_j A_j)$. Since the chain ground space is a
-    linear subspace, it contains every linear combination
+    $\mathcal G_{N,L}(\bigoplus_j \mu_j A_j)$. Since this ground space is
+    linear, it contains every linear combination
     of such vectors, and hence contains
     $\spn\{V^{(N)}(A_j): j=1,\ldots,g\}$. Thus
     \[
@@ -458,5 +461,5 @@ vectors.
 \end{proof}
 
 \noindent\emph{Remark.} A separate kernel-identification statement for these direct-sum
-block families would convert the chain-ground-space statement into the
+block families would convert the periodic-boundary ground-space statement into the
 corresponding statement for $\ker(H_N)$.

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -30,9 +30,9 @@ Set
   \qquad
   V^{(N)}(A)=\Gamma_N^A(I).
 \end{align}
-For the cyclic chain, with $\operatorname{res}_{s,L}$ denoting restriction to
-the length-$L$ interval beginning at $s\in \mathbb Z/N\mathbb Z$, the local
-ground-space condition is
+For the ring with periodic boundary conditions, with $\operatorname{res}_{s,L}$
+denoting restriction to the length-$L$ interval beginning at
+$s\in \mathbb Z/N\mathbb Z$, the local ground-space condition is
 \begin{align}
   \mathcal K_{N,L}(A)
   =
@@ -97,7 +97,7 @@ together with the separated normalized block hypotheses.  Thus the current
 Lean statements no longer replace Condition C1 by a length-one span condition
 in the boundary-decomposition path.  The remaining mathematical boundary lies
 later in the argument: after the cyclic constraints have been propagated into
-the open-boundary sum, the boundary conditions themselves must be compared.
+the trace-form sum, the boundary conditions themselves must be compared.
 
 The resulting parent-Hamiltonian theorem in \cite[Section~IV.C]{Cirac2021Matrix}
 is

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -234,9 +234,9 @@ and make the sum defining $S_N$ internal.\footnote{Lean declarations:
 and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1}.}
 What remains is the source boundary-condition comparison: starting with a
-periodic-chain vector in $\mathcal K_{N,L}(\widehat A)$, produce
-block-diagonal boundary matrices whose block components are again periodic
-block-chain vectors.
+vector in the periodic-boundary space $\mathcal K_{N,L}(\widehat A)$, produce
+block-diagonal boundary matrices whose block components again belong to the
+blockwise periodic-boundary spaces.
 
 The present formal boundary isolates the remaining source comparison as a
 family of complementary-word identities.  Suppose
@@ -261,7 +261,7 @@ implies
   \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal K_{N,L}(A_j)
   \qquad (1\le j\le b).
 \end{align}
-Thus the open-boundary representation of \(\psi\) is not the obstruction. The
+Thus the trace representation of \(\psi\) is not the obstruction. The
 periodic component theorem proves the displayed conclusion from these
 complementary-word identities. The remaining source-level work in this note is
 to present the \(C^j,D^j,E^j\) comparison from
@@ -276,7 +276,7 @@ as an unconditional hypothesis-free equality theorem in the source range.\footno
 The live blueprint records that larger source statement in source notation,
 without claiming that it is proved.\footnote{Blueprint locations:
 \path{def:parent_hamiltonian_ground_space_bnt} for the block-diagonal
-periodic-chain ground space,
+periodic-boundary ground space,
 \path{lem:isup_chain_ground_space_block_le_assembled} for the forward
 inclusion, \path{thm:block_diagonal_ground_space_intersection} for the
 PGVWC07 block-diagonal intersection identity,
@@ -314,8 +314,8 @@ complementary-word identity as an external hypothesis is
   \sum_{j=1}^b \mathcal K_{N,L}(A_j).
 \end{align}
 
-The following implication is not available.  The open-boundary space
-$\mathcal G_N^A$ is not contained in the cyclic-chain ground space
+The following implication is not available.  The trace-form space
+$\mathcal G_N^A$ is not contained in the periodic-boundary ground space
 $\mathcal K_{N,L}(A)$ for an arbitrary boundary matrix $X$.  If the
 cyclic window crosses the chosen virtual boundary, then a vector
 $\Gamma_N^A(X)$ has coefficients of the form
@@ -360,8 +360,9 @@ in the more conservative range
   L\ge (L_0+1)+3(b-1)(L_0+1)+1.
 \end{align}
 The boundary-closing reductions now separate into three forms: a decomposition
-into periodic block-chain vectors, a block-diagonal boundary representation whose
-components already belong to the periodic block-chain spaces, and the
+into blockwise vectors with periodic boundary conditions, a block-diagonal
+boundary representation whose components already belong to the corresponding
+blockwise periodic-boundary spaces, and the
 complementary-word formulation displayed above.\footnote{Lean declarations:
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition},
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap},
@@ -390,7 +391,8 @@ For the next display, abbreviate
   \qquad
   V_j=V^{(N)}(A_j).
 \end{align}
-Thus the desired periodic-chain proof is the composition of the two implications
+Thus the desired proof with periodic boundary conditions is the composition of
+the two implications
 \begin{align}
   \psi\in\mathcal K_{N,L}(\widehat A)
   &\Longrightarrow


### PR DESCRIPTION
## Summary
- replace local “cyclic-chain” and “periodic-chain” prose by periodic-boundary ground-space language
- describe \(\mathcal G_{N,L}\) as the ground space on the \(N\)-site ring where appropriate
- replace the misleading “open-boundary” description of \(\Gamma_N(X)\) by trace-form terminology in the block-diagonal paper-gap note

## Scope
This is a prose/source-alignment cleanup only. It changes no Lean statement, blueprint label, or mathematical dependency.

Refs #2651.
Refs #190.

## Validation
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording in LaTeX sources; no Lean, labels, or proof structure changes.
> 
> **Overview**
> Aligns reader-facing prose in the parent-Hamiltonian blueprint (ch13 block intersections and BNT consequences) and the block-diagonal paper-gap note with **periodic-boundary ground space** language instead of “cyclic-chain” / “periodic-chain” wording. Definitions, lemmas, and theorems are retitled and rephrased so \(\mathcal G_{N,L}\) is described as the ground space on the **\(N\)-site ring** with length-\(L\) windows, and boundary steps are called **closure-property** inclusions at the periodic boundary rather than “cyclic boundary-closing.”
> 
> In `cpgsv21_block_diagonal_parent_ground_space.tex`, the misleading **open-boundary** label for \(\Gamma_N(X)\) / \(\mathcal G_N^A\) is replaced by **trace-form** terminology, with matching updates to periodic-boundary phrasing in the remaining boundary-comparison narrative. **No Lean declarations, blueprint labels, or mathematical dependencies change**—terminology and source alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111928dea1b30a70885d3cf195dc2d2910accda2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->