### PR TITLE
doc(blueprint): correct Kraus-CPTP composition uses

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_pure_state_recovery.tex
@@ -42,7 +42,7 @@
     \label{lem:is_kraus_cptp_comp}
     \lean{isKrausCPTP_comp}
     \leanok
-    \uses{def:is_kraus_cptp, lem:is_kraus_cptp_id}
+    \uses{def:is_kraus_cptp}
     The composition of two trace-preserving completely positive maps is again
     trace-preserving completely positive. If $\mathcal{S}$ has Kraus operators
     $A_i$ and $\mathcal{T}$ has Kraus operators $B_j$, then $\mathcal{S} \circ


### PR DESCRIPTION
## Summary

- correct the `\uses` tag for `lem:is_kraus_cptp_comp`
- remove the identity-map lemma from the dependency list, leaving only `def:is_kraus_cptp`

Closes #2863.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `cd blueprint && leanblueprint checkdecls`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint `\uses` metadata only; no Lean or runtime behavior changes.
> 
> **Overview**
> Updates the blueprint dependency metadata for **Composition of trace-preserving completely positive maps** (`lem:is_kraus_cptp_comp`).
> 
> The `\uses` tag no longer lists `lem:is_kraus_cptp_id`; it now depends only on `def:is_kraus_cptp`, matching the lemma’s proof (Kraus form of the composite and trace preservation via the two maps’ resolutions of identity, without invoking the identity-map lemma).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb11d9ba2cbeb96911e008622b9bad31b5635d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->