### PR TITLE
doc(ch16): add trace-pairing transfer diagram

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -100,6 +100,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNKrausMap": "",
     "TNStinespring": "",
     "TNChoiMatrix": "",
+    "TNTransferMapTracePairing": "",
     "TNTwoPointCorrelator": "",
 }
 

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1243,6 +1243,18 @@ a common dilation space.
 \label{sec:trace_pairing_expansion}
 %% =========================================================
 
+The trace-pairing expansion separates a linear map into the scalar input
+pairing, the transfer coefficients, and the output basis element:
+\[
+    T(\rho)=\sum_i\sum_j t_{ij}\,\tr(\sigma_j\rho)\,\sigma_i.
+\]
+The diagram records the same factorization by closing the input matrix with
+$\sigma_j$, weighting the resulting scalar by $t_{ij}$, and producing the output
+matrix through $\sigma_i$:
+\begin{center}
+    \TNTransferMapTracePairing
+\end{center}
+
 \begin{definition}[Trace-self-dual basis]\label{def:trace_pairing_self_dual_basis}
     \lean{TracePairingSelfDualBasis}
     \leanok

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1293,8 +1293,8 @@
 }
 
 % Trace-pairing transfer form
-% T(rho)=sum_{i,j} t_ij tr(sigma_j rho) sigma_i.  The input matrix is closed
-% against sigma_j, the scalar coefficient t_ij joins the two basis labels, and
+% T(rho)=sum_{i,j} t_ij tr(sigma_j rho) sigma_i.  The trace loop passes through
+% rho and sigma_j; the scalar coefficient t_ij joins the two basis labels, and
 % sigma_i supplies the output matrix legs.
 \newcommand{\TNTransferMapTracePairing}{%
     \begin{tikzpicture}[tn picture]
@@ -1302,15 +1302,18 @@
         \node[draw, fill=white, inner sep=1.4pt] (tpSigJ) at (-0.48,0) {$\sigma_j$};
         \node[draw, fill=white, inner sep=1.4pt] (tpT) at (0.82,0) {$t_{ij}$};
         \node[draw, fill=white, inner sep=1.4pt] (tpSigI) at (2.12,0) {$\sigma_i$};
-        \draw[tn leg] (tpRho.north west)
-            .. controls (-2.10,0.40) and (-2.10,-0.40) .. (tpRho.south west);
         \draw[tn leg] (tpRho.north east) -- (tpSigJ.north west);
         \draw[tn leg] (tpRho.south east) -- (tpSigJ.south west);
-        \draw[tn phys leg] (tpSigJ.east) -- (tpT.west);
+        \draw[tn leg] (tpSigJ.north east)
+            .. controls (-0.12,0.52) and (-1.92,0.52) .. (tpRho.north west);
+        \draw[tn leg] (tpSigJ.south east)
+            .. controls (-0.12,-0.52) and (-1.92,-0.52) .. (tpRho.south west);
+        \draw[tn phys leg] (tpSigJ.north)
+            .. controls (-0.32,0.78) and (0.62,0.78) .. (tpT.north);
         \draw[tn phys leg] (tpT.east) -- (tpSigI.west);
         \draw[tn leg] (tpSigI.north east) -- ++(0.72,0);
         \draw[tn leg] (tpSigI.south east) -- ++(0.72,0);
-        \node at (-1.08,-0.66) {$\tr(\sigma_j\rho)$};
+        \node at (-1.08,-0.82) {$\tr(\sigma_j\rho)$};
         \node at (3.22,0) {$T(\rho)$};
     \end{tikzpicture}%
 }

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -1292,6 +1292,29 @@
     \end{tikzpicture}%
 }
 
+% Trace-pairing transfer form
+% T(rho)=sum_{i,j} t_ij tr(sigma_j rho) sigma_i.  The input matrix is closed
+% against sigma_j, the scalar coefficient t_ij joins the two basis labels, and
+% sigma_i supplies the output matrix legs.
+\newcommand{\TNTransferMapTracePairing}{%
+    \begin{tikzpicture}[tn picture]
+        \node[draw, fill=white, inner sep=1.4pt] (tpRho) at (-1.55,0) {$\rho$};
+        \node[draw, fill=white, inner sep=1.4pt] (tpSigJ) at (-0.48,0) {$\sigma_j$};
+        \node[draw, fill=white, inner sep=1.4pt] (tpT) at (0.82,0) {$t_{ij}$};
+        \node[draw, fill=white, inner sep=1.4pt] (tpSigI) at (2.12,0) {$\sigma_i$};
+        \draw[tn leg] (tpRho.north west)
+            .. controls (-2.10,0.40) and (-2.10,-0.40) .. (tpRho.south west);
+        \draw[tn leg] (tpRho.north east) -- (tpSigJ.north west);
+        \draw[tn leg] (tpRho.south east) -- (tpSigJ.south west);
+        \draw[tn phys leg] (tpSigJ.east) -- (tpT.west);
+        \draw[tn phys leg] (tpT.east) -- (tpSigI.west);
+        \draw[tn leg] (tpSigI.north east) -- ++(0.72,0);
+        \draw[tn leg] (tpSigI.south east) -- ++(0.72,0);
+        \node at (-1.08,-0.66) {$\tr(\sigma_j\rho)$};
+        \node at (3.22,0) {$T(\rho)$};
+    \end{tikzpicture}%
+}
+
 % Two-point correlator <X_0 Y_n> = tr(Y E_A^n(X rho^R)): on the transfer-map
 % (M_D) line, start from the fixed point rho^R, insert X, propagate by n copies
 % of the transfer map E_A, insert Y, and close the line by the trace.

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -70,7 +70,7 @@ name: TNPEPSStateContraction TNPEPSTorusGeometry TNPEPSVertexScalarBalance
 name: TNKrausMap TNStinespring
 {{ obj.tn_svg_html }}
 
-name: TNChoiMatrix
+name: TNChoiMatrix TNTransferMapTracePairing
 {{ obj.tn_svg_html }}
 
 name: TNTwoPointCorrelator


### PR DESCRIPTION
## Summary

- add a trace-pairing transfer diagram for the expansion
  \(T(\rho)=\sum_i\sum_j t_{ij}\,\operatorname{tr}(\sigma_j\rho)\,\sigma_i\)
- register the new zero-argument tensor-network macro for PDF and web rendering
- add the formula-first lead paragraph in chapter 16

Closes #2855.

## Validation

- `git diff --check`
- `cd blueprint/src && PYTHONPATH=Packages python3 Packages/tn_diagrams.py --check --smoke-render TNTransferMapTracePairing`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint pdf`
- `cd blueprint && leanblueprint web`
- rendered and inspected PDF page 242 containing `\TNTransferMapTracePairing`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram plumbing only; no changes to Lean proofs, runtime logic, or security-sensitive code.
> 
> **Overview**
> Adds a **trace-pairing transfer** tensor-network figure for \(T(\rho)=\sum_{i,j} t_{ij}\,\tr(\sigma_j\rho)\,\sigma_i\) in chapter 16’s trace-pairing section.
> 
> The PR introduces the zero-argument TikZ macro `\TNTransferMapTracePairing` (trace loop on \(\rho\) and \(\sigma_j\), coefficient \(t_{ij}\), output via \(\sigma_i\)), wires it through `tn_diagrams.py` and the plastex template for PDF/web SVG rendering, and adds a short formula-first lead plus centered diagram before the existing trace-self-dual basis material.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d707b4581dd7695d97a66b16f88acc3cc188c9ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->