### PR TITLE
doc(blueprint): wire Wielandt references into uses graph

### DIFF
--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -442,6 +442,8 @@ boundary conditions (PBC).
 \end{definition}
 
 \begin{remark}\leanok
+    \uses{lem:primitive_implies_irreducible,
+        thm:irred_tensor_aperiodic_normal, thm:blocking_primitivity}
     The algebraic characterization of normality in
     Definition~\ref{def:normal} --- eventual full matrix span,
     equivalently eventual block injectivity --- is equivalent to the

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -474,10 +474,13 @@ irreducible unital blocks and the algebra-spanning input used later.
     which preserves the TP normalization.
 \end{proof}
 
-The passage from irreducible tensors to full algebra spanning uses Burnside's
-theorem: an irreducible subalgebra of $\MN{D}$ is all of $\MN{D}$. It is
-developed alongside the Wielandt material in Chapter~\ref{ch:wielandt}; see
-Theorem~\ref{thm:irreducible_action_cumulative_span}.
+\begin{remark}[Burnside input for cumulative spanning]\leanok
+    \uses{thm:irreducible_action_cumulative_span}
+    The passage from irreducible tensors to full algebra spanning uses Burnside's
+    theorem: an irreducible subalgebra of $\MN{D}$ is all of $\MN{D}$. It is
+    developed alongside the Wielandt material in Chapter~\ref{ch:wielandt}; see
+    Theorem~\ref{thm:irreducible_action_cumulative_span}.
+\end{remark}
 
 \begin{lemma}[The algebra span reaches a finite cumulative span]\label{lem:algspan_cumulative_span}
     \lean{MPSTensor.exists_cumulativeSpan_eq_top_of_algSpan_eq_top}


### PR DESCRIPTION
## Summary

- add explicit `\uses` tags to the chapter-2 normality-equivalence remark for the Wielandt/canonical-form results it cites
- turn the chapter-9 Burnside paragraph into a remark with an explicit dependency on `thm:irreducible_action_cumulative_span`

This addresses the Wielandt cross-chapter `\uses` part of #2295.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint metadata (`\uses` tags and remark structure); no Lean proof or runtime logic changes.
> 
> **Overview**
> This PR updates the blueprint **`\uses`** dependency graph so cross-chapter Wielandt/canonical citations are explicit for Lean blueprint sync.
> 
> In **chapter 2**, the normality-equivalence remark now declares dependencies on **`lem:primitive_implies_irreducible`**, **`thm:irred_tensor_aperiodic_normal`**, and **`thm:blocking_primitivity`**—the results it already names when relating algebraic and spectral normality.
> 
> In **chapter 9**, the Burnside/Wielandt paragraph is wrapped in a labeled remark with **`\uses{thm:irreducible_action_cumulative_span}`**, instead of standing as unstructured prose before **`lem:algspan_cumulative_span`**.
> 
> A trivial newline fix at the end of **`ch02_mps.tex`** is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71cccb320d3cb4f63d3cf0b2a164ed24d9501dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->