### PR TITLE
doc(channels): record peripheral terminal roles

### DIFF
--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -364,6 +364,19 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     $|\lambda| = r$.
 \end{definition}
 
+\begin{remark}[Peripheral conventions for channels]%
+    \label{rem:peripheral_conventions_channels}
+    \leanok
+    \uses{def:peripheral_spectrum, def:peripheral_eigenvalues,
+        thm:peripheral_unit_circle}
+    The spectral-radius convention of
+    Definition~\ref{def:peripheral_spectrum} is the usual bounded-operator
+    notion. For channels the spectral radius is $1$, so the channel arguments
+    below use the unit-circle set of Definition~\ref{def:peripheral_eigenvalues}.
+    Theorem~\ref{thm:peripheral_unit_circle} records the corresponding
+    definitional fact $|\lambda|=1$.
+\end{remark}
+
 \begin{theorem}[$1$ is a peripheral eigenvalue]\label{thm:one_peripheral}
     \lean{one_mem_peripheralEigenvalues}
     \leanok
@@ -774,6 +787,18 @@ matching the weighted-trace argument in
     (Theorem~\ref{thm:one_peripheral}), the
     only element is $1$.
 \end{proof}
+
+\begin{remark}[Period-one characterization]%
+    \label{rem:primitive_period_one_characterization}
+    \leanok
+    \uses{def:channel_period, thm:primitive_iff_period_one}
+    The period $p(E)$ counts peripheral eigenvalues without multiplicity.
+    Theorem~\ref{thm:primitive_iff_period_one} is therefore the period-one
+    characterization of primitivity. The spectral estimates below are stated
+    directly with Definition~\ref{def:primitive_channel}, since they use the
+    absence of peripheral eigenvalues other than $1$, not a separate counting
+    hypothesis.
+\end{remark}
 
 \begin{theorem}[Complementary transfer-map gap for primitive maps]%
     \label{thm:primitive_compl_lt_one}


### PR DESCRIPTION
## Summary

- add a Chapter 4 remark distinguishing the bounded-operator peripheral spectrum from the channel unit-circle convention
- add a period-one characterization remark explaining how `channelPeriod` and the primitive-period theorem are kept as terminal characterizations

This addresses the Chapter 4 peripheral-spectrum portion of #2295 without forcing these statements into later spectral-gap estimates.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build`
- `cd blueprint && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX in the blueprint; no runtime, auth, or formal proof changes beyond sync metadata on remarks.
> 
> **Overview**
> Chapter 4 blueprint prose gains two **reader-facing remarks** in the peripheral-spectrum / primitivity section—no theorem or Lean logic changes.
> 
> The first (**peripheral conventions for channels**) states that the general bounded-operator **peripheral spectrum** (spectral radius) is the standard notion, while channel arguments use the **unit-circle peripheral eigenvalues** definition because the channel spectral radius is 1, and points to the existing unit-circle theorem as the definitional link.
> 
> The second (**period-one characterization**) clarifies that **channel period** counts peripheral eigenvalues without multiplicity, that **primitivity iff period one** is the terminal counting characterization, and that later **spectral gap** estimates are stated via **primitive channel** (only eigenvalue 1 on the periphery) rather than re-invoking period as a separate hypothesis.
> 
> Both remarks are wired into the blueprint with `\leanok` and `\uses{...}` for leanblueprint sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36e3a3754df448cd5388d628e58e62cda6b4264a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->