### PR TITLE
doc(spectral): record mixed-transfer terminal roles

### DIFF
--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -207,6 +207,20 @@ mixed transfer power.
     $A^\sigma (B^\sigma)^\dagger$.
 \end{proof}
 
+\begin{remark}[Two traces for the mixed transfer map]%
+    \label{rem:mixed_transfer_two_traces}
+    \leanok
+    \uses{thm:mixed_trace_identity, lem:word_trace_entrywise, thm:overlap_trace}
+    There are two different trace operations here. Evaluating $F_{AB}^N$ at the
+    identity and then taking the matrix trace gives
+    $\sum_\sigma \tr(A^\sigma(B^\sigma)^\dagger)$; by
+    Lemma~\ref{lem:word_trace_entrywise}, each summand is the Hilbert--Schmidt
+    inner product of the two word matrices. Taking the operator trace of
+    $F_{AB}^N$ instead gives the periodic-boundary overlap $O_{AB}(N)$, by
+    Lemma~\ref{thm:overlap_trace}. The spectral arguments below use this
+    operator-trace identity.
+\end{remark}
+
 \section{Frobenius norm estimates}
 
 The transfer-operator gap proofs use the Frobenius (Hilbert--Schmidt) norm
@@ -731,6 +745,24 @@ the Perron--Frobenius fixed point.
     with the overlap--trace identity
     (Lemma~\ref{thm:overlap_trace}).
 \end{proof}
+
+\begin{remark}[Power decay and overlap decay]%
+    \label{rem:irreducible_tp_power_decay_trace}
+    \leanok
+    \uses{thm:transfer_pow_zero_irr_tp, lem:trace_expansion, thm:overlap_trace}
+    The pointwise power-decay theorem gives the same trace-level decay by a
+    finite matrix-unit calculation. For matrix units $E_{pq}$,
+    Theorem~\ref{thm:transfer_pow_zero_irr_tp} gives
+    $F_{AB}^N(E_{pq}) \to 0$. Since the sum is finite,
+    \[
+        \Tr(F_{AB}^N)
+        =
+        \sum_{p,q}(F_{AB}^N(E_{pq}))_{pq}
+        \longrightarrow 0.
+    \]
+    Lemma~\ref{thm:overlap_trace} identifies the trace with the overlap, hence
+    $O_{AB}(N)=\Tr(F_{AB}^N)\to 0$.
+\end{remark}
 
 \begin{theorem}[Rectangular transfer-operator gap (irreducible-TP)]%
     \label{thm:transfer_operator_gap_rect_irr_tp}


### PR DESCRIPTION
## Summary

- add a Chapter 7 remark distinguishing the matrix trace of `F_{AB}^N(Id)` from the operator trace used for overlaps
- add a remark showing how irreducible trace-preserving pointwise power decay gives trace-level overlap decay through matrix units
- leave the self-overlap auxiliary formalization markers intact; possible removal of `SelfOverlapAux` is deferred to a separate cleanup

This addresses the spectral mixed-transfer portion of #2295 as a blueprint-only keep/wire decision.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls /private/tmp/ch07-spectral-terminal-roles/blueprint/lean_decls` against the built main worktree environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX in the blueprint with existing lean sync markers; no runtime or proof code changes.
> 
> **Overview**
> Chapter 7 blueprint prose now spells out two trace conventions for mixed transfer powers: **matrix trace** of `F_{AB}^N(\Id)` (Hilbert–Schmidt word inner products) versus **operator trace** `Tr(F_{AB}^N)` (MPV overlap), and states that the spectral chapter relies on the latter.
> 
> After the irreducible-TP overlap-decay theorem, a second remark records the alternate route from **pointwise** `F_{AB}^N(E_{pq}) → 0` through matrix-unit expansion of `Tr(F_{AB}^N)` to `O_{AB}(N) → 0`, mirroring the injective case earlier in the chapter.
> 
> Both remarks are marked `\leanok` with `\uses{...}` dependency tags for blueprint–Lean sync; no formal proofs or Lean definitions are changed in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609393c625bfd100aa9c6c5ae4213801b738aebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->