### PR TITLE
doc(parent): align spectral-gap source prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -20,14 +20,19 @@ state, obtained from the intersection property of the local ground spaces. For a
 normal tensor the corresponding conclusion follows, under the stated
 closed-boundary comparison and length hypotheses, after inverting a long-word
 commutation back to the injectivity length and closing the periodic boundary.
-When the local terms commute the construction gives a nearest-neighbor commuting
-parent Hamiltonian, the setting of the renormalization fixed points of
-\cite{Cirac2016MPDO_arXiv}; under an additional cyclic-window overlap estimate
-this Hamiltonian is gapped. For a tensor in block-injective canonical form
-$A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$, the
-block-diagonal sections reduce the ground space toward the span of the block
-vectors $\{V^{(N)}(A_j)\}$, the ground-space generation theorem
-\cite[Theorem~IV.16]{Cirac2021Matrix} (\cite[Theorem~12]{PerezGarcia2007Matrix}).
+When the local terms commute the construction gives the nearest-neighbor
+commuting parent Hamiltonians in the pure-state theorem relating
+renormalization fixed points, zero correlation length, and
+nearest-neighbor commuting parent-Hamiltonian ground states in
+\cite{Cirac2016MPDO_arXiv}. The spectral-gap section records the martingale
+row-sum criterion and keeps the overlapping-window principal-angle estimate as
+an explicit hypothesis. For a tensor in block-injective canonical form
+$A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$,
+\cite[Theorem~IV.16]{Cirac2021Matrix}
+(\cite[Theorem~12]{PerezGarcia2007Matrix}) states that the periodic
+parent-Hamiltonian ground space is spanned by the vectors
+$\{V^{(N)}(A_j)\}$. The sections below establish open-segment recursion and
+conditional boundary-closing reductions toward this theorem.
 
 \input{chapter/ch13_parent_hamiltonian_injective_ground_spaces}
 \input{chapter/ch13_parent_hamiltonian_injective_boundary}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -900,12 +900,16 @@ explicit input.
     $N$, for which the martingale condition of
     Theorem~\ref{thm:martingale_criterion} holds.
     Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
-    obtain the MPS gap by controlling the principal angles between overlapping
-    local ground spaces. For the explicit cyclic-window constants displayed
-    here, the remaining quantitative comparison is the overlapping-window
-    estimate used as a hypothesis in Theorem~\ref{thm:friedrichs_gap_bound}; the
-    preceding lemmas reduce the martingale inequality and the spectral gap to
-    that estimate.
+    obtain the MPS gap from the principal-angle bound
+    \[
+        \alpha:=\max_{1\le s<L}\cos\theta_s<1,
+    \]
+    where $\theta_s$ is the smallest non-zero principal angle between the kernels
+    of two local terms at cyclic distance $s$. For the explicit cyclic-window
+    constants displayed here, the remaining quantitative comparison is the
+    overlapping-window estimate used as a hypothesis in
+    Theorem~\ref{thm:friedrichs_gap_bound}; the preceding lemmas reduce the
+    martingale inequality and the spectral gap to that estimate.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
     overlapping pairs and the spectral gap follows directly without the
     martingale argument.)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -3,12 +3,16 @@
 
 A frustration-free Hamiltonian is \emph{gapped} if the first excited
 eigenvalue is bounded away from zero uniformly in the chain length $N$.
-For MPS parent Hamiltonians, the spectral gap follows from the martingale
-method of Fannes--Nachtergaele--Werner and
+For MPS parent Hamiltonians, the martingale method of
+Fannes--Nachtergaele--Werner and
 Nachtergaele~\cite{Fannes1992Finitely, Nachtergaele1996Spectral}, as recalled
 by Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
 and in the later formulation of Kastoryano and
-Lucia~\cite{Kastoryano2018Martingale}.
+Lucia~\cite{Kastoryano2018Martingale}, reduces a uniform gap to principal-angle
+estimates for overlapping local ground spaces. The results below establish the
+finite-row and cyclic-window reductions in the present convention; the
+MPS-specific principal-angle, equivalently norm-compression, estimate remains an
+explicit input.
 
 \begin{definition}[Parent ground space in the Hilbert-space realization]
     \label{def:parent_ground_space_es}
@@ -56,7 +60,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     parent Hamiltonian annihilates it.
 \end{lemma}
 
-\begin{remark}[Euclidean local projectors]
+\begin{remark}[Hilbert-space local projectors]
     \label{rem:euclidean_local_projector_ingredients}
     \lean{MPSTensor.parentInteractionES}
     \lean{MPSTensor.cyclicRestrictES}
@@ -65,25 +69,26 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{def:ground_space_es, rem:cyclic_window_operators}
     Let $P_L^{\mathrm{ES}}(A)$ denote the orthogonal projector onto
-    $(G_L^{\mathrm{ES}}(A))^\perp$ on the Euclidean $L$-site space. For a cyclic
-    window starting at $i$ and an outside configuration $\tau$, the
-    boundary-filled restriction map $R_{i,\tau}$ evaluates an $N$-site
-    Euclidean vector on that window. The Euclidean local term
+    $(G_L^{\mathrm{ES}}(A))^\perp$ on the canonical $\ell^2$ $L$-site Hilbert
+    space. For a cyclic window starting at $i$ and an outside configuration
+    $\tau$, the boundary-filled restriction map $R_{i,\tau}$ evaluates an
+    $N$-site vector in this realization on that window. The local term
     $h_{i,\mathrm{ES}}$ is the corresponding
     $N$-site local projector, and $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is
     the basic positive summand in its cyclic-averaging formula.
 \end{remark}
 
-\begin{lemma}[Positivity of the Euclidean local summands]
+\begin{lemma}[Positivity of the Hilbert-space local summands]
     \label{lem:euclidean_local_projector_positive}
     \lean{MPSTensor.parentInteractionES_isPositive}
     \lean{MPSTensor.localTermESSummand_isPositive}
     \lean{MPSTensor.localTermESSummand_sum_isPositive}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients}
-    The Euclidean local projector $P_L^{\mathrm{ES}}(A)$ is positive. Consequently,
-    every summand $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is positive, and so
-    is the finite sum over $\tau$.
+    The Hilbert-space local projector $P_L^{\mathrm{ES}}(A)$ is positive.
+    Consequently, every summand
+    $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is positive, and so is
+    the finite sum over $\tau$.
 \end{lemma}
 
 \begin{proof}
@@ -92,13 +97,13 @@ Lucia~\cite{Kastoryano2018Martingale}.
     positivity, and finite sums of positive operators remain positive.
 \end{proof}
 
-\begin{lemma}[Cyclic averaging for the Euclidean-space local terms]
+\begin{lemma}[Cyclic averaging for the Hilbert-space local terms]
     \label{lem:local_term_es_average}
     \lean{MPSTensor.parentHamiltonianES_eq_sum_localTermES}
     \lean{MPSTensor.localTermES_eq_average_localTermESSummand}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients, lem:euclidean_local_projector_positive}
-    The Euclidean-space parent Hamiltonian is the sum of the Euclidean-space
+    The Hilbert-space parent Hamiltonian is the sum of the Hilbert-space
     local terms $H_{N,\mathrm{ES}} = \sum_i h_{i,\mathrm{ES}}$, and each local
     term admits the exact cyclic-averaging formula
     \begin{equation}\label{eq:ph_cyclic_averaging}
@@ -109,38 +114,39 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    Unfold the Euclidean-space local term and compare it
+    Unfold the Hilbert-space local term and compare it
     configuration-by-configuration with the cyclic restrictions. The $d^{-L}$
     factor compensates for the $d^L$ choices of the window coordinates in the
     ambient configuration parameter $\tau$.
 \end{proof}
 
-\begin{lemma}[Positivity of the Euclidean-space Hamiltonian]
+\begin{lemma}[Positivity of the Hilbert-space Hamiltonian]
     \label{lem:transported_es_positive}
     \lean{MPSTensor.localTermES_isPositive}
     \lean{MPSTensor.parentHamiltonianES_isPositive}
     \leanok
     \uses{lem:local_term_es_average}
-    Each Euclidean-space local term $h_{i,\mathrm{ES}}$ is positive, hence the
-    full Euclidean-space parent Hamiltonian $H_{N,\mathrm{ES}}$ is positive.
+    Each Hilbert-space local term $h_{i,\mathrm{ES}}$ is positive, hence the full
+    Hilbert-space parent Hamiltonian $H_{N,\mathrm{ES}}$ is positive.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    Apply the averaging formula~(\ref{eq:ph_cyclic_averaging}): $h_{i,\mathrm{ES}}$ is a non-negative scalar
-    multiple of a finite sum of positive conjugates of $P_L^{\mathrm{ES}}(A)$, hence is
-    itself positive. Summing over $i$ yields positivity of $H_{N,\mathrm{ES}}$.
+    Apply the averaging formula~(\ref{eq:ph_cyclic_averaging}):
+    $h_{i,\mathrm{ES}}$ is a non-negative scalar multiple of a finite sum of
+    positive conjugates of $P_L^{\mathrm{ES}}(A)$, hence is itself positive.
+    Summing over $i$ yields positivity of $H_{N,\mathrm{ES}}$.
 \end{proof}
 
-\begin{lemma}[Euclidean local terms are symmetric projections]
+\begin{lemma}[Hilbert-space local terms are symmetric projections]
     \label{lem:transported_es_local_projections}
     \lean{MPSTensor.parentInteractionES_isSymmetricProjection}
     \lean{MPSTensor.localTermES_isSymmetricProjection}
     \leanok
     \uses{rem:euclidean_local_projector_ingredients, lem:transported_es_positive}
-    The Euclidean local projector $P_L^{\mathrm{ES}}(A)$ is a symmetric projection, and
-    every Euclidean local term $h_{i,\mathrm{ES}}$ on the $N$-site chain is a
-    symmetric projection.
+    The Hilbert-space local projector $P_L^{\mathrm{ES}}(A)$ is a symmetric
+    projection, and every Hilbert-space local term $h_{i,\mathrm{ES}}$ on the
+    $N$-site chain is a symmetric projection.
 \end{lemma}
 
 \begin{proof}
@@ -156,12 +162,13 @@ Lucia~\cite{Kastoryano2018Martingale}.
     definition.
 \end{proof}
 
-\begin{lemma}[Kernel of the Euclidean parent interaction]\label{lem:parent_interaction_es_kernel}
+\begin{lemma}[Kernel of the Hilbert-space parent interaction]
+    \label{lem:parent_interaction_es_kernel}
     \lean{MPSTensor.parentInteractionES_apply_eq_zero_iff}
     \leanok
     \uses{def:ground_space_es, rem:euclidean_local_projector_ingredients}
-    The Euclidean local interaction $P_L^{\mathrm{ES}}(A)$ annihilates exactly the
-    Euclidean local ground space:
+    The Hilbert-space local interaction $P_L^{\mathrm{ES}}(A)$ annihilates exactly
+    the Hilbert-space local ground space:
     \[
         P_L^{\mathrm{ES}}(A)v=0 \quad\Longleftrightarrow\quad
         v\in G_L^{\mathrm{ES}}(A).
@@ -175,14 +182,15 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $G_L^{\mathrm{ES}}(A)$.
 \end{proof}
 
-\begin{lemma}[Local-term kernel via cyclic restrictions]\label{lem:local_term_es_kernel_restrictions}
+\begin{lemma}[Local-term kernel via cyclic restrictions]
+    \label{lem:local_term_es_kernel_restrictions}
     \lean{MPSTensor.localTermES_eq_zero_iff_forall_cyclicRestrictES_mem_groundSpaceES}
     \lean{MPSTensor.cyclicRestrictES_mem_groundSpaceES_of_localTermES_eq_zero}
     \leanok
     \uses{lem:parent_interaction_es_kernel, rem:euclidean_local_projector_ingredients}
-    For $L\le N$, a Euclidean local term $h_{i,\mathrm{ES}}$ annihilates a vector
-    $v$ iff every boundary-filled restriction of $v$ to the cyclic $L$-window
-    starting at $i$ lies in $G_L^{\mathrm{ES}}(A)$.
+    For $L\le N$, a Hilbert-space local term $h_{i,\mathrm{ES}}$ annihilates a
+    vector $v$ iff every boundary-filled restriction of $v$ to the cyclic
+    $L$-window starting at $i$ lies in $G_L^{\mathrm{ES}}(A)$.
 \end{lemma}
 
 \begin{proof}
@@ -202,8 +210,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{thm:ground_space_intersection, lem:local_term_es_kernel_restrictions,
         lem:mem_ground_space_es}
     If $A$ is injective and $L\ge2$, then on an $(L+1)$-site chain the kernels of
-    the two adjacent Euclidean $L$-site local terms have common kernel equal to
-    the Euclidean $(L+1)$-site MPS ground space:
+    the two adjacent Hilbert-space $L$-site local terms have common kernel equal
+    to the Hilbert-space $(L+1)$-site MPS ground space:
     \[
         h_{0,\mathrm{ES}}v=0\ \text{ and }\ h_{1,\mathrm{ES}}v=0
         \quad\Longleftrightarrow\quad
@@ -223,7 +231,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     the same kernel--restriction characterization.
 \end{proof}
 
-\begin{lemma}[Non-overlap positivity for Euclidean local terms]
+\begin{lemma}[Non-overlap positivity for Hilbert-space local terms]
     \label{lem:transported_es_nonoverlap_positive}
     \lean{MPSTensor.CyclicWindowsDisjoint}
     \lean{MPSTensor.CyclicWindowsDisjoint.symm}
@@ -232,7 +240,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \lean{MPSTensor.localTermES_re_inner_nonneg_of_cyclic_windows_disjoint}
     \leanok
     \uses{lem:transported_es_local_projections, rem:projection_geometry_rowsum_identities}
-    Let $L\le N$ and let $h_{i,\mathrm{ES}},h_{j,\mathrm{ES}}$ be Euclidean local
+    Let $L\le N$ and let $h_{i,\mathrm{ES}},h_{j,\mathrm{ES}}$ be Hilbert-space local
     terms whose cyclic $L$-windows are site-disjoint: no site of the periodic chain
     has cyclic offset $<L$ from both $i$ and $j$. Then the terms commute pointwise:
     for every vector $v$,
@@ -302,7 +310,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{lem:transported_es_positive, thm:parent_ground_space_es_kernel,
         lem:quadratic_form_to_norm_bound}
-    Let $H_{N,L}^{\mathrm{ES}}(A)$ be the Euclidean-space representative of the
+    Let $H_{N,L}^{\mathrm{ES}}(A)$ be the Hilbert-space representative of the
     parent Hamiltonian. If a constant $\gamma > 0$ satisfies the uniform
     quadratic-form estimate
     \begin{equation}\label{eq:ph_uniform_quadratic_form}
@@ -322,8 +330,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
 
 \begin{proof}
     \leanok
-    The Euclidean-space Hamiltonian is positive by
-    Lemma~\ref{lem:transported_es_positive}, and its Euclidean-space ground
+    The Hilbert-space Hamiltonian is positive by
+    Lemma~\ref{lem:transported_es_positive}, and its Hilbert-space ground
     space is its kernel by Theorem~\ref{thm:parent_ground_space_es_kernel}.
     Therefore the abstract spectral-theorem conversion of
     Lemma~\ref{lem:quadratic_form_to_norm_bound} applies directly. The
@@ -444,7 +452,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{lem:ordered_projection_rowsum_reduction, def:parent_hamiltonian_es,
         rem:euclidean_local_projector_ingredients, lem:transported_es_local_projections}
-    For a fixed chain length $N$, suppose the Euclidean-space local terms
+    For a fixed chain length $N$, suppose the Hilbert-space local terms
     $h_{i,\mathrm{ES}}$ satisfy the ordered row-sum estimate
     \begin{equation}\label{eq:ph_ordered_rowsum_estimate}
         \operatorname{Re}\langle h_{i,\mathrm{ES}} v,h_{j,\mathrm{ES}}v\rangle
@@ -452,7 +460,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \qquad (i\ne j),
     \end{equation}
     with $\sum_{j\ne i}c_{ij}\le1$ and $\gamma\le1$. Then the
-    Euclidean-space parent Hamiltonian satisfies
+    Hilbert-space parent Hamiltonian satisfies
     \[
         \gamma\operatorname{Re}\langle H_{N,L}^{\mathrm{ES}}v,v\rangle
         \le
@@ -477,7 +485,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \leanok
     \uses{lem:parent_hamiltonian_ordered_rowsum_quadratic,
         lem:parent_hamiltonian_es_quadratic_reduction, lem:transported_es_local_projections}
-    Assume uniformly for every $N\ge2L$ that the Euclidean-space local terms
+    Assume uniformly for every $N\ge2L$ that the Hilbert-space local terms
     satisfy the ordered row-sum estimate~(\ref{eq:ph_ordered_rowsum_estimate})
     with $\gamma=1/(4L)$. If $L>1$, then
     $1/(4L)>0$ and, for every
@@ -494,7 +502,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
         lem:parent_hamiltonian_es_quadratic_reduction}
     The fixed-chain row-sum reduction supplies the quadratic-form estimate with
     $\gamma=1/(4L)$ for every admissible $N$. The positivity and kernel
-    identification of the Euclidean-space Hamiltonian then allow
+    identification of the Hilbert-space Hamiltonian then allow
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} to convert this
     quadratic-form estimate into the norm lower bound on the orthogonal
     complement of the ground space.
@@ -515,8 +523,8 @@ Lucia~\cite{Kastoryano2018Martingale}.
         \ge -(1-\gamma)\frac{1}{m}
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle,
     \]
-    and the Euclidean-space local terms are symmetric projections, then the
-    Euclidean-space Hamiltonian satisfies $H_{N,L}^{\mathrm{ES}}{}^2\ge
+    and the Hilbert-space local terms are symmetric projections, then the
+    Hilbert-space Hamiltonian satisfies $H_{N,L}^{\mathrm{ES}}{}^2\ge
         \gamma H_{N,L}^{\mathrm{ES}}$ as a quadratic form.
 \end{lemma}
 
@@ -607,7 +615,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     \uses{lem:cyclic_window_support_offsets, def:cyclic_windows_overlap,
         lem:transported_es_nonoverlap_positive}
     If $L\le N$ and the cyclic supports $S_i$ and $S_j$ do not meet, then the
-    Euclidean local terms have non-negative ordered cross term:
+    Hilbert-space local terms have non-negative ordered cross term:
     \[
         0\le\operatorname{Re}\langle h_{i,\mathrm{ES}}v,
         h_{j,\mathrm{ES}}v\rangle.
@@ -692,7 +700,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     bound $m=2(L-1)$ for the overlap relation among length-$L$ local windows,
     and
     Lemma~\ref{lem:transported_es_local_projections} supplies the symmetric
-    projection structure of each Euclidean local term. If two cyclic supports
+    projection structure of each Hilbert-space local term. If two cyclic supports
     do not meet, the corresponding windows are site-disjoint, so
     Lemma~\ref{lem:cyclic_window_nonoverlap_positive} gives the required
     non-negative ordered cross term. Apply
@@ -876,7 +884,7 @@ Lucia~\cite{Kastoryano2018Martingale}.
     $\lambda \ge \gamma$~\cite{Kastoryano2018Martingale}.
 \end{proof}
 
-\begin{lemma}[Martingale condition for MPS]\label{lem:martingale_mps}
+\begin{lemma}[MPS principal-angle input for the martingale condition]\label{lem:martingale_mps}
     \notready
     \uses{thm:martingale_criterion, def:parent_interaction,
         def:local_term_parent, thm:ground_space_intersection, def:injective}
@@ -884,19 +892,20 @@ Lucia~\cite{Kastoryano2018Martingale}.
     Definition~\ref{def:parent_interaction}. Let $h_L(A) := \Pi_{G_L(A)^\perp}$
     be the $L$-site parent interaction, and for each chain length and site $i$
     let $h_i$ denote its translate as in Definition~\ref{def:local_term_parent}.
-    Then for every pair of overlapping terms $h_i$ and $h_j$ with
+    For every pair of overlapping terms $h_i$ and $h_j$ with
     $0 < d_N(i,j) < L$, where $d_N(i,j) := \min(|i-j|,\, N-|i-j|)$ is the
     cyclic distance on the ring (i.e.\ whose $L$-site supports share at
-    least one site under periodic boundary conditions),
-    the martingale condition of Theorem~\ref{thm:martingale_criterion} holds with
-    constants $c_{\{i,j\}}$ and $\gamma > 0$ depending only on $A$ (not on $N$).
+    least one site under periodic boundary conditions), the source martingale
+    argument asks for constants $c_{\{i,j\}}$ and $\gamma > 0$, independent of
+    $N$, for which the martingale condition of
+    Theorem~\ref{thm:martingale_criterion} holds.
     Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
-    obtain this uniformity by the martingale method, invoking finite-chain-state
-    estimates to control the constants. For the explicit cyclic-window
-    constants displayed here, the remaining quantitative step is the
-    overlapping-window estimate used as a hypothesis in
-    Theorem~\ref{thm:friedrichs_gap_bound}; the preceding lemmas reduce the
-    martingale inequality and the spectral gap to that estimate.
+    obtain the MPS gap by controlling the principal angles between overlapping
+    local ground spaces. For the explicit cyclic-window constants displayed
+    here, the remaining quantitative comparison is the overlapping-window
+    estimate used as a hypothesis in Theorem~\ref{thm:friedrichs_gap_bound}; the
+    preceding lemmas reduce the martingale inequality and the spectral gap to
+    that estimate.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
     overlapping pairs and the spectral gap follows directly without the
     martingale argument.)

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -16,8 +16,9 @@
 
 \section{The source assertion}
 
-The martingale-method paragraph in Cirac--Perez-Garcia--Schuch--Verstraete 2021 can be compared with the
-quantitative estimate isolated in the formal parent-Hamiltonian proof.\footnote{For
+The martingale-method paragraph in Cirac--Perez-Garcia--Schuch--Verstraete 2021
+can be compared with the quantitative estimate isolated in the formal
+parent-Hamiltonian proof.\footnote{For
     traceability, this note corresponds to
     \href{https://github.com/LionSR/TNLean/issues/1044}{issue \#1044}. The remaining
     quantitative estimate is recorded in
@@ -86,7 +87,7 @@ finite cyclic blocking convention needed for the formal statement below.
 The formal development has separated the finite-row martingale algebra from the
 remaining MPS-specific principal-angle estimate. Fix an interaction range
 $L>1$ and an $N$-site periodic chain with $N\ge 2L$. Let $p_i$ denote the
-Euclidean-space representative of the length-$L$ local parent-Hamiltonian
+Hilbert-space representative of the length-$L$ local parent-Hamiltonian
 projection at the cyclic window starting at $i$. Write $i\sim_L j$ when the two
 length-$L$ cyclic windows intersect and $i\ne j$.
 For each fixed $i$, the number of indices $j$ with $i\sim_L j$ is at most
@@ -212,7 +213,7 @@ replacement input than the review text states explicitly.
 \section{Relation to the blueprint}
 
 The blueprint item labelled \path{lem:martingale_mps} in
-\path{blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex}
+\path{blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex}
 separates the finite-row martingale reduction from the still-open quantitative
 estimate.
 It does not assert that the displayed all-$L>1$ cyclic-window bound has already


### PR DESCRIPTION
Summary:
- State the CPGSV/FNW-Nachtergaele martingale argument as a principal-angle input, rather than as an already-derived cyclic-window estimate.
- Replace local Euclidean-space prose in the spectral-gap section with Hilbert-space realization terminology.
- Fix the martingale-overlap paper-gap note so it points to the actual blueprint item for lem:martingale_mps.

Validation:
- git diff --check
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci
- lake exe cache get
- lake build TNLean -q --log-level=info (passed with pre-existing warnings)
- cd blueprint && leanblueprint checkdecls

Refs #952.
Refs #2633.
Refs #190.
Refs #460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and cross-reference fixes only; no Lean or runtime behavior changes.
> 
> **Overview**
> **Documentation-only** updates to the parent-Hamiltonian blueprint and the martingale-overlap paper-gap note so reader-facing prose matches how the formal spectral-gap development is actually structured.
> 
> The chapter introduction and **Spectral gap** section now say the martingale row-sum machinery is in place while the **MPS-specific overlapping-window principal-angle / norm-compression estimate remains an explicit hypothesis**, rather than reading as if the cyclic-window bound were already derived from the literature. **`lem:martingale_mps`** is retitled and rewritten to frame CPGSV’s argument as supplying principal angles (\(\alpha=\max\cos\theta_s<1\)) as input to the formal reductions, not as proving the displayed martingale inequality outright.
> 
> Throughout **`ch13_parent_hamiltonian_spectral_gap.tex`**, **“Euclidean-space”** wording is replaced with **Hilbert-space realization** terminology (local projectors, Hamiltonian, local terms) for consistency with the \(\ell^2\) identification used in the formalization.
> 
> **`docs/paper-gaps/cpgsv21_martingale_overlap.tex`** now points **`lem:martingale_mps`** at **`ch13_parent_hamiltonian_spectral_gap.tex`** (not the commuting-gap file) and uses the same Hilbert-space label in the formal-reduction section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56f93fb27d98e2c063e0f6a1fa8032236f79ad0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->