### PR TITLE
doc(parent): distinguish commuting projector source form

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -128,13 +128,14 @@ corresponds to a parent commuting Hamiltonian when there are local projectors
 Writing \(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\), the source proof uses the
 corresponding product identity \(P_{AX}\circ P_{XB}=P_K\).
 
-The present declaration records this idempotent-product identity and the
-commutation of \(P_{AX}\) and \(P_{XB}\). It does not yet assert tensor-product
-locality, self-adjointness, or orthogonality. Consequently the witness
-\(P_{AX}=P_{XB}=P_K\) is available for any idempotent \(P_K\); the source content
-is recovered only after the locality hypotheses are added. This scope
-restriction is recorded in
-`docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`.
+**Scope restriction (CPSV16 Definition D.2):** The present declaration records
+this idempotent-product identity and the commutation of \(P_{AX}\) and
+\(P_{XB}\). It does not yet assert tensor-product locality, self-adjointness,
+or orthogonality. Consequently the witness \(P_{AX}=P_{XB}=P_K\) is available
+for any idempotent \(P_K\). Documented in
+`docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`. Elimination:
+add tensor-product locality and orthogonal-projector data, then derive this
+idempotent-product declaration from the source condition.
 
 See arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2259--2289. -/
 structure HasCommutingParentHam (P_K : E →ₗ[ℂ] E) where

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -132,7 +132,9 @@ The present declaration records this idempotent-product identity and the
 commutation of \(P_{AX}\) and \(P_{XB}\). It does not yet assert tensor-product
 locality, self-adjointness, or orthogonality. Consequently the witness
 \(P_{AX}=P_{XB}=P_K\) is available for any idempotent \(P_K\); the source content
-is recovered only after the locality hypotheses are added.
+is recovered only after the locality hypotheses are added. This scope
+restriction is recorded in
+`docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`.
 
 See arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2259--2289. -/
 structure HasCommutingParentHam (P_K : E →ₗ[ℂ] E) where

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -135,9 +135,9 @@ is recovered only after the locality hypotheses are added.
 
 See arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2259--2289. -/
 structure HasCommutingParentHam (P_K : E →ₗ[ℂ] E) where
-  /-- Projector onto the AX region. -/
+  /-- Idempotent endomorphism representing the left local kernel projector. -/
   P_AX : E →ₗ[ℂ] E
-  /-- Projector onto the XB region. -/
+  /-- Idempotent endomorphism representing the right local kernel projector. -/
   P_XB : E →ₗ[ℂ] E
   /-- \(P_{AX}\) is idempotent. -/
   hAX_idem : P_AX ∘ₗ P_AX = P_AX

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -136,17 +136,17 @@ is recovered only after the locality hypotheses are added.
 
 See arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2259--2289. -/
 structure HasCommutingParentHam (P_K : E →ₗ[ℂ] E) where
-  /-- Idempotent endomorphism representing the left local kernel projector. -/
+  /-- Left idempotent endomorphism in the product representation. -/
   P_AX : E →ₗ[ℂ] E
-  /-- Idempotent endomorphism representing the right local kernel projector. -/
+  /-- Right idempotent endomorphism in the product representation. -/
   P_XB : E →ₗ[ℂ] E
   /-- \(P_{AX}\) is idempotent. -/
   hAX_idem : P_AX ∘ₗ P_AX = P_AX
   /-- \(P_{XB}\) is idempotent. -/
   hXB_idem : P_XB ∘ₗ P_XB = P_XB
-  /-- The projectors commute: \([P_{AX}, P_{XB}] = 0\). -/
+  /-- The idempotent endomorphisms commute: \([P_{AX}, P_{XB}] = 0\). -/
   hcomm : P_AX ∘ₗ P_XB = P_XB ∘ₗ P_AX
-  /-- \(P_K\) is the intersection projector: \(P_{AX} \circ P_{XB} = P_K\). -/
+  /-- The idempotent product identity: \(P_{AX} \circ P_{XB} = P_K\). -/
   hK : P_AX ∘ₗ P_XB = P_K
 
 /-- In the current abstract setting, every idempotent endomorphism has a

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -22,10 +22,11 @@ and is deferred.
 * `Decorrelation.IsDecorrelated` — regions \(A\) and \(B\) are decorrelated w.r.t. a
   subspace \(K\) when \(P_K O_A (1 - P_K) O_B P_K = 0\) for all observables
   \(O_A, O_B\) on the respective regions.
-* `Decorrelation.HasCommutingParentHam` — a subspace \(K\) corresponds to a parent
-  commuting Hamiltonian, expressed as the intersection of two local kernels
-  \(K_{AX} \otimes H_B \cap H_A \otimes K_{XB}\) where the corresponding
-  projectors commute.
+* `Decorrelation.HasCommutingParentHam` — the idempotent-product form
+  \(P_{AX} \circ P_{XB}=P_K\) obtained from the Appendix D.2 condition
+  \([Q_{AX},Q_{XB}]=0\) and
+  \(K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})\). The present declaration
+  does not yet include tensor-product locality or orthogonal projectors.
 
 ## Main results
 
@@ -114,25 +115,25 @@ def IsDecorrelated (P_K : E →ₗ[ℂ] E)
   ∀ O_A ∈ ObsA, ∀ O_B ∈ ObsB,
     P_K ∘ₗ O_A ∘ₗ (LinearMap.id - P_K) ∘ₗ O_B ∘ₗ P_K = 0
 
-/-- **Parent commuting Hamiltonian representation**: a subspace (given by its
-idempotent endomorphism \(P_K\)) corresponds to a parent commuting Hamiltonian if
-there exist idempotent endomorphisms \(P_{AX}\) and \(P_{XB}\) (acting on regions AX and
-XB respectively) that commute and whose intersection recovers \(P_K\).
+/-- **Idempotent-product form of the parent commuting Hamiltonian condition.**
 
-Formally: \([Q_{AX}, Q_{XB}] = 0\) where \(Q = 1 - P\), and
-\(K = (K_{AX} \otimes H_B) \cap (H_A \otimes K_{XB})\), which in projector
-language means \(P_{AX} \circ P_{XB} = P_K\).
+In arXiv:1606.00608, Appendix D.2, Definition D.2, a subspace \(K_{AXB}\)
+corresponds to a parent commuting Hamiltonian when there are local projectors
+\(Q_{AX}\) and \(Q_{XB}\) with
+\[
+  [Q_{AX},Q_{XB}]=0,\qquad
+  K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
+\]
+Writing \(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\), the source proof uses the
+corresponding product identity \(P_{AX}\circ P_{XB}=P_K\).
 
-Note: this definition only requires idempotence and commutativity, not
-orthogonality / self-adjointness. Locality (that \(P_{AX}\) acts on the AX
-tensor factor and \(P_{XB}\) on XB) is not enforced in this abstract setting;
-it will be added once tensor-product Hilbert space formulation is
-available. In particular, the trivial witness \(P_{AX} = P_{XB} = P_K\) always
-satisfies this predicate for any idempotent \(P_K\); non-trivial content
-arises only when combined with locality constraints (see
-`commutingHam_isDecorrelated`).
+The present declaration records this idempotent-product identity and the
+commutation of \(P_{AX}\) and \(P_{XB}\). It does not yet assert tensor-product
+locality, self-adjointness, or orthogonality. Consequently the witness
+\(P_{AX}=P_{XB}=P_K\) is available for any idempotent \(P_K\); the source content
+is recovered only after the locality hypotheses are added.
 
-See arXiv:1606.00608, Appendix D, Section D.2, Definition D.2. -/
+See arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2259--2289. -/
 structure HasCommutingParentHam (P_K : E →ₗ[ℂ] E) where
   /-- Projector onto the AX region. -/
   P_AX : E →ₗ[ℂ] E

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -23,7 +23,8 @@ and is deferred.
   subspace \(K\) when \(P_K O_A (1 - P_K) O_B P_K = 0\) for all observables
   \(O_A, O_B\) on the respective regions.
 * `Decorrelation.HasCommutingParentHam` — the idempotent-product form
-  \(P_{AX} \circ P_{XB}=P_K\) obtained from the Appendix D.2 condition
+  \(P_{AX} \circ P_{XB}=P_K\) obtained from the arXiv:1606.00608,
+  Appendix D.2 condition
   \([Q_{AX},Q_{XB}]=0\) and
   \(K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})\). The present declaration
   does not yet include tensor-product locality or orthogonal projectors.

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -134,7 +134,7 @@ this idempotent-product identity and the commutation of \(P_{AX}\) and
 or orthogonality. Consequently the witness \(P_{AX}=P_{XB}=P_K\) is available
 for any idempotent \(P_K\). Documented in
 `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`. Elimination:
-add tensor-product locality and orthogonal-projector data, then derive this
+add tensor-product locality, self-adjointness, and orthogonality, then derive this
 idempotent-product declaration from the source condition.
 
 See arXiv:1606.00608, Appendix D.2, lines 2205--2218 and 2259--2289. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -203,10 +203,11 @@ for local projectors $Q_{AX}$ and $Q_{XB}$ with
     K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
 \]
 Writing $P_{AX}=1-Q_{AX}$ and $P_{XB}=1-Q_{XB}$ gives, for the idempotent
-$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$. The present formal
-statements keep this idempotent identity and its algebraic consequences; they
-do not include the tensor-product locality and orthogonal-projector hypotheses
-of the source definition.
+$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$. The statements in this
+subsection keep this idempotent identity and its algebraic consequences; they do
+not include the tensor-product locality and orthogonal-projector hypotheses of
+the source definition. This scope restriction is recorded in
+\path{docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex}.
 
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}
     \lean{Decorrelation.IsDecorrelated}
@@ -230,7 +231,7 @@ of the source definition.
     \]
     In the source, this is the equation obtained from local projectors
     $Q_{AX}$ and $Q_{XB}$ satisfying $[Q_{AX},Q_{XB}]=0$ and
-    $K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})$. The formal predicate
+    $K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})$. This definition
     records only the idempotent-product part of that condition.
 \end{definition}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -203,11 +203,11 @@ for local projectors $Q_{AX}$ and $Q_{XB}$ with
     K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
 \]
 Writing $P_{AX}=1-Q_{AX}$ and $P_{XB}=1-Q_{XB}$ gives, for the idempotent
-$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$. The statements in this
-subsection keep this idempotent identity and its algebraic consequences; they do
-not include the tensor-product locality and orthogonal-projector hypotheses of
-the source definition. This scope restriction is recorded in
-\path{docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex}.
+$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$.
+% Scope restriction: this subsection keeps the idempotent-product consequence
+% and not the tensor-product locality or orthogonal-projector hypotheses of the
+% source definition. See
+% docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex.
 
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}
     \lean{Decorrelation.IsDecorrelated}
@@ -231,8 +231,10 @@ the source definition. This scope restriction is recorded in
     \]
     In the source, this is the equation obtained from local projectors
     $Q_{AX}$ and $Q_{XB}$ satisfying $[Q_{AX},Q_{XB}]=0$ and
-    $K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})$. This definition
-    records only the idempotent-product part of that condition.
+    $K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})$.
+    % Scope restriction: this definition records only the idempotent-product
+    % part of the source condition. See
+    % docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex.
 \end{definition}
 
 \begin{theorem}[Idempotence gives a tautological parent commuting Hamiltonian]%

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -194,9 +194,19 @@ normalization.
 \section{Decorrelation and parent commuting Hamiltonians}%
 \label{sec:decorrelation}
 
-This section develops the abstract operator-algebraic formulation of
-decorrelation and its connection to parent commuting Hamiltonians, following
-\cite[Appendix~D, Section~D.2]{Cirac2016MPDO_arXiv}.
+This section develops the idempotent-product formulation used for the
+decorrelation implication. In Appendix~D.2 of
+\cite{Cirac2016MPDO_arXiv}, the parent commuting Hamiltonian condition is stated
+for local projectors $Q_{AX}$ and $Q_{XB}$ with
+\[
+    [Q_{AX},Q_{XB}]=0,\qquad
+    K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
+\]
+Writing $P_{AX}=1-Q_{AX}$ and $P_{XB}=1-Q_{XB}$ gives the idempotent identity
+$P_{AX}P_{XB}=P_{AXB}$ used below. The present formal statements keep this
+idempotent identity and its algebraic consequences; they do not include the
+tensor-product locality and orthogonal-projector hypotheses of the source
+definition.
 
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}
     \lean{Decorrelation.IsDecorrelated}
@@ -211,10 +221,16 @@ decorrelation and its connection to parent commuting Hamiltonians, following
 \begin{definition}[Parent commuting Hamiltonian representation]\label{def:has_commuting_parent_ham}
     \lean{Decorrelation.HasCommutingParentHam}
     \leanok
-    A subspace $K$ (given by its idempotent endomorphism $P_K$) corresponds to
-    a \emph{parent commuting Hamiltonian} if there exist idempotent endomorphisms
-    $P_{AX}$ and $P_{XB}$ that commute and satisfy
-    $P_{AX} \circ P_{XB} = P_K$.
+    The idempotent form of the Appendix~D.2 parent commuting Hamiltonian condition
+    consists of commuting idempotent endomorphisms $P_{AX}$ and $P_{XB}$ such
+    that, for the idempotent $P_K$ associated to $K$,
+    \[
+        P_{AX}\circ P_{XB}=P_K.
+    \]
+    In the source, this is the equation obtained from local projectors
+    $Q_{AX}$ and $Q_{XB}$ satisfying $[Q_{AX},Q_{XB}]=0$ and
+    $K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})$. The formal predicate
+    records only the idempotent-product part of that condition.
 \end{definition}
 
 \begin{theorem}[Idempotence gives a tautological parent commuting Hamiltonian]%

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -202,11 +202,11 @@ for local projectors $Q_{AX}$ and $Q_{XB}$ with
     [Q_{AX},Q_{XB}]=0,\qquad
     K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
 \]
-Writing $P_{AX}=1-Q_{AX}$ and $P_{XB}=1-Q_{XB}$ gives the idempotent identity
-$P_{AX}P_{XB}=P_{AXB}$ used below. The present formal statements keep this
-idempotent identity and its algebraic consequences; they do not include the
-tensor-product locality and orthogonal-projector hypotheses of the source
-definition.
+Writing $P_{AX}=1-Q_{AX}$ and $P_{XB}=1-Q_{XB}$ gives, for the idempotent
+$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$. The present formal
+statements keep this idempotent identity and its algebraic consequences; they
+do not include the tensor-product locality and orthogonal-projector hypotheses
+of the source definition.
 
 \begin{definition}[Decorrelation]\label{def:is_decorrelated}
     \lean{Decorrelation.IsDecorrelated}
@@ -221,9 +221,10 @@ definition.
 \begin{definition}[Parent commuting Hamiltonian representation]\label{def:has_commuting_parent_ham}
     \lean{Decorrelation.HasCommutingParentHam}
     \leanok
-    The idempotent form of the Appendix~D.2 parent commuting Hamiltonian condition
-    consists of commuting idempotent endomorphisms $P_{AX}$ and $P_{XB}$ such
-    that, for the idempotent $P_K$ associated to $K$,
+    The idempotent form of the parent commuting Hamiltonian condition of
+    \cite[Appendix~D.2]{Cirac2016MPDO_arXiv} consists of commuting idempotent
+    endomorphisms $P_{AX}$ and $P_{XB}$ such that, for the idempotent $P_K$
+    associated to $K$,
     \[
         P_{AX}\circ P_{XB}=P_K.
     \]

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -83,6 +83,10 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
 - `cpgsv21_block_diagonal_parent_ground_space.tex` records the degenerate
   parent-Hamiltonian block-diagonal boundary-condition theorem behind the
   periodic block decomposition and the BNT ground-space span.
+- `cpsv16_parent_commuting_hamiltonian_scope.tex` records that the current
+  parent commuting Hamiltonian predicate keeps only the idempotent-product
+  consequence of CPSV16 Definition D.2, while the source definition also has
+  tensor-product locality and orthogonal-projector hypotheses.
 
 For the periodic (irreducible-form) MPS Fundamental Theorem of
 arXiv:1708.00029, the overlap-dichotomy development has one route-alignment

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -19,7 +19,8 @@
 Definition~D.2 of \cite{Cirac2016MPDO_arXiv} states the parent commuting
 Hamiltonian condition for a tripartite Hilbert space
 \(\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\).  It uses local
-projectors \(Q_{AX}\) and \(Q_{XB}\) satisfying\footnote{Local source:
+projectors \(Q_{AX}\) and \(Q_{XB}\).  Let \(K_{AX}\) and \(K_{XB}\) denote
+their kernels.  The source condition is\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex}:2205--2218, labels
 \path{QAXQXB} and \path{KAXBKAXKXB}.}
 \begin{align}
@@ -33,7 +34,8 @@ The proof of Proposition~D.3 then writes
   P_{AX}P_{XB}=P_{AXB}.
 \end{align}
 This is the identity obtained from commuting orthogonal projectors onto the two
-local kernel complements.\footnote{Local source:
+local kernels \(K_{AX}\) and \(K_{XB}\), equivalently the complements of the
+ranges of \(Q_{AX}\) and \(Q_{XB}\).\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex}:2259--2289, in particular labels
 \path{PAXQAX}, \path{PXBQXB}, and \path{arrggg}.}
 

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -34,8 +34,7 @@ The proof of Proposition~D.3 then writes
   P_{AX}P_{XB}=P_{AXB}.
 \end{align}
 This is the identity obtained from commuting orthogonal projectors onto the two
-local kernels \(K_{AX}\) and \(K_{XB}\), equivalently the complements of the
-ranges of \(Q_{AX}\) and \(Q_{XB}\).\footnote{Local source:
+local kernels \(K_{AX}\) and \(K_{XB}\).\footnote{Local source:
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex}:2259--2289, in particular labels
 \path{PAXQAX}, \path{PXBQXB}, and \path{arrggg}.}
 

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -1,0 +1,80 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The parent commuting Hamiltonian condition in Cirac--Perez-Garcia--Schuch--Verstraete 2016}
+\author{}
+\date{2026-06-15}
+
+\begin{document}
+\maketitle
+
+\section{Source condition}
+
+Definition~D.2 of \cite{Cirac2016MPDO_arXiv} states the parent commuting
+Hamiltonian condition for a tripartite Hilbert space
+\(\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\).  It uses local
+projectors \(Q_{AX}\) and \(Q_{XB}\) satisfying\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex}:2205--2218, labels
+\path{QAXQXB} and \path{KAXBKAXKXB}.}
+\begin{align}
+  [Q_{AX},Q_{XB}]&=0,\\
+  K_{AXB}&=(K_{AX}\otimes\mathcal H_B)
+    \cap(\mathcal H_A\otimes K_{XB}).
+\end{align}
+The proof of Proposition~D.3 then writes
+\(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\), and uses the product identity
+\begin{align}
+  P_{AX}P_{XB}=P_{AXB}.
+\end{align}
+This is the identity obtained from commuting orthogonal projectors onto the two
+local kernel complements.\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex}:2259--2289, in particular labels
+\path{PAXQAX}, \path{PXBQXB}, and \path{arrggg}.}
+
+\section{Current boundary}
+
+The current declaration \leanid{Decorrelation.HasCommutingParentHam} records
+only the idempotent-product part of this condition.\footnote{See
+\doclink{TNLean/MPS/ParentHamiltonian/Decorrelation}.}  For a complex vector
+space \(E\), it asks for endomorphisms \(P_{AX},P_{XB}:E\to E\) such that
+\begin{align}
+  P_{AX}^2=P_{AX},\qquad
+  P_{XB}^2=P_{XB},\qquad
+  P_{AX}P_{XB}=P_{XB}P_{AX},\qquad
+  P_{AX}P_{XB}=P_K.
+\end{align}
+It does not assert a tensor decomposition of \(E\), local action on the
+\(AX\) and \(XB\) tensor factors, self-adjointness, orthogonality, or the
+existence of source projectors \(Q_{AX}\) and \(Q_{XB}\).  Consequently every
+idempotent \(P_K\) has the tautological witness
+\(P_{AX}=P_{XB}=P_K\), recorded by
+\leanid{Decorrelation.HasCommutingParentHam.ofIdem}.
+
+Thus the present declaration is not Definition~D.2 itself.  It is the algebraic
+idempotent-product consequence of Definition~D.2 that is sufficient for the
+backward decorrelation implication already proved in the file.
+
+\section{Elimination plan}
+
+A source-faithful version should introduce the tensor-product setting
+\(\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B\), the local subspaces
+\(K_{AX}\) and \(K_{XB}\), and the corresponding orthogonal projectors
+\(Q_{AX}\) and \(Q_{XB}\).  From the source hypotheses it should derive the
+idempotent-product declaration above as a lemma, with \(P_K=P_{AXB}\).
+
+After that tensor-product version is available, the blueprint entry for the
+source parent commuting Hamiltonian condition should point to that source-level
+statement.  The current idempotent-product declaration can remain as the
+algebraic lemma used in the backward direction of Proposition~D.3.  The work is
+tracked by \ghissue{2633} and \ghissue{190}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary
- Display the Appendix D.2 source projector and kernel equations before the local idempotent abstraction.
- Clarify that the local commuting-Hamiltonian predicate records the idempotent product identity and consequences, not tensor-product locality or orthogonal-projector structure.
- Update the corresponding Lean docstrings with the same source boundary.
- Add docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex to record the omitted locality and orthogonality hypotheses and the elimination plan.

## Validation
- git diff --check origin/main
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci
- lake env lean TNLean/MPS/ParentHamiltonian/Decorrelation.lean
- lake build TNLean -q --log-level=info
- cd blueprint && leanblueprint checkdecls
- cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode cpsv16_parent_commuting_hamiltonian_scope.tex

Refs #2633
Refs #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and prose updates only; formal definitions and theorems are unchanged.
> 
> **Overview**
> **Documentation-only:** aligns Lean, blueprint, and paper-gap notes so CPSV16 Appendix D.2 Definition D.2 is not read as fully formalized in `Decorrelation.HasCommutingParentHam`.
> 
> The Lean module doc and `HasCommutingParentHam` docstring now lead with the source local projectors \(Q_{AX}, Q_{XB}\), kernel intersection, and the derived idempotent product \(P_{AX}\circ P_{XB}=P_K\), and state explicitly that the current predicate is only that **idempotent-product + commutation** fragment (no tensor locality, orthogonality, or self-adjointness). Field comments are retitled from “projector” to “idempotent endomorphism” without changing the structure.
> 
> Blueprint **§Decorrelation** (`ch13_parent_hamiltonian_commuting_gap.tex`) is rewritten the same way: source equations first, then the idempotent form linked to `\lean{Decorrelation.HasCommutingParentHam}`, with scope comments pointing at the gap note.
> 
> Adds **`docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`** (source vs current boundary, tautological `ofIdem` witness, elimination plan; issues #2633 / #190) and indexes it in **`docs/paper-gaps/README.md`**.
> 
> No changes to proofs or to the fields of `HasCommutingParentHam`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a37c899c6244f8e39403adc984cc942b2b7475e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->