### PR TITLE
refactor(Wielandt): retire blocked assembly completion

### DIFF
--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -472,34 +472,6 @@ theorem exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors
   exact ⟨D + N₁ + D, by
     simpa [data.hB] using data.rankOne_mem_wordSpan_of_wordSpan_eq_top hBtop⟩
 
-/-- **Wielandt Lemma 2(b) blocked word-span saturation from supplied word-eigenvector data.**
-
-Given word eigenvectors of length `L` with nonzero eigenvalues and `IsNormal A`,
-produces `wordSpan A N = ⊤` for an explicit `N`.
-
-This eliminates the `hRankOne` hypothesis from `wielandt_blocked_assembly` by
-using `exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors` to internally
-produce the rank-one element. -/
-theorem wielandt_blocked_assembly_complete [NeZero D]
-    (A : MPSTensor d D)
-    (L : ℕ) (hL : 0 < L)
-    (σ₀ τ₀ : Fin L → Fin d)
-    (φ ψ : Fin D → ℂ)
-    (hφ : φ ≠ 0) (hψ : ψ ≠ 0)
-    (μ ν : ℂ) (hμ : μ ≠ 0) (hν : ν ≠ 0)
-    (heigφ : evalWord A (List.ofFn σ₀) *ᵥ φ = μ • φ)
-    (heigψ : (evalWord A (List.ofFn τ₀))ᵀ *ᵥ ψ = ν • ψ)
-    (hNormal : IsNormal A) :
-    ∃ N : ℕ, wordSpan A N = ⊤ := by
-  -- Step 1: Get the rank-one element in the blocked word span
-  obtain ⟨m_blocked, hRankOne⟩ :=
-    exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors
-      A L hL σ₀ τ₀ φ ψ μ ν hμ hν heigφ heigψ hNormal
-  -- Step 2: Apply the blocked fixed-length matrix spanning lemma
-  exact ⟨(D - 1 + (m_blocked + (D - 1))) * L,
-    wielandt_blocked_assembly A hNormal L hL σ₀ φ hφ μ hμ heigφ
-      τ₀ ψ hψ ν hν heigψ hRankOne⟩
-
 end ExternalEigenvectors
 
 end MPSTensor

--- a/blueprint/src/chapter/ch08_wielandt.tex
+++ b/blueprint/src/chapter/ch08_wielandt.tex
@@ -1202,23 +1202,6 @@ used to produce rank-one elements.
     Lemma~\ref{lem:blocking_transfer}.
 \end{proof}
 
-\begin{theorem}[Blocked fixed-length matrix spanning from word eigenvectors]
-    \label{thm:wielandt_blocked_assembly_complete}
-    \lean{MPSTensor.wielandt_blocked_assembly_complete}
-    \leanok
-    \uses{thm:wielandt_blocked_assembly}
-    Suppose $A$ is normal and $L > 0$. If a length-$L$ word has a nonzero
-    eigenvector and a length-$L$ word has a nonzero transpose eigenvector, then
-    there exists $N$ such that $S_N(A)=\MN{D}$.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:rankone_extraction_blockTensor, thm:wielandt_blocked_assembly}
-    The rank-one extraction theorem supplies the blocked rank-one element
-    required by Theorem~\ref{thm:wielandt_blocked_assembly}; apply the blocked
-    assembly theorem.
-\end{proof}
-
 \begin{theorem}[Rank-one extraction for blocked tensor]%
     \label{thm:rankone_extraction_blockTensor}
     \lean{MPSTensor.exists_rankOne_mem_wordSpan_blockTensor}


### PR DESCRIPTION
## Summary

- Remove the unused convenience theorem `MPSTensor.wielandt_blocked_assembly_complete`.
- Remove the corresponding Chapter 8 blueprint theorem and proof block.

## Rationale

The theorem has no Lean consumers and no incoming blueprint references. The paper-facing fixed-length statement remains `MPSTensor.wielandt_lemma2b`, and the underlying ingredients `MPSTensor.exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors` and `MPSTensor.wielandt_blocked_assembly` remain in place.

Addresses #2295.

## Checks

- `rg -n "wielandt_blocked_assembly_complete|thm:wielandt_blocked_assembly_complete" TNLean blueprint/src docs || true`
- `lake env lean TNLean/Wielandt/RankOne/ExtractionFull.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake exe checkdecls blueprint/lean_decls`
- `lake build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dead-code removal only; no callers or proof-path changes to `wielandt_lemma2b` or the underlying assembly/extraction theorems.
> 
> **Overview**
> Removes the unused convenience layer **`MPSTensor.wielandt_blocked_assembly_complete`** from `ExtractionFull.lean` and drops the matching Chapter 8 blueprint theorem **`thm:wielandt_blocked_assembly_complete`** (statement + proof).
> 
> That wrapper only chained **`exists_rankOne_in_wordSpan_blockTensor_of_wordEigenvectors`** with **`wielandt_blocked_assembly`**; the paper-facing fixed-length result **`wielandt_lemma2b`** and those ingredients are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30e30ee6e6bf29ea73c0b9a65d08ce63f833459c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->