### PR TITLE
refactor(Channel): retire peripheral unit-circle lemma

### DIFF
--- a/TNLean/Channel/Peripheral/Spectrum.lean
+++ b/TNLean/Channel/Peripheral/Spectrum.lean
@@ -99,13 +99,6 @@ theorem norm_inv_eq_one_of_norm_eq_one {μ : ℂ} (hμ : ‖μ‖ = 1) :
 theorem ne_zero_of_norm_eq_one {μ : ℂ} (hμ : ‖μ‖ = 1) : μ ≠ 0 := by
   intro h; simp [h] at hμ
 
-/-- Definitional auxiliary lemma: peripheral eigenvalues lie on the unit circle. -/
-theorem peripheralEigenvalues_subset_unit_circle
-    {V : Type*} [AddCommGroup V] [Module ℂ V]
-    (f : V →ₗ[ℂ] V) :
-    peripheralEigenvalues f ⊆ {μ : ℂ | ‖μ‖ = 1} :=
-  fun _ hμ => hμ.2
-
 /-- In finite dimensions, the peripheral eigenvalue set is finite. -/
 theorem peripheralEigenvalues_finite
     {V : Type*} [AddCommGroup V] [Module ℂ V]

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -367,14 +367,11 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \begin{remark}[Peripheral conventions for channels]%
     \label{rem:peripheral_conventions_channels}
     \leanok
-    \uses{def:peripheral_spectrum, def:peripheral_eigenvalues,
-        thm:peripheral_unit_circle}
+    \uses{def:peripheral_spectrum, def:peripheral_eigenvalues}
     The spectral-radius convention of
     Definition~\ref{def:peripheral_spectrum} is the usual bounded-operator
     notion. For channels the spectral radius is $1$, so the channel arguments
     below use the unit-circle set of Definition~\ref{def:peripheral_eigenvalues}.
-    Theorem~\ref{thm:peripheral_unit_circle} records the corresponding
-    definitional fact $|\lambda|=1$.
 \end{remark}
 
 \begin{theorem}[$1$ is a peripheral eigenvalue]\label{thm:one_peripheral}
@@ -387,18 +384,6 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 
 \begin{proof}\leanok
     $\rho$ is an eigenvector with eigenvalue~$1$, and $|1| = 1$.
-\end{proof}
-
-\begin{theorem}[Peripheral eigenvalues lie on the unit circle]\label{thm:peripheral_unit_circle}
-    \lean{peripheralEigenvalues_subset_unit_circle}
-    \leanok
-    \uses{def:peripheral_eigenvalues}
-    Every peripheral eigenvalue $\lambda$ satisfies $|\lambda| = 1$.
-\end{theorem}
-
-\begin{proof}\leanok
-    This is the defining condition in
-    Definition~\ref{def:peripheral_eigenvalues}.
 \end{proof}
 
 \begin{theorem}[Finiteness of peripheral eigenvalues]\label{thm:peripheral_finite}


### PR DESCRIPTION
## Summary

- Remove `peripheralEigenvalues_subset_unit_circle`, which only restates the second conjunct of `peripheralEigenvalues`.
- Remove the corresponding Chapter 4 blueprint theorem and the preceding remark's reference to it.

## Rationale

The declaration has no Lean consumers. The mathematical content remains in the definition of `peripheralEigenvalues`: a peripheral eigenvalue is an eigenvalue with `|λ| = 1`.

Addresses #2295.

## Checks

- `rg -n "peripheralEigenvalues_subset_unit_circle|thm:peripheral_unit_circle|peripheral_unit_circle" TNLean blueprint/src docs || true`
- `lake env lean TNLean/Channel/Peripheral/Spectrum.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake build`
- `lake exe checkdecls blueprint/lean_decls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dead-code removal only; no changes to `peripheralEigenvalues` or downstream proofs.
> 
> **Overview**
> This PR **drops** `peripheralEigenvalues_subset_unit_circle` from `TNLean/Channel/Peripheral/Spectrum.lean`. That theorem only unpacked the second conjunct of membership in `peripheralEigenvalues` (`‖μ‖ = 1`) and had no other Lean callers.
> 
> In **Chapter 4** (`ch04_channels.tex`), it removes theorem `thm:peripheral_unit_circle` and its proof, and trims the peripheral-conventions remark so it no longer cites that theorem. The mathematical content stays in **Definition** `peripheral_eigenvalues` (eigenvalue plus unit modulus).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548af18754ad6989345d0814e48b5c41704381e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->