### PR TITLE
doc(MPS/ParentHamiltonian): flag L0+1<N ground-state range narrowing vs CPGSV21

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -901,12 +901,14 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction (chain longer than interaction range):** The source
-(arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
-periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
-AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge` (\(L₀ + 1 < N\)) excludes
-that case, where the boundary comparison's complement word \(\mathrm{Fin}(N - (L₀+1))\) is
-empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving \(N = L₀+1\) directly (the single window is the whole ring). -/
+(arXiv:2011.12127, Section IV.C, lines 2087--2094) places no lower bound on the
+ring length beyond \(N \ge L₀+1\), so it covers the minimal ring \(N = L₀+1\),
+where a single length-\(L₀+1\) window already wraps the whole ring. The
+hypothesis \(L₀ + 1 < N\) excludes that minimal ring, because the
+boundary-comparison word over the \(N - (L₀+1)\) sites outside the two windows is
+empty there. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
+eliminate by proving the \(N = L₀+1\) case directly (the single window is the
+whole ring). -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -942,12 +944,14 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction (chain longer than interaction range):** The source
-(arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
-periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
-AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge` (\(L₀ + 1 < N\)) excludes
-that case, where the boundary comparison's complement word \(\mathrm{Fin}(N - (L₀+1))\) is
-empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving \(N = L₀+1\) directly (the single window is the whole ring). -/
+(arXiv:2011.12127, Section IV.C, lines 2087--2094) places no lower bound on the
+ring length beyond \(N \ge L₀+1\), so it covers the minimal ring \(N = L₀+1\),
+where a single length-\(L₀+1\) window already wraps the whole ring. The
+hypothesis \(L₀ + 1 < N\) excludes that minimal ring, because the
+boundary-comparison word over the \(N - (L₀+1)\) sites outside the two windows is
+empty there. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
+eliminate by proving the \(N = L₀+1\) case directly (the single window is the
+whole ring). -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -985,12 +989,14 @@ with \(L₀+1<N\).
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction (chain longer than interaction range):** The source
-(arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
-periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
-AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge` (\(L₀ + 1 < N\)) excludes
-that case, where the boundary comparison's complement word \(\mathrm{Fin}(N - (L₀+1))\) is
-empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving \(N = L₀+1\) directly (the single window is the whole ring). -/
+(arXiv:2011.12127, Section IV.C, lines 2087--2094) places no lower bound on the
+ring length beyond \(N \ge L₀+1\), so it covers the minimal ring \(N = L₀+1\),
+where a single length-\(L₀+1\) window already wraps the whole ring. The
+hypothesis \(L₀ + 1 < N\) excludes that minimal ring, because the
+boundary-comparison word over the \(N - (L₀+1)\) sites outside the two windows is
+empty there. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
+eliminate by proving the \(N = L₀+1\) case directly (the single window is the
+whole ring). -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) (hNlarge : L₀ + 1 < N) :
@@ -1009,14 +1015,15 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (chain longer than interaction range):** The source theorem
-(arXiv:2011.12127, theorem thm:4:unique-gs-L0_plus_1, lines 2087--2094) proves
-uniqueness for every periodic chain with \(N \ge L₀+1\), including the minimal
-\(N = L₀+1\) ring (the AKLT \(L₀=2\) remark checks the 3-site ring).
-`hN` (\(L₀ + 1 < N\)) excludes that case, where the boundary comparison's complement
-word \(\mathrm{Fin}(N - (L₀+1))\) is empty. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; eliminate by proving
-\(N = L₀+1\) directly (the single window is the whole ring). -/
+**Scope restriction (chain longer than interaction range):** The source
+uniqueness theorem (arXiv:2011.12127, Section IV.C, lines 2087--2094) places no
+lower bound on the ring length beyond \(N \ge L₀+1\), so it covers the minimal
+ring \(N = L₀+1\), where the single length-\(L₀+1\) window already wraps the
+whole ring. The hypothesis \(L₀ + 1 < N\) excludes that minimal ring, because the
+boundary-comparison word over the \(N - (L₀+1)\) sites outside the two windows is
+empty there. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
+eliminate by proving the \(N = L₀+1\) case directly (the single window is the
+whole ring). -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -852,7 +852,13 @@ Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
 **Unfaithful:** This proof relies directly or transitively on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (minimal ring):** This boundary comparison is stated only for
+\(L₀+1<N\). The source theorem (arXiv:2011.12127, Section IV.C, lines 2087--2094)
+also covers \(N=L₀+1\), where the complement word in the boundary-closing
+argument has length zero. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the empty-complement
+cyclic-boundary case separately. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -900,15 +906,13 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (chain longer than interaction range):** The source
-(arXiv:2011.12127, Section IV.C, lines 2087--2094) places no lower bound on the
-ring length beyond \(N \ge L₀+1\), so it covers the minimal ring \(N = L₀+1\),
-where a single length-\(L₀+1\) window already wraps the whole ring. The
-hypothesis \(L₀ + 1 < N\) excludes that minimal ring, because the
-boundary-comparison word over the \(N - (L₀+1)\) sites outside the two windows is
-empty there. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving the \(N = L₀+1\) case directly (the single window is the
-whole ring). -/
+**Scope restriction (minimal ring):** The source theorem (arXiv:2011.12127,
+Section IV.C, lines 2087--2094) places no lower bound on the ring length beyond
+\(N \ge L₀+1\). The strict hypothesis \(L₀+1<N\) excludes \(N=L₀+1\), where the
+complement word in the boundary-closing argument has length zero and the two
+boundary-crossing words coincide. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the empty-complement
+cyclic-boundary case separately. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -943,15 +947,13 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (chain longer than interaction range):** The source
-(arXiv:2011.12127, Section IV.C, lines 2087--2094) places no lower bound on the
-ring length beyond \(N \ge L₀+1\), so it covers the minimal ring \(N = L₀+1\),
-where a single length-\(L₀+1\) window already wraps the whole ring. The
-hypothesis \(L₀ + 1 < N\) excludes that minimal ring, because the
-boundary-comparison word over the \(N - (L₀+1)\) sites outside the two windows is
-empty there. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving the \(N = L₀+1\) case directly (the single window is the
-whole ring). -/
+**Scope restriction (minimal ring):** The source theorem (arXiv:2011.12127,
+Section IV.C, lines 2087--2094) places no lower bound on the ring length beyond
+\(N \ge L₀+1\). The strict hypothesis \(L₀+1<N\) excludes \(N=L₀+1\), where the
+complement word in the boundary-closing argument has length zero and the two
+boundary-crossing words coincide. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the empty-complement
+cyclic-boundary case separately. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -988,15 +990,13 @@ with \(L₀+1<N\).
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (chain longer than interaction range):** The source
-(arXiv:2011.12127, Section IV.C, lines 2087--2094) places no lower bound on the
-ring length beyond \(N \ge L₀+1\), so it covers the minimal ring \(N = L₀+1\),
-where a single length-\(L₀+1\) window already wraps the whole ring. The
-hypothesis \(L₀ + 1 < N\) excludes that minimal ring, because the
-boundary-comparison word over the \(N - (L₀+1)\) sites outside the two windows is
-empty there. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving the \(N = L₀+1\) case directly (the single window is the
-whole ring). -/
+**Scope restriction (two-site boundary case):** This corollary applies the
+range-reduction theorem at interaction range \(2L₀\). Under the hypothesis
+\(2L₀\le N\), the extra bound \(L₀+1<N\) is automatic for \(1<L₀\); it only
+excludes \(L₀=1\), \(N=2\). Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; eliminate by removing the
+strict bound from the range-reduction theorem or by treating this two-site
+cyclic case separately. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) (hNlarge : L₀ + 1 < N) :
@@ -1015,15 +1015,13 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (chain longer than interaction range):** The source
-uniqueness theorem (arXiv:2011.12127, Section IV.C, lines 2087--2094) places no
-lower bound on the ring length beyond \(N \ge L₀+1\), so it covers the minimal
-ring \(N = L₀+1\), where the single length-\(L₀+1\) window already wraps the
-whole ring. The hypothesis \(L₀ + 1 < N\) excludes that minimal ring, because the
-boundary-comparison word over the \(N - (L₀+1)\) sites outside the two windows is
-empty there. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving the \(N = L₀+1\) case directly (the single window is the
-whole ring). -/
+**Scope restriction (minimal ring):** The source theorem (arXiv:2011.12127,
+thm:4:unique-gs-L0_plus_1, lines 2087--2094) places no lower bound on the ring
+length beyond \(N \ge L₀+1\). The strict hypothesis \(L₀+1<N\) excludes
+\(N=L₀+1\), where the complement word in the boundary-closing argument has
+length zero and the two boundary-crossing words coincide. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the empty-complement
+cyclic-boundary case separately. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -899,7 +899,14 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 **Unfaithful:** This proof relies directly or transitively on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (chain longer than interaction range):** The source
+(arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
+periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
+AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge : L₀ + 1 < N` excludes
+that case, where the boundary comparison's complement word `Fin (N - (L₀+1))` is
+empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
+eliminate by proving `N = L₀+1` directly (the single window is the whole ring). -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -933,7 +940,14 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 **Unfaithful:** This proof relies directly or transitively on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (chain longer than interaction range):** The source
+(arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
+periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
+AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge : L₀ + 1 < N` excludes
+that case, where the boundary comparison's complement word `Fin (N - (L₀+1))` is
+empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
+eliminate by proving `N = L₀+1` directly (the single window is the whole ring). -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -969,7 +983,14 @@ with \(L₀+1<N\).
 **Unfaithful:** This proof relies directly or transitively on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (chain longer than interaction range):** The source
+(arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
+periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
+AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge : L₀ + 1 < N` excludes
+that case, where the boundary comparison's complement word `Fin (N - (L₀+1))` is
+empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
+eliminate by proving `N = L₀+1` directly (the single window is the whole ring). -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) (hNlarge : L₀ + 1 < N) :
@@ -987,7 +1008,15 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 **Unfaithful:** This proof relies directly or transitively on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (chain longer than interaction range):** The source theorem
+(arXiv:2011.12127, `thm:4:unique-gs-L0_plus_1`, lines 2087--2094) proves
+uniqueness for every periodic chain with \(N \ge L₀+1\), including the minimal
+\(N = L₀+1\) ring (the AKLT \(L₀=2\) remark checks the 3-site ring).
+`hN : L₀ + 1 < N` excludes that case, where the boundary comparison's complement
+word `Fin (N - (L₀+1))` is empty. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; eliminate by proving
+`N = L₀+1` directly (the single window is the whole ring). -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -903,10 +903,10 @@ Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the co
 **Scope restriction (chain longer than interaction range):** The source
 (arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
 periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
-AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge : L₀ + 1 < N` excludes
-that case, where the boundary comparison's complement word `Fin (N - (L₀+1))` is
+AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge` (\(L₀ + 1 < N\)) excludes
+that case, where the boundary comparison's complement word \(\mathrm{Fin}(N - (L₀+1))\) is
 empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving `N = L₀+1` directly (the single window is the whole ring). -/
+eliminate by proving \(N = L₀+1\) directly (the single window is the whole ring). -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -944,10 +944,10 @@ Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the co
 **Scope restriction (chain longer than interaction range):** The source
 (arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
 periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
-AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge : L₀ + 1 < N` excludes
-that case, where the boundary comparison's complement word `Fin (N - (L₀+1))` is
+AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge` (\(L₀ + 1 < N\)) excludes
+that case, where the boundary comparison's complement word \(\mathrm{Fin}(N - (L₀+1))\) is
 empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving `N = L₀+1` directly (the single window is the whole ring). -/
+eliminate by proving \(N = L₀+1\) directly (the single window is the whole ring). -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -987,10 +987,10 @@ Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the co
 **Scope restriction (chain longer than interaction range):** The source
 (arXiv:2011.12127, Section IV.C, lines 2078--2094) proves uniqueness for every
 periodic chain with \(N \ge L₀+1\), including the minimal \(N = L₀+1\) ring (the
-AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge : L₀ + 1 < N` excludes
-that case, where the boundary comparison's complement word `Fin (N - (L₀+1))` is
+AKLT \(L₀=2\) remark checks the 3-site ring). `hNlarge` (\(L₀ + 1 < N\)) excludes
+that case, where the boundary comparison's complement word \(\mathrm{Fin}(N - (L₀+1))\) is
 empty. Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`;
-eliminate by proving `N = L₀+1` directly (the single window is the whole ring). -/
+eliminate by proving \(N = L₀+1\) directly (the single window is the whole ring). -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) (hNlarge : L₀ + 1 < N) :
@@ -1010,13 +1010,13 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction (chain longer than interaction range):** The source theorem
-(arXiv:2011.12127, `thm:4:unique-gs-L0_plus_1`, lines 2087--2094) proves
+(arXiv:2011.12127, theorem thm:4:unique-gs-L0_plus_1, lines 2087--2094) proves
 uniqueness for every periodic chain with \(N \ge L₀+1\), including the minimal
 \(N = L₀+1\) ring (the AKLT \(L₀=2\) remark checks the 3-site ring).
-`hN : L₀ + 1 < N` excludes that case, where the boundary comparison's complement
-word `Fin (N - (L₀+1))` is empty. Documented in
+`hN` (\(L₀ + 1 < N\)) excludes that case, where the boundary comparison's complement
+word \(\mathrm{Fin}(N - (L₀+1))\) is empty. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; eliminate by proving
-`N = L₀+1` directly (the single window is the whole ring). -/
+\(N = L₀+1\) directly (the single window is the whole ring). -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -848,10 +848,10 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
 /-- Boundary matrices agree once their right-products with every \(A^j\) agree:
 \(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j\Rightarrow
 Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
-**Unfaithful:** Relies on a coordinate comparison deviating from
-arXiv:2011.12127, Section IV.C, lines 2078--2079.
-**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); the \(N=L₀+1\)
-empty-complement case is tracked in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
+whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); same note tracks \(N=L₀+1\). -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -895,10 +895,10 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 /-- Closure-property containment
 \(\mathcal G_{N,L}(A) \subseteq \mathbb C\,V^{(N)}(A)\) for \(L>L₀\) and
 \(L₀+1<N\), following arXiv:2011.12127, Section IV.C, lines 2078--2090.
-**Unfaithful:** Relies on a coordinate comparison deviating from
-arXiv:2011.12127, Section IV.C, lines 2078--2079.
-**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); the \(N=L₀+1\)
-empty-complement case is tracked in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
+whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); same note tracks \(N=L₀+1\). -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -929,10 +929,10 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 
 /-- On a periodic chain, \(\mathcal G_{N,L}(A)=\mathbb C\,V^{(N)}(A)\) for
 \(L>L₀\) and \(L₀+1<N\), by arXiv:2011.12127, Section IV.C, lines 2078--2090.
-**Unfaithful:** Relies on a coordinate comparison deviating from
-arXiv:2011.12127, Section IV.C, lines 2078--2079.
-**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); the \(N=L₀+1\)
-empty-complement case is tracked in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
+whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); same note tracks \(N=L₀+1\). -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -965,10 +965,10 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
 
 /-- Unique ground state for tensors injective after blocking at range \(2L₀\),
 with \(L₀+1<N\).
-**Unfaithful:** Relies on a coordinate comparison deviating from
-arXiv:2011.12127, Section IV.C, lines 2078--2079.
-**Scope restriction (two-site boundary case):** The extra \(L₀+1<N\) excludes only
-\(L₀=1,N=2\) under \(2L₀\le N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
+whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (two-site case):** Same note tracks excluded \(L₀=1,N=2\). -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) (hNlarge : L₀ + 1 < N) :
@@ -983,10 +983,10 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 
 /-- Unique ground state for normal tensors at range \(L₀+1\), with \(L₀+1<N\):
 \(\dim \mathcal G_{N,L₀+1}(A)=1\).
-**Unfaithful:** Relies on a coordinate comparison deviating from
-arXiv:2011.12127, Section IV.C, lines 2078--2079.
-**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); the \(N=L₀+1\)
-empty-complement case is tracked in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
+whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
+**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); same note tracks \(N=L₀+1\). -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -845,20 +845,13 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
   exact closure_property_boundary_right_products_eq_of_chainGroundSpace
     (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ
 
-/-- The two boundary-condition matrix families agree once their right-products
-with every \(A^j\) agree:
-\(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j \Rightarrow
+/-- Boundary matrices agree once their right-products with every \(A^j\) agree:
+\(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j\Rightarrow
 Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (minimal ring):** This boundary comparison is stated only for
-\(L₀+1<N\). The source theorem (arXiv:2011.12127, Section IV.C, lines 2087--2094)
-also covers \(N=L₀+1\), where the complement word in the boundary-closing
-argument has length zero. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the empty-complement
-cyclic-boundary case separately. -/
+**Unfaithful:** Relies on a coordinate comparison deviating from
+arXiv:2011.12127, Section IV.C, lines 2078--2079.
+**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); the \(N=L₀+1\)
+empty-complement case is tracked in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -902,17 +895,10 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 /-- Closure-property containment
 \(\mathcal G_{N,L}(A) \subseteq \mathbb C\,V^{(N)}(A)\) for \(L>L₀\) and
 \(L₀+1<N\), following arXiv:2011.12127, Section IV.C, lines 2078--2090.
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (minimal ring):** The source theorem (arXiv:2011.12127,
-Section IV.C, lines 2087--2094) places no lower bound on the ring length beyond
-\(N \ge L₀+1\). The strict hypothesis \(L₀+1<N\) excludes \(N=L₀+1\), where the
-complement word in the boundary-closing argument has length zero and the two
-boundary-crossing words coincide. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the empty-complement
-cyclic-boundary case separately. -/
+**Unfaithful:** Relies on a coordinate comparison deviating from
+arXiv:2011.12127, Section IV.C, lines 2078--2079.
+**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); the \(N=L₀+1\)
+empty-complement case is tracked in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -943,17 +929,10 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 
 /-- On a periodic chain, \(\mathcal G_{N,L}(A)=\mathbb C\,V^{(N)}(A)\) for
 \(L>L₀\) and \(L₀+1<N\), by arXiv:2011.12127, Section IV.C, lines 2078--2090.
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (minimal ring):** The source theorem (arXiv:2011.12127,
-Section IV.C, lines 2087--2094) places no lower bound on the ring length beyond
-\(N \ge L₀+1\). The strict hypothesis \(L₀+1<N\) excludes \(N=L₀+1\), where the
-complement word in the boundary-closing argument has length zero and the two
-boundary-crossing words coincide. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the empty-complement
-cyclic-boundary case separately. -/
+**Unfaithful:** Relies on a coordinate comparison deviating from
+arXiv:2011.12127, Section IV.C, lines 2078--2079.
+**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); the \(N=L₀+1\)
+empty-complement case is tracked in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -986,17 +965,10 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
 
 /-- Unique ground state for tensors injective after blocking at range \(2L₀\),
 with \(L₀+1<N\).
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (two-site boundary case):** This corollary applies the
-range-reduction theorem at interaction range \(2L₀\). Under the hypothesis
-\(2L₀\le N\), the extra bound \(L₀+1<N\) is automatic for \(1<L₀\); it only
-excludes \(L₀=1\), \(N=2\). Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; eliminate by removing the
-strict bound from the range-reduction theorem or by treating this two-site
-cyclic case separately. -/
+**Unfaithful:** Relies on a coordinate comparison deviating from
+arXiv:2011.12127, Section IV.C, lines 2078--2079.
+**Scope restriction (two-site boundary case):** The extra \(L₀+1<N\) excludes only
+\(L₀=1,N=2\) under \(2L₀\le N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : 2 * L₀ ≤ N) (hNlarge : L₀ + 1 < N) :
@@ -1011,17 +983,10 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 
 /-- Unique ground state for normal tensors at range \(L₀+1\), with \(L₀+1<N\):
 \(\dim \mathcal G_{N,L₀+1}(A)=1\).
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (minimal ring):** The source theorem (arXiv:2011.12127,
-thm:4:unique-gs-L0_plus_1, lines 2087--2094) places no lower bound on the ring
-length beyond \(N \ge L₀+1\). The strict hypothesis \(L₀+1<N\) excludes
-\(N=L₀+1\), where the complement word in the boundary-closing argument has
-length zero and the two boundary-crossing words coincide. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the empty-complement
-cyclic-boundary case separately. -/
+**Unfaithful:** Relies on a coordinate comparison deviating from
+arXiv:2011.12127, Section IV.C, lines 2078--2079.
+**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); the \(N=L₀+1\)
+empty-complement case is tracked in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -280,16 +280,22 @@ coincide and the comparison carries no information. This is a genuine narrowing
 of the source theorem rather than a typo: the conclusion at $N=L_0+1$ is true
 (it is the source's minimal case), but the present proof does not reach it.
 
-Elimination plan: prove the $N=L_0+1$ case directly. There the parent
-Hamiltonian has a single term covering the whole ring, so the periodic ground
-space is the global MPS line with no boundary-crossing comparison; alternatively,
-extend the witness-comparison lemma to the empty complement word. Either route
-removes $L_0+1<N$ from
+Elimination plan: prove the empty-complement case of the boundary-closing
+argument. When $N=L_0+1$, the complement word has length zero and the two
+boundary-crossing words coincide; one must still use the cyclic local constraints
+to identify the periodic ground space with the MPS line. Thus the missing step is
+not a single-window kernel computation, but a separate cyclic-boundary argument
+in the degenerate complement case. Alternatively, extend the witness-comparison
+lemma to include the empty complement word. Either route removes $L_0+1<N$ from
+\path{MPSTensor.wrapped_mirror_witness_agree_of_chainGroundSpace},
 \path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
 \path{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal},
-\path{MPSTensor.parentHamiltonian_unique_gs_injective}, and
-\path{MPSTensor.parentHamiltonian_unique_gs_normal}. The narrowing is recorded
-in those four declarations with a \texttt{Scope restriction} docstring marker.
+\path{MPSTensor.parentHamiltonian_unique_gs_normal}, and, through this
+range-reduction theorem, the range-$2L_0$ corollary
+\path{MPSTensor.parentHamiltonian_unique_gs_injective}. In the latter corollary,
+the bound $L_0+1<N$ is automatic from $2L_0\le N$ for $1<L_0$ and only excludes
+the two-site case $L_0=1$, $N=2$. The narrowing is recorded in these declarations
+with a \texttt{Scope restriction} docstring marker.
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -65,10 +65,13 @@ boundary-closing sentence, and
 
 \section{The formal statement}
 
-The corresponding formal statement keeps the intended hypotheses. In
+The corresponding formal statement keeps the intended hypotheses, with one
+formalization-added range restriction, $L_0+1<N$, recorded as a scope
+restriction in Section~\ref{sec:scope-minimal-ring}. In
 mathematical terms, it assumes that $A$ is normal, that $A$ is injective
 after blocking a positive number $L_0$ of sites, and that the ring has length
-$N\ge 2$ with an interaction range $L$ satisfying $L_0<L\le N$. The desired
+$N\ge 2$ with an interaction range $L$ satisfying $L_0<L\le N$, together with the
+strict bound $L_0+1<N$. The desired
 conclusion is that the periodic-boundary ground space is the line spanned by
 the periodic MPS vector
 $\Omega_N(A)$:
@@ -256,6 +259,38 @@ the two boundary-crossing words
 The direct comparison of these two restrictions, and the left-multiplied
 coordinate comparison obtained after taking first-letter restrictions, are
 consequences of the one-site commutation identity \(XA^k=A^kX\).
+
+\section{Scope restriction: the minimal ring}
+\label{sec:scope-minimal-ring}
+
+The source theorem \path{thm:4:unique-gs-L0_plus_1}
+(\path{Papers/2011.12127/TN-Review-main.tex}:2087--2094) asserts a unique ground
+state for the range-$(L_0+1)$ parent Hamiltonian on a normal MPS, with no lower
+bound separating the ring length $N$ from the interaction range. The minimal
+case $N=L_0+1$, in which the single length-$(L_0+1)$ window already wraps the
+whole ring, is explicitly intended: the source's AKLT remark ($L_0=2$) checks
+uniqueness on the three-site ring by hand, via
+$\mathcal G_{1,2}\cap\mathcal G_{2,3}=\mathcal G_{1,2,3}$.
+
+The formal statements add the strict hypothesis $L_0+1<N$, so they cover only
+$N\ge L_0+2$ and exclude that minimal ring. The restriction is forced by the
+boundary-closing argument: the closure-property comparison ranges over a
+complement word $\mu\colon \mathrm{Fin}\,(N-(L_0+1))\to\mathrm{Fin}\,d$, which is
+the empty function exactly when $N=L_0+1$, so the two boundary-crossing windows
+coincide and the comparison carries no information. This is a genuine narrowing
+of the source theorem rather than a typo: the conclusion at $N=L_0+1$ is true
+(it is the source's minimal case), but the present proof does not reach it.
+
+Elimination plan: prove the $N=L_0+1$ case directly. There the parent
+Hamiltonian has a single term covering the whole ring, so the periodic ground
+space is the global MPS line with no boundary-crossing comparison; alternatively,
+extend the witness-comparison lemma to the empty complement word. Either route
+removes $L_0+1<N$ from
+\path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
+\path{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal},
+\path{MPSTensor.parentHamiltonian_unique_gs_injective}, and
+\path{MPSTensor.parentHamiltonian_unique_gs_normal}. The narrowing is recorded
+in those four declarations with a \texttt{Scope restriction} docstring marker.
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -82,10 +82,10 @@ In the formal statement this is the equality between the periodic-boundary groun
 space and the subspace \(\mathbb C\,\Omega_N(A)\). The hard inclusion into
 \(\mathbb C\,\Omega_N(A)\) is the remaining range-reduction lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:904 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:912 for
 \path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
 and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:939 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:955 for
 \path{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}. The formal hypotheses
 are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, \path{L0 + 1 < N}, and
@@ -264,13 +264,12 @@ consequences of the one-site commutation identity \(XA^k=A^kX\).
 \label{sec:scope-minimal-ring}
 
 The source theorem \path{thm:4:unique-gs-L0_plus_1}
-(\path{Papers/2011.12127/TN-Review-main.tex}:2087--2094) asserts a unique ground
-state for the range-$(L_0+1)$ parent Hamiltonian on a normal MPS, with no lower
-bound separating the ring length $N$ from the interaction range. The minimal
-case $N=L_0+1$, in which the single length-$(L_0+1)$ window already wraps the
-whole ring, is explicitly intended: the source's AKLT remark ($L_0=2$) checks
-uniqueness on the three-site ring by hand, via
-$\mathcal G_{1,2}\cap\mathcal G_{2,3}=\mathcal G_{1,2,3}$.
+(\path{Papers/2011.12127/TN-Review-main.tex}:2087--2090) asserts a unique ground
+state for the range-$(L_0+1)$ parent Hamiltonian on a normal MPS, placing no
+lower bound on the ring length $N$ beyond the $N\ge L_0+1$ needed to define a
+range-$(L_0+1)$ term. The minimal case $N=L_0+1$, in which the single
+length-$(L_0+1)$ window already wraps the whole ring, is therefore covered by the
+source statement.
 
 The formal statements add the strict hypothesis $L_0+1<N$, so they cover only
 $N\ge L_0+2$ and exclude that minimal ring. The restriction is forced by the

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -82,10 +82,10 @@ In the formal statement this is the equality between the periodic-boundary groun
 space and the subspace \(\mathbb C\,\Omega_N(A)\). The hard inclusion into
 \(\mathbb C\,\Omega_N(A)\) is the remaining range-reduction lemma.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:912 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:902 for
 \path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
 and
-\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:955 for
+\path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:936 for
 \path{MPSTensor.chainGroundSpace_eq_mpvSubmodule_normal}. The formal hypotheses
 are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{0 < L0}, \path{2 <= N}, \path{L0 + 1 < N}, and


### PR DESCRIPTION
## Summary

This documentation-only PR records a scope restriction in the normal parent-Hamiltonian uniqueness chain.

The source theorem in arXiv:2011.12127, Section IV.C, lines 2087--2090, states the uniqueness result for the range-$(L_0+1)$ parent Hamiltonian without imposing a strict lower bound on the ring length beyond the implicit condition $N\ge L_0+1$. The formal statements currently require $L_0+1<N$, so they exclude the minimal ring $N=L_0+1$.

The restriction affects the boundary-closing helper and the four downstream range-reduction / uniqueness declarations in `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`:

- `wrapped_mirror_witness_agree_of_chainGroundSpace`
- `chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction`
- `chainGroundSpace_eq_mpvSubmodule_normal`
- `parentHamiltonian_unique_gs_injective`
- `parentHamiltonian_unique_gs_normal`

The excluded case is exactly the empty-complement case in the current boundary-comparison formulation. This is a scope restriction: the narrower formal statements remain mathematically correct, but they do not yet cover the full source range.

## Changes

- Adds `**Scope restriction**` markers to the affected Lean docstrings, keeping the pre-existing `**Unfaithful:**` boundary-comparison markers self-contained.
- Updates `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` to list the strict formal hypothesis, explain the minimal-ring restriction, and record the elimination plan.
- Corrects the paper-gap line pointers after the docstring changes.

No theorem signatures, hypotheses, or proofs are changed.

## Issue References

Refs #190, #460.