### PR TITLE
refactor(Spectral): retire unused mixed-transfer trace formulae

### DIFF
--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -22,7 +22,6 @@ multi-block fundamental theorem.
 * `mixedTransferMap`: definition of `F_{AB}`
 * `mixedTransferMap_self`: `F_{AA} = E_A`
 * `mixedTransferMap_pow_apply`: `F_{AB}^N(X) = ∑_σ w_A(σ) X w_B(σ)†`
-* `trace_mixedTransferMap_pow_identity`: trace formula for MPV cross-correlations
 
 ## Rectangular mixed transfer maps for different bond dimensions
 
@@ -140,21 +139,6 @@ theorem transferMap_pow_apply' (A : MPSTensor d D) (N : ℕ) :
           evalWord A (List.ofFn σ) * X * (evalWord A (List.ofFn σ))ᴴ := by
   rw [← mixedTransferMap_self]
   exact mixedTransferMap_pow_apply A A N
-
-/-- **Trace of iterated mixed transfer encodes MPV cross-correlations.** -/
-theorem trace_mixedTransferMap_pow_identity (A B : MPSTensor d D) (N : ℕ) :
-    Matrix.trace (((mixedTransferMap A B) ^ N) (1 : Matrix (Fin D) (Fin D) ℂ)) =
-      ∑ σ : Fin N → Fin d,
-        Matrix.trace (evalWord A (List.ofFn σ) * (evalWord B (List.ofFn σ))ᴴ) := by
-  rw [mixedTransferMap_pow_apply]; simp
-
-/-- The cross-correlation trace expands as a double sum over matrix indices. -/
-theorem mpv_inner_product_via_trace (A B : MPSTensor d D) (N : ℕ)
-    (σ : Fin N → Fin d) :
-    Matrix.trace (evalWord A (List.ofFn σ) * (evalWord B (List.ofFn σ))ᴴ) =
-      ∑ j : Fin D, ∑ k : Fin D,
-        (evalWord A (List.ofFn σ) j k) * starRingEnd ℂ (evalWord B (List.ofFn σ) j k) := by
-  simp [Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.conjTranspose_apply]
 
 end IteratedTransfer
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -88,32 +88,6 @@ we assume the trace-preserving normalization
         \{0,\ldots,d{-}1\} \times \{0,\ldots,d{-}1\}^N$.
 \end{proof}
 
-\begin{lemma}[Matrix trace of iterated mixed transfer at the identity]\label{thm:mixed_trace_identity}
-    \lean{MPSTensor.trace_mixedTransferMap_pow_identity}
-    \leanok
-    \uses{def:mixed_transfer, def:eval_word}
-    For $N \ge 0$,
-    \[
-        \tr(F_{AB}^N(\Id))
-        =
-        \sum_{\sigma}
-        \tr(A^\sigma (B^\sigma)^\dagger).
-    \]
-    This is the matrix trace of $F_{AB}^N$ evaluated at the
-    identity matrix.
-    It should \emph{not} be confused with the operator trace
-    $\Tr(F_{AB}^N)$; its relation to the MPV overlap is proved in the
-    next section.
-\end{lemma}
-
-\begin{proof}\leanok\uses{thm:mixed_pow}
-    Apply the matrix trace to each summand in
-    Lemma~\ref{thm:mixed_pow} with $X = \Id$:
-    $\tr(F_{AB}^N(\Id))
-        = \sum_\sigma \tr(A^\sigma \cdot \Id \cdot (B^\sigma)^\dagger)
-        = \sum_\sigma \tr(A^\sigma (B^\sigma)^\dagger)$.
-\end{proof}
-
 \section{MPV overlap as transfer trace}
 
 Recall from Definition~\ref{def:mpv_overlap} that
@@ -188,38 +162,6 @@ mixed transfer power.
     the matrix-unit indices exactly as in
     Lemma~\ref{thm:overlap_trace}.
 \end{proof}
-
-\begin{lemma}[Word trace as entrywise inner product]\label{lem:word_trace_entrywise}
-    \lean{MPSTensor.mpv_inner_product_via_trace}
-    \leanok
-    \uses{def:eval_word}
-    For a word $\sigma \in \{0,\ldots,d{-}1\}^N$,
-    \[
-        \tr(A^\sigma (B^\sigma)^\dagger)
-        =
-        \sum_{j,k = 0}^{D-1}
-        (A^\sigma)_{jk} \overline{(B^\sigma)_{jk}}.
-    \]
-\end{lemma}
-
-\begin{proof}\leanok
-    Expand the matrix trace and the $(j,j)$-entry of
-    $A^\sigma (B^\sigma)^\dagger$.
-\end{proof}
-
-\begin{remark}[Two traces for the mixed transfer map]%
-    \label{rem:mixed_transfer_two_traces}
-    \leanok
-    \uses{thm:mixed_trace_identity, lem:word_trace_entrywise, thm:overlap_trace}
-    There are two different trace operations here. Evaluating $F_{AB}^N$ at the
-    identity and then taking the matrix trace gives
-    $\sum_\sigma \tr(A^\sigma(B^\sigma)^\dagger)$; by
-    Lemma~\ref{lem:word_trace_entrywise}, each summand is the Hilbert--Schmidt
-    inner product of the two word matrices. Taking the operator trace of
-    $F_{AB}^N$ instead gives the periodic-boundary overlap $O_{AB}(N)$, by
-    Lemma~\ref{thm:overlap_trace}. The spectral arguments below use this
-    operator-trace identity.
-\end{remark}
 
 \section{Frobenius norm estimates}
 


### PR DESCRIPTION
## Summary
- remove the unused matrix-trace formula for `F_{AB}^N(1)`
- remove the unused entrywise expansion of `tr(A^sigma (B^sigma)^*)`
- remove the corresponding blueprint passages, which were not part of the source-facing periodic-overlap route

## Rationale
The source-facing overlap statement remains `trace_mixedTransferMap_pow_eq_mpvOverlap` in `TNLean/Spectral/MPVOverlapTrace.lean`. This PR only retires two auxiliary matrix-trace statements with no Lean consumers, together with the blueprint exposition that existed solely to distinguish them from the operator-trace identity used below.

Addresses #2295.

## Checks
- `rg -n "trace_mixedTransferMap_pow_identity|mpv_inner_product_via_trace|thm:mixed_trace_identity|lem:word_trace_entrywise|rem:mixed_transfer_two_traces" TNLean blueprint/src docs`
- `lake env lean TNLean/Spectral/MixedTransfer.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake build`
- `lake exe checkdecls blueprint/lean_decls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dead-code removal only; no changes to the overlap or spectral-gap proof chain consumers rely on.
> 
> **Overview**
> Removes two **unused** Lean lemmas from `MixedTransfer.lean`—`trace_mixedTransferMap_pow_identity` (matrix trace of `F_{AB}^N` at the identity) and `mpv_inner_product_via_trace` (entrywise expansion of word-matrix traces)—and drops their module doc bullet for the first.
> 
> The **periodic MPV overlap route is unchanged**: `trace_mixedTransferMap_pow_eq_mpvOverlap` in `MPVOverlapTrace.lean` remains the formal link between operator trace and `mpvOverlap`.
> 
> Matching blueprint material in `ch07_spectral.tex` is deleted: the mixed-trace-at-identity lemma, the word-trace entrywise lemma, and the remark distinguishing matrix trace at `Id` from operator trace `Tr(F_{AB}^N)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20114f5b6805c5e10b9b2cbf1f5186abafb6be19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->