### PR TITLE
refactor(PEPS): retire superseded closed-torus staircasePair_insert_eq

### DIFF
--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -664,9 +664,9 @@ already contracted the \(V\setminus P'\) boundary.  Inverting the closed state o
 \(P'\) therefore reduces to inverting \(V\setminus S\)
 (`deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective`), which
 is *not* blocked-tensor injective at the corollary's minimal size
-\(2L+1\le \mathrm{width}\), \(2K+1\le \mathrm{height}\): at the row \(y+K-1\)
+\(2L+1\le W\), \(2K+1\le H\): at the row \(y+K-1\)
 the two end windows together occupy all columns \([x-L+1,x+L]\), leaving a
-complement band of width \(\mathrm{width}-2L\), which is \(1\) at the minimal
+complement band of width \(W-2L\), which is \(1\) at the minimal
 width, so no injective \(L\times K\) window translate fits through that row.
 Injectivity of the added completed corner \(P'\setminus S\) plays no role in this
 collapse.

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -21,13 +21,14 @@ deformed state on `S` with the *extended* insert `extendInsert R S C`, where the
 extended insert pairs `C` with the genuine network block of the added vertices
 `S \ R`.  The extension reuses the three-block factorization
 `ThreeBlockGeometry.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical`
-of `TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean`: with the geometry
-`red = R`, `blue = S \ R`, `complement = univ \ S`, the host `univ \ red = univ \ R`
-is the complement block of the deformed state on `R`, and the factorization splits its
-weight into the blue-coupling combination of the `univ \ S` complement weights.  The
+of `TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean`: with red block \(R\),
+blue block \(S\setminus R\), and complement \(V\setminus S\), the host
+\(V\setminus R\) is the complement block of the deformed state on \(R\), and the
+factorization splits its weight into the blue-coupling combination of the
+\(V\setminus S\) complement weights.  The
 blue-coupling coefficient `threeBlockBlueCoeff`, contracted against `C`, is exactly the
 extended insert.  The factorization carries an interior-bond multiplicity factor on the
-`univ \ S` block, a nonzero scalar at positive bond dimensions, which cancels.
+\(V\setminus S\) block, a nonzero scalar at positive bond dimensions, which cancels.
 
 The deformed state is read as a function of the *full* physical configuration through
 `assembleRegionσ`, so the identity is a region-independent equality of functions on
@@ -44,9 +45,9 @@ chaining `horizontalStaircase_patch_extend_eq` extends the two end windows' stat
 staircase patch and chains them at the closed-torus level (Step 2).  The faithful Step 3
 stripping is the open-boundary shared-corner cancellation `staircasePair_insert_eq_open` of
 `TNLean/PEPS/TorusWindowChain6.lean`, which cancels only the injective completed corner and
-never inverts the non-injective torus complement `univ \ S`; the collapse lemma
+never inverts the torus complement \(V\setminus S\); the collapse lemma
 `deformedRegionStateAssembled_extendInsert_eq` below records why no closed-torus inversion on
-a superset of the end pair can avoid `univ \ S`.  See
+a superset of the end pair can avoid \(V\setminus S\).  See
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
 
 ## References
@@ -70,14 +71,15 @@ variable {A : Tensor G d}
 
 /-! ### The nested-region three-block geometry
 
-For `R ⊆ S` the three blocks `red = R`, `blue = S \ R`, `complement = univ \ S`
-partition the vertex set, with host `univ \ red = univ \ R`.  This is the geometry
-whose three-block factorization splits the deformed-state complement weight on
-`univ \ R` into the `univ \ S` complement weights, the blue coupling carrying the
-added vertices `S \ R`. -/
+For `R ⊆ S` the three blocks \(R\), \(S\setminus R\), and \(V\setminus S\)
+partition the vertex set, with host \(V\setminus R\).  This is the geometry whose
+three-block factorization splits the deformed-state complement weight on
+\(V\setminus R\) into the \(V\setminus S\) complement weights, the blue coupling
+carrying the added vertices \(S\setminus R\). -/
 
-/-- The nested-region three-block geometry for `R ⊆ S`: `red = R`, `blue = S \ R`,
-`complement = univ \ S`.  The host `univ \ red` is `univ \ R`, the complement block
+/-- The nested-region three-block geometry for `R ⊆ S`: red block \(R\), blue block
+\(S\setminus R\), and complement \(V\setminus S\).  The host is \(V\setminus R\),
+the complement block
 of the deformed state on `R`.
 
 Source: arXiv:1804.04964, Section 3, Lemma `injective_union`, lines 1324--1400 of
@@ -655,21 +657,25 @@ The faithful Step 3 stripping is *not* run on the closed-torus patch equality
 `horizontalStaircase_patch_extend_eq` above.  Enlarging the compared region from the end
 pair `S` to any superset `P'` (the patch, or the patch with the corner completed) leaves the
 assembled state unchanged: by `deformedRegionStateAssembled_extendInsert_eq` the assembled
-state on `P'` with `extendInsert (hS : S ⊆ P') C` is the assembled state on `S` with `C`,
-since `univ \ S = (P' \ S) ⊔ (univ \ P')` and the closed state has already contracted the
-`univ \ P'` boundary.  Inverting the closed state on `P'` therefore reduces to inverting
-`univ \ S` (`deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective`), which
-is *not* blocked-tensor injective at the corollary's minimal size `2 * L + 1 ≤ width`,
-`2 * K + 1 ≤ height`: at the row `y + K - 1` the two end windows together occupy all columns
-`[x - L + 1, x + L]`, leaving a complement band of width `width - 2 * L`, which is `1` at the
-minimal width, so no injective `L × K` window translate fits through that row.  Injectivity
-of the added completed corner `P' \ S` plays no role in this collapse.
+state on \(P'\) with the extension of \(C\) from \(S\) to \(P'\) is the assembled
+state on \(S\) with \(C\), since
+\(V\setminus S = (P'\setminus S)\sqcup(V\setminus P')\) and the closed state has
+already contracted the \(V\setminus P'\) boundary.  Inverting the closed state on
+\(P'\) therefore reduces to inverting \(V\setminus S\)
+(`deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective`), which
+is *not* blocked-tensor injective at the corollary's minimal size
+\(2L+1\le \mathrm{width}\), \(2K+1\le \mathrm{height}\): at the row \(y+K-1\)
+the two end windows together occupy all columns \([x-L+1,x+L]\), leaving a
+complement band of width \(\mathrm{width}-2L\), which is \(1\) at the minimal
+width, so no injective \(L\times K\) window translate fits through that row.
+Injectivity of the added completed corner \(P'\setminus S\) plays no role in this
+collapse.
 
 The faithful Step 3 is therefore the open-boundary shared-corner cancellation
 `staircasePair_insert_eq_open` of `TNLean/PEPS/TorusWindowChain6.lean`: it re-derives the
 patch chaining at the open-boundary (tensor-on-region) level and cancels only the *shared*
 injective completed corner `horizontalStaircaseCompletedCorner` (an `L × K` window, injective
-by hypothesis) common to both sides, never asserting injectivity of `univ \ S`.  See
+by hypothesis) common to both sides, never asserting injectivity of \(V\setminus S\).  See
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3. -/
 
 end Torus

--- a/TNLean/PEPS/TorusWindowChain2.lean
+++ b/TNLean/PEPS/TorusWindowChain2.lean
@@ -41,11 +41,12 @@ deformed state of its corner-extended insert; `horizontalConsecutiveWindow_exten
 passes the agreement of two consecutive windows to the consecutive-window comparison
 engine, giving the open-boundary equality on the union (Step 1's display).  The patch
 chaining `horizontalStaircase_patch_extend_eq` extends the two end windows' states to the
-staircase patch and chains them (Step 2), and the staircase-pair stripping
-`staircasePair_insert_eq` inverts the end-pair complement, leaving the open-boundary
-equality on the staircase end pair (Step 3).  The stripping takes the end-pair complement
-injectivity as a hypothesis, the content the note's corner-completion supplies; its
-construction from the window hypotheses is the residual recorded in
+staircase patch and chains them at the closed-torus level (Step 2).  The faithful Step 3
+stripping is the open-boundary shared-corner cancellation `staircasePair_insert_eq_open` of
+`TNLean/PEPS/TorusWindowChain6.lean`, which cancels only the injective completed corner and
+never inverts the non-injective torus complement `univ \ S`; the collapse lemma
+`deformedRegionStateAssembled_extendInsert_eq` below records why no closed-torus inversion on
+a superset of the end pair can avoid `univ \ S`.  See
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
 
 ## References
@@ -648,79 +649,28 @@ theorem horizontalStaircaseRightWindow_subset_endPair (s : TorusVertex width hei
     horizontalStaircaseRightWindow s L K ⊆ horizontalStaircaseEndPair s L K :=
   Finset.subset_union_right
 
--- The end-pair region and the blocked-tensor injectivity predicate are whnf-expensive over
--- the discrete torus (the boundary-configuration type unfolds the cyclic-rectangle edge
--- arithmetic); marking them irreducible keeps the complement-inversion engine from
--- unfolding the injectivity type during unification.
-attribute [local irreducible] horizontalStaircaseEndPair RegionBlockedTensorInjective
+/-! ### Step 3 is the open-boundary shared-corner cancellation
 
-/-- **The staircase-pair stripping (Step 3).** If the two end windows carry deformed
-inserts whose assembled states agree, and the torus complement of the staircase end pair
-is blocked-tensor injective, then the corner-extended inserts of the two end windows on
-the end pair are equal: the note's Step 3 open-boundary equality
-`C₀ ⊔ T_{W_{L+K-1}} = T_{W₀} ⊔ C_{L+K-1}` on `S = W₀ ⊔ W_{L+K-1}`.  Extending each end
-window's state to the end pair carries the genuine block of the opposite window across the
-single crossing bond; the agreement of the window states makes the two end-pair states
-agree; the complement-inversion engine then strips the closed-torus equality to the
-open-boundary equality of the end-pair inserts.
-
-The end-pair complement injectivity is taken here as an explicit hypothesis.  This is the
-wrong engine for the source's Step 3: at the corollary's minimal size `2 * L + 1 ≤ width`,
-`2 * K + 1 ≤ height` the torus complement `univ \ S` is *not* blocked-tensor injective under
-the one-orientation window hypotheses, so `hcompl` is not derivable.  At the row `y + K - 1`
-the two end windows together occupy all columns `[x - L + 1, x + L]`, leaving a complement
-band of width `width - 2 * L`, which is `1` at the minimal width and below `L` whenever
-`width < 3 * L`; no injective `L × K` window translate fits through that row, so `univ \ S`
-is not a union of injective window translates.  The faithful Step 3 instead cancels the
-*shared* injective completed corner `horizontalStaircaseCompletedCorner` (an `L × K` window,
-injective by hypothesis) common to both sides of the patch equality, never asserting
-injectivity of `univ \ S`.
-
-The shared-corner cancellation cannot be run on the *closed-torus* patch equality
-`horizontalStaircase_patch_extend_eq`.  Enlarging the compared region from the end pair `S`
-to any superset `P'` (the patch, or the patch with the corner completed) leaves the
+The faithful Step 3 stripping is *not* run on the closed-torus patch equality
+`horizontalStaircase_patch_extend_eq` above.  Enlarging the compared region from the end
+pair `S` to any superset `P'` (the patch, or the patch with the corner completed) leaves the
 assembled state unchanged: by `deformedRegionStateAssembled_extendInsert_eq` the assembled
 state on `P'` with `extendInsert (hS : S ⊆ P') C` is the assembled state on `S` with `C`,
 since `univ \ S = (P' \ S) ⊔ (univ \ P')` and the closed state has already contracted the
 `univ \ P'` boundary.  Inverting the closed state on `P'` therefore reduces to inverting
-`univ \ S` (`deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective`),
-which fails at the minimal size for every `P'`; injectivity of the added completed corner
-`P' \ S` plays no role.  The shared-corner cancellation is an open-boundary operation: it
-needs an equality of inserts on `P'` as tensors, which the closed-torus patch equality does
-not provide.  The faithful Step 3 therefore requires re-deriving the patch chaining of
-Step 2 at the open-boundary (tensor-on-region) level — chaining the consecutive-window
-open-boundary equalities `horizontalConsecutiveWindow_extend_eq` across the patch — so that
-the completed corner can be cancelled locally.  This is the residual recorded in
-`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3.
+`univ \ S` (`deformedRegionStateAssembled_extendInsert_eq_of_subComplementInjective`), which
+is *not* blocked-tensor injective at the corollary's minimal size `2 * L + 1 ≤ width`,
+`2 * K + 1 ≤ height`: at the row `y + K - 1` the two end windows together occupy all columns
+`[x - L + 1, x + L]`, leaving a complement band of width `width - 2 * L`, which is `1` at the
+minimal width, so no injective `L × K` window translate fits through that row.  Injectivity
+of the added completed corner `P' \ S` plays no role in this collapse.
 
-Source: arXiv:1804.04964, proof sketch at lines 2320--2445 of
-`Papers/1804.04964/paper_normal.tex` (add two-two tensors in the corner and invert);
+The faithful Step 3 is therefore the open-boundary shared-corner cancellation
+`staircasePair_insert_eq_open` of `TNLean/PEPS/TorusWindowChain6.lean`: it re-derives the
+patch chaining at the open-boundary (tensor-on-region) level and cancels only the *shared*
+injective completed corner `horizontalStaircaseCompletedCorner` (an `L × K` window, injective
+by hypothesis) common to both sides, never asserting injectivity of `univ \ S`.  See
 `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3. -/
-theorem staircasePair_insert_eq (s : TorusVertex width height)
-    (hpos : ∀ e : Edge (torusGraph width height), 0 < B.bondDim e)
-    (hcompl : RegionBlockedTensorInjective (G := torusGraph width height) B
-      (Finset.univ \ horizontalStaircaseEndPair s L K))
-    (C₀ : RegionInsert (G := torusGraph width height) (d := d) B
-      (horizontalStaircaseRightWindow s L K))
-    (Cend : RegionInsert (G := torusGraph width height) (d := d) B
-      (horizontalStaircaseLeftWindow s L K))
-    (hstate : deformedRegionStateAssembled (G := torusGraph width height) B
-        (horizontalStaircaseRightWindow s L K) C₀ =
-      deformedRegionStateAssembled (G := torusGraph width height) B
-        (horizontalStaircaseLeftWindow s L K) Cend) :
-    extendInsert (G := torusGraph width height)
-        (horizontalStaircaseRightWindow_subset_endPair s) C₀ =
-      extendInsert (G := torusGraph width height)
-        (horizontalStaircaseLeftWindow_subset_endPair s) Cend := by
-  -- Invert the end-pair complement: it suffices the two end-pair states agree.
-  refine deformedRegionStateAssembled_insert_eq_of_complementInjective
-    (G := torusGraph width height) B (horizontalStaircaseEndPair s L K) hcompl _ _ ?_
-  funext cfg
-  rw [← deformedRegionState_extend
-      (horizontalStaircaseRightWindow_subset_endPair s) hpos C₀,
-    ← deformedRegionState_extend
-      (horizontalStaircaseLeftWindow_subset_endPair s) hpos Cend,
-    hstate]
 
 end Torus
 

--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -835,51 +835,11 @@ site-independent tensor and produces the global phase of
     where the middle equality is the hypothesis.
 \end{proof}
 
-\begin{theorem}[End-pair stripping under complement injectivity]
-    \label{thm:peps_staircase_pair_insert_eq_complement_injective}
-    \lean{TNLean.PEPS.staircasePair_insert_eq}
-    \leanok
-    \uses{def:peps_horizontal_staircase_patch,
-        thm:peps_corner_extension_state_preserves}
-    Suppose $1<W$, $1<H$, all bond dimensions are positive, and the torus
-    complement $V\setminus S$ of the staircase end pair is blocked-tensor
-    injective.  If the two end-window inserts have equal deformed states, then
-    their extensions to $S$ are equal:
-    \[
-        \operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)
-        =
-        \operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}}).
-    \]
-\end{theorem}
-% This is a complement-injectivity variant of the stripping step, not the
-% source minimal-size argument.
-\begin{proof}
-    \leanok
-    The state-preservation theorem moves the two end-window states to the end
-    pair:
-    \[
-        \Psi_{A,S,\operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)}
-        =
-        \Psi_{A,W_{\mathrm{right}},C_0}
-        =
-        \Psi_{A,W_{\mathrm{left}},C_{\mathrm{end}}}
-        =
-        \Psi_{A,S,\operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}})}.
-    \]
-    Complement injectivity then gives
-    \[
-        \begin{gathered}
-        V\setminus S\text{ is blocked-tensor injective},\\
-        \Psi_{A,S,\operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)}
-        =
-        \Psi_{A,S,\operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}})}
-        \end{gathered}
-        \quad\Longrightarrow\quad
-        \operatorname{Ext}_{W_{\mathrm{right}}\subseteq S}(C_0)
-        =
-        \operatorname{Ext}_{W_{\mathrm{left}}\subseteq S}(C_{\mathrm{end}}).
-    \]
-\end{proof}
+% The end-pair stripping under full complement injectivity has been retired: at the
+% corollary's minimal size $V\setminus S$ is not blocked-tensor injective, so its hypothesis
+% is not derivable.  The faithful Step~3 is the open-boundary shared-corner cancellation
+% \ref{thm:peps_staircase_pair_insert_eq_open}, which inverts only the injective completed
+% corner $Q$ and never $V\setminus S$.
 
 \begin{lemma}[Two-block merge collapse]
     \label{lem:peps_two_block_merge_collapse}

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -462,18 +462,17 @@ $K-1$, so $\mathrm{univ} \setminus P$ has the same sub-$L$ band there.
 The faithful step is therefore the shared-block cancellation above, which
 needs only injectivity of the completed rectangle $Q$ (an $L \times K$
 window, injective by hypothesis) and never asserts injectivity of
-$\mathrm{univ} \setminus S$. The Lean stripping
-\leanid{staircasePair_insert_eq} currently discharges Step~3 with the
-full-complement engine
-\leanid{deformedRegionStateAssembled_insert_eq_of_complementInjective}
-and so carries
-\leanid{RegionBlockedTensorInjective}~$B\;(\mathrm{univ} \setminus
+$\mathrm{univ} \setminus S$. The Lean stripping is the open-boundary
+shared-corner cancellation \leanid{staircasePair_insert_eq_open}: it cancels
+the shared injective completed rectangle $Q$ from the patch equality and never
+inverts $\mathrm{univ} \setminus S$. An earlier closed-torus stripping
+discharged Step~3 with the full-complement engine
+\leanid{deformedRegionStateAssembled_insert_eq_of_complementInjective} and so
+carried \leanid{RegionBlockedTensorInjective}~$B\;(\mathrm{univ} \setminus
 \text{\leanid{horizontalStaircaseEndPair}}\;s\,L\,K)$ as an explicit
-hypothesis. That hypothesis is not derivable at the minimal size, by the
-argument above; the eliminating step is to replace the full-complement
-engine by a shared-injective-block cancellation engine for $Q$, which
-inverts the common completed-corner block rather than the whole
-complement.
+hypothesis not derivable at the minimal size; it has been removed in favour of
+the shared-injective-block cancellation engine for $Q$, which inverts the
+common completed-corner block rather than the whole complement.
 
 \subsection{Step 4: the single-crossing extraction}
 
@@ -814,16 +813,17 @@ the consecutive-window engine, leaving an open-boundary equality of inserts
 on each consecutive-window union. The patch chaining
 \path{horizontalStaircase_patch_extend_eq} extends the two end windows'
 states to the patch and chains them at the \emph{closed-torus} level, giving
-an equality of the two patch assembled states; and the stripping
-\path{staircasePair_insert_eq} inverts the end-pair complement, leaving the
-open-boundary equality on the end pair $S$ --- under an explicit hypothesis
-that is not derivable at the minimal size.
+an equality of the two patch assembled states. The faithful Step~3 stripping
+\path{staircasePair_insert_eq_open} instead chains the patch at the
+open-boundary level and cancels the shared injective completed corner $Q$,
+leaving the open-boundary equality on the end pair $S$ with no
+$\mathrm{univ} \setminus S$ hypothesis (the open-boundary route below).
 
-One residual remains, and the route to it is the open-boundary chaining, not
-a complement assembly. The stripping \path{staircasePair_insert_eq} takes the
-blocked-tensor injectivity of $\mathrm{univ} \setminus S$ (the torus
-complement of the staircase end pair) as an explicit hypothesis. As Step~3
-records, that hypothesis is \emph{not} derivable at the corollary's minimal
+The route to that stripping is the open-boundary chaining, not a complement
+assembly. A closed-torus stripping would take the blocked-tensor injectivity
+of $\mathrm{univ} \setminus S$ (the torus complement of the staircase end
+pair) as an explicit hypothesis. As Step~3 records, that hypothesis is
+\emph{not} derivable at the corollary's minimal
 size: $\mathrm{univ} \setminus S$ is not a union of injective window
 translates, because the end pair occupies all columns of one row and the
 complement band there has width below $L$. Completing the corner does not


### PR DESCRIPTION
### Motivation

- The closed-torus `staircasePair_insert_eq` lemma (`TNLean/PEPS/TorusWindowChain2.lean`, line 599)
  carried `hcompl : RegionBlockedTensorInjective B (Finset.univ \ horizontalStaircaseEndPair s L K)`,
  which is not derivable at the corollary's minimal torus size `2L+1 × 2K+1`: at the critical row
  the two end windows together occupy all columns, leaving a complement band too narrow for an
  injective `L × K` window (see `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`, Step 3).
- The paper-faithful Step 3 (arXiv:1804.04964, lines 2320–2445) cancels the shared injective
  completed-corner block `Q` and is already formalized as `staircasePair_insert_eq_open` in
  `TNLean/PEPS/TorusWindowChain6.lean`. The closed-torus version has no callers and is dead code.
- Continues paper alignment for the 2D overlapping-window argument; see #2749 and tracking #2738.

### Description

- **`TNLean/PEPS/TorusWindowChain2.lean`**: removes `staircasePair_insert_eq` and its dedicated
  `[local irreducible]` attributes (73 deletions); adds a module comment recording the closed-torus
  collapse obstruction and pointing to `staircasePair_insert_eq_open` as the paper-faithful engine.
- **`blueprint/src/chapter/ch24_peps_ft_torus.tex`**: drops the blueprint entry
  `thm:peps_staircase_pair_insert_eq_complement_injective` ("End-pair stripping under complement
  injectivity") and inserts a cross-reference to the faithful
  `thm:peps_staircase_pair_insert_eq_open` entry.
- **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`**: updates the Step 3 paper-gap note to
  describe the open-boundary shared-corner engine as the current formalization path and the
  full-complement stripping as removed.
- No `sorry` introduced; no remaining Lean callers of the deleted theorem.

### Testing

- Lean CI (`lean_action_ci.yml`) validates the build after deletion; `rg -n "staircasePair_insert_eq" TNLean/` confirms no remaining callers.
- Blueprint Lint CI validates the updated `ch24_peps_ft_torus.tex`.

---
Addresses #2749

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and dead-code removal only; the paper-faithful Step 3 remains in `TorusWindowChain6.lean` with no callers of the deleted theorem.
> 
> **Overview**
> Removes the superseded **closed-torus** Step 3 lemma `staircasePair_insert_eq`, which required `RegionBlockedTensorInjective` on the torus complement `V \ S` of the staircase end pair—a hypothesis that does not hold at the corollary’s minimal torus size `2L+1 × 2K+1`.
> 
> Documentation is aligned with the **open-boundary** path: Step 3 is described as `staircasePair_insert_eq_open` in `TorusWindowChain6.lean`, which cancels only the shared injective completed corner and never inverts `V \ S`. The blueprint drops `thm:peps_staircase_pair_insert_eq_complement_injective` in favor of a comment pointing at `thm:peps_staircase_pair_insert_eq_open`; the paper-gap note is updated the same way.
> 
> `TorusWindowChain2.lean` keeps the collapse lemmas and related machinery; module comments are tightened (notation, Step 3 routing). No new `sorry`s; grep shows no remaining Lean references to the deleted theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 872747ce86b2d1889eaaf498b62ea96d2e89587c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->