### PR TITLE
doc(parent): use boundary matrix identity terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
@@ -11,9 +11,9 @@ import TNLean.MPS.Core.BlockingInfrastructure
 The boundary-closing argument of
 [Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127, Section IV.C,
 lines 2078--2079] reduces, after blocking \(L_0\) sites into one, to the
-single-site windowed matrix equation already proved for the blocked tensor
-`blockTensor A L₀`.  This file supplies the bookkeeping that turns that blocked
-equation back into a statement about ordinary length-\(L_0\) and
+single-site closing-boundary matrix identity already proved for the blocked
+tensor `blockTensor A L₀`.  This file supplies the bookkeeping that turns that
+blocked identity back into a statement about ordinary length-\(L_0\) and
 length-\(L_0 K\) words of `A`.
 
 Starting from the blocked matrix equation
@@ -24,9 +24,9 @@ Starting from the blocked matrix equation
 \]
 where \(b\) is a single block letter and \(c_b\) is an iterated block index of the
 complement, the result produces the block matrix equation in the shape consumed
-by the boundary-matrix commutation lemma (Boundary matrix commutation from a
-block-window equation), with the head ranging over every length-L₀ word and the
-complement over every length-L₀K word.
+by the boundary-matrix commutation lemma from the coordinate comparison, with
+the head ranging over every length-L₀ word and the complement over every
+length-L₀K word.
 
 The proof sends each length-\(L_0\) word \(s\) to its canonical block letter in
 \(\mathrm{Fin}(d^{L_0})\) and regroups each length-\(L_0 K\) complement word \(c\)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -77,7 +77,7 @@ theorem closure_property_mirror_padded_products_of_left_word_products
       (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
   exact sub_eq_zero.mp hZ
 
-/-- Block-window matrix equation obtained from the closing-boundary local
+/-- Boundary matrix identity obtained from the closing-boundary local
 constraints.
 
 Let \(A\) be \(L_0\)-block-injective, let \(L_0<M\), let
@@ -89,7 +89,7 @@ length-\(L_0\) word \(\alpha\),
 \[
   X A^\alpha A^\nu = A^\alpha Y_\nu .
 \]
-This is the block-window equation needed by the block-injective
+This is the coordinate comparison needed by the block-injective
 boundary-matrix commutation lemma.
 
 **Open gap:** The proof is the missing coordinate form of the boundary-closing
@@ -322,18 +322,18 @@ for all outside letters \(\eta\) and physical letters \(j\).
 
 **Unfaithful:** This proof relies on
 `closure_property_boundary_block_window_equation_of_groundSpaceMap`, whose proof
-is the open block-window equation in the boundary-closing argument of
+is the open boundary matrix identity in the boundary-closing argument of
 arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
-block-injective commutation lemma turns that block-window equation into the
+block-injective commutation lemma turns that coordinate comparison into the
 one-site commutation identity for the boundary matrix \(X\). The verified
 boundary-restriction equality lemma
 `boundary_restrictions_eq_of_commutes_and_one_sided` and the block-injective
 commutation lemma
 `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` reduce the whole
-boundary-closing step to this block-window equation, which is the transitive
+boundary-closing step to this boundary matrix identity, which is the transitive
 dependency for the coordinate consequences below. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
-block-window equation from the closing-boundary local constraints; tracked in
+boundary matrix identity from the closing-boundary local constraints; tracked in
 issue 2405. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -446,11 +446,11 @@ boundary-closing comparison is
 
 **Unfaithful:** This proof currently relies on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`, whose proof
-depends on the unproved block-window equation at the closing boundary. This
+depends on the unproved boundary matrix identity at the closing boundary. This
 deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
 the coordinate form of the boundary-closing inverting-and-growing-back argument.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the block-window equation from the closing-boundary local
+Elimination: prove the boundary matrix identity from the closing-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
 in issue 2405.
 
@@ -511,12 +511,12 @@ remaining boundary-closing comparison is
 
 **Unfaithful:** This proof uses
 `closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap`; that theorem
-transitively depends on the unproved block-window equation at the closing
+transitively depends on the unproved boundary matrix identity at the closing
 boundary in `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
 deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
 the coordinate form of the boundary-closing inverting-and-growing-back argument.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the block-window equation from the closing-boundary local
+Elimination: prove the boundary matrix identity from the closing-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
 in issue 2405. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
@@ -573,12 +573,12 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
 
 **Unfaithful:** This proof currently relies on
 `closure_property_mirror_left_word_products_of_groundSpaceMap`, which
-transitively depends on the unproved block-window equation at the closing
+transitively depends on the unproved boundary matrix identity at the closing
 boundary in `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
 deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
 the coordinate form of the boundary-closing inverting-and-growing-back argument.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the block-window equation from the closing-boundary local
+Elimination: prove the boundary matrix identity from the closing-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
 in issue 2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap


### PR DESCRIPTION
## Summary

This prose-only PR replaces the local phrase "block-window equation" in the normal parent-Hamiltonian boundary-closing comments with the source-facing language of a boundary matrix identity or coordinate comparison.

The mathematical statement and declaration names are unchanged. The goal is to make the reader-facing text match the role of the remaining closure-property comparison in arXiv:2011.12127, Section IV.C, lines 2078--2079.

## Changes

- In `BoundaryClosingStripping.lean`, describe the remaining obligation as a boundary matrix identity / coordinate comparison at the closing boundary.
- In `BoundaryBlockMatEq.lean`, describe the blocked statement as a closing-boundary matrix identity and avoid the old local phrase in module prose.

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping -q --log-level=info`

The Lean build reports the pre-existing `closure_property_boundary_block_window_equation_of_groundSpaceMap` `sorry` warning.

Refs #2405, #190, #460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and docstring edits only; no logic, APIs, or proof changes.
> 
> **Overview**
> **Documentation-only** update to parent-Hamiltonian boundary-closing module comments in `BoundaryBlockMatEq.lean` and `BoundaryClosingStripping.lean`.
> 
> Reader-facing text now describes the remaining closure-property obligation as a **closing-boundary matrix identity** or **coordinate comparison** (aligned with arXiv:2011.12127 Section IV.C), instead of the local phrase **block-window equation**. **Unfaithful** / open-gap notes and elimination steps use the same wording.
> 
> **No change** to theorem statements, proof bodies, or names such as `closure_property_boundary_block_window_equation_of_groundSpaceMap`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 990210d3beec1dd2057e60b1ea08a6ae20808945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->