### PR TITLE
doc(parent): distinguish NNCPH and parent commuting terminology

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -20,10 +20,10 @@ state, obtained from the intersection property of the local ground spaces. For a
 normal tensor the corresponding conclusion follows, under the stated
 closed-boundary comparison and length hypotheses, after inverting a long-word
 commutation back to the injectivity length and closing the periodic boundary.
-When the local terms commute the construction gives the nearest-neighbor
-commuting parent Hamiltonians in the pure-state theorem relating
-renormalization fixed points, zero correlation length, and
-nearest-neighbor commuting parent-Hamiltonian ground states in
+When the length-two local terms commute, the construction records the
+zero-energy part of the condition that $V^{(N)}(A)$ is a ground state of a
+nearest-neighbor commuting parent Hamiltonian in the pure-state theorem relating
+renormalization fixed points, zero correlation length, and such ground states in
 \cite{Cirac2016MPDO_arXiv}. The spectral-gap section records the martingale
 row-sum criterion and keeps the overlapping-window principal-angle estimate as
 an explicit hypothesis. For a tensor in block-injective canonical form

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -7,6 +7,12 @@ parent terms commute, $h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2)$; the implication from
 commuting terms back to a renormalization fixed point uses a left-canonical
 normalization.
 
+The nearest-neighbor commuting parent Hamiltonian condition in
+\cite[Definition~3.9 and Theorem~3.10]{Cirac2016MPDO_arXiv} is distinct from
+the parent commuting Hamiltonian condition of Appendix~D.2, which is stated for
+local projectors $Q_{AX}$ and $Q_{XB}$. The latter appears in the decorrelation
+subsection below.
+
 \begin{definition}[Commuting parent Hamiltonian]\label{def:is_commuting_parent_ham}
     \lean{MPSTensor.IsCommutingParentHam}
     \leanok

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -83,6 +83,10 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
 - `cpgsv21_block_diagonal_parent_ground_space.tex` records the degenerate
   parent-Hamiltonian block-diagonal boundary-condition theorem behind the
   periodic block decomposition and the BNT ground-space span.
+- `cpsv16_nncph_ground_state_scope.tex` records that the current
+  nearest-neighbor commuting parent Hamiltonian ground-state predicate keeps
+  the zero-energy ground-vector clause of CPSV16 Theorem 3.10(iii), not the
+  full source ground-space spanning condition.
 - `cpsv16_parent_commuting_hamiltonian_scope.tex` records that the current
   parent commuting Hamiltonian predicate keeps only the idempotent-product
   consequence of CPSV16 Definition D.2, while the source definition also has


### PR DESCRIPTION
## Summary

This documentation-only PR sharpens the terminology in the parent-Hamiltonian chapter around two different source phrases in arXiv:1606.00608:

- Theorem 3.10 / Definition 3.9: nearest-neighbor commuting parent Hamiltonian, used in the RFP = ZCL = NNCPH ground-state theorem.
- Appendix D.2: parent commuting Hamiltonian, stated for local projectors $Q_{AX}$ and $Q_{XB}$ in the decorrelation argument.

The edit keeps these phrases separate in the chapter opening and in the commuting-parent-Hamiltonian section, and adds the missing `cpsv16_nncph_ground_state_scope.tex` bullet to the paper-gap README.

No Lean declarations, theorem statuses, or blueprint tags are changed.

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

`leanblueprint checkdecls` could not run in this fresh worktree because no generated `blueprint/lean_decls` file is present in the checkout.

Refs #2633, #190.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and README index updates only; no Lean, theorem tags, or runtime behavior changes.
> 
> **Overview**
> Documentation-only edits clarify two different phrases from arXiv:1606.00608 in the parent-Hamiltonian blueprint.
> 
> The chapter introduction now says that commuting length-two terms record the **zero-energy** ground-vector clause for a nearest-neighbor commuting parent Hamiltonian (NNCPH) in the RFP / zero correlation length / NNCPH pure-state theorem, rather than implying the full commuting-Hamiltonian construction.
> 
> The commuting-parent-Hamiltonian section adds an explicit note that **NNCPH** (Definition 3.9 / Theorem 3.10) is not the same as the **parent commuting Hamiltonian** in Appendix D.2 (`Q_{AX}`, `Q_{XB}`), which is tied to the decorrelation material below.
> 
> `docs/paper-gaps/README.md` gains a bullet for `cpsv16_nncph_ground_state_scope.tex`, documenting that the formal NNCPH ground-state predicate matches Theorem 3.10(iii)’s zero-energy part, not the full source ground-space spanning condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc2e981f8c9617a4c885a249b4c298ec44cb10a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->