### PR TITLE
doc(parent): align boundary witness terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingWitness.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingWitness.lean
@@ -12,8 +12,8 @@ import TNLean.MPS.ParentHamiltonian.WrappingWindow
 Coordinate identities saying that outside configurations with the same labels on
 the sites outside a cyclic window determine the same boundary-crossing witness.
 These are the witness-independence facts needed to choose a representative
-outside configuration for the open block-window matrix comparison in the
-boundary-closing step.
+outside configuration for the closing-boundary coordinate comparison in the
+step of closing the periodic boundary.
 -/
 
 open scoped Matrix BigOperators
@@ -135,7 +135,7 @@ theorem wrappedMiddleBackground_first_products_eq_of_complement_eq
 If an outside configuration has the same word on the sites outside the window
 as the local coordinate configuration \(\tau^+_\eta(\mu)\), then the two
 matrices representing the last-site restriction are equal. This is the
-last-site witness-independence step for the open block-window matrix
+last-site witness-independence step for the closing-boundary coordinate
 comparison. -/
 theorem wrappedMiddleBackground_witness_eq_of_complement_eq
     {A : MPSTensor d D} {L₀ M : ℕ}
@@ -239,8 +239,8 @@ theorem mirrorMiddleBackground_first_products_eq_of_complement_eq
 If an outside configuration has the same word on the sites outside the window
 as the local coordinate configuration \(\tau^-_\eta(\mu)\), then the two
 matrices representing the opposite boundary-crossing restriction are equal. This
-is the opposite-window witness-independence step for the open block-window
-matrix comparison. -/
+is the opposite-window witness-independence step for the closing-boundary
+coordinate comparison. -/
 theorem mirrorMiddleBackground_witness_eq_of_complement_eq
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
@@ -15,10 +15,10 @@ commutes with every one-site matrix `A j`. This is the block-injective analogue 
 length-\(L_0\) block span and the complement cancellation handled by the block
 annihilation lemma `eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul`.
 
-This is the "L2" step of the boundary-closing decomposition for the normal
-range-reduction argument of arXiv:2011.12127, Section IV.C; it isolates the whole
-remaining obligation onto the block matrix equation hypothesis `hMatEq` (the "L1"
-keystone, not yet proved). See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
+For the normal range-reduction argument of arXiv:2011.12127, Section IV.C, this
+reduces the one-site commutation relation to the displayed boundary matrix
+identity, which is not yet proved. See
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 -/
 
 open scoped Matrix BigOperators
@@ -27,11 +27,11 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **Block-injective boundary-matrix commutation (L2).**
+/-- **Block-injective boundary-matrix commutation.**
 
 Let `A` be block injective with injectivity length \(L_0 > 0\). Suppose a boundary
 matrix `X` and a family `Y` of matrices indexed by length-`K` complement words
-satisfy the block matrix equation
+satisfy the boundary matrix identity
 \[
   X \cdot A^{\sigma_{\mathrm{tail}}} \cdot A^{\sigma_{\mathrm{comp}}}
   = A^{\sigma_{\mathrm{tail}}} \cdot Y_{\sigma_{\mathrm{comp}}}
@@ -42,7 +42,7 @@ for every length-\(L_0\) head word `σ_tail` and every length-`K` complement wor
 The length-\(L_0\) head span exhausts the full matrix algebra, promoting the equation
 to all matrices \(M_1\), and the block annihilation lemma cancels the length-`K`
 complement.
-This isolates the whole boundary-closing gap onto `hMatEq`. -/
+Thus the displayed identity implies the commutation relation \(XA^j=A^jX\). -/
 theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
     {A : MPSTensor d D} {L₀ K : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {X : Matrix (Fin D) (Fin D) ℂ}
@@ -94,10 +94,10 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq
       (le_trans (Nat.le_succ K) (Nat.le_mul_of_pos_right (K + 1) hL₀)) hB
   exact sub_eq_zero.mp hzero
 
-/-- **Boundary-restriction equality from commutation and the one-sided products (L3).**
+/-- **Boundary-restriction equality from commutation and the one-sided products.**
 
-Suppose \(X\) commutes with every one-site matrix \(A^j\), as in the
-block-window commutation lemma, and the two boundary-crossing supports give the
+Suppose \(X\) commutes with every one-site matrix \(A^j\), as obtained from the
+boundary matrix identity, and the two boundary-crossing supports give the
 one-sided product equations
 \[
   W_\eta \, A^j = A^\mu \, A^j \, X,
@@ -129,7 +129,8 @@ equation then yields
   =
   V_\eta A^j .
 \]
-This is the "L3" step of the boundary-closing decomposition; see
+This is the comparison of the two boundary-crossing restrictions after the
+one-site commutation relation has been obtained; see
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem boundary_restrictions_eq_of_commutes_and_one_sided
     {A : MPSTensor d D} {L₀ m : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)


### PR DESCRIPTION
Summary:
- replace the remaining reader-facing "open block-window" wording in the boundary witness file by closing-boundary coordinate comparison language
- describe the commutation reduction through the displayed boundary matrix identity rather than local L1/L2/L3 labels
- keep theorem statements and declaration names unchanged

Checks:
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- git diff --check
- lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingWitness TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock -q --log-level=info

Refs #2405, #190, #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and docstring edits only; no Lean proofs, hypotheses, or API surface changed.
> 
> **Overview**
> **Documentation-only** updates to reader-facing prose in `BoundaryClosingWitness.lean` and `BoundaryMatrixBlock.lean`; theorem statements and declaration names are unchanged.
> 
> In the boundary witness file, wording shifts from **“open block-window matrix comparison”** to **closing-boundary coordinate comparison** when describing periodic boundary closing and the last-site / opposite-window witness-independence steps.
> 
> In `BoundaryMatrixBlock`, module and theorem docs no longer use **L1/L2/L3** step labels. They instead describe the normal range-reduction chain as reducing one-site commutation to the **displayed boundary matrix identity** (still unproved), and frame the second theorem as comparing boundary-crossing restrictions **after** commutation is obtained from that identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc13238db11f36fd9077b0ae4105f015be84e642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->