### PR TITLE
refactor(Spectral): retire irreducible-TP power decay

### DIFF
--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -241,43 +241,6 @@ theorem spectralRadius_mixedTransfer_lt_one_of_irreducible_TP
   exact hAB <| modulus_one_eigenvalue_implies_gauge_of_irreducible_TP
     A B hA_irr hB_irr hA_left hB_left hEq.ge
 
--- The CLM power-decay argument uses the same finite-dimensional endomorphism instances.
-set_option synthInstance.maxHeartbeats 200000 in
--- The same continuous-endomorphism instance search reappears in the power-decay argument.
-/--
-**Power decay** for the mixed transfer operator of distinct irreducible left-canonical
-blocks of the same bond dimension.
--/
-theorem mixedTransfer_pow_tendsto_zero_of_irreducible_TP
-    (A B : MPSTensor d D)
-    (hA_irr : IsIrreducibleTensor (d := d) (D := D) A)
-    (hB_irr : IsIrreducibleTensor (d := d) (D := D) B)
-    (hA_left : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-  (hB_left : ∑ i : Fin d, (B i)ᴴ * B i = 1)
-  (hAB : ¬ GaugePhaseEquiv A B)
-  (X : Matrix (Fin D) (Fin D) ℂ) :
-  Filter.Tendsto (fun n => ((mixedTransferMap A B) ^ n) X)
-    Filter.atTop (nhds 0) := by
-  let V := Matrix (Fin D) (Fin D) ℂ
-  let Φ : (V →ₗ[ℂ] V) ≃ₐ[ℂ] (V →L[ℂ] V) := Module.End.toContinuousLinearMap V
-  let F' : V →L[ℂ] V := Φ (mixedTransferMap A B)
-  have h_clm : Filter.Tendsto (fun n => F' ^ n) Filter.atTop (nhds 0) :=
-    @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
-      (instGCNormedRingMatrixCLM D D) (instGCCompleteSpaceMatrixCLM D D)
-      (instGCNormedAlgebraMatrixCLM D D) F' <| by
-      simpa only [mixedTransferSpectralRadius, F', Φ] using
-        spectralRadius_mixedTransfer_lt_one_of_irreducible_TP
-          A B hA_irr hB_irr hA_left hB_left hAB
-  have h_eval := (ContinuousLinearMap.apply ℂ V X).continuous.tendsto (0 : V →L[ℂ] V)
-  rw [map_zero] at h_eval
-  suffices hpow : ∀ n, ((mixedTransferMap A B) ^ n) X = (F' ^ n) X by
-    simp_rw [hpow]
-    exact h_eval.comp h_clm
-  intro n
-  have h_pow : F' ^ n = Φ ((mixedTransferMap A B) ^ n) := (map_pow Φ _ n).symm
-  simp only [h_pow]
-  rfl
-
 end SameDimension
 
 section SameDimensionOverlap

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -654,22 +654,6 @@ the Perron--Frobenius fixed point.
     (Lemma~\ref{thm:spectral_radius_le_one}).
 \end{proof}
 
-\begin{theorem}[Transfer power decay (irreducible-TP)]%
-    \label{thm:transfer_pow_zero_irr_tp}
-    \lean{MPSTensor.mixedTransfer_pow_tendsto_zero_of_irreducible_TP}
-    \leanok
-    \uses{def:mixed_transfer, def:gauge_phase_equiv,
-        def:irreducible_tensor}
-    Under the hypotheses of
-    Theorem~\ref{thm:transfer_operator_gap_irr_tp},
-    $F_{AB}^n(X) \to 0$ for every $X \in \MN{D}$.
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:transfer_operator_gap_irr_tp}
-    By the Gelfand formula,
-    $\rho_{\spec}(F_{AB}) < 1$ implies $\|F_{AB}^n\|_{\mathrm{op}} \to 0$.
-\end{proof}
-
 \begin{theorem}[Overlap decay (irreducible-TP)]%
     \label{thm:overlap_decay_irr_tp}
     \lean{MPSTensor.mpvOverlap_tendsto_zero_of_irreducible_TP}
@@ -687,24 +671,6 @@ the Perron--Frobenius fixed point.
     with the overlap--trace identity
     (Lemma~\ref{thm:overlap_trace}).
 \end{proof}
-
-\begin{remark}[Power decay and overlap decay]%
-    \label{rem:irreducible_tp_power_decay_trace}
-    \leanok
-    \uses{thm:transfer_pow_zero_irr_tp, lem:trace_expansion, thm:overlap_trace}
-    The pointwise power-decay theorem gives the same trace-level decay by a
-    finite matrix-unit calculation. For matrix units $E_{pq}$,
-    Theorem~\ref{thm:transfer_pow_zero_irr_tp} gives
-    $F_{AB}^N(E_{pq}) \to 0$. Since the sum is finite,
-    \[
-        \Tr(F_{AB}^N)
-        =
-        \sum_{p,q}(F_{AB}^N(E_{pq}))_{pq}
-        \longrightarrow 0.
-    \]
-    Lemma~\ref{thm:overlap_trace} identifies the trace with the overlap, hence
-    $O_{AB}(N)=\Tr(F_{AB}^N)\to 0$.
-\end{remark}
 
 \begin{theorem}[Rectangular transfer-operator gap (irreducible-TP)]%
     \label{thm:transfer_operator_gap_rect_irr_tp}


### PR DESCRIPTION
## Motivation

Issue #2295 tracks proven-but-unused results whose blueprint entries have no mathematical consumer. The irreducible-TP pointwise power-decay theorem is a local auxiliary consequence of the strict mixed-transfer spectral-radius gap; it has no Lean consumer, and the source-facing overlap-decay theorem already uses the spectral-radius gap together with the overlap-trace identity directly.

The Wolf-source check does not identify this pointwise MPS mixed-transfer iterate statement as a standalone Wolf theorem. The retained neighboring results are the strict mixed-transfer gap and overlap decay.

## Description

- Remove `MPSTensor.mixedTransfer_pow_tendsto_zero_of_irreducible_TP`.
- Remove the matching blueprint theorem `thm:transfer_pow_zero_irr_tp`.
- Remove the blueprint remark whose only purpose was to route trace decay through that retired theorem.

## Testing

- `rg -n "mixedTransfer_pow_tendsto_zero_of_irreducible_TP|transfer_pow_zero_irr_tp|irreducible_tp_power_decay_trace" TNLean blueprint docs --glob "!blueprint/web/**" --glob "!blueprint/print/**"`
- `lake env lean TNLean/Spectral/TransferOperatorGapNT.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `lake build`

Addresses part of #2295.