### PR TITLE
doc(parent): use periodic-boundary closure prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -37,7 +37,8 @@ difference is zero.
 **Scope restriction (conditional reduction):** This is only a stripping
 reduction. It assumes the left-multiplied coordinate comparison through the
 hypothesis `hLeft`, and does not derive that comparison from the
-boundary-closing sentence in arXiv:2011.12127, Section IV.C, lines 2078--2079.
+source sentence on closing the boundaries in arXiv:2011.12127, Section IV.C,
+lines 2078--2079.
 The remaining reconstruction is documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_mirror_padded_products_of_left_word_products
@@ -92,10 +93,10 @@ length-\(L_0\) word \(\alpha\),
 This is the coordinate comparison needed by the block-injective
 boundary-matrix commutation lemma.
 
-**Open gap:** The proof is the missing coordinate form of the boundary-closing
-inverting-and-growing-back argument in arXiv:2011.12127, Section IV.C,
-lines 2078--2079. The statement is the source-faithful coordinate obligation;
-the body remains open. Documented in
+**Open gap:** The proof is the missing coordinate form of the
+inverting-and-growing-back argument when closing the periodic boundary in
+arXiv:2011.12127, Section IV.C, lines 2078--2079. The statement is the
+source-faithful coordinate obligation; the body remains open. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 displayed matrix equation from the closing-boundary local constraints; tracked
 in issue 2405. -/
@@ -194,9 +195,9 @@ left-multiplied coordinate comparison
 
 **Scope restriction (conditional reduction):** This theorem combines the
 preceding reductions under the displayed left-multiplied comparison. It does not
-derive that comparison from the boundary-closing sentence in arXiv:2011.12127,
-Section IV.C, lines 2078--2079. The source does not display this formula; see
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+derive that comparison from the source sentence on closing the boundaries in
+arXiv:2011.12127, Section IV.C, lines 2078--2079. The source does not display
+this formula; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -304,8 +305,8 @@ restriction of \(\psi\) lies in \(G_{L_0+1}(A)\). For every outside letter
 \(\eta\), the two outside configurations \(\tau^+_\eta(\mu)\) and
 \(\tau^-_\eta(\mu)\) are local coordinate notation for the cyclic support
 crossing the last site and the opposite boundary-crossing support, with the same
-word \(\mu\) on the sites outside the window. The boundary-closing step is the
-equality
+word \(\mu\) on the sites outside the window. The closure-property comparison
+at the periodic boundary is the equality
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
   =
@@ -322,16 +323,17 @@ for all outside letters \(\eta\) and physical letters \(j\).
 
 **Unfaithful:** This proof relies on
 `closure_property_boundary_block_window_equation_of_groundSpaceMap`, whose proof
-is the open boundary matrix identity in the boundary-closing argument of
-arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
+is the open boundary matrix identity in the argument for closing the periodic
+boundary in arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
 block-injective commutation lemma turns that coordinate comparison into the
 one-site commutation identity for the boundary matrix \(X\). The verified
 boundary-restriction equality lemma
 `boundary_restrictions_eq_of_commutes_and_one_sided` and the block-injective
 commutation lemma
 `boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` reduce the whole
-boundary-closing step to this boundary matrix identity, which is the transitive
-dependency for the coordinate consequences below. Documented in
+closure-property step at the periodic boundary to this boundary matrix identity,
+which is the transitive dependency for the coordinate consequences below.
+Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 boundary matrix identity from the closing-boundary local constraints; tracked in
 issue 2405. -/
@@ -382,7 +384,7 @@ theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     μ hComm hWrap hMirror
 
 /-- Left-multiplied comparison of the two cyclic restriction coordinates from
-equality of the two boundary-closing restrictions.
+equality of the two restrictions at the periodic boundary.
 
 If the two cyclic restrictions agree, then their first-letter restrictions give
 \[
@@ -393,8 +395,8 @@ If the two cyclic restrictions agree, then their first-letter restrictions give
 Multiplying this equality on the left by \(A^\alpha\) and on the right by
 \(A^\sigma\) gives the displayed coordinate comparison.
 
-**Scope restriction (boundary-closing restriction equality):** This lemma
-assumes the equality of the two boundary-closing restrictions rather than
+**Scope restriction (periodic-boundary restriction equality):** This lemma
+assumes the equality of the two restrictions at the periodic boundary rather than
 deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions
@@ -437,7 +439,7 @@ lemma closure_property_wrapped_mirror_left_word_products_of_boundary_restriction
 
 For \(\psi=\Gamma_{M+1}(X)\), after fixing a boundary letter \(\eta\), a
 physical letter \(j\), and length-\(L_0\) words \(\alpha,\sigma\), the
-boundary-closing comparison is
+periodic-boundary coordinate comparison is
 \[
   A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
   =
@@ -448,13 +450,14 @@ boundary-closing comparison is
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`, whose proof
 depends on the unproved boundary matrix identity at the closing boundary. This
 deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
-the coordinate form of the boundary-closing inverting-and-growing-back argument.
+the coordinate form of the inverting-and-growing-back argument when closing the
+periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the boundary matrix identity from the closing-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
 in issue 2405.
 
-The comparison is derived from the boundary-closing restriction equality
+The comparison is derived from the periodic-boundary restriction equality
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
   =
@@ -497,12 +500,12 @@ theorem closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap
   exact closure_property_wrapped_mirror_left_word_products_of_boundary_restrictions
     (A := A) hInj hL₀ (le_of_lt hM) YAt hYAt μ hRestrict
 
-/-- Left-multiplied boundary-closing comparison for an open-chain
+/-- Left-multiplied periodic-boundary comparison for an open-chain
 representation.
 
 For \(\psi=\Gamma_{M+1}(X)\), after fixing a boundary letter \(\eta\), a
 physical letter \(j\), and length-\(L_0\) words \(\alpha,\sigma\), the
-remaining boundary-closing comparison is
+remaining periodic-boundary coordinate comparison is
 \[
   A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
   =
@@ -514,7 +517,8 @@ remaining boundary-closing comparison is
 transitively depends on the unproved boundary matrix identity at the closing
 boundary in `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
 deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
-the coordinate form of the boundary-closing inverting-and-growing-back argument.
+the coordinate form of the inverting-and-growing-back argument when closing the
+periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the boundary matrix identity from the closing-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
@@ -576,7 +580,8 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
 transitively depends on the unproved boundary matrix identity at the closing
 boundary in `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
 deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
-the coordinate form of the boundary-closing inverting-and-growing-back argument.
+the coordinate form of the inverting-and-growing-back argument when closing the
+periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the boundary matrix identity from the closing-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -852,8 +852,7 @@ Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); same note tracks
-the excluded equality case. -/
+**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); excludes equality. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -900,8 +899,7 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); same note tracks
-the excluded equality case. -/
+**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); excludes equality. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -935,8 +933,7 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); same note tracks
-the excluded equality case. -/
+**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); excludes equality. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -990,8 +987,7 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); same note tracks
-the excluded equality case. -/
+**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); excludes equality. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -20,7 +20,7 @@ ground space is spanned by the MPS vector
 
 For injective \(A\) and lengths \(2 \le N\), \(1<L\le N\), the periodic-chain
 ground space is one-dimensional, spanned by the MPS vector, via open-chain
-build-up and boundary closing:
+build-up and the step of closing the periodic boundary:
 
 1. **Open chain**: By iterated application of the intersection property,
    any state satisfying all local ground-space conditions has the form
@@ -34,10 +34,11 @@ build-up and boundary closing:
 
 ## Main results
 
-The periodic-chain ground space `chainGroundSpace A L N` is the intersection of the
-cyclic-window constraints, which the MPS vector satisfies. Reducing those to a boundary
-matrix \(X\) with \(\psi=\Gamma_N(X)\), the boundary-closing comparison forces \(X\) scalar:
-the ground space is \(\mathbb C\,V^{(N)}(A)\), and at window length \(L_0+1\) for normal tensors.
+The periodic-chain ground space `chainGroundSpace A L N` is the intersection of
+the cyclic-window constraints, which the MPS vector satisfies. Reducing those to
+a boundary matrix \(X\) with \(\psi=\Gamma_N(X)\), the closure-property
+comparison at the periodic boundary forces \(X\) scalar: the ground space is
+\(\mathbb C\,V^{(N)}(A)\), also at window length \(L_0+1\) for normal tensors.
 
 ## References
 
@@ -49,8 +50,8 @@ the ground space is \(\mathbb C\,V^{(N)}(A)\), and at window length \(L_0+1\) fo
 
 ## Remaining mathematical ingredients
 
-The remaining coordinate form of the boundary-closing ingredient is the passage
-from
+The remaining coordinate form of the closure-property ingredient at the periodic
+boundary is the passage from
 \[
   A^\mu A^j X=Y^+_{\tau^+_\eta(\mu)}A^j,\qquad
   X A^j A^\mu=A^jY^-_{\tau^-_\eta(\mu)}
@@ -327,7 +328,7 @@ block-injective tensors.
 This combines cyclic window monotonicity (peeling longer cyclic windows down to
 \(L₀ + 1\)), the non-wrapping cyclic/contiguous identification, and the open-chain
 closure-property argument for block-injective tensors. It stops at open-chain
-membership; the boundary-closing scalarity step remains separate. -/
+membership; the scalarity step at the periodic boundary remains separate. -/
 theorem chainGroundSpace_le_groundSpace_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -439,7 +440,7 @@ After the cyclic-to-open-chain step writes a periodic-chain vector as
 \(\psi=\Gamma_N(X)\), the two reduced cyclic windows used when closing the
 boundary expose the boundary matrix \(X\) on opposite sides of the same
 length \(N-(L₀+1)\) complement word. This theorem gives the local algebraic
-output needed for the remaining boundary-closing comparison
+output needed for the remaining periodic-boundary coordinate comparison
 (arXiv:2011.12127, Section IV.C, lines 2078--2079). -/
 theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
@@ -569,7 +570,7 @@ theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_two_sided_middle_c
   exact groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_positive_word_commutes
     (A := A) (L₀ := L₀) (m := m + 2) (N := N) hInj hL₀ (by omega) hComm
 
-/-- Reindexed boundary-closing comparison puts the boundary vector in
+/-- Reindexed periodic-boundary comparison puts the boundary vector in
 \(\mathbb C\,V^{(N)}(A)\).
 
 The inputs are \(A^\mu A^j X=Y^+_{\tau^+_\eta(\mu)}A^j\),
@@ -851,7 +852,8 @@ Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); same note tracks \(N=L₀+1\). -/
+**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); same note tracks
+the excluded equality case. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -898,7 +900,8 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); same note tracks \(N=L₀+1\). -/
+**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); same note tracks
+the excluded equality case. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -932,7 +935,8 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); same note tracks \(N=L₀+1\). -/
+**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); same note tracks
+the excluded equality case. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -986,7 +990,8 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (minimal ring):** Assumes \(L₀+1<N\); same note tracks \(N=L₀+1\). -/
+**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); same note tracks
+the excluded equality case. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -852,7 +852,7 @@ Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); excludes equality. -/
+**Scope restriction:** \(L₀+1<N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -899,7 +899,7 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); excludes equality. -/
+**Scope restriction:** \(L₀+1<N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -933,7 +933,7 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); excludes equality. -/
+**Scope restriction:** \(L₀+1<N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -987,7 +987,7 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction (case \(N=L₀+1\)):** Assumes \(L₀+1<N\); excludes equality. -/
+**Scope restriction:** \(L₀+1<N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :


### PR DESCRIPTION
Summary:
- replace reader-facing "boundary-closing" noun phrases by closure-property language at the periodic boundary
- restate the open coordinate obligation as the inverting-and-growing-back argument when closing the periodic boundary
- replace "minimal ring" scope markers with the explicit case N = L0 + 1 while keeping UniqueGroundState.lean within the 1000-line guard

Checks:
- python3 scripts/check_oversized_lean_files.py --root .
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- git diff --check
- lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info
  - passes with the pre-existing sorry warning at TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean:103

Refs #2405, #190, #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and docstring edits only; no Lean definitions, proofs, or API changes.
> 
> **Overview**
> **Documentation-only** updates in `BoundaryClosingStripping.lean` and `UniqueGroundState.lean`: reader-facing docstrings and module comments are reworded so **“boundary-closing”** noun phrases become **closure-property** language at the **periodic boundary**, aligned with arXiv:2011.12127 Section IV.C.
> 
> Open-gap and **Unfaithful** notes now describe the missing step as the coordinate form of the **inverting-and-growing-back** argument **when closing the periodic boundary**, and scope labels shift from **“boundary-closing restriction equality”** to **periodic-boundary restriction / coordinate comparison**. On several theorems in `UniqueGroundState.lean`, **“Scope restriction (minimal ring)”** is shortened to **“Scope restriction:”** with the same \(L₀+1<N\) pointer to `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` (no change to hypotheses or proofs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7040d0439770486382e60d1a3e9b5cf6a503ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->