### PR TITLE
doc(parent): align block-diagonal boundary prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -15,9 +15,8 @@ one-step identity from arXiv:quant-ph/0608197
   \qquad S_M=\bigvee_jG_M(A_j),
 \]
 as used in Theorem 12 of arXiv:quant-ph/0608197. The separate periodic
-step is the boundary-closing comparison with block-diagonal boundary
-conditions, as in the closing-boundary sentence of arXiv:2011.12127,
-Section IV.C.
+step is the comparison obtained when closing the boundaries with block-diagonal
+boundary conditions, as in arXiv:2011.12127, Section IV.C.
 -/
 
 open scoped Matrix BigOperators
@@ -104,9 +103,10 @@ conditions.
 
 **Unfaithful:** This proof relies on
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+transitively uses the boundary-condition comparison at boundary-crossing windows
+rather than deriving it from arXiv:2011.12127, Section IV.C, lines 2126--2128.
+Documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`;
+prove the comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -185,9 +185,10 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
 
 **Unfaithful:** This proof relies on the finite-\(C_1\) inclusion and
 internal-direct-sum conclusions above, which transitively use the
-boundary-closing coordinate comparison rather than deriving it from
-arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+boundary-condition comparison at boundary-crossing windows rather than deriving
+it from arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -234,9 +235,11 @@ block components produced here.
 
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -311,9 +314,11 @@ vectors lie in \(\mathcal G_{N,L}(A_j)\).
 
 **Unfaithful:** This proof relies on
 `exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -376,7 +381,7 @@ range,
   \subseteq
   \bigvee_j G_N(A_j),
 \]
-and the right-hand local block sum is internal. The boundary-closing comparison
+and the right-hand local block sum is internal. The periodic-boundary comparison
 from arXiv:quant-ph/0608197, with block-diagonal boundary conditions,
 replaces \(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\). -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital
@@ -426,9 +431,11 @@ to close the boundaries with block-diagonal boundary conditions.
 
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -669,7 +676,7 @@ The boundary matrix remains outside the window, so the restricted vector is
 \]
 If the cyclic window crosses the chosen cut, the boundary matrix lies between
 the two pieces of the window after trace rotation.  The block-diagonal
-boundary-closing input is the matrix identity
+periodic-boundary input is the matrix identity
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
 \]
@@ -706,7 +713,7 @@ Thus it remains only to prove the same membership for the windows satisfying
 \]
 
 In the notation of arXiv:quant-ph/0608197, Theorem 12, these are the
-boundary-closing windows controlled by the comparison
+boundary-crossing windows controlled by the comparison
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
 \]
@@ -779,8 +786,8 @@ lies in \(\mathcal G_{N,L}(A_j)\). Then
 \[
   \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j).
 \]
-The source boundary-closing step is to prove the displayed periodic constraint
-for each block from the block-diagonal boundary conditions. In
+The source periodic-boundary comparison is to prove the displayed periodic
+constraint for each block from the block-diagonal boundary conditions. In
 Theorem 12 of arXiv:quant-ph/0608197, this is the comparison
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
@@ -806,7 +813,7 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_gr
   rw [hψX]
   exact groundSpaceMap_toTensorFromBlocks_blockDiagonal_mem_iSup_chainGroundSpace μ A X hX
 
-/-- Block-diagonal boundary closing gives the periodic block-chain equality in
+/-- Block-diagonal boundary representation gives the periodic block-chain equality in
 the finite injectivity range.
 
 Let
@@ -829,7 +836,7 @@ belongs to \(\mathcal G_{N,L}(A_j)\). Then
 \]
 and the sum \(\bigvee_jG_N(A_j)\) is internal.
 
-The source boundary-closing step is to obtain the displayed block-diagonal
+The source periodic-boundary step is to obtain the displayed block-diagonal
 boundary representation and the periodic constraints for each block from the
 inverting-and-re-growing argument in Perez-Garcia, Verstraete, Wolf, and Cirac
 (arXiv:quant-ph/0608197) and Cirac, Perez-Garcia, Schuch, and Verstraete
@@ -837,9 +844,11 @@ inverting-and-re-growing argument in Perez-Garcia, Verstraete, Wolf, and Cirac
 
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -899,9 +908,11 @@ and the sum \(\bigvee_jG_N(A_j)\) is internal.
 
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -1,12 +1,13 @@
-\section{Block-diagonal boundary closing}\label{sec:block_diagonal_boundary_closing}
+\section{Block-diagonal boundary conditions for periodic ground spaces}
+\label{sec:block_diagonal_boundary_closing}
 
 For a block-diagonal tensor $B=\bigoplus_{j=1}^g\mu_jA_j$ with $\mu_j\ne0$, this
 section gives conditional reductions toward identifying the periodic chain ground
 space $\mathcal G_{N,L}(B)$ with the linear span $\bigvee_j\mathcal G_{N,L}(A_j)$
 of the single-block periodic ground spaces
-(\cite[Theorem~IV.16]{Cirac2021Matrix}). The lemmas below supply the
-boundary-closing inputs: block-diagonal boundary conditions, local
-boundary-crossing coordinate identities, and single-block periodic-boundary
+(\cite[Theorem~IV.16]{Cirac2021Matrix}). The lemmas below supply the inputs for
+closing the periodic boundary with block-diagonal boundary conditions: local
+boundary-crossing coordinate identities and single-block periodic-boundary
 membership.
 
 \begin{lemma}[Normalized BNT blocks give the large-length block intersection]
@@ -524,7 +525,7 @@ in both cases.
     Hence the restricted vector lies in $G_L(A_j)$.
     % Crossing-window note, not part of this non-wrapping lemma: after trace
     % rotation, $\mu_j^N X_j$ lies between the two pieces of the interval. The
-    % missing block-diagonal boundary-closing comparison is
+    % missing block-diagonal periodic-boundary comparison is
     % $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$ from
     % \cite[Theorem~12]{PerezGarcia2007Matrix}.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -34,7 +34,7 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
     Lemma~\ref{lem:isup_chain_ground_space_block_le_assembled}. The second
     inclusion and internal directness are
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}.
-    % The remaining arXiv:quant-ph/0608197 boundary-closing step with
+    % The remaining arXiv:quant-ph/0608197 periodic-boundary comparison with
     % block-diagonal boundary
     % conditions replaces
     % $\bigvee_jG_N(A_j)$ by $\sum_j\mathcal G_{N,L}(A_j)$.
@@ -132,7 +132,7 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
     assumption, so the finite sum lies in the linear span of these spaces.
 \end{proof}
 
-\begin{lemma}[Block-diagonal boundary closing gives the reverse inclusion]
+\begin{lemma}[Block-diagonal boundary representation gives the reverse inclusion]
     \label{lem:block_diagonal_boundary_representation_inclusion}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap}
     \leanok
@@ -162,7 +162,7 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
     $\psi\in\mathcal G_{N,L}(B)$.
 \end{proof}
 
-\begin{lemma}[Block-diagonal boundary closing gives equality in the finite range]
+\begin{lemma}[Block-diagonal boundary representation gives equality in the finite range]
     \label{lem:bnt_block_diagonal_boundary_representation_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary}
     \leanok


### PR DESCRIPTION
## Summary

- replace remaining block-diagonal "boundary-closing" prose by periodic-boundary and boundary-crossing language
- point the block-diagonal `**Unfaithful:**` markers to `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`
- retitle the conditional boundary-representation lemmas in the blueprint to match their hypotheses

## Mathematical Context

This is a documentation-only continuation of the parent-Hamiltonian prose cleanup. The direct gap is the block-diagonal boundary-condition comparison for boundary-crossing windows, tracked by #2651 and recorded in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. This also sits under the parent-Hamiltonian tracking issue #190 and the degenerate ground-space capstone #460.

No Lean theorem statement, proof term, import, or blueprint `\lean{}` link is changed.

## Checks

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root .`

Refs #2651.
Refs #190.
Refs #460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX-only edits with no executable or API changes; risk is limited to documentation consistency.
> 
> **Overview**
> This PR is **prose and documentation only**: theorem statements, proofs, imports, and blueprint `\lean{}` links are unchanged.
> 
> In **`BNTBlockDiagonalChain.lean`**, reader-facing text replaces **“boundary-closing”** with **periodic-boundary**, **boundary-crossing windows**, and **boundary-condition comparison** wording aligned with arXiv:2011.12127 Section IV.C (lines **2126–2128**). Every updated **`**Unfaithful:**`** block now cites **`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`** instead of **`cpgsv21_normal_range_reduction.tex`**, and describes the missing step as the comparison at **boundary-crossing windows** rather than a “boundary-closing coordinate comparison.”
> 
> The blueprint **retitles** the block-diagonal section to *Block-diagonal boundary conditions for periodic ground spaces* and reframes lemmas/comments (e.g. “boundary closing” → **boundary representation** / **periodic-boundary comparison**) in **`ch13_parent_hamiltonian_block_diagonal.tex`** and **`ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`** so headings match conditional hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfbdba3fa28f791e47d686afd9b88d4ff1f9309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->