### PR TITLE
doc(parent): align block-diagonal gap citations

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.ParentHamiltonian.WrappingWindow
 
 This file isolates the cyclic-interval step for a block component when the
 interval crosses the boundary cut.  The input is the blockwise matrix identity
-appearing in the boundary-closing part of arXiv:quant-ph/0608197, Theorem
+appearing in the boundary-condition comparison of arXiv:quant-ph/0608197, Theorem
 12.
 
 The equality theorem here is conditional on the matrix identities indexed by
@@ -483,7 +483,7 @@ segment \(0,\ldots,a-1\),
 \]
 then the restriction is the local vector \(\Gamma_L^{A_j}(E)\).
 
-This is the matrix form of the boundary-closing comparison in
+This is the matrix form of the boundary-crossing comparison in
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456. -/
 theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix
     {r : ℕ} {dim : Fin r → ℕ}
@@ -586,7 +586,7 @@ then the restriction belongs to \(G_L(A_j)\).  The middle word
 is incorporated into the boundary matrix
 \(Y A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}\).
 
-This is the equation form of the boundary-closing reduction used after the
+This is the equation form of the boundary-crossing reduction used after the
 blockwise comparison in arXiv:quant-ph/0608197, Theorem 12, proof lines
 1454--1456. -/
 theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_boundary_identity
@@ -747,9 +747,9 @@ wrapped word \(\beta\),
 The normalization \(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) and these
 compatibility identities give the matrix identities indexed by complementary
 words used in the injective periodic-chain theorem for each block.
-This is the boundary-closing comparison in arXiv:quant-ph/0608197, Theorem
-12, proof lines 1446--1451, followed by the periodic conclusion in
-lines 1454--1456.
+This is the boundary-condition comparison at a boundary-crossing interval in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451, followed by the
+periodic conclusion in lines 1454--1456.
 -/
 theorem
     blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective
@@ -882,9 +882,11 @@ arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456.
 
 **Unfaithful:** This proof relies on
 `exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -933,7 +935,7 @@ theorem
 /-- Matrix identities indexed by complementary words give the block-diagonal
 periodic-chain equality in the finite BNT range.
 
-This theorem combines two steps of the source boundary-closing argument:
+This theorem combines two steps of the source boundary-condition argument:
 first obtain block-diagonal boundary conditions, then use the
 Pérez-García--Verstraete--Wolf--Cirac \(C,D,E\) comparison, in the displayed
 matrix form indexed by complementary words, to put each single-block vector in
@@ -942,9 +944,11 @@ form for every boundary-crossing interval; it does not assert the comparison.
 
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -48,9 +48,11 @@ window, not terminology of the source statement.
 
 **Unfaithful:** This proof relies on
 `exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -114,9 +116,11 @@ equality.
 
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -47,9 +47,11 @@ block-diagonal boundary conditions of arXiv:2011.12127, lines 2126--2128.
 
 **Unfaithful:** This proof relies on
 `exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -119,9 +121,11 @@ remaining step recorded in
 
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; prove the
+comparison. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -56,7 +56,7 @@ theorem iSup_chainGroundSpace_block_le_toTensorFromBlocks
   exact iSup_le fun j =>
     chainGroundSpace_block_le_toTensorFromBlocks μ A (hμ j) hN hLN
 
-/-- Boundary-closing equality for the block-diagonal periodic chain.
+/-- Boundary-condition equality for the block-diagonal periodic chain.
 
 Let \(B=\bigoplus_j\mu_jA_j\). If closing the periodic boundary with
 block-diagonal boundary conditions gives
@@ -67,8 +67,9 @@ then the already proved blockwise inclusion gives
 \[
   \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j).
 \]
-This states the remaining PGVWC07/CPGSV21 boundary-closing step as a single
-hypothesis; it does not prove that hypothesis. -/
+This states the boundary-condition comparison for the block-diagonal periodic
+chain as a single hypothesis; it does not prove that hypothesis. See
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_chainGroundSpace_of_boundary_closing
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -98,8 +99,9 @@ for all \(M\ge L\), then
 \]
 This is the conditional propagation step in the proof of PGVWC07, Theorem
 12: the one-step identities propagate cyclic local constraints to
-\(S_N\). The later source step is closing the boundaries with block-diagonal
-boundary conditions, replacing \(S_N\) by the periodic block-chain sum. -/
+\(S_N\). The later source step is the boundary-condition comparison for
+block-diagonal boundary conditions, replacing \(S_N\) by the periodic
+block-chain sum. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -51,7 +51,7 @@ vectors.
         S_{m+1}.
     \]
     Let $H_{S_L,N}$ denote the periodic parent Hamiltonian whose local
-    ground space is $S_L$. The boundary-closing conclusion of the same theorem is
+    ground space is $S_L$. The periodic-boundary conclusion of the same theorem is
     \[
         \ker H_{S_L,N}
         =
@@ -191,7 +191,7 @@ vectors.
     % This closure-property step is not the inclusion
     % $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails for a general
     % open-boundary matrix crossing the periodic boundary.
-    The source boundary-closing conclusion is
+    The source periodic-boundary conclusion is
     \[
         \ker H_{S_L,N}
         =


### PR DESCRIPTION
## Summary

- repoint block-diagonal `**Unfaithful:**` markers to `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`
- update their source reference to arXiv:2011.12127, Section IV.C, lines 2126--2128
- replace remaining block-diagonal "boundary-closing" prose by boundary-condition, boundary-crossing, and periodic-boundary wording
- leave the single-block normal range-reduction citations unchanged

## Mathematical Context

This is a documentation-only follow-up to #2888 and #2651. The affected results concern the block-diagonal PGVWC/CPGSV boundary-condition comparison at boundary-crossing windows. The normal range-reduction note remains the correct paper-gap note for the single-block closure-property files and for `BNTBlockIntersection.lean`; this PR does not alter those citations.

No Lean theorem statement, proof term, import, declaration name, or blueprint `\lean{}` link is changed.

## Checks

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root .`

I also attempted a focused local `lake build` for the changed Lean modules. The fresh worktree first had a corrupt dependency checkout, then attempted to rebuild Mathlib from source; I stopped that long rebuild before completion. GitHub CI should provide the full Lean build verdict.

Refs #2651.
Refs #190.
Refs #460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint text only; no executable Lean or proof logic changes.
> 
> **Overview**
> Documentation-only alignment for block-diagonal parent-Hamiltonian material: comments and blueprint prose are updated without changing Lean theorem statements, proof terms, imports, or declaration names.
> 
> **Unfaithful** markers in the block-diagonal Lean modules (`BNTBlockDiagonalCrossing`, `BNTBlockDiagonalPGVWCComparison`, `BNTBlockDiagonalTraceDecomposition`) now cite `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` and arXiv:2011.12127 Section IV.C lines **2126--2128** (replacing `cpgsv21_normal_range_reduction.tex` and lines 2078--2079). Wording shifts from **boundary-closing** to **boundary-condition**, **boundary-crossing**, and **periodic-boundary** where it describes the PGVWC/CPGSV block-diagonal comparison.
> 
> `BlockDiagonalChainGroundSpace.lean` gets the same terminology refresh and points the conditional boundary step at the block-diagonal paper-gap note. Blueprint `ch13_parent_hamiltonian_bnt_consequences.tex` uses **periodic-boundary conclusion** instead of boundary-closing in two places. Single-block normal range-reduction citations (e.g. `BNTBlockIntersection.lean`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac58c37a37495a7793e8f6c0e86c8fa57d43f578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->