### PR TITLE
doc(parent): align normal-boundary prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean
@@ -8,13 +8,12 @@ import TNLean.MPS.Core.BlockingInfrastructure
 /-!
 # Block-to-letter translation of the boundary block matrix equation
 
-The boundary-closing argument of
-[Cirac--Perez-Garcia--Schuch--Verstraete 2021, arXiv:2011.12127, Section IV.C,
-lines 2078--2079] reduces, after blocking \(L_0\) sites into one, to the
-single-site closing-boundary matrix identity already proved for the blocked
-tensor `blockTensor A L₀`.  This file supplies the bookkeeping that turns that
-blocked identity back into a statement about ordinary length-\(L_0\) and
-length-\(L_0 K\) words of `A`.
+After blocking \(L_0\) sites into one, the comparison used when closing the
+periodic boundary in [Cirac--Perez-Garcia--Schuch--Verstraete 2021,
+arXiv:2011.12127, Section IV.C, lines 2078--2079] reduces to the single-site
+matrix identity for the blocked tensor \(A^{[L_0]}\). The result transports the
+blocked matrix identity to ordinary length-\(L_0\) and length-\(L_0 K\) word
+products of \(A\).
 
 Starting from the blocked matrix equation
 \[
@@ -23,19 +22,20 @@ Starting from the blocked matrix equation
   A^{w(b)} \, Y_{c_b},
 \]
 where \(b\) is a single block letter and \(c_b\) is an iterated block index of the
-complement, the result produces the block matrix equation in the shape consumed
-by the boundary-matrix commutation lemma from the coordinate comparison, with
-the head ranging over every length-L₀ word and the complement over every
-length-L₀K word.
+complement, the result gives the block matrix equation used by the
+boundary-matrix commutation lemma from the coordinate comparison, with the first
+factor ranging over every length-\(L_0\) word and the complement over every
+length-\(L_0K\) word.
 
 The proof sends each length-\(L_0\) word \(s\) to its canonical block letter in
 \(\mathrm{Fin}(d^{L_0})\) and regroups each length-\(L_0 K\) complement word \(c\)
 through the isomorphism \(\mathrm{Fin}(d^{L_0 K}) \cong (\mathrm{Fin}(d^{L_0}))^K\),
 both invertible by the blocking round-trip lemmas.
 
-This is a step of the boundary-closing decomposition for the normal
-range-reduction argument; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`
-and the tracking issue for the remaining boundary-closing obligation.
+This is the block-to-word form of the comparison used when closing the periodic
+boundary in the normal range-reduction argument; see
+docs/paper-gaps/cpgsv21_normal_range_reduction.tex for the remaining
+comparison at the periodic boundary.
 
 ## References
 
@@ -51,8 +51,8 @@ variable {d D : ℕ}
 
 /-- **Block-to-letter translation of the boundary block matrix equation.**
 
-Suppose the blocked tensor satisfies, for every single block letter `b` and every
-iterated block index `cb` of the complement,
+Suppose the blocked tensor satisfies, for every single block letter \(b\) and
+every iterated block index \(c_b\) of the complement,
 \[
   X \, A^{w(b)} \, A^{\mathrm{flatten}(w(c_b))} = A^{w(b)} \, Y_{c_b},
 \]
@@ -67,7 +67,7 @@ for which the block matrix equation
 holds for *every* length-\(L_0\) head word \(\sigma_{\mathrm{tail}}\) and *every*
 length-\(L_0 K\) complement word \(\sigma_{\mathrm{comp}}\).
 
-The conclusion is the block matrix equation consumed by the boundary-matrix
+The conclusion is the block matrix equation used by the boundary-matrix
 commutation step. -/
 theorem block_matEq_of_blocked_matEq
     {A : MPSTensor d D} {L₀ Kb : ℕ}
@@ -86,12 +86,12 @@ theorem block_matEq_of_blocked_matEq
     YB (directToIteratedBlockIndex d L₀ Kb
       (blockIndexOfList d (L₀ * Kb) (List.ofFn c) (by simp))), ?_⟩
   intro s c
-  -- Realize the head `s` as a single block letter `b`.
+  -- Regard the head word as a single block letter.
   set b : Fin (blockPhysDim d L₀) :=
     blockIndexOfList d L₀ (List.ofFn s) (by simp) with hb
   have hbword : wordOfBlock d L₀ b = List.ofFn s := by
     rw [hb]; exact wordOfBlock_blockIndexOfList d L₀ (List.ofFn s) (by simp)
-  -- Realize the complement `c` as a grouped iterated block index `cb`.
+  -- Regard the complement word as a grouped iterated block index.
   set i : Fin (blockPhysDim d (L₀ * Kb)) :=
     blockIndexOfList d (L₀ * Kb) (List.ofFn c) (by simp) with hi
   set cb : Fin (blockPhysDim (blockPhysDim d L₀) Kb) :=

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -6,11 +6,12 @@ Authors: TNLean contributors
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingWitness
 
 /-!
-# Boundary conditions for the closure property
+# Cyclic-window constraints at the periodic boundary
 
-Coordinate identities for the boundary-crossing cyclic windows in the normal
-parent-Hamiltonian closure step of arXiv:2011.12127, Section IV.C. The opposite
-window shares the complementary word \(\mu\).
+Coordinate identities for the boundary-crossing restrictions used when closing
+the periodic boundary in the normal parent-Hamiltonian closure step of
+arXiv:2011.12127, Section IV.C. The opposite window shares the complementary
+word \(\mu\).
 -/
 
 open scoped Matrix BigOperators
@@ -19,7 +20,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Pointwise complement reduction for the boundary-closing product equation.
+/-- Pointwise complement reduction for a boundary-crossing product equation.
 
 The auxiliary boundary conditions may depend on the fixed physical letter and
 the length-\(L_0\) word. If, for each pair \(j,\sigma\), the conditions
@@ -84,7 +85,7 @@ theorem boundary_closing_product_eq_of_pointwise_compatible_boundary_assignments
           evalWord A (List.ofFn σ) := by
             rw [hmirror]
 
-/-- Complement reduction for the boundary-closing product equation.
+/-- Complement reduction for a boundary-crossing product equation.
 
 Suppose two auxiliary boundary conditions have the same complementary words as
 \(\tau^+_\eta(\mu)\) and \(\tau^-_\eta(\mu)\), respectively.  If the desired
@@ -143,7 +144,7 @@ boundary condition \(\tau\),
 \]
 
 These are one-sided coordinate consequences of the cyclic-window constraints
-used to model the boundary-closing argument. The source paragraph in
+used when closing the periodic boundary. The source paragraph in
 arXiv:2011.12127, Section IV.C, lines 2078--2079, states the corresponding
 closure-property step, but does not display these coordinate equations. -/
 theorem closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
@@ -219,7 +220,7 @@ lemma closure_property_boundary_one_sided_products_of_groundSpaceMap
     rw [hcomp] at h
     simpa using h
 
-/-- Product form of the boundary-crossing restrictions at the closing boundary.
+/-- Product form of the boundary-crossing restrictions when closing the periodic boundary.
 
 For the \(L_0-1\) adjacent restrictions from \(M+1-L_0\) to \(M\), the two
 boundary letters are indexed by
@@ -333,7 +334,7 @@ theorem closure_property_boundary_condition_product_of_window_witnesses
     rw [hsum, Nat.mod_eq_of_lt (by omega)]
   simpa [Y, hstart, hend] using hprod
 
-/-- Product equation obtained by moving from the last site through the closing
+/-- Product equation obtained by moving from the last site through the periodic
 boundary to the opposite boundary-crossing support.
 
 For a fixed boundary condition \(\rho\), the window matrices satisfy
@@ -406,10 +407,10 @@ lemma closure_property_boundary_condition_long_product_of_window_witnesses
       rw [hsum, Nat.add_mod_left]
     rw [hsite]
 
-/-- Equal closed-boundary restrictions determine the first-letter boundary
+/-- Equal boundary-crossing restrictions determine the first-letter boundary
 products.
 
-Suppose the two length-\((L_0+1)\) restrictions at the closed boundary are
+Suppose the two boundary-crossing restrictions of length \(L_0+1\) are
 represented by \(Y_M(\tau^+_\eta(\mu))\) and
 \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\). If the restrictions agree, then for every
 physical letter \(j\), their first-letter restrictions give
@@ -418,7 +419,7 @@ physical letter \(j\), their first-letter restrictions give
   =
   Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
 \]
-**Scope restriction (boundary-closing restriction equality):** This lemma assumes this equality
+**Scope restriction (boundary-crossing restriction equality):** This lemma assumes this equality
 rather than deriving arXiv:2011.12127, Section IV.C, lines 2078--2079; documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_boundary_first_products_of_restrictions
@@ -477,9 +478,9 @@ lemma closure_property_boundary_first_products_of_restrictions
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j] at hvec
   exact hleft.symm.trans (hvec.trans hright)
 
-/-- Right-products determine the two restrictions at the closed boundary.
+/-- Right-products determine the two boundary-crossing restrictions.
 
-Suppose the two length-\((L_0+1)\) restrictions at the closed boundary are
+Suppose the two boundary-crossing restrictions of length \(L_0+1\) are
 represented by \(Y_M(\tau^+_\eta(\mu))\) and
 \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\).  If, for every physical letter \(j\),
 \[
@@ -541,13 +542,13 @@ lemma closure_property_boundary_restriction_eq_of_first_products
     hMinus j
   exact hleft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) (hProd j)).trans hright.symm)
 
-/-- Boundary-closing restrictions from first-letter product equations.
+/-- Boundary-crossing restrictions from first-letter product equations.
 
 If the two length-\((L_0+1)\) restrictions are represented by witnesses
 \(Y_i(\tau)\), and the first-letter boundary products agree for every
-boundary letter and physical letter, then the two cyclic restrictions used
-when closing the boundary agree for every boundary letter. This is only the
-final reduction; it does not supply the product equations themselves. -/
+boundary letter and physical letter, then the two boundary-crossing restrictions
+used when closing the periodic boundary agree for every boundary letter. This is
+only the final reduction; it does not prove the product equations themselves. -/
 lemma closure_property_boundary_restrictions_eq_of_first_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -580,7 +581,7 @@ lemma closure_property_boundary_restrictions_eq_of_first_products
     (hProd η)
 
 /-- Auxiliary boundary-condition product obtained from equality of the two
-closing-boundary restrictions.
+boundary-crossing restrictions.
 
 Suppose that, for every outside letter \(\eta\), the two boundary conditions
 with outside letter \(\eta\) and complementary word \(\mu\) give the same
@@ -597,9 +598,9 @@ Then there are boundary conditions with the same complementary word and with
   Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
 \]
 The source says that the same inverting and growing-back argument may be used
-when closing the boundary. In coordinates, the remaining comparison is the
-displayed restriction equality.
-**Scope restriction (boundary-closing restriction equality):** Assumes the displayed equality
+when closing the periodic boundary. In coordinates, the remaining comparison is
+the displayed restriction equality.
+**Scope restriction (boundary-crossing restriction equality):** Assumes the displayed equality
 rather than deriving arXiv:2011.12127, Section IV.C, lines 2078--2079; documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
@@ -653,8 +654,8 @@ lemma closure_property_auxiliary_boundary_product_eq_of_closing_restrictions
     simpa [ρPlus, ρMinus] using
       congrArg (fun Y => Y * evalWord A (List.ofFn σ)) hfirst
 
-/-- Auxiliary boundary-condition product obtained from right-products at the
-two closing boundary matrices.
+/-- Auxiliary boundary-condition product obtained from right-products for the
+two boundary-crossing restrictions.
 
 Suppose that, for every boundary letter \(\eta\) and every physical letter
 \(j\),
@@ -670,7 +671,7 @@ Then there are boundary conditions with the same complementary word and with
   Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
 \]
 This is the composition of the right-product-to-restriction step with the
-auxiliary product extraction from equal closing-boundary restrictions. -/
+auxiliary product extraction from equal boundary-crossing restrictions. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_right_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -708,7 +709,7 @@ lemma closure_property_auxiliary_boundary_product_eq_of_right_products
     (hYAt ⟨M + 1 - L₀, by omega⟩
       (mirrorMiddleBackground L₀ (M + 1) η μ)) (hProd η)
 
-/-- Cancellation form of the opposite-boundary coordinate comparison.
+/-- Cancellation form of the opposite boundary-crossing coordinate comparison.
 
 If the difference
 \[
@@ -751,14 +752,15 @@ lemma closure_property_mirror_right_product_eq_of_right_word_products
       (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
   exact sub_eq_zero.mp hsub
 
-/-- Auxiliary boundary-condition product obtained from the opposite-boundary
-coordinate comparison after multiplication by length-\(L_0\) words.
+/-- Auxiliary boundary-condition product obtained from the opposite
+boundary-crossing coordinate comparison after multiplication by length-\(L_0\)
+words.
 
-Suppose that the last boundary already gives
+Suppose that the window beginning at \(M\) already gives
 \[
   Y_M(\tau^+_\eta(\mu)) A^j = A^\mu A^jX
 \]
-and that the opposite boundary satisfies the comparison
+and that the opposite boundary-crossing window satisfies the comparison
 \[
   Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma
   =
@@ -769,8 +771,8 @@ products span the full matrix algebra, this comparison implies
 \[
   Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j = A^\mu A^jX .
 \]
-Together with the last-boundary equation this supplies the product equations
-needed for the auxiliary boundary-condition product. -/
+Together with the equation for the window beginning at \(M\), this gives the
+product equations needed for the auxiliary boundary-condition product. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -1,13 +1,15 @@
 
-\section{Boundary closing for normal tensors}\label{sec:normal_boundary_closing}
+\section{Closing the periodic boundary for normal tensors}\label{sec:normal_boundary_closing}
 
-The results here compare the two boundary-crossing cyclic restrictions
+This section isolates the comparison used when closing the periodic boundary.
+It compares the two boundary-crossing restrictions
 $\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)$ and
 $\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)$ of a chain ground
 state. Once the one-sided boundary products are known, equality of the two
 restrictions follows from the commutation identity $XA^j=A^jX$ for every
-physical letter $j$. The remaining boundary-closing step is to derive these
-identities from the boundary matrix identity in the closure-property comparison.
+physical letter $j$. The remaining step is to derive these identities from the
+boundary matrix identity obtained from the cyclic-window constraints in the
+closure-property comparison.
 
 \begin{lemma}[Block-to-letter translation of the boundary block matrix equation]
     \label{lem:block_mateq_of_blocked_mateq}
@@ -110,11 +112,11 @@ identities from the boundary matrix identity in the closure-property comparison.
 
 \begin{proof}
     \notready
-    This is the coordinate matrix formulation of the boundary-closing part of
-    the inverting-and-growing-back argument in
+    This is the coordinate matrix formulation of the part of the
+    inverting-and-growing-back argument used when closing the periodic boundary in
     \cite[Section~IV.C, lines~2078--2079]{Cirac2021Matrix}. A complete proof
-    must derive the displayed equation from the closing-boundary local
-    constraints recorded above.
+    must derive the displayed equation from the cyclic-window constraints
+    recorded above.
 \end{proof}
 
 \begin{lemma}[Boundary restrictions from commutation and one-sided products]
@@ -299,14 +301,14 @@ identities from the boundary matrix identity in the closure-property comparison.
     equalities.
 \end{proof}
 
-\begin{lemma}[Closed-boundary restriction from right products]
+\begin{lemma}[Boundary-crossing restriction from right products]
     \label{lem:closed_boundary_restriction_from_right_products}
     \lean{MPSTensor.closure_property_boundary_restriction_eq_of_first_products}
     \leanok
     \uses{rem:cyclic_window_operators, lem:first_letter_restrictions_determine}
     Let $A$ be an MPS tensor, let $L_0>0$, and let $L_0\le M$. Suppose the two
-    length-$(L_0+1)$ restrictions at the closed boundary are represented by
-    boundary matrices $Y^+_{\eta,\mu}$ and $Y^-_{\eta,\mu}$:
+    boundary-crossing restrictions of length $L_0+1$ are represented by boundary
+    matrices $Y^+_{\eta,\mu}$ and $Y^-_{\eta,\mu}$:
     \[
         B^+_{\eta,\mu}(\psi)=\Gamma_{L_0+1}(Y^+_{\eta,\mu}),
         \qquad
@@ -423,7 +425,7 @@ identities from the boundary matrix identity in the closure-property comparison.
     the two length-$(L_0+1)$ restrictions.
 \end{proof}
 
-\begin{lemma}[Auxiliary product from closing-boundary restrictions]
+\begin{lemma}[Auxiliary product from boundary-crossing restrictions]
     \label{lem:closure_property_auxiliary_product_from_closing_restrictions}
     \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_closing_restrictions}
     \leanok
@@ -777,7 +779,7 @@ identities from the boundary matrix identity in the closure-property comparison.
 \begin{proof}
     \leanok
     Lemma~\ref{lem:closure_property_boundary_one_sided_products_ground_space_map}
-    gives the last-boundary equation
+    gives the equation for the boundary-crossing window beginning at $M$,
     \[
         Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
     \]
@@ -785,7 +787,7 @@ identities from the boundary matrix identity in the closure-property comparison.
     Lemma~\ref{lem:closure_property_auxiliary_product_from_opposite_boundary_left_words}
     then give the displayed boundary conditions and product equation.
     % Source note: arXiv:2011.12127, Section IV.C, lines 2078--2079,
-    % says that the corresponding boundary-closing argument is analogous.
+    % says that the corresponding argument for closing the periodic boundary is analogous.
     % The assumed equation is the coordinate form isolated in
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
@@ -839,8 +841,8 @@ identities from the boundary matrix identity in the closure-property comparison.
         =
         A^\mu A^jX .
     \]
-    The last-boundary equation from
-    Lemma~\ref{lem:closure_property_boundary_one_sided_products_ground_space_map}
+    The equation for the boundary-crossing window beginning at $M$, from
+    Lemma~\ref{lem:closure_property_boundary_one_sided_products_ground_space_map},
     gives
     \[
         Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX .
@@ -850,7 +852,7 @@ identities from the boundary matrix identity in the closure-property comparison.
     identifies the two restrictions.
 \end{proof}
 
-\begin{theorem}[Equality of the boundary-closing cyclic restrictions]
+\begin{theorem}[Equality of the boundary-crossing restrictions]
     \label{thm:closure_property_boundary_restrictions_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}
     \leanok
@@ -878,10 +880,10 @@ identities from the boundary matrix identity in the closure-property comparison.
         \tau^-_\eta(\mu)_{k+1}=\mu_k,
     \]
     and put the letter $\eta$ on the remaining sites. The notation
-    $\tau^\pm_\eta(\mu)$ is a coordinate parametrization for the
-    boundary-closing comparison in \cite[Section~IV.C, lines~2078--2079]
+    $\tau^\pm_\eta(\mu)$ is a coordinate parametrization for the comparison used
+    when closing the periodic boundary in \cite[Section~IV.C, lines~2078--2079]
     {Cirac2021Matrix}; it is not notation from the source.
-    The boundary-closing step is the equality
+    The corresponding boundary-crossing restriction equality is
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
         =
@@ -918,16 +920,16 @@ identities from the boundary matrix identity in the closure-property comparison.
         Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
     \]
     Lemma~\ref{lem:closed_boundary_restrictions_from_first_letter_products}
-    then identifies the two cyclic restrictions. Thus the full boundary
-    restriction conclusion has been reduced to the boundary matrix identity in
-    the closure-property comparison. The derivation of that identity from the
-    closing-boundary local constraints is
-    the remaining part of the boundary-closing sentence in
+    then identifies the two boundary-crossing restrictions. Thus the restriction
+    equality has been reduced to the boundary matrix identity in the
+    closure-property comparison. The derivation of that identity from the
+    cyclic-window constraints at the periodic boundary is the remaining part of
+    the source sentence on closing the periodic boundary in
     \cite[lines~2078--2079]{Cirac2021Matrix}; it is recorded in
     \path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex}.
 \end{proof}
 
-\subsection{Reverse comparison at the closing boundary}\label{subsec:normal_boundary_closing_reverse}
+\subsection{Reverse comparison for boundary-crossing restrictions}\label{subsec:normal_boundary_closing_reverse}
 
 This subsection runs the comparison in the reverse direction: from equality of
 the two cyclic restrictions it recovers the first-letter product equation
@@ -1034,8 +1036,8 @@ left-multiplied boundary comparison.
 
 \begin{proof}
     \notready
-    The representations by the matrices $Y_i(\tau)$ supply the local
-    ground-space hypothesis for the preceding lemma.
+    The matrices $Y_i(\tau)$ give the local ground-space representations needed
+    in the preceding lemma.
     Once the preceding boundary-restriction equality is proved, it gives
     \[
         \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
@@ -1088,18 +1090,20 @@ left-multiplied boundary comparison.
         A^\alpha
         \left(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\right).
     \]
-    The last-boundary one-sided equation gives
+    The one-sided equation for the boundary-crossing window beginning at $M$
+    gives
     \[
         Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX.
     \]
     Substitution gives the displayed identity.
-    % The cited paragraph does not display the first comparison. It is
-    % the coordinate reconstruction isolated here for the closing-boundary step
-    % of \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
+    % The cited paragraph does not display the first comparison. It is the
+    % coordinate reconstruction isolated here for the boundary-crossing
+    % restrictions used when closing the periodic boundary in
+    % \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
-\begin{lemma}[Letterwise restriction comparison at the closing boundary]
+\begin{lemma}[Letterwise comparison of boundary-crossing restrictions]
     \label{lem:closure_property_fixed_boundary_letter_chain_ground_space}
     \lean{MPSTensor.closure_property_fixed_boundary_letter_eq_of_chainGroundSpace}
     \leanok
@@ -1200,12 +1204,13 @@ left-multiplied boundary comparison.
         A^\mu A^jXA^\sigma .
     \]
     % The cited paragraph does not display this formula. It is the coordinate
-    % reconstruction isolated here for the closing-boundary step of
-    % \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
+    % reconstruction isolated here for the boundary-crossing restrictions used
+    % when closing the periodic boundary in \cite[lines~2078--2079]{Cirac2021Matrix}.
+    % Remaining gap recorded in
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
-\begin{theorem}[Product equality after closing the boundary]
+\begin{theorem}[Product equality after closing the periodic boundary]
     \label{thm:boundary_closing_word_equation_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_closing_product_eq_of_chainGroundSpace}
     \leanok
@@ -1253,10 +1258,10 @@ left-multiplied boundary comparison.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^jA^\sigma,
     \]
-    which is the product equality needed after closing the boundary.
+    which is the product equality needed when closing the periodic boundary.
 \end{proof}
 
-\begin{theorem}[Right-product equality after closing the boundary]
+\begin{theorem}[Right-product equality after closing the periodic boundary]
     \label{thm:boundary_closing_right_products_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_right_products_eq_of_chainGroundSpace}
     \leanok
@@ -1279,7 +1284,7 @@ left-multiplied boundary comparison.
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
     \]
     This is the one-site product equality used to compare the two boundary
-    matrices after closing the boundary.
+    matrices when closing the periodic boundary.
 \end{theorem}
 
 \begin{proof}
@@ -1319,7 +1324,7 @@ left-multiplied boundary comparison.
     $L_0+1<N$, and $L_0<L\le N$, and let
     $\psi\in\mathcal G_{N,L}(A)$ have an open-chain representation
     $\psi=\Gamma_N(X)$.  Suppose $Y^{+}$ and $Y^{-}$ are two families of
-    matrices obtained from the two boundary-crossing local constraints used
+    matrices obtained from the two boundary-crossing cyclic-window constraints used
     in the closure property, and that they satisfy,
     for every physical letter $j$ and every boundary condition $\tau$,
     \[
@@ -1379,7 +1384,7 @@ left-multiplied boundary comparison.
     \]
     Write $N=M+1$. The two boundary-crossing supports start at
     $M$ and $M+1-L_0$.  Let $Y_i(\tau)$
-    denote the cyclic-window witness supplied by
+    denote the cyclic-window witness given by
     Lemma~\ref{lem:chain_ground_space_window_witnesses} at the window beginning at
     $i$.  The first step identifies the two abstract boundary-condition families
     with the two boundary-crossing witnesses:
@@ -1409,7 +1414,7 @@ left-multiplied boundary comparison.
 In the injective case, for $N\ge2$ and $1<L\le N$, the chain ground space equals
 $\spn\{V^{(N)}(A)\}$, so the parent Hamiltonian has a unique ground state in
 that length range. In the normal case the same conclusion is the payoff of the
-section, given the closed-boundary comparison and the length hypotheses
+section, given the boundary-crossing comparison and the length hypotheses
 $N\ge2$, $L_0+1<N$, and $L_0<L\le N$.
 
 \begin{theorem}[Chain ground space is spanned by the MPS vector in the injective case]%
@@ -1458,13 +1463,13 @@ $N\ge2$, $L_0+1<N$, and $L_0<L\le N$.
         thm:conditional_normal_range_reduction_witness_comparison,
         lem:padded_complement_annihilation}
     For a chain ground state, the open-chain containment gives
-    $\psi=\Gamma_N(X)$. The two boundary-crossing local constraints give
+    $\psi=\Gamma_N(X)$. The two boundary-crossing cyclic-window constraints give
     \[
         A^\mu A^j X = Y^+_{\tau^+_\eta(\mu)}A^j,
         \qquad
         X A^j A^\mu = A^jY^-_{\tau^-_\eta(\mu)}.
     \]
-    The remaining closed-boundary comparison is the equality
+    The remaining boundary-crossing comparison is the equality
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}.
     \]


### PR DESCRIPTION
## Summary

- Replaces local “boundary-closing” phrasing in the normal parent-Hamiltonian closing section with source-faithful language about closing the periodic boundary.
- Describes the two compared objects as boundary-crossing restrictions and cyclic-window constraints.
- Removes “bookkeeping” and file-oriented prose from the block-to-letter matrix-equation translation.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- direct Lean check of `TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
- direct Lean check of `TNLean/MPS/ParentHamiltonian/BoundaryBlockMatEq.lean`

Refs #2405. Refs #2368. Refs #460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and comment rewording dominate; the only logic touch is a small `simpa` argument list in an existing proof.
> 
> **Overview**
> Realigns reader-facing prose in the normal parent-Hamiltonian **periodic boundary** story so it matches the CPGSV source wording instead of informal “boundary-closing” / “closed boundary” labels.
> 
> In **Lean** (`BoundaryClosing.lean`, `BoundaryBlockMatEq.lean`), module headers, theorem docstrings, and inline comments now speak of **closing the periodic boundary**, **boundary-crossing restrictions**, and **cyclic-window constraints**; the block-to-letter file drops “bookkeeping” / tracking-issue tone and tightens how the blocked identity is described. `BoundaryBlockMatEq` also extends the closing `simpa` with `[hb, hi, hcb]` (proof behavior only).
> 
> The **blueprint** chapter `ch13_parent_hamiltonian_normal_closing.tex` is updated in parallel: section title, lemma/theorem names in prose, proof sketches, and gap notes use the same vocabulary (e.g. boundary-crossing restrictions vs. closed-boundary restrictions, cyclic-window constraints vs. closing-boundary local constraints).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f362f8da8b33eaecd3a52d1f42391c4f22469af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->