### PR TITLE
doc(parent): align periodic-boundary titles

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -91,7 +91,7 @@ closure-property comparison.
     gives $X A^j-A^jX=0$.
 \end{proof}
 
-\begin{lemma}[Coordinate matrix identity at the closing boundary]
+\begin{lemma}[Coordinate matrix identity for closing the periodic boundary]
     \label{lem:closure_property_boundary_block_window_equation_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}
     \leanok
@@ -539,7 +539,7 @@ closure-property comparison.
     gives the displayed boundary conditions and product equation.
 \end{proof}
 
-\begin{lemma}[Opposite-boundary comparison after multiplication by words]
+\begin{lemma}[Boundary-crossing comparison after multiplication by words]
     \label{lem:closure_property_opposite_boundary_comparison_from_right_words}
     \lean{MPSTensor.closure_property_mirror_right_product_eq_of_right_word_products}
     \leanok
@@ -578,7 +578,7 @@ closure-property comparison.
     Lemma~\ref{lem:padded_complement_annihilation} gives $Z_{\eta,j}=0$.
 \end{proof}
 
-\begin{lemma}[Opposite-boundary comparison after left multiplication by words]
+\begin{lemma}[Boundary-crossing comparison after left multiplication by words]
     \label{lem:closure_property_opposite_boundary_comparison_from_left_words}
     \lean{MPSTensor.closure_property_mirror_padded_products_of_left_word_products}
     \leanok
@@ -617,7 +617,7 @@ closure-property comparison.
     $Z_{\eta,j,\sigma}=0$.
 \end{proof}
 
-\begin{lemma}[Auxiliary product from the opposite-boundary comparison]
+\begin{lemma}[Auxiliary product from the boundary-crossing comparison]
     \label{lem:closure_property_auxiliary_product_from_opposite_boundary_words}
     \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_mirror_padded_products}
     \leanok
@@ -684,7 +684,7 @@ closure-property comparison.
     then gives the displayed boundary conditions and auxiliary product.
 \end{proof}
 
-\begin{lemma}[Auxiliary product from the left-multiplied opposite-boundary comparison]
+\begin{lemma}[Auxiliary product from the left-multiplied boundary-crossing comparison]
     \label{lem:closure_property_auxiliary_product_from_opposite_boundary_left_words}
     \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products}
     \leanok
@@ -1055,7 +1055,7 @@ left-multiplied boundary comparison.
     \]
 \end{proof}
 
-\begin{theorem}[Left-multiplied coordinate comparison at the closing boundary]
+\begin{theorem}[Left-multiplied coordinate comparison for closing the periodic boundary]
     \label{thm:closure_property_mirror_left_word_products_ground_space}
     \lean{MPSTensor.closure_property_mirror_left_word_products_of_groundSpaceMap}
     \leanok


### PR DESCRIPTION
## Summary

- Retitle six normal-closing blueprint entries so their headings use periodic-boundary and boundary-crossing terminology.
- Leave theorem labels, Lean declaration links, statements, hypotheses, and proof sketches unchanged.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only reader-facing LaTeX titles change; labels, Lean sync metadata, and theorem content stay the same.
> 
> **Overview**
> **Documentation-only** retitling in `ch13_parent_hamiltonian_normal_closing.tex`: six `\begin{lemma}` / `\begin{theorem}` optional titles are updated so headings match the chapter’s **periodic-boundary** and **boundary-crossing** wording (e.g. “opposite-boundary” → “boundary-crossing”, “at the closing boundary” → “for closing the periodic boundary”).
> 
> **No mathematical or formal changes:** `\label{...}`, `\lean{...}`, statements, hypotheses, and proof bodies are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e55f2e3dc04b5e57dc011c8e1a98f07d946d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->