### PR TITLE
doc(parent): align periodic-boundary prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingCoordinate.lean
@@ -6,7 +6,7 @@ Authors: TNLean contributors
 import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 
 /-!
-# Coordinate consequences for closing the parent-Hamiltonian boundary
+# Coordinate consequences for the periodic-boundary comparison
 
 This file contains formula-level consequences of the boundary-condition
 comparison lemmas in `BoundaryClosing`.
@@ -18,7 +18,8 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- The last-boundary first-product equation remains true after right
+/-- The first-product equation for the boundary-crossing window beginning at
+\(M\) remains true after right
 multiplication by any length-\(L_0\) word:
 \[
   Y_\rho A^j A^\sigma =
@@ -47,8 +48,8 @@ theorem wrappedMiddleBackground_first_products_eq_of_complement_eq_right_word
     (wrappedMiddleBackground_first_products_eq_of_complement_eq
       (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ j)
 
-/-- The opposite-boundary first-product equation remains true after right
-multiplication by any length-\(L_0\) word:
+/-- The first-product equation for the second boundary-crossing window remains
+true after right multiplication by any length-\(L_0\) word:
 \[
   Y_\rho A^j A^\sigma =
   Y_{\tau^-_\eta(\mu)} A^j A^\sigma .
@@ -102,7 +103,8 @@ theorem closure_property_boundary_condition_product_of_window_witnesses_mul_righ
     (closure_property_boundary_condition_product_of_window_witnesses
       (A := A) hInj hL₀ hM YAt hYAt ρ)
 
-/-- Adjacent-window transport followed by the last-boundary one-sided equation.
+/-- Adjacent-window transport followed by the one-sided equation at the window
+beginning at \(M\).
 
 For a boundary condition \(\rho\), the adjacent windows from \(M+1-L_0\) to
 \(M\) give
@@ -111,11 +113,12 @@ For a boundary condition \(\rho\), the adjacent windows from \(M+1-L_0\) to
   =
   A^{\rho_1\cdots\rho_{L_0-1}}Y_M(\rho).
 \]
-Multiplying by \(A^j\) and using the last-boundary equation for
+Multiplying by \(A^j\) and using the one-sided equation for the window beginning
+at \(M\), for
 \(\psi=\Gamma_{M+1}(X)\) gives the displayed formula below.  This is the
 transport identity supplied by the adjacent-window argument; for
 \(\rho=\tau^-_\eta(\mu)\) it is distinct from the remaining padded identity
-in the closing-boundary comparison. -/
+in the periodic-boundary comparison. -/
 theorem closure_property_boundary_condition_transport_wrapped_product_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -8,12 +8,13 @@ import TNLean.MPS.ParentHamiltonian.BoundaryStripping
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
 
 /-!
-# Stripping reductions for the closing boundary
+# Stripping reductions for the periodic-boundary comparison
 
-Left-word stripping reductions for the closing boundary: a boundary difference
-killed by every length-\(L_0\) word product on the left vanishes (block
-injectivity), reducing the closing-boundary comparison to a single padded
-coordinate identity in arXiv:2011.12127, Section IV.C.
+Left-word stripping reductions for the comparison used when closing the periodic
+boundary: a boundary difference killed by every length-\(L_0\) word product on
+the left vanishes by block injectivity, reducing the periodic-boundary
+comparison to a single padded coordinate identity in arXiv:2011.12127,
+Section IV.C.
 -/
 
 open scoped Matrix BigOperators
@@ -22,9 +23,9 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Left-word stripping for the opposite-boundary coordinate comparison.
+/-- Left-word stripping for the second boundary-crossing coordinate comparison.
 
-Let \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\) be the matrix representing the opposite
+Let \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\) be the matrix representing the second
 boundary-crossing restriction. If, after fixing the physical letter \(j\) and
 the right word \(\sigma\), the difference
 \[
@@ -37,7 +38,7 @@ difference is zero.
 **Scope restriction (conditional reduction):** This is only a stripping
 reduction. It assumes the left-multiplied coordinate comparison through the
 hypothesis `hLeft`, and does not derive that comparison from the
-source sentence on closing the boundaries in arXiv:2011.12127, Section IV.C,
+periodic-boundary closure-property sentence in arXiv:2011.12127, Section IV.C,
 lines 2078--2079.
 The remaining reconstruction is documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
@@ -78,7 +79,7 @@ theorem closure_property_mirror_padded_products_of_left_word_products
       (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
   exact sub_eq_zero.mp hZ
 
-/-- Boundary matrix identity obtained from the closing-boundary local
+/-- Boundary matrix identity obtained from the periodic-boundary local
 constraints.
 
 Let \(A\) be \(L_0\)-block-injective, let \(L_0<M\), let
@@ -94,11 +95,11 @@ This is the coordinate comparison needed by the block-injective
 boundary-matrix commutation lemma.
 
 **Open gap:** The proof is the missing coordinate form of the
-inverting-and-growing-back argument when closing the periodic boundary in
+inverting-and-growing-back argument at the periodic boundary in
 arXiv:2011.12127, Section IV.C, lines 2078--2079. The statement is the
 source-faithful coordinate obligation; the body remains open. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
-displayed matrix equation from the closing-boundary local constraints; tracked
+displayed matrix equation from the periodic-boundary local constraints; tracked
 in issue 2405. -/
 theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -115,14 +116,14 @@ theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
   sorry
 
 /-- Auxiliary boundary-condition product from the left-word form of the
-opposite-boundary coordinate comparison.
+second boundary-crossing coordinate comparison.
 
-Suppose the last boundary gives
+Suppose the one-sided equation for the window beginning at \(M\) gives
 \[
   Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX
 \]
-and the opposite-boundary difference becomes zero after left multiplication by
-every length-\(L_0\) word product:
+and the second boundary-crossing difference becomes zero after left
+multiplication by every length-\(L_0\) word product:
 \[
   A^\alpha\,Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma
   =
@@ -134,7 +135,7 @@ Then the auxiliary boundary conditions \(\rho^+_{j,\sigma}\) and
 **Scope restriction (conditional reduction):** This lemma assumes the
 left-multiplied coordinate comparison and derives the auxiliary boundary-product
 condition from it. The comparison is the coordinate reconstruction used here for
-the closing-boundary sentence in arXiv:2011.12127, Section IV.C,
+the periodic-boundary closure-property sentence in arXiv:2011.12127, Section IV.C,
 lines 2078--2079, and is documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 lemma closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
@@ -180,13 +181,14 @@ lemma closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_product
 /-- Auxiliary boundary-condition product from the left-multiplied coordinate
 form and the one-sided boundary equations of an open-chain representation.
 
-For \(\psi=\Gamma_{M+1}(X)\), the last boundary supplies
+For \(\psi=\Gamma_{M+1}(X)\), the one-sided equation for the window beginning at
+\(M\) supplies
 \[
   Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX.
 \]
 Thus the auxiliary product equation follows once, for every pair of
-length-\(L_0\) words \(\alpha,\sigma\), the opposite boundary satisfies the
-left-multiplied coordinate comparison
+length-\(L_0\) words \(\alpha,\sigma\), the second boundary-crossing window
+satisfies the left-multiplied coordinate comparison
 \[
   A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
   =
@@ -195,9 +197,10 @@ left-multiplied coordinate comparison
 
 **Scope restriction (conditional reduction):** This theorem combines the
 preceding reductions under the displayed left-multiplied comparison. It does not
-derive that comparison from the source sentence on closing the boundaries in
-arXiv:2011.12127, Section IV.C, lines 2078--2079. The source does not display
-this formula; see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+derive that comparison from the closure-property sentence at the periodic
+boundary in arXiv:2011.12127, Section IV.C, lines 2078--2079. The source does
+not display this formula; see
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -235,7 +238,7 @@ theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_wo
   exact closure_property_auxiliary_boundary_product_eq_of_mirror_left_word_products
     (A := A) hInj hL₀ hM YAt hYAt X μ hOneSided.1 hLeft
 
-/-- Boundary restrictions from the left-multiplied closing-boundary comparison.
+/-- Boundary restrictions from the left-multiplied boundary-crossing comparison.
 
 Let \(\psi=\Gamma_{M+1}(X)\), and let \(Y_i(\tau)\) represent the
 length-\((L_0+1)\) cyclic restrictions of \(\psi\). If, for every boundary
@@ -253,9 +256,9 @@ then
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
 
-**Scope restriction (left-multiplied closing-boundary comparison):** This theorem
+**Scope restriction (left-multiplied boundary-crossing comparison):** This theorem
 assumes the displayed left-multiplied comparison rather than deriving it from
-the closing-boundary equality in arXiv:2011.12127, Section IV.C,
+the periodic-boundary closure-property step in arXiv:2011.12127, Section IV.C,
 lines 2078--2079. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words
@@ -298,13 +301,13 @@ theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap_left_words
   intro η j
   exact (hOneSided.1 η j).trans (hMirrorRight η j).symm
 
-/-- Equality of the two cyclic restrictions used when closing the boundary.
+/-- Equality of the two cyclic restrictions used at the periodic boundary.
 
 Let \(\psi=\Gamma_{M+1}(X)\), and suppose each length-\((L_0+1)\) cyclic
 restriction of \(\psi\) lies in \(G_{L_0+1}(A)\). For every outside letter
 \(\eta\), the two outside configurations \(\tau^+_\eta(\mu)\) and
 \(\tau^-_\eta(\mu)\) are local coordinate notation for the cyclic support
-crossing the last site and the opposite boundary-crossing support, with the same
+crossing the last site and the second boundary-crossing support, with the same
 word \(\mu\) on the sites outside the window. The closure-property comparison
 at the periodic boundary is the equality
 \[
@@ -323,8 +326,8 @@ for all outside letters \(\eta\) and physical letters \(j\).
 
 **Unfaithful:** This proof relies on
 `closure_property_boundary_block_window_equation_of_groundSpaceMap`, whose proof
-is the open boundary matrix identity in the argument for closing the periodic
-boundary in arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
+is the open boundary matrix identity in the periodic-boundary closure-property
+argument in arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
 block-injective commutation lemma turns that coordinate comparison into the
 one-site commutation identity for the boundary matrix \(X\). The verified
 boundary-restriction equality lemma
@@ -335,7 +338,7 @@ closure-property step at the periodic boundary to this boundary matrix identity,
 which is the transitive dependency for the coordinate consequences below.
 Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
-boundary matrix identity from the closing-boundary local constraints; tracked in
+boundary matrix identity from the periodic-boundary local constraints; tracked in
 issue 2405. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -448,12 +451,12 @@ periodic-boundary coordinate comparison is
 
 **Unfaithful:** This proof currently relies on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`, whose proof
-depends on the unproved boundary matrix identity at the closing boundary. This
-deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
-the coordinate form of the inverting-and-growing-back argument when closing the
-periodic boundary.
+depends on the unproved boundary matrix identity for the periodic-boundary
+comparison. This deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079
+by leaving open the coordinate form of the inverting-and-growing-back argument
+at the periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the boundary matrix identity from the closing-boundary local
+Elimination: prove the boundary matrix identity from the periodic-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
 in issue 2405.
 
@@ -514,13 +517,14 @@ remaining periodic-boundary coordinate comparison is
 
 **Unfaithful:** This proof uses
 `closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap`; that theorem
-transitively depends on the unproved boundary matrix identity at the closing
-boundary in `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
+transitively depends on the unproved boundary matrix identity for the
+periodic-boundary comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
 deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
 the coordinate form of the inverting-and-growing-back argument when closing the
 periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the boundary matrix identity from the closing-boundary local
+Elimination: prove the boundary matrix identity from the periodic-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
 in issue 2405. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
@@ -563,8 +567,8 @@ theorem closure_property_mirror_left_word_products_of_groundSpaceMap
             evalWord A (List.ofFn σ)) := by
           rw [hOneSided.1 η j]
 
-/-- Auxiliary boundary-condition product equation needed at the closing
-boundary.
+/-- Auxiliary boundary-condition product equation needed for the
+periodic-boundary comparison.
 
 For each pair \(j,\sigma\), this states the existence of boundary conditions
 \(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with the same complementary
@@ -577,13 +581,14 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
 
 **Unfaithful:** This proof currently relies on
 `closure_property_mirror_left_word_products_of_groundSpaceMap`, which
-transitively depends on the unproved boundary matrix identity at the closing
-boundary in `closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
+transitively depends on the unproved boundary matrix identity for the
+periodic-boundary comparison in
+`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
 deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
 the coordinate form of the inverting-and-growing-back argument when closing the
 periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the boundary matrix identity from the closing-boundary local
+Elimination: prove the boundary matrix identity from the periodic-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
 in issue 2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingWitness.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingWitness.lean
@@ -12,8 +12,8 @@ import TNLean.MPS.ParentHamiltonian.WrappingWindow
 Coordinate identities saying that outside configurations with the same labels on
 the sites outside a cyclic window determine the same boundary-crossing witness.
 These are the witness-independence facts needed to choose a representative
-outside configuration for the closing-boundary coordinate comparison in the
-step of closing the periodic boundary.
+outside configuration for the coordinate comparison used when closing the
+periodic boundary.
 -/
 
 open scoped Matrix BigOperators
@@ -135,7 +135,7 @@ theorem wrappedMiddleBackground_first_products_eq_of_complement_eq
 If an outside configuration has the same word on the sites outside the window
 as the local coordinate configuration \(\tau^+_\eta(\mu)\), then the two
 matrices representing the last-site restriction are equal. This is the
-last-site witness-independence step for the closing-boundary coordinate
+last-site witness-independence step for the periodic-boundary coordinate
 comparison. -/
 theorem wrappedMiddleBackground_witness_eq_of_complement_eq
     {A : MPSTensor d D} {L₀ M : ℕ}
@@ -157,7 +157,7 @@ theorem wrappedMiddleBackground_witness_eq_of_complement_eq
     (wrappedMiddleBackground_first_products_eq_of_complement_eq
       (A := A) hInj hL₀ hM η μ ρ hρ hYρ hYτ)
 
-/-- For the opposite boundary-crossing interval, any outside configuration with
+/-- For the second boundary-crossing interval, any outside configuration with
 the same word on the sites outside the window gives the same restriction as the
 local coordinate configuration \(\tau^-_\eta(\mu)\) used here for a coordinate
 form of the closure property. -/
@@ -205,7 +205,7 @@ theorem cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
     omega
   rwa [hsite] at hrho
 
-/-- Matrix consequence at the opposite boundary-crossing support. If an
+/-- Matrix consequence at the second boundary-crossing support. If an
 outside configuration has the same word on the sites outside the window as
 \(\tau^-_\eta(\mu)\), then
 \[
@@ -234,12 +234,12 @@ theorem mirrorMiddleBackground_first_products_eq_of_complement_eq
     (cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
 
-/-- Witness uniqueness at the opposite boundary-crossing support.
+/-- Witness uniqueness at the second boundary-crossing support.
 
 If an outside configuration has the same word on the sites outside the window
 as the local coordinate configuration \(\tau^-_\eta(\mu)\), then the two
-matrices representing the opposite boundary-crossing restriction are equal. This
-is the opposite-window witness-independence step for the closing-boundary
+matrices representing the second boundary-crossing restriction are equal. This
+is the second-window witness-independence step for the periodic-boundary
 coordinate comparison. -/
 theorem mirrorMiddleBackground_witness_eq_of_complement_eq
     {A : MPSTensor d D} {L₀ M : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean
@@ -11,7 +11,8 @@ The cyclic-local propagation step for the block-diagonal parent Hamiltonian: if
 the local ground space \(G_L(A)\) lies in \(S_L\) and the subspaces propagate by
 \(\mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d = S_{m+1}\), then the cyclic
 chain ground space \(\mathcal G_{N,L}(A)\) lies in \(S_N\). This is the
-cyclic-local part of PGVWC07, Theorem 12, before the boundary-closing step.
+cyclic-local part of PGVWC07, Theorem 12, before the periodic-boundary
+comparison.
 -/
 
 open scoped Matrix BigOperators
@@ -28,7 +29,7 @@ If \(G_L(A)\subseteq S_L\) and the subspaces \(S_m\) satisfy
 \]
 for all \(m\ge L\), then \(\mathcal G_{N,L}(A)\subseteq S_N\).  This is the
 cyclic-local part of the proof of PGVWC07, Theorem 12, before the
-boundary-closing step. -/
+periodic-boundary comparison. -/
 theorem chainGroundSpace_le_of_local_le_restriction_intersection_submodules
     (A : MPSTensor d D) (S : (M : ℕ) → Submodule ℂ (NSiteSpace d M))
     {L N : ℕ} (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N) [NeZero d]

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -172,9 +172,9 @@ the intersections
 \[
   \mathbb C^d\otimes S_M \cap S_M\otimes \mathbb C^d = S_{M+1}
 \]
-hold for all \(M\ge L\), then the state lies in \(S_N\). This is the open-segment
-iteration used in PGVWC07, Theorem 12, before the periodic-chain
-boundary-closing step. -/
+hold for all \(M\ge L\), then the state lies in \(S_N\). This is the
+open-segment iteration used in PGVWC07, Theorem 12, before the periodic-chain
+conclusion. -/
 theorem contiguous_mem_of_restriction_intersection_submodules
     (S : (M : ℕ) → Submodule ℂ (NSiteSpace d M))
     {L N : ℕ} (hL : 0 < L) (hLN : L ≤ N) [NeZero d]

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -20,7 +20,7 @@ ground space is spanned by the MPS vector
 
 For injective \(A\) and lengths \(2 \le N\), \(1<L\le N\), the periodic-chain
 ground space is one-dimensional, spanned by the MPS vector, via open-chain
-build-up and the step of closing the periodic boundary:
+build-up and the closure-property step at the periodic boundary:
 
 1. **Open chain**: By iterated application of the intersection property,
    any state satisfying all local ground-space conditions has the form
@@ -666,8 +666,8 @@ theorem wrapped_mirror_witness_agree_of_right_products
       Ymirror (mirrorMiddleBackground L₀ N η μ) := by
   exact right_witness_unique_of_isNBlkInjective (A := A) hInj hL₀ hProd
 
-/-- The full restriction equality at the closed boundary follows from equality
-after fixing each first physical index:
+/-- The full equality of the two boundary-crossing restrictions follows from
+equality after fixing each first physical index:
 \((\forall j,\ R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu})
 \Rightarrow B^+_{\eta,\mu}=B^-_{\eta,\mu}\).  This is a coordinate form of
 the comparison described in arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
@@ -814,8 +814,8 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     (A := A) hInj hL₀ hM hψ hψX YAt hYAt η μ j
   exact hLeft.trans ((congrArg (fun Y => groundSpaceMap A L₀ Y) hProd).trans hRight.symm)
 
-/-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) at the closed boundary,
-obtained from the first-letter family.
+/-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) for the two
+boundary-crossing restrictions, obtained from the first-letter family.
 **Unfaithful:** This proof relies directly or transitively on
 `closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
 form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
@@ -852,7 +852,7 @@ Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction:** \(L₀+1<N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Scope restriction:** \(L₀+1<N\); see the same paper-gap note. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -899,7 +899,7 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction:** \(L₀+1<N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Scope restriction:** \(L₀+1<N\); see the same paper-gap note. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
     (_hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -933,7 +933,7 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction:** \(L₀+1<N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Scope restriction:** \(L₀+1<N\); see the same paper-gap note. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {L N : ℕ} (hN : 2 ≤ N) (hL : L₀ < L) (hLN : L ≤ N)
@@ -987,7 +987,7 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 **Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
 whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
-**Scope restriction:** \(L₀+1<N\); see `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+**Scope restriction:** \(L₀+1<N\); see the same paper-gap note. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {N : ℕ} (hN : L₀ + 1 < N) :

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -49,7 +49,7 @@ The main formal statements show that the two identities
 imply commutation with fixed-length word products; that fixed-length
 commutation propagates to long words; and that block injectivity then gives
 \(XA_j=A_jX\) for every one-site matrix. They also record the one-sided
-uniqueness consequences of block injectivity used in the boundary-closing
+uniqueness consequences of block injectivity used in the periodic-boundary
 comparison.
 
 ## References
@@ -401,7 +401,7 @@ private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
 
 /-- Block injectivity strips the cyclic-window tail block at the boundary and
 yields the one-sided compatibility \(C_τ A_j X = Y_τ A_j\). The
-complementary opposite cyclic-window comparison is the remaining local step
+complementary second cyclic-window comparison is the remaining local step
 needed for the two-sided relation. -/
 theorem wrapping_window_compatibility_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -447,7 +447,7 @@ theorem wrapping_window_compatibility_of_isNBlkInjective
         (evalWord A (List.ofFn σ_tail) * (Y τ * A j)) := by
           simp [Matrix.mul_assoc]
 
-/-- The opposite cyclic position used in the closure property exposes the
+/-- The second cyclic position used in the closure property exposes the
 compatibility \(X A_j C_τ = A_j Y_τ\) after block-injective stripping of the
 trailing \(L₀\)-site block. -/
 theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
@@ -605,7 +605,7 @@ The one-sided inputs have the form
   \qquad
   X A^j A^\mu = A^jY^-_{\tau^-_\eta(\mu)}.
 \]
-The boundary-closing comparison
+The boundary-crossing comparison
 \[
   Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}
 \]
@@ -753,7 +753,7 @@ theorem boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes
 /-- If left multiplication by \(Z\) annihilates every word product of length \(k\),
 and words of some longer length \(n\) span the full matrix algebra, then \(Z = 0\).
 
-This is the padding form needed in the normal boundary-closing argument: a
+This is the padding form needed in the normal periodic-boundary argument: a
 zero-product relation obtained for a short complement word can be multiplied by
 all padding words up to any length whose exact word span is \(\top\). -/
 theorem eq_zero_of_mul_evalWord_eq_zero_of_wordSpan_eq_top
@@ -812,9 +812,10 @@ theorem eq_zero_of_mul_evalWord_eq_zero_of_isNBlkInjective_of_le_mul
 /-- A right boundary witness is unique once its products with all one-site
 tensors are fixed.
 
-This is the one-sided uniqueness consequence of block injectivity used in
-boundary-closing arguments: a positive block-injective word span turns equality
-after multiplying by each one-site tensor into equality of the boundary matrices. -/
+This is the one-sided uniqueness consequence of block injectivity used in the
+periodic-boundary comparison: a positive block-injective word span turns
+equality after multiplying by each one-site tensor into equality of the
+boundary matrices. -/
 theorem right_witness_unique_of_isNBlkInjective
     {A : MPSTensor d D} {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
     {Y₁ Y₂ : Matrix (Fin D) (Fin D) ℂ}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -18,8 +18,8 @@ an injective tensor, when $N\ge2$ and $1<L\le N$, the parent Hamiltonian is
 frustration-free and the periodic MPS vector $V^{(N)}(A)$ is its unique ground
 state, obtained from the intersection property of the local ground spaces. For a
 normal tensor the corresponding conclusion follows, under the stated
-closed-boundary comparison and length hypotheses, after inverting a long-word
-commutation back to the injectivity length and closing the periodic boundary.
+periodic-boundary comparison and length hypotheses, after inverting a long-word
+commutation back to the injectivity length.
 When the length-two local terms commute, the construction records the
 zero-energy part of the condition that $V^{(N)}(A)$ is a ground state of a
 nearest-neighbor commuting parent Hamiltonian in the pure-state theorem relating
@@ -32,7 +32,7 @@ $A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$,
 (\cite[Theorem~12]{PerezGarcia2007Matrix}) states that the periodic
 parent-Hamiltonian ground space is spanned by the vectors
 $\{V^{(N)}(A_j)\}$. The sections below establish open-segment recursion and
-conditional boundary-closing reductions toward this theorem.
+conditional reductions to the periodic-boundary comparison toward this theorem.
 
 \input{chapter/ch13_parent_hamiltonian_injective_ground_spaces}
 \input{chapter/ch13_parent_hamiltonian_injective_boundary}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_boundary.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_boundary.tex
@@ -1,7 +1,7 @@
 
-\section{Boundary closing for injective tensors}\label{sec:injective_boundary_closing}
+\section{Periodic-boundary comparison for injective tensors}\label{sec:injective_boundary_closing}
 
-On the periodic ring the two cyclic supports that cross the closing boundary
+On the periodic ring the two cyclic supports that cross the periodic-boundary cut
 expose the same complementary word, and matching their boundary matrices forces
 $X$ to commute with every $A^j$. This section derives the boundary-crossing
 compatibilities $C^+_\tau A^j X = Y_\tau A^j$ and $X A^j C^-_\tau = A^j Y_\tau$
@@ -13,7 +13,7 @@ and combines them into the commutation $X A^j = A^j X$.
     \leanok
     \uses{def:l_blk_injective, rem:cyclic_window_operators}
     Assume $A$ is $L_0$-block-injective with $L_0>0$ and $M \ge L_0$.
-    If the reduced cyclic interval used in closing the boundary at the last site
+    If the reduced cyclic interval crossing the last site
     has boundary matrices $Y_\tau$, then for every physical letter $j$ one has
     \begin{equation}\label{eq:ph_wrapped_window_compat}
         C^+_\tau A^j X = Y_\tau A^j,
@@ -30,25 +30,25 @@ and combines them into the commutation $X A^j = A^j X$.
     identity~(\ref{eq:ph_wrapped_window_compat}).
 \end{proof}
 
-\begin{lemma}[Boundary-crossing compatibility at the opposite boundary position]%
+\begin{lemma}[Boundary-crossing compatibility at the second boundary position]%
     \label{lem:mirror_wrapped_window_one_sided_compatibility}
     \lean{MPSTensor.wrapping_window_mirror_compatibility_of_isNBlkInjective}
     \leanok
     \uses{def:l_blk_injective, rem:cyclic_window_operators}
     Assume $A$ is $L_0$-block-injective with $L_0>0$ and $M \ge L_0$.
-    If the opposite reduced cyclic interval used in closing the boundary has
+    If the second boundary-crossing reduced cyclic interval has
     boundary matrices $Y_\tau$, then
     \[
         X A^j C^-_\tau = A^j Y_\tau
     \]
     for every physical letter $j$, where $C^-_\tau$ is the complementary word
-    seen from the opposite cyclic position.
+    seen from the second cyclic position.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{lem:ground_space_map_injective_blk}
-    Factor the cyclic word at the opposite cyclic position, rotate
+    Factor the cyclic word at the second cyclic position, rotate
     the trace, and use injectivity of $\Gamma_{L_0}$ to remove the
     length-$L_0$ test word.
 \end{proof}
@@ -72,8 +72,7 @@ and combines them into the commutation $X A^j = A^j X$.
         X A^j C^-_\tau = A^j Y^-_\tau,
     \end{equation}
     where $C^+_\tau$ and $C^-_\tau$ are the complementary words exposed by the
-    two opposite cyclic intervals used in closing the boundary, both of reduced
-    length $L_0+1$.
+    two boundary-crossing cyclic intervals, both of reduced length $L_0+1$.
 \end{theorem}
 
 \begin{proof}
@@ -117,7 +116,7 @@ and combines them into the commutation $X A^j = A^j X$.
 \begin{proof}
     \leanok
     Substitute $\psi=\Gamma_{M+1}(X)$ in the two cyclic restrictions at the
-    last site and at the opposite boundary-crossing support. Lemmas
+    last site and at the second boundary-crossing support. Lemmas
     \ref{lem:wrapped_window_one_sided_compatibility} and
     \ref{lem:mirror_wrapped_window_one_sided_compatibility} then give the two
     equations in~(\ref{eq:ph_closure_boundary_crossing_gamma_equations}).
@@ -171,7 +170,7 @@ and combines them into the commutation $X A^j = A^j X$.
     used outside the complementary sites and a word $\mu$ of length
     $M+1-(L_0+1)$. Write $\tau^+_\eta(\mu)$ for the boundary condition at the
     support crossing the last site and $\tau^-_\eta(\mu)$ for the boundary
-    condition at the opposite boundary-crossing support. Their exposed complements
+    condition at the second boundary-crossing support. Their exposed complements
     are both exactly $\mu$.
 \end{lemma}
 
@@ -179,7 +178,7 @@ and combines them into the commutation $X A^j = A^j X$.
     \leanok
     Put the same letter $\eta$ on the remaining sites. Fill the physical sites
     $L_0,\ldots,M-1$ with $\mu$ for the support crossing the last site, and fill
-    the sites $1,\ldots,M-L_0$ with $\mu$ for the opposite boundary-crossing
+    the sites $1,\ldots,M-L_0$ with $\mu$ for the second boundary-crossing
     support.
     The two complement-extraction identities are then immediate from the index
     arithmetic. The same outside-site calculation gives, for any $\rho$ with
@@ -226,7 +225,7 @@ and combines them into the commutation $X A^j = A^j X$.
         \Longrightarrow
         Y_\rho A^j = Y_{\tau^+_\eta(\mu)}A^j,
     \]
-    and the opposite boundary-crossing condition satisfies
+    and the second boundary-crossing condition satisfies
     \[
         \rho_{k+1}=\mu_k
         \Longrightarrow
@@ -350,7 +349,7 @@ and combines them into the commutation $X A^j = A^j X$.
     product equation for the chosen pair $j,\sigma$.
 \end{proof}
 
-\begin{lemma}[Endpoint words at the closing boundary]
+\begin{lemma}[Endpoint words for the periodic-boundary windows]
     \label{lem:boundary_closing_endpoint_word_products}
     \lean{MPSTensor.boundary_closing_endpoint_word_products_common_background}
     \leanok
@@ -389,7 +388,7 @@ and combines them into the commutation $X A^j = A^j X$.
     displayed product equation.
 \end{proof}
 
-\begin{lemma}[Boundary-condition product at the closing boundary]
+\begin{lemma}[Boundary-condition product for the periodic-boundary windows]
     \label{lem:closure_property_boundary_condition_product_window_witnesses}
     \lean{MPSTensor.closure_property_boundary_condition_product_of_window_witnesses,
         MPSTensor.closure_property_boundary_condition_product_of_window_witnesses_mul_right}
@@ -439,7 +438,7 @@ and combines them into the commutation $X A^j = A^j X$.
     equality by $R$.
 \end{proof}
 
-\begin{lemma}[Transport followed by the last-boundary equation]
+\begin{lemma}[Transport followed by the one-sided boundary equation]
     \label{lem:boundary_transport_wrapped_product_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_condition_transport_wrapped_product_of_groundSpaceMap}
     \leanok
@@ -472,7 +471,7 @@ and combines them into the commutation $X A^j = A^j X$.
         =
         A^{\rho_1}\cdots A^{\rho_{L_0-1}}Y_M(\rho)A^j .
     \]
-    The last-boundary one-sided equation for $\psi=\Gamma_{M+1}(X)$ gives
+    The one-sided equation for the window beginning at $M$ gives
     \[
         Y_M(\rho)A^j
         =
@@ -481,7 +480,7 @@ and combines them into the commutation $X A^j = A^j X$.
     Substitution gives the displayed formula.
 \end{proof}
 
-\begin{lemma}[Long boundary-condition product at the closing boundary]
+\begin{lemma}[Long boundary-condition product for the periodic-boundary windows]
     \label{lem:closure_property_boundary_condition_long_product_window_witnesses}
     \lean{MPSTensor.closure_property_boundary_condition_long_product_of_window_witnesses}
     \leanok
@@ -552,7 +551,7 @@ and combines them into the commutation $X A^j = A^j X$.
     condition
     $\tau^+_\eta(\mu)$. Lemma~\ref{lem:wrapped_middle_backgrounds} rewrites the
     first cyclic-window complement as $\mu$, while the assumed comparison at
-    $\tau^-_\eta(\mu)$ rewrites the opposite boundary matrix to the same
+    $\tau^-_\eta(\mu)$ rewrites the second boundary matrix to the same
     $Y_\mu$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -1,7 +1,7 @@
 
-\section{Closing the periodic boundary for normal tensors}\label{sec:normal_boundary_closing}
+\section{Periodic-boundary comparison for normal tensors}\label{sec:normal_boundary_closing}
 
-This section isolates the comparison used when closing the periodic boundary.
+This section isolates the periodic-boundary comparison.
 It compares the two boundary-crossing restrictions
 $\operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)$ and
 $\operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)$ of a chain ground
@@ -91,7 +91,7 @@ closure-property comparison.
     gives $X A^j-A^jX=0$.
 \end{proof}
 
-\begin{lemma}[Coordinate matrix identity for closing the periodic boundary]
+\begin{lemma}[Coordinate matrix identity for the periodic-boundary closure property]
     \label{lem:closure_property_boundary_block_window_equation_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}
     \leanok
@@ -113,7 +113,7 @@ closure-property comparison.
 \begin{proof}
     \notready
     This is the coordinate matrix formulation of the part of the
-    inverting-and-growing-back argument used when closing the periodic boundary in
+    inverting-and-growing-back argument at the periodic boundary in
     \cite[Section~IV.C, lines~2078--2079]{Cirac2021Matrix}. A complete proof
     must derive the displayed equation from the cyclic-window constraints
     recorded above.
@@ -217,7 +217,7 @@ closure-property comparison.
     \[
         Y_\rho=Y_{\tau^+_\eta(\mu)}.
     \]
-    The same assertion holds for the opposite boundary-crossing window:
+    The same assertion holds for the second boundary-crossing window:
     if $\rho$ has the same outside word as $\tau^-_\eta(\mu)$, then
     \[
         Y_\rho=Y_{\tau^-_\eta(\mu)}.
@@ -787,7 +787,7 @@ closure-property comparison.
     Lemma~\ref{lem:closure_property_auxiliary_product_from_opposite_boundary_left_words}
     then give the displayed boundary conditions and product equation.
     % Source note: arXiv:2011.12127, Section IV.C, lines 2078--2079,
-    % says that the corresponding argument for closing the periodic boundary is analogous.
+    % says that the corresponding periodic-boundary argument is analogous.
     % The assumed equation is the coordinate form isolated in
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
@@ -881,7 +881,7 @@ closure-property comparison.
     \]
     and put the letter $\eta$ on the remaining sites. The notation
     $\tau^\pm_\eta(\mu)$ is a coordinate parametrization for the comparison used
-    when closing the periodic boundary in \cite[Section~IV.C, lines~2078--2079]
+    at the periodic boundary in \cite[Section~IV.C, lines~2078--2079]
     {Cirac2021Matrix}; it is not notation from the source.
     The corresponding boundary-crossing restriction equality is
     \[
@@ -924,7 +924,7 @@ closure-property comparison.
     equality has been reduced to the boundary matrix identity in the
     closure-property comparison. The derivation of that identity from the
     cyclic-window constraints at the periodic boundary is the remaining part of
-    the source sentence on closing the periodic boundary in
+    the source closure-property sentence at the periodic boundary in
     \cite[lines~2078--2079]{Cirac2021Matrix}; it is recorded in
     \path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex}.
 \end{proof}
@@ -1055,7 +1055,7 @@ left-multiplied boundary comparison.
     \]
 \end{proof}
 
-\begin{theorem}[Left-multiplied coordinate comparison for closing the periodic boundary]
+\begin{theorem}[Left-multiplied coordinate comparison at the periodic boundary]
     \label{thm:closure_property_mirror_left_word_products_ground_space}
     \lean{MPSTensor.closure_property_mirror_left_word_products_of_groundSpaceMap}
     \leanok
@@ -1098,7 +1098,7 @@ left-multiplied boundary comparison.
     Substitution gives the displayed identity.
     % The cited paragraph does not display the first comparison. It is the
     % coordinate reconstruction isolated here for the boundary-crossing
-    % restrictions used when closing the periodic boundary in
+    % restrictions used at the periodic boundary in
     % \cite[lines~2078--2079]{Cirac2021Matrix}. Remaining gap recorded in
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
@@ -1205,12 +1205,12 @@ left-multiplied boundary comparison.
     \]
     % The cited paragraph does not display this formula. It is the coordinate
     % reconstruction isolated here for the boundary-crossing restrictions used
-    % when closing the periodic boundary in \cite[lines~2078--2079]{Cirac2021Matrix}.
+    % at the periodic boundary in \cite[lines~2078--2079]{Cirac2021Matrix}.
     % Remaining gap recorded in
     % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
-\begin{theorem}[Product equality after closing the periodic boundary]
+\begin{theorem}[Product equality at the periodic boundary]
     \label{thm:boundary_closing_word_equation_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_closing_product_eq_of_chainGroundSpace}
     \leanok
@@ -1258,10 +1258,10 @@ left-multiplied boundary comparison.
         =
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^jA^\sigma,
     \]
-    which is the product equality needed when closing the periodic boundary.
+    which is the product equality needed for the periodic-boundary comparison.
 \end{proof}
 
-\begin{theorem}[Right-product equality after closing the periodic boundary]
+\begin{theorem}[Right-product equality at the periodic boundary]
     \label{thm:boundary_closing_right_products_chain_ground_space}
     \lean{MPSTensor.closure_property_boundary_right_products_eq_of_chainGroundSpace}
     \leanok
@@ -1284,7 +1284,7 @@ left-multiplied boundary comparison.
         Y_{M+1-L_0}(\tau^{-}_{\eta}(\mu))A^j.
     \]
     This is the one-site product equality used to compare the two boundary
-    matrices when closing the periodic boundary.
+    matrices in the periodic-boundary comparison.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -54,12 +54,12 @@ The source then says that this argument can be iterated. Hence the ground space
 obtained from all length-$L_0+1$ terms agrees with the ground space obtained from
 all longer length-$L_0+k$ terms. When $k=L_0$, the proof either appeals to the
 previous $2L_0$-range uniqueness theorem or applies the same kind of argument
-when closing the periodic boundary. The resulting theorem states that a normal
+at the periodic boundary. The resulting theorem states that a normal
 MPS which becomes injective after blocking $L_0$ sites has a unique ground state
 for the parent Hamiltonian whose interaction range is $L_0+1$.
 \footnote{Source location:
 \path{Papers/2011.12127/TN-Review-main.tex}:2078--2079 for the iteration and
-boundary-closing sentence, and
+periodic-boundary closure-property sentence, and
 \path{Papers/2011.12127/TN-Review-main.tex}:2087--2090 for the theorem labeled
 \path{thm:4:unique-gs-L0_plus_1}.}
 
@@ -163,10 +163,11 @@ the boundary-crossing word.
 
 In the coordinate form used here, \(\mu\) denotes the nonempty word placed on
 the sites outside the two cyclic windows and \(\eta\) is the letter used on the
-remaining outside sites. This is a coordinate form of the boundary-closing
-sentence in Section~IV.C, lines 2078--2079. The reduction isolates the movement
-of \(X\) as an identity between boundary-restriction matrices in the
-closure-property comparison, which implies the one-site commutation identity.
+remaining outside sites. This is a coordinate form of the periodic-boundary
+closure-property sentence in Section~IV.C, lines 2078--2079. The reduction
+isolates the movement of \(X\) as an identity between boundary-restriction
+matrices in the closure-property comparison, which implies the one-site
+commutation identity.
 After choosing boundary-restriction matrices for the two boundary-crossing
 restrictions, the verified one-sided boundary-product lemma gives, for every
 physical letter \(j\),
@@ -175,9 +176,9 @@ physical letter \(j\),
   \qquad
   XA^jA^\mu=A^jV_\eta .
 \]
-Here \(W_\eta\) is the boundary-restriction matrix for the last-site boundary
-restriction and \(V_\eta\) is the boundary-restriction matrix for the opposite
-boundary-crossing restriction.
+Here \(W_\eta\) is the boundary-restriction matrix for the boundary-crossing
+restriction beginning at the last site, and \(V_\eta\) is the
+boundary-restriction matrix for the second boundary-crossing restriction.
 \footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:338 for
 \path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
@@ -189,7 +190,8 @@ the block-injective commutation lemma: for every physical letter \(k\),
 \[
   XA^k=A^kX.
 \]
-This is the one-site commutation step in the boundary-closing argument.\footnote{
+This is the one-site commutation step in the periodic-boundary closure-property
+argument.\footnote{
 In the formal proof of
 \leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
 the commutation identity is obtained at
@@ -233,10 +235,10 @@ then \(XA^k=A^kX\) for every physical letter \(k\).\footnote{Formal location:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:46 for
 \leanid{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}.}
 The remaining mathematical task is therefore to derive this matrix comparison
-from the closing-boundary local constraints. After that equation is
+from the periodic-boundary local constraints. After that equation is
 proved, the block-injective commutation lemma supplies the one-site commutation
 identity, the boundary-restriction equality lemma supplies the equality of the
-two boundary restrictions, and the boundary-closing step follows.\footnote{The
+two boundary restrictions, and the periodic-boundary comparison follows.\footnote{The
 present source-labelled statement for this step is
 \leanid{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}.}
 
@@ -273,14 +275,14 @@ source statement.
 
 The formal statements add the strict hypothesis $L_0+1<N$, so they cover only
 $N\ge L_0+2$ and exclude that minimal ring. The restriction is forced by the
-boundary-closing argument: the closure-property comparison ranges over a
+periodic-boundary closure-property argument: the comparison ranges over a
 complement word $\mu\colon \mathrm{Fin}\,(N-(L_0+1))\to\mathrm{Fin}\,d$, which is
 the empty function exactly when $N=L_0+1$, so the two boundary-crossing windows
 coincide and the comparison carries no information. This is a genuine narrowing
 of the source theorem rather than a typo: the conclusion at $N=L_0+1$ is true
 (it is the source's minimal case), but the present proof does not reach it.
 
-Elimination plan: prove the empty-complement case of the boundary-closing
+Elimination plan: prove the empty-complement case of the periodic-boundary
 argument. When $N=L_0+1$, the complement word has length zero and the two
 boundary-crossing words coincide; one must still use the cyclic local constraints
 to identify the periodic ground space with the MPS line. Thus the missing step is
@@ -305,7 +307,7 @@ source-error claim. The cited Cirac--Perez-Garcia--Schuch--Verstraete 2021
 argument is not refuted. The source compresses two mathematical steps which the
 formalization must keep separate: the $B$-region inverting and growing-back
 open-chain range reduction, and the movement of the trace-form matrix \(X\)
-through the boundary-crossing word when closing the periodic boundary.
+through the boundary-crossing word in the periodic-boundary comparison.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.


### PR DESCRIPTION
## Summary

- Replace remaining reader-facing parent-Hamiltonian prose that described a "closing-boundary" or "closed-boundary" step with periodic-boundary and boundary-crossing terminology.
- Align the normal-range paper-gap note and the corresponding blueprint section headings with the same language.
- Leave Lean declarations, statements, hypotheses, labels, and proof bodies unchanged.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `lake env lean` on the seven touched Lean files from the main checkout, with only the existing `sorry` warning for issue 2405

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and prose edits only; no executable Lean or proof logic changes.
> 
> **Overview**
> This PR is **documentation-only**: it renames reader-facing parent-Hamiltonian language from “closing-boundary” / “closed-boundary” / “boundary-closing step” to **periodic-boundary comparison**, **boundary-crossing windows**, and related phrasing.
> 
> Updates span Lean module and theorem docstrings (`BoundaryClosingCoordinate`, `BoundaryClosingStripping`, `BoundaryClosingWitness`, `CyclicSubmoduleIteration`, `CyclicWindow`, `UniqueGroundState`, `WrappingWindow`), blueprint chapter 13 (section titles and narrative in injective/normal boundary and closing sections), and `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. **Lean declarations, hypotheses, proofs, and labels are unchanged**; open-gap and unfaithful-dependency notes still point at the same lemmas and issue 2405.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab57812cdb9e0ca480708dfeb8dacfee87c66bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->