### PR TITLE
doc(parent): align BNT periodic-boundary prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -68,7 +68,7 @@ This is the equation used in PGVWC07, Theorem 12, proof lines
 
 **Unfaithful:** This proof relies on
 `wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
+transitively uses the periodic-boundary coordinate comparison rather than
 deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors_c1
@@ -184,7 +184,7 @@ then gives the simultaneous product span for every
 
 **Unfaithful:** This proof relies on
 `hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
+transitively uses the periodic-boundary coordinate comparison rather than
 deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
@@ -247,7 +247,7 @@ spaces.
 
 **Unfaithful:** This proof relies on
 `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, which transitively uses
-the boundary-closing coordinate comparison rather than deriving it from
+the periodic-boundary coordinate comparison rather than deriving it from
 arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
@@ -312,7 +312,7 @@ length above the BNT block-separation bound.
 
 **Unfaithful:** This proof relies on
 `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, which transitively uses
-the boundary-closing coordinate comparison rather than deriving it from
+the periodic-boundary coordinate comparison rather than deriving it from
 arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
@@ -390,8 +390,9 @@ theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital
 direct sum.
 
 **Unfaithful:** This proof relies on the finite-\(C_1\) internal-direct-sum and
-block-intersection conclusions above, which transitively use the boundary-closing
-coordinate comparison rather than deriving it from arXiv:2011.12127,
+block-intersection conclusions above, which transitively use the
+periodic-boundary coordinate comparison rather than deriving it from
+arXiv:2011.12127,
 Section IV.C, lines 2078--2079. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
@@ -523,7 +524,7 @@ separate one-site injectivity assumption.
 
 **Unfaithful:** This proof relies on
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
+transitively uses the periodic-boundary coordinate comparison rather than
 deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
 in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
 theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital_c1

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -79,7 +79,7 @@ Parent-Hamiltonian notes live here too, but they are not part of the current
 non-periodic FT cleanup loop unless explicitly brought back into scope.
 
 - `cpgsv21_normal_range_reduction.tex` records the normal parent-Hamiltonian
-  range-reduction comparison and the remaining boundary-closing identity.
+  range-reduction comparison and the remaining periodic-boundary identity.
 - `cpgsv21_block_diagonal_parent_ground_space.tex` records the degenerate
   parent-Hamiltonian block-diagonal boundary-condition theorem behind the
   periodic block decomposition and the BNT ground-space span.

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -364,11 +364,11 @@ in the more conservative range
 \begin{align}
   L\ge (L_0+1)+3(b-1)(L_0+1)+1.
 \end{align}
-The boundary-closing reductions now separate into three forms: a decomposition
-into blockwise vectors with periodic boundary conditions, a block-diagonal
-boundary representation whose components already belong to the corresponding
-blockwise periodic-boundary spaces, and the boundary-crossing coordinate
-formulation displayed above.\footnote{Lean declarations:
+The periodic-boundary comparison reductions now separate into three forms: a
+decomposition into blockwise vectors with periodic boundary conditions, a
+block-diagonal boundary representation whose components already belong to the
+corresponding blockwise periodic-boundary spaces, and the boundary-crossing
+coordinate formulation displayed above.\footnote{Lean declarations:
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_boundary_decomposition},
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_le_iSup_of_blockDiagonal_boundary_groundSpaceMap},
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition},

--- a/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
+++ b/docs/paper-gaps/rmp_example_parent_hamiltonian_scope.tex
@@ -144,7 +144,7 @@ Hamiltonian is the sum of translated local terms.\footnote{See
 The theorem that the parent Hamiltonian annihilates the MPS vector is already
 available.\footnote{See
 \path{TNLean/MPS/ParentHamiltonian/Basic.lean}:118--128.}
-The normal-MPS range-reduction theorem still depends on the boundary-closing
+The normal-MPS range-reduction theorem still depends on the periodic-boundary
 comparison, which is the remaining formal gap for the general unique-ground-state
 statement.\footnote{Formal declaration:
 \leanid{wrapped_mirror_witness_agree_of_chainGroundSpace}. See


### PR DESCRIPTION
## Summary

- replace multi-block/BNT unfaithfulness markers that described a "boundary-closing" comparison with the source-aligned periodic-boundary comparison
- align the related paper-gap notes and index entry with the same terminology
- leave all declarations, theorem statements, proofs, and blueprint labels unchanged

Refs #2405.
Refs #2651.
Refs #190.
Refs #460.

## Checks

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `LEAN_PATH="$LP" lean TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and paper-gap terminology only; no executable or proof logic changes.
> 
> **Overview**
> This PR is **documentation-only**: it renames the formal gap described in **Unfaithful** docstrings and paper-gap notes from **boundary-closing** to **periodic-boundary**, matching Cirac et al. Section IV.C wording. **No** Lean declarations, theorem statements, proofs, or blueprint labels change.
> 
> In `BNTBlockIntersection.lean`, seven **Unfaithful** blocks now say the cited theorems depend transitively on the **periodic-boundary coordinate comparison** (still not derived from arXiv:2011.12127 IV.C). Related `docs/paper-gaps/` updates: `README.md` index entry, `cpgsv21_block_diagonal_parent_ground_space.tex` (“periodic-boundary comparison reductions”), and `rmp_example_parent_hamiltonian_scope.tex` (normal-MPS range-reduction gap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6922b19c46a97cb5aeb111af8689409d71c38cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->