### PR TITLE
doc(parent): align closure-property residual prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -10,10 +10,10 @@ import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Data.List.OfFn
 
 /-!
-# Block-word stripping for block-injective parent-Hamiltonian arguments
+# Block-word cancellation for block-injective parent-Hamiltonian arguments
 
-This file provides the algebraic stripping lemmas needed in the periodic
-parent-Hamiltonian closure argument for block-injective tensors.
+This file provides the algebraic word-span cancellation lemmas needed in the
+periodic parent-Hamiltonian closure argument for block-injective tensors.
 
 ## Main results
 
@@ -28,10 +28,10 @@ If words of a fixed length \(L\) span the full matrix algebra, then the trace ma
 `groundSpaceMap A L` is injective. We use this to formulate a block-word
 compatibility argument: if a family indexed by length-\(L₀\) words satisfies a
 common right-factor relation after multiplying by every length-\(K\) suffix, then
-block injectivity at length \(L₀\) strips the suffix and produces a common right
+block injectivity at length \(L₀\) cancels the suffix and produces a common right
 factor already at block length \(L₀\).
 
-The final theorem applies this stripping mechanism to commutation relations:
+The final theorem applies this word-span cancellation mechanism to commutation relations:
 commutation with all words of length \(m ≥ L₀\) forces commutation with all block
 words of length \(L₀\).
 
@@ -148,7 +148,7 @@ private theorem exists_right_factor_of_block_letter_compatibility
     _ = gen σ * ∑ τ, c τ • Y τ := by simp [Finset.mul_sum]
     _ = evalWord A (List.ofFn σ) * X := by rfl
 
-/-- Block-word stripping theorem: compatibility with every suffix word of a fixed
+/-- Block-word cancellation theorem: compatibility with every suffix word of a fixed
 length \(K\) implies a common right factor already at block length \(L₀\). -/
 theorem exists_right_factor_of_block_word_compatibility
     {A : MPSTensor d D} {K L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -10,8 +10,8 @@ import TNLean.MPS.ParentHamiltonian.BoundaryClosingWitness
 
 Coordinate identities for the boundary-crossing restrictions used when closing
 the periodic boundary in the normal parent-Hamiltonian closure step of
-arXiv:2011.12127, Section IV.C. The opposite window shares the complementary
-word \(\mu\).
+arXiv:2011.12127, Section IV.C. The second boundary-crossing window shares the
+complementary word \(\mu\).
 -/
 
 open scoped Matrix BigOperators
@@ -335,7 +335,7 @@ theorem closure_property_boundary_condition_product_of_window_witnesses
   simpa [Y, hstart, hend] using hprod
 
 /-- Product equation obtained by moving from the last site through the periodic
-boundary to the opposite boundary-crossing support.
+boundary to the second boundary-crossing support.
 
 For a fixed boundary condition \(\rho\), the window matrices satisfy
 \[
@@ -709,7 +709,7 @@ lemma closure_property_auxiliary_boundary_product_eq_of_right_products
     (hYAt ⟨M + 1 - L₀, by omega⟩
       (mirrorMiddleBackground L₀ (M + 1) η μ)) (hProd η)
 
-/-- Cancellation form of the opposite boundary-crossing coordinate comparison.
+/-- Cancellation form of the second boundary-crossing coordinate comparison.
 
 If the difference
 \[
@@ -760,7 +760,7 @@ Suppose that the window beginning at \(M\) already gives
 \[
   Y_M(\tau^+_\eta(\mu)) A^j = A^\mu A^jX
 \]
-and that the opposite boundary-crossing window satisfies the comparison
+and that the second boundary-crossing window satisfies the comparison
 \[
   Y_{M+1-L_0}(\tau^-_\eta(\mu)) A^j A^\sigma
   =

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean
@@ -752,7 +752,7 @@ lemma closure_property_mirror_right_product_eq_of_right_word_products
       (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
   exact sub_eq_zero.mp hsub
 
-/-- Auxiliary boundary-condition product obtained from the opposite
+/-- Auxiliary boundary-condition product obtained from the second
 boundary-crossing coordinate comparison after multiplication by length-\(L_0\)
 words.
 

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -8,10 +8,10 @@ import TNLean.MPS.ParentHamiltonian.BoundaryStripping
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
 
 /-!
-# Stripping reductions for the periodic-boundary comparison
+# Word-span cancellation reductions for the periodic-boundary comparison
 
-Left-word stripping reductions for the comparison used when closing the periodic
-boundary: a boundary difference killed by every length-\(L_0\) word product on
+Left-word cancellation reductions for the periodic-boundary closure-property
+comparison: a boundary difference killed by every length-\(L_0\) word product on
 the left vanishes by block injectivity, reducing the periodic-boundary
 comparison to a single padded coordinate identity in arXiv:2011.12127,
 Section IV.C.
@@ -23,7 +23,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Left-word stripping for the second boundary-crossing coordinate comparison.
+/-- Left-word cancellation for the second boundary-crossing coordinate comparison.
 
 Let \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\) be the matrix representing the second
 boundary-crossing restriction. If, after fixing the physical letter \(j\) and
@@ -35,8 +35,8 @@ the right word \(\sigma\), the difference
 is killed by left multiplication by every length-\(L_0\) word product, then the
 difference is zero.
 
-**Scope restriction (conditional reduction):** This is only a stripping
-reduction. It assumes the left-multiplied coordinate comparison through the
+**Scope restriction (conditional reduction):** This is only a word-span
+cancellation reduction. It assumes the left-multiplied coordinate comparison through the
 hypothesis `hLeft`, and does not derive that comparison from the
 periodic-boundary closure-property sentence in arXiv:2011.12127, Section IV.C,
 lines 2078--2079.
@@ -315,8 +315,8 @@ at the periodic boundary is the equality
   =
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
-After choosing window witnesses, the remaining coordinate reconstruction is the
-boundary product comparison
+After choosing cyclic-window representation matrices, the remaining coordinate
+reconstruction is the boundary product comparison
 \[
   Y_M(\tau^+_\eta(\mu))A^j
   =

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -466,10 +466,9 @@ The comparison is derived from the periodic-boundary restriction equality
   =
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
-The displayed restriction equality is the remaining local form of the sentence
-in arXiv:2011.12127, Section IV.C, lines 2078--2079, that the
-inverting-and-growing-back argument may also be applied when closing the
-boundary. See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+The displayed restriction equality is the remaining local form of the
+periodic-boundary closure-property sentence in arXiv:2011.12127, Section IV.C,
+lines 2078--2079. See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
 theorem closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingWitness.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingWitness.lean
@@ -7,13 +7,12 @@ import TNLean.MPS.ParentHamiltonian.BoundaryOverlap
 import TNLean.MPS.ParentHamiltonian.WrappingWindow
 
 /-!
-# Boundary-crossing witness comparisons for the closure property
+# Boundary-restriction matrix comparisons for the closure property
 
 Coordinate identities saying that outside configurations with the same labels on
-the sites outside a cyclic window determine the same boundary-crossing witness.
-These are the witness-independence facts needed to choose a representative
-outside configuration for the coordinate comparison used when closing the
-periodic boundary.
+the sites outside a cyclic window determine the same boundary-restriction
+matrix. These independence facts let one choose a representative outside
+configuration for the periodic-boundary closure-property comparison.
 -/
 
 open scoped Matrix BigOperators
@@ -130,13 +129,13 @@ theorem wrappedMiddleBackground_first_products_eq_of_complement_eq
     (cyclicRestrictₗ_wrappedMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
 
-/-- Witness uniqueness at the last-site boundary-crossing support.
+/-- Boundary-restriction matrix uniqueness at the last-site boundary-crossing support.
 
 If an outside configuration has the same word on the sites outside the window
 as the local coordinate configuration \(\tau^+_\eta(\mu)\), then the two
 matrices representing the last-site restriction are equal. This is the
-last-site witness-independence step for the periodic-boundary coordinate
-comparison. -/
+independence step for the last-site boundary-restriction matrix in the
+periodic-boundary coordinate comparison. -/
 theorem wrappedMiddleBackground_witness_eq_of_complement_eq
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)
@@ -234,13 +233,13 @@ theorem mirrorMiddleBackground_first_products_eq_of_complement_eq
     (cyclicRestrictₗ_mirrorMiddleBackground_eq_of_complement_eq
       hL₀ hM η μ ρ hρ)
 
-/-- Witness uniqueness at the second boundary-crossing support.
+/-- Boundary-restriction matrix uniqueness at the second boundary-crossing support.
 
 If an outside configuration has the same word on the sites outside the window
 as the local coordinate configuration \(\tau^-_\eta(\mu)\), then the two
 matrices representing the second boundary-crossing restriction are equal. This
-is the second-window witness-independence step for the periodic-boundary
-coordinate comparison. -/
+is the independence step for the second boundary-restriction matrix in the
+periodic-boundary coordinate comparison. -/
 theorem mirrorMiddleBackground_witness_eq_of_complement_eq
     {A : MPSTensor d D} {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ ≤ M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean
@@ -104,11 +104,11 @@ one-sided product equations
   \qquad
   X \, A^j \, A^\mu = A^j \, V_\eta,
 \]
-for the wrapped witness \(W_\eta\) and mirror witness \(V_\eta\). Then the two
-witnesses agree after right multiplication by each one-site matrix:
+for the boundary-restriction matrices \(W_\eta\) and \(V_\eta\). Then the two
+matrices agree after right multiplication by each one-site matrix:
 \(W_\eta \, A^j = V_\eta \, A^j\).
 
-The mirror equation and the commutation relations give, for every \(k\),
+The second one-sided equation and the commutation relations give, for every \(k\),
 \[
   A^k V_\eta
   =
@@ -118,8 +118,8 @@ The mirror equation and the commutation relations give, for every \(k\),
   =
   A^k A^\mu X .
 \]
-Left witness uniqueness therefore forces \(V_\eta=A^\mu X\). The wrapped
-equation then yields
+The left-sided uniqueness lemma therefore forces \(V_\eta=A^\mu X\). The first
+one-sided equation then yields
 \[
   W_\eta A^j
   =

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -496,8 +496,8 @@ theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
 
 After the reduced cyclic-window compatibilities at the boundary have been converted into a
 family of identities \(XA^\omega=A^\omega X\) for one word length \(m \ge L₀\),
-the existing block-stripping theorem makes \(X\) commute with the full matrix
-algebra. Hence \(X\) is scalar and
+the existing block-word cancellation theorem makes \(X\) commute with the full
+matrix algebra. Hence \(X\) is scalar and
 \(\Gamma_N(X)\in \mathbb C\,V^{(N)}(A)\). -/
 theorem groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes
     {A : MPSTensor d D} {L₀ m N : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -437,10 +437,10 @@ theorem chainGroundSpace_eq_mpvSubmodule {A : MPSTensor d D} [NeZero D]
 at the boundary for an open-chain boundary matrix.
 
 After the cyclic-to-open-chain step writes a periodic-chain vector as
-\(\psi=\Gamma_N(X)\), the two reduced cyclic windows used when closing the
-boundary expose the boundary matrix \(X\) on opposite sides of the same
-length \(N-(L₀+1)\) complement word. This theorem gives the local algebraic
-output needed for the remaining periodic-boundary coordinate comparison
+\(\psi=\Gamma_N(X)\), the two reduced cyclic windows used in the
+periodic-boundary closure-property step expose the boundary matrix \(X\) on the
+two sides of the same length \(N-(L₀+1)\) complement word. This theorem gives
+the local algebraic output needed for the remaining periodic-boundary coordinate comparison
 (arXiv:2011.12127, Section IV.C, lines 2078--2079). -/
 theorem chainGroundSpace_wrapped_boundary_compatibilities_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -703,7 +703,7 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
       (mirrorMiddleBackground L₀ (M + 1) η μ) ψ j]
   exact hfixed j
 
-/-- Product equality needed after closing the boundary,
+/-- Product equality needed in the periodic-boundary closure-property step,
 \(Y_M(\tau^+_\eta(\mu))A^jA^\sigma =
 Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\).
 **Unfaithful:** This proof relies directly or transitively on

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -82,12 +82,12 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ### Cyclic config decomposition at the wrapping position
+/-! ### Cyclic config decomposition at the last-site boundary-crossing position
 
 These lemmas analyze the structure of `cyclicCfg` at position \(N-1\),
 where the window wraps from the last site back to the first sites. -/
 
-/-- At the wrapping position \(N-1\), the cyclic config's last site is
+/-- At the last-site boundary-crossing position \(N-1\), the cyclic config's last site is
 \(\sigma_w(0)\). -/
 private theorem cyclicCfg_last_eq {N L : ℕ} (hN : 2 ≤ N) (hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d) :
@@ -201,15 +201,15 @@ theorem init_evalWord_split {A : MPSTensor d D}
       rw [dif_neg (by rw [hoffset]; omega)]
       congr 1; ext; simp; omega
 
-/-! ### Mirror factorization at the opposite wrapped position
+/-! ### Factorization at the second boundary-crossing position
 
-At the wrapped position \(N - L + 1\), the cyclic word starts with the last window
-site, then runs through the complement, then finishes with the remaining
-\(L - 1\) window sites.  This yields the factorization needed for the mirror
-block-injective extraction. -/
+At the second boundary-crossing position \(N - L + 1\), the cyclic word starts
+with the last window site, then runs through the complement, then finishes with
+the remaining \(L - 1\) window sites.  This yields the factorization needed for
+the second block-injective extraction. -/
 
-/-- At the opposite wrapped position \(N - L + 1\), site \(0\) carries the final
-window entry \(\sigma_w(L-1)\). -/
+/-- At the second boundary-crossing position \(N - L + 1\), site \(0\) carries
+the final window entry \(\sigma_w(L-1)\). -/
 private theorem cyclicCfg_mirror_zero_eq {N L : ℕ} (hN : 2 ≤ N) (hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d) :
     cyclicCfg (by omega : 0 < N) L ⟨N - L + 1, by omega⟩ σ_w τ ⟨0, by omega⟩ =
@@ -226,7 +226,7 @@ private theorem cyclicCfg_mirror_zero_eq {N L : ℕ} (hN : 2 ≤ N) (hLN : L ≤
   ext
   exact hoffset
 
-/-- At the opposite wrapped position \(N - L + 1\), the complement sites
+/-- At the second boundary-crossing position \(N - L + 1\), the complement sites
 \(1,\ldots,N-L\) keep their \(\tau\) values. -/
 private theorem cyclicCfg_mirror_complement_site {N L : ℕ}
     (hN : 2 ≤ N) (_hLN : L ≤ N) (hL : 1 < L)
@@ -240,8 +240,8 @@ private theorem cyclicCfg_mirror_complement_site {N L : ℕ}
     rw [this, Nat.mod_eq_of_lt (by omega)]
   rw [dif_neg (show ¬((k + N - (N - L + 1)) % N < L) by rw [hoffset]; omega)]
 
-/-- At the opposite wrapped position \(N - L + 1\), the final \(L - 1\) physical
-sites carry the first \(L - 1\) entries of the window. -/
+/-- At the second boundary-crossing position \(N - L + 1\), the final \(L - 1\)
+physical sites carry the first \(L - 1\) entries of the window. -/
 private theorem cyclicCfg_mirror_window_site {N L : ℕ}
     (hN : 2 ≤ N) (_hLN : L ≤ N) (hL : 1 < L)
     (σ_w : Fin L → Fin d) (τ : Fin N → Fin d)
@@ -257,7 +257,7 @@ private theorem cyclicCfg_mirror_window_site {N L : ℕ}
   rw [dif_pos (show (N - L + 1 + k + N - (N - L + 1)) % N < L by rw [hoffset]; omega)]
   congr 1; ext; simp [hoffset]
 
-/-- At the opposite wrapped position \(N - L + 1\), the cyclic word factors as
+/-- At the second boundary-crossing position \(N - L + 1\), the cyclic word factors as
 the final window letter, then the complement word, then the remaining
 \((L - 1)\)-site window head. -/
 private theorem evalWord_cyclicCfg_cons {A : MPSTensor d D}
@@ -448,7 +448,7 @@ theorem wrapping_window_compatibility_of_isNBlkInjective
           simp [Matrix.mul_assoc]
 
 /-- The second cyclic position used in the closure property exposes the
-compatibility \(X A_j C_τ = A_j Y_τ\) after block-injective stripping of the
+compatibility \(X A_j C_τ = A_j Y_τ\) after block-injective cancellation of the
 trailing \(L₀\)-site block. -/
 theorem wrapping_window_mirror_compatibility_of_isNBlkInjective
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -544,10 +544,11 @@ with the same word \(\mu\) on complementary sites and the same matrix
 /-- A boundary condition whose cyclic-window complement is the prescribed
 word on the complementary sites.
 
-For the wrapped window at the last site, the complement occupies physical sites
-\(L₀, \ldots, N - 2\).  This construction fills exactly those sites with \(\mu\); the
-remaining sites receive the letter \(\eta\) and do not affect the complement word
-extracted by the wrapped boundary identity. -/
+For the boundary-crossing window beginning at the last site, the complement
+occupies physical sites \(L₀, \ldots, N - 2\).  This construction fills exactly
+those sites with \(\mu\); the remaining sites receive the letter \(\eta\) and do
+not affect the complement word extracted by the last-site boundary-crossing
+identity. -/
 def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
   fun i =>
@@ -556,12 +557,12 @@ def wrappedMiddleBackground (L₀ N : ℕ) (η : Fin d)
     else
       η
 
-/-- A boundary condition whose mirror-window complement is the prescribed
-word on the complementary sites.
+/-- A boundary condition whose second boundary-crossing window complement is the
+prescribed word on the complementary sites.
 
-For the opposite wrapped window, the complement occupies physical sites
-\(1, \ldots, N - L₀ - 1\).  This construction fills exactly those sites with \(\mu\); all
-other sites receive the letter \(\eta\). -/
+For the second boundary-crossing window, the complement occupies physical sites
+\(1, \ldots, N - L₀ - 1\).  This construction fills exactly those sites with
+\(\mu\); all other sites receive the letter \(\eta\). -/
 def mirrorMiddleBackground (L₀ N : ℕ) (η : Fin d)
     (μ : Fin (N - (L₀ + 1)) → Fin d) : Fin N → Fin d :=
   fun i =>

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_boundary.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_boundary.tex
@@ -26,8 +26,8 @@ and combines them into the commutation $X A^j = A^j X$.
     \uses{lem:ground_space_map_injective_blk}
     The trace identity for this cyclic interval is tested against all words of
     length $L_0$. Injectivity of $\Gamma_{L_0}$, which follows from
-    $L_0$-block injectivity, strips the test word and gives the displayed matrix
-    identity~(\ref{eq:ph_wrapped_window_compat}).
+    $L_0$-block injectivity, turns these test-word identities into the displayed
+    matrix identity~(\ref{eq:ph_wrapped_window_compat}).
 \end{proof}
 
 \begin{lemma}[Boundary-crossing compatibility at the second boundary position]%
@@ -687,7 +687,7 @@ completed downstream.
     When $N = 0$ or $L > N$, set $\mathcal{G}_{N,L}(A) := \top$ by convention.
 \end{definition}
 
-\begin{lemma}[Cyclic-window witnesses inside the periodic ground space]
+\begin{lemma}[Cyclic-window representation matrices inside the periodic ground space]
     \label{lem:chain_ground_space_window_witnesses}
     \lean{MPSTensor.chainGroundSpace_window_witnesses}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_boundary.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_boundary.tex
@@ -2,7 +2,8 @@
 
 This section reduces a commutation or annihilation relation that holds for all
 long word products $A^w$ back to the injectivity length $L_0$, then uses this
-reduction to close the periodic boundary. Throughout, $A^w := A^{i_1}\cdots
+reduction in the periodic-boundary closure-property step. Throughout,
+$A^w := A^{i_1}\cdots
 A^{i_L}$ denotes the product along a word $w = (i_1,\ldots,i_L)$, $\Gamma_N$
 sends a boundary matrix to its open-chain vector, and $A$ being
 \emph{$L_0$-block-injective} means $\spn\{A^u : |u|=L_0\} = \MN{D}$, so a
@@ -159,7 +160,7 @@ $\MN{D}$.
     by a length-$k$ suffix and use the same spanning argument.
 \end{proof}
 
-\begin{lemma}[One-sided boundary witnesses are unique]
+\begin{lemma}[One-sided boundary matrices are unique]
     \label{lem:one_sided_boundary_witness_unique}
     \lean{MPSTensor.right_witness_unique_of_isNBlkInjective}
     \lean{MPSTensor.left_witness_unique_of_isNBlkInjective}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -153,7 +153,7 @@ closure-property comparison.
     \[
         X A^w=A^wX
     \]
-    Hence the mirror equation gives, for every $k$,
+    Hence the second one-sided equation gives, for every $k$,
     \[
         A^kV_\eta
         =
@@ -164,7 +164,7 @@ closure-property comparison.
         A^kA^\mu X .
     \]
     Lemma~\ref{lem:one_sided_boundary_witness_unique} gives
-    $V_\eta=A^\mu X$. The wrapped equation then gives
+    $V_\eta=A^\mu X$. The first one-sided equation then gives
     \[
         W_\eta A^j
         =
@@ -204,7 +204,7 @@ closure-property comparison.
     matrices $Y^+_{\tau^+_\eta(\mu)}$ and $Y^-_{\tau^-_\eta(\mu)}$.
 \end{proof}
 
-\begin{lemma}[Outside labels determine boundary-crossing witnesses]
+\begin{lemma}[Outside labels determine boundary-restriction matrices]
     \label{lem:outside_labels_determine_boundary_witnesses}
     \lean{MPSTensor.wrappedMiddleBackground_witness_eq_of_complement_eq}
     \lean{MPSTensor.mirrorMiddleBackground_witness_eq_of_complement_eq}
@@ -402,7 +402,7 @@ closure-property comparison.
 
 \begin{proof}
     \notready
-    The window-witness lemma gives matrices
+    The cyclic-window representation lemma gives matrices
     $Y_M(\tau^+_\eta(\mu))$ and
     $Y_{M+1-L_0}(\tau^-_\eta(\mu))$ such that
     \[
@@ -1131,7 +1131,7 @@ left-multiplied boundary comparison.
 
 \begin{proof}
     \notready
-    Let $Y_i(\tau)$ be the window witnesses of
+    Let $Y_i(\tau)$ be the representation matrices supplied by
     Lemma~\ref{lem:chain_ground_space_window_witnesses}.  By
     Theorem~\ref{thm:boundary_closing_right_products_chain_ground_space},
     \[
@@ -1384,10 +1384,10 @@ left-multiplied boundary comparison.
     \]
     Write $N=M+1$. The two boundary-crossing supports start at
     $M$ and $M+1-L_0$.  Let $Y_i(\tau)$
-    denote the cyclic-window witness given by
+    denote the cyclic-window representation matrix given by
     Lemma~\ref{lem:chain_ground_space_window_witnesses} at the window beginning at
     $i$.  The first step identifies the two abstract boundary-condition families
-    with the two boundary-crossing witnesses:
+    with the two boundary-restriction matrices:
     \[
         Y^{+}_{\tau^{+}_{\eta}(\mu)}
         =

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -22,7 +22,7 @@ Section~IV.C of Cirac--P\'erez-Garc\'ia--Schuch--Verstraete
 \href{https://github.com/LionSR/TNLean/issues/1042}{issue \#1042}. The principal
 range-reduction comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/588}{issue \#588}; the
-comparison needed when closing the boundary is recorded in
+periodic-boundary comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}; its current
 coordinate form is recorded in
 \href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405};


### PR DESCRIPTION
## Summary

This documentation-only cleanup removes residual reader-facing terminology in the parent-Hamiltonian closure-property branch that was not aligned with the source language of Cirac--Perez-Garcia--Schuch--Verstraete, Section IV.C.

The changes keep all Lean declaration names, theorem statements, proof terms, blueprint labels, and blueprint status tags fixed. They only rephrase prose:

- “opposite boundary-crossing” and “closing the boundary” are replaced by the periodic-boundary closure-property and second boundary-crossing language.
- “wrapped/mirror witness” prose is replaced by boundary-restriction matrix or first/second one-sided equation language.
- “stripping” prose is replaced by word-span cancellation language, while stable labels and declaration names such as `block_word_stripping` are left unchanged.
- Blueprint theorem titles are updated where the title itself was reader-facing prose.

Refs #2405. Refs #2651. Refs #190. Refs #460.

## Validation

- `git diff --check`
- targeted residual-terminology `rg` scan over the touched parent-Hamiltonian Lean and blueprint files
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- direct Lean checks for:
  - `TNLean/MPS/ParentHamiltonian/BlockStrip.lean`
  - `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`
  - `TNLean/MPS/ParentHamiltonian/BoundaryClosingWitness.lean`
  - `TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean`
  - `TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean`
  - `TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean`
  - `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`

`BoundaryClosingStripping.lean` still reports the pre-existing tracked `sorry` warning in the open closure-property comparison obligation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint text only; no executable Lean or proof logic changes. Residual risk is limited to documentation drift or misleading wording, not runtime or formal correctness.
> 
> **Overview**
> Aligns **reader-facing prose** in the parent-Hamiltonian periodic-boundary closure-property branch with Cirac–Pérez-García–Schuch–Verstraete Section IV.C wording. **Lean theorem names, statements, proof terms, blueprint labels, and sync tags are unchanged.**
> 
> Terminology updates include: **“opposite” / mirror-window** language → **second boundary-crossing** support; **“closing the boundary”** → **periodic-boundary closure-property** step; **witness** prose → **boundary-restriction matrix** and **first/second one-sided equation**; **stripping** prose → **word-span cancellation** (stable identifiers such as `block_word_stripping` and file names like `BoundaryClosingStripping.lean` stay as-is). Matching edits appear in `blueprint/src/chapter/ch13_parent_hamiltonian_*` and `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
> 
> **Unfaithful / open-gap** annotations and the existing `sorry` in `BoundaryClosingStripping.lean` are not altered—only how those obligations are described.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa31ae344f15fc0185eec6f85d5252a8d6f1f393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->