### PR TITLE
doc(parent): align NNCPH ground-vector scope

### DIFF
--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -15,15 +15,17 @@ Following the proof in Section 3.3 of that paper, the two directions have very
 different external provenance and so are stated here as **separate** axioms with
 **separate** citations:
 
-* `Axioms.rfp_to_nncph_commute` — RFP ⟹ NNCPH. Per
+* `Axioms.rfp_to_nncph_commute` — RFP ⟹ the NNCPH commutation equations. Per
   arXiv:1606.00608 Section 3.3 (line 1307 of the source): *"The implication
   RFP ⟹ NNCPH is trivial from Theorem [charact-MPS]"*. It is
   therefore **not** gated on [Beigi 2012]; it is gated only on
   Theorem 3.10 of arXiv:1606.00608 (the full structural
   characterization of RFPs via product-of-entangled-pairs).
-* `Axioms.beigi_nncph_to_rfp` — NNCPH ⟹ RFP. This is the
-  non-trivial direction. Per arXiv:1606.00608 Section 3.3 (line 1307): *"To
-  prove the reverse, we will use [Beigi]"*. It is gated on S. Beigi,
+* `Axioms.beigi_nncph_to_rfp` — pairwise length-two commutativity ⟹ RFP. This
+  is the present axiom-backed reverse implication; the source NNCPH condition
+  also includes the parent-Hamiltonian ground-space statement recorded below.
+  Per arXiv:1606.00608 Section 3.3 (line 1307): *"To prove the reverse, we
+  will use [Beigi]"*. It is gated on S. Beigi,
   *J. Phys. A: Math. Theor.* **45** (2012) 025306 — the ground-space
   theorem for nearest-neighbor commuting 1D Hamiltonians with finite
   degeneracy.
@@ -92,7 +94,8 @@ open scoped Matrix BigOperators
 
 namespace Axioms
 
-/-- **RFP ⟹ NNCPH** direction of arXiv:1606.00608 Section 3.3 Theorem 3.10.
+/-- **RFP ⟹ NNCPH commutation equations** in arXiv:1606.00608 Section 3.3
+Theorem 3.10.
 
 For a normal MPS tensor `A` in RFP, the two-site parent-Hamiltonian
 `localTerm` projectors pairwise commute on every finite periodic chain
@@ -120,8 +123,9 @@ axiom rfp_to_nncph_commute {d D : ℕ} [NeZero D]
       MPSTensor.localTerm A 2 N i * MPSTensor.localTerm A 2 N j =
         MPSTensor.localTerm A 2 N j * MPSTensor.localTerm A 2 N i
 
-/-- **NNCPH ⟹ RFP** direction of arXiv:1606.00608 Section 3.3 Theorem 3.10,
-the non-trivial implication gated on [Beigi 2012].
+/-- Pairwise length-two commutativity ⟹ RFP, the present axiom-backed form of
+the **NNCPH ⟹ RFP** direction of arXiv:1606.00608 Section 3.3 Theorem 3.10,
+gated on [Beigi 2012].
 
 For a normal MPS tensor `A` in left-canonical form, if the two-site
 parent-Hamiltonian `localTerm` projectors pairwise commute on every

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -12,7 +12,7 @@ import TNLean.Axioms.Beigi
 /-!
 # Commuting parent Hamiltonians
 
-This file records the commutativity clauses for parent Hamiltonians and the
+This file records the commutation equations for parent Hamiltonians and the
 length-two specialization used in the nearest-neighbor commuting parent
 Hamiltonian part of arXiv:1606.00608.
 
@@ -22,8 +22,8 @@ Hamiltonian part of arXiv:1606.00608.
   Hamiltonian on \(N\) sites with block length \(L\) mutually commute.
 * `MPSTensor.IsNNCPH A N` — length-two commutativity of the translated parent
   interaction terms.
-* `MPSTensor.IsNNCPHGroundState A N` — the nearest-neighbor local terms commute
-  and annihilate the periodic MPS vector.
+* `MPSTensor.IsNNCPHGroundState A N` — the length-two local terms commute and
+  annihilate the periodic MPS vector.
 
 ## Main results
 
@@ -37,12 +37,13 @@ Hamiltonian part of arXiv:1606.00608.
   \(Aᵢ = XΛUᵢX⁻¹\), the even-chain product-of-pairs factorization, and the
   two-site projector identities, without invoking
   `Axioms.rfp_to_nncph_commute`.
-* `MPSTensor.rfp_implies_nncph` — construction for the RFP \(\Longrightarrow\) NNCPH direction of
-  Theorem 3.10.
+* `MPSTensor.rfp_implies_nncph` — construction of the length-two commutation
+  equations in the RFP \(\Longrightarrow\) NNCPH direction of Theorem 3.10.
 * `MPSTensor.rfp_implies_nncph_ground_state` — the same direction with the
-  frustration-free ground-state condition for the MPS vector included.
-* `MPSTensor.nncph_implies_rfp` — construction for the NNCPH \(\Longrightarrow\) RFP direction of
-  Theorem 3.10.
+  zero-energy ground-vector equation for the MPS vector included.
+* `MPSTensor.nncph_implies_rfp` — axiom-backed reverse implication from
+  pairwise length-two commutativity to RFP. The source NNCPH condition also
+  includes the parent-Hamiltonian ground-space statement recorded below.
 
 ## References
 
@@ -71,7 +72,7 @@ def IsCommutingParentHam (A : MPSTensor d D) (L N : ℕ) : Prop :=
     localTerm A L N i * localTerm A L N j = localTerm A L N j * localTerm A L N i
 
 /-- **Nearest-neighbor commuting parent Hamiltonian** (NNCPH): the length-two
-commutativity clause for the translated parent interaction terms.
+commutation equations for the translated parent interaction terms.
 
 See arXiv:1606.00608, Definition 3.9. The source definition of a parent
 Hamiltonian also includes the ground-space spanning condition, which is not part
@@ -79,9 +80,9 @@ of this predicate. -/
 def IsNNCPH (A : MPSTensor d D) (N : ℕ) : Prop :=
   IsCommutingParentHam A 2 N
 
-/-- The ground-state condition for a nearest-neighbor commuting
-parent Hamiltonian: the length-two local terms commute and annihilate the
-periodic MPS vector V^{(N)}(A).
+/-- The commutation and zero-energy equations for the nearest-neighbor
+commuting parent-Hamiltonian statement: the length-two local terms commute and
+annihilate the periodic MPS vector V^{(N)}(A).
 
 See arXiv:1606.00608, Theorem 3.10(iii), source line 539. This predicate records
 the commutativity and annihilation equations for the MPS vector. The full source
@@ -89,8 +90,8 @@ parent-Hamiltonian condition also includes the ground-space spanning assertion
 from Definition 3.9, and Theorem 3.10 also includes the canonical-form and
 zero-correlation-length equivalences.
 
-**Scope restriction (ground vector):** This is the zero-energy ground-vector
-clause for the canonical parent interaction, not the full source ground-space
+**Scope restriction (ground vector):** These are the zero-energy ground-vector
+equations for the canonical parent interaction, not the full source ground-space
 spanning condition. Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 def IsNNCPHGroundState (A : MPSTensor d D) (N : ℕ) : Prop :=
@@ -117,7 +118,7 @@ theorem IsNNCPHGroundState.isFrustrationFree {A : MPSTensor d D} {N : ℕ}
   h.2
 
 /-- If the length-two parent terms commute and N ≥ 2, then the periodic MPS
-vector is a ground state of a nearest-neighbor commuting parent Hamiltonian. -/
+vector satisfies the NNCPH commutation and zero-energy condition. -/
 theorem IsNNCPH.isNNCPHGroundState {A : MPSTensor d D} {N : ℕ}
     (h : IsNNCPH A N) (hN : 2 ≤ N) :
     IsNNCPHGroundState A N :=
@@ -174,7 +175,8 @@ theorem IsCommutingParentHam.ham_comm_localTerm {A : MPSTensor d D} {L N : ℕ}
   ext j : 1
   exact _h j i
 
-/-- **Theorem 3.10(i)⟹(iii)** (arXiv:1606.00608): RFP implies NNCPH.
+/-- **Theorem 3.10(i)⟹(iii)** (arXiv:1606.00608): RFP implies the NNCPH
+commutation equations.
 A normal renormalization fixed-point tensor has a nearest-neighbor
 commuting parent Hamiltonian.
 
@@ -193,9 +195,8 @@ theorem rfp_implies_nncph (A : MPSTensor d D) [NeZero D]
   exact Axioms.rfp_to_nncph_commute A hNT hRFP N hN i j
 
 /-- **Theorem 3.10(i)⟹(iii)** (arXiv:1606.00608), ground-vector form:
-RFP implies that the periodic MPS vector is a ground state of a
-nearest-neighbor commuting parent Hamiltonian on every chain of length at least
-two.
+RFP implies that the periodic MPS vector satisfies the zero-energy equation for
+commuting nearest-neighbor parent terms on every chain of length at least two.
 
 This theorem adds the frustration-free ground-vector equation to
 `rfp_implies_nncph`.
@@ -211,7 +212,8 @@ theorem rfp_implies_nncph_ground_state (A : MPSTensor d D) [NeZero D]
     IsNNCPHGroundState A N :=
   (rfp_implies_nncph A hRFP hNT N hN).isNNCPHGroundState hN
 
-/-- **Theorem 3.10(iii)⟹(i)** (arXiv:1606.00608): NNCPH implies RFP.
+/-- **Theorem 3.10(iii)⟹(i)** (arXiv:1606.00608): pairwise length-two
+commutativity implies RFP in the present axiom-backed theorem.
 Gated on S. Beigi, *J. Phys. A: Math. Theor.* **45** (2012) 025306 —
 the ground-space characterization of commuting nearest-neighbor 1D
 Hamiltonians with finite degeneracy (`Axioms.beigi_nncph_to_rfp`).

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -20,10 +20,10 @@ subsection below.
     The parent Hamiltonian with block length~$L$ on $N$ sites has
     \emph{commuting} local terms if
     $h_i h_j = h_j h_i$ for all $i,j \in \{0,\ldots,N{-}1\}$.
-    This records the translated commutativity clause
+    This records the translated commutation equation
     $[\tau_j(P_L),P_L]=0$ from
     \cite[Definition~3.9]{Cirac2016MPDO_arXiv}; the ground-space spanning
-    clause in the same definition is a separate parent-Hamiltonian condition.
+    statement in the same definition is a separate parent-Hamiltonian condition.
 \end{definition}
 
 \begin{definition}[Nearest-neighbor commuting parent Hamiltonian]\label{def:is_nncph}
@@ -31,7 +31,7 @@ subsection below.
     \leanok
     \uses{def:is_commuting_parent_ham}
     The nearest-neighbor commuting condition is the length-$2$ specialization
-    of the preceding commutativity clause. For every
+    of the preceding commutation equation. For every
     $i,j\in\{0,\ldots,N{-}1\}$,
     \[
         h_i h_j=h_j h_i.
@@ -41,14 +41,13 @@ subsection below.
     ground-space spanning property.
 \end{definition}
 
-\begin{definition}[Ground state of a nearest-neighbor commuting parent Hamiltonian]%
+\begin{definition}[Commutation and zero-energy equations for nearest-neighbor parent terms]%
     \label{def:is_nncph_ground_state}
     \lean{MPSTensor.IsNNCPHGroundState}
     \leanok
     \uses{def:is_nncph, def:is_frustration_free}
-    The MPS vector $V^{(N)}(A)$ is a ground state of a nearest-neighbor
-    commuting parent Hamiltonian when the length-two local terms commute and
-    annihilate the vector:
+    This condition records the commutation equation and the zero-energy equation
+    for the nearest-neighbor parent terms:
     \[
         h_i h_j = h_j h_i,\qquad
         h_i V^{(N)}(A)=0.
@@ -71,8 +70,8 @@ subsection below.
     \leanok
     \uses{lem:parent_hamiltonian_ff}
     The nearest-neighbor condition is the length-$2$ specialization of the
-    general commuting condition. The ground-state condition contains this
-    commuting equation and the frustration-free equation for $V^{(N)}(A)$.
+    general commuting condition. This condition contains the commuting equation
+    and the frustration-free equation for $V^{(N)}(A)$.
     For $N\ge 2$, Lemma~\ref{lem:parent_hamiltonian_ff} with $L=2$ gives
     \[
         h_i\,V^{(N)}(A)=0
@@ -92,14 +91,15 @@ subsection below.
     Theorem~3.10 in~\cite{Cirac2016MPDO_arXiv}.
 \end{theorem}
 
-\begin{theorem}[Renormalization fixed points are ground states of a nearest-neighbor commuting parent Hamiltonian]%
+\begin{theorem}[Renormalization fixed points satisfy the NNCPH commutation and zero-energy equations]%
     \label{thm:rfp_implies_nncph_ground_state}
     \lean{MPSTensor.rfp_implies_nncph_ground_state}
     \leanok
     \uses{thm:rfp_implies_nncph, def:is_nncph_ground_state}
     If $A$ has nonzero virtual dimension and is a normal renormalization fixed
-    point, then for every chain length $N \ge 2$ the MPS vector $V^{(N)}(A)$ is
-    a ground state of a nearest-neighbor commuting parent Hamiltonian:
+    point, then for every chain length $N \ge 2$ the MPS vector $V^{(N)}(A)$
+    satisfies the commutation and zero-energy equations for nearest-neighbor
+    parent terms:
     \[
         h_i h_j = h_j h_i,\qquad
         h_i V^{(N)}(A)=0.


### PR DESCRIPTION
## Summary

This PR tightens the wording around the nearest-neighbor commuting parent-Hamiltonian entries so that the blueprint and Lean docstrings distinguish the source statement from the current formal predicate.

The source Definition 3.9 also requires the parent-Hamiltonian ground-space spanning property, while the present predicate records the length-two commutation equation together with the zero-energy equation for the periodic MPS vector. The PR therefore replaces reader-facing phrases that described this as the full ground-state condition by equation-level language.

No Lean declarations, theorem statements, proofs, or blueprint status tags are changed.

Refs #2633. Refs #190. Refs #2380.

## Validation

- `LEAN_PATH="$LP" lean TNLean/Axioms/Beigi.lean`
- `LEAN_PATH="$LP" lean TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX/docstring edits only; no changes to definitions, axioms, theorems, or proofs.
> 
> **Overview**
> **Documentation-only** updates in `TNLean/Axioms/Beigi.lean`, `TNLean/MPS/ParentHamiltonian/Commuting.lean`, and blueprint `ch13_parent_hamiltonian_commuting_gap.tex`. No Lean declarations, proofs, or `\leanok` tags change.
> 
> Reader-facing language now describes what the library **actually formalizes**—length-two **commutation equations** plus **zero-energy** equations for `V^{(N)}(A)`—instead of phrasing that suggests the full CPSV Definition 3.9 / Theorem 3.10 ground-state or ground-space spanning conditions. Axiom and theorem docstrings spell out that `beigi_nncph_to_rfp` / `nncph_implies_rfp` use **pairwise length-two commutativity** as the hypothesis, while the source NNCPH notion also includes the parent-Hamiltonian ground-space clause (still documented via existing scope notes).
> 
> The blueprint renames the `IsNNCPHGroundState` definition and the `rfp_implies_nncph_ground_state` theorem titles to **commutation and zero-energy equations** language, matching the Lean docstrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cc65e61d6f1a4f913cd08355b38b20c38b35fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->