### PR TITLE
doc(parent): align PGVWC comparison prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -6,9 +6,8 @@ section gives conditional reductions toward identifying the periodic chain groun
 space $\mathcal G_{N,L}(B)$ with the linear span $\bigvee_j\mathcal G_{N,L}(A_j)$
 of the single-block periodic ground spaces
 (\cite[Theorem~IV.16]{Cirac2021Matrix}). The lemmas below supply the inputs for
-closing the periodic boundary with block-diagonal boundary conditions: local
-boundary-crossing coordinate identities and single-block periodic-boundary
-membership.
+the periodic-boundary comparison with block-diagonal boundary conditions:
+boundary-condition equations and single-block periodic-boundary membership.
 
 \begin{lemma}[Normalized BNT blocks give the large-length block intersection]
     \label{lem:bnt_direct_sum_unital_block_intersection_ge}
@@ -1116,7 +1115,7 @@ in both cases.
     then gives the periodic-boundary constraint for each block.
 \end{proof}
 
-\begin{lemma}[PGVWC trace comparisons under block injectivity give single-block constraints]
+\begin{lemma}[$C^j,D^j,E^j$ trace comparisons give single-block constraints]
     \label{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}
     \leanok
@@ -1160,13 +1159,12 @@ in both cases.
     \[
         ((\mu_j^NX_j)A^j_\beta)A^j_\rho=A^j_\beta E_{j,i,\rho} .
     \]
-    These are precisely the boundary-crossing coordinate
-    identities of
+    These are precisely the block-diagonal boundary-condition equations of
     Lemma~\ref{lem:block_diagonal_boundary_component_complementary_word_identities_injective},
     which gives the periodic-boundary constraint for each block.
 \end{proof}
 
-\begin{lemma}[PGVWC trace comparisons give periodic-boundary single-block states]
+\begin{lemma}[$C^j,D^j,E^j$ trace comparisons give periodic-boundary single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1}
     \leanok
@@ -1213,7 +1211,7 @@ in both cases.
     \[
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
     \]
-    For this representation, the assumed PGVWC trace comparisons give matrices
+    For this representation, the assumed $C^j,D^j,E^j$ trace comparison gives matrices
     $C^j_{i,\rho}$. Lemma~\ref{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     then gives, for every $j$,
     \[
@@ -1221,7 +1219,7 @@ in both cases.
     \]
 \end{proof}
 
-\begin{lemma}[PGVWC comparisons give periodic single-block states]
+\begin{lemma}[$C^j$ boundary comparison gives periodic single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_pgvwc_comparison}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1}
     \leanok
@@ -1265,8 +1263,9 @@ in both cases.
     \[
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
     \]
-    For these boundary conditions, the assumed PGVWC comparison supplies the
-    matrices $C^j_{i,\rho}$. Lemma~\ref{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+    For these boundary conditions, the assumed $C^j$ boundary comparison supplies the
+    matrices $C^j_{i,\rho}$.
+    Lemma~\ref{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
     gives, for every $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
@@ -1290,8 +1289,8 @@ in both cases.
     \[
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
     \]
-    the corresponding boundary conditions satisfy the boundary-crossing
-    coordinate identities: for every boundary-crossing interval $i$, every word
+    the corresponding boundary conditions satisfy the block-diagonal
+    boundary-condition equations: for every boundary-crossing interval $i$, every word
     $\beta$ before the cut, and every outside word $\rho$ of length $N-L$,
     \[
         \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho} .

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -50,7 +50,7 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
         B=\bigoplus_{j=1}^g\mu_jA_j,
         \qquad \mu_j\ne0\quad(1\le j\le g).
     \]
-    If closing the periodic boundary with block-diagonal boundary conditions gives
+    If the periodic-boundary comparison with block-diagonal boundary conditions gives
     \[
         \mathcal G_{N,L}(B)
         \subseteq
@@ -219,7 +219,7 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
     \[
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
     \]
-    the boundary-crossing coordinate identities hold: for every block $j$,
+    the block-diagonal boundary-condition equations hold: for every block $j$,
     boundary-crossing interval $i$, word $\beta$ before the cut, and outside
     word $\rho$ of length $N-L$, there is a matrix $E_{j,i,\rho}$ such that
     \[
@@ -260,7 +260,7 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[PGVWC comparisons give equality in the finite range]
+\begin{lemma}[$C^j$ boundary comparisons give equality in the finite range]
     \label{lem:bnt_block_diagonal_pgvwc_comparison_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison}
     \leanok
@@ -319,7 +319,7 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[PGVWC trace comparisons give equality in the finite range]
+\begin{lemma}[$C^j,D^j,E^j$ trace comparisons give equality in the finite range]
     \label{lem:bnt_block_diagonal_trace_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition}
     \leanok


### PR DESCRIPTION
## Summary

This PR replaces reader-facing PGVWC acronym prose in the block-diagonal parent-Hamiltonian blueprint with the comparison actually used in the local source proof of `2blocks.2`: the matrices `C^j`, `D^j`, and `E^j`, together with the induced block-diagonal boundary-condition equations.

It also replaces a remaining “closing the periodic boundary” sentence by “periodic-boundary comparison” in the same block-diagonal boundary-condition discussion.

No Lean declarations, theorem statements, proofs, or blueprint status tags are changed.

Refs #2651. Refs #190. Refs #460.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "PGVWC|boundary-crossing coordinate|closing the periodic boundary|closing periodic boundary" blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex` returned no matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to two blueprint TeX files; no Lean or proof logic changes.
> 
> **Overview**
> Reader-facing prose in the block-diagonal parent-Hamiltonian blueprint chapters is updated so hypotheses and lemma titles name the **actual matrix comparisons** used in the local proof (`C^j`, `C^j,D^j,E^j` trace identities) instead of the **PGVWC** acronym.
> 
> Wording shifts from **“boundary-crossing coordinate identities”** to **block-diagonal boundary-condition equations**, and from **“closing the periodic boundary”** to **periodic-boundary comparison** with block-diagonal boundary conditions. **Lean labels, theorem statements, and proofs are unchanged**—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e65616702aac192a9bec52254a08b00d7b86a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->