### PR TITLE
doc(parent): align spectral-gap window prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -14,7 +14,7 @@ finite-row and cyclic-window reductions in the present convention; the
 MPS-specific principal-angle, equivalently norm-compression, estimate remains an
 explicit input.
 
-\begin{definition}[Parent ground space in the Hilbert-space realization]
+\begin{definition}[Parent ground space under the canonical $\ell^2$ identification]
     \label{def:parent_ground_space_es}
     \lean{MPSTensor.parentHamiltonianGroundSpaceES}
     \leanok
@@ -24,7 +24,7 @@ explicit input.
     $\ell^{2}(\{0,\ldots,d-1\}^N)$.
 \end{definition}
 
-\begin{definition}[Parent Hamiltonian in the Hilbert-space realization]
+\begin{definition}[Parent Hamiltonian under the canonical $\ell^2$ identification]
     \label{def:parent_hamiltonian_es}
     \lean{MPSTensor.parentHamiltonianES}
     \leanok
@@ -34,12 +34,12 @@ explicit input.
     $\ell^{2}(\{0,\ldots,d-1\}^N)$.
 \end{definition}
 
-\begin{theorem}[Kernel of the Hilbert-space parent Hamiltonian]
+\begin{theorem}[Kernel after the canonical $\ell^2$ identification]
     \label{thm:parent_ground_space_es_kernel}
     \lean{MPSTensor.parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES}
     \leanok
     Under the canonical $\ell^2$ identification of the $N$-site state space, the
-    Hilbert-space parent ground space is exactly the kernel of the corresponding
+    parent ground space is exactly the kernel of the corresponding
     parent Hamiltonian.
 \end{theorem}
 
@@ -47,20 +47,20 @@ explicit input.
     \leanok
     This is an immediate unraveling of the definitions: both constructions are
     obtained from the same parent Hamiltonian by conjugating with the canonical
-    identification between the site space and the Hilbert-space realization, so
+    identification between the site space and the $\ell^2$ space, so
     the ground space is precisely the kernel after this identification.
 \end{proof}
 
-\begin{lemma}[Membership in the Hilbert-space parent ground space]
+\begin{lemma}[Membership after the canonical $\ell^2$ identification]
     \label{lem:mem_parent_ground_space_es}
     \lean{MPSTensor.mem_parentHamiltonianGroundSpaceES_iff}
     \leanok
     \uses{thm:parent_ground_space_es_kernel}
-    A vector belongs to the Hilbert-space parent ground space exactly when the
+    A vector belongs to the identified parent ground space exactly when the
     parent Hamiltonian annihilates it.
 \end{lemma}
 
-\begin{remark}[Hilbert-space local projectors]
+\begin{remark}[Local projectors under the canonical $\ell^2$ identification]
     \label{rem:euclidean_local_projector_ingredients}
     \lean{MPSTensor.parentInteractionES}
     \lean{MPSTensor.cyclicRestrictES}
@@ -71,8 +71,9 @@ explicit input.
     Let $P_L^{\mathrm{ES}}(A)$ denote the orthogonal projector onto
     $(G_L^{\mathrm{ES}}(A))^\perp$ on the canonical $\ell^2$ $L$-site Hilbert
     space. For a cyclic window starting at $i$ and an outside configuration
-    $\tau$, the boundary-filled restriction map $R_{i,\tau}$ evaluates an
-    $N$-site vector in this realization on that window. The local term
+    $\tau$, the map $R_{i,\tau}$ restricts an $N$-site vector to that
+    length-$L$ cyclic window with the outside configuration fixed by $\tau$.
+    The local term
     $h_{i,\mathrm{ES}}$ is the corresponding
     $N$-site local projector, and $R_{i,\tau}^{\dagger} P_L^{\mathrm{ES}}(A) R_{i,\tau}$ is
     the basic positive summand in its cyclic-averaging formula.
@@ -189,8 +190,9 @@ explicit input.
     \leanok
     \uses{lem:parent_interaction_es_kernel, rem:euclidean_local_projector_ingredients}
     For $L\le N$, a Hilbert-space local term $h_{i,\mathrm{ES}}$ annihilates a
-    vector $v$ iff every boundary-filled restriction of $v$ to the cyclic
-    $L$-window starting at $i$ lies in $G_L^{\mathrm{ES}}(A)$.
+    vector $v$ iff every restriction of $v$ to the cyclic length-$L$ window
+    starting at $i$, with the outside configuration fixed, lies in
+    $G_L^{\mathrm{ES}}(A)$.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -34,7 +34,7 @@ explicit input.
     $\ell^{2}(\{0,\ldots,d-1\}^N)$.
 \end{definition}
 
-\begin{theorem}[Kernel after the canonical $\ell^2$ identification]
+\begin{theorem}[Kernel under the canonical $\ell^2$ identification]
     \label{thm:parent_ground_space_es_kernel}
     \lean{MPSTensor.parentHamiltonianGroundSpaceES_eq_ker_parentHamiltonianES}
     \leanok
@@ -51,12 +51,12 @@ explicit input.
     the ground space is precisely the kernel after this identification.
 \end{proof}
 
-\begin{lemma}[Membership after the canonical $\ell^2$ identification]
+\begin{lemma}[Membership criterion under the canonical $\ell^2$ identification]
     \label{lem:mem_parent_ground_space_es}
     \lean{MPSTensor.mem_parentHamiltonianGroundSpaceES_iff}
     \leanok
     \uses{thm:parent_ground_space_es_kernel}
-    A vector belongs to the identified parent ground space exactly when the
+    A vector belongs to $\mathcal G_{N,L}^{\mathrm{ES}}(A)$ exactly when the
     parent Hamiltonian annihilates it.
 \end{lemma}
 


### PR DESCRIPTION
## Summary

This PR replaces two pieces of reader-facing spectral-gap blueprint prose with terminology closer to the martingale-method source discussion.

It describes the transported parent Hamiltonian and ground space through the canonical `ll^2` identification, and describes `R_{i,	au}` as restriction to a cyclic length-`L` window with the outside configuration fixed. This avoids the less source-facing phrases “Hilbert-space realization” and “boundary-filled restriction”.

No Lean declarations, theorem statements, proofs, labels, or blueprint status tags are changed.

Refs #952. Refs #460.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "Hilbert-space realization|boundary-filled restriction" blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex` returned no matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tex prose and titles only; no Lean, labels, or formal statements are modified.
> 
> **Overview**
> Reader-facing prose in `ch13_parent_hamiltonian_spectral_gap.tex` is retitled and reworded so the transported parent Hamiltonian and ground space are described via the **canonical \(\ell^2\) identification** instead of “Hilbert-space realization,” including matching tweaks in a kernel proof.
> 
> The remark on local projectors and **Lemma (local-term kernel via cyclic restrictions)** now describe **`R_{i,\tau}`** as restriction to a cyclic length-\(L\) window with the outside configuration fixed by \(\tau\), replacing “boundary-filled restriction.”
> 
> **Lean links, labels, theorem statements, and proofs are unchanged**—only exposition and environment titles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2072262d75b621f7608672206d6f4003b2284b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->