### PR TITLE
doc(parent): align normal-boundary reduction prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_boundary.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_boundary.tex
@@ -30,9 +30,13 @@ $\MN{D}$.
 \begin{proof}
     \leanok
     Induct on $K$. For $K = 0$ the empty suffix gives $Z_u = A^u Y_{\emptyset}$.
-    For the successor step, fix the first physical index and apply the induction
-    hypothesis to the shortened suffix. This reduces the statement to letter
-    equation on the right. Extending that letter equation to all
+    For the successor step, fix the first physical index $i$ and apply the
+    induction hypothesis to the shortened suffix. This gives a matrix $X_i$
+    satisfying
+    \[
+        Z_u A^i = A^u X_i
+    \]
+    for every word $u$ of length $L_0$. Extending this letter equation to all
     length-$L_0$ words and decomposing $\Id$ in the spanning family
     $\{A^u : |u| = L_0\}$ yields a common factor $X$.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_boundary.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_boundary.tex
@@ -1,8 +1,9 @@
-\section{Reducing long-word relations to the injectivity length}\label{sec:block_word_stripping}
+\section{Injectivity-length reduction for the closure property}\label{sec:block_word_stripping}
 
-This section reduces a commutation or annihilation relation that holds for all
-long word products $A^w$ back to the injectivity length $L_0$, then uses this
-reduction in the periodic-boundary closure-property step. Throughout,
+This section implements the inverting-and-growing-back reduction from
+\cite[Section~IV.C]{Cirac2021Matrix}: a commutation or annihilation relation
+for length-$m$ word products is reduced to the injectivity length $L_0$, then
+used in the periodic-boundary closure-property step. Throughout,
 $A^w := A^{i_1}\cdots
 A^{i_L}$ denotes the product along a word $w = (i_1,\ldots,i_L)$, $\Gamma_N$
 sends a boundary matrix to its open-chain vector, and $A$ being
@@ -10,7 +11,7 @@ sends a boundary matrix to its open-chain vector, and $A$ being
 relation valid on every length-$L_0$ product extends by linearity to all of
 $\MN{D}$.
 
-\begin{theorem}[Common right factor from block-word compatibility]
+\begin{theorem}[Common right factor from suffix equations]
     \label{thm:block_word_strip_right_factor}
     \lean{MPSTensor.exists_right_factor_of_block_word_compatibility}
     \leanok
@@ -31,7 +32,7 @@ $\MN{D}$.
     Induct on $K$. For $K = 0$ the empty suffix gives $Z_u = A^u Y_{\emptyset}$.
     For the successor step, fix the first physical index and apply the induction
     hypothesis to the shortened suffix. This reduces the statement to letter
-    compatibility on the right. Extending that letter compatibility to all
+    equation on the right. Extending that letter equation to all
     length-$L_0$ words and decomposing $\Id$ in the spanning family
     $\{A^u : |u| = L_0\}$ yields a common factor $X$.
 \end{proof}
@@ -77,7 +78,7 @@ $\MN{D}$.
     to the identity matrix.
 \end{proof}
 
-\begin{theorem}[Block-word commutation from long-word commutation]
+\begin{theorem}[Injectivity-length commutation from length-$m$ commutation]
     \label{thm:block_word_strip_commutes}
     \lean{MPSTensor.commutes_block_words_of_commutes_long_words_of_isNBlkInjective}
     \leanok
@@ -100,7 +101,7 @@ $\MN{D}$.
     length-$L_0$ words shows $R = X$, hence $X A^u = A^u X$.
 \end{proof}
 
-\begin{theorem}[Centrality from long-word commutation]
+\begin{theorem}[Centrality from length-$m$ commutation]
     \label{thm:block_word_strip_central}
     \lean{MPSTensor.commutes_all_of_commutes_long_words_of_isNBlkInjective}
     \leanok
@@ -189,7 +190,7 @@ $\MN{D}$.
     right multiplication in place of left multiplication.
 \end{proof}
 
-\begin{lemma}[Generator commutation from long-word commutation]
+\begin{lemma}[Generator commutation from length-$m$ commutation]
     \label{lem:boundary_matrix_commutes_long_words}
     \lean{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_long_word_commutes}
     \leanok
@@ -203,7 +204,7 @@ $\MN{D}$.
     Apply Theorem~\ref{thm:block_word_strip_central} with $M = A^i$.
 \end{proof}
 
-\begin{theorem}[MPS-line containment from long-word commutation]
+\begin{theorem}[MPS-line containment from length-$m$ commutation]
     \label{thm:ground_space_map_mpv_of_long_word_commutes}
     \lean{MPSTensor.groundSpaceMap_mem_mpvSubmodule_of_isNBlkInjective_of_long_word_commutes}
     \leanok


### PR DESCRIPTION
## Summary

This PR replaces reader-facing “long-word” and “block-word compatibility” phrasing in the normal-boundary part of the parent-Hamiltonian blueprint with source-facing language from the closure-property discussion: the inverting-and-growing-back reduction to the injectivity length.

The mathematical statements and displayed equations are unchanged. Stable labels, Lean declaration references, and blueprint status tags are unchanged.

Refs #2405. Refs #460.

## Validation

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "long-word|block-word compatibility|Block-word|compatibility on the right|long word" blueprint/src/chapter/ch13_parent_hamiltonian_normal_boundary.tex` returned no matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX prose and proof exposition only; no Lean or mathematical statement changes.
> 
> **Overview**
> **Documentation-only** alignment of `ch13_parent_hamiltonian_normal_boundary.tex` with the closure-property / Cirac inverting-and-growing-back narrative.
> 
> The section title becomes **“Injectivity-length reduction for the closure property”**; the opening paragraph cites Cirac Section IV.C and describes reduction of length-$m$ commutation/annihilation to injectivity length $L_0$. Theorem and lemma **titles** are retitled (e.g. “suffix equations”, “length-$m$ commutation” instead of “long-word” / “block-word compatibility”). One proof step is spelled out explicitly: fixing physical index $i$, induction yields $Z_u A^i = A^u X_i$ before extending to all length-$L_0$ words.
> 
> **Unchanged:** displayed equations, `\label{}` names, `\lean{}` declarations, and `\leanok` / `\uses{}` tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2186833d3a17637e3f35926d393db7a0fda58197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->