### PR TITLE
doc(parent): align local ground-space identification prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
@@ -7,7 +7,7 @@
     \[
         \mathcal H_{N}^{(d)} := \{0,\ldots,d{-}1\}^{N} \to \C.
     \]
-    This is the computational-basis realization used throughout the chapter for
+    This is the computational-basis identification used throughout the chapter for
     periodic-chain states.
 \end{definition}
 
@@ -87,7 +87,7 @@ $A^{\sigma(0)}\cdots A^{\sigma(L-1)}$.
 \begin{lemma}[Ambient-space dimension]\label{lem:nsite_space_finrank}
     \lean{MPSTensor.nSiteSpace_finrank}
     \leanok
-    The above Hilbert-space realization satisfies
+    The above coefficient space satisfies
     \[
         \dim\!(\{0,\ldots,d{-}1\}^L \to \C)=d^L.
     \]
@@ -123,7 +123,7 @@ The canonical parent interaction at range $L$ is
 The sources also allow any positive local interaction with this kernel; the
 orthogonal projector is the canonical representative used here.
 
-\begin{definition}[Local ground space in the canonical \texorpdfstring{$\ell^2$}{l2} realization]\label{def:ground_space_es}
+\begin{definition}[Local ground space under the canonical \texorpdfstring{$\ell^2$}{l2} identification]\label{def:ground_space_es}
     \lean{MPSTensor.groundSpaceES}
     \leanok
     \uses{def:nsite_space_parent, def:ground_space_parent}
@@ -134,14 +134,14 @@ orthogonal projector is the canonical representative used here.
         \simeq \ell^{2}(\{0,\ldots,d{-}1\}^{L})
     \]
     be the canonical computational-basis identification. The local ground space
-    in this $\ell^2$ realization is
+    under this $\ell^2$ identification is
     \[
         G_{L}^{\mathrm{ES}}(A):=\iota_L(G_L(A))
         \subseteq \ell^{2}(\{0,\ldots,d{-}1\}^{L}).
     \]
 \end{definition}
 
-\begin{lemma}[Membership in the canonical \texorpdfstring{$\ell^2$}{l2} realization]\label{lem:mem_ground_space_es}
+\begin{lemma}[Membership under the canonical \texorpdfstring{$\ell^2$}{l2} identification]\label{lem:mem_ground_space_es}
     \lean{MPSTensor.mem_groundSpaceES_iff}
     \leanok
     \uses{def:ground_space_es, def:ground_space_parent}
@@ -377,7 +377,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
     Appending a last letter to a word corresponds to right multiplication by the
     corresponding tensor letter, while prepending a first letter corresponds to left
     multiplication. The restriction maps are the associated linear maps on the
-    Hilbert spaces in the computational-basis realization, together with their
+    state spaces under the computational-basis identification, together with their
     pointwise formulas.
 \end{remark}
 


### PR DESCRIPTION
## Summary
- replace remaining “realization” phrasing in the local ground-space setup by computational-basis and canonical \(\ell^2\) identification language
- keep all blueprint labels, `\lean{}` tags, and `\leanok` status tags unchanged
- leave the mathematical spectral-gap and parent-Hamiltonian trackers open

Refs #952.
Refs #460.
Refs #190.

## Checks
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording in a LaTeX blueprint chapter; no code, APIs, or formal proof content changed.
> 
> **Overview**
> **Terminology-only** edits in `ch13_parent_hamiltonian_injective_ground_spaces.tex` so reader-facing prose matches the computational-basis / canonical \(\ell^2\) **identification** wording used elsewhere.
> 
> Swaps “realization” for “identification” in the \(N\)-site Hilbert space definition, renames the ambient-space lemma to refer to the **coefficient space**, retitles the \(\ell^2\) ground-space definition and membership lemma to “under the canonical … identification”, and updates the restriction remark to “state spaces under the computational-basis identification”. **Labels, `\lean{}` tags, and math are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a79bbe5ac5975542f10c6d9cc0416a8450a9bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->