### PR TITLE
doc(parent): align BNT representative prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -9,7 +9,7 @@ of the single-block periodic ground spaces
 the periodic-boundary comparison with block-diagonal boundary conditions:
 boundary-condition equations and single-block periodic-boundary membership.
 
-\begin{lemma}[Normalized BNT blocks give the large-length block intersection]
+\begin{lemma}[Normalized BNT representatives give the large-length block intersection]
     \label{lem:bnt_direct_sum_unital_block_intersection_ge}
     \lean{MPSTensor.pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1}
@@ -18,8 +18,10 @@ boundary-condition equations and single-block periodic-boundary membership.
     \uses{lem:unital_block_separating_product_span,
         lem:product_span_block_image_direct_sum,
         lem:block_restriction_intersection_subspace}
-    Let $A^1,\ldots,A^r$ be separated BNT blocks, each irreducible, in
-    left-canonical form, and with normalized self-overlap. Suppose $L_0>0$, and
+    Let $A^1,\ldots,A^r$ be normalized representatives of a basis of normal
+    tensors: each representative is irreducible and left-canonical, has
+    normalized self-overlap, and no two distinct same-dimensional representatives
+    are gauge-phase equivalent. Suppose $L_0>0$, and
     for every block $j$ the map
     \[
         \Gamma_{L_0}^{A^j}:\MN{D_j}\to
@@ -72,13 +74,15 @@ boundary-condition equations and single-block periodic-boundary membership.
     $n+2$ gives the two directness statements.
 \end{proof}
 
-\begin{lemma}[Normalized BNT blocks give an eventual block intersection]
+\begin{lemma}[Normalized BNT representatives give an eventual block intersection]
     \label{lem:bnt_direct_sum_unital_block_intersection}
     \lean{MPSTensor.pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital_c1}
     \leanok
     \uses{lem:bnt_direct_sum_unital_block_intersection_ge}
-    Let $A^1,\ldots,A^r$ be separated BNT blocks, each irreducible, in
-    left-canonical form, and with normalized self-overlap. Suppose $L_0>0$, and
+    Let $A^1,\ldots,A^r$ be normalized representatives of a basis of normal
+    tensors: each representative is irreducible and left-canonical, has
+    normalized self-overlap, and no two distinct same-dimensional representatives
+    are gauge-phase equivalent. Suppose $L_0>0$, and
     for every block $j$ the map
     \[
         \Gamma_{L_0}^{A^j}:\MN{D_j}\to
@@ -237,7 +241,8 @@ boundary-condition equations and single-block periodic-boundary membership.
     \leanok
     \uses{lem:bnt_direct_sum_unital_block_intersection_ge,
         lem:block_diagonal_periodic_constraints_propagated_sum}
-    Let $A_1,\ldots,A_g$ be separated normalized BNT blocks. Suppose
+    Let $A_1,\ldots,A_g$ be normalized representatives of a basis of normal
+    tensors, with no gauge-phase-equivalent distinct representatives. Suppose
     $L_0>0$, and for every block $j$ the map
     \[
         \Gamma_{L_0}^{A^j}:\MN{D_j}\to

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -19,9 +19,9 @@ boundary-condition equations and single-block periodic-boundary membership.
         lem:product_span_block_image_direct_sum,
         lem:block_restriction_intersection_subspace}
     Let $A^1,\ldots,A^r$ be normalized representatives of a basis of normal
-    tensors: each representative is irreducible and left-canonical, has
-    normalized self-overlap, and no two distinct same-dimensional representatives
-    are gauge-phase equivalent. Suppose $L_0>0$, and
+    tensors: each representative is irreducible, the family is left-canonical,
+    the self-overlaps are normalized, and no two distinct same-dimensional
+    representatives are gauge-phase equivalent. Suppose $L_0>0$, and
     for every block $j$ the map
     \[
         \Gamma_{L_0}^{A^j}:\MN{D_j}\to
@@ -80,9 +80,9 @@ boundary-condition equations and single-block periodic-boundary membership.
     \leanok
     \uses{lem:bnt_direct_sum_unital_block_intersection_ge}
     Let $A^1,\ldots,A^r$ be normalized representatives of a basis of normal
-    tensors: each representative is irreducible and left-canonical, has
-    normalized self-overlap, and no two distinct same-dimensional representatives
-    are gauge-phase equivalent. Suppose $L_0>0$, and
+    tensors: each representative is irreducible, the family is left-canonical,
+    the self-overlaps are normalized, and no two distinct same-dimensional
+    representatives are gauge-phase equivalent. Suppose $L_0>0$, and
     for every block $j$ the map
     \[
         \Gamma_{L_0}^{A^j}:\MN{D_j}\to
@@ -242,9 +242,9 @@ boundary-condition equations and single-block periodic-boundary membership.
     \uses{lem:bnt_direct_sum_unital_block_intersection_ge,
         lem:block_diagonal_periodic_constraints_propagated_sum}
     Let $A_1,\ldots,A_g$ be normalized representatives of a basis of normal
-    tensors: each representative is irreducible and left-canonical, has
-    normalized self-overlap, and no two distinct same-dimensional representatives
-    are gauge-phase equivalent. Suppose
+    tensors: each representative is irreducible, the family is left-canonical,
+    the self-overlaps are normalized, and no two distinct same-dimensional
+    representatives are gauge-phase equivalent. Suppose
     $L_0>0$, and for every block $j$ the map
     \[
         \Gamma_{L_0}^{A^j}:\MN{D_j}\to

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -242,7 +242,9 @@ boundary-condition equations and single-block periodic-boundary membership.
     \uses{lem:bnt_direct_sum_unital_block_intersection_ge,
         lem:block_diagonal_periodic_constraints_propagated_sum}
     Let $A_1,\ldots,A_g$ be normalized representatives of a basis of normal
-    tensors, with no gauge-phase-equivalent distinct representatives. Suppose
+    tensors: each representative is irreducible and left-canonical, has
+    normalized self-overlap, and no two distinct same-dimensional representatives
+    are gauge-phase equivalent. Suppose
     $L_0>0$, and for every block $j$ the map
     \[
         \Gamma_{L_0}^{A^j}:\MN{D_j}\to

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -390,7 +390,9 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
         lem:isup_chain_ground_space_block_le_assembled,
         lem:bnt_block_diagonal_periodic_constraints_internal_sum}
     Let $A_1,\ldots,A_g$ be normalized representatives of a basis of normal
-    tensors, with no gauge-phase-equivalent distinct representatives, and let
+    tensors: each representative is irreducible and left-canonical, has
+    normalized self-overlap, and no two distinct same-dimensional representatives
+    are gauge-phase equivalent, and let
     \[
         B=\bigoplus_{j=1}^g\mu_jA_j,
         \qquad \mu_j\ne0.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -389,8 +389,8 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
     \uses{lem:block_diagonal_boundary_decomposition_inclusion,
         lem:isup_chain_ground_space_block_le_assembled,
         lem:bnt_block_diagonal_periodic_constraints_internal_sum}
-    Let $A_1,\ldots,A_g$ be separated normalized blocks in the basis of normal
-    tensors, and let
+    Let $A_1,\ldots,A_g$ be normalized representatives of a basis of normal
+    tensors, with no gauge-phase-equivalent distinct representatives, and let
     \[
         B=\bigoplus_{j=1}^g\mu_jA_j,
         \qquad \mu_j\ne0.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -390,9 +390,9 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
         lem:isup_chain_ground_space_block_le_assembled,
         lem:bnt_block_diagonal_periodic_constraints_internal_sum}
     Let $A_1,\ldots,A_g$ be normalized representatives of a basis of normal
-    tensors: each representative is irreducible and left-canonical, has
-    normalized self-overlap, and no two distinct same-dimensional representatives
-    are gauge-phase equivalent, and let
+    tensors: each representative is irreducible, the family is left-canonical,
+    the self-overlaps are normalized, and no two distinct same-dimensional
+    representatives are gauge-phase equivalent, and let
     \[
         B=\bigoplus_{j=1}^g\mu_jA_j,
         \qquad \mu_j\ne0.


### PR DESCRIPTION
Summary:
- Replace reader-facing "separated BNT blocks" language by normalized representatives of a basis of normal tensors.
- Make the gauge-phase non-equivalence condition explicit in the affected block-intersection statements.
- Leave Lean declarations, equations, and blueprint tags unchanged.

Refs #2651.
Refs #190.

Checks:
- git diff --check
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --ci

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to LaTeX lemma titles and hypothesis wording; no Lean or proof logic changes.
> 
> **Overview**
> Reader-facing hypotheses in four block-diagonal blueprint lemmas are retitled and rewritten so **“separated BNT blocks”** becomes **normalized representatives of a basis of normal tensors**, with irreducibility, left-canonical form, normalized self-overlap, and **no gauge-phase equivalence among same-dimensional pairs** spelled out in the lemma body instead of implied by “separated.”
> 
> **Lean** `\lean{...}` names, equations, and `\leanok` tags are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1e2e0773b0223c5eef0206cf9863d59f0108c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->