### PR TITLE
doc(parent): align BNT trace-consequence prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -483,9 +483,10 @@ parent-Hamiltonian ground space.
         \C\,V^{(N)}(A)=\C\,V^{(N)}(B),
     \]
     by equality of the periodic-boundary constraint spaces, followed by
-    injective uniqueness. For same-dimensional separated BNT blocks, the
-    non-equivalence condition supplies this non-proportionality at arbitrarily
-    large chain lengths; the direct-sum injectivity hypotheses remain
+    injective uniqueness. For same-dimensional normalized BNT representatives
+    that are not gauge-phase equivalent, the non-equivalence condition supplies
+    this non-proportionality at arbitrarily large chain lengths; the
+    direct-sum injectivity hypotheses remain
     explicit. Combining the equal-dimension and unequal-dimension branches
     over all ordered block pairs gives one common positive length $S_0$ with
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -18,9 +18,11 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
         lem:pair_trace_separation_to_pairwise_block_separation,
         lem:block_separating_equations_from_pairwise_separation,
         lem:product_word_span_from_bnt_block_separation}
-    Let $A^1,\ldots,A^r$ be separated BNT blocks satisfying the
-    irreducibility, left-canonicality, and normalized self-overlap hypotheses
-    used in the direct-sum comparison. Fix $L_0>0$. Assume that, for every
+    Let $A^1,\ldots,A^r$ be normalized representatives of a basis of normal
+    tensors: each representative is irreducible, the family is left-canonical,
+    the self-overlaps are normalized, and no two distinct same-dimensional
+    representatives are gauge-phase equivalent. Fix $L_0>0$. Assume that, for
+    every
     block $j$, the map
     \[
         \Gamma_{L_0}^{A^j}:\MN{D_j}\to
@@ -57,7 +59,8 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
     \leanok
     Lemma~\ref{lem:direct_sum_two_block_dimension_step} gives homogeneous
     trace separation at length $3(L_0+1)$ for every ordered pair of distinct
-    BNT blocks. Lemma~\ref{lem:pair_trace_separation_to_pairwise_block_separation}
+    normalized BNT representatives.
+    Lemma~\ref{lem:pair_trace_separation_to_pairwise_block_separation}
     converts these trace-separation equations into the displayed pairwise
     block-separating equations. Multiplying the equations for the $r-1$
     blocks different from $k$ gives a block-separating equation for $k$, and
@@ -699,7 +702,7 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
 
 Propagating the single-length product span through a period window gives the
 block-intersection identity for all sufficiently large $n$, both from a general
-period window and from the separated BNT hypotheses. The full product span at
+period window and from the normalized BNT representative hypotheses. The full product span at
 length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
 
 \begin{lemma}[Period-window form of the block intersection identity]
@@ -788,10 +791,11 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
         lem:pair_trace_separation_to_pairwise_block_separation,
         lem:block_separating_equations_from_pairwise_separation,
         lem:period_window_block_restriction_intersection}
-    Let $A^1,\ldots,A^r$ be separated BNT blocks satisfying the
-    irreducibility, left-canonicality, and normalized self-overlap hypotheses
-    used in the direct-sum comparison. Assume $L>1$, and assume that, for
-    every block $j$,
+    Let $A^1,\ldots,A^r$ be normalized representatives of a basis of normal
+    tensors: each representative is irreducible, the family is left-canonical,
+    the self-overlaps are normalized, and no two distinct same-dimensional
+    representatives are gauge-phase equivalent. Assume $L>1$, and assume that,
+    for every block $j$,
     \[
         \spn\{A^j_a:a=0,\ldots,d-1\}=\MN{D_j},
         \qquad
@@ -890,7 +894,8 @@ length $n$ also makes the sum of the local spaces $G_n(A^j)$ direct.
         =
         \prod_j \MN{D_j}.
     \]
-    In particular, for separated BNT blocks satisfying the same normalization,
+    In particular, for normalized BNT representatives satisfying the displayed
+    unital normalization,
     if $L_0>0$ and $\Gamma_{L_0}^{A^j}$ is injective for every block $j$,
     the same conclusion holds with
     \[


### PR DESCRIPTION
Summary:
- Replace remaining "separated BNT blocks" shorthand in the block-intersection trace-consequence blueprint with normalized representatives of a basis of normal tensors.
- State the irreducibility, left-canonical family, normalized self-overlap, and gauge-phase non-equivalence hypotheses explicitly where the tagged Lean statements require them.
- Leave all Lean declarations, equations, labels, and blueprint tags unchanged.

Refs #2651.
Refs #190.

Checks:
- git diff --check
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --ci

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reader-facing LaTeX prose only; no code, APIs, or formal proof statements modified.
> 
> **Overview**
> **Documentation-only** updates in the parent-Hamiltonian block-intersection trace-consequence blueprint (`ch13_parent_hamiltonian_block_intersections.tex` and `ch13_parent_hamiltonian_block_intersections_trace_consequences.tex`).
> 
> The shorthand **“separated BNT blocks”** is replaced by **normalized representatives of a basis of normal tensors**, with the hypotheses spelled out where the tagged Lean statements need them: irreducibility, left-canonical family, normalized self-overlaps, and **no gauge-phase equivalence** among distinct same-dimensional representatives. Wording is aligned in the dimension-step discussion (non-proportionality from non-equivalence), main BNT direct-sum lemmas, period-window block-intersection lemma, and the unital product-span corollary.
> 
> **Lean tags, equations, labels, and declarations are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab2259ee1ab0ad3729b853b3d2f9a80999614c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->