### PR TITLE
doc(parent): align overview martingale prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -18,21 +18,22 @@ an injective tensor, when $N\ge2$ and $1<L\le N$, the parent Hamiltonian is
 frustration-free and the periodic MPS vector $V^{(N)}(A)$ is its unique ground
 state, obtained from the intersection property of the local ground spaces. For a
 normal tensor the corresponding conclusion follows, under the stated
-periodic-boundary comparison and length hypotheses, after inverting a long-word
-commutation back to the injectivity length.
+closure-property and length hypotheses, from the inverting-and-growing-back
+argument at the injectivity length.
 When the length-two local terms commute, the construction records the
 zero-energy part of the condition that $V^{(N)}(A)$ is a ground state of a
 nearest-neighbor commuting parent Hamiltonian in the pure-state theorem relating
 renormalization fixed points, zero correlation length, and such ground states in
 \cite{Cirac2016MPDO_arXiv}. The spectral-gap section records the martingale
-row-sum criterion and keeps the overlapping-window principal-angle estimate as
+condition for overlapping local terms and keeps the principal-angle estimate as
 an explicit hypothesis. For a tensor in block-injective canonical form
 $A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$,
 \cite[Theorem~IV.16]{Cirac2021Matrix}
 (\cite[Theorem~12]{PerezGarcia2007Matrix}) states that the periodic
 parent-Hamiltonian ground space is spanned by the vectors
-$\{V^{(N)}(A_j)\}$. The sections below establish open-segment recursion and
-conditional reductions to the periodic-boundary comparison toward this theorem.
+$\{V^{(N)}(A_j)\}$. The sections below establish the intersection property for
+open segments and the closure-property inclusion at the periodic boundary toward
+this theorem.
 
 \input{chapter/ch13_parent_hamiltonian_injective_ground_spaces}
 \input{chapter/ch13_parent_hamiltonian_injective_boundary}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -9,10 +9,9 @@ Nachtergaele~\cite{Fannes1992Finitely, Nachtergaele1996Spectral}, as recalled
 by Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
 and in the later formulation of Kastoryano and
 Lucia~\cite{Kastoryano2018Martingale}, reduces a uniform gap to principal-angle
-estimates for overlapping local ground spaces. The results below establish the
-finite-row and cyclic-window reductions in the present convention; the
-MPS-specific principal-angle, equivalently norm-compression, estimate remains an
-explicit input.
+estimates for overlapping local ground spaces. The results below state the
+martingale condition for the cyclic-window local terms; the MPS-specific
+principal-angle estimate remains an explicit input.
 
 \begin{definition}[Parent ground space under the canonical $\ell^2$ identification]
     \label{def:parent_ground_space_es}
@@ -203,7 +202,7 @@ explicit input.
     local projector with membership in $G_L^{\mathrm{ES}}(A)$.
 \end{proof}
 
-\begin{theorem}[Adjacent local kernels realize the intersection property]
+\begin{theorem}[Intersection property for two adjacent local kernels]
     \label{thm:adjacent_local_kernels_ground_space_es}
     \lean{MPSTensor.mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero}
     \lean{MPSTensor.adjacent_localTermES_eq_zero_of_mem_groundSpaceES_succ}
@@ -303,7 +302,7 @@ explicit input.
         \ge \gamma^2 \sum_k |c_k|^2 = \gamma^2 \|v\|^2$.
 \end{proof}
 
-\subsection{Finite projection row-sum reductions}\label{subsec:spectral_gap_rowsum}
+\subsection{Martingale condition for a finite family of projections}\label{subsec:spectral_gap_rowsum}
 
 \begin{lemma}[Parent-Hamiltonian quadratic-form reduction]
     \label{lem:parent_hamiltonian_es_quadratic_reduction}
@@ -448,7 +447,7 @@ explicit input.
     reduction then applies.
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian ordered row-sum quadratic-form reduction]
+\begin{lemma}[Quadratic-form estimate from the martingale condition]
     \label{lem:parent_hamiltonian_ordered_rowsum_quadratic}
     \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds}
     \leanok
@@ -731,13 +730,13 @@ explicit input.
     \leanok
     \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
     Apply Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}.
-    Its non-overlap positivity and finite-row hypotheses are already internal to
+    Its non-overlap positivity and finite-family hypotheses are already internal to
     the preceding reduction; the overlapping estimate
     (\ref{eq:ph_cyclic_overlap_friedrichs}) supplies its remaining ordered
     cross-term condition.
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian gap from an overlapping cyclic norm-compression estimate]
+\begin{lemma}[Parent-Hamiltonian gap from a principal-angle bound for overlapping cyclic windows]
     \label{lem:parent_hamiltonian_cyclic_overlap_norm_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound}
     \leanok


### PR DESCRIPTION
Summary:
- Align the parent-Hamiltonian chapter overview with source terminology: intersection property, closure property, and inverting-and-growing-back.
- Retitle spectral-gap martingale entries around the martingale condition and principal-angle input.
- Leave formulas, labels, Lean declarations, and blueprint tags unchanged.

Refs #2405.
Refs #952.
Refs #190.
Refs #460.

Checks:
- git diff --check
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --ci

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX documentation and display titles only; no code, proofs, or blueprint–Lean bindings were modified.
> 
> **Overview**
> **Documentation-only** updates to the parent-Hamiltonian blueprint chapter so reader-facing language matches the source terminology (intersection property, closure property, inverting-and-growing-back, martingale condition). **No** formulas, labels, Lean declarations, or mathematical content change.
> 
> The **chapter overview** now describes normal-tensor ground states via the **closure property** and **inverting-and-growing-back** (replacing periodic-boundary comparison / long-word commutation wording), the spectral-gap blurb as the **martingale condition** for overlapping local terms with the **principal-angle estimate** as explicit input, and the block-theorem roadmap as **intersection property on open segments** plus **closure-property inclusion** at the periodic boundary.
> 
> The **spectral-gap section** intro and several **theorem/lemma/subsection titles** are retitled around the martingale condition and principal-angle bounds (e.g. adjacent-kernels theorem, finite-family projections subsection, quadratic-form and cyclic-overlap gap lemmas). One proof line swaps “finite-row” for **finite-family** hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d36d0fb7a0d3834ab74cd88faa98f47b017b266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->