### PR TITLE
doc(parent-hamiltonian): separate NNCPH ground-vector and ground-space scopes

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -14,7 +14,10 @@ import TNLean.Axioms.Beigi
 
 This file records the commutation equations for parent Hamiltonians and the
 length-two specialization used in the nearest-neighbor commuting parent
-Hamiltonian part of arXiv:1606.00608.
+Hamiltonian part of arXiv:1606.00608. In the source, Definition 3.9 also
+requires the parent-Hamiltonian ground space to be spanned by the periodic MPS
+vectors associated to the BNT components; that spanning condition is not part
+of the predicates in this file.
 
 ## Main definitions
 
@@ -23,7 +26,8 @@ Hamiltonian part of arXiv:1606.00608.
 * `MPSTensor.IsNNCPH A N` — length-two commutativity of the translated parent
   interaction terms.
 * `MPSTensor.IsNNCPHGroundState A N` — the length-two local terms commute and
-  annihilate the periodic MPS vector.
+  annihilate the periodic MPS vector \(V^{(N)}(A)\): it is the conjunction of
+  `IsNNCPH A N` and `IsFrustrationFree A 2 N (mpv A)`.
 
 ## Main results
 
@@ -40,10 +44,12 @@ Hamiltonian part of arXiv:1606.00608.
 * `MPSTensor.rfp_implies_nncph` — construction of the length-two commutation
   equations in the RFP \(\Longrightarrow\) NNCPH direction of Theorem 3.10.
 * `MPSTensor.rfp_implies_nncph_ground_state` — the same direction with the
-  zero-energy ground-vector equation for the MPS vector included.
+  zero-energy ground-vector equation for the MPS vector included, but without
+  the source ground-space spanning assertion.
 * `MPSTensor.nncph_implies_rfp` — axiom-backed reverse implication from
   pairwise length-two commutativity to RFP. The source NNCPH condition also
-  includes the parent-Hamiltonian ground-space statement recorded below.
+  includes the parent-Hamiltonian ground-space spanning statement recorded
+  below.
 
 ## References
 
@@ -66,7 +72,8 @@ See arXiv:1606.00608, Definition 3.9. The source writes the local translated
 condition as $[\tau_j(P_L),P_L]=0$ for the interacting translates; this
 predicate records the resulting pairwise commutativity of the translated local
 terms. The source definition of a parent Hamiltonian also includes the
-ground-space spanning condition. -/
+ground-space spanning condition by the periodic MPS vectors of the BNT
+components. -/
 def IsCommutingParentHam (A : MPSTensor d D) (L N : ℕ) : Prop :=
   ∀ i j : Fin N,
     localTerm A L N i * localTerm A L N j = localTerm A L N j * localTerm A L N i
@@ -74,9 +81,9 @@ def IsCommutingParentHam (A : MPSTensor d D) (L N : ℕ) : Prop :=
 /-- **Nearest-neighbor commuting parent Hamiltonian** (NNCPH): the length-two
 commutation equations for the translated parent interaction terms.
 
-See arXiv:1606.00608, Definition 3.9. The source definition of a parent
-Hamiltonian also includes the ground-space spanning condition, which is not part
-of this predicate. -/
+See arXiv:1606.00608, Definition 3.9. The source nearest-neighbor condition
+also fixes \(L=2\) and includes the parent-Hamiltonian ground-space spanning
+condition, which is not part of this predicate. -/
 def IsNNCPH (A : MPSTensor d D) (N : ℕ) : Prop :=
   IsCommutingParentHam A 2 N
 
@@ -87,12 +94,14 @@ annihilate the periodic MPS vector V^{(N)}(A).
 See arXiv:1606.00608, Theorem 3.10(iii), source line 539. This predicate records
 the commutativity and annihilation equations for the MPS vector. The full source
 parent-Hamiltonian condition also includes the ground-space spanning assertion
-from Definition 3.9, and Theorem 3.10 also includes the canonical-form and
-zero-correlation-length equivalences.
+from Definition 3.9: for \(N>L\), the ground space is spanned by the periodic
+MPS vectors associated to the BNT components. Theorem 3.10 also includes the
+canonical-form and zero-correlation-length equivalences.
 
-**Scope restriction (ground vector):** These are the zero-energy ground-vector
-equations for the canonical parent interaction, not the full source ground-space
-spanning condition. Documented in
+**Scope restriction (ground vector):** This predicate is exactly
+`IsNNCPH A N ∧ IsFrustrationFree A 2 N (mpv A)`: the length-two commutation
+equation and the zero-energy equation for \(V^{(N)}(A)\). It is not the full
+source ground-space spanning condition. Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 def IsNNCPHGroundState (A : MPSTensor d D) (N : ℕ) : Prop :=
   IsNNCPH A N ∧ IsFrustrationFree A 2 N (mpv A)
@@ -103,22 +112,23 @@ theorem IsNNCPH.isCommutingParentHam {A : MPSTensor d D} {N : ℕ} (h : IsNNCPH 
     IsCommutingParentHam A 2 N :=
   h
 
-/-- A nearest-neighbor commuting parent-Hamiltonian ground state has commuting
+/-- The zero-energy nearest-neighbor ground-vector condition includes commuting
 length-two local terms. -/
 theorem IsNNCPHGroundState.isNNCPH {A : MPSTensor d D} {N : ℕ}
     (h : IsNNCPHGroundState A N) :
     IsNNCPH A N :=
   h.1
 
-/-- A nearest-neighbor commuting parent-Hamiltonian ground state is
-frustration-free for the length-two parent Hamiltonian. -/
+/-- The zero-energy nearest-neighbor ground-vector condition includes the
+frustration-free equation for the length-two parent Hamiltonian. -/
 theorem IsNNCPHGroundState.isFrustrationFree {A : MPSTensor d D} {N : ℕ}
     (h : IsNNCPHGroundState A N) :
     IsFrustrationFree A 2 N (mpv A) :=
   h.2
 
 /-- If the length-two parent terms commute and N ≥ 2, then the periodic MPS
-vector satisfies the NNCPH commutation and zero-energy condition. -/
+vector satisfies the NNCPH commutation and zero-energy condition. This does not
+assert the source ground-space spanning condition. -/
 theorem IsNNCPH.isNNCPHGroundState {A : MPSTensor d D} {N : ℕ}
     (h : IsNNCPH A N) (hN : 2 ≤ N) :
     IsNNCPHGroundState A N :=
@@ -177,8 +187,8 @@ theorem IsCommutingParentHam.ham_comm_localTerm {A : MPSTensor d D} {L N : ℕ}
 
 /-- **Theorem 3.10(i)⟹(iii)** (arXiv:1606.00608): RFP implies the NNCPH
 commutation equations.
-A normal renormalization fixed-point tensor has a nearest-neighbor
-commuting parent Hamiltonian.
+A normal renormalization fixed-point tensor has commuting length-two parent
+terms.
 
 Per arXiv:1606.00608 Section 3.3 (source line 1307), this direction is
 *"trivial from Theorem [charact-MPS]"*; it therefore does not depend
@@ -203,8 +213,9 @@ This theorem adds the frustration-free ground-vector equation to
 
 **Scope restriction (ground vector):** The source theorem states the
 three-way equivalence for canonical-form tensors and requires the full
-parent-Hamiltonian ground-space condition. This theorem proves only the
-commutation and zero-energy equations for $V^{(N)}(A)$. Documented in
+parent-Hamiltonian ground-space condition, namely spanning by the periodic MPS
+vectors of the BNT components. This theorem proves only the commutation and
+zero-energy equations for \(V^{(N)}(A)\). Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem rfp_implies_nncph_ground_state (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)
@@ -222,7 +233,8 @@ Hamiltonians with finite degeneracy (`Axioms.beigi_nncph_to_rfp`).
 $|V^{(N)}(A)\rangle$ is a ground state of a nearest-neighbor commuting parent
 Hamiltonian for every $N>2$, including the parent-Hamiltonian ground-space
 condition. The present theorem takes as hypothesis only the translated
-length-two commutativity equations. Documented in
+length-two commutativity equations; it does not assume that the ground space is
+spanned by the periodic MPS/BNT vectors. Documented in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 
 Note: with the present Lean definition, `IsRFP` is a normalization-sensitive

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -10,12 +10,16 @@ import Mathlib.LinearAlgebra.Projection
 
 This file defines the notion of **decorrelation** for a subspace with
 respect to two disjoint regions, and proves the backward direction of the
-decorrelation--parent-commuting-Hamiltonian equivalence: a parent commuting
+decorrelation--parent-commuting-Hamiltonian equivalence in its algebraic
+idempotent-product form: the product identity obtained from a parent commuting
 Hamiltonian implies decorrelation when observables respect locality.
 
 This is the backward direction of Proposition D.3 from arXiv:1606.00608,
-Appendix D, Section D.2. The forward direction requires tensor-product formulation
-and is deferred.
+Appendix D, Section D.2. The full source condition uses local projectors on
+\(AX\) and \(XB\) and the ground-space intersection
+\(K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})\); the present declaration
+records only the idempotent-product consequence. The forward direction requires
+the tensor-product formulation and is deferred.
 
 ## Main definitions
 
@@ -31,8 +35,9 @@ and is deferred.
 
 ## Main results
 
-* `Decorrelation.commutingHam_isDecorrelated` — parent commuting Hamiltonian →
-  decorrelation (Proposition D.3, backward direction)
+* `Decorrelation.commutingHam_isDecorrelated` — idempotent-product form of
+  parent commuting Hamiltonian → decorrelation (Proposition D.3, backward
+  direction)
 
 ## References
 
@@ -116,7 +121,7 @@ def IsDecorrelated (P_K : E →ₗ[ℂ] E)
   ∀ O_A ∈ ObsA, ∀ O_B ∈ ObsB,
     P_K ∘ₗ O_A ∘ₗ (LinearMap.id - P_K) ∘ₗ O_B ∘ₗ P_K = 0
 
-/-- **Idempotent-product form of the parent commuting Hamiltonian condition.**
+/-- **Idempotent-product consequence of the parent commuting Hamiltonian condition.**
 
 In arXiv:1606.00608, Appendix D.2, Definition D.2, a subspace \(K_{AXB}\)
 corresponds to a parent commuting Hamiltonian when there are local projectors
@@ -126,13 +131,17 @@ corresponds to a parent commuting Hamiltonian when there are local projectors
   K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
 \]
 Writing \(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\), the source proof uses the
-corresponding product identity \(P_{AX}\circ P_{XB}=P_K\).
+corresponding product identity \(P_{AX}\circ P_{XB}=P_K\). The structure below
+records this identity and the commutation of \(P_{AX}\) and \(P_{XB}\), but not
+the full source condition.
 
 **Scope restriction (CPSV16 Definition D.2):** The present declaration records
 this idempotent-product identity and the commutation of \(P_{AX}\) and
-\(P_{XB}\). It does not yet assert tensor-product locality, self-adjointness,
-or orthogonality. Consequently the witness \(P_{AX}=P_{XB}=P_K\) is available
-for any idempotent \(P_K\). Documented in
+\(P_{XB}\). It does not yet assert the source tensor-product locality, the
+local projectors \(Q_{AX}\), \(Q_{XB}\), self-adjointness, orthogonality, or the
+ground-space intersection
+\(K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB})\). Consequently the
+witness \(P_{AX}=P_{XB}=P_K\) is available for any idempotent \(P_K\). Documented in
 `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`. Elimination:
 add tensor-product locality, self-adjointness, and orthogonality, then derive this
 idempotent-product declaration from the source condition.
@@ -170,14 +179,16 @@ def HasCommutingParentHam.ofIdem
   hK := hK_idem
 
 /-- **Proposition D.3, backward direction** (arXiv:1606.00608, Appendix D, Section D.2):
-If a subspace K corresponds to a parent commuting Hamiltonian through
-\(P_K = P_{AX} \circ P_{XB}\) with \([P_{AX}, P_{XB}] = 0\), and observables on
-region A commute with \(P_{XB}\) while observables on region B commute with \(P_{AX}\), then
-regions A and B are decorrelated w.r.t. K.
+If the idempotent-product consequence of a parent commuting Hamiltonian is
+given by \(P_K = P_{AX} \circ P_{XB}\) with
+\([P_{AX}, P_{XB}] = 0\), and observables on region A commute with \(P_{XB}\)
+while observables on region B commute with \(P_{AX}\), then regions A and B are
+decorrelated w.r.t. K.
 
 The commutation hypotheses are scoped to the *specific* witnessing projectors
-\(P_{AX}\) and \(P_{XB}\), not all linear maps. This captures the locality structure:
-A-observables commute with the XB-projector and vice versa.
+\(P_{AX}\) and \(P_{XB}\), not all linear maps. In the source this is supplied
+by the tensor-product locality: A-observables commute with the XB-projector and
+vice versa.
 
 ## Proof outline
 
@@ -193,7 +204,8 @@ composition \(P_K \circ O_A \circ (1 - P_K) \circ O_B \circ P_K\) factors as
 
 The converse (IsDecorrelated → HasCommutingParentHam) requires constructing
 *local* projectors \(P_{AX}\) and \(P_{XB}\) on the AX and XB tensor factors.
-In this abstract (non-tensor-product) setting, `HasCommutingParentHam` is
+In this abstract setting, before the tensor-product locality hypotheses are
+present, `HasCommutingParentHam` is
 trivially satisfiable by \(P_{AX} = P_{XB} = P_K\), so an abstract iff would be
 vacuous. The forward direction is deferred to the tensor-product setting.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -12,6 +12,9 @@ The nearest-neighbor commuting parent Hamiltonian condition in
 the parent commuting Hamiltonian condition of Appendix~D.2, which is stated for
 local projectors $Q_{AX}$ and $Q_{XB}$. The latter appears in the decorrelation
 subsection below.
+In Definition~3.9 the parent-Hamiltonian condition also says that, for
+$N>L$, the ground space is spanned by the periodic MPS vectors associated to
+the BNT components; nearest-neighbor means the specialization $L=2$.
 
 \begin{definition}[Commuting parent Hamiltonian]\label{def:is_commuting_parent_ham}
     \lean{MPSTensor.IsCommutingParentHam}
@@ -22,8 +25,9 @@ subsection below.
     $h_i h_j = h_j h_i$ for all $i,j \in \{0,\ldots,N{-}1\}$.
     This records the translated commutation equation
     $[\tau_j(P_L),P_L]=0$ from
-    \cite[Definition~3.9]{Cirac2016MPDO_arXiv}; the ground-space spanning
-    statement in the same definition is a separate parent-Hamiltonian condition.
+    \cite[Definition~3.9]{Cirac2016MPDO_arXiv}; the same source definition
+    also requires the ground space to be spanned, for $N>L$, by the periodic
+    MPS vectors of the BNT components.
 \end{definition}
 
 \begin{definition}[Nearest-neighbor commuting parent Hamiltonian]\label{def:is_nncph}
@@ -37,8 +41,8 @@ subsection below.
         h_i h_j=h_j h_i.
     \]
     The source definition \cite[Definition~3.9]{Cirac2016MPDO_arXiv} also
-    requires the corresponding parent Hamiltonian to have the prescribed
-    ground-space spanning property.
+    requires the corresponding parent Hamiltonian to have $L=2$ and to have
+    the prescribed ground-space spanning property for $N>2$.
 \end{definition}
 
 \begin{definition}[Commutation and zero-energy equations for nearest-neighbor parent terms]%
@@ -52,10 +56,12 @@ subsection below.
         h_i h_j = h_j h_i,\qquad
         h_i V^{(N)}(A)=0.
     \]
-    This is the zero-energy part of the ground-state condition appearing in
-    \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}; the full source parent
-    Hamiltonian condition also includes the spanning assertion from
-    Definition~3.9.
+    This is the ground-vector part of the condition appearing in
+    \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}: the MPS vector has zero
+    energy for the translated two-site parent terms, and those terms commute.
+    The missing source assertion is that the whole parent-Hamiltonian ground
+    space is spanned by the corresponding periodic MPS vectors from the BNT
+    components.
     % Scope restriction recorded in
     % docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex.
 \end{definition}
@@ -70,8 +76,9 @@ subsection below.
     \leanok
     \uses{lem:parent_hamiltonian_ff}
     The nearest-neighbor condition is the length-$2$ specialization of the
-    general commuting condition. This condition contains the commuting equation
-    and the frustration-free equation for $V^{(N)}(A)$.
+    general commuting condition. The ground-vector condition above contains
+    this commuting equation together with the frustration-free equation for
+    $V^{(N)}(A)$; it does not assert the source ground-space spanning property.
     For $N\ge 2$, Lemma~\ref{lem:parent_hamiltonian_ff} with $L=2$ gives
     \[
         h_i\,V^{(N)}(A)=0
@@ -84,8 +91,9 @@ subsection below.
     \leanok
     \uses{def:is_rfp, def:is_nncph, def:normal}
     If $A$ has nonzero virtual dimension and is a normal renormalization fixed
-    point, then for every chain length $N \ge 2$ the parent Hamiltonian with
-    $L = 2$ has commuting local terms.
+    point, then for every chain length $N \ge 2$ the two-site parent terms
+    commute. This theorem records the commutation part of the nearest-neighbor
+    source condition, not the ground-space spanning part.
     This implication is cited here from the product-of-entangled-pairs
     description in Appendix~B of
     Theorem~3.10 in~\cite{Cirac2016MPDO_arXiv}.
@@ -166,7 +174,7 @@ subsection below.
         \prod_{p=0}^{n-1}
         \phi_2\bigl(\sigma_{2p},\sigma_{2p+1}\bigr).
     \]
-    The nearest-neighbor parent projectors must also be identified with
+    The two-site parent projectors must also be identified with
     idempotents $p_i$ satisfying
     \[
         h_i(A,2)=p_i,\qquad p_i^2=p_i,\qquad p_ip_j=p_jp_i.
@@ -201,7 +209,8 @@ subsection below.
 \label{sec:decorrelation}
 
 This section develops the idempotent-product formulation used for the
-decorrelation implication. In Appendix~D.2 of
+decorrelation implication. It is not the full Appendix~D source condition.
+In Appendix~D.2 of
 \cite{Cirac2016MPDO_arXiv}, the parent commuting Hamiltonian condition is stated
 for local projectors $Q_{AX}$ and $Q_{XB}$ with
 \[
@@ -209,7 +218,9 @@ for local projectors $Q_{AX}$ and $Q_{XB}$ with
     K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
 \]
 Writing $P_{AX}=1-Q_{AX}$ and $P_{XB}=1-Q_{XB}$ gives, for the idempotent
-$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$.
+$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$. The definition below records
+this idempotent-product consequence, not the tensor-product locality,
+orthogonal-projector, or ground-space-intersection hypotheses of Appendix~D.2.
 % Scope restriction: this subsection keeps the idempotent-product consequence
 % and not the tensor-product locality or orthogonal-projector hypotheses of the
 % source definition. See
@@ -496,8 +507,9 @@ $P_K$ used below, the identity $P_{AX}P_{XB}=P_K$.
     \]
     where $Q_{AX} = 1 - P_{AX}$ and $Q_{XB} = 1 - P_{XB}$ are the
     complementary projectors.
-    This is the frustration-free form of the parent Hamiltonian from
-    \cite[Appendix~D, Section~D.2]{Cirac2016MPDO_arXiv}.
+    This is the algebraic identity obtained from the complementary projectors
+    in \cite[Appendix~D, Section~D.2]{Cirac2016MPDO_arXiv}; it is not the full
+    source parent commuting Hamiltonian condition.
 \end{theorem}
 
 \begin{proof}
@@ -517,9 +529,11 @@ $P_K$ used below, the identity $P_{AX}P_{XB}=P_K$.
         \quad\Longleftrightarrow\quad
         P_{AX} v = v \text{ and }  P_{XB} v = v.
     \]
-    This is the algebraic form of equation~(D.2) from
+    This is the algebraic consequence corresponding to equation~(D.2) from
     \cite{Cirac2016MPDO_arXiv}:
     $K_{AXB} = (K_{AX} \otimes H_B) \cap (H_A \otimes K_{XB})$.
+    The source equation itself also carries the tensor-product local-subspace
+    hypotheses.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

- separate the source NNCPH ground-space spanning condition from the formalized ground-vector/zero-energy condition
- state that `HasCommutingParentHam` records the Appendix D idempotent-product consequence, not the full local-projector condition
- align the Chapter 13 commuting-gap prose with the CPSV16 Definition 3.9 and Appendix D scope notes

## References

Refs #2633.
Refs #190.

Paper-gap notes:
- `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`
- `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`

## Checks

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.ParentHamiltonian.Commuting TNLean.MPS.ParentHamiltonian.Decorrelation`
- `lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Decorrelation.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose only; no changes to definitions, proofs, or axioms.
> 
> **Overview**
> Documentation-only alignment with CPSV16: the formalized predicates are spelled out as **narrower** than the paper’s parent-Hamiltonian definitions.
> 
> **NNCPH / Definition 3.9:** Lean module docs and Chapter 13 now state that `IsCommutingParentHam`, `IsNNCPH`, and related theorems capture translated **commutation** (and, for `IsNNCPHGroundState`, **`IsNNCPH ∧ IsFrustrationFree` on `mpv A`**) but **not** the source ground-space spanning by periodic MPS/BNT vectors for \(N>L\). Theorem blurbs for `rfp_implies_nncph`, `rfp_implies_nncph_ground_state`, and `nncph_implies_rfp` are tightened the same way.
> 
> **Appendix D decorrelation:** `Decorrelation.lean` and the blueprint frame `HasCommutingParentHam` and `commutingHam_isDecorrelated` as the **idempotent-product consequence** \(P_{AX}P_{XB}=P_K\) with commuting idempotents, explicitly **not** the full D.2 data (local \(Q_{AX},Q_{XB}\), tensor-product intersection \(K_{AXB}\), etc.). Hamiltonian and ground-membership theorems are labeled as algebraic consequences, not the full source condition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51dfab89691e272f32c85ba946c7f9446800570c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->