### PR TITLE
doc(parent): clarify trace-decomposition comparison prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -78,7 +78,7 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
 
-/-- Finite-length block injectivity gives the periodic-chain inclusion into the
+/-- Finite-length block injectivity gives the periodic-boundary inclusion into the
 sum of local block ground spaces.
 
 Let
@@ -141,7 +141,7 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_dir
   rw [← hM1]
   simpa [Nat.add_assoc] using hstep
 
-/-- The normalized BNT block-separation hypotheses give the periodic-chain
+/-- The normalized BNT block-separation hypotheses give the periodic-boundary
 inclusion into \(S_N\), and \(S_N\) is a direct sum of local block spaces.
 
 Let
@@ -180,7 +180,7 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
   · exact groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL₀ hUnital (by omega)
 
-/-- Finite-length block injectivity gives the periodic-chain inclusion into
+/-- Finite-length block injectivity gives the periodic-boundary inclusion into
 \(S_N\), and \(S_N\) is an internal direct sum of local block ground spaces.
 
 **Unfaithful:** This proof relies on the finite-\(C_1\) inclusion and
@@ -228,7 +228,7 @@ length. Then every
 \[
   \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).
 \]
-This is an open-boundary decomposition. The periodic upgrade in
+This is an open-boundary decomposition. The periodic-boundary upgrade in
 arXiv:quant-ph/0608197, Theorem 12, is a separate boundary-condition
 comparison: one must prove \(\psi_j\in\mathcal G_{N,L}(A_j)\) for the
 block components produced here.
@@ -303,7 +303,7 @@ lies in the open-boundary ground space \(G_N(A_j)\).
 
 The latter membership is the defining open-boundary range property of the
 displayed boundary matrix. The substantive assertion is the block-diagonal
-representation of \(\psi\). The periodic-chain upgrade is the separate
+representation of \(\psi\). The periodic-boundary upgrade is the separate
 boundary-condition comparison for the cyclic windows crossing the chosen cut.
 
 This proves the displayed statement. The

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -16,9 +16,10 @@ appearing in the boundary-condition comparison of arXiv:quant-ph/0608197, Theore
 12.
 
 The equality theorem here is conditional on the matrix identities indexed by
-complementary words obtained from the source \(C^j,D^j,E^j\) comparison. The
+complementary words obtained after the source \(C^j,D^j\) comparison and the
+normalized \(E^j\)-calculation. The
 Pérez-García--Verstraete--Wolf--Cirac (PGVWC) comparison theorem below proves
-the periodic-chain conclusion for each block once those identities are in the
+the periodic-boundary conclusion for each block once those identities are in the
 boundary-crossing form used in Theorem 12. Deriving these identities
 from the source comparison is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
@@ -673,7 +674,7 @@ word \(\rho\) there is a matrix \(E\) such that, for every wrapped word
 If those complementary word products span the full matrix algebra in each
 block, then the word-span stripping theorem gives a right boundary-matrix
 identity, and the preceding theorem gives the
-periodic-chain constraint. -/
+periodic-boundary constraint. -/
 theorem blockDiagonal_boundary_component_chainGroundSpace_of_complementary_word_identities
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -746,7 +747,7 @@ wrapped word \(\beta\),
 \]
 The normalization \(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) and these
 compatibility identities give the matrix identities indexed by complementary
-words used in the injective periodic-chain theorem for each block.
+words used in the injective periodic-boundary theorem for each block.
 This is the boundary-condition comparison at a boundary-crossing interval in
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451, followed by the
 periodic conclusion in lines 1454--1456.
@@ -859,8 +860,9 @@ representation to periodic single-block states.
 Under the normalized BNT hypotheses, every vector in the block-diagonal
 periodic chain space has block-diagonal boundary conditions \(X_j\).  If those
 same boundary conditions satisfy the matrix identities, indexed by complementary
-words, that the Pérez-García--Verstraete--Wolf--Cirac proof derives from the
-\(C^j,D^j,E^j\) comparison: for every boundary-crossing interval \(i\),
+words, that the Pérez-García--Verstraete--Wolf--Cirac proof derives after the
+trace-decomposition comparison and the normalized \(E^j\)-calculation: for every
+boundary-crossing interval \(i\),
 wrapped word \(\beta\), and complementary word \(\rho\),
 \[
   \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho},
@@ -933,14 +935,15 @@ theorem
       μ A hN hLN X hBlk hUnital hNlarge (hIdentity X hψX)
 
 /-- Matrix identities indexed by complementary words give the block-diagonal
-periodic-chain equality in the finite BNT range.
+periodic-boundary equality in the finite BNT range.
 
 This theorem combines two steps of the source boundary-condition argument:
-first obtain block-diagonal boundary conditions, then use the
-Pérez-García--Verstraete--Wolf--Cirac \(C,D,E\) comparison, in the displayed
-matrix form indexed by complementary words, to put each single-block vector in
-the corresponding periodic block chain space. The theorem assumes this matrix
-form for every boundary-crossing interval; it does not assert the comparison.
+first obtain block-diagonal boundary conditions, then use the matrix form
+indexed by complementary words to put each single-block vector in the
+corresponding periodic-boundary block space. That matrix form is the result of
+the trace-decomposition comparison and the normalized \(E^j\)-calculation; the
+theorem assumes it for every boundary-crossing interval and does not derive the
+comparison.
 
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -13,9 +13,10 @@ The word-indexed Pérez-García--Verstraete--Wolf--Cirac comparison
   =
   \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho
 \]
-is the local boundary-crossing coordinate form of the \(C^j,D^j,E^j\)
-trace comparison from arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1451. It implies the periodic-boundary single-block constraints
+is the local boundary-crossing coordinate form of the \(C^j,D^j\) trace
+comparison from arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451,
+after specializing \(D^j_\beta\) to \((\mu_j^N X_j)A^j_\beta\). The normalized
+\(E^j\)-calculation then implies the periodic-boundary single-block constraints
 and the finite-range block-diagonal periodic-boundary equality used here.
 -/
 
@@ -101,7 +102,7 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c
 /-- PGVWC comparison identities give the block-diagonal periodic-boundary equality
 in the finite BNT range.
 
-This theorem assumes the source \(C^j,D^j,E^j\) comparison only up to the
+This theorem assumes the source \(C^j,D^j\) comparison only up to the
 word-indexed matrix identity
 \[
   A^j_\beta C^j_{i,\rho}
@@ -109,7 +110,8 @@ word-indexed matrix identity
   \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho
 \]
 for every boundary-crossing interval, local word \(\beta\) before the cut,
-and outside word \(\rho\). The normalized \(E^j\)-calculation and the
+and outside word \(\rho\), with \(D^j_\beta\) already specialized to
+\((\mu_j^NX_j)A^j_\beta\). The normalized \(E^j\)-calculation and the
 block-injective crossing-window argument then give the periodic-boundary
 single-block constraints, and hence the block-diagonal periodic-boundary
 equality.

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -10,8 +10,10 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
 This file packages a finite-spanning form of the PGVWC trace-decomposition
 hypothesis into the block-diagonal boundary and finite-range equality
 conclusions. The remaining source step is to derive that trace-decomposition
-equality from the \(C^j,D^j,E^j\) comparison in arXiv:quant-ph/0608197,
-Theorem 12.
+equality from the \(C^j,D^j\) comparison in arXiv:quant-ph/0608197, Theorem 12,
+after specializing \(D^j_\beta\) to the block-diagonal boundary expression
+\((\mu_j^N X_j)A^j_\beta\). The normalized \(E^j\)-calculation is then supplied
+by the downstream complementary-word lemmas.
 -/
 
 open scoped Matrix BigOperators
@@ -107,7 +109,7 @@ theorem
     blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
       μ A hN hLN X hTraceSpan hBlk hUnital hNlarge C hCoeff
 
-/-- PGVWC trace decompositions give the block-diagonal periodic-chain equality
+/-- PGVWC trace decompositions give the block-diagonal periodic-boundary equality
 in the finite BNT range.
 
 This theorem combines the block-diagonal boundary representation with the
@@ -115,8 +117,8 @@ trace-decomposition form of the Pérez-García--Verstraete--Wolf--Cirac
 boundary-crossing comparison. It assumes a finite simultaneous word-spanning
 length \(m\) and the trace equality at that length, for every
 boundary-crossing interval and every block-diagonal boundary representation.
-Deriving that equality from the source \(C^j,D^j,E^j\) comparison is the
-remaining step recorded in
+Deriving that equality from the source \(C^j,D^j\) comparison, with
+\(D^j_\beta=(\mu_j^N X_j)A^j_\beta\), is the remaining step recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
 **Unfaithful:** This proof relies on

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -1122,7 +1122,7 @@ in both cases.
     then gives the periodic-boundary constraint for each block.
 \end{proof}
 
-\begin{lemma}[$C^j,D^j,E^j$ trace comparisons give single-block constraints]
+\begin{lemma}[Trace-decomposition comparisons give single-block constraints]
     \label{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}
     \leanok
@@ -1171,7 +1171,7 @@ in both cases.
     which gives the periodic-boundary constraint for each block.
 \end{proof}
 
-\begin{lemma}[$C^j,D^j,E^j$ trace comparisons give periodic-boundary single-block states]
+\begin{lemma}[Trace-decomposition comparisons give periodic-boundary single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1}
     \leanok
@@ -1218,8 +1218,10 @@ in both cases.
     \[
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
     \]
-    For this representation, the assumed $C^j,D^j,E^j$ trace comparison gives matrices
-    $C^j_{i,\rho}$. Lemma~\ref{lem:block_diagonal_boundary_component_trace_decomposition_injective}
+    For this representation, the assumed trace-decomposition comparison gives
+    matrices $C^j_{i,\rho}$; here the source matrix $D^j_\beta$ has already
+    been specialized to $(\mu_j^NX_j)A^j_\beta$.
+    Lemma~\ref{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     then gives, for every $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -8,7 +8,8 @@ explicitly include a boundary inclusion, a block-diagonal boundary
 representation, or periodic-boundary membership for the single-block states.
 When the hypotheses are written with words $\beta$ and $\rho$, these words are
 local coordinates for a boundary-crossing restriction. The cited source phrases
-the comparison through the $C^j,D^j,E^j$ trace identities.
+the comparison through the trace-decomposition identities with
+$D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
 
 \begin{lemma}[The block-diagonal periodic-boundary space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
@@ -319,7 +320,7 @@ the comparison through the $C^j,D^j,E^j$ trace identities.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[$C^j,D^j,E^j$ trace comparisons give equality in the finite range]
+\begin{lemma}[Trace-decomposition comparisons give equality in the finite range]
     \label{lem:bnt_block_diagonal_trace_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition}
     \leanok


### PR DESCRIPTION
## Summary

- clarify that the remaining BNT block-diagonal comparison is a trace-decomposition comparison with the source matrix D^j_beta already specialized to (mu_j^N X_j) A^j_beta
- separate that C^j,D^j comparison from the later normalized E^j calculation in Lean docstrings and blueprint prose
- replace the remaining local "periodic-chain" wording in this comparison layer by "periodic-boundary" where the source argument concerns the boundary condition

Refs #2651.
Refs #190.
Refs #460.

## Checks

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose edits only; no Lean logic or API changes in the touched files.
> 
> **Overview**
> This PR is **documentation-only** in the BNT block-diagonal parent-Hamiltonian layer (Lean module docstrings and matching blueprint text). No theorem statements or proof scripts change.
> 
> It reframes the remaining PGVWC boundary comparison as a **trace-decomposition** step with \(D^j_\beta\) already specialized to \((\mu_j^N X_j)A^j_\beta\), and treats the normalized \(E^j\) calculation as a **separate downstream** step rather than one bundled \(C^j,D^j,E^j\) comparison.
> 
> In that comparison layer, wording is aligned from **periodic-chain** to **periodic-boundary** where the argument is about closing cyclic boundary conditions. Blueprint lemma titles and proofs are updated accordingly (e.g. trace-decomposition comparisons vs. the old \(C^j,D^j,E^j\) trace-comparison labels).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a543a8ff878daa85c01e7a48754ce4c5aba71485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->