### PR TITLE
feat(channel): formalize Wolf Radon-Nikodym

### DIFF
--- a/TNLean/Channel/RadonNikodym.lean
+++ b/TNLean/Channel/RadonNikodym.lean
@@ -3,20 +3,25 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.OrderedCP
+import TNLean.Channel.KrausFreedom
 
 /-!
 # Radon–Nikodym theorem for CP maps and open-system representation
 (Wolf Section 2.1, Theorem 2.4 and Theorem 2.5)
 
-This file formalizes the canonical Radon–Nikodym theorem for completely
-positive maps (Wolf Theorem 2.4) and the open-system representation theorem
-(Wolf Theorem 2.5, Eq. (2.14)).
+This file formalizes the Radon–Nikodym theorem for completely positive maps
+(Wolf, *Quantum Channels & Operations*, Theorem 2.4) and the open-system
+representation theorem (Wolf, *Quantum Channels & Operations*, Theorem 2.5,
+Eq. (2.14)).
 
-The Radon–Nikodym theorem says: for CP maps `T₁, T₂`, there exist a
-Stinespring matrix `V` for `T₁ + T₂` and PSD operators `P₁, P₂` on the
-dilation space with `P₁ + P₂ = 𝟙` such that `Tᵢ(A) = V†(A ⊗ Pᵢ)V`. In our
-canonical realization, `V` is built from concatenated Kraus families of
-`T₁` and `T₂`, and `P₁, P₂` are the orthogonal block projectors.
+Wolf's Radon–Nikodym theorem says: if a finite family of CP maps `Tᵢ` sums
+to a map `T` with a supplied Stinespring representation
+`T(A) = V†(A ⊗ 𝟙_r)V`, then there are PSD operators `Pᵢ` on that same
+dilation space, summing to `𝟙_r`, such that `Tᵢ(A) = V†(A ⊗ Pᵢ)V`.
+
+The file also keeps the earlier binary block-diagonal corollary: for CP maps
+`T₁, T₂`, one may construct a Stinespring matrix for `T₁ + T₂` by
+concatenating Kraus families and take the two block projectors as `P₁, P₂`.
 
 The open-system representation says: every CPTP map `T` can be written as
 `T(ρ) = tr_r(V ρ V†)` for an isometry `V`, i.e. as the reduced unitary
@@ -35,10 +40,16 @@ evolution on a system-plus-environment.
   the identity: resolution of identity on the dilation space.
 * `Matrix.blockDiagTopProj_posSemidef`,
   `Matrix.blockDiagBotProj_posSemidef` — both are PSD.
-* `IsCPMap.exists_radon_nikodym` (Wolf Theorem 2.4 binary form):
+* `IsCPMap.radon_nikodym_of_stinespring`
+  (Wolf, *Quantum Channels & Operations*, Theorem 2.4):
+  finite-family Radon–Nikodym theorem relative to a supplied Stinespring
+  representation.
+* `IsCPMap.exists_radon_nikodym`
+  (Wolf, *Quantum Channels & Operations*, Theorem 2.4, binary form):
   for CP `T₁, T₂`, there exist a Stinespring matrix `V` and two PSD
   operators `P₁, P₂` with `P₁ + P₂ = 𝟙` such that `Tᵢ(A) = V†(A ⊗ Pᵢ)V`.
-* `IsChannel.exists_stinespring_open_system` (Wolf Theorem 2.5 reduced form):
+* `IsChannel.exists_stinespring_open_system`
+  (Wolf, *Quantum Channels & Operations*, Theorem 2.5, reduced form):
   every CPTP map admits an isometric Stinespring dilation realizing it as
   the reduced dynamics `T(ρ) = tr_r(V ρ V†)`.
 
@@ -112,6 +123,223 @@ theorem Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap
   rw [← Matrix.mul_kronecker_mul (A := (1 * A : Matrix (Fin D) (Fin D) ℂ))
       (B := (1 : Matrix (Fin D) (Fin D) ℂ)) (A' := Cᴴ * 1) (B' := C)]
   simp
+
+/-! ### Weighted Stinespring compression -/
+
+/-- Compressing a `Fin`-indexed Stinespring matrix by `P = CᴴC` gives the
+Kraus sum for the corresponding linear combinations of its blocks. -/
+theorem weighted_stinespring_eq_kraus_sum_gen
+    {η : Type*} [Fintype η]
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (C : Matrix η (Fin r) ℂ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    (stinespringV K)ᴴ * Matrix.kroneckerMap (· * ·) X (Cᴴ * C) * stinespringV K =
+      ∑ α : η,
+        (∑ j : Fin r, C α j • K j)ᴴ * X * (∑ j : Fin r, C α j • K j) := by
+  classical
+  rw [← Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap_gen X C]
+  have h_reassoc :
+      (stinespringV K)ᴴ *
+        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C)ᴴ *
+          Matrix.kroneckerMap (· * ·) X (1 : Matrix η η ℂ) *
+          Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C) *
+        stinespringV K =
+      ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C) *
+          stinespringV K)ᴴ *
+        Matrix.kroneckerMap (· * ·) X (1 : Matrix η η ℂ) *
+        ((Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C) *
+          stinespringV K) := by
+    rw [Matrix.conjTranspose_mul]
+    simp only [Matrix.mul_assoc]
+  rw [h_reassoc]
+  rw [← stinespringVGen_linear_combination (K := K) C]
+  exact stinespring_dual_representation_gen
+    (K := fun α : η => ∑ j : Fin r, C α j • K j) X
+
+/-- The `j`-th ancilla block of a supplied Stinespring matrix. -/
+noncomputable def stinespringBlock
+    (V : Matrix (Fin D × Fin r) (Fin D) ℂ) (j : Fin r) :
+    Matrix (Fin D) (Fin D) ℂ :=
+  fun a b => V (a, j) b
+
+/-- Reassembling the ancilla blocks of a supplied Stinespring matrix recovers
+the original matrix. -/
+theorem stinespringV_stinespringBlock
+    (V : Matrix (Fin D × Fin r) (Fin D) ℂ) :
+    stinespringV (stinespringBlock (D := D) (r := r) V) = V := by
+  ext x b
+  rcases x with ⟨a, j⟩
+  rfl
+
+/-- Radon--Nikodym theorem relative to a supplied Stinespring matrix, with an
+explicit Kraus row family for the components.
+
+The finite row type `η` is partitioned by `label : η → ι`.  The Kraus rows in
+the fibre over `i` represent the component map `Tᵢ i`, and all rows together
+represent `T`.  If the supplied Stinespring dilation has at most as many
+ancilla rows as this family, then the fibre Gram matrices of the Kraus-freedom
+isometry give the Radon--Nikodym operators on the supplied dilation space. -/
+theorem radon_nikodym_of_stinespring_of_kraus_family
+    {ι η : Type*} [Fintype ι] [DecidableEq ι] [Fintype η]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (Tᵢ : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (V : Matrix (Fin D × Fin r) (Fin D) ℂ)
+    (label : η → ι)
+    (B : η → Matrix (Fin D) (Fin D) ℂ)
+    (hV : ∀ X, T X =
+      Vᴴ * Matrix.kroneckerMap (· * ·) X (1 : Matrix (Fin r) (Fin r) ℂ) * V)
+    (hComponent : ∀ i X,
+      Tᵢ i X = ∑ α : η, if label α = i then B α * X * (B α)ᴴ else 0)
+    (hTotalKraus : ∀ X, ∑ α : η, B α * X * (B α)ᴴ = T X)
+    (hCard : Fintype.card (Fin r) ≤ Fintype.card η) :
+    ∃ P : ι → Matrix (Fin r) (Fin r) ℂ,
+      (∀ i, (P i).PosSemidef) ∧
+      (∑ i, P i = 1) ∧
+      ∀ i X,
+        Tᵢ i X = Vᴴ * Matrix.kroneckerMap (· * ·) X (P i) * V := by
+  classical
+  let K : Fin r → Matrix (Fin D) (Fin D) ℂ := stinespringBlock V
+  let A : Fin r → Matrix (Fin D) (Fin D) ℂ := fun j => (K j)ᴴ
+  have hVeq : stinespringV K = V := stinespringV_stinespringBlock (D := D) (r := r) V
+  have hsame : ∀ X : Matrix (Fin D) (Fin D) ℂ,
+      ∑ α : η, B α * X * (B α)ᴴ = ∑ j : Fin r, A j * X * (A j)ᴴ := by
+    intro X
+    calc
+      ∑ α : η, B α * X * (B α)ᴴ = T X := hTotalKraus X
+      _ = Vᴴ * Matrix.kroneckerMap (· * ·) X
+            (1 : Matrix (Fin r) (Fin r) ℂ) * V := hV X
+      _ = (stinespringV K)ᴴ * Matrix.kroneckerMap (· * ·) X
+            (1 : Matrix (Fin r) (Fin r) ℂ) * stinespringV K := by rw [hVeq]
+      _ = ∑ j : Fin r, A j * X * (A j)ᴴ := by
+            rw [stinespring_dual_representation (K := K) (A := X)]
+            simp [A]
+  obtain ⟨W, hW, hB⟩ := kraus_rectangular_freedom' B A hsame hCard
+  let C : ι → Matrix η (Fin r) ℂ := fun i α j =>
+    if label α = i then star (W α j) else 0
+  refine ⟨fun i => (C i)ᴴ * C i, ?_, ?_, ?_⟩
+  · intro i
+    exact Matrix.posSemidef_conjTranspose_mul_self (C i)
+  · ext j k
+    simp only [Matrix.sum_apply, Matrix.mul_apply, Matrix.conjTranspose_apply, C]
+    rw [Finset.sum_comm]
+    have hcollapse : ∀ α : η,
+        (∑ i : ι,
+          star (if label α = i then star (W α j) else 0) *
+            (if label α = i then star (W α k) else 0)) =
+          W α j * star (W α k) := by
+      intro α
+      rw [Finset.sum_eq_single (label α)]
+      · simp
+      · intro i _ hi
+        have hne : label α ≠ i := fun h => hi h.symm
+        simp [hne]
+      · intro h
+        exact absurd (Finset.mem_univ (label α)) h
+    simp_rw [hcollapse]
+    have hentry := congr_fun (congr_fun hW k) j
+    simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply] at hentry
+    simpa [Matrix.one_apply, eq_comm, mul_comm] using hentry
+  · intro i X
+    calc
+      Tᵢ i X = ∑ α : η, if label α = i then B α * X * (B α)ᴴ else 0 :=
+        hComponent i X
+      _ = ∑ α : η, (∑ j : Fin r, C i α j • K j)ᴴ * X *
+            (∑ j : Fin r, C i α j • K j) := by
+          refine Finset.sum_congr rfl ?_
+          intro α _
+          by_cases hα : label α = i
+          · have hlin : (∑ j : Fin r, C i α j • K j)ᴴ = B α := by
+              rw [hB α]
+              rw [Matrix.conjTranspose_sum]
+              simp [C, hα, A, Matrix.conjTranspose_smul]
+            rw [if_pos hα, ← hlin]
+            simp [Matrix.conjTranspose_conjTranspose]
+          · have hzero : (∑ j : Fin r, C i α j • K j) = 0 := by
+              simp [C, hα]
+            rw [if_neg hα, hzero]
+            simp
+      _ = (stinespringV K)ᴴ * Matrix.kroneckerMap (· * ·) X ((C i)ᴴ * C i) *
+            stinespringV K := by
+          rw [weighted_stinespring_eq_kraus_sum_gen (K := K) (C := C i) (X := X)]
+      _ = Vᴴ * Matrix.kroneckerMap (· * ·) X ((C i)ᴴ * C i) * V := by rw [hVeq]
+
+/-! ### Wolf Theorem 2.4 (finite-family supplied Stinespring form) -/
+
+/-- **Wolf Theorem 2.4 (Radon--Nikodym for quantum instruments).**
+
+Let a finite nonempty family of completely positive maps `Tᵢ` sum to a map `T`
+with a supplied Stinespring representation `T(X) = Vᴴ (X ⊗ 𝟙_r) V`.  Then
+there are positive operators `Pᵢ` on the same dilation space, summing to the
+identity, such that
+`Tᵢ(X) = Vᴴ (X ⊗ Pᵢ) V`.
+
+This is the source-faithful finite-family statement of
+Wolf, *Quantum Channels & Operations*, Theorem 2.4.  No minimality of the
+Stinespring representation is assumed.
+
+**Local fix (nonempty family):** The source theorem states a set of component
+maps.  The Lean statement makes the index type nonempty, since for an empty
+family the conclusion `∑ i, P i = 1` is false for a nonzero supplied dilation.
+This boundary is recorded in
+`docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex`. -/
+theorem IsCPMap.radon_nikodym_of_stinespring
+    {ι : Type*} [Fintype ι] [Nonempty ι]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (Tᵢ : ι → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (hTᵢ : ∀ i, IsCPMap (Tᵢ i))
+    (V : Matrix (Fin D × Fin r) (Fin D) ℂ)
+    (hV : ∀ X, T X =
+      Vᴴ * Matrix.kroneckerMap (· * ·) X (1 : Matrix (Fin r) (Fin r) ℂ) * V)
+    (hsum : (∑ i, Tᵢ i) = T) :
+    ∃ P : ι → Matrix (Fin r) (Fin r) ℂ,
+      (∀ i, (P i).PosSemidef) ∧
+      (∑ i, P i = 1) ∧
+      ∀ i X,
+        Tᵢ i X = Vᴴ * Matrix.kroneckerMap (· * ·) X (P i) * V := by
+  classical
+  let s : ι → ℕ := fun i => Classical.choose (hTᵢ i)
+  let B₀ : (i : ι) → Fin (s i) → Matrix (Fin D) (Fin D) ℂ :=
+    fun i => Classical.choose (Classical.choose_spec (hTᵢ i))
+  have hB₀ : ∀ i X, Tᵢ i X = ∑ a : Fin (s i), B₀ i a * X * (B₀ i a)ᴴ := by
+    intro i
+    exact Classical.choose_spec (Classical.choose_spec (hTᵢ i))
+  let i₀ : ι := Classical.choice ‹Nonempty ι›
+  let Row := Sum (Sigma fun i : ι => Fin (s i)) (Fin r)
+  let label : Row → ι := fun α => match α with
+    | Sum.inl x => x.1
+    | Sum.inr _ => i₀
+  let B : Row → Matrix (Fin D) (Fin D) ℂ := fun α => match α with
+    | Sum.inl x => B₀ x.1 x.2
+    | Sum.inr _ => 0
+  have hComponent : ∀ i X,
+      Tᵢ i X = ∑ α : Row, if label α = i then B α * X * (B α)ᴴ else 0 := by
+    intro i X
+    rw [hB₀ i X]
+    simp only [Row, Fintype.sum_sum_type]
+    rw [Fintype.sum_sigma]
+    simp [label, B]
+  have hTotalKraus : ∀ X, ∑ α : Row, B α * X * (B α)ᴴ = T X := by
+    intro X
+    simp only [Row, Fintype.sum_sum_type]
+    rw [Fintype.sum_sigma]
+    simp only [B, Matrix.zero_mul, Matrix.conjTranspose_zero, Matrix.mul_zero,
+      Finset.sum_const_zero, add_zero]
+    calc
+      ∑ x : ι, ∑ y : Fin (s x), B₀ x y * X * (B₀ x y)ᴴ = ∑ x : ι, Tᵢ x X := by
+        refine Finset.sum_congr rfl ?_
+        intro i _
+        exact (hB₀ i X).symm
+      _ = T X := by
+        have happ := congrArg
+          (fun F : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ => F X)
+          hsum
+        simpa [Finset.sum_apply] using happ
+  have hCard : Fintype.card (Fin r) ≤ Fintype.card Row := by
+    let emb : Fin r ↪ Row := ⟨Sum.inr, by
+      intro a b h
+      exact Sum.inr.inj h⟩
+    exact Fintype.card_le_of_embedding emb
+  exact radon_nikodym_of_stinespring_of_kraus_family Tᵢ V label B hV
+    hComponent hTotalKraus hCard
 
 /-! ### Wolf Theorem 2.4 (Radon–Nikodym, binary form) -/
 

--- a/TNLean/Channel/Stinespring.lean
+++ b/TNLean/Channel/Stinespring.lean
@@ -99,6 +99,78 @@ theorem stinespring_dual_representation {r : ℕ}
     mul_ite, mul_one, mul_zero, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
   rw [Finset.sum_comm]
 
+/-! ### Finite-index Stinespring compression lemmas -/
+
+/-- The Stinespring matrix for a Kraus family indexed by an arbitrary finite type.
+
+This is the same coordinate construction as `stinespringV`; the latter is kept
+`Fin`-indexed because most channel declarations use a natural number as Kraus
+rank. Wolf's Radon--Nikodym theorem for instruments naturally groups Kraus
+operators by a finite outcome type. -/
+noncomputable def stinespringVGen {η : Type*}
+    (K : η → Matrix (Fin D) (Fin D) ℂ) :
+    Matrix (Fin D × η) (Fin D) ℂ :=
+  fun ⟨i, j⟩ k => K j i k
+
+@[simp]
+theorem stinespringVGen_apply {η : Type*}
+    (K : η → Matrix (Fin D) (Fin D) ℂ) (i : Fin D) (j : η) (k : Fin D) :
+    stinespringVGen K (i, j) k = K j i k := rfl
+
+/-- Stinespring dual representation for a Kraus family indexed by an arbitrary
+finite type. -/
+theorem stinespring_dual_representation_gen {η : Type*} [Fintype η] [DecidableEq η]
+    (K : η → Matrix (Fin D) (Fin D) ℂ) (A : Matrix (Fin D) (Fin D) ℂ) :
+    (stinespringVGen K)ᴴ *
+      (kroneckerMap (· * ·) A (1 : Matrix η η ℂ)) *
+      stinespringVGen K =
+      ∑ j : η, (K j)ᴴ * A * K j := by
+  ext a b
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply,
+    stinespringVGen_apply, kroneckerMap_apply, Matrix.one_apply,
+    Matrix.sum_apply, Fintype.sum_prod_type,
+    mul_ite, mul_one, mul_zero, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
+  exact Finset.sum_comm
+
+/-- A linear combination of Kraus blocks is obtained by left-multiplying the
+Stinespring matrix by `1 ⊗ C`. -/
+theorem stinespringVGen_linear_combination
+    {η : Type*}
+    (K : Fin r → Matrix (Fin D) (Fin D) ℂ)
+    (C : Matrix η (Fin r) ℂ) :
+    stinespringVGen (fun α : η => ∑ j : Fin r, C α j • K j) =
+      Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C *
+        stinespringV K := by
+  ext x b
+  rcases x with ⟨a, α⟩
+  simp only [stinespringVGen_apply, stinespringV_apply, Matrix.sum_apply,
+    Matrix.smul_apply, smul_eq_mul, Matrix.mul_apply, Matrix.kroneckerMap_apply,
+    Matrix.one_apply, Fintype.sum_prod_type]
+  rw [Finset.sum_eq_single a]
+  · simp
+  · intro a' _ ha'
+    have haa' : a ≠ a' := fun h => ha' h.symm
+    simp [haa']
+  · intro h
+    exact absurd (Finset.mem_univ a) h
+
+/-- The Kronecker identity
+`A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙)(𝟙 ⊗ C)` for an arbitrary finite row type. -/
+theorem Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap_gen
+    {η : Type*} [Fintype η] [DecidableEq η]
+    (A : Matrix (Fin D) (Fin D) ℂ) (C : Matrix η (Fin r) ℂ) :
+    (Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C)ᴴ *
+        Matrix.kroneckerMap (· * ·) A (1 : Matrix η η ℂ) *
+        Matrix.kroneckerMap (· * ·) (1 : Matrix (Fin D) (Fin D) ℂ) C =
+      Matrix.kroneckerMap (· * ·) A (Cᴴ * C) := by
+  rw [Matrix.conjTranspose_kronecker]
+  rw [show (1 : Matrix (Fin D) (Fin D) ℂ)ᴴ = 1 from Matrix.conjTranspose_one]
+  rw [← Matrix.mul_kronecker_mul (A := (1 : Matrix (Fin D) (Fin D) ℂ)) (B := A)
+      (A' := Cᴴ) (B' := (1 : Matrix η η ℂ))]
+  rw [← Matrix.mul_kronecker_mul (A := (1 * A : Matrix (Fin D) (Fin D) ℂ))
+      (B := (1 : Matrix (Fin D) (Fin D) ℂ)) (A' := Cᴴ * 1) (B' := C)]
+  simp
+
 /-- **Stinespring representation, Schrödinger picture** (Wolf Theorem 2.2):
 
   `T(ρ)_{ij} = ∑_k (V ρ V†)_{(i,k),(j,k)} = tr_r(V ρ V†)`

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -89,8 +89,11 @@ default root.
     block projectors on the dilation space, PSD and summing to `𝟙` ✓
   - `Matrix.kroneckerMap_conjTranspose_mul_kroneckerMap` — Kronecker
     identity `A ⊗ (CᴴC) = (𝟙 ⊗ C)ᴴ (A ⊗ 𝟙) (𝟙 ⊗ C)` ✓
-  - `IsCPMap.exists_radon_nikodym` — Wolf Theorem 2.4 binary form:
-    for CP `T₁, T₂`, a Stinespring matrix for `T₁ + T₂` yields
+  - `IsCPMap.radon_nikodym_of_stinespring` — Wolf, *Quantum Channels &
+    Operations*, Theorem 2.4, source-faithful finite-family form relative to a
+    supplied Stinespring representation ✓
+  - `IsCPMap.exists_radon_nikodym` — binary block-diagonal corollary:
+    for CP `T₁, T₂`, a constructed Stinespring matrix for `T₁ + T₂` yields
     PSD `P₁ + P₂ = 𝟙` with `Tᵢ(A) = V†(A ⊗ Pᵢ)V` ✓
 
 * **Theorem 2.5** (open-system representation, reduced form):

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -894,7 +894,68 @@ a common dilation space.
     and $P_{\mathrm{top}} + P_{\mathrm{bot}} = \Id$.
 \end{definition}
 
-\begin{theorem}[Radon--Nikodym theorem for CP maps]
+\begin{theorem}[Radon--Nikodym theorem for finite quantum instruments]
+    \label{thm:cp_radon_nikodym_of_stinespring}
+    \lean{IsCPMap.radon_nikodym_of_stinespring}
+    \leanok
+    \uses{def:cp_map, def:stinespring_v}
+    Let $\{T_i\}_{i\in I}$ be a nonempty finite family of completely positive
+    maps, let $T : \MN{D} \to \MN{D}$ satisfy $\sum_{i\in I}T_i=T$, and
+    suppose that $T$ has a supplied Stinespring representation
+    \[
+        T(A)=V^\dagger(A\otimes\Id_r)V.
+    \]
+    Then there are positive semidefinite operators $P_i\in \MN{r}$ with
+    \[
+        \sum_{i\in I}P_i=\Id_r.
+    \]
+    For every $i\in I$ and $A\in \MN{D}$,
+    \[
+        T_i(A)=V^\dagger(A\otimes P_i)V
+    \]
+    This is \cite[Theorem~2.4]{Wolf2012Quantum}, with the nonempty-family condition
+    made explicit; see
+    \path{docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:kraus_rectangular_freedom'}
+    Choose Kraus families for the component maps $T_i$ and group all their
+    Kraus operators into one finite family.  Add zero Kraus operators to one
+    component so that this grouped family has at least as many rows as the
+    supplied Stinespring dilation.  Write the grouped Kraus operators as
+    $B_\alpha$, with a label map $\ell(\alpha)\in I$, and write the Kraus
+    operators obtained from the blocks of $V$ as $A_j$.  Rectangular Kraus
+    freedom gives a matrix $W$ with
+    \[
+        W^\dagger W=\Id_r,
+        \qquad
+        B_\alpha=\sum_{j=0}^{r-1}W_{\alpha j}A_j.
+    \]
+    For the fibre over $i$, set
+    \[
+        (C_i)_{\alpha j}
+        =
+        \begin{cases}
+            \overline{W_{\alpha j}}, & \ell(\alpha)=i,\\
+            0, & \ell(\alpha)\ne i,
+        \end{cases}
+        \qquad
+        P_i=C_i^\dagger C_i.
+    \]
+    Then $P_i\ge 0$ and $\sum_i P_i=\Id_r$ follows from $W^\dagger W=\Id_r$.
+    Finally,
+    \[
+        V^\dagger(A\otimes P_i)V
+        =
+        \sum_{\ell(\alpha)=i}B_\alpha A B_\alpha^\dagger
+        =
+        T_i(A),
+    \]
+    which proves the claim.
+\end{proof}
+
+\begin{theorem}[Binary Radon--Nikodym theorem for CP maps]
     \label{thm:cp_exists_radon_nikodym}
     \lean{IsCPMap.exists_radon_nikodym}
     \leanok
@@ -911,10 +972,11 @@ a common dilation space.
 
 \begin{remark}[Relation with Wolf's Radon--Nikodym theorem]
     \label{rem:cp_radon_nikodym_scope}
-    \cite[Theorem~2.4]{Wolf2012Quantum} treats a finite family of completely
-    positive maps relative to a supplied Stinespring dilation
-    $T(A)=V^\dagger(A\otimes\Id_r)V$.  The theorem above proves the binary
-    case for the block-diagonal dilation constructed from $T_1$ and $T_2$.
+    Theorem~\ref{thm:cp_radon_nikodym_of_stinespring} is the source-faithful
+    finite-family statement relative to a supplied Stinespring dilation.
+    Theorem~\ref{thm:cp_exists_radon_nikodym} is the earlier binary
+    block-diagonal corollary in which the common dilation is constructed from
+    the Kraus families of $T_1$ and $T_2$.
 \end{remark}
 
 \begin{proof}\leanok

--- a/docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex
+++ b/docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex
@@ -1,0 +1,71 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{./command}
+\providecommand{\leanid}[1]{\path{#1}}
+
+\title{The nonempty-family condition in Wolf's Radon--Nikodym theorem}
+\author{}
+\date{2026-06-16}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+Wolf's Radon--Nikodym theorem for quantum instruments states that, if
+\(\{T_i\}\) is a family of completely positive maps satisfying
+\(\sum_i T_i=T\) and
+\[
+  T(A)=V^\dagger(A\otimes \mathbf 1_r)V,
+\]
+then there are positive operators \(P_i\in\mathcal M_r\) such that
+\[
+  \sum_i P_i=\mathbf 1_r,
+  \qquad
+  T_i(A)=V^\dagger(A\otimes P_i)V.
+\]
+The local source is
+\path{Notes/WolfNoteTexSource/ch02_representations.tex}:402--407, titled
+``Radon--Nikodym for quantum instruments'' in
+\cite{Wolf2012Quantum}.
+
+\section{Local boundary}
+
+The Lean theorem \leanid{IsCPMap.radon_nikodym_of_stinespring} makes the index
+type nonempty.  This is not a strengthening of a mathematical hypothesis in the
+substantive case; it is the finite-type boundary needed for the identity
+\[
+  \sum_i P_i=\mathbf 1_r
+\]
+to be meaningful as a resolution of the identity by instrument components.  If
+the index type were empty, then the hypotheses \(\sum_i T_i=T\) force
+\(T=0\).  One may still supply the zero Stinespring matrix
+\(V=0\), but the conclusion would ask
+\[
+  0=\mathbf 1_r
+\]
+in \(\mathcal M_r\), which is false for a nonzero dilation dimension.
+
+Thus the formal theorem states the source theorem in the nonempty instrument
+case.  The blueprint entry records the same boundary explicitly by saying
+``nonempty finite family.''
+
+\section{Elimination plan}
+
+No mathematical proof gap is expected for the nonempty case.  An empty-index
+variant would need a different conclusion, for example a vacuous statement with
+zero dilation space or no identity resolution.  Such a statement is not the
+instrument theorem used in the development.
+
+Verdict: local correction of a well-posedness boundary in the printed finite-family
+statement.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation

- Wolf *Quantum Channels & Operations*, Theorem 2.4 states: given a CP map $T$ with Stinespring representation $T(A) = V^\dagger(A \otimes \mathbf{1}_r)V$ and a finite family of CP maps $T_1, \ldots, T_k$ with $\sum_i T_i = T$, there exist positive operators $P_1, \ldots, P_k \in M_r$ with $\sum_i P_i = \mathbf{1}_r$ and $T_i(A) = V^\dagger(A \otimes P_i)V$; source: `Notes/WolfNoteTexSource/ch02_representations.tex:402–408`.
- The existing declaration `IsCPMap.exists_radon_nikodym` covers only the binary case ($k = 2$) relative to a block-diagonal dilation it constructs internally; this restriction is recorded as `rem:cp_radon_nikodym_scope` in the blueprint (added in LionSR/TNLean#2880). Formalizing the source-faithful statement addresses LionSR/QICLean#157.

### Description

- `TNLean/Channel/RadonNikodym.lean`: adds `IsCPMap.radon_nikodym_of_stinespring`, the source-faithful Wolf Thm 2.4 — given a Stinespring representation $(r, V)$ of $T$ and a finite nonempty family $T_1, \ldots, T_k$ with $\sum_i T_i = T$, produces positive operators $P_i \in M_r$ with $\sum_i P_i = \mathbf{1}_r$ and $T_i(A) = V^\dagger(A \otimes P_i)V$ for all $A$.
- Supporting results added: finite-index Stinespring compression lemmas (`stinespringVGen`, `stinespringBlock`, weighted compression) and an auxiliary `radon_nikodym_of_stinespring_of_kraus_family` built via rectangular Kraus freedom (`kraus_rectangular_freedom'`).
- `TNLean/Channel/WolfChapter2Index.lean`: records Wolf Thm 2.4 as formalized.
- `blueprint/src/chapter/ch16_channel_representations.tex`: adds a blueprint entry for Wolf Thm 2.4 with `\lean{IsCPMap.radon_nikodym_of_stinespring}` and `\leanok`; documents `IsCPMap.exists_radon_nikodym` explicitly as the binary block-diagonal corollary.

### Testing

- `lake env lean TNLean/Channel/RadonNikodym.lean`
- `lake env lean TNLean/Channel/WolfChapter2Index.lean`
- `lake build TNLean.Channel.RadonNikodym TNLean.Channel.WolfChapter2Index`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `cd blueprint && leanblueprint checkdecls`

---
Closes LionSR/QICLean#157

> [!NOTE]
> **Medium Risk**
> Large new proofs in core channel representation theory; correctness depends on Kraus freedom and Stinespring identities, but scope is additive with no runtime or security surface.
>
> **Overview**
> Adds **Wolf Theorem 2.4** in its source-faithful form: `IsCPMap.radon_nikodym_of_stinespring` shows that when a CP map `T` is given with a fixed Stinespring dilation `T(X) = V†(X ⊗ 𝟙)V` and a finite nonempty family of CP maps sums to `T`, there exist PSD ancilla operators `Pᵢ` with `∑ Pᵢ = 𝟙` and `Tᵢ(X) = V†(X ⊗ Pᵢ)V`.
>
> The proof route introduces finite-index Stinespring tooling (`stinespringVGen`, weighted compression lemmas, `stinespringBlock`), a Kraus-family helper `radon_nikodym_of_stinespring_of_kraus_family` that builds `Pᵢ` via **rectangular Kraus freedom** (`kraus_rectangular_freedom'`), and packages component Kraus operators (with padding) before invoking that helper.
>
> **Documentation** is aligned so `exists_radon_nikodym` is explicitly the **binary block-diagonal corollary** (concatenated Kraus + top/bottom projectors), with matching updates in `WolfChapter2Index.lean` and the channel-representations blueprint chapter.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f740721271c18b30c216b36d7fbda5e0a94f9fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive proofs in channel representation theory; correctness hinges on Kraus freedom and Stinespring identities, with no runtime or security impact.
> 
> **Overview**
> Adds **Wolf Theorem 2.4** in the source-faithful form: when a CP map `T` is given with a fixed Stinespring dilation `T(X) = V†(X ⊗ 𝟙)V` and a **finite nonempty** family of CP maps sums to `T`, there exist PSD ancilla operators `Pᵢ` with `∑ Pᵢ = 𝟙` and `Tᵢ(X) = V†(X ⊗ Pᵢ)V` (`IsCPMap.radon_nikodym_of_stinespring`).
> 
> The proof introduces finite-index Stinespring helpers in `Stinespring.lean` (`stinespringVGen`, weighted compression, `stinespringBlock`), a Kraus-family lemma `radon_nikodym_of_stinespring_of_kraus_family` that builds `Pᵢ` via **rectangular Kraus freedom** (`kraus_rectangular_freedom'`), and packages component Kraus operators (with zero-padding so the grouped family is large enough) before invoking that helper.
> 
> **Documentation** reframes `exists_radon_nikodym` as the **binary block-diagonal corollary** (concatenated Kraus + top/bottom projectors), with matching blueprint and `WolfChapter2Index` updates. A short note documents why the formal statement requires a **nonempty** instrument index (`docs/paper-gaps/wolf_radon_nikodym_nonempty_family.tex`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c4f2ebc6fbc80a14136bfd9f8cfad13e534d19d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->