### PR TITLE
feat(MPS/Periodic): connect normal canonical form to irreducible form

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -272,6 +272,7 @@ import TNLean.PiAlgebra.Construction
 import TNLean.PiAlgebra.FundamentalTheoremComplete
 import TNLean.PiAlgebra.TIReduction
 import TNLean.PiAlgebra.GlobalSymmetry
+import TNLean.MPS.Periodic.NormalCanonicalPeriodOne
 
 -- Layer 3b: MPO / MPDO / LPDO foundations
 import TNLean.MPS.MPDO.Defs

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -250,6 +250,7 @@ import TNLean.MPS.Periodic.ZGauge
 import TNLean.MPS.Periodic.Symmetry
 import TNLean.MPS.Periodic.ProjectiveRep
 import TNLean.MPS.Periodic.Applications
+import TNLean.MPS.Periodic.NormalCanonicalPeriodOne
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.CanonicalForm.Definitions
@@ -272,7 +273,6 @@ import TNLean.PiAlgebra.Construction
 import TNLean.PiAlgebra.FundamentalTheoremComplete
 import TNLean.PiAlgebra.TIReduction
 import TNLean.PiAlgebra.GlobalSymmetry
-import TNLean.MPS.Periodic.NormalCanonicalPeriodOne
 
 -- Layer 3b: MPO / MPDO / LPDO foundations
 import TNLean.MPS.MPDO.Defs

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -148,7 +148,8 @@ structure IsIrreducibleForm (A : MPSTensor d D) where
   period : Fin r → ℕ
   /-- Periodicity of each block. -/
   periodic : ∀ k, IsPeriodic (period k) (blocks k)
-  /-- Weights are strictly positive real scalars (embedded in `ℂ`). -/
+  /-- Weights are strictly positive real scalars (embedded in `ℂ`).
+  arXiv:1708.00029, lines 252--261, convention \(\mu_j>0\). -/
   weight_pos : ∀ k, 0 < (μ k).re ∧ (μ k).im = 0
   /-- Reassembled block tensor generates the same MPV family. -/
   sameMPV : SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ) blocks)

--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -142,14 +142,14 @@ structure IsIrreducibleForm (A : MPSTensor d D) where
   dim : Fin r → ℕ
   /-- Block tensors. -/
   blocks : (k : Fin r) → MPSTensor d (dim k)
-  /-- Positive complex weights. -/
+  /-- Complex weights, written as positive real scalars. -/
   μ : Fin r → ℂ
   /-- Every block is periodic with period `period k`. -/
   period : Fin r → ℕ
   /-- Periodicity of each block. -/
   periodic : ∀ k, IsPeriodic (period k) (blocks k)
   /-- Weights are strictly positive real scalars (embedded in `ℂ`). -/
-  weight_pos : ∀ k, 0 < (μ k).re
+  weight_pos : ∀ k, 0 < (μ k).re ∧ (μ k).im = 0
   /-- Reassembled block tensor generates the same MPV family. -/
   sameMPV : SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ) blocks)
 

--- a/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
+++ b/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
@@ -25,7 +25,9 @@ decomposition whose block periods are all equal to `1`.
 Source context: arXiv:1708.00029, lines 258--271. The paper's irreducible form
 uses weights `μ_j > 0`. The local normal-canonical definition only assumes
 nonzero complex weights, so the positive-weight convention is stated here as a
-separate hypothesis; see
+separate hypothesis. The imaginary-zero conjunct records the paper's real-weight
+convention; the constructed irreducible-form witness only needs its
+positive-real-part consequence. See
 `docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex`. -/
 def isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos
     (hNCF : IsNormalCanonicalForm (d := d) μ blocks)

--- a/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
+++ b/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Periodic.Defs
+import TNLean.PiAlgebra.CanonicalFormSepAux
+
+/-!
+# Normal canonical forms as period-one irreducible forms
+
+This file records the implication from normal canonical block hypotheses to
+irreducible form in the period-one case.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d r : ℕ} {dim : Fin r → ℕ}
+variable {μ : Fin r → ℂ} {blocks : (k : Fin r) → MPSTensor d (dim k)}
+
+/-- A normal canonical block family with positive real weights is an irreducible-form
+decomposition whose block periods are all equal to `1`.
+
+Source context: arXiv:1708.00029, lines 258--271. The paper's irreducible form
+uses weights `μ_j > 0`. The local normal-canonical definition only assumes
+nonzero complex weights, so the positive-weight convention is stated here as a
+separate hypothesis; see
+`docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex`. -/
+def isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos
+    (hNCF : IsNormalCanonicalForm (d := d) μ blocks)
+    (hμpos : ∀ k, 0 < (μ k).re ∧ (μ k).im = 0) :
+    IsIrreducibleForm (toTensorFromBlocks (d := d) (μ := μ) blocks) where
+  r := r
+  dim := dim
+  blocks := blocks
+  μ := μ
+  period := fun _ => 1
+  periodic := by
+    intro k
+    rw [IsPeriodic.one_iff_primitive]
+    exact ⟨hNCF.block_irreducible k, hNCF.leftCanonical k, hNCF.block_primitive k⟩
+  weight_pos := fun k => (hμpos k).1
+  sameMPV := fun _ _ => rfl
+
+/-- In the irreducible-form witness obtained from positive-weight normal canonical
+hypotheses, every block period is `1`.
+
+Source context: arXiv:1708.00029, lines 258--271. -/
+theorem isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos_period_eq_one
+    (hNCF : IsNormalCanonicalForm (d := d) μ blocks)
+    (hμpos : ∀ k, 0 < (μ k).re ∧ (μ k).im = 0) :
+    ∀ k : Fin r,
+      (isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos
+        (d := d) (μ := μ) (blocks := blocks) hNCF hμpos).period k = 1 := by
+  intro k
+  rfl
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
+++ b/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
@@ -26,8 +26,7 @@ Source context: arXiv:1708.00029, lines 258--271. The paper's irreducible form
 uses weights `μ_j > 0`. The local normal-canonical definition only assumes
 nonzero complex weights, so the positive-weight convention is stated here as a
 separate hypothesis. The imaginary-zero conjunct records the paper's real-weight
-convention; the constructed irreducible-form witness only needs its
-positive-real-part consequence. See
+convention. See
 `docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex`. -/
 def toIsIrreducibleFormOfWeightPos
     (hNCF : IsNormalCanonicalForm (d := d) μ blocks)
@@ -42,7 +41,7 @@ def toIsIrreducibleFormOfWeightPos
     intro k
     rw [IsPeriodic.one_iff_primitive]
     exact ⟨hNCF.block_irreducible k, hNCF.leftCanonical k, hNCF.block_primitive k⟩
-  weight_pos := fun k => (hμpos k).1
+  weight_pos := hμpos
   sameMPV := fun _ _ => rfl
 
 /-- In the irreducible-form witness obtained from positive-weight normal canonical

--- a/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
+++ b/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
@@ -12,8 +12,6 @@ This file records the implication from normal canonical block hypotheses to
 irreducible form in the period-one case.
 -/
 
-open scoped Matrix BigOperators
-
 namespace MPSTensor
 
 variable {d r : ℕ} {dim : Fin r → ℕ}

--- a/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
+++ b/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
@@ -29,7 +29,7 @@ separate hypothesis. The imaginary-zero conjunct records the paper's real-weight
 convention; the constructed irreducible-form witness only needs its
 positive-real-part consequence. See
 `docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex`. -/
-def isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos
+def toIsIrreducibleFormOfWeightPos
     (hNCF : IsNormalCanonicalForm (d := d) μ blocks)
     (hμpos : ∀ k, 0 < (μ k).re ∧ (μ k).im = 0) :
     IsIrreducibleForm (toTensorFromBlocks (d := d) (μ := μ) blocks) where
@@ -49,11 +49,11 @@ def isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos
 hypotheses, every block period is `1`.
 
 Source context: arXiv:1708.00029, lines 258--271. -/
-theorem isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos_period_eq_one
+theorem toIsIrreducibleFormOfWeightPos_period_eq_one
     (hNCF : IsNormalCanonicalForm (d := d) μ blocks)
     (hμpos : ∀ k, 0 < (μ k).re ∧ (μ k).im = 0) :
     ∀ k : Fin r,
-      (isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos
+      (toIsIrreducibleFormOfWeightPos
         (d := d) (μ := μ) (blocks := blocks) hNCF hμpos).period k = 1 := by
   intro k
   rfl

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -49,8 +49,8 @@ $p$-divisibility of the transfer map.
 
 \begin{remark}[Positive-weight normal canonical form gives irreducible form]
     \label{rem:irr_form_vs_ncf}
-\lean{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos,
-    MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos_period_eq_one}
+\lean{MPSTensor.toIsIrreducibleFormOfWeightPos,
+    MPSTensor.toIsIrreducibleFormOfWeightPos_period_eq_one}
 \leanok
     A normal canonical block family whose weights satisfy the positive real
     convention $\mu_j>0$ assembles to a tensor in irreducible form, and the

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -38,11 +38,13 @@ $p$-divisibility of the transfer map.
     \[
         A^i = \bigoplus_{j \in J} \mu_j\, A_j^i,
     \]
-    where each block $A_j$ is an $m_j$-periodic tensor. The source fixes the
-    phases by the convention $\mu_j>0$, so the weights are positive real
-    scalars.
-    This is the standard form introduced in
-    \cite[Section~II]{DeLasCuevas2017Irreducible}.
+    where each block $A_j$ is an $m_j$-periodic tensor. Following
+    \cite[Section~II]{DeLasCuevas2017Irreducible}, the phases are fixed by the
+    convention $\mu_j>0$, so the weights are positive real scalars.
+    % Source check: arXiv:1708.00029, lines 252--261 define irreducible form
+    % with the positive-weight convention. The non-repeated basis of periodic
+    % tensors is introduced later, at lines 287--303, and is not part of this
+    % definition.
     It extends the normal canonical form
     (Definition~\ref{def:is_normal_canonical_form}),
     which requires the stronger condition that every block is $1$-periodic.

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -33,8 +33,7 @@ $p$-divisibility of the transfer map.
 \begin{definition}[Irreducible form]
     \label{def:irreducible_form}
     \lean{MPSTensor.IsIrreducibleForm}
-    % Not marked as formalized: the current Lean structure records
-    % \operatorname{Re}(\mu_j)>0 but not \operatorname{Im}(\mu_j)=0.
+    \leanok
     A tensor $A$ is in \emph{irreducible form} if it is block-diagonal
     \[
         A^i = \bigoplus_{j \in J} \mu_j\, A_j^i,

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -39,8 +39,9 @@ $p$-divisibility of the transfer map.
     \[
         A^i = \bigoplus_{j \in J} \mu_j\, A_j^i,
     \]
-    where each block $A_j$ is an $m_j$-periodic tensor and each
-    weight $\mu_j>0$ is a positive real scalar.
+    where each block $A_j$ is an $m_j$-periodic tensor. The source fixes the
+    phases by the convention $\mu_j>0$, so the weights are positive real
+    scalars.
     This is the standard form introduced in
     \cite[Section~II]{DeLasCuevas2017Irreducible}.
     It extends the normal canonical form

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -49,13 +49,25 @@ $p$-divisibility of the transfer map.
     which requires the stronger condition that every block is $1$-periodic.
 \end{definition}
 
-\begin{remark}[Relation to normal canonical form]\notready
+\begin{remark}[Positive-weight normal canonical form gives irreducible form]
     \label{rem:irr_form_vs_ncf}
-    Every tensor in normal canonical form
-    (Definition~\ref{def:is_normal_canonical_form})
-    is in irreducible form with all periods equal to~$1$.
-    The irreducible form is strictly more general: it accommodates
-    blocks such as the antiferromagnet, which are $2$-periodic.
+\lean{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos,
+    MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos_period_eq_one}
+\leanok
+    A normal canonical block family whose weights satisfy the positive real
+    convention $\mu_j>0$ assembles to a tensor in irreducible form, and the
+    corresponding irreducible-form witness has all periods equal to~$1$.
+    This is the period-one part of the paper's statement that normal tensors are
+    periodic tensors with period~$1$.
+
+    The positivity of the weights is part of the irreducible-form convention.
+    If a canonical-form decomposition is written with arbitrary nonzero complex
+    coefficients, one must first normalize their phases before applying this
+    implication; see
+    \path{docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex}.
+    With this convention understood, irreducible form is strictly more general:
+    it also accommodates blocks such as the antiferromagnet, which are
+    $2$-periodic.
 \end{remark}
 
 \noindent Physical-index rotation was introduced in

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -33,7 +33,8 @@ $p$-divisibility of the transfer map.
 \begin{definition}[Irreducible form]
     \label{def:irreducible_form}
     \lean{MPSTensor.IsIrreducibleForm}
-    \leanok
+    % Not marked as formalized: the current Lean structure records
+    % \operatorname{Re}(\mu_j)>0 but not \operatorname{Im}(\mu_j)=0.
     A tensor $A$ is in \emph{irreducible form} if it is block-diagonal
     \[
         A^i = \bigoplus_{j \in J} \mu_j\, A_j^i,

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -58,7 +58,8 @@ $p$-divisibility of the transfer map.
     A normal canonical block family whose weights satisfy the positive real
     convention $\mu_j>0$ assembles to a tensor in irreducible form, and the
     corresponding irreducible-form witness has all periods equal to~$1$.
-    This is the period-one part of the paper's statement that normal tensors are
+    This is the period-one part of the statement in
+    \cite[Section~II]{DeLasCuevas2017Irreducible} that normal tensors are
     periodic tensors with period~$1$.
 
     The positivity of the weights is part of the irreducible-form convention.

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -65,9 +65,14 @@ $p$-divisibility of the transfer map.
     coefficients, one must first normalize their phases before applying this
     implication; see
     \path{docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex}.
-    With this convention understood, irreducible form is strictly more general:
-    it also accommodates blocks such as the antiferromagnet, which are
-    $2$-periodic.
+\end{remark}
+
+\begin{remark}[Irreducible form allows higher periods]
+    \label{rem:irreducible_form_higher_periods}
+\notready
+    The converse containment is not part of the formalized implication above.
+    Irreducible form permits periodic blocks with period larger than~$1$; for
+    instance, the antiferromagnetic example has period~$2$.
 \end{remark}
 
 \noindent Physical-index rotation was introduced in

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -38,10 +38,8 @@ $p$-divisibility of the transfer map.
     \[
         A^i = \bigoplus_{j \in J} \mu_j\, A_j^i,
     \]
-    where each block $A_j$ is an $m_j$-periodic tensor,
-    each weight $\mu_j \neq 0$, and the blocks are pairwise
-    non-repeated (no two distinct $j, j'$ are related by a gauge
-    transformation and a unit-modulus scalar).
+    where each block $A_j$ is an $m_j$-periodic tensor and each
+    weight $\mu_j>0$ is a positive real scalar.
     This is the standard form introduced in
     \cite[Section~II]{DeLasCuevas2017Irreducible}.
     It extends the normal canonical form
@@ -63,8 +61,10 @@ $p$-divisibility of the transfer map.
     The positivity of the weights is part of the irreducible-form convention.
     If a canonical-form decomposition is written with arbitrary nonzero complex
     coefficients, one must first normalize their phases before applying this
-    implication; see
-    \path{docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex}.
+    implication.
+    % Maintainer note: the positive-real hypothesis is explicit because the
+    % local normal-canonical predicate only assumes nonzero complex weights; see
+    % docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex.
 \end{remark}
 
 \begin{remark}[Irreducible form allows higher periods]

--- a/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
+++ b/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
@@ -34,24 +34,25 @@ positive real part.  The formal predicate for normal canonical block hypotheses,
 inherited from the non-periodic canonical-form formulation, assumes only that
 the complex weights are nonzero and ordered by modulus.
 
-Consequently the available formal statement is the following restricted implication:
-normal canonical hypotheses together with the paper's positive real convention
-\(\operatorname{Re}\mu_j>0\) and \(\operatorname{Im}\mu_j=0\) gives an
-irreducible-form witness whose block periods are all \(1\).\footnote{Formal
-declarations:
-\leanid{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos} and
-\leanid{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos_period_eq_one}
-in \doclink{TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean}.}
+Consequently the available formal construction uses the load-bearing condition
+\(\operatorname{Re}\mu_j>0\) to build an irreducible-form witness whose block
+periods are all \(1\).  The declaration also assumes
+\(\operatorname{Im}\mu_j=0\), not because the target structure records this
+condition, but to keep the statement under the paper's positive-real convention
+\(\mu_j>0\).\footnote{Formal declarations:
+\leanid{MPSTensor.toIsIrreducibleFormOfWeightPos} and
+\leanid{MPSTensor.toIsIrreducibleFormOfWeightPos_period_eq_one} in
+\doclink{TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean}.}
 
 \section{Conclusion}
 
 This is a scope restriction of the current formal statement, not a mathematical
 disagreement with the paper.  The paper's irreducible-form convention already
-uses positive weights.  To remove the extra hypothesis from the implication,
-one must either realign the normal-canonical predicate to store the same
-positive-weight convention, or prove and formalize the phase-normalization step which replaces
-nonzero complex weights by positive ones without changing the represented
-matrix-product-vector family.
+uses positive weights.  To remove the extra positivity hypothesis from applying
+the implication to the local normal-canonical predicate, one must either realign
+that predicate to store the same positive-weight convention, or prove and
+formalize the phase-normalization step which replaces nonzero complex weights by
+positive ones without changing the represented matrix-product-vector family.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
+++ b/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
@@ -39,8 +39,8 @@ normal canonical hypotheses together with the paper's positive real convention
 \(\operatorname{Re}\mu_j>0\) and \(\operatorname{Im}\mu_j=0\) gives an
 irreducible-form witness whose block periods are all \(1\).\footnote{Formal
 declarations:
-\path{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos} and
-\path{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos_period_eq_one}
+\leanid{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos} and
+\leanid{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos_period_eq_one}
 in \doclink{TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean}.}
 
 \section{Conclusion}

--- a/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
+++ b/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
@@ -33,6 +33,9 @@ positive-weight convention needed by that structure: each weight has strictly
 positive real part.  The formal predicate for normal canonical block hypotheses,
 inherited from the non-periodic canonical-form formulation, assumes only that
 the complex weights are nonzero and ordered by modulus.
+Thus the source definition of irreducible form itself is not yet marked as
+formalized in the blueprint: the formal predicate does not store the
+\(\operatorname{Im}\mu_j=0\) part of the paper's convention.
 
 Consequently the available formal construction uses the load-bearing condition
 \(\operatorname{Re}\mu_j>0\) to build an irreducible-form witness whose block

--- a/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
+++ b/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
@@ -28,21 +28,15 @@ assembles to an irreducible-form tensor whose periods are all equal to \(1\).
 
 \section{The formal statements}
 
-The formal predicate for irreducible form records the part of the paper's
-positive-weight convention needed by that structure: each weight has strictly
-positive real part.  The formal predicate for normal canonical block hypotheses,
-inherited from the non-periodic canonical-form formulation, assumes only that
-the complex weights are nonzero and ordered by modulus.
-Thus the source definition of irreducible form itself is not yet marked as
-formalized in the blueprint: the formal predicate does not store the
-\(\operatorname{Im}\mu_j=0\) part of the paper's convention.
+The formal predicate for irreducible form records the paper's positive-weight
+convention: \(\operatorname{Re}\mu_j>0\) and \(\operatorname{Im}\mu_j=0\).
+The formal predicate for normal canonical block hypotheses, inherited from the
+non-periodic canonical-form formulation, assumes only that the complex weights
+are nonzero and ordered by modulus.
 
-Consequently the available formal construction uses the load-bearing condition
-\(\operatorname{Re}\mu_j>0\) to build an irreducible-form witness whose block
-periods are all \(1\).  The declaration also assumes
-\(\operatorname{Im}\mu_j=0\), not because the target structure records this
-condition, but to keep the statement under the paper's positive-real convention
-\(\mu_j>0\).\footnote{Formal declarations:
+Consequently the available formal construction assumes the paper's
+positive-real convention and builds an irreducible-form witness whose block
+periods are all \(1\).\footnote{Formal declarations:
 \leanid{MPSTensor.toIsIrreducibleFormOfWeightPos} and
 \leanid{MPSTensor.toIsIrreducibleFormOfWeightPos_period_eq_one} in
 \doclink{TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean}.}

--- a/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
+++ b/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
@@ -1,0 +1,59 @@
+\documentclass[11pt]{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{command}
+
+\title{Positive Weights in the Normal-Canonical Implication to Irreducible Form}
+\author{}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\section{The assertion}
+
+The periodic-MPS paper states that normal tensors are precisely periodic
+tensors of period \(1\), and that when all blocks in the irreducible
+decomposition are normal the decomposition is the canonical form in the sense of
+Ci15.\footnote{\cite[Section~II]{DeLasCuevas2017Irreducible}; the local source
+passage is arXiv:1708.00029, lines 258--271.}
+In the same paragraph the irreducible-form weights are fixed by the convention
+\(\mu_j>0\).
+
+The blueprint records the corresponding implication: a normal canonical block family
+assembles to an irreducible-form tensor whose periods are all equal to \(1\).
+
+\section{The formal statements}
+
+The formal predicate for irreducible form records the part of the paper's
+positive-weight convention needed by that structure: each weight has strictly
+positive real part.  The formal predicate for normal canonical block hypotheses,
+inherited from the non-periodic canonical-form formulation, assumes only that
+the complex weights are nonzero and ordered by modulus.
+
+Consequently the available formal statement is the following restricted implication:
+normal canonical hypotheses together with the paper's positive real convention
+\(\operatorname{Re}\mu_j>0\) and \(\operatorname{Im}\mu_j=0\) gives an
+irreducible-form witness whose block periods are all \(1\).\footnote{Formal
+declarations:
+\path{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos} and
+\path{MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos_period_eq_one}
+in \doclink{TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean}.}
+
+\section{Conclusion}
+
+This is a scope restriction of the current formal statement, not a mathematical
+disagreement with the paper.  The paper's irreducible-form convention already
+uses positive weights.  To remove the extra hypothesis from the implication,
+one must either realign the normal-canonical predicate to store the same
+positive-weight convention, or prove and formalize the phase-normalization step which replaces
+nonzero complex weights by positive ones without changing the represented
+matrix-product-vector family.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
+++ b/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
@@ -34,6 +34,10 @@ The formal predicate for normal canonical block hypotheses, inherited from the
 non-periodic canonical-form formulation, assumes only that the complex weights
 are nonzero and ordered by modulus.
 
+The paper introduces a minimal non-repeated basis of periodic tensors later in
+Section~II. That basis condition is separate from the irreducible-form
+definition considered here.
+
 Consequently the available formal construction assumes the paper's
 positive-real convention and builds an irreducible-form witness whose block
 periods are all \(1\).\footnote{Formal declarations:


### PR DESCRIPTION
## Summary

This PR records the period-one implication from the periodic MPS paper: a normal canonical block family with the paper's positive real weight convention gives an irreducible-form witness, and that witness has all block periods equal to 1.

It adds `MPSTensor.isIrreducibleForm_of_isNormalCanonicalForm_of_weight_pos` and the companion period theorem, exposes the new module through `TNLean.lean`, marks the corresponding blueprint remark `\leanok`, and adds a paper-gap note explaining the remaining weight-normalization restriction.

## Mathematical Point

In arXiv:1708.00029, irreducible form is written with weights $\mu_j>0$. The current `IsNormalCanonicalForm` predicate assumes only nonzero complex weights. Therefore this PR proves the positive-weight implication, rather than claiming the unrestricted nonzero-weight statement. Removing that explicit hypothesis requires a phase-normalization theorem for the block weights.

Refs #2277.

## Checks

- `lake env lean TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean`
- `lake build TNLean.MPS.Periodic.NormalCanonicalPeriodOne`
- `lake env lean TNLean.lean`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error 1708_normal_canonical_irreducible_form_weights.tex && latexmk -c 1708_normal_canonical_irreducible_form_weights.tex`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation; tightens a predicate field and does not touch runtime or security-sensitive code.
> 
> **Overview**
> Formalizes the **period-one** link from arXiv:1708.00029: a normal canonical block family with **positive real** weights (`μ_j > 0`) yields an `IsIrreducibleForm` witness for the assembled tensor, with every block period **1**.
> 
> **Lean:** New `TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean` (`toIsIrreducibleFormOfWeightPos`, `toIsIrreducibleFormOfWeightPos_period_eq_one`); root import in `TNLean.lean`. **`IsIrreducibleForm.weight_pos`** now requires `0 < Re μ` and `Im μ = 0`, matching the paper’s convention.
> 
> **Docs:** Blueprint `ch22_periodic_ft.tex` updates the irreducible-form definition (positive weights; non-repeated basis deferred), marks the NCF→irreducible remark `\leanok`, and adds a separate remark on higher periods. **`docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex`** documents why positivity is an explicit hypothesis vs. `IsNormalCanonicalForm` (nonzero complex weights only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415c101449fb9d1f0574ee6f89f28c012bce6479. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->