### PR TITLE
doc(parent): distinguish commuting terminology

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1,11 +1,10 @@
-\section{Commuting parent Hamiltonians}\label{sec:commuting_parent_ham}
+\section{Translated parent-term commutation}\label{sec:commuting_parent_ham}
 
-A parent Hamiltonian has \emph{commuting} local terms when all translated
-interaction projectors commute with each other. For normal tensors this
-section relates the renormalization fixed points to the tensors whose length-two
-parent terms commute, $h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2)$; the implication from
-commuting terms back to a renormalization fixed point uses a left-canonical
-normalization.
+This section concerns the commutation equation for translated parent terms in a
+periodic chain. For normal tensors it relates renormalization fixed points to
+the tensors whose length-two parent terms commute,
+$h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2)$; the implication from commuting terms back
+to a renormalization fixed point uses a left-canonical normalization.
 
 The nearest-neighbor commuting parent Hamiltonian condition in
 \cite[Definition~3.9 and Theorem~3.10]{Cirac2016MPDO_arXiv} is distinct from
@@ -16,7 +15,7 @@ In Definition~3.9 the parent-Hamiltonian condition also says that, for
 $N>L$, the ground space is spanned by the periodic MPS vectors associated to
 the BNT components; nearest-neighbor means the specialization $L=2$.
 
-\begin{definition}[Commuting parent Hamiltonian]\label{def:is_commuting_parent_ham}
+\begin{definition}[Translated parent-term commutation]\label{def:is_commuting_parent_ham}
     \lean{MPSTensor.IsCommutingParentHam}
     \leanok
     \uses{def:local_term_parent}
@@ -30,7 +29,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     MPS vectors of the BNT components.
 \end{definition}
 
-\begin{definition}[Nearest-neighbor commuting parent Hamiltonian]\label{def:is_nncph}
+\begin{definition}[Nearest-neighbor translated parent-term commutation]\label{def:is_nncph}
     \lean{MPSTensor.IsNNCPH}
     \leanok
     \uses{def:is_commuting_parent_ham}
@@ -123,7 +122,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     Lemma~\ref{lem:parent_hamiltonian_ff} with $L=2$.
 \end{proof}
 
-\begin{remark}[Product-of-pairs equations for the nearest-neighbor commuting parent Hamiltonian]%
+\begin{remark}[Product-of-pairs equations for nearest-neighbor parent-term commutation]%
     \label{rem:product_pair_projectors}
     \lean{MPSTensor.productPairWindow}
     \lean{MPSTensor.productPairWindow_one}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -1,4 +1,4 @@
-\section{Decorrelation and the Appendix D parent-commuting condition}%
+\section{Decorrelation and the idempotent-product parent-commuting condition}%
 \label{sec:decorrelation}
 
 This section develops the idempotent-product formulation used for the
@@ -29,10 +29,10 @@ orthogonal-projector, or ground-space-intersection hypotheses of Appendix~D.2.
     for all $O_A \in \mathcal{O}_A$, $O_B \in \mathcal{O}_B$.
 \end{definition}
 
-\begin{definition}[Appendix D idempotent-product consequence]\label{def:has_commuting_parent_ham}
+\begin{definition}[Idempotent-product parent-commuting structure]\label{def:has_commuting_parent_ham}
     \lean{Decorrelation.HasCommutingParentHam}
     \leanok
-    The algebraic datum used below records only the idempotent-product
+    The structure used below records only the idempotent-product
     consequence of the parent commuting Hamiltonian condition of
     \cite[Appendix~D.2]{Cirac2016MPDO_arXiv}. It consists of commuting
     idempotent endomorphisms $P_{AX}$ and $P_{XB}$ such that, for the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -1,8 +1,8 @@
-\section{Decorrelation and parent commuting Hamiltonians}%
+\section{Decorrelation and the Appendix D parent-commuting condition}%
 \label{sec:decorrelation}
 
 This section develops the idempotent-product formulation used for the
-decorrelation implication. It is not the full Appendix~D source condition.
+decorrelation implication from Appendix~D. It is not the full source condition.
 In Appendix~D.2 of
 \cite{Cirac2016MPDO_arXiv}, the parent commuting Hamiltonian condition is stated
 for local projectors $Q_{AX}$ and $Q_{XB}$ with
@@ -29,10 +29,10 @@ orthogonal-projector, or ground-space-intersection hypotheses of Appendix~D.2.
     for all $O_A \in \mathcal{O}_A$, $O_B \in \mathcal{O}_B$.
 \end{definition}
 
-\begin{definition}[Idempotent-product data]\label{def:has_commuting_parent_ham}
+\begin{definition}[Appendix D idempotent-product consequence]\label{def:has_commuting_parent_ham}
     \lean{Decorrelation.HasCommutingParentHam}
     \leanok
-    The algebraic data used below records only the idempotent-product
+    The algebraic datum used below records only the idempotent-product
     consequence of the parent commuting Hamiltonian condition of
     \cite[Appendix~D.2]{Cirac2016MPDO_arXiv}. It consists of commuting
     idempotent endomorphisms $P_{AX}$ and $P_{XB}$ such that, for the


### PR DESCRIPTION
## Summary

This PR clarifies the blueprint terminology around two distinct source notions in Cirac--Perez-Garcia--Schuch--Verstraete 2016. The chapter now names the Definition 3.9 condition as translated parent-term commutation, while the decorrelation chapter names the Appendix D condition separately as the parent-commuting condition and its idempotent-product consequence.

The change is prose-only: no Lean declarations or theorem statements are changed.

Refs #2633.
Refs #190.

## Checks

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

`leanblueprint checkdecls` was attempted in the fresh worktree, but stopped before checking declarations because the generated `blueprint/lean_decls` file was absent. The repository sync script above passed, and CI regenerates `blueprint/lean_decls`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX renames and prose; no Lean or formal statement changes.
> 
> **Overview**
> Renames reader-facing blueprint prose so **Definition 3.9** (translated parent terms on a periodic chain) and **Appendix D.2** (local projectors / idempotent-product structure) are not conflated under generic “commuting parent Hamiltonian” wording.
> 
> In `ch13_parent_hamiltonian_commuting_gap.tex`, the section and definition titles now say **translated parent-term commutation** (including the nearest-neighbor specialization), and the opening paragraph frames the section around that commutation equation rather than a full Hamiltonian notion.
> 
> In `ch13_parent_hamiltonian_decorrelation.tex`, the decorrelation section title and the idempotent-product definition are retitled to stress the **parent-commuting / idempotent-product** side of Appendix D, with minor wording tweaks (“from Appendix~D”, “structure” vs “algebraic data”). **Lean `\lean{...}` hooks, labels, and mathematical content are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3ed05564cac7b752ca776b33cee5b4bb79dded5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->