### PR TITLE
feat(MPS/Periodic): expose sector-overlap transport

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -229,7 +229,7 @@ private lemma sectorOverlap_succ_eq {m : ℕ} [NeZero D] [NeZero m]
 /-- **One-step transport of sector overlaps from cyclic-sector decompositions.**
 
 For positive lengths, the cross overlap of the compressed cyclic sectors is
-invariant under the simultaneous index shift `(u, v) → (u+1, v+1)`.
+invariant under the simultaneous index shift (u, v) ↦ (u + 1, v + 1).
 This is the formal overlap version of the translation-operator step in
 arXiv:1708.00029, lines 985--1002. -/
 lemma sectorOverlap_succ_eq_of_cyclicSectorDecomp {m : ℕ} [NeZero D] [NeZero m]

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -226,6 +226,28 @@ private lemma sectorOverlap_succ_eq {m : ℕ} [NeZero D] [NeZero m]
   rw [hL']
   exact sum_trace_proj_overlap_shift A B PA PB hLetterA hLetterB u v
 
+/-- **One-step transport of sector overlaps from cyclic-sector decompositions.**
+
+For positive lengths, the cross overlap of the compressed cyclic sectors is
+invariant under the simultaneous index shift `(u, v) → (u+1, v+1)`.
+This is the formal overlap version of the translation-operator step in
+arXiv:1708.00029, lines 985--1002. -/
+lemma sectorOverlap_succ_eq_of_cyclicSectorDecomp {m : ℕ} [NeZero D] [NeZero m]
+    (A B : MPSTensor d D)
+    (hA_lc : IsLeftCanonical A) (hB_lc : IsLeftCanonical B)
+    {dimA dimB : Fin m → ℕ}
+    (blocksA : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
+    (blocksB : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
+    (hA_cyclic : IsCyclicSectorDecomp A blocksA)
+    (hB_cyclic : IsCyclicSectorDecomp B blocksB)
+    (u v : Fin m) (N : ℕ) (hN : 0 < N) :
+    mpvOverlap (d := blockPhysDim d m) (blocksA (u + 1)) (blocksB (v + 1)) N =
+      mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
+  obtain ⟨PA, _φA, hPAproj, _hPAsum, hShiftA, _hCommA, hTraceA, _⟩ := hA_cyclic
+  obtain ⟨PB, _φB, hPBproj, _hPBsum, hShiftB, _hCommB, hTraceB, _⟩ := hB_cyclic
+  exact sectorOverlap_succ_eq A B hA_lc hB_lc blocksA blocksB PA PB
+    hPAproj hPBproj hShiftA hShiftB hTraceA hTraceB u v N hN
+
 /-- Self-overlap of an irreducible, transfer-primitive, trace-preserving tensor
 tends to `1` (arXiv:1708.00029, Appendix A, first paragraph). -/
 private lemma selfOverlap_tendsto_one_of_irreducible_primitive_TP
@@ -419,13 +441,11 @@ private lemma sectorGaugePhaseEquiv_succ_of_cyclicTransport
     overlap_norm_tendsto_one_of_gaugePhase_cast (blocksA u) (blocksB v) hdim
       hIrrA_u hIrrB_v (hA_blocks_lc u) (hB_blocks_lc v) hPrimA_u hPrimB_v hMatch
   -- Step B: the cross overlap is invariant under `(u, v) → (u+1, v+1)` at positive lengths.
-  obtain ⟨PA, _φA, hPAproj, _hPAsum, hShiftA, _hCommA, hTraceA, _⟩ := hA_cyclic
-  obtain ⟨PB, _φB, hPBproj, _hPBsum, hShiftB, _hCommB, hTraceB, _⟩ := hB_cyclic
   have hShiftEq : ∀ N : ℕ, 0 < N →
       mpvOverlap (d := blockPhysDim d m) (blocksA (u + 1)) (blocksB (v + 1)) N =
         mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := fun N hN =>
-    sectorOverlap_succ_eq A B hA.leftCanonical hB.leftCanonical blocksA blocksB PA PB
-      hPAproj hPBproj hShiftA hShiftB hTraceA hTraceB u v N hN
+    sectorOverlap_succ_eq_of_cyclicSectorDecomp A B hA.leftCanonical hB.leftCanonical
+      blocksA blocksB hA_cyclic hB_cyclic u v N hN
   -- Step C: transport the norm limit, then conclude gauge-phase equivalence at `(u+1, v+1)`.
   have hNorm_succ :
       Tendsto (fun N => ‖mpvOverlap (d := blockPhysDim d m)

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -609,6 +609,29 @@ unconditional result.
     Definition~\ref{def:cyclic_sector_decomp}.
 \end{proof}
 
+\begin{lemma}[One-site transport of sector overlaps]
+    \label{lem:sector_overlap_succ_eq_cyclic_sector_decomp}
+    \lean{MPSTensor.sectorOverlap_succ_eq_of_cyclicSectorDecomp}
+    \leanok
+    \uses{def:cyclic_sector_decomp, def:mpv_overlap, def:blocked_tensor,
+        thm:offdiag_shift_adjoint_cyclic_shift}
+    Let $A$ and $B$ be left-canonical tensors with cyclic sector
+    decompositions $\{A_u\}_{u\in\mathbb Z_m}$ and
+    $\{B_v\}_{v\in\mathbb Z_m}$. For every $u,v\in\mathbb Z_m$ and every
+    $N>0$,
+    \[
+        O_{A_{u+1},B_{v+1}}(N)=O_{A_u,B_v}(N).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Choose the projection families $P_u$ and $Q_v$ from the two cyclic sector
+    decompositions. The single-site relations
+    $P_{u+1}A^i=A^iP_u$ and $Q_{v+1}B^i=B^iQ_v$ move the final physical
+    letter through the trace. Summing over all words and reindexing the
+    blocked configurations gives the stated equality of overlaps.
+\end{proof}
+
 \begin{lemma}[Off-diagonal eigenvectors of the period transfer vanish]
     \label{lem:offdiag_eigenvector_eq_zero_periodic}
     \lean{MPSTensor.offDiag_eigenvector_eq_zero_of_isPeriodic}
@@ -822,7 +845,8 @@ unconditional result.
 \begin{lemma}[Sector-match propagation under translation]\label{lem:sector_match_propagation}
     \lean{MPSTensor.sectorMatch_propagation}
     \leanok
-    \uses{def:periodic_tensor, def:cyclic_sector_decomp}
+    \uses{def:periodic_tensor, def:cyclic_sector_decomp,
+        lem:sector_overlap_succ_eq_cyclic_sector_decomp}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
     cyclic sector decompositions whose sectors are left-canonical. Suppose

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -627,9 +627,22 @@ unconditional result.
 \begin{proof}\leanok
     Choose the projection families $P_u$ and $Q_v$ from the two cyclic sector
     decompositions. The single-site relations
-    $P_{u+1}A^i=A^iP_u$ and $Q_{v+1}B^i=B^iQ_v$ move the final physical
-    letter through the trace. Summing over all words and reindexing the
-    blocked configurations gives the stated equality of overlaps.
+    $P_{u+1}A^i=A^iP_u$ and $Q_{v+1}B^i=B^iQ_v$ give the following
+    trace-sum identity, where $T$ is the one-site rotation of physical words:
+    \[
+    \begin{aligned}
+        O_{A_{u+1},B_{v+1}}(N)
+        &=\sum_{\tau\in[d]^{Nm}}\operatorname{tr}(P_{u+1}A^\tau)\,
+            \overline{\operatorname{tr}(Q_{v+1}B^\tau)}\\
+        &=\sum_{\tau\in[d]^{Nm}}\operatorname{tr}(P_{u+1}A^{T\tau})\,
+            \overline{\operatorname{tr}(Q_{v+1}B^{T\tau})}\\
+        &=\sum_{\tau\in[d]^{Nm}}\operatorname{tr}(P_uA^\tau)\,
+            \overline{\operatorname{tr}(Q_vB^\tau)}
+        =O_{A_u,B_v}(N).
+    \end{aligned}
+    \]
+    The first and last equalities are the cyclic-sector trace formula after
+    reindexing blocked words as physical words of length $Nm$.
 \end{proof}
 
 \begin{lemma}[Off-diagonal eigenvectors of the period transfer vanish]

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -158,29 +158,30 @@ ranges (replacing earlier published-version labels such as ``A.8'' and
 ``A.14--A.18'' that do not occur in the local source), and the
 $\kappa/\theta/\phi$ phase assembly is now stated explicitly as load-bearing.
 
-\textbf{Missing infrastructure (identified by adversarial proof-attempts).} The
-two open Case-3 leaves reduce to a common gap: \leanid{IsCyclicSectorDecomp}
-exposes only \emph{blocked-letter} data (the commutation $P_k\,(\bar A)_i=(\bar
-A)_i\,P_k$ and the adjoint shift $\mathcal E_A^{*}(P_{k+1})=P_k$), but the
-appendix argument needs \emph{single-site} structure that is currently absent
-from the repository (and from Mathlib):
+\textbf{Formalized single-site inputs.} The single-site off-diagonal
+decomposition is now formalized from the cyclic adjoint-shift relation:
+\path{offDiag_shift_of_adjoint_cyclic_shift} proves
+$P_{u+1}A^i=A^iP_u$, \path{eq_sum_offDiag_of_adjoint_cyclic_shift} proves
+$A^i=\sum_u P_{u+1}A^iP_u$, and the cyclic-sector wrappers
+\path{IsCyclicSectorDecomp.offDiag_shift} and
+\path{IsCyclicSectorDecomp.eq_sum_offDiag} expose these consequences for a
+chosen cyclic sector decomposition. This is the inverse-indexed form of
+\emph{eq:Aoffdiag}, lines~335--339; the later \emph{eq:Auprop}, line~1014,
+defines the sector letters $A_u^i=P_uA^iP_{u+1}$.
+
+The one-site sector-overlap translation is also formalized:
+\path{sectorOverlap_succ_eq_of_cyclicSectorDecomp} proves, for every
+$N>0$,
+\[
+    O_{A_{u+1},B_{v+1}}(N)=O_{A_u,B_v}(N).
+\]
+It is the overlap-sum form of the translation step in lines~985--1002, using
+the single-site relations inside the paired trace sum and the repository's
+inverse cyclic indexing convention.
+
+\textbf{Remaining Case-3 input.} After these single-site inputs, the open
+Case-3 leaf is the contraction and phase-assembly step:
 \begin{itemize}
-  \item \emph{Single-site off-diagonal decomposition} $A^i=\sum_u P_uA^iP_{u+1}$
-    (\emph{eq:Auprop}, line~1043). This is the bridge from the corner-compressed
-    sectors back to the global matrices $A^i$, required to even \emph{state} the
-    contraction in \leanid{repeatedBlocks_of_blockedSectorGaugePhase}. Adding it
-    (as a field of \leanid{IsCyclicSectorDecomp} or a derived lemma) is the key
-    enabling step.
-  \item \emph{Single-site sector-overlap translation invariance}: that
-    $\lVert\langle V_N(A_{u+1})|V_N(B_{v+1})\rangle\rVert$ and
-    $\lVert\langle V_N(A_u)|V_N(B_v)\rangle\rVert$ share an $N\to\infty$ limit,
-    obtained by applying the dual single-site shifts $\sum_iA_i^{\dagger}P_{u+1}A_i=P_u$
-    and $\sum_iB_i^{\dagger}Q_{v+1}B_i=Q_v$ inside the paired trace sum. This is the
-    one missing lemma for \leanid{sectorGaugePhaseEquiv_succ_of_cyclicTransport};
-    given it, that leaf closes via the proved
-    \leanid{gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP} and the
-    proved sector primitivity. There is no one-physical-site offset reblocking
-    equivalence on configurations in the repo (only the $m\cdot n$ regrouping).
   \item \emph{Per-sector corner unitaries}: upgrading the compression LinearEquiv
     $\varphi_u$ to a multiplicative $\ast$-isomorphism with a unitary intertwiner
     $U_v=P_uU_vQ_v$ on $\mathrm{Fin}\,D$ (\emph{eq:Cvprop}); and the $m$-factor
@@ -188,9 +189,12 @@ from the repository (and from Mathlib):
     \leanid{tensor_proportional} is its $m=2$ shadow) plus the $\kappa/\theta/\phi$
     telescoping into the global unitary $U=\sum_u e^{i\phi_{u+q}}P_uU_{u+q}Q_{u+q}$.
 \end{itemize}
-These are the remaining obligations for \leanid{sectorGaugePhaseEquiv_succ_of_cyclicTransport}
-and \leanid{repeatedBlocks_of_blockedSectorGaugePhase}; each is a focused
-infrastructure development rather than a one-step discharge.
+This is the remaining obligation for
+\path{repeatedBlocks_of_blockedSectorGaugePhase}. The one-step transport
+\path{sectorGaugePhaseEquiv_succ_of_cyclicTransport} is closed by the
+single-site overlap theorem above together with
+\path{gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP} and the
+proved sector primitivity.
 
 \section{Scope restriction: independence without spanning}
 

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -159,18 +159,20 @@ ranges (replacing earlier published-version labels such as ``A.8'' and
 $\kappa/\theta/\phi$ phase assembly is now stated explicitly as load-bearing.
 
 \textbf{Formalized single-site inputs.} The single-site off-diagonal
-decomposition is now formalized from the cyclic adjoint-shift relation:
-\path{offDiag_shift_of_adjoint_cyclic_shift} proves
-$P_{u+1}A^i=A^iP_u$, \path{eq_sum_offDiag_of_adjoint_cyclic_shift} proves
-$A^i=\sum_u P_{u+1}A^iP_u$, and the cyclic-sector wrappers
-\path{IsCyclicSectorDecomp.offDiag_shift} and
-\path{IsCyclicSectorDecomp.eq_sum_offDiag} expose these consequences for a
-chosen cyclic sector decomposition. This is the inverse-indexed form of
+decomposition is now formalized from the cyclic adjoint-shift
+relation.\footnote{The formal declarations are
+\leanid{offDiag_shift_of_adjoint_cyclic_shift},
+\leanid{eq_sum_offDiag_of_adjoint_cyclic_shift},
+\leanid{IsCyclicSectorDecomp.offDiag_shift}, and
+\leanid{IsCyclicSectorDecomp.eq_sum_offDiag}.} It gives
+$P_{u+1}A^i=A^iP_u$ and $A^i=\sum_u P_{u+1}A^iP_u$ for a chosen cyclic
+sector decomposition. This is the inverse-indexed form of
 \emph{eq:Aoffdiag}, lines~335--339; the later \emph{eq:Auprop}, line~1014,
 defines the sector letters $A_u^i=P_uA^iP_{u+1}$.
 
-The one-site sector-overlap translation is also formalized:
-\path{sectorOverlap_succ_eq_of_cyclicSectorDecomp} proves, for every
+Let $O_{C,D}(N):=\langle V_N(C)\mid V_N(D)\rangle$. The one-site
+sector-overlap translation is also formalized.\footnote{Formal declaration:
+\leanid{sectorOverlap_succ_eq_of_cyclicSectorDecomp}.} It proves, for every
 $N>0$,
 \[
     O_{A_{u+1},B_{v+1}}(N)=O_{A_u,B_v}(N).
@@ -189,12 +191,14 @@ Case-3 leaf is the contraction and phase-assembly step:
     \leanid{tensor_proportional} is its $m=2$ shadow) plus the $\kappa/\theta/\phi$
     telescoping into the global unitary $U=\sum_u e^{i\phi_{u+q}}P_uU_{u+q}Q_{u+q}$.
 \end{itemize}
-This is the remaining obligation for
-\path{repeatedBlocks_of_blockedSectorGaugePhase}. The one-step transport
-\path{sectorGaugePhaseEquiv_succ_of_cyclicTransport} is closed by the
-single-site overlap theorem above together with
-\path{gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP} and the
-proved sector primitivity.
+This is the remaining obligation for the repeated-blocks assembly
+theorem.\footnote{Formal declaration:
+\leanid{repeatedBlocks_of_blockedSectorGaugePhase}.} The one-step
+transport theorem is closed by the single-site overlap theorem above together
+with the overlap-to-gauge theorem and the proved sector primitivity.\footnote{
+The formal declarations are
+\leanid{sectorGaugePhaseEquiv_succ_of_cyclicTransport} and
+\leanid{gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP}.}
 
 \section{Scope restriction: independence without spanning}
 


### PR DESCRIPTION
### Motivation

- Closes the missing lemma identified in `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex` (arXiv:1708.00029, Appendix A, Case 3, lines 985–1002): single-site sector-overlap translation invariance for cyclic transport.
- For periodic tensors $A$ and $B$ with cyclic sector decompositions, the sector overlap at adjacent cyclic indices $O_{A_{u+1},B_{v+1}}(N) = O_{A_u,B_v}(N)$ for $N > 0$ is the key input needed to close `sectorGaugePhaseEquiv_succ_of_cyclicTransport` via `gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP` together with already-proved sector primitivity. See #2373.

### Description

- `TNLean/MPS/Periodic/Overlap/Case3.lean`: adds the public theorem `MPSTensor.sectorOverlap_succ_eq_of_cyclicSectorDecomp` stating that, for $N > 0$, the sector overlap satisfies $O_{A_{u+1},B_{v+1}}(N) = O_{A_u,B_v}(N)$. The proof inserts the dual single-site shift equations inside the paired trace sum to advance the sector index by one. The sector-match propagation argument is updated to call this theorem instead of destructing the decompositions directly.
- `blueprint/src/chapter/ch22_periodic_ft.tex`: adds the corresponding lemma entry with `\lean{}` and `\leanok` tags.
- `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`: records that the off-diagonal single-site decomposition and the one-site sector-overlap transport are now formalized; isolates the remaining Case-3 input as the per-sector corner-unitary contraction and phase-assembly step for `repeatedBlocks_of_blockedSectorGaugePhase`.

### Testing

- `lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean`
- `lake build TNLean.MPS.Periodic.Overlap.Case3`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error 1708_periodic_overlap_route_alignment.tex`

---
Closes #2373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and API refactor in formalized MPS periodic overlap theory; no runtime, auth, or data-path changes. Remaining Case-3 **`sorry`** is unchanged in scope.
> 
> **Overview**
> Adds the public Lean theorem **`MPSTensor.sectorOverlap_succ_eq_of_cyclicSectorDecomp`**, which states that for cyclic sector decompositions and **N > 0**, sector cross-overlaps are unchanged under the simultaneous shift **(u, v) ↦ (u+1, v+1)**—the appendix translation step (arXiv:1708.00029, lines 985–1002). It packages the existing low-level proof behind **`IsCyclicSectorDecomp`** hypotheses.
> 
> **`sectorGaugePhaseEquiv_succ_of_cyclicTransport`** now calls this theorem instead of unpacking projection data inline, which closes the one-step cyclic transport step in the sector-match propagation chain.
> 
> The blueprint gains a matching lemma with **`\leanok`**, and the periodic overlap alignment note is updated to record single-site overlap transport as formalized while the **Ω_u / corner-unitary contraction** for **`repeatedBlocks_of_blockedSectorGaugePhase`** remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64dbcd13b87792297d87de3956e8abb659a36a50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->