### PR TITLE
doc(parent): mark block boundary equalities conditional

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -3,13 +3,14 @@
 The periodic ground-space theorem states that, for sufficiently long periodic
 systems, the periodic-boundary ground space of a parent Hamiltonian is generated
 by a basis of normal tensors~\cite[Theorem~IV.16]{Cirac2021Matrix}. The lemmas
-in this subsection are reductions toward that statement: their hypotheses
-explicitly include a boundary inclusion, a block-diagonal boundary
-representation, or periodic-boundary membership for the single-block states.
-When the hypotheses are written with words $\beta$ and $\rho$, these words are
-local coordinates for a boundary-crossing restriction. The cited source phrases
-the comparison through the trace-decomposition identities with
-$D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
+in this subsection are conditional reductions toward that statement. Their
+hypotheses explicitly include a boundary inclusion, a block-diagonal boundary
+representation, or periodic-boundary membership for the single-block states; in
+the source theorem these conditions are obtained from the boundary-condition
+comparison in the periodic ring. When the hypotheses are written with words
+$\beta$ and $\rho$, these words are local coordinates for a boundary-crossing
+restriction. The cited source phrases the comparison through the
+trace-decomposition identities with $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
 
 \begin{lemma}[The block-diagonal periodic-boundary space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
@@ -163,7 +164,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     $\psi\in\mathcal G_{N,L}(B)$.
 \end{proof}
 
-\begin{lemma}[Block-diagonal boundary representation gives equality in the finite range]
+\begin{lemma}[Block-diagonal boundary representation reduces to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_boundary_representation_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary}
     \leanok
@@ -203,7 +204,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}.
 \end{proof}
 
-\begin{lemma}[Matrix identities give equality in the finite range]
+\begin{lemma}[Boundary-condition identities reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_complementary_identities_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}
     \leanok
@@ -261,7 +262,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[$C^j$ boundary comparisons give equality in the finite range]
+\begin{lemma}[$C^j$ boundary comparisons reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_pgvwc_comparison_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison}
     \leanok
@@ -320,7 +321,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[Trace-decomposition comparisons give equality in the finite range]
+\begin{lemma}[Trace-decomposition comparisons reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_trace_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition}
     \leanok
@@ -383,7 +384,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[Boundary decomposition gives equality in the finite injectivity range]
+\begin{lemma}[Boundary decomposition reduces to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_boundary_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -10,12 +10,12 @@ $N$-site ring the parent Hamiltonian has the periodic-boundary ground space
 $\mathcal G_{N,L}(\bigoplus_j\mu_j A_j)$. The results below establish the
 open-segment recursion
 $\C^d\otimes S_m\cap S_m\otimes\C^d=S_{m+1}$ and, conditional on the
-closure-property inclusion at the periodic boundary, reduce the
+block-diagonal boundary-condition comparison in the periodic ring, reduce the
 periodic-boundary ground space to the span
 $\spn\{V^{(N)}(A_j):j=1,\ldots,g\}$ of the basis-of-normal-tensors component
 vectors.
 
-\begin{theorem}[Block-diagonal local recursion and periodic-boundary closure]
+\begin{theorem}[Block-diagonal local recursion and boundary-condition comparison]
     \label{thm:block_diagonal_ground_space_intersection}
     \notready
     \uses{def:ground_space_parent, def:chain_ground_space, def:l_blk_injective,
@@ -366,7 +366,8 @@ vectors.
         \qquad
         N\ge L+L_0,
     \]
-    and assume the closure-property inclusion at the periodic boundary
+    and assume the block-diagonal boundary-condition comparison in the
+    periodic ring,
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
         \subseteq
@@ -387,10 +388,10 @@ vectors.
     \cite[Theorem~12]{PerezGarcia2007Matrix}. The shorter range stated in
     \cite[lines~2126--2128]{Cirac2021Matrix} requires the strengthened
     block-diagonal re-growing step. These hypotheses do not by themselves give
-    the displayed closure-property inclusion at the periodic boundary. That
-    inclusion follows only
-    after the block-diagonal boundary conditions have been compared across the
-    windows crossing the chosen periodic-boundary cut. Since $g\ge2$
+    the displayed boundary-condition comparison in the periodic ring. That
+    comparison follows only after the block-diagonal boundary conditions have
+    been compared across the windows crossing the chosen periodic-boundary cut.
+    Since $g\ge2$
     and $L_0\ge1$,
     \[
         L\ge 3(g-1)(L_0+1)+1 \ge 3L_0+4 > L_0,
@@ -404,7 +405,7 @@ vectors.
         \quad\Longrightarrow\quad
         \exists n\ge1,\; V^{(n)}(A_j)\ne V^{(n)}(A_k).
     \]
-    By the assumed closure-property inclusion at the periodic boundary,
+    By the assumed block-diagonal boundary-condition comparison,
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j \mu_j A_j\right)
         \subseteq


### PR DESCRIPTION
## Summary
- Mark the block-diagonal periodic-boundary equalities as conditional reductions toward the source theorem.
- Replace the visible closure-inclusion phrasing in the BNT consequence section with the source language of block-diagonal boundary-condition comparison.
- Keep the displayed boundary equations, Lean links, and blueprint dependencies unchanged.

## Source
- Perez-Garcia et al., Theorem “Degeneracy of the ground space v2”.
- Cirac et al., Section IV.C, block-diagonal boundary conditions and inverting and re-growing tensors.

## Validation
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Refs #2651.
Refs #190.
Refs #460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX blueprint wording and lemma titles only; no Lean or runtime code changes.
> 
> **Overview**
> Blueprint prose in **ch13** is tightened so block-diagonal periodic-boundary lemmas read as **conditional reductions** toward the cited periodic ground-space theorem, not as standalone finite-range equalities.
> 
> The opening of `ch13_parent_hamiltonian_block_diagonal_chain_equality.tex` now states that boundary inclusion, block-diagonal representation, and single-block periodic membership are hypotheses whose role in the source is obtained from **boundary-condition comparison in the periodic ring**. Six lemma titles shift from “equality in the finite range” (or injectivity range) to **“… reduce to periodic-boundary equality”**; labels, Lean links, and proof bodies are unchanged.
> 
> In `ch13_parent_hamiltonian_bnt_consequences.tex`, **closure-property** wording at the periodic boundary is replaced with **block-diagonal boundary-condition comparison in the periodic ring** in the section intro, Theorem `block_diagonal_ground_space_intersection`, and Theorem `parent_ground_space_le_bnt_span` (hypothesis and proof). The proof clarifies that length hypotheses alone do not imply that comparison—it requires comparing block-diagonal boundary conditions across windows at the periodic cut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6f0111bee2e4985b447a0137b4059b36bf7a66b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->