### PR TITLE
feat(MPS/CanonicalForm/CyclicSectors): expose cyclic-sector letter identity

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors/CommutingProj.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/CommutingProj.lean
@@ -14,6 +14,7 @@ orthogonal projections.
 
 ## Main declarations
 
+* `exists_blockDecomp_of_commuting_projections_with_letter`
 * `exists_blockDecomp_of_commuting_projections`
 
 ## References
@@ -34,13 +35,92 @@ variable {m : ℕ}
 
 /-- If a left-canonical tensor commutes with a family of orthogonal projections summing to `1`,
 then it decomposes into compressed sectors whose direct-sum tensor is `SameMPV₂`-equivalent to the
-original tensor.
+original tensor. The compression isomorphism also sends each compressed sector
+letter to the corresponding ambient corner `P k * A i * P k`.
 
 Exposes per-sector compression linear equivalences
 `φ k : M_{dim k}(ℂ) ≃ₗ[ℂ] cornerSubmodule (P k)` and the intertwining identity tying the
 compressed adjoint transfer map to the sector adjoint transfer map on the corner of `P k`.
 Returning a `LinearEquiv` lets downstream consumers transport corner-level irreducibility /
 primitivity structure across the compression. -/
+theorem exists_blockDecomp_of_commuting_projections_with_letter
+    (A : MPSTensor d D)
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hComm : ∀ k : Fin m, ∀ i : Fin d, P k * A i = A i * P k) :
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k))
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+      (∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) ∧
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
+      (∀ k (N : ℕ) (σ : Fin N → Fin d),
+        mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := d) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := d) (D := D)
+            (fun i => (P k * A i)ᴴ) ((φ k X).1)) ∧
+      (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ) ∧
+      (∀ k (i : Fin d), (φ k (blocks k i)).1 = P k * A i * P k) := by
+  -- For each k, sector tensor P_k * A_i is P_k-supported
+  have hSectorSupp : ∀ k i, P k * (P k * A i) * P k = P k * A i := by
+    intro k i
+    rw [← Matrix.mul_assoc (P k) (P k) _, (hPproj k).2,
+      hComm k i, Matrix.mul_assoc, (hPproj k).2]
+  -- TP condition for each sector
+  have hSectorTP : ∀ k, ∑ i : Fin d, (P k * A i)ᴴ * (P k * A i) = P k := by
+    intro k
+    have hterm : ∀ i, (P k * A i)ᴴ * (P k * A i) = (A i)ᴴ * A i * P k := by
+      intro i
+      rw [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+      rw [← Matrix.mul_assoc (P k)ᴴ (P k) (A i), (hPproj k).1.eq, (hPproj k).2]
+      rw [hComm k i, ← Matrix.mul_assoc]
+    simp_rw [hterm, ← Finset.sum_mul, hLeft, Matrix.one_mul]
+  -- Apply compression to each sector
+  choose dim blocks φ hDim hTPblocks hMPVblocks hIntertwine hMul hStar hLetterRaw using fun k =>
+    exists_compressedTensor_of_supported_projection_with_letter
+      (fun i => P k * A i) (P k) (hPproj k) (hSectorSupp k) (hSectorTP k)
+  -- Per-sector trace relation: mpv(blocks k) σ = tr(P_k · evalWord A σ)
+  have hSectorTrace : ∀ k (N : ℕ) (σ : Fin N → Fin d),
+      mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace := by
+    intro k N σ
+    rw [hMPVblocks k N σ]
+    congr 1
+    exact left_mul_evalWord_leftSectorTensor_of_commutes (P k) A (hPproj k).2 (hComm k) _
+  have hLetter : ∀ k (i : Fin d), (φ k (blocks k i)).1 = P k * A i * P k := by
+    intro k i
+    calc
+      (φ k (blocks k i)).1 = P k * A i := hLetterRaw k i
+      _ = P k * A i * P k := by
+          calc
+            P k * A i = A i * P k := hComm k i
+            _ = A i * (P k * P k) := by rw [(hPproj k).2]
+            _ = (A i * P k) * P k := by rw [Matrix.mul_assoc]
+            _ = (P k * A i) * P k := by rw [← hComm k i]
+  refine ⟨dim, blocks, φ, hTPblocks, ?_, hSectorTrace, hIntertwine, hMul, hStar, hLetter⟩
+  -- SameMPV₂ follows from summing per-sector traces over the projection partition
+  intro N σ
+  rw [mpv_toTensorFromBlocks_eq_sum]; simp only [one_pow, one_smul]
+  simp only [mpv, coeff]
+  conv_lhs => rw [show evalWord A (List.ofFn σ) = 1 * evalWord A (List.ofFn σ) from by
+    rw [Matrix.one_mul]]
+  rw [show (1 : MatrixAlg D) = ∑ k : Fin m, P k from hPsum.symm]
+  rw [Finset.sum_mul, Matrix.trace_sum]
+  congr 1; ext k
+  exact (hSectorTrace k N σ).symm
+
+/-- If a left-canonical tensor commutes with a family of orthogonal projections summing to `1`,
+then it decomposes into compressed sectors whose direct-sum tensor is `SameMPV₂`-equivalent to the
+original tensor.
+
+This is the projection of
+`exists_blockDecomp_of_commuting_projections_with_letter` that forgets the
+letter-expansion identity. -/
 theorem exists_blockDecomp_of_commuting_projections
     (A : MPSTensor d D)
     (P : Fin m → MatrixAlg D)
@@ -64,42 +144,9 @@ theorem exists_blockDecomp_of_commuting_projections
         (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
       (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
         (φ k Xᴴ).1 = ((φ k X).1)ᴴ) := by
-  -- For each k, sector tensor P_k * A_i is P_k-supported
-  have hSectorSupp : ∀ k i, P k * (P k * A i) * P k = P k * A i := by
-    intro k i
-    rw [← Matrix.mul_assoc (P k) (P k) _, (hPproj k).2,
-      hComm k i, Matrix.mul_assoc, (hPproj k).2]
-  -- TP condition for each sector
-  have hSectorTP : ∀ k, ∑ i : Fin d, (P k * A i)ᴴ * (P k * A i) = P k := by
-    intro k
-    have hterm : ∀ i, (P k * A i)ᴴ * (P k * A i) = (A i)ᴴ * A i * P k := by
-      intro i
-      rw [Matrix.conjTranspose_mul, Matrix.mul_assoc]
-      rw [← Matrix.mul_assoc (P k)ᴴ (P k) (A i), (hPproj k).1.eq, (hPproj k).2]
-      rw [hComm k i, ← Matrix.mul_assoc]
-    simp_rw [hterm, ← Finset.sum_mul, hLeft, Matrix.one_mul]
-  -- Apply compression to each sector
-  choose dim blocks φ hDim hTPblocks hMPVblocks hIntertwine hMul hStar using fun k =>
-    exists_compressedTensor_of_supported_projection
-      (fun i => P k * A i) (P k) (hPproj k) (hSectorSupp k) (hSectorTP k)
-  -- Per-sector trace relation: mpv(blocks k) σ = tr(P_k · evalWord A σ)
-  have hSectorTrace : ∀ k (N : ℕ) (σ : Fin N → Fin d),
-      mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace := by
-    intro k N σ
-    rw [hMPVblocks k N σ]
-    congr 1
-    exact left_mul_evalWord_leftSectorTensor_of_commutes (P k) A (hPproj k).2 (hComm k) _
-  refine ⟨dim, blocks, φ, hTPblocks, ?_, hSectorTrace, hIntertwine, hMul, hStar⟩
-  -- SameMPV₂ follows from summing per-sector traces over the projection partition
-  intro N σ
-  rw [mpv_toTensorFromBlocks_eq_sum]; simp only [one_pow, one_smul]
-  simp only [mpv, coeff]
-  conv_lhs => rw [show evalWord A (List.ofFn σ) = 1 * evalWord A (List.ofFn σ) from by
-    rw [Matrix.one_mul]]
-  rw [show (1 : MatrixAlg D) = ∑ k : Fin m, P k from hPsum.symm]
-  rw [Finset.sum_mul, Matrix.trace_sum]
-  congr 1; ext k
-  exact (hSectorTrace k N σ).symm
+  obtain ⟨dim, blocks, φ, hLC, hMPV, hTrace, hIntertwine, hMul, hStar, _hLetter⟩ :=
+    exists_blockDecomp_of_commuting_projections_with_letter A P hPproj hPsum hLeft hComm
+  exact ⟨dim, blocks, φ, hLC, hMPV, hTrace, hIntertwine, hMul, hStar⟩
 
 end CommutingProjectionDecomposition
 

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/CommutingProj.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/CommutingProj.lean
@@ -36,7 +36,7 @@ variable {m : ℕ}
 /-- If a left-canonical tensor commutes with a family of orthogonal projections summing to `1`,
 then it decomposes into compressed sectors whose direct-sum tensor is `SameMPV₂`-equivalent to the
 original tensor. The compression isomorphism also sends each compressed sector
-letter to the corresponding ambient corner `P k * A i * P k`.
+letter to the corresponding ambient corner \(P_k A_i P_k\).
 
 Exposes per-sector compression linear equivalences
 `φ k : M_{dim k}(ℂ) ≃ₗ[ℂ] cornerSubmodule (P k)` and the intertwining identity tying the

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -26,6 +26,7 @@ multiplicative, and star-preserving identities.
 
 ## Main declarations
 
+* `exists_compressedTensor_of_supported_projection_with_letter`
 * `exists_compressedTensor_of_supported_projection`
 
 ## References
@@ -80,6 +81,8 @@ private lemma evalWord_conj_unitary
 
 /-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
 space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.
+Moreover, the compression equivalence sends each compressed letter back to the
+ambient supported letter.
 
 Exposes the **compression linear equivalence** `φ : M_n(ℂ) ≃ₗ[ℂ] cornerSubmodule P`
 together with the **intertwining identity**
@@ -89,7 +92,7 @@ as a `LinearEquiv` lets downstream callers transport the corner restriction of t
 transfer map into the compressed matrix algebra (and transport corner-level irreducibility
 back via conjugation).  The linear map is an isometry for the canonical inner products; the
 isometry property is witnessed separately where needed. -/
-theorem exists_compressedTensor_of_supported_projection
+theorem exists_compressedTensor_of_supported_projection_with_letter
     (A : MPSTensor d D) (P : MatrixAlg D)
     (hP : IsOrthogonalProjection P)
     (hSupp : ∀ i : Fin d, P * A i * P = A i)
@@ -105,7 +108,8 @@ theorem exists_compressedTensor_of_supported_projection
           transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1)) ∧
       (∀ X Y : Matrix (Fin n) (Fin n) ℂ,
         (φ (X * Y)).1 = (φ X).1 * (φ Y).1) ∧
-      (∀ X : Matrix (Fin n) (Fin n) ℂ, (φ Xᴴ).1 = ((φ X).1)ᴴ) := by
+      (∀ X : Matrix (Fin n) (Fin n) ℂ, (φ Xᴴ).1 = ((φ X).1)ᴴ) ∧
+      (∀ i : Fin d, (φ (C i)).1 = A i) := by
   classical
   -- Spectral diagonalization of P
   let hHerm : P.IsHermitian := hP.1
@@ -275,7 +279,7 @@ theorem exists_compressedTensor_of_supported_projection
   let cornerEmbed : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P :=
     cornerCompressionLinearEquiv (P := P) (Pdiag := Pdiag) Umat eST eS P0 hP0_def
       hP_decomp hPdiag_UPU hPdiag_std_lin hPdiag_back hU'U hUU
-  refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  refine ⟨n, C, cornerEmbed, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   -- (1) Trace identity: n = tr P
   · exact htrace
   -- (2) TP condition: ∑ C_i† C_i = 1
@@ -577,6 +581,64 @@ theorem exists_compressedTensor_of_supported_projection
   · intro X
     change expand Xᴴ = (expand X)ᴴ
     exact (cornerCompressionExpand_conjTranspose Umat eST eS X).symm
+  -- (7) Letter expansion: φ(C_i) is the original supported ambient letter.
+  · intro i
+    change expand (C i) = A i
+    have hExM_C : Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i) = B11 i := by
+      change Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm
+        (Matrix.reindexLinearEquiv ℂ ℂ eS eS (B11 i)) = B11 i
+      rw [Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
+        Matrix.reindexLinearEquiv_refl_refl]
+      rfl
+    have hExST_X : Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm (X i) = B i := by
+      have hXi_eq : X i = Matrix.reindexLinearEquiv ℂ ℂ eST eST (B i) := rfl
+      rw [hXi_eq, Matrix.reindexLinearEquiv_comp_apply, Equiv.self_trans_symm,
+        Matrix.reindexLinearEquiv_refl_refl]
+      rfl
+    have hBlockBack :
+        Matrix.reindexLinearEquiv ℂ ℂ eST.symm eST.symm
+            (Matrix.fromBlocks
+              (Matrix.reindexLinearEquiv ℂ ℂ eS.symm eS.symm (C i))
+              (0 : Matrix S T ℂ) (0 : Matrix T S ℂ) (0 : Matrix T T ℂ)) =
+          B i := by
+      rw [hExM_C, ← hX_block i]
+      exact hExST_X
+    have hA_i : A i = Umat * B i * Umatᴴ := by
+      change A i = Umat * (Umatᴴ * A i * Umat) * Umatᴴ
+      calc
+        A i = (Umat * Umatᴴ) * A i * (Umat * Umatᴴ) := by rw [hUU]; simp
+        _ = Umat * (Umatᴴ * A i * Umat) * Umatᴴ := by simp [Matrix.mul_assoc]
+    calc
+      expand (C i) = Umat * B i * Umatᴴ := by
+        rw [hexpand_def, hBlockBack]
+      _ = A i := hA_i.symm
+
+/-- Compress a tensor supported on an orthogonal projection to the corresponding sector bond
+space.  The compressed tensor has the same sector MPVs and inherits the left-canonical equation.
+
+This is the projection of
+`exists_compressedTensor_of_supported_projection_with_letter` that forgets the
+letter-expansion identity. -/
+theorem exists_compressedTensor_of_supported_projection
+    (A : MPSTensor d D) (P : MatrixAlg D)
+    (hP : IsOrthogonalProjection P)
+    (hSupp : ∀ i : Fin d, P * A i * P = A i)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = P) :
+    ∃ (n : ℕ) (C : MPSTensor d n)
+      (φ : Matrix (Fin n) (Fin n) ℂ ≃ₗ[ℂ] cornerSubmodule P),
+      ((n : ℂ) = Matrix.trace P) ∧
+      (∑ i : Fin d, (C i)ᴴ * C i = 1) ∧
+      (∀ (N : ℕ) (σ : Fin N → Fin d),
+        mpv C σ = Matrix.trace (P * evalWord A (List.ofFn σ))) ∧
+      (∀ X : Matrix (Fin n) (Fin n) ℂ,
+        (φ (transferMap (d := d) (D := n) (fun i => (C i)ᴴ) X)).1 =
+          transferMap (d := d) (D := D) (fun i => (A i)ᴴ) ((φ X).1)) ∧
+      (∀ X Y : Matrix (Fin n) (Fin n) ℂ,
+        (φ (X * Y)).1 = (φ X).1 * (φ Y).1) ∧
+      (∀ X : Matrix (Fin n) (Fin n) ℂ, (φ Xᴴ).1 = ((φ X).1)ᴴ) := by
+  obtain ⟨n, C, φ, hdim, hCtp, hCmpv, hIntertwine, hMul, hStar, _hLetter⟩ :=
+    exists_compressedTensor_of_supported_projection_with_letter A P hP hSupp hTP
+  exact ⟨n, C, φ, hdim, hCtp, hCmpv, hIntertwine, hMul, hStar⟩
 
 end Compression
 

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
@@ -14,6 +14,7 @@ projections fixed by the adjoint transfer map.
 
 * `commutes_letters_of_adjoint_fixed_projection`
 * `exists_blockDecomp_of_adjoint_fixed_projections`
+* `exists_blockDecomp_of_adjoint_fixed_projections_with_letter`
 * `offDiag_shift_of_adjoint_cyclic_shift`
 * `eq_sum_offDiag_of_adjoint_cyclic_shift`
 * `offDiag_shift_evalWord_of_adjoint_cyclic_shift`

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
@@ -91,6 +91,42 @@ theorem exists_blockDecomp_of_adjoint_fixed_projections
         (A := A) hLeft (hP := hPproj k) (hFix := hFix k) i
   exact exists_blockDecomp_of_commuting_projections A P hPproj hPsum hLeft hComm
 
+/-- Adjoint-fixed projections give compressed blocks, and the compression maps
+send each compressed letter to the corresponding ambient corner.
+
+This is the letter-level refinement of
+`exists_blockDecomp_of_adjoint_fixed_projections`. -/
+theorem exists_blockDecomp_of_adjoint_fixed_projections_with_letter
+    {m : ℕ}
+    (A : MPSTensor d D)
+    (P : Fin m → MatrixAlg D)
+    (hPproj : ∀ k : Fin m, IsOrthogonalProjection (P k))
+    (hPsum : ∑ k : Fin m, P k = 1)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hFix : ∀ k : Fin m, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P k) = P k) :
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor d (dim k))
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+      (∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1) ∧
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin m => (1 : ℂ)) blocks) ∧
+      (∀ k (N : ℕ) (σ : Fin N → Fin d),
+        mpv (blocks k) σ = (P k * evalWord A (List.ofFn σ)).trace) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := d) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := d) (D := D)
+            (fun i => (P k * A i)ᴴ) ((φ k X).1)) ∧
+      (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ) ∧
+      (∀ k (i : Fin d), (φ k (blocks k i)).1 = P k * A i * P k) := by
+  have hComm : ∀ k : Fin m, ∀ i : Fin d, P k * A i = A i * P k := by
+    intro k i
+    exact commutes_letters_of_adjoint_fixed_projection
+        (A := A) hLeft (hP := hPproj k) (hFix := hFix k) i
+  exact exists_blockDecomp_of_commuting_projections_with_letter A P hPproj hPsum hLeft hComm
+
 end FixedAdjointProjection
 
 section CyclicShiftOffDiagonal

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
@@ -270,35 +270,6 @@ theorem exists_cyclic_sector_decomp_after_blocking_with_letter
   exact ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace, hIntertwine,
     hMul, hStar, hLetter, hNondeg⟩
 
-/-- Corner-letter identity extracted from the cyclic-sector decomposition after blocking.
-
-For the blocked cyclic sectors in arXiv:1708.00029, Appendix A, Lemma bdcf
-and eq. Cu,
-the corner isomorphism sends each compressed sector letter to the corresponding ambient
-corner of the blocked tensor. -/
-theorem exists_cyclic_sector_corner_letter_after_blocking
-    {d D m : ℕ} [NeZero D] [NeZero m]
-    (A : MPSTensor d D)
-    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hIrr : IsIrreducibleTensor A)
-    (ρ : MatrixAlg D) (hρ : ρ.PosDef)
-    (hρfix : Kraus.adjointMap (fun i : Fin d => (A i)ᴴ) ρ = ρ)
-    (hIrrMap : IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
-    {γ : ℂ} (hγprim : IsPrimitiveRoot γ m)
-    (hperiph : peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
-      Set.range (fun j : Fin m => γ ^ (j : ℕ))) :
-    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
-      (P : Fin m → MatrixAlg D)
-      (φ : (k : Fin m) →
-        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
-      ∀ k (i : Fin (blockPhysDim d m)),
-        (φ k (blocks k i)).1 = P k * (blockTensor A m) i * P k := by
-  obtain ⟨dim, blocks, P, φ, _hLC, _hMPV, _hPproj, _hPsum, _hcyclic, _hComm, _hTrace,
-    _hIntertwine, _hMul, _hStar, hLetter, _hNondeg⟩ :=
-    exists_cyclic_sector_decomp_after_blocking_with_letter
-      A hTP hIrr ρ hρ hρfix hIrrMap hγprim hperiph
-  exact ⟨dim, blocks, P, φ, hLetter⟩
-
 /-- Cyclic-sector decomposition after blocking.
 
 This is the projection of

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
@@ -270,6 +270,34 @@ theorem exists_cyclic_sector_decomp_after_blocking_with_letter
   exact ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace, hIntertwine,
     hMul, hStar, hLetter, hNondeg⟩
 
+/-- Corner-letter identity extracted from the cyclic-sector decomposition after blocking.
+
+For the blocked cyclic sectors in arXiv:1708.00029, Appendix A, eqs. `Cu` and `Auprop`,
+the corner isomorphism sends each compressed sector letter to the corresponding ambient
+corner of the blocked tensor. -/
+theorem exists_cyclic_sector_corner_letter_after_blocking
+    {d D m : ℕ} [NeZero D] [NeZero m]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A)
+    (ρ : MatrixAlg D) (hρ : ρ.PosDef)
+    (hρfix : Kraus.adjointMap (fun i : Fin d => (A i)ᴴ) ρ = ρ)
+    (hIrrMap : IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
+    {γ : ℂ} (hγprim : IsPrimitiveRoot γ m)
+    (hperiph : peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+      Set.range (fun j : Fin m => γ ^ (j : ℕ))) :
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+      (P : Fin m → MatrixAlg D)
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+      ∀ k (i : Fin (blockPhysDim d m)),
+        (φ k (blocks k i)).1 = P k * (blockTensor A m) i * P k := by
+  obtain ⟨dim, blocks, P, φ, _hLC, _hMPV, _hPproj, _hPsum, _hcyclic, _hComm, _hTrace,
+    _hIntertwine, _hMul, _hStar, hLetter, _hNondeg⟩ :=
+    exists_cyclic_sector_decomp_after_blocking_with_letter
+      A hTP hIrr ρ hρ hρfix hIrrMap hγprim hperiph
+  exact ⟨dim, blocks, P, φ, hLetter⟩
+
 /-- Cyclic-sector decomposition after blocking.
 
 This is the projection of

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
@@ -153,9 +153,11 @@ spectral projections. Returns:
 - cyclic shift: `transferMap (fun i => (A i)ᴴ) (P (k+1)) = P k`,
 - commutation: each `P k` commutes with every blocked letter,
 - trace relation: `mpv (blocks k) σ = (P k * evalWord (blockTensor A m) σ).trace`,
+- letter expansion: `φ k (blocks k i)` is the ambient corner
+  `P k * (blockTensor A m) i * P k`,
 - MPV equivalence: the direct-sum tensor is `SameMPV₂`-equivalent to the blocked tensor,
 - nondegeneracy: every sector dimension is positive (`∀ k, dim k ≠ 0`). -/
-theorem exists_cyclic_sector_decomp_after_blocking
+theorem exists_cyclic_sector_decomp_after_blocking_with_letter
     {d D m : ℕ} [NeZero D] [NeZero m]
     (A : MPSTensor d D)
     (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
@@ -188,6 +190,8 @@ theorem exists_cyclic_sector_decomp_after_blocking
         (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
       (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
         (φ k Xᴴ).1 = ((φ k X).1)ᴴ) ∧
+      (∀ k (i : Fin (blockPhysDim d m)),
+        (φ k (blocks k i)).1 = P k * (blockTensor A m) i * P k) ∧
       (∀ k, dim k ≠ 0) := by
   -- Step 1: Get cyclic decomposition data
   let K : Fin d → MatrixAlg D := fun i => (A i)ᴴ
@@ -212,9 +216,10 @@ theorem exists_cyclic_sector_decomp_after_blocking
       (blockTensor A m i)ᴴ * blockTensor A m i = 1 :=
     leftCanonical_blockTensor (d := d) (D := D) (A := A) (L := m) hTP
   -- Step 5: Apply the CyclicSectors decomposition
-  obtain ⟨dim, blocks, φ, hLC, hMPV_hTrace⟩ := exists_blockDecomp_of_adjoint_fixed_projections
+  obtain ⟨dim, blocks, φ, hLC, hMPV_hTrace⟩ :=
+    exists_blockDecomp_of_adjoint_fixed_projections_with_letter
     (blockTensor A m) P hPproj hPsum hTP_blocked hFix
-  obtain ⟨hMPV, hTrace, hIntertwine, hMul, hStar⟩ := hMPV_hTrace
+  obtain ⟨hMPV, hTrace, hIntertwine, hMul, hStar, hLetter⟩ := hMPV_hTrace
   -- Step 6: Derive commutation from the adjoint fix property
   have hComm : ∀ k (i : Fin (blockPhysDim d m)),
       P k * (blockTensor A m) i = (blockTensor A m) i * P k := by
@@ -263,7 +268,53 @@ theorem exists_cyclic_sector_decomp_after_blocking
       rw [← h0, Matrix.trace_one, Fintype.card_fin, hk, Nat.cast_zero]
     exact (isOrthogonalProjection_posSemidef (hPproj k)).trace_eq_zero_iff.mp htrace_zero
   exact ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace, hIntertwine,
-    hMul, hStar, hNondeg⟩
+    hMul, hStar, hLetter, hNondeg⟩
+
+/-- Cyclic-sector decomposition after blocking.
+
+This is the projection of
+`exists_cyclic_sector_decomp_after_blocking_with_letter` that forgets the
+letter-expansion identity. -/
+theorem exists_cyclic_sector_decomp_after_blocking
+    {d D m : ℕ} [NeZero D] [NeZero m]
+    (A : MPSTensor d D)
+    (hTP : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hIrr : IsIrreducibleTensor A)
+    (ρ : MatrixAlg D) (hρ : ρ.PosDef)
+    (hρfix : Kraus.adjointMap (fun i : Fin d => (A i)ᴴ) ρ = ρ)
+    (hIrrMap : IsIrreducibleMap (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)))
+    {γ : ℂ} (hγprim : IsPrimitiveRoot γ m)
+    (hperiph : peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+      Set.range (fun j : Fin m => γ ^ (j : ℕ))) :
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+      (P : Fin m → MatrixAlg D)
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+      (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
+      SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) ∧
+      (∀ k, IsOrthogonalProjection (P k)) ∧
+      (∑ k : Fin m, P k = 1) ∧
+      (∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) ∧
+      (∀ k (i : Fin (blockPhysDim d m)),
+        P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
+      (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+        mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := blockPhysDim d m) (D := D)
+            (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1)) ∧
+      (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ) ∧
+      (∀ k, dim k ≠ 0) := by
+  obtain ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace,
+    hIntertwine, hMul, hStar, _hLetter, hNondeg⟩ :=
+    exists_cyclic_sector_decomp_after_blocking_with_letter
+      A hTP hIrr ρ hρ hρfix hIrrMap hγprim hperiph
+  exact ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hcyclic, hComm, hTrace,
+    hIntertwine, hMul, hStar, hNondeg⟩
 
 end CyclicSectorRelation
 

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
@@ -272,8 +272,8 @@ theorem exists_cyclic_sector_decomp_after_blocking_with_letter
 
 /-- Corner-letter identity extracted from the cyclic-sector decomposition after blocking.
 
-For the blocked cyclic sectors in arXiv:1708.00029, Appendix A, Lemma `bdcf`
-and eq. `Cu`,
+For the blocked cyclic sectors in arXiv:1708.00029, Appendix A, Lemma bdcf
+and eq. Cu,
 the corner isomorphism sends each compressed sector letter to the corresponding ambient
 corner of the blocked tensor. -/
 theorem exists_cyclic_sector_corner_letter_after_blocking

--- a/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CyclicSectorRelation.lean
@@ -272,7 +272,8 @@ theorem exists_cyclic_sector_decomp_after_blocking_with_letter
 
 /-- Corner-letter identity extracted from the cyclic-sector decomposition after blocking.
 
-For the blocked cyclic sectors in arXiv:1708.00029, Appendix A, eqs. `Cu` and `Auprop`,
+For the blocked cyclic sectors in arXiv:1708.00029, Appendix A, Lemma `bdcf`
+and eq. `Cu`,
 the corner isomorphism sends each compressed sector letter to the corresponding ambient
 corner of the blocked tensor. -/
 theorem exists_cyclic_sector_corner_letter_after_blocking

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -133,7 +133,8 @@ theorem IsCyclicSectorDecomp.eq_sum_offDiag [NeZero D] [NeZero m]
   exact ⟨P, hPproj, hPsum,
     eq_sum_offDiag_of_adjoint_cyclic_shift A hP.leftCanonical hPproj hPsum hShift i⟩
 
-private def cyclicSuccOfPos {m : ℕ} (hm : 0 < m) (k : Fin m) : Fin m :=
+/-- The successor of a cyclic index modulo a positive period. -/
+def cyclicSuccOfPos {m : ℕ} (hm : 0 < m) (k : Fin m) : Fin m :=
   ⟨(k.1 + 1) % m, Nat.mod_lt _ hm⟩
 
 /-- A periodic tensor of period `m`, after blocking by `m`, admits cyclic-sector
@@ -289,6 +290,23 @@ theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
   exact ⟨dim, blocks, hLC, hMPV,
     ⟨P, φ, hPproj, hPsum, hCyclic', hComm, hTrace, hIntertwine, hMul, hStar⟩,
     hNondeg⟩
+
+/-- Corner-letter identity extracted from the cyclic-sector decomposition of a periodic tensor.
+
+Source: arXiv:1708.00029, Appendix A, Lemma bdcf and eq. Cu. -/
+theorem exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic
+    [NeZero D] (A : MPSTensor d D) {m : ℕ}
+    (hP : IsPeriodic m A) :
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+      (P : Fin m → MatrixAlg D)
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+      ∀ k (i : Fin (blockPhysDim d m)),
+        (φ k (blocks k i)).1 = P k * (blockTensor A m) i * P k := by
+  obtain ⟨dim, blocks, P, φ, _hLC, _hMPV, _hPproj, _hPsum, _hCyclic, _hComm,
+    _hTrace, _hIntertwine, _hMul, _hStar, _hNondeg, hLetter⟩ :=
+    exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic A hP
+  exact ⟨dim, blocks, P, φ, hLetter⟩
 
 /-- Corner primitivity and irreducibility for a cyclic sector.
 

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -133,24 +133,52 @@ theorem IsCyclicSectorDecomp.eq_sum_offDiag [NeZero D] [NeZero m]
   exact ⟨P, hPproj, hPsum,
     eq_sum_offDiag_of_adjoint_cyclic_shift A hP.leftCanonical hPproj hPsum hShift i⟩
 
-/-- A periodic tensor of period `m`, after blocking by `m`, admits a cyclic
-sector decomposition.
+private def cyclicSuccOfPos {m : ℕ} (hm : 0 < m) (k : Fin m) : Fin m :=
+  ⟨(k.1 + 1) % m, Nat.mod_lt _ hm⟩
 
-Source: arXiv:1708.00029, Lemma bdcf, lines 404--423. This theorem records the
-existence of the cyclic projectors and corner blocks C_u = P_u A^{(m)}: the
-blocks are left-canonical, reproduce the blocked tensor's MPV family, satisfy
-`IsCyclicSectorDecomp`, and have nonzero bond dimensions. The normality and
-non-repetition conclusions of Lemma bdcf are stated separately below, for
-example in `sectorBlocked_isNormal_of_isPeriodic` and
+/-- A periodic tensor of period `m`, after blocking by `m`, admits cyclic-sector
+decomposition data whose compression maps send each sector letter to the
+corresponding ambient corner.
+
+Source: arXiv:1708.00029, Lemma bdcf, lines 404--423, and eq. Cu. This theorem
+records the existence of the cyclic projectors and corner blocks
+C_u = P_u A^{(m)}. The blocks are left-canonical, reproduce the blocked tensor's
+MPV family, satisfy the cyclic-sector relations, have nonzero bond dimensions,
+and obey the corner-letter identity. The normality and non-repetition
+conclusions of Lemma bdcf are stated separately below, for example in
+`sectorBlocked_isNormal_of_isPeriodic` and
 `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces`. -/
-theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
-    [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
+theorem exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic
+    [NeZero D] (A : MPSTensor d D) {m : ℕ}
     (hP : IsPeriodic m A) :
-    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+      (P : Fin m → MatrixAlg D)
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
       (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
       SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) ∧
-      IsCyclicSectorDecomp A blocks ∧
-      (∀ k, dim k ≠ 0) := by
+      (∀ k, IsOrthogonalProjection (P k)) ∧
+      (∑ k : Fin m, P k = 1) ∧
+      (∀ k,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ)
+          (P (cyclicSuccOfPos hP.period_pos k)) = P k) ∧
+      (∀ k (i : Fin (blockPhysDim d m)),
+        P k * (blockTensor A m) i = (blockTensor A m) i * P k) ∧
+      (∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+        mpv (blocks k) σ = (P k * evalWord (blockTensor A m) (List.ofFn σ)).trace) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (transferMap (d := blockPhysDim d m) (D := dim k)
+            (fun i => (blocks k i)ᴴ) X)).1 =
+          transferMap (d := blockPhysDim d m) (D := D)
+            (fun i => (P k * blockTensor A m i)ᴴ) ((φ k X).1)) ∧
+      (∀ k (X Y : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
+      (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+        (φ k Xᴴ).1 = ((φ k X).1)ᴴ) ∧
+      (∀ k, dim k ≠ 0) ∧
+      ∀ k (i : Fin (blockPhysDim d m)),
+        (φ k (blocks k i)).1 = P k * (blockTensor A m) i * P k := by
+  letI : NeZero m := ⟨Nat.ne_of_gt hP.period_pos⟩
   obtain ⟨K, h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
     conjTranspose_kraus_setup A hP.leftCanonical hP.irreducible
   obtain ⟨ω, hωprim⟩ := hP.primitiveRoot
@@ -223,102 +251,44 @@ theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
           _ = (ω ^ m) ^ (j : ℕ) := by rw [pow_mul]
           _ = 1 := by simp [hωprim.pow_eq_one]
       simpa [hperiph_roots] using hpow
-  obtain ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTraceNondeg⟩ :=
-    exists_cyclic_sector_decomp_after_blocking
+  obtain ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTrace,
+    hIntertwine, hMul, hStar, hLetter, hNondeg⟩ :=
+    exists_cyclic_sector_decomp_after_blocking_with_letter
       A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
-  obtain ⟨hTrace, hIntertwine, hMul, hStar, hNondeg⟩ := hTraceNondeg
-  exact ⟨dim, blocks, hLC, hMPV,
-    ⟨P, φ, hPproj, hPsum, hCyclic, hComm, hTrace, hIntertwine, hMul, hStar⟩, hNondeg⟩
+  have hCyclic' :
+      ∀ k,
+        transferMap (d := d) (D := D) (fun i => (A i)ᴴ)
+          (P (cyclicSuccOfPos hP.period_pos k)) = P k := by
+    intro k
+    simpa [cyclicSuccOfPos, Fin.add_def] using hCyclic k
+  exact ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hCyclic', hComm, hTrace,
+    hIntertwine, hMul, hStar, hNondeg, hLetter⟩
 
-/-- A periodic tensor of period `m`, after blocking by `m`, admits cyclic-sector
-data whose compression maps send each sector letter to the corresponding
-ambient corner.
+/-- A periodic tensor of period `m`, after blocking by `m`, admits a cyclic
+sector decomposition.
 
-Source: arXiv:1708.00029, Appendix A, Lemma `bdcf` and eq. `Cu`. -/
-theorem exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic
+Source: arXiv:1708.00029, Lemma bdcf, lines 404--423. This theorem is the
+projection of
+`exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic` that
+forgets the explicit corner-letter identity. -/
+theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A) :
-    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
-      (P : Fin m → MatrixAlg D)
-      (φ : (k : Fin m) →
-        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
-      ∀ k (i : Fin (blockPhysDim d m)),
-        (φ k (blocks k i)).1 = P k * (blockTensor A m) i * P k := by
-  obtain ⟨_K, _h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
-    conjTranspose_kraus_setup A hP.leftCanonical hP.irreducible
-  obtain ⟨ω, hωprim⟩ := hP.primitiveRoot
-  have hM : (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := Matrix.PosDef.one
-  letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixNormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM
-  letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixSeminormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM.posSemidef
-  letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
-    Matrix.toMatrixInnerProductSpace (n := Fin D) (𝕜 := ℂ) 1 hM.posSemidef
-  have hAdj :
-      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) =
-        (transferMap (d := d) (D := D) A).adjoint := by
-    simpa using transferMap_conjTranspose_eq_adjoint (d := d) (D := D) (A := A)
-  have hperiph_roots :
-      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
-        {μ : ℂ | μ ^ m = 1} := by
-    ext μ
-    constructor
-    · intro hμ
-      have hEigAdj :
-          Module.End.HasEigenvalue ((transferMap (d := d) (D := D) A).adjoint) μ := by
-        simpa [hAdj] using hμ.1
-      have hEig :
-          Module.End.HasEigenvalue (transferMap (d := d) (D := D) A) (star μ) :=
-        (Module.End.hasEigenvalue_adjoint_iff
-          (E := transferMap (d := d) (D := D) A) (μ := star μ)).2 <| by
-            simpa [star_star] using hEigAdj
-      have hNorm : ‖star μ‖ = 1 := by
-        simpa [norm_star] using hμ.2
-      have hStarMem :
-          star μ ∈ peripheralEigenvalues (transferMap (d := d) (D := D) A) :=
-        ⟨hEig, hNorm⟩
-      have hpowStar : (star μ) ^ m = 1 := by
-        simpa [hP.peripheral_eq] using hStarMem
-      have hpow : μ ^ m = 1 := by
-        have := congrArg star hpowStar
-        simpa using this
-      exact hpow
-    · intro hμ
-      have hpowStar : (star μ) ^ m = 1 := by
-        have := congrArg star hμ
-        simpa using this
-      have hStarMem :
-          star μ ∈ peripheralEigenvalues (transferMap (d := d) (D := D) A) := by
-        simpa [hP.peripheral_eq] using hpowStar
-      have hEigAdj :
-          Module.End.HasEigenvalue ((transferMap (d := d) (D := D) A).adjoint) μ := by
-          simpa [star_star] using
-            (Module.End.hasEigenvalue_adjoint_iff
-              (E := transferMap (d := d) (D := D) A) (μ := star μ)).1 hStarMem.1
-      have hNorm : ‖μ‖ = 1 := by
-        simpa [norm_star] using hStarMem.2
-      exact ⟨by simpa [hAdj] using hEigAdj, hNorm⟩
-  have hperiph_range :
-      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
-        Set.range (fun j : Fin m => ω ^ (j : ℕ)) := by
-    ext μ
-    constructor
-    · intro hμ
-      have hpow : μ ^ m = 1 := by
-        simpa [hperiph_roots] using hμ
-      obtain ⟨i, hi, hωi⟩ := hωprim.eq_pow_of_pow_eq_one hpow
-      exact ⟨⟨i, hi⟩, by simpa using hωi⟩
-    · rintro ⟨j, rfl⟩
-      have hpow : (ω ^ (j : ℕ)) ^ m = 1 := by
-        calc
-          (ω ^ (j : ℕ)) ^ m = ω ^ ((j : ℕ) * m) := by rw [pow_mul]
-          _ = ω ^ (m * (j : ℕ)) := by rw [Nat.mul_comm]
-          _ = (ω ^ m) ^ (j : ℕ) := by rw [pow_mul]
-          _ = 1 := by simp [hωprim.pow_eq_one]
-      simpa [hperiph_roots] using hpow
-  exact exists_cyclic_sector_corner_letter_after_blocking
-    A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
-
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)),
+      (∀ k, ∑ i : Fin (blockPhysDim d m), (blocks k i)ᴴ * blocks k i = 1) ∧
+      SameMPV₂ (blockTensor A m) (toTensorFromBlocks (μ := fun _ => 1) blocks) ∧
+      IsCyclicSectorDecomp A blocks ∧
+      (∀ k, dim k ≠ 0) := by
+  obtain ⟨dim, blocks, P, φ, hLC, hMPV, hPproj, hPsum, hCyclic, hComm, hTrace,
+    hIntertwine, hMul, hStar, hNondeg, _hLetter⟩ :=
+    exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic A hP
+  have hCyclic' :
+      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k := by
+    intro k
+    simpa [cyclicSuccOfPos, Fin.add_def] using hCyclic k
+  exact ⟨dim, blocks, hLC, hMPV,
+    ⟨P, φ, hPproj, hPsum, hCyclic', hComm, hTrace, hIntertwine, hMul, hStar⟩,
+    hNondeg⟩
 
 /-- Corner primitivity and irreducibility for a cyclic sector.
 

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -230,6 +230,95 @@ theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
   exact ⟨dim, blocks, hLC, hMPV,
     ⟨P, φ, hPproj, hPsum, hCyclic, hComm, hTrace, hIntertwine, hMul, hStar⟩, hNondeg⟩
 
+/-- A periodic tensor of period `m`, after blocking by `m`, admits cyclic-sector
+data whose compression maps send each sector letter to the corresponding
+ambient corner.
+
+Source: arXiv:1708.00029, Appendix A, eqs. `Cu` and `Auprop`. -/
+theorem exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic
+    [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
+    (hP : IsPeriodic m A) :
+    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+      (P : Fin m → MatrixAlg D)
+      (φ : (k : Fin m) →
+        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+      ∀ k (i : Fin (blockPhysDim d m)),
+        (φ k (blocks k i)).1 = P k * (blockTensor A m) i * P k := by
+  obtain ⟨_K, _h_unitalK, hIrrK, ρ, hρ_pd, h_adjfix, rfl⟩ :=
+    conjTranspose_kraus_setup A hP.leftCanonical hP.irreducible
+  obtain ⟨ω, hωprim⟩ := hP.primitiveRoot
+  have hM : (1 : Matrix (Fin D) (Fin D) ℂ).PosDef := Matrix.PosDef.one
+  letI : NormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixNormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM
+  letI : SeminormedAddCommGroup (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixSeminormedAddCommGroup (n := Fin D) (𝕜 := ℂ) 1 hM.posSemidef
+  letI : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+    Matrix.toMatrixInnerProductSpace (n := Fin D) (𝕜 := ℂ) 1 hM.posSemidef
+  have hAdj :
+      transferMap (d := d) (D := D) (fun i => (A i)ᴴ) =
+        (transferMap (d := d) (D := D) A).adjoint := by
+    simpa using transferMap_conjTranspose_eq_adjoint (d := d) (D := D) (A := A)
+  have hperiph_roots :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        {μ : ℂ | μ ^ m = 1} := by
+    ext μ
+    constructor
+    · intro hμ
+      have hEigAdj :
+          Module.End.HasEigenvalue ((transferMap (d := d) (D := D) A).adjoint) μ := by
+        simpa [hAdj] using hμ.1
+      have hEig :
+          Module.End.HasEigenvalue (transferMap (d := d) (D := D) A) (star μ) :=
+        (Module.End.hasEigenvalue_adjoint_iff
+          (E := transferMap (d := d) (D := D) A) (μ := star μ)).2 <| by
+            simpa [star_star] using hEigAdj
+      have hNorm : ‖star μ‖ = 1 := by
+        simpa [norm_star] using hμ.2
+      have hStarMem :
+          star μ ∈ peripheralEigenvalues (transferMap (d := d) (D := D) A) :=
+        ⟨hEig, hNorm⟩
+      have hpowStar : (star μ) ^ m = 1 := by
+        simpa [hP.peripheral_eq] using hStarMem
+      have hpow : μ ^ m = 1 := by
+        have := congrArg star hpowStar
+        simpa using this
+      exact hpow
+    · intro hμ
+      have hpowStar : (star μ) ^ m = 1 := by
+        have := congrArg star hμ
+        simpa using this
+      have hStarMem :
+          star μ ∈ peripheralEigenvalues (transferMap (d := d) (D := D) A) := by
+        simpa [hP.peripheral_eq] using hpowStar
+      have hEigAdj :
+          Module.End.HasEigenvalue ((transferMap (d := d) (D := D) A).adjoint) μ := by
+          simpa [star_star] using
+            (Module.End.hasEigenvalue_adjoint_iff
+              (E := transferMap (d := d) (D := D) A) (μ := star μ)).1 hStarMem.1
+      have hNorm : ‖μ‖ = 1 := by
+        simpa [norm_star] using hStarMem.2
+      exact ⟨by simpa [hAdj] using hEigAdj, hNorm⟩
+  have hperiph_range :
+      peripheralEigenvalues (transferMap (d := d) (D := D) (fun i => (A i)ᴴ)) =
+        Set.range (fun j : Fin m => ω ^ (j : ℕ)) := by
+    ext μ
+    constructor
+    · intro hμ
+      have hpow : μ ^ m = 1 := by
+        simpa [hperiph_roots] using hμ
+      obtain ⟨i, hi, hωi⟩ := hωprim.eq_pow_of_pow_eq_one hpow
+      exact ⟨⟨i, hi⟩, by simpa using hωi⟩
+    · rintro ⟨j, rfl⟩
+      have hpow : (ω ^ (j : ℕ)) ^ m = 1 := by
+        calc
+          (ω ^ (j : ℕ)) ^ m = ω ^ ((j : ℕ) * m) := by rw [pow_mul]
+          _ = ω ^ (m * (j : ℕ)) := by rw [Nat.mul_comm]
+          _ = (ω ^ m) ^ (j : ℕ) := by rw [pow_mul]
+          _ = 1 := by simp [hωprim.pow_eq_one]
+      simpa [hperiph_roots] using hpow
+  exact exists_cyclic_sector_corner_letter_after_blocking
+    A hP.leftCanonical hP.irreducible ρ hρ_pd h_adjfix hIrrK hωprim hperiph_range
+
 
 /-- Corner primitivity and irreducibility for a cyclic sector.
 

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -741,13 +741,13 @@ private lemma not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces
   -- by the compressed-primitivity scaling argument of
   -- `period_eq_of_gaugePhaseEquiv_of_isPeriodic` (Case1.lean), giving
   -- `(transferMap A) ^ m U = ζ⁻¹ • U` with `‖ζ⁻¹‖ = 1`.  This is the genuinely
-  -- missing piece: `IsCyclicSectorDecomp` exposes only the transfer-map / trace
-  -- intertwiners and a `φ`-multiplicative `∗`-isomorphism onto `cornerSubmodule (P k)`,
-  -- not the *letter-level* corner correspondence
+  -- missing piece: the local hypotheses of this contradiction lemma do not yet
+  -- carry the *letter-level* corner correspondence
   -- `φ_u (blocks u i) = P u * (blockTensor A m) i * P u`
   -- needed to turn the compressed gauge relation into the corner eigenvector
-  -- equation.  Closing it requires either strengthening `IsCyclicSectorDecomp` with
-  -- that correspondence or a transfer-map-level construction.
+  -- equation.  The constructed cyclic sectors now expose this correspondence;
+  -- closing this proof still requires threading or using it here and carrying
+  -- out the support-unitary calculation.
   obtain ⟨U, ζ, hζ, hU_ne, hSupp, hEig⟩ :
       ∃ (U : MatrixAlg D) (ζ : ℂ), ‖ζ‖ = 1 ∧ U ≠ 0 ∧ U = P u * U * P v ∧
         ((transferMap (d := d) (D := D) A) ^ m) U = ζ • U := by

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -291,23 +291,6 @@ theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
     ⟨P, φ, hPproj, hPsum, hCyclic', hComm, hTrace, hIntertwine, hMul, hStar⟩,
     hNondeg⟩
 
-/-- Corner-letter identity extracted from the cyclic-sector decomposition of a periodic tensor.
-
-Source: arXiv:1708.00029, Appendix A, Lemma bdcf and eq. Cu. -/
-theorem exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic
-    [NeZero D] (A : MPSTensor d D) {m : ℕ}
-    (hP : IsPeriodic m A) :
-    ∃ (dim : Fin m → ℕ) (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
-      (P : Fin m → MatrixAlg D)
-      (φ : (k : Fin m) →
-        Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
-      ∀ k (i : Fin (blockPhysDim d m)),
-        (φ k (blocks k i)).1 = P k * (blockTensor A m) i * P k := by
-  obtain ⟨dim, blocks, P, φ, _hLC, _hMPV, _hPproj, _hPsum, _hCyclic, _hComm,
-    _hTrace, _hIntertwine, _hMul, _hStar, _hNondeg, hLetter⟩ :=
-    exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic A hP
-  exact ⟨dim, blocks, P, φ, hLetter⟩
-
 /-- Corner primitivity and irreducibility for a cyclic sector.
 
 This isolates the channel-level input behind

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlap.lean
@@ -234,7 +234,7 @@ theorem exists_cyclic_sector_decomp_after_blocking_of_isPeriodic
 data whose compression maps send each sector letter to the corresponding
 ambient corner.
 
-Source: arXiv:1708.00029, Appendix A, eqs. `Cu` and `Auprop`. -/
+Source: arXiv:1708.00029, Appendix A, Lemma `bdcf` and eq. `Cu`. -/
 theorem exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic
     [NeZero D] (A : MPSTensor d D) {m : ℕ} [NeZero m]
     (hP : IsPeriodic m A) :

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -637,7 +637,7 @@ unconditional result.
     \uses{thm:cyclic_sector_decomp_after_blocking_periodic, def:blocked_tensor}
     Under the hypotheses of the cyclic-sector construction for the blocked
     tensor $A^{(m)}$, there are sector tensors $C_k$, projections $P_k$, and
-    corner isomorphisms
+    linear corner isomorphisms
     \[
         \varphi_k : M_{\dim C_k}(\mathbb C)
             \longrightarrow P_k M_D(\mathbb C) P_k
@@ -661,8 +661,8 @@ unconditional result.
     \[
         C_k^i=V_k^\dagger B_{kk}^iV_k,
     \]
-    where $V_k$ identifies the support with $\mathbb C^{\dim C_k}$. The corner
-    isomorphism is the inverse transport
+    where $V_k$ identifies the support with $\mathbb C^{\dim C_k}$. The linear
+    corner isomorphism is the inverse transport
     \[
         X\longmapsto
         U

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -632,7 +632,7 @@ unconditional result.
 
 \begin{lemma}[Corner image of a compressed blocked letter]
     \label{lem:cyclic_sector_compression_letter}
-    \lean{MPSTensor.exists_cyclic_sector_corner_letter_after_blocking}
+    \lean{MPSTensor.exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic}
     \leanok
     \uses{thm:cyclic_sector_decomp_after_blocking_periodic, def:blocked_tensor}
     Under the hypotheses of the cyclic-sector construction for the blocked
@@ -651,18 +651,34 @@ unconditional result.
 \end{lemma}
 
 \begin{proof}\leanok
-    The sector tensor is obtained by transporting the corner block of the
-    supported ambient letter through the compression isomorphism. If
-    $B^i=U^\dagger (A^{(m)})^i U$ is written in the basis in which $P_k$ is
-    diagonal and $B_{kk}^i$ is its $k$th corner block, then
+    Let $U$ diagonalize $P_k$, so that
     \[
-        C_k^i = V_k^\dagger B_{kk}^i V_k,
-        \qquad
-        \varphi_k(C_k^i)
-          = P_k (A^{(m)})^i P_k .
+        U^\dagger P_k U=
+        \begin{pmatrix} I & 0 \\ 0 & 0 \end{pmatrix}.
     \]
-    Thus the compressed letter is precisely the inverse image of the ambient
-    corner under~$\varphi_k$.
+    Write $B^i=U^\dagger (A^{(m)})^i U$, and let $B_{kk}^i$ be the corner block
+    on the support of $P_k$. The sector tensor is
+    \[
+        C_k^i=V_k^\dagger B_{kk}^iV_k,
+    \]
+    where $V_k$ identifies the support with $\mathbb C^{\dim C_k}$. The corner
+    isomorphism is the inverse transport
+    \[
+        X\longmapsto
+        U
+        \begin{pmatrix} V_k X V_k^\dagger & 0 \\ 0 & 0 \end{pmatrix}
+        U^\dagger .
+    \]
+    Hence
+    \[
+        \varphi_k(C_k^i)
+        =
+        U
+        \begin{pmatrix} B_{kk}^i & 0 \\ 0 & 0 \end{pmatrix}
+        U^\dagger
+        =
+        P_k (A^{(m)})^i P_k .
+    \]
 \end{proof}
 
 \begin{lemma}[One-site transport of sector overlaps]

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -630,6 +630,34 @@ unconditional result.
     Definition~\ref{def:cyclic_sector_decomp}.
 \end{proof}
 
+\begin{lemma}[Cyclic-sector compression remembers the blocked letters]
+    \label{lem:cyclic_sector_compression_letter}
+    \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking_with_letter}
+    \leanok
+    \uses{def:cyclic_sector_decomp, def:blocked_tensor}
+    In the cyclic-sector construction obtained from the spectral projections of
+    a periodic tensor, the compression isomorphism remembers the ambient
+    blocked letter. More precisely, if $P_k$ is the $k$th spectral projection,
+    $C_k$ is the corresponding compressed blocked tensor, and
+    \[
+        \varphi_k : M_{\dim C_k}(\mathbb C)
+            \longrightarrow P_k M_D(\mathbb C) P_k
+    \]
+    is the corner isomorphism, then for every blocked physical letter $i$,
+    \[
+        \varphi_k(C_k^i)=P_k (A^{(m)})^i P_k .
+    \]
+    This is the formal counterpart of the corner-letter definition in
+    \cite[eqs.~\emph{Cu}, \emph{Auprop}]{DeLasCuevas2017Irreducible}.
+\end{lemma}
+
+\begin{proof}\leanok
+    The compressed sector tensor is constructed by conjugating the corner of
+    $P_k (A^{(m)})^i P_k$ into the matrix algebra on the support of $P_k$.
+    Applying the inverse corner isomorphism therefore returns exactly the same
+    ambient corner.
+\end{proof}
+
 \begin{lemma}[One-site transport of sector overlaps]
     \label{lem:sector_overlap_succ_eq_cyclic_sector_decomp}
     \lean{MPSTensor.sectorOverlap_succ_eq_of_cyclicSectorDecomp}

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -647,7 +647,7 @@ unconditional result.
         \varphi_k(C_k^i)=P_k (A^{(m)})^i P_k .
     \]
     This is the corner-letter identity used in
-    \cite[eqs.~\emph{Cu}, \emph{Auprop}]{DeLasCuevas2017Irreducible}.
+    \cite[Lemma~\emph{bdcf}, eq.~\emph{Cu}]{DeLasCuevas2017Irreducible}.
 \end{lemma}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -632,19 +632,17 @@ unconditional result.
 
 \begin{lemma}[Corner image of a compressed blocked letter]
     \label{lem:cyclic_sector_compression_letter}
-    \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking_with_letter}
+    \lean{MPSTensor.exists_cyclic_sector_corner_letter_after_blocking}
     \leanok
-    \uses{def:cyclic_sector_decomp, def:blocked_tensor}
-    In the cyclic-sector construction obtained from the spectral projections of
-    a periodic tensor, the compression isomorphism sends each sector letter to
-    the corresponding corner of the ambient blocked letter. More precisely, if
-    $P_k$ is the $k$th spectral projection,
-    $C_k$ is the corresponding compressed blocked tensor, and
+    \uses{thm:cyclic_sector_decomp_after_blocking_periodic, def:blocked_tensor}
+    Under the hypotheses of the cyclic-sector construction for the blocked
+    tensor $A^{(m)}$, there are sector tensors $C_k$, projections $P_k$, and
+    corner isomorphisms
     \[
         \varphi_k : M_{\dim C_k}(\mathbb C)
             \longrightarrow P_k M_D(\mathbb C) P_k
     \]
-    is the corner isomorphism, then for every blocked physical letter $i$,
+    such that, for every blocked physical letter $i$,
     \[
         \varphi_k(C_k^i)=P_k (A^{(m)})^i P_k .
     \]
@@ -653,10 +651,18 @@ unconditional result.
 \end{lemma}
 
 \begin{proof}\leanok
-    The compressed sector tensor is constructed by conjugating the corner of
-    $P_k (A^{(m)})^i P_k$ into the matrix algebra on the support of $P_k$.
-    Applying the inverse corner isomorphism therefore returns exactly the same
-    ambient corner.
+    The sector tensor is obtained by transporting the corner block of the
+    supported ambient letter through the compression isomorphism. If
+    $B^i=U^\dagger (A^{(m)})^i U$ is written in the basis in which $P_k$ is
+    diagonal and $B_{kk}^i$ is its $k$th corner block, then
+    \[
+        C_k^i = V_k^\dagger B_{kk}^i V_k,
+        \qquad
+        \varphi_k(C_k^i)
+          = P_k (A^{(m)})^i P_k .
+    \]
+    Thus the compressed letter is precisely the inverse image of the ambient
+    corner under~$\varphi_k$.
 \end{proof}
 
 \begin{lemma}[One-site transport of sector overlaps]

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -630,14 +630,15 @@ unconditional result.
     Definition~\ref{def:cyclic_sector_decomp}.
 \end{proof}
 
-\begin{lemma}[Cyclic-sector compression remembers the blocked letters]
+\begin{lemma}[Corner image of a compressed blocked letter]
     \label{lem:cyclic_sector_compression_letter}
     \lean{MPSTensor.exists_cyclic_sector_decomp_after_blocking_with_letter}
     \leanok
     \uses{def:cyclic_sector_decomp, def:blocked_tensor}
     In the cyclic-sector construction obtained from the spectral projections of
-    a periodic tensor, the compression isomorphism remembers the ambient
-    blocked letter. More precisely, if $P_k$ is the $k$th spectral projection,
+    a periodic tensor, the compression isomorphism sends each sector letter to
+    the corresponding corner of the ambient blocked letter. More precisely, if
+    $P_k$ is the $k$th spectral projection,
     $C_k$ is the corresponding compressed blocked tensor, and
     \[
         \varphi_k : M_{\dim C_k}(\mathbb C)
@@ -647,7 +648,7 @@ unconditional result.
     \[
         \varphi_k(C_k^i)=P_k (A^{(m)})^i P_k .
     \]
-    This is the formal counterpart of the corner-letter definition in
+    This is the corner-letter identity used in
     \cite[eqs.~\emph{Cu}, \emph{Auprop}]{DeLasCuevas2017Irreducible}.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -630,9 +630,9 @@ unconditional result.
     Definition~\ref{def:cyclic_sector_decomp}.
 \end{proof}
 
-\begin{lemma}[Corner image of a compressed blocked letter]
-    \label{lem:cyclic_sector_compression_letter}
-    \lean{MPSTensor.exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic}
+\begin{theorem}[Cyclic-sector decomposition with compressed corner letters]
+    \label{thm:cyclic_sector_compression_letter}
+    \lean{MPSTensor.exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic}
     \leanok
     \uses{thm:cyclic_sector_decomp_after_blocking_periodic, def:blocked_tensor}
     Under the hypotheses of the cyclic-sector construction for the blocked
@@ -642,13 +642,17 @@ unconditional result.
         \varphi_k : M_{\dim C_k}(\mathbb C)
             \longrightarrow P_k M_D(\mathbb C) P_k
     \]
-    such that, for every blocked physical letter $i$,
+    whose sector tensors are left-canonical, reproduce the blocked
+    matrix-product vectors, have nonzero bond dimensions, and carry the cyclic
+    adjoint-transfer decomposition of
+    Theorem~\ref{thm:cyclic_sector_decomp_after_blocking_periodic}. In addition,
+    for every blocked physical letter $i$,
     \[
         \varphi_k(C_k^i)=P_k (A^{(m)})^i P_k .
     \]
     This is the corner-letter identity used in
     \cite[Lemma~\emph{bdcf}, eq.~\emph{Cu}]{DeLasCuevas2017Irreducible}.
-\end{lemma}
+\end{theorem}
 
 \begin{proof}\leanok
     Let $U$ diagonalize $P_k$, so that

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -172,7 +172,7 @@ defines the sector letters $A_u^i=P_uA^iP_{u+1}$.
 
 The construction of the cyclic sectors also now records the letter-level
 corner identity.\footnote{Formal declaration:
-\leanid{exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic}.} If
+\leanid{exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic}.} If
 $\varphi_u$ is the compression isomorphism from the compressed sector algebra
 onto $P_uM_DP_u$, then
 \[

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -170,6 +170,20 @@ sector decomposition. This is the inverse-indexed form of
 \emph{eq:Aoffdiag}, lines~335--339; the later \emph{eq:Auprop}, line~1014,
 defines the sector letters $A_u^i=P_uA^iP_{u+1}$.
 
+The construction of the cyclic sectors also now records the letter-level
+corner identity.\footnote{Formal declaration:
+\leanid{exists_cyclic_sector_decomp_after_blocking_with_letter}.} If
+$\varphi_u$ is the compression isomorphism from the compressed sector algebra
+onto $P_uM_DP_u$, then
+\[
+    \varphi_u(C_u^{\mathbf i})=
+        P_u (A^{(m)})^{\mathbf i} P_u .
+\]
+This is the exposed formal version of the source corner-letter definitions
+\emph{Cu} and \emph{Auprop}. It supplies the missing correspondence between a
+compressed sector gauge and the ambient corner in the Step~2 spectral route; it
+does not yet construct the resulting off-diagonal modulus-one eigenvector.
+
 Let $O_{C,D}(N):=\langle V_N(C)\mid V_N(D)\rangle$. The one-site
 sector-overlap translation is also formalized.\footnote{Formal declaration:
 \leanid{sectorOverlap_succ_eq_of_cyclicSectorDecomp}.} It proves, for every

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -172,17 +172,17 @@ defines the sector letters $A_u^i=P_uA^iP_{u+1}$.
 
 The construction of the cyclic sectors also now records the letter-level
 corner identity.\footnote{Formal declaration:
-\leanid{exists_cyclic_sector_decomp_after_blocking_with_letter}.} If
+\leanid{exists_cyclic_sector_corner_letter_after_blocking_of_isPeriodic}.} If
 $\varphi_u$ is the compression isomorphism from the compressed sector algebra
 onto $P_uM_DP_u$, then
 \[
     \varphi_u(C_u^{\mathbf i})=
         P_u (A^{(m)})^{\mathbf i} P_u .
 \]
-This is the exposed formal version of the source corner-letter definitions
-\emph{Cu} and \emph{Auprop}. It supplies the missing correspondence between a
-compressed sector gauge and the ambient corner in the Step~2 spectral route; it
-does not yet construct the resulting off-diagonal modulus-one eigenvector.
+This is the exposed formal version of the blocked corner-letter relation in
+Lemma~\emph{bdcf} and \emph{Cu}. It supplies the missing correspondence between
+a compressed sector gauge and the ambient corner in the Step~2 spectral route;
+it does not yet construct the resulting off-diagonal modulus-one eigenvector.
 
 Let $O_{C,D}(N):=\langle V_N(C)\mid V_N(D)\rangle$. The one-site
 sector-overlap translation is also formalized.\footnote{Formal declaration:


### PR DESCRIPTION
### Motivation

- Step 2 of `not_gaugePhaseEquiv_of_orthogonal_cyclicSector_traces` needs the corner-letter identity
  \[
    \varphi_k(C_k^i)=P_k(A^{(m)})^iP_k,
  \]
  for the cyclic-sector construction associated to arXiv:1708.00029, Appendix A.
- The existing sector-construction theorems produced the compressed tensors and corner isomorphisms, but did not expose this letter identity as a reusable conclusion.

### Description

- `Compression.lean`: adds `exists_compressedTensor_of_supported_projection_with_letter`, proving `(φ (C i)).1 = A i` by the spectral block expansion.
- `CommutingProj.lean`: lifts the letter identity to `P k * A i * P k` using commutation with the projection and idempotence of the projection.
- `FixedAdjoint.lean`: threads the identity through the adjoint-fixed projection construction.
- `CyclicSectorRelation.lean`: threads the identity through the blocked cyclic-sector construction.
- `SelfOverlap.lean`: exposes the `IsPeriodic` wrapper as full cyclic-sector decomposition data with the corner-letter identity, and keeps the original theorem name as the projection that forgets the additional letter conclusion.
- Chapter 22 of the blueprint and `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex` record this bridge for the Step 2 spectral route.

This prepares the Step 2 spectral route in #2393, but the off-diagonal modulus-one eigenvector is not yet constructed; the result therefore does not close #2393.

### Testing

- `lake build TNLean.MPS.Periodic.Overlap.SelfOverlap` (build succeeds with the known existing `sorry` warning at `SelfOverlap.lean:681`)
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorRelation`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

References #2393.
