### PR TITLE
feat(MPS/ParentHamiltonian): isolate boundary trace equation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -236,7 +236,7 @@ theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
   refine ⟨Y, ?_⟩
   intro α ν
   -- The available identity `hTrace α ν` probes only single letters. The open
-  -- closing step must produce length-`L₀` word probes before block injectivity
+  -- closing step must produce length-\(L_0\) word probes before block injectivity
   -- can separate the matrix difference.
   sorry
 

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -213,9 +213,10 @@ boundary-matrix commutation lemma.
 inverting-and-growing-back argument at the periodic boundary in
 arXiv:2011.12127, Section IV.C, lines 2078--2079. The trace rotation from the
 last cyclic window is formalized in
-`closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`; the
-remaining step is to promote the resulting trace identities for the probes
-\(A^j\) to the displayed matrix equation. Documented in
+`closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`; it gives
+only the single-letter trace probes \(A^j\). The remaining step is to obtain
+trace identities against length-\(L_0\) word products, which separate matrices
+by block injectivity, and hence derive the displayed matrix equation. Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in issue 2405. -/
 theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
@@ -234,11 +235,9 @@ theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
       (A := A) hL₀ hM hψX hLocal
   refine ⟨Y, ?_⟩
   intro α ν
-  have hTraceαν : ∀ j : Fin d,
-      Matrix.trace
-          (A j * (X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν))) =
-        Matrix.trace (A j * (evalWord A (List.ofFn α) * Y ν)) :=
-    fun j => hTrace α ν j
+  -- The available identity `hTrace α ν` probes only single letters. The open
+  -- closing step must produce length-`L₀` word probes before block injectivity
+  -- can separate the matrix difference.
   sorry
 
 /-- Auxiliary boundary-condition product from the left-word form of the

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -235,9 +235,9 @@ theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
       (A := A) hL₀ hM hψX hLocal
   refine ⟨Y, ?_⟩
   intro α ν
-  -- The available identity `hTrace α ν` probes only single letters. The open
-  -- closing step must produce length-\(L_0\) word probes before block injectivity
-  -- can separate the matrix difference.
+  -- The available trace identity probes only single letters. The open closing
+  -- step must produce length-\(L_0\) word probes before block injectivity can
+  -- separate the matrix difference.
   sorry
 
 /-- Auxiliary boundary-condition product from the left-word form of the

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -76,8 +76,123 @@ theorem closure_property_mirror_padded_products_of_left_word_products
     simpa [Matrix.mul_sub, sub_eq_zero] using h
   have hZ : Z = 0 :=
     eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul
-      (A := A) (L₀ := L₀) (k := L₀) (q := 1) hInj (by omega) (by omega) hzero
+      (A := A) (L₀ := L₀) (k := L₀) (q := 1) (Z := Z)
+      hInj (by omega) (by omega) hzero
   exact sub_eq_zero.mp hZ
+
+/-- Trace form of the boundary block-window equation.
+
+For \(\psi=\Gamma_{M+1}(X)\), the cyclic-window constraint at the window starting
+at the last site gives, after rotating the trace, matrices \(Y_\nu\) such that
+\[
+  \operatorname{tr}\!\left(A^j X A^\alpha A^\nu\right)
+  =
+  \operatorname{tr}\!\left(A^j A^\alpha Y_\nu\right)
+\]
+for every physical letter \(j\), every length-\(L_0\) word \(\alpha\), and every
+complementary word \(\nu\). This is the trace-rotation part of the
+periodic-boundary inverting-and-growing-back argument in arXiv:2011.12127,
+Section IV.C, lines 2078--2079. -/
+theorem closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hL₀ : 0 < L₀) (hM : L₀ < M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (hLocal : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ ∈
+        groundSpace A (L₀ + 1)) :
+    ∃ Y : (Fin (M + 1 - (L₀ + 1)) → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+      ∀ (α : Fin L₀ → Fin d) (ν : Fin (M + 1 - (L₀ + 1)) → Fin d) (j : Fin d),
+        Matrix.trace
+            (A j * (X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν))) =
+          Matrix.trace (A j * (evalWord A (List.ofFn α) * Y ν)) := by
+  classical
+  have hKpos : 0 < M + 1 - (L₀ + 1) := by omega
+  let τOfComplement :
+      (Fin (M + 1 - (L₀ + 1)) → Fin d) → Fin (M + 1) → Fin d :=
+    fun ν i =>
+      if h : L₀ ≤ i.val ∧ i.val < M then
+        ν ⟨i.val - L₀, by omega⟩
+      else
+        ν ⟨0, hKpos⟩
+  have hLocalWitness :
+      ∀ ν : Fin (M + 1 - (L₀ + 1)) → Fin d,
+        ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+          cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1)
+              (⟨M, by omega⟩ : Fin (M + 1)) (τOfComplement ν) ψ =
+            groundSpaceMap A (L₀ + 1) Y := by
+    intro ν
+    have hmem := hLocal (⟨M, by omega⟩ : Fin (M + 1)) (τOfComplement ν)
+    rw [groundSpace, LinearMap.mem_range] at hmem
+    obtain ⟨Y, hY⟩ := hmem
+    exact ⟨Y, hY.symm⟩
+  choose Y hY using hLocalWitness
+  refine ⟨Y, ?_⟩
+  intro α ν j
+  have hTrace :
+      Matrix.trace
+          (evalWord A (List.ofFn (cyclicCfg (by omega : 0 < M + 1) (L₀ + 1)
+            (⟨M, by omega⟩ : Fin (M + 1)) (Fin.cons j α) (τOfComplement ν))) * X) =
+        Matrix.trace (evalWord A (List.ofFn (Fin.cons j α)) * Y ν) := by
+    simpa [cyclicRestrictₗ_apply, groundSpaceMap_apply, hψX] using
+      congr_fun (hY ν) (Fin.cons j α)
+  have hSnoc := evalWord_cyclicCfg_snoc (A := A) (M := M) (L := L₀ + 1)
+    (show 1 ≤ M by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    (show 1 < L₀ + 1 by omega) (Fin.cons j α) (τOfComplement ν)
+  rw [hSnoc] at hTrace
+  have hSplit := init_evalWord_split (A := A) (M := M) (L := L₀ + 1)
+    (show 1 ≤ M by omega) (show L₀ + 1 ≤ M + 1 by omega)
+    (show 1 < L₀ + 1 by omega) (Fin.cons j α) (τOfComplement ν)
+  rw [hSplit] at hTrace
+  have htail :
+      List.ofFn (fun k : Fin (L₀ + 1 - 1) =>
+          (@Fin.cons L₀ (fun _ => Fin d) j α) ⟨k.val + 1, by
+            have hlen : L₀ + 1 - 1 = L₀ := by omega
+            have hk' : k.val < L₀ := by
+              exact Nat.lt_of_lt_of_eq k.isLt hlen
+            exact Nat.succ_lt_succ hk'⟩) =
+        List.ofFn α := by
+    apply List.ext_getElem
+    · simp only [List.length_ofFn]
+      omega
+    · intro k hk₁ hk₂
+      simp only [List.length_ofFn] at hk₁ hk₂
+      simp only [List.getElem_ofFn]
+      have hidx : (⟨k + 1, by
+          have hlen : L₀ + 1 - 1 = L₀ := by omega
+          have hk' : k < L₀ := by
+            exact Nat.lt_of_lt_of_eq hk₁ hlen
+          exact Nat.succ_lt_succ hk'⟩ : Fin (L₀ + 1)) =
+          (⟨k, hk₂⟩ : Fin L₀).succ := by
+        ext
+        simp
+      rw [hidx, Fin.cons_succ]
+  have hcomp :
+      List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+          τOfComplement ν ⟨k.val + (L₀ + 1) - 1, by omega⟩) =
+        List.ofFn ν := by
+    apply List.ext_getElem
+    · simp only [List.length_ofFn]
+    · intro k hk₁ hk₂
+      simp only [List.length_ofFn] at hk₁
+      simp only [List.getElem_ofFn]
+      simp [τOfComplement]
+      split_ifs with hkM
+      · congr 1
+      · omega
+  rw [htail, hcomp] at hTrace
+  rw [evalWord_ofFn_cons] at hTrace
+  calc
+    Matrix.trace (A j * (X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν)))
+        = Matrix.trace
+            ((evalWord A (List.ofFn α) * evalWord A (List.ofFn ν) * A j) * X) := by
+          simpa [Matrix.mul_assoc] using
+            (Matrix.trace_mul_cycle'
+              (A j) X (evalWord A (List.ofFn α) * evalWord A (List.ofFn ν)))
+    _ = Matrix.trace (A j * evalWord A (List.ofFn α) * Y ν) := by
+          simpa [Matrix.mul_assoc] using hTrace
+    _ = Matrix.trace (A j * (evalWord A (List.ofFn α) * Y ν)) := by
+          simp [Matrix.mul_assoc]
 
 /-- Boundary matrix identity obtained from the periodic-boundary local
 constraints.
@@ -96,11 +211,12 @@ boundary-matrix commutation lemma.
 
 **Open gap:** The proof is the missing coordinate form of the
 inverting-and-growing-back argument at the periodic boundary in
-arXiv:2011.12127, Section IV.C, lines 2078--2079. The statement is the
-source-faithful coordinate obligation; the body remains open. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
-displayed matrix equation from the periodic-boundary local constraints; tracked
-in issue 2405. -/
+arXiv:2011.12127, Section IV.C, lines 2078--2079. The trace rotation from the
+last cyclic window is formalized in
+`closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`; the
+remaining step is to promote the resulting trace identities for the probes
+\(A^j\) to the displayed matrix equation. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in issue 2405. -/
 theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -113,6 +229,16 @@ theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
       ∀ (α : Fin L₀ → Fin d) (ν : Fin (M + 1 - (L₀ + 1)) → Fin d),
         X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν) =
           evalWord A (List.ofFn α) * Y ν := by
+  obtain ⟨Y, hTrace⟩ :=
+    closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
+      (A := A) hL₀ hM hψX hLocal
+  refine ⟨Y, ?_⟩
+  intro α ν
+  have hTraceαν : ∀ j : Fin d,
+      Matrix.trace
+          (A j * (X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν))) =
+        Matrix.trace (A j * (evalWord A (List.ofFn α) * Y ν)) :=
+    fun j => hTrace α ν j
   sorry
 
 /-- Auxiliary boundary-condition product from the left-word form of the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -106,11 +106,50 @@ from the cyclic-window constraints crossing the periodic cut.
     gives $X A^j-A^jX=0$.
 \end{proof}
 
+\begin{lemma}[Trace identity from the boundary-crossing cyclic window]
+    \label{lem:closure_property_boundary_block_window_trace_ground_space_map}
+    \lean{MPSTensor.closure_property_boundary_block_window_trace_eq_of_groundSpaceMap}
+    \leanok
+    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    Let $A$ be a tensor with virtual dimension at least one, and let
+    $L_0>0$ and $L_0<M$. Let
+    \[
+        \psi=\Gamma_{M+1}(X)
+    \]
+    and assume that every cyclic restriction of length $L_0+1$ belongs to
+    $G_{L_0+1}(A)$. Then there are boundary matrices $Y_\nu$, indexed by
+    nonempty complementary words $\nu$ of length $M+1-(L_0+1)$, such that,
+    for every physical letter $j$ and every word $\alpha$ of length $L_0$,
+    \[
+        \operatorname{tr}\left(A^j X A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Choose the matrix representing the cyclic restriction whose window begins at
+    the last site. The cyclic word is
+    \[
+        \alpha\,\nu\,j
+    \]
+    after deleting the first letter from the window and reading the complement.
+    The trace of the open-chain representation is then rotated across the
+    periodic boundary:
+    \[
+        \operatorname{tr}\left(A^\alpha A^\nu A^jX\right)
+        =
+        \operatorname{tr}\left(A^jX A^\alpha A^\nu\right).
+    \]
+\end{proof}
+
 \begin{lemma}[Matrix identity $X A^\alpha A^\nu=A^\alpha Y_\nu$ from cyclic-window constraints]
     \label{lem:closure_property_boundary_block_window_equation_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}
     \leanok
-    \uses{def:ground_space_map, rem:cyclic_window_operators}
+    \uses{def:ground_space_map, rem:cyclic_window_operators,
+        lem:closure_property_boundary_block_window_trace_ground_space_map}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0<M$, and
     $D\ge1$. Let
     \[
@@ -129,9 +168,15 @@ from the cyclic-window constraints crossing the periodic cut.
     \notready
     This is the boundary-matrix formulation of the inverting-and-growing-back
     argument at the periodic boundary in
-    \cite[Section~IV.C, lines~2078--2079]{Cirac2021Matrix}. A complete proof
-    must derive the displayed equation from the cyclic-window constraints
-    recorded above.
+    \cite[Section~IV.C, lines~2078--2079]{Cirac2021Matrix}. The preceding
+    lemma proves the trace identities
+    \[
+        \operatorname{tr}\left(A^j X A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
+    \]
+    The remaining step is to promote these trace identities, for all physical
+    letters $j$, to the displayed matrix equation.
 \end{proof}
 
 \begin{lemma}[Boundary restrictions from commutation and one-sided products]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -129,18 +129,29 @@ from the cyclic-window constraints crossing the periodic cut.
 
 \begin{proof}
     \leanok
-    Choose the matrix representing the cyclic restriction whose window begins at
-    the last site. The cyclic word is
+    Let \(Y_\nu\) be the matrix representing the cyclic restriction whose window
+    begins at the last site. The cyclic word is
     \[
         \alpha\,\nu\,j
     \]
-    after deleting the first letter from the window and reading the complement.
-    The trace of the open-chain representation is then rotated across the
-    periodic boundary:
+    after deleting the first letter from the window and reading the complement,
+    so the ground-space representation gives
     \[
         \operatorname{tr}\left(A^\alpha A^\nu A^jX\right)
         =
-        \operatorname{tr}\left(A^jX A^\alpha A^\nu\right).
+        \operatorname{tr}\left(A^jA^\alpha Y_\nu\right).
+    \]
+    Cyclicity of the trace gives
+    \[
+        \operatorname{tr}\left(A^jX A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^\alpha A^\nu A^jX\right).
+    \]
+    Therefore
+    \[
+        \operatorname{tr}\left(A^jX A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^jA^\alpha Y_\nu\right).
     \]
 \end{proof}
 
@@ -175,8 +186,11 @@ from the cyclic-window constraints crossing the periodic cut.
         =
         \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
     \]
-    The remaining step is to promote these trace identities, for all physical
-    letters $j$, to the displayed matrix equation.
+    These are only single-letter probes. They do not separate matrices for a
+    general \(L_0\)-block-injective tensor. The remaining step is to obtain
+    identities against all length-\(L_0\) word products, which span the full
+    matrix algebra by block injectivity, and hence derive the displayed matrix
+    equation.
 \end{proof}
 
 \begin{lemma}[Boundary restrictions from commutation and one-sided products]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -129,7 +129,7 @@ from the cyclic-window constraints crossing the periodic cut.
 
 \begin{proof}
     \leanok
-    Let \(Y_\nu\) be the matrix representing the cyclic restriction whose window
+    Let $Y_\nu$ be the matrix representing the cyclic restriction whose window
     begins at the last site. The cyclic word is
     \[
         \alpha\,\nu\,j
@@ -187,8 +187,8 @@ from the cyclic-window constraints crossing the periodic cut.
         \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
     \]
     These are only single-letter probes. They do not separate matrices for a
-    general \(L_0\)-block-injective tensor. The remaining step is to obtain
-    identities against all length-\(L_0\) word products, which span the full
+    general $L_0$-block-injective tensor. The remaining step is to obtain
+    identities against all length-$L_0$ word products, which span the full
     matrix algebra by block injectivity, and hence derive the displayed matrix
     equation.
 \end{proof}

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -243,11 +243,15 @@ identity
 \]
 formalized as
 \leanid{MPSTensor.closure_property_boundary_block_window_trace_eq_of_groundSpaceMap}.
-The remaining mathematical task is to promote these trace identities, for all
-physical letters \(j\), to the matrix comparison above. After that equation is
-proved, the block-injective commutation lemma supplies the one-site commutation
-identity, the boundary-restriction equality lemma supplies the equality of the
-two boundary restrictions, and the periodic-boundary comparison follows.\footnote{The
+These identities probe the matrix difference only by the single letters
+\(A^j\), and therefore do not separate matrices for a general
+\(L_0\)-block-injective tensor. The remaining mathematical task is to obtain
+the corresponding trace identities against all length-\(L_0\) word products
+\(A^\beta\), or an equivalent coordinate comparison; those products span the
+full matrix algebra by block injectivity. After that equation is proved, the
+block-injective commutation lemma supplies the one-site commutation identity,
+the boundary-restriction equality lemma supplies the equality of the two
+boundary restrictions, and the periodic-boundary comparison follows.\footnote{The
 present source-labelled statement for this step is
 \leanid{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}.}
 

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -234,8 +234,17 @@ length-\(L_0\) word \(\alpha\) and every complementary word \(\nu\),
 then \(XA^k=A^kX\) for every physical letter \(k\).\footnote{Formal location:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:46 for
 \leanid{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}.}
-The remaining mathematical task is therefore to derive this matrix comparison
-from the periodic-boundary local constraints. After that equation is
+The trace rotation at the last cyclic window has now been isolated as the
+identity
+\[
+  \operatorname{tr}\left(A^j X A^\alpha A^\nu\right)
+  =
+  \operatorname{tr}\left(A^j A^\alpha Y_\nu\right),
+\]
+formalized as
+\leanid{MPSTensor.closure_property_boundary_block_window_trace_eq_of_groundSpaceMap}.
+The remaining mathematical task is to promote these trace identities, for all
+physical letters \(j\), to the matrix comparison above. After that equation is
 proved, the block-injective commutation lemma supplies the one-site commutation
 identity, the boundary-restriction equality lemma supplies the equality of the
 two boundary restrictions, and the periodic-boundary comparison follows.\footnote{The


### PR DESCRIPTION
### Motivation

- The boundary-closing argument for the normal range-reduction proof (arXiv:2011.12127 §IV.C, lines 2078–2090; see issue #2405) requires promoting trace identities to a full matrix equation; this PR isolates the verified trace-rotation step to expose the remaining open obligation as a single matrix promotion.
- The trace identity — that for ψ = Γ_{M+1}(X) there exist matrices Y_ν with tr(A^j X A^α A^ν) = tr(A^j A^α Y_ν) for all physical letters j, length-L₀ words α, and complementary words ν — is now proved; only the promotion to X A^α A^ν = A^α Y_ν remains open.

### Description

- `TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean`: proves new theorem `closure_property_boundary_block_window_trace_eq_of_groundSpaceMap` using the last-site cyclic window, trace cycling, and list/word splitting lemmas.
- `closure_property_boundary_block_window_equation_of_groundSpaceMap` now calls that result and retains `sorry` only for the single remaining promotion from trace identities to the matrix equation X A^α A^ν = A^α Y_ν.
- Minor call-site fix: passes `(Z := Z)` explicitly into `eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul`.
- `blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex`: adds `\leanok` entry for the trace lemma.
- `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`: updates the paper-gap note to record the trace step as formalized and the matrix promotion as the remaining open obligation.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `git diff --check`

---
Addresses #2405

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a self-contained Lean proof and doc/blueprint sync; the critical matrix step stays behind `sorry` with unchanged downstream dependencies.
> 
> **Overview**
> This PR **proves the trace-rotation step** of the periodic-boundary block-window argument and **narrows the open gap** to promoting those traces to a full matrix equation.
> 
> In `BoundaryClosingStripping.lean`, **`closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`** is new and complete: from ψ = Γ_{M+1}(X) and local cyclic-window ground-space constraints, it builds boundary matrices **Y_ν** and shows **tr(A^j X A^α A^ν) = tr(A^j A^α Y_ν)** via the last-site window, cyclic word splitting, and trace cycling. **`closure_property_boundary_block_window_equation_of_groundSpaceMap`** now **imports that result** but still ends in **`sorry`** for **X A^α A^ν = A^α Y_ν**, with comments that single-letter trace probes are insufficient for block injectivity until length-**L₀** word probes exist. A small call-site fix passes **`(Z := Z)`** into **`eq_zero_of_evalWord_mul_eq_zero_of_isNBlkInjective_of_le_mul`**.
> 
> The blueprint adds a **`\leanok`** lemma for the trace identity and reframes the matrix lemma proof as **notready**, depending on the trace step. The paper-gap note records the trace identity as formalized and the **matrix promotion** as the remaining task (issue #2405).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbab2d75b0c5e7d0dd469f84d38eba854c021f75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->