### PR TITLE
feat(Algebra): add finite-cycle coboundary lemma

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -27,6 +27,7 @@ import TNLean.Algebra.LinearMapAux
 import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.UnitModulusPowerSum
+import TNLean.Algebra.FiniteCycleCoboundary
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.MatrixFrobenius

--- a/TNLean/Algebra/FiniteCycleCoboundary.lean
+++ b/TNLean/Algebra/FiniteCycleCoboundary.lean
@@ -20,15 +20,15 @@ namespace TNLean.Algebra
 
 variable {G : Type*} [CommGroup G]
 
-/-- The total product around the cycle is the partial product of the first
-n edges, multiplied by the last edge. -/
-lemma prod_univ_eq_partialProd_last {n : ℕ} (κ : Fin (n + 1) → G) :
+/-- The total product around the cycle is the product of the first `n` edges,
+multiplied by the last edge. -/
+lemma prod_univ_eq_prod_castSucc_last {n : ℕ} (κ : Fin (n + 1) → G) :
     (∏ v : Fin (n + 1), κ v) =
-      Fin.partialProd (fun v : Fin n => κ v.castSucc) (Fin.last n) * κ (Fin.last n) := by
+      (∏ v : Fin n, κ v.castSucc) * κ (Fin.last n) := by
   rw [Fin.prod_univ_castSucc]
-  congr 1
-  show (∏ v : Fin n, κ v.castSucc) =
-    Fin.partialProd (fun v : Fin n => κ v.castSucc) (Fin.last n)
+
+private lemma prod_eq_partialProd_last {n : ℕ} (ψ : Fin n → G) :
+    (∏ v : Fin n, ψ v) = Fin.partialProd ψ (Fin.last n) := by
   rw [← Fin.prod_ofFn]
   rw [Fin.partialProd]
   rw [List.take_of_length_le]
@@ -53,8 +53,13 @@ lemma exists_fin_succ_coboundary_of_prod_eq_one {n : ℕ}
     have hquot : (Fin.partialProd ψ v.castSucc)⁻¹ * Fin.partialProd ψ v.succ = ψ v :=
       Fin.partialProd_right_inv ψ v
     simpa [φ, ψ] using hquot.symm
-  · have hlast : Fin.partialProd ψ (Fin.last n) * κ (Fin.last n) = 1 := by
-      simpa [ψ, prod_univ_eq_partialProd_last κ] using hprod
+  · have hsplit : (∏ v : Fin n, κ v.castSucc) * κ (Fin.last n) = 1 := by
+      simpa [prod_univ_eq_prod_castSucc_last κ] using hprod
+    have hpartial : (∏ v : Fin n, κ v.castSucc) =
+        Fin.partialProd ψ (Fin.last n) := by
+      simpa [ψ] using prod_eq_partialProd_last ψ
+    have hlast : Fin.partialProd ψ (Fin.last n) * κ (Fin.last n) = 1 := by
+      simpa [hpartial] using hsplit
     have hlast' : (Fin.partialProd ψ (Fin.last n))⁻¹ = κ (Fin.last n) := by
       calc
         (Fin.partialProd ψ (Fin.last n))⁻¹ =

--- a/TNLean/Algebra/FiniteCycleCoboundary.lean
+++ b/TNLean/Algebra/FiniteCycleCoboundary.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.BigOperators.Fin
+
+/-!
+# Coboundaries on a finite cycle
+
+This module records the elementary multiplicative fact that a product-one
+family of scalars around a finite cycle is a coboundary.  It is the algebraic
+form of the phase telescoping used in arXiv:1708.00029, Appendix A, lines
+1093--1102: from phases whose product is one, choose vertex phases so that
+each edge phase is the ratio of consecutive vertex phases.
+-/
+
+open scoped BigOperators
+
+namespace TNLean.Algebra
+
+variable {G : Type*} [CommGroup G]
+
+/-- The total product around the cycle is the partial product of the first
+n edges, multiplied by the last edge. -/
+lemma prod_univ_eq_partialProd_last {n : ℕ} (κ : Fin (n + 1) → G) :
+    (∏ v : Fin (n + 1), κ v) =
+      Fin.partialProd (fun v : Fin n => κ v.castSucc) (Fin.last n) * κ (Fin.last n) := by
+  rw [Fin.prod_univ_castSucc]
+  congr 1
+  show (∏ v : Fin n, κ v.castSucc) =
+    Fin.partialProd (fun v : Fin n => κ v.castSucc) (Fin.last n)
+  rw [← Fin.prod_ofFn]
+  rw [Fin.partialProd]
+  rw [List.take_of_length_le]
+  simp
+
+/-- A product-one family on a finite cycle is a multiplicative coboundary.
+
+This is the group-valued version of the phase choice in arXiv:1708.00029,
+Appendix A, lines 1093--1102.  The witness is
+φ(k) = (κ₀ ··· κ_{k-1})⁻¹; hence κ_k = φ(k) · φ(k+1)⁻¹ for each
+interior edge, and the hypothesis ∏ κ = 1 supplies the closing equation
+κ(n) = φ(n) · φ(0)⁻¹ at the last vertex. -/
+lemma exists_fin_succ_coboundary_of_prod_eq_one {n : ℕ}
+    (κ : Fin (n + 1) → G) (hprod : ∏ v : Fin (n + 1), κ v = 1) :
+    ∃ φ : Fin (n + 1) → G,
+      (∀ v : Fin n, κ v.castSucc = φ v.castSucc * (φ v.succ)⁻¹) ∧
+      κ (Fin.last n) = φ (Fin.last n) * (φ 0)⁻¹ := by
+  let ψ : Fin n → G := fun v => κ v.castSucc
+  let φ : Fin (n + 1) → G := fun v => (Fin.partialProd ψ v)⁻¹
+  refine ⟨φ, ?_, ?_⟩
+  · intro v
+    have hquot : (Fin.partialProd ψ v.castSucc)⁻¹ * Fin.partialProd ψ v.succ = ψ v :=
+      Fin.partialProd_right_inv ψ v
+    simpa [φ, ψ] using hquot.symm
+  · have hlast : Fin.partialProd ψ (Fin.last n) * κ (Fin.last n) = 1 := by
+      simpa [ψ, prod_univ_eq_partialProd_last κ] using hprod
+    have hlast' : (Fin.partialProd ψ (Fin.last n))⁻¹ = κ (Fin.last n) := by
+      calc
+        (Fin.partialProd ψ (Fin.last n))⁻¹ =
+            (Fin.partialProd ψ (Fin.last n))⁻¹ * 1 := by simp
+        _ = (Fin.partialProd ψ (Fin.last n))⁻¹ *
+            (Fin.partialProd ψ (Fin.last n) * κ (Fin.last n)) := by rw [hlast]
+        _ = κ (Fin.last n) := by simp
+    simp [φ, hlast']
+
+end TNLean.Algebra

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -974,7 +974,7 @@ unconditional result.
 
 \begin{lemma}[Splitting the last edge of a finite cycle]%
     \label{lem:finite_cycle_product_split_last}
-    \lean{TNLean.Algebra.prod_univ_eq_partialProd_last}
+    \lean{TNLean.Algebra.prod_univ_eq_prod_castSucc_last}
     \leanok
     \uses{}
     For elements $\kappa_0,\ldots,\kappa_n$ of a commutative group,

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -981,7 +981,7 @@ unconditional result.
     \[
         \prod_{k=0}^{n}\kappa_k
         =
-        \left(\prod_{k=0}^{n-1}\kappa_k\right)\kappa_n.
+        \left(\prod_{k=0}^{n-1}\kappa_k\right)\cdot\kappa_n.
     \]
 \end{lemma}
 

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -972,6 +972,70 @@ unconditional result.
     \]
 \end{lemma}
 
+\begin{lemma}[Splitting the last edge of a finite cycle]%
+    \label{lem:finite_cycle_product_split_last}
+    \lean{TNLean.Algebra.prod_univ_eq_partialProd_last}
+    \leanok
+    \uses{}
+    For elements $\kappa_0,\ldots,\kappa_n$ of a commutative group,
+    \[
+        \prod_{k=0}^{n}\kappa_k
+        =
+        \left(\prod_{k=0}^{n-1}\kappa_k\right)\kappa_n.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{}
+    Separate the final factor from the product over the finite interval.
+\end{proof}
+
+\begin{lemma}[Finite-cycle coboundary]\label{lem:finite_cycle_coboundary}
+    \lean{TNLean.Algebra.exists_fin_succ_coboundary_of_prod_eq_one}
+    \leanok
+    \uses{}
+    Let $G$ be a commutative group, and let
+    $\kappa_0,\ldots,\kappa_n\in G$. If
+    \[
+        \prod_{k=0}^{n}\kappa_k=1,
+    \]
+    then there are $\varphi_0,\ldots,\varphi_n\in G$ such that, for every
+    $k<n$,
+    \[
+        \kappa_k=\varphi_k\varphi_{k+1}^{-1},
+    \]
+    and
+    \[
+        \kappa_n=\varphi_n\varphi_0^{-1}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:finite_cycle_product_split_last}
+    Set $\varphi_k=(\kappa_0\cdots\kappa_{k-1})^{-1}$, with the empty product
+    equal to $1$. For $k<n$,
+    \[
+        \varphi_k\varphi_{k+1}^{-1}
+        =
+        (\kappa_0\cdots\kappa_{k-1})^{-1}
+        (\kappa_0\cdots\kappa_k)
+        =
+        \kappa_k.
+    \]
+    The remaining identity follows from
+    \[
+        (\kappa_0\cdots\kappa_{n-1})\kappa_n=1,
+    \]
+    which gives
+    \[
+        \varphi_n\varphi_0^{-1}
+        =
+        (\kappa_0\cdots\kappa_{n-1})^{-1}
+        =
+        \kappa_n.
+    \]
+\end{proof}
+
 \begin{lemma}[Per-site proportionality from blocked sector match]%
     \label{lem:sector_tensor_proportional_blocked_match}
     \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}


### PR DESCRIPTION
### Motivation

- The phase-telescoping argument in arXiv:1708.00029, Appendix A, lines 1093-1102, locally `Papers/1708.00029/main.tex:1093-1102`, requires the following finite-cycle statement: edge phases `κ_i` whose product around one period is `1` can be written as phase differences `κ_i = φ_i * (φ_{i+1})⁻¹`, with the last equation wrapping from the final vertex to the first.
- This algebraic lemma is needed to close the remaining Case 3 gap in the periodic-overlap dichotomy; see #873.
- This PR is stacked on #2923.

### Description

- Adds `TNLean.Algebra.FiniteCycleCoboundary`.
- Uses Mathlib's `Fin.partialProd` for the prefix products of the first `n` edges.
- Proves `prod_univ_eq_partialProd_last`, separating the total cycle product into the partial product of the first `n` edges and the last edge.
- Proves `exists_fin_succ_coboundary_of_prod_eq_one`: for `κ : Fin (n + 1) -> G` in a commutative group, if `∏ i, κ i = 1`, then there are vertex phases `φ : Fin (n + 1) -> G` such that the interior identities are `κ i = φ_i * (φ_{i+1})⁻¹` and the final identity is the corresponding wrap-around equation.
- Exposes the new module from `TNLean.lean`.

### Testing

- `lake env lean TNLean/Algebra/FiniteCycleCoboundary.lean`
- `lake build TNLean.Algebra.FiniteCycleCoboundary TNLean`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff --check`
- Proof-integrity scan found no `sorry`, `axiom`, `native_decide`, or `unsafeCast` in `TNLean/Algebra/FiniteCycleCoboundary.lean`.

Addresses #873

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained elementary group algebra with no changes to auth, channels, or existing theorem proofs; only a new import and blueprint documentation.
> 
> **Overview**
> Adds **`TNLean.Algebra.FiniteCycleCoboundary`**, formalizing that edge factors `κ` on `Fin (n+1)` in a commutative group with **∏ κ = 1** admit vertex phases `φ` with interior coboundary identities and a wrap-around last edge.
> 
> The main witness uses **`Fin.partialProd`** inverses; a helper lemma splits the full cycle product into the first `n` edges times the last factor. The module is **imported from `TNLean.lean`**.
> 
> **Blueprint** (`ch22_periodic_ft.tex`) gains matching lemmas **`lem:finite_cycle_product_split_last`** and **`lem:finite_cycle_coboundary`** with `\lean` links, supporting the phase-telescoping step toward the periodic overlap dichotomy (Case 3).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1ad757a99eff4135fcd87ec97fe6bf12b10281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->