### PR TITLE
feat(MPS/ParentHamiltonian): separate length-word trace identities

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -194,6 +194,40 @@ theorem closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
     _ = Matrix.trace (A j * (evalWord A (List.ofFn α) * Y ν)) := by
           simp [Matrix.mul_assoc]
 
+/-- Length-\(L_0\) trace identities imply the boundary block-window matrix equation.
+
+Let \(A\) be \(L_0\)-block-injective. If, for every length-\(L_0\) word
+\(\beta\),
+\[
+  \operatorname{tr}\!\left(A^\beta X A^\alpha A^\nu\right)
+  =
+  \operatorname{tr}\!\left(A^\beta A^\alpha Y_\nu\right),
+\]
+then block injectivity gives
+\[
+  X A^\alpha A^\nu=A^\alpha Y_\nu .
+\]
+This is the trace-separation step needed after the periodic-boundary
+inverting-and-growing-back argument has produced the length-\(L_0\) trace
+identities. -/
+theorem block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective
+    {A : MPSTensor d D} {L₀ K : ℕ} (hInj : IsNBlkInjective A L₀)
+    {X : Matrix (Fin D) (Fin D) ℂ}
+    (Y : (Fin K → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hTrace : ∀ (α : Fin L₀ → Fin d) (ν : Fin K → Fin d)
+        (β : Fin L₀ → Fin d),
+      Matrix.trace (evalWord A (List.ofFn β) *
+          (X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν))) =
+        Matrix.trace (evalWord A (List.ofFn β) *
+          (evalWord A (List.ofFn α) * Y ν))) :
+    ∀ (α : Fin L₀ → Fin d) (ν : Fin K → Fin d),
+      X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν) =
+        evalWord A (List.ofFn α) * Y ν := by
+  intro α ν
+  apply groundSpaceMap_injective_of_isNBlkInjective hInj
+  ext β
+  simpa [groundSpaceMap_apply] using hTrace α ν β
+
 /-- Boundary matrix identity obtained from the periodic-boundary local
 constraints.
 
@@ -214,10 +248,13 @@ inverting-and-growing-back argument at the periodic boundary in
 arXiv:2011.12127, Section IV.C, lines 2078--2079. The trace rotation from the
 last cyclic window is formalized in
 `closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`; it gives
-only the single-letter trace probes \(A^j\). The remaining step is to obtain
-trace identities against length-\(L_0\) word products, which separate matrices
-by block injectivity, and hence derive the displayed matrix equation. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in issue 2405. -/
+the trace identities visible at that cyclic window. The remaining step is to
+obtain the corresponding trace identities against all length-\(L_0\) word
+products. The algebraic separation of matrices from those identities is
+formalized in
+`block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective`.
+Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in
+issue 2405. -/
 theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -234,10 +271,12 @@ theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
     closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
       (A := A) hL₀ hM hψX hLocal
   refine ⟨Y, ?_⟩
-  intro α ν
-  -- The available trace identity probes only single letters. The open closing
-  -- step must produce length-\(L_0\) word probes before block injectivity can
-  -- separate the matrix difference.
+  apply block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective
+    (A := A) hInj Y
+  intro α ν β
+  have hTraceRotation := hTrace
+  -- The remaining closing step must produce these length-\(L_0\) trace identities
+  -- from the boundary-crossing cyclic-window constraints.
   sorry
 
 /-- Auxiliary boundary-condition product from the left-word form of the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -155,12 +155,51 @@ from the cyclic-window constraints crossing the periodic cut.
     \]
 \end{proof}
 
+\begin{theorem}[Length-word trace separation for the boundary block window]
+    \label{thm:block_window_matrix_equation_trace_word_products}
+    \lean{MPSTensor.block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective}
+    \leanok
+    \uses{def:l_blk_injective, def:eval_word}
+    Let $A$ be $L_0$-block-injective. Let $X$ be a boundary matrix, and let
+    $Y_\nu$ be a matrix for each complementary word $\nu$ of length $K$.
+    Suppose that, for every word $\alpha$ of length $L_0$, every word $\beta$
+    of length $L_0$, and every complementary word $\nu$,
+    \[
+        \operatorname{tr}\left(A^\beta X A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^\beta A^\alpha Y_\nu\right).
+    \]
+    Then, for every word $\alpha$ of length $L_0$ and every complementary word
+    $\nu$,
+    \[
+        X A^\alpha A^\nu=A^\alpha Y_\nu .
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:ground_space_map_injective_blk}
+    The trace identities say exactly that
+    \[
+        \Gamma_{L_0}(X A^\alpha A^\nu)
+        =
+        \Gamma_{L_0}(A^\alpha Y_\nu)
+    \]
+    for each fixed pair $(\alpha,\nu)$. Since $A$ is $L_0$-block-injective,
+    $\Gamma_{L_0}$ is injective by
+    Lemma~\ref{lem:ground_space_map_injective_blk}. Hence
+    \[
+        X A^\alpha A^\nu=A^\alpha Y_\nu .
+    \]
+\end{proof}
+
 \begin{lemma}[Matrix identity $X A^\alpha A^\nu=A^\alpha Y_\nu$ from cyclic-window constraints]
     \label{lem:closure_property_boundary_block_window_equation_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}
     \leanok
     \uses{def:ground_space_map, rem:cyclic_window_operators,
-        lem:closure_property_boundary_block_window_trace_ground_space_map}
+        lem:closure_property_boundary_block_window_trace_ground_space_map,
+        thm:block_window_matrix_equation_trace_word_products}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0<M$, and
     $D\ge1$. Let
     \[
@@ -186,11 +225,17 @@ from the cyclic-window constraints crossing the periodic cut.
         =
         \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
     \]
-    These are only single-letter probes. They do not separate matrices for a
-    general $L_0$-block-injective tensor. The remaining step is to obtain
-    identities against all length-$L_0$ word products, which span the full
-    matrix algebra by block injectivity, and hence derive the displayed matrix
-    equation.
+    These identities test the matrix difference after left multiplication by
+    $A^j$. They do not by themselves test against every length-$L_0$ word
+    product. The remaining step is to prove, for every word $\beta$ of length
+    $L_0$,
+    \[
+        \operatorname{tr}\left(A^\beta X A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^\beta A^\alpha Y_\nu\right).
+    \]
+    Theorem~\ref{thm:block_window_matrix_equation_trace_word_products} then
+    gives the displayed matrix equation.
 \end{proof}
 
 \begin{lemma}[Boundary restrictions from commutation and one-sided products]

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -243,12 +243,17 @@ identity
 \]
 formalized as
 \leanid{MPSTensor.closure_property_boundary_block_window_trace_eq_of_groundSpaceMap}.
-These identities probe the matrix difference only by the single letters
+These identities pair the matrix difference only with the single letters
 \(A^j\), and therefore do not separate matrices for a general
 \(L_0\)-block-injective tensor. The remaining mathematical task is to obtain
 the corresponding trace identities against all length-\(L_0\) word products
 \(A^\beta\), or an equivalent coordinate comparison; those products span the
-full matrix algebra by block injectivity. After that equation is proved, the
+full matrix algebra by block injectivity. The trace-separation theorem records
+the algebraic consequence: if these length-\(L_0\) trace identities are known,
+then \(XA^\alpha A^\nu=A^\alpha Y_\nu\).\footnote{Formal location:
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:213 for
+\leanid{MPSTensor.block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective}.}
+After that equation is proved from the cyclic-window constraints, the
 block-injective commutation lemma supplies the one-site commutation identity,
 the boundary-restriction equality lemma supplies the equality of the two
 boundary restrictions, and the periodic-boundary comparison follows.\footnote{The


### PR DESCRIPTION
### Motivation

- Issue #2405 requires proving the boundary-closing comparison for the normal range-reduction argument in arXiv:2011.12127, Section IV.C, lines 2078-2090.
- The local algebraic step is to turn trace identities against all length-$L_0$ word products $A^\beta$ into the boundary block-window matrix equation $XA^\alpha A^\nu = A^\alpha Y_\nu$.
- This PR proves that algebraic implication and narrows the sole remaining `sorry` in `closure_property_boundary_block_window_equation_of_groundSpaceMap` to the construction of those length-$L_0$ trace identities from the boundary-crossing cyclic-window constraints.

### Description

- `TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean`: adds proved theorem `block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective`, using injectivity of the trace map $\Gamma_{L_0}$ from $L_0$-block injectivity.
- `blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex`: adds the corresponding theorem `thm:block_window_matrix_equation_trace_word_products` and updates the open boundary block-window proof sketch by displaying the remaining length-$L_0$ trace identity.
- `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`: records that the trace-separation theorem supplies $XA^\alpha A^\nu=A^\alpha Y_\nu$ once the length-$L_0$ trace identities are known.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `lake build TNLean` (completes successfully; pre-existing PEPS warnings and periodic-overlap `sorry` warnings are unrelated to this patch)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Refs #2405

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and a small proved algebraic theorem; no change to the source-facing boundary statement, and the main boundary proof still ends at the same `sorry` with a narrower stated obligation.
>
> **Overview**
> Adds a proved Lean theorem `block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective`: assuming full length-\(L_0\) left-word trace identities \(\operatorname{tr}(A^\beta X A^\alpha A^\nu)=\operatorname{tr}(A^\beta A^\alpha Y_\nu)\), \(L_0\)-block injectivity yields the matrix equation \(X A^\alpha A^\nu = A^\alpha Y_\nu\) via injectivity of \(\Gamma_{L_0}\).
>
> Refactors `closure_property_boundary_block_window_equation_of_groundSpaceMap` to call that theorem; the sole remaining `sorry` is now explicitly deriving those length-\(L_0\) trace identities from cyclic-window data.
>
> Blueprint ch13 gains matching theorem `thm:block_window_matrix_equation_trace_word_products` and updates the not-ready lemma proof to cite it. The CPGSV21 gap note documents the separated algebraic step and points to the new Lean name (issue #2405).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4636657625750a4322d019b71580655109bb8748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
