### PR TITLE
doc(blueprint): align Wielandt headline hypotheses with source and Lean

### DIFF
--- a/blueprint/src/chapter/ch08_wielandt.tex
+++ b/blueprint/src/chapter/ch08_wielandt.tex
@@ -601,8 +601,8 @@ The results follow~\cite{Sanz2010Quantum}.
         lem:one_step_augment_word_span, lem:one_step_augment_normal_kraus_rank,
         thm:wielandt_case2_normal_generator}
     Let $A$ be an MPS tensor with bond dimension $D \ge 1$, satisfying
-    $\sum_i (A^i)^\dagger A^i=\Id$, and suppose that $A$ is primitive
-    with a positive-definite fixed point. If $S_1(A)$ contains an
+    $\sum_i (A^i)^\dagger A^i=\Id$, and suppose that $A$ is primitive.
+    If $S_1(A)$ contains an
     invertible matrix $X$, then
     \begin{equation}\label{eq:wld_case2_one_step_wordspan_top}
         S_{D^2 - \krausrk(A) + 1}(A)=\MN{D}.
@@ -617,8 +617,8 @@ The results follow~\cite{Sanz2010Quantum}.
     \uses{lem:one_step_augment_word_span, lem:one_step_augment_normal_kraus_rank,
         thm:wielandt_case2_normal_generator}
     Adjoin $X$ as an extra first Kraus operator, obtaining
-    $\widetilde A$. Primitivity with a positive-definite fixed point and
-    normalization give normality of $A$, hence normality of $\widetilde A$;
+    $\widetilde A$. Primitivity and normalization give normality of $A$,
+    hence normality of $\widetilde A$;
     the Kraus rank and all exact word spans are unchanged. The first Kraus operator of
     $\widetilde A$ is invertible, so
     Theorem~\ref{thm:wielandt_case2_normal_generator} gives
@@ -653,8 +653,8 @@ The results follow~\cite{Sanz2010Quantum}.
     \uses{lem:kraus_mem_word_span_one, thm:wielandt_case2_one_step_span,
         cor:wielandt_case2_one_step_index}
     Let $A$ be an MPS tensor with bond dimension $D \ge 1$, satisfying
-    $\sum_i (A^i)^\dagger A^i=\Id$, and suppose that $A$ is primitive
-    with a positive-definite fixed point. If some Kraus operator $A^{i_0}$
+    $\sum_i (A^i)^\dagger A^i=\Id$, and suppose that $A$ is primitive.
+    If some Kraus operator $A^{i_0}$
     is invertible, then
     \[
         S_{D^2 - \krausrk(A) + 1}(A)=\MN{D},
@@ -748,8 +748,8 @@ The results follow~\cite{Sanz2010Quantum}.
         thm:eigenvector_spreading, lem:rank_one_noninvertible_eigenvector,
         thm:lemma2b_assembly}
     Let $A$ be an MPS tensor with bond dimension $D \ge 1$, satisfying
-    $\sum_i (A^i)^\dagger A^i=\Id$, and suppose that $A$ is primitive
-    with a positive-definite fixed point. If $S_1(A)$ contains a
+    $\sum_i (A^i)^\dagger A^i=\Id$, and suppose that $A$ is primitive.
+    If $S_1(A)$ contains a
     non-invertible matrix $X$ with a nonzero eigenvalue, then
     \[
         S_{D^2}(A)=\MN{D}.
@@ -803,8 +803,8 @@ The results follow~\cite{Sanz2010Quantum}.
     \uses{lem:kraus_mem_word_span_one, thm:wielandt_case3_one_step_span,
         cor:wielandt_case3_one_step_index}
     Let $A$ be an MPS tensor with bond dimension $D \ge 1$, satisfying
-    $\sum_i (A^i)^\dagger A^i=\Id$, and suppose that $A$ is primitive
-    with a positive-definite fixed point. If some Kraus operator $A^{i_0}$
+    $\sum_i (A^i)^\dagger A^i=\Id$, and suppose that $A$ is primitive.
+    If some Kraus operator $A^{i_0}$
     is non-invertible and has an eigenvector $\varphi \ne 0$ with nonzero
     eigenvalue $\mu$, then
     \[
@@ -828,7 +828,7 @@ The results follow~\cite{Sanz2010Quantum}.
     \leanok
     \uses{def:normal}
     Let $A$ be a normalized MPS tensor ($\sum_i (A^i)^\dagger A^i = \Id$)
-    that is primitive with a positive-definite fixed point.
+    that is primitive.
     Then
     \[
         \iota(A) \le


### PR DESCRIPTION
## Summary

A faithfulness audit of the Quantum-Wielandt area found that the **Lean signatures are clean** (no smuggled hypotheses), but the **blueprint headline statements over-stated the hypotheses**: they read "primitive **with a positive-definite fixed point**", a clause present in neither the source nor the linked Lean declarations.

- **Source** (Sanz–Pérez-García–Wolf–Cirac, *A quantum version of Wielandt's inequality*, Theorem 1): hypothesis is a "primitive quantum channel" — no positive-definite-fixed-point assumption.
- **Lean** (`iIndex_le_general_of_isPrimitivePaper` and the case-2/3 declarations): assume only `IsPrimitivePaper` (the pure spreading condition). The positive-definite fixed point is **derived** internally from primitivity + normalization (via the generalized Frobenius theorem / `isStronglyIrreduciblePaper_of_isPrimitivePaper`), not assumed.

So the blueprint described a *stricter* theorem than the one actually proven and `\lean{}`-linked — an under-claim of the result's generality, and a mismatch between the `\leanok`-tagged statement and its target declaration's real hypotheses.

## Changes (documentation only)

Dropped "with a positive-definite fixed point" from the five headline statements and the one proof line referencing it as a given:

| Entry | `\lean{}` target |
|-------|------------------|
| `thm:wielandt_case2_one_step_span` | `wordSpan_eq_top_of_isPrimitivePaper_of_mem_wordSpan_one_of_isUnit` |
| `cor:wielandt_case2_generator` | `wordSpan_eq_top_of_isPrimitivePaper_of_isUnit` (+ index) |
| `thm:wielandt_case3_one_step_span` | `wordSpan_eq_top_of_isPrimitivePaper_of_mem_wordSpan_one_of_noninvertible_eigenvector` |
| `cor:wielandt_case3_generator` | `wordSpan_eq_top_of_isPrimitivePaper_of_noninvertible_eigenvector` (+ index) |
| `thm:wielandt_general` | `iIndex_le_general_of_isPrimitivePaper` |

The supporting-lemma entries (`ch08_wielandt.tex`:1439/1592/1618/1639) are **left unchanged** — they are the auxiliary "primitive + positive-definite fixed point ⇒ irreducible / normal" route that genuinely assumes the positive-definite fixed point (matching `isNormal_of_isPrimitiveMPS_with_posDef`).

No Lean changed; no `\lean{}` / `\leanok` / `\uses{}` tags changed. 11 insertions / 11 deletions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX blueprint text only; no code or proof logic changes.
> 
> **Overview**
> **Documentation-only** alignment in `ch08_wielandt.tex`: five headline statements and one proof sentence no longer assume a **positive-definite fixed point** alongside primitivity.
> 
> The hypotheses now read that \(A\) is **primitive** (with normalization where already stated), matching **Sanz–Pérez-García–Wolf–Cirac** Theorem 1 and the linked Lean targets (`IsPrimitivePaper` / `*_of_isPrimitivePaper_*`). Positive-definiteness remains an **internal consequence** in the formal proof route, not a stated assumption on these theorems.
> 
> **Affected entries:** `thm:wielandt_case2_one_step_span`, `cor:wielandt_case2_generator`, `thm:wielandt_case3_one_step_span`, `cor:wielandt_case3_generator`, `thm:wielandt_general`; the case (2) one-step proof now says normality follows from **primitivity and normalization** rather than citing positive-definite fixed point as given.
> 
> No Lean, `\lean{}`, `\leanok`, or `\uses{}` tag changes. Auxiliary lemmas that genuinely assume positive-definite \(\rho\) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5815a9845eb49de6737ad092f2673acc1e93f146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->