### PR TITLE
feat(MPS/ParentHamiltonian): isolate length-word trace obligation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -194,6 +194,50 @@ theorem closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
     _ = Matrix.trace (A j * (evalWord A (List.ofFn α) * Y ν)) := by
           simp [Matrix.mul_assoc]
 
+/-- Length-\(L_0\) trace form of the boundary block-window equation.
+
+Let \(A\) be \(L_0\)-block-injective and let
+\(\psi=\Gamma_{M+1}(X)\). The periodic-boundary
+inverting-and-growing-back argument in arXiv:2011.12127, Section IV.C,
+lines 2078--2079, should give boundary matrices \(Y_\nu\) such that
+\[
+  \operatorname{tr}\!\left(A^\beta X A^\alpha A^\nu\right)
+  =
+  \operatorname{tr}\!\left(A^\beta A^\alpha Y_\nu\right)
+\]
+for all length-\(L_0\) words \(\alpha,\beta\) and every complementary word
+\(\nu\).
+
+**Open gap:** The trace rotation from the last cyclic window is formalized in
+`closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`; it gives
+the displayed identities only for one-letter probes. The missing step is the
+source reconstruction that extends those probes to all length-\(L_0\) word
+products. Documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in issue 2405. -/
+theorem closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (hLocal : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ ∈
+        groundSpace A (L₀ + 1)) :
+    ∃ Y : (Fin (M + 1 - (L₀ + 1)) → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+      ∀ (α : Fin L₀ → Fin d) (ν : Fin (M + 1 - (L₀ + 1)) → Fin d)
+          (β : Fin L₀ → Fin d),
+        Matrix.trace (evalWord A (List.ofFn β) *
+            (X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν))) =
+          Matrix.trace (evalWord A (List.ofFn β) *
+            (evalWord A (List.ofFn α) * Y ν)) := by
+  obtain ⟨Y, _hTraceOne⟩ :=
+    closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
+      (A := A) hL₀ hM hψX hLocal
+  refine ⟨Y, ?_⟩
+  intro α ν β
+  -- The missing source step extends the one-letter trace probes to length-\(L_0\)
+  -- probes using the periodic-boundary inverting-and-growing-back argument.
+  sorry
+
 /-- Length-\(L_0\) trace identities imply the boundary block-window matrix equation.
 
 Let \(A\) be \(L_0\)-block-injective. If, for every length-\(L_0\) word
@@ -267,17 +311,12 @@ theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
       ∀ (α : Fin L₀ → Fin d) (ν : Fin (M + 1 - (L₀ + 1)) → Fin d),
         X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν) =
           evalWord A (List.ofFn α) * Y ν := by
-  obtain ⟨Y, hTrace⟩ :=
-    closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
-      (A := A) hL₀ hM hψX hLocal
+  obtain ⟨Y, hTraceWord⟩ :=
+    closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX hLocal
   refine ⟨Y, ?_⟩
-  apply block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective
-    (A := A) hInj Y
-  intro α ν β
-  have hTraceRotation := hTrace
-  -- The remaining closing step must produce these length-\(L_0\) trace identities
-  -- from the boundary-crossing cyclic-window constraints.
-  sorry
+  exact block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective
+    (A := A) hInj Y hTraceWord
 
 /-- Auxiliary boundary-condition product from the left-word form of the
 second boundary-crossing coordinate comparison.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -155,6 +155,49 @@ from the cyclic-window constraints crossing the periodic cut.
     \]
 \end{proof}
 
+\begin{theorem}[Trace identities with length-$L_0$ probes from cyclic-window constraints]
+    \label{thm:closure_property_boundary_block_window_trace_word_ground_space_map}
+    \lean{MPSTensor.closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap}
+    \uses{def:ground_space_map, rem:cyclic_window_operators,
+        lem:closure_property_boundary_block_window_trace_ground_space_map}
+    Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0<M$, and
+    $D\ge1$. Let
+    \[
+        \psi=\Gamma_{M+1}(X)
+    \]
+    and assume that every cyclic restriction of length $L_0+1$ belongs to
+    $G_{L_0+1}(A)$. Then there are boundary matrices $Y_\nu$, indexed by
+    nonempty complementary words $\nu$ of length $M+1-(L_0+1)$, such that, for
+    every word $\alpha$ of length $L_0$ and every word $\beta$ of length $L_0$,
+    \[
+        \operatorname{tr}\left(A^\beta X A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^\beta A^\alpha Y_\nu\right).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \notready
+    Lemma~\ref{lem:closure_property_boundary_block_window_trace_ground_space_map}
+    gives the same identity when the left probe is a single letter:
+    \[
+        \operatorname{tr}\left(A^j X A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
+    \]
+    For a word $\beta=j_1\cdots j_{L_0}$, write
+    $\beta_{\le r}=j_1\cdots j_r$. The periodic-boundary reconstruction proceeds
+    by proving, for every $1\le r\le L_0$, that the cyclic restrictions crossing
+    the cut give
+    \[
+        \operatorname{tr}\left(A^{\beta_{\le r}} X A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^{\beta_{\le r}} A^\alpha Y_\nu\right).
+    \]
+    The case $r=1$ is the preceding lemma, and the case $r=L_0$ gives the
+    asserted identity for every length-$L_0$ probe $A^\beta$.
+\end{proof}
+
 \begin{theorem}[Length-word trace separation for the boundary block window]
     \label{thm:block_window_matrix_equation_trace_word_products}
     \lean{MPSTensor.block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective}
@@ -196,9 +239,8 @@ from the cyclic-window constraints crossing the periodic cut.
 \begin{lemma}[Matrix identity $X A^\alpha A^\nu=A^\alpha Y_\nu$ from cyclic-window constraints]
     \label{lem:closure_property_boundary_block_window_equation_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}
-    \leanok
     \uses{def:ground_space_map, rem:cyclic_window_operators,
-        lem:closure_property_boundary_block_window_trace_ground_space_map,
+        thm:closure_property_boundary_block_window_trace_word_ground_space_map,
         thm:block_window_matrix_equation_trace_word_products}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0<M$, and
     $D\ge1$. Let
@@ -216,19 +258,8 @@ from the cyclic-window constraints crossing the periodic cut.
 
 \begin{proof}
     \notready
-    This is the boundary-matrix formulation of the inverting-and-growing-back
-    argument at the periodic boundary in
-    \cite[Section~IV.C, lines~2078--2079]{Cirac2021Matrix}. The preceding
-    lemma proves the trace identities
-    \[
-        \operatorname{tr}\left(A^j X A^\alpha A^\nu\right)
-        =
-        \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
-    \]
-    These identities test the matrix difference after left multiplication by
-    $A^j$. They do not by themselves test against every length-$L_0$ word
-    product. The remaining step is to prove, for every word $\beta$ of length
-    $L_0$,
+    Theorem~\ref{thm:closure_property_boundary_block_window_trace_word_ground_space_map}
+    gives, for every word $\beta$ of length $L_0$,
     \[
         \operatorname{tr}\left(A^\beta X A^\alpha A^\nu\right)
         =

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -92,8 +92,7 @@ are named \path{IsNormal A} and \path{IsNBlkInjective A L0}, together with
 \path{L0 < L <= N}.}
 
 The blueprint records the corresponding closure-property step in
-``Closure-property step toward uniqueness of the ground state'' in
-\path{blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex}:1403--1417, labelled
+\path{blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex}, labelled
 \path{thm:normal_range_reduction_containment}. Its proof sketch separates the
 open-chain intersection iteration from the comparison at the periodic boundary,
 matching the source distinction between the intersection property and the
@@ -133,13 +132,19 @@ through the older single-site intersection lemma.
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:328 for
 \path{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}.}
 
-\section{The remaining commutation identity}
+\section{The remaining block-window identity}
 
 After the open-boundary range reduction, a periodic-boundary ground state can
-be written in trace form with a matrix $X$. The point left to prove is that the
-cyclic length-$L_0+1$ constraints force $X$ to commute with the one-site
-matrices of $A$; block injectivity then forces $X$ to be scalar, and hence the
-state lies in \(\mathbb C\,\Omega_N(A)\).
+be written in trace form with a matrix \(X\). The point left to prove is the
+block-window identity
+\[
+  XA^\alpha A^\nu=A^\alpha Y_\nu
+\]
+for every length-\(L_0\) word \(\alpha\) and every nonempty complementary word
+\(\nu\). The block-injective commutation lemma then gives
+\(XA^k=A^kX\) for every one-site matrix of \(A\). Block injectivity finally
+forces \(X\) to be scalar, and hence the state lies in
+\(\mathbb C\,\Omega_N(A)\).
 
 This is why the open-chain containment cannot simply be reversed. Let
 \(\Gamma_N(X)\) denote the length-\(N\) trace-form vector
@@ -180,10 +185,10 @@ Here \(W_\eta\) is the boundary-restriction matrix for the boundary-crossing
 restriction beginning at the last site, and \(V_\eta\) is the
 boundary-restriction matrix for the second boundary-crossing restriction.
 \footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:338 for
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean} for
 \path{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
 and
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:371--372 for the use of
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosing.lean} for
 \path{MPSTensor.closure_property_boundary_one_sided_products_of_groundSpaceMap}.}
 This local matrix comparison gives the following commutation identity through
 the block-injective commutation lemma: for every physical letter \(k\),
@@ -194,8 +199,8 @@ This is the one-site commutation step in the periodic-boundary closure-property
 argument.\footnote{
 In the formal proof of
 \leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap},
-the commutation identity is obtained at
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:376--378.}
+the commutation identity is obtained from
+\leanid{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}.}
 
 For an \(N\)-site vector \(\psi\),
 \(\operatorname{Res}^{\tau}_{i,L}(\psi)\) denotes the \(L\)-site vector whose
@@ -218,9 +223,9 @@ the two cyclic restrictions
 Thus the equality of boundary restrictions is no longer the primitive open
 comparison: it is a checked consequence of the one-sided products and the
 commutation identity.\footnote{Formal locations:
-\path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:134 for
+\path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean} for
 \leanid{MPSTensor.boundary_restrictions_eq_of_commutes_and_one_sided}, and
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:379 for its
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean} for its
 use in
 \leanid{MPSTensor.closure_property_boundary_restrictions_eq_of_groundSpaceMap}.}
 
@@ -232,7 +237,7 @@ length-\(L_0\) word \(\alpha\) and every complementary word \(\nu\),
   XA^\alpha A^\nu=A^\alpha Y_\nu,
 \]
 then \(XA^k=A^kX\) for every physical letter \(k\).\footnote{Formal location:
-\path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean}:46 for
+\path{TNLean/MPS/ParentHamiltonian/BoundaryMatrixBlock.lean} for
 \leanid{MPSTensor.boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq}.}
 The trace rotation at the last cyclic window has now been isolated as the
 identity
@@ -248,10 +253,12 @@ These identities pair the matrix difference only with the single letters
 \(L_0\)-block-injective tensor. The remaining mathematical task is to obtain
 the corresponding trace identities against all length-\(L_0\) word products
 \(A^\beta\), or an equivalent coordinate comparison; those products span the
-full matrix algebra by block injectivity. The trace-separation theorem records
-the algebraic consequence: if these length-\(L_0\) trace identities are known,
-then \(XA^\alpha A^\nu=A^\alpha Y_\nu\).\footnote{Formal location:
-\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean}:213 for
+full matrix algebra by block injectivity.\footnote{The open formal statement is
+\leanid{MPSTensor.closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap}.}
+The trace-separation theorem records the algebraic consequence: if these
+length-\(L_0\) trace identities are known, then
+\(XA^\alpha A^\nu=A^\alpha Y_\nu\).\footnote{Formal location:
+\path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean} for
 \leanid{MPSTensor.block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective}.}
 After that equation is proved from the cyclic-window constraints, the
 block-injective commutation lemma supplies the one-site commutation identity,
@@ -329,12 +336,15 @@ through the boundary-crossing word in the periodic-boundary comparison.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.
-The last mathematical point is the commutation identity \(XA^k=A^kX\) for every
-physical letter \(k\). The present formalization proves that the full
-boundary-restriction equality follows from this identity and the one-sided
-boundary products. If this local matrix equation proves the commutation identity,
-the remaining difference is only expository. If it reveals an additional
-mathematical obstruction, the conclusion should be revised accordingly.
+The last mathematical point is to derive, from the cyclic length-\((L_0+1)\)
+constraints at the periodic boundary, matrices \(Y_\nu\) satisfying
+\[
+  XA^\alpha A^\nu=A^\alpha Y_\nu
+\]
+for every length-\(L_0\) word \(\alpha\) and every nonempty complementary word
+\(\nu\). The block-injective commutation lemma then gives \(XA^k=A^kX\) for
+every physical letter \(k\), and the verified boundary-restriction equality
+lemma supplies the periodic-boundary comparison.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- Issue #2405 is narrowed to one precise periodic-boundary step: obtain trace identities against all length-$L_0$ word products from the cyclic-window constraints in arXiv:2011.12127, §IV.C, lines 2078–2090.
- The algebraic step from those identities to $X A^\alpha A^\nu = A^\alpha Y_\nu$ is already proved on `main`.

### Description

- Add `closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap`, whose statement is exactly the remaining length-$L_0$ trace identity
  $$\operatorname{tr}(A^\beta X A^\alpha A^\nu) = \operatorname{tr}(A^\beta A^\alpha Y_\nu)$$
  for all length-$L_0$ words $\alpha, \beta$ and every complementary word $\nu$.
- Refactor `closure_property_boundary_block_window_equation_of_groundSpaceMap` to compose the above trace statement with `block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective`.
- Update blueprint ch13 (`ch13_parent_hamiltonian_normal_closing.tex`) with the matching theorem and a formula-first proof sketch.
- Update `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`: remove a stale blueprint line range and restate the remaining step as the block-window identity, not merely the later commutation consequence.
- The single `sorry` in `BoundaryClosingStripping.lean` is moved to the new length-word trace theorem; the remaining obligation is now visible at the correct mathematical level. This PR does not close #2405.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Refs #2405

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure and documentation only; no behavior change beyond relocating the single `sorry` to the correctly scoped formal statement.
> 
> **Overview**
> **Isolates issue #2405** by naming the missing periodic-boundary step explicitly: trace identities with **all length-\(L_0\)** left probes \(A^\beta\), not only single-letter \(A^j\).
> 
> Adds `closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap` (obtains \(Y_\nu\) from the existing one-letter trace lemma, then **`sorry`** on extending probes). **`closure_property_boundary_block_window_equation_of_groundSpaceMap`** is refactored to chain that theorem with the already-proved `block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective`, so the open obligation sits at the trace layer instead of inside the matrix-equation proof.
> 
> Blueprint **ch13** gets a matching `\notready` theorem and proof sketch (prefix-word induction); the block-window lemma proof now cites it. **`cpgsv21_normal_range_reduction.tex`** reframes the remaining gap as deriving \(XA^\alpha A^\nu = A^\alpha Y_\nu\) (block-window identity), with updated Lean cross-references and without stale blueprint line ranges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5496d63eb29d5f131a613995c90c1ac61f20f838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

