### PR TITLE
feat(MPS/Examples): formalize the Majumdar-Ghosh state as an MPS (#2319)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -304,6 +304,7 @@ import TNLean.MPS.Examples.Cluster
 import TNLean.MPS.Examples.EvenParity
 import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.Examples.GHZParentHamiltonian
+import TNLean.MPS.Examples.MajumdarGhosh
 import TNLean.MPS.Examples.ZMod2
 
 -- Layer 5b: Renormalization fixed points (RFP) — pure-state scaffolding

--- a/TNLean/MPS/Examples/MajumdarGhosh.lean
+++ b/TNLean/MPS/Examples/MajumdarGhosh.lean
@@ -1,0 +1,350 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Defs
+import TNLean.MPS.Core.Transfer
+
+/-!
+# Majumdar-Ghosh state as a Matrix Product State
+
+This module defines the Majumdar-Ghosh (MG) state as a concrete MPS tensor with
+physical dimension `d = 2` (spin-1/2) and bond dimension `D = 3`, and proves its
+key properties.
+
+The Majumdar-Ghosh state is the exact dimer ground state of the spin-1/2 chain
+`H = ∑ Sᵢ · Sᵢ₊₁ + ½ ∑ Sᵢ · Sᵢ₊₂`.  On an even periodic chain it is the
+superposition of the two nearest-neighbour dimer (singlet) coverings,
+`(1,2)(3,4)…` and `(2,3)(4,5)…(N,1)`, and is the one-dimensional analogue of a
+resonating valence-bond state.
+
+## Bond dimension and the source notation
+
+The review of arXiv:2011.12127 (lines 2397-2405) writes the tensor in the
+valence-bond shorthand
+\(A = [|0⟩((02| + (20|) + |1⟩((12| + (21|)] \otimes Y\), with
+\[
+Y =
+\begin{pmatrix}
+0 & -1 \\
+1 & 0
+\end{pmatrix}
+\]
+encoding the singlet.  Read literally as \((ab|=|a⟩⟨b|\) on a separate
+three-level factor tensored with the two-level singlet space, that shorthand
+would describe a six-dimensional bond. Its two-site contractions do not have the
+singlet-pair support pattern: same-letter traces can be nonzero while
+opposite-letter traces vanish. The shorthand is therefore treated here as a
+schematic of the valence-bond construction. After the singlet \(Y\) is
+contracted, the resulting matrix product operator acts on a three-dimensional
+bond, with the antisymmetry of \(Y\) supplying the relative sign
+\(-1/\sqrt{2}\) below.
+
+The tensor below is the bond-dimension-three contracted representative used in
+this example. The file proves its left-canonical equation, transfer-map value,
+non-injectivity, and non-normality. The equality between its matrix product
+vectors and the even-ring Majumdar-Ghosh dimer superposition is not yet
+formalized; the source-notation gap is recorded in
+`docs/paper-gaps/rmp_majumdar_ghosh_tensor_gap.tex`.
+
+The three bond levels are the two spin-1/2 values of an open singlet partner
+together with the closed inter-dimer link.
+
+## Main definitions
+
+* `majumdarGhoshTensor` : the Majumdar-Ghosh MPS tensor with
+  \(A^0\) having nonzero entries \((A^0)_{01}=1\) and
+  \((A^0)_{20}=1/\sqrt{2}\), and \(A^1\) having nonzero entries
+  \((A^1)_{02}=1\) and \((A^1)_{10}=-1/\sqrt{2}\)
+
+## Main results
+
+* `majumdarGhosh_left_canonical` : the tensor is in left-canonical (isometric)
+  form, `(A⁰)ᴴ A⁰ + (A¹)ᴴ A¹ = 1`
+* `majumdarGhosh_transferMap_one` : the transfer map sends the identity to
+  `diag(2, 1/2, 1/2)`
+* `majumdarGhosh_not_isInjective` : the tensor is not injective
+* `majumdarGhosh_not_isNBlkInjective_one` / `_two` : the tensor is not 1- or
+  2-block injective
+* `majumdarGhosh_not_isNormal` : the tensor is not normal, as no blocking length
+  makes it block injective, matching the two-periodic dimer-covering structure
+  of the physical example
+
+## References
+
+* RMP review (arXiv:2011.12127) lines 2397-2405
+* Verstraete, Cirac — Computational power of PEPS
+* Majumdar, Ghosh (1969) — original dimer model
+-/
+
+open scoped Matrix BigOperators
+open Matrix Finset MPSTensor
+
+noncomputable section
+
+namespace MPSTensor
+
+/-! ### Definition -/
+
+/-- The Majumdar-Ghosh MPS tensor: a spin-1/2 chain with physical dimension
+2 and bond dimension 3.
+
+\[
+A^0 =
+\begin{pmatrix}
+0 & 1 & 0 \\
+0 & 0 & 0 \\
+1/\sqrt{2} & 0 & 0
+\end{pmatrix},
+\qquad
+A^1 =
+\begin{pmatrix}
+0 & 0 & 1 \\
+-1/\sqrt{2} & 0 & 0 \\
+0 & 0 & 0
+\end{pmatrix}.
+\]
+
+The relative sign in \(A^1\) is the antisymmetry of the singlet \(Y\). -/
+def majumdarGhoshTensor : MPSTensor 2 3 := fun i =>
+  match i with
+  | 0 => !![0, 1, 0; 0, 0, 0; (↑(1 / Real.sqrt 2) : ℂ), 0, 0]
+  | 1 => !![0, 0, 1; -(↑(1 / Real.sqrt 2) : ℂ), 0, 0; 0, 0, 0]
+
+@[simp]
+lemma majumdarGhoshTensor_zero :
+    majumdarGhoshTensor 0 = !![0, 1, 0; 0, 0, 0; (↑(1 / Real.sqrt 2) : ℂ), 0, 0] := rfl
+
+@[simp]
+lemma majumdarGhoshTensor_one :
+    majumdarGhoshTensor 1 = !![0, 0, 1; -(↑(1 / Real.sqrt 2) : ℂ), 0, 0; 0, 0, 0] := rfl
+
+/-! ### Scalar arithmetic -/
+
+private lemma inv_ofReal_sqrt2_mul_self :
+    (↑(Real.sqrt 2) : ℂ)⁻¹ * (↑(Real.sqrt 2) : ℂ)⁻¹ = 1 / 2 := by
+  rw [← mul_inv, ← Complex.ofReal_mul, Real.mul_self_sqrt (by positivity)]
+  norm_num
+
+/-! ### Conjugate transposes -/
+
+@[simp]
+lemma majumdarGhoshTensor_zero_conjTranspose :
+    (majumdarGhoshTensor 0)ᴴ = !![0, 0, (↑(1 / Real.sqrt 2) : ℂ); 1, 0, 0; 0, 0, 0] := by
+  ext a b; fin_cases a <;> fin_cases b <;>
+    simp [majumdarGhoshTensor, Matrix.conjTranspose_apply, Complex.conj_ofReal]
+
+@[simp]
+lemma majumdarGhoshTensor_one_conjTranspose :
+    (majumdarGhoshTensor 1)ᴴ = !![0, -(↑(1 / Real.sqrt 2) : ℂ), 0; 0, 0, 0; 1, 0, 0] := by
+  ext a b; fin_cases a <;> fin_cases b <;>
+    simp [majumdarGhoshTensor, Matrix.conjTranspose_apply, Complex.conj_ofReal]
+
+/-! ### Canonical form and transfer map -/
+
+/-- The Majumdar-Ghosh tensor is in left-canonical (isometric) form:
+`(A⁰)ᴴ A⁰ + (A¹)ᴴ A¹ = 1`. -/
+theorem majumdarGhosh_left_canonical :
+    (majumdarGhoshTensor 0)ᴴ * majumdarGhoshTensor 0 +
+      (majumdarGhoshTensor 1)ᴴ * majumdarGhoshTensor 1 = 1 := by
+  ext a b
+  fin_cases a <;> fin_cases b <;>
+    simp [majumdarGhoshTensor, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Fin.sum_univ_three, Complex.conj_ofReal, inv_ofReal_sqrt2_mul_self]
+  all_goals norm_num
+
+/-- The transfer map of the Majumdar-Ghosh tensor sends the identity to
+`E(1) = A⁰ (A⁰)ᴴ + A¹ (A¹)ᴴ = diag(2, 1/2, 1/2)`. -/
+theorem majumdarGhosh_transferMap_one :
+    transferMap majumdarGhoshTensor 1 =
+      !![2, 0, 0; 0, 1 / 2, 0; 0, 0, 1 / 2] := by
+  ext a b
+  simp only [transferMap_apply, Fin.sum_univ_two, Matrix.mul_one, Matrix.add_apply]
+  fin_cases a <;> fin_cases b <;>
+    simp [majumdarGhoshTensor, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      Fin.sum_univ_three, Complex.conj_ofReal, inv_ofReal_sqrt2_mul_self]
+  all_goals norm_num
+
+/-! ### Non-injectivity -/
+
+/-- The Majumdar-Ghosh tensor is **not** injective: the span of `{A⁰, A¹}` lies
+in the proper subspace of matrices whose `(2,2)` entry vanishes, so it is at most
+two-dimensional and cannot be all of `M₃(ℂ)`. -/
+theorem majumdarGhosh_not_isInjective : ¬ IsInjective majumdarGhoshTensor := by
+  intro h
+  have hmem : (1 : Matrix (Fin 3) (Fin 3) ℂ) ∈
+      Submodule.span ℂ (Set.range majumdarGhoshTensor) := h ▸ Submodule.mem_top
+  suffices hzero : ∀ M ∈ Submodule.span ℂ (Set.range majumdarGhoshTensor), M 2 2 = 0 by
+    have h1 := hzero _ hmem
+    simp at h1
+  intro M hM
+  induction hM using Submodule.span_induction with
+  | mem x hx =>
+    obtain ⟨k, rfl⟩ := hx
+    fin_cases k <;> simp [majumdarGhoshTensor]
+  | zero => simp
+  | add x y _ _ hx hy => simp [Matrix.add_apply, hx, hy]
+  | smul c x _ hx => simp [Matrix.smul_apply, hx]
+
+/-! ### Non-normality
+
+The Majumdar-Ghosh state is a symmetry-broken cat of the two nearest-neighbour
+dimer coverings, so its tensor is non-normal: no blocking length makes the
+length-`N` products span the full matrix algebra `M₃(ℂ)`.  The obstruction is a
+two-periodic grading of the bond.  Write
+`oddSet = {(0,1), (0,2), (1,0), (2,0)}` and
+`evenSet = {(0,0), (1,1), (1,2), (2,1), (2,2)}` for the two complementary sets of
+matrix positions.  Each generator `Aⁱ` is supported on `oddSet`, and the two sets
+are exchanged under left multiplication by an `Aⁱ`.  Consequently every
+odd-length product is supported on `oddSet` (so its `(2,2)` entry vanishes) and
+every even-length product is supported on `evenSet` (so its `(1,0)` entry
+vanishes).  Either way the length-`N` span misses a basic matrix unit. -/
+
+-- Each subgoal expands the entry of `Aⁱ * evalWord w` over both physical indices
+-- `i` with a single uniform `simp` carrying every vanishing entry of the tail; for
+-- any one index only the subset that survives the sparse row of `Aⁱ` is used, so
+-- `linter.unusedSimpArgs` is disabled rather than splitting into per-index fact lists.
+set_option linter.unusedSimpArgs false in
+/-- The `(2,2)` entry of any odd-length Majumdar-Ghosh product and the `(1,0)`
+entry of any even-length product both vanish.  Proved by induction on the word,
+using that left multiplication by a generator exchanges the two complementary
+support sets. -/
+private lemma majumdarGhosh_evalWord_grading :
+    ∀ w : List (Fin 2),
+      ((Odd w.length → (evalWord majumdarGhoshTensor w) 2 2 = 0) ∧
+        (Odd w.length → (evalWord majumdarGhoshTensor w) 1 1 = 0) ∧
+        (Odd w.length → (evalWord majumdarGhoshTensor w) 1 2 = 0) ∧
+        (Odd w.length → (evalWord majumdarGhoshTensor w) 2 1 = 0) ∧
+        (Odd w.length → (evalWord majumdarGhoshTensor w) 0 0 = 0)) ∧
+      ((Even w.length → (evalWord majumdarGhoshTensor w) 0 1 = 0) ∧
+        (Even w.length → (evalWord majumdarGhoshTensor w) 0 2 = 0) ∧
+        (Even w.length → (evalWord majumdarGhoshTensor w) 1 0 = 0) ∧
+        (Even w.length → (evalWord majumdarGhoshTensor w) 2 0 = 0)) := by
+  intro w
+  induction w with
+  | nil =>
+    refine ⟨⟨?_, ?_, ?_, ?_, ?_⟩, ?_, ?_, ?_, ?_⟩ <;>
+      simp only [List.length_nil] <;> intro h <;> simp at h ⊢
+  | cons i w ih =>
+    obtain ⟨⟨ho22, ho11, ho12, ho21, ho00⟩, he01, he02, he10, he20⟩ := ih
+    -- An odd-length `i :: w` has an even-length tail `w`, and conversely.
+    have hodd_tail : Odd (i :: w).length → Even w.length := fun h => by
+      rw [List.length_cons, Nat.odd_add_one, Nat.not_odd_iff_even] at h; exact h
+    have heven_tail : Even (i :: w).length → Odd w.length := fun h => by
+      rw [List.length_cons, Nat.even_add_one, Nat.not_even_iff_odd] at h; exact h
+    -- Odd-length targets use the even-support vanishing entries of the tail.
+    refine ⟨⟨fun h => ?_, fun h => ?_, fun h => ?_, fun h => ?_, fun h => ?_⟩,
+      fun h => ?_, fun h => ?_, fun h => ?_, fun h => ?_⟩
+    · have hw := hodd_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          he01 hw, he02 hw, he10 hw, he20 hw]
+    · have hw := hodd_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          he01 hw, he02 hw, he10 hw, he20 hw]
+    · have hw := hodd_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          he01 hw, he02 hw, he10 hw, he20 hw]
+    · have hw := hodd_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          he01 hw, he02 hw, he10 hw, he20 hw]
+    · have hw := hodd_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          he01 hw, he02 hw, he10 hw, he20 hw]
+    -- Even-length targets use the odd-support vanishing entries of the tail.
+    · have hw := heven_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          ho22 hw, ho11 hw, ho12 hw, ho21 hw, ho00 hw]
+    · have hw := heven_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          ho22 hw, ho11 hw, ho12 hw, ho21 hw, ho00 hw]
+    · have hw := heven_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          ho22 hw, ho11 hw, ho12 hw, ho21 hw, ho00 hw]
+    · have hw := heven_tail h
+      rw [evalWord_cons]; fin_cases i <;>
+        simp [majumdarGhoshTensor, Matrix.mul_apply, Fin.sum_univ_three,
+          ho22 hw, ho11 hw, ho12 hw, ho21 hw, ho00 hw]
+
+/-- For odd-length words the `(2,2)` entry of the Majumdar-Ghosh product vanishes. -/
+private lemma majumdarGhosh_evalWord_22_of_odd {w : List (Fin 2)} (hw : Odd w.length) :
+    (evalWord majumdarGhoshTensor w) 2 2 = 0 :=
+  (majumdarGhosh_evalWord_grading w).1.1 hw
+
+/-- For even-length words the `(1,0)` entry of the Majumdar-Ghosh product vanishes. -/
+private lemma majumdarGhosh_evalWord_10_of_even {w : List (Fin 2)} (hw : Even w.length) :
+    (evalWord majumdarGhoshTensor w) 1 0 = 0 :=
+  (majumdarGhosh_evalWord_grading w).2.2.2.1 hw
+
+/-- The Majumdar-Ghosh tensor is not `N`-block injective for any odd `N`: the
+`(2,2)` matrix unit is not in the span of the length-`N` products. -/
+theorem majumdarGhosh_not_isNBlkInjective_of_odd {N : ℕ} (hN : Odd N) :
+    ¬ IsNBlkInjective majumdarGhoshTensor N := by
+  intro h
+  have hmem : Matrix.single (2 : Fin 3) (2 : Fin 3) (1 : ℂ) ∈
+      Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
+        evalWord majumdarGhoshTensor (List.ofFn σ)) := h ▸ Submodule.mem_top
+  suffices hzero : ∀ M ∈ Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
+      evalWord majumdarGhoshTensor (List.ofFn σ)), M 2 2 = 0 by
+    have h1 := hzero _ hmem
+    simp [Matrix.single] at h1
+  intro M hM
+  induction hM using Submodule.span_induction with
+  | mem x hx =>
+    obtain ⟨σ, rfl⟩ := hx
+    exact majumdarGhosh_evalWord_22_of_odd (by simpa [List.length_ofFn] using hN)
+  | zero => simp
+  | add x y _ _ hx hy => simp [Matrix.add_apply, hx, hy]
+  | smul c x _ hx => simp [Matrix.smul_apply, hx]
+
+/-- The Majumdar-Ghosh tensor is not `N`-block injective for any even `N`: the
+`(1,0)` matrix unit is not in the span of the length-`N` products. -/
+theorem majumdarGhosh_not_isNBlkInjective_of_even {N : ℕ} (hN : Even N) :
+    ¬ IsNBlkInjective majumdarGhoshTensor N := by
+  intro h
+  have hmem : Matrix.single (1 : Fin 3) (0 : Fin 3) (1 : ℂ) ∈
+      Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
+        evalWord majumdarGhoshTensor (List.ofFn σ)) := h ▸ Submodule.mem_top
+  suffices hzero : ∀ M ∈ Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
+      evalWord majumdarGhoshTensor (List.ofFn σ)), M 1 0 = 0 by
+    have h1 := hzero _ hmem
+    simp [Matrix.single] at h1
+  intro M hM
+  induction hM using Submodule.span_induction with
+  | mem x hx =>
+    obtain ⟨σ, rfl⟩ := hx
+    exact majumdarGhosh_evalWord_10_of_even (by simpa [List.length_ofFn] using hN)
+  | zero => simp
+  | add x y _ _ hx hy => simp [Matrix.add_apply, hx, hy]
+  | smul c x _ hx => simp [Matrix.smul_apply, hx]
+
+/-- The Majumdar-Ghosh tensor is not `1`-block injective. -/
+theorem majumdarGhosh_not_isNBlkInjective_one :
+    ¬ IsNBlkInjective majumdarGhoshTensor 1 :=
+  majumdarGhosh_not_isNBlkInjective_of_odd (by decide)
+
+/-- The Majumdar-Ghosh tensor is not `2`-block injective. -/
+theorem majumdarGhosh_not_isNBlkInjective_two :
+    ¬ IsNBlkInjective majumdarGhoshTensor 2 :=
+  majumdarGhosh_not_isNBlkInjective_of_even (by decide)
+
+/-- The Majumdar-Ghosh tensor is **not** normal: no blocking length `N` makes it
+`N`-block injective.  This algebraic obstruction matches the expected
+two-dimer-covering structure: the bond carries a two-periodic grading that no
+amount of blocking removes. -/
+theorem majumdarGhosh_not_isNormal : ¬ IsNormal majumdarGhoshTensor := by
+  rintro ⟨N, hN⟩
+  rcases Nat.even_or_odd N with he | ho
+  · exact majumdarGhosh_not_isNBlkInjective_of_even he hN
+  · exact majumdarGhosh_not_isNBlkInjective_of_odd ho hN
+
+end MPSTensor
+
+end

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -335,6 +335,136 @@ symmetry-protected topological (SPT) order.
 \end{remark}
 
 %% ===================================================================
+\section{The Majumdar--Ghosh state}\label{sec:majumdar_ghosh}
+%% ===================================================================
+
+The Majumdar--Ghosh state is the exact dimer ground state of the spin-$\tfrac12$
+chain
+$H=\sum \boldsymbol{S}_i\cdot\boldsymbol{S}_{i+1}
++\tfrac12\sum\boldsymbol{S}_i\cdot\boldsymbol{S}_{i+2}$.
+On an even periodic chain it is the symmetric superposition of the two
+nearest-neighbour singlet coverings $(1,2)(3,4)\cdots$ and
+$(2,3)(4,5)\cdots(N,1)$, the one-dimensional analogue of a
+resonating valence-bond state.
+
+\begin{definition}[Majumdar--Ghosh tensor]\label{def:majumdar_ghosh_tensor}
+    \lean{MPSTensor.majumdarGhoshTensor}
+    \leanok
+    \uses{def:mps_tensor}
+    Set $d = 2$ (spin-$\tfrac12$) and $D = 3$. The Majumdar--Ghosh tensor is
+    the family $\{A^0, A^1\} \subset \MN{3}$ defined by
+    \[
+        A^0 =
+        \begin{pmatrix} 0 & 1 & 0 \\ 0 & 0 & 0 \\ \tfrac1{\sqrt2} & 0 & 0 \end{pmatrix},
+        \qquad
+        A^1 =
+        \begin{pmatrix} 0 & 0 & 1 \\ -\tfrac1{\sqrt2} & 0 & 0 \\ 0 & 0 & 0 \end{pmatrix}.
+    \]
+    The three bond levels are the two spin-$\tfrac12$ values of an open singlet
+    partner together with the closed inter-dimer link; the relative sign
+    $-\tfrac1{\sqrt2}$ is the antisymmetry of the singlet.  The equality between
+    the matrix product vectors of these matrices and the even-ring dimer
+    superposition, with normalization and cyclic convention fixed, is a separate
+    verification, not part of this definition.
+\end{definition}
+
+\begin{theorem}[Majumdar--Ghosh tensor is in left-canonical form]%
+\label{thm:majumdar_ghosh_left_canonical}
+    \lean{MPSTensor.majumdarGhosh_left_canonical}
+    \leanok
+    \uses{def:majumdar_ghosh_tensor}
+    The Majumdar--Ghosh tensor is isometric: $(A^0)^\dagger A^0 + (A^1)^\dagger A^1
+    = \mathbb 1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Direct multiplication of the two displayed matrices gives
+    $(A^0)^\dagger A^0=\diag(\tfrac12,1,0)$ and
+    $(A^1)^\dagger A^1=\diag(\tfrac12,0,1)$.
+\end{proof}
+
+\begin{theorem}[Transfer map of the Majumdar--Ghosh tensor]%
+\label{thm:majumdar_ghosh_transfer}
+    \lean{MPSTensor.majumdarGhosh_transferMap_one}
+    \leanok
+    \uses{def:majumdar_ghosh_tensor, def:transfer_map}
+    The transfer map of the Majumdar--Ghosh tensor sends the identity to the
+    diagonal matrix $\E_A(\mathbb 1) = \diag(2, \tfrac12, \tfrac12)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Substitute the two matrices in
+    $\E_A(\mathbb 1)=A^0(A^0)^\dagger+A^1(A^1)^\dagger$ and multiply.
+\end{proof}
+
+\begin{theorem}[Majumdar--Ghosh tensor is not injective]%
+\label{thm:majumdar_ghosh_not_injective}
+    \lean{MPSTensor.majumdarGhosh_not_isInjective}
+    \leanok
+    \uses{def:majumdar_ghosh_tensor, def:injective}
+    The Majumdar--Ghosh tensor is not injective: every element of
+    $\spn_{\C}\{A^0, A^1\}$ has vanishing $(2,2)$ entry, so the span is a proper
+    subspace of~$\MN{3}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The matrix unit $E_{22}$ has nonzero $(2,2)$ entry, while every linear
+    combination of $A^0$ and $A^1$ has zero $(2,2)$ entry.
+\end{proof}
+
+\begin{theorem}[Majumdar--Ghosh tensor is not normal]%
+\label{thm:majumdar_ghosh_not_normal}
+    \lean{MPSTensor.majumdarGhosh_not_isNormal}
+    \leanok
+    \uses{def:majumdar_ghosh_tensor, def:normal}
+    The Majumdar--Ghosh tensor is not normal: no blocking length makes the
+    products of that length span the full matrix algebra~$\MN{3}$.  This
+    non-normality is the algebraic signature expected from the two-periodic
+    dimer-covering structure.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The bond carries a two-periodic grading with complementary support sets
+    $\{(0,1),(0,2),(1,0),(2,0)\}$ and $\{(0,0),(1,1),(1,2),(2,1),(2,2)\}$ that
+    are exchanged by left multiplication with a generator. Let $E_{ij}$ denote
+    the $(i,j)$ matrix unit. Then, for every blocking length $N$,
+    \begin{align*}
+        N\text{ odd}
+        &\Rightarrow
+        \bigl(\forall w,\ |w|=N \Rightarrow (A^w)_{22}=0\bigr)
+        \Rightarrow
+        E_{22}\notin\spn_{\C}\{A^w: |w|=N\},\\
+        N\text{ even}
+        &\Rightarrow
+        \bigl(\forall w,\ |w|=N \Rightarrow (A^w)_{10}=0\bigr)
+        \Rightarrow
+        E_{10}\notin\spn_{\C}\{A^w: |w|=N\}.
+    \end{align*}
+    Hence no fixed-length word span is all of $\MN{3}$.
+\end{proof}
+
+\begin{remark}\label{rem:majumdar_ghosh_bond_dimension}
+    The review writes the tensor in the valence-bond shorthand
+    $A = [\ket0((02|+(20|) + \ket1((12|+(21|)]\otimes Y$ with the singlet
+    $Y = \left(\begin{smallmatrix}0 & -1 \\ 1 & 0\end{smallmatrix}\right)$.  Read
+    literally as $(ab| = \ketbra{a}{b}$ on a separate three-level factor tensored
+    with the two-level singlet space, that shorthand would describe a
+    six-dimensional bond. Its two-site contractions do not have the singlet-pair
+    support pattern: same-letter traces can be nonzero while opposite-letter
+    traces vanish. The shorthand is therefore treated here as a schematic of the
+    valence-bond construction: contracting the singlet $Y$ leaves a matrix
+    product operator on a three-dimensional bond, with the antisymmetry of $Y$
+    supplying the relative sign. The contracted tensor is the $D = 3$
+    representative in Definition~\ref{def:majumdar_ghosh_tensor}. The
+    source-notation gap and the missing matrix-product-vector identification are
+    recorded in \path{docs/paper-gaps/rmp_majumdar_ghosh_tensor_gap.tex}.
+\end{remark}
+
+%% ===================================================================
 \section{The cluster state}\label{sec:cluster}
 %% ===================================================================
 

--- a/docs/paper-gaps/rmp_majumdar_ghosh_tensor_gap.tex
+++ b/docs/paper-gaps/rmp_majumdar_ghosh_tensor_gap.tex
@@ -1,0 +1,134 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Source-Notation Gap: The Majumdar--Ghosh Example Tensor}
+\author{}
+\date{2026-06-16}
+
+\begin{document}
+\maketitle
+
+\section{The assertion}
+
+The review \cite{Cirac2021Matrix} describes the Majumdar--Ghosh model as the
+one-dimensional resonating-valence-bond state, the superposition of the two
+nearest-neighbour singlet coverings of a periodic spin-$\tfrac12$ chain.  It
+then writes the MPS tensor in the shorthand
+\begin{align}
+    A
+    =
+    \bigl[
+      |0\rangle\bigl((02|+(20|\bigr)
+      +
+      |1\rangle\bigl((12|+(21|\bigr)
+    \bigr]\otimes Y,
+    \qquad
+    Y=
+    \begin{pmatrix}0&-1\\1&0\end{pmatrix},
+    \tag{\cite[lines~2397--2405]{Cirac2021Matrix}}
+\end{align}
+where $Y$ is the singlet tensor used earlier in the examples appendix.
+
+The formal example file introduces instead the following bond-dimension-three
+matrices:
+\begin{align}
+    A^0 =
+    \begin{pmatrix}
+        0&1&0\\
+        0&0&0\\
+        1/\sqrt2&0&0
+    \end{pmatrix},
+    \qquad
+    A^1 =
+    \begin{pmatrix}
+        0&0&1\\
+        -1/\sqrt2&0&0\\
+        0&0&0
+    \end{pmatrix}.
+    \tag{formal example}
+\end{align}
+The formalized results about this tensor are its left-canonical equation, its
+transfer map on the identity, non-injectivity, and non-normality.\footnote{Formal
+declarations:
+\leanid{MPSTensor.majumdarGhoshTensor},
+\leanid{MPSTensor.majumdarGhosh\_left\_canonical},
+\leanid{MPSTensor.majumdarGhosh\_transferMap\_one},
+\leanid{MPSTensor.majumdarGhosh\_not\_isInjective}, and
+\leanid{MPSTensor.majumdarGhosh\_not\_isNormal} in
+\doclink{TNLean/MPS/Examples/MajumdarGhosh}.}
+
+\section{The point at issue}
+
+The review formula is not a literal bond-dimension-three formula.  If
+$(ab|$ is read as $|a\rangle\langle b|$ on a three-dimensional auxiliary
+factor and the displayed tensor product with $Y$ is taken literally, then the
+bond space is
+\begin{align}
+    \mathbb C^3\otimes\mathbb C^2,
+\end{align}
+so the bond dimension is $6$.  Writing
+\begin{align}
+    B^0=E_{02}+E_{20},\qquad B^1=E_{12}+E_{21},
+\end{align}
+the literal matrices would be $\widetilde A^i=B^i\otimes Y$.  Their two-site
+periodic contractions factor:
+\begin{align}
+    \tr(\widetilde A^i\widetilde A^j)
+    =
+    \tr(B^iB^j)\,\tr(Y^2).
+\end{align}
+Since $Y^2=-I_2$ and
+\begin{align}
+    \tr\bigl((B^0)^2\bigr)=2,\qquad
+    \tr\bigl((B^1)^2\bigr)=2,\qquad
+    \tr(B^0B^1)=\tr(B^1B^0)=0,
+\end{align}
+the literal two-letter amplitudes have nonzero same-letter contractions and
+zero opposite-letter contractions.  This is not the support pattern of a
+two-site singlet, whose coefficients are carried by the opposite-letter words
+$01$ and $10$ with opposite signs.
+
+Thus the review formula must be interpreted as valence-bond shorthand rather
+than as a literal $6\times6$ MPS representation.  The bond-dimension-three
+matrices above are the contracted representative used in the formal example:
+the two spin-$\tfrac12$ values of an open singlet partner and the closed
+inter-dimer link are kept as the three bond states, and the antisymmetry of
+$Y$ supplies the relative sign in $A^1$.
+
+\section{Current formal boundary}
+
+The repository does not yet contain a theorem identifying the matrix-product
+vectors of the displayed bond-dimension-three tensor with the Majumdar--Ghosh
+dimer superposition on even rings.  Such a theorem would have to state the
+finite-size vector identity, with the parity, normalization, and cyclic
+convention fixed, for example by comparing the coefficient
+\begin{align}
+    \tr(A^{i_1}\cdots A^{i_N})
+\end{align}
+with the sum of the two products of singlet coefficients on the coverings
+$(1,2)(3,4)\cdots$ and $(2,3)(4,5)\cdots(N,1)$.
+
+Until that theorem is proved, the formalized object should be described as the
+bond-dimension-three contracted representative used for the algebraic example,
+not as a formally established presentation of the Majumdar--Ghosh state itself.
+The elementary statements already proved about it remain independent of this
+identification.
+
+\section{Verdict}
+
+This is an open gap in the example's physical identification.  The literal
+reading of the review shorthand does not give the intended singlet-pair support
+pattern, while the contracted $D=3$ tensor has not yet been proved in Lean to
+produce the Majumdar--Ghosh dimer superposition.  The present formalization
+therefore records only the concrete tensor and its algebraic properties.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

Adds the Majumdar--Ghosh example tensor as an explicit `MPSTensor 2 3`, proves its elementary algebraic properties, and records the remaining source-notation gap. This advances #2319, but it does not yet prove the finite-size matrix-product-vector identity with the Majumdar--Ghosh dimer wavefunction.

**Source:** arXiv:2011.12127 (`Papers/2011.12127/TN-Review-main.tex` lines 2397--2405).

## Source Notation

The review writes the tensor in the valence-bond shorthand
$A = [\ket0((02|+(20|)+\ket1((12|+(21|)]\otimes Y$, with
$Y=\left(\begin{smallmatrix}0&-1\\1&0\end{smallmatrix}\right)$.
Read literally as $(ab|=\ket a\bra b$ on a separate three-level factor tensored with the two-level singlet space, this is a six-dimensional bond.

The PR treats that display as valence-bond shorthand rather than as a literal $D=6$ MPS tensor. The formal object is the contracted $D=3$ representative
$$A^0=\begin{pmatrix}0&1&0\\0&0&0\\\tfrac1{\sqrt2}&0&0\end{pmatrix},\qquad A^1=\begin{pmatrix}0&0&1\\-\tfrac1{\sqrt2}&0&0\\0&0&0\end{pmatrix}.$$
The equality between this tensor's periodic matrix product vectors and the even-ring Majumdar--Ghosh dimer superposition is documented as open in `docs/paper-gaps/rmp_majumdar_ghosh_tensor_gap.tex`, with the parity, normalization, and cyclic convention left for a future theorem.

## Proven Statements

- `majumdarGhoshTensor : MPSTensor 2 3`, the explicit tensor.
- `majumdarGhosh_left_canonical`, the left-canonical equation $(A^0)^\dagger A^0+(A^1)^\dagger A^1=\mathbb 1$.
- `majumdarGhosh_transferMap_one`, the identity image $\mathcal E_A(\mathbb 1)=\operatorname{diag}(2,\tfrac12,\tfrac12)$.
- Conjugate-transpose value lemmas for the two displayed matrices.
- `majumdarGhosh_not_isInjective`, non-injectivity of the one-site span.
- `majumdarGhosh_not_isNBlkInjective_of_odd` / `_of_even`, with the one- and two-block corollaries.
- `majumdarGhosh_not_isNormal`, non-normality for every blocking length.

The non-normality proof uses a two-periodic grading of the bond. The generators are supported on $\{(0,1),(0,2),(1,0),(2,0)\}$, and left multiplication by a generator exchanges this set with $\{(0,0),(1,1),(1,2),(2,1),(2,2)\}$. Hence every odd-length product has vanishing $(2,2)$ entry and every even-length product has vanishing $(1,0)$ entry, so the fixed-length product span always misses a matrix unit.

## Deferred

The parent-Hamiltonian-side twofold dimerized ground space is left for follow-up. The finite-size MPV identity with the even-ring dimer superposition is also deferred and tracked by the new paper-gap note.

## Validation

- `lake env lean TNLean/MPS/Examples/MajumdarGhosh.lean`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint pdf`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error rmp_majumdar_ghosh_tensor_gap.tex`
- `git diff --check`
- `rg -n "ofReal_inv_sqrt2_mul_self|\\b(sorry|admit|axiom|native_decide|unsafeCast)\\b" TNLean/MPS/Examples/MajumdarGhosh.lean`
