### PR TITLE
feat(MPS/Examples): AKLT correlation length and example decay of correlations (#2317)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -299,12 +299,14 @@ import TNLean.MPS.MPDO.BlockedRFPConstruction
 
 -- MPS examples
 import TNLean.MPS.Examples.AKLT
+import TNLean.MPS.Examples.AKLTCorrelation
 import TNLean.MPS.Examples.AKLTRotation
 import TNLean.MPS.Examples.Cluster
 import TNLean.MPS.Examples.EvenParity
 import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.Examples.GHZParentHamiltonian
 import TNLean.MPS.Examples.ZMod2
+import TNLean.MPS.Examples.ZeroCorrelationExamples
 
 -- Layer 5b: Renormalization fixed points (RFP) — pure-state scaffolding
 import TNLean.MPS.RFP.Defs

--- a/TNLean/MPS/Examples/AKLTCorrelation.lean
+++ b/TNLean/MPS/Examples/AKLTCorrelation.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Examples.AKLT
+import TNLean.MPS.Core.Correlations
+
+/-!
+# AKLT correlation length
+
+This module computes the spectrum of the AKLT transfer map and the resulting
+finite correlation length.  The AKLT tensor (`MPSTensor.akltTensor`) has a
+transfer map `E_A(X) = ∑ᵢ A^i X (A^i)ᴴ` with leading eigenvalue `1` and a single
+subleading eigenvalue `-1/3` of algebraic multiplicity three.  The three Pauli
+matrices `σx`, `σy`, `σz` are explicit eigenvectors for `-1/3`, while the
+identity is the eigenvector for `1`; together they form a basis of `M₂(ℂ)`, so
+the full spectrum is `{1, -1/3, -1/3, -1/3}`.
+
+The subleading eigenvalue has modulus `1/3`, so the AKLT correlation length is
+`ξ = -1/log|λ₂| = 1/log 3`, a finite value: the AKLT state has exponentially
+decaying connected correlations with decay rate `(1/3)ⁿ`.
+
+## Main results
+
+* `aklt_transferMap_sigmaZ`, `aklt_transferMap_sigmaX`, `aklt_transferMap_sigmaY`
+  — the three Pauli matrices are eigenvectors of the AKLT transfer map with
+  eigenvalue `-1/3`
+* `aklt_transferMap_hasEigenvalue_neg_third` — `-1/3` is an eigenvalue of the
+  AKLT transfer map
+* `aklt_transferMap_hasEigenvalue_one` — `1` is an eigenvalue of the AKLT
+  transfer map (the identity is the corresponding eigenvector)
+* `aklt_subleading_norm` — the subleading eigenvalue has modulus `1/3`
+* `aklt_correlationLength_eq` — the AKLT correlation length is `1/log 3`
+* `aklt_correlationLength_pos` — the AKLT correlation length is positive (finite)
+
+## References
+
+* RMP review (arXiv:2011.12127), Section 2.3 and Example III.1
+  ("Correlations, Entanglement, and the Transfer Matrix").  The AKLT transfer
+  matrix has spectrum `{1, -1/3, -1/3, -1/3}` and correlation length
+  `ξ = 1/log 3`.
+* Affleck, Kennedy, Lieb, Tasaki (1987) — original AKLT construction.
+-/
+
+open scoped Matrix BigOperators
+open Matrix MPSTensor
+
+noncomputable section
+
+namespace MPSTensor
+
+/-! ### Pauli eigenvectors of the AKLT transfer map
+
+The AKLT transfer map fixes the identity (`aklt_transferMap_one`) and scales each
+of the three Pauli matrices by `-1/3`.  These four matrices form a basis of
+`M₂(ℂ)`, so the spectrum is `{1, -1/3, -1/3, -1/3}`. -/
+
+/-- `(√3)² = 3` as a complex equation. -/
+private lemma aklt_sqrt3_sq : (↑(Real.sqrt 3) : ℂ) ^ 2 = 3 := by
+  rw [← Complex.ofReal_pow, Real.sq_sqrt (by positivity), Complex.ofReal_ofNat]
+
+/-- `(√2)² = 2` as a complex equation. -/
+private lemma aklt_sqrt2_sq : (↑(Real.sqrt 2) : ℂ) ^ 2 = 2 := by
+  rw [← Complex.ofReal_pow, Real.sq_sqrt (by positivity), Complex.ofReal_ofNat]
+
+/-- `σz = diag(1, -1)` is an eigenvector of the AKLT transfer map with eigenvalue
+`-1/3`. -/
+theorem aklt_transferMap_sigmaZ :
+    transferMap akltTensor (!![(1 : ℂ), 0; 0, -1]) =
+      (-1 / 3 : ℂ) • !![(1 : ℂ), 0; 0, -1] := by
+  ext i j
+  simp only [transferMap_apply, Fin.sum_univ_three, Matrix.add_apply,
+    akltTensor_conjTranspose, Matrix.smul_apply, smul_eq_mul]
+  fin_cases i <;> fin_cases j <;>
+    simp only [akltTensor, one_div, Complex.ofReal_inv, smul_of, smul_cons,
+      smul_eq_mul, mul_one, mul_zero, Matrix.smul_empty, mul_neg,
+      Fin.zero_eta, Fin.isValue, Fin.mk_one, mul_apply, of_apply, cons_val',
+      cons_val_fin_one, cons_val_zero, cons_val_one, Fin.sum_univ_two,
+      zero_mul, add_zero, zero_add, Complex.ofReal_div, neg_smul, neg_of,
+      neg_cons, neg_zero, Matrix.neg_empty, neg_mul, neg_neg] <;>
+    field_simp <;>
+    ring_nf <;>
+    norm_num [aklt_sqrt3_sq, aklt_sqrt2_sq]
+
+/-- `σx = !![0, 1; 1, 0]` is an eigenvector of the AKLT transfer map with
+eigenvalue `-1/3`. -/
+theorem aklt_transferMap_sigmaX :
+    transferMap akltTensor (!![(0 : ℂ), 1; 1, 0]) =
+      (-1 / 3 : ℂ) • !![(0 : ℂ), 1; 1, 0] := by
+  ext i j
+  simp only [transferMap_apply, Fin.sum_univ_three, Matrix.add_apply,
+    akltTensor_conjTranspose, Matrix.smul_apply, smul_eq_mul]
+  fin_cases i <;> fin_cases j <;>
+    simp only [akltTensor, one_div, Complex.ofReal_inv, smul_of, smul_cons,
+      smul_eq_mul, mul_one, mul_zero, Matrix.smul_empty, mul_neg,
+      Fin.zero_eta, Fin.isValue, Fin.mk_one, mul_apply, of_apply, cons_val',
+      cons_val_fin_one, cons_val_zero, cons_val_one, Fin.sum_univ_two,
+      zero_mul, add_zero, zero_add, Complex.ofReal_div, neg_smul, neg_of,
+      neg_cons, neg_zero, Matrix.neg_empty, neg_mul] <;>
+    field_simp <;>
+    ring_nf <;>
+    norm_num [aklt_sqrt3_sq, aklt_sqrt2_sq]
+
+/-- `σy = !![0, -i; i, 0]` is an eigenvector of the AKLT transfer map with
+eigenvalue `-1/3`.  The off-diagonal entries come only from `A⁰ = (1/√3) σz`,
+giving the prefactor `(1/√3)·(1/√3) = 1/3`; the diagonal entries vanish. -/
+theorem aklt_transferMap_sigmaY :
+    transferMap akltTensor (!![(0 : ℂ), -Complex.I; Complex.I, 0]) =
+      (-1 / 3 : ℂ) • !![(0 : ℂ), -Complex.I; Complex.I, 0] := by
+  ext i j
+  simp only [transferMap_apply, Fin.sum_univ_three, Matrix.add_apply,
+    akltTensor_conjTranspose, Matrix.smul_apply, smul_eq_mul]
+  fin_cases i <;> fin_cases j <;>
+    simp only [akltTensor, one_div, Complex.ofReal_inv, smul_of, smul_cons,
+      smul_eq_mul, mul_one, mul_zero, Matrix.smul_empty, mul_neg,
+      Fin.zero_eta, Fin.isValue, Fin.mk_one, mul_apply, of_apply, cons_val',
+      cons_val_fin_one, cons_val_zero, cons_val_one, Fin.sum_univ_two,
+      zero_mul, add_zero, zero_add, Complex.ofReal_div, neg_smul, neg_of,
+      neg_cons, neg_zero, Matrix.neg_empty, neg_mul, neg_neg] <;>
+    field_simp <;>
+    ring_nf <;>
+    norm_num [aklt_sqrt3_sq, aklt_sqrt2_sq]
+
+/-! ### Spectrum and correlation length -/
+
+/-- `σz` is a nonzero matrix, so it witnesses `-1/3` as a genuine eigenvalue. -/
+private lemma sigmaZ_ne_zero : (!![(1 : ℂ), 0; 0, -1]) ≠ 0 := by
+  intro h
+  have : (!![(1 : ℂ), 0; 0, -1]) 0 0 = (0 : Matrix (Fin 2) (Fin 2) ℂ) 0 0 := by rw [h]
+  simp at this
+
+/-- The subleading eigenvalue `-1/3` is a genuine eigenvalue of the AKLT transfer
+map, witnessed by the eigenvector `σz`. -/
+theorem aklt_transferMap_hasEigenvalue_neg_third :
+    Module.End.HasEigenvalue (transferMap akltTensor) (-1 / 3 : ℂ) :=
+  Module.End.hasEigenvalue_of_hasEigenvector
+    (Module.End.hasEigenvector_iff.mpr
+      ⟨Module.End.mem_eigenspace_iff.mpr aklt_transferMap_sigmaZ, sigmaZ_ne_zero⟩)
+
+/-- The leading eigenvalue `1` is a genuine eigenvalue of the AKLT transfer map,
+witnessed by the identity as eigenvector (`aklt_transferMap_one`). -/
+theorem aklt_transferMap_hasEigenvalue_one :
+    Module.End.HasEigenvalue (transferMap akltTensor) (1 : ℂ) :=
+  Module.End.hasEigenvalue_of_hasEigenvector
+    (Module.End.hasEigenvector_iff.mpr
+      ⟨Module.End.mem_eigenspace_iff.mpr (by rw [one_smul]; exact aklt_transferMap_one),
+        one_ne_zero⟩)
+
+/-- The subleading eigenvalue of the AKLT transfer map has modulus `1/3`. -/
+theorem aklt_subleading_norm : ‖(-1 / 3 : ℂ)‖ = 1 / 3 := by
+  rw [neg_div, norm_neg, Complex.norm_div]
+  norm_num
+
+/-- The AKLT correlation length, computed from the subleading eigenvalue
+`λ₂ = -1/3`, equals `1/log 3`.  Since `0 < 1/log 3 < ∞`, the AKLT state has a
+finite, positive correlation length: its connected correlations decay
+exponentially with rate `(1/3)ⁿ`. -/
+theorem aklt_correlationLength_eq :
+    correlationLength (-1 / 3 : ℂ) = 1 / Real.log 3 := by
+  rw [correlationLength, aklt_subleading_norm,
+    show (1 / 3 : ℝ) = (3 : ℝ)⁻¹ by norm_num, Real.log_inv]
+  rw [div_neg, neg_div, neg_neg]
+
+/-- The AKLT correlation length is positive: `0 < 1/log 3`. -/
+theorem aklt_correlationLength_pos :
+    0 < correlationLength (-1 / 3 : ℂ) := by
+  apply correlationLength_pos
+  · rw [aklt_subleading_norm]; norm_num
+  · rw [aklt_subleading_norm]; norm_num
+
+end MPSTensor
+
+end

--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -659,6 +659,50 @@ theorem cluster_hasStringOrder (g : Multiplicative (ZMod 2 × ZMod 2)) :
 
 end StringOrder
 
+/-! ### Zero correlation length
+
+The single-site cluster transfer map is not idempotent, but after blocking two
+sites the channel becomes a renormalization fixed point.  This is the
+transfer-matrix signature of zero correlation length, contrasting with the AKLT
+state whose subleading transfer-map eigenvalue `-1/3` gives a finite correlation
+length `ξ = 1/\log 3` (see `TNLean.MPS.Examples.AKLTCorrelation`). -/
+
+/-- Closed form of the blocked cluster transfer map: it sends every `X` to the
+scalar `(X₀₀ + X₁₁)/2` times the identity.  In particular its image is the
+one-dimensional space of scalars, the transfer-matrix signature of a
+renormalization fixed point. -/
+theorem clusterBlocked_transferMap_apply (X : Matrix (Fin 2) (Fin 2) ℂ) :
+    transferMap clusterBlocked X = ((X 0 0 + X 1 1) / 2 : ℂ) • 1 := by
+  ext i j
+  fin_cases i <;> fin_cases j <;>
+    simp only [transferMap_apply, Fin.sum_univ_four, clusterBlocked_zero, clusterBlocked_one,
+      clusterBlocked_two, clusterBlocked_three, Matrix.add_apply, Matrix.mul_apply,
+      Fin.sum_univ_two, Matrix.conjTranspose_apply, Matrix.smul_apply, Matrix.of_apply,
+      Matrix.cons_val', Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.empty_val',
+      Matrix.cons_val_fin_one, Matrix.one_apply, smul_eq_mul] <;>
+    norm_num [Complex.ext_iff, Complex.add_re, Complex.add_im] <;>
+    first
+      | trivial
+      | (constructor <;> ring)
+
+/-- The length-`2` blocked cluster transfer map is idempotent: `E² = E`.
+
+Using the closed form `E(X) = ((X₀₀ + X₁₁)/2)·I` (`clusterBlocked_transferMap_apply`),
+the diagonal entries of `E(X)` are each `(X₀₀ + X₁₁)/2`, so applying `E` again
+reproduces the same scalar. -/
+theorem clusterBlocked_transferMap_idempotent :
+    transferMap clusterBlocked ∘ₗ transferMap clusterBlocked = transferMap clusterBlocked := by
+  ext X i j : 3
+  rw [LinearMap.comp_apply, clusterBlocked_transferMap_apply,
+    clusterBlocked_transferMap_apply]
+  simp only [Matrix.smul_apply, Matrix.one_apply, smul_eq_mul]
+  fin_cases i <;> fin_cases j <;> norm_num
+
+/-- The length-`2` blocked cluster tensor is a renormalization fixed point: its
+transfer map is idempotent (`clusterBlocked_transferMap_idempotent`). -/
+theorem clusterBlocked_isRFP : IsRFP clusterBlocked :=
+  clusterBlocked_transferMap_idempotent
+
 end MPSTensor
 
 end

--- a/TNLean/MPS/Examples/ZeroCorrelationExamples.lean
+++ b/TNLean/MPS/Examples/ZeroCorrelationExamples.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Examples.GHZ
+import TNLean.MPS.Examples.Cluster
+import TNLean.MPS.RFP.ZeroCorrelationLength
+
+/-!
+# Zero correlation length of the GHZ and cluster states
+
+This module records the zero-correlation-length property of the GHZ and cluster
+states, contrasting them with the AKLT state (`TNLean.MPS.Examples.AKLTCorrelation`),
+whose transfer map has a subleading eigenvalue `-1/3` and hence a finite
+correlation length `ξ = 1/log 3`.
+
+Both the GHZ tensor and the length-`2` blocked cluster tensor are renormalization
+fixed points: their transfer maps are idempotent.  By the single-block
+equivalence `zcl_iff_idempotent_transfer`, an idempotent transfer map has zero
+correlation length, so the connected correlator is independent of the separation
+(here, constant beyond range, in contrast to the exponential `(1/3)ⁿ` decay of
+the AKLT state).
+
+## Main results
+
+* `ghz_isZCL` — the GHZ tensor has zero correlation length
+* `clusterBlocked_isZCL` — the blocked cluster tensor has zero correlation length
+
+The supporting renormalization-fixed-point facts `clusterBlocked_isRFP` and
+`clusterBlocked_transferMap_idempotent` are proved in
+`TNLean.MPS.Examples.Cluster`.
+
+## References
+
+* RMP review (arXiv:2011.12127), Example III.1 (GHZ) and Appendix (cluster
+  state).  Renormalization fixed points have zero correlation length.
+* arXiv:1606.00608, Section 3.2 — the single-block zero-correlation-length
+  equivalence with transfer-map idempotence.
+-/
+
+open scoped Matrix BigOperators
+open Matrix MPSTensor
+
+namespace MPSTensor
+
+/-! ### GHZ -/
+
+/-- The GHZ tensor has zero correlation length: its idempotent transfer map
+(`ghz_isRFP`) yields correlations independent of the separation.  This is the
+contrast with the AKLT state, whose subleading eigenvalue `-1/3` gives a finite
+correlation length. -/
+theorem ghz_isZCL : IsZCL ghzTensor :=
+  (zcl_iff_idempotent_transfer ghzTensor).mpr ghz_isRFP
+
+/-! ### Cluster -/
+
+/-- The blocked cluster tensor has zero correlation length: its idempotent
+transfer map (`clusterBlocked_isRFP`) yields correlations independent of the
+separation.  The single-site cluster transfer map is not idempotent; blocking
+two sites produces the renormalization fixed point. -/
+theorem clusterBlocked_isZCL : IsZCL clusterBlocked :=
+  (zcl_iff_idempotent_transfer clusterBlocked).mpr clusterBlocked_isRFP
+
+end MPSTensor

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -171,6 +171,25 @@ non-injective, renormalization-fixed-point MPS.
     non-decaying mode behind its long-range ferromagnetic correlations.
 \end{remark}
 
+\begin{theorem}[GHZ zero correlation length]\label{thm:ghz_zcl}
+    \lean{MPSTensor.ghz_isZCL}
+    \leanok
+    \uses{def:is_zcl, thm:ghz_is_rfp, thm:zcl_iff_idempotent_transfer}
+    The GHZ tensor has zero correlation length: its idempotent transfer map
+    (Theorem~\ref{thm:ghz_is_rfp}) gives correlations independent of the
+    separation.  This contrasts with the AKLT state
+    (Theorem~\ref{thm:aklt_correlation_length}), whose subleading eigenvalue
+    $-\tfrac13$ produces a finite correlation length $1/\log 3$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:zcl_iff_idempotent_transfer, thm:ghz_is_rfp}
+    Immediate from the idempotence of the GHZ transfer map and the equivalence
+    of zero correlation length with transfer-map idempotence
+    (Theorem~\ref{thm:zcl_iff_idempotent_transfer}).
+\end{proof}
+
 %% ===================================================================
 \section{The AKLT state}\label{sec:aklt}
 %% ===================================================================
@@ -335,6 +354,67 @@ symmetry-protected topological (SPT) order.
 \end{remark}
 
 %% ===================================================================
+\subsection{Correlation length}\label{subsec:aklt_correlation_length}
+%% ===================================================================
+
+The AKLT state is the canonical example of a finite correlation length.  Its
+transfer map has leading eigenvalue $1$ and a single subleading eigenvalue
+$-\tfrac13$ of multiplicity three; the three Pauli matrices are the subleading
+eigenvectors and the identity is the leading one.  The subleading modulus
+$\tfrac13$ gives the correlation length $\xi = 1/\log 3$, and connected
+correlations decay as $(\tfrac13)^n$.
+
+\begin{theorem}[Pauli eigenvectors of the AKLT transfer map]\label{thm:aklt_pauli_eigenvectors}
+    \lean{MPSTensor.aklt_transferMap_sigmaZ, MPSTensor.aklt_transferMap_sigmaX,
+        MPSTensor.aklt_transferMap_sigmaY}
+    \leanok
+    \uses{def:aklt_tensor, def:transfer_map}
+    Each of the three Pauli matrices $\sigma_x$, $\sigma_y$, $\sigma_z$ is an
+    eigenvector of the AKLT transfer map with eigenvalue $-\tfrac13$:
+    \[
+        \E_A(\sigma_k) = -\tfrac13\, \sigma_k, \qquad k \in \{x, y, z\}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Each identity is an entrywise computation from the AKLT matrices, using
+    $(\sqrt{3})^2 = 3$ and $(\sqrt{2})^2 = 2$ to clear the prefactors.
+\end{proof}
+
+\begin{theorem}[Subleading eigenvalue of the AKLT transfer map]\label{thm:aklt_subleading_eigenvalue}
+    \lean{MPSTensor.aklt_transferMap_hasEigenvalue_neg_third}
+    \leanok
+    \uses{thm:aklt_pauli_eigenvectors}
+    The value $-\tfrac13$ is an eigenvalue of the AKLT transfer map, with
+    $\sigma_z$ as eigenvector.  Together with the leading eigenvalue $1$
+    (eigenvector $\Id$) and the basis $\{\Id, \sigma_x, \sigma_y, \sigma_z\}$ of
+    $\MN{2}$, the AKLT transfer map has spectrum
+    $\{1, -\tfrac13, -\tfrac13, -\tfrac13\}$.
+\end{theorem}
+
+\begin{theorem}[AKLT correlation length]\label{thm:aklt_correlation_length}
+    \lean{MPSTensor.aklt_correlationLength_eq}
+    \leanok
+    \uses{def:correlation_length, thm:aklt_subleading_eigenvalue}
+    The AKLT correlation length, computed from the subleading eigenvalue
+    $\lambda_2 = -\tfrac13$, equals
+    \[
+        \xi = -\frac{1}{\log |\lambda_2|} = \frac{1}{\log 3}.
+    \]
+    It is finite and positive, so the AKLT state has exponentially decaying
+    connected correlations with decay rate $(\tfrac13)^n$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:correlation_length_pos}
+    The subleading modulus is $|{-\tfrac13}| = \tfrac13$, so
+    $\xi = -1/\log\tfrac13 = 1/\log 3$, and positivity follows from
+    Lemma~\ref{lem:correlation_length_pos}.
+\end{proof}
+
+%% ===================================================================
 \section{The cluster state}\label{sec:cluster}
 %% ===================================================================
 
@@ -495,6 +575,41 @@ computation and provides another example of a non-trivial SPT phase.
     Theorem~\ref{thm:has_string_order_of_symmetric_injective}, which then yields
     string order for every $g$.  The cluster state is thus the first explicit
     witness of that criterion.
+\end{proof}
+
+\begin{theorem}[Blocked cluster transfer map is idempotent]\label{thm:cluster_blocked_idempotent}
+    \lean{MPSTensor.clusterBlocked_transferMap_idempotent}
+    \leanok
+    \uses{def:cluster_tensor, def:transfer_map}
+    The length-$2$ blocked cluster transfer map satisfies $\E_A^2 = \E_A$.  In
+    closed form it sends every $X$ to the scalar $(X_{00} + X_{11})/2$ times the
+    identity, so its image is one-dimensional.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The single-site cluster transfer map is not idempotent, but the four blocked
+    matrices give the closed form $\E_A(X) = \tfrac12 (X_{00} + X_{11})\,\Id$,
+    which is manifestly idempotent.
+\end{proof}
+
+\begin{theorem}[Cluster zero correlation length]\label{thm:cluster_zcl}
+    \lean{MPSTensor.clusterBlocked_isZCL}
+    \leanok
+    \uses{def:is_zcl, thm:cluster_blocked_idempotent, thm:zcl_iff_idempotent_transfer}
+    The length-$2$ blocked cluster tensor has zero correlation length: its
+    idempotent transfer map (Theorem~\ref{thm:cluster_blocked_idempotent}) gives
+    correlations independent of the separation.  Like the GHZ state, and unlike
+    the AKLT state, the cluster state is a renormalization fixed point with zero
+    correlation length.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:zcl_iff_idempotent_transfer, thm:cluster_blocked_idempotent}
+    Immediate from the idempotence of the blocked cluster transfer map and the
+    equivalence of zero correlation length with transfer-map idempotence
+    (Theorem~\ref{thm:zcl_iff_idempotent_transfer}).
 \end{proof}
 
 %% ===================================================================

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -402,8 +402,7 @@ correlations decay as $(\tfrac13)^n$.
     \[
         \xi = -\frac{1}{\log |\lambda_2|} = \frac{1}{\log 3}.
     \]
-    It is finite and positive, so the AKLT state has exponentially decaying
-    connected correlations with decay rate $(\tfrac13)^n$.
+    It is finite and positive.
 \end{theorem}
 
 \begin{proof}
@@ -710,7 +709,8 @@ computation and provides another example of a non-trivial SPT phase.
 \end{proof}
 
 \begin{theorem}[Blocked cluster transfer map is idempotent]\label{thm:cluster_blocked_idempotent}
-    \lean{MPSTensor.clusterBlocked_transferMap_idempotent}
+    \lean{MPSTensor.clusterBlocked_transferMap_idempotent,
+        MPSTensor.clusterBlocked_transferMap_apply}
     \leanok
     \uses{def:cluster_tensor, def:transfer_map}
     The length-$2$ blocked cluster transfer map satisfies $\E_A^2 = \E_A$.  In

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -383,18 +383,18 @@ correlations decay as $(\tfrac13)^n$.
 \end{proof}
 
 \begin{theorem}[Subleading eigenvalue of the AKLT transfer map]\label{thm:aklt_subleading_eigenvalue}
-    \lean{MPSTensor.aklt_transferMap_hasEigenvalue_neg_third}
+    \lean{MPSTensor.aklt_transferMap_hasEigenvalue_one,
+        MPSTensor.aklt_transferMap_hasEigenvalue_neg_third}
     \leanok
     \uses{thm:aklt_pauli_eigenvectors}
-    The value $-\tfrac13$ is an eigenvalue of the AKLT transfer map, with
-    $\sigma_z$ as eigenvector.  Together with the leading eigenvalue $1$
-    (eigenvector $\Id$) and the basis $\{\Id, \sigma_x, \sigma_y, \sigma_z\}$ of
-    $\MN{2}$, the AKLT transfer map has spectrum
-    $\{1, -\tfrac13, -\tfrac13, -\tfrac13\}$.
+    The value $1$ is the leading eigenvalue of the AKLT transfer map, with the
+    identity $\Id$ as eigenvector, and $-\tfrac13$ is a subleading eigenvalue,
+    with $\sigma_z$ as eigenvector.  The subleading modulus is therefore
+    $\tfrac13$.
 \end{theorem}
 
 \begin{theorem}[AKLT correlation length]\label{thm:aklt_correlation_length}
-    \lean{MPSTensor.aklt_correlationLength_eq}
+    \lean{MPSTensor.aklt_correlationLength_eq, MPSTensor.aklt_correlationLength_pos}
     \leanok
     \uses{def:correlation_length, thm:aklt_subleading_eigenvalue}
     The AKLT correlation length, computed from the subleading eigenvalue
@@ -409,9 +409,11 @@ correlations decay as $(\tfrac13)^n$.
 \begin{proof}
     \leanok
     \uses{lem:correlation_length_pos}
-    The subleading modulus is $|{-\tfrac13}| = \tfrac13$, so
-    $\xi = -1/\log\tfrac13 = 1/\log 3$, and positivity follows from
-    Lemma~\ref{lem:correlation_length_pos}.
+    The subleading modulus is $|{-\tfrac13}| = \tfrac13$, so rewriting the
+    correlation length at $\lambda_2 = -\tfrac13$ gives
+    $\xi = -1/\log\tfrac13 = 1/\log 3$.  Since $0 < \tfrac13 < 1$, positivity is
+    the specialization of Lemma~\ref{lem:correlation_length_pos} to
+    $\lambda_2 = -\tfrac13$.
 \end{proof}
 
 %% ===================================================================


### PR DESCRIPTION
## Summary

Formalizes the AKLT correlation length and the GHZ/cluster zero-correlation-length
statements, addressing #2317. Source: arXiv:2011.12127 (Cirac–Pérez-García–Schuch–
Verstraete, *Matrix Product States and Projected Entangled Pair States*), Section 2.3
("Correlations, Entanglement, and the Transfer Matrix") and Example III.1.

## AKLT transfer-map spectrum (derived, not assumed)

Computing `E_A(X) = ∑ᵢ A^i X (A^i)ᴴ` from the explicit `akltTensor`
(`A⁰ = (1/√3)σz`, `A¹ = (√2/√3)σ⁺`, `A² = -(√2/√3)σ⁻`) on the basis
`{I, σx, σy, σz}` of M₂(ℂ) gives:

- `E_A(I)  =  I`            (eigenvalue **1**, the existing `aklt_transferMap_one`)
- `E_A(σx) = -1/3 · σx`     (eigenvalue **-1/3**)
- `E_A(σy) = -1/3 · σy`     (eigenvalue **-1/3**)
- `E_A(σz) = -1/3 · σz`     (eigenvalue **-1/3**)

So the spectrum is **{1, -1/3, -1/3, -1/3}**. Each eigenvector identity is proved
by direct entrywise computation (no eigenvalue is taken on faith). The subleading
eigenvalue has modulus **1/3**, hence the correlation length

```
ξ = -1/log|λ₂| = -1/log(1/3) = 1/log 3
```

is finite and positive: connected correlations decay as (1/3)ⁿ.

## Proven

New module `TNLean/MPS/Examples/AKLTCorrelation.lean`:
- `aklt_transferMap_sigmaZ`, `aklt_transferMap_sigmaX`, `aklt_transferMap_sigmaY`
  — the three Pauli eigenvectors with eigenvalue `-1/3`.
- `aklt_transferMap_hasEigenvalue_neg_third` — `-1/3` is a genuine eigenvalue of
  the transfer map (`Module.End.HasEigenvalue`, witnessed by `σz`).
- `aklt_transferMap_hasEigenvalue_one` — `1` is a genuine eigenvalue (witnessed by `I`).
- `aklt_subleading_norm` — `‖-1/3‖ = 1/3`.
- `aklt_correlationLength_eq` — `correlationLength (-1/3) = 1/log 3` (reuses the
  existing `correlationLength` definition from `MPS/Core/Correlations.lean`).
- `aklt_correlationLength_pos` — the correlation length is positive.

New module `TNLean/MPS/Examples/ZeroCorrelationExamples.lean`:
- `ghz_isZCL` — the GHZ tensor has zero correlation length (via the existing
  `ghz_isRFP` and `zcl_iff_idempotent_transfer`).
- `clusterBlocked_isZCL` — the length-2 blocked cluster tensor has zero
  correlation length.

Extended `TNLean/MPS/Examples/Cluster.lean`:
- `clusterBlocked_transferMap_apply` — closed form `E_A(X) = ((X₀₀+X₁₁)/2)·I`.
- `clusterBlocked_transferMap_idempotent` — `E_A² = E_A` (the single-site cluster
  transfer map is **not** idempotent; blocking two sites produces the RFP).
- `clusterBlocked_isRFP`.

All three example states are contrasted: GHZ and (blocked) cluster are
renormalization fixed points with zero correlation length; the AKLT state has the
finite correlation length `1/log 3`.

## Existing API reused (no reinvention)

Targeted the existing `correlationLength`, `connectedCorrelator`,
`Module.End.HasEigenvalue`, `IsRFP`, `IsZCL`, and `zcl_iff_idempotent_transfer`.

## Deferred / not included

None of the three targets is deferred. The AKLT *bound* `|C(X,Y;n)| ≤ C·(1/3)ⁿ`
as an unconditional connected-correlator statement (vs. the spectral fact proved
here) is out of scope; the existing `connectedCorrelator_bound` already provides
the conditional form, and extracting the per-observable coefficients is tracked
separately (#1447).

## Integrity

No `sorry`/`axiom`/`native_decide`/`admit`. `#print axioms` on every headline
result shows only `[propext, Classical.choice, Quot.sound]`. `lake build` of all
three modules succeeds (8421 jobs). Blueprint entries added in
`blueprint/src/chapter/ch15_examples.tex` with `\lean{}`/`\leanok`; prose checker
passes.

Closes #2317

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-layer formalizations that reuse existing correlation/RFP APIs; no changes to auth, persistence, or core runtime paths.
> 
> **Overview**
> Adds **formal Lean proofs** for example-state correlation behavior, wired into the root import surface and Chapter 15 blueprint.
> 
> **AKLT (finite ξ):** New `AKLTCorrelation` module derives the transfer-map action on Pauli matrices (eigenvalue `-1/3` for σx, σy, σz; leading `1` on the identity) from explicit `akltTensor` arithmetic—not assumed spectrum—and concludes **`correlationLength (-1/3) = 1/log 3`** with positivity.
> 
> **GHZ & blocked cluster (zero ξ):** `ZeroCorrelationExamples` proves **`ghz_isZCL`** and **`clusterBlocked_isZCL`** by applying existing **`zcl_iff_idempotent_transfer`** to **`ghz_isRFP`** and the new cluster facts. **`Cluster`** gains a closed form **`E(X) = ((X₀₀+X₁₁)/2)·I`**, idempotence **`E² = E`**, and **`clusterBlocked_isRFP`**.
> 
> Blueprint **`ch15_examples.tex`** documents GHZ/cluster zero correlation length, AKLT Pauli eigenvectors/subleading eigenvalue, and correlation length, with `\lean{}` links to the new theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d5ffd99fe7f298b2b12b681a400c6c072063cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->