### PR TITLE
feat(MPS/ParentHamiltonian): handle unit trace probes

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -23,6 +23,20 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
+private theorem evalWord_ofFn_one (A : MPSTensor d D) (σ : Fin 1 → Fin d) :
+    evalWord A (List.ofFn σ) = A (σ 0) := by
+  have hlist : List.ofFn σ = [σ 0] := by
+    apply List.ext_getElem
+    · simp
+    · intro n hn _
+      simp only [List.length_ofFn] at hn
+      have hn0 : n = 0 := by
+        omega
+      subst n
+      simp
+  rw [hlist]
+  simp [evalWord_cons, evalWord_nil]
+
 /-- Left-word cancellation for the second boundary-crossing coordinate comparison.
 
 Let \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\) be the matrix representing the second
@@ -229,11 +243,14 @@ theorem closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSp
             (X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν))) =
           Matrix.trace (evalWord A (List.ofFn β) *
             (evalWord A (List.ofFn α) * Y ν)) := by
-  obtain ⟨Y, _hTraceOne⟩ :=
+  obtain ⟨Y, hTraceOne⟩ :=
     closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
       (A := A) hL₀ hM hψX hLocal
   refine ⟨Y, ?_⟩
   intro α ν β
+  by_cases hL₀_one : L₀ = 1
+  · subst hL₀_one
+    simpa [evalWord_ofFn_one] using hTraceOne α ν (β 0)
   -- The missing source step extends the one-letter trace probes to length-\(L_0\)
   -- probes using the periodic-boundary inverting-and-growing-back argument.
   sorry

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -185,6 +185,9 @@ from the cyclic-window constraints crossing the periodic cut.
         =
         \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
     \]
+    Hence the theorem is already proved in the special case $L_0=1$. For
+    $L_0>1$, the remaining point is the promotion from single-letter probes to
+    longer word probes.
     For a word $\beta=j_1\cdots j_{L_0}$, write
     $\beta_{\le r}=j_1\cdots j_r$. The periodic-boundary reconstruction proceeds
     by proving, for every $1\le r\le L_0$, that the cyclic restrictions crossing


### PR DESCRIPTION
### Motivation

- Continues the formalization of the periodic-boundary closure-property comparison from arXiv:2011.12127, §IV.C, lines 2078–2090, tracked in #2405. The open theorem requires, for every length-$L_0$ probe word $\beta$ and complementary word $\nu$, the trace identity $\operatorname{tr}(A^\beta X A^\alpha A^\nu) = \operatorname{tr}(A^\beta A^\alpha Y_\nu)$; this PR closes the $L_0 = 1$ (single-letter probe) branch.
- The single-letter trace identity was already proved; this PR reuses it to discharge the one-site case.

### Description

- Add a private auxiliary lemma `evalWord_ofFn_one` reducing evaluation of one-site words (`List.ofFn σ`) to the single tensor letter `A (σ 0)`.
- Prove the $L_0 = 1$ branch of `closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap` by reusing `closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`; the $L_0 > 1$ branch retains a proof placeholder.
- Update the blueprint proof sketch (`blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex`) to record that the $L_0 = 1$ case is complete and that the open part is the promotion from single-letter to longer word probes.

The general $L_0 > 1$ reconstruction remains the open part of #2405.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Refs #2405

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized formalization in an already-partial proof path; no auth, runtime, or API surface changes.
> 
> **Overview**
> Closes the **$L_0=1$** branch of the periodic-boundary length-$L_0$ trace probe theorem (`closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap`), reusing the existing single-letter trace identity instead of leaving the whole statement as `sorry`.
> 
> Adds private lemma **`evalWord_ofFn_one`** so one-site `List.ofFn` words reduce to the tensor letter `A (σ 0)`, then a **`by_cases`** on `L₀ = 1` instantiates the one-letter hypothesis at `β 0`. The **`L₀ > 1`** promotion from single-letter to full word probes remains **`sorry`** (#2405).
> 
> The blueprint proof sketch for the trace-word theorem now states that **$L_0=1$ is complete** and that the open work is extending probes to longer words.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13b9967b85ba18b74e1aababe1269895666afc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

