### PR TITLE
feat(PiAlgebra): derive canonical form from primitive blocks

### DIFF
--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -214,10 +214,10 @@ variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
 /-- **Canonical form from primitive injective blocks.**
 
-Source context: arXiv:1606.00608, Section II.C and eq. `II_CF1`.
+Source context: arXiv:1606.00608, Section II.C and eq. II_CF1.
 The first four canonical-form clauses are supplied as hypotheses. The
 self-overlap clause follows from peripheral primitivity of each left-canonical
-injective block via `MPSTensor.overlap_tendsto_one_of_peripheralPrimitive`. -/
+injective block via the spectral gap of the complementary transfer map. -/
 theorem of_peripheral_primitive
     (hInj : ∀ k, IsInjective (A k))
     (hLeft : ∀ k, ∑ i : Fin d, (A k i)ᴴ * (A k i) = 1)

--- a/TNLean/PiAlgebra/CanonicalFormSepAux.lean
+++ b/TNLean/PiAlgebra/CanonicalFormSepAux.lean
@@ -212,6 +212,27 @@ namespace IsCanonicalForm
 variable {r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {A : (k : Fin r) → MPSTensor d (dim k)}
 
+/-- **Canonical form from primitive injective blocks.**
+
+Source context: arXiv:1606.00608, Section II.C and eq. `II_CF1`.
+The first four canonical-form clauses are supplied as hypotheses. The
+self-overlap clause follows from peripheral primitivity of each left-canonical
+injective block via `MPSTensor.overlap_tendsto_one_of_peripheralPrimitive`. -/
+theorem of_peripheral_primitive
+    (hInj : ∀ k, IsInjective (A k))
+    (hLeft : ∀ k, ∑ i : Fin d, (A k i)ᴴ * (A k i) = 1)
+    (hμ_antitone : Antitone (fun k : Fin r => ‖μ k‖))
+    (hμ_ne_zero : ∀ k, μ k ≠ 0)
+    (hDim : ∀ k, 0 < dim k)
+    (hPrim : ∀ k, _root_.IsPrimitive (transferMap (d := d) (D := dim k) (A k))) :
+    IsCanonicalForm μ A := by
+  refine ⟨hInj, hLeft, hμ_antitone, hμ_ne_zero, ?_⟩
+  intro k
+  letI : NeZero (dim k) := ⟨Nat.ne_of_gt (hDim k)⟩
+  exact
+    MPSTensor.overlap_tendsto_one_of_peripheralPrimitive
+      (A := A k) (hInj k) (hLeft k) (hPrim k)
+
 /-- The canonical-form conditions imply blockwise injectivity data. -/
 def toHasInjectiveBlocks (hCF : IsCanonicalForm μ A) : HasInjectiveBlocks (d := d) A :=
   HasInjectiveBlocks.ofForall hCF.block_injective

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -1425,14 +1425,12 @@ a common length $p = m_k e_k$, the $p$-blocked alphabet is identified with the
 $e_k$-fold tensor power of the $m_k$-blocked alphabet, so each sector reblocked
 through its own period agrees with the directly $p$-blocked block.
 
-% No Lean declaration proves IsCanonicalForm from these hypotheses; the per-block
-% overlap clause is backed by
-% MPSTensor.overlap_tendsto_one_of_peripheralPrimitive (injective) but the bundled
-% statement is unformalized. Marked \notready; not cited as proven elsewhere.
 \begin{lemma}[Canonical form from peripheral primitivity]%
     \label{thm:canonical_from_primitive}
-    \notready
-    \uses{def:is_canonical_form, def:injective, def:tp_kraus}
+    \lean{MPSTensor.IsCanonicalForm.of_peripheral_primitive}
+    \leanok
+    \uses{def:is_canonical_form, def:injective, def:tp_kraus,
+        def:primitive_channel, thm:primitive_overlap}
     Let $(\mu_k,A_k)_{k=1}^r$ be nonzero weights and injective left-canonical
     blocks with positive bond dimensions, non-increasing moduli
     $|\mu_1|\ge\cdots\ge|\mu_r|>0$, and $\sigma_\partial(\E_{A_k}) = \{1\}$. Then
@@ -1440,6 +1438,17 @@ through its own period agrees with the directly $p$-blocked block.
     Definition~\ref{def:is_canonical_form}, and $O_{A_k A_k}(N) \to 1$ for every
     $k$.
 \end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:is_canonical_form, thm:primitive_compl_lt_one, thm:primitive_overlap}
+    The injectivity, left-canonical equation, weight ordering, and nonzero-weight
+    clauses are exactly the hypotheses.  For each block, peripheral primitivity
+    gives the complementary spectral gap
+    $\rho_{\spec}(\E_{A_k}-P) < 1$ by Theorem~\ref{thm:primitive_compl_lt_one}.
+    Theorem~\ref{thm:primitive_overlap} then gives the missing convergence
+    $O_{A_k A_k}(N)\to 1$.
+\end{proof}
 
 \begin{lemma}[Adjoint primitivity equivalence]%
     \label{thm:primitive_adjoint_equiv}

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -1430,7 +1430,7 @@ through its own period agrees with the directly $p$-blocked block.
     \lean{MPSTensor.IsCanonicalForm.of_peripheral_primitive}
     \leanok
     \uses{def:is_canonical_form, def:injective, def:tp_kraus,
-        def:primitive_channel, thm:primitive_overlap}
+        def:primitive_channel}
     Let $(\mu_k,A_k)_{k=1}^r$ be nonzero weights and injective left-canonical
     blocks with positive bond dimensions, non-increasing moduli
     $|\mu_1|\ge\cdots\ge|\mu_r|>0$, and $\sigma_\partial(\E_{A_k}) = \{1\}$. Then

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -1446,8 +1446,7 @@ through its own period agrees with the directly $p$-blocked block.
     clauses are exactly the hypotheses.  For each block, peripheral primitivity
     gives the complementary spectral gap
     $\rho_{\spec}(\E_{A_k}-P) < 1$ by Theorem~\ref{thm:primitive_compl_lt_one}.
-    Theorem~\ref{thm:primitive_overlap} then gives the missing convergence
-    $O_{A_k A_k}(N)\to 1$.
+    Theorem~\ref{thm:primitive_overlap} then yields $O_{A_k A_k}(N)\to 1$.
 \end{proof}
 
 \begin{lemma}[Adjoint primitivity equivalence]%


### PR DESCRIPTION
### Motivation

- Blueprint lemma `thm:canonical_from_primitive` (`blueprint/src/chapter/ch09_canonical.tex`, arXiv:1606.00608 §II.C) was marked `\notready`: no Lean declaration produced `MPSTensor.IsCanonicalForm` from primitive injective left-canonical blocks.
- The per-block overlap convergence $O_{A_k A_k}(N) \to 1$ was already available through the primitive-overlap development; only the bundled `IsCanonicalForm` conclusion was missing.

### Description

- Adds `MPSTensor.IsCanonicalForm.of_peripheral_primitive` in `TNLean/PiAlgebra/CanonicalFormSepAux.lean`.
- The theorem assumes blockwise injectivity, the left-canonical equation, non-increasing nonzero weights, positive bond dimensions, and primitivity of each transfer map ($\sigma_\partial(\mathcal{E}_{A_k}) = \{1\}$), and constructs `MPSTensor.IsCanonicalForm`.
- Promotes `thm:canonical_from_primitive` in `blueprint/src/chapter/ch09_canonical.tex` from `\notready` to `\leanok`, with a proof sketch passing through `thm:primitive_compl_lt_one` and then `thm:primitive_overlap`.

### Testing

- `lake exe cache get`
- `lake build TNLean.PiAlgebra.CanonicalFormSepAux`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/PiAlgebra/CanonicalFormSepAux.lean || true`

---
Closes #2268

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive formalization and blueprint sync; reuses existing primitive-overlap machinery with no auth, IO, or behavioral runtime changes.
> 
> **Overview**
> **Bundles** the previously missing step: from injective left-canonical blocks with peripheral-spectrum primitive transfer maps (`σ_∂(ℰ_{A_k}) = {1}`), positive bond dimension, and ordered nonzero weights, the PR **constructs** `MPSTensor.IsCanonicalForm` instead of assuming the self-overlap clause.
> 
> The new theorem `MPSTensor.IsCanonicalForm.of_peripheral_primitive` in `CanonicalFormSepAux.lean` takes the first four canonical-form hypotheses as inputs and **derives** `O_{A_k A_k}(N) → 1` per block via `overlap_tendsto_one_of_peripheralPrimitive` (using `NeZero` from `hDim`).
> 
> The blueprint **promotes** Lemma `thm:canonical_from_primitive` in `ch09_canonical.tex` from `\notready` to `\leanok`, with a short proof sketch through the complementary spectral gap and primitive-overlap results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bac7b61f3ea51c65a73d154208b79c6f4d771f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->