### PR TITLE
doc(examples): link AKLT subleading modulus theorem

### DIFF
--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -384,7 +384,8 @@ correlations decay as $(\tfrac13)^n$.
 
 \begin{theorem}[Subleading eigenvalue of the AKLT transfer map]\label{thm:aklt_subleading_eigenvalue}
     \lean{MPSTensor.aklt_transferMap_hasEigenvalue_one,
-        MPSTensor.aklt_transferMap_hasEigenvalue_neg_third}
+        MPSTensor.aklt_transferMap_hasEigenvalue_neg_third,
+        MPSTensor.aklt_subleading_norm}
     \leanok
     \uses{thm:aklt_pauli_eigenvectors}
     The value $1$ is the leading eigenvalue of the AKLT transfer map, with the

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -385,7 +385,8 @@ correlations decay as $(\tfrac13)^n$.
 \begin{theorem}[Subleading eigenvalue of the AKLT transfer map]\label{thm:aklt_subleading_eigenvalue}
     \lean{MPSTensor.aklt_transferMap_hasEigenvalue_one,
         MPSTensor.aklt_transferMap_hasEigenvalue_neg_third,
-        MPSTensor.aklt_subleading_norm}
+        MPSTensor.aklt_subleading_norm,
+        MPSTensor.aklt_transferMap_one}
     \leanok
     \uses{thm:aklt_pauli_eigenvectors}
     The value $1$ is the leading eigenvalue of the AKLT transfer map, with the


### PR DESCRIPTION
### Motivation
- The blueprint theorem `thm:aklt_subleading_eigenvalue` states that the subleading modulus is \(1/3\), but its `\lean{}` tag listed only the two eigenvalue witnesses (`MPSTensor.aklt_transferMap_hasEigenvalue_one` and `MPSTensor.aklt_transferMap_hasEigenvalue_neg_third`).
- Issue #2934 identifies `MPSTensor.aklt_subleading_norm` as the Lean declaration proving the modulus claim; adding it completes the blueprint–Lean link for this theorem. See `blueprint/src/chapter/ch15_examples.tex`, label `thm:aklt_subleading_eigenvalue`, and arXiv:2011.12127 Section 2.3.

### Description
- Added `MPSTensor.aklt_subleading_norm` to the `\lean{}` tag of `thm:aklt_subleading_eigenvalue` in `blueprint/src/chapter/ch15_examples.tex`.
- Left the theorem statement and proof prose unchanged.

### Testing
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

---
Closes #2934

> [!NOTE]
> **Low Risk**
> Documentation-only change to a blueprint `\lean{}` tag; no Lean or runtime behavior is modified.
>
> **Overview**
> The blueprint `\lean{}` tag on **`thm:aklt_subleading_eigenvalue`** now includes **`MPSTensor.aklt_subleading_norm`**, alongside the existing eigenvalue witnesses, so the Lean link covers the theorem's claim that the subleading modulus is **1/3**.
>
> Theorem wording and proof text are unchanged; this is blueprint–Lean sync only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed8cc47df838d9efa0dba1f8de0407a4ab20868b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to a LaTeX `\lean{}` tag; no Lean proofs or runtime behavior change.
> 
> **Overview**
> **Blueprint–Lean sync** for `thm:aklt_subleading_eigenvalue` in `ch15_examples.tex`: the `\lean{}` tag now lists **`MPSTensor.aklt_subleading_norm`** (subleading modulus \(1/3\)) and **`MPSTensor.aklt_transferMap_one`**, together with the existing eigenvalue witnesses `aklt_transferMap_hasEigenvalue_one` and `aklt_transferMap_hasEigenvalue_neg_third`.
> 
> Theorem statement, proof text, and Lean code are unchanged—only the blueprint citation set is updated so the modulus sentence in the theorem is formally linked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b7c90be246756f934b14b385757c19af46b197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->