### PR TITLE
doc(MPS/ParentHamiltonian): link normal-closing gap to length-probe issue

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -227,7 +227,8 @@ for all length-\(L_0\) words \(\alpha,\beta\) and every complementary word
 the displayed identities only for one-letter probes. The missing step is the
 source reconstruction that extends those probes to all length-\(L_0\) word
 products. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in issue 2405. -/
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in issue 2929
+under issue 2405. -/
 theorem closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -315,7 +316,7 @@ products. The algebraic separation of matrices from those identities is
 formalized in
 `block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective`.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; tracked in
-issue 2405. -/
+issue 2929 under issue 2405. -/
 theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -559,7 +560,7 @@ which is the transitive dependency for the coordinate consequences below.
 Documented in
 `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
 boundary matrix identity from the periodic-boundary local constraints; tracked in
-issue 2405. -/
+issue 2929 under issue 2405. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -678,7 +679,7 @@ at the periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the boundary matrix identity from the periodic-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
-in issue 2405.
+in issue 2929 under issue 2405.
 
 The comparison is derived from the periodic-boundary restriction equality
 \[
@@ -745,7 +746,7 @@ periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the boundary matrix identity from the periodic-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
-in issue 2405. -/
+in issue 2929 under issue 2405. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -809,7 +810,7 @@ periodic boundary.
 Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
 Elimination: prove the boundary matrix identity from the periodic-boundary local
 constraints and reprove this theorem without the unfaithful dependency; tracked
-in issue 2405. -/
+in issue 2929 under issue 2405. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -26,6 +26,8 @@ periodic-boundary comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}; its current
 coordinate form is recorded in
 \href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405};
+the length-\(L_0\) trace-probe leaf is recorded in
+\href{https://github.com/LionSR/TNLean/issues/2929}{issue \#2929};
 and the parent-Hamiltonian consequences are recorded in
 \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}
 


### PR DESCRIPTION
### Motivation

- Issue #2929 was opened as the leaf obligation for the length-\(L_0\) trace-probe theorem (arXiv:2011.12127, Section IV.C, lines 2078--2090), while the open-gap and **Unfaithful** docstrings in `BoundaryClosingStripping.lean` only cited the broader tracker #2405. The traceability links need updating so that a reader can find the precise leaf obligation without searching the issue history.
- The paper-gap note `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` similarly lacked a pointer to #2929.

### Description

- `TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean`: open-gap and **Unfaithful** docstrings updated to cite #2929 as the length-\(L_0\) trace-probe leaf obligation, with #2405 retained as the broader periodic-boundary closure tracker. No Lean proof logic changed.
- `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`: footnote link to #2929 added alongside the existing #2405 entry for the length-\(L_0\) trace-probe leaf.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

---
Refs #2405. Addresses #2929

> [!NOTE]
> **Low Risk**
> Comment and documentation edits only; no executable Lean or proof logic changes.
>
> **Overview**
> This PR only updates **issue traceability** for the periodic-boundary normal range-reduction gap; no Lean proofs or theorem statements change.
>
> In `BoundaryClosingStripping.lean`, open-gap and **Unfaithful** docstrings that previously pointed at issue **#2405** now cite **#2929** as the leaf obligation (length-\(L_0\) trace-probe / boundary matrix step), with **#2405** kept as the broader periodic-boundary closure tracker (`… tracked in issue 2929 under issue 2405`).
>
> The paper-gap note `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` adds a footnote link to **#2929** for the length-\(L_0\) trace-probe leaf, alongside the existing **#2405** coordinate-form entry.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f6dc986dbb796cce77f6c7da7413982632e328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>