### PR TITLE
feat(MPS/ParentHamiltonian): prove injective boundary block-window case

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -208,6 +208,56 @@ theorem closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
     _ = Matrix.trace (A j * (evalWord A (List.ofFn α) * Y ν)) := by
           simp [Matrix.mul_assoc]
 
+/-- One-site-injective form of the boundary block-window matrix equation.
+
+If the single-site matrices \(A^j\) already span the full matrix algebra, then
+the trace identities obtained from the last boundary-crossing cyclic window
+separate matrices directly:
+\[
+  X A^\alpha A^\nu=A^\alpha Y_\nu .
+\]
+
+**Scope restriction (one-site injective case):** The source argument in
+arXiv:2011.12127, Section IV.C, lines 2078--2079, assumes only
+\(L_0\)-block injectivity. This result records the narrower case in which
+one-site injectivity makes the single-site trace probes separating. The general
+length-\(L_0\) trace-probe reconstruction is still documented in
+`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+theorem closure_property_boundary_block_window_equation_of_groundSpaceMap_of_isInjective
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hA : IsInjective A) (hL₀ : 0 < L₀) (hM : L₀ < M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (hLocal : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ ∈
+        groundSpace A (L₀ + 1)) :
+    ∃ Y : (Fin (M + 1 - (L₀ + 1)) → Fin d) → Matrix (Fin D) (Fin D) ℂ,
+      ∀ (α : Fin L₀ → Fin d) (ν : Fin (M + 1 - (L₀ + 1)) → Fin d),
+        X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν) =
+          evalWord A (List.ofFn α) * Y ν := by
+  obtain ⟨Y, hTraceOne⟩ :=
+    closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
+      (A := A) hL₀ hM hψX hLocal
+  refine ⟨Y, ?_⟩
+  intro α ν
+  let Z : Matrix (Fin D) (Fin D) ℂ :=
+    X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν) -
+      evalWord A (List.ofFn α) * Y ν
+  have hZker : Z ∈ (traceMulRightPi A).ker := by
+    ext j
+    have hleft : Matrix.trace (A j * Z) = 0 := by
+      dsimp [Z]
+      rw [Matrix.mul_sub, Matrix.trace_sub]
+      exact sub_eq_zero.mpr (hTraceOne α ν j)
+    calc
+      Matrix.trace (Z * A j) = Matrix.trace (A j * Z) := Matrix.trace_mul_comm Z (A j)
+      _ = 0 := hleft
+  have hZzero : Z = 0 := by
+    have hker := traceMulRightPi_ker_eq_bot (A := A) hA
+    rw [hker] at hZker
+    simpa using hZker
+  exact sub_eq_zero.mp hZzero
+
 /-- Length-\(L_0\) trace form of the boundary block-window equation.
 
 Let \(A\) be \(L_0\)-block-injective and let

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -173,20 +173,22 @@ from the cyclic-window constraints crossing the periodic cut.
     \[
         X A^\alpha A^\nu=A^\alpha Y_\nu .
     \]
-    This is the one-site-injective special case of the boundary block-window
-    comparison; the source theorem only assumes $L_0$-block injectivity.
+    % This is the one-site-injective special case of the boundary block-window
+    % comparison; the source theorem only assumes $L_0$-block injectivity.
 \end{lemma}
 
 \begin{proof}
     \leanok
+    \uses{lem:closure_property_boundary_block_window_trace_ground_space_map,
+        thm:trace_pairing_injective}
     Lemma~\ref{lem:closure_property_boundary_block_window_trace_ground_space_map}
-    gives
+    gives, for every physical letter $j$,
     \[
         \operatorname{tr}\left(A^jX A^\alpha A^\nu\right)
         =
         \operatorname{tr}\left(A^jA^\alpha Y_\nu\right)
     \]
-    for every physical letter $j$. Thus the trace of
+    Thus the trace of
     \[
         A^j\left(X A^\alpha A^\nu-A^\alpha Y_\nu\right)
     \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -191,13 +191,22 @@ from the cyclic-window constraints crossing the periodic cut.
         =
         \operatorname{tr}\left(A^jA^\alpha Y_\nu\right)
     \]
-    Thus the trace of
+    Put
     \[
-        A^j\left(X A^\alpha A^\nu-A^\alpha Y_\nu\right)
+        Z=X A^\alpha A^\nu-A^\alpha Y_\nu .
     \]
-    is zero for every $j$. Since the matrices $A^j$ span the full matrix
-    algebra, the trace pairing separates matrices, and the displayed
-    difference is zero.
+    For every physical letter $j$, the preceding identity gives
+    \[
+        \operatorname{tr}(A^j Z)=0 .
+    \]
+    Since the matrices $A^j$ span the full matrix algebra, the trace pairing
+    gives
+    \[
+        \bigl(\forall j,\ \operatorname{tr}(A^j Z)=0\bigr)
+        \quad\Longrightarrow\quad
+        Z=0 .
+    \]
+    Hence $X A^\alpha A^\nu=A^\alpha Y_\nu$.
 \end{proof}
 
 \begin{theorem}[Trace identities with length-$L_0$ probes from cyclic-window constraints]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -161,8 +161,8 @@ from the cyclic-window constraints crossing the periodic cut.
     \leanok
     \uses{def:injective, rem:cyclic_window_operators,
         lem:closure_property_boundary_block_window_trace_ground_space_map}
-    Suppose that the single-site matrices of $A$ span the full matrix algebra,
-    let $L_0>0$ and $L_0<M$, and let
+    Let $A$ be a tensor with virtual dimension at least one whose single-site
+    matrices span the full matrix algebra. Let $L_0>0$ and $L_0<M$, and let
     \[
         \psi=\Gamma_{M+1}(X).
     \]
@@ -173,16 +173,19 @@ from the cyclic-window constraints crossing the periodic cut.
     \[
         X A^\alpha A^\nu=A^\alpha Y_\nu .
     \]
-    % This is the one-site-injective special case of the boundary block-window
-    % comparison; the source theorem only assumes $L_0$-block injectivity.
+    % Scope restriction: the source argument in arXiv:2011.12127, Section~IV.C,
+    % lines 2078--2079, assumes only $L_0$-block injectivity. This lemma records
+    % the narrower one-site-injective case; the general case is documented in
+    % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{lem:closure_property_boundary_block_window_trace_ground_space_map,
         thm:trace_pairing_injective}
+    For every physical letter $j$,
     Lemma~\ref{lem:closure_property_boundary_block_window_trace_ground_space_map}
-    gives, for every physical letter $j$,
+    gives
     \[
         \operatorname{tr}\left(A^jX A^\alpha A^\nu\right)
         =

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -155,6 +155,46 @@ from the cyclic-window constraints crossing the periodic cut.
     \]
 \end{proof}
 
+\begin{lemma}[One-site-injective boundary block-window identity]
+    \label{lem:closure_property_boundary_block_window_equation_ground_space_map_injective}
+    \lean{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap_of_isInjective}
+    \leanok
+    \uses{def:injective, rem:cyclic_window_operators,
+        lem:closure_property_boundary_block_window_trace_ground_space_map}
+    Suppose that the single-site matrices of $A$ span the full matrix algebra,
+    let $L_0>0$ and $L_0<M$, and let
+    \[
+        \psi=\Gamma_{M+1}(X).
+    \]
+    If every cyclic restriction of length $L_0+1$ belongs to $G_{L_0+1}(A)$,
+    then there are boundary matrices $Y_\nu$, indexed by nonempty
+    complementary words $\nu$ of length $M+1-(L_0+1)$, such that, for every
+    word $\alpha$ of length $L_0$,
+    \[
+        X A^\alpha A^\nu=A^\alpha Y_\nu .
+    \]
+    This is the one-site-injective special case of the boundary block-window
+    comparison; the source theorem only assumes $L_0$-block injectivity.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:closure_property_boundary_block_window_trace_ground_space_map}
+    gives
+    \[
+        \operatorname{tr}\left(A^jX A^\alpha A^\nu\right)
+        =
+        \operatorname{tr}\left(A^jA^\alpha Y_\nu\right)
+    \]
+    for every physical letter $j$. Thus the trace of
+    \[
+        A^j\left(X A^\alpha A^\nu-A^\alpha Y_\nu\right)
+    \]
+    is zero for every $j$. Since the matrices $A^j$ span the full matrix
+    algebra, the trace pairing separates matrices, and the displayed
+    difference is zero.
+\end{proof}
+
 \begin{theorem}[Trace identities with length-$L_0$ probes from cyclic-window constraints]
     \label{thm:closure_property_boundary_block_window_trace_word_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap}


### PR DESCRIPTION
### Motivation

Issue #2929 asks for the length-\(L_0\) trace-probe reconstruction in the normal parent-Hamiltonian boundary comparison. The general CPGSV21 step (arXiv:2011.12127, Section IV.C, lines 2078--2090) still requires promoting single-site trace probes to length-\(L_0\) word probes.

This PR records the proved one-site-injective case: when the matrices \(A^j\) already span the full matrix algebra, the single-site trace identities from the last boundary-crossing cyclic window separate matrices directly.

### Description

- Adds `MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap_of_isInjective`.
- The theorem proves
  \[
    X A^\alpha A^\nu = A^\alpha Y_\nu
  \]
  from the existing single-site trace identity and one-site injectivity.
- Adds the corresponding blueprint entry with `\leanok`, explicitly marked as the one-site-injective special case rather than the source theorem (arXiv:2011.12127, Section IV.C).

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` followed by `lake exe checkdecls blueprint/lean_decls`

The Lean checks still report the pre-existing `sorry` warning for the general length-\(L_0\) reconstruction; this PR does not claim to close that gap.

---
Refs #2929

Also refs #2405, #460.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a self-contained formal proof and blueprint sync in the MPS parent-Hamiltonian layer; it does not change the still-open general boundary reconstruction path.
> 
> **Overview**
> Adds **`closure_property_boundary_block_window_equation_of_groundSpaceMap_of_isInjective`**, which derives **\(X A^\alpha A^\nu = A^\alpha Y_\nu\)** from the existing single-site trace identities and **one-site injectivity** via `traceMulRightPi_ker_eq_bot` (difference \(Z\) lies in the trace kernel, hence is zero).
> 
> The blueprint gains a matching **one-site-injective** lemma with `\leanok`, explicitly scoped as a special case—not the full CPGSV21 **\(L_0\)**-block-injective reconstruction still tracked in the paper-gap note and left with `sorry` elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd50ec35a5e15a7efa5a8561e78ba689f871a76c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->