### PR TITLE
feat(MPS/ParentHamiltonian): expose PGVWC CDE trace identities

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -213,6 +213,7 @@ import TNLean.MPS.Symmetry.StringOrder
 import TNLean.MPS.Core.MultiBlock
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
+import TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities
 import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
 import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace

--- a/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
@@ -4,6 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 
+/-!
+# PGVWC C-D-E identities from trace decompositions
+
+This file derives the word-valued \(C^j,D^j,E^j\) matrix identities from
+matching left and right block trace decompositions in arXiv:quant-ph/0608197,
+Theorem 12, proof lines 1446--1451.
+
+The formula for \(E^j\) uses the adjointed word product
+\[
+  E^j=\sum_\rho C^j_\rho (A^j_\rho)^\dagger ,
+\]
+which is the form compatible with the normalization
+\(\sum_\rho A^j_\rho(A^j_\rho)^\dagger=I\). The source line omits this adjoint;
+the correction is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+-/
+
 open scoped Matrix BigOperators
 
 namespace MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- Explicit PGVWC \(C^j,D^j,E^j\) identities from the trace decompositions.
+
+Assume the right trace decomposition has
+\[
+  D^j_\beta=X_jA^j_\beta .
+\]
+If the two trace decompositions agree for every wrapped word \(\beta\),
+complementary word \(\rho\), and middle word \(w\), then for every block \(j\)
+there is a matrix
+\[
+  E^j=\sum_\rho C^j_\rho A^{j\dagger}_\rho
+\]
+such that
+\[
+  D^j_\beta=A^j_\beta E^j,\qquad
+  A^j_\beta C^j_\rho=A^j_\beta E^jA^j_\rho .
+\]
+This is the word-valued form of arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1446--1451.
+
+**Local fix (adjoint correction):** The source line writes
+\(E^j=\sum_k C^j_kA^j_k\), while the normalization step uses
+\(\sum_k A^j_kA^{j\dagger}_k=I\). The formal statement uses the adjointed
+matrix \(E^j=\sum_k C^j_kA^{j\dagger}_k\), as recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem pgvwc07_complementary_word_cde_identities_of_trace_decomposition
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {m K M : ℕ} (hSpan : WordTupleSpanTop A m)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (C : (j : Fin r) → (Fin M → Fin d) →
+      Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hCoeff : ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      ∀ w : Fin m → Fin d,
+        (∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) (List.ofFn β) * C j ρ) *
+              evalWord (A j) (List.ofFn w))) =
+        (∑ j : Fin r,
+          Matrix.trace
+            (((X j * evalWord (A j) (List.ofFn β)) *
+                evalWord (A j) (List.ofFn ρ)) *
+              evalWord (A j) (List.ofFn w)))) :
+    ∀ j : Fin r,
+      ∃ E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        E = (∑ ρ : Fin M → Fin d, C j ρ * (evalWord (A j) (List.ofFn ρ))ᴴ) ∧
+        (∀ β : Fin K → Fin d,
+          X j * evalWord (A j) (List.ofFn β) =
+            evalWord (A j) (List.ofFn β) * E) ∧
+        (∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+          evalWord (A j) (List.ofFn β) * C j ρ =
+            evalWord (A j) (List.ofFn β) * E *
+              evalWord (A j) (List.ofFn ρ)) := by
+  classical
+  intro j
+  let E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ :=
+    ∑ ρ : Fin M → Fin d, C j ρ * (evalWord (A j) (List.ofFn ρ))ᴴ
+  have hCompat :
+      ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+        evalWord (A j) (List.ofFn β) * C j ρ =
+          (X j * evalWord (A j) (List.ofFn β)) *
+            evalWord (A j) (List.ofFn ρ) :=
+    (pgvwc07_complementary_word_compatibility_of_trace_decomposition
+      (A := A) (m := m) (K := K) (M := M) hSpan X C hCoeff) j
+  have hIds :=
+    pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
+      (A := A j) (K := K) (M := M) (C := C j)
+      (Dmat := fun β : Fin K → Fin d => X j * evalWord (A j) (List.ofFn β))
+      (sum_evalWord_mul_conjTranspose_evalWord (A j) (hUnital j) M)
+      hCompat
+  refine ⟨E, rfl, ?_, ?_⟩
+  · intro β
+    simpa [E] using hIds.1 β
+  · intro ρ β
+    simpa [E] using hIds.2 ρ β
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -377,8 +377,14 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
         \sum_\rho A^j_\rho\left(A^j_\rho\right)^\dagger=I .
     \]
     Lemma~\ref{lem:normalized_boundary_matrix_identities}, applied to the
-    two word alphabets, gives the displayed formula for \(E^j\) and the two
-    identities involving \(D^j_\beta\) and \(C^j_\rho\).
+    two word alphabets, gives
+    \[
+        E^j=\sum_\rho C^j_\rho\left(A^j_\rho\right)^\dagger,
+        \qquad
+        D^j_\beta=A^j_\beta E^j,
+        \qquad
+        A^j_\beta C^j_\rho=A^j_\beta E^jA^j_\rho .
+    \]
 \end{proof}
 
 \begin{lemma}[Complementary-word boundary identities from a compatibility hypothesis]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -323,6 +323,64 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
     $A_bC_a=D_bB_a$ gives $A_bC_a=A_bEB_a$.
 \end{proof}
 
+\begin{lemma}[Explicit \(C^j,D^j,E^j\) identities from trace decompositions]
+    \label{lem:pgvwc_cde_identities_from_trace_decompositions}
+    \lean{MPSTensor.pgvwc07_complementary_word_cde_identities_of_trace_decomposition}
+    \leanok
+    \uses{lem:sum_evalWord_mul_conjTranspose_evalWord,
+        lem:blockwise_word_boundary_compatibility_from_traces,
+        lem:normalized_boundary_matrix_identities}
+    Let $A^1,\ldots,A^g$ be block tensors with the common word-span property
+    at length $m$. Fix matrices $X_j$, and put
+    \[
+        D^j_\beta=X_jA^j_\beta .
+    \]
+    Suppose that $C^j_\rho$ is indexed by a block $j$ and a complementary word
+    $\rho$ of length $M$, and assume that, for every wrapped word $\beta$ of
+    length $K$, every complementary word $\rho$, and every middle word $w$ of
+    length $m$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_\rho A^j_w\right)
+        =
+        \sum_j\tr\!\left(D^j_\beta A^j_\rho A^j_w\right).
+    \]
+    If each block satisfies
+    \[
+        \sum_a A^j_aA^{j\,\dagger}_a=I,
+    \]
+    then for every block $j$ there is a matrix
+    \[
+        E^j=\sum_\rho C^j_\rho\left(A^j_\rho\right)^\dagger
+    \]
+    such that, for every wrapped word $\beta$ and complementary word $\rho$,
+    \[
+        D^j_\beta=A^j_\beta E^j,
+        \qquad
+        A^j_\beta C^j_\rho=A^j_\beta E^jA^j_\rho .
+    \]
+    This is the calculation in
+    \cite[Theorem~12, proof lines~1446--1451]{PerezGarcia2007Matrix}, with
+    the adjoint on \(A^j_\rho\) required by the displayed normalization.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:sum_evalWord_mul_conjTranspose_evalWord,
+        lem:blockwise_word_boundary_compatibility_from_traces,
+        lem:normalized_boundary_matrix_identities}
+    Lemma~\ref{lem:blockwise_word_boundary_compatibility_from_traces} gives
+    \[
+        A^j_\beta C^j_\rho=D^j_\beta A^j_\rho .
+    \]
+    The single-letter normalization gives the word normalization
+    \[
+        \sum_\rho A^j_\rho\left(A^j_\rho\right)^\dagger=I .
+    \]
+    Lemma~\ref{lem:normalized_boundary_matrix_identities}, applied to the
+    two word alphabets, gives the displayed formula for \(E^j\) and the two
+    identities involving \(D^j_\beta\) and \(C^j_\rho\).
+\end{proof}
+
 \begin{lemma}[Complementary-word boundary identities from a compatibility hypothesis]
     \label{lem:complementary_word_boundary_identities_from_pgvwc}
     \lean{MPSTensor.pgvwc07_complementary_word_boundary_identities_of_compatibility}


### PR DESCRIPTION
### Motivation

- Continues the formalization of the PGVWC07 parent-Hamiltonian argument for block-injective MPS
  (arXiv:quant-ph/0608197, Theorem `2blocks.2`, lines 1446–1451; see #2651).
- The word-level identities relating $C^j$, $D^j$, and $E^j$ are the missing link between the
  existing conditional PGVWC comparison interface in `BNTBlockDiagonalPGVWCComparison.lean`
  and the source argument; this leaf proves them from trace-decomposition hypotheses.
- Also refs #190, #460 (parent-Hamiltonian formalization trackers).

### Description

- **New file** `TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean`: proves
  `pgvwc07_complementary_word_cde_identities_of_trace_decomposition`.
  Given matching left/right block trace decompositions with $D^j_\beta = X_j A^j_\beta$
  and per-block normalization $\sum_a A^j_a A^{j\dagger}_a = I$, the lemma establishes
  (arXiv:quant-ph/0608197, lines 1449–1451):
  - $E^j = \sum_\rho C^j_\rho (A^j_\rho)^\dagger$
  - $D^j_\beta = A^j_\beta E^j$
  - $A^j_\beta C^j_\rho = A^j_\beta E^j A^j_\rho$

  The proof composes existing `word_compatibility_from_traces` and
  `two_length_boundary_matrix_identities` lemmas. The trace decomposition is assumed
  as a hypothesis; it is not derived from the periodic boundary condition.
  The adjoint convention for $E^j$ follows the normalization $\sum_\rho A^j_\rho (A^j_\rho)^\dagger = I$
  (documented in the Lean file and blueprint; see #2405).
- **Blueprint** `blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex`:
  adds the corresponding lemma with paper notation and `\lean{}` / `\leanok` tags.
- **Root module** `TNLean.lean`: imports `TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities`.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean`
- `lake build TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `lake exe checkdecls blueprint/lean_decls`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean || true`
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
Addresses #2651

> [!NOTE]
> **Low Risk**
> New formal proof module and blueprint sync only; no changes to auth, runtime behavior, or existing theorem statements beyond wiring the new import.
>
> **Overview**
> This PR adds **`pgvwc07_complementary_word_cde_identities_of_trace_decomposition`**, a leaf in the PGVWC parent-Hamiltonian comparison: from matching left/right block trace decompositions (with \(D^j_\beta = X_j A^j_\beta\)) and per-block \(\sum_a A^j_a A^{j\dagger}_a = I\), it proves per block \(E^j = \sum_\rho C^j_\rho (A^j_\rho)^\dagger\) and the identities \(D^j_\beta = A^j_\beta E^j\) and \(A^j_\beta C^j_\rho = A^j_\beta E^j A^j_\rho\). The proof is a short composition of existing **word compatibility from traces** and **two-length boundary matrix identities** lemmas; it does **not** derive the trace decomposition from the periodic boundary condition.
>
> The formal statement uses the **adjoint correction** on \(E^j\) (documented in Lean and blueprint) to align with normalization \(\sum_\rho A^j_\rho (A^j_\rho)^\dagger = I\). A matching blueprint lemma is added in `ch13_parent_hamiltonian_block_intersections_trace_consequences.tex`, and **`TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities`** is imported from **`TNLean.lean`**.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb36946c398c61a3ef2899e187cd361bead00987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proof and blueprint sync only; no runtime or changes to existing theorem statements beyond the new import.
> 
> **Overview**
> Adds **`pgvwc07_complementary_word_cde_identities_of_trace_decomposition`**, bridging the PGVWC parent-Hamiltonian comparison: from matching block trace decompositions (with \(D^j_\beta = X_j A^j_\beta\)) and per-block \(\sum_a A^j_a A^{j\dagger}_a = I\), it proves per block \(E^j = \sum_\rho C^j_\rho (A^j_\rho)^\dagger\) and \(D^j_\beta = A^j_\beta E^j\), \(A^j_\beta C^j_\rho = A^j_\beta E^j A^j_\rho\). The proof is a short composition of existing **word compatibility from traces** and **two-length boundary matrix identities**; the trace decomposition remains an explicit hypothesis.
> 
> The formal statement uses an **adjoint on \(E^j\)** (documented in Lean and blueprint) to match normalization \(\sum_\rho A^j_\rho (A^j_\rho)^\dagger = I\). Blueprint chapter 13 gains the matching lemma with `\lean{}` tags; **`TNLean.lean`** imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cb66433b57ad2f034b3d6734a394d491feb936b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->