### PR TITLE
feat(MPS/ParentHamiltonian): prove boundary word trace identities

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -186,6 +186,7 @@ import TNLean.MPS.ParentHamiltonian.BoundaryClosingWitness
 import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingCoordinate
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping
+import TNLean.MPS.ParentHamiltonian.BoundaryClosingAuxiliary
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixBlock
 import TNLean.MPS.ParentHamiltonian.BoundaryBlockMatEq
 import TNLean.Axioms.Beigi

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingAuxiliary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingAuxiliary.lean
@@ -31,8 +31,13 @@ word \(\mu\) as the two displayed boundary conditions, and satisfying
   Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
 \]
 
-The proof applies the left-multiplied boundary comparison and then chooses the
-corresponding auxiliary boundary conditions. -/
+The proof applies the left-multiplied boundary comparison
+\[
+  A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
+  =
+  A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr)
+\]
+and then chooses the corresponding auxiliary boundary conditions. -/
 theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingAuxiliary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingAuxiliary.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping
+
+/-!
+# Auxiliary boundary products for the periodic-boundary comparison
+
+This file contains the final auxiliary boundary-condition product obtained from
+the boundary-crossing comparison in the periodic-boundary closure step of
+arXiv:2011.12127, Section IV.C.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- Auxiliary boundary-condition product equation needed for the
+periodic-boundary comparison.
+
+For each pair \(j,\sigma\), this states the existence of boundary conditions
+\(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with the same complementary
+word \(\mu\) as the two displayed boundary conditions, and satisfying
+\[
+  Y_M(\rho^+_{j,\sigma}) A^j A^\sigma
+  =
+  Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
+\]
+
+The proof applies the left-multiplied boundary comparison and then chooses the
+corresponding auxiliary boundary conditions. -/
+theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
+    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
+    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
+    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
+    (hψX : ψ = groundSpaceMap A (M + 1) X)
+    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
+      Matrix (Fin D) (Fin D) ℂ)
+    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+        groundSpaceMap A (L₀ + 1) (YAt i τ))
+    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
+    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
+      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
+          (k : Fin (M + 1 - (L₀ + 1))),
+        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
+      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
+        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
+          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
+            evalWord A (List.ofFn σ) := by
+  have hLeft :=
+    closure_property_mirror_left_word_products_of_groundSpaceMap
+      (A := A) hInj hL₀ hM hψX YAt hYAt μ
+  exact closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words
+    (A := A) hInj hL₀ (le_of_lt hM) hψX YAt hYAt μ hLeft
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -258,11 +258,21 @@ lines 2078--2079, gives boundary matrices \(Y_\nu\) such that
 for all length-\(L_0\) words \(\alpha,\beta\) and every complementary word
 \(\nu\).
 
-The proof chooses boundary matrices for all cyclic restrictions. The
-boundary-crossing equations move \(X\) through the first boundary letter, the
-adjacent boundary-window product transports across the remaining \(L_0-1\)
-letters, and the outside-label uniqueness lemma identifies the final boundary
-matrix with \(Y_\nu\). -/
+The proof chooses boundary matrices for all cyclic restrictions. The first
+boundary-crossing equation is
+\[
+  X A^{\rho_0}A^{\rho_1\cdots\rho_{M-L_0}}
+  =A^{\rho_0}Y_{M+1-L_0}(\rho).
+\]
+The adjacent boundary-window product gives
+\[
+  Y_{M+1-L_0}(\rho)A^{\rho_{M+1-L_0}\cdots\rho_{M-1}}
+  =A^{\rho_1\cdots\rho_{L_0-1}}Y_M(\rho).
+\]
+The outside-label uniqueness lemma identifies \(Y_M(\rho)\) with \(Y_\nu\), hence
+\[
+  X A^\alpha A^\nu=A^\alpha Y_\nu .
+\] -/
 theorem closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -764,10 +774,14 @@ reconstruction is the boundary product comparison
 \]
 for all outside letters \(\eta\) and physical letters \(j\).
 
-The proof uses the boundary block-window identity to derive the one-site
-commutation relation for \(X\). The one-sided boundary products then identify
-the first-letter products of the two boundary matrices, and hence the two
-cyclic restrictions. -/
+The boundary block-window identity \(XA^\alpha A^\nu=A^\alpha Y_\nu\) gives,
+by block injectivity, \(XA^k=A^kX\) for every physical letter \(k\). The
+one-sided boundary products and this commutation relation give
+\[
+  Y_M(\tau^+_\eta(\mu))A^j=Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j,
+\]
+and the first-letter restriction equality implies equality of the two cyclic
+restrictions. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -931,8 +945,16 @@ periodic-boundary coordinate comparison is
   A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr).
 \]
 
-The proof combines the equality of the two boundary-crossing restrictions with
-the one-sided product equation for the window beginning at the last site. -/
+The restriction equality
+\[
+  \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)=
+  \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi)
+\]
+and the one-sided product equation
+\[
+  Y_M(\tau^+_\eta(\mu))A^j=A^\mu A^jX
+\]
+combine to give the displayed coordinate comparison. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean
@@ -23,20 +23,6 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-private theorem evalWord_ofFn_one (A : MPSTensor d D) (σ : Fin 1 → Fin d) :
-    evalWord A (List.ofFn σ) = A (σ 0) := by
-  have hlist : List.ofFn σ = [σ 0] := by
-    apply List.ext_getElem
-    · simp
-    · intro n hn _
-      simp only [List.length_ofFn] at hn
-      have hn0 : n = 0 := by
-        omega
-      subst n
-      simp
-  rw [hlist]
-  simp [evalWord_cons, evalWord_nil]
-
 /-- Left-word cancellation for the second boundary-crossing coordinate comparison.
 
 Let \(Y_{M+1-L_0}(\tau^-_\eta(\mu))\) be the matrix representing the second
@@ -263,7 +249,7 @@ theorem closure_property_boundary_block_window_equation_of_groundSpaceMap_of_isI
 Let \(A\) be \(L_0\)-block-injective and let
 \(\psi=\Gamma_{M+1}(X)\). The periodic-boundary
 inverting-and-growing-back argument in arXiv:2011.12127, Section IV.C,
-lines 2078--2079, should give boundary matrices \(Y_\nu\) such that
+lines 2078--2079, gives boundary matrices \(Y_\nu\) such that
 \[
   \operatorname{tr}\!\left(A^\beta X A^\alpha A^\nu\right)
   =
@@ -272,12 +258,11 @@ lines 2078--2079, should give boundary matrices \(Y_\nu\) such that
 for all length-\(L_0\) words \(\alpha,\beta\) and every complementary word
 \(\nu\).
 
-**Open gap:** The trace rotation from the last cyclic window is formalized in
-`closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`; it gives
-the displayed identities only for one-letter probes. The missing step is the
-source reconstruction that extends those probes to all length-\(L_0\) word
-products. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+The proof chooses boundary matrices for all cyclic restrictions. The
+boundary-crossing equations move \(X\) through the first boundary letter, the
+adjacent boundary-window product transports across the remaining \(L_0-1\)
+letters, and the outside-label uniqueness lemma identifies the final boundary
+matrix with \(Y_\nu\). -/
 theorem closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -293,17 +278,211 @@ theorem closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSp
             (X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν))) =
           Matrix.trace (evalWord A (List.ofFn β) *
             (evalWord A (List.ofFn α) * Y ν)) := by
-  obtain ⟨Y, hTraceOne⟩ :=
-    closure_property_boundary_block_window_trace_eq_of_groundSpaceMap
-      (A := A) hL₀ hM hψX hLocal
+  classical
+  have hKpos : 0 < M + 1 - (L₀ + 1) := by omega
+  have hLocalWitness :
+      ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
+        ∃ Y : Matrix (Fin D) (Fin D) ℂ,
+          cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
+            groundSpaceMap A (L₀ + 1) Y := by
+    intro i τ
+    have hmem := hLocal i τ
+    rw [groundSpace, LinearMap.mem_range] at hmem
+    obtain ⟨Y, hY⟩ := hmem
+    exact ⟨Y, hY.symm⟩
+  choose YAt hYAt using hLocalWitness
+  let Y : (Fin (M + 1 - (L₀ + 1)) → Fin d) → Matrix (Fin D) (Fin D) ℂ :=
+    fun ν => YAt (⟨M, by omega⟩ : Fin (M + 1))
+      (wrappedMiddleBackground L₀ (M + 1) (ν ⟨0, hKpos⟩) ν)
   refine ⟨Y, ?_⟩
   intro α ν β
-  by_cases hL₀_one : L₀ = 1
-  · subst hL₀_one
-    simpa [evalWord_ofFn_one] using hTraceOne α ν (β 0)
-  -- The missing source step extends the one-letter trace probes to length-\(L_0\)
-  -- probes using the periodic-boundary inverting-and-growing-back argument.
-  sorry
+  have hMat :
+      X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν) =
+        evalWord A (List.ofFn α) * Y ν := by
+    let α₀ : Fin d := α ⟨0, hL₀⟩
+    let αTail : Fin (L₀ - 1) → Fin d := fun r => α ⟨r.val + 1, by omega⟩
+    let γ : Fin (M - 1) → Fin d := fun r =>
+      if h : r.val < L₀ - 1 then
+        αTail ⟨r.val, h⟩
+      else
+        ν ⟨r.val - (L₀ - 1), by omega⟩
+    let ρ : Fin (M + 1) → Fin d := fun k =>
+      if h0 : k.val = 0 then
+        α₀
+      else if hM' : k.val < M then
+        γ ⟨k.val - 1, by omega⟩
+      else
+        α₀
+    have hMirror :=
+      (closure_property_wrapped_mirror_compatibilities_of_groundSpaceMap
+        (A := A) hInj hL₀ (le_of_lt hM) hψX YAt hYAt).2 α₀ ρ
+    have hTransport :=
+      closure_property_boundary_condition_product_of_window_witnesses
+        (A := A) hInj hL₀ (le_of_lt hM) YAt hYAt ρ
+    have hρComp :
+        ∀ k : Fin (M + 1 - (L₀ + 1)),
+          ρ ⟨k.val + L₀, by omega⟩ = ν k := by
+      intro k
+      dsimp only [ρ, γ]
+      split_ifs with hzero hlt hγ
+      · omega
+      · omega
+      · congr 1
+        ext
+        simp
+        omega
+      · omega
+    have hYρ : YAt (⟨M, by omega⟩ : Fin (M + 1)) ρ = Y ν := by
+      simpa [Y] using
+        wrappedMiddleBackground_witness_eq_of_complement_eq
+          (A := A) hInj hL₀ (le_of_lt hM) (ν ⟨0, hKpos⟩) ν ρ
+          hρComp
+          (hYAt (⟨M, by omega⟩ : Fin (M + 1)) ρ)
+          (hYAt (⟨M, by omega⟩ : Fin (M + 1))
+            (wrappedMiddleBackground L₀ (M + 1) (ν ⟨0, hKpos⟩) ν))
+    have hHeadρ :
+        (fun r : Fin (L₀ - 1) => ρ ⟨r.val + 1, by omega⟩) = αTail := by
+      ext r
+      have hzero : ¬ r.val + 1 = 0 := by omega
+      have hlt : r.val + 1 < M := by omega
+      have hγ : r.val + 1 - 1 < L₀ - 1 := by omega
+      simp [ρ, γ, αTail, hlt]
+    have hα_eval :
+        evalWord A (List.ofFn α) = A α₀ * evalWord A (List.ofFn αTail) := by
+      let α' : Fin ((L₀ - 1) + 1) → Fin d := fun i => α ⟨i.val, by omega⟩
+      have hαlist : List.ofFn α = List.ofFn α' := by
+        apply List.ext_getElem
+        · simp only [List.length_ofFn]
+          omega
+        · intro n hn₁ hn₂
+          simp only [List.length_ofFn] at hn₁ hn₂
+          simp only [List.getElem_ofFn, α']
+      have htail : α' ∘ Fin.succ = αTail := by
+        ext r
+        simp [α', αTail]
+      rw [hαlist, evalWord_ofFn_succ, htail]
+      simp [α', α₀]
+    have hWord :
+        evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+            ρ ⟨k.val + 1, by omega⟩)) *
+          evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+            ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) =
+        evalWord A (List.ofFn αTail) * evalWord A (List.ofFn ν) := by
+      let full : Fin (M - 1) → Fin d := fun n => ρ ⟨n.val + 1, by omega⟩
+      have hLeftList :
+          List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+              ρ ⟨k.val + 1, by omega⟩) ++
+            List.ofFn (fun r : Fin (L₀ - 1) =>
+              ρ ⟨M + 1 - L₀ + r.val, by omega⟩) =
+          List.ofFn full := by
+        rw [← List.ofFn_fin_append]
+        apply List.ext_getElem
+        · simp only [List.length_ofFn]
+          omega
+        · intro n hn₁ hn₂
+          simp only [List.length_ofFn] at hn₁ hn₂
+          simp only [List.getElem_ofFn]
+          by_cases hnLeft : n < M + 1 - (L₀ + 1)
+          · let i : Fin (M + 1 - (L₀ + 1)) := ⟨n, hnLeft⟩
+            have hidx :
+                (⟨n, hn₁⟩ :
+                  Fin ((M + 1 - (L₀ + 1)) + (L₀ - 1))) =
+                  Fin.castAdd (L₀ - 1) i := by
+              ext
+              simp [i]
+            rw [hidx, Fin.append_left]
+          · let i : Fin (L₀ - 1) :=
+              ⟨n - (M + 1 - (L₀ + 1)), by omega⟩
+            have hidx :
+                (⟨n, hn₁⟩ :
+                  Fin ((M + 1 - (L₀ + 1)) + (L₀ - 1))) =
+                  Fin.natAdd (M + 1 - (L₀ + 1)) i := by
+              ext
+              simp [i]
+              omega
+            rw [hidx, Fin.append_right]
+            congr 1
+            ext
+            simp [i]
+            omega
+      have hRightList :
+          List.ofFn αTail ++ List.ofFn ν = List.ofFn full := by
+        rw [← List.ofFn_fin_append]
+        apply List.ext_getElem
+        · simp only [List.length_ofFn]
+          omega
+        · intro n hn₁ hn₂
+          simp only [List.length_ofFn] at hn₁ hn₂
+          simp only [List.getElem_ofFn]
+          by_cases hnAlpha : n < L₀ - 1
+          · let i : Fin (L₀ - 1) := ⟨n, hnAlpha⟩
+            have hidx :
+                (⟨n, hn₁⟩ :
+                  Fin ((L₀ - 1) + (M + 1 - (L₀ + 1)))) =
+                  Fin.castAdd (M + 1 - (L₀ + 1)) i := by
+              ext
+              simp [i]
+            rw [hidx, Fin.append_left]
+            simpa [full, i] using (congr_fun hHeadρ i).symm
+          · let k : Fin (M + 1 - (L₀ + 1)) :=
+              ⟨n - (L₀ - 1), by omega⟩
+            have hidx :
+                (⟨n, hn₁⟩ :
+                  Fin ((L₀ - 1) + (M + 1 - (L₀ + 1)))) =
+                  Fin.natAdd (L₀ - 1) k := by
+              ext
+              simp [k]
+              omega
+            rw [hidx, Fin.append_right]
+            have hcomp := hρComp k
+            have hsite :
+                (⟨k.val + L₀, by omega⟩ : Fin (M + 1)) =
+                  ⟨n + 1, by omega⟩ := by
+              ext
+              simp [k]
+              omega
+            rw [hsite] at hcomp
+            simpa [full, k] using hcomp.symm
+      rw [← evalWord_append, ← evalWord_append, hLeftList, hRightList]
+    calc
+      X * evalWord A (List.ofFn α) * evalWord A (List.ofFn ν)
+          = X * (A α₀ * evalWord A (List.ofFn αTail)) *
+              evalWord A (List.ofFn ν) := by rw [hα_eval]
+      _ = X * A α₀ *
+              (evalWord A (List.ofFn αTail) * evalWord A (List.ofFn ν)) := by
+            simp [Matrix.mul_assoc]
+      _ = X * A α₀ *
+              (evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+                  ρ ⟨k.val + 1, by omega⟩)) *
+                evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+                  ρ ⟨M + 1 - L₀ + r.val, by omega⟩))) := by
+            rw [hWord]
+      _ = (X * A α₀ *
+              evalWord A (List.ofFn (fun k : Fin (M + 1 - (L₀ + 1)) =>
+                ρ ⟨k.val + 1, by omega⟩))) *
+              evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+                ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) := by
+            simp [Matrix.mul_assoc]
+      _ = (A α₀ * YAt ⟨M + 1 - L₀, by omega⟩ ρ) *
+              evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+                ρ ⟨M + 1 - L₀ + r.val, by omega⟩)) := by
+            rw [hMirror]
+      _ = A α₀ *
+              (YAt ⟨M + 1 - L₀, by omega⟩ ρ *
+                evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+                  ρ ⟨M + 1 - L₀ + r.val, by omega⟩))) := by
+            simp [Matrix.mul_assoc]
+      _ = A α₀ *
+              (evalWord A (List.ofFn (fun r : Fin (L₀ - 1) =>
+                  ρ ⟨r.val + 1, by omega⟩)) *
+                YAt ⟨M, by omega⟩ ρ) := by
+            rw [hTransport]
+      _ = A α₀ * (evalWord A (List.ofFn αTail) * Y ν) := by
+            rw [hHeadρ, hYρ]
+      _ = (A α₀ * evalWord A (List.ofFn αTail)) * Y ν := by
+            simp [Matrix.mul_assoc]
+      _ = evalWord A (List.ofFn α) * Y ν := by rw [hα_eval]
+  rw [hMat]
 
 /-- Length-\(L_0\) trace identities imply the boundary block-window matrix equation.
 
@@ -354,17 +533,9 @@ length-\(L_0\) word \(\alpha\),
 This is the coordinate comparison needed by the block-injective
 boundary-matrix commutation lemma.
 
-**Open gap:** The proof is the missing coordinate form of the
-inverting-and-growing-back argument at the periodic boundary in
-arXiv:2011.12127, Section IV.C, lines 2078--2079. The trace rotation from the
-last cyclic window is formalized in
-`closure_property_boundary_block_window_trace_eq_of_groundSpaceMap`; it gives
-the trace identities visible at that cyclic window. The remaining step is to
-obtain the corresponding trace identities against all length-\(L_0\) word
-products. The algebraic separation of matrices from those identities is
-formalized in
-`block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective`.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+The proof first obtains the length-\(L_0\) trace identities from the cyclic
+boundary windows. Block injectivity then separates the resulting trace
+pairings, giving the displayed matrix identity. -/
 theorem closure_property_boundary_block_window_equation_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -584,7 +755,7 @@ at the periodic boundary is the equality
   =
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
-After choosing cyclic-window representation matrices, the remaining coordinate
+After choosing cyclic-window representation matrices, the coordinate
 reconstruction is the boundary product comparison
 \[
   Y_M(\tau^+_\eta(\mu))A^j
@@ -593,23 +764,10 @@ reconstruction is the boundary product comparison
 \]
 for all outside letters \(\eta\) and physical letters \(j\).
 
-**Unfaithful:** This proof relies on
-`closure_property_boundary_block_window_equation_of_groundSpaceMap`, whose proof
-is the open boundary matrix identity in the periodic-boundary closure-property
-argument in arXiv:2011.12127, Section IV.C, lines 2078--2079. The verified
-block-injective commutation lemma turns that coordinate comparison into the
-one-site commutation identity for the boundary matrix \(X\). The verified
-boundary-restriction equality lemma
-`boundary_restrictions_eq_of_commutes_and_one_sided` and the block-injective
-commutation lemma
-`boundary_matrix_commutes_of_isNBlkInjective_of_block_matEq` reduce the whole
-closure-property step at the periodic boundary to this boundary matrix identity,
-which is the transitive dependency for the coordinate consequences below.
-Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. Elimination: prove the
-length-\(L_0\) trace-probe identities from the periodic-boundary local
-constraints, then obtain the boundary matrix identity by trace separation;
-see the tracking paragraph in the paper-gap note. -/
+The proof uses the boundary block-window identity to derive the one-site
+commutation relation for \(X\). The one-sided boundary products then identify
+the first-letter products of the two boundary matrices, and hence the two
+cyclic restrictions. -/
 theorem closure_property_boundary_restrictions_eq_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -719,27 +877,15 @@ periodic-boundary coordinate comparison is
   A^\alpha\bigl(Y_M(\tau^+_\eta(\mu))A^jA^\sigma\bigr).
 \]
 
-**Unfaithful:** This proof currently relies on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`, whose proof
-depends on the unproved boundary matrix identity for the periodic-boundary
-comparison. This deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079
-by leaving open the coordinate form of the inverting-and-growing-back argument
-at the periodic boundary.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the length-\(L_0\) trace-probe identities from the
-periodic-boundary local constraints, obtain the boundary matrix identity by
-trace separation, and reprove this theorem without the unfaithful dependency;
-see the tracking paragraph in the paper-gap note.
-
 The comparison is derived from the periodic-boundary restriction equality
 \[
   \operatorname{Res}^{\tau^+_\eta(\mu)}_{M,L_0+1}(\psi)
   =
   \operatorname{Res}^{\tau^-_\eta(\mu)}_{M+1-L_0,L_0+1}(\psi).
 \]
-The displayed restriction equality is the remaining local form of the
+The displayed restriction equality is the local form of the
 periodic-boundary closure-property sentence in arXiv:2011.12127, Section IV.C,
-lines 2078--2079. See `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. -/
+lines 2078--2079. -/
 theorem closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -778,26 +924,15 @@ representation.
 
 For \(\psi=\Gamma_{M+1}(X)\), after fixing a boundary letter \(\eta\), a
 physical letter \(j\), and length-\(L_0\) words \(\alpha,\sigma\), the
-remaining periodic-boundary coordinate comparison is
+periodic-boundary coordinate comparison is
 \[
   A^\alpha\bigl(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\bigr)
   =
   A^\alpha\bigl(A^\mu A^jXA^\sigma\bigr).
 \]
 
-**Unfaithful:** This proof uses
-`closure_property_wrapped_mirror_left_word_products_of_groundSpaceMap`; that theorem
-transitively depends on the unproved boundary matrix identity for the
-periodic-boundary comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
-deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
-the coordinate form of the inverting-and-growing-back argument when closing the
-periodic boundary.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the length-\(L_0\) trace-probe identities from the
-periodic-boundary local constraints, obtain the boundary matrix identity by
-trace separation, and reprove this theorem without the unfaithful dependency;
-see the tracking paragraph in the paper-gap note. -/
+The proof combines the equality of the two boundary-crossing restrictions with
+the one-sided product equation for the window beginning at the last site. -/
 theorem closure_property_mirror_left_word_products_of_groundSpaceMap
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -837,59 +972,5 @@ theorem closure_property_mirror_left_word_products_of_groundSpaceMap
           (evalWord A (List.ofFn μ) * A j * X *
             evalWord A (List.ofFn σ)) := by
           rw [hOneSided.1 η j]
-
-/-- Auxiliary boundary-condition product equation needed for the
-periodic-boundary comparison.
-
-For each pair \(j,\sigma\), this states the existence of boundary conditions
-\(\rho^+_{j,\sigma}\) and \(\rho^-_{j,\sigma}\) with the same complementary
-word \(\mu\) as the two displayed boundary conditions, and satisfying
-\[
-  Y_M(\rho^+_{j,\sigma}) A^j A^\sigma
-  =
-  Y_{M+1-L_0}(\rho^-_{j,\sigma}) A^j A^\sigma .
-\]
-
-**Unfaithful:** This proof currently relies on
-`closure_property_mirror_left_word_products_of_groundSpaceMap`, which
-transitively depends on the unproved boundary matrix identity for the
-periodic-boundary comparison in
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`. This
-deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079 by leaving open
-the coordinate form of the inverting-and-growing-back argument when closing the
-periodic boundary.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
-Elimination: prove the length-\(L_0\) trace-probe identities from the
-periodic-boundary local constraints, obtain the boundary matrix identity by
-trace separation, and reprove this theorem without the unfaithful dependency;
-see the tracking paragraph in the paper-gap note. -/
-theorem closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap
-    {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
-    (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
-    {ψ : NSiteSpace d (M + 1)} {X : Matrix (Fin D) (Fin D) ℂ}
-    (hψX : ψ = groundSpaceMap A (M + 1) X)
-    (YAt : (i : Fin (M + 1)) → (Fin (M + 1) → Fin d) →
-      Matrix (Fin D) (Fin D) ℂ)
-    (hYAt : ∀ (i : Fin (M + 1)) (τ : Fin (M + 1) → Fin d),
-      cyclicRestrictₗ (show 0 < M + 1 by omega) (L₀ + 1) i τ ψ =
-        groundSpaceMap A (L₀ + 1) (YAt i τ))
-    (μ : Fin (M + 1 - (L₀ + 1)) → Fin d) :
-    ∃ ρPlus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
-    ∃ ρMinus : (j : Fin d) → (Fin L₀ → Fin d) → Fin (M + 1) → Fin d,
-      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
-          (k : Fin (M + 1 - (L₀ + 1))),
-        ρPlus j σ ⟨k.val + L₀, by omega⟩ = μ k) ∧
-      (∀ (j : Fin d) (σ : Fin L₀ → Fin d)
-          (k : Fin (M + 1 - (L₀ + 1))),
-        ρMinus j σ ⟨k.val + 1, by omega⟩ = μ k) ∧
-      ∀ (j : Fin d) (σ : Fin L₀ → Fin d),
-        YAt ⟨M, by omega⟩ (ρPlus j σ) * A j * evalWord A (List.ofFn σ) =
-          YAt ⟨M + 1 - L₀, by omega⟩ (ρMinus j σ) * A j *
-            evalWord A (List.ofFn σ) := by
-  have hLeft :=
-    closure_property_mirror_left_word_products_of_groundSpaceMap
-      (A := A) hInj hL₀ hM hψX YAt hYAt μ
-  exact closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap_left_words
-    (A := A) hInj hL₀ (le_of_lt hM) hψX YAt hYAt μ hLeft
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.BoundaryClosing
 import TNLean.MPS.ParentHamiltonian.BoundaryClosingStripping
+import TNLean.MPS.ParentHamiltonian.BoundaryClosingAuxiliary
 import TNLean.MPS.ParentHamiltonian.ExtendRight
 import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.RestrictTransport
@@ -48,10 +49,10 @@ comparison at the periodic boundary forces \(X\) scalar: the ground space is
 * [FNW92] Sections 3–4
 * [PGVWC07] arXiv:quant-ph/0608197, Sections 5–6
 
-## Remaining mathematical ingredients
+## Periodic-boundary comparison
 
-The remaining coordinate form of the closure-property ingredient at the periodic
-boundary is the passage from
+The coordinate form of the closure-property ingredient at the periodic boundary
+is the passage from
 \[
   A^\mu A^j X=Y^+_{\tau^+_\eta(\mu)}A^j,\qquad
   X A^j A^\mu=A^jY^-_{\tau^-_\eta(\mu)}
@@ -62,7 +63,9 @@ to
 \]
 for the same complementary-site word \(\mu\). The source states the
 closure-property step in arXiv:2011.12127, Section IV.C, lines 2078--2079; the
-displayed equations are the local coordinate form used in this formalization.
+displayed equations are the local coordinate form used here.
+The boundary block-window identity supplies the commutation relation for
+\(X\), and the one-sided products then identify the two boundary matrices.
 
 The open-chain build-up follows the inverting-and-growing-back argument from
 arXiv:2011.12127, Section IV.C, lines 2049--2078.  The normal case also uses the
@@ -706,10 +709,8 @@ theorem closure_property_boundary_restriction_eq_of_fixed_boundary_letters
 /-- Product equality needed in the periodic-boundary closure-property step,
 \(Y_M(\tau^+_\eta(\mu))A^jA^\sigma =
 Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\).
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+This is the product form of the periodic-boundary comparison in
+arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
 theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -737,10 +738,8 @@ theorem closure_property_boundary_closing_product_eq_of_chainGroundSpace
 
 /-- Matrix equality obtained from the product equality and block injectivity:
 \(Y_M(\tau^+_\eta(\mu))A^j = Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j\).
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+This is the first-letter product form of the periodic-boundary comparison in
+arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
 theorem closure_property_boundary_right_products_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -777,10 +776,8 @@ theorem closure_property_boundary_right_products_eq_of_chainGroundSpace
 
 /-- First-letter restriction equality \(R_jB^+_{\eta,\mu}=R_jB^-_{\eta,\mu}\),
 obtained by restricting the displayed matrix equation at the first physical index.
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+This is the first-letter restriction form of the periodic-boundary comparison in
+arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
 theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -816,10 +813,8 @@ theorem closure_property_fixed_boundary_letter_eq_of_chainGroundSpace
 
 /-- Restriction equality \(B^+_{\eta,\mu}=B^-_{\eta,\mu}\) for the two
 boundary-crossing restrictions, obtained from the first-letter family.
-**Unfaithful:** This proof relies directly or transitively on
-`closure_property_boundary_restrictions_eq_of_groundSpaceMap`; its coordinate
-form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+This is the restriction form of the periodic-boundary comparison in
+arXiv:2011.12127, Section IV.C, lines 2078--2079. -/
 theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ M : ℕ}
     (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀) (hM : L₀ < M)
@@ -849,9 +844,6 @@ theorem closure_property_boundary_restriction_eq_of_chainGroundSpace
 /-- Boundary matrices agree once their right-products with every \(A^j\) agree:
 \(Y^+_{\tau^+_\eta(\mu)}A^j=Y^-_{\tau^-_\eta(\mu)}A^j\Rightarrow
 Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}\).
-**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
-whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction:** \(L₀+1<N\); see the same paper-gap note. -/
 theorem wrapped_mirror_witness_agree_of_chainGroundSpace
     {A : MPSTensor d D} [NeZero D] {L₀ L N : ℕ}
@@ -896,9 +888,6 @@ theorem wrapped_mirror_witness_agree_of_chainGroundSpace
 /-- Closure-property containment
 \(\mathcal G_{N,L}(A) \subseteq \mathbb C\,V^{(N)}(A)\) for \(L>L₀\) and
 \(L₀+1<N\), following arXiv:2011.12127, Section IV.C, lines 2078--2090.
-**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
-whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction:** \(L₀+1<N\); see the same paper-gap note. -/
 theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
     {A : MPSTensor d D} [NeZero D]
@@ -930,9 +919,6 @@ theorem chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction
 
 /-- On a periodic chain, \(\mathcal G_{N,L}(A)=\mathbb C\,V^{(N)}(A)\) for
 \(L>L₀\) and \(L₀+1<N\), by arXiv:2011.12127, Section IV.C, lines 2078--2090.
-**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
-whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction:** \(L₀+1<N\); see the same paper-gap note. -/
 theorem chainGroundSpace_eq_mpvSubmodule_normal {A : MPSTensor d D} [NeZero D]
     (hA : IsNormal A) {L₀ : ℕ} (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -966,9 +952,6 @@ theorem groundSpace_unique_periodic {A : MPSTensor d D} [NeZero D] (hA : IsInjec
 
 /-- Unique ground state for tensors injective after blocking at range \(2L₀\),
 with \(L₀+1<N\).
-**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
-whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction (two-site case):** Same note tracks excluded \(L₀=1,N=2\). -/
 theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)
@@ -984,9 +967,6 @@ theorem parentHamiltonian_unique_gs_injective {A : MPSTensor d D} [NeZero D]
 
 /-- Unique ground state for normal tensors at range \(L₀+1\), with \(L₀+1<N\):
 \(\dim \mathcal G_{N,L₀+1}(A)=1\).
-**Unfaithful:** Relies on `closure_property_boundary_restrictions_eq_of_groundSpaceMap`,
-whose coordinate form deviates from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison.
 **Scope restriction:** \(L₀+1<N\); see the same paper-gap note. -/
 theorem parentHamiltonian_unique_gs_normal {A : MPSTensor d D} [NeZero D]
     {L₀ : ℕ} (hA : IsNormal A) (hInj : IsNBlkInjective A L₀) (hL₀ : 0 < L₀)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -19,11 +19,11 @@ $Y_i(\tau)$ below satisfy
 \]
 Once the one-sided boundary products are known, equality of the restrictions
 follows from the boundary-matrix commutation relation $XA^j=A^jX$ for every
-physical letter $j$. The remaining step is to derive the block-window identity
+physical letter $j$. The block-window identity
 \[
     X A^\alpha A^\nu=A^\alpha Y_\nu
 \]
-from the cyclic-window constraints crossing the periodic cut.
+is derived from the cyclic-window constraints crossing the periodic cut.
 
 \begin{lemma}[Block-to-letter translation of the boundary block matrix equation]
     \label{lem:block_mateq_of_blocked_mateq}
@@ -212,8 +212,11 @@ from the cyclic-window constraints crossing the periodic cut.
 \begin{theorem}[Trace identities with length-$L_0$ probes from cyclic-window constraints]
     \label{thm:closure_property_boundary_block_window_trace_word_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap}
+    \leanok
     \uses{def:ground_space_map, rem:cyclic_window_operators,
-        lem:closure_property_boundary_block_window_trace_ground_space_map}
+        lem:closure_property_boundary_crossing_equations_ground_space_map,
+        lem:closure_property_boundary_condition_product_window_witnesses,
+        lem:outside_labels_determine_boundary_witnesses}
     Let $A$ be $L_0$-block-injective with $L_0>0$, $L_0<M$, and
     $D\ge1$. Let
     \[
@@ -231,28 +234,19 @@ from the cyclic-window constraints crossing the periodic cut.
 \end{theorem}
 
 \begin{proof}
-    \notready
-    Lemma~\ref{lem:closure_property_boundary_block_window_trace_ground_space_map}
-    gives the same identity when the left probe is a single letter:
+    \leanok
+    Choose representation matrices for every cyclic restriction of length
+    $L_0+1$. Fix $\alpha$ and $\nu$. The boundary-crossing equations move the
+    matrix $X$ through the first boundary letter. The adjacent boundary-window
+    product then transports this comparison through the remaining $L_0-1$
+    letters. Finally, the outside-label uniqueness lemma identifies the final
+    boundary matrix with the matrix $Y_\nu$ attached to the complementary word
+    $\nu$. Thus
     \[
-        \operatorname{tr}\left(A^j X A^\alpha A^\nu\right)
-        =
-        \operatorname{tr}\left(A^j A^\alpha Y_\nu\right).
+        X A^\alpha A^\nu=A^\alpha Y_\nu .
     \]
-    Hence the theorem is already proved in the special case $L_0=1$. For
-    $L_0>1$, the remaining point is the promotion from single-letter probes to
-    longer word probes. The source describes this as applying the same
-    inverting-and-growing-back argument when closing the boundary
-    \cite[Section~IV.C, lines~2078--2079]{Cirac2021Matrix}; it does not spell
-    out the coordinate reconstruction. What remains to be supplied is a
-    boundary-crossing comparison which, for every length-$L_0$ word $\beta$,
-    derives
-    \[
-        \operatorname{tr}\left(A^\beta X A^\alpha A^\nu\right)
-        =
-        \operatorname{tr}\left(A^\beta A^\alpha Y_\nu\right)
-    \]
-    from the cyclic restrictions crossing the periodic cut.
+    Multiplying on the left by $A^\beta$ and taking the trace gives the
+    asserted identity for every length-$L_0$ word $\beta$.
 \end{proof}
 
 \begin{theorem}[Length-word trace separation for the boundary block window]
@@ -296,6 +290,7 @@ from the cyclic-window constraints crossing the periodic cut.
 \begin{lemma}[Matrix identity $X A^\alpha A^\nu=A^\alpha Y_\nu$ from cyclic-window constraints]
     \label{lem:closure_property_boundary_block_window_equation_ground_space_map}
     \lean{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}
+    \leanok
     \uses{def:ground_space_map, rem:cyclic_window_operators,
         thm:closure_property_boundary_block_window_trace_word_ground_space_map,
         thm:block_window_matrix_equation_trace_word_products}
@@ -314,7 +309,7 @@ from the cyclic-window constraints crossing the periodic cut.
 \end{lemma}
 
 \begin{proof}
-    \notready
+    \leanok
     Theorem~\ref{thm:closure_property_boundary_block_window_trace_word_ground_space_map}
     gives, for every word $\beta$ of length $L_0$,
     \[
@@ -1097,7 +1092,7 @@ from the cyclic-window constraints crossing the periodic cut.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     Choose matrices $Y_i(\tau)$ representing the length-$(L_0+1)$
     restrictions. The one-sided boundary-product lemma gives, for every
     outside letter $\eta$ and physical letter $j$,
@@ -1125,11 +1120,7 @@ from the cyclic-window constraints crossing the periodic cut.
         Y_{M+1-L_0}(\tau^-_\eta(\mu))A^j .
     \]
     Lemma~\ref{lem:closed_boundary_restrictions_from_first_letter_products}
-    then identifies the two boundary-crossing restrictions. Thus the restriction
-    equality has been reduced to the boundary matrix identity in the
-    closure-property comparison. The derivation of that identity from the
-    cyclic-window constraints at the periodic boundary is the remaining part of
-    the source closure-property sentence at the periodic boundary in
-    \cite[lines~2078--2079]{Cirac2021Matrix}; it is recorded in
-    \path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex}.
+    then identifies the two boundary-crossing restrictions, giving the
+    periodic-boundary comparison of
+    \cite[lines~2078--2079]{Cirac2021Matrix}.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -237,11 +237,23 @@ is derived from the cyclic-window constraints crossing the periodic cut.
     \leanok
     Choose representation matrices for every cyclic restriction of length
     $L_0+1$. Fix $\alpha$ and $\nu$. The boundary-crossing equations move the
-    matrix $X$ through the first boundary letter. The adjacent boundary-window
-    product then transports this comparison through the remaining $L_0-1$
-    letters. Finally, the outside-label uniqueness lemma identifies the final
-    boundary matrix with the matrix $Y_\nu$ attached to the complementary word
-    $\nu$. Thus
+    matrix $X$ through the first boundary letter. In local boundary notation
+    this has the form
+    \[
+        X A^{\rho_0}A^{\rho_1\cdots\rho_{M-L_0}}
+        =
+        A^{\rho_0}Y_{M+1-L_0}(\rho).
+    \]
+    The adjacent boundary-window product then transports this comparison
+    through the remaining $L_0-1$ boundary letters:
+    \[
+        Y_{M+1-L_0}(\rho)A^{\rho_{M+1-L_0}\cdots\rho_{M-1}}
+        =
+        A^{\rho_1\cdots\rho_{L_0-1}}Y_M(\rho).
+    \]
+    Finally, the outside-label uniqueness lemma identifies the final boundary
+    matrix with the matrix $Y_\nu$ attached to the complementary word $\nu$.
+    Thus
     \[
         X A^\alpha A^\nu=A^\alpha Y_\nu .
     \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_reverse.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_reverse.tex
@@ -538,7 +538,7 @@ $N\ge2$, $L_0+1<N$, and $L_0<L\le N$.
         \qquad
         X A^j A^\mu = A^jY^-_{\tau^-_\eta(\mu)}.
     \]
-    The remaining boundary-crossing comparison is the equality
+    The boundary-crossing comparison is the equality
     \[
         Y^+_{\tau^+_\eta(\mu)} = Y^-_{\tau^-_\eta(\mu)}.
     \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_reverse.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_reverse.tex
@@ -227,8 +227,8 @@ left-multiplied boundary comparison.
     \lean{MPSTensor.closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap}
     \leanok
     \uses{def:l_blk_injective, def:ground_space_map, rem:cyclic_window_operators,
-        lem:closure_property_boundary_one_sided_products_ground_space_map,
-        lem:closure_property_auxiliary_product_from_opposite_boundary_words}
+        thm:closure_property_mirror_left_word_products_ground_space,
+        thm:closure_property_auxiliary_boundary_product_ground_space_left_words}
     Let $A$ be $L_0$-block-injective with $L_0>0$ and $D\ge1$. Let $\psi$ be a
     state on the chain of length $M+1$ with open-chain representation
     $\psi=\Gamma_{M+1}(X)$.  Let $Y_i(\tau)$ be matrices satisfying
@@ -255,28 +255,26 @@ left-multiplied boundary comparison.
 \end{theorem}
 
 \begin{proof}
-    \notready
-    Lemma~\ref{lem:closure_property_boundary_one_sided_products_ground_space_map}
-    gives
+    \leanok
+    Theorem~\ref{thm:closure_property_mirror_left_word_products_ground_space}
+    gives, for every boundary letter $\eta$, physical letter $j$, and words
+    $\alpha,\sigma$ of length $L_0$,
     \[
-        Y_M(\tau^+_{\eta}(\mu))A^j
+        A^\alpha
+        \left(Y_{M+1-L_0}(\tau^-_\eta(\mu))A^jA^\sigma\right)
         =
-        A^\mu A^j X .
+        A^\alpha
+        \left(A^\mu A^jXA^\sigma\right).
     \]
-    By
-    Lemma~\ref{lem:closure_property_auxiliary_product_from_opposite_boundary_words},
-    it remains to prove, for every boundary letter $\eta$, every physical
-    letter $j$, and every word $\sigma$ of length $L_0$,
+    Theorem~\ref{thm:closure_property_auxiliary_boundary_product_ground_space_left_words}
+    applies this left-multiplied comparison together with the one-sided
+    boundary products and gives the displayed boundary conditions
+    $\rho^+_{j,\sigma}$ and $\rho^-_{j,\sigma}$, including
     \[
-        Y_{M+1-L_0}(\tau^-_{\eta}(\mu))A^jA^\sigma
+        Y_M(\rho^+_{j,\sigma})A^jA^\sigma
         =
-        A^\mu A^jXA^\sigma .
+        Y_{M+1-L_0}(\rho^-_{j,\sigma})A^jA^\sigma .
     \]
-    % The cited paragraph does not display this formula. It is the coordinate
-    % reconstruction isolated here for the boundary-crossing restrictions used
-    % at the periodic boundary in \cite[lines~2078--2079]{Cirac2021Matrix}.
-    % Remaining gap recorded in
-    % docs/paper-gaps/cpgsv21_normal_range_reduction.tex.
 \end{proof}
 
 \begin{theorem}[Product equality at the periodic boundary]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_reverse.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing_reverse.tex
@@ -104,7 +104,7 @@ left-multiplied boundary comparison.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     The matrices $Y_i(\tau)$ give the local ground-space representations needed
     in the preceding lemma.
     Once the preceding boundary-restriction equality is proved, it gives
@@ -150,7 +150,7 @@ left-multiplied boundary comparison.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     Once the comparison of the two cyclic restrictions is available, it gives
     \[
         A^\alpha
@@ -199,7 +199,7 @@ left-multiplied boundary comparison.
 \end{lemma}
 
 \begin{proof}
-    \notready
+    \leanok
     Let $Y_i(\tau)$ be the representation matrices supplied by
     Lemma~\ref{lem:chain_ground_space_window_witnesses}.  By
     Theorem~\ref{thm:boundary_closing_right_products_chain_ground_space},
@@ -301,7 +301,7 @@ left-multiplied boundary comparison.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     \uses{thm:closure_property_auxiliary_boundary_product_chain_ground_space,
         thm:boundary_closing_product_pointwise_compatible_boundary_assignments}
     Theorem~\ref{thm:closure_property_auxiliary_boundary_product_chain_ground_space}
@@ -355,7 +355,7 @@ left-multiplied boundary comparison.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     Fix $j$ and set
     \[
         Z_j=
@@ -430,7 +430,7 @@ left-multiplied boundary comparison.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     The reduced cyclic-window compatibilities at the boundary give, for every
     physical letter $j$,
     \[
@@ -525,7 +525,7 @@ $N\ge2$, $L_0+1<N$, and $L_0<L\le N$.
 \end{theorem}
 
 \begin{proof}
-    \notready
+    \leanok
     \uses{thm:reduced_wrapped_boundary_compatibilities,
         thm:conditional_normal_range_reduction_witness_comparison,
         lem:padded_complement_annihilation}

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -25,8 +25,8 @@ range-reduction comparison is recorded in
 periodic-boundary comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}; its current
 coordinate form is recorded in
-\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}, with the
-length-$L_0$ trace-probe step isolated in
+\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}; the
+length-$L_0$ trace-probe step was isolated in
 \href{https://github.com/LionSR/TNLean/issues/2929}{issue \#2929};
 and the parent-Hamiltonian consequences are recorded in
 \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}
@@ -68,7 +68,7 @@ periodic-boundary closure-property sentence, and
 \section{The formal statement}
 
 The corresponding formal statement keeps the intended hypotheses, with one
-formalization-added range restriction, $L_0+1<N$, recorded as a scope
+additional range restriction, $L_0+1<N$, recorded as a scope
 restriction in Section~\ref{sec:scope-minimal-ring}. In
 mathematical terms, it assumes that $A$ is normal, that $A$ is injective
 after blocking a positive number $L_0$ of sites, and that the ring has length
@@ -82,7 +82,8 @@ $\Omega_N(A)$:
 \]
 In the formal statement this is the equality between the periodic-boundary ground
 space and the subspace \(\mathbb C\,\Omega_N(A)\). The hard inclusion into
-\(\mathbb C\,\Omega_N(A)\) is the remaining range-reduction lemma.
+\(\mathbb C\,\Omega_N(A)\) is the range-reduction lemma for the non-minimal
+ring case \(L_0+1<N\).
 \footnote{Formal locations:
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:902 for
 \path{MPSTensor.chainGroundSpace_le_mpvSubmodule_of_normal_range_reduction},
@@ -134,10 +135,10 @@ through the older single-site intersection lemma.
 \path{TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean}:328 for
 \path{MPSTensor.chainGroundSpace_le_groundSpace_of_isNBlkInjective}.}
 
-\section{The remaining block-window identity}
+\section{The boundary block-window identity}
 
 After the open-boundary range reduction, a periodic-boundary ground state can
-be written in trace form with a matrix \(X\). The point left to prove is the
+be written in trace form with a matrix \(X\). The boundary comparison uses the
 block-window identity
 \[
   XA^\alpha A^\nu=A^\alpha Y_\nu
@@ -165,7 +166,7 @@ written as
     A^{\omega_{\mathrm{head}}}Y_\rho\right)
 \end{align}
 for a matrix \(Y_\rho\) depending only on the labels outside the window.
-The closure-property comparison supplies the missing movement of \(X\) through
+The closure-property comparison supplies the movement of \(X\) through
 the boundary-crossing word.
 
 In the coordinate form used here, \(\mu\) denotes the nonempty word placed on
@@ -248,17 +249,17 @@ identity
   =
   \operatorname{tr}\left(A^j A^\alpha Y_\nu\right),
 \]
-formalized as
+recorded as
 \leanid{MPSTensor.closure_property_boundary_block_window_trace_eq_of_groundSpaceMap}.
 These identities pair the matrix difference only with the single letters
 \(A^j\), and therefore do not separate matrices for a general
-\(L_0\)-block-injective tensor. The remaining mathematical task is to obtain
-the corresponding trace identities against all length-\(L_0\) word products
-\(A^\beta\), or an equivalent coordinate comparison; those products span the
-full matrix algebra by block injectivity.\footnote{The open formal statement is
+\(L_0\)-block-injective tensor. The corresponding trace identities against all
+length-\(L_0\) word products \(A^\beta\) are now obtained from the same
+boundary-crossing cyclic-window comparison; those products span the full matrix
+algebra by block injectivity.\footnote{Formal statement:
 \leanid{MPSTensor.closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap}.}
-The trace-separation theorem records the algebraic consequence: if these
-length-\(L_0\) trace identities are known, then
+The trace-separation theorem records the algebraic consequence: these
+length-\(L_0\) trace identities give
 \(XA^\alpha A^\nu=A^\alpha Y_\nu\).\footnote{Formal location:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean} for
 \leanid{MPSTensor.block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective}.}
@@ -266,7 +267,7 @@ After that equation is proved from the cyclic-window constraints, the
 block-injective commutation lemma supplies the one-site commutation identity,
 the boundary-restriction equality lemma supplies the equality of the two
 boundary restrictions, and the periodic-boundary comparison follows.\footnote{The
-present source-labelled statement for this step is
+source-labelled statement for this step is
 \leanid{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}.}
 
 Equivalently, the same boundary phenomenon can be recognized in coordinate
@@ -328,18 +329,18 @@ with a \texttt{Scope restriction} docstring marker.
 
 \section{Conclusion}
 
-The classification is an open gap. It identifies a difference between the
-compressed source proof and the available formal lemmas; it is not a
-source-error claim. The cited Cirac--Perez-Garcia--Schuch--Verstraete 2021
-argument is not refuted. The source compresses two mathematical steps which the
-formalization must keep separate: the $B$-region inverting and growing-back
-open-chain range reduction, and the movement of the trace-form matrix \(X\)
-through the boundary-crossing word in the periodic-boundary comparison.
+This note records two distinctions between the compressed source proof and the
+available formal lemmas; it is not a source-error claim. The cited
+Cirac--Perez-Garcia--Schuch--Verstraete 2021 argument is not refuted. The source
+compresses two mathematical steps which the present proof keeps separate: the
+$B$-region inverting and growing-back open-chain range reduction, and the
+movement of the trace-form matrix \(X\) through the boundary-crossing word in
+the periodic-boundary comparison.
 
 The open-chain part has been proved under the intended block-injective
 hypotheses, though not by reusing the older single-site intersection theorem.
-The last mathematical point is to derive, from the cyclic length-\((L_0+1)\)
-constraints at the periodic boundary, the length-\(L_0\) trace identities
+For the nonempty-complement periodic-boundary comparison, the cyclic
+length-\((L_0+1)\) constraints now give the length-\(L_0\) trace identities
 \[
   \operatorname{tr}(A^\beta X A^\alpha A^\nu)
   =
@@ -352,7 +353,9 @@ word \(\nu\). The trace-separation lemma then gives the matrix identity
 \]
 for every \(\alpha,\nu\). The block-injective commutation lemma then gives
 \(XA^k=A^kX\) for every physical letter \(k\), and the verified boundary-restriction equality
-lemma supplies the periodic-boundary comparison.
+lemma supplies the periodic-boundary comparison. The remaining restriction
+recorded here is the minimal ring case \(N=L_0+1\), where the complement word is
+empty and the present boundary-crossing comparison does not apply.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- The length-`L₀` word-probe trace identity is the main remaining step in the periodic-boundary closure argument for the parent Hamiltonian uniqueness proof, following arXiv:2011.12127, Section IV.C, lines 2078–2090 (see #2929).
- The single-letter probe theorem was already proved; this closes the final gap by extending the result to all length-`L₀` words using the periodic-boundary inverting-and-growing-back argument of Section IV.C.
- Resolves the `sorry` in `closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap` that was blocking downstream uniqueness theorems.

### Description

- **New**: `TNLean/MPS/ParentHamiltonian/BoundaryClosingAuxiliary.lean` — proves `closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`, extracted from the stripping file.
- **Modified**: `TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean` — proves `closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap`: for `L₀`-block-injective `A`, every cyclic restriction of length `L₀+1` in `G_{L₀+1}(A)` yields boundary matrices `Y_ν` satisfying `tr(Aᵝ X Aᵅ Aᵛ) = tr(Aᵝ Aᵅ Y_ν)` for all words `α,β` with `|α|=|β|=L₀` and complement words `ν`. The proof transports the boundary matrix through the boundary-crossing cyclic window, identifies the final boundary matrix from outside labels, and applies block-injective trace separation.
- **Modified**: `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean` — updates imports to re-export the new auxiliary module.
- **Modified**: `TNLean.lean` — registers `TNLean.MPS.ParentHamiltonian.BoundaryClosingAuxiliary`.
- **Modified**: `blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex` and `ch13_parent_hamiltonian_normal_closing_reverse.tex` — marks the trace-word theorem and boundary restriction equality entries as `\leanok`.
- **Modified**: `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` — records that the nonempty-complement comparison is now obtained; the `N = L₀+1` case remains out of scope as documented.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BoundaryClosingAuxiliary.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`
- `lake build TNLean`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean TNLean/MPS/ParentHamiltonian/BoundaryClosingAuxiliary.lean TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean || true`
- Blueprint sync (`python3 scripts/blueprint_lean_sync.py --root . --ci`) and oversized-file guard pass.
- `lake exe checkdecls blueprint/lean_decls`

---
Closes #2929

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large, proof-heavy change in the MPS parent-Hamiltonian periodic-closure layer; correctness hinges on the new boundary transport argument and downstream uniqueness theorems, though scope stays within existing formalized hypotheses.
> 
> **Overview**
> Closes the main periodic-boundary gap in the parent-Hamiltonian uniqueness track: **`closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap`** now has a full proof (the previous `sorry` and one-letter-only fallback are removed). The argument builds boundary matrices from cyclic windows, transports \(X\) through boundary-crossing and adjacent-window products, identifies \(Y_\nu\) from outside labels, and derives \(X A^\alpha A^\nu = A^\alpha Y_\nu\); existing trace-separation then yields the matrix block-window identity and feeds **`closure_property_boundary_restrictions_eq_of_groundSpaceMap`** and the left-word / mirror comparison chain.
> 
> **`closure_property_auxiliary_boundary_product_eq_of_groundSpaceMap`** moves to new **`BoundaryClosingAuxiliary.lean`**; root and **`UniqueGroundState`** imports are updated. Docstrings drop “unfaithful” / paper-gap dependency language where those steps are now proved; blueprint ch13 entries and **`cpgsv21_normal_range_reduction.tex`** record the nonempty-complement case as obtained, with **\(N = L_0+1\)** still noted as out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98721ae9fd88ff0f054d76c5b64d72e7a281bf49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->