### PR TITLE
feat(parent): state NNCPH ground-space condition

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -29,6 +29,9 @@ clause from Definition 3.9.
 * `MPSTensor.HasParentHamiltonianGroundSpaceSpanning B L A` — the Definition
   3.9 condition that the kernel of \(H_L^{(N)}\) is spanned by the BNT vectors
   \(V^{(N)}(A_j)\) for every \(N>L\).
+* `MPSTensor.HasNNCPHGroundSpace B A N` — the fixed-chain nearest-neighbor
+  form: length-two commutation, zero energy of \(V^{(N)}(B)\), and the
+  ground-space spanning equation.
 
 ## Main results
 
@@ -121,6 +124,25 @@ def HasParentHamiltonianGroundSpaceSpanning (B : MPSTensor d D) (L : ℕ)
     {r : ℕ} {dim : Fin r → ℕ} (A : (j : Fin r) → MPSTensor d (dim j)) : Prop :=
   ∀ N : ℕ, L < N → LinearMap.ker (parentHamiltonian B L N) = bntMPSVectorSpan A N
 
+/-- Fixed-chain nearest-neighbor commuting parent-Hamiltonian ground-space
+condition from arXiv:1606.00608, Definition 3.9 and Theorem 3.10(iii).
+
+For a canonical-form tensor \(B\) with BNT components \(A_j\), this packages
+the three finite-chain equations:
+\[
+  h_i h_j=h_j h_i,\qquad
+  h_iV^{(N)}(B)=0,\qquad
+  \ker H_2^{(N)}(B)=\operatorname{span}\{V^{(N)}(A_j)\}_j .
+\]
+The source theorem quantifies this condition over all \(N>2\).  This definition
+only records the condition for one fixed chain length; it does not assert that
+the displayed spanning equation has been proved for any tensor. -/
+def HasNNCPHGroundSpace (B : MPSTensor d D)
+    {r : ℕ} {dim : Fin r → ℕ} (A : (j : Fin r) → MPSTensor d (dim j))
+    (N : ℕ) : Prop :=
+  IsNNCPHGroundState B N ∧
+    LinearMap.ker (parentHamiltonian B 2 N) = bntMPSVectorSpan A N
+
 /-- The nearest-neighbor commuting condition is a special case of the commuting
 parent Hamiltonian (length two). -/
 theorem IsNNCPH.isCommutingParentHam {A : MPSTensor d D} {N : ℕ} (h : IsNNCPH A N) :
@@ -148,6 +170,49 @@ theorem IsNNCPH.isNNCPHGroundState {A : MPSTensor d D} {N : ℕ}
     (h : IsNNCPH A N) (hN : 2 ≤ N) :
     IsNNCPHGroundState A N :=
   ⟨h, parentHamiltonian_frustrationFree A 2 N hN⟩
+
+/-- The full fixed-chain NNCPH ground-space condition includes the
+commutation and zero-energy equations. -/
+theorem HasNNCPHGroundSpace.isNNCPHGroundState {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    {N : ℕ} (h : HasNNCPHGroundSpace B A N) :
+    IsNNCPHGroundState B N :=
+  h.1
+
+/-- The full fixed-chain NNCPH ground-space condition includes length-two
+translated parent-term commutation. -/
+theorem HasNNCPHGroundSpace.isNNCPH {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    {N : ℕ} (h : HasNNCPHGroundSpace B A N) :
+    IsNNCPH B N :=
+  h.isNNCPHGroundState.isNNCPH
+
+/-- The full fixed-chain NNCPH ground-space condition includes zero energy of
+the periodic MPS vector. -/
+theorem HasNNCPHGroundSpace.isFrustrationFree {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    {N : ℕ} (h : HasNNCPHGroundSpace B A N) :
+    IsFrustrationFree B 2 N (mpv B) :=
+  h.isNNCPHGroundState.isFrustrationFree
+
+/-- The full fixed-chain NNCPH ground-space condition contains the BNT
+ground-space spanning equation. -/
+theorem HasNNCPHGroundSpace.groundSpaceSpanning {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    {N : ℕ} (h : HasNNCPHGroundSpace B A N) :
+    LinearMap.ker (parentHamiltonian B 2 N) = bntMPSVectorSpan A N :=
+  h.2
+
+/-- Quantifying the fixed-chain NNCPH ground-space condition over \(N>2\)
+supplies the nearest-neighbor instance of the parent-Hamiltonian spanning
+predicate. -/
+theorem HasNNCPHGroundSpace.hasParentHamiltonianGroundSpaceSpanning
+    {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    (h : ∀ N : ℕ, 2 < N → HasNNCPHGroundSpace B A N) :
+    HasParentHamiltonianGroundSpaceSpanning B 2 A := by
+  intro N hN
+  exact (h N hN).groundSpaceSpanning
 
 /-- If the two-site parent terms are idempotents \(pᵢ\) with
 \(pᵢpⱼ = pⱼpᵢ\), then the nearest-neighbor parent Hamiltonian is commuting on

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -85,15 +85,40 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     equation for a single periodic MPS vector.
 \end{definition}
 
+\begin{definition}[Nearest-neighbor commuting parent-Hamiltonian ground-space condition]%
+    \label{def:has_nncph_ground_space}
+    \lean{MPSTensor.HasNNCPHGroundSpace}
+    \leanok
+    \uses{def:is_nncph_ground_state, def:parent_hamiltonian_ground_space_spanning}
+    For a fixed chain length $N$, this condition is the conjunction of the
+    nearest-neighbor commutation equation, the zero-energy equation for the MPS
+    vector, and the ground-space spanning equation:
+    \[
+        h_i h_j=h_j h_i,\qquad
+        h_iV^{(N)}(B)=0,\qquad
+        \ker H_2^{(N)}(B)
+        =
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
+    \]
+    The source statement in
+    \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv} quantifies this condition
+    over all $N>2$.
+\end{definition}
+
 \begin{remark}[Elementary consequences of the commuting definition]
     \lean{MPSTensor.IsNNCPH.isCommutingParentHam}
     \lean{MPSTensor.IsNNCPHGroundState.isNNCPH}
     \lean{MPSTensor.IsNNCPHGroundState.isFrustrationFree}
     \lean{MPSTensor.IsNNCPH.isNNCPHGroundState}
+    \lean{MPSTensor.HasNNCPHGroundSpace.isNNCPHGroundState}
+    \lean{MPSTensor.HasNNCPHGroundSpace.isNNCPH}
+    \lean{MPSTensor.HasNNCPHGroundSpace.isFrustrationFree}
+    \lean{MPSTensor.HasNNCPHGroundSpace.groundSpaceSpanning}
+    \lean{MPSTensor.HasNNCPHGroundSpace.hasParentHamiltonianGroundSpaceSpanning}
     \lean{MPSTensor.IsCommutingParentHam.symm}
     \lean{MPSTensor.IsCommutingParentHam.ham_comm_localTerm}
     \leanok
-    \uses{lem:parent_hamiltonian_ff}
+    \uses{lem:parent_hamiltonian_ff, def:has_nncph_ground_space}
     The nearest-neighbor condition is the length-$2$ specialization of the
     general commuting condition. The ground-vector condition above contains
     this commuting equation together with the frustration-free equation for
@@ -103,6 +128,14 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         h_i\,V^{(N)}(A)=0
     \]
     for every site $i$.
+    The fixed-chain ground-space condition also contains
+    \[
+        \ker H_2^{(N)}(B)
+        =
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\},
+    \]
+    and quantifying this condition over all $N>2$ gives the
+    nearest-neighbor case of the spanning condition above.
 \end{remark}
 
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -69,9 +69,17 @@ formal development. The source definition of a parent Hamiltonian also requires
 the whole ground-state subspace to be spanned by the periodic MPS vectors for
 $N>L$. That spanning condition is now named separately as
 \leanid{MPSTensor.HasParentHamiltonianGroundSpaceSpanning}; it is not part of
-\leanid{MPSTensor.IsNNCPHGroundState}. The present predicate is therefore a
-necessary finite-chain ground-vector condition, not the complete source
-ground-space statement.
+\leanid{MPSTensor.IsNNCPHGroundState}. The fixed-chain predicate
+\leanid{MPSTensor.HasNNCPHGroundSpace} packages the commutation equation, the
+zero-energy equation, and the spanning equation
+\begin{align}
+  \ker H_2^{(N)}(B)
+  =
+  \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}.
+\end{align}
+The source theorem should use this predicate quantified over \(N>2\). The
+predicate is only a named condition; it does not prove that the spanning
+equation holds for any concrete canonical-form tensor.
 
 This still does not prove the full source theorem.  The present declarations do
 not yet prove the named ground-space spanning condition, the three-way


### PR DESCRIPTION
## Summary

- add `MPSTensor.HasNNCPHGroundSpace`, the fixed-chain NNCPH ground-space condition combining length-two commutation, zero energy of `V^(N)(B)`, and the Definition 3.9 BNT spanning equation
- add elementary projection lemmas and the implication from `∀ N > 2, HasNNCPHGroundSpace` to the nearest-neighbor spanning predicate
- align the commuting-gap blueprint and the NNCPH scope note with the new source-faithful predicate

Refs #2633.

## Testing

- `lake env lean /Users/siruilu/Local/agentFormalization/wt/parent-nncph-groundspace-2633/TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

## Scope

This PR states the source ground-space condition needed for arXiv:1606.00608, Theorem 3.10(iii). It does not prove the spanning theorem or remove the axiom-backed RFP/NNCPH bridge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Predicate definitions and documentation only; no changes to axiom-backed RFP/NNCPH bridges or runtime behavior.
> 
> **Overview**
> Introduces **`MPSTensor.HasNNCPHGroundSpace`**, a fixed-chain predicate that matches Cirac et al. Theorem 3.10(iii) by combining **`IsNNCPHGroundState`** (length-two commutation and zero energy of \(V^{(N)}(B)\)) with the Definition 3.9 BNT ground-space equation \(\ker H_2^{(N)}(B) = \operatorname{span}\{V^{(N)}(A_j)\}\).
> 
> Adds elementary projection lemmas from the new predicate to its parts, plus **`hasParentHamiltonianGroundSpaceSpanning`**, which shows that quantifying over all \(N>2\) recovers the existing **`HasParentHamiltonianGroundSpaceSpanning`** at \(L=2\). The commuting-gap blueprint and the NNCPH scope note are updated to document the predicate and clarify that it is **named only**—no spanning theorem or axiom removal in this change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a31680d0534be8e297fa6c02d837165fe5d606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->