### PR TITLE
feat(MPS/ParentHamiltonian): add fixed crossing trace decomposition

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
+
+/-!
+# Trace decompositions at a boundary-crossing interval
+
+This file records the fixed-interval trace-decomposition equality obtained from
+the block-diagonal local constraint at a cyclic interval crossing the boundary
+cut.  It is the local coefficient form of the two trace decompositions in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1444, specialized to the
+block-diagonal boundary conditions used in arXiv:2011.12127, Section IV.C,
+lines 2126--2128.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- A fixed boundary-crossing local constraint gives the corresponding trace
+decomposition.
+
+Let a cyclic interval of length \(L\) begin at \(i\), with \(N<i+L\).  For a
+local word \(\sigma\), write
+\[
+  \beta=\sigma_{N-i}\cdots\sigma_{L-1},\qquad
+  \rho=\tau_{i+L-N}\cdots\tau_{i-1},\qquad
+  w=\sigma_0\cdots\sigma_{N-i-1}.
+\]
+If the block sum of the cyclic restrictions lies in
+\(\bigvee_jG_L(A^j)\), then there are matrices \(C^j_{i,\tau}\) such that
+\[
+  \sum_j\operatorname{tr}(A^j_\beta C^j_{i,\tau} A^j_w)
+  =
+  \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr)
+\]
+for every local word \(\sigma\).  This is the fixed-interval form of the
+trace-decomposition comparison used in PGVWC07, Theorem 12. -/
+theorem blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (i : Fin N) (τ : Fin N → Fin d) (hi : N < i.val + L)
+    (hmem :
+      (∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
+        ⨆ j : Fin r, groundSpace (A j) L) :
+    ∃ C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ∀ σ : Fin L → Fin d,
+        let headWord : List (Fin d) := List.ofFn fun k : Fin (i.val + L - N) =>
+          σ ⟨N - i.val + k.val, by omega⟩
+        let middleWord : List (Fin d) := List.ofFn fun k : Fin (N - L) =>
+          τ ⟨i.val + L - N + k.val, by omega⟩
+        let tailWord : List (Fin d) := List.ofFn fun k : Fin (N - i.val) =>
+          σ ⟨k.val, by omega⟩
+        (∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) headWord * C j) * evalWord (A j) tailWord)) =
+        (∑ j : Fin r,
+          Matrix.trace
+            ((((μ j) ^ N • X j) * evalWord (A j) headWord *
+                evalWord (A j) middleWord) *
+              evalWord (A j) tailWord)) := by
+  classical
+  obtain ⟨φ, hφmem, hφsum⟩ :=
+    exists_sum_mem_of_mem_iSup_fin (fun j : Fin r => groundSpace (A j) L) hmem
+  have hMatrix : ∀ j : Fin r,
+      ∃ Cj : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        φ j = groundSpaceMap (A j) L Cj := by
+    intro j
+    have hφj := hφmem j
+    rw [groundSpace, LinearMap.mem_range] at hφj
+    rcases hφj with ⟨Cj, hCj⟩
+    exact ⟨Cj, hCj.symm⟩
+  choose C hC using hMatrix
+  refine ⟨C, ?_⟩
+  intro σ
+  let headWord : List (Fin d) := List.ofFn fun k : Fin (i.val + L - N) =>
+    σ ⟨N - i.val + k.val, by omega⟩
+  let middleWord : List (Fin d) := List.ofFn fun k : Fin (N - L) =>
+    τ ⟨i.val + L - N + k.val, by omega⟩
+  let tailWord : List (Fin d) := List.ofFn fun k : Fin (N - i.val) =>
+    σ ⟨k.val, by omega⟩
+  have hσ : List.ofFn σ = tailWord ++ headWord := by
+    apply List.ext_getElem
+    · simp [tailWord, headWord, List.length_ofFn]
+      omega
+    · intro k hk₁ hk₂
+      have hkL : k < L := by
+        simpa only [List.length_ofFn] using hk₁
+      simp only [List.getElem_ofFn]
+      by_cases hkTail : k < N - i.val
+      · rw [List.getElem_append_left]
+        · have htail :
+              tailWord[k]'(by simpa [tailWord, List.length_ofFn] using hkTail) =
+                σ ⟨k, hkL⟩ := by
+            simp only [tailWord, List.getElem_ofFn]
+          rw [htail]
+        · simpa [tailWord, List.length_ofFn] using hkTail
+      · rw [List.getElem_append_right]
+        · have hidx : k - tailWord.length < headWord.length := by
+            simp [tailWord, headWord, List.length_ofFn]
+            omega
+          have hhead :
+              headWord[k - tailWord.length]'hidx = σ ⟨k, hkL⟩ := by
+            simp only [headWord, List.getElem_ofFn]
+            congr 1
+            ext
+            simp [tailWord, List.length_ofFn]
+            omega
+          rw [hhead]
+        · simpa [tailWord, List.length_ofFn] using
+            (show tailWord.length ≤ k by simp [tailWord, List.length_ofFn]; omega)
+  have hLeft :
+      (∑ j : Fin r,
+          Matrix.trace
+            ((evalWord (A j) headWord * C j) * evalWord (A j) tailWord)) =
+        ∑ j : Fin r, φ j σ := by
+    refine Finset.sum_congr rfl ?_
+    intro j _
+    have hφj :
+        φ j σ = Matrix.trace (evalWord (A j) (List.ofFn σ) * C j) := by
+      rw [hC j, groundSpaceMap_apply]
+    calc
+      Matrix.trace
+          ((evalWord (A j) headWord * C j) * evalWord (A j) tailWord)
+          =
+        Matrix.trace
+          (evalWord (A j) tailWord * (evalWord (A j) headWord * C j)) :=
+            Matrix.trace_mul_comm _ _
+      _ =
+        Matrix.trace
+          ((evalWord (A j) tailWord * evalWord (A j) headWord) * C j) := by
+            rw [Matrix.mul_assoc]
+      _ = Matrix.trace (evalWord (A j) (List.ofFn σ) * C j) := by
+            rw [hσ, evalWord_append]
+      _ = φ j σ := hφj.symm
+  have hSum :
+      (∑ j : Fin r, φ j σ) =
+        ∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j)) σ := by
+    calc
+      (∑ j : Fin r, φ j σ) = (∑ j : Fin r, φ j) σ := by simp
+      _ =
+        (∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j))) σ := by
+            rw [← hφsum]
+      _ =
+        ∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j)) σ := by simp
+  have hRight :
+      (∑ j : Fin r,
+          Matrix.trace
+            ((((μ j) ^ N • X j) * evalWord (A j) headWord *
+                evalWord (A j) middleWord) *
+              evalWord (A j) tailWord)) =
+        ∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j)) σ := by
+    refine Finset.sum_congr rfl ?_
+    intro j _
+    have hApply :=
+      blockDiagonal_boundary_cyclicRestrict_component_apply_crossing
+        μ A hN hLN X j i τ hi σ
+    calc
+      Matrix.trace
+          ((((μ j) ^ N • X j) * evalWord (A j) headWord *
+              evalWord (A j) middleWord) *
+            evalWord (A j) tailWord)
+          =
+        Matrix.trace
+          (((μ j) ^ N • X j) *
+            ((evalWord (A j) headWord * evalWord (A j) middleWord) *
+              evalWord (A j) tailWord)) := by
+            simp [Matrix.mul_assoc]
+      _ =
+        Matrix.trace
+          (((evalWord (A j) headWord * evalWord (A j) middleWord) *
+              evalWord (A j) tailWord) *
+            ((μ j) ^ N • X j)) :=
+            Matrix.trace_mul_comm _ _
+      _ =
+        cyclicRestrictₗ hN L i τ
+          (groundSpaceMap (A j) N ((μ j) ^ N • X j)) σ := by
+            simpa [headWord, middleWord, tailWord] using hApply.symm
+  exact hLeft.trans (hSum.trans hRight.symm)
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
+import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace
 
 /-!
 # Finite-spanning versions of trace-decomposition results for block-diagonal parent spaces

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -581,6 +581,48 @@ in both cases.
     $R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)(\sigma)$.
 \end{proof}
 
+\begin{lemma}[Boundary-crossing trace decomposition from the local constraint]
+    \label{lem:block_diagonal_boundary_crossing_trace_decomposition}
+    \lean{MPSTensor.blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_coefficient_formula}
+    Assume $0<N$, $L\le N$, and let the cyclic interval beginning at $i$
+    cross the boundary cut, so $N<i+L$. Put $a=i+L-N$. For a local word
+    $\sigma$ of length $L$, write
+    \[
+        \beta=\sigma_{N-i}\cdots\sigma_{L-1},\qquad
+        \rho=\tau_a\cdots\tau_{i-1},\qquad
+        \alpha=\sigma_0\cdots\sigma_{N-i-1}.
+    \]
+    If
+    \[
+        \sum_j
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in\bigvee_jG_L(A_j),
+    \]
+    then there are matrices $C^j_{i,\tau}$ such that, for every $\sigma$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\tau}A^j_\alpha\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_\alpha\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_coefficient_formula}
+    Decompose the local vector in $\bigvee_jG_L(A_j)$ as a sum of vectors
+    $\Gamma_L^{A_j}(C^j_{i,\tau})$.  Evaluating at $\sigma$ gives
+    \[
+        \sum_j\tr\!\left(A^j_{\alpha\beta}C^j_{i,\tau}\right).
+    \]
+    Trace cyclicity rewrites this as
+    $\sum_j\tr(A^j_\beta C^j_{i,\tau}A^j_\alpha)$.  On the other hand,
+    Lemma~\ref{lem:block_diagonal_boundary_crossing_coefficient_formula}
+    gives the second trace expression for the same local coefficient sum.
+\end{proof}
+
 \begin{lemma}[Boundary-crossing cyclic intervals from the boundary matrix identity]
     \label{lem:block_diagonal_boundary_crossing_matrix_identity}
     \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix}


### PR DESCRIPTION
## Summary
- add the fixed boundary-crossing trace-decomposition lemma used in the PGVWC07 block-diagonal boundary-condition comparison
- place the lemma in a companion file so the existing crossing file stays below the line limit
- add the matching blueprint entry with the trace equation, using the local membership hypothesis directly

This is a source-faithful intermediate step toward #2651. It does not yet derive the full PGVWC07 blockwise comparison or close the issue.

Refs #2651

## Checks
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics and blueprint sync; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **formal Lean proof** that when the summed boundary-crossing cyclic restrictions lie in the block ground-space span, the PGVWC07-style **two-sided trace identity** holds at a fixed crossing interval (matrices `C^j` vs. `(μ_j^N X_j)` boundary traces).
> 
> The lemma lives in **`BNTBlockDiagonalCrossingTrace.lean`** so the main crossing file stays under the size limit; **`BNTBlockDiagonalTraceDecomposition.lean`** now imports that companion module. The blueprint chapter gains the matching **`lem:block_diagonal_boundary_crossing_trace_decomposition`** entry linked to `blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30ee6fd29ecc89a1d8d32a0e9b60b998a1223a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->