### PR TITLE
doc(parent): mark normal closure comparison complete

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_normal_closing.tex
@@ -613,7 +613,7 @@ is derived from the cyclic-window constraints crossing the periodic cut.
 \end{lemma}
 
 \begin{proof}
-    \notready
+    \leanok
     The cyclic-window representation lemma gives matrices
     $Y_M(\tau^+_\eta(\mu))$ and
     $Y_{M+1-L_0}(\tau^-_\eta(\mu))$ such that

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -263,11 +263,11 @@ length-\(L_0\) trace identities give
 \(XA^\alpha A^\nu=A^\alpha Y_\nu\).\footnote{Formal location:
 \path{TNLean/MPS/ParentHamiltonian/BoundaryClosingStripping.lean} for
 \leanid{MPSTensor.block_window_matrix_equation_of_trace_evalWord_mul_eq_of_isNBlkInjective}.}
-After that equation is proved from the cyclic-window constraints, the
-block-injective commutation lemma supplies the one-site commutation identity,
-the boundary-restriction equality lemma supplies the equality of the two
-boundary restrictions, and the periodic-boundary comparison follows.\footnote{The
-source-labelled statement for this step is
+The equation is now obtained from the cyclic-window constraints. The
+block-injective commutation lemma then supplies the one-site commutation
+identity, the boundary-restriction equality lemma supplies the equality of the
+two boundary restrictions, and the periodic-boundary comparison follows.
+\footnote{The source-labelled statement for this step is
 \leanid{MPSTensor.closure_property_boundary_block_window_equation_of_groundSpaceMap}.}
 
 Equivalently, the same boundary phenomenon can be recognized in coordinate


### PR DESCRIPTION
## Summary
- mark the blueprint proof of the boundary-crossing restriction equality as complete
- update the CPGSV21 normal-range gap note from conditional wording to the current proved state

The relevant declarations have no `sorryAx` dependency beyond standard Lean axioms, so this closes the remaining #2405 bookkeeping.

Closes #2405

## Checks
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `lake env lean --stdin` with `#print axioms` for `closure_property_boundary_block_window_trace_evalWord_mul_eq_of_groundSpaceMap`, `closure_property_boundary_block_window_equation_of_groundSpaceMap`, `closure_property_boundary_restriction_eq_of_chainGroundSpace`, and `closure_property_boundary_restrictions_eq_of_groundSpaceMap`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint status flags only; no runtime, auth, or proof code changes.
> 
> **Overview**
> **Blueprint sync:** The proof of Lemma *Equality of the two restrictions crossing the periodic cut* (`closure_property_boundary_restriction_chain_ground_space`) is switched from `\notready` to `\leanok`, so the blueprint now records that step as formally verified in Lean.
> 
> **Gap note:** In `cpgsv21_normal_range_reduction.tex`, the boundary block-window chain is rewritten from future/conditional wording (“after that equation is proved…”) to the current state: the matrix equation comes from cyclic-window constraints, then commutation, boundary-restriction equality, and the periodic-boundary comparison follow as documented lemmas.
> 
> No Lean or proof logic changes—bookkeeping for #2405 after axiom checks on the cited declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9d01257f065b3d1b877a82dcb210c97e19caef8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->