### PR TITLE
feat(MPS): open-boundary MPS infrastructure and the W state (#2318)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -149,6 +149,7 @@ import TNLean.Spectral.QuantitativeGap
 
 -- Layer 3: MPS core
 import TNLean.MPS.Defs
+import TNLean.MPS.OpenBoundary
 import TNLean.MPS.Core.RepeatedWord
 import TNLean.MPS.Tactic.Basic
 import TNLean.MPS.Chain.Defs
@@ -307,6 +308,7 @@ import TNLean.MPS.Examples.EvenParity
 import TNLean.MPS.Examples.GHZ
 import TNLean.MPS.Examples.GHZParentHamiltonian
 import TNLean.MPS.Examples.MajumdarGhosh
+import TNLean.MPS.Examples.WState
 import TNLean.MPS.Examples.ZMod2
 import TNLean.MPS.Examples.ZeroCorrelationExamples
 

--- a/TNLean/MPS/Examples/WState.lean
+++ b/TNLean/MPS/Examples/WState.lean
@@ -1,0 +1,194 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.OpenBoundary
+
+/-!
+# The W state as an open-boundary Matrix Product State
+
+The W state on `N` sites is the single-excitation symmetric state
+\[
+    \ket{W_N}
+    = \ket{10\cdots0} + \ket{010\cdots0} + \cdots + \ket{0\cdots01},
+\]
+the (unnormalized) equal-weight superposition of all configurations with exactly
+one excitation.
+
+Following arXiv:2011.12127 (lines 2348--2362), the W state is an open-boundary
+MPS with bond dimension `D = 2` and physical dimension `d = 2`, with the
+site-independent tensor
+\[
+    A^0 = \begin{pmatrix}1&0\\0&1\end{pmatrix},
+    \qquad
+    A^1 = \begin{pmatrix}0&1\\0&0\end{pmatrix},
+\]
+and boundary covectors `(l| = (0|` and `|r) = |1)`.  The open-boundary
+contraction `(l| A^{σ_1} ⋯ A^{σ_N} |r)` is `1` exactly when `σ` has a single
+excitation, reproducing `\ket{W_N}`.
+
+This is not a translation-invariant representation: the boundary is not closed by
+a trace.  Closing it periodically would give `tr(A^{σ_1} ⋯ A^{σ_N})`, a different
+(and, for the W state, unattainable at fixed bond dimension) object; see the
+discussion in arXiv:2011.12127, line 2362, and the bond-dimension lower bound
+recorded in `docs/paper-gaps/rmp_w_state_ti_bound.tex`.
+
+## Main definitions
+
+* `wTensor` — the open-boundary W tensor `A^0 = I`, `A^1 = raising`.
+* `wLeftBoundary`, `wRightBoundary` — the covectors `(0|` and `|1)`.
+* `wIndicator` — the configuration amplitude of `\ket{W_N}`: `1` on
+  single-excitation configurations, `0` elsewhere.
+
+## Main results
+
+* `wTensor_openState_eq_wIndicator` — the open-boundary contraction of `wTensor`
+  reproduces the W state: `openState wLeftBoundary wRightBoundary wTensor N`
+  equals `wIndicator N`, for every `N`.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete 2021, arXiv:2011.12127, lines
+  2348--2362.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+/-! ### The W tensor and its boundary vectors -/
+
+/-- The W MPS tensor with `d = D = 2`:
+`A^0 = I` and `A^1 = !![0,1;0,0]` (the single raising operator).
+Source: arXiv:2011.12127, line 2358. -/
+def wTensor : MPSTensor 2 2 :=
+  fun i => if i = 0 then 1 else !![(0 : ℂ), 1; 0, 0]
+
+@[simp] lemma wTensor_zero : wTensor 0 = 1 := rfl
+
+@[simp] lemma wTensor_one : wTensor 1 = !![(0 : ℂ), 1; 0, 0] := rfl
+
+/-- The left boundary covector `(l| = (0|`. Source: arXiv:2011.12127, line 2360. -/
+def wLeftBoundary : Fin 2 → ℂ := Pi.single 0 1
+
+/-- The right boundary vector `|r) = |1)`. Source: arXiv:2011.12127, line 2360. -/
+def wRightBoundary : Fin 2 → ℂ := Pi.single 1 1
+
+/-- The single raising matrix `A^1 = !![0,1;0,0]`. -/
+private def raising : Matrix (Fin 2) (Fin 2) ℂ := !![(0 : ℂ), 1; 0, 0]
+
+/-- `A^1` squares to zero: two excitations annihilate the chain. -/
+lemma raising_mul_raising : raising * raising = 0 := by
+  ext i j; fin_cases i <;> fin_cases j <;>
+    simp [raising, Matrix.mul_apply, Fin.sum_univ_two]
+
+/-! ### The W-state amplitude
+
+We classify the ordered product `evalWord wTensor w` by the number of excitations
+(`1` letters) in the word `w`: it is the identity with no excitations, the raising
+matrix with one excitation, and zero with two or more.  Reading off the `(0,1)`
+entry against the boundary covectors gives the W-state amplitude. -/
+
+/-- The word product of `wTensor` is governed by the excitation count:
+* no excitations give the identity;
+* exactly one excitation gives the raising matrix `A^1`;
+* two or more excitations annihilate, giving the zero matrix. -/
+lemma evalWord_wTensor (w : List (Fin 2)) :
+    evalWord wTensor w =
+      match w.count 1 with
+      | 0 => 1
+      | 1 => raising
+      | _ => 0 := by
+  induction w with
+  | nil => simp
+  | cons i w ih =>
+    rw [evalWord_cons, ih, List.count_cons]
+    match i with
+    | 0 =>
+      -- head is `0`: `A^0 = I`, the count is unchanged.
+      simp
+    | 1 =>
+      -- head is `1`: `A^1 = raising`, the count increases by one.
+      rw [show wTensor 1 = raising from rfl]
+      simp only [Fin.isValue, beq_self_eq_true, if_true]
+      rcases hc : w.count 1 with _ | _ | k
+      · exact mul_one raising
+      · exact raising_mul_raising
+      · exact mul_zero raising
+
+/-- The boundary contraction reads off the `(0,1)` entry: identity gives `0`,
+the raising matrix gives `1`, and the zero matrix gives `0`. -/
+private lemma openCoeff_wTensor_entry (w : List (Fin 2)) :
+    openCoeff wLeftBoundary wRightBoundary wTensor w = (evalWord wTensor w) 0 1 := by
+  simp only [openCoeff, wLeftBoundary, wRightBoundary]
+  rw [single_dotProduct]
+  simp [Matrix.mulVec]
+
+/-- The open-boundary contraction of `wTensor` against `(0|·|1)` is `1` exactly
+when the word has a single excitation, and `0` otherwise. -/
+lemma openCoeff_wTensor (w : List (Fin 2)) :
+    openCoeff wLeftBoundary wRightBoundary wTensor w =
+      if w.count 1 = 1 then 1 else 0 := by
+  rw [openCoeff_wTensor_entry, evalWord_wTensor]
+  rcases hc : w.count 1 with _ | _ | k
+  · simp
+  · simp [raising]
+  · simp
+
+/-! ### The W-state identification -/
+
+/-- The amplitude of the (unnormalized) W state `\ket{W_N}` in the computational
+basis: `1` on configurations with exactly one excitation, `0` otherwise.
+Source: arXiv:2011.12127, line 2350. -/
+def wIndicator (N : ℕ) : Cfg 2 N → ℂ :=
+  fun σ => if (List.ofFn σ).count 1 = 1 then 1 else 0
+
+@[simp] lemma wIndicator_apply (N : ℕ) (σ : Cfg 2 N) :
+    wIndicator N σ = if (List.ofFn σ).count 1 = 1 then 1 else 0 := rfl
+
+/-- **Central identification.** The open-boundary contraction of the W tensor with
+boundary covectors `(0|` and `|1)` reproduces the W state on every number of
+sites `N`:
+\[
+    \ket{W_N}
+    = \sum_{\sigma} (0|\, A^{\sigma_1} \cdots A^{\sigma_N}\, |1)\, \ket{\sigma}.
+\]
+Source: arXiv:2011.12127, lines 2350--2361. -/
+theorem wTensor_openState_eq_wIndicator (N : ℕ) :
+    openState wLeftBoundary wRightBoundary wTensor N = wIndicator N := by
+  funext σ
+  rw [openState_apply, openCoeff_wTensor, wIndicator_apply]
+
+/-! ### A concrete three-site witness
+
+The three single-excitation configurations of `\ket{W_3}` each receive amplitude
+`1`, and any configuration with a different number of excitations receives
+amplitude `0`.  These are direct instances of the identification above. -/
+
+/-- The configuration with the single excitation at site `k`, among `N` sites. -/
+def excitedAt (N : ℕ) (k : Fin N) : Cfg 2 N := fun j => if j = k then 1 else 0
+
+/-- A single-excitation configuration has exactly one `1`, so its W-state
+amplitude is `1`. -/
+theorem wState_three_excitedAt (k : Fin 3) :
+    openState wLeftBoundary wRightBoundary wTensor 3 (excitedAt 3 k) = 1 := by
+  rw [wTensor_openState_eq_wIndicator, wIndicator_apply, if_pos]
+  fin_cases k <;> decide
+
+/-- The all-zero configuration has no excitation, so its W-state amplitude is
+`0`: the W state has no vacuum component. -/
+theorem wState_three_vacuum :
+    openState wLeftBoundary wRightBoundary wTensor 3 (fun _ => 0) = 0 := by
+  rw [wTensor_openState_eq_wIndicator, wIndicator_apply, if_neg]
+  decide
+
+/-- A two-excitation configuration receives amplitude `0`: the W state has no
+multiply-excited component. -/
+theorem wState_three_double :
+    openState wLeftBoundary wRightBoundary wTensor 3
+        (fun j => if j = 0 then 1 else if j = 1 then 1 else 0) = 0 := by
+  rw [wTensor_openState_eq_wIndicator, wIndicator_apply, if_neg]
+  decide
+
+end MPSTensor

--- a/TNLean/MPS/OpenBoundary.lean
+++ b/TNLean/MPS/OpenBoundary.lean
@@ -37,8 +37,8 @@ real boundary vectors, so the bilinear and sesquilinear pairings agree there.
 
 * `openCoeff vL vR A w` — the boundary contraction `vL ⬝ (evalWord A w) ⬝ vR` of a
   word `w`.
-* `openState vL vR A N` — the open-boundary state on `N` sites as an element of
-  `NSiteSpace`, sending `σ` to `openCoeff vL vR A (List.ofFn σ)`.
+* `openState vL vR A N` — the open-boundary state on `N` sites as a function on
+  configurations, sending `σ` to `openCoeff vL vR A (List.ofFn σ)`.
 
 ## References
 

--- a/TNLean/MPS/OpenBoundary.lean
+++ b/TNLean/MPS/OpenBoundary.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Defs
+import TNLean.MPS.Overlap.Basic
+
+import Mathlib.Data.Matrix.Mul
+
+/-!
+# Open-boundary matrix product states
+
+The translation-invariant tensors of `TNLean.MPS.Defs` close a chain into a ring
+by tracing the ordered matrix product.  Some states only admit a non-periodic
+representation: the matrix product is closed not by a trace but by a left and a
+right boundary vector.
+
+This file adds the minimal infrastructure for that contraction.  For a tensor
+`A : MPSTensor d D`, a left boundary `vL : Fin D → ℂ`, a right boundary
+`vR : Fin D → ℂ`, and a configuration `σ : Cfg d N`, the open-boundary amplitude
+is
+\[
+    \langle v_L \mid A^{\sigma_1} A^{\sigma_2} \cdots A^{\sigma_N} \mid v_R\rangle
+    = v_L^{\mathsf T}\,
+      \bigl(A^{\sigma_1} \cdots A^{\sigma_N}\bigr)\,
+      v_R,
+\]
+and the open-boundary state assembles these amplitudes into a vector indexed by
+configurations.
+
+The boundary is written with `vecMul`/`mulVec` rather than a conjugate transpose:
+the source uses the bilinear pairing `(l| M |r)` and the W-state example below has
+real boundary vectors, so the bilinear and sesquilinear pairings agree there.
+
+## Main definitions
+
+* `openCoeff vL vR A w` — the boundary contraction `vL ⬝ (evalWord A w) ⬝ vR` of a
+  word `w`.
+* `openState vL vR A N` — the open-boundary state on `N` sites as an element of
+  `NSiteSpace`, sending `σ` to `openCoeff vL vR A (List.ofFn σ)`.
+
+## References
+
+* Cirac--Pérez-García--Schuch--Verstraete 2021, arXiv:2011.12127, lines
+  2348--2362 (the open-boundary contraction `(l| A^{i_1} … A^{i_N} |r)`).
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The open-boundary contraction of a word `w` against a left boundary covector
+`vL` and a right boundary vector `vR`:
+\(v_L^{\mathsf T}\,(\mathrm{evalWord}\,A\,w)\,v_R\).
+
+This is the bilinear pairing `(l| A^{w} |r)` of arXiv:2011.12127, lines
+2358--2362. -/
+noncomputable def openCoeff (vL vR : Fin D → ℂ) (A : MPSTensor d D)
+    (w : List (Fin d)) : ℂ :=
+  vL ⬝ᵥ (evalWord A w).mulVec vR
+
+@[simp] lemma openCoeff_def (vL vR : Fin D → ℂ) (A : MPSTensor d D) (w : List (Fin d)) :
+    openCoeff vL vR A w = vL ⬝ᵥ (evalWord A w).mulVec vR := rfl
+
+/-- The empty-word contraction is the boundary overlap `vL ⬝ vR`. -/
+@[simp] lemma openCoeff_nil (vL vR : Fin D → ℂ) (A : MPSTensor d D) :
+    openCoeff vL vR A [] = vL ⬝ᵥ vR := by
+  simp [openCoeff]
+
+/-- Peeling the first letter: the contraction of `i :: w` pushes `A i` into the
+left boundary covector. -/
+lemma openCoeff_cons (vL vR : Fin D → ℂ) (A : MPSTensor d D)
+    (i : Fin d) (w : List (Fin d)) :
+    openCoeff vL vR A (i :: w) =
+      openCoeff (Matrix.vecMul vL (A i)) vR A w := by
+  simp only [openCoeff, evalWord_cons]
+  rw [← Matrix.mulVec_mulVec, Matrix.dotProduct_mulVec]
+
+/-- The open-boundary state on `N` sites: the configuration amplitudes
+`σ ↦ (l| A^{σ_1} ⋯ A^{σ_N} |r)`, assembled as a function on configurations.
+
+This is the W-state-style state vector of arXiv:2011.12127, line 2361. -/
+noncomputable def openState (vL vR : Fin D → ℂ) (A : MPSTensor d D) (N : ℕ) :
+    Cfg d N → ℂ :=
+  fun σ : Cfg d N => openCoeff vL vR A (List.ofFn σ)
+
+@[simp] lemma openState_apply (vL vR : Fin D → ℂ) (A : MPSTensor d D)
+    (N : ℕ) (σ : Cfg d N) :
+    openState vL vR A N σ = openCoeff vL vR A (List.ofFn σ) := rfl
+
+end MPSTensor

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -548,6 +548,132 @@ resonating valence-bond state.
 \end{remark}
 
 %% ===================================================================
+\section{The W state}\label{sec:w_state}
+%% ===================================================================
+
+The W state on $N$ sites is the single-excitation symmetric state
+\[
+    \ket{W_N}
+    = \ket{10\cdots0} + \ket{010\cdots0} + \cdots + \ket{0\cdots01},
+\]
+the equal-weight superposition of all configurations with exactly one
+excitation. Unlike the preceding examples it has no finite-bond
+translation-invariant representation; it is presented with open boundary
+conditions, where the matrix product is closed by a left and a right boundary
+vector rather than by a trace.
+
+\begin{definition}[Open-boundary contraction]\label{def:open_coeff}
+    \lean{MPSTensor.openCoeff}
+    \leanok
+    \uses{def:mps_tensor, def:eval_word}
+    For a tensor $A$ with bond dimension $D$, a left boundary covector
+    $v_L\in\C^D$, a right boundary vector $v_R\in\C^D$, and a word
+    $w=(i_1,\ldots,i_k)$, the open-boundary contraction is the bilinear pairing
+    \[
+        (v_L|\, A^{i_1} A^{i_2}\cdots A^{i_k}\, |v_R)
+        = v_L^{\mathsf T}\,\bigl(A^{i_1}\cdots A^{i_k}\bigr)\, v_R.
+    \]
+\end{definition}
+
+\begin{definition}[Open-boundary state]\label{def:open_state}
+    \lean{MPSTensor.openState}
+    \leanok
+    \uses{def:open_coeff}
+    The open-boundary state on $N$ sites assigns to each configuration
+    $\sigma=(\sigma_1,\ldots,\sigma_N)$ the amplitude
+    $(v_L|\, A^{\sigma_1}\cdots A^{\sigma_N}\, |v_R)$.
+\end{definition}
+
+\begin{definition}[W tensor and boundary vectors]\label{def:w_tensor}
+    \lean{MPSTensor.wTensor}
+    \leanok
+    \uses{def:mps_tensor}
+    Set $d = D = 2$. The W tensor is the site-independent family
+    \[
+        A^0 = \begin{pmatrix}1&0\\0&1\end{pmatrix},
+        \qquad
+        A^1 = \begin{pmatrix}0&1\\0&0\end{pmatrix},
+    \]
+    with left boundary covector $(l|=(0|$ and right boundary vector $|r)=|1)$.
+    Here $A^1$ is the single raising operator: it sends $|1)\mapsto|0)$ and
+    annihilates $|0)$, and squares to zero.
+\end{definition}
+
+\begin{definition}[W-state indicator]\label{def:w_indicator}
+    \lean{MPSTensor.wIndicator}
+    \leanok
+    For $N\ge0$, the W-state amplitude is the indicator of the
+    single-excitation configurations:
+    \[
+        \ket{W_N}(\sigma_1,\ldots,\sigma_N)
+        =
+        \begin{cases}
+            1, & \text{exactly one } \sigma_j = 1, \\
+            0, & \text{otherwise}.
+        \end{cases}
+    \]
+\end{definition}
+
+\begin{theorem}[The open-boundary contraction is the W state]%
+\label{thm:w_state_identification}
+    \lean{MPSTensor.wTensor_openState_eq_wIndicator}
+    \leanok
+    \uses{def:w_tensor, def:open_state, def:w_indicator}
+    For every $N$, the open-boundary state of the W tensor with boundary
+    vectors $(0|$ and $|1)$ equals the W state:
+    \[
+        \ket{W_N}
+        = \sum_{\sigma} (0|\, A^{\sigma_1} \cdots A^{\sigma_N}\, |1)\,
+          \ket{\sigma}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:w_tensor, def:open_state}
+    Because $A^0$ is the identity and $A^1$ is the raising operator with
+    $A^1 A^1 = 0$, the ordered product $A^{\sigma_1}\cdots A^{\sigma_N}$ depends
+    only on the number of excitations of $\sigma$: it is the identity with no
+    excitation, the raising operator with one excitation, and zero with two or
+    more. Reading off the $(0,1)$ matrix element against the boundary vectors
+    therefore gives $1$ on the single-excitation configurations and $0$
+    elsewhere, which is the W-state amplitude.
+\end{proof}
+
+\begin{theorem}[Three-site single excitations]%
+\label{thm:w_state_three_excited}
+    \lean{MPSTensor.wState_three_excitedAt}
+    \leanok
+    \uses{thm:w_state_identification}
+    On three sites, each of the three single-excitation configurations
+    $\ket{100}$, $\ket{010}$, $\ket{001}$ receives W-state amplitude $1$, while
+    the vacuum $\ket{000}$ and the doubly-excited $\ket{110}$ receive
+    amplitude $0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:w_state_identification}
+    Direct instances of Theorem~\ref{thm:w_state_identification}: the excitation
+    count is one in the first three cases and zero or two in the others.
+\end{proof}
+
+\begin{remark}[No finite-bond translation-invariant representation]%
+\label{rem:w_state_ti_bound}
+    \uses{def:w_tensor}
+    The open-boundary representation above is not translation invariant: the
+    chain is closed by boundary vectors, not by a trace. The review observes
+    that no translation-invariant representation of fixed bond dimension exists:
+    any translation-invariant matrix product state equal to $\ket{W_N}$ must
+    have bond dimension growing with $N$, satisfying a bound of the form
+    $D^3\log D = \Omega(N)$. The review obtains this by combining the matrix
+    product state representation theory of \cite{PerezGarcia2007MPSReps} with
+    the quantitative quantum Wielandt inequality. That asymptotic lower bound is
+    not formalized here; it is recorded as a deferred result in
+    \path{docs/paper-gaps/rmp_w_state_ti_bound.tex}.
+\end{remark}
+
+%% ===================================================================
 \section{The cluster state}\label{sec:cluster}
 %% ===================================================================
 

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -662,14 +662,15 @@ left and a right boundary vector rather than by a trace.
     count is one in the first three cases and zero or two in the others.
 \end{proof}
 
-\begin{remark}[No finite-bond translation-invariant representation]%
+\begin{remark}[No fixed-bond translation-invariant family]%
 \label{rem:w_state_ti_bound}
     \uses{def:w_tensor}
     The open-boundary representation above is not translation invariant: the
     chain is closed by boundary vectors, not by a trace. The review observes
-    that no translation-invariant representation of fixed bond dimension exists:
-    any translation-invariant matrix product state equal to $\ket{W_N}$ must
-    have bond dimension growing with $N$, satisfying a bound of the form
+    that there is no translation-invariant representation whose bond dimension
+    is bounded independently of $N$: any translation-invariant matrix product
+    state equal to $\ket{W_N}$ must have bond dimension growing with $N$,
+    satisfying a bound of the form
     $D^3\log D = \Omega(N)$. The review obtains this by combining the matrix
     product state representation theory of \cite{PerezGarcia2007Matrix} with
     the quantitative quantum Wielandt inequality. That asymptotic lower bound is

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -557,10 +557,10 @@ The W state on $N$ sites is the single-excitation symmetric state
     = \ket{10\cdots0} + \ket{010\cdots0} + \cdots + \ket{0\cdots01},
 \]
 the equal-weight superposition of all configurations with exactly one
-excitation. Unlike the preceding examples it has no finite-bond
-translation-invariant representation; it is presented with open boundary
-conditions, where the matrix product is closed by a left and a right boundary
-vector rather than by a trace.
+excitation. Unlike the preceding examples it has no translation-invariant
+representation with bond dimension bounded independently of $N$; it is
+presented with open boundary conditions, where the matrix product is closed by a
+left and a right boundary vector rather than by a trace.
 
 \begin{definition}[Open-boundary contraction]\label{def:open_coeff}
     \lean{MPSTensor.openCoeff}

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -586,6 +586,8 @@ vector rather than by a trace.
 
 \begin{definition}[W tensor and boundary vectors]\label{def:w_tensor}
     \lean{MPSTensor.wTensor}
+    \lean{MPSTensor.wLeftBoundary}
+    \lean{MPSTensor.wRightBoundary}
     \leanok
     \uses{def:mps_tensor}
     Set $d = D = 2$. The W tensor is the site-independent family
@@ -643,6 +645,8 @@ vector rather than by a trace.
 \begin{theorem}[Three-site single excitations]%
 \label{thm:w_state_three_excited}
     \lean{MPSTensor.wState_three_excitedAt}
+    \lean{MPSTensor.wState_three_vacuum}
+    \lean{MPSTensor.wState_three_double}
     \leanok
     \uses{thm:w_state_identification}
     On three sites, each of the three single-excitation configurations

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -667,7 +667,7 @@ vector rather than by a trace.
     any translation-invariant matrix product state equal to $\ket{W_N}$ must
     have bond dimension growing with $N$, satisfying a bound of the form
     $D^3\log D = \Omega(N)$. The review obtains this by combining the matrix
-    product state representation theory of \cite{PerezGarcia2007MPSReps} with
+    product state representation theory of \cite{PerezGarcia2007Matrix} with
     the quantitative quantum Wielandt inequality. That asymptotic lower bound is
     not formalized here; it is recorded as a deferred result in
     \path{docs/paper-gaps/rmp_w_state_ti_bound.tex}.

--- a/docs/paper-gaps/rmp_w_state_ti_bound.tex
+++ b/docs/paper-gaps/rmp_w_state_ti_bound.tex
@@ -1,0 +1,115 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Deferred Result: The Translation-Invariant Bond-Dimension Lower Bound
+for the W State}
+\author{}
+\date{2026-06-17}
+
+\begin{document}
+\maketitle
+
+\section{The source statement}
+
+The review \cite{Cirac2021Matrix} presents the W state
+\begin{align}
+    \ket{W}
+    = \ket{10\cdots0} + \ket{010\cdots0} + \cdots + \ket{0\cdots01}
+\end{align}
+on $N$ sites as an open-boundary matrix product state of bond dimension
+$D = 2$, with the site-independent tensor
+\begin{align}
+    A^0 = \begin{pmatrix}1&0\\0&1\end{pmatrix},
+    \qquad
+    A^1 = \begin{pmatrix}0&1\\0&0\end{pmatrix},
+    \tag{\cite[lines~2358--2360]{Cirac2021Matrix}}
+\end{align}
+and boundary covectors $(l|=(0|$ and $|r)=|1)$.  It then observes
+that this is not a translation-invariant representation, and states the
+following bound \cite[line~2362]{Cirac2021Matrix}: any translation-invariant
+matrix product state whose periodic contraction equals $\ket{W}$ on $N$ sites
+must have a bond dimension $D$ that grows with the system size, satisfying a
+bound of the form
+\begin{align}
+    D^3 \log D = \Omega(N),
+    \label{eq:wbound}
+\end{align}
+which in particular forces $D = \Omega\bigl(N^{1/(3+\delta)}\bigr)$ for every
+$\delta > 0$.
+
+\section{Why this is a separate, deferred theorem}
+
+The bound \eqref{eq:wbound} is not proved in the review.  The review obtains it
+by combining two external results:
+
+\begin{enumerate}
+    \item the matrix product state representation theory of
+        \cite{PerezGarcia2007MPSReps}, which controls when a state on $N$ sites
+        admits a translation-invariant representation at a given bond dimension;
+        and
+    \item the quantum version of Wielandt's inequality, whose sharp
+        $D^2$-scaling form (after \cite{Sanz2010Quantum} and the subsequent
+        sharpening attributed in the review to Micha\l{}ek and Shitov) bounds
+        the blocking length at which a primitive tensor's products span the
+        full matrix algebra.
+\end{enumerate}
+
+The conclusion is asymptotic in $N$: it constrains the growth rate of the
+optimal bond dimension, not a single finite-size identity.  Establishing it in
+the formal development would require:
+
+\begin{itemize}
+    \item a faithful statement of the translation-invariant representability
+        criterion of \cite{PerezGarcia2007MPSReps} for a prescribed
+        finite-size state;
+    \item the quantitative quantum Wielandt inequality with its explicit
+        $D^2$ (and the refined $D^3 \log D$) scaling, beyond the qualitative
+        primitivity and span-growth statements presently available in the
+        \leanid{Wielandt} development;
+    \item the asymptotic combination of the two into the growth bound
+        \eqref{eq:wbound}, including the rank/dimension argument specific to the
+        single-excitation symmetric state.
+\end{itemize}
+
+Each of these is a substantial independent development; together they are a
+multi-step effort well beyond the open-boundary identification recorded in the
+example file.
+
+\section{What is formalized}
+
+The example file establishes the open-boundary side of the source statement.
+It defines the site-independent W tensor, the boundary covectors, and the
+open-boundary contraction, and proves the central identification: for every
+$N$, the open-boundary amplitudes
+\begin{align}
+    (0|\, A^{\sigma_1} \cdots A^{\sigma_N}\, |1)
+\end{align}
+equal the indicator of the single-excitation configurations, so the
+open-boundary state is exactly the (unnormalized) W state.\footnote{Formal
+declarations:
+\leanid{MPSTensor.wTensor},
+\leanid{MPSTensor.openState},
+\leanid{MPSTensor.wTensor_openState_eq_wIndicator}.}
+
+The translation-invariant lower bound \eqref{eq:wbound} is \emph{not} formalized
+and is \emph{not} asserted as an established fact anywhere in the development.
+
+\section{Verdict}
+
+This is a deferred result, not a gap in a claimed formalization.  The
+open-boundary $D=2$ representation is fully proved.  The translation-invariant
+bond-dimension lower bound is recorded here as an unformalized source statement
+requiring the representation theory of \cite{PerezGarcia2007MPSReps} and the
+quantitative quantum Wielandt inequality; it should be tracked as a follow-up
+once that quantitative machinery is available.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

Formalizes the W state as an open-boundary matrix product state, addressing
the first target of #2318. Adds the minimal site-uniform open-boundary MPS
infrastructure (boundary-vector contraction), the explicit $D=2$ W tensors from
the source, and the central identification proof, for **general $N$**.

## Source

arXiv:2011.12127 (Cirac--Pérez-García--Schuch--Verstraete, RMP review),
lines 2348--2362. The W state
$\ket{W_N}=\ket{10\cdots0}+\cdots+\ket{0\cdots01}$ is an open-boundary MPS with
$d=D=2$:
$$A^0=\begin{pmatrix}1&0\\0&1\end{pmatrix},\quad A^1=\begin{pmatrix}0&1\\0&0\end{pmatrix},$$
with boundary covectors $(l|=(0|$, $|r)=|1)$, and
$\ket{W}=\sum (l|A^{i_1}\cdots A^{i_N}|r)\,\ket{i_1\dots i_N}$.

## Infrastructure added

`TNLean/MPS/OpenBoundary.lean` — minimal, reusable open-boundary contraction on
a (site-uniform) tensor with explicit boundary vectors:
- `MPSTensor.openCoeff vL vR A w` = bilinear pairing $v_L^{\mathsf T}(\mathrm{evalWord}\,A\,w)v_R$,
  with `openCoeff_nil`, `openCoeff_cons`.
- `MPSTensor.openState vL vR A N` = the open-boundary state vector on
  configurations.

This is the boundary-vector contraction the source uses; the existing
`MPSChainTensor` closes the chain by a **trace**, which is not the open-boundary
W-state contraction, so the boundary-vector pairing is the genuinely missing
piece.

## W-state tensors (`TNLean/MPS/Examples/WState.lean`)

- `wTensor`, `wLeftBoundary`, `wRightBoundary`, `wIndicator`.

## Proven (general $N$, no `sorry`/`axiom`/`native_decide`)

- `evalWord_wTensor`: the ordered product is the identity / raising / zero
  according to the excitation count (0 / 1 / ≥2), via $A^1A^1=0$.
- **`wTensor_openState_eq_wIndicator`** — the central identification: for every
  $N$, the open-boundary contraction equals $\ket{W_N}$ (the single-excitation
  indicator). `#print axioms` shows only `propext`, `Classical.choice`,
  `Quot.sound`.
- Concrete witnesses: `wState_three_excitedAt` (each $\ket{100},\ket{010},\ket{001}$
  has amplitude 1), `wState_three_vacuum`, `wState_three_double` (amplitude 0).

The state identity is **derived**, not asserted (per the Faithfulness rule and
the Majumdar--Ghosh precedent in #2928).

## Deferred (target b)

The translation-invariant bond-dimension lower bound $D^3\log D=\Omega(N)$ is
**not** formalized and **not** asserted anywhere. The review derives it by
combining the MPS-representation theory of `PerezGarcia2007MPSReps` with the
quantitative quantum Wielandt inequality — a multi-PR effort beyond the current
qualitative Wielandt machinery. It is recorded as a deferred result with a
precise statement and elimination plan in
`docs/paper-gaps/rmp_w_state_ti_bound.tex` and as
Remark~\ref{rem:w_state_ti_bound} in the blueprint. A follow-up issue should
track the quantitative bound.

## Blueprint

New "The W state" section in `ch15_examples.tex` (mirrors GHZ/AKLT/MG), with
`\lean{}`/`\leanok` only on the proven results.

## Verification

- `lake build` (full, 8945 jobs) — success.
- `lake exe lint-style` on new files — clean.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` — passes.
- No `sorry`/`axiom`/`native_decide`/`admit` in any claimed result.

Advances #2318.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New MPS example and definitions only; no changes to auth, channels, or core FT paths. Deferred asymptotic bound is explicitly not asserted in Lean.
> 
> **Overview**
> Adds **open-boundary MPS** contraction (`openCoeff`, `openState`) alongside trace-closed periodic chains, and formalizes the **W state** as a $D=2$ site-uniform tensor with boundaries $(0|$ and $|1)$.
> 
> The main theorem **`wTensor_openState_eq_wIndicator`** shows that boundary contraction equals the single-excitation indicator for **all** $N$, using excitation-count behavior of `evalWord` and $A^1 A^1 = 0$. Three-site corollaries and blueprint **§The W state** mirror other chapter-15 examples.
> 
> The review’s translation-invariant bond-dimension lower bound $D^3\log D = \Omega(N)$ is **not** proved; it is documented as deferred in `docs/paper-gaps/rmp_w_state_ti_bound.tex` and a blueprint remark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b640c9b48b88c102f3d37d195c41621e132e6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->