### PR TITLE
feat(parent): record BNT span kernel inclusion

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -214,6 +214,43 @@ theorem HasNNCPHGroundSpace.hasParentHamiltonianGroundSpaceSpanning
   intro N hN
   exact (h N hN).groundSpaceSpanning
 
+/-- If each BNT vector is killed by the parent Hamiltonian, then their span is
+contained in the parent-Hamiltonian kernel.
+
+This is the easy inclusion in the source spanning equation
+\[
+  \ker H_L^{(N)}(B)
+  =
+  \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}
+\]
+from arXiv:1606.00608, Definition 3.9, source lines 522--524. -/
+theorem bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_annihilates
+    {B : MPSTensor d D} {r : ℕ} {dim : Fin r → ℕ}
+    {A : (j : Fin r) → MPSTensor d (dim j)} {L N : ℕ}
+    (h : ∀ j : Fin r, parentHamiltonian B L N (mpv (A j)) = 0) :
+    bntMPSVectorSpan A N ≤ LinearMap.ker (parentHamiltonian B L N) := by
+  rw [bntMPSVectorSpan]
+  refine Submodule.span_le.mpr ?_
+  intro v hv
+  rcases hv with ⟨j, rfl⟩
+  exact LinearMap.mem_ker.mpr (h j)
+
+/-- If each BNT vector is frustration-free for the parent Hamiltonian, then the
+BNT span is contained in the parent-Hamiltonian kernel.
+
+This records the zero-energy half of the source parent-Hamiltonian ground-space
+spanning condition from arXiv:1606.00608, Definition 3.9, source lines
+522--524. The reverse inclusion is the hard spanning direction. -/
+theorem bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_frustrationFree
+    {B : MPSTensor d D} {r : ℕ} {dim : Fin r → ℕ}
+    {A : (j : Fin r) → MPSTensor d (dim j)} {L N : ℕ}
+    (h : ∀ j : Fin r, IsFrustrationFree B L N (mpv (A j))) :
+    bntMPSVectorSpan A N ≤ LinearMap.ker (parentHamiltonian B L N) := by
+  refine bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_annihilates ?_
+  intro j
+  simp only [parentHamiltonian, LinearMap.sum_apply]
+  exact Finset.sum_eq_zero fun i _ => h j i
+
 /-- If the two-site parent terms are idempotents \(pᵢ\) with
 \(pᵢpⱼ = pⱼpᵢ\), then the nearest-neighbor parent Hamiltonian is commuting on
 that finite chain. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -138,6 +138,46 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     nearest-neighbor case of the spanning condition above.
 \end{remark}
 
+\begin{lemma}[Zero-energy BNT vectors lie in the parent-Hamiltonian kernel]
+    \label{lem:bnt_span_le_parent_hamiltonian_kernel}
+    \lean{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_annihilates}
+    \lean{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_frustrationFree}
+    \leanok
+    \uses{def:bnt_span, def:is_frustration_free, def:parent_hamiltonian}
+    Let $B$ be a canonical-form tensor with BNT components
+    $A_1,\ldots,A_g$. If every component vector has zero energy for the
+    parent Hamiltonian,
+    \[
+        H_L^{(N)}(B)V^{(N)}(A_j)=0
+        \qquad (1\le j\le g),
+    \]
+    then
+    \[
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
+        \subseteq
+        \ker H_L^{(N)}(B).
+    \]
+    It is enough to assume the local frustration-free equations
+    $h_iV^{(N)}(A_j)=0$ for every $i$ and $j$.
+    This is the easy inclusion in the source ground-space spanning equation of
+    \cite[Definition~3.9]{Cirac2016MPDO_arXiv}; the reverse inclusion is the
+    remaining spanning direction.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The kernel is a linear subspace. Hence it is enough to check the generators
+    $V^{(N)}(A_j)$. The first hypothesis gives this directly. Under the
+    local frustration-free equations,
+    \[
+        H_L^{(N)}(B)V^{(N)}(A_j)
+        =
+        \sum_i h_iV^{(N)}(A_j)
+        =
+        0.
+    \]
+\end{proof}
+
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}
     \lean{MPSTensor.rfp_implies_nncph}
     \leanok

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -80,6 +80,19 @@ zero-energy equation, and the spanning equation
 The source theorem should use this predicate quantified over \(N>2\). The
 predicate is only a named condition; it does not prove that the spanning
 equation holds for any concrete canonical-form tensor.
+The easy inclusion in the spanning equation is now recorded: if each component
+vector \(V^{(N)}(A_j)\) is annihilated by the parent Hamiltonian, or more
+strongly by every local term, then
+\begin{align}
+  \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}
+  \subseteq
+  \ker H_L^{(N)}(B).
+\end{align}
+\footnote{Formal locations:
+\leanid{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_annihilates}
+and
+\leanid{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_frustrationFree}.}
+This does not prove the reverse inclusion.
 
 This still does not prove the full source theorem.  The present declarations do
 not yet prove the named ground-space spanning condition, the three-way


### PR DESCRIPTION
## Summary
- add the elementary inclusion from zero-energy BNT component vectors into the parent-Hamiltonian kernel
- add the equivalent local frustration-free version, by summing the local parent terms
- record the result in the parent-Hamiltonian blueprint and in the CPSV16 ground-state scope note

## Scope
This is the easy direction of the source ground-space spanning equation in CPSV16 Definition 3.9. It does not prove the reverse inclusion, and it does not close the remaining spanning problem.

Refs #2633.

## Checks
- `lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check && python3 scripts/check_oversized_lean_files.py --root .`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and elementary linear-algebra lemmas only; no changes to axioms, Hamiltonian definitions, or critical paths.
> 
> **Overview**
> **Records the easy direction** of the CPSV16 Definition 3.9 ground-space spanning identity: if every BNT component vector \(V^{(N)}(A_j)\) has zero energy under the parent Hamiltonian—or equivalently is frustration-free for each local term—then their span lies in \(\ker H_L^{(N)}(B)\).
> 
> Lean adds `bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_annihilates` (span-in-kernel from generator annihilation) and `bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_frustrationFree` (derived by summing local terms). The parent-Hamiltonian blueprint chapter gets a matching lemma, and the CPSV16 ground-state scope note states this inclusion is proved while the **reverse spanning direction remains open**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca60c98d28d49cb403f415b2c5a0824d164a08f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->