### PR TITLE
refactor(parent): specialize martingale gap via eta

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -18,7 +18,7 @@ estimate remains an explicit hypothesis.
 * `parentHamiltonianES_gap_bound_of_overlap_norm_constant` — the corresponding
   positive-gap bound from a strict uniform compression coefficient.
 * `parentHamiltonian_gapped` — conditional uniform spectral gap for MPS parent
-  Hamiltonians on injective tensors, under the same principal-angle input.
+  Hamiltonians under the same principal-angle input.
 * `parentHamiltonian_gapped_of_overlap_norm_constant` — the corresponding
   uniform spectral gap from a strict uniform compression coefficient.
 -/
@@ -83,7 +83,7 @@ This is the specialization of
 \]
 For this value, \(1-η\,2(L-1)=1/(4L)\). -/
 theorem parentHamiltonianES_gap_bound_of_friedrichs
-    (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (hL : 1 < L)
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
       j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
         ∀ v : EuclideanSpace ℂ (Cfg d N),
@@ -148,10 +148,10 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
 /--
 **Conditional spectral gap for MPS parent Hamiltonians.**
 
-For an injective MPS tensor \(A\) and interaction range \(L > 1\), the
-overlapping-window norm-compression estimate implies the existence of a uniform
-gap \(γ > 0\) (independent of system size \(N\)). For all \(N ≥ 2L\), every vector
-in the orthogonal complement of the ground space satisfies
+For an MPS tensor \(A\) and interaction range \(L > 1\), the overlapping-window
+norm-compression estimate implies the existence of a uniform gap \(γ > 0\)
+(independent of system size \(N\)). For all \(N ≥ 2L\), every vector in the
+orthogonal complement of the ground space satisfies
 \(γ ‖v‖ ≤ ‖H_{\mathrm{ES}} v‖\).
 
 The orthogonal complement is computed in the `EuclideanSpace` structure
@@ -184,7 +184,7 @@ The proof below invokes
 `parentHamiltonianES_gap_bound_of_friedrichs`, which combines the already
 formalized martingale reductions after the overlapping-window estimate is given. -/
 theorem parentHamiltonian_gapped
-    (A : MPSTensor d D) (hA : IsInjective A) (L : ℕ) (hL : 1 < L)
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
       j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
         ∀ v : EuclideanSpace ℂ (Cfg d N),
@@ -195,7 +195,7 @@ theorem parentHamiltonian_gapped
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
-  obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_friedrichs A hA L hL
+  obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_friedrichs A L hL
     hOverlapNorm
   exact ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, hgap⟩
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -31,32 +31,6 @@ variable {d D : ℕ}
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
 
-/-- Gap bound from the overlapping cyclic-window principal-angle estimate for the
-MPS parent Hamiltonian.
-
-The hypothesis is the precise norm-compression estimate for overlapping
-cyclic-window local projections. The finite row-counting geometry, non-overlap
-positivity, projection-geometry comparison, and spectral-theorem step are already
-formalized in `Martingale.Reduction`. The comparison between this explicit
-cyclic-window hypothesis and the martingale paragraph in arXiv:2011.12127,
-Section IV.C, is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
-theorem parentHamiltonianES_gap_bound_of_friedrichs
-    (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (hL : 1 < L)
-    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
-      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
-        ∀ v : EuclideanSpace ℂ (Cfg d N),
-          ‖localTermES A L i (localTermES A L j v)‖ ≤
-            ((1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
-              (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) * ‖localTermES A L i v‖) :
-    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
-    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
-      (v : EuclideanSpace ℂ (Cfg d N)),
-      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
-        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
-          ‖parentHamiltonianES A L N v‖ := by
-  exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound A L hL
-    hOverlapNorm
-
 /-- Gap bound from a strict uniform overlapping cyclic-window compression
 coefficient for the MPS parent Hamiltonian.
 
@@ -90,6 +64,86 @@ theorem parentHamiltonianES_gap_bound_of_overlap_norm_constant
           ‖parentHamiltonianES A L N v‖ := by
   exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
     A L hL hηnonneg hηlt hOverlapNorm
+
+/-- Gap bound from the overlapping cyclic-window principal-angle estimate for the
+MPS parent Hamiltonian.
+
+The hypothesis is the precise norm-compression estimate for overlapping
+cyclic-window local projections. The finite row-counting geometry, non-overlap
+positivity, projection-geometry comparison, and spectral-theorem step are already
+formalized in `Martingale.Reduction`. The comparison between this explicit
+cyclic-window hypothesis and the martingale paragraph in arXiv:2011.12127,
+Section IV.C, is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`.
+
+This is the specialization of
+`parentHamiltonianES_gap_bound_of_overlap_norm_constant` with
+\[
+  η =
+  \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}.
+\]
+For this value, \(1-η\,2(L-1)=1/(4L)\). -/
+theorem parentHamiltonianES_gap_bound_of_friedrichs
+    (A : MPSTensor d D) (_hA : IsInjective A) (L : ℕ) (hL : 1 < L)
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            ((1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) * ‖localTermES A L i v‖) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  let m : ℝ := (((2 * (L - 1) : ℕ) : ℝ))
+  let η : ℝ := (1 - ((1 : ℝ) / (4 * (L : ℝ)))) * m⁻¹
+  have hLgt : (1 : ℝ) < (L : ℝ) := by
+    exact_mod_cast hL
+  have hLpos : 0 < (L : ℝ) := by linarith
+  have hdenpos : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
+  have hδpos : 0 < (1 : ℝ) / (4 * (L : ℝ)) :=
+    div_pos zero_lt_one hdenpos
+  have hδlt : (1 : ℝ) / (4 * (L : ℝ)) < 1 := by
+    rw [div_lt_iff₀ hdenpos]
+    nlinarith
+  have hmpos : 0 < m := by
+    dsimp [m]
+    exact_mod_cast (Nat.mul_pos (by decide : 0 < 2) (Nat.sub_pos_of_lt hL))
+  have hmne : m ≠ 0 := ne_of_gt hmpos
+  have hηnonneg : 0 ≤ η := by
+    dsimp [η]
+    exact mul_nonneg (by linarith) (inv_nonneg.mpr hmpos.le)
+  have hcoef :
+      1 - η * m = (1 : ℝ) / (4 * (L : ℝ)) := by
+    dsimp [η]
+    calc
+      1 - ((1 - (1 : ℝ) / (4 * (L : ℝ))) * m⁻¹) * m
+          = 1 - (1 - (1 : ℝ) / (4 * (L : ℝ))) * (m⁻¹ * m) := by ring
+      _ = 1 - (1 - (1 : ℝ) / (4 * (L : ℝ))) * 1 := by
+        rw [inv_mul_cancel₀ hmne]
+      _ = (1 : ℝ) / (4 * (L : ℝ)) := by ring
+  have hcoefFull :
+      1 - η * (((2 * (L - 1) : ℕ) : ℝ)) =
+        (1 : ℝ) / (4 * (L : ℝ)) := by
+    simpa [m] using hcoef
+  have hηlt : η * m < 1 := by
+    linarith
+  have hOverlapNormη : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L i v‖ := by
+    simpa [η, m] using hOverlapNorm
+  obtain ⟨_, hgap⟩ :=
+    parentHamiltonianES_gap_bound_of_overlap_norm_constant A L hL hηnonneg
+      hηlt hOverlapNormη
+  refine ⟨?_, ?_⟩
+  · exact hδpos
+  · intro N hLN v hv
+    have hgap' := hgap N hLN v hv
+    rw [hcoefFull] at hgap'
+    simpa [div_eq_mul_inv, mul_assoc, mul_left_comm, mul_comm] using hgap'
 
 /--
 **Conditional spectral gap for MPS parent Hamiltonians.**

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -906,11 +906,16 @@ principal-angle estimate remains an explicit input.
         \alpha:=\max_{1\le s<L}\cos\theta_s<1,
     \]
     where $\theta_s$ is the smallest non-zero principal angle between the kernels
-    of two local terms at cyclic distance $s$. For the explicit cyclic-window
-    constants displayed here, the remaining quantitative comparison is the
-    overlapping-window estimate used as a hypothesis in
-    Theorem~\ref{thm:friedrichs_gap_bound}; the preceding lemmas reduce the
-    martingale inequality and the spectral gap to that estimate.
+    of two local terms at cyclic distance $s$. In the present cyclic-window
+    convention, the remaining quantitative comparison is to obtain a constant
+    $\eta\ge0$, independent of $N$, such that
+    \[
+        \|h_i h_j v\|\le \eta\|h_i v\|,
+        \qquad \eta\,2(L-1)<1,
+    \]
+    for every overlapping off-diagonal pair. Theorem~\ref{thm:friedrichs_gap_bound_constant}
+    shows that this is enough for a positive gap; the preceding lemmas reduce the
+    martingale inequality and the spectral gap to this norm-compression estimate.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
     overlapping pairs and the spectral gap follows directly without the
     martingale argument.)
@@ -949,30 +954,39 @@ principal-angle estimate remains an explicit input.
     satisfying the row-sum hypothesis of
     Theorem~\ref{thm:martingale_criterion}.
 
-    \emph{Explicit cyclic-window constant.}
-    With the row coefficient above and
+    \emph{Norm-compression constant.}
+    It remains to compare the cited principal-angle estimates with the
+    cyclic-window norm-compression statement
     \[
-        \gamma_L=\frac{1}{4L},
+        \|h_i h_j v\|\le \eta\|h_i v\|,
+        \qquad \eta\,2(L-1)<1.
     \]
-    the martingale condition is the fixed cyclic-window estimate
+    If such an $\eta$ is obtained, Theorem~\ref{thm:friedrichs_gap_bound_constant}
+    gives the gap constant $1-\eta\,2(L-1)$. The frequently displayed
+    fixed-coefficient form is the specialization with
+    \[
+        \eta=\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)},
+        \qquad
+        1-\eta\,2(L-1)=\frac{1}{4L}.
+    \]
+    In this special case the martingale condition becomes
     \[
         h_i h_j + h_j h_i
         \ge
         -\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}(h_i+h_j)
     \]
-    for every overlapping off-diagonal pair. A sufficient form, used below, is
-    the one-sided norm-compression estimate
+    for every overlapping off-diagonal pair, and a sufficient one-sided form is
     \[
         \|h_i h_j v\|
         \le
         \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}\|h_i v\|.
     \]
     The qualitative smallest-non-zero-principal-angle conclusion $\alpha<1$
-    does not by itself imply this numerical bound; the missing step is the
-    uniform overlapping-window estimate with the displayed coefficient. Thus the
-    remaining comparison is whether the principal-angle estimates cited in
+    does not by itself imply a numerical bound satisfying
+    $\eta\,2(L-1)<1$. Thus the remaining comparison is whether the
+    principal-angle estimates cited in
     \cite{Fannes1992Finitely, Nachtergaele1996Spectral,
-        Kastoryano2018Martingale} supply this cyclic-window inequality, with
+        Kastoryano2018Martingale} supply such a cyclic-window inequality, with
     constants independent of $N$, under the convention used here.
     % Paper-gap note: docs/paper-gaps/cpgsv21_martingale_overlap.tex.
 \end{proof}
@@ -996,7 +1010,8 @@ principal-angle estimate remains an explicit input.
         lem:cyclic_window_nonoverlap_positive,
         lem:parent_hamiltonian_cyclic_window_friedrichs_gap,
         lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
-        lem:parent_hamiltonian_cyclic_overlap_norm_gap}
+        lem:parent_hamiltonian_cyclic_overlap_norm_gap,
+        thm:friedrichs_gap_bound_constant}
     Let $A$ be injective and let $L>1$. Suppose that, for every $N\ge2L$ and
     every overlapping off-diagonal pair of cyclic length-$L$ windows,
     \[
@@ -1040,7 +1055,16 @@ principal-angle estimate remains an explicit input.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} states the
     same overlap-only formulation, and
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} states a sufficient
-    norm-compression formulation. Applying that norm-compression formulation to
+    norm-compression formulation. Equivalently, this is the
+    constant-compression theorem below with
+    \[
+        \eta =
+        \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}.
+    \]
+    Since
+    \[
+        1-\eta\,2(L-1)=\frac{1}{4L},
+    \]
     the displayed hypothesis gives the stated lower bound with
     $\gamma_L=1/(4L)$.
 \end{proof}
@@ -1076,6 +1100,8 @@ principal-angle estimate remains an explicit input.
         \eta\,\|h_{i,\mathrm{ES}}v\|.
     \]
     It gives $0<1-\eta m$ and the stated norm lower bound.
+    The preceding fixed-coefficient theorem is the specialization
+    $\eta=(1-1/(4L))/(2(L-1))$.
 \end{proof}
 
 \begin{theorem}[Conditional spectral gap for MPS parent Hamiltonians]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -1012,7 +1012,7 @@ principal-angle estimate remains an explicit input.
         lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
         lem:parent_hamiltonian_cyclic_overlap_norm_gap,
         thm:friedrichs_gap_bound_constant}
-    Let $A$ be injective and let $L>1$. Suppose that, for every $N\ge2L$ and
+    Let $A$ be a tensor and let $L>1$. Suppose that, for every $N\ge2L$ and
     every overlapping off-diagonal pair of cyclic length-$L$ windows,
     \[
         \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
@@ -1109,7 +1109,7 @@ principal-angle estimate remains an explicit input.
     \lean{MPSTensor.parentHamiltonian_gapped}
     \leanok
     \uses{thm:friedrichs_gap_bound}
-    For an injective tensor $A$ and a range $L > 1$, assume the overlapping
+    For a tensor $A$ and a range $L > 1$, assume the overlapping
     cyclic-window norm-compression estimate of
     Theorem~\ref{thm:friedrichs_gap_bound}. Then there exists $\gamma > 0$ such
     that for every $N \ge 2L$ and every vector

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -224,11 +224,19 @@ The corresponding theorem entries
 \path{thm:friedrichs_gap_bound} and
 \path{thm:friedrichs_gap_bound_constant} point respectively to the special
 coefficient theorem and to the constant-$\eta$ theorem in
-\path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. The latter theorem is
-conditional on (E) and (N$_\eta$). Thus all finite-row, cyclic-window,
-non-overlap, norm-compression, and spectral-theorem reductions are proved, while
-the MPS-specific principal-angle or norm-compression estimate remains to be
-proved or matched precisely to the cited martingale estimates.
+\path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. The special coefficient
+theorem is the specialization of the constant-$\eta$ theorem with
+\[
+    \eta=\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)},
+    \qquad
+    1-\eta\,2(L-1)=\frac{1}{4L}.
+\]
+Both theorem entries are therefore conditional on the same norm-compression
+input, specialized either to this displayed coefficient or to an arbitrary
+coefficient satisfying (E). Thus all finite-row, cyclic-window, non-overlap,
+norm-compression, and spectral-theorem reductions are proved, while the
+MPS-specific principal-angle or norm-compression estimate remains to be proved
+or matched precisely to the cited martingale estimates.
 
 Once the quantitative comparison with the cited martingale estimates is settled,
 the blueprint should say either that a compression bound (N$_\eta$) with


### PR DESCRIPTION
## Summary
- prove the fixed-coefficient martingale gap theorem as the specialization of the constant-eta theorem
- record the coefficient calculation
  \[
    \eta=(1-1/(4L))/(2(L-1)),\qquad 1-\eta\,2(L-1)=1/(4L)
  \]
  in Lean, the blueprint, and the martingale paper-gap note
- update `lem:martingale_mps` so the open source-comparison target is the constant-eta norm-compression estimate, not only the special displayed coefficient

## Scope
This does not prove the remaining principal-angle or norm-compression estimate. It only aligns the formal reduction and reader-facing prose around the already-formalized constant-eta boundary.

Refs #952.

## Checks
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check && python3 scripts/check_oversized_lean_files.py --root .`
- `lake build`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && cd blueprint && leanblueprint checkdecls` (then removed generated `blueprint/lean_decls`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and proof-structure refactor only; the remaining principal-angle estimate is still an explicit hypothesis and spectral-gap logic is unchanged aside from removing an unused injectivity parameter.
> 
> **Overview**
> **Refactors the fixed-coefficient martingale gap bound** so `parentHamiltonianES_gap_bound_of_friedrichs` is proved by specializing `parentHamiltonianES_gap_bound_of_overlap_norm_constant` at \(\eta=(1-1/(4L))/(2(L-1))\), with an in-file proof that \(1-\eta\,2(L-1)=1/(4L)\). The constant-\(\eta\) theorem is listed first; the Friedrichs theorem no longer forwards to a separate reduction entry.
> 
> **Weakens hypotheses** on the conditional gap theorems: `parentHamiltonian_gapped` and the Friedrichs gap bound drop the unused `IsInjective A` assumption.
> 
> **Aligns reader-facing text** in the blueprint (`lem:martingale_mps`, gap theorems) and `docs/paper-gaps/cpgsv21_martingale_overlap.tex` so the open quantitative target is general norm compression with \(\eta\,2(L-1)<1\), with the \(1/(4L)\) coefficient documented as that specialization—not a separate proof boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e508d6ce6aefc205c7c1407f5ff405491909633. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->