### PR TITLE
feat(parent): extract fixed complementary trace compatibility

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -507,6 +507,49 @@ theorem pgvwc07_blockwise_word_compatibility_of_trace_decomposition
     (fun k => Dmat k β * evalWord (A k) (List.ofFn ρ))
     (hCoeff ρ β) j
 
+/-- Fixed complementary-word compatibility from equality of the two coefficient
+decompositions in the Perez-Garcia--Verstraete--Wolf--Cirac block-diagonal
+intersection proof.
+
+Fix a complementary word \(\rho\). If, for every wrapped word \(\beta\) and
+middle word \(w\), the trace decompositions agree with
+\[
+  D^j_\beta=X_jA^j_\beta ,
+\]
+then the blockwise matrices satisfy
+\[
+  A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho .
+\]
+This is the fixed-\(\rho\) form of the comparison in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451. -/
+theorem pgvwc07_fixed_complementary_word_compatibility_of_trace_decomposition
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {m K M : ℕ} (hSpan : WordTupleSpanTop A m)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (ρ : Fin M → Fin d)
+    (hCoeff : ∀ β : Fin K → Fin d, ∀ w : Fin m → Fin d,
+      (∑ j : Fin r,
+        Matrix.trace
+          ((evalWord (A j) (List.ofFn β) * C j) *
+            evalWord (A j) (List.ofFn w))) =
+      (∑ j : Fin r,
+        Matrix.trace
+          (((X j * evalWord (A j) (List.ofFn β)) *
+              evalWord (A j) (List.ofFn ρ)) *
+            evalWord (A j) (List.ofFn w)))) :
+    ∀ j : Fin r, ∀ β : Fin K → Fin d,
+      evalWord (A j) (List.ofFn β) * C j =
+        (X j * evalWord (A j) (List.ofFn β)) *
+          evalWord (A j) (List.ofFn ρ) := by
+  intro j β
+  exact block_matrices_eq_of_wordTupleSpanTop_trace A hSpan
+    (fun k => evalWord (A k) (List.ofFn β) * C k)
+    (fun k =>
+      (X k * evalWord (A k) (List.ofFn β)) * evalWord (A k) (List.ofFn ρ))
+    (hCoeff β) j
+
 /-- Word-valued compatibility for a block-diagonal boundary matrix.
 
 Assume the right trace decomposition has

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -237,6 +237,42 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
     $D^j_\beta=X_jA^j_\beta$ is immediate.
 \end{proof}
 
+\begin{lemma}[Fixed complementary-word compatibility from traces]
+    \label{lem:fixed_complementary_word_boundary_compatibility_from_traces}
+    \lean{MPSTensor.pgvwc07_fixed_complementary_word_compatibility_of_trace_decomposition}
+    \leanok
+    \uses{lem:block_matrices_equal_from_trace_pairings}
+    Let $A^1,\ldots,A^g$ be block tensors with the common word-span property
+    at length $m$. Fix a complementary word $\rho$ of length $M$ and matrices
+    $C^j_\rho,X_j\in\MN{D_j}$. If, for every wrapped word $\beta$ of length
+    $K$ and every middle word $w$ of length $m$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_\rho A^j_w\right)
+        =
+        \sum_j\tr\!\left((X_jA^j_\beta)A^j_\rho A^j_w\right),
+    \]
+    then
+    \[
+        A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho
+    \]
+    for every block $j$ and every wrapped word $\beta$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_matrices_equal_from_trace_pairings}
+    Fix $\beta$ and set
+    \[
+        \Delta_j=A^j_\beta C^j_\rho-(X_jA^j_\beta)A^j_\rho .
+    \]
+    The trace equality gives
+    \[
+        \sum_j\tr(\Delta_jA^j_w)=0
+    \]
+    for every word $w$ of length $m$. The common word-span property and the
+    product trace pairing imply $\Delta_j=0$ for every $j$.
+\end{proof}
+
 \begin{lemma}[Normalized boundary matrix identities]
     \label{lem:normalized_boundary_matrix_identities}
     \lean{MPSTensor.pgvwc07_boundary_matrix_identities_of_indexed_compatibility}


### PR DESCRIPTION
Stacked on #2944.

Refs #2651.

This records the fixed-complementary-word extraction in the PGVWC07 trace comparison. For a fixed outside word \(ho\), the trace equality for all wrapped words \(eta\) and middle words \(w\) implies
\[
  A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho.
\]
This is the fixed-\(ho\) form of the comparison in arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451. It does not claim the full family indexed by all complementary words; that remains the next step for #2651.

Verification:
- `lake env lean TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `python3 scripts/check_oversized_lean_files.py --root .`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; proofs reuse the existing trace-pairing extraction with no changes to auth, data, or runtime behavior.
> 
> **Overview**
> This PR **extracts the fixed-ρ step** of the PGVWC07 trace comparison (Theorem 12, proof lines 1446–1451): when ρ is held fixed, trace agreement for every wrapped word β and middle word w implies **\(A^j_\beta C^j_\rho = (X_j A^j_\beta) A^j_\rho\)** per block.
> 
> The new Lean theorem `pgvwc07_fixed_complementary_word_compatibility_of_trace_decomposition` instantiates `block_matrices_eq_of_wordTupleSpanTop_trace` with the fixed-ρ coefficient hypothesis (C is block-local, not word-indexed). The blueprint gains matching **Lemma** `lem:fixed_complementary_word_boundary_compatibility_from_traces` with `\leanok` sync to that name.
> 
> This is **not** the full family over all complementary words ρ; that remains separate (e.g. via `pgvwc07_complementary_word_compatibility_of_trace_decomposition`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b438410888c82a2cd93c6939d29f1a8c6ae6298d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->