### PR TITLE
feat(parent): derive boundary-crossing PGVWC comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
+import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 
 /-!
 # Trace decompositions at a boundary-crossing interval
@@ -193,5 +194,86 @@ theorem blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
           (groundSpaceMap (A j) N ((μ j) ^ N • X j)) σ := by
             simpa [headWord, middleWord, tailWord] using hApply.symm
   exact hLeft.trans (hSum.trans hRight.symm)
+
+/-- Fixed boundary-crossing PGVWC comparison from the local block-sum constraint.
+
+For a cyclic interval of length \(L\) beginning at \(i\), with \(N<i+L\), the
+preceding trace decomposition has a fixed complementary word
+\[
+  \rho(k)=\tau_{i+L-N+k},\qquad 0\le k<N-L.
+\]
+If the tail-word products at length \(N-i\) span the blockwise product algebra,
+then the trace decomposition implies, for every block \(j\) and every wrapped
+word \(\beta\) before the cut,
+\[
+  A^j_\beta C^j
+  =
+  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+\]
+This is the fixed-interval form of the Perez-Garcia--Verstraete--Wolf--Cirac
+\(C^j,D^j\) comparison in arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1446--1448. The source writes the local coordinates as
+\(i_1,\ldots,i_{m+1}\); here \(\beta\) is the wrapped word before the cut and
+\(\rho\) is the complementary outside word. -/
+theorem blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (i : Fin N) (τ : Fin N → Fin d) (hi : N < i.val + L)
+    (hSpan : WordTupleSpanTop A (N - i.val))
+    (hmem :
+      (∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
+        ⨆ j : Fin r, groundSpace (A j) L) :
+    ∃ C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      let ρ : Fin (N - L) → Fin d := fun k =>
+        τ ⟨i.val + L - N + k.val, by omega⟩
+      ∀ j : Fin r, ∀ β : Fin (i.val + L - N) → Fin d,
+        evalWord (A j) (List.ofFn β) * C j =
+          (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+            evalWord (A j) (List.ofFn ρ) := by
+  classical
+  obtain ⟨C, hTrace⟩ :=
+    blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
+      μ A hN hLN X i τ hi hmem
+  refine ⟨C, ?_⟩
+  let ρ : Fin (N - L) → Fin d := fun k =>
+    τ ⟨i.val + L - N + k.val, by omega⟩
+  refine
+    pgvwc07_fixed_complementary_word_compatibility_of_trace_decomposition
+      (A := A) (m := N - i.val) (K := i.val + L - N) (M := N - L)
+      hSpan (fun j => (μ j) ^ N • X j) C ρ ?_
+  intro β w
+  let σ : Fin L → Fin d := fun k =>
+    if hk : k.val < N - i.val then
+      w ⟨k.val, hk⟩
+    else
+      β ⟨k.val - (N - i.val), by omega⟩
+  have hHead :
+      (List.ofFn fun k : Fin (i.val + L - N) =>
+        σ ⟨N - i.val + k.val, by omega⟩) = List.ofFn β := by
+    apply List.ext_getElem
+    · simp
+    · intro n hn₁ hn₂
+      simp only [List.getElem_ofFn]
+      have hnot : ¬N - i.val + n < N - i.val := by omega
+      simp [σ, hnot]
+  have hMiddle :
+      (List.ofFn fun k : Fin (N - L) =>
+        τ ⟨i.val + L - N + k.val, by omega⟩) = List.ofFn ρ := by
+    rfl
+  have hTail :
+      (List.ofFn fun k : Fin (N - i.val) =>
+        σ ⟨k.val, by omega⟩) = List.ofFn w := by
+    apply List.ext_getElem
+    · simp
+    · intro n hn₁ hn₂
+      simp only [List.getElem_ofFn]
+      have hlt : n < N - i.val := by
+        simpa using hn₁
+      simp [σ, hlt]
+  simpa [hHead, hMiddle, hTail, Matrix.mul_assoc] using hTrace σ
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -623,6 +623,47 @@ in both cases.
     gives the second trace expression for the same local coefficient sum.
 \end{proof}
 
+\begin{theorem}[Fixed boundary-crossing PGVWC comparison from the local block-sum constraint]
+    \label{thm:block_diagonal_boundary_crossing_pgvwc_comparison}
+    \lean{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_trace_decomposition,
+        lem:fixed_complementary_word_boundary_compatibility_from_traces}
+    Assume $0<N$, $L\le N$, and let the cyclic interval beginning at $i$
+    cross the boundary cut, so $N<i+L$. Put $a=i+L-N$ and
+    $\rho=\tau_a\cdots\tau_{i-1}$. Suppose also that the block tensors have
+    the common word-span property at length $N-i$. If
+    \[
+        \sum_j
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in\bigvee_jG_L(A_j),
+    \]
+    then there are matrices $C^j_{i,\tau}$ such that, for every block $j$
+    and every word $\beta$ of length $a$,
+    \[
+        A^j_\beta C^j_{i,\tau}
+        =
+        \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_trace_decomposition,
+        lem:fixed_complementary_word_boundary_compatibility_from_traces}
+    Lemma~\ref{lem:block_diagonal_boundary_crossing_trace_decomposition}
+    gives matrices $C^j_{i,\tau}$ with
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\tau}A^j_\alpha\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_\alpha\right)
+    \]
+    for every word $\alpha$ of length $N-i$ and every word $\beta$ of length
+    $a$. The fixed complementary-word trace comparison, applied with
+    $X_j$ replaced by $\mu_j^NX_j$, gives the displayed matrix identity.
+\end{proof}
+
 \begin{lemma}[Boundary-crossing cyclic intervals from the boundary matrix identity]
     \label{lem:block_diagonal_boundary_crossing_matrix_identity}
     \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix}


### PR DESCRIPTION
Stacked on #2950. Advances #2651.\n\nSummary:\n- derive the fixed boundary-crossing PGVWC C^j,D^j comparison from the local block-sum constraint\n- record the corresponding blueprint theorem with the source equation\n\nSource anchors:\n- arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1448\n- arXiv:2011.12127, Section IV.C, lines 2126--2128\n\nChecks:\n- lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean\n- lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace\n- lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition\n- python3 scripts/blueprint_lean_sync.py --root . --ci\n- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci\n- git diff --check\n\nNote: bare leanblueprint checkdecls did not run in this checkout because blueprint/lean_decls is not a tracked/generated file before web generation; the project sync checker above verified the new blueprint declaration against current Lean source.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization in parent-Hamiltonian MPS theory with no runtime, auth, or data-path changes; risk is limited to proof correctness in this module stack.
> 
> **Overview**
> Adds the **fixed boundary-crossing PGVWC** matrix identity \(A^j_\beta C^j = ((\mu_j^N X_j)A^j_\beta)A^j_\rho\) as a formal consequence of the local block-sum constraint when tail words span the block product algebra.
> 
> In Lean, `blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup` pulls \(C^j\) from the existing trace-decomposition lemma, then applies `pgvwc07_fixed_complementary_word_compatibility_of_trace_decomposition` (new import from `BlockIntersectionProperty`) with a constructed local word \(\sigma\) that aligns head/middle/tail pieces with \(\beta\), \(\rho\), and \(w\).
> 
> The blueprint chapter gains **Theorem** `block_diagonal_boundary_crossing_pgvwc_comparison` (`\leanok`), wired to that Lean name and proved by citing the trace-decomposition lemma plus the fixed complementary-word trace comparison.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77828ac61d0b7e1ec632f9b30450ce8d486c4cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->