### PR TITLE
feat(parent): derive fixed crossing block membership

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -276,4 +276,48 @@ theorem blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
       simp [σ, hlt]
   simpa [hHead, hMiddle, hTail, Matrix.mul_assoc] using hTrace σ
 
+/-- Fixed boundary-crossing PGVWC comparison gives local block membership.
+
+For a cyclic interval of length \(L\) beginning at \(i\), with \(N<i+L\), assume
+that the local block sum lies in \(\bigvee_jG_L(A^j)\) and that the tail-word
+products of length \(N-i\) span the blockwise product algebra. The preceding
+PGVWC \(C^j,D^j\) comparison then supplies, for each block \(j\), the boundary
+matrix required to write
+\[
+  R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+\]
+as a vector in \(G_L(A^j)\).
+
+This is the fixed-window local-membership consequence of arXiv:quant-ph/0608197,
+Theorem 12, proof lines 1436--1456, in the block-diagonal boundary-condition
+coordinates used in arXiv:2011.12127, Section IV.C, lines 2126--2128. -/
+theorem
+    blockDiagonal_boundary_crossing_component_mem_groundSpace_of_pgvwc_comparison_of_sum_mem_iSup
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (i : Fin N) (τ : Fin N → Fin d) (hi : N < i.val + L)
+    (hSpan : WordTupleSpanTop A (N - i.val))
+    (hmem :
+      (∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
+        ⨆ j : Fin r, groundSpace (A j) L) :
+    ∀ j : Fin r,
+      cyclicRestrictₗ hN L i τ
+          (groundSpaceMap (A j) N ((μ j) ^ N • X j)) ∈
+        groundSpace (A j) L := by
+  classical
+  obtain ⟨C, hC⟩ :=
+    blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
+      μ A hN hLN X i τ hi hSpan hmem
+  intro j
+  refine
+    blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix
+      μ A hN hLN X j i τ hi ?_
+  refine ⟨C j, ?_⟩
+  intro β
+  exact (hC j β).symm
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -39,8 +39,9 @@ If the block sum of the cyclic restrictions lies in
   =
   \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr)
 \]
-for every local word \(\sigma\).  This is the fixed-interval form of the
-trace-decomposition comparison used in PGVWC07, Theorem 12. -/
+for every local word \(\sigma\). This is the fixed-interval
+trace-decomposition comparison used in Perez-Garcia--Verstraete--Wolf--Cirac,
+Theorem 12. -/
 theorem blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -195,7 +196,8 @@ theorem blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
             simpa [headWord, middleWord, tailWord] using hApply.symm
   exact hLeft.trans (hSum.trans hRight.symm)
 
-/-- Fixed boundary-crossing PGVWC comparison from the local block-sum constraint.
+/-- Fixed boundary-crossing \(C^j,D^j\) comparison from the local block-sum
+constraint.
 
 For a cyclic interval of length \(L\) beginning at \(i\), with \(N<i+L\), the
 preceding trace decomposition has a fixed complementary word
@@ -210,11 +212,11 @@ word \(\beta\) before the cut,
   =
   \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
 \]
-This is the fixed-interval form of the Perez-Garcia--Verstraete--Wolf--Cirac
-\(C^j,D^j\) comparison in arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1448. The source writes the local coordinates as
-\(i_1,\ldots,i_{m+1}\); here \(\beta\) is the wrapped word before the cut and
-\(\rho\) is the complementary outside word. -/
+This is the fixed cyclic-interval coordinate form of the
+Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j\) comparison in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1448. The source writes
+the local coordinates as \(i_1,\ldots,i_{m+1}\); here \(\beta\) is the wrapped
+word before the cut and \(\rho\) is the complementary outside word. -/
 theorem blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -276,13 +278,13 @@ theorem blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
       simp [σ, hlt]
   simpa [hHead, hMiddle, hTail, Matrix.mul_assoc] using hTrace σ
 
-/-- Fixed boundary-crossing PGVWC comparison gives local block membership.
+/-- Fixed boundary-crossing \(C^j,D^j\) comparison gives local block membership.
 
 For a cyclic interval of length \(L\) beginning at \(i\), with \(N<i+L\), assume
 that the local block sum lies in \(\bigvee_jG_L(A^j)\) and that the tail-word
 products of length \(N-i\) span the blockwise product algebra. The preceding
-PGVWC \(C^j,D^j\) comparison then supplies, for each block \(j\), the boundary
-matrix required to write
+Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j\) comparison then supplies,
+for each block \(j\), the boundary matrix required to write
 \[
   R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
 \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -664,6 +664,44 @@ in both cases.
     $X_j$ replaced by $\mu_j^NX_j$, gives the displayed matrix identity.
 \end{proof}
 
+\begin{theorem}[Fixed boundary-crossing block membership from the PGVWC comparison]
+    \label{thm:block_diagonal_boundary_crossing_component_mem_ground_space}
+    \lean{MPSTensor.blockDiagonal_boundary_crossing_component_mem_groundSpace_of_pgvwc_comparison_of_sum_mem_iSup}
+    \leanok
+    \uses{thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+        lem:block_diagonal_boundary_crossing_matrix_identity}
+    Assume $0<N$, $L\le N$, and let the cyclic interval beginning at $i$
+    cross the boundary cut, so $N<i+L$. Suppose that the block tensors have
+    the common word-span property at length $N-i$ and that
+    \[
+        \sum_j
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in\bigvee_jG_L(A_j).
+    \]
+    Then each block component of the fixed boundary-crossing restriction lies
+    in its local block space:
+    \[
+        R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
+        \in G_L(A_j).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+        lem:block_diagonal_boundary_crossing_matrix_identity}
+    Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison}
+    gives matrices $C^j_{i,\tau}$ with
+    \[
+        A^j_\beta C^j_{i,\tau}
+        =
+        \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+    \]
+    Thus $E=C^j_{i,\tau}$ satisfies the boundary matrix identity required in
+    Lemma~\ref{lem:block_diagonal_boundary_crossing_matrix_identity}, and the
+    displayed membership follows for every block $j$.
+\end{proof}
+
 \begin{lemma}[Boundary-crossing cyclic intervals from the boundary matrix identity]
     \label{lem:block_diagonal_boundary_crossing_matrix_identity}
     \lean{MPSTensor.blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -623,7 +623,7 @@ in both cases.
     gives the second trace expression for the same local coefficient sum.
 \end{proof}
 
-\begin{theorem}[Fixed boundary-crossing PGVWC comparison from the local block-sum constraint]
+\begin{theorem}[Fixed boundary-crossing $C^j,D^j$ comparison from the local block-sum constraint]
     \label{thm:block_diagonal_boundary_crossing_pgvwc_comparison}
     \lean{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup}
     \leanok
@@ -645,6 +645,9 @@ in both cases.
         =
         \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
     \]
+    This theorem is the fixed cyclic-interval coordinate form of the
+    Perez-Garcia--Verstraete--Wolf--Cirac comparison; it does not assert the
+    full periodic-boundary ground-space statement.
 \end{theorem}
 
 \begin{proof}
@@ -664,7 +667,7 @@ in both cases.
     $X_j$ replaced by $\mu_j^NX_j$, gives the displayed matrix identity.
 \end{proof}
 
-\begin{theorem}[Fixed boundary-crossing block membership from the PGVWC comparison]
+\begin{theorem}[Fixed boundary-crossing component in the local block space]
     \label{thm:block_diagonal_boundary_crossing_component_mem_ground_space}
     \lean{MPSTensor.blockDiagonal_boundary_crossing_component_mem_groundSpace_of_pgvwc_comparison_of_sum_mem_iSup}
     \leanok
@@ -684,6 +687,8 @@ in both cases.
         R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
         \in G_L(A_j).
     \]
+    This is the corresponding fixed-interval block-diagonal boundary-condition
+    consequence.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
This PR is stacked on #2951 and advances #2651. It does not close #2651, because the remaining periodic-boundary step still has to remove the fixed-tail span/family issue without adding a non-source hypothesis.

Summary:
- derives fixed boundary-crossing block membership from the PGVWC comparison established in #2951;
- uses the existing crossing-window boundary-matrix lemma to place each fixed component in \(G_L(A_j)\);
- records the corresponding blueprint theorem without presenting it as the final unconditional periodic-boundary statement.

Source anchors:
- PGVWC07 Theorem 12 proof, trace comparison and direct-sum step, lines 1436--1456 of the local source;
- Cirac et al. review, Section IV.C, boundary-condition closure discussion around lines 2126--2128 of the local source.

Checks:
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and blueprint sync only; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds a Lean theorem showing that, for a **boundary-crossing** cyclic window, the local block-sum hypothesis plus word-span yields **per-block** membership of each fixed restriction in `G_L(A^j)`. The proof runs the existing PGVWC \(C^j,D^j\) comparison, then applies the crossing-window boundary-matrix lemma.
> 
> The blueprint gains a matching **fixed boundary-crossing component in the local block space** theorem and proof, with wording updates on the PGVWC comparison theorem so it is clearly a fixed-interval coordinate form, not the full periodic-boundary closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abf6628f6d95e3e2c4a2a87dacc40c007895ae4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->