### PR TITLE
doc(parent): align boundary-comparison terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
 
 /-!
-# PGVWC comparison identities for block-diagonal parent spaces
+# Boundary-condition comparisons for block-diagonal parent spaces
 
 The word-indexed Pérez-García--Verstraete--Wolf--Cirac comparison
 \[
@@ -26,8 +26,8 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- PGVWC comparison identities upgrade the block-diagonal boundary
-representation to periodic single-block states.
+/-- The \(C^j,D^j\) boundary-condition comparison upgrades a block-diagonal
+boundary representation to periodic single-block states.
 
 Under the normalized BNT hypotheses, every vector in the block-diagonal
 periodic-boundary ground space has block-diagonal boundary conditions \(X_j\). If those
@@ -53,9 +53,10 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external comparison hypothesis; tracked in issue 2651. -/
+derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1446--1456, and use it to remove the external comparison hypothesis;
+tracked in issue 2651. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -101,8 +102,8 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c
   exact blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective
     μ A hN hLN X hBlk hUnital hNlarge C hCompat
 
-/-- PGVWC comparison identities give the block-diagonal periodic-boundary equality
-in the finite BNT range.
+/-- The \(C^j,D^j\) boundary-condition comparison gives the block-diagonal
+periodic-boundary equality in the finite BNT range.
 
 This theorem assumes the source \(C^j,D^j\) comparison only up to the
 word-indexed matrix identity
@@ -124,9 +125,10 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external comparison hypothesis; tracked in issue 2651. -/
+derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1446--1456, and use it to remove the external comparison hypothesis;
+tracked in issue 2651. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -7,11 +7,11 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace
 /-!
 # Finite-spanning versions of trace-decomposition results for block-diagonal parent spaces
 
-This file packages a finite-spanning form of the PGVWC trace-decomposition
-hypothesis into the block-diagonal boundary and finite-range equality
-conclusions. The remaining source step is to derive that trace-decomposition
-equality from the \(C^j,D^j\) comparison in arXiv:quant-ph/0608197, Theorem 12,
-after specializing \(D^j_\beta\) to the block-diagonal boundary expression
+This file packages a finite-spanning form of the trace decompositions in
+Perez-Garcia--Verstraete--Wolf--Cirac, Theorem 12, into the block-diagonal
+boundary and finite-range equality conclusions. The remaining source step is to
+derive that trace-decomposition equality from the \(C^j,D^j\) comparison after
+specializing \(D^j_\beta\) to the block-diagonal boundary expression
 \((\mu_j^N X_j)A^j_\beta\). The normalized \(E^j\)-calculation is then supplied
 by the downstream complementary-word lemmas.
 -/
@@ -22,8 +22,8 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- PGVWC trace decompositions upgrade the block-diagonal boundary
-representation to periodic single-block states.
+/-- Source trace decompositions upgrade a block-diagonal boundary representation
+to periodic single-block states.
 
 Under the normalized BNT hypotheses, every vector in the block-diagonal
 periodic chain space has block-diagonal boundary conditions \(X_j\). Assume
@@ -53,9 +53,10 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external trace-decomposition hypothesis; tracked in issue 2651. -/
+derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1446--1456, and use it to remove the external trace-decomposition
+hypothesis; tracked in issue 2651. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -111,8 +112,8 @@ theorem
     blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
       μ A hN hLN X hTraceSpan hBlk hUnital hNlarge C hCoeff
 
-/-- PGVWC trace decompositions give the block-diagonal periodic-boundary equality
-in the finite BNT range.
+/-- Source trace decompositions give the block-diagonal periodic-boundary
+equality in the finite BNT range.
 
 This theorem combines the block-diagonal boundary representation with the
 trace-decomposition form of the Pérez-García--Verstraete--Wolf--Cirac
@@ -129,9 +130,10 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external trace-decomposition hypothesis; tracked in issue 2651. -/
+derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1446--1456, and use it to remove the external trace-decomposition
+hypothesis; tracked in issue 2651. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -9,15 +9,17 @@ import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 /-!
 # Boundary matrix identities
 
-Normalized boundary-matrix identities from the Perez-Garcia-Verstraete-Wolf-Cirac
-block-diagonal intersection proof: from \(A_b C_a=D_b B_a\) with right-normalized
-\(B\) and \(E=\sum_a C_a B_a^\dagger\), one obtains \(D_b=A_b E\) and
+Normalized \(C,D,E\) boundary-matrix identities from the
+Perez-Garcia--Verstraete--Wolf--Cirac block-diagonal intersection proof: from
+\(A_b C_a=D_b B_a\) with right-normalized \(B\) and
+\(E=\sum_a C_a B_a^\dagger\), one obtains \(D_b=A_b E\) and
 \(A_b C_a=A_b E B_a\).
 
 ## References
 
-* arXiv:quant-ph/0608197 (Perez-Garcia-Verstraete-Wolf-Cirac 2007), Theorem 12,
-  proof around \(A_b C_a=D_b A_a\) and \(E=\sum_a C_a A_a^\dagger\).
+* arXiv:quant-ph/0608197 (Perez-Garcia--Verstraete--Wolf--Cirac 2007),
+  Theorem 12, proof around \(A_b C_a=D_b A_a\) and
+  \(E=\sum_a C_a A_a^\dagger\).
 -/
 
 open scoped Matrix BigOperators
@@ -26,7 +28,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Two-index boundary-matrix identities in the PGVWC boundary comparison.
+/-- Two-index boundary-matrix identities in the \(C,D,E\) boundary comparison.
 
 This abstracts the normalized matrix calculation in arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1451.
@@ -73,8 +75,8 @@ theorem pgvwc07_boundary_matrix_identities_of_two_index_compatibility
     A b * C a = Dmat b * B a := hCompat a b
     _ = A b * (∑ c : κ, C c * (B c)ᴴ) * B a := by rw [hD b]
 
-/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof,
-for an arbitrary finite index set.
+/-- Boundary-matrix identities in the block-diagonal intersection proof, for an
+arbitrary finite index set.
 
 Assume
 \[
@@ -101,7 +103,7 @@ theorem pgvwc07_boundary_matrix_identities_of_indexed_compatibility
   exact pgvwc07_boundary_matrix_identities_of_two_index_compatibility
     A A C Dmat hUnital hCompat
 
-/-- Boundary-matrix identities in the PGVWC block-diagonal intersection proof. -/
+/-- Boundary-matrix identities in the block-diagonal intersection proof. -/
 theorem pgvwc07_boundary_matrix_identities_of_compatibility
     (A : MPSTensor d D)
     (C Dmat : Fin d → Matrix (Fin D) (Fin D) ℂ)
@@ -113,7 +115,8 @@ theorem pgvwc07_boundary_matrix_identities_of_compatibility
   exact pgvwc07_boundary_matrix_identities_of_indexed_compatibility
     A C Dmat hUnital hCompat
 
-/-- Word-indexed boundary-matrix identities in the PGVWC boundary comparison.
+/-- Word-indexed boundary-matrix identities in the \(C,D,E\) boundary
+comparison.
 
 This is the same normalized matrix calculation with the finite index set taken
 to be words of a fixed length:
@@ -144,8 +147,8 @@ theorem pgvwc07_boundary_word_matrix_identities_of_compatibility
 
 /-- Two-length word-indexed boundary-matrix identities.
 
-This is the word-alphabet form of the PGVWC07 calculation in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451.
+This is the word-alphabet form of the \(C,D,E\) calculation in
+Perez-Garcia--Verstraete--Wolf--Cirac, Theorem 12, proof lines 1446--1451.
 
 The two index sets are words of lengths \(K\) and \(M\):
 \[
@@ -178,10 +181,11 @@ theorem pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
     (fun ρ : Fin M → Fin d => evalWord A (List.ofFn ρ))
     C Dmat hUnital hCompat
 
-/-- Complementary-word boundary identities from a two-length PGVWC comparison.
+/-- Complementary-word boundary identities from a two-length \(C,D,E\)
+comparison.
 
-This is the boundary-crossing form of the PGVWC07 calculation in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451.
+This is the boundary-crossing form of the Perez-Garcia--Verstraete--Wolf--Cirac
+calculation in arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451.
 
 Let \(X\in M_D(\mathbb C)\) be a matrix. Assume that for every complementary
 word \(\rho\) and wrapped word \(\beta\),

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -271,7 +271,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[$C^j$ boundary comparisons reduce to periodic-boundary equality]
+\begin{lemma}[$C^j,D^j$ boundary-condition comparisons reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_pgvwc_comparison_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison}
     \leanok


### PR DESCRIPTION
This PR is a small terminology cleanup for the parent-Hamiltonian boundary-comparison route. It does not change theorem statements or proofs.

Summary:
- replaces reader-facing shorthand such as "PGVWC comparison" with the source-facing \(C^j,D^j,E^j\) boundary-condition comparison language;
- aligns the trace-decomposition wrappers with the wording of the Perez-Garcia--Verstraete--Wolf--Cirac proof of Theorem 12;
- updates the matching blueprint title in the block-diagonal chain-equality section.

Source anchors:
- arXiv:quant-ph/0608197, Theorem 12 proof, especially the \(A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}\) comparison and the subsequent \(E^j\) calculation;
- arXiv:2011.12127, Section IV.C, block-diagonal boundary conditions.

Checks:
- `lake env lean TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

Refs #190.
Refs #2651.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint title edits only; no executable Lean or proof changes.
> 
> **Overview**
> **Documentation-only** terminology cleanup for the parent-Hamiltonian block-diagonal route. **Theorem statements, proof terms, and Lean identifiers are unchanged.**
> 
> Reader-facing prose now favors the source **\(C^j,D^j,E^j\) boundary-condition comparison** instead of shorthand like “PGVWC comparison” or “PGVWC trace decompositions,” in `BNTBlockDiagonalPGVWCComparison.lean`, `BNTBlockDiagonalTraceDecomposition.lean`, and `BoundaryMatrixIdentities.lean`. Module headers, theorem docstrings, and **Unfaithful** elimination notes are updated consistently (including spelling **Perez-Garcia--Verstraete--Wolf--Cirac** in those notes).
> 
> The blueprint lemma title in `ch13_parent_hamiltonian_block_diagonal_chain_equality.tex` is aligned: **“\(C^j,D^j\) boundary-condition comparisons reduce to periodic-boundary equality.”**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dab6fa31a86d67e16e2659266a906e23dc4c672a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->