### PR TITLE
feat(parent): name all-chain NNCPH ground spaces

### DIFF
--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -16,11 +16,10 @@ different external provenance and so are stated here as **separate** axioms with
 **separate** citations:
 
 * `Axioms.rfp_to_nncph_commute` — RFP ⟹ the NNCPH commutation equations. Per
-  arXiv:1606.00608 Section 3.3 (line 1307 of the source): *"The implication
-  RFP ⟹ NNCPH is trivial from Theorem [charact-MPS]"*. It is
-  therefore **not** gated on [Beigi 2012]; it is gated only on
-  Theorem `thm:charact-MPS` of arXiv:1606.00608 (source lines 543--555), the
-  structural characterization of RFP tensors.
+  arXiv:1606.00608 Section 3.3 (source line 1307), the proof derives this
+  implication from the structural characterization theorem. It is therefore
+  **not** gated on [Beigi 2012]; it is gated on the structural characterization
+  of RFP tensors in arXiv:1606.00608, source lines 543--555.
 * `Axioms.beigi_nncph_to_rfp` — pairwise length-two commutativity ⟹ RFP. This
   is the present axiom-backed reverse implication; the source NNCPH condition
   also includes the parent-Hamiltonian ground-space statement recorded below.
@@ -37,8 +36,8 @@ projectors.
 
 **Scope restriction (ground-state condition):** The source theorem states a
 three-way equivalence for tensors in canonical form and uses the condition that
-`|V^{(N)}(A)⟩` is a ground state of a nearest-neighbor commuting parent
-Hamiltonian for every `N > 2`. That includes the parent-Hamiltonian
+\(|V^{(N)}(A)\rangle\) is a ground state of a nearest-neighbor commuting parent
+Hamiltonian for every \(N > 2\). That includes the parent-Hamiltonian
 ground-space condition. The axioms below state only the translated two-site
 commutativity conditions appearing in the parent-Hamiltonian hypotheses.
 Documented in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
@@ -55,7 +54,8 @@ in the proofs of
 ## TODO
 
 Replace `Axioms.rfp_to_nncph_commute` with a Lean proof that uses the
-structural form of Theorem `thm:charact-MPS` in arXiv:1606.00608. The structural
+structural characterization theorem in arXiv:1606.00608, source lines
+543--555. The structural
 construction in
 `TNLean/MPS/RFP/CommutingBridge.lean` (`ProductPairBridge`) already
 encodes the key combinatorial content; the missing piece is the
@@ -87,8 +87,8 @@ states. Formalization is expected to require:
   arXiv:1606.00608).
 * Cirac, Pérez-García, Schuch, Verstraete, "Matrix Product States and
   Projected Entangled Pair States: Concepts, Symmetries, and Theorems",
-  arXiv:1606.00608 Section 3.3 Theorems `thm:main-MPS` and
-  `thm:charact-MPS`, Appendix B and Appendix D.2.
+  arXiv:1606.00608 Section 3.3, the pure-state main theorem, the structural
+  characterization theorem, Appendix B, and Appendix D.2.
 -/
 
 open scoped Matrix BigOperators
@@ -108,10 +108,9 @@ Unfolded on the NNCPH side, the commutativity condition is exactly
 unfolded form avoids a circular import between this axiom module and
 the file that consumes it.
 
-**Citation.** This direction is attributed in arXiv:1606.00608 Section 3.3
-(source line 1307) as *"trivial from Theorem [charact-MPS]"*, i.e.,
-from the structural characterization in Theorem `thm:charact-MPS` (source
-lines 543--555). It does **not** depend on S. Beigi (2012). A structural
+**Citation.** This direction is derived in arXiv:1606.00608 Section 3.3
+(source line 1307) from the structural characterization theorem (source lines
+543--555). It does **not** depend on S. Beigi (2012). A structural
 construction for the product-of-entangled-pairs form lives in
 `TNLean/MPS/RFP/CommutingBridge.lean` as `ProductPairBridge`.
 

--- a/TNLean/Axioms/Beigi.lean
+++ b/TNLean/Axioms/Beigi.lean
@@ -19,8 +19,8 @@ different external provenance and so are stated here as **separate** axioms with
   arXiv:1606.00608 Section 3.3 (line 1307 of the source): *"The implication
   RFP ⟹ NNCPH is trivial from Theorem [charact-MPS]"*. It is
   therefore **not** gated on [Beigi 2012]; it is gated only on
-  Theorem 3.10 of arXiv:1606.00608 (the full structural
-  characterization of RFPs via product-of-entangled-pairs).
+  Theorem `thm:charact-MPS` of arXiv:1606.00608 (source lines 543--555), the
+  structural characterization of RFP tensors.
 * `Axioms.beigi_nncph_to_rfp` — pairwise length-two commutativity ⟹ RFP. This
   is the present axiom-backed reverse implication; the source NNCPH condition
   also includes the parent-Hamiltonian ground-space statement recorded below.
@@ -55,8 +55,8 @@ in the proofs of
 ## TODO
 
 Replace `Axioms.rfp_to_nncph_commute` with a Lean proof that uses the
-product-of-entangled-pairs structural form (Appendix B of
-arXiv:1606.00608). The structural construction in
+structural form of Theorem `thm:charact-MPS` in arXiv:1606.00608. The structural
+construction in
 `TNLean/MPS/RFP/CommutingBridge.lean` (`ProductPairBridge`) already
 encodes the key combinatorial content; the missing piece is the
 extraction of a `ProductPairBridge A` witness from `IsRFP A` and
@@ -87,7 +87,8 @@ states. Formalization is expected to require:
   arXiv:1606.00608).
 * Cirac, Pérez-García, Schuch, Verstraete, "Matrix Product States and
   Projected Entangled Pair States: Concepts, Symmetries, and Theorems",
-  arXiv:1606.00608 Section 3.3 Theorem 3.10, Appendix B and Appendix D.2.
+  arXiv:1606.00608 Section 3.3 Theorems `thm:main-MPS` and
+  `thm:charact-MPS`, Appendix B and Appendix D.2.
 -/
 
 open scoped Matrix BigOperators
@@ -109,11 +110,10 @@ the file that consumes it.
 
 **Citation.** This direction is attributed in arXiv:1606.00608 Section 3.3
 (source line 1307) as *"trivial from Theorem [charact-MPS]"*, i.e.,
-from Theorem 3.10 itself. It does **not** depend on S. Beigi (2012);
-it depends only on the product-of-entangled-pairs structural form
-(Appendix B of arXiv:1606.00608). A structural construction for that decomposition
-lives in `TNLean/MPS/RFP/CommutingBridge.lean` as
-`ProductPairBridge`.
+from the structural characterization in Theorem `thm:charact-MPS` (source
+lines 543--555). It does **not** depend on S. Beigi (2012). A structural
+construction for the product-of-entangled-pairs form lives in
+`TNLean/MPS/RFP/CommutingBridge.lean` as `ProductPairBridge`.
 
 See the module docstring for the formalization plan. -/
 axiom rfp_to_nncph_commute {d D : ℕ} [NeZero D]

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -49,7 +49,8 @@ clause from Definition 3.9.
   `Axioms.rfp_to_nncph_commute`.
 * `MPSTensor.rfp_implies_nncph` — construction of the length-two commutation
   equations in the RFP \(\Longrightarrow\) NNCPH direction, using the
-  structural characterization of `thm:charact-MPS`.
+  structural characterization theorem of arXiv:1606.00608, source lines
+  543--555.
 * `MPSTensor.rfp_implies_nncph_ground_state` — the same direction with the
   zero-energy ground-vector equation for the MPS vector included, but without
   the source ground-space spanning assertion.
@@ -338,11 +339,10 @@ commutation equations.
 A normal renormalization fixed-point tensor has commuting length-two parent
 terms.
 
-Per arXiv:1606.00608 Section 3.3 (source line 1307), this direction is
-*"trivial from Theorem [charact-MPS]"*; it therefore does not depend
-on S. Beigi (2012). It is conditioned on the structural characterization
-`thm:charact-MPS` (source lines 543--555), stated here as
-`Axioms.rfp_to_nncph_commute`. -/
+Per arXiv:1606.00608 Section 3.3, the proof passage at source line 1307
+derives this direction from the structural characterization theorem, so it does
+not depend on S. Beigi (2012). It is conditioned on that source theorem
+(source lines 543--555), stated here as `Axioms.rfp_to_nncph_commute`. -/
 theorem rfp_implies_nncph (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)
     (N : ℕ) (hN : 2 ≤ N) :

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -32,6 +32,8 @@ clause from Definition 3.9.
 * `MPSTensor.HasNNCPHGroundSpace B A N` — the fixed-chain nearest-neighbor
   form: length-two commutation, zero energy of \(V^{(N)}(B)\), and the
   ground-space spanning equation.
+* `MPSTensor.HasNNCPHGroundSpaces B A` — the all-chain source condition:
+  `HasNNCPHGroundSpace B A N` for every \(N>2\).
 
 ## Main results
 
@@ -46,7 +48,8 @@ clause from Definition 3.9.
   two-site projector identities, without invoking
   `Axioms.rfp_to_nncph_commute`.
 * `MPSTensor.rfp_implies_nncph` — construction of the length-two commutation
-  equations in the RFP \(\Longrightarrow\) NNCPH direction of Theorem 3.10.
+  equations in the RFP \(\Longrightarrow\) NNCPH direction, using the
+  structural characterization of `thm:charact-MPS`.
 * `MPSTensor.rfp_implies_nncph_ground_state` — the same direction with the
   zero-energy ground-vector equation for the MPS vector included, but without
   the source ground-space spanning assertion.
@@ -143,6 +146,18 @@ def HasNNCPHGroundSpace (B : MPSTensor d D)
   IsNNCPHGroundState B N ∧
     LinearMap.ker (parentHamiltonian B 2 N) = bntMPSVectorSpan A N
 
+/-- All-chain nearest-neighbor commuting parent-Hamiltonian ground-space
+condition.
+
+This is the source quantification in arXiv:1606.00608, Theorem 3.10(iii):
+for every \(N>2\), the nearest-neighbor parent terms commute, the periodic MPS
+vector has zero energy, and the ground space of \(H_2^{(N)}\) is spanned by the
+BNT vectors. It packages only the condition; it does not prove the spanning
+equation for any tensor. -/
+def HasNNCPHGroundSpaces (B : MPSTensor d D)
+    {r : ℕ} {dim : Fin r → ℕ} (A : (j : Fin r) → MPSTensor d (dim j)) : Prop :=
+  ∀ N : ℕ, 2 < N → HasNNCPHGroundSpace B A N
+
 /-- The nearest-neighbor commuting condition is a special case of the commuting
 parent Hamiltonian (length two). -/
 theorem IsNNCPH.isCommutingParentHam {A : MPSTensor d D} {N : ℕ} (h : IsNNCPH A N) :
@@ -213,6 +228,22 @@ theorem HasNNCPHGroundSpace.hasParentHamiltonianGroundSpaceSpanning
     HasParentHamiltonianGroundSpaceSpanning B 2 A := by
   intro N hN
   exact (h N hN).groundSpaceSpanning
+
+/-- The all-chain NNCPH ground-space condition gives the fixed-chain condition. -/
+theorem HasNNCPHGroundSpaces.hasNNCPHGroundSpace {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    {N : ℕ} (h : HasNNCPHGroundSpaces B A) (hN : 2 < N) :
+    HasNNCPHGroundSpace B A N :=
+  h N hN
+
+/-- The all-chain source condition contains the parent-Hamiltonian
+ground-space spanning clause. -/
+theorem HasNNCPHGroundSpaces.hasParentHamiltonianGroundSpaceSpanning
+    {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    (h : HasNNCPHGroundSpaces B A) :
+    HasParentHamiltonianGroundSpaceSpanning B 2 A := by
+  exact HasNNCPHGroundSpace.hasParentHamiltonianGroundSpaceSpanning h
 
 /-- If each BNT vector is killed by the parent Hamiltonian, then their span is
 contained in the parent-Hamiltonian kernel.
@@ -309,8 +340,8 @@ terms.
 
 Per arXiv:1606.00608 Section 3.3 (source line 1307), this direction is
 *"trivial from Theorem [charact-MPS]"*; it therefore does not depend
-on S. Beigi (2012). It is conditioned only on the product-of-entangled-pairs
-structural form (Appendix B), stated here as
+on S. Beigi (2012). It is conditioned on the structural characterization
+`thm:charact-MPS` (source lines 543--555), stated here as
 `Axioms.rfp_to_nncph_commute`. -/
 theorem rfp_implies_nncph (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -105,6 +105,26 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     over all $N>2$.
 \end{definition}
 
+\begin{definition}[All-chain nearest-neighbor commuting parent-Hamiltonian ground-space condition]%
+    \label{def:has_nncph_ground_spaces}
+    \lean{MPSTensor.HasNNCPHGroundSpaces}
+    \leanok
+    \uses{def:has_nncph_ground_space}
+    This is the source quantification in
+    \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}. For every $N>2$, the
+    fixed-chain condition of Definition~\ref{def:has_nncph_ground_space}
+    holds:
+    \[
+        h_i h_j=h_j h_i,\qquad
+        h_iV^{(N)}(B)=0,\qquad
+        \ker H_2^{(N)}(B)
+        =
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
+    \]
+    This is a named condition. It does not prove the ground-space spanning
+    equation for a concrete canonical-form tensor.
+\end{definition}
+
 \begin{remark}[Elementary consequences of the commuting definition]
     \lean{MPSTensor.IsNNCPH.isCommutingParentHam}
     \lean{MPSTensor.IsNNCPHGroundState.isNNCPH}
@@ -115,6 +135,8 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \lean{MPSTensor.HasNNCPHGroundSpace.isFrustrationFree}
     \lean{MPSTensor.HasNNCPHGroundSpace.groundSpaceSpanning}
     \lean{MPSTensor.HasNNCPHGroundSpace.hasParentHamiltonianGroundSpaceSpanning}
+    \lean{MPSTensor.HasNNCPHGroundSpaces.hasNNCPHGroundSpace}
+    \lean{MPSTensor.HasNNCPHGroundSpaces.hasParentHamiltonianGroundSpaceSpanning}
     \lean{MPSTensor.IsCommutingParentHam.symm}
     \lean{MPSTensor.IsCommutingParentHam.ham_comm_localTerm}
     \leanok
@@ -136,6 +158,8 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \]
     and quantifying this condition over all $N>2$ gives the
     nearest-neighbor case of the spanning condition above.
+    This is exactly the condition named in
+    Definition~\ref{def:has_nncph_ground_spaces}.
 \end{remark}
 
 \begin{lemma}[Zero-energy BNT vectors lie in the parent-Hamiltonian kernel]
@@ -186,9 +210,9 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     point, then for every chain length $N \ge 2$ the two-site parent terms
     commute. This theorem records the commutation part of the nearest-neighbor
     source condition, not the ground-space spanning part.
-    This implication is cited here from the product-of-entangled-pairs
-    description in Appendix~B of
-    Theorem~3.10 in~\cite{Cirac2016MPDO_arXiv}.
+    This implication is cited here from the structural characterization theorem
+    for renormalization fixed points in~\cite{Cirac2016MPDO_arXiv}; the source
+    proof says that RFP $\Rightarrow$ NNCPH is immediate from that theorem.
 \end{theorem}
 
 \begin{theorem}[Renormalization fixed points satisfy the NNCPH commutation and zero-energy equations]%

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -83,10 +83,10 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
 - `cpgsv21_block_diagonal_parent_ground_space.tex` records the degenerate
   parent-Hamiltonian block-diagonal boundary-condition theorem behind the
   periodic block decomposition and the BNT ground-space span.
-- `cpsv16_nncph_ground_state_scope.tex` records that the current
-  nearest-neighbor commuting parent Hamiltonian ground-state predicate keeps
-  the zero-energy ground-vector clause of CPSV16 Theorem 3.10(iii), not the
-  full source ground-space spanning condition.
+- `cpsv16_nncph_ground_state_scope.tex` records the separation between the
+  zero-energy ground-vector predicate and the source ground-space spanning
+  predicates for CPSV16 Theorem 3.10(iii). The all-chain condition is now
+  named, but the spanning equation has not been proved for concrete tensors.
 - `cpsv16_parent_commuting_hamiltonian_scope.tex` records that the current
   parent commuting Hamiltonian predicate keeps only the idempotent-product
   consequence of CPSV16 Definition D.2, while the source definition also has

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -77,9 +77,10 @@ zero-energy equation, and the spanning equation
   =
   \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}.
 \end{align}
-The source theorem should use this predicate quantified over \(N>2\). The
-predicate is only a named condition; it does not prove that the spanning
-equation holds for any concrete canonical-form tensor.
+The source theorem should use the all-chain predicate
+\leanid{MPSTensor.HasNNCPHGroundSpaces}, which quantifies this fixed-chain
+condition over \(N>2\). The predicate is only a named condition; it does not
+prove that the spanning equation holds for any concrete canonical-form tensor.
 The easy inclusion in the spanning equation is now recorded: if each component
 vector \(V^{(N)}(A_j)\) is annihilated by the parent Hamiltonian, or more
 strongly by every local term, then


### PR DESCRIPTION
This PR advances the source-faithful formulation of arXiv:1606.00608, Theorem 3.10(iii). It does not prove the full RFP = ZCL = NNCPH equivalence.

Summary:
- adds `MPSTensor.HasNNCPHGroundSpaces`, the all-chain condition saying that `HasNNCPHGroundSpace B A N` holds for every `N > 2`;
- proves the elementary projections from the all-chain condition to the fixed-chain condition and to the nearest-neighbor parent-Hamiltonian spanning predicate;
- adds the corresponding blueprint entry and updates the NNCPH gap note;
- corrects the RFP => NNCPH citation surface: the source proof uses the structural characterization theorem `thm:charact-MPS`, not Theorem 3.10 itself.

Source anchors:
- arXiv:1606.00608, equation `eq:parent`, lines 517--519;
- Definition before `thm:main-MPS`, lines 522--524: parent-Hamiltonian ground-space spanning, commuting condition, and nearest-neighbor specialization;
- `thm:main-MPS`, lines 534--540: the all-chain NNCPH clause;
- `thm:charact-MPS`, lines 543--555, and proof line 1307 for the RFP => NNCPH direction.

Checks:
- `lake env lean TNLean/Axioms/Beigi.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

Refs #2633.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and new definitional predicates only; no change to axiom statements or proof logic beyond citation text.
> 
> **Overview**
> Introduces **`MPSTensor.HasNNCPHGroundSpaces`**, the arXiv:1606.00608 Theorem 3.10(iii) condition that **`HasNNCPHGroundSpace B A N`** holds for every **\(N > 2\)**, with projection lemmas to the fixed-chain predicate and **`HasParentHamiltonianGroundSpaceSpanning`**. The blueprint chapter and **`cpsv16_nncph_ground_state_scope.tex`** / README are updated to document that the all-chain spanning predicate is **named only**—no new proof of the kernel-span equation for concrete tensors.
> 
> **RFP ⇒ NNCPH** documentation and theorem comments now cite the **structural characterization theorem** (source lines 543–555), not “trivial from Theorem 3.10” / Appendix B alone; **`Axioms.rfp_to_nncph_commute`** wording in **`Beigi.lean`** matches that split from Beigi (2012).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd33d84ad5e47273fdd58188c9a454401727394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->