### PR TITLE
doc(parent): record martingale gap ledger boundary

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -34,17 +34,16 @@ variable {d D : ℕ}
 /-- Gap bound from a strict uniform overlapping cyclic-window compression
 coefficient for the MPS parent Hamiltonian.
 
-This is the source-faithful form of the remaining martingale input in
+This is the current formal boundary for applying the martingale input in
 arXiv:2011.12127, Section IV.C (the martingale-2 estimate), with an arbitrary
-compression constant.  It does not
-assert the special coefficient used in
+compression constant. It does not assert the special coefficient used in
 `parentHamiltonianES_gap_bound_of_friedrichs`; instead, it says that any uniform
-bound
+overlapping-window compression bound
 
 \(‖p_i p_j v‖ ≤ η ‖p_i v‖\)
 
-with \(η * 2(L-1) < 1\) yields the positive gap constant
-\(1 - η * 2(L-1)\).  The comparison between this flexible cyclic-window
+with \(2(L-1)\eta < 1\) yields the positive gap constant
+\(1 - 2(L-1)\eta\). The comparison between this flexible cyclic-window
 hypothesis and the cited FNW--Nachtergaele--Kastoryano principal-angle estimates
 is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_overlap_norm_constant

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -83,6 +83,10 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
 - `cpgsv21_block_diagonal_parent_ground_space.tex` records the degenerate
   parent-Hamiltonian block-diagonal boundary-condition theorem behind the
   periodic block decomposition and the BNT ground-space span.
+- `cpgsv21_martingale_overlap.tex` records the spectral-gap martingale
+  comparison: the finite-row cyclic-window reduction is formalized, while the
+  remaining source comparison is the overlapping-window principal-angle, or
+  norm-compression, estimate tracked by issue #952.
 - `cpsv16_nncph_ground_state_scope.tex` records the separation between the
   zero-energy ground-vector predicate and the source ground-space spanning
   predicates for CPSV16 Theorem 3.10(iii). The all-chain condition is now


### PR DESCRIPTION
Summary
- add the martingale-overlap paper-gap note to the paper-gap ledger
- replace the source-faithfulness claim in the flexible gap theorem docstring by the precise current formal boundary
- state the remaining comparison as the overlapping-window principal-angle, or norm-compression, estimate

Validation
- lake build TNLean.MPS.ParentHamiltonian.Martingale.Gap
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- git diff --check origin/main..HEAD

Refs #952.
Refs #190.
Refs #460.