### PR TITLE
doc(parent): name principal-angle compression reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -488,4 +488,36 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
   exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
     A L hL hγpos hγle hηle hOverlapNorm
 
+/-- Finite-row norm-compression form of the martingale argument.
+
+Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.C, lines 2168--2182,
+relates the parent-Hamiltonian gap to the principal angles between overlapping
+local ground spaces, equivalently to a norm-compression estimate for the
+corresponding excitation projections. In the cyclic-window specialization, if
+every overlapping pair satisfies
+\[
+  \|p_i p_j v\| \le \eta \|p_i v\|,
+  \qquad \eta\,2(L-1)<1,
+\]
+then the Euclidean-space parent Hamiltonians have the displayed uniform lower
+bound. The MPS-specific proof of this principal-angle estimate remains separate;
+it is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem parentHamiltonianES_gap_bound_of_principal_angle_compression
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
+    (hηnonneg : 0 ≤ η)
+    (hηlt : η * (((2 * (L - 1) : ℕ) : ℝ)) < 1)
+    (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L i v‖) :
+    0 < 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        (1 - η * (((2 * (L - 1) : ℕ) : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ :=
+  parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
+    A L hL hηnonneg hηlt hOverlapNorm
+
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -784,6 +784,7 @@ principal-angle estimate remains an explicit input.
     \label{lem:parent_hamiltonian_cyclic_overlap_norm_constant_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_principal_angle_compression}
     \leanok
     \uses{lem:parent_hamiltonian_finite_overlap_norm_quadratic,
         lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive,
@@ -806,6 +807,11 @@ principal-angle estimate remains an explicit input.
     \[
         (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
     \]
+    The strict form is also recorded as the principal-angle, or norm-compression,
+    reduction used in the martingale passage of
+    Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}.
+    It does not prove the remaining MPS-specific estimate; it isolates the
+    finite-row martingale argument once that estimate is supplied.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
This PR records the cyclic-window strict compression reduction with a name tied to the martingale passage of Cirac--Perez-Garcia--Schuch--Verstraete, Section IV.C.

Summary:
- adds `MPSTensor.parentHamiltonianES_gap_bound_of_principal_angle_compression` as a direct wrapper around the existing strict norm-compression reduction;
- states in the docstring that the remaining MPS-specific principal-angle estimate is not proved here and is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`;
- adds the new Lean tag to the existing blueprint lemma for the constant-eta cyclic overlap compression bound.

Source anchor:
- `Papers/2011.12127/TN-Review-main.tex`, lines 2168--2182: the martingale method, overlapping pairs, and principal angles between $\ker h_i$ and $\ker h_j$.

Checks:
- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Reduction`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Gap`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main..HEAD`

Refs #952.