### PR TITLE
feat(rfp): add BNT zero-correlation-length predicates

### DIFF
--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.RFP.Defs
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.Correlations
+import TNLean.Spectral.MixedTransfer
 
 /-!
 # Zero correlation length (ZCL) for MPS tensors
@@ -18,13 +19,16 @@ Three conditions are introduced:
 * `IsCID A` — correlations are independent of distance.
 * `IsLocallyOrthogonal A` — the local single-block convention used here; it is
   transfer-map idempotence.
+* `IsBNTLocallyOrthogonal blocks` — the source BNT-level mixed-sector
+  equations.
+* `IsBNTZCL A blocks` — CID together with the BNT-level mixed-sector
+  equations.
 * `IsZCL A` — the conjunction of local orthogonality and CID.
 
 The proved local result identifies this single-block convention with an
-idempotent transfer map (`IsRFP`). The source theorem also has a BNT-level local
-orthogonality condition, namely vanishing mixed transfer maps between distinct
-BNT components. That mixed-sector part is not represented by this single-block
-predicate; see `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
+idempotent transfer map (`IsRFP`). The BNT-family predicate records the
+mixed-sector part of the source definition; the full BNT-level ZCL theorem is
+still tracked in `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
 -/
 
 open scoped Matrix ComplexOrder
@@ -32,6 +36,7 @@ open scoped Matrix ComplexOrder
 namespace MPSTensor
 
 variable {d D : ℕ}
+variable {g : ℕ} {dim : Fin g → ℕ}
 
 /-- Correlations independent of distance (arXiv:1606.00608, Definition 3.3):
 the connected two-point correlation function through the transfer map is
@@ -65,6 +70,43 @@ def IsLocallyOrthogonal (A : MPSTensor d D) : Prop :=
 BNT block. -/
 lemma isLocallyOrthogonal_iff_isRFP (A : MPSTensor d D) :
     IsLocallyOrthogonal A ↔ IsRFP A :=
+  Iff.rfl
+
+/-- BNT-level local orthogonality (arXiv:1606.00608, Definition 3.5):
+for distinct BNT components `j ≠ j'`, the mixed-sector transfer matrix
+`𝔼_{j,j'} = ∑ i, A_j^i ⊗ \overline{A_{j'}^i}` vanishes.
+
+This is the source local-orthogonality condition used in the pure-state ZCL
+theorem. The rectangular mixed transfer operator is the corresponding linear
+map form of the displayed mixed-sector matrix. -/
+def IsBNTLocallyOrthogonal
+    (blocks : (j : Fin g) → MPSTensor d (dim j)) : Prop :=
+  ∀ j j' : Fin g, j ≠ j' → mixedTransferMap₂ (blocks j) (blocks j') = 0
+
+/-- Unfolding of BNT-level local orthogonality into the mixed transfer
+equations. -/
+lemma isBNTLocallyOrthogonal_iff
+    (blocks : (j : Fin g) → MPSTensor d (dim j)) :
+    IsBNTLocallyOrthogonal blocks ↔
+      ∀ j j' : Fin g, j ≠ j' → mixedTransferMap₂ (blocks j) (blocks j') = 0 :=
+  Iff.rfl
+
+/-- BNT-level zero correlation length (arXiv:1606.00608, Definition 3.6):
+the generated family has correlations independent of distance and its BNT
+components satisfy the mixed-sector local-orthogonality equations.
+
+The relation saying that `blocks` are the BNT components of `A` is supplied by
+the surrounding canonical-form data; this predicate records the two conditions
+appearing in the source definition. -/
+def IsBNTZCL (A : MPSTensor d D)
+    (blocks : (j : Fin g) → MPSTensor d (dim j)) : Prop :=
+  IsCID A ∧ IsBNTLocallyOrthogonal blocks
+
+/-- Unfolding of BNT-level zero correlation length into CID and BNT local
+orthogonality. -/
+lemma isBNTZCL_iff (A : MPSTensor d D)
+    (blocks : (j : Fin g) → MPSTensor d (dim j)) :
+    IsBNTZCL A blocks ↔ IsCID A ∧ IsBNTLocallyOrthogonal blocks :=
   Iff.rfl
 
 /-- Zero correlation length in the single-block convention: a tensor has ZCL

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.RFP.Defs
+import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Core.Correlations
 import TNLean.Spectral.MixedTransfer
@@ -21,14 +22,15 @@ Three conditions are introduced:
   transfer-map idempotence.
 * `IsBNTLocallyOrthogonal blocks` — the source BNT-level mixed-sector
   equations.
-* `IsBNTZCL A blocks` — CID together with the BNT-level mixed-sector
-  equations.
+* `IsBNTZCL A blocks` — the family `blocks` is a BNT for `A`, and `A`
+  satisfies CID together with the BNT-level mixed-sector equations.
 * `IsZCL A` — the conjunction of local orthogonality and CID.
 
 The proved local result identifies this single-block convention with an
-idempotent transfer map (`IsRFP`). The BNT-family predicate records the
-mixed-sector part of the source definition; the full BNT-level ZCL theorem is
-still tracked in `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
+idempotent transfer map (`IsRFP`). The BNT-family predicate records the source
+definition with an explicit BNT relation between `A` and `blocks`; the full
+BNT-level ZCL theorem is still tracked in
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
 -/
 
 open scoped Matrix ComplexOrder
@@ -92,21 +94,21 @@ lemma isBNTLocallyOrthogonal_iff
   Iff.rfl
 
 /-- BNT-level zero correlation length (arXiv:1606.00608, Definition 3.6):
-the generated family has correlations independent of distance and its BNT
-components satisfy the mixed-sector local-orthogonality equations.
-
-The relation saying that `blocks` are the BNT components of `A` is supplied by
-the surrounding canonical-form data; this predicate records the two conditions
-appearing in the source definition. -/
+`blocks` is a basis of normal tensors for `A`, the generated family has
+correlations independent of distance, and its BNT components satisfy the
+mixed-sector local-orthogonality equations. -/
 def IsBNTZCL (A : MPSTensor d D)
     (blocks : (j : Fin g) → MPSTensor d (dim j)) : Prop :=
-  IsCID A ∧ IsBNTLocallyOrthogonal blocks
+  IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
+    IsCID A ∧ IsBNTLocallyOrthogonal blocks
 
-/-- Unfolding of BNT-level zero correlation length into CID and BNT local
-orthogonality. -/
+/-- Unfolding of BNT-level zero correlation length into the BNT relation, CID,
+and BNT local orthogonality. -/
 lemma isBNTZCL_iff (A : MPSTensor d D)
     (blocks : (j : Fin g) → MPSTensor d (dim j)) :
-    IsBNTZCL A blocks ↔ IsCID A ∧ IsBNTLocallyOrthogonal blocks :=
+    IsBNTZCL A blocks ↔
+      IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
+        IsCID A ∧ IsBNTLocallyOrthogonal blocks :=
   Iff.rfl
 
 /-- Zero correlation length in the single-block convention: a tensor has ZCL

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -363,15 +363,16 @@ and rates for the single-tensor transfer map $\E_A$.
 \begin{definition}[BNT zero correlation length]\label{def:is_bnt_zcl}
     \lean{MPSTensor.IsBNTZCL}
     \leanok
-    \uses{def:is_cid, def:is_bnt_locally_orthogonal}
-    If $A$ is in canonical form with BNT components $(A_j)_j$, the BNT
-    zero-correlation-length condition is
+    \uses{def:bnt_cpsv, def:is_cid, def:is_bnt_locally_orthogonal}
+    Let $(A_j)_j$ be a basis of normal tensors for $A$. The BNT
+    zero-correlation-length condition is that
     \[
         \operatorname{CID}(A)
-        \qquad\text{and}\qquad
-        \E_{j,j'}=0
     \]
-    for every pair of distinct BNT components.
+    and, for every pair of distinct BNT components,
+    \[
+        \E_{j,j'}=0.
+    \]
     This is \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
 \end{definition}
 

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -338,12 +338,41 @@ and rates for the single-tensor transfer map $\E_A$.
         \E_A^2=\E_A .
     \]
     The source local-orthogonality condition for a BNT family is instead the
-    collection of mixed-sector equations
+    collection of mixed-sector equations for distinct components,
     \[
-        \E_{j,j'}=0 \qquad (j\ne j').
+        \E_{j,j'}=0.
     \]
-    Thus this definition records the one-block idempotence convention, not the
-    full BNT-level condition of \cite[Definition~3.5]{Cirac2016MPDO_arXiv}.
+    Thus this definition records the one-block idempotence convention.
+\end{definition}
+
+\begin{definition}[BNT local orthogonality]%
+    \label{def:is_bnt_locally_orthogonal}
+    \lean{MPSTensor.IsBNTLocallyOrthogonal}
+    \leanok
+    \uses{def:mixed_transfer_rect}
+    Let $(A_j)_j$ be the BNT components of a tensor in canonical form. The
+    family is \emph{locally orthogonal} when, for every pair of distinct
+    components,
+    \[
+        \E_{j,j'}=\sum_i A_j^i\otimes \overline{A_{j'}^i}=0.
+    \]
+    This is the mixed-sector condition of
+    \cite[Definition~3.5]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[BNT zero correlation length]\label{def:is_bnt_zcl}
+    \lean{MPSTensor.IsBNTZCL}
+    \leanok
+    \uses{def:is_cid, def:is_bnt_locally_orthogonal}
+    If $A$ is in canonical form with BNT components $(A_j)_j$, the BNT
+    zero-correlation-length condition is
+    \[
+        \operatorname{CID}(A)
+        \qquad\text{and}\qquad
+        \E_{j,j'}=0
+    \]
+    for every pair of distinct BNT components.
+    This is \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[RFP normal tensor is injective]\label{thm:rfp_nt_injective}
@@ -566,7 +595,7 @@ and rates for the single-tensor transfer map $\E_A$.
 \begin{definition}[Zero correlation length]\label{def:is_zcl}
     \lean{MPSTensor.IsZCL}
     \leanok
-    \uses{def:is_locally_orthogonal, def:is_cid}
+    \uses{def:is_locally_orthogonal, def:is_bnt_zcl, def:is_cid}
     In the single-block convention, an MPS tensor has \emph{zero correlation
         length} when
     \[
@@ -574,8 +603,8 @@ and rates for the single-tensor transfer map $\E_A$.
         \qquad\text{and}\qquad
         \operatorname{CID}(A)
     \]
-    both hold. The source definition combines CID with BNT-level local
-    orthogonality, namely the equations $\E_{j,j'}=0$ for $j\ne j'$.
+    both hold. The source definition is the BNT condition in
+    Definition~\ref{def:is_bnt_zcl}.
 \end{definition}
 
 \begin{theorem}[CID implies RFP]\label{thm:isCID_implies_isRFP}
@@ -606,8 +635,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \]
     This is the idempotence/CID part of
     \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}. The full source theorem for
-    canonical-form tensors also includes the BNT-level local-orthogonality
-    equations $\E_{j,j'}=0$ for $j\ne j'$.
+    canonical-form tensors also uses Definition~\ref{def:is_bnt_zcl}.
 \end{theorem}
 \begin{proof}\leanok
     The forward direction extracts the idempotence hypothesis. The reverse uses

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -82,13 +82,14 @@ direction of that displayed equivalence is immediate because the left-hand side
 already contains $\mathbb E_A^2=\mathbb E_A$.
 
 This is a useful local statement, but it is not the source theorem
-\path{TheoremZCLPure}: the source theorem also contains the mixed-sector
-local-orthogonality equations (LO).
+\path{TheoremZCLPure}: the source theorem uses the BNT-family predicate
+\leanid{MPSTensor.IsBNTZCL}, whose local-orthogonality part is the
+mixed-sector equations (LO).
 
 \section{Elimination plan}
 
-A source-faithful formalization of the pure theorem should introduce a
-BNT-family version of local orthogonality carrying the equations
+The formalization now has a BNT-family version of local orthogonality carrying
+the equations
 \[
   \mathbb E_{j,j'}=0 \qquad (j\ne j'),
 \]
@@ -99,7 +100,7 @@ and a BNT-family ZCL predicate
   \mathrm{CID}(A)\wedge
   \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr).
 \]
-The target theorem for tensors in canonical form is then
+The remaining target theorem for tensors in canonical form is then
 \[
   \mathrm{ZCL}_{\mathrm{BNT}}(A)
   \Longleftrightarrow
@@ -107,12 +108,11 @@ The target theorem for tensors in canonical form is then
 \]
 The existing single-block theorem supplies only the CID consequence of
 idempotence and should remain marked as a scope restriction until the
-mixed-sector equations are part of the statement.\footnote{Tracked by
+canonical-form theorem is stated with the BNT predicate.\footnote{Tracked by
 \ghissue{2597}.}
 
 The present theorem is therefore a scope restriction: it records the one-block
-idempotence/CID consequence, while the mixed-sector local-orthogonality equations
-remain open.
+idempotence/CID consequence, while the BNT-level equivalence remains open.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Summary
- add the BNT-level local-orthogonality predicate from arXiv:1606.00608, Definition 3.5, as the mixed-sector equations E_{j,j'}=0 for distinct BNT components
- add the BNT zero-correlation-length predicate as CID together with that local-orthogonality condition
- update the correlations blueprint and the pure-ZCL paper-gap note so the remaining gap is the canonical-form equivalence theorem, not the missing predicate

Source anchors
- Papers/1606.00608/MPDO-22-12-17-2.tex:467--479: local orthogonality and ZCL definitions
- Papers/1606.00608/MPDO-22-12-17-2.tex:500--503: pure-state ZCL characterization
- Papers/1606.00608/MPDO-22-12-17-2.tex:1248--1268: proof reduction to the mixed-sector equations

Validation
- lake build TNLean.MPS.RFP.ZeroCorrelationLength
- lake build TNLean
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- cd blueprint && leanblueprint checkdecls
- git diff --check

Notes
- The full theorem `IsBNTZCL A blocks ↔ E_A^2 = E_A` for canonical-form tensors is not proved here.

Refs #2597.