### PR TITLE
feat(periodic): normalize normal-canonical phases

### DIFF
--- a/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
+++ b/TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Periodic.Defs
+import TNLean.MPS.SharedInfra.Scaling
 import TNLean.PiAlgebra.CanonicalFormSepAux
 
 /-!
@@ -16,6 +17,20 @@ namespace MPSTensor
 
 variable {d r : ℕ} {dim : Fin r → ℕ}
 variable {μ : Fin r → ℂ} {blocks : (k : Fin r) → MPSTensor d (dim k)}
+
+/-- Replace each nonzero complex normal-canonical weight by its positive real
+modulus, as in the irreducible-form convention of arXiv:1708.00029, lines
+252--261. -/
+noncomputable def positiveRealWeights (μ : Fin r → ℂ) : Fin r → ℂ :=
+  fun k => (‖μ k‖ : ℂ)
+
+/-- Absorb the phase of each nonzero normal-canonical weight into its block.
+With weights `positiveRealWeights μ`, these blocks generate the same MPV family
+as the original weighted block tensor. -/
+noncomputable def phaseNormalizedBlocks
+    (μ : Fin r → ℂ) (blocks : (k : Fin r) → MPSTensor d (dim k)) :
+    (k : Fin r) → MPSTensor d (dim k) :=
+  fun k i => (μ k / (‖μ k‖ : ℂ)) • blocks k i
 
 /-- A normal canonical block family with positive real weights is an irreducible-form
 decomposition whose block periods are all equal to `1`.
@@ -52,6 +67,84 @@ theorem toIsIrreducibleFormOfWeightPos_period_eq_one
     ∀ k : Fin r,
       (toIsIrreducibleFormOfWeightPos
         (d := d) (μ := μ) (blocks := blocks) hNCF hμpos).period k = 1 := by
+  intro k
+  rfl
+
+/-- Phase normalization does not change the MPV family represented by the
+weighted block tensor.  The identity is
+\[
+  \mu_k^N V^{(N)}(A_k)
+    = \|\mu_k\|^N V^{(N)}((\mu_k/\|\mu_k\|)A_k)
+\]
+for each block contribution. -/
+theorem sameMPV₂_toTensorFromBlocks_phaseNormalized
+    (hμ : ∀ k, μ k ≠ 0) :
+    SameMPV₂
+      (toTensorFromBlocks (d := d) (μ := μ) blocks)
+      (toTensorFromBlocks (d := d) (μ := positiveRealWeights μ)
+        (phaseNormalizedBlocks μ blocks)) := by
+  intro N σ
+  rw [mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  simp only [positiveRealWeights]
+  change μ k ^ N • (blocks k).mpv σ =
+    (↑‖μ k‖ : ℂ) ^ N •
+      mpv (fun i => (μ k / (‖μ k‖ : ℂ)) • blocks k i) σ
+  rw [mpv_smul]
+  have hnorm_ne : ((‖μ k‖ : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast norm_ne_zero_iff.mpr (hμ k)
+  have hphase : (‖μ k‖ : ℂ) * (μ k / (‖μ k‖ : ℂ)) = μ k := by
+    field_simp [hnorm_ne]
+  let t := mpv (blocks k) σ
+  change μ k ^ N * t =
+    (↑‖μ k‖ : ℂ) ^ N * ((μ k / (‖μ k‖ : ℂ)) ^ N * t)
+  calc
+    μ k ^ N * t =
+        ((↑‖μ k‖ : ℂ) * (μ k / (‖μ k‖ : ℂ))) ^ N * t := by
+      rw [hphase]
+    _ = (↑‖μ k‖ : ℂ) ^ N * ((μ k / (‖μ k‖ : ℂ)) ^ N * t) := by
+      rw [mul_pow, mul_assoc]
+
+/-- A normal canonical block family gives an irreducible-form witness after
+absorbing each block-weight phase into the corresponding block.
+
+Source context: arXiv:1708.00029, lines 252--271. The paper writes the
+irreducible-form weights as positive real numbers `μ_j > 0`. If the same
+decomposition is first written with nonzero complex coefficients, replacing
+`μ_j` by `‖μ_j‖` and `A_j` by `(μ_j / ‖μ_j‖) A_j` gives the paper's convention
+without changing the represented MPV family. -/
+noncomputable def toIsIrreducibleFormOfPhaseNormalized
+    (hNCF : IsNormalCanonicalForm (d := d) μ blocks) :
+    IsIrreducibleForm (toTensorFromBlocks (d := d) (μ := μ) blocks) where
+  r := r
+  dim := dim
+  blocks := phaseNormalizedBlocks μ blocks
+  μ := positiveRealWeights μ
+  period := fun _ => 1
+  periodic := by
+    intro k
+    have hPeriod : IsPeriodic 1 (blocks k) := by
+      rw [IsPeriodic.one_iff_primitive]
+      exact ⟨hNCF.block_irreducible k, hNCF.leftCanonical k, hNCF.block_primitive k⟩
+    simpa [phaseNormalizedBlocks] using
+      isPeriodic_smul_of_norm_one
+        (phase_norm_one (hNCF.mu_ne_zero k)) (blocks k) hPeriod
+  weight_pos := by
+    intro k
+    constructor
+    · simpa [positiveRealWeights] using norm_pos_iff.mpr (hNCF.mu_ne_zero k)
+    · simp [positiveRealWeights]
+  sameMPV := sameMPV₂_toTensorFromBlocks_phaseNormalized hNCF.mu_ne_zero
+
+/-- In the irreducible-form witness obtained by phase-normalizing a normal
+canonical block family, every block period is `1`.
+
+Source context: arXiv:1708.00029, lines 258--271. -/
+theorem toIsIrreducibleFormOfPhaseNormalized_period_eq_one
+    (hNCF : IsNormalCanonicalForm (d := d) μ blocks) :
+    ∀ k : Fin r,
+      (toIsIrreducibleFormOfPhaseNormalized
+        (d := d) (μ := μ) (blocks := blocks) hNCF).period k = 1 := by
   intro k
   rfl
 

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -50,25 +50,18 @@ $p$-divisibility of the transfer map.
     which requires the stronger condition that every block is $1$-periodic.
 \end{definition}
 
-\begin{remark}[Positive-weight normal canonical form gives irreducible form]
+\begin{remark}[Normal canonical form gives irreducible form]
     \label{rem:irr_form_vs_ncf}
-\lean{MPSTensor.toIsIrreducibleFormOfWeightPos,
-    MPSTensor.toIsIrreducibleFormOfWeightPos_period_eq_one}
+\lean{MPSTensor.toIsIrreducibleFormOfPhaseNormalized,
+    MPSTensor.toIsIrreducibleFormOfPhaseNormalized_period_eq_one}
 \leanok
-    A normal canonical block family whose weights satisfy the positive real
-    convention $\mu_j>0$ assembles to a tensor in irreducible form, and the
-    corresponding irreducible-form witness has all periods equal to~$1$.
-    This is the period-one part of the statement in
+    Let $A^i=\bigoplus_j \mu_j A_j^i$ be a normal canonical block family with
+    nonzero complex weights. Replacing $\mu_j$ by $|\mu_j|$ and $A_j$ by
+    $(\mu_j/|\mu_j|)A_j$ gives the positive-weight irreducible form convention
+    and does not change the MPV family. The corresponding irreducible-form
+    witness has all periods equal to~$1$. This is the period-one part of the statement in
     \cite[Section~II]{DeLasCuevas2017Irreducible} that normal tensors are
     periodic tensors with period~$1$.
-
-    The positivity of the weights is part of the irreducible-form convention.
-    If a canonical-form decomposition is written with arbitrary nonzero complex
-    coefficients, one must first normalize their phases before applying this
-    implication.
-    % Maintainer note: the positive-real hypothesis is explicit because the
-    % local normal-canonical predicate only assumes nonzero complex weights; see
-    % docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex.
 \end{remark}
 
 \begin{remark}[Irreducible form allows higher periods]

--- a/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
+++ b/docs/paper-gaps/1708_normal_canonical_irreducible_form_weights.tex
@@ -6,7 +6,7 @@
 
 \input{command}
 
-\title{Positive Weights in the Normal-Canonical Implication to Irreducible Form}
+\title{Phase-Normalized Weights in the Normal-Canonical Implication to Irreducible Form}
 \author{}
 \date{\today}
 
@@ -38,22 +38,24 @@ The paper introduces a minimal non-repeated basis of periodic tensors later in
 Section~II. That basis condition is separate from the irreducible-form
 definition considered here.
 
-Consequently the available formal construction assumes the paper's
-positive-real convention and builds an irreducible-form witness whose block
-periods are all \(1\).\footnote{Formal declarations:
-\leanid{MPSTensor.toIsIrreducibleFormOfWeightPos} and
-\leanid{MPSTensor.toIsIrreducibleFormOfWeightPos_period_eq_one} in
+The formalization now proves the phase-normalized construction.  From a normal
+canonical block family with nonzero complex weights \(\mu_j\), it replaces
+\(\mu_j\) by \(|\mu_j|\) and \(A_j\) by \((\mu_j/|\mu_j|)A_j\).  The assembled
+tensor has the same matrix-product-vector family, the irreducible-form weights
+are positive real numbers, and all periods are \(1\).\footnote{Formal
+declarations:
+\leanid{MPSTensor.toIsIrreducibleFormOfPhaseNormalized} and
+\leanid{MPSTensor.toIsIrreducibleFormOfPhaseNormalized_period_eq_one} in
 \doclink{TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean}.}
 
 \section{Conclusion}
 
-This is a scope restriction of the current formal statement, not a mathematical
-disagreement with the paper.  The paper's irreducible-form convention already
-uses positive weights.  To remove the extra positivity hypothesis from applying
-the implication to the local normal-canonical predicate, one must either realign
-that predicate to store the same positive-weight convention, or prove and
-formalize the phase-normalization step which replaces nonzero complex weights by
-positive ones without changing the represented matrix-product-vector family.
+This note is now a record of the resolved discrepancy.  The paper's
+irreducible-form convention uses positive weights, and the formalization
+supplies the phase-normalization step needed to pass from the local
+normal-canonical predicate, whose weights are nonzero complex numbers, to that
+positive-weight convention without changing the represented
+matrix-product-vector family.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

Closes #2277.

The periodic MPS paper writes the irreducible form with positive weights: `Papers/1708.00029/main.tex:252-271` defines
\[
A^i = \bigoplus_j \mu_j A_j^i, \qquad \mu_j > 0,
\]
and notes that normal tensors are precisely the period-one case. The local normal-canonical predicate allowed nonzero complex weights, so the previous bridge to irreducible form still required an explicit positive-real hypothesis.

### Description

This PR formalizes the phase normalization implicit in the source convention. For a normal canonical block family with nonzero complex weights, it replaces each weight by `‖μ_j‖` and each block by `(μ_j / ‖μ_j‖) A_j`. The assembled tensor has the same MPV family, and the resulting irreducible-form witness has all periods equal to `1`.

Main new declarations:

- `MPSTensor.positiveRealWeights`
- `MPSTensor.phaseNormalizedBlocks`
- `MPSTensor.sameMPV₂_toTensorFromBlocks_phaseNormalized`
- `MPSTensor.toIsIrreducibleFormOfPhaseNormalized`
- `MPSTensor.toIsIrreducibleFormOfPhaseNormalized_period_eq_one`

The blueprint remark `rem:irr_form_vs_ncf` is updated to point to the phase-normalized statement, and the paper-gap note is rewritten as a resolved discrepancy record.

### Testing

- `lake build TNLean.MPS.Periodic.NormalCanonicalPeriodOne`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/Periodic/NormalCanonicalPeriodOne.lean`