### PR TITLE
feat(peps): surface injective chain FT

### DIFF
--- a/TNLean/MPS/Chain/Defs.lean
+++ b/TNLean/MPS/Chain/Defs.lean
@@ -49,6 +49,17 @@ def cyclicSucc : Fin n → Fin n
 @[simp] lemma cyclicSucc_val (k : Fin (n + 1)) :
     (cyclicSucc k).val = (k.val + 1) % (n + 1) := rfl
 
+/-- The cyclic successor is addition by one on `Fin n`. -/
+@[simp] lemma cyclicSucc_eq_add_one [NeZero n] (k : Fin n) :
+    cyclicSucc k = k + 1 := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
+  apply Fin.ext
+  rw [cyclicSucc_val, Fin.val_add, Fin.val_one']
+  calc
+    (↑k + 1) % (m + 1)
+        = (↑k % (m + 1) + 1 % (m + 1)) % (m + 1) := Nat.add_mod _ _ _
+    _ = (↑k + 1 % (m + 1)) % (m + 1) := by rw [Nat.mod_eq_of_lt k.isLt]
+
 /-- Cyclic gauge equivalence on a periodic chain:
 `Bₖ^σ = Zₖ Aₖ^σ Zₖ₊₁⁻¹`, where the successor is taken modulo `n`. -/
 def GaugeEquiv (A B : MPSChainTensor d D n) : Prop :=

--- a/TNLean/PEPS/CycleMPSChainArc.lean
+++ b/TNLean/PEPS/CycleMPSChainArc.lean
@@ -162,6 +162,29 @@ theorem isWindowInjective_const [NeZero n] {B : MPSTensor d D} {L : ℕ}
   rw [hcast]
   exact hB
 
+/-- Sitewise algebraic injectivity is window injectivity at length one.
+
+This is the `L = 1` specialization used for the injective closed-chain
+Fundamental Theorem in arXiv:1804.04964, Theorem `thm:inj_MPS`
+(lines 688--725). -/
+theorem isWindowInjective_one_of_isInjective [NeZero n] {A : MPSChainTensor d D n}
+    (hA : IsInjective A) : IsWindowInjective A 1 := by
+  intro s
+  have hrange : (Set.range fun a : Fin 1 → Fin d => arcEval A s (List.ofFn a)) =
+      Set.range (A (s : Fin n)) := by
+    ext M
+    constructor
+    · rintro ⟨a, hM⟩
+      refine ⟨a 0, ?_⟩
+      simpa only [List.ofFn_succ, List.ofFn_zero, arcEval_cons, arcEval_nil,
+        Matrix.mul_one] using hM
+    · rintro ⟨i, hM⟩
+      refine ⟨fun _ => i, ?_⟩
+      simpa only [List.ofFn_succ, List.ofFn_zero, arcEval_cons, arcEval_nil,
+        Matrix.mul_one] using hM
+  rw [hrange]
+  exact hA (s : Fin n)
+
 /-- Left multiplication by the letter at the preceding site maps the full
 arc span one site downstream into the arc span one letter longer. -/
 private theorem mul_left_letter_mem_arc_span [NeZero n]

--- a/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
@@ -1,3 +1,4 @@
+import TNLean.Algebra.ScalarCommutant
 import TNLean.PEPS.CycleMPSChainOverlapInsertion
 
 /-!
@@ -460,6 +461,24 @@ open MPSChainTensor
 
 /-! ### The site-dependent closed-chain corollary -/
 
+private lemma fin_cyclic_induction {m : ℕ} [NeZero m] {P : Fin m → Prop}
+    (h0 : P 0) (hstep : ∀ i : Fin m, P i → P (i + 1)) (i : Fin m) : P i := by
+  induction hi : i.val generalizing i with
+  | zero => obtain rfl : i = 0 := Fin.ext (by simpa using hi); exact h0
+  | succ k ih =>
+      have hk : k < m := by have := i.isLt; omega
+      have e : (⟨k, hk⟩ : Fin m) + 1 = i := by
+        apply Fin.ext
+        have hmod_one : 1 < m := by omega
+        have hone : (1 : Fin m).val = 1 := by
+          have : (1 : Fin m).val = 1 % m := Fin.val_one' m
+          rw [this]
+          exact Nat.mod_eq_of_lt hmod_one
+        rw [Fin.val_add, Fin.val_mk, hone, hi]
+        exact Nat.mod_eq_of_lt (by have := i.isLt; omega)
+      rw [← e]
+      exact hstep _ (ih ⟨k, hk⟩ rfl)
+
 /-- **Fundamental Theorem for site-dependent normal closed chains at
 `n ≥ 2L + 1`** (arXiv:1804.04964, Section `normal_alt`, lines 1915--2295 of
 `Papers/1804.04964/paper_normal.tex`: the closed-chain corollary after
@@ -689,6 +708,149 @@ theorem fundamentalTheorem_normalMPSChain_of_overlap {n L d D : ℕ} [NeZero n]
   have hr := hrel v.val i
   rw [Fin.cast_val_eq_self] at hr
   exact hr
+
+/-- **Fundamental Theorem for injective closed MPS chains** (arXiv:1804.04964,
+Theorem `thm:inj_MPS`, lines 688--725), in the uniform physical- and
+bond-dimension setting.
+
+Two site-dependent injective MPS chains on `n ≥ 3` sites which generate the
+same closed-chain state are cyclically gauge equivalent.  This is the
+`L = 1` specialization of
+`TNLean.PEPS.fundamentalTheorem_normalMPSChain_of_overlap`; at length one,
+window injectivity is exactly sitewise algebraic injectivity. -/
+theorem fundamentalTheorem_injectiveMPSChain_of_sameState {n d D : ℕ} [NeZero n]
+    (hn : 3 ≤ n) (A B : MPSChainTensor d D n) (hA : IsInjective A)
+    (hB : IsInjective B) (hAB : SameState A B) : GaugeEquiv A B :=
+  fundamentalTheorem_normalMPSChain_of_overlap (hL := Nat.zero_lt_one)
+    (hn := by simpa using hn) A B
+    (isWindowInjective_one_of_isInjective hA)
+    (isWindowInjective_one_of_isInjective hB) hAB
+
+/-- **Uniqueness of the injective closed-chain gauge**, the uniqueness clause
+of arXiv:1804.04964, Theorem `thm:inj_MPS`, line 724.
+
+If two cyclic gauge families relate the same injective chain `A` to `B`, then
+they differ by one nonzero scalar, independent of the bond. -/
+theorem fundamentalTheorem_injectiveMPSChain_gauge_unique {n d D : ℕ} [NeZero n]
+    (A B : MPSChainTensor d D n) (hA : IsInjective A)
+    (Z Z' : Fin n → GL (Fin D) ℂ)
+    (hZ : ∀ (k : Fin n) (i : Fin d),
+      B k i = (Z k : Matrix (Fin D) (Fin D) ℂ) * A k i *
+        (((Z (cyclicSucc k))⁻¹ : GL (Fin D) ℂ) :
+          Matrix (Fin D) (Fin D) ℂ))
+    (hZ' : ∀ (k : Fin n) (i : Fin d),
+      B k i = (Z' k : Matrix (Fin D) (Fin D) ℂ) * A k i *
+        (((Z' (cyclicSucc k))⁻¹ : GL (Fin D) ℂ) :
+          Matrix (Fin D) (Fin D) ℂ)) :
+    ∃ c : ℂˣ, ∀ k : Fin n, (Z' k : Matrix (Fin D) (Fin D) ℂ) =
+      (c : ℂ) • (Z k : Matrix (Fin D) (Fin D) ℂ) := by
+  classical
+  cases D with
+  | zero =>
+      refine ⟨1, fun k => ?_⟩
+      exact Subsingleton.elim _ _
+  | succ D' =>
+      let C : Fin n → GL (Fin (Nat.succ D')) ℂ := fun k => (Z k)⁻¹ * Z' k
+      have hinter : ∀ (k : Fin n) (i : Fin d),
+          (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A k i =
+            A k i * (C (k + 1) :
+              Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+        intro k i
+        have hEq :
+            (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A k i *
+                (((Z (cyclicSucc k))⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
+                  Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)
+              =
+            (Z' k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A k i *
+                (((Z' (cyclicSucc k))⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
+                  Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+          rw [← hZ k i, hZ' k i]
+        have hcong := congrArg
+          (fun M : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ =>
+            (((Z k)⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
+                Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * M *
+              (Z' (k + 1) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)) hEq
+        simpa [C, Matrix.mul_assoc] using hcong.symm
+      have hmul_all : ∀ (k : Fin n) (M : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ),
+          M ∈ Submodule.span ℂ (Set.range (A k)) →
+            (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * M =
+              M * (C (k + 1) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+        intro k M hM
+        induction hM using Submodule.span_induction with
+        | mem M hM =>
+            rcases hM with ⟨i, rfl⟩
+            exact hinter k i
+        | zero => simp
+        | add X Y _ _ hX hY =>
+            rw [Matrix.mul_add, Matrix.add_mul, hX, hY]
+        | smul a X _ hX =>
+            rw [Matrix.mul_smul, Matrix.smul_mul, hX]
+      have hCstep : ∀ k : Fin n,
+          (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) =
+            (C (k + 1) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+        intro k
+        have hmem : (1 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) ∈
+            Submodule.span ℂ (Set.range (A k)) := by
+          rw [hA k]
+          exact Submodule.mem_top
+        simpa using hmul_all k 1 hmem
+      have hC_eq_zero : ∀ k : Fin n,
+          (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) =
+            (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) :=
+        fin_cyclic_induction rfl (fun k hk => by
+          calc
+            (C (k + 1) : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)
+                = (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) :=
+                  (hCstep k).symm
+            _ = (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := hk)
+      have hcommA0 : ∀ i : Fin d,
+          (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) * A 0 i =
+            A 0 i * (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+        intro i
+        have h := hinter 0 i
+        rw [hC_eq_zero (0 + 1)] at h
+        exact h
+      have hscalar := Matrix.isScalar_of_commute_span_eq_top
+        (Z := (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ))
+        (MPSTensor.IsInjective.span_eq_top (hA 0)) (fun M hM => by
+          rcases hM with ⟨i, rfl⟩
+          exact hcommA0 i)
+      rcases hscalar with ⟨c, hc⟩
+      have hc_ne : c ≠ 0 := by
+        intro hc0
+        have hC0 : (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) = 0 := by
+          rw [hc]
+          ext i j
+          simp [hc0]
+        have hmul :
+            (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
+                (((C 0)⁻¹ : GL (Fin (Nat.succ D')) ℂ) :
+                  Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) = 1 := by
+          simp
+        rw [hC0, Matrix.zero_mul] at hmul
+        exact
+          (one_ne_zero :
+            (1 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) ≠ 0) hmul.symm
+      refine ⟨Units.mk0 c hc_ne, fun k => ?_⟩
+      calc
+        (Z' k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)
+            = (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
+                (C k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+              simp [C]
+        _ = (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
+              (C 0 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+              rw [hC_eq_zero k]
+        _ = (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
+              Matrix.scalar (Fin (Nat.succ D')) c := by
+              rw [hc]
+        _ = (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) *
+              (c • (1 : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ)) := by
+              rw [Matrix.smul_one_eq_diagonal, Matrix.scalar_apply]
+        _ = c • (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+              rw [Matrix.mul_smul, Matrix.mul_one]
+        _ = ((Units.mk0 c hc_ne : ℂˣ) : ℂ) •
+              (Z k : Matrix (Fin (Nat.succ D')) (Fin (Nat.succ D')) ℂ) := by
+              simp
 
 end PEPS
 end TNLean

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1007,6 +1007,21 @@ recorded in the route note
     is injective, for a general window length $L$.
 \end{definition}
 
+\begin{lemma}[Injectivity is window injectivity at length one]%
+    \label{lem:isWindowInjective_one_of_isInjective}
+    \lean{MPSChainTensor.isWindowInjective_one_of_isInjective}
+    \leanok
+    \uses{def:chain_arc_window_injective, def:injective}
+    If every tensor in a closed chain is injective, then the chain is
+    window injective at length \(1\).  Indeed, the length-one arc products
+    at site \(s\) are precisely the matrices of the tensor at site \(s\).
+\end{lemma}
+\begin{proof}\leanok
+    The family of length-one words is identified with the physical alphabet.
+    Under this identification the length-one arc product is exactly the
+    corresponding local matrix, so the two spanning conditions coincide.
+\end{proof}
+
 \begin{lemma}[Arc spanning from window injectivity]%
     \label{lem:isWindowInjective_arc_span}
     \lean{MPSChainTensor.IsWindowInjective.arc_span}
@@ -1225,6 +1240,68 @@ recorded in the route note
     against a nonzero arc product forces $\prod_v \mu_v = 1$, and
     dressing the gauges with the partial products of the scalars absorbs
     them, including across the seam.
+\end{proof}
+
+\begin{corollary}[Fundamental Theorem for injective closed MPS chains]%
+    \label{cor:fundamentalTheorem_injectiveMPSChain_of_sameState}
+    \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_of_sameState}
+    \leanok
+    \uses{cor:fundamentalTheorem_normalMPSChain_of_overlap,
+        lem:isWindowInjective_one_of_isInjective}
+    Let \(A_0,\ldots,A_{n-1}\) and \(B_0,\ldots,B_{n-1}\) be two
+    site-dependent closed chains on \(n \ge 3\) sites, with common physical
+    dimension and common bond dimension.  Suppose every local tensor in
+    both chains is injective and the two closed-chain states are equal.
+    Then there are invertible matrices \(Z_0,\ldots,Z_{n-1}\), one per
+    bond of the closed chain, such that
+    \[
+        B_v^i = Z_v\, A_v^i\, Z_{v+1}^{-1}
+    \]
+    for every site \(v\) and every physical index \(i\), with indices read
+    cyclically.  This is the \(L=1\), uniform-dimension instance of
+    \cite[Theorem~\textup{thm:inj\_MPS}, lines~688--725]{Molnar2018NormalPEPS}.
+\end{corollary}
+\begin{proof}\leanok
+    \uses{cor:fundamentalTheorem_normalMPSChain_of_overlap,
+        lem:isWindowInjective_one_of_isInjective}
+    Apply Corollary~\ref{cor:fundamentalTheorem_normalMPSChain_of_overlap}
+    with \(L=1\).  The size condition becomes \(n \ge 3\), and
+    Lemma~\ref{lem:isWindowInjective_one_of_isInjective} converts the
+    sitewise injectivity hypotheses into the required window-injectivity
+    hypotheses.
+\end{proof}
+
+\begin{theorem}[Uniqueness of the injective closed-chain gauge]%
+    \label{thm:fundamentalTheorem_injectiveMPSChain_gauge_unique}
+    \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_gauge_unique}
+    \leanok
+    \uses{cor:fundamentalTheorem_injectiveMPSChain_of_sameState,
+        def:chain_arc_window_injective}
+    Under the hypotheses of
+    Corollary~\ref{cor:fundamentalTheorem_injectiveMPSChain_of_sameState},
+    suppose \(Z_v\) and \(Z'_v\) are two families of invertible matrices
+    satisfying
+    \[
+        B_v^i = Z_v\, A_v^i\, Z_{v+1}^{-1}
+        \quad\text{and}\quad
+        B_v^i = Z'_v\, A_v^i\, (Z'_{v+1})^{-1}
+    \]
+    for every \(v,i\).  Then there is a single nonzero scalar \(c\) such
+    that \(Z'_v = c Z_v\) for every bond \(v\).  This is the uniqueness
+    clause in \cite[line~724]{Molnar2018NormalPEPS}.
+\end{theorem}
+\begin{proof}\leanok
+    For each bond put \(C_v = Z_v^{-1}Z'_v\).  Comparing the two gauge
+    relations gives
+    \[
+        C_v A_v^i = A_v^i C_{v+1}
+    \]
+    for every local matrix.  Since the matrices of \(A_v\) span the full
+    matrix algebra, evaluating this identity on the identity matrix gives
+    \(C_v=C_{v+1}\); hence all \(C_v\) are one common matrix.  The same
+    relation then says that this common matrix commutes with the full
+    matrix algebra, so it is a scalar matrix.  Its invertibility makes the
+    scalar nonzero.
 \end{proof}
 
 Two remarks place these statements against \cite{Molnar2018NormalPEPS}.  The


### PR DESCRIPTION
Summary
- add the length-one window-injectivity specialization for sitewise injective MPS chains
- surface the uniform-dimension injective closed-chain theorem as the L = 1 case of the site-dependent normal closed-chain theorem
- add the gauge uniqueness clause: two cyclic gauge families differ by one nonzero scalar
- update the PEPS normal-capstone blueprint entries for the L = 1 theorem and uniqueness

Scope
- This is the uniform physical- and bond-dimension instance of arXiv:1804.04964, thm:inj_MPS, lines 688--725, matching the existing `MPSChainTensor d D n` setting.
- The translation-invariant single-gauge/root-of-unity corollary remains separate.

Validation
- lake build TNLean.PEPS.CycleMPSChainArc
- lake build TNLean.PEPS.CycleMPSChainOverlapCapstone
- lake build TNLean
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- leanblueprint checkdecls
- python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main
- python3 scripts/check_oversized_lean_files.py
- git diff --check

Refs #2919.