### PR TITLE
refactor(peps): move Edge.ofAdj auxiliary lemmas

### DIFF
--- a/TNLean/PEPS/Defs.lean
+++ b/TNLean/PEPS/Defs.lean
@@ -73,6 +73,50 @@ omit [Fintype V] in
     Edge.ofAdj e.2.2 = e := by
   rw [Edge.ofAdj_of_lt e.2.2 e.2.1]
 
+omit [Fintype V] in
+/-- The image edge `Edge.ofAdj h` is independent of the incidence direction of the
+adjacency `h`: orienting the pair `(u, v)` and the pair `(v, u)` gives the same
+edge, since `Edge.ofAdj` places the smaller endpoint first either way. -/
+theorem Edge.ofAdj_symm {G : SimpleGraph V} {u v : V} (h : G.Adj u v) :
+    Edge.ofAdj h = Edge.ofAdj h.symm := by
+  rcases lt_or_gt_of_ne (G.ne_of_adj h) with huv | hvu
+  · rw [Edge.ofAdj_of_lt h huv, Edge.ofAdj_of_gt h.symm huv]
+  · rw [Edge.ofAdj_of_gt h hvu, Edge.ofAdj_of_lt h.symm hvu]
+
+omit [Fintype V] in
+/-- An edge is determined by its unordered endpoint pair: if `(u, v)` is, in some
+order, the ordered endpoint pair of `e`, then orienting `(u, v)` with `Edge.ofAdj`
+recovers `e`. This is the bookkeeping that makes edge constructions independent
+of the order in which an unordered adjacent pair is presented. -/
+theorem Edge.ofAdj_eq_of_endpoints {G : SimpleGraph V} {u v : V} (h : G.Adj u v)
+    (e : Edge G)
+    (H : (u = e.1.1 ∧ v = e.1.2) ∨ (u = e.1.2 ∧ v = e.1.1)) :
+    Edge.ofAdj h = e := by
+  apply Subtype.ext
+  rcases Edge.ofAdj_endpoints h with ⟨o1, o2⟩ | ⟨o1, o2⟩ <;>
+    rcases H with ⟨hu, hv⟩ | ⟨hu, hv⟩
+  · exact Prod.ext (o1.trans hu) (o2.trans hv)
+  · exfalso
+    have hlt : (Edge.ofAdj h).1.1 < (Edge.ofAdj h).1.2 := (Edge.ofAdj h).2.1
+    rw [o1, o2, hu, hv] at hlt
+    exact absurd hlt (not_lt.mpr e.2.1.le)
+  · exfalso
+    have hlt : (Edge.ofAdj h).1.1 < (Edge.ofAdj h).1.2 := (Edge.ofAdj h).2.1
+    rw [o1, o2, hu, hv] at hlt
+    exact absurd hlt (not_lt.mpr e.2.1.le)
+  · exact Prod.ext (o1.trans hv) (o2.trans hu)
+
+omit [Fintype V] in
+/-- Two `Edge.ofAdj` constructions agree when their adjacent pairs have the same
+unordered endpoints: orienting `(u, v)` and `(u', v')` gives the same edge
+whenever `{u, v} = {u', v'}`. -/
+theorem Edge.ofAdj_eq_ofAdj {G : SimpleGraph V} {u v u' v' : V} (h1 : G.Adj u v)
+    (h2 : G.Adj u' v')
+    (H : (u = u' ∧ v = v') ∨ (u = v' ∧ v = u')) :
+    Edge.ofAdj h1 = Edge.ofAdj h2 := by
+  rw [Edge.ofAdj_eq_of_endpoints h1 (Edge.ofAdj h2)]
+  rcases Edge.ofAdj_endpoints h2 with ⟨o1, o2⟩ | ⟨o1, o2⟩ <;> rw [o1, o2] <;> tauto
+
 /-- Edges incident to a vertex `v`. -/
 abbrev IncidentEdge (G : SimpleGraph V) (v : V) : Type _ :=
   { e : Edge G // e.1.1 = v ∨ e.1.2 = v }

--- a/TNLean/PEPS/IsoTransport.lean
+++ b/TNLean/PEPS/IsoTransport.lean
@@ -38,48 +38,6 @@ variable {V W : Type*} [Fintype V] [LinearOrder V] [Fintype W] [LinearOrder W]
 
 /-! ### The edge action of a graph isomorphism -/
 
-omit [Fintype V] [Fintype W] in
-/-- The image edge `Edge.ofAdj h` is independent of the incidence direction of the
-adjacency `h`: orienting the pair `(u, v)` and the pair `(v, u)` gives the same
-edge, since `Edge.ofAdj` places the smaller endpoint first either way. -/
-theorem Edge.ofAdj_symm {u v : V} (h : G.Adj u v) :
-    Edge.ofAdj h = Edge.ofAdj h.symm := by
-  rcases lt_or_gt_of_ne (G.ne_of_adj h) with huv | hvu
-  · rw [Edge.ofAdj_of_lt h huv, Edge.ofAdj_of_gt h.symm huv]
-  · rw [Edge.ofAdj_of_gt h hvu, Edge.ofAdj_of_lt h.symm hvu]
-
-omit [Fintype V] [Fintype W] in
-/-- An edge is determined by its unordered endpoint pair: if `(u, v)` is, in some
-order, the ordered endpoint pair of `e`, then orienting `(u, v)` with `Edge.ofAdj`
-recovers `e`.  This is the bookkeeping that makes the edge action of an
-isomorphism well defined regardless of which order the isomorphism produces. -/
-theorem Edge.ofAdj_eq_of_endpoints {u v : V} (h : G.Adj u v) (e : Edge G)
-    (H : (u = e.1.1 ∧ v = e.1.2) ∨ (u = e.1.2 ∧ v = e.1.1)) :
-    Edge.ofAdj h = e := by
-  apply Subtype.ext
-  rcases Edge.ofAdj_endpoints h with ⟨o1, o2⟩ | ⟨o1, o2⟩ <;>
-    rcases H with ⟨hu, hv⟩ | ⟨hu, hv⟩
-  · exact Prod.ext (o1.trans hu) (o2.trans hv)
-  · exfalso
-    have hlt : (Edge.ofAdj h).1.1 < (Edge.ofAdj h).1.2 := (Edge.ofAdj h).2.1
-    rw [o1, o2, hu, hv] at hlt
-    exact absurd hlt (not_lt.mpr e.2.1.le)
-  · exfalso
-    have hlt : (Edge.ofAdj h).1.1 < (Edge.ofAdj h).1.2 := (Edge.ofAdj h).2.1
-    rw [o1, o2, hu, hv] at hlt
-    exact absurd hlt (not_lt.mpr e.2.1.le)
-  · exact Prod.ext (o1.trans hv) (o2.trans hu)
-
-omit [Fintype V] in
-/-- Two `Edge.ofAdj` constructions agree when their adjacent pairs have the same
-unordered endpoints: orienting `(u, v)` and `(u', v')` gives the same edge whenever
-`{u, v} = {u', v'}`. -/
-theorem Edge.ofAdj_eq_ofAdj {u v u' v' : V} (h1 : G.Adj u v) (h2 : G.Adj u' v')
-    (H : (u = u' ∧ v = v') ∨ (u = v' ∧ v = u')) :
-    Edge.ofAdj h1 = Edge.ofAdj h2 := by
-  rw [Edge.ofAdj_eq_of_endpoints h1 (Edge.ofAdj h2)]
-  rcases Edge.ofAdj_endpoints h2 with ⟨o1, o2⟩ | ⟨o1, o2⟩ <;> rw [o1, o2] <;> tauto
-
 /-- The edge of `G'` obtained by pushing an edge of `G` through the graph
 isomorphism `φ`: apply `φ` to both endpoints and reorder them into the `Edge`
 convention with `Edge.ofAdj`.  The isomorphism may swap the order of the two

--- a/TNLean/PEPS/TorusLatticeGraph.lean
+++ b/TNLean/PEPS/TorusLatticeGraph.lean
@@ -139,6 +139,16 @@ def torusVerticalNeighbor {width height : ℕ}
     (v w : TorusVertex width height) : Prop :=
   v.1 = w.1 ∧ (v.2 + 1 = w.2 ∨ w.2 + 1 = v.2)
 
+/-- The horizontal cyclic-neighbour relation is symmetric. -/
+theorem torusHorizontalNeighbor_symm {width height : ℕ} {v w : TorusVertex width height}
+    (h : torusHorizontalNeighbor v w) : torusHorizontalNeighbor w v :=
+  ⟨h.1.symm, h.2.imp (·) (·) |>.elim Or.inr Or.inl⟩
+
+/-- The vertical cyclic-neighbour relation is symmetric. -/
+theorem torusVerticalNeighbor_symm {width height : ℕ} {v w : TorusVertex width height}
+    (h : torusVerticalNeighbor v w) : torusVerticalNeighbor w v :=
+  ⟨h.1.symm, h.2.imp (·) (·) |>.elim Or.inr Or.inl⟩
+
 instance instDecidableTorusHorizontalNeighbor {width height : ℕ}
     (v w : TorusVertex width height) : Decidable (torusHorizontalNeighbor v w) := by
   unfold torusHorizontalNeighbor; infer_instance

--- a/TNLean/PEPS/TorusTranslation.lean
+++ b/TNLean/PEPS/TorusTranslation.lean
@@ -95,18 +95,6 @@ theorem torusVerticalNeighbor_translate (a : ZMod width) (b : ZMod height)
     · exact ⟨by rw [hx], Or.inl (by rw [add_right_comm, hy])⟩
     · exact ⟨by rw [hx], Or.inr (by rw [add_right_comm, hy])⟩
 
-omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
-/-- The horizontal cyclic-neighbour relation is symmetric. -/
-theorem torusHorizontalNeighbor_symm {v w : TorusVertex width height}
-    (h : torusHorizontalNeighbor v w) : torusHorizontalNeighbor w v :=
-  ⟨h.1.symm, h.2.imp (·) (·) |>.elim Or.inr Or.inl⟩
-
-omit [NeZero width] [NeZero height] [Fact (1 < width)] [Fact (1 < height)] in
-/-- The vertical cyclic-neighbour relation is symmetric. -/
-theorem torusVerticalNeighbor_symm {v w : TorusVertex width height}
-    (h : torusVerticalNeighbor v w) : torusVerticalNeighbor w v :=
-  ⟨h.1.symm, h.2.imp (·) (·) |>.elim Or.inr Or.inl⟩
-
 /-! ### The translation graph automorphism -/
 
 /-- Translation of the torus by `(a, b)` as a graph automorphism: the coordinate


### PR DESCRIPTION
## Summary
- Move the general `Edge.ofAdj_symm`, `Edge.ofAdj_eq_of_endpoints`, and `Edge.ofAdj_eq_ofAdj` lemmas from `IsoTransport.lean` to `Defs.lean`.
- Move the torus-neighbour symmetry lemmas from `TorusTranslation.lean` to `TorusLatticeGraph.lean`.
- No mathematical statements change; the API is now colocated with the definitions it concerns.

## Validation
- `lake build TNLean.PEPS.TorusLatticeGraph TNLean.PEPS.TorusTranslation TNLean.PEPS.TorusTranslationInvariant TNLean.PEPS.TorusWitnessCapstone TNLean.PEPS.TorusAbsorbedCovariance TNLean.PEPS.SingletonEdgeBlockingData`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check origin/main...HEAD`

Closes #2611.