### PR TITLE
refactor(wielandt): retire orphan bridge lemmas

### DIFF
--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -254,16 +254,4 @@ lemma isIrreducibleTensor_of_isIrreducibleAction
     have hP1 := congrArg LinearMap.toMatrix' hfid
     simpa [V, f, LinearMap.toMatrix'_toLin', LinearMap.toMatrix'_id] using hP1
 
-/-! ## Part 3: Irreducible action → cumulative span -/
-
-/-- `IsIrreducibleAction` implies the cumulative span reaches `⊤` at some finite level.
-
-This is Burnside's theorem (`burnside_matrix`, proven in `TNLean.Algebra.BurnsideTheorem`)
-combined with `exists_cumulativeSpan_eq_top_of_algSpan_eq_top`. -/
-lemma exists_cumulativeSpan_eq_top_of_isIrreducibleAction [NeZero D]
-    (A : MPSTensor d D) (hIrr : IsIrreducibleAction A) :
-    ∃ N : ℕ, cumulativeSpan A N = ⊤ := by
-  have hBurn : algSpan A = ⊤ := burnside_matrix (A := A) hIrr
-  exact exists_cumulativeSpan_eq_top_of_algSpan_eq_top A hBurn
-
 end MPSTensor

--- a/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/CumulativeToWordSpan.lean
@@ -8,7 +8,6 @@ import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
 import TNLean.Wielandt.RankOne.Products
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.BurnsideTheorem
-import TNLean.Algebra.IrreducibleTensorAction
 
 /-!
 # From Cumulative Span to Word Span
@@ -53,9 +52,6 @@ supplied by strong irreducibility, i.e. peripheral spectrum `{1}`.
 
 * `isNormal_of_isIrreducibleAction_of_aperiodic`:
   If `IsIrreducibleAction A`, `1 ∈ wordSpan A 1`, and `NeZero D`, then `IsNormal A`.
-
-* `isNormal_of_isIrreducibleTensor_of_aperiodic`:
-  If `IsIrreducibleTensor A`, `1 ∈ wordSpan A 1`, and `NeZero D`, then `IsNormal A`.
 
 ## References
 
@@ -279,19 +275,6 @@ theorem isNormal_of_isIrreducibleAction_of_aperiodic [NeZero D]
     (hone : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A 1) :
     IsNormal A := by
   exact isNormal_of_algSpan_eq_top_of_aperiodic A (burnside_matrix A hIrr) hone
-
-/-- If `IsIrreducibleTensor A`, `1 ∈ wordSpan A 1`, and `NeZero D`, then `IsNormal A`.
-
-Extends the chain with `IsIrreducibleTensor → IsIrreducibleAction`
-(proved in `IrreducibleTensorAction.lean`). This is the conclusion later combined
-with strong irreducibility, which supplies the aperiodicity hypothesis. -/
-theorem isNormal_of_isIrreducibleTensor_of_aperiodic [NeZero D]
-    (A : MPSTensor d D)
-    (hIrr : IsIrreducibleTensor A)
-    (hone : (1 : Matrix (Fin D) (Fin D) ℂ) ∈ wordSpan A 1) :
-    IsNormal A :=
-  isNormal_of_isIrreducibleAction_of_aperiodic A
-    (isIrreducibleAction_of_isIrreducibleTensor A hIrr) hone
 
 /-! ## Part 5: Additional useful lemmas -/
 

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -442,8 +442,7 @@ boundary conditions (PBC).
 \end{definition}
 
 \begin{remark}\leanok
-    \uses{lem:primitive_implies_irreducible,
-        thm:irred_tensor_aperiodic_normal, thm:blocking_primitivity}
+    \uses{lem:primitive_implies_irreducible, thm:blocking_primitivity}
     The algebraic characterization of normality in
     Definition~\ref{def:normal} --- eventual full matrix span,
     equivalently eventual block injectivity --- is equivalent to the
@@ -453,9 +452,8 @@ boundary conditions (PBC).
     with trivial peripheral spectrum. This equivalence is proved in
     \cite[Proposition~3]{Sanz2010Quantum}. In what follows, the
     directions of the equivalence are supplied by
-    Lemma~\ref{lem:primitive_implies_irreducible},
-    Theorem~\ref{thm:irred_tensor_aperiodic_normal}, and
-    Theorem~\ref{thm:blocking_primitivity}. In particular, every
+    Lemma~\ref{lem:primitive_implies_irreducible}
+    and Theorem~\ref{thm:blocking_primitivity}. In particular, every
     subsequent use of ``normal'' here refers to this single notion;
     Definition~\ref{def:is_normal_canonical_form} employs the spectral
     formulation, but it describes the same class of tensors.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -442,7 +442,8 @@ boundary conditions (PBC).
 \end{definition}
 
 \begin{remark}\leanok
-    \uses{lem:primitive_implies_irreducible, thm:blocking_primitivity}
+    \uses{lem:primitive_implies_irreducible, thm:burnside_matrix,
+        thm:algspan_to_normal, thm:blocking_primitivity}
     The algebraic characterization of normality in
     Definition~\ref{def:normal} --- eventual full matrix span,
     equivalently eventual block injectivity --- is equivalent to the
@@ -452,8 +453,9 @@ boundary conditions (PBC).
     with trivial peripheral spectrum. This equivalence is proved in
     \cite[Proposition~3]{Sanz2010Quantum}. In what follows, the
     directions of the equivalence are supplied by
-    Lemma~\ref{lem:primitive_implies_irreducible}
-    and Theorem~\ref{thm:blocking_primitivity}. In particular, every
+    Lemma~\ref{lem:primitive_implies_irreducible}, the Burnside route
+    through Theorem~\ref{thm:algspan_to_normal}, and
+    Theorem~\ref{thm:blocking_primitivity}. In particular, every
     subsequent use of ``normal'' here refers to this single notion;
     Definition~\ref{def:is_normal_canonical_form} employs the spectral
     formulation, but it describes the same class of tensors.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -443,7 +443,8 @@ boundary conditions (PBC).
 
 \begin{remark}\leanok
     \uses{lem:primitive_implies_irreducible, thm:burnside_matrix,
-        thm:algspan_to_normal, thm:blocking_primitivity}
+        thm:normal_from_primitive_posdef, thm:algspan_to_normal,
+        thm:blocking_primitivity}
     The algebraic characterization of normality in
     Definition~\ref{def:normal} --- eventual full matrix span,
     equivalently eventual block injectivity --- is equivalent to the
@@ -453,9 +454,11 @@ boundary conditions (PBC).
     with trivial peripheral spectrum. This equivalence is proved in
     \cite[Proposition~3]{Sanz2010Quantum}. In what follows, the
     directions of the equivalence are supplied by
-    Lemma~\ref{lem:primitive_implies_irreducible}, the Burnside route
-    through Theorem~\ref{thm:algspan_to_normal}, and
-    Theorem~\ref{thm:blocking_primitivity}. In particular, every
+    Lemma~\ref{lem:primitive_implies_irreducible},
+    Theorem~\ref{thm:normal_from_primitive_posdef} for primitive normalized
+    tensors with positive-definite fixed point, the Burnside route through
+    Theorem~\ref{thm:algspan_to_normal} for the aperiodic algebraic
+    criterion, and Theorem~\ref{thm:blocking_primitivity}. In particular, every
     subsequent use of ``normal'' here refers to this single notion;
     Definition~\ref{def:is_normal_canonical_form} employs the spectral
     formulation, but it describes the same class of tensors.

--- a/blueprint/src/chapter/ch08_wielandt.tex
+++ b/blueprint/src/chapter/ch08_wielandt.tex
@@ -1559,25 +1559,6 @@ For Burnside-style arguments it is more natural to work with invariant
     action already generates the full endomorphism algebra.
 \end{remark}
 
-\begin{theorem}[Irreducible action implies eventual cumulative spanning]%
-    \label{thm:irreducible_action_cumulative_span}
-    \lean{MPSTensor.exists_cumulativeSpan_eq_top_of_isIrreducibleAction}\leanok
-    \uses{def:cumulative_span, def:irreducible_action}
-    Assume $D > 0$.
-    If $A$ acts irreducibly on $\C^D$, then there exists $N$ such that
-    $T_N(A) = \MN{D}$.
-\end{theorem}
-
-\begin{proof}\leanok\uses{thm:burnside_matrix}
-    By Theorem~\ref{thm:burnside_matrix}, $\algspn(A) = \MN{D}$.
-    Every element of the algebra span is a linear combination of word products,
-    hence belongs to $T_n(A)$ for some~$n$.
-    Since $\MN{D}$ is finite-dimensional, the ascending chain
-    $T_0(A) \le T_1(A) \le \cdots$ stabilizes, so one can choose a uniform
-    $N$ with $T_N(A) = \MN{D}$.
-\end{proof}
-
-
 \subsection{From primitivity to strong irreducibility and normality}%
 \label{subsec:prim_normality_connection}
 
@@ -1795,41 +1776,6 @@ span.
     there exists $N$ with $T_N(A) = \MN{D}$
     (by the ascending chain condition on finite-dimensional subspaces).
     Apply Theorem~\ref{thm:cumspan_to_normal}.
-\end{proof}
-
-\begin{theorem}[Irreducible tensor plus aperiodicity implies normality]%
-    \label{thm:irred_tensor_aperiodic_normal}
-    \lean{MPSTensor.isNormal_of_isIrreducibleTensor_of_aperiodic}
-    \leanok
-    \uses{def:normal, def:irreducible_tensor, def:word_span}
-    If $A$ is an irreducible tensor, $D > 0$,
-    and $\Id \in S_1(A)$, then $A$ is normal.
-    This assembles the full chain:
-    \[
-        \text{irreducible tensor}
-        \xrightarrow{\ref{thm:irreducible_tensor_to_action}}
-        \text{irreducible action}
-        \xrightarrow{\text{Burnside}}
-        \algspn(A) = \MN{D}
-        \xrightarrow{\ref{thm:algspan_to_normal}}
-        \text{normal}.
-    \]
-    This corresponds to the irreducibility-to-normality direction of
-    \cite[Proposition~3]{Sanz2010Quantum}.
-    The Burnside step is supplied by
-    Theorems~\ref{thm:irreducible_tensor_to_action}
-    and~\ref{thm:burnside_matrix}.
-\end{theorem}
-
-\begin{proof}\leanok
-    \uses{thm:algspan_to_normal, thm:burnside_matrix,
-        thm:irreducible_tensor_to_action}
-    By Theorem~\ref{thm:irreducible_tensor_to_action},
-    $A$ acts irreducibly on $\C^D$.
-    By Theorem~\ref{thm:burnside_matrix},
-    $\algspn(A) = \MN{D}$.
-    By Theorem~\ref{thm:algspan_to_normal} with the
-    aperiodicity hypothesis, $A$ is normal.
 \end{proof}
 
 \begin{remark}[Normal canonical form avoids the aperiodicity step]\label{rem:d1_bypasses_aperiodicity}

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -475,11 +475,13 @@ irreducible unital blocks and the algebra-spanning input used later.
 \end{proof}
 
 \begin{remark}[Burnside input for cumulative spanning]\leanok
-    \uses{thm:burnside_matrix, lem:algspan_cumulative_span}
-    The passage from irreducible tensors to full algebra spanning uses Burnside's
-    theorem: an irreducible subalgebra of $\MN{D}$ is all of $\MN{D}$.
-    Once the algebra span is full, finite-dimensionality gives a single
-    cumulative span that already equals $\MN{D}$.
+    \uses{thm:irreducible_tensor_to_action, thm:burnside_matrix,
+        lem:algspan_cumulative_span}
+    The passage from irreducible tensors to full algebra spanning first passes
+    through the irreducible action on $\C^D$. Burnside's theorem then says that
+    the resulting irreducible subalgebra of $\MN{D}$ is all of $\MN{D}$. Once
+    the algebra span is full, finite-dimensionality gives a single cumulative
+    span that already equals $\MN{D}$.
 \end{remark}
 
 \begin{lemma}[The algebra span reaches a finite cumulative span]\label{lem:algspan_cumulative_span}

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -475,11 +475,11 @@ irreducible unital blocks and the algebra-spanning input used later.
 \end{proof}
 
 \begin{remark}[Burnside input for cumulative spanning]\leanok
-    \uses{thm:irreducible_action_cumulative_span}
+    \uses{thm:burnside_matrix, lem:algspan_cumulative_span}
     The passage from irreducible tensors to full algebra spanning uses Burnside's
-    theorem: an irreducible subalgebra of $\MN{D}$ is all of $\MN{D}$. It is
-    developed alongside the Wielandt material in Chapter~\ref{ch:wielandt}; see
-    Theorem~\ref{thm:irreducible_action_cumulative_span}.
+    theorem: an irreducible subalgebra of $\MN{D}$ is all of $\MN{D}$.
+    Once the algebra span is full, finite-dimensionality gives a single
+    cumulative span that already equals $\MN{D}$.
 \end{remark}
 
 \begin{lemma}[The algebra span reaches a finite cumulative span]\label{lem:algspan_cumulative_span}


### PR DESCRIPTION
## Summary

- Retire the two remaining chapter 7 zero-consumer bridge declarations tracked in #2295: `MPSTensor.exists_cumulativeSpan_eq_top_of_isIrreducibleAction` and `MPSTensor.isNormal_of_isIrreducibleTensor_of_aperiodic`.
- Remove the corresponding blueprint theorem blocks and retarget neighboring blueprint remarks to the retained component results: Burnside, finite cumulative spanning, primitive-to-irreducible, and blocking primitivity.
- Keep the chapter 4 entries `peripheralSpectrum` and `isPrimitive_iff_period_one`: Wolf chapter 6 explicitly discusses the peripheral spectrum and primitive maps with trivial peripheral spectrum, so these are not treated as removable orphans.

## Source check

The Wolf chapter 6 source contains the peripheral-spectrum definition and primitive-map equivalences. The two retired Wielandt statements are local assembly lemmas for the formalization: they package Burnside plus finite-dimensional stabilization, and Burnside plus the tensor-to-action bridge and aperiodicity. They do not occur as Wolf statements and have no Lean consumers.

## Validation

- `lake build TNLean`
- `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check`

Refs #2295