### PR TITLE
refactor(peps): generalize gauge conjugation bridge

### DIFF
--- a/TNLean/PEPS/TorusEdgeGaugeCovariance.lean
+++ b/TNLean/PEPS/TorusEdgeGaugeCovariance.lean
@@ -118,25 +118,11 @@ theorem gaugeConj_eq_of_coeffIdentities (A B : Tensor G d) (R : Finset V)
       (↑Z₂⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ))
     h₁ h₂ M
 
-end CoeffBridge
-
-/-! ### The conjugation covariance on a torus edge from coefficient identities
-
-When two gauges both realize a region-insertion coefficient identity of `A` through `B` over a
-common region `R` and its single boundary edge, their conjugations coincide on every bond
-matrix: the determinacy bridge `gaugeConj_eq_of_coeffIdentities` together with the surjectivity
-of the bond-dimension reindexing.  The identity families are produced from one reference
-blocking datum per orientation class by transporting the reference coefficient identity along
-the class translations (`regionInsertedCoeff_translate_coeffIdentity`). -/
-
-section TorusFamily
-
-variable {width height d : ℕ} [NeZero width] [NeZero height]
-  [Fact (1 < width)] [Fact (1 < height)]
+/-! ### Arbitrary target matrices from coefficient identities -/
 
 /-- **Single-edge conjugation covariance from two coefficient identities.**
 
-On the single boundary edge `f` of a region `R`, with `B`'s region and complement blocked-tensor
+On a boundary edge `f` of a region `R`, with `B`'s region and complement blocked-tensor
 injective and positive bonds, suppose the per-edge gauge `Z₁` and a second gauge `Z₂` (both
 invertible over `B.bondDim f.1`) each realize the region-insertion coefficient identity of `A`
 through `B` on `f` by conjugation.  Then they induce the same conjugation map on every bond
@@ -146,29 +132,27 @@ This is `gaugeConj_eq_of_coeffIdentities` read on an arbitrary target matrix: th
 reindexing is surjective, so every `N` is a reindexed `M`, and the determinacy applies.  Reading
 it on `N` over `B.bondDim f.1` (rather than `reindex M`) is the conjugation-covariance shape at
 the edge `f.1`. -/
-theorem gaugeConj_eq_of_coeffIdentities_torus
-    {A B : Tensor (torusGraph width height) d}
-    (R : Finset (TorusVertex width height))
-    (f : {f : Edge (torusGraph width height) //
-      IsRegionBoundaryEdge (G := torusGraph width height) R f})
-    (hRB : RegionBlockedTensorInjective (G := torusGraph width height) B R)
-    (hCB : RegionBlockedTensorInjective (G := torusGraph width height) B (Finset.univ \ R))
-    (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
+theorem gaugeConj_eq_of_coeffIdentities_target
+    (A B : Tensor G d) (R : Finset V)
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
+    (hRB : RegionBlockedTensorInjective (G := G) B R)
+    (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
+    (hposB : ∀ g : Edge G, 0 < B.bondDim g)
     {hE₁ hE₂ : A.bondDim f.1 = B.bondDim f.1}
     (Z₁ Z₂ : GL (Fin (B.bondDim f.1)) ℂ)
     (h₁ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
-      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
-      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
-      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
-        regionInsertedCoeff (G := torusGraph width height) B R f
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f
           ((Z₁ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
               Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₁) M *
             (↑Z₁⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
     (h₂ : ∀ (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
-      (σ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) R)
-      (τ : RegionPhysicalConfig (V := TorusVertex width height) (d := d) (Finset.univ \ R)),
-      regionInsertedCoeff (G := torusGraph width height) A R f M σ τ =
-        regionInsertedCoeff (G := torusGraph width height) B R f
+      (σ : RegionPhysicalConfig (V := V) (d := d) R)
+      (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
+      regionInsertedCoeff (G := G) A R f M σ τ =
+        regionInsertedCoeff (G := G) B R f
           ((Z₂ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
               Matrix.reindexAlgEquiv ℂ ℂ (finCongr hE₂) M *
             (↑Z₂⁻¹ : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)) σ τ)
@@ -188,7 +172,7 @@ theorem gaugeConj_eq_of_coeffIdentities_torus
   rw [hcast] at hmain
   exact hmain
 
-end TorusFamily
+end CoeffBridge
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/TorusGaugeUniqueness.lean
+++ b/TNLean/PEPS/TorusGaugeUniqueness.lean
@@ -16,7 +16,7 @@ The route mirrors the source.  A gauge family realizing the bare-edge absorbed e
 edge `e` induces, at any region with `e` on its boundary, the region-insertion coefficient
 identity in conjugation form, conjugated by the orientation-adapted absorbing gauge of `X e`
 (`regionConjIdentity_of_edgeAbsorbed`); two families realizing the same bare-edge equality
-therefore induce the same conjugation map (`gaugeConj_eq_of_coeffIdentities_torus`), so their
+therefore induce the same conjugation map (`gaugeConj_eq_of_coeffIdentities_target`), so their
 absorbing gauges differ by a nonzero scalar (`gl_conj_unique_scalar`), and unwinding the
 orientation adaptation gives the per-edge proportionality `X' e = c · X e`
 (`torusAbsorbedGauge_unique_scalar`).
@@ -152,7 +152,7 @@ at that edge: `X' f.1 = c · X f.1` for a nonzero scalar `c`.
 
 Both families induce the conjugation-form coefficient identity at `R`, `f`, conjugated by their
 orientation-adapted absorbing gauges (`regionConjIdentity_of_edgeAbsorbed`); the region-insertion
-transfer map is determined by the identity (`gaugeConj_eq_of_coeffIdentities_torus`), so the two
+transfer map is determined by the identity (`gaugeConj_eq_of_coeffIdentities_target`), so the two
 absorbing gauges induce the same conjugation and differ by a nonzero scalar
 (`gl_conj_unique_scalar`).  Unwinding the orientation adaptation gives the proportionality of
 the gauges themselves — with the inverse constant on the transposed-inverse branch, which the
@@ -191,7 +191,7 @@ theorem torusAbsorbedGauge_unique_scalar_of_region
           Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) * N *
         (↑(absorbedBoundaryGauge (G := torusGraph width height) B R f (X' f.1))⁻¹ :
           Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) := fun N =>
-    gaugeConj_eq_of_coeffIdentities_torus (A := A) (B := B) R f hRB hCB hposB
+    gaugeConj_eq_of_coeffIdentities_target (A := A) (B := B) R f hRB hCB hposB
       (hE₁ := congr_fun hbd f.1) (hE₂ := congr_fun hbd f.1)
       (absorbedBoundaryGauge (G := torusGraph width height) B R f (X f.1))
       (absorbedBoundaryGauge (G := torusGraph width height) B R f (X' f.1))

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -1680,7 +1680,7 @@ The remaining obligations are the following.
           declarations: \leanid{TNLean.PEPS.exists_regionEdgeGauge_torus_coeff},
           \leanid{TNLean.PEPS.reindexAlgEquiv_gaugeConj},
           \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities}, and
-          \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities_torus}.}
+          \leanid{TNLean.PEPS.gaugeConj_eq_of_coeffIdentities_target}.}
           What remains is the geometric production of the two matched coefficient
           identities at every edge: reading the per-edge gauge off the reference blocking
           datum transported along each class translation, and matching its region and


### PR DESCRIPTION
## Summary

- Move the arbitrary-target conjugation bridge out of the torus-specific section by replacing `gaugeConj_eq_of_coeffIdentities_torus` with the graph-level `gaugeConj_eq_of_coeffIdentities_target`.
- Update the torus gauge-uniqueness consumer to use the graph-level bridge.
- Update the Section 3 route note to cite the new graph-level declaration.

The old `_torus` name is not kept as a deprecated alias because the generalized statement is no longer torus-specific.

## Validation

- `lake build TNLean.PEPS.TorusEdgeGaugeCovariance TNLean.PEPS.TorusGaugeUniqueness`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check`

Closes #2619