### PR TITLE
doc(rfp): mark ZCL equivalence scope

### DIFF
--- a/TNLean/MPS/RFP/Assembly.lean
+++ b/TNLean/MPS/RFP/Assembly.lean
@@ -7,16 +7,20 @@ import TNLean.MPS.RFP.ZeroCorrelationLength
 import TNLean.MPS.RFP.StructuralForm
 
 /-!
-# Equivalence of RFP and ZCL
+# Per-block equivalence of RFP and ZCL
 
-This file proves the forward and backward directions of the main
-equivalence from arXiv:1606.00608, Theorem 3.10 (partial):
+This file proves the single-block consequence used in the RFP-ZCL comparison
+from arXiv:1606.00608, Theorem 3.10:
 
-> For a canonical-form MPS tensor, being a renormalization fixed point (RFP)
-> is equivalent to having zero correlation length (ZCL).
+> for each block of a canonical-form MPS tensor, the block is a
+> renormalization fixed point (RFP) if and only if that block has the local
+> zero-correlation-length (ZCL) property.
 
-The NNCPH (nearest-neighbour commuting parent Hamiltonian) direction of
-Theorem 3.10 is deferred to a later module.
+**Scope restriction:** The source theorem uses the BNT-family ZCL condition:
+CID together with local orthogonality between distinct BNT elements. The theorem
+in this file applies the single-block predicate to one chosen block and does not
+by itself formalize the full BNT-family statement. This restriction is recorded
+in `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
 
 This reduces directly to `zcl_iff_idempotent_transfer` (Theorem 3.8).
 -/
@@ -27,11 +31,17 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- **Theorem 3.10** (arXiv:1606.00608, partial): For a canonical-form MPS
-tensor, RFP is equivalent to ZCL.
+/-- Per-block RFP-ZCL equivalence inside a canonical form
+(arXiv:1606.00608, Theorem 3.10, single-block consequence).
 
-The full theorem also includes equivalence with the NNCPH condition; that
-direction is deferred.
+For a canonical-form MPS tensor, each chosen block is a renormalization fixed
+point if and only if that same block has the local zero-correlation-length
+property.
+
+**Scope restriction:** The source theorem uses a BNT-family ZCL condition,
+namely CID together with local orthogonality between distinct BNT elements. This
+declaration only applies the single-block predicate to `A k`. See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
 
 Proved by `zcl_iff_idempotent_transfer.symm`. -/
 theorem rfp_iff_zcl {r : ℕ} {dim : Fin r → ℕ}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -644,14 +644,23 @@ and rates for the single-tensor transfer map $\E_A$.
     separation-independent.
 \end{proof}
 
-\begin{theorem}[Canonical-form blocks satisfy RFP iff ZCL]%
+\begin{theorem}[Single-block RFP iff ZCL inside a canonical form]%
     \label{thm:rfp_iff_zcl}
     \lean{MPSTensor.rfp_iff_zcl}
     \leanok
     \uses{def:is_canonical_form, def:is_rfp, def:is_zcl}
-    For a tensor in canonical form, each block is a renormalization fixed point
-    if and only if it has zero correlation length.
-    This is the RFP--ZCL part of \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}.
+    Let $A^i=\bigoplus_k \mu_k A_k^i$ be a tensor in canonical form. For each
+    $k$, the tensor $A_k$ is a renormalization fixed point if and only if
+    $A_k$ has zero correlation length.
+
+    This is the single-block consequence of
+    \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}. The ZCL condition in the source
+    theorem is the BNT-family condition: CID together with the local
+    orthogonality equations
+    \[
+        \mathbb E_{j,j'}=0 \qquad (j\ne j'),
+    \]
+    as in Definition~\ref{def:is_bnt_zcl}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:zcl_iff_idempotent_transfer}


### PR DESCRIPTION
## Summary

- Sharpen the RFP-ZCL assembly docstring so it states the checked single-block consequence rather than the full BNT-family theorem.
- Update the corresponding blueprint theorem to display the canonical-form block decomposition and the mixed-sector local-orthogonality equations required by the source ZCL condition.
- Point the scope restriction to `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.

## Source check

The source theorem in arXiv:1606.00608 uses ZCL for a canonical-form family: CID together with local orthogonality of distinct BNT elements. The present Lean theorem applies the single-block ZCL predicate to a chosen block, so the prose now describes it as a single-block consequence rather than the full RFP-ZCL part of Theorem 3.10.

## Validation

- `lake env lean TNLean/MPS/RFP/Assembly.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`

Refs #2633
Refs #2597