### PR TITLE
doc(parent): clarify compression angle input

### DIFF
--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -50,7 +50,13 @@ For a symmetric projection `P`, the ordered cross term satisfies
 bound `‖P (Q v)‖ ≤ c ‖P v‖` implies
 `Re ⟪P v, Q v⟫ ≥ -c Re ⟪P v, v⟫`. This is the
 projection-geometry conversion from a principal-angle norm estimate to the
-ordered quadratic-form estimate used by the martingale row-sum argument. -/
+ordered quadratic-form estimate used by the martingale row-sum argument.
+
+The norm-compression hypothesis is directional. If it holds for every `v`, then
+`P v = 0` forces `P (Q v) = 0`; equivalently, `Q` maps `ker P` into `ker P`.
+Thus a principal-angle estimate used here must supply this compressed-product
+bound, not only a qualitative lower bound on a non-zero angle between the two
+projected subspaces. -/
 theorem re_inner_apply_apply_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
     (hP : P.IsSymmetricProjection) {c : ℝ}
     (hNorm : ∀ v : E, ‖P (Q v)‖ ≤ c * ‖P v‖) (v : E) :

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -244,6 +244,18 @@ The qualitative fact that two finite-dimensional subspaces have a well-defined
 principal-angle decomposition is not enough: the martingale reduction needs a
 uniform numerical bound after the same blocking convention has been fixed.
 
+There is also a directional point. If (N$_\eta$) is imposed for all vectors
+$v$, then $p_i v=0$ implies $p_i p_j v=0$. Thus $p_j$ maps $\ker p_i$ into
+$\ker p_i$. This is stronger than merely knowing that the
+smallest non-zero principal angle between the two local ground spaces is
+positive. The source comparison must therefore identify a principal-angle
+estimate that gives the directed compressed-product bound (N$_\eta$), or the
+formal hypothesis should be restated directly in the anticommutator form
+\[
+    h_i h_j+h_jh_i\ge -c_{ij}(1-\gamma)(h_i+h_j)
+\]
+used in \cite[Section~IV.C]{Cirac2021Matrix}.
+
 \section{Relation to the blueprint}
 
 The blueprint item labelled \path{lem:martingale_mps} in


### PR DESCRIPTION
## Summary

- Record in `ProjectionGeometry` that the norm-compression hypothesis is directional: if it holds for every vector, then `Q` maps `ker P` into `ker P`.
- Add the same observation to the martingale paper-gap note for the overlapping-window estimate.
- Keep the remaining #952 task explicit: the cited principal-angle estimates still have to be converted to the directed compressed-product bound, or the formal input should be restated in the anticommutator form used in the review.

## Source check

The review text states the martingale condition through the anticommutator inequality and principal angles between overlapping local ground spaces. The formal reduction currently uses the stronger one-sided norm-compression estimate `‖p_i p_j v‖ ≤ η ‖p_i v‖`. This PR records the mathematical implication of that directionality without claiming that the missing MPS estimate has been proved.

## Validation

- `lake env lean TNLean/Analysis/ProjectionGeometry.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`

Refs #952