### PR TITLE
doc(parent): retarget block-boundary residual

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -108,7 +108,7 @@ rather than deriving it from arXiv:2011.12127, Section IV.C, lines 2126--2128.
 Documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 Elimination: derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison
 from arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it
-to remove the external boundary-condition hypothesis; tracked in issue 2651. -/
+to discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -192,7 +192,7 @@ it from arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external boundary-condition hypothesis; tracked in issue 2651. -/
+discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -245,7 +245,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external boundary-condition hypothesis; tracked in issue 2651. -/
+discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -326,7 +326,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external boundary-condition hypothesis; tracked in issue 2651. -/
+discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -445,7 +445,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external boundary-condition hypothesis; tracked in issue 2651. -/
+discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -860,7 +860,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external boundary-condition hypothesis; tracked in issue 2651. -/
+discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -926,7 +926,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-remove the external boundary-condition hypothesis; tracked in issue 2651. -/
+discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -888,8 +888,8 @@ which uses boundary-crossing comparison hypotheses not derived from
 arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) comparison from arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1456, and remove the external complementary-word
-identity hypothesis; tracked in issue 2651. -/
+Theorem 12, proof lines 1446--1456, and discharge the currently assumed
+complementary-word identity; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -952,8 +952,8 @@ which uses boundary-crossing comparison hypotheses not derived from
 arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) comparison from arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1456, and remove the external complementary-word
-identity hypothesis; tracked in issue 2651. -/
+Theorem 12, proof lines 1446--1456, and discharge the currently assumed
+complementary-word identity; tracked in issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -55,8 +55,8 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
 boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1456, and use it to remove the external comparison hypothesis;
-tracked in issue 2651. -/
+lines 1446--1456, and use it to discharge the currently assumed comparison;
+tracked in issue 2971. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -127,8 +127,8 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
 boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1456, and use it to remove the external comparison hypothesis;
-tracked in issue 2651. -/
+lines 1446--1456, and use it to discharge the currently assumed comparison;
+tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -55,8 +55,8 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
 boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1456, and use it to remove the external trace-decomposition
-hypothesis; tracked in issue 2651. -/
+lines 1446--1456, and use it to discharge the currently assumed
+trace-decomposition equality; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -132,8 +132,8 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
 boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1456, and use it to remove the external trace-decomposition
-hypothesis; tracked in issue 2651. -/
+lines 1446--1456, and use it to discharge the currently assumed
+trace-decomposition equality; tracked in issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -56,7 +56,10 @@ Cirac et al. describe the degenerate parent-Hamiltonian ground space for a
 matrix product state with more than one block in canonical form in Section~IV.C
 of \cite{Cirac2021Matrix}.\footnote{For
 	traceability, the periodic-boundary block-component comparison was tracked by
-	\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}. Pull
+	\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}, which is
+	now closed. The remaining derivation of the source comparison currently
+	assumed by the conditional theorems is tracked by
+	\href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}. Pull
 	request~\#2724 records the conditional reduction on the main branch, reducing
 	the unconditional target to the boundary-crossing comparison identities.
 	Earlier reductions were tracked by
@@ -296,8 +299,8 @@ containment, and \path{thm:gs_eq_bnt_span} for the final span statement, all in
     \psi_j\in\mathcal K_{N,L}(A_j)
   \right\}.
 \end{align}
-The source-level boundary-condition statement not yet stated without the
-boundary-crossing coordinate identity as an external hypothesis is
+The source-level boundary-condition statement not yet stated without assuming
+the boundary-crossing coordinate identity is
 \begin{align}
   \left[
     b\ge2
@@ -375,8 +378,8 @@ coordinate formulation displayed above.\footnote{Lean declarations:
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary},
 and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}.}
-These reductions do not yet state the source theorem without the
-boundary-crossing comparison as an external hypothesis.
+These reductions do not yet state the source theorem without assuming the
+boundary-crossing comparison.
 For
 \begin{align}
   X=\bigoplus_j X_j,
@@ -466,9 +469,10 @@ then
 \end{align}
 for every block $j$ in the block-injective range.\footnote{Lean declaration:
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}.}
-The unconditional target of
-\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} is reduced to
-deriving those trace-decomposition equalities from the PGVWC07
+After \href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} was
+closed, the remaining source-comparison target is tracked by
+\href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}: derive those
+currently assumed trace-decomposition equalities from the PGVWC07
 \(C^j,D^j,E^j\) comparison in the source range
 \begin{align}
   b\ge2,


### PR DESCRIPTION
## Summary

- Open #2971 for the remaining PGVWC07 boundary-comparison residual after the work tracked in issue 2651 was completed.
- Retarget the block-diagonal parent-Hamiltonian **Unfaithful** markers from issue 2651 to #2971.
- Update the paper-gap note to state that the issue 2651 component is complete and that #2971 now tracks removal of the remaining external comparison hypotheses.

## Source check

The mathematical target is unchanged: derive the Pérez-García--Verstraete--Wolf--Cirac `C^j,D^j,E^j` boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, in the block-diagonal boundary-condition setting described in arXiv:2011.12127, Section IV.C, lines 2126--2128.

## Validation

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`

Refs #2971
Refs #190
Refs #460
Refs issue 2651

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX traceability edits only; no proof or API changes.
> 
> **Overview**
> Documentation-only update after the work tracked in issue 2651 was completed: the remaining PGVWC07 boundary-comparison work is tracked in **#2971**.
> 
> **Unfaithful** docstrings on conditional block-diagonal parent-Hamiltonian theorems (`BNTBlockDiagonalChain`, `BNTBlockDiagonalCrossing`, `BNTBlockDiagonalPGVWCComparison`, `BNTBlockDiagonalTraceDecomposition`) now point to **#2971** and describe the goal as **discharging** the comparison, complementary-word identity, or trace-decomposition equality that proofs still **assume**, instead of “removing an external hypothesis.”
> 
> `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` is aligned: the issue 2651 component is noted as complete, **#2971** owns the residual derivation, and wording shifts from “external hypothesis” to “assuming” the boundary-crossing comparison. **No Lean proofs or theorem statements change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5684078b1c0fdd63f0a30e6566058a9344193fe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
