### PR TITLE
doc(parent): align gap terminology with sources

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -6,11 +6,10 @@ import TNLean.MPS.ParentHamiltonian.GroundSpace
 import TNLean.MPS.SharedInfra.BlockAssembly
 
 /-!
-# Local ground spaces of block-diagonal tensors
+# Local spaces of block-diagonal tensors
 
-This file identifies the local parent-Hamiltonian ground space of a
-block-diagonal tensor with the linear sum of the local ground spaces of its
-blocks.
+This file identifies the local MPS space \(G_L\) of a block-diagonal tensor with
+the linear sum of the corresponding local spaces of its blocks.
 
 ## References
 
@@ -137,8 +136,8 @@ end BlockSumGroundSpace
 
 open BlockSumGroundSpace
 
-/-- One block's local ground space is contained in the local ground space of the
-block-diagonal tensor when that block has nonzero weight.
+/-- One block's local space is contained in the local space of the block-diagonal
+tensor when that block has nonzero weight.
 
 This is the single-summand direction of the local identity
 \[
@@ -186,8 +185,8 @@ theorem groundSpace_block_le_toTensorFromBlocks
   · intro hj
     exact (hj (Finset.mem_univ _)).elim
 
-/-- The local ground space of a block-diagonal tensor is the linear sum of the local
-ground spaces of its blocks:
+/-- The local space of a block-diagonal tensor is the linear sum of the local
+spaces of its blocks:
 \[
   G_L\!\left(\bigoplus_j \mu_j A_j\right)=\bigvee_j G_L(A_j).
 \]

--- a/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
@@ -41,10 +41,10 @@ parent Hamiltonian this hypothesis is automatic because \(H = ∑ᵢ hᵢ\) is a
 sum of orthogonal projectors.
 
 This is the operator-theoretic content of the Kastoryano–Lucia /
-Nachtergaele martingale method: once the MPS-specific projector
-geometry (Friedrichs angle on overlapping local ground spaces plus
-the row-sum bound) produces the operator inequality \(H² ≥ γ H\) for the
-PSD operator \(H\), the norm lower bound — and hence the spectral gap
+Nachtergaele martingale method: once the MPS-specific principal-angle, or
+norm-compression, estimates for overlapping local ground spaces, together
+with the row-sum bound, produce the operator inequality \(H² ≥ γ H\) for
+the PSD operator \(H\), the norm lower bound — and hence the spectral gap
 for eigenvectors of \(H\) — follows by the spectral theorem. This lemma
 provides the final spectral-theorem step; the remaining MPS-specific
 quadratic-form hypothesis is stated separately in

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -349,12 +349,12 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
     hFriedrichs
 
 /-- Uniform explicit gap-bound reduction from the remaining overlapping-window
-Friedrichs estimate.
+principal-angle, or norm-compression, estimate.
 
 The concrete cyclic-window row-cardinality bound, local symmetric-projection
 structure, and non-overlap positivity are already proved.  Consequently it is
-enough to assume the displayed ordered Friedrichs lower bound only for pairs whose
-cyclic supports overlap. -/
+enough to assume the displayed ordered lower bound only for pairs whose cyclic
+supports overlap. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -3,8 +3,9 @@
 
 The periodic ground-space theorem states that, for sufficiently long periodic
 systems, the periodic-boundary ground space of a parent Hamiltonian is generated
-by a basis of normal tensors~\cite[Theorem~IV.16]{Cirac2021Matrix}. The lemmas
-in this subsection are conditional reductions toward that statement. Their
+by a basis of normal tensors of the initial tensor
+\(A\)~\cite[Theorem~IV.16]{Cirac2021Matrix}. The lemmas in this subsection are
+conditional reductions toward that statement. Their
 hypotheses explicitly include a boundary inclusion, a block-diagonal boundary
 representation, or periodic-boundary membership for the single-block states; in
 the source theorem these conditions are obtained from the boundary-condition

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -1,8 +1,9 @@
 
 \section{Spectral gap}\label{sec:spectral_gap}
 
-A frustration-free Hamiltonian is \emph{gapped} if the first excited
-eigenvalue is bounded away from zero uniformly in the chain length $N$.
+A frustration-free Hamiltonian is \emph{gapped} if the smallest nonzero
+eigenvalue, equivalently the gap above the ground space, is bounded away from
+zero uniformly in the chain length $N$.
 For MPS parent Hamiltonians, the martingale method of
 Fannes--Nachtergaele--Werner and
 Nachtergaele~\cite{Fannes1992Finitely, Nachtergaele1996Spectral}, as recalled
@@ -849,7 +850,7 @@ principal-angle estimate remains an explicit input.
         \sum_{\substack{j\ne i\\ \{i,j\}\text{ overlapping}}}c_{\{i,j\}}\le1
     \]
     for every $i$.
-    Then the smallest positive eigenvalue of $H$ satisfies
+    Then the smallest nonzero eigenvalue of $H$ satisfies
     $\lambda_{\min}^+(H) \ge \gamma$.
 \end{theorem}
 


### PR DESCRIPTION
## Summary

- Replace “first excited” / “smallest positive” spectral-gap language by the source phrase “smallest nonzero eigenvalue” / gap above the ground space.
- Replace “Friedrichs angle” prose by principal-angle / norm-compression wording while leaving declaration names unchanged.
- Describe `G_L` and block-sum objects as local spaces before passing to Hamiltonian kernels.
- State that the block-diagonal periodic theorem uses a basis of normal tensors of the initial tensor `A`.

## Source check

The wording follows arXiv:2011.12127 Section IV.C around the martingale method and Theorem IV.16, and PGVWC07 around the local spaces `\mathcal G_L^A`. No theorem statements, declarations, or proof terms change.

## Validation

- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`

Refs #190
Refs #460
Refs #952
Refs #2971