### PR TITLE
feat(mpdo): prove ancillary trace cptp

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -287,6 +287,7 @@ import TNLean.MPS.MPDO.VerticalCF
 import TNLean.MPS.MPDO.BiCFDerivation
 import TNLean.MPS.MPDO.ZCL
 import TNLean.MPS.MPDO.RFP
+import TNLean.MPS.MPDO.KrausCPTP
 import TNLean.MPS.MPDO.RFPViaTS
 import TNLean.MPS.MPDO.PRFP
 import TNLean.MPS.MPDO.LocalPurificationRFP

--- a/TNLean/MPS/MPDO/KrausCPTP.lean
+++ b/TNLean/MPS/MPDO/KrausCPTP.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.Defs
+
+/-!
+# Trace-preserving completely positive maps in Kraus form
+
+This file records the minimal finite-dimensional predicate for
+trace-preserving completely positive maps used in the MPDO RFP development.
+The map is represented by rectangular Kraus operators
+`Aᵢ : Matrix β α ℂ`, so that it may act between matrix algebras of different
+dimensions.
+
+## Main declarations
+
+* `IsKrausCPTP`: a trace-preserving completely positive map in rectangular
+  Kraus form.
+* `isKrausCPTP_id`: the identity map is trace-preserving completely positive.
+* `isKrausCPTP_comp`: composition preserves the trace-preserving completely
+  positive property.
+-/
+
+open scoped Matrix BigOperators
+
+/-- A **trace-preserving completely positive map** in Kraus form
+`S(X) = ∑ᵢ Aᵢ X Aᵢ†` with `∑ᵢ Aᵢ† Aᵢ = I`; rectangular Kraus operators
+`Aᵢ : β × α` allow different in/out dimensions. The Kraus form itself gives
+completely positive, and the resolution-of-identity condition is exactly trace
+preservation. arXiv:1606.00608 Definition 4.1 uses tp-CP maps on the physical
+indices. -/
+def IsKrausCPTP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
+    (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : Prop :=
+  ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
+    (∀ X, S X = ∑ i, A i * X * (A i)ᴴ) ∧ (∑ i, (A i)ᴴ * A i = (1 : Matrix α α ℂ))
+
+/-- The identity map is trace-preserving completely positive; the single Kraus
+operator is the identity matrix. -/
+theorem isKrausCPTP_id {α : Type*} [Fintype α] [DecidableEq α] :
+    IsKrausCPTP (LinearMap.id : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) := by
+  refine ⟨1, fun _ => 1, ?_, ?_⟩
+  · intro X
+    simp
+  · simp
+
+/-- Composition of trace-preserving completely positive maps is again
+trace-preserving completely positive. If `T` has Kraus operators `Bⱼ` and `S`
+has Kraus operators `Aᵢ`, then `S ∘ T` has Kraus operators `Aᵢ Bⱼ`, and the
+resolution of identity for the composite follows from those of `S` and `T`:
+∑ᵢⱼ (AᵢBⱼ)† (AᵢBⱼ) =
+∑ⱼ Bⱼ† (∑ᵢ Aᵢ† Aᵢ) Bⱼ = ∑ⱼ Bⱼ† Bⱼ = I. -/
+theorem isKrausCPTP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Fintype β]
+    [DecidableEq β] [Fintype γ] [DecidableEq γ]
+    {T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ}
+    {S : Matrix β β ℂ →ₗ[ℂ] Matrix γ γ ℂ}
+    (hT : IsKrausCPTP T) (hS : IsKrausCPTP S) : IsKrausCPTP (S ∘ₗ T) := by
+  obtain ⟨r, A, hA_form, hA_tp⟩ := hS
+  obtain ⟨s, B, hB_form, hB_tp⟩ := hT
+  refine ⟨r * s, fun k => A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2, ?_, ?_⟩
+  · intro X
+    rw [LinearMap.comp_apply, hB_form X, hA_form,
+      ← finProdFinEquiv.sum_comp (fun k => (A (finProdFinEquiv.symm k).1 *
+          B (finProdFinEquiv.symm k).2) * X *
+        (A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2)ᴴ)]
+    simp only [Equiv.symm_apply_apply, Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.conjTranspose_mul, Matrix.mul_assoc]
+  · rw [← finProdFinEquiv.sum_comp (fun k => (A (finProdFinEquiv.symm k).1 *
+        B (finProdFinEquiv.symm k).2)ᴴ *
+      (A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2))]
+    simp only [Equiv.symm_apply_apply, Fintype.sum_prod_type, Matrix.conjTranspose_mul]
+    rw [Finset.sum_comm, ← hB_tp]
+    refine Finset.sum_congr rfl (fun j _ => ?_)
+    have step : ∑ i : Fin r, (B j)ᴴ * (A i)ᴴ * (A i * B j)
+        = (B j)ᴴ * ((∑ i : Fin r, (A i)ᴴ * A i) * B j) := by
+      simp only [Matrix.sum_mul, Matrix.mul_sum, Matrix.mul_assoc]
+    rw [step, hA_tp, Matrix.one_mul]

--- a/TNLean/MPS/MPDO/PRFP.lean
+++ b/TNLean/MPS/MPDO/PRFP.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.MPDO.RFPViaTS
+import TNLean.MPS.MPDO.KrausCPTP
 import TNLean.MPS.RFP.Defs
 
 /-!
@@ -24,10 +24,10 @@ configurations.
 
 The source text immediately after Definition 4.4 observes that tracing the
 ancilla gives a trace-preserving completely positive map on the spin degrees of
-freedom. This additional structure is recorded separately as
-`IsPRFPWithTracePreservingSpinReduction`, so that the source-named predicate
-`IsPRFP` remains the literal Definition 4.4 statement. The theorem equating
-purification RFP with zero correlation length remains a separate open result.
+freedom. This structure is proved separately for the ancillary trace map, so
+that the source-named predicate `IsPRFP` remains the literal Definition 4.4
+statement. The theorem equating purification RFP with zero correlation length
+remains a separate open result.
 
 ## Main definitions
 
@@ -40,7 +40,7 @@ purification RFP with zero correlation length remains a separate open result.
 * `MPOTensor.HasPurificationRFPWitness`: the source purification-RFP witness.
 * `MPOTensor.IsPRFP`: the source purification-RFP predicate.
 * `MPOTensor.IsPRFPWithTracePreservingSpinReduction`: the PRFP predicate
-  together with the trace-preserving spin map.
+  viewed together with the proved trace-preserving spin reduction.
 
 ## References
 
@@ -113,6 +113,120 @@ condition of Definition 4.1. -/
 def HasTracePreservingSpinReduction (d dK : ℕ) : Prop :=
   IsKrausCPTP (ancillaryTraceMap d dK)
 
+/-- The Kraus operator projecting the spin--ancilla space onto the spin sector
+with fixed ancillary label `k`. This is the one-site Kraus family for the
+ancillary trace in arXiv:1606.00608, lines 761--764. -/
+private noncomputable def ancillaryTraceKraus (d dK : ℕ) (k : Fin dK) :
+    Matrix (Fin d) (Fin d × Fin dK) ℂ :=
+  Matrix.of fun i p => if i = p.1 ∧ k = p.2 then 1 else 0
+
+private lemma ancillaryTraceKraus_mul_apply (d dK : ℕ)
+    (X : Matrix (Fin d × Fin dK) (Fin d × Fin dK) ℂ)
+    (k : Fin dK) (i : Fin d) (q : Fin d × Fin dK) :
+    (ancillaryTraceKraus d dK k * X) i q = X (i, k) q := by
+  classical
+  rw [Matrix.mul_apply]
+  rw [Finset.sum_eq_single (i, k)]
+  · simp [ancillaryTraceKraus]
+  · rintro ⟨i', k'⟩ _ hne
+    have hnot : ¬ (i = i' ∧ k = k') := by
+      intro h
+      exact hne (Prod.ext h.1 h.2).symm
+    simp [ancillaryTraceKraus, hnot]
+  · intro hmem
+    simp at hmem
+
+private lemma ancillaryTraceKraus_mul_conjTranspose_apply (d dK : ℕ)
+    (X : Matrix (Fin d × Fin dK) (Fin d × Fin dK) ℂ)
+    (k : Fin dK) (i j : Fin d) :
+    (ancillaryTraceKraus d dK k * X * (ancillaryTraceKraus d dK k)ᴴ) i j =
+      X (i, k) (j, k) := by
+  classical
+  rw [Matrix.mul_apply]
+  rw [Finset.sum_eq_single (j, k)]
+  · rw [ancillaryTraceKraus_mul_apply]
+    simp [ancillaryTraceKraus, Matrix.conjTranspose_apply]
+  · rintro ⟨j', k'⟩ _ hne
+    have hnot : ¬ (j = j' ∧ k = k') := by
+      intro h
+      exact hne (Prod.ext h.1 h.2).symm
+    rw [ancillaryTraceKraus_mul_apply]
+    simp [ancillaryTraceKraus, Matrix.conjTranspose_apply, hnot]
+  · intro hmem
+    simp at hmem
+
+private lemma ancillaryTraceKraus_conjTranspose_mul_apply (d dK : ℕ)
+    (k : Fin dK) (p q : Fin d × Fin dK) :
+    ((ancillaryTraceKraus d dK k)ᴴ * ancillaryTraceKraus d dK k) p q =
+      if p.1 = q.1 ∧ k = p.2 ∧ k = q.2 then 1 else 0 := by
+  classical
+  rw [Matrix.mul_apply]
+  by_cases h : p.1 = q.1 ∧ k = p.2 ∧ k = q.2
+  · rw [Finset.sum_eq_single p.1]
+    · simp [ancillaryTraceKraus, Matrix.conjTranspose_apply, h]
+    · intro i _ hi
+      have hp : ¬ (i = p.1) := by
+        exact hi
+      have hleft : ¬ (i = p.1 ∧ k = p.2) := by
+        intro hi'
+        exact hp hi'.1
+      simp [ancillaryTraceKraus, Matrix.conjTranspose_apply, hleft]
+    · intro hmem
+      simp at hmem
+  · rw [if_neg h]
+    apply Finset.sum_eq_zero
+    intro i _
+    by_cases hip : i = p.1 ∧ k = p.2
+    · have hiq : ¬ (i = q.1 ∧ k = q.2) := by
+        intro hiq
+        exact h ⟨hip.1.symm.trans hiq.1, hip.2, hiq.2⟩
+      have hpq : p.1 = q.1 → ¬ p.2 = q.2 := by
+        intro hspin hanc
+        exact h ⟨hspin, hip.2, hip.2.trans hanc⟩
+      simpa [ancillaryTraceKraus, Matrix.conjTranspose_apply, hip] using hpq
+    · simp [ancillaryTraceKraus, Matrix.conjTranspose_apply, hip]
+
+/-- The ancillary trace is trace-preserving and completely positive. The Kraus
+operators are the fixed-ancilla projections from the spin--ancilla space onto
+the spin space, one for each ancillary label. This is the tpCPM obtained after
+tracing the ancillary index in arXiv:1606.00608, lines 761--764. -/
+theorem ancillaryTraceMap_isKrausCPTP (d dK : ℕ) :
+    IsKrausCPTP (ancillaryTraceMap d dK) := by
+  classical
+  refine ⟨dK, ancillaryTraceKraus d dK, ?_, ?_⟩
+  · intro X
+    ext i j
+    change (∑ k : Fin dK, X (i, k) (j, k)) =
+      (∑ k, ancillaryTraceKraus d dK k * X * (ancillaryTraceKraus d dK k)ᴴ) i j
+    rw [Matrix.sum_apply]
+    exact Finset.sum_congr rfl fun k _ =>
+      (ancillaryTraceKraus_mul_conjTranspose_apply d dK X k i j).symm
+  · ext p q
+    by_cases hpq : p = q
+    · subst q
+      rw [Matrix.sum_apply, Matrix.one_apply_eq]
+      rw [Finset.sum_eq_single p.2]
+      · simp [ancillaryTraceKraus_conjTranspose_mul_apply]
+      · intro k _ hk
+        simp [ancillaryTraceKraus_conjTranspose_mul_apply, hk]
+      · intro hmem
+        simp at hmem
+    · rw [Matrix.sum_apply, Matrix.one_apply_ne hpq]
+      apply Finset.sum_eq_zero
+      intro k _
+      have hnot : ¬ (p.1 = q.1 ∧ k = p.2 ∧ k = q.2) := by
+        intro h
+        apply hpq
+        exact Prod.ext h.1 (h.2.1.symm.trans h.2.2)
+      simp [ancillaryTraceKraus_conjTranspose_mul_apply, hnot]
+
+/-- The post-ancilla spin reduction is trace-preserving and completely positive
+for every ancillary dimension. This is the one-site tpCPM obtained by tracing
+ancillas in arXiv:1606.00608, lines 761--764. -/
+theorem hasTracePreservingSpinReduction (d dK : ℕ) :
+    HasTracePreservingSpinReduction d dK :=
+  ancillaryTraceMap_isKrausCPTP d dK
+
 /-- The purification-RFP witness from arXiv:1606.00608,
 Definition `def:Puri-RFP` (lines 756--764): there is a purifying spin-ancilla
 MPS tensor satisfying the global purification equation, and that purifying
@@ -127,17 +241,15 @@ purification-RFP witness. -/
 def IsPRFP (M : MPOTensor d D) : Prop :=
   HasPurificationRFPWitness M
 
-/-- Purification RFP together with the trace-preserving spin structure recorded
-after Definition `def:Puri-RFP` in arXiv:1606.00608, lines 761--764.
+/-- Purification RFP viewed together with the trace-preserving spin structure
+recorded after Definition `def:Puri-RFP` in arXiv:1606.00608, lines 761--764.
 
-This is the source purification-RFP predicate together with the specific
-trace-preserving completely positive map obtained by tracing the ancillary
-physical index. It is not the two-map mixed-state RFP condition of Definition
-4.1. -/
+The trace-preserving completely positive map is the ancillary trace map, and
+`hasTracePreservingSpinReduction` proves this structure for every ancillary
+dimension. Thus this predicate is the source purification-RFP predicate, not
+the two-map mixed-state RFP condition of Definition 4.1. -/
 def IsPRFPWithTracePreservingSpinReduction (M : MPOTensor d D) : Prop :=
-  ∃ (dK D' : ℕ) (A : Fin d → Fin dK → Matrix (Fin D') (Fin D') ℂ),
-    HasGlobalPurificationEquation M A ∧ MPSTensor.IsRFP (purificationTensor A) ∧
-      HasTracePreservingSpinReduction d dK
+  IsPRFP M
 
 /-- A purification RFP supplies the global purification-RFP witness. -/
 theorem IsPRFP.hasPurificationRFPWitness {M : MPOTensor d D}
@@ -148,17 +260,21 @@ theorem IsPRFP.hasPurificationRFPWitness {M : MPOTensor d D}
 purification-RFP predicate. -/
 theorem IsPRFPWithTracePreservingSpinReduction.isPRFP {M : MPOTensor d D}
     (h : IsPRFPWithTracePreservingSpinReduction M) : IsPRFP M :=
-  by
-  rcases h with ⟨dK, D', A, hglobal, hRFP, _htrace⟩
-  exact ⟨dK, D', A, hglobal, hRFP⟩
+  h
+
+/-- A purification RFP has the trace-preserving spin reduction recorded after
+arXiv:1606.00608, Definition `def:Puri-RFP`, lines 761--764. -/
+theorem IsPRFP.withTracePreservingSpinReduction {M : MPOTensor d D}
+    (h : IsPRFP M) : IsPRFPWithTracePreservingSpinReduction M :=
+  h
 
 /-- A purification RFP with trace-preserving spin reduction carries the
 post-ancilla tpCPM structure on the spin degrees of freedom. -/
 theorem IsPRFPWithTracePreservingSpinReduction.hasTracePreservingSpinReduction
     {M : MPOTensor d D} (h : IsPRFPWithTracePreservingSpinReduction M) :
-    ∃ dK : ℕ, HasTracePreservingSpinReduction d dK := by
-  rcases h with ⟨dK, _D', _A, _hglobal, _hRFP, htrace⟩
-  exact ⟨dK, htrace⟩
+  ∃ dK : ℕ, HasTracePreservingSpinReduction d dK := by
+  rcases h with ⟨dK, _D', _A, _hglobal, _hRFP⟩
+  exact ⟨dK, MPOTensor.hasTracePreservingSpinReduction d dK⟩
 
 /-- A purification-RFP witness contains a purifying tensor satisfying the global
 purification equation. -/

--- a/TNLean/MPS/MPDO/RFPViaTS.lean
+++ b/TNLean/MPS/MPDO/RFPViaTS.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.MPDO.Defs
+import TNLean.MPS.MPDO.KrausCPTP
 
 /-!
 # MPDO renormalization fixed point via trace-preserving CP maps (Definition 4.1)
@@ -36,8 +36,8 @@ the predicate.
 
 ## Main definitions
 
-* `IsKrausCPTP`: a trace-preserving completely positive map in rectangular Kraus
-  form.
+* `IsKrausCPTP`: the rectangular Kraus-form predicate for trace-preserving
+  completely positive maps used in Definition 4.1.
 * `MPOTensor.physClose1`, `MPOTensor.physClose2`: the one-site and two-site
   physical operators as linear maps in the virtual operator `X`.
 * `MPOTensor.IsRFPViaTS`: Definition 4.1, the tp-CP-map renormalization
@@ -50,56 +50,6 @@ the predicate.
 -/
 
 open scoped Matrix BigOperators
-
-/-- A **trace-preserving completely positive map** in Kraus form
-`S(X) = ∑ᵢ Aᵢ X Aᵢ†` with `∑ᵢ Aᵢ† Aᵢ = I`; rectangular Kraus operators
-`Aᵢ : β × α` allow different in/out dimensions. The Kraus form is automatically
-completely positive, and the resolution-of-identity condition is exactly trace
-preservation. arXiv:1606.00608 Definition 4.1 uses tp-CP maps on the physical
-indices. -/
-def IsKrausCPTP {α β : Type*} [Fintype α] [DecidableEq α] [Fintype β] [DecidableEq β]
-    (S : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ) : Prop :=
-  ∃ (r : ℕ) (A : Fin r → Matrix β α ℂ),
-    (∀ X, S X = ∑ i, A i * X * (A i)ᴴ) ∧ (∑ i, (A i)ᴴ * A i = (1 : Matrix α α ℂ))
-
-/-- The identity map is trace-preserving completely positive (the single Kraus
-operator is the identity matrix). -/
-theorem isKrausCPTP_id {α : Type*} [Fintype α] [DecidableEq α] :
-    IsKrausCPTP (LinearMap.id : Matrix α α ℂ →ₗ[ℂ] Matrix α α ℂ) := by
-  refine ⟨1, fun _ => 1, ?_, ?_⟩
-  · intro X; simp
-  · simp
-
-/-- **Composition of trace-preserving completely positive maps is again
-trace-preserving completely positive.** If `T` has Kraus operators `Bⱼ` and `S`
-has Kraus operators `Aᵢ`, then `S ∘ T` has Kraus operators `Aᵢ Bⱼ`, and the
-resolution of identity for the composite follows from those of `S` and `T`:
-∑ᵢⱼ (AᵢBⱼ)† (AᵢBⱼ) = ∑ⱼ Bⱼ† (∑ᵢ Aᵢ† Aᵢ) Bⱼ = ∑ⱼ Bⱼ† Bⱼ = I. -/
-theorem isKrausCPTP_comp {α β γ : Type*} [Fintype α] [DecidableEq α] [Fintype β]
-    [DecidableEq β] [Fintype γ] [DecidableEq γ]
-    {T : Matrix α α ℂ →ₗ[ℂ] Matrix β β ℂ} {S : Matrix β β ℂ →ₗ[ℂ] Matrix γ γ ℂ}
-    (hT : IsKrausCPTP T) (hS : IsKrausCPTP S) : IsKrausCPTP (S ∘ₗ T) := by
-  obtain ⟨r, A, hA_form, hA_tp⟩ := hS
-  obtain ⟨s, B, hB_form, hB_tp⟩ := hT
-  refine ⟨r * s, fun k => A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2, ?_, ?_⟩
-  · intro X
-    rw [LinearMap.comp_apply, hB_form X, hA_form,
-      ← finProdFinEquiv.sum_comp (fun k => (A (finProdFinEquiv.symm k).1 *
-          B (finProdFinEquiv.symm k).2) * X *
-        (A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2)ᴴ)]
-    simp only [Equiv.symm_apply_apply, Fintype.sum_prod_type]
-    refine Finset.sum_congr rfl fun i _ => ?_
-    simp only [Matrix.mul_sum, Matrix.sum_mul, Matrix.conjTranspose_mul, Matrix.mul_assoc]
-  · rw [← finProdFinEquiv.sum_comp (fun k => (A (finProdFinEquiv.symm k).1 *
-        B (finProdFinEquiv.symm k).2)ᴴ *
-      (A (finProdFinEquiv.symm k).1 * B (finProdFinEquiv.symm k).2))]
-    simp only [Equiv.symm_apply_apply, Fintype.sum_prod_type, Matrix.conjTranspose_mul]
-    rw [Finset.sum_comm, ← hB_tp]
-    refine Finset.sum_congr rfl (fun j _ => ?_)
-    have step : ∑ i : Fin r, (B j)ᴴ * (A i)ᴴ * (A i * B j)
-        = (B j)ᴴ * ((∑ i : Fin r, (A i)ᴴ * A i) * B j) := by
-      simp only [Matrix.sum_mul, Matrix.mul_sum, Matrix.mul_assoc]
-    rw [step, hA_tp, Matrix.one_mul]
 
 namespace MPOTensor
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_foundations.tex
@@ -158,6 +158,41 @@
     \cite[lines~751 and~761--764]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{theorem}[The ancillary trace is trace-preserving completely positive]
+    \label{thm:mpdo_ancillary_trace_map_is_kraus_cptp}
+    \lean{MPOTensor.ancillaryTraceMap_isKrausCPTP}
+    \leanok
+    \uses{def:mpdo_ancillary_trace_map, def:is_kraus_cptp}
+    For every ancillary dimension, the one-site ancillary trace map is
+    trace-preserving and completely positive.
+\end{theorem}
+\begin{proof}
+    \leanok
+    For each ancillary label \(k\), let \(V_k\) be the projection from the
+    spin--ancilla space onto the spin space with fixed ancillary label:
+    \[
+        (V_k)_{i,(j,\ell)}
+        =
+        \begin{cases}
+            1, & i=j\text{ and }k=\ell,\\
+            0, & \text{otherwise}.
+        \end{cases}
+    \]
+    Then
+    \[
+        (V_k X V_k^\dagger)_{ij}=X_{(i,k),(j,k)},
+    \]
+    so summing over \(k\) gives the ancillary trace. The identity resolution is
+    entrywise:
+    \[
+        \sum_k (V_k^\dagger V_k)_{(i,k'),(j,\ell')}
+        =
+        \delta_{ij}\delta_{k'\ell'} .
+    \]
+    Thus the operators \(V_k\) form a trace-preserving Kraus family for the
+    ancillary trace.
+\end{proof}
+
 \begin{definition}[Global purification equation]
     \label{def:mpdo_global_purification_equation}
     \lean{MPOTensor.HasGlobalPurificationEquation}
@@ -186,8 +221,8 @@
     \lean{MPOTensor.HasTracePreservingSpinReduction}
     \leanok
     \uses{def:mpdo_ancillary_trace_map, def:is_kraus_cptp}
-    The spin reduction obtained by tracing the ancillary index is required to
-    be a trace-preserving completely positive map:
+    The spin reduction obtained by tracing the ancillary index is
+    trace-preserving and completely positive when
     \[
         \operatorname{tr}_a
         \quad\text{is a tpCPM}.
@@ -195,6 +230,22 @@
     This is the structure described immediately after Definition~4.4 in
     \cite[lines~761--764]{Cirac2016MPDO_arXiv}.
 \end{definition}
+
+\begin{corollary}[Trace-preserving spin reduction of the ancillary trace]
+    \label{cor:mpdo_has_trace_preserving_spin_reduction}
+    \lean{MPOTensor.hasTracePreservingSpinReduction}
+    \leanok
+    \uses{def:mpdo_has_trace_preserving_spin_reduction,
+        thm:mpdo_ancillary_trace_map_is_kraus_cptp}
+    For every ancillary dimension, the spin reduction obtained by tracing the
+    ancillary index is trace-preserving and completely positive.
+\end{corollary}
+\begin{proof}
+    \leanok
+    This is exactly
+    Theorem~\ref{thm:mpdo_ancillary_trace_map_is_kraus_cptp}, unpacked through
+    Definition~\ref{def:mpdo_has_trace_preserving_spin_reduction}.
+\end{proof}
 
 \begin{definition}[Purification RFP witness]
     \label{def:mpdo_purification_rfp_witness}
@@ -236,13 +287,13 @@
     \label{def:mpdo_prfp_trace_preserving_spin_reduction}
     \lean{MPOTensor.IsPRFPWithTracePreservingSpinReduction}
     \leanok
-    \uses{def:mpdo_is_prfp, def:mpdo_has_trace_preserving_spin_reduction}
-    A purification RFP has trace-preserving spin reduction when, in addition,
-    the partial trace over the ancillary index gives the trace-preserving
-    completely positive map of
-    Definition~\ref{def:mpdo_has_trace_preserving_spin_reduction}. This records
+    \uses{def:mpdo_is_prfp, cor:mpdo_has_trace_preserving_spin_reduction}
+    A purification RFP is viewed together with trace-preserving spin reduction
+    by applying Corollary~\ref{cor:mpdo_has_trace_preserving_spin_reduction} to
+    the ancillary trace map appearing in its purification equation. This records
     the structure obtained after tracing the ancillary indices in
-    \cite[lines~761--764]{Cirac2016MPDO_arXiv}.
+    \cite[lines~761--764]{Cirac2016MPDO_arXiv}, without adding a separate
+    hypothesis to Definition~4.4.
 \end{definition}
 
 \begin{definition}[Local purification RFP condition]\label{def:is_local_purification_rfp}

--- a/docs/paper-gaps/cpsv16_purification_rfp_definition.tex
+++ b/docs/paper-gaps/cpsv16_purification_rfp_definition.tex
@@ -89,7 +89,10 @@ one-site tpCPM; it is not the two-map mixed-state RFP condition
 \leanid{MPOTensor.HasGlobalPurificationEquation}, the pure-state witness is
 \leanid{MPOTensor.HasPurificationRFPWitness}, and the source predicate is
 \leanid{MPOTensor.IsPRFP}. The ancillary-trace map is
-\leanid{MPOTensor.ancillaryTraceMap}; the corresponding tpCPM condition is
+\leanid{MPOTensor.ancillaryTraceMap}; its Kraus-form trace-preserving
+complete positivity is
+\leanid{MPOTensor.ancillaryTraceMap_isKrausCPTP}, and the corresponding
+spin-reduction condition is
 \leanid{MPOTensor.HasTracePreservingSpinReduction}. Only after the remaining
 theorem is proved should the theorem
 \[


### PR DESCRIPTION
## Summary

This PR proves that the one-site ancillary trace map used in the purification-RFP definition is trace-preserving and completely positive. The proof uses the fixed-ancilla projection Kraus operators
\[
  (V_k)_{i,(j,\ell)} = \delta_{ij}\delta_{k\ell},
\]
so that \((V_k X V_k^\dagger)_{ij} = X_{(i,k),(j,k)}\) and \(\sum_k V_k^\dagger V_k = I\).

It also moves the minimal rectangular Kraus-form CPTP predicate into `TNLean.MPS.MPDO.KrausCPTP`, so `PRFP.lean` no longer imports the mixed-state RFP module just for `IsKrausCPTP`. The source predicate `MPOTensor.IsPRFP` remains the faithful Definition 4.4 predicate; the trace-preserving spin reduction is now derived from `MPOTensor.ancillaryTraceMap_isKrausCPTP` rather than carried as an additional witness.

The blueprint and the purification-RFP paper-gap note are updated to record the new Kraus theorem and its spin-reduction corollary.

Closes #2963.

## Validation

- `lake build TNLean`
- `lake build TNLean.MPS.MPDO.KrausCPTP TNLean.MPS.MPDO.RFPViaTS TNLean.MPS.MPDO.PRFP`
- `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized MPDO formalization and documentation; the main API shift is collapsing `IsPRFPWithTracePreservingSpinReduction` to `IsPRFP`, which currently has no external callers beyond `PRFP.lean`.
> 
> **Overview**
> Adds **`TNLean.MPS.MPDO.KrausCPTP`** with the rectangular Kraus-form **`IsKrausCPTP`** predicate (moved out of **`RFPViaTS.lean`**, together with identity and composition lemmas) and wires it through the root import list. **`PRFP.lean`** now imports **`KrausCPTP`** instead of the mixed-state RFP module only to get that predicate.
> 
> **`ancillaryTraceMap_isKrausCPTP`** is proved in **`PRFP.lean`** using fixed-ancilla projection Kraus operators; **`hasTracePreservingSpinReduction`** follows. Trace-preserving spin reduction after Definition 4.4 is therefore **derived**, not an extra witness: **`IsPRFPWithTracePreservingSpinReduction`** is redefined as **`IsPRFP`**, with new equivalences and **`hasTracePreservingSpinReduction`** using the global proof.
> 
> Blueprint chapter 21 and **`cpsv16_purification_rfp_definition.tex`** document the Kraus theorem, corollary, and updated PRFP wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b97b7c016bd0ff025c44bb881ed3e98e62ac451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->