### PR TITLE
feat(algebra): add cyclic phase coboundary

### DIFF
--- a/TNLean/Algebra/FiniteCycleCoboundary.lean
+++ b/TNLean/Algebra/FiniteCycleCoboundary.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Analysis.Complex.Circle
 
 /-!
 # Coboundaries on a finite cycle
@@ -68,5 +69,55 @@ lemma exists_fin_succ_coboundary_of_prod_eq_one {n : ℕ}
             (Fin.partialProd ψ (Fin.last n) * κ (Fin.last n)) := by rw [hlast]
         _ = κ (Fin.last n) := by simp
     simp [φ, hlast']
+
+/-- A product-one family on a nonempty finite cycle is a cyclic coboundary.
+
+This is the same phase choice as `exists_fin_succ_coboundary_of_prod_eq_one`,
+rewritten in the cyclic notation used in arXiv:1708.00029, Appendix A, lines
+1093--1102: after choosing vertex phases `φ`, every edge phase satisfies
+`κ v = φ v * (φ (v + 1))⁻¹`. -/
+lemma exists_fin_cyclic_coboundary_of_prod_eq_one {m : ℕ} [NeZero m]
+    (κ : Fin m → G) (hprod : ∏ v : Fin m, κ v = 1) :
+    ∃ φ : Fin m → G, ∀ v : Fin m, κ v = φ v * (φ (v + 1))⁻¹ := by
+  rcases m with _ | n
+  · exact (NeZero.ne 0 rfl).elim
+  obtain ⟨φ, hsucc, hlast⟩ := exists_fin_succ_coboundary_of_prod_eq_one κ hprod
+  refine ⟨φ, ?_⟩
+  intro v
+  rcases Fin.eq_castSucc_or_eq_last v with ⟨w, rfl⟩ | rfl
+  · simpa using hsucc w
+  · have hlast_add : (Fin.last n + 1 : Fin (n + 1)) = 0 := by
+      ext
+      simp
+    simpa [hlast_add] using hlast
+
+/-- A product-one family of complex phases on a nonempty finite cycle is a
+cyclic coboundary by complex phases.
+
+This is the complex-scalar form of the phase choice in arXiv:1708.00029,
+Appendix A, lines 1093--1102.  If `κ_v` has unit modulus and `∏_v κ_v = 1`,
+then one may choose unit-modulus vertex phases `φ_v` such that
+`κ_v = φ_v · φ_{v+1}^{-1}` around the cycle. -/
+lemma exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one {m : ℕ} [NeZero m]
+    (κ : Fin m → ℂ) (hκ : ∀ v : Fin m, ‖κ v‖ = 1)
+    (hprod : ∏ v : Fin m, κ v = 1) :
+    ∃ φ : Fin m → ℂ,
+      (∀ v : Fin m, ‖φ v‖ = 1) ∧
+      ∀ v : Fin m, κ v = φ v * (φ (v + 1))⁻¹ := by
+  let κc : Fin m → Circle := fun v =>
+    ⟨κ v, by simpa [Submonoid.unitSphere] using hκ v⟩
+  have hprod_c : ∏ v : Fin m, κc v = 1 := by
+    apply Circle.ext
+    calc
+      ((∏ v : Fin m, κc v : Circle) : ℂ) = ∏ v : Fin m, (κc v : ℂ) := by
+        exact map_prod Circle.coeHom κc Finset.univ
+      _ = ∏ v : Fin m, κ v := by
+        simp [κc]
+      _ = 1 := hprod
+  obtain ⟨φc, hφc⟩ :=
+    exists_fin_cyclic_coboundary_of_prod_eq_one κc hprod_c
+  refine ⟨fun v => (φc v : ℂ), fun v => Circle.norm_coe (φc v), ?_⟩
+  intro v
+  exact congrArg (fun z : Circle => (z : ℂ)) (hφc v)
 
 end TNLean.Algebra

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -692,9 +692,11 @@ Appendix A lines 1023--1117:
 The available chain inputs are `decompositionMap` / `exists_rightInverse` in
 `MPS/Chain/OneSidedInverse.lean` (realizing Ω_u) and the two-site
 proportionality theorem `tensor_proportional` in `MPS/Chain/TensorEquality.lean`.
-The remaining mathematical input is the `m`-factor cyclic contraction *together
-with* the κ/θ/φ phase assembly that passes from `hBlockMatch` to a global
-`RepeatedBlocks` witness. See
+The finite-cycle phase choice in lines 1093--1102 is now isolated as
+`TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one`.
+Thus the remaining mathematical input is the `m`-factor cyclic contraction
+that produces the sector phases κ_v with `∏ v, κ_v = 1` and `‖κ_v‖ = 1`,
+after which the phase-coboundary lemma performs the κ/θ/φ telescoping. See
 docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
 private lemma repeatedBlocks_of_blockedSectorGaugePhase
     [NeZero D] (A B : MPSTensor d D)
@@ -732,9 +734,11 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     RepeatedBlocks A B := by
   -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
   -- contraction theorem built from `decompositionMap` (the Ω_u inverses) that,
-  -- together with the κ/θ/φ phase assembly (lines 1078--1117), upgrades the
-  -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one
-  -- global gauge. The available two-site theorem is `tensor_proportional`.
+  -- after producing product-one unit phases κ_v, uses
+  -- `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one`
+  -- for the κ/θ/φ telescoping (lines 1093--1102). This upgrades the per-sector
+  -- blocked gauge data in `hBlockMatch` to one global phase and one global
+  -- gauge. The available two-site theorem is `tensor_proportional`.
   sorry
 
 /-- **Per-site proportionality** (eq:thetaACprop, arXiv:1708.00029 lines

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -985,6 +985,8 @@ unconditional result.
 
 \begin{lemma}[Finite-cycle coboundary]\label{lem:finite_cycle_coboundary}
     \lean{TNLean.Algebra.exists_fin_succ_coboundary_of_prod_eq_one}
+    \lean{TNLean.Algebra.exists_fin_cyclic_coboundary_of_prod_eq_one}
+    \lean{TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one}
     \leanok
     \uses{}
     Let $G$ be a commutative group, and let
@@ -1001,6 +1003,10 @@ unconditional result.
     \[
         \kappa_n=\varphi_n\varphi_0^{-1}.
     \]
+    Equivalently, on a nonempty finite cyclic index set, a product-one family
+    satisfies $\kappa_k=\varphi_k\varphi_{k+1}^{-1}$ for every cyclic edge.
+    In particular, a product-one family of complex unit phases admits such a
+    choice with all $\varphi_k$ again of unit modulus.
 \end{lemma}
 
 \begin{proof}\leanok


### PR DESCRIPTION
## Summary

This PR adds two finite-cycle coboundary lemmas for the phase bookkeeping in arXiv:1708.00029, Appendix A, lines 1093--1102.

The existing lemma `exists_fin_succ_coboundary_of_prod_eq_one` distinguished the last edge of a cycle. The new `exists_fin_cyclic_coboundary_of_prod_eq_one` restates the same fact in cyclic notation: for a product-one family `κ : Fin m -> G`, one can choose `φ` with `κ v = φ v * (φ (v + 1))⁻¹` for every sector. The complex specialization `exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one` additionally preserves unit modulus of the chosen vertex phases.

The Case 3 placeholder documentation now points to this phase-coboundary lemma explicitly, so the remaining #873 gap is narrowed to the m-factor Ω-contraction producing product-one unit phases. This PR does not claim to close the full contraction argument.

## Validation

- `lake env lean TNLean/Algebra/FiniteCycleCoboundary.lean`
- `lake build TNLean.Algebra.FiniteCycleCoboundary`
- `lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean` (succeeds with the existing tracked `sorry` warning)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `git diff --check`

Refs #873.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure algebra on a small module plus documentation; no changes to proved MPS logic beyond comments, and the Case 3 `sorry` remains.
> 
> **Overview**
> Adds **finite-cycle coboundary** lemmas in `TNLean.Algebra.FiniteCycleCoboundary` for the arXiv:1708.00029 Appendix A phase bookkeeping (lines 1093–1102).
> 
> **`exists_fin_cyclic_coboundary_of_prod_eq_one`** restates the existing succ/last coboundary in uniform cyclic form: from `∏ κ = 1` on `Fin m`, choose `φ` with `κ v = φ v * (φ (v + 1))⁻¹` for every sector. **`exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one`** is the ℂ specialization: when each `κ v` has unit modulus, the witness `φ` can also be chosen with `‖φ v‖ = 1`, via a `Circle` lift and `map_prod` on `Circle.coeHom`.
> 
> Case 3 placeholder comments in `MPS/Periodic/Overlap/Case3.lean` now cite the complex unit lemma for κ/θ/φ telescoping and state that the remaining #873 gap is the **m-factor cyclic contraction** producing product-one unit phases—not the phase choice itself. The blueprint lemma `lem:finite_cycle_coboundary` links the two new Lean names and notes the cyclic and unit-modulus corollaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60a11c5ca6f17b1b674ac1bea6db388ea03d7b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->