### PR TITLE
feat(parent): add anticommutator martingale reduction

### DIFF
--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -453,6 +453,53 @@ theorem quadraticForm_sum_projections_of_anticommutator_rowCol {γ : ℝ} (hγle
         add_le_add le_rfl hCrossSum
     _ = (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := hHH.symm
 
+/-- Finite-overlap anticommutator reduction for symmetric projections.
+
+Choose the coefficient \(c_{ij}=1/m\) on interacting off-diagonal pairs and
+\(c_{ij}=0\) otherwise. Row and column cardinality bounds by \(m\) make these
+coefficients summable. If noninteracting pairs have non-negative
+anticommutator quadratic form, and interacting pairs satisfy the source
+anticommutator estimate with coefficient \(1/m\), then the sum satisfies
+\(H² ≥ γH\) as a quadratic form. -/
+theorem quadraticForm_sum_projections_of_finite_overlap_anticommutator
+    {γ : ℝ} (hγle : γ ≤ 1)
+    (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
+    (overlaps : ι → ι → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hRowCard : ∀ i,
+      ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hColCard : ∀ j,
+      ((Finset.univ.erase j).filter (fun i => overlaps i j)).card ≤ m)
+    (hDisjointAnti : ∀ i j, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : E, 0 ≤
+        (⟪P i v, P j v⟫_ℂ).re + (⟪P j v, P i v⟫_ℂ).re)
+    (hAnti : ∀ i j, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : E,
+        - (1 - γ) * ((m : ℝ)⁻¹) *
+            ((⟪P i v, v⟫_ℂ).re + (⟪P j v, v⟫_ℂ).re) ≤
+          (⟪P i v, P j v⟫_ℂ).re + (⟪P j v, P i v⟫_ℂ).re) :
+    ∀ v : E,
+      γ * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤
+        (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := by
+  classical
+  let c : ι → ι → ℝ := fun i j => if overlaps i j then ((m : ℝ)⁻¹) else 0
+  have hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1 := by
+    intro i
+    simpa [c] using indicator_row_sum_le_one_of_card_le overlaps hm hRowCard i
+  have hCol : ∀ j, (∑ i ∈ Finset.univ.erase j, c i j) ≤ 1 := by
+    intro j
+    simpa [c] using
+      indicator_row_sum_le_one_of_card_le (fun j i => overlaps i j) hm hColCard j
+  have hAntiAll : ∀ i j, j ∈ Finset.univ.erase i → ∀ v : E,
+      -(1 - γ) * c i j *
+          ((⟪P i v, v⟫_ℂ).re + (⟪P j v, v⟫_ℂ).re) ≤
+        (⟪P i v, P j v⟫_ℂ).re + (⟪P j v, P i v⟫_ℂ).re := by
+    intro i j hij v
+    by_cases hoverlap : overlaps i j
+    · simpa [c, hoverlap] using hAnti i j hij hoverlap v
+    · simpa [c, hoverlap] using hDisjointAnti i j hij hoverlap v
+  exact quadraticForm_sum_projections_of_anticommutator_rowCol hγle P hP c
+    hRow hCol hAntiAll
+
 /-- Finite-overlap Friedrichs conditions for a family of symmetric projections.
 
 Assume that each row has at most `m` interacting off-diagonal entries.  On an

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -201,6 +201,136 @@ theorem crossTerm_sum_bound_of_ordered_rowSum {γ : ℝ} (hγle : γ ≤ 1)
             intro j hj
             exact hCross i j hj
 
+/-- Anticommutator bounds imply the aggregate off-diagonal bound used in the
+martingale method, once the corresponding coefficient-weighted diagonal sum is
+controlled.
+
+Here `q i` is the nonnegative diagonal quadratic form of the `i`-th projection,
+`cross i j` is the ordered real cross term, and `c i j` is a coefficient matrix
+whose weighted diagonal contribution is at most twice the total diagonal form.
+The hypothesis `hAnti` is the real-valued form of the source martingale condition
+`P_i P_j + P_j P_i ≥ -(1 - γ)c_{ij}(P_i + P_j)`, after evaluating on a vector. -/
+theorem crossTerm_sum_bound_of_anticommutator_coeffSum {γ : ℝ} (hγle : γ ≤ 1)
+    (q : ι → ℝ) (cross c : ι → ι → ℝ)
+    (hCoeff : (∑ i, ∑ j ∈ Finset.univ.erase i, c i j * (q i + q j)) ≤
+      2 * ∑ i, q i)
+    (hCrossSymm : ∀ i j, cross j i = cross i j)
+    (hAnti : ∀ i j, j ∈ Finset.univ.erase i →
+      -(1 - γ) * c i j * (q i + q j) ≤ cross i j + cross j i) :
+    -(1 - γ) * (∑ i, q i) ≤
+      ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j := by
+  let coeffSum : ℝ := ∑ i, ∑ j ∈ Finset.univ.erase i, c i j * (q i + q j)
+  let crossSum : ℝ := ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j
+  have hnonneg : 0 ≤ 1 - γ := sub_nonneg.mpr hγle
+  have hCoeffNeg :
+      -(1 - γ) * (2 * ∑ i, q i) ≤ -(1 - γ) * coeffSum := by
+    have hmul : (1 - γ) * coeffSum ≤ (1 - γ) * (2 * ∑ i, q i) :=
+      mul_le_mul_of_nonneg_left hCoeff hnonneg
+    calc
+      -(1 - γ) * (2 * ∑ i, q i) = -((1 - γ) * (2 * ∑ i, q i)) := by ring
+      _ ≤ -((1 - γ) * coeffSum) := neg_le_neg hmul
+      _ = -(1 - γ) * coeffSum := by ring
+  have hAntiSum : -(1 - γ) * coeffSum ≤ 2 * crossSum := by
+    calc
+      -(1 - γ) * coeffSum =
+          ∑ i, ∑ j ∈ Finset.univ.erase i, -(1 - γ) * c i j * (q i + q j) := by
+            change -(1 - γ) *
+                (∑ i, ∑ j ∈ Finset.univ.erase i, c i j * (q i + q j)) =
+              ∑ i, ∑ j ∈ Finset.univ.erase i, -(1 - γ) * c i j * (q i + q j)
+            rw [Finset.mul_sum]
+            refine Finset.sum_congr rfl ?_
+            intro i _
+            rw [Finset.mul_sum]
+            refine Finset.sum_congr rfl ?_
+            intro j _hj
+            ring
+      _ ≤ ∑ i, ∑ j ∈ Finset.univ.erase i, (cross i j + cross j i) := by
+            refine Finset.sum_le_sum ?_
+            intro i _
+            refine Finset.sum_le_sum ?_
+            intro j hj
+            exact hAnti i j hj
+      _ = ∑ i, ∑ j ∈ Finset.univ.erase i, (cross i j + cross i j) := by
+            refine Finset.sum_congr rfl ?_
+            intro i _
+            refine Finset.sum_congr rfl ?_
+            intro j _hj
+            rw [hCrossSymm i j]
+      _ = 2 * crossSum := by
+            simp [crossSum, two_mul, Finset.sum_add_distrib]
+  have htwice :
+      2 * (-(1 - γ) * (∑ i, q i)) ≤ 2 * crossSum := by
+    calc
+      2 * (-(1 - γ) * (∑ i, q i)) = -(1 - γ) * (2 * ∑ i, q i) := by ring
+      _ ≤ -(1 - γ) * coeffSum := hCoeffNeg
+      _ ≤ 2 * crossSum := hAntiSum
+  nlinarith [htwice]
+
+/-- Row- and column-summable anticommutator bounds imply the aggregate
+off-diagonal bound used in the martingale method.
+
+This is the row-sum form of the source martingale estimate. The column condition
+is automatic in the usual symmetric-coefficient case, but it is stated separately
+so the lemma does not require a symmetry assumption on `c`. -/
+theorem crossTerm_sum_bound_of_anticommutator_rowCol {γ : ℝ} (hγle : γ ≤ 1)
+    (q : ι → ℝ) (cross c : ι → ι → ℝ)
+    (hq_nonneg : ∀ i, 0 ≤ q i)
+    (hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
+    (hCol : ∀ j, (∑ i ∈ Finset.univ.erase j, c i j) ≤ 1)
+    (hCrossSymm : ∀ i j, cross j i = cross i j)
+    (hAnti : ∀ i j, j ∈ Finset.univ.erase i →
+      -(1 - γ) * c i j * (q i + q j) ≤ cross i j + cross j i) :
+    -(1 - γ) * (∑ i, q i) ≤
+      ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j := by
+  refine crossTerm_sum_bound_of_anticommutator_coeffSum hγle q cross c ?_
+    hCrossSymm hAnti
+  let rowPart : ℝ := ∑ i, ∑ j ∈ Finset.univ.erase i, c i j * q i
+  let colPart : ℝ := ∑ i, ∑ j ∈ Finset.univ.erase i, c i j * q j
+  have hRowWeighted : rowPart ≤ ∑ i, q i := by
+    refine Finset.sum_le_sum ?_
+    intro i _
+    calc
+      (∑ j ∈ Finset.univ.erase i, c i j * q i) =
+          (∑ j ∈ Finset.univ.erase i, c i j) * q i := by
+            rw [← Finset.sum_mul]
+      _ ≤ 1 * q i := mul_le_mul_of_nonneg_right (hRow i) (hq_nonneg i)
+      _ = q i := by ring
+  have hColWeighted : (∑ j, ∑ i ∈ Finset.univ.erase j, c i j * q j) ≤ ∑ j, q j := by
+    refine Finset.sum_le_sum ?_
+    intro j _
+    calc
+      (∑ i ∈ Finset.univ.erase j, c i j * q j) =
+          (∑ i ∈ Finset.univ.erase j, c i j) * q j := by
+            rw [← Finset.sum_mul]
+      _ ≤ 1 * q j := mul_le_mul_of_nonneg_right (hCol j) (hq_nonneg j)
+      _ = q j := by ring
+  have hColSwap : colPart = ∑ j, ∑ i ∈ Finset.univ.erase j, c i j * q j := by
+    let f : ι → ι → ℝ := fun i j => c i j * q j
+    have hsplit₁ := sum_sum_eq_diag_add_offdiag (fun i j => f i j)
+    have hsplit₂ := sum_sum_eq_diag_add_offdiag (fun j i => f i j)
+    have htotal : (∑ i, ∑ j, f i j) = ∑ j, ∑ i, f i j := by
+      rw [Finset.sum_comm]
+    have hadd :
+        (∑ i, f i i) + (∑ i, ∑ j ∈ Finset.univ.erase i, f i j) =
+          (∑ i, f i i) + (∑ j, ∑ i ∈ Finset.univ.erase j, f i j) := by
+      calc
+        (∑ i, f i i) + (∑ i, ∑ j ∈ Finset.univ.erase i, f i j) =
+            ∑ i, ∑ j, f i j := hsplit₁.symm
+        _ = ∑ j, ∑ i, f i j := htotal
+        _ = (∑ j, f j j) + (∑ j, ∑ i ∈ Finset.univ.erase j, f i j) := hsplit₂
+        _ = (∑ i, f i i) + (∑ j, ∑ i ∈ Finset.univ.erase j, f i j) := rfl
+    change (∑ i, ∑ j ∈ Finset.univ.erase i, f i j) =
+      ∑ j, ∑ i ∈ Finset.univ.erase j, f i j
+    exact add_left_cancel hadd
+  calc
+    (∑ i, ∑ j ∈ Finset.univ.erase i, c i j * (q i + q j)) =
+        rowPart + colPart := by
+          simp [rowPart, colPart, mul_add, Finset.sum_add_distrib]
+    _ ≤ (∑ i, q i) + ∑ j, q j := add_le_add hRowWeighted (by
+          rw [hColSwap]
+          exact hColWeighted)
+    _ = 2 * ∑ i, q i := by ring
+
 private theorem indicator_row_sum_le_one_of_card_le (overlaps : ι → ι → Prop)
     [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
     (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
@@ -250,6 +380,58 @@ theorem quadraticForm_sum_projections_of_ordered_rowSum {γ : ℝ} (hγle : γ �
       ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j :=
     crossTerm_sum_bound_of_ordered_rowSum hγle q cross c hq_nonneg hRow
       (fun i j hj => by simpa [q, cross] using hCross i j hj v)
+  have hDiag : (∑ i, cross i i) = ∑ i, q i := by
+    refine Finset.sum_congr rfl ?_
+    intro i _
+    exact (hP i).re_inner_apply_apply_self v
+  have hSplit := sum_sum_eq_diag_add_offdiag (fun i j => cross i j)
+  have hHq : (⟪(∑ i, P i) v, v⟫_ℂ).re = ∑ i, q i := by
+    change RCLike.re (⟪(∑ i, P i) v, v⟫_ℂ) = ∑ i, q i
+    simpa [q] using re_inner_sum_apply_left P v
+  have hHH : (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re =
+      ∑ i, q i + ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j := by
+    change RCLike.re (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ) =
+      ∑ i, q i + ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j
+    rw [re_inner_sum_apply_apply P v, hSplit, hDiag]
+  calc
+    γ * (⟪(∑ i, P i) v, v⟫_ℂ).re
+        = γ * (∑ i, q i) := by rw [hHq]
+    _ = (∑ i, q i) + (-(1 - γ) * (∑ i, q i)) := by ring
+    _ ≤ (∑ i, q i) + ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j :=
+        add_le_add le_rfl hCrossSum
+    _ = (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := hHH.symm
+
+/-- If the anticommutator forms of a finite family of symmetric projections
+satisfy row- and column-summable bounds, then the sum satisfies
+`H² ≥ γ H` as a quadratic form.
+
+This is the source martingale condition in quadratic-form language:
+`P_i P_j + P_j P_i ≥ -(1 - γ)c_{ij}(P_i + P_j)` on off-diagonal pairs, together
+with row and column sums bounded by one. -/
+theorem quadraticForm_sum_projections_of_anticommutator_rowCol {γ : ℝ} (hγle : γ ≤ 1)
+    (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
+    (c : ι → ι → ℝ)
+    (hRow : ∀ i, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
+    (hCol : ∀ j, (∑ i ∈ Finset.univ.erase j, c i j) ≤ 1)
+    (hAnti : ∀ i j, j ∈ Finset.univ.erase i → ∀ v : E,
+      -(1 - γ) * c i j *
+          ((⟪P i v, v⟫_ℂ).re + (⟪P j v, v⟫_ℂ).re) ≤
+        (⟪P i v, P j v⟫_ℂ).re + (⟪P j v, P i v⟫_ℂ).re) :
+    ∀ v : E,
+      γ * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤
+        (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := by
+  intro v
+  let q : ι → ℝ := fun i => RCLike.re (⟪P i v, v⟫_ℂ)
+  let cross : ι → ι → ℝ := fun i j => RCLike.re (⟪P i v, P j v⟫_ℂ)
+  have hq_nonneg : ∀ i, 0 ≤ q i := fun i => (hP i).re_inner_nonneg v
+  have hCrossSymm : ∀ i j, cross j i = cross i j := by
+    intro i j
+    simpa [cross] using (inner_re_symm (𝕜 := ℂ) (P i v) (P j v)).symm
+  have hCrossSum : -(1 - γ) * (∑ i, q i) ≤
+      ∑ i, ∑ j ∈ Finset.univ.erase i, cross i j :=
+    crossTerm_sum_bound_of_anticommutator_rowCol hγle q cross c hq_nonneg
+      hRow hCol hCrossSymm (fun i j hj => by
+        simpa [q, cross] using hAnti i j hj v)
   have hDiag : (∑ i, cross i i) = ∑ i, q i := by
     refine Finset.sum_congr rfl ?_
     intro i _

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -249,6 +249,15 @@ row-cardinality estimates, the diagonal term j = i is excluded. -/
 def cyclicWindowsOverlap (N L : ℕ) (i j : Fin N) : Prop :=
   ∃ k : Fin N, k ∈ cyclicWindowSupport N L i ∧ k ∈ cyclicWindowSupport N L j
 
+/-- Cyclic-window overlap is symmetric. -/
+theorem cyclicWindowsOverlap_comm (N L : ℕ) (i j : Fin N) :
+    cyclicWindowsOverlap N L i j ↔ cyclicWindowsOverlap N L j i := by
+  constructor
+  · rintro ⟨k, hki, hkj⟩
+    exact ⟨k, hkj, hki⟩
+  · rintro ⟨k, hkj, hki⟩
+    exact ⟨k, hki, hkj⟩
+
 /-- The cyclic-window overlap relation is decidable on a finite chain. -/
 instance cyclicWindowsOverlap_decidableRel (N L : ℕ) :
     DecidableRel (cyclicWindowsOverlap N L) := by

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -73,7 +73,7 @@ theorem parentHamiltonianES_norm_bound_of_quadratic_form
 uniform quadratic-form estimate with constant \(1 / (4 * L)\).
 
 Thus the remaining MPS-specific content is precisely to prove the hypothesis
-`hQuad` from the principal-angle / anti-commutator estimate and the finite
+`hQuad` from the principal-angle / anticommutator estimate and the finite
 row-sum bound; the positivity, kernel transport, and spectral-theorem conversion
 are already available here. -/
 theorem parentHamiltonianES_gap_bound_of_quadratic_form
@@ -244,6 +244,101 @@ theorem parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds
     nlinarith [hLge_one]
   exact parentHamiltonianES_quadratic_form_of_anticommutator_local_term_bounds
     A L N hγle (c N) (hRow N hLN) (hCol N hLN) (hAnti N hLN) v
+
+/-- Fixed-chain martingale quadratic-form estimate from a finite-overlap
+anticommutator estimate.
+
+This version chooses coefficient \(1/m\) on the marked overlapping pairs and
+\(0\) otherwise. It is the finite-overlap specialization of the source
+anticommutator condition
+\[
+  h_i h_j+h_j h_i\ge -(1-\gamma)m^{-1}(h_i+h_j).
+\]
+The row and column cardinality hypotheses make the coefficient sums at most
+one; non-overlapping pairs are handled by non-negativity of the corresponding
+anticommutator quadratic form. -/
+theorem parentHamiltonianES_quadratic_form_of_finite_overlap_anticommutator
+    (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
+    (overlaps : Fin N → Fin N → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hRowCard : ∀ i : Fin N,
+      ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hColCard : ∀ j : Fin N,
+      ((Finset.univ.erase j).filter (fun i => overlaps i j)).card ≤ m)
+    (hDisjointAnti : ∀ i j : Fin N, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+          (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re)
+    (hAnti : ∀ i j : Fin N, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        - (1 - γ) * ((m : ℝ)⁻¹) *
+            ((⟪localTermES A L i v, v⟫_ℂ).re +
+              (⟪localTermES A L j v, v⟫_ℂ).re) ≤
+          (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+            (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re) :
+    ∀ v : EuclideanSpace ℂ (Cfg d N),
+      γ * (⟪parentHamiltonianES A L N v, v⟫_ℂ).re ≤
+        (⟪parentHamiltonianES A L N v,
+          parentHamiltonianES A L N v⟫_ℂ).re := by
+  intro v
+  simpa [parentHamiltonianES_eq_sum_localTermES A L N] using
+    (ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_anticommutator
+      (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
+      (fun i : Fin N => localTermES A L i)
+      (fun i : Fin N => localTermES_isSymmetricProjection A L i) overlaps hm
+      hRowCard hColCard hDisjointAnti hAnti v)
+
+/-- Uniform explicit gap-bound reduction from a finite-overlap anticommutator
+martingale estimate.
+
+For parent-Hamiltonian windows of length \(L\), the finite-row coefficient is
+\(m=2(L-1)\). If every admissible chain has row and column overlap cardinality
+bounded by this value, non-overlapping pairs have non-negative anticommutator
+quadratic form, and overlapping pairs satisfy the source anticommutator estimate
+with coefficient \(1/m\), then the explicit lower bound with constant \(1/(4L)\)
+follows. -/
+theorem parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (overlaps : ∀ N : ℕ, Fin N → Fin N → Prop)
+    [∀ N : ℕ, DecidableRel (overlaps N)]
+    (hRowCard : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i : Fin N),
+      ((Finset.univ.erase i).filter (fun j => overlaps N i j)).card ≤ 2 * (L - 1))
+    (hColCard : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (j : Fin N),
+      ((Finset.univ.erase j).filter (fun i => overlaps N i j)).card ≤ 2 * (L - 1))
+    (hDisjointAnti : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → ¬ overlaps N i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+            (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re)
+    (hAnti : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → overlaps N i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹) *
+              ((⟪localTermES A L i v, v⟫_ℂ).re +
+                (⟪localTermES A L j v, v⟫_ℂ).re) ≤
+            (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+              (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
+  intro N hLN v
+  have hLpos : (0 : ℝ) < (L : ℝ) := by
+    exact_mod_cast Nat.zero_lt_of_lt hL
+  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
+    exact_mod_cast Nat.le_of_lt hL
+  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
+    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
+    rw [div_le_iff₀ hden]
+    nlinarith [hLge_one]
+  have hm : 0 < 2 * (L - 1) :=
+    Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
+  exact parentHamiltonianES_quadratic_form_of_finite_overlap_anticommutator
+    A L N hγle (overlaps N) hm (hRowCard N hLN) (hColCard N hLN)
+    (hDisjointAnti N hLN) (hAnti N hLN) v
 
 /-- Fixed-chain martingale quadratic-form estimate from finite-overlap
 principal-angle hypotheses.
@@ -449,6 +544,61 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
   exact parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs A L hL hFriedrichs
+
+/-- Uniform explicit gap-bound reduction from the cyclic-window anticommutator
+martingale estimate.
+
+For cyclic windows with \(N ≥ 2L\), the overlap relation has at most
+\(2(L-1)\) off-diagonal neighbours in each row and column. Hence the remaining
+analytic input can be stated directly in the source anticommutator form on
+overlapping pairs:
+\[
+  h_i h_j+h_jh_i\ge
+  -\Bigl(1-\frac{1}{4L}\Bigr)\frac{1}{2(L-1)}(h_i+h_j).
+\]
+Non-overlapping pairs are handled by the established disjoint-window positivity. -/
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (hAnti : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹) *
+              ((⟪localTermES A L i v, v⟫_ℂ).re +
+                (⟪localTermES A L j v, v⟫_ℂ).re) ≤
+            (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+              (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  refine parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator A L hL
+    (fun N => cyclicWindowsOverlap N L) ?_ ?_ ?_ hAnti
+  · intro N hLN i
+    exact cyclicWindowsOverlap_card_le hLN hL i
+  · intro N hLN j
+    have hset :
+        ((Finset.univ.erase j).filter (fun i => cyclicWindowsOverlap N L i j)) =
+          ((Finset.univ.erase j).filter (fun i => cyclicWindowsOverlap N L j i)) := by
+      ext i
+      simp only [Finset.mem_filter, Finset.mem_erase, Finset.mem_univ, and_true]
+      rw [cyclicWindowsOverlap_comm N L i j]
+    rw [hset]
+    exact cyclicWindowsOverlap_card_le hLN hL j
+  · intro N hLN i j _hij hnot v
+    have hnonneg₁ :
+        0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re :=
+      localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A (by omega) hnot v
+    have hnot_symm : ¬ cyclicWindowsOverlap N L j i := by
+      intro hji
+      exact hnot ((cyclicWindowsOverlap_comm N L i j).mpr hji)
+    have hnonneg₂ :
+        0 ≤ (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re :=
+      localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A (by omega)
+        hnot_symm v
+    linarith
 
 /-- Uniform explicit gap-bound reduction from a norm-compression form of the
 overlapping-window Friedrichs estimate.

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -129,6 +129,41 @@ theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
       (fun i : Fin N => localTermES A L i)
       (fun i : Fin N => localTermES_isSymmetricProjection A L i) c hRow hCross v)
 
+/-- Fixed-chain martingale quadratic-form estimate from source anticommutator
+row bounds.
+
+arXiv:2011.12127, Section IV.C, equation \(4:\mathrm{martingale}\text{-}2\),
+uses the local estimate
+\[
+  h_i h_j+h_j h_i \ge -c_{ij}(1-\gamma)(h_i+h_j)
+\]
+with row-summable coefficients. This theorem is the Euclidean-space
+parent-Hamiltonian instantiation of that anticommutator form. The column-sum
+hypothesis is stated separately; it follows from the row-sum condition when the
+coefficient matrix is symmetric. -/
+theorem parentHamiltonianES_quadratic_form_of_anticommutator_local_term_bounds
+    (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
+    (c : Fin N → Fin N → ℝ)
+    (hRow : ∀ i : Fin N, (∑ j ∈ Finset.univ.erase i, c i j) ≤ 1)
+    (hCol : ∀ j : Fin N, (∑ i ∈ Finset.univ.erase j, c i j) ≤ 1)
+    (hAnti : ∀ i j : Fin N, j ∈ Finset.univ.erase i →
+      ∀ v : EuclideanSpace ℂ (Cfg d N),
+        - (1 - γ) * c i j *
+            ((⟪localTermES A L i v, v⟫_ℂ).re +
+              (⟪localTermES A L j v, v⟫_ℂ).re) ≤
+          (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+            (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re) :
+    ∀ v : EuclideanSpace ℂ (Cfg d N),
+      γ * (⟪parentHamiltonianES A L N v, v⟫_ℂ).re ≤
+        (⟪parentHamiltonianES A L N v,
+          parentHamiltonianES A L N v⟫_ℂ).re := by
+  intro v
+  simpa [parentHamiltonianES_eq_sum_localTermES A L N] using
+    (ProjectionGeometry.quadraticForm_sum_projections_of_anticommutator_rowCol
+      (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
+      (fun i : Fin N => localTermES A L i)
+      (fun i : Fin N => localTermES_isSymmetricProjection A L i) c hRow hCol hAnti v)
+
 /-- Uniform explicit gap-bound reduction from ordered local cross-term row
 bounds.
 
@@ -166,6 +201,49 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
     nlinarith [hLge_one]
   exact parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
     A L N hγle (c N) (hRow N hLN) (hCross N hLN) v
+
+/-- Uniform explicit gap-bound reduction from source anticommutator row bounds.
+
+arXiv:2011.12127, Section IV.C, equation \(4:\mathrm{martingale}\text{-}2\),
+states the martingale condition in the anticommutator form
+\[
+  h_i h_j+h_jh_i\ge -c_{ij}(1-\gamma)(h_i+h_j).
+\]
+For the explicit choice \(\gamma=1/(4L)\), this theorem converts that condition,
+with row and column coefficient sums bounded by one for every finite chain, into
+the same spectral-gap lower bound as the ordered-cross-term reduction. -/
+theorem parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (c : ∀ N : ℕ, Fin N → Fin N → ℝ)
+    (hRow : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i : Fin N),
+      (∑ j ∈ Finset.univ.erase i, c N i j) ≤ 1)
+    (hCol : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (j : Fin N),
+      (∑ i ∈ Finset.univ.erase j, c N i j) ≤ 1)
+    (hAnti : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → ∀ v : EuclideanSpace ℂ (Cfg d N),
+        - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) * c N i j *
+            ((⟪localTermES A L i v, v⟫_ℂ).re +
+              (⟪localTermES A L j v, v⟫_ℂ).re) ≤
+          (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+            (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  refine parentHamiltonianES_gap_bound_of_quadratic_form A L hL ?_
+  intro N hLN v
+  have hLpos : (0 : ℝ) < (L : ℝ) := by
+    exact_mod_cast Nat.zero_lt_of_lt hL
+  have hLge_one : (1 : ℝ) ≤ (L : ℝ) := by
+    exact_mod_cast Nat.le_of_lt hL
+  have hγle : ((1 : ℝ) / (4 * (L : ℝ))) ≤ 1 := by
+    have hden : 0 < 4 * (L : ℝ) := mul_pos (by norm_num) hLpos
+    rw [div_le_iff₀ hden]
+    nlinarith [hLge_one]
+  exact parentHamiltonianES_quadratic_form_of_anticommutator_local_term_bounds
+    A L N hγle (c N) (hRow N hLN) (hCol N hLN) (hAnti N hLN) v
 
 /-- Fixed-chain martingale quadratic-form estimate from finite-overlap
 principal-angle hypotheses.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -26,9 +26,10 @@ When the length-two local terms commute, the construction records the
 zero-energy part of the condition that $V^{(N)}(A)$ is a ground state of a
 nearest-neighbor commuting parent Hamiltonian in the pure-state theorem relating
 renormalization fixed points, zero correlation length, and such ground states in
-\cite{Cirac2016MPDO_arXiv}. The spectral-gap section records the martingale
-condition for overlapping local terms and keeps the principal-angle estimate as
-an explicit hypothesis. For a tensor in block-injective canonical form
+\cite{Cirac2016MPDO_arXiv}. The spectral-gap section records the source
+anticommutator martingale condition for overlapping local terms, together with
+cyclic norm-compression estimates as sufficient stronger hypotheses. For a tensor
+in block-injective canonical form
 $A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$,
 \cite[Theorem~IV.16]{Cirac2021Matrix}
 (\cite[Theorem~12]{PerezGarcia2007Matrix}) states that the periodic

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -427,6 +427,35 @@ sufficient stronger hypotheses.
     dividing by two, the same quadratic-form estimate follows.
 \end{proof}
 
+\begin{lemma}[Finite-overlap projection anticommutator reduction]
+    \label{lem:finite_overlap_projection_anticommutator_reduction}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_anticommutator}
+    \leanok
+    \uses{lem:anticommutator_projection_rowsum_reduction}
+    Let $P_i$ be a finite family of symmetric projections and let
+    $\gamma\le1$. Suppose an interaction predicate $i\sim j$ has at most $m$
+    off-diagonal neighbours in each row and in each column, where $m>0$. If
+    noninteracting pairs have non-negative anticommutator form and interacting
+    pairs satisfy
+    \[
+        \operatorname{Re}\langle P_i v,P_jv\rangle
+        +\operatorname{Re}\langle P_j v,P_iv\rangle
+        \ge
+        -(1-\gamma)\frac{1}{m}
+        \bigl(\operatorname{Re}\langle P_i v,v\rangle
+        +\operatorname{Re}\langle P_j v,v\rangle\bigr),
+    \]
+    then $H=\sum_iP_i$ satisfies $H^2\ge\gamma H$ as a quadratic form.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Choose $c_{ij}=1/m$ on interacting pairs and $c_{ij}=0$ otherwise. The row
+    and column cardinality bounds give the corresponding coefficient sums, and
+    the noninteracting anticommutator non-negativity supplies the zero-coefficient
+    estimates. Apply Lemma~\ref{lem:anticommutator_projection_rowsum_reduction}.
+\end{proof}
+
 \begin{lemma}[Finite-overlap projection row-sum reduction]
     \label{lem:finite_overlap_projection_rowsum_reduction}
     \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap}
@@ -584,6 +613,41 @@ sufficient stronger hypotheses.
     of the ground space.
 \end{proof}
 
+\begin{lemma}[Parent-Hamiltonian finite-overlap anticommutator reduction]
+    \label{lem:parent_hamiltonian_finite_overlap_anticommutator_gap}
+    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_anticommutator}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator}
+    \leanok
+    \uses{lem:finite_overlap_projection_anticommutator_reduction,
+        lem:parent_hamiltonian_es_quadratic_reduction,
+        lem:transported_es_local_projections}
+    Fix $L>1$ and set $m=2(L-1)$. Suppose uniformly for every $N\ge2L$ that
+    the overlap relation on local windows has at most $m$ off-diagonal
+    neighbours in each row and in each column. If non-overlapping local terms
+    have non-negative anticommutator form, and overlapping local terms satisfy
+    \[
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+        +\operatorname{Re}\langle h_{j,\mathrm{ES}}v,h_{i,\mathrm{ES}}v\rangle
+        \ge
+        -\Bigl(1-\frac{1}{4L}\Bigr)\frac{1}{m}
+        \bigl(
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle
+        +\operatorname{Re}\langle h_{j,\mathrm{ES}}v,v\rangle
+        \bigr),
+    \]
+    then the explicit norm lower bound with constant $1/(4L)$ follows for
+    vectors in $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Apply the finite-overlap anticommutator projection reduction to the
+    Hilbert-space local terms. The resulting quadratic-form estimate has
+    $\gamma=1/(4L)$, and
+    Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} converts it to the
+    norm lower bound.
+\end{proof}
+
 \begin{lemma}[Parent-Hamiltonian finite-overlap martingale quadratic reduction]
     \label{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
     \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs}
@@ -682,6 +746,19 @@ sufficient stronger hypotheses.
     Two length-$L$ cyclic windows overlap, written $i\sim_L j$, when their
     supports meet: $S_i\cap S_j\ne\varnothing$.
 \end{definition}
+
+\begin{lemma}[Cyclic-window overlap symmetry]
+    \label{lem:cyclic_windows_overlap_symmetry}
+    \lean{MPSTensor.cyclicWindowsOverlap_comm}
+    \leanok
+    \uses{def:cyclic_windows_overlap}
+    For length-$L$ cyclic windows, $i\sim_Lj$ if and only if $j\sim_Li$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Both assertions say that the two cyclic supports have a common site.
+\end{proof}
 
 \begin{lemma}[Concrete non-overlap positivity for cyclic supports]
     \label{lem:cyclic_window_nonoverlap_positive}
@@ -809,6 +886,40 @@ sufficient stronger hypotheses.
     the preceding reduction; the overlapping estimate
     (\ref{eq:ph_cyclic_overlap_friedrichs}) supplies its remaining ordered
     cross-term condition.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from a cyclic anticommutator estimate]
+    \label{lem:parent_hamiltonian_cyclic_overlap_anticommutator_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator}
+    \leanok
+    \uses{lem:parent_hamiltonian_finite_overlap_anticommutator_gap,
+        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive,
+        lem:cyclic_windows_overlap_symmetry}
+    Fix $L>1$ and let $i\sim_L j$ mean that the cyclic supports of the
+    length-$L$ windows at $i$ and $j$ meet. Suppose uniformly for every
+    $N\ge2L$ that overlapping off-diagonal terms satisfy
+    \[
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+        +\operatorname{Re}\langle h_{j,\mathrm{ES}}v,h_{i,\mathrm{ES}}v\rangle
+        \ge
+        -\Bigl(1-\frac{1}{4L}\Bigr)\frac{1}{2(L-1)}
+        \bigl(
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle
+        +\operatorname{Re}\langle h_{j,\mathrm{ES}}v,v\rangle
+        \bigr).
+    \]
+    Then the explicit norm lower bound with constant $1/(4L)$ follows for
+    vectors in $(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The cyclic overlap relation is symmetric, and
+    Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives at most $2(L-1)$
+    overlapping off-diagonal windows in each row and column. If two cyclic
+    supports do not meet, Lemma~\ref{lem:cyclic_window_nonoverlap_positive}
+    gives non-negative ordered cross terms in both orders. Apply the
+    finite-overlap anticommutator reduction.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian gap from sufficient cyclic norm compression]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -9,10 +9,12 @@ Fannes--Nachtergaele--Werner and
 Nachtergaele~\cite{Fannes1992Finitely, Nachtergaele1996Spectral}, as recalled
 by Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}
 and in the later formulation of Kastoryano and
-Lucia~\cite{Kastoryano2018Martingale}, reduces a uniform gap to principal-angle
-estimates for overlapping local ground spaces. The results below state the
-martingale condition for the cyclic-window local terms; the MPS-specific
-principal-angle estimate remains an explicit input.
+Lucia~\cite{Kastoryano2018Martingale}, reduces a uniform gap to an
+anticommutator estimate for overlapping local terms. Principal angles between
+the corresponding local ground spaces give the geometric interpretation of this
+estimate. The results below state the anticommutator condition for the
+cyclic-window local terms and also record cyclic norm-compression estimates as
+sufficient stronger hypotheses.
 
 \begin{definition}[Parent ground space under the canonical $\ell^2$ identification]
     \label{def:parent_ground_space_es}
@@ -350,6 +352,8 @@ principal-angle estimate remains an explicit input.
     \lean{ProjectionGeometry.re_inner_sum_apply_apply}
     \lean{ProjectionGeometry.sum_sum_eq_diag_add_offdiag}
     \lean{ProjectionGeometry.crossTerm_sum_bound_of_ordered_rowSum}
+    \lean{ProjectionGeometry.crossTerm_sum_bound_of_anticommutator_coeffSum}
+    \lean{ProjectionGeometry.crossTerm_sum_bound_of_anticommutator_rowCol}
     \leanok
     The projection-geometry reduction uses the following elementary Hilbert-space
     identities: the diagonal identity
@@ -362,8 +366,10 @@ principal-angle estimate remains an explicit input.
     finite-sum expansions of
     $\operatorname{Re}\langle (\sum_i P_i)v,v\rangle$ and
     $\operatorname{Re}\langle (\sum_i P_i)v,(\sum_i P_i)v\rangle$; the
-    diagonal/off-diagonal split of the ordered double sum; and the aggregate
-    off-diagonal estimate obtained from row sums $\sum_{j\ne i}c_{ij}\le1$.
+    diagonal/off-diagonal split of the ordered double sum; the aggregate
+    off-diagonal estimate obtained from row sums $\sum_{j\ne i}c_{ij}\le1$; and
+    the corresponding aggregate estimate for the anticommutator martingale
+    condition.
 \end{remark}
 
 \begin{lemma}[Ordered projection row-sum quadratic-form reduction]
@@ -389,6 +395,36 @@ principal-angle estimate remains an explicit input.
     $\operatorname{Re}\langle P_i v,v\rangle$, while the row-summable ordered
     cross-term bounds control the off-diagonal contribution by
     $-(1-\gamma)\sum_i\operatorname{Re}\langle P_i v,v\rangle$.
+\end{proof}
+
+\begin{lemma}[Projection anticommutator row-sum reduction]
+    \label{lem:anticommutator_projection_rowsum_reduction}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_anticommutator_rowCol}
+    \leanok
+    \uses{rem:projection_geometry_rowsum_identities}
+    Let $P_i$ be a finite family of symmetric projections and let
+    $H=\sum_iP_i$. Suppose the anticommutator forms obey
+    \[
+        \operatorname{Re}\langle P_i v,P_jv\rangle
+        +\operatorname{Re}\langle P_j v,P_iv\rangle
+        \ge
+        -(1-\gamma)c_{ij}
+        \bigl(\operatorname{Re}\langle P_i v,v\rangle
+        +\operatorname{Re}\langle P_j v,v\rangle\bigr)
+        \qquad (i\ne j),
+    \]
+    with row sums $\sum_{j\ne i}c_{ij}\le1$, column sums
+    $\sum_{i\ne j}c_{ij}\le1$, and $\gamma\le1$. Then
+    $H^2\ge\gamma H$ as a quadratic form.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expand $\operatorname{Re}\langle Hv,Hv\rangle$ as an ordered double sum. The
+    anticommutator bound controls the sum of each ordered term with its reversed
+    term. The row and column estimates bound the coefficient-weighted diagonal
+    contribution by twice $\sum_i\operatorname{Re}\langle P_i v,v\rangle$; after
+    dividing by two, the same quadratic-form estimate follows.
 \end{proof}
 
 \begin{lemma}[Finite-overlap projection row-sum reduction]
@@ -508,6 +544,44 @@ principal-angle estimate remains an explicit input.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} to convert this
     quadratic-form estimate into the norm lower bound on the orthogonal
     complement of the ground space.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from the anticommutator martingale condition]
+    \label{lem:parent_hamiltonian_anticommutator_rowsum_gap}
+    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_anticommutator_local_term_bounds}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds}
+    \leanok
+    \uses{lem:anticommutator_projection_rowsum_reduction,
+        lem:parent_hamiltonian_es_quadratic_reduction,
+        lem:transported_es_local_projections}
+    Assume uniformly for every $N\ge2L$ that the Hilbert-space local terms satisfy
+    the anticommutator martingale estimate
+    \[
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
+        +\operatorname{Re}\langle h_{j,\mathrm{ES}}v,h_{i,\mathrm{ES}}v\rangle
+        \ge
+        -c_{ij}\Bigl(1-\frac{1}{4L}\Bigr)
+        \bigl(
+        \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle
+        +\operatorname{Re}\langle h_{j,\mathrm{ES}}v,v\rangle
+        \bigr)
+    \]
+    for $i\ne j$, with row and column coefficient sums bounded by one. If
+    $L>1$, then $1/(4L)>0$ and, for every
+    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
+    \[
+        \frac{1}{4L}\|v\|\le
+        \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The fixed-chain anticommutator row-sum reduction supplies the quadratic-form
+    estimate with $\gamma=1/(4L)$ for every admissible $N$. The positivity and
+    kernel identification of the Hilbert-space Hamiltonian then convert this
+    quadratic-form estimate into the norm lower bound on the orthogonal complement
+    of the ground space.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian finite-overlap martingale quadratic reduction]
@@ -737,7 +811,7 @@ principal-angle estimate remains an explicit input.
     cross-term condition.
 \end{proof}
 
-\begin{lemma}[Parent-Hamiltonian gap from a principal-angle bound for overlapping cyclic windows]
+\begin{lemma}[Parent-Hamiltonian gap from sufficient cyclic norm compression]
     \label{lem:parent_hamiltonian_cyclic_overlap_norm_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound}
     \leanok
@@ -808,11 +882,11 @@ principal-angle estimate remains an explicit input.
     \[
         (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
     \]
-    The strict form is also recorded as the principal-angle, or norm-compression,
-    reduction used in the martingale passage of
+    This strict compression form is a sufficient strengthening of the
+    anticommutator martingale estimate in
     Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}.
     It does not prove the remaining MPS-specific estimate; it isolates the
-    finite-row martingale argument once that estimate is supplied.
+    finite-row martingale argument once such a strengthening is supplied.
 \end{lemma}
 
 \begin{proof}
@@ -892,7 +966,7 @@ principal-angle estimate remains an explicit input.
     $\lambda \ge \gamma$~\cite{Kastoryano2018Martingale}.
 \end{proof}
 
-\begin{lemma}[MPS principal-angle input for the martingale condition]\label{lem:martingale_mps}
+\begin{lemma}[MPS anticommutator input for the martingale condition]\label{lem:martingale_mps}
     \notready
     \uses{thm:martingale_criterion, def:parent_interaction,
         def:local_term_parent, thm:ground_space_intersection, def:injective}
@@ -913,16 +987,26 @@ principal-angle estimate remains an explicit input.
         h_i h_j+h_j h_i \ge -c_{ij}(1-\gamma)(h_i+h_j)
     \]
     and interpret it as a lower bound on the smallest non-zero principal angle
-    between the local ground spaces $\ker h_i$ and $\ker h_j$. In the present
-    cyclic-window convention, the remaining quantitative comparison is to obtain
-    a constant $\eta\ge0$, independent of $N$, such that
+    between the local ground spaces $\ker h_i$ and $\ker h_j$. In the
+    Hilbert-space formulation above, the source condition is the corresponding
+    quadratic-form inequality
+    \[
+        \operatorname{Re}\langle h_i v,h_jv\rangle
+        +\operatorname{Re}\langle h_j v,h_iv\rangle
+        \ge
+        -c_{ij}(1-\gamma)
+        \bigl(\operatorname{Re}\langle h_i v,v\rangle
+        +\operatorname{Re}\langle h_j v,v\rangle\bigr),
+    \]
+    with row-summable coefficients. Lemma~\ref{lem:parent_hamiltonian_anticommutator_rowsum_gap}
+    records the formal reduction from this estimate to the spectral gap. A
+    directed norm-compression estimate, independent of $N$, such as
     \[
         \|h_i h_j v\|\le \eta\|h_i v\|,
         \qquad \eta\,2(L-1)<1,
     \]
-    for every overlapping off-diagonal pair. Theorem~\ref{thm:friedrichs_gap_bound_constant}
-    shows that this is enough for a positive gap; the preceding lemmas reduce the
-    martingale inequality and the spectral gap to this norm-compression estimate.
+    for every overlapping off-diagonal pair is a sufficient stronger hypothesis;
+    Theorem~\ref{thm:friedrichs_gap_bound_constant} records that consequence.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
     overlapping pairs and the spectral gap follows directly without the
     martingale argument.)
@@ -940,15 +1024,16 @@ principal-angle estimate remains an explicit input.
     \]
     where $P$ projects onto
     $\ker(h_i+h_j)=\ker h_i\cap\ker h_j$ and $\ell$ is the overlap length.
-    What remains is to convert the cited estimate, with its blocking
-    convention and constants, into the excitation-projection inequality
+    What remains is to derive the anticommutator estimate above, with its
+    blocking convention and constants, for the cyclic-window local terms. The
+    intersection property identifies $\ker h_i\cap\ker h_j$ with the parent ground
+    space on the union of the two windows, but it does not by itself supply this
+    numerical inequality. The directed excitation-projection estimate
     \[
         \|h_i h_j v\|\le \eta\|h_i v\|,
         \qquad \eta\,2(L-1)<1.
     \]
-    The intersection property identifies $\ker h_i\cap\ker h_j$ with the
-    parent ground space on the union of the two windows, but it does not by
-    itself supply this numerical inequality.
+    remains useful as a sufficient strengthening of the source condition.
 
     \emph{Row-sum bound.}
     Since $L \ge 2$, each site $i$ overlaps with at most $2(L-1)$
@@ -962,39 +1047,49 @@ principal-angle estimate remains an explicit input.
     satisfying the row-sum hypothesis of
     Theorem~\ref{thm:martingale_criterion}.
 
-    \emph{Norm-compression constant.}
+    \emph{Anticommutator constant.}
     It remains to compare the cited principal-angle estimates with the
-    cyclic-window norm-compression statement
+    cyclic-window anticommutator statement
+    \[
+        h_i h_j+h_jh_i
+        \ge
+        -c_{\{i,j\}}(1-\gamma)(h_i+h_j).
+    \]
+    If this estimate is obtained with the displayed row-summable coefficients,
+    Lemma~\ref{lem:parent_hamiltonian_anticommutator_rowsum_gap} gives the gap.
+    A sufficient stronger route is the norm-compression statement
     \[
         \|h_i h_j v\|\le \eta\|h_i v\|,
         \qquad \eta\,2(L-1)<1.
     \]
     If such an $\eta$ is obtained, Theorem~\ref{thm:friedrichs_gap_bound_constant}
     gives the gap constant $1-\eta\,2(L-1)$. The frequently displayed
-    fixed-coefficient form is the specialization with
+    fixed-coefficient compression form is the specialization with
     \[
         \eta=\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)},
         \qquad
         1-\eta\,2(L-1)=\frac{1}{4L}.
     \]
-    In this special case the martingale condition becomes
+    In the corresponding anticommutator form the martingale condition is
     \[
         h_i h_j + h_j h_i
         \ge
         -\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}(h_i+h_j)
     \]
-    for every overlapping off-diagonal pair, and a sufficient one-sided form is
+    for every overlapping off-diagonal pair, and a sufficient one-sided
+    strengthening is
     \[
         \|h_i h_j v\|
         \le
         \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}\|h_i v\|.
     \]
     A qualitative statement that the relevant smallest non-zero principal angles
-    are positive is not by itself enough: the martingale reduction needs the
-    displayed numerical bound with $\eta\,2(L-1)<1$. Thus the remaining
-    comparison is whether the principal-angle estimates cited in
+    are positive is not by itself enough: the martingale reduction needs a
+    numerical anticommutator bound with row-summable coefficients, or a stronger
+    norm-compression bound with $\eta\,2(L-1)<1$. Thus the remaining comparison is
+    whether the principal-angle estimates cited in
     \cite{Fannes1992Finitely, Nachtergaele1996Spectral,
-        Kastoryano2018Martingale} supply such a cyclic-window inequality, with
+        Kastoryano2018Martingale} supply such a cyclic-window estimate, with
     constants independent of $N$, under the convention used here.
     % Paper-gap note: docs/paper-gaps/cpgsv21_martingale_overlap.tex.
 \end{proof}
@@ -1047,10 +1142,11 @@ principal-angle estimate remains an explicit input.
     Lemma~\ref{lem:parent_hamiltonian_es_quadratic_reduction} reduces the present
     theorem to the remaining MPS-specific task: deriving the uniform
     quadratic-form estimate. Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
-    establishes the finite-sum algebra from ordered cross-term row bounds, and
-    Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
+    establishes the finite-sum algebra from ordered cross-term row bounds, while
+    Lemma~\ref{lem:parent_hamiltonian_anticommutator_rowsum_gap} records the
+    source anticommutator martingale condition. Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
     and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} state the
-    common finite-overlap principal-angle specialization with $m=2(L-1)$.
+    common finite-overlap ordered-cross-term specialization with $m=2(L-1)$.
     Lemma~\ref{lem:transported_es_nonoverlap_positive} supplies the non-overlap
     positivity statement for site-disjoint windows, and
     Lemma~\ref{lem:cyclic_window_nonoverlap_positive} translates this to the
@@ -1059,7 +1155,8 @@ principal-angle estimate remains an explicit input.
     row-cardinality bound.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap} combines
     these results with the finite-overlap reduction, so the only additional
-    input is the principal-angle estimate for overlapping cyclic windows.
+    input is the ordered anticommutator or cross-term estimate for overlapping
+    cyclic windows.
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} states the
     same overlap-only formulation, and
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} states a sufficient

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -87,8 +87,9 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
   periodic block decomposition and the BNT ground-space span.
 - `cpgsv21_martingale_overlap.tex` records the spectral-gap martingale
   comparison: the finite-row cyclic-window reduction is formalized, while the
-  remaining source comparison is the overlapping-window principal-angle, or
-  norm-compression, estimate tracked by issue #952.
+  remaining source comparison is the overlapping-window anticommutator estimate;
+  the local norm-compression statements are sufficient stronger substitutes
+  tracked by issue #952.
 - `cpsv16_nncph_ground_state_scope.tex` records the separation between the
   zero-energy ground-vector predicate and the source ground-space spanning
   predicates for CPSV16 Theorem 3.10(iii). The all-chain condition is now

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -166,11 +166,17 @@ For a symmetric projection $p_i$ one has
     \ge -\|p_i v\| \|p_i p_j v\|.
 \]
 Thus (N), together with $\operatorname{Re}\langle p_i v,v\rangle=\|p_i v\|^2$,
-implies (F). This is the projection-geometry comparison used in the formal proof:
-a norm-compression estimate for each overlapping pair is converted by
-Cauchy--Schwarz to the ordered cross-term estimate, and the finite row-sum
-argument converts those ordered estimates into the global gap bound.\footnote{The
-    current formal anchors are the cyclic-window reductions
+implies (F). This is a sufficient projection-geometry comparison used in the
+formal proof: a norm-compression estimate for each overlapping pair is converted
+by Cauchy--Schwarz to the ordered cross-term estimate, and the finite row-sum
+argument converts those ordered estimates into the global gap bound. The formal
+development also records the source anticommutator row-sum reduction directly,
+without passing through this stronger one-sided estimate.\footnote{The
+    current formal anchors include the anticommutator row-sum reductions
+    \leanid{crossTerm_sum_bound_of_anticommutator_rowCol},
+    \leanid{quadraticForm_sum_projections_of_anticommutator_rowCol}, and
+    \leanid{parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds}.
+    The cyclic-window compression reductions are
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs},
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound},
     and
@@ -184,11 +190,14 @@ argument converts those ordered estimates into the global gap bound.\footnote{Th
     \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. The
     projection-geometry reductions used by these statements are in
     \path{TNLean/Analysis/ProjectionGeometry.lean}. The declaration names keep the
-    earlier word \path{friedrichs}; this note uses the source terminology
-    ``principal angle'' and ``norm compression'' for the mathematical input.}
+    earlier word \path{friedrichs}; this note uses ``anticommutator estimate'' for
+    the source condition and ``norm compression'' for the local sufficient
+    strengthening.}
 
-The flexible constant formulation is the current formal boundary. Instead of
-requiring the special coefficient in (N), it assumes that for some $\eta\ge 0$,
+The anticommutator row-sum formulation is now the source-faithful formal
+boundary. The flexible constant formulation is a sufficient compression boundary:
+instead of requiring the special coefficient in (N), it assumes that for some
+$\eta\ge 0$,
 \begin{equation}
     \eta\,2(L-1)<1
     \tag{E}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -176,6 +176,10 @@ without passing through this stronger one-sided estimate.\footnote{The
     \leanid{crossTerm_sum_bound_of_anticommutator_rowCol},
     \leanid{quadraticForm_sum_projections_of_anticommutator_rowCol}, and
     \leanid{parentHamiltonianES_gap_bound_of_anticommutator_local_term_bounds}.
+    The finite-overlap anticommutator reductions are
+    \leanid{quadraticForm_sum_projections_of_finite_overlap_anticommutator},
+    \leanid{parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator}, and
+    \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator}.
     The cyclic-window compression reductions are
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs},
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound},
@@ -194,8 +198,9 @@ without passing through this stronger one-sided estimate.\footnote{The
     the source condition and ``norm compression'' for the local sufficient
     strengthening.}
 
-The anticommutator row-sum formulation is now the source-faithful formal
-boundary. The flexible constant formulation is a sufficient compression boundary:
+The anticommutator row-sum formulation, including its finite-overlap
+cyclic-window specialization, is now the source-faithful formal boundary. The
+flexible constant formulation is a sufficient compression boundary:
 instead of requiring the special coefficient in (N), it assumes that for some
 $\eta\ge 0$,
 \begin{equation}
@@ -305,9 +310,11 @@ The conclusion is a difference between the review paragraph and the formal
 quantitative statement, with one mathematical comparison still to be made. The
 source states the martingale condition in terms of general row-sum coefficients
 and invokes principal-angle estimates to obtain a positive MPS parent-Hamiltonian
-gap. The formal proof contains the finite-overlap row reduction for cyclic
-windows, specializes the row coefficients to $c_{ij}=1/(2(L-1))$, and reduces
-the remaining MPS-specific work to a norm-compression estimate
+gap. The formal proof contains the direct finite-overlap anticommutator
+reduction for cyclic windows, specializes the row coefficients to
+$c_{ij}=1/(2(L-1))$ on overlapping pairs, and leaves the remaining MPS-specific
+work as the source anticommutator estimate. It also records the stronger
+norm-compression route
 \[
     \|p_i p_j v\|\le \eta\|p_i v\|,
     \qquad
@@ -317,8 +324,8 @@ The earlier coefficient
 \[
     \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}
 \]
-is a sufficient special case, not the only possible way to use the formal
-martingale reduction.
+is a sufficient special case for this stronger route, not the only possible way
+to use the formal martingale reduction.
 
 The Cirac--Perez-Garcia--Schuch--Verstraete 2021 statement is not being
 challenged. The comparison records that the available formal argument is more


### PR DESCRIPTION
## Summary

- add projection-geometry reductions for the source anticommutator martingale estimate with row and column coefficient sums
- specialize the anticommutator reduction to finite-overlap families and to cyclic parent-Hamiltonian windows, using overlap symmetry, row/column cardinality, and non-overlap positivity
- update the spectral-gap blueprint and martingale paper-gap note so cyclic norm-compression is described as a sufficient stronger hypothesis, not the source estimate itself

Refs #952.
Refs #460.
Refs #190.

## Validation

- `LEAN_PATH="$(cd /Users/siruilu/Local/agentFormalization/TNLean && lake env printenv LEAN_PATH)" lean -R . TNLean/Analysis/ProjectionGeometry.lean`
- `LEAN_PATH="$(cd /Users/siruilu/Local/agentFormalization/TNLean && lake env printenv LEAN_PATH)" lean -R . TNLean/MPS/ParentHamiltonian/CyclicWindow.lean`
- `LEAN_PATH="/tmp/tnlean-anticom-o:$(cd /Users/siruilu/Local/agentFormalization/TNLean && lake env printenv LEAN_PATH)" lean -R . -o /tmp/tnlean-anticom-o/TNLean/MPS/ParentHamiltonian/Martingale/Transport.olean -i /tmp/tnlean-anticom-o/TNLean/MPS/ParentHamiltonian/Martingale/Transport.ilean TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean`
- `LEAN_PATH="/tmp/tnlean-anticom-o:$(cd /Users/siruilu/Local/agentFormalization/TNLean && lake env printenv LEAN_PATH)" lean -R . TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check`
