### PR TITLE
doc(periodic): align Z gauge with multiplicities

### DIFF
--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -386,13 +386,17 @@ unconditional result.
 % MPV family. The Z-gauge/root-of-unity construction is already formalized.
 \begin{theorem}[Periodic Fundamental Theorem]\notready
     \label{thm:periodic_ft}
-    \lean{MPSTensor.zgauge_construction, MPSTensor.equalCase_zgauge_of_power_sums,
-        MPSTensor.fundamentalTheorem_periodic_equalCase_matching,
-        MPSTensor.fundamentalTheorem_periodic_equalCase}
-    \uses{def:irreducible_form, def:z_gauge_equiv}
-    Let $A$ and $B$ be MPS tensors in irreducible form,
-    with bases of periodic blocks
-    $\{A_j\}_{j \in J}$ and $\{B_k\}_{k \in K}$ respectively.
+    \uses{def:irreducible_form}
+    Let $A$ and $B$ be MPS tensors in irreducible form. Write
+    \[
+        A^i=\bigoplus_{j\in J}(R_j\otimes A_j^i),
+        \qquad
+        B^i=\bigoplus_{k\in K}(S_k\otimes B_k^i),
+    \]
+    where $\{A_j\}_{j \in J}$ and $\{B_k\}_{k \in K}$ are bases of periodic
+    tensors, $R_j$ and $S_k$ are diagonal multiplicity matrices of sizes
+    $r_j\times r_j$ and $s_k\times s_k$, and $A_j^i$ and $B_k^i$ act on
+    bond spaces of dimensions $D_j$ and $D_k$.
     Suppose that $\mathcal{V}(A) = \mathcal{V}(B)$
     (equal MPV families for all lengths $N$).
 
@@ -401,25 +405,16 @@ unconditional result.
     period $m_j$.
     Moreover, for each $j \in J$ there exists:
     \begin{enumerate}
-        \item an invertible matrix $Y_j$ of size $D_j \times D_{\pi(j)}$,
+        \item an invertible matrix $Y_j$ of size $D_{\pi(j)} \times D_j$,
               and
-        \item a diagonal unitary matrix $Z_j$ of size $D_j \times D_j$
-              satisfying $Z_j^{m_j} = \Id$ and
-              $[A_j^i, Z_j] = 0$ for all~$i$,
+        \item a diagonal unitary matrix $Z_j$ of size $r_j \times r_j$
+              satisfying $Z_j^{m_j} = \Id_{r_j}$,
     \end{enumerate}
-    such that, for every physical index~$i$,
-    \[
-        Z_j\, A_j^i = Y_j\, B_{\pi(j)}^i\, Y_j^{-1}
-    \]
-    For each periodic block, the extra freedom is encoded by
-    \begin{center}
-        \TNPeriodicGauge{m_j}{Z_j}{m_j}
-    \end{center}
-    rather than by an ordinary gauge alone: the operator $Z_j$
-    sits on the closing virtual bond and satisfies $Z_j^{m_j}=\Id$.
-    Equivalently, setting $Y = \bigoplus_j Y_j \otimes \Id_{r_j}$
-    and $Z = \bigoplus_j Z_j \otimes \Id_{r_j}$, one has
-    $Z A^i = Y B^i Y^{-1}$ for all $i$,
+    such that $B_{\pi(j)}^i = Y_j A_j^i Y_j^{-1}$ for every physical
+    index~$i$, and, after reordering the diagonal entries of the
+    multiplicity matrix $S_{\pi(j)}$, one has $Z_j R_j = S_{\pi(j)}$.
+    Equivalently, setting $Z = \bigoplus_j Z_j \otimes \Id_{D_j}$ gives an
+    invertible matrix $Y$ such that $Z A^i = Y B^i Y^{-1}$ for all $i$,
     with $[A^i, Z] = 0$ and $\mathcal{V}(A) = \mathcal{V}(ZA)$.
 
     \noindent\emph{Remark.}


### PR DESCRIPTION
## Summary

- Correct the periodic equal-case blueprint statement so the root-of-unity matrix `Z_j` acts on the multiplicity factor of size `r_j`, not on the tensor bond space of size `D_j`.
- State the source relation `Z_j R_j = S_{π(j)}` after reordering multiplicities, and set `Z = ⊕_j Z_j ⊗ Id_{D_j}`.
- Keep the theorem text aligned with arXiv:1708.00029, Theorem 3.8 / proof of the equal case.

## Source check

In `Papers/1708.00029/main.tex`, the irreducible form is

```tex
A^i = \bigoplus_{j\in J} (R_j \otimes A_j^i),
```

with `R_j` an `r_j × r_j` diagonal multiplicity matrix. The equal-case theorem states `Z_j^{m_j}=1_{r_j}`, relates multiplicities by `Z_j R_j = S_j` after reordering, and defines `Z = ⊕_j Z_j ⊗ 1_{D_j}`.

## Validation

- `git diff --check origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`

Refs #82.
Refs #619.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a marked-notready LaTeX theorem; no Lean or runtime code in the diff.
> 
> **Overview**
> Updates the **notready** periodic Fundamental Theorem (`thm:periodic_ft`) so the equal-case conclusion matches De Las Cuevas et al. (Theorem 3.8): tensors are written as **⊕_j (R_j ⊗ A_j^i)** with diagonal multiplicity matrices **R_j**, **S_k** separate from bond-space periodic blocks **A_j^i**, **B_k^i**.
> 
> **Z-gauge placement and conclusions are corrected:** **Z_j** is **r_j × r_j** on the multiplicity factor with **Z_j^{m_j} = Id_{r_j}**, not **D_j × D_j** on the tensor bond; block tensors relate by **B_{π(j)}^i = Y_j A_j^i Y_j^{-1}** with **Y_j** of size **D_{π(j)} × D_j**. After reordering **S_{π(j)}**, **Z_j R_j = S_{π(j)}**; globally **Z = ⊕_j Z_j ⊗ Id_{D_j}** yields **Z A^i = Y B^i Y^{-1}** with **[A^i,Z]=0** and unchanged MPVs for **ZA**.
> 
> The old block-level **[A_j^i, Z_j]=0** / **Z_j A_j^i = Y_j B_{π(j)}^i Y_j^{-1}** wording and the **TNPeriodicGauge** diagram are dropped; **\lean{...}** pointers to partial Lean periodic-FT lemmas and **\uses{def:z_gauge_equiv}** are removed from this theorem header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aba1c293aa1fa63415b3a841b275cb5c5b48516d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->