### PR TITLE
doc(periodic): normalize 1708 source names

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
@@ -22,7 +22,7 @@ projections fixed by the adjoint transfer map.
 ## References
 
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix A]
-* [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1708.00029, eq:Aoffdiag/eq:Auprop]
+* [De las Cuevas–Cirac–Schuch–Pérez-García, arXiv:1708.00029, eq:Aoffdiag/eq:Auprop]
 * [Wolf, *Quantum Channels & Operations*, Chapter 6]
 -/
 

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -17,7 +17,7 @@ to channel / QPF normalization, following:
 
 * Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix A
   (CFII definition: TP + full-rank diagonal fixed point), and
-* Cirac–Pérez-García–Schuch–Verstraete, arXiv:1708.00029, Section 2.1
+* De las Cuevas–Cirac–Schuch–Pérez-García, arXiv:1708.00029, Section 2.1
   (irreducible form II discussion, diagonal fixed point).
 
 ## Main results
@@ -43,7 +43,7 @@ to channel / QPF normalization, following:
 ## References
 
 * [Cirac et al., arXiv:1606.00608, Section 2.3 and Appendix A][Cirac2017Annals]
-* [Cirac et al., arXiv:1708.00029, Section 2.1][Cirac2017Irreducible]
+* [De las Cuevas et al., arXiv:1708.00029, Section 2.1][Cirac2017Irreducible]
 * [Pérez-García et al., quant-ph/0608197, Theorem 3][PerezGarcia2007]
 -/
 

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -54,7 +54,7 @@ The Z-gauge construction (Theorem 3.8 steps 5–7) is fully proved.
 
 ## Key references
 
-* arXiv:1708.00029 (De las Cuevas–Schuch–Pérez-García–Cirac, 2017)
+* arXiv:1708.00029 (De las Cuevas–Cirac–Schuch–Pérez-García, 2017)
 * `MPSTensor.ft_sector_bnt_proportional_sector_match_witnesses` — current
   sector-decomposition matching template for the non-periodic theorem
 * Z-gauge construction lemmas in `ZGauge.lean`

--- a/TNLean/MPS/Periodic/ProjectiveRep.lean
+++ b/TNLean/MPS/Periodic/ProjectiveRep.lean
@@ -42,7 +42,7 @@ representation data — the cocycle identity and the construction of a
 
 ## References
 
-* arXiv:1708.00029 Section 4.2 (de las Cuevas–Schuch–Pérez-García–Cirac, 2017) —
+* arXiv:1708.00029 Section 4.2 (De las Cuevas–Cirac–Schuch–Pérez-García, 2017) —
   SPT cocycle classification.
 * arXiv:0802.0447 — original projective-representation construction (injective
   case).

--- a/TNLean/MPS/Periodic/Symmetry.lean
+++ b/TNLean/MPS/Periodic/Symmetry.lean
@@ -51,7 +51,7 @@ names, including `PeriodicEqualCaseFT`,
 
 ## References
 
-* arXiv:1708.00029 Section 4 (de las Cuevas–Schuch–Pérez-García–Cirac, 2017)
+* arXiv:1708.00029 Section 4 (De las Cuevas–Cirac–Schuch–Pérez-García, 2017)
 * arXiv:0802.0447 Section III (Pérez-García–Wolf–Sanz–Verstraete–Cirac,
   *Characterizing Symmetries in a Projected Entangled Pair State*)
 * M. M. Wolf, *Quantum Channels & Operations*, Chapter 6.

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1,7 +1,7 @@
 %% =========================================================
 %% Chapter: Periodic MPS - irreducible form and the periodic
 %% Fundamental Theorem. Source: \cite[Sections~3--4]{DeLasCuevas2017Irreducible}.
-%% (de las Cuevas--Schuch--P\'erez-Garc\'ia--Cirac).
+%% (De las Cuevas--Cirac--Schuch--P\'erez-Garc\'ia).
 %% =========================================================
 
 \chapter{Periodic MPS: irreducible form and the periodic Fundamental Theorem}%


### PR DESCRIPTION
## Summary

- Normalize reader-facing references to arXiv:1708.00029 to the author order in the local paper source.
- Update Lean module docstrings/comments and the periodic blueprint chapter header.
- Keep this to bibliographic/prose alignment; no mathematical statements or Lean declarations are changed.

## Source check

`Papers/1708.00029/main.tex` gives the title `Irreducible forms of Matrix Product States: Theory and Applications` and the author order

```text
Gemma De las Cuevas; J. Ignacio Cirac; Norbert Schuch; David Perez-Garcia
```

The edited references now use De las Cuevas--Cirac--Schuch--Pérez-García for arXiv:1708.00029.

## Validation

- `lake env lean TNLean/MPS/Irreducible/FormII.lean`
- `lake env lean TNLean/MPS/Periodic/FundamentalTheorem.lean`
- `lake env lean TNLean/MPS/Periodic/ProjectiveRep.lean`
- `lake env lean TNLean/MPS/Periodic/Symmetry.lean`
- `lake env lean TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean`
- `git diff --check origin/main`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`

Refs #619.
Refs #82.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to bibliographic strings; no runtime, CI logic, or formal statements are affected.
> 
> **Overview**
> Reader-facing citations of **arXiv:1708.00029** are updated so author order matches `Papers/1708.00029/main.tex`: **De las Cuevas–Cirac–Schuch–Pérez-García** (replacing older Cirac-first or Schuch-before-Cirac spellings).
> 
> Touches module docstrings in `FixedAdjoint.lean`, `FormII.lean`, `FundamentalTheorem.lean`, `ProjectiveRep.lean`, and `Periodic/Symmetry.lean`, plus the periodic blueprint chapter header in `ch22_periodic_ft.tex`. **No Lean theorems, definitions, or proofs are modified**—only comments and blueprint prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82135228d13680aa8b5a904d6b08e04f73c25ac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->