### PR TITLE
doc(parent): record PGVWC comparison status

### DIFF
--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -84,7 +84,10 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
   range-reduction comparison and the remaining periodic-boundary identity.
 - `cpgsv21_block_diagonal_parent_ground_space.tex` records the degenerate
   parent-Hamiltonian block-diagonal boundary-condition theorem behind the
-  periodic block decomposition and the BNT ground-space span.
+  periodic block decomposition and the BNT ground-space span. The fixed-window
+  PGVWC07 \(C^j,D^j\) comparison is now formalized under a crossing-tail
+  word-span hypothesis; the remaining boundary is the source-range
+  block-diagonal boundary representation and discharge of those span hypotheses.
 - `cpgsv21_martingale_overlap.tex` records the spectral-gap martingale
   comparison: the finite-row cyclic-window reduction is formalized, while the
   remaining source comparison is the overlapping-window principal-angle, or

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -87,7 +87,8 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
   periodic block decomposition and the BNT ground-space span. The fixed-window
   PGVWC07 \(C^j,D^j\) comparison is now formalized under a crossing-tail
   word-span hypothesis; the remaining boundary is the source-range
-  block-diagonal boundary representation and discharge of those span hypotheses.
+  block-diagonal boundary representation and replacement of that span-dependent
+  route by the source \(C^j,D^j,E^j\) comparison.
 - `cpgsv21_martingale_overlap.tex` records the spectral-gap martingale
   comparison: the finite-row cyclic-window reduction is formalized, while the
   remaining source comparison is the overlapping-window principal-angle, or

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -472,8 +472,9 @@ for every block $j$ in the block-injective range.\footnote{Lean declaration:
 
 The word-indexed \(C^j,D^j\) route is closer to the proof of
 \cite[Theorem~\emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}.
-For a fixed boundary-crossing interval, the local block-sum constraint and the
-word-tuple span at the complementary tail length now give matrices
+For a fixed boundary-crossing interval starting at site \(i\), the local
+block-sum constraint and the word-tuple span of the wrapped tail word of
+length \(N-i\) now give matrices
 \(C^j_{i,\rho}\) satisfying
 \begin{align}
   A^j_\beta C^j_{i,\rho}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -493,9 +493,9 @@ and the still-used block-diagonal boundary representation of a vector
 After \href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} was
 closed, the remaining source-comparison target is tracked by
 \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}: remove the
-remaining external boundary-representation input and discharge the crossing-tail
-word-span hypotheses from the PGVWC07 \(C^j,D^j,E^j\) comparison in the source
-range
+remaining external boundary-representation input, and replace the
+span-dependent crossing-tail route by the PGVWC07 \(C^j,D^j,E^j\) comparison
+in the source range
 \begin{align}
   b\ge2,
   \qquad

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -452,12 +452,12 @@ every block $j$,
   \quad\Longrightarrow\quad
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
-This is the conditional reduction recorded by pull request~\#2724.  The
-formal PGVWC trace-comparison step now records the following implication.  Assume
-the common word-span property for the middle-word length \(m\). If, for every
-boundary-crossing interval, word $\beta$ before the cut, outside word $\rho$,
-and middle word $w$ of length \(m\), the two PGVWC07 trace comparisons
-satisfy
+This is the conditional reduction recorded by pull request~\#2724.  There are
+now two formal PGVWC comparison routes. The trace-decomposition route records
+the following implication. Assume the common word-span property for the
+middle-word length \(m\). If, for every boundary-crossing interval, word
+$\beta$ before the cut, outside word $\rho$, and middle word $w$ of length \(m\),
+the two PGVWC07 trace comparisons satisfy
 \begin{align}
   \sum_j\tr\!\left(A^j_\beta C^j_\rho A^j_w\right)
   =
@@ -469,11 +469,32 @@ then
 \end{align}
 for every block $j$ in the block-injective range.\footnote{Lean declaration:
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}.}
+
+The word-indexed \(C^j,D^j\) route is closer to the proof of
+\cite[Theorem~\emph{Degeneracy of the ground space v2}]{PerezGarcia2007MPSReps}.
+For a fixed boundary-crossing interval, the local block-sum constraint and the
+word-tuple span at the complementary tail length now give matrices
+\(C^j_{i,\rho}\) satisfying
+\begin{align}
+  A^j_\beta C^j_{i,\rho}
+  =
+  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+\end{align}
+This is formalized as
+\leanid{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup}
+and assembled into
+\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1}.
+Thus the comparison itself is no longer only a free trace-decomposition
+hypothesis: the present proof boundary is the crossing-tail word-span hypothesis
+and the still-used block-diagonal boundary representation of a vector
+\(\psi\in\mathcal K_{N,L}(\widehat A)\).
+
 After \href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} was
 closed, the remaining source-comparison target is tracked by
-\href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}: derive those
-currently assumed trace-decomposition equalities from the PGVWC07
-\(C^j,D^j,E^j\) comparison in the source range
+\href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}: remove the
+remaining external boundary-representation input and discharge the crossing-tail
+word-span hypotheses from the PGVWC07 \(C^j,D^j,E^j\) comparison in the source
+range
 \begin{align}
   b\ge2,
   \qquad


### PR DESCRIPTION
Summary:
- records the two formal PGVWC comparison routes now present in the parent-Hamiltonian gap note
- identifies the remaining boundary after #2651 and #2977 as the crossing-tail word-span hypotheses and the block-diagonal boundary representation
- updates the paper-gap index so the current PGVWC status is visible to later readers

Validation:
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main
- git diff --check

Refs #2971
Refs #460
Refs #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to paper-gap notes; no code or proof logic changes.
> 
> **Overview**
> Updates **parent-Hamiltonian paper-gap documentation** so it matches the current Lean proof boundary after recent PGVWC work.
> 
> The block-diagonal parent ground-space note now describes **two formal PGVWC comparison routes**: the existing trace-decomposition implication and a new **word-indexed \(C^j,D^j\)** route (with cited Lean theorems) that derives the crossing comparison from a local block-sum constraint plus a **crossing-tail word-span** hypothesis. It states that the PGVWC comparison is no longer documented as a bare assumed trace identity; the open work is the **block-diagonal boundary representation** for \(\psi\in\mathcal K_{N,L}(\widehat A)\) and replacing the span-dependent crossing-tail path with the source **\(C^j,D^j,E^j\)** comparison—aligned with issue **#2971**.
> 
> The paper-gaps **README** index entry for `cpgsv21_block_diagonal_parent_ground_space.tex` is extended with the same PGVWC status for readers scanning the directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b804153ba97c4e9a2955696d072e5e6e4971146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->