### PR TITLE
chore(periodic,parent): clarify 1708 citations and imports

### DIFF
--- a/TNLean/Algebra/GramMatrixLI.lean
+++ b/TNLean/Algebra/GramMatrixLI.lean
@@ -13,7 +13,8 @@ convergence to any matrix with nonzero determinant (e.g. a diagonal matrix
 with positive entries). The special case of convergence to the identity is
 `eventually_linearIndependent_of_gram_tendsto_id`.
 
-Both are used in the MPDO papers arXiv:1606.00608 and arXiv:1708.00029.
+Both are used in the MPDO paper arXiv:1606.00608 and in the irreducible-form
+MPS paper arXiv:1708.00029.
 -/
 
 open scoped BigOperators InnerProductSpace
@@ -46,7 +47,7 @@ theorem eventually_linearIndependent_of_gram_tendsto_nondegenerate
     Matrix.linearIndependent_of_det_gram_ne_zero (𝕜 := ℂ) (v := fun i => v i N) hN
 
 /--
-**Lem1 (MPDO 1606.00608 / 1708.00029)**: eventual linear independence from
+**Lem1 (arXiv:1606.00608 / arXiv:1708.00029)**: eventual linear independence from
 Gram-matrix convergence to the identity.
 
 Special case of `eventually_linearIndependent_of_gram_tendsto_nondegenerate`

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -43,7 +43,7 @@ to channel / QPF normalization, following:
 ## References
 
 * [Cirac et al., arXiv:1606.00608, Section 2.3 and Appendix A][Cirac2017Annals]
-* [De las Cuevas et al., arXiv:1708.00029, Section 2.1][Cirac2017Irreducible]
+* [De las Cuevas et al., arXiv:1708.00029, Section 2.1][DeLasCuevas2017Irreducible]
 * [Pérez-García et al., quant-ph/0608197, Theorem 3][PerezGarcia2007]
 -/
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -2,6 +2,8 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Analysis.ProjectionGeometry
+import TNLean.MPS.ParentHamiltonian.CyclicWindow
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -23,7 +23,8 @@ Z-gauge theory used in its equal-case strengthening:
   proportional MPVs imply the dichotomy; here it is a direct hypothesis.)
 
 * **Supporting lemmas for Theorem 3.8**: The equal-case strengthening produces per-block
-  Z-gauge data (diagonal Z with Z^m = 1) from the Newton–Girard identity on sector weights.
+  Z-gauge data (diagonal Z with Z^m = 1) from the Newton–Girard identity on
+  multiplicity entries.
   The Z-gauge construction is packaged in `zgauge_construction` and
   `perBlock_zgauge_of_power_eq`.
 
@@ -530,7 +531,8 @@ overlap dichotomy and per-block weight power equality, then:
 
 1. **Block matching**: equal block counts, a bijection, and per-block `HetRepeatedBlocks`.
 2. **Scalar multiplicity-entry Z-gauge**: for each matched pair with period `m_j`,
-   there exists a `1 × 1` diagonal matrix `Z_j` with `Z_j^{m_j} = 1` and
+   there exists a `1 × 1` diagonal matrix `Z_j` with `Z_j^{m_j} = 1` and the
+   inverse-orientation scalar relation
    `Z_j * diag(μB_{perm j}) = diag(μA_j)`.
 3. **Multiplicity-entry equality**: `μA_j` and `μB_{perm j}` determine the same
    singleton multiset.

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -42,13 +42,11 @@ Theorem 3.4 is stated in two forms:
   which encode the paper's proportional-MPV assumption.
 
   **Caveat**: `periodicOverlapDichotomy` is stated and callable, but its proof still
-  depends on admitted lemmas in the split periodic-overlap modules:
-  `TNLean.MPS.Periodic.Overlap.SelfOverlap`,
-  `TNLean.MPS.Periodic.Overlap.Case2`,
-  `TNLean.MPS.Periodic.Overlap.Case3`, and
-  `TNLean.MPS.Periodic.Overlap.Dichotomy`. Subsequent results using the
-  `_of_isPeriodic` variant therefore inherit those proof obligations and should
-  not be treated as unconditional.
+  depends on the remaining Case-3 contraction and phase-assembly theorem
+  `repeatedBlocks_of_blockedSectorGaugePhase` in
+  `TNLean.MPS.Periodic.Overlap.Case3`. Subsequent results using the
+  `_of_isPeriodic` variant therefore inherit that obligation and should not be
+  treated as unconditional.
 
 The Z-gauge construction (Theorem 3.8 steps 5–7) is fully proved.
 
@@ -302,9 +300,9 @@ The `PeriodicOverlapHypothesis` parameter can be supplied via
 `PeriodicOverlapHypothesis.ofIsPeriodic`, which uses `periodicOverlapDichotomy`
 to fill the `hetRepeatedBlocks_of_nondecaying` field; see
 `fundamentalTheorem_periodic_proportional_of_isPeriodic`. Note that
-`periodicOverlapDichotomy` still relies on several admitted sub-lemmas in the split
-`TNLean.MPS.Periodic.Overlap.*` modules, so callers going through that route inherit
-those obligations. -/
+`periodicOverlapDichotomy` still relies on the remaining Case-3 contraction and
+phase-assembly theorem `repeatedBlocks_of_blockedSectorGaugePhase`, so callers
+going through that route inherit that obligation. -/
 theorem fundamentalTheorem_periodic_proportional
     (A : (j : Fin rA) → MPSTensor d (dimA j))
     (B : (k : Fin rB) → MPSTensor d (dimB k))
@@ -377,9 +375,11 @@ overlaps do not all vanish must match up to bijection and per-block `HetRepeated
 equivalence.
 
 **Remaining proof obligations.** `periodicOverlapDichotomy` is stated and callable, but
-its proof in `TNLean/MPS/Periodic/Overlap.lean` still contains several
-admitted sub-lemmas. Subsequent users of this theorem inherit those obligations — this
-variant is a convenience reformulation, not an unconditional strengthening. -/
+its proof still uses the remaining Case-3 contraction and phase-assembly theorem
+`repeatedBlocks_of_blockedSectorGaugePhase` from
+`TNLean.MPS.Periodic.Overlap.Case3`. Subsequent users of this theorem inherit
+that obligation: this variant is a convenience reformulation, not an
+unconditional strengthening. -/
 theorem fundamentalTheorem_periodic_proportional_of_isPeriodic
     (A : (j : Fin rA) → MPSTensor d (dimA j))
     (B : (k : Fin rB) → MPSTensor d (dimB k))
@@ -403,14 +403,17 @@ theorem fundamentalTheorem_periodic_proportional_of_isPeriodic
 
 end ProportionalCase
 
-/-! ## Z-gauge construction (Theorem 3.8, steps 5–7) -/
+/-! ## Multiplicity-entry Z-gauge construction (Theorem 3.8, steps 5–7) -/
 
 section ZGaugeConstruction
 
-/-- **Z-gauge diagonal from matched m-th powers (Theorem 3.8, step 7).**
+/-- **Multiplicity-entry Z-gauge from matched m-th powers (Theorem 3.8, step 7).**
 
-If two weight families have equal `m`-th powers and the denominators are nonzero, the
-Z-gauge diagonal `Z = diag(μ_i/ν_i)` satisfies `Z^m = 1` and `Z · diag(ν) = diag(μ)`.
+If two lists of multiplicity entries have equal `m`-th powers and the denominator
+entries are nonzero, the diagonal matrix `Z = diag(μ_i / ν_i)` satisfies
+`Z^m = 1` and `Z · diag(ν) = diag(μ)`. This is the scalar-entry orientation of the
+source relation `Z_j R_j = S_j` after choosing which multiplicity matrix is named
+`μ` and which is named `ν`.
 
 Combines `zGaugeDiagonal_pow_eq_one` and `zGaugeDiagonal_mul_diagonal`. -/
 theorem zgauge_construction
@@ -425,10 +428,11 @@ theorem zgauge_construction
    zGaugeDiagonal_pow_eq_one m μ ν hpow hν,
    zGaugeDiagonal_mul_diagonal μ ν hν⟩
 
-/-- **Per-block Z-gauge (Theorem 3.8, step 7 instantiated for `Fin r`).**
+/-- **Per-block multiplicity-entry Z-gauge (Theorem 3.8, step 7 for `Fin r`).**
 
-Convenience reformulation: given matched sector weights indexed by `Fin r` whose `m`-th powers
-agree and whose denominators are nonzero, produces the diagonal Z-gauge matrix. -/
+Convenience reformulation: given matched multiplicity entries indexed by `Fin r`
+whose `m`-th powers agree and whose denominator entries are nonzero, produces the
+diagonal Z-gauge matrix. -/
 theorem perBlock_zgauge_of_power_eq
     {r : ℕ} (m : ℕ) (μ ν : Fin r → ℂ)
     (hpow : ∀ i, μ i ^ m = ν i ^ m)
@@ -438,28 +442,32 @@ theorem perBlock_zgauge_of_power_eq
       Z * Matrix.diagonal ν = Matrix.diagonal μ :=
   zgauge_construction m μ ν hpow hν
 
-/-- **Weight multiset recovery via Newton-Girard (Theorem 3.8, step 6).**
+/-- **Multiplicity-entry multiset recovery via Newton-Girard (Theorem 3.8, step 6).**
 
-If two weight families have equal power sums for all positive exponents, they determine
-the same multiset. Direct reformulation of `Matrix.sum_pow_eq_implies_multiset_eq`. -/
+If two finite lists of multiplicity entries have equal power sums for all positive
+exponents, they determine the same multiset. Direct reformulation of
+`Matrix.sum_pow_eq_implies_multiset_eq`. -/
 theorem weight_multisets_eq_of_power_sums_eq
     {r : ℕ} (μ ν : Fin r → ℂ)
     (h : ∀ k : ℕ, 0 < k → ∑ i : Fin r, μ i ^ k = ∑ i : Fin r, ν i ^ k) :
     Finset.univ.val.map μ = Finset.univ.val.map ν :=
   Matrix.sum_pow_eq_implies_multiset_eq μ ν h
 
-/-- **Full Z-gauge construction (Theorem 3.8, steps 5–7 composed).**
+/-- **Scalar multiplicity-entry Z-gauge construction (Theorem 3.8, steps 5–7).**
 
-Given two sector weight families where:
+Given two multiplicity-entry families where:
 1. The `m`-th powers agree pointwise,
-2. The denominators are nonzero,
+2. The denominator entries are nonzero,
 3. Power sums agree for all positive exponents,
 
-produces: weight multiset equality, a diagonal Z with `Z^m = 1`, and `Z · diag(ν) = diag(μ)`.
+produces: multiplicity-entry multiset equality, a diagonal Z with `Z^m = 1`, and
+`Z · diag(ν) = diag(μ)`.
 
 In the full Theorem 3.8 proof, hypothesis (3) follows from BNT linear independence + equal
 MPVs (via `power_sums_eq_of_eventually_eq_hetero`), and hypothesis (1) is the Newton-Girard
-consequence of (3) restricted to multiples of `m`. -/
+consequence of (3) restricted to multiples of `m`. The source theorem uses
+matrix-valued multiplicities `R_j` and `S_j`; this theorem is the scalar-entry
+component used by the current Lean statement. -/
 theorem equalCase_zgauge_of_power_sums
     {r : ℕ} (m : ℕ) (μ ν : Fin r → ℂ)
     (hν : ∀ i, ν i ≠ 0)
@@ -479,7 +487,8 @@ end ZGaugeConstruction
 The equal-case Fundamental Theorem of MPS in irreducible form combines:
 
 1. **Theorem 3.4** (`fundamentalTheorem_periodic_proportional`): block matching.
-2. **Z-gauge construction** (`equalCase_zgauge_of_power_sums`): Newton–Girard + Z-gauge diagonal.
+2. **Z-gauge construction** (`equalCase_zgauge_of_power_sums`):
+   Newton–Girard plus a scalar multiplicity-entry Z-gauge diagonal.
 
 **Remaining source hypotheses:** The `PeriodicOverlapHypothesis` and per-block weight
 power equality hypotheses remain to be discharged from the periodic overlap dichotomy
@@ -514,22 +523,26 @@ theorem fundamentalTheorem_periodic_equalCase_matching
   fundamentalTheorem_periodic_proportional hA.blocks hB.blocks
     hNonRepA hNonRepB hOverlap
 
-/-- **Theorem 3.8: Periodic FT, equal case (arXiv:1708.00029).**
+/-- **Scalar component of the equal-case periodic FT (arXiv:1708.00029).**
 
 If two MPS tensors in irreducible form with non-repeating blocks satisfy the periodic
 overlap dichotomy and per-block weight power equality, then:
 
 1. **Block matching**: equal block counts, a bijection, and per-block `HetRepeatedBlocks`.
-2. **Per-block Z-gauge**: for each matched pair with period `m_j`, there exists a diagonal
-   `Z_j` with `Z_j^{m_j} = 1` and `Z_j * diag(μB_{perm j}) = diag(μA_j)`.
-3. **Weight multiset equality**: `μA_j` and `μB_{perm j}` determine the same multiset.
+2. **Scalar multiplicity-entry Z-gauge**: for each matched pair with period `m_j`,
+   there exists a `1 × 1` diagonal matrix `Z_j` with `Z_j^{m_j} = 1` and
+   `Z_j * diag(μB_{perm j}) = diag(μA_j)`.
+3. **Multiplicity-entry equality**: `μA_j` and `μB_{perm j}` determine the same
+   singleton multiset.
 
 This composes Theorem 3.4 with the Z-gauge construction.
 
 **Remaining source hypotheses:** The `PeriodicOverlapHypothesis` and `hPowEq` hypotheses
 remain to be discharged from the periodic overlap dichotomy and coefficient extraction
 theory. The Z-gauge construction itself (`equalCase_zgauge_of_power_sums`) is fully
-proved. -/
+proved. The source theorem allows arbitrary diagonal multiplicity matrices
+`R_j, S_j`; the present theorem records the scalar multiplicity-entry component,
+not the full multiplicity-space statement. -/
 theorem fundamentalTheorem_periodic_equalCase
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hA : IsIrreducibleForm A) (hB : IsIrreducibleForm B)

--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -491,10 +491,10 @@ The equal-case Fundamental Theorem of MPS in irreducible form combines:
 2. **Z-gauge construction** (`equalCase_zgauge_of_power_sums`):
    Newton–Girard plus a scalar multiplicity-entry Z-gauge diagonal.
 
-**Remaining source hypotheses:** The `PeriodicOverlapHypothesis` and per-block weight
-power equality hypotheses remain to be discharged from the periodic overlap dichotomy
-(Proposition 3.3) and the coefficient extraction theory. The Z-gauge construction itself
-is fully proved.
+**Remaining source hypotheses:** The `PeriodicOverlapHypothesis` and per-block
+multiplicity-entry power equality hypotheses remain to be discharged from the
+periodic overlap dichotomy (Proposition 3.3) and the coefficient extraction theory.
+The Z-gauge construction itself is fully proved.
 -/
 
 section EqualCase
@@ -527,13 +527,12 @@ theorem fundamentalTheorem_periodic_equalCase_matching
 /-- **Scalar component of the equal-case periodic FT (arXiv:1708.00029).**
 
 If two MPS tensors in irreducible form with non-repeating blocks satisfy the periodic
-overlap dichotomy and per-block weight power equality, then:
+overlap dichotomy and per-block multiplicity-entry power equality, then:
 
 1. **Block matching**: equal block counts, a bijection, and per-block `HetRepeatedBlocks`.
 2. **Scalar multiplicity-entry Z-gauge**: for each matched pair with period `m_j`,
-   there exists a `1 × 1` diagonal matrix `Z_j` with `Z_j^{m_j} = 1` and the
-   inverse-orientation scalar relation
-   `Z_j * diag(μB_{perm j}) = diag(μA_j)`.
+   there exists a `1 × 1` diagonal matrix `Z_j` with `Z_j^{m_j} = 1` and
+   `Z_j * diag(μA_j) = diag(μB_{perm j})`.
 3. **Multiplicity-entry equality**: `μA_j` and `μB_{perm j}` determine the same
    singleton multiset.
 
@@ -555,38 +554,42 @@ theorem fundamentalTheorem_periodic_equalCase
     (hOverlap : PeriodicOverlapHypothesis hA.blocks hB.blocks)
     (hPowEq : ∀ (perm : Fin hA.r ≃ Fin hB.r),
       (∀ j, HetRepeatedBlocks (hA.blocks j) (hB.blocks (perm j))) →
-      ∀ j N, 0 < N → (hA.μ j) ^ N = (hB.μ (perm j)) ^ N)
-    (hμB_ne : ∀ k, hB.μ k ≠ 0) :
+      ∀ j N, 0 < N → (hA.μ j) ^ N = (hB.μ (perm j)) ^ N) :
     -- Block matching:
     ∃ (_ : hA.r = hB.r) (perm : Fin hA.r ≃ Fin hB.r),
       -- Per-block HetRepeatedBlocks:
       (∀ j, HetRepeatedBlocks (hA.blocks j) (hB.blocks (perm j))) ∧
-      -- Per-block Z-gauge + weight multiset equality:
+      -- Per-block Z-gauge + multiplicity-entry multiset equality:
       (∀ j, ∃ Z : Matrix (Fin 1) (Fin 1) ℂ,
         Z ^ (hA.period j) = 1 ∧
-        Z * Matrix.diagonal (fun _ : Fin 1 => hB.μ (perm j)) =
-          Matrix.diagonal (fun _ : Fin 1 => hA.μ j) ∧
+        Z * Matrix.diagonal (fun _ : Fin 1 => hA.μ j) =
+          Matrix.diagonal (fun _ : Fin 1 => hB.μ (perm j)) ∧
         ({hA.μ j} : Multiset ℂ) = {hB.μ (perm j)}) := by
   -- Step 1: Block matching via Theorem 3.4.
   obtain ⟨hrAB, perm, hRep⟩ :=
     fundamentalTheorem_periodic_equalCase_matching A B hA hB hNonRepA hNonRepB hOverlap
   refine ⟨hrAB, perm, hRep, fun j => ?_⟩
-  -- Step 2: Per-block weight power equality from hypothesis.
+  -- Step 2: Per-block multiplicity-entry power equality from hypothesis.
   have hPowEqJ : ∀ N : ℕ, 0 < N → (hA.μ j) ^ N = (hB.μ (perm j)) ^ N :=
     hPowEq perm hRep j
-  -- Step 3: Z-gauge construction from matched weights.
+  -- Step 3: Z-gauge construction from matched multiplicity entries.
   have hPow_period : (hA.μ j) ^ (hA.period j) = (hB.μ (perm j)) ^ (hA.period j) :=
     hPowEqJ (hA.period j) (hA.periodic j).period_pos
+  have hμA_ne : hA.μ j ≠ 0 := by
+    intro hzero
+    have hcontr : (0 : ℝ) < 0 := by
+      simpa [hzero] using (hA.weight_pos j).1
+    exact (lt_irrefl (0 : ℝ)) hcontr
   obtain ⟨Z, hZpow, hZmul, hMultiset⟩ :=
     equalCase_zgauge_of_power_sums (hA.period j)
-      (fun _ : Fin 1 => hA.μ j) (fun _ : Fin 1 => hB.μ (perm j))
-      (fun _ => hμB_ne (perm j))
-      (fun _ => hPow_period)
-      (fun k hk => by simp only [Fin.sum_univ_one, hPowEqJ k hk])
+      (fun _ : Fin 1 => hB.μ (perm j)) (fun _ : Fin 1 => hA.μ j)
+      (fun _ => hμA_ne)
+      (fun _ => hPow_period.symm)
+      (fun k hk => by simp only [Fin.sum_univ_one, (hPowEqJ k hk).symm])
   refine ⟨Z, hZpow, hZmul, ?_⟩
   -- Convert Finset.univ.val.map to multiset singleton equality.
   simp only [Finset.univ_unique] at hMultiset
-  exact hMultiset
+  exact hMultiset.symm
 
 end EqualCase
 

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -58,8 +58,8 @@ theorem periodicOverlapDichotomy
   --                            → `periodicOverlap_tendsto_zero_of_no_sector_match`
   --   * same period/dim, a sector match
   --                            → `periodicOverlap_gaugeEquiv_of_sector_match`
-  -- Each branch theorem is proved; the sector-match branch is proved modulo the
-  -- two Case-3 leaves `sectorGaugePhaseEquiv_succ_of_cyclicTransport` and
+  -- Each branch theorem is proved; the sector-match branch is proved modulo
+  -- the remaining Case-3 contraction and phase-assembly theorem
   -- `repeatedBlocks_of_blockedSectorGaugePhase`.
   classical
   by_cases hm : m_a = m_b

--- a/TNLean/MPS/Periodic/Symmetry/EqualCaseFTHyp.lean
+++ b/TNLean/MPS/Periodic/Symmetry/EqualCaseFTHyp.lean
@@ -30,20 +30,28 @@ section PeriodicEqualCaseFTHyp
 
 variable {d D : ℕ}
 
-/-- The **periodic equal-case Fundamental Theorem of MPS** (Theorem 3.8 of
-arXiv:1708.00029) stated as a Prop, suitable for use as an explicit hypothesis.
+/-- Coarse abstract form of the periodic equal-case Fundamental Theorem of MPS,
+motivated by Theorem 3.8 of arXiv:1708.00029 and stated as a Prop for use as
+an explicit hypothesis.
 
 Given two tensors of the same physical/bond dimensions in irreducible form that
 generate the same matrix-product-vector family, this hypothesis asserts the existence
 of a positive period `m` and a `Z_m`-gauge equivalence between the two tensors.
 
+The source theorem has finer blockwise multiplicity data: after matching bases of
+periodic tensors, each block has its own period `m_j` and a diagonal matrix `Z_j`
+on the multiplicity space with `Z_j R_j = S_j`. The present hypothesis forgets
+that blockwise structure and records only the resulting global finite-order
+intertwining relation.
+
 Note that the Lean theorem `fundamentalTheorem_periodic_equalCase` in
 `MPS/Periodic/FundamentalTheorem.lean` requires four extra hypotheses beyond
 irreducibility and `SameMPV` (non-repetition of blocks for both tensors, the periodic
 overlap dichotomy, and a per-block weight-power equality). The Prop introduced here
-asserts the *unconditional* equal-case FT, so it is strictly stronger than the current
-repo theorem; callers committing to it are committing to the missing analytic content
-of `periodicOverlapDichotomy` (#78 / #81). The convention follows the analogous
+asserts an unconditional abstract equal-case hypothesis, so it is strictly stronger
+than the current repository theorem; callers committing to it are committing to the
+hypotheses recorded in `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.
+The convention follows the analogous
 hypothesis in `MPS/Periodic/Applications.lean`. -/
 def PeriodicEqualCaseFT (d D : ℕ) : Prop :=
   ∀ {X Y : MPSTensor d D},

--- a/TNLean/MPS/Periodic/ZGauge.lean
+++ b/TNLean/MPS/Periodic/ZGauge.lean
@@ -37,12 +37,12 @@ section ZGaugeDiagonal
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
-/-- Diagonal matrix implementing the periodic Z-gauge from a matched list of weights. -/
+/-- Diagonal matrix implementing the periodic Z-gauge from matched multiplicity entries. -/
 noncomputable def zGaugeDiagonal (μ ν : n → ℂ) : Matrix n n ℂ :=
   Matrix.diagonal (fun i => zGaugeEntry (μ i) (ν i))
 
-/-- If matched weights have equal `m`-th powers and the denominator weights are nonzero, then
-the associated Z-gauge diagonal satisfies `Z^m = 1`. -/
+/-- If matched multiplicity entries have equal `m`-th powers and the denominator entries
+are nonzero, then the associated Z-gauge diagonal satisfies `Z^m = 1`. -/
 theorem zGaugeDiagonal_pow_eq_one
     (m : ℕ) (μ ν : n → ℂ)
     (hpow : ∀ i, μ i ^ m = ν i ^ m)

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -268,19 +268,19 @@ The following compatibility theorems are proved in the present chapter.
     \lean{MPSTensor.ZGaugeEquiv}
     \leanok
     Let $A$ be an $m$-periodic irreducible tensor of bond dimension $D$.
-    A \emph{$Z$-gauge transformation} of $A$ is a diagonal unitary
-    matrix $Z \in \MN{D}$ satisfying:
+    The present global $Z$-gauge predicate is an algebraic witness
+    $Z \in \MN{D}$ satisfying:
     \begin{enumerate}
         \item $Z$ commutes with every Kraus operator: $[A^i, Z] = 0$
               for all physical indices $i$, and
-        \item $Z^m = \Id_D$ (all diagonal entries are $m$-th roots of unity).
+        \item $Z^m = \Id_D$.
     \end{enumerate}
-    Replacing $A$ by $ZA$ (i.e.\ $A^i \mapsto Z A^i$) leaves the
-    MPV family invariant for lengths $N$ that are multiples of $m$,
-    because the factor $\tr(Z^N) = \tr(\Id) = D$ for $N \equiv 0 \pmod{m}$.
     Two tensors $A, B$ are \emph{$Z$-gauge equivalent} if there exists
     an invertible $Y$ and a $Z$-gauge transformation $Z$ for $A$ such that
     $Z A^i = Y B^i Y^{-1}$ for all~$i$.
+    The source equal-case theorem uses the stronger block-multiplicity
+    diagonal gauges \(Z_j\) from Theorem~\ref{thm:periodic_ft}; those
+    data are not part of this global predicate.
 \end{definition}
 
 \begin{remark}[$Z$-gauge is trivial for period-$1$ blocks]

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -18,14 +18,15 @@ $p$-divisibility of the transfer map.
 \section{Periodic irreducible form and physical-index rotation}%
 \label{sec:periodic_irreducible_rotation}
 
-\begin{definition}[Periodic tensor]
+\begin{definition}[Left-canonical periodic tensor]
     \label{def:periodic_tensor}
     \lean{MPSTensor.IsPeriodic}
     \leanok
-    An irreducible MPS tensor $A$ of bond dimension $D$ is
-    \emph{$m$-periodic} (for some $m \ge 1$) if the peripheral spectrum
-    of its transfer map $\E_A$ is exactly the $m$-th roots of unity
-    $\{e^{2\pi i k/m} : 0 \le k < m\}$.
+    A left-canonical irreducible MPS tensor $A$ of bond dimension $D$ is
+    \emph{$m$-periodic} (for some $m \ge 1$) if the peripheral spectrum of
+    its transfer map $\E_A$ is exactly the $m$-th roots of unity
+    $\{e^{2\pi i k/m} : 0 \le k < m\}$. This is the normalized form-II
+    convention used later in the source.
     A $1$-periodic tensor is exactly an irreducible tensor with
     primitive transfer map (Definition~\ref{def:primitive_channel}).
 \end{definition}
@@ -268,7 +269,7 @@ The following compatibility theorems are proved in the present chapter.
     \lean{MPSTensor.ZGaugeEquiv}
     \leanok
     Let $A$ be an $m$-periodic irreducible tensor of bond dimension $D$.
-    The present global $Z$-gauge predicate is an algebraic witness
+    A global finite-order intertwining relation is given by a matrix
     $Z \in \MN{D}$ satisfying:
     \begin{enumerate}
         \item $Z$ commutes with every Kraus operator: $[A^i, Z] = 0$
@@ -278,9 +279,9 @@ The following compatibility theorems are proved in the present chapter.
     Two tensors $A, B$ are \emph{$Z$-gauge equivalent} if there exists
     an invertible $Y$ and a $Z$-gauge transformation $Z$ for $A$ such that
     $Z A^i = Y B^i Y^{-1}$ for all~$i$.
-    The source equal-case theorem uses the stronger block-multiplicity
-    diagonal gauges \(Z_j\) from Theorem~\ref{thm:periodic_ft}; those
-    data are not part of this global predicate.
+    The source equal-case theorem uses the finer block-multiplicity diagonal
+    gauges $Z_j$ from Theorem~\ref{thm:periodic_ft}; those multiplicity-space
+    matrices are not part of this global relation.
 \end{definition}
 
 \begin{remark}[$Z$-gauge is trivial for period-$1$ blocks]
@@ -423,15 +424,100 @@ unconditional result.
     which is left here as a separate hypothesis.
 \end{theorem}
 
+\begin{theorem}[Diagonal multiplicity gauge from equal powers]
+    \label{thm:zgauge_construction}
+    \lean{MPSTensor.zgauge_construction}
+    \leanok
+    \uses{lem:z_gauge_diagonal_pow, lem:z_gauge_diagonal_mul}
+    Let $(\mu_i)_{i\in I}$ and $(\nu_i)_{i\in I}$ be two finite lists of
+    nonzero multiplicity entries. If $\mu_i^m=\nu_i^m$ for every $i\in I$,
+    then there exists a diagonal matrix $Z$ such that
+    \[
+        Z^m=\Id,
+        \qquad
+        Z\,\diag(\nu)=\diag(\mu).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Take $Z=\diag(\mu_i/\nu_i)_{i\in I}$ and apply the two diagonal
+    identities from Lemmas~\ref{lem:z_gauge_diagonal_pow} and
+    \ref{lem:z_gauge_diagonal_mul}.
+\end{proof}
+
+\begin{theorem}[Scalar multiplicity gauge from power sums]
+    \label{thm:equalcase_zgauge_power_sums}
+    \lean{MPSTensor.equalCase_zgauge_of_power_sums}
+    \leanok
+    \uses{thm:zgauge_construction}
+    Let $(\mu_i)_{i\in I}$ and $(\nu_i)_{i\in I}$ be two finite lists of
+    multiplicity entries. Suppose that the $\nu_i$ are nonzero, that
+    $\mu_i^m=\nu_i^m$ for every $i\in I$, and that
+    \[
+        \sum_{i\in I}\mu_i^k=\sum_{i\in I}\nu_i^k
+    \]
+    for every positive integer $k$. Then the two lists determine the same
+    multiset, and there is a diagonal $Z$ satisfying
+    $Z^m=\Id$ and $Z\,\diag(\nu)=\diag(\mu)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:zgauge_construction} to obtain $Z$, and apply the
+    Newton--Girard power-sum identity to recover the multiplicity multiset.
+\end{proof}
+
+\begin{theorem}[Conditional matching of periodic bases]
+    \label{thm:periodic_equalcase_matching}
+    \lean{MPSTensor.fundamentalTheorem_periodic_equalCase_matching}
+    \leanok
+    \uses{def:irreducible_form}
+    Let $A$ and $B$ be in irreducible form, and suppose their bases of periodic
+    tensors contain no repeated pair of distinct basis elements. If the
+    periodic-overlap hypothesis holds for the two bases, then the two bases
+    have the same cardinality and are matched by a bijection whose matched
+    elements are repeated blocks.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply the proportional-case periodic Fundamental Theorem to the two bases
+    extracted from the irreducible-form decompositions.
+\end{proof}
+
+\begin{theorem}[Conditional scalar equal-case component]
+    \label{thm:periodic_equalcase_scalar_component}
+    \lean{MPSTensor.fundamentalTheorem_periodic_equalCase}
+    \leanok
+    \uses{thm:periodic_equalcase_matching, thm:equalcase_zgauge_power_sums}
+    Let $A$ and $B$ be in irreducible form, and suppose their bases of periodic
+    tensors contain no repeated pair of distinct basis elements. Assume the
+    periodic-overlap hypothesis and the corresponding power equality for the
+    scalar multiplicity entries. Then the bases are matched by a bijection, and
+    each matched pair has a scalar diagonal $Z_j\in M_1(\mathbb C)$ with
+    \[
+        Z_j^{m_j}=\Id,
+        \qquad
+        Z_j\,\diag(\mu_{B,\pi(j)})=\diag(\mu_{A,j}).
+    \]
+    The two scalar multiplicity entries also determine the same singleton
+    multiset.
+\end{theorem}
+
+\begin{proof}\leanok
+    First use Theorem~\ref{thm:periodic_equalcase_matching} to match the
+    periodic bases. For each matched block, apply
+    Theorem~\ref{thm:equalcase_zgauge_power_sums} to the singleton list of
+    multiplicity entries.
+\end{proof}
+
 \subsection{Periodic overlap dichotomy}
 
-\begin{definition}[Cyclic sector decomposition]%
+\begin{definition}[Off-diagonal sector decomposition]%
     \label{def:cyclic_sector_decomp}
     \lean{MPSTensor.IsCyclicSectorDecomp}
     \leanok
     \uses{def:periodic_tensor}
     A family of compressed sector tensors
-    $(C_k)_{k=0}^{m-1}$ on corner bond spaces forms a \emph{cyclic sector
+    $(C_k)_{k=0}^{m-1}$ on corner bond spaces forms an \emph{off-diagonal
         decomposition} of the blocked tensor $A^{(m)}$ if there exist orthogonal
     projections $P_0,\dotsc,P_{m-1}$ on the ambient bond space such that
     $\sum_k P_k = \Id$, the projections satisfy the cyclic-shift relation
@@ -1074,7 +1160,7 @@ unconditional result.
     every sector $A_u$ has nonzero virtual dimension. If there are sectors
     $u_0,v_0$ with $d_{u_0}=e_{v_0}$ and
     $A_{u_0}\sim_{\mathrm{gp}}B_{v_0}$ after identifying their virtual spaces,
-    then $A$ and $B$ are equivalent up to repeated blocks.
+    then $A$ and $B$ are repeated blocks.
 \end{theorem}
 
 \begin{theorem}[Different bond dimensions imply asymptotic orthogonality]%
@@ -1097,7 +1183,8 @@ unconditional result.
     alternatives holds:
     \begin{enumerate}
         \item $\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$;
-        \item $A$ and $B$ are equivalent up to repeated blocks.
+        \item $A$ and $B$ are repeated blocks, i.e. they differ by a
+              unit-modulus phase and an invertible gauge.
     \end{enumerate}
 \end{theorem}
 \begin{proof}\notready
@@ -1262,12 +1349,12 @@ unconditional result.
         thm:periodic_self_overlap_tendsto}
     Let $A$ and $B$ be periodic tensors with the same matrix product vectors.
     Then their bond dimensions agree, and after identifying the bond spaces,
-    $A$ and $B$ are equivalent up to repeated blocks.
+    $A$ and $B$ are repeated blocks.
 \end{theorem}
 \begin{proof}\notready
     By Theorem~\ref{thm:periodic_overlap_dichotomy}, either the overlap
     $\braket{V^{(N)}(A)}{V^{(N)}(B)}$ tends to $0$ or the bond dimensions agree
-    and $A$ and $B$ are equivalent up to repeated blocks. In the decay case,
+    and $A$ and $B$ are repeated blocks. In the decay case,
     equality of the MPV families gives, for every $N$,
     \begin{equation}\label{eq:pft_decay_mpv_equality}
         \braket{V^{(N)}(A)}{V^{(N)}(B)}
@@ -1298,14 +1385,14 @@ unconditional result.
     Assume that whenever two periodic tensors have proportional MPV families,
     one can rescale one tensor by a unit-modulus phase so that the MPV families
     agree exactly. Then proportional periodic MPV families already force the
-    tensors to agree up to repeated blocks.
+    tensors to be repeated blocks.
 \end{theorem}
 \begin{proof}\notready
     Apply the phase-rescaling hypothesis to replace $A$ by a periodic tensor
     $A'$ with the same MPV family as $B$. Theorem~\ref{thm:peripheral_periodic_ft_proportional_same}
     then yields repeated-block equivalence between $A'$ and $B$. Since $A'$
     differs from $A$ only by a unit-modulus phase, $A$ and $A'$ are themselves
-    equivalent up to repeated blocks, and transitivity gives the claim.
+    repeated blocks, and transitivity gives the claim.
 \end{proof}
 
 \begin{remark}[Proportional periodic FT]\notready
@@ -1316,8 +1403,8 @@ unconditional result.
     coefficient arrays with nonzero limits as hypotheses. That is not the
     hypothesis set of the source theorem.
     A faithful statement must instead derive the nondecaying cross-overlap
-    witnesses from the proportional MPV hypothesis and the periodic BNT
-    structure.
+    witnesses from the proportional MPV hypothesis and the basis of periodic
+    tensors.
 \end{remark}
 
 \section{Physical symmetries on periodic MPS}\label{sec:periodic_symmetry}

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -492,7 +492,8 @@ unconditional result.
     tensors contain no repeated pair of distinct basis elements. Assume the
     periodic-overlap hypothesis and the corresponding power equality for the
     scalar multiplicity entries. Then the bases are matched by a bijection, and
-    each matched pair has a scalar diagonal $Z_j\in M_1(\mathbb C)$ with
+    each matched pair has a scalar diagonal $Z_j\in M_1(\mathbb C)$ with the
+    inverse-orientation scalar relation
     \[
         Z_j^{m_j}=\Id,
         \qquad
@@ -1183,8 +1184,8 @@ unconditional result.
     alternatives holds:
     \begin{enumerate}
         \item $\braket{V^{(N)}(A)}{V^{(N)}(B)} \to 0$ as $N\to\infty$;
-        \item $A$ and $B$ are repeated blocks, i.e. they differ by a
-              unit-modulus phase and an invertible gauge.
+        \item $A$ and $B$ are related by the repeated-block relation, i.e. they
+              differ by a unit-modulus phase and an invertible gauge.
     \end{enumerate}
 \end{theorem}
 \begin{proof}\notready

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -205,7 +205,7 @@ The following compatibility theorems are proved in the present chapter.
 \begin{definition}[Entrywise periodic $Z$-gauge ratio]\label{def:z_gauge_entry}
     \lean{MPSTensor.zGaugeEntry}
     \leanok
-    Given complex weights $\mu,\nu$, define the entrywise
+    Given complex multiplicity entries $\mu,\nu$, define the entrywise
     $Z$-gauge ratio by
     \[
         z(\mu,\nu) := \mu/\nu.
@@ -236,7 +236,7 @@ The following compatibility theorems are proved in the present chapter.
     \lean{MPSTensor.zGaugeDiagonal}
     \leanok
     \uses{def:z_gauge_entry}
-    For matched weight families $(\mu_i)_i$ and $(\nu_i)_i$ on a finite
+    For matched multiplicity entries $(\mu_i)_i$ and $(\nu_i)_i$ on a finite
     index type, define the diagonal matrix
     \[
         Z := \diag\!(z(\mu_i,\nu_i))_i.
@@ -254,7 +254,7 @@ The following compatibility theorems are proved in the present chapter.
     \]
 \end{lemma}
 
-\begin{lemma}[Diagonal $Z$-gauge transports diagonal weights]\label{lem:z_gauge_diagonal_mul}
+\begin{lemma}[Diagonal $Z$-gauge transports diagonal multiplicities]\label{lem:z_gauge_diagonal_mul}
     \lean{MPSTensor.zGaugeDiagonal_mul_diagonal}
     \leanok
     \uses{def:z_gauge_diagonal, lem:z_gauge_entry_mul}
@@ -492,12 +492,11 @@ unconditional result.
     tensors contain no repeated pair of distinct basis elements. Assume the
     periodic-overlap hypothesis and the corresponding power equality for the
     scalar multiplicity entries. Then the bases are matched by a bijection, and
-    each matched pair has a scalar diagonal $Z_j\in M_1(\mathbb C)$ with the
-    inverse-orientation scalar relation
+    each matched pair has a scalar diagonal $Z_j\in M_1(\mathbb C)$ with
     \[
         Z_j^{m_j}=\Id,
         \qquad
-        Z_j\,\diag(\mu_{B,\pi(j)})=\diag(\mu_{A,j}).
+        Z_j\,\diag(\mu_{A,j})=\diag(\mu_{B,\pi(j)}).
     \]
     The two scalar multiplicity entries also determine the same singleton
     multiset.

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -11,7 +11,10 @@
 
 **Leaning on** (not audited in detail):
 - **CPSV21**: Cirac, Pérez-García, Schuch, Verstraete, *Matrix product states and projected entangled pair states: Concepts, symmetries, theorems*, Rev. Mod. Phys. **93**, 045003 (2021), arXiv:2011.12127 — used for the rendered numbering of the BNT and Fundamental Theorem statements.
-- **DSSPC17**: De las Cuevas, Schuch, Pérez-García, Cirac, *Continuum limits of matrix product states*, arXiv:1708.00029 — used in `Periodic/FundamentalTheorem.lean`.
+- **DeLasCuevas2017Irreducible**: Gemma De las Cuevas, J. Ignacio Cirac,
+  Norbert Schuch, David Pérez-García, *Irreducible forms of Matrix Product
+  States: Theory and Applications*, arXiv:1708.00029 — used in
+  `Periodic/FundamentalTheorem.lean`.
 
 **Scope**: This audit covers MPS / pure-state sections of PGVWC07 and CPSV16, plus a full Wielandt source-paper crosswalk (§9). The MPDO / mixed-state sections of CPSV16 (§IV, Appendix C) are listed for completeness but not deeply traced. A separate MPDO coverage audit is recommended.
 
@@ -212,7 +215,9 @@ Listed for completeness; detailed MPDO coverage audit is out of scope.
 | `Periodic/Overlap/Case3.lean` | 6 | Non-decaying self-overlap ⇒ gauge equivalence |
 | `Periodic/Overlap/Dichotomy.lean` | 4 | Top-level dichotomy assembly |
 
-These 15 sorrys cascade into `Periodic/FundamentalTheorem.lean` (Theorem 3.4 of DSSPC17), which has a conditional proof that takes the dichotomy as a hypothesis.
+These 15 sorrys cascade into `Periodic/FundamentalTheorem.lean` (Theorem 3.4
+of arXiv:1708.00029), which has a conditional proof that takes the dichotomy
+as a hypothesis.
 
 ### 4.2 Parent Hamiltonian cluster (issue #1484/#1485)
 

--- a/docs/audits/2026-05-08-mps-ft-paper-coverage.md
+++ b/docs/audits/2026-05-08-mps-ft-paper-coverage.md
@@ -22,9 +22,10 @@
 
 ---
 
-## 1. Current sorry/axiom statistics
+## 1. May 2026 sorry/axiom snapshot and current periodic-overlap update
 
-Collected 2026-05-08 with `rg -n "\bsorry\b|axiom" TNLean/MPS/ TNLean/PEPS/`:
+Historical snapshot collected 2026-05-08 with
+`rg -n "\bsorry\b|axiom" TNLean/MPS/ TNLean/PEPS/`:
 
 | File | Lines | Sorry count | Notes |
 |---|---|---|---|
@@ -38,7 +39,10 @@ Collected 2026-05-08 with `rg -n "\bsorry\b|axiom" TNLean/MPS/ TNLean/PEPS/`:
 | `TNLean/PEPS/FundamentalTheorem.lean` | 738 | 4 | PEPS FT (out of scope) |
 | **Total MPS** | — | **20** | Excluding PEPS |
 
-The periodic overlap dichotomy cluster (`Case2`, `Case3`, `Dichotomy`, `SelfOverlap`) accounts for 15 of 20 MPS sorrys — these are tracked by issue #81 ("periodic overlap dichotomy").
+As of 2026-06-17, the periodic-overlap cluster has been reduced to one live
+`sorry`, at `TNLean/MPS/Periodic/Overlap/Case3.lean`, for the
+`repeatedBlocks_of_blockedSectorGaugePhase` contraction and phase-assembly
+theorem. This is tracked by issue #873 under the proposition-level tracker #81.
 
 ---
 
@@ -210,13 +214,10 @@ Listed for completeness; detailed MPDO coverage audit is out of scope.
 
 | File | Sorrys | Dependency |
 |---|---|---|
-| `Periodic/Overlap/SelfOverlap.lean` | 2 | Self-overlap convergence converse |
-| `Periodic/Overlap/Case2.lean` | 3 | Non-decaying cross-family overlap ⇒ gauge inequivalence |
-| `Periodic/Overlap/Case3.lean` | 6 | Non-decaying self-overlap ⇒ gauge equivalence |
-| `Periodic/Overlap/Dichotomy.lean` | 4 | Top-level dichotomy assembly |
+| `Periodic/Overlap/Case3.lean` | 1 | Full-cycle contraction and phase assembly for repeated blocks (#873) |
 
-These 15 sorrys cascade into `Periodic/FundamentalTheorem.lean` (Theorem 3.4
-of arXiv:1708.00029), which has a conditional proof that takes the dichotomy
+This remaining `sorry` cascades into `Periodic/FundamentalTheorem.lean`
+(Theorem 3.4 of arXiv:1708.00029), whose conditional proof takes the dichotomy
 as a hypothesis.
 
 ### 4.2 Parent Hamiltonian cluster (issue #1484/#1485)

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -24,11 +24,9 @@ statements restrict the source.\footnote{Formal files:
 \leanid{TNLean/MPS/Periodic/Overlap/}. Local source:
 \leanid{Papers/1708.00029/main.tex}. Paper-level umbrella:
 \href{https://github.com/LionSR/TNLean/issues/619}{issue \#619}; proposition-level
-subtracking: \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81}
-(self-overlap limit and non-matching decay,
-\href{https://github.com/LionSR/TNLean/issues/448}{issue \#448}; sector-match
-propagation and gauge assembly,
-\href{https://github.com/LionSR/TNLean/issues/450}{issue \#450}).}
+subtracking: \href{https://github.com/LionSR/TNLean/issues/81}{issue \#81};
+the remaining Case-3 contraction and phase-assembly obligation is tracked by
+\href{https://github.com/LionSR/TNLean/issues/873}{issue \#873}.}
 
 The source proposition is \emph{equal-or-orthogonal-generalized}.\footnote{Stated
 in \cite{DeLasCuevas2017Irreducible}, lines 589--609, and proved in Appendix~A,


### PR DESCRIPTION
## Summary
- correct residual arXiv:1708.00029 citation prose and the De las Cuevas reference key in reader-facing documentation
- describe the current global `ZGaugeEquiv` blueprint entry as a finite-order algebraic relation, not the full source multiplicity-space diagonal gauge
- add the direct imports needed by `Martingale/Reduction.lean` for the anticommutator reduction declarations merged from #2980
- align the scalar equal-case \(Z\)-gauge component with the source orientation \(Z_jR_j=S_j\), and use multiplicity-entry language instead of sector-weight language

## Validation
- `lake env lean TNLean/Algebra/GramMatrixLI.lean`
- `lake env lean TNLean/MPS/Irreducible/FormII.lean`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Reduction`
- `lake env lean TNLean/MPS/Periodic/FundamentalTheorem.lean`
- `lake env lean TNLean/MPS/Periodic/ZGauge.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation, blueprint sync, and import wiring; the only behavioral Lean change is a localized proof refactor in `fundamentalTheorem_periodic_equalCase` with no auth or runtime impact.
> 
> **Overview**
> Documentation and alignment pass for arXiv:1708.00029 periodic MPS work: citations, terminology, gap tracking, blueprint sync, and a small Lean proof fix.
> 
> **Citations and references** split MPDO (1606.00608) from irreducible-form MPS (1708.00029) in `GramMatrixLI` and fix the De las Cuevas bibliography key in `FormII` and the MPS FT audit doc.
> 
> **Terminology** renames reader-facing “sector weights” to **multiplicity entries** across periodic FT Lean modules, `ZGauge.lean`, and blueprint `ch22_periodic_ft.tex`, and clarifies that global `ZGaugeEquiv` is a coarse finite-order intertwining relation, not the paper’s blockwise multiplicity-space diagonal gauges.
> 
> **Periodic overlap gaps** prose now points to a **single** remaining obligation—Case-3 `repeatedBlocks_of_blockedSectorGaugePhase` (#873)—instead of a multi-module sorry cluster.
> 
> **Blueprint** adds `\leanok` entries for proved scalar Z-gauge pieces (`zgauge_construction`, `equalCase_zgauge_of_power_sums`, conditional equal-case matching/scalar component) while keeping source Theorem 3.8 `\notready`.
> 
> **`fundamentalTheorem_periodic_equalCase`** drops hypothesis `hμB_ne`, derives `hA.μ j ≠ 0` from `weight_pos`, and fixes Z-gauge orientation to `Z * diag(μA) = diag(μB)`.
> 
> **`Martingale/Reduction.lean`** gains direct imports for `ProjectionGeometry` and `CyclicWindow` after merged anticommutator reductions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5851b1bfe5f080b97ab03a9868073a4951724060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->