### PR TITLE
feat(parent): package NNCPH ground-space condition

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -347,7 +347,13 @@ Under the same Appendix B product-of-pairs extraction used for
 `rfp_implies_nncph_of_appendixBExtraction`, the nearest-neighbor parent terms
 commute and the periodic MPS vector \(V^{(N)}(A)\) has zero energy. This adds
 only the standard parent-Hamiltonian frustration-free equation; it does not
-assert the source ground-space spanning clause from Definition 3.9. -/
+assert the source ground-space spanning clause from Definition 3.9.
+
+**Scope restriction (ground vector):** The source implication uses the full
+nearest-neighbor commuting parent Hamiltonian condition, including the
+ground-space spanning clause. This theorem proves only the ground-vector
+zero-energy equation under the Appendix B extraction hypothesis. Documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem rfp_implies_nncph_ground_state_of_appendixBExtraction
     (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -48,6 +48,8 @@ clause from Definition 3.9.
   \(Aᵢ = XΛUᵢX⁻¹\), the even-chain product-of-pairs factorization, and the
   two-site projector identities, without invoking
   `Axioms.rfp_to_nncph_commute`.
+* `MPSTensor.rfp_implies_nncph_ground_state_of_appendixBExtraction` — the same
+  conditional theorem with the zero-energy equation for \(V^{(N)}(A)\) included.
 * `MPSTensor.rfp_implies_nncph` — construction of the length-two commutation
   equations in the RFP \(\Longrightarrow\) NNCPH direction, using the
   structural characterization theorem of arXiv:1606.00608, source lines
@@ -246,6 +248,28 @@ theorem HasNNCPHGroundSpaces.hasParentHamiltonianGroundSpaceSpanning
     HasParentHamiltonianGroundSpaceSpanning B 2 A := by
   exact HasNNCPHGroundSpace.hasParentHamiltonianGroundSpaceSpanning h
 
+/-- The all-chain NNCPH ground-space condition is exactly the all-chain
+commutation-and-zero-energy condition together with the source ground-space
+spanning clause.
+
+This is the formal unpacking of arXiv:1606.00608, Definition 3.9 and
+Theorem 3.10(iii): the theorem statement quantifies over \(N>2\), while
+Definition 3.9 supplies the spanning equation for the nearest-neighbor
+parent Hamiltonian. -/
+theorem hasNNCPHGroundSpaces_iff_forall_isNNCPHGroundState_and_groundSpaceSpanning
+    {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)} :
+    HasNNCPHGroundSpaces B A ↔
+      (∀ N : ℕ, 2 < N → IsNNCPHGroundState B N) ∧
+        HasParentHamiltonianGroundSpaceSpanning B 2 A := by
+  constructor
+  · intro h
+    exact
+      ⟨fun N hN => (h N hN).isNNCPHGroundState,
+        h.hasParentHamiltonianGroundSpaceSpanning⟩
+  · rintro ⟨hGround, hSpan⟩ N hN
+    exact ⟨hGround N hN, hSpan N hN⟩
+
 /-- If each BNT vector is killed by the parent Hamiltonian, then their span is
 contained in the parent-Hamiltonian kernel.
 
@@ -316,6 +340,23 @@ theorem rfp_implies_nncph_of_appendixBExtraction (A : MPSTensor d D) [NeZero D]
     IsNNCPH A N :=
   commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction
     A hNT hRFP hLeft hExtract N
+
+/-- Conditional ground-vector form of Theorem 3.10(i)⟹(iii).
+
+Under the same Appendix B product-of-pairs extraction used for
+`rfp_implies_nncph_of_appendixBExtraction`, the nearest-neighbor parent terms
+commute and the periodic MPS vector \(V^{(N)}(A)\) has zero energy. This adds
+only the standard parent-Hamiltonian frustration-free equation; it does not
+assert the source ground-space spanning clause from Definition 3.9. -/
+theorem rfp_implies_nncph_ground_state_of_appendixBExtraction
+    (A : MPSTensor d D) [NeZero D]
+    (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
+    (hExtract : AppendixBProductPairExtraction
+      (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
+    (N : ℕ) (hN : 2 ≤ N) :
+    IsNNCPHGroundState A N :=
+  (rfp_implies_nncph_of_appendixBExtraction A hRFP hNT hLeft hExtract N).isNNCPHGroundState
+    hN
 
 /-- The commuting condition is symmetric: if `h i j` holds, then `h j i` holds. -/
 theorem IsCommutingParentHam.symm {A : MPSTensor d D} {L N : ℕ}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -137,6 +137,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \lean{MPSTensor.HasNNCPHGroundSpace.hasParentHamiltonianGroundSpaceSpanning}
     \lean{MPSTensor.HasNNCPHGroundSpaces.hasNNCPHGroundSpace}
     \lean{MPSTensor.HasNNCPHGroundSpaces.hasParentHamiltonianGroundSpaceSpanning}
+    \lean{MPSTensor.hasNNCPHGroundSpaces_iff_forall_isNNCPHGroundState_and_groundSpaceSpanning}
     \lean{MPSTensor.IsCommutingParentHam.symm}
     \lean{MPSTensor.IsCommutingParentHam.ham_comm_localTerm}
     \leanok
@@ -158,7 +159,9 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \]
     and quantifying this condition over all $N>2$ gives the
     nearest-neighbor case of the spanning condition above.
-    This is exactly the condition named in
+    Conversely, the all-chain condition is exactly the conjunction of the
+    all-chain ground-vector equations and the nearest-neighbor instance of the
+    spanning condition above. This is precisely the condition named in
     Definition~\ref{def:has_nncph_ground_spaces}.
 \end{remark}
 
@@ -276,6 +279,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \lean{MPSTensor.AppendixBProductPairExtraction.commuting_twoSite_localTerms}
     \lean{MPSTensor.commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction}
     \lean{MPSTensor.rfp_implies_nncph_of_appendixBExtraction}
+    \lean{MPSTensor.rfp_implies_nncph_ground_state_of_appendixBExtraction}
     \leanok
     The Appendix~B structural form supplies
     \[
@@ -309,7 +313,9 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     which is the nearest-neighbor commuting conclusion for every finite chain.
     The even-chain factorization and the two-site projector identification are
     the inputs supplied by Appendix~B of \cite{Cirac2016MPDO_arXiv}; given them,
-    the local terms commute.
+    the local terms commute. Together with Lemma~\ref{lem:parent_hamiltonian_ff},
+    they also give the zero-energy equation for \(V^{(N)}(A)\), still without
+    asserting the source ground-space spanning condition.
 \end{remark}
 
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -81,6 +81,11 @@ The source theorem should use the all-chain predicate
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, which quantifies this fixed-chain
 condition over \(N>2\). The predicate is only a named condition; it does not
 prove that the spanning equation holds for any concrete canonical-form tensor.
+The equivalence
+\leanid{MPSTensor.hasNNCPHGroundSpaces_iff_forall_isNNCPHGroundState_and_groundSpaceSpanning}
+records this separation formally: the all-chain source condition is exactly the
+all-chain ground-vector equations together with the nearest-neighbor instance of
+the ground-space spanning clause.
 The easy inclusion in the spanning equation is now recorded: if each component
 vector \(V^{(N)}(A_j)\) is annihilated by the parent Hamiltonian, or more
 strongly by every local term, then


### PR DESCRIPTION
Summary:
- adds a definition-level equivalence unpacking the all-chain NNCPH ground-space condition as all-chain ground-vector equations plus the source ground-space spanning clause
- adds the Appendix B conditional ground-vector wrapper, using the existing product-of-pairs commutation theorem and frustration-freeness of the canonical parent interaction
- updates the parent-Hamiltonian blueprint and CPSV16 gap note so the source condition is stated without conflating it with the narrower ground-vector predicate

Validation:
- lake build TNLean.MPS.ParentHamiltonian.Commuting
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/check_oversized_lean_files.py
- git diff --check

Refs #2633
Refs #190
Refs #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean formalization and documentation only; no changes to axioms, auth, or runtime behavior.
> 
> **Overview**
> Formalizes how the **all-chain** NNCPH ground-space predicate (`HasNNCPHGroundSpaces`) relates to weaker pieces: a new **iff** shows it is exactly “for every \(N>2\), `IsNNCPHGroundState`” **plus** the nearest-neighbor **ground-space spanning** clause (`HasParentHamiltonianGroundSpaceSpanning`), so the paper’s Definition 3.9 spanning requirement is not conflated with the ground-vector-only predicate.
> 
> Adds **`rfp_implies_nncph_ground_state_of_appendixBExtraction`**, which under the same Appendix B product-of-pairs extraction as the existing commutation theorem derives **`IsNNCPHGroundState`** (commutation + zero energy for \(V^{(N)}(A)\) via `IsNNCPH.isNNCPHGroundState`), still **without** the spanning clause.
> 
> The parent-Hamiltonian blueprint chapter and `cpsv16_nncph_ground_state_scope.tex` are updated to cite the new Lean names and state the iff / Appendix B ground-vector scope explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 216a5a75b543b77187b62cf63c77a75c2964c689. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->