### PR TITLE
doc(periodic): record independence-only scope

### DIFF
--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1244,6 +1244,15 @@ unconditional result.
     \[
         \ker \Phi_N=\{0\}.
     \]
+
+    \emph{Scope restriction.}  The source consequence following
+    \cite[Proposition~3.3]{DeLasCuevas2017Irreducible} also states that
+    the non-zero vectors $\ket{V_N(A_j)}$ span the vector $\ket{V_N(A)}$;
+    this spanning assertion is what the paper cites as justification for
+    the phrase ``basis of periodic vectors''.  The theorem recorded here
+    contains only the independence assertion.  This restriction and its
+    elimination plan are recorded in
+    \path{docs/paper-gaps/1708_periodic_overlap_route_alignment.tex}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1250,9 +1250,10 @@ unconditional result.
     the non-zero vectors $\ket{V_N(A_j)}$ span the vector $\ket{V_N(A)}$;
     this spanning assertion is what the paper cites as justification for
     the phrase ``basis of periodic vectors''.  The theorem recorded here
-    contains only the independence assertion.  This restriction and its
-    elimination plan are recorded in
-    \path{docs/paper-gaps/1708_periodic_overlap_route_alignment.tex}.
+    contains only the independence assertion.  The corresponding paper-gap
+    note, \path{docs/paper-gaps/1708_periodic_overlap_route_alignment.tex},
+    Section ``Scope restriction: independence without spanning'', records
+    this restriction and its elimination plan.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
## Summary

This PR adds a scope-restriction note to the blueprint theorem on eventual linear independence of periodic vectors.

The source consequence following Proposition 3.3 of arXiv:1708.00029 states two assertions: the non-zero vectors \(\ket{V_N(A_j)}\) are linearly independent, and they span \(\ket{V_N(A)}\). The current formalized theorem records only the independence assertion. The added note makes clear that the spanning assertion is not yet part of this blueprint entry.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

Not run locally: a Lake module build. This branch changes only blueprint prose, and the fresh worktree began reconstructing the Mathlib cache rather than checking changed Lean content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint prose only; no Lean or runtime behavior changes.
> 
> **Overview**
> Adds a **scope restriction** note to the blueprint theorem on eventual linear independence of periodic vectors (`thm:periodic_basis_eventually_li`).
> 
> The note states that the consequence after Proposition 3.3 in De las Cuevas et al. includes both linear independence of the non-zero \(\ket{V_N(A_j)}\) and **spanning** of \(\ket{V_N(A)}\)—the latter is what the paper uses to justify “basis of periodic vectors.” The entry formalized here records **only** the independence half (\(\ker \Phi_N = \{0\}\)). It cross-references `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex` (section “Scope restriction: independence without spanning”) for the gap and planned closure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca4e2b92e98da923e058c3bdbbabc759e2d09ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->