### PR TITLE
feat(parent): expose anticommutator gap wrapper

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -15,10 +15,14 @@ estimate remains an explicit hypothesis.
 
 * `parentHamiltonianES_gap_bound_of_friedrichs` — the explicit gap bound
   obtained from the overlapping-window norm-compression estimate.
+* `parentHamiltonianES_gap_bound_of_anticommutator` — the explicit gap bound
+  obtained from the source anticommutator estimate.
 * `parentHamiltonianES_gap_bound_of_overlap_norm_constant` — the corresponding
   positive-gap bound from a strict uniform compression coefficient.
 * `parentHamiltonian_gapped` — conditional uniform spectral gap for MPS parent
   Hamiltonians under the same principal-angle input.
+* `parentHamiltonian_gapped_of_anticommutator` — conditional uniform spectral
+  gap under the source anticommutator estimate.
 * `parentHamiltonian_gapped_of_overlap_norm_constant` — the corresponding
   uniform spectral gap from a strict uniform compression coefficient.
 -/
@@ -30,6 +34,41 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-! ### Uniform spectral gap for the MPS parent Hamiltonian -/
+
+/-- Gap bound from the cyclic-window anticommutator martingale estimate.
+
+This is the source-facing form of the MPS parent-Hamiltonian gap reduction.  The
+hypothesis is the anticommutator lower bound appearing in arXiv:2011.12127,
+Section IV.C, equation `eq:4:martingale-2`, specialized to overlapping cyclic
+windows:
+\[
+  h_i h_j+h_j h_i
+  \ge
+  -\left(1-\frac1{4L}\right)\frac1{2(L-1)}(h_i+h_j).
+\]
+The finite row-counting geometry, cyclic-window non-overlap positivity, and
+martingale reduction are proved in `Martingale.Reduction`.  This theorem does
+not prove the remaining MPS-specific anticommutator estimate; it exposes it as
+the final conditional input. -/
+theorem parentHamiltonianES_gap_bound_of_anticommutator
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (hAnti : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹) *
+              ((⟪localTermES A L i v, v⟫_ℂ).re +
+                (⟪localTermES A L j v, v⟫_ℂ).re) ≤
+            (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+              (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re) :
+    0 < (1 : ℝ) / (4 * (L : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator
+    A L hL hAnti
 
 /-- Gap bound from a strict uniform overlapping cyclic-window compression
 coefficient for the MPS parent Hamiltonian.
@@ -196,6 +235,40 @@ theorem parentHamiltonian_gapped
         γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
   obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_friedrichs A L hL
     hOverlapNorm
+  exact ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, hgap⟩
+
+/--
+**Conditional spectral gap from the source anticommutator estimate.**
+
+For an MPS tensor \(A\) and interaction range \(L > 1\), the cyclic-window
+anticommutator estimate
+\[
+  h_i h_j+h_jh_i\ge
+  -\left(1-\frac1{4L}\right)\frac1{2(L-1)}(h_i+h_j)
+\]
+for overlapping off-diagonal pairs implies a uniform gap \(γ>0\), independent
+of the chain length.
+
+This is the public gapped theorem matching the martingale condition in
+arXiv:2011.12127, Section IV.C, equation `eq:4:martingale-2`. The
+MPS-specific proof of the anticommutator estimate remains the open input. -/
+theorem parentHamiltonian_gapped_of_anticommutator
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
+    (hAnti : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
+              (((2 * (L - 1) : ℕ) : ℝ)⁻¹) *
+              ((⟪localTermES A L i v, v⟫_ℂ).re +
+                (⟪localTermES A L j v, v⟫_ℂ).re) ≤
+            (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re +
+              (⟪localTermES A L j v, localTermES A L i v⟫_ℂ).re) :
+    ∃ γ > 0, ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
+  obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_anticommutator A L hL
+    hAnti
   exact ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, hgap⟩
 
 /--

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -39,7 +39,7 @@ variable {d D : ℕ}
 
 This is the source-facing form of the MPS parent-Hamiltonian gap reduction.  The
 hypothesis is the anticommutator lower bound appearing in arXiv:2011.12127,
-Section IV.C, equation `eq:4:martingale-2`, specialized to overlapping cyclic
+Section IV.C, equation eq:4:martingale-2, specialized to overlapping cyclic
 windows:
 \[
   h_i h_j+h_j h_i
@@ -250,7 +250,7 @@ for overlapping off-diagonal pairs implies a uniform gap \(γ>0\), independent
 of the chain length.
 
 This is the public gapped theorem matching the martingale condition in
-arXiv:2011.12127, Section IV.C, equation `eq:4:martingale-2`. The
+arXiv:2011.12127, Section IV.C, equation eq:4:martingale-2. The
 MPS-specific proof of the anticommutator estimate remains the open input. -/
 theorem parentHamiltonian_gapped_of_anticommutator
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -1289,8 +1289,7 @@ sufficient stronger hypotheses.
     \label{thm:anticommutator_gap_bound}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_anticommutator}
     \leanok
-    \uses{lem:parent_hamiltonian_cyclic_overlap_anticommutator_gap,
-        lem:martingale_mps}
+    \uses{lem:parent_hamiltonian_cyclic_overlap_anticommutator_gap}
     Let \(L>1\). Suppose that for every \(N\ge2L\) and every overlapping
     off-diagonal pair of cyclic length-\(L\) windows,
     \[
@@ -1315,9 +1314,8 @@ sufficient stronger hypotheses.
 \begin{proof}
     \leanok
     This is Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_anticommutator_gap}
-    stated as the public conditional gap theorem.  The remaining mathematical
-    input is exactly the anticommutator estimate isolated in
-    Lemma~\ref{lem:martingale_mps}.
+    stated as the public conditional gap theorem, with the anticommutator
+    inequality retained as an explicit hypothesis.
 \end{proof}
 
 \begin{theorem}[Gap bound from a strict cyclic compression constant]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -1285,6 +1285,41 @@ sufficient stronger hypotheses.
     $\gamma_L=1/(4L)$.
 \end{proof}
 
+\begin{theorem}[Gap bound from a cyclic anticommutator estimate]
+    \label{thm:anticommutator_gap_bound}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_anticommutator}
+    \leanok
+    \uses{lem:parent_hamiltonian_cyclic_overlap_anticommutator_gap,
+        lem:martingale_mps}
+    Let \(L>1\). Suppose that for every \(N\ge2L\) and every overlapping
+    off-diagonal pair of cyclic length-\(L\) windows,
+    \[
+        h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}
+        + h_{j,\mathrm{ES}}h_{i,\mathrm{ES}}
+        \ge
+        -\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}
+          (h_{i,\mathrm{ES}}+h_{j,\mathrm{ES}})
+    \]
+    in quadratic form. Then the parent Hamiltonian has the explicit gap
+    constant
+    \[
+        \gamma_L := \frac{1}{4L}>0.
+    \]
+    Concretely, if \(N\ge2L\) and
+    \(v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp\), then
+    \[
+        \gamma_L\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    This is Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_anticommutator_gap}
+    stated as the public conditional gap theorem.  The remaining mathematical
+    input is exactly the anticommutator estimate isolated in
+    Lemma~\ref{lem:martingale_mps}.
+\end{proof}
+
 \begin{theorem}[Gap bound from a strict cyclic compression constant]
     \label{thm:friedrichs_gap_bound_constant}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_overlap_norm_constant}
@@ -1323,10 +1358,12 @@ sufficient stronger hypotheses.
 \begin{theorem}[Conditional spectral gap for MPS parent Hamiltonians]
     \label{thm:parent_hamiltonian_gapped}
     \lean{MPSTensor.parentHamiltonian_gapped}
+    \lean{MPSTensor.parentHamiltonian_gapped_of_anticommutator}
     \leanok
-    \uses{thm:friedrichs_gap_bound}
-    For a tensor $A$ and a range $L > 1$, assume the overlapping
-    cyclic-window norm-compression estimate of
+    \uses{thm:anticommutator_gap_bound, thm:friedrichs_gap_bound}
+    For a tensor $A$ and a range $L > 1$, assume either the cyclic-window
+    anticommutator estimate of Theorem~\ref{thm:anticommutator_gap_bound} or the
+    stronger overlapping cyclic-window norm-compression estimate of
     Theorem~\ref{thm:friedrichs_gap_bound}. Then there exists $\gamma > 0$ such
     that for every $N \ge 2L$ and every vector
     $v \in (\mathcal G_{N,L}^{\mathrm{ES}}(A))^{\perp}$ one has
@@ -1339,8 +1376,8 @@ sufficient stronger hypotheses.
 
 \begin{proof}
     \leanok
-    This follows immediately from Theorem~\ref{thm:friedrichs_gap_bound} by
-    taking $\gamma$ to be the explicit constant produced there.
+    This follows immediately from the corresponding explicit theorem by taking
+    $\gamma$ to be the constant produced there.
 \end{proof}
 
 \begin{theorem}[Conditional spectral gap from a strict cyclic compression constant]

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -180,6 +180,10 @@ without passing through this stronger one-sided estimate.\footnote{The
     \leanid{quadraticForm_sum_projections_of_finite_overlap_anticommutator},
     \leanid{parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator}, and
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator}.
+    The corresponding final gap statements are
+    \leanid{parentHamiltonianES_gap_bound_of_anticommutator} and
+    \leanid{parentHamiltonian_gapped_of_anticommutator} in
+    \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}.
     The cyclic-window compression reductions are
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs},
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound},


### PR DESCRIPTION
Summary:
- adds public gap theorems in `Martingale.Gap` under the cyclic-window anticommutator estimate matching arXiv:2011.12127, Section IV.C
- keeps the older norm-compression route as a sufficient stronger hypothesis
- updates the spectral-gap blueprint and martingale paper-gap note to make the anticommutator estimate the visible final conditional input

Validation:
- lake build TNLean.MPS.ParentHamiltonian.Martingale.Gap
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/check_forbidden_lean_tokens.py --base-ref origin/main
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/check_oversized_lean_files.py
- git diff --check

Refs #952
Refs #460
Refs #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and thin Lean wrappers over existing proofs; no auth, runtime, or behavioral changes beyond new public theorem names.
> 
> **Overview**
> Adds **public** conditional spectral-gap theorems in `Martingale/Gap.lean` that take the cyclic-window **anticommutator** estimate (arXiv:2011.12127 martingale-2) as the hypothesis, with gap constant **γ = 1/(4L)**. Each new theorem is a thin `exact` wrapper around the existing reduction in `Martingale.Reduction`; the MPS-specific anticommutator bound stays an explicit open input.
> 
> **`parentHamiltonianES_gap_bound_of_anticommutator`** and **`parentHamiltonian_gapped_of_anticommutator`** mirror the Friedrichs / norm-compression entry points so readers can cite the source-facing condition directly. The blueprint gains **Theorem `anticommutator_gap_bound`** and broadens **conditional spectral gap** to allow either anticommutator or stronger overlap norm-compression. The martingale paper-gap note links to these final `Gap.lean` declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12b4bbe104e86f6d9a6cc2fd3628fdd9609f4c85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->