### PR TITLE
doc(peps): record TI MPS description scope

### DIFF
--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2721,7 +2721,7 @@ state is invariant under the cyclic shift. Its conclusion is not a gauge
 between two given tensor families: the proof applies the non-translation
 invariant closed-chain theorem to the family and its cyclic shift, obtains
 per-bond gauges \(Z_i\), and then telescopes them to construct a repeated
-tensor \(B=Z_1^{-1}A_1\) that gives the same state.
+tensor \(B=A_1Z_1^{-1}\) that gives the same state.
 
 This corollary is not covered by the two-tensor results above. The already
 formalized statements compare two supplied tensors, or two supplied repeated

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2722,6 +2722,18 @@ between two given tensor families: the proof applies the non-translation
 invariant closed-chain theorem to the family and its cyclic shift, obtains
 per-bond gauges \(Z_i\), and then telescopes them to construct a repeated
 tensor \(B=A_1Z_1^{-1}\) that gives the same state.
+Writing \(T\) for the cyclic shift, the source assertion is the implication
+\[
+    \begin{gathered}
+    T\Psi(A_1,\ldots,A_n)=\Psi(A_1,\ldots,A_n) \\
+    \Longrightarrow \\
+    D_1=\cdots=D_n
+    \quad\text{and}\quad
+    \exists B,\ \Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B),
+    \end{gathered}
+\]
+with \(B=A_1Z_1^{-1}\) after the gauges from the comparison with the shifted
+chain are telescoped.
 
 This corollary is not covered by the two-tensor results above. The already
 formalized statements compare two supplied tensors, or two supplied repeated
@@ -2735,7 +2747,19 @@ faithful statement therefore requires a per-bond, rectangular matrix model in
 which the adjacent invertible gauges first imply equality of the bond
 dimensions. Until that vocabulary exists, the intended first theorem is the
 uniform-\(D\) existence statement, carrying this scope restriction explicitly;
-the per-bond-dimension theorem remains a separate follow-up.
+the per-bond-dimension theorem remains a separate follow-up. In symbols, the
+initial restricted statement is only
+\[
+    T\Psi(A_1,\ldots,A_n)=\Psi(A_1,\ldots,A_n)
+    \quad\Longrightarrow\quad
+    \exists B,\ \Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B),
+\]
+under a prior uniform bond-dimension hypothesis on the family \(A_i\).
+
+\emph{Verdict: scope restriction.} The uniform-\(D\) theorem can record the
+existence of the repeated tensor \(B\), but it cannot express the source's
+equal-bond-dimension conclusion as a theorem with mathematical content. The
+per-bond rectangular version remains open.
 
 \section*{The strengthening to $n \ge 2L+1$ via overlapping windows}
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2711,6 +2711,32 @@ $n \ge 2L + 1$ sites from it, and reuse the matrix-level collapse above
 verbatim — the collapse itself nowhere uses $3L \le n$ beyond consuming the
 per-bond family.
 
+\section*{The Applications translation-invariant description corollary}
+
+The Applications section contains a different translation-invariance
+corollary (lines 1801--1890 of
+\path{Papers/1804.04964/paper_normal.tex}), tracked by \ghissue{2920}. Its
+input is a single site-dependent injective MPS whose resulting closed-chain
+state is invariant under the cyclic shift. Its conclusion is not a gauge
+between two given tensor families: the proof applies the non-translation
+invariant closed-chain theorem to the family and its cyclic shift, obtains
+per-bond gauges \(Z_i\), and then telescopes them to construct a repeated
+tensor \(B=Z_1^{-1}A_1\) that gives the same state.
+
+This corollary is not covered by the two-tensor results above. The already
+formalized statements compare two supplied tensors, or two supplied repeated
+tensors, with the same closed-chain state. They do not start from one
+site-dependent family and a cyclic-shift invariance hypothesis on its state,
+and they do not construct the comparison tensor internally. A uniform
+matrix-tensor version would be faithful to the existence of the repeated
+description, but would make the source's ``all bond dimensions are the same''
+conclusion vacuous: the type already fixes one bond dimension \(D\). The fully
+faithful statement therefore requires a per-bond, rectangular matrix model in
+which the adjacent invertible gauges first imply equality of the bond
+dimensions. Until that vocabulary exists, the intended first theorem is the
+uniform-\(D\) existence statement, carrying this scope restriction explicitly;
+the per-bond-dimension theorem remains a separate follow-up.
+
 \section*{The strengthening to $n \ge 2L+1$ via overlapping windows}
 
 The plan recorded in the previous section is carried out: the source's


### PR DESCRIPTION
## Summary
- records the Applications-section translation-invariant MPS description corollary from arXiv:1804.04964, lines 1801--1890
- distinguishes this single-family cyclic-invariance statement from the existing two-tensor translation-invariant corollaries
- records the uniform-D scope restriction and the per-bond-dimension follow-up needed for the source's equal-bond-dimension conclusion

## Validation
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main..HEAD`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error peps_normal_ft_section3_route.tex` (succeeds; the large pre-existing note still emits layout/font warnings)

Refs #2920.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a LaTeX gap-tracking note; no code, auth, or runtime behavior is affected.
> 
> **Overview**
> Adds a new section to the normal PEPS route note documenting the **Applications-section** translation-invariant MPS description corollary (arXiv:1804.04964, lines 1801–1890), tracked as GitHub issue **#2920**.
> 
> The new text contrasts this result with the already formalized two-tensor translation-invariant corollaries: it starts from **one** site-dependent injective family plus **cyclic-shift invariance** of the closed-chain state, and concludes with equal bond dimensions and a repeated tensor \(B\) (with \(B=A_1Z_1^{-1}\) after telescoping gauges from comparing the family to its shift)—not a gauge between two given families.
> 
> It records a **scope restriction** for the first Lean target: under uniform bond dimension \(D\), only the existence statement \(\exists B\) with \(\Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B)\) is meaningful; the source’s \(D_1=\cdots=D_n\) conclusion needs a future per-bond rectangular model. **Verdict:** uniform-\(D\) can capture repeated-tensor existence; equal bond dimensions stay open until that vocabulary exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7483d5d339236d663db10964872f4f0f077bf7bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->