### PR TITLE
doc(peps): preserve injective TI MPS target

### DIFF
--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2721,7 +2721,7 @@ state is invariant under the cyclic shift. Its conclusion is not a gauge
 between two given tensor families: the proof applies the non-translation
 invariant closed-chain theorem to the family and its cyclic shift, obtains
 per-bond gauges \(Z_i\), and then telescopes them to construct a repeated
-tensor \(B=A_1Z_1^{-1}\) that gives the same state.
+injective tensor \(B=A_1Z_1^{-1}\) that gives the same state.
 Writing \(T\) for the cyclic shift, the source assertion is the implication
 \[
     \begin{gathered}
@@ -2729,7 +2729,8 @@ Writing \(T\) for the cyclic shift, the source assertion is the implication
     \Longrightarrow \\
     D_1=\cdots=D_n
     \quad\text{and}\quad
-    \exists B,\ \Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B),
+    \exists B,\ B\text{ is injective and }
+    \Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B),
     \end{gathered}
 \]
 with \(B=A_1Z_1^{-1}\) after the gauges from the comparison with the shifted
@@ -2752,14 +2753,15 @@ initial restricted statement is only
 \[
     T\Psi(A_1,\ldots,A_n)=\Psi(A_1,\ldots,A_n)
     \quad\Longrightarrow\quad
-    \exists B,\ \Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B),
+    \exists B,\ B\text{ is injective and }
+    \Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B),
 \]
 under a prior uniform bond-dimension hypothesis on the family \(A_i\).
 
 \emph{Verdict: scope restriction.} The uniform-\(D\) theorem can record the
-existence of the repeated tensor \(B\), but it cannot express the source's
-equal-bond-dimension conclusion as a theorem with mathematical content. The
-per-bond rectangular version remains open.
+existence of the repeated injective tensor \(B\), but it cannot express the
+source's equal-bond-dimension conclusion as a theorem with mathematical
+content. The per-bond rectangular version remains open.
 
 \section*{The strengthening to $n \ge 2L+1$ via overlapping windows}
 


### PR DESCRIPTION
## Summary

This follow-up to #2989 keeps the Applications-section TI MPS corollary note faithful to arXiv:1804.04964, lines 1801--1890.

The displayed source assertion and the restricted uniform-D target now both require the repeated tensor B to be injective. The equal-bond-dimension conclusion remains the part that cannot yet be expressed faithfully without a per-bond rectangular matrix model.

## Validation

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a LaTeX gap note; no Lean or runtime behavior changes.
> 
> **Overview**
> Updates the **Applications translation-invariant MPS corollary** gap note (`peps_normal_ft_section3_route.tex`) so the documented source targets match arXiv:1804.04964 (lines 1801–1890), following #2989.
> 
> The note now states that the telescoped repeated tensor **\(B = A_1 Z_1^{-1}\)** must be **injective**, not merely “repeated.” That injectivity condition is added to the full source implication, the uniform-\(D\) restricted target, and the verdict paragraph (existence of a **repeated injective** \(B\)).
> 
> The **equal bond dimensions** conclusion is unchanged: it still cannot be expressed faithfully without a per-bond rectangular matrix model; only the injectivity piece of the target is sharpened in prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc95ae7e65bf1a1b13cc2c81c7ddca5139eebc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->