### PR TITLE
refactor(periodic): extract gauge-phase repeated-block conversion

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -84,24 +84,8 @@ private theorem period_eq_of_gaugePhaseEquiv_of_isPeriodic
   have h_eig_eq : ‖ζ‖ ^ 2 = 1 := by
     rw [hζ_norm]
     norm_num
-  -- RepeatedBlocks A B with phase ζ⁻¹
-  have hRepeated : RepeatedBlocks A B := by
-    refine ⟨ζ⁻¹, X⁻¹, by rw [norm_inv, hζ_norm, inv_one], ?_⟩
-    intro i
-    -- Goal: A i = ζ⁻¹ • (↑(X⁻¹) * B i * ↑((X⁻¹)⁻¹))
-    -- Simplify (X⁻¹)⁻¹ = X
-    simp only [inv_inv]
-    -- Goal: A i = ζ⁻¹ • (X⁻¹.val * B i * X.val)
-    -- Show X⁻¹ * B i * X = ζ • A i
-    have hconj : X⁻¹.val * B i * X.val = ζ • A i := by
-      rw [hBi i, mul_smul_comm, smul_mul_assoc]
-      congr 1
-      calc X⁻¹.val * (X.val * A i * X⁻¹.val) * X.val
-          = X⁻¹.val * X.val * A i * (X⁻¹.val * X.val) := by
-            simp only [Matrix.mul_assoc]
-        _ = 1 * A i * 1 := by rw [Units.inv_mul]
-        _ = A i := by simp
-    rw [hconj, smul_smul, inv_mul_cancel₀ hζ_ne, one_smul]
+  have hRepeated : RepeatedBlocks A B :=
+    repeatedBlocks_of_gaugePhaseData_norm_one X hζ_norm hBi
   -- Peripheral eigenvalue equality via conjugation
   have hSpec : peripheralEigenvalues (transferMap (d := d) (D := D) A) =
       peripheralEigenvalues (transferMap (d := d) (D := D) B) := by

--- a/TNLean/MPS/Periodic/Overlap/GaugePhase.lean
+++ b/TNLean/MPS/Periodic/Overlap/GaugePhase.lean
@@ -102,4 +102,53 @@ theorem gaugePhase_scalar_norm_eq_one_of_leftCanonical_irreducible
       (by simp [hτ_fix]) (by rw [hEB_σ, hζζ_real])).symm
   nlinarith [norm_nonneg ζ]
 
+/-- A unit-modulus gauge-phase relation gives a repeated-block relation.
+
+If \(B^i=\zeta X A^i X^{-1}\) and \(|\zeta|=1\), then
+\(A^i=\zeta^{-1}X^{-1}B^iX\), which is the `RepeatedBlocks A B`
+relation. This is the final algebraic conversion used after the phase
+normalization step in arXiv:1708.00029, Appendix A, lines 1082--1117. -/
+theorem repeatedBlocks_of_gaugePhaseData_norm_one
+    {A B : MPSTensor d D} (X : GL (Fin D) ℂ) {ζ : ℂ}
+    (hζ_norm : ‖ζ‖ = 1)
+    (hB :
+      ∀ i : Fin d,
+        B i =
+          ζ • ((X : Matrix (Fin D) (Fin D) ℂ) * A i *
+            ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) :
+    RepeatedBlocks A B := by
+  have hζ_ne : ζ ≠ 0 := by
+    exact norm_ne_zero_iff.mp (by rw [hζ_norm]; norm_num)
+  refine ⟨ζ⁻¹, X⁻¹, by rw [norm_inv, hζ_norm, inv_one], ?_⟩
+  intro i
+  simp only [inv_inv]
+  have hconj :
+      X⁻¹.val * B i * X.val = ζ • A i := by
+    rw [hB i, mul_smul_comm, smul_mul_assoc]
+    congr 1
+    calc
+      X⁻¹.val * (X.val * A i * X⁻¹.val) * X.val
+          = X⁻¹.val * X.val * A i * (X⁻¹.val * X.val) := by
+              simp only [Matrix.mul_assoc]
+      _ = 1 * A i * 1 := by rw [Units.inv_mul]
+      _ = A i := by simp
+  rw [hconj, smul_smul, inv_mul_cancel₀ hζ_ne, one_smul]
+
+/-- A gauge-phase equivalence between left-canonical irreducible blocks is a
+repeated-block relation.
+
+The scalar has unit modulus by the Perron--Frobenius normalization step above;
+the remaining conversion is purely algebraic. -/
+theorem gaugePhaseEquiv_to_repeatedBlocks_of_leftCanonical_irreducible
+    [NeZero D] {A B : MPSTensor d D}
+    (h : GaugePhaseEquiv A B)
+    (hA_left : IsLeftCanonical A) (hB_left : IsLeftCanonical B)
+    (hB_irr : IsIrreducibleTensor B) :
+    RepeatedBlocks A B := by
+  obtain ⟨X, ζ, hζ_ne, hB⟩ := h
+  exact repeatedBlocks_of_gaugePhaseData_norm_one X
+    (gaugePhase_scalar_norm_eq_one_of_leftCanonical_irreducible
+      hA_left hB_left hB_irr hζ_ne hB)
+    hB
+
 end MPSTensor


### PR DESCRIPTION
## Summary
- extract the algebraic conversion from a unit-modulus gauge-phase relation to `RepeatedBlocks` into `GaugePhase.lean`
- replace the local proof in `Case1.lean` by the shared lemma

## Validation
- `lake exe cache get`
- `lake build TNLean.MPS.Periodic.Overlap.GaugePhase TNLean.MPS.Periodic.Overlap.Case1`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/Periodic/Overlap/Case1.lean TNLean/MPS/Periodic/Overlap/GaugePhase.lean || true`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor only: logic is relocated and reused, with no change to statements or proof strategy beyond deduplication.
> 
> **Overview**
> The inline proof in `Case1.lean` that turns a unit-modulus gauge-phase relation into `RepeatedBlocks` is **moved into `GaugePhase.lean`** as shared lemmas.
> 
> **`repeatedBlocks_of_gaugePhaseData_norm_one`** captures the purely algebraic step (given `|ζ| = 1` and `B^i = ζ X A^i X⁻¹`). **`gaugePhaseEquiv_to_repeatedBlocks_of_leftCanonical_irreducible`** wires that together with the existing Perron–Frobenius `|ζ| = 1` result for left-canonical irreducible blocks. `period_eq_of_gaugePhaseEquiv_of_isPeriodic` now calls the shared lemma instead of a local `calc` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 295a0215f0a3bc00c5d508d2da3c13941951e294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->