### PR TITLE
doc(blueprint): restore FT chapters to content

### DIFF
--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -20,6 +20,6 @@
 \input{chapter/ch19_entropy_corollaries}
 \input{chapter/ch20_mpdo}
 \input{chapter/ch21_mpdo_rfp}
-% \input{chapter/ch22_periodic_ft}
-% \input{chapter/ch23_algebraic_ft}
-% \input{chapter/ch24_peps_ft}
+\input{chapter/ch22_periodic_ft}
+\input{chapter/ch23_algebraic_ft}
+\input{chapter/ch24_peps_ft}


### PR DESCRIPTION
## Summary
- restore the periodic MPS, algebraic FT, and PEPS blueprint chapters to `content.tex`
- keep the requested order: MPDO/RFP, then periodic MPS, then algebraic FT, with PEPS last
- resolve the unresolved blueprint labels currently coming from omitted chapters

## Validation
- `leanblueprint web` from `blueprint/` completed locally after rendering the restored periodic, algebraic, and PEPS pages
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to which chapters are included in the blueprint; no runtime or proof logic is modified.
> 
> **Overview**
> **Re-enables three blueprint chapters** in `content.tex` that were previously commented out: periodic MPS (`ch22_periodic_ft`), algebraic FT (`ch23_algebraic_ft`), and PEPS FT (`ch24_peps_ft`).
> 
> They are wired back in **after** the MPDO chapters (`ch20`–`ch21`) in the order periodic MPS → algebraic FT → PEPS, so the full blueprint build and web output include those sections again and cross-references to their labels resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ec3ace98cf8799a4f06ed6b4593d217312dafd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->