### PR TITLE
feat(Algebra): add shifted finite-cycle phase coboundary

### DIFF
--- a/TNLean/Algebra/FiniteCycleCoboundary.lean
+++ b/TNLean/Algebra/FiniteCycleCoboundary.lean
@@ -120,4 +120,21 @@ lemma exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one {m : ℕ} [NeZero
   intro v
   exact congrArg (fun z : Circle => (z : ℂ)) (hφc v)
 
+/-- Shifted sector form of the finite-cycle phase choice.
+
+This is the form used in the periodic-overlap phase assembly of
+arXiv:1708.00029, Appendix A, lines 1093--1102.  If the sector comparison is
+indexed by an offset `q`, the same vertex phases satisfy the coboundary equation
+at the matched sector `u + q`. -/
+lemma exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one
+    {m : ℕ} [NeZero m]
+    (κ : Fin m → ℂ) (hκ : ∀ v : Fin m, ‖κ v‖ = 1)
+    (hprod : ∏ v : Fin m, κ v = 1) (q : Fin m) :
+    ∃ φ : Fin m → ℂ,
+      (∀ v : Fin m, ‖φ v‖ = 1) ∧
+      ∀ u : Fin m, κ (u + q) = φ (u + q) * (φ (u + q + 1))⁻¹ := by
+  obtain ⟨φ, hφ_norm, hφ⟩ :=
+    exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one κ hκ hprod
+  exact ⟨φ, hφ_norm, fun u => hφ (u + q)⟩
+
 end TNLean.Algebra

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -693,7 +693,9 @@ The available chain inputs are `decompositionMap` / `exists_rightInverse` in
 `MPS/Chain/OneSidedInverse.lean` (realizing Ω_u) and the two-site
 proportionality theorem `tensor_proportional` in `MPS/Chain/TensorEquality.lean`.
 The finite-cycle phase choice in lines 1093--1102 is now isolated as
-`TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one`.
+`TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one`; the
+offset-indexed form needed for the sector match `(u, u + q)` is
+`TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`.
 Thus the remaining mathematical input is the `m`-factor cyclic contraction
 that produces the sector phases κ_v with `∏ v, κ_v = 1` and `‖κ_v‖ = 1`,
 after which the phase-coboundary lemma performs the κ/θ/φ telescoping. See
@@ -735,9 +737,9 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
   -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
   -- contraction theorem built from `decompositionMap` (the Ω_u inverses) that,
   -- after producing product-one unit phases κ_v, uses
-  -- `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one`
-  -- for the κ/θ/φ telescoping (lines 1093--1102). This upgrades the per-sector
-  -- blocked gauge data in `hBlockMatch` to one global phase and one global
+  -- `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`
+  -- for the offset-indexed κ/θ/φ telescoping (lines 1093--1102). This upgrades the
+  -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one global
   -- gauge. The available two-site theorem is `tensor_proportional`.
   sorry
 


### PR DESCRIPTION
## Summary

This PR adds the offset-indexed form of the finite-cycle complex phase coboundary lemma used in the periodic-overlap Case 3 phase assembly.

The existing lemma states that if `κ : Fin m → ℂ` has unit modulus and product one, then there are unit phases `φ` with

\[
  \kappa_v = \phi_v\,\phi_{v+1}^{-1}.
\]

The new corollary records the exact form needed after sector propagation with offset `q`:

\[
  \kappa_{u+q} = \phi_{u+q}\,\phi_{u+q+1}^{-1}.
\]

This is the phase choice in arXiv:1708.00029, Appendix A, lines 1093--1102, written with the `(u, u + q)` indexing used by `Case3.lean`. The Case 3 comments now point to this shifted endpoint rather than only to the unshifted lemma.

This does not close #873. It removes a small indexing mismatch from the remaining `m`-factor cyclic contraction and global gauge assembly.

Refs #873.

## Validation

- `lake env lean TNLean/Algebra/FiniteCycleCoboundary.lean`
- `lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean` (only the pre-existing Case 3 contraction `sorry` warning)
- `lake build TNLean.MPS.Periodic.Overlap.Case3` (same pre-existing warning)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/Algebra/FiniteCycleCoboundary.lean TNLean/MPS/Periodic/Overlap/Case3.lean` (only the pre-existing Case 3 `sorry`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure algebra lemma plus comment updates; no runtime or proof-completion changes beyond a one-line reindexing argument.
> 
> **Overview**
> Adds **`exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`**, a corollary of the existing product-one unit-phase coboundary lemma: for offset `q`, the same witness `φ` satisfies `κ (u + q) = φ (u + q) · φ (u + q + 1)⁻¹` for all `u`, matching the `(u, u + q)` sector indexing in periodic-overlap Case 3.
> 
> **Case 3** comments in `repeatedBlocks_of_blockedSectorGaugePhase` now cite this shifted lemma for the κ/θ/φ telescoping step instead of the unshifted form. The main contraction proof remains `sorry`; no proof obligations are closed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23662097efb7c8bf67e77d8c874efe3aea17aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->