### PR TITLE
doc(parent): cite PGVWC theorem 2blocks.2

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -14,7 +14,7 @@ one-step identity from arXiv:quant-ph/0608197
   \mathbb C^d\otimes S_M\cap S_M\otimes\mathbb C^d=S_{M+1},
   \qquad S_M=\bigvee_jG_M(A_j),
 \]
-as used in Theorem 12 of arXiv:quant-ph/0608197. The separate periodic
+as used in Theorem 2blocks.2 of arXiv:quant-ph/0608197. The separate periodic
 step is the comparison obtained when closing the boundaries with block-diagonal
 boundary conditions, as in arXiv:2011.12127, Section IV.C.
 -/
@@ -42,7 +42,7 @@ Then, for every \(N\ge L\) in that range,
 \[
   \mathcal G_{N,L}(B)\subseteq S_N.
 \]
-This is the inclusion into \(S_N\) in Theorem 12 of
+This is the inclusion into \(S_N\) in Theorem 2blocks.2 of
 arXiv:quant-ph/0608197 (proof lines 1430--1456). The step that closes the
 boundaries with block-diagonal boundary conditions, replacing \(S_N\) by the sum
 of periodic block ground spaces, is separate. -/
@@ -96,7 +96,7 @@ Consequently, for every \(N\ge L\) in this range,
   \mathcal G_{N,L}(B)\subseteq S_N.
 \]
 This is the inclusion into the linear span of block local ground spaces used in
-Theorem 12 of arXiv:quant-ph/0608197 (proof lines
+Theorem 2blocks.2 of arXiv:quant-ph/0608197 (proof lines
 1430--1456). The replacement of \(S_N\) by periodic block chain spaces is the
 separate step of closing the boundaries with block-diagonal boundary
 conditions.
@@ -107,7 +107,7 @@ transitively uses the boundary-condition comparison at boundary-crossing windows
 rather than deriving it from arXiv:2011.12127, Section IV.C, lines 2126--2128.
 Documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 Elimination: derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison
-from arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it
+from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1456, and use it
 to discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -150,7 +150,7 @@ Let
 \[
   B=\bigoplus_j\mu_jA_j,\qquad S_N=\bigvee_jG_N(A_j).
 \]
-At the lengths used in Theorem 12 of arXiv:quant-ph/0608197
+At the lengths used in Theorem 2blocks.2 of arXiv:quant-ph/0608197
 (arXiv:quant-ph/0608197, proof lines 1430--1456), one has
 \[
   \mathcal G_{N,L}(B)\subseteq S_N,
@@ -191,7 +191,7 @@ boundary-condition comparison at boundary-crossing windows rather than deriving
 it from arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -233,7 +233,7 @@ length. Then every
   \psi=\sum_j\psi_j,\qquad \psi_j\in G_N(A_j).
 \]
 This is an open-boundary decomposition. The periodic-boundary upgrade in
-arXiv:quant-ph/0608197, Theorem 12, is a separate boundary-condition
+arXiv:quant-ph/0608197, Theorem 2blocks.2, is a separate boundary-condition
 comparison: one must prove \(\psi_j\in\mathcal G_{N,L}(A_j)\) for the
 block components produced here.
 
@@ -244,7 +244,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -325,7 +325,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
@@ -444,7 +444,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -514,7 +514,7 @@ Let \(B=\bigoplus_j\mu_jA_j\). For block-diagonal boundary conditions
   \sum_j R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right).
 \]
 This is the cyclic-window form of the block-diagonal boundary-condition
-identity used in Theorem 12 of arXiv:quant-ph/0608197, proof lines
+identity used in Theorem 2blocks.2 of arXiv:quant-ph/0608197, proof lines
 1430--1434. -/
 theorem cyclicRestrictₗ_groundSpaceMap_toTensorFromBlocks_blockDiagonal_eq_sum
     {r : ℕ} {dim : Fin r → ℕ}
@@ -550,7 +550,7 @@ extraction step
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
 \]
-in Theorem 12 of Perez-Garcia, Verstraete, Wolf, and Cirac (2007).
+in Theorem 2blocks.2 of Perez-Garcia, Verstraete, Wolf, and Cirac (2007).
 It does not yet identify the individual
 summands with vectors in the corresponding \(G_L(A_j)\). -/
 theorem blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
@@ -690,7 +690,7 @@ periodic-boundary input is the matrix identity
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}
 \]
-from Theorem 12 of Perez-Garcia, Verstraete, Wolf, and Cirac (2007). -/
+from Theorem 2blocks.2 of Perez-Garcia, Verstraete, Wolf, and Cirac (2007). -/
 theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_nonwrapping
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -722,7 +722,7 @@ Thus it remains only to prove the same membership for the windows satisfying
   N<i+L.
 \]
 
-In the notation of arXiv:quant-ph/0608197, Theorem 12, these are the
+In the notation of arXiv:quant-ph/0608197, Theorem 2blocks.2, these are the
 boundary-crossing windows controlled by the comparison
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
@@ -798,7 +798,7 @@ lies in \(\mathcal G_{N,L}(A_j)\). Then
 \]
 The source periodic-boundary comparison is to prove the displayed periodic
 constraint for each block from the block-diagonal boundary conditions. In
-Theorem 12 of arXiv:quant-ph/0608197, this is the comparison
+Theorem 2blocks.2 of arXiv:quant-ph/0608197, this is the comparison
 \[
   A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}.
 \]
@@ -859,7 +859,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -925,7 +925,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -20,7 +20,7 @@ complementary words obtained after the source \(C^j,D^j\) comparison and the
 normalized \(E^j\)-calculation. The
 Pérez-García--Verstraete--Wolf--Cirac (PGVWC) comparison theorem below proves
 the periodic-boundary conclusion for each block once those identities are in the
-boundary-crossing form used in Theorem 12. Deriving these identities
+boundary-crossing form used in Theorem 2blocks.2. Deriving these identities
 from the source comparison is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
@@ -52,7 +52,7 @@ summand is the left-boundary summand with
   C^j_a=A^j_\rho A^j_a(\mu_j^{M+1}X_j).
 \]
 This is the block-summand form of the boundary-crossing specialization of
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1452. -/
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1452. -/
 theorem blockDiagonal_boundary_last_cyclicRestrict_component_eq_leftBoundaryComponent
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -140,7 +140,7 @@ left-boundary summands with
   C^j_a=A^j_\rho A^j_a\,(\mu_j^{M+1}X_j).
 \]
 This is the boundary-crossing specialization of the two trace
-decompositions in arXiv:quant-ph/0608197, Theorem 12, proof lines
+decompositions in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines
 1436--1452. -/
 theorem blockDiagonal_boundary_last_cyclicRestrict_sum_eq_leftBoundaryComponents
     {r : ℕ} {dim : Fin r → ℕ}
@@ -181,7 +181,7 @@ the product algebra. Then there are matrices \(E_j\) such that
 for every block \(j\) and all boundary letters \(a,b\).
 
 This is the direct cyclic-window instance of the coefficient comparison
-\(A_bC_a=A_bEA_a\) in arXiv:quant-ph/0608197, Theorem 12, proof lines
+\(A_bC_a=A_bEA_a\) in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines
 1436--1452. -/
 theorem blockDiagonal_boundary_last_coefficients_of_sum_mem_iSup
     {r : ℕ} {dim : Fin r → ℕ}
@@ -227,7 +227,7 @@ span the product algebra. Then the \(j\)-th cyclic restriction at the window
 beginning at the last site is a vector in
 \(G_{m+2}(A^j)\). This is the local membership consequence of the displayed
 identity \(A_b^jC_a^j=A_b^jE^jA_a^j\) in arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1436--1452. -/
+Theorem 2blocks.2, proof lines 1436--1452. -/
 theorem
     blockDiagonal_boundary_last_cyclicRestrict_component_mem_groundSpace_of_sum_mem_iSup
     {r : ℕ} {dim : Fin r → ℕ}
@@ -355,7 +355,7 @@ Then, for every local word \(\sigma\),
   \mu_j^NX_j\right).
 \]
 This is the coefficient identity for the boundary-crossing part of
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456. -/
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1456. -/
 theorem blockDiagonal_boundary_cyclicRestrict_component_apply_crossing
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -485,7 +485,7 @@ segment \(0,\ldots,a-1\),
 then the restriction is the local vector \(\Gamma_L^{A_j}(E)\).
 
 This is the matrix form of the boundary-crossing comparison in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456. -/
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1456. -/
 theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_crossing_matrix
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -588,7 +588,7 @@ is incorporated into the boundary matrix
 \(Y A^j_{\tau_a}\cdots A^j_{\tau_{i-1}}\).
 
 This is the equation form of the boundary-crossing reduction used after the
-blockwise comparison in arXiv:quant-ph/0608197, Theorem 12, proof lines
+blockwise comparison in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines
 1454--1456. -/
 theorem blockDiagonal_boundary_cyclicRestrict_component_mem_groundSpace_of_boundary_identity
     {r : ℕ} {dim : Fin r → ℕ}
@@ -642,7 +642,7 @@ Then every component
 belongs to \(\mathcal G_{N,L}(A_j)\).
 
 This isolates the equation which remains after comparing the \(j\)-th block
-component in arXiv:quant-ph/0608197, Theorem 12; the
+component in arXiv:quant-ph/0608197, Theorem 2blocks.2; the
 non-boundary-crossing intervals are handled by the contiguous calculation. -/
 theorem blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
     {r : ℕ} {dim : Fin r → ℕ}
@@ -749,7 +749,7 @@ The normalization \(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) and these
 compatibility identities give the matrix identities indexed by complementary
 words used in the injective periodic-boundary theorem for each block.
 This is the boundary-condition comparison at a boundary-crossing interval in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451, followed by the
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451, followed by the
 periodic conclusion in lines 1454--1456.
 -/
 theorem
@@ -811,7 +811,7 @@ These identities give
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
 \]
 This is the boundary-crossing trace-decomposition form of
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456.
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1456.
 
 **Local fix (adjoint correction):** The matrix identity used here
 replaces the source's \(E^j=\sum_k C^j_kA^j_k\) by
@@ -880,7 +880,7 @@ form. Deriving this displayed form from the source comparison is documented in
 
 This result follows the block-diagonal boundary conditions of arXiv:2011.12127,
 lines 2126--2128, and precedes the final equality in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456.
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1454--1456.
 
 **Unfaithful:** This proof relies on
 `exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
@@ -888,7 +888,7 @@ which uses boundary-crossing comparison hypotheses not derived from
 arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) comparison from arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1456, and discharge the currently assumed
+Theorem 2blocks.2, proof lines 1446--1456, and discharge the currently assumed
 complementary-word identity; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
@@ -952,7 +952,7 @@ which uses boundary-crossing comparison hypotheses not derived from
 arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the PGVWC07 \(C^j,D^j,E^j\) comparison from arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1456, and discharge the currently assumed
+Theorem 2blocks.2, proof lines 1446--1456, and discharge the currently assumed
 complementary-word identity; tracked in issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -11,7 +11,7 @@ import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 This file records the fixed-interval trace-decomposition equality obtained from
 the block-diagonal local constraint at a cyclic interval crossing the boundary
 cut.  It is the local coefficient form of the two trace decompositions in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1444, specialized to the
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1444, specialized to the
 block-diagonal boundary conditions used in arXiv:2011.12127, Section IV.C,
 lines 2126--2128.
 -/
@@ -41,7 +41,7 @@ If the block sum of the cyclic restrictions lies in
 \]
 for every local word \(\sigma\). This is the fixed-interval
 trace-decomposition comparison used in Perez-Garcia--Verstraete--Wolf--Cirac,
-Theorem 12. -/
+Theorem 2blocks.2. -/
 theorem blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
@@ -214,7 +214,7 @@ word \(\beta\) before the cut,
 \]
 This is the fixed cyclic-interval coordinate form of the
 Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j\) comparison in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1448. The source writes
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1448. The source writes
 the local coordinates as \(i_1,\ldots,i_{m+1}\); here \(\beta\) is the wrapped
 word before the cut and \(\rho\) is the complementary outside word. -/
 theorem blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
@@ -291,7 +291,7 @@ for each block \(j\), the boundary matrix required to write
 as a vector in \(G_L(A^j)\).
 
 This is the fixed-window local-membership consequence of arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1436--1456, in the block-diagonal boundary-condition
+Theorem 2blocks.2, proof lines 1436--1456, in the block-diagonal boundary-condition
 coordinates used in arXiv:2011.12127, Section IV.C, lines 2126--2128. -/
 theorem
     blockDiagonal_boundary_crossing_component_mem_groundSpace_of_pgvwc_comparison_of_sum_mem_iSup

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -14,7 +14,7 @@ The word-indexed Pérez-García--Verstraete--Wolf--Cirac comparison
   \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho
 \]
 is the local boundary-crossing coordinate form of the \(C^j,D^j\) trace
-comparison from arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451,
+comparison from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451,
 after specializing \(D^j_\beta\) to \((\mu_j^N X_j)A^j_\beta\). The normalized
 \(E^j\)-calculation then implies the periodic-boundary single-block constraints
 and the finite-range block-diagonal periodic-boundary equality used here.
@@ -41,7 +41,7 @@ comparison, in the word-indexed boundary-crossing form
 then the single-block vectors \(\Gamma_N^{A_j}(\mu_j^NX_j)\) satisfy the
 periodic-boundary constraints.
 
-This records the source comparison in arXiv:quant-ph/0608197, Theorem 12,
+This records the source comparison in arXiv:quant-ph/0608197, Theorem 2blocks.2,
 proof lines 1446--1451, before the normalized \(E^j\)-calculation turns it
 into the boundary-crossing identities with \(E_{j,i,\rho}\).
 The words \(\beta\) and \(\rho\) are local coordinates for a boundary-crossing
@@ -54,7 +54,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
 lines 1446--1456, and use it to discharge the currently assumed comparison;
 tracked in issue 2971. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
@@ -119,7 +119,7 @@ Pérez-García--Verstraete--Wolf--Cirac comparison gives matrices
 Combining this with the existing normalized \(E^j\)-calculation gives the
 periodic single-block constraints.
 
-This is the source comparison in arXiv:quant-ph/0608197, Theorem 12, proof
+This is the source comparison in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
 lines 1436--1451, specialized to the block-diagonal boundary conditions of
 arXiv:2011.12127, Section IV.C, lines 2126--2128.
 
@@ -236,7 +236,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
 lines 1446--1456, and use it to discharge the currently assumed comparison;
 tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace
 # Finite-spanning versions of trace-decomposition results for block-diagonal parent spaces
 
 This file packages a finite-spanning form of the trace decompositions in
-Perez-Garcia--Verstraete--Wolf--Cirac, Theorem 12, into the block-diagonal
+Perez-Garcia--Verstraete--Wolf--Cirac, Theorem 2blocks.2, into the block-diagonal
 boundary and finite-range equality conclusions. The remaining source step is to
 derive that trace-decomposition equality from the \(C^j,D^j\) comparison after
 specializing \(D^j_\beta\) to the block-diagonal boundary expression
@@ -44,7 +44,7 @@ single-block vectors
 belong to \(\mathcal G_{N,L}(A_j)\).
 
 This is the finite-spanning reformulation of the trace-decomposition form of
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456, after the
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1436--1456, after the
 block-diagonal boundary conditions of arXiv:2011.12127, lines 2126--2128.
 
 **Unfaithful:** This proof relies on
@@ -54,7 +54,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
 lines 1446--1456, and use it to discharge the currently assumed
 trace-decomposition equality; tracked in issue 2971. -/
 theorem
@@ -131,7 +131,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
 lines 1446--1456, and use it to discharge the currently assumed
 trace-decomposition equality; tracked in issue 2971. -/
 theorem

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -13,7 +13,7 @@ PGVWC07 one-step block-intersection identity.
 
 ## References
 
-* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12 and the
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2 and the
   direct-sum lemma used there.
 -/
 
@@ -63,7 +63,7 @@ Writing \(S_m=\bigvee_j G_m(A_j)\), the identity is
 \[
   \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}.
 \]
-This is the equation used in PGVWC07, Theorem 12, proof lines
+This is the equation used in PGVWC07, Theorem 2blocks.2, proof lines
 1430--1452.
 
 **Unfaithful:** This proof relies on

--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -10,7 +10,7 @@ import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
 
 This file combines the local block-diagonal ground-space identity with the
 abstract cyclic-to-open propagation step used in the parent-Hamiltonian proof
-of PGVWC07, Theorem 12.
+of PGVWC07, Theorem 2blocks.2.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -16,7 +16,7 @@ equality for the join of the block ground spaces.
 
 ## References
 
-* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12, proof around
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2, proof around
   \(A_b C_a=D_b A_a\) and \(E=\sum_a C_a A_a^\dagger\).
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2021], Section IV.C, lines
   2120--2129.
@@ -341,7 +341,7 @@ theorem block_matrices_eq_of_wordTupleSpanTop_trace
 trace decomposition in the block ground-space sum.
 
 This is the coefficient-comparison direction in the proof of
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12.  If a vector
+[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2.  If a vector
 with coefficients
 \[
   \sum_j\operatorname{tr}(A^j_b C^j_a A^j_w)
@@ -439,7 +439,7 @@ theorem pgvwc07_boundary_identities_of_leftBoundaryComponent_mem_iSup
 decompositions in the PGVWC block-diagonal intersection proof.
 
 For fixed physical indices \(a,b\), the coefficient comparison in
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12, gives
+[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2, gives
 \[
   \sum_j \operatorname{tr}\!\left(
     A^j_b C^j_a A^j_{i_2}\cdots A^j_{i_m}\right)
@@ -479,7 +479,7 @@ then the blockwise matrices satisfy
   A^j_\beta C^j_\rho=D^j_\beta A^j_\rho .
 \]
 This is the word form needed for the boundary-crossing comparison in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451. -/
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451. -/
 theorem pgvwc07_blockwise_word_compatibility_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -521,7 +521,7 @@ then the blockwise matrices satisfy
   A^j_\beta C^j_\rho=(X_jA^j_\beta)A^j_\rho .
 \]
 This is the fixed-\(\rho\) form of the comparison in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451. -/
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451. -/
 theorem pgvwc07_fixed_complementary_word_compatibility_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -562,7 +562,7 @@ Then the word-valued trace comparison gives
 \]
 This is the exact compatibility hypothesis used by the complementary-word
 boundary theorem, following the boundary-crossing comparison in
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451. -/
+arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451. -/
 theorem pgvwc07_complementary_word_compatibility_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -604,7 +604,7 @@ such that
 \[
   (X_jA^j_\beta)A^j_\rho=A^j_\beta E_{j,\rho}.
 \]
-This is the word-valued form of arXiv:quant-ph/0608197, Theorem 12,
+This is the word-valued form of arXiv:quant-ph/0608197, Theorem 2blocks.2,
 proof lines 1446--1451.
 
 **Local fix (adjoint correction):** The source line writes
@@ -665,7 +665,7 @@ imply
 \]
 This is the local membership step in
 [Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197),
-Theorem 12, proof lines 1446--1452. -/
+Theorem 2blocks.2, proof lines 1446--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -708,7 +708,7 @@ the vector itself lies in
 \]
 This is the restriction form of the open-segment step in
 [Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197),
-Theorem 12, proof lines 1442--1452. -/
+Theorem 2blocks.2, proof lines 1442--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -838,7 +838,7 @@ equivalent to the two fixed-boundary conditions
 \]
 This is the one-step block-intersection identity of
 [Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197),
-Theorem 12, proof lines 1442--1452. -/
+Theorem 2blocks.2, proof lines 1442--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -899,7 +899,7 @@ the \((n+2)\)-site block ground space is the intersection of the inverse
 images of \(S_n\) under all fixed last-letter and fixed first-letter
 restrictions.  This is the restriction-subspace form of
 [Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197),
-Theorem 12, proof lines 1442--1452. -/
+Theorem 2blocks.2, proof lines 1442--1452. -/
 theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))

--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -13,7 +13,7 @@ the linear sum of the corresponding local spaces of its blocks.
 
 ## References
 
-* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12,
+* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 2blocks.2,
   proof lines 1430--1434, where
   \(S=\bigoplus_j\mathcal G_L^{A^j}\).
 -/
@@ -117,7 +117,7 @@ parametrizations:
 \]
 
 This is the block-diagonal boundary-condition identity used in PGVWC07,
-Theorem 12, proof lines 1430--1434. -/
+Theorem 2blocks.2, proof lines 1430--1434. -/
 theorem groundSpaceMap_toTensorFromBlocks_eq_sum_blockDiagonal
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j)) (L : ℕ)

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -18,7 +18,7 @@ Perez-Garcia--Verstraete--Wolf--Cirac block-diagonal intersection proof: from
 ## References
 
 * arXiv:quant-ph/0608197 (Perez-Garcia--Verstraete--Wolf--Cirac 2007),
-  Theorem 12, proof around \(A_b C_a=D_b A_a\) and
+  Theorem 2blocks.2, proof around \(A_b C_a=D_b A_a\) and
   \(E=\sum_a C_a A_a^\dagger\).
 -/
 
@@ -31,7 +31,7 @@ variable {d D : ℕ}
 /-- Two-index boundary-matrix identities in the \(C,D,E\) boundary comparison.
 
 This abstracts the normalized matrix calculation in arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1451.
+Theorem 2blocks.2, proof lines 1446--1451.
 
 This is the same normalized calculation when the right-normalized family is
 indexed by a finite set and the left family is indexed by an arbitrary set:
@@ -148,7 +148,7 @@ theorem pgvwc07_boundary_word_matrix_identities_of_compatibility
 /-- Two-length word-indexed boundary-matrix identities.
 
 This is the word-alphabet form of the \(C,D,E\) calculation in
-Perez-Garcia--Verstraete--Wolf--Cirac, Theorem 12, proof lines 1446--1451.
+Perez-Garcia--Verstraete--Wolf--Cirac, Theorem 2blocks.2, proof lines 1446--1451.
 
 The two index sets are words of lengths \(K\) and \(M\):
 \[
@@ -185,7 +185,7 @@ theorem pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
 comparison.
 
 This is the boundary-crossing form of the Perez-Garcia--Verstraete--Wolf--Cirac
-calculation in arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451.
+calculation in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451.
 
 Let \(X\in M_D(\mathbb C)\) be a matrix. Assume that for every complementary
 word \(\rho\) and wrapped word \(\beta\),

--- a/TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicSubmoduleIteration.lean
@@ -11,7 +11,7 @@ The cyclic-local propagation step for the block-diagonal parent Hamiltonian: if
 the local ground space \(G_L(A)\) lies in \(S_L\) and the subspaces propagate by
 \(\mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d = S_{m+1}\), then the cyclic
 chain ground space \(\mathcal G_{N,L}(A)\) lies in \(S_N\). This is the
-cyclic-local part of PGVWC07, Theorem 12, before the periodic-boundary
+cyclic-local part of PGVWC07, Theorem 2blocks.2, before the periodic-boundary
 comparison.
 -/
 
@@ -28,7 +28,7 @@ If \(G_L(A)\subseteq S_L\) and the subspaces \(S_m\) satisfy
   \mathbb C^d\otimes S_m \cap S_m\otimes \mathbb C^d = S_{m+1}
 \]
 for all \(m\ge L\), then \(\mathcal G_{N,L}(A)\subseteq S_N\).  This is the
-cyclic-local part of the proof of PGVWC07, Theorem 12, before the
+cyclic-local part of the proof of PGVWC07, Theorem 2blocks.2, before the
 periodic-boundary comparison. -/
 theorem chainGroundSpace_le_of_local_le_restriction_intersection_submodules
     (A : MPSTensor d D) (S : (M : ℕ) → Submodule ℂ (NSiteSpace d M))

--- a/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/CyclicWindow.lean
@@ -173,7 +173,7 @@ the intersections
   \mathbb C^d\otimes S_M \cap S_M\otimes \mathbb C^d = S_{M+1}
 \]
 hold for all \(M\ge L\), then the state lies in \(S_N\). This is the
-open-segment iteration used in PGVWC07, Theorem 12, before the periodic-chain
+open-segment iteration used in PGVWC07, Theorem 2blocks.2, before the periodic-chain
 conclusion. -/
 theorem contiguous_mem_of_restriction_intersection_submodules
     (S : (M : ℕ) → Submodule ℂ (NSiteSpace d M))

--- a/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
@@ -9,7 +9,7 @@ import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 
 This file derives the word-valued \(C^j,D^j,E^j\) matrix identities from
 matching left and right block trace decompositions in arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1451.
+Theorem 2blocks.2, proof lines 1446--1451.
 
 The formula for \(E^j\) uses the adjointed word product
 \[
@@ -44,7 +44,7 @@ such that
   D^j_\beta=A^j_\beta E^j,\qquad
   A^j_\beta C^j_\rho=A^j_\beta E^jA^j_\rho .
 \]
-This is the word-valued form of arXiv:quant-ph/0608197, Theorem 12, proof
+This is the word-valued form of arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
 lines 1446--1451.
 
 **Local fix (adjoint correction):** The source line writes

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -32,7 +32,7 @@ cyclic norm-compression estimates as sufficient stronger hypotheses. For a tenso
 in block-injective canonical form
 $A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$,
 \cite[Theorem~IV.16]{Cirac2021Matrix}
-(\cite[Theorem~12]{PerezGarcia2007Matrix}) states that the periodic
+(\cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}) states that the periodic
 parent-Hamiltonian ground space is spanned by the vectors
 $\{V^{(N)}(A_j)\}$. The sections below record the open-segment recursion and the
 conditional reductions for the boundary-condition comparison in the periodic

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -503,7 +503,7 @@ in both cases.
     % Next source step, not proven by this membership lemma: blockwise
     % extraction
     % $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$
-    % from \cite[Theorem~12]{PerezGarcia2007Matrix}.
+    % from \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}.
 \end{proof}
 
 \begin{lemma}[Cyclic windows not crossing the cut]
@@ -538,7 +538,7 @@ in both cases.
     % rotation, $\mu_j^N X_j$ lies between the two pieces of the interval. The
     % missing block-diagonal periodic-boundary comparison is
     % $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$ from
-    % \cite[Theorem~12]{PerezGarcia2007Matrix}.
+    % \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}.
 \end{proof}
 
 \begin{lemma}[Boundary-crossing coefficient formula]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -395,7 +395,7 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
         A^j_\beta C^j_\rho=A^j_\beta E^jA^j_\rho .
     \]
     This is the calculation in
-    \cite[Theorem~12, proof lines~1446--1451]{PerezGarcia2007Matrix}, with
+    \cite[Theorem~\emph{2blocks.2}, proof lines~1446--1451]{PerezGarcia2007Matrix}, with
     the adjoint on \(A^j_\rho\) required by the displayed normalization.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -30,7 +30,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
         \exists n\ge1,\; V^{(n)}(A_j)\ne V^{(n)}(A_k).
     \]
     Let $L_0$ be a common injectivity length. Assume the multi-block range used
-    in \cite[Theorem~12]{PerezGarcia2007Matrix}:
+    in \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}:
     \[
         g\ge2,
         \qquad
@@ -43,7 +43,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
         S_m:=\bigoplus_{j=1}^gG_m(A_j).
     \]
     The open-segment recursion in
-    \cite[Theorem~12]{PerezGarcia2007Matrix} says that, for every
+    \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix} says that, for every
     $m\ge L$,
     \[
         \C^d\otimes S_m
@@ -98,7 +98,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
         |i_1\cdots i_{m+1}\rangle.
     \]
     The direct-sum separation lemma used in
-    \cite[Theorem~12]{PerezGarcia2007Matrix}, together with injectivity
+    \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}, together with injectivity
     of each block, gives the blockwise matrix identity
     \[
         A^j_{i_{m+1}} C^j_{i_1}
@@ -112,7 +112,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     % Local fix (PGVWC07 printed formula): this correction is recorded in
     % docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex.
     The printed formula in
-    \cite[Theorem~12, proof lines~1449--1451]{PerezGarcia2007Matrix} omits the
+    \cite[Theorem~\emph{2blocks.2}, proof lines~1449--1451]{PerezGarcia2007Matrix} omits the
     adjoint on $A^j_a$; the adjointed form is forced by the displayed
     normalization below.
     In the normalization used in the source proof,
@@ -195,7 +195,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     $S=\bigoplus_j\mathcal G_L^{A^j}$.
     The passage from the open-segment recursion to the $N$-site ring is the
     separate closure-property step at the periodic boundary in
-    \cite[Theorem~12]{PerezGarcia2007Matrix}.
+    \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}.
     % This closure-property step is not the inclusion
     % $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails for a general
     % open-boundary matrix crossing the periodic boundary.
@@ -234,7 +234,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     \cite[lines~2126--2128]{Cirac2021Matrix}.
 \end{lemma}
 % The ground-space theorem below uses the conservative length range of
-% \cite[Theorem~12]{PerezGarcia2007Matrix}.
+% \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}.
 
 \begin{proof}
     \notready
@@ -393,7 +393,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     \notready
     \uses{thm:chain_ground_space_eq_mpv_normal}
     The length hypotheses are the conservative range used in
-    \cite[Theorem~12]{PerezGarcia2007Matrix}. The shorter range stated in
+    \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}. The shorter range stated in
     \cite[lines~2126--2128]{Cirac2021Matrix} requires the strengthened
     block-diagonal re-growing step. These hypotheses do not by themselves give
     the displayed boundary-condition comparison in the periodic ring. That


### PR DESCRIPTION
## Summary

This PR normalizes the parent-Hamiltonian citations of the PGVWC07 block-diagonal ground-space theorem.

The local source file `Papers/quant-ph_0608197/MPSarchive.tex` labels the theorem as `2blocks.2` and titles it "Degeneracy of the ground space v2". The parent-Hamiltonian Lean docstrings and blueprint prose were still referring to the same result as "Theorem 12". This made the live #2971 boundary-comparison path harder to check against the source.

This PR changes those references to `Theorem 2blocks.2` in the Lean docstrings, and to `Theorem~\emph{2blocks.2}` in blueprint citations. No theorem statements or proofs are changed.

Refs #2971.

## Checks

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && leanblueprint checkdecls`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint citation edits only; no executable or proof logic changes.
> 
> **Overview**
> Parent-Hamiltonian **documentation** now cites Perez–García–Verstraete–Wolf–Cirac (PGVWC07) **Theorem `2blocks.2`** (“Degeneracy of the ground space v2”) instead of **“Theorem 12”**, matching `Papers/quant-ph_0608197/MPSarchive.tex`.
> 
> Updates are **wording only** in Lean module/theorem docstrings (BNT block-diagonal chain, crossing, trace, PGVWC comparison, block intersection, boundary matrices, etc.) and in blueprint `\cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}` (and proof-line citations). **No** Lean statements, proofs, or formal definitions change.
> 
> This aligns cross-references for the **#2971** boundary-comparison gap notes with the labeled source theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a92b1f6458dc91949c64a35c79f14ad35221bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->