### PR TITLE
feat(periodic): derive per-sector repeated blocks

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -668,6 +668,64 @@ lemma sectorMatch_propagation
   obtain ⟨hdim, _, hg⟩ := key l
   exact ⟨hdim, hg⟩
 
+/-- Per-sector `RepeatedBlocks` consequence of the propagated gauge-phase data.
+
+This auxiliary result is weaker than the Case 3 conclusion: it gives a
+`RepeatedBlocks` relation for each compressed sector pair
+`(blocksA u, blocksB (u + q))` after the dimension cast.  It does not assemble
+the sector gauges into one global gauge for `A` and `B`; that is precisely the
+remaining `Ω_u` contraction and phase-assembly step in arXiv:1708.00029,
+Appendix A, lines 1023--1117. -/
+private lemma sectorRepeatedBlocks_of_blockedMatch
+    [NeZero D]
+    (B : MPSTensor d D)
+    {m : ℕ} [NeZero m]
+    (hB : IsPeriodic m B)
+    {dimA dimB : Fin m → ℕ}
+    (blocksA :
+      (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
+    (blocksB :
+      (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
+    (hA_blocks_lc :
+      ∀ k, ∑ i : Fin (blockPhysDim d m),
+        (blocksA k i)ᴴ * blocksA k i = 1)
+    (hB_blocks_lc :
+      ∀ k, ∑ i : Fin (blockPhysDim d m),
+        (blocksB k i)ᴴ * blocksB k i = 1)
+    (hB_mpv :
+      SameMPV₂ (blockTensor B m)
+        (toTensorFromBlocks (μ := fun _ => 1) blocksB))
+    (hB_cyclic : IsCyclicSectorDecomp B blocksB)
+    (q : Fin m)
+    (hBlockMatch : ∀ u : Fin m,
+      ∃ (hdim : dimA u = dimB (u + q)),
+        GaugePhaseEquiv
+          (cast (congr_arg
+            (MPSTensor (blockPhysDim d m)) hdim)
+            (blocksA u))
+          (blocksB (u + q)))
+    (hNondeg : ∀ u, dimA u ≠ 0) :
+    ∀ u : Fin m,
+      ∃ (hdim : dimA u = dimB (u + q)),
+        RepeatedBlocks
+          (cast (congr_arg
+            (MPSTensor (blockPhysDim d m)) hdim)
+            (blocksA u))
+          (blocksB (u + q)) := by
+  intro u
+  obtain ⟨hdim, hMatch⟩ := hBlockMatch u
+  have hB_nonzero : dimB (u + q) ≠ 0 := hdim ▸ hNondeg u
+  haveI : NeZero (dimB (u + q)) := ⟨hB_nonzero⟩
+  obtain ⟨_hPrimB, hIrrB⟩ :=
+    primitive_and_irreducible_sectorBlocks_of_cyclicDecomp B hB blocksB
+      hB_blocks_lc hB_mpv hB_cyclic (u + q) hB_nonzero
+  have hAcast_lc : IsLeftCanonical
+      (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocksA u)) :=
+    (leftCanonical_cast_dim hdim (blocksA u)).mpr (hA_blocks_lc u)
+  exact ⟨hdim,
+    gaugePhaseEquiv_to_repeatedBlocks_of_leftCanonical_irreducible
+      hMatch hAcast_lc (hB_blocks_lc (u + q)) hIrrB⟩
+
 /-- Full-cycle contraction step for periodic-overlap Case 3.
 
 At this point the sector transport has already been abstracted into


### PR DESCRIPTION
## Summary

This PR proves the immediate per-sector consequence of the propagated Case 3 gauge-phase data.

Given

```lean
hBlockMatch : ∀ u : Fin m,
  ∃ hdim : dimA u = dimB (u + q),
    GaugePhaseEquiv
      (cast (congr_arg (MPSTensor (blockPhysDim d m)) hdim) (blocksA u))
      (blocksB (u + q))
```

the new private lemma `sectorRepeatedBlocks_of_blockedMatch` derives, for each sector `u`, a `RepeatedBlocks` relation between the dimension-cast `blocksA u` and `blocksB (u + q)`.

The proof uses the existing Perron-Frobenius normalization wrapper `gaugePhaseEquiv_to_repeatedBlocks_of_leftCanonical_irreducible`; irreducibility of the `B` sector comes from `primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`, and nonzero dimension is transported across the matched dimension equality.

This is deliberately weaker than the source conclusion in arXiv:1708.00029, Appendix A, lines 1023--1117. It does not assemble the sector gauges into one global gauge for `A` and `B`; the `m`-factor `Ω_u` contraction and phase assembly remain the target of #873.

Refs #873.

## Validation

- `lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean` (only the pre-existing Case 3 contraction `sorry` warning)
- `lake build TNLean.MPS.Periodic.Overlap.Case3` (same pre-existing warning)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/Periodic/Overlap/Case3.lean` (only the pre-existing Case 3 `sorry`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean proof addition in periodic overlap Case 3; no runtime, auth, or API surface changes, and the main contraction lemma still uses `sorry`.
> 
> **Overview**
> Adds private lemma **`sectorRepeatedBlocks_of_blockedMatch`** in `Case3.lean`, turning propagated per-sector **`GaugePhaseEquiv`** data (`hBlockMatch`) into **`RepeatedBlocks`** for each pair `(blocksA u, blocksB (u + q))` after the dimension cast.
> 
> For each sector `u`, the proof pulls irreducibility of the `B` block from **`primitive_and_irreducible_sectorBlocks_of_cyclicDecomp`**, transports left-canonicality across the cast, and applies **`gaugePhaseEquiv_to_repeatedBlocks_of_leftCanonical_irreducible`**. The docstring states this is **weaker** than the full Appendix A conclusion: it does not merge sector gauges into one global gauge for `A` and `B`; the `Ω_u` contraction / phase assembly in **`repeatedBlocks_of_blockedSectorGaugePhase`** remains open (#873).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0641621434b9bce93e9ae9bfe633ec8a6f6a055d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->