### PR TITLE
doc(parent): expose PGVWC boundary E formula

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -12,8 +12,8 @@ import TNLean.MPS.ParentHamiltonian.WrappingWindow
 
 This file isolates the cyclic-interval step for a block component when the
 interval crosses the boundary cut.  The input is the blockwise matrix identity
-appearing in the boundary-condition comparison of arXiv:quant-ph/0608197, Theorem
-12.
+appearing in the boundary-condition comparison of arXiv:quant-ph/0608197,
+Theorem 2blocks.2.
 
 The equality theorem here is conditional on the matrix identities indexed by
 complementary words obtained after the source \(C^j,D^j\) comparison and the

--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -97,8 +97,8 @@ for all \(M\ge L\), then
 \[
   \mathcal G_{N,L}(B)\subseteq S_N.
 \]
-This is the conditional propagation step in the proof of PGVWC07, Theorem
-12: the one-step identities propagate cyclic local constraints to
+This is the conditional propagation step in the proof of PGVWC07,
+Theorem 2blocks.2: the one-step identities propagate cyclic local constraints to
 \(S_N\). The later source step is the boundary-condition comparison for
 block-diagonal boundary conditions, replacing \(S_N\) by the periodic
 block-chain sum. -/

--- a/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockSumGroundSpace.lean
@@ -193,8 +193,8 @@ spaces of its blocks:
 
 The reverse inclusion uses \(\mu_j\ne0\) to insert
 \((\mu_j^L)^{-1}X\) in the \(j\)-th diagonal boundary block.  This is the
-local identity \(G_L(B)=S_L\) used in the proof of PGVWC07, Theorem
-12. -/
+local identity \(G_L(B)=S_L\) used in the proof of PGVWC07,
+Theorem 2blocks.2. -/
 theorem groundSpace_toTensorFromBlocks_eq_iSup
     {r : ℕ} {dim : Fin r → ℕ}
     (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -181,6 +181,65 @@ theorem pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
     (fun ρ : Fin M → Fin d => evalWord A (List.ofFn ρ))
     C Dmat hUnital hCompat
 
+/-- Complementary-word boundary identities, with the \(E_\rho\) formula, from a
+two-length \(C,D,E\) comparison.
+
+This is the boundary-crossing form of the Perez-Garcia--Verstraete--Wolf--Cirac
+calculation in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451.
+
+Let \(X\in M_D(\mathbb C)\) be a matrix. Assume that for every complementary
+word \(\rho\) and wrapped word \(\beta\),
+\[
+  A_\beta C_\rho=(X A_\beta)A_\rho,
+\]
+and that the complementary-word products are right-normalized. Then, for every
+complementary word \(\rho\), there is a matrix \(E_\rho\) such that for every
+wrapped word \(\beta\),
+\[
+  (X A_\beta)A_\rho=A_\beta E_\rho
+\]
+with
+\[
+  E_\rho=\left(\sum_\gamma C_\gamma A_\gamma^\dagger\right)A_\rho .
+\]. -/
+theorem pgvwc07_complementary_word_boundary_identities_formula_of_compatibility
+    (A : MPSTensor d D) {K M : ℕ}
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (C : (Fin M → Fin d) → Matrix (Fin D) (Fin D) ℂ)
+    (hUnital :
+      ∑ ρ : Fin M → Fin d,
+        evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ = 1)
+    (hCompat : ∀ ρ : Fin M → Fin d, ∀ β : Fin K → Fin d,
+      evalWord A (List.ofFn β) * C ρ =
+        (X * evalWord A (List.ofFn β)) * evalWord A (List.ofFn ρ)) :
+    ∀ ρ : Fin M → Fin d,
+      ∃ E : Matrix (Fin D) (Fin D) ℂ,
+        E =
+          (∑ γ : Fin M → Fin d, C γ * (evalWord A (List.ofFn γ))ᴴ) *
+            evalWord A (List.ofFn ρ) ∧
+        ∀ β : Fin K → Fin d,
+          (X * evalWord A (List.ofFn β)) * evalWord A (List.ofFn ρ) =
+            evalWord A (List.ofFn β) * E := by
+  classical
+  intro ρ
+  let E₀ : Matrix (Fin D) (Fin D) ℂ :=
+    ∑ γ : Fin M → Fin d, C γ * (evalWord A (List.ofFn γ))ᴴ
+  refine ⟨E₀ * evalWord A (List.ofFn ρ), rfl, ?_⟩
+  intro β
+  have hRect :
+      evalWord A (List.ofFn β) * C ρ =
+        evalWord A (List.ofFn β) * E₀ * evalWord A (List.ofFn ρ) :=
+    (pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
+      (A := A) (C := C)
+      (Dmat := fun β : Fin K → Fin d => X * evalWord A (List.ofFn β))
+      hUnital hCompat).2 ρ β
+  calc
+    (X * evalWord A (List.ofFn β)) * evalWord A (List.ofFn ρ)
+        = evalWord A (List.ofFn β) * C ρ := (hCompat ρ β).symm
+    _ = evalWord A (List.ofFn β) * E₀ * evalWord A (List.ofFn ρ) := hRect
+    _ = evalWord A (List.ofFn β) * (E₀ * evalWord A (List.ofFn ρ)) := by
+          rw [Matrix.mul_assoc]
+
 /-- Complementary-word boundary identities from a two-length \(C,D,E\)
 comparison.
 
@@ -213,24 +272,10 @@ theorem pgvwc07_complementary_word_boundary_identities_of_compatibility
         ∀ β : Fin K → Fin d,
           (X * evalWord A (List.ofFn β)) * evalWord A (List.ofFn ρ) =
             evalWord A (List.ofFn β) * E := by
-  classical
   intro ρ
-  let E₀ : Matrix (Fin D) (Fin D) ℂ :=
-    ∑ γ : Fin M → Fin d, C γ * (evalWord A (List.ofFn γ))ᴴ
-  refine ⟨E₀ * evalWord A (List.ofFn ρ), ?_⟩
-  intro β
-  have hRect :
-      evalWord A (List.ofFn β) * C ρ =
-        evalWord A (List.ofFn β) * E₀ * evalWord A (List.ofFn ρ) :=
-    (pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
-      (A := A) (C := C)
-      (Dmat := fun β : Fin K → Fin d => X * evalWord A (List.ofFn β))
-      hUnital hCompat).2 ρ β
-  calc
-    (X * evalWord A (List.ofFn β)) * evalWord A (List.ofFn ρ)
-        = evalWord A (List.ofFn β) * C ρ := (hCompat ρ β).symm
-    _ = evalWord A (List.ofFn β) * E₀ * evalWord A (List.ofFn ρ) := hRect
-    _ = evalWord A (List.ofFn β) * (E₀ * evalWord A (List.ofFn ρ)) := by
-          rw [Matrix.mul_assoc]
+  obtain ⟨E, _hE, hIdentity⟩ :=
+    pgvwc07_complementary_word_boundary_identities_formula_of_compatibility
+      A X C hUnital hCompat ρ
+  exact ⟨E, hIdentity⟩
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -425,7 +425,7 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
 
 \begin{lemma}[Complementary-word boundary identities from a compatibility hypothesis]
     \label{lem:complementary_word_boundary_identities_from_pgvwc}
-    \lean{MPSTensor.pgvwc07_complementary_word_boundary_identities_of_compatibility}
+    \lean{MPSTensor.pgvwc07_complementary_word_boundary_identities_formula_of_compatibility}
     \leanok
     \uses{lem:normalized_boundary_matrix_identities}
     Let $A_\beta$ be the products over wrapped words of length $K$, let
@@ -440,8 +440,11 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
     \[
         A_\beta C_\rho=(X A_\beta)A_\rho.
     \]
-    Then, for every complementary word $\rho$, there is a matrix $E_\rho$ such
-    that for every wrapped word $\beta$,
+    Then, for every complementary word $\rho$, with
+    \[
+        E_\rho=\left(\sum_\gamma C_\gamma A_\gamma^\dagger\right)A_\rho,
+    \]
+    one has, for every wrapped word $\beta$,
     \[
         (X A_\beta)A_\rho=A_\beta E_\rho.
     \]


### PR DESCRIPTION
## Summary

This PR makes the PGVWC07 complementary-word boundary identity state the boundary matrix explicitly:

\[
  E_\rho=\left(\sum_\gamma C_\gamma A_\gamma^\dagger\right)A_\rho.
\]

The previous theorem only returned the matrix existentially. The old existential theorem remains as a wrapper, while the blueprint entry now points to the formula-level statement. This keeps the boundary-condition comparison written in the source notation \(C,D,E\), rather than hiding the load-bearing step behind a formal name.

It also removes three remaining split-line references to PGVWC07 as “Theorem 12”, replacing them with the local source label `Theorem 2blocks.2`.

This does not close #2971. It clarifies the formal boundary around the remaining block-diagonal boundary-representation and crossing-tail span hypotheses.

Refs #2971.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `rg -n "Theorem\\s+12|Theorem~12|theorem 12|^12\\." TNLean/MPS/ParentHamiltonian blueprint/src/chapter/ch13_parent_hamiltonian*.tex docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`
- `lake build TNLean` (passes; only pre-existing warnings in PEPS/example/periodic files, including the existing Case 3 `sorry` warning)
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and API layering only; proof logic is refactored, not changed in behavior, with no auth, security, or runtime impact.
> 
> **Overview**
> The PGVWC complementary-word boundary identity is split so the **load-bearing** statement is no longer purely existential: new theorem `pgvwc07_complementary_word_boundary_identities_formula_of_compatibility` proves `(X A_β)A_ρ = A_β E_ρ` with **explicit** \(E_\rho = (\sum_\gamma C_\gamma A_\gamma^\dagger) A_\rho\). The previous `pgvwc07_complementary_word_boundary_identities_of_compatibility` remains as a thin wrapper that obtains `E` from the formula version.
> 
> Blueprint lemma `lem:complementary_word_boundary_identities_from_pgvwc` now `\lean`-links to the formula theorem and states \(E_\rho\) in the lemma text before the boundary identity.
> 
> Reader-facing docstrings in three parent-Hamiltonian files retarget split-line PGVWC07 citations from **Theorem 12** to the local label **Theorem 2blocks.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06700f623ca5d01a2c4eb39dd8758e2a9779a59c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->