### PR TITLE
feat(chain): add block word decomposition map

### DIFF
--- a/TNLean/MPS/Chain/OneSidedInverse.lean
+++ b/TNLean/MPS/Chain/OneSidedInverse.lean
@@ -21,6 +21,8 @@ This gives the **decomposition property**: for any `X ∈ M_D(ℂ)`, there exist
   (the one-sided inverse).
 * `MPSTensor.IsInjective.exists_decomposition` — any matrix can be decomposed as a
   linear combination of the `A i`.
+* `MPSTensor.IsNBlkInjective.exists_rightInverse` — the corresponding right inverse
+  for all length-`N` word products.
 
 ## References
 
@@ -71,6 +73,58 @@ theorem decompositionMap_sum {A : MPSTensor d D} (hA : IsInjective A)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     ∑ i, decompositionMap hA X i • A i = X := by
   have := decompositionMap_spec hA X
+  rwa [Fintype.linearCombination_apply] at this
+
+/-! ## Right inverses for block-injective word spans -/
+
+/-- The linear combination map over all length-`N` words is surjective for an
+`N`-block-injective tensor. -/
+theorem IsNBlkInjective.linearCombination_surjective {A : MPSTensor d D} {N : ℕ}
+    (hA : IsNBlkInjective A N) :
+    Function.Surjective
+      (Fintype.linearCombination ℂ
+        (fun σ : Fin N → Fin d => evalWord A (List.ofFn σ))) :=
+  (span_range_eq_top_iff_surjective_fintypeLinearCombination ℂ
+    (fun σ : Fin N → Fin d => evalWord A (List.ofFn σ))).mp hA
+
+/-- An `N`-block-injective tensor has a linear right inverse for the span of
+length-`N` word products.
+
+This is the algebraic right inverse denoted by `Ω_u` in arXiv:1708.00029,
+Appendix A, equations `eq:Fu` and `eq:Omegauprop`, after specializing to a
+chosen sector tensor and an injective repetition length. -/
+theorem IsNBlkInjective.exists_rightInverse {A : MPSTensor d D} {N : ℕ}
+    (hA : IsNBlkInjective A N) :
+    ∃ Ω : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ((Fin N → Fin d) → ℂ),
+      ∀ X,
+        Fintype.linearCombination ℂ
+          (fun σ : Fin N → Fin d => evalWord A (List.ofFn σ)) (Ω X) = X := by
+  obtain ⟨Ω, hΩ⟩ :=
+    (Fintype.linearCombination ℂ
+      (fun σ : Fin N → Fin d => evalWord A (List.ofFn σ))).exists_rightInverse_of_surjective
+      (LinearMap.range_eq_top.mpr hA.linearCombination_surjective)
+  exact ⟨Ω, fun X => by simpa using LinearMap.congr_fun hΩ X⟩
+
+/-- Noncomputable right inverse for the length-`N` word span of an
+`N`-block-injective tensor. -/
+noncomputable def blockDecompositionMap {A : MPSTensor d D} {N : ℕ}
+    (hA : IsNBlkInjective A N) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ((Fin N → Fin d) → ℂ) :=
+  (hA.exists_rightInverse).choose
+
+theorem blockDecompositionMap_spec {A : MPSTensor d D} {N : ℕ}
+    (hA : IsNBlkInjective A N) (X : Matrix (Fin D) (Fin D) ℂ) :
+    Fintype.linearCombination ℂ
+      (fun σ : Fin N → Fin d => evalWord A (List.ofFn σ))
+      (blockDecompositionMap hA X) = X :=
+  (hA.exists_rightInverse).choose_spec X
+
+@[simp]
+theorem blockDecompositionMap_sum {A : MPSTensor d D} {N : ℕ}
+    (hA : IsNBlkInjective A N) (X : Matrix (Fin D) (Fin D) ℂ) :
+    ∑ σ : Fin N → Fin d,
+      blockDecompositionMap hA X σ • evalWord A (List.ofFn σ) = X := by
+  have := blockDecompositionMap_spec hA X
   rwa [Fintype.linearCombination_apply] at this
 
 end MPSTensor

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -747,8 +747,9 @@ Appendix A lines 1023--1117:
   ξ = η/m and a single global unitary U = Σ_u e^{iφ_{u+q}} P_u U_{u+q} Q_{u+q}
   (eq:result and lines 1110--1117), giving A^i = e^{iξ} U B^i U†.
 
-The available chain inputs are `decompositionMap` / `exists_rightInverse` in
-`MPS/Chain/OneSidedInverse.lean` (realizing Ω_u) and the two-site
+The available chain inputs are `blockDecompositionMap` /
+`IsNBlkInjective.exists_rightInverse` in `MPS/Chain/OneSidedInverse.lean`
+(realizing Ω_u for a chosen injective word length) and the two-site
 proportionality theorem `tensor_proportional` in `MPS/Chain/TensorEquality.lean`.
 The finite-cycle phase choice in lines 1093--1102 is now isolated as
 `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one`; the
@@ -793,8 +794,8 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     (hNormal : ∀ u, IsNormal (blocksA u)) :
     RepeatedBlocks A B := by
   -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
-  -- contraction theorem built from `decompositionMap` (the Ω_u inverses) that,
-  -- after producing product-one unit phases κ_v, uses
+  -- contraction theorem built from `blockDecompositionMap` (the Ω_u inverses)
+  -- that, after producing product-one unit phases κ_v, uses
   -- `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`
   -- for the offset-indexed κ/θ/φ telescoping (lines 1093--1102). This upgrades the
   -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one global


### PR DESCRIPTION
## Summary

This PR adds the length-`N` analogue of the existing one-site `decompositionMap`.

For an `N`-block-injective tensor, the length-`N` word products span the full matrix algebra. The new declarations package the corresponding linear-combination surjectivity and a chosen right inverse:

- `IsNBlkInjective.linearCombination_surjective`
- `IsNBlkInjective.exists_rightInverse`
- `blockDecompositionMap`
- `blockDecompositionMap_spec`
- `blockDecompositionMap_sum`

Mathematically, this is the algebraic form of the `Ω_u` right inverse in arXiv:1708.00029, Appendix A, equations `eq:Fu` and `eq:Omegauprop`, after choosing an injective repetition length for a sector tensor.

The Case 3 comments now point to `blockDecompositionMap` as the available right-inverse input for the remaining `m`-factor cyclic contraction. This does not close #873; it supplies the right-inverse interface that the contraction will use.

Refs #873.

## Validation

- `lake env lean TNLean/MPS/Chain/OneSidedInverse.lean`
- `lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean` (only the pre-existing Case 3 contraction `sorry` warning)
- `lake build TNLean.MPS.Chain.OneSidedInverse`
- `lake build TNLean.MPS.Periodic.Overlap.Case3` (same pre-existing warning)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/Chain/OneSidedInverse.lean TNLean/MPS/Periodic/Overlap/Case3.lean` (only the pre-existing Case 3 `sorry`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style linear algebra layered on existing `IsNBlkInjective`; no runtime or auth paths, and Case 3 proof obligations remain `sorry`.
> 
> **Overview**
> Adds the **length-`N` word-product** analogue of the existing one-site `decompositionMap` for `IsInjective` tensors in `OneSidedInverse.lean`.
> 
> For `IsNBlkInjective A N`, the PR proves surjectivity of linear combinations over all `evalWord A (List.ofFn σ)` with `σ : Fin N → Fin d`, existence of a linear right inverse (paper `Ω_u`), and packages a chosen inverse as **`blockDecompositionMap`** with **`blockDecompositionMap_spec`** / **`blockDecompositionMap_sum`**. Module docs tie this to arXiv:1708.00029 Appendix A (`eq:Fu`, `eq:Omegauprop`).
> 
> **Case 3** documentation only: comments for the remaining `m`-factor cyclic contraction now point at **`blockDecompositionMap`** / **`IsNBlkInjective.exists_rightInverse`** instead of the single-site **`decompositionMap`**; the `sorry` in `repeatedBlocks_of_blockedSectorGaugePhase` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a830099f0cb265fe9dc0b922ce57d9e77212edde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->