### PR TITLE
doc(blueprint): hide unfinished FT chapters

### DIFF
--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -67,8 +67,7 @@ multiplicative-domain, Perron--Frobenius, and overlap-decay tools used to
 control normal blocks. Chapters~\ref{ch:wielandt} and~\ref{ch:canonical}
 supply the blocking, primitivity, irreducibility, and canonical-form reductions.
 Chapter~\ref{ch:canonical} includes the invariant-projection splitting.
-Chapter~\ref{ch:algebraic_ft} records the product-algebra block permutation
-argument. Chapter~\ref{ch:bnt} supplies bases of normal tensors and the
+Chapter~\ref{ch:bnt} supplies bases of normal tensors and the
 power-sum comparison. The
 after-blocking reductions in Section~\ref{sec:reduction_to_normal_form} give
 the common primitive block decompositions used immediately in
@@ -76,7 +75,7 @@ Chapter~\ref{ch:ft_proof}, which records the conditional theorem
 statements.
 % Maintainer note: the same-index direct-sum lemmas used after a block
 % correspondence has already been fixed are collected later in
-% Chapter~\ref{ch:algebraic_ft}, because they are facts about block-diagonal
+% the algebraic-FT draft chapter, because they are facts about block-diagonal
 % gauges, not part of the canonical-form reduction or of the BNT block-matching
 % proof. The remaining BNT matching and fixed-length span inputs are kept as
 % explicit hypotheses until the corresponding source steps are supplied.
@@ -90,15 +89,14 @@ not to any additional input for the Fundamental Theorem.
 Parent Hamiltonians, correlations, examples, channel representations, normal
 forms, quantum dynamical semigroups, operator convexity, entropy, and matrix
 product operators and density operators are then collected.
-Chapter~\ref{ch:periodic_ft_apps} develops the direct Fundamental Theorem for
-periodically repeated tensors in irreducible form, together with the
-compatibility theorems for physical-index
-rotation (Definition~\ref{def:rotate_physical} in Chapter~\ref{ch:symmetry}).
+A later draft treats the direct Fundamental Theorem for periodically repeated
+tensors in irreducible form, together with the compatibility theorems for
+physical-index rotation (Definition~\ref{def:rotate_physical} in
+Chapter~\ref{ch:symmetry}).
 % Maintainer note: the rotation definition is internal bookkeeping for the
 % periodic MPS material, not an external-paper input or part of the Molnar
 % algebraic-FT chapter.
-Chapter~\ref{ch:algebraic_ft}
-gives the fixed-length algebraic Fundamental Theorem of~\cite{Molnar2018NormalPEPS}.
-Chapter~\ref{ch:peps_ft} records the PEPS analogs.
+The algebraic and PEPS draft chapters remain in the repository but are omitted
+from the generated blueprint while their statements are being stabilized.
 These later topics use the Fundamental Theorem, or develop later
 finite-dimensional channel theory, rather than enter its proof.

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -498,10 +498,9 @@ boundary conditions (PBC).
     spectral sense.
     Chapter~\ref{ch:canonical} treats the normal canonical form needed
     for the blocking-based multi-block theory, while
-    Chapter~\ref{ch:periodic_ft_apps} develops the separate periodic
-    irreducible-form extension. This section isolates the stronger
-    block-injective form used in the injective and block-injective
-    arguments.
+    the periodic irreducible-form extension is kept separate. This section
+    isolates the stronger block-injective form used in the injective and
+    block-injective arguments.
 \end{remark}
 
 \begin{definition}[Block projection]\label{def:block_projection}

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -20,6 +20,6 @@
 \input{chapter/ch19_entropy_corollaries}
 \input{chapter/ch20_mpdo}
 \input{chapter/ch21_mpdo_rfp}
-\input{chapter/ch22_periodic_ft}
-\input{chapter/ch23_algebraic_ft}
-\input{chapter/ch24_peps_ft}
+% \input{chapter/ch22_periodic_ft}
+% \input{chapter/ch23_algebraic_ft}
+% \input{chapter/ch24_peps_ft}


### PR DESCRIPTION
## Summary

- hide the periodic MPS, algebraic FT, and PEPS blueprint chapters from the generated site by commenting their `\input` lines in `blueprint/src/content.tex`
- keep the chapter sources in the repository, but remove them from the visible blueprint content order

## Reason

These chapters were temporarily restored to resolve cross-chapter labels, but the visible chapters no longer refer to the hidden labels that caused that failure. They can therefore be hidden again without breaking the generated blueprint.

## Checks

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_bibtex.py`
- `cd blueprint && leanblueprint web` (local build reached only through `ch-mpdo_rfp.html`; no unresolved-label errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and build-order only; chapter sources remain and CI checks reported a clean local blueprint build without unresolved labels.
> 
> **Overview**
> **Removes** the periodic MPS, algebraic FT, and PEPS chapters from the **generated** blueprint by commenting their `\input` lines in `content.tex`, while **keeping** the `.tex` sources in the repo.
> 
> **Rewrites** reader-facing prose in the intro and MPS chapter so it no longer treats those as numbered blueprint chapters: dropped references to `ch:algebraic_ft` / `ch:periodic_ft_apps` / PEPS in the roadmap, reframed them as **draft** material omitted until statements stabilize, and softened the canonical-form remark so the periodic extension is described generically instead of via `Chapter~\ref{ch:periodic_ft_apps}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a1bff3ba5d5f185a381b6f3e706d1f7a6a02229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->