### PR TITLE
feat(periodic): choose common sector omega maps

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean
@@ -334,6 +334,46 @@ theorem blockTensor_isInjective_mul_of_blockTensor_isInjective
     (isNBlkInjective_mul_of_isNBlkInjective A hm
       ((isNBlkInjective_iff_blockTensor_isInjective A N).2 hN))
 
+/-- **Common exact block-injectivity length for a finite normal left-canonical family.**
+
+Let `blocks k` be a finite family of positive-dimensional left-canonical normal tensors.
+Then there is a single positive length `L` such that every block is `L`-block-injective.
+
+The proof first uses the bounded positive blocking theorem for each block, and then takes
+the product of the finitely many individual lengths. Exact block-injectivity persists at
+positive multiples, so this product is a common length for all sectors. -/
+theorem exists_common_isNBlkInjective_of_isNormal_leftCanonical
+    {r d : ℕ} {dim : Fin r → ℕ}
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (hLeft : ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hNonzero : ∀ k, dim k ≠ 0)
+    (hNormal : ∀ k, IsNormal (blocks k)) :
+    ∃ L : ℕ, 0 < L ∧ ∀ k : Fin r, IsNBlkInjective (blocks k) L := by
+  classical
+  haveI : ∀ k : Fin r, NeZero (dim k) := fun k => ⟨hNonzero k⟩
+  have hBlock : ∀ k : Fin r, ∃ L : ℕ, 0 < L ∧ L ≤ (dim k) ^ 4 ∧
+      IsInjective (blockTensor (d := d) (D := dim k) (blocks k) L) := by
+    intro k
+    exact exists_pos_blockTensor_isInjective_le_pow_four_of_isNormal_leftCanonical
+      (blocks k) (hLeft k) (hNormal k)
+  let L : Fin r → ℕ := fun k => Classical.choose (hBlock k)
+  have hL_pos : ∀ k, 0 < L k := fun k => (Classical.choose_spec (hBlock k)).1
+  have hL_inj : ∀ k,
+      IsInjective (blockTensor (d := d) (D := dim k) (blocks k) (L k)) :=
+    fun k => (Classical.choose_spec (hBlock k)).2.2
+  refine ⟨∏ k : Fin r, L k, Finset.prod_pos fun k _ => hL_pos k, ?_⟩
+  intro k
+  have hL_blk : IsNBlkInjective (blocks k) (L k) :=
+    (isNBlkInjective_iff_blockTensor_isInjective (blocks k) (L k)).2 (hL_inj k)
+  have hcommon : (∏ j : Fin r, L j) = (∏ j ∈ Finset.univ.erase k, L j) * L k := by
+    simpa using (Finset.prod_erase_mul (s := Finset.univ) (a := k) (f := L)
+      (Finset.mem_univ k)).symm
+  have hmult_pos : 0 < ∏ j ∈ Finset.univ.erase k, L j :=
+    Finset.prod_pos fun j _ => hL_pos j
+  have hmul := isNBlkInjective_mul_of_isNBlkInjective
+    (blocks k) hmult_pos hL_blk
+  simpa [hcommon] using hmul
+
 /-- **IsNormal is preserved by blocking.**
 
 If `A` is normal (`∃ N, wordSpan A N = ⊤`), then `blockTensor A P` is also normal

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Periodic.Overlap.Case2
+import TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain
+import TNLean.MPS.Chain.OneSidedInverse
 
 /-!
 # Periodic overlap dichotomy: Case 3
@@ -726,6 +728,33 @@ private lemma sectorRepeatedBlocks_of_blockedMatch
     gaugePhaseEquiv_to_repeatedBlocks_of_leftCanonical_irreducible
       hMatch hAcast_lc (hB_blocks_lc (u + q)) hIrrB⟩
 
+/-- Common `Ω_u` right inverses for the sector blocks.
+
+This is the Lean form of the normality input in arXiv:1708.00029, Appendix A,
+lines 1026--1040, equations `eq:Fu` and `eq:Omegauprop`: after choosing one
+common positive word length, every sector block has a right inverse for the
+linear span of its length-`L` word products. -/
+private lemma exists_common_sectorDecompositionMaps_of_isNormal_leftCanonical
+    {m : ℕ} [NeZero m] {dim : Fin m → ℕ}
+    (blocks : (k : Fin m) → MPSTensor d (dim k))
+    (hBlocks_lc :
+      ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)
+    (hNondeg : ∀ k, dim k ≠ 0)
+    (hNormal : ∀ k, IsNormal (blocks k)) :
+    ∃ L : ℕ, 0 < L ∧
+      ∃ Ω : (k : Fin m) →
+          Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] ((Fin L → Fin d) → ℂ),
+        ∀ (k : Fin m) (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
+          Fintype.linearCombination ℂ
+            (fun σ : Fin L → Fin d => evalWord (blocks k) (List.ofFn σ))
+            ((Ω k) X) = X := by
+  obtain ⟨L, hL_pos, hL⟩ :=
+    exists_common_isNBlkInjective_of_isNormal_leftCanonical
+      blocks hBlocks_lc hNondeg hNormal
+  refine ⟨L, hL_pos, fun k => blockDecompositionMap (hL k), ?_⟩
+  intro k X
+  exact blockDecompositionMap_spec (hL k) X
+
 /-- Full-cycle contraction step for periodic-overlap Case 3.
 
 At this point the sector transport has already been abstracted into
@@ -793,9 +822,12 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     (hNondeg : ∀ u, dimA u ≠ 0)
     (hNormal : ∀ u, IsNormal (blocksA u)) :
     RepeatedBlocks A B := by
+  obtain ⟨L, hL_pos, Ω, hΩ⟩ :=
+    exists_common_sectorDecompositionMaps_of_isNormal_leftCanonical
+      blocksA hA_blocks_lc hNondeg hNormal
   -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
-  -- contraction theorem built from `blockDecompositionMap` (the Ω_u inverses)
-  -- that, after producing product-one unit phases κ_v, uses
+  -- contraction theorem built from the common `L` and the right inverses `Ω u`
+  -- satisfying `hΩ`; after producing product-one unit phases κ_v, it uses
   -- `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`
   -- for the offset-indexed κ/θ/φ telescoping (lines 1093--1102). This upgrades the
   -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one global

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -735,7 +735,7 @@ lines 1026--1040, equations `eq:Fu` and `eq:Omegauprop`: after choosing one
 common positive word length, every sector block has a right inverse for the
 linear span of its length-`L` word products. -/
 private lemma exists_common_sectorDecompositionMaps_of_isNormal_leftCanonical
-    {m : ℕ} [NeZero m] {dim : Fin m → ℕ}
+    {m : ℕ} {dim : Fin m → ℕ}
     (blocks : (k : Fin m) → MPSTensor d (dim k))
     (hBlocks_lc :
       ∀ k, ∑ i : Fin d, (blocks k i)ᴴ * blocks k i = 1)


### PR DESCRIPTION
## Summary

This PR records the next algebraic input for the Case 3 branch of the periodic-overlap proof.

It adds a finite-family normality lemma: a positive-dimensional left-canonical finite family of normal tensors admits one common positive exact block-injectivity length. The proof chooses positive injective blocking lengths for the individual sectors and takes their product, using persistence of exact block-injectivity at positive multiples.

It then packages the corresponding sector right inverses in `Case3.lean` as a common family of maps `Ω u`, matching arXiv:1708.00029 Appendix A, lines 1026--1040 (`eq:Fu` and `eq:Omegauprop`). The remaining Case 3 placeholder now starts after the common length and right inverses have been chosen.

This does not close #873. The remaining work is still the cyclic contraction producing the sector phases, the product-one/unit-modulus phase facts, and the global gauge assembly.

## Validation

- `lake env lean TNLean/MPS/CanonicalForm/SectorComparison/NormalityChain.lean`
- `lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain TNLean.MPS.Periodic.Overlap.Case3`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `lake build`

The only proof-integrity placeholder in the touched files is the pre-existing `repeatedBlocks_of_blockedSectorGaugePhase` `sorry`, tracked by #873.

Refs #873 #450 #81 #619

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds proved lemmas and a small wiring change in a file that already contained the main `sorry`; no changes to auth, data, or completed proof paths.
> 
> **Overview**
> **Normality chain:** New theorem `exists_common_isNBlkInjective_of_isNormal_leftCanonical` shows a finite left-canonical normal sector family shares one positive exact block-injectivity length `L`, by taking per-sector bounded injective block lengths and their product, using `isNBlkInjective_mul_of_isNBlkInjective`.
> 
> **Case 3:** Imports `NormalityChain` and `OneSidedInverse`, adds `exists_common_sectorDecompositionMaps_of_isNormal_leftCanonical` (one `L` and per-sector `Ω` with `blockDecompositionMap_spec`, matching arXiv:1708.00029 `eq:Fu` / `eq:Omegauprop`). `repeatedBlocks_of_blockedSectorGaugePhase` now **obtains** `⟨L, Ω, hΩ⟩` up front; the **`sorry`** is unchanged and still covers the full cyclic contraction and global gauge assembly (lines 1023–1117).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc21a67e5273683f89ea55a524043a3f0908e8f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->