### PR TITLE
feat(mps-chain): telescope cyclic-shift gauges

### DIFF
--- a/TNLean/MPS/Chain/TranslationInvariance.lean
+++ b/TNLean/MPS/Chain/TranslationInvariance.lean
@@ -14,6 +14,60 @@ namespace MPSChainTensor
 
 variable {d D n : ℕ}
 
+/-! ### Telescoping a chain against its cyclic shift -/
+
+/-- **Telescoping a cyclic-shift gauge comparison**
+(arXiv:1804.04964, Applications section, lines 1828--1862).
+
+If a site-dependent closed chain is gauge equivalent to its cyclic shift, then
+each site tensor is obtained from the first tensor by invertible matrices on
+the two virtual legs.  This is the formal version of the source passage
+expressing all tensors \(A_i\) in terms of \(A_1\) and the products \(L_i\),
+\(R_i\). -/
+theorem exists_gauge_to_first_of_cyclicShift_gaugeEquiv [NeZero n]
+    {A : MPSChainTensor d D n} (hA : GaugeEquiv A (cyclicShift A)) :
+    ∀ k : Fin n, ∃ L R : GL (Fin D) ℂ, ∀ i : Fin d,
+      A k i = (L : Matrix (Fin D) (Fin D) ℂ) * A 0 i *
+        (((R⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) := by
+  obtain ⟨Z, hZ⟩ := hA
+  intro k
+  induction hk : k.val generalizing k with
+  | zero =>
+      refine ⟨1, 1, ?_⟩
+      intro i
+      have hk0 : k = 0 := Fin.ext (by simpa using hk)
+      subst k
+      simp
+  | succ m ih =>
+      have hm : m < n := by
+        have hklt := k.isLt
+        omega
+      let j : Fin n := ⟨m, hm⟩
+      have hsucc : cyclicSucc j = k := by
+        rw [cyclicSucc_eq_add_one]
+        apply Fin.ext
+        have hn2 : 2 ≤ n := by
+          have hklt := k.isLt
+          omega
+        have hone : ((1 : Fin n).val) = 1 := by
+          have h := Fin.val_one' n
+          rw [h]
+          exact Nat.mod_eq_of_lt (by omega)
+        rw [Fin.val_add_eq_ite, hone]
+        change (if n ≤ m + 1 then m + 1 - n else m + 1) = k.val
+        rw [hk]
+        split_ifs <;> omega
+      obtain ⟨L, R, hLR⟩ := ih j rfl
+      refine ⟨Z j * L, Z k * R, ?_⟩
+      intro i
+      have hZj := hZ j i
+      change A (cyclicSucc j) i =
+        (Z j : Matrix (Fin D) (Fin D) ℂ) * A j i *
+          (((Z (cyclicSucc j))⁻¹ : GL (Fin D) ℂ) :
+            Matrix (Fin D) (Fin D) ℂ) at hZj
+      rw [← hsucc, hZj, hLR i, hsucc]
+      simp [Matrix.mul_assoc, mul_inv_rev]
+
 /-- **Single gauge for translation-invariant chains**.
 
 If `A` is injective and the constant chains `(A, …, A)` and `(B, …, B)`

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1307,6 +1307,28 @@ recorded in the route note
     hypothesis.
 \end{proof}
 
+\begin{corollary}[Telescoping against the first tensor]%
+    \label{cor:exists_gauge_to_first_of_cyclicShift_gaugeEquiv}
+    \lean{MPSChainTensor.exists_gauge_to_first_of_cyclicShift_gaugeEquiv}
+    \leanok
+    \uses{def:mps_chain_cyclic_shift}
+    Suppose a closed chain \(A_0,\ldots,A_{n-1}\) is gauge equivalent to its
+    cyclic shift.  Then for every site \(v\) there are invertible matrices
+    \(L_v\) and \(R_v\) such that
+    \[
+        A_v^i = L_v\, A_0^i\, R_v^{-1}
+    \]
+    for every physical index \(i\).  This is the telescoping step in
+    \cite[lines~1828--1862]{Molnar2018NormalPEPS}, where the products denoted
+    \(L_i\) and \(R_i\) express all tensors through the first one.
+\end{corollary}
+\begin{proof}\leanok
+    Write the cyclic-shift gauge relation from one site to the next and
+    iterate it along the chain.  At the first site one takes
+    \(L_0=R_0=I\); passing from \(v\) to \(v+1\) multiplies the left and
+    right virtual factors by the adjacent gauges.
+\end{proof}
+
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%
     \label{thm:fundamentalTheorem_injectiveMPSChain_gauge_unique}
     \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_gauge_unique}


### PR DESCRIPTION
## Summary

This PR adds a source-faithful telescoping step for the translation-invariant MPS route.  If a site-dependent closed chain is gauge equivalent to its cyclic shift, then every site tensor is expressed from the first tensor by invertible matrices on the two virtual legs.  This formalizes the telescoping passage in arXiv:1804.04964, Applications section, lines 1828--1862.

The corresponding blueprint corollary is recorded in the PEPS normal capstone chapter, with the statement written purely in tensor notation rather than by naming the Lean theorem in prose.

Refs #2920.

## Verification

- `lake build TNLean`
- after rebasing onto current `origin/main`: `lake build TNLean.MPS.Chain.TranslationInvariance TNLean.PEPS.CycleMPSChainOverlapCapstone`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; no changes to existing theorem statements or runtime behavior.
> 
> **Overview**
> Adds the **telescoping step** on the translation-invariant MPS route: from gauge equivalence between a site-dependent closed chain and its cyclic shift, every site tensor is expressed as \(A_v^i = L_v A_0^i R_v^{-1}\) with invertible virtual-leg matrices.
> 
> Lean formalizes this as `MPSChainTensor.exists_gauge_to_first_of_cyclicShift_gaugeEquiv` in `TranslationInvariance.lean`, proved by induction on the site index using the per-site cyclic-shift gauge relation and matrix algebra (`mul_assoc`, `mul_inv_rev`). The blueprint gains matching corollary `cor:exists_gauge_to_first_of_cyclicShift_gaugeEquiv` in the PEPS normal capstone chapter, aligned with Molnar2018 Applications lines 1828–1862.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5964acf0a03e221da52694e1571412c853a05e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->