### PR TITLE
feat(periodic): expose sector omega sum form

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -745,15 +745,14 @@ private lemma exists_common_sectorDecompositionMaps_of_isNormal_leftCanonical
       ∃ Ω : (k : Fin m) →
           Matrix (Fin (dim k)) (Fin (dim k)) ℂ →ₗ[ℂ] ((Fin L → Fin d) → ℂ),
         ∀ (k : Fin m) (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
-          Fintype.linearCombination ℂ
-            (fun σ : Fin L → Fin d => evalWord (blocks k) (List.ofFn σ))
-            ((Ω k) X) = X := by
+          ∑ σ : Fin L → Fin d,
+            (Ω k X σ) • evalWord (blocks k) (List.ofFn σ) = X := by
   obtain ⟨L, hL_pos, hL⟩ :=
     exists_common_isNBlkInjective_of_isNormal_leftCanonical
       blocks hBlocks_lc hNondeg hNormal
   refine ⟨L, hL_pos, fun k => blockDecompositionMap (hL k), ?_⟩
   intro k X
-  exact blockDecompositionMap_spec (hL k) X
+  exact blockDecompositionMap_sum (hL k) X
 
 /-- Full-cycle contraction step for periodic-overlap Case 3.
 
@@ -826,8 +825,8 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     exists_common_sectorDecompositionMaps_of_isNormal_leftCanonical
       blocksA hA_blocks_lc hNondeg hNormal
   -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
-  -- contraction theorem built from the common `L` and the right inverses `Ω u`
-  -- satisfying `hΩ`; after producing product-one unit phases κ_v, it uses
+  -- contraction theorem built from the common `L` and the sum-form right inverses
+  -- `Ω u` satisfying `hΩ`; after producing product-one unit phases κ_v, it uses
   -- `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`
   -- for the offset-indexed κ/θ/φ telescoping (lines 1093--1102). This upgrades the
   -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one global


### PR DESCRIPTION
## Summary

This PR restates the common sector decomposition-map helper in `TNLean.MPS.Periodic.Overlap.Case3` so that the chosen maps `Ω_u` satisfy the explicit finite-sum identity

```lean
∑ σ : Fin L → Fin d, (Ω k X σ) • evalWord (blocks k) (List.ofFn σ) = X
```

rather than presenting the same right-inverse property through `Fintype.linearCombination`.

This is the form used in arXiv:1708.00029, Appendix A, equations `eq:Fu` and `eq:Omegauprop`, and it is the form needed by the later cyclic contraction step. The proof now uses the existing theorem `blockDecompositionMap_sum`. No hypotheses are changed, and no new `sorry` is introduced; the pre-existing contraction gap in `repeatedBlocks_of_blockedSectorGaugePhase` remains the next mathematical step.

## Validation

- `lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean`
- `lake build TNLean.MPS.Periodic.Overlap.Case3`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `lake build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only restatement of an already-proved right-inverse property; no new axioms, hypotheses, or behavioral changes beyond the lemma’s conclusion shape.
> 
> **Overview**
> Restates **`exists_common_sectorDecompositionMaps_of_isNormal_leftCanonical`** so each sector map `Ω_k` is characterized by the explicit identity **∑_σ (Ω_k X σ) • evalWord … = X**, matching arXiv:1708.00029 Appendix A (`eq:Fu` / `eq:Omegauprop`) instead of packaging the same fact as `Fintype.linearCombination`.
> 
> The proof now cites **`blockDecompositionMap_sum`** (equivalent to the old `blockDecompositionMap_spec` step). A comment in **`repeatedBlocks_of_blockedSectorGaugePhase`** notes that the pending cyclic contraction will use these sum-form inverses. **Hypotheses and proof obligations are unchanged**; the existing `sorry` in that lemma is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28f25b0a78b8df1b9b358d25e691e57b4e6f8cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->