### PR TITLE
feat(peps): combine cyclic-shift gauge telescope

### DIFF
--- a/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
@@ -1,4 +1,5 @@
 import TNLean.Algebra.ScalarCommutant
+import TNLean.MPS.Chain.TranslationInvariance
 import TNLean.PEPS.CycleMPSChainOverlapInsertion
 
 /-!
@@ -742,6 +743,25 @@ theorem fundamentalTheorem_injectiveMPSChain_cyclicShift {n d D : ℕ} [NeZero n
     (hTI : IsCyclicShiftInvariantState A) : GaugeEquiv A (cyclicShift A) :=
   fundamentalTheorem_injectiveMPSChain_of_sameState hn A (cyclicShift A) hA
     (IsInjective.cyclicShift hA) hTI
+
+/-- **Gauge-to-first-tensor form of an injective closed-chain MPS**
+(arXiv:1804.04964, Applications section, lines 1807--1862), in the uniform
+physical- and bond-dimension setting.
+
+If an injective site-dependent closed-chain MPS generates a state invariant
+under cyclic translation, then every local tensor is obtained from the first
+one by invertible matrices on the left and right virtual legs.  This is the
+source's displayed \(L_i,R_i\) step before the final repeated-tensor
+collapse. -/
+theorem exists_gauge_to_first_of_cyclicShiftInvariantState
+    {n d D : ℕ} [NeZero n]
+    (hn : 3 ≤ n) (A : MPSChainTensor d D n) (hA : IsInjective A)
+    (hTI : IsCyclicShiftInvariantState A) :
+    ∀ k : Fin n, ∃ L R : GL (Fin D) ℂ, ∀ i : Fin d,
+      A k i = (L : Matrix (Fin D) (Fin D) ℂ) * A 0 i *
+        (((R⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) :=
+  MPSChainTensor.exists_gauge_to_first_of_cyclicShift_gaugeEquiv
+    (fundamentalTheorem_injectiveMPSChain_cyclicShift hn A hA hTI)
 
 /-- **Uniqueness of the injective closed-chain gauge**, the uniqueness clause
 of arXiv:1804.04964, Theorem `thm:inj_MPS`, line 724.

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1329,6 +1329,28 @@ recorded in the route note
     right virtual factors by the adjacent gauges.
 \end{proof}
 
+\begin{corollary}[Gauge-to-first description from a cyclic-invariant state]%
+    \label{cor:exists_gauge_to_first_of_cyclicShiftInvariantState}
+    \lean{TNLean.PEPS.exists_gauge_to_first_of_cyclicShiftInvariantState}
+    \leanok
+    \uses{cor:fundamentalTheorem_injectiveMPSChain_cyclicShift,
+        cor:exists_gauge_to_first_of_cyclicShift_gaugeEquiv}
+    Let \(A_0,\ldots,A_{n-1}\) be an injective site-dependent closed chain
+    on \(n\ge 3\) sites.  If its generated state is invariant under the
+    cyclic translation of the sites, then for every site \(v\) there are
+    invertible matrices \(L_v\) and \(R_v\) such that
+    \[
+        A_v^i = L_v\, A_0^i\, R_v^{-1}
+    \]
+    for every physical index \(i\).  This is the uniform-bond-dimension form
+    of the \(L_v,R_v\) step in the Applications-section proof of
+    \cite[lines~1803--1890]{Molnar2018NormalPEPS}.
+\end{corollary}
+\begin{proof}\leanok
+    Apply the injective chain theorem to the chain and its cyclic shift, then
+    telescope the resulting bond gauges around the chain.
+\end{proof}
+
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%
     \label{thm:fundamentalTheorem_injectiveMPSChain_gauge_unique}
     \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_gauge_unique}


### PR DESCRIPTION
## Summary

This PR combines the two previously separated steps in the Applications-section translation-invariance route for injective closed-chain MPS.  From a single injective site-dependent chain whose closed-chain state is invariant under cyclic translation, it first applies the cyclic-shift comparison theorem and then telescopes the resulting bond gauges to express every site tensor through the first tensor:

\[
A_v^i = L_v A_0^i R_v^{-1}.
\]

The matching blueprint corollary is added immediately after the cyclic-shift comparison and telescoping entries.  This is still the displayed \(L_v,R_v\) step of arXiv:1804.04964, lines 1807--1862; it does not yet prove the final repeated-tensor state equality \(\Psi(A_0,\ldots,A_{n-1})=\Psi(B,\ldots,B)\).

Refs #2920.

## Verification

- `lake exe cache get`
- `lake build TNLean.PEPS.CycleMPSChainOverlapCapstone`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization wiring and blueprint sync; no runtime, auth, or data-path changes. Risk is limited to proof/decl naming consistency with existing theorems.
> 
> **Overview**
> Adds a **single end-to-end statement** for injective closed-chain MPS whose state is invariant under cyclic translation: every site tensor is expressed as \(A_v^i = L_v A_0^i R_v^{-1}\) with invertible \(L_v,R_v\).
> 
> In Lean, `TNLean.PEPS.exists_gauge_to_first_of_cyclicShiftInvariantState` composes the existing cyclic-shift gauge comparison (`fundamentalTheorem_injectiveMPSChain_cyclicShift`) with telescoping (`MPSChainTensor.exists_gauge_to_first_of_cyclicShift_gaugeEquiv` from the new `TranslationInvariance` import). The blueprint gains matching **Corollary** `cor:exists_gauge_to_first_of_cyclicShiftInvariantState` with `\leanok` proof citing those two steps.
> 
> This is the paper’s \(L_v,R_v\) Applications-section step (arXiv:1804.04964, ~1807–1862); it does **not** yet prove the final repeated-tensor state equality.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 381c43e0b2e0ebae8900f474213520e0ada32270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->