### PR TITLE
feat(peps): telescope cyclic chain gauges

### DIFF
--- a/TNLean/PEPS/CycleMPSChainArc.lean
+++ b/TNLean/PEPS/CycleMPSChainArc.lean
@@ -119,6 +119,39 @@ lemma arcEval_const [NeZero n] (B : MPSTensor d D) (s : ℕ) (w : List (Fin d)) 
   | nil => rfl
   | cons i w ih => rw [arcEval_cons, MPSTensor.evalWord_cons, ih (s + 1)]
 
+/-- **Arc products telescope under a cyclic gauge**
+(arXiv:1804.04964, Applications section, lines 1863--1889).
+
+If two site-dependent chains are related by a cyclic virtual gauge, then every
+arc product of the second chain is the corresponding arc product of the first
+chain conjugated by the gauges at the two boundary bonds.  For a full closed
+chain this is the cancellation mechanism behind the source's substitution of
+the \(L_i,R_i\) expression into the trace. -/
+theorem arcEval_eq_gauge_conj [NeZero n] {A B : MPSChainTensor d D n}
+    {Z : Fin n → GL (Fin D) ℂ}
+    (hZ : ∀ (k : Fin n) (i : Fin d),
+      B k i = (Z k : Matrix (Fin D) (Fin D) ℂ) * A k i *
+        (((Z (cyclicSucc k))⁻¹ : GL (Fin D) ℂ) :
+          Matrix (Fin D) (Fin D) ℂ))
+    (s : ℕ) (w : List (Fin d)) :
+    arcEval B s w =
+      (Z (s : Fin n) : Matrix (Fin D) (Fin D) ℂ) * arcEval A s w *
+        (((Z ((s + w.length : ℕ) : Fin n))⁻¹ : GL (Fin D) ℂ) :
+          Matrix (Fin D) (Fin D) ℂ) := by
+  induction w generalizing s with
+  | nil =>
+      simp only [arcEval_nil, List.length_nil, Nat.add_zero, Matrix.mul_one,
+        Units.mul_inv]
+  | cons i w ih =>
+      have hsucc : cyclicSucc (s : Fin n) = ((s + 1 : ℕ) : Fin n) := by
+        rw [cyclicSucc_eq_add_one]
+        norm_num [Nat.cast_add]
+      have hlen : s + (i :: w).length = s + 1 + w.length := by
+        rw [List.length_cons]
+        omega
+      rw [arcEval_cons, arcEval_cons, hZ (s : Fin n) i, hsucc, ih (s + 1), hlen]
+      simp only [Matrix.mul_assoc, Units.inv_mul_cancel_left]
+
 /-- The arc product of the word of the first `k + 1` letters of a tuple
 peels its last letter at the matching site. -/
 lemma arcEval_take_succ [NeZero n] (A : MPSChainTensor d D n) (s : ℕ)
@@ -288,6 +321,17 @@ lemma coeff_eq_trace_arcEval [NeZero n] (A : MPSChainTensor d D n)
   rw [arcEval_ofFn_eq_prod A (fun k => k) σ 0 fun k => by
     rw [Nat.zero_add, Fin.cast_val_eq_self]]
   rfl
+
+/-- A cyclic virtual gauge leaves the closed-chain state unchanged
+(arXiv:1804.04964, Applications section, lines 1863--1889). -/
+theorem GaugeEquiv.sameState [NeZero n] {A B : MPSChainTensor d D n}
+    (hAB : GaugeEquiv A B) : SameState A B := by
+  obtain ⟨Z, hZ⟩ := hAB
+  intro σ
+  rw [coeff_eq_trace_arcEval A σ, coeff_eq_trace_arcEval B σ]
+  have hEval := arcEval_eq_gauge_conj (A := A) (B := B) (Z := Z) hZ 0 (List.ofFn σ)
+  rw [hEval, List.length_ofFn]
+  simpa using (MPSTensor.trace_conj_eq (Z 0) (arcEval A 0 (List.ofFn σ))).symm
 
 /-- Rotating the closed trace one site forward: the leading letter moves to
 the end of the word, and the arc rebases one site downstream. -/

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1242,6 +1242,31 @@ recorded in the route note
     them, including across the seam.
 \end{proof}
 
+\begin{theorem}[Cyclic gauges preserve closed-chain states]%
+    \label{thm:mps_chain_gaugeEquiv_sameState}
+    \lean{MPSChainTensor.arcEval_eq_gauge_conj}
+    \lean{MPSChainTensor.GaugeEquiv.sameState}
+    \leanok
+    \uses{def:chain_arc_window_injective, def:non_ti_chain}
+    Let \(A_0,\ldots,A_{n-1}\) and \(B_0,\ldots,B_{n-1}\) be two
+    site-dependent closed chains with a cyclic gauge relation
+    \[
+        B_v^i = Z_v\, A_v^i\, Z_{v+1}^{-1}
+    \]
+    at every site.  Then they generate the same closed-chain state.  More
+    generally, the product along any arc is conjugated by the two gauges on
+    the boundary bonds of that arc; for a full turn around the chain the
+    two boundary bonds coincide, and cyclicity of trace removes the
+    remaining conjugation.
+\end{theorem}
+\begin{proof}\leanok
+    Iterate the sitewise gauge relation along the arc.  Consecutive
+    boundary matrices cancel, leaving only the gauges at the two ends.
+    For a word of length \(n\) read from the first site, the two ends are
+    the same bond, so the closed trace is invariant under the resulting
+    conjugation.
+\end{proof}
+
 \begin{corollary}[Fundamental Theorem for injective closed MPS chains]%
     \label{cor:fundamentalTheorem_injectiveMPSChain_of_sameState}
     \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_of_sameState}


### PR DESCRIPTION
## Summary

This PR adds the closed-chain trace-telescoping lemma for site-dependent MPS chains.

- proves that a cyclic gauge relation conjugates every arc product by the gauges on the two boundary bonds
- proves that cyclic gauge-equivalent closed chains generate the same closed-chain state
- records the result in the PEPS normal-capstone blueprint section

This is a partial step toward the translation-invariant description from a cyclic-invariant injective MPS. It supplies the trace cancellation needed after constructing a constant-chain gauge witness, but it does not yet construct the repeated tensor itself.

Refs #2920.

## Validation

- Build completed successfully (1749 jobs).
- Build completed successfully (3452 jobs).
- ℹ [8637/8950] Replayed TNLean.MPS.Examples.AKLTRotation
info: TNLean/MPS/Examples/AKLTRotation.lean:441:66: Try this:
  [apply] ring_nf
  
  The `ring` tactic failed to close the goal. Use `ring_nf` to obtain a normal form.
    
  Note that `ring` works primarily in *commutative* rings. If you have a noncommutative ring, abelian group or module, consider using `noncomm_ring`, `abel` or `module` instead.
info: TNLean/MPS/Examples/AKLTRotation.lean:472:66: Try this:
  [apply] ring_nf
  
  The `ring` tactic failed to close the goal. Use `ring_nf` to obtain a normal form.
    
  Note that `ring` works primarily in *commutative* rings. If you have a noncommutative ring, abelian group or module, consider using `noncomm_ring`, `abel` or `module` instead.
⚠ [8695/8950] Replayed TNLean.PEPS.EdgeScalarSolve
warning: TNLean/PEPS/EdgeScalarSolve.lean:250:10: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:251:11: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:257:11: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:258:10: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:264:10: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:265:11: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:350:2: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:353:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:356:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:368:2: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:371:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/EdgeScalarSolve.lean:374:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8696/8950] Replayed TNLean.PEPS.TensorFactorScalar
warning: TNLean/PEPS/TensorFactorScalar.lean:214:0: `piProduct_forms_scalar` does not use the following hypothesis in its type:
  • [DecidableEq ι] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
⚠ [8697/8950] Replayed TNLean.PEPS.FundamentalTheorem
warning: TNLean/PEPS/FundamentalTheorem.lean:286:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.isVertexInjective_reindexTensor`:
  [Fintype V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [Fintype V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/FundamentalTheorem.lean:282:0: `isVertexInjective_reindexTensor` does not use the following hypothesis in its type:
  • [Fintype V] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
warning: TNLean/PEPS/FundamentalTheorem.lean:628:6: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/FundamentalTheorem.lean:632:4: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/FundamentalTheorem.lean:740:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.nonempty_incidentEdge_of_connected`:
  [Fintype V]
  [DecidableRel G.Adj]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [Fintype V] [DecidableRel G.Adj] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/FundamentalTheorem.lean:738:0: `nonempty_incidentEdge_of_connected` does not use the following hypothesis in its type:
  • [DecidableRel G.Adj] (#5)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/PEPS/FundamentalTheorem.lean:738:0: `nonempty_incidentEdge_of_connected` does not use the following hypothesis in its type:
  • [Fintype V] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8704/8950] Replayed TNLean.PEPS.RegionBlock.Recovery5
warning: TNLean/PEPS/RegionBlock/Recovery5.lean:87:53: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
⚠ [8708/8950] Replayed TNLean.PEPS.RegionBlock.Recovery9
warning: TNLean/PEPS/RegionBlock/Recovery9.lean:110:5: unused variable `hvB`

Note: This linter can be disabled with `set_option linter.unusedVariables false`
⚠ [8711/8950] Replayed TNLean.PEPS.RegionBlock.BlockRangeCoincidence
warning: TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean:401:5: unused variable `hDim`

Note: This linter can be disabled with `set_option linter.unusedVariables false`
warning: TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean:467:4: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean:471:2: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
⚠ [8712/8950] Replayed TNLean.PEPS.RegionBlock.ThreeBlockResonate
warning: TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean:480:60: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean:488:60: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
⚠ [8713/8950] Replayed TNLean.PEPS.RegionBlock.ThreeBlockResonate2
warning: TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean:264:60: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean:272:60: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
⚠ [8715/8950] Replayed TNLean.PEPS.RegionBlock.UnionInjectivity
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:69:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:75:54: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:77:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:82:54: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:95:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:101:54: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:103:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:108:54: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:466:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:470:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:644:48: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:647:36: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:887:26: 'exact e2' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivity.lean:887:26: this tactic is never executed

Note: This linter can be disabled with `set_option linter.unreachableTactic false`
⚠ [8717/8950] Replayed TNLean.PEPS.RegionBlock.BlockCoeffTransfer
warning: TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean:182:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean:511:17: This simp argument is unused:
  smul_eq_mul

Hint: Omit it from the simp argument list.
  simp only [̵s̵m̵u̵l̵_̵e̵q̵_̵m̵u̵l̵]̵ ̵at this ⊢

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
warning: TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean:512:31: 'rw [Finset.sum_mul]' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
warning: TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean:512:31: this tactic is never executed

Note: This linter can be disabled with `set_option linter.unreachableTactic false`
⚠ [8722/8950] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityGeneral
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean:81:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.ThreeBlockGeometry.sdiff_red_eq_blue_union_complement`:
  [LinearOrder V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [LinearOrder V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean:121:8: automatically included section variable(s) unused in theorem `TNLean.PEPS.ThreeBlockGeometry.complPhysical_apply_blue`:
  [LinearOrder V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [LinearOrder V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean:128:8: automatically included section variable(s) unused in theorem `TNLean.PEPS.ThreeBlockGeometry.complPhysical_apply_not_blue`:
  [LinearOrder V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [LinearOrder V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean:304:60: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean:312:60: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
⚠ [8723/8950] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityGeneralBlue
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean:92:60: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean:100:60: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean:359:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean:397:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
⚠ [8724/8950] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityGeneral2
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:47:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:53:54: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:55:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:60:54: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:39:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.ThreeBlockGeometry.isBlueBoundaryEdge_of_hostBoundary_blue`:
  [DecidableRel G.Adj]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [DecidableRel G.Adj] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:36:0: `ThreeBlockGeometry.isBlueBoundaryEdge_of_hostBoundary_blue` does not use the following hypothesis in its type:
  • [DecidableRel G.Adj] (#6)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:72:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:78:54: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:80:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:85:54: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:65:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.ThreeBlockGeometry.isComplBoundaryEdge_of_hostBoundary_compl`:
  [DecidableRel G.Adj]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [DecidableRel G.Adj] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:63:0: `ThreeBlockGeometry.isComplBoundaryEdge_of_hostBoundary_compl` does not use the following hypothesis in its type:
  • [DecidableRel G.Adj] (#6)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:90:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.ThreeBlockGeometry.hostBoundary_hostVertex_mem_blue_or_compl`:
  [DecidableRel G.Adj]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [DecidableRel G.Adj] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:88:0: `ThreeBlockGeometry.hostBoundary_hostVertex_mem_blue_or_compl` does not use the following hypothesis in its type:
  • [DecidableRel G.Adj] (#6)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:433:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:437:42: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:427:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.ThreeBlockGeometry.isRegionBoundaryEdge_red_of_host`:
  [DecidableRel G.Adj]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [DecidableRel G.Adj] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:425:0: `ThreeBlockGeometry.isRegionBoundaryEdge_red_of_host` does not use the following hypothesis in its type:
  • [DecidableRel G.Adj] (#6)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:609:48: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:612:36: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:848:26: 'exact e2' tactic does nothing

Note: This linter can be disabled with `set_option linter.unusedTactic false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:729:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:848:26: this tactic is never executed

Note: This linter can be disabled with `set_option linter.unreachableTactic false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:881:8: automatically included section variable(s) unused in theorem `TNLean.PEPS.twoRegionGeometry_blue`:
  [LinearOrder V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [LinearOrder V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:884:8: automatically included section variable(s) unused in theorem `TNLean.PEPS.twoRegionGeometry_complement`:
  [LinearOrder V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [LinearOrder V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:887:8: automatically included section variable(s) unused in theorem `TNLean.PEPS.twoRegionGeometry_red`:
  [LinearOrder V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [LinearOrder V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean:943:35: This simp argument is unused:
  Finset.coe_cons

Hint: Omit it from the simp argument list.
  simp [F̵i̵n̵s̵e̵t̵.̵c̵o̵e̵_̵c̵o̵n̵s̵,̵ ̵Set.subset_insert]

Note: This linter can be disabled with `set_option linter.unusedSimpArgs false`
⚠ [8728/8950] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap3b
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3b.lean:153:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
⚠ [8731/8950] Replayed TNLean.PEPS.RegionTransportInsertion
warning: TNLean/PEPS/RegionTransportInsertion.lean:77:2: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8738/8950] Replayed TNLean.PEPS.TorusEdgeBlockingCrossing
warning: TNLean/PEPS/TorusEdgeBlockingCrossing.lean:98:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/TorusEdgeBlockingCrossing.lean:113:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/PEPS/TorusEdgeBlockingCrossing.lean:111:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/TorusEdgeBlockingCrossing.lean:141:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/TorusEdgeBlockingCrossing.lean:268:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8739/8950] Replayed TNLean.PEPS.TorusWindowRegion
warning: TNLean/PEPS/TorusWindowRegion.lean:121:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/TorusWindowRegion.lean:255:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8772/8950] Replayed TNLean.PEPS.RegionBlock.CoarseThreeSite8
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean:57:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.isRegionBoundaryEdge_singleCrossing`:
  [Fintype V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [Fintype V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean:56:0: `isRegionBoundaryEdge_singleCrossing` does not use the following hypothesis in its type:
  • [Fintype V] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean:71:0: automatically included section variable(s) unused in theorem `TNLean.PEPS.crossingEdge_unique`:
  [Fintype V]
consider restructuring your `variable` declarations so that the variables are not in scope or explicitly omit them:
  omit [Fintype V] in theorem ...

Note: This linter can be disabled with `set_option linter.unusedSectionVars false`
warning: TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean:69:0: `crossingEdge_unique` does not use the following hypothesis in its type:
  • [Fintype V] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8791/8950] Replayed TNLean.PEPS.TorusWitnessCapstone
warning: TNLean/PEPS/TorusWitnessCapstone.lean:100:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
⚠ [8800/8950] Replayed TNLean.PEPS.RegionBlock.InsertResidual
warning: TNLean/PEPS/RegionBlock/InsertResidual.lean:613:4: `push_neg` has been deprecated. Prefer using `push Not` instead.
If you'd rather continue using `push_neg` in your project, you can implement it as follows:
```
open Lean.Parser.Tactic in
macro "push_neg" cfg:optConfig loc:(location)? : tactic =>
  `(tactic| push $cfg:optConfig Not $[$loc]?)
```
⚠ [8804/8950] Replayed TNLean.PEPS.RegionBlock.GaugeInjectivity
warning: TNLean/PEPS/RegionBlock/GaugeInjectivity.lean:253:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/RegionBlock/GaugeInjectivity.lean:285:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/RegionBlock/GaugeInjectivity.lean:292:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/RegionBlock/GaugeInjectivity.lean:561:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/RegionBlock/GaugeInjectivity.lean:596:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8812/8950] Replayed TNLean.PEPS.RegionBlock.UnionInjectivityOverlap6
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean:327:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean:444:100: This line exceeds the 100 character limit, please shorten it!

Note: This linter can be disabled with `set_option linter.style.longLine false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean:491:0: `hc_transport` does not use the following hypothesis in its type:
  • [DecidableEq V] (#3)

Consider removing this hypothesis and using `classical` in the proof instead. For terms, consider using `open scoped Classical in` at the term level (not the command level).

Note: This linter can be disabled with `set_option linter.unusedDecidableInType false`
warning: TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean:512:0: `exists_regionBoundaryLabel_union_eq` does not use the following hypothesis in its type:
  • [Fintype V] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
⚠ [8815/8950] Replayed TNLean.PEPS.TorusGaugeUniqueness
warning: TNLean/PEPS/TorusGaugeUniqueness.lean:466:12: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/TorusGaugeUniqueness.lean:526:12: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8831/8950] Replayed TNLean.PEPS.CycleMPSInjectivity
warning: TNLean/PEPS/CycleMPSInjectivity.lean:58:2: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSInjectivity.lean:78:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSInjectivity.lean:82:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSInjectivity.lean:472:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSInjectivity.lean:474:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8832/8950] Replayed TNLean.PEPS.CycleMPSFundamentalTheorem
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:68:0: `edgeGaugeAt_of_fst` does not use the following hypothesis in its type:
  • [Fintype V] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:77:0: `edgeGaugeAt_of_snd` does not use the following hypothesis in its type:
  • [Fintype V] (#2)

Consider replacing this hypothesis with the corresponding instance of `Finite` and using `Fintype.ofFinite` in the proof, or removing it entirely.

Note: This linter can be disabled with `set_option linter.unusedFintypeInType false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:256:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:349:6: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:358:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:365:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:385:4: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:532:8: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:542:8: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
warning: TNLean/PEPS/CycleMPSFundamentalTheorem.lean:638:8: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8833/8950] Replayed TNLean.PEPS.CycleMPSTranslationInvariant
warning: TNLean/PEPS/CycleMPSTranslationInvariant.lean:315:8: The `show` tactic should only be used to indicate intermediate goal states for readability.
However, this tactic invocation changed the goal. Please use `change` instead for these purposes.

Note: This linter can be disabled with `set_option linter.style.show false`
⚠ [8917/8950] Replayed TNLean.MPS.Periodic.Overlap.Case3
warning: TNLean/MPS/Periodic/Overlap/Case3.lean:790:14: declaration uses `sorry`
Build completed successfully (8950 jobs).
- ✓ No newly added reader-facing prose violations found.
- Scanning Lean source tree …
  Found 7845 declarations in Lean source
Scanning blueprint .tex files …
  Found 2811 unique \lean{} references in blueprint
  Found 2832 theorem-like blueprint entries

======================================================================
  BLUEPRINT ↔ LEAN SYNC REPORT
======================================================================

Per-chapter formalization progress:
  Chapter                                             Done / Total       %
  --------------------------------------------------------------------
  ch02_mps.tex                                          51 /    51  100.0%
  ch03_single.tex                                       12 /    12  100.0%
  ch04_channels.tex                                     65 /    65  100.0%
  ch05_schwarz.tex                                      49 /    49  100.0%
  ch06_qpf.tex                                          37 /    37  100.0%
  ch07_spectral.tex                                    101 /   101  100.0%
  ch08_wielandt.tex                                     83 /    83  100.0%
  ch09_canonical.tex                                    67 /    67  100.0%
  ch10_bnt.tex                                          54 /    54  100.0%
  ch11_fundamental_theorem_proof.tex                    15 /    15  100.0%
  ch12_symmetry.tex                                     64 /    64  100.0%
  ch13_parent_hamiltonian_block_diagonal.tex            37 /    37  100.0%
  ch13_parent_hamiltonian_block_diagonal_chain_equality.tex    10 /    10  100.0%
  ch13_parent_hamiltonian_block_intersections.tex      129 /   129  100.0%
  ch13_parent_hamiltonian_block_intersections_trace_consequences.tex    31 /    31  100.0%
  ch13_parent_hamiltonian_commuting_gap.tex             51 /    57   89.5%
  ch13_parent_hamiltonian_decorrelation.tex             16 /    16  100.0%
  ch13_parent_hamiltonian_injective_boundary.tex        35 /    35  100.0%
  ch13_parent_hamiltonian_injective_ground_spaces.tex    83 /    83  100.0%
  ch13_parent_hamiltonian_normal_boundary.tex           15 /    15  100.0%
  ch13_parent_hamiltonian_normal_closing.tex            25 /    25  100.0%
  ch13_parent_hamiltonian_normal_closing_reverse.tex    15 /    15  100.0%
  ch13_parent_hamiltonian_spectral_gap.tex              77 /    77  100.0%
  ch14_correlations.tex                                 29 /    29  100.0%
  ch15_examples.tex                                     69 /    69  100.0%
  ch16_channel_representations.tex                      99 /    99  100.0%
  ch17_semigroup.tex                                   138 /   138  100.0%
  ch18_operator_convexity.tex                           22 /    26   84.6%
  ch19_entropy.tex                                      27 /    29   93.1%
  ch19_entropy_corollaries.tex                           4 /     4  100.0%
  ch20_mpdo_canonical_forms.tex                         26 /    28   92.9%
  ch20_mpdo_foundations.tex                             15 /    15  100.0%
  ch21_mpdo_rfp_algebra_structure.tex                  150 /   150  100.0%
  ch21_mpdo_rfp_area_law.tex                            36 /    36  100.0%
  ch21_mpdo_rfp_blocked_rfp.tex                         20 /    20  100.0%
  ch21_mpdo_rfp_commuting_form_gsnnch.tex               22 /    22  100.0%
  ch21_mpdo_rfp_foundations.tex                         21 /    21  100.0%
  ch21_mpdo_rfp_fusion_isometries.tex                    8 /     8  100.0%
  ch21_mpdo_rfp_pure_state_recovery.tex                 13 /    13  100.0%
  ch21_mpdo_rfp_simple_local_structure.tex              30 /    30  100.0%
  ch22_periodic_ft.tex                                  72 /    75   96.0%
  ch23_algebraic_ft.tex                                 71 /    71  100.0%
  ch24_peps_ft_balanced_edge_scalars.tex                18 /    18  100.0%
  ch24_peps_ft_edge_kernel_gauges.tex                   52 /    52  100.0%
  ch24_peps_ft_edge_middle.tex                          49 /    49  100.0%
  ch24_peps_ft_foundations.tex                          58 /    58  100.0%
  ch24_peps_ft_normal_capstone.tex                      73 /    73  100.0%
  ch24_peps_ft_normal_square.tex                       258 /   258  100.0%
  ch24_peps_ft_normal_union.tex                         72 /    72  100.0%
  ch24_peps_ft_region_transfer.tex                     127 /   127  100.0%
  ch24_peps_ft_torus.tex                                96 /    96  100.0%
  ch24_peps_ft_torus_bond_local.tex                      3 /     3  100.0%
  ch24_peps_ft_torus_bond_uniform.tex                    6 /     6  100.0%
  ch24_peps_ft_torus_row_cut_obstruction.tex             3 /     3  100.0%
  ch24_peps_ft_torus_window_peel4.tex                    3 /     3  100.0%
  ch24_peps_ft_torus_window_realizes.tex                 3 /     3  100.0%
  --------------------------------------------------------------------
  TOTAL                                               2815 /  2832   99.4%

✓ Blueprint and Lean code are in sync.
- Scanning Lean source tree …
  Found 7845 declarations in Lean source
Scanning blueprint .tex files …
  Found 2811 unique \lean{} references in blueprint
  Found 2832 theorem-like blueprint entries
  Updated blueprint/lean_decls with 2811 entries

======================================================================
  BLUEPRINT ↔ LEAN SYNC REPORT
======================================================================

Per-chapter formalization progress:
  Chapter                                             Done / Total       %
  --------------------------------------------------------------------
  ch02_mps.tex                                          51 /    51  100.0%
  ch03_single.tex                                       12 /    12  100.0%
  ch04_channels.tex                                     65 /    65  100.0%
  ch05_schwarz.tex                                      49 /    49  100.0%
  ch06_qpf.tex                                          37 /    37  100.0%
  ch07_spectral.tex                                    101 /   101  100.0%
  ch08_wielandt.tex                                     83 /    83  100.0%
  ch09_canonical.tex                                    67 /    67  100.0%
  ch10_bnt.tex                                          54 /    54  100.0%
  ch11_fundamental_theorem_proof.tex                    15 /    15  100.0%
  ch12_symmetry.tex                                     64 /    64  100.0%
  ch13_parent_hamiltonian_block_diagonal.tex            37 /    37  100.0%
  ch13_parent_hamiltonian_block_diagonal_chain_equality.tex    10 /    10  100.0%
  ch13_parent_hamiltonian_block_intersections.tex      129 /   129  100.0%
  ch13_parent_hamiltonian_block_intersections_trace_consequences.tex    31 /    31  100.0%
  ch13_parent_hamiltonian_commuting_gap.tex             51 /    57   89.5%
  ch13_parent_hamiltonian_decorrelation.tex             16 /    16  100.0%
  ch13_parent_hamiltonian_injective_boundary.tex        35 /    35  100.0%
  ch13_parent_hamiltonian_injective_ground_spaces.tex    83 /    83  100.0%
  ch13_parent_hamiltonian_normal_boundary.tex           15 /    15  100.0%
  ch13_parent_hamiltonian_normal_closing.tex            25 /    25  100.0%
  ch13_parent_hamiltonian_normal_closing_reverse.tex    15 /    15  100.0%
  ch13_parent_hamiltonian_spectral_gap.tex              77 /    77  100.0%
  ch14_correlations.tex                                 29 /    29  100.0%
  ch15_examples.tex                                     69 /    69  100.0%
  ch16_channel_representations.tex                      99 /    99  100.0%
  ch17_semigroup.tex                                   138 /   138  100.0%
  ch18_operator_convexity.tex                           22 /    26   84.6%
  ch19_entropy.tex                                      27 /    29   93.1%
  ch19_entropy_corollaries.tex                           4 /     4  100.0%
  ch20_mpdo_canonical_forms.tex                         26 /    28   92.9%
  ch20_mpdo_foundations.tex                             15 /    15  100.0%
  ch21_mpdo_rfp_algebra_structure.tex                  150 /   150  100.0%
  ch21_mpdo_rfp_area_law.tex                            36 /    36  100.0%
  ch21_mpdo_rfp_blocked_rfp.tex                         20 /    20  100.0%
  ch21_mpdo_rfp_commuting_form_gsnnch.tex               22 /    22  100.0%
  ch21_mpdo_rfp_foundations.tex                         21 /    21  100.0%
  ch21_mpdo_rfp_fusion_isometries.tex                    8 /     8  100.0%
  ch21_mpdo_rfp_pure_state_recovery.tex                 13 /    13  100.0%
  ch21_mpdo_rfp_simple_local_structure.tex              30 /    30  100.0%
  ch22_periodic_ft.tex                                  72 /    75   96.0%
  ch23_algebraic_ft.tex                                 71 /    71  100.0%
  ch24_peps_ft_balanced_edge_scalars.tex                18 /    18  100.0%
  ch24_peps_ft_edge_kernel_gauges.tex                   52 /    52  100.0%
  ch24_peps_ft_edge_middle.tex                          49 /    49  100.0%
  ch24_peps_ft_foundations.tex                          58 /    58  100.0%
  ch24_peps_ft_normal_capstone.tex                      73 /    73  100.0%
  ch24_peps_ft_normal_square.tex                       258 /   258  100.0%
  ch24_peps_ft_normal_union.tex                         72 /    72  100.0%
  ch24_peps_ft_region_transfer.tex                     127 /   127  100.0%
  ch24_peps_ft_torus.tex                                96 /    96  100.0%
  ch24_peps_ft_torus_bond_local.tex                      3 /     3  100.0%
  ch24_peps_ft_torus_bond_uniform.tex                    6 /     6  100.0%
  ch24_peps_ft_torus_row_cut_obstruction.tex             3 /     3  100.0%
  ch24_peps_ft_torus_window_peel4.tex                    3 /     3  100.0%
  ch24_peps_ft_torus_window_realizes.tex                 3 /     3  100.0%
  --------------------------------------------------------------------
  TOTAL                                               2815 /  2832   99.4%

✓ Blueprint and Lean code are in sync.
- 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and blueprint text in PEPS/MPS theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds the **cyclic gauge telescoping** lemmas needed when substituting \(L_i,R_i\) expressions into closed-chain traces (Molnár et al., Applications section).
> 
> In Lean (`CycleMPSChainArc.lean`), **`arcEval_eq_gauge_conj`** shows that if \(B\) is obtained from \(A\) by a cyclic virtual gauge \(B_v^i = Z_v A_v^i Z_{v+1}^{-1}\), then each arc product of \(B\) equals the matching arc product of \(A\) conjugated by \(Z\) at the start bond and \(Z^{-1}\) at the end bond. **`GaugeEquiv.sameState`** deduces that such gauge-related chains have the same closed-chain state by rewriting coefficients as traces and using trace invariance under conjugation when the arc wraps the full chain.
> 
> The PEPS normal-capstone blueprint gains **Theorem “Cyclic gauges preserve closed-chain states”**, linked to those Lean names, as a formal step toward the translation-invariant description from a cyclic-invariant injective MPS (trace cancellation after a constant-chain gauge witness; constructing the repeated tensor is still out of scope). Refs #2920.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5c321fd9060e41168c3960adc6e8663e02f47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->