### PR TITLE
style(peps): clear Lean linter warnings

### DIFF
--- a/TNLean/MPS/Examples/AKLTRotation.lean
+++ b/TNLean/MPS/Examples/AKLTRotation.lean
@@ -438,7 +438,7 @@ lemma R_su2Diag_eq_rotZ (θ : ℝ) :
       Fin.mk_one, Fin.isValue, Complex.ofReal_zero, Complex.ofReal_one, Complex.ofReal_neg,
       neg_mul, mul_neg, neg_zero, mul_zero, zero_mul, add_zero, zero_add, mul_one, one_mul,
       hexpP, hexpN, hcos, hsin] <;>
-    (ring_nf; (try (simp only [Complex.I_sq, Complex.I_pow_four]; ring));
+    (ring_nf; (try (simp only [Complex.I_sq, Complex.I_pow_four]; ring_nf));
       (try linear_combination hpyth))
 
 /-- Conjugating the Pauli vector by the cover `su2Xrot β` realizes the rotation by
@@ -469,7 +469,7 @@ lemma R_su2Xrot_eq_rotX (β : ℝ) :
       Fin.mk_one, Fin.isValue, Complex.ofReal_zero, Complex.ofReal_one, Complex.ofReal_neg,
       neg_mul, mul_neg, neg_zero, mul_zero, zero_mul, add_zero, zero_add, mul_one, one_mul,
       hcos, hsin] <;>
-    (ring_nf; (try (simp only [Complex.I_sq, Complex.I_pow_four]; ring));
+    (ring_nf; (try (simp only [Complex.I_sq, Complex.I_pow_four]; ring_nf));
       (try linear_combination hpyth))
 
 

--- a/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
+++ b/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
@@ -67,7 +67,7 @@ variable [NeZero n]
 
 /-- The gauge matrix at an incidence whose stored first endpoint is the
 vertex. -/
-theorem edgeGaugeAt_of_fst {V : Type*} [Fintype V] [LinearOrder V]
+theorem edgeGaugeAt_of_fst {V : Type*} [LinearOrder V]
     {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ} (A : Tensor G d)
     (X : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ) (v : V) (ie : IncidentEdge G v)
     (h : ie.1.1.1 = v) :
@@ -76,7 +76,7 @@ theorem edgeGaugeAt_of_fst {V : Type*} [Fintype V] [LinearOrder V]
 
 /-- The gauge matrix at an incidence whose stored second endpoint is the
 vertex. -/
-theorem edgeGaugeAt_of_snd {V : Type*} [Fintype V] [LinearOrder V]
+theorem edgeGaugeAt_of_snd {V : Type*} [LinearOrder V]
     {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ} (A : Tensor G d)
     (X : (e : Edge G) → GL (Fin (A.bondDim e)) ℂ) (v : V) (ie : IncidentEdge G v)
     (h : ¬ ie.1.1.1 = v) :
@@ -253,7 +253,7 @@ theorem cycleLeftGauge_eq (hn : 3 ≤ n) (A : MPSTensor d D)
   · -- The bond entering site `0` is the seam edge, stored first endpoint `0`.
     have hfst : (cycleSuccEdge hn (v - 1)).1.1 = v := by
       rw [cycleSuccEdge_val_of_eq hn (pred_zero_wrap hn hv0)]
-      show v - 1 + 1 = v
+      change v - 1 + 1 = v
       rw [sub_add_cancel]
     have hM : cycleLeftGauge hn A X v =
         (X (cycleSuccEdge hn (v - 1)) : Matrix (Fin D) (Fin D) ℂ) :=
@@ -346,7 +346,7 @@ theorem cycleGaugeOfEdgeGauge_edgeGaugeOfCycleGauge (hn : 3 ≤ n)
     have hpair := cycleSuccEdge_val_of_eq hn (pred_zero_wrap hn hv0)
     have hcond : ¬ ((cycleSuccEdge hn (v - 1)).1.1 + 1 = (cycleSuccEdge hn (v - 1)).1.2) := by
       rw [hpair]
-      show ¬ (v - 1 + 1) + 1 = v - 1
+      change ¬ (v - 1 + 1) + 1 = v - 1
       rw [sub_add_cancel]
       intro h
       have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
@@ -355,14 +355,14 @@ theorem cycleGaugeOfEdgeGauge_edgeGaugeOfCycleGauge (hn : 3 ≤ n)
       have := v.isLt
       split_ifs at hval <;> omega
     rw [edgeGaugeOfCycleGauge, if_neg hcond, hpair]
-    show ((Z (v - 1 + 1))⁻¹)⁻¹ = Z v
+    change ((Z (v - 1 + 1))⁻¹)⁻¹ = Z v
     rw [sub_add_cancel, inv_inv]
   · rw [if_neg hv0]
     have hpair := cycleSuccEdge_val_of_lt hn (pred_val_lt hn hv0)
     have hcond : (cycleSuccEdge hn (v - 1)).1.1 + 1 = (cycleSuccEdge hn (v - 1)).1.2 := by
       rw [hpair]
     rw [edgeGaugeOfCycleGauge, if_pos hcond, hpair]
-    show glTranspose (glTranspose (Z (v - 1 + 1))) = Z v
+    change glTranspose (glTranspose (Z (v - 1 + 1))) = Z v
     rw [sub_add_cancel, glTranspose_glTranspose]
 
 end GaugeConversion
@@ -382,7 +382,7 @@ theorem exists_ne_zero_of_isNBlkInjective {L : ℕ} (hL : 0 < L) (hD : 0 < D)
       MPSTensor.evalWord B (List.ofFn σ)) ⊆ {0} := by
     rintro _ ⟨σ, rfl⟩
     obtain ⟨L', rfl⟩ : ∃ L', L = L' + 1 := ⟨L - 1, by omega⟩
-    show MPSTensor.evalWord B (List.ofFn σ) ∈ ({0} : Set (Matrix (Fin D) (Fin D) ℂ))
+    change MPSTensor.evalWord B (List.ofFn σ) ∈ ({0} : Set (Matrix (Fin D) (Fin D) ℂ))
     rw [Set.mem_singleton_iff, List.ofFn_succ, MPSTensor.evalWord_cons, hall (σ 0),
       Matrix.zero_mul]
   have hle : (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) ≤ ⊥ := by
@@ -529,7 +529,7 @@ theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL
       have hcond : ¬ ((cycleSuccEdge hn3 (v - 1)).1.1 + 1 = (cycleSuccEdge hn3 (v - 1)).1.2) := by
         have hpair := cycleSuccEdge_val_of_eq hn3 (pred_zero_wrap hn3 hv0)
         rw [hpair]
-        show ¬ (v - 1 + 1) + 1 = v - 1
+        change ¬ (v - 1 + 1) + 1 = v - 1
         rw [sub_add_cancel]
         intro h
         have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
@@ -539,7 +539,7 @@ theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL
         split_ifs at hval <;> omega
       have hZ1 : (cycleSuccEdge hn3 (v - 1)).1.1 = v := by
         rw [cycleSuccEdge_val_of_eq hn3 (pred_zero_wrap hn3 hv0)]
-        show v - 1 + 1 = v
+        change v - 1 + 1 = v
         rw [sub_add_cancel]
       rw [edgeGaugeOfCycleGauge, edgeGaugeOfCycleGauge, if_neg hcond, if_neg hcond, hZ1]
         at hce
@@ -635,7 +635,7 @@ theorem fundamentalTheorem_normalMPS_gauge_unique {n L d D : ℕ} [NeZero n] (hL
         apply Fin.ext
         have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
         rw [Fin.val_add_eq_ite, h1]
-        show (if n ≤ k + 1 then k + 1 - n else k + 1) = k + 1
+        change (if n ≤ k + 1 then k + 1 - n else k + 1) = k + 1
         split_ifs <;> omega
       rw [← hsucc, hstep ⟨k, hk'⟩, IH hk']
   exact ⟨μ 0, fun v => by rw [hμ v, hconst v]⟩

--- a/TNLean/PEPS/CycleMPSInjectivity.lean
+++ b/TNLean/PEPS/CycleMPSInjectivity.lean
@@ -55,7 +55,7 @@ def arcSite {L : ℕ} (hLn : L < n) (s : Fin n) (j : Fin L) : Fin n :=
 theorem arcSite_mem {L : ℕ} (hLn : L < n) (s : Fin n) (j : Fin L) :
     arcSite hLn s j ∈ cycleArcFrom s L := by
   rw [mem_cycleArcFrom]
-  show (s + ⟨j.val, lt_trans j.isLt hLn⟩ - s).val < L
+  change (s + ⟨j.val, lt_trans j.isLt hLn⟩ - s).val < L
   rw [add_sub_cancel_left]
   exact j.isLt
 
@@ -75,11 +75,11 @@ def arcSiteEquiv {L : ℕ} (hLn : L < n) (s : Fin n) :
   invFun w := ⟨(w.1 - s).val, mem_cycleArcFrom.mp w.2⟩
   left_inv j := by
     apply Fin.ext
-    show ((s + ⟨j.val, lt_trans j.isLt hLn⟩ - s : Fin n)).val = j.val
+    change ((s + ⟨j.val, lt_trans j.isLt hLn⟩ - s : Fin n)).val = j.val
     rw [add_sub_cancel_left]
   right_inv w := by
     apply Subtype.ext
-    show s + (⟨(w.1 - s).val, _⟩ : Fin n) = w.1
+    change s + (⟨(w.1 - s).val, _⟩ : Fin n) = w.1
     rw [show (⟨(w.1 - s).val, lt_trans (mem_cycleArcFrom.mp w.2) hLn⟩ : Fin n) = w.1 - s from
       Fin.ext rfl, add_comm, sub_add_cancel]
 
@@ -469,9 +469,9 @@ theorem regionBlockedTensorInjective_cycleTensorOfMPS (hn : 3 ≤ n) {L : ℕ} (
       fun w => x ⟨(w.1 - s).val, mem_cycleArcFrom.mp w.2⟩ with hτ
     have hword : arcWord hLn s τ = x := by
       funext j
-      show x ⟨((arcSite hLn s j : Fin n) - s).val, _⟩ = x j
+      change x ⟨((arcSite hLn s j : Fin n) - s).val, _⟩ = x j
       refine congrArg x (Fin.ext ?_)
-      show ((s + ⟨j.val, lt_trans j.isLt hLn⟩ - s : Fin n)).val = j.val
+      change ((s + ⟨j.val, lt_trans j.isLt hLn⟩ - s : Fin n)).val = j.val
       rw [add_sub_cancel_left]
     have hcτ : ∑ bdry' : RegionBoundaryConfig (G := SimpleGraph.cycleGraph n)
         (cycleTensorOfMPS hn A) (cycleArcFrom s L),

--- a/TNLean/PEPS/CycleMPSTranslationInvariant.lean
+++ b/TNLean/PEPS/CycleMPSTranslationInvariant.lean
@@ -312,7 +312,7 @@ theorem fundamentalTheorem_normalMPS_translationInvariant {n L d D : ℕ} [NeZer
         apply Fin.ext
         have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
         rw [Fin.val_add_eq_ite, h1]
-        show (if n ≤ k + 1 then k + 1 - n else k + 1) = k + 1
+        change (if n ≤ k + 1 then k + 1 - n else k + 1) = k + 1
         split_ifs <;> omega
       rw [← hsucc, hstep ⟨k, hk'⟩, IH hk']
   -- The gauge at site `k` is the starting gauge scaled by the `k`-th power.

--- a/TNLean/PEPS/EdgeScalarSolve.lean
+++ b/TNLean/PEPS/EdgeScalarSolve.lean
@@ -247,22 +247,34 @@ omit [Fintype V] [DecidableRel G.Adj] in
 theorem edge0_inc_v0 (v₀ w₀ : V) (hadj : G.Adj v₀ w₀) :
     (edge0 (G := G) v₀ w₀ hadj).1.1 = v₀ ∨ (edge0 (G := G) v₀ w₀ hadj).1.2 = v₀ := by
   rcases lt_or_gt_of_ne (G.ne_of_adj hadj) with h | h
-  · left; show min v₀ w₀ = v₀; exact min_eq_left h.le
-  · right; show max v₀ w₀ = v₀; exact max_eq_left h.le
+  · left
+    change min v₀ w₀ = v₀
+    exact min_eq_left h.le
+  · right
+    change max v₀ w₀ = v₀
+    exact max_eq_left h.le
 
 omit [Fintype V] [DecidableRel G.Adj] in
 theorem edge0_inc_w0 (v₀ w₀ : V) (hadj : G.Adj v₀ w₀) :
     (edge0 (G := G) v₀ w₀ hadj).1.1 = w₀ ∨ (edge0 (G := G) v₀ w₀ hadj).1.2 = w₀ := by
   rcases lt_or_gt_of_ne (G.ne_of_adj hadj) with h | h
-  · right; show max v₀ w₀ = w₀; exact max_eq_right h.le
-  · left; show min v₀ w₀ = w₀; exact min_eq_right h.le
+  · right
+    change max v₀ w₀ = w₀
+    exact max_eq_right h.le
+  · left
+    change min v₀ w₀ = w₀
+    exact min_eq_right h.le
 
 omit [Fintype V] [DecidableRel G.Adj] in
 theorem edge0_v0Inc (v₀ w₀ : V) (hadj : G.Adj v₀ w₀) :
     v0Inc (G := G) v₀ (edge0 (G := G) v₀ w₀ hadj) := by
   rcases lt_or_gt_of_ne (G.ne_of_adj hadj) with h | h
-  · left; show min v₀ w₀ = v₀; exact min_eq_left h.le
-  · right; show max v₀ w₀ = v₀; exact max_eq_left h.le
+  · left
+    change min v₀ w₀ = v₀
+    exact min_eq_left h.le
+  · right
+    change max v₀ w₀ = v₀
+    exact max_eq_left h.le
 
 /-- If the edge scalar is `1` on every `v₀`-incident edge other than `{v₀, w₀}`,
 then the `v₀`-incident part of the oriented incidence product at a vertex
@@ -347,13 +359,13 @@ theorem unit_at_v0 (v₀ w₀ : V) (hadj : G.Adj v₀ w₀) (t : V → ℂˣ) (s
     edgeScalarUnit (G := G) s v₀ ⟨edge0 (G := G) v₀ w₀ hadj, hinc⟩ = t v₀ := by
   have hne : v₀ ≠ w₀ := G.ne_of_adj hadj
   rw [edgeScalarUnit, hs0]
-  show (if (edge0 (G := G) v₀ w₀ hadj).1.1 = v₀ then _ else _) = t v₀
+  change (if (edge0 (G := G) v₀ w₀ hadj).1.1 = v₀ then _ else _) = t v₀
   rcases lt_or_gt_of_ne hne with h | h
   · have hl : (edge0 (G := G) v₀ w₀ hadj).1.1 = v₀ := by
-      show min v₀ w₀ = v₀; exact min_eq_left h.le
+      change min v₀ w₀ = v₀; exact min_eq_left h.le
     rw [if_pos hl, if_pos h]
   · have hl : ¬ (edge0 (G := G) v₀ w₀ hadj).1.1 = v₀ := by
-      show ¬ min v₀ w₀ = v₀; rw [min_eq_right h.le]; exact ne_of_lt h
+      change ¬ min v₀ w₀ = v₀; rw [min_eq_right h.le]; exact ne_of_lt h
     rw [if_neg hl, if_neg (not_lt.mpr h.le), inv_inv]
 
 omit [Fintype V] [DecidableRel G.Adj] in
@@ -365,13 +377,13 @@ theorem unit_at_w0 (v₀ w₀ : V) (hadj : G.Adj v₀ w₀) (t : V → ℂˣ) (s
     edgeScalarUnit (G := G) s w₀ ⟨edge0 (G := G) v₀ w₀ hadj, hinc⟩ = (t v₀)⁻¹ := by
   have hne : v₀ ≠ w₀ := G.ne_of_adj hadj
   rw [edgeScalarUnit, hs0]
-  show (if (edge0 (G := G) v₀ w₀ hadj).1.1 = w₀ then _ else _) = (t v₀)⁻¹
+  change (if (edge0 (G := G) v₀ w₀ hadj).1.1 = w₀ then _ else _) = (t v₀)⁻¹
   rcases lt_or_gt_of_ne hne with h | h
   · have hl : ¬ (edge0 (G := G) v₀ w₀ hadj).1.1 = w₀ := by
-      show ¬ min v₀ w₀ = w₀; rw [min_eq_left h.le]; exact ne_of_lt h
+      change ¬ min v₀ w₀ = w₀; rw [min_eq_left h.le]; exact ne_of_lt h
     rw [if_neg hl, if_pos h]
   · have hl : (edge0 (G := G) v₀ w₀ hadj).1.1 = w₀ := by
-      show min v₀ w₀ = w₀; exact min_eq_right h.le
+      change min v₀ w₀ = w₀; exact min_eq_right h.le
     rw [if_pos hl, if_neg (not_lt.mpr h.le)]
 
 /-! ### Existence: solving the oriented incidence equation -/

--- a/TNLean/PEPS/FundamentalTheorem.lean
+++ b/TNLean/PEPS/FundamentalTheorem.lean
@@ -279,6 +279,7 @@ theorem post_absorption_edge_insertion_equality (A B : Tensor G d)
   rw [hZt, hZit, map_mul, map_mul]
   rfl
 
+omit [Fintype V] in
 /-- Reindexing a PEPS tensor along a bond-dimension equality preserves vertex
 injectivity: the local coefficient family of the reindexed tensor is the
 original family precomposed with the bondwise index recast, an injective
@@ -625,11 +626,11 @@ theorem exists_stateCoeff_ne_zero (A : Tensor G d)
     -- Some complement physical configuration gives a nonzero complement weight.
     obtain ⟨τ₀, hτ₀⟩ : ∃ τ, vertexComplementWeight (G := G) A v starCfg₀ τ ≠ 0 := by
       by_contra hall
-      push_neg at hall
+      push Not at hall
       exact hne (by funext τ; simpa [vertexComplementTensorFamily] using hall τ)
     -- Suppose, for contradiction, every state coefficient vanishes.
     by_contra hzero
-    push_neg at hzero
+    push Not at hzero
     -- For each physical leg `σ₁` at `v`, the complement weights form a kernel
     -- vector of the local tensor map at `v`.
     have hkernel : ∀ σ₁ : Fin d,
@@ -735,6 +736,7 @@ theorem prod_perVertexScalar_eq_one (A B : Tensor G d)
     rw [one_mul]; exact h1.symm
   exact mul_right_cancel₀ hσ h2
 
+omit [Fintype V] [DecidableRel G.Adj] in
 /-- On a connected graph with more than one vertex, every vertex has a nonempty
 incident-edge set. -/
 theorem nonempty_incidentEdge_of_connected [Nontrivial V]

--- a/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
@@ -104,7 +104,6 @@ theorem regionInsertedCoeff_eq_blockTransferRow (A B : Tensor G d) (R : Finset V
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hAB : SameState A B)
     (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
     (σ : RegionPhysicalConfig (V := V) (d := d) R)
@@ -120,7 +119,7 @@ theorem regionInsertedCoeff_eq_blockTransferRow (A B : Tensor G d) (R : Finset V
       (funext (fun σ' =>
         (regionInsertedCoeff_eq_region_blockedMap A R f M σ' τ).symm))⟩
   -- The block-level image coincidence transports it into the second tensor's range.
-  rw [range_regionBlockedTensorMap_eq_of_sameState A B R hAB hCA hCB hposA hposB hDim]
+  rw [range_regionBlockedTensorMap_eq_of_sameState A B R hAB hCA hCB hposA hposB]
     at hmemA
   rw [LinearMap.mem_range] at hmemA
   obtain ⟨c, hc⟩ := hmemA
@@ -179,7 +178,7 @@ theorem regionBlockedTensorInjective_doubleCompl (A : Tensor G d) (R : Finset V)
     rw [Function.comp_apply, Function.comp_apply, LinearEquiv.funCongrLeft_apply,
       LinearMap.funLeft_apply]
     -- `Ψ bdry = regionDoubleComplBoundaryConfig bdry`, `Φ σ = regionDoubleComplPhysicalConfig σ`.
-    show regionBlockedTensorFamily (G := G) A (Finset.univ \ (Finset.univ \ R))
+    change regionBlockedTensorFamily (G := G) A (Finset.univ \ (Finset.univ \ R))
         (regionDoubleComplBoundaryConfig (G := G) A R bdry)
         (regionDoubleComplPhysicalConfig (V := V) (d := d) R σ) =
       regionBlockedTensorFamily (G := G) A R bdry σ
@@ -218,13 +217,12 @@ theorem range_regionBlockedTensorMap_compl_eq_of_sameState (A B : Tensor G d) (R
     (hAB : SameState A B)
     (hRA : RegionBlockedTensorInjective (G := G) A R)
     (hRB : RegionBlockedTensorInjective (G := G) B R)
-    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim) :
+    (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e) :
     LinearMap.range (regionBlockedTensorMap (G := G) A (Finset.univ \ R)) =
       LinearMap.range (regionBlockedTensorMap (G := G) B (Finset.univ \ R)) :=
   range_regionBlockedTensorMap_eq_of_sameState A B (Finset.univ \ R) hAB
     (regionBlockedTensorInjective_doubleCompl A R hRA)
-    (regionBlockedTensorInjective_doubleCompl B R hRB) hposA hposB hDim
+    (regionBlockedTensorInjective_doubleCompl B R hRB) hposA hposB
 
 /-! ### The transfer kernel through the second tensor's complement block
 
@@ -261,7 +259,6 @@ theorem blockTransferRow_mem_range (A B : Tensor G d) (R : Finset V)
     (hRB : RegionBlockedTensorInjective (G := G) B R)
     (hAB : SameState A B)
     (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
     (μ : RegionBoundaryConfig (G := G) B R) :
@@ -275,7 +272,7 @@ theorem blockTransferRow_mem_range (A B : Tensor G d) (R : Finset V)
         LinearMap.range (regionBlockedTensorMap (G := G) B (Finset.univ \ R)) := by
     intro σ'
     rw [← range_regionBlockedTensorMap_compl_eq_of_sameState A B R hAB hRA hRB
-      hposA hposB hDim]
+      hposA hposB]
     rw [LinearMap.mem_range]
     exact ⟨regionComplementRow (G := G) A R f M σ',
       (funext (fun τ =>
@@ -320,7 +317,6 @@ theorem blockTransferRow_eq_complement_blockedMap (A B : Tensor G d) (R : Finset
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hAB : SameState A B)
     (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
     (μ : RegionBoundaryConfig (G := G) B R) :
@@ -329,7 +325,7 @@ theorem blockTransferRow_eq_complement_blockedMap (A B : Tensor G d) (R : Finset
       regionBlockedTensorMap (G := G) B (Finset.univ \ R)
         (transferCoeff (G := G) A B R hRB hCB f M μ) := by
   obtain ⟨c, hc⟩ :=
-    blockTransferRow_mem_range A B R hRA hRB hAB hposA hposB hDim f M μ
+    blockTransferRow_mem_range A B R hRA hRB hAB hposA hposB f M μ
   -- `transferCoeff` is the complement left inverse of the transferred row coordinate,
   -- which is `regionBlockedTensorMap B (univ \ R) c` by the membership `hc`.
   have htc : transferCoeff (G := G) A B R hRB hCB f M μ = c := by
@@ -370,7 +366,6 @@ theorem regionInsertedCoeff_eq_doubleSum_transferCoeff_block (A B : Tensor G d) 
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hAB : SameState A B)
     (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
     (σ : RegionPhysicalConfig (V := V) (d := d) R)
@@ -382,12 +377,12 @@ theorem regionInsertedCoeff_eq_doubleSum_transferCoeff_block (A B : Tensor G d) 
             regionBlockedWeight (G := G) B (Finset.univ \ R) ν' τ *
             regionBlockedWeight (G := G) B R μ σ := by
   -- The region-side reading.
-  rw [regionInsertedCoeff_eq_blockTransferRow A B R hRB hCA hCB hAB hposA hposB hDim f M σ τ,
+  rw [regionInsertedCoeff_eq_blockTransferRow A B R hRB hCA hCB hAB hposA hposB f M σ τ,
     regionBlockedTensorMap_apply]
   refine Finset.sum_congr rfl (fun μ _ => ?_)
   -- The transferred row coordinate is the complement blocked map of the kernel.
   have hrow := congrFun
-    (blockTransferRow_eq_complement_blockedMap A B R hRA hRB hCB hAB hposA hposB hDim f M μ) τ
+    (blockTransferRow_eq_complement_blockedMap A B R hRA hRB hCB hAB hposA hposB f M μ) τ
   rw [hrow, regionBlockedTensorMap_apply, smul_eq_mul, Finset.sum_mul]
   refine Finset.sum_congr rfl (fun ν' _ => ?_)
   rw [smul_eq_mul]
@@ -425,7 +420,6 @@ theorem regionInsertedCoeff_eq_of_transferCoeff_form_block (A B : Tensor G d) (R
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hAB : SameState A B)
     (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
     (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
@@ -441,7 +435,7 @@ theorem regionInsertedCoeff_eq_of_transferCoeff_form_block (A B : Tensor G d) (R
       regionInsertedCoeff (G := G) B R f N σ τ := by
   classical
   rw [regionInsertedCoeff_eq_doubleSum_transferCoeff_block A B R hRA hRB hCA hCB hAB
-      hposA hposB hDim f M σ τ,
+      hposA hposB f M σ τ,
     regionInsertedCoeff_eq]
   -- Reindex the second tensor's complement-boundary sum by the complement equivalence.
   set E := regionComplementBoundaryConfigEquiv (G := G) B R with hE
@@ -507,9 +501,7 @@ theorem doubleSum_kernel_injective (B : Tensor G d) (R : Finset V)
       funext σ
       rw [regionBlockedTensorMap_apply, regionBlockedTensorMap_apply]
       have := heq σ τ
-      simp only [smul_eq_mul, Finset.sum_mul]
-      simp only [smul_eq_mul] at this ⊢
-      convert this using 2 <;> rw [Finset.sum_mul]
+      simpa only [smul_eq_mul, Finset.sum_mul] using this
     exact congrFun (regionBlockedTensorMap_injective_of_injective (G := G) B R hRB hmap)
   -- For each `μ`, the two complement rows agree by complement injectivity.
   funext μ
@@ -611,7 +603,6 @@ theorem transferCoeff_eq_incidentKernel_iff_coeff_eq (A B : Tensor G d) (R : Fin
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hAB : SameState A B)
     (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
     (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) :
@@ -623,14 +614,14 @@ theorem transferCoeff_eq_incidentKernel_iff_coeff_eq (A B : Tensor G d) (R : Fin
   constructor
   · intro hker σ τ
     refine regionInsertedCoeff_eq_of_transferCoeff_form_block A B R hRA hRB hCA hCB hAB
-      hposA hposB hDim f M N (fun μ ν' => ?_) σ τ
+      hposA hposB f M N (fun μ ν' => ?_) σ τ
     have := congrFun (congrFun hker μ) ν'
     rwa [incidentKernel] at this
   · intro hcoeff
     -- Both kernels reproduce the same coefficient `coeff_A M = coeff_B N`; uniqueness.
     refine doubleSum_kernel_injective B R hRB hCB _ _ (fun σ τ => ?_)
     rw [← regionInsertedCoeff_eq_doubleSum_transferCoeff_block A B R hRA hRB hCA hCB hAB
-        hposA hposB hDim f M σ τ,
+        hposA hposB f M σ τ,
       doubleSum_incidentKernel_eq_regionInsertedCoeff B R f N σ τ, hcoeff σ τ]
 
 /-- **The transfer kernel of the identity is the incident kernel of the identity.**
@@ -655,7 +646,7 @@ theorem transferCoeff_one_eq_incidentKernel_one (A B : Tensor G d) (R : Finset V
     transferCoeff (G := G) A B R hRB hCB f 1 =
       incidentKernel (G := G) B R f 1 := by
   rw [transferCoeff_eq_incidentKernel_iff_coeff_eq A B R hRA hRB hCA hCB hAB
-    hposA hposB hDim f 1 1]
+    hposA hposB f 1 1]
   intro σ τ
   rw [regionInsertedCoeff_one_eq_stateCoeff (G := G) A R f σ τ,
     regionInsertedCoeff_one_eq_stateCoeff (G := G) B R f σ τ,
@@ -687,7 +678,6 @@ theorem coeffTransfer_iff_transferCoeff_incidentForm (A B : Tensor G d) (R : Fin
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hAB : SameState A B)
     (hposA : ∀ e : Edge G, 0 < A.bondDim e) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
     (∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
         ∃ N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ,
@@ -701,7 +691,7 @@ theorem coeffTransfer_iff_transferCoeff_incidentForm (A B : Tensor G d) (R : Fin
   refine forall_congr' (fun M => ?_)
   refine exists_congr (fun N => ?_)
   exact (transferCoeff_eq_incidentKernel_iff_coeff_eq A B R hRA hRB hCA hCB hAB
-    hposA hposB hDim f M N).symm
+    hposA hposB f M N).symm
 
 /-! ### The per-edge gauge from a block-frame coefficient transfer
 

--- a/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
@@ -397,8 +397,7 @@ theorem range_regionBlockedTensorMap_eq_of_sameState (A B : Tensor G d) (R : Fin
     (hCA : RegionBlockedTensorInjective (G := G) A (Finset.univ \ R))
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hposA : ∀ e : Edge G, 0 < A.bondDim e)
-    (hposB : ∀ e : Edge G, 0 < B.bondDim e)
-    (hDim : A.bondDim = B.bondDim) :
+    (hposB : ∀ e : Edge G, 0 < B.bondDim e) :
     LinearMap.range (regionBlockedTensorMap (G := G) A R) =
       LinearMap.range (regionBlockedTensorMap (G := G) B R) := by
   rw [range_regionBlockedTensorMap_eq_span_regionPartialState A R hCA hposA,
@@ -464,11 +463,11 @@ theorem exists_stateCoeff_ne_zero_of_regionInjective (A : Tensor G d) (R : Finse
   obtain ⟨τ₀, hτ₀⟩ :
       ∃ τ, regionBlockedWeight (G := G) A (Finset.univ \ R) ν₀ τ ≠ 0 := by
     by_contra hall
-    push_neg at hall
+    push Not at hall
     exact hne (by funext τ; simpa [regionBlockedTensorFamily] using hall τ)
   -- Suppose, for contradiction, every closed state coefficient vanishes.
   by_contra hzero
-  push_neg at hzero
+  push Not at hzero
   -- Then every partial state across the region cut vanishes.
   have hpartial : ∀ τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R),
       regionPartialState (G := G) A R τ = 0 := by

--- a/TNLean/PEPS/RegionBlock/BondLocalFromReconcile.lean
+++ b/TNLean/PEPS/RegionBlock/BondLocalFromReconcile.lean
@@ -163,7 +163,7 @@ theorem coeffTransfer_of_regionResonateReconcile (A B : Tensor G d) (R : Finset 
           (τ : RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ R)),
           regionInsertedCoeff (G := G) A R f M σ τ =
             regionInsertedCoeff (G := G) B R f N σ τ :=
-  coeffTransfer_of_bondLocal A B R hRA hRB hCA hCB hAB hposA hposB hDim f
+  coeffTransfer_of_bondLocal A B R hRA hRB hCA hCB hAB hposA hposB f
     (isBondLocalTransferKernel_of_regionResonateReconcile A B R hRB hCB f
       hvA hvB hvAout hAB hA hB hposA hposB hDim hrec)
 

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -653,7 +653,7 @@ theorem isBondLocalTransferKernel_of_coherentFrames
     IsBondLocalTransferKernel (G := G) A B F.frame.red hRB hCB
       (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle) := by
   rw [bondLocal_iff_coeffTransfer A B F.frame.red F.frame.red_injective hRB
-    (regionInjective_compl_red F hP hposA) hCB hAB hposA hposB hbond
+    (regionInjective_compl_red F hP hposA) hCB hAB hposA hposB
     (singleBoundaryEdge (G := G) A F.frame.red F.frame.blue e hsingle)]
   intro M
   exact exists_regionInsertedCoeff_eq_sharedRegion F F' hP hP' hred hblue hcompl hbond hAB

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite8.lean
@@ -53,6 +53,7 @@ def singleCrossing (A : Tensor G d) (red blue : Finset V) (e : Edge G)
     {g : Edge G // IsCrossingEdge (G := G) A red blue g} :=
   ⟨e, (hsingle e).mpr rfl⟩
 
+omit [Fintype V] in
 /-- The single red-to-blue crossing edge is a boundary edge of the red region. -/
 theorem isRegionBoundaryEdge_singleCrossing (A : Tensor G d) (red blue : Finset V) (e : Edge G)
     (hsingle : ∀ g : Edge G, IsCrossingEdge (G := G) A red blue g ↔ g = e) :
@@ -66,6 +67,7 @@ def singleBoundaryEdge (A : Tensor G d) (red blue : Finset V) (e : Edge G)
     {f : Edge G // IsRegionBoundaryEdge (G := G) red f} :=
   ⟨e, isRegionBoundaryEdge_singleCrossing (G := G) A red blue e hsingle⟩
 
+omit [Fintype V] in
 /-- Under the singleton hypothesis, the crossing-edge subtype has the single boundary
 edge as its only inhabitant. -/
 theorem crossingEdge_unique (A : Tensor G d) (red blue : Finset V) (e : Edge G)
@@ -92,6 +94,7 @@ noncomputable def singletonCrossingEquiv (A : Tensor G d) (red blue : Finset V) 
     rfl
   right_inv y := rfl
 
+omit [Fintype V] in
 /-- The single-leg crossing bundle equivalence reads a crossing configuration at the
 single crossing edge. -/
 @[simp] theorem singletonCrossingEquiv_apply (A : Tensor G d) (red blue : Finset V) (e : Edge G)
@@ -114,6 +117,7 @@ noncomputable def singletonBundleMatrix (A : Tensor G d) (red blue : Finset V) (
   fun p q => M (singletonCrossingEquiv (G := G) A red blue e hsingle p)
     (singletonCrossingEquiv (G := G) A red blue e hsingle q)
 
+omit [Fintype V] in
 /-- The single-leg crossing equivalence of the red-to-blue crossing label of a red
 boundary configuration is the configuration's value on the single crossing edge. -/
 theorem singletonCrossingEquiv_redBoundaryRBCrossing (red blue : Finset V) (e : Edge G)
@@ -132,6 +136,7 @@ configurations carry the same value on every red boundary edge not crossing to t
 blue region -- is, when the only red-to-blue crossing is the single edge `e`, the
 single-edge agreement `SameAwayFromBond` on the single boundary edge `e`. -/
 
+omit [Fintype V] in
 /-- Under the singleton hypothesis, the whole-bundle agreement is the single-edge
 agreement on the single boundary edge `e`. -/
 theorem sameAwayFromRBBundle_iff_sameAwayFromBond (red blue : Finset V) (e : Edge G)

--- a/TNLean/PEPS/RegionBlock/GaugeInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/GaugeInjectivity.lean
@@ -250,7 +250,7 @@ lemma prod_region_edgeGauge_eq_prod_factor (B : Tensor G d)
         (fun (v : V) (ie : IncidentEdge G v) =>
           if h : v ∈ R then edgeGaugeAt B X v ie (ζ ie.1) (ξ ⟨v, h⟩ ie) else 1) w.1 ie from
     Finset.prod_congr rfl fun w _ => Finset.prod_congr rfl fun ie _ => by
-      show edgeGaugeAt B X w.1 ie (ζ ie.1) (ξ w ie) =
+      change edgeGaugeAt B X w.1 ie (ζ ie.1) (ξ w ie) =
         if h : w.1 ∈ R then edgeGaugeAt B X w.1 ie (ζ ie.1) (ξ ⟨w.1, h⟩ ie) else 1
       rw [dif_pos w.2]]
   rw [prod_region_incident_eq_prod_edge R
@@ -282,14 +282,14 @@ noncomputable def regionBoundaryFiberEquiv (B : Tensor G d) (R : Finset V)
   left_inv ζ := by
     apply Subtype.ext
     funext e
-    show (if hb : IsRegionBoundaryEdge (G := G) R e then bdry ⟨e, hb⟩ else ζ.1 e) = ζ.1 e
+    change (if hb : IsRegionBoundaryEdge (G := G) R e then bdry ⟨e, hb⟩ else ζ.1 e) = ζ.1 e
     by_cases hb : IsRegionBoundaryEdge (G := G) R e
     · rw [dif_pos hb]
       exact (congrFun ζ.2 ⟨e, hb⟩).symm
     · rw [dif_neg hb]
   right_inv h := by
     funext e
-    show (if hb : IsRegionBoundaryEdge (G := G) R e.1 then bdry ⟨e.1, hb⟩ else h ⟨e.1, hb⟩) =
+    change (if hb : IsRegionBoundaryEdge (G := G) R e.1 then bdry ⟨e.1, hb⟩ else h ⟨e.1, hb⟩) =
       h e
     rw [dif_neg e.2]
 
@@ -558,7 +558,7 @@ theorem regionLocalOfGlobal_fiber_card (B : Tensor G d) (R : Finset V)
       funext w ie
       obtain ⟨v, hv⟩ := w
       obtain ⟨e, hie⟩ := ie
-      show regionGlobalOfLocal (G := G) B R ξ h e = ξ ⟨v, hv⟩ ⟨e, hie⟩
+      change regionGlobalOfLocal (G := G) B R ξ h e = ξ ⟨v, hv⟩ ⟨e, hie⟩
       by_cases hleft : e.1.1 = v
       · subst v
         have hinc : IsRegionIncidentEdge (G := G) R e := Or.inl hv
@@ -593,7 +593,7 @@ theorem regionLocalOfGlobal_fiber_card (B : Tensor G d) (R : Finset V)
     · -- The free labels of a rebuilt configuration are the free labels.
       intro h _
       funext e
-      show regionGlobalOfLocal (G := G) B R ξ h e.1 = h e
+      change regionGlobalOfLocal (G := G) B R ξ h e.1 = h e
       rw [regionGlobalOfLocal, dif_neg e.2]
   · rw [Finset.card_univ, Fintype.card_pi]
     simp only [Fintype.card_fin]

--- a/TNLean/PEPS/RegionBlock/InsertResidual.lean
+++ b/TNLean/PEPS/RegionBlock/InsertResidual.lean
@@ -610,7 +610,7 @@ theorem insertOuterBondProd_smul_insertResidual_eq (A : Tensor G d) (R : Finset 
       regionBlockedWeight_bridge_eq_smul_insertResidual (G := G) A R hv μ σ η hcons]
   · rw [if_neg hcons]
     rw [InsertConsistent] at hcons
-    push_neg at hcons
+    push Not at hcons
     obtain ⟨g, hgv, hne⟩ := hcons
     rw [insertResidual_eq_zero_of_inconsistent (G := G) A R μ σ η g hgv hne, smul_zero]
 

--- a/TNLean/PEPS/RegionBlock/Recovery5.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery5.lean
@@ -84,7 +84,7 @@ theorem regionBoundaryEdgeInVertex_compl_eq_outVertex (R : Finset V)
   rw [regionBoundaryEdgeInVertex, regionBoundaryEdgeOutVertex,
     regionBoundaryEdgeToCompl]
   rcases f.2 with ⟨h1, h2⟩ | ⟨h1, h2⟩
-  · rw [if_pos h1, if_neg (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1)]
+  · rw [if_pos h1, if_neg (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h1)]
   · rw [if_neg h1, if_pos (by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h1⟩)]
 
 /-! ### The blocked-region tensor map and its left inverse

--- a/TNLean/PEPS/RegionBlock/Recovery9.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery9.lean
@@ -107,7 +107,6 @@ Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 254--582 of
 theorem regionInsertionOp_realizes_of_realizes_on_stateVec (A B : Tensor G d)
     (R : Finset V) (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (hvA : LinearIndependent ℂ (A.component (regionBoundaryEdgeInVertex (G := G) R f)))
-    (hvB : LinearIndependent ℂ (B.component (regionBoundaryEdgeInVertex (G := G) R f)))
     (hB : IsVertexInjective B) (hposB : ∀ e : Edge G, 0 < B.bondDim e)
     (M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ)
     (N : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ)
@@ -256,7 +255,7 @@ theorem isIncidentMatrixForm_of_coeff_eq (A B : Tensor G d) (R : Finset V)
           (localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f) c) =
         localTensorMap B (regionBoundaryEdgeInVertex (G := G) R f)
           (localIncidentMatrixOp B (regionBoundaryEdgeInIncident (G := G) R f) N.transpose c) :=
-    regionInsertionOp_realizes_of_realizes_on_stateVec A B R f hvA hvB hB hposB M N
+    regionInsertionOp_realizes_of_realizes_on_stateVec A B R f hvA hB hposB M N
       (regionInsertionOp_regionStateVec_eq_of_coeff_eq A B R f hvA hvB hAB hposB hDim M N hcoeff)
   -- Read off the incident-matrix form of the virtual pullback.
   exact localVirtualOpOfPhysicalOpAt_eq_of_realizes B hvB

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -477,7 +477,7 @@ theorem hostLabel_p2_eq_hostLabel_regionMerge_complement
       rcases f.2 with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
       · -- `f.1.1 ∈ univ \ red`, `f.1.2 ∉ univ \ red` i.e. `f.1.2 ∈ red`.
         have h2red : f.1.1.2 ∈ D.red := by
-          have := h2nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          have := h2nothost; rw [Finset.mem_sdiff] at this; push Not at this
           exact this (Finset.mem_univ _)
         have h2notcompl : f.1.1.2 ∉ D.complement := fun hc =>
           (Finset.disjoint_left.mp D.red_disjoint_complement) h2red hc
@@ -485,7 +485,7 @@ theorem hostLabel_p2_eq_hostLabel_regionMerge_complement
         · refine Or.inl ⟨hc1, h2notcompl⟩
         · exact absurd hc2 h2notcompl
       · have h1red : f.1.1.1 ∈ D.red := by
-          have := h1nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          have := h1nothost; rw [Finset.mem_sdiff] at this; push Not at this
           exact this (Finset.mem_univ _)
         have h1notcompl : f.1.1.1 ∉ D.complement := fun hc =>
           (Finset.disjoint_left.mp D.red_disjoint_complement) h1red hc

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
@@ -261,7 +261,7 @@ theorem hostLabel_p2_eq_hostLabel_regionMerge_blue
     have hbdry : IsRegionBoundaryEdge (G := G) D.blue f.1 := by
       rcases f.2 with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
       · have h2red : f.1.1.2 ∈ D.red := by
-          have := h2nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          have := h2nothost; rw [Finset.mem_sdiff] at this; push Not at this
           exact this (Finset.mem_univ _)
         have h2notblue : f.1.1.2 ∉ D.blue := fun hb =>
           (Finset.disjoint_left.mp D.red_disjoint_blue) h2red hb
@@ -269,7 +269,7 @@ theorem hostLabel_p2_eq_hostLabel_regionMerge_blue
         · refine Or.inl ⟨hb1, h2notblue⟩
         · exact absurd hb2 h2notblue
       · have h1red : f.1.1.1 ∈ D.red := by
-          have := h1nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          have := h1nothost; rw [Finset.mem_sdiff] at this; push Not at this
           exact this (Finset.mem_univ _)
         have h1notblue : f.1.1.1 ∉ D.blue := fun hb =>
           (Finset.disjoint_left.mp D.red_disjoint_blue) h1red hb

--- a/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockTransfer.lean
@@ -192,7 +192,6 @@ theorem coeffTransfer_of_bondLocal (A B : Tensor G d) (R : Finset V)
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hAB : SameState A B)
     (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f})
     (hbond : IsBondLocalTransferKernel (G := G) A B R hRB hCB f) :
     ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
@@ -205,7 +204,7 @@ theorem coeffTransfer_of_bondLocal (A B : Tensor G d) (R : Finset V)
   obtain ⟨N, hN⟩ := hbond M
   refine ⟨N, ?_⟩
   exact (transferCoeff_eq_incidentKernel_iff_coeff_eq A B R hRA hRB hCA hCB hAB
-    hposA hposB hDim f M N).mp hN
+    hposA hposB f M N).mp hN
 
 /-- **Bond locality is exactly the coefficient transfer.** The transfer kernel of
 every inserted matrix on the boundary edge `f` of the red region is bond-local if and
@@ -228,7 +227,6 @@ theorem bondLocal_iff_coeffTransfer (A B : Tensor G d) (R : Finset V)
     (hCB : RegionBlockedTensorInjective (G := G) B (Finset.univ \ R))
     (hAB : SameState A B)
     (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
     IsBondLocalTransferKernel (G := G) A B R hRB hCB f ↔
       ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
@@ -238,7 +236,7 @@ theorem bondLocal_iff_coeffTransfer (A B : Tensor G d) (R : Finset V)
             regionInsertedCoeff (G := G) A R f M σ τ =
               regionInsertedCoeff (G := G) B R f N σ τ :=
   (coeffTransfer_iff_transferCoeff_incidentForm A B R hRA hRB hCA hCB hAB
-    hposA hposB hDim f).symm
+    hposA hposB f).symm
 
 /-- **The identity transfer is bond-local.** For a single tensor `A`, the transfer
 kernel `transferCoeff A A R f M` of any inserted matrix `M` is the incident-matrix
@@ -258,7 +256,7 @@ theorem isBondLocalTransferKernel_self (A : Tensor G d) (R : Finset V)
   intro M
   refine ⟨M, ?_⟩
   exact (transferCoeff_eq_incidentKernel_iff_coeff_eq A A R hRA hRA hCA hCA
-    (fun _ => rfl) hposA hposA rfl f M M).mpr (fun _ _ => rfl)
+    (fun _ => rfl) hposA hposA f M M).mpr (fun _ _ => rfl)
 
 /-! ### The per-edge gauge from bond locality in both directions
 
@@ -278,7 +276,6 @@ theorem SharedNormalEdgeBlockingData.coeffTransferAB
     (D : SharedNormalEdgeBlockingData A B e)
     (hAB : SameState A B)
     (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
-    (hDim : A.bondDim = B.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
     (hbondAB : IsBondLocalTransferKernel (G := G) A B D.red
       D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) f) :
@@ -290,7 +287,7 @@ theorem SharedNormalEdgeBlockingData.coeffTransferAB
             regionInsertedCoeff (G := G) B D.red f N σ τ :=
   coeffTransfer_of_bondLocal A B D.red D.regionInjective_red_A D.regionInjective_red_B
     (D.regionInjective_compl_red_A hposA) (D.regionInjective_compl_red_B hposB) hAB
-    hposA hposB hDim f hbondAB
+    hposA hposB f hbondAB
 
 /-- The backward coefficient transfer of a shared one-edge blocking datum, derived from
 the `B → A` bond locality (the shared datum with the two tensors swapped). For each
@@ -300,7 +297,6 @@ theorem SharedNormalEdgeBlockingData.coeffTransferBA
     (D : SharedNormalEdgeBlockingData A B e)
     (hBA : SameState B A)
     (hposA : ∀ g : Edge G, 0 < A.bondDim g) (hposB : ∀ g : Edge G, 0 < B.bondDim g)
-    (hDim : B.bondDim = A.bondDim)
     (f : {f : Edge G // IsRegionBoundaryEdge (G := G) D.red f})
     (hbondBA : IsBondLocalTransferKernel (G := G) B A D.red
       D.regionInjective_red_A (D.regionInjective_compl_red_A hposA) f) :
@@ -312,7 +308,7 @@ theorem SharedNormalEdgeBlockingData.coeffTransferBA
             regionInsertedCoeff (G := G) A D.red f M σ τ :=
   coeffTransfer_of_bondLocal B A D.red D.regionInjective_red_B D.regionInjective_red_A
     (D.regionInjective_compl_red_B hposB) (D.regionInjective_compl_red_A hposA) hBA
-    hposB hposA hDim f hbondBA
+    hposB hposA f hbondBA
 
 /-- **The per-edge gauge from two-directional bond locality.** Given a shared one-edge
 blocking datum for the two tensors of `SameState A B`, positive bond dimensions,
@@ -343,18 +339,18 @@ theorem SharedNormalEdgeBlockingData.exists_regionEdgeGauge
       D.regionInjective_red_A (D.regionInjective_compl_red_A hposA) f)
     (hmul : ∀ M M' : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
       coeffTransferMap (G := G) A B D.red f
-          (D.coeffTransferAB hAB hposA hposB hDim f hbondAB) (M * M') =
+          (D.coeffTransferAB hAB hposA hposB f hbondAB) (M * M') =
         coeffTransferMap (G := G) A B D.red f
-            (D.coeffTransferAB hAB hposA hposB hDim f hbondAB) M *
+            (D.coeffTransferAB hAB hposA hposB f hbondAB) M *
           coeffTransferMap (G := G) A B D.red f
-            (D.coeffTransferAB hAB hposA hposB hDim f hbondAB) M') :
+            (D.coeffTransferAB hAB hposA hposB f hbondAB) M') :
     ∃ hEdge : A.bondDim f.1 = B.bondDim f.1,
       ∃ Z : GL (Fin (B.bondDim f.1)) ℂ,
         ∀ M : Matrix (Fin (A.bondDim f.1)) (Fin (A.bondDim f.1)) ℂ,
           (regionInsertionTransfer_of_coeffTransfer A B D.red f
               D.regionInjective_red_B (D.regionInjective_compl_red_B hposB) hAB hposB hDim
-              (D.coeffTransferAB hAB hposA hposB hDim f hbondAB)
-              (D.coeffTransferBA hAB.symm hposA hposB hDim.symm f hbondBA) hmul).fwd M =
+              (D.coeffTransferAB hAB hposA hposB f hbondAB)
+              (D.coeffTransferBA hAB.symm hposA hposB f hbondBA) hmul).fwd M =
             (Z : Matrix (Fin (B.bondDim f.1)) (Fin (B.bondDim f.1)) ℂ) *
               Matrix.reindexAlgEquiv ℂ ℂ (finCongr hEdge) M *
               ((Z⁻¹ : GL (Fin (B.bondDim f.1)) ℂ) :
@@ -363,8 +359,8 @@ theorem SharedNormalEdgeBlockingData.exists_regionEdgeGauge
     D.regionInjective_red_A (D.regionInjective_compl_red_A hposA)
     D.regionInjective_red_B (D.regionInjective_compl_red_B hposB)
     hAB hposA hposB hDim
-    (D.coeffTransferAB hAB hposA hposB hDim f hbondAB)
-    (D.coeffTransferBA hAB.symm hposA hposB hDim.symm f hbondBA) hmul
+    (D.coeffTransferAB hAB hposA hposB f hbondAB)
+    (D.coeffTransferBA hAB.symm hposA hposB f hbondBA) hmul
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivity.lean
@@ -66,20 +66,20 @@ theorem isBlueBoundaryEdge_of_hostBoundary_blue
   rcases hf with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
   · -- `f.1.1 ∈ univ \ red`, `f.1.2 ∈ red`.
     have h2red : f.1.2 ∈ D.red := by
-      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      rw [Finset.mem_sdiff] at h2nothost; push Not at h2nothost
       exact h2nothost (Finset.mem_univ _)
     have h2notblue : f.1.2 ∉ D.blue := fun hbl =>
       (Finset.disjoint_left.mp D.red_disjoint_blue) h2red hbl
     rcases hb with ⟨_, hb1⟩ | ⟨h2host', _⟩
     · exact Or.inl ⟨hb1, h2notblue⟩
-    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red)
+    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h2red)
   · have h1red : f.1.1 ∈ D.red := by
-      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      rw [Finset.mem_sdiff] at h1nothost; push Not at h1nothost
       exact h1nothost (Finset.mem_univ _)
     have h1notblue : f.1.1 ∉ D.blue := fun hbl =>
       (Finset.disjoint_left.mp D.red_disjoint_blue) h1red hbl
     rcases hb with ⟨h1host', _⟩ | ⟨_, hb2⟩
-    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red)
+    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h1red)
     · exact Or.inr ⟨h1notblue, hb2⟩
 
 /-- A boundary edge of the host `univ \ red` whose host-side endpoint lies in the
@@ -92,20 +92,20 @@ theorem isComplBoundaryEdge_of_hostBoundary_compl
     IsRegionBoundaryEdge (G := G) D.complement f := by
   rcases hf with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
   · have h2red : f.1.2 ∈ D.red := by
-      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      rw [Finset.mem_sdiff] at h2nothost; push Not at h2nothost
       exact h2nothost (Finset.mem_univ _)
     have h2notcompl : f.1.2 ∉ D.complement := fun hcl =>
       (Finset.disjoint_left.mp D.red_disjoint_complement) h2red hcl
     rcases hc with ⟨_, hc1⟩ | ⟨h2host', _⟩
     · exact Or.inl ⟨hc1, h2notcompl⟩
-    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red)
+    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h2red)
   · have h1red : f.1.1 ∈ D.red := by
-      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      rw [Finset.mem_sdiff] at h1nothost; push Not at h1nothost
       exact h1nothost (Finset.mem_univ _)
     have h1notcompl : f.1.1 ∉ D.complement := fun hcl =>
       (Finset.disjoint_left.mp D.red_disjoint_complement) h1red hcl
     rcases hc with ⟨h1host', _⟩ | ⟨_, hc2⟩
-    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red)
+    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h1red)
     · exact Or.inr ⟨h1notcompl, hc2⟩
 
 /-- The host-side endpoint of a host boundary edge lies in the blue block or in the
@@ -463,11 +463,11 @@ theorem isRegionBoundaryEdge_red_of_host
   rcases hg with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
   · have h1notred : g.1.1 ∉ D.red := (Finset.mem_sdiff.mp h1host).2
     have h2red : g.1.2 ∈ D.red := by
-      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      rw [Finset.mem_sdiff] at h2nothost; push Not at h2nothost
       exact h2nothost (Finset.mem_univ _)
     exact Or.inr ⟨h1notred, h2red⟩
   · have h1red : g.1.1 ∈ D.red := by
-      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      rw [Finset.mem_sdiff] at h1nothost; push Not at h1nothost
       exact h1nothost (Finset.mem_univ _)
     have h2notred : g.1.2 ∉ D.red := (Finset.mem_sdiff.mp h2host).2
     exact Or.inl ⟨h1red, h2notred⟩
@@ -641,10 +641,10 @@ theorem regionBlockedWeight_complement_eq_smul_constrained
     -- A crossing edge is a red boundary edge, hence a host boundary edge.
     have hhost : IsRegionBoundaryEdge (G := G) (Finset.univ \ D.red) g := by
       rcases hg.1 with ⟨h1red, h2notred⟩ | ⟨h1notred, h2red⟩
-      · exact Or.inr ⟨by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red,
+      · exact Or.inr ⟨by rw [Finset.mem_sdiff]; push Not; exact fun _ => h1red,
           by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h2notred⟩⟩
       · exact Or.inl ⟨by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h1notred⟩,
-          by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red⟩
+          by rw [Finset.mem_sdiff]; push Not; exact fun _ => h2red⟩
     have h1 := congrFun hq.2.1 ⟨g, hhost⟩
     have h2 := congrFun hq0host ⟨g, hhost⟩
     rw [regionBoundaryLabel_apply] at h1 h2
@@ -884,7 +884,8 @@ theorem regionBlockedTensorInjective_union
     rw [hh', hb', hc'] at e1
     rw [e2]
     -- `host q' = hostLabelFrom (blue q) (compl q) = host q`, and `host q' = bdry'`.
-    rw [← e1] at e2 ⊢ <;> exact e2
+    rw [← e1] at e2
+    rw [← e1]
   · intro h; exact absurd (Finset.mem_univ _) h
 
 /-- **The host block is blocked-tensor injective.** The set complement of the red block

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean
@@ -73,6 +73,7 @@ structure ThreeBlockGeometry (V : Type*) [Fintype V] [DecidableEq V] : Type _ wh
 
 variable (g : ThreeBlockGeometry V)
 
+omit [LinearOrder V] in
 /-- The set complement of the red block is the disjoint union of the blue and
 complement blocks.
 
@@ -118,6 +119,7 @@ def ThreeBlockGeometry.complPhysical
         · exact absurd hbl hb
       · exact hc⟩
 
+omit [LinearOrder V] in
 @[simp] theorem ThreeBlockGeometry.complPhysical_apply_blue
     (σblue : RegionPhysicalConfig (V := V) (d := d) g.blue)
     (σcompl : RegionPhysicalConfig (V := V) (d := d) g.complement)
@@ -125,6 +127,7 @@ def ThreeBlockGeometry.complPhysical
     g.complPhysical (d := d) σblue σcompl w = σblue ⟨w.1, hb⟩ := by
   rw [ThreeBlockGeometry.complPhysical, dif_pos hb]
 
+omit [LinearOrder V] in
 @[simp] theorem ThreeBlockGeometry.complPhysical_apply_not_blue
     (σblue : RegionPhysicalConfig (V := V) (d := d) g.blue)
     (σcompl : RegionPhysicalConfig (V := V) (d := d) g.complement)
@@ -301,7 +304,7 @@ theorem ThreeBlockGeometry.hostLabel_p2_eq_hostLabel_regionMerge_complement
       rcases f.2 with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
       · -- `f.1.1 ∈ univ \ red`, `f.1.2 ∉ univ \ red` i.e. `f.1.2 ∈ red`.
         have h2red : f.1.1.2 ∈ g.red := by
-          have := h2nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          have := h2nothost; rw [Finset.mem_sdiff] at this; push Not at this
           exact this (Finset.mem_univ _)
         have h2notcompl : f.1.1.2 ∉ g.complement := fun hc =>
           (Finset.disjoint_left.mp g.red_disjoint_complement) h2red hc
@@ -309,7 +312,7 @@ theorem ThreeBlockGeometry.hostLabel_p2_eq_hostLabel_regionMerge_complement
         · refine Or.inl ⟨hc1, h2notcompl⟩
         · exact absurd hc2 h2notcompl
       · have h1red : f.1.1.1 ∈ g.red := by
-          have := h1nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          have := h1nothost; rw [Finset.mem_sdiff] at this; push Not at this
           exact this (Finset.mem_univ _)
         have h1notcompl : f.1.1.1 ∉ g.complement := fun hc =>
           (Finset.disjoint_left.mp g.red_disjoint_complement) h1red hc

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral2.lean
@@ -33,6 +33,7 @@ variable (g : ThreeBlockGeometry V)
 
 The source's `injective_union`, re-derived over the bare geometry. -/
 
+omit [DecidableRel G.Adj] in
 /-- A boundary edge of the host `univ \ red` whose host-side endpoint lies in the blue
 block is a boundary edge of the blue block: the host-side endpoint is in blue, and the
 red-side endpoint lies outside blue (the blocks are disjoint). -/
@@ -44,22 +45,23 @@ theorem ThreeBlockGeometry.isBlueBoundaryEdge_of_hostBoundary_blue
   rcases hf with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
   · -- `f.1.1 ∈ univ \ red`, `f.1.2 ∈ red`.
     have h2red : f.1.2 ∈ g.red := by
-      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      rw [Finset.mem_sdiff] at h2nothost; push Not at h2nothost
       exact h2nothost (Finset.mem_univ _)
     have h2notblue : f.1.2 ∉ g.blue := fun hbl =>
       (Finset.disjoint_left.mp g.red_disjoint_blue) h2red hbl
     rcases hb with ⟨_, hb1⟩ | ⟨h2host', _⟩
     · exact Or.inl ⟨hb1, h2notblue⟩
-    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red)
+    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h2red)
   · have h1red : f.1.1 ∈ g.red := by
-      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      rw [Finset.mem_sdiff] at h1nothost; push Not at h1nothost
       exact h1nothost (Finset.mem_univ _)
     have h1notblue : f.1.1 ∉ g.blue := fun hbl =>
       (Finset.disjoint_left.mp g.red_disjoint_blue) h1red hbl
     rcases hb with ⟨h1host', _⟩ | ⟨_, hb2⟩
-    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red)
+    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h1red)
     · exact Or.inr ⟨h1notblue, hb2⟩
 
+omit [DecidableRel G.Adj] in
 /-- A boundary edge of the host `univ \ red` whose host-side endpoint lies in the
 complement block is a boundary edge of the complement block. -/
 theorem ThreeBlockGeometry.isComplBoundaryEdge_of_hostBoundary_compl
@@ -69,22 +71,23 @@ theorem ThreeBlockGeometry.isComplBoundaryEdge_of_hostBoundary_compl
     IsRegionBoundaryEdge (G := G) g.complement f := by
   rcases hf with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
   · have h2red : f.1.2 ∈ g.red := by
-      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      rw [Finset.mem_sdiff] at h2nothost; push Not at h2nothost
       exact h2nothost (Finset.mem_univ _)
     have h2notcompl : f.1.2 ∉ g.complement := fun hcl =>
       (Finset.disjoint_left.mp g.red_disjoint_complement) h2red hcl
     rcases hc with ⟨_, hc1⟩ | ⟨h2host', _⟩
     · exact Or.inl ⟨hc1, h2notcompl⟩
-    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red)
+    · exact absurd h2host' (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h2red)
   · have h1red : f.1.1 ∈ g.red := by
-      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      rw [Finset.mem_sdiff] at h1nothost; push Not at h1nothost
       exact h1nothost (Finset.mem_univ _)
     have h1notcompl : f.1.1 ∉ g.complement := fun hcl =>
       (Finset.disjoint_left.mp g.red_disjoint_complement) h1red hcl
     rcases hc with ⟨h1host', _⟩ | ⟨_, hc2⟩
-    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red)
+    · exact absurd h1host' (by rw [Finset.mem_sdiff]; push Not; exact fun _ => h1red)
     · exact Or.inr ⟨h1notcompl, hc2⟩
 
+omit [DecidableRel G.Adj] in
 /-- The host-side endpoint of a host boundary edge lies in the blue block or in the
 complement block, by the disjoint cover `univ \ red = blue ⊔ complement`. -/
 theorem ThreeBlockGeometry.hostBoundary_hostVertex_mem_blue_or_compl
@@ -422,6 +425,7 @@ theorem ThreeBlockGeometry.blueRedCrossing_fiber_card
           (fun eg : Edge G => g.IsBlueRedCrossingEdge A eg))
         (fun eg => by simp [Finset.mem_filter]) (fun eg => A.bondDim eg)]
 
+omit [DecidableRel G.Adj] in
 /-- A host boundary edge is a red boundary edge: having one endpoint in `univ \ red`
 and one in `red` is the same as having one endpoint in `red` and one outside. -/
 theorem ThreeBlockGeometry.isRegionBoundaryEdge_red_of_host
@@ -430,11 +434,11 @@ theorem ThreeBlockGeometry.isRegionBoundaryEdge_red_of_host
   rcases hg with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
   · have h1notred : eg.1.1 ∉ g.red := (Finset.mem_sdiff.mp h1host).2
     have h2red : eg.1.2 ∈ g.red := by
-      rw [Finset.mem_sdiff] at h2nothost; push_neg at h2nothost
+      rw [Finset.mem_sdiff] at h2nothost; push Not at h2nothost
       exact h2nothost (Finset.mem_univ _)
     exact Or.inr ⟨h1notred, h2red⟩
   · have h1red : eg.1.1 ∈ g.red := by
-      rw [Finset.mem_sdiff] at h1nothost; push_neg at h1nothost
+      rw [Finset.mem_sdiff] at h1nothost; push Not at h1nothost
       exact h1nothost (Finset.mem_univ _)
     have h2notred : eg.1.2 ∉ g.red := (Finset.mem_sdiff.mp h2host).2
     exact Or.inl ⟨h1red, h2notred⟩
@@ -606,10 +610,10 @@ theorem ThreeBlockGeometry.regionBlockedWeight_complement_eq_smul_constrained
     -- A crossing edge is a red boundary edge, hence a host boundary edge.
     have hhost : IsRegionBoundaryEdge (G := G) (Finset.univ \ g.red) eg := by
       rcases hg.1 with ⟨h1red, h2notred⟩ | ⟨h1notred, h2red⟩
-      · exact Or.inr ⟨by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h1red,
+      · exact Or.inr ⟨by rw [Finset.mem_sdiff]; push Not; exact fun _ => h1red,
           by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h2notred⟩⟩
       · exact Or.inl ⟨by rw [Finset.mem_sdiff]; exact ⟨Finset.mem_univ _, h1notred⟩,
-          by rw [Finset.mem_sdiff]; push_neg; exact fun _ => h2red⟩
+          by rw [Finset.mem_sdiff]; push Not; exact fun _ => h2red⟩
     have h1 := congrFun hq.2.1 ⟨eg, hhost⟩
     have h2 := congrFun hq0host ⟨eg, hhost⟩
     rw [regionBoundaryLabel_apply] at h1 h2
@@ -726,7 +730,8 @@ injective. -/
 
 open scoped Classical in
 /-- **The union lemma of the normal PEPS Fundamental Theorem.** The host block
-`univ \ red`, the union of the blue and complement injective blocks of the geometry, is blocked-tensor injective.
+`univ \ red`, the union of the blue and complement injective blocks of the
+geometry, is blocked-tensor injective.
 
 A coefficient family `c` annihilating the host blocked-region weight family is stripped
 of the blue block (`complCoeff_combination_eq_zero`), leaving the `c`-weighted complement
@@ -845,7 +850,8 @@ theorem ThreeBlockGeometry.regionBlockedTensorInjective_union
     rw [hh', hb', hc'] at e1
     rw [e2]
     -- `host q' = hostLabelFrom (blue q) (compl q) = host q`, and `host q' = bdry'`.
-    rw [← e1] at e2 ⊢ <;> exact e2
+    rw [← e1] at e2
+    rw [← e1]
   · intro h; exact absurd (Finset.mem_univ _) h
 
 /-! ### The disjoint two-region union lemma
@@ -878,15 +884,19 @@ def twoRegionGeometry (S T : Finset V) (hST : Disjoint S T) : ThreeBlockGeometry
     simp only [Finset.mem_union, Finset.mem_sdiff, Finset.mem_univ, true_and, iff_true]
     tauto
 
+omit [LinearOrder V] in
 @[simp] theorem twoRegionGeometry_blue (S T : Finset V) (hST : Disjoint S T) :
     (twoRegionGeometry (V := V) S T hST).blue = S := rfl
 
+omit [LinearOrder V] in
 @[simp] theorem twoRegionGeometry_complement (S T : Finset V) (hST : Disjoint S T) :
     (twoRegionGeometry (V := V) S T hST).complement = T := rfl
 
+omit [LinearOrder V] in
 @[simp] theorem twoRegionGeometry_red (S T : Finset V) (hST : Disjoint S T) :
     (twoRegionGeometry (V := V) S T hST).red = Finset.univ \ (S ∪ T) := rfl
 
+omit [LinearOrder V] in
 /-- The host block of the two-region geometry is the union `S ∪ T`. -/
 theorem twoRegionGeometry_univ_sdiff_red (S T : Finset V) (hST : Disjoint S T) :
     Finset.univ \ (twoRegionGeometry (V := V) S T hST).red = S ∪ T := by
@@ -940,7 +950,7 @@ theorem regionBlockedTensorInjective_biUnion_disjoint {ι : Type*}
           (by rintro rfl; exact hi hj)
       refine regionBlockedTensorInjective_union_disjoint hdisj_it
         (hR i (by simp)) (ih ?_ ?_) hpos
-      · exact hdisj.mono (by simp [Finset.coe_cons, Set.subset_insert])
+      · exact hdisj.mono (by simp [Set.subset_insert])
       · exact fun j hj => hR j (by simp [hj])
 
 end PEPS

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
@@ -89,7 +89,7 @@ theorem ThreeBlockGeometry.hostLabel_p2_eq_hostLabel_regionMerge_blue
     have hbdry : IsRegionBoundaryEdge (G := G) g.blue f.1 := by
       rcases f.2 with ⟨h1host, h2nothost⟩ | ⟨h1nothost, h2host⟩
       · have h2red : f.1.1.2 ∈ g.red := by
-          have := h2nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          have := h2nothost; rw [Finset.mem_sdiff] at this; push Not at this
           exact this (Finset.mem_univ _)
         have h2notblue : f.1.1.2 ∉ g.blue := fun hb =>
           (Finset.disjoint_left.mp g.red_disjoint_blue) h2red hb
@@ -97,7 +97,7 @@ theorem ThreeBlockGeometry.hostLabel_p2_eq_hostLabel_regionMerge_blue
         · refine Or.inl ⟨hb1, h2notblue⟩
         · exact absurd hb2 h2notblue
       · have h1red : f.1.1.1 ∈ g.red := by
-          have := h1nothost; rw [Finset.mem_sdiff] at this; push_neg at this
+          have := h1nothost; rw [Finset.mem_sdiff] at this; push Not at this
           exact this (Finset.mem_univ _)
         have h1notblue : f.1.1.1 ∉ g.blue := fun hb =>
           (Finset.disjoint_left.mp g.red_disjoint_blue) h1red hb
@@ -347,6 +347,9 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_complCoeff_sum_blue
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨hp, hhost, hq⟩ := hpq
     exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩
+
+namespace ThreeBlockGeometry
+
 open scoped Classical in
 /-- **The core blue smul-factorization (pointwise).** The blue mirror of
 `regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical`: the blue
@@ -356,7 +359,7 @@ the blue blocked-region weight.
 
 Source: arXiv:1804.04964, Section 3, Lemma `inj_isomorph`, lines 355--486 of
 `Papers/1804.04964/paper_normal.tex`. -/
-theorem ThreeBlockGeometry.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue
+theorem regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue
     (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ g.red))
     (σblue : RegionPhysicalConfig (V := V) (d := d) g.blue)
     (σcompl : RegionPhysicalConfig (V := V) (d := d) g.complement) :
@@ -373,6 +376,8 @@ theorem ThreeBlockGeometry.regionInteriorBondProd_smul_regionBlockedWeight_three
     g.threeBlockDoubleSum_eq_complCoeff_sum_blue bdry σblue σcompl]
   refine Finset.sum_congr rfl (fun bβ _ => ?_)
   rw [smul_eq_mul, mul_comm]
+
+end ThreeBlockGeometry
 
 open scoped Classical in
 /-- **The core blue smul-factorization (as functions of `σblue`).** The blue
@@ -394,7 +399,8 @@ theorem regionInteriorBondProd_smul_geometryBlueWeight_eq
           regionBlockedWeight (G := G) A g.blue bβ := by
   funext σblue
   rw [Pi.smul_apply, Finset.sum_apply,
-    g.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue bdry σblue σcompl]
+    g.regionInteriorBondProd_smul_regionBlockedWeight_threeBlockComplPhysical_blue
+      bdry σblue σcompl]
   refine Finset.sum_congr rfl (fun bβ _ => ?_)
   rw [Pi.smul_apply]
 

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3b.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap3b.lean
@@ -150,7 +150,8 @@ theorem overlap_bridge_rightCoupling_eq_zero {R₁ R₂ : Finset V}
   -- It suffices to show the scaled combination vanishes.
   rw [← smul_right_injective ℂ hcrossne |>.eq_iff (a := _) (b := (0 : _)), smul_zero]
   -- The crossing collapse expresses the scaled combination through the `R₂\R₁` weights.
-  have hcollapse := (overlapRightGeometry (V := V) R₁ R₂).crossingBond_smul_complCoeff_combination_eq
+  have hcollapse :=
+    (overlapRightGeometry (V := V) R₁ R₂).crossingBond_smul_complCoeff_combination_eq
     (A := A) row bβ σcompl
   rw [hcollapse]
   -- Per `bc'`, transport the host coefficient sum to `R₂` and apply the bridge identity.

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap5.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap5.lean
@@ -84,6 +84,7 @@ The fused leg `complPhysical σblue σcompl` ranges over every physical configur
 and complement blocks (the red block is disjoint from the host), so reading the prescribed leg on
 the blue block and on the complement block recovers it. -/
 
+omit [LinearOrder V] in
 /-- The fused complement physical leg is surjective: every physical configuration of the host
 `univ \ g.red` is `g.complPhysical σblue σcompl` for some blue and complement legs. -/
 theorem ThreeBlockGeometry.complPhysical_surjective (g : ThreeBlockGeometry V) :

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityOverlap6.lean
@@ -324,7 +324,8 @@ theorem overlapFiber_bridge_rightCoupling_eq_zero {R₁ R₂ : Finset V}
   have hcrossne : ((overlapRightGeometry (V := V) R₁ R₂).blueRedCrossingBondProd A : ℂ) ≠ 0 :=
     Nat.cast_ne_zero.mpr hcrosspos.ne'
   rw [← smul_right_injective ℂ hcrossne |>.eq_iff (a := _) (b := (0 : _)), smul_zero]
-  have hcollapse := (overlapRightGeometry (V := V) R₁ R₂).crossingBond_smul_complCoeff_combination_eq
+  have hcollapse :=
+    (overlapRightGeometry (V := V) R₁ R₂).crossingBond_smul_complCoeff_combination_eq
     (A := A) row bβ σcompl
   rw [hcollapse]
   have hcoeff : ∀ bc' : RegionBoundaryConfig (G := G) A
@@ -441,7 +442,8 @@ theorem overlapFiber_bridgeRow_eq_zero {R₁ R₂ : Finset V}
     exact overlapFiber_bridge_rightCoupling_eq_zero (G := G) (A := A) hR₁ c hc hpos δ σcompl bβ
   -- Feed to the rebuild: the interior-bond scaled host-weight combination vanishes.
   have hrebuild := fun σblue σcompl =>
-    overlapRight_bondProd_smul_hostWeight_combination_eq_zero (G := G) (A := A) (R₁ := R₁) (R₂ := R₂)
+    overlapRight_bondProd_smul_hostWeight_combination_eq_zero (G := G) (A := A)
+      (R₁ := R₁) (R₂ := R₂)
       row hrowhyp σblue σcompl
   -- interior bond positive ⟹ host-weight combination vanishes through complPhysical.
   have hintne : (regionInteriorBondProd (G := G) A g.blue : ℂ) ≠ 0 :=
@@ -489,6 +491,7 @@ same union host label as `q₀` by the partition determinacy, so the fiber coeff
 label is forced to vanish. -/
 
 set_option linter.unusedSectionVars false in
+omit [DecidableEq V] in
 open scoped Classical in
 /-- Transport of host annihilation along a region-set equality: if a coefficient family `c`
 annihilates the blocked weights of `R`, then its transport annihilates the blocked weights of an
@@ -510,6 +513,7 @@ theorem hc_transport {S R : Finset V} (h : S = R)
   rw [hb]
 
 set_option linter.unusedSectionVars false in
+omit [Fintype V] in
 open scoped Classical in
 /-- **Union host-boundary surjectivity.** With positive bond dimensions, every union `R₁ ∪ R₂`
 boundary configuration is the union boundary label of some global virtual configuration: read the

--- a/TNLean/PEPS/RegionTransportInsertion.lean
+++ b/TNLean/PEPS/RegionTransportInsertion.lean
@@ -74,7 +74,7 @@ theorem regionBoundaryConfigMap_boundaryEdgeMap (A : Tensor G d) (φ : G ≃g G'
       Fin.cast (transport_bondDim_boundaryEdgeMap A φ R f).symm (g f) := by
   have hrt : regionBoundaryEdgeMapEquiv φ R (boundaryEdgeMap φ R f) = f := by
     rw [boundaryEdgeMap, Equiv.apply_symm_apply]
-  show g (regionBoundaryEdgeMapEquiv φ R (boundaryEdgeMap φ R f)) = _
+  change g (regionBoundaryEdgeMapEquiv φ R (boundaryEdgeMap φ R f)) = _
   -- The argument equals `f`, so the value equals `g f` up to the bond-dimension cast: the cast
   -- preserves the underlying natural-number value, which is `(g ·).val` evaluated at equal points.
   apply Fin.eq_of_val_eq

--- a/TNLean/PEPS/TensorFactorScalar.lean
+++ b/TNLean/PEPS/TensorFactorScalar.lean
@@ -185,7 +185,7 @@ theorem threeLeg_residual_forms_scalar [Nonempty α] [Nonempty β] [Nonempty γ]
 
 section PiProduct
 
-variable {ι : Type*} [Fintype ι] [DecidableEq ι] {n : ι → Type*}
+variable {ι : Type*} [Fintype ι] {n : ι → Type*}
 variable [∀ i, Fintype (n i)] [∀ i, DecidableEq (n i)]
 
 omit [DecidableEq α] [DecidableEq β] [DecidableEq γ] in
@@ -202,7 +202,7 @@ theorem exists_ne_zero_row_of_isUnit {m : Type*} [Fintype m] [DecidableEq m]
   simp only [h0, zero_mul, Finset.sum_const_zero] at hval
   exact one_ne_zero hval.symm
 
-omit [DecidableEq α] [DecidableEq β] [DecidableEq γ] [Fintype ι] [DecidableEq ι] in
+omit [DecidableEq α] [DecidableEq β] [DecidableEq γ] [Fintype ι] in
 /-- A reference configuration: per leg, a base row paired with a column on which
 the invertible per-leg matrix is nonzero. -/
 theorem exists_ref_config (N : (i : ι) → Matrix (n i) (n i) ℂ)

--- a/TNLean/PEPS/TorusEdgeBlockingCrossing.lean
+++ b/TNLean/PEPS/TorusEdgeBlockingCrossing.lean
@@ -95,7 +95,7 @@ theorem torusRightEdge_endpoints_of_lt {p : TorusVertex width height}
     (torusRightEdge p).1.1 = p ∧ (torusRightEdge p).1.2 = (p.1 + 1, p.2) := by
   have hadj : (torusGraph width height).Adj p (p.1 + 1, p.2) := torusGraph_adj_right p.1 p.2
   have hcmp : p < ((p.1 + 1, p.2) : TorusVertex width height) := by
-    show toLex (p.1.val, p.2.val) < toLex ((p.1 + 1).val, p.2.val)
+    change toLex (p.1.val, p.2.val) < toLex ((p.1 + 1).val, p.2.val)
     rw [Prod.Lex.toLex_lt_toLex]
     exact Or.inl (by rw [ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]; omega)
   rw [torusRightEdge, Edge.ofAdj_of_lt hadj hcmp]
@@ -108,9 +108,11 @@ theorem torusUpEdge_endpoints_of_lt {p : TorusVertex width height}
     (torusUpEdge p).1.1 = p ∧ (torusUpEdge p).1.2 = (p.1, p.2 + 1) := by
   have hadj : (torusGraph width height).Adj p (p.1, p.2 + 1) := torusGraph_adj_up p.1 p.2
   have hcmp : p < ((p.1, p.2 + 1) : TorusVertex width height) := by
-    show toLex (p.1.val, p.2.val) < toLex (p.1.val, (p.2 + 1).val)
+    change toLex (p.1.val, p.2.val) < toLex (p.1.val, (p.2 + 1).val)
     rw [Prod.Lex.toLex_lt_toLex]
-    exact Or.inr ⟨rfl, by rw [ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]; omega⟩
+    exact Or.inr ⟨rfl, by
+      rw [ZMod.val_add_of_lt (by rw [ZMod.val_one]; omega), ZMod.val_one]
+      omega⟩
   rw [torusUpEdge, Edge.ofAdj_of_lt hadj hcmp]
   exact ⟨rfl, rfl⟩
 
@@ -138,7 +140,7 @@ theorem horizontalReferenceEdge_val {xStart yStart : ℕ}
   · rw [torusHorizontalReferenceEdge, href.1]; exact ZMod.val_cast_of_lt (by omega)
   · rw [torusHorizontalReferenceEdge, href.1]; exact ZMod.val_cast_of_lt (by omega)
   · rw [torusHorizontalReferenceEdge, href.2]
-    show ((xStart + 1 : ℕ) + 1 : ZMod width).val = xStart + 2
+    change ((xStart + 1 : ℕ) + 1 : ZMod width).val = xStart + 2
     rw [show ((xStart + 1 : ℕ) + 1 : ZMod width) = ((xStart + 2 : ℕ) : ZMod width) from by
       push_cast; ring]
     exact ZMod.val_cast_of_lt (by omega)
@@ -265,7 +267,7 @@ theorem verticalReferenceEdge_val {xStart yStart : ℕ}
   · rw [torusVerticalReferenceEdge, href.1]; exact ZMod.val_cast_of_lt (by omega)
   · rw [torusVerticalReferenceEdge, href.2]; exact ZMod.val_cast_of_lt (by omega)
   · rw [torusVerticalReferenceEdge, href.2]
-    show ((yStart + 1 : ℕ) + 1 : ZMod height).val = yStart + 2
+    change ((yStart + 1 : ℕ) + 1 : ZMod height).val = yStart + 2
     rw [show ((yStart + 1 : ℕ) + 1 : ZMod height) = ((yStart + 2 : ℕ) : ZMod height) from by
       push_cast; ring]
     exact ZMod.val_cast_of_lt (by omega)

--- a/TNLean/PEPS/TorusGaugeUniqueness.lean
+++ b/TNLean/PEPS/TorusGaugeUniqueness.lean
@@ -463,7 +463,7 @@ theorem torusCovariantAbsorbedGauge_unique_classScalar
         (((xhStart + 1 : ℕ) : ZMod width), ((yhStart + 2 : ℕ) : ZMod height)) :=
       (torusRightEdge_endpoints_of_lt
         (p := (((xhStart + 1 : ℕ) : ZMod width), ((yhStart + 2 : ℕ) : ZMod height)))
-        (by show ((xhStart + 1 : ℕ) : ZMod width).val + 1 < width
+        (by change ((xhStart + 1 : ℕ) : ZMod width).val + 1 < width
             rw [ZMod.val_cast_of_lt (by omega : xhStart + 1 < width)]
             omega)).1
     -- The translated reference edge is the right edge at the translated left endpoint.
@@ -523,7 +523,7 @@ theorem torusCovariantAbsorbedGauge_unique_classScalar
         (((xhStart + 2 : ℕ) : ZMod width), ((yhStart + 1 : ℕ) : ZMod height)) :=
       (torusUpEdge_endpoints_of_lt
         (p := (((xhStart + 2 : ℕ) : ZMod width), ((yhStart + 1 : ℕ) : ZMod height)))
-        (by show ((yhStart + 1 : ℕ) : ZMod height).val + 1 < height
+        (by change ((yhStart + 1 : ℕ) : ZMod height).val + 1 < height
             rw [ZMod.val_cast_of_lt (by omega : yhStart + 1 < height)]
             omega)).1
     have hEeq : Edge.map (translate a b)

--- a/TNLean/PEPS/TorusWindowBondLocal.lean
+++ b/TNLean/PEPS/TorusWindowBondLocal.lean
@@ -97,7 +97,6 @@ theorem windowCoeffTransferAB_of_bondLocal {A B : Tensor (torusGraph width heigh
     (hAB : SameState A B)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
-    (hDim : A.bondDim = B.bondDim)
     (hbondAB : IsBondLocalTransferKernel (G := torusGraph width height) A B
       (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
       (by
@@ -139,7 +138,7 @@ theorem windowCoeffTransferAB_of_bondLocal {A B : Tensor (torusGraph width heigh
     (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
     hRA hRB (hA.regionBlockedTensorInjective_windowComplement hUA hL hK hxw hyh _)
     (hB.regionBlockedTensorInjective_windowComplement hUB hL hK hxw hyh _)
-    hAB hposA hposB hDim
+    hAB hposA hposB
     ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega) (by omega)
       ha0 haw hbh⟩ hbondAB
 
@@ -165,7 +164,6 @@ theorem windowCoeffTransferBA_of_bondLocal {A B : Tensor (torusGraph width heigh
     (hAB : SameState A B)
     (hposA : ∀ g : Edge (torusGraph width height), 0 < A.bondDim g)
     (hposB : ∀ g : Edge (torusGraph width height), 0 < B.bondDim g)
-    (hDim : A.bondDim = B.bondDim)
     (hbondBA : IsBondLocalTransferKernel (G := torusGraph width height) B A
       (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
       (by
@@ -207,7 +205,7 @@ theorem windowCoeffTransferBA_of_bondLocal {A B : Tensor (torusGraph width heigh
     (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
     hRB hRA (hB.regionBlockedTensorInjective_windowComplement hUB hL hK hxw hyh _)
     (hA.regionBlockedTensorInjective_windowComplement hUA hL hK hxw hyh _)
-    hAB.symm hposB hposA hDim.symm
+    hAB.symm hposB hposA
     ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega) (by omega)
       ha0 haw hbh⟩ hbondBA
 
@@ -285,19 +283,19 @@ theorem exists_windowEdgeCoeffIdentityWitness_of_bondLocal
           ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
             (by omega) ha0 haw hbh⟩
           (windowCoeffTransferAB_of_bondLocal hA hB hUA hUB hL hK ha0 haw hbh hxw hyh hAB
-            hposA hposB hDim hbondAB) (M * M') =
+            hposA hposB hbondAB) (M * M') =
         coeffTransferMap (G := torusGraph width height) A B
             (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
             ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
               (by omega) ha0 haw hbh⟩
             (windowCoeffTransferAB_of_bondLocal hA hB hUA hUB hL hK ha0 haw hbh hxw hyh hAB
-              hposA hposB hDim hbondAB) M *
+              hposA hposB hbondAB) M *
           coeffTransferMap (G := torusGraph width height) A B
             (horizontalStaircaseLeftWindow ((a : ZMod width), (b : ZMod height)) L K)
             ⟨_, isRegionBoundaryEdge_horizontalStaircaseLeftWindow_referenceEdge A (by omega)
               (by omega) ha0 haw hbh⟩
             (windowCoeffTransferAB_of_bondLocal hA hB hUA hUB hL hK ha0 haw hbh hxw hyh hAB
-              hposA hposB hDim hbondAB) M') :
+              hposA hposB hbondAB) M') :
     ∃ (Z Zref : GL (Fin (B.bondDim
         (horizontalStaircaseReferenceEdge ((a : ZMod width), (b : ZMod height)) L K))) ℂ)
       (hE : A.bondDim
@@ -309,9 +307,9 @@ theorem exists_windowEdgeCoeffIdentityWitness_of_bondLocal
   exists_windowEdgeCoeffIdentityWitness_of_coeffTransfer hA hB hUA hUB hL hK ha0 haw hbh hxw hyh
     hAB hposA hposB hDim
     (windowCoeffTransferAB_of_bondLocal hA hB hUA hUB hL hK ha0 haw hbh hxw hyh hAB
-      hposA hposB hDim hbondAB)
+      hposA hposB hbondAB)
     (windowCoeffTransferBA_of_bondLocal hA hB hUA hUB hL hK ha0 haw hbh hxw hyh hAB
-      hposA hposB hDim hbondBA)
+      hposA hposB hbondBA)
     hmul
 
 end PEPS

--- a/TNLean/PEPS/TorusWindowRegion.lean
+++ b/TNLean/PEPS/TorusWindowRegion.lean
@@ -118,7 +118,7 @@ theorem horizontalStaircaseEdge_val {L K a b : ℕ} (hL : 0 < L)
   · rw [href.1]; exact ZMod.val_cast_of_lt (by omega)
   · rw [href.1]; exact ZMod.val_cast_of_lt (by omega)
   · rw [href.2]
-    show (((a + L - 1 : ℕ) : ZMod width) + 1).val = a + L
+    change (((a + L - 1 : ℕ) : ZMod width) + 1).val = a + L
     rw [show ((a + L - 1 : ℕ) : ZMod width) + 1 = ((a + L : ℕ) : ZMod width) from by
       rw [← Nat.cast_add_one]; congr 1; omega]
     exact ZMod.val_cast_of_lt (by omega)
@@ -252,7 +252,7 @@ theorem verticalStaircaseEdge_val {L K a b : ℕ} (hK : 0 < K)
   · rw [href.1]; exact ZMod.val_cast_of_lt (by omega)
   · rw [href.2]; exact ZMod.val_cast_of_lt (by omega)
   · rw [href.2]
-    show (((b + K - 1 : ℕ) : ZMod height) + 1).val = b + K
+    change (((b + K - 1 : ℕ) : ZMod height) + 1).val = b + K
     rw [show ((b + K - 1 : ℕ) : ZMod height) + 1 = ((b + K : ℕ) : ZMod height) from by
       rw [← Nat.cast_add_one]; congr 1; omega]
     exact ZMod.val_cast_of_lt (by omega)

--- a/TNLean/PEPS/TorusWitnessCapstone.lean
+++ b/TNLean/PEPS/TorusWitnessCapstone.lean
@@ -97,9 +97,9 @@ The reference horizontal gauge `Zh` and its coefficient identity come from
 horizontal edge as the translation image of the reference edge
 (`translate_horizontalReferenceEdge`), the reference coefficient identity transports to that
 edge realized by the transported gauge (`edgeCoeffIdentityWitness_translate`), supplying both
-witness identities.  This is the horizontal half of the translation construction of the witnesses; the
-per-edge gauge family is the transported reference, the source's *"X, the same matrix on all
-horizontal edges"* read in the ordered edge convention.
+witness identities.  This is the horizontal half of the translation construction of the
+witnesses; the per-edge gauge family is the transported reference, the source's *"X, the
+same matrix on all horizontal edges"* read in the ordered edge convention.
 
 Source: arXiv:1804.04964, Section 3, proof of Theorem 3, lines 1449--1572 of
 `Papers/1804.04964/paper_normal.tex`. -/


### PR DESCRIPTION
## Summary

- replace PEPS linter-reported goal-changing `show` tactics by `change` where appropriate
- replace deprecated `push_neg` uses by `push Not`
- remove unused section/typeclass and proof hypotheses from PEPS helper lemmas, propagating the more general statements through local call sites
- silence two informational `ring` suggestions in `AKLTRotation` by using `ring_nf`

This is a warning-cleanup follow-up to the PEPS branch review discussion. The remaining `lake build TNLean` warning is the pre-existing `sorry` in `TNLean/MPS/Periodic/Overlap/Case3.lean`, which is a separate proof obligation rather than a PEPS linter cleanup.

Refs #3007.

## Validation

- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactors and signature generalizations with propagated call-site updates; no runtime or security impact, with low risk of accidental breakage if a removed hypothesis was still needed somewhere outside the diff.
> 
> **Overview**
> **PEPS linter cleanup** across cycle MPS, region-block, torus window, and related files: goal-changing `show` → `change`, deprecated `push_neg` → `push Not`, and `ring` → `ring_nf` in `AKLTRotation` to silence tactic hints.
> 
> **Generalized lemmas** by removing unused `[Fintype V]` (and similar) from statements and adding targeted `omit [...]` where proofs do not need full graph finiteness/decidability assumptions.
> 
> **API tightening** on region blocked-tensor transfer: drops the redundant `hDim : A.bondDim = B.bondDim` argument from `range_regionBlockedTensorMap_eq_of_sameState`, `coeffTransfer_of_bondLocal`, and downstream theorems, with call sites updated; one recovery lemma drops an unused `hvB` parameter from `regionInsertionOp_realizes_of_realizes_on_stateVec`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 439a53e8bdd3207e00523ea61d14c99968a4fe4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->