### PR TITLE
doc(parent): align martingale source boundary prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -10,16 +10,18 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 /-!
 # Martingale estimate for parent Hamiltonians
 
-The MPS parent-Hamiltonian spectral gap is reduced to a uniform Friedrichs-angle
-bound on adjacent local ground spaces. For the frustration-free sum of orthogonal
-projectors \(H=\sum_i h_i\), the principal-angle estimate on overlapping length-\(L\)
-windows yields the anticommutator inequality
+The MPS parent-Hamiltonian spectral gap is reduced to the anticommutator
+martingale condition stated in arXiv:2011.12127, Section IV.C. For the
+frustration-free sum of orthogonal projectors \(H=\sum_i h_i\), the required
+estimate for overlapping length-\(L\) windows has the form
 \(h_i h_j+h_j h_i \ge -c_{ij}(1-\gamma)(h_i+h_j)\) with row sums
 \(\sum_{j\ne i} c_{ij}\le 1\), since at most \(2(L-1)\) local terms overlap a
 given window. Together with \(h_i^2=h_i\) this gives the quadratic-form
 inequality \(H^2\ge \gamma H\), and the spectral theorem turns that into the
 norm bound \(\gamma\|v\|\le \|Hv\|\) on \((\ker H)^\perp\). The
-Friedrichs-angle estimate itself remains a separate hypothesis.
+MPS-specific anticommutator estimate remains a separate hypothesis. A
+norm-compression estimate from principal angles is also recorded as a sufficient
+stronger route.
 
 The four components are:
 
@@ -27,10 +29,10 @@ The four components are:
   `FrustrationFree.spectralGap_of_martingale` (quadratic form implies norm bound);
 * `Martingale.Transport` — Euclidean local projectors, ground-space and
   Hamiltonian transport, positivity, commutation, and kernel identification;
-* `Martingale.Reduction` — martingale quadratic-form reduction chain from
-  ordered cross-term bounds down to concrete cyclic-window Friedrichs;
-* `Martingale.Gap` — conditional gap theorems from the overlapping
-  cyclic-window estimate.
+* `Martingale.Reduction` — martingale quadratic-form reductions from ordered
+  cross-term and anticommutator bounds to concrete cyclic-window estimates;
+* `Martingale.Gap` — conditional gap theorems from the overlapping cyclic-window
+  anticommutator estimate and from sufficient norm-compression estimates.
 
 ## Argument
 
@@ -43,11 +45,13 @@ The four components are:
    the intersection of their kernels.
 4. **Martingale operator bound**: the intersection property identifies the
    kernels of overlapping local terms. The remaining quantitative input is the
-   Friedrichs-angle estimate, equivalently the anticommutator bound
+   anticommutator estimate
 
         \(h_i h_j+h_j h_i\ge -c_{ij}(1-\gamma)(h_i+h_j)\)
 
    with coefficients whose rows are summable uniformly in the chain length.
+   Principal-angle estimates may supply this bound through a norm-compression
+   inequality for the corresponding excitation projections.
 5. **Row-sum bound** \(\sum_{j\ne i} c_{ij}\le 1\): at most \(2(L-1)\) local terms
    overlap a given length-\(L\) cyclic window under the convention used here.
 6. **Quadratic form to norm bound**: combining these estimates with \(h_i^2=h_i\)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -8,8 +8,10 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 # Uniform spectral gap for the MPS parent Hamiltonian
 
 **Root-only.** This file contains the final conditional spectral-gap theorems
-for the MPS parent Hamiltonian. The overlapping-window principal-angle
-estimate remains an explicit hypothesis.
+for the MPS parent Hamiltonian. The source anticommutator estimate remains an
+explicit hypothesis. A cyclic-window norm-compression estimate, obtainable from
+principal-angle bounds when available, is recorded as a sufficient stronger
+hypothesis.
 
 ## Main results
 
@@ -20,7 +22,7 @@ estimate remains an explicit hypothesis.
 * `parentHamiltonianES_gap_bound_of_overlap_norm_constant` — the corresponding
   positive-gap bound from a strict uniform compression coefficient.
 * `parentHamiltonian_gapped` — conditional uniform spectral gap for MPS parent
-  Hamiltonians under the same principal-angle input.
+  Hamiltonians under the explicit norm-compression input.
 * `parentHamiltonian_gapped_of_anticommutator` — conditional uniform spectral
   gap under the source anticommutator estimate.
 * `parentHamiltonian_gapped_of_overlap_norm_constant` — the corresponding
@@ -73,18 +75,18 @@ theorem parentHamiltonianES_gap_bound_of_anticommutator
 /-- Gap bound from a strict uniform overlapping cyclic-window compression
 coefficient for the MPS parent Hamiltonian.
 
-This is the current formal boundary for applying the martingale input in
-arXiv:2011.12127, Section IV.C (the martingale-2 estimate), with an arbitrary
-compression constant. It does not assert the special coefficient used in
+This is the constant-flexible form of the norm-compression route to the
+martingale bound. It does not assert the special coefficient used in
 `parentHamiltonianES_gap_bound_of_friedrichs`; instead, it says that any uniform
 overlapping-window compression bound
 
 \(‖p_i p_j v‖ ≤ η ‖p_i v‖\)
 
 with \(2(L-1)\eta < 1\) yields the positive gap constant
-\(1 - 2(L-1)\eta\). The comparison between this flexible cyclic-window
-hypothesis and the cited FNW--Nachtergaele--Kastoryano principal-angle estimates
-is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+\(1 - 2(L-1)\eta\). This is a sufficient strengthening of the source
+anticommutator hypothesis. The comparison with the cited
+FNW--Nachtergaele--Kastoryano principal-angle estimates is recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_overlap_norm_constant
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)
@@ -103,8 +105,8 @@ theorem parentHamiltonianES_gap_bound_of_overlap_norm_constant
   exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
     A L hL hηnonneg hηlt hOverlapNorm
 
-/-- Gap bound from the overlapping cyclic-window principal-angle estimate for the
-MPS parent Hamiltonian.
+/-- Gap bound from the explicit overlapping cyclic-window norm-compression
+estimate for the MPS parent Hamiltonian.
 
 The hypothesis is the precise norm-compression estimate for overlapping
 cyclic-window local projections. The finite row-counting geometry, non-overlap
@@ -184,7 +186,7 @@ theorem parentHamiltonianES_gap_bound_of_friedrichs
     simpa [div_eq_mul_inv, mul_assoc, mul_left_comm, mul_comm] using hgap'
 
 /--
-**Conditional spectral gap for MPS parent Hamiltonians.**
+**Conditional spectral gap from an explicit norm-compression estimate.**
 
 For an MPS tensor \(A\) and interaction range \(L > 1\), the overlapping-window
 norm-compression estimate implies the existence of a uniform gap \(γ > 0\)
@@ -218,7 +220,9 @@ Combined with \(h_i^2 = h_i\), this yields the quadratic-form inequality
 by `FrustrationFree.spectralGap_of_martingale` is automatic here because
 \(H_N = ∑ᵢ hᵢ\) is a sum of orthogonal projectors.
 
-The proof below invokes
+This theorem records the stronger norm-compression route. The source-facing
+conditional theorem is `parentHamiltonian_gapped_of_anticommutator`. The proof
+below invokes
 `parentHamiltonianES_gap_bound_of_friedrichs`, which combines the already
 formalized martingale reductions after the overlapping-window estimate is given. -/
 theorem parentHamiltonian_gapped

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -22,7 +22,8 @@ concrete cyclic-window overlap predicate and its row-cardinality bound
 \(2(L - 1)\). The final reduction theorems (`*_gap_bound_of_cyclic_window_*`)
 supply all the already-proved structural input (local projection,
 non-overlap positivity, and row cardinality) and leave only the
-principal-angle estimate as a remaining hypothesis.
+source anticommutator estimate, or a sufficient norm-compression estimate, as a
+remaining hypothesis.
 
 The abstract spectral-theorem step (`FrustrationFree.spectralGap_of_martingale`)
 and the projection-geometry lemmas (`ProjectionGeometry.quadraticForm_sum_*`)
@@ -42,8 +43,8 @@ variable {d D : ℕ}
 implies the corresponding norm lower bound on the orthogonal complement of the
 Euclidean-space ground space.
 
-This theorem isolates the operator-theoretic part of the remaining
-principal-angle estimate. The hypotheses already include the quantitative
+This theorem isolates the operator-theoretic part of the remaining martingale
+estimate. The hypotheses already include the quantitative
 martingale estimate
 
 \(γ \operatorname{Re}\langle H_N v, v\rangle ≤
@@ -75,9 +76,10 @@ theorem parentHamiltonianES_norm_bound_of_quadratic_form
 uniform quadratic-form estimate with constant \(1 / (4 * L)\).
 
 Thus the remaining MPS-specific content is precisely to prove the hypothesis
-`hQuad` from the principal-angle / anticommutator estimate and the finite
-row-sum bound; the positivity, kernel transport, and spectral-theorem conversion
-are already available here. -/
+`hQuad` from the source anticommutator estimate, or from a sufficient
+norm-compression estimate, together with the finite row-sum bound. The
+positivity, kernel transport, and spectral-theorem conversion are already
+available here. -/
 theorem parentHamiltonianES_gap_bound_of_quadratic_form
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (hQuad : ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
@@ -523,8 +525,8 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
       localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A (by omega) hnot v)
     hFriedrichs
 
-/-- Uniform explicit gap-bound reduction from the remaining overlapping-window
-principal-angle, or norm-compression, estimate.
+/-- Uniform explicit gap-bound reduction from an ordered overlapping-window
+cross-term estimate.
 
 The concrete cyclic-window row-cardinality bound, local symmetric-projection
 structure, and non-overlap positivity are already proved.  Consequently it is
@@ -603,13 +605,13 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_anticommutator
     linarith
 
 /-- Uniform explicit gap-bound reduction from a norm-compression form of the
-overlapping-window Friedrichs estimate.
+overlapping-window martingale estimate.
 
 It suffices to prove that for every overlapping off-diagonal pair the compressed
-product of transported local projections satisfies
+product of local projections satisfies
 \(‖hᵢ (hⱼ v)‖ ≤ (1 - 1/(4L)) / (2(L-1)) * ‖hᵢ v‖\).  The abstract projection
-geometry converts this principal-angle style condition into the ordered
-Friedrichs lower bound and then applies the finite-overlap martingale reduction. -/
+geometry converts this norm-compression condition into the ordered cross-term
+lower bound and then applies the finite-overlap martingale reduction. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
@@ -672,8 +674,9 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
 /-- Uniform gap-bound reduction from a strict overlap norm-compression constant.
 
 If every overlapping off-diagonal cyclic pair satisfies the compression estimate
-with coefficient \(η\), and \(η * (2 * (L - 1)) < 1\), then the transported parent
-Hamiltonians have gap constant \(1 - η * (2 * (L - 1))\).  Thus any uniform
+with coefficient \(η\), and \(η * (2 * (L - 1)) < 1\), then the parent
+Hamiltonians under the canonical \(\ell^2\) identification have gap constant
+\(1 - η * (2 * (L - 1))\).  Thus any uniform
 compression constant strictly below the reciprocal of the cyclic overlap degree
 yields a positive gap. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -22,10 +22,10 @@ state, obtained from the intersection property of the local ground spaces. For a
 normal tensor the corresponding conclusion follows, under the stated
 closure-property and length hypotheses, from the inverting-and-growing-back
 argument at the injectivity length.
-When the length-two local terms commute, the construction records the
-zero-energy part of the condition that $V^{(N)}(A)$ is a ground state of a
-nearest-neighbor commuting parent Hamiltonian in the pure-state theorem relating
-renormalization fixed points, zero correlation length, and such ground states in
+The nearest-neighbor section separates the translated parent-term commutation
+and zero-energy equations for $V^{(N)}(A)$ from the source ground-space spanning
+clause in the pure-state theorem relating renormalization fixed points, zero
+correlation length, and nearest-neighbor commuting parent Hamiltonians in
 \cite{Cirac2016MPDO_arXiv}. The spectral-gap section records the source
 anticommutator martingale condition for overlapping local terms, together with
 cyclic norm-compression estimates as sufficient stronger hypotheses. For a tensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -194,9 +194,9 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     $G_L(B)$ with the subspace denoted in the source by
     $S=\bigoplus_j\mathcal G_L^{A^j}$.
     The passage from the open-segment recursion to the $N$-site ring is the
-    separate closure-property step at the periodic boundary in
+    separate boundary-condition comparison in the periodic ring in
     \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}.
-    % This closure-property step is not the inclusion
+    % This periodic-boundary comparison is not the inclusion
     % $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails for a general
     % open-boundary matrix crossing the periodic boundary.
     The source periodic-boundary conclusion is


### PR DESCRIPTION
## Summary

- Make the parent-Hamiltonian martingale summaries treat the arXiv:2011.12127 anticommutator estimate as the source-facing boundary.
- Describe norm-compression/principal-angle estimates as sufficient stronger hypotheses rather than the primary source condition.
- Align the Chapter 13 overview with the separated NNCPH commutation/zero-energy equations and ground-space spanning clause.
- Rename the residual step in the BNT consequence paragraph as a boundary-condition comparison in the periodic ring.

## Validation

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Gap`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Reduction`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- `lake build TNLean` (only the pre-existing `TNLean/MPS/Periodic/Overlap/Case3.lean` sorry warning)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` followed by `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

Refs #952.
Refs #2633.
Refs #460.
Refs #190.