### PR TITLE
feat(parent): add boundary-crossing PGVWC equality reduction

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -212,6 +212,72 @@ theorem
   intro j i hi ρ β
   exact hC i ρ hi j β
 
+/-- Boundary-crossing local constraints give the block-diagonal periodic-boundary
+equality in the finite BNT range.
+
+Let
+\[
+  B=\bigoplus_j\mu_jA_j.
+\]
+Assume the normalized BNT block-separation hypotheses and the finite injectivity
+range. If every boundary-crossing interval has the simultaneous block-word
+spanning property needed to separate the block traces, then the local constraint
+for a vector in \(\mathcal G_{N,L}(B)\) gives the Pérez-García--Verstraete--Wolf--
+Cirac \(C^j,D^j\) comparison. The preceding theorem then shows that the
+corresponding block components lie in the single-block periodic chain spaces.
+Consequently
+\[
+  \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j),
+\]
+and the length-\(N\) single-block spaces are independent.
+
+This is the equality-level form of PGVWC07, Theorem 12, proof lines 1436--1451,
+specialized to the block-diagonal boundary conditions of
+arXiv:2011.12127, Section IV.C, lines 2126--2128.
+
+**Scope restriction (crossing span):** The theorem assumes that the simultaneous
+block-word tuples of length \(N-i\) span the product algebra for each
+boundary-crossing interval beginning at \(i\). Removing this visible span
+hypothesis from the finite BNT range is part of the remaining PGVWC07
+boundary-comparison cleanup recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
+**Unfaithful:** This proof still relies on
+`exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`
+for the block-diagonal boundary representation of \(\psi\). Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
+derive that representation and the crossing comparison from the source
+boundary-condition argument; tracked in issue 2971. -/
+theorem
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hCrossingSpan :
+      ∀ i : Fin N, N < i.val + L → WordTupleSpanTop A (N - i.val)) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  exact
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+      (fun ψ hψ =>
+        exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1
+          μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+          hNlarge hCrossingSpan hψ)
+
 /-- The \(C^j,D^j\) boundary-condition comparison gives the block-diagonal
 periodic-boundary equality in the finite BNT range.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -331,6 +331,63 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
+\begin{lemma}[$C^j,D^j$ comparisons at boundary-crossing intervals reduce to periodic-boundary equality]
+    \label{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison}
+    \leanok
+    \uses{lem:bnt_block_diagonal_boundary_representation_equality,
+        lem:block_diagonal_boundary_local_sum_mem,
+        thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+        lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
+    in addition that $L+L_0\le N$. Assume also that, for every
+    boundary-crossing interval beginning at $i$, the simultaneous products
+    \[
+        w\longmapsto (A^1_w,\ldots,A^g_w),
+        \qquad |w|=N-i,
+    \]
+    span the product algebra $\prod_j\MN{D_j}$. Then
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =
+        \bigvee_j\mathcal G_{N,L}(A_j),
+    \]
+    and the $N$-site ground spaces $G_N(A_j)=\mathcal G_{N,N}(A_j)$
+    have internal sum.
+    This is the equality-level consequence of the boundary-condition comparison
+    in \cite[Theorem~12, proof lines~1436--1451]{PerezGarcia2007Matrix}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:bnt_block_diagonal_boundary_representation_equality,
+        lem:block_diagonal_boundary_local_sum_mem,
+        thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+        lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+    For each $\psi$,
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality} gives
+    block-diagonal boundary conditions $X_j$.  For a boundary-crossing interval,
+    Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem} puts the sum of the
+    restricted block components in $\bigvee_jG_L(A_j)$.  The stated product-span
+    hypothesis and
+    Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison} give the
+    matrices $C^j_{i,\rho}$ satisfying
+    \[
+        A^j_\beta C^j_{i,\rho}
+        =
+        \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+    \]
+    Lemma~\ref{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+    then gives
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
+    \]
+    for every $j$. Applying
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality} again
+    gives the displayed equality and internality.
+\end{proof}
+
 \begin{lemma}[Trace-decomposition comparisons reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_trace_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition}


### PR DESCRIPTION
## Summary

This PR adds the equality-level parent-Hamiltonian consequence of the boundary-crossing PGVWC comparison argument.

- adds `MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison`
- records the corresponding blueprint lemma in the block-diagonal chain-equality section
- keeps the finite crossing-span hypothesis explicit and marks the remaining block-diagonal boundary-representation dependence as unfaithful, citing the existing paper-gap note

This is progress on the PGVWC07 boundary-comparison cleanup, but it does not close the issue because the source-faithful boundary representation and span-removal step are still open.

Refs #2971.
Refs #190.
Refs #1809.

## Validation

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

Note: I also ran `leanblueprint web`; it exited successfully in degraded mode but reported the local Python `leanblueprint` module import failure and renderer warnings, so I did not count it as a source validation check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only formalization and blueprint sync in parent-Hamiltonian theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds the **equality-level** block-diagonal periodic ground-space statement when boundary-crossing intervals satisfy a **word-tuple span** hypothesis instead of assuming the full \(C^j,D^j\) comparison up front.
> 
> In Lean, **`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison`** plugs `exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1` into the existing `of_bnt_c1_blockBoundary` reduction, concluding \(\mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j)\) plus **`iSupIndep`** on single-block \(N\)-site ground spaces. Docstrings keep the finite crossing-span assumption and the remaining **unfaithful** dependence on the block-diagonal boundary representation explicit (issue 2971).
> 
> The blueprint gains **`lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality`**, aligned with that theorem and citing the crossing PGVWC comparison chain (boundary representation, local sum membership, span → \(C^j_{i,\rho}\), injectivity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feec648276ad9877eb392c001b085101d65940e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->