### PR TITLE
doc(parent): record PGVWC07 ground-space equality wrapper

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -14,7 +14,7 @@ The word-indexed Pérez-García--Verstraete--Wolf--Cirac comparison
   \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho
 \]
 is the local boundary-crossing coordinate form of the \(C^j,D^j\) trace
-comparison from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof lines 1446--1451,
+comparison from arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451,
 after specializing \(D^j_\beta\) to \((\mu_j^N X_j)A^j_\beta\). The normalized
 \(E^j\)-calculation then implies the periodic-boundary single-block constraints
 and the finite-range block-diagonal periodic-boundary equality used here.
@@ -41,7 +41,7 @@ comparison, in the word-indexed boundary-crossing form
 then the single-block vectors \(\Gamma_N^{A_j}(\mu_j^NX_j)\) satisfy the
 periodic-boundary constraints.
 
-This records the source comparison in arXiv:quant-ph/0608197, Theorem 2blocks.2,
+This records the source comparison in arXiv:quant-ph/0608197, Theorem 12,
 proof lines 1446--1451, before the normalized \(E^j\)-calculation turns it
 into the boundary-crossing identities with \(E_{j,i,\rho}\).
 The words \(\beta\) and \(\rho\) are local coordinates for a boundary-crossing
@@ -54,7 +54,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1446--1456, and use it to discharge the currently assumed comparison;
 tracked in issue 2971. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
@@ -119,7 +119,7 @@ Pérez-García--Verstraete--Wolf--Cirac comparison gives matrices
 Combining this with the existing normalized \(E^j\)-calculation gives the
 periodic single-block constraints.
 
-This is the source comparison in arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
+This is the source comparison in arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1436--1451, specialized to the block-diagonal boundary conditions of
 arXiv:2011.12127, Section IV.C, lines 2126--2128.
 
@@ -278,6 +278,57 @@ theorem
           μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
           hNlarge hCrossingSpan hψ)
 
+/-- Boundary-crossing local constraints give the ground-space equality stated in
+Pérez-García--Verstraete--Wolf--Cirac, Theorem 12.
+
+The preceding theorem proves this equality together with an independence
+statement for the length-\(N\) single-block spaces. This theorem records only
+the equality conclusion
+\[
+  \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+  =
+  \bigvee_j\mathcal G_{N,L}(A_j),
+\]
+which is the ground-space assertion in the source theorem.
+
+**Scope restriction (crossing span):** The theorem assumes that the simultaneous
+block-word tuples of length \(N-i\) span the product algebra for each
+boundary-crossing interval beginning at \(i\). Removing this visible span
+hypothesis from the finite BNT range is part of the remaining PGVWC07
+boundary-comparison cleanup recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
+**Unfaithful:** This proof still relies on
+`exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`
+for the block-diagonal boundary representation of \(\psi\). Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
+derive that representation and the crossing comparison from the source
+boundary-condition argument; tracked in issue 2971. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hCrossingSpan :
+      ∀ i : Fin N, N < i.val + L → WordTupleSpanTop A (N - i.val)) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  exact
+    (chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+      hNlarge hCrossingSpan).1
+
 /-- The \(C^j,D^j\) boundary-condition comparison gives the block-diagonal
 periodic-boundary equality in the finite BNT range.
 
@@ -302,7 +353,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
 derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 2blocks.2, proof
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1446--1456, and use it to discharge the currently assumed comparison;
 tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -388,6 +388,30 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     gives the displayed equality and internality.
 \end{proof}
 
+\begin{lemma}[Boundary-crossing comparisons give the PGVWC07 ground-space equality]
+    \label{lem:bnt_block_diagonal_crossing_pgvwc_comparison_ground_space}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison}
+    \leanok
+    \uses{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}, one has
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =
+        \bigvee_j\mathcal G_{N,L}(A_j).
+    \]
+    This records only the ground-space equality conclusion of
+    \cite[Theorem~12]{PerezGarcia2007Matrix}; the independence of the
+    $N$-site spaces is a separate conclusion of
+    Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The claim is the equality part of
+    Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
+\end{proof}
+
 \begin{lemma}[Trace-decomposition comparisons reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_trace_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition}


### PR DESCRIPTION
## Summary
- Adds a source-facing wrapper theorem that keeps only the ground-space equality conclusion of PGVWC07 Theorem 12.
- Adds the matching blueprint lemma, separated from the stronger technical statement that also proves independence of the length-`N` single-block spaces.
- Replaces the remaining paper-local label `2blocks.2` in the comparison file by the bibliographic theorem number, Theorem 12.

## Checks
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Refs #2971
Refs #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and proof wiring only; no changes to computational logic or security-sensitive paths, with proofs delegating to existing lemmas.
> 
> **Overview**
> Aligns PGVWC07 citations in the block-diagonal comparison Lean file with **Theorem 12** (replacing the local label `2blocks.2`) and adds formal statements that mirror the paper’s boundary-crossing route to the block-diagonal ground-space equality.
> 
> New Lean theorems package the **crossing-span + PGVWC** hypotheses into `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison` (equality plus length-`N` independence) and a thin wrapper `chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison` that keeps only the ground-space equality from PGVWC07 Theorem 12. Matching blueprint lemmas in `ch13_parent_hamiltonian_block_diagonal_chain_equality.tex` split the full technical lemma from the source-facing ground-space-only lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c08d0eb7cc014981266fc547e23fab551ecabf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->