### PR TITLE
doc(parent): record PGVWC comparison ground-space wrapper

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -47,6 +47,12 @@ into the boundary-crossing identities with \(E_{j,i,\rho}\).
 The words \(\beta\) and \(\rho\) are local coordinates for a boundary-crossing
 window, not terminology of the source statement.
 
+**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
+assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+range derived from length-\(L_0\) block injectivity,
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
 **Unfaithful:** This proof relies on
 `exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
 which transitively uses the boundary-condition comparison at boundary-crossing
@@ -122,6 +128,12 @@ periodic single-block constraints.
 This is the source comparison in arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1436--1451, specialized to the block-diagonal boundary conditions of
 arXiv:2011.12127, Section IV.C, lines 2126--2128.
+
+**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
+assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+range derived from length-\(L_0\) block injectivity,
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
 **Unfaithful:** This proof still relies on
 `exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`
@@ -235,6 +247,12 @@ This is the equality-level form of PGVWC07, Theorem 12, proof lines 1436--1451,
 specialized to the block-diagonal boundary conditions of
 arXiv:2011.12127, Section IV.C, lines 2126--2128.
 
+**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
+assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+range derived from length-\(L_0\) block injectivity,
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
 **Scope restriction (crossing span):** The theorem assumes that the simultaneous
 block-word tuples of length \(N-i\) span the product algebra for each
 boundary-crossing interval beginning at \(i\). Removing this visible span
@@ -291,6 +309,12 @@ the equality conclusion
 \]
 which is the ground-space assertion in the source theorem.
 
+**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
+assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+range derived from length-\(L_0\) block injectivity,
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
 **Scope restriction (crossing span):** The theorem assumes that the simultaneous
 block-word tuples of length \(N-i\) span the product algebra for each
 boundary-crossing interval beginning at \(i\). Removing this visible span
@@ -346,6 +370,12 @@ block-injective crossing-window argument then give the periodic-boundary
 single-block constraints, and hence the block-diagonal periodic-boundary
 equality.
 
+**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
+assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+range derived from length-\(L_0\) block injectivity,
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
 **Unfaithful:** This proof relies on
 `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,
 which transitively uses the boundary-condition comparison at boundary-crossing
@@ -397,5 +427,72 @@ theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_compa
         exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
           μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
           hNlarge hψ (fun X hψX => hComparison hψ X hψX))
+
+/-- The \(C^j,D^j\) boundary-condition comparison gives the ground-space
+equality stated in PGVWC07, Theorem 12.
+
+The preceding theorem proves this equality together with an independence
+statement for the length-\(N\) single-block spaces. This theorem records only
+the equality conclusion
+\[
+  \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+  =
+  \bigvee_j\mathcal G_{N,L}(A_j),
+\]
+under the assumed word-indexed \(C^j,D^j\) comparison.
+
+**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
+assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+range derived from length-\(L_0\) block injectivity,
+\((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
+
+**Unfaithful:** This proof relies on
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
+derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
+boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
+lines 1446--1456, and use it to discharge the currently assumed comparison;
+tracked in issue 2971. -/
+theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hComparison :
+      ∀ {ψ : NSiteSpace d N},
+        ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+          ∃ C : ∀ (j : Fin r) (_ : Fin N),
+            (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+            ∀ (j : Fin r) (i : Fin N),
+              N < i.val + L →
+                ∀ ρ : Fin (N - L) → Fin d,
+                  ∀ β : Fin (i.val + L - N) → Fin d,
+                    evalWord (A j) (List.ofFn β) * C j i ρ =
+                      (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                        evalWord (A j) (List.ofFn ρ)) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+      ⨆ j : Fin r, chainGroundSpace (A j) L N := by
+  exact
+    (chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+      hNlarge hComparison).1
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -331,6 +331,33 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
+\begin{lemma}[$C^j,D^j$ comparisons give the PGVWC07 ground-space equality]
+    \label{lem:bnt_block_diagonal_pgvwc_comparison_ground_space}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison}
+    \leanok
+    \uses{lem:bnt_block_diagonal_pgvwc_comparison_equality}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_pgvwc_comparison_equality}, one has
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =
+        \bigvee_j\mathcal G_{N,L}(A_j).
+    \]
+    This records only the ground-space equality conclusion obtained from the
+    \(C^j,D^j\) boundary-condition comparison in
+    \cite[Theorem~12, proof lines~1446--1456]{PerezGarcia2007Matrix}; the
+    independence of the \(N\)-site spaces is a separate conclusion of
+    Lemma~\ref{lem:bnt_block_diagonal_pgvwc_comparison_equality}.
+    The statement is still in the length-$L_0$ injectivity range displayed in
+    that lemma, not the shorter source range of PGVWC07.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The claim is the equality part of
+    Lemma~\ref{lem:bnt_block_diagonal_pgvwc_comparison_equality}.
+\end{proof}
+
 \begin{lemma}[$C^j,D^j$ comparisons at boundary-crossing intervals reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison}
@@ -355,8 +382,17 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \]
     and the $N$-site ground spaces $G_N(A_j)=\mathcal G_{N,N}(A_j)$
     have internal sum.
-    This is the equality-level consequence of the boundary-condition comparison
-    in \cite[Theorem~12, proof lines~1436--1451]{PerezGarcia2007Matrix}.
+    The present formal statement is the equality-level consequence of the
+    boundary-condition comparison in
+    \cite[Theorem~12, proof lines~1436--1451]{PerezGarcia2007Matrix} in the
+    length-$L_0$ injectivity range
+    \[
+        L\ge (L_0+1)+3(g-1)(L_0+1)+1.
+    \]
+    The source theorem has the shorter bound
+    \[
+        L\ge 3(g-1)(L_0+1)+1.
+    \]
 \end{lemma}
 
 \begin{proof}
@@ -404,6 +440,8 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \cite[Theorem~12]{PerezGarcia2007Matrix}; the independence of the
     $N$-site spaces is a separate conclusion of
     Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
+    The statement is still in the length-$L_0$ injectivity range displayed in
+    that lemma, not the shorter source range of PGVWC07.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
Summary:
- Adds `MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison`, the equality-only projection of the existing `C^j,D^j` comparison theorem.
- Adds blueprint label `lem:bnt_block_diagonal_pgvwc_comparison_ground_space`.
- Marks the present length-`L₀` injectivity range separately from the shorter PGVWC07 source range.

Source:
PGVWC07 Theorem 12, proof lines 1446-1456, together with the block-diagonal boundary-condition discussion in arXiv:2011.12127, Section IV.C, lines 2126-2128.

Validation:
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`

This does not close #2971: the block-diagonal boundary representation and the derivation of the PGVWC07 `C^j,D^j,E^j` comparison from the source hypotheses are still open.

Refs #2971
Refs #190
Refs #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and thin theorem wrappers only; no change to proof logic beyond extracting an existing conclusion.
> 
> **Overview**
> Adds **`chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison`**, which states only the block-diagonal ground-space equality \(\mathcal G_{N,L}(\bigoplus_j\mu_jA_j)=\bigvee_j\mathcal G_{N,L}(A_j)\) under the assumed \(C^j,D^j\) comparison—by projecting the `.1` component of the existing equality-plus-independence theorem.
> 
> The blueprint gains matching lemma **`lem:bnt_block_diagonal_pgvwc_comparison_ground_space`**. Several PGVWC-related Lean docstrings and blueprint lemmas now explicitly note that formal statements use the **length-\(L_0\) injectivity** range on \(L\), not PGVWC07’s shorter source bound (with the comparison recorded in the paper-gaps doc).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4835e8f03eb0603c773e4dc399f07b069bc564db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->