### PR TITLE
doc(parent): replace PGVWC internal labels

### DIFF
--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -328,7 +328,7 @@ then the same equation holds after replacing letters by words of length \(L\):
   \sum_\rho A_\rho A_\rho^\dagger=I.
 \]
 This is the iterated form of the normalization used in arXiv:quant-ph/0608197,
-Theorem 2blocks.2, proof line 1450. -/
+Theorem 12, proof line 1450. -/
 theorem sum_evalWord_mul_conjTranspose_evalWord
     (A : MPSTensor d D)
     (hRight : ∑ i : Fin d, A i * (A i)ᴴ = 1) :

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -185,7 +185,7 @@ theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital
 /-- Finite-length block injectivity gives the periodic-boundary inclusion into
 \(S_N\), and \(S_N\) is an internal direct sum of local block ground spaces.
 
-**Unfaithful:** This proof relies on the finite-\(C_1\) inclusion and
+**Unfaithful:** This proof relies on the finite-length-injectivity inclusion and
 internal-direct-sum conclusions above, which transitively use the
 boundary-condition comparison at boundary-crossing windows rather than deriving
 it from arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -56,10 +56,11 @@ theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
     hUnital
 
-/-- Condition-C1 form of the PGVWC one-step block-intersection identity.
+/-- Length-\(L_0\) injectivity form of the PGVWC one-step block-intersection
+identity.
 
-Under a common Condition C1 length \(L_0\), the source length is \(L_0+1\).
-Writing \(S_m=\bigvee_j G_m(A_j)\), the identity is
+Assume each block is injective at a common length \(L_0\). At the source length
+\(L_0+1\), writing \(S_m=\bigvee_j G_m(A_j)\), the identity is
 \[
   \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}.
 \]
@@ -168,15 +169,17 @@ theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital
   exact wordTupleSpanTop_of_ge_of_common_blockInjective_of_unital_of_pairBlockSeparatingWords
     A hBlk hUnital hPair (by simpa [S] using hn)
 
-/-- Condition-C1 form of the BNT product span at all sufficiently large lengths.
+/-- Length-\(L_0\) injectivity form of the BNT product span at all sufficiently
+large lengths.
 
-Assume Condition C1 for every block at the common length \(L_0\) and the
+Assume every block is injective at the common length \(L_0\) and the
 normalization
 \[
   \sum_a A^j_aA^{j\dagger}_a=I.
 \]
-The normalization propagates Condition C1 from \(L_0\) to \(L_0+1\) and
-\(3(L_0+1)\). The BNT direct-sum argument at the source length \(L_0+1\)
+The normalization propagates this finite-length injectivity from \(L_0\) to
+\(L_0+1\) and \(3(L_0+1)\). The BNT direct-sum argument at the source length
+\(L_0+1\)
 then gives the simultaneous product span for every
 \[
   n\ge (L_0+1)+(r-1)\,3(L_0+1).
@@ -242,8 +245,8 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
     (wordTupleSpanTop_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
 
-/-- Condition-C1 form of the internal-direct-sum conclusion for the block local
-spaces.
+/-- Length-\(L_0\) injectivity form of the internal-direct-sum conclusion for
+the block local spaces.
 
 **Unfaithful:** This proof relies on
 `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, which transitively uses
@@ -307,8 +310,8 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
     hUnital
 
-/-- Condition-C1 form of the one-step block-intersection identity at every
-length above the BNT block-separation bound.
+/-- Length-\(L_0\) injectivity form of the one-step block-intersection identity
+at every length above the BNT block-separation bound.
 
 **Unfaithful:** This proof relies on
 `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, which transitively uses
@@ -386,10 +389,11 @@ theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital
     pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn⟩
 
-/-- Condition-C1 form of the large-length block intersection as an internal
-direct sum.
+/-- Length-\(L_0\) injectivity form of the large-length block intersection as
+an internal direct sum.
 
-**Unfaithful:** This proof relies on the finite-\(C_1\) internal-direct-sum and
+**Unfaithful:** This proof relies on the finite-length-injectivity
+internal-direct-sum and
 block-intersection conclusions above, which transitively use the
 periodic-boundary coordinate comparison rather than deriving it from
 arXiv:2011.12127,
@@ -519,8 +523,8 @@ theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital
   exact pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
     A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn
 
-/-- Condition-C1 form of the eventual block-intersection identity without a
-separate one-site injectivity assumption.
+/-- Length-\(L_0\) injectivity form of the eventual block-intersection identity
+without a separate one-site injectivity assumption.
 
 **Unfaithful:** This proof relies on
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, which

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -32,7 +32,7 @@ cyclic norm-compression estimates as sufficient stronger hypotheses. For a tenso
 in block-injective canonical form
 $A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$,
 \cite[Theorem~IV.16]{Cirac2021Matrix}
-(\cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}) states that the periodic
+and \cite[Theorem~12]{PerezGarcia2007Matrix} state that the periodic
 parent-Hamiltonian ground space is spanned by the vectors
 $\{V^{(N)}(A_j)\}$. The sections below record the open-segment recursion and the
 conditional reductions for the boundary-condition comparison in the periodic

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -395,7 +395,7 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
         A^j_\beta C^j_\rho=A^j_\beta E^jA^j_\rho .
     \]
     This is the calculation in
-    \cite[Theorem~\emph{2blocks.2}, proof lines~1446--1451]{PerezGarcia2007Matrix}, with
+    \cite[Theorem~12, proof lines~1446--1451]{PerezGarcia2007Matrix}, with
     the adjoint on \(A^j_\rho\) required by the displayed normalization.
 \end{lemma}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -30,7 +30,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
         \exists n\ge1,\; V^{(n)}(A_j)\ne V^{(n)}(A_k).
     \]
     Let $L_0$ be a common injectivity length. Assume the multi-block range used
-    in \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}:
+    in \cite[Theorem~12]{PerezGarcia2007Matrix}:
     \[
         g\ge2,
         \qquad
@@ -43,7 +43,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
         S_m:=\bigoplus_{j=1}^gG_m(A_j).
     \]
     The open-segment recursion in
-    \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix} says that, for every
+    \cite[Theorem~12]{PerezGarcia2007Matrix} says that, for every
     $m\ge L$,
     \[
         \C^d\otimes S_m
@@ -98,7 +98,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
         |i_1\cdots i_{m+1}\rangle.
     \]
     The direct-sum separation lemma used in
-    \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}, together with injectivity
+    \cite[Theorem~12]{PerezGarcia2007Matrix}, together with injectivity
     of each block, gives the blockwise matrix identity
     \[
         A^j_{i_{m+1}} C^j_{i_1}
@@ -112,7 +112,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     % Local fix (PGVWC07 printed formula): this correction is recorded in
     % docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex.
     The printed formula in
-    \cite[Theorem~\emph{2blocks.2}, proof lines~1449--1451]{PerezGarcia2007Matrix} omits the
+    \cite[Theorem~12, proof lines~1449--1451]{PerezGarcia2007Matrix} omits the
     adjoint on $A^j_a$; the adjointed form is forced by the displayed
     normalization below.
     In the normalization used in the source proof,
@@ -195,7 +195,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     $S=\bigoplus_j\mathcal G_L^{A^j}$.
     The passage from the open-segment recursion to the $N$-site ring is the
     separate boundary-condition comparison in the periodic ring in
-    \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}.
+    \cite[Theorem~12]{PerezGarcia2007Matrix}.
     % This periodic-boundary comparison is not the inclusion
     % $G_N(A_j)\subseteq\mathcal G_{N,L}(A_j)$, which fails for a general
     % open-boundary matrix crossing the periodic boundary.
@@ -234,7 +234,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     \cite[lines~2126--2128]{Cirac2021Matrix}.
 \end{lemma}
 % The ground-space theorem below uses the conservative length range of
-% \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}.
+% \cite[Theorem~12]{PerezGarcia2007Matrix}.
 
 \begin{proof}
     \notready
@@ -393,7 +393,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
     \notready
     \uses{thm:chain_ground_space_eq_mpv_normal}
     The length hypotheses are the conservative range used in
-    \cite[Theorem~\emph{2blocks.2}]{PerezGarcia2007Matrix}. The shorter range stated in
+    \cite[Theorem~12]{PerezGarcia2007Matrix}. The shorter range stated in
     \cite[lines~2126--2128]{Cirac2021Matrix} requires the strengthened
     block-diagonal re-growing step. These hypotheses do not by themselves give
     the displayed boundary-condition comparison in the periodic ring. That


### PR DESCRIPTION
## Summary
- cite PGVWC07 Theorem 12 by its published theorem number in the parent-Hamiltonian blueprint, instead of the source-internal label `2blocks.2`
- rewrite parent-Hamiltonian docstring headings from "Condition-C1 form" to the mathematical hypothesis of finite-length injectivity at a common length \(L_0\)
- keep the existing unfaithful/scope markers, but state their finite-length hypotheses without local shorthand

## Verification
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe cache get`
- `lake build TNLean.MPS.Core.Blocking TNLean.MPS.ParentHamiltonian.BNTBlockIntersection TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain`
- `git diff --check`

Refs #190.
Refs #460.
Refs #2971.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX citation edits only; no logic, APIs, or proof terms change.
> 
> **Overview**
> This PR **aligns parent-Hamiltonian documentation** with published PGVWC07 numbering and clearer mathematical wording, without changing Lean proofs or theorem names.
> 
> **Blueprint (ch. 13):** Every citation of the internal label `Theorem 2blocks.2` in `\cite{PerezGarcia2007Matrix}` is replaced by **Theorem 12**, including the main chapter intro, trace-consequence lemmas, and BNT periodic-boundary consequences. The Cirac review is cited alongside PGVWC for the periodic ground-space statement where the intro previously only referenced the internal theorem name.
> 
> **Lean docstrings:** In `Blocking.lean`, the word-normalization lemma comment now points to **Theorem 12** (proof line 1450) instead of `2blocks.2`. In `BNTBlockIntersection.lean` and `BNTBlockDiagonalChain.lean`, headings and narratives that said **"Condition-C1 form"** are rewritten to describe **length-\(L_0\) injectivity** (common finite injectivity at \(L_0\), propagation via normalization, source length \(L_0+1\)). Unfaithful markers are unchanged in substance but refer to **finite-length-injectivity** hypotheses instead of "finite-\(C_1\)" shorthand.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee9dc93d26d2a986f5286fcbc1e8f51588da741e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->