### PR TITLE
doc(blueprint): hide MPDO draft chapters

### DIFF
--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -87,8 +87,8 @@ symmetry gauges, projective bond representations, and string-order criteria;
 its Kraus-mixing step appeals only to the later channel-representation chapter,
 not to any additional input for the Fundamental Theorem.
 Parent Hamiltonians, correlations, examples, channel representations, normal
-forms, quantum dynamical semigroups, operator convexity, entropy, and matrix
-product operators and density operators are then collected.
+forms, quantum dynamical semigroups, operator convexity, and entropy are then
+collected.
 A later draft treats the direct Fundamental Theorem for periodically repeated
 tensors in irreducible form, together with the compatibility theorems for
 physical-index rotation (Definition~\ref{def:rotate_physical} in
@@ -96,7 +96,8 @@ Chapter~\ref{ch:symmetry}).
 % Maintainer note: the rotation definition is internal bookkeeping for the
 % periodic MPS material, not an external-paper input or part of the Molnar
 % algebraic-FT chapter.
-The algebraic and PEPS draft chapters remain in the repository but are omitted
-from the generated blueprint while their statements are being stabilized.
+The matrix-product-operator, periodic, algebraic, and PEPS draft chapters remain
+in the repository but are omitted from the generated blueprint while their
+statements are being stabilized.
 These later topics use the Fundamental Theorem, or develop later
 finite-dimensional channel theory, rather than enter its proof.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -74,7 +74,6 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \label{def:blockwise_product_word_span}
     \lean{MPSTensor.WordTupleSpanTop}
     \leanok
-    \uses{rem:word_tuple_span_top}
     For a fixed blocked length $m$, the fixed-length form of the
     block-injective canonical-form condition is
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex
@@ -309,7 +309,7 @@ $V^{(N)}(A_j)$ associated to the chosen basis of normal tensors:
 \begin{lemma}[Block-diagonal boundary reduction from block-separating equations]
     \label{lem:conditional_block_split_from_bnt_block_separation}
     \notready
-    \uses{def:bnt, rem:word_tuple_span_top,
+    \uses{def:bnt, def:blockwise_product_word_span,
         def:parent_hamiltonian_ground_space_bnt, def:bnt_span}
     Let $A^i=\bigoplus_j\mu_j A_j^i$ be in block-injective canonical form, with
     $A_1,\ldots,A_g$ a basis of normal tensors.  Assume $1 < L$ and

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -18,8 +18,8 @@
 \input{chapter/ch18_operator_convexity}
 \input{chapter/ch19_entropy}
 \input{chapter/ch19_entropy_corollaries}
-\input{chapter/ch20_mpdo}
-\input{chapter/ch21_mpdo_rfp}
+% \input{chapter/ch20_mpdo}
+% \input{chapter/ch21_mpdo_rfp}
 % \input{chapter/ch22_periodic_ft}
 % \input{chapter/ch23_algebraic_ft}
 % \input{chapter/ch24_peps_ft}


### PR DESCRIPTION
### Motivation

- The MPDO and RFP draft chapters (`ch20_mpdo`, `ch21_mpdo_rfp`) are still being stabilized; including them in the generated blueprint publishes statements that may change, which can mislead readers of the public output.
- Hiding these chapters from the built blueprint (while keeping the source files in the repository) keeps the reader-facing output focused on completed material.

### Description

- `blueprint/src/content.tex`: commented out the two `\input` lines for `ch20_mpdo` and `ch21_mpdo_rfp`, excluding them from the generated blueprint. The source `.tex` files remain in the repository.
- `blueprint/src/chapter/ch01_intro.tex`: updated the introduction to inform readers that the matrix-product-operator, periodic, algebraic, and PEPS draft chapters are currently omitted from the generated blueprint while their statements are being stabilized.

### Testing

- `leanblueprint web` was run successfully.
- `git diff --check` passed.
- `leanblueprint checkdecls` was not run (the generated `blueprint/lean_decls` file was absent in the fresh worktree; a full project build is required first). Blueprint lint CI (`lint-blueprint.yml`) will validate label references on push.

---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint inclusion only; no Lean or runtime behavior changes.
>
> **Overview**
> **Stops including the MPDO draft chapters** (`ch20_mpdo`, `ch21_mpdo_rfp`) in the built blueprint by commenting their `\input` lines in `content.tex`; the source files stay in the repo.
>
> The **introduction** is updated so the post–Fundamental Theorem topic list no longer promises matrix-product operators/density operators in the published outline, and readers are told that **matrix-product-operator, periodic, algebraic, and PEPS** draft chapters are omitted from the generated blueprint while statements are being stabilized.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 070d8304f228add9eedbf6c5f3b6e177d30e3b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint inclusion only; no Lean or runtime behavior changes.
> 
> **Overview**
> **Excludes the MPDO draft chapters** from the built blueprint by commenting out `\input` for `ch20_mpdo` and `ch21_mpdo_rfp` in `content.tex`; the `.tex` sources stay in the repo.
> 
> The **introduction** no longer lists matrix-product operators/density operators among the published post–FT topics, and now states that **matrix-product-operator, periodic, algebraic, and PEPS** draft chapters are omitted from the generated blueprint while statements stabilize.
> 
> A **blueprint dependency fix** in the parent-Hamiltonian material replaces `\uses{rem:word_tuple_span_top}` (in the hidden MPDO chapter) with `\uses{def:blockwise_product_word_span}` on one lemma, and drops an obsolete `\uses` on the fixed-length block-injective definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7682f41e4da03a597cad97ffa4fed41c9336dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->