### PR TITLE
doc(parent): distinguish PGVWC07 indices from cut words

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -16,7 +16,7 @@ block-diagonal boundary conditions used in arXiv:2011.12127, Section IV.C,
 lines 2126--2128.
 
 The paper writes the two decompositions with \(C^j_{i_1}\) and
-\(D^j_{i_{m+1}}\). Below, \(\beta\) and \(\alpha\) are the two pieces of the
+\(D^j_{i_{m+1}}\). Below, \(\beta\) and \(w\) are the two pieces of the
 local word after opening the cut, while \(\rho\) is the complementary outside
 word on the sites not lying in the local interval.
 -/

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -14,6 +14,11 @@ cut.  It is the local coefficient form of the two trace decompositions in
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1444, specialized to the
 block-diagonal boundary conditions used in arXiv:2011.12127, Section IV.C,
 lines 2126--2128.
+
+The paper writes the two decompositions with \(C^j_{i_1}\) and
+\(D^j_{i_{m+1}}\). Below, \(\beta\) and \(\alpha\) are the two pieces of the
+local word after opening the cut, while \(\rho\) is the complementary outside
+word on the sites not lying in the local interval.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -18,6 +18,11 @@ comparison from arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451,
 after specializing \(D^j_\beta\) to \((\mu_j^N X_j)A^j_\beta\). The normalized
 \(E^j\)-calculation then implies the periodic-boundary single-block constraints
 and the finite-range block-diagonal periodic-boundary equality used here.
+
+The source proof writes this comparison with site-indexed matrices
+\(C^j_{i_1}\), \(D^j_{i_{m+1}}\), and the derived matrix \(E^j\). The words
+\(\beta\) and \(\rho\) below are cut-adapted coordinates for the same
+periodic-boundary comparison, not additional source terminology.
 -/
 
 open scoped Matrix BigOperators
@@ -127,7 +132,10 @@ periodic single-block constraints.
 
 This is the source comparison in arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1436--1451, specialized to the block-diagonal boundary conditions of
-arXiv:2011.12127, Section IV.C, lines 2126--2128.
+arXiv:2011.12127, Section IV.C, lines 2126--2128. Here \(\rho\) is the
+complementary outside word produced by opening the cyclic interval;
+arXiv:quant-ph/0608197 writes the same step with the boundary indices \(i_1\)
+and \(i_{m+1}\).
 
 **Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
 assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
@@ -365,10 +373,12 @@ word-indexed matrix identity
 \]
 for every boundary-crossing interval, local word \(\beta\) before the cut,
 and outside word \(\rho\), with \(D^j_\beta\) already specialized to
-\((\mu_j^NX_j)A^j_\beta\). The normalized \(E^j\)-calculation and the
-block-injective crossing-window argument then give the periodic-boundary
-single-block constraints, and hence the block-diagonal periodic-boundary
-equality.
+\((\mu_j^NX_j)A^j_\beta\). The words \(\beta\) and \(\rho\) are formal
+word coordinates for the opened boundary comparison, refining the source
+end-site notation rather than replacing it. The normalized \(E^j\)-calculation
+and the block-injective crossing-window argument then give the
+periodic-boundary single-block constraints, and hence the block-diagonal
+periodic-boundary equality.
 
 **Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
 assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -374,8 +374,9 @@ word-indexed matrix identity
 for every boundary-crossing interval, local word \(\beta\) before the cut,
 and outside word \(\rho\), with \(D^j_\beta\) already specialized to
 \((\mu_j^NX_j)A^j_\beta\). The words \(\beta\) and \(\rho\) are formal
-word coordinates for the opened boundary comparison, refining the source
-end-site notation rather than replacing it. The normalized \(E^j\)-calculation
+word coordinates for the opened boundary comparison; they reindex the source
+end-site comparison by blocked words rather than replacing the source notation.
+The normalized \(E^j\)-calculation
 and the block-injective crossing-window argument then give the
 periodic-boundary single-block constraints, and hence the block-diagonal
 periodic-boundary equality.

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -14,6 +14,11 @@ derive that trace-decomposition equality from the \(C^j,D^j\) comparison after
 specializing \(D^j_\beta\) to the block-diagonal boundary expression
 \((\mu_j^N X_j)A^j_\beta\). The normalized \(E^j\)-calculation is then supplied
 by the downstream complementary-word lemmas.
+
+The variables \(\beta\), \(\rho\), and \(w\) are not names from the paper.
+They are the three word coordinates obtained by opening a boundary-crossing
+cyclic interval; the source proof uses the boundary indices \(i_1\) and
+\(i_{m+1}\) for the corresponding matrices \(C^j\) and \(D^j\).
 -/
 
 open scoped Matrix BigOperators
@@ -35,7 +40,7 @@ boundary-crossing trace decompositions
   =
   \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr)
 \]
-hold for every boundary-crossing interval \(i\), wrapped word \(\beta\),
+hold for every boundary-crossing interval \(i\), cut word \(\beta\),
 complementary word \(\rho\), and word \(w\) of length \(m\), then the
 single-block vectors
 \[

--- a/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 
 /-!
-# PGVWC07 \(C^j,D^j,E^j\) identities from trace decompositions
+# \(C^j,D^j,E^j\) matrix identities from trace decompositions
 
 This file derives the word-valued \(C^j,D^j,E^j\) matrix identities from
 matching left and right block trace decompositions in arXiv:quant-ph/0608197,

--- a/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
@@ -5,11 +5,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty
 
 /-!
-# PGVWC C-D-E identities from trace decompositions
+# PGVWC07 \(C^j,D^j,E^j\) identities from trace decompositions
 
 This file derives the word-valued \(C^j,D^j,E^j\) matrix identities from
 matching left and right block trace decompositions in arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1451.
+
+In the source proof the auxiliary matrices are indexed by the boundary indices
+\(i_1\) and \(i_{m+1}\). The variables \(\beta\) and \(\rho\) below are the
+cut-adapted word coordinates used to express the same comparison after a
+periodic interval has been opened at the chosen cut.
 
 The formula for \(E^j\) uses the adjointed word product
 \[
@@ -33,7 +38,7 @@ Assume the right trace decomposition has
 \[
   D^j_\beta=X_jA^j_\beta .
 \]
-If the two trace decompositions agree for every wrapped word \(\beta\),
+If the two trace decompositions agree for every cut word \(\beta\),
 complementary word \(\rho\), and middle word \(w\), then for every block \(j\)
 there is a matrix
 \[
@@ -45,7 +50,9 @@ such that
   A^j_\beta C^j_\rho=A^j_\beta E^jA^j_\rho .
 \]
 This is the word-valued form of arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1451.
+lines 1446--1451. The source notation is \(C^j_{i_1}\) and
+\(D^j_{i_{m+1}}\); the parameters \(\beta\) and \(\rho\) are the local word
+coordinates used here to state the same identity for an opened cyclic interval.
 
 **Local fix (adjoint correction):** The source line writes
 \(E^j=\sum_k C^j_kA^j_k\), while the normalization step uses

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -594,6 +594,8 @@ in both cases.
         \rho=\tau_a\cdots\tau_{i-1},\qquad
         \alpha=\sigma_0\cdots\sigma_{N-i-1}.
     \]
+    These are the formal cut-adapted word coordinates used to compare with
+    the source decompositions involving $C^j_{i_1}$ and $D^j_{i_{m+1}}$.
     If
     \[
         \sum_j
@@ -646,8 +648,9 @@ in both cases.
         \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
     \]
     This theorem is the fixed cyclic-interval coordinate form of the
-    Perez-Garcia--Verstraete--Wolf--Cirac comparison; it does not assert the
-    full periodic-boundary ground-space statement.
+    Perez-Garcia--Verstraete--Wolf--Cirac comparison
+    $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$; it does not assert
+    the full periodic-boundary ground-space statement.
 \end{theorem}
 
 \begin{proof}
@@ -1225,6 +1228,8 @@ in both cases.
         =
         \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
     \]
+    This is the formal word-coordinate counterpart of the source $C^j,D^j$
+    comparison, with $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     Then, for every block $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -10,7 +10,7 @@ hypotheses explicitly include a boundary inclusion, a block-diagonal boundary
 representation, or periodic-boundary membership for the single-block states; in
 the source theorem these conditions are obtained from the boundary-condition
 comparison in the periodic ring. The source proof
-\cite{PerezGarcia2007MPSReps} writes this comparison with $C^j_{i_1}$,
+\cite{PerezGarcia2007Matrix} writes this comparison with $C^j_{i_1}$,
 $D^j_{i_{m+1}}$, and the normalized matrix $E^j$; the symbols $\beta$ and
 $\rho$ below are formal word variables introduced after opening the periodic
 cut, not additional terminology from the paper. In these

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -9,16 +9,18 @@ conditional reductions toward that statement. Their
 hypotheses explicitly include a boundary inclusion, a block-diagonal boundary
 representation, or periodic-boundary membership for the single-block states; in
 the source theorem these conditions are obtained from the boundary-condition
-comparison in the periodic ring. In the word-indexed versions below, $\beta$ is
-the wrapped head word of length $i+L-N$ at the periodic cut, while $\rho$ is the
-complementary outside word of length $N-L$ on the remaining sites. The source
-comparison is the matrix identity
+comparison in the periodic ring. The source proof
+\cite{PerezGarcia2007MPSReps} writes this comparison with $C^j_{i_1}$,
+$D^j_{i_{m+1}}$, and the normalized matrix $E^j$; the symbols $\beta$ and
+$\rho$ below are formal word variables introduced after opening the periodic
+cut, not additional terminology from the paper. In these
+coordinates the source comparison becomes
 \[
     A^j_\beta C^j_{i,\rho}
     =
     \bigl(\mu_j^N X_j A^j_\beta\bigr)A^j_\rho,
 \]
-which is the word-indexed form of
+which is the formal word-coordinate counterpart of
 $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$ with
 $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
 

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -472,6 +472,10 @@ for every block $j$ in the block-injective range.\footnote{Lean declaration:
 
 The word-indexed \(C^j,D^j\) route is closer to the proof of
 \cite[Theorem~12]{PerezGarcia2007MPSReps}.
+The words \(\beta\) and \(\rho\) are local word coordinates introduced after
+opening and blocking the cyclic boundary comparison; they refine the source
+end-site notation \(i_1,i_{m+1}\), and are not additional hypotheses or
+terminology from the paper.
 For a fixed boundary-crossing interval starting at site \(i\), the local
 block-sum constraint and the word-tuple span of the wrapped tail word of
 length \(N-i\) now give matrices

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -473,9 +473,9 @@ for every block $j$ in the block-injective range.\footnote{Lean declaration:
 The word-indexed \(C^j,D^j\) route is closer to the proof of
 \cite[Theorem~12]{PerezGarcia2007MPSReps}.
 The words \(\beta\) and \(\rho\) are local word coordinates introduced after
-opening and blocking the cyclic boundary comparison; they refine the source
-end-site notation \(i_1,i_{m+1}\), and are not additional hypotheses or
-terminology from the paper.
+opening and blocking the cyclic boundary comparison; they reindex the source
+end-site comparison \(i_1,i_{m+1}\) by blocked words, and are not additional
+hypotheses or terminology from the paper.
 For a fixed boundary-crossing interval starting at site \(i\), the local
 block-sum constraint and the word-tuple span of the wrapped tail word of
 length \(N-i\) now give matrices


### PR DESCRIPTION
### Motivation

- The PGVWC07 boundary-comparison route for the block-diagonal parent-Hamiltonian theorem uses source notation ($C^j_{i_1}$, $D^j_{i_{m+1}}$, $E^j$), while the formalization uses word variables after opening the periodic cut.
- A reader needs a precise dictionary between the source end-site comparison and the formal word-coordinate comparison, as tracked in #2971.
- The source reference is arXiv:quant-ph/0608197, Theorem 12, proof lines 1436-1456, together with arXiv:2011.12127, Section IV.C, lines 2126-2128.

### Description

- Updated Lean module docstrings in `PGVWCCDEIdentities.lean`, `BNTBlockDiagonalPGVWCComparison.lean`, `BNTBlockDiagonalTraceDecomposition.lean`, and `BNTBlockDiagonalCrossingTrace.lean` to state how the source matrices $C^j_{i_1}$, $D^j_{i_{m+1}}$, and $E^j$ are compared with the formal word variables.
- Clarified that $\beta$ and the tail word are the two local-word pieces after opening the cut, while $\rho$ is the complementary outside word. In the blueprint this tail word is denoted $\alpha$; in `BNTBlockDiagonalCrossingTrace.lean` it is denoted $w$.
- Updated the parent-Hamiltonian blueprint prose and `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` to distinguish source terminology from formal coordinates.
- No theorem statement, proof, or `\leanok` tag is changed. The proof gap tracked in #2971 remains open.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

Refs #2971.
Refs #190.