### PR TITLE
feat(MPS/Periodic/Overlap): carry cyclic sector corner letters

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.Periodic.Overlap.Case2
+import TNLean.MPS.Periodic.Overlap.Case3Transport
 import TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain
 import TNLean.MPS.Chain.OneSidedInverse
 
@@ -35,213 +35,6 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-! ## Case 3: Same period, sector match → gauge-equivalent (Appendix A, main case) -/
-
-/-! ### One-site rotation covariance of the cross sector overlap
-
-The translation-operator step of arXiv:1708.00029, Appendix A (lines 985--1002)
-moves the matched sector pair `(u, v)` to `(u+1, v+1)`.  Formalized below as a
-single physical-site cyclic rotation of the underlying word: the single-site
-off-diagonal shift `P_{k+1} A^i = A^i P_k` (eq:Aoffdiag, supplied by
-`offDiag_shift_of_adjoint_cyclic_shift`) carries the cyclic index forward by one
-per site, and the trace is invariant under cyclic rotation of the word, so the
-cross overlap is unchanged by the simultaneous shift. -/
-
-/-- One-site cyclic rotation of a configuration of length `L'+1`:
-move the last letter to the front. -/
-def rotateCfg {d L' : ℕ} : (Fin (L' + 1) → Fin d) ≃ (Fin (L' + 1) → Fin d) where
-  toFun σ := Fin.cons (σ (Fin.last L')) (Fin.init σ)
-  invFun τ := Fin.snoc (Fin.tail τ) (τ 0)
-  left_inv σ := by
-    funext j
-    refine Fin.lastCases ?_ ?_ j
-    · simp [Fin.snoc_last, Fin.cons_zero]
-    · intro i
-      simp [Fin.snoc_castSucc, Fin.init]
-  right_inv τ := by
-    funext j
-    refine Fin.cases ?_ ?_ j
-    · simp [Fin.cons_zero, Fin.snoc_last]
-    · intro i
-      simp [Fin.cons_succ, Fin.tail]
-
-/-- Word evaluation of the rotated configuration pulls the last letter to the front. -/
-private lemma evalWord_ofFn_rotateCfg {L' : ℕ} (A : MPSTensor d D)
-    (σ : Fin (L' + 1) → Fin d) :
-    evalWord A (List.ofFn (rotateCfg σ)) =
-      A (σ (Fin.last L')) * evalWord A (List.ofFn (Fin.init σ)) := by
-  simp only [rotateCfg, Equiv.coe_fn_mk, List.ofFn_cons, evalWord_cons]
-
-/-- Word evaluation of the original configuration pulls the last letter to the right. -/
-private lemma evalWord_ofFn_eq_init_mul_last {L' : ℕ} (A : MPSTensor d D)
-    (σ : Fin (L' + 1) → Fin d) :
-    evalWord A (List.ofFn σ) =
-      evalWord A (List.ofFn (Fin.init σ)) * A (σ (Fin.last L')) := by
-  rw [List.ofFn_succ']
-  rw [show (List.ofFn fun i => σ (Fin.castSucc i)) = List.ofFn (Fin.init σ) from rfl]
-  rw [List.concat_eq_append, evalWord_append]
-  simp [evalWord_cons, evalWord_nil]
-
-/-- **Per-configuration trace covariance** under one-site rotation (eq:Aoffdiag,
-arXiv:1708.00029 lines 985--1002).  Given the single-site off-diagonal shift
-`P (k+1) * A i = A i * P k`, the projector-weighted trace at index `k+1` of the
-rotated word equals the projector-weighted trace at index `k` of the original
-word. -/
-private lemma trace_proj_evalWord_rotateCfg {L' m : ℕ} [NeZero m] (A : MPSTensor d D)
-    (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
-    (hShift : ∀ (k : Fin m) (i : Fin d), P (k + 1) * A i = A i * P k)
-    (k : Fin m) (σ : Fin (L' + 1) → Fin d) :
-    (P (k + 1) * evalWord A (List.ofFn (rotateCfg σ))).trace =
-      (P k * evalWord A (List.ofFn σ)).trace := by
-  rw [evalWord_ofFn_rotateCfg, evalWord_ofFn_eq_init_mul_last]
-  -- `tr(P(k+1) * A(last) * W)`: apply the shift, then cycle the trace.
-  rw [← Matrix.mul_assoc, hShift k (σ (Fin.last L'))]
-  rw [Matrix.mul_assoc, Matrix.trace_mul_comm, Matrix.mul_assoc]
-
-/-- **Physical projector-overlap covariance** under one-site rotation.
-The cross overlap built from projector-weighted traces is invariant under the
-simultaneous one-step shift `(u, v) → (u+1, v+1)`, for any positive length
-(arXiv:1708.00029 lines 985--1002, translation operator `T`). -/
-private lemma sum_trace_proj_overlap_shift {L' m : ℕ} [NeZero m]
-    (A B : MPSTensor d D)
-    (P Q : Fin m → Matrix (Fin D) (Fin D) ℂ)
-    (hShiftA : ∀ (k : Fin m) (i : Fin d), P (k + 1) * A i = A i * P k)
-    (hShiftB : ∀ (k : Fin m) (i : Fin d), Q (k + 1) * B i = B i * Q k)
-    (u v : Fin m) :
-    (∑ σ : Fin (L' + 1) → Fin d,
-        (P (u + 1) * evalWord A (List.ofFn σ)).trace *
-          star ((Q (v + 1) * evalWord B (List.ofFn σ)).trace)) =
-      ∑ σ : Fin (L' + 1) → Fin d,
-        (P u * evalWord A (List.ofFn σ)).trace *
-          star ((Q v * evalWord B (List.ofFn σ)).trace) := by
-  rw [← Equiv.sum_comp (rotateCfg (d := d) (L' := L'))
-    (fun σ => (P (u + 1) * evalWord A (List.ofFn σ)).trace *
-      star ((Q (v + 1) * evalWord B (List.ofFn σ)).trace))]
-  refine Finset.sum_congr rfl fun σ _ => ?_
-  rw [trace_proj_evalWord_rotateCfg A P hShiftA u σ,
-    trace_proj_evalWord_rotateCfg B Q hShiftB v σ]
-
-/-- Bridge between blocked configurations of length `N` and physical
-configurations of length `N * m`.  Uses the canonical `MPSTensor.decodeBlockEquiv`
-from `TNLean.MPS.Core.Blocking`. -/
-private noncomputable def blockedCfgEquiv (d N m : ℕ) :
-    (Fin N → Fin (blockPhysDim d m)) ≃ (Fin (N * m) → Fin d) :=
-  ((Equiv.arrowCongr (Equiv.refl (Fin N)) (decodeBlockEquiv d m)).trans
-    (Equiv.curry (Fin N) (Fin m) (Fin d)).symm).trans
-    (Equiv.arrowCongr finProdFinEquiv (Equiv.refl (Fin d)))
-
-private lemma ofFn_blockedCfgEquiv (d N m : ℕ) (σ : Fin N → Fin (blockPhysDim d m)) :
-    List.ofFn (blockedCfgEquiv d N m σ) = flattenBlockedWord d m (List.ofFn σ) := by
-  have hfun : (blockedCfgEquiv d N m σ) =
-      fun k : Fin (N * m) =>
-        decodeBlock d m (σ (finProdFinEquiv.symm k).1) ((finProdFinEquiv.symm k).2) := by
-    funext k
-    simp [blockedCfgEquiv, Equiv.arrowCongr, Equiv.curry, decodeBlockEquiv_apply,
-      Function.comp]
-  rw [hfun, List.ofFn_mul]
-  rw [flattenBlockedWord, List.map_ofFn]
-  congr 1
-  refine congrArg List.ofFn (funext fun i => ?_)
-  -- The grouped index `⟨i*m+j⟩` decodes to `(i, j)` under `finProdFinEquiv`.
-  have hsymm : ∀ j : Fin m,
-      finProdFinEquiv.symm
-          (⟨(i : ℕ) * m + (j : ℕ),
-            by
-              calc
-                (i : ℕ) * m + (j : ℕ) < ((i : ℕ) + 1) * m := by
-                  have := j.isLt; rw [Nat.add_mul, Nat.one_mul]; omega
-                _ ≤ N * m := Nat.mul_le_mul_right _ (by have := i.isLt; omega)⟩ :
-            Fin (N * m)) = (i, j) := by
-    intro j
-    rw [Equiv.symm_apply_eq]
-    apply Fin.ext
-    -- `finProdFinEquiv (i, j) = ⟨j + m * i, _⟩` by definition.
-    change (i : ℕ) * m + (j : ℕ) = (j : ℕ) + m * (i : ℕ)
-    rw [Nat.mul_comm m (i : ℕ), Nat.add_comm]
-  simp only [hsymm]
-  change (List.ofFn fun j : Fin m => decodeBlock d m (σ i) j) = (wordOfBlock d m ∘ σ) i
-  simp [wordOfBlock, Function.comp]
-
-/-- The cross overlap of two compressed cyclic sectors, expanded via the
-`IsCyclicSectorDecomp` trace formula and reindexed to physical configurations
-of length `N * m`. -/
-private lemma sectorOverlap_eq_physical_sum {m : ℕ} [NeZero D] [NeZero m]
-    (A B : MPSTensor d D)
-    {dimA dimB : Fin m → ℕ}
-    (blocksA : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
-    (blocksB : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
-    (PA PB : Fin m → Matrix (Fin D) (Fin D) ℂ)
-    (hTraceA : ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
-      mpv (blocksA k) σ = (PA k * evalWord (blockTensor A m) (List.ofFn σ)).trace)
-    (hTraceB : ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
-      mpv (blocksB k) σ = (PB k * evalWord (blockTensor B m) (List.ofFn σ)).trace)
-    (u v : Fin m) (N : ℕ) :
-    mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N =
-      ∑ τ : Fin (N * m) → Fin d,
-        (PA u * evalWord A (List.ofFn τ)).trace *
-          star ((PB v * evalWord B (List.ofFn τ)).trace) := by
-  classical
-  rw [mpvOverlap]
-  rw [← Equiv.sum_comp (blockedCfgEquiv d N m)
-    (fun τ : Fin (N * m) → Fin d =>
-      (PA u * evalWord A (List.ofFn τ)).trace *
-        star ((PB v * evalWord B (List.ofFn τ)).trace))]
-  refine Finset.sum_congr rfl fun σ _ => ?_
-  rw [hTraceA u N σ, hTraceB v N σ, ofFn_blockedCfgEquiv,
-    ← evalWord_blockTensor, ← evalWord_blockTensor]
-
-/-- **One-step transport of the cross sector overlap** (positive lengths,
-arXiv:1708.00029 lines 985--1002).  For `N ≥ 1`, the cross overlap of compressed
-cyclic sectors is invariant under the simultaneous index shift
-`(u, v) → (u+1, v+1)`. -/
-private lemma sectorOverlap_succ_eq {m : ℕ} [NeZero D] [NeZero m]
-    (A B : MPSTensor d D)
-    (hA_lc : ∑ i : Fin d, (A i)ᴴ * A i = 1)
-    (hB_lc : ∑ i : Fin d, (B i)ᴴ * B i = 1)
-    {dimA dimB : Fin m → ℕ}
-    (blocksA : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
-    (blocksB : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
-    (PA PB : Fin m → Matrix (Fin D) (Fin D) ℂ)
-    (hPAproj : ∀ k, IsOrthogonalProjection (PA k))
-    (hPBproj : ∀ k, IsOrthogonalProjection (PB k))
-    (hShiftA : ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (PA (k + 1)) = PA k)
-    (hShiftB : ∀ k, transferMap (d := d) (D := D) (fun i => (B i)ᴴ) (PB (k + 1)) = PB k)
-    (hTraceA : ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
-      mpv (blocksA k) σ = (PA k * evalWord (blockTensor A m) (List.ofFn σ)).trace)
-    (hTraceB : ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
-      mpv (blocksB k) σ = (PB k * evalWord (blockTensor B m) (List.ofFn σ)).trace)
-    (u v : Fin m) (N : ℕ) (hN : 0 < N) :
-    mpvOverlap (d := blockPhysDim d m) (blocksA (u + 1)) (blocksB (v + 1)) N =
-      mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
-  have hLetterA := offDiag_shift_of_adjoint_cyclic_shift A hA_lc hPAproj hShiftA
-  have hLetterB := offDiag_shift_of_adjoint_cyclic_shift B hB_lc hPBproj hShiftB
-  rw [sectorOverlap_eq_physical_sum A B blocksA blocksB PA PB hTraceA hTraceB,
-    sectorOverlap_eq_physical_sum A B blocksA blocksB PA PB hTraceA hTraceB]
-  obtain ⟨L', hL'⟩ : ∃ L', N * m = L' + 1 :=
-    Nat.exists_eq_succ_of_ne_zero (Nat.mul_ne_zero hN.ne' (NeZero.ne m))
-  rw [hL']
-  exact sum_trace_proj_overlap_shift A B PA PB hLetterA hLetterB u v
-
-/-- **One-step transport of sector overlaps from cyclic-sector decompositions.**
-
-For positive lengths, the cross overlap of the compressed cyclic sectors is
-invariant under the simultaneous index shift (u, v) ↦ (u + 1, v + 1).
-This is the formal overlap version of the translation-operator step in
-arXiv:1708.00029, lines 985--1002. -/
-lemma sectorOverlap_succ_eq_of_cyclicSectorDecomp {m : ℕ} [NeZero D] [NeZero m]
-    (A B : MPSTensor d D)
-    (hA_lc : IsLeftCanonical A) (hB_lc : IsLeftCanonical B)
-    {dimA dimB : Fin m → ℕ}
-    (blocksA : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
-    (blocksB : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
-    (hA_cyclic : IsCyclicSectorDecomp A blocksA)
-    (hB_cyclic : IsCyclicSectorDecomp B blocksB)
-    (u v : Fin m) (N : ℕ) (hN : 0 < N) :
-    mpvOverlap (d := blockPhysDim d m) (blocksA (u + 1)) (blocksB (v + 1)) N =
-      mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
-  obtain ⟨PA, _φA, hPAproj, _hPAsum, hShiftA, _hCommA, hTraceA, _⟩ := hA_cyclic
-  obtain ⟨PB, _φB, hPBproj, _hPBsum, hShiftB, _hCommB, hTraceB, _⟩ := hB_cyclic
-  exact sectorOverlap_succ_eq A B hA_lc hB_lc blocksA blocksB PA PB
-    hPAproj hPBproj hShiftA hShiftB hTraceA hTraceB u v N hN
 
 /-- Self-overlap of an irreducible, transfer-primitive, trace-preserving tensor
 tends to `1` (arXiv:1708.00029, Appendix A, first paragraph). -/
@@ -810,6 +603,23 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
     (hA_cyclic : IsCyclicSectorDecomp A blocksA)
     (hB_cyclic : IsCyclicSectorDecomp B blocksB)
+    {PA PB : Fin m → MatrixAlg D}
+    {φA : (k : Fin m) →
+      Matrix (Fin (dimA k)) (Fin (dimA k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PA k)}
+    {φB : (k : Fin m) →
+      Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PB k)}
+    (hPAproj : ∀ k, IsOrthogonalProjection (PA k))
+    (hPBproj : ∀ k, IsOrthogonalProjection (PB k))
+    (hPAsum : ∑ k : Fin m, PA k = 1)
+    (hPBsum : ∑ k : Fin m, PB k = 1)
+    (hAShift :
+      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (PA (k + 1)) = PA k)
+    (hBShift :
+      ∀ k, transferMap (d := d) (D := D) (fun i => (B i)ᴴ) (PB (k + 1)) = PB k)
+    (hA_letter : ∀ k (i : Fin (blockPhysDim d m)),
+      (φA k (blocksA k i)).1 = PA k * (blockTensor A m) i * PA k)
+    (hB_letter : ∀ k (i : Fin (blockPhysDim d m)),
+      (φB k (blocksB k i)).1 = PB k * (blockTensor B m) i * PB k)
     (q : Fin m)
     (hBlockMatch : ∀ u : Fin m,
       ∃ (hdim : dimA u = dimB (u + q)),
@@ -848,6 +658,15 @@ equivalent (after dimension cast). The injectivity contraction argument
 shows these per-sector gauges combine into a single global gauge for
 `RepeatedBlocks`.
 
+The named corner data record the blocked sector tensors
+\[
+  C_u^\alpha = P_u (A^{[m]})^\alpha P_u,\qquad
+  D_v^\alpha = Q_v (B^{[m]})^\alpha Q_v.
+\]
+These are the projective pieces in arXiv:1708.00029, Lemma bdcf,
+lines 395--407, before Appendix A introduces the one-site maps
+\(A_u^i = P_u A^i P_{u+1}\).
+
 The nondegeneracy hypothesis `hNondeg` ensures every sector has
 positive bond dimension. Without this, zero-dimensional sectors
 satisfy `IsNormal`, `GaugePhaseEquiv`, and `hBlockMatch` vacuously,
@@ -879,6 +698,23 @@ lemma sectorTensor_proportional_of_blockedMatch
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
     (hA_cyclic : IsCyclicSectorDecomp A blocksA)
     (hB_cyclic : IsCyclicSectorDecomp B blocksB)
+    {PA PB : Fin m → MatrixAlg D}
+    {φA : (k : Fin m) →
+      Matrix (Fin (dimA k)) (Fin (dimA k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PA k)}
+    {φB : (k : Fin m) →
+      Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PB k)}
+    (hPAproj : ∀ k, IsOrthogonalProjection (PA k))
+    (hPBproj : ∀ k, IsOrthogonalProjection (PB k))
+    (hPAsum : ∑ k : Fin m, PA k = 1)
+    (hPBsum : ∑ k : Fin m, PB k = 1)
+    (hAShift :
+      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (PA (k + 1)) = PA k)
+    (hBShift :
+      ∀ k, transferMap (d := d) (D := D) (fun i => (B i)ᴴ) (PB (k + 1)) = PB k)
+    (hA_letter : ∀ k (i : Fin (blockPhysDim d m)),
+      (φA k (blocksA k i)).1 = PA k * (blockTensor A m) i * PA k)
+    (hB_letter : ∀ k (i : Fin (blockPhysDim d m)),
+      (φB k (blocksB k i)).1 = PB k * (blockTensor B m) i * PB k)
     (q : Fin m)
     (hBlockMatch : ∀ u : Fin m,
       ∃ (hdim : dimA u = dimB (u + q)),
@@ -892,7 +728,8 @@ lemma sectorTensor_proportional_of_blockedMatch
     RepeatedBlocks A B := by
   exact repeatedBlocks_of_blockedSectorGaugePhase
     A B hA_lc hB_lc blocksA blocksB hA_blocks_lc hB_blocks_lc
-    hA_mpv hB_mpv hA_cyclic hB_cyclic q hBlockMatch hNondeg hNormal
+    hA_mpv hB_mpv hA_cyclic hB_cyclic hPAproj hPBproj hPAsum hPBsum
+    hAShift hBShift hA_letter hB_letter q hBlockMatch hNondeg hNormal
 
 /-- **Case 3: a matching sector implies gauge equivalence**. If two periodic tensors have
 the same period and a compressed sector match exists, then they are related by a gauge
@@ -908,6 +745,11 @@ tensor. The `hSomeMatch` witness provides a single matching sector pair
 `(u₀, v₀)` with compatible dimensions (the nondegeneracy of `dimA u₀`
 follows from `hNondegA`), from which translation propagation extends the
 match to all sectors.
+
+The named projectors and corner identifications realize the blocked sector
+tensors as the corners \(C_u^\alpha = P_u (A^{[m]})^\alpha P_u\) and
+\(D_v^\alpha = Q_v (B^{[m]})^\alpha Q_v\), matching the \(C_u\)-notation
+used in Lemma bdcf before the Appendix A contraction step.
 
 This is the sector-match case of the appendix proof, arXiv:1708.00029 lines
 961--1117 (conclusion A^i = e^{iξ} U B^i U† at lines 1110--1117). -/
@@ -934,6 +776,23 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
     (hA_cyclic : IsCyclicSectorDecomp A blocksA)
     (hB_cyclic : IsCyclicSectorDecomp B blocksB)
+    {PA PB : Fin m → MatrixAlg D}
+    {φA : (k : Fin m) →
+      Matrix (Fin (dimA k)) (Fin (dimA k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PA k)}
+    {φB : (k : Fin m) →
+      Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PB k)}
+    (hPAproj : ∀ k, IsOrthogonalProjection (PA k))
+    (hPBproj : ∀ k, IsOrthogonalProjection (PB k))
+    (hPAsum : ∑ k : Fin m, PA k = 1)
+    (hPBsum : ∑ k : Fin m, PB k = 1)
+    (hAShift :
+      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (PA (k + 1)) = PA k)
+    (hBShift :
+      ∀ k, transferMap (d := d) (D := D) (fun i => (B i)ᴴ) (PB (k + 1)) = PB k)
+    (hA_letter : ∀ k (i : Fin (blockPhysDim d m)),
+      (φA k (blocksA k i)).1 = PA k * (blockTensor A m) i * PA k)
+    (hB_letter : ∀ k (i : Fin (blockPhysDim d m)),
+      (φB k (blocksB k i)).1 = PB k * (blockTensor B m) i * PB k)
     (hNondegA : ∀ u, dimA u ≠ 0)
     (hSomeMatch : ∃ (u₀ v₀ : Fin m) (hdim : dimA u₀ = dimB v₀),
       GaugePhaseEquiv
@@ -966,7 +825,8 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
       (hNondegA u)
   -- Stage 3: contract the (reindexed) per-sector matches into a global gauge.
   refine sectorTensor_proportional_of_blockedMatch A B hA_lc hB_lc blocksA blocksB
-    hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic (v₀ - u₀) ?_ hNondegA hNormal
+    hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hPAproj hPBproj
+    hPAsum hPBsum hAShift hBShift hA_letter hB_letter (v₀ - u₀) ?_ hNondegA hNormal
   -- Reindex `hprop` from the (u₀ + l, v₀ + l) form to the (u, u + (v₀ - u₀)) form
   -- by taking l = u - u₀, so u₀ + l = u and v₀ + l = u + (v₀ - u₀).
   intro u

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -601,21 +601,13 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
     (hB_mpv :
       SameMPV₂ (blockTensor B m)
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
-    (hA_cyclic : IsCyclicSectorDecomp A blocksA)
-    (hB_cyclic : IsCyclicSectorDecomp B blocksB)
     {PA PB : Fin m → MatrixAlg D}
     {φA : (k : Fin m) →
       Matrix (Fin (dimA k)) (Fin (dimA k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PA k)}
     {φB : (k : Fin m) →
       Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PB k)}
-    (hPAproj : ∀ k, IsOrthogonalProjection (PA k))
-    (hPBproj : ∀ k, IsOrthogonalProjection (PB k))
-    (hPAsum : ∑ k : Fin m, PA k = 1)
-    (hPBsum : ∑ k : Fin m, PB k = 1)
-    (hAShift :
-      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (PA (k + 1)) = PA k)
-    (hBShift :
-      ∀ k, transferMap (d := d) (D := D) (fun i => (B i)ᴴ) (PB (k + 1)) = PB k)
+    (hA_cyclic : IsCyclicSectorDecompWith A blocksA PA φA)
+    (hB_cyclic : IsCyclicSectorDecompWith B blocksB PB φB)
     (hA_letter : ∀ k (i : Fin (blockPhysDim d m)),
       (φA k (blocksA k i)).1 = PA k * (blockTensor A m) i * PA k)
     (hB_letter : ∀ k (i : Fin (blockPhysDim d m)),
@@ -696,21 +688,13 @@ lemma sectorTensor_proportional_of_blockedMatch
     (hB_mpv :
       SameMPV₂ (blockTensor B m)
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
-    (hA_cyclic : IsCyclicSectorDecomp A blocksA)
-    (hB_cyclic : IsCyclicSectorDecomp B blocksB)
     {PA PB : Fin m → MatrixAlg D}
     {φA : (k : Fin m) →
       Matrix (Fin (dimA k)) (Fin (dimA k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PA k)}
     {φB : (k : Fin m) →
       Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PB k)}
-    (hPAproj : ∀ k, IsOrthogonalProjection (PA k))
-    (hPBproj : ∀ k, IsOrthogonalProjection (PB k))
-    (hPAsum : ∑ k : Fin m, PA k = 1)
-    (hPBsum : ∑ k : Fin m, PB k = 1)
-    (hAShift :
-      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (PA (k + 1)) = PA k)
-    (hBShift :
-      ∀ k, transferMap (d := d) (D := D) (fun i => (B i)ᴴ) (PB (k + 1)) = PB k)
+    (hA_cyclic : IsCyclicSectorDecompWith A blocksA PA φA)
+    (hB_cyclic : IsCyclicSectorDecompWith B blocksB PB φB)
     (hA_letter : ∀ k (i : Fin (blockPhysDim d m)),
       (φA k (blocksA k i)).1 = PA k * (blockTensor A m) i * PA k)
     (hB_letter : ∀ k (i : Fin (blockPhysDim d m)),
@@ -728,8 +712,8 @@ lemma sectorTensor_proportional_of_blockedMatch
     RepeatedBlocks A B := by
   exact repeatedBlocks_of_blockedSectorGaugePhase
     A B hA_lc hB_lc blocksA blocksB hA_blocks_lc hB_blocks_lc
-    hA_mpv hB_mpv hA_cyclic hB_cyclic hPAproj hPBproj hPAsum hPBsum
-    hAShift hBShift hA_letter hB_letter q hBlockMatch hNondeg hNormal
+    hA_mpv hB_mpv hA_cyclic hB_cyclic hA_letter hB_letter q hBlockMatch hNondeg
+    hNormal
 
 /-- **Case 3: a matching sector implies gauge equivalence**. If two periodic tensors have
 the same period and a compressed sector match exists, then they are related by a gauge
@@ -774,21 +758,13 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
     (hB_mpv :
       SameMPV₂ (blockTensor B m)
         (toTensorFromBlocks (μ := fun _ => 1) blocksB))
-    (hA_cyclic : IsCyclicSectorDecomp A blocksA)
-    (hB_cyclic : IsCyclicSectorDecomp B blocksB)
     {PA PB : Fin m → MatrixAlg D}
     {φA : (k : Fin m) →
       Matrix (Fin (dimA k)) (Fin (dimA k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PA k)}
     {φB : (k : Fin m) →
       Matrix (Fin (dimB k)) (Fin (dimB k)) ℂ ≃ₗ[ℂ] cornerSubmodule (PB k)}
-    (hPAproj : ∀ k, IsOrthogonalProjection (PA k))
-    (hPBproj : ∀ k, IsOrthogonalProjection (PB k))
-    (hPAsum : ∑ k : Fin m, PA k = 1)
-    (hPBsum : ∑ k : Fin m, PB k = 1)
-    (hAShift :
-      ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (PA (k + 1)) = PA k)
-    (hBShift :
-      ∀ k, transferMap (d := d) (D := D) (fun i => (B i)ᴴ) (PB (k + 1)) = PB k)
+    (hA_cyclic : IsCyclicSectorDecompWith A blocksA PA φA)
+    (hB_cyclic : IsCyclicSectorDecompWith B blocksB PB φB)
     (hA_letter : ∀ k (i : Fin (blockPhysDim d m)),
       (φA k (blocksA k i)).1 = PA k * (blockTensor A m) i * PA k)
     (hB_letter : ∀ k (i : Fin (blockPhysDim d m)),
@@ -815,18 +791,22 @@ theorem periodicOverlap_gaugeEquiv_of_sector_match
   obtain ⟨u₀, v₀, hdim₀, hMatch⟩ := hSomeMatch
   have hA_lc := hA.leftCanonical
   have hB_lc := hB.leftCanonical
+  have hA_cyclic_exists : IsCyclicSectorDecomp A blocksA :=
+    ⟨PA, φA, hA_cyclic⟩
+  have hB_cyclic_exists : IsCyclicSectorDecomp B blocksB :=
+    ⟨PB, φB, hB_cyclic⟩
   -- Stage 1: propagate the single match to every offset `l` around the cycle.
   have hprop := sectorMatch_propagation A B hA hB blocksA blocksB
-    hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic
+    hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic_exists hB_cyclic_exists
     hdim₀ (hNondegA u₀) hMatch
   -- Stage 2: each sector of `A` is a normal tensor.
   have hNormal : ∀ u, IsNormal (blocksA u) := fun u =>
-    sectorBlocked_isNormal_of_isPeriodic A hA blocksA hA_blocks_lc hA_mpv hA_cyclic u
-      (hNondegA u)
+    sectorBlocked_isNormal_of_isPeriodic A hA blocksA hA_blocks_lc hA_mpv
+      hA_cyclic_exists u (hNondegA u)
   -- Stage 3: contract the (reindexed) per-sector matches into a global gauge.
   refine sectorTensor_proportional_of_blockedMatch A B hA_lc hB_lc blocksA blocksB
-    hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hPAproj hPBproj
-    hPAsum hPBsum hAShift hBShift hA_letter hB_letter (v₀ - u₀) ?_ hNondegA hNormal
+    hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hA_letter
+    hB_letter (v₀ - u₀) ?_ hNondegA hNormal
   -- Reindex `hprop` from the (u₀ + l, v₀ + l) form to the (u, u + (v₀ - u₀)) form
   -- by taking l = u - u₀, so u₀ + l = u and v₀ + l = u + (v₀ - u₀).
   intro u

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -463,7 +463,7 @@ lemma sectorMatch_propagation
   obtain ⟨hdim, _, hg⟩ := key l
   exact ⟨hdim, hg⟩
 
-/-- Per-sector `RepeatedBlocks` consequence of the propagated gauge-phase data.
+/-- Per-sector `RepeatedBlocks` consequence of the propagated gauge-phase equivalences.
 
 This auxiliary result is weaker than the Case 3 conclusion: it gives a
 `RepeatedBlocks` relation for each compressed sector pair
@@ -631,8 +631,8 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
   -- `Ω u` satisfying `hΩ`; after producing product-one unit phases κ_v, it uses
   -- `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`
   -- for the offset-indexed κ/θ/φ telescoping (lines 1093--1102). This upgrades the
-  -- per-sector blocked gauge data in `hBlockMatch` to one global phase and one global
-  -- gauge. The available two-site theorem is `tensor_proportional`.
+  -- per-sector blocked gauge-phase equivalences in `hBlockMatch` to one global
+  -- phase and one global gauge. The available two-site theorem is `tensor_proportional`.
   sorry
 
 /-- **Per-site proportionality** (eq:thetaACprop, arXiv:1708.00029 lines
@@ -650,7 +650,8 @@ equivalent (after dimension cast). The injectivity contraction argument
 shows these per-sector gauges combine into a single global gauge for
 `RepeatedBlocks`.
 
-The named corner data record the blocked sector tensors
+The specified projectors \(P_u\), \(Q_v\) and corner identifications
+\(\varphi_u\), \(\psi_v\) record the blocked sector tensors
 \[
   C_u^\alpha = P_u (A^{[m]})^\alpha P_u,\qquad
   D_v^\alpha = Q_v (B^{[m]})^\alpha Q_v.
@@ -730,7 +731,7 @@ tensor. The `hSomeMatch` witness provides a single matching sector pair
 follows from `hNondegA`), from which translation propagation extends the
 match to all sectors.
 
-The named projectors and corner identifications realize the blocked sector
+The specified projectors and corner identifications realize the blocked sector
 tensors as the corners \(C_u^\alpha = P_u (A^{[m]})^\alpha P_u\) and
 \(D_v^\alpha = Q_v (B^{[m]})^\alpha Q_v\), matching the \(C_u\)-notation
 used in Lemma bdcf before the Appendix A contraction step.

--- a/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
@@ -1,0 +1,228 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.Periodic.Overlap.Case2
+
+/-!
+# Periodic overlap dichotomy: Case 3 transport
+
+This module contains the one-site transport of cross-sector overlaps used in
+the equal-period sector-match case of arXiv:1708.00029, Appendix A.
+-/
+
+open scoped Matrix BigOperators ComplexOrder InnerProductSpace
+open Filter Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### One-site rotation covariance of the cross sector overlap
+
+The translation-operator step of arXiv:1708.00029, Appendix A (lines 985--1002)
+moves the matched sector pair `(u, v)` to `(u+1, v+1)`.  Formalized below as a
+single physical-site cyclic rotation of the underlying word: the single-site
+off-diagonal shift `P_{k+1} A^i = A^i P_k` (eq:Aoffdiag, supplied by
+`offDiag_shift_of_adjoint_cyclic_shift`) carries the cyclic index forward by one
+per site, and the trace is invariant under cyclic rotation of the word, so the
+cross overlap is unchanged by the simultaneous shift. -/
+
+/-- One-site cyclic rotation of a configuration of length `L'+1`:
+move the last letter to the front. -/
+def rotateCfg {d L' : ℕ} : (Fin (L' + 1) → Fin d) ≃ (Fin (L' + 1) → Fin d) where
+  toFun σ := Fin.cons (σ (Fin.last L')) (Fin.init σ)
+  invFun τ := Fin.snoc (Fin.tail τ) (τ 0)
+  left_inv σ := by
+    funext j
+    refine Fin.lastCases ?_ ?_ j
+    · simp [Fin.snoc_last, Fin.cons_zero]
+    · intro i
+      simp [Fin.snoc_castSucc, Fin.init]
+  right_inv τ := by
+    funext j
+    refine Fin.cases ?_ ?_ j
+    · simp [Fin.cons_zero, Fin.snoc_last]
+    · intro i
+      simp [Fin.cons_succ, Fin.tail]
+
+/-- Word evaluation of the rotated configuration pulls the last letter to the front. -/
+private lemma evalWord_ofFn_rotateCfg {L' : ℕ} (A : MPSTensor d D)
+    (σ : Fin (L' + 1) → Fin d) :
+    evalWord A (List.ofFn (rotateCfg σ)) =
+      A (σ (Fin.last L')) * evalWord A (List.ofFn (Fin.init σ)) := by
+  simp only [rotateCfg, Equiv.coe_fn_mk, List.ofFn_cons, evalWord_cons]
+
+/-- Word evaluation of the original configuration pulls the last letter to the right. -/
+private lemma evalWord_ofFn_eq_init_mul_last {L' : ℕ} (A : MPSTensor d D)
+    (σ : Fin (L' + 1) → Fin d) :
+    evalWord A (List.ofFn σ) =
+      evalWord A (List.ofFn (Fin.init σ)) * A (σ (Fin.last L')) := by
+  rw [List.ofFn_succ']
+  rw [show (List.ofFn fun i => σ (Fin.castSucc i)) = List.ofFn (Fin.init σ) from rfl]
+  rw [List.concat_eq_append, evalWord_append]
+  simp [evalWord_cons, evalWord_nil]
+
+/-- **Per-configuration trace covariance** under one-site rotation (eq:Aoffdiag,
+arXiv:1708.00029 lines 985--1002).  Given the single-site off-diagonal shift
+`P (k+1) * A i = A i * P k`, the projector-weighted trace at index `k+1` of the
+rotated word equals the projector-weighted trace at index `k` of the original
+word. -/
+private lemma trace_proj_evalWord_rotateCfg {L' m : ℕ} [NeZero m] (A : MPSTensor d D)
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (hShift : ∀ (k : Fin m) (i : Fin d), P (k + 1) * A i = A i * P k)
+    (k : Fin m) (σ : Fin (L' + 1) → Fin d) :
+    (P (k + 1) * evalWord A (List.ofFn (rotateCfg σ))).trace =
+      (P k * evalWord A (List.ofFn σ)).trace := by
+  rw [evalWord_ofFn_rotateCfg, evalWord_ofFn_eq_init_mul_last]
+  -- `tr(P(k+1) * A(last) * W)`: apply the shift, then cycle the trace.
+  rw [← Matrix.mul_assoc, hShift k (σ (Fin.last L'))]
+  rw [Matrix.mul_assoc, Matrix.trace_mul_comm, Matrix.mul_assoc]
+
+/-- **Physical projector-overlap covariance** under one-site rotation.
+The cross overlap built from projector-weighted traces is invariant under the
+simultaneous one-step shift `(u, v) → (u+1, v+1)`, for any positive length
+(arXiv:1708.00029 lines 985--1002, translation operator `T`). -/
+private lemma sum_trace_proj_overlap_shift {L' m : ℕ} [NeZero m]
+    (A B : MPSTensor d D)
+    (P Q : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (hShiftA : ∀ (k : Fin m) (i : Fin d), P (k + 1) * A i = A i * P k)
+    (hShiftB : ∀ (k : Fin m) (i : Fin d), Q (k + 1) * B i = B i * Q k)
+    (u v : Fin m) :
+    (∑ σ : Fin (L' + 1) → Fin d,
+        (P (u + 1) * evalWord A (List.ofFn σ)).trace *
+          star ((Q (v + 1) * evalWord B (List.ofFn σ)).trace)) =
+      ∑ σ : Fin (L' + 1) → Fin d,
+        (P u * evalWord A (List.ofFn σ)).trace *
+          star ((Q v * evalWord B (List.ofFn σ)).trace) := by
+  rw [← Equiv.sum_comp (rotateCfg (d := d) (L' := L'))
+    (fun σ => (P (u + 1) * evalWord A (List.ofFn σ)).trace *
+      star ((Q (v + 1) * evalWord B (List.ofFn σ)).trace))]
+  refine Finset.sum_congr rfl fun σ _ => ?_
+  rw [trace_proj_evalWord_rotateCfg A P hShiftA u σ,
+    trace_proj_evalWord_rotateCfg B Q hShiftB v σ]
+
+/-- Bridge between blocked configurations of length `N` and physical
+configurations of length `N * m`.  Uses the canonical `MPSTensor.decodeBlockEquiv`
+from `TNLean.MPS.Core.Blocking`. -/
+private noncomputable def blockedCfgEquiv (d N m : ℕ) :
+    (Fin N → Fin (blockPhysDim d m)) ≃ (Fin (N * m) → Fin d) :=
+  ((Equiv.arrowCongr (Equiv.refl (Fin N)) (decodeBlockEquiv d m)).trans
+    (Equiv.curry (Fin N) (Fin m) (Fin d)).symm).trans
+    (Equiv.arrowCongr finProdFinEquiv (Equiv.refl (Fin d)))
+
+private lemma ofFn_blockedCfgEquiv (d N m : ℕ) (σ : Fin N → Fin (blockPhysDim d m)) :
+    List.ofFn (blockedCfgEquiv d N m σ) = flattenBlockedWord d m (List.ofFn σ) := by
+  have hfun : (blockedCfgEquiv d N m σ) =
+      fun k : Fin (N * m) =>
+        decodeBlock d m (σ (finProdFinEquiv.symm k).1) ((finProdFinEquiv.symm k).2) := by
+    funext k
+    simp [blockedCfgEquiv, Equiv.arrowCongr, Equiv.curry, decodeBlockEquiv_apply,
+      Function.comp]
+  rw [hfun, List.ofFn_mul]
+  rw [flattenBlockedWord, List.map_ofFn]
+  congr 1
+  refine congrArg List.ofFn (funext fun i => ?_)
+  -- The grouped index `⟨i*m+j⟩` decodes to `(i, j)` under `finProdFinEquiv`.
+  have hsymm : ∀ j : Fin m,
+      finProdFinEquiv.symm
+          (⟨(i : ℕ) * m + (j : ℕ),
+            by
+              calc
+                (i : ℕ) * m + (j : ℕ) < ((i : ℕ) + 1) * m := by
+                  have := j.isLt; rw [Nat.add_mul, Nat.one_mul]; omega
+                _ ≤ N * m := Nat.mul_le_mul_right _ (by have := i.isLt; omega)⟩ :
+            Fin (N * m)) = (i, j) := by
+    intro j
+    rw [Equiv.symm_apply_eq]
+    apply Fin.ext
+    -- `finProdFinEquiv (i, j) = ⟨j + m * i, _⟩` by definition.
+    change (i : ℕ) * m + (j : ℕ) = (j : ℕ) + m * (i : ℕ)
+    rw [Nat.mul_comm m (i : ℕ), Nat.add_comm]
+  simp only [hsymm]
+  change (List.ofFn fun j : Fin m => decodeBlock d m (σ i) j) = (wordOfBlock d m ∘ σ) i
+  simp [wordOfBlock, Function.comp]
+
+/-- The cross overlap of two compressed cyclic sectors, expanded via the
+`IsCyclicSectorDecomp` trace formula and reindexed to physical configurations
+of length `N * m`. -/
+private lemma sectorOverlap_eq_physical_sum {m : ℕ} [NeZero D] [NeZero m]
+    (A B : MPSTensor d D)
+    {dimA dimB : Fin m → ℕ}
+    (blocksA : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
+    (blocksB : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
+    (PA PB : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (hTraceA : ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+      mpv (blocksA k) σ = (PA k * evalWord (blockTensor A m) (List.ofFn σ)).trace)
+    (hTraceB : ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+      mpv (blocksB k) σ = (PB k * evalWord (blockTensor B m) (List.ofFn σ)).trace)
+    (u v : Fin m) (N : ℕ) :
+    mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N =
+      ∑ τ : Fin (N * m) → Fin d,
+        (PA u * evalWord A (List.ofFn τ)).trace *
+          star ((PB v * evalWord B (List.ofFn τ)).trace) := by
+  classical
+  rw [mpvOverlap]
+  rw [← Equiv.sum_comp (blockedCfgEquiv d N m)
+    (fun τ : Fin (N * m) → Fin d =>
+      (PA u * evalWord A (List.ofFn τ)).trace *
+        star ((PB v * evalWord B (List.ofFn τ)).trace))]
+  refine Finset.sum_congr rfl fun σ _ => ?_
+  rw [hTraceA u N σ, hTraceB v N σ, ofFn_blockedCfgEquiv,
+    ← evalWord_blockTensor, ← evalWord_blockTensor]
+
+/-- **One-step transport of the cross sector overlap** (positive lengths,
+arXiv:1708.00029 lines 985--1002).  For `N ≥ 1`, the cross overlap of compressed
+cyclic sectors is invariant under the simultaneous index shift
+`(u, v) → (u+1, v+1)`. -/
+private lemma sectorOverlap_succ_eq {m : ℕ} [NeZero D] [NeZero m]
+    (A B : MPSTensor d D)
+    (hA_lc : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hB_lc : ∑ i : Fin d, (B i)ᴴ * B i = 1)
+    {dimA dimB : Fin m → ℕ}
+    (blocksA : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
+    (blocksB : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
+    (PA PB : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (hPAproj : ∀ k, IsOrthogonalProjection (PA k))
+    (hPBproj : ∀ k, IsOrthogonalProjection (PB k))
+    (hShiftA : ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (PA (k + 1)) = PA k)
+    (hShiftB : ∀ k, transferMap (d := d) (D := D) (fun i => (B i)ᴴ) (PB (k + 1)) = PB k)
+    (hTraceA : ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+      mpv (blocksA k) σ = (PA k * evalWord (blockTensor A m) (List.ofFn σ)).trace)
+    (hTraceB : ∀ k (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
+      mpv (blocksB k) σ = (PB k * evalWord (blockTensor B m) (List.ofFn σ)).trace)
+    (u v : Fin m) (N : ℕ) (hN : 0 < N) :
+    mpvOverlap (d := blockPhysDim d m) (blocksA (u + 1)) (blocksB (v + 1)) N =
+      mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
+  have hLetterA := offDiag_shift_of_adjoint_cyclic_shift A hA_lc hPAproj hShiftA
+  have hLetterB := offDiag_shift_of_adjoint_cyclic_shift B hB_lc hPBproj hShiftB
+  rw [sectorOverlap_eq_physical_sum A B blocksA blocksB PA PB hTraceA hTraceB,
+    sectorOverlap_eq_physical_sum A B blocksA blocksB PA PB hTraceA hTraceB]
+  obtain ⟨L', hL'⟩ : ∃ L', N * m = L' + 1 :=
+    Nat.exists_eq_succ_of_ne_zero (Nat.mul_ne_zero hN.ne' (NeZero.ne m))
+  rw [hL']
+  exact sum_trace_proj_overlap_shift A B PA PB hLetterA hLetterB u v
+
+/-- **One-step transport of sector overlaps from cyclic-sector decompositions.**
+
+For positive lengths, the cross overlap of the compressed cyclic sectors is
+invariant under the simultaneous index shift (u, v) ↦ (u + 1, v + 1).
+This is the formal overlap version of the translation-operator step in
+arXiv:1708.00029, lines 985--1002. -/
+lemma sectorOverlap_succ_eq_of_cyclicSectorDecomp {m : ℕ} [NeZero D] [NeZero m]
+    (A B : MPSTensor d D)
+    (hA_lc : IsLeftCanonical A) (hB_lc : IsLeftCanonical B)
+    {dimA dimB : Fin m → ℕ}
+    (blocksA : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimA k))
+    (blocksB : (k : Fin m) → MPSTensor (blockPhysDim d m) (dimB k))
+    (hA_cyclic : IsCyclicSectorDecomp A blocksA)
+    (hB_cyclic : IsCyclicSectorDecomp B blocksB)
+    (u v : Fin m) (N : ℕ) (hN : 0 < N) :
+    mpvOverlap (d := blockPhysDim d m) (blocksA (u + 1)) (blocksB (v + 1)) N =
+      mpvOverlap (d := blockPhysDim d m) (blocksA u) (blocksB v) N := by
+  obtain ⟨PA, _φA, hPAproj, _hPAsum, hShiftA, _hCommA, hTraceA, _⟩ := hA_cyclic
+  obtain ⟨PB, _φB, hPBproj, _hPBsum, hShiftB, _hCommB, hTraceB, _⟩ := hB_cyclic
+  exact sectorOverlap_succ_eq A B hA_lc hB_lc blocksA blocksB PA PB
+    hPAproj hPBproj hShiftA hShiftB hTraceA hTraceB u v N hN
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
@@ -102,9 +102,8 @@ private lemma sum_trace_proj_overlap_shift {L' m : ℕ} [NeZero m]
   rw [trace_proj_evalWord_rotateCfg A P hShiftA u σ,
     trace_proj_evalWord_rotateCfg B Q hShiftB v σ]
 
-/-- Bridge between blocked configurations of length `N` and physical
-configurations of length `N * m`.  Uses the canonical `MPSTensor.decodeBlockEquiv`
-from `TNLean.MPS.Core.Blocking`. -/
+/-- Equivalence between blocked configurations of length `N` and physical
+configurations of length `N * m`, via `MPSTensor.decodeBlockEquiv`. -/
 private noncomputable def blockedCfgEquiv (d N m : ℕ) :
     (Fin N → Fin (blockPhysDim d m)) ≃ (Fin (N * m) → Fin d) :=
   ((Equiv.arrowCongr (Equiv.refl (Fin N)) (decodeBlockEquiv d m)).trans

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -67,10 +67,30 @@ theorem periodicOverlapDichotomy
     haveI : NeZero m_a := ⟨hA.period_pos.ne'⟩
     by_cases hD : D₁ = D₂
     · subst hD
-      obtain ⟨dimA, blocksA, hA_blocks_lc, hA_mpv, hA_cyclic, hNondegA⟩ :=
-        exists_cyclic_sector_decomp_after_blocking_of_isPeriodic A hA
-      obtain ⟨dimB, blocksB, hB_blocks_lc, hB_mpv, hB_cyclic, hNondegB⟩ :=
-        exists_cyclic_sector_decomp_after_blocking_of_isPeriodic B hB
+      obtain ⟨dimA, blocksA, PA, φA, hA_blocks_lc, hA_mpv, hPAproj, hPAsum,
+        hAShift', hAComm, hATrace, hAIntertwine, hAMul, hAStar, hNondegA,
+        hA_letter⟩ :=
+        exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic A hA
+      obtain ⟨dimB, blocksB, PB, φB, hB_blocks_lc, hB_mpv, hPBproj, hPBsum,
+        hBShift', hBComm, hBTrace, hBIntertwine, hBMul, hBStar, hNondegB,
+        hB_letter⟩ :=
+        exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic B hB
+      have hAShift :
+          ∀ k, transferMap (d := d) (D := D₁) (fun i => (A i)ᴴ) (PA (k + 1)) =
+            PA k := by
+        intro k
+        simpa [cyclicNextOfPos, Fin.add_def] using hAShift' k
+      have hBShift :
+          ∀ k, transferMap (d := d) (D := D₁) (fun i => (B i)ᴴ) (PB (k + 1)) =
+            PB k := by
+        intro k
+        simpa [cyclicNextOfPos, Fin.add_def] using hBShift' k
+      have hA_cyclic : IsCyclicSectorDecomp A blocksA :=
+        ⟨PA, φA, hPAproj, hPAsum, hAShift, hAComm, hATrace, hAIntertwine,
+          hAMul, hAStar⟩
+      have hB_cyclic : IsCyclicSectorDecomp B blocksB :=
+        ⟨PB, φB, hPBproj, hPBsum, hBShift, hBComm, hBTrace, hBIntertwine,
+          hBMul, hBStar⟩
       by_cases hmatch : ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
           GaugePhaseEquiv
             (cast (congr_arg (MPSTensor (blockPhysDim d m_a)) hdim) (blocksA u₀))
@@ -78,7 +98,9 @@ theorem periodicOverlapDichotomy
       · refine Or.inr ⟨rfl, ?_⟩
         simpa using
           periodicOverlap_gaugeEquiv_of_sector_match A B hA hB blocksA blocksB
-            hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hNondegA hmatch
+            hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic
+            hPAproj hPBproj hPAsum hPBsum hAShift hBShift hA_letter hB_letter
+            hNondegA hmatch
       · refine Or.inl ?_
         refine periodicOverlap_tendsto_zero_of_no_sector_match A B hA hB blocksA blocksB
           hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hNondegA hNondegB ?_

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -85,12 +85,16 @@ theorem periodicOverlapDichotomy
             PB k := by
         intro k
         simpa [cyclicNextOfPos, Fin.add_def] using hBShift' k
+      have hA_cyclic_with : IsCyclicSectorDecompWith A blocksA PA φA :=
+        ⟨hPAproj, hPAsum, hAShift, hAComm, hATrace, hAIntertwine, hAMul,
+          hAStar⟩
+      have hB_cyclic_with : IsCyclicSectorDecompWith B blocksB PB φB :=
+        ⟨hPBproj, hPBsum, hBShift, hBComm, hBTrace, hBIntertwine, hBMul,
+          hBStar⟩
       have hA_cyclic : IsCyclicSectorDecomp A blocksA :=
-        ⟨PA, φA, hPAproj, hPAsum, hAShift, hAComm, hATrace, hAIntertwine,
-          hAMul, hAStar⟩
+        ⟨PA, φA, hA_cyclic_with⟩
       have hB_cyclic : IsCyclicSectorDecomp B blocksB :=
-        ⟨PB, φB, hPBproj, hPBsum, hBShift, hBComm, hBTrace, hBIntertwine,
-          hBMul, hBStar⟩
+        ⟨PB, φB, hB_cyclic_with⟩
       by_cases hmatch : ∃ (u₀ v₀ : Fin m_a) (hdim : dimA u₀ = dimB v₀),
           GaugePhaseEquiv
             (cast (congr_arg (MPSTensor (blockPhysDim d m_a)) hdim) (blocksA u₀))
@@ -98,9 +102,8 @@ theorem periodicOverlapDichotomy
       · refine Or.inr ⟨rfl, ?_⟩
         simpa using
           periodicOverlap_gaugeEquiv_of_sector_match A B hA hB blocksA blocksB
-            hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic
-            hPAproj hPBproj hPAsum hPBsum hAShift hBShift hA_letter hB_letter
-            hNondegA hmatch
+            hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic_with
+            hB_cyclic_with hA_letter hB_letter hNondegA hmatch
       · refine Or.inl ?_
         refine periodicOverlap_tendsto_zero_of_no_sector_match A B hA hB blocksA blocksB
           hA_blocks_lc hB_blocks_lc hA_mpv hB_mpv hA_cyclic hB_cyclic hNondegA hNondegB ?_

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
@@ -84,13 +84,13 @@ algebras, so irreducibility and primitivity may be transferred through the
 corner representation.  The underlying linear maps are isometries for the
 canonical inner products; the support isometries record this property where
 needed. -/
-def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
+def IsCyclicSectorDecompWith [NeZero D] [NeZero m] (A : MPSTensor d D)
     {dim : Fin m → ℕ}
-    (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)) : Prop :=
-  ∃ (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k))
+    (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
     (φ : (k : Fin m) →
-      Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
-    (∀ k, IsOrthogonalProjection (P k)) ∧
+      Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)) : Prop :=
+  (∀ k, IsOrthogonalProjection (P k)) ∧
     (∑ k : Fin m, P k = 1) ∧
     (∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k) ∧
     (∀ k (i : Fin (blockPhysDim d m)),
@@ -106,6 +106,17 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
       (φ k (X * Y)).1 = (φ k X).1 * (φ k Y).1) ∧
     (∀ k (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ),
       (φ k Xᴴ).1 = ((φ k X).1)ᴴ)
+
+/-- A cyclic-sector decomposition with existentially quantified projectors and
+corner identifications. Use `IsCyclicSectorDecompWith` when the particular
+projectors and corner maps are part of the surrounding statement. -/
+def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
+    {dim : Fin m → ℕ}
+    (blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)) : Prop :=
+  ∃ (P : Fin m → Matrix (Fin D) (Fin D) ℂ)
+    (φ : (k : Fin m) →
+      Matrix (Fin (dim k)) (Fin (dim k)) ℂ ≃ₗ[ℂ] cornerSubmodule (P k)),
+    IsCyclicSectorDecompWith A blocks P φ
 
 /-- The single-site off-diagonal grading carried by a cyclic sector decomposition:
 each unblocked Kraus operator carries the cyclic projection index `k` to `k + 1`,

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -513,7 +513,7 @@ unconditional result.
 
 \begin{definition}[Off-diagonal sector decomposition]%
     \label{def:cyclic_sector_decomp}
-    \lean{MPSTensor.IsCyclicSectorDecomp}
+    \lean{MPSTensor.IsCyclicSectorDecomp, MPSTensor.IsCyclicSectorDecompWith}
     \leanok
     \uses{def:periodic_tensor}
     A family of compressed sector tensors
@@ -530,6 +530,9 @@ unconditional result.
         P_k \cdot M_D(\mathbb{C}) \cdot P_k$
     (multiplicative and adjoint-preserving) intertwining the compressed adjoint
     transfer map with the sector adjoint transfer map on the corner of~$P_k$.
+    We shall sometimes keep these projections and corner isomorphisms as
+    specified witnesses; forgetting the witnesses gives the displayed
+    decomposition.
     This is the inverse cyclic indexing of the off-diagonal convention in
     \cite[Appendix~A]{DeLasCuevas2017Irreducible}. There the same adjoint
     transfer map is written $E^*$, and the source projectors satisfy
@@ -1119,13 +1122,13 @@ unconditional result.
 \begin{lemma}[Per-site proportionality from blocked sector match]%
     \label{lem:sector_tensor_proportional_blocked_match}
     \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
-    \leanok
+    \notready
     \uses{lem:sector_match_propagation, def:cyclic_sector_decomp}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
-    cyclic sector decompositions whose sectors are left-canonical. Let $P_u$
-    and $Q_v$ be the cyclic projectors, and let the corner identifications
-    realize the blocked sector tensors by
+    cyclic sector decompositions whose sectors are left-canonical. Let the
+    specified cyclic projectors be $P_u$ and $Q_v$, and let the specified
+    corner identifications realize the blocked sector tensors by
     \[
         A_u^\alpha = P_u\bar A^\alpha P_u,
         \qquad
@@ -1164,8 +1167,8 @@ unconditional result.
         def:cyclic_sector_decomp}
     Let $A$ and $B$ be periodic tensors with the same period $m$. Let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
-    cyclic sector decompositions whose sectors are left-canonical, with cyclic
-    projectors $P_u,Q_v$ satisfying
+    cyclic sector decompositions whose sectors are left-canonical, with
+    specified cyclic projectors $P_u,Q_v$ and corner identifications satisfying
     \[
         A_u^\alpha = P_u\bar A^\alpha P_u,
         \qquad

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1119,11 +1119,19 @@ unconditional result.
 \begin{lemma}[Per-site proportionality from blocked sector match]%
     \label{lem:sector_tensor_proportional_blocked_match}
     \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
-    \notready
+    \leanok
     \uses{lem:sector_match_propagation, def:cyclic_sector_decomp}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
-    cyclic sector decompositions whose sectors are left-canonical. Assume
+    cyclic sector decompositions whose sectors are left-canonical. Let $P_u$
+    and $Q_v$ be the cyclic projectors, and let the corner identifications
+    realize the blocked sector tensors by
+    \[
+        A_u^\alpha = P_u\bar A^\alpha P_u,
+        \qquad
+        B_v^\alpha = Q_v\bar B^\alpha Q_v.
+    \]
+    Assume
     $d_u\ne0$ and $A_u$ is normal for every $u$. Fix $q\in\mathbb Z_m$ and
     assume that for every $u$ there are $d_u=e_{u+q}$, $\zeta_u\ne0$, and
     $X_u\in\GL_{d_u}(\C)$ such that
@@ -1156,7 +1164,14 @@ unconditional result.
         def:cyclic_sector_decomp}
     Let $A$ and $B$ be periodic tensors with the same period $m$. Let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
-    cyclic sector decompositions whose sectors are left-canonical, and assume
+    cyclic sector decompositions whose sectors are left-canonical, with cyclic
+    projectors $P_u,Q_v$ satisfying
+    \[
+        A_u^\alpha = P_u\bar A^\alpha P_u,
+        \qquad
+        B_v^\alpha = Q_v\bar B^\alpha Q_v.
+    \]
+    Assume
     every sector $A_u$ has nonzero virtual dimension. If there are sectors
     $u_0,v_0$ with $d_{u_0}=e_{v_0}$ and
     $A_{u_0}\sim_{\mathrm{gp}}B_{v_0}$ after identifying their virtual spaces,


### PR DESCRIPTION
## Summary

This PR threads the cyclic projectors and corner identifications from the cyclic sector decomposition into the Case 3 sector-match interfaces. The added hypotheses record the blocked sector tensors as the corners

\[
A_u^\alpha = P_u \bar A^\alpha P_u, \qquad B_v^\alpha = Q_v \bar B^\alpha Q_v.
\]

This is a preparatory step for #873: it makes the data needed for the Appendix A contraction visible at the public Case 3 boundary, without attempting to complete the remaining contraction theorem.

The dichotomy proof now obtains the stronger sector-decomposition package with these letter identities and passes the named projector/corner data through to the sector-match theorem. The blueprint statement for the two affected entries was updated to state the same mathematical assumptions.

The one-step cross-sector overlap transport lemmas were split into `Case3Transport.lean`; this is a mechanical move to keep `Case3.lean` below the repository file-length guard after the new interface data was added.

## Validation

- `lake build TNLean.MPS.Periodic.Overlap.Dichotomy`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint web`
- `lake build TNLean`
- `PATH=/Users/siruilu/Library/Python/3.9/bin:$PATH leanblueprint checkdecls`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`

## Proof status

No new proof obligation is introduced. The existing `sorry` in `MPSTensor.repeatedBlocks_of_blockedSectorGaugePhase` remains the Case 3 contraction step tracked by #873.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactoring and interface threading only; no new proof obligations and no auth or runtime impact. Risk is mainly API churn across Case 3 and dichotomy call sites.
> 
> **Overview**
> Case 3 sector-match APIs now take **named** cyclic projectors `P_u`/`Q_v`, corner maps `φ`/`ψ`, and **letter identities** \(\varphi_k(C_k^i)=P_k(A^{[m]})^i P_k\) (and the \(B\)-side analogue), so Appendix A contraction data is visible at the public boundary without completing that proof.
> 
> `IsCyclicSectorDecomp` is split into existential `IsCyclicSectorDecomp` and witness-carrying `IsCyclicSectorDecompWith`; `periodicOverlapDichotomy` pulls the stronger `exists_cyclic_sector_decomp_with_letter_after_blocking_of_isPeriodic` package and threads it into `periodicOverlap_gaugeEquiv_of_sector_match`.
> 
> One-site cross-sector overlap transport is **moved unchanged** from `Case3.lean` to new `Case3Transport.lean` (file-length guard). The existing `sorry` in `repeatedBlocks_of_blockedSectorGaugePhase` is unchanged.
> 
> Blueprint cyclic-sector and sector-match statements are updated to match the new hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc9f6708bf3bc90b311bcf7057775798b5757e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->