### PR TITLE
doc(parent): align source comparison terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -106,9 +106,9 @@ conditions.
 transitively uses the boundary-condition comparison at boundary-crossing windows
 rather than deriving it from arXiv:2011.12127, Section IV.C, lines 2126--2128.
 Documented in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
-Elimination: derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison
-from arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it
-to discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
+Elimination: derive the \(C^j,D^j,E^j\) boundary-condition comparison from
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -190,7 +190,7 @@ internal-direct-sum conclusions above, which transitively use the
 boundary-condition comparison at boundary-crossing windows rather than deriving
 it from arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
@@ -243,7 +243,7 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
@@ -313,9 +313,9 @@ representation of \(\psi\). The periodic-boundary upgrade is the separate
 boundary-condition comparison for the cyclic windows crossing the chosen cut.
 
 This proves the displayed statement. The
-Pérez-García--Verstraete--Wolf--Cirac boundary-condition comparison
-(arXiv:quant-ph/0608197, proof lines 1454--1456; arXiv:2011.12127, lines
-2126--2128) shows, under the comparison identities, that these same component
+boundary-condition comparison in arXiv:quant-ph/0608197, proof lines
+1454--1456, and arXiv:2011.12127, lines 2126--2128, shows, under the
+comparison identities, that these same component
 vectors lie in \(\mathcal G_{N,L}(A_j)\).
 
 **Unfaithful:** This proof relies on
@@ -324,7 +324,7 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem
@@ -443,7 +443,7 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
@@ -858,7 +858,7 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
@@ -924,7 +924,7 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) boundary-condition comparison from
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
 discharge the currently assumed boundary-condition comparison; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -17,10 +17,10 @@ Theorem 12.
 
 The equality theorem here is conditional on the matrix identities indexed by
 complementary words obtained after the source \(C^j,D^j\) comparison and the
-normalized \(E^j\)-calculation. The
-Pérez-García--Verstraete--Wolf--Cirac (PGVWC) comparison theorem below proves
-the periodic-boundary conclusion for each block once those identities are in the
-boundary-crossing form used in Theorem 12. Deriving these identities
+normalized \(E^j\)-calculation. The comparison theorem from
+arXiv:quant-ph/0608197 below proves the periodic-boundary conclusion for each
+block once those identities are in the boundary-crossing form used in
+Theorem 12. Deriving these identities
 from the source comparison is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 -/
@@ -666,7 +666,7 @@ theorem blockDiagonal_boundary_component_chainGroundSpace_of_boundary_identities
 the periodic constraints for each block.
 
 For each boundary-crossing interval, assume that for every complementary
-word \(\rho\) there is a matrix \(E\) such that, for every wrapped word
+word \(\rho\) there is a matrix \(E\) such that, for every cut word
 \(\beta\),
 \[
   \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E
@@ -734,12 +734,12 @@ theorem
   exact wordSpan_eq_top_of_ge_of_unital (A j) (hUnital j)
     ((wordSpan_eq_top_iff_isNBlkInjective (A j) L₀).mpr (hBlk j)) (by omega)
 
-/-- PGVWC complementary-word comparisons give the periodic constraints for each
+/-- Source complementary-word comparisons give the periodic constraints for each
 block under block injectivity.
 
 For each boundary-crossing interval beginning at \(i\), assume there are
 matrices \(C^j_{i,\rho}\) indexed by complementary words such that, for every
-wrapped word \(\beta\),
+cut word \(\beta\),
 \[
   A^j_\beta C^j_{i,\rho}
   =
@@ -781,12 +781,12 @@ theorem
     (sum_evalWord_mul_conjTranspose_evalWord (A j) (hUnital j) (N - L))
     (hCompat j i hi) ρ
 
-/-- PGVWC trace decompositions give the periodic constraints for each block
+/-- Source trace decompositions give the periodic constraints for each block
 under block injectivity.
 
 For each boundary-crossing interval beginning at \(i\), assume there are
 matrices \(C^j_{i,\rho}\) indexed by complementary words such that the two
-trace decompositions agree for every wrapped word \(\beta\), complementary word
+trace decompositions agree for every cut word \(\beta\), complementary word
 \(\rho\), and middle word \(w\):
 \[
   \sum_j\operatorname{tr}(A^j_\beta C^j_{i,\rho}A^j_w)
@@ -802,7 +802,7 @@ the blockwise identity
 The normalization \(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) and the
 compatibility identity for the complementary word \(\rho\) then give, for each
 block \(j\) and interval \(i\), a matrix \(E_{j,i,\rho}\) such that, for every
-wrapped word \(\beta\),
+cut word \(\beta\),
 \[
   ((\mu_j^NX_j)A^j_\beta)A^j_\rho=A^j_\beta E_{j,i,\rho}.
 \]
@@ -860,10 +860,10 @@ representation to periodic single-block states.
 Under the normalized BNT hypotheses, every vector in the block-diagonal
 periodic chain space has block-diagonal boundary conditions \(X_j\).  If those
 same boundary conditions satisfy the matrix identities, indexed by complementary
-words, that the Pérez-García--Verstraete--Wolf--Cirac proof derives after the
-trace-decomposition comparison and the normalized \(E^j\)-calculation: for every
+words, that the source proof derives after the trace-decomposition comparison
+and the normalized \(E^j\)-calculation: for every
 boundary-crossing interval \(i\),
-wrapped word \(\beta\), and complementary word \(\rho\),
+cut word \(\beta\), and complementary word \(\rho\),
 \[
   \mu_j^N X_jA^j_\beta A^j_\rho=A^j_\beta E_{j,i,\rho},
 \]
@@ -873,8 +873,9 @@ then the single-block vectors
 \]
 belong to \(\mathcal G_{N,L}(A_j)\).
 
-These identities are assumptions of this theorem. The PGVWC comparison theorem
-below gives the conclusion for each block from the displayed boundary-crossing
+These identities are assumptions of this theorem. The boundary-condition
+comparison theorem below gives the conclusion for each block from the displayed
+boundary-crossing
 form. Deriving this displayed form from the source comparison is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
@@ -887,8 +888,8 @@ arXiv:quant-ph/0608197, Theorem 12, proof lines 1454--1456.
 which uses boundary-crossing comparison hypotheses not derived from
 arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) comparison from arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1456, and discharge the currently assumed
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and discharge the currently assumed
 complementary-word identity; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
@@ -951,8 +952,8 @@ comparison.
 which uses boundary-crossing comparison hypotheses not derived from
 arXiv:2011.12127, Section IV.C, lines 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the PGVWC07 \(C^j,D^j,E^j\) comparison from arXiv:quant-ph/0608197,
-Theorem 12, proof lines 1446--1456, and discharge the currently assumed
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and discharge the currently assumed
 complementary-word identity; tracked in issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -7,7 +7,7 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace
 /-!
 # Boundary-condition comparisons for block-diagonal parent spaces
 
-The word-indexed Pérez-García--Verstraete--Wolf--Cirac comparison
+The word-indexed comparison from arXiv:quant-ph/0608197
 \[
   A^j_\beta C^j_{i,\rho}
   =
@@ -36,8 +36,8 @@ boundary representation to periodic single-block states.
 
 Under the normalized BNT hypotheses, every vector in the block-diagonal
 periodic-boundary ground space has block-diagonal boundary conditions \(X_j\). If those
-same boundary conditions satisfy the Pérez-García--Verstraete--Wolf--Cirac
-comparison, in the word-indexed boundary-crossing form
+same boundary conditions satisfy the source comparison, in the word-indexed
+boundary-crossing form
 \[
   A^j_\beta C^j_{i,\rho}
   =
@@ -52,8 +52,8 @@ into the boundary-crossing identities with \(E_{j,i,\rho}\).
 The words \(\beta\) and \(\rho\) are local coordinates for a boundary-crossing
 window, not terminology of the source statement.
 
-**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
-assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+**Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
@@ -64,9 +64,9 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1456, and use it to discharge the currently assumed comparison;
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+discharge the currently assumed comparison;
 tracked in issue 2971. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -119,9 +119,8 @@ Assume the block-diagonal periodic vector has already been written with
 block-diagonal boundary conditions \(X_j\).  For every cyclic interval crossing
 the cut, the local constraint puts the sum of the block restrictions in
 \(\bigvee_j G_L(A_j)\).  If the complementary tail words span the product
-matrix algebra in the corresponding length \(N-i\), the fixed-window
-Pérez-García--Verstraete--Wolf--Cirac comparison gives matrices
-\(C^j_{i,\rho}\) satisfying
+matrix algebra in the corresponding length \(N-i\), the source comparison gives
+matrices \(C^j_{i,\rho}\) satisfying
 \[
   A^j_\beta C^j_{i,\rho}
   =
@@ -137,8 +136,8 @@ complementary outside word produced by opening the cyclic interval;
 arXiv:quant-ph/0608197 writes the same step with the boundary indices \(i_1\)
 and \(i_{m+1}\).
 
-**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
-assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+**Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
@@ -251,12 +250,13 @@ Consequently
 \]
 and the length-\(N\) single-block spaces are independent.
 
-This is the equality-level form of PGVWC07, Theorem 12, proof lines 1436--1451,
+This is the equality-level form of Theorem 12 of arXiv:quant-ph/0608197,
+proof lines 1436--1451,
 specialized to the block-diagonal boundary conditions of
 arXiv:2011.12127, Section IV.C, lines 2126--2128.
 
-**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
-assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+**Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
@@ -264,8 +264,8 @@ range derived from length-\(L_0\) block injectivity,
 **Scope restriction (crossing span):** The theorem assumes that the simultaneous
 block-word tuples of length \(N-i\) span the product algebra for each
 boundary-crossing interval beginning at \(i\). Removing this visible span
-hypothesis from the finite BNT range is part of the remaining PGVWC07
-boundary-comparison cleanup recorded in
+hypothesis from the finite BNT range is part of the remaining source-faithful
+boundary comparison recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
 **Unfaithful:** This proof still relies on
@@ -305,7 +305,7 @@ theorem
           hNlarge hCrossingSpan hψ)
 
 /-- Boundary-crossing local constraints give the ground-space equality stated in
-Pérez-García--Verstraete--Wolf--Cirac, Theorem 12.
+Theorem 12 of arXiv:quant-ph/0608197.
 
 The preceding theorem proves this equality together with an independence
 statement for the length-\(N\) single-block spaces. This theorem records only
@@ -317,8 +317,8 @@ the equality conclusion
 \]
 which is the ground-space assertion in the source theorem.
 
-**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
-assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+**Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
@@ -326,8 +326,8 @@ range derived from length-\(L_0\) block injectivity,
 **Scope restriction (crossing span):** The theorem assumes that the simultaneous
 block-word tuples of length \(N-i\) span the product algebra for each
 boundary-crossing interval beginning at \(i\). Removing this visible span
-hypothesis from the finite BNT range is part of the remaining PGVWC07
-boundary-comparison cleanup recorded in
+hypothesis from the finite BNT range is part of the remaining source-faithful
+boundary comparison recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
 **Unfaithful:** This proof still relies on
@@ -375,14 +375,14 @@ for every boundary-crossing interval, local word \(\beta\) before the cut,
 and outside word \(\rho\), with \(D^j_\beta\) already specialized to
 \((\mu_j^NX_j)A^j_\beta\). The words \(\beta\) and \(\rho\) are formal
 word coordinates for the opened boundary comparison; they reindex the source
-end-site comparison by blocked words rather than replacing the source notation.
+end-site comparison by blocked words rather than replacing the source indices.
 The normalized \(E^j\)-calculation
 and the block-injective crossing-window argument then give the
 periodic-boundary single-block constraints, and hence the block-diagonal
 periodic-boundary equality.
 
-**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
-assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+**Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
@@ -393,7 +393,7 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
+derive the \(C^j,D^j,E^j\)
 boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1446--1456, and use it to discharge the currently assumed comparison;
 tracked in issue 2971. -/
@@ -440,7 +440,7 @@ theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_compa
           hNlarge hψ (fun X hψX => hComparison hψ X hψX))
 
 /-- The \(C^j,D^j\) boundary-condition comparison gives the ground-space
-equality stated in PGVWC07, Theorem 12.
+equality stated in Theorem 12 of arXiv:quant-ph/0608197.
 
 The preceding theorem proves this equality together with an independence
 statement for the length-\(N\) single-block spaces. This theorem records only
@@ -452,8 +452,8 @@ the equality conclusion
 \]
 under the assumed word-indexed \(C^j,D^j\) comparison.
 
-**Scope restriction (length-\(L_0\) injectivity range):** PGVWC07, Theorem 12,
-assumes \(L\ge 3(b-1)(L_0+1)+1\).  This theorem is stated in the current BNT
+**Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
 range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
@@ -464,7 +464,7 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
+derive the \(C^j,D^j,E^j\)
 boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1446--1456, and use it to discharge the currently assumed comparison;
 tracked in issue 2971. -/

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -7,8 +7,8 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace
 /-!
 # Finite-spanning versions of trace-decomposition results for block-diagonal parent spaces
 
-This file packages a finite-spanning form of the trace decompositions in
-Perez-Garcia--Verstraete--Wolf--Cirac, Theorem 12, into the block-diagonal
+This file records a finite-spanning form of the trace decompositions in
+Theorem 12 of arXiv:quant-ph/0608197 and applies it to the block-diagonal
 boundary and finite-range equality conclusions. The remaining source step is to
 derive that trace-decomposition equality from the \(C^j,D^j\) comparison after
 specializing \(D^j_\beta\) to the block-diagonal boundary expression
@@ -58,9 +58,9 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1456, and use it to discharge the currently assumed
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+discharge the currently assumed
 trace-decomposition equality; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
@@ -121,8 +121,8 @@ theorem
 equality in the finite BNT range.
 
 This theorem combines the block-diagonal boundary representation with the
-trace-decomposition form of the Pérez-García--Verstraete--Wolf--Cirac
-boundary-crossing comparison. It assumes a finite simultaneous word-spanning
+trace-decomposition form of the boundary-condition comparison in
+arXiv:quant-ph/0608197, Theorem 12. It assumes a finite simultaneous word-spanning
 length \(m\) and the trace equality at that length, for every
 boundary-crossing interval and every block-diagonal boundary representation.
 Deriving that equality from the source \(C^j,D^j\) comparison, with
@@ -135,9 +135,9 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the Perez-Garcia--Verstraete--Wolf--Cirac \(C^j,D^j,E^j\)
-boundary-condition comparison from arXiv:quant-ph/0608197, Theorem 12, proof
-lines 1446--1456, and use it to discharge the currently assumed
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+discharge the currently assumed
 trace-decomposition equality; tracked in issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -16,8 +16,8 @@ equality for the join of the block ground spaces.
 
 ## References
 
-* [Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12, proof around
-  \(A_b C_a=D_b A_a\) and \(E=\sum_a C_a A_a^\dagger\).
+* arXiv:quant-ph/0608197, Theorem 12, proof around \(A_b C_a=D_b A_a\)
+  and \(E=\sum_a C_a A_a^\dagger\).
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2021], Section IV.C, lines
   2120--2129.
 -/
@@ -61,7 +61,7 @@ theorem exists_sum_mem_of_mem_iSup_fin
     intro i
     exact Submodule.add_mem _ (hfy i) (hfz i)
 
-/-- The left-boundary summand in the PGVWC block-diagonal intersection proof:
+/-- The left-boundary summand in the source block-diagonal intersection proof:
 \[
   \sigma\longmapsto
   \operatorname{tr}(A_{\sigma_{n+2}} C_{\sigma_1}
@@ -75,7 +75,7 @@ noncomputable def pgvwc07LeftBoundaryComponent
     (A (σ (Fin.last (n + 1))) * C (σ 0) *
       evalWord A (List.ofFn (Fin.tail (Fin.init σ))))
 
-/-- Fixing the first physical index in the PGVWC left-boundary summand gives the
+/-- Fixing the first physical index in the source left-boundary summand gives the
 usual ground-space parametrization with boundary matrix \(C_a\). -/
 theorem restrictFirst_pgvwc07LeftBoundaryComponent
     (A : MPSTensor d D) (C : Fin d → Matrix (Fin D) (Fin D) ℂ)
@@ -169,7 +169,7 @@ theorem groundSpaceMap_cons_snoc_trace_boundary
     _ = Matrix.trace ((A b * X * A a) * evalWord A (List.ofFn w)) := by
             simp [Matrix.mul_assoc]
 
-/-- The left-boundary summand is a ground-space vector once the PGVWC boundary
+/-- The left-boundary summand is a ground-space vector once the boundary
 identity \(A_bC_a=A_bEA_a\) holds. -/
 theorem pgvwc07LeftBoundaryComponent_eq_groundSpaceMap
     (A : MPSTensor d D) (C : Fin d → Matrix (Fin D) (Fin D) ℂ)
@@ -211,7 +211,7 @@ theorem pgvwc07LeftBoundaryComponent_eq_groundSpaceMap
     _ = Matrix.trace (((A a * M) * A b) * E) := by
             rw [← Matrix.mul_assoc]
 
-/-- The left-boundary summand belongs to \(G_{n+2}(A)\) once the PGVWC
+/-- The left-boundary summand belongs to \(G_{n+2}(A)\) once the
 boundary identity \(A_bC_a=A_bEA_a\) holds. -/
 theorem pgvwc07LeftBoundaryComponent_mem_groundSpace
     (A : MPSTensor d D) (C : Fin d → Matrix (Fin D) (Fin D) ℂ)
@@ -222,7 +222,7 @@ theorem pgvwc07LeftBoundaryComponent_mem_groundSpace
   rw [groundSpace, LinearMap.mem_range]
   exact ⟨E, rfl⟩
 
-/-- A finite sum of PGVWC left-boundary summands lies in the supremum of the
+/-- A finite sum of source left-boundary summands lies in the supremum of the
 corresponding block ground spaces. -/
 theorem pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace
     {r : ℕ} {dim : Fin r → ℕ}
@@ -337,11 +337,11 @@ theorem block_matrices_eq_of_wordTupleSpanTop_trace
         using sub_eq_zero.mpr (hTrace w)) j
   exact sub_eq_zero.mp hzero
 
-/-- Blockwise boundary identities from membership of a PGVWC left-boundary
+/-- Blockwise boundary identities from membership of a source left-boundary
 trace decomposition in the block ground-space sum.
 
 This is the coefficient-comparison direction in the proof of
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12.  If a vector
+Theorem 12 of arXiv:quant-ph/0608197. If a vector
 with coefficients
 \[
   \sum_j\operatorname{tr}(A^j_b C^j_a A^j_w)
@@ -436,10 +436,10 @@ theorem pgvwc07_boundary_identities_of_leftBoundaryComponent_mem_iSup
     (fun k => A k b * C k a) (fun k => A k b * E k * A k a) hCoeff j
 
 /-- Boundary-matrix compatibility from equality of the two coefficient
-decompositions in the PGVWC block-diagonal intersection proof.
+decompositions in the source block-diagonal intersection proof.
 
 For fixed physical indices \(a,b\), the coefficient comparison in
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007], Theorem 12, gives
+Theorem 12 of arXiv:quant-ph/0608197 gives
 \[
   \sum_j \operatorname{tr}\!\left(
     A^j_b C^j_a A^j_{i_2}\cdots A^j_{i_m}\right)
@@ -467,12 +467,11 @@ theorem pgvwc07_blockwise_compatibility_of_trace_decomposition
     (fun k => A k b * C k a) (fun k => Dmat k b * A k a) (hCoeff a b) j
 
 /-- Word-valued boundary-matrix compatibility from equality of the two
-coefficient decompositions in the Perez-Garcia--Verstraete--Wolf--Cirac
-block-diagonal intersection proof.
+coefficient decompositions in the proof of Theorem 12 of arXiv:quant-ph/0608197.
 
 This is the same extraction as
 `pgvwc07_blockwise_compatibility_of_trace_decomposition`, with the boundary
-letters replaced by words.  If, for every wrapped word \(\beta\), complementary
+letters replaced by words. If, for every cut word \(\beta\), complementary
 word \(\rho\), and middle word \(w\), the two trace decompositions agree,
 then the blockwise matrices satisfy
 \[
@@ -508,10 +507,9 @@ theorem pgvwc07_blockwise_word_compatibility_of_trace_decomposition
     (hCoeff ρ β) j
 
 /-- Fixed complementary-word compatibility from equality of the two coefficient
-decompositions in the Perez-Garcia--Verstraete--Wolf--Cirac block-diagonal
-intersection proof.
+decompositions in the proof of Theorem 12 of arXiv:quant-ph/0608197.
 
-Fix a complementary word \(\rho\). If, for every wrapped word \(\beta\) and
+Fix a complementary word \(\rho\). If, for every cut word \(\beta\) and
 middle word \(w\), the trace decompositions agree with
 \[
   D^j_\beta=X_jA^j_\beta ,
@@ -590,13 +588,13 @@ theorem pgvwc07_complementary_word_compatibility_of_trace_decomposition
       (A := A) (m := m) (K := K) (M := M) hSpan C
       (fun j β => X j * evalWord (A j) (List.ofFn β)) hCoeff
 
-/-- Complementary-word boundary identities from the PGVWC trace decompositions.
+/-- Complementary-word boundary identities from the source trace decompositions.
 
 Assume the right trace decomposition has
 \[
   D^j_\beta=X_jA^j_\beta .
 \]
-If the two trace decompositions agree for every wrapped word \(\beta\),
+If the two trace decompositions agree for every cut word \(\beta\),
 complementary word \(\rho\), and middle word \(w\), then the normalization
 \(\sum_\rho A^j_\rho A^{j\dagger}_\rho=I\) and the compatibility identity give,
 for every block \(j\) and complementary word \(\rho\), a matrix \(E_{j,\rho}\)
@@ -645,7 +643,7 @@ theorem pgvwc07_complementary_word_boundary_identities_of_trace_decomposition
       (A := A) (m := m) (K := K) (M := M) hSpan X C hCoeff) j)
     ρ
 
-/-- The composed PGVWC open-segment step from the trace decompositions to
+/-- The composed open-segment step from the trace decompositions to
 membership in the supremum of block ground spaces.
 
 For a vector with left-boundary trace decomposition
@@ -664,8 +662,7 @@ imply
   \psi\in \bigvee_j G_{n+2}(A^j).
 \]
 This is the local membership step in
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197),
-Theorem 12, proof lines 1446--1452. -/
+Theorem 12 of arXiv:quant-ph/0608197, proof lines 1446--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -698,7 +695,7 @@ physical index or the last physical index always gives a vector in
 \[
   \bigvee_j G_{n+1}(A^j).
 \]
-Under the PGVWC common word-span hypothesis and the normalization
+Under the common word-span hypothesis and the normalization
 \[
   \sum_a A^j_a A^{j\dagger}_a=I,
 \]
@@ -707,8 +704,7 @@ the vector itself lies in
   \bigvee_j G_{n+2}(A^j).
 \]
 This is the restriction form of the open-segment step in
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197),
-Theorem 12, proof lines 1442--1452. -/
+Theorem 12 of arXiv:quant-ph/0608197, proof lines 1442--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -825,7 +821,7 @@ theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
 
 /-- One-step block intersection as a restriction characterization.
 
-Under the PGVWC common word-span hypothesis and the normalization
+Under the common word-span hypothesis and the normalization
 \[
   \sum_a A^j_a A^{j\dagger}_a=I,
 \]
@@ -837,8 +833,7 @@ equivalent to the two fixed-boundary conditions
   \psi(a,-)\in\bigvee_jG_{n+1}(A^j).
 \]
 This is the one-step block-intersection identity of
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197),
-Theorem 12, proof lines 1442--1452. -/
+Theorem 12 of arXiv:quant-ph/0608197, proof lines 1442--1452. -/
 theorem pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -894,7 +889,7 @@ theorem pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions
 
 /-- Subspace form of the one-step block intersection identity.
 
-Let \(S_n=\bigvee_jG_{n+1}(A^j)\).  Under the PGVWC common word-span
+Let \(S_n=\bigvee_jG_{n+1}(A^j)\). Under the common word-span
 hypothesis and the normalization
 \[
   \sum_a A^j_a A^{j\dagger}_a=I,
@@ -902,8 +897,7 @@ hypothesis and the normalization
 the \((n+2)\)-site block ground space is the intersection of the inverse
 images of \(S_n\) under all fixed last-letter and fixed first-letter
 restrictions.  This is the restriction-subspace form of
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197),
-Theorem 12, proof lines 1442--1452. -/
+Theorem 12 of arXiv:quant-ph/0608197, proof lines 1442--1452. -/
 theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
@@ -920,7 +914,7 @@ theorem pgvwc07_iSup_groundSpace_eq_restriction_intersection
   simpa [restrictLast, restrictFirst] using
     (pgvwc07_mem_iSup_groundSpace_iff_iSup_restrictions A hSpan hUnital ψ).symm
 
-/-- Product spans give the PGVWC one-step intersection identity as an internal
+/-- Product spans give the one-step block-intersection identity as an internal
 direct sum.
 
 Let
@@ -941,8 +935,8 @@ then \(S_{n+1}\) and \(\bigvee_jG_{n+2}(A^j)\) are internal direct sums, and
   \bigvee_jG_{n+2}(A^j).
 \]
 This is the one-step block-intersection formula of
-[Perez-Garcia--Verstraete--Wolf--Cirac 2007] (arXiv:quant-ph/0608197) together
-with the directness needed to read the joins as direct sums of local block
+Theorem 12 of arXiv:quant-ph/0608197 together with the directness needed to
+read the joins as direct sums of local block
 spaces. -/
 theorem pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop
     {r : ℕ} {dim : Fin r → ℕ}
@@ -962,7 +956,7 @@ theorem pgvwc07_directSum_restriction_intersection_of_wordTupleSpanTop
     groundSpace_iSupIndep_of_wordTupleSpanTop A hSpan_succ_succ,
     pgvwc07_iSup_groundSpace_eq_restriction_intersection A hSpan hUnital⟩
 
-/-- Period-window form of the PGVWC one-step block intersection.
+/-- Period-window form of the one-step block intersection.
 
 If a positive period and a complete residue window give full homogeneous
 blockwise product spans, then the one-step block-intersection subspace equality

--- a/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean
@@ -9,16 +9,15 @@ import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 /-!
 # Boundary matrix identities
 
-Normalized \(C,D,E\) boundary-matrix identities from the
-Perez-Garcia--Verstraete--Wolf--Cirac block-diagonal intersection proof: from
+Normalized \(C,D,E\) boundary-matrix identities from Theorem 12 of
+arXiv:quant-ph/0608197: from
 \(A_b C_a=D_b B_a\) with right-normalized \(B\) and
 \(E=\sum_a C_a B_a^\dagger\), one obtains \(D_b=A_b E\) and
 \(A_b C_a=A_b E B_a\).
 
 ## References
 
-* arXiv:quant-ph/0608197 (Perez-Garcia--Verstraete--Wolf--Cirac 2007),
-  Theorem 12, proof around \(A_b C_a=D_b A_a\) and
+* arXiv:quant-ph/0608197, Theorem 12, proof around \(A_b C_a=D_b A_a\) and
   \(E=\sum_a C_a A_a^\dagger\).
 -/
 
@@ -147,8 +146,8 @@ theorem pgvwc07_boundary_word_matrix_identities_of_compatibility
 
 /-- Two-length word-indexed boundary-matrix identities.
 
-This is the word-alphabet form of the \(C,D,E\) calculation in
-Perez-Garcia--Verstraete--Wolf--Cirac, Theorem 12, proof lines 1446--1451.
+This is the word-alphabet form of the \(C,D,E\) calculation in Theorem 12 of
+arXiv:quant-ph/0608197, proof lines 1446--1451.
 
 The two index sets are words of lengths \(K\) and \(M\):
 \[
@@ -156,7 +155,7 @@ The two index sets are words of lengths \(K\) and \(M\):
   \sum_\rho B_\rho B_\rho^\dagger=I.
 \]
 This is the word form needed when a boundary-crossing cyclic interval has a
-wrapped word and a complementary word of different lengths. -/
+cut word and a complementary word of different lengths. -/
 theorem pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
     (A : MPSTensor d D) {K M : ℕ}
     (C : (Fin M → Fin d) → Matrix (Fin D) (Fin D) ℂ)
@@ -184,17 +183,17 @@ theorem pgvwc07_boundary_word_matrix_identities_of_two_length_compatibility
 /-- Complementary-word boundary identities, with the \(E_\rho\) formula, from a
 two-length \(C,D,E\) comparison.
 
-This is the boundary-crossing form of the Perez-Garcia--Verstraete--Wolf--Cirac
-calculation in arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451.
+This is the boundary-crossing form of the calculation in Theorem 12 of
+arXiv:quant-ph/0608197, proof lines 1446--1451.
 
 Let \(X\in M_D(\mathbb C)\) be a matrix. Assume that for every complementary
-word \(\rho\) and wrapped word \(\beta\),
+word \(\rho\) and cut word \(\beta\),
 \[
   A_\beta C_\rho=(X A_\beta)A_\rho,
 \]
 and that the complementary-word products are right-normalized. Then, for every
 complementary word \(\rho\), there is a matrix \(E_\rho\) such that for every
-wrapped word \(\beta\),
+cut word \(\beta\),
 \[
   (X A_\beta)A_\rho=A_\beta E_\rho
 \]
@@ -243,17 +242,17 @@ theorem pgvwc07_complementary_word_boundary_identities_formula_of_compatibility
 /-- Complementary-word boundary identities from a two-length \(C,D,E\)
 comparison.
 
-This is the boundary-crossing form of the Perez-Garcia--Verstraete--Wolf--Cirac
-calculation in arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451.
+This is the boundary-crossing form of the calculation in Theorem 12 of
+arXiv:quant-ph/0608197, proof lines 1446--1451.
 
 Let \(X\in M_D(\mathbb C)\) be a matrix. Assume that for every complementary
-word \(\rho\) and wrapped word \(\beta\),
+word \(\rho\) and cut word \(\beta\),
 \[
   A_\beta C_\rho=(X A_\beta)A_\rho,
 \]
 and that the complementary-word products are right-normalized. Then, for every
 complementary word \(\rho\), there is a matrix \(E_\rho\) such that for every
-wrapped word \(\beta\),
+cut word \(\beta\),
 \[
   (X A_\beta)A_\rho=A_\beta E_\rho
 \]. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -333,7 +333,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[$C^j,D^j$ comparisons give the PGVWC07 ground-space equality]
+\begin{lemma}[$C^j,D^j$ comparisons give the periodic block ground-space equality]
     \label{lem:bnt_block_diagonal_pgvwc_comparison_ground_space}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison}
     \leanok
@@ -351,7 +351,8 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     independence of the \(N\)-site spaces is a separate conclusion of
     Lemma~\ref{lem:bnt_block_diagonal_pgvwc_comparison_equality}.
     The statement is still in the length-$L_0$ injectivity range displayed in
-    that lemma, not the shorter source range of PGVWC07.
+    that lemma, not the shorter range in
+    \cite[Theorem~12]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}
@@ -426,7 +427,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     gives the displayed equality and internality.
 \end{proof}
 
-\begin{lemma}[Boundary-crossing comparisons give the PGVWC07 ground-space equality]
+\begin{lemma}[Boundary-crossing comparisons give the periodic block ground-space equality]
     \label{lem:bnt_block_diagonal_crossing_pgvwc_comparison_ground_space}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison}
     \leanok
@@ -443,7 +444,8 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     $N$-site spaces is a separate conclusion of
     Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
     The statement is still in the length-$L_0$ injectivity range displayed in
-    that lemma, not the shorter source range of PGVWC07.
+    that lemma, not the shorter range in
+    \cite[Theorem~12]{PerezGarcia2007Matrix}.
 \end{lemma}
 
 \begin{proof}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -47,8 +47,8 @@ When weights are present, write
 \end{align}
 for the corresponding block-diagonal tensor.  The letters $g$ and $b$ both
 denote the number of blocks below: $g$ follows the review's block-injective
-canonical form notation, while $b$ follows PGVWC07's notation around
-Theorem~12.
+canonical form notation, while $b$ follows
+\cite[Theorem~12]{PerezGarcia2007MPSReps}.
 
 \section{The source assertion}
 
@@ -88,8 +88,9 @@ After blocking, the corresponding word-span statement is
 \end{align}
 
 The current Lean development separates the product-span input from
-the finite blocking hypothesis.  First, it proves the one-step PGVWC07
-intersection identity under the displayed product-span equation.  Then the
+the finite blocking hypothesis.  First, it proves the one-step intersection
+identity from \cite[Theorem~12]{PerezGarcia2007MPSReps} under the displayed
+product-span equation.  Then the
 normalized basis-of-normal-tensors (BNT) theorems derive that product span in
 the finite Condition C1 range from the injectivity of
 \begin{align}
@@ -281,13 +282,15 @@ as an unconditional hypothesis-free equality theorem in the source range.\footno
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1}, and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}.}
 
-The live blueprint records that larger source statement in source notation,
-without claiming that it is proved.\footnote{Blueprint locations:
+The live blueprint records that larger source statement with explicit citations
+and separately marks the local cut coordinates used by the formalization,
+without claiming that the source statement is proved.\footnote{Blueprint locations:
 \path{def:parent_hamiltonian_ground_space_bnt} for the block-diagonal
 periodic-boundary ground space,
 \path{lem:isup_chain_ground_space_block_le_assembled} for the forward
 inclusion, \path{thm:block_diagonal_ground_space_intersection} for the
-PGVWC07 block-diagonal intersection identity,
+block-diagonal intersection identity from
+\cite[Theorem~12]{PerezGarcia2007MPSReps},
 \path{thm:parent_ground_space_le_bnt_span} for the parent-ground-space
 containment, and \path{thm:gs_eq_bnt_span} for the final span statement, all in
 \path{blueprint/src/chapter/ch13_parent_hamiltonian_bnt_consequences.tex}.} With this notation,
@@ -453,11 +456,13 @@ every block $j$,
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
 This is the conditional reduction recorded by pull request~\#2724.  There are
-now two formal PGVWC comparison routes. The trace-decomposition route records
-the following implication. Assume the common word-span property for the
-middle-word length \(m\). If, for every boundary-crossing interval, word
+now two formal routes to the boundary-condition comparison. The
+trace-decomposition route records the following implication. Assume the common
+word-span property for the middle-word length \(m\). If, for every
+boundary-crossing interval, word
 $\beta$ before the cut, outside word $\rho$, and middle word $w$ of length \(m\),
-the two PGVWC07 trace comparisons satisfy
+the two trace comparisons from \cite[Theorem~12]{PerezGarcia2007MPSReps}
+satisfy
 \begin{align}
   \sum_j\tr\!\left(A^j_\beta C^j_\rho A^j_w\right)
   =
@@ -498,8 +503,8 @@ After \href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} was
 closed, the remaining source-comparison target is tracked by
 \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}: remove the
 remaining external boundary-representation input, and replace the
-span-dependent crossing-tail route by the PGVWC07 \(C^j,D^j,E^j\) comparison
-in the source range
+span-dependent crossing-tail route by the \(C^j,D^j,E^j\) comparison from
+\cite[Theorem~12]{PerezGarcia2007MPSReps} in the source range
 \begin{align}
   b\ge2,
   \qquad


### PR DESCRIPTION
### Motivation

- The block-diagonal parent-Hamiltonian blueprint prose and paper-gap note used reader-facing author-year shorthand where direct citations to Theorem 12 of arXiv:quant-ph/0608197 are clearer and required by the prose convention for source-dependent statements.
- The boundary-crossing coordinate symbols \(\beta\) and \(\rho\) were sometimes presented as source terminology rather than as local coordinates introduced by opening the cyclic interval at a cut.
- A few blueprint lemma titles named a source label instead of stating the mathematical content.

This PR is part of the source-citation alignment for the block-diagonal parent ground-space. It does not close #2971; the external boundary-comparison hypotheses remain visible. Refs #2971.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`: replace author-year shorthand in docstrings with direct citations to Theorem 12 of arXiv:quant-ph/0608197, and clarify that \(\beta\) and \(\rho\) are local cut coordinates.
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`: align docstrings to cite the comparison identity by its source location.
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`: update boundary-condition terminology and use “cut word” for the opened cyclic interval coordinate.
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`: align dependent unfaithful-marker docstrings with the same source-citation phrasing.
- `TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean` and `TNLean/MPS/ParentHamiltonian/BoundaryMatrixIdentities.lean`: propagate the same “cut word” convention and direct Theorem 12 citations in sibling parent-Hamiltonian docstrings.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`: retitle affected lemmas to state the periodic block ground-space equality, and cite `\cite[Theorem~12]{PerezGarcia2007Matrix}` for the source range.
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: update the paper-gap note so it separately names source citations and local cut coordinates.

No Lean theorem statement, definition body, or proof term is changed; this is a documentation and blueprint prose cleanup.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities`
- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

The full `lake build TNLean` completed successfully; it still reports pre-existing style/header warnings and known existing `sorry` warnings outside this prose cleanup.