### PR TITLE
doc(parent): sync martingale anticommutator gap note

### DIFF
--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -281,10 +281,20 @@ The blueprint item labelled \path{lem:martingale_mps} in
 separates the finite-row martingale reduction from the still-open quantitative
 estimate.
 It does not assert that the displayed all-$L>1$ cyclic-window bound has already
-been obtained from the cited principal-angle estimates. Instead, it states that
-bound as the hypothesis of Theorem \path{thm:friedrichs_gap_bound}.
+been obtained from the cited principal-angle estimates. Instead, it records the
+source anticommutator estimate as the hypothesis of
+Theorem \path{thm:anticommutator_gap_bound}, and records norm-compression
+estimates as sufficient stronger hypotheses.
 
-The corresponding theorem entries
+The source-facing theorem entry
+\path{thm:anticommutator_gap_bound} points to
+\leanid{parentHamiltonianES_gap_bound_of_anticommutator} in
+\path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. Its hypothesis is the
+cyclic-window anticommutator lower bound with coefficient
+\[
+    \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}.
+\]
+The theorem entries
 \path{thm:friedrichs_gap_bound} and
 \path{thm:friedrichs_gap_bound_constant} point respectively to the special
 coefficient theorem and to the constant-$\eta$ theorem in
@@ -295,11 +305,11 @@ theorem is the specialization of the constant-$\eta$ theorem with
     \qquad
     1-\eta\,2(L-1)=\frac{1}{4L}.
 \]
-Both theorem entries are therefore conditional on the same norm-compression
-input, specialized either to this displayed coefficient or to an arbitrary
-coefficient satisfying (E). Thus all finite-row, cyclic-window, non-overlap,
-norm-compression, and spectral-theorem reductions are proved, while the
-MPS-specific principal-angle or norm-compression estimate remains to be proved
+The two norm-compression theorem entries are therefore conditional on the same
+stronger input, specialized either to this displayed coefficient or to an
+arbitrary coefficient satisfying (E). Thus all finite-row, cyclic-window,
+non-overlap, anticommutator, norm-compression, and spectral-theorem reductions
+are proved, while the MPS-specific anticommutator estimate remains to be proved
 or matched precisely to the cited martingale estimates.
 
 Once the quantitative comparison with the cited martingale estimates is settled,


### PR DESCRIPTION
### Motivation

- `docs/paper-gaps/cpgsv21_martingale_overlap.tex` records the gap between the formal martingale reduction (arXiv:2011.12127 §IV.C, `eq:4:martingale-2`) and the MPS-specific anticommutator estimate still to be proved. The blueprint-relation section was missing an explicit reference to `thm:anticommutator_gap_bound` as the source-facing cyclic-window anticommutator boundary.
- Keeps the paper-gap note aligned with the current state of `Martingale/Gap.lean`, which exposes `parentHamiltonianES_gap_bound_of_anticommutator` as the anticommutator lower-bound entry point.
- Partial documentation step toward closing the principal-angle estimate tracked in #952; see also #460, #190.

### Description

- Updates `docs/paper-gaps/cpgsv21_martingale_overlap.tex`:
  - Names `thm:anticommutator_gap_bound` as the source-facing cyclic-window anticommutator boundary in the **Relation to the blueprint** section, with a pointer to `parentHamiltonianES_gap_bound_of_anticommutator` in `Gap.lean`.
  - Retains `thm:friedrichs_gap_bound` and `thm:friedrichs_gap_bound_constant` as the stronger norm-compression route sharing the same specialized coefficient when η is fixed.
  - Clarifies that the finite-row, cyclic-window, anticommutator, norm-compression, and spectral-theorem reductions are all proved; the remaining open work is the anticommutator estimate itself (not only the principal-angle / norm-compression wording).
- Documentation-only change; no Lean source or blueprint `.tex` files are modified.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

---
Refs #952

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX prose with no Lean or runtime behavior changes.
>
> **Overview**
> Updates the **Relation to the blueprint** section in `docs/paper-gaps/cpgsv21_martingale_overlap.tex` so it matches how the formal blueprint splits the martingale gap story.
>
> The note now treats **`thm:anticommutator_gap_bound`** as the **source-facing** boundary: the cyclic-window anticommutator lower bound (with the displayed coefficient) is recorded as that theorem's hypothesis, with a pointer to `parentHamiltonianES_gap_bound_of_anticommutator` in `Gap.lean`. **`thm:friedrichs_gap_bound`** and **`thm:friedrichs_gap_bound_constant`** are described as the **stronger norm-compression** route that still shares the same specialized coefficient when \(\eta\) is fixed.
>
> The closing paragraph is reworded so the proved reductions explicitly include **anticommutator** steps, and the open MPS-specific work is named as the **anticommutator estimate** (not only principal-angle / norm-compression wording).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 879fd54357e6c2553b8dee80b70606aa6260c194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>