### PR TITLE
feat(Channel): connect IsCPMap to Mathlib's CompletelyPositiveMap

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -58,6 +58,7 @@ import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring
 import TNLean.Channel.OrderedCP
+import TNLean.Channel.CompletelyPositiveBridge
 import TNLean.Channel.RadonNikodym
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.POVM

--- a/TNLean/Channel/CompletelyPositiveBridge.lean
+++ b/TNLean/Channel/CompletelyPositiveBridge.lean
@@ -6,7 +6,7 @@ import TNLean.Channel.Basic
 import Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap
 
 /-!
-# Bridge from Kraus positivity to Mathlib's completely positive maps
+# Kraus complete positivity as a Mathlib completely positive map
 
 This file connects TNLean's concrete Kraus-operator notion of complete positivity
 (`IsCPMap`) to Mathlib's abstract C⋆-algebra type `CompletelyPositiveMap`.
@@ -21,16 +21,16 @@ the entrywise image of a positive block matrix `M` under a single Kraus term
 `dᵢ` carrying `Kᵢ` on every diagonal entry.  Conjugation preserves positivity
 (`star_right_conjugate_nonneg`), and a finite sum of positive elements is positive.
 
-The bridge makes the Kraus/Stinespring characterisation already formalised in
-`TNLean/Channel/` visible to Mathlib's abstract positive-map and
-completely-positive-map API, without discarding the concrete finite-dimensional
-channel interface used for Wolf-style theorems.
+Every Kraus-represented completely positive map thus satisfies the Mathlib
+`CompletelyPositiveMap` positivity condition, making the concrete
+finite-dimensional channel results available alongside the abstract
+C⋆-algebra positivity theory.
 
 ## Main results
 
 * `IsCPMap.map_cstarMatrix_nonneg` — the entrywise complete-positivity inequality.
-* `IsCPMap.toCompletelyPositiveMap` — packages an `IsCPMap` as a Mathlib
-  `CompletelyPositiveMap`.
+* `IsCPMap.toCompletelyPositiveMap` — exhibits a Kraus-represented completely
+  positive map as a Mathlib `CompletelyPositiveMap`.
 
 ## References
 
@@ -73,17 +73,7 @@ private lemma conjugate_blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin 
     ite_mul, zero_mul, mul_ite, mul_zero, Finset.sum_ite_eq, Finset.sum_ite_eq',
     Finset.mem_univ, if_true]
 
-/-- Entrywise evaluation commutes with finite sums of `CStarMatrix` values. -/
-private lemma cstar_sum_apply {ι m nn A : Type*} [AddCommMonoid A] (s : Finset ι)
-    (G : ι → CStarMatrix m nn A) (a : m) (b : nn) :
-    (∑ i ∈ s, G i) a b = ∑ i ∈ s, G i a b := by
-  classical
-  induction s using Finset.induction with
-  | empty => simp
-  | insert x s hx ih =>
-      rw [Finset.sum_insert hx, Finset.sum_insert hx, CStarMatrix.add_apply, ih]
-
-/-- A linear self-map of `M_D(ℂ)`, reinterpreted as a linear self-map of the
+/-- A linear self-map of `M_D(ℂ)`, identified with a linear self-map of the
 C⋆-algebra `CStarMatrix (Fin D) (Fin D) ℂ` (the two types are definitionally
 equal). -/
 def cstarMap (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
@@ -113,7 +103,8 @@ private lemma map_eq_sum_conjugate
   rw [hmap]
   apply CStarMatrix.ext
   intro a b
-  rw [CStarMatrix.map_apply, cstar_sum_apply]
+  rw [CStarMatrix.map_apply]
+  erw [Matrix.sum_apply]
   simp only [conjugate_blockDiagConst_apply]
 
 /-- **Kraus complete positivity, entrywise form.** If `E` is completely positive
@@ -129,13 +120,18 @@ theorem map_cstarMatrix_nonneg
   exact Finset.sum_nonneg fun i _ =>
     star_right_conjugate_nonneg hM (blockDiagConst k (K i))
 
-/-- **Bridge to Mathlib's `CompletelyPositiveMap`.** A TNLean completely positive
-map (`IsCPMap`, defined through a Kraus representation) is a Mathlib completely
-positive map on `CStarMatrix (Fin D) (Fin D) ℂ`. -/
+/-- **Kraus complete positivity implies the Mathlib condition.** Every completely
+positive map admitting a Kraus representation `E(X) = ∑ᵢ Kᵢ X Kᵢ†` is a
+Mathlib `CompletelyPositiveMap` on `CStarMatrix (Fin D) (Fin D) ℂ`. -/
 def toCompletelyPositiveMap
     {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} (hE : IsCPMap E) :
     CStarMatrix (Fin D) (Fin D) ℂ →CP CStarMatrix (Fin D) (Fin D) ℂ where
   toLinearMap := cstarMap E
   map_cstarMatrix_nonneg' k M hM := hE.map_cstarMatrix_nonneg k M hM
+
+@[simp] lemma toCompletelyPositiveMap_apply
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} (hE : IsCPMap E)
+    (X : CStarMatrix (Fin D) (Fin D) ℂ) :
+    hE.toCompletelyPositiveMap X = E X := rfl
 
 end IsCPMap

--- a/TNLean/Channel/CompletelyPositiveBridge.lean
+++ b/TNLean/Channel/CompletelyPositiveBridge.lean
@@ -19,7 +19,7 @@ entrywise to a positive `k × k` matrix over `A₁` yields a positive matrix ove
 the entrywise image of a positive block matrix `M` under a single Kraus term
 `X ↦ Kᵢ X Kᵢ†` equals the conjugation `dᵢ * M * dᵢ†` by the block-diagonal matrix
 `dᵢ` carrying `Kᵢ` on every diagonal entry.  Conjugation preserves positivity
-(`star_right_conjugate_nonneg`), and a finite sum of positive elements is positive.
+and a finite sum of positive elements is positive.
 
 Every Kraus-represented completely positive map thus satisfies the Mathlib
 `CompletelyPositiveMap` positivity condition, making the concrete
@@ -103,8 +103,10 @@ private lemma map_eq_sum_conjugate
   rw [hmap]
   apply CStarMatrix.ext
   intro a b
-  rw [CStarMatrix.map_apply]
-  erw [Matrix.sum_apply]
+  rw [CStarMatrix.map_apply,
+    show (∑ i, blockDiagConst k (K i) * M * star (blockDiagConst k (K i))) a b
+        = ∑ i, (blockDiagConst k (K i) * M * star (blockDiagConst k (K i))) a b
+      from Matrix.sum_apply a b Finset.univ _]
   simp only [conjugate_blockDiagConst_apply]
 
 /-- **Kraus complete positivity, entrywise form.** If `E` is completely positive

--- a/TNLean/Channel/CompletelyPositiveBridge.lean
+++ b/TNLean/Channel/CompletelyPositiveBridge.lean
@@ -6,10 +6,10 @@ import TNLean.Channel.Basic
 import Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap
 
 /-!
-# Kraus complete positivity as a Mathlib completely positive map
+# Kraus complete positivity as complete positivity on C⋆-matrices
 
 This file connects TNLean's concrete Kraus-operator notion of complete positivity
-(`IsCPMap`) to Mathlib's abstract C⋆-algebra type `CompletelyPositiveMap`.
+(`IsCPMap`) to the abstract C⋆-algebra type `CompletelyPositiveMap`.
 
 A completely positive map in TNLean is a linear map `E : M_D(ℂ) →ₗ[ℂ] M_D(ℂ)`
 admitting a Kraus representation `E(X) = ∑ᵢ Kᵢ X Kᵢ†` (`IsCPMap`).  Mathlib's
@@ -21,16 +21,16 @@ the entrywise image of a positive block matrix `M` under a single Kraus term
 `dᵢ` carrying `Kᵢ` on every diagonal entry.  Conjugation preserves positivity
 and a finite sum of positive elements is positive.
 
-Every Kraus-represented completely positive map thus satisfies the Mathlib
+Every Kraus-represented completely positive map therefore satisfies the
 `CompletelyPositiveMap` positivity condition, making the concrete
-finite-dimensional channel results available alongside the abstract
-C⋆-algebra positivity theory.
+finite-dimensional channel results available alongside the abstract C⋆-algebra
+positivity theory.
 
 ## Main results
 
 * `IsCPMap.map_cstarMatrix_nonneg` — the entrywise complete-positivity inequality.
-* `IsCPMap.toCompletelyPositiveMap` — exhibits a Kraus-represented completely
-  positive map as a Mathlib `CompletelyPositiveMap`.
+* `IsCPMap.toCompletelyPositiveMap` — exhibits an `IsCPMap` as a
+  `CompletelyPositiveMap`.
 
 ## References
 
@@ -73,7 +73,7 @@ private lemma conjugate_blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin 
     ite_mul, zero_mul, mul_ite, mul_zero, Finset.sum_ite_eq, Finset.sum_ite_eq',
     Finset.mem_univ, if_true]
 
-/-- A linear self-map of `M_D(ℂ)`, identified with a linear self-map of the
+/-- A linear self-map of `M_D(ℂ)`, reinterpreted as a linear self-map of the
 C⋆-algebra `CStarMatrix (Fin D) (Fin D) ℂ` (the two types are definitionally
 equal). -/
 def cstarMap (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
@@ -122,9 +122,9 @@ theorem map_cstarMatrix_nonneg
   exact Finset.sum_nonneg fun i _ =>
     star_right_conjugate_nonneg hM (blockDiagConst k (K i))
 
-/-- **Kraus complete positivity implies the Mathlib condition.** Every completely
-positive map admitting a Kraus representation `E(X) = ∑ᵢ Kᵢ X Kᵢ†` is a
-Mathlib `CompletelyPositiveMap` on `CStarMatrix (Fin D) (Fin D) ℂ`. -/
+/-- **Kraus complete positivity implies the abstract condition.** A linear map
+admitting a Kraus representation `E(X) = ∑ᵢ Kᵢ X Kᵢ†` is a completely positive
+map on `CStarMatrix (Fin D) (Fin D) ℂ`. -/
 def toCompletelyPositiveMap
     {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} (hE : IsCPMap E) :
     CStarMatrix (Fin D) (Fin D) ℂ →CP CStarMatrix (Fin D) (Fin D) ℂ where

--- a/TNLean/Channel/CompletelyPositiveBridge.lean
+++ b/TNLean/Channel/CompletelyPositiveBridge.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Basic
+import Mathlib.Analysis.CStarAlgebra.CompletelyPositiveMap
+
+/-!
+# Bridge from Kraus positivity to Mathlib's completely positive maps
+
+This file connects TNLean's concrete Kraus-operator notion of complete positivity
+(`IsCPMap`) to Mathlib's abstract C⋆-algebra type `CompletelyPositiveMap`.
+
+A completely positive map in TNLean is a linear map `E : M_D(ℂ) →ₗ[ℂ] M_D(ℂ)`
+admitting a Kraus representation `E(X) = ∑ᵢ Kᵢ X Kᵢ†` (`IsCPMap`).  Mathlib's
+`CompletelyPositiveMap A₁ A₂` requires that, for every `k`, applying the map
+entrywise to a positive `k × k` matrix over `A₁` yields a positive matrix over
+`A₂`.  Identifying `M_D(ℂ)` with the C⋆-algebra `CStarMatrix (Fin D) (Fin D) ℂ`,
+the entrywise image of a positive block matrix `M` under a single Kraus term
+`X ↦ Kᵢ X Kᵢ†` equals the conjugation `dᵢ * M * dᵢ†` by the block-diagonal matrix
+`dᵢ` carrying `Kᵢ` on every diagonal entry.  Conjugation preserves positivity
+(`star_right_conjugate_nonneg`), and a finite sum of positive elements is positive.
+
+The bridge makes the Kraus/Stinespring characterisation already formalised in
+`TNLean/Channel/` visible to Mathlib's abstract positive-map and
+completely-positive-map API, without discarding the concrete finite-dimensional
+channel interface used for Wolf-style theorems.
+
+## Main results
+
+* `IsCPMap.map_cstarMatrix_nonneg` — the entrywise complete-positivity inequality.
+* `IsCPMap.toCompletelyPositiveMap` — packages an `IsCPMap` as a Mathlib
+  `CompletelyPositiveMap`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.1][Wolf2012QChannels]
+-/
+
+open scoped Matrix CStarAlgebra ComplexOrder MatrixOrder
+open Matrix
+
+variable {D : ℕ}
+
+namespace IsCPMap
+
+/-- The block-diagonal `k × k` matrix over `M_D(ℂ)` carrying the operator `W`
+on every diagonal entry.  Conjugation of a block matrix by this element realises
+the entrywise action of the single Kraus term `X ↦ W * X * Wᴴ`. -/
+private def blockDiagConst (k : ℕ) (W : Matrix (Fin D) (Fin D) ℂ) :
+    CStarMatrix (Fin k) (Fin k) (CStarMatrix (Fin D) (Fin D) ℂ) :=
+  Matrix.diagonal (fun _ : Fin k => CStarMatrix.ofMatrix W)
+
+private lemma blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin D) ℂ) (a b : Fin k) :
+    blockDiagConst k W a b = if a = b then CStarMatrix.ofMatrix W else 0 := by
+  simp [blockDiagConst, Matrix.diagonal_apply]
+
+private lemma star_blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin D) ℂ) (a b : Fin k) :
+    star (blockDiagConst k W) a b = if a = b then star (CStarMatrix.ofMatrix W) else 0 := by
+  rw [CStarMatrix.star_apply, blockDiagConst_apply]
+  by_cases h : a = b
+  · subst h; simp
+  · rw [if_neg (fun h' => h h'.symm), if_neg h, star_zero]
+
+/-- Conjugating a block matrix `M` by `blockDiagConst k W` acts entrywise as the
+single Kraus term `X ↦ W * X * Wᴴ`. -/
+private lemma conjugate_blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin D) ℂ)
+    (M : CStarMatrix (Fin k) (Fin k) (CStarMatrix (Fin D) (Fin D) ℂ)) (a b : Fin k) :
+    (blockDiagConst k W * M * star (blockDiagConst k W)) a b
+      = CStarMatrix.ofMatrix W * M a b * star (CStarMatrix.ofMatrix W) := by
+  classical
+  simp only [CStarMatrix.mul_apply, blockDiagConst_apply, star_blockDiagConst_apply,
+    ite_mul, zero_mul, mul_ite, mul_zero, Finset.sum_ite_eq, Finset.sum_ite_eq',
+    Finset.mem_univ, if_true]
+
+/-- Entrywise evaluation commutes with finite sums of `CStarMatrix` values. -/
+private lemma cstar_sum_apply {ι m nn A : Type*} [AddCommMonoid A] (s : Finset ι)
+    (G : ι → CStarMatrix m nn A) (a : m) (b : nn) :
+    (∑ i ∈ s, G i) a b = ∑ i ∈ s, G i a b := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert x s hx ih =>
+      rw [Finset.sum_insert hx, Finset.sum_insert hx, CStarMatrix.add_apply, ih]
+
+/-- A linear self-map of `M_D(ℂ)`, reinterpreted as a linear self-map of the
+C⋆-algebra `CStarMatrix (Fin D) (Fin D) ℂ` (the two types are definitionally
+equal). -/
+def cstarMap (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    CStarMatrix (Fin D) (Fin D) ℂ →ₗ[ℂ] CStarMatrix (Fin D) (Fin D) ℂ := E
+
+@[simp] lemma cstarMap_apply
+    (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : CStarMatrix (Fin D) (Fin D) ℂ) : cstarMap E X = E X := rfl
+
+/-- For a Kraus family `K`, the entrywise image of a block matrix `M` under
+`E(X) = ∑ᵢ Kᵢ X Kᵢ†` is the sum of conjugations by the block-diagonal Kraus
+matrices. -/
+private lemma map_eq_sum_conjugate
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    {r : ℕ} {K : Fin r → Matrix (Fin D) (Fin D) ℂ}
+    (hK : ∀ X, E X = ∑ i, K i * X * (K i)ᴴ) (k : ℕ)
+    (M : CStarMatrix (Fin k) (Fin k) (CStarMatrix (Fin D) (Fin D) ℂ)) :
+    M.map (cstarMap E)
+      = ∑ i, blockDiagConst k (K i) * M * star (blockDiagConst k (K i)) := by
+  have hmap : M.map (cstarMap E)
+      = M.map fun X =>
+        ∑ i, CStarMatrix.ofMatrix (K i) * X * star (CStarMatrix.ofMatrix (K i)) := by
+    apply CStarMatrix.ext
+    intro a b
+    rw [CStarMatrix.map_apply, CStarMatrix.map_apply, cstarMap_apply, hK]
+    rfl
+  rw [hmap]
+  apply CStarMatrix.ext
+  intro a b
+  rw [CStarMatrix.map_apply, cstar_sum_apply]
+  simp only [conjugate_blockDiagConst_apply]
+
+/-- **Kraus complete positivity, entrywise form.** If `E` is completely positive
+(admits a Kraus representation), then applying `E` entrywise to a positive block
+matrix over `M_D(ℂ)` yields a positive block matrix.  This is the defining
+property of a Mathlib `CompletelyPositiveMap`. -/
+theorem map_cstarMatrix_nonneg
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} (hE : IsCPMap E)
+    (k : ℕ) (M : CStarMatrix (Fin k) (Fin k) (CStarMatrix (Fin D) (Fin D) ℂ))
+    (hM : 0 ≤ M) : 0 ≤ M.map (cstarMap E) := by
+  obtain ⟨r, K, hK⟩ := hE
+  rw [map_eq_sum_conjugate hK k M]
+  exact Finset.sum_nonneg fun i _ =>
+    star_right_conjugate_nonneg hM (blockDiagConst k (K i))
+
+/-- **Bridge to Mathlib's `CompletelyPositiveMap`.** A TNLean completely positive
+map (`IsCPMap`, defined through a Kraus representation) is a Mathlib completely
+positive map on `CStarMatrix (Fin D) (Fin D) ℂ`. -/
+def toCompletelyPositiveMap
+    {E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} (hE : IsCPMap E) :
+    CStarMatrix (Fin D) (Fin D) ℂ →CP CStarMatrix (Fin D) (Fin D) ℂ where
+  toLinearMap := cstarMap E
+  map_cstarMatrix_nonneg' k M hM := hE.map_cstarMatrix_nonneg k M hM
+
+end IsCPMap

--- a/TNLean/Channel/CompletelyPositiveBridge.lean
+++ b/TNLean/Channel/CompletelyPositiveBridge.lean
@@ -73,7 +73,7 @@ private lemma conjugate_blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin 
     ite_mul, zero_mul, mul_ite, mul_zero, Finset.sum_ite_eq, Finset.sum_ite_eq',
     Finset.mem_univ, if_true]
 
-/-- A linear self-map of `M_D(ℂ)`, reinterpreted as a linear self-map of the
+/-- A linear self-map of `M_D(ℂ)`, identified with a linear self-map of the
 C⋆-algebra `CStarMatrix (Fin D) (Fin D) ℂ` (the two types are definitionally
 equal). -/
 def cstarMap (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -49,6 +49,40 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     to $E \otimes \id_n$ being positive for all~$n$.
 \end{definition}
 
+\begin{theorem}[Entrywise complete positivity from a Kraus representation]
+    \label{thm:cp_map_entrywise_complete_positive}
+    \lean{IsCPMap.map_cstarMatrix_nonneg}
+    \leanok
+    \uses{def:cp_map}
+    Let $E : \MN{D} \to \MN{D}$ be completely positive in the Kraus sense.
+    For every $k$ and every positive block matrix
+    $M \in M_k(\MN{D})$, the entrywise image
+    \[
+        (E(M_{ab}))_{a,b}
+    \]
+    is again positive in $M_k(\MN{D})$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Write $E(X)=\sum_i K_i X K_i^\dagger$.  For each $i$, let $d_i$ be
+    the block-diagonal matrix with $K_i$ on every diagonal block.  Then
+    \[
+        (E(M_{ab}))_{a,b}=\sum_i d_i M d_i^\dagger .
+    \]
+    Each term on the right is positive because conjugation preserves
+    positivity, and a finite sum of positive matrices is positive.
+\end{proof}
+
+\begin{definition}[Kraus maps as abstract completely positive maps]
+    \label{def:cp_map_to_abstract_completely_positive}
+    \lean{IsCPMap.toCompletelyPositiveMap}
+    \leanok
+    \uses{def:cp_map, thm:cp_map_entrywise_complete_positive}
+    Every Kraus-represented completely positive map
+    $E : \MN{D} \to \MN{D}$ determines a completely positive map between
+    the matrix $C^*$-algebras in the entrywise positivity sense.
+\end{definition}
+
 \begin{theorem}[CP maps are positive]\label{thm:cp_is_positive}
     \lean{IsCPMap.isPositiveMap}
     \leanok

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -73,15 +73,20 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     positivity, and a finite sum of positive matrices is positive.
 \end{proof}
 
-\begin{definition}[Kraus maps as abstract completely positive maps]
-    \label{def:cp_map_to_abstract_completely_positive}
+\begin{theorem}[Kraus maps as abstract completely positive maps]
+    \label{thm:cp_map_to_abstract_completely_positive}
     \lean{IsCPMap.toCompletelyPositiveMap}
     \leanok
     \uses{def:cp_map, thm:cp_map_entrywise_complete_positive}
     Every Kraus-represented completely positive map
     $E : \MN{D} \to \MN{D}$ determines a completely positive map between
     the matrix $C^*$-algebras in the entrywise positivity sense.
-\end{definition}
+\end{theorem}
+
+\begin{proof}\leanok
+    The defining entrywise positivity condition is exactly
+    Theorem~\ref{thm:cp_map_entrywise_complete_positive}.
+\end{proof}
 
 \begin{theorem}[CP maps are positive]\label{thm:cp_is_positive}
     \lean{IsCPMap.isPositiveMap}


### PR DESCRIPTION
### Motivation
- Implements §6 of `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md` (introduced in LionSR/TNLean#3011): connect TNLean's Kraus-operator complete positivity (`IsCPMap`) to Mathlib 4.31's abstract `CompletelyPositiveMap` typeclass on `CStarMatrix (Fin D) (Fin D) ℂ`.
- Enables downstream use of the `PositiveLinearMap` API for self-adjointness and monotonicity results in `TNLean/Channel/Schwarz/OperatorJensenAux.lean` (Wolf §5, Theorems 5.11–5.13) once the connection to Mathlib's abstract types is established.
- Continues the formalization of Wolf Ch. 2 Kraus and Stinespring representations; see LionSR/QICLean#158.

### Description
- Added `TNLean/Channel/CompletelyPositiveBridge.lean` with three new proof-clean declarations (no `sorry` or `axiom`):
  - `IsCPMap.cstarMap` — the channel retyped as a self-map of `CStarMatrix (Fin D) (Fin D) ℂ`.
  - `IsCPMap.map_cstarMatrix_nonneg` — for a Kraus representation E(X) = ∑ᵢ Kᵢ X Kᵢ†, applying E entrywise to a positive block matrix M over M_D(ℂ) yields a positive block matrix; each Kraus term acts as conjugation by the block-diagonal matrix dᵢ (carrying Kᵢ on every diagonal entry), and conjugation preserves positivity via `star_right_conjugate_nonneg`.
  - `IsCPMap.toCompletelyPositiveMap` — produces a Mathlib `CompletelyPositiveMap` from an `IsCPMap`.
- Modified `TNLean.lean` to import the new module in the channel layer.
- The `PositiveLinearMap` connection already exists in `Channel/Basic.lean` (`IsPositiveMap.toPositiveLinearMap`); this PR supplies the missing `CompletelyPositiveMap` half.

### Testing
- Lean CI (`lean_action_ci.yml`) validates the full build.
- New declarations contain no `sorry` or `axiom`.

---
Addresses LionSR/QICLean#158

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; no changes to runtime behavior or existing channel semantics beyond a new import in the build graph.
> 
> **Overview**
> Adds a **bridge** from TNLean’s Kraus-based `IsCPMap` to Mathlib’s abstract `CompletelyPositiveMap` on `CStarMatrix (Fin D) (Fin D) ℂ`, so channel proofs can use the C⋆-algebra positivity API (e.g. downstream Schwarz/Jensen work).
> 
> New module `TNLean/Channel/CompletelyPositiveBridge.lean` shows that entrywise application of a Kraus map to a positive block matrix is a sum of block-diagonal conjugations (`blockDiagConst`), hence nonnegative via `star_right_conjugate_nonneg`. Main lemmas: `IsCPMap.map_cstarMatrix_nonneg` and `IsCPMap.toCompletelyPositiveMap`, plus `cstarMap` as the definitional retyping of the linear map.
> 
> `TNLean.lean` imports the module in the channel layer. Blueprint **ch04** documents the entrywise CP theorem and the abstract `CompletelyPositiveMap` packaging, linked to the Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8866d770ef361812e1ae85adfd79f5f9169eb15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->