### PR TITLE
chore(mathlib): use native idempotent and order facts

### DIFF
--- a/TNLean/Algebra/ProjectionTriangularTrace.lean
+++ b/TNLean/Algebra/ProjectionTriangularTrace.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Defs
 import TNLean.Channel.Irreducible.Basic
+import Mathlib.Algebra.Ring.Idempotent
 
 /-!
 # Projection-triangular trace lemma
@@ -45,16 +46,13 @@ lemma proj_add_projCompl : P + (1 - P) = (1 : Matrix (Fin D) (Fin D) ℂ) := by
   simp
 
 lemma proj_mul_projCompl (hP : IsOrthogonalProjection P) : P * (1 - P) = 0 := by
-  -- `P*(1-P) = P - P*P = 0`.
-  rw [mul_sub, mul_one, hP.2, sub_self]
+  exact IsIdempotentElem.mul_one_sub_self hP.2
 
 lemma projCompl_mul_proj (hP : IsOrthogonalProjection P) : (1 - P) * P = 0 := by
-  -- `(1-P)*P = P - P*P = 0`.
-  rw [sub_mul, one_mul, hP.2, sub_self]
+  exact IsIdempotentElem.one_sub_mul_self hP.2
 
 lemma projCompl_mul_projCompl (hP : IsOrthogonalProjection P) : (1 - P) * (1 - P) = (1 - P) := by
-  -- `(1-P)^2 = (1-P) - (1-P)P`.
-  rw [mul_sub, mul_one, projCompl_mul_proj (P := P) hP, sub_zero]
+  exact IsIdempotentElem.one_sub hP.2
 
 end Auxiliary
 

--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -141,16 +141,6 @@ def densityMatrices (D : ℕ) : Set (Matrix (Fin D) (Fin D) ℂ) :=
 @[simp] lemma mem_densityMatrices {ρ : Matrix (Fin D) (Fin D) ℂ} :
     ρ ∈ densityMatrices D ↔ ρ.PosSemidef ∧ trace ρ = 1 := Iff.rfl
 
-/-! ### Auxiliary lemmas for closedness -/
-
-/-- The set of nonneg complex numbers (those with `0 ≤ z` in `ComplexOrder`) is closed. -/
-private lemma isClosed_complex_nonneg : IsClosed {z : ℂ | 0 ≤ z} := by
-  have : {z : ℂ | 0 ≤ z} = {z | 0 ≤ z.re ∧ z.im = 0} := by
-    ext z; simp [Complex.nonneg_iff, eq_comm]
-  rw [this]
-  exact (isClosed_le continuous_const Complex.continuous_re).inter
-    (isClosed_eq Complex.continuous_im continuous_const)
-
 /-- The quadratic form `X ↦ star v ⬝ᵥ X.mulVec v` is continuous. -/
 private lemma continuous_quadraticForm (v : Fin D → ℂ) :
     Continuous (fun X : Matrix (Fin D) (Fin D) ℂ => star v ⬝ᵥ X.mulVec v) :=
@@ -158,16 +148,13 @@ private lemma continuous_quadraticForm (v : Fin D → ℂ) :
 
 /-! ### Auxiliary lemmas for boundedness -/
 
-/-- For a nonneg complex number `z` (in `ComplexOrder`), `‖z‖ = z.re`. -/
-private lemma norm_of_complex_nonneg {z : ℂ} (hz : 0 ≤ z) : ‖z‖ = z.re := by
-  obtain ⟨h_re, h_im⟩ := Complex.nonneg_iff.mp hz
-  rw [Complex.norm_eq_sqrt_sq_add_sq, h_im.symm, zero_pow (by norm_num : 2 ≠ 0),
-    add_zero, Real.sqrt_sq h_re]
-
 /-- For PSD `X`, each diagonal entry norm is bounded by the trace norm. -/
 private lemma posSemidef_diag_norm_le_trace_norm {X : Matrix (Fin D) (Fin D) ℂ}
     (hX : X.PosSemidef) (i : Fin D) : ‖X i i‖ ≤ ‖trace X‖ := by
-  rw [norm_of_complex_nonneg hX.diag_nonneg, norm_of_complex_nonneg hX.trace_nonneg,
+  rw [show ‖X i i‖ = (X i i).re from by
+      simpa using congrArg Complex.re (Complex.norm_of_nonneg' hX.diag_nonneg),
+    show ‖trace X‖ = (trace X).re from by
+      simpa using congrArg Complex.re (Complex.norm_of_nonneg' hX.trace_nonneg),
     show (trace X).re = ∑ j : Fin D, (X j j).re from by simp [Matrix.trace, Matrix.diag]]
   exact single_le_sum (fun j _ => (Complex.nonneg_iff.mp (hX.diag_nonneg (i := j))).1)
     (mem_univ i)
@@ -214,7 +201,8 @@ private lemma posSemidef_entry_norm_le_trace_norm {X : Matrix (Fin D) (Fin D) �
   set v := WithLp.toLp (p := 2) (fun k : Fin D => B k j)
   have sq_le_trace : ∀ k, ‖WithLp.toLp (p := 2) (fun l : Fin D => B l k)‖ ^ 2
       ≤ ‖trace (Bᴴ * B)‖ := fun k => by
-    rw [col_norm_sq_eq_diag, ← norm_of_complex_nonneg hX'.diag_nonneg]
+    rw [col_norm_sq_eq_diag, ← show ‖(Bᴴ * B) k k‖ = ((Bᴴ * B) k k).re from by
+      simpa using congrArg Complex.re (Complex.norm_of_nonneg' hX'.diag_nonneg)]
     exact posSemidef_diag_norm_le_trace_norm hX' k
   calc ‖inner (𝕜 := ℂ) u v‖
       ≤ ‖u‖ * ‖v‖ := norm_inner_le_norm ..
@@ -261,7 +249,8 @@ theorem isClosed_posSemidef :
       Matrix.posSemidef_iff_dotProduct_mulVec]
   rw [this]
   exact (isClosed_eq continuous_star continuous_id).inter
-    (isClosed_iInter fun v => isClosed_complex_nonneg.preimage (continuous_quadraticForm v))
+    (isClosed_iInter fun v =>
+      (isClosed_le continuous_const continuous_id).preimage (continuous_quadraticForm v))
 
 /-- The set of density matrices is compact (Heine-Borel).
 

--- a/TNLean/Channel/Semigroup/CPClosure.lean
+++ b/TNLean/Channel/Semigroup/CPClosure.lean
@@ -181,16 +181,6 @@ section PosSemidefiniteClosure
 
 variable {m : Type*}
 
-/-- The nonnegative cone of `ℂ` is closed. -/
-private lemma isClosed_complex_nonneg_generic :
-    IsClosed {z : ℂ | 0 ≤ z} := by
-  have : {z : ℂ | 0 ≤ z} = {z | 0 ≤ z.re ∧ z.im = 0} := by
-    ext z
-    simp [Complex.nonneg_iff, eq_comm]
-  rw [this]
-  exact (isClosed_le continuous_const Complex.continuous_re).inter
-    (isClosed_eq Complex.continuous_im continuous_const)
-
 /-- The quadratic form `X ↦ star v ⬝ᵥ X.mulVec v` is continuous. -/
 private lemma continuous_quadraticForm_generic [Fintype m] (v : m → ℂ) :
     Continuous (fun X : Matrix m m ℂ => star v ⬝ᵥ X.mulVec v) :=
@@ -211,8 +201,7 @@ theorem matrix_isClosed_posSemidef [Finite m] :
   rw [this]
   exact (isClosed_eq continuous_star continuous_id).inter
     (isClosed_iInter fun v =>
-      isClosed_complex_nonneg_generic.preimage
-        (continuous_quadraticForm_generic v))
+      (isClosed_le continuous_const continuous_id).preimage (continuous_quadraticForm_generic v))
 
 end PosSemidefiniteClosure
 

--- a/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/Compression.lean
@@ -137,7 +137,7 @@ theorem exists_compressedTensor_of_supported_projection_with_letter_and_isometry
     have hfun : (fun k => f k * f k) = f := by
       apply Matrix.diagonal_injective
       simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
-    exact mul_self_eq_self_or_eq_one (f j) (congrFun hfun j)
+    exact IsIdempotentElem.iff_eq_zero_or_one.mp (congrFun hfun j)
   -- Index splitting
   let p : Fin D → Prop := fun j => f j = 1
   haveI : DecidablePred p := fun _ => inferInstance

--- a/TNLean/MPS/RFP/Decorrelation.lean
+++ b/TNLean/MPS/RFP/Decorrelation.lean
@@ -27,7 +27,6 @@ All results are fully proved (no `sorry`).
 
 ### Commuting idempotent algebra (`LinearMap` namespace)
 
-* `comp_idem_of_comm_idem` — product of commuting idempotents is idempotent
 * `idem_comp_left_absorb` — `P ∘ (P ∘ Q) = P ∘ Q`
 * `idem_comp_right_absorb` — `(P ∘ Q) ∘ Q = P ∘ Q`
 * `comm_idem_cross_absorb_left` — `(P ∘ Q) ∘ P = P ∘ Q` when `[P, Q] = 0`
@@ -71,15 +70,6 @@ section CommutingIdempotentAlgebra
 variable {E : Type*} [AddCommGroup E] [Module ℂ E]
 
 namespace LinearMap
-
-/-- Product of commuting idempotent endomorphisms is idempotent.
-This wraps Mathlib's `IsIdempotentElem.mul_of_commute`. -/
-theorem comp_idem_of_comm_idem
-    {P Q : E →ₗ[ℂ] E}
-    (hP : P ∘ₗ P = P) (hQ : Q ∘ₗ Q = Q)
-    (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
-    (P ∘ₗ Q) ∘ₗ (P ∘ₗ Q) = P ∘ₗ Q :=
-  IsIdempotentElem.mul_of_commute hcomm hP hQ
 
 /-- Left absorption: `P ∘ (P ∘ Q) = P ∘ Q` when `P` is idempotent. -/
 theorem idem_comp_left_absorb
@@ -165,9 +155,9 @@ namespace Decorrelation
 theorem HasCommutingParentHam.pK_idem {P_K : E →ₗ[ℂ] E}
     (h : HasCommutingParentHam P_K) :
     P_K ∘ₗ P_K = P_K := by
-  simpa [h.hK] using
-    (LinearMap.comp_idem_of_comm_idem (P := h.P_AX) (Q := h.P_XB)
-      h.hAX_idem h.hXB_idem h.hcomm)
+  change IsIdempotentElem P_K
+  simpa [h.hK, Module.End.mul_eq_comp] using
+    (IsIdempotentElem.mul_of_commute h.hcomm h.hAX_idem h.hXB_idem)
 
 /-- `P_AX ∘ P_K = P_K`: the AX-projector absorbs `P_K` from the left. -/
 theorem HasCommutingParentHam.pAX_comp_pK {P_K : E →ₗ[ℂ] E}

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp.lean
@@ -161,7 +161,7 @@ theorem exists_twoBlock_decomp_of_lowerZero
       simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
     have hj : f j * f j = f j := by
       simpa using congrArg (fun g => g j) hfun
-    exact mul_self_eq_self_or_eq_one (f j) hj
+    exact IsIdempotentElem.iff_eq_zero_or_one.mp hj
   -- Split the eigenbasis indices into the `1`-eigenspace and the `0`-eigenspace.
   let p : Fin D → Prop := fun j => f j = 1
   haveI : DecidablePred p := fun j => by
@@ -503,7 +503,7 @@ theorem exists_twoBlock_decomp_of_lowerZero_strict
     have hfun : (fun k => f k * f k) = f := by
       apply Matrix.diagonal_injective
       simpa [Matrix.diagonal_mul_diagonal] using hDiag_idem
-    exact mul_self_eq_self_or_eq_one (f j) (congrFun hfun j)
+    exact IsIdempotentElem.iff_eq_zero_or_one.mp (congrFun hfun j)
   -- ═══ Index splitting ═══
   let p : Fin D → Prop := fun j => f j = 1
   haveI : DecidablePred p := fun _ => inferInstance

--- a/TNLean/MPS/Structure/InvariantSubspaceDecomp/Basic.lean
+++ b/TNLean/MPS/Structure/InvariantSubspaceDecomp/Basic.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Algebra.ProjectionTriangularTrace
 import TNLean.MPS.FundamentalTheorem.Multi
 
+import Mathlib.Algebra.GroupWithZero.Idempotent
 import Mathlib.Analysis.Matrix.Spectrum
 import Mathlib.Data.Fintype.EquivFin
 import Mathlib.Data.Fintype.Sum
@@ -74,19 +75,6 @@ noncomputable def twoBlockTensor (A₁ : MPSTensor d n) (A₂ : MPSTensor d m) :
     (μ := fun _ => (1 : ℂ)) (A := twoBlockBlocks (d := d) (n := n) (m := m) A₁ A₂)
 
 end TwoBlock
-
-/-! ## Small auxiliary lemmas -/
-
-/-- If `z : ℂ` satisfies `z * z = z`, then `z = 0` or `z = 1`. -/
-lemma mul_self_eq_self_or_eq_one (z : ℂ) (hz : z * z = z) : z = 0 ∨ z = 1 := by
-  have hz' : z * (z - 1) = 0 := by
-    calc
-      z * (z - 1) = z * z - z := by ring
-      _ = 0 := by simpa using sub_eq_zero.mpr hz
-  rcases mul_eq_zero.mp hz' with h0 | h1
-  · exact Or.inl h0
-  · right
-    exact sub_eq_zero.mp h1
 
 /-! ## Block-diagonal evaluation / trace lemmas -/
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1164,6 +1164,56 @@ Removed unused local convenience wrappers:
 The first and third merely restated `cumulativeSpan_eq_top`, while the second
 was just `evalWord_nil`.  No Lean or blueprint declaration referred to them.
 
+### Complex scalar idempotents, 2026-06-19
+
+Removed the local scalar lemma:
+
+- `MPSTensor.mul_self_eq_self_or_eq_one`
+
+This theorem specialized Mathlib's general idempotent-element result
+`IsIdempotentElem.iff_eq_zero_or_one` to complex numbers.  The three local
+uses in invariant-subspace splitting and cyclic-sector compression now call
+the Mathlib theorem directly.
+
+### Complex nonnegative cone and norm, 2026-06-19
+
+Removed private local proofs of standard complex-order facts:
+
+- `isClosed_complex_nonneg`
+- `norm_of_complex_nonneg`
+- `isClosed_complex_nonneg_generic`
+
+Mathlib 4.31 supplies the ordered-topology instance for the complex order under
+`ComplexOrder`, so the closedness proof is now
+`isClosed_le continuous_const continuous_id`.  For nonnegative complex numbers,
+the bounded-density-matrix argument now derives the real norm identity from
+`Complex.norm_of_nonneg'`.
+
+### Commuting idempotent products, 2026-06-19
+
+Removed the local linear-map specialization:
+
+- `LinearMap.comp_idem_of_comm_idem`
+
+The theorem was exactly `IsIdempotentElem.mul_of_commute` for endomorphisms
+written with composition notation.  The commuting-parent-Hamiltonian proof now
+uses the Mathlib theorem directly.
+
+### Projection-complement idempotent algebra, 2026-06-19
+
+The projection-triangular trace file keeps its local projection-complement
+lemma names because they are part of the internal proof script, but their
+handwritten matrix-ring proofs have been replaced by Mathlib's general
+idempotent-complement API:
+
+- `IsIdempotentElem.mul_one_sub_self`
+- `IsIdempotentElem.one_sub_mul_self`
+- `IsIdempotentElem.one_sub`
+
+Thus `MPSTensor.proj_mul_projCompl`, `MPSTensor.projCompl_mul_proj`, and
+`MPSTensor.projCompl_mul_projCompl` now only translate
+`IsOrthogonalProjection P` into the corresponding general idempotent fact.
+
 ### Deprecation-policy exceptions
 
 The usual convention in `docs/MATHLIB_style.md` is to keep a public
@@ -1204,6 +1254,10 @@ pass-throughs:
 - `MPSTensor.matrix_in_cumulativeSpan`, `MPSTensor.one_eq_evalWord_nil`, and
   `MPSTensor.wordSpan_generates_full_algebra`.  These were immediate
   restatements of `cumulativeSpan_eq_top` or `evalWord_nil`.
+- `MPSTensor.mul_self_eq_self_or_eq_one`.  This was the complex-number
+  specialization of `IsIdempotentElem.iff_eq_zero_or_one`.
+- `LinearMap.comp_idem_of_comm_idem`.  This was the endomorphism-composition
+  specialization of `IsIdempotentElem.mul_of_commute`.
 
 ## Verification performed
 
@@ -1254,6 +1308,7 @@ lake build TNLean.Channel.Irreducible.Basic TNLean.MPS.Irreducible.Adjoint \
   TNLean.MPS.Periodic.SectorIrreducibility.HLiftCore -q --log-level=info
 lake env lean TNLean/Algebra/MatrixAux.lean --json
 lake env lean TNLean/Spectral/GaugeConstruction.lean --json
+lake build TNLean.Algebra.ProjectionTriangularTrace -q --log-level=info
 lake env lean TNLean/Spectral/TransferOperatorGapNT.lean --json
 lake env lean TNLean/Spectral/TransferOperatorGapRect.lean
 lake env lean TNLean/Spectral/PrimitiveOverlap.lean


### PR DESCRIPTION
## Summary

This PR continues the Mathlib 4.31 cleanup after the dependency upgrade. It removes or thins local elementary facts whose mathematical content is already present in Mathlib 4.31.

The changes are:

- Replace `MPSTensor.mul_self_eq_self_or_eq_one` by Mathlib's general theorem `IsIdempotentElem.iff_eq_zero_or_one` at the invariant-subspace and cyclic-sector use sites.
- Replace local proofs that the nonnegative cone `{z : ℂ | 0 ≤ z}` is closed by `isClosed_le continuous_const continuous_id`, using the `ComplexOrder` ordered-topology instance.
- Replace the private norm lemma for nonnegative complex numbers by `Complex.norm_of_nonneg'` in the density-matrix boundedness argument.
- Replace the linear-map specialization `LinearMap.comp_idem_of_comm_idem` by direct use of `IsIdempotentElem.mul_of_commute` in the commuting-parent-Hamiltonian proof.
- Replace handwritten projection-complement algebra in `ProjectionTriangularTrace` by `IsIdempotentElem.mul_one_sub_self`, `IsIdempotentElem.one_sub_mul_self`, and `IsIdempotentElem.one_sub`.
- Record these replacements in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`.

No theorem statement is strengthened or weakened. The PR removes local elementary layers and points the affected proofs at Mathlib's native statements.

## Verification

```text
lake build TNLean.Channel.Basic TNLean.Channel.Semigroup.CPClosure TNLean.MPS.Structure.InvariantSubspaceDecomp TNLean.MPS.CanonicalForm.CyclicSectors.Compression TNLean.MPS.RFP.Decorrelation -q --log-level=info
lake build TNLean.Algebra.ProjectionTriangularTrace -q --log-level=info
python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main
python3 scripts/blueprint_lean_sync.py --root . --ci
git diff --check
```

The Lean builds report only pre-existing style/header warnings in upstream dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactors to Mathlib 4.31 facts; no API or mathematical statement changes beyond deleting duplicate local lemmas.
> 
> **Overview**
> Continues the Mathlib 4.31 cleanup by **dropping local elementary lemmas** whose content already lives in Mathlib, and **rewiring proofs** to the canonical APIs. No theorem statements are changed.
> 
> **Idempotents:** Removes `MPSTensor.mul_self_eq_self_or_eq_one` and `LinearMap.comp_idem_of_comm_idem`. Invariant-subspace splitting, cyclic-sector compression, and `HasCommutingParentHam.pK_idem` now use `IsIdempotentElem.iff_eq_zero_or_one` and `IsIdempotentElem.mul_of_commute`. Projection-complement steps in `ProjectionTriangularTrace` call `IsIdempotentElem.mul_one_sub_self`, `one_sub_mul_self`, and `one_sub` instead of hand-written matrix algebra.
> 
> **Complex order / topology:** Deletes private closedness and norm lemmas for nonnegative complexes in `TNLean.Channel.Basic` and `CPClosure`. PSD cone closedness uses `isClosed_le continuous_const continuous_id` under `ComplexOrder`; density-matrix bounds use `Complex.norm_of_nonneg'`.
> 
> **Docs:** The Mathlib 4.31 replacement audit documents these removals and the projection-complement idempotent rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8531c4d1aef73bd40e07a8149d133f46240060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->