### PR TITLE
chore(mathlib): use trace extensionality lemmas

### DIFF
--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -80,10 +80,10 @@ theorem trace_mul_right_eq_zero_iff {n : Type*} [Fintype n]
     (∀ N : Matrix n n ℂ, Matrix.trace (M * N) = 0) ↔ M = 0 := by
   classical
   constructor
-  · intro h; ext i j
-    have hNM : Matrix.trace (Matrix.single j i (1 : ℂ) * M) = 0 :=
-      (Matrix.trace_mul_comm M _).symm.trans (h _)
-    simpa [Matrix.trace_single_mul (i := j) (j := i) (a := (1 : ℂ))] using hNM
+  · intro h
+    exact (Matrix.ext_iff_trace_mul_right (A := M) (B := 0)).2 (by
+      intro N
+      simpa using h N)
   · intro h N; simp [h]
 
 end Matrix

--- a/TNLean/MPS/Chain/TensorEquality.lean
+++ b/TNLean/MPS/Chain/TensorEquality.lean
@@ -28,25 +28,20 @@ variable {d D : ℕ}
       Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (B₁ i * X * B₂ j)) :
     ∀ i j, A₂ j * A₁ i = B₂ j * B₁ i := by
   intro i j
-  have hzero :
-      A₂ j * A₁ i - B₂ j * B₁ i = 0 := by
-    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (A₂ j * A₁ i - B₂ j * B₁ i)).1
-    intro X
-    have hX := hInt X i j
-    have hcycA : Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (A₂ j * A₁ i * X) := by
-      simpa [Matrix.mul_assoc] using
-        (Matrix.trace_mul_cycle (A₁ i) X (A₂ j))
-    have hcycB : Matrix.trace (B₁ i * X * B₂ j) = Matrix.trace (B₂ j * B₁ i * X) := by
-      simpa [Matrix.mul_assoc] using
-        (Matrix.trace_mul_cycle (B₁ i) X (B₂ j))
-    calc
-      Matrix.trace ((A₂ j * A₁ i - B₂ j * B₁ i) * X)
-          = Matrix.trace (A₂ j * A₁ i * X) - Matrix.trace (B₂ j * B₁ i * X) := by
-              simp [sub_mul]
-      _ = Matrix.trace (A₁ i * X * A₂ j) - Matrix.trace (B₁ i * X * B₂ j) := by
-            rw [hcycA, hcycB]
-      _ = 0 := by simp [hX]
-  exact sub_eq_zero.mp hzero
+  apply (Matrix.ext_iff_trace_mul_right).2
+  intro X
+  have hX := hInt X i j
+  have hcycA : Matrix.trace (A₁ i * X * A₂ j) = Matrix.trace (A₂ j * A₁ i * X) := by
+    simpa [Matrix.mul_assoc] using
+      (Matrix.trace_mul_cycle (A₁ i) X (A₂ j))
+  have hcycB : Matrix.trace (B₁ i * X * B₂ j) = Matrix.trace (B₂ j * B₁ i * X) := by
+    simpa [Matrix.mul_assoc] using
+      (Matrix.trace_mul_cycle (B₁ i) X (B₂ j))
+  calc
+    Matrix.trace (A₂ j * A₁ i * X)
+        = Matrix.trace (A₁ i * X * A₂ j) := hcycA.symm
+    _ = Matrix.trace (B₁ i * X * B₂ j) := hX
+    _ = Matrix.trace (B₂ j * B₁ i * X) := hcycB
 
 /-- External insertion trace agreement implies equality of the mixed products
 `A₁ i * A₂ j = B₁ i * B₂ j` for all physical indices. -/
@@ -56,25 +51,20 @@ variable {d D : ℕ}
       Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (B₂ j * Y * B₁ i)) :
     ∀ i j, A₁ i * A₂ j = B₁ i * B₂ j := by
   intro i j
-  have hzero :
-      A₁ i * A₂ j - B₁ i * B₂ j = 0 := by
-    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (A₁ i * A₂ j - B₁ i * B₂ j)).1
-    intro Y
-    have hY := hExt Y i j
-    have hcycA : Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (A₁ i * A₂ j * Y) := by
-      simpa [Matrix.mul_assoc] using
-        (Matrix.trace_mul_cycle (A₂ j) Y (A₁ i))
-    have hcycB : Matrix.trace (B₂ j * Y * B₁ i) = Matrix.trace (B₁ i * B₂ j * Y) := by
-      simpa [Matrix.mul_assoc] using
-        (Matrix.trace_mul_cycle (B₂ j) Y (B₁ i))
-    calc
-      Matrix.trace ((A₁ i * A₂ j - B₁ i * B₂ j) * Y)
-          = Matrix.trace (A₁ i * A₂ j * Y) - Matrix.trace (B₁ i * B₂ j * Y) := by
-              simp [sub_mul]
-      _ = Matrix.trace (A₂ j * Y * A₁ i) - Matrix.trace (B₂ j * Y * B₁ i) := by
-            rw [hcycA, hcycB]
-      _ = 0 := by simp [hY]
-  exact sub_eq_zero.mp hzero
+  apply (Matrix.ext_iff_trace_mul_right).2
+  intro Y
+  have hY := hExt Y i j
+  have hcycA : Matrix.trace (A₂ j * Y * A₁ i) = Matrix.trace (A₁ i * A₂ j * Y) := by
+    simpa [Matrix.mul_assoc] using
+      (Matrix.trace_mul_cycle (A₂ j) Y (A₁ i))
+  have hcycB : Matrix.trace (B₂ j * Y * B₁ i) = Matrix.trace (B₁ i * B₂ j * Y) := by
+    simpa [Matrix.mul_assoc] using
+      (Matrix.trace_mul_cycle (B₂ j) Y (B₁ i))
+  calc
+    Matrix.trace (A₁ i * A₂ j * Y)
+        = Matrix.trace (A₂ j * Y * A₁ i) := hcycA.symm
+    _ = Matrix.trace (B₂ j * Y * B₁ i) := hY
+    _ = Matrix.trace (B₁ i * B₂ j * Y) := hcycB
 
 /-- Lemma 2 of arXiv:1804.04964 (2-site case): two injective tensor pairs that
 agree under all virtual insertions on both bonds are proportional. -/

--- a/TNLean/PEPS/CycleMPSChainArc.lean
+++ b/TNLean/PEPS/CycleMPSChainArc.lean
@@ -384,18 +384,16 @@ theorem eq_of_trace_pairing_span {ι : Sort*} {F : ι → Matrix (Fin D) (Fin D)
     (hspan : Submodule.span ℂ (Set.range F) = ⊤)
     {M N : Matrix (Fin D) (Fin D) ℂ}
     (h : ∀ i, Matrix.trace (M * F i) = Matrix.trace (N * F i)) : M = N := by
-  have hzero : ∀ Q : Matrix (Fin D) (Fin D) ℂ,
-      Matrix.trace ((M - N) * Q) = 0 := by
-    intro Q
-    have hQ : Q ∈ Submodule.span ℂ (Set.range F) := hspan ▸ Submodule.mem_top
-    induction hQ using Submodule.span_induction with
-    | mem x hx =>
-        obtain ⟨i, rfl⟩ := hx
-        rw [Matrix.sub_mul, Matrix.trace_sub, h i, sub_self]
-    | zero => rw [Matrix.mul_zero, Matrix.trace_zero]
-    | add x y _ _ hx hy => rw [Matrix.mul_add, Matrix.trace_add, hx, hy, add_zero]
-    | smul c x _ hx => rw [Matrix.mul_smul, Matrix.trace_smul, hx, smul_zero]
-  exact sub_eq_zero.mp (MPSTensor.trace_mul_right_eq_zero hzero)
+  apply (Matrix.ext_iff_trace_mul_right).2
+  intro Q
+  have hQ : Q ∈ Submodule.span ℂ (Set.range F) := hspan ▸ Submodule.mem_top
+  induction hQ using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨i, rfl⟩ := hx
+      exact h i
+  | zero => simp
+  | add x y _ _ hx hy => simp [Matrix.mul_add, Matrix.trace_add, hx, hy]
+  | smul c x _ hx => simp [Matrix.trace_smul, hx]
 
 /-- **Uniqueness of a right factor against a spanning family** — the
 spanning-family form of the uniqueness of the bond operator

--- a/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
@@ -540,18 +540,6 @@ theorem insertionHom_unique [NeZero n] {B : MPSChainTensor d D n} {L : ℕ}
 
 /-! ### The conjugation between same-state chains -/
 
-/-- Two matrices with equal trace pairings against every matrix on the left
-are equal. -/
-private theorem eq_of_trace_mul_left_eq {M N : Matrix (Fin D) (Fin D) ℂ}
-    (h : ∀ X : Matrix (Fin D) (Fin D) ℂ,
-      Matrix.trace (X * M) = Matrix.trace (X * N)) : M = N := by
-  have h0 : ∀ X : Matrix (Fin D) (Fin D) ℂ,
-      Matrix.trace ((M - N) * X) = 0 := by
-    intro X
-    rw [Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_mul_comm M X,
-      Matrix.trace_mul_comm N X, h X, sub_self]
-  exact sub_eq_zero.mp (MPSTensor.trace_mul_right_eq_zero h0)
-
 /-- **The conjugation between two same-state site-dependent chains at length
 `n ≥ 2L + 1`** (arXiv:1804.04964, Lemma 5 and the closed-chain corollary of
 Section `normal_alt`, lines 1961--2295 of
@@ -621,7 +609,7 @@ theorem exists_conjugation_of_sameState [NeZero n] {L : ℕ} (hL : 0 < L)
   have hAw : arcEval A p w =
       ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * arcEval B p w *
         (P : Matrix (Fin D) (Fin D) ℂ) := by
-    apply eq_of_trace_mul_left_eq
+    apply (Matrix.ext_iff_trace_mul_left).2
     intro X
     calc Matrix.trace (X * arcEval A p w)
         = Matrix.trace (Φ X * arcEval B p w) := hpair' X w hw

--- a/TNLean/PEPS/CycleMPSOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSOverlapInsertion.lean
@@ -247,18 +247,6 @@ private theorem matrix_one_ne_zero (hD : 0 < D) :
   rw [Matrix.one_apply_eq] at hentry
   exact one_ne_zero hentry
 
-/-- Two matrices with equal trace pairings against every matrix on the left
-are equal. -/
-private theorem eq_of_trace_mul_left_eq {M N : Matrix (Fin D) (Fin D) ℂ}
-    (h : ∀ X : Matrix (Fin D) (Fin D) ℂ,
-      Matrix.trace (X * M) = Matrix.trace (X * N)) : M = N := by
-  have h0 : ∀ X : Matrix (Fin D) (Fin D) ℂ,
-      Matrix.trace ((M - N) * X) = 0 := by
-    intro X
-    rw [Matrix.sub_mul, Matrix.trace_sub, Matrix.trace_mul_comm M X,
-      Matrix.trace_mul_comm N X, h X, sub_self]
-  exact sub_eq_zero.mp (trace_mul_right_eq_zero h0)
-
 /-- Any list of declared length is the word of a tuple. -/
 private theorem exists_ofFn_of_length {l : List (Fin d)} {k : ℕ}
     (hl : l.length = k) : ∃ a : Fin k → Fin d, List.ofFn a = l := by
@@ -439,7 +427,7 @@ theorem exists_conjugation_of_mpv_eq {n L : ℕ} (hL : 0 < L) (hn : 2 * L + 1 �
   have hAw : evalWord A w =
       ((P⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * evalWord B w *
         (P : Matrix (Fin D) (Fin D) ℂ) := by
-    apply eq_of_trace_mul_left_eq
+    apply (Matrix.ext_iff_trace_mul_left).2
     intro X
     calc Matrix.trace (X * evalWord A w)
         = Matrix.trace (Φ X * evalWord B w) := hpair X w hw

--- a/TNLean/PEPS/CycleMPSWordTransport.lean
+++ b/TNLean/PEPS/CycleMPSWordTransport.lean
@@ -129,20 +129,17 @@ theorem eq_of_trace_mul_evalWord_eq {B : MPSTensor d D} {m : ℕ}
     (h : ∀ ρ : Fin m → Fin d,
       Matrix.trace (M * evalWord B (List.ofFn ρ)) =
         Matrix.trace (N * evalWord B (List.ofFn ρ))) : M = N := by
-  have hzero : ∀ Q : Matrix (Fin D) (Fin D) ℂ,
-      Matrix.trace ((M - N) * Q) = 0 := by
-    intro Q
-    have hQ : Q ∈ Submodule.span ℂ (Set.range fun ρ : Fin m → Fin d =>
-        evalWord B (List.ofFn ρ)) := hspan ▸ Submodule.mem_top
-    induction hQ using Submodule.span_induction with
-    | mem x hx =>
-        obtain ⟨ρ, rfl⟩ := hx
-        rw [Matrix.sub_mul, Matrix.trace_sub, h ρ, sub_self]
-    | zero => rw [Matrix.mul_zero, Matrix.trace_zero]
-    | add x y _ _ hx hy => rw [Matrix.mul_add, Matrix.trace_add, hx, hy, add_zero]
-    | smul c x _ hx => rw [Matrix.mul_smul, Matrix.trace_smul, hx, smul_zero]
-  have hMN : M - N = 0 := trace_mul_right_eq_zero hzero
-  exact sub_eq_zero.mp hMN
+  apply (Matrix.ext_iff_trace_mul_right).2
+  intro Q
+  have hQ : Q ∈ Submodule.span ℂ (Set.range fun ρ : Fin m → Fin d =>
+      evalWord B (List.ofFn ρ)) := hspan ▸ Submodule.mem_top
+  induction hQ using Submodule.span_induction with
+  | mem x hx =>
+      obtain ⟨ρ, rfl⟩ := hx
+      exact h ρ
+  | zero => simp
+  | add x y _ _ hx hy => simp [Matrix.mul_add, Matrix.trace_add, hx, hy]
+  | smul c x _ hx => simp [Matrix.trace_smul, hx]
 
 /-! ### The generic transport construction -/
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -782,9 +782,10 @@ Keep for now:
 
 - Positive-semidefinite kernel lemmas for sums, unless a direct Mathlib theorem
   is found.
-- Trace-pairing wrappers if they are used pervasively, though they should be
-  reproved using `Matrix.ext_iff_trace_mul_left` and
-  `Matrix.ext_iff_trace_mul_right`.
+- Trace-pairing wrappers only when they are part of TNLean's public
+  mathematical vocabulary.  Private equality-form wrappers should use
+  `Matrix.ext_iff_trace_mul_left` and `Matrix.ext_iff_trace_mul_right`
+  directly.
 
 ### `TNLean/Algebra/BlockTriangularTrace.lean`
 
@@ -1214,6 +1215,30 @@ Thus `MPSTensor.proj_mul_projCompl`, `MPSTensor.projCompl_mul_proj`, and
 `MPSTensor.projCompl_mul_projCompl` now only translate
 `IsOrthogonalProjection P` into the corresponding general idempotent fact.
 
+### Trace-pairing extensionality, 2026-06-19
+
+Mathlib 4.31 has equality-form trace-pairing extensionality lemmas:
+
+- `Matrix.ext_iff_trace_mul_left`
+- `Matrix.ext_iff_trace_mul_right`
+
+The blueprint-facing theorem `Matrix.trace_mul_right_eq_zero_iff` is retained,
+because it is a named TNLean statement used in the MPS trace-pairing chapter.
+Its proof now uses `Matrix.ext_iff_trace_mul_right` rather than expanding
+matrix entries by hand.
+
+Several equality proofs no longer pass through the artificial subtraction
+step `M - N = 0`.  They now apply the Mathlib equality-form theorem directly:
+
+- `MPSTensor.internal_products_eq`
+- `MPSTensor.external_products_eq`
+- `MPSTensor.eq_of_trace_mul_evalWord_eq`
+- `eq_of_trace_pairing_span` in `TNLean.PEPS.CycleMPSChainArc`
+
+The two private `eq_of_trace_mul_left_eq` helpers in the PEPS overlap
+insertion files were removed; their use sites now call
+`Matrix.ext_iff_trace_mul_left` directly.
+
 ### Deprecation-policy exceptions
 
 The usual convention in `docs/MATHLIB_style.md` is to keep a public
@@ -1333,6 +1358,10 @@ lake build TNLean.Algebra.MatrixAux TNLean.Spectral.GaugeConstruction \
   -q --log-level=info
 lake env lean TNLean/Spectral/QuantitativeGap.lean --json
 lake env lean TNLean/MPS/Structure/PrimitivityBridge.lean --json
+lake build TNLean.Algebra.TracePairing TNLean.MPS.Chain.TensorEquality \
+  TNLean.PEPS.CycleMPSWordTransport TNLean.PEPS.CycleMPSChainArc \
+  TNLean.PEPS.CycleMPSOverlapInsertion TNLean.PEPS.CycleMPSChainOverlapWindow \
+  TNLean.PEPS.CycleMPSChainOverlapInsertion -q --log-level=info
 ```
 
 The final root build also succeeds:


### PR DESCRIPTION
### Motivation

- Continues the Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`): replaces local trace-pairing equality arguments with Mathlib 4.31's `Matrix.ext_iff_trace_mul_right` and `Matrix.ext_iff_trace_mul_left`.
- Two private `eq_of_trace_mul_left_eq` helpers in `TNLean/PEPS/` duplicated logic now available natively in Mathlib.

### Description

- `TNLean/Algebra/TracePairing.lean`: reprove `Matrix.trace_mul_right_eq_zero_iff` using `Matrix.ext_iff_trace_mul_right`; retain the theorem because it is blueprint-facing.
- `TNLean/MPS/Chain/TensorEquality.lean`: apply `Matrix.ext_iff_trace_mul_right` directly in the two-site tensor equality reductions (`internal_products_eq`, `external_products_eq`).
- `TNLean/PEPS/CycleMPSWordTransport.lean`, `TNLean/PEPS/CycleMPSChainArc.lean`, `TNLean/PEPS/CycleMPSOverlapInsertion.lean`, `TNLean/PEPS/CycleMPSChainOverlapInsertion.lean`: use `Matrix.ext_iff_trace_mul_right` and `Matrix.ext_iff_trace_mul_left` in spanning-family trace-stripping lemmas; remove two private `eq_of_trace_mul_left_eq` helpers.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: record this trace-pairing extensionality batch.
- No theorem statements are changed and no new `sorry` or axioms are introduced.

### Testing

- `lake build TNLean.Algebra.TracePairing TNLean.MPS.Chain.TensorEquality TNLean.PEPS.CycleMPSWordTransport TNLean.PEPS.CycleMPSChainArc TNLean.PEPS.CycleMPSOverlapInsertion TNLean.PEPS.CycleMPSChainOverlapWindow TNLean.PEPS.CycleMPSChainOverlapInsertion -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean build reports only pre-existing style/header warnings in imported files.

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactors with no statement changes; risk is limited to Mathlib API alignment and slightly shorter proof scripts in MPS/PEPS trace arguments.
> 
> **Overview**
> This PR refactors trace-pairing equality proofs to use Mathlib 4.31's **`Matrix.ext_iff_trace_mul_left`** and **`Matrix.ext_iff_trace_mul_right`** instead of the old pattern of proving `M - N = 0` via `trace_mul_right_eq_zero_iff` or duplicate private helpers.
> 
> The public theorem **`Matrix.trace_mul_right_eq_zero_iff`** is unchanged in statement; its forward direction now delegates to `ext_iff_trace_mul_right` instead of a hand-built single-entry argument. MPS two-site lemmas (`internal_products_eq`, `external_products_eq`), PEPS spanning-family stripping (`eq_of_trace_pairing_span`, `eq_of_trace_mul_evalWord_eq`), and conjugation steps in the overlap insertion files apply the Mathlib lemmas directly. Two private **`eq_of_trace_mul_left_eq`** copies in the PEPS overlap files are removed.
> 
> The Mathlib 4.31 replacement audit documents this batch and adds focused `lake build` targets for the touched modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4074839e88802cc8341cf9dccb8ba46f39ef508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->