### PR TITLE
style(MPS/ParentHamiltonian): align martingale overlap terminology

### DIFF
--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -14,11 +14,11 @@ ordered off-diagonal terms satisfy a row-summable cross-term bound, then
 `H = ∑ i, P i` satisfies `H² ≥ γ H` as a quadratic form.  The file also records
 that commuting symmetric projections have nonnegative ordered cross terms, and
 converts norm-compression estimates for products of projections into the ordered
-Friedrichs cross-term bounds used by the row-sum reduction.
+cross-term bounds used by the row-sum reduction.
 
-The statements deliberately keep the MPS/Friedrichs-angle estimates as explicit
+The statements deliberately keep the MPS-specific overlap estimates as explicit
 hypotheses.  They provide the reusable projection-geometry layer into which the
-model-specific overlap and row-sum bounds can later be plugged.
+model-specific overlap and row-sum bounds are inserted.
 -/
 
 open scoped InnerProductSpace
@@ -38,7 +38,7 @@ theorem re_inner_apply_apply_self {P : E →ₗ[𝕜] E} (hP : P.IsSymmetricProj
   rw [show ⟪P v, P v⟫_𝕜 = ⟪P (P v), v⟫_𝕜 from (hP.isSymmetric (P v) v).symm, hidem]
 
 /-- A norm bound on the compressed product of two projections gives the ordered
-Friedrichs lower bound.
+cross-term lower bound.
 
 For a symmetric projection `P`, the ordered cross term satisfies
 `Re ⟪P v, Q v⟫ = Re ⟪P v, P (Q v)⟫`. Hence Cauchy--Schwarz shows that a
@@ -498,25 +498,26 @@ theorem quadraticForm_sum_projections_of_finite_overlap_anticommutator
   exact quadraticForm_sum_projections_of_anticommutator_rowCol hγle P hP c
     hRow hCol hAntiAll
 
-/-- Finite-overlap Friedrichs conditions for a family of symmetric projections.
+/-- Finite-overlap ordered cross-term conditions for a family of symmetric
+projections.
 
 Assume that each row has at most `m` interacting off-diagonal entries.  On an
-interacting pair, a Friedrichs-angle estimate supplies the ordered bound with
+interacting pair, an ordered cross-term estimate supplies the bound with
 coefficient `1 / m`; on a noninteracting pair, the ordered cross term is
 nonnegative.  Then choosing coefficient `1 / m` on interacting pairs and `0`
 on noninteracting pairs gives row sums at most one, so the abstract row-sum
 reduction gives `H² ≥ γ H` as a quadratic form.
 
 This is the abstract finite-range step: locality provides the cardinal bound
-(for parent Hamiltonians, `m = 2 * (L - 1)`), while the analytic Friedrichs-angle
-argument provides the interacting-pair estimate. -/
+(for parent Hamiltonians, `m = 2 * (L - 1)`), while the analytic part provides
+the interacting-pair estimate. -/
 theorem quadraticForm_sum_projections_of_finite_overlap {γ : ℝ} (hγle : γ ≤ 1)
     (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
     (overlaps : ι → ι → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
     (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
     (hDisjoint : ∀ i j, j ∈ Finset.univ.erase i → ¬ overlaps i j →
       ∀ v : E, 0 ≤ (⟪P i v, P j v⟫_ℂ).re)
-    (hFriedrichs : ∀ i j, j ∈ Finset.univ.erase i → overlaps i j →
+    (hCrossTerm : ∀ i j, j ∈ Finset.univ.erase i → overlaps i j →
       ∀ v : E,
         - (1 - γ) * ((m : ℝ)⁻¹) * (⟪P i v, v⟫_ℂ).re ≤
           (⟪P i v, P j v⟫_ℂ).re) :
@@ -533,11 +534,11 @@ theorem quadraticForm_sum_projections_of_finite_overlap {γ : ℝ} (hγle : γ �
         (⟪P i v, P j v⟫_ℂ).re := by
     intro i j hij v
     by_cases hoverlap : overlaps i j
-    · simpa [c, hoverlap] using hFriedrichs i j hij hoverlap v
+    · simpa [c, hoverlap] using hCrossTerm i j hij hoverlap v
     · simpa [c, hoverlap] using hDisjoint i j hij hoverlap v
   exact quadraticForm_sum_projections_of_ordered_rowSum hγle P hP c hRow hCross
 
-/-- Finite-overlap row-sum reduction from a norm-compression Friedrichs bound.
+/-- Finite-overlap row-sum reduction from a norm-compression bound.
 
 For symmetric projections, a principal-angle style estimate
 `‖P_i (P_j v)‖ ≤ (1 - γ) m⁻¹ ‖P_i v‖` on every interacting pair implies the

--- a/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/AbstractCriterion.lean
@@ -48,7 +48,7 @@ the PSD operator \(H\), the norm lower bound — and hence the spectral gap
 for eigenvectors of \(H\) — follows by the spectral theorem. This lemma
 provides the final spectral-theorem step; the remaining MPS-specific
 quadratic-form hypothesis is stated separately in
-`MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs`. -/
+`MPSTensor.parentHamiltonianES_gap_bound_of_overlap_norm_bound`. -/
 theorem spectralGap_of_martingale {ι : Type*} [Fintype ι] {γ : ℝ} (hγ : 0 < γ)
     {H : EuclideanSpace ℂ ι →ₗ[ℂ] EuclideanSpace ℂ ι} (hH : H.IsPositive)
     (hOpIneq : ∀ v, γ * (⟪H v, v⟫_ℂ).re ≤ (⟪H v, H v⟫_ℂ).re) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -15,7 +15,7 @@ hypothesis.
 
 ## Main results
 
-* `parentHamiltonianES_gap_bound_of_friedrichs` — the explicit gap bound
+* `parentHamiltonianES_gap_bound_of_overlap_norm_bound` — the explicit gap bound
   obtained from the overlapping-window norm-compression estimate.
 * `parentHamiltonianES_gap_bound_of_anticommutator` — the explicit gap bound
   obtained from the source anticommutator estimate.
@@ -39,7 +39,7 @@ variable {d D : ℕ}
 
 /-- Gap bound from the cyclic-window anticommutator martingale estimate.
 
-This is the source-facing form of the MPS parent-Hamiltonian gap reduction.  The
+This is the source-matching form of the MPS parent-Hamiltonian gap reduction.  The
 hypothesis is the anticommutator lower bound appearing in arXiv:2011.12127,
 Section IV.C, equation eq:4:martingale-2, specialized to overlapping cyclic
 windows:
@@ -77,7 +77,7 @@ coefficient for the MPS parent Hamiltonian.
 
 This is the constant-flexible form of the norm-compression route to the
 martingale bound. It does not assert the special coefficient used in
-`parentHamiltonianES_gap_bound_of_friedrichs`; instead, it says that any uniform
+`parentHamiltonianES_gap_bound_of_overlap_norm_bound`; instead, it says that any uniform
 overlapping-window compression bound
 
 \(‖p_i p_j v‖ ≤ η ‖p_i v‖\)
@@ -122,7 +122,7 @@ This is the specialization of
   \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}.
 \]
 For this value, \(1-η\,2(L-1)=1/(4L)\). -/
-theorem parentHamiltonianES_gap_bound_of_friedrichs
+theorem parentHamiltonianES_gap_bound_of_overlap_norm_bound
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (hOverlapNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
       j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
@@ -220,10 +220,10 @@ Combined with \(h_i^2 = h_i\), this yields the quadratic-form inequality
 by `FrustrationFree.spectralGap_of_martingale` is automatic here because
 \(H_N = ∑ᵢ hᵢ\) is a sum of orthogonal projectors.
 
-This theorem records the stronger norm-compression route. The source-facing
+This theorem records the stronger norm-compression route. The source-matching
 conditional theorem is `parentHamiltonian_gapped_of_anticommutator`. The proof
 below invokes
-`parentHamiltonianES_gap_bound_of_friedrichs`, which combines the already
+`parentHamiltonianES_gap_bound_of_overlap_norm_bound`, which combines the already
 formalized martingale reductions after the overlapping-window estimate is given. -/
 theorem parentHamiltonian_gapped
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
@@ -237,7 +237,7 @@ theorem parentHamiltonian_gapped
       (v : EuclideanSpace ℂ (Cfg d N)),
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
-  obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_friedrichs A L hL
+  obtain ⟨hγ, hgap⟩ := parentHamiltonianES_gap_bound_of_overlap_norm_bound A L hL
     hOverlapNorm
   exact ⟨(1 : ℝ) / (4 * (L : ℝ)), hγ, hgap⟩
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -72,7 +72,7 @@ theorem parentHamiltonianES_norm_bound_of_quadratic_form
     (parentHamiltonianES_isPositive A L N) (hQuad N hLN) v hvKer
 
 /-- The exact explicit gap-bound reduction needed by
-`parentHamiltonianES_gap_bound_of_friedrichs` follows from the corresponding
+`parentHamiltonianES_gap_bound_of_overlap_norm_bound` follows from the corresponding
 uniform quadratic-form estimate with constant \(1 / (4 * L)\).
 
 Thus the remaining MPS-specific content is precisely to prove the hypothesis
@@ -344,8 +344,8 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_anticommutator
     A L N hγle (overlaps N) hm (hRowCard N hLN) (hColCard N hLN)
     (hDisjointAnti N hLN) (hAnti N hLN) v
 
-/-- Fixed-chain martingale quadratic-form estimate from finite-overlap
-principal-angle hypotheses.
+/-- Fixed-chain martingale quadratic-form estimate from finite-overlap ordered
+cross-term hypotheses.
 
 This is the local-window specialization of
 `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap`.  The
@@ -354,7 +354,7 @@ estimate is needed.  If each row has at most \(m\) such pairs, the non-overlap
 cross terms are nonnegative, and every overlap obeys the ordered estimate with
 coefficient \(1 / m\), then the Euclidean-space parent Hamiltonian satisfies
 \(H² ≥ γ H\) as a quadratic form. -/
-theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
+theorem parentHamiltonianES_quadratic_form_of_finite_overlap_ordered_cross_term
     (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
     (overlaps : Fin N → Fin N → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
     (hProj : ∀ i : Fin N, (localTermES A L i).IsSymmetricProjection)
@@ -363,7 +363,7 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
     (hDisjoint : ∀ i j : Fin N, j ∈ Finset.univ.erase i → ¬ overlaps i j →
       ∀ v : EuclideanSpace ℂ (Cfg d N),
         0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re)
-    (hFriedrichs : ∀ i j : Fin N, j ∈ Finset.univ.erase i → overlaps i j →
+    (hCrossTerm : ∀ i j : Fin N, j ∈ Finset.univ.erase i → overlaps i j →
       ∀ v : EuclideanSpace ℂ (Cfg d N),
         - (1 - γ) * ((m : ℝ)⁻¹) * (⟪localTermES A L i v, v⟫_ℂ).re ≤
           (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re) :
@@ -376,15 +376,15 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
     (ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap
       (ι := Fin N) (E := EuclideanSpace ℂ (Cfg d N)) hγle
       (fun i : Fin N => localTermES A L i) hProj overlaps hm hCard hDisjoint
-      hFriedrichs v)
+      hCrossTerm v)
 
 /-- Fixed-chain martingale quadratic-form estimate from finite-overlap
-norm-compression principal-angle hypotheses.
+norm-compression hypotheses.
 
 For each overlapping pair, it is enough to bound the compressed product
 \(‖hᵢ (hⱼ v)‖\) by \((1 - γ) / m\) times \(‖hᵢ v‖\).  The abstract
-projection-geometry lemma converts this principal-angle style norm estimate into the ordered
-cross-term bound consumed by the finite-overlap row-sum reduction. -/
+projection-geometry lemma converts this norm estimate into the ordered cross-term
+bound consumed by the finite-overlap row-sum reduction. -/
 theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound
     (A : MPSTensor d D) (L N : ℕ) {γ : ℝ} (hγle : γ ≤ 1)
     (overlaps : Fin N → Fin N → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
@@ -441,16 +441,17 @@ theorem parentHamiltonianES_quadratic_form_of_finite_overlap_norm_bound_of_le
       (fun i : Fin N => localTermES_isSymmetricProjection A L i) overlaps hm hCard
       hDisjoint hηle hOverlapNorm v)
 
-/-- Uniform explicit gap-bound reduction from finite-overlap principal-angle
+/-- Uniform explicit gap-bound reduction from finite-overlap ordered cross-term
 hypotheses.
 
 For parent-Hamiltonian windows of length \(L\), the expected finite-range bound is
 \(m = 2 * (L - 1)\): each local term overlaps at most that many other cyclic
 translates when \(N ≥ 2L\).  This theorem leaves the Euclidean-space local projection
 structure, the cyclic-window overlap predicate, non-overlap positivity, and the
-principal-angle estimate as explicit hypotheses. It only performs the finite-overlap
-row-sum reduction and the existing quadratic-form-to-gap conversion. -/
-theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
+ordered cross-term estimate as explicit hypotheses. It only performs the
+finite-overlap row-sum reduction and the existing quadratic-form-to-gap
+conversion. -/
+theorem parentHamiltonianES_gap_bound_of_finite_overlap_ordered_cross_term
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (overlaps : ∀ N : ℕ, Fin N → Fin N → Prop)
     [∀ N : ℕ, DecidableRel (overlaps N)]
@@ -462,7 +463,7 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
       j ∈ Finset.univ.erase i → ¬ overlaps N i j →
         ∀ v : EuclideanSpace ℂ (Cfg d N),
           0 ≤ (⟪localTermES A L i v, localTermES A L j v⟫_ℂ).re)
-    (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+    (hCrossTerm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
       j ∈ Finset.univ.erase i → overlaps N i j →
         ∀ v : EuclideanSpace ℂ (Cfg d N),
           - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
@@ -487,9 +488,9 @@ theorem parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs
     nlinarith [hLge_one]
   have hm : 0 < 2 * (L - 1) :=
     Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
-  exact parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs
+  exact parentHamiltonianES_quadratic_form_of_finite_overlap_ordered_cross_term
     A L N hγle (overlaps N) hm (hProj N hLN) (hCard N hLN)
-    (hDisjoint N hLN) (hFriedrichs N hLN) v
+    (hDisjoint N hLN) (hCrossTerm N hLN) v
 
 /-- Uniform explicit gap-bound reduction using the concrete cyclic-window overlap
 predicate.
@@ -500,11 +501,11 @@ to the martingale method.  The row-cardinality estimate is supplied by
 `cyclicWindowsOverlap_card_le`, local projection structure is supplied by
 `localTermES_isSymmetricProjection`, and non-overlap positivity is supplied by
 `localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap`.  Consequently the
-only remaining local hypothesis is the principal-angle estimate for pairs
+only remaining local hypothesis is the ordered cross-term estimate for pairs
 marked by `cyclicWindowsOverlap`. -/
-theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_ordered_cross_term
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
-    (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+    (hCrossTerm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
       j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
         ∀ v : EuclideanSpace ℂ (Cfg d N),
           - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
@@ -517,13 +518,13 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  exact parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs A L hL
+  exact parentHamiltonianES_gap_bound_of_finite_overlap_ordered_cross_term A L hL
     (fun N => cyclicWindowsOverlap N L)
     (fun N _hLN i => localTermES_isSymmetricProjection A L i)
     (fun N hLN i => cyclicWindowsOverlap_card_le hLN hL i)
     (fun N hLN i j _hij hnot v =>
       localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A (by omega) hnot v)
-    hFriedrichs
+    hCrossTerm
 
 /-- Uniform explicit gap-bound reduction from an ordered overlapping-window
 cross-term estimate.
@@ -532,9 +533,9 @@ The concrete cyclic-window row-cardinality bound, local symmetric-projection
 structure, and non-overlap positivity are already proved.  Consequently it is
 enough to assume the displayed ordered lower bound only for pairs whose cyclic
 supports overlap. -/
-theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_ordered_cross_term
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
-    (hFriedrichs : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+    (hCrossTerm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
       j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
         ∀ v : EuclideanSpace ℂ (Cfg d N),
           - (1 - ((1 : ℝ) / (4 * (L : ℝ)))) *
@@ -547,7 +548,7 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  exact parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs A L hL hFriedrichs
+  exact parentHamiltonianES_gap_bound_of_cyclic_window_ordered_cross_term A L hL hCrossTerm
 
 /-- Uniform explicit gap-bound reduction from the cyclic-window anticommutator
 martingale estimate.
@@ -626,7 +627,7 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound
       v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
         ((1 : ℝ) / (4 * (L : ℝ))) * ‖v‖ ≤
           ‖parentHamiltonianES A L N v‖ := by
-  refine parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs A L hL ?_
+  refine parentHamiltonianES_gap_bound_of_cyclic_window_overlap_ordered_cross_term A L hL ?_
   intro N hLN i j hij hoverlap v
   have hCross :
       -((1 - ((1 : ℝ) / (4 * (L : ℝ)))) *

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -648,8 +648,8 @@ sufficient stronger hypotheses.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian finite-overlap martingale quadratic reduction]
-    \label{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
-    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_friedrichs}
+    \label{lem:parent_hamiltonian_finite_overlap_ordered_cross_term_quadratic}
+    \lean{MPSTensor.parentHamiltonianES_quadratic_form_of_finite_overlap_ordered_cross_term}
     \leanok
     \uses{lem:finite_overlap_projection_rowsum_reduction, def:parent_hamiltonian_es}
     For a fixed chain length $N$, let $m$ be a positive integer and let
@@ -805,10 +805,10 @@ sufficient stronger hypotheses.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian gap from a finite-overlap martingale estimate]
-    \label{lem:parent_hamiltonian_finite_overlap_friedrichs_gap}
-    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_friedrichs}
+    \label{lem:parent_hamiltonian_finite_overlap_ordered_cross_term_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_finite_overlap_ordered_cross_term}
     \leanok
-    \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic,
+    \uses{lem:parent_hamiltonian_finite_overlap_ordered_cross_term_quadratic,
         lem:parent_hamiltonian_es_quadratic_reduction}
     Fix $L>1$ and set $m=2(L-1)$. Suppose uniformly for every $N\ge2L$ that
     the hypotheses of the fixed-chain finite-overlap martingale reduction hold
@@ -825,10 +825,10 @@ sufficient stronger hypotheses.
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian gap from a cyclic-window martingale estimate]
-    \label{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
-    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_friedrichs}
+    \label{lem:parent_hamiltonian_cyclic_window_ordered_cross_term_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_ordered_cross_term}
     \leanok
-    \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
+    \uses{lem:parent_hamiltonian_finite_overlap_ordered_cross_term_gap,
         lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections,
         lem:cyclic_window_nonoverlap_positive}
     Fix $L>1$ and let $i\sim_L j$ mean that the cyclic supports of the
@@ -845,7 +845,7 @@ sufficient stronger hypotheses.
 
 \begin{proof}
     \leanok
-    \uses{lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
+    \uses{lem:parent_hamiltonian_finite_overlap_ordered_cross_term_gap,
         lem:cyclic_window_overlap_cardinality, lem:transported_es_local_projections,
         lem:cyclic_window_nonoverlap_positive}
     Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the row-cardinality
@@ -856,19 +856,19 @@ sufficient stronger hypotheses.
     do not meet, the corresponding windows are site-disjoint, so
     Lemma~\ref{lem:cyclic_window_nonoverlap_positive} gives the required
     non-negative ordered cross term. Apply
-    Lemma~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} with these
+    Lemma~\ref{lem:parent_hamiltonian_finite_overlap_ordered_cross_term_gap} with these
     facts and the overlapping-window estimate~(\ref{eq:ph_cyclic_window_overlap_estimate}).
 \end{proof}
 
 \begin{lemma}[Parent-Hamiltonian gap from an overlapping cyclic martingale estimate]
-    \label{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap}
-    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs}
+    \label{lem:parent_hamiltonian_cyclic_overlap_ordered_cross_term_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_ordered_cross_term}
     \leanok
-    \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
+    \uses{lem:parent_hamiltonian_cyclic_window_ordered_cross_term_gap}
     Fix $L>1$ and let $i\sim_L j$ mean that the cyclic supports of the
     length-$L$ windows at $i$ and $j$ meet. Suppose uniformly for every
     $N\ge2L$ that overlapping off-diagonal terms satisfy
-    \begin{equation}\label{eq:ph_cyclic_overlap_friedrichs}
+    \begin{equation}\label{eq:ph_cyclic_overlap_ordered_cross_term}
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\tfrac{1}{4L})\frac{1}{2(L-1)}
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,v\rangle.
@@ -879,11 +879,11 @@ sufficient stronger hypotheses.
 
 \begin{proof}
     \leanok
-    \uses{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}
-    Apply Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap}.
+    \uses{lem:parent_hamiltonian_cyclic_window_ordered_cross_term_gap}
+    Apply Lemma~\ref{lem:parent_hamiltonian_cyclic_window_ordered_cross_term_gap}.
     Its non-overlap positivity and finite-family hypotheses are already internal to
     the preceding reduction; the overlapping estimate
-    (\ref{eq:ph_cyclic_overlap_friedrichs}) supplies its remaining ordered
+    (\ref{eq:ph_cyclic_overlap_ordered_cross_term}) supplies its remaining ordered
     cross-term condition.
 \end{proof}
 
@@ -925,7 +925,7 @@ sufficient stronger hypotheses.
     \label{lem:parent_hamiltonian_cyclic_overlap_norm_gap}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound}
     \leanok
-    \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
+    \uses{lem:parent_hamiltonian_cyclic_overlap_ordered_cross_term_gap,
         rem:projection_geometry_rowsum_identities}
     Fix $L>1$. Suppose uniformly for every $N\ge2L$ and every overlapping
     off-diagonal pair that
@@ -940,7 +940,7 @@ sufficient stronger hypotheses.
 
 \begin{proof}
     \leanok
-    \uses{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
+    \uses{lem:parent_hamiltonian_cyclic_overlap_ordered_cross_term_gap,
         rem:projection_geometry_rowsum_identities}
     For an overlapping pair, Cauchy--Schwarz and $h_{i,\mathrm{ES}}^2
     =h_{i,\mathrm{ES}}$ give
@@ -1116,7 +1116,7 @@ sufficient stronger hypotheses.
         \qquad \eta\,2(L-1)<1,
     \]
     for every overlapping off-diagonal pair is a sufficient stronger hypothesis;
-    Theorem~\ref{thm:friedrichs_gap_bound_constant} records that consequence.
+    Theorem~\ref{thm:overlap_norm_gap_bound_constant} records that consequence.
     (When $L = 1$ the interaction terms have disjoint supports, so there are no
     overlapping pairs and the spectral gap follows directly without the
     martingale argument.)
@@ -1172,7 +1172,7 @@ sufficient stronger hypotheses.
         \|h_i h_j v\|\le \eta\|h_i v\|,
         \qquad \eta\,2(L-1)<1.
     \]
-    If such an $\eta$ is obtained, Theorem~\ref{thm:friedrichs_gap_bound_constant}
+    If such an $\eta$ is obtained, Theorem~\ref{thm:overlap_norm_gap_bound_constant}
     gives the gap constant $1-\eta\,2(L-1)$. The frequently displayed
     fixed-coefficient compression form is the specialization with
     \[
@@ -1205,8 +1205,8 @@ sufficient stronger hypotheses.
 \end{proof}
 
 \begin{theorem}[Gap bound from cyclic overlap compression]
-    \label{thm:friedrichs_gap_bound}
-    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_friedrichs}
+    \label{thm:overlap_norm_gap_bound}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_overlap_norm_bound}
     \leanok
     \uses{def:parent_ground_space_es, def:parent_hamiltonian_es,
         thm:parent_ground_space_es_kernel,
@@ -1217,14 +1217,14 @@ sufficient stronger hypotheses.
         lem:transported_es_nonoverlap_positive,
         lem:parent_hamiltonian_es_quadratic_reduction,
         lem:parent_hamiltonian_ordered_rowsum_gap,
-        lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic,
-        lem:parent_hamiltonian_finite_overlap_friedrichs_gap,
+        lem:parent_hamiltonian_finite_overlap_ordered_cross_term_quadratic,
+        lem:parent_hamiltonian_finite_overlap_ordered_cross_term_gap,
         lem:cyclic_window_overlap_cardinality,
         lem:cyclic_window_nonoverlap_positive,
-        lem:parent_hamiltonian_cyclic_window_friedrichs_gap,
-        lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap,
+        lem:parent_hamiltonian_cyclic_window_ordered_cross_term_gap,
+        lem:parent_hamiltonian_cyclic_overlap_ordered_cross_term_gap,
         lem:parent_hamiltonian_cyclic_overlap_norm_gap,
-        thm:friedrichs_gap_bound_constant}
+        thm:overlap_norm_gap_bound_constant}
     Let $A$ be a tensor and let $L>1$. Suppose that, for every $N\ge2L$ and
     every overlapping off-diagonal pair of cyclic length-$L$ windows,
     \[
@@ -1254,8 +1254,8 @@ sufficient stronger hypotheses.
     quadratic-form estimate. Lemma~\ref{lem:parent_hamiltonian_ordered_rowsum_gap}
     establishes the finite-sum algebra from ordered cross-term row bounds, while
     Lemma~\ref{lem:parent_hamiltonian_anticommutator_rowsum_gap} records the
-    source anticommutator martingale condition. Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_quadratic}
-    and~\ref{lem:parent_hamiltonian_finite_overlap_friedrichs_gap} state the
+    source anticommutator martingale condition. Lemmas~\ref{lem:parent_hamiltonian_finite_overlap_ordered_cross_term_quadratic}
+    and~\ref{lem:parent_hamiltonian_finite_overlap_ordered_cross_term_gap} state the
     common finite-overlap ordered-cross-term specialization with $m=2(L-1)$.
     Lemma~\ref{lem:transported_es_nonoverlap_positive} supplies the non-overlap
     positivity statement for site-disjoint windows, and
@@ -1263,11 +1263,11 @@ sufficient stronger hypotheses.
     concrete support-disjoint cyclic windows.
     Lemma~\ref{lem:cyclic_window_overlap_cardinality} gives the finite-overlap
     row-cardinality bound.
-    Lemma~\ref{lem:parent_hamiltonian_cyclic_window_friedrichs_gap} combines
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_window_ordered_cross_term_gap} combines
     these results with the finite-overlap reduction, so the only additional
     input is the ordered anticommutator or cross-term estimate for overlapping
     cyclic windows.
-    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_friedrichs_gap} states the
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_ordered_cross_term_gap} states the
     same overlap-only formulation, and
     Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_gap} states a sufficient
     norm-compression formulation. Equivalently, this is the
@@ -1318,7 +1318,7 @@ sufficient stronger hypotheses.
 \end{proof}
 
 \begin{theorem}[Gap bound from a strict cyclic compression constant]
-    \label{thm:friedrichs_gap_bound_constant}
+    \label{thm:overlap_norm_gap_bound_constant}
     \lean{MPSTensor.parentHamiltonianES_gap_bound_of_overlap_norm_constant}
     \leanok
     \uses{lem:parent_hamiltonian_cyclic_overlap_norm_constant_gap}
@@ -1357,11 +1357,11 @@ sufficient stronger hypotheses.
     \lean{MPSTensor.parentHamiltonian_gapped}
     \lean{MPSTensor.parentHamiltonian_gapped_of_anticommutator}
     \leanok
-    \uses{thm:anticommutator_gap_bound, thm:friedrichs_gap_bound}
+    \uses{thm:anticommutator_gap_bound, thm:overlap_norm_gap_bound}
     For a tensor $A$ and a range $L > 1$, assume either the cyclic-window
     anticommutator estimate of Theorem~\ref{thm:anticommutator_gap_bound} or the
     stronger overlapping cyclic-window norm-compression estimate of
-    Theorem~\ref{thm:friedrichs_gap_bound}. Then there exists $\gamma > 0$ such
+    Theorem~\ref{thm:overlap_norm_gap_bound}. Then there exists $\gamma > 0$ such
     that for every $N \ge 2L$ and every vector
     $v \in (\mathcal G_{N,L}^{\mathrm{ES}}(A))^{\perp}$ one has
     \[
@@ -1381,7 +1381,7 @@ sufficient stronger hypotheses.
     \label{thm:parent_hamiltonian_gapped_constant}
     \lean{MPSTensor.parentHamiltonian_gapped_of_overlap_norm_constant}
     \leanok
-    \uses{thm:friedrichs_gap_bound_constant}
+    \uses{thm:overlap_norm_gap_bound_constant}
     For a tensor $A$ and a range $L>1$, suppose there is a constant
     $\eta\ge0$ such that $\eta\,2(L-1)<1$ and, for every $N\ge2L$ and every
     overlapping off-diagonal pair of cyclic length-$L$ windows,
@@ -1399,6 +1399,6 @@ sufficient stronger hypotheses.
 
 \begin{proof}
     \leanok
-    This follows from Theorem~\ref{thm:friedrichs_gap_bound_constant} by taking
+    This follows from Theorem~\ref{thm:overlap_norm_gap_bound_constant} by taking
     $\gamma=1-\eta\,2(L-1)$.
 \end{proof}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -185,7 +185,7 @@ without passing through this stronger one-sided estimate.\footnote{The
     \leanid{parentHamiltonian_gapped_of_anticommutator} in
     \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}.
     The cyclic-window compression reductions are
-    \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_friedrichs},
+    \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_ordered_cross_term},
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound},
     and
     \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le}
@@ -197,14 +197,15 @@ without passing through this stronger one-sided estimate.\footnote{The
     \leanid{parentHamiltonian_gapped_of_overlap_norm_constant} in
     \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. The
     projection-geometry reductions used by these statements are in
-    \path{TNLean/Analysis/ProjectionGeometry.lean}. The declaration names keep the
-    earlier word \path{friedrichs}; this note uses ``anticommutator estimate'' for
+    \path{TNLean/Analysis/ProjectionGeometry.lean}. The declaration names
+    identify the intermediate ordered cross-term estimate and the sufficient
+    norm-compression estimates; this note uses ``anticommutator estimate'' for
     the source condition and ``norm compression'' for the local sufficient
     strengthening.}
 
 The anticommutator row-sum formulation, including its finite-overlap
-cyclic-window specialization, is now the source-faithful formal boundary. The
-flexible constant formulation is a sufficient compression boundary:
+cyclic-window specialization, is now the formal condition matching the source.
+The flexible constant formulation records a sufficient norm-compression variant:
 instead of requiring the special coefficient in (N), it assumes that for some
 $\eta\ge 0$,
 \begin{equation}
@@ -229,19 +230,21 @@ terms, row-sum coefficients for overlapping terms, and principal-angle estimates
 for local ground spaces. The point still requiring a mathematical check is
 quantitative and conventional.
 
-First, the formal theorem asks for a uniform compression constant $\eta$ for
-overlapping cyclic-window pairs, with $\eta\,2(L-1)<1$. The review text states
-the general martingale condition with coefficients $c_{ij}$ whose rows add to
-one, and it refers to blocking and principal angles to obtain a positive gap.
-It does not by itself identify the Fannes--Nachtergaele--Werner,
-Nachtergaele, or Kastoryano--Lucia estimates with the bound (N$_\eta$) for this
-fixed cyclic-window convention. The stronger displayed coefficient in (N),
-equivalently the choice
+First, the source-matching formal theorem asks for the cyclic-window
+anticommutator estimate
 \[
-    \eta=\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)},
+    p_i p_j+p_jp_i
+    \ge
+    -\left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}(p_i+p_j)
 \]
-is therefore not the only possible target; any source-derived $\eta$ satisfying
-(E) would suffice for the existing gap theorem.
+for overlapping off-diagonal pairs. The review text states the same martingale
+condition with general coefficients $c_{ij}$ whose rows add to one, and it
+refers to blocking and principal angles to obtain a positive gap. It does not by
+itself identify the Fannes--Nachtergaele--Werner, Nachtergaele, or
+Kastoryano--Lucia estimates with this coefficient and this fixed cyclic-window
+convention. A proof may instead derive a row-sum anticommutator estimate with
+different positive constants and then specialize the final gap constant
+accordingly.
 
 Second, the blocking parameter in the cited martingale argument must be matched
 with the formal convention. The formal statement is uniform for all $N\ge 2L$
@@ -255,20 +258,22 @@ the same blocking convention.
 Consequently the remaining comparison is not whether the row-sum algebra is
 valid; that part has been isolated and formalized. The remaining comparison is
 whether the cited FNW--Nachtergaele--Kastoryano principal-angle estimates supply
-an overlapping cyclic-window estimate of the form (N$_\eta$) with
-$\eta\,2(L-1)<1$, or whether the formal development is using a stronger
-replacement input than the review text states explicitly.
+the required cyclic-window anticommutator estimate, with constants independent
+of the chain length, after the same blocking convention has been fixed.
 The qualitative fact that two finite-dimensional subspaces have a well-defined
 principal-angle decomposition is not enough: the martingale reduction needs a
 uniform numerical bound after the same blocking convention has been fixed.
 
-There is also a directional point. If (N$_\eta$) is imposed for all vectors
+The norm-compression route remains available as a stronger sufficient target:
+any estimate (N$_\eta$) with $\eta\,2(L-1)<1$ gives a positive gap through the
+already formalized reduction. There is, however, a directional point. If
+(N$_\eta$) is imposed for all vectors
 $v$, then $p_i v=0$ implies $p_i p_j v=0$. Thus $p_j$ maps $\ker p_i$ into
 $\ker p_i$. This is stronger than merely knowing that the
 smallest non-zero principal angle between the two local ground spaces is
-positive. The source comparison must therefore identify a principal-angle
-estimate that gives the directed compressed-product bound (N$_\eta$), or the
-formal hypothesis should be restated directly in the anticommutator form
+positive. A proof using compression must therefore identify a principal-angle
+estimate that gives the directed compressed-product bound (N$_\eta$). A direct
+proof can instead target the anticommutator form
 \[
     h_i h_j+h_jh_i\ge -c_{ij}(1-\gamma)(h_i+h_j)
 \]
@@ -286,7 +291,7 @@ source anticommutator estimate as the hypothesis of
 Theorem \path{thm:anticommutator_gap_bound}, and records norm-compression
 estimates as sufficient stronger hypotheses.
 
-The source-facing theorem entry
+The source-matching theorem entry
 \path{thm:anticommutator_gap_bound} points to
 \leanid{parentHamiltonianES_gap_bound_of_anticommutator} in
 \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. Its hypothesis is the
@@ -295,8 +300,8 @@ cyclic-window anticommutator lower bound with coefficient
     \left(1-\frac{1}{4L}\right)\frac{1}{2(L-1)}.
 \]
 The theorem entries
-\path{thm:friedrichs_gap_bound} and
-\path{thm:friedrichs_gap_bound_constant} point respectively to the special
+\path{thm:overlap_norm_gap_bound} and
+\path{thm:overlap_norm_gap_bound_constant} point respectively to the special
 coefficient theorem and to the constant-$\eta$ theorem in
 \path{TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean}. The special coefficient
 theorem is the specialization of the constant-$\eta$ theorem with
@@ -313,10 +318,11 @@ are proved, while the MPS-specific anticommutator estimate remains to be proved
 or matched precisely to the cited martingale estimates.
 
 Once the quantitative comparison with the cited martingale estimates is settled,
-the blueprint should say either that a compression bound (N$_\eta$) with
-$\eta\,2(L-1)<1$ follows from those estimates under the cyclic-window convention
-used here, or that the final MPS gap theorem uses a deliberately stronger
-replacement estimate.
+the blueprint should say that the cyclic-window anticommutator estimate follows
+from those estimates under the convention used here. If the proof instead goes
+through norm compression, the blueprint should say explicitly that the
+compression bound (N$_\eta$) with $\eta\,2(L-1)<1$ is a stronger sufficient
+estimate implying the anticommutator route.
 
 \section{Conclusion}
 


### PR DESCRIPTION
### Motivation

- Declarations in `TNLean/MPS/ParentHamiltonian/Martingale/` used `friedrichs` in their names, encoding a Friedrichs-type compression framing that does not match the source condition in arXiv:2011.12127, Section IV.C. The source condition is the overlapping-window anticommutator estimate; the norm-compression route is a stronger sufficient hypothesis.
- Aligning declaration names to the source terminology removes misleading vocabulary and improves traceability to arXiv:2011.12127 §IV.C (see also #952).

### Description

- `TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean`, `Gap.lean`, `AbstractCriterion.lean`: rename `friedrichs`-keyed declarations to `ordered_cross_term` and `overlap_norm` names (e.g., `parentHamiltonianES_gap_bound_of_friedrichs` → `parentHamiltonianES_gap_bound_of_overlap_norm_bound`; hypothesis parameter `hFriedrichs` → `hCrossTerm`).
- `TNLean/Analysis/ProjectionGeometry.lean`: remove residual "Friedrichs" wording from the projection-geometry layer feeding the row-sum reduction.
- `blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex`: update blueprint labels and `\lean{}` tags to match renamed declarations (e.g., `thm:friedrichs_gap_bound*` → `thm:overlap_norm_gap_bound*`).
- `docs/paper-gaps/cpgsv21_martingale_overlap.tex`: revise so the open quantitative target is stated as the cyclic-window anticommutator estimate (arXiv:2011.12127 §IV.C), with norm-compression bounds recorded as stronger sufficient hypotheses.
- **No compatibility alias is provided.** The old names encode `friedrichs`, which does not correspond to the source terminology (see [`docs/CONTRIBUTING.md` §Mathematical-language renames](docs/CONTRIBUTING.md#mathematical-language-renames)).

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `leanblueprint checkdecls` could not be run locally (no generated `blueprint/lean_decls` in this fresh worktree); Lean CI (`lean_action_ci.yml`) will validate the renamed declarations.

---
Addresses #952
Refs #460
Refs #190

> [!NOTE]
> **Low Risk**
> Rename-only across Lean, blueprint, and docs with no proof or API logic changes; downstream callers must use the new theorem names because deprecated aliases were omitted.
>
> **Overview**
> This PR is a **terminology and documentation alignment** pass for the parent-Hamiltonian martingale chain; it does not change the underlying reduction logic.
>
> **Lean:** Symbols that used `friedrichs` in their names are renamed to match the mathematical role—e.g. `parentHamiltonianES_gap_bound_of_friedrichs` → `parentHamiltonianES_gap_bound_of_overlap_norm_bound`, finite-overlap lemmas → `*_ordered_cross_term`, and hypothesis parameters `hFriedrichs` → `hCrossTerm`. Comments in `ProjectionGeometry.lean` and the Martingale modules drop "Friedrichs" wording in favor of **ordered cross-term** and **norm-compression** language. No deprecated aliases are added.
>
> **Blueprint & paper-gap:** `ch13_parent_hamiltonian_spectral_gap.tex` updates lemma/theorem labels and `\lean{}` tags to the new declaration names; theorem labels move from `thm:friedrichs_gap_bound*` to `thm:overlap_norm_gap_bound*`. `docs/paper-gaps/cpgsv21_martingale_overlap.tex` is revised so the **open quantitative target** is the cyclic-window **anticommutator** estimate (matching arXiv:2011.12127 §IV.C), with norm-compression bounds recorded explicitly as **stronger sufficient** hypotheses—not as the primary source-facing condition.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e008c9dc641699370069b09b0c3ac4a2c31007fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>