### PR TITLE
feat(Algebra): extract tensor-product phase scalars

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -28,6 +28,7 @@ import TNLean.Algebra.MatrixAux
 import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.UnitModulusPowerSum
 import TNLean.Algebra.FiniteCycleCoboundary
+import TNLean.Algebra.PiTensorProductPhase
 import TNLean.Algebra.BurnsideMatrix
 import TNLean.Algebra.IrreducibleTensorAction
 import TNLean.Algebra.PerronFrobenius.RankOne

--- a/TNLean/Algebra/PiTensorProductPhase.lean
+++ b/TNLean/Algebra/PiTensorProductPhase.lean
@@ -8,11 +8,11 @@ import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.PiTensorProduct.Dual
 
 /-!
-# Phase extraction from a cyclic tensor-product identity
+# Phase extraction from a product-tensor identity
 
 This file isolates the algebraic proportionality step in arXiv:1708.00029,
-Appendix A, lines 1070--1084.  Once the preceding \(F_u,\Omega_u\) contraction
-has produced a product-tensor identity, the result below extracts the
+Appendix A, lines 1072--1080.  Once the preceding \(F_u,\Omega_u\) contraction
+has produced the uniform product-tensor identity, the result below extracts the
 sectorwise scalars whose product is the global phase.
 -/
 
@@ -47,7 +47,7 @@ reduction from that identity to the uniform form used here is tracked by issue
 The reference entries are the formal analogue of choosing one nonzero matrix
 entry in each right-invertible sector block after the \(F_u,\Omega_u\)
 contraction has produced the displayed product-tensor identity. -/
-theorem exists_kappa_of_pi_tensor_product_resultprop
+theorem exists_kappa_of_piTensorProduct_eq_smul
     {d m : ℕ}
     {row col : Fin m → Type*}
     (A B : (v : Fin m) → Fin d → Matrix (row v) (col v) ℂ)

--- a/TNLean/Algebra/PiTensorProductPhase.lean
+++ b/TNLean/Algebra/PiTensorProductPhase.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Data.Complex.Basic
-import Mathlib.LinearAlgebra.Matrix.StdBasis
+import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.PiTensorProduct.Dual
 
 /-!
@@ -22,20 +22,10 @@ namespace TNLean.Algebra
 
 namespace PiTensorProductPhase
 
-/-- Coordinate functional on a matrix entry. -/
-def matrixEntryDual {r c : Type*} (a : r) (b : c) :
-    Module.Dual ℂ (Matrix r c ℂ) where
-  toFun M := M a b
-  map_add' M N := by simp
-  map_smul' z M := by simp
-
 /-- Coordinate functional normalized to take the matrix `M` to one at entry `(a,b)`. -/
 noncomputable def normalizedMatrixEntryDual {r c : Type*} (M : Matrix r c ℂ)
-    (a : r) (b : c) : Module.Dual ℂ (Matrix r c ℂ) where
-  toFun N := (M a b)⁻¹ * N a b
-  map_add' N N' := by simp [mul_add]
-  map_smul' z N := by
-    simp [mul_assoc, mul_comm]
+    (a : r) (b : c) : Module.Dual ℂ (Matrix r c ℂ) :=
+  (M a b)⁻¹ • Matrix.entryLinearMap ℂ ℂ a b
 
 @[simp]
 lemma normalizedMatrixEntryDual_apply_self {r c : Type*} {M : Matrix r c ℂ}
@@ -43,15 +33,22 @@ lemma normalizedMatrixEntryDual_apply_self {r c : Type*} {M : Matrix r c ℂ}
     normalizedMatrixEntryDual M a b M = 1 := by
   simp [normalizedMatrixEntryDual, hM]
 
-/-- arXiv:1708.00029, Appendix A, lines 1070--1084: a product-tensor identity
+/-- arXiv:1708.00029, Appendix A, lines 1072--1080: a product-tensor identity
 with a nonzero reference tensor implies sectorwise proportionality, and the
 sector scalars multiply to the global scalar.
 
+**Scope restriction (arXiv:1708.00029, Appendix A, lines 1068--1080):** this
+theorem starts from the uniform identity
+\(\bigotimes_v A_v(\sigma_v)=z\cdot\bigotimes_v B_v(\sigma_v)\).  The paper
+first obtains a cyclically shifted product identity between sector labels; the
+reduction from that identity to the uniform form used here is tracked by issue
+#873.
+
 The reference entries are the formal analogue of choosing one nonzero matrix
 entry in each right-invertible sector block after the \(F_u,\Omega_u\)
-contraction has produced `eq:resultprop`. -/
-theorem exists_kappa_of_piTensorProduct_resultprop
-    {d m : ℕ} [NeZero m]
+contraction has produced the displayed product-tensor identity. -/
+theorem exists_kappa_of_pi_tensor_product_resultprop
+    {d m : ℕ}
     {row col : Fin m → Type*}
     (A B : (v : Fin m) → Fin d → Matrix (row v) (col v) ℂ)
     (z : ℂ) (hz : z ≠ 0)
@@ -77,7 +74,8 @@ theorem exists_kappa_of_piTensorProduct_resultprop
   refine ⟨κ, hκ_prod, ?_⟩
   intro v i
   ext a b
-  let entry : Module.Dual ℂ (Matrix (row v) (col v) ℂ) := matrixEntryDual a b
+  let entry : Module.Dual ℂ (Matrix (row v) (col v) ℂ) :=
+    Matrix.entryLinearMap ℂ ℂ a b
   let ell' : (w : Fin m) → Module.Dual ℂ (Matrix (row w) (col w) ℂ) :=
     Function.update ell v entry
   have hcoord :
@@ -93,7 +91,7 @@ theorem exists_kappa_of_piTensorProduct_resultprop
         A v i a b * ∏ w ∈ Finset.univ \ {v}, κ w := by
     rw [Finset.prod_eq_mul_prod_sdiff_singleton_of_mem (Finset.mem_univ v)]
     congr 1
-    · simp [ell', entry, matrixEntryDual]
+    · simp [ell', entry]
     · apply Finset.prod_congr rfl
       intro w hw
       have hw_ne : w ≠ v := by
@@ -111,7 +109,7 @@ theorem exists_kappa_of_piTensorProduct_resultprop
         simpa using (Finset.mem_sdiff.mp hw).2
       simp [ell', ell, Function.update_of_ne hw_ne, hB_ref w]
     have hfirst : ell' v (B v (Function.update ref v i v)) = B v i a b := by
-      simp [ell', entry, matrixEntryDual]
+      simp [ell', entry]
     rw [hfirst, hcomp, mul_one]
   let P : ℂ := ∏ w ∈ Finset.univ \ {v}, κ w
   have hκ_split : κ v * P = z := by

--- a/TNLean/Algebra/PiTensorProductPhase.lean
+++ b/TNLean/Algebra/PiTensorProductPhase.lean
@@ -1,0 +1,137 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Data.Complex.Basic
+import Mathlib.LinearAlgebra.Matrix.StdBasis
+import Mathlib.LinearAlgebra.PiTensorProduct.Dual
+
+/-!
+# Phase extraction from a cyclic tensor-product identity
+
+This file isolates the algebraic proportionality step in arXiv:1708.00029,
+Appendix A, lines 1070--1084.  Once the preceding \(F_u,\Omega_u\) contraction
+has produced a product-tensor identity, the result below extracts the
+sectorwise scalars whose product is the global phase.
+-/
+
+open scoped BigOperators TensorProduct
+
+namespace TNLean.Algebra
+
+namespace PiTensorProductPhase
+
+/-- Coordinate functional on a matrix entry. -/
+def matrixEntryDual {r c : Type*} (a : r) (b : c) :
+    Module.Dual ℂ (Matrix r c ℂ) where
+  toFun M := M a b
+  map_add' M N := by simp
+  map_smul' z M := by simp
+
+/-- Coordinate functional normalized to take the matrix `M` to one at entry `(a,b)`. -/
+noncomputable def normalizedMatrixEntryDual {r c : Type*} (M : Matrix r c ℂ)
+    (a : r) (b : c) : Module.Dual ℂ (Matrix r c ℂ) where
+  toFun N := (M a b)⁻¹ * N a b
+  map_add' N N' := by simp [mul_add]
+  map_smul' z N := by
+    simp [mul_assoc, mul_comm]
+
+@[simp]
+lemma normalizedMatrixEntryDual_apply_self {r c : Type*} {M : Matrix r c ℂ}
+    {a : r} {b : c} (hM : M a b ≠ 0) :
+    normalizedMatrixEntryDual M a b M = 1 := by
+  simp [normalizedMatrixEntryDual, hM]
+
+/-- arXiv:1708.00029, Appendix A, lines 1070--1084: a product-tensor identity
+with a nonzero reference tensor implies sectorwise proportionality, and the
+sector scalars multiply to the global scalar.
+
+The reference entries are the formal analogue of choosing one nonzero matrix
+entry in each right-invertible sector block after the \(F_u,\Omega_u\)
+contraction has produced `eq:resultprop`. -/
+theorem exists_kappa_of_piTensorProduct_resultprop
+    {d m : ℕ} [NeZero m]
+    {row col : Fin m → Type*}
+    (A B : (v : Fin m) → Fin d → Matrix (row v) (col v) ℂ)
+    (z : ℂ) (hz : z ≠ 0)
+    (ref : Fin m → Fin d) (r : (v : Fin m) → row v) (c : (v : Fin m) → col v)
+    (hB_ref : ∀ v : Fin m, B v (ref v) (r v) (c v) ≠ 0)
+    (hresult :
+      ∀ σ : Fin m → Fin d,
+        (⨂ₜ[ℂ] v : Fin m, A v (σ v)) =
+          z • (⨂ₜ[ℂ] v : Fin m, B v (σ v))) :
+    ∃ κ : Fin m → ℂ,
+      (∏ v : Fin m, κ v = z) ∧
+      ∀ (v : Fin m) (i : Fin d), A v i = κ v • B v i := by
+  classical
+  let ell : (v : Fin m) → Module.Dual ℂ (Matrix (row v) (col v) ℂ) :=
+    fun v => normalizedMatrixEntryDual (B v (ref v)) (r v) (c v)
+  let κ : Fin m → ℂ := fun v => ell v (A v (ref v))
+  have hκ_prod : ∏ v : Fin m, κ v = z := by
+    have h :=
+      congrArg
+        (fun T => PiTensorProduct.dualDistrib (⨂ₜ[ℂ] v : Fin m, ell v) T)
+        (hresult ref)
+    simpa [ell, κ, hB_ref] using h
+  refine ⟨κ, hκ_prod, ?_⟩
+  intro v i
+  ext a b
+  let entry : Module.Dual ℂ (Matrix (row v) (col v) ℂ) := matrixEntryDual a b
+  let ell' : (w : Fin m) → Module.Dual ℂ (Matrix (row w) (col w) ℂ) :=
+    Function.update ell v entry
+  have hcoord :
+      (∏ w : Fin m, ell' w (A w (Function.update ref v i w))) =
+        z * ∏ w : Fin m, ell' w (B w (Function.update ref v i w)) := by
+    have h :=
+      congrArg
+        (fun T => PiTensorProduct.dualDistrib (⨂ₜ[ℂ] w : Fin m, ell' w) T)
+        (hresult (Function.update ref v i))
+    simpa using h
+  have hprodA :
+      (∏ w : Fin m, ell' w (A w (Function.update ref v i w))) =
+        A v i a b * ∏ w ∈ Finset.univ \ {v}, κ w := by
+    rw [Finset.prod_eq_mul_prod_sdiff_singleton_of_mem (Finset.mem_univ v)]
+    congr 1
+    · simp [ell', entry, matrixEntryDual]
+    · apply Finset.prod_congr rfl
+      intro w hw
+      have hw_ne : w ≠ v := by
+        simpa using (Finset.mem_sdiff.mp hw).2
+      simp [ell', κ, Function.update_of_ne hw_ne]
+  have hprodB :
+      (∏ w : Fin m, ell' w (B w (Function.update ref v i w))) =
+        B v i a b := by
+    rw [Finset.prod_eq_mul_prod_sdiff_singleton_of_mem (Finset.mem_univ v)]
+    have hcomp :
+        (∏ x ∈ Finset.univ \ {v}, ell' x (B x (Function.update ref v i x))) = 1 := by
+      apply Finset.prod_eq_one
+      intro w hw
+      have hw_ne : w ≠ v := by
+        simpa using (Finset.mem_sdiff.mp hw).2
+      simp [ell', ell, Function.update_of_ne hw_ne, hB_ref w]
+    have hfirst : ell' v (B v (Function.update ref v i v)) = B v i a b := by
+      simp [ell', entry, matrixEntryDual]
+    rw [hfirst, hcomp, mul_one]
+  let P : ℂ := ∏ w ∈ Finset.univ \ {v}, κ w
+  have hκ_split : κ v * P = z := by
+    change κ v * (∏ w ∈ Finset.univ \ {v}, κ w) = z
+    rw [Finset.sdiff_singleton_eq_erase,
+      Finset.mul_prod_erase Finset.univ κ (Finset.mem_univ v)]
+    exact hκ_prod
+  have hP_ne : P ≠ 0 := by
+    intro hP
+    exact hz (by rw [← hκ_split, hP, mul_zero])
+  apply mul_right_cancel₀ hP_ne
+  calc
+    A v i a b * P = z * B v i a b := by
+      simpa [P, hprodA, hprodB] using hcoord
+    _ = (κ v * B v i a b) * P := by
+      rw [← hκ_split]
+      ring
+    _ = ((κ v • B v i) a b) * P := by
+      simp [Matrix.smul_apply]
+
+end PiTensorProductPhase
+
+end TNLean.Algebra

--- a/TNLean/Algebra/PiTensorProductPhase.lean
+++ b/TNLean/Algebra/PiTensorProductPhase.lean
@@ -41,8 +41,8 @@ sector scalars multiply to the global scalar.
 theorem starts from the uniform identity
 \(\bigotimes_v A_v(\sigma_v)=z\cdot\bigotimes_v B_v(\sigma_v)\).  The paper
 first obtains a cyclically shifted product identity between sector labels; the
-reduction from that identity to the uniform form used here is tracked by issue
-#873.
+reduction from that identity to the uniform form used here is recorded in
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.
 
 The reference entries are the formal analogue of choosing one nonzero matrix
 entry in each right-invertible sector block after the \(F_u,\Omega_u\)

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -511,6 +511,49 @@ unconditional result.
 
 \subsection{Periodic overlap dichotomy}
 
+\begin{theorem}[Sector scalars from a product tensor identity]
+    \label{thm:periodic_product_tensor_phase_extraction}
+    \lean{TNLean.Algebra.PiTensorProductPhase.exists_kappa_of_pi_tensor_product_resultprop}
+    \leanok
+    Let $z\in\C$ be nonzero. For each sector $v=0,\ldots,m-1$, let
+    $\{A_v^i\}_i$ and $\{B_v^i\}_i$ be families of complex matrices with the
+    same rectangular size. Suppose that for every choice of letters
+    $\sigma=(\sigma_v)_v$,
+    \[
+        \bigotimes_{v=0}^{m-1} A_v^{\sigma_v}
+        =
+        z\,\bigotimes_{v=0}^{m-1} B_v^{\sigma_v}.
+    \]
+    Suppose also that for each $v$ there is a reference letter $i_v$ and a
+    matrix entry $(r_v,c_v)$ with
+    $(B_v^{i_v})_{r_v,c_v}\ne 0$. Then there are scalars
+    $\kappa_v\in\C$ such that
+    \[
+        \prod_{v=0}^{m-1}\kappa_v=z,
+        \qquad
+        A_v^i=\kappa_v B_v^i
+    \]
+    for every sector $v$ and every letter $i$.
+
+    This is the scalar extraction used in
+    \cite[Appendix~A, lines~1072--1080]{DeLasCuevas2017Irreducible}, after the
+    contraction with the maps $F_u$ and $\Omega_u$ has produced the displayed
+    product-tensor identity.
+\end{theorem}
+
+\begin{proof}\leanok
+    For each sector choose the coordinate functional at the nonzero reference
+    entry and normalize it so that it takes the value $1$ on
+    $B_v^{i_v}$. Applying the tensor product of these functionals to the
+    reference tensor identity gives $\prod_v\kappa_v=z$. To prove the
+    proportionality in sector $v$, replace only the $v$-th functional by the
+    coordinate functional at an arbitrary entry $(r,c)$ and apply the tensor
+    identity with $\sigma_v=i$ and all other letters fixed at their references.
+    The product over the other sectors is nonzero because its product with
+    $\kappa_v$ is $z$, so cancellation gives
+    $(A_v^i)_{r,c}=(\kappa_v B_v^i)_{r,c}$ for every entry.
+\end{proof}
+
 \begin{definition}[Off-diagonal sector decomposition]%
     \label{def:cyclic_sector_decomp}
     \lean{MPSTensor.IsCyclicSectorDecomp, MPSTensor.IsCyclicSectorDecompWith}

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -513,7 +513,7 @@ unconditional result.
 
 \begin{theorem}[Sector scalars from a product tensor identity]
     \label{thm:periodic_product_tensor_phase_extraction}
-    \lean{TNLean.Algebra.PiTensorProductPhase.exists_kappa_of_pi_tensor_product_resultprop}
+    \lean{TNLean.Algebra.PiTensorProductPhase.exists_kappa_of_piTensorProduct_eq_smul}
     \leanok
     Let $z\in\C$ be nonzero. For each sector $v=0,\ldots,m-1$, let
     $\{A_v^i\}_i$ and $\{B_v^i\}_i$ be families of complex matrices with the


### PR DESCRIPTION
### Motivation

- Isolates the Appendix A proportionality step from arXiv:1708.00029, lines 1070--1084: once the $F_u, \Omega_u$ contraction has produced the product-tensor identity, sector scalars $\kappa_v$ with $\prod_v \kappa_v = z$ and sectorwise proportionality $A_v^i = \kappa_v B_v^i$ must be extracted.
- Preparatory work toward #873; does not yet prove the cyclically shifted product-tensor identity from the source, the unit-modulus normalization, the finite-cycle phase choice, or the final global gauge statement.

### Description

- Adds `TNLean/Algebra/PiTensorProductPhase.lean`, a new self-contained algebra module.
- Imports the new module from `TNLean.lean`.
- Proves `exists_kappa_of_piTensorProduct_eq_smul`: given a uniform indexed tensor-product identity `⨂ A = z • ⨂ B` for all index choices `σ` and nonzero reference entries in each sector, produces sector scalars `κ_v` with `∏ κ_v = z` and `A v i = κ_v • B v i` everywhere. The proof reads off coordinates using normalized matrix-entry duals and `PiTensorProduct.dualDistrib`.

### Testing

- `lake build TNLean.Algebra.PiTensorProductPhase -q --log-level=info`
- `lake build TNLean -q --log-level=info`

---
Refs #873

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained pure algebra with no auth, I/O, or runtime behavior changes; only a new module, one root import, and blueprint documentation.
> 
> **Overview**
> **Adds** `TNLean/Algebra/PiTensorProductPhase.lean` and wires it into the root import list in `TNLean.lean`.
> 
> The main result is **`exists_kappa_of_piTensorProduct_eq_smul`**: from a family-wide identity `⨂ₜ A_v(σ_v) = z • ⨂ₜ B_v(σ_v)` for all index choices `σ`, plus nonzero reference entries in each `B` sector, the proof builds sector scalars `κ_v` with `∏ κ_v = z` and `A v i = κ_v • B v i` everywhere. The argument uses **normalized matrix-entry duals** and **`PiTensorProduct.dualDistrib`** to read off coordinates (arXiv:1708.00029 Appendix A, lines 1072–1080).
> 
> **Blueprint:** `ch22_periodic_ft.tex` gains theorem `thm:periodic_product_tensor_phase_extraction` (`\leanok`) in the periodic overlap dichotomy subsection, linked to that Lean name. This is preparatory for the periodic overlap route (#873); it does not yet prove the contraction that produces the identity or downstream gauge steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 336e658390391757565444cce7da2ea19018f297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->