### PR TITLE
refactor(Channel/Semigroup): use native Mathlib idempotent projection facts

### DIFF
--- a/TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean
@@ -25,20 +25,6 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-/-! ## Projection complement lemmas -/
-
-/-- `(1 - P) * P = 0` for an orthogonal projection `P`. -/
-theorem orthogonalProjection_complement_mul
-    {P : Mat} (hP : IsOrthogonalProjection P) :
-    (1 - P) * P = 0 := by
-  rw [sub_mul, one_mul, hP.2, sub_self]
-
-/-- `P * (1 - P) = 0` for an orthogonal projection `P`. -/
-theorem orthogonalProjection_mul_complement
-    {P : Mat} (hP : IsOrthogonalProjection P) :
-    P * (1 - P) = 0 := by
-  rw [mul_sub, mul_one, hP.2, sub_self]
-
 /-! ## (3) → (4): Invariant compression → block-upper-triangular Lindblad
 
 The key algebraic step: if `T_t` preserves the compressed algebra `P M_d P`,
@@ -54,8 +40,8 @@ theorem lindblad_block_of_generatorPreservesCompression
     ∀ j : Fin F.r, (1 - P) * F.L j * P = 0 := by
   have hPP : P * P = P := hP.2
   have hP_herm : Pᴴ = P := hP.1
-  have hQP := orthogonalProjection_complement_mul hP
-  have hPQ := orthogonalProjection_mul_complement hP
+  have hQP := IsIdempotentElem.one_sub_mul_self hP.2
+  have hPQ := IsIdempotentElem.mul_one_sub_self hP.2
   have hLP_compress : P * F.toLinearMap P * P = F.toLinearMap P := by
     have h1 := hgen 1; simp only [mul_one] at h1; rwa [hPP] at h1
   have hQ_LP : (1 - P) * F.toLinearMap P = 0 := by
@@ -107,7 +93,7 @@ theorem kappa_block_of_generatorPreservesCompression
     (hgen : GeneratorPreservesCompression F.toLinearMap P)
     (hblock : ∀ j : Fin F.r, (1 - P) * F.L j * P = 0) :
     (1 - P) * F.toGeneratorDecomp.κ * P = 0 := by
-  have hQP := orthogonalProjection_complement_mul hP
+  have hQP := IsIdempotentElem.one_sub_mul_self hP.2
   have hLP_compress : P * F.toLinearMap P * P = F.toLinearMap P := by
     have h1 := hgen 1; simp only [mul_one] at h1; rwa [hP.2] at h1
   have hQ_LP : (1 - P) * F.toLinearMap P = 0 := by
@@ -223,8 +209,8 @@ theorem generator_preserves_compression_of_blockUpperTriangular
   set κ : Mat := Complex.I • F.H + (1/2 : ℂ) • ∑ j : Fin F.r, (F.L j)ᴴ * F.L j
   have hPP : P * P = P := hP.2
   have hP_herm : Pᴴ = P := hP.1
-  have hQP := orthogonalProjection_complement_mul hP
-  have hPQ := orthogonalProjection_mul_complement hP
+  have hQP := IsIdempotentElem.one_sub_mul_self hP.2
+  have hPQ := IsIdempotentElem.mul_one_sub_self hP.2
   have hL_block_ct : ∀ j : Fin F.r, P * (F.L j)ᴴ * (1 - P) = 0 := by
     intro j
     have h := congrArg Matrix.conjTranspose (hL_block j)

--- a/TNLean/Channel/Semigroup/RelaxationConditions.lean
+++ b/TNLean/Channel/Semigroup/RelaxationConditions.lean
@@ -82,14 +82,8 @@ private theorem not_isNontrivialProjection_of_eq_smul_one
     have hc : c * c = c := by
       have h00 := congrFun (congrFun hIdem 0) 0
       simpa using h00
-    have hc01 : c = 0 ∨ c = 1 := by
-      have hfac : c * (c - 1) = 0 := by
-        calc
-          c * (c - 1) = c * c - c := by ring
-          _ = 0 := by rw [hc, sub_self]
-      rcases mul_eq_zero.mp hfac with hc0 | hc1
-      · exact Or.inl hc0
-      · exact Or.inr (sub_eq_zero.mp hc1)
+    have hc01 : c = 0 ∨ c = 1 :=
+      IsIdempotentElem.iff_eq_zero_or_one.mp hc
     rcases hc01 with hc0 | hc1
     · exact hP_nt.2.1 (by rw [hP, hc0, zero_smul])
     · exact hP_nt.2.2 (by rw [hP, hc1, one_smul])
@@ -98,7 +92,7 @@ private theorem lower_left_block_vanishes_on_adjoin
     {P : Mat} (hP : IsOrthogonalProjection P) (S : Set Mat)
     (hS : ∀ A : Mat, A ∈ S → (1 - P) * A * P = 0) :
     ∀ A : Mat, A ∈ Algebra.adjoin ℂ S → (1 - P) * A * P = 0 := by
-  have hQP := orthogonalProjection_complement_mul hP
+  have hQP := IsIdempotentElem.one_sub_mul_self hP.2
   have hblock_mul :
       ∀ A B : Mat,
         (1 - P) * A * P = 0 →
@@ -650,7 +644,7 @@ private theorem finrank_traceless_blockUT_add_D_le
     intro M; rfl
   have hφ_one : φ (1 : Mat) = 0 := by
     rw [hφ_apply, Matrix.one_mul]
-    exact orthogonalProjection_complement_mul hP.1
+    exact IsIdempotentElem.one_sub_mul_self hP.1.2
   have h_sup : K_φ ⊔ K_τ = ⊤ := by
     simpa [φ, τ, K_φ, K_τ] using
       ker_sup_traceless_eq_top_of_one_mem_ker φ hφ_one hD_ne
@@ -832,7 +826,7 @@ private theorem exists_traceless_blockUT_lindblad_form
       simp only [LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
       rw [hL'_def]
       simp only [Matrix.mul_add, Matrix.add_mul, smul_mul_assoc, mul_smul_comm]
-      rw [Matrix.one_mul, orthogonalProjection_complement_mul hP.1, smul_zero, add_zero]
+      rw [Matrix.one_mul, IsIdempotentElem.one_sub_mul_self hP.1.2, smul_zero, add_zero]
       rw [← Matrix.mul_assoc]
       exact hBlock j
     · -- Traceless

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1215,6 +1215,36 @@ Thus `MPSTensor.proj_mul_projCompl`, `MPSTensor.projCompl_mul_proj`, and
 `MPSTensor.projCompl_mul_projCompl` now only translate
 `IsOrthogonalProjection P` into the corresponding general idempotent fact.
 
+### Semigroup projection-complement cleanup, 2026-06-19
+
+The reducible-QDS generator-compression file contained two public
+projection-complement theorems:
+
+- `orthogonalProjection_complement_mul`
+- `orthogonalProjection_mul_complement`
+
+They were exact matrix-projection specializations of Mathlib's general
+idempotent identities:
+
+- `IsIdempotentElem.one_sub_mul_self`
+- `IsIdempotentElem.mul_one_sub_self`
+
+No blueprint entry or non-Archive Lean declaration outside the semigroup proof
+cluster referred to the local theorem names.  They have therefore been removed,
+and the generator-compression and relaxation-condition proofs now call the
+Mathlib idempotent-complement theorems directly.
+
+The same pass also replaced the private scalar calculation in
+`not_isNontrivialProjection_of_eq_smul_one`: the proof now uses
+`IsIdempotentElem.iff_eq_zero_or_one` instead of factoring `c * (c - 1)`.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression \
+  TNLean.Channel.Semigroup.RelaxationConditions -q --log-level=info
+```
+
 ### Trace-pairing extensionality, 2026-06-19
 
 Mathlib 4.31 has equality-form trace-pairing extensionality lemmas:
@@ -1283,6 +1313,10 @@ pass-throughs:
   specialization of `IsIdempotentElem.iff_eq_zero_or_one`.
 - `LinearMap.comp_idem_of_comm_idem`.  This was the endomorphism-composition
   specialization of `IsIdempotentElem.mul_of_commute`.
+- `orthogonalProjection_complement_mul` and
+  `orthogonalProjection_mul_complement`.  These were the matrix-projection
+  specializations of `IsIdempotentElem.one_sub_mul_self` and
+  `IsIdempotentElem.mul_one_sub_self`.
 
 ## Verification performed
 
@@ -1362,6 +1396,8 @@ lake build TNLean.Algebra.TracePairing TNLean.MPS.Chain.TensorEquality \
   TNLean.PEPS.CycleMPSWordTransport TNLean.PEPS.CycleMPSChainArc \
   TNLean.PEPS.CycleMPSOverlapInsertion TNLean.PEPS.CycleMPSChainOverlapWindow \
   TNLean.PEPS.CycleMPSChainOverlapInsertion -q --log-level=info
+lake build TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression \
+  TNLean.Channel.Semigroup.RelaxationConditions -q --log-level=info
 ```
 
 The final root build also succeeds:


### PR DESCRIPTION
### Motivation

- `TNLean/Channel/Semigroup` contained two local lemmas for idempotent projection
  complements — the identities $(1-P)P = 0$ and $P(1-P) = 0$ for an idempotent
  element $P$ — whose statements are exact instances of the Mathlib 4.31 lemmas
  `IsIdempotentElem.one_sub_mul_self` and `IsIdempotentElem.mul_one_sub_self`.
- A private scalar step in `RelaxationConditions` factored $c(c-1) = 0$ for a
  scalar idempotent, duplicating `IsIdempotentElem.iff_eq_zero_or_one` from
  Mathlib 4.31.
- Removing these aliases reduces maintenance burden and aligns with the Mathlib
  4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`).

### Description

- Removed two semigroup projection-complement aliases from
  `TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean` and
  `TNLean/Channel/Semigroup/RelaxationConditions.lean`; their statements are
  subsumed by `IsIdempotentElem.one_sub_mul_self` and
  `IsIdempotentElem.mul_one_sub_self`.
- Updated generator-compression and relaxation-condition proofs to call the
  Mathlib idempotent facts directly via the local idempotency hypothesis `hP.2`.
- Replaced the private scalar idempotent factorization in
  `not_isNontrivialProjection_of_eq_smul_one` with
  `IsIdempotentElem.iff_eq_zero_or_one`.
- Recorded this cleanup in the Mathlib 4.31 replacement audit and added a
  focused build check for the two semigroup modules.
- No theorem statements or mathematical conclusions were changed.

### Testing

- `lake build TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression TNLean.Channel.Semigroup.RelaxationConditions -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build -q --log-level=info`
- Full build reports only pre-existing style warnings and the known periodic-overlap `sorry` warning in `TNLean/MPS/Periodic/Overlap/Case3.lean`.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavioral changes; risk is limited to Lean proof correctness, covered by targeted builds.
>
> **Overview**
> Removes two local semigroup lemmas that duplicated Mathlib's idempotent-complement identities `(1-P)P = 0` and `P(1-P) = 0`, and rewrites **generator-compression** and **relaxation-conditions** proofs to cite `IsIdempotentElem.one_sub_mul_self` and `IsIdempotentElem.mul_one_sub_self` from `hP.2` instead.
>
> In **RelaxationConditions**, the private scalar step in `not_isNontrivialProjection_of_eq_smul_one` now uses `IsIdempotentElem.iff_eq_zero_or_one` rather than factoring `c*(c-1)`.
>
> The Mathlib 4.31 replacement audit documents this cleanup and adds a focused build check for the two semigroup modules.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee1eb32d5b51f322a7e6faa13e98af10ad75a44c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>