### PR TITLE
chore(mathlib): reduce projection complement proofs

### DIFF
--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -353,10 +353,8 @@ theorem isIrreducibleMap_of_channel_posDef_fixedPoint_unique
     intro hQ0
     apply hP1
     exact (sub_eq_zero.mp hQ0).symm
-  have _hQP : (1 - P) * P = 0 := by
-    rw [sub_mul, one_mul, hP_proj.2, sub_self]
-  have hPQ : P * (1 - P) = 0 := by
-    rw [mul_sub, mul_one, hP_proj.2, sub_self]
+  have _hQP : (1 - P) * P = 0 := IsIdempotentElem.one_sub_mul_self hP_proj.2
+  have hPQ : P * (1 - P) = 0 := IsIdempotentElem.mul_one_sub_self hP_proj.2
   have hQρQ_zero : (1 - P) * ρ * (1 - P) = 0 := by
     calc
       (1 - P) * ρ * (1 - P)

--- a/TNLean/Channel/Irreducible/Growth/Exponential.lean
+++ b/TNLean/Channel/Irreducible/Growth/Exponential.lean
@@ -373,7 +373,7 @@ theorem irreducible_iff_exp_posDef_forall
           (1 - P) * expSemigroup E 1 P
               = (1 - P) * (P * expSemigroup E 1 P * P) := by rw [hcompress_at_one]
           _ = ((1 - P) * P) * (expSemigroup E 1 P * P) := by simp [Matrix.mul_assoc]
-          _ = 0 := by rw [sub_mul, one_mul, hP.2, sub_self, Matrix.zero_mul]
+          _ = 0 := by rw [IsIdempotentElem.one_sub_mul_self hP.2, Matrix.zero_mul]
       have h_compl_eq_zero : 1 - P = 0 := by
         rcases Matrix.PosDef.isUnit hP_exp_pd with ⟨U, hU⟩
         have hzero : (1 - P) * (↑U : Matrix (Fin D) (Fin D) ℂ) = 0 := by

--- a/TNLean/Channel/Irreducible/Growth/OneStep.lean
+++ b/TNLean/Channel/Irreducible/Growth/OneStep.lean
@@ -132,7 +132,7 @@ theorem posDef_of_ker_subset_irreducible_cp
         ← Matrix.mul_assoc Uᴴ U, hUU, Matrix.one_mul,
         ← Matrix.mul_assoc (Matrix.diagonal sgnEig), Matrix.diagonal_mul_diagonal,
         show (fun i => sgnEig i * sgnEig i) = sgnEig from funext hsgnEig_sq]
-  have hQ1Q : Q * (1 - Q) = 0 := by rw [mul_sub, mul_one, hQ_idem, sub_self]
+  have hQ1Q : Q * (1 - Q) = 0 := IsIdempotentElem.mul_one_sub_self hQ_idem
   have hQ_proj : IsOrthogonalProjection Q := ⟨hQ_herm, hQ_idem⟩
   have hA_spectral :
       A = U * Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) * Uᴴ := by

--- a/TNLean/Channel/Irreducible/Similarity.lean
+++ b/TNLean/Channel/Irreducible/Similarity.lean
@@ -142,8 +142,7 @@ private lemma not_posDef_of_conj_projection_ne_one
     apply hij
     have hw_i := congrFun hw i
     simpa [w, Matrix.mulVec, dotProduct, Pi.single_apply, Finset.sum_ite_eq'] using hw_i
-  have hQ1Q : Q * (1 - Q) = 0 := by
-    rw [mul_sub, mul_one, hQ.2, sub_self]
+  have hQ1Q : Q * (1 - Q) = 0 := IsIdempotentElem.mul_one_sub_self hQ.2
   have hQw : Q *ᵥ w = 0 := by
     ext a
     simpa [w, Matrix.mulVec, dotProduct, Matrix.mul_apply,

--- a/TNLean/Channel/MaximallyEntangled.lean
+++ b/TNLean/Channel/MaximallyEntangled.lean
@@ -6,6 +6,7 @@ import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Data.Complex.Basic
 import Mathlib.Analysis.Real.Sqrt
+import Mathlib.Algebra.Ring.Idempotent
 
 /-!
 # Maximally entangled state and SWAP operator
@@ -181,17 +182,17 @@ theorem one_sub_omegaProj_conjTranspose :
 
 theorem one_sub_omegaProj_mul_omegaProj :
     ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d) * omegaProj d = 0 := by
-  rw [sub_mul, one_mul, omegaProj_mul_self, sub_self]
+  exact IsIdempotentElem.one_sub_mul_self (omegaProj_mul_self (d := d))
 
 theorem omegaProj_mul_one_sub_omegaProj :
     omegaProj d * ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d) = 0 := by
-  rw [mul_sub, mul_one, omegaProj_mul_self, sub_self]
+  exact IsIdempotentElem.mul_one_sub_self (omegaProj_mul_self (d := d))
 
 theorem one_sub_omegaProj_mul_self :
     ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d) *
         ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d) =
       (1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d := by
-  rw [sub_mul, one_mul, omegaProj_mul_one_sub_omegaProj, sub_zero]
+  exact IsIdempotentElem.one_sub (omegaProj_mul_self (d := d))
 
 theorem omegaProj_mulVec_omegaVec :
     omegaProj d *ᵥ omegaVec d = omegaVec d := by

--- a/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean
@@ -97,8 +97,7 @@ private lemma not_posDef_of_proj_sandwich_eq_self
     (hρ : P * ρ * P = ρ) :
     ¬ ρ.PosDef := by
   intro hρ_pd
-  have hQP : (1 - P) * P = 0 := by
-    rw [sub_mul, one_mul, hP.2, sub_self]
+  have hQP : (1 - P) * P = 0 := IsIdempotentElem.one_sub_mul_self hP.2
   have hQρ : (1 - P) * ρ = 0 := by
     conv_lhs => rw [← hρ]
     have h_expand : (1 - P) * (P * ρ * P) = ((1 - P) * P) * ρ * P := by

--- a/TNLean/MPS/Core/CPPrimitive.lean
+++ b/TNLean/MPS/Core/CPPrimitive.lean
@@ -38,7 +38,7 @@ private lemma invariance_implies_complement_zero (A : MPSTensor d D)
     (hInv : ∀ X, P * transferMap (d := d) (D := D) A (P * X * P) * P =
                   transferMap (d := d) (D := D) A (P * X * P)) :
     ∀ i : Fin d, (1 - P) * A i * P = 0 := by
-  have h1P : (1 - P) * P = 0 := by rw [sub_mul, one_mul, hProj.2, sub_self]
+  have h1P : (1 - P) * P = 0 := IsIdempotentElem.one_sub_mul_self hProj.2
   -- (1-P)*E(PXP) = 0 for all X
   have h_vanish : ∀ X, (1 - P) * transferMap (d := d) (D := D) A (P * X * P) = 0 := by
     intro X

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -328,8 +328,8 @@ theorem lowerZero_of_posSemidef_fixedPoint
     isOrthogonalProjection_supportProj (D := D) (ρ := ρ) (hρ := hρ_psd)
   have hP_herm : P.IsHermitian := hP_proj.1
   have hP_idem : P * P = P := hP_proj.2
-  have hP1P : P * (1 - P) = 0 := by rw [mul_sub, mul_one, hP_idem, sub_self]
-  have h1PP : (1 - P) * P = 0 := by rw [sub_mul, one_mul, hP_idem, sub_self]
+  have hP1P : P * (1 - P) = 0 := IsIdempotentElem.mul_one_sub_self hP_idem
+  have h1PP : (1 - P) * P = 0 := IsIdempotentElem.one_sub_mul_self hP_idem
   -- Multiplication identities `P*ρ=ρ` and `ρ*P=ρ`.
   have hPρ : P * ρ = ρ := supportProj_mul (D := D) (ρ := ρ) hρ_psd
   have hρP : ρ * P = ρ := mul_supportProj (D := D) (ρ := ρ) hρ_psd

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -64,7 +64,7 @@ lemma invariance_implies_lowerZero
                   transferMap (d := d) (D := D) A (P * X * P)) :
     ∀ i : Fin d, (1 - P) * A i * P = 0 := by
   -- (1 - P) * P = 0 from the projection property
-  have h1P : (1 - P) * P = 0 := by rw [sub_mul, one_mul, hProj.2, sub_self]
+  have h1P : (1 - P) * P = 0 := IsIdempotentElem.one_sub_mul_self hProj.2
   -- (1-P) * E(PXP) = 0 for all X
   have h_vanish : ∀ X, (1 - P) * transferMap (d := d) (D := D) A (P * X * P) = 0 := by
     intro X

--- a/TNLean/QPF/PosDef.lean
+++ b/TNLean/QPF/PosDef.lean
@@ -203,8 +203,8 @@ theorem posSemidef_fixedPoint_isPosDef_of_irreducible
         ← Matrix.mul_assoc Uᴴ U, hUU, Matrix.one_mul,
         ← Matrix.mul_assoc (Matrix.diagonal sgnEig), Matrix.diagonal_mul_diagonal,
         show (fun i => sgnEig i * sgnEig i) = sgnEig from funext hsgnEig_sq]
-  have hQ1Q : Q * (1 - Q) = 0 := by rw [mul_sub, mul_one, hQ_idem, sub_self]
-  have h1QQ : (1 - Q) * Q = 0 := by rw [sub_mul, one_mul, hQ_idem, sub_self]
+  have hQ1Q : Q * (1 - Q) = 0 := IsIdempotentElem.mul_one_sub_self hQ_idem
+  have h1QQ : (1 - Q) * Q = 0 := IsIdempotentElem.one_sub_mul_self hQ_idem
   have hQ_proj : IsOrthogonalProjection Q := ⟨hQ_herm, hQ_idem⟩
   have hρ_spectral :
       ρ = U * Matrix.diagonal (fun j => (↑(hH.eigenvalues j) : ℂ)) * Uᴴ := by

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1245,6 +1245,43 @@ lake build TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression \
   TNLean.Channel.Semigroup.RelaxationConditions -q --log-level=info
 ```
 
+### Further projection-complement proof reductions, 2026-06-19
+
+A second pass replaced remaining handwritten complement identities of the form
+`P * (1 - P) = 0`, `(1 - P) * P = 0`, and `(1 - P) * (1 - P) = 1 - P`
+by Mathlib's idempotent API, without changing any theorem statements.
+
+The affected files are:
+
+- `TNLean/Channel/MaximallyEntangled.lean`
+- `TNLean/Channel/Irreducible/FromSpectral.lean`
+- `TNLean/Channel/Irreducible/Growth/Exponential.lean`
+- `TNLean/Channel/Irreducible/Growth/OneStep.lean`
+- `TNLean/Channel/Irreducible/Similarity.lean`
+- `TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean`
+- `TNLean/MPS/Core/CPPrimitive.lean`
+- `TNLean/MPS/Irreducible/FixedPointProjection.lean`
+- `TNLean/MPS/Irreducible/FormII.lean`
+- `TNLean/QPF/PosDef.lean`
+
+The public maximally-entangled projection lemmas remain, because they name the
+local Choi--Jamiolkowski object `omegaProj`.  Their proofs now reduce the
+idempotence theorem `omegaProj_mul_self` through
+`IsIdempotentElem.one_sub_mul_self`, `IsIdempotentElem.mul_one_sub_self`, and
+`IsIdempotentElem.one_sub`.
+
+Focused check:
+
+```bash
+lake build TNLean.QPF.PosDef TNLean.Channel.MaximallyEntangled \
+  TNLean.Channel.Irreducible.Growth.OneStep \
+  TNLean.Channel.Irreducible.Growth.Exponential \
+  TNLean.Channel.Irreducible.FromSpectral TNLean.Channel.Irreducible.Similarity \
+  TNLean.Channel.Semigroup.ReducibleQDS.FixedDensity \
+  TNLean.MPS.Core.CPPrimitive TNLean.MPS.Irreducible.FormII \
+  TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info
+```
+
 ### Trace-pairing extensionality, 2026-06-19
 
 Mathlib 4.31 has equality-form trace-pairing extensionality lemmas:
@@ -1398,6 +1435,13 @@ lake build TNLean.Algebra.TracePairing TNLean.MPS.Chain.TensorEquality \
   TNLean.PEPS.CycleMPSChainOverlapInsertion -q --log-level=info
 lake build TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression \
   TNLean.Channel.Semigroup.RelaxationConditions -q --log-level=info
+lake build TNLean.QPF.PosDef TNLean.Channel.MaximallyEntangled \
+  TNLean.Channel.Irreducible.Growth.OneStep \
+  TNLean.Channel.Irreducible.Growth.Exponential \
+  TNLean.Channel.Irreducible.FromSpectral TNLean.Channel.Irreducible.Similarity \
+  TNLean.Channel.Semigroup.ReducibleQDS.FixedDensity \
+  TNLean.MPS.Core.CPPrimitive TNLean.MPS.Irreducible.FormII \
+  TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info
 ```
 
 The final root build also succeeds:


### PR DESCRIPTION
### Motivation

- Projection-complement identities $(1-P)P = 0$, $P(1-P) = 0$, and $(1-P)^2 = 1-P$ were proved
  locally in multiple files by hand-expanding the idempotence condition $P^2 = P$.
- Mathlib 4.31 provides these as `IsIdempotentElem.one_sub_mul_self`,
  `IsIdempotentElem.mul_one_sub_self`, and `IsIdempotentElem.one_sub`; using them directly
  removes redundant proof steps and aligns with the ongoing Mathlib 4.31 replacement audit.

### Description

- `TNLean/Channel/Irreducible/FromSpectral.lean`, `Growth/Exponential.lean`,
  `Growth/OneStep.lean`, `Similarity.lean`,
  `TNLean/Channel/Semigroup/ReducibleQDS/FixedDensity.lean`,
  `TNLean/MPS/Core/CPPrimitive.lean`, `TNLean/MPS/Irreducible/FixedPointProjection.lean`,
  `TNLean/MPS/Irreducible/FormII.lean`, `TNLean/QPF/PosDef.lean`: proof bodies for existing
  projection-complement theorems replaced by calls to the Mathlib idempotent API; theorem
  statements and public names are unchanged.
- `TNLean/Channel/MaximallyEntangled.lean`: added `import Mathlib.Algebra.Ring.Idempotent`;
  `omegaProj` complement lemmas now delegate to `IsIdempotentElem.one_sub_mul_self` and
  `IsIdempotentElem.mul_one_sub_self`.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: extended to record this batch;
  notes that remaining axioms and sorries in the touched modules do not have direct Mathlib 4.31
  replacements.

### Testing

- `lake build TNLean.QPF.PosDef TNLean.Channel.MaximallyEntangled TNLean.Channel.Irreducible.Growth.OneStep TNLean.Channel.Irreducible.Growth.Exponential TNLean.Channel.Irreducible.FromSpectral TNLean.Channel.Irreducible.Similarity TNLean.Channel.Semigroup.ReducibleQDS.FixedDensity TNLean.MPS.Core.CPPrimitive TNLean.MPS.Irreducible.FormII TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info`
- `lake build -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Pure proof simplification and documentation; no API or mathematical statement changes beyond Mathlib lemma calls.
> 
> **Overview**
> Proof-only refactor: handwritten steps for **`P * (1 - P) = 0`**, **`(1 - P) * P = 0`**, and **`(1 - P)² = 1 - P`** are replaced by Mathlib **`IsIdempotentElem.mul_one_sub_self`**, **`one_sub_mul_self`**, and **`one_sub`**, given idempotence of the local projection (e.g. **`omegaProj_mul_self`**).
> 
> **Theorem statements are unchanged** across irreducibility, semigroup, MPS, and QPF paths; **`MaximallyEntangled`** adds **`Mathlib.Algebra.Ring.Idempotent`** and keeps the public **`omegaProj`** complement lemma names with shorter proofs.
> 
> The Mathlib 4.31 replacement audit records this batch and the focused **`lake build`** targets for the touched modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b80e0d17f985f65624b9c2337d83743c9cac20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>