### PR TITLE
refactor(Algebra): remove projection pass-through lemmas

### DIFF
--- a/TNLean/Algebra/ProjectionTriangularTrace.lean
+++ b/TNLean/Algebra/ProjectionTriangularTrace.lean
@@ -38,25 +38,6 @@ abbrev Q (P : Matrix (Fin D) (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ :=
 noncomputable def diagPart (A : MPSTensor d D) (P : Matrix (Fin D) (Fin D) ℂ) : MPSTensor d D :=
   fun i => P * A i * P + (1 - P) * A i * (1 - P)
 
-section Auxiliary
-
-variable (P : Matrix (Fin D) (Fin D) ℂ)
-
-lemma proj_add_projCompl : P + (1 - P) = (1 : Matrix (Fin D) (Fin D) ℂ) := by
-  simp
-
-lemma proj_mul_projCompl (hP : IsOrthogonalProjection P) : P * (1 - P) = 0 := by
-  exact IsIdempotentElem.mul_one_sub_self hP.2
-
-lemma projCompl_mul_proj (hP : IsOrthogonalProjection P) : (1 - P) * P = 0 := by
-  exact IsIdempotentElem.one_sub_mul_self hP.2
-
-lemma projCompl_mul_projCompl (hP : IsOrthogonalProjection P) : (1 - P) * (1 - P) = (1 - P) := by
-  exact IsIdempotentElem.one_sub hP.2
-
-end Auxiliary
-
-
 /-- If each letter satisfies `(1-P) * A i * P = 0`, then every word evaluation satisfies
 `(1-P) * evalWord A w * P = 0`.
 
@@ -70,10 +51,10 @@ lemma lowerZero_evalWord (A : MPSTensor d D) (P : Matrix (Fin D) (Fin D) ℂ)
   induction w with
   | nil =>
       -- `(1-P) * 1 * P = (1-P)P = 0`.
-      simpa [evalWord] using projCompl_mul_proj (P := P) hP
+      simpa [evalWord] using IsIdempotentElem.one_sub_mul_self hP.2
   | cons i w ih =>
       have hsum : P + (1 - P) = (1 : Matrix (Fin D) (Fin D) ℂ) :=
-        proj_add_projCompl (P := P)
+        by simp
       calc
         (1 - P) * evalWord A (i :: w) * P
             = (1 - P) * A i * evalWord A w * P := by
@@ -116,16 +97,16 @@ lemma evalWord_diagPart_eq (A : MPSTensor d D) (P : Matrix (Fin D) (Fin D) ℂ)
   induction w with
   | nil =>
       have hPP : P * P = P := hP.2
-      have hQQ : (1 - P) * (1 - P) = (1 - P) := projCompl_mul_projCompl (P := P) hP
-      have hsum : P + (1 - P) = (1 : Matrix (Fin D) (Fin D) ℂ) := proj_add_projCompl (P := P)
+      have hQQ : (1 - P) * (1 - P) = (1 - P) := IsIdempotentElem.one_sub hP.2
+      have hsum : P + (1 - P) = (1 : Matrix (Fin D) (Fin D) ℂ) := by simp
       -- `evalWord` is `1` on the empty word.
       simp [evalWord, hPP, hQQ, hsum]
   | cons i w ih =>
       have hPP : P * P = P := hP.2
-      have hP1P : P * (1 - P) = 0 := proj_mul_projCompl (P := P) hP
-      have h1PP : (1 - P) * P = 0 := projCompl_mul_proj (P := P) hP
-      have hQQ : (1 - P) * (1 - P) = (1 - P) := projCompl_mul_projCompl (P := P) hP
-      have hsum : P + (1 - P) = (1 : Matrix (Fin D) (Fin D) ℂ) := proj_add_projCompl (P := P)
+      have hP1P : P * (1 - P) = 0 := IsIdempotentElem.mul_one_sub_self hP.2
+      have h1PP : (1 - P) * P = 0 := IsIdempotentElem.one_sub_mul_self hP.2
+      have hQQ : (1 - P) * (1 - P) = (1 - P) := IsIdempotentElem.one_sub hP.2
+      have hsum : P + (1 - P) = (1 : Matrix (Fin D) (Fin D) ℂ) := by simp
       have hLowerWord : (1 - P) * evalWord A w * P = 0 :=
         lowerZero_evalWord (d := d) (D := D) A P hP hLower w
       -- First simplify the `diagPart` product: cross terms vanish because `P*(1-P)=0`
@@ -236,8 +217,8 @@ lemma trace_eq_trace_diag_of_proj (P : Matrix (Fin D) (Fin D) ℂ)
     (hP : IsOrthogonalProjection P) (M : Matrix (Fin D) (Fin D) ℂ) :
     Matrix.trace M = Matrix.trace (P * M * P) + Matrix.trace ((1 - P) * M * (1 - P)) := by
   classical
-  have hP1P : P * (1 - P) = 0 := proj_mul_projCompl (P := P) hP
-  have h1PP : (1 - P) * P = 0 := projCompl_mul_proj (P := P) hP
+  have hP1P : P * (1 - P) = 0 := IsIdempotentElem.mul_one_sub_self hP.2
+  have h1PP : (1 - P) * P = 0 := IsIdempotentElem.one_sub_mul_self hP.2
   have htrPQ : Matrix.trace (P * M * (1 - P)) = 0 := by
     calc
       Matrix.trace (P * M * (1 - P))
@@ -258,7 +239,7 @@ lemma trace_eq_trace_diag_of_proj (P : Matrix (Fin D) (Fin D) ℂ)
   calc
     Matrix.trace M
         = Matrix.trace ((P + (1 - P)) * M * (P + (1 - P))) := by
-            simp [proj_add_projCompl (P := P)]
+            simp
     _ = Matrix.trace (P * M * P + P * M * (1 - P) + (1 - P) * M * P + (1 - P) * M * (1 - P)) := by
             have hExpand : (P + (1 - P)) * M * (P + (1 - P)) =
                 P * M * P + P * M * (1 - P) + (1 - P) * M * P + (1 - P) * M * (1 - P) := by

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1202,18 +1202,23 @@ uses the Mathlib theorem directly.
 
 ### Projection-complement idempotent algebra, 2026-06-19
 
-The projection-triangular trace file keeps its local projection-complement
-lemma names because they are part of the internal proof script, but their
-handwritten matrix-ring proofs have been replaced by Mathlib's general
-idempotent-complement API:
+The projection-triangular trace file originally carried local
+projection-complement lemmas whose statements were exact specializations of
+Mathlib's general idempotent-complement API:
 
 - `IsIdempotentElem.mul_one_sub_self`
 - `IsIdempotentElem.one_sub_mul_self`
 - `IsIdempotentElem.one_sub`
 
-Thus `MPSTensor.proj_mul_projCompl`, `MPSTensor.projCompl_mul_proj`, and
-`MPSTensor.projCompl_mul_projCompl` now only translate
-`IsOrthogonalProjection P` into the corresponding general idempotent fact.
+The pass-through names have now been removed:
+
+- `MPSTensor.proj_add_projCompl`
+- `MPSTensor.proj_mul_projCompl`
+- `MPSTensor.projCompl_mul_proj`
+- `MPSTensor.projCompl_mul_projCompl`
+
+The internal projection-triangular trace proofs call `simp` or the Mathlib
+idempotent-complement theorems directly.
 
 ### Semigroup projection-complement cleanup, 2026-06-19
 
@@ -1280,6 +1285,27 @@ lake build TNLean.QPF.PosDef TNLean.Channel.MaximallyEntangled \
   TNLean.Channel.Semigroup.ReducibleQDS.FixedDensity \
   TNLean.MPS.Core.CPPrimitive TNLean.MPS.Irreducible.FormII \
   TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info
+```
+
+### Projection-triangular pass-through removal, 2026-06-19
+
+The internal `ProjectionTriangularTrace` proof no longer introduces local
+abbreviating lemmas for `P + (1 - P) = 1` or the three idempotent-complement
+identities.  The proof now uses `simp`,
+`IsIdempotentElem.mul_one_sub_self`,
+`IsIdempotentElem.one_sub_mul_self`, and `IsIdempotentElem.one_sub` at each
+use site.  This removes a small pass-through layer without changing the main
+statements:
+
+- `MPSTensor.lowerZero_evalWord`
+- `MPSTensor.evalWord_diagPart_eq`
+- `MPSTensor.trace_eq_trace_diag_of_proj`
+- `MPSTensor.sameMPV_diagPart_of_lowerZero`
+
+Focused check:
+
+```bash
+lake build TNLean.Algebra.ProjectionTriangularTrace -q --log-level=info
 ```
 
 ### Trace-pairing extensionality, 2026-06-19


### PR DESCRIPTION
### Motivation

- Four local `proj_*` lemmas in the `Auxiliary` block of `ProjectionTriangularTrace` restated facts already present in Mathlib (`P + (1 − P) = 1`, complement idempotent identities), adding indirection without mathematical content.
- Removing them reduces the internal proof footprint and eliminates redundancy with the Mathlib 4.31 idempotent API already used elsewhere.

### Description

- `TNLean/Algebra/ProjectionTriangularTrace.lean`: removed four local wrapper lemmas (`proj_*`) from the internal `Auxiliary` block. The proofs of `lowerZero_evalWord`, `evalWord_diagPart_eq`, and `trace_eq_trace_diag_of_proj` now call `IsIdempotentElem.mul_one_sub_self`, `IsIdempotentElem.one_sub_mul_self`, `IsIdempotentElem.one_sub`, and `simp` directly. All public declarations — including `sameMPV_diagPart_of_lowerZero` — are unchanged.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: updated to record the pass-through-layer removal.

### Testing

- `lake build TNLean.Algebra.ProjectionTriangularTrace -q --log-level=info`
- `lake build -q --log-level=info`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
<!-- No linked issue found; please link one manually using `Addresses #N` in the PR body. -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or theorem statement changes; behavior rests on the same Mathlib idempotent lemmas already used elsewhere in the Mathlib 4.31 cleanup.
> 
> **Overview**
> Removes the local **Auxiliary** block in `ProjectionTriangularTrace` that only restated `P + (1 - P) = 1` and the three complement idempotent identities (`proj_*` lemmas). Those steps now call **`simp`** or Mathlib's **`IsIdempotentElem.mul_one_sub_self`**, **`one_sub_mul_self`**, and **`one_sub`** directly inside **`lowerZero_evalWord`**, **`evalWord_diagPart_eq`**, and **`trace_eq_trace_diag_of_proj`**.
> 
> **Public results are unchanged** (including **`sameMPV_diagPart_of_lowerZero`**). The Mathlib 4.31 replacement audit documents the pass-through removal and the focused **`ProjectionTriangularTrace`** build check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b25c9032a0516bd8c96bb845d673259bf0399f71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>