### PR TITLE
feat(Algebra): normalize periodic sector scalars

### DIFF
--- a/TNLean/Algebra/PiTensorProductPhase.lean
+++ b/TNLean/Algebra/PiTensorProductPhase.lean
@@ -137,8 +137,10 @@ to have product one.
 
 This is the product-one form used to pass from a uniform product-tensor
 proportionality to sector scalars satisfying \(\prod_v \kappa_v=1\) and
-\(A_v^i=(\kappa_v\xi)B_v^i\). It starts from the uniform product-tensor
-identity, as in
+\(A_v^i=(\kappa_v\xi)B_v^i\).
+
+**Scope restriction (arXiv:1708.00029, Appendix A, lines 1068--1080):** this
+theorem starts from the uniform product-tensor identity, as in
 `exists_kappa_of_piTensorProduct_eq_smul`; the contraction producing that
 identity from the \(F_u,\Omega_u\) maps is recorded separately in
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/

--- a/TNLean/Algebra/PiTensorProductPhase.lean
+++ b/TNLean/Algebra/PiTensorProductPhase.lean
@@ -135,8 +135,10 @@ translation step has made the scalar \(z\) independent of the sector label,
 choosing a common root \(\xi\) with \(\xi^m=z\) normalizes the sector scalars
 to have product one.
 
-This is the product-one form used in eq:thetaACprop and eq:prodkappaprop. It
-starts from the uniform product-tensor identity, as in
+This is the product-one form used to pass from a uniform product-tensor
+proportionality to sector scalars satisfying \(\prod_v \kappa_v=1\) and
+\(A_v^i=(\kappa_v\xi)B_v^i\). It starts from the uniform product-tensor
+identity, as in
 `exists_kappa_of_piTensorProduct_eq_smul`; the contraction producing that
 identity from the \(F_u,\Omega_u\) maps is recorded separately in
 `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/

--- a/TNLean/Algebra/PiTensorProductPhase.lean
+++ b/TNLean/Algebra/PiTensorProductPhase.lean
@@ -130,6 +130,58 @@ theorem exists_kappa_of_piTensorProduct_eq_smul
     _ = ((κ v • B v i) a b) * P := by
       simp [Matrix.smul_apply]
 
+/-- arXiv:1708.00029, Appendix A, lines 1072--1080: after the preceding
+translation step has made the scalar \(z\) independent of the sector label,
+choosing a common root \(\xi\) with \(\xi^m=z\) normalizes the sector scalars
+to have product one.
+
+This is the product-one form used in eq:thetaACprop and eq:prodkappaprop. It
+starts from the uniform product-tensor identity, as in
+`exists_kappa_of_piTensorProduct_eq_smul`; the contraction producing that
+identity from the \(F_u,\Omega_u\) maps is recorded separately in
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
+theorem exists_kappa_product_one_of_piTensorProduct_eq_root_smul
+    {d m : ℕ} [NeZero m]
+    {row col : Fin m → Type*}
+    (A B : (v : Fin m) → Fin d → Matrix (row v) (col v) ℂ)
+    (z ξ : ℂ) (hz : z ≠ 0) (hξ_pow : ξ ^ m = z)
+    (ref : Fin m → Fin d) (r : (v : Fin m) → row v) (c : (v : Fin m) → col v)
+    (hB_ref : ∀ v : Fin m, B v (ref v) (r v) (c v) ≠ 0)
+    (hresult :
+      ∀ σ : Fin m → Fin d,
+        (⨂ₜ[ℂ] v : Fin m, A v (σ v)) =
+          z • (⨂ₜ[ℂ] v : Fin m, B v (σ v))) :
+    ∃ κ : Fin m → ℂ,
+      (∏ v : Fin m, κ v = 1) ∧
+      ∀ (v : Fin m) (i : Fin d), A v i = (κ v * ξ) • B v i := by
+  classical
+  obtain ⟨κ₀, hκ₀_prod, hκ₀⟩ :=
+    exists_kappa_of_piTensorProduct_eq_smul
+      A B z hz ref r c hB_ref hresult
+  have hξ_ne : ξ ≠ 0 := by
+    intro hξ_zero
+    have hpow_zero : ξ ^ m = 0 := by
+      rw [hξ_zero]
+      exact zero_pow (NeZero.ne m)
+    exact hz (by rw [← hξ_pow, hpow_zero])
+  let κ : Fin m → ℂ := fun v => κ₀ v / ξ
+  refine ⟨κ, ?_, ?_⟩
+  · calc
+      ∏ v : Fin m, κ v =
+          (∏ v : Fin m, κ₀ v) / (∏ _v : Fin m, ξ) := by
+        simp [κ, Finset.prod_div_distrib]
+      _ = z / ξ ^ m := by
+        simp [hκ₀_prod]
+      _ = 1 := by
+        rw [hξ_pow, div_self hz]
+  · intro v i
+    calc
+      A v i = κ₀ v • B v i := hκ₀ v i
+      _ = (κ v * ξ) • B v i := by
+        have hκ_mul : κ v * ξ = κ₀ v := by
+          simp [κ, hξ_ne]
+        rw [hκ_mul]
+
 end PiTensorProductPhase
 
 end TNLean.Algebra

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -576,9 +576,12 @@ The finite-cycle phase choice in lines 1093--1102 is now isolated as
 `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_of_prod_eq_one`; the
 offset-indexed form needed for the sector match `(u, u + q)` is
 `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`.
+The product-one scalar extraction in lines 1072--1080 is isolated as
+`PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul`.
 Thus the remaining mathematical input is the `m`-factor cyclic contraction
-that produces the sector phases κ_v with `∏ v, κ_v = 1` and `‖κ_v‖ = 1`,
-after which the phase-coboundary lemma performs the κ/θ/φ telescoping. See
+that produces the uniform product-tensor identity and the unit-modulus
+normalization of the resulting sector phases; after that, the algebraic scalar
+extraction and the phase-coboundary lemma perform the κ/θ/φ telescoping. See
 docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
 private lemma repeatedBlocks_of_blockedSectorGaugePhase
     [NeZero D] (A B : MPSTensor d D)
@@ -628,7 +631,9 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
       blocksA hA_blocks_lc hNondeg hNormal
   -- Remaining obligation (arXiv:1708.00029 lines 1023--1117): an `m`-factor cyclic
   -- contraction theorem built from the common `L` and the sum-form right inverses
-  -- `Ω u` satisfying `hΩ`; after producing product-one unit phases κ_v, it uses
+  -- `Ω u` satisfying `hΩ`; after producing the uniform product-tensor identity,
+  -- it applies `PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul`
+  -- and the unit-modulus argument from left-canonical normalization, then uses
   -- `TNLean.Algebra.exists_fin_complex_unit_cyclic_coboundary_shift_of_prod_eq_one`
   -- for the offset-indexed κ/θ/φ telescoping (lines 1093--1102). This upgrades the
   -- per-sector blocked gauge-phase equivalences in `hBlockMatch` to one global
@@ -639,6 +644,11 @@ private lemma repeatedBlocks_of_blockedSectorGaugePhase
 1073--1076):
 After injectivity contraction, the sector-restricted tensors satisfy
 A_u^i = κ_v · e^{iη/m} · B_v^i with ∏ κ_v = 1 and |κ_v| = 1.
+The product-one scalar extraction from the uniform product identity is supplied
+by
+`PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul`,
+which formalizes arXiv:1708.00029, Appendix A lines 1072--1080 after a common
+root \(e^{i\eta/m}\) has been chosen.
 
 The offset `q` accounts for the cyclic shift between sector labelings of
 `A` and `B`: propagation from a match at `(u₀, v₀)` yields pairs

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -554,6 +554,48 @@ unconditional result.
     $(A_v^i)_{r,c}=(\kappa_v B_v^i)_{r,c}$ for every entry.
 \end{proof}
 
+\begin{theorem}[Product-one sector scalars after choosing a root]
+    \label{thm:periodic_product_one_phase_extraction}
+    \lean{TNLean.Algebra.PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul}
+    \leanok
+    \uses{thm:periodic_product_tensor_phase_extraction}
+    Let $m>0$, let $z\in\C$ be nonzero, and choose $\xi\in\C$ with
+    $\xi^m=z$. For each sector $v=0,\ldots,m-1$, let $\{A_v^i\}_i$ and
+    $\{B_v^i\}_i$ be families of complex matrices with the same rectangular
+    size. Suppose that for every choice of letters $\sigma=(\sigma_v)_v$,
+    \[
+        \bigotimes_{v=0}^{m-1} A_v^{\sigma_v}
+        =
+        z\,\bigotimes_{v=0}^{m-1} B_v^{\sigma_v}.
+    \]
+    Suppose also that each sector has a reference letter $i_v$ and a matrix
+    entry $(r_v,c_v)$ with $(B_v^{i_v})_{r_v,c_v}\ne0$. Then there are scalars
+    $\kappa_v\in\C$ such that
+    \[
+        \prod_{v=0}^{m-1}\kappa_v=1,
+        \qquad
+        A_v^i=\kappa_v\xi\,B_v^i
+    \]
+    for every sector $v$ and every letter $i$.
+
+    This is the normalization in
+    \cite[Appendix~A, lines~1072--1080]{DeLasCuevas2017Irreducible}: after the
+    preceding translation step has made the scalar independent of the sector
+    label, choosing a common $m$-th root of that scalar leaves a product-one
+    family of sector scalars.
+\end{theorem}
+
+\begin{proof}\leanok
+    Apply Theorem~\ref{thm:periodic_product_tensor_phase_extraction} to obtain
+    scalars $\mu_v$ with $\prod_v\mu_v=z$ and $A_v^i=\mu_vB_v^i$. Since
+    $m>0$, the identities $\xi^m=z$ and $z\ne0$ imply $\xi\ne0$. Put
+    $\kappa_v=\mu_v/\xi$. Then
+    \[
+        \prod_v\kappa_v=\frac{\prod_v\mu_v}{\xi^m}=\frac{z}{z}=1,
+    \]
+    and $A_v^i=(\kappa_v\xi)B_v^i$.
+\end{proof}
+
 \begin{definition}[Off-diagonal sector decomposition]%
     \label{def:cyclic_sector_decomp}
     \lean{MPSTensor.IsCyclicSectorDecomp, MPSTensor.IsCyclicSectorDecompWith}
@@ -1166,7 +1208,8 @@ unconditional result.
     \label{lem:sector_tensor_proportional_blocked_match}
     \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
     \notready
-    \uses{lem:sector_match_propagation, def:cyclic_sector_decomp}
+    \uses{lem:sector_match_propagation, def:cyclic_sector_decomp,
+        thm:periodic_product_one_phase_extraction, lem:finite_cycle_coboundary}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
     cyclic sector decompositions whose sectors are left-canonical. Let the


### PR DESCRIPTION
### Motivation
- Contributes to the m-factor cyclic contraction for blocked sector gauges in arXiv:1708.00029, Appendix A, lines 1023--1117 (see #873).
- Formalizes the product-one normalization step (eq:prodkappaprop, line 1079): given a common m-th root ξ of the global scalar z, the sector scalars κ_v extracted from a uniform product-tensor identity can be arranged to satisfy ∏_v κ_v = 1.
- This is a prerequisite for the κ/θ/φ phase-telescoping argument in arXiv:1708.00029, lines 1082--1102, which upgrades per-sector proportionality to a single global gauge.

### Description
- Adds `PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul` in `TNLean/Algebra/PiTensorProductPhase.lean`: given tensors `A`, `B` with a uniform product-tensor identity `⊗_v A_v(σ_v) = z · ⊗_v B_v(σ_v)` and a common m-th root `ξ` with `ξ^m = z`, produces sector scalars `κ : Fin m → ℂ` with `∏ κ v = 1` and `A v i = (κ v * ξ) • B v i` for all v, i (arXiv:1708.00029, Appendix A, lines 1072--1080).
- Updates `TNLean/MPS/Periodic/Overlap/Case3.lean` to reference the new theorem in the `sorry` comment for `repeatedBlocks_of_blockedSectorGaugePhase`; that private lemma retains an existing `sorry` pending the full cyclic contraction.
- Updates `blueprint/src/chapter/ch22_periodic_ft.tex` with corresponding blueprint entries for the new theorem.

### Testing
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.
- `TNLean/MPS/Periodic/Overlap/Case3.lean` retains one pre-existing `sorry` at `repeatedBlocks_of_blockedSectorGaugePhase`; no new `sorry` is introduced by this PR.

---
Addresses #873

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 20f4c1deb50618ff611de196f50ec6ea76bbe016. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New self-contained algebra on top of an existing theorem; only doc/blueprint and comment updates elsewhere, with no new sorries or runtime/security impact.
> 
> **Overview**
> Adds **`exists_kappa_product_one_of_piTensorProduct_eq_root_smul`** in `PiTensorProductPhase.lean`: from the existing uniform product-tensor identity `⊗ A = z • ⊗ B`, and a common root `ξ` with `ξ^m = z`, it produces sector scalars with **∏ κ = 1** and **A v i = (κ v * ξ) • B v i** (arXiv:1708.00029 Appendix A, 1072–1080). The proof reuses `exists_kappa_of_piTensorProduct_eq_smul` and sets `κ v = κ₀ v / ξ`.
> 
> **Case3** comments now point this theorem as the formalized scalar step in the cyclic contraction pipeline; **`repeatedBlocks_of_blockedSectorGaugePhase`** still ends in `sorry` (m-factor contraction not in this PR).
> 
> The **blueprint** gains `thm:periodic_product_one_phase_extraction` (`\leanok`) and lists it in the dependencies of the not-ready per-site proportionality lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a7642496d42c950009421fd2954f41f8c8dffe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->