### PR TITLE
feat(Analysis): add strict finite-overlap compression bound

### DIFF
--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -598,6 +598,47 @@ theorem quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le
     _ ≤ ((1 - γ) * ((m : ℝ)⁻¹)) * ‖P i v‖ :=
       mul_le_mul_of_nonneg_right hηle (norm_nonneg (P i v))
 
+/-- Finite-overlap row-sum reduction from a strict norm-compression coefficient.
+
+If interacting pairs satisfy `‖P_i (P_j v)‖ ≤ η ‖P_i v‖` and
+`η * m < 1`, then the finite sum of symmetric projections satisfies
+`H² ≥ (1 - η * m)H` as a quadratic form.  Thus a compression coefficient
+strictly below the reciprocal of the overlap degree gives a positive
+martingale constant. -/
+theorem quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_lt
+    {η : ℝ} (hηnonneg : 0 ≤ η)
+    (P : ι → E →ₗ[ℂ] E) (hP : ∀ i, (P i).IsSymmetricProjection)
+    (overlaps : ι → ι → Prop) [DecidableRel overlaps] {m : ℕ} (hm : 0 < m)
+    (hηlt : η * (m : ℝ) < 1)
+    (hCard : ∀ i, ((Finset.univ.erase i).filter (fun j => overlaps i j)).card ≤ m)
+    (hDisjoint : ∀ i j, j ∈ Finset.univ.erase i → ¬ overlaps i j →
+      ∀ v : E, 0 ≤ (⟪P i v, P j v⟫_ℂ).re)
+    (hOverlapNorm : ∀ i j, j ∈ Finset.univ.erase i → overlaps i j →
+      ∀ v : E, ‖P i (P j v)‖ ≤ η * ‖P i v‖) :
+    0 < 1 - η * (m : ℝ) ∧
+    ∀ v : E,
+      (1 - η * (m : ℝ)) * (⟪(∑ i, P i) v, v⟫_ℂ).re ≤
+        (⟪(∑ i, P i) v, (∑ i, P i) v⟫_ℂ).re := by
+  have hmRpos : 0 < (m : ℝ) := by
+    exact_mod_cast hm
+  have hγpos : 0 < 1 - η * (m : ℝ) := by
+    linarith
+  refine ⟨hγpos, ?_⟩
+  have hγle : 1 - η * (m : ℝ) ≤ 1 := by
+    have hmul_nonneg : 0 ≤ η * (m : ℝ) :=
+      mul_nonneg hηnonneg hmRpos.le
+    linarith
+  have hηle : η ≤ (1 - (1 - η * (m : ℝ))) * ((m : ℝ)⁻¹) := by
+    have hmne : (m : ℝ) ≠ 0 := ne_of_gt hmRpos
+    have hηeq : η = (1 - (1 - η * (m : ℝ))) * ((m : ℝ)⁻¹) := by
+      calc
+        η = η * ((m : ℝ) * ((m : ℝ)⁻¹)) := by
+          rw [mul_inv_cancel₀ hmne, mul_one]
+        _ = (1 - (1 - η * (m : ℝ))) * ((m : ℝ)⁻¹) := by ring
+    exact le_of_eq hηeq
+  exact quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le hγle
+    P hP overlaps hm hCard hDisjoint hηle hOverlapNorm
+
 end OffDiagonal
 
 end ProjectionGeometry

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -600,8 +600,8 @@ theorem quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le
 
 /-- Finite-overlap row-sum reduction from a strict norm-compression coefficient.
 
-If interacting pairs satisfy `‖P_i (P_j v)‖ ≤ η ‖P_i v‖` and
-`η * m < 1`, then the finite sum of symmetric projections satisfies
+If interacting pairs satisfy `‖P_i (P_j v)‖ ≤ η ‖P_i v‖`, with
+`0 ≤ η` and `η * m < 1`, then the finite sum of symmetric projections satisfies
 `H² ≥ (1 - η * m)H` as a quadratic form.  Thus a compression coefficient
 strictly below the reciprocal of the overlap degree gives a positive
 martingale constant. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -496,7 +496,7 @@ sufficient stronger hypotheses.
     \end{equation}
     Then $H=\sum_iP_i$ satisfies $H^2\ge\gamma H$ as a quadratic form. The same
     conclusion holds from a separate compression coefficient $\eta$ whenever
-    $\eta\le (1-\gamma)/m$. In particular, if $\eta m<1$, then
+    $\eta\le (1-\gamma)/m$. In particular, if $0\le \eta$ and $\eta m<1$, then
     \[
         H^2\ge (1-\eta m)H
     \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -483,6 +483,7 @@ sufficient stronger hypotheses.
     \label{lem:finite_overlap_projection_norm_reduction}
     \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound}
     \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_le}
+    \lean{ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_lt}
     \leanok
     \uses{lem:finite_overlap_projection_rowsum_reduction,
         rem:projection_geometry_rowsum_identities}
@@ -495,7 +496,11 @@ sufficient stronger hypotheses.
     \end{equation}
     Then $H=\sum_iP_i$ satisfies $H^2\ge\gamma H$ as a quadratic form. The same
     conclusion holds from a separate compression coefficient $\eta$ whenever
-    $\eta\le (1-\gamma)/m$.
+    $\eta\le (1-\gamma)/m$. In particular, if $\eta m<1$, then
+    \[
+        H^2\ge (1-\eta m)H
+    \]
+    and $1-\eta m>0$.
 \end{lemma}
 
 \begin{proof}
@@ -509,7 +514,7 @@ sufficient stronger hypotheses.
     If a separate coefficient $\eta$ is used, the assumption
     $\eta\le(1-\gamma)/m$ first weakens that estimate to
     (\ref{eq:ph_finite_overlap_norm_compression}). The finite-overlap row-sum
-    reduction then applies.
+    reduction then applies. For the strict form take $\gamma=1-\eta m$.
 \end{proof}
 
 \begin{lemma}[Quadratic-form estimate from the martingale condition]


### PR DESCRIPTION
### Motivation

- The martingale proof of the MPS parent-Hamiltonian spectral gap requires, for every overlapping cyclic-window pair $(i,j)$, a norm-compression estimate $\|p_i p_j v\| \le \eta \|p_i v\|$ with $\eta \cdot 2(L-1) < 1$ (arXiv:2011.12127 §IV.C; see `docs/paper-gaps/cpgsv21_martingale_overlap.tex`).
- The existing projection-geometry layer has the general finite-overlap compression theorem; the strict-$\eta$ corollary and positivity of $1 - \eta m$ are missing and are needed by the wrappers in `Martingale/Gap.lean`.

### Description

- Added `ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_lt` to `TNLean/Analysis/ProjectionGeometry.lean`: for a finite family of symmetric projections with overlap degree $m$ and a compression constant $\eta$ satisfying $\eta m < 1$, the estimate $\|P_i(P_j v)\| \le \eta \|P_i v\|$ yields the quadratic-form bound $H^2 \ge (1 - \eta m) H$ together with positivity of $1 - \eta m$. This isolates the scalar $\gamma = 1 - \eta m$ in the abstract projection-geometry layer used by the martingale reduction.
- Updated `blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex` to record the strict finite-overlap norm-compression consequence.

### Testing

- `lake env lean TNLean/Analysis/ProjectionGeometry.lean`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `lake exe checkdecls blueprint/lean_decls`

---
Refs #952

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive analysis and blueprint documentation; no runtime or security-sensitive paths, and the new result composes existing projection-geometry lemmas.
> 
> **Overview**
> Adds **`ProjectionGeometry.quadraticForm_sum_projections_of_finite_overlap_norm_bound_of_lt`**, so martingale gap arguments can use a compression constant **η** with **ηm &lt; 1** without first choosing a separate **γ**. From **‖Pᵢ(Pⱼv)‖ ≤ η‖Pᵢv‖** on overlapping pairs, the theorem gives **H² ≥ (1 − ηm)H** as a quadratic form and **1 − ηm &gt; 0**; the proof sets **γ = 1 − ηm** and applies the existing **`_of_le`** reduction.
> 
> The blueprint lemma on finite-overlap norm-compression (**`ch13_parent_hamiltonian_spectral_gap.tex`**) now links this Lean name and states the strict consequence **H² ≥ (1 − ηm)H** when **0 ≤ η** and **ηm &lt; 1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377fb50e57bb80ac48f825c202c580041c2df904. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->