### PR TITLE
refactor(MPS/Periodic): remove relation-law restatements

### DIFF
--- a/TNLean/MPS/Periodic/Defs.lean
+++ b/TNLean/MPS/Periodic/Defs.lean
@@ -42,45 +42,21 @@ abbrev SameState (A B : PeriodicMPSTensor (d := d) (D := D) m) : Prop :=
 abbrev GaugeEquiv (A B : PeriodicMPSTensor (d := d) (D := D) m) : Prop :=
   MPSChainTensor.GaugeEquiv A B
 
-theorem SameState.refl (A : PeriodicMPSTensor (d := d) (D := D) m) : SameState A A :=
-  MPSChainTensor.SameState.refl A
-
-theorem SameState.symm {A B : PeriodicMPSTensor (d := d) (D := D) m}
-    (h : SameState A B) : SameState B A :=
-  MPSChainTensor.SameState.symm h
-
-theorem SameState.trans {A B C : PeriodicMPSTensor (d := d) (D := D) m}
-    (hAB : SameState A B) (hBC : SameState B C) :
-    SameState A C :=
-  MPSChainTensor.SameState.trans hAB hBC
-
 def instEquivalenceSameState :
     Equivalence (SameState (d := d) (D := D) (m := m)) where
   -- `Equivalence` is a structure (not a class): this is a convenience bundle,
   -- not intended to be found via typeclass search.
-  refl := SameState.refl
-  symm := SameState.symm
-  trans := SameState.trans
-
-theorem GaugeEquiv.refl (A : PeriodicMPSTensor (d := d) (D := D) m) : GaugeEquiv A A :=
-  MPSChainTensor.GaugeEquiv.refl A
-
-theorem GaugeEquiv.symm {A B : PeriodicMPSTensor (d := d) (D := D) m}
-    (h : GaugeEquiv A B) : GaugeEquiv B A :=
-  MPSChainTensor.GaugeEquiv.symm h
-
-theorem GaugeEquiv.trans {A B C : PeriodicMPSTensor (d := d) (D := D) m}
-    (hAB : GaugeEquiv A B) (hBC : GaugeEquiv B C) :
-    GaugeEquiv A C :=
-  MPSChainTensor.GaugeEquiv.trans hAB hBC
+  refl := MPSChainTensor.SameState.refl
+  symm := MPSChainTensor.SameState.symm
+  trans := MPSChainTensor.SameState.trans
 
 def instEquivalenceGaugeEquiv :
     Equivalence (GaugeEquiv (d := d) (D := D) (m := m)) where
   -- `Equivalence` is a structure (not a class): this is a convenience bundle,
   -- not intended to be found via typeclass search.
-  refl := GaugeEquiv.refl
-  symm := GaugeEquiv.symm
-  trans := GaugeEquiv.trans
+  refl := MPSChainTensor.GaugeEquiv.refl
+  symm := MPSChainTensor.GaugeEquiv.symm
+  trans := MPSChainTensor.GaugeEquiv.trans
 
 end PeriodicMPSTensor
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -96,6 +96,9 @@ The clearest replacements are:
 - Further Lean 4.31 elaboration checks removed local heartbeat bounds from the
   POVM unitary-comparison proof, the irreducible-channel spectral-radius scalar
   proof, and the semigroup perturbation derivative proof.
+- The periodic-MPS equivalence bundles now cite the chain-level relation laws
+  directly.  Six local theorem declarations that only restated reflexivity,
+  symmetry, and transitivity for the periodic abbreviations were removed.
 
 There are also important non-replacements.
 
@@ -1308,6 +1311,32 @@ Focused check:
 lake build TNLean.Algebra.ProjectionTriangularTrace -q --log-level=info
 ```
 
+### Periodic relation-law pass-through removal, 2026-06-19
+
+`PeriodicMPSTensor.SameState` and `PeriodicMPSTensor.GaugeEquiv` are
+abbreviations for the corresponding `MPSChainTensor` relations.  The periodic
+reflexivity, symmetry, and transitivity theorems therefore added no new
+periodic-MPS content.  The equivalence bundles now cite the chain-level
+relation laws directly, while retaining the blueprint-facing bundle names:
+
+- `MPSTensor.PeriodicMPSTensor.instEquivalenceSameState`
+- `MPSTensor.PeriodicMPSTensor.instEquivalenceGaugeEquiv`
+
+Removed declarations:
+
+- `MPSTensor.PeriodicMPSTensor.SameState.refl`
+- `MPSTensor.PeriodicMPSTensor.SameState.symm`
+- `MPSTensor.PeriodicMPSTensor.SameState.trans`
+- `MPSTensor.PeriodicMPSTensor.GaugeEquiv.refl`
+- `MPSTensor.PeriodicMPSTensor.GaugeEquiv.symm`
+- `MPSTensor.PeriodicMPSTensor.GaugeEquiv.trans`
+
+Focused check:
+
+```bash
+lake build TNLean.MPS.Periodic.Defs -q --log-level=info
+```
+
 ### Trace-pairing extensionality, 2026-06-19
 
 Mathlib 4.31 has equality-form trace-pairing extensionality lemmas:
@@ -1380,6 +1409,13 @@ pass-throughs:
   `orthogonalProjection_mul_complement`.  These were the matrix-projection
   specializations of `IsIdempotentElem.one_sub_mul_self` and
   `IsIdempotentElem.mul_one_sub_self`.
+- `MPSTensor.PeriodicMPSTensor.SameState.refl`,
+  `MPSTensor.PeriodicMPSTensor.SameState.symm`,
+  `MPSTensor.PeriodicMPSTensor.SameState.trans`,
+  `MPSTensor.PeriodicMPSTensor.GaugeEquiv.refl`,
+  `MPSTensor.PeriodicMPSTensor.GaugeEquiv.symm`, and
+  `MPSTensor.PeriodicMPSTensor.GaugeEquiv.trans`.  These were exact
+  restatements of the chain-level relation laws for the periodic abbreviations.
 
 ## Verification performed
 


### PR DESCRIPTION
### Motivation

- `PeriodicMPSTensor.SameState` and `PeriodicMPSTensor.GaugeEquiv` are defined as
  abbreviations for the corresponding `MPSChainTensor` relations, so the six
  declarations restating their reflexivity, symmetry, and transitivity at the
  periodic level are exact pass-through layers that add no mathematical content.
- Recorded in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md` as part
  of the Mathlib 4.31 local-wrapper cleanup.

### Description

- `TNLean/MPS/Periodic/Defs.lean`: removed six declarations that restated
  chain-level relation laws for the periodic abbreviations:
  - `MPSTensor.PeriodicMPSTensor.SameState.refl`
  - `MPSTensor.PeriodicMPSTensor.SameState.symm`
  - `MPSTensor.PeriodicMPSTensor.SameState.trans`
  - `MPSTensor.PeriodicMPSTensor.GaugeEquiv.refl`
  - `MPSTensor.PeriodicMPSTensor.GaugeEquiv.symm`
  - `MPSTensor.PeriodicMPSTensor.GaugeEquiv.trans`
- The equivalence bundle declarations
  `MPSTensor.PeriodicMPSTensor.instEquivalenceSameState` and
  `MPSTensor.PeriodicMPSTensor.instEquivalenceGaugeEquiv` are retained; their
  fields now cite `MPSChainTensor.SameState.*` and `MPSChainTensor.GaugeEquiv.*`
  directly.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: updated to record
  this pass-through-layer removal.

### Testing

- `lake build TNLean.MPS.Periodic.Defs -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- Build reports only pre-existing style/docstring warnings and the known
  `TNLean/MPS/Periodic/Overlap/Case3.lean` sorry warning.

---
No linked issue identified — the change originates from the Mathlib 4.31 audit
documented in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`.

> [!NOTE]
> **Low Risk**
> Proof-only deduplication in periodic definitions with no API or mathematical change beyond dropping redundant theorem names.
> 
> **Overview**
> Removes six periodic-MPS theorems (`SameState` and `GaugeEquiv` reflexivity, symmetry, transitivity) that only forwarded to `MPSChainTensor`, since `PeriodicMPSTensor` relations are abbreviations for the chain-level ones.
> 
> **`instEquivalenceSameState`** and **`instEquivalenceGaugeEquiv`** still exist for blueprint-facing names; their fields now reference `MPSChainTensor.SameState.*` and `MPSChainTensor.GaugeEquiv.*` directly. The Mathlib 4.31 replacement audit documents the cleanup and lists the removed declarations under deprecation-policy exceptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeb5e9d6a0bd0764931c4f5362b1cd2242671909. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>