### PR TITLE
refactor(PEPS): remove redundant accessor declarations

### DIFF
--- a/TNLean/PEPS/NormalBondDimension.lean
+++ b/TNLean/PEPS/NormalBondDimension.lean
@@ -209,8 +209,8 @@ theorem bondDim_apply_eq_of_coherentFrames
     rw [hBc]
     exact F'.frame.coarseTensor_isVertexInjective.scaleVertex (0 : Fin 3)
       (Nat.cast_ne_zero.mpr hcApos.ne')
-  have hposAc : ∀ f : Edge coarseGraph, 0 < Ac.bondDim f := F.frame.coarseTensor_pos_bondDim
-  have hposBc : ∀ f : Edge coarseGraph, 0 < Bc.bondDim f := F'.frame.coarseTensor_pos_bondDim
+  have hposAc : ∀ f : Edge coarseGraph, 0 < Ac.bondDim f := F.frame.pos_coarseBondDim
+  have hposBc : ∀ f : Edge coarseGraph, 0 < Bc.bondDim f := F'.frame.pos_coarseBondDim
   -- The insertion algebra equivalence on the coarse `r-b` bond forces equal sizes.
   have hΦ := edgeTransferAlgEquiv Ac Bc coarseEdgeRB
     (hAcInj.edgeBlockedThreeSiteInjective hposAc coarseEdgeRB)

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite.lean
@@ -289,10 +289,6 @@ theorem coarseTensor_isVertexInjective : IsVertexInjective (F.coarseTensor) := b
     exact LinearMap.funLeft_injective_of_surjective ℂ ℂ _
       (coarseProj_surjective F.pos_dim (F.regionOf v))
 
-/-- The coarse tensor has positive bond dimensions on every coarse edge. -/
-theorem coarseTensor_pos_bondDim : ∀ f : Edge coarseGraph, 0 < (F.coarseTensor).bondDim f :=
-  F.pos_coarseBondDim
-
 /-- **The coarse three-site chain is injective at the `r-b` edge.** The endpoint
 super-sites (red and blue blocks) and the middle super-site (complement block) are
 all injective, so the edge-blocked three-site injectivity hypothesis holds for the
@@ -305,7 +301,7 @@ Source: arXiv:1804.04964, Section 3, proof of Theorem 3, the three-site chain af
 theorem coarseTensor_edgeBlockedThreeSiteInjective :
     EdgeBlockedThreeSiteInjective (G := coarseGraph) (F.coarseTensor) coarseEdgeRB :=
   F.coarseTensor_isVertexInjective.edgeBlockedThreeSiteInjective
-    F.coarseTensor_pos_bondDim coarseEdgeRB
+    F.pos_coarseBondDim coarseEdgeRB
 
 end CoarseBlockingFrame
 
@@ -350,7 +346,7 @@ theorem coarse_exists_edgeInsertedCoeff_eq {A B : Tensor G d}
           edgeInsertedCoeff (G := coarseGraph) (F'.coarseTensor) coarseEdgeRB σ N :=
   exists_edgeInsertedCoeff_eq (G := coarseGraph) (F.coarseTensor) (F'.coarseTensor)
     coarseEdgeRB F.coarseTensor_edgeBlockedThreeSiteInjective
-    F'.coarseTensor_edgeBlockedThreeSiteInjective hsame F'.coarseTensor_pos_bondDim M
+    F'.coarseTensor_edgeBlockedThreeSiteInjective hsame F'.pos_coarseBondDim M
 
 end PEPS
 end TNLean

--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean
@@ -431,7 +431,7 @@ noncomputable def regionEdgeTransfer
     (edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
       (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
       (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
-      F'.frame.coarseTensor_pos_bondDim
+      F'.frame.pos_coarseBondDim
       (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M))
 
 open scoped Classical in
@@ -473,7 +473,7 @@ theorem regionEdgeTransfer_regionInsertedCoeff
   set Ncoarse := edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
     (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
     (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
-    F'.frame.coarseTensor_pos_bondDim Mcoarse with hNc
+    F'.frame.pos_coarseBondDim Mcoarse with hNc
   have hMrecover :
       Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle) Mcoarse = M := by
     rw [hMc, ← Matrix.symm_reindexAlgEquiv, AlgEquiv.apply_symm_apply]
@@ -487,7 +487,7 @@ theorem regionEdgeTransfer_regionInsertedCoeff
   exact edgeTransferMatrix_edgeInsertedCoeff (F.frame.coarseTensor) (F'.frame.coarseTensor)
     coarseEdgeRB (F.frame.coarseTensor_edgeBlockedThreeSiteInjective)
     (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective) hsame
-    F'.frame.coarseTensor_pos_bondDim Mcoarse s
+    F'.frame.pos_coarseBondDim Mcoarse s
 
 /-- **The concrete single-edge transfer is multiplicative.** The conjugated coarse
 edge-transfer matrix sends a product to the product of the transfers: the coarse transfer is
@@ -520,23 +520,23 @@ theorem regionEdgeTransfer_mul
   rw [show edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
         (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
         (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
-        F'.frame.coarseTensor_pos_bondDim
+        F'.frame.pos_coarseBondDim
         (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M *
           Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M') =
       edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
           (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
           (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
-          F'.frame.coarseTensor_pos_bondDim
+          F'.frame.pos_coarseBondDim
           (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M) *
         edgeTransferMatrix (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
           (F.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
           (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective).endpoint_linearIndependent.2
-          F'.frame.coarseTensor_pos_bondDim
+          F'.frame.pos_coarseBondDim
           (Matrix.reindexAlgEquiv ℂ ℂ (bridgeEquiv (G := G) F e hsingle).symm M') from
       edgeTransferMatrix_mul (F.frame.coarseTensor) (F'.frame.coarseTensor) coarseEdgeRB
         (F.frame.coarseTensor_edgeBlockedThreeSiteInjective)
         (F'.frame.coarseTensor_edgeBlockedThreeSiteInjective) hsame
-        F'.frame.coarseTensor_pos_bondDim _ _]
+        F'.frame.pos_coarseBondDim _ _]
   exact map_mul _ _ _
 
 /-- **The concrete single-edge transfer matches the region-inserted coefficient over the

--- a/TNLean/PEPS/TorusRowColumnReductionObstruction.lean
+++ b/TNLean/PEPS/TorusRowColumnReductionObstruction.lean
@@ -217,11 +217,6 @@ theorem Aunits_isNBlkInjective : IsNBlkInjective Aunits 1 :=
 theorem gaugeEquiv_Aunits_Bunits : GaugeEquiv Aunits Bunits :=
   ⟨Gunit⁻¹, fun i => by rw [Bunits, inv_inv]⟩
 
-/-- `Aunits` and `Bunits` generate the same matrix product vector family: gauge
-equivalence preserves every closed-chain coefficient. -/
-theorem sameMPV_Aunits_Bunits : SameMPV Aunits Bunits :=
-  gaugeEquiv_Aunits_Bunits.sameMPV
-
 /-- `Bunits` is injective at block length one: gauge equivalence preserves
 injectivity, since conjugation by an invertible matrix maps a spanning family to a
 spanning family. -/
@@ -270,7 +265,8 @@ the section "No coherence question between rows". -/
 theorem rowCutGaugeFactorizes_false : ¬ RowCutGaugeFactorizes := by
   intro hRoute
   obtain ⟨Z, lam, hprod, hrel⟩ :=
-    hRoute Aunits Bunits Aunits_isNBlkInjective Bunits_isNBlkInjective sameMPV_Aunits_Bunits
+    hRoute Aunits Bunits Aunits_isNBlkInjective Bunits_isNBlkInjective
+      gaugeEquiv_Aunits_Bunits.sameMPV
   -- Specialize the relation to the matrix units and clear the inverse on the left.
   -- `Z * (Ginv (single a b 1) Gmat) = lam • (single a b 1 * Z)`.
   have hZrel : ∀ a b : Fin 4,

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -99,6 +99,9 @@ The clearest replacements are:
 - The periodic-MPS equivalence bundles now cite the chain-level relation laws
   directly.  Six local theorem declarations that only restated reflexivity,
   symmetry, and transitivity for the periodic abbreviations were removed.
+- Two PEPS pass-through declarations were removed: a coarse-frame
+  bond-positivity accessor that only exposed the structure field, and a one-use
+  same-state restatement in the row-cut obstruction example.
 
 There are also important non-replacements.
 
@@ -1337,6 +1340,26 @@ Focused check:
 lake build TNLean.MPS.Periodic.Defs -q --log-level=info
 ```
 
+### PEPS accessor pass-through removal, 2026-06-19
+
+Two PEPS declarations had no independent mathematical content and no blueprint
+references:
+
+- `TNLean.PEPS.CoarseBlockingFrame.coarseTensor_pos_bondDim` only exposed the
+  structure field `CoarseBlockingFrame.pos_coarseBondDim`.  The coarse
+  three-site and normal-bond-dimension proofs now use the field directly.
+- `TNLean.PEPS.sameMPV_Aunits_Bunits` only applied
+  `gaugeEquiv_Aunits_Bunits.sameMPV` at one row-cut obstruction proof site.
+  That proof now calls the gauge-invariance theorem directly.
+
+Focused check:
+
+```bash
+lake build TNLean.PEPS.RegionBlock.CoarseThreeSite11 \
+  TNLean.PEPS.NormalBondDimension TNLean.PEPS.TorusRowColumnReductionObstruction \
+  -q --log-level=info
+```
+
 ### Trace-pairing extensionality, 2026-06-19
 
 Mathlib 4.31 has equality-form trace-pairing extensionality lemmas:
@@ -1416,6 +1439,10 @@ pass-throughs:
   `MPSTensor.PeriodicMPSTensor.GaugeEquiv.symm`, and
   `MPSTensor.PeriodicMPSTensor.GaugeEquiv.trans`.  These were exact
   restatements of the chain-level relation laws for the periodic abbreviations.
+- `TNLean.PEPS.CoarseBlockingFrame.coarseTensor_pos_bondDim`.  This only
+  returned the `pos_coarseBondDim` field from a `CoarseBlockingFrame`.
+- `TNLean.PEPS.sameMPV_Aunits_Bunits`.  This was a one-use application of
+  `gaugeEquiv_Aunits_Bunits.sameMPV`.
 
 ## Verification performed
 


### PR DESCRIPTION
### Motivation

- Two PEPS declarations had no independent mathematical content: one re-stated an existing structure field, and the other re-stated an existing gauge-invariance consequence for a single call site.
- Removing them reduces duplication and makes call sites reference the primary structure field or theorem directly.
- Recorded in the Mathlib 4.31 replacement audit as part of the ongoing pass-through-layer cleanup.

### Description

- `TNLean/PEPS/RegionBlock/CoarseThreeSite.lean`, `TNLean/PEPS/RegionBlock/CoarseThreeSite11.lean`: removed `CoarseBlockingFrame.coarseTensor_pos_bondDim`, which only returned the existing `CoarseBlockingFrame.pos_coarseBondDim` field; call sites updated to use the field directly.
- `TNLean/PEPS/NormalBondDimension.lean`, `TNLean/PEPS/TorusRowColumnReductionObstruction.lean`: removed `sameMPV_Aunits_Bunits`, a single-use re-statement of `gaugeEquiv_Aunits_Bunits.sameMPV`; call site updated to use the gauge-invariance theorem directly.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: updated to record this cleanup.
- Neither removed declaration is blueprint-facing; no blueprint tags require updating.

### Testing

- `lake exe cache get`
- `lake build TNLean.PEPS.RegionBlock.CoarseThreeSite11 TNLean.PEPS.NormalBondDimension TNLean.PEPS.TorusRowColumnReductionObstruction -q --log-level=info`
- `lake build -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `leanblueprint checkdecls`
- Build passes with only pre-existing style/docstring warnings and the known `TNLean/MPS/Periodic/Overlap/Case3.lean` sorry warning.

---
No linked issue found — the author should link one manually if this work is tracked.

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f14fdb2d668ee7ea93a970317572a13274430825. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>