### PR TITLE
refactor(PEPS): inline example pass-through proofs

### DIFF
--- a/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
+++ b/TNLean/PEPS/PhysicalToVirtualCounterexample.lean
@@ -153,17 +153,13 @@ theorem left_injective : Function.Injective (localTensorMap a3 (0 : V3)) := by
   funext η
   exact (IsEmpty.false η).elim
 
-/-- Middle tensor family is linearly independent (its index type is empty). -/
-theorem middle_injective : EdgeMiddleTensorInjective (G := g3) a3 e3 :=
-  linearIndependent_empty_type
-
 /-- The blocked three-site object is injective. -/
 theorem a3_edge_blocked_three_site_injective :
     EdgeBlockedThreeSiteInjective (G := g3) a3 e3 :=
   { left_injective := by
       have : e3.1.1 = (0 : V3) := e3_left
       rw [this]; exact left_injective
-    middle_injective := middle_injective
+    middle_injective := linearIndependent_empty_type
     right_injective := by
       have : e3.1.2 = (1 : V3) := e3_right
       rw [this]; exact right_injective }

--- a/TNLean/PEPS/TorusRowColumnReductionObstruction.lean
+++ b/TNLean/PEPS/TorusRowColumnReductionObstruction.lean
@@ -167,10 +167,9 @@ theorem Gmat_blocks_not_proportional :
 The injective `A`-super-tensor of the refutation is the matrix-unit family on the
 bond space `Fin 4`, indexed by the physical super-index `Fin 16 ≃ Fin 4 × Fin 4`.
 Its range is all single matrices, which span the whole matrix algebra, so it is
-injective at block length one (`Aunits_isNBlkInjective`).  The conjugate
-`Bunits i = Ginv (Aunits i) Gmat` has the same closed-chain coefficients
-(`sameMPV`) and the same block injectivity, but the conjugator is `Gunit`, not a
-per-edge product. -/
+injective at block length one.  The conjugate
+`Bunits i = Ginv (Aunits i) Gmat` has the same closed-chain coefficients and the
+same block injectivity, but the conjugator is `Gunit`, not a per-edge product. -/
 
 
 /-- The physical super-index `Fin 16` read as a pair `Fin 4 × Fin 4`. -/
@@ -209,20 +208,9 @@ theorem Aunits_isInjective : IsInjective Aunits := by
     rw [Matrix.smul_single, smul_eq_mul, mul_one]]
   exact Submodule.smul_mem _ _ (single_mem_span_Aunits a b)
 
-/-- `Aunits` is injective at block length one. -/
-theorem Aunits_isNBlkInjective : IsNBlkInjective Aunits 1 :=
-  isNBlkInjective_one_of_isInjective Aunits_isInjective
-
 /-- `Bunits` is the `Gunit⁻¹`-gauge of `Aunits`. -/
 theorem gaugeEquiv_Aunits_Bunits : GaugeEquiv Aunits Bunits :=
   ⟨Gunit⁻¹, fun i => by rw [Bunits, inv_inv]⟩
-
-/-- `Bunits` is injective at block length one: gauge equivalence preserves
-injectivity, since conjugation by an invertible matrix maps a spanning family to a
-spanning family. -/
-theorem Bunits_isNBlkInjective : IsNBlkInjective Bunits 1 :=
-  isNBlkInjective_one_of_isInjective
-    (isInjective_of_gaugeEquiv Aunits_isInjective gaugeEquiv_Aunits_Bunits)
 
 /-! ### The route's required principle and its refutation
 
@@ -264,9 +252,13 @@ arXiv:1804.04964.  Documented in `docs/paper-gaps/peps_normal_ft_2d_overlap.tex`
 the section "No coherence question between rows". -/
 theorem rowCutGaugeFactorizes_false : ¬ RowCutGaugeFactorizes := by
   intro hRoute
+  have hAblk : IsNBlkInjective Aunits 1 :=
+    isNBlkInjective_one_of_isInjective Aunits_isInjective
+  have hBblk : IsNBlkInjective Bunits 1 :=
+    isNBlkInjective_one_of_isInjective
+      (isInjective_of_gaugeEquiv Aunits_isInjective gaugeEquiv_Aunits_Bunits)
   obtain ⟨Z, lam, hprod, hrel⟩ :=
-    hRoute Aunits Bunits Aunits_isNBlkInjective Bunits_isNBlkInjective
-      gaugeEquiv_Aunits_Bunits.sameMPV
+    hRoute Aunits Bunits hAblk hBblk gaugeEquiv_Aunits_Bunits.sameMPV
   -- Specialize the relation to the matrix units and clear the inverse on the left.
   -- `Z * (Ginv (single a b 1) Gmat) = lam • (single a b 1 * Z)`.
   have hZrel : ∀ a b : Fin 4,

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -102,6 +102,8 @@ The clearest replacements are:
 - Two PEPS pass-through declarations were removed: a coarse-frame
   bond-positivity accessor that only exposed the structure field, and a one-use
   same-state restatement in the row-cut obstruction example.
+- Three more PEPS example pass-through declarations were removed by inlining
+  their immediate witnesses at the only proof sites where they were used.
 
 There are also important non-replacements.
 
@@ -1360,6 +1362,32 @@ lake build TNLean.PEPS.RegionBlock.CoarseThreeSite11 \
   -q --log-level=info
 ```
 
+### PEPS example pass-through removal, 2026-06-19
+
+The follow-up PEPS scan found three exported example declarations that named
+only immediate proof steps and had no blueprint references:
+
+- `TNLean.PEPS.middle_injective` in
+  `TNLean/PEPS/PhysicalToVirtualCounterexample.lean` was exactly
+  `linearIndependent_empty_type`, used once as the middle-injectivity field of
+  the three-site counterexample.
+- `TNLean.PEPS.Aunits_isNBlkInjective` in
+  `TNLean/PEPS/TorusRowColumnReductionObstruction.lean` was the direct
+  one-block injectivity consequence of `Aunits_isInjective`.
+- `TNLean.PEPS.Bunits_isNBlkInjective` in the same file was the corresponding
+  one-block consequence after transporting injectivity along
+  `gaugeEquiv_Aunits_Bunits`.
+
+The remaining proofs now use these witnesses locally at the structure field or
+route-specialization site, so no additional public theorem names are exported.
+
+Focused check:
+
+```bash
+lake build TNLean.PEPS.PhysicalToVirtualCounterexample \
+  TNLean.PEPS.TorusRowColumnReductionObstruction -q --log-level=info
+```
+
 ### Trace-pairing extensionality, 2026-06-19
 
 Mathlib 4.31 has equality-form trace-pairing extensionality lemmas:
@@ -1443,6 +1471,11 @@ pass-throughs:
   returned the `pos_coarseBondDim` field from a `CoarseBlockingFrame`.
 - `TNLean.PEPS.sameMPV_Aunits_Bunits`.  This was a one-use application of
   `gaugeEquiv_Aunits_Bunits.sameMPV`.
+- `TNLean.PEPS.middle_injective`.  This was the empty-index linear-independence
+  witness `linearIndependent_empty_type` for one example structure field.
+- `TNLean.PEPS.Aunits_isNBlkInjective` and
+  `TNLean.PEPS.Bunits_isNBlkInjective`.  These were one-use consequences of the
+  standard one-block injectivity theorem.
 
 ## Verification performed
 


### PR DESCRIPTION
### Motivation

- Three exported PEPS example declarations in `PhysicalToVirtualCounterexample.lean` and `TorusRowColumnReductionObstruction.lean` named immediate proof witnesses with no blueprint references; removing them reduces the public API surface without affecting the underlying mathematics.
- The Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`) records this cleanup alongside other pass-through removals from the upgrade cycle.

### Description

- `TNLean/PEPS/PhysicalToVirtualCounterexample.lean`: inlined the empty-index middle-injectivity witness into the `middle_injective` field of `a3_edge_blocked_three_site_injective`, using `linearIndependent_empty_type` directly.
- `TNLean/PEPS/TorusRowColumnReductionObstruction.lean`: removed `Aunits_isNBlkInjective` and `Bunits_isNBlkInjective`; `rowCutGaugeFactorizes_false` now builds the one-block injectivity hypotheses locally before applying `RowCutGaugeFactorizes`. Module comments tightened.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: the three removed names are recorded in the deprecation-policy exception list.
- The main mathematical statements (`PhysicalToVirtualCounterexample`, `rowCutGaugeFactorizes_false`) and the underlying refutation arguments are unchanged.

### Testing

- `lake build TNLean.PEPS.PhysicalToVirtualCounterexample TNLean.PEPS.TorusRowColumnReductionObstruction -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- `lake build -q --log-level=info`
- Root build reports only pre-existing style warnings and the known `TNLean/MPS/Periodic/Overlap/Case3.lean` `sorry` warning.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
_No linked issue found. Please link the relevant issue with `Addresses #N` or `Closes #N` if one exists._

> [!NOTE]
> **Low Risk**
> Proof-structure cleanup only; no change to statements, APIs, or mathematical conclusions in the PEPS counterexamples.
>
> **Overview**
> Removes three **exported PEPS example theorems** that only wrapped immediate proof steps, with no blueprint references. The counterexamples and refutations are unchanged.
>
> In `PhysicalToVirtualCounterexample`, the `middle_injective` field of `a3_edge_blocked_three_site_injective` now uses `linearIndependent_empty_type` directly instead of a separate `middle_injective` theorem.
>
> In `TorusRowColumnReductionObstruction`, `Aunits_isNBlkInjective` and `Bunits_isNBlkInjective` are gone; `rowCutGaugeFactorizes_false` builds the one-block injectivity hypotheses locally before applying `RowCutGaugeFactorizes`. Module comments are tightened accordingly.
>
> The Mathlib 4.31 replacement audit documents this pass-through removal and adds the three names to the deprecation-policy exception list.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67dc9b923332237af58403963e6ce8eef1b4c9b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>