### PR TITLE
refactor(Spectral): remove Frobenius nonnegativity wrapper

### DIFF
--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -44,9 +44,6 @@ variable {m n : ℕ}
 noncomputable def frobSq (X : Matrix (Fin m) (Fin n) ℂ) : ℝ :=
   ‖X‖ ^ 2
 
-lemma frobSq_nonneg (X : Matrix (Fin m) (Fin n) ℂ) : 0 ≤ frobSq X :=
-  sq_nonneg ‖X‖
-
 /-- The squared Frobenius norm is the sum of the squared entry norms. -/
 lemma frobSq_eq_sum (X : Matrix (Fin m) (Fin n) ℂ) :
     frobSq X = ∑ i : Fin m, ∑ j : Fin n, ‖X i j‖ ^ 2 := by

--- a/TNLean/Spectral/TransferOperatorGap.lean
+++ b/TNLean/Spectral/TransferOperatorGap.lean
@@ -82,7 +82,7 @@ theorem mixedTransferSpectralRadius_eq (A B : MPSTensor d D) :
 
 /-! ### Frobenius norm squared
 
-The definition and basic lemmas (`frobSq`, `frobSq_nonneg`, `frobSq_eq_zero_iff`,
+The definition and basic lemmas (`frobSq`, `frobSq_eq_zero_iff`,
 `frobSq_pos_of_ne_zero`, `frobSq_smul`, `frobSq_trace`, `matToES`, …) are
 provided by `TNLean.Spectral.FrobeniusNorm` for general rectangular matrices. -/
 
@@ -192,7 +192,10 @@ private lemma hs_contraction_mixedTransfer [NeZero D]
         Finset.sum_mul_sq_le_sq_mul_sq Finset.univ fA fB
     _ = (D : ℝ) * frobSq X := by rw [h_A, h_B]
     _ ≤ (D : ℝ) ^ 2 * frobSq X := by
-        nlinarith [sq_nonneg ((D : ℝ) - 1), frobSq_nonneg X,
+        nlinarith [sq_nonneg ((D : ℝ) - 1),
+          show 0 ≤ frobSq X from by
+            rw [frobSq]
+            exact sq_nonneg _,
           show (1 : ℝ) ≤ D from by exact_mod_cast NeZero.one_le (n := D)]
 
 /-! ### Eigenvalue bound -/

--- a/TNLean/Spectral/TransferOperatorGapRect.lean
+++ b/TNLean/Spectral/TransferOperatorGapRect.lean
@@ -153,7 +153,10 @@ private lemma hs_contraction_rect [NeZero D₁] [NeZero D₂]
         Finset.sum_mul_sq_le_sq_mul_sq Finset.univ fA fB
     _ = (D₁ : ℝ) * frobSq X := by rw [h_A, h_B]
     _ ≤ (D₁ : ℝ) ^ 2 * frobSq X := by
-        nlinarith [sq_nonneg ((D₁ : ℝ) - 1), frobSq_nonneg X,
+        nlinarith [sq_nonneg ((D₁ : ℝ) - 1),
+          show 0 ≤ frobSq X from by
+            rw [frobSq]
+            exact sq_nonneg _,
           show (1 : ℝ) ≤ D₁ from by exact_mod_cast NeZero.one_le (n := D₁)]
 
 end HSContraction

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -104,6 +104,8 @@ The clearest replacements are:
   same-state restatement in the row-cut obstruction example.
 - Three more PEPS example pass-through declarations were removed by inlining
   their immediate witnesses at the only proof sites where they were used.
+- The Frobenius-square nonnegativity wrapper `MPSTensor.frobSq_nonneg` was
+  removed; the two transfer estimates now unfold `frobSq` and use `sq_nonneg`.
 
 There are also important non-replacements.
 
@@ -819,6 +821,8 @@ Frobenius norm is now the foundation for matrix Hilbert-Schmidt arguments:
 `frobSq` is a squared Mathlib Frobenius norm, and the entrywise sum formula is
 kept as `frobSq_eq_sum` for trace and finite-sum arguments.  The local squared
 norm remains only as a convenience wrapper for downstream transfer estimates.
+The separate nonnegativity wrapper `MPSTensor.frobSq_nonneg` has been removed:
+the needed fact is exactly `sq_nonneg ‖X‖` after unfolding `frobSq`.
 
 The old `TNLean/Algebra/MatrixFrobenius.lean` pass-through file exposed only
 positive-definiteness of the identity matrix for the Frobenius inner product.
@@ -1476,6 +1480,8 @@ pass-throughs:
 - `TNLean.PEPS.Aunits_isNBlkInjective` and
   `TNLean.PEPS.Bunits_isNBlkInjective`.  These were one-use consequences of the
   standard one-block injectivity theorem.
+- `MPSTensor.frobSq_nonneg`.  This was the immediate square-nonnegativity fact
+  for the definition `frobSq X = ‖X‖ ^ 2`.
 
 ## Verification performed
 


### PR DESCRIPTION
### Motivation

- `frobSq_nonneg` in `TNLean.Spectral.FrobeniusNorm` restated `0 ≤ ‖X‖ ^ 2` for the definition `frobSq X = ‖X‖ ^ 2`; this follows immediately from `sq_nonneg` with no independent mathematical content.
- The Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`) identified this as a trivial restatement that qualifies for removal under the deprecation-policy exception for exact pass-through results.

### Description

- Deleted `frobSq_nonneg` from `TNLean/Spectral/FrobeniusNorm.lean`.
- Updated `TNLean/Spectral/TransferOperatorGap.lean` and `TNLean/Spectral/TransferOperatorGapRect.lean`: the square and rectangular Hilbert–Schmidt contraction steps now unfold `frobSq` locally and apply `sq_nonneg` directly.
- Recorded the deletion in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`.
- The rest of the Frobenius-square API is unchanged: `frobSq`, `frobSq_eq_sum`, `frobSq_trace`, positivity from nonzero matrices, scalar multiplication, and the Euclidean-space norm identities remain available.

No compatibility alias is provided — the old name encodes a pass-through layer with no independent mathematical statement (see [`docs/CONTRIBUTING.md` Section Mathematical-language renames](../blob/main/docs/CONTRIBUTING.md#mathematical-language-renames)).

### Testing

- `lake build TNLean.Spectral.FrobeniusNorm TNLean.Spectral.TransferOperatorGap TNLean.Spectral.TransferOperatorGapRect -q --log-level=info` succeeded.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` reported no new prose violations.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` and `lake exe checkdecls blueprint/lean_decls` confirmed no stale blueprint references.
- Full `lake build -q --log-level=info` completed with only pre-existing warnings and the known `TNLean/MPS/Periodic/Overlap/Case3.lean` `sorry` warning.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or theorem-statement changes beyond removing a trivial wrapper; spectral gap mathematics is unchanged.
> 
> **Overview**
> Removes the exported lemma **`MPSTensor.frobSq_nonneg`**, which only restated `0 ≤ ‖X‖ ^ 2` for `frobSq X = ‖X‖ ^ 2`.
> 
> The square and rectangular Hilbert–Schmidt contraction steps in **`TransferOperatorGap`** and **`TransferOperatorGapRect`** now unfold **`frobSq`** locally and use **`sq_nonneg`** instead of the wrapper. Module comments and the Mathlib 4.31 replacement audit document the deletion as a pass-through cleanup; the rest of the Frobenius-square API is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ebc5da51a44261370c5edc722652d3a32f49548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>