### PR TITLE
refactor(MPS): remove RFP example wrappers

### DIFF
--- a/TNLean/MPS/Examples/Cluster.lean
+++ b/TNLean/MPS/Examples/Cluster.lean
@@ -698,11 +698,6 @@ theorem clusterBlocked_transferMap_idempotent :
   simp only [Matrix.smul_apply, Matrix.one_apply, smul_eq_mul]
   fin_cases i <;> fin_cases j <;> norm_num
 
-/-- The length-`2` blocked cluster tensor is a renormalization fixed point: its
-transfer map is idempotent (`clusterBlocked_transferMap_idempotent`). -/
-theorem clusterBlocked_isRFP : IsRFP clusterBlocked :=
-  clusterBlocked_transferMap_idempotent
-
 end MPSTensor
 
 end

--- a/TNLean/MPS/Examples/ZeroCorrelationExamples.lean
+++ b/TNLean/MPS/Examples/ZeroCorrelationExamples.lean
@@ -26,8 +26,7 @@ the AKLT state).
 * `ghz_isZCL` — the GHZ tensor has zero correlation length
 * `clusterBlocked_isZCL` — the blocked cluster tensor has zero correlation length
 
-The supporting renormalization-fixed-point facts `clusterBlocked_isRFP` and
-`clusterBlocked_transferMap_idempotent` are proved in
+The supporting blocked-cluster transfer-map idempotence theorem is proved in
 `TNLean.MPS.Examples.Cluster`.
 
 ## References
@@ -55,10 +54,10 @@ theorem ghz_isZCL : IsZCL ghzTensor :=
 /-! ### Cluster -/
 
 /-- The blocked cluster tensor has zero correlation length: its idempotent
-transfer map (`clusterBlocked_isRFP`) yields correlations independent of the
+transfer map yields correlations independent of the
 separation.  The single-site cluster transfer map is not idempotent; blocking
 two sites produces the renormalization fixed point. -/
 theorem clusterBlocked_isZCL : IsZCL clusterBlocked :=
-  (zcl_iff_idempotent_transfer clusterBlocked).mpr clusterBlocked_isRFP
+  (zcl_iff_idempotent_transfer clusterBlocked).mpr clusterBlocked_transferMap_idempotent
 
 end MPSTensor

--- a/TNLean/MPS/MPDO/RFP.lean
+++ b/TNLean/MPS/MPDO/RFP.lean
@@ -41,10 +41,6 @@ variable {d D : ℕ}
 theorem isRFP_iff_isZCL (M : MPOTensor d D) : IsRFP M ↔ IsZCL M :=
   Iff.rfl
 
-/-- `IsRFP M` implies `IsZCL M`. -/
-theorem IsRFP.isZCL {M : MPOTensor d D} (h : IsRFP M) : IsZCL M :=
-  h
-
 /-- `IsRFP M` is equivalent to the pure-state RFP condition for the
 doubled-index MPS tensor. -/
 theorem isRFP_iff_toMPSTensor_isRFP (M : MPOTensor d D) :

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -106,6 +106,8 @@ The clearest replacements are:
   their immediate witnesses at the only proof sites where they were used.
 - The Frobenius-square nonnegativity wrapper `MPSTensor.frobSq_nonneg` was
   removed; the two transfer estimates now unfold `frobSq` and use `sq_nonneg`.
+- Two RFP/ZCL wrappers were removed: an unused MPDO implication method that
+  repeated `MPOTensor.isRFP_iff_isZCL`, and a one-use cluster-example RFP fact.
 
 There are also important non-replacements.
 
@@ -1482,6 +1484,10 @@ pass-throughs:
   standard one-block injectivity theorem.
 - `MPSTensor.frobSq_nonneg`.  This was the immediate square-nonnegativity fact
   for the definition `frobSq X = ‖X‖ ^ 2`.
+- `MPOTensor.IsRFP.isZCL`.  This was an unused implication method repeating the
+  blueprint-facing equivalence `MPOTensor.isRFP_iff_isZCL`.
+- `MPSTensor.clusterBlocked_isRFP`.  This was a one-use restatement of the
+  blueprint-facing theorem `MPSTensor.clusterBlocked_transferMap_idempotent`.
 
 ## Verification performed
 


### PR DESCRIPTION
### Motivation

- Two thin wrapper declarations in the RFP/ZCL formalization had no blueprint references and no independent proof content: `MPOTensor.IsRFP.isZCL` (an unused implication method duplicating `MPOTensor.isRFP_iff_isZCL`) and `MPSTensor.clusterBlocked_isRFP` (a one-use restatement of `clusterBlocked_transferMap_idempotent`). Their presence widened the public declaration surface without contributing any mathematical result.
- Both removals were identified in the Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`, lines 1487–1490).

### Description

- `TNLean/MPS/MPDO/RFP.lean`: removed `MPOTensor.IsRFP.isZCL`, an unused implication method repeating the blueprint-facing equivalence `MPOTensor.isRFP_iff_isZCL`; the equivalence itself is unchanged.
- `TNLean/MPS/Examples/Cluster.lean`: removed `MPSTensor.clusterBlocked_isRFP`, a one-use restatement of `clusterBlocked_transferMap_idempotent`.
- `TNLean/MPS/Examples/ZeroCorrelationExamples.lean`: updated `clusterBlocked_isZCL` to cite `clusterBlocked_transferMap_idempotent` directly via `zcl_iff_idempotent_transfer`, removing the intermediary call site.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: recorded both removals in the Mathlib 4.31 replacement audit.

No compatibility aliases are provided — both removed names were internal wrappers with no blueprint `\lean{}` references. The mathematical statements about zero correlation length and cluster transfer-map idempotence are unchanged.

### Testing

- `lake build TNLean.MPS.MPDO.RFP TNLean.MPS.Examples.Cluster TNLean.MPS.Examples.ZeroCorrelationExamples -q --log-level=info`
- `lake build TNLean -q --log-level=info` (root build; only pre-existing style warnings)
- `lake exe checkdecls blueprint/lean_decls` and `cd blueprint && leanblueprint checkdecls`
- `rg -n "\b(sorry|axiom)\b" TNLean -g "*.lean" -g "!TNLean/Archive/**"` (no new sorrys or axioms; known Lorentz-normal-form and periodic Case3 sorries remain)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-only cleanup with inlined witnesses; no change to mathematical statements or public API beyond removed aliases.
> 
> **Overview**
> Removes two **thin wrapper lemmas** with no independent proof content and wires call sites to the underlying theorems.
> 
> **MPDO:** deletes unused `MPOTensor.IsRFP.isZCL` (duplicate of `isRFP_iff_isZCL`). **Cluster examples:** deletes `MPSTensor.clusterBlocked_isRFP` and has `clusterBlocked_isZCL` use `clusterBlocked_transferMap_idempotent` directly through `zcl_iff_idempotent_transfer`. Module docs and the Mathlib 4.31 replacement audit are updated to match.
> 
> **Zero correlation length** and **blocked cluster transfer-map idempotence** are unchanged; only redundant declaration names are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a41b1ccbf324ec041e9d2ac452949c9f18fd946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>