### PR TITLE
refactor(Channel): use star-projection positivity

### DIFF
--- a/TNLean/Channel/Irreducible/Basic.lean
+++ b/TNLean/Channel/Irreducible/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Data.Matrix.Basis
+import Mathlib.Analysis.Matrix.Order
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.Tactic.NoncommRing
 
@@ -31,7 +32,7 @@ on matrix algebras `M_D(ℂ)`.
 * [Evans, Høegh-Krohn, *Spectral properties of positive maps*, 1978][Evans1978Spectral]
 -/
 
-open scoped Matrix ComplexOrder BigOperators
+open scoped Matrix ComplexOrder BigOperators MatrixOrder
 
 variable {D : ℕ}
 
@@ -41,14 +42,6 @@ variable {D : ℕ}
 These correspond to projections onto subspaces of `ℂ^D`. -/
 def IsOrthogonalProjection (P : Matrix (Fin D) (Fin D) ℂ) : Prop :=
   P.IsHermitian ∧ P * P = P
-
-/-- The zero matrix is an orthogonal projection. -/
-lemma isOrthogonalProjection_zero : IsOrthogonalProjection (0 : Matrix (Fin D) (Fin D) ℂ) :=
-  ⟨Matrix.isHermitian_zero, by simp only [Matrix.zero_mul]⟩
-
-/-- The identity matrix is an orthogonal projection. -/
-lemma isOrthogonalProjection_one : IsOrthogonalProjection (1 : Matrix (Fin D) (Fin D) ℂ) :=
-  ⟨Matrix.isHermitian_one, by simp only [Matrix.one_mul]⟩
 
 /-- An orthogonal projection is a star projection. -/
 theorem IsOrthogonalProjection.isStarProjection {P : Matrix (Fin D) (Fin D) ℂ}
@@ -64,6 +57,14 @@ theorem IsStarProjection.isOrthogonalProjection {P : Matrix (Fin D) (Fin D) ℂ}
   change Pᴴ = P
   simpa [Matrix.star_eq_conjTranspose] using hP.2
 
+/-- The zero matrix is an orthogonal projection. -/
+lemma isOrthogonalProjection_zero : IsOrthogonalProjection (0 : Matrix (Fin D) (Fin D) ℂ) :=
+  (IsStarProjection.zero (R := Matrix (Fin D) (Fin D) ℂ)).isOrthogonalProjection
+
+/-- The identity matrix is an orthogonal projection. -/
+lemma isOrthogonalProjection_one : IsOrthogonalProjection (1 : Matrix (Fin D) (Fin D) ℂ) :=
+  (IsStarProjection.one (R := Matrix (Fin D) (Fin D) ℂ)).isOrthogonalProjection
+
 /-- The complement of an orthogonal projection is an orthogonal projection. -/
 theorem IsOrthogonalProjection.one_sub {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) : IsOrthogonalProjection (1 - P) :=
@@ -72,10 +73,8 @@ theorem IsOrthogonalProjection.one_sub {P : Matrix (Fin D) (Fin D) ℂ}
 /-- An orthogonal projection is positive semidefinite. -/
 theorem isOrthogonalProjection_posSemidef {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) :
-    P.PosSemidef := by
-  have hPP : P = Pᴴ * P := by rw [hP.1, hP.2]
-  rw [hPP]
-  exact P.posSemidef_conjTranspose_mul_self
+    P.PosSemidef :=
+  Matrix.nonneg_iff_posSemidef.mp hP.isStarProjection.nonneg
 
 /-! ### Irreducibility of CP maps -/
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -108,6 +108,9 @@ The clearest replacements are:
   removed; the two transfer estimates now unfold `frobSq` and use `sq_nonneg`.
 - Two RFP/ZCL wrappers were removed: an unused MPDO implication method that
   repeated `MPOTensor.isRFP_iff_isZCL`, and a one-use cluster-example RFP fact.
+- The elementary orthogonal-projection witnesses for `0`, `1`, and positivity
+  now pass through Mathlib's `IsStarProjection.zero`, `IsStarProjection.one`,
+  `IsStarProjection.nonneg`, and `Matrix.nonneg_iff_posSemidef`.
 
 There are also important non-replacements.
 
@@ -749,6 +752,10 @@ Applied projection follow-up:
   predicate `IsOrthogonalProjection` with Mathlib's `IsStarProjection`.
   The complement theorem `IsOrthogonalProjection.one_sub` is proved through
   Mathlib's `IsStarProjection.one_sub`.
+- The elementary witnesses that `0` and `1` are orthogonal projections now use
+  Mathlib's corresponding star-projection constructors, and the proof that an
+  orthogonal projection is positive semidefinite now uses
+  `IsStarProjection.nonneg` followed by `Matrix.nonneg_iff_posSemidef`.
 - Duplicate complement-projection proofs were removed from
   `TNLean/MPS/Irreducible/Adjoint.lean`,
   `TNLean/Channel/Irreducible/FromSpectral.lean`, and


### PR DESCRIPTION
### Motivation

- The proofs of `isOrthogonalProjection_zero`, `isOrthogonalProjection_one`, and `isOrthogonalProjection_posSemidef` in `Channel/Irreducible/Basic.lean` reproduced facts already available via Mathlib's star-projection API, duplicating effort and diverging from the upstream library.
- Replacing the local derivations with `IsStarProjection.zero`, `IsStarProjection.one`, and `IsStarProjection.nonneg` reduces proof debt and aligns the channel-irreducibility layer with Mathlib 4.31.
- Records the additional projection cleanup in the ongoing Mathlib 4.31 replacement audit.

### Description

- `TNLean/Channel/Irreducible/Basic.lean`: rewrites three lemmas to delegate through Mathlib's star-projection API:
  - `isOrthogonalProjection_zero` — now via `IsStarProjection.zero` through the existing bridge between `IsStarProjection` and the local `IsOrthogonalProjection` predicate.
  - `isOrthogonalProjection_one` — analogously via `IsStarProjection.one`.
  - `isOrthogonalProjection_posSemidef` — now via `IsStarProjection.nonneg` composed with `Matrix.nonneg_iff_posSemidef`, replacing the prior derivation that rewrote the projection as `Pᴴ * P`.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records this additional projection cleanup.
- No theorem statements, type signatures, or blueprint declarations are changed.

### Testing

- `lake build TNLean.Channel.Irreducible.Basic -q --log-level=info`
- `lake build TNLean.Channel.Irreducible.FromSpectral TNLean.MPS.Irreducible.FixedPointProjection TNLean.MPS.Periodic.Overlap.Case3 -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `rg -n "\b(sorry|axiom)\b" TNLean -g '*.lean' -g '!TNLean/Archive/**'` — scan reports only existing sanctioned axiom boundary and known `sorry` declarations; this PR introduces none.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof-only refactor in foundational channel lemmas with unchanged statements; behavior should match prior proofs via Mathlib’s star-projection facts.
> 
> **Overview**
> **`TNLean/Channel/Irreducible/Basic.lean`** keeps the same `IsOrthogonalProjection` API but swaps three elementary proofs for Mathlib’s star-projection layer: `isOrthogonalProjection_zero` / `isOrthogonalProjection_one` now come from `IsStarProjection.zero` / `.one` via the existing `IsStarProjection` ↔ `IsOrthogonalProjection` bridge, and `isOrthogonalProjection_posSemidef` uses `IsStarProjection.nonneg` with `Matrix.nonneg_iff_posSemidef` instead of rewriting `P` as `Pᴴ * P`. The file adds `Mathlib.Analysis.Matrix.Order` and `open scoped MatrixOrder`, and moves the `0`/`1` lemmas below the bridge theorems.
> 
> The Mathlib 4.31 replacement audit documents this cleanup; **no theorem statements or downstream signatures change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46d233027732f76289e0271d0d7e3c0be444b0a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->