### PR TITLE
chore(MPS/CanonicalForm): remove cyclic-sector heartbeat

### DIFF
--- a/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
+++ b/TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean
@@ -104,10 +104,6 @@ theorem afterBlocking_perBlockCyclicData_of_sameMPV₂
       exists_primitive_irreducible_cyclic_sector_decomp_of_TP_of_isIrreducibleTensor
         (d := d) (D := dimB k) (blocksB k) (hTPB k) (hIrrB k)
 
-set_option maxHeartbeats 800000 in
--- The next theorem has a large dependent existential conclusion, matching the
--- CPSV witnesses used by the later sector comparison.
-
 /-- **Two-sided common-length relabeled cyclic-sector theorem.**
 
 Starting from `SameMPV₂ A B`, this theorem chooses one positive physical blocking

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -95,7 +95,8 @@ The clearest replacements are:
   blueprint points directly to the latter.
 - Further Lean 4.31 elaboration checks removed local heartbeat bounds from the
   POVM unitary-comparison proof, the irreducible-channel spectral-radius scalar
-  proof, and the semigroup perturbation derivative proof.
+  proof, the semigroup perturbation derivative proof, and the common
+  cyclic-sector data theorem.
 - The periodic-MPS equivalence bundles now cite the chain-level relation laws
   directly.  Six local theorem declarations that only restated reflexivity,
   symmetry, and transitivity for the periodic abbreviations were removed.
@@ -1116,6 +1117,11 @@ finite-dimensional Hilbert-space structure used in the rectangular isometry
 argument explicit.  The remaining local `maxHeartbeats` bound around the
 partial-isometry extension theorem was retested under Lean 4.31 and is still
 needed for elaboration.
+
+In `TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData`, the common
+positive-blocking-length cyclic-sector theorem now elaborates under the default
+Lean 4.31 heartbeat budget.  The local theorem-level `maxHeartbeats` override
+and its comment were removed.
 
 The determinant-one unitary-channel theorem no longer has the duplicate
 `channelDet_norm_eq_one_iff_exists_unitaryChannel_of_channel` restatement.  The


### PR DESCRIPTION
### Motivation

- The theorem-level `set_option maxHeartbeats 800000` override in `CommonSectorData.lean` was added as a workaround for slow elaboration. Under Lean 4.31, the theorem `afterBlocking_commonLengthCommonSectorData_of_sameMPV₂` elaborates within the default heartbeat budget, making the override obsolete.
- Update the Mathlib 4.31 replacement audit to record this heartbeat cleanup and note that `TNLean.Channel.KrausFreedom` still requires its own local bound after retesting.

### Description

- `TNLean/MPS/CanonicalForm/SectorComparison/CommonSectorData.lean`: remove the theorem-level `set_option maxHeartbeats 800000` and its explanatory comment (4 lines deleted); the proof body is unchanged.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: add an entry recording the heartbeat cleanup for `CommonSectorData` and confirming `TNLean.Channel.KrausFreedom` still needs its local bound.

### Testing

- `lake build TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData -q --log-level=info`
- `lake build TNLean.Channel.KrausFreedom -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `rg -n "\b(sorry|axiom)\b" TNLean -g "*.lean" -g "!TNLean/Archive/**"`

---
<!-- No linked issue found; author should link one if applicable. -->

> [!NOTE]
> **Low Risk**
> Proof-only elaboration tweak with no statement or logic changes; risk is limited to build/elaboration regressions on other Lean versions.
> 
> **Overview**
> Removes the theorem-level `set_option maxHeartbeats 800000` (and its explanatory comment) ahead of **`afterBlocking_commonLengthCommonSectorData_of_sameMPV₂`** in `CommonSectorData.lean`. Under **Lean 4.31**, that two-sided common blocking-length cyclic-sector witness now elaborates with the default heartbeat budget; the proof body is unchanged.
> 
> The Mathlib 4.31 replacement audit is updated to list this theorem among heartbeat cleanups and to note that **`TNLean.Channel.KrausFreedom`** still needs its own local bound after retesting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab28cfd5828e9c4ed21337ee383d66f689304068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>