### PR TITLE
chore(PEPS/TwoInjectiveComparison): drop redundant maxHeartbeats override

### DIFF
--- a/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
+++ b/TNLean/PEPS/TwoInjectiveComparison/Basic.lean
@@ -709,10 +709,6 @@ theorem gauge_inv
   · subst h; simp
   · rw [if_neg (fun hk => h hk.symm), if_neg h]
 
-set_option maxHeartbeats 400000 in
--- The `Classical`-derived `Fintype (SharedBondConfig bondDim)` instance is
--- noncomputable, so unifying it across the four gauge-extraction calls below
--- exceeds the default heartbeat budget; a modest raise keeps the proof robust.
 open scoped Classical in
 /-- **Bond gauge from the full contraction (operator-Schmidt uniqueness).**
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1394,6 +1394,16 @@ lake build TNLean.PEPS.PhysicalToVirtualCounterexample \
   TNLean.PEPS.TorusRowColumnReductionObstruction -q --log-level=info
 ```
 
+### PEPS two-injective heartbeat retest, 2026-06-19
+
+In `TNLean.PEPS.TwoInjectiveComparison.Basic`, the operator-Schmidt bond-gauge
+extraction theorem now elaborates under the default Lean 4.31 heartbeat budget.
+The local theorem-level `maxHeartbeats` override and its comment were removed.
+The diagonal-family lemma in
+`TNLean.Channel.Schwarz.PositiveOnAbelian.Consequences` was retested in the same
+pass and still times out at the default budget during the simultaneous
+diagonalization proof, so its local heartbeat bound remains.
+
 ### Trace-pairing extensionality, 2026-06-19
 
 Mathlib 4.31 has equality-form trace-pairing extensionality lemmas:


### PR DESCRIPTION
### Motivation

- Lean 4.31 no longer requires a local heartbeat raise for `exists_bondGauge_of_fullContraction` in `TNLean/PEPS/TwoInjectiveComparison/Basic.lean`; the operator-Schmidt bond-gauge extraction theorem now elaborates within the default budget.
- The Mathlib 4.31 replacement audit document is updated to record this improvement and to confirm that the diagonal-family lemma in `TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean` still requires its retained `maxHeartbeats` bound.

### Description

- `TNLean/PEPS/TwoInjectiveComparison/Basic.lean`: deleted `set_option maxHeartbeats 400000` and its explanatory comment; the proof body of `exists_bondGauge_of_fullContraction` is unchanged.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: added 8 lines recording that `exists_bondGauge_of_fullContraction` now elaborates at the default heartbeat budget, and that the positive-on-abelian diagonal-family lemma retains its bound.

### Testing

- `lake build TNLean.PEPS.TwoInjectiveComparison.Basic -q --log-level=info`
- `lake build TNLean.Channel.Schwarz.PositiveOnAbelian.Consequences -q --log-level=info`
- `rg -n "\b(sorry|axiom)\b" TNLean -g "*.lean" -g "!TNLean/Archive/**"` (no new sorrys)
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

> [!NOTE]
> **Low Risk**
> Proof-only elaboration cleanup with no statement or logic changes; audit documentation only elsewhere.
>
> **Overview**
> **Lean 4.31** no longer needs a local heartbeat raise for `exists_bondGauge_of_fullContraction` in `TNLean.PEPS.TwoInjectiveComparison.Basic`: the `set_option maxHeartbeats 400000` line and its explanatory comment are deleted; the proof body is unchanged.
>
> The **Mathlib 4.31 replacement audit** is updated to note that this theorem now elaborates at the default budget, while the diagonal-family lemma in `TNLean.Channel.Schwarz.PositiveOnAbelian.Consequences` was retested and **still** requires its retained `maxHeartbeats` bound.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa27de4bf6e05f0a2db85a1bb63a4cba411be868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>