### PR TITLE
chore(Channel/Semigroup/Basic): drop maxHeartbeats overrides

### DIFF
--- a/TNLean/Channel/Semigroup/Basic.lean
+++ b/TNLean/Channel/Semigroup/Basic.lean
@@ -248,9 +248,6 @@ theorem expSemigroup_toCLM
     endEquiv (expSemigroup L t) = expSemigroupCLM (endEquiv L) t := by
   simp [expSemigroup, AlgEquiv.apply_symm_apply]
 
-set_option maxHeartbeats 1000000 in
--- The derivative proof combines CLM-valued differentiation with a restricted-
--- scalars bilinear evaluation map; elaboration is otherwise too expensive.
 /-- The derivative of `t ↦ exp(tL)(X)` at time `t` is `exp(tL)(L X)`. -/
 theorem hasDerivAt_expSemigroup_apply
     (L : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -353,8 +350,6 @@ theorem expSemigroup_isContinuousDynSemigroup
 
 /-! ## Proposition 7.1: Continuous semigroup → exp(tL) -/
 
-set_option maxHeartbeats 1200000 in
--- The interval-integral differentiability argument triggers a heavy normalization step.
 /-- In a finite-dimensional normed algebra, the Bochner integral `(1/ε) • ∫₀^ε S(t) dt`
 is close to `S(0) = 1` for small `ε`, hence invertible. From this and the semigroup
 property, `S` is right-differentiable at `0`.
@@ -542,8 +537,6 @@ private theorem continuous_semigroup_hasDerivWithinAt_zero
     rwa [mul_assoc, Units.mul_inv, mul_one] at hmul
   exact hder.hasDerivWithinAt.congr hS_eq (hS_eq 0 (Set.mem_Ici.mpr (le_refl 0)))
 
-set_option maxHeartbeats 800000 in
--- The ODE uniqueness step over CLM endomorphisms needs extra heartbeats for elaboration.
 /-- **Wolf Proposition 7.1** (continuous semigroup → exponential form):
 Every norm-continuous dynamical semigroup on the finite-dimensional algebra
 `M_D(ℂ)` is of the form `T_t = exp(t • L)` for a unique generator `L`. -/
@@ -642,8 +635,6 @@ theorem continuousDynSemigroup_eq_exp
       simpa [show u + (v - u) = v by ring] using hS_add u (v - u) hu hvt)
     (by simp [hS_zero])
 
-set_option maxHeartbeats 800000 in
--- Comparing the one-sided derivatives of two exponential semigroups is elaboration-heavy.
 /-- Uniqueness of the generator: if `exp(t•L) = exp(t•L')` for all `t ≥ 0`,
 then `L = L'`. Proof: both CLM semigroups agree on `[0,∞)`, hence their
 derivatives within `[0,∞)` at `t = 0` agree. Since `[0,∞)` has unique

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1103,6 +1103,12 @@ elaborates under the default Lean 4.31 budget.  The same pass removed two inert
 proof-normalization steps from `TNLean.Channel.Semigroup.LindbladForm.Basic`
 that Lean 4.31 reports as unused.
 
+A subsequent check of `TNLean.Channel.Semigroup.Basic` removed the four
+remaining theorem-level heartbeat bounds in that file.  Lean 4.31 now
+elaborates the exponential-semigroup derivative, the one-sided differentiability
+lemma for continuous semigroups, the exponential-form theorem, and generator
+uniqueness under the default heartbeat budget.
+
 In `TNLean.Channel.POVM.Uniqueness`, the Gram-matrix comparison theorem
 `exists_unitary_mul_eq_of_conjTranspose_mul_eq` no longer needs its old local
 heartbeat bound.  Its proof already names the Euclidean-space inner-product and


### PR DESCRIPTION
### Motivation

- Following the Mathlib 4.31 upgrade (PR LionSR/TNLean#3006), Lean elaborates the
  CLM-valued semigroup derivative, the interval-integral differentiability
  argument, Wolf Proposition 7.1 (exponential form of a continuous semigroup),
  and generator uniqueness within the default heartbeat budget. The four
  theorem-level `set_option maxHeartbeats` overrides in
  `TNLean/Channel/Semigroup/Basic.lean` are no longer needed.
- Removes obsolete performance annotations, keeping the file aligned with
  the Mathlib 4.31 replacement audit
  (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`).

### Description

- `TNLean/Channel/Semigroup/Basic.lean`: removed four `set_option maxHeartbeats`
  overrides and their associated comment lines from:
  - `hasDerivAt_expSemigroup_apply` (was 1 000 000 heartbeats)
  - `continuous_semigroup_hasDerivWithinAt_zero` (was 1 200 000 heartbeats)
  - `continuousDynSemigroup_eq_exp` — Wolf Proposition 7.1 (was 800 000 heartbeats)
  - generator-uniqueness theorem (was 800 000 heartbeats)
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: added a
  paragraph recording this removal in the Mathlib 4.31 audit log.
- No `sorry` or `axiom` introduced.

### Testing

- `lake build TNLean.Channel.Semigroup.Basic -q --log-level=info`
- `! rg -n "set_option maxHeartbeats" TNLean/Channel/Semigroup/Basic.lean`
- `rg -n "\b(sorry|axiom)\b" TNLean -g "*.lean" -g "!TNLean/Archive/**"`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a4b00bfbf46e28eab4f357ea790c9cc0f32bc17c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->