### PR TITLE
chore(Channel/Semigroup): remove Lindblad heartbeats

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -63,9 +63,6 @@ private def sandRCLM (D : ℕ) (P : MatChoi D) : MatChoi D →L[ℝ] MatChoi D :
 
 /-! ## Proposition 7.3: CP semigroup ↔ CCP generator (Wolf Proposition 7.3) -/
 
-set_option maxHeartbeats 2000000 in
--- The proof composes CLM-valued derivatives with Choi/projected-Choi maps and
--- then takes one-sided slope limits; source elaboration otherwise times out.
 /-- **Wolf Proposition 7.3 (direction 1 → 2)**: If `T_t = exp(tL)` is a semigroup
 of completely positive maps, then `L` is conditionally completely positive.
 
@@ -258,9 +255,6 @@ private theorem quadMap_apply (G : GeneratorDecomp D) (ρ : sgMat D) :
     quadMap G ρ = G.κ * ρ * G.κᴴ := by
   simp [quadMap, Kraus.mapLM_apply, Kraus.map_apply]
 
-set_option maxHeartbeats 800000 in
--- Expanding the one-step Kraus map into the generator-plus-quadratic form
--- needs extra normalization heartbeats, but only in this local theorem.
 private theorem eulerStep_apply (G : GeneratorDecomp D) (s : ℝ) (ρ : sgMat D) :
     eulerStep G s ρ =
       ρ + s • (G.φ ρ + -(G.κ * ρ) + -(ρ * G.κᴴ)) + (s * s) • (G.κ * ρ * G.κᴴ) := by
@@ -313,9 +307,6 @@ private theorem eulerStep_toCLM_eq (G : GeneratorDecomp D) (s : ℝ) :
   simp only [Matrix.add_apply, Matrix.smul_apply, Matrix.neg_apply, Complex.real_smul,
     Complex.ofReal_mul, Complex.coe_smul, smul_eq_mul, sub_eq_add_neg, pow_two]
 
-set_option maxHeartbeats 1000000 in
--- The specialization of the generic exponential remainder estimate to CLM endomorphisms
--- requires a large normalization simp step.
 private theorem norm_expSemigroupCLM_sub_one_add_smul_le [NeZero D]
     (A : sgCLM D) {s : ℝ} (hs : 0 ≤ s) :
     ‖expSemigroupCLM A s - (1 + (s : ℂ) • A)‖ ≤ s ^ 2 * ‖A‖ ^ 2 * Real.exp (s * ‖A‖) := by

--- a/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
@@ -79,8 +79,6 @@ private lemma expSemigroupCLM_mul_comm_local
     simp
   exact hc.exp_left.eq
 
-set_option maxHeartbeats 2000000 in
--- The chain-rule / derivative-normalization proof below is source-level expensive on CLMs.
 /-- CLM-level version: trace-annihilating → trace constant under exp semigroup. -/
 private lemma trace_expSemigroupCLM_eq
     (L_CLM : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -141,8 +139,6 @@ theorem isTracePreservingMap_expSemigroup_of_isTraceAnnihilating
   exact trace_expSemigroupCLM_eq L_CLM hTA_CLM t ρ
 
 
-set_option maxHeartbeats 2000000 in
--- The right-derivative / slope comparison argument is source-level expensive on semigroup CLMs.
 /-- If `exp(tL)` is trace-preserving for all `t ≥ 0`, then `L` is trace-annihilating.
 
 **Proof**: The function `f(t) = trace(exp(tL)(ρ))` satisfies `f(t) = trace(ρ)` for

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1264,6 +1264,26 @@ lake build TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression \
   TNLean.Channel.Semigroup.RelaxationConditions -q --log-level=info
 ```
 
+### Lindblad-form heartbeat retest, 2026-06-19
+
+`TNLean.Channel.Semigroup.LindbladForm.EulerStep` no longer needs its three
+theorem-level heartbeat bounds.  Lean 4.31 now elaborates the conditional
+complete-positivity direction of Wolf Proposition 7.3, the one-step Kraus-map
+expansion, and the CLM exponential-remainder estimate under the default
+heartbeat budget.
+
+The same retest removed the two theorem-level heartbeat bounds from
+`TNLean.Channel.Semigroup.LindbladForm.TraceBridge`: the CLM trace-constant
+lemma and the right-derivative trace-annihilation theorem also elaborate under
+the default budget.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Semigroup.LindbladForm.EulerStep \
+  TNLean.Channel.Semigroup.LindbladForm.TraceBridge -q --log-level=info
+```
+
 ### Further projection-complement proof reductions, 2026-06-19
 
 A second pass replaced remaining handwritten complement identities of the form


### PR DESCRIPTION
## Summary

- remove three theorem-level `maxHeartbeats` overrides from `TNLean.Channel.Semigroup.LindbladForm.EulerStep`
- remove two theorem-level `maxHeartbeats` overrides from `TNLean.Channel.Semigroup.LindbladForm.TraceBridge`
- record that Lean 4.31 now elaborates these Lindblad-form semigroup proofs at the default heartbeat budget

## Validation

- `lake build TNLean.Channel.Semigroup.LindbladForm.EulerStep TNLean.Channel.Semigroup.LindbladForm.TraceBridge -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `! rg -n "set_option maxHeartbeats" TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean`
- `rg -n "\b(sorry|axiom)\b" TNLean -g "*.lean" -g "!TNLean/Archive/**"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only maintenance with no statement changes; risk is limited to possible reintroduction of elaboration timeouts on older Lean versions or if dependencies regress.
> 
> **Overview**
> Removes **five** theorem-level `set_option maxHeartbeats` overrides that were added under Lean 4.29 so heavy Lindblad semigroup proofs would elaborate. **No theorem statements or proof logic change**—only the local heartbeat budget lines and their comments go away.
> 
> In **`EulerStep.lean`**, the default budget now suffices for Wolf Proposition 7.3’s CP→CCP direction (`cp_semigroup_implies_ccp_generator`), the one-step Kraus/Euler map expansion (`eulerStep_apply`), and the CLM exponential remainder bound (`norm_expSemigroupCLM_sub_one_add_smul_le`).
> 
> In **`TraceBridge.lean`**, the same retest drops overrides on the CLM trace-constant lemma under a trace-annihilating generator (`trace_expSemigroupCLM_eq`) and on trace-preserving semigroups implying trace-annihilation (`isTraceAnnihilating_of_isTracePreservingMap_semigroup`).
> 
> The Mathlib 4.31 audit doc gains a **Lindblad-form heartbeat retest** section recording the focused `lake build` on `EulerStep` and `TraceBridge`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eff678f13f5c2682774de4c53ee06fc59e41c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->