### PR TITLE
chore(Channel/Semigroup): remove primitivity heartbeat

### DIFF
--- a/TNLean/Channel/Semigroup/Primitivity/Basic.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Basic.lean
@@ -88,8 +88,6 @@ structure IsQuantumDynSemigroup
 If `λ` is an eigenvalue of `exp(t₀ · L)`, then `λ^(t/t₀)` is an eigenvalue
 of `exp(t · L)`. This uses `spectrum.exp_mem_exp`. -/
 
-set_option maxHeartbeats 5000000 in
--- The spectral-mapping step uses `spectrum.exp_mem_exp` on a large CLM expression.
 /-- If `μ` is an eigenvalue of `L`, then `exp(t · μ)` is an eigenvalue of
 `exp(t · L)` (spectral mapping theorem for exp). -/
 theorem eigenvalue_exp_of_eigenvalue_generator

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1578,6 +1578,20 @@ lake build TNLean.QPF.PosDef TNLean.Channel.MaximallyEntangled \
   TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info
 ```
 
+### Semigroup primitivity heartbeat retest, 2026-06-19
+
+`TNLean.Channel.Semigroup.Primitivity.Basic` no longer needs its local heartbeat
+bound around the spectral-mapping theorem
+`eigenvalue_exp_of_eigenvalue_generator`.  Lean 4.31 elaborates the
+`spectrum.exp_mem_exp` argument for the finite-dimensional CLM algebra under
+the default heartbeat budget.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Semigroup.Primitivity.Basic -q --log-level=info
+```
+
 The final root build also succeeds:
 
 ```text


### PR DESCRIPTION
### Motivation

- Under Lean 4.29, the spectral-mapping theorem `eigenvalue_exp_of_eigenvalue_generator`
  in `TNLean.Channel.Semigroup.Primitivity.Basic` required `set_option maxHeartbeats 5000000`
  because `spectrum.exp_mem_exp` on a large continuous-linear-map algebra exceeded the default
  elaboration budget.
- A focused retest under Lean 4.31 confirms the override is no longer needed: the
  `spectrum.exp_mem_exp` argument for the finite-dimensional CLM algebra now elaborates within
  the default heartbeat budget. This finding is recorded in the Mathlib 4.31 replacement audit
  (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`, §"Semigroup primitivity
  heartbeat retest, 2026-06-19").

### Description

- `TNLean/Channel/Semigroup/Primitivity/Basic.lean`: remove `set_option maxHeartbeats 5000000`
  and its explanatory comment (2 lines deleted; no proof body or statement change).
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: add the
  "Semigroup primitivity heartbeat retest, 2026-06-19" section documenting the focused build
  check and its outcome.

### Testing

- `lake build TNLean.Channel.Semigroup.Primitivity.Basic -q --log-level=info` — focused check
  confirming the default budget suffices.
- `! rg -n "set_option maxHeartbeats" TNLean/Channel/Semigroup/Primitivity/Basic.lean` — no
  override remains.
- `rg -n "\b(sorry|axiom)\b" TNLean -g "*.lean" -g "!TNLean/Archive/**"` — no new sorrys
  introduced.
- Lean CI (`lean_action_ci.yml`) validates the full build.

---

> [!NOTE]
> **Low Risk**
> Proof-only cleanup with no statement or logic changes; risk is limited to possible elaboration regressions on older Lean versions, which the documented build check mitigates.
>
> **Overview**
> **Lean 4.31** no longer needs a theorem-level heartbeat bump for the spectral-mapping lemma `eigenvalue_exp_of_eigenvalue_generator` in `TNLean.Channel.Semigroup.Primitivity.Basic`. The PR removes the surrounding `set_option maxHeartbeats 5000000` and its explanatory comment; the proof body is unchanged.
>
> The Mathlib 4.31 replacement audit gains a **2026-06-19** note that `spectrum.exp_mem_exp` elaborates for the finite-dimensional CLM algebra under the default budget, with a focused `lake build TNLean.Channel.Semigroup.Primitivity.Basic` check.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f524b8a16c68a3f5abf28bd5ad38d23e3c25fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>