### PR TITLE
chore(Channel/Semigroup): remove subsequence heartbeat

### DIFF
--- a/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
@@ -265,8 +265,6 @@ private theorem compression_eq_limit_of_tendsto
       (fun n => hρ_PMP (φ n)))
     hφ_tendsto
 
-set_option maxHeartbeats 4000000 in
--- Needed for the Taylor remainder normalization step inside the subsequence limit argument.
 private theorem generator_vanishes_at_limit
     [NeZero D]
     {L : Mat →ₗ[ℂ] Mat}

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1317,6 +1317,19 @@ lake build TNLean.Channel.Semigroup.LindbladForm.EulerStep \
   TNLean.Channel.Semigroup.LindbladForm.TraceBridge -q --log-level=info
 ```
 
+### Reducible-QDS subsequence heartbeat retest, 2026-06-19
+
+`TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis` no longer needs its
+theorem-level heartbeat bound around the subsequence-limit argument
+`generator_vanishes_at_limit`.  Lean 4.31 elaborates the Taylor-remainder
+normalization step under the default heartbeat budget.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis -q --log-level=info
+```
+
 ### Further projection-complement proof reductions, 2026-06-19
 
 A second pass replaced remaining handwritten complement identities of the form


### PR DESCRIPTION
### Motivation

- `generator_vanishes_at_limit` in `TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean`
  previously required a theorem-level `set_option maxHeartbeats 4000000` override because
  Lean 4.29 needed extra elaboration budget for the Taylor-remainder normalization step
  in the subsequence-limit argument.
- Lean 4.31 (the current toolchain) elaborates this theorem under the default heartbeat budget,
  making the override unnecessary. This was confirmed during the Mathlib 4.31 replacement audit
  (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`, §Reducible-QDS subsequence heartbeat retest).

### Description

- `TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean`: removes the
  `set_option maxHeartbeats 4000000` wrapper and its comment around
  `generator_vanishes_at_limit`. The proof body is unchanged.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records the focused retest
  confirming the heartbeat bound is no longer needed under Lean 4.31.

### Testing

- `lake build TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis -q --log-level=info`
- `! rg -n "set_option maxHeartbeats" TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean`
- `rg -n "\\b(sorry|axiom)\\b" TNLean -g "*.lean" -g "!TNLean/Archive/**"`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`

---
<!-- No linked issue found for this maintenance item. If one exists, replace this comment with: Addresses #N -->

> [!NOTE]
> **Low Risk**
> Proof-only elaboration cleanup with no statement or logic changes; risk is limited to possible regressions on older Lean versions that still needed the heartbeat bump.
>
> **Overview**
> Removes the theorem-level `set_option maxHeartbeats 4000000` wrapper and its comment around **`generator_vanishes_at_limit`** in `SubsequenceAnalysis.lean`. The proof is unchanged; Lean **4.31** now elaborates the Taylor-remainder normalization in that subsequence-limit argument under the default heartbeat budget.
>
> The Mathlib 4.31 replacement audit documents this retest and the focused `lake build TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis` check.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0172aed63fc9be2fcff169bc2bd56c1a8f7a36b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only elaboration cleanup with no statement or logic changes; risk is mainly building on an older Lean that still needed the heartbeat bump.
> 
> **Overview**
> Removes the theorem-level `set_option maxHeartbeats 4000000` wrapper and its explanatory comment around **`generator_vanishes_at_limit`** in `SubsequenceAnalysis.lean`. The proof is unchanged; Lean **4.31** elaborates the Taylor-remainder normalization in that subsequence-limit step under the default heartbeat budget.
> 
> The Mathlib 4.31 replacement audit adds a **Reducible-QDS subsequence heartbeat retest** note documenting the focused `lake build TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis` check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb40616b700201cc947479dd1889b7c78b12066f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->