### PR TITLE
chore(MPS/ParentHamiltonian): remove wrapping-window heartbeats

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -331,9 +331,6 @@ Use \(\operatorname{tr}(P \cdot Q) = \operatorname{tr}(Q \cdot P)\) to rotate
 across the periodic boundary,
 then extract a matrix equation via `groundSpaceMap_injective`. -/
 
-set_option maxHeartbeats 800000 in
--- Expanding `cyclicCfg` and rotating the trace across the periodic boundary produces
--- large normalization goals, so this proof needs a larger heartbeat budget.
 private theorem wrapping_window_matEq {A : MPSTensor d D} [NeZero D]
     (hA : IsInjective A) {L : ℕ} (hL : 1 < L) {M : ℕ} (hM : 1 ≤ M) (hLN : L ≤ M + 1)
     {X : Matrix (Fin D) (Fin D) ℂ}
@@ -888,9 +885,6 @@ theorem left_witness_unique_of_isNBlkInjective
         f (1 : Matrix (Fin D) (Fin D) ℂ)) hmul
   simpa using h1
 
-set_option maxHeartbeats 800000 in
--- The double spanning argument over window tails and complements creates large
--- `LinearMap.ext_on_range` goals, so we raise the heartbeat budget here as well.
 /-- If `groundSpaceMap A N X` lies in every cyclic window's ground space,
 then \(X\) commutes with all generators \(A_j\).
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -743,6 +743,20 @@ Applied martingale follow-up:
   `LinearMap.IsPositive.smul_of_nonneg` directly, with the scalar nonnegativity
   discharged by `positivity` under `ComplexOrder`.
 
+Applied wrapping-window follow-up:
+
+- The two theorem-level `maxHeartbeats` bounds in
+  `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean` were removed.  Under Lean
+  4.31, both the trace-rotation extraction lemma `wrapping_window_matEq` and
+  the boundary commutation theorem `boundary_matrix_commutes` elaborate under
+  the default heartbeat budget.
+
+Focused check:
+
+```bash
+lake build TNLean.MPS.ParentHamiltonian.WrappingWindow -q --log-level=info
+```
+
 Applied projection follow-up:
 
 - `TNLean/Channel/Irreducible/Basic.lean` now bridges the local matrix


### PR DESCRIPTION
### Motivation

- `wrapping_window_matEq` and `boundary_matrix_commutes` in `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean` carried theorem-level `set_option maxHeartbeats 800000` overrides added for an earlier toolchain version.
- Under Lean 4.31 / Mathlib 4.31, both proofs elaborate within the default heartbeat budget, making the overrides unnecessary.

### Description

- `TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`: removed two `set_option maxHeartbeats 800000` blocks (six lines total) from the proofs of `wrapping_window_matEq` and `boundary_matrix_commutes`. Proof scripts are unchanged; only the elaboration-budget overrides and inline comments are removed.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: added an entry recording that both lemmas elaborate within Lean's default heartbeat limit after the Mathlib 4.31 upgrade.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.WrappingWindow -q --log-level=info` confirms no timeout after removal.
- `rg -n "set_option maxHeartbeats" TNLean/MPS/ParentHamiltonian/WrappingWindow.lean` confirms removal.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` and `python3 scripts/blueprint_lean_sync.py --root . --ci`.
- `lake exe checkdecls blueprint/lean_decls`.

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No proof or API changes—only removed compiler limits and audit notes; behavior of the periodic boundary commutation chain is unchanged.
> 
> **Overview**
> Removes two theorem-level `set_option maxHeartbeats 800000` blocks from **`TNLean/MPS/ParentHamiltonian/WrappingWindow.lean`** for **`wrapping_window_matEq`** and **`boundary_matrix_commutes`**. Proof scripts are unchanged; only the elaboration budget overrides and their comments go away.
> 
> The Mathlib 4.31 audit doc now records that both lemmas elaborate under Lean's **default** heartbeat limit after the upgrade, with **`lake build TNLean.MPS.ParentHamiltonian.WrappingWindow`** as the focused check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3293ddf62d78de80d1f2d36093c689ebc1695634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->