### PR TITLE
chore(Channel/Schwarz): remove abelian-characterization heartbeats

### DIFF
--- a/TNLean/Channel/Schwarz/PositiveOnAbelian/Characterization.lean
+++ b/TNLean/Channel/Schwarz/PositiveOnAbelian/Characterization.lean
@@ -152,9 +152,6 @@ private lemma weighted_block_sum_posSemidef {n D : ℕ}
 -- the block quadratic form is nonneg whenever every scalar matrix is PSD.
 -- Proved via the joint-eigenspace decomposition
 -- (LinearMap.IsSymmetric.directSum_isInternal_of_pairwise_commute).
-set_option maxHeartbeats 1600000 in
--- Elaborating the joint-eigenspace decomposition and the finite-index reduction
--- requires more heartbeats than the default.
 private lemma blockForm_nonneg_of_scalarPSD_of_commuting {n D : ℕ}
     (M : Fin n → Fin n → Matrix (Fin D) (Fin D) ℂ)
     (hMadj : ∀ i j, (M j i)ᴴ = M i j)
@@ -440,9 +437,6 @@ private lemma blockForm_nonneg_of_scalarPSD_of_commuting {n D : ℕ}
       intro j _
       rw [← hformTerm i j]
 
-set_option maxHeartbeats 1600000 in
--- Elaborating the simultaneous-diagonalization argument expands enough definitions
--- that the default heartbeat limit may time out.
 theorem quadraticForm_nonneg_of_isPositiveMap_of_commuting_images
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsPositiveMap T)

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -133,6 +133,13 @@ There are also important non-replacements.
   `BlockTriangular.pow`; the local `evalWord` inductions remain necessary
   unless the word-product arguments are reorganized through a submonoid or
   subsemiring construction.
+- The `SO(3)` Euler-angle factorization in
+  `TNLean/MPS/Examples/AKLTRotation.lean` remains local.  Mathlib 4.31 provides
+  the special-orthogonal group interface, a two-dimensional membership
+  characterization, and the `Complex.arg` trigonometric identities used by the
+  local proof, but it does not provide a direct `SO(3)` Euler decomposition.
+  Removing the theorem-level `maxHeartbeats` bound from `so3_euler_decomp`
+  still times out at the default budget.
 
 ## Mathlib 4.31 material found
 
@@ -1154,6 +1161,19 @@ In `TNLean.MPS.CanonicalForm.SectorComparison.CommonSectorData`, the common
 positive-blocking-length cyclic-sector theorem now elaborates under the default
 Lean 4.31 heartbeat budget.  The local theorem-level `maxHeartbeats` override
 and its comment were removed.
+
+In `TNLean.Channel.Schwarz.PositiveOnAbelian.Characterization`, the two
+simultaneous-diagonalization results no longer need theorem-level heartbeat
+bounds.  Lean 4.31 elaborates both
+`blockForm_nonneg_of_scalarPSD_of_commuting` and
+`quadraticForm_nonneg_of_isPositiveMap_of_commuting_images` under the default
+budget.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Schwarz.PositiveOnAbelian.Characterization -q --log-level=info
+```
 
 The determinant-one unitary-channel theorem no longer has the duplicate
 `channelDet_norm_eq_one_iff_exists_unitaryChannel_of_channel` restatement.  The


### PR DESCRIPTION
### Motivation

- The simultaneous-diagonalization proofs in `TNLean.Channel.Schwarz.PositiveOnAbelian.Characterization` carried theorem-level `set_option maxHeartbeats 1600000` overrides (8× the project default). After the Lean 4.31 / Mathlib 4.31 upgrade (PR #3006) the default elaboration budget suffices; these overrides are now dead weight.
- Removing them reduces the set of local heartbeat exceptions that must be monitored across future toolchain bumps.

### Description

- `TNLean/Channel/Schwarz/PositiveOnAbelian/Characterization.lean`: removed `set_option maxHeartbeats 1600000` from two proofs — the private lemma `blockForm_nonneg_of_scalarPSD_of_commuting` and the main theorem `quadraticForm_nonneg_of_isPositiveMap_of_commuting_images`. Mathematical content and proof steps are unchanged; only the compiler budget setting is removed.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: updated to record that both simultaneous-diagonalization results in `Channel/Schwarz` build within default heartbeats on Lean 4.31. Also documents that `so3_euler_decomp` in `TNLean/MPS/Examples/AKLTRotation.lean` retains its local `maxHeartbeats` bound — Mathlib 4.31 does not yet provide a direct `SO(3)` Euler decomposition (see issue #2291), so that override is not removed in this PR.

### Testing

- `lake build TNLean.Channel.Schwarz.PositiveOnAbelian.Characterization -q --log-level=info`
- `lake build TNLean.MPS.Examples.AKLTRotation -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
<!-- No linked issue identified — please link one manually if applicable. -->

> [!NOTE]
> **Low Risk**
> Proof-only elaboration tuning and documentation; no statement or logic changes to the Schwarz characterization theorems.
>
> **Overview**
> **Lean 4.31 elaboration cleanup** for the Schwarz positive-on-abelian chain: the private lemma `blockForm_nonneg_of_scalarPSD_of_commuting` and the main theorem `quadraticForm_nonneg_of_isPositiveMap_of_commuting_images` no longer wrap their proofs in `set_option maxHeartbeats 1600000`. The mathematical proofs are unchanged; only the compiler budget overrides are removed because default heartbeats suffice on 4.31.
>
> The Mathlib 4.31 replacement audit is updated to record that both simultaneous-diagonalization results in `TNLean.Channel.Schwarz.PositiveOnAbelian.Characterization` build without theorem-level heartbeat bounds, with the focused `lake build` check noted. It also clarifies that **`SO(3)` Euler-angle factorization** in `TNLean/MPS/Examples/AKLTRotation.lean` remains local — Mathlib still has no direct `SO(3)` Euler decomposition, and removing `maxHeartbeats` from `so3_euler_decomp` still times out at the default budget (that bound is **not** removed in this PR).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21f91294196c82b397bc6bb585fe158fc257e6ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Elaboration-only cleanup with no theorem or proof logic changes; risk is limited to possible heartbeat regressions on other Lean versions.
> 
> **Overview**
> After the Lean 4.31 / Mathlib 4.31 upgrade, **`TNLean/Channel/Schwarz/PositiveOnAbelian/Characterization.lean`** no longer needs `set_option maxHeartbeats 1600000` on **`blockForm_nonneg_of_scalarPSD_of_commuting`** or **`quadraticForm_nonneg_of_isPositiveMap_of_commuting_images`**. Proofs are unchanged; only the per-theorem heartbeat overrides and their comments are removed.
> 
> **`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`** records that both results build under the default budget, with the focused `lake build TNLean.Channel.Schwarz.PositiveOnAbelian.Characterization` check. The audit also notes that **`so3_euler_decomp`** in AKLT rotation still needs a local heartbeat bound and that a related diagonal-family lemma in **`Consequences.lean`** was retested and still times out at default — outside this PR’s scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b44116885343257f3ba1e2d2c1acf00e71ed438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->