### PR TITLE
chore(Spectral): remove transfer-gap synthesis heartbeat

### DIFF
--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -174,9 +174,6 @@ private theorem eigenvector_gives_gauge_of_irreducible_TP [NeZero D]
     (A := A) (B := B) (SA := SA) (SB := SB) (X' := X') (μ := μ)
     hSA_det hSB_det hX'u hμ hInter2
 
-set_option synthInstance.maxHeartbeats 200000 in
--- The non-rectangular spectral-radius extraction still spends extra time finding
--- the continuous-linear-map completeness structure used by `exists_mem_spectrum_of_isAlgClosed`.
 /-- If the mixed transfer spectral radius of two irreducible left-canonical tensors is at least
 `1`, then the tensors are gauge-phase equivalent. -/
 theorem modulus_one_eigenvalue_implies_gauge_of_irreducible_TP

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -849,10 +849,11 @@ now unfold the local `matToES` abbreviations at the call site and apply
 Mathlib's `Matrix.frobenius_norm_mul` directly.
 
 The Mathlib 4.31 pass also removes local synthesis-budget bounds from the
-square transfer-gap theorem, the rectangular transfer-gap theorem, and the
-rectangular non-translation-invariant gap theorem.  The remaining
-non-rectangular non-translation-invariant spectral-radius extraction still
-keeps its local `synthInstance.maxHeartbeats` bound.
+square transfer-gap theorem, the rectangular transfer-gap theorem, the
+rectangular non-translation-invariant gap theorem, and the non-rectangular
+non-translation-invariant spectral-radius extraction.  These proofs now name the
+continuous-linear-map normed structures directly enough that the former local
+`synthInstance.maxHeartbeats` adjustments are no longer needed.
 
 ### Remaining axiom boundary recheck, 2026-06-19
 
@@ -1146,11 +1147,16 @@ completeness.
 The local spectral-radius extraction theorems in
 `TNLean.Spectral.TransferOperatorGap`, `TNLean.Spectral.TransferOperatorGapRect`,
 and `TNLean.Spectral.TransferOperatorGapNT` were retested under Lean 4.31.  The
-square transfer-gap theorem, the rectangular transfer-gap theorem, and the
-Perron--Frobenius gauge extraction in the non-translation-invariant file no
-longer need their previous local bounds.  The non-rectangular
-non-translation-invariant spectral-radius extraction still keeps its local
-`synthInstance.maxHeartbeats` bound.
+square transfer-gap theorem, the rectangular transfer-gap theorem, the
+Perron--Frobenius gauge extraction in the non-translation-invariant file, and
+the non-rectangular non-translation-invariant spectral-radius extraction no
+longer need their previous local bounds.
+
+Focused check for the final non-translation-invariant removal:
+
+```bash
+lake build TNLean.Spectral.TransferOperatorGapNT -q --log-level=info
+```
 
 The scalar spectral-radius identity `spectralRadius_smul` in
 `TNLean.Channel.Irreducible.SpectralRadius` also no longer needs a local


### PR DESCRIPTION
### Motivation

- `set_option synthInstance.maxHeartbeats 200000` in `TNLean/Spectral/TransferOperatorGapNT.lean` was added to allow Lean to synthesize `ContinuousLinearMap` normed-space and algebra instances during spectrum extraction. Under Lean/Mathlib 4.31 the proof pins these instances explicitly, so the override is no longer needed.
- The Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`) should record that this file now elaborates within the default synthesis budget, consistent with the other transfer-gap theorems that have already shed local `maxHeartbeats` bounds.

### Description

- `TNLean/Spectral/TransferOperatorGapNT.lean`: remove the `set_option synthInstance.maxHeartbeats 200000` override and its accompanying comment preceding `modulus_one_eigenvalue_implies_gauge_of_irreducible_TP`. No theorem statements or mathematical content change.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: add an entry recording that the non-translation-invariant spectral-radius extraction in the transfer-gap setting now elaborates within the default synthesis budget; include the focused `lake build TNLean.Spectral.TransferOperatorGapNT` check note.

### Testing

- `lake build TNLean.Spectral.TransferOperatorGapNT -q --log-level=info`
- `lake build TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities -q --log-level=info`
- `! rg -n "synthInstance.maxHeartbeats|maxHeartbeats" TNLean/Spectral/TransferOperatorGapNT.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only maintenance and audit documentation; no theorem statements or mathematical content change.
>
> **Overview**
> Removes the **`set_option synthInstance.maxHeartbeats 200000`** block (and its comment) ahead of **`modulus_one_eigenvalue_implies_gauge_of_irreducible_TP`** in **`TNLean/Spectral/TransferOperatorGapNT.lean`**. The theorem's proof is unchanged; it already pins **`ContinuousLinearMap`** normed/algebra instances and finite-dimensional completeness explicitly enough that Lean 4.31 no longer needs a raised heartbeat limit for the spectrum extraction step.
>
> Updates **`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`** so the non-rectangular non-translation-invariant spectral-radius extraction is listed with the other transfer-gap theorems that shed local **`maxHeartbeats`** bounds, and adds the focused **`lake build TNLean.Spectral.TransferOperatorGapNT`** check note.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 350458a107e0c8de8e6e63ef443c8be2c58ef4ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->