### PR TITLE
feat(MPS/ParentHamiltonian): isolate PGVWC boundary representation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -113,6 +113,112 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c
   exact blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective
     μ A hN hLN X hBlk hUnital hNlarge C hCompat
 
+/-- Boundary representation plus crossing local constraints give periodic
+single-block states.
+
+Assume the vector \(\psi\in\mathcal G_{N,L}(\oplus_j\mu_jA_j)\) has already
+been written with block-diagonal boundary matrices \(X_j\). If every
+boundary-crossing interval has the simultaneous block-word spanning property,
+then the local constraint produces the word-indexed \(C^j,D^j\) comparison,
+and the normalized \(E^j\)-calculation gives
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+\]
+
+This theorem isolates the remaining boundary-representation input. It no
+longer calls the current BNT boundary-representation theorem; that theorem is
+used only in the BNT specialization below.
+
+This is the boundary-representation factor of the comparison in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456, specialized to the
+block-diagonal boundary conditions in arXiv:2011.12127, Section IV.C, lines
+2126--2128.
+
+**Scope restriction (crossing span):** This theorem assumes that the
+simultaneous block-word tuples of length \(N-i\) span the product algebra at
+each boundary-crossing interval \(i\). Removing that span hypothesis is part of
+the remaining comparison with the cited source recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem
+    exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hLN : L ≤ N)
+    (hNlarge : L + L₀ ≤ N)
+    (hCrossingSpan :
+      ∀ i : Fin N, N < i.val + L → WordTupleSpanTop A (N - i.val))
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (hBoundary :
+      ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X))) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  classical
+  obtain ⟨X, hψX⟩ := hBoundary
+  have hExists :
+      ∀ i : Fin N, ∀ ρ : Fin (N - L) → Fin d,
+        ∃ C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          N < i.val + L →
+            ∀ j : Fin r, ∀ β : Fin (i.val + L - N) → Fin d,
+              evalWord (A j) (List.ofFn β) * C j =
+                (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                  evalWord (A j) (List.ofFn ρ) := by
+    intro i ρ
+    by_cases hcross : N < i.val + L
+    · let τ : Fin N → Fin d := fun t =>
+        if htail : i.val + L - N ≤ t.val ∧ t.val < i.val then
+          ρ ⟨t.val - (i.val + L - N), by omega⟩
+        else
+          default
+      have hρ : (List.ofFn fun k : Fin (N - L) =>
+          τ ⟨i.val + L - N + k.val, by omega⟩) = List.ofFn ρ := by
+        apply List.ext_getElem
+        · simp
+        · intro n hn₁ hn₂
+          simp only [List.getElem_ofFn]
+          have hn : n < N - L := by
+            simpa using hn₂
+          have htail :
+              i.val + L ≤ i.val + L - N + n + N ∧
+                (⟨i.val + L - N + n, by omega⟩ : Fin N) < i := by
+            constructor
+            · omega
+            · change i.val + L - N + n < i.val
+              omega
+          simp [τ, htail]
+      have hmem :
+          (∑ j : Fin r,
+              cyclicRestrictₗ hN L i τ
+                (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
+            ⨆ j : Fin r, groundSpace (A j) L :=
+        blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
+          μ A hμ hN hLN hψ X hψX i τ
+      obtain ⟨C, hC⟩ :=
+        blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
+          μ A hN hLN X i τ hcross (hCrossingSpan i hcross) hmem
+      refine ⟨C, ?_⟩
+      intro _ j β
+      simpa [hρ] using hC j β
+    · refine ⟨fun j => 0, ?_⟩
+      intro hi
+      exact False.elim (hcross hi)
+  choose C hC using hExists
+  refine ⟨X, hψX, ?_⟩
+  exact blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective
+    μ A hN hLN X hBlk hUnital hNlarge (fun j i ρ => C i ρ j)
+    (by
+      intro j i hi ρ β
+      exact hC i ρ hi j β)
+
 /-- Boundary-crossing local constraints supply the \(C^j,D^j\) comparison.
 
 Assume the block-diagonal periodic vector has already been written with
@@ -175,61 +281,17 @@ theorem
       ∀ j : Fin r,
         groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
   classical
-  refine exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
-    μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
-    hNlarge hψ ?_
-  intro X hψX
-  have hExists :
-      ∀ i : Fin N, ∀ ρ : Fin (N - L) → Fin d,
-        ∃ C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
-          N < i.val + L →
-            ∀ j : Fin r, ∀ β : Fin (i.val + L - N) → Fin d,
-              evalWord (A j) (List.ofFn β) * C j =
-                (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
-                  evalWord (A j) (List.ofFn ρ) := by
-    intro i ρ
-    by_cases hcross : N < i.val + L
-    · let τ : Fin N → Fin d := fun t =>
-        if htail : i.val + L - N ≤ t.val ∧ t.val < i.val then
-          ρ ⟨t.val - (i.val + L - N), by omega⟩
-        else
-          default
-      have hρ : (List.ofFn fun k : Fin (N - L) =>
-          τ ⟨i.val + L - N + k.val, by omega⟩) = List.ofFn ρ := by
-        apply List.ext_getElem
-        · simp
-        · intro n hn₁ hn₂
-          simp only [List.getElem_ofFn]
-          have hn : n < N - L := by
-            simpa using hn₂
-          have htail :
-              i.val + L ≤ i.val + L - N + n + N ∧
-                (⟨i.val + L - N + n, by omega⟩ : Fin N) < i := by
-            constructor
-            · omega
-            · change i.val + L - N + n < i.val
-              omega
-          simp [τ, htail]
-      have hmem :
-          (∑ j : Fin r,
-              cyclicRestrictₗ hN L i τ
-                (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
-            ⨆ j : Fin r, groundSpace (A j) L :=
-        blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
-          μ A hμ hN hLN hψ X hψX i τ
-      obtain ⟨C, hC⟩ :=
-        blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
-          μ A hN hLN X i τ hcross (hCrossingSpan i hcross) hmem
-      refine ⟨C, ?_⟩
-      intro _ j β
-      simpa [hρ] using hC j β
-    · refine ⟨fun j => 0, ?_⟩
-      intro hi
-      exact False.elim (hcross hi)
-  choose C hC using hExists
-  refine ⟨fun j i ρ => C i ρ j, ?_⟩
-  intro j i hi ρ β
-  exact hC i ρ hi j β
+  have hBoundary :
+      ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) := by
+    obtain ⟨X, hψX, _hOpen⟩ :=
+      exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
+        μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
+    exact ⟨X, hψX⟩
+  exact
+    exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary
+      μ A hμ hBlk hUnital hN hLN hNlarge hCrossingSpan hψ hBoundary
 
 /-- Boundary-crossing local constraints give the block-diagonal periodic-boundary
 equality in the finite BNT range.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -1258,6 +1258,51 @@ in both cases.
     then gives the periodic-boundary constraint for each block.
 \end{proof}
 
+\begin{lemma}[Boundary representation and crossing constraints give periodic components]
+    \label{lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+        lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+    Assume $0<N$, $L\le N$, and $L+L_0\le N$. Suppose each block $A_j$
+    is $L_0$-block-injective and satisfies
+    \[
+        \sum_a A^j_aA^{j\dagger}_a=I .
+    \]
+    Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right),
+        \qquad
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
+    \]
+    If every boundary-crossing interval has the corresponding tail-word
+    spanning property, then there are block-diagonal boundary conditions $X_j$
+    with the displayed representation of $\psi$ and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+        lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+    For a boundary-crossing interval, the local constraint on $\psi$ and the
+    boundary representation give a vector in $\bigvee_jG_L(A_j)$ by
+    Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}. The crossing
+    comparison theorem supplies matrices $C^j_{i,\rho}$ satisfying
+    \[
+        A^j_\beta C^j_{i,\rho}
+        =
+        ((\mu_j^NX_j)A^j_\beta)A^j_\rho .
+    \]
+    Lemma~\ref{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
+    then gives the single-block periodic constraints.
+\end{proof}
+
 \begin{lemma}[Trace-decomposition comparisons give single-block constraints]
     \label{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -492,7 +492,9 @@ length \(N-i\) now give matrices
 \end{align}
 This is formalized as
 \leanid{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup}
-and assembled into
+and, once a block-diagonal boundary representation of \(\psi\) is fixed, into
+\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary}.
+The current BNT specialization then obtains that boundary representation through
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1}.
 Thus the comparison itself is no longer only a free trace-decomposition
 hypothesis: the present proof boundary is the crossing-tail word-span hypothesis


### PR DESCRIPTION
### Motivation

- Continues the removal of external comparison hypotheses from the block-diagonal parent-Hamiltonian theorems, isolating the boundary representation step so it can be supplied explicitly (see #2971).
- Source: Pérez-García–Verstraete–Wolf–Cirac, arXiv:quant-ph/0608197, Theorem 12 (proof lines 1446–1456); block-diagonal boundary-condition discussion in arXiv:2011.12127, Section IV.C, lines 2126–2128.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`: adds `MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary`, which takes an explicit block-diagonal boundary representation of the ground state and derives single-block periodic constraints from the crossing comparison, without invoking the BNT boundary-representation theorem at this step.
- Reorganizes `exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1` into a specialization: it first obtains the boundary matrices via `exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`, then applies the new theorem.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex`: adds lemma `lem:block_diagonal_boundary_periodic_components_from_crossing_boundary`, recording the two-stage boundary structure.
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: records the two remaining inputs — the explicit boundary representation and the crossing-tail word-span hypothesis.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`

---
Addresses #2971

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-structure refactor in formal Lean with blueprint/doc sync only; no changes to runtime, auth, or data paths.
> 
> **Overview**
> Introduces **`exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary`**, which assumes an explicit block-diagonal boundary representation of \(\psi\) and derives single-block periodic constraints from crossing local constraints plus tail-word span, without invoking the BNT boundary-representation theorem in that step.
> 
> **Refactors** `exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1` into a thin specialization: obtain the boundary matrices via `exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`, then apply the new theorem.
> 
> The **blueprint** adds a matching lemma (`lem:block_diagonal_boundary_periodic_components_from_crossing_boundary`), and the **paper-gap note** records the two-stage proof boundary (crossing comparison + explicit boundary input vs. BNT boundary lemma).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbef9e16dbaa42cb175e25b4d7094f9307db4b8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->