### PR TITLE
refactor(Channel/Semigroup): use trace-pairing extensionality

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
@@ -133,7 +133,8 @@ theorem generatorDecomp_of_gksl
   -- Need: Σ Kᵢ†Kᵢ = G.κ + G.κ† (from TA via trace pairing non-degeneracy)
   have hTA_G : IsTraceAnnihilating G.toLinearMap := hG ▸ hTA
   have hdiff : ∑ i : Fin r, (K i)ᴴ * K i - G.κ - G.κᴴ = 0 := by
-    apply Matrix.eq_zero_of_forall_trace_mul_eq_zero
+    refine (Matrix.ext_iff_trace_mul_right
+      (A := ∑ i : Fin r, (K i)ᴴ * K i - G.κ - G.κᴴ) (B := 0)).2 ?_
     intro ρ
     have h := hTA_G ρ
     simp only [GeneratorDecomp.toLinearMap_apply] at h
@@ -150,8 +151,10 @@ theorem generatorDecomp_of_gksl
     rw [hcycl] at h
     -- trace(ρ * G.κ†) = trace(G.κ† * ρ) by cyclic property
     rw [Matrix.trace_mul_comm ρ G.κᴴ, ← trace_sub, ← trace_sub] at h
-    convert h using 1
-    simp only [sub_mul]
+    have hzero : trace ((∑ i : Fin r, (K i)ᴴ * K i - G.κ - G.κᴴ) * ρ) = 0 := by
+      convert h using 1
+      simp only [sub_mul]
+    simpa using hzero
   -- Σ Kᵢ†Kᵢ - G.κ - G.κ† = 0 ⟹ Σ Kᵢ†Kᵢ = G.κ + G.κ†
   rw [sub_sub] at hdiff
   exact sub_eq_zero.mp hdiff

--- a/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
@@ -14,7 +14,6 @@ trace-preserving semigroups.
 
 ## Main results
 
-* `Matrix.eq_zero_of_forall_trace_mul_eq_zero` — non-degeneracy of trace pairing.
 * `isTracePreservingMap_expSemigroup_of_isTraceAnnihilating` — TA → TP semigroup.
 * `isTraceAnnihilating_of_isTracePreservingMap_semigroup` — TP semigroup → TA.
 -/
@@ -27,21 +26,6 @@ noncomputable section
 variable {D : ℕ}
 
 section LindbladForms
-
-/-! ## Trace pairing non-degeneracy -/
-
-/-- Non-degeneracy of the trace pairing: if `trace(A * B) = 0` for all `B`,
-then `A = 0`. This uses the standard basis matrices `E_{ij}`. -/
-theorem Matrix.eq_zero_of_forall_trace_mul_eq_zero
-    {A : Matrix (Fin D) (Fin D) ℂ}
-    (h : ∀ B : Matrix (Fin D) (Fin D) ℂ, trace (A * B) = 0) :
-    A = 0 := by
-  ext i j
-  -- Take B = single j i 1 (= E_{ji})
-  have := h (Matrix.single j i 1)
-  rw [Matrix.trace_mul_single] at this
-  -- this : MulOpposite.op 1 • A i j = 0
-  simpa using this
 
 /-! ## Equivalence: trace-annihilating ↔ trace-preserving semigroup -/
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -93,6 +93,10 @@ The clearest replacements are:
   statement.  The duplicate `_of_channel` theorem had the same hypotheses and
   conclusion as `channelDet_norm_eq_one_iff_exists_unitaryChannel`, so the
   blueprint points directly to the latter.
+- The Lindblad-form trace-constraint proof now uses Mathlib's
+  `Matrix.ext_iff_trace_mul_right` directly.  The one-use local theorem
+  `Matrix.eq_zero_of_forall_trace_mul_eq_zero` was removed from
+  `TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean`.
 - Further Lean 4.31 elaboration checks removed local heartbeat bounds from the
   POVM unitary-comparison proof, the irreducible-channel spectral-radius scalar
   proof, and the semigroup perturbation derivative proof.
@@ -1424,6 +1428,10 @@ step `M - N = 0`.  They now apply the Mathlib equality-form theorem directly:
 The two private `eq_of_trace_mul_left_eq` helpers in the PEPS overlap
 insertion files were removed; their use sites now call
 `Matrix.ext_iff_trace_mul_left` directly.
+
+The Lindblad-form trace bridge also no longer exports the one-use theorem
+`Matrix.eq_zero_of_forall_trace_mul_eq_zero`: the GKSL trace-constraint proof
+uses `Matrix.ext_iff_trace_mul_right` directly at the equality step.
 
 ### Deprecation-policy exceptions
 


### PR DESCRIPTION
### Motivation
- `TraceBridge.lean` contained a one-use local theorem `Matrix.eq_zero_of_forall_trace_mul_eq_zero` (non-degeneracy of the trace pairing: if `trace(A * B) = 0` for all matrices `B`, then `A = 0`) that duplicates Mathlib 4.31's `Matrix.ext_iff_trace_mul_right`.
- Removing the redundant local theorem keeps the GKSL trace-constraint proof aligned with the Mathlib library and reduces the local maintenance surface.
- Recorded in the Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`).

### Description
- `TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean`: removes the local theorem `Matrix.eq_zero_of_forall_trace_mul_eq_zero` and its section header (16 lines deleted); removes the corresponding entry from the module's main-results list.
- `TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean`: the GKSL trace-constraint proof (`generatorDecomp_of_gksl`) now applies `Matrix.ext_iff_trace_mul_right` directly at the matrix equality step.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records this removal in the Mathlib 4.31 replacement audit (8 lines added).
- No `sorry` introduced; no theorem statement changed.

### Testing
- `lake build TNLean.Channel.Semigroup.LindbladForm.GKSLTheorem -q --log-level=info` — build passes at step 2996/3014 with no new errors.
- Relies on Lean CI (`lean_action_ci.yml`) for full validation.