### PR TITLE
refactor(Channel): use trace-pairing extensionality

### DIFF
--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -227,15 +227,13 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
   have hT_inner : ∀ A : MatrixAlg d,
       T A = (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A * (↑P : MatrixAlg d) := by
     intro A
-    suffices h : ∀ B, trace ((T A -
-        (↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A * (↑P : MatrixAlg d)) * B) = 0 by
-      exact sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff _).mp h)
+    apply (Matrix.ext_iff_trace_mul_right).2
     intro B
-    rw [sub_mul, trace_sub, hAdj A B]
-    change trace (A * Td B) -
+    rw [hAdj A B]
+    change trace (A * Td B) =
       trace ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d) * A *
-        (↑P : MatrixAlg d) * B) = 0
-    rw [show Td B = Td_equiv B from rfl, hP B, sub_eq_zero]
+        (↑P : MatrixAlg d) * B)
+    rw [show Td B = Td_equiv B from rfl, hP B]
     simpa only [Matrix.mul_assoc] using
       (Matrix.trace_mul_cycle (A * (↑P : MatrixAlg d)) B
         ((↑(P⁻¹ : GL (Fin d) ℂ) : MatrixAlg d)))

--- a/TNLean/Channel/KrausFreedom.lean
+++ b/TNLean/Channel/KrausFreedom.lean
@@ -62,12 +62,8 @@ theorem kraus_dual_eq_of_map_eq
       ∑ α : Fin r₁, (B α)ᴴ * Y * B α =
       ∑ j : Fin r₂, (A j)ᴴ * Y * A j := by
   intro Y
-  suffices hsuff : ∀ X : Matrix (Fin D) (Fin D) ℂ,
-      trace ((∑ α : Fin r₁, (B α)ᴴ * Y * B α -
-              ∑ j : Fin r₂, (A j)ᴴ * Y * A j) * X) = 0 by
-    exact sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff _).mp hsuff)
+  apply (Matrix.ext_iff_trace_mul_right).2
   intro X
-  rw [sub_mul, Matrix.trace_sub]
   simp_rw [Finset.sum_mul, Matrix.trace_sum]
   have trace_cycle : ∀ K : Matrix (Fin D) (Fin D) ℂ,
       trace (Kᴴ * Y * K * X) = trace (K * X * Kᴴ * Y) := fun K => by
@@ -76,7 +72,7 @@ theorem kraus_dual_eq_of_map_eq
   simp_rw [trace_cycle]
   rw [← Matrix.trace_sum, ← Matrix.trace_sum,
       ← Finset.sum_mul, ← Finset.sum_mul]
-  rw [h X]; ring
+  rw [h X]
 
 /-- Map equality implies equal Stinespring Gramians:
 `∑ Bα†Bα = ∑ Aj†Aj`. -/

--- a/TNLean/Channel/KrausRepresentation.lean
+++ b/TNLean/Channel/KrausRepresentation.lean
@@ -46,23 +46,17 @@ theorem kraus_sum_conjTranspose_mul_of_tp
     (hK : ∀ X, T X = ∑ i : Fin r, K i * X * (K i)ᴴ)
     (htp : IsTracePreservingMap T) :
     ∑ i : Fin r, (K i)ᴴ * K i = 1 := by
-  -- Show `∑ᵢ Kᵢ†Kᵢ - 1 = 0` via trace pairing nondegeneracy.
   -- For any `N`: `tr((∑ᵢ Kᵢ†Kᵢ) N) = ∑ᵢ tr(Kᵢ†KᵢN) = ∑ᵢ tr(KᵢNKᵢ†) = tr(T(N)) = tr(N)`.
-  suffices h : ∀ N : Matrix (Fin D) (Fin D) ℂ,
-      trace ((∑ i : Fin r, (K i)ᴴ * K i - 1) * N) = 0 by
-    have := (Matrix.trace_mul_right_eq_zero_iff _).mp h
-    exact sub_eq_zero.mp this
+  apply (Matrix.ext_iff_trace_mul_right).2
   intro N
-  rw [sub_mul, Matrix.one_mul]
-  rw [show ((∑ i, (K i)ᴴ * K i) * N - N).trace =
-    ((∑ i, (K i)ᴴ * K i) * N).trace - N.trace from Matrix.trace_sub _ _]
+  rw [Matrix.one_mul]
   rw [Finset.sum_mul, Matrix.trace_sum]
   simp_rw [show ∀ i : Fin r,
     ((K i)ᴴ * K i * N).trace = (K i * N * (K i)ᴴ).trace from
     fun i => by rw [Matrix.mul_assoc ((K i)ᴴ), Matrix.trace_mul_comm, Matrix.mul_assoc]]
   rw [← Matrix.trace_sum]
   conv_lhs => rw [← hK N]
-  rw [htp N, sub_self]
+  rw [htp N]
 
 /-- **Theorem 2.1 item 1 (normalization ⟹ TP, Eq. (2.8))**:
 If `∑ᵢ Kᵢ†Kᵢ = 𝟙`, then `T(X) = ∑ᵢ Kᵢ X Kᵢ†` is trace-preserving. -/

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1609,6 +1609,21 @@ exponentials, and related definitional equalities whose elaboration changed
 between Mathlib 4.29 and 4.31.  No theorem statement was intentionally
 strengthened or weakened by these repairs.
 
+## Additional trace-pairing use-site cleanup, 2026-06-19
+
+Mathlib's equality-form trace-pairing theorem
+`Matrix.ext_iff_trace_mul_right` now replaces the remaining zero-difference
+trace-pairing conversions in the channel layer:
+
+- `TNLean/Channel/KrausRepresentation.lean`
+- `TNLean/Channel/KrausFreedom.lean`
+- `TNLean/Channel/Determinant/UnitaryCharacterization.lean`
+
+The affected proofs now establish matrix equality directly by comparing
+`trace (A * X)` against all test matrices `X`, rather than proving
+`trace ((A - B) * X) = 0` and then invoking the local zero-form trace-pairing
+wrapper.
+
 ## Conclusions
 
 Mathlib 4.31 materially improves the background library for TNLean, especially


### PR DESCRIPTION
### Motivation

- Proof cleanup in the channel layer: the pre-existing proofs of Kraus TP normalization, Kraus duality, and the determinant-saturation unitary characterization each showed `trace ((A - B) * X) = 0` for all test matrices `X`, then applied `Matrix.trace_mul_right_eq_zero_iff` and `sub_eq_zero`. Mathlib 4.31 provides `Matrix.ext_iff_trace_mul_right`, which characterizes matrix equality directly via trace pairing, eliminating the subtraction detour.
- This is follow-up cleanup identified in the Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`, §"Additional trace-pairing use-site cleanup, 2026-06-19"), following the initial audit in PR #3006.

### Description

- `TNLean/Channel/KrausRepresentation.lean`: refactor `kraus_sum_conjTranspose_mul_of_tp` to open with `Matrix.ext_iff_trace_mul_right` and prove `trace (A * X)` matches the target directly.
- `TNLean/Channel/KrausFreedom.lean`: same pattern applied to `kraus_dual_eq_of_map_eq`.
- `TNLean/Channel/Determinant/UnitaryCharacterization.lean`: same pattern applied to `hT_inner`.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records the additional cleanup (15 lines added).
- No theorem statements are changed; this is a proof-only refactor.

### Testing

- `lake build TNLean.Channel.KrausRepresentation TNLean.Channel.KrausFreedom TNLean.Channel.Determinant.UnitaryCharacterization -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check origin/main..HEAD`
- `rg -n "Matrix\.trace_mul_right_eq_zero_iff" TNLean/Channel -g "*.lean" -g "!TNLean/Archive/**"` returned no remaining channel uses.
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no theorem statement changes; behavior is unchanged aside from relying on the standard Mathlib extensionality lemma.
> 
> **Overview**
> **Proof refactor** in three channel files: Kraus TP normalization (`kraus_sum_conjTranspose_mul_of_tp`), Kraus dual-map equality (`kraus_dual_eq_of_map_eq`), and the determinant-saturation unitary characterization (`hT_inner`).
> 
> Each proof previously showed `trace ((A - B) * X) = 0` for all test matrices `X`, then applied `Matrix.trace_mul_right_eq_zero_iff` and `sub_eq_zero`. They now open with **`Matrix.ext_iff_trace_mul_right`** and prove **`trace (A * X)`** matches the target side directly—same mathematics, fewer subtraction steps.
> 
> The Mathlib 4.31 replacement audit documents this as follow-up to the earlier trace-pairing cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b8cdfc82245b4892621c301d78e4f2557717cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>