### PR TITLE
refactor(Channel/Irreducible): drop projection witnesses

### DIFF
--- a/TNLean/Channel/Irreducible/Basic.lean
+++ b/TNLean/Channel/Irreducible/Basic.lean
@@ -57,14 +57,6 @@ theorem IsStarProjection.isOrthogonalProjection {P : Matrix (Fin D) (Fin D) ℂ}
   change Pᴴ = P
   simpa [Matrix.star_eq_conjTranspose] using hP.2
 
-/-- The zero matrix is an orthogonal projection. -/
-lemma isOrthogonalProjection_zero : IsOrthogonalProjection (0 : Matrix (Fin D) (Fin D) ℂ) :=
-  (IsStarProjection.zero (R := Matrix (Fin D) (Fin D) ℂ)).isOrthogonalProjection
-
-/-- The identity matrix is an orthogonal projection. -/
-lemma isOrthogonalProjection_one : IsOrthogonalProjection (1 : Matrix (Fin D) (Fin D) ℂ) :=
-  (IsStarProjection.one (R := Matrix (Fin D) (Fin D) ℂ)).isOrthogonalProjection
-
 /-- The complement of an orthogonal projection is an orthogonal projection. -/
 theorem IsOrthogonalProjection.one_sub {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) : IsOrthogonalProjection (1 - P) :=

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -109,9 +109,9 @@ The clearest replacements are:
   removed; the two transfer estimates now unfold `frobSq` and use `sq_nonneg`.
 - Two RFP/ZCL wrappers were removed: an unused MPDO implication method that
   repeated `MPOTensor.isRFP_iff_isZCL`, and a one-use cluster-example RFP fact.
-- The elementary orthogonal-projection witnesses for `0`, `1`, and positivity
-  now pass through Mathlib's `IsStarProjection.zero`, `IsStarProjection.one`,
-  `IsStarProjection.nonneg`, and `Matrix.nonneg_iff_posSemidef`.
+- The unused elementary orthogonal-projection witnesses for `0` and `1` were
+  removed.  Positivity of an orthogonal projection now passes through Mathlib's
+  `IsStarProjection.nonneg` and `Matrix.nonneg_iff_posSemidef`.
 
 There are also important non-replacements.
 
@@ -767,9 +767,9 @@ Applied projection follow-up:
   predicate `IsOrthogonalProjection` with Mathlib's `IsStarProjection`.
   The complement theorem `IsOrthogonalProjection.one_sub` is proved through
   Mathlib's `IsStarProjection.one_sub`.
-- The elementary witnesses that `0` and `1` are orthogonal projections now use
-  Mathlib's corresponding star-projection constructors, and the proof that an
-  orthogonal projection is positive semidefinite now uses
+- The unused elementary witnesses that `0` and `1` are orthogonal projections
+  were removed.  The proof that an orthogonal projection is positive
+  semidefinite now uses
   `IsStarProjection.nonneg` followed by `Matrix.nonneg_iff_posSemidef`.
 - Duplicate complement-projection proofs were removed from
   `TNLean/MPS/Irreducible/Adjoint.lean`,


### PR DESCRIPTION
### Motivation
- The Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`) identified `isOrthogonalProjection_zero` and `isOrthogonalProjection_one` in `TNLean/Channel/Irreducible/Basic.lean` as unused local witnesses for the zero and identity orthogonal projections, both already available through `IsStarProjection.zero` and `IsStarProjection.one`.

### Description
- `TNLean/Channel/Irreducible/Basic.lean`: removed `isOrthogonalProjection_zero` and `isOrthogonalProjection_one` (8 lines deleted). These were local witnesses for the zero and identity projections, each an exact instance of the corresponding Mathlib star-projection constructor, with no consumers elsewhere in the development.
- The equivalence between `IsOrthogonalProjection` and Mathlib's `IsStarProjection`, the complement theorem `IsOrthogonalProjection.one_sub`, and the positive-semidefiniteness result `isOrthogonalProjection_posSemidef` are unchanged.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: updated to record that these elementary witnesses were removed rather than passed through local declarations.
- No mathematical statement used elsewhere in the development changes.

### Testing
- `lake build TNLean.Channel.Irreducible.Basic -q --log-level=info`
- `lake build TNLean -q --log-level=info` (full build; completed with the existing style/deprecation warnings and the known periodic-overlap `sorry` warning)
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the build.

---
No linked issue found. The cleanup was identified in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md` (added in #3011). The author should link an issue if one exists.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Documentation and deletion of unused lemmas only; no theorem statements or downstream proof sites change.
>
> **Overview**
> This PR **removes** the local lemmas `isOrthogonalProjection_zero` and `isOrthogonalProjection_one` from `TNLean/Channel/Irreducible/Basic.lean`. They were thin wrappers around Mathlib's `IsStarProjection.zero` / `IsStarProjection.one` and were **not referenced** elsewhere in the development.
>
> The substantive `IsOrthogonalProjection` ↔ `IsStarProjection` bridge, complement theorem `IsOrthogonalProjection.one_sub`, and PSD witness via `isOrthogonalProjection_posSemidef` are **unchanged**. Callers that need `0` or `1` as projections can use Mathlib star-projection constructors directly.
>
> The Mathlib 4.31 replacement audit is updated to say these elementary witnesses were **removed** (not that `0`/`1` still pass through local declarations).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ca78a146376f49173b509f6753e34789ddc25b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->