### PR TITLE
refactor(Wielandt/Primitivity): use Mathlib matrix basis expansion

### DIFF
--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -208,21 +208,6 @@ Every linear functional `φ : M_D(ℂ) → ℂ` can be represented as
 `φ(N) = tr(M_φ · N)` for a unique matrix `M_φ`.  We prove this concretely
 by exhibiting `M_φ i j = φ(e_{ji})` and checking the trace identity. -/
 
-/-- Decomposition of a matrix as a sum of scalar multiples of standard basis
-matrices. -/
-private theorem matrix_eq_sum_smul_single
-    (M : Matrix (Fin D) (Fin D) ℂ) :
-    M = ∑ i, ∑ j, M i j • Matrix.single i j (1 : ℂ) := by
-  ext a b
-  simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul,
-    Matrix.single_apply, mul_ite, mul_one, mul_zero]
-  conv_rhs =>
-    arg 2; ext i; arg 2; ext j
-    rw [show (if i = a ∧ j = b then M i j else 0) =
-      (if i = a then (if j = b then M i j else 0) else 0)
-      from by split_ifs <;> simp_all]
-  simp [Finset.sum_ite_eq', Finset.mem_univ]
-
 /-- Every linear functional `φ` on `M_D(ℂ)` decomposes as
 `φ(N) = ∑_{i,j} N i j · φ(e_{ij})`. -/
 private theorem linearMap_apply_eq_sum
@@ -230,8 +215,12 @@ private theorem linearMap_apply_eq_sum
     (N : Matrix (Fin D) (Fin D) ℂ) :
     φ N = ∑ i : Fin D, ∑ j : Fin D,
       N i j * φ (Matrix.single i j 1) := by
-  conv_lhs => rw [matrix_eq_sum_smul_single N]
-  simp only [map_sum, LinearMap.map_smul, smul_eq_mul]
+  conv_lhs => rw [Matrix.matrix_eq_sum_single N]
+  simp only [map_sum]
+  refine Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => ?_
+  rw [show Matrix.single i j (N i j) = N i j • Matrix.single i j (1 : ℂ) by
+    rw [Matrix.smul_single, smul_eq_mul, mul_one]]
+  rw [LinearMap.map_smul, smul_eq_mul]
 
 /-- The **trace-pairing representation**: for every linear functional `φ`,
 `φ(N) = tr(M_φ · N)` where `M_φ i j = φ(e_{ji})`. -/

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -120,6 +120,9 @@ The clearest replacements are:
   martingale transport file now uses Mathlib's `EuclideanSpace.basisFun` and
   `OrthonormalBasis.sum_repr`, rather than reproving the expansion by
   pointwise simplification.
+- The Wielandt strong-irreducibility trace-representation proof now uses
+  Mathlib's `Matrix.matrix_eq_sum_single`; the private coordinate-expansion
+  theorem was removed.
 
 There are also important non-replacements.
 
@@ -1531,6 +1534,25 @@ insertion files were removed; their use sites now call
 The Lindblad-form trace bridge also no longer exports the one-use theorem
 `Matrix.eq_zero_of_forall_trace_mul_eq_zero`: the GKSL trace-constraint proof
 uses `Matrix.ext_iff_trace_mul_right` directly at the equality step.
+
+### Matrix-basis expansion in Wielandt primitivity, 2026-06-19
+
+Removed the private local matrix-coordinate expansion:
+
+- `matrix_eq_sum_smul_single`
+
+This theorem was the scalar-matrix-unit form of Mathlib's
+`Matrix.matrix_eq_sum_single`.  The trace-representation helper
+`linearMap_apply_eq_sum` in
+`TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank` now rewrites by the
+Mathlib theorem and only performs the local scalar simplification from
+`Matrix.single i j (N i j)` to `N i j • Matrix.single i j 1`.
+
+Focused check:
+
+```bash
+lake build TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank -q --log-level=info
+```
 
 ### Deprecation-policy exceptions
 


### PR DESCRIPTION
### Motivation

- The private wrapper `matrix_eq_sum_smul_single` in `TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank` duplicated Mathlib 4.31's `Matrix.matrix_eq_sum_single`, which now provides the same matrix basis-expansion identity.
- Removing the wrapper continues the Mathlib 4.31 replacement audit cleanup, reducing locally-maintained duplicate infrastructure in the Wielandt chapter.

### Description

- `TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean`: removed the private `matrix_eq_sum_smul_single` helper; rewrote the trace-representation coordinate lemma `linearMap_apply_eq_sum` to go through Mathlib 4.31's `Matrix.matrix_eq_sum_single`, with a local step that rewrites `Matrix.single i j (N i j)` as a scalar multiple of a unit matrix.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: recorded this replacement as completed cleanup.
- No public API or theorem statement changes; behavior of downstream trace-pairing arguments is unchanged.

### Testing

- `lake build TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- Root build reports only pre-existing warnings (periodic Case 3 `sorry`, style/deprecation notices).

---
No linked issue found. This PR implements a standalone cleanup item from the Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`). If a tracking issue exists, please add `Addresses #N` here.

> [!NOTE]
> **Low Risk**
> Proof-only Mathlib deduplication with no public API or theorem statement changes; behavior of downstream trace-pairing arguments is unchanged.
>
> **Overview**
> **Removes** the private duplicate `matrix_eq_sum_smul_single` and routes the trace-representation coordinate lemma `linearMap_apply_eq_sum` through Mathlib 4.31's `Matrix.matrix_eq_sum_single`, with only the local step that rewrites `Matrix.single i j (N i j)` as a scalar multiple of a unit matrix.
>
> The Mathlib 4.31 replacement audit documents this as completed cleanup alongside other matrix-basis pass-through removals.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae97ecdc2f6eca8998747b0d88302ee88fe8b90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only Mathlib deduplication with no public API changes; downstream trace-pairing arguments are unchanged.
> 
> **Overview**
> Removes the private duplicate **`matrix_eq_sum_smul_single`** and routes **`linearMap_apply_eq_sum`** through Mathlib 4.31's **`Matrix.matrix_eq_sum_single`**, with only the local step that rewrites **`Matrix.single i j (N i j)`** as **`N i j • Matrix.single i j 1`**.
> 
> The Mathlib 4.31 replacement audit documents this as completed cleanup; no public API or theorem statements change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced85e7268504c0c46d1e78dde54d1cb32821e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->