### PR TITLE
refactor(MPS/Channel): use Mathlib diagonal matrix-unit sums

### DIFF
--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -130,10 +130,6 @@ private theorem stdBasis_mul_conjTranspose_self (i j : Fin d) :
   simpa only [stdBasis_conjTranspose_eq_swap] using
     (stdBasis_conjTranspose_mul_self (d := d) (i := j) (j := i))
 
-private theorem sum_single_diag_one :
-    ∑ j : Fin d, Matrix.single j j (1 : ℂ) = (1 : MatrixAlg d) := by
-  simpa only using (Matrix.sum_single_one (m := Fin d) (α := ℂ))
-
 /-- Summing `E_{ij} E_{ij}^†` over the standard matrix basis yields `d • 1`. -/
 theorem sum_stdBasis_mul_conjTranspose :
     ∑ ij : Fin d × Fin d,
@@ -159,7 +155,7 @@ theorem sum_stdBasis_mul_conjTranspose :
           simp only [Finset.sum_const, Finset.card_univ, Fintype.card_fin, smul_single,
             nsmul_eq_mul, mul_one, smul_eq_mul]
     _ = (d : ℂ) • ∑ i : Fin d, Matrix.single i i (1 : ℂ) := by rw [Finset.smul_sum]
-    _ = (d : ℂ) • (1 : MatrixAlg d) := by rw [sum_single_diag_one]
+    _ = (d : ℂ) • (1 : MatrixAlg d) := by rw [Matrix.sum_single_one]
 
 /-- If a finite family of nonnegative reals has total sum at most `0`, then every term is `0`. -/
 lemma eq_zero_of_nonneg_of_sum_le_zero {ι : Type*} [Fintype ι]

--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -188,15 +188,6 @@ theorem scalarConditionalExpectation_mem_adjointFixedPoints
 
 /-! ## Complete positivity and weighted trace preservation -/
 
-/-- An auxiliary lemma identity: `∑ j, single j j c = c • 1` for `c : ℂ`.
-
-The sum of diagonal basis matrices with a common scalar equals that scalar
-times the identity. -/
-private lemma sum_single_diag_const {D : ℕ} (c : ℂ) :
-    (∑ j : Fin D, Matrix.single j j c : Matrix (Fin D) (Fin D) ℂ) =
-      c • (1 : Matrix (Fin D) (Fin D) ℂ) := by
-  rw [Matrix.sum_single_eq_diagonal, Matrix.smul_one_eq_diagonal]
-
 /-- **Wolf Corollary 6.6, CP part.**
 
 The scalar conditional expectation `E_σ` is completely positive whenever `σ`
@@ -264,8 +255,8 @@ theorem scalarConditionalExpectation_isCPMap
                 (fun i => (S * X * S) i i) Finset.univ).symm
       _ = ∑ j : Fin D, Matrix.single j j (Matrix.trace (S * X * S)) := by
             simp [Matrix.trace, Matrix.diag]
-      _ = (Matrix.trace (S * X * S)) • (1 : Mat) :=
-            sum_single_diag_const (D := D) (Matrix.trace (S * X * S))
+      _ = (Matrix.trace (S * X * S)) • (1 : Mat) := by
+            rw [Matrix.sum_single_eq_diagonal, Matrix.smul_one_eq_diagonal]
       _ = (Matrix.trace (σ * X)) • (1 : Mat) := by
             congr 1
             calc Matrix.trace (S * X * S)

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -52,10 +52,6 @@ private lemma ofReal_re_eq_self_of_pos {z : ℂ} (hz : 0 < z) :
   · rfl
   · simp [hz_im]
 
-private lemma sum_single_diag_const (c : ℂ) :
-    ∑ i : Fin D, Matrix.single i i c = c • (1 : Mat) := by
-  rw [Matrix.sum_single_eq_diagonal, Matrix.smul_one_eq_diagonal]
-
 private lemma matrixUnits_map (X : Mat) :
     ∑ p : Fin D × Fin D,
       Matrix.single p.1 p.2 (1 : ℂ) * X * (Matrix.single p.1 p.2 (1 : ℂ))ᴴ =
@@ -79,7 +75,7 @@ private lemma matrixUnits_map (X : Mat) :
     _ = ∑ j : Fin D, Matrix.single j j (Matrix.trace X) := by
           simp [Matrix.trace, Matrix.diag]
     _ = Matrix.trace X • (1 : Mat) := by
-          simpa using sum_single_diag_const (D := D) (c := Matrix.trace X)
+          rw [Matrix.sum_single_eq_diagonal, Matrix.smul_one_eq_diagonal]
 
 /-- **Lemma B.1** (arXiv:1606.00608, Appendix B): a normal tensor in canonical
 form II that is an RFP admits the decomposition `A i = X * Λ * U i * X⁻¹`

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -123,6 +123,10 @@ The clearest replacements are:
 - The Wielandt strong-irreducibility trace-representation proof now uses
   Mathlib's `Matrix.matrix_eq_sum_single`; the private coordinate-expansion
   theorem was removed.
+- Three one-use diagonal matrix-unit sum wrappers were removed; the
+  determinant, fixed-point conditional expectation, and RFP structural proofs
+  now call `Matrix.sum_single_one`, `Matrix.sum_single_eq_diagonal`, or
+  `Matrix.smul_one_eq_diagonal` directly.
 
 There are also important non-replacements.
 
@@ -1624,6 +1628,13 @@ pass-throughs:
   blueprint-facing equivalence `MPOTensor.isRFP_iff_isZCL`.
 - `MPSTensor.clusterBlocked_isRFP`.  This was a one-use restatement of the
   blueprint-facing theorem `MPSTensor.clusterBlocked_transferMap_idempotent`.
+- `sum_single_diag_const` in
+  `TNLean.Channel.FixedPoint.ConditionalExpectation` and
+  `TNLean.MPS.RFP.StructuralFull`.  Both were one-use local diagonal
+  matrix-unit sum wrappers for `Matrix.sum_single_eq_diagonal` followed by
+  `Matrix.smul_one_eq_diagonal`.
+- `sum_single_diag_one` in `TNLean.Channel.Determinant.HilbertSchmidt`.  This
+  was a one-use local specialization of `Matrix.sum_single_one`.
 
 ## Verification performed
 


### PR DESCRIPTION
## Summary

This PR removes three private one-use wrappers around diagonal sums of matrix units.  The determinant/Hilbert-Schmidt, fixed-point conditional expectation, and RFP structural proofs now use Mathlib's statements directly:

- `Matrix.sum_single_one`
- `Matrix.sum_single_eq_diagonal`
- `Matrix.smul_one_eq_diagonal`

The Mathlib 4.31 replacement audit is updated to record these replacements.

## Validation

- `lake build TNLean.Channel.Determinant.HilbertSchmidt TNLean.Channel.FixedPoint.ConditionalExpectation TNLean.MPS.RFP.StructuralFull -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no public API or behavioral change; mathematical statements are unchanged.
> 
> **Overview**
> Deletes **three one-use private lemmas** that only wrapped Mathlib diagonal-sum facts, and rewrites the affected proof steps to cite Mathlib directly.
> 
> In **Hilbert–Schmidt** (`sum_stdBasis_mul_conjTranspose`), the final step now uses `Matrix.sum_single_one` instead of local `sum_single_diag_one`. In **scalar conditional expectation** (Kraus CP proof) and **RFP structural full** (`matrixUnits_map`), proofs now chain `Matrix.sum_single_eq_diagonal` with `Matrix.smul_one_eq_diagonal` instead of `sum_single_diag_const`.
> 
> The **Mathlib 4.31 replacement audit** documents these removals alongside the existing diagonal-sum replacement notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a32f20db4f8d908c5f2368312a72fb808ffc7ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->