### PR TITLE
feat(MPS/ParentHamiltonian): derive trace span in block comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -144,7 +144,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 derive the \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
 discharge the currently assumed
-trace-decomposition equality; tracked in issue 2971. -/
+trace-decomposition equality. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -200,6 +200,83 @@ theorem
     blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
       μ A hN hLN X hTraceSpan hBlk hUnital hNlarge C hCoeff
 
+/-- BNT normalization gives the common middle-word product span.
+
+In arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1451, condition C1 is
+used to separate the two trace decompositions at a common middle-word length.
+Under the finite block-injectivity and BNT hypotheses used here, the
+block-separation theorem gives that simultaneous product span at
+\[
+  (L_0+1)+(r-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr).
+\]
+The remaining hypothesis is therefore the trace-decomposition equality itself,
+with \(D^j_\beta\) specialized to \((\mu_j^NX_j)A^j_\beta\).
+
+**Unfaithful:** This proof still relies on
+`exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1`,
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
+derive the block-diagonal boundary representation and the displayed
+trace-decomposition equality from the source boundary-condition argument. -/
+theorem
+    exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (hTrace :
+      let m : ℕ :=
+        (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
+      ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+          ∃ C : ∀ (j : Fin r) (_ : Fin N),
+            (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+            ∀ i : Fin N,
+              N < i.val + L →
+                ∀ ρ : Fin (N - L) → Fin d,
+                  ∀ β : Fin (i.val + L - N) → Fin d,
+                    ∀ w : Fin m → Fin d,
+                      (∑ j : Fin r,
+                        Matrix.trace
+                          ((evalWord (A j) (List.ofFn β) * C j i ρ) *
+                            evalWord (A j) (List.ofFn w))) =
+                      (∑ j : Fin r,
+                        Matrix.trace
+                          ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                              evalWord (A j) (List.ofFn ρ)) *
+                            evalWord (A j) (List.ofFn w)))) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  classical
+  let m : ℕ :=
+    (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
+  have hTraceSpan : WordTupleSpanTop A m :=
+    wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital (by simp [m])
+  exact
+    exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
+      μ A hμ hIrr hLeft hOverlap hBlocks hTraceSpan hBlk hL₀ hUnital hN hL hLN hRange
+      hNlarge hψ hTrace
+
 /-- Source trace decompositions give the block-diagonal periodic-boundary
 equality in the finite BNT range.
 
@@ -221,7 +298,7 @@ windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 derive the \(C^j,D^j,E^j\) boundary-condition comparison from
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
 discharge the currently assumed
-trace-decomposition equality; tracked in issue 2971. -/
+trace-decomposition equality. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -272,5 +349,77 @@ theorem
         exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
           μ A hμ hIrr hLeft hOverlap hBlocks hTraceSpan hBlk hL₀ hUnital hN hL hLN hRange
           hNlarge hψ (fun X hψX => hTrace hψ X hψX))
+
+/-- BNT normalization gives the common middle-word product span for the
+ground-space equality.
+
+This is the finite block-injective specialization of the preceding equality
+theorem. The simultaneous product span at the middle-word length used in
+arXiv:quant-ph/0608197, Theorem 12, is derived from the BNT hypotheses; the
+remaining input is the trace-decomposition equality from arXiv:quant-ph/0608197,
+Theorem 12, proof lines 1436--1448, with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\).
+
+**Unfaithful:** This proof still relies on
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary`,
+which transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
+derive the block-diagonal boundary representation and the displayed
+trace-decomposition equality from the source boundary-condition argument. -/
+theorem
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hTrace :
+      let m : ℕ :=
+        (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
+      ∀ {ψ : NSiteSpace d N},
+        ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+            ∃ C : ∀ (j : Fin r) (_ : Fin N),
+              (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+              ∀ i : Fin N,
+                N < i.val + L →
+                  ∀ ρ : Fin (N - L) → Fin d,
+                    ∀ β : Fin (i.val + L - N) → Fin d,
+                      ∀ w : Fin m → Fin d,
+                        (∑ j : Fin r,
+                          Matrix.trace
+                            ((evalWord (A j) (List.ofFn β) * C j i ρ) *
+                              evalWord (A j) (List.ofFn w))) =
+                        (∑ j : Fin r,
+                          Matrix.trace
+                            ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                                evalWord (A j) (List.ofFn ρ)) *
+                              evalWord (A j) (List.ofFn w)))) :
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N ∧
+      iSupIndep (fun j : Fin r => groundSpace (A j) N) := by
+  classical
+  let m : ℕ :=
+    (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1)))
+  have hTraceSpan : WordTupleSpanTop A m :=
+    wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
+      A hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital (by simp [m])
+  exact
+    chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
+      μ A hμ hIrr hLeft hOverlap hBlocks hTraceSpan hBlk hL₀ hUnital hN hL hLN hRange
+      hNlarge hTrace
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -1414,6 +1414,67 @@ in both cases.
     \]
 \end{proof}
 
+\begin{lemma}[BNT product span gives trace-decomposition periodic components]
+    \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_bnt_span}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span}
+    \leanok
+    \uses{lem:unital_block_separating_product_span,
+        lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
+    addition that $L+L_0\le N$ and
+    \[
+        L\ge
+        (L_0+1)+(g-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr)+1.
+    \]
+    Put
+    \[
+        m=(L_0+1)+(g-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr).
+    \]
+    Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right).
+    \]
+    Suppose that whenever
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+    \]
+    there are matrices $C^j_{i,\rho}$ such that, for every
+    boundary-crossing interval $i$, every outside word $\rho$ of length $N-L$,
+    every word $\beta$ before the cut, and every word $w$ of length $m$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    Then there are block-diagonal boundary conditions $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:unital_block_separating_product_span,
+        lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
+    Lemma~\ref{lem:unital_block_separating_product_span} gives
+    \[
+        \spn\{(A^1_w,\ldots,A^g_w):|w|=m\}
+        =
+        \prod_j\MN{D_j}.
+    \]
+    Applying
+    Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
+    with this middle-word span gives the stated block-diagonal boundary
+    conditions and the periodic-boundary constraint in each block.
+\end{proof}
+
 \begin{lemma}[$C^j$ boundary comparison gives periodic single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_pgvwc_comparison}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -518,6 +518,67 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
+\begin{lemma}[BNT product span gives trace-decomposition ground-space equality]
+    \label{lem:bnt_block_diagonal_trace_decomposition_bnt_span_equality}
+    \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span}
+    \leanok
+    \uses{lem:unital_block_separating_product_span,
+        lem:bnt_block_diagonal_trace_decomposition_equality}
+    With the hypotheses and notation of
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
+    in addition that $L+L_0\le N$ and
+    \[
+        L\ge
+        (L_0+1)+(g-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr)+1.
+    \]
+    Put
+    \[
+        m=(L_0+1)+(g-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr).
+    \]
+    Assume that, for every
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+    \]
+    and every block-diagonal boundary representation
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+    \]
+    there are matrices $C^j_{i,\rho}$ such that, for every
+    boundary-crossing interval $i$, every outside word $\rho$ of length $N-L$,
+    every word $\beta$ before the cut, and every word $w$ of length $m$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    Then
+    \[
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
+        =
+        \bigvee_j\mathcal G_{N,L}(A_j),
+    \]
+    and the $N$-site ground spaces $G_N(A_j)=\mathcal G_{N,N}(A_j)$
+    have internal sum.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:unital_block_separating_product_span,
+        lem:bnt_block_diagonal_trace_decomposition_equality}
+    Lemma~\ref{lem:unital_block_separating_product_span} gives
+    \[
+        \spn\{(A^1_w,\ldots,A^g_w):|w|=m\}
+        =
+        \prod_j\MN{D_j}.
+    \]
+    Applying
+    Lemma~\ref{lem:bnt_block_diagonal_trace_decomposition_equality} with this
+    middle-word span gives the equality of periodic-boundary ground spaces and
+    the internality of the sum of the $N$-site spaces.
+\end{proof}
+
 \begin{lemma}[Boundary decomposition reduces to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_boundary_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -475,6 +475,26 @@ then
 for every block $j$ in the block-injective range.\footnote{Lean declaration:
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}.}
 
+In the normalized BNT finite range, this common middle-word span is no longer an
+external assumption. If
+\begin{align}
+  m=(L_0+1)+(b-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr),
+  \qquad
+  L\ge m+1,
+\end{align}
+then the normalized block-separation theorem gives
+\begin{align}
+  \operatorname{span}\{(A^1_w,\ldots,A^b_w):|w|=m\}
+  =
+  \prod_j M_{D_j}(\mathbb C).
+\end{align}
+Consequently the trace-decomposition implication in the finite range only keeps
+the displayed trace comparison and the block-diagonal boundary representation
+as external inputs.\footnote{Lean declarations:
+\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span}
+and
+\leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span}.}
+
 The word-indexed \(C^j,D^j\) route is closer to the proof of
 \cite[Theorem~12]{PerezGarcia2007MPSReps}.
 The words \(\beta\) and \(\rho\) are local word coordinates introduced after
@@ -496,9 +516,9 @@ and, once a block-diagonal boundary representation of \(\psi\) is fixed, into
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary}.
 The current BNT specialization then obtains that boundary representation through
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1}.
-Thus the comparison itself is no longer only a free trace-decomposition
-hypothesis: the present proof boundary is the crossing-tail word-span hypothesis
-and the still-used block-diagonal boundary representation of a vector
+Thus the crossing comparison is not an independent trace-comparison assumption:
+the present proof boundary is the crossing-tail word-span hypothesis and the
+still-used block-diagonal boundary representation of a vector
 \(\psi\in\mathcal K_{N,L}(\widehat A)\).
 This crossing-tail span hypothesis should not be confused with the
 large-length BNT product-span bound: if the boundary-crossing interval begins


### PR DESCRIPTION
### Motivation

- The separate middle-word product-span assumption is removed from the trace-decomposition branch of the block-diagonal parent-Hamiltonian comparison in the finite block-injective BNT range; that span is now derived from the BNT hypotheses rather than assumed as an external input.
- Continues the formalization effort toward the comparison identity in Pérez-García–Verstraete–Wolf–Cirac, Theorem 12 (arXiv:quant-ph/0608197, proof lines 1436–1456) and the block-diagonal boundary representation in Cirac–Pérez-García–Schuch–Verstraete, Section IV.C, lines 2126–2128 (arXiv:2011.12127); see #2971.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`: adds two theorems that build the middle-word product span (at length $m = (L_0+1)+(g-1)((L_0+1)+((L_0+1)+(L_0+1)))$, $L \ge m+1$) from normalized block separation via `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, then call the existing trace-decomposition conclusions to give: (i) periodic-boundary single-block components from the trace-decomposition comparison; (ii) ground-space equality and internality.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex` and `ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`: new blueprint entries for the finite-range trace route, recording that the remaining external inputs are the trace comparison (PGVWC07 Theorem 12) and the block-diagonal boundary representation (CPSV21 §IV.C).
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: updated to reflect the narrowed proof boundary.
- Proofs are marked **Unfaithful** where boundary data—the trace-decomposition equality and the block-diagonal boundary representation—is not yet derived from the source papers.
- Does not close #2971; the source-faithful trace-decomposition equality and block-diagonal boundary representation remain assumed.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv21_block_diagonal_parent_ground_space.tex && latexmk -c cpgsv21_block_diagonal_parent_ground_space.tex`
- Note: `bash scripts/build-paper-gaps.sh` failed in an unrelated existing PEPS note (`docs/paper-gaps/peps_normal_ft_2d_overlap.tex:530`). `leanblueprint checkdecls` could not run (local environment missing `blueprint/lean_decls`).
- Full build validation via Lean CI (`lean_action_ci.yml`).

---
Refs #2971

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and documentation only; no runtime, auth, or data paths. Relies on existing unfaithful boundary steps unchanged aside from weaker hypotheses.
> 
> **Overview**
> In the finite block-injective BNT range, the **middle-word product span** at length \(m\) is no longer assumed on the trace-decomposition branch: two new Lean theorems build `WordTupleSpanTop` via `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, then delegate to the existing trace-decomposition conclusions for **single-block periodic components** and **block-diagonal ground-space equality**.
> 
> Matching **blueprint** lemmas and **`cpgsv21_block_diagonal_parent_ground_space.tex`** record that the narrowed external inputs are the trace comparison and block-diagonal boundary representation; **Unfaithful** docstrings are tightened (issue \#2971 dropped from some elimination lines). Does not close \#2971.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e4cf03b41c9ba5fc6989869dab41ea13a99f378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->