### PR TITLE
refactor(MPS/ParentHamiltonian): use Mathlib Euclidean basis expansion

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -228,8 +228,7 @@ private theorem replaceWindow_commute_of_cyclic_windows_disjoint {N L : ℕ}
 private theorem euclideanSpace_eq_sum_single {α : Type*} [Fintype α] [DecidableEq α]
     (x : EuclideanSpace ℂ α) :
     x = ∑ a : α, x a • EuclideanSpace.single a (1 : ℂ) := by
-  ext a
-  simp [Finset.sum_apply, Pi.single_apply]
+  simpa using ((EuclideanSpace.basisFun α ℂ).sum_repr x).symm
 
 private theorem linearMap_apply_eq_sum {α : Type*} [Fintype α] [DecidableEq α]
     (P : EuclideanSpace ℂ α →ₗ[ℂ] EuclideanSpace ℂ α)

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -116,6 +116,10 @@ The clearest replacements are:
 - The unused elementary orthogonal-projection witnesses for `0` and `1` were
   removed.  Positivity of an orthogonal projection now passes through Mathlib's
   `IsStarProjection.nonneg` and `Matrix.nonneg_iff_posSemidef`.
+- The Euclidean-space coordinate expansion in the parent-Hamiltonian
+  martingale transport file now uses Mathlib's `EuclideanSpace.basisFun` and
+  `OrthonormalBasis.sum_repr`, rather than reproving the expansion by
+  pointwise simplification.
 
 There are also important non-replacements.
 
@@ -1734,6 +1738,26 @@ The affected proofs now establish matrix equality directly by comparing
 `trace (A * X)` against all test matrices `X`, rather than proving
 `trace ((A - B) * X) = 0` and then invoking the local zero-form trace-pairing
 wrapper.
+
+## Euclidean-space basis expansion, 2026-06-19
+
+`TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean` contained a private
+coordinate expansion theorem
+
+- `euclideanSpace_eq_sum_single`
+
+which proved directly that a vector in `EuclideanSpace` is the sum of its
+coordinates times the standard coordinate vectors.  Mathlib 4.31 supplies this
+as the standard orthonormal-basis expansion for `EuclideanSpace.basisFun`.
+The local theorem is still useful as a shaped private statement for the
+subsequent linear-map coordinate calculation, but its proof is now just
+`OrthonormalBasis.sum_repr` specialized to `EuclideanSpace.basisFun`.
+
+Focused check:
+
+```bash
+lake build TNLean.MPS.ParentHamiltonian.Martingale.Transport -q --log-level=info
+```
 
 ## Conclusions
 


### PR DESCRIPTION
### Motivation

- The private lemma `euclideanSpace_eq_sum_single` in the parent-Hamiltonian martingale
  transport file reproduced the standard orthonormal-basis coordinate expansion by
  pointwise `ext`/`simp`. Mathlib 4.31 provides this directly as `OrthonormalBasis.sum_repr`
  applied to `EuclideanSpace.basisFun`, making the local proof redundant.
- Recorded as a completed item in the Mathlib 4.31 replacement audit
  (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`), which identifies places
  where TNLean can replace local proofs with standard Mathlib declarations.

### Description

- `TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean`: proof of
  `euclideanSpace_eq_sum_single` replaced by `OrthonormalBasis.sum_repr` specialized to
  `EuclideanSpace.basisFun`. The theorem statement is unchanged; downstream use in
  `linearMap_apply_eq_sum` is unaffected.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: entry added recording the
  Euclidean-basis coordinate expansion as a completed replacement.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Transport -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

---
_(No linked issue found — please add `Addresses #N` referencing the relevant issue.)_

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a private helper with no public API or axiom boundary changes; behavior of the martingale transport file is unchanged.
>
> **Overview**
> The private lemma `euclideanSpace_eq_sum_single` in `Transport.lean` still states the same coordinate expansion, but its proof no longer uses `ext` and pointwise `simp`; it is **`OrthonormalBasis.sum_repr`** for **`EuclideanSpace.basisFun`**.
>
> Downstream use in `linearMap_apply_eq_sum` is unchanged. The Mathlib 4.31 replacement audit documents this as part of the ongoing deduplication of elementary linear algebra.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c7fb6af399e55d4e844c89c7627b47c369c01c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>