### PR TITLE
refactor(Channel/Semigroup): inline Kossakowski identity sum

### DIFF
--- a/TNLean/Channel/Semigroup/KossakowskiForm.lean
+++ b/TNLean/Channel/Semigroup/KossakowskiForm.lean
@@ -117,22 +117,6 @@ def KossakowskiForm.toLinearMap (K : KossakowskiForm D) :
 
 /-! ### Auxiliary lemmas for Kossakowski ↔ Lindblad conversion -/
 
-/-- Collapsing a sum weighted by the identity matrix:
-`∑_l (1 : Matrix) l k • f(l) = f(k)`. -/
-private lemma sum_one_smul_eq {n : ℕ}
-    {M : Type*} [AddCommMonoid M] [Module ℂ M]
-    (k : Fin n) (f : Fin n → M) :
-    ∑ l : Fin n,
-      (1 : Matrix (Fin n) (Fin n) ℂ) l k • f l = f k := by
-  simp only [Matrix.one_apply]
-  have : ∀ l : Fin n,
-      (if l = k then (1 : ℂ) else 0) • f l =
-      if l = k then f l else 0 := by
-    intro l; split_ifs <;> simp
-  simp_rw [this]
-  exact (Finset.sum_ite_eq' _ k (fun l => f l)).trans
-    (by simp)
-
 /-- The dissipator equals ½ of the Kossakowski commutator sum
 (for a single operator). This connects the two forms. -/
 private lemma dissipator_eq_half_kossakowski
@@ -266,7 +250,7 @@ theorem kossakowski_iff_lindblad
     apply Finset.sum_congr rfl
     intro k _
     symm
-    exact sum_one_smul_eq k _
+    simp [kossakowskiTerm, Matrix.one_apply, Finset.sum_add_distrib]
 
 end KossakowskiForms
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -97,6 +97,10 @@ The clearest replacements are:
   `Matrix.ext_iff_trace_mul_right` directly.  The one-use local theorem
   `Matrix.eq_zero_of_forall_trace_mul_eq_zero` was removed from
   `TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean`.
+- The Kossakowski-to-Lindblad comparison now collapses the identity-matrix
+  finite sum directly at the proof site using `Matrix.one_apply`,
+  `Finset.sum_add_distrib`, and Mathlib's if-supported finite-sum
+  simplification.  The private lemma `sum_one_smul_eq` was removed.
 - Further Lean 4.31 elaboration checks removed local heartbeat bounds from the
   POVM unitary-comparison proof, the irreducible-channel spectral-radius scalar
   proof, the semigroup perturbation derivative proof, and the common
@@ -1779,6 +1783,24 @@ Focused check:
 
 ```bash
 lake build TNLean.MPS.ParentHamiltonian.Martingale.Transport -q --log-level=info
+```
+
+## Kossakowski identity-sum cleanup, 2026-06-19
+
+`TNLean/Channel/Semigroup/KossakowskiForm.lean` had a private theorem
+`sum_one_smul_eq` saying that a finite sum weighted by the identity matrix
+collapses to the diagonal term.  After `Matrix.one_apply`, this is just an
+if-supported finite sum.
+
+The backward Lindblad-to-Kossakowski direction now unfolds the single
+Kossakowski summand and lets `simp`, together with `Finset.sum_add_distrib`,
+collapse the two if-supported sums directly.  The mathematical statement of
+`kossakowski_iff_lindblad` is unchanged.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Semigroup.KossakowskiForm -q --log-level=info
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- The private lemma `sum_one_smul_eq` in `KossakowskiForm.lean` was an auxiliary
  lemma that can be eliminated by unfolding `kossakowskiTerm` directly, simplifying
  the backward (Lindblad-to-Kossakowski) direction of the proof.
- Removing the intermediate lemma keeps the file self-contained and reduces
  indirection in the proof of Wolf Theorem 7.1 (ii ↔ i).
- The Mathlib 4.31 replacement audit is updated to record the removed lemma.

### Description

- `TNLean/Channel/Semigroup/KossakowskiForm.lean`: removes the private lemma
  `sum_one_smul_eq`; the Lindblad-to-Kossakowski backward direction now unfolds
  `kossakowskiTerm` and uses `simp` with `Matrix.one_apply` and
  `Finset.sum_add_distrib` to collapse the two identity-weighted finite sums in
  place. The public theorem `kossakowski_iff_lindblad` (Wolf Theorem 7.1, forms
  (ii) ↔ (i)) is unchanged in statement and scope.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records the removed
  auxiliary lemma in the Mathlib 4.31 replacement audit log.

### Testing

- `lake build TNLean.Channel.Semigroup.KossakowskiForm -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
_No linked issue identified. If a tracking issue exists for this cleanup, add `Addresses #N` here._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one equivalence direction with no API or theorem statement changes.
>
> **Overview**
> Removes the private helper **`sum_one_smul_eq`** from `KossakowskiForm.lean` and finishes the Lindblad→Kossakowski step by unfolding **`kossakowskiTerm`** and using **`simp`** with **`Matrix.one_apply`** and **`Finset.sum_add_distrib`** to collapse the identity-weighted finite sum in place.
>
> **`kossakowski_iff_lindblad`** is unchanged; the Mathlib 4.31 replacement audit documents the cleanup.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dbbcd66252cdc30c16535befc5b4e7e1ac3f8a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No API or theorem statement changes; only one proof direction is simplified with standard Mathlib finite-sum lemmas.
> 
> **Overview**
> Proof-only refactor in **`KossakowskiForm.lean`**: the private helper **`sum_one_smul_eq`** is removed, and the Lindblad→Kossakowski step of **`kossakowski_iff_lindblad`** now unfolds **`kossakowskiTerm`** and uses **`simp`** with **`Matrix.one_apply`** and **`Finset.sum_add_distrib`** to collapse the identity-weighted finite sum in place.
> 
> The public theorem **`kossakowski_iff_lindblad`** (Wolf Theorem 7.1, (ii) ↔ (i)) is unchanged. The Mathlib 4.31 replacement audit documents the cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbd360e9ed27f8f435c3ade26a57e6905ef4b8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->