### PR TITLE
refactor(MPS/MPDO): inline scalar 1×1 matrix auxiliary lemmas

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean
@@ -44,25 +44,21 @@ def duplicateScalarBlocks :
     (k : Fin 2) → MPSTensor 1 (duplicateScalarDim k)
   | _ => fun _ => (1 : Matrix (Fin 1) (Fin 1) ℂ)
 
-private theorem span_singleton_one_finOne_eq_top :
-    (ℂ ∙ (1 : Matrix (Fin 1) (Fin 1) ℂ)) = ⊤ := by
-  refine (Submodule.span_singleton_eq_top_iff ℂ
-    (1 : Matrix (Fin 1) (Fin 1) ℂ)).2 ?_
-  intro M
-  refine ⟨M 0 0, ?_⟩
-  ext i j
-  have hi : i = 0 := Fin.eq_zero i
-  have hj : j = 0 := Fin.eq_zero j
-  subst hi
-  subst hj
-  simp
-
 /-- Each duplicate scalar block is injective. -/
 theorem duplicateScalarBlocks_isInjective :
     ∀ k, IsInjective (duplicateScalarBlocks k) := by
   intro k
+  have hspan : (ℂ ∙ (1 : Matrix (Fin 1) (Fin 1) ℂ)) = ⊤ := by
+    refine (Submodule.span_singleton_eq_top_iff ℂ
+      (1 : Matrix (Fin 1) (Fin 1) ℂ)).2 ?_
+    intro M
+    refine ⟨M 0 0, ?_⟩
+    ext i j
+    obtain rfl : i = 0 := Fin.eq_zero i
+    obtain rfl : j = 0 := Fin.eq_zero j
+    simp
   simpa [duplicateScalarBlocks, duplicateScalarDim, IsInjective, Set.range_const] using
-    span_singleton_one_finOne_eq_top
+    hspan
 
 /-- The duplicate scalar blocks are left-canonical. -/
 theorem duplicateScalarBlocks_leftCanonical :

--- a/TNLean/MPS/MPDO/LocalPurificationRFP.lean
+++ b/TNLean/MPS/MPDO/LocalPurificationRFP.lean
@@ -158,11 +158,6 @@ lemma witnessM_entry (i j : Fin 2) :
   simp only [witnessM, Matrix.submatrix_apply, witnessA, Fin.sum_univ_two]
   fin_cases i <;> fin_cases j <;> simp [amp_mul_conj]
 
-/-- A `1 × 1` triple matrix product evaluates entrywise. -/
-private lemma mul_triple_one (A B C : Matrix (Fin 1) (Fin 1) ℂ) (i j : Fin 1) :
-    (A * B * C) i j = A 0 0 * B 0 0 * C 0 0 := by
-  fin_cases i; fin_cases j; simp [Matrix.mul_apply]
-
 /-- The transfer map of the witness MPO is `½ • id`: its leading eigenvalue is `½`,
 not `1`, reflecting the maximally mixed reduced state. -/
 lemma transferMap_witnessM :
@@ -172,9 +167,9 @@ lemma transferMap_witnessM :
   obtain rfl : a = 0 := Subsingleton.elim a 0
   obtain rfl : b = 0 := Subsingleton.elim b 0
   rw [transferMap_apply]
-  simp only [Matrix.sum_apply, Fin.sum_univ_two, Matrix.add_apply, mul_triple_one,
-    Matrix.conjTranspose_apply, witnessM_entry, LinearMap.smul_apply, LinearMap.id_apply,
-    Matrix.smul_apply, smul_eq_mul]
+  simp only [Matrix.sum_apply, Fin.sum_univ_two, Matrix.add_apply, Matrix.mul_apply,
+    Fin.sum_univ_one, Matrix.conjTranspose_apply, witnessM_entry, LinearMap.smul_apply,
+    LinearMap.id_apply, Matrix.smul_apply, smul_eq_mul]
   simp only [Fin.reduceEq, ↓reduceIte, star_zero, mul_zero, zero_mul, add_zero,
     show star (2⁻¹ : ℂ) = 2⁻¹ from by simp]
   ring
@@ -192,10 +187,10 @@ lemma witnessAcombined_isRFP : MPSTensor.IsRFP witnessAcombined := by
     have e1 : (1 : Fin (2 * 2)).divNat = 0 ∧ (1 : Fin (2 * 2)).modNat = 1 := by decide
     have e2 : (2 : Fin (2 * 2)).divNat = 1 ∧ (2 : Fin (2 * 2)).modNat = 0 := by decide
     have e3 : (3 : Fin (2 * 2)).divNat = 1 ∧ (3 : Fin (2 * 2)).modNat = 1 := by decide
-    simp only [mul_triple_one, Matrix.conjTranspose_apply, witnessAcombined, purificationTensor,
-      witnessA, Matrix.of_apply, LinearMap.id_apply, e0.1, e0.2, e1.1, e1.2, e2.1, e2.2,
-      e3.1, e3.2, witnessAmplitude, Fin.reduceEq, ↓reduceIte, zero_mul, add_zero,
-      ← starRingEnd_apply, map_inv₀, Complex.conj_ofReal]
+    simp only [Matrix.mul_apply, Fin.sum_univ_one, Matrix.conjTranspose_apply,
+      witnessAcombined, purificationTensor, witnessA, Matrix.of_apply, LinearMap.id_apply, e0.1,
+      e0.2, e1.1, e1.2, e2.1, e2.2, e3.1, e3.2, witnessAmplitude, Fin.reduceEq, ↓reduceIte,
+      zero_mul, add_zero, ← starRingEnd_apply, map_inv₀, Complex.conj_ofReal]
     linear_combination (2 * X 0 0) * sqrt2_inv_mul_self
   rw [MPSTensor.IsRFP, h, LinearMap.comp_id]
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -131,6 +131,11 @@ The clearest replacements are:
   determinant, fixed-point conditional expectation, and RFP structural proofs
   now call `Matrix.sum_single_one`, `Matrix.sum_single_eq_diagonal`, or
   `Matrix.smul_one_eq_diagonal` directly.
+- Two MPDO scalar-block helpers were removed.  The duplicate-block
+  counterexample now proves the `1 × 1` span fact locally using
+  `Submodule.span_singleton_eq_top_iff`, and the local-purification example
+  simplifies `1 × 1` triple products directly with `Matrix.mul_apply` and
+  `Fin.sum_univ_one`.
 
 There are also important non-replacements.
 
@@ -1808,10 +1813,27 @@ Kossakowski summand and lets `simp`, together with `Finset.sum_add_distrib`,
 collapse the two if-supported sums directly.  The mathematical statement of
 `kossakowski_iff_lindblad` is unchanged.
 
-Focused check:
+## MPDO scalar one-dimensional cleanup, 2026-06-19
+
+Two private declarations in the MPDO layer were only named one-dimensional
+matrix calculations:
+
+- `span_singleton_one_finOne_eq_top` in
+  `TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean`.
+- `mul_triple_one` in `TNLean/MPS/MPDO/LocalPurificationRFP.lean`.
+
+The duplicate-block counterexample now proves the needed span statement inside
+`duplicateScalarBlocks_isInjective` from
+`Submodule.span_singleton_eq_top_iff`.  The local-purification example now
+evaluates the two `1 × 1` triple products by simplifying `Matrix.mul_apply`
+with `Fin.sum_univ_one`.  No public MPDO statement changes.
+
+Focused checks:
 
 ```bash
 lake build TNLean.Channel.Semigroup.KossakowskiForm -q --log-level=info
+lake build TNLean.MPS.MPDO.BiCFDerivation.Counterexample \
+  TNLean.MPS.MPDO.LocalPurificationRFP -q --log-level=info
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- Two private auxiliary lemmas in the MPDO layer — `span_singleton_one_finOne_eq_top` (in `BiCFDerivation/Counterexample.lean`) and `mul_triple_one` (in `LocalPurificationRFP.lean`) — each duplicate a Mathlib result for `1 × 1` matrices and appear only at their local call sites.
- Removing them in favour of inline Mathlib rewrites reduces local duplication and records the change in the Mathlib 4.31 replacement audit.

### Description

- `TNLean/MPS/MPDO/BiCFDerivation/Counterexample.lean`: removes `span_singleton_one_finOne_eq_top`; the span fact `(ℂ ∙ 1) = ⊤` is now proved inline via `Submodule.span_singleton_eq_top_iff`.
- `TNLean/MPS/MPDO/LocalPurificationRFP.lean`: removes `mul_triple_one`; `1 × 1` triple products are now evaluated inline via `Matrix.mul_apply` and `Fin.sum_univ_one`.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records the removal of both auxiliary lemmas.
- No public MPDO theorem statements change.

### Testing

- `lake build TNLean.MPS.MPDO.BiCFDerivation.Counterexample TNLean.MPS.MPDO.LocalPurificationRFP -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

---

<!-- No linked issue found; please link one manually if applicable. -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavioral changes; risk is limited to whether the inlined Lean proofs still build.
> 
> **Overview**
> Removes two private `1 × 1` matrix auxiliary lemmas from the MPDO layer and inlines their logic at the only use sites.
> 
> In **`Counterexample.lean`**, `duplicateScalarBlocks_isInjective` now proves `(ℂ ∙ 1) = ⊤` locally via `Submodule.span_singleton_eq_top_iff` instead of calling `span_singleton_one_finOne_eq_top`. In **`LocalPurificationRFP.lean`**, `transferMap_witnessM` and `witnessAcombined_isRFP` unfold triple products with `Matrix.mul_apply` and `Fin.sum_univ_one` instead of `mul_triple_one`.
> 
> The Mathlib 4.31 replacement audit documents the removal; **no public MPDO theorem statements change**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee885880791ba77149887a6f865761d18f3105cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavioral changes; risk is limited to whether the inlined Lean proofs still build.
> 
> **Overview**
> Removes two private **1 × 1** matrix helpers in the MPDO layer and inlines their Mathlib-style reasoning at the only use sites, as part of the Mathlib 4.31 replacement audit.
> 
> In **`BiCFDerivation/Counterexample.lean`**, `duplicateScalarBlocks_isInjective` now proves `(ℂ ∙ 1) = ⊤` locally via `Submodule.span_singleton_eq_top_iff` (with `obtain rfl` for `Fin 1` indices) instead of calling `span_singleton_one_finOne_eq_top`. In **`LocalPurificationRFP.lean`**, `transferMap_witnessM` and `witnessAcombined_isRFP` unfold triple products with `Matrix.mul_apply` and `Fin.sum_univ_one` instead of `mul_triple_one`.
> 
> The audit doc records the removal; **no public MPDO theorem statements change**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de340e9f071d481b6fa29f897a5aae5337e2824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->