### PR TITLE
refactor(MPS/QPF): use Mathlib PSD kernel criterion

### DIFF
--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -257,13 +257,6 @@ private lemma dotProduct_mulVec_conjTranspose
     star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y := by
   rw [Matrix.dotProduct_mulVec, Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
 
-private lemma mulVec_eq_zero_of_quadForm_eq_zero
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef)
-    (x : Fin D → ℂ) (hx : star x ⬝ᵥ (ρ *ᵥ x) = 0) :
-    ρ *ᵥ x = 0 := by
-  classical
-  exact (hρ.dotProduct_mulVec_zero_iff x).mp hx
-
 /-- If `ρ` is PSD and `E_A(ρ)=ρ`, then `ker ρ` is invariant under each adjoint Kraus operator.
 
 Formally, `ρ *ᵥ x = 0` implies `ρ *ᵥ ((A i)ᴴ *ᵥ x) = 0`.
@@ -302,7 +295,7 @@ private lemma ker_invariant_under_adjoint
           h_sum_zero i (Finset.mem_univ _)
     exact Complex.ext hre (hρ_psd.isHermitian.im_star_dotProduct_mulVec_self _)
   intro i
-  exact mulVec_eq_zero_of_quadForm_eq_zero ρ hρ_psd _ (h_each_zero i)
+  exact (hρ_psd.dotProduct_mulVec_zero_iff _).mp (h_each_zero i)
 
 
 /-- If `ρ` is a PSD fixed point of the transfer map, then its support projection is invariant:

--- a/TNLean/QPF/PosDef.lean
+++ b/TNLean/QPF/PosDef.lean
@@ -54,13 +54,6 @@ variable {d D : ℕ}
 
 section PosDef
 
-private lemma mulVec_eq_zero_of_quadForm_eq_zero
-    (ρ : Matrix (Fin D) (Fin D) ℂ) (hρ : ρ.PosSemidef)
-    (x : Fin D → ℂ) (hx : star x ⬝ᵥ (ρ *ᵥ x) = 0) :
-    ρ *ᵥ x = 0 := by
-  classical
-  exact (hρ.dotProduct_mulVec_zero_iff x).mp hx
-
 private lemma ker_invariant_under_adjoint
     (A : MPSTensor d D)
     (ρ : Matrix (Fin D) (Fin D) ℂ)
@@ -90,7 +83,7 @@ private lemma ker_invariant_under_adjoint
       h_sum_zero i (Finset.mem_univ _)
     exact Complex.ext hre (hρ_psd.isHermitian.im_star_dotProduct_mulVec_self _)
   intro i
-  exact mulVec_eq_zero_of_quadForm_eq_zero ρ hρ_psd _ (h_each_zero i)
+  exact (hρ_psd.dotProduct_mulVec_zero_iff _).mp (h_each_zero i)
 
 private lemma ker_contains_all_of_span
     (A : MPSTensor d D) (hA : IsInjective A)
@@ -129,7 +122,7 @@ theorem posSemidef_fixedPoint_isPosDef
   suffices h_ne : star x ⬝ᵥ (ρ *ᵥ x) ≠ 0 from
     lt_of_le_of_ne h_nonneg (Ne.symm h_ne)
   intro h_zero
-  have h_ker := mulVec_eq_zero_of_quadForm_eq_zero ρ hρ_psd x h_zero
+  have h_ker := (hρ_psd.dotProduct_mulVec_zero_iff x).mp h_zero
   have h_inv := ker_invariant_under_adjoint A ρ hρ_psd hρ_fix x h_ker
   have h_all := ker_contains_all_of_span A hA ρ x h_inv
   have h_surj : ∀ v : Fin D → ℂ, ρ *ᵥ v = 0 := by

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -140,6 +140,9 @@ The clearest replacements are:
   `Submodule.span_singleton_eq_top_iff`, and the local-purification example
   simplifies `1 × 1` triple products directly with `Matrix.mul_apply` and
   `Fin.sum_univ_one`.
+- The PSD kernel-zero step in the QPF and MPS fixed-point projection proofs now
+  calls `Matrix.PosSemidef.dotProduct_mulVec_zero_iff` directly.  Two private
+  wrappers named `mulVec_eq_zero_of_quadForm_eq_zero` were removed.
 
 There are also important non-replacements.
 
@@ -1863,6 +1866,25 @@ The private helper remains as the shared expansion used by the transfer-matrix
 proof sites, but its proof now cites `Matrix.matrix_eq_sum_single` directly and
 simplifies by `Matrix.smul_single`, `smul_eq_mul`, and `mul_one` to recover the
 local notation.  The transfer-matrix statements are unchanged.
+
+## PSD kernel-zero wrapper cleanup, 2026-06-19
+
+Two private lemmas named `mulVec_eq_zero_of_quadForm_eq_zero` were exact
+one-line wrappers around Mathlib's positive-semidefinite kernel criterion
+`Matrix.PosSemidef.dotProduct_mulVec_zero_iff`:
+
+- `TNLean/QPF/PosDef.lean`
+- `TNLean/MPS/Irreducible/FixedPointProjection.lean`
+
+Both files now invoke `hρ_psd.dotProduct_mulVec_zero_iff` at the use sites.
+The fixed-point and positive-definiteness statements are unchanged.
+
+Focused check:
+
+```bash
+lake build TNLean.QPF.PosDef \
+  TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info
+```
 
 ## Conclusions
 


### PR DESCRIPTION
### Motivation

- Two private lemmas named `mulVec_eq_zero_of_quadForm_eq_zero`, one in `TNLean/QPF/PosDef.lean` and one in `TNLean/MPS/Irreducible/FixedPointProjection.lean`, were exact one-line restatements of the Mathlib criterion `Matrix.PosSemidef.dotProduct_mulVec_zero_iff` (available in Mathlib 4.31).
- Removing these wrappers reduces duplication and aligns with the Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`).

### Description

- Removed the private lemma `mulVec_eq_zero_of_quadForm_eq_zero` from `TNLean/QPF/PosDef.lean` and `TNLean/MPS/Irreducible/FixedPointProjection.lean`.
- The proofs `posSemidef_fixedPoint_isPosDef` (QPF) and `ker_invariant_under_adjoint` (MPS fixed-point projection) now call `hρ_psd.dotProduct_mulVec_zero_iff` directly at the use sites.
- Updated `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md` to record the removed wrappers.
- No mathematical statements were changed; this is a proof-internal reorganization.

### Testing

- `lake build TNLean.QPF.PosDef TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or statement changes; behavior matches the previous wrappers via the same Mathlib criterion.
>
> **Overview**
> Removes two identical private lemmas `mulVec_eq_zero_of_quadForm_eq_zero` from `TNLean/QPF/PosDef.lean` and `TNLean/MPS/Irreducible/FixedPointProjection.lean`. Each was a one-line pass-through to Mathlib's `Matrix.PosSemidef.dotProduct_mulVec_zero_iff`.
>
> **QPF** (`posSemidef_fixedPoint_isPosDef`) and **MPS** (`ker_invariant_under_adjoint`) now call `hρ_psd.dotProduct_mulVec_zero_iff` directly when turning a zero quadratic form into `ρ *ᵥ x = 0`. The positive-definiteness and fixed-point support-projection theorems are unchanged.
>
> The Mathlib 4.31 replacement audit documents the removal and the focused `lake build` targets for the two modules.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c1d711bc5173d6e0ed1bfe73473610ac89ee669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or statement changes; behavior matches the previous wrappers via the same Mathlib criterion.
> 
> **Overview**
> Removes two identical private lemmas `mulVec_eq_zero_of_quadForm_eq_zero` from `TNLean/QPF/PosDef.lean` and `TNLean/MPS/Irreducible/FixedPointProjection.lean`. Each was a one-line pass-through to Mathlib's `Matrix.PosSemidef.dotProduct_mulVec_zero_iff`.
> 
> **QPF** (`posSemidef_fixedPoint_isPosDef`) and **MPS** (`ker_invariant_under_adjoint`) now call `hρ_psd.dotProduct_mulVec_zero_iff` directly when turning a zero quadratic form into `ρ *ᵥ x = 0`. The positive-definiteness and fixed-point support-projection theorems are unchanged.
> 
> The Mathlib 4.31 replacement audit documents the removal and the focused `lake build` targets for the two modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e07a1547b1134dcca08cd0f64fa772db6d471d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->