### PR TITLE
refactor(Channel/Semigroup): inline CFC sqrt factorization

### DIFF
--- a/TNLean/Channel/Semigroup/KossakowskiForm.lean
+++ b/TNLean/Channel/Semigroup/KossakowskiForm.lean
@@ -132,16 +132,6 @@ private lemma dissipator_eq_half_kossakowski
   -- This is a ℂ-module identity: a-(1/2)b-(1/2)c = (1/2)((a-b)+(a-c))
   module
 
-/-- The PSD factorization: for `C ≥ 0`, `√C† * √C = C`. -/
-private lemma posSemidef_sqrt_factorization {n : ℕ}
-    (C : Matrix (Fin n) (Fin n) ℂ) (hC : C.PosSemidef) :
-    (CFC.sqrt C)ᴴ * CFC.sqrt C = C := by
-  have hC_nonneg : 0 ≤ C := Matrix.nonneg_iff_posSemidef.mpr hC
-  have hsqrt_psd : (CFC.sqrt C).PosSemidef :=
-    Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg C)
-  rw [hsqrt_psd.isHermitian.eq]
-  simpa using CFC.sqrt_mul_sqrt_self C hC_nonneg
-
 /-- Bilinear sum identity: `Σⱼ (Σₖ B_{jk}•Fₖ) * M * (Σₖ B_{jk}•Fₖ)†`
 equals `Σₖₗ (B†B)_{lk} • (Fₖ * M * Fₗ†)`. Used in Kossakowski ↔ Lindblad. -/
 private lemma kraus_sum_eq_double_sum {n : ℕ}
@@ -186,7 +176,13 @@ theorem kossakowski_iff_lindblad
     rintro ⟨KF, hKF⟩
     let B : Matrix (Fin KF.n) (Fin KF.n) ℂ := CFC.sqrt KF.C
     have hB : KF.C = Bᴴ * B := by
-      simpa [B] using (posSemidef_sqrt_factorization KF.C KF.C_posSemidef).symm
+      have hC_nonneg : 0 ≤ KF.C :=
+        Matrix.nonneg_iff_posSemidef.mpr KF.C_posSemidef
+      have hsqrt_psd : (CFC.sqrt KF.C).PosSemidef :=
+        Matrix.nonneg_iff_posSemidef.mp (CFC.sqrt_nonneg KF.C)
+      change KF.C = (CFC.sqrt KF.C)ᴴ * CFC.sqrt KF.C
+      rw [hsqrt_psd.isHermitian.eq]
+      simpa using (CFC.sqrt_mul_sqrt_self KF.C hC_nonneg).symm
     -- Define Lindblad operators: `Lⱼ = Σₖ B_{jk} • Fₖ`
     refine ⟨⟨KF.n, KF.H, fun j => ∑ k, B j k • KF.F k, KF.H_hermitian⟩, ?_⟩
     rw [hKF]

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1931,6 +1931,29 @@ positive real eigenvalue cast to a nonzero complex scalar.  The local
 `TNLean.Algebra.LinearMapAux` file contained only these declarations, and its
 imports were removed.
 
+## Kossakowski CFC square-root cleanup, 2026-06-19
+
+`TNLean/Channel/Semigroup/KossakowskiForm.lean` also had the private theorem
+`posSemidef_sqrt_factorization`, whose only role was to restate the CFC
+square-root factorization for a positive semidefinite complex matrix.
+
+The forward Kossakowski-to-Lindblad direction now uses the Mathlib facts
+directly:
+
+- `Matrix.nonneg_iff_posSemidef`
+- `CFC.sqrt_nonneg`
+- `CFC.sqrt_mul_sqrt_self`
+
+Thus the proof still constructs the same square-root factor `B = CFC.sqrt C`,
+but the intermediate theorem has been removed.  This reduces one local
+pass-through layer around Mathlib's C-star-algebra functional-calculus API.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Semigroup.KossakowskiForm -q --log-level=info
+```
+
 ## Conclusions
 
 Mathlib 4.31 materially improves the background library for TNLean, especially


### PR DESCRIPTION
## Summary

This PR removes the private pass-through theorem `posSemidef_sqrt_factorization` from `KossakowskiForm.lean`.

The forward Kossakowski-to-Lindblad direction now proves the factorization for `B = CFC.sqrt KF.C` directly from Mathlib CFC square-root facts, using `Matrix.nonneg_iff_posSemidef`, `CFC.sqrt_nonneg`, and `CFC.sqrt_mul_sqrt_self`. The mathematical statement of `kossakowski_iff_lindblad` is unchanged.

The Mathlib 4.31 replacement audit is updated with this cleanup.

## Validation

- `lake exe cache get`
- `lake build TNLean.Channel.Semigroup.KossakowskiForm -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

The focused Lean build reports only pre-existing short-copyright header warnings in imported semigroup/channel files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no statement or API changes; behavior of the Kossakowski–Lindblad conversion is unchanged.
> 
> **Overview**
> Removes the private wrapper `posSemidef_sqrt_factorization` from `KossakowskiForm.lean` and proves `KF.C = Bᴴ * B` for `B = CFC.sqrt KF.C` inline in the forward direction of **`kossakowski_iff_lindblad`**, using Mathlib’s `Matrix.nonneg_iff_posSemidef`, `CFC.sqrt_nonneg`, and `CFC.sqrt_mul_sqrt_self`.
> 
> The equivalence theorem and the Lindblad construction are unchanged; this only drops a pass-through layer around the CFC square-root API. The Mathlib 4.31 replacement audit documents the cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e98e924ace1be5f0ca67bf25c8e48b829ddd0ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->