### PR TITLE
refactor(Channel/Irreducible): inline factorial scalar facts

### DIFF
--- a/TNLean/Channel/Irreducible/Growth/Exponential.lean
+++ b/TNLean/Channel/Irreducible/Growth/Exponential.lean
@@ -98,16 +98,6 @@ private theorem isPositiveMap_smul_nonneg
     exact_mod_cast hc
   simpa only [LinearMap.smul_apply, Complex.coe_smul] using (hE X hX).smul hcC
 
-private lemma inv_factorial_nonneg (n : ℕ) :
-    0 ≤ ((n.factorial : ℂ)⁻¹) := by
-  have hfac_pos : (0 : ℂ) < (n.factorial : ℂ) := by
-    exact_mod_cast Nat.factorial_pos n
-  exact le_of_lt (inv_pos.mpr hfac_pos)
-
-private lemma inv_factorial_ne_zero (n : ℕ) :
-    ((n.factorial : ℂ)⁻¹) ≠ 0 :=
-  inv_ne_zero (by exact_mod_cast Nat.factorial_ne_zero n)
-
 private lemma pos_of_matrix_ne_zero
     {A : Matrix (Fin D) (Fin D) ℂ} (hA : A ≠ 0) : 0 < D := by
   by_contra hD
@@ -259,7 +249,7 @@ theorem exp_truncation_posDef_of_irreducible_cp
     isPositiveMap_smul_nonneg hCP.isPositiveMap ht.le
   have hterm_psd : ∀ k : ℕ, (term k).PosSemidef := by
     intro k
-    simpa only using (iterate_posSemidef hF_pos hA k).smul (inv_factorial_nonneg k)
+    simpa only using (iterate_posSemidef hF_pos hA k).smul (by positivity)
   have hsum_psd : (∑ k ∈ Finset.range D, term k).PosSemidef := by
     refine Matrix.posSemidef_sum (s := Finset.range D) (x := term) ?_
     intro k hk
@@ -277,7 +267,8 @@ theorem exp_truncation_posDef_of_irreducible_cp
         (s := Finset.range D) (term := term) (fun i _hi => hterm_psd i) hsum_zero hk
     change (((k.factorial : ℂ)⁻¹) • ((F ^ k) A)) *ᵥ v = 0 at hterm_zero
     rw [Matrix.smul_mulVec] at hterm_zero
-    exact (smul_eq_zero.mp hterm_zero).resolve_left (inv_factorial_ne_zero k)
+    exact (smul_eq_zero.mp hterm_zero).resolve_left
+      (inv_ne_zero (by exact_mod_cast Nat.factorial_ne_zero k))
   have hterm_zero_E : ∀ k ∈ Finset.range D, ((E ^ k) A) *ᵥ v = 0 := by
     intro k hk
     have hkF : ((F ^ k) A) *ᵥ v = 0 := hterm_zero_F k hk
@@ -324,7 +315,7 @@ theorem exp_posDef_of_irreducible_cp
   refine exp_apply_posDef_of_trunc_posDef (D := D) Φ A ?_ ?_
   · intro n
     rw [endEquiv_pow_apply]
-    exact (iterate_posSemidef hF_pos hA n).smul (inv_factorial_nonneg n)
+    exact (iterate_posSemidef hF_pos hA n).smul (by positivity)
   · have htrunc₀ :=
       exp_truncation_posDef_of_irreducible_cp E hCP hIrr A hA hA_ne ht
     have hsum_eq :

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1421,6 +1421,26 @@ lake build TNLean.QPF.PosDef TNLean.Channel.MaximallyEntangled \
   TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info
 ```
 
+### Exponential inverse-factorial scalar cleanup, 2026-06-19
+
+`TNLean/Channel/Irreducible/Growth/Exponential.lean` had two private scalar
+lemmas:
+
+- `inv_factorial_nonneg`
+- `inv_factorial_ne_zero`
+
+Both were pass-through wrappers around Mathlib's factorial positivity and
+nonzero facts.  The exponential positivity proof now invokes the native facts
+at the use sites: `positivity` proves the nonnegative inverse-factorial
+coefficient, and `Nat.factorial_ne_zero` under `inv_ne_zero` supplies the
+scalar nonzero fact used to cancel a vanishing scalar multiple.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Irreducible.Growth.Exponential -q --log-level=info
+```
+
 ### Projection-triangular pass-through removal, 2026-06-19
 
 The internal `ProjectionTriangularTrace` proof no longer introduces local


### PR DESCRIPTION
### Motivation

- Two private lemmas, `inv_factorial_nonneg` and `inv_factorial_ne_zero`, in
  `TNLean/Channel/Irreducible/Growth/Exponential.lean` duplicated facts already
  available in Mathlib; removing them reduces unnecessary indirection in the
  irreducible-CP exponential positivity chain.
- The Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`)
  flags private pass-through scalar lemmas as candidates for direct Mathlib use.

### Description

- **`TNLean/Channel/Irreducible/Growth/Exponential.lean`**: removes the private
  lemmas `inv_factorial_nonneg` and `inv_factorial_ne_zero`. The two call sites
  in `exp_truncation_posDef_of_irreducible_cp` and `exp_posDef_of_irreducible_cp`
  now discharge the corresponding goals with `positivity` (for the nonnegative
  $1/k!$ coefficient) and `inv_ne_zero` together with `Nat.factorial_ne_zero`
  (for the nonzero scalar used in `smul_eq_zero`), respectively.
- No theorem statements change; this is a proof-internal reorganization.
- **`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`**: updated to
  record this cleanup.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Irreducible.Growth.Exponential -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- Lean build reports only pre-existing warnings in imported files; no new errors.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with inlined Mathlib facts; no API or mathematical statement changes in the Wolf exponential irreducibility chain.
>
> **Overview**
> Removes the private pass-through lemmas `inv_factorial_nonneg` and `inv_factorial_ne_zero` from `TNLean/Channel/Irreducible/Growth/Exponential.lean`. The irreducible CP exponential positivity arguments (`exp_truncation_posDef_of_irreducible_cp` and `exp_posDef_of_irreducible_cp`) now discharge inverse-factorial facts at the call sites: `positivity` for nonnegative `1/k!` coefficients in PSD scaling steps, and `inv_ne_zero` with `Nat.factorial_ne_zero` when canceling a zero scalar multiple in the truncation contradiction.
>
> **No theorem statements change.** The Mathlib 4.31 replacement audit documents this cleanup.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 100f9b3d6a3b6006dd7a5b8e9e75a12f49741018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with inlined Mathlib facts; no API or mathematical statement changes in the Wolf exponential irreducibility chain.
> 
> **Overview**
> Removes two private pass-through lemmas (`inv_factorial_nonneg`, `inv_factorial_ne_zero`) from `TNLean/Channel/Irreducible/Growth/Exponential.lean`. The irreducible CP exponential positivity arguments now discharge inverse-factorial facts at the call sites in `exp_truncation_posDef_of_irreducible_cp` and `exp_posDef_of_irreducible_cp`: **`positivity`** for nonnegative \(1/k!\) coefficients when scaling PSD terms, and **`inv_ne_zero`** with **`Nat.factorial_ne_zero`** when ruling out a zero scalar in `smul_eq_zero`.
> 
> **No theorem statements change.** The Mathlib 4.31 replacement audit documents this cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c877774ed0a1e10c2b3d2ad64563bc8b48c7804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->