### PR TITLE
refactor(Channel/Schwarz): use positivity for scalar weights

### DIFF
--- a/TNLean/Channel/Schwarz/SchwarzNotCP.lean
+++ b/TNLean/Channel/Schwarz/SchwarzNotCP.lean
@@ -62,11 +62,11 @@ transpose and trace-times-identity. -/
 theorem wolfExample53_isPositive : IsPositiveMap wolfExample53 := by
   intro A hA
   have htranspose : ((1 / 2 : ℂ) • Aᵀ).PosSemidef :=
-    hA.transpose.smul (by norm_num [Complex.nonneg_iff])
+    hA.transpose.smul (by positivity)
   have htraceId : ((1 / 4 : ℂ) • (Matrix.trace A • (1 : M2))).PosSemidef := by
     have htrace : ((Matrix.trace A) • (1 : M2)).PosSemidef :=
       Matrix.PosSemidef.one.smul hA.trace_nonneg
-    exact htrace.smul (by norm_num [Complex.nonneg_iff])
+    exact htrace.smul (by positivity)
   simpa [wolfExample53] using htranspose.add htraceId
 
 private noncomputable def wolfExample53Gap (A : M2) : M2 :=
@@ -182,7 +182,7 @@ private lemma wolfExample53Gap_posSemidef_of_trace_zero (A : M2) (htr : Matrix.t
   rw [wolfExample53Gap_eq_of_trace_zero A htr]
   have h1 : ((1 / 2 : ℂ) • (Aᴴ * A)ᵀ).PosSemidef :=
     (Matrix.posSemidef_conjTranspose_mul_self A).transpose.smul
-      (by norm_num [Complex.nonneg_iff])
+      (by positivity)
   have h2base : (Matrix.trace (A * Aᴴ) • (1 : M2) - A * Aᴴ).PosSemidef :=
     trace_smul_one_sub_posSemidef_of_posSemidef (A * Aᴴ)
       (Matrix.posSemidef_self_mul_conjTranspose A)
@@ -191,7 +191,7 @@ private lemma wolfExample53Gap_posSemidef_of_trace_zero (A : M2) (htr : Matrix.t
   have h2 : ((1 / 4 : ℂ) • ((Matrix.trace (Aᴴ * A) • (1 : M2) - A * Aᴴ)ᵀ)).PosSemidef := by
     have h2' : ((Matrix.trace (Aᴴ * A) • (1 : M2) - A * Aᴴ)ᵀ).PosSemidef := by
       simpa [htrace] using h2base.transpose
-    exact h2'.smul (by norm_num [Complex.nonneg_iff])
+    exact h2'.smul (by positivity)
   exact h1.add h2
 
 /-- Wolf Example 5.3 satisfies the Schwarz inequality.

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -979,7 +979,7 @@ The Schwarz non-completely-positive example also had two private numeral facts:
 - `complex_one_quarter_nonneg`
 
 These were removed.  The four positivity uses now discharge the complex
-nonnegativity side condition directly by `norm_num [Complex.nonneg_iff]`.
+nonnegativity side condition directly by `positivity` under `ComplexOrder`.
 
 Focused check:
 


### PR DESCRIPTION
### Motivation
- In Wolf Example 5.3 (`SchwarzNotCP.lean`), four scalar nonnegativity obligations (coefficients 1/2 and 1/4 for `PosSemidef.smul`) were discharged by `norm_num [Complex.nonneg_iff]`; the `positivity` tactic (under `ComplexOrder`) discharges them directly, without requiring manual expansion of the nonnegativity condition.

### Description
- `TNLean/Channel/Schwarz/SchwarzNotCP.lean`: the four proof obligations that 1/2 and 1/4 are nonnegative complex scalars in Wolf Example 5.3 now use `by positivity` (with `ComplexOrder`) instead of `norm_num [Complex.nonneg_iff]`. No theorem statements change.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: updated to record that the Schwarz scalar nonnegativity steps use `positivity` rather than expanded `Complex.nonneg_iff` proofs.

### Testing
- `lake exe cache get`
- `lake build TNLean.Channel.Schwarz.SchwarzNotCP -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- The focused Lean build reports only pre-existing short-copyright header warnings.

---
No linked issue identified. The branch name `codex/native-schwarz-scalars` contains no issue number and the PR body contains no issue reference. Link one manually if this PR addresses an open issue (e.g., the Wolf Ch5 tracking issue LionSR/QICLean#30).

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or theorem changes; only how scalar nonnegativity is discharged in existing positivity arguments.
>
> **Overview**
> In **Wolf Example 5.3** (`SchwarzNotCP.lean`), the four proof obligations that **1/2** and **1/4** are nonnegative complex scalars for `PosSemidef.smul` now use **`by positivity`** (with **`ComplexOrder`**) instead of **`norm_num [Complex.nonneg_iff]`**. Theorem statements are unchanged.
>
> The Mathlib 4.31 replacement audit is updated to say those Schwarz scalar steps use **`positivity`** rather than expanded **`Complex.nonneg_iff`** proofs.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4c2e248114dae420e9f04b7f467361cbae3edf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only tactic swap in an existing positivity argument; no API, definitions, or theorem statements change.
> 
> **Overview**
> In **Wolf Example 5.3** (`SchwarzNotCP.lean`), four side conditions that the coefficients **1/2** and **1/4** are nonnegative complex scalars for `PosSemidef.smul` now close with **`by positivity`** (with **`ComplexOrder`**) instead of **`norm_num [Complex.nonneg_iff]`**. No theorem statements or proof architecture change.
> 
> The Mathlib 4.31 replacement audit documents that those Schwarz scalar steps use **`positivity`** rather than manual **`Complex.nonneg_iff`** expansion, consistent with removing the old private `complex_one_half_nonneg` / `complex_one_quarter_nonneg` lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9535db1f3a82a7b2a8ae0069b5cb55d531be211b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->