### PR TITLE
refactor(Channel/Semigroup): use Commute scalar API

### DIFF
--- a/TNLean/Channel/Semigroup/Basic.lean
+++ b/TNLean/Channel/Semigroup/Basic.lean
@@ -146,14 +146,6 @@ def expSemigroupCLM
 
 /-! ### Semigroup law for exp -/
 
-/-- `(t : ℂ) • L` commutes with `(s : ℂ) • L`. -/
-private theorem smul_comm_CLM
-    (L : MatrixCLM (Fin D))
-    (t s : ℂ) : Commute (t • L) (s • L) :=
-  by
-    ext X i j
-    simp [mul_left_comm]
-
 theorem expSemigroupCLM_add
     (L : MatrixCLM (Fin D))
     (t s : ℝ) :
@@ -162,7 +154,8 @@ theorem expSemigroupCLM_add
   have hsum : (((t : ℂ) + (s : ℂ)) • L) = (t : ℂ) • L + (s : ℂ) • L := by
     exact add_smul (t : ℂ) (s : ℂ) L
   rw [expSemigroupCLM, hcast, hsum]
-  exact NormedSpace.exp_add_of_commute (smul_comm_CLM L t s)
+  exact NormedSpace.exp_add_of_commute
+    (((Commute.refl L).smul_left (t : ℂ)).smul_right (s : ℂ))
 
 theorem expSemigroupCLM_zero
     (L : MatrixCLM (Fin D)) :

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1149,7 +1149,9 @@ The remaining semigroup proofs use the same structures directly through
 A later pass also removed the private convergence-ball helper `mem_exp_ball`
 from `TNLean.Channel.Semigroup.Basic`.  The semigroup law for
 `expSemigroupCLM` now calls Mathlib's ball-free
-`NormedSpace.exp_add_of_commute` directly.
+`NormedSpace.exp_add_of_commute` directly.  The same proof now uses
+`Commute.refl`, `Commute.smul_left`, and `Commute.smul_right` directly, so the
+private scalar-commutation helper `smul_comm_CLM` is no longer needed.
 
 A subsequent dissipative-drift pass removed the analogous private
 convergence-ball lemma from `TNLean.Channel.Semigroup.Dissipative`.  The


### PR DESCRIPTION
### Motivation

- The private helper `smul_comm_CLM` in `TNLean/Channel/Semigroup/Basic.lean` became redundant after the Mathlib 4.31 replacement audit (PR #3011): Mathlib's `Commute.refl`, `Commute.smul_left`, and `Commute.smul_right` supply the scalar-commutativity argument to `NormedSpace.exp_add_of_commute` directly.
- Removing private helpers that duplicate Mathlib API reduces future maintenance burden and keeps the codebase aligned with the upstream library.

### Description

- **`TNLean/Channel/Semigroup/Basic.lean`**: removed the private helper `smul_comm_CLM`. The proof of `expSemigroupCLM_add` now uses `Commute.refl L`, `Commute.smul_left`, and `Commute.smul_right` from Mathlib to supply commutativity of `(t : ℂ) • L` and `(s : ℂ) • L` required by `NormedSpace.exp_add_of_commute`. The statement of `expSemigroupCLM_add` is unchanged.
- **`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`**: updated to record that `smul_comm_CLM` is no longer needed alongside the earlier ball-free `exp_add_of_commute` cleanup.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Semigroup.Basic -q --log-level=info` — reports only pre-existing short-copyright header warnings.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or theorem statement changes; behavior of the exponential semigroup law is unchanged.
>
> **Overview**
> Removes the private helper **`smul_comm_CLM`** from `TNLean/Channel/Semigroup/Basic.lean`. The proof of **`expSemigroupCLM_add`** is unchanged in statement; commutation of `(t : ℂ) • L` and `(s : ℂ) • L` is now supplied to **`NormedSpace.exp_add_of_commute`** via Mathlib's **`Commute.refl`**, **`Commute.smul_left`**, and **`Commute.smul_right`** instead of a hand-written matrix-entry argument.
>
> The Mathlib 4.31 replacement audit documents that **`smul_comm_CLM`** is no longer needed alongside the earlier ball-free **`exp_add_of_commute`** cleanup.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 482d38b13b2ac5c793fcf5ae452a21b441e56d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no statement or API changes; behavior of the exponential semigroup addition law is unchanged.
> 
> **Overview**
> Removes the private helper **`smul_comm_CLM`** from `TNLean/Channel/Semigroup/Basic.lean`. The theorem **`expSemigroupCLM_add`** is unchanged; its proof now feeds **`NormedSpace.exp_add_of_commute`** via Mathlib's **`Commute.refl`**, **`Commute.smul_left`**, and **`Commute.smul_right`** instead of a hand-written matrix-entry commutativity argument.
> 
> The Mathlib 4.31 replacement audit notes that **`smul_comm_CLM`** is obsolete alongside the earlier ball-free **`exp_add_of_commute`** cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f37622967ba45910dbacb705f18a2214b69ca761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->