### PR TITLE
refactor(Channel/Semigroup): use Mathlib mulLeftRight hom

### DIFF
--- a/TNLean/Channel/Semigroup/Dissipative.lean
+++ b/TNLean/Channel/Semigroup/Dissipative.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.MatrixOperatorSpace
 import TNLean.Channel.Semigroup.CPClosure
+import Mathlib.Algebra.Azumaya.Defs
 import Mathlib.Analysis.Normed.Operator.Mul
 import Mathlib.Analysis.Normed.Algebra.MatrixExponential
 
@@ -72,28 +73,13 @@ private def clmExpD (T : MatrixCLM (Fin D)) : MatrixCLM (Fin D) :=
   letI : NormedRing (MatrixCLM (Fin D)) := ContinuousLinearMap.toNormedRing
   NormedSpace.exp T
 
-private def rightMulAlgHom (D : ℕ) : (Mat D)ᵐᵒᵖ →ₐ[ℂ] LM D where
-  toFun := fun B => LinearMap.mulRight ℂ (MulOpposite.unop B)
-  map_zero' := by
-    ext ρ i j
-    simp
-  map_add' A B := by
-    ext ρ i j
-    simp [Matrix.mul_add]
-  map_one' := by
-    ext ρ i j
-    simp
-  map_mul' A B := by
-    ext ρ i j
-    simp [mul_assoc]
-  commutes' c := by
-    ext ρ i j
-    rw [MulOpposite.algebraMap_apply]
-    simp [LinearMap.mulRight_apply, Algebra.algebraMap_eq_smul_one]
+private abbrev rightMulAlgHom (D : ℕ) : (Mat D)ᵐᵒᵖ →ₐ[ℂ] LM D :=
+  (AlgHom.mulLeftRight ℂ (Mat D)).comp
+    (Algebra.TensorProduct.includeRight (R := ℂ) (A := Mat D) (B := (Mat D)ᵐᵒᵖ))
 
 private theorem rightMulAlgHom_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
     rightMulAlgHom D A ρ = ρ * MulOpposite.unop A := by
-  rfl
+  simp [rightMulAlgHom]
 
 private abbrev leftMulCLMAlgHom (D : ℕ) : Mat D →ₐ[ℂ] MatrixCLM (Fin D) :=
   (endEquivD D).toAlgHom.comp (leftMulAlgHom D)
@@ -119,12 +105,6 @@ private theorem rightMulCLM_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
   change rightMulAlgHom D A ρ = ρ * MulOpposite.unop A
   exact rightMulAlgHom_apply A ρ
 
-private theorem left_right_commute (A B : Mat D) :
-    Commute (leftMulCLMAlgHom D A) (rightMulCLMAlgHom D (MulOpposite.op B)) := by
-  ext ρ i j
-  change (A * (ρ * B)) i j = ((A * ρ) * B) i j
-  rw [Matrix.mul_assoc]
-
 private theorem mulLeft_eq_leftMulAlgHom (A : Mat D) :
     LinearMap.mulLeft ℂ A = leftMulAlgHom D A := by
   ext ρ i j
@@ -133,7 +113,8 @@ private theorem mulLeft_eq_leftMulAlgHom (A : Mat D) :
 private theorem mulRight_eq_rightMulAlgHom (A : Mat D) :
     LinearMap.mulRight ℂ A = rightMulAlgHom D (MulOpposite.op A) := by
   ext ρ i j
-  simp [rightMulAlgHom_apply]
+  rw [rightMulAlgHom_apply]
+  simp
 
 private theorem endEquiv_mulLeft (A : Mat D) :
     endEquivD D (LinearMap.mulLeft ℂ A) = leftMulCLMAlgHom D A := by
@@ -142,6 +123,11 @@ private theorem endEquiv_mulLeft (A : Mat D) :
 private theorem endEquiv_mulRight (A : Mat D) :
     endEquivD D (LinearMap.mulRight ℂ A) = rightMulCLMAlgHom D (MulOpposite.op A) := by
   simpa [rightMulCLMAlgHom] using congrArg (endEquivD D) (mulRight_eq_rightMulAlgHom (D := D) A)
+
+private theorem left_right_commute (A B : Mat D) :
+    Commute (leftMulCLMAlgHom D A) (rightMulCLMAlgHom D (MulOpposite.op B)) := by
+  rw [← endEquiv_mulLeft (D := D) A, ← endEquiv_mulRight (D := D) B]
+  exact (LinearMap.commute_mulLeft_right (R := ℂ) A B).map (endEquivD D)
 
 private theorem endEquiv_dissipativeDrift
     (κ : Mat D) :
@@ -154,7 +140,11 @@ private theorem endEquiv_dissipativeDrift
     _ = -leftMulCLMAlgHom D κ - rightMulCLMAlgHom D (MulOpposite.op κᴴ) := by
           rw [endEquiv_mulLeft, endEquiv_mulRight]
     _ = leftMulCLMAlgHom D (-κ) + rightMulCLMAlgHom D (MulOpposite.op (-κᴴ)) := by
-          simp [sub_eq_add_neg]
+          rw [sub_eq_add_neg]
+          congr 1
+          · exact (map_neg (leftMulCLMAlgHom D) κ).symm
+          · rw [← map_neg (rightMulCLMAlgHom D) (MulOpposite.op κᴴ)]
+            simp
 
 private theorem exp_leftMulCLM
     (A : Mat D) :

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -105,6 +105,11 @@ The clearest replacements are:
   `Matrix.matrix_eq_sum_single` directly, with `Matrix.smul_single` used only
   to match the local scalar-matrix-unit notation.  The private helper remains
   as the shared statement used at the transfer-matrix proof sites.
+- The dissipative-drift right-multiplication algebra hom now comes from
+  Mathlib's `AlgHom.mulLeftRight`, composed with
+  `Algebra.TensorProduct.includeRight`.  The former hand-written algebra-hom
+  fields for right multiplication were removed, and the left-right
+  multiplication commutation proof now cites `LinearMap.commute_mulLeft_right`.
 - Further Lean 4.31 elaboration checks removed local heartbeat bounds from the
   POVM unitary-comparison proof, the irreducible-channel spectral-radius scalar
   proof, the semigroup perturbation derivative proof, and the common
@@ -1954,6 +1959,34 @@ Focused check:
 
 ```bash
 lake build TNLean.Channel.Semigroup.KossakowskiForm -q --log-level=info
+```
+
+## Dissipative right-multiplication hom cleanup, 2026-06-19
+
+`TNLean/Channel/Semigroup/Dissipative.lean` contained a hand-written algebra
+homomorphism
+
+- `rightMulAlgHom : (Mat D)ᵐᵒᵖ →ₐ[ℂ] (Mat D →ₗ[ℂ] Mat D)`
+
+whose fields only expressed that an element of the opposite algebra acts by
+right multiplication.  Mathlib 4.31 supplies the corresponding bimodule action
+as
+
+- `AlgHom.mulLeftRight ℂ (Mat D) :
+  (Mat D ⊗[ℂ] (Mat D)ᵐᵒᵖ) →ₐ[ℂ] Module.End ℂ (Mat D)`.
+
+The local right-action hom is now the composition of this Mathlib hom with
+`Algebra.TensorProduct.includeRight`.  The proof keeps the local shaped
+application lemma `rightMulAlgHom_apply`, but that lemma is now a `simp`
+consequence of `AlgHom.mulLeftRight_apply`.  The proof that left and right
+multiplication commute now maps Mathlib's `LinearMap.commute_mulLeft_right`
+through `endEquivD`, rather than reproving associativity pointwise on matrix
+entries.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.Semigroup.Dissipative -q --log-level=info
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- `TNLean/Channel/Semigroup/Dissipative.lean` contained a hand-written right-multiplication algebra homomorphism whose role is now covered by `AlgHom.mulLeftRight` in Mathlib 4.31, as identified in the Mathlib 4.31 replacement audit.
- Replacing the local construction with the Mathlib counterpart removes redundant `map_*` fields and reduces the maintenance surface in the dissipative-drift semigroup module.

### Description

- `TNLean/Channel/Semigroup/Dissipative.lean`: replaces the hand-written opposite-algebra right-multiplication homomorphism with `AlgHom.mulLeftRight` composed with `Algebra.TensorProduct.includeRight`; adds import of `Mathlib.Algebra.Azumaya.Defs` for the new API.
- The local `rightMulAlgHom_apply` lemma is retained with the same statement; its proof is simplified to `simp` via `AlgHom.mulLeftRight_apply` instead of manual `map_*` fields.
- Downstream definitions (`left_right_commute`, `mulRight_eq_rightMulAlgHom`, `endEquiv_dissipativeDrift`) are adjusted to match the new definition. No mathematical statements are changed.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records the `AlgHom.mulLeftRight` replacement.

### Testing

- `lake build TNLean.Channel.Semigroup.Dissipative` (focused build; reports only pre-existing dependency warnings).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- Full build validated by Lean CI (`lean_action_ci.yml`).

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof-only refactor delegating to Mathlib; dissipative semigroup statements and behavior are unchanged.
> 
> **Overview**
> Replaces the hand-written opposite-algebra **right-multiplication** homomorphism in `Dissipative.lean` with Mathlib 4.31’s `AlgHom.mulLeftRight`, composed with `Algebra.TensorProduct.includeRight` (new import from `Mathlib.Algebra.Azumaya.Defs`). The local `map_*` boilerplate is dropped; `rightMulAlgHom_apply` is unchanged in statement and now follows from `simp`.
> 
> **Left/right commute** and related bridge lemmas (`mulRight_eq_rightMulAlgHom`, `endEquiv_dissipativeDrift`) are updated to use `LinearMap.commute_mulLeft_right` via `endEquivD` instead of entrywise associativity. **No changes** to the main dissipative-drift semigroup theorems.
> 
> The Mathlib 4.31 replacement audit doc records this cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f378fecf35ddbd575f65954d84b3403e0db7caec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->