### PR TITLE
refactor(Wielandt): use Mathlib multiplication-map commutation

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -507,9 +507,10 @@ private theorem map_mulRight_map_mulLeft_comm
     Submodule.map (LinearMap.mulLeft ℂ a)
       (Submodule.map (LinearMap.mulRight ℂ b) S) := by
   simp only [← Submodule.map_comp]
-  congr 1
-  ext x
-  simp [LinearMap.mulLeft_apply, LinearMap.mulRight_apply, Matrix.mul_assoc]
+  rw [show LinearMap.mulRight ℂ b ∘ₗ LinearMap.mulLeft ℂ a =
+      LinearMap.mulLeft ℂ a ∘ₗ LinearMap.mulRight ℂ b by
+    simpa [Module.End.mul_eq_comp] using
+      (LinearMap.commute_mulLeft_right (R := ℂ) a b).eq.symm]
 
 /-- **Structural permanence**: if `finrank(R_n) = finrank(R_{n+1})` then
 `R_{n+2} = (A i₀) · R_{n+1}`. -/

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -151,6 +151,9 @@ The clearest replacements are:
 - Two span-growth multiplication-map composition proofs now use Mathlib's
   bundled matrix multiplication-map identities `mulLeftLinearMap_mul` and
   `mulRightLinearMap_mul`, rather than pointwise associativity expansions.
+- The rectangular-span permanence proof now obtains commutation of left- and
+  right-multiplication maps from Mathlib's `LinearMap.commute_mulLeft_right`,
+  rather than reproving matrix associativity pointwise.
 
 There are also important non-replacements.
 
@@ -1990,6 +1993,25 @@ Focused check:
 
 ```bash
 lake build TNLean.Channel.Semigroup.Dissipative -q --log-level=info
+```
+
+## Rectangular-span multiplication-map commutation cleanup, 2026-06-19
+
+`TNLean/Wielandt/RectangularSpan/Universality.lean` had a private theorem
+`map_mulRight_map_mulLeft_comm` proving that submodule images by left and right
+matrix multiplication commute.  The old proof expanded the two linear maps on a
+test matrix and used `Matrix.mul_assoc`.
+
+The proof now cites Mathlib's abstract algebra statement
+`LinearMap.commute_mulLeft_right`, converting the resulting equality in
+`Module.End` to the explicit `LinearMap.comp` form used by
+`Submodule.map_comp`.  The theorem remains as the local submodule-map shape
+needed by the rectangular-span permanence argument.
+
+Focused check:
+
+```bash
+lake build TNLean.Wielandt.RectangularSpan.Universality -q --log-level=info
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- The private lemma `map_mulRight_map_mulLeft_comm` in
  `TNLean/Wielandt/RectangularSpan/Universality.lean` proved that submodule
  images under left and right matrix multiplication commute, via a pointwise
  argument that expanded the two linear maps on a test matrix and invoked
  `Matrix.mul_assoc`. Mathlib 4.31 already provides this as
  `LinearMap.commute_mulLeft_right`, making the local proof redundant.
- The Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`)
  records this cleanup as part of the ongoing effort to delegate local
  matrix-algebra arguments to the upstream library.

### Description

- `TNLean/Wielandt/RectangularSpan/Universality.lean`: the proof of the private
  lemma `map_mulRight_map_mulLeft_comm` is rewritten to cite Mathlib's
  `LinearMap.commute_mulLeft_right` and converts the resulting `Module.End`
  equality to the explicit `LinearMap.comp` form required by
  `Submodule.map_comp` via `Module.End.mul_eq_comp`. No theorem statements
  change; the lemma shape needed by the rectangular-span permanence argument
  is preserved.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: a new section
  records this replacement.

### Testing

- `lake build TNLean.Wielandt.RectangularSpan.Universality -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

The focused Lean build reports only pre-existing header/import warnings in
dependencies.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor of a private helper with unchanged statements; the rectangular-span permanence argument still depends on the same lemma shape.
> 
> **Overview**
> The private lemma `map_mulRight_map_mulLeft_comm` still states that submodule images under left and right matrix multiplication commute, but its proof no longer unfolds maps on a test matrix and uses `Matrix.mul_assoc`. It now rewrites through `Submodule.map_comp` and cites Mathlib's `LinearMap.commute_mulLeft_right`, with `Module.End.mul_eq_comp` to match the `∘ₗ` composition form the permanence chain expects.
> 
> The Mathlib 4.31 replacement audit documents this as delegating commutation to Mathlib instead of a local associativity argument; no downstream theorem statements change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ea545b8791e6b4d2e4d75e85a468b6feccca1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper with unchanged statement and a single downstream use; proof-only refactor with no API or behavioral changes.
> 
> **Overview**
> Proof-only cleanup for the rectangular-span permanence chain: the private lemma **`map_mulRight_map_mulLeft_comm`** still states that submodule images under left and right matrix multiplication commute, but the proof no longer unfolds maps on a test matrix and uses **`Matrix.mul_assoc`**.
> 
> It now rewrites through **`Submodule.map_comp`** and cites Mathlib's **`LinearMap.commute_mulLeft_right`**, with **`Module.End.mul_eq_comp`** to match the **`∘ₗ`** composition form expected downstream (e.g. in **`rectSpan_nilpIndex_succ2_eq_mulLeft_of_finrank_eq`**). No public theorem statements change.
> 
> The Mathlib 4.31 replacement audit documents this as delegating commutation to Mathlib instead of a local associativity argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05e45c725588424bf88be7df9d74a5f54a98a0aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->