### PR TITLE
refactor(Wielandt): use Mathlib matrix multiplication maps

### DIFF
--- a/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
@@ -9,6 +9,7 @@ import TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan
 import TNLean.Wielandt.RectangularSpan.Universality
 import Mathlib.LinearAlgebra.Dimension.Finrank
 import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.LinearAlgebra.Matrix.Bilinear
 
 /-!
 # Invertible-element word span growth
@@ -196,9 +197,8 @@ theorem mulLeft_pow_image_wordSpan_le (A : MPSTensor d D)
                 (Submodule.map (LinearMap.mulLeft ℂ (A i₀ ^ k)) (wordSpan A n)) := by
               rw [← Submodule.map_comp]
               congr 1
-              ext x
-              simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
-                pow_succ', ← Matrix.mul_assoc]
+              rw [pow_succ']
+              exact mulLeftLinearMap_mul (o := Fin D) (R := ℂ) (A i₀) (A i₀ ^ k)
           _ ≤ Submodule.map (LinearMap.mulLeft ℂ (A i₀)) (wordSpan A (n + k)) :=
               Submodule.map_mono ih
           _ ≤ wordSpan A ((n + k) + 1) :=
@@ -409,8 +409,7 @@ private theorem map_mulRight_map_mulRight
       Submodule.map (LinearMap.mulRight ℂ (b * c)) S := by
   simp only [← Submodule.map_comp]
   congr 1
-  ext x
-  simp only [LinearMap.comp_apply, LinearMap.mulRight_apply, Matrix.mul_assoc]
+  exact (mulRightLinearMap_mul (l := Fin D) (R := ℂ) b c).symm
 
 /-- If `dim(S_r) = dim(S_{r+1})`, then every later word span is absorbed into
 the right-multiplication image of `S_r` by powers of the invertible generator.

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -148,6 +148,9 @@ The clearest replacements are:
 - The PSD kernel-zero step in the QPF and MPS fixed-point projection proofs now
   calls `Matrix.PosSemidef.dotProduct_mulVec_zero_iff` directly.  Two private
   wrappers named `mulVec_eq_zero_of_quadForm_eq_zero` were removed.
+- Two span-growth multiplication-map composition proofs now use Mathlib's
+  bundled matrix multiplication-map identities `mulLeftLinearMap_mul` and
+  `mulRightLinearMap_mul`, rather than pointwise associativity expansions.
 
 There are also important non-replacements.
 


### PR DESCRIPTION
### Motivation
- Two proofs in `InvertibleWordSpan.lean` expanded matrix associativity pointwise via `ext`/`simp`. Mathlib 4.31 provides bundled multiplication-map identities (`mulLeftLinearMap_mul`, `mulRightLinearMap_mul`) that make these steps direct one-liners.
- This replacement is part of the Mathlib 4.31 replacement audit tracked in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`.

### Description
- `TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean`:
  - `mulLeft_pow_image_wordSpan_le`: replaced pointwise `ext`/`simp [Matrix.mul_assoc]` with `mulLeftLinearMap_mul` (left-power span-growth step).
  - `map_mulRight_map_mulRight`: replaced pointwise `ext`/`simp [Matrix.mul_assoc]` with `mulRightLinearMap_mul` (right-multiplication composition helper).
  - Adds import of `Mathlib.LinearAlgebra.Matrix.Bilinear`.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records the two replacements.
- No public theorem statements or definitions are changed.

### Testing
- `lake build TNLean.Wielandt.SpanGrowth.InvertibleWordSpan -q --log-level=info` (reports only pre-existing header/import warnings).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- Lean CI (`lean_action_ci.yml`) validates the full build.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof-only refactor in auxiliary Wielandt span-growth lemmas; behavior and theorem statements are unchanged.
> 
> **Overview**
> Replaces hand-written **matrix associativity** steps in invertible word-span growth proofs with Mathlib 4.31’s bundled identities **`mulLeftLinearMap_mul`** and **`mulRightLinearMap_mul`**, instead of `ext`/`simp` on `Matrix.mul_assoc`.
> 
> In **`InvertibleWordSpan.lean`**, **`mulLeft_pow_image_wordSpan_le`** and private **`map_mulRight_map_mulRight`** are shortened accordingly; **`Mathlib.LinearAlgebra.Matrix.Bilinear`** is added for those lemmas. **No public theorem statements or definitions change.**
> 
> The Mathlib 4.31 replacement audit documents these two substitutions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 176372ac2a075767a172817b2e734a89fe7a1dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->