### PR TITLE
refactor(Algebra/Wielandt): use basis top criterion

### DIFF
--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -62,16 +62,9 @@ theorem span_range_mul_nonzero_mul_eq_top {n : Type*} [Fintype n]
     exact hprod ▸
       Submodule.subset_span
         (Set.mem_range_self (R, S))
-  apply eq_top_iff.mpr
-  have hbasis :
-      Submodule.span ℂ (Set.range (Matrix.stdBasis ℂ n n)) ≤
-        Submodule.span ℂ
-          (Set.range fun RS : Matrix n n ℂ × Matrix n n ℂ => RS.1 * C * RS.2) := by
-    refine Submodule.span_le.2 ?_
-    rintro M ⟨ij, rfl⟩
-    rcases ij with ⟨i, j⟩
-    simpa [Matrix.stdBasis_eq_single] using hsingle i j
-  simpa [(Matrix.stdBasis ℂ n n).span_eq] using hbasis
+  refine (Submodule.eq_top_iff_forall_basis_mem (Matrix.stdBasis ℂ n n)).2 ?_
+  rintro ⟨i, j⟩
+  simpa [Matrix.stdBasis_eq_single] using hsingle i j
 
 /-- Nondegeneracy of the trace pairing on square matrices over `ℂ`:
 if `trace (M * N) = 0` for all `N`, then `M = 0`. -/

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -347,17 +347,9 @@ theorem wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis
         _ = Matrix.single i j (1 : ℂ) := houter
     simpa [hcalc] using hprod
   -- Conclude `wordSpan = ⊤` by showing it contains the standard matrix basis.
-  apply eq_top_iff.mpr
-  have hbasis :
-      Submodule.span ℂ (Set.range (Matrix.stdBasis ℂ (Fin D) (Fin D))) ≤
-        wordSpan A (n + m) := by
-    refine Submodule.span_le.2 ?_
-    rintro M ⟨ij, rfl⟩
-    rcases ij with ⟨i, j⟩
-    simpa [Matrix.stdBasis_eq_single] using hsingle i j
-  have htop_le :
-      (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) ≤ wordSpan A (n + m) := by
-    simpa [(Matrix.stdBasis ℂ (Fin D) (Fin D)).span_eq] using hbasis
-  exact htop_le
+  refine (Submodule.eq_top_iff_forall_basis_mem
+    (Matrix.stdBasis ℂ (Fin D) (Fin D))).2 ?_
+  rintro ⟨i, j⟩
+  simpa [Matrix.stdBasis_eq_single] using hsingle i j
 
 end MPSTensor

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -154,6 +154,9 @@ The clearest replacements are:
 - The rectangular-span permanence proof now obtains commutation of left- and
   right-multiplication maps from Mathlib's `LinearMap.commute_mulLeft_right`,
   rather than reproving matrix associativity pointwise.
+- Two standard-basis spanning arguments now use Mathlib's
+  `Submodule.eq_top_iff_forall_basis_mem` directly, avoiding local detours
+  through `Matrix.stdBasis.span_eq` and `Submodule.span_le`.
 
 There are also important non-replacements.
 


### PR DESCRIPTION
### Motivation

- Both `span_range_mul_nonzero_mul_eq_top` (`TNLean/Algebra/TracePairing.lean`) and `wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis` (`TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean`) prove a matrix submodule equals `⊤` by chaining `eq_top_iff`, a `span_le` argument, and `Matrix.stdBasis.span_eq`.
- Mathlib 4.31 provides `Submodule.eq_top_iff_forall_basis_mem`, which directly encodes this criterion, making the local multi-step argument unnecessary.
- The Mathlib 4.31 replacement audit records this as aligning with the upstream API.

### Description

- `TNLean/Algebra/TracePairing.lean`: replaced the chained span argument in `span_range_mul_nonzero_mul_eq_top` with `Submodule.eq_top_iff_forall_basis_mem` applied to `Matrix.stdBasis`; membership of each standard basis element (via the existing `hsingle` lemmas) is retained.
- `TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean`: same replacement in `wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis`.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records the upstream API alignment.
- Theorem statements are unchanged; only the proof terms are shortened.

### Testing

- `lake build TNLean.Algebra.TracePairing TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

No linked issue identified; author should add `Addresses #N` once one is created or found.

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged theorem statements; no runtime, auth, or data-path impact.
>
> **Overview**
> Two proofs that a matrix submodule equals `⊤` now finish by **`Submodule.eq_top_iff_forall_basis_mem`** on `Matrix.stdBasis`, instead of chaining `eq_top_iff`, a `span_le` argument, and `Matrix.stdBasis.span_eq`.
>
> **`span_range_mul_nonzero_mul_eq_top`** in `TracePairing.lean` and **`wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis`** in `VectorToMatrixSpan.lean` still show each standard basis element lies in the span (via the existing `hsingle` lemmas); only the "span is all of `⊤`" step is shortened.
>
> The Mathlib 4.31 replacement audit records this as aligning with upstream API and dropping the local detour through `stdBasis.span_eq`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13bd7b376d22a5429b1f0fde203745ef3344c849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged theorem statements; no runtime, security, or data-path impact.
> 
> **Overview**
> Proof-only refactor: two arguments that a matrix submodule equals **`⊤`** now close with **`Submodule.eq_top_iff_forall_basis_mem`** on **`Matrix.stdBasis`**, instead of **`eq_top_iff`**, a **`span_le`** step, and **`Matrix.stdBasis.span_eq`**.
> 
> In **`span_range_mul_nonzero_mul_eq_top`** (`TracePairing.lean`) and **`wordSpan_eq_top_of_vectorSpreadSpan_eq_top_of_rankOneBasis`** (`VectorToMatrixSpan.lean`), the work showing each standard basis matrix lies in the span is unchanged (**`hsingle`**); only the final “hence the submodule is all of **`⊤`**” step is shortened.
> 
> The Mathlib 4.31 replacement audit documents this as aligning with upstream API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c66b7ed54f03bc1254c637a1f1beb6782f4a6bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->