### PR TITLE
refactor(Algebra): use trace-pairing iff directly

### DIFF
--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -170,11 +170,6 @@ lemma SameMPV.trace_evalWord {A B : MPSTensor d D} (h : SameMPV A B) (w : List (
   -- Use the `SameMPV` equality on the configuration `σ := w.get`.
   simpa [mpv, coeff, List.ofFn_get] using h w.length w.get
 
-/-- Nondegeneracy of the trace pairing on `D×D` complex matrices. -/
-lemma trace_mul_right_eq_zero {M : Matrix (Fin D) (Fin D) ℂ}
-    (h : ∀ N : Matrix (Fin D) (Fin D) ℂ, Matrix.trace (M * N) = 0) : M = 0 := by
-  simpa using (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) M).1 h
-
 /-- The linear map `M ↦ (i ↦ trace (M * A i))`. -/
 noncomputable def traceMulRightPi (A : MPSTensor d D) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin d → ℂ) :=
@@ -208,7 +203,7 @@ theorem traceMulRightPi_ker_eq_bot {A : MPSTensor d D} (hA : IsInjective A) :
     intro i
     simpa using congrArg (· i) hM
   -- Use trace nondegeneracy.
-  exact trace_mul_right_eq_zero fun N => by
+  exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) M).1 fun N => by
     simpa [Matrix.traceLinearMap_apply] using congrArg (· N) hφ
 
 /-- If `A` is injective and `A`, `B` generate the same MPV family,

--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -203,7 +203,8 @@ theorem sameMPV_of_sameMPVFrom_of_injective [NeZero D]
   set S := ∑ i, c i • B i
   have hS : S = 1 := by
     suffices h : S - 1 = 0 from sub_eq_zero.mp h
-    apply trace_mul_right_eq_zero; intro N
+    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (S - 1)).1
+    intro N
     -- The linear functional tr((S−1) · _) vanishes on wordSpan B N₀ = ⊤
     have hf : (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
         (LinearMap.mulLeft ℂ (S - 1)) = 0 := by

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -437,11 +437,11 @@ theorem pairTraceSeparatingAt_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
         exact hΔ w)
       M hM
   constructor
-  · apply trace_mul_right_eq_zero
+  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₁) ΔA).1
     intro M
     have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
-  · apply trace_mul_right_eq_zero
+  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₂) ΔB).1
     intro N
     have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
@@ -501,11 +501,11 @@ theorem pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop {D₁ D₂ : �
         exact hΔ w hw)
       M (by simpa [pairCumulativeSpan] using hM)
   constructor
-  · apply trace_mul_right_eq_zero
+  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₁) ΔA).1
     intro M
     have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
-  · apply trace_mul_right_eq_zero
+  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₂) ΔB).1
     intro N
     have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
@@ -593,11 +593,11 @@ theorem pairTraceSeparatingAll_of_pairAllWordsSpanTop {D₁ D₂ : ℕ}
         exact hΔ w)
       M (by simpa [pairAllWordsSpan] using hM)
   constructor
-  · apply trace_mul_right_eq_zero
+  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₁) ΔA).1
     intro M
     have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
-  · apply trace_mul_right_eq_zero
+  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₂) ΔB).1
     intro N
     have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -235,7 +235,7 @@ theorem leftTraceWordMap_injective_of_isNBlkInjective {A : MPSTensor d D}
     · intro t
       simpa [leftTraceWordMap_apply, Matrix.traceLinearMap_apply] using
         congrArg (fun f => f t) hZ
-  exact trace_mul_right_eq_zero fun N => by
+  exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) Z).1 fun N => by
     simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
 
 /-- Under block injectivity, the trace-test image has the full boundary-matrix

--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -63,7 +63,7 @@ theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D}
       · intro σ
         simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
           congrArg (fun ψ => ψ σ) hX
-    exact trace_mul_right_eq_zero fun N => by
+    exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) X).1 fun N => by
       have hNX : Matrix.trace (N * X) = 0 := by
         simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
       calc

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -251,7 +251,7 @@ theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
       · intro σ
         simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
           congrArg (fun ψ => ψ σ) hX
-    exact trace_mul_right_eq_zero fun N => by
+    exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) X).1 fun N => by
       have hNX : Matrix.trace (N * X) = 0 := by
         simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
       calc

--- a/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
+++ b/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
@@ -112,7 +112,7 @@ theorem mpv_ne_zero_of_isNBlkInjective {A : MPSTensor d D} [NeZero D]
       evalWord A w₂ = 0 := by
     intro w₂ hw₂
     -- Show ∀ M, tr(evalWord A w₂ * M) = 0 to get evalWord A w₂ = 0.
-    apply trace_mul_right_eq_zero
+    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (evalWord A w₂)).1
     intro M
     -- The functional P ↦ tr(P * evalWord A w₂) vanishes on wordSpan A L₀ = ⊤.
     have hφ : (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -374,7 +374,7 @@ private theorem eq_zero_of_trace_evalWord_mul_eq_zero {A : MPSTensor d D}
     · simpa [wordSpan] using hwordK
     · intro σ
       simp [Matrix.traceLinearMap_apply, h σ]
-  exact trace_mul_right_eq_zero fun N => by
+  exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) X).1 fun N => by
     have hNX : Matrix.trace (N * X) = 0 := by
       simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
     calc Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -149,7 +149,10 @@ theorem isCID_implies_isRFP
   suffices h_diff : transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) -
       transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)) = 0 from
     eq_of_sub_eq_zero h_diff
-  apply trace_mul_right_eq_zero; intro N
+  apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D)
+    (transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) -
+      transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)))).1
+  intro N
   -- From IsCID with n=2, m=1: correlator equality gives trace equality
   have h := hCID ↑u hρ_pd hρ_fix X N 2 1 (by omega) (by omega)
   simp only [connectedCorrelator_def, twoPointExpectation_transfer] at h

--- a/TNLean/PEPS/CycleMPSInjectivity.lean
+++ b/TNLean/PEPS/CycleMPSInjectivity.lean
@@ -393,7 +393,7 @@ theorem matrix_eq_zero_of_isNBlkInjective {L : ℕ} {A : MPSTensor d D}
       rw [hpair]
       exact hC x
     simpa using hle hM
-  have hCt : Cᵀ = 0 := MPSTensor.trace_mul_right_eq_zero hker
+  have hCt : Cᵀ = 0 := (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) Cᵀ).1 hker
   simpa using congrArg Matrix.transpose hCt
 
 variable [NeZero n]

--- a/TNLean/PiAlgebra/Construction.lean
+++ b/TNLean/PiAlgebra/Construction.lean
@@ -247,7 +247,9 @@ theorem piTrace_mul_right_eq_zero
       ∑ k, Matrix.trace (M k * N k) = 0) :
     M = 0 := by
   classical
-  funext k; apply trace_mul_right_eq_zero; intro N_k
+  funext k
+  apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin (dim k)) (M k)).1
+  intro N_k
   have := h (Function.update 0 k N_k)
   rwa [Finset.sum_eq_single k
     (fun j _ hj => by rw [Function.update_of_ne hj, Pi.zero_apply, mul_zero, Matrix.trace_zero])

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -164,6 +164,9 @@ The clearest replacements are:
 - The Kadison-Schwarz finite-index Kraus-map conjugate-transpose facts now
   defer to the general `Kraus.map_conjTranspose` theorem.  The later
   multiplicative-domain files no longer reprove the same finite-sum identity.
+- The one-way `MPSTensor.trace_mul_right_eq_zero` wrapper was removed.  Call
+  sites now use the forward direction of the public
+  `Matrix.trace_mul_right_eq_zero_iff` theorem directly.
 
 There are also important non-replacements.
 
@@ -878,7 +881,8 @@ Keep for now:
 - Trace-pairing wrappers only when they are part of TNLean's public
   mathematical vocabulary.  Private equality-form wrappers should use
   `Matrix.ext_iff_trace_mul_left` and `Matrix.ext_iff_trace_mul_right`
-  directly.
+  directly.  The one-way `MPSTensor.trace_mul_right_eq_zero` specialization has
+  been removed in favor of `Matrix.trace_mul_right_eq_zero_iff`.
 
 ### `TNLean/Algebra/BlockTriangularTrace.lean`
 

--- a/docs/audits/block_separation_core_memo.txt
+++ b/docs/audits/block_separation_core_memo.txt
@@ -218,7 +218,7 @@ Files:
 
 File: `TNLean/Algebra/TracePairing.lean`:
 
-* `trace_mul_right_eq_zero` (nondegeneracy of trace pairing).
+* `Matrix.trace_mul_right_eq_zero_iff` (nondegeneracy of trace pairing).
 * `traceMulRightPi_ker_eq_bot` (injectivity of the “Gram map” when A is injective).
 
 These are plausible ingredients for the “injectivity gives spanning ⇒ enough equations” step


### PR DESCRIPTION
### Motivation

- `MPSTensor.trace_mul_right_eq_zero` was a one-way specialization of the upstream Mathlib lemma `Matrix.trace_mul_right_eq_zero_iff`. Removing it in favour of calling the Mathlib iff's forward direction directly eliminates project-internal duplication and keeps all call sites aligned with the authoritative upstream statement.

### Description

- `TNLean/Algebra/TracePairing.lean`: removed `MPSTensor.trace_mul_right_eq_zero` (the one-way wrapper around `Matrix.trace_mul_right_eq_zero_iff`).
- Updated eleven call sites to use `Matrix.trace_mul_right_eq_zero_iff` forward direction directly: `TNLean/MPS/FundamentalTheorem/FiniteLength.lean`, `TNLean/MPS/MPDO/BiCFDerivation/Core.lean`, `TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean`, `TNLean/MPS/ParentHamiltonian/BlockStrip.lean`, `TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean`, `TNLean/MPS/ParentHamiltonian/Nonvanishing.lean`, `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`, `TNLean/MPS/RFP/ZeroCorrelationLength.lean`, `TNLean/PEPS/CycleMPSInjectivity.lean`, `TNLean/PiAlgebra/Construction.lean`.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md` and `docs/audits/block_separation_core_memo.txt` updated to point to the retained Mathlib theorem `Matrix.trace_mul_right_eq_zero_iff`.

### Testing

- `lake build` on all changed modules (`TNLean.Algebra.TracePairing`, `TNLean.MPS.FundamentalTheorem.FiniteLength`, `TNLean.MPS.MPDO.BiCFDerivation.Core`, `TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput`, `TNLean.MPS.ParentHamiltonian.BlockStrip`, `TNLean.MPS.ParentHamiltonian.IntersectionProperty`, `TNLean.MPS.ParentHamiltonian.Nonvanishing`, `TNLean.MPS.ParentHamiltonian.UniqueGroundState`, `TNLean.MPS.RFP.ZeroCorrelationLength`, `TNLean.PEPS.CycleMPSInjectivity`, `TNLean.PiAlgebra.Construction`).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 30d05041d7673cc6068fcaa72cf80ab42c1df59f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with no API or proof-strategy change; risk is limited to typo-level breakage at call sites, covered by `lake build`.
> 
> **Overview**
> Removes the one-way `MPSTensor.trace_mul_right_eq_zero` wrapper and routes trace nondegeneracy through Mathlib’s `Matrix.trace_mul_right_eq_zero_iff` forward direction at every former call site.
> 
> **`TNLean/Algebra/TracePairing.lean`** drops the duplicate lemma; proofs that concluded `M = 0` from vanishing trace pairings now apply `(Matrix.trace_mul_right_eq_zero_iff …).1` with the same matrix and index type (`Fin D`, `Fin D₁`, etc.).
> 
> **Call sites** updated across MPS fundamental theorem, MPDO biCF derivation, parent Hamiltonian, RFP zero correlation length, PEPS cycle injectivity, and Pi-algebra construction—logic unchanged, only the cited theorem.
> 
> **Docs** (`2026-06-18_mathlib_4_31_replacement_audit.md`, `block_separation_core_memo.txt`) now point at `Matrix.trace_mul_right_eq_zero_iff` instead of the removed wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a5f6261f2132e51a4c82a504fcbca218ab464b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->