### PR TITLE
refactor(Channel/Schwarz): centralize Kraus star map

### DIFF
--- a/TNLean/Channel/Schwarz/KadisonSchwarz.lean
+++ b/TNLean/Channel/Schwarz/KadisonSchwarz.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Channel.Basic
+import TNLean.Channel.Schwarz.Basic
 
 /-!
 # Kadison–Schwarz inequality for completely positive maps
@@ -70,6 +70,24 @@ theorem krausMap_one_of_unital (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
 theorem krausAdjointMap_one_of_TP (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (h : IsTPKraus K) : krausAdjointMap K 1 = 1 := by
   simp only [krausAdjointMap, mul_one]; exact h
+
+/-- The finite-index Kadison-Schwarz Kraus map is the general Kraus map. -/
+theorem krausMap_eq_map (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    krausMap K X = Kraus.map K X :=
+  rfl
+
+/-- The Kadison-Schwarz Kraus map commutes with conjugate transpose. -/
+theorem krausMap_conjTranspose (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    krausMap K Xᴴ = (krausMap K X)ᴴ := by
+  simpa [krausMap_eq_map] using (Kraus.map_conjTranspose (K := K) X).symm
+
+/-- The conjugate transpose of a Kadison-Schwarz Kraus map. -/
+theorem conjTranspose_krausMap (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    (krausMap K X)ᴴ = krausMap K Xᴴ := by
+  simpa [krausMap_eq_map] using Kraus.map_conjTranspose (K := K) X
 
 /-- The adjoint Kraus map equals the Kraus map with conjugate-transposed operators. -/
 private theorem krausAdjointMap_eq (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (Y) :

--- a/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
@@ -56,13 +56,6 @@ private theorem trace_krausMap_of_tp (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
   conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
   rw [← trace_sum, ← Finset.sum_mul, show ∑ i : Fin d, (K i)ᴴ * K i = 1 from h_tp, one_mul]
 
-/-- The conjugate transpose of `krausMap K X` is `krausMap K (X†)`. -/
-private theorem krausMap_conjTranspose (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    (krausMap K X)ᴴ = krausMap K Xᴴ := by
-  simp only [krausMap, conjTranspose_sum, conjTranspose_mul, conjTranspose_conjTranspose,
-    mul_assoc]
-
 end AuxiliaryLemmas
 
 /-! ## KS equality for peripheral eigenvectors -/
@@ -173,7 +166,7 @@ theorem ks_gap_eq_sum_squares (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
   -- Now use: ∑ KᵢX†Kᵢ† = E(X†) = E(X)†
   have hEXconj : ∑ i : Fin d, K i * Xᴴ * (K i)ᴴ = (E X)ᴴ := by
     change E Xᴴ = (E X)ᴴ
-    exact (krausMap_conjTranspose K X).symm
+    exact krausMap_conjTranspose K X
   -- And: E(X)† * (∑ KᵢKᵢ†) = E(X)† since ∑ KᵢKᵢ† = I
   have hunit : (∑ i : Fin d, (E X)ᴴ * K i * (K i)ᴴ) = (E X)ᴴ := by
     simp_rw [mul_assoc]

--- a/TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean
@@ -44,14 +44,6 @@ section AuxiliaryLemmas
     krausMap K (μ • X) = μ • krausMap K X := by
   simp [krausMap, Finset.smul_sum, mul_assoc]
 
-theorem krausMap_conjTranspose (K : Fin d → Mat) (X : Mat) :
-    krausMap K Xᴴ = (krausMap K X)ᴴ := by
-  simp [krausMap, conjTranspose_sum, conjTranspose_mul, mul_assoc]
-
-theorem conjTranspose_krausMap (K : Fin d → Mat) (X : Mat) :
-    (krausMap K X)ᴴ = krausMap K Xᴴ := by
-  rw [krausMap_conjTranspose]
-
 end AuxiliaryLemmas
 
 section Definitions

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -161,6 +161,9 @@ The clearest replacements are:
   multiplication map in their definitions.  The pass-through lemmas
   `biRectSpan_eq_map_comp` and `cumulativeBiRectSpan_eq_map_comp`, which only
   specialized `Submodule.map_comp`, were removed.
+- The Kadison-Schwarz finite-index Kraus-map conjugate-transpose facts now
+  defer to the general `Kraus.map_conjTranspose` theorem.  The later
+  multiplicative-domain files no longer reprove the same finite-sum identity.
 
 There are also important non-replacements.
 
@@ -2019,6 +2022,37 @@ Focused check:
 
 ```bash
 lake build TNLean.Wielandt.RectangularSpan.Universality -q --log-level=info
+```
+
+## Kadison-Schwarz Kraus star-interface cleanup, 2026-06-19
+
+`TNLean/Channel/Schwarz/KadisonSchwarz.lean`,
+`TNLean/Channel/Schwarz/MultiplicativeDomain.lean`, and
+`TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean` each carried their own
+version, or proof, of the same statement that a finite Kraus map commutes with
+conjugate transpose.
+
+The two public Kadison-Schwarz orientations are now proved once in
+`KadisonSchwarz.lean` from the general channel-interface theorem
+`Kraus.map_conjTranspose`, through the definitional equality between
+`KadisonSchwarz.krausMap` and `Kraus.map`.  The private proof in
+`MultiplicativeDomain.lean` and the duplicate public proofs in
+`MultiplicativeDomainFull.lean` were removed; downstream statements keep the
+same names and mathematical content.
+
+Focused checks:
+
+```bash
+lake build TNLean.Channel.Schwarz.KadisonSchwarz \
+  TNLean.Channel.Schwarz.MultiplicativeDomain \
+  TNLean.Channel.Schwarz.MultiplicativeDomainFull -q --log-level=info
+lake build TNLean.Channel.Determinant.HeisenbergDual \
+  TNLean.Channel.FixedPoint.Algebra \
+  TNLean.Channel.Peripheral.ClosureFixedPoint \
+  TNLean.Channel.Peripheral.CyclicGroup \
+  TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorDecomposition \
+  TNLean.MPS.Periodic.Overlap.SelfOverlapSetup \
+  TNLean.MPS.Periodic.SectorIrreducibility.HLift -q --log-level=info
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- The conjugate-transpose compatibility facts for the finite-index Kadison–Schwarz Kraus map were proved separately in three files (`KadisonSchwarz.lean`, `MultiplicativeDomain.lean`, and `MultiplicativeDomainFull.lean`), producing redundant proof code.
- The general channel-interface theorem `Kraus.map_conjTranspose` already establishes that a finite Kraus map commutes with conjugate transpose; the three independent proofs can be replaced by a single derivation.
- Centralizing eliminates the risk of the three proofs drifting apart if the Kraus API changes.

### Description

- `TNLean/Channel/Schwarz/KadisonSchwarz.lean`: proved `krausMap_conjTranspose` and `conjTranspose_krausMap` once, using the definitional equality `krausMap_eq_map` and the existing general theorem `Kraus.map_conjTranspose`; import updated to `TNLean.Channel.Schwarz.Basic` to reach this API.
- `TNLean/Channel/Schwarz/MultiplicativeDomain.lean`: removed the private proof of the conjugate-transpose compatibility fact (1 addition, 8 deletions); call sites now reference the centralized lemmas in `KadisonSchwarz.lean`.
- `TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean`: removed duplicate public proofs of `krausMap_conjTranspose` and `conjTranspose_krausMap` from the `AuxiliaryLemmas` section (8 deletions); downstream theorem names and mathematical statements are unchanged.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: documented the deduplication under the "Kadison–Schwarz Kraus star-interface cleanup" entry.

No mathematical content changed; this is a proof-organization reorganization only.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Schwarz.KadisonSchwarz TNLean.Channel.Schwarz.MultiplicativeDomain TNLean.Channel.Schwarz.MultiplicativeDomainFull -q --log-level=info`
- Downstream build check: `lake build TNLean.Channel.Determinant.HeisenbergDual TNLean.Channel.FixedPoint.Algebra TNLean.Channel.Peripheral.ClosureFixedPoint TNLean.Channel.Peripheral.CyclicGroup TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorDecomposition TNLean.MPS.Periodic.Overlap.SelfOverlapSetup TNLean.MPS.Periodic.SectorIrreducibility.HLift -q --log-level=info`
- Post-rebase focused check: `lake build TNLean.Channel.Schwarz.KadisonSchwarz TNLean.Channel.Schwarz.MultiplicativeDomain TNLean.Channel.Schwarz.MultiplicativeDomainFull TNLean.Channel.Determinant.HeisenbergDual TNLean.Channel.FixedPoint.Algebra -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
No linked issue identified. The author should link one manually if this reorganization addresses an open task.

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavioral changes; downstream theorems keep the same names and rely on definitional equality plus an existing general lemma.
>
> **Overview**
> **Finite-index Kadison–Schwarz `krausMap` star facts are proved once** in `KadisonSchwarz.lean` via `krausMap_eq_map` and the channel theorem `Kraus.map_conjTranspose`, including both `krausMap_conjTranspose` and `conjTranspose_krausMap`. The file's import is switched to `TNLean.Channel.Schwarz.Basic` to reach that API.
>
> **Duplicate proofs are removed** from `MultiplicativeDomain.lean` (private lemma) and `MultiplicativeDomainFull.lean` (public duplicates in `AuxiliaryLemmas`). Call sites such as the KS gap decomposition now cite the centralized lemmas; theorem names and statements downstream are unchanged.
>
> The Mathlib 4.31 replacement audit documents this deduplication and the focused `lake build` checks.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 761a1fc572772d68f7dda632730d94a648fd9a5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only deduplication with no behavioral or public API changes; downstream files still use the same lemma names via the shared `KadisonSchwarz` module.
> 
> **Overview**
> **Kadison–Schwarz `krausMap` star compatibility is proved in one place.** `KadisonSchwarz.lean` now imports `TNLean.Channel.Schwarz.Basic`, adds `krausMap_eq_map`, and derives `krausMap_conjTranspose` / `conjTranspose_krausMap` from `Kraus.map_conjTranspose` instead of a separate finite-sum proof.
> 
> **Duplicate proofs are deleted downstream.** The private lemma in `MultiplicativeDomain.lean` and the public copies in `MultiplicativeDomainFull.lean` are removed; sites such as the KS gap decomposition cite the centralized theorems. **Theorem names and statements are unchanged.**
> 
> The Mathlib 4.31 replacement audit records this cleanup and the focused `lake build` checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e34a6d72411048c909812455cbf3f86bdeff84d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->