### PR TITLE
refactor(Channel): share Fin zero-padding sum

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -24,6 +24,7 @@ import TNLean.Algebra.GramMatrixLI
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixAux
+import TNLean.Algebra.FinSum
 import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.UnitModulusPowerSum
 import TNLean.Algebra.FiniteCycleCoboundary

--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Logic.Equiv.Fin.Basic
+
+/-!
+# Finite initial-segment sums
+
+This file collects small finite-sum identities for `Fin` index types.
+-/
+
+open scoped BigOperators
+
+namespace Fin
+
+/-- A sum over `Fin r` can be rewritten as a zero-padded sum over `Fin s`
+when `r ≤ s`. -/
+theorem sum_castLE_extend_zero {r s : ℕ} {β : Type*} [AddCommMonoid β]
+    (f : Fin r → β) (h : r ≤ s) :
+    ∑ j : Fin r, f j =
+      ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
+  classical
+  calc
+    ∑ j : Fin r, f j =
+        ∑ α : { i : Fin s // (i : ℕ) < r }, f ⟨α.1.val, α.2⟩ := by
+          refine Fintype.sum_equiv (Fin.castLEquiv h) f
+            (fun α : { i : Fin s // (i : ℕ) < r } => f ⟨α.1.val, α.2⟩) ?_
+          intro j
+          simp [Fin.castLEquiv]
+    _ = ∑ α ∈ (Finset.univ.filter fun α : Fin s => α.val < r),
+          if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
+          rw [show (Finset.univ : Finset { i : Fin s // (i : ℕ) < r }) =
+              (Finset.univ : Finset (Fin s)).subtype (fun i : Fin s => (i : ℕ) < r) by
+                ext α
+                simp]
+          have hsub :=
+            Finset.sum_subtype_eq_sum_filter
+              (s := (Finset.univ : Finset (Fin s)))
+              (p := fun i : Fin s => (i : ℕ) < r)
+              (f := fun α : Fin s =>
+                if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0)
+          have hleft :
+              (∑ α ∈ (Finset.univ : Finset (Fin s)).subtype
+                    (fun i : Fin s => (i : ℕ) < r),
+                  (if hlt : (α : Fin s).val < r then f ⟨(α : Fin s).val, hlt⟩ else 0)) =
+                ∑ α ∈ (Finset.univ : Finset (Fin s)).subtype
+                    (fun i : Fin s => (i : ℕ) < r),
+                  f ⟨(α : Fin s).val, α.2⟩ := by
+            refine Finset.sum_congr rfl ?_
+            intro α _
+            simp [α.2]
+          exact hleft.symm.trans hsub
+    _ = ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
+          have hfilter :=
+            Finset.sum_filter
+              (s := (Finset.univ : Finset (Fin s)))
+              (p := fun α : Fin s => α.val < r)
+              (f := fun α : Fin s =>
+                if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0)
+          have hright :
+              (∑ α : Fin s,
+                if α.val < r then
+                  (if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0)
+                else 0) =
+                ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
+            refine Finset.sum_congr rfl ?_
+            intro α _
+            by_cases hlt : α.val < r <;> simp [hlt]
+          exact hfilter.trans hright
+
+end Fin

--- a/TNLean/Channel/KrausFreedom.lean
+++ b/TNLean/Channel/KrausFreedom.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Channel.Basic
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Stinespring
+import TNLean.Algebra.FinSum
 import TNLean.Algebra.TracePairing
 
 /-!
@@ -90,29 +91,6 @@ theorem kraus_conjTranspose_mul_eq_of_map_eq
 
 /-! ### Rectangular Kraus freedom -/
 
-/-- Reindexing a sum from `Fin r₂` to `Fin r₁` via zero-padding. -/
-private lemma sum_pad_zeros {r₁ r₂ : ℕ} {β : Type*} [AddCommMonoid β]
-    (f : Fin r₂ → β) (hCard : r₂ ≤ r₁) :
-    ∑ j : Fin r₂, f j =
-    ∑ α : Fin r₁, if hlt : α.val < r₂ then f ⟨α.val, hlt⟩ else 0 := by
-  symm
-  have hsub : ∑ α ∈ Finset.univ.filter (fun α : Fin r₁ => α.val < r₂),
-      (if hlt : α.val < r₂ then f ⟨α.val, hlt⟩ else 0) =
-      ∑ α : Fin r₁, if hlt : α.val < r₂ then f ⟨α.val, hlt⟩ else 0 := by
-    apply Finset.sum_subset (Finset.filter_subset _ _)
-    intro α _ hα
-    have : ¬(α.val < r₂) := by simpa using hα
-    simp [dif_neg this]
-  rw [← hsub]; symm
-  apply Finset.sum_nbij (fun j : Fin r₂ =>
-    (⟨j.val, Nat.lt_of_lt_of_le j.isLt hCard⟩ : Fin r₁))
-  · intro j _; exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, j.isLt⟩
-  · intro j₁ _ j₂ _ hj; exact Fin.ext (Fin.mk.inj hj)
-  · intro α hα
-    have hα' := (Finset.mem_filter.mp (Finset.mem_coe.mp hα)).2
-    exact ⟨⟨α.val, hα'⟩, Finset.mem_coe.mpr (Finset.mem_univ _), Fin.ext rfl⟩
-  · intro j _; simp [Fin.eta]
-
 private abbrev KrausCoeffSpace (r : ℕ) := EuclideanSpace ℂ (Fin r)
 
 private abbrev KrausEntrySpace (D : ℕ) := EuclideanSpace ℂ (Fin D × Fin D)
@@ -170,7 +148,7 @@ theorem kraus_rectangular_freedom
   have hBA' : ∀ X, ∑ α : Fin r₁, B α * X * (B α)ᴴ =
       ∑ α : Fin r₁, A' α * X * (A' α)ᴴ := by
     intro X; rw [h X]
-    rw [sum_pad_zeros (fun j => A j * X * (A j)ᴴ) hCard]
+    rw [Fin.sum_castLE_extend_zero (fun j => A j * X * (A j)ᴴ) hCard]
     apply Finset.sum_congr rfl; intro α _
     simp only [A']; split_ifs <;> simp
   -- Dual map equality
@@ -296,7 +274,8 @@ theorem kraus_rectangular_freedom
       have := congr_fun (congr_fun hU_mat_eq α) (a, b)
       simpa [Matrix.mul_apply, MB, MA'] using this.symm
     rw [h_entry]; simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
-    rw [sum_pad_zeros (fun j => U_mat α (Fin.castLE hCard j) * (A j) a b) hCard]
+    rw [Fin.sum_castLE_extend_zero
+      (fun j => U_mat α (Fin.castLE hCard j) * (A j) a b) hCard]
     apply Finset.sum_congr rfl; intro β _
     simp only [A']; split_ifs with hlt
     · simp only [Fin.eta, Fin.castLE]

--- a/TNLean/Channel/KrausRank.lean
+++ b/TNLean/Channel/KrausRank.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Spectrum
 import Mathlib.Data.Fintype.Card
+import TNLean.Algebra.FinSum
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Channel.ChoiJamiolkowski
 
@@ -65,34 +66,6 @@ def HasKrausRankLE (E : Mat →ₗ[ℂ] Mat) (r : ℕ) : Prop :=
 noncomputable def choiRank (E : Mat →ₗ[ℂ] Mat) : ℕ :=
   (ChoiJamiolkowski.choiMatrix E).rank
 
-/-- A sum indexed by `Fin r` can be padded by zeros to a larger `Fin s`. -/
-private lemma sum_pad_zeros {r s : ℕ} {β : Type*} [AddCommMonoid β]
-    (f : Fin r → β) (hCard : r ≤ s) :
-    ∑ j : Fin r, f j =
-      ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
-  symm
-  have hsub :
-      ∑ α ∈ Finset.univ.filter (fun α : Fin s => α.val < r),
-          (if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0) =
-        ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
-    apply Finset.sum_subset (Finset.filter_subset _ _)
-    intro α _ hα
-    have : ¬ α.val < r := by
-      simpa using hα
-    simp [dif_neg this]
-  rw [← hsub]
-  symm
-  apply Finset.sum_nbij (fun j : Fin r => (⟨j.val, Nat.lt_of_lt_of_le j.isLt hCard⟩ : Fin s))
-  · intro j _
-    exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, j.isLt⟩
-  · intro j₁ _ j₂ _ hj
-    exact Fin.ext (Fin.mk.inj hj)
-  · intro α hα
-    have hα' := (Finset.mem_filter.mp (Finset.mem_coe.mp hα)).2
-    exact ⟨⟨α.val, hα'⟩, Finset.mem_coe.mpr (Finset.mem_univ _), Fin.ext rfl⟩
-  · intro j _
-    simp [Fin.eta]
-
 /-- If `E` has `r` Kraus operators and `r ≤ s`, then it also has `s` Kraus
 operators obtained by zero-padding. -/
 theorem hasKrausCard_mono {E : Mat →ₗ[ℂ] Mat} {r s : ℕ}
@@ -102,7 +75,7 @@ theorem hasKrausCard_mono {E : Mat →ₗ[ℂ] Mat} {r s : ℕ}
   rcases hE with ⟨K, hK⟩
   refine ⟨fun α => if hlt : α.val < r then K ⟨α.val, hlt⟩ else 0, ?_⟩
   intro X
-  rw [hK X, sum_pad_zeros (f := fun j => K j * X * (K j)ᴴ) hCard]
+  rw [hK X, Fin.sum_castLE_extend_zero (f := fun j => K j * X * (K j)ᴴ) hCard]
   refine Finset.sum_congr rfl ?_
   intro α _
   simp only

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -167,6 +167,9 @@ The clearest replacements are:
 - The one-way `MPSTensor.trace_mul_right_eq_zero` wrapper was removed.  Call
   sites now use the forward direction of the public
   `Matrix.trace_mul_right_eq_zero_iff` theorem directly.
+- The two private Kraus zero-padding sum lemmas are replaced by the shared
+  `Fin.sum_castLE_extend_zero`, proved from Mathlib's `Fin.castLEquiv` and the
+  standard subtype/filter finite-sum identities.
 
 There are also important non-replacements.
 
@@ -2057,6 +2060,30 @@ lake build TNLean.Channel.Determinant.HeisenbergDual \
   TNLean.MPS.CanonicalForm.SectorComparison.CyclicSectorDecomposition \
   TNLean.MPS.Periodic.Overlap.SelfOverlapSetup \
   TNLean.MPS.Periodic.SectorIrreducibility.HLift -q --log-level=info
+```
+
+## Fin zero-padding sum cleanup, 2026-06-19
+
+`TNLean/Channel/KrausRank.lean` and `TNLean/Channel/KrausFreedom.lean` both had
+private lemmas named `sum_pad_zeros`.  Each lemma proved the same initial
+segment identity: a sum over `Fin r` may be rewritten as a zero-padded sum over
+`Fin s` when `r ≤ s`.
+
+The new general lemma
+
+- `Fin.sum_castLE_extend_zero`
+
+in `TNLean/Algebra/FinSum.lean` proves this once from Mathlib's
+`Fin.castLEquiv`, together with `Finset.sum_subtype_eq_sum_filter` and
+`Finset.sum_filter`.  The two Kraus files now call this shared theorem at their
+padding sites and no longer carry local `sum_nbij` proofs.
+
+Focused check:
+
+```bash
+lake build TNLean.Algebra.FinSum \
+  TNLean.Channel.KrausRank \
+  TNLean.Channel.KrausFreedom -q --log-level=info
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- `TNLean.Channel.KrausRank` and `TNLean.Channel.KrausFreedom` each contained a
  private `sum_pad_zeros` lemma proving the same identity: a sum over `Fin r`
  equals a zero-padded sum over `Fin s` when `r ≤ s`. The duplication was
  identified in the Mathlib 4.31 replacement audit
  (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`).
- Consolidating this identity into a shared algebra module removes the duplicated
  proof and makes the result available to other Channel files.

### Description

- Adds `TNLean/Algebra/FinSum.lean` with the lemma `Fin.sum_castLE_extend_zero`:
  for `r ≤ s` and `f : Fin r → β`, the sum `∑ j : Fin r, f j` equals
  `∑ α : Fin s, if α.val < r then f ⟨α.val, _⟩ else 0`. Proved from Mathlib's
  `Fin.castLEquiv`, `Finset.sum_subtype_eq_sum_filter`, and `Finset.sum_filter`.
- Removes the duplicate private `sum_pad_zeros` lemma from
  `TNLean/Channel/KrausRank.lean` and `TNLean/Channel/KrausFreedom.lean`; both
  now call `Fin.sum_castLE_extend_zero` at the Kraus zero-padding steps
  (including rectangular Kraus freedom).
- Registers `TNLean.Algebra.FinSum` in the root import surface (`TNLean.lean`).
- Records the consolidation in the Mathlib 4.31 replacement audit document.
- No mathematical content of any public theorem is changed.

### Testing

- `lake exe cache get`
- `lake build TNLean.Algebra.FinSum TNLean.Channel.KrausRank TNLean.Channel.KrausFreedom -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
<!-- No linked issue found — author should add `Addresses #N` or `Closes #N` manually. -->

> [!NOTE]
> **Low Risk**
> Pure refactor of duplicated finite-sum algebra with no change to public Kraus theorem statements; risk is limited to proof maintenance in channel files that already depended on the same identity.
>
> **Overview**
> Introduces **`TNLean.Algebra.FinSum`** with **`Fin.sum_castLE_extend_zero`**, which rewrites a sum over `Fin r` as a zero-padded sum over `Fin s` when `r ≤ s`, using Mathlib's `Fin.castLEquiv` and standard finset subtype/filter sum lemmas.
>
> **`KrausRank`** and **`KrausFreedom`** drop their duplicate private **`sum_pad_zeros`** proofs and call the shared theorem at Kraus zero-padding steps (including rectangular Kraus freedom). The module is added to the root import surface, and the Mathlib 4.31 replacement audit documents the consolidation.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9839775af0afb4138fdadab5f4941f4809ceea09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no change to public theorem statements; risk is limited to the padding rewrites in KrausRank and KrausFreedom.
> 
> **Overview**
> **Adds** `TNLean.Algebra.FinSum` with **`Fin.sum_castLE_extend_zero`**, which rewrites `∑ j : Fin r, f j` as a zero-padded sum over `Fin s` when `r ≤ s`, using Mathlib's `Fin.castLEquiv` and finset subtype/filter sum lemmas.
> 
> **Removes** duplicate private **`sum_pad_zeros`** proofs from **`KrausRank`** and **`KrausFreedom`**; those proofs now call the shared lemma at Kraus zero-padding steps (including rectangular Kraus freedom). **`TNLean.lean`** imports the new module, and the Mathlib 4.31 replacement audit documents the consolidation. Public Kraus theorem statements are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e05f1e52485b12265cbf0ee499f8aabc192616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->