### PR TITLE
refactor(Algebra): share Frobenius trace identity

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.Matrix.PosDef
+import Mathlib.Analysis.Matrix.Normed
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.CStarAlgebra.Matrix
@@ -16,10 +17,57 @@ Extracted from various files for reusability.
 
 ## Main results
 
+- `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`: the Hilbert--Schmidt
+  trace form of the Frobenius norm
 - `Matrix.PosSemidef.mulVec_eq_zero_left/right`: kernel containment for PSD matrix sums
 -/
 
-open scoped Matrix BigOperators ComplexOrder
+open scoped Matrix BigOperators ComplexOrder Matrix.Norms.Frobenius
+
+namespace Matrix
+
+section FrobeniusTrace
+
+variable {m n : Type*} [Fintype m] [Fintype n]
+
+/-- Entrywise form of the Hilbert--Schmidt trace identity. -/
+theorem trace_conjTranspose_mul_self_re_eq_sum_normSq
+    (A : Matrix m n ℂ) :
+    (trace (Aᴴ * A)).re = ∑ j : n, ∑ i : m, ‖A i j‖ ^ 2 := by
+  have hstar_mul_re : ∀ z : ℂ, (star z * z).re = ‖z‖ ^ 2 := by
+    intro z
+    rw [show star z = starRingEnd ℂ z from rfl, Complex.conj_mul',
+      ← Complex.ofReal_pow]
+    exact Complex.ofReal_re _
+  simp only [trace, diag, mul_apply, conjTranspose_apply, Complex.re_sum]
+  refine Finset.sum_congr rfl ?_
+  intro j _
+  refine Finset.sum_congr rfl ?_
+  intro i _
+  simpa only [RCLike.star_def, Complex.mul_re, Complex.conj_re, Complex.conj_im,
+    neg_mul, sub_neg_eq_add] using hstar_mul_re (A i j)
+
+/-- The real trace of `Aᴴ * A` is the square of Mathlib's Frobenius norm. -/
+theorem trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq
+    (A : Matrix m n ℂ) :
+    (trace (Aᴴ * A)).re = ‖A‖ ^ 2 := by
+  rw [trace_conjTranspose_mul_self_re_eq_sum_normSq]
+  rw [Matrix.frobenius_norm_def, ← Real.sqrt_eq_rpow, Real.sq_sqrt]
+  · calc
+      ∑ j : n, ∑ i : m, ‖A i j‖ ^ 2 =
+          ∑ j : n, ∑ i : m, ‖A i j‖ ^ (2 : ℝ) := by
+            refine Finset.sum_congr rfl ?_
+            intro j _
+            refine Finset.sum_congr rfl ?_
+            intro i _
+            exact (Real.rpow_natCast (‖A i j‖) 2).symm
+      _ = ∑ i : m, ∑ j : n, ‖A i j‖ ^ (2 : ℝ) := by
+            rw [Finset.sum_comm]
+  · positivity
+
+end FrobeniusTrace
+
+end Matrix
 
 /-! ## Kernel intersection for PSD matrices -/
 

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -17,6 +17,8 @@ Extracted from various files for reusability.
 
 ## Main results
 
+- `Matrix.trace_conjTranspose_mul_self_re_eq_sum_norm_sq`: entrywise Hilbert--Schmidt
+  trace identity
 - `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`: the Hilbert--Schmidt
   trace form of the Frobenius norm
 - `Matrix.PosSemidef.mulVec_eq_zero_left/right`: kernel containment for PSD matrix sums
@@ -31,7 +33,7 @@ section FrobeniusTrace
 variable {m n : Type*} [Fintype m] [Fintype n]
 
 /-- Entrywise form of the Hilbert--Schmidt trace identity. -/
-theorem trace_conjTranspose_mul_self_re_eq_sum_normSq
+theorem trace_conjTranspose_mul_self_re_eq_sum_norm_sq
     (A : Matrix m n ℂ) :
     (trace (Aᴴ * A)).re = ∑ j : n, ∑ i : m, ‖A i j‖ ^ 2 := by
   have hstar_mul_re : ∀ z : ℂ, (star z * z).re = ‖z‖ ^ 2 := by
@@ -47,11 +49,11 @@ theorem trace_conjTranspose_mul_self_re_eq_sum_normSq
   simpa only [RCLike.star_def, Complex.mul_re, Complex.conj_re, Complex.conj_im,
     neg_mul, sub_neg_eq_add] using hstar_mul_re (A i j)
 
-/-- The real trace of `Aᴴ * A` is the square of Mathlib's Frobenius norm. -/
+/-- The real trace of `Aᴴ * A` is the square of the Frobenius norm. -/
 theorem trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq
     (A : Matrix m n ℂ) :
     (trace (Aᴴ * A)).re = ‖A‖ ^ 2 := by
-  rw [trace_conjTranspose_mul_self_re_eq_sum_normSq]
+  rw [trace_conjTranspose_mul_self_re_eq_sum_norm_sq]
   rw [Matrix.frobenius_norm_def, ← Real.sqrt_eq_rpow, Real.sq_sqrt]
   · calc
       ∑ j : n, ∑ i : m, ‖A i j‖ ^ 2 =

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -238,7 +238,7 @@ lemma channelDet_norm_one_hs_norm_ge [NeZero d]
       (Matrix.trace (Aᴴ * A)).re =
           ∑ ij : Fin d × Fin d, ∑ kl : Fin d × Fin d,
             ‖(Φ (b ij)) kl.1 kl.2‖ ^ 2 := by
-              simp only [stdBasis, Matrix.trace_conjTranspose_mul_self_re_eq_sum_normSq,
+              simp only [stdBasis, Matrix.trace_conjTranspose_mul_self_re_eq_sum_norm_sq,
                 LinearMap.toMatrix_apply, Module.Basis.map_repr, Module.Basis.map_apply,
                 Module.Basis.coe_reindex, Function.comp_apply,
                 Equiv.sigmaEquivProd_symm_apply, Pi.basis_apply, Pi.basisFun_apply,
@@ -270,7 +270,7 @@ lemma channelDet_norm_one_hs_norm_ge [NeZero d]
                       ‖Φ (Matrix.stdBasis ℂ (Fin d) (Fin d) ij) i j‖ ^ 2 := by
                         rw [Finset.sum_comm]
             exact hsum_sq.trans
-              (Matrix.trace_conjTranspose_mul_self_re_eq_sum_normSq
+              (Matrix.trace_conjTranspose_mul_self_re_eq_sum_norm_sq
                 (A := Φ (Matrix.stdBasis ℂ (Fin d) (Fin d) ij))).symm
   calc
     (d : ℝ) ^ 2 ≤ (Matrix.trace (Aᴴ * A)).re :=

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Determinant.Bound
+import TNLean.Algebra.MatrixAux
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.InnerProductSpace.Trace
@@ -167,23 +168,6 @@ lemma eq_zero_of_nonneg_of_sum_le_zero {ι : Type*} [Fintype ι]
   have h3 := Finset.sum_eq_zero_iff_of_nonneg (fun i _ => hf i) |>.mp h2
   exact h3 i (Finset.mem_univ i)
 
-private lemma complex_star_mul_re (z : ℂ) : (star z * z).re = ‖z‖ ^ 2 := by
-  rw [show star z = starRingEnd ℂ z from rfl, Complex.conj_mul',
-    ← Complex.ofReal_pow]
-  exact Complex.ofReal_re _
-
-private lemma trace_conjTranspose_mul_self_re_eq_sum_sq {m n : Type*} [Fintype m] [Fintype n]
-    (A : Matrix m n ℂ) :
-    (Matrix.trace (Aᴴ * A)).re = ∑ j, ∑ i, ‖A i j‖ ^ 2 := by
-  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.conjTranspose_apply,
-    Complex.re_sum]
-  refine Finset.sum_congr rfl ?_
-  intro j _
-  refine Finset.sum_congr rfl ?_
-  intro i _
-  simpa only [RCLike.star_def, Complex.mul_re, Complex.conj_re, Complex.conj_im,
-    neg_mul, sub_neg_eq_add] using complex_star_mul_re (A i j)
-
 private lemma matrix_det_norm_one_trace_conjTranspose_mul_self_ge [NeZero d]
     (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (hdet : ‖A.det‖ = 1) :
     (d : ℝ) ^ 2 ≤ (Matrix.trace (Aᴴ * A)).re := by
@@ -254,7 +238,7 @@ lemma channelDet_norm_one_hs_norm_ge [NeZero d]
       (Matrix.trace (Aᴴ * A)).re =
           ∑ ij : Fin d × Fin d, ∑ kl : Fin d × Fin d,
             ‖(Φ (b ij)) kl.1 kl.2‖ ^ 2 := by
-              simp only [stdBasis, trace_conjTranspose_mul_self_re_eq_sum_sq,
+              simp only [stdBasis, Matrix.trace_conjTranspose_mul_self_re_eq_sum_normSq,
                 LinearMap.toMatrix_apply, Module.Basis.map_repr, Module.Basis.map_apply,
                 Module.Basis.coe_reindex, Function.comp_apply,
                 Equiv.sigmaEquivProd_symm_apply, Pi.basis_apply, Pi.basisFun_apply,
@@ -286,7 +270,7 @@ lemma channelDet_norm_one_hs_norm_ge [NeZero d]
                       ‖Φ (Matrix.stdBasis ℂ (Fin d) (Fin d) ij) i j‖ ^ 2 := by
                         rw [Finset.sum_comm]
             exact hsum_sq.trans
-              (trace_conjTranspose_mul_self_re_eq_sum_sq
+              (Matrix.trace_conjTranspose_mul_self_re_eq_sum_normSq
                 (A := Φ (Matrix.stdBasis ℂ (Fin d) (Fin d) ij))).symm
   calc
     (d : ℝ) ^ 2 ≤ (Matrix.trace (Aᴴ * A)).re :=

--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -99,7 +99,7 @@ lemma norm_matToES_sq (M : Matrix (Fin m) (Fin n) ℂ) :
       ← Complex.ofReal_pow]]
   exact Complex.ofReal_re _
 
-/-- The Euclidean-space norm of a flattened matrix is Mathlib's Frobenius norm. -/
+/-- The Euclidean-space norm of a flattened matrix is the Frobenius norm. -/
 lemma norm_matToES_eq_frobenius_norm (M : Matrix (Fin m) (Fin n) ℂ) :
     ‖matToES M‖ = ‖M‖ := by
   rw [← sq_eq_sq₀ (norm_nonneg _) (norm_nonneg _)]

--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.Matrix.Normed
 import Mathlib.Analysis.Matrix.Order
+import TNLean.Algebra.MatrixAux
 
 /-!
 # Frobenius norm squared and Euclidean-space embedding for matrices
@@ -54,13 +55,7 @@ lemma frobSq_eq_sum (X : Matrix (Fin m) (Fin n) ℂ) :
 /-- The Frobenius norm squared equals `(trace(X† X)).re`. -/
 lemma frobSq_trace (X : Matrix (Fin m) (Fin n) ℂ) :
     frobSq X = (Matrix.trace (Xᴴ * X)).re := by
-  rw [frobSq_eq_sum]
-  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply,
-    Matrix.conjTranspose_apply, Complex.re_sum]
-  rw [Finset.sum_comm]
-  congr 1; ext i; congr 1; ext j
-  rw [show star (X j i) * X j i = ↑(Complex.normSq (X j i)) from
-    Complex.normSq_eq_conj_mul_self.symm, Complex.ofReal_re, Complex.normSq_eq_norm_sq]
+  rw [frobSq, Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq]
 
 lemma frobSq_eq_zero_iff (X : Matrix (Fin m) (Fin n) ℂ) : frobSq X = 0 ↔ X = 0 := by
   rw [frobSq, sq_eq_zero_iff, norm_eq_zero]


### PR DESCRIPTION
### Motivation
- The real part of the trace identity $\operatorname{tr}(A^\dagger A)_{\mathbb{R}} = \sum_{i,j} \|A_{ij}\|^2$ was proved independently in both `TNLean.Channel.Determinant.HilbertSchmidt` and `TNLean.Spectral.FrobeniusNorm`; consolidating it removes the duplication.
- Placing the Frobenius-norm bridge $\operatorname{tr}(A^\dagger A)_{\mathbb{R}} = \|A\|^2$ in `TNLean.Algebra.MatrixAux` (layer 0) makes it available to all downstream modules without re-proof.

### Description
- **`TNLean/Algebra/MatrixAux.lean`**: adds two shared public lemmas:
  - `Matrix.trace_conjTranspose_mul_self_re_eq_sum_normSq`: the identity `(trace (Aᴴ * A)).re = ∑ i j, ‖A i j‖²`
  - `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`: the Frobenius-norm form `(trace (Aᴴ * A)).re = ‖A‖²`, derived from Mathlib 4.31 `Matrix.frobenius_norm_def`
  - Adds import of `Mathlib.Analysis.Matrix.Normed` for the norm bridge.
- **`TNLean/Channel/Determinant/HilbertSchmidt.lean`**: removes the private `complex_star_mul_re` / `trace_conjTranspose_mul_self_re_eq_sum_sq` block; the AM--GM Hilbert--Schmidt argument now cites the shared `Matrix.trace_conjTranspose_mul_self_re_eq_sum_normSq`.
- **`TNLean/Spectral/FrobeniusNorm.lean`**: shortens `frobSq_trace` to a one-line rewrite through `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`; mathematical content is unchanged.
- No new `sorry` introduced; the pre-existing `Periodic.Overlap.Case3` warning is unrelated to this change.

### Testing
- `lake build TNLean.Algebra.MatrixAux TNLean.Spectral.FrobeniusNorm TNLean.Channel.Determinant.HilbertSchmidt`
- `lake build TNLean` (full build; only pre-existing repository warnings reported)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
No linked issue found — please link one manually if this change addresses a tracked task.

> [!NOTE]
> **Low Risk**
> Proof-only deduplication with no API or runtime behavior changes; mathematical statements are preserved by moving lemmas to a shared module.
> 
> **Overview**
> Centralizes duplicated Hilbert--Schmidt / Frobenius trace proofs in **`TNLean.Algebra.MatrixAux`**, then rewires callers to use the shared lemmas instead of local copies.
> 
> **`MatrixAux`** gains public `Matrix.trace_conjTranspose_mul_self_re_eq_sum_normSq` (entrywise `(trace (Aᴴ * A)).re`) and `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq` (ties that real trace to Mathlib's `‖A‖²` via `frobenius_norm_def`), with `Mathlib.Analysis.Matrix.Normed` imported for the norm bridge.
> 
> **`HilbertSchmidt`** drops the private `complex_star_mul_re` / `trace_conjTranspose_mul_self_re_eq_sum_sq` block and imports `MatrixAux`; the AM--GM Hilbert--Schmidt argument now cites `Matrix.trace_conjTranspose_mul_self_re_eq_sum_normSq`.
> 
> **`FrobeniusNorm.frobSq_trace`** is shortened to a one-line rewrite through `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq` instead of re-proving the trace expansion inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4dc92e19f073a1b0e354a313433fa641ae33a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only consolidation with no runtime or API behavior changes; lemmas are relocated and callers updated without altering theorems.
> 
> **Overview**
> **Deduplicates** Hilbert–Schmidt / Frobenius trace proofs by moving them into **`TNLean.Algebra.MatrixAux`** and pointing existing callers at the shared lemmas.
> 
> **`MatrixAux`** now exports `Matrix.trace_conjTranspose_mul_self_re_eq_sum_norm_sq` (entrywise `(trace (Aᴴ * A)).re`) and `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq` (same real trace equals `‖A‖²` via Mathlib `frobenius_norm_def`), with `Mathlib.Analysis.Matrix.Normed` added for the norm bridge.
> 
> **`HilbertSchmidt`** drops the private `complex_star_mul_re` / `trace_conjTranspose_mul_self_re_eq_sum_sq` block, imports `MatrixAux`, and the AM–GM Hilbert–Schmidt calc cites the shared sum-norm lemma.
> 
> **`FrobeniusNorm.frobSq_trace`** is reduced to rewriting through `trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq` instead of an inline trace expansion; stated math is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d01657bef410603486099b5a99584bab2952653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->