### PR TITLE
refactor(Spectral): share Frobenius word-sum lemmas

### DIFF
--- a/TNLean/Spectral/TransferOperatorGap.lean
+++ b/TNLean/Spectral/TransferOperatorGap.lean
@@ -132,22 +132,31 @@ The Euclidean-space embedding `matToES` is imported from
 `TNLean.Spectral.FrobeniusNorm`; submultiplicativity is Mathlib's
 Frobenius-norm estimate. -/
 
-private lemma trace_cycle_for_frobSq (w v : Matrix (Fin D) (Fin D) ℂ) :
-    (w * vᴴ * (v * wᴴ)).trace = (wᴴ * w * (vᴴ * v)).trace := by
-  rw [Matrix.mul_assoc w vᴴ _, ← Matrix.mul_assoc vᴴ v wᴴ,
-      ← Matrix.mul_assoc w (vᴴ * v) wᴴ,
-      Matrix.trace_mul_comm (w * (vᴴ * v)) wᴴ,
-      ← Matrix.mul_assoc wᴴ w (vᴴ * v)]
+private lemma trace_cycle_for_frobSq_right {D₁ D₂ : ℕ}
+    (v : Matrix (Fin D₁) (Fin D₂) ℂ) (M : Matrix (Fin D₂) (Fin D₂) ℂ) :
+    ((v * Mᴴ)ᴴ * (v * Mᴴ)).trace = (Mᴴ * M * (vᴴ * v)).trace := by
+  have h1 : (v * Mᴴ)ᴴ = M * vᴴ := by
+    simp [Matrix.conjTranspose_mul]
+  rw [h1]
+  rw [Matrix.mul_assoc M vᴴ _, ← Matrix.mul_assoc vᴴ v Mᴴ,
+    ← Matrix.mul_assoc M (vᴴ * v) Mᴴ,
+    Matrix.trace_mul_comm (M * (vᴴ * v)) Mᴴ,
+    ← Matrix.mul_assoc Mᴴ M (vᴴ * v)]
 
-private lemma sum_frobSq_right (B : MPSTensor d D) (hB : ∑ i : Fin d, (B i)ᴴ * B i = 1)
-    (v : Matrix (Fin D) (Fin D) ℂ) (n : ℕ) :
+/-- Right multiplication by trace-preserving word products preserves the Frobenius square
+after summing over all words. -/
+lemma sum_frobSq_right {D₁ D₂ : ℕ}
+    (B : MPSTensor d D₂) (hB : ∑ i : Fin d, (B i)ᴴ * B i = 1)
+    (v : Matrix (Fin D₁) (Fin D₂) ℂ) (n : ℕ) :
     ∑ σ : Fin n → Fin d, frobSq (v * (evalWord B (List.ofFn σ))ᴴ) = frobSq v := by
-  simp only [frobSq_trace, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose]
-  conv_lhs => arg 2; ext σ; rw [trace_cycle_for_frobSq (evalWord B (List.ofFn σ)) v]
+  simp_rw [frobSq_trace]
+  conv_lhs => arg 2; ext σ; rw [trace_cycle_for_frobSq_right v (evalWord B (List.ofFn σ))]
   rw [← Complex.re_sum, ← Matrix.trace_sum, ← Finset.sum_mul,
       word_conjTranspose_mul_sum B hB n, Matrix.one_mul]
 
-private lemma sum_frobSq_words (K : MPSTensor d D) (hK : ∑ i : Fin d, (K i)ᴴ * K i = 1)
+/-- The Frobenius squares of all trace-preserving word products of a fixed length sum to the
+bond dimension. -/
+lemma sum_frobSq_words (K : MPSTensor d D) (hK : ∑ i : Fin d, (K i)ᴴ * K i = 1)
     (n : ℕ) :
     ∑ σ : Fin n → Fin d, frobSq (evalWord K (List.ofFn σ)) = (D : ℝ) := by
   simp only [frobSq_trace]

--- a/TNLean/Spectral/TransferOperatorGapRect.lean
+++ b/TNLean/Spectral/TransferOperatorGapRect.lean
@@ -81,39 +81,6 @@ submultiplicativity gives the mixed-shape estimate used below. -/
 
 section HSContraction
 
-/-- Right-sum identity: `∑_σ ‖X · w_B(σ)†‖_F² = ‖X‖_F²` for rectangular X.
-
-The proof uses trace cycling: `frobSq(v M†) = tr(M† M · v† v).re`, then sum over σ. -/
-private lemma sum_frobSq_rect_right
-    (B : MPSTensor d D₂) (hB : ∑ i : Fin d, (B i)ᴴ * B i = 1)
-    (v : Matrix (Fin D₁) (Fin D₂) ℂ) (n : ℕ) :
-    ∑ σ : Fin n → Fin d, frobSq (v * (evalWord B (List.ofFn σ))ᴴ) = frobSq v := by
-  -- Trace-cycle: tr((v M†)† (v M†)) = tr(M† M v† v)
-  have trace_cycle : ∀ M : Matrix (Fin D₂) (Fin D₂) ℂ,
-      ((v * Mᴴ)ᴴ * (v * Mᴴ)).trace = (Mᴴ * M * (vᴴ * v)).trace := by
-    intro M
-    have h1 : (v * Mᴴ)ᴴ = M * vᴴ := by
-      simp [Matrix.conjTranspose_mul]
-    rw [h1]
-    rw [Matrix.mul_assoc M vᴴ _, ← Matrix.mul_assoc vᴴ v Mᴴ,
-      ← Matrix.mul_assoc M (vᴴ * v) Mᴴ,
-      Matrix.trace_mul_comm (M * (vᴴ * v)) Mᴴ,
-      ← Matrix.mul_assoc Mᴴ M (vᴴ * v)]
-  -- Apply trace cycling to the sum.
-  simp_rw [frobSq_trace]
-  conv_lhs => arg 2; ext σ; rw [trace_cycle (evalWord B (List.ofFn σ))]
-  rw [← Complex.re_sum, ← Matrix.trace_sum, ← Finset.sum_mul,
-    word_conjTranspose_mul_sum B hB n, Matrix.one_mul]
-
-/-- Word Frobenius norm sum for square matrices: `∑_σ ‖w_K(σ)‖_F² = D₁`. -/
-private lemma sum_frobSq_rect_words
-    (K : MPSTensor d D₁) (hK : ∑ i : Fin d, (K i)ᴴ * K i = 1)
-    (n : ℕ) :
-    ∑ σ : Fin n → Fin d, frobSq (evalWord K (List.ofFn σ)) = (D₁ : ℝ) := by
-  simp_rw [frobSq_trace]
-  rw [← Complex.re_sum, ← Matrix.trace_sum, word_conjTranspose_mul_sum K hK n]
-  simp [Matrix.trace_one, Fintype.card_fin]
-
 /-- **Uniform Frobenius-norm bound**: `‖F₂^n(X)‖_F² ≤ D₁² · ‖X‖_F²`
 for the rectangular mixed transfer operator. -/
 private lemma hs_contraction_rect [NeZero D₁] [NeZero D₂]
@@ -143,9 +110,9 @@ private lemma hs_contraction_rect [NeZero D₁] [NeZero D₂]
           Matrix.frobenius_norm_mul (evalWord A (List.ofFn σ))
             (X * (evalWord B (List.ofFn σ))ᴴ))
   have h_A : ∑ σ : Fin n → Fin d, fA σ ^ 2 = (D₁ : ℝ) := by
-    simp_rw [hfA_def, norm_matToES_sq]; exact sum_frobSq_rect_words A hA_norm n
+    simp_rw [hfA_def, norm_matToES_sq]; exact sum_frobSq_words A hA_norm n
   have h_B : ∑ σ : Fin n → Fin d, fB σ ^ 2 = frobSq X := by
-    simp_rw [hfB_def, norm_matToES_sq]; exact sum_frobSq_rect_right B hB_norm X n
+    simp_rw [hfB_def, norm_matToES_sq]; exact sum_frobSq_right B hB_norm X n
   calc ‖matToES _‖ ^ 2
       ≤ (∑ σ : Fin n → Fin d, fA σ * fB σ) ^ 2 :=
         pow_le_pow_left₀ (norm_nonneg _) h_chain 2


### PR DESCRIPTION
### Motivation

- The Frobenius word-sum identities used in the square and rectangular
  transfer-operator gap estimates were duplicated between
  `TransferOperatorGap.lean` and `TransferOperatorGapRect.lean`.
- Sharing these lemmas removes the private duplicates `sum_frobSq_rect_right`
  and `sum_frobSq_rect_words` from the rectangular file, reducing duplication
  in the `Spectral` module.

### Description

- `TNLean/Spectral/TransferOperatorGap.lean`: proves and exposes two shared lemmas:
  - The rectangular right-multiplication identity
    ```
    ∑ σ : Fin n → Fin d, frobSq (v * (evalWord B (List.ofFn σ))ᴴ) = frobSq v
    ```
    for `v : Matrix (Fin D₁) (Fin D₂) ℂ`, under the trace-preserving
    normalization `∑ i : Fin d, (B i)ᴴ * B i = 1`.
  - The word-product identity
    ```
    ∑ σ : Fin n → Fin d, frobSq (evalWord K (List.ofFn σ)) = (D : ℝ)
    ```
- `TNLean/Spectral/TransferOperatorGapRect.lean`: removes private duplicate lemmas
  `sum_frobSq_rect_right` and `sum_frobSq_rect_words`, replacing them with calls
  to the shared versions from `TransferOperatorGap`.
- The key algebraic step is trace cycling
  `((v * Mᴴ)ᴴ * (v * Mᴴ)).trace = (Mᴴ * M * (vᴴ * v)).trace`
  via `Matrix.trace_mul_comm`. The contraction estimate continues to use
  `Matrix.frobenius_norm_mul`.

### Testing

- `lake build TNLean.Spectral.TransferOperatorGap TNLean.Spectral.TransferOperatorGapRect -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.
  Full build reports only pre-existing style warnings and the known
  `TNLean/MPS/Periodic/Overlap/Case3.lean` `sorry`.

---
No linked issue found — please link the relevant issue manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or runtime behavior change; contraction estimates still use the same algebraic steps via shared lemmas.
> 
> **Overview**
> **Deduplicates** Hilbert–Schmidt Frobenius word-sum identities used in both square and rectangular mixed transfer-operator gap proofs.
> 
> In `TransferOperatorGap.lean`, the old square-only trace-cycling helper is replaced by a **rectangular** `trace_cycle_for_frobSq_right`, and two lemmas are published for reuse: `sum_frobSq_right` (right multiplication by trace-preserving word products preserves summed `frobSq`) and `sum_frobSq_words` (word products sum to bond dimension). The square `hs_contraction_mixedTransfer` proof now calls these shared lemmas instead of inline variants.
> 
> `TransferOperatorGapRect.lean` **drops** the private duplicates `sum_frobSq_rect_right` and `sum_frobSq_rect_words` and wires `hs_contraction_rect` to the same shared lemmas via its existing import of `TransferOperatorGap`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220b69fbf2ab0f2424000dbd327744da000f7294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->