### PR TITLE
refactor(Spectral): reuse transfer trace identity

### DIFF
--- a/TNLean/Spectral/PrimitiveOverlap.lean
+++ b/TNLean/Spectral/PrimitiveOverlap.lean
@@ -189,10 +189,7 @@ theorem mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one
   -- First derive `trace((transferMap A)^N) → 1`.
   have hTP : IsTracePreservingMap (transferMap (d := d) (D := D) A) := by
     intro X
-    -- same proof as `MPSTensor.trace_transferMap` in `TransferOperatorGap.lean`
-    rw [transferMap_apply, Matrix.trace_sum]
-    conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
-    rw [← Matrix.trace_sum, ← Finset.sum_mul, hNorm, one_mul]
+    exact trace_transferMap A X hNorm
   have htrρ : Matrix.trace ρ ≠ 0 := by
     intro htr0
     exact hρ_ne ((Matrix.PosSemidef.trace_eq_zero_iff hρ_psd).1 htr0)


### PR DESCRIPTION
### Motivation

- `TNLean/Spectral/PrimitiveOverlap.lean` inlined a matrix trace expansion and cyclic trace identity to establish `IsTracePreservingMap (transferMap A)` for a normalized tensor, duplicating the calculation already proved in `MPSTensor.trace_transferMap`.
- Removing the duplicate keeps the primitive-overlap proof concise and ensures trace-preservation is always justified via the single existing lemma.

### Description

- `TNLean/Spectral/PrimitiveOverlap.lean`: in the proof of `mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one`, replaced the inline trace-cycling argument with a direct call to `MPSTensor.trace_transferMap`, which establishes `Matrix.trace (transferMap A X) = Matrix.trace X` under the normalization `∑ i : Fin d, (A i)ᴴ * A i = 1`.
- No theorem statements or hypotheses change; this is a proof-internal reorganization only.

### Testing

- `lake exe cache get`
- `lake build TNLean.Spectral.PrimitiveOverlap -q --log-level=info` — focused build reports only pre-existing style warnings in imported files.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor reusing an existing lemma; no API or mathematical statement changes.
>
> **Overview**
> In **`mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one`**, the proof that **`transferMap`** is trace-preserving no longer inlines the matrix trace sum and cyclic identity.
>
> It now applies the existing lemma **`trace_transferMap`** (from **`TransferOperatorGap`**) for each **`X`**, matching how other spectral proofs justify **`Matrix.trace (transferMap A X) = Matrix.trace X`** under the normalization **`∑ i, (A i)ᴴ * A i = 1`**.
>
> **No theorem statements or hypotheses change**—only proof structure is deduplicated.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88fce195efbac4e0cdc7275948f2b178082dcf08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or mathematical statement changes; behavior matches the removed inline argument.
> 
> **Overview**
> In **`mpvOverlap_tendsto_one_of_transfer_spectralRadius_compl_lt_one`**, the step that shows **`transferMap A`** is trace-preserving no longer repeats the matrix trace sum and cyclic trace rewrite.
> 
> For each **`X`**, the proof now calls **`trace_transferMap`** from **`TransferOperatorGap`**, which already proves **`Matrix.trace (transferMap A X) = Matrix.trace X`** under **`∑ i, (A i)ᴴ * A i = 1`**.
> 
> **Theorem statements and hypotheses are unchanged**—only proof structure is deduplicated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29916e40f37e46143e354a6dc632661d5eb9410f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->