### PR TITLE
refactor(Channel/Schwarz): share Kraus trace preservation

### DIFF
--- a/TNLean/Channel/Peripheral/GroupStructure.lean
+++ b/TNLean/Channel/Peripheral/GroupStructure.lean
@@ -68,18 +68,6 @@ quantum channels:
 
 /-! ## Auxiliary lemmas for the divisibility proof -/
 
-/-- The transfer map preserves the matrix trace when the Kraus family is trace-preserving
-(i.e., `∑ᵢ Kᵢ† Kᵢ = I`). -/
-private lemma trace_transferMap_of_tp
-    {r : ℕ}
-    (K : Fin r → MatrixAlg D)
-    (hTP : KadisonSchwarz.IsTPKraus (d := r) (D := D) K)
-    (X : MatrixAlg D) :
-    Matrix.trace (MPSTensor.transferMap (d := r) (D := D) K X) = Matrix.trace X := by
-  simp only [MPSTensor.transferMap_apply, Matrix.trace_sum]
-  conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
-  rw [← Matrix.trace_sum, ← Finset.sum_mul, hTP, one_mul]
-
 /-- The trace of an orthogonal projection (Hermitian idempotent matrix) over `ℂ` is a natural
 number — it equals the number of unit eigenvalues. -/
 private lemma exists_natCast_eq_trace_of_orthogonal_projection
@@ -150,7 +138,11 @@ private lemma period_dvd_dim_of_cyclic_projections
     (hcyclic : ∀ k, MPSTensor.transferMap (d := r) (D := D) K (P (k + 1)) = P k) :
     m ∣ D := by
   set E := MPSTensor.transferMap (d := r) (D := D) K
-  have htrace_pres := trace_transferMap_of_tp K hTP
+  have htrace_pres :
+      ∀ X : MatrixAlg D, Matrix.trace (E X) = Matrix.trace X := by
+    intro X
+    simpa [E, MPSTensor.transferMap_apply, KadisonSchwarz.krausMap] using
+      (KadisonSchwarz.trace_krausMap_of_tp (D := D) K hTP X)
   have htrace_step : ∀ k : Fin m, Matrix.trace (P k) = Matrix.trace (P (k + 1)) := by
     intro k
     calc Matrix.trace (P k)

--- a/TNLean/Channel/Schwarz/KadisonSchwarz.lean
+++ b/TNLean/Channel/Schwarz/KadisonSchwarz.lean
@@ -71,6 +71,16 @@ theorem krausAdjointMap_one_of_TP (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (h : IsTPKraus K) : krausAdjointMap K 1 = 1 := by
   simp only [krausAdjointMap, mul_one]; exact h
 
+/-- A trace-preserving Kraus family preserves the matrix trace. -/
+theorem trace_krausMap_of_tp (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
+    (h_tp : IsTPKraus K)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    trace (krausMap K X) = trace X := by
+  simp only [krausMap, trace_sum]
+  conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
+  rw [← trace_sum, ← Finset.sum_mul, show ∑ i : Fin d, (K i)ᴴ * K i = 1 from h_tp,
+    one_mul]
+
 /-- The finite-index Kadison-Schwarz Kraus map is the general Kraus map. -/
 theorem krausMap_eq_map (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin D) ℂ) :
@@ -203,9 +213,7 @@ theorem hilbertSchmidt_contraction (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
   have h_nonneg := (kadison_schwarz K h_unital X).trace_nonneg
   rw [trace_sub] at h_nonneg
   have h_pres : trace (krausMap K (Xᴴ * X)) = trace (Xᴴ * X) := by
-    simp only [krausMap, trace_sum]
-    conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
-    rw [← trace_sum, ← Finset.sum_mul, show ∑ i : Fin d, (K i)ᴴ * K i = 1 from h_tp, one_mul]
+    exact trace_krausMap_of_tp K h_tp (Xᴴ * X)
   rw [h_pres] at h_nonneg
   exact le_of_sub_nonneg h_nonneg
 

--- a/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
@@ -42,22 +42,6 @@ variable {d D : ℕ}
 
 namespace KadisonSchwarz
 
-/-! ## Auxiliary lemmas -/
-
-section AuxiliaryLemmas
-
-/-- Trace of `krausMap` equals trace of the original matrix times ∑ Kᵢ† Kᵢ. When TP, this
-equals the original trace. -/
-private theorem trace_krausMap_of_tp (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (h_tp : IsTPKraus K)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    trace (krausMap K X) = trace X := by
-  simp only [krausMap, trace_sum]
-  conv_lhs => arg 2; ext i; rw [Matrix.trace_mul_cycle]
-  rw [← trace_sum, ← Finset.sum_mul, show ∑ i : Fin d, (K i)ᴴ * K i = 1 from h_tp, one_mul]
-
-end AuxiliaryLemmas
-
 /-! ## KS equality for peripheral eigenvectors -/
 
 section KSEquality


### PR DESCRIPTION
### Motivation

- The `Channel/Schwarz` layer contained two independent copies of the same trace-preservation identity for Kraus maps: both derived `trace (krausMap K X) = trace X` via trace cycling under `IsTPKraus K`.
- The peripheral group-structure proof contained the same argument again, expressed through `MPSTensor.transferMap`.
- Consolidating at the layer where `krausMap` and `IsTPKraus` are defined removes this duplication without altering any mathematical statement.

### Description

- Promoted the identity `trace (krausMap K X) = trace X` under `IsTPKraus K` from a private helper in `MultiplicativeDomain.lean` to a named theorem in `KadisonSchwarz.lean`.
- Updated `KadisonSchwarz.hilbertSchmidt_contraction` and `KadisonSchwarz.ks_equality_of_peripheral_eigenvector` to use the shared theorem.
- Deleted the private duplicate from `MultiplicativeDomain.lean`.
- Replaced the private transfer-map trace-preservation lemma in `PeripheralSpectrum.GroupStructure` by the shared Kraus-map theorem, using the definitional equality between `krausMap` and `MPSTensor.transferMap`.
- No mathematical statement is weakened or strengthened.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Schwarz.KadisonSchwarz TNLean.Channel.Schwarz.MultiplicativeDomain TNLean.Channel.Schwarz.MultiplicativeDomainPowers TNLean.Channel.Schwarz.MultiplicativeDomainFull -q --log-level=info`
- `lake build TNLean.Channel.Schwarz.KadisonSchwarz TNLean.Channel.Schwarz.MultiplicativeDomain TNLean.Channel.Peripheral.GroupStructure -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- Focused builds report only pre-existing style warnings in imported files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure proof refactor with no API or mathematical changes beyond relocating a shared lemma.
> 
> **Overview**
> **Deduplicates** the trace-preservation identity `trace (krausMap K X) = trace X` under `IsTPKraus K`, which had been copied in several Channel/Schwarz and peripheral proofs.
> 
> The lemma is now a single public theorem **`KadisonSchwarz.trace_krausMap_of_tp`** in `KadisonSchwarz.lean`. **`hilbertSchmidt_contraction`** and **`ks_equality_of_peripheral_eigenvector`** call that theorem instead of inlining the trace-cycling argument.
> 
> The private duplicate in **`MultiplicativeDomain.lean`** and the transfer-map-specific helper in **`GroupStructure.lean`** are removed; **`period_dvd_dim_of_cyclic_projections`** obtains trace preservation for `MPSTensor.transferMap` via definitional equality with `krausMap`. **No theorem statements change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9750ae7b706bdf54922e1d36940d6bf2a371cd65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->