### PR TITLE
refactor(Channel/FixedPoint): inline single-use Kraus unitality conversion

### DIFF
--- a/TNLean/Channel/FixedPoint/Algebra.lean
+++ b/TNLean/Channel/FixedPoint/Algebra.lean
@@ -67,14 +67,6 @@ section AuxiliaryLemmas
     adjointMap K (1 : Mat) = 1 := by
   simpa [adjointMap, IsTP, Matrix.mul_one] using h_tp
 
-private theorem isUnitalKraus_of_isUnital (K : Fin d → Mat) (h_unital : IsUnital K) :
-    KadisonSchwarz.IsUnitalKraus K := by
-  simpa [IsUnital, KadisonSchwarz.IsUnitalKraus] using h_unital
-
-private theorem isUnital_conjTranspose_of_isTP (K : Fin d → Mat) (h_tp : IsTP K) :
-    IsUnital (fun i => (K i)ᴴ) := by
-  simpa [IsUnital, IsTP] using h_tp
-
 end AuxiliaryLemmas
 
 section FixedPoints
@@ -119,7 +111,7 @@ theorem mem_multiplicativeDomain_of_mem_fixedPoints
     {X : Mat} (hX : X ∈ fixedPoints K) :
     X ∈ KadisonSchwarz.multiplicativeDomain K := by
   let h_unitalKS : KadisonSchwarz.IsUnitalKraus K :=
-    isUnitalKraus_of_isUnital K h_unital
+    by simpa [IsUnital, KadisonSchwarz.IsUnitalKraus] using h_unital
   have hXeq : map K X = X := hX
   have h_left_eq_map : map K (Xᴴ * X) = (map K X)ᴴ * map K X := by
     calc
@@ -238,7 +230,7 @@ noncomputable def adjointFixedPointsStarSubalgebra
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) :
     StarSubalgebra ℂ Mat :=
   fixedPointsStarSubalgebra (K := fun i => (K i)ᴴ)
-    (h_unital := isUnital_conjTranspose_of_isTP K h_tp) hρ
+    (h_unital := by simpa [IsUnital, IsTP] using h_tp) hρ
     (by simpa [adjointMap, map] using hρ_fix)
 
 @[simp] theorem mem_adjointFixedPointsStarSubalgebra
@@ -266,7 +258,7 @@ theorem fixedPoints_in_multiplicativeDomain
     {X : Mat} (hX : X ∈ adjointFixedPoints K) :
     X ∈ KadisonSchwarz.multiplicativeDomain (fun i => (K i)ᴴ) := by
   have h_unital : IsUnital (fun i => (K i)ᴴ) :=
-    isUnital_conjTranspose_of_isTP K h_tp
+    by simpa [IsUnital, IsTP] using h_tp
   exact mem_multiplicativeDomain_of_mem_fixedPoints (K := fun i => (K i)ᴴ) h_unital hρ
     (by simpa [adjointMap, map] using hρ_fix)
     (by simpa [fixedPoints, adjointFixedPoints, map, adjointMap] using hX)
@@ -297,7 +289,7 @@ theorem fixedPoint_commutes_kraus
     (hXX : Xᴴ * X ∈ adjointFixedPoints K) :
     ∀ i : Fin d, X * K i = K i * X := by
   have h_unital : IsUnital (fun i => (K i)ᴴ) :=
-    isUnital_conjTranspose_of_isTP K h_tp
+    by simpa [IsUnital, IsTP] using h_tp
   have hX' : map (fun i => (K i)ᴴ) X = X := by
     simpa [adjointFixedPoints, adjointMap, map] using hX
   have hXX' : map (fun i => (K i)ᴴ) (Xᴴ * X) = Xᴴ * X := by

--- a/TNLean/Channel/FixedPoint/Algebra.lean
+++ b/TNLean/Channel/FixedPoint/Algebra.lean
@@ -67,6 +67,10 @@ section AuxiliaryLemmas
     adjointMap K (1 : Mat) = 1 := by
   simpa [adjointMap, IsTP, Matrix.mul_one] using h_tp
 
+private theorem isUnital_conjTranspose_of_isTP (K : Fin d → Mat) (h_tp : IsTP K) :
+    IsUnital (fun i => (K i)ᴴ) := by
+  simpa [IsUnital, IsTP] using h_tp
+
 end AuxiliaryLemmas
 
 section FixedPoints
@@ -230,7 +234,7 @@ noncomputable def adjointFixedPointsStarSubalgebra
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) :
     StarSubalgebra ℂ Mat :=
   fixedPointsStarSubalgebra (K := fun i => (K i)ᴴ)
-    (h_unital := by simpa [IsUnital, IsTP] using h_tp) hρ
+    (h_unital := isUnital_conjTranspose_of_isTP K h_tp) hρ
     (by simpa [adjointMap, map] using hρ_fix)
 
 @[simp] theorem mem_adjointFixedPointsStarSubalgebra
@@ -258,7 +262,7 @@ theorem fixedPoints_in_multiplicativeDomain
     {X : Mat} (hX : X ∈ adjointFixedPoints K) :
     X ∈ KadisonSchwarz.multiplicativeDomain (fun i => (K i)ᴴ) := by
   have h_unital : IsUnital (fun i => (K i)ᴴ) :=
-    by simpa [IsUnital, IsTP] using h_tp
+    isUnital_conjTranspose_of_isTP K h_tp
   exact mem_multiplicativeDomain_of_mem_fixedPoints (K := fun i => (K i)ᴴ) h_unital hρ
     (by simpa [adjointMap, map] using hρ_fix)
     (by simpa [fixedPoints, adjointFixedPoints, map, adjointMap] using hX)
@@ -289,7 +293,7 @@ theorem fixedPoint_commutes_kraus
     (hXX : Xᴴ * X ∈ adjointFixedPoints K) :
     ∀ i : Fin d, X * K i = K i * X := by
   have h_unital : IsUnital (fun i => (K i)ᴴ) :=
-    by simpa [IsUnital, IsTP] using h_tp
+    isUnital_conjTranspose_of_isTP K h_tp
   have hX' : map (fun i => (K i)ᴴ) X = X := by
     simpa [adjointFixedPoints, adjointMap, map] using hX
   have hXX' : map (fun i => (K i)ᴴ) (Xᴴ * X) = Xᴴ * X := by


### PR DESCRIPTION
### Motivation

`TNLean.Channel.FixedPoint.Algebra` had a private conversion from `Kraus.IsUnital` to `KadisonSchwarz.IsUnitalKraus` whose only use was a definitional unfold. That single-use conversion is better supplied locally at the point where the Kadison--Schwarz multiplicative-domain API needs it.

The separate conversion from `IsTP K` to unitality of the conjugate-transposed Kraus family is used in three places and remains as a single private lemma.

### Description

- Removed the single-use private lemma `isUnitalKraus_of_isUnital`.
- Kept `isUnital_conjTranspose_of_isTP` as the shared proof of `IsTP K -> IsUnital (fun i => (K i)ᴴ)`.
- Left all fixed-point, multiplicative-domain, and `StarSubalgebra` statements unchanged.

### Testing

- `lake build TNLean.Channel.FixedPoint.Algebra -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `git diff --cached --check`

The focused build reports only existing short copyright-header warnings in imported files and the edited file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in fixed-point algebra with no API or behavioral changes.
> 
> **Overview**
> Removes the private helper `isUnitalKraus_of_isUnital` from `TNLean/Channel/FixedPoint/Algebra.lean` and supplies the same `IsUnital K → KadisonSchwarz.IsUnitalKraus K` step inline in `mem_multiplicativeDomain_of_mem_fixedPoints` via `by simpa [IsUnital, KadisonSchwarz.IsUnitalKraus] using h_unital`.
> 
> No change to theorem statements or to the shared lemma `isUnital_conjTranspose_of_isTP`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1490164806d90808682bdae1f9c9c90ff4329dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->