### PR TITLE
refactor(Channel/Schwarz): share Kraus conjugate normalization

### DIFF
--- a/TNLean/Channel/Schwarz/KadisonSchwarz.lean
+++ b/TNLean/Channel/Schwarz/KadisonSchwarz.lean
@@ -105,9 +105,17 @@ private theorem krausAdjointMap_eq (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (Y
   simp [krausAdjointMap, krausMap, conjTranspose_conjTranspose]
 
 /-- The conjugate-transposed operators of a TP family form a unital family. -/
-private theorem isUnitalKraus_conjTranspose (h : IsTPKraus K) :
-    IsUnitalKraus (fun i => (K i)ᴴ) := by
+theorem isUnitalKraus_conjTranspose {K : Fin d → Matrix (Fin D) (Fin D) ℂ}
+    (h : IsTPKraus (d := d) (D := D) K) :
+    IsUnitalKraus (d := d) (D := D) (fun i => (K i)ᴴ) := by
   change ∑ i, (K i)ᴴ * ((K i)ᴴ)ᴴ = 1
+  simp only [conjTranspose_conjTranspose]; exact h
+
+/-- The conjugate-transposed operators of a unital family form a TP family. -/
+theorem isTPKraus_conjTranspose {K : Fin d → Matrix (Fin D) (Fin D) ℂ}
+    (h : IsUnitalKraus (d := d) (D := D) K) :
+    IsTPKraus (d := d) (D := D) (fun i => (K i)ᴴ) := by
+  change ∑ i, ((K i)ᴴ)ᴴ * (K i)ᴴ = 1
   simp only [conjTranspose_conjTranspose]; exact h
 
 /-- **Kadison-Schwarz inequality** (Wolf, Chapter 5, Equation (5.2)).

--- a/TNLean/MPS/Irreducible/Adjoint.lean
+++ b/TNLean/MPS/Irreducible/Adjoint.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 import TNLean.MPS.Irreducible.FormII
 import TNLean.Channel.Irreducible.Basic
+import TNLean.Channel.Schwarz.KadisonSchwarz
 
 /-!
 # Irreducibility and conjugate-transposed Kraus families
@@ -13,8 +14,9 @@ This file transfers irreducibility between an MPS tensor and the CP map built
 from its conjugate-transposed Kraus family. The main theorem
 `isIrreducibleCP_transferMap_conjTranspose_of_isIrreducibleTensor` is
 complemented by its converse
-`isIrreducibleTensor_of_isIrreducibleMap_conjTranspose` and by the unital/TP
-conversion lemmas for conjugate-transposed Kraus families.
+`isIrreducibleTensor_of_isIrreducibleMap_conjTranspose`. The unital/TP
+conversion lemmas for conjugate-transposed Kraus families live in
+`TNLean.Channel.Schwarz.KadisonSchwarz`.
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -177,27 +179,3 @@ theorem exists_unitary_diag_posDef_adjointFixedPoint_of_unital_of_isIrreducibleT
   exact ⟨hSame, hΛ_pd, hΛ_diag, hUnitalB, hΛ_fixB⟩
 
 end MPSTensor
-
-namespace KadisonSchwarz
-
-variable {d D : ℕ}
-
-/-- The conjugate-transposed operators of a TP family form a unital family.
-
-This lemma is useful when switching between the Schrödinger-picture condition
-`∑ᵢ Kᵢ† Kᵢ = I` (trace-preserving) and the Heisenberg-picture condition for the
-adjoint family `i ↦ Kᵢ†`. -/
-theorem isUnitalKraus_conjTranspose {K : Fin d → Matrix (Fin D) (Fin D) ℂ}
-    (h : IsTPKraus (d := d) (D := D) K) :
-    IsUnitalKraus (d := d) (D := D) (fun i => (K i)ᴴ) := by
-  rw [isUnitalKraus_iff, isTPKraus_iff] at *
-  simpa [Matrix.conjTranspose_conjTranspose] using h
-
-/-- The conjugate-transposed operators of a unital family form a TP family. -/
-theorem isTPKraus_conjTranspose {K : Fin d → Matrix (Fin D) (Fin D) ℂ}
-    (h : IsUnitalKraus (d := d) (D := D) K) :
-    IsTPKraus (d := d) (D := D) (fun i => (K i)ᴴ) := by
-  rw [isUnitalKraus_iff, isTPKraus_iff] at *
-  simpa [Matrix.conjTranspose_conjTranspose] using h
-
-end KadisonSchwarz


### PR DESCRIPTION
### Motivation

The conjugate-transpose normalization facts for Kraus families belong with `IsUnitalKraus` and `IsTPKraus`, which are defined in `TNLean.Channel.Schwarz.KadisonSchwarz`.

Before this change, `KadisonSchwarz.lean` had the TP-to-unital direction only as a private helper, while `TNLean.MPS.Irreducible.Adjoint` exported both directions in the `KadisonSchwarz` namespace. That made the MPS layer carry a theorem whose statement is purely about the Schwarz-layer Kraus normalization definitions.

### Description

- Promoted `KadisonSchwarz.isUnitalKraus_conjTranspose` from a private helper to a public theorem in `KadisonSchwarz.lean`.
- Added the reverse theorem `KadisonSchwarz.isTPKraus_conjTranspose` in the same file.
- Removed the duplicate theorem block from `MPS/Irreducible/Adjoint.lean` and updated that module docstring to point to the Schwarz layer.
- Existing downstream uses keep the same theorem names and statements.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Schwarz.KadisonSchwarz TNLean.MPS.Irreducible.Adjoint TNLean.MPS.SharedInfra.KrausAdjointSetup TNLean.MPS.CanonicalForm.BlockingViaAdjoint TNLean.MPS.CanonicalForm.CyclicSectors.FixedAdjoint -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- The focused build reports only pre-existing style warnings in imported files.

---
_(No linked issue found — please open one and update this footer with `Addresses #N`.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layering-only refactor with unchanged theorem statements and names; no runtime or security impact.
> 
> **Overview**
> **Kraus unital/TP normalization under conjugate transpose** now lives entirely in `KadisonSchwarz.lean` next to `IsUnitalKraus` and `IsTPKraus`, instead of being duplicated from the MPS irreducibility layer.
> 
> `isUnitalKraus_conjTranspose` is promoted from a private helper to a public theorem (proof uses direct `change`/`simp` on the sum identities). The reverse fact **`isTPKraus_conjTranspose`** is added in the same file. The duplicate `KadisonSchwarz` theorem block is removed from `MPS/Irreducible/Adjoint.lean`, which now imports `KadisonSchwarz` and documents that those lemmas live in the Schwarz module. Call sites keep the same `KadisonSchwarz.*` names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a36e31249852b5bf11b8dda35ca91013782d1fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->