### PR TITLE
refactor(Channel): share positive semidefinite closedness

### DIFF
--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -28,6 +28,7 @@ Chapter 6 of Wolf's lecture notes.
 * `IsCPMap.isPositiveMap`: completely positive maps are positive
 * `IsChannel`: completely positive + trace-preserving (CPTP)
 * `IsPositiveMap.map_isHermitian`: positive maps preserve Hermiticity
+* `matrix_isClosed_posSemidef`: the positive semidefinite cone is closed
 * `densityMatrices_isCompact`: the set of density matrices is compact
 * `densityMatrices_isConvex`: the set of density matrices is convex
 * `IsChannel.map_densityMatrices`: channels map density matrices to density matrices
@@ -142,8 +143,8 @@ def densityMatrices (D : ℕ) : Set (Matrix (Fin D) (Fin D) ℂ) :=
     ρ ∈ densityMatrices D ↔ ρ.PosSemidef ∧ trace ρ = 1 := Iff.rfl
 
 /-- The quadratic form `X ↦ star v ⬝ᵥ X.mulVec v` is continuous. -/
-private lemma continuous_quadraticForm (v : Fin D → ℂ) :
-    Continuous (fun X : Matrix (Fin D) (Fin D) ℂ => star v ⬝ᵥ X.mulVec v) :=
+private lemma continuous_quadraticForm {m : Type*} [Fintype m] (v : m → ℂ) :
+    Continuous (fun X : Matrix m m ℂ => star v ⬝ᵥ X.mulVec v) :=
   Continuous.dotProduct continuous_const (Continuous.matrix_mulVec continuous_id continuous_const)
 
 /-! ### Auxiliary lemmas for boundedness -/
@@ -235,22 +236,31 @@ theorem posSemidef_trace_bounded_isBounded (c : ℝ) :
           pow_le_pow_left₀ (norm_nonneg _) (hentry i j) 2
     _ = (↑D * c) ^ 2 := by simp [sum_const]; ring
 
-/-- The PSD cone is closed.
+/-- The PSD cone is closed for matrices over any finite index type.
 
 Proof: `PosSemidef X ↔ X.IsHermitian ∧ ∀ v, 0 ≤ star v ⬝ᵥ X.mulVec v`.
 - `{X | X.IsHermitian}` is closed (continuous `conjTranspose`).
 - Each `{X | 0 ≤ star v ⬝ᵥ X.mulVec v}` is closed (preimage of closed
   nonneg cone under continuous quadratic form). -/
-theorem isClosed_posSemidef :
-    IsClosed {X : Matrix (Fin D) (Fin D) ℂ | X.PosSemidef} := by
-  have : {X : Matrix (Fin D) (Fin D) ℂ | X.PosSemidef}
-    = {X | X.IsHermitian} ∩ ⋂ (v : Fin D → ℂ), {X | 0 ≤ star v ⬝ᵥ X.mulVec v} := by
-    ext X; simp only [Set.mem_setOf_eq, Set.mem_inter_iff, Set.mem_iInter,
+theorem matrix_isClosed_posSemidef {m : Type*} [Finite m] :
+    IsClosed {X : Matrix m m ℂ | X.PosSemidef} := by
+  classical
+  letI := Fintype.ofFinite m
+  have : {X : Matrix m m ℂ | X.PosSemidef}
+      = {X | X.IsHermitian} ∩
+        ⋂ (v : m → ℂ), {X | 0 ≤ star v ⬝ᵥ X.mulVec v} := by
+    ext X
+    simp only [Set.mem_setOf_eq, Set.mem_inter_iff, Set.mem_iInter,
       Matrix.posSemidef_iff_dotProduct_mulVec]
   rw [this]
   exact (isClosed_eq continuous_star continuous_id).inter
     (isClosed_iInter fun v =>
       (isClosed_le continuous_const continuous_id).preimage (continuous_quadraticForm v))
+
+/-- The PSD cone is closed on `Fin D`-indexed matrices. -/
+theorem isClosed_posSemidef :
+    IsClosed {X : Matrix (Fin D) (Fin D) ℂ | X.PosSemidef} :=
+  matrix_isClosed_posSemidef
 
 /-- The set of density matrices is compact (Heine-Borel).
 

--- a/TNLean/Channel/Semigroup/CPClosure.lean
+++ b/TNLean/Channel/Semigroup/CPClosure.lean
@@ -177,34 +177,6 @@ theorem Finset.isCPMap_sum
 
 end GenericCPClosure
 
-section PosSemidefiniteClosure
-
-variable {m : Type*}
-
-/-- The quadratic form `X ↦ star v ⬝ᵥ X.mulVec v` is continuous. -/
-private lemma continuous_quadraticForm_generic [Fintype m] (v : m → ℂ) :
-    Continuous (fun X : Matrix m m ℂ => star v ⬝ᵥ X.mulVec v) :=
-  Continuous.dotProduct continuous_const
-    (Continuous.matrix_mulVec continuous_id continuous_const)
-
-/-- The PSD cone is closed for matrices over any finite index type. -/
-theorem matrix_isClosed_posSemidef [Finite m] :
-    IsClosed {X : Matrix m m ℂ | X.PosSemidef} := by
-  classical
-  letI := Fintype.ofFinite m
-  have : {X : Matrix m m ℂ | X.PosSemidef}
-      = {X | X.IsHermitian} ∩
-        ⋂ (v : m → ℂ), {X | 0 ≤ star v ⬝ᵥ X.mulVec v} := by
-    ext X
-    simp only [Set.mem_setOf_eq, Set.mem_inter_iff, Set.mem_iInter,
-      Matrix.posSemidef_iff_dotProduct_mulVec]
-  rw [this]
-  exact (isClosed_eq continuous_star continuous_id).inter
-    (isClosed_iInter fun v =>
-      (isClosed_le continuous_const continuous_id).preimage (continuous_quadraticForm_generic v))
-
-end PosSemidefiniteClosure
-
 namespace ChoiJamiolkowski
 
 variable {D : ℕ}


### PR DESCRIPTION
### Motivation

- The closedness theorem for the positive semidefinite cone on finite-index matrix algebras duplicated proof infrastructure between `TNLean.Channel.Basic` (where density matrices and the PSD cone are developed) and `TNLean.Channel.Semigroup.CPClosure`.
- Centralizing the result in `Channel.Basic` removes the duplication and co-locates the theorem with the density-matrix theory it supports.

### Description

- `TNLean/Channel/Basic.lean`: added `matrix_isClosed_posSemidef`, the general `[Finite m]` closedness theorem for the positive semidefinite cone; `isClosed_posSemidef` is retained as a one-line `Fin D` specialization.
- `TNLean/Channel/Semigroup/CPClosure.lean`: removed the duplicate `PosSemidefiniteClosure` section (~30 lines) and its private `continuous_quadraticForm` auxiliary; callers such as `isClosed_setOf_isCPMap` now reach `matrix_isClosed_posSemidef` through the existing `Channel.Basic` import.
- No theorem statement or mathematical content is altered.

### Testing

- `lake build TNLean.Channel.Basic TNLean.Channel.Semigroup.CPClosure TNLean.Channel.Semigroup.LindbladForm.EulerStep -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---

> [!NOTE]
> **Low Risk**
> Proof relocation and deduplication only; no change to statements or mathematical content, and build targets were validated in the PR description.
>
> **Overview**
> **PSD cone closedness** now lives in `TNLean.Channel.Basic` next to density-matrix theory, instead of a duplicate block in `CPClosure`.
>
> `matrix_isClosed_posSemidef` is the general `[Finite m]` theorem; `isClosed_posSemidef` on `Fin D` is a one-line specialization. The shared helper `continuous_quadraticForm` is generalized to any `Fintype m` (and made non-`private` in the sense of visibility for the PSD proof—actually it's still `private` in Basic). The entire `PosSemidefiniteClosure` section (~30 lines) is removed from `TNLean.Channel.Semigroup.CPClosure`; `isClosed_setOf_isCPMap` and other callers still use `matrix_isClosed_posSemidef` via the existing `Semigroup.Basic` → `Channel.Basic` import chain.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dee259e671d3d18a2161b4f78be40bcabc0e6df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof relocation and deduplication only; no change to theorem statements or mathematical content, with build targets validated in the PR description.
> 
> **Overview**
> **PSD cone closedness** is consolidated in `TNLean.Channel.Basic` instead of a duplicate proof block in `CPClosure`.
> 
> `matrix_isClosed_posSemidef` is now the shared `[Finite m]` theorem there; `isClosed_posSemidef` on `Fin D` is a one-line specialization. The helper `continuous_quadraticForm` is generalized to any `Fintype m` so the same proof covers arbitrary finite index types. The `PosSemidefiniteClosure` section (~30 lines, including a second copy of that theorem) is removed from `TNLean.Channel.Semigroup.CPClosure`; `isClosed_setOf_isCPMap` and other callers still use `matrix_isClosed_posSemidef` via existing imports.
> 
> Theorem statements and proofs are unchanged—this is relocation and deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd1376655684b49ffeca3d2a43bcbb1ee66cb2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->