### PR TITLE
refactor(Channel/Irreducible): inline single sandwich calculation

### DIFF
--- a/TNLean/Channel/Irreducible/Basic.lean
+++ b/TNLean/Channel/Irreducible/Basic.lean
@@ -104,28 +104,6 @@ structure HasUniqueFixedPoint [DecidableEq (Fin D)]
   /-- Any PSD fixed point is a scalar multiple of `ρ`. -/
   unique : ∀ σ : Matrix (Fin D) (Fin D) ℂ, σ.PosSemidef → E σ = σ → ∃ c : ℂ, σ = c • ρ
 
-/-! ### Auxiliary matrix algebra lemmas -/
-
-/-- Entry computation for a sandwich product with a single-entry matrix. -/
-private lemma mul_single_mul_eq [DecidableEq (Fin D)]
-    (Q P : Matrix (Fin D) (Fin D) ℂ) (k l : Fin D) :
-    Q * Matrix.single k l (1 : ℂ) * P =
-      Matrix.of (fun i j => Q i k * P l j) := by
-  ext i j
-  simp only [Matrix.mul_apply, Matrix.of_apply, Matrix.single_apply]
-  have inner_eq : ∀ x, ∑ x₁, Q i x₁ * (if k = x₁ ∧ l = x then 1 else 0) =
-      if l = x then Q i k else 0 := by
-    intro x
-    by_cases hlx : l = x
-    · subst hlx; simp only [and_true]
-      rw [Finset.sum_eq_single k] <;> simp (config := { contextual := true }) [Ne.symm]
-    · simp only [hlx, and_false, ite_false, mul_zero, Finset.sum_const_zero]
-  simp_rw [inner_eq]
-  rw [Finset.sum_eq_single l]
-  · simp
-  · intro b _ hbl; simp [Ne.symm hbl]
-  · simp
-
 /-- If `(1 - P) * M * P = 0` for all matrices `M`, then `P = 0` or `P = 1`.
 This is the final step: an invariant subspace of every matrix must be trivial. -/
 lemma proj_zero_or_one_of_sandwich [DecidableEq (Fin D)]
@@ -139,12 +117,19 @@ lemma proj_zero_or_one_of_sandwich [DecidableEq (Fin D)]
       by_contra h_all; push Not at h_all
       exact hP (Matrix.ext fun i j => h_all i j)
     ext i k
-    have h_eq := mul_single_mul_eq (1 - P) P k l₀
-    rw [h (Matrix.single k l₀ 1)] at h_eq
-    have h_entry := congr_fun (congr_fun h_eq i) j₀
-    simp [Matrix.of_apply] at h_entry
+    have h_entry := congr_fun (congr_fun (h (Matrix.single k l₀ 1)) i) j₀
+    have hsum :
+        ∑ x, ((1 - P) * Matrix.single k l₀ (1 : ℂ)) i x * P x j₀ =
+          (1 - P) i k * P l₀ j₀ := by
+      rw [Finset.sum_eq_single l₀]
+      · simp
+      · intro b _ hb
+        simp [Matrix.mul_single_apply_of_ne, hb]
+      · simp
+    have h_prod : (1 - P) i k * P l₀ j₀ = 0 := by
+      exact hsum ▸ (by simpa [Matrix.mul_apply] using h_entry)
     simp only [Matrix.sub_apply, Matrix.one_apply, Matrix.zero_apply]
-    exact h_entry.resolve_right hlj
+    exact (mul_eq_zero.mp h_prod).resolve_right hlj
 
 /-- `(M * Mᴴ) c c = ∑ x, ‖M c x‖²` for any matrix `M`. -/
 lemma diagonal_mul_conjTranspose_eq_normSq_sum


### PR DESCRIPTION
### Motivation
- The private helper `mul_single_mul_eq` was used in only one call site (`proj_zero_or_one_of_sandwich`); inlining it removes a private declaration with no reuse value and reduces proof complexity.

### Description
- Modified `TNLean/Channel/Irreducible/Basic.lean`: removed the private lemma `mul_single_mul_eq` (a matrix-unit sandwich calculation) and computed its single use inline in `proj_zero_or_one_of_sandwich` via `Matrix.mul_single_apply_of_ne` and `mul_eq_zero`.
- The mathematical statement of `proj_zero_or_one_of_sandwich` and irreducibility theory are unchanged; no callers are affected.

### Testing
- `lake build TNLean.Channel.Irreducible.Basic -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
No linked issue found (branch `codex/irreducible-single-sandwich` contains no `issue-N` pattern; no `Closes`/`Addresses`/`Fixes #N` in the body or commit messages). Please link a relevant issue manually if one exists.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma; no API or mathematical statement changes, with existing callers unchanged.
> 
> **Overview**
> **Refactors** the proof of `proj_zero_or_one_of_sandwich` by dropping the private helper `mul_single_mul_eq` and computing the relevant `(1 - P) * Matrix.single * P` entry inline.
> 
> The new proof applies the universal hypothesis directly, collapses the inner product sum with `Finset.sum_eq_single`, and uses `Matrix.mul_single_apply_of_ne` plus `mul_eq_zero` to derive `(1 - P) i k * P l₀ j₀ = 0`. The lemma's statement and irreducibility theory are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41032775579bfe5019261e7c1ffd5f11931be058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file Lean proof refactor with no API or mathematical statement changes; existing callers are unaffected.
> 
> **Overview**
> **Proof-only refactor** in `TNLean/Channel/Irreducible/Basic.lean`: the private helper `mul_single_mul_eq` is removed because it had a single use.
> 
> The proof of `proj_zero_or_one_of_sandwich` now applies the universal hypothesis to `Matrix.single k l₀ 1`, collapses the relevant matrix entry sum with `Finset.sum_eq_single` and `Matrix.mul_single_apply_of_ne`, and finishes with `mul_eq_zero` instead of going through the deleted lemma. The lemma’s statement and downstream callers (`RelaxationConditions`, `CPPrimitive`, etc.) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c1bebd49c1e39001a61278a0a5a7c3652b11ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->