### PR TITLE
refactor(Channel/Semigroup): inline interval integral conversion

### DIFF
--- a/TNLean/Channel/Semigroup/Perturbation.lean
+++ b/TNLean/Channel/Semigroup/Perturbation.lean
@@ -372,12 +372,6 @@ private lemma dysonTerm_succ_nonpos (L L' : MatrixCLM (Fin D)) (n : ℕ) {t : �
   rw [Real.volume_Icc, ENNReal.ofReal_eq_zero]
   linarith
 
-/-- For `t ≥ 0`, the set integral `∫ s in Icc 0 t` equals the interval integral `∫ s in 0..t`. -/
-private lemma setIntegral_Icc_eq_intervalIntegral {E : Type*} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] {f : ℝ → E} {t : ℝ} (ht : 0 ≤ t) :
-    ∫ s in Set.Icc 0 t, f s = ∫ s in (0 : ℝ)..t, f s := by
-  rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le ht]
-
 /-- Each Dyson iterate `t ↦ T'ⁿ(t)` is continuous in the time parameter. -/
 theorem dysonTerm_continuous (L L' : MatrixCLM (Fin D)) (n : ℕ) :
     Continuous (fun t => dysonTerm L L' t n) := by
@@ -400,7 +394,8 @@ theorem dysonTerm_continuous (L L' : MatrixCLM (Fin D)) (n : ℕ) :
       apply ContinuousOn.congr hG_cont.continuousOn
       intro t ht
       dsimp only
-      rw [dysonTerm_succ, setIntegral_Icc_eq_intervalIntegral ht]
+      rw [dysonTerm_succ, integral_Icc_eq_integral_Ioc,
+        ← intervalIntegral.integral_of_le ht]
     -- On Iic 0: dysonTerm is 0 (hence continuous there).
     have h_Iic : ContinuousOn (fun t => dysonTerm L L' t (n + 1)) (Set.Iic 0) :=
       continuousOn_const.congr fun _ ht => dysonTerm_succ_nonpos L L' n ht
@@ -544,7 +539,7 @@ theorem norm_dysonRemainder_le (L L' : MatrixCLM (Fin D)) {t : ℝ} (ht : 0 ≤ 
             · exact mul_nonneg hM_nn (norm_nonneg _)
         _ = C * u ^ N := by simp only [hC_def, mul_pow]; ring
     -- Convert set integral to interval integral
-    rw [setIntegral_Icc_eq_intervalIntegral hs0]
+    rw [integral_Icc_eq_integral_Ioc, ← intervalIntegral.integral_of_le hs0]
     -- Integrability of the bound function
     have hCu_int : IntervalIntegrable (fun u => C * u ^ N) volume 0 s :=
       (continuous_const.mul (continuous_pow N)).intervalIntegrable 0 s


### PR DESCRIPTION
### Motivation

- The private lemma `setIntegral_Icc_eq_intervalIntegral` in `TNLean/Channel/Semigroup/Perturbation.lean` is a pass-through wrapper around standard Mathlib interval-integral identities with no independent mathematical content.
- Removing it reduces indirection and keeps the proof sites directly anchored to Mathlib lemmas.

### Description

- Removed the private lemma `setIntegral_Icc_eq_intervalIntegral` from `TNLean/Channel/Semigroup/Perturbation.lean`.
- In `dysonTerm_continuous` and `norm_dysonRemainder_le`, rewrites of `∫ s in Icc 0 t` to `∫ s in 0..t` now use `integral_Icc_eq_integral_Ioc` and `intervalIntegral.integral_of_le` from Mathlib directly.
- No mathematical content changed; this removes only a local pass-through statement around standard interval-integral normalization.

### Testing

- `lake build TNLean.Channel.Semigroup.Perturbation` (reports only existing copyright-header warnings)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one file with no API or runtime behavior changes; mathematical content is unchanged.
> 
> **Overview**
> Deletes the private lemma `setIntegral_Icc_eq_intervalIntegral` in `Perturbation.lean`, which only forwarded standard set-to-interval integral identities.
> 
> In **`dysonTerm_continuous`** and **`norm_dysonRemainder_le`**, converting `∫ s in Icc 0 t` to `∫ s in 0..t` now chains **`integral_Icc_eq_integral_Ioc`** with **`intervalIntegral.integral_of_le`** at the rewrite site instead of calling the local lemma. No change to the mathematical statements or proof strategy beyond this indirection removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e308a7708b1118c18a85a20da956246c372ed48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->