### PR TITLE
refactor(Channel/Semigroup): compose trace evaluation map

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
@@ -29,22 +29,12 @@ section LindbladForms
 
 /-! ## Equivalence: trace-annihilating ↔ trace-preserving semigroup -/
 
-/-- The trace-evaluation functional as an ℝ-linear map:
-`T ↦ trace(T(ρ))` for a fixed matrix `ρ`. -/
-private def traceEvalLM (ρ : Matrix (Fin D) (Fin D) ℂ) :
-    (Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ) →ₗ[ℝ] ℂ where
-  toFun T := trace (T ρ)
-  map_add' T S := by simp
-  map_smul' r T := by
-    change trace (((r : ℂ) • T ρ)) = r • trace (T ρ)
-    rw [Matrix.trace_smul]
-    simp [Complex.real_smul]
-
 /-- The trace-evaluation functional as an ℝ-continuous linear map:
 `T ↦ trace(T(ρ))` for a fixed matrix `ρ`. -/
 private def traceEvalCLM (ρ : Matrix (Fin D) (Fin D) ℂ) :
     (Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ) →L[ℝ] ℂ :=
-  ⟨traceEvalLM ρ, (traceEvalLM ρ).continuous_of_finiteDimensional⟩
+  ((LinearMap.toContinuousLinearMap (Matrix.traceLinearMap (Fin D) ℂ ℂ)).restrictScalars ℝ).comp
+    ((ContinuousLinearMap.apply ℂ (Matrix (Fin D) (Fin D) ℂ) ρ).restrictScalars ℝ)
 
 private lemma traceEvalCLM_apply
     (T : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ)


### PR DESCRIPTION
### Motivation
- `TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean` contained a private real-linear map `traceEvalLM` whose linearity was hand-proved via `map_add'` and `map_smul'` fields. The same continuous-linear functional is obtained directly by composing `Matrix.traceLinearMap` with `ContinuousLinearMap.apply`, making the hand-written proof redundant.

### Description
- Modified `TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean` (−12 / +2 lines): removed the private construction `traceEvalLM` (including `toFun`, `map_add'`, and `map_smul'` proved via `Matrix.trace_smul`) and replaced it with the composition of `Matrix.traceLinearMap` with `ContinuousLinearMap.apply` at a fixed density matrix `ρ`, restricted to real scalars via `restrictScalars ℝ` so the domain matches the real time parameter in the derivative arguments.
- The public definitions `traceEvalCLM_apply` and the trace-annihilation ↔ trace-preservation equivalences for continuous semigroups are unchanged.

### Testing
- Focused build: `lake build TNLean.Channel.Semigroup.LindbladForm.TraceBridge -q --log-level=info` (reports only pre-existing copyright-header warnings).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
Addresses #

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely internal refactor of a private helper using standard Mathlib linear maps; public lemmas and equivalences are unchanged.
> 
> **Overview**
> **Refactors** how `traceEvalCLM` is built in `TraceBridge.lean`: drops the private hand-proved linear map `traceEvalLM` (`map_add'` / `map_smul'` via `Matrix.trace_smul`) and defines the same ℝ-continuous functional as **composition** of `Matrix.traceLinearMap` with `ContinuousLinearMap.apply` at fixed `ρ`, using `restrictScalars ℝ` so the scalar field matches the real time parameter in the derivative arguments.
> 
> `traceEvalCLM_apply` and the trace-annihilating ↔ trace-preserving semigroup theorems are **unchanged** in behavior; only the internal construction is simplified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deeb13f29a50a92316d8127d0c346eb855e0a969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->