### PR TITLE
refactor(Spectral): compose continuous trace functionals

### DIFF
--- a/TNLean/Spectral/MPVOverlapDecay.lean
+++ b/TNLean/Spectral/MPVOverlapDecay.lean
@@ -143,10 +143,8 @@ local notation "V" => Matrix (Fin D₁) (Fin D₂) ℂ
 /-- Trace, viewed as a linear functional on the Banach algebra of continuous endomorphisms.
 
 On finite-dimensional spaces this is automatically continuous. -/
-noncomputable def traceCLMRect : (V →L[ℂ] V) →ₗ[ℂ] ℂ where
-  toFun F := LinearMap.trace ℂ V (F : V →ₗ[ℂ] V)
-  map_add' F G := by simp
-  map_smul' c F := by simp
+noncomputable def traceCLMRect : (V →L[ℂ] V) →ₗ[ℂ] ℂ :=
+  (LinearMap.trace ℂ V).comp (ContinuousLinearMap.coeLM ℂ)
 
 /-- If `F^n → 0` in operator norm, then `trace(F^n) → 0`. -/
 lemma tendsto_trace_pow_of_tendsto_zero_rect
@@ -160,10 +158,10 @@ lemma tendsto_trace_pow_of_tendsto_zero_rect
   have h := (hcont.tendsto (0 : V →L[ℂ] V)).comp hF
   have hzero : traceCLMRect (D₁ := D₁) (D₂ := D₂) (0 : V →L[ℂ] V) = 0 := by
     simp [traceCLMRect]
-  change Tendsto
-      ((fun G : V →L[ℂ] V => LinearMap.trace ℂ V ((G : V →ₗ[ℂ] V))) ∘ fun n => F ^ n)
-      atTop (nhds (0 : ℂ))
-  simpa [traceCLMRect, Function.comp_apply, hzero] using h
+  change Tendsto (((LinearMap.trace ℂ V) ∘
+      (fun G : V →L[ℂ] V => G.toLinearMap)) ∘ fun n => F ^ n) atTop
+      (nhds (0 : ℂ))
+  simpa [traceCLMRect, ContinuousLinearMap.coeLM, Function.comp_apply, hzero] using h
 
 /-- If the rectangular mixed transfer map has spectral radius `< 1`, then `mpvOverlap → 0`. -/
 theorem mpvOverlap_tendsto_zero_of_mixedTransferSpectralRadius_lt_one

--- a/TNLean/Spectral/PrimitiveOverlap.lean
+++ b/TNLean/Spectral/PrimitiveOverlap.lean
@@ -58,10 +58,8 @@ local notation "V" => Matrix (Fin D) (Fin D) ℂ
 /-- Trace, viewed as a linear functional on the Banach algebra of continuous endomorphisms.
 
 On finite-dimensional spaces this is automatically continuous. -/
-noncomputable def traceCLM : (V →L[ℂ] V) →ₗ[ℂ] ℂ where
-  toFun F := LinearMap.trace ℂ V F
-  map_add' F G := by simp
-  map_smul' c F := by simp
+noncomputable def traceCLM : (V →L[ℂ] V) →ₗ[ℂ] ℂ :=
+  (LinearMap.trace ℂ V).comp (ContinuousLinearMap.coeLM ℂ)
 
 /-- If `F^n → 0` in operator norm, then `trace(F^n) → 0`. -/
 lemma tendsto_trace_pow_of_tendsto_zero
@@ -76,9 +74,10 @@ lemma tendsto_trace_pow_of_tendsto_zero
   have h := (hcont.tendsto (0 : V →L[ℂ] V)).comp hF
   have hzero : traceCLM (D := D) (0 : V →L[ℂ] V) = 0 := by
     simp [traceCLM]
-  change Tendsto ((fun G : V →L[ℂ] V => LinearMap.trace ℂ V G) ∘ fun n => F ^ n)
-      atTop (nhds (0 : ℂ))
-  simpa [traceCLM, Function.comp_apply, hzero] using h
+  change Tendsto (((LinearMap.trace ℂ V) ∘
+      (fun G : V →L[ℂ] V => G.toLinearMap)) ∘ fun n => F ^ n) atTop
+      (nhds (0 : ℂ))
+  simpa [traceCLM, ContinuousLinearMap.coeLM, Function.comp_apply, hzero] using h
 
 /-- **Trace convergence from a complementary transfer-map gap.**
 


### PR DESCRIPTION
### Motivation

- `traceCLM` (in `PrimitiveOverlap.lean`) and `traceCLMRect` (in `MPVOverlapDecay.lean`)
  were each defined with hand-written `add_map` and `smul_map` fields, duplicating
  linearity proofs already provided by `ContinuousLinearMap.coeLM` and
  `LinearMap.trace` in Mathlib.
- Replacing both definitions with the standard composition
  `(LinearMap.trace ℂ V).comp (ContinuousLinearMap.coeLM ℂ)` removes the duplication
  and expresses the trace functionals directly through existing Mathlib structure.

### Description

- `TNLean/Spectral/PrimitiveOverlap.lean`: `traceCLM` redefined as
  `(LinearMap.trace ℂ V).comp (ContinuousLinearMap.coeLM ℂ)`; closing proof steps
  in `tendsto_trace_pow_of_tendsto_zero` adjusted to match the composed-map expression
  using `simpa` with `ContinuousLinearMap.coeLM`.
- `TNLean/Spectral/MPVOverlapDecay.lean`: `traceCLMRect` given the analogous
  composed form; closing steps in `tendsto_trace_pow_of_tendsto_zero_rect` updated
  accordingly.
- No theorem statements or hypotheses change; this is a proof-internal reorganization only.

### Testing

- `lake exe cache get`
- `lake build TNLean.Spectral.PrimitiveOverlap TNLean.Spectral.MPVOverlapDecay -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- The focused Lean build reports only existing style/header warnings in these files and imports.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small proof refactor in spectral overlap lemmas with no API or mathematical statement changes.
> 
> **Overview**
> **Refactors** how trace is packaged as a linear map on continuous endomorphisms in `PrimitiveOverlap.lean` and `MPVOverlapDecay.lean`.
> 
> `traceCLM` and `traceCLMRect` no longer use hand-built `toFun` / `map_add'` / `map_smul'`; both are now `(LinearMap.trace ℂ V).comp (ContinuousLinearMap.coeLM ℂ)`, reusing Mathlib’s linearity instead of duplicate `simp` proofs.
> 
> The closing steps in `tendsto_trace_pow_of_tendsto_zero` and `tendsto_trace_pow_of_tendsto_zero_rect` are updated so the continuity argument `simpa`s through `ContinuousLinearMap.coeLM` and the composed definition. **Theorem statements and hypotheses are unchanged**—proof-internal cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901a5351cb42ff6298ca21158b960a2caccf310d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->