### PR TITLE
refactor(Channel/Semigroup): use finite-dimensional compression CLMs

### DIFF
--- a/TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean
@@ -148,7 +148,7 @@ theorem generatorPreservesCompression_of_semigroupPreservesCompression
     rfl
   -- Build a CLM from compress
   let compressCLM : Mat →L[ℝ] Mat :=
-    ⟨compress, LinearMap.continuous_of_finiteDimensional compress⟩
+    LinearMap.toContinuousLinearMap compress
   -- compressCLM applied to anything gives P * · * P
   have hclm_eq : ∀ M : Mat, compressCLM M = P * M * P := hcompress_apply
   -- g(t) := P * f(t) * P has derivative P * L(Y) * P at t = 0
@@ -306,7 +306,7 @@ theorem semigroup_preserves_compression_of_generator
   have hcompress : ∀ M : Mat, compress M = P * M * P := fun M => by
     simp [compress, LinearMap.mulLeft, LinearMap.mulRight, Matrix.mul_assoc]
   let compressCLM : Mat →L[ℂ] Mat :=
-    ⟨compress, LinearMap.continuous_of_finiteDimensional compress⟩
+    LinearMap.toContinuousLinearMap compress
   have hcompress_clm : ∀ M : Mat, compressCLM M = P * M * P := hcompress
   letI : CompleteSpace (Mat →L[ℂ] Mat) :=
     FiniteDimensional.complete ℂ (Mat →L[ℂ] Mat)


### PR DESCRIPTION
### Motivation
- `GeneratorCompression.lean` constructed `ContinuousLinearMap` values via the explicit pair `⟨compress, LinearMap.continuous_of_finiteDimensional compress⟩`; the Mathlib idiomatic form for finite-dimensional spaces is `LinearMap.toContinuousLinearMap`, already used elsewhere in the project (e.g. in `MatrixOperatorSpace`).
- Replacing the explicit constructor removes a direct reference to the internal continuity proof and aligns with the established project pattern.

### Description
- Modified `TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean` (2 lines changed).
- In `generatorPreservesCompression_of_semigroupPreservesCompression`: the ℝ-linear local `compressCLM` now uses `LinearMap.toContinuousLinearMap compress`.
- In `semigroup_preserves_compression_of_generator`: the ℂ-linear local `compressCLM` now uses `LinearMap.toContinuousLinearMap compress`.
- The underlying compression maps (`M ↦ P * M * P`) and all proof steps are unchanged; no mathematical content is altered.

### Testing
- `lake build TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression` succeeds.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` passes with no new prose violations.
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
_No linked issue found — if a tracking issue for `Channel/Semigroup` cleanup exists, please add an `Addresses #N` reference._

> [!NOTE]
> **Low Risk**
> Proof-only refactor with identical linear maps; no API or runtime behavior change.
> 
> **Overview**
> **Mechanical refactor** in `GeneratorCompression.lean`: both `compressCLM` definitions (ℝ-linear in `generatorPreservesCompression_of_semigroupPreservesCompression` and ℂ-linear in `semigroup_preserves_compression_of_generator`) no longer use the explicit `ContinuousLinearMap` constructor with `LinearMap.continuous_of_finiteDimensional`.
> 
> They now call **`LinearMap.toContinuousLinearMap compress`**, matching the Mathlib finite-dimensional pattern used elsewhere (e.g. `Module.End.toContinuousLinearMap` in `MatrixOperatorSpace`). The underlying compression maps and proof steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e118e6c82a562ad6de1e717abf6942eb1ba8971f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with identical linear maps; no API or mathematical behavior change.
> 
> **Overview**
> In **`GeneratorCompression.lean`**, both local **`compressCLM`** bindings (ℝ-linear in **`generatorPreservesCompression_of_semigroupPreservesCompression`** and ℂ-linear in **`semigroup_preserves_compression_of_generator`**) no longer use the explicit **`ContinuousLinearMap`** pair **`⟨compress, LinearMap.continuous_of_finiteDimensional compress⟩`**.
> 
> They now use **`LinearMap.toContinuousLinearMap compress`**, matching the finite-dimensional Mathlib pattern already used elsewhere in TNLean (e.g. **`MatrixOperatorSpace`**). The compression maps **`M ↦ P * M * P`** and the surrounding proofs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa0c5057600112771b719e8c81433e738758585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->