### PR TITLE
refactor(Channel/Semigroup): reuse finite-dimensional Choi CLM

### DIFF
--- a/TNLean/Channel/Semigroup/CPClosure.lean
+++ b/TNLean/Channel/Semigroup/CPClosure.lean
@@ -197,9 +197,8 @@ private noncomputable def choiLinearOnCLM :
 
 /-- The Choi matrix as a continuous linear map on continuous endomorphisms. -/
 noncomputable def choiCLM :
-    MatrixCLM (Fin D) →L[ℂ] Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ where
-  toLinearMap := choiLinearOnCLM
-  cont := choiLinearOnCLM.continuous_of_finiteDimensional
+    MatrixCLM (Fin D) →L[ℂ] Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
+  LinearMap.toContinuousLinearMap choiLinearOnCLM
 
 end ChoiJamiolkowski
 


### PR DESCRIPTION
### Motivation

- `choiCLM` in `Channel/Semigroup/CPClosure` was built with an anonymous `ContinuousLinearMap` structure constructor, manually specifying `toLinearMap := choiLinearOnCLM` and `cont := choiLinearOnCLM.continuous_of_finiteDimensional`. Mathlib's `LinearMap.toContinuousLinearMap` provides exactly this construction for linear maps on finite-dimensional spaces, removing the need to spell out both fields.

### Description

- `TNLean/Channel/Semigroup/CPClosure.lean`: `choiCLM` is now `LinearMap.toContinuousLinearMap choiLinearOnCLM` (+2 / −3 lines). The underlying linear map `choiLinearOnCLM` is unchanged, and all downstream uses (e.g. `isClosed_setOf_isCPMap` via `choiCLM.continuous`) are unaffected. No declarations added or removed; no mathematical content altered.

### Testing

- `lake build TNLean.Channel.Semigroup.CPClosure -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single definitional refactor with no API or proof changes; continuity still comes from finite-dimensionality via Mathlib.
> 
> **Overview**
> **`choiCLM`** in `CPClosure.lean` no longer uses an explicit `ContinuousLinearMap` constructor with separate `toLinearMap` and `continuous_of_finiteDimensional` fields. It is now **`LinearMap.toContinuousLinearMap choiLinearOnCLM`**, aligning with the usual Mathlib pattern for finite-dimensional linear maps.
> 
> **`choiLinearOnCLM`** is unchanged. Call sites such as **`isClosed_setOf_isCPMap`** (continuity for the PSD preimage) and **`choiRCLM`** in Lindblad Euler-step arguments still use the same **`choiCLM`** API; this is a definitional cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08261663bd0ce9e177f40707a8813f8f59b2f728. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->