### PR TITLE
refactor(Channel/Semigroup): reuse native semigroup CLMs

### DIFF
--- a/TNLean/Channel/Semigroup/Basic.lean
+++ b/TNLean/Channel/Semigroup/Basic.lean
@@ -260,22 +260,8 @@ theorem hasDerivAt_expSemigroup_apply
         (fun u : ℝ => expSemigroupCLM (endEquiv L) u)
         (expSemigroupCLM (endEquiv L) t * endEquiv L) t :=
     hasDerivAt_expSemigroupCLM (endEquiv L) t
-  let evalXₗ : MatrixCLM (Fin D) →ₗ[ℝ] Matrix (Fin D) (Fin D) ℂ :=
-    { toFun := fun T => T X
-      map_add' := by
-        intro T₁ T₂
-        simp only [_root_.add_apply]
-      map_smul' := by
-        intro r T
-        change ((r • T) X) = r • (T X)
-        rfl }
   let evalX : MatrixCLM (Fin D) →L[ℝ] Matrix (Fin D) (Fin D) ℂ :=
-    evalXₗ.mkContinuous ‖X‖ fun T =>
-      by
-        change ‖T X‖ ≤ ‖X‖ * ‖T‖
-        calc
-          ‖T X‖ ≤ ‖T‖ * ‖X‖ := ContinuousLinearMap.le_opNorm T X
-          _ = ‖X‖ * ‖T‖ := mul_comm ‖T‖ ‖X‖
+    (ContinuousLinearMap.apply ℂ (Matrix (Fin D) (Fin D) ℂ) X).restrictScalars ℝ
   have hApply :=
       @HasFDerivAt.comp_hasDerivAt ℝ _
         (MatrixCLM (Fin D))
@@ -461,20 +447,13 @@ private theorem continuous_semigroup_hasDerivWithinAt_zero
     -- Pull S(h) out of integral
     have hpull : S h * intervalIntegral S 0 ε MeasureTheory.volume =
         intervalIntegral (fun t => S h * S t) 0 ε MeasureTheory.volume := by
-      let Lleftₗ : MatrixCLM (Fin D) →ₗ[ℝ] MatrixCLM (Fin D) :=
-        { toFun := fun T => S h * T
-          map_add' := by
-            intro T U
-            ext X
-            simp [mul_apply_eq_comp, map_add]
-          map_smul' := by
-            intro r T
-            ext X
-            simp [mul_apply_eq_comp] }
       let Lleft : MatrixCLM (Fin D) →L[ℝ] MatrixCLM (Fin D) :=
-        Lleftₗ.mkContinuous ‖S h‖ fun T => by
-          exact norm_mul_le (S h) T
+        (ContinuousLinearMap.compL ℂ
+          (Matrix (Fin D) (Fin D) ℂ)
+          (Matrix (Fin D) (Fin D) ℂ)
+          (Matrix (Fin D) (Fin D) ℂ) (S h)).restrictScalars ℝ
       have happly (T : MatrixCLM (Fin D)) : Lleft T = S h * T := by
+        ext X
         rfl
       have hS_int : IntervalIntegrable S MeasureTheory.volume 0 ε :=
         Continuous.intervalIntegrable (μ := MeasureTheory.volume) (u := S) hS_cont 0 ε


### PR DESCRIPTION
### Motivation

- `TNLean/Channel/Semigroup/Basic.lean` contained two ad hoc `LinearMap` records with explicit norm bounds for continuous-linear-map (CLM) operations that Mathlib already provides natively.
- Replacing them with native Mathlib operators reduces boilerplate and makes the constructions more readable and maintainable.

### Description

- Modified `TNLean/Channel/Semigroup/Basic.lean` (6 additions, 27 deletions).
- The derivative proof now uses `ContinuousLinearMap.apply` for point evaluation at a matrix, replacing a hand-built `LinearMap` record.
- The interval-integral argument now uses `ContinuousLinearMap.compL` (scalar field restricted from `ℂ` to `ℝ`) for left composition by `S h`, replacing an ad hoc construction with explicit norm bounds.
- Semigroup identities and all mathematical content are unchanged; only the CLM plumbing is restructured.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Semigroup.Basic -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
<!-- No linked issue found: branch name, PR body, commit messages, and file-based issue search yielded no issue number. Author should link an issue manually if one exists. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one file; no API or runtime behavior changes, only Mathlib CLM wiring.
> 
> **Overview**
> In `TNLean/Channel/Semigroup/Basic.lean`, two proofs that previously built **continuous linear maps by hand** now use Mathlib’s standard operators.
> 
> In **`hasDerivAt_expSemigroup_apply`**, point evaluation at a fixed matrix `X` is **`ContinuousLinearMap.apply` … `restrictScalars ℝ`** instead of a custom `LinearMap` plus `mkContinuous` with an explicit `‖X‖` norm bound.
> 
> In **`continuous_semigroup_hasDerivWithinAt_zero`** (the `hSQ` / `hpull` step), left multiplication by `S h` is **`ContinuousLinearMap.compL` … `restrictScalars ℝ`** instead of another ad hoc `LinearMap` and `mkContinuous` using `norm_mul_le`. The `happly` lemma now uses **`ext X`** to match the new API.
> 
> **Semigroup identities and all mathematical steps are unchanged**; only CLM construction and plumbing are simplified (−27 / +6 lines).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 319817c5d1e367558d1de0341d31781602a0ed42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->