### PR TITLE
refactor(Channel/Semigroup): use bounded multiplication continuity

### DIFF
--- a/TNLean/Channel/Semigroup/Dissipative.lean
+++ b/TNLean/Channel/Semigroup/Dissipative.lean
@@ -87,14 +87,6 @@ private abbrev leftMulCLMAlgHom (D : ℕ) : Mat D →ₐ[ℂ] MatrixCLM (Fin D) 
 private abbrev rightMulCLMAlgHom (D : ℕ) : (Mat D)ᵐᵒᵖ →ₐ[ℂ] MatrixCLM (Fin D) :=
   (endEquivD D).toAlgHom.comp (rightMulAlgHom D)
 
-private lemma continuous_leftMulCLMAlgHom :
-    Continuous (leftMulCLMAlgHom D) :=
-  (leftMulCLMAlgHom D).toLinearMap.continuous_of_finiteDimensional
-
-private lemma continuous_rightMulCLMAlgHom :
-    Continuous (rightMulCLMAlgHom D) :=
-  (rightMulCLMAlgHom D).toLinearMap.continuous_of_finiteDimensional
-
 private theorem leftMulCLM_apply (A ρ : Mat D) :
     leftMulCLMAlgHom D A ρ = A * ρ := by
   change leftMulAlgHom D A ρ = A * ρ
@@ -104,6 +96,33 @@ private theorem rightMulCLM_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
     rightMulCLMAlgHom D A ρ = ρ * MulOpposite.unop A := by
   change rightMulAlgHom D A ρ = ρ * MulOpposite.unop A
   exact rightMulAlgHom_apply A ρ
+
+private lemma continuous_leftMulCLMAlgHom :
+    Continuous (leftMulCLMAlgHom D) := by
+  have h_eq : (leftMulCLMAlgHom D : Mat D → MatrixCLM (Fin D)) =
+      ContinuousLinearMap.mul ℂ (Mat D) := by
+    funext A
+    apply ContinuousLinearMap.ext
+    intro ρ
+    rw [leftMulCLM_apply]
+    rfl
+  rw [h_eq]
+  exact (ContinuousLinearMap.mul ℂ (Mat D)).continuous
+
+private lemma continuous_rightMulCLMAlgHom :
+    Continuous (rightMulCLMAlgHom D) := by
+  have hunop : Continuous (MulOpposite.unop : (Mat D)ᵐᵒᵖ → Mat D) :=
+    MulOpposite.continuous_unop
+  have h_eq : (rightMulCLMAlgHom D : (Mat D)ᵐᵒᵖ → MatrixCLM (Fin D)) =
+      fun A : (Mat D)ᵐᵒᵖ =>
+        (ContinuousLinearMap.mul ℂ (Mat D)).flip (MulOpposite.unop A) := by
+    funext A
+    apply ContinuousLinearMap.ext
+    intro ρ
+    rw [rightMulCLM_apply]
+    rfl
+  rw [h_eq]
+  exact (ContinuousLinearMap.mul ℂ (Mat D)).flip.continuous.comp hunop
 
 private theorem mulLeft_eq_leftMulAlgHom (A : Mat D) :
     LinearMap.mulLeft ℂ A = leftMulAlgHom D A := by


### PR DESCRIPTION
### Motivation

- The continuity proofs for the left- and right-multiplication algebra homomorphisms in `TNLean/Channel/Semigroup/Dissipative.lean` previously invoked finite-dimensionality directly on the homomorphisms. They can instead be derived from Mathlib's bounded multiplication map `ContinuousLinearMap.mul`, a more direct reduction.
- No mathematical content changes: the exponential identities and the dissipative drift exponential theorem are unaffected.

### Description

- Modified `TNLean/Channel/Semigroup/Dissipative.lean`.
- Continuity proofs for `continuous_leftMulCLMAlgHom` and `continuous_rightMulCLMAlgHom` are rewritten: each map is shown equal (entrywise via `leftMulCLM_apply` / `rightMulCLM_apply`) to `ContinuousLinearMap.mul` on matrices, so continuity follows from Mathlib's bounded multiplication. The right-multiplication case additionally composes `mul.flip` with continuity of `MulOpposite.unop`.
- These lemmas are repositioned to follow the apply lemmas on which they now depend.
- `exp_leftMulCLM`, `exp_rightMulCLM`, and the dissipative drift exponential theorem are unchanged in statement and proof structure.

### Testing

- `lake build TNLean.Channel.Semigroup.Dissipative -q --log-level=info`
- Prose check: `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Blueprint sync: `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
_No linked issue found. This PR appears to be a self-contained proof reorganization; the maintainer may wish to link a relevant issue manually._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local proof refactor in one Lean file with no API or mathematical statement changes; risk is limited to whether the new continuity arguments typecheck and remain compatible with `NormedSpace.map_exp`.
> 
> **Overview**
> **Proof-only refactor** in `TNLean/Channel/Semigroup/Dissipative.lean` for the dissipative drift semigroup machinery—no change to theorem statements or downstream exponential / CP results.
> 
> `continuous_leftMulCLMAlgHom` and `continuous_rightMulCLMAlgHom` no longer use `continuous_of_finiteDimensional` on the algebra homomorphisms. Each is shown pointwise equal to matrix multiplication via `ContinuousLinearMap.mul` (using `leftMulCLM_apply` / `rightMulCLM_apply`), so continuity comes from Mathlib’s bounded multiplication. The right case identifies the map with `mul.flip` after `MulOpposite.unop` and composes with `MulOpposite.continuous_unop`.
> 
> Those two lemmas are **moved below** the apply lemmas they now depend on. `exp_leftMulCLM`, `exp_rightMulCLM`, and `expSemigroup_dissipativeDrift_apply` still call the same continuity lemmas unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 928f4b107b01c3ccee47ec38316f9b97d13a93d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->