### PR TITLE
refactor(Spectral): use trace CLM for cross correlations

### DIFF
--- a/TNLean/Spectral/CrossCorrelation.lean
+++ b/TNLean/Spectral/CrossCorrelation.lean
@@ -59,13 +59,13 @@ theorem cross_correlation_tendsto_zero
       Filter.atTop (nhds 0) := by
   -- Compose: F^N(X) → 0 (by the transfer-operator gap) and trace is continuous.
   have h := mixedTransfer_pow_tendsto_zero A B hA hB hA_norm hB_norm hAB X
-  have h_cont : Continuous (Matrix.traceLinearMap (Fin D) ℂ ℂ) :=
-    LinearMap.continuous_of_finiteDimensional _
+  let tr : Matrix (Fin D) (Fin D) ℂ →L[ℂ] ℂ :=
+    LinearMap.toContinuousLinearMap (Matrix.traceLinearMap (Fin D) ℂ ℂ)
   have h2 : Filter.Tendsto
       (fun N => (Matrix.traceLinearMap (Fin D) ℂ ℂ) (((mixedTransferMap A B) ^ N) X))
       Filter.atTop (nhds 0) := by
-    rw [← map_zero (Matrix.traceLinearMap (Fin D) ℂ ℂ)]
-    exact h_cont.continuousAt.tendsto.comp h
+    simpa [tr, Function.comp_def, Matrix.traceLinearMap_apply] using
+      (tr.continuous.tendsto 0).comp h
   simpa [Matrix.traceLinearMap_apply] using h2
 
 /-- **Self-correlation persists**: If `ρ` is a fixed point of `E_A`, then


### PR DESCRIPTION
### Motivation
- The proof of `cross_correlation_tendsto_zero` in `TNLean/Spectral/CrossCorrelation.lean` established continuity of the trace functional via `LinearMap.continuous_of_finiteDimensional`, a one-off step that reconstructs what `LinearMap.toContinuousLinearMap` provides directly as a Mathlib-native `ContinuousLinearMap`. Using the latter makes the limit argument a single composition chain without an intermediate `Continuous` hypothesis.
- The theorem statement, hypotheses, and transfer-gap argument are unchanged.

### Description
- `TNLean/Spectral/CrossCorrelation.lean` — proof body of `cross_correlation_tendsto_zero` only:
  - Continuity of `Matrix.traceLinearMap` is now obtained via `LinearMap.toContinuousLinearMap` rather than `LinearMap.continuous_of_finiteDimensional`.
  - The convergence to zero is derived by composing `.continuous.tendsto 0` with `mixedTransfer_pow_tendsto_zero` and rewriting to `Matrix.trace` using `Matrix.traceLinearMap_apply`.
  - No definitions, lemmas, or theorem statements were added or changed.

### Testing
- `lake exe cache get`
- `lake build TNLean.Spectral.CrossCorrelation -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check` and `git diff --cached --check` (no trailing whitespace)

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in spectral theory; no API or mathematical statement changes.
> 
> **Overview**
> **`cross_correlation_tendsto_zero`** is unchanged at the statement level; only the Lean proof that trace commutes with the mixed-transfer limit is rewritten.
> 
> Instead of a one-off `Continuous (Matrix.traceLinearMap …)` via `LinearMap.continuous_of_finiteDimensional`, the proof now packages trace as a continuous linear map with `LinearMap.toContinuousLinearMap`, applies `tr.continuous.tendsto 0` composed with `mixedTransfer_pow_tendsto_zero`, and rewrites back to `Matrix.trace` using `Matrix.traceLinearMap_apply`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52043c6f5234e0ec0cae5988174076a6030b9e7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only change in spectral theory with no API or mathematical statement changes.
> 
> **Overview**
> **`cross_correlation_tendsto_zero`** is unchanged at the statement level; only the Lean proof that trace commutes with the mixed-transfer limit is rewritten.
> 
> The proof no longer builds `Continuous (Matrix.traceLinearMap …)` with `LinearMap.continuous_of_finiteDimensional` and a manual `continuousAt.tendsto.comp` step. It introduces `tr` as `LinearMap.toContinuousLinearMap (Matrix.traceLinearMap …)`, derives convergence on the linear-map formulation with `(tr.continuous.tendsto 0).comp` applied to `mixedTransfer_pow_tendsto_zero`, then rewrites to `Matrix.trace` via `Matrix.traceLinearMap_apply`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97672b4d98ea5c2539cdadb657803cdfdcb881e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->