### PR TITLE
refactor(MPS/Symmetry): use trace CLM for string order

### DIFF
--- a/TNLean/MPS/Symmetry/StringOrderDefs.lean
+++ b/TNLean/MPS/Symmetry/StringOrderDefs.lean
@@ -286,17 +286,17 @@ lemma stringOrderBoundaryParam_tendsto_zero_of_spectralRadius_lt_one
       exact (map_pow (Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
         (twistedTransferMap A u) L).symm
     exact congrArg (fun T => T Y) hpow_eq
-  let φ : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] ℂ :=
-    (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
-      ((LinearMap.mulLeft ℂ Λ).comp (LinearMap.mulLeft ℂ X))
-  have hφ_cont : Continuous φ := LinearMap.continuous_of_finiteDimensional φ
+  let φ : Matrix (Fin D) (Fin D) ℂ →L[ℂ] ℂ :=
+    LinearMap.toContinuousLinearMap <|
+      (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
+        ((LinearMap.mulLeft ℂ Λ).comp (LinearMap.mulLeft ℂ X))
   have hφ0 :
       Filter.Tendsto (fun L => φ (((twistedTransferMap A u) ^ L) Y))
         Filter.atTop (nhds (φ 0)) :=
-    hφ_cont.continuousAt.tendsto.comp hIter0
+    (φ.continuous.tendsto 0).comp hIter0
   simpa only [map_zero, stringOrderBoundaryParam, twistedTransferIter, φ,
-    LinearMap.comp_apply, LinearMap.mulLeft_apply, Matrix.traceLinearMap_apply,
-    Matrix.mul_assoc] using hφ0
+    LinearMap.coe_toContinuousLinearMap', LinearMap.comp_apply, LinearMap.mulLeft_apply,
+    Matrix.traceLinearMap_apply, Matrix.mul_assoc] using hφ0
 
 /-- Local symmetry in the virtual FCS language of the paper: there is a unitary
 virtual intertwiner satisfying the phased covariance relation and preserving the


### PR DESCRIPTION
### Motivation

The string-order decay proof still derived continuity of a trace-pairing functional by a proof-local finite-dimensionality argument. Mathlib 4.31 already provides the finite-dimensional equivalence from linear maps to continuous linear maps, so this local continuity layer can be removed.

### Description

- Modified `TNLean/MPS/Symmetry/StringOrderDefs.lean`.
- In `stringOrderBoundaryParam_tendsto_zero_of_spectralRadius_lt_one`, the trace–boundary pairing functional `φ` is now defined as a `ContinuousLinearMap` via `LinearMap.toContinuousLinearMap`, eliminating the explicit `continuous_of_finiteDimensional` step and the separate `hφ_cont` continuity hypothesis.
- The spectral-radius limit now composes with `φ.continuous.tendsto 0` directly, in place of `hφ_cont.continuousAt.tendsto`.
- The theorem statement and the spectral-radius / iterate argument above this block are unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.Symmetry.StringOrderDefs -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `git diff --cached --check`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor inside one lemma; no API or mathematical statement changes.
>
> **Overview**
> In **`stringOrderBoundaryParam_tendsto_zero_of_spectralRadius_lt_one`**, the trace–boundary pairing functional **φ** is no longer a bare `LinearMap` with a local **`continuous_of_finiteDimensional`** step. It is built as a **`ContinuousLinearMap`** via **`LinearMap.toContinuousLinearMap`**, and the limit step uses **`φ.continuous.tendsto`** instead of **`continuousAt`** from that ad hoc continuity lemma.
>
> The **`simpa`** at the end picks up **`LinearMap.coe_toContinuousLinearMap'`** so the rewritten **φ** still matches **`stringOrderBoundaryParam`**. The lemma's statement and the spectral-radius / iterate argument above this block are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5b5d1e2d48054bb556e8c2fd422a9a6b46c7bd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-lemma proof refactor with no API or mathematical statement changes.
> 
> **Overview**
> In **`stringOrderBoundaryParam_tendsto_zero_of_spectralRadius_lt_one`**, the trace–boundary pairing **φ** is now a **`ContinuousLinearMap`** built with **`LinearMap.toContinuousLinearMap`**, instead of a bare **`LinearMap`** plus a local **`continuous_of_finiteDimensional`** step.
> 
> The iterate limit composes with **`φ.continuous.tendsto 0`** directly (replacing **`hφ_cont.continuousAt.tendsto`**), and the closing **`simpa`** adds **`LinearMap.coe_toContinuousLinearMap'`** so **φ** still aligns with **`stringOrderBoundaryParam`**. The lemma statement and the spectral-radius / iterate argument above this block are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed879f15a8596b17c888d8b68f96947f6db59179. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->