### PR TITLE
refactor(Channel/FixedPoint): use CLMs in Cesaro limits

### DIFF
--- a/TNLean/Channel/FixedPoint/Cesaro.lean
+++ b/TNLean/Channel/FixedPoint/Cesaro.lean
@@ -289,10 +289,11 @@ theorem IsChannel.exists_posSemidef_fixedPoint
   have hρ_psd : ρ.PosSemidef := hρ_mem.1
   have hρ_tr : trace ρ = 1 := hρ_mem.2
   -- Step 6: Show E(ρ) = ρ via telescoping + convergence
-  have hE_cont : Continuous E := LinearMap.continuous_of_finiteDimensional E
+  let E' : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+    LinearMap.toContinuousLinearMap E
   -- σ ∘ φ → ρ, E ∘ σ ∘ φ → E(ρ)
-  have h_Eσ : Filter.Tendsto (E ∘ σ ∘ φ) Filter.atTop (nhds (E ρ)) :=
-    (hE_cont.tendsto ρ).comp hφ_tendsto
+  have h_Eσ : Filter.Tendsto (E ∘ σ ∘ φ) Filter.atTop (nhds (E ρ)) := by
+    simpa [E'] using (E'.continuous.tendsto ρ).comp hφ_tendsto
   -- (E(σ(φ k)) - σ(φ k)) → E(ρ) - ρ
   have h_diff : Filter.Tendsto (fun k => (E ∘ σ ∘ φ) k - (σ ∘ φ) k)
       Filter.atTop (nhds (E ρ - ρ)) :=

--- a/TNLean/Channel/Irreducible/Ergodicity.lean
+++ b/TNLean/Channel/Irreducible/Ergodicity.lean
@@ -97,10 +97,13 @@ theorem IsChannel.cesaroMean_subseq_limit_fixedPoint
   have hσ_mem : σ ∈ densityMatrices D :=
     (densityMatrices_isCompact (D := D)).isClosed.mem_of_tendsto hσ_tendsto <|
       Filter.Eventually.of_forall fun k => hces_mem (ψ k)
-  have hE_cont : Continuous E := LinearMap.continuous_of_finiteDimensional E
+  let E' : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+    LinearMap.toContinuousLinearMap E
   have h_Eσ : Filter.Tendsto (fun k => E (cesaroMean E ρ (ψ k + 1)))
-      Filter.atTop (nhds (E σ)) :=
-    (hE_cont.tendsto σ).comp hσ_tendsto
+      Filter.atTop (nhds (E σ)) := by
+    change Filter.Tendsto (E ∘ fun k => cesaroMean E ρ (ψ k + 1))
+      Filter.atTop (nhds (E σ))
+    simpa [E'] using (E'.continuous.tendsto σ).comp hσ_tendsto
   have h_diff : Filter.Tendsto
       (fun k => E (cesaroMean E ρ (ψ k + 1)) - cesaroMean E ρ (ψ k + 1))
       Filter.atTop (nhds (E σ - σ)) :=


### PR DESCRIPTION
### Motivation

The Cesaro fixed-point arguments transported convergence through a channel by first proving continuity from finite dimensionality. Mathlib 4.31 provides the finite-dimensional map from linear maps to continuous linear maps, so these proof-local continuity witnesses can be removed.

### Description

This PR replaces the local `LinearMap.continuous_of_finiteDimensional` continuity facts in `IsChannel.exists_posSemidef_fixedPoint` and `IsChannel.cesaroMean_subseq_limit_fixedPoint` with bundled maps `LinearMap.toContinuousLinearMap E`. The mathematical statements and telescoping arguments are unchanged.

Files modified:
- `TNLean/Channel/FixedPoint/Cesaro.lean`
- `TNLean/Channel/Irreducible/Ergodicity.lean`

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.FixedPoint.Cesaro TNLean.Channel.Irreducible.Ergodicity -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `git diff --cached --check`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in channel fixed-point/ergodicity lemmas; no API, runtime, or mathematical statement changes.
>
> **Overview**
> Cesàro fixed-point proofs now push convergence through **`LinearMap.toContinuousLinearMap E`** instead of ad hoc **`LinearMap.continuous_of_finiteDimensional`** witnesses.
>
> In **`IsChannel.exists_posSemidef_fixedPoint`** (`Cesaro.lean`) and **`IsChannel.cesaroMean_subseq_limit_fixedPoint`** (`Ergodicity.lean`), the local continuity fact is replaced by a bundled continuous linear map `E'`, and **`Filter.Tendsto`** for `E` along Cesàro subsequences is obtained via **`E'.continuous.tendsto`**. The ergodicity lemma additionally rewrites the goal as **`E ∘ …`** before **`simpa`**. Telescoping identities and limit arguments are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90bed29ade35d620789a36612cfb60a07b5b5651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in channel fixed-point lemmas; no API or statement changes.
> 
> **Overview**
> Cesàro fixed-point proofs now route **`Filter.Tendsto`** for channel iterates through a bundled **`LinearMap.toContinuousLinearMap E`** (`E'`) instead of a local **`LinearMap.continuous_of_finiteDimensional`** witness.
> 
> In **`IsChannel.exists_posSemidef_fixedPoint`** (`Cesaro.lean`) and **`IsChannel.cesaroMean_subseq_limit_fixedPoint`** (`Ergodicity.lean`), continuity is obtained via **`E'.continuous.tendsto`**, with **`simpa [E']`** to align **`E`** with the CLM. The ergodicity lemma adds a **`change`** to **`E ∘ …`** before that step. Telescoping and limit arguments are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47f0402d421fa2e255522cea7ad491e921918a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->