### PR TITLE
refactor(Channel/Irreducible): use CLM for corner convergence

### DIFF
--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -325,8 +325,12 @@ theorem isIrreducibleMap_of_channel_posDef_fixedPoint_unique
   have hcorner_tendsto : Filter.Tendsto
       (fun k => P * cesaroMean E ρ₀ (φ k + 1) * P)
       Filter.atTop (nhds (P * σ * P)) := by
-    exact ((LinearMap.continuous_of_finiteDimensional
-      (sandwichLinearMap (D := D) P P)).tendsto σ).comp hσ_tendsto
+    let corner : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+      LinearMap.toContinuousLinearMap (sandwichLinearMap (D := D) P P)
+    change Filter.Tendsto
+      ((sandwichLinearMap (D := D) P P) ∘ fun k => cesaroMean E ρ₀ (φ k + 1))
+      Filter.atTop (nhds ((sandwichLinearMap (D := D) P P) σ))
+    simpa [corner] using (corner.continuous.tendsto σ).comp hσ_tendsto
   have hcorner_seq_eq :
       (fun k => P * cesaroMean E ρ₀ (φ k + 1) * P) =
         fun k => cesaroMean E ρ₀ (φ k + 1) := by


### PR DESCRIPTION
### Motivation

The irreducibility-from-spectral proof transported a Cesaro subsequence limit through the corner map by proving continuity from finite dimensionality. The corner map is already a linear map, so Mathlib 4.31 can bundle it as a continuous linear map directly.

### Description

This PR replaces the proof-local `LinearMap.continuous_of_finiteDimensional` use for `sandwichLinearMap P P` with `LinearMap.toContinuousLinearMap`. The theorem statement and invariant-corner argument are unchanged.

- File modified: `TNLean/Channel/Irreducible/FromSpectral.lean`

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Irreducible.FromSpectral -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check HEAD~1..HEAD`
- `git diff --cached --check`

---
<!-- No linked issue found. Add `Addresses #N` here when a tracking issue exists. -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma; no statement or API changes, only a different Mathlib continuity route for the same limit step.
>
> **Overview**
> In **`isIrreducibleMap_of_channel_posDef_fixedPoint_unique`**, the proof that Cesàro means converge inside the corner **`P · · · P`** now goes through **`LinearMap.toContinuousLinearMap (sandwichLinearMap P P)`** instead of invoking **`LinearMap.continuous_of_finiteDimensional`** on that map ad hoc.
>
> The argument is unchanged: rewrite the sequence as composition with **`sandwichLinearMap`**, apply **`continuous.tendsto`**, then relate back to **`P * … * P`**. This matches how **`sandwichLinearMap`** continuity is handled elsewhere (e.g. **`SpectralRadius.lean`**).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49c726d1f4d04a07cf98660ec49e9a381b7001c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-lemma proof refactor with no statement or API changes; only the Mathlib continuity route for the same limit step.
> 
> **Overview**
> In **`isIrreducibleMap_of_channel_posDef_fixedPoint_unique`**, the step showing Cesàro subsequence limits commute with the corner map **`P · · · P`** no longer calls **`LinearMap.continuous_of_finiteDimensional`** on **`sandwichLinearMap P P`**.
> 
> The proof now packages that map as **`LinearMap.toContinuousLinearMap (sandwichLinearMap P P)`**, rewrites the limit as composition with **`sandwichLinearMap`**, and applies **`corner.continuous.tendsto`**. The target limit and the rest of the invariant-corner argument are unchanged.
> 
> This aligns with how **`sandwichLinearMap`** continuity is obtained elsewhere (e.g. **`SpectralRadius.lean`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22659bb6ad18ef9a7bff28340239057a62d9d005. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->