### PR TITLE
refactor(Channel/PerronFrobenius): use CLM for norm map continuity

### DIFF
--- a/TNLean/Channel/PerronFrobenius/Normalization.lean
+++ b/TNLean/Channel/PerronFrobenius/Normalization.lean
@@ -280,9 +280,10 @@ theorem continuousAt_normMap
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (ρ : Matrix (Fin D) (Fin D) ℂ) (htr : Matrix.trace (E ρ) ≠ 0) :
     ContinuousAt (normMap (D := D) E) ρ := by
-  -- Continuity of the linear map `E` in finite dimension.
-  have hE : Continuous (fun ρ : Matrix (Fin D) (Fin D) ℂ => E ρ) :=
-    E.continuous_of_finiteDimensional
+  let E' : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+    LinearMap.toContinuousLinearMap E
+  have hE : Continuous (fun ρ : Matrix (Fin D) (Fin D) ℂ => E ρ) := by
+    simpa [E'] using E'.continuous
   have htrace :
       ContinuousAt (fun ρ : Matrix (Fin D) (Fin D) ℂ => Matrix.trace (E ρ)) ρ :=
     hE.matrix_trace.continuousAt


### PR DESCRIPTION
### Motivation

The Perron-Frobenius normalization map still proved continuity of the numerator by a local finite-dimensionality argument. Mathlib 4.31 provides the finite-dimensional bundling `LinearMap.toContinuousLinearMap`, which gives the needed continuity directly.

### Description

This PR replaces the `E.continuous_of_finiteDimensional` witness in `continuousAt_normMap` with the bundled continuous linear map `LinearMap.toContinuousLinearMap E`. The statement and normalization argument are unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.PerronFrobenius.Normalization -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `git diff --cached --check`

---
_(No linked issue found — author should link one manually.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavioral change; continuity witness is swapped for an equivalent Mathlib API.
> 
> **Overview**
> In **`continuousAt_normMap`**, the proof that the linear map **`E`** is continuous no longer uses **`E.continuous_of_finiteDimensional`**. It now introduces **`E' := LinearMap.toContinuousLinearMap E`** and derives continuity from **`E'.continuous`**, matching the Mathlib 4.31 finite-dimensional bundling used elsewhere in the channel code.
> 
> The theorem statement and the rest of the argument (trace continuity, invertibility at nonzero denominator, **`ContinuousAt.smul`**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 083b823ebd3e65c31f144d52ae2a90a01cf5d2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->