### PR TITLE
refactor(Channel/Semigroup): use CLMs in subsequence limits

### DIFF
--- a/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
@@ -137,9 +137,9 @@ private theorem channel_fixedPoint_in_PMP
         (fun n => hσ_PMP (φ n)))
       hφ_tendsto
   -- Show E(ρ) = ρ by telescoping
-  have hE_cont : Continuous E := LinearMap.continuous_of_finiteDimensional E
-  have h_Eσ : Filter.Tendsto (E ∘ σ ∘ φ) Filter.atTop (nhds (E ρ)) :=
-    (hE_cont.tendsto ρ).comp hφ_tendsto
+  let E' : Mat →L[ℂ] Mat := LinearMap.toContinuousLinearMap E
+  have h_Eσ : Filter.Tendsto (E ∘ σ ∘ φ) Filter.atTop (nhds (E ρ)) := by
+    simpa [E'] using (E'.continuous.tendsto ρ).comp hφ_tendsto
   have h_diff : Filter.Tendsto (fun k => (E ∘ σ ∘ φ) k - (σ ∘ φ) k)
       Filter.atTop (nhds (E ρ - ρ)) :=
     h_Eσ.sub hφ_tendsto
@@ -274,14 +274,14 @@ private theorem generator_vanishes_at_limit
     (hφ_mono : StrictMono φ)
     (hφ_tendsto : Filter.Tendsto (fun n => ρ_shift (φ n)) Filter.atTop (nhds ρ)) :
     L ρ = 0 := by
-  have hL_cont : Continuous L := LinearMap.continuous_of_finiteDimensional L
-  have hL_tendsto : Filter.Tendsto (fun n => L (ρ_shift (φ n))) Filter.atTop (nhds (L ρ)) :=
-    (hL_cont.tendsto ρ).comp hφ_tendsto
+  set E : Mat →L[ℂ] Mat := endEquiv L
+  have hL_tendsto : Filter.Tendsto (fun n => L (ρ_shift (φ n))) Filter.atTop (nhds (L ρ)) := by
+    change Filter.Tendsto (E ∘ fun n => ρ_shift (φ n)) Filter.atTop (nhds (E ρ))
+    exact (E.continuous.tendsto ρ).comp hφ_tendsto
   suffices h_to_zero :
       Filter.Tendsto (fun n => L (ρ_shift (φ n))) Filter.atTop (nhds 0) by
     exact tendsto_nhds_unique hL_tendsto h_to_zero
   obtain ⟨R, hR⟩ := density_subseq_norm_bounded (D := D) ρ_shift hρ_mem (φ := φ)
-  set E : Mat →L[ℂ] Mat := endEquiv L
   have hE_apply : ∀ X : Mat, E X = L X := by
     intro X
     rfl


### PR DESCRIPTION
### Motivation

The reducible-QDS subsequence argument still transported two limits through linear maps by proving continuity from finite dimensionality. Mathlib 4.31 provides bundled continuous linear maps for these maps, so the proof-local continuity witnesses can be removed.

### Description

This PR replaces the finite-dimensional continuity witnesses in `channel_fixedPoint_in_PMP` and `generator_vanishes_at_limit` with continuous linear maps: `LinearMap.toContinuousLinearMap E` for the channel action and the existing `endEquiv L` continuous-linear representation for the generator. The statements and the Cesaro/Taylor arguments are unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `git diff --cached --check`

---
_(No linked issue found — please add an `Addresses #N` reference before merge.)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one file with no API or mathematical changes; aligns with existing CLM usage elsewhere in ReducibleQDS.
> 
> **Overview**
> Subsequence limit steps in `channel_fixedPoint_in_PMP` and `generator_vanishes_at_limit` no longer build continuity from `LinearMap.continuous_of_finiteDimensional`. They now go through bundled continuous linear maps: `LinearMap.toContinuousLinearMap E` for the channel map and `endEquiv L` (moved earlier in `generator_vanishes_at_limit`) for the generator.
> 
> **Cesàro telescoping, Taylor bounds, and theorem statements are unchanged**—only how limits are pushed through `E` and `L`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23fcb4636256d639e86296c64068784e7315d4a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->