### PR TITLE
refactor(Channel/Irreducible): remove unused sandwich CLM

### DIFF
--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -47,15 +47,6 @@ variable {D : ℕ}
 
 section SimilarityCLM
 
-private noncomputable def sandwichLinearMap
-    (L R : Matrix (Fin D) (Fin D) ℂ) :
-    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
-  toFun X := L * X * R
-  map_add' X Y := by
-    simp [Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
-  map_smul' a X := by
-    simp [Matrix.mul_assoc]
-
 private noncomputable def sandwichLinearEquiv
     (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0) :
     Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
@@ -91,56 +82,6 @@ private noncomputable def sandwichLinearEquiv
     simp [Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
   map_smul' a X := by
     simp [Matrix.mul_assoc]
-
-private noncomputable def sandwichEquiv
-    (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0) :
-    Matrix (Fin D) (Fin D) ℂ ≃L[ℂ] Matrix (Fin D) (Fin D) ℂ where
-  toFun X := C * X * Cᴴ
-  invFun X := C⁻¹ * X * (Cᴴ)⁻¹
-  left_inv X := by
-    have hC_unit : IsUnit C.det := Ne.isUnit hC
-    have hCstar : Cᴴ.det ≠ 0 := by
-      rw [Matrix.det_conjTranspose]
-      exact star_ne_zero.mpr hC
-    have hCstar_unit : IsUnit (Cᴴ.det) := Ne.isUnit hCstar
-    calc
-      C⁻¹ * (C * X * Cᴴ) * (Cᴴ)⁻¹
-          = (C⁻¹ * C) * X * (Cᴴ * (Cᴴ)⁻¹) := by
-              simp [Matrix.mul_assoc]
-      _ = X := by
-            simp [Matrix.nonsing_inv_mul C hC_unit,
-              Matrix.mul_nonsing_inv Cᴴ hCstar_unit]
-  right_inv X := by
-    have hC_unit : IsUnit C.det := Ne.isUnit hC
-    have hCstar : Cᴴ.det ≠ 0 := by
-      rw [Matrix.det_conjTranspose]
-      exact star_ne_zero.mpr hC
-    have hCstar_unit : IsUnit (Cᴴ.det) := Ne.isUnit hCstar
-    calc
-      C * (C⁻¹ * X * (Cᴴ)⁻¹) * Cᴴ
-          = (C * C⁻¹) * X * ((Cᴴ)⁻¹ * Cᴴ) := by
-              simp [Matrix.mul_assoc]
-      _ = X := by
-            simp [Matrix.mul_nonsing_inv C hC_unit,
-              Matrix.nonsing_inv_mul Cᴴ hCstar_unit]
-  map_add' X Y := by
-    simp [Matrix.mul_add, Matrix.add_mul, Matrix.mul_assoc]
-  map_smul' a X := by
-    simp [Matrix.mul_assoc]
-  continuous_toFun :=
-    (LinearMap.toContinuousLinearMap (sandwichLinearMap (D := D) C Cᴴ)).continuous
-  continuous_invFun :=
-    (LinearMap.toContinuousLinearMap (sandwichLinearMap (D := D) C⁻¹ (Cᴴ)⁻¹)).continuous
-
-@[simp] private lemma sandwichEquiv_apply
-    (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    sandwichEquiv (D := D) C hC X = C * X * Cᴴ := rfl
-
-@[simp] private lemma sandwichEquiv_symm_apply
-    (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    (sandwichEquiv (D := D) C hC).symm X = C⁻¹ * X * (Cᴴ)⁻¹ := rfl
 
 private lemma spectralRadius_similarity_eq
     (C : Matrix (Fin D) (Fin D) ℂ) (hC : C.det ≠ 0)


### PR DESCRIPTION
### Motivation

The spectral-radius similarity proof now uses the linear sandwich equivalence and an algebraic spectrum argument. The older continuous sandwich equivalence, together with its private linear-map continuity helper, no longer contributes to the proof.

### Description

Removes the unused private `sandwichLinearMap`, `sandwichEquiv`, and its two private simp lemmas from `TNLean/Channel/Irreducible/SpectralRadius.lean`. The active theorem statements and proof path are unchanged: `spectralRadius_similarity_eq` and the Wolf 6.3(4) theorems still hold via `sandwichLinearEquiv` and `AlgEquiv.spectrum_eq`.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Irreducible.SpectralRadius -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `git diff --cached --check`

---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup of private definitions with no references in this module; public theorems and the remaining proof path are untouched.
>
> **Overview**
> Deletes dead private helpers in `SpectralRadius.lean` that supported an older continuous similarity route: `sandwichLinearMap`, `sandwichEquiv`, and two `@[simp]` lemmas for the equiv.
>
> **`spectralRadius_similarity_eq`** and the Wolf 6.3(4) theorems are unchanged; similarity invariance still goes through **`sandwichLinearEquiv`** and **`AlgEquiv.spectrum_eq`**, not the removed continuous equiv.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f260134e81afeeb9362cf8d8cd3a5006863b6a42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only cleanup of private definitions with no remaining references in this module; public theorems and the proof path are untouched.
> 
> **Overview**
> Removes **private dead code** from `SpectralRadius.lean` that supported an older continuous similarity route: `sandwichLinearMap`, `sandwichEquiv`, and two `@[simp]` lemmas for the continuous equiv.
> 
> **`sandwichLinearEquiv`** and **`spectralRadius_similarity_eq`** (via `AlgEquiv.spectrum_eq`) are unchanged, as are the Wolf 6.3(4) theorems that depend on them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd17654845f527682c33ac23c9610bbb3dc30aa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->