### PR TITLE
refactor(MPS/CanonicalForm): use GL vector equivalence

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -8,6 +8,7 @@ import TNLean.MPS.Core.Blocking
 import TNLean.MPS.SharedInfra.Scaling
 import TNLean.MPS.CanonicalForm.Existence
 import TNLean.PiAlgebra.CanonicalFormSepAux
+import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 
 open scoped Matrix BigOperators ComplexOrder MatrixOrder
 
@@ -99,35 +100,8 @@ structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
   bondDim_le : ∑ k : Fin r, dim k ≤ D
 
 private noncomputable def gaugeMulVecLinearEquiv {D : ℕ} (X : GL (Fin D) ℂ) :
-    (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) where
-  toFun v := (X : Matrix (Fin D) (Fin D) ℂ) *ᵥ v
-  invFun v := (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *ᵥ v)
-  left_inv := by
-    intro v
-    calc
-      (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *ᵥ
-          ((X : Matrix (Fin D) (Fin D) ℂ) *ᵥ v))
-          = ((((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
-              (X : Matrix (Fin D) (Fin D) ℂ)) *ᵥ v) := by
-              simp [Matrix.mulVec_mulVec]
-      _ = v := by
-            simp
-  right_inv := by
-    intro v
-    calc
-      ((X : Matrix (Fin D) (Fin D) ℂ) *ᵥ
-          ((((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *ᵥ v)))
-          = (((X : Matrix (Fin D) (Fin D) ℂ) *
-              (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) *ᵥ v) := by
-              simp [Matrix.mulVec_mulVec]
-      _ = v := by
-            simp
-  map_add' := by
-    intro v w
-    simp [Matrix.mulVec_add]
-  map_smul' := by
-    intro c v
-    simp [Matrix.mulVec_smul]
+    (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) :=
+  (Matrix.GeneralLinearGroup.toLin X).toLinearEquiv
 
 private theorem isIrreducibleAction_gaugeEquiv
     {D : ℕ} {A B : MPSTensor d D}


### PR DESCRIPTION
### Motivation

- Mathlib 4.31 provides the general-linear vector action as `Matrix.GeneralLinearGroup.toLin`.
- The TP-gauge proof was carrying a private hand-built `ℂ`-linear equivalence with explicit inverse, additivity, and scalar-linearity fields that duplicated library infrastructure.

### Description

- `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`: replaces `gaugeMulVecLinearEquiv` (hand-built `LinearEquiv` with explicit `invFun`, `map_add`, `map_smul` proofs) with `(Matrix.GeneralLinearGroup.toLin X).toLinearEquiv`.
- Adds import `Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs`.
- The invariant-subspace argument and all public statements (`isIrreducibleAction_gaugeEquiv`, `exists_pgvwc07_unital_dualDiag_data_of_irreducible`, and the PGVWC07 TP-gauge family) are unchanged in statement and proof structure.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction.TPGauge -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build on merge.

---
No linked issue identified — no open issue references this file or the `gaugeMulVecLinearEquiv` refactor. A new issue can be opened if maintainers wish to track Mathlib-integration cleanups in `MPS/CanonicalForm`.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one private helper; no API or mathematical statement changes to the exported theorems.
> 
> **Overview**
> In `TPGauge.lean`, **`gaugeMulVecLinearEquiv`** no longer builds a `ℂ`-linear equivalence from scratch (explicit `toFun`/`invFun`, inverse proofs, and `map_add`/`map_smul`). It is now **`(Matrix.GeneralLinearGroup.toLin X).toLinearEquiv`**, aligned with Mathlib 4.31's GL action on `Fin D → ℂ`.
> 
> A direct import of **`Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs`** was added. **`isIrreducibleAction_gaugeEquiv`** and all public TP-gauge / PGVWC07 theorems are unchanged in statement and proof structure aside from relying on the library equivalence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870ed54dfe3e2a67790bdfdc43a2b1ea7a80904f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only change in one private helper with no API or theorem statement changes; behavior is intended to match the removed manual construction.
> 
> **Overview**
> Replaces the private hand-built `ℂ`-linear equivalence **`gaugeMulVecLinearEquiv`** in `TPGauge.lean` with **`(Matrix.GeneralLinearGroup.toLin X).toLinearEquiv`**, dropping ~25 lines of explicit inverse, additivity, and scalar-linearity proofs that duplicate Mathlib 4.31.
> 
> Adds **`Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs`**. **`isIrreducibleAction_gaugeEquiv`** still uses the same name and call site; exported PGVWC07 / TP-gauge theorems are unchanged in statements and proof structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f6e28bc2f7d417efb3c466937c0ef4c34727fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->