### PR TITLE
refactor(Channel/Semigroup): use shared end equivalence

### DIFF
--- a/TNLean/Channel/Semigroup/CPClosure.lean
+++ b/TNLean/Channel/Semigroup/CPClosure.lean
@@ -39,9 +39,6 @@ noncomputable section
 private abbrev LM (D : ℕ) :=
   Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ
 
-private abbrev endEquivD (D : ℕ) : LM D ≃ₐ[ℂ] MatrixCLM (Fin D) :=
-  matrixEndEquiv (Fin D)
-
 section GenericCPClosure
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
@@ -225,8 +222,8 @@ theorem IsCPMap.of_tendsto_toCLM [NeZero D]
     {E : ℕ → LM D} {F : LM D}
     (hE : ∀ n, IsCPMap (E n))
     (hlim : @Filter.Tendsto ℕ (MatrixCLM (Fin D))
-      (fun n => endEquivD D (E n)) Filter.atTop
-      (nhds (endEquivD D F))) :
+      (fun n => endEquiv (D := D) (E n)) Filter.atTop
+      (nhds (endEquiv (D := D) F))) :
     IsCPMap F :=
   (isClosed_setOf_isCPMap (D := D)).mem_of_tendsto hlim
     (Filter.Eventually.of_forall hE)
@@ -255,21 +252,21 @@ private def expSemigroupSeriesTerm (L : LM D) (t : ℝ) (n : ℕ) :
     MatrixCLM (Fin D) :=
   letI : NormedRing (MatrixCLM (Fin D)) := ContinuousLinearMap.toNormedRing
   letI : NormedAlgebra ℂ (MatrixCLM (Fin D)) := ContinuousLinearMap.toNormedAlgebra
-  ((Nat.factorial n : ℂ)⁻¹) • (((t : ℂ) • endEquivD D L) ^ n)
+  ((Nat.factorial n : ℂ)⁻¹) • (((t : ℂ) • endEquiv (D := D) L) ^ n)
 
 private theorem hasSum_expSemigroup_series
     (L : LM D) (t : ℝ) :
     @HasSum (MatrixCLM (Fin D)) ℕ ContinuousLinearMap.toNormedRing.toAddCommMonoid
       PseudoMetricSpace.toUniformSpace.toTopologicalSpace
       (expSemigroupSeriesTerm L t)
-      (expSeriesCLM (((t : ℂ) • endEquivD D L))) (SummationFilter.unconditional ℕ) := by
+      (expSeriesCLM (((t : ℂ) • endEquiv (D := D) L))) (SummationFilter.unconditional ℕ) := by
   unfold expSemigroupSeriesTerm expSeriesCLM
   exact @NormedSpace.exp_series_hasSum_exp' ℂ (MatrixCLM (Fin D))
     _ _ _
     ContinuousLinearMap.toNormedRing
     ContinuousLinearMap.toNormedAlgebra
     (TNOperatorSpace.instCompleteSpaceMatrixCLM (Fin D))
-    (((t : ℂ) • endEquivD D L))
+    (((t : ℂ) • endEquiv (D := D) L))
 
 /-- If `L` itself is completely positive, then `exp(tL)` is completely positive for all `t ≥ 0`. -/
 theorem IsCPMap.expSemigroup
@@ -281,7 +278,7 @@ theorem IsCPMap.expSemigroup
     exact isCPMap_finZero _
   · haveI : NeZero D := ⟨hD⟩
     let termLM : ℕ → LM D := fun n =>
-      (endEquivD D).symm (((Nat.factorial n : ℂ)⁻¹) • (((t : ℂ) • endEquivD D L) ^ n))
+      (endEquiv (D := D)).symm (((Nat.factorial n : ℂ)⁻¹) • (((t : ℂ) • endEquiv (D := D) L) ^ n))
     have hterm : ∀ n : ℕ, IsCPMap (termLM n) := by
       intro n
       have hcoef : ((t : ℂ) ^ n / Nat.factorial n : ℂ) =
@@ -293,20 +290,20 @@ theorem IsCPMap.expSemigroup
           _ = (((t ^ n / Nat.factorial n : ℝ)) : ℂ) := by
             rw [← Complex.ofReal_div]
       have hpowCP : IsCPMap (L ^ n) := hL.pow n
-      have hbase : (endEquivD D).symm (((t : ℂ) • endEquivD D L)) = ((t : ℂ) • L) := by
-        apply (endEquivD D).injective
-        simpa using (map_smul (endEquivD D) (t : ℂ) L).symm
-      have hpow_map : (endEquivD D).symm ((((t : ℂ) • endEquivD D L) ^ n)) =
+      have hbase : (endEquiv (D := D)).symm (((t : ℂ) • endEquiv (D := D) L)) = ((t : ℂ) • L) := by
+        apply (endEquiv (D := D)).injective
+        simpa using (map_smul (endEquiv (D := D)) (t : ℂ) L).symm
+      have hpow_map : (endEquiv (D := D)).symm ((((t : ℂ) • endEquiv (D := D) L) ^ n)) =
           (((t : ℂ) • L) ^ n) := by
         calc
-          (endEquivD D).symm ((((t : ℂ) • endEquivD D L) ^ n))
-              = ((endEquivD D).symm (((t : ℂ) • endEquivD D L))) ^ n :=
-                  map_pow (endEquivD D).symm ((t : ℂ) • endEquivD D L) n
+          (endEquiv (D := D)).symm ((((t : ℂ) • endEquiv (D := D) L) ^ n))
+              = ((endEquiv (D := D)).symm (((t : ℂ) • endEquiv (D := D) L))) ^ n :=
+                  map_pow (endEquiv (D := D)).symm ((t : ℂ) • endEquiv (D := D) L) n
           _ = (((t : ℂ) • L) ^ n) := by rw [hbase]
       have hterm_eq : termLM n = (((t ^ n / Nat.factorial n : ℝ) : ℂ) • (L ^ n)) := by
         calc
           termLM n = ((Nat.factorial n : ℂ)⁻¹) •
-              ((endEquivD D).symm ((((t : ℂ) • endEquivD D L) ^ n))) := by
+              ((endEquiv (D := D)).symm ((((t : ℂ) • endEquiv (D := D) L) ^ n))) := by
                 simp [termLM]
           _ = ((Nat.factorial n : ℂ)⁻¹) • (((t : ℂ) • L) ^ n) := by
                 rw [hpow_map]
@@ -322,12 +319,12 @@ theorem IsCPMap.expSemigroup
     have hpartial : ∀ n : ℕ, IsCPMap (partialLM n) := by
       intro n
       exact Finset.isCPMap_sum (s := Finset.range n) termLM (fun i hi => hterm i)
-    have hlim : Filter.Tendsto (fun n => endEquivD D (partialLM n)) Filter.atTop
-        (nhds (endEquivD D (_root_.expSemigroup L t))) := by
+    have hlim : Filter.Tendsto (fun n => endEquiv (D := D) (partialLM n)) Filter.atTop
+        (nhds (endEquiv (D := D) (_root_.expSemigroup L t))) := by
       have hseries :=
         (hasSum_expSemigroup_series (D := D) L t).tendsto_sum_nat
       have hpartial_eq :
-          ∀ n, endEquivD D (partialLM n) =
+          ∀ n, endEquiv (D := D) (partialLM n) =
             @Finset.sum ℕ (MatrixCLM (Fin D))
               ContinuousLinearMap.toNormedRing.toAddCommMonoid
               (Finset.range n) (expSemigroupSeriesTerm L t) := by
@@ -342,10 +339,10 @@ theorem IsCPMap.expSemigroup
       have hseries' :=
         Filter.Tendsto.congr (fun n => (hpartial_eq n).symm) hseries
       have hlimit :
-          expSeriesCLM (((t : ℂ) • endEquivD D L)) =
-            endEquivD D (_root_.expSemigroup L t) := by
-        change expSemigroupCLM (endEquivD D L) t =
-          endEquivD D (_root_.expSemigroup L t)
+          expSeriesCLM (((t : ℂ) • endEquiv (D := D) L)) =
+            endEquiv (D := D) (_root_.expSemigroup L t) := by
+        change expSemigroupCLM (endEquiv (D := D) L) t =
+          endEquiv (D := D) (_root_.expSemigroup L t)
         rw [← expSemigroup_toCLM]
       rw [hlimit] at hseries'
       exact hseries'

--- a/TNLean/Channel/Semigroup/Dissipative.lean
+++ b/TNLean/Channel/Semigroup/Dissipative.lean
@@ -44,9 +44,6 @@ variable {D : ℕ}
 private abbrev Mat (D : ℕ) := Matrix (Fin D) (Fin D) ℂ
 private abbrev LM (D : ℕ) := Mat D →ₗ[ℂ] Mat D
 
-private abbrev endEquivD (D : ℕ) : LM D ≃ₐ[ℂ] MatrixCLM (Fin D) :=
-  matrixEndEquiv (Fin D)
-
 /-- The linear drift generator `ρ ↦ -κρ - ρκ†`. -/
 abbrev dissipativeDrift (κ : Mat D) : LM D :=
   -(LinearMap.mulLeft ℂ κ) - LinearMap.mulRight ℂ κᴴ
@@ -82,10 +79,10 @@ private theorem rightMulAlgHom_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
   simp [rightMulAlgHom]
 
 private abbrev leftMulCLMAlgHom (D : ℕ) : Mat D →ₐ[ℂ] MatrixCLM (Fin D) :=
-  (endEquivD D).toAlgHom.comp (leftMulAlgHom D)
+  (endEquiv (D := D)).toAlgHom.comp (leftMulAlgHom D)
 
 private abbrev rightMulCLMAlgHom (D : ℕ) : (Mat D)ᵐᵒᵖ →ₐ[ℂ] MatrixCLM (Fin D) :=
-  (endEquivD D).toAlgHom.comp (rightMulAlgHom D)
+  (endEquiv (D := D)).toAlgHom.comp (rightMulAlgHom D)
 
 private theorem leftMulCLM_apply (A ρ : Mat D) :
     leftMulCLMAlgHom D A ρ = A * ρ := by
@@ -136,25 +133,28 @@ private theorem mulRight_eq_rightMulAlgHom (A : Mat D) :
   simp
 
 private theorem endEquiv_mulLeft (A : Mat D) :
-    endEquivD D (LinearMap.mulLeft ℂ A) = leftMulCLMAlgHom D A := by
-  simpa [leftMulCLMAlgHom] using congrArg (endEquivD D) (mulLeft_eq_leftMulAlgHom (D := D) A)
+    endEquiv (D := D) (LinearMap.mulLeft ℂ A) = leftMulCLMAlgHom D A := by
+  simpa [leftMulCLMAlgHom] using
+    congrArg (endEquiv (D := D)) (mulLeft_eq_leftMulAlgHom (D := D) A)
 
 private theorem endEquiv_mulRight (A : Mat D) :
-    endEquivD D (LinearMap.mulRight ℂ A) = rightMulCLMAlgHom D (MulOpposite.op A) := by
-  simpa [rightMulCLMAlgHom] using congrArg (endEquivD D) (mulRight_eq_rightMulAlgHom (D := D) A)
+    endEquiv (D := D) (LinearMap.mulRight ℂ A) = rightMulCLMAlgHom D (MulOpposite.op A) := by
+  simpa [rightMulCLMAlgHom] using
+    congrArg (endEquiv (D := D)) (mulRight_eq_rightMulAlgHom (D := D) A)
 
 private theorem left_right_commute (A B : Mat D) :
     Commute (leftMulCLMAlgHom D A) (rightMulCLMAlgHom D (MulOpposite.op B)) := by
   rw [← endEquiv_mulLeft (D := D) A, ← endEquiv_mulRight (D := D) B]
-  exact (LinearMap.commute_mulLeft_right (R := ℂ) A B).map (endEquivD D)
+  exact (LinearMap.commute_mulLeft_right (R := ℂ) A B).map (endEquiv (D := D))
 
 private theorem endEquiv_dissipativeDrift
     (κ : Mat D) :
-    endEquivD D (dissipativeDrift κ) =
+    endEquiv (D := D) (dissipativeDrift κ) =
       leftMulCLMAlgHom D (-κ) + rightMulCLMAlgHom D (MulOpposite.op (-κᴴ)) := by
   calc
-    endEquivD D (dissipativeDrift κ)
-        = -(endEquivD D (LinearMap.mulLeft ℂ κ)) - endEquivD D (LinearMap.mulRight ℂ κᴴ) := by
+    endEquiv (D := D) (dissipativeDrift κ)
+        = -(endEquiv (D := D) (LinearMap.mulLeft ℂ κ)) -
+          endEquiv (D := D) (LinearMap.mulRight ℂ κᴴ) := by
             simp [dissipativeDrift]
     _ = -leftMulCLMAlgHom D κ - rightMulCLMAlgHom D (MulOpposite.op κᴴ) := by
           rw [endEquiv_mulLeft, endEquiv_mulRight]
@@ -199,7 +199,7 @@ theorem expSemigroup_dissipativeDrift_apply
       NormedSpace.exp (-(t : ℂ) • κ) * ρ *
         (NormedSpace.exp (-(t : ℂ) • κ))ᴴ := by
   have hκ :
-      expSemigroupCLM (endEquivD D (dissipativeDrift κ)) t =
+      expSemigroupCLM (endEquiv (D := D) (dissipativeDrift κ)) t =
         leftMulCLMAlgHom D (NormedSpace.exp (-(t : ℂ) • κ)) *
           rightMulCLMAlgHom D
             (MulOpposite.op (NormedSpace.exp (-(t : ℂ) • κᴴ))) := by
@@ -242,7 +242,7 @@ theorem expSemigroup_dissipativeDrift_apply
         (y := rightMulCLMAlgHom D (MulOpposite.op (-(t : ℂ) • κᴴ)))
         hcomm
     rw [expSemigroupCLM, hsplit, hsum, exp_leftMulCLM, exp_rightMulCLM]
-  change expSemigroupCLM (endEquivD D (dissipativeDrift κ)) t ρ = _
+  change expSemigroupCLM (endEquiv (D := D) (dissipativeDrift κ)) t ρ = _
   rw [hκ]
   have hconj : NormedSpace.exp (-(t : ℂ) • κᴴ) =
       (NormedSpace.exp (-(t : ℂ) • κ))ᴴ := by


### PR DESCRIPTION
### Motivation

- `CPClosure.lean` and `Dissipative.lean` each defined a private abbreviation `endEquivD` that duplicated the shared `endEquiv (D := D)` from `TNLean.Channel.Semigroup.Basic`, the canonical linear equivalence between endomorphisms and continuous linear endomorphisms on \`M_D(ℂ)\`.
- Removing the local aliases consolidates all references to a single declaration and eliminates the duplication.

### Description

- `TNLean/Channel/Semigroup/CPClosure.lean`: removed private abbreviation `endEquivD`; updated `IsCPMap.of_tendsto_toCLM` and the exponential semigroup CP closure proofs to reference `endEquiv (D := D)` directly.
- `TNLean/Channel/Semigroup/Dissipative.lean`: removed private abbreviation `endEquivD`; updated `endEquiv` lemmas and `expSemigroup_dissipativeDrift_apply` to reference `endEquiv (D := D)` directly.
- No mathematical content is changed; all proofs still rely on the same underlying `matrixEndEquiv` definition.

### Testing

- `lake build TNLean.Channel.Semigroup.CPClosure TNLean.Channel.Semigroup.Dissipative` completed with only pre-existing header warnings in imported files.
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
_No linked issue found: the branch name contains no issue reference and no open issue matches the changed files. Please link one manually if applicable._

> [!NOTE]
> **Low Risk**
> Rename-only refactor with no new logic; semigroup CP and dissipative proofs still refer to the same `matrixEndEquiv` definition.
>
> **Overview**
> **Unifies** the finite-dimensional endomorphism algebra equivalence by dropping duplicate private `endEquivD` abbreviations in `CPClosure.lean` and `Dissipative.lean` and calling the shared **`endEquiv (D := D)`** from `TNLean.Channel.Semigroup.Basic` everywhere those files previously used the local alias.
>
> All touched proofs (**`IsCPMap.of_tendsto_toCLM`**, exponential semigroup CP closure, dissipative drift **`endEquiv`** lemmas, and **`expSemigroup_dissipativeDrift_apply`**) are updated mechanically; behavior is unchanged aside from naming and a few line breaks in `Dissipative.lean`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554e821dded94ce38587ce511772eaaf53e45d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Rename-only refactor with identical definitions; semigroup CP and dissipative proofs still use the same `matrixEndEquiv` via `endEquiv`.
> 
> **Overview**
> **Removes duplicate local aliases** for the matrix endomorphism ↔ `MatrixCLM` equivalence in `CPClosure.lean` and `Dissipative.lean`, routing every former `endEquivD` use through the shared **`endEquiv (D := D)`** in `TNLean.Channel.Semigroup.Basic` (same underlying `matrixEndEquiv`).
> 
> **`CPClosure.lean`**: `IsCPMap.of_tendsto_toCLM`, the exponential semigroup series, and `IsCPMap.expSemigroup` now reference `endEquiv` directly.
> 
> **`Dissipative.lean`**: left/right multiplication CLM algebra homomorphisms and `endEquiv_*` lemmas, plus `expSemigroup_dissipativeDrift_apply`, are updated the same way; a few proof lines are reflowed only.
> 
> No proof or API behavior change beyond naming consolidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a29b8945675ac8f24560e1f785118d13c4de1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->