### PR TITLE
refactor(Channel/Schwarz): use native fin-two equivalence

### DIFF
--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -66,37 +66,25 @@ open Matrix Finset
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
 private noncomputable def finTwoSumEquiv (α : Type*) : α × Fin 2 ≃ α ⊕ α :=
-  (((Equiv.prodCongr (Equiv.refl α)
-      ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm)).trans
-    (Equiv.prodSumDistrib α (Fin 1) (Fin 1))).trans
-    (Equiv.sumCongr (Equiv.prodUnique α (Fin 1)) (Equiv.prodUnique α (Fin 1))))
+  ((Equiv.prodCongr (Equiv.refl α) finTwoEquiv).trans (Equiv.prodComm α Bool)).trans
+    (Equiv.boolProdEquivSum α)
 
 @[simp] private theorem finTwoSumEquiv_apply_zero {α : Type*} (a : α) :
     finTwoSumEquiv α (a, 0) = Sum.inl a := by
-  change Sum.map Prod.fst Prod.fst
-      ((Equiv.prodSumDistrib α (Fin 1) (Fin 1))
-        (a, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 0))) = Sum.inl a
-  rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
-  rw [finSumFinEquiv_symm_apply_castSucc]
-  simp
+  simp [finTwoSumEquiv, finTwoEquiv]
 
 @[simp] private theorem finTwoSumEquiv_apply_one {α : Type*} (a : α) :
     finTwoSumEquiv α (a, 1) = Sum.inr a := by
-  change Sum.map Prod.fst Prod.fst
-      ((Equiv.prodSumDistrib α (Fin 1) (Fin 1))
-        (a, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 1))) = Sum.inr a
-  rw [show (1 : Fin 2) = Fin.last 1 by rfl]
-  rw [finSumFinEquiv_symm_last]
-  simp
+  simp [finTwoSumEquiv, finTwoEquiv]
 
 @[simp] private theorem finTwoSumEquiv_symm_inl {α : Type*} (a : α) :
     (finTwoSumEquiv α).symm (Sum.inl a) = (a, 0) := by
-  rw [← Equiv.eq_symm_apply]
+  rw [Equiv.symm_apply_eq]
   exact finTwoSumEquiv_apply_zero a
 
 @[simp] private theorem finTwoSumEquiv_symm_inr {α : Type*} (a : α) :
     (finTwoSumEquiv α).symm (Sum.inr a) = (a, 1) := by
-  rw [← Equiv.eq_symm_apply]
+  rw [Equiv.symm_apply_eq]
   exact finTwoSumEquiv_apply_one a
 
 /-! ## Definitions of n-positivity -/


### PR DESCRIPTION
### Motivation

- The private `finTwoSumEquiv` in `Channel.Schwarz.TwoPositive` routed through `Fin 1 ⊕ Fin 1` and erased singleton factors, which is roundabout when Mathlib 4.31 provides `finTwoEquiv : Fin 2 ≃ Bool` and `Equiv.boolProdEquivSum` as direct primitives.
- Replacing the construction with Mathlib primitives shortens the proof scripts and reduces the gap between the private helper and its mathematical content.

### Description

- Modified `TNLean/Channel/Schwarz/TwoPositive.lean`: reimplemented the private equivalence `finTwoSumEquiv : α × Fin 2 ≃ α ⊕ α` using `finTwoEquiv` and `Equiv.boolProdEquivSum` instead of the previous `Fin 1 ⊕ Fin 1` route.
- The public API and `@[simp]` lemmas for `(a, 0)`, `(a, 1)`, `Sum.inl`, and `Sum.inr` are unchanged; no edits to `Is2PositiveMap.isPositiveMap` or `kadison_schwarz_2positive`.
- Net diff: 6 additions, 18 deletions — proof scripts for the simp lemmas are shortened via `Equiv.symm_apply_eq` in place of manual `finSumFinEquiv` rewrites.

### Testing

- `lake exe cache get` (cache available; 8516 files decompressed).
- `lake build TNLean.Channel.Schwarz.TwoPositive -q --log-level=info` passed.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` passed.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passed.
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---

> [!NOTE]
> **Low Risk**
> Private helper refactor only; no theorem statements or downstream call sites change in the diff.
>
> **Overview**
> Reimplements the private `finTwoSumEquiv` in `TwoPositive.lean` so `α × Fin 2` maps to `α ⊕ α` via Mathlib's `finTwoEquiv` (`Fin 2 ≃ Bool`) and `Equiv.boolProdEquivSum`, instead of routing through `Fin 1 ⊕ Fin 1` and singleton `prodUnique` steps.
>
> The **type and API are unchanged**—the same `@[simp]` lemmas for `(a,0)`, `(a,1)`, `Sum.inl`, and `Sum.inr` still hold, so block-matrix proofs (`Is2PositiveMap.isPositiveMap`, `kadison_schwarz_2positive`) do not need edits. Proof scripts for those lemmas are shortened (`simp` / `Equiv.symm_apply_eq` instead of manual `finSumFinEquiv` rewrites).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b8209dbe373468968db86f4898a5c89148e01d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper and proof-script changes only; no theorem statements or downstream call sites are modified.
> 
> **Overview**
> Reimplements the private helper **`finTwoSumEquiv`** (`α × Fin 2 ≃ α ⊕ α`) in `TwoPositive.lean` using Mathlib’s **`finTwoEquiv`** (`Fin 2 ≃ Bool`) and **`Equiv.boolProdEquivSum`**, instead of routing through `Fin 1 ⊕ Fin 1`, `finSumFinEquiv`, and singleton `prodUnique` steps.
> 
> The **type and `@[simp]` API are unchanged** (maps for `(a,0)`, `(a,1)`, `Sum.inl`, and `Sum.inr`), so **`Is2PositiveMap.isPositiveMap`** and **`kadison_schwarz_2positive`** still use the same equivalence without edits. Proof scripts for the simp lemmas are shorter (`simp` / `Equiv.symm_apply_eq` vs manual `finSumFinEquiv` rewrites).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 974f214bac3453e9d0d5a8b35893a80631a6312d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->