### PR TITLE
refactor(Channel/Determinant): compose vectorization equivalence

### DIFF
--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -44,11 +44,9 @@ variable {d : ℕ}
 /-- Column-stacking vectorization as a linear equivalence. -/
 private noncomputable def matrixVecLinearEquiv (d : ℕ) :
     MatrixAlg d ≃ₗ[ℂ] (Fin d × Fin d → ℂ) :=
-  LinearEquiv.ofBijective
-    { toFun := Matrix.vec
-      map_add' := Matrix.vec_add
-      map_smul' := Matrix.vec_smul }
-    Matrix.vec_bijective
+  (Matrix.ofLinearEquiv ℂ).symm.trans
+    ((LinearEquiv.curry ℂ ℂ (Fin d) (Fin d)).symm.trans
+      (LinearEquiv.funCongrLeft ℂ ℂ (Equiv.prodComm (Fin d) (Fin d))))
 
 section WolfStatements
 
@@ -284,6 +282,7 @@ theorem channelDet_unitary_eq_one (U : Matrix.unitaryGroup (Fin d) ℂ) :
   have hvec : ∀ X : MatrixAlg d,
       e (unitaryChannel U X) = Matrix.toLin' M (e X) := by
     intro X
+    -- The equivalence `e` is the column-stacking vectorization used by `Matrix.vec`.
     change Matrix.vec (((U : MatrixAlg d) * X * (U : MatrixAlg d)ᴴ) : MatrixAlg d) =
       M.mulVec (Matrix.vec X)
     symm


### PR DESCRIPTION
### Motivation

- The private hand-built vectorization equivalence in `TNLean.Channel.Determinant.UnitaryCharacterization` constructed a `LinearEquiv` manually from `Matrix.vec` and `vec_bijective`, packaging bijectivity by hand rather than composing Mathlib-native equivalences.
- Replacing it with a composition of Mathlib-native equivalences reduces bespoke boilerplate and aligns with Mathlib conventions for linear equivalences.

### Description

- Modified `TNLean/Channel/Determinant/UnitaryCharacterization.lean` (3 additions, 5 deletions).
- The private definition `matrixVecLinearEquiv` is now expressed as a composition of `Matrix.ofLinearEquiv`, `LinearEquiv.curry`, `LinearEquiv.funCongrLeft`, and `Equiv.prodComm` rather than a hand-built equivalence from `Matrix.vec` plus `vec_bijective`.
- The resulting equivalence is definitionally the same column-stacking map, so the determinant argument (`channelDet_unitary_eq_one` and call sites) is unchanged in mathematical content.

### Testing

- `lake exe cache get` (succeeded; reused 8516 decompressed files)
- `lake build TNLean.Channel.Determinant.UnitaryCharacterization -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---

> [!NOTE]
> **Low Risk**
> Single private helper refactor with no API or proof-structure changes beyond the equivalence definition.
>
> **Overview**
> **`matrixVecLinearEquiv`** in `UnitaryCharacterization.lean` no longer builds a `LinearEquiv` by hand from `Matrix.vec` plus `vec_bijective`. It is now **`Matrix.ofLinearEquiv`**, **`LinearEquiv.curry`**, and **`Equiv.prodComm`** composed in the standard way.
>
> Call sites (e.g. **`channelDet_unitary_eq_one`**) are unchanged; the map is still the column-stacking **`Matrix.vec`** equivalence, so the determinant/unitary argument is the same with less bespoke bijectivity packaging.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 319f8cfe6ce90718117e677090a761bb8a2d8666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper refactor with no public API or proof-structure changes beyond how the equivalence is defined.
> 
> **Overview**
> **`matrixVecLinearEquiv`** no longer packages **`Matrix.vec`** via **`LinearEquiv.ofBijective`** and **`vec_bijective`**. It is now built by composing **`Matrix.ofLinearEquiv`**, **`LinearEquiv.curry`**, **`LinearEquiv.funCongrLeft`**, and **`Equiv.prodComm`**—the usual Mathlib route to the same column-stacking map.
> 
> **`channelDet_unitary_eq_one`** only gains a short comment that **`e`** is that vectorization; the **`change Matrix.vec …`** step and the rest of the determinant argument are unchanged in substance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3314ecee88271010416b0c39abd6b9ada319fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->