### PR TITLE
refactor(MPS/CanonicalForm): use GL vector equivalence

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -99,35 +99,8 @@ structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
   bondDim_le : ∑ k : Fin r, dim k ≤ D
 
 private noncomputable def gaugeMulVecLinearEquiv {D : ℕ} (X : GL (Fin D) ℂ) :
-    (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) where
-  toFun v := (X : Matrix (Fin D) (Fin D) ℂ) *ᵥ v
-  invFun v := (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *ᵥ v)
-  left_inv := by
-    intro v
-    calc
-      (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *ᵥ
-          ((X : Matrix (Fin D) (Fin D) ℂ) *ᵥ v))
-          = ((((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
-              (X : Matrix (Fin D) (Fin D) ℂ)) *ᵥ v) := by
-              simp [Matrix.mulVec_mulVec]
-      _ = v := by
-            simp
-  right_inv := by
-    intro v
-    calc
-      ((X : Matrix (Fin D) (Fin D) ℂ) *ᵥ
-          ((((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *ᵥ v)))
-          = (((X : Matrix (Fin D) (Fin D) ℂ) *
-              (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ))) *ᵥ v) := by
-              simp [Matrix.mulVec_mulVec]
-      _ = v := by
-            simp
-  map_add' := by
-    intro v w
-    simp [Matrix.mulVec_add]
-  map_smul' := by
-    intro c v
-    simp [Matrix.mulVec_smul]
+    (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) :=
+  (Matrix.GeneralLinearGroup.toLin X).toLinearEquiv
 
 private theorem isIrreducibleAction_gaugeEquiv
     {D : ℕ} {A B : MPSTensor d D}


### PR DESCRIPTION
### Motivation

- `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` contained a hand-built
  linear equivalence `gaugeMulVecLinearEquiv` representing the action of the
  gauge group `GL(D, ℂ)` on vectors `Fin D → ℂ`, with manual proofs of
  `left_inv`, `right_inv`, `map_add'`, and `map_smul'`.
- Mathlib provides this equivalence natively via
  `Matrix.GeneralLinearGroup.toLin` composed with `.toLinearEquiv`, making the
  local construction redundant.

### Description

- Modified `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` (2 additions,
  29 deletions).
- Replaced the definition of `gaugeMulVecLinearEquiv` with the Mathlib native
  construction `Matrix.GeneralLinearGroup.toLin … |>.toLinearEquiv`; the forward
  and inverse actions are definitionally equal to the previous hand-built map.
- Removed the manual `left_inv`, `right_inv`, `map_add'`, and `map_smul'`
  proof blocks that were subsumed by the Mathlib definition.
- `isIrreducibleAction_gaugeEquiv` is unchanged; no theorem statements or
  mathematical content are affected.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction.TPGauge -q --log-level=info`
- `lake exe cache get` (succeeded; reused 8516 decompressed files)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
<!-- No linked issue found; author should link one manually if this closes or addresses an open task. -->

> [!NOTE]
> **Low Risk**
> Local refactor of a private helper with no API or theorem statement changes; irreducibility-under-gauge logic is untouched.
>
> **Overview**
> Replaces the hand-built **`gaugeMulVecLinearEquiv`** in `TPGauge.lean` with Mathlib's **`Matrix.GeneralLinearGroup.toLin`** composed with **`.toLinearEquiv`**, so the gauge action on `Fin D → ℂ` comes from the standard GL linear map instead of a local structure with manual inverse and linearity proofs.
>
> **`isIrreducibleAction_gaugeEquiv`** is unchanged and still uses the same `gaugeMulVecLinearEquiv` name; only the definition shrinks by removing the long `left_inv` / `right_inv` / `map_add'` / `map_smul'` block.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ae0c11bf27465dafeda30a6953b4e30e263e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private helper refactor with no API or theorem changes; irreducibility-under-gauge logic is unchanged.
> 
> **Overview**
> **`gaugeMulVecLinearEquiv`** in `TPGauge.lean` is no longer built by hand with explicit `toFun`/`invFun` and proofs of inverse and linearity. It is now **`(Matrix.GeneralLinearGroup.toLin X).toLinearEquiv`**, delegating the gauge action of **`GL (Fin D) ℂ`** on **`Fin D → ℂ`** to Mathlib.
> 
> **`isIrreducibleAction_gaugeEquiv`** and all public theorems are unchanged; only the private helper definition shrinks (~27 lines removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae5719524eebb7c629fa836cb836e0be3164ab1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->