### PR TITLE
refactor(MPS/Periodic): use unit multiplication equivalences

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -35,23 +35,21 @@ variable {d D : ℕ}
 /-- The conjugation `Y ↦ X Y Xᴴ` as a linear equivalence on matrices. -/
 private noncomputable def glConjEquiv (X : GL (Fin D) ℂ) :
     Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
-  LinearEquiv.ofLinear
-    ((LinearMap.mulLeft ℂ X.val).comp (LinearMap.mulRight ℂ X.valᴴ))
-    ((LinearMap.mulLeft ℂ X⁻¹.val).comp (LinearMap.mulRight ℂ X⁻¹.valᴴ))
-    (LinearMap.ext fun Y => by
-      simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
-        LinearMap.mulRight_apply, LinearMap.id_apply, ← Matrix.mul_assoc]
-      rw [Units.mul_inv, one_mul, Matrix.mul_assoc Y,
-        show X⁻¹.valᴴ * X.valᴴ = 1 from by
-          rw [← Matrix.conjTranspose_mul, Units.mul_inv]; simp,
-        mul_one])
-    (LinearMap.ext fun Y => by
-      simp only [LinearMap.comp_apply, LinearMap.mulLeft_apply,
-        LinearMap.mulRight_apply, LinearMap.id_apply, ← Matrix.mul_assoc]
-      rw [Units.inv_mul, one_mul, Matrix.mul_assoc Y,
-        show X.valᴴ * X⁻¹.valᴴ = 1 from by
-          rw [← Matrix.conjTranspose_mul, Units.inv_mul]; simp,
-        mul_one])
+  (X.mulLeftLinearEquiv ℂ (Matrix (Fin D) (Fin D) ℂ)).trans
+    ((star X).mulRightLinearEquiv ℂ)
+
+@[simp] private lemma glConjEquiv_apply (X : GL (Fin D) ℂ)
+    (Y : Matrix (Fin D) (Fin D) ℂ) :
+    glConjEquiv X Y = X.val * Y * X.valᴴ := rfl
+
+@[simp] private lemma glConjEquiv_symm_apply (X : GL (Fin D) ℂ)
+    (Y : Matrix (Fin D) (Fin D) ℂ) :
+    (glConjEquiv X).symm Y = X⁻¹.val * Y * X⁻¹.valᴴ := by
+  simp only [glConjEquiv]
+  rw [LinearEquiv.symm_trans_apply]
+  rw [Units.symm_mulRightLinearEquiv_apply, Units.symm_mulLeftLinearEquiv_apply]
+  rw [Units.coe_star_inv]
+  simp [Matrix.star_eq_conjTranspose, Matrix.mul_assoc]
 
 /-- **GaugePhaseEquiv preserves periods.**
 
@@ -93,11 +91,9 @@ private theorem period_eq_of_gaugePhaseEquiv_of_isPeriodic
         (glConjEquiv X).conj (transferMap (d := d) (D := D) A) := by
       apply LinearMap.ext; intro Y
       rw [hEB_eq, hζζ_real, show (↑(‖ζ‖ ^ 2) : ℂ) = (1 : ℂ) from by simp [h_eig_eq],
-        one_smul,
-        show (glConjEquiv X).conj (transferMap (d := d) (D := D) A) Y =
-          X.val * (transferMap (d := d) (D := D) A
-            (X⁻¹.val * (Y * X⁻¹.valᴴ)) * X.valᴴ) from rfl]
-      simp only [Matrix.mul_assoc]
+        one_smul]
+      simp [LinearEquiv.conj_apply, transferMap_apply, Finset.mul_sum, Finset.sum_mul,
+        Matrix.mul_assoc]
     rw [hEB_is_conj]
     exact (peripheralEigenvalues_conj (glConjEquiv X)
       (transferMap (d := d) (D := D) A)).symm


### PR DESCRIPTION
### Motivation

- The conjugation map `Y ↦ X Y Xᴴ` in `TNLean.MPS.Periodic.Overlap.Case1` was built locally via `LinearEquiv.ofLinear` with two `LinearMap.ext` inverse proofs. Mathlib's `Units.mulLeftLinearEquiv` and `Units.mulRightLinearEquiv` provide the same construction directly, removing the local proof duplication.

### Description

- Modified file: `TNLean/MPS/Periodic/Overlap/Case1.lean`.
- `glConjEquiv` is redefined as `Units.mulLeftLinearEquiv X` composed with `Units.mulRightLinearEquiv (star X)`, replacing the prior `LinearEquiv.ofLinear` construction. New `@[simp]` lemmas cover the forward map and inverse.
- The `hEB_is_conj` step in `period_eq_of_gaugePhaseEquiv_of_isPeriodic` now closes via `simp` through `LinearEquiv.conj_apply`, `transferMap_apply`, and finite-sum rewrites, replacing a manual `rfl`/`show` block.
- No change to theorem statements or the periodic-overlap argument; proof engineering only.

### Testing

- `lake env lean TNLean/MPS/Periodic/Overlap/Case1.lean`
- `lake exe cache get` (reused 8516 decompressed files)
- `lake build TNLean.MPS.Periodic.Overlap.Case1 -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Local refactor in one periodic-overlap lemma file; mathematics and public API unchanged.
>
> **Overview**
> **`glConjEquiv`** in `Case1.lean` no longer builds conjugation `Y ↦ X Y Xᴴ` from scratch with `LinearEquiv.ofLinear` and two `LinearMap.ext` inverse proofs. It is now **`mulLeftLinearEquiv` composed with `mulRightLinearEquiv` on `star X`**, with new `@[simp]` lemmas for the forward map and the inverse.
>
> The **`hEB_is_conj`** step in `period_eq_of_gaugePhaseEquiv_of_isPeriodic` drops a manual `rfl`/`show` block and instead **`simp`s** through `LinearEquiv.conj_apply`, `transferMap_apply`, and finite-sum rewrites.
>
> No change to theorems or the periodic-overlap argument—proof engineering only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a5dbde5134efdfab8fb4f1b7de51a05112a9d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file private proof refactor with no API or mathematical statement changes.
> 
> **Overview**
> **`glConjEquiv`** in `Case1.lean` is rebuilt from Mathlib’s **`Units.mulLeftLinearEquiv`** and **`mulRightLinearEquiv (star X)`** instead of a hand-written `LinearEquiv.ofLinear` with two inverse `LinearMap.ext` proofs. New private **`@[simp]`** lemmas spell out the forward map and inverse as matrix multiplication.
> 
> In **`period_eq_of_gaugePhaseEquiv_of_isPeriodic`**, the **`hEB_is_conj`** step drops a manual `rfl`/`show` block and closes with **`simp`** on `LinearEquiv.conj_apply`, `transferMap_apply`, and finset sum rewrites.
> 
> Theorem statements and the periodic-overlap argument are unchanged—proof engineering only in this file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810d552ec05a59a09c5c1ec9f4848dfe1932744c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->