### PR TITLE
refactor(MPS/ParentHamiltonian): use function congruence for site reindexing

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
+++ b/TNLean/MPS/ParentHamiltonian/RestrictTransport.lean
@@ -60,13 +60,9 @@ variable {d D : ℕ}
 /-- The linear equivalence between `NSiteSpace d M` and `NSiteSpace d N`
 induced by a proof \(h : M = N\), reindexing configurations via `Fin.cast`. -/
 def reindexSites {d : ℕ} {M N : ℕ} (h : M = N) :
-    NSiteSpace d M ≃ₗ[ℂ] NSiteSpace d N where
-  toFun ψ σ := ψ (σ ∘ Fin.cast h)
-  invFun ψ σ := ψ (σ ∘ Fin.cast h.symm)
-  map_add' _ _ := rfl
-  map_smul' _ _ := rfl
-  left_inv ψ := by subst h; rfl
-  right_inv ψ := by subst h; rfl
+    NSiteSpace d M ≃ₗ[ℂ] NSiteSpace d N :=
+  LinearEquiv.funCongrLeft ℂ ℂ
+    (Equiv.arrowCongr (finCongr h.symm) (Equiv.refl (Fin d)))
 
 @[simp] theorem reindexSites_apply {M N : ℕ} (h : M = N)
     (ψ : NSiteSpace d M) (σ : Fin N → Fin d) :


### PR DESCRIPTION
### Motivation
- Eliminates an explicit `LinearEquiv` record for `MPSTensor.reindexSites` by delegating to Mathlib's `LinearEquiv.funCongrLeft`; reduces proof obligations maintained outside Mathlib.
- Continues the site-reindexing transport API in `RestrictTransport.lean` (see #869).

### Description
- `TNLean/MPS/ParentHamiltonian/RestrictTransport.lean`: replaces the hand-written `LinearEquiv` for `MPSTensor.reindexSites` with `LinearEquiv.funCongrLeft` applied to the configuration equivalence `Equiv.arrowCongr (finCongr h.symm) (Equiv.refl (Fin d))`.
- The explicit inverse and linearity fields are removed; inverse and linearity are supplied by Mathlib.
- Public `@[simp]` lemmas (`reindexSites_apply`, `reindexSites_symm_apply`, etc.) are unchanged in statement and still close by `rfl`; downstream callers are unaffected.

### Testing
- `lake env lean TNLean/MPS/ParentHamiltonian/RestrictTransport.lean`
- `lake exe cache get` (reused 8516 decompressed files)
- `lake build TNLean.MPS.ParentHamiltonian.RestrictTransport -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses #869

> [!NOTE]
> **Low Risk**
> Single-definition refactor in one file with unchanged public simp lemmas; no API or proof-obligation changes for downstream transport theorems.
>
> **Overview**
> **`MPSTensor.reindexSites`** is no longer built with an explicit `LinearEquiv` record (`toFun` / `invFun` / linearity proofs). It is now **`LinearEquiv.funCongrLeft`** composed with **`Equiv.arrowCongr (finCongr h.symm) (Equiv.refl (Fin d))`**, delegating inverse and linearity to Mathlib.
>
> The **`@[simp]` lemmas** (`reindexSites_apply`, `reindexSites_symm_apply`, etc.) are unchanged in statement and still end in `rfl`, so callers that reindex via `σ ∘ Fin.cast h` behave the same; only the implementation is shorter.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e41629a7d105057de16262e4a10c47741852bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-definition refactor with unchanged API and simp lemmas; no security or runtime impact.
> 
> **Overview**
> **`MPSTensor.reindexSites`** no longer uses a hand-built `LinearEquiv` (`toFun` / `invFun` / `map_add'` / `map_smul'` / inverse proofs). It is now **`LinearEquiv.funCongrLeft`** on **`Equiv.arrowCongr (finCongr h.symm) (Equiv.refl (Fin d))`**, so inverse and ℂ-linearity come from Mathlib.
> 
> The public **`@[simp]`** lemmas (`reindexSites_apply`, `reindexSites_symm_apply`, `reindexSites_rfl`, etc.) are unchanged and still close with **`rfl`**, so transport theorems that unfold reindexing via `σ ∘ Fin.cast h` behave the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8df24bc9da0f92727bd2cf9dbd4b3fe84cb8f53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->