### PR TITLE
refactor(PEPS): use arrow congruence for region physical configs

### DIFF
--- a/TNLean/PEPS/RegionTransport.lean
+++ b/TNLean/PEPS/RegionTransport.lean
@@ -240,11 +240,8 @@ theorem regionBlockedWeight_transport (A : Tensor G d) (φ : G ≃g G') (R : Fin
 /-- The physical-configuration equivalence induced by `φ` on the region. -/
 def regionPhysicalConfigMapEquiv (φ : G ≃g G') (R : Finset V) :
     RegionPhysicalConfig (V := V) (d := d) R ≃
-      RegionPhysicalConfig (V := W) (d := d) (Region.map φ R) where
-  toFun := regionPhysicalConfigMap φ R
-  invFun τ' w := τ' ((regionVertexMapEquiv φ R).symm w)
-  left_inv τ := by funext w; simp [regionPhysicalConfigMap]
-  right_inv τ' := by funext w; simp [regionPhysicalConfigMap]
+      RegionPhysicalConfig (V := W) (d := d) (Region.map φ R) :=
+  Equiv.arrowCongr (regionVertexMapEquiv φ R).symm (Equiv.refl (Fin d))
 
 /-- The transported blocked-region tensor family is the original family reindexed: the
 boundary index by `regionBoundaryConfigMapEquiv`, the physical-leg domain by


### PR DESCRIPTION
### Motivation

- `regionPhysicalConfigMapEquiv` (the physical-configuration equivalence induced by a graph isomorphism `φ` on a region) was hand-written with explicit `toFun`, `invFun`, `left_inv`, and `right_inv` fields.
- Mathlib's `Equiv.arrowCongr` produces the same equivalence directly from the existing `regionVertexMapEquiv`, removing four lines of proof.

### Description

- Modified `TNLean/PEPS/RegionTransport.lean`: replaced the body of `regionPhysicalConfigMapEquiv` with `Equiv.arrowCongr (regionVertexMapEquiv φ R).symm (Equiv.refl (Fin d))`.
- The forward map remains precomposition by `regionVertexMapEquiv φ R`; the mathematical content and all downstream transport formulae are unchanged.

### Testing

- `lake env lean TNLean/PEPS/RegionTransport.lean`
- `lake exe cache get` (reused 8516 decompressed files)
- `lake build TNLean.PEPS.RegionTransport -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

<!-- No linked issue found. If this PR addresses an open issue, add `Addresses #N` here. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS region transport; no API or behavioral change beyond definitional equivalence.
> 
> **Overview**
> **`regionPhysicalConfigMapEquiv`** is no longer built by hand with `toFun` / `invFun` and `left_inv` / `right_inv` proofs. It is now **`Equiv.arrowCongr (regionVertexMapEquiv φ R).symm (Equiv.refl (Fin d))`**, matching the same pattern as boundary configs via `piCongrLeft` / `arrowCongr`.
> 
> The induced map is still precomposition along **`regionVertexMapEquiv φ R`**; **`regionPhysicalConfigMap`** and downstream transport lemmas (e.g. **`regionBlockedTensorFamily_transport_comp`**) are unchanged in meaning—only the equivalence definition is simplified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd85957334c19ffa25dc4966bc4be303312e698. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->