### PR TITLE
refactor(PEPS): use arrow congruence for double-complement configs

### DIFF
--- a/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
+++ b/TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean
@@ -147,15 +147,8 @@ region physical configuration on `R` corresponds to one on `univ \ (univ \ R)` b
 reading each vertex under the double-complement vertex equivalence. -/
 def regionDoubleComplPhysicalConfigEquiv (R : Finset V) :
     RegionPhysicalConfig (V := V) (d := d) R ≃
-      RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ (Finset.univ \ R)) where
-  toFun := regionDoubleComplPhysicalConfig (V := V) (d := d) R
-  invFun σ := fun w => σ ((regionDoubleComplVertexEquiv (V := V) R).symm w)
-  left_inv σ := by
-    funext w
-    simp only [regionDoubleComplPhysicalConfig, Equiv.apply_symm_apply]
-  right_inv σ := by
-    funext w
-    simp only [regionDoubleComplPhysicalConfig, Equiv.symm_apply_apply]
+      RegionPhysicalConfig (V := V) (d := d) (Finset.univ \ (Finset.univ \ R)) :=
+  Equiv.arrowCongr (regionDoubleComplVertexEquiv (V := V) R).symm (Equiv.refl (Fin d))
 
 /-- **Double-complement transport of blocked-tensor injectivity.** If the region
 `R` is blocked-tensor injective, then so is `univ \ (univ \ R)`. The blocked tensor


### PR DESCRIPTION
### Motivation

- `regionDoubleComplPhysicalConfigEquiv` in `BlockCoeffTransfer.lean` was constructed
  with four explicit proof fields (`toFun`, `invFun`, `left_inv`, `right_inv`). The
  standard Mathlib construction `Equiv.arrowCongr` packages exactly this
  "reindex domain, leave codomain fixed" pattern, making the mathematical content
  more direct and removing ad hoc proof obligations.
- The change reduces proof size without altering any downstream lemma statements.

### Description

- Modified `TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean` (line ~147): replaced
  the four-field explicit `Equiv` structure for `regionDoubleComplPhysicalConfigEquiv`
  with `Equiv.arrowCongr (regionDoubleComplVertexEquiv R).symm (Equiv.refl (Fin d))`.
- Transport statements and downstream uses (e.g., `regionBlockedTensorInjective_doubleCompl`
  setting `Φ := regionDoubleComplPhysicalConfigEquiv`) are unchanged in statement and intent;
  this is a proof-style simplification only.

### Testing

- `lake build TNLean.PEPS.RegionBlock.BlockCoeffTransfer -q --log-level=info`
- `lake env lean TNLean/PEPS/RegionBlock/BlockCoeffTransfer.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean CI (`lean_action_ci.yml`) validates the full build on merge.

---
No linked issue identified. Author should add `Addresses #N` once an issue is created or found.

> [!NOTE]
> **Low Risk**
> Small definitional simplification in PEPS region-block theory with no new logic or API surface; behavior matches the previous explicit equivalence.
>
> **Overview**
> **`regionDoubleComplPhysicalConfigEquiv`** in `BlockCoeffTransfer.lean` no longer builds a custom `Equiv` with explicit `toFun`/`invFun` and `left_inv`/`right_inv` proofs. It is now **`Equiv.arrowCongr`** of `regionDoubleComplVertexEquiv.symm` with the identity on `Fin d`, which is the standard library packaging of "reindex vertices, leave local indices fixed."
>
> Downstream uses (e.g. `regionBlockedTensorInjective_doubleCompl` setting `Φ := regionDoubleComplPhysicalConfigEquiv`) are unchanged in intent; this is a proof-style simplification only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a4c819861a3e11c55b415b1238ffafc34a86d11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Definitional refactor in PEPS region-block theory with no new logic or API changes; equivalence behavior matches the previous explicit construction.
> 
> **Overview**
> **`regionDoubleComplPhysicalConfigEquiv`** in `BlockCoeffTransfer.lean` no longer builds a custom `Equiv` with explicit `toFun`/`invFun` and `left_inv`/`right_inv` proofs. It is now **`Equiv.arrowCongr`** of `regionDoubleComplVertexEquiv.symm` with the identity on `Fin d`, which is the standard Mathlib packaging of reindexing vertices while leaving local physical indices fixed.
> 
> Downstream lemmas (e.g. `regionBlockedTensorInjective_doubleCompl` with `Φ := regionDoubleComplPhysicalConfigEquiv`) are unchanged in statement and behavior; this is proof-style simplification only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e1f73c6e7e03c569a5c59f7cfcc87b98f1657f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->