### PR TITLE
refactor(PEPS): use pi congruence for double-complement boundary configs

### DIFF
--- a/TNLean/PEPS/RegionBlock/Recovery10.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery10.lean
@@ -134,17 +134,9 @@ boundary configuration on `R` corresponds to one on `univ \ (univ \ R)` by readi
 each crossing edge under the double-complement boundary-edge equivalence. -/
 def regionDoubleComplBoundaryConfigEquiv (A : Tensor G d) (R : Finset V) :
     RegionBoundaryConfig (G := G) A R ≃
-      RegionBoundaryConfig (G := G) A (Finset.univ \ (Finset.univ \ R)) where
-  toFun := regionDoubleComplBoundaryConfig (G := G) A R
-  invFun bdry := fun e => bdry ((regionBoundaryEdgeDoubleComplEquiv (G := G) R).symm e)
-  left_inv bdry := by
-    funext e
-    simp only [regionDoubleComplBoundaryConfig]
-    congr 1
-  right_inv bdry := by
-    funext e
-    simp only [regionDoubleComplBoundaryConfig]
-    congr 1
+      RegionBoundaryConfig (G := G) A (Finset.univ \ (Finset.univ \ R)) :=
+  Equiv.piCongrLeft' (fun f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f} =>
+      Fin (A.bondDim f.1)) (regionBoundaryEdgeDoubleComplEquiv (G := G) R).symm
 
 /-- **The double-complement transport of the blocked tensor map.** The blocked
 tensor map of `univ \ (univ \ R)` applied to a row `c`, evaluated at the


### PR DESCRIPTION
### Motivation

- The hand-written `regionDoubleComplBoundaryConfigEquiv` spelled out `toFun`, `invFun`, `left_inv`, and `right_inv` manually; replacing it with `Equiv.piCongrLeft'` removes redundant proof work and delegates to a Mathlib equivalence.

### Description

- `TNLean/PEPS/RegionBlock/Recovery10.lean`: replace the hand-written double-complement boundary-configuration equivalence with `Equiv.piCongrLeft'` over bond indices `Fin (A.bondDim f.1)`, reindexing boundary edges via `regionBoundaryEdgeDoubleComplEquiv … .symm`.
- Downstream callers `regionBlockedTensorMap_doubleCompl` and `regionBlockedTensorInjective_doubleCompl` are unchanged.

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/Recovery10.lean`
- `lake build TNLean.PEPS.RegionBlock.BlockCoeffTransfer -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean CI (`lean_action_ci.yml`) validates the full build.

---

> [!NOTE]
> **Low Risk**
> Single-definition refactor in formal Lean with no API or proof-obligation changes beyond the equivalence construction; low risk if `piCongrLeft'` matches the previous map (as validated by existing builds).
>
> **Overview**
> **`regionDoubleComplBoundaryConfigEquiv`** in `Recovery10.lean` no longer builds the double-complement boundary-configuration equivalence by hand (`toFun` / `invFun` / `left_inv` / `right_inv`). It is now **`Equiv.piCongrLeft'`** over bond indices `Fin (A.bondDim f.1)`, reindexing boundary edges with **`regionBoundaryEdgeDoubleComplEquiv … .symm`**.
>
> The mathematical role of the equivalence is unchanged; callers such as **`regionBlockedTensorMap_doubleCompl`** and **`regionBlockedTensorInjective_doubleCompl`** still use the same name and API.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8aaa8a5bef933cf7e68474387c60567e06d034c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-definition Lean refactor with no theorem statement or caller signature changes; risk is low assuming `piCongrLeft'` matches the previous equivalence (as CI builds validate).
> 
> **Overview**
> **`regionDoubleComplBoundaryConfigEquiv`** in `Recovery10.lean` is no longer built with explicit `toFun` / `invFun` / `left_inv` / `right_inv` lemmas. It is now **`Equiv.piCongrLeft'`**, reindexing each boundary edge via **`regionBoundaryEdgeDoubleComplEquiv … .symm`** while keeping bond indices as **`Fin (A.bondDim f.1)`**.
> 
> The equivalence still transports boundary configurations between **`R`** and **`univ \ (univ \ R)`**; proofs such as **`regionBlockedTensorMap_doubleCompl`** and downstream uses in **`BlockCoeffTransfer`** keep the same API and still rely on **`regionDoubleComplBoundaryConfig`** for the forward map in tensor-map reindexing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd27aa3ff67ca66d8f257364728563302c7b4378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->