### PR TITLE
refactor(PEPS/RegionBlock): use piCongrLeft' for complement boundary configs

### DIFF
--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
@@ -156,8 +156,8 @@ theorem redBundleInsertedCoeff_bondModelMatrix_eq_configSum
           (regionBoundaryLabel (G := G) A (Finset.univ \ F.frame.red) η) =
         regionBoundaryLabel (G := G) A F.frame.red η from by
       funext f
-      simp only [regionComplementBoundaryConfigEquiv, Equiv.coe_fn_symm_mk,
-        regionBoundaryLabel_apply, regionBoundaryEdgeComplEquiv_apply_coe]]
+      simp [regionComplementBoundaryConfigEquiv, Equiv.piCongrLeft',
+        regionBoundaryLabel_apply, regionBoundaryEdgeComplEquiv_symm_apply_coe]]
     by_cases hag : SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
         (regionBoundaryLabel (G := G) A F.frame.red ζr)
         (regionBoundaryLabel (G := G) A F.frame.red η)

--- a/TNLean/PEPS/RegionBlock/Recovery6.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery6.lean
@@ -158,21 +158,9 @@ complement-side reading. -/
 configuration on `R` corresponds to one on `univ \ R` by reading each crossing edge
 under the boundary-edge identification. -/
 def regionComplementBoundaryConfigEquiv (A : Tensor G d) (R : Finset V) :
-    RegionBoundaryConfig (G := G) A R ≃ RegionBoundaryConfig (G := G) A (Finset.univ \ R) where
-  toFun := regionComplementBoundaryConfig (G := G) A R
-  invFun bdry' := fun f => bdry' (regionBoundaryEdgeComplEquiv (G := G) R f)
-  left_inv bdry := by
-    funext f
-    change regionComplementBoundaryConfig (G := G) A R bdry
-      (regionBoundaryEdgeComplEquiv (G := G) R f) = bdry f
-    rw [regionComplementBoundaryConfig]
-    congr 1
-  right_inv bdry' := by
-    funext g
-    change regionComplementBoundaryConfig (G := G) A R
-      (fun f => bdry' (regionBoundaryEdgeComplEquiv (G := G) R f)) g = bdry' g
-    rw [regionComplementBoundaryConfig]
-    congr 1
+    RegionBoundaryConfig (G := G) A R ≃ RegionBoundaryConfig (G := G) A (Finset.univ \ R) :=
+  Equiv.piCongrLeft' (fun f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f} =>
+      Fin (A.bondDim f.1)) (regionBoundaryEdgeComplEquiv (G := G) R)
 
 @[simp] theorem regionComplementBoundaryConfigEquiv_apply (A : Tensor G d) (R : Finset V)
     (bdry : RegionBoundaryConfig (G := G) A R) :


### PR DESCRIPTION
### Motivation
- `regionComplementBoundaryConfigEquiv` was built by hand with explicit `toFun`, `invFun`, and inverse proofs. Replacing it with Mathlib's `Equiv.piCongrLeft'` — an equivalence on dependent-function types reindexed along a fiber bijection — removes all manual inverse reasoning and aligns the construction with standard Mathlib patterns.

### Description
- `TNLean/PEPS/RegionBlock/Recovery6.lean`: replace the hand-constructed `regionComplementBoundaryConfigEquiv` (explicit `toFun`/`invFun` with inverse lemmas) with `Equiv.piCongrLeft'` over bond-index fibers, reindexed by `regionBoundaryEdgeComplEquiv`. The `@[simp] apply` lemma identifying the equivalence with `regionComplementBoundaryConfig` is preserved unchanged.
- `TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean`: update one downstream proof step that previously unfolded the old inverse definition; it now proceeds by `simp` with `Equiv.piCongrLeft'` and `regionBoundaryEdgeComplEquiv_symm_apply_coe`.
- No mathematical content is changed. No `sorry` is introduced.

### Testing
- `lake env lean TNLean/PEPS/RegionBlock/Recovery6.lean`
- `lake env lean TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
No linked issue identified. No issue reference was found in the branch name, commit messages, or PR body. Please link one manually if this work addresses a tracked task.

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style refactor of an equivalence definition and one proof; no API or runtime behavior change beyond the same mathematical map.
>
> **Overview**
> **`regionComplementBoundaryConfigEquiv`** is no longer built by hand (`toFun` / `invFun` and inverse lemmas). It is now **`Equiv.piCongrLeft'`** over bond-index fibers, reindexing boundary edges with **`regionBoundaryEdgeComplEquiv`**. The existing **`@[simp] apply`** lemma still identifies the equivalence with **`regionComplementBoundaryConfig`**.
>
> In **`CoarseThreeSite10`**, the step that relates the symm-reindexed host boundary label to the red boundary label is updated to **`simp`** with **`Equiv.piCongrLeft'`** and **`regionBoundaryEdgeComplEquiv_symm_apply_coe`** instead of lemmas that unfolded the old inverse definition.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b539ad56be0e7000d28e73660a4d49e25a1dad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mathlib-style equivalence refactor with unchanged map and API; only proof tactics updated downstream.
> 
> **Overview**
> **`regionComplementBoundaryConfigEquiv`** is no longer defined with explicit `toFun` / `invFun` and hand-written inverse proofs. It is now **`Equiv.piCongrLeft'`** on bond-index fibers **`Fin (A.bondDim f.1)`**, reindexed along **`regionBoundaryEdgeComplEquiv`**. The **`@[simp]`** lemma **`regionComplementBoundaryConfigEquiv_apply`** still identifies the equivalence with **`regionComplementBoundaryConfig`**.
> 
> In **`CoarseThreeSite10`**, the step equating the symm-reindexed complement host boundary label with the red boundary label now **`simp`**s with **`Equiv.piCongrLeft'`** and **`regionBoundaryEdgeComplEquiv_symm_apply_coe`** instead of lemmas that unfolded the old inverse definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae770aa489edd11aac5fa0af5cc4eae997710598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->