### PR TITLE
refactor(PEPS): use pi congruence for torus boundary configs

### DIFF
--- a/TNLean/PEPS/TorusGaugedWeightCovariance.lean
+++ b/TNLean/PEPS/TorusGaugedWeightCovariance.lean
@@ -86,26 +86,10 @@ noncomputable def tiBoundaryConfigEquiv (T : Tensor (torusGraph width height) d)
     (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
     (R : Finset (TorusVertex width height)) :
     RegionBoundaryConfig (G := torusGraph width height) T R ≃
-      RegionBoundaryConfig (G := torusGraph width height) T (Region.map (translate a b) R) where
-  toFun := tiBoundaryConfigMap T hT a b R
-  invFun bdry' := (regionBoundaryConfigMapEquiv T (translate a b) R).symm
-    (fun f => Fin.cast (congrFun (congrArg Tensor.bondDim (hT a b)) f.1).symm (bdry' f))
-  left_inv bdry := by
-    beta_reduce
-    have hcollapse : (fun f => Fin.cast
-        (congrFun (congrArg Tensor.bondDim (hT a b)) f.1).symm
-        (tiBoundaryConfigMap T hT a b R bdry f)) =
-        regionBoundaryConfigMap T (translate a b) R bdry := by
-      funext f
-      apply Fin.eq_of_val_eq
-      simp [tiBoundaryConfigMap]
-    rw [hcollapse, ← regionBoundaryConfigMapEquiv_apply, Equiv.symm_apply_apply]
-  right_inv bdry' := by
-    beta_reduce
-    funext f
-    rw [tiBoundaryConfigMap, ← regionBoundaryConfigMapEquiv_apply, Equiv.apply_symm_apply]
-    apply Fin.eq_of_val_eq
-    simp
+      RegionBoundaryConfig (G := torusGraph width height) T (Region.map (translate a b) R) :=
+  (regionBoundaryConfigMapEquiv T (translate a b) R).trans
+    (Equiv.piCongrRight fun f =>
+      finCongr (congrFun (congrArg Tensor.bondDim (hT a b)) f.1))
 
 @[simp] theorem tiBoundaryConfigEquiv_apply (T : Tensor (torusGraph width height) d)
     (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)


### PR DESCRIPTION
### Motivation

- The hand-written `invFun` / `left_inv` / `right_inv` proof for `tiBoundaryConfigEquiv` in `TNLean/PEPS/TorusGaugedWeightCovariance.lean` is more complex than necessary.
- Mathlib's `Equiv.piCongrRight` together with `finCongr` provides a concise, principled construction of the same equivalence from the fibrewise bond-dimension equality supplied by torus translation invariance.

### Description

- Modified `TNLean/PEPS/TorusGaugedWeightCovariance.lean` (4 additions, 20 deletions).
- `tiBoundaryConfigEquiv` is now defined as `regionBoundaryConfigMapEquiv` composed with `Equiv.piCongrRight`, using `finCongr` on each boundary leg for the bond-dimension equality from torus translation invariance.
- The public interface — `tiBoundaryConfigMap` and `tiBoundaryConfigEquiv_apply` — is unchanged; downstream lemmas (surjectivity, blocked-weight covariance) keep the same statements and proof paths.
- No `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced.

### Testing

- `lake env lean TNLean/PEPS/TorusGaugedWeightCovariance.lean`
- `lake build TNLean.PEPS.TorusGaugedWeightCovariance -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/TorusGaugedWeightCovariance.lean` (no matches)

---
<!-- No linked issue found. Please add `Addresses #N` once one is identified. -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS torus transport; no API or runtime behavior change beyond a shorter equivalence definition.
> 
> **Overview**
> **`tiBoundaryConfigEquiv`** is no longer built with hand-written `invFun` / `left_inv` / `right_inv` proofs. It is now **`regionBoundaryConfigMapEquiv` composed with `Equiv.piCongrRight`**, using **`finCongr`** on each boundary leg for the bond-dimension equality from torus translation invariance.
> 
> **`tiBoundaryConfigMap`** and **`tiBoundaryConfigEquiv_apply`** are unchanged, so downstream lemmas (surjectivity, blocked-weight covariance, etc.) keep the same statements and proof paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5217c31033d2dcaa1fe4d8912fef62f7fa024e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS torus transport; public API and downstream lemma statements are unchanged.
> 
> **Overview**
> **`tiBoundaryConfigEquiv`** is rebuilt as **`regionBoundaryConfigMapEquiv` transposed with `Equiv.piCongrRight`**, applying **`finCongr`** on each boundary leg from torus translation invariance bond-dimension equalities, instead of a manual `Equiv` with custom **`invFun`** / **`left_inv`** / **`right_inv`** proofs.
> 
> **`tiBoundaryConfigMap`** and **`@[simp] tiBoundaryConfigEquiv_apply`** are unchanged, so callers still see the same map and downstream lemmas (surjectivity, blocked-weight covariance, etc.) need no statement updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553a1801e263148a7acd994eef41870abf75786c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->