### PR TITLE
refactor(PEPS): use pi congruence for boundary casts

### DIFF
--- a/TNLean/PEPS/RegionBlock/ReindexInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/ReindexInjectivity.lean
@@ -31,17 +31,8 @@ by casting every open leg across the bond-dimension equality. -/
 noncomputable def regionBoundaryConfigCastEquiv (T : Tensor G d) {bd : Edge G → ℕ}
     (h : bd = T.bondDim) (R : Finset V) :
     RegionBoundaryConfig (G := G) (reindexTensor (G := G) T h) R ≃
-      RegionBoundaryConfig (G := G) T R where
-  toFun bdry := fun f => Fin.cast (congr_fun h f.1) (bdry f)
-  invFun bdry := fun f => Fin.cast (congr_fun h f.1).symm (bdry f)
-  left_inv bdry := by
-    funext f
-    apply Fin.eq_of_val_eq
-    simp
-  right_inv bdry := by
-    funext f
-    apply Fin.eq_of_val_eq
-    simp
+      RegionBoundaryConfig (G := G) T R :=
+  Equiv.piCongrRight fun f => finCongr (congr_fun h f.1)
 
 /-- **A bond-dimension reindex preserves blocked-region linear independence.**
 


### PR DESCRIPTION
### Motivation

- `regionBoundaryConfigCastEquiv` was constructed by hand with explicit `toFun`/`invFun` and `Fin.cast` inverse lemmas, duplicating what Mathlib's `Equiv.piCongrRight` provides directly.
- Replacing the hand-written construction with the standard Mathlib pattern reduces proof size and aligns with Mathlib conventions for pointwise casts along a bond-dimension equality.

### Description

- Modified `TNLean/PEPS/RegionBlock/ReindexInjectivity.lean`.
- `regionBoundaryConfigCastEquiv` is now defined via `Equiv.piCongrRight` with `finCongr (congr_fun h f.1)` on each boundary leg, replacing the previous manual `toFun`/`invFun` construction.
- `regionBlockedTensorInjective_reindexTensor` and its use of the equivalence are unchanged; the refactor only simplifies the definition of the boundary-configuration bijection.
- No new `sorry` or `axiom` introduced.

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/ReindexInjectivity.lean`
- `lake build TNLean.PEPS.RegionBlock.ReindexInjectivity -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionBlock/ReindexInjectivity.lean` — no matches.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one Lean definition; no change to the injectivity theorem or downstream API.
>
> **Overview**
> **`regionBoundaryConfigCastEquiv`** is no longer built by hand with `toFun`/`invFun` and `Fin.cast` inverse lemmas; it is now **`Equiv.piCongrRight`** with **`finCongr (congr_fun h f.1)`** on each boundary leg, matching the usual Mathlib pattern for pointwise casts along `bd = T.bondDim`.
>
> **`regionBlockedTensorInjective_reindexTensor`** and its use of that equivalence are unchanged—the refactor only shrinks and standardizes the definition of the boundary-configuration bijection.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df064bf5bc4bb06563384784bd064161ff0d2618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor of a single equivalence definition in PEPS region-block theory; no API or theorem behavior change.
> 
> **Overview**
> **`regionBoundaryConfigCastEquiv`** no longer uses a hand-built `Equiv` with `toFun`/`invFun`, `Fin.cast`, and inverse proofs. It is now **`Equiv.piCongrRight`** with **`finCongr (congr_fun h f.1)`** on each boundary leg—the usual Mathlib pattern for pointwise casts along `bd = T.bondDim`.
> 
> **`regionBlockedTensorInjective_reindexTensor`** is unchanged; only the definition of the boundary-configuration bijection is smaller and more idiomatic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f10919550928464e63cb8e7c6485a4fd73cd929. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->