### PR TITLE
refactor(PEPS): use pi congruence for virtual config casts

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean
+++ b/TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean
@@ -310,16 +310,8 @@ theorem GaugeEquiv.sameState {A B : Tensor G d} (h : GaugeEquiv A B) :
   classical
   rcases h with ⟨hDim, X, hX⟩
   intro σ
-  let φ : VirtualConfig A ≃ VirtualConfig B := {
-    toFun := fun η e => Fin.cast (congr_fun hDim e) (η e)
-    invFun := fun η e => Fin.cast (Eq.symm (congr_fun hDim e)) (η e)
-    left_inv := fun η => by
-      funext e
-      simp
-    right_inv := fun η => by
-      funext e
-      simp
-  }
+  let φ : VirtualConfig A ≃ VirtualConfig B :=
+    Equiv.piCongrRight fun e => finCongr (congr_fun hDim e)
   have hB : stateCoeff B σ = stateCoeff (applyGauge A X) σ := by
     unfold stateCoeff
     rw [← φ.sum_comp (fun η : VirtualConfig B =>


### PR DESCRIPTION
### Motivation

- Simplify the proof of `GaugeEquiv.sameState` in `EdgeInsertion.lean` by replacing a bespoke cast equivalence with the Mathlib API.
- The hand-written `Equiv` on `VirtualConfig` required explicit `left_inv` / `right_inv` proofs with `Fin.cast`; `Equiv.piCongrRight` with `finCongr` supplies the same equivalence from the bond-dimension equality produced by gauge equivalence.

### Description

- **File modified:** `TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean` (2 additions, 10 deletions).
- In `GaugeEquiv.sameState`, replaced the local `Equiv` construction on `VirtualConfig` (using `Fin.cast` with manual `left_inv` / `right_inv`) with `Equiv.piCongrRight` and `finCongr` applied pointwise at each edge's bond-dimension equality.
- The state-equivalence argument and all other proof steps are unchanged.
- No definitions introduced or removed; no `sorry` present.

### Testing

- `lake env lean TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean`
- `lake build TNLean.PEPS.FundamentalTheorem.EdgeInsertion -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean` (no matches)

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof-only refactor in one theorem; no API, definitions, or runtime behavior changes.
> 
> **Overview**
> In **`GaugeEquiv.sameState`** (`EdgeInsertion.lean`), the proof that gauge equivalence yields the same PEPS state no longer builds a hand-rolled `VirtualConfig A ≃ VirtualConfig B` with `Fin.cast` and explicit `left_inv` / `right_inv` lemmas.
> 
> It now uses **`Equiv.piCongrRight`** with pointwise **`finCongr`** from the bond-dimension equalities in `GaugeEquiv`. The `stateCoeff` reindexing via `φ.sum_comp` and the rest of the argument are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc3d7a098b55edf635a1ad8bcd877f86dfacde7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->