### PR TITLE
refactor(PEPS): use pi congruence in blocked weight reindex

### DIFF
--- a/TNLean/PEPS/RegionBlock/Insertion.lean
+++ b/TNLean/PEPS/RegionBlock/Insertion.lean
@@ -288,9 +288,10 @@ theorem regionBlockedWeight_reindexTensor (B : Tensor G d) {bd : Edge G → ℕ}
   classical
   rw [regionBlockedWeight, regionBlockedWeight]
   -- Reindex the constrained virtual-configuration sum by casting every bond.
-  refine Finset.sum_nbij'
-    (fun ζ => fun e => Fin.cast (congr_fun h e) (ζ e))
-    (fun ζ => fun e => Fin.cast (congr_fun h e).symm (ζ e)) ?_ ?_ ?_ ?_ ?_
+  let φ : VirtualConfig (reindexTensor (G := G) B h) ≃ VirtualConfig B :=
+    Equiv.piCongrRight fun e =>
+      finCongr (by simpa [reindexTensor_bondDim] using congr_fun h e)
+  refine Finset.sum_nbij' φ φ.symm ?_ ?_ ?_ ?_ ?_
   · -- Forward map lands in the complement filter.
     intro ζ hζ
     simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hζ ⊢
@@ -298,6 +299,8 @@ theorem regionBlockedWeight_reindexTensor (B : Tensor G d) {bd : Edge G → ℕ}
     have hf : regionBoundaryLabel (G := G) (reindexTensor (G := G) B h) R ζ f = bdry f :=
       congrFun hζ f
     rw [regionBoundaryLabel_apply] at hf ⊢
+    change Fin.cast (by simpa [reindexTensor_bondDim] using congr_fun h f.1) (ζ f.1) =
+      Fin.cast (by simpa [reindexTensor_bondDim] using congr_fun h f.1) (bdry f)
     rw [hf]
   · -- Backward map lands in the original filter.
     intro ζ hζ
@@ -306,20 +309,22 @@ theorem regionBlockedWeight_reindexTensor (B : Tensor G d) {bd : Edge G → ℕ}
     have hf : regionBoundaryLabel (G := G) B R ζ f = Fin.cast (congr_fun h f.1) (bdry f) :=
       congrFun hζ f
     rw [regionBoundaryLabel_apply] at hf ⊢
-    rw [hf]
-    simp
+    apply Fin.eq_of_val_eq
+    change (((finCongr (by simpa [reindexTensor_bondDim] using congr_fun h f.1)).symm
+      (ζ f.1) : Fin ((reindexTensor (G := G) B h).bondDim f.1)) : ℕ) = (bdry f : ℕ)
+    rw [finCongr_symm_apply_coe]
+    simpa using congrArg Fin.val hf
   · -- Left inverse.
     intro ζ _
-    funext e
-    simp
+    exact φ.left_inv ζ
   · -- Right inverse.
     intro ζ _
-    funext e
-    simp
+    exact φ.right_inv ζ
   · -- Matching summand: products of casts agree.
     intro ζ _
     refine Finset.prod_congr rfl fun w _ => ?_
     rw [reindexTensor_component]
+    congr 1
 
 open scoped Classical in
 /-- `regionInsertedCoeff` transports along a bond-dimension reindex by conjugating


### PR DESCRIPTION
### Motivation

- The proof of `regionBlockedWeight_reindexTensor` in `TNLean/PEPS/RegionBlock/Insertion.lean` used explicit forward/backward virtual-configuration casts for the `Finset.sum_nbij'` bijection, making the reindexing argument verbose and hard to follow.
- Replacing the manual casts with a single `Equiv.piCongrRight` equivalence consolidates the bijection into one local definition and shortens the proof without altering the theorem statement or boundary-condition logic.

### Description

- `TNLean/PEPS/RegionBlock/Insertion.lean` (modified): the proof of `regionBlockedWeight_reindexTensor` now constructs a local equivalence `φ : VirtualConfig (reindexTensor …) ≃ VirtualConfig B` via `Equiv.piCongrRight` with pointwise `finCongr` derived from `reindexTensor_bondDim` and `h`. The `Finset.sum_nbij'` left/right inverse goals use `φ.left_inv`/`φ.right_inv` instead of manual `funext`/`simp` on per-edge casts. Filter obligations are discharged with `change` and `Fin.eq_of_val_eq`/`finCongr_symm_apply_coe` so boundary labels align under the equivalence.
- The theorem statement and boundary-condition argument are mathematically unchanged.
- No sorrys, axioms, or integrity issues introduced (see Testing).

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/Insertion.lean`
- `lake build TNLean.PEPS.RegionBlock.Insertion -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionBlock/Insertion.lean` (no matches)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Only the Lean proof of an existing theorem changes; no API or mathematical statement updates.
>
> **Overview**
> Refactors the proof of **`regionBlockedWeight_reindexTensor`** in `Insertion.lean` without changing the theorem statement.
>
> The virtual-configuration reindexing for `Finset.sum_nbij'` is now a single local equivalence **`φ : VirtualConfig (reindexTensor …) ≃ VirtualConfig B`** built as **`Equiv.piCongrRight`** with pointwise **`finCongr`** from `reindexTensor_bondDim` and `h`. Left/right inverse goals use **`φ.left_inv`** / **`φ.right_inv`** instead of manual `funext`/`simp` on per-edge casts.
>
> The forward and backward filter obligations are spelled out with **`change`** and **`Fin.eq_of_val_eq`** / **`finCongr_symm_apply_coe`** so boundary labels align under the equivalence rather than bare **`Fin.cast`**/`simp`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit debc66364f1b831c3ba3f2e8bcb58b318d8388f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only the Lean proof of an existing theorem changes; no API, definitions, or mathematical statements are modified.
> 
> **Overview**
> Refactors only the **proof** of `regionBlockedWeight_reindexTensor` in `Insertion.lean`; the theorem statement and downstream uses (e.g. `regionInsertedCoeff_reindexTensor`) are unchanged.
> 
> The `Finset.sum_nbij'` bijection on virtual configurations is now a single local equivalence **`φ : VirtualConfig (reindexTensor …) ≃ VirtualConfig B`** built with **`Equiv.piCongrRight`** and pointwise **`finCongr`** from `reindexTensor_bondDim` and `h`, instead of explicit per-edge `Fin.cast` forward/backward maps. Inverse goals use **`φ.left_inv`** / **`φ.right_inv`**; filter obligations use **`change`**, **`Fin.eq_of_val_eq`**, and **`finCongr_symm_apply_coe`** so boundary labels line up under **`φ`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad301c1d5657bf03115a83c791ec48d5faca98da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->