### PR TITLE
refactor(PEPS): use finite-type equivalence for local fiber sum

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem/OneVertexComparison.lean
+++ b/TNLean/PEPS/FundamentalTheorem/OneVertexComparison.lean
@@ -249,19 +249,24 @@ theorem constrained_mu_sum_collapse (A : Tensor G d) (v : V) (ie : IncidentEdge 
       ∑ j : Fin (A.bondDim ie.1), F (Function.update ρ ie j) := by
   classical
   rw [← Finset.sum_filter]
-  refine Finset.sum_nbij' (fun μ => μ ie) (fun j => Function.update ρ ie j) ?_ ?_ ?_ ?_ ?_
-  · intro μ _; exact Finset.mem_univ _
-  · intro j _
-    rw [Finset.mem_filter]
-    exact ⟨Finset.mem_univ _, fun c hc => Function.update_of_ne hc _ _⟩
-  · intro μ hμ
-    rw [Finset.mem_filter] at hμ
-    rw [(sameAwayFromBond_iff_update A v ie μ ρ).mp hμ.2]
-    simp
-  · intro j _; simp
-  · intro μ hμ
-    rw [Finset.mem_filter] at hμ
-    rw [← (sameAwayFromBond_iff_update A v ie μ ρ).mp hμ.2]
+  let φ : {μ : LocalVirtualConfig A v // SameAwayFromBond ie μ ρ} ≃
+      Fin (A.bondDim ie.1) := {
+    toFun := fun μ => μ.1 ie
+    invFun := fun j =>
+      ⟨Function.update ρ ie j, fun c hc => Function.update_of_ne hc _ _⟩
+    left_inv := fun μ => by
+      apply Subtype.ext
+      exact ((sameAwayFromBond_iff_update A v ie μ.1 ρ).mp μ.2).symm
+    right_inv := fun j => by
+      simp }
+  rw [← Finset.sum_subtype_eq_sum_filter (s := Finset.univ) (f := F)
+    (p := fun μ => SameAwayFromBond ie μ ρ)]
+  simpa using Fintype.sum_equiv φ
+    (fun μ : {μ : LocalVirtualConfig A v // SameAwayFromBond ie μ ρ} => F μ.1)
+    (fun j : Fin (A.bondDim ie.1) => F (Function.update ρ ie j)) (by
+      intro μ
+      change F μ.1 = F (Function.update ρ ie (μ.1 ie))
+      exact congrArg F ((sameAwayFromBond_iff_update A v ie μ.1 ρ).mp μ.2))
 
 /-- Split a global virtual configuration into the value on a chosen edge and the
 configuration on all remaining edges. -/


### PR DESCRIPTION
### Motivation

- The existing proof of `constrained_mu_sum_collapse` in `OneVertexComparison.lean` used `Finset.sum_nbij'` to reindex the filtered sum over local virtual configurations agreeing with `ρ` off bond `ie`. This bijection-based approach requires manual forward/backward witnesses and side-conditions.
- Using an explicit `Equiv` between `{μ // SameAwayFromBond ie μ ρ}` and `Fin (A.bondDim ie.1)`, together with `Finset.sum_subtype_eq_sum_filter` and `Fintype.sum_equiv`, gives a more direct finite-sum transport from Mathlib.

### Description

- **File modified**: `TNLean/PEPS/FundamentalTheorem/OneVertexComparison.lean`
- In `constrained_mu_sum_collapse`: replaced the `Finset.sum_nbij'` bijection proof with an explicit `Equiv` between the constrained local configuration subtype `{μ // SameAwayFromBond ie μ ρ}` and the bond-index type `Fin (A.bondDim ie.1)`.
- `Finset.sum_subtype_eq_sum_filter` and `Fintype.sum_equiv` carry the sum transport; `sameAwayFromBond_iff_update` still supplies the identification `μ ↔ Function.update ρ ie (μ ie)`.
- The statement of `constrained_mu_sum_collapse` and all surrounding PEPS comparison lemmas are unchanged.

### Testing

- `lake env lean TNLean/PEPS/FundamentalTheorem/OneVertexComparison.lean`
- `lake build TNLean.PEPS.FundamentalTheorem.OneVertexComparison -q`
- `lake build TNLean -q` (pre-existing warnings and one pre-existing `sorry` at `TNLean/MPS/Periodic/Overlap/Case3.lean:586:14` remain; no new failures from this change)
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/FundamentalTheorem/OneVertexComparison.lean` (clean)

---

_No linked issue found — please link the relevant issue manually if one exists._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma; no API or mathematical statement changes, and downstream PEPS comparison lemmas still call the same theorem.
>
> **Overview**
> **`constrained_mu_sum_collapse`** is reproved without changing its statement: the filtered sum over local virtual configs that agree with `ρ` off bond `ie` still reindexes to a sum over `Fin (A.bondDim ie.1)` via `Function.update ρ ie j`.
>
> The old **`Finset.sum_nbij'`** bijection proof is replaced by an explicit **`Equiv`** between `{μ // SameAwayFromBond ie μ ρ}` and that finite fiber, with **`Finset.sum_subtype_eq_sum_filter`** and **`Fintype.sum_equiv`** carrying the sum. **`sameAwayFromBond_iff_update`** still supplies the identification `μ` ↔ `Function.update ρ ie (μ ie)`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e095540b88e24301c1cc9f64af6d72fe1e36b55e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor of a single lemma; no statement or API changes, and downstream callers such as `twoBlock_lhs_collapsed` are unchanged.
> 
> **Overview**
> **`constrained_mu_sum_collapse`** is reproved with the same statement: a filtered sum over local virtual configs agreeing with `ρ` off bond `ie` still equals a sum over `Fin (A.bondDim ie.1)` via `Function.update ρ ie j`.
> 
> The **`Finset.sum_nbij'`** bijection proof is replaced by an explicit **`Equiv`** from `{μ // SameAwayFromBond ie μ ρ}` to that fiber, with **`Finset.sum_subtype_eq_sum_filter`** and **`Fintype.sum_equiv`** transporting the sum. **`sameAwayFromBond_iff_update`** still identifies each constrained `μ` with `Function.update ρ ie (μ ie)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93628575867bd5248b95816a25bdc03f22f04038. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->