### PR TITLE
refactor(PEPS/RegionBlock): use sum congruence for matching filters

### DIFF
--- a/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
+++ b/TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean
@@ -164,13 +164,10 @@ theorem sum_regionBlockedWeight_mul_complement (A : Tensor G d) (R : Finset V)
     refine Finset.sum_congr rfl (fun μ _ => ?_)
     rw [Finset.sum_mul_sum]
     refine Finset.sum_congr rfl (fun ζ _ => ?_)
-    refine Finset.sum_nbij' id id ?_ ?_ (fun _ _ => rfl) (fun _ _ => rfl) (fun ξ hξ => rfl)
-    · intro ξ hξ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
-      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ).mp hξ
-    · intro ξ hξ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
-      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ).mpr hξ
+    refine Finset.sum_congr ?_ (fun ξ _ => rfl)
+    ext ξ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    exact regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ
 
 /-! ### The partial state lies in the span of the blocked-region weights
 

--- a/TNLean/PEPS/RegionBlock/GaugeBridge.lean
+++ b/TNLean/PEPS/RegionBlock/GaugeBridge.lean
@@ -203,14 +203,11 @@ theorem regionInsertedCoeff_eq_doubleSum (A : Tensor G d) (R : Finset V)
     rw [mul_assoc, Finset.sum_mul_sum, Finset.mul_sum]
     refine Finset.sum_congr rfl (fun ζ _ => ?_)
     rw [Finset.mul_sum]
-    refine Finset.sum_nbij' id id ?_ ?_ (fun _ _ => rfl) (fun _ _ => rfl) ?_
-    · intro ξ hξ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
-      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R ν ξ).mp hξ
-    · intro ξ hξ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
-      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R ν ξ).mpr hξ
-    · intro ξ _; simp only [id_eq]; ring
+    refine Finset.sum_congr ?_ (fun ξ _ => ?_)
+    · ext ξ
+      simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+      exact regionBoundaryLabel_compl_eq_iff (G := G) A R ν ξ
+    · ring
 
 /-! ### Global-product form of the gauged region weight
 

--- a/TNLean/PEPS/RegionBlock/Recovery.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery.lean
@@ -190,13 +190,10 @@ theorem regionInsertedCoeff_identity_eq_doubleSum (A : Tensor G d) (R : Finset V
     refine Finset.sum_congr rfl (fun μ _ => ?_)
     rw [Finset.sum_mul_sum]
     refine Finset.sum_congr rfl (fun ζ _ => ?_)
-    refine Finset.sum_nbij' id id ?_ ?_ (fun _ _ => rfl) (fun _ _ => rfl) (fun ξ hξ => rfl)
-    · intro ξ hξ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
-      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ).mp hξ
-    · intro ξ hξ
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hξ ⊢
-      exact (regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ).mpr hξ
+    refine Finset.sum_congr ?_ (fun ξ _ => rfl)
+    ext ξ
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and]
+    exact regionBoundaryLabel_compl_eq_iff (G := G) A R μ ξ
 
 /-! ### Multiplicity collapse to the closed state coefficient
 


### PR DESCRIPTION
### Motivation

- Three `Finset.sum_nbij' id id` identity-bijection transports in the PEPS region-block lemmas
  were unnecessarily verbose: the underlying filtered index sets are extensionally equal, so
  `Finset.sum_congr` applies directly.
- Using `Finset.sum_congr` together with `ext ξ` and `regionBoundaryLabel_compl_eq_iff` makes
  the equality of the region and complement boundary filter sets explicit, removing dead bijection
  bookkeeping and improving proof readability.

### Description

- `TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean` (−7 / +4): replace
  `Finset.sum_nbij' id id` with `Finset.sum_congr` over equal filtered domains.
- `TNLean/PEPS/RegionBlock/GaugeBridge.lean` (−8 / +5): same replacement; the existing `ring`
  step on the summand is retained.
- `TNLean/PEPS/RegionBlock/Recovery.lean` (−7 / +4): same replacement.
- No theorem statements, definitions, or sorries are added or removed.

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/GaugeBridge.lean`
- `lake env lean TNLean/PEPS/RegionBlock/BlockRangeCoincidence.lean`
- `lake env lean TNLean/PEPS/RegionBlock/Recovery.lean`
- `lake build TNLean.PEPS.RegionBlock.GaugeBridge TNLean.PEPS.RegionBlock.BlockRangeCoincidence TNLean.PEPS.RegionBlock.Recovery -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast"` on all changed files — no new occurrences;
  pre-existing `TNLean/MPS/Periodic/Overlap/Case3.lean:586:14` sorry is unrelated to this change.
- Full `lake build TNLean` passes; pre-existing header/docstring/style warnings are unaffected.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS region-block lemmas with no API or runtime behavior changes; mathematical claims and theorem statements are preserved.
>
> **Overview**
> Replaces three **identity bijection** transports (`Finset.sum_nbij' id id`) with **`Finset.sum_congr`** over **equal filtered index sets** in `BlockRangeCoincidence.lean`, `GaugeBridge.lean`, and `Recovery.lean`.
>
> Each site now shows the complement-side `Finset.mem_filter` predicate matches the region boundary label via **`ext ξ`** and **`regionBoundaryLabel_compl_eq_iff`**, instead of proving membership in both directions for `id`. Summands and theorem statements are unchanged; `GaugeBridge` still uses **`ring`** on the summand step where the old proof did.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2101ed753379dd00a5215c29912e8551c603d146. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or runtime changes; mathematical claims are unchanged.
> 
> **Overview**
> Three PEPS region-block proofs no longer use **`Finset.sum_nbij' id id`** to reindex sums over filtered virtual configurations. They now apply **`Finset.sum_congr`** on index sets that are definitionally the same, with **`ext ξ`**, **`simp`** on **`Finset.mem_filter`**, and **`regionBoundaryLabel_compl_eq_iff`** to equate the complement-side boundary filter with the region-side filter.
> 
> **`BlockRangeCoincidence.lean`**, **`Recovery.lean`**, and **`GaugeBridge.lean`** each get this swap at the step that merges complement and region boundary filters after distributing products of sums. Summands stay **`rfl`** (or **`ring`** in **`GaugeBridge`**); theorem statements and sorries are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812a4a2f2436c8c2bb6b38bceca4204183cc6c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->