### PR TITLE
refactor(PEPS/RegionBlock): use filter congruence in three-block sums

### DIFF
--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean
@@ -753,15 +753,15 @@ theorem threeBlockDoubleSum_eq_blueCoeff_sum
   rw [regionBlockedWeight, threeBlockBlueCoeff, Finset.sum_mul_sum]
   -- Reindex the product over `(p, q)` against the separated double sum.
   rw [Finset.filter_filter, ← Finset.sum_product']
-  refine Finset.sum_nbij' (fun p => (p.1, p.2)) (fun p => (p.1, p.2)) ?_ ?_
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-  · -- A `bc'`-fiber pair maps to the separated product index set.
-    rintro ⟨p, q⟩ hpq
+  refine Finset.sum_congr ?_ (fun _ _ => rfl)
+  ext x
+  rcases x with ⟨p, q⟩
+  constructor
+  · intro hpq
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨⟨hhost, hagree⟩, hbc⟩ := hpq
     exact ⟨hbc, hhost, hbc ▸ hagree.symm⟩
-  · -- A separated product index maps back to a `bc'`-fiber pair.
-    rintro ⟨p, q⟩ hpq
+  · intro hpq
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨hp, hhost, hq⟩ := hpq
     exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩

--- a/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
+++ b/TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean
@@ -516,13 +516,15 @@ theorem threeBlockDoubleSum_eq_complCoeff_sum_blue
   refine Finset.sum_congr rfl (fun bβ _ => ?_)
   rw [regionBlockedWeight, threeBlockComplCoeff, Finset.sum_mul_sum]
   rw [Finset.filter_filter, ← Finset.sum_product']
-  refine Finset.sum_nbij' (fun p => (p.1, p.2)) (fun p => (p.1, p.2)) ?_ ?_
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-  · rintro ⟨p, q⟩ hpq
+  refine Finset.sum_congr ?_ (fun _ _ => rfl)
+  ext x
+  rcases x with ⟨p, q⟩
+  constructor
+  · intro hpq
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨⟨hhost, hagree⟩, hbβ⟩ := hpq
     exact ⟨hbβ, hhost, hbβ ▸ hagree.symm⟩
-  · rintro ⟨p, q⟩ hpq
+  · intro hpq
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨hp, hhost, hq⟩ := hpq
     exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean
@@ -572,15 +572,15 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_blueCoeff_sum
   rw [regionBlockedWeight, threeBlockBlueCoeff, Finset.sum_mul_sum]
   -- Reindex the product over `(p, q)` against the separated double sum.
   rw [Finset.filter_filter, ← Finset.sum_product']
-  refine Finset.sum_nbij' (fun p => (p.1, p.2)) (fun p => (p.1, p.2)) ?_ ?_
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-  · -- A `bc'`-fiber pair maps to the separated product index set.
-    rintro ⟨p, q⟩ hpq
+  refine Finset.sum_congr ?_ (fun _ _ => rfl)
+  ext x
+  rcases x with ⟨p, q⟩
+  constructor
+  · intro hpq
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨⟨hhost, hagree⟩, hbc⟩ := hpq
     exact ⟨hbc, hhost, hbc ▸ hagree.symm⟩
-  · -- A separated product index maps back to a `bc'`-fiber pair.
-    rintro ⟨p, q⟩ hpq
+  · intro hpq
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨hp, hhost, hq⟩ := hpq
     exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩

--- a/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
+++ b/TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean
@@ -337,13 +337,15 @@ theorem ThreeBlockGeometry.threeBlockDoubleSum_eq_complCoeff_sum_blue
   refine Finset.sum_congr rfl (fun bβ _ => ?_)
   rw [regionBlockedWeight, threeBlockComplCoeff, Finset.sum_mul_sum]
   rw [Finset.filter_filter, ← Finset.sum_product']
-  refine Finset.sum_nbij' (fun p => (p.1, p.2)) (fun p => (p.1, p.2)) ?_ ?_
-    (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
-  · rintro ⟨p, q⟩ hpq
+  refine Finset.sum_congr ?_ (fun _ _ => rfl)
+  ext x
+  rcases x with ⟨p, q⟩
+  constructor
+  · intro hpq
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨⟨hhost, hagree⟩, hbβ⟩ := hpq
     exact ⟨hbβ, hhost, hbβ ▸ hagree.symm⟩
-  · rintro ⟨p, q⟩ hpq
+  · intro hpq
     simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hpq ⊢
     obtain ⟨hp, hhost, hq⟩ := hpq
     exact ⟨⟨hhost, hp.trans hq.symm⟩, hp⟩


### PR DESCRIPTION
### Motivation

- Four decoupling lemmas in `TNLean/PEPS/RegionBlock/` used `Finset.sum_nbij'` with identity bijections to transport sums over three-block product-filter index sets. The identity bijections add no mathematical content and can be eliminated by proving the filter sets equal directly.
- Replacing `Finset.sum_nbij'` with `Finset.sum_congr` (after a single `ext`/`rcases` step) simplifies each proof and makes the index-reindexing argument more transparent.

### Description

- `TNLean/PEPS/RegionBlock/ThreeBlockResonate.lean`: replaced two `Finset.sum_nbij'` identity transports with `Finset.sum_congr` after proving the product-index filter equal by extensionality.
- `TNLean/PEPS/RegionBlock/ThreeBlockResonate2.lean`: same replacement in two lemmas.
- `TNLean/PEPS/RegionBlock/UnionInjectivityGeneral.lean`: same replacement.
- `TNLean/PEPS/RegionBlock/UnionInjectivityGeneralBlue.lean`: same replacement.
- In each case the filter equality is established using the same boundary-label implications already present in the original proof. No theorem statements or summands are changed.

### Testing

- `lake env lean` run on all four modified files.
- `lake build TNLean.PEPS.RegionBlock.ThreeBlockResonate TNLean.PEPS.RegionBlock.ThreeBlockResonate2 TNLean.PEPS.RegionBlock.UnionInjectivityGeneral TNLean.PEPS.RegionBlock.UnionInjectivityGeneralBlue`.
- `lake build TNLean` (full build); no new failures. Pre-existing `sorry` at `TNLean/MPS/Periodic/Overlap/Case3.lean:586:14` and pre-existing style warnings remain unchanged.
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast"` on all four modified files returns no results.
- `check_reader_facing_prose.py` and `blueprint_lean_sync.py` report no new issues.

---
_No issue linked — please link one manually._

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or mathematical statement changes; risk is limited to Lean proof correctness, which CI validates on the touched files.
>
> **Overview**
> In four three-block **decoupling** lemmas (`threeBlockDoubleSum_eq_blueCoeff_sum` / `threeBlockDoubleSum_eq_complCoeff_sum_blue` and their `ThreeBlockGeometry` mirrors), the step that reindexes a `Finset.sum_product'` after `Finset.sum_mul_sum` no longer uses **`Finset.sum_nbij'`** with the identity on `(p, q)`.
>
> Instead each proof applies **`Finset.sum_congr`** once the **filtered product index set** is shown equal to the separated double-sum index set via **`ext`**, **`rcases`**, and the same host / boundary-label implications as before. **Summands and theorem statements are unchanged**; only the transport argument is simplified.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8678980c9923d002d0692387fdc9645b063d1c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or mathematical statement changes; risk is limited to Lean proof correctness on the touched files.
> 
> **Overview**
> In four **three-block decoupling** lemmas in `TNLean/PEPS/RegionBlock/` (`threeBlockDoubleSum_eq_blueCoeff_sum`, `threeBlockDoubleSum_eq_complCoeff_sum_blue`, and the `ThreeBlockGeometry` mirrors), the reindexing step after `Finset.sum_product'` no longer uses **`Finset.sum_nbij'`** with the identity on `(p, q)`.
> 
> Each proof now applies **`Finset.sum_congr`** once the filtered product index set is shown equal to the separated double-sum index set via **`ext`**, **`rcases`**, and the same host / boundary-label implications as before. **Theorem statements and summands are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae553521c7ab70d33c171cd6cd64bab0cc6cb079. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->