### PR TITLE
refactor(PEPS): use prod comm equivalence in torus sum

### DIFF
--- a/TNLean/PEPS/TorusWindowChain4.lean
+++ b/TNLean/PEPS/TorusWindowChain4.lean
@@ -493,15 +493,16 @@ theorem threeBlockBlueCoeff_comp {R S P : Finset V} (hRS : R ⊆ S) (hSP : S ⊆
           ∏ w : {w : V // w ∈ P \ S}, A.component w.1 (fun ie => p.1 ie.1) (σ₂ w))]
       refine Finset.sum_congr rfl (fun bc'' _ => ?_)
       rw [Finset.sum_mul_sum, Finset.filter_filter, ← Finset.sum_product']
-      refine Finset.sum_nbij' (i := fun q => (q.2, q.1)) (j := fun p => (p.2, p.1))
-        ?_ ?_ (fun _ _ => rfl) (fun _ _ => rfl) (fun _ _ => rfl)
+      refine Finset.sum_equiv (Equiv.prodComm _ _) ?_ (fun _ _ => rfl)
+      rintro ⟨q₁, q₂⟩
+      constructor
       · -- A `(q₁, q₂)` index of the separated sum maps to an agreeing-pair fiber element.
-        rintro ⟨q₁, q₂⟩ hq
+        intro hq
         simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hq ⊢
         obtain ⟨⟨hR, hS₁⟩, hS₂, hP⟩ := hq
         exact ⟨⟨⟨hR, hP⟩, hS₂.trans hS₁.symm⟩, hS₁⟩
       · -- An agreeing-pair fiber element maps back to a `(q₁, q₂)` separated index.
-        rintro ⟨q₂, q₁⟩ hq
+        intro hq
         simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product] at hq ⊢
         obtain ⟨⟨⟨hR, hP⟩, hagree⟩, hfib⟩ := hq
         exact ⟨⟨hR, hfib⟩, hagree.trans hfib, hP⟩


### PR DESCRIPTION
### Motivation

- `threeBlockBlueCoeff_comp` in `TNLean/PEPS/TorusWindowChain4.lean` used a hand-built `Finset.sum_nbij'` to swap the product-configuration pair $(q_2, q_1) \leftrightarrow (q_1, q_2)$. Mathlib's `Finset.sum_equiv` along `Equiv.prodComm` is the canonical way to perform this reindexing.
- Replacing the bespoke pair-swap with the standard Mathlib combinator reduces proof complexity without changing the mathematical content.

### Description

- `TNLean/PEPS/TorusWindowChain4.lean` (modified): in `threeBlockBlueCoeff_comp`, the explicit `Finset.sum_nbij'`-based pair-swap is replaced by `Finset.sum_equiv Equiv.prodComm`. The membership arguments for the separated and agreeing-pair index sets are preserved. The theorem statement and summands are unchanged.

### Testing

- `lake env lean TNLean/PEPS/TorusWindowChain4.lean`
- `lake build TNLean.PEPS.TorusWindowChain4 -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/TorusWindowChain4.lean` — no new occurrences
- Full build reports only pre-existing warnings and the existing `TNLean/MPS/Periodic/Overlap/Case3.lean:586:14` sorry; no new failures from this change.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS formalization with no runtime or API changes; mathematical content of `threeBlockBlueCoeff_comp` is unchanged.
> 
> **Overview**
> In **`threeBlockBlueCoeff_comp`**, the step that reindexes a product of two filtered configuration sums is refactored: a hand-built **`Finset.sum_nbij'`** pair swap `(q₂, q₁) ↔ (q₁, q₂)` is replaced by **`Finset.sum_equiv`** along **`Equiv.prodComm`**.
> 
> The forward and inverse **membership** arguments for the separated vs agreeing-pair index sets are unchanged in substance; they are just phrased with **`constructor`** / **`intro`** on **`⟨q₁, q₂⟩`** instead of custom **`i`** / **`j`** maps. The theorem statement and summands are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b3708013866f4ec0ed5a640fe294dc36757e61f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->