### PR TITLE
refactor(PEPS/RegionBlock): use product equivalences in coarse sum

### DIFF
--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean
@@ -646,11 +646,14 @@ theorem perPair_threeRegionProduct_eq
   simp only [Finset.mul_sum, Finset.sum_mul]
   rw [← Fintype.sum_prod_type', ← Fintype.sum_prod_type', ← Fintype.sum_prod_type',
     ← Fintype.sum_prod_type']
-  refine Finset.sum_nbij' (fun t => ((t.2, t.1.1), t.1.2))
-    (fun t => ((t.1.2, t.2), t.1.1)) (fun _ _ => Finset.mem_univ _)
-    (fun _ _ => Finset.mem_univ _) (fun _ _ => rfl) (fun _ _ => rfl) ?_
-  rintro ⟨⟨ζb, ζc⟩, ζr⟩ _
-  dsimp only
+  let φ : ((VirtualConfig A × VirtualConfig A) × VirtualConfig A) ≃
+      ((VirtualConfig A × VirtualConfig A) × VirtualConfig A) :=
+    (Equiv.prodComm (VirtualConfig A × VirtualConfig A) (VirtualConfig A)).trans
+      (Equiv.prodAssoc (VirtualConfig A) (VirtualConfig A) (VirtualConfig A)).symm
+  refine Fintype.sum_equiv φ _ _ ?_
+  rintro ⟨⟨ζb, ζc⟩, ζr⟩
+  dsimp only [φ]
+  simp only [Equiv.trans_apply, Equiv.prodComm_apply, Equiv.prodAssoc_symm_apply, Prod.swap]
   -- Combine the three selectors and the matrix factor into one selector.
   by_cases hr : regionBoundaryLabel (G := G) A F.frame.red ζr =
       F.frame.legEquivRed (fun ie => ηL ie.1)


### PR DESCRIPTION
### Motivation

- The proof of `perPair_threeRegionProduct_eq` used a hand-built bijection via `Finset.sum_nbij'` to justify cyclic reindexing of a triple sum over virtual configurations. Expressing this reindexing via `Fintype.sum_equiv` with Mathlib product-equivalence combinators (`Equiv.prodComm`, `Equiv.prodAssoc`) is more direct and idiomatic.

### Description

- Modified `TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean` (8 additions, 5 deletions).
- In `perPair_threeRegionProduct_eq`: replaced the `Finset.sum_nbij'` bijection step with `Fintype.sum_equiv` applied to the composition of `Equiv.prodComm` and `Equiv.prodAssoc.symm`, with `simp` discharging the reindexing equalities.
- The theorem statement, the boundary-label `by_cases` selector analysis, and the rest of the proof are unchanged.

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean` — passes.
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionBlock/CoarseThreeSite7.lean` — no violations.
- Full build (`lake build TNLean`) passes; pre-existing warnings and `TNLean/MPS/Periodic/Overlap/Case3.lean:586:14` sorry are unchanged.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma with no API or runtime behavior changes; mathematical content is preserved.
> 
> **Overview**
> In **`perPair_threeRegionProduct_eq`**, the proof step that **cyclically reindexes** a triple sum over virtual configs (after flattening nested sums) no longer uses a hand-built **`Finset.sum_nbij'`** bijection.
> 
> It now introduces an explicit **`φ`** as **`Equiv.prodComm`** composed with **`Equiv.prodAssoc.symm`**, then applies **`Fintype.sum_equiv`** and **`simp`** on the equivalence laws. The **goal statement**, the **boundary-label `by_cases`**, and the rest of the M-coupled descent chain are **unchanged**—only how the reindexing is justified in Lean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5100c5f0422168775f5bf89348fd719a538b9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma with no API or runtime changes; the mathematical reindexing is the same.
> 
> **Overview**
> In **`perPair_threeRegionProduct_eq`**, the step that **cyclically reindexes** a triple sum over virtual configs (after distributing and flattening nested sums) no longer uses a hand-built **`Finset.sum_nbij'`** bijection.
> 
> The proof now names **`φ`** as **`Equiv.prodComm`** composed with **`Equiv.prodAssoc.symm`**, applies **`Fintype.sum_equiv`**, and uses **`simp`** on the equivalence laws for the reindexing case. The **lemma statement**, boundary-label **`by_cases`**, and downstream M-coupled descent are **unchanged**—only how the cyclic reordering is justified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0951fd9fcece44b9d018417c899dc122db1c322. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->