### PR TITLE
refactor(PEPS): use pi congruence for gauge state cast

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean
+++ b/TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean
@@ -310,16 +310,8 @@ theorem GaugeEquiv.sameState {A B : Tensor G d} (h : GaugeEquiv A B) :
   classical
   rcases h with ⟨hDim, X, hX⟩
   intro σ
-  let φ : VirtualConfig A ≃ VirtualConfig B := {
-    toFun := fun η e => Fin.cast (congr_fun hDim e) (η e)
-    invFun := fun η e => Fin.cast (Eq.symm (congr_fun hDim e)) (η e)
-    left_inv := fun η => by
-      funext e
-      simp
-    right_inv := fun η => by
-      funext e
-      simp
-  }
+  let φ : VirtualConfig A ≃ VirtualConfig B :=
+    Equiv.piCongrRight fun e => finCongr (congr_fun hDim e)
   have hB : stateCoeff B σ = stateCoeff (applyGauge A X) σ := by
     unfold stateCoeff
     rw [← φ.sum_comp (fun η : VirtualConfig B =>


### PR DESCRIPTION
### Motivation

- The proof of `GaugeEquiv.sameState` in `TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean`
  constructed a `VirtualConfig A ≃ VirtualConfig B` equivalence by hand: explicit forward and
  inverse maps using `Fin.cast` on each edge, together with separate `left_inv` and `right_inv`
  proofs.
- Mathlib's `Equiv.piCongrRight` combined with `finCongr` encodes the same reindexing of virtual
  bond indices directly, removing the manual construction.

### Description

- Modified `TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean` (2 additions, 10 deletions).
- In `GaugeEquiv.sameState`, replaced the hand-written `VirtualConfig A ≃ VirtualConfig B`
  equivalence with `φ := Equiv.piCongrRight (fun e ↦ finCongr (congr_fun hDim e))`.
- The downstream step rewriting `stateCoeff B σ` via `φ.sum_comp` and the call to
  `applyGauge_stateCoeff` are unchanged.

### Testing

- `lake env lean TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean`
- `lake build TNLean.PEPS.FundamentalTheorem.EdgeInsertion -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean` (no matches)
- `lake build TNLean -q --log-level=info` (only pre-existing warnings; the known sorry at `TNLean/MPS/Periodic/Overlap/Case3.lean:586:14` is pre-existing)
- Lean CI (`lean_action_ci.yml`) validates the full build.

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a PEPS gauge theorem; no API or runtime behavior change.
>
> **Overview**
> In **`GaugeEquiv.sameState`**, the proof no longer builds a hand-written equivalence `VirtualConfig A ≃ VirtualConfig B` with `Fin.cast` on each edge and explicit `left_inv` / `right_inv` simp proofs.
>
> It now defines **`φ`** as **`Equiv.piCongrRight`** composed with **`finCongr (congr_fun hDim e)`** per edge—the same reindexing of virtual bond indices, expressed with Mathlib's dependent product equivalence API. The downstream step that rewrites **`stateCoeff B σ`** via **`φ.sum_comp`** and ties into **`applyGauge_stateCoeff`** is unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a839a631b53656fcfcfaf7bc1be3eb54e60d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- /CURSOR_SUMMARY -->