### PR TITLE
refactor(PEPS): use pi congruence for boundary casts

### DIFF
--- a/TNLean/PEPS/RegionBlock/ReindexInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/ReindexInjectivity.lean
@@ -31,17 +31,8 @@ by casting every open leg across the bond-dimension equality. -/
 noncomputable def regionBoundaryConfigCastEquiv (T : Tensor G d) {bd : Edge G → ℕ}
     (h : bd = T.bondDim) (R : Finset V) :
     RegionBoundaryConfig (G := G) (reindexTensor (G := G) T h) R ≃
-      RegionBoundaryConfig (G := G) T R where
-  toFun bdry := fun f => Fin.cast (congr_fun h f.1) (bdry f)
-  invFun bdry := fun f => Fin.cast (congr_fun h f.1).symm (bdry f)
-  left_inv bdry := by
-    funext f
-    apply Fin.eq_of_val_eq
-    simp
-  right_inv bdry := by
-    funext f
-    apply Fin.eq_of_val_eq
-    simp
+      RegionBoundaryConfig (G := G) T R :=
+  Equiv.piCongrRight fun f => finCongr (congr_fun h f.1)
 
 /-- **A bond-dimension reindex preserves blocked-region linear independence.**
 


### PR DESCRIPTION
### Motivation
- `regionBoundaryConfigCastEquiv`, the cast equivalence for boundary configurations of a reindexed PEPS tensor, was constructed by hand using `Fin.cast` on each boundary leg with explicit `left_inv` and `right_inv` proofs, duplicating Mathlib machinery.
- Mathlib's `Equiv.piCongrRight` provides this equivalence directly, composing `finCongr (congr_fun h f.1)` per open edge and delegating bijectivity to Mathlib.

### Description
- `TNLean/PEPS/RegionBlock/ReindexInjectivity.lean` (+2/−11): replace the manual structure literal for `regionBoundaryConfigCastEquiv` with `Equiv.piCongrRight`. Remove the hand-written `Fin.cast` inverse and its two proof obligations (`left_inv`, `right_inv`).
- The public name and type of `regionBoundaryConfigCastEquiv` are unchanged; `regionBlockedTensorInjective_reindexTensor`, which precomposes the blocked family with this map and applies `linearIndependent_equiv`, is unaffected.

### Testing
- `lake env lean TNLean/PEPS/RegionBlock/ReindexInjectivity.lean`
- `lake build TNLean.PEPS.RegionBlock.ReindexInjectivity -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionBlock/ReindexInjectivity.lean` (no matches)
- `lake build TNLean -q --log-level=info` (only pre-existing warnings)
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one Lean file; no changes to theorem statements or downstream call sites beyond the equivalent definition.
> 
> **Overview**
> **`regionBoundaryConfigCastEquiv`** is no longer built by hand with `Fin.cast` on each boundary leg and custom `left_inv` / `right_inv` proofs. It is now **`Equiv.piCongrRight`** composed with **`finCongr (congr_fun h f.1)`** per open edge, delegating bijectivity to Mathlib.
> 
> The public name and type of the equivalence are unchanged, so **`regionBlockedTensorInjective_reindexTensor`** still precomposes the blocked family with this map and applies **`linearIndependent_equiv`**—behavior is the same, with less boilerplate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014856d1a22ffc41cf3e9b97f329ea99ddd20232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>