### PR TITLE
refactor(PEPS): use pi congruence for torus boundary casts

### DIFF
--- a/TNLean/PEPS/TorusGaugedWeightCovariance.lean
+++ b/TNLean/PEPS/TorusGaugedWeightCovariance.lean
@@ -86,26 +86,10 @@ noncomputable def tiBoundaryConfigEquiv (T : Tensor (torusGraph width height) d)
     (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)
     (R : Finset (TorusVertex width height)) :
     RegionBoundaryConfig (G := torusGraph width height) T R ≃
-      RegionBoundaryConfig (G := torusGraph width height) T (Region.map (translate a b) R) where
-  toFun := tiBoundaryConfigMap T hT a b R
-  invFun bdry' := (regionBoundaryConfigMapEquiv T (translate a b) R).symm
-    (fun f => Fin.cast (congrFun (congrArg Tensor.bondDim (hT a b)) f.1).symm (bdry' f))
-  left_inv bdry := by
-    beta_reduce
-    have hcollapse : (fun f => Fin.cast
-        (congrFun (congrArg Tensor.bondDim (hT a b)) f.1).symm
-        (tiBoundaryConfigMap T hT a b R bdry f)) =
-        regionBoundaryConfigMap T (translate a b) R bdry := by
-      funext f
-      apply Fin.eq_of_val_eq
-      simp [tiBoundaryConfigMap]
-    rw [hcollapse, ← regionBoundaryConfigMapEquiv_apply, Equiv.symm_apply_apply]
-  right_inv bdry' := by
-    beta_reduce
-    funext f
-    rw [tiBoundaryConfigMap, ← regionBoundaryConfigMapEquiv_apply, Equiv.apply_symm_apply]
-    apply Fin.eq_of_val_eq
-    simp
+      RegionBoundaryConfig (G := torusGraph width height) T (Region.map (translate a b) R) :=
+  (regionBoundaryConfigMapEquiv T (translate a b) R).trans
+    (Equiv.piCongrRight fun f =>
+      finCongr (congrFun (congrArg Tensor.bondDim (hT a b)) f.1))
 
 @[simp] theorem tiBoundaryConfigEquiv_apply (T : Tensor (torusGraph width height) d)
     (hT : IsTorusTranslationInvariant T) (a : ZMod width) (b : ZMod height)


### PR DESCRIPTION
### Motivation

- `tiBoundaryConfigEquiv` was defined with hand-written `invFun` and `left_inv` / `right_inv` proofs. These are derivable from Mathlib's `Equiv.piCongrRight` via the fibrewise `finCongr` arising from translation-invariant bond dimensions, removing the need for explicit inverse proofs.

### Description

- Modified `TNLean/PEPS/TorusGaugedWeightCovariance.lean`: rewrites `tiBoundaryConfigEquiv` as the composition of `regionBoundaryConfigMapEquiv` with `Equiv.piCongrRight` over `finCongr`.
- The forward map `tiBoundaryConfigMap` and the simp lemma `tiBoundaryConfigEquiv_apply` (which holds by `rfl`) are unchanged; call sites (`surjectivity`, `Equiv.sum_comp`, etc.) are unaffected.
- Eliminates 20 lines of hand-written inverse and inverse-law proofs.

### Testing

- `lake env lean TNLean/PEPS/TorusGaugedWeightCovariance.lean`
- `lake build TNLean.PEPS.TorusGaugedWeightCovariance -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/TorusGaugedWeightCovariance.lean || true`
- `lake build TNLean -q --log-level=info`
- Pre-existing style/header warnings and the known periodic-overlap `sorry` in `TNLean/MPS/Periodic/Overlap/Case3.lean` are unrelated to this change.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS torus covariance; no API or runtime behavior change beyond Mathlib-derived inverse laws.
>
> **Overview**
> **`tiBoundaryConfigEquiv`** is no longer built with hand-written `invFun` and `left_inv` / `right_inv` proofs. It is now **`regionBoundaryConfigMapEquiv`** composed with **`Equiv.piCongrRight`** and fibrewise **`finCongr`** from translation-invariant bond dimensions.
>
> The forward map is still **`tiBoundaryConfigMap`**; **`tiBoundaryConfigEquiv_apply`** remains **`rfl`**, so callers (surjectivity, **`Equiv.sum_comp`**, etc.) are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d299c255a25a85f25c4f47685c2bc55f4efd57a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>