### PR TITLE
refactor(PEPS): use pi congruence for complement boundaries

### DIFF
--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
@@ -155,9 +155,11 @@ theorem redBundleInsertedCoeff_bondModelMatrix_eq_configSum
     rw [show (regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).symm
           (regionBoundaryLabel (G := G) A (Finset.univ \ F.frame.red) η) =
         regionBoundaryLabel (G := G) A F.frame.red η from by
+      apply (regionComplementBoundaryConfigEquiv (G := G) A F.frame.red).injective
+      rw [Equiv.apply_symm_apply, regionComplementBoundaryConfigEquiv_apply]
       funext f
-      simp [regionComplementBoundaryConfigEquiv, Equiv.piCongrLeft',
-        regionBoundaryLabel_apply, regionBoundaryEdgeComplEquiv_symm_apply_coe]]
+      rw [regionComplementBoundaryConfig, regionBoundaryLabel_apply, regionBoundaryLabel_apply]
+      congr 1]
     by_cases hag : SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
         (regionBoundaryLabel (G := G) A F.frame.red ζr)
         (regionBoundaryLabel (G := G) A F.frame.red η)


### PR DESCRIPTION
### Motivation

- The complement and double-complement boundary-configuration equivalences in the PEPS region-block recovery route (`Recovery6`, `Recovery10`) were built by spelling out `toFun`/`invFun` and proving `left_inv`/`right_inv` manually.
- These maps are dependent-function precomposition along the already-defined boundary-edge equivalences, so `Equiv.piCongrLeft'` from Mathlib provides the construction directly without the boilerplate.

### Description

- `TNLean/PEPS/RegionBlock/Recovery6.lean`: `regionComplementBoundaryConfigEquiv` redefined as `Equiv.piCongrLeft'` precomposing along `regionBoundaryEdgeComplEquiv`; explicit `invFun` and inverse-law proofs removed.
- `TNLean/PEPS/RegionBlock/Recovery10.lean`: `regionDoubleComplBoundaryConfigEquiv` redefined as `Equiv.piCongrLeft'` precomposing along `(regionBoundaryEdgeDoubleComplEquiv).symm`; explicit `invFun` and inverse-law proofs removed.
- `TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean`: downstream proof updated to derive the symm-reindexed boundary-label identity through injectivity of `regionComplementBoundaryConfigEquiv` and `Equiv.apply_symm_apply`, replacing the previous `Equiv.coe_fn_symm_mk` unfolding.
- No new `sorry`s introduced; no mathematical statements changed.

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/Recovery6.lean`
- `lake env lean TNLean/PEPS/RegionBlock/Recovery10.lean`
- `lake env lean TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean`
- `lake build TNLean.PEPS.RegionBlock.Recovery6 TNLean.PEPS.RegionBlock.Recovery10 TNLean.PEPS.RegionBlock.CoarseThreeSite10 -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionBlock/Recovery6.lean TNLean/PEPS/RegionBlock/Recovery10.lean TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean || true` (no new sorrys)
- `lake build TNLean -q --log-level=info`
- Builds produce only the repository's pre-existing style/header warnings and the known periodic-overlap `sorry` warning in `TNLean/MPS/Periodic/Overlap/Case3.lean`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS region-block recovery; no changes to definitions of coefficients or mathematical claims.
> 
> **Overview**
> Redefines complement and double-complement **boundary-configuration equivalences** in the PEPS region-block recovery route as `Equiv.piCongrLeft'` precomposition along the existing boundary-edge equivalences, dropping hand-built `invFun` and inverse-law proofs.
> 
> In **`CoarseThreeSite10`**, the step that identifies the symm-reindexed host boundary label with the red-region label no longer unfolds the equivalence via `simp`; it uses **injectivity** of `regionComplementBoundaryConfigEquiv`, `Equiv.apply_symm_apply`, and `regionComplementBoundaryConfigEquiv_apply`, then pointwise `regionBoundaryLabel`/`regionComplementBoundaryConfig` rewrites.
> 
> No stated lemmas or behavior change—Lean proof maintenance only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa77ac19188438ecd3f40a56a73c3a128ce0b93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->