### PR TITLE
refactor(PEPS): use pi congruence for physical transport

### DIFF
--- a/TNLean/PEPS/RegionTransport.lean
+++ b/TNLean/PEPS/RegionTransport.lean
@@ -241,7 +241,7 @@ theorem regionBlockedWeight_transport (A : Tensor G d) (φ : G ≃g G') (R : Fin
 def regionPhysicalConfigMapEquiv (φ : G ≃g G') (R : Finset V) :
     RegionPhysicalConfig (V := V) (d := d) R ≃
       RegionPhysicalConfig (V := W) (d := d) (Region.map φ R) :=
-  Equiv.arrowCongr (regionVertexMapEquiv φ R).symm (Equiv.refl (Fin d))
+  Equiv.piCongrLeft' (fun _ : {w : V // w ∈ R} => Fin d) (regionVertexMapEquiv φ R).symm
 
 /-- The transported blocked-region tensor family is the original family reindexed: the
 boundary index by `regionBoundaryConfigMapEquiv`, the physical-leg domain by


### PR DESCRIPTION
### Motivation

- `regionPhysicalConfigMapEquiv` is the precomposition-by-`regionVertexMapEquiv` equivalence on physical configurations, which have constant fibre `Fin d`; the hand-built `toFun`/`invFun`/`left_inv`/`right_inv` fields are unnecessary because Mathlib's `Equiv.piCongrLeft'` provides exactly this construction.
- Aligns `regionPhysicalConfigMapEquiv` with `regionBoundaryConfigMapEquiv`, which already uses the same Mathlib pattern; no linked issue was found — the author should link one manually if applicable.

### Description

- Modified `TNLean/PEPS/RegionTransport.lean` (+2 / −5): replaced the hand-built equivalence definition (`toFun`, `invFun`, `left_inv`, `right_inv` fields) for `regionPhysicalConfigMapEquiv` with a direct application of `Equiv.piCongrLeft'` over constant fibres `Fin d`, reindexing domain vertices via `(regionVertexMapEquiv φ R).symm`.
- The definition of `regionPhysicalConfigMap` and downstream transport lemmas (e.g. `regionBlockedTensorFamily_transport_comp`) are unchanged in mathematical content.

### Testing

- `lake env lean TNLean/PEPS/RegionTransport.lean`
- `lake exe cache get`
- `lake build TNLean.PEPS.RegionTransport -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionTransport.lean || true`
- `lake build TNLean -q --log-level=info`
- Pre-existing style/header warnings and the known periodic-overlap sorry in `TNLean/MPS/Periodic/Overlap/Case3.lean` remain; no new issues introduced.

---

> [!NOTE]
> **Low Risk**
> Small proof refactor in PEPS region transport; no API or runtime behavior change beyond the equivalent definition of an existing equivalence.
>
> **Overview**
> **`regionPhysicalConfigMapEquiv`** is no longer built by hand with `toFun` / `invFun` and `left_inv` / `right_inv` proofs. It is now **`Equiv.piCongrLeft'`** over constant fibres **`Fin d`**, reindexing domain vertices with **`(regionVertexMapEquiv φ R).symm`**—the same Mathlib pattern already used for **`regionBoundaryConfigMapEquiv`**.
>
> The separate **`regionPhysicalConfigMap`** definition and downstream transport lemmas (e.g. **`regionBlockedTensorFamily_transport_comp`**) are unchanged in intent; only the equivalence is defined more uniformly.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1d095b0e7f19effdce3d5ef4deb3d6320ef9a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-definition proof refactor in PEPS region transport; no API or mathematical behavior change beyond an equivalent equivalence construction.
> 
> **Overview**
> **`regionPhysicalConfigMapEquiv`** is now defined with **`Equiv.piCongrLeft'`** over constant fibres **`Fin d`**, reindexing region vertices via **`(regionVertexMapEquiv φ R).symm`**, instead of **`Equiv.arrowCongr`** with **`Equiv.refl (Fin d)`**.
> 
> This matches how **`regionBoundaryConfigMapEquiv`** is already built. **`regionPhysicalConfigMap`** and lemmas such as **`regionBlockedTensorFamily_transport_comp`** are unchanged in meaning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a1be2246db50fb6bf36e7261f395abd8ff7472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->