### PR TITLE
refactor(MPS/Core): use arrow congruence for word reversal

### DIFF
--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -341,16 +341,7 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
   have hLeft : ∑ i : Fin d, (Aadj i)ᴴ * Aadj i = 1 := by
     simpa [Aadj] using hRight
   let revEquiv : (Fin L → Fin d) ≃ (Fin L → Fin d) :=
-    { toFun := fun ρ => ρ ∘ Fin.rev
-      invFun := fun ρ => ρ ∘ Fin.rev
-      left_inv := by
-        intro ρ
-        ext i
-        simp [Function.comp_def]
-      right_inv := by
-        intro ρ
-        ext i
-        simp [Function.comp_def] }
+    Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))
   calc
     ∑ ρ : Fin L → Fin d,
         evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ
@@ -361,7 +352,8 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
             intro ρ _
             have hword :
                 List.ofFn (revEquiv ρ) = (List.ofFn ρ).reverse := by
-              simpa [revEquiv] using list_ofFn_comp_fin_rev (σ := ρ)
+              simpa [revEquiv, Equiv.arrowCongr, Function.comp_def] using
+                list_ofFn_comp_fin_rev (σ := ρ)
             have hAdjEval :
                 (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ =
                   evalWord A (List.ofFn ρ) := by


### PR DESCRIPTION
### Motivation

- The hand-built reversal equivalence on words of length `L` in `sum_evalWord_mul_conjTranspose_evalWord` (a local `revEquiv` with explicit inverse proofs) can be replaced by Mathlib's `Equiv.arrowCongr` applied to `Fin.revPerm`, matching patterns used elsewhere in the repository (e.g. `rotateConfig`).
- This reduces reliance on local equivalence machinery and aligns the proof with established Mathlib idioms for permutation-indexed families.

### Description

- Modified `TNLean/MPS/Core/Blocking.lean`: in the proof of `sum_evalWord_mul_conjTranspose_evalWord`, replaced the local `revEquiv` definition with `Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))`.
- The reversed-word step still goes through `list_ofFn_comp_fin_rev`; the only proof change is unfolding `revEquiv`, `Equiv.arrowCongr`, and `Function.comp_def` in the `hword` simplification instead of the old local equivalence definition.
- No mathematical content is changed; no new `sorry`s are introduced.

### Testing

- `lake env lean TNLean/MPS/Core/Blocking.lean`
- `lake exe cache get`
- `lake build TNLean.MPS.Core.Blocking -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/Core/Blocking.lean || true`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof-only refactor in `Blocking.lean` with no API or mathematical content changes.
> 
> **Overview**
> In **`sum_evalWord_mul_conjTranspose_evalWord`**, the proof’s word-reversal step no longer builds a custom equivalence on `Fin L → Fin d`; it uses **`Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))`**, consistent with other MPS code (e.g. `rotateConfig`).
> 
> The **`hword`** step still applies `list_ofFn_comp_fin_rev`; only the simp/unfold layer changes (`revEquiv`, `Equiv.arrowCongr`, `Function.comp_def`) instead of manual `left_inv` / `right_inv` proofs. **No change to the stated theorem or its mathematical argument.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7858a47f0690dfa5d7a77a6068d4d9334b5a9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->