### PR TITLE
refactor(MPS): use finRotate for periodic config rotation

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
@@ -30,28 +30,26 @@ cross overlap is unchanged by the simultaneous shift. -/
 
 /-- One-site cyclic rotation of a configuration of length `L'+1`:
 move the last letter to the front. -/
-def rotateCfg {d L' : ℕ} : (Fin (L' + 1) → Fin d) ≃ (Fin (L' + 1) → Fin d) where
-  toFun σ := Fin.cons (σ (Fin.last L')) (Fin.init σ)
-  invFun τ := Fin.snoc (Fin.tail τ) (τ 0)
-  left_inv σ := by
-    funext j
-    refine Fin.lastCases ?_ ?_ j
-    · simp [Fin.snoc_last, Fin.cons_zero]
-    · intro i
-      simp [Fin.snoc_castSucc, Fin.init]
-  right_inv τ := by
-    funext j
-    refine Fin.cases ?_ ?_ j
-    · simp [Fin.cons_zero, Fin.snoc_last]
-    · intro i
-      simp [Fin.cons_succ, Fin.tail]
+def rotateCfg {d L' : ℕ} : (Fin (L' + 1) → Fin d) ≃ (Fin (L' + 1) → Fin d) :=
+  Equiv.arrowCongr (finRotate (L' + 1)) (Equiv.refl (Fin d))
 
 /-- Word evaluation of the rotated configuration pulls the last letter to the front. -/
 private lemma evalWord_ofFn_rotateCfg {L' : ℕ} (A : MPSTensor d D)
     (σ : Fin (L' + 1) → Fin d) :
     evalWord A (List.ofFn (rotateCfg σ)) =
       A (σ (Fin.last L')) * evalWord A (List.ofFn (Fin.init σ)) := by
-  simp only [rotateCfg, Equiv.coe_fn_mk, List.ofFn_cons, evalWord_cons]
+  have hrotate : rotateCfg σ = Fin.cons (σ (Fin.last L')) (Fin.init σ) := by
+    funext j
+    refine Fin.cases ?_ ?_ j
+    · change σ ((finRotate (L' + 1)).symm 0) = σ (Fin.last L')
+      exact congrArg σ (Fin.ext (by simp))
+    · intro i
+      change σ ((finRotate (L' + 1)).symm i.succ) = σ i.castSucc
+      exact congrArg σ (Fin.ext (by
+        rw [finRotate_symm_apply]
+        rw [Fin.val_sub_one_of_ne_zero (by simp)]
+        simp))
+  simp only [hrotate, List.ofFn_cons, evalWord_cons]
 
 /-- Word evaluation of the original configuration pulls the last letter to the right. -/
 private lemma evalWord_ofFn_eq_init_mul_last {L' : ℕ} (A : MPSTensor d D)


### PR DESCRIPTION
### Motivation

- The hand-written `rotateCfg` equivalence in `TNLean/MPS/Periodic/Overlap/Case3Transport.lean`
  used custom `Fin.cons`/`Fin.snoc` with explicit `left_inv`/`right_inv` proofs.
  Replacing it with Mathlib's `Equiv.arrowCongr (finRotate …)` reduces bespoke code while
  preserving the mathematical content (one-site cyclic rotation of physical configurations,
  arXiv:1708.00029, Appendix A).

### Description

- Modified `TNLean/MPS/Periodic/Overlap/Case3Transport.lean`:
  - `rotateCfg` is now defined as `Equiv.arrowCongr (finRotate (L' + 1)) (Equiv.refl (Fin d))`.
  - `evalWord_ofFn_rotateCfg` is adapted: it first establishes
    `rotateCfg σ = Fin.cons (σ (Fin.last L')) (Fin.init σ)` via `finRotate_symm_apply`,
    then applies the existing `List.ofFn_cons` / `evalWord_cons` steps.
  - Public lemmas consuming `rotateCfg` (trace covariance and overlap shift) are unchanged.
  - No new `sorry` or proof-integrity workaround introduced.

### Testing

- `lake env lean TNLean/MPS/Periodic/Overlap/Case3Transport.lean`
- `lake build TNLean.MPS.Periodic.Overlap.Case3Transport -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/Periodic/Overlap/Case3Transport.lean || true`
- `lake build TNLean -q --log-level=info`

---
No issue found. If this refactor addresses an open issue, please link it manually with `Addresses #N`.

> [!NOTE]
> **Low Risk**
> Local proof refactor in Case 3 transport with no API or mathematical claim changes beyond the new definition of `rotateCfg`.
>
> **Overview**
> **`rotateCfg`** is no longer built by hand with `Fin.cons` / `Fin.snoc` and explicit `left_inv` / `right_inv` proofs. It is now **`Equiv.arrowCongr (finRotate (L' + 1)) (Equiv.refl (Fin d))`**, aligning periodic "last letter to front" rotation with Mathlib's cyclic index map.
>
> **`evalWord_ofFn_rotateCfg`** no longer unfolds the old equivalence directly. It first proves **`rotateCfg σ = Fin.cons (σ (Fin.last L')) (Fin.init σ)`** using `finRotate_symm_apply` and related `Fin` lemmas, then reuses the same `List.ofFn_cons` / `evalWord_cons` step as before.
>
> No change to the public lemmas that consume `rotateCfg` (trace covariance and overlap shift); behavior is intended to be definitionally the same with less custom equivalence code.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c777937066736701f08390b978aa3d7e3fa205ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one MPS periodic overlap file with no changes to public lemmas or mathematical statements.
> 
> **Overview**
> **`rotateCfg`** in Case 3 transport is redefined from a hand-built `Equiv` (`Fin.cons` / `Fin.snoc` plus `left_inv` / `right_inv`) to **`Equiv.arrowCongr (finRotate (L' + 1)) (Equiv.refl (Fin d))`**, so one-site “last letter to front” rotation uses Mathlib’s cyclic index map.
> 
> **`evalWord_ofFn_rotateCfg`** no longer unfolds the old equivalence; it first proves **`rotateCfg σ = Fin.cons (σ (Fin.last L')) (Fin.init σ)`** via `finRotate_symm_apply` and related `Fin` lemmas, then keeps the same `List.ofFn_cons` / `evalWord_cons` finish.
> 
> Downstream lemmas (`trace_proj_evalWord_rotateCfg`, `sum_trace_proj_overlap_shift`, sector overlap transport) are untouched and still call `rotateCfg` the same way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9964e17a150d6b39511768278e546b45786c46b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->