### PR TITLE
refactor(PEPS): use subtype equivalence for incident edges

### DIFF
--- a/TNLean/PEPS/IsoTransport.lean
+++ b/TNLean/PEPS/IsoTransport.lean
@@ -106,13 +106,14 @@ theorem Edge.map_incident (φ : G ≃g G') {v : V} {e : Edge G}
 as a bijection.  The underlying map is the edge action `Edge.map φ`; the incidence
 is preserved because `φ` sends the endpoint equal to `v` to one equal to `φ v`. -/
 def IncidentEdge.equiv (φ : G ≃g G') (v : V) :
-    IncidentEdge G v ≃ IncidentEdge G' (φ v) where
-  toFun ie := ⟨Edge.map φ ie.1, Edge.map_incident φ ie.2⟩
-  invFun ie := ⟨Edge.map φ.symm ie.1, by
-    have h := Edge.map_incident φ.symm (v := φ v) ie.2
-    simpa using h⟩
-  left_inv ie := by apply Subtype.ext; simp
-  right_inv ie := by apply Subtype.ext; simp
+    IncidentEdge G v ≃ IncidentEdge G' (φ v) :=
+  (Edge.equiv φ).subtypeEquiv fun e => by
+    constructor
+    · intro h
+      exact Edge.map_incident φ h
+    · intro h
+      have h' := Edge.map_incident φ.symm (v := φ v) h
+      simpa using h'
 
 omit [Fintype V] [Fintype W] in
 @[simp] theorem IncidentEdge.equiv_coe (φ : G ≃g G') (v : V)


### PR DESCRIPTION
### Motivation

- `IncidentEdge.equiv` was constructed by hand with explicit `toFun`/`invFun` fields and `Subtype.ext` inverse proofs, duplicating the inverse laws already encapsulated in `Edge.equiv φ`.
- The existing lemma `Edge.map_incident` already transports the incidence condition through `φ` and `φ.symm`, making the manual duplication redundant.

### Description

- Rewrites `IncidentEdge.equiv` in `TNLean/PEPS/IsoTransport.lean` as the subtype equivalence `(Edge.equiv φ).subtypeEquiv`, with incidence transported by `Edge.map_incident`.
- `IncidentEdge.equiv_coe` remains provable by `rfl`, preserving definitional compatibility with downstream PEPS transport code.
- No change to the interface or mathematical content of `IncidentEdge.equiv`.

### Testing

- `lake env lean TNLean/PEPS/IsoTransport.lean`
- `lake build TNLean.PEPS.IsoTransport -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/IsoTransport.lean || true`
- Full build reports only existing warnings outside the touched file, including the known `TNLean/MPS/Periodic/Overlap/Case3.lean` sorry.

---

> [!NOTE]
> **Low Risk**
> Local proof refactor in PEPS iso transport; no API or behavioral change beyond the new construction of the same equivalence.
> 
> **Overview**
> **`IncidentEdge.equiv`** is no longer built by hand with explicit `toFun`/`invFun` and `Subtype.ext` inverse proofs. It is now **`(Edge.equiv φ).subtypeEquiv`**, with forward and backward incidence handled only through **`Edge.map_incident`** on `φ` and `φ.symm`.
> 
> The downstream contract is unchanged: **`IncidentEdge.equiv_coe`** still holds by **`rfl`**, so PEPS transport code that depends on the equivalence keeps the same definitional behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b8eb6fdecf5691927fd2d929afde974bed5fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local proof refactor in PEPS iso transport with no API or behavioral change beyond equivalent construction of the same equivalence.
> 
> **Overview**
> **`IncidentEdge.equiv`** is refactored to build the same bijection via **`(Edge.equiv φ).subtypeEquiv`** instead of hand-written **`toFun`/`invFun`** and **`Subtype.ext`** inverse proofs. Forward and backward incidence are supplied only through **`Edge.map_incident`** on **`φ`** and **`φ.symm`**.
> 
> The public shape of the equivalence is unchanged: **`IncidentEdge.equiv_coe`** still holds by **`rfl`**, so downstream PEPS transport code keeps the same definitional behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152e62c6e5c957fdd8aab7a8db75695ebff66531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->