### PR TITLE
refactor(PEPS): use subtype product equivalence for incidence swap

### DIFF
--- a/TNLean/PEPS/EdgeScalarSolve.lean
+++ b/TNLean/PEPS/EdgeScalarSolve.lean
@@ -66,11 +66,12 @@ instance (e : Edge G) : DecidableEq (incVertex (G := G) e) := by
 /-- Swap the index of the disjoint union over incident edges from
 "vertex, then incident edge" to "edge, then incident vertex". -/
 noncomputable def sigmaSwap :
-    (Σ v : V, IncidentEdge G v) ≃ (Σ e : Edge G, incVertex (G := G) e) where
-  toFun p := ⟨p.2.1, ⟨p.1, p.2.2⟩⟩
-  invFun q := ⟨q.2.1, ⟨q.1, q.2.2⟩⟩
-  left_inv _ := rfl
-  right_inv _ := rfl
+    (Σ v : V, IncidentEdge G v) ≃ (Σ e : Edge G, incVertex (G := G) e) :=
+  ((Equiv.subtypeProdEquivSigmaSubtype
+      (fun (v : V) (e : Edge G) => e.1.1 = v ∨ e.1.2 = v)).symm.trans
+    ((Equiv.prodComm V (Edge G)).subtypeEquiv fun _ => Iff.rfl)).trans
+      (Equiv.subtypeProdEquivSigmaSubtype
+        (fun (e : Edge G) (v : V) => e.1.1 = v ∨ e.1.2 = v))
 
 omit [DecidableRel G.Adj] in
 /-- The product of the two oriented endpoint contributions of a single edge is


### PR DESCRIPTION
### Motivation

- `sigmaSwap` in `PEPS/EdgeScalarSolve.lean` was defined by explicit `toFun` / `invFun` fields with manual inverse proofs. Replacing this construction with Mathlib's `Equiv.subtypeProdEquivSigmaSubtype`, composed with `Equiv.prodComm` via `Equiv.subtypeEquiv`, reduces bespoke proof obligations and aligns the construction with the library (arXiv:1804.04964, Section 3).

### Description

- **`TNLean/PEPS/EdgeScalarSolve.lean`** (6 additions, 5 deletions): `sigmaSwap` is now built as a chain of Mathlib equivalences — `(Equiv.subtypeProdEquivSigmaSubtype).symm`, `Equiv.prodComm` transported through subtypes via `Equiv.subtypeEquiv`, and `Equiv.subtypeProdEquivSigmaSubtype` — replacing the previous explicit `toFun`/`invFun` definition with manual inverse lemmas.
- The equivalence still reindexes pairs from `(Σ v : V, IncidentEdge v)` to `(Σ e : Edge G, IncVertex e)`.
- The downstream lemma `prod_orientedIncidence_eq_one` (which applies `Equiv.prod_comp (sigmaSwap).symm`) is unchanged; the refactor is definitionally compatible.
- No mathematical content is altered.

### Testing

- `lake env lean TNLean/PEPS/EdgeScalarSolve.lean`
- `lake build TNLean.PEPS.EdgeScalarSolve -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/EdgeScalarSolve.lean || true`
- Full build (`lake build TNLean -q --log-level=info`): passes with only pre-existing warnings (including the known sorry in `MPS/Periodic/Overlap/Case3.lean`).
- Relies on Lean CI (`lean_action_ci.yml`) to validate the build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one combinatorial lemma; behavior is intended to stay definitionally compatible for the existing product-cancellation proof.
>
> **Overview**
> **`sigmaSwap`** in `EdgeScalarSolve.lean` is no longer defined by explicit `toFun` / `invFun` and `rfl` inverse lemmas. It is built as a chain of Mathlib equivalences: `Equiv.subtypeProdEquivSigmaSubtype` (sym), `Equiv.prodComm` on `V × Edge G` via `subtypeEquiv`, and another `subtypeProdEquivSigmaSubtype`.
>
> The equivalence still reindexes `(Σ v, IncidentEdge)` to `(Σ e, incVertex e)`; **`prod_orientedIncidence_eq_one`** is unchanged and still uses `Equiv.prod_comp (sigmaSwap).symm`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82754cf1627f6e0ab2709f7587803dd95e0db433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor of one combinatorial equivalence with no changes to downstream lemmas or mathematical statements.
> 
> **Overview**
> **`sigmaSwap`** in `EdgeScalarSolve.lean` is no longer built with explicit `toFun` / `invFun` and `rfl` inverse lemmas. It is now a composition of Mathlib equivalences: `Equiv.subtypeProdEquivSigmaSubtype` (sym), `Equiv.prodComm` on `V × Edge G` via `subtypeEquiv`, and another `subtypeProdEquivSigmaSubtype`.
> 
> The map still reindexes `(Σ v, IncidentEdge)` to `(Σ e, incVertex e)`. **`prod_orientedIncidence_eq_one`** is untouched and still applies `Equiv.prod_comp (sigmaSwap).symm`; the change is intended to stay definitionally compatible with that proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a10e3b64d2542781ef14b0642480c60093851573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->