### PR TITLE
refactor(PEPS/RegionBlock): use pi congruence for complement boundaries

### DIFF
--- a/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
+++ b/TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean
@@ -156,7 +156,7 @@ theorem redBundleInsertedCoeff_bondModelMatrix_eq_configSum
           (regionBoundaryLabel (G := G) A (Finset.univ \ F.frame.red) η) =
         regionBoundaryLabel (G := G) A F.frame.red η from by
       funext f
-      simp only [regionComplementBoundaryConfigEquiv, Equiv.coe_fn_symm_mk,
+      simp only [regionComplementBoundaryConfigEquiv_symm_apply,
         regionBoundaryLabel_apply, regionBoundaryEdgeComplEquiv_apply_coe]]
     by_cases hag : SameAwayFromRBBundle (G := G) A F.frame.red F.frame.blue
         (regionBoundaryLabel (G := G) A F.frame.red ζr)

--- a/TNLean/PEPS/RegionBlock/Recovery6.lean
+++ b/TNLean/PEPS/RegionBlock/Recovery6.lean
@@ -158,26 +158,24 @@ complement-side reading. -/
 configuration on `R` corresponds to one on `univ \ R` by reading each crossing edge
 under the boundary-edge identification. -/
 def regionComplementBoundaryConfigEquiv (A : Tensor G d) (R : Finset V) :
-    RegionBoundaryConfig (G := G) A R ≃ RegionBoundaryConfig (G := G) A (Finset.univ \ R) where
-  toFun := regionComplementBoundaryConfig (G := G) A R
-  invFun bdry' := fun f => bdry' (regionBoundaryEdgeComplEquiv (G := G) R f)
-  left_inv bdry := by
-    funext f
-    change regionComplementBoundaryConfig (G := G) A R bdry
-      (regionBoundaryEdgeComplEquiv (G := G) R f) = bdry f
-    rw [regionComplementBoundaryConfig]
-    congr 1
-  right_inv bdry' := by
-    funext g
-    change regionComplementBoundaryConfig (G := G) A R
-      (fun f => bdry' (regionBoundaryEdgeComplEquiv (G := G) R f)) g = bdry' g
-    rw [regionComplementBoundaryConfig]
-    congr 1
+    RegionBoundaryConfig (G := G) A R ≃ RegionBoundaryConfig (G := G) A (Finset.univ \ R) :=
+  Equiv.piCongrLeft' _ (regionBoundaryEdgeComplEquiv (G := G) R)
 
 @[simp] theorem regionComplementBoundaryConfigEquiv_apply (A : Tensor G d) (R : Finset V)
     (bdry : RegionBoundaryConfig (G := G) A R) :
     regionComplementBoundaryConfigEquiv (G := G) A R bdry =
       regionComplementBoundaryConfig (G := G) A R bdry := rfl
+
+@[simp] theorem regionComplementBoundaryConfigEquiv_symm_apply (A : Tensor G d) (R : Finset V)
+    (bdry : RegionBoundaryConfig (G := G) A (Finset.univ \ R))
+    (f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f}) :
+    ((regionComplementBoundaryConfigEquiv (G := G) A R).symm bdry) f =
+      bdry (regionBoundaryEdgeComplEquiv (G := G) R f) := by
+  change ((Equiv.piCongrLeft'
+      (fun f : {f : Edge G // IsRegionBoundaryEdge (G := G) R f} => Fin (A.bondDim f.1))
+      (regionBoundaryEdgeComplEquiv (G := G) R)).symm bdry) f =
+    bdry (regionBoundaryEdgeComplEquiv (G := G) R f)
+  rw [Equiv.piCongrLeft'_symm_apply]
 
 /-- Applying the complement boundary-configuration reindexing twice (for `R` and
 then for `univ \ R`) is the double-complement boundary-configuration transport. -/


### PR DESCRIPTION
### Motivation

- The complement-boundary configuration equivalence
  `RegionBoundaryConfig A R ≃ RegionBoundaryConfig A (Finset.univ \ R)`
  was hand-written with explicit `toFun`, `invFun`, `left_inv`, and `right_inv`
  fields, duplicating the transport structure of `Equiv.piCongrLeft'` applied to
  `regionBoundaryEdgeComplEquiv`.
- Expressing the reindexing as a native Mathlib dependent-function equivalence
  removes a redundant definitional layer and keeps the region-block recovery
  arguments in terms of standard `Equiv.piCongrLeft'` transports.

### Description

- `TNLean/PEPS/RegionBlock/Recovery6.lean`: replaces the hand-written
  complement-boundary equivalence with `Equiv.piCongrLeft'` over
  `regionBoundaryEdgeComplEquiv`; adds the inverse compatibility lemma
  `regionComplementBoundaryConfigEquiv_symm_apply`, proved from
  `Equiv.piCongrLeft'_symm_apply`.
- `TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean`: updates one downstream
  proof to use `regionComplementBoundaryConfigEquiv_symm_apply` instead of
  unfolding the old hand-written inverse.
- No new `sorry` introduced; no `@[deprecated]` alias needed (pure refactor).

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/Recovery6.lean`
- `lake env lean TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean`
- `lake build TNLean.PEPS.RegionBlock.CoarseThreeSite10 -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionBlock/Recovery6.lean TNLean/PEPS/RegionBlock/CoarseThreeSite10.lean || true` (no new sorrys)
- `lake build TNLean -q --log-level=info` (full build passes with only pre-existing warnings)

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5390fa8f2289c34c79211e0282ef988059decef9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>