### PR TITLE
refactor(PEPS/RegionBlock): use subtype equivalence for inserted vertices

### DIFF
--- a/TNLean/PEPS/RegionBlock/InsertSplit.lean
+++ b/TNLean/PEPS/RegionBlock/InsertSplit.lean
@@ -43,22 +43,23 @@ variable {G : SimpleGraph V} [DecidableRel G.Adj] {d : ℕ}
 noncomputable def insertVertexComplEquiv (R : Finset V) {v : V} (hv : v ∉ R) :
     {w : V // w ∈ R} ≃
       {w : {x : V // x ∈ insert v R} //
-        w ∈ ({⟨v, Finset.mem_insert_self v R⟩} : Finset {x : V // x ∈ insert v R})ᶜ} where
-  toFun w := ⟨⟨w.1, Finset.mem_insert_of_mem w.2⟩, by
-    simp only [Finset.mem_compl, Finset.mem_singleton]
-    intro hc
-    have : w.1 = v := congrArg Subtype.val hc
-    exact hv (this ▸ w.2)⟩
-  invFun w := ⟨w.1.1, by
-    have hne : w.1.1 ≠ v := by
-      intro hc
-      have : w.1 = ⟨v, Finset.mem_insert_self v R⟩ := Subtype.ext hc
-      exact (Finset.mem_compl.mp w.2) (Finset.mem_singleton.mpr this)
-    rcases Finset.mem_insert.mp w.1.2 with h | h
-    · exact absurd h hne
-    · exact h⟩
-  left_inv w := rfl
-  right_inv w := by ext; rfl
+        w ∈ ({⟨v, Finset.mem_insert_self v R⟩} : Finset {x : V // x ∈ insert v R})ᶜ} :=
+  (Equiv.subtypeSubtypeEquivSubtype (p := fun x : V => x ∈ insert v R)
+      (q := fun x : V => x ∈ R) (fun h => Finset.mem_insert_of_mem h)).symm.trans
+    (Equiv.subtypeEquivRight (fun w : {x : V // x ∈ insert v R} => by
+      constructor
+      · intro hw
+        simp only [Finset.mem_compl, Finset.mem_singleton]
+        intro hsingle
+        have hval : w.1 = v := congrArg Subtype.val hsingle
+        exact hv (hval ▸ hw)
+      · intro hcomp
+        have hne : w ≠ ⟨v, Finset.mem_insert_self v R⟩ := by
+          simpa only [Finset.mem_compl, Finset.mem_singleton] using hcomp
+        rcases Finset.mem_insert.mp w.2 with h | h
+        · exfalso
+          exact hne (Subtype.ext h)
+        · exact h))
 
 /-- The physical configuration on a region `R`, obtained by restricting a physical
 configuration on the inserted region `insert v R`. -/


### PR DESCRIPTION
### Motivation

- `insertVertexComplEquiv` in `TNLean.PEPS.RegionBlock.InsertSplit` previously gave explicit forward and inverse maps, proving the two inverse laws by hand.
- Composing Mathlib's `Equiv.subtypeSubtypeEquivSubtype` with `Equiv.subtypeEquivRight` expresses the same equivalence with less local proof, reducing it to a single membership iff between `R` and the complement of `{v}` in `insert v R`.

### Description

- Modified: `TNLean/PEPS/RegionBlock/InsertSplit.lean`
  - `insertVertexComplEquiv`: reimplemented by composing `Equiv.subtypeSubtypeEquivSubtype` and `Equiv.subtypeEquivRight`; the equivalence type is unchanged (vertices of `R` correspond to non-`v` vertices of `insert v R` under the hypothesis `v ∉ R`).
  - Downstream definitions `prod_region_insert_split` and callers in `InsertResidual.lean` and `ScalarExtraction.lean` are unaffected; no theorem statements are modified.

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/InsertSplit.lean`
- `lake build TNLean.PEPS.RegionBlock.InsertSplit -q --log-level=info`
- `lake build TNLean.PEPS.RegionBlock.InsertResidual -q --log-level=info`
- `lake build TNLean.PEPS.RegionBlock.ScalarExtraction -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionBlock/InsertSplit.lean || true`
- `lake build TNLean -q --log-level=info`
- Builds complete with existing repository warnings (including the pre-existing `TNLean/MPS/Periodic/Overlap/Case3.lean` sorry warning).

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one Lean definition with no API or theorem statement changes; downstream builds were validated.
>
> **Overview**
> **`insertVertexComplEquiv`** in `InsertSplit.lean` is reimplemented by composing Mathlib's `Equiv.subtypeSubtypeEquivSubtype` and `Equiv.subtypeEquivRight` instead of spelling out `toFun` / `invFun` and proving `left_inv` / `right_inv` manually.
>
> The equivalence type is unchanged: vertices of `R` still match non-`v` vertices of `insert v R` when `v ∉ R`. The only local proof is the iff between membership in `R` and lying outside the singleton inserted vertex. **`prod_region_insert_split`** and other callers still reindex through the same definition; no theorem statements or PEPS insertion logic are modified.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77e38fd93a73019394d978cc303325cea670d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor of one definition with unchanged types and theorem statements; PEPS insertion logic is unaffected.
> 
> **Overview**
> **`insertVertexComplEquiv`** in `InsertSplit.lean` is reimplemented by composing Mathlib's `Equiv.subtypeSubtypeEquivSubtype` and `Equiv.subtypeEquivRight` instead of spelling out `toFun` / `invFun` and proving `left_inv` / `right_inv` by hand.
> 
> The equivalence type is unchanged: vertices of `R` still correspond to non-`v` vertices of `insert v R` when `v ∉ R`. The only local proof is the iff between membership in `R` and lying outside the singleton inserted vertex. **`prod_region_insert_split`** and other callers still reindex through the same definition; no theorem statements or PEPS insertion logic are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832c8cfe92b86886912d8d2e4320d32bf66b61a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->