### PR TITLE
refactor(PEPS): use native product split for touching edges

### DIFF
--- a/TNLean/PEPS/RegionBlock/KernelDescent.lean
+++ b/TNLean/PEPS/RegionBlock/KernelDescent.lean
@@ -315,35 +315,16 @@ instance instFintypeExteriorConfig (A : Tensor G d) (R : Finset V) :
 /-- A global virtual configuration is the labels on the edges touching `R`
 together with the labels on the edges entirely outside `R`. -/
 noncomputable def regionTouchSplit (A : Tensor G d) (R : Finset V) :
-    VirtualConfig A ≃ TouchConfig (G := G) A R × ExteriorConfig (G := G) A R where
-  toFun ζ := (fun f => ζ f.1, fun f => ζ f.1)
-  invFun x := fun f =>
-    if h : IsTouchingEdge (G := G) R f then x.1 ⟨f, h⟩ else x.2 ⟨f, h⟩
-  left_inv ζ := by
-    funext f
-    dsimp only
-    by_cases h : IsTouchingEdge (G := G) R f
-    · rw [dif_pos h]
-    · rw [dif_neg h]
-  right_inv x := by
-    apply Prod.ext
-    · funext f
-      have h : IsTouchingEdge (G := G) R f.1 := f.2
-      dsimp only
-      rw [dif_pos h]
-    · funext f
-      have h : ¬ IsTouchingEdge (G := G) R f.1 := f.2
-      dsimp only
-      rw [dif_neg h]
+    VirtualConfig A ≃ TouchConfig (G := G) A R × ExteriorConfig (G := G) A R :=
+  Equiv.piEquivPiSubtypeProd (fun f : Edge G => IsTouchingEdge (G := G) R f)
+    (fun f => Fin (A.bondDim f))
 
 omit [Fintype V] in
 @[simp] theorem regionTouchSplit_symm_apply_touch (A : Tensor G d) (R : Finset V)
     (t : TouchConfig (G := G) A R) (x : ExteriorConfig (G := G) A R)
     (f : {f : Edge G // IsTouchingEdge (G := G) R f}) :
     (regionTouchSplit (G := G) A R).symm (t, x) f.1 = t f := by
-  have h : IsTouchingEdge (G := G) R f.1 := f.2
-  change (if hh : IsTouchingEdge (G := G) R f.1 then t ⟨f.1, hh⟩ else x ⟨f.1, hh⟩) = t f
-  rw [dif_pos h]
+  rw [regionTouchSplit, Equiv.piEquivPiSubtypeProd_symm_apply, dif_pos f.2]
 
 omit [Fintype V] in
 /-- The boundary label of a split configuration depends only on the touching


### PR DESCRIPTION
### Motivation

- `regionTouchSplit` in `TNLean/PEPS/RegionBlock/KernelDescent.lean` splits a global virtual configuration into touching-edge labels and exterior-edge labels via the decidable predicate `IsTouchingEdge R`.
- The previous definition carried explicit `toFun`/`invFun` fields with hand-written `left_inv` and `right_inv` proofs by cases on `IsTouchingEdge`. Mathlib's `Equiv.piEquivPiSubtypeProd` provides the same splitting for any decidable predicate on the index type, making the custom construction unnecessary.

### Description

- `TNLean/PEPS/RegionBlock/KernelDescent.lean` modified (4 additions, 23 deletions).
- `regionTouchSplit` is now defined as `Equiv.piEquivPiSubtypeProd (fun f : Edge G => IsTouchingEdge R f) (fun f => Fin (A.bondDim f))`, replacing the explicit equivalence with manual inversion proofs.
- The statement of the public `@[simp]` lemma `regionTouchSplit_symm_apply_touch` is unchanged; its proof is shortened using `Equiv.piEquivPiSubtypeProd_symm_apply` and `dif_pos`.
- No mathematical statements change; downstream kernel-descent arguments summing over this split are unaffected.

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/KernelDescent.lean`
- `lake build TNLean.PEPS.RegionBlock.KernelDescent -q --log-level=info`
- `lake build TNLean.PEPS.RegionBlock.ScalarExtraction -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/RegionBlock/KernelDescent.lean || true`
- `lake build TNLean -q --log-level=info`
- Relies on Lean CI (`lean_action_ci.yml`) for full validation.

---
*(No linked issue found — no `Closes`/`Fixes`/`Refs` reference in the branch name, commit messages, or PR body. The author may wish to link one manually.)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no change to definitions or lemmas used by kernel descent; same pattern already appears in `CycleMPSInjectivity.lean`.
> 
> **Overview**
> **`regionTouchSplit`** in `KernelDescent.lean` is now **`Equiv.piEquivPiSubtypeProd`** on `IsTouchingEdge` and bond indices, instead of a hand-built `toFun`/`invFun` with case-split inversion proofs.
> 
> The public **`@[simp]`** lemma **`regionTouchSplit_symm_apply_touch`** is unchanged; its proof uses **`Equiv.piEquivPiSubtypeProd_symm_apply`**. No downstream kernel-descent statements change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e856b6082b59f5857ad19ebe2149186b6ece017. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->