### PR TITLE
refactor(PEPS): use native incident-edge product split

### DIFF
--- a/TNLean/PEPS/VertexComplement/KernelDescent.lean
+++ b/TNLean/PEPS/VertexComplement/KernelDescent.lean
@@ -49,30 +49,9 @@ on the edges not incident to `j`. -/
 noncomputable def vertexConfigSplitAt (A : Tensor G d) (j : V) :
     VirtualConfig A ≃
       LocalVirtualConfig A j ×
-        ((f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1)) where
-  toFun ζ :=
-    (fun ie : IncidentEdge G j => ζ ie.1, fun f => ζ f.1)
-  invFun x := fun f =>
-    if h : IsIncidentEdge (G := G) j f then
-      x.1 ⟨f, h⟩
-    else
-      x.2 ⟨f, h⟩
-  left_inv ζ := by
-    funext f
-    dsimp only
-    by_cases h : IsIncidentEdge (G := G) j f
-    · rw [dif_pos h]
-    · rw [dif_neg h]
-  right_inv x := by
-    apply Prod.ext
-    · funext ie
-      have h : IsIncidentEdge (G := G) j ie.1 := ie.2
-      dsimp only
-      rw [dif_pos h]
-    · funext f
-      have h : ¬ IsIncidentEdge (G := G) j f.1 := f.2
-      dsimp only
-      rw [dif_neg h]
+        ((f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1)) :=
+  Equiv.piEquivPiSubtypeProd (fun f : Edge G => IsIncidentEdge (G := G) j f)
+    (fun f => Fin (A.bondDim f))
 
 omit [Fintype V] in
 @[simp] theorem vertexConfigSplitAt_fst (A : Tensor G d) (j : V) (ζ : VirtualConfig A)
@@ -85,10 +64,8 @@ omit [Fintype V] in
     (r : (f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1))
     (ie : IncidentEdge G j) :
     (vertexConfigSplitAt (G := G) A j).symm (η, r) ie.1 = η ie := by
-  have h : IsIncidentEdge (G := G) j ie.1 := ie.2
-  change (if hh : IsIncidentEdge (G := G) j ie.1 then η ⟨ie.1, hh⟩ else r ⟨ie.1, hh⟩) =
-    η ie
-  rw [dif_pos h]
+  unfold vertexConfigSplitAt IsIncidentEdge
+  rw [Equiv.piEquivPiSubtypeProd_symm_apply, dif_pos ie.2]
 
 /-! ### Kernel condition -/
 


### PR DESCRIPTION
### Motivation

- `vertexConfigSplitAt` had a hand-written `toFun` / `invFun` / inverse-proof layer that duplicated the functionality of `Equiv.piEquivPiSubtypeProd` from Mathlib.
- Delegating to the standard Mathlib equivalence removes the manual proof obligation and makes the construction easier to audit.

### Description

- Modified: `TNLean/PEPS/VertexComplement/KernelDescent.lean`
- `vertexConfigSplitAt` is now defined via `Equiv.piEquivPiSubtypeProd`, which splits a global PEPS virtual configuration at a vertex into incident-edge labels and non-incident-edge labels.
- The `@[simp]` lemmas `vertexConfigSplitAt_fst` and `vertexConfigSplitAt_symm_apply_incident` are preserved; the inverse incident-edge projection is proved from `piEquivPiSubtypeProd_symm_apply` after unfolding `IsIncidentEdge`.
- No mathematical statement is changed.

### Testing

- `lake env lean TNLean/PEPS/VertexComplement/KernelDescent.lean`
- `lake build TNLean.PEPS.VertexComplement.KernelDescent -q --log-level=info`
- `lake build TNLean.PEPS.RegionBlock.KernelDescent -q --log-level=info`
- `lake build TNLean.PEPS.RegionBlock.ScalarExtraction -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/VertexComplement/KernelDescent.lean || true`

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof-only refactor in Lean with no runtime or API change; behavior is delegated to a standard Mathlib equivalence.
> 
> **Overview**
> **`vertexConfigSplitAt`** in `KernelDescent.lean` no longer defines a custom `toFun` / `invFun` with manual `left_inv` / `right_inv` proofs. It is now a one-liner via **`Equiv.piEquivPiSubtypeProd`**, splitting a global PEPS virtual configuration at complement vertex `j` into incident-edge labels (`LocalVirtualConfig`) and non-incident-edge bond indices.
> 
> The existing **`@[simp]`** lemmas **`vertexConfigSplitAt_fst`** and **`vertexConfigSplitAt_symm_apply_incident`** stay; the latter’s proof is shortened to unfold and apply **`piEquivPiSubtypeProd_symm_apply`** instead of a case split on **`IsIncidentEdge`**.
> 
> No change to the equivalence’s type or to downstream kernel-descent arguments that depend on this split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d1d2ff16f2f8cac5d909e9e69f0b6f80c897ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->