### PR TITLE
refactor(Channel/Schwarz): use native Bool split for Fin two

### DIFF
--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -66,28 +66,16 @@ open Matrix Finset
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
 private noncomputable def finTwoSumEquiv (α : Type*) : α × Fin 2 ≃ α ⊕ α :=
-  (((Equiv.prodCongr (Equiv.refl α)
-      ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm)).trans
-    (Equiv.prodSumDistrib α (Fin 1) (Fin 1))).trans
-    (Equiv.sumCongr (Equiv.prodUnique α (Fin 1)) (Equiv.prodUnique α (Fin 1))))
+  ((Equiv.prodCongr (Equiv.refl α) finTwoEquiv).trans (Equiv.prodComm α Bool)).trans
+    (Equiv.boolProdEquivSum α)
 
 @[simp] private theorem finTwoSumEquiv_apply_zero {α : Type*} (a : α) :
     finTwoSumEquiv α (a, 0) = Sum.inl a := by
-  change Sum.map Prod.fst Prod.fst
-      ((Equiv.prodSumDistrib α (Fin 1) (Fin 1))
-        (a, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 0))) = Sum.inl a
-  rw [show (0 : Fin 2) = Fin.castSucc (0 : Fin 1) by rfl]
-  rw [finSumFinEquiv_symm_apply_castSucc]
-  simp
+  simp [finTwoSumEquiv, finTwoEquiv]
 
 @[simp] private theorem finTwoSumEquiv_apply_one {α : Type*} (a : α) :
     finTwoSumEquiv α (a, 1) = Sum.inr a := by
-  change Sum.map Prod.fst Prod.fst
-      ((Equiv.prodSumDistrib α (Fin 1) (Fin 1))
-        (a, ((finSumFinEquiv : Fin 1 ⊕ Fin 1 ≃ Fin 2).symm 1))) = Sum.inr a
-  rw [show (1 : Fin 2) = Fin.last 1 by rfl]
-  rw [finSumFinEquiv_symm_last]
-  simp
+  simp [finTwoSumEquiv, finTwoEquiv]
 
 @[simp] private theorem finTwoSumEquiv_symm_inl {α : Type*} (a : α) :
     (finTwoSumEquiv α).symm (Sum.inl a) = (a, 0) := by


### PR DESCRIPTION
### Motivation

- The private equivalence `finTwoSumEquiv : α × Fin 2 ≃ α ⊕ α` in `TwoPositive.lean` was constructed by routing through `Fin 1 ⊕ Fin 1` and then eliminating two singleton factors, which is more indirect than necessary.
- Mathlib provides `finTwoEquiv : Fin 2 ≃ Bool`, `Equiv.prodComm`, and `Equiv.boolProdEquivSum` that compose to the same endpoint directly.
- Simplifying this private helper reduces proof complexity without altering any mathematical statement or public API.

### Description

- Modified `TNLean/Channel/Schwarz/TwoPositive.lean`: rewrote the private equivalence `finTwoSumEquiv` using Mathlib's `finTwoEquiv`, `Equiv.prodComm`, and `Equiv.boolProdEquivSum` instead of the detour through `Fin 1 ⊕ Fin 1`.
- The `apply_zero` and `apply_one` simp lemmas now reduce directly by `simp [finTwoSumEquiv, finTwoEquiv]`.
- No mathematical statement is changed; the block-matrix positivity arguments retain the same local name and endpoint behaviour.

### Testing

- `lake env lean TNLean/Channel/Schwarz/TwoPositive.lean`
- `lake build TNLean.Channel.Schwarz.TwoPositive -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/Channel/Schwarz/TwoPositive.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Module build reported only pre-existing short-copyright header warnings in the imported Schwarz files.

---
No linked issue identified — this is a self-contained internal refactor.

> [!NOTE]
> **Low Risk**
> Localized proof refactor in a private helper with preserved endpoint simp lemmas; no API or mathematical claims altered.
> 
> **Overview**
> **Refactors** the private equivalence `finTwoSumEquiv : α × Fin 2 ≃ α ⊕ α` so it is built from Mathlib's `finTwoEquiv`, `Equiv.prodComm`, and `Equiv.boolProdEquivSum`, instead of routing through `Fin 1 ⊕ Fin 1` and singleton-factor eliminations.
> 
> The `apply_zero` / `apply_one` simp lemmas are shortened to `simp [finTwoSumEquiv, finTwoEquiv]`; the symmetric `inl` / `inr` lemmas are unchanged in behavior. **No downstream theorem statements or uses of `finTwoSumEquiv` change**—only the internal construction and proof scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906d4ea5b67ddc35721a91f6b808c4f149040897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>