### PR TITLE
refactor(Channel/Determinant): use native Matrix.vec

### DIFF
--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -41,13 +41,6 @@ open ChannelDeterminant.Internal
 
 variable {d : ℕ}
 
-/-- Column-stacking vectorization as a linear equivalence. -/
-private noncomputable def matrixVecLinearEquiv (d : ℕ) :
-    MatrixAlg d ≃ₗ[ℂ] (Fin d × Fin d → ℂ) :=
-  (Matrix.ofLinearEquiv ℂ).symm.trans
-    ((LinearEquiv.curry ℂ ℂ (Fin d) (Fin d)).symm.trans
-      (LinearEquiv.funCongrLeft ℂ ℂ (Equiv.prodComm (Fin d) (Fin d))))
-
 section WolfStatements
 
 variable {T : MatrixEnd d}
@@ -276,7 +269,12 @@ private theorem forward_det_one_implies_unitaryChannel [NeZero d]
 /-- The determinant of a unitary channel equals `1`. -/
 theorem channelDet_unitary_eq_one (U : Matrix.unitaryGroup (Fin d) ℂ) :
     channelDet (unitaryChannel U) = 1 := by
-  let e : MatrixAlg d ≃ₗ[ℂ] (Fin d × Fin d → ℂ) := matrixVecLinearEquiv d
+  let e : MatrixAlg d ≃ₗ[ℂ] (Fin d × Fin d → ℂ) :=
+    LinearEquiv.ofBijective
+      { toFun := Matrix.vec
+        map_add' := Matrix.vec_add
+        map_smul' := Matrix.vec_smul }
+      Matrix.vec_bijective
   let M : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
     ((U : MatrixAlg d).map star) ⊗ₖ (U : MatrixAlg d)
   have hvec : ∀ X : MatrixAlg d,


### PR DESCRIPTION
### Motivation

- The private helper `matrixVecLinearEquiv` in `TNLean/Channel/Determinant/UnitaryCharacterization.lean` built column-stacking vectorization by manually composing `Matrix.ofLinearEquiv`, `LinearEquiv.curry`, and a product-coordinate swap, adding bespoke boilerplate beyond what Mathlib provides natively.
- Mathlib's `Matrix.vec` API supplies the same equivalence directly via `Matrix.vec_bijective`, `Matrix.vec_add`, and `Matrix.vec_smul`, without the manual composition.
- No linked issue — this is a self-contained internal refactor in the native-Mathlib-API cleanup series.

### Description

- Modified `TNLean/Channel/Determinant/UnitaryCharacterization.lean`: deleted the private helper `matrixVecLinearEquiv`.
- In `channelDet_unitary_eq_one`, the linear equivalence is now defined at the single use site via `LinearEquiv.ofBijective` on `Matrix.vec`, using `Matrix.vec_add`, `Matrix.vec_smul`, and `Matrix.vec_bijective`.
- No mathematical statement is changed; the determinant computation still uses column-stacking vectorization and the same Kronecker-product identity for unitary conjugation.

### Testing

- `lake env lean TNLean/Channel/Determinant/UnitaryCharacterization.lean`
- `lake build TNLean.Channel.Determinant.UnitaryCharacterization -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/Channel/Determinant/UnitaryCharacterization.lean`
- Module build reported only pre-existing style/header and dependency warnings from imported files.

---

No linked issue — this is a self-contained internal refactor.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single theorem with no API or behavioral changes beyond Lean proof structure.
> 
> **Overview**
> **Refactors** how column-stacking vectorization is packaged in the unitary-channel determinant proof, without changing the mathematics.
> 
> The private helper `matrixVecLinearEquiv` (built from `Matrix.ofLinearEquiv`, `LinearEquiv.curry`, and a coordinate swap) is **deleted**. In `channelDet_unitary_eq_one`, the proof now defines the linear equivalence `e` at the use site with `LinearEquiv.ofBijective` on `Matrix.vec`, using `Matrix.vec_add`, `Matrix.vec_smul`, and `Matrix.vec_bijective`.
> 
> The rest of the argument—the Kronecker identity, conjugation of `LinearMap.det`, and unitary determinant—is unchanged; only the vectorization API wiring is simplified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f89630ae4c3b804ddcdfe1f29f21c1a6a7416a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>