### PR TITLE
refactor(MPS/CanonicalForm): inline GL vector equivalence

### DIFF
--- a/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
+++ b/TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean
@@ -99,10 +99,6 @@ structure PGVWC07PositiveLengthWitness (A : MPSTensor d D) where
   original bond dimension. -/
   bondDim_le : ∑ k : Fin r, dim k ≤ D
 
-private noncomputable def gaugeMulVecLinearEquiv {D : ℕ} (X : GL (Fin D) ℂ) :
-    (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) :=
-  (Matrix.GeneralLinearGroup.toLin X).toLinearEquiv
-
 private theorem isIrreducibleAction_gaugeEquiv
     {D : ℕ} {A B : MPSTensor d D}
     (hGauge : GaugeEquiv (d := d) (D := D) A B)
@@ -110,7 +106,8 @@ private theorem isIrreducibleAction_gaugeEquiv
     IsIrreducibleAction (d := d) (D := D) B := by
   classical
   rcases hGauge with ⟨X, hX⟩
-  let T : (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) := gaugeMulVecLinearEquiv X
+  let T : (Fin D → ℂ) ≃ₗ[ℂ] (Fin D → ℂ) :=
+    (Matrix.GeneralLinearGroup.toLin X).toLinearEquiv
   intro W hW
   let W' : Submodule ℂ (Fin D → ℂ) := W.map T.symm.toLinearMap
   have hW' : IsInvariantSubmodule (d := d) (D := D) A W' := by


### PR DESCRIPTION
### Motivation

- The private auxiliary definition `gaugeMulVecLinearEquiv` in `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean` was solely a local alias for the Mathlib linear equivalence `(Matrix.GeneralLinearGroup.toLin X).toLinearEquiv`, with a single call site.
- Removing the local alias reduces the surface of private definitions and makes the proof refer directly to Mathlib's linear equivalence.

### Description

- `TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`: removed the private `gaugeMulVecLinearEquiv` definition; the single call site in `isIrreducibleAction_gaugeEquiv` now refers directly to `(Matrix.GeneralLinearGroup.toLin X).toLinearEquiv`.
- No mathematical statements are changed; the invariant-subspace transport argument still uses the same invertible bond-space linear equivalence.

### Testing

- `lake env lean TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- `lake build TNLean.MPS.CanonicalForm.NormalReduction.TPGauge -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/MPS/CanonicalForm/NormalReduction/TPGauge.lean`
- Module build reported only pre-existing style/header and dependency warnings from imported files.

---
<!-- No linked issue identified; author should link one manually. -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single private lemma; no API, semantics, or security-sensitive behavior changes.
>
> **Overview**
> Removes the private helper `gaugeMulVecLinearEquiv` from `TPGauge.lean` and uses Mathlib's `(Matrix.GeneralLinearGroup.toLin X).toLinearEquiv` directly in `isIrreducibleAction_gaugeEquiv`.
>
> **No change to statements or proof strategy** — irreducible action is still transported across gauge equivalence by mapping invariant submodules through the same invertible bond-space linear equivalence.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0138ec08bf41e216cac852232c0bf365f314f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>