### PR TITLE
refactor(PEPS): use native predicate splits

### DIFF
--- a/TNLean/PEPS/EdgeMiddlePhysical/KernelDescent.lean
+++ b/TNLean/PEPS/EdgeMiddlePhysical/KernelDescent.lean
@@ -25,48 +25,57 @@ private def middleIncidentToComplement (e : Edge G) {j : V}
     {f : Edge G // f ≠ e} :=
   ⟨ie.1, edge_ne_of_middle_incident_for_physical (G := G) e hj ie⟩
 
+/-- Complement edges incident to a middle vertex are the incident edges at that vertex. -/
+private def incidentComplementEquiv (e : Edge G) {j : V} (hj : j ∈ edgeMiddleVertices e) :
+    {f : {f : Edge G // f ≠ e} // IsIncidentTo (G := G) e j f} ≃ IncidentEdge G j where
+  toFun f := ⟨f.1.1, f.2⟩
+  invFun ie := ⟨middleIncidentToComplement (G := G) e hj ie, ie.2⟩
+  left_inv f := by
+    apply Subtype.ext
+    apply Subtype.ext
+    rfl
+  right_inv ie := by
+    apply Subtype.ext
+    rfl
+
 /-- The star-bond split equivalence at a middle vertex `j`. -/
 noncomputable def edgeComplementConfigSplitAt (A : Tensor G d) (e : Edge G) {j : V}
     (hj : j ∈ edgeMiddleVertices e) :
     EdgeComplementConfig (G := G) A e ≃
       LocalVirtualConfig A j ×
         ((f : {f : {f : Edge G // f ≠ e} // ¬ IsIncidentTo (G := G) e j f}) →
-          Fin (A.bondDim f.1.1)) where
-  toFun ζ :=
-    (fun ie : IncidentEdge G j =>
-        ζ (middleIncidentToComplement (G := G) e hj ie),
-      fun f => ζ f.1)
-  invFun x := fun f =>
-    if h : IsIncidentTo (G := G) e j f then
-      x.1 ⟨f.1, h⟩
-    else
-      x.2 ⟨f, h⟩
-  left_inv ζ := by
-    funext f
-    dsimp only
-    by_cases h : IsIncidentTo (G := G) e j f
-    · rw [dif_pos h]
-      rfl
-    · rw [dif_neg h]
-  right_inv x := by
-    apply Prod.ext
-    · funext ie
-      have h : IsIncidentTo (G := G) e j (middleIncidentToComplement (G := G) e hj ie) :=
-        ie.2
-      dsimp only
-      rw [dif_pos h]
-      rfl
-    · funext f
-      have h : ¬ IsIncidentTo (G := G) e j f.1 := f.2
-      dsimp only
-      rw [dif_neg h]
+          Fin (A.bondDim f.1.1)) :=
+  (Equiv.piEquivPiSubtypeProd
+      (fun f : {f : Edge G // f ≠ e} => IsIncidentTo (G := G) e j f)
+      (fun f => Fin (A.bondDim f.1))).trans
+    (Equiv.prodCongr
+      (Equiv.piCongrLeft
+        (fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+        (incidentComplementEquiv (G := G) e hj))
+      (Equiv.refl _))
 
 @[simp] theorem edgeComplementConfigSplitAt_fst (A : Tensor G d) (e : Edge G) {j : V}
     (hj : j ∈ edgeMiddleVertices e) (ζ : EdgeComplementConfig (G := G) A e)
     (ie : IncidentEdge G j) :
     (edgeComplementConfigSplitAt (G := G) A e hj ζ).1 ie =
       edgeComplementValue (G := G) A e ζ hj ie :=
-  rfl
+  by
+    let a : {f : {f : Edge G // f ≠ e} // IsIncidentTo (G := G) e j f} :=
+      ⟨middleIncidentToComplement (G := G) e hj ie, ie.2⟩
+    have hieq : (incidentComplementEquiv (G := G) e hj) a = ie := by
+      apply Subtype.ext
+      rfl
+    change
+      (Equiv.piCongrLeft
+        (fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+        (incidentComplementEquiv (G := G) e hj)) (fun x => ζ x.1) ie =
+        ζ (middleIncidentToComplement (G := G) e hj ie)
+    rw [← hieq]
+    exact Equiv.piCongrLeft_apply_apply
+      (P := fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+      (e := incidentComplementEquiv (G := G) e hj)
+      (f := fun x => ζ x.1)
+      (a := a)
 
 @[simp] theorem edgeComplementValue_edgeComplementConfigSplitAt_symm
     (A : Tensor G d) (e : Edge G) {j : V} (hj : j ∈ edgeMiddleVertices e)
@@ -76,14 +85,29 @@ noncomputable def edgeComplementConfigSplitAt (A : Tensor G d) (e : Edge G) {j :
     (ie : IncidentEdge G j) :
     edgeComplementValue (G := G) A e
         ((edgeComplementConfigSplitAt (G := G) A e hj).symm (η, r)) hj ie = η ie := by
-  have h : IsIncidentTo (G := G) e j (middleIncidentToComplement (G := G) e hj ie) :=
-    ie.2
   change (edgeComplementConfigSplitAt (G := G) A e hj).symm (η, r)
       (middleIncidentToComplement (G := G) e hj ie) = η ie
   rw [edgeComplementConfigSplitAt]
-  dsimp only [Equiv.coe_fn_symm_mk]
-  rw [dif_pos h]
-  rfl
+  change (if h : IsIncidentTo (G := G) e j (middleIncidentToComplement (G := G) e hj ie)
+    then
+      (Equiv.piCongrLeft
+        (fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+        (incidentComplementEquiv (G := G) e hj)).symm η
+          ⟨middleIncidentToComplement (G := G) e hj ie, h⟩
+    else r ⟨middleIncidentToComplement (G := G) e hj ie, h⟩) = η ie
+  rw [dif_pos (show IsIncidentTo (G := G) e j
+    (middleIncidentToComplement (G := G) e hj ie) from ie.2)]
+  have hsymm := Equiv.piCongrLeft_symm_apply
+    (P := fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+    (e := incidentComplementEquiv (G := G) e hj)
+    (g := η)
+    (a := ⟨middleIncidentToComplement (G := G) e hj ie, ie.2⟩)
+  have hηeq :
+      η ((incidentComplementEquiv (G := G) e hj)
+        ⟨middleIncidentToComplement (G := G) e hj ie, ie.2⟩) = η ie := by
+    cases ie
+    rfl
+  exact hsymm.trans hηeq
 
 /-! ### Kernel-descent construction for the middle block -/
 
@@ -203,8 +227,28 @@ theorem extraIndicator_split (S : Finset V) {j : V}
     intro f hinc
     have hIs : IsIncidentTo (G := G) e j f := hinc
     rw [edgeComplementConfigSplitAt]
-    dsimp only [Equiv.coe_fn_symm_mk]
+    change (if h : IsIncidentTo (G := G) e j f then
+      (Equiv.piCongrLeft
+        (fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+        (incidentComplementEquiv (G := G) e hj)).symm η ⟨f, h⟩
+    else r ⟨f, h⟩) = η ⟨f.1, hinc⟩
     rw [dif_pos hIs]
+    have hieq :
+        (incidentComplementEquiv (G := G) e hj) ⟨f, hIs⟩ =
+          (⟨f.1, hinc⟩ : IncidentEdge G j) := by
+      apply Subtype.ext
+      rfl
+    have hsymm := Equiv.piCongrLeft_symm_apply
+      (P := fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+      (e := incidentComplementEquiv (G := G) e hj)
+      (g := η)
+      (a := ⟨f, hIs⟩)
+    have hηeq :
+        η ((incidentComplementEquiv (G := G) e hj) ⟨f, hIs⟩) =
+          η (⟨f.1, hinc⟩ : IncidentEdge G j) := by
+      cases hieq
+      rfl
+    exact hsymm.trans hηeq
   congr 1
   apply propext
   constructor

--- a/TNLean/PEPS/VertexComplement/KernelDescent.lean
+++ b/TNLean/PEPS/VertexComplement/KernelDescent.lean
@@ -43,41 +43,52 @@ incident to `j`. -/
 theorem isIncidentEdge_of_incident (j : V) (ie : IncidentEdge G j) :
     IsIncidentEdge (G := G) j ie.1 := ie.2
 
+/-- Edges incident to `j`, as a subtype, are the incident edges at `j`. -/
+private def incidentEdgeEquiv (j : V) :
+    {f : Edge G // IsIncidentEdge (G := G) j f} ≃ IncidentEdge G j where
+  toFun f := ⟨f.1, f.2⟩
+  invFun ie := ⟨ie.1, ie.2⟩
+  left_inv f := by
+    apply Subtype.ext
+    rfl
+  right_inv ie := by
+    apply Subtype.ext
+    rfl
+
 /-- The split equivalence at a complement vertex `j`: a global virtual
 configuration is the local configuration at `j` together with the configuration
 on the edges not incident to `j`. -/
 noncomputable def vertexConfigSplitAt (A : Tensor G d) (j : V) :
     VirtualConfig A ≃
       LocalVirtualConfig A j ×
-        ((f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1)) where
-  toFun ζ :=
-    (fun ie : IncidentEdge G j => ζ ie.1, fun f => ζ f.1)
-  invFun x := fun f =>
-    if h : IsIncidentEdge (G := G) j f then
-      x.1 ⟨f, h⟩
-    else
-      x.2 ⟨f, h⟩
-  left_inv ζ := by
-    funext f
-    dsimp only
-    by_cases h : IsIncidentEdge (G := G) j f
-    · rw [dif_pos h]
-    · rw [dif_neg h]
-  right_inv x := by
-    apply Prod.ext
-    · funext ie
-      have h : IsIncidentEdge (G := G) j ie.1 := ie.2
-      dsimp only
-      rw [dif_pos h]
-    · funext f
-      have h : ¬ IsIncidentEdge (G := G) j f.1 := f.2
-      dsimp only
-      rw [dif_neg h]
+        ((f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1)) :=
+  (Equiv.piEquivPiSubtypeProd
+      (fun f : Edge G => IsIncidentEdge (G := G) j f)
+      (fun f => Fin (A.bondDim f))).trans
+    (Equiv.prodCongr
+      (Equiv.piCongrLeft
+        (fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+        (incidentEdgeEquiv (G := G) j))
+      (Equiv.refl _))
 
 omit [Fintype V] in
 @[simp] theorem vertexConfigSplitAt_fst (A : Tensor G d) (j : V) (ζ : VirtualConfig A)
     (ie : IncidentEdge G j) :
-    (vertexConfigSplitAt (G := G) A j ζ).1 ie = ζ ie.1 := rfl
+    (vertexConfigSplitAt (G := G) A j ζ).1 ie = ζ ie.1 := by
+  let a : {f : Edge G // IsIncidentEdge (G := G) j f} := ⟨ie.1, ie.2⟩
+  have hieq : (incidentEdgeEquiv (G := G) j) a = ie := by
+    apply Subtype.ext
+    rfl
+  change
+    (Equiv.piCongrLeft
+      (fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+      (incidentEdgeEquiv (G := G) j)) (fun x => ζ x.1) ie = ζ ie.1
+  rw [← hieq]
+  exact Equiv.piCongrLeft_apply_apply
+    (P := fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+    (e := incidentEdgeEquiv (G := G) j)
+    (f := fun x => ζ x.1)
+    (a := a)
 
 omit [Fintype V] in
 @[simp] theorem vertexConfigSplitAt_symm_apply_incident (A : Tensor G d) (j : V)
@@ -85,10 +96,22 @@ omit [Fintype V] in
     (r : (f : {f : Edge G // ¬ IsIncidentEdge (G := G) j f}) → Fin (A.bondDim f.1))
     (ie : IncidentEdge G j) :
     (vertexConfigSplitAt (G := G) A j).symm (η, r) ie.1 = η ie := by
-  have h : IsIncidentEdge (G := G) j ie.1 := ie.2
-  change (if hh : IsIncidentEdge (G := G) j ie.1 then η ⟨ie.1, hh⟩ else r ⟨ie.1, hh⟩) =
-    η ie
-  rw [dif_pos h]
+  rw [vertexConfigSplitAt]
+  change (if h : IsIncidentEdge (G := G) j ie.1 then
+    (Equiv.piCongrLeft
+      (fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+      (incidentEdgeEquiv (G := G) j)).symm η ⟨ie.1, h⟩
+  else r ⟨ie.1, h⟩) = η ie
+  rw [dif_pos (show IsIncidentEdge (G := G) j ie.1 from ie.2)]
+  have hsymm := Equiv.piCongrLeft_symm_apply
+    (P := fun ie : IncidentEdge G j => Fin (A.bondDim ie.1))
+    (e := incidentEdgeEquiv (G := G) j)
+    (g := η)
+    (a := ⟨ie.1, ie.2⟩)
+  have hηeq : η ((incidentEdgeEquiv (G := G) j) ⟨ie.1, ie.2⟩) = η ie := by
+    cases ie
+    rfl
+  exact hsymm.trans hηeq
 
 /-! ### Kernel condition -/
 


### PR DESCRIPTION
### Motivation

- The two hand-written finite configuration splits `vertexConfigSplitAt` and
  `edgeComplementConfigSplitAt` in the PEPS kernel-descent files duplicate
  functionality already available in Mathlib via `Equiv.piEquivPiSubtypeProd`.
- Removing the project-specific infrastructure reduces maintenance burden and
  aligns the PEPS split machinery with the rest of the Mathlib 4.31 upgrade
  pass (`codex/mathlib-4-31-native-pass-8`).
- No mathematical declarations or blueprint statements are changed by this
  refactor; the mathematical interface presented to downstream proofs is
  preserved through the kept public `simp` lemmas.

### Description

- `TNLean/PEPS/VertexComplement/KernelDescent.lean`: replaces
  `vertexConfigSplitAt` — the decomposition of a global virtual configuration
  into edge labels incident to a vertex and the complementary edges — with
  `Equiv.piEquivPiSubtypeProd` composed with `Equiv.piCongrLeft`, bridged by a
  small private graph-specific equivalence from the incident-edge subtype to
  `IncidentEdge`.
- `TNLean/PEPS/EdgeMiddlePhysical/KernelDescent.lean`: replaces
  `edgeComplementConfigSplitAt` — the decomposition of the complement of a
  distinguished edge into the star at a middle vertex and the remaining
  complement edges — using the same Mathlib equivalence machinery.
- Public `simp` lemmas are kept; no blueprint labels, mathematical declarations,
  or theorem statements are affected.

### Testing

- `lake env lean TNLean/PEPS/VertexComplement/KernelDescent.lean`
- `lake env lean TNLean/PEPS/EdgeMiddlePhysical/KernelDescent.lean`
- `lake env lean TNLean/PEPS/RegionBlock/KernelDescent.lean`
- `lake env lean TNLean/PEPS/EdgeMiddlePhysical.lean`
- `lake env lean TNLean/PEPS/RegionBlock/Recovery3.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem/OneVertexComparison.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem.lean`
- `lake build TNLean.PEPS.VertexComplement.KernelDescent TNLean.PEPS.EdgeMiddlePhysical.KernelDescent -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/PEPS/VertexComplement/KernelDescent.lean TNLean/PEPS/EdgeMiddlePhysical/KernelDescent.lean || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lake build reports only pre-existing short-header style warnings in imported PEPS files.

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 03cce7ec0ff1827dac3f6c1780866546a8f2d526. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>