### PR TITLE
refactor(Channel/Peripheral): use native fin rotation

### DIFF
--- a/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
+++ b/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Peripheral.Cycles
+import Mathlib.Logic.Equiv.Fin.Rotate
 
 /-!
 # Multi-cycle block-permutation decompositions
@@ -285,15 +286,12 @@ def totalProj (M : MultiCycleDecomposition T) : M.Idx → MatrixAlg D :=
 `Equiv.Perm.sigmaCongrRight`. -/
 noncomputable def totalPerm (M : MultiCycleDecomposition T) :
     Equiv.Perm M.Idx :=
-  Equiv.Perm.sigmaCongrRight (fun c : M.ι =>
-    { toFun := fun k => k + 1
-      invFun := fun k => k - 1
-      left_inv := by intro k; simp
-      right_inv := by intro k; simp })
+  Equiv.Perm.sigmaCongrRight (fun c : M.ι => finRotate (M.period c))
 
 @[simp]
 lemma totalPerm_apply (M : MultiCycleDecomposition T) (x : M.Idx) :
-    M.totalPerm x = ⟨x.1, x.2 + 1⟩ := rfl
+    M.totalPerm x = ⟨x.1, x.2 + 1⟩ := by
+  simp [totalPerm, finRotate_apply]
 
 /-- **Flattening construction.**  A multi-cycle decomposition gives a
 `CycleStructure` on the total block-index type
@@ -317,7 +315,7 @@ noncomputable def toCycleStructure (M : MultiCycleDecomposition T) :
       exact M.isProj c k)
     (by
       rintro ⟨c, k⟩
-      change T (M.P c (k + 1)) = M.P c k
+      rw [M.totalPerm_apply ⟨c, k⟩]
       exact M.cyclic c k)
     (by
       rintro ⟨c, k⟩ X


### PR DESCRIPTION
### Motivation

- The hand-written cyclic permutation in `MultiCycleDecomposition.totalPerm` duplicated logic already present in Mathlib as `finRotate`.
- Delegating to Mathlib's native finite rotation equivalence removes the local spelling of the inverse and inverse laws.

### Description

- Modified `TNLean/Channel/Peripheral/MultiCycleDecomposition.lean`: replaced the per-cycle shift `k ↦ k + 1` construction with Mathlib's `finRotate` permutation.
- The flattened multi-cycle permutation remains the sigma-product of per-cycle shifts; the public lemma `totalPerm_apply` keeps that computational description.
- No theorem statements, blueprint references, or mathematical content are changed.

### Testing

- `lake env lean TNLean/Channel/Peripheral/MultiCycleDecomposition.lean`
- `lake build TNLean.Channel.Peripheral.MultiCycleDecomposition -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/Channel/Peripheral/MultiCycleDecomposition.lean || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- The Lake build reports only pre-existing style warnings.

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 64a179f2b63b9838e34014d8da9a76de45e0b933. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local proof refactor in peripheral channel theory with no API or mathematical statement changes.
> 
> **Overview**
> **`MultiCycleDecomposition.totalPerm`** no longer builds per-cycle `k ↦ k + 1` equivalences by hand; each cycle now uses Mathlib’s **`finRotate (M.period c)`** inside `Equiv.Perm.sigmaCongrRight`, with a new import from `Mathlib.Logic.Equiv.Fin.Rotate`.
> 
> The public shape is unchanged: **`totalPerm_apply`** still states `⟨x.1, x.2 + 1⟩`, but the proof goes through **`finRotate_apply`**. In **`toCycleStructure`**, the cyclic hypothesis rewrites with **`totalPerm_apply`** before applying **`M.cyclic`**, instead of unfolding the permutation inline.
> 
> No bundled definitions, theorem statements, or mathematical claims are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5413baaf1157541c49026451d8abd78d62a44e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->