### PR TITLE
refactor(MPS/Core): use native fin reversal

### DIFF
--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -9,6 +9,7 @@ import TNLean.MPS.Tactic.Basic
 import Mathlib.Data.Fintype.BigOperators
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Data.Fin.Rev
 import Mathlib.Data.Fin.Tuple.Basic
 import Mathlib.Algebra.BigOperators.Fin
 import Mathlib.Algebra.Star.BigOperators
@@ -341,16 +342,7 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
   have hLeft : ∑ i : Fin d, (Aadj i)ᴴ * Aadj i = 1 := by
     simpa [Aadj] using hRight
   let revEquiv : (Fin L → Fin d) ≃ (Fin L → Fin d) :=
-    { toFun := fun ρ => ρ ∘ Fin.rev
-      invFun := fun ρ => ρ ∘ Fin.rev
-      left_inv := by
-        intro ρ
-        ext i
-        simp [Function.comp_def]
-      right_inv := by
-        intro ρ
-        ext i
-        simp [Function.comp_def] }
+    Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))
   calc
     ∑ ρ : Fin L → Fin d,
         evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ
@@ -361,7 +353,10 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
             intro ρ _
             have hword :
                 List.ofFn (revEquiv ρ) = (List.ofFn ρ).reverse := by
-              simpa [revEquiv] using list_ofFn_comp_fin_rev (σ := ρ)
+              have hrevApply : revEquiv ρ = ρ ∘ Fin.rev := by
+                funext i
+                simp [revEquiv, Function.comp_def]
+              simpa [hrevApply] using list_ofFn_comp_fin_rev (σ := ρ)
             have hAdjEval :
                 (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ =
                   evalWord A (List.ofFn ρ) := by


### PR DESCRIPTION
### Motivation

- The hand-built `Equiv` for word reversal in `sum_evalWord_mul_conjTranspose_evalWord` duplicated what Mathlib already provides via `Fin.revPerm`, increasing maintenance burden with no mathematical benefit.

### Description

- `TNLean/MPS/Core/Blocking.lean`: replaces the manually defined `revEquiv` (with explicit `toFun`, `invFun`, `left_inv`, `right_inv`) with `Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))`, using Mathlib's native finite reversal permutation.
- Adds `import Mathlib.Data.Fin.Rev`.
- The proof of the reversal identity now uses a short `hrevApply` step (`revEquiv ρ = ρ ∘ Fin.rev`) before reusing `list_ofFn_comp_fin_rev`.
- No theorem statements, blueprint references, or mathematical content are changed.

### Testing

- `lake env lean TNLean/MPS/Core/Blocking.lean`
- `lake build TNLean.MPS.Core.Blocking -q --log-level=info`
- `git diff --check`
- `rg -n "\b(sorry|axiom|admit|native_decide|unsafeCast)\b" TNLean/MPS/Core/Blocking.lean || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

The Lake build reports only pre-existing style warnings; no new issues introduced.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged theorems; behavior is the same reversal-on-words argument, now wired through standard Mathlib equivalences.
> 
> **Overview**
> **Refactors** the word-reversal bijection in `sum_evalWord_mul_conjTranspose_evalWord` so it uses Mathlib's `Fin.revPerm` instead of a hand-built `Equiv`.
> 
> `revEquiv` is now `Equiv.arrowCongr Fin.revPerm (Equiv.refl (Fin d))`, matching patterns like `rotateConfig` elsewhere in MPS. The proof that `List.ofFn (revEquiv ρ)` reverses `List.ofFn ρ` adds a short `hrevApply` step (`revEquiv ρ = ρ ∘ Fin.rev`) before reusing `list_ofFn_comp_fin_rev`.
> 
> Adds `import Mathlib.Data.Fin.Rev`. **No** theorem statements or mathematical claims change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d19a8d07029ebd01e9e346b49427b75a8b336231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>