### PR TITLE
refactor(PEPS): use native cast product congruence

### DIFF
--- a/TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean
+++ b/TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean
@@ -309,17 +309,9 @@ theorem GaugeEquiv.sameState {A B : Tensor G d} (h : GaugeEquiv A B) :
     SameState A B := by
   classical
   rcases h with ⟨hDim, X, hX⟩
+  let φ : VirtualConfig A ≃ VirtualConfig B :=
+    Equiv.piCongrRight fun e => finCongr (congr_fun hDim e)
   intro σ
-  let φ : VirtualConfig A ≃ VirtualConfig B := {
-    toFun := fun η e => Fin.cast (congr_fun hDim e) (η e)
-    invFun := fun η e => Fin.cast (Eq.symm (congr_fun hDim e)) (η e)
-    left_inv := fun η => by
-      funext e
-      simp
-    right_inv := fun η => by
-      funext e
-      simp
-  }
   have hB : stateCoeff B σ = stateCoeff (applyGauge A X) σ := by
     unfold stateCoeff
     rw [← φ.sum_comp (fun η : VirtualConfig B =>

--- a/TNLean/PEPS/RegionBlock/ReindexInjectivity.lean
+++ b/TNLean/PEPS/RegionBlock/ReindexInjectivity.lean
@@ -31,17 +31,8 @@ by casting every open leg across the bond-dimension equality. -/
 noncomputable def regionBoundaryConfigCastEquiv (T : Tensor G d) {bd : Edge G → ℕ}
     (h : bd = T.bondDim) (R : Finset V) :
     RegionBoundaryConfig (G := G) (reindexTensor (G := G) T h) R ≃
-      RegionBoundaryConfig (G := G) T R where
-  toFun bdry := fun f => Fin.cast (congr_fun h f.1) (bdry f)
-  invFun bdry := fun f => Fin.cast (congr_fun h f.1).symm (bdry f)
-  left_inv bdry := by
-    funext f
-    apply Fin.eq_of_val_eq
-    simp
-  right_inv bdry := by
-    funext f
-    apply Fin.eq_of_val_eq
-    simp
+      RegionBoundaryConfig (G := G) T R :=
+  Equiv.piCongrRight fun f => finCongr (congr_fun h f.1)
 
 /-- **A bond-dimension reindex preserves blocked-region linear independence.**
 


### PR DESCRIPTION
### Motivation

- Two proofs in the PEPS formalization construct finite-index transport equivalences by hand (`toFun`, `invFun`, and inverse proofs), when `Equiv.piCongrRight` composed with `finCongr` already provides the same pointwise bond-index transport in one step.
- The replacement is consistent with analogous patterns used elsewhere in the PEPS files (e.g., `castLocalVirtualConfig`, `stateCoeff_reindexTensor`), reducing proof length and making the transport structure explicit.

### Description

- `TNLean/PEPS/RegionBlock/ReindexInjectivity.lean`: replaces `regionBoundaryConfigCastEquiv`, the boundary-configuration bijection for a bond-dimension reindex, with a one-liner using `Equiv.piCongrRight` and `finCongr`.
- `TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean`: replaces the virtual-configuration reindex in `GaugeEquiv.sameState` (the open-edge gauge equivalence proof) with the same `Equiv.piCongrRight ∘ finCongr` pattern, removing approximately 15 lines of explicit index-cast proof steps.
- Mathematical statements in both files are unchanged; only the encoding of pointwise bond-index transport is simplified.

### Testing

- `lake env lean TNLean/PEPS/RegionBlock/ReindexInjectivity.lean`
- `lake env lean TNLean/PEPS/FundamentalTheorem/EdgeInsertion.lean`
- `lake build TNLean.PEPS.RegionBlock.ReindexInjectivity TNLean.PEPS.FundamentalTheorem.EdgeInsertion -q --log-level=info`
- Proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in changed files.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavioral changes; risk is limited to Lean proof maintenance if `piCongrRight`/`finCongr` simp lemmas differ from the old defs.
> 
> **Overview**
> Replaces two bespoke `Fin.cast` equivalences with Mathlib's **`Equiv.piCongrRight`** composed with **`finCongr`**, aligning PEPS proofs with the same transport pattern already used elsewhere (e.g. `castLocalVirtualConfig`, `stateCoeff_reindexTensor`).
> 
> In **`regionBoundaryConfigCastEquiv`**, the boundary-configuration bijection for a bond-dimension reindex is now a one-liner instead of a manual `toFun` / `invFun` / inverse proofs. In **`GaugeEquiv.sameState`**, the virtual-configuration map between gauge-equivalent tensors is defined the same way, dropping ~15 lines of boilerplate while the `stateCoeff` argument is unchanged.
> 
> **No statement or proof obligation changes**—only how the index casts are packaged for `sum_comp` and `linearIndependent_equiv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508266b1a4d52d20447f8e0efd8b199e729b327e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>