### PR TITLE
refactor(MPS/SharedInfra): use native sigma congruence

### DIFF
--- a/TNLean/MPS/SharedInfra/SectorDecomposition.lean
+++ b/TNLean/MPS/SharedInfra/SectorDecomposition.lean
@@ -225,10 +225,7 @@ noncomputable def sectorFlatEquiv
     (β : Fin Q.basisCount ≃ Fin P.basisCount)
     (τ : (k : Fin Q.basisCount) → Fin (Q.copies k) ≃ Fin (P.copies (β k))) :
     Fin Q.totalCopies ≃ Fin P.totalCopies :=
-  (Q.flatIndexEquiv.symm.trans
-    ((Equiv.sigmaCongrRight τ).trans
-      (Equiv.sigmaCongrLeft (β := fun k' : Fin P.basisCount =>
-        Fin (P.copies k')) β))).trans P.flatIndexEquiv
+  (Q.flatIndexEquiv.symm.trans (Equiv.sigmaCongr β τ)).trans P.flatIndexEquiv
 
 @[simp]
 theorem sectorFlatEquiv_apply
@@ -239,7 +236,7 @@ theorem sectorFlatEquiv_apply
     sectorFlatEquiv (P := P) (Q := Q) β τ s =
       P.flatIndexEquiv ⟨β (Q.flatIndexEquiv.symm s).1,
         τ (Q.flatIndexEquiv.symm s).1 (Q.flatIndexEquiv.symm s).2⟩ := by
-  simp [sectorFlatEquiv, Equiv.sigmaCongrLeft_apply,
+  simp [sectorFlatEquiv, Equiv.sigmaCongr, Equiv.sigmaCongrLeft_apply,
     Equiv.sigmaCongrRight_apply]
 
 /-- Flat-sector dimensions of $P$ and $Q$ agree along `sectorFlatEquiv`,
@@ -258,7 +255,7 @@ theorem flatDim_sectorFlatEquiv
 
 /-- **Total bond dimension matches across matched sector decompositions.**
 
-If $P$ and $Q$ admit a matched basis bijection with matched per-block bond
+If $P$ and $Q$ have a matched basis bijection with matched per-block bond
 dimensions and matched copy permutations, then their total bond dimensions
 $\sum_s D_s$ coincide.
 


### PR DESCRIPTION
### Motivation

- `sectorFlatEquiv` in `MPS/SharedInfra/SectorDecomposition.lean` was constructed via an explicit two-step chain (`sigmaCongrRight` composed with `sigmaCongrLeft`). Mathlib's bundled `Equiv.sigmaCongr` performs the same operation in one step, reducing boilerplate and aligning with upstream convention.
- A one-word docstring edit in `totalDim_eq_of_match` replaces "admit" with "have" to prevent proof-integrity scans from flagging English prose as a proof placeholder.

### Description

- `TNLean/MPS/SharedInfra/SectorDecomposition.lean`: rewrites `sectorFlatEquiv` to use `Equiv.sigmaCongr β τ` directly instead of composing `sigmaCongrRight` and `sigmaCongrLeft`. The induced equivalence is mathematically unchanged: a flat `Q`-sector index is unflattened to a pair `(k, q)`, sent to `(β k, τ_k q)`, and flattened in `P`.
- The `sectorFlatEquiv_apply` proof unfolds `Equiv.sigmaCongr` at the simp step where the pointwise formula is needed.
- One docstring word in `totalDim_eq_of_match` is adjusted ("admit" → "have") to avoid false positives in proof-integrity scans.
- No mathematical content is changed; no new `sorry` are introduced.

### Testing

- `lake env lean TNLean/MPS/SharedInfra/SectorDecomposition.lean`
- `lake env lean TNLean/MPS/FundamentalTheorem/SectorBNT/FundamentalCoord.lean`
- `lake build TNLean.MPS.SharedInfra.SectorDecomposition -q --log-level=info`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.FundamentalCoord -q --log-level=info`
- Proof-integrity scan on changed Lean files for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

_No linked issue found. This PR is part of the `mathlib-4-31-native-pass` refactor series; link a parent tracking issue manually if one exists._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in shared sector-decomposition infrastructure; no change to the induced equivalence or downstream theorem statements.
>
> **Overview**
> **`sectorFlatEquiv`** is rewritten to use Mathlib's bundled **`Equiv.sigmaCongr β τ`** instead of chaining **`sigmaCongrRight`** and **`sigmaCongrLeft`**. The map is the same: unflatten a `Q` sector, apply the matched basis bijection and per-block copy permutations, then flatten in `P`.
>
> The **`sectorFlatEquiv_apply`** proof now unfolds **`Equiv.sigmaCongr`** at the simp step (along with the existing left/right apply lemmas). A one-word docstring tweak in **`totalDim_eq_of_match`** ("admit" → "have") avoids false positives in proof-integrity scans on prose.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf71f2bd72e3f7d961a50acdc1f9150595d4035e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only infrastructure refactor with no change to theorem statements or the induced equivalence; downstream FT code still relies on the same `sectorFlatEquiv_apply` formula.
> 
> **Overview**
> **`sectorFlatEquiv`** is refactored to build the flattened sector permutation with Mathlib’s bundled **`Equiv.sigmaCongr β τ`** instead of composing **`sigmaCongrRight`** and **`sigmaCongrLeft`**. The map is unchanged: unflatten a `Q` index, apply the matched basis bijection and per-block copy permutations, then flatten in `P`.
> 
> The **`sectorFlatEquiv_apply`** proof now unfolds **`Equiv.sigmaCongr`** in its `simp` step. In **`totalDim_eq_of_match`**, the docstring wording **“admit” → “have”** avoids false positives from proof-integrity scans on English prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276c975339636fbb813e68bb90994b9d8a3813a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->