### PR TITLE
refactor(MPS/Periodic): use native fin rotation

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3Transport.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Periodic.Overlap.Case2
+import Mathlib.Logic.Equiv.Fin.Rotate
 
 /-!
 # Periodic overlap dichotomy: Case 3 transport
@@ -30,28 +31,28 @@ cross overlap is unchanged by the simultaneous shift. -/
 
 /-- One-site cyclic rotation of a configuration of length `L'+1`:
 move the last letter to the front. -/
-def rotateCfg {d L' : ℕ} : (Fin (L' + 1) → Fin d) ≃ (Fin (L' + 1) → Fin d) where
-  toFun σ := Fin.cons (σ (Fin.last L')) (Fin.init σ)
-  invFun τ := Fin.snoc (Fin.tail τ) (τ 0)
-  left_inv σ := by
-    funext j
-    refine Fin.lastCases ?_ ?_ j
-    · simp [Fin.snoc_last, Fin.cons_zero]
-    · intro i
-      simp [Fin.snoc_castSucc, Fin.init]
-  right_inv τ := by
-    funext j
-    refine Fin.cases ?_ ?_ j
-    · simp [Fin.cons_zero, Fin.snoc_last]
-    · intro i
-      simp [Fin.cons_succ, Fin.tail]
+def rotateCfg {d L' : ℕ} : (Fin (L' + 1) → Fin d) ≃ (Fin (L' + 1) → Fin d) :=
+  Equiv.arrowCongr (finRotate (L' + 1)) (Equiv.refl (Fin d))
+
+private lemma rotateCfg_eq_cons_init {d L' : ℕ} (σ : Fin (L' + 1) → Fin d) :
+    rotateCfg σ = Fin.cons (σ (Fin.last L')) (Fin.init σ) := by
+  funext j
+  refine Fin.cases ?_ ?_ j
+  · exact congrArg σ <| Fin.ext <| by
+      rw [finRotate_symm_apply]
+      simp
+  · intro i
+    exact congrArg σ <| Fin.ext <| by
+      rw [finRotate_symm_apply]
+      simp [Fin.val_sub_one_of_ne_zero]
 
 /-- Word evaluation of the rotated configuration pulls the last letter to the front. -/
 private lemma evalWord_ofFn_rotateCfg {L' : ℕ} (A : MPSTensor d D)
     (σ : Fin (L' + 1) → Fin d) :
     evalWord A (List.ofFn (rotateCfg σ)) =
       A (σ (Fin.last L')) * evalWord A (List.ofFn (Fin.init σ)) := by
-  simp only [rotateCfg, Equiv.coe_fn_mk, List.ofFn_cons, evalWord_cons]
+  rw [rotateCfg_eq_cons_init σ]
+  simp only [List.ofFn_cons, evalWord_cons]
 
 /-- Word evaluation of the original configuration pulls the last letter to the right. -/
 private lemma evalWord_ofFn_eq_init_mul_last {L' : ℕ} (A : MPSTensor d D)


### PR DESCRIPTION
### Motivation

- `rotateCfg`, the one-site cyclic rotation of a configuration of length $L'+1$ (moving the last letter to the front), was implemented as a hand-built `Equiv` with explicit `toFun`/`invFun` and two inverse proofs. Mathlib already provides `finRotate`, which, lifted to function types by `Equiv.arrowCongr`, gives the same equivalence without the bespoke proof burden.

### Description

- Modified `TNLean/MPS/Periodic/Overlap/Case3Transport.lean`:
  - Added import `Mathlib.Logic.Equiv.Fin.Rotate`.
  - Replaced the hand-written `rotateCfg` definition with `Equiv.arrowCongr (finRotate (L' + 1)) (Equiv.refl (Fin d))`.
  - Added private lemma `rotateCfg_eq_cons_init`, recording the pointwise formula `rotateCfg σ = Fin.cons (σ (Fin.last L')) (Fin.init σ)`; this lemma drives the proof of `evalWord_ofFn_rotateCfg` in place of unfolding the former definition.
  - No mathematical statement is changed. The pre-existing `sorry` at `Case3.lean:586` is not introduced or moved by this PR.

### Testing

- `lake env lean TNLean/MPS/Periodic/Overlap/Case3Transport.lean`
- `lake build TNLean.MPS.Periodic.Overlap.Case3Transport -q --log-level=info`
- `lake env lean TNLean/MPS/Periodic/Overlap/Case3.lean` — passes with the pre-existing warning `TNLean/MPS/Periodic/Overlap/Case3.lean:586:14: warning: declaration uses sorry` only.
- `git diff --check`
- Proof-integrity marker scan on `TNLean/MPS/Periodic/Overlap/Case3Transport.lean`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one Lean file; behavior is pinned by `rotateCfg_eq_cons_init` and does not touch auth, data, or runtime code.
> 
> **Overview**
> **`rotateCfg`** in periodic Case 3 transport is no longer a hand-built equivalence on `Fin.cons` / `Fin.init`; it is **`Equiv.arrowCongr (finRotate (L' + 1)) (Equiv.refl (Fin d))`**, with a new import from Mathlib.
> 
> The old "last letter to the front" shape is kept as the private lemma **`rotateCfg_eq_cons_init`**, and **`evalWord_ofFn_rotateCfg`** now rewrites through that lemma instead of unfolding the former definition. Downstream transport lemmas still use **`rotateCfg`** the same way; no stated mathematics changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 675656c9103d0ecb08325a17427e9369f1a066b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>