### PR TITLE
refactor(Axioms/Entropy): use native sigma product equivalences

### DIFF
--- a/TNLean/Axioms/Entropy.lean
+++ b/TNLean/Axioms/Entropy.lean
@@ -73,26 +73,27 @@ def abcEquiv {dA dB dC : ℕ} {m : ℕ} {dL dR : Fin m → ℕ}
 tripartite shape `A × (B × C)`. -/
 def sigmaAssoc {dA dC : ℕ} {m : ℕ} (dL dR : Fin m → ℕ) :
     (Σ j : Fin m, (Fin dA × Fin (dL j)) × (Fin (dR j) × Fin dC)) ≃
-      (Fin dA × ((Σ j : Fin m, Fin (dL j) × Fin (dR j)) × Fin dC)) where
-  toFun := fun ⟨j, x⟩ =>
-    let a : Fin dA := x.1.1
-    let l : Fin (dL j) := x.1.2
-    let r : Fin (dR j) := x.2.1
-    let c : Fin dC := x.2.2
-    (a, (⟨j, (l, r)⟩, c))
-  invFun := fun x =>
-    let a : Fin dA := x.1
-    let j : Fin m := x.2.1.1
-    let l : Fin (dL j) := x.2.1.2.1
-    let r : Fin (dR j) := x.2.1.2.2
-    let c : Fin dC := x.2.2
-    ⟨j, ((a, l), (r, c))⟩
-  left_inv := by
-    rintro ⟨j, ⟨⟨a, l⟩, ⟨r, c⟩⟩⟩
-    rfl
-  right_inv := by
-    rintro ⟨a, ⟨⟨j, ⟨l, r⟩⟩, c⟩⟩
-    rfl
+      (Fin dA × ((Σ j : Fin m, Fin (dL j) × Fin (dR j)) × Fin dC)) :=
+  calc
+    (Σ j : Fin m, (Fin dA × Fin (dL j)) × (Fin (dR j) × Fin dC)) ≃
+        (Σ j : Fin m, Fin dA × ((Fin (dL j) × Fin (dR j)) × Fin dC)) :=
+      Equiv.sigmaCongrRight fun j =>
+        (Equiv.prodAssoc (Fin dA) (Fin (dL j)) (Fin (dR j) × Fin dC)).trans
+          (Equiv.prodCongr (Equiv.refl (Fin dA))
+            (Equiv.prodAssoc (Fin (dL j)) (Fin (dR j)) (Fin dC)).symm)
+    _ ≃ (Σ j : Fin m, ((Fin (dL j) × Fin (dR j)) × Fin dC) × Fin dA) :=
+      Equiv.sigmaCongrRight fun j =>
+        Equiv.prodComm (Fin dA) ((Fin (dL j) × Fin (dR j)) × Fin dC)
+    _ ≃ (Σ j : Fin m, (Fin (dL j) × Fin (dR j)) × Fin dC) × Fin dA :=
+      (Equiv.sigmaProdDistrib
+        (fun j : Fin m => (Fin (dL j) × Fin (dR j)) × Fin dC)
+        (Fin dA)).symm
+    _ ≃ Fin dA × (Σ j : Fin m, (Fin (dL j) × Fin (dR j)) × Fin dC) :=
+      Equiv.prodComm _ _
+    _ ≃ Fin dA × ((Σ j : Fin m, Fin (dL j) × Fin (dR j)) × Fin dC) :=
+      Equiv.prodCongr (Equiv.refl (Fin dA))
+        (Equiv.sigmaProdDistrib
+          (fun j : Fin m => Fin (dL j) × Fin (dR j)) (Fin dC)).symm
 
 /-- Lift a unitary on the middle subsystem `B` to the tripartite space
 `A ⊗ B ⊗ C` as `1_A ⊗ U_B ⊗ 1_C`. -/


### PR DESCRIPTION
### Motivation

- The `HayashiMarkov.sigmaAssoc` equivalence in `TNLean/Axioms/Entropy.lean` was defined with explicit `toFun`/`invFun` components, each with a `rfl`-based inverse proof, for a reassociation of the dependent-sum index type.
- Mathlib provides `Equiv.prodAssoc`, `Equiv.sigmaCongrRight`, `Equiv.prodComm`, and `Equiv.sigmaProdDistrib`, which compose directly to the same result, removing the need for the hand-written proof terms.
- No linked issue — part of the native-Mathlib-equivalence cleanup series.

### Description

- Modified `TNLean/Axioms/Entropy.lean`: replaced the hand-written `HayashiMarkov.sigmaAssoc` definition (explicit `toFun`/`invFun` with `rfl` inverse proofs) with a `calc` chain of standard Mathlib equivalences.
- The equivalence reassociates `Σ j : Fin m, (Fin dA × Fin (dL j)) × (Fin (dR j) × Fin dC)` to `Fin dA × ((Σ j : Fin m, Fin (dL j) × Fin (dR j)) × Fin dC)`, used to rewrite the index space in the Hayashi–Markov decomposition for the equality case of strong subadditivity.
- The chain uses `Equiv.sigmaCongrRight`, `Equiv.prodAssoc`, `Equiv.prodCongr`, `Equiv.prodComm`, and `Equiv.sigmaProdDistrib`.
- No entropy axiom, theorem statement, or matrix expression is changed. No new `axiom` or `sorry` is introduced.

### Testing

- `lake env lean TNLean/Axioms/Entropy.lean`
- `lake env lean TNLean/Entropy/MarkovChain.lean`
- `lake build TNLean.Axioms.Entropy -q --log-level=info` — passes (existing header-style warnings unchanged)
- Proof-integrity scan for newly added `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`: none found
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
_No linked issue found. This is a self-contained internal reorganization in the native-Mathlib-equivalence cleanup series._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor of an internal index reassociation with no axiom or API changes.
> 
> **Overview**
> **`HayashiMarkov.sigmaAssoc`** is reimplemented as a **`calc`** chain of Mathlib **`Equiv`** lemmas (`sigmaCongrRight`, `prodAssoc`, `prodComm`, `sigmaProdDistrib`, etc.) instead of a hand-written `toFun` / `invFun` with `rfl` inverse proofs.
> 
> The **source and target index types are unchanged**, and **`blockState`** still reindexes matrices with the same equivalence. No entropy axioms, theorem statements, or matrix formulas are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d8c9a5dd74e8937cb18c98192c2e29735982643. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->