### PR TITLE
refactor(Channel/Peripheral): use native fin rotation in multicycles

### DIFF
--- a/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
+++ b/TNLean/Channel/Peripheral/MultiCycleDecomposition.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Peripheral.Cycles
+import Mathlib.Logic.Equiv.Fin.Rotate
 
 /-!
 # Multi-cycle block-permutation decompositions
@@ -285,15 +286,14 @@ def totalProj (M : MultiCycleDecomposition T) : M.Idx → MatrixAlg D :=
 `Equiv.Perm.sigmaCongrRight`. -/
 noncomputable def totalPerm (M : MultiCycleDecomposition T) :
     Equiv.Perm M.Idx :=
-  Equiv.Perm.sigmaCongrRight (fun c : M.ι =>
-    { toFun := fun k => k + 1
-      invFun := fun k => k - 1
-      left_inv := by intro k; simp
-      right_inv := by intro k; simp })
+  Equiv.Perm.sigmaCongrRight (fun c : M.ι => finRotate (M.period c))
 
 @[simp]
 lemma totalPerm_apply (M : MultiCycleDecomposition T) (x : M.Idx) :
-    M.totalPerm x = ⟨x.1, x.2 + 1⟩ := rfl
+    M.totalPerm x = ⟨x.1, x.2 + 1⟩ := by
+  cases x with
+  | mk c k =>
+    simp [totalPerm, finRotate_apply]
 
 /-- **Flattening construction.**  A multi-cycle decomposition gives a
 `CycleStructure` on the total block-index type
@@ -317,7 +317,7 @@ noncomputable def toCycleStructure (M : MultiCycleDecomposition T) :
       exact M.isProj c k)
     (by
       rintro ⟨c, k⟩
-      change T (M.P c (k + 1)) = M.P c k
+      rw [totalPerm_apply]
       exact M.cyclic c k)
     (by
       rintro ⟨c, k⟩ X


### PR DESCRIPTION
### Motivation

- The hand-written per-cycle shift in `totalPerm` constructed an `Equiv.Perm` record with explicit `toFun`, `invFun`, and inverse proofs, duplicating the cyclic rotation logic Mathlib already provides as `finRotate`.
- Replacing the local construction with `finRotate (M.period c)` simplifies the definition and removes the redundant inline inverse proofs.
- No mathematical statement, theorem, or public lemma is changed.

### Description

- Modified `TNLean/Channel/Peripheral/MultiCycleDecomposition.lean`:
  - `totalPerm` now uses `finRotate (M.period c)` instead of an explicit `Equiv.Perm` record with hand-written `toFun`, `invFun`, `left_inv`, and `right_inv`.
  - `totalPerm_apply` records the same concrete formula `⟨c, k⟩ ↦ ⟨c, k + 1⟩` via `finRotate_apply`.
  - The cyclic-action field in `toCycleStructure` rewrites through `totalPerm_apply` instead of relying on definitional unfolding of the old record.
- The flattened multi-cycle permutation (`Equiv.Perm.sigmaCongrRight` with per-cycle action `k ↦ k + 1` on `Fin (M.period c)`) is unchanged.

### Testing

- `lake env lean TNLean/Channel/Peripheral/MultiCycleDecomposition.lean`
- `lake build TNLean.Channel.Peripheral.MultiCycleDecomposition -q --log-level=info` — passes with existing header-style warnings.
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/Channel/Peripheral/MultiCycleDecomposition.lean || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
No linked issue identified — this is a self-contained internal reorganization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in peripheral channel formalization; no change to statements or runtime behavior, only definition and proof style.
> 
> **Overview**
> **Refactors** `MultiCycleDecomposition.totalPerm` to build each per-cycle shift with Mathlib's `finRotate` instead of an inline `Equiv.Perm` record (`toFun` / `invFun` / inverse lemmas), and adds `import Mathlib.Logic.Equiv.Fin.Rotate`.
> 
> The flattened permutation is still `Equiv.Perm.sigmaCongrRight` with action `k ↦ k + 1` on each `Fin (M.period c)`. `totalPerm_apply` now proves `⟨c, k + 1⟩` via `finRotate_apply`, and the cyclic-action field in `toCycleStructure` rewrites through that lemma rather than definitional unfolding of the old definition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0eb7d82b1b2d8795ff8ef503548f690b2225c11f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->