### PR TITLE
refactor(MPS/Chain): use native fin rotation

### DIFF
--- a/TNLean/MPS/Chain/Defs.lean
+++ b/TNLean/MPS/Chain/Defs.lean
@@ -1,6 +1,7 @@
 import TNLean.MPS.Defs
 
 import Batteries.Data.Fin
+import Mathlib.Logic.Equiv.Fin.Rotate
 
 /-!
 # Non-translation-invariant MPS chains
@@ -40,25 +41,17 @@ def IsInjective (A : MPSChainTensor d D n) : Prop :=
   ∀ k : Fin n, MPSTensor.IsInjective (A k)
 
 /-- Cyclic successor on `Fin n`, sending the last site back to `0`. -/
-def cyclicSucc : Fin n → Fin n
-  | ⟨i, hi⟩ =>
-      match n with
-      | 0 => False.elim (Nat.not_lt_zero _ hi)
-      | m + 1 => ⟨(i + 1) % (m + 1), Nat.mod_lt _ (Nat.succ_pos _)⟩
+def cyclicSucc : Fin n → Fin n :=
+  finRotate n
 
 @[simp] lemma cyclicSucc_val (k : Fin (n + 1)) :
-    (cyclicSucc k).val = (k.val + 1) % (n + 1) := rfl
+    (cyclicSucc k).val = (k.val + 1) % (n + 1) := by
+  simp [cyclicSucc, Fin.val_add]
 
 /-- The cyclic successor is addition by one on `Fin n`. -/
 @[simp] lemma cyclicSucc_eq_add_one [NeZero n] (k : Fin n) :
     cyclicSucc k = k + 1 := by
-  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (NeZero.ne n)
-  apply Fin.ext
-  rw [cyclicSucc_val, Fin.val_add, Fin.val_one']
-  calc
-    (↑k + 1) % (m + 1)
-        = (↑k % (m + 1) + 1 % (m + 1)) % (m + 1) := Nat.add_mod _ _ _
-    _ = (↑k + 1 % (m + 1)) % (m + 1) := by rw [Nat.mod_eq_of_lt k.isLt]
+  simp [cyclicSucc, finRotate_apply]
 
 /-! ### Cyclic shift of a closed chain -/
 


### PR DESCRIPTION
### Motivation
- The cyclic successor `cyclicSucc` on finite chain sites was implemented as a custom `Fin` map. Mathlib provides `finRotate n`, which is the standard equivalent permutation, yielding shorter and more maintainable proofs.

### Description
- `TNLean/MPS/Chain/Defs.lean`: `cyclicSucc` is redefined as `finRotate n`, replacing the previous hand-written cyclic successor on `Fin n`.
- `cyclicSucc_val` is re-proved using the native `Fin.val_add` formula.
- `cyclicSucc_eq_add_one` is re-proved directly from `finRotate_apply`.
- No mathematical statements are changed; the public name `cyclicSucc` and all downstream consumers (`cyclicShift`, `GaugeEquiv`, etc.) are unaffected.

### Testing
- `lake env lean TNLean/MPS/Chain/Defs.lean`
- `lake env lean TNLean/MPS/Chain/TranslationInvariance.lean`
- `lake env lean TNLean/MPS/Chain/GaugePhase.lean`
- `lake build TNLean.MPS.Chain.Defs TNLean.MPS.Chain.TranslationInvariance TNLean.MPS.Chain.GaugePhase -q --log-level=info`: passes, with existing header-style warnings.
- Proof-integrity scan: no new `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` introduced.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
<!-- No linked issue identified; author should add `Addresses #N` manually if applicable. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized definitional refactor in one Lean file with no API or mathematical statement changes; downstream modules only depend on the unchanged `cyclicSucc` interface.
> 
> **Overview**
> **`cyclicSucc`** on periodic MPS chain sites is no longer a hand-written `Fin` successor; it is **`finRotate n`** from Mathlib (`Mathlib.Logic.Equiv.Fin.Rotate`).
> 
> The **`cyclicSucc_val`** and **`cyclicSucc_eq_add_one`** lemmas are re-proved with shorter `simp` arguments (`Fin.val_add`, `finRotate_apply`) instead of manual `Nat.mod` reasoning. The name **`cyclicSucc`** and behavior for **`cyclicShift`**, **`GaugeEquiv`**, and downstream chain files are unchanged—this is implementation/proof cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc99ec53956a30bf79373aa325a3debb1b9c7b92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->