### PR TITLE
refactor(Wielandt): use native pi submodules for rectangular ranges

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Ranges.lean
+++ b/TNLean/Wielandt/RectangularSpan/Ranges.lean
@@ -82,48 +82,29 @@ theorem mem_range_mulLeft_iff_cols
 
 /-- The submodule of matrices whose columns lie in `range (Matrix.toLin' P)`. -/
 noncomputable def colRangeSubmodule (P : Matrix (Fin D) (Fin D) ℂ) :
-    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) where
-  carrier := { M | ∀ j : Fin D, M.col j ∈ LinearMap.range (Matrix.toLin' P) }
-  zero_mem' := by
-    intro j
-    have hcol : (0 : Matrix (Fin D) (Fin D) ℂ).col j = (0 : Fin D → ℂ) := by
-      ext i
-      simp [Matrix.col_apply]
-    -- rewrite `0` as the `j`-th column of the zero matrix
-    exact hcol.symm ▸ (LinearMap.range (Matrix.toLin' P)).zero_mem
-  add_mem' := by
-    intro M N hM hN j
-    -- columnwise additivity
-    have hcol : (M + N).col j = M.col j + N.col j := by
-      ext i
-      simp [Matrix.col_apply]
-    -- use submodule closure
-    simpa [hcol] using
-      (Submodule.add_mem (LinearMap.range (Matrix.toLin' P)) (hM j) (hN j))
-  smul_mem' := by
-    intro a M hM j
-    have hcol : (a • M).col j = a • M.col j := by
-      ext i
-      simp [Matrix.col_apply]
-    simpa [hcol] using
-      (Submodule.smul_mem (LinearMap.range (Matrix.toLin' P)) a (hM j))
+    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+  Submodule.comap (Matrix.transposeLinearEquiv (Fin D) (Fin D) ℂ ℂ).toLinearMap
+    (Submodule.pi Set.univ (fun _ : Fin D => LinearMap.range (Matrix.toLin' P)))
 
 /-- Identify the range of left-multiplication as the submodule of matrices whose columns lie in
 `range (Matrix.toLin' P)`. -/
 theorem range_mulLeft_eq_pi (P : Matrix (Fin D) (Fin D) ℂ) :
     LinearMap.range (LinearMap.mulLeft ℂ P) = colRangeSubmodule (D := D) P := by
   ext M
-  simpa [colRangeSubmodule] using (mem_range_mulLeft_iff_cols (D := D) P M)
+  change M ∈ LinearMap.range (LinearMap.mulLeft ℂ P) ↔
+    ∀ j ∈ (Set.univ : Set (Fin D)), Mᵀ j ∈ LinearMap.range (Matrix.toLin' P)
+  simpa [Matrix.col, Matrix.transpose_apply] using
+    (mem_range_mulLeft_iff_cols (D := D) P M)
 
 /-- The submodule `colRangeSubmodule P` is linearly equivalent to the product of
 the column ranges. -/
 noncomputable def colRangeSubmoduleEquiv (P : Matrix (Fin D) (Fin D) ℂ) :
     colRangeSubmodule (D := D) P ≃ₗ[ℂ]
       (Fin D → LinearMap.range (Matrix.toLin' P)) where
-  toFun M j := ⟨M.1.col j, M.2 j⟩
+  toFun M j := ⟨M.1.col j, M.2 j (Set.mem_univ j)⟩
   invFun f :=
     ⟨fun i j => (f j).1 i, by
-      intro j
+      intro j _
       change Matrix.col (fun i k => (f k).1 i : Matrix (Fin D) (Fin D) ℂ) j ∈
         LinearMap.range (Matrix.toLin' P)
       have hcol :

--- a/TNLean/Wielandt/RectangularSpan/Ranges.lean
+++ b/TNLean/Wielandt/RectangularSpan/Ranges.lean
@@ -221,43 +221,26 @@ theorem mem_range_mulRight_iff_rows
 
 /-- The submodule of matrices whose rows lie in `range (Q.vecMulLinear)`. -/
 noncomputable def rowRangeSubmodule (Q : Matrix (Fin D) (Fin D) ℂ) :
-    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) where
-  carrier := { M | ∀ i : Fin D, M.row i ∈ LinearMap.range (Q.vecMulLinear) }
-  zero_mem' := by
-    intro i
-    have hrow : (0 : Matrix (Fin D) (Fin D) ℂ).row i = (0 : Fin D → ℂ) := by
-      ext j
-      simp [Matrix.row_apply]
-    exact hrow.symm ▸ (LinearMap.range (Q.vecMulLinear)).zero_mem
-  add_mem' := by
-    intro M N hM hN i
-    have hrow : (M + N).row i = M.row i + N.row i := by
-      ext j
-      simp [Matrix.row_apply]
-    simpa [hrow] using
-      (Submodule.add_mem (LinearMap.range (Q.vecMulLinear)) (hM i) (hN i))
-  smul_mem' := by
-    intro a M hM i
-    have hrow : (a • M).row i = a • M.row i := by
-      ext j
-      simp [Matrix.row_apply]
-    simpa [hrow] using
-      (Submodule.smul_mem (LinearMap.range (Q.vecMulLinear)) a (hM i))
+    Submodule ℂ (Matrix (Fin D) (Fin D) ℂ) :=
+  Submodule.pi Set.univ (fun _ : Fin D => LinearMap.range (Q.vecMulLinear))
 
 /-- Identify the range of right-multiplication as the submodule of matrices whose rows lie in
 `range (Q.vecMulLinear)`. -/
 theorem range_mulRight_eq_pi (Q : Matrix (Fin D) (Fin D) ℂ) :
     LinearMap.range (LinearMap.mulRight ℂ Q) = rowRangeSubmodule (D := D) Q := by
   ext M
-  simpa [rowRangeSubmodule] using (mem_range_mulRight_iff_rows (D := D) Q M)
+  change M ∈ LinearMap.range (LinearMap.mulRight ℂ Q) ↔
+    ∀ i ∈ (Set.univ : Set (Fin D)), M i ∈ LinearMap.range (Q.vecMulLinear)
+  simpa [Matrix.row] using
+    (mem_range_mulRight_iff_rows (D := D) Q M)
 
 /-- The submodule `rowRangeSubmodule Q` is linearly equivalent to the product of the row ranges. -/
 noncomputable def rowRangeSubmoduleEquiv (Q : Matrix (Fin D) (Fin D) ℂ) :
     rowRangeSubmodule (D := D) Q ≃ₗ[ℂ] (Fin D → LinearMap.range (Q.vecMulLinear)) where
-  toFun M i := ⟨M.1.row i, M.2 i⟩
+  toFun M i := ⟨M.1.row i, M.2 i (Set.mem_univ i)⟩
   invFun f :=
     ⟨fun i j => (f i).1 j, by
-      intro i
+      intro i _
       change Matrix.row (fun i k => (f i).1 k : Matrix (Fin D) (Fin D) ℂ) i ∈
         LinearMap.range (Q.vecMulLinear)
       have hrow :


### PR DESCRIPTION
## Summary

This PR replaces the hand-built row and column range submodules in `TNLean.Wielandt.RectangularSpan.Ranges` by native Mathlib product-submodule constructions.

- `rowRangeSubmodule` is now `Submodule.pi Set.univ` applied to the range of `Matrix.toLin' P`.
- `colRangeSubmodule` is the comap of the same product submodule along `Matrix.transposeLinearEquiv`, so columns are represented as rows after transposition.
- The public range-identification lemmas, linear equivalences, and rank formulas keep their existing names and conclusions.

## Validation

- `lake env lean TNLean/Wielandt/RectangularSpan/Ranges.lean`
- `lake build TNLean.Wielandt.RectangularSpan.Ranges -q --log-level=info`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

The module build still reports the pre-existing copyright-header style warning in `TNLean/Wielandt/RectangularSpan/Ranges.lean`; this PR does not change that header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single module with no API renames; risk is mainly that the new definitions must remain propositionally equal to the old ones for downstream `simp`/`rfl` paths.
> 
> **Overview**
> **`colRangeSubmodule` and `rowRangeSubmodule`** no longer spell out carrier and `zero_mem` / `add_mem` / `smul_mem` by hand. They are built from Mathlib’s product submodules: rows use `Submodule.pi Set.univ` over `LinearMap.range (Q.vecMulLinear)`, and columns use the **transpose** linear equiv’s `Submodule.comap` into that same kind of product over `Matrix.toLin' P`.
> 
> **`range_mulLeft_eq_pi` and `range_mulRight_eq_pi`** now bridge membership through the pi formulation (transpose rows / matrix rows on `Set.univ`) before `simpa` with the existing column/row characterizations, instead of a one-step `simpa` on the old carrier.
> 
> **`colRangeSubmoduleEquiv` and `rowRangeSubmoduleEquiv`** only adjust for pi membership proofs (`Set.mem_univ`, extra `_` in `invFun`), so the equivalences still target `Fin D →` the per-index ranges. **`finrank_range_mulLeft` / `finrank_range_mulRight`** and the rest of the public API are unchanged in name and statement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 427e2935096a776226f5139f88e8b59fc326d1a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->