### PR TITLE
refactor(Algebra): use native end-to-CLM equivalence

### DIFF
--- a/TNLean/Algebra/MatrixOperatorSpace.lean
+++ b/TNLean/Algebra/MatrixOperatorSpace.lean
@@ -13,8 +13,6 @@ used for square complex matrices and their continuous linear endomorphisms.
 ## Main declarations
 
 * `TNLean.MatrixCLM` — continuous complex endomorphisms of square matrices
-* `TNLean.matrixEndEquiv` — the finite-dimensional equivalence between linear
-  and continuous matrix endomorphisms
 * `TNOperatorSpace` — scoped operator-norm, real-scalar, and
   finite-dimensional structure shared across the semigroup and channel files
 -/
@@ -29,11 +27,6 @@ noncomputable section
 /-- Complex continuous endomorphisms of square matrices. -/
 abbrev MatrixCLM (n : Type*) [Fintype n] [DecidableEq n] :=
   Matrix n n ℂ →L[ℂ] Matrix n n ℂ
-
-/-- The finite-dimensional equivalence between linear and continuous matrix endomorphisms. -/
-abbrev matrixEndEquiv (n : Type*) [Fintype n] [DecidableEq n] :
-    (Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) ≃ₐ[ℂ] MatrixCLM n :=
-  Module.End.toContinuousLinearMap (Matrix n n ℂ)
 
 end
 end TNLean
@@ -207,7 +200,7 @@ instance (n : Type*) [Fintype n] [DecidableEq n] :
 
 instance (n : Type*) [Fintype n] [DecidableEq n] :
     FiniteDimensional ℂ (TNLean.MatrixCLM n) :=
-  (TNLean.matrixEndEquiv n).toLinearEquiv.finiteDimensional
+  (Module.End.toContinuousLinearMap (Matrix n n ℂ)).toLinearEquiv.finiteDimensional
 
 instance (n : Type*) [Fintype n] [DecidableEq n] :
     CompleteSpace (TNLean.MatrixCLM n) :=

--- a/TNLean/Channel/Irreducible/SpectralRadius.lean
+++ b/TNLean/Channel/Irreducible/SpectralRadius.lean
@@ -91,7 +91,7 @@ private lemma spectralRadius_similarity_eq
         ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)) E) := by
   let Φ : (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) ≃ₐ[ℂ]
       TNLean.MatrixCLM (Fin D) :=
-    TNLean.matrixEndEquiv (Fin D)
+    Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)
   have hsim_alg :
       similarityMap (D := D) C E =
         (sandwichLinearEquiv (D := D) C hC).symm.conjAlgEquiv ℂ E := by
@@ -126,7 +126,8 @@ private lemma spectralRadius_smul
     spectralRadius ℂ (c • F) = (‖c‖₊ : ℝ≥0∞) * spectralRadius ℂ F := by
   letI : FiniteDimensional ℂ
       (Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ) :=
-    (TNLean.matrixEndEquiv (Fin D)).toLinearEquiv.finiteDimensional
+    (Module.End.toContinuousLinearMap
+      (Matrix (Fin D) (Fin D) ℂ)).toLinearEquiv.finiteDimensional
   have hF_nonempty : (spectrum ℂ F).Nonempty :=
     spectrum.nonempty_of_isAlgClosed_of_finiteDimensional ℂ F
   have hspec : spectrum ℂ (c • F) = c • spectrum ℂ F := by

--- a/TNLean/Channel/Semigroup/Basic.lean
+++ b/TNLean/Channel/Semigroup/Basic.lean
@@ -112,7 +112,7 @@ This uses finite-dimensionality of `Matrix (Fin D) (Fin D) ℂ`. -/
 abbrev endEquiv :
     (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) ≃ₐ[ℂ]
     MatrixCLM (Fin D) :=
-  matrixEndEquiv (Fin D)
+  Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ)
 
 /-! ## Semigroup definitions -/
 


### PR DESCRIPTION
### Motivation

- The project-local `TNLean.matrixEndEquiv` abbreviation introduced no independent mathematical content: it was the specialization of Mathlib's `Module.End.toContinuousLinearMap` to square complex matrices.
- Removing it eliminates a redundant indirection following the Mathlib 4.31 upgrade and aligns call sites with the native Mathlib equivalence throughout the codebase.

### Description

- `TNLean/Algebra/MatrixOperatorSpace.lean`: removes the `matrixEndEquiv` abbreviation and its module-docstring entry; the `FiniteDimensional` instance for `MatrixCLM` now cites `Module.End.toContinuousLinearMap` directly.
- `TNLean/Channel/Semigroup/Basic.lean`: `endEquiv` notation now points directly to the Mathlib equivalence rather than through the removed local abbreviation.
- `TNLean/Channel/Irreducible/SpectralRadius.lean`: the similarity map and `spectralRadius_smul` proofs use `Module.End.toContinuousLinearMap` directly for both the algebra equivalence and the finite-dimensionality witness.
- No theorem statement changes and no new proof assumptions are introduced.

### Testing

- `lake env lean TNLean/Algebra/MatrixOperatorSpace.lean`
- `lake build TNLean.Channel.Semigroup.Basic -q --log-level=info`
- `lake build TNLean.Channel.Irreducible.SpectralRadius -q --log-level=info`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- The Lake builds report pre-existing copyright-header and module-docstring style warnings in imported files; this PR does not change those headers or imported modules.

---
_No linked issue found — no open issue matches the changed files or the `codex/mathlib-4-31-native-pass-18` branch. Please link one manually if applicable._

> [!NOTE]
> **Low Risk**
> Mechanical alias removal with no API or proof-statement changes; behavior stays tied to the same Mathlib equivalence.
>
> **Overview**
> Removes the local **`TNLean.matrixEndEquiv`** abbreviation and uses Mathlib's **`Module.End.toContinuousLinearMap (Matrix n n ℂ)`** everywhere that equivalence was needed.
>
> **`MatrixOperatorSpace`** drops the abbrev and its module-doc bullet; the **`FiniteDimensional`** instance for **`MatrixCLM`** now cites that Mathlib map directly. **`Channel.Semigroup.Basic`** keeps **`endEquiv`** as notation but defines it with the same Mathlib equivalence. **`SpectralRadius`** updates the similarity and **`spectralRadius_smul`** proofs to use it for the algebra equiv and finite-dimensionality witness.
>
> No theorem statements or proof assumptions change—only which name points at the shared Mathlib definition.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b01350ff33f5323905511e63eef5f86ff5636f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename with no API or mathematical behavior change; the same Mathlib equivalence is used everywhere.
> 
> **Overview**
> Deletes the project-local **`TNLean.matrixEndEquiv`** abbreviation (it was only **`Module.End.toContinuousLinearMap (Matrix n n ℂ)`**) and updates the **`MatrixOperatorSpace`** module doc accordingly.
> 
> **`FiniteDimensional`** for **`MatrixCLM`**, semigroup **`endEquiv`**, and spectral-radius proofs now name **`Module.End.toContinuousLinearMap (Matrix … ℂ)`** directly instead of going through the removed alias. No theorem statements or proof assumptions change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4faf0438c2bdcc464d22449405cd92f40d6441eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->