### PR TITLE
refactor(PEPS): use native physical product equivalence

### DIFF
--- a/TNLean/PEPS/TorusRowColumnReductionObstruction.lean
+++ b/TNLean/PEPS/TorusRowColumnReductionObstruction.lean
@@ -171,15 +171,13 @@ injective at block length one.  The conjugate
 `Bunits i = Ginv (Aunits i) Gmat` has the same closed-chain coefficients and the
 same block injectivity, but the conjugator is `Gunit`, not a per-edge product. -/
 
-
-/-- The physical super-index `Fin 16` read as a pair `Fin 4 × Fin 4`. -/
-def physEquiv : Fin 16 ≃ Fin 4 × Fin 4 := (finProdFinEquiv (m := 4) (n := 4)).symm
-
 /-- The matrix-unit super-tensor: the physical index `k : Fin 16` decodes to a pair
 `(a, b) : Fin 4 × Fin 4`, and `Aunits k = single a b 1`.  Its range is the set of
 all matrix units. -/
 noncomputable def Aunits : MPSTensor 16 4 :=
-  fun k => Matrix.single (physEquiv k).1 (physEquiv k).2 1
+  fun k =>
+    let p := (finProdFinEquiv (m := 4) (n := 4)).symm k
+    Matrix.single p.1 p.2 1
 
 /-- The conjugate super-tensor `Bunits i = Gunit⁻¹ (Aunits i) Gunit`. -/
 noncomputable def Bunits : MPSTensor 16 4 :=
@@ -189,7 +187,7 @@ noncomputable def Bunits : MPSTensor 16 4 :=
 index `finProdFinEquiv (a, b)`. -/
 theorem Aunits_finProd (a b : Fin 4) :
     Aunits (finProdFinEquiv (a, b)) = Matrix.single a b 1 := by
-  simp [Aunits, physEquiv]
+  simp [Aunits]
 
 /-- Every matrix unit lies in the span of the range of `Aunits`, since it is a value
 of `Aunits`. -/


### PR DESCRIPTION
### Motivation

- The local `physEquiv` definition in `TNLean.PEPS.TorusRowColumnReductionObstruction` is an alias for `(finProdFinEquiv (m := 4) (n := 4)).symm` — a standard Mathlib equivalence — with no additional mathematical content.
- Replacing it with the Mathlib original inline removes an unnecessary indirection.

### Description

- `TNLean/PEPS/TorusRowColumnReductionObstruction.lean`: removes the `physEquiv` definition and decodes the `Fin 16` physical super-index directly via `(finProdFinEquiv (m := 4) (n := 4)).symm` in the body of `Aunits`.
- The lemma `Aunits_finProd` is simplified: the `physEquiv` unfolding step is dropped, and `simp [Aunits]` suffices.
- No theorem statements or hypotheses change; the behaviour of the row-column reduction obstruction witness is unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.PEPS.TorusRowColumnReductionObstruction -q --log-level=info`
- `git diff origin/main --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

The build reports pre-existing copyright-header style warnings in `TNLean/PEPS/TorusRowColumnReductionObstruction.lean`; this PR does not change those headers.

---
No linked issue identified. The branch name `codex/mathlib-4-31-native-pass-19` carries no issue reference; the author should link a relevant issue manually if one exists.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one PEPS file with unchanged statements and no logic changes.
> 
> **Overview**
> Removes the local `physEquiv` alias and decodes `Fin 16` physical indices in `Aunits` inline via Mathlib's `(finProdFinEquiv (m := 4) (n := 4)).symm`.
> 
> The `Aunits_finProd` proof drops the extra `physEquiv` simp step and only unfolds `Aunits`. **No theorem statements or assumptions change**; behavior of the row-column reduction obstruction witness is the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897ef191034b8cfc5bc99df3973f57759357e99d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single PEPS file with no statement or logical changes.
> 
> **Overview**
> Removes the local `physEquiv` alias (equivalent to Mathlib's `(finProdFinEquiv (m := 4) (n := 4)).symm`) and decodes `Fin 16` physical indices directly inside `Aunits` via a `let p := …` binding.
> 
> The `Aunits_finProd` proof no longer unfolds `physEquiv`; `simp [Aunits]` alone closes it. **Theorem statements, hypotheses, and the obstruction witness behavior are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3161946acc0c2082af3e2502d25ed49e789ac240. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->