### PR TITLE
refactor(MPS/MPDO): use native fin rotation facts

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -151,15 +151,7 @@ end MPOTensor
 /-- `finRotate` advances the value by one modulo `N`. -/
 theorem coe_finRotate_mod {N : ℕ} (i : Fin N) :
     ((finRotate N) i : ℕ) = (i.val + 1) % N := by
-  match N with
-  | 0 => exact i.elim0
-  | n + 1 =>
-    rw [coe_finRotate]
-    rcases eq_or_ne i (Fin.last n) with h | h
-    · subst h; simp [Fin.val_last, Nat.mod_self]
-    · rw [if_neg h]
-      have : (i : ℕ) < n := Fin.val_lt_last h
-      rw [Nat.mod_eq_of_lt (by omega)]
+  simp [Fin.add_def, finRotate_apply]
 
 /-- The value of the `p`-fold cyclic shift is `(i + p) mod N`. -/
 theorem coe_finRotate_pow {N : ℕ} (p : ℕ) (i : Fin N) :
@@ -201,11 +193,8 @@ theorem append_comp_finRotate_pow {α : Type*} {p q : ℕ}
 theorem cast_comp_finRotate_pow {N M : ℕ} (h : N = M) (p : ℕ) :
     (Fin.cast h) ∘ ((finRotate N : Fin N → Fin N)^[p])
       = ((finRotate M : Fin M → Fin M)^[p]) ∘ (Fin.cast h) := by
-  funext i
-  apply Fin.ext
-  simp only [Function.comp_apply, Fin.val_cast]
-  rw [coe_finRotate_pow, coe_finRotate_pow]
-  subst h; rfl
+  subst h
+  rfl
 
 /-- **Window-to-prefix configuration identity.** Placing the `m`-block `u` at the
 front (with `z, x` after) equals placing it in the middle (with `x` before and


### PR DESCRIPTION
### Motivation
- `MPOTensor.coe_finRotate_mod` and `cast_comp_finRotate_pow` in `TNLean/MPS/MPDO/AreaLaw.lean` used ad hoc proofs for cyclic-shift facts that Mathlib already provides via `finRotate_apply` in `Mathlib.Logic.Equiv.Fin.Rotate`.
- Replacing these with the native Mathlib API removes manual case-splits and index arithmetic, yielding shorter proofs aligned with upstream.

### Description
- `TNLean/MPS/MPDO/AreaLaw.lean`:
  - `MPOTensor.coe_finRotate_mod`: removes the case-split on `N` that manually handled the last index; closes with `simp [Fin.add_def, finRotate_apply]`.
  - `cast_comp_finRotate_pow`: drops the `funext`/`Fin.ext`/`coe_finRotate_pow` argument; closes with `subst h; rfl` after substituting the length equality `N = M`.
  - No theorem statements, hypotheses, or downstream declarations change.

### Testing
- `lake exe cache get`
- `lake build TNLean.MPS.MPDO.AreaLaw -q --log-level=info`
- `git diff origin/main --check`
- `git diff origin/main | rg -n "sorry|axiom|admit|native_decide|unsafeCast|opaque|constant"`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

The Lean build reports only pre-existing header/import style warnings in files on the dependency path.

---
No linked issue identified. The branch name `codex/mathlib-4-31-native-pass-20` carries no issue reference; the author should link a relevant issue manually if one exists.

> [!NOTE]
> **Low Risk**
> Local proof refactors in one Lean file with no API or mathematical statement changes.
> 
> **Overview**
> Proof-only cleanup in `TNLean/MPS/MPDO/AreaLaw.lean` for cyclic-shift lemmas used in MPDO area-law / translation-invariance arguments.
> 
> **`coe_finRotate_mod`** no longer case-splits on `N` and manually handles the last index; it closes with `simp [Fin.add_def, finRotate_apply]` using Mathlib's `finRotate` API (aligned with `Mathlib.Logic.Equiv.Fin.Rotate`).
> 
> **`cast_comp_finRotate_pow`** drops the `funext` / `Fin.ext` / `coe_finRotate_pow` argument and finishes with `subst h; rfl` once `N = M` is substituted.
> 
> No statement or downstream theorem changes—only shorter proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f81cb1ed5849030647c7c0bf7654be00221adf6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local proof refactors in one Lean file with no changes to statements, hypotheses, or downstream theorems.
> 
> **Overview**
> Proof-only cleanup in `TNLean/MPS/MPDO/AreaLaw.lean` for cyclic-shift lemmas used in MPDO area-law arguments. **Theorem statements and downstream uses are unchanged.**
> 
> **`coe_finRotate_mod`** drops the manual `N` case-split and last-index handling; the proof is now `simp [Fin.add_def, finRotate_apply]` instead of ad hoc arithmetic.
> 
> **`cast_comp_finRotate_pow`** no longer uses `funext`, `Fin.ext`, and `coe_finRotate_pow`; after `subst h` for `N = M`, it closes with `rfl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d008ff3d4eba0cf80f55de10e15bdd4a9b9e72c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->