### PR TITLE
refactor(MPS/Core): use native arrow congruence for word reversal

### DIFF
--- a/TNLean/MPS/Core/Blocking.lean
+++ b/TNLean/MPS/Core/Blocking.lean
@@ -341,16 +341,7 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
   have hLeft : ∑ i : Fin d, (Aadj i)ᴴ * Aadj i = 1 := by
     simpa [Aadj] using hRight
   let revEquiv : (Fin L → Fin d) ≃ (Fin L → Fin d) :=
-    { toFun := fun ρ => ρ ∘ Fin.rev
-      invFun := fun ρ => ρ ∘ Fin.rev
-      left_inv := by
-        intro ρ
-        ext i
-        simp [Function.comp_def]
-      right_inv := by
-        intro ρ
-        ext i
-        simp [Function.comp_def] }
+    Fin.revPerm.arrowCongr (Equiv.refl (Fin d))
   calc
     ∑ ρ : Fin L → Fin d,
         evalWord A (List.ofFn ρ) * (evalWord A (List.ofFn ρ))ᴴ
@@ -361,7 +352,8 @@ theorem sum_evalWord_mul_conjTranspose_evalWord
             intro ρ _
             have hword :
                 List.ofFn (revEquiv ρ) = (List.ofFn ρ).reverse := by
-              simpa [revEquiv] using list_ofFn_comp_fin_rev (σ := ρ)
+              simpa [revEquiv, Equiv.arrowCongr, Function.comp_def] using
+                list_ofFn_comp_fin_rev (σ := ρ)
             have hAdjEval :
                 (evalWord Aadj (List.ofFn (revEquiv ρ)))ᴴ =
                   evalWord A (List.ofFn ρ) := by


### PR DESCRIPTION
### Motivation
- The proof of `sum_evalWord_mul_conjTranspose_evalWord` in `TNLean/MPS/Core/Blocking.lean` used a hand-written `Equiv` for index reversal on length-`L` words, building explicit `toFun` / `invFun` fields and `Fin.rev` composition lemmas.
- Mathlib 4.31 already provides this equivalence as `Fin.revPerm.arrowCongr (Equiv.refl (Fin d))`, making the local construction redundant.

### Description
- Modified `TNLean/MPS/Core/Blocking.lean`: replaced the local `revEquiv` construction with `Fin.revPerm.arrowCongr (Equiv.refl (Fin d))`, the standard Mathlib instance of `Equiv.arrowCongr`.
- The `hword` step now unfolds the new equivalence via `Equiv.arrowCongr` and `Function.comp_def` before applying `list_ofFn_comp_fin_rev`.
- No theorem statements, hypotheses, or mathematical content are changed.

### Testing
- `lake exe cache get`
- `lake build TNLean.MPS.Core.Blocking -q --log-level=info`
- Changed-file proof-integrity token scan for `sorry`, `axiom`, `admit`, `native_decide`, and unsafe tokens.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
<!-- No linked issue found. Add "Addresses #N" here if one exists. -->

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only change in MPS blocking lemmas; no statements, APIs, or runtime behavior change.
>
> **Overview**
> In **`sum_evalWord_mul_conjTranspose_evalWord`** (`TNLean/MPS/Core/Blocking.lean`), the proof's word-reversal reindexing no longer builds a local `Equiv` with explicit `toFun` / `invFun` and `Fin.rev` composition lemmas.
>
> **`revEquiv`** is now **`Fin.revPerm.arrowCongr (Equiv.refl (Fin d))`**, matching Mathlib's standard function equivalence API. The **`hword`** step (`List.ofFn (revEquiv ρ) = (List.ofFn ρ).reverse`) unfolds **`revEquiv`** via **`Equiv.arrowCongr`** and **`Function.comp_def`** before applying **`list_ofFn_comp_fin_rev`**.
>
> Proof-only refactor: same theorem and argument structure, less boilerplate.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c199b30cff2f308a84e54cd4cdca8ef621d2c9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->