### PR TITLE
refactor(Algebra): use native finite product split

### DIFF
--- a/TNLean/Algebra/FiniteCycleCoboundary.lean
+++ b/TNLean/Algebra/FiniteCycleCoboundary.lean
@@ -21,13 +21,6 @@ namespace TNLean.Algebra
 
 variable {G : Type*} [CommGroup G]
 
-/-- The total product around the cycle is the product of the first `n` edges,
-multiplied by the last edge. -/
-lemma prod_univ_eq_prod_castSucc_last {n : ℕ} (κ : Fin (n + 1) → G) :
-    (∏ v : Fin (n + 1), κ v) =
-      (∏ v : Fin n, κ v.castSucc) * κ (Fin.last n) := by
-  rw [Fin.prod_univ_castSucc]
-
 private lemma prod_eq_partialProd_last {n : ℕ} (ψ : Fin n → G) :
     (∏ v : Fin n, ψ v) = Fin.partialProd ψ (Fin.last n) := by
   rw [← Fin.prod_ofFn]
@@ -55,7 +48,7 @@ lemma exists_fin_succ_coboundary_of_prod_eq_one {n : ℕ}
       Fin.partialProd_right_inv ψ v
     simpa [φ, ψ] using hquot.symm
   · have hsplit : (∏ v : Fin n, κ v.castSucc) * κ (Fin.last n) = 1 := by
-      simpa [prod_univ_eq_prod_castSucc_last κ] using hprod
+      simpa [Fin.prod_univ_castSucc] using hprod
     have hpartial : (∏ v : Fin n, κ v.castSucc) =
         Fin.partialProd ψ (Fin.last n) := by
       simpa [ψ] using prod_eq_partialProd_last ψ

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1134,24 +1134,6 @@ unconditional result.
     \]
 \end{lemma}
 
-\begin{lemma}[Splitting the last edge of a finite cycle]%
-    \label{lem:finite_cycle_product_split_last}
-    \lean{TNLean.Algebra.prod_univ_eq_prod_castSucc_last}
-    \leanok
-    \uses{}
-    For elements $\kappa_0,\ldots,\kappa_n$ of a commutative group,
-    \[
-        \prod_{k=0}^{n}\kappa_k
-        =
-        \left(\prod_{k=0}^{n-1}\kappa_k\right)\cdot\kappa_n.
-    \]
-\end{lemma}
-
-\begin{proof}\leanok
-    \uses{}
-    Separate the final factor from the product over the finite interval.
-\end{proof}
-
 \begin{lemma}[Finite-cycle coboundary]\label{lem:finite_cycle_coboundary}
     \lean{TNLean.Algebra.exists_fin_succ_coboundary_of_prod_eq_one}
     \lean{TNLean.Algebra.exists_fin_cyclic_coboundary_of_prod_eq_one}
@@ -1179,7 +1161,7 @@ unconditional result.
 \end{lemma}
 
 \begin{proof}\leanok
-    \uses{lem:finite_cycle_product_split_last}
+    \uses{}
     Set $\varphi_k=(\kappa_0\cdots\kappa_{k-1})^{-1}$, with the empty product
     equal to $1$. For $k<n$,
     \[
@@ -1190,7 +1172,7 @@ unconditional result.
         =
         \kappa_k.
     \]
-    The remaining identity follows from
+    Separating the final factor in the product-one hypothesis gives
     \[
         (\kappa_0\cdots\kappa_{n-1})\kappa_n=1,
     \]


### PR DESCRIPTION
### Motivation

- Removes the local lemma `prod_univ_eq_prod_castSucc_last`, which merely restated Mathlib's `Fin.prod_univ_castSucc` without adding mathematical content, reducing duplication in the `Algebra` module.
- Aligns the blueprint with the Lean development: the finite-cycle product-split step is now described inline in the coboundary proof rather than as a named standalone lemma.

### Description

- `TNLean/Algebra/FiniteCycleCoboundary.lean`: removed `prod_univ_eq_prod_castSucc_last`; the proof of `exists_fin_succ_coboundary_of_prod_eq_one` now calls Mathlib's `Fin.prod_univ_castSucc` directly to split the product into `castSucc` factors plus the final edge.
- `blueprint/src/chapter/ch22_periodic_ft.tex`: removed the standalone lemma "Splitting the last edge of a finite cycle" (`lem:finite_cycle_product_split_last`); that step is now described inline in the finite-cycle coboundary proof, and the `\uses{}` annotation no longer references the removed lemma.

### Testing

- `lake build TNLean.Algebra.FiniteCycleCoboundary -q --log-level=info`
- Proof-integrity token scan confirmed no `sorry`, `axiom`, `admit`, `native_decide`, or unsafe tokens in the changed diff.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls` was attempted but halted: no generated `blueprint/lean_decls` file in this worktree; full declaration checking deferred to CI.
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof and documentation refactor only; mathematical content is unchanged and coboundary lemmas still depend on the same Mathlib identity.
> 
> **Overview**
> Removes the local Lean lemma `prod_univ_eq_prod_castSucc_last` and uses Mathlib's `Fin.prod_univ_castSucc` directly in `exists_fin_succ_coboundary_of_prod_eq_one` when splitting the cycle product into interior `castSucc` factors and the closing edge.
> 
> The blueprint drops the standalone lemma **Splitting the last edge of a finite cycle** (`lem:finite_cycle_product_split_last`) and its `\lean` link; the finite-cycle coboundary proof now states that product split inline and no longer `\uses` the removed lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd6b0e534bf7cfedfddddce0d5bc31d0247180f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->