### PR TITLE
refactor(Algebra): centralize matrix zero-sum squares

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -21,6 +21,10 @@ Extracted from various files for reusability.
   trace identity
 - `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`: the Hilbert--Schmidt
   trace form of the Frobenius norm
+- `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`: a positive sum of squares
+  vanishes only if every summand vanishes
+- `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
+  variant
 - `Matrix.PosSemidef.mulVec_eq_zero_left/right`: kernel containment for PSD matrix sums
 -/
 
@@ -68,6 +72,49 @@ theorem trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq
   · positivity
 
 end FrobeniusTrace
+
+section SumSquaresZero
+
+variable {ι n : Type*} [Fintype ι] [Fintype n]
+
+/-- If `∑ᵢ Bᵢ * Bᵢ† = 0`, then every `Bᵢ` is zero. -/
+theorem eq_zero_of_sum_mul_conjTranspose_eq_zero
+    (B : ι → Matrix n n ℂ)
+    (h : ∑ i : ι, B i * (B i)ᴴ = 0) :
+    ∀ i, B i = 0 := by
+  intro i
+  have htrace_nonneg :
+      ∀ j : ι, 0 ≤ ((B j * (B j)ᴴ).trace).re :=
+    fun j =>
+      (Complex.le_def.mp (Matrix.posSemidef_self_mul_conjTranspose (B j)).trace_nonneg).1
+  have htrace_sum :
+      ∑ j : ι, ((B j * (B j)ᴴ).trace).re = 0 := by
+    rw [← Complex.re_sum, ← Matrix.trace_sum, h]
+    simp
+  have htrace_re : ((B i * (B i)ᴴ).trace).re = 0 :=
+    le_antisymm
+      (by
+        linarith [Finset.sum_eq_zero_iff_of_nonneg (fun j _ => htrace_nonneg j)
+          |>.mp htrace_sum i (Finset.mem_univ i)])
+      (htrace_nonneg i)
+  have hpsd := Matrix.posSemidef_self_mul_conjTranspose (B i)
+  have htrace_zero : (B i * (B i)ᴴ).trace = 0 :=
+    Complex.ext htrace_re (Complex.le_def.mp hpsd.trace_nonneg).2.symm
+  exact Matrix.self_mul_conjTranspose_eq_zero.mp (hpsd.trace_eq_zero_iff.mp htrace_zero)
+
+/-- If `∑ᵢ Bᵢ† * Bᵢ = 0`, then every `Bᵢ` is zero. -/
+theorem eq_zero_of_sum_conjTranspose_mul_self_eq_zero
+    (B : ι → Matrix n n ℂ)
+    (h : ∑ i : ι, (B i)ᴴ * B i = 0) :
+    ∀ i, B i = 0 := by
+  have hstar :
+      ∀ i, (B i)ᴴ = 0 :=
+    eq_zero_of_sum_mul_conjTranspose_eq_zero (fun i => (B i)ᴴ) (by
+      simpa only [Matrix.conjTranspose_conjTranspose] using h)
+  intro i
+  exact Matrix.conjTranspose_eq_zero.mp (hstar i)
+
+end SumSquaresZero
 
 end Matrix
 

--- a/TNLean/Channel/Irreducible/Basic.lean
+++ b/TNLean/Channel/Irreducible/Basic.lean
@@ -20,11 +20,6 @@ on matrix algebras `M_D(ℂ)`.
 * `IsIrreducibleMap`: a CP map with no non-trivial invariant projection
 * `HasUniqueFixedPoint`: unique PSD fixed point (up to scalar), which is positive definite
 
-## Main lemmas
-
-* `diagonal_mul_conjTranspose_eq_normSq_sum`: diagonal of `M * Mᴴ` is a sum of squared norms
-* `eq_zero_of_sum_mul_conjTranspose_eq_zero`: if `∑ Bᵢ Bᵢᴴ = 0` then each `Bᵢ = 0`
-
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 6.2,
@@ -130,36 +125,3 @@ lemma proj_zero_or_one_of_sandwich [DecidableEq (Fin D)]
       exact hsum ▸ (by simpa [Matrix.mul_apply] using h_entry)
     simp only [Matrix.sub_apply, Matrix.one_apply, Matrix.zero_apply]
     exact (mul_eq_zero.mp h_prod).resolve_right hlj
-
-/-- `(M * Mᴴ) c c = ∑ x, ‖M c x‖²` for any matrix `M`. -/
-lemma diagonal_mul_conjTranspose_eq_normSq_sum
-    (M : Matrix (Fin D) (Fin D) ℂ) (c : Fin D) :
-    (M * Mᴴ) c c = ↑(∑ x, Complex.normSq (M c x)) := by
-  rw [Matrix.mul_apply, Complex.ofReal_sum]
-  congr 1; ext x
-  simp [Matrix.conjTranspose_apply, Complex.normSq_eq_conj_mul_self]; ring
-
-/-- If `∑ᵢ Bᵢ * Bᵢᴴ = 0` then each `Bᵢ = 0`, since each term is PSD. -/
-lemma eq_zero_of_sum_mul_conjTranspose_eq_zero {ι : Type*} [Fintype ι]
-    (B : ι → Matrix (Fin D) (Fin D) ℂ)
-    (h : ∑ i : ι, B i * (B i)ᴴ = 0) :
-    ∀ i, B i = 0 := by
-  have h_each_diag : ∀ k c, (B k * (B k)ᴴ) c c = 0 := by
-    intro k c
-    have h_diag_eq : ∑ k' : ι, (B k' * (B k')ᴴ) c c = 0 := by
-      have := congr_fun (congr_fun h c) c
-      simpa only [Matrix.sum_apply, Matrix.zero_apply] using this
-    simp_rw [diagonal_mul_conjTranspose_eq_normSq_sum] at h_diag_eq ⊢
-    have h_nonneg : ∀ k', (0 : ℝ) ≤ ∑ x, Complex.normSq (B k' c x) :=
-      fun k' => Finset.sum_nonneg (fun x _ => Complex.normSq_nonneg _)
-    have h_sum_real : ∑ k' : ι, ∑ x, Complex.normSq (B k' c x) = 0 := by
-      exact_mod_cast h_diag_eq
-    simp [(Finset.sum_eq_zero_iff_of_nonneg (fun k' _ => h_nonneg k')).mp
-      h_sum_real k (Finset.mem_univ _)]
-  intro i; ext a b
-  have h_ii := h_each_diag i a
-  rw [diagonal_mul_conjTranspose_eq_normSq_sum] at h_ii
-  have h_sum_real : ∑ x, Complex.normSq (B i a x) = 0 := by exact_mod_cast h_ii
-  exact Complex.normSq_eq_zero.mp
-    ((Finset.sum_eq_zero_iff_of_nonneg (fun x _ => Complex.normSq_nonneg _)).mp
-      h_sum_real b (Finset.mem_univ _))

--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.PerronFrobenius.Normalization
+import TNLean.Algebra.MatrixAux
 import TNLean.Axioms.BrouwerFixedPoint
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Core.TPGauge
@@ -210,7 +211,7 @@ theorem adjointTransferMap_ne_zero_of_nonzero
   simp only [transferMap_apply, Matrix.mul_one] at h1
   -- ∑ (A j)ᴴ * ((A j)ᴴ)ᴴ = 0, so each (A j)ᴴ = 0, so each A j = 0.
   have h3 : ∀ j : Fin d, (A j)ᴴ = 0 :=
-    eq_zero_of_sum_mul_conjTranspose_eq_zero (fun j => (A j)ᴴ) h1
+    Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero (fun j => (A j)ᴴ) h1
   have : (A i)ᴴ = 0 := h3 i
   exact hi (Matrix.conjTranspose_eq_zero.mp this)
 

--- a/TNLean/Channel/PerronFrobenius/Normalization.lean
+++ b/TNLean/Channel/PerronFrobenius/Normalization.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
+import TNLean.Algebra.MatrixAux
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Schwarz.KadisonSchwarz
 
@@ -168,7 +169,8 @@ theorem IsIrreducibleMap.map_posSemidef_ne_zero
       simpa [hK] using hEρ
     simpa [hB', Matrix.mul_assoc, Matrix.conjTranspose_mul] using this
   have hKiB : ∀ i : Fin r, K i * Bᴴ = 0 :=
-    eq_zero_of_sum_mul_conjTranspose_eq_zero (B := fun i : Fin r => K i * Bᴴ) hsum0
+    Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero
+      (B := fun i : Fin r => K i * Bᴴ) hsum0
   have hKiρ : ∀ i : Fin r, K i * ρ = 0 := by
     intro i
     rw [hB']

--- a/TNLean/Channel/Schwarz/Basic.lean
+++ b/TNLean/Channel/Schwarz/Basic.lean
@@ -1,4 +1,5 @@
 import TNLean.Channel.Basic
+import TNLean.Algebra.MatrixAux
 
 /-!
 # CP Schwarz / Multiplicative-domain formalization for Kraus maps
@@ -270,29 +271,6 @@ theorem ks_equality_of_peripheral_eigenvector_of_fixedPoint
 
 /-! ## KS gap decomposition and Kraus-level commutation -/
 
-omit [DecidableEq n] in
-/-- If `∑ᵢ Rᵢ†Rᵢ = 0`, then each `Rᵢ = 0`. -/
-private lemma each_zero_of_sum_conjTranspose_mul_self_zero
-    (R : ι → Matrix n n ℂ)
-    (h : ∑ i : ι, (R i)ᴴ * R i = 0) :
-    ∀ i : ι, R i = 0 := by
-  intro i
-  have h_psd_i := Matrix.posSemidef_conjTranspose_mul_self (R i)
-  have h_each_nonneg : ∀ j : ι, 0 ≤ ((R j)ᴴ * R j).trace.re :=
-    fun j => (Complex.le_def.mp (Matrix.posSemidef_conjTranspose_mul_self (R j)).trace_nonneg).1
-  have h_tr_sum_re : (∑ j : ι, ((R j)ᴴ * R j).trace.re) = 0 := by
-    rw [← Complex.re_sum, ← Matrix.trace_sum, h]
-    simp
-  have h_tr_re : ((R i)ᴴ * R i).trace.re = 0 :=
-    le_antisymm
-      (by
-        linarith [Finset.sum_eq_zero_iff_of_nonneg (fun j _ => h_each_nonneg j)
-            |>.mp h_tr_sum_re i (Finset.mem_univ i)])
-      (h_each_nonneg i)
-  have h_tr_zero : ((R i)ᴴ * R i).trace = 0 :=
-    Complex.ext h_tr_re (Complex.le_def.mp h_psd_i.trace_nonneg).2.symm
-  exact Matrix.conjTranspose_mul_self_eq_zero.mp (h_psd_i.trace_eq_zero_iff.mp h_tr_zero)
-
 /-- **KS gap decomposition** at the level of Kraus operators.
 
 For unital `E(X)=∑ᵢKᵢXKᵢ†`,
@@ -358,8 +336,8 @@ theorem kraus_commute_of_ks_equality (K : ι → Matrix n n ℂ)
     simpa [h_gap] using this
   -- Each square term must vanish.
   have h_each :=
-    each_zero_of_sum_conjTranspose_mul_self_zero
-      (R := fun i => X * (K i)ᴴ - (K i)ᴴ * map K X) h_sum_zero
+    Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero
+      (B := fun i => X * (K i)ᴴ - (K i)ᴴ * map K X) h_sum_zero
   intro i
   exact sub_eq_zero.mp (h_each i)
 

--- a/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
@@ -87,26 +87,6 @@ end KSEquality
 
 section KSGapDecomposition
 
-/-- If `∑ᵢ Rᵢ† Rᵢ = 0`, then each `Rᵢ = 0`. -/
-private lemma each_zero_of_sum_conjTranspose_mul_self_zero
-    (R : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (h : ∑ i : Fin d, (R i)ᴴ * R i = 0) :
-    ∀ i : Fin d, R i = 0 := by
-  intro i
-  have h_psd_i := Matrix.posSemidef_conjTranspose_mul_self (R i)
-  have h_each_nonneg : ∀ j, 0 ≤ ((R j)ᴴ * R j).trace.re :=
-    fun j => (Complex.le_def.mp (Matrix.posSemidef_conjTranspose_mul_self (R j)).trace_nonneg).1
-  have h_tr_sum_re : (∑ j : Fin d, ((R j)ᴴ * R j).trace.re) = 0 := by
-    rw [← Complex.re_sum, ← Matrix.trace_sum, h]; simp
-  have h_tr_re : ((R i)ᴴ * R i).trace.re = 0 :=
-    le_antisymm
-      (by linarith [Finset.sum_eq_zero_iff_of_nonneg (fun j _ => h_each_nonneg j)
-            |>.mp h_tr_sum_re i (Finset.mem_univ i)])
-      (h_each_nonneg i)
-  have h_tr_zero : ((R i)ᴴ * R i).trace = 0 :=
-    Complex.ext h_tr_re (Complex.le_def.mp h_psd_i.trace_nonneg).2.symm
-  exact Matrix.conjTranspose_mul_self_eq_zero.mp (h_psd_i.trace_eq_zero_iff.mp h_tr_zero)
-
 /-- **KS gap decomposition**. The Kadison-Schwarz gap decomposes as a sum of
 squares at the Kraus-operator level:
 
@@ -179,7 +159,7 @@ theorem kraus_commute_of_ks_equality (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     rw [h_gap] at this
     exact this
   -- Each term is zero
-  have h_each := each_zero_of_sum_conjTranspose_mul_self_zero
+  have h_each := Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero
     (fun i => X * (K i)ᴴ - (K i)ᴴ * krausMap K X) h_sum_zero
   intro i
   exact sub_eq_zero.mp (h_each i)

--- a/TNLean/Channel/Semigroup/ReducibleQDS/Equivalence.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/Equivalence.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Channel.Semigroup.ReducibleQDS.FixedDensity
 import TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression
 import TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis
+import TNLean.Algebra.MatrixAux
 
 /-!
 # Reducibility Definition and Full Equivalence (Wolf Proposition 7.6)
@@ -114,12 +115,11 @@ theorem wolf_prop_7_6_full_equivalence
 /-- If `∑ⱼ Bⱼ Bⱼ† = 0` for square matrices, then each `Bⱼ = 0`.
 
 This is the key algebraic fact needed for the (3) → (4) direction of
-Wolf Proposition 7.6. The proof delegates to the existing
-`eq_zero_of_sum_mul_conjTranspose_eq_zero` from `Channel.Irreducible.Basic`. -/
+Wolf Proposition 7.6. -/
 theorem sum_conjTranspose_mul_self_eq_zero_imp
     {r : ℕ} (B : Fin r → Mat)
     (h : ∑ j, B j * (B j)ᴴ = 0) :
     ∀ j, B j = 0 :=
-  eq_zero_of_sum_mul_conjTranspose_eq_zero B h
+  Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero B h
 
 end -- noncomputable section

--- a/TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Algebra.MatrixOperatorSpace
+import TNLean.Algebra.MatrixAux
 import TNLean.Channel.Semigroup.ReducibleQDS.Defs
 
 /-!
@@ -82,7 +83,7 @@ theorem lindblad_block_of_generatorPreservesCompression
               rw [← Matrix.mul_assoc, hPP]
       _ = (1 - P) * (F.L j * P * (F.L j)ᴴ) * (1 - P) := by
               simp [Matrix.mul_assoc]
-  exact eq_zero_of_sum_mul_conjTranspose_eq_zero _ hsum_zero
+  exact Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero _ hsum_zero
 
 /-- If the generator preserves the compression and all Lindblad operators
 satisfy `(1-P)*Lⱼ*P = 0`, then the effective Hamiltonian `κ` also satisfies

--- a/TNLean/MPS/Core/CPPrimitive.lean
+++ b/TNLean/MPS/Core/CPPrimitive.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.Core.Transfer
+import TNLean.Algebra.MatrixAux
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Schwarz.KadisonSchwarz
 
@@ -15,10 +16,9 @@ variable {d D : ℕ}
 /-! ## MPS injectivity implies irreducibility of the transfer map
 
 The general definitions (`IsOrthogonalProjection`, `IsIrreducibleMap`,
-`HasUniqueFixedPoint`) and the supporting matrix-algebra lemmas
-(`diagonal_mul_conjTranspose_eq_normSq_sum`,
-`eq_zero_of_sum_mul_conjTranspose_eq_zero`) live in
-`TNLean.Channel.Irreducible.Basic`.
+`HasUniqueFixedPoint`) are stated in `TNLean.Channel.Irreducible.Basic`. The
+supporting sum-of-squares matrix lemma
+`Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero` is stated in `TNLean.Algebra.MatrixAux`.
 
 This file proves the MPS-specific connection: injectivity of an MPS tensor
 implies irreducibility of its transfer map.
@@ -63,7 +63,7 @@ private lemma invariance_implies_complement_zero (A : MPSTensor d D)
     simp_rw [key, ← Finset.sum_mul, ← Finset.mul_sum]
     rw [show ∑ i : Fin d, A i * P * (A i)ᴴ = transferMap (d := d) (D := D) A P from by
       rw [transferMap_apply], h_EP, zero_mul]
-  exact eq_zero_of_sum_mul_conjTranspose_eq_zero _ h_sum_zero
+  exact Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero _ h_sum_zero
 
 /-! #### The main irreducibility theorem -/
 

--- a/TNLean/MPS/Irreducible/FormII.lean
+++ b/TNLean/MPS/Irreducible/FormII.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.Core.OrthogonalProjectionInvariance
 import TNLean.QPF.Assembly
 import Mathlib.LinearAlgebra.Matrix.IsDiag
@@ -89,7 +90,7 @@ lemma invariance_implies_lowerZero
     simp_rw [key, ← Finset.sum_mul, ← Finset.mul_sum]
     rw [show ∑ i : Fin d, A i * P * (A i)ᴴ = transferMap (d := d) (D := D) A P from by
       rw [transferMap_apply], h_EP, zero_mul]
-  exact eq_zero_of_sum_mul_conjTranspose_eq_zero _ h_sum_zero
+  exact Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero _ h_sum_zero
 
 /-- **Irreducible tensor ⇒ irreducible CP map.**
 

--- a/TNLean/MPS/Periodic/SectorIrreducibility/ProjectionOrtho.lean
+++ b/TNLean/MPS/Periodic/SectorIrreducibility/ProjectionOrtho.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.CanonicalForm.CyclicSectors
+import TNLean.Algebra.MatrixAux
 import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Irreducible.PeriodicBlocking
@@ -88,7 +89,7 @@ theorem pairwise_mul_zero_of_orthogonalProjection_sum_one
                     _ = P i * (P k * P i) := by rw [(hPproj k).2]
                     _ = P i * P k * P i := by simp [Matrix.mul_assoc]
       _ = 0 := hsum_erase
-  have hB_zero := eq_zero_of_sum_mul_conjTranspose_eq_zero B hsum_B
+  have hB_zero := Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero B hsum_B
   have hPiPj : P i * P j = 0 := by
     by_cases hji : j = i
     · exact False.elim (hij hji.symm)
@@ -141,4 +142,3 @@ theorem preservesCorner_of_adjoint_fixed_projection
                     simp only [Matrix.mul_assoc]
             _ = (A i)ᴴ * (P * X * P) * A i := by
                     simp only [Matrix.mul_assoc, hP.2]
-


### PR DESCRIPTION
### Motivation

- The "zero sum of positive-semidefinite matrix squares implies each summand is zero" argument was duplicated as private lemmas in `Channel.Schwarz.Basic`, `Channel.Schwarz.MultiplicativeDomain`, and as an entrywise diagonal norm-square expansion in `Channel.Irreducible.Basic`.
- Centralizing these in `Algebra.MatrixAux` removes duplication and leverages Mathlib 4.31 PSD facts (`PosSemidef.trace_eq_zero_iff`, `self_mul_conjTranspose_eq_zero`, `conjTranspose_eq_zero`) in place of the lower-level entrywise `normSq` approach.

### Description

- **`TNLean/Algebra/MatrixAux.lean`** (+45): Adds `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero` and `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`, proved via PSD summands and trace nonnegativity.
- **`TNLean/Channel/Irreducible/Basic.lean`** (−38): Removes the unused entrywise diagonal norm-square lemma.
- **`TNLean/Channel/Schwarz/Basic.lean`** (−25), **`TNLean/Channel/Schwarz/MultiplicativeDomain.lean`** (−21): Removes two private zero-sum square lemmas, replaced by the shared `Matrix` theorems.
- **`TNLean/Channel/PerronFrobenius/Existence.lean`**, **`TNLean/Channel/PerronFrobenius/Normalization.lean`**, **`TNLean/Channel/Semigroup/ReducibleQDS/Equivalence.lean`**, **`TNLean/Channel/Semigroup/ReducibleQDS/GeneratorCompression.lean`**, **`TNLean/MPS/Core/CPPrimitive.lean`**, **`TNLean/MPS/Irreducible/FormII.lean`**, **`TNLean/MPS/Periodic/SectorIrreducibility/ProjectionOrtho.lean`**: Updated imports and call sites to use the shared `Matrix` lemmas; external theorem statements are unchanged.

### Testing

- `lake build TNLean.Algebra.MatrixAux TNLean.Channel.Schwarz.Basic TNLean.Channel.Schwarz.MultiplicativeDomain TNLean.Channel.Irreducible.Basic TNLean.Channel.PerronFrobenius.Existence TNLean.Channel.PerronFrobenius.Normalization TNLean.Channel.Semigroup.ReducibleQDS.Equivalence TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression TNLean.MPS.Irreducible.FormII TNLean.MPS.Core.CPPrimitive TNLean.MPS.Periodic.SectorIrreducibility.ProjectionOrtho -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Proof-integrity scan: no `sorry`, `axiom`, `admit`, `native_decide`, `unsafeCast`, or `unsafeCoerce` introduced.
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---

> [!NOTE]
> **Low Risk**
> Pure lemma relocation and proof refactor with no change to stated theorems; low risk aside from import-graph and naming at call sites.
>
> **Overview**
> **Centralizes** the "zero sum of matrix squares ⇒ each summand is zero" argument in `TNLean.Algebra.MatrixAux` as `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero` and `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`, proved via PSD summands and trace nonnegativity instead of entrywise `normSq` on diagonals.
>
> **Removes** the duplicate lemmas (and unused `diagonal_mul_conjTranspose_eq_normSq_sum`) from `Channel.Irreducible.Basic` and **deletes** the two private Schwarz copies in `Channel.Schwarz.Basic` and `MultiplicativeDomain.lean`.
>
> **Wires** Perron–Frobenius, reducible QDS, Kadison–Schwarz gap steps, and MPS irreducibility/projection proofs to the shared `Matrix` theorems via new `MatrixAux` imports; external theorem statements are unchanged aside from the `Matrix.` prefix at call sites.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18fd5cf31faf218da618d81de55ed4ac6e8c4228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure lemma relocation and proof refactor with no change to external theorem statements; risk is limited to import graph and qualified names at call sites.
> 
> **Overview**
> **Moves** the “zero sum of matrix squares ⇒ each summand is zero” argument into `TNLean.Algebra.MatrixAux` as `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero` and `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`, proved via PSD summands and trace nonnegativity instead of entrywise `normSq` on diagonals.
> 
> **Deletes** the duplicate implementations from `Channel.Irreducible.Basic` (including unused `diagonal_mul_conjTranspose_eq_normSq_sum`) and the two private copies in `Channel.Schwarz.Basic` and `Channel.Schwarz.MultiplicativeDomain`.
> 
> **Updates** Perron–Frobenius, reducible QDS, Kadison–Schwarz gap, and MPS irreducibility/projection proofs to import `MatrixAux` and call the shared `Matrix` theorems; stated theorems are unchanged aside from the `Matrix.` prefix at use sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2365196e7950935b74afab9eff4f5df4405a41ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->