### PR TITLE
refactor(Algebra): use native trace extensionality

### DIFF
--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -203,7 +203,7 @@ theorem traceMulRightPi_ker_eq_bot {A : MPSTensor d D} (hA : IsInjective A) :
     intro i
     simpa using congrArg (· i) hM
   -- Use trace nondegeneracy.
-  exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) M).1 fun N => by
+  exact (Matrix.ext_iff_trace_mul_right (A := M) (B := 0)).2 fun N => by
     simpa [Matrix.traceLinearMap_apply] using congrArg (· N) hφ
 
 /-- If `A` is injective and `A`, `B` generate the same MPV family,

--- a/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
+++ b/TNLean/MPS/FundamentalTheorem/FiniteLength.lean
@@ -203,7 +203,7 @@ theorem sameMPV_of_sameMPVFrom_of_injective [NeZero D]
   set S := ∑ i, c i • B i
   have hS : S = 1 := by
     suffices h : S - 1 = 0 from sub_eq_zero.mp h
-    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (S - 1)).1
+    apply (Matrix.ext_iff_trace_mul_right (A := S - 1) (B := 0)).2
     intro N
     -- The linear functional tr((S−1) · _) vanishes on wordSpan B N₀ = ⊤
     have hf : (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp

--- a/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/Core.lean
@@ -437,11 +437,11 @@ theorem pairTraceSeparatingAt_of_pairWordTupleSpanTop {D₁ D₂ : ℕ}
         exact hΔ w)
       M hM
   constructor
-  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₁) ΔA).1
+  · apply (Matrix.ext_iff_trace_mul_right (A := ΔA) (B := 0)).2
     intro M
     have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
-  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₂) ΔB).1
+  · apply (Matrix.ext_iff_trace_mul_right (A := ΔB) (B := 0)).2
     intro N
     have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
@@ -501,11 +501,11 @@ theorem pairTraceSeparatingUpTo_of_pairCumulativeWordTupleSpanTop {D₁ D₂ : �
         exact hΔ w hw)
       M (by simpa [pairCumulativeSpan] using hM)
   constructor
-  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₁) ΔA).1
+  · apply (Matrix.ext_iff_trace_mul_right (A := ΔA) (B := 0)).2
     intro M
     have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
-  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₂) ΔB).1
+  · apply (Matrix.ext_iff_trace_mul_right (A := ΔB) (B := 0)).2
     intro N
     have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
@@ -593,11 +593,11 @@ theorem pairTraceSeparatingAll_of_pairAllWordsSpanTop {D₁ D₂ : ℕ}
         exact hΔ w)
       M (by simpa [pairAllWordsSpan] using hM)
   constructor
-  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₁) ΔA).1
+  · apply (Matrix.ext_iff_trace_mul_right (A := ΔA) (B := 0)).2
     intro M
     have hpair := hZeroOnSpan (M, 0) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair
-  · apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D₂) ΔB).1
+  · apply (Matrix.ext_iff_trace_mul_right (A := ΔB) (B := 0)).2
     intro N
     have hpair := hZeroOnSpan (0, N) (by rw [hSpan]; exact Submodule.mem_top)
     simpa using hpair

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumInput.lean
@@ -235,7 +235,7 @@ theorem leftTraceWordMap_injective_of_isNBlkInjective {A : MPSTensor d D}
     · intro t
       simpa [leftTraceWordMap_apply, Matrix.traceLinearMap_apply] using
         congrArg (fun f => f t) hZ
-  exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) Z).1 fun N => by
+  exact (Matrix.ext_iff_trace_mul_right (A := Z) (B := 0)).2 fun N => by
     simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
 
 /-- Under block injectivity, the trace-test image has the full boundary-matrix

--- a/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockStrip.lean
@@ -63,12 +63,13 @@ theorem groundSpaceMap_injective_of_wordSpan_eq_top {A : MPSTensor d D}
       · intro σ
         simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
           congrArg (fun ψ => ψ σ) hX
-    exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) X).1 fun N => by
+    exact (Matrix.ext_iff_trace_mul_right (A := X) (B := 0)).2 fun N => by
       have hNX : Matrix.trace (N * X) = 0 := by
         simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
       calc
         Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
         _ = 0 := hNX
+        _ = Matrix.trace (0 * N) := by simp
   exact LinearMap.ker_eq_bot.mp hker
 
 /-- Block injectivity at length \(L₀\) makes the map \(Γ_{L₀}\) injective. -/

--- a/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/IntersectionProperty.lean
@@ -251,12 +251,13 @@ theorem groundSpaceMap_injective {A : MPSTensor d D} (hA : IsInjective A)
       · intro σ
         simpa [groundSpaceMap_apply, Matrix.traceLinearMap_apply] using
           congrArg (fun ψ => ψ σ) hX
-    exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) X).1 fun N => by
+    exact (Matrix.ext_iff_trace_mul_right (A := X) (B := 0)).2 fun N => by
       have hNX : Matrix.trace (N * X) = 0 := by
         simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
       calc
         Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
         _ = 0 := hNX
+        _ = Matrix.trace (0 * N) := by simp
   exact LinearMap.ker_eq_bot.mp hker
 
 /-- For an injective tensor, the ground space has dimension exactly \(D^2\) for

--- a/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
+++ b/TNLean/MPS/ParentHamiltonian/Nonvanishing.lean
@@ -112,7 +112,7 @@ theorem mpv_ne_zero_of_isNBlkInjective {A : MPSTensor d D} [NeZero D]
       evalWord A w₂ = 0 := by
     intro w₂ hw₂
     -- Show ∀ M, tr(evalWord A w₂ * M) = 0 to get evalWord A w₂ = 0.
-    apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) (evalWord A w₂)).1
+    apply (Matrix.ext_iff_trace_mul_right (A := evalWord A w₂) (B := 0)).2
     intro M
     -- The functional P ↦ tr(P * evalWord A w₂) vanishes on wordSpan A L₀ = ⊤.
     have hφ : (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp
@@ -140,6 +140,7 @@ theorem mpv_ne_zero_of_isNBlkInjective {A : MPSTensor d D} [NeZero D]
         = Matrix.trace (M * evalWord A w₂) := Matrix.trace_mul_comm ..
       _ = 0 := by
           simpa [Matrix.traceLinearMap_apply] using congrArg (· M) hφ
+      _ = Matrix.trace (0 * M) := by simp
   exact allZero_contradiction hInj hL₀ (by omega : 0 < N - L₀) hprod_zero
 
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -374,11 +374,12 @@ private theorem eq_zero_of_trace_evalWord_mul_eq_zero {A : MPSTensor d D}
     · simpa [wordSpan] using hwordK
     · intro σ
       simp [Matrix.traceLinearMap_apply, h σ]
-  exact (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) X).1 fun N => by
+  exact (Matrix.ext_iff_trace_mul_right (A := X) (B := 0)).2 fun N => by
     have hNX : Matrix.trace (N * X) = 0 := by
       simpa [Matrix.traceLinearMap_apply] using congrArg (fun f => f N) hφ
     calc Matrix.trace (X * N) = Matrix.trace (N * X) := Matrix.trace_mul_comm X N
     _ = 0 := hNX
+    _ = Matrix.trace (0 * N) := by simp
 
 /-! ### Uniqueness theorems -/
 

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -149,9 +149,10 @@ theorem isCID_implies_isRFP
   suffices h_diff : transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) -
       transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)) = 0 from
     eq_of_sub_eq_zero h_diff
-  apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin D)
-    (transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) -
-      transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)))).1
+  apply (Matrix.ext_iff_trace_mul_right
+    (A := transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) -
+      transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)))
+    (B := 0)).2
   intro N
   -- From IsCID with n=2, m=1: correlator equality gives trace equality
   have h := hCID ↑u hρ_pd hρ_fix X N 2 1 (by omega) (by omega)
@@ -162,7 +163,11 @@ theorem isCID_implies_isRFP
   -- Goal: tr((E(E(X*ρR)) - E(X*ρR)) * N) = 0
   rw [sub_mul, Matrix.trace_sub,
     Matrix.trace_mul_comm _ N, Matrix.trace_mul_comm _ N]
-  exact sub_eq_zero.mpr heq
+  calc
+    Matrix.trace (N * transferMap A (transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ)))) -
+        Matrix.trace (N * transferMap A (X * (u : Matrix (Fin D) (Fin D) ℂ))) = 0 :=
+      sub_eq_zero.mpr heq
+    _ = Matrix.trace (0 * N) := by simp
 
 /-- Single-block ZCL is equivalent to transfer-map idempotence (i.e. `IsRFP`).
 

--- a/TNLean/PEPS/CycleMPSInjectivity.lean
+++ b/TNLean/PEPS/CycleMPSInjectivity.lean
@@ -393,7 +393,9 @@ theorem matrix_eq_zero_of_isNBlkInjective {L : ℕ} {A : MPSTensor d D}
       rw [hpair]
       exact hC x
     simpa using hle hM
-  have hCt : Cᵀ = 0 := (Matrix.trace_mul_right_eq_zero_iff (n := Fin D) Cᵀ).1 hker
+  have hCt : Cᵀ = 0 := (Matrix.ext_iff_trace_mul_right (A := Cᵀ) (B := 0)).2
+    fun M => by
+      simpa using hker M
   simpa using congrArg Matrix.transpose hCt
 
 variable [NeZero n]

--- a/TNLean/PiAlgebra/Construction.lean
+++ b/TNLean/PiAlgebra/Construction.lean
@@ -248,12 +248,14 @@ theorem piTrace_mul_right_eq_zero
     M = 0 := by
   classical
   funext k
-  apply (Matrix.trace_mul_right_eq_zero_iff (n := Fin (dim k)) (M k)).1
+  apply (Matrix.ext_iff_trace_mul_right (A := M k) (B := 0)).2
   intro N_k
   have := h (Function.update 0 k N_k)
-  rwa [Finset.sum_eq_single k
-    (fun j _ hj => by rw [Function.update_of_ne hj, Pi.zero_apply, mul_zero, Matrix.trace_zero])
-    (fun hk => absurd (Finset.mem_univ k) hk), Function.update_self] at this
+  have htrace : Matrix.trace (M k * N_k) = 0 := by
+    rwa [Finset.sum_eq_single k
+      (fun j _ hj => by rw [Function.update_of_ne hj, Pi.zero_apply, mul_zero, Matrix.trace_zero])
+      (fun hk => absurd (Finset.mem_univ k) hk), Function.update_self] at this
+  simpa using htrace
 
 end PiTraceNondeg
 


### PR DESCRIPTION
### Motivation

- Mathlib 4.31 provides `Matrix.ext_iff_trace_mul_right`, which directly characterises matrix equality by vanishing right trace pairings.
- Internal proof scripts were routing through TNLean's project-level wrapper `Matrix.trace_mul_right_eq_zero_iff` for this purpose; switching to the Mathlib primitive removes one layer of indirection.
- A reported blueprint reference to `LinearMap.IsSymmetricProjection.re_inner_nonneg` is absent on the current base; the blueprint already names the correct projection-geometry declarations and no change is required there.

### Description

- `TNLean/Algebra/TracePairing.lean`: the forward direction of `Matrix.trace_mul_right_eq_zero_iff` is now derived via `Matrix.ext_iff_trace_mul_right`; the blueprint-facing statement is retained.
- Proof scripts in `MPS/ParentHamiltonian/` (BlockStrip, IntersectionProperty, Nonvanishing, UniqueGroundState), `MPS/FundamentalTheorem/FiniteLength.lean`, `MPS/MPDO/BiCFDerivation/` (Core, DirectSumInput), `MPS/RFP/ZeroCorrelationLength.lean`, `PEPS/CycleMPSInjectivity.lean`, and `PiAlgebra/Construction.lean` are updated to invoke `Matrix.ext_iff_trace_mul_right` directly rather than routing through the project wrapper. A few proof scripts add short `calc` steps to match the `A - B` formulation of the extensionality lemma.
- No mathematical statement changes; no `sorry` introduced.

### Testing

- `lake build TNLean.Algebra.TracePairing TNLean.MPS.ParentHamiltonian.Nonvanishing TNLean.MPS.ParentHamiltonian.IntersectionProperty TNLean.MPS.ParentHamiltonian.UniqueGroundState TNLean.MPS.ParentHamiltonian.BlockStrip TNLean.MPS.RFP.ZeroCorrelationLength TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput TNLean.MPS.MPDO.BiCFDerivation.Core TNLean.MPS.FundamentalTheorem.FiniteLength TNLean.PEPS.CycleMPSInjectivity TNLean.PiAlgebra.Construction -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff -U0 HEAD^..HEAD -- '*.lean' | rg -n "^\+.*\b(sorry|axiom|admit|native_decide|unsafeCast|unsafeCoerce|opaque|constant)\b" || true`

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mechanical proof refactor with no statement changes; only import/API routing to Mathlib’s trace extensionality lemma.
> 
> **Overview**
> Proof scripts across MPS, PEPS, and Pi-algebra now call Mathlib’s **`Matrix.ext_iff_trace_mul_right`** instead of the project wrapper **`Matrix.trace_mul_right_eq_zero_iff`**, aligning with Mathlib 4.31 and dropping one indirection layer.
> 
> In **`TracePairing.lean`**, the forward direction of **`trace_mul_right_eq_zero_iff`** is derived from that lemma; the public iff statement is unchanged. Call sites in parent-Hamiltonian, finite-length FT, MPDO biCF, RFP/ZCL, cycle MPS injectivity, and Pi-algebra proofs pass explicit **`A`** and **`B := 0`**; several **`calc`** steps end with **`Matrix.trace (0 * N)`** so goals match the **`A - B`** form of extensionality.
> 
> No theorem statements or proof obligations change—refactor only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40dd4d7d73bdbbb351c6dfdbfc2329e026230940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->