### PR TITLE
refactor(Channel): use native left multiplication hom

### DIFF
--- a/TNLean/Channel/Semigroup/Dissipative.lean
+++ b/TNLean/Channel/Semigroup/Dissipative.lean
@@ -53,13 +53,6 @@ abbrev dissipativeDrift (κ : Mat D) : LM D :=
     dissipativeDrift κ ρ = -κ * ρ - ρ * κᴴ := by
   simp [dissipativeDrift, LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
 
-private abbrev leftMulAlgHom (D : ℕ) : Mat D →ₐ[ℂ] LM D :=
-  Algebra.lmul ℂ (Mat D)
-
-private theorem leftMulAlgHom_apply (A ρ : Mat D) :
-    leftMulAlgHom D A ρ = A * ρ := by
-  simp [leftMulAlgHom]
-
 private def matExpD (A : Mat D) : Mat D :=
   letI : NormedRing (Mat D) := Matrix.linftyOpNormedRing (n := Fin D) (α := ℂ)
   letI : NormedAlgebra ℂ (Mat D) :=
@@ -79,15 +72,14 @@ private theorem rightMulAlgHom_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
   simp [rightMulAlgHom]
 
 private abbrev leftMulCLMAlgHom (D : ℕ) : Mat D →ₐ[ℂ] MatrixCLM (Fin D) :=
-  (endEquiv (D := D)).toAlgHom.comp (leftMulAlgHom D)
+  (endEquiv (D := D)).toAlgHom.comp (Algebra.lmul ℂ (Mat D))
 
 private abbrev rightMulCLMAlgHom (D : ℕ) : (Mat D)ᵐᵒᵖ →ₐ[ℂ] MatrixCLM (Fin D) :=
   (endEquiv (D := D)).toAlgHom.comp (rightMulAlgHom D)
 
 private theorem leftMulCLM_apply (A ρ : Mat D) :
     leftMulCLMAlgHom D A ρ = A * ρ := by
-  change leftMulAlgHom D A ρ = A * ρ
-  exact leftMulAlgHom_apply A ρ
+  rfl
 
 private theorem rightMulCLM_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
     rightMulCLMAlgHom D A ρ = ρ * MulOpposite.unop A := by
@@ -121,11 +113,6 @@ private lemma continuous_rightMulCLMAlgHom :
   rw [h_eq]
   exact (ContinuousLinearMap.mul ℂ (Mat D)).flip.continuous.comp hunop
 
-private theorem mulLeft_eq_leftMulAlgHom (A : Mat D) :
-    LinearMap.mulLeft ℂ A = leftMulAlgHom D A := by
-  ext ρ i j
-  simp
-
 private theorem mulRight_eq_rightMulAlgHom (A : Mat D) :
     LinearMap.mulRight ℂ A = rightMulAlgHom D (MulOpposite.op A) := by
   ext ρ i j
@@ -134,8 +121,7 @@ private theorem mulRight_eq_rightMulAlgHom (A : Mat D) :
 
 private theorem endEquiv_mulLeft (A : Mat D) :
     endEquiv (D := D) (LinearMap.mulLeft ℂ A) = leftMulCLMAlgHom D A := by
-  simpa [leftMulCLMAlgHom] using
-    congrArg (endEquiv (D := D)) (mulLeft_eq_leftMulAlgHom (D := D) A)
+  rfl
 
 private theorem endEquiv_mulRight (A : Mat D) :
     endEquiv (D := D) (LinearMap.mulRight ℂ A) = rightMulCLMAlgHom D (MulOpposite.op A) := by


### PR DESCRIPTION
### Motivation

- `Channel/Semigroup/Dissipative.lean` contained a private `leftMulAlgHom` abbreviation that was an alias for `Algebra.lmul ℂ (Mat D)`, together with an application lemma `leftMulAlgHom_apply`, adding an unnecessary indirection.
- Mathlib 4.31 exposes `Algebra.lmul` as a direct algebra homomorphism into the endomorphism algebra, making the private intermediate definition superfluous.

### Description

- Modified `TNLean/Channel/Semigroup/Dissipative.lean`: `leftMulCLMAlgHom` now composes `endEquiv` directly with `Algebra.lmul`, eliminating the private `leftMulAlgHom` abbreviation, its application lemma, and the equality connection to `LinearMap.mulLeft`.
- Proofs of `leftMulCLM_apply` and `endEquiv_mulLeft` collapse to `rfl` with the intermediate step removed.
- The right multiplication homomorphism and its lemmas are unchanged; Mathlib 4.31 does not expose the required continuous opposite-side algebra homomorphism with this codomain.
- No mathematical statement is altered.

### Testing

- `lake build TNLean.Channel.Semigroup.Dissipative -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`: none found.

---
No linked issue identified — this is a self-contained internal refactor.

> [!NOTE]
> **Low Risk**
> Local proof cleanup in one Lean file with no API or behavioral change to the dissipative semigroup theorems.
> 
> **Overview**
> **Dissipative drift** left multiplication is wired through Mathlib's `Algebra.lmul` instead of a private `leftMulAlgHom` alias and its application/equality lemmas.
> 
> `leftMulCLMAlgHom` now composes `endEquiv` with `Algebra.lmul` directly. Several proofs (`leftMulCLM_apply`, `endEquiv_mulLeft`) collapse to **`rfl`** because the extra bridge to `LinearMap.mulLeft` is gone. The **right** multiplication homomorphism and its lemmas are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d9c62d694d0567d0f1bd62ebc36f36944c90525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only cleanup in a single Lean file with no API or mathematical statement changes.
> 
> **Overview**
> **Dissipative semigroup** wiring in `Dissipative.lean` drops a private `leftMulAlgHom` alias (and its `leftMulAlgHom_apply` and `mulLeft_eq_leftMulAlgHom` lemmas) in favor of composing `leftMulCLMAlgHom` directly with Mathlib’s `Algebra.lmul ℂ (Mat D)`.
> 
> With that bridge removed, **`leftMulCLM_apply`** and **`endEquiv_mulLeft`** are proved by **`rfl`** instead of rewriting through `LinearMap.mulLeft`. Right-multiplication helpers (`rightMulAlgHom`, `mulRight_eq_rightMulAlgHom`, etc.) are untouched; stated theorems and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e945fb562c1dfe51cbc797332ef13db6208136a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->