### PR TITLE
refactor(MPS/RFP): use native ordered complex facts

### DIFF
--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -43,15 +43,6 @@ variable {d D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-private lemma ofReal_re_eq_self_of_pos {z : ℂ} (hz : 0 < z) :
-    ((z.re : ℝ) : ℂ) = z := by
-  have h := (Complex.lt_def).1 hz
-  have hz_im : z.im = 0 := by
-    simpa using h.2.symm
-  refine Complex.ext ?_ ?_
-  · rfl
-  · simp [hz_im]
-
 private lemma matrixUnits_map (X : Mat) :
     ∑ p : Fin D × Fin D,
       Matrix.single p.1 p.2 (1 : ℂ) * X * (Matrix.single p.1 p.2 (1 : ℂ))ᴴ =
@@ -161,9 +152,12 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     rw [Matrix.posDef_diagonal_iff] at hdiag_pd
     exact hdiag_pd
   have htr_re_eq : (((Matrix.trace ρ).re : ℝ) : ℂ) = Matrix.trace ρ :=
-    ofReal_re_eq_self_of_pos hρ_pd.trace_pos
+    (RCLike.ofReal_eq_re_of_isSelfAdjoint
+      (IsSelfAdjoint.of_nonneg (le_of_lt hρ_pd.trace_pos))).mp rfl
   have hρii_re_eq : ∀ k : Fin D, (((ρ k k).re : ℝ) : ℂ) = ρ k k :=
-    fun k => ofReal_re_eq_self_of_pos (hρdiag_pos k)
+    fun k =>
+      (RCLike.ofReal_eq_re_of_isSelfAdjoint
+        (IsSelfAdjoint.of_nonneg (le_of_lt (hρdiag_pos k)))).mp rfl
   have hDpos_nat : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
   have hDpos : 0 < (D : ℝ) := by
     exact_mod_cast hDpos_nat
@@ -255,9 +249,9 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     by_cases hij : i = j
     · subst hij
       have hρii_re_pos : 0 < (ρ i i).re := by
-        exact (Complex.lt_def).1 (hρdiag_pos i) |>.1
+        exact (RCLike.pos_iff.mp (hρdiag_pos i)).1
       have htr_re_pos : 0 < (Matrix.trace ρ).re := by
-        exact (Complex.lt_def).1 hρ_pd.trace_pos |>.1
+        exact (RCLike.pos_iff.mp hρ_pd.trace_pos).1
       have harg_nonneg : 0 ≤ ((D : ℝ) * (ρ i i).re) / (Matrix.trace ρ).re := by
         exact div_nonneg (by positivity) (le_of_lt htr_re_pos)
       have htr_re_ne : (Matrix.trace ρ).re ≠ 0 := by
@@ -431,9 +425,9 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
   · intro k
     apply Real.sqrt_pos.2
     have hk_pos : 0 < (ρ k k).re := by
-      exact (Complex.lt_def).1 (hρdiag_pos k) |>.1
+      exact (RCLike.pos_iff.mp (hρdiag_pos k)).1
     have htr_pos : 0 < (Matrix.trace ρ).re := by
-      exact (Complex.lt_def).1 hρ_pd.trace_pos |>.1
+      exact (RCLike.pos_iff.mp hρ_pd.trace_pos).1
     positivity
   · intro i
     calc


### PR DESCRIPTION
### Motivation

- The local private helper `ofReal_re_eq_self_of_pos` in `TNLean/MPS/RFP/StructuralFull.lean` duplicated functionality available in Mathlib's ordered `RCLike` hierarchy since Mathlib v4.31.0.
- Replacing it with native Mathlib lemmas reduces proof length and aligns the file with the `RCLike` API used elsewhere in the project.

### Description

- `TNLean/MPS/RFP/StructuralFull.lean` (modified): removes the private helper `ofReal_re_eq_self_of_pos` and rewires the proof of `rfp_nt_structural_full` to use:
  - `RCLike.ofReal_eq_re_of_isSelfAdjoint` (with `IsSelfAdjoint.of_nonneg`) for the `htr_re_eq` and `hρii_re_eq` steps that previously used a hand-built `Complex.ext` argument;
  - `RCLike.pos_iff` for every step extracting `0 < z.re` from `0 < z`, replacing direct projection of `Complex.lt_def`.
- No mathematical statement is changed; all downstream theorems retain the same signatures and proof strategy.

### Testing

- `lake build TNLean.MPS.RFP.StructuralFull -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

---
*(No linked issue found — no `Closes`/`Fixes`/`Refs` reference in the branch name, commit messages, or PR body. The author may wish to link one manually.)*

> [!NOTE]
> **Low Risk**
> Proof-only refactor inside one Lean file; no API or runtime behavior changes.
> 
> **Overview**
> In **`StructuralFull`**, the local helper **`ofReal_re_eq_self_of_pos`** is removed and the **`rfp_nt_structural_full`** proof is rewired to Mathlib's ordered **`RCLike`** API.
> 
> **`htr_re_eq`** and **`hρii_re_eq`** now use **`RCLike.ofReal_eq_re_of_isSelfAdjoint`** with **`IsSelfAdjoint.of_nonneg`** from positive-definite trace/diagonal data, instead of a hand-built **`Complex.ext`** argument. Every step that needed **`0 < z.re`** from **`0 < z`** now goes through **`RCLike.pos_iff`** rather than projecting **`Complex.lt_def`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df5ad2386e66bae9230044f11d53ff81a1bbfce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single Lean file; no API, runtime, or mathematical statement changes.
> 
> **Overview**
> **`StructuralFull.lean`** drops the local helper **`ofReal_re_eq_self_of_pos`** and rewrites parts of the **`rfp_nt_structural_full`** proof to use Mathlib’s ordered **`RCLike`** lemmas instead of hand-built **`Complex.ext`** / **`Complex.lt_def`** steps.
> 
> **`htr_re_eq`** and **`hρii_re_eq`** now use **`RCLike.ofReal_eq_re_of_isSelfAdjoint`** with **`IsSelfAdjoint.of_nonneg`** from positive trace and diagonal entries. Every place that needed **`0 < z.re`** from **`0 < z`** goes through **`RCLike.pos_iff`** rather than projecting **`Complex.lt_def`**.
> 
> Theorem statements and the overall proof strategy are unchanged; this is proof cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e3c87fbfd0af76208f3a0201ee6ad399caaf6bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->