### PR TITLE
refactor(Channel/Schwarz): use native complex positivity

### DIFF
--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -239,9 +239,9 @@ lemma povmDiagonal_posDef (w : ι → ℝ) {t : ℝ}
     cases a with
     | inl ip =>
         rcases ip with ⟨i, p⟩
-        simpa [d, Complex.lt_def] using hw i
+        simpa [d] using (RCLike.pos_iff.mpr ⟨hw i, rfl⟩ : (0 : ℂ) < (w i : ℂ))
     | inr p =>
-        simpa [d, Complex.lt_def] using ht
+        simpa [d] using (RCLike.pos_iff.mpr ⟨ht, rfl⟩ : (0 : ℂ) < (t : ℂ))
   simpa [povmDiagonal, d] using hdiag
 
 /-- The inverse of the scalar block-diagonal matrix `povmDiagonal w t`, assuming


### PR DESCRIPTION
### Motivation

- Direct unfolding of `Complex.lt_def` in `povmDiagonal_posDef` is more
  fragile and verbose than using Mathlib's `RCLike.pos_iff`, which closes
  `(0 : ℂ) < …` goals directly from real-part hypotheses.
- Replacing the two manual unfoldings with `RCLike.pos_iff.mpr` aligns the
  proof with the `RCLike` order API available in Mathlib 4.31.
- Part of the broader `mathlib-4-31-native-pass-*` series, which replaces
  ad-hoc positivity arguments with canonical Mathlib lemmas.

### Description

- Modified `TNLean/Channel/Schwarz/OperatorJensenAux.lean`: the two
  diagonal-entry positivity subproofs in `povmDiagonal_posDef` no longer
  unfold `Complex.lt_def`; they now close `(0 : ℂ) < …` via
  `RCLike.pos_iff.mpr` from the existing real hypotheses `hw i` and `ht`.
- No mathematical statement is changed; the `povmDiagonal_posDef` conclusion
  and downstream uses (e.g. `povm_resolvent_inv_le`) are unaffected.

### Testing

- `lake build TNLean.Channel.Schwarz.OperatorJensenAux -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Line-length scan for `TNLean/Channel/Schwarz/OperatorJensenAux.lean`.

---
No linked issue identified — this is a self-contained proof-style refactor.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single lemma with no API or behavior change.
> 
> **Overview**
> In **`povmDiagonal_posDef`**, the two diagonal-entry positivity subproofs no longer unfold **`Complex.lt_def`**. They now close **`(0 : ℂ) < …`** via **`RCLike.pos_iff.mpr`** from the existing real hypotheses **`hw i`** and **`ht`**.
> 
> The **`povmDiagonal`** / **`Matrix.PosDef.diagonal`** statement and downstream uses (e.g. **`povm_resolvent_inv_le`**) are unchanged; this is a proof-style cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dafa63f33ff9dede940b2815e53ba2e609a2beab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only change in a single lemma with no API or behavior change.
> 
> **Overview**
> In **`povmDiagonal_posDef`**, the two diagonal-entry positivity subproofs no longer unfold **`Complex.lt_def`**. They now close **`(0 : ℂ) < …`** via **`RCLike.pos_iff.mpr`** from the existing real hypotheses **`hw i`** and **`ht`**.
> 
> The lemma’s statement and downstream uses (e.g. **`povm_resolvent_inv_le`**) are unchanged; this is proof-style cleanup aligned with Mathlib 4.31’s **`RCLike`** order API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca191fd68baa65b7a22e6094ed9c012f3483fee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->