### PR TITLE
refactor(Channel/PF): use native real trace criterion

### DIFF
--- a/TNLean/Channel/PerronFrobenius/Existence.lean
+++ b/TNLean/Channel/PerronFrobenius/Existence.lean
@@ -117,14 +117,12 @@ theorem exists_posSemidef_eigenvector
   -- Extract a positive real eigenvalue from the nonnegative (real) trace.
   set r : ℝ := (Matrix.trace (E ρ)).re
   have hr_nonneg : 0 ≤ r := by
-    simpa [r] using (Complex.nonneg_iff.mp hEρ_psd.trace_nonneg).1
-  have htr_im : (Matrix.trace (E ρ)).im = 0 := by
-    -- `Complex.nonneg_iff` provides the imaginary-part condition as `0 = z.im`.
-    simpa using (Complex.nonneg_iff.mp hEρ_psd.trace_nonneg).2.symm
+    simpa [r] using (RCLike.nonneg_iff.mp hEρ_psd.trace_nonneg).1
   have htr_eq : Matrix.trace (E ρ) = (r : ℂ) := by
-    apply Complex.ext
-    · simp [r]
-    · simp [htr_im]
+    symm
+    exact
+      (RCLike.ofReal_eq_re_of_isSelfAdjoint
+        (IsSelfAdjoint.of_nonneg hEρ_psd.trace_nonneg)).mp rfl
   have hr_ne : r ≠ 0 := by
     intro hr0
     apply htr_ne


### PR DESCRIPTION
### Motivation

- The proof of `exists_posSemidef_eigenvector` in `TNLean/Channel/PerronFrobenius/Existence.lean`
  extracted a real eigenvalue from a nonneg trace using `Complex.nonneg_iff` and a manual
  `Complex.ext` reconstruction; Mathlib 4.31 provides native lemmas that handle both steps
  directly, reducing proof size and eliminating a standalone imaginary-part subproof.

### Description

- Modified `TNLean/Channel/PerronFrobenius/Existence.lean` (5 additions, 7 deletions, net −2 lines).
- In `exists_posSemidef_eigenvector`: replaced `Complex.nonneg_iff` with `RCLike.nonneg_iff`
  to extract nonnegativity of the real eigenvalue `r` from a nonneg trace.
- Replaced the manual `Complex.ext` argument reconstructing `Matrix.trace (E ρ) = (r : ℂ)` with
  a single call to `RCLike.ofReal_eq_re_of_isSelfAdjoint`, using `IsSelfAdjoint.of_nonneg` on
  the positive-semidefinite trace.
- Removed the standalone `htr_im` subproof, which is no longer needed.
- No change to the theorem statement, type signature, or downstream callers.

### Testing

- `lake build TNLean.Channel.PerronFrobenius.Existence -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` (none found).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

_No linked issue found. Branch name `codex/mathlib-4-31-native-pass-30` does not encode an issue number; no `Addresses #N` reference appears in commits or PR body. Author should link the relevant issue manually if one exists._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one theorem with no API or runtime behavior change.
>
> **Overview**
> In **`exists_posSemidef_eigenvector`**, the step that turns a nonnegative trace of `E ρ` into a positive real eigenvalue `r` is refactored only—no change to the statement or downstream callers.
>
> **Nonnegativity of `r`** now uses `RCLike.nonneg_iff` instead of `Complex.nonneg_iff`.
>
> The proof that **`Matrix.trace (E ρ) = (r : ℂ)`** no longer builds a separate imaginary-part lemma or a `Complex.ext` argument; it uses `RCLike.ofReal_eq_re_of_isSelfAdjoint` with `IsSelfAdjoint.of_nonneg` on the PSD trace.
>
> The standalone `htr_im` subproof is removed as a result.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a59ec1f460b9fe9a1e2fe45e809cbafc935f3c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one theorem with no API or runtime behavior change.
> 
> **Overview**
> In **`exists_posSemidef_eigenvector`** (`TNLean/Channel/PerronFrobenius/Existence.lean`), only the proof that a nonnegative PSD trace yields a positive real eigenvalue `r` is rewritten; the theorem statement and callers are unchanged.
> 
> **`hr_nonneg`** now uses `RCLike.nonneg_iff` instead of `Complex.nonneg_iff`. **`htr_eq`** (`Matrix.trace (E ρ) = (r : ℂ)`) drops the separate `htr_im` lemma and `Complex.ext` case split in favor of `RCLike.ofReal_eq_re_of_isSelfAdjoint` with `IsSelfAdjoint.of_nonneg` on the trace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0b9536a50dbee2fdf617487ec1483d470565f58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->