### PR TITLE
refactor(Channel/FixedPoint): use native trace realness

### DIFF
--- a/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
+++ b/TNLean/Channel/FixedPoint/ConditionalExpectation.lean
@@ -269,12 +269,10 @@ theorem scalarConditionalExpectation_isCPMap
   have hcpK : IsCPMap (Kraus.mapLM K) := isCPMap_of_krausMapLM K
   -- Rewrite `scalarConditionalExpectation σ` as `(σ.trace.re)⁻¹ • Kraus.mapLM K`.
   have htr_nn : (0 : ℂ) ≤ σ.trace := Matrix.PosSemidef.trace_nonneg hσ
-  have htr_re_nn : (0 : ℝ) ≤ σ.trace.re := (Complex.nonneg_iff.mp htr_nn).1
-  have htr_im : σ.trace.im = 0 := (Complex.nonneg_iff.mp htr_nn).2.symm
-  have htr_eq : ((σ.trace.re : ℝ) : ℂ) = σ.trace := by
-    apply Complex.ext
-    · simp
-    · simp [htr_im]
+  have htr_re_nn : (0 : ℝ) ≤ σ.trace.re := (RCLike.nonneg_iff.mp htr_nn).1
+  have htr_eq : ((σ.trace.re : ℝ) : ℂ) = σ.trace :=
+    (RCLike.ofReal_eq_re_of_isSelfAdjoint
+      (IsSelfAdjoint.of_nonneg htr_nn)).mp rfl
   -- `scalarConditionalExpectation σ = ((σ.trace.re)⁻¹ : ℂ) • Kraus.mapLM K`.
   have hrw : scalarConditionalExpectation σ =
       (((σ.trace.re : ℝ)⁻¹ : ℝ) : ℂ) • Kraus.mapLM K := by


### PR DESCRIPTION
### Motivation

- `scalarConditionalExpectation_isCPMap` contained a proof that the trace of a positive-semidefinite matrix is a nonneg real, implemented via a manual `Complex.ext` argument plus a separate `σ.trace.im = 0` lemma. Mathlib 4.31.0 provides `RCLike.nonneg_iff` and `RCLike.ofReal_eq_re_of_isSelfAdjoint` that subsume both steps directly, reducing local proof complexity.
- Continuation of the Mathlib 4.31.0 native-lemma pass replacing locally-duplicated combinators with their Mathlib equivalents.

### Description

- Modified `TNLean/Channel/FixedPoint/ConditionalExpectation.lean`:
  - Replaced `Complex.nonneg_iff` with `RCLike.nonneg_iff` to establish that the real part of a nonneg complex trace is nonneg.
  - Replaced a hand-written `Complex.ext` reconstruction of `((σ.trace.re : ℝ) : ℂ) = σ.trace` with `RCLike.ofReal_eq_re_of_isSelfAdjoint`.
  - Removed the separate imaginary-part subgoal (`σ.trace.im = 0`); the new lemma subsumes it.
  - No mathematical statement is changed; the scalar conditional expectation theorem and downstream CP-closure argument retain the same mathematical content.

### Testing

- `lake build TNLean.Channel.FixedPoint.ConditionalExpectation -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` (all clear).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
No linked issue identified — this is a self-contained internal refactor.

> [!NOTE]
> **Low Risk**
> Proof-only refactor inside an existing theorem; no API or runtime behavior changes.
> 
> **Overview**
> In **`scalarConditionalExpectation_isCPMap`**, the step that shows a PSD matrix's trace is a nonnegative real is simplified: **`Complex.nonneg_iff`** becomes **`RCLike.nonneg_iff`**, and the equality **`((σ.trace.re : ℝ) : ℂ) = σ.trace`** is proved with **`RCLike.ofReal_eq_re_of_isSelfAdjoint`** instead of a hand-written **`Complex.ext`** argument plus a separate **`σ.trace.im = 0`** lemma.
> 
> The downstream rewrite **`scalarConditionalExpectation σ = (σ.trace.re)⁻¹ • Kraus.mapLM K`** and the CP closure argument are unchanged in intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a227faa644997bfac9983968dde1611c97b408. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor inside an existing theorem; no API or mathematical statement changes.
> 
> **Overview**
> In **`scalarConditionalExpectation_isCPMap`**, the proof that a PSD matrix’s trace is a nonnegative real is shortened by swapping **`Complex.nonneg_iff`** for **`RCLike.nonneg_iff`** and proving **`((σ.trace.re : ℝ) : ℂ) = σ.trace`** with **`RCLike.ofReal_eq_re_of_isSelfAdjoint`** instead of **`Complex.ext`** plus a separate **`σ.trace.im = 0`** step.
> 
> The rewrite of **`scalarConditionalExpectation σ`** as **`(σ.trace.re)⁻¹ • Kraus.mapLM K`** and the CP closure argument are unchanged in substance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 204b366f5bd47a56d77ade2f96eeb1c4ce1187a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->