### PR TITLE
refactor(Channel/Schwarz): use native trace nonnegativity

### DIFF
--- a/TNLean/Channel/Schwarz/Basic.lean
+++ b/TNLean/Channel/Schwarz/Basic.lean
@@ -279,7 +279,8 @@ private lemma each_zero_of_sum_conjTranspose_mul_self_zero
   intro i
   have h_psd_i := Matrix.posSemidef_conjTranspose_mul_self (R i)
   have h_each_nonneg : ∀ j : ι, 0 ≤ ((R j)ᴴ * R j).trace.re :=
-    fun j => (Complex.le_def.mp (Matrix.posSemidef_conjTranspose_mul_self (R j)).trace_nonneg).1
+    fun j => (RCLike.nonneg_iff.mp
+      (Matrix.posSemidef_conjTranspose_mul_self (R j)).trace_nonneg).1
   have h_tr_sum_re : (∑ j : ι, ((R j)ᴴ * R j).trace.re) = 0 := by
     rw [← Complex.re_sum, ← Matrix.trace_sum, h]
     simp
@@ -290,7 +291,7 @@ private lemma each_zero_of_sum_conjTranspose_mul_self_zero
             |>.mp h_tr_sum_re i (Finset.mem_univ i)])
       (h_each_nonneg i)
   have h_tr_zero : ((R i)ᴴ * R i).trace = 0 :=
-    Complex.ext h_tr_re (Complex.le_def.mp h_psd_i.trace_nonneg).2.symm
+    Complex.ext h_tr_re (RCLike.nonneg_iff.mp h_psd_i.trace_nonneg).2
   exact Matrix.conjTranspose_mul_self_eq_zero.mp (h_psd_i.trace_eq_zero_iff.mp h_tr_zero)
 
 /-- **KS gap decomposition** at the level of Kraus operators.

--- a/TNLean/Channel/Schwarz/Basic.lean
+++ b/TNLean/Channel/Schwarz/Basic.lean
@@ -292,7 +292,7 @@ private lemma each_zero_of_sum_conjTranspose_mul_self_zero
       (h_each_nonneg i)
   have h_tr_zero : ((R i)ᴴ * R i).trace = 0 :=
     Complex.ext h_tr_re (RCLike.nonneg_iff.mp h_psd_i.trace_nonneg).2
-  exact Matrix.conjTranspose_mul_self_eq_zero.mp (h_psd_i.trace_eq_zero_iff.mp h_tr_zero)
+  exact Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp h_tr_zero
 
 /-- **KS gap decomposition** at the level of Kraus operators.
 

--- a/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
@@ -95,7 +95,8 @@ private lemma each_zero_of_sum_conjTranspose_mul_self_zero
   intro i
   have h_psd_i := Matrix.posSemidef_conjTranspose_mul_self (R i)
   have h_each_nonneg : ∀ j, 0 ≤ ((R j)ᴴ * R j).trace.re :=
-    fun j => (Complex.le_def.mp (Matrix.posSemidef_conjTranspose_mul_self (R j)).trace_nonneg).1
+    fun j => (RCLike.nonneg_iff.mp
+      (Matrix.posSemidef_conjTranspose_mul_self (R j)).trace_nonneg).1
   have h_tr_sum_re : (∑ j : Fin d, ((R j)ᴴ * R j).trace.re) = 0 := by
     rw [← Complex.re_sum, ← Matrix.trace_sum, h]; simp
   have h_tr_re : ((R i)ᴴ * R i).trace.re = 0 :=
@@ -104,7 +105,7 @@ private lemma each_zero_of_sum_conjTranspose_mul_self_zero
             |>.mp h_tr_sum_re i (Finset.mem_univ i)])
       (h_each_nonneg i)
   have h_tr_zero : ((R i)ᴴ * R i).trace = 0 :=
-    Complex.ext h_tr_re (Complex.le_def.mp h_psd_i.trace_nonneg).2.symm
+    Complex.ext h_tr_re (RCLike.nonneg_iff.mp h_psd_i.trace_nonneg).2
   exact Matrix.conjTranspose_mul_self_eq_zero.mp (h_psd_i.trace_eq_zero_iff.mp h_tr_zero)
 
 /-- **KS gap decomposition**. The Kadison-Schwarz gap decomposes as a sum of

--- a/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomain.lean
@@ -106,7 +106,7 @@ private lemma each_zero_of_sum_conjTranspose_mul_self_zero
       (h_each_nonneg i)
   have h_tr_zero : ((R i)ᴴ * R i).trace = 0 :=
     Complex.ext h_tr_re (RCLike.nonneg_iff.mp h_psd_i.trace_nonneg).2
-  exact Matrix.conjTranspose_mul_self_eq_zero.mp (h_psd_i.trace_eq_zero_iff.mp h_tr_zero)
+  exact Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp h_tr_zero
 
 /-- **KS gap decomposition**. The Kadison-Schwarz gap decomposes as a sum of
 squares at the Kraus-operator level:


### PR DESCRIPTION
### Motivation

- Two private helper lemmas in `TNLean/Channel/Schwarz/Basic.lean` and `TNLean/Channel/Schwarz/MultiplicativeDomain.lean` extracted real and imaginary parts of nonneg PSD traces via `Complex.le_def.mp` on `trace_nonneg`, which is tied to `Complex`-specific structure rather than the generic `RCLike` API.
- Aligning with the Mathlib 4.31 `RCLike.nonneg_iff` interface eliminates the detour through `Complex.le_def` projections and makes the proofs uniform across `RCLike` instances.
- No issue is linked to this PR; the author should link or open one if this is part of a tracked cleanup series.

### Description

- Modified `TNLean/Channel/Schwarz/Basic.lean` and `TNLean/Channel/Schwarz/MultiplicativeDomain.lean`.
- In `each_zero_of_sum_conjTranspose_mul_self_zero` in both files, the proof steps that read the real and imaginary parts of nonneg PSD traces now go through `RCLike.nonneg_iff` instead of `Complex.le_def.mp` on `trace_nonneg`; the extra `.symm` on the imaginary component in the `Complex.ext` step is also dropped.
- Lemma statements, Kadison–Schwarz gap arguments, and all downstream callers are unchanged.

### Testing

- `lake build TNLean.Channel.Schwarz.Basic TNLean.Channel.Schwarz.MultiplicativeDomain -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` — none found.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Lean CI (`lean_action_ci.yml`) validates the full build on merge.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in private lemmas with no API or runtime behavior changes.
> 
> **Overview**
> In **`each_zero_of_sum_conjTranspose_mul_self_zero`** in `TNLean/Channel/Schwarz/Basic.lean` and `TNLean/Channel/Schwarz/MultiplicativeDomain.lean`, the proof steps that read **real and imaginary parts** of nonneg PSD traces now go through Mathlib's **`RCLike.nonneg_iff`** instead of **`Complex.le_def.mp`** on `trace_nonneg`.
> 
> The lemma statements and the surrounding Kadison–Schwarz / sum-of-squares arguments are unchanged; only the trace nonnegativity projections are aligned with the generic `RCLike` API (including dropping the extra **`.symm`** on the imaginary component in the `Complex.ext` step).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7454b489b22f1f603a4a85d0d7010dd23632e8d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in duplicated private lemmas with no API or behavioral changes; risk is limited to Mathlib lemma wiring.
> 
> **Overview**
> Refactors the private helper `each_zero_of_sum_conjTranspose_mul_self_zero` in **Schwarz/Basic** and **Schwarz/MultiplicativeDomain** so trace nonnegativity from PSD `Rᵢ†Rᵢ` terms is read via Mathlib’s `RCLike.nonneg_iff` instead of manual `Complex.le_def` projections on real and imaginary parts.
> 
> The step from “trace is zero” to “`Rᵢ = 0`” now goes through `Matrix.trace_conjTranspose_mul_self_eq_zero_iff` directly, replacing the older `conjTranspose_mul_self_eq_zero` / `trace_eq_zero_iff` composition. **Theorem statements and downstream Kadison–Schwarz gap arguments are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad38621c95b8f022e117e14c5e612b9d17a9edcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->