### PR TITLE
refactor(Channel/Semigroup): use native trace zero iff

### DIFF
--- a/TNLean/Channel/Semigroup/LiouvillianKernel.lean
+++ b/TNLean/Channel/Semigroup/LiouvillianKernel.lean
@@ -374,8 +374,9 @@ private theorem each_commutator_eq_zero_of_sum_eq_zero
     have h_psd_j := Matrix.posSemidef_conjTranspose_mul_self (A * F.L j - F.L j * A)
     have h_each_nonneg : ∀ k : Fin F.r,
         0 ≤ ((A * F.L k - F.L k * A)ᴴ * (A * F.L k - F.L k * A)).trace.re :=
-      fun k => (Complex.le_def.mp
-        (Matrix.posSemidef_conjTranspose_mul_self (A * F.L k - F.L k * A)).trace_nonneg).1
+      fun k => (RCLike.nonneg_iff.mp
+        (Matrix.posSemidef_conjTranspose_mul_self
+          (A * F.L k - F.L k * A)).trace_nonneg).1
     have h_tr_sum_re :
         (∑ k : Fin F.r,
           ((A * F.L k - F.L k * A)ᴴ * (A * F.L k - F.L k * A)).trace.re) = 0 := by
@@ -388,8 +389,8 @@ private theorem each_commutator_eq_zero_of_sum_eq_zero
         (h_each_nonneg j)
     have h_tr_zero :
         ((A * F.L j - F.L j * A)ᴴ * (A * F.L j - F.L j * A)).trace = 0 :=
-      Complex.ext h_tr_re (Complex.le_def.mp h_psd_j.trace_nonneg).2.symm
-    exact Matrix.conjTranspose_mul_self_eq_zero.mp (h_psd_j.trace_eq_zero_iff.mp h_tr_zero)
+      Complex.ext h_tr_re (RCLike.nonneg_iff.mp h_psd_j.trace_nonneg).2
+    exact Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp h_tr_zero
   exact sub_eq_zero.mp hj
 
 /-- Wolf Theorem 7.2, faithful direction.


### PR DESCRIPTION
### Motivation

- The private proof helper `each_commutator_eq_zero_of_sum_eq_zero` in `LiouvillianKernel.lean` used older PSD trace-zero API (`Complex.le_def`, manual `conjTranspose_mul_self_eq_zero` composed with `trace_eq_zero_iff`). Mathlib now provides direct lemmas that make the argument shorter and more idiomatic (Wolf §7.2).

### Description

- Modified `TNLean/Channel/Semigroup/LiouvillianKernel.lean` (5 additions, 4 deletions).
- Nonnegativity extraction (`0 ≤ trace.re` for each `[A, Lⱼ]†[A, Lⱼ]`) now uses `RCLike.nonneg_iff` on `trace_nonneg`, replacing `Complex.le_def` wiring in both the per-term bounds and the imaginary part via `Complex.ext`.
- The step concluding `A * F.L j - F.L j * A = 0` from a zero trace now applies `Matrix.trace_conjTranspose_mul_self_eq_zero_iff` directly, replacing the composition of `conjTranspose_mul_self_eq_zero` and `trace_eq_zero_iff`.
- Wolf §7.2 kernel/commutant theorem statements and overall proof strategy are unchanged; this is a proof-cleanup only.

### Testing

- `lake build TNLean.Channel.Semigroup.LiouvillianKernel -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

---
No linked issue identified — author should link one manually.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a private helper; no API or behavioral changes to the Liouvillian kernel theorems.
>
> **Overview**
> Refactors the private proof **`each_commutator_eq_zero_of_sum_eq_zero`** in `LiouvillianKernel.lean` so the "sum of PSD squares is zero ⇒ each commutator vanishes" step uses standard Mathlib lemmas instead of older `Complex.le_def` / PSD trace-zero API wiring.
>
> **Nonnegativity:** extracting `0 ≤ trace.re` from each `[A, Lⱼ]†[A, Lⱼ]` now goes through **`RCLike.nonneg_iff`** on `trace_nonneg`, for both the per-term bounds and the imaginary part in **`Complex.ext`**.
>
> **Zero matrix:** concluding `A * F.L j - F.L j * A = 0` from a zero trace now applies **`Matrix.trace_conjTranspose_mul_self_eq_zero_iff`** directly, replacing **`conjTranspose_mul_self_eq_zero`** composed with **`trace_eq_zero_iff`**.
>
> Wolf 7.2 kernel/commutant statements and the overall proof strategy are unchanged; this is a proof-cleanup only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b39093d21862dfdbd7906143a6371f9ba5d414e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Private proof helper only; no API or behavioral changes to the Liouvillian kernel theorems.
> 
> **Overview**
> Proof-only cleanup in the private helper **`each_commutator_eq_zero_of_sum_eq_zero`** (Wolf §7.2 faithful direction); theorem statements and proof strategy are unchanged.
> 
> **Nonnegativity:** bounds on `trace.re` for each `[A, Lⱼ]†[A, Lⱼ]` now use **`RCLike.nonneg_iff`** on PSD `trace_nonneg`, replacing **`Complex.le_def`** wiring (including the imaginary part in **`Complex.ext`**).
> 
> **Vanishing commutator:** from zero trace, the proof now applies **`Matrix.trace_conjTranspose_mul_self_eq_zero_iff`** directly instead of composing **`conjTranspose_mul_self_eq_zero`** with **`trace_eq_zero_iff`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8fb3d047d11183be2265a213989ba69119a8ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->