### PR TITLE
refactor(Channel/Determinant): use native trace nonnegativity

### DIFF
--- a/TNLean/Channel/Determinant/HeisenbergDual.lean
+++ b/TNLean/Channel/Determinant/HeisenbergDual.lean
@@ -133,7 +133,7 @@ private theorem heisenberg_dual_ks_eq_stdBasis [NeZero d]
   have hgap_trace_nonneg : ∀ ij : Fin d × Fin d,
       0 ≤ (Matrix.trace (Td (e ij * (e ij)ᴴ) - Td (e ij) * (Td (e ij))ᴴ)).re := by
     intro ij
-    exact (Complex.le_def.mp (hgap_psd ij).trace_nonneg).1
+    exact (RCLike.nonneg_iff.mp (hgap_psd ij).trace_nonneg).1
   have hgap_trace_sum_le : ∑ ij : Fin d × Fin d,
       (Matrix.trace (Td (e ij * (e ij)ᴴ) - Td (e ij) * (Td (e ij))ᴴ)).re ≤ 0 := by
     have hTd_one : Td 1 = 1 := by
@@ -181,7 +181,7 @@ private theorem heisenberg_dual_ks_eq_stdBasis [NeZero d]
   intro ij
   have hpsd := hgap_psd ij
   have htr_re := hgap_trace_zero ij
-  have htr_im := (Complex.le_def.mp hpsd.trace_nonneg).2.symm
+  have htr_im := (RCLike.nonneg_iff.mp hpsd.trace_nonneg).2
   have htr : Matrix.trace (Td (e ij * (e ij)ᴴ) - Td (e ij) * (Td (e ij))ᴴ) = 0 :=
     Complex.ext htr_re htr_im
   exact sub_eq_zero.mp (hpsd.trace_eq_zero_iff.mp htr)


### PR DESCRIPTION
### Motivation

- The private lemma in `Channel/Determinant/HeisenbergDual` used `Complex.le_def` to manually unfold nonnegative trace facts from PSD gap matrices in the Kadison–Schwarz trace-summing step. Mathlib's `RCLike.nonneg_iff` supplies these real and imaginary projections directly, removing the manual unfolding.

### Description

- Modified `TNLean/Channel/Determinant/HeisenbergDual.lean`.
- In the Kadison–Schwarz trace-summing step of the Heisenberg-dual argument (Wolf Thm. 6.1(2)), replaced two uses of `Complex.le_def` unfolding with `RCLike.nonneg_iff.mp` applied to `(hgap_psd ij).trace_nonneg`: one for the real-part inequality `0 ≤ …re`, one for the imaginary-part equality used in `Complex.ext`. The imaginary-part step drops the previous `.symm` since `nonneg_iff` supplies the equality directly.
- No change to theorem statements, the Heisenberg-dual determinant saturation argument, or the downstream multiplicativity theorem.

### Testing

- `lake build TNLean.Channel.Determinant.HeisenbergDual -q --log-level=info`
- Diff checked with `git diff --check HEAD~1..HEAD`.
- Added-line scan confirmed no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`.
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
No linked issue found — please link a relevant issue manually.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Two-line proof refactor in a private lemma; no changes to statements, APIs, or runtime behavior.
>
> **Overview**
> In **`heisenberg_dual_ks_eq_stdBasis`**, the Kadison–Schwarz trace-summing step no longer unfolds **`Complex.le_def`** to read off real and imaginary parts of nonnegative traces from PSD gap matrices.
>
> Those two proof obligations now use **`RCLike.nonneg_iff.mp`** on **`(hgap_psd ij).trace_nonneg`**: one for **`0 ≤ …re`**, one for the imaginary part used in **`Complex.ext`**. The imaginary-part line drops the previous **`.symm`**, since **`nonneg_iff`** supplies the needed equality directly.
>
> No change to the Heisenberg-dual determinant saturation argument or the downstream multiplicativity theorem—only how trace nonnegativity is projected in this private lemma.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04aa74371d20589b546be57a6322210f0d2c80b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- /CURSOR_SUMMARY -->