### PR TITLE
refactor(Channel/Determinant): use native scalar positivity

### DIFF
--- a/TNLean/Channel/Determinant/UnitaryCharacterization.lean
+++ b/TNLean/Channel/Determinant/UnitaryCharacterization.lean
@@ -107,8 +107,8 @@ private theorem extract_unitary_from_inner_form [NeZero d]
     exact one_ne_zero (show (1 : MatrixAlg d) = 0 by
       rw [← hPPinv, hP_zero, zero_mul])
   -- Step 4: c is a positive real number
-  have hc_re_nonneg : 0 ≤ c.re := (Complex.nonneg_iff.mp hc_nonneg).1
-  have hc_im_zero : c.im = 0 := (Complex.nonneg_iff.mp hc_nonneg).2.symm
+  have hc_re_nonneg : 0 ≤ c.re := (RCLike.nonneg_iff.mp hc_nonneg).1
+  have hc_im_zero : c.im = 0 := (RCLike.nonneg_iff.mp hc_nonneg).2
   have hc_re_pos : 0 < c.re := by
     rcases lt_or_eq_of_le hc_re_nonneg with h | h
     · exact h


### PR DESCRIPTION
### Motivation

- The normalization step for the Skolem–Noether implementer in
  `TNLean/Channel/Determinant/UnitaryCharacterization.lean` used `Complex.nonneg_iff` directly
  to extract `0 ≤ c.re` and `c.im = 0` from `0 ≤ c`. Mathlib 4.31 provides the more general
  `RCLike.nonneg_iff`, which subsumes this case and removes the specialization to `ℂ`.
- Part of the Mathlib 4.31 API-alignment pass over `Channel/Determinant`.

### Description

- Modified `TNLean/Channel/Determinant/UnitaryCharacterization.lean` (+2 / −2 lines).
- In the private helper `extract_unitary_from_inner_form`, replaced `Complex.nonneg_iff` with
  `RCLike.nonneg_iff` to decompose a nonnegative center scalar `c` into `0 ≤ c.re` and
  `c.im = 0`. The imaginary-part branch drops the previous `.symm`, matching the component
  order of `RCLike.nonneg_iff`.
- Determinant saturation lemmas and the unitary-channel characterization theorems (Wolf §6.1(2))
  are unchanged.
- No new `sorry` introduced.

### Testing

- `lake build TNLean.Channel.Determinant.UnitaryCharacterization -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`: clean.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Two-line proof refactor in a private helper; behavior of the characterization theorems is unchanged.
>
> **Overview**
> In **`extract_unitary_from_inner_form`** (Skolem–Noether unitary normalization), the proof that the center scalar **`c`** is a positive real now uses **`RCLike.nonneg_iff`** instead of **`Complex.nonneg_iff`** to read **`0 ≤ c.re`** and **`c.im = 0`** from **`0 ≤ c`**.
>
> The imaginary-part step drops the previous **`.symm`** on the second component of the iff, matching **`RCLike`**'s lemma statement. No change to determinant saturation or the main Wolf 6.1(2) theorems.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30aa2a225c14f82bbe51b465d2e9b78e1a9bf5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->