### PR TITLE
refactor(MPS/MPDO): use native trace positivity

### DIFF
--- a/TNLean/MPS/MPDO/AreaLaw.lean
+++ b/TNLean/MPS/MPDO/AreaLaw.lean
@@ -257,8 +257,8 @@ namespace Matrix
 theorem PosSemidef.smul_inv_trace {n : Type*} [Fintype n]
     {P : Matrix n n ℂ} (hP : P.PosSemidef) : (P.trace⁻¹ • P).PosSemidef := by
   have htr_nonneg : (0 : ℂ) ≤ P.trace := hP.trace_nonneg
-  have hre : 0 ≤ P.trace.re := htr_nonneg.1
-  have him : P.trace.im = 0 := (Complex.le_def.mp htr_nonneg).2.symm
+  have hre : 0 ≤ P.trace.re := (RCLike.nonneg_iff.mp htr_nonneg).1
+  have him : P.trace.im = 0 := (RCLike.nonneg_iff.mp htr_nonneg).2
   set r : ℝ := P.trace.re with hr
   have htr_eq : P.trace = (r : ℂ) := Complex.ext rfl (by simp [him, hr])
   have hinv_eq : (P.trace)⁻¹ = ((r⁻¹ : ℝ) : ℂ) := by rw [htr_eq, Complex.ofReal_inv]


### PR DESCRIPTION
### Motivation

- `RCLike.nonneg_iff` is the canonical Mathlib lemma for decomposing a nonneg element of an `RCLike` instance into its real and imaginary parts. The previous proof of `Matrix.PosSemidef.smul_inv_trace` reached the same decomposition via `Complex.le_def` and direct field projection, which is less aligned with the Mathlib API.

### Description

- `TNLean/MPS/MPDO/AreaLaw.lean`: in `Matrix.PosSemidef.smul_inv_trace`, the two intermediate hypotheses extracting `0 ≤ P.trace.re` and `P.trace.im = 0` from `hP.trace_nonneg` now use `(RCLike.nonneg_iff.mp htr_nonneg)` instead of `Complex.le_def.mp` and direct structure projection. The lemma statement and the remainder of the proof are unchanged.

### Testing

- `lake build TNLean.MPS.MPDO.AreaLaw -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` (none found)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a localized lemma; no API or behavioral changes.
> 
> **Overview**
> In **`Matrix.PosSemidef.smul_inv_trace`** (`AreaLaw.lean`), the two lines that read off **`P.trace.re ≥ 0`** and **`P.trace.im = 0`** from **`hP.trace_nonneg`** now go through **`RCLike.nonneg_iff`** instead of **`Complex.le_def`** / direct structure projection.
> 
> The lemma's statement and the rest of the proof (real trace normalization and **`PosSemidef.smul`**) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c625ecde4ed3fbf51a4716a49535a24773014776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->