### PR TITLE
refactor(MPS/Symmetry): use native scalar positivity

### DIFF
--- a/TNLean/MPS/Symmetry/StringOrderAux.lean
+++ b/TNLean/MPS/Symmetry/StringOrderAux.lean
@@ -446,8 +446,8 @@ theorem virtualUnitary_of_gaugePhaseEquiv_twisted
     have hdiag_nonneg := (Matrix.posSemidef_diagonal_iff).1 hdiag_psd
     exact hdiag_nonneg ⟨0, NeZero.pos D⟩
   have hc_eq_real : c = (c.re : ℂ) := by
-    exact Complex.ext rfl (by simpa using (Complex.nonneg_iff.mp hc_nonneg).2.symm)
-  have hcre_nonneg : 0 ≤ c.re := (Complex.nonneg_iff.mp hc_nonneg).1
+    exact Complex.ext rfl (RCLike.nonneg_iff.mp hc_nonneg).2
+  have hcre_nonneg : 0 ≤ c.re := (RCLike.nonneg_iff.mp hc_nonneg).1
   have hcre_ne0 : c.re ≠ 0 := by
     intro h0
     apply hc_ne0


### PR DESCRIPTION
### Motivation

- The proof of `virtualUnitary_of_gaugePhaseEquiv_twisted` in `TNLean/MPS/Symmetry/StringOrderAux.lean`
  showed the scalar fixed point `c` is real and that `c.re ≥ 0` using direct `Complex.nonneg_iff`
  projections; Mathlib 4.31 provides `RCLike.nonneg_iff`, the preferred generic API, which
  collapses the separate `Complex.ext` / `simpa` step for `hc_eq_real` to a single application.

### Description

- Modified `TNLean/MPS/Symmetry/StringOrderAux.lean` (2 additions, 2 deletions).
- In `virtualUnitary_of_gaugePhaseEquiv_twisted`: replaced `Complex.nonneg_iff` with
  `RCLike.nonneg_iff` in the string-order scalar realness argument, and collapsed the
  `Complex.ext` / `simpa` proof of `hc_eq_real` to a direct `Complex.ext` application.
- No change to the theorem statement, type signature, or downstream callers.

### Testing

- `lake build TNLean.MPS.Symmetry.StringOrderAux -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` (none found).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

_No linked issue found. Branch name `codex/mathlib-4-31-native-pass-37` does not encode an issue number; no `Addresses #N` reference appears in commits or PR body. Author should link the relevant issue manually if one exists._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma; no API or runtime behavior changes.
>
> **Overview**
> In `virtualUnitary_of_gaugePhaseEquiv_twisted`, the steps that show the scalar fixed point `c` is real and that `c.re ≥ 0` now use Mathlib's **`RCLike.nonneg_iff`** instead of **`Complex.nonneg_iff`** (with the previous `Complex.ext` / `simpa` proof of `hc_eq_real` collapsed to a direct `Complex.ext` application).
>
> No change to the theorem statement or the surrounding virtual-unitary construction.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06690feff630f2dfa13f1f3fb21bfbffd5091d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>