### PR TITLE
refactor(Channel/Peripheral): use native scalar positivity

### DIFF
--- a/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean
@@ -246,8 +246,8 @@ theorem exists_peripheral_unitary_of_irreducible_schwarz
     have hdiag_nonneg := (Matrix.posSemidef_diagonal_iff).1 hdiag_psd
     exact hdiag_nonneg ⟨0, NeZero.pos D⟩
   have hc_eq_real : c = (c.re : ℂ) :=
-    Complex.ext rfl (by simpa using (Complex.nonneg_iff.mp hc_nonneg).2.symm)
-  have hcre_nonneg : 0 ≤ c.re := (Complex.nonneg_iff.mp hc_nonneg).1
+    Complex.ext rfl (RCLike.nonneg_iff.mp hc_nonneg).2
+  have hcre_nonneg : 0 ≤ c.re := (RCLike.nonneg_iff.mp hc_nonneg).1
   have hcre_ne0 : c.re ≠ 0 := by
     intro h0
     apply hc_ne0


### PR DESCRIPTION
### Motivation

- The peripheral-eigenvector normalization step in `exists_peripheral_unitary_of_irreducible_schwarz` used direct projections through `Complex.nonneg_iff`, which is more fragile than the `RCLike` order API available in Mathlib 4.31.
- Replacing those projections with `RCLike.nonneg_iff` aligns the positivity argument with canonical Mathlib lemmas, consistent with the broader `mathlib-4-31-native-pass-*` series.

### Description

- Modified `TNLean/Channel/Peripheral/CyclicDecomposition/PeripheralUnitary.lean`: the scalar realness subproof in `exists_peripheral_unitary_of_irreducible_schwarz` now uses `RCLike.nonneg_iff` instead of direct `Complex.nonneg_iff` projections when establishing that the peripheral normalization scalar `c` has nonnegative real part.
- No mathematical statement is changed; the conclusion of `exists_peripheral_unitary_of_irreducible_schwarz` and all downstream uses are unaffected.

### Testing

- `lake build TNLean.Channel.Peripheral.CyclicDecomposition.PeripheralUnitary -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

---
No linked issue identified — this is a self-contained proof-style refactor.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma with no changes to statements or runtime behavior.
>
> **Overview**
> In `exists_peripheral_unitary_of_irreducible_schwarz`, the step that shows the peripheral normalization scalar `c` is real and has nonnegative real part now uses **`RCLike.nonneg_iff`** instead of **`Complex.nonneg_iff`**.
>
> The `hc_eq_real` and `hcre_nonneg` proofs are otherwise unchanged; no API or theorem statements are modified.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d477f94894d997411e3c786f13e173120dab054e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>