### PR TITLE
refactor(MPS/MPDO): use native trace-matrix positivity

### DIFF
--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -314,7 +314,7 @@ stronger property for the sector trace matrix is the remaining MPDO-specific
 evidence. -/
 theorem traceMatrixRe_nonneg (data : ExplicitEtaOperators hη) (k h : Fin hη.m) :
     0 ≤ data.traceMatrixRe k h :=
-  (Complex.le_def.mp (data.eta_pos k h).trace_nonneg).1
+  (RCLike.nonneg_iff.mp (data.eta_pos k h).trace_nonneg).1
 
 end ExplicitEtaOperators
 


### PR DESCRIPTION
### Motivation
- `traceMatrixRe_nonneg` in `TNLean/MPS/MPDO/SimpleLocalStructure.lean` previously
  unfolded `Complex.le_def` to project the real part of a nonneg trace. Mathlib
  provides `RCLike.nonneg_iff` as the idiomatic lemma for this step in the generic
  `RCLike` interface.
- This is a proof-style cleanup in the SAL (simple MPDO local structure) argument
  from arXiv:1606.00608, Appendix C.2; no theorem statement or downstream reasoning
  changes.

### Description
- `TNLean/MPS/MPDO/SimpleLocalStructure.lean`: one-line proof change in
  `traceMatrixRe_nonneg` — replaces `Complex.le_def` unfolding with
  `RCLike.nonneg_iff` applied to `(data.eta_pos k h).trace_nonneg`.
- No API or behavioral change; no new declarations introduced.

### Testing
- `lake build TNLean.MPS.MPDO.SimpleLocalStructure -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
<!-- No linked issue found. The branch `codex/mathlib-4-31-native-pass-39` does not match the `*/issue-{N}-*` pattern and the body contains no `Closes`/`Fixes`/`Addresses` reference. Please link the relevant issue manually. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line proof refactor in a local lemma with no API or behavioral change.
>
> **Overview**
> **`traceMatrixRe_nonneg`** now derives entrywise nonnegativity of `traceMatrixRe` via Mathlib's **`RCLike.nonneg_iff`** applied to `(data.eta_pos k h).trace_nonneg`, instead of unfolding **`Complex.le_def`** on the trace.
>
> The theorem statement and downstream SAL trace-matrix reasoning are unchanged; this is a proof-style cleanup aligned with generic `RCLike` lemmas.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a696fac5e43f51f5ebf67ec18f04d9a56402774. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->