### PR TITLE
refactor(Channel/Irreducible): use native complex order facts

### DIFF
--- a/TNLean/Channel/Irreducible/Growth/Exponential.lean
+++ b/TNLean/Channel/Irreducible/Growth/Exponential.lean
@@ -153,13 +153,13 @@ private theorem posSemidef_mulVec_eq_zero_of_not_dot_pos
   have hq_nonneg : 0 ≤ star v ⬝ᵥ (M *ᵥ v) :=
     hM.dotProduct_mulVec_nonneg v
   have hq_zero : star v ⬝ᵥ (M *ᵥ v) = 0 := by
-    rcases Complex.nonneg_iff.mp hq_nonneg with ⟨hre_nonneg, him_zero⟩
+    rcases RCLike.nonneg_iff.mp hq_nonneg with ⟨hre_nonneg, him_zero⟩
     have h_re_not_pos : ¬ 0 < (star v ⬝ᵥ (M *ᵥ v)).re := by
       intro hre_pos
-      exact hnot ((Complex.pos_iff).2 ⟨hre_pos, him_zero⟩)
+      exact hnot (RCLike.pos_iff.2 ⟨hre_pos, him_zero⟩)
     have h_re_zero : (star v ⬝ᵥ (M *ᵥ v)).re = 0 :=
       le_antisymm (le_of_not_gt h_re_not_pos) hre_nonneg
-    exact Complex.ext h_re_zero him_zero.symm
+    exact Complex.ext h_re_zero him_zero
   exact (hM.dotProduct_mulVec_zero_iff v).mp hq_zero
 
 -- A vanishing PSD sum forces each summand to vanish.

--- a/TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean
+++ b/TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean
@@ -145,14 +145,14 @@ theorem orthogonal_trace_pos_of_irreducible_cp
       have hterm_not_pos : ¬ 0 < Matrix.trace (B * ((E ^ t) A)) := by
         intro hpos
         exact hno ⟨t, ht_pos, ht_le, hpos⟩
-      rcases Complex.nonneg_iff.mp hterm_nonneg with ⟨hre_nonneg, him_zero⟩
+      rcases RCLike.nonneg_iff.mp hterm_nonneg with ⟨hre_nonneg, him_zero⟩
       have h_re_not_pos : ¬ 0 < (Matrix.trace (B * ((E ^ t) A))).re := by
         intro hre_pos
-        exact hterm_not_pos ((Complex.pos_iff).2 ⟨hre_pos, him_zero⟩)
+        exact hterm_not_pos (RCLike.pos_iff.2 ⟨hre_pos, him_zero⟩)
       have h_re_le : (Matrix.trace (B * ((E ^ t) A))).re ≤ 0 := le_of_not_gt h_re_not_pos
       have h_re_zero : (Matrix.trace (B * ((E ^ t) A))).re = 0 :=
         le_antisymm h_re_le hre_nonneg
-      exact Complex.ext h_re_zero him_zero.symm
+      exact Complex.ext h_re_zero him_zero
   have hsum_zero :
       ∑ k ∈ Finset.range (n + 1), n.choose k • Matrix.trace (B * ((E ^ k) A)) = 0 := by
     refine Finset.sum_eq_zero ?_


### PR DESCRIPTION
### Motivation

- `Complex.nonneg_iff` and `Complex.pos_iff` are `Complex`-specific projections; the more general `RCLike.nonneg_iff` and `RCLike.pos_iff` API is the preferred Mathlib abstraction for ordered-field properties over `ℂ`.
- The change is proof-internal: no theorem statements or public definitions are altered.

### Description

- `TNLean/Channel/Irreducible/Growth/Exponential.lean`: replace `Complex.nonneg_iff`/`Complex.pos_iff` with `RCLike.nonneg_iff`/`RCLike.pos_iff` in the positivity argument for `posSemidef_mulVec_eq_zero_of_not_dot_pos`; adjust the final `Complex.ext` step to use `him_zero` directly (matching the projection shape of the RCLike lemmas).
- `TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean`: same API swap in the trace-term contradiction proof.
- All theorem statements and proof strategies are unchanged.

### Testing

- `lake build TNLean.Channel.Irreducible.Growth -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` (none introduced).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

<!-- No linked issue found. Please add `Addresses #N` or `Closes #N` once one is created. -->

> [!NOTE]
> **Low Risk**
> Proof-only API cleanup in private lemmas; behavior and public theorems are unchanged.
> 
> **Overview**
> Swaps **`Complex.nonneg_iff`** / **`Complex.pos_iff`** for **`RCLike.nonneg_iff`** and **`RCLike.pos_iff`** in two private positivity arguments: `posSemidef_mulVec_eq_zero_of_not_dot_pos` in **Exponential.lean** and the trace-term contradiction in **OrthogonalTrace.lean**.
> 
> The final **`Complex.ext`** step now uses **`him_zero`** directly instead of **`him_zero.symm`**, matching the projection shape from the RCLike lemmas. No theorem statements or proof strategy changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a6018551763ca5d262cb45d50d760b4a1532056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>