### PR TITLE
refactor(Channel): use native density trace positivity

### DIFF
--- a/TNLean/Channel/DensityRetract.lean
+++ b/TNLean/Channel/DensityRetract.lean
@@ -159,7 +159,9 @@ theorem trace_matrixAbs_add_self_ne_zero_of_trace_one
     have := congrArg Complex.re hsum
     simpa [Complex.add_re] using this
   have : ¬ ((Matrix.trace (matrixAbs B)).re + 1 = 0) := by
-    linarith [(Complex.nonneg_iff.mp habs_nonneg).1]
+    have hre_nonneg : 0 ≤ (Matrix.trace (matrixAbs B)).re :=
+      (RCLike.nonneg_iff.mp habs_nonneg).1
+    linarith
   exact this hre
 
 @[simp]


### PR DESCRIPTION
### Motivation
- In the proof of `trace_matrixAbs_add_self_ne_zero_of_trace_one` (`TNLean/Channel/DensityRetract.lean`), real-part nonnegativity of the complex trace value was extracted via `Complex.nonneg_iff`, a complex-number-specific projection. The more general `RCLike.nonneg_iff` is sufficient and consistent with the `RCLike` abstraction used elsewhere in the file.

### Description
- `TNLean/Channel/DensityRetract.lean`: in the proof of `trace_matrixAbs_add_self_ne_zero_of_trace_one`, replace the inline `(Complex.nonneg_iff.mp habs_nonneg).1` argument to `linarith` with an explicit intermediate step `hre_nonneg : 0 ≤ (Matrix.trace (matrixAbs B)).re` via `RCLike.nonneg_iff.mp`, followed by `linarith` on that named hypothesis. Net change: one line to three.
- No changes to theorem statements, definitions, or other density-retraction declarations (`densityRetract`, etc.).

### Testing
- `lake build TNLean.Channel.DensityRetract -q --log-level=info`
- Added-line scan confirmed no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

---
_No linked issue identified. If this addresses an open issue, please add `Addresses #N` here._

> [!NOTE]
> **Low Risk**
> Proof-only change in a local lemma; no runtime behavior or public API changes.
>
> **Overview**
> In **`trace_matrixAbs_add_self_ne_zero_of_trace_one`**, the contradiction step that shows `(Matrix.trace (matrixAbs B)).re + 1 ≠ 0` no longer goes through **`Complex.nonneg_iff`** in a single **`linarith`** call.
>
> The proof now names **`hre_nonneg`** explicitly via **`RCLike.nonneg_iff.mp habs_nonneg`**, then uses **`linarith`**. No changes to **`densityRetract`** or other density-retraction statements—only this internal positivity extraction.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d9ccf2285d8e1f912b626b4a3ada7aa88e01296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>