### PR TITLE
refactor(Wielandt): use native trace positivity

### DIFF
--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -494,11 +494,11 @@ private theorem trace_conjTranspose_posDef_mul_lower [NeZero D]
     have hBne : B ≠ 0 := by
       intro h; simp [h] at hB
     have hpsd : (Bᴴ * ρ * B).PosSemidef := hρ.posSemidef.conjTranspose_mul_mul_same B
-    have hre_nonneg : 0 ≤ f B := (Complex.nonneg_iff.mp hpsd.trace_nonneg).1
+    have hre_nonneg : 0 ≤ f B := (RCLike.nonneg_iff.mp hpsd.trace_nonneg).1
     rcases eq_or_lt_of_le hre_nonneg with h | h
     · exfalso
       have him : (Matrix.trace (Bᴴ * ρ * B)).im = 0 :=
-        (Complex.nonneg_iff.mp hpsd.trace_nonneg).2.symm
+        (RCLike.nonneg_iff.mp hpsd.trace_nonneg).2
       exact hBne (eq_zero_of_trace_conjTranspose_mul_posDef_mul_eq_zero ρ hρ B
         (Complex.ext h.symm him))
     · exact h
@@ -620,11 +620,11 @@ theorem hasEventuallyFullKrausRank_of_isStronglyIrreduciblePaper [NeZero D]
   set N := E - Pρ with hN_def
   set Ê := Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ) N with hÊ_def
   -- Step 2: Trace of ρ is real and positive (from PosDef)
-  have htr_nonneg := Complex.nonneg_iff.mp hρPD.posSemidef.trace_nonneg
-  have htr_im : (Matrix.trace ρ).im = 0 := htr_nonneg.2.symm
+  have htr_nonneg := RCLike.nonneg_iff.mp hρPD.posSemidef.trace_nonneg
+  have htr_im : (Matrix.trace ρ).im = 0 := htr_nonneg.2
   have htr_re_pos : 0 < (Matrix.trace ρ).re := by
     rcases eq_or_lt_of_le htr_nonneg.1 with h | h
-    · exact absurd (Complex.ext h.symm htr_nonneg.2.symm) hP.trace_ne_zero
+    · exact absurd (Complex.ext h.symm htr_nonneg.2) hP.trace_ne_zero
     · exact h
   -- Step 3: Uniform positive lower bound: c * ‖B‖² ≤ tr(B†ρB).re
   obtain ⟨c, hcpos, hcbound⟩ := trace_conjTranspose_posDef_mul_lower ρ hρPD


### PR DESCRIPTION
### Motivation

- Align the Wielandt primitivity proof with Mathlib v4.31.0's unified `RCLike` API: `RCLike.nonneg_iff` replaces `Complex.nonneg_iff` when extracting trace realness and nonnegativity from positive semidefinite matrices in the **(c)→(b)** route.
- Eliminates a `Complex`-specific dependency in the positive-definite trace lower-bound argument, making the proof consistent with Mathlib's type-class hierarchy.

### Description

- Modified `TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean` (proof-internal changes only; no changes to theorem statements or hypotheses):
  - `trace_conjTranspose_posDef_mul_lower`: use `RCLike.nonneg_iff` for sphere positivity of `tr(B†ρB)`.
  - `hasEventuallyFullKrausRank_of_isStronglyIrreduciblePaper`: use `RCLike.nonneg_iff` to extract realness and positivity of `tr(ρ)` from `ρ.PosDef`. Imaginary-part equalities no longer require `.symm` because `RCLike.nonneg_iff` projects the imaginary component in the orientation the proofs expect.

### Testing

- `lake build TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` (none introduced).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only API alignment with Mathlib's RCLike trace lemmas; no changes to definitions, interfaces, or proof conclusions.
> 
> **Overview**
> Replaces **`Complex.nonneg_iff`** with Mathlib's **`RCLike.nonneg_iff`** when extracting real/nonnegative trace facts from positive semidefinite matrices in the Wielandt **(c)→(b)** route.
> 
> The updates are in **`trace_conjTranspose_posDef_mul_lower`** (sphere positivity for `tr(B†ρB)`) and **`hasEventuallyFullKrausRank_of_isStronglyIrreduciblePaper`** (real, positive `tr(ρ)` from `ρ.PosDef`). Imaginary-part equalities no longer need **`.symm`** because **`RCLike.nonneg_iff`** projects the imaginary component in the shape the proofs expect.
> 
> No change to theorem statements or the overall proof strategy—only how trace realness is obtained from PSD trace nonnegativity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f2f67df491d5217e65f2bd67bf90cf6ee5132d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->