### PR TITLE
refactor(QPF): use native diagonal positivity

### DIFF
--- a/TNLean/QPF/Uniqueness.lean
+++ b/TNLean/QPF/Uniqueness.lean
@@ -211,7 +211,7 @@ lemma exists_critical_scalar [Nonempty (Fin D)]
     rw [h_shift, hct]
     exact (Matrix.IsUnit.posSemidef_star_right_conjugate_iff hV_unit).mpr
       (Matrix.posSemidef_diagonal_iff.mpr (fun i => by
-        simp only [Complex.nonneg_iff]
+        rw [RCLike.nonneg_iff]
         constructor
         · exact_mod_cast sub_nonneg.mpr (minEigenvalue_le hH_herm i)
         · simp [Complex.ofReal_im]))


### PR DESCRIPTION
### Motivation

- The diagonal positive-semidefinite step in `exists_critical_scalar` was using `Complex.nonneg_iff` via `simp`, which is not the canonical Mathlib API for ordered complex numbers.
- `RCLike.nonneg_iff` is the native Mathlib lemma for this purpose and gives a single-step rewrite without the `Complex`-specific detour.

### Description

- `TNLean/QPF/Uniqueness.lean`: replaced the `simp [Complex.nonneg_iff]` call in the diagonal positivity step of `exists_critical_scalar` with `rw [RCLike.nonneg_iff]` (one line changed).
- No changes to theorem statements, the critical-scalar argument structure, or QPF uniqueness results.

### Testing

- `lake build TNLean.QPF.Uniqueness -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` (none found).
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line proof refactor in a linear-algebra lemma with no changes to statements, APIs, or runtime behavior.
>
> **Overview**
> In **`exists_critical_scalar`**, the step showing `(H - c₀ • 1)` is positive semidefinite via diagonal eigenvalues now rewrites with **`RCLike.nonneg_iff`** instead of simplifying with **`Complex.nonneg_iff`**.
>
> The rest of the critical-scalar argument and the QPF uniqueness theorems are unchanged; this is a one-line proof cleanup aligned with Mathlib's native ordered-complex API.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99457522742eef8574e66369a04bbf67289168e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->