### PR TITLE
refactor(MPS/Irreducible): use native diagonal positivity

### DIFF
--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -493,7 +493,7 @@ private lemma max_shift_posSemidef [Nonempty (Fin D)]
   rw [show Uᴴ = star U by simp [Matrix.star_eq_conjTranspose]]
   exact (Matrix.IsUnit.posSemidef_star_right_conjugate_iff hU_unit).mpr
     (Matrix.posSemidef_diagonal_iff.mpr (fun i => by
-      simp only [Complex.nonneg_iff]
+      rw [RCLike.nonneg_iff]
       constructor
       · exact_mod_cast sub_nonneg.mpr (le_maxEigenvalue hX i)
       · simp [Complex.ofReal_im]))


### PR DESCRIPTION
### Motivation

- The proof of diagonal nonnegativity in `max_shift_posSemidef` used `simp only [Complex.nonneg_iff]`, which is specific to the `Complex` type. Replacing it with `RCLike.nonneg_iff` via `rw` is the idiomatic Mathlib 4.31 form and is more general.

### Description

- `TNLean/MPS/Irreducible/FixedPointProjection.lean`: in `max_shift_posSemidef`, replaced `simp only [Complex.nonneg_iff]` with `rw [RCLike.nonneg_iff]` followed by `constructor` for the real and imaginary parts. No API or mathematical statement changes; fixed-point projection lemma statements are unchanged.

### Testing

- `lake build TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info`
- `git diff --check`
- Scan of added lines for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`: none found.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Lean CI (`lean_action_ci.yml`) validates the full build.

---

> [!NOTE]
> **Low Risk**
> Single-line proof refactor in a private lemma; no API or mathematical statement changes.
> 
> **Overview**
> In **`max_shift_posSemidef`**, the proof that each diagonal entry of the spectral shift matrix is nonnegative now **`rw`s `RCLike.nonneg_iff`** instead of **`simp only [Complex.nonneg_iff]`**, then uses **`constructor`** for the real/im parts. Behavior of the fixed-point projection lemmas is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cde3ac612556b1b4e13834fd9edef2f8a9ed979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>