### PR TITLE
refactor(Channel/FixedPoint): use native Cesaro positivity

### DIFF
--- a/TNLean/Channel/FixedPoint/Cesaro.lean
+++ b/TNLean/Channel/FixedPoint/Cesaro.lean
@@ -100,9 +100,9 @@ private theorem psd_orthogonal_difference_eq_zero
   -- Sum of nonneg reals = 0 ⟹ each = 0
   have hY_diag_zero : ∀ j, star (e j) ⬝ᵥ Y.mulVec (e j) = 0 := by
     have him : ∀ j, (star (e j) ⬝ᵥ Y.mulVec (e j)).im = 0 :=
-      fun j => (Complex.nonneg_iff.mp (hY_nonneg j)).2.symm
+      fun j => (RCLike.nonneg_iff.mp (hY_nonneg j)).2
     have hre_nonneg : ∀ j, 0 ≤ (star (e j) ⬝ᵥ Y.mulVec (e j)).re :=
-      fun j => (Complex.nonneg_iff.mp (hY_nonneg j)).1
+      fun j => (RCLike.nonneg_iff.mp (hY_nonneg j)).1
     have hre_sum : ∑ j, (star (e j) ⬝ᵥ Y.mulVec (e j)).re = 0 := by
       have h1 := map_sum Complex.reAddGroupHom (fun j => star (e j) ⬝ᵥ Y.mulVec (e j)) Finset.univ
       rw [← hY_tr_sum, hY_tr] at h1; exact h1.symm


### PR DESCRIPTION
### Motivation

- The private lemma `psd_orthogonal_difference_eq_zero` in `Channel/FixedPoint/Cesaro.lean` (the linear-algebra step behind Wolf Prop. 6.8) extracted the nonnegative real part and zero imaginary part from a PSD inner product using `Complex.nonneg_iff` projections. Mathlib's `RCLike.nonneg_iff` covers this case directly and avoids the asymmetric `.symm` step on the imaginary-part projection.

### Description

- `TNLean/Channel/FixedPoint/Cesaro.lean`: in the private lemma `psd_orthogonal_difference_eq_zero`, replace `Complex.nonneg_iff` projections with `RCLike.nonneg_iff` to unpack the nonnegativity of each eigen-direction inner product `⟨eⱼ, Y eⱼ⟩`. The imaginary-part step no longer needs `.symm`. No theorem statements or Cesàro fixed-point results change.

### Testing

- `lake build TNLean.Channel.FixedPoint.Cesaro -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a private lemma; no API or behavioral changes to channel fixed-point theorems.
> 
> **Overview**
> In **`psd_orthogonal_difference_eq_zero`** (the linear-algebra step behind Wolf Prop. 6.8 in `Cesaro.lean`), the proof that each eigen-direction inner product `⟨eⱼ, Y eⱼ⟩` is zero now uses Mathlib's **`RCLike.nonneg_iff`** instead of **`Complex.nonneg_iff`** to read off **nonnegative real part** and **zero imaginary part** from `hY_nonneg`.
> 
> The imaginary-part step no longer needs **`.symm`** on the `im = 0` projection. No theorem statements or Cesàro fixed-point results change—only this positivity unpacking in the private lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3004b29611df2d3168002cddbc874637477680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->