### PR TITLE
refactor(Channel): use native diagonal positivity

### DIFF
--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -157,7 +157,7 @@ private lemma posSemidef_diag_norm_le_trace_norm {X : Matrix (Fin D) (Fin D) ℂ
     show ‖trace X‖ = (trace X).re from by
       simpa using congrArg Complex.re (Complex.norm_of_nonneg' hX.trace_nonneg),
     show (trace X).re = ∑ j : Fin D, (X j j).re from by simp [Matrix.trace, Matrix.diag]]
-  exact single_le_sum (fun j _ => (Complex.nonneg_iff.mp (hX.diag_nonneg (i := j))).1)
+  exact single_le_sum (fun j _ => (RCLike.nonneg_iff.mp (hX.diag_nonneg (i := j))).1)
     (mem_univ i)
 
 /-- For PSD `X = Bᴴ * B`, the entry `(Bᴴ * B) i j` equals an inner product of column vectors. -/


### PR DESCRIPTION
### Motivation

- The proof step in `posSemidef_diag_norm_le_trace_norm` (`Channel.Basic`) that turns a PSD diagonal entry into a non-negative real used `Complex.nonneg_iff`. Mathlib's `RCLike.nonneg_iff` provides the same projection for any `RCLike` field and is already available via the existing import, making the proof more uniform with the surrounding Mathlib lemmas.

### Description

- `TNLean/Channel/Basic.lean`: one-line change in the proof of `posSemidef_diag_norm_le_trace_norm`; `Complex.nonneg_iff` is replaced by `RCLike.nonneg_iff` to align with Mathlib's generic `RCLike` hierarchy.
- No public statement, definition, or downstream channel boundedness result is changed.

### Testing

- `lake build TNLean.Channel.Basic -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
No linked issue found — the branch `codex/mathlib-4-31-native-pass-46` contains no `issue-{N}` reference. Please link an issue manually if this PR addresses one.

> [!NOTE]
> **Low Risk**
> Single-line proof refactor in a private lemma with no API or behavioral change to channel theory.
>
> **Overview**
> In **`posSemidef_diag_norm_le_trace_norm`**, the step that turns PSD diagonal nonnegativity into a real summand now uses **`RCLike.nonneg_iff`** instead of **`Complex.nonneg_iff`**.
>
> The proof structure and all downstream channel boundedness results are unchanged; this only aligns the helper with Mathlib's generic **`RCLike`** lemmas (already available via the existing import).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a06b6ef65a6c74b49ec09dc0fd3db7b80aeef9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>