### PR TITLE
refactor(Channel/Schwarz): use native abelian positivity

### DIFF
--- a/TNLean/Channel/Schwarz/PositiveOnAbelian/Characterization.lean
+++ b/TNLean/Channel/Schwarz/PositiveOnAbelian/Characterization.lean
@@ -78,7 +78,7 @@ private lemma blockHermitian_of_blockPositive {n D : ℕ}
       rw [hinnerSum i r, Finset.mul_sum]
       rfl
     have hqreal : star q = q := by
-      have hqim : q.im = 0 := (Complex.nonneg_iff.mp hq).2.symm
+      have hqim : q.im = 0 := (RCLike.nonneg_iff.mp hq).2
       apply Complex.ext
       · simp only [RCLike.star_def, conj_re]
       · simp only [RCLike.star_def, conj_im, hqim, neg_zero]


### PR DESCRIPTION
### Motivation

- The proof of `blockHermitian_of_blockPositive` in the positive-on-abelian characterization used `Complex.nonneg_iff`, a `Complex`-specific lemma, where the more general `RCLike.nonneg_iff` applies directly. This substitution uses the general `RCLike` interface consistently with the surrounding proof.
- No mathematical content changes; exported theorem statements are unchanged.

### Description

- `TNLean/Channel/Schwarz/PositiveOnAbelian/Characterization.lean` (1 line changed): in the private lemma `blockHermitian_of_blockPositive`, replaced `(Complex.nonneg_iff.mp hq).2.symm` with `(RCLike.nonneg_iff.mp hq).2` in the step that extracts the imaginary part of the quadratic form scalar `q` to establish `star q = q`. The exported positive-on-abelian characterization theorems are unchanged.

### Testing

- `lake build TNLean.Channel.Schwarz.PositiveOnAbelian.Characterization -q --log-level=info` — focused build succeeds; style warnings appear only in pre-existing imported files.
- Scanned added lines for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` — none introduced.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`

---
No linked issue found. The bot was unable to identify a corresponding GitHub issue from the branch name (`codex/mathlib-4-31-native-pass-47`), commit messages, or PR body. Please link one manually if applicable.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Single-line proof refactor in a private lemma; behavior and exported theorems are unchanged.
>
> **Overview**
> In **`blockHermitian_of_blockPositive`**, the step that shows the quadratic form scalar `q` is real now uses **`RCLike.nonneg_iff`** instead of **`Complex.nonneg_iff`**, taking the imaginary part as `.2` without an extra **`.symm`**.
>
> No theorem statements or proof structure elsewhere in the positive-on-abelian characterization change.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bbae1a71d060ce5e4405f46932a6399a1620f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->