### PR TITLE
refactor(Channel/Schwarz): use native Choi negativity order fact

### DIFF
--- a/TNLean/Channel/Schwarz/SchwarzNotCP.lean
+++ b/TNLean/Channel/Schwarz/SchwarzNotCP.lean
@@ -283,6 +283,6 @@ theorem wolfExample53_not_cp : ¬ IsCPMap wolfExample53 := by
   have hneg : ¬ (0 : ℂ) ≤
       star wolfExample53AntisymmVec ⬝ᵥ
         (ChoiJamiolkowski.choiMatrix wolfExample53).mulVec wolfExample53AntisymmVec := by
-    rw [wolfExample53_choi_negative_antisymm, Complex.nonneg_iff]
+    rw [wolfExample53_choi_negative_antisymm, RCLike.nonneg_iff]
     norm_num
   exact hneg hnonneg


### PR DESCRIPTION
### Motivation

- `Complex.nonneg_iff` is specific to the complex numbers; Mathlib 4.31 provides `RCLike.nonneg_iff`, which generalises the same nonnegativity criterion to any `RCLike` instance.
- Replacing the complex-specific lemma removes an unnecessary type-class specialisation in the Choi-negativity argument for Wolf Example 5.3 (the transpose-trace map is positive but not completely positive).

### Description

- `TNLean/Channel/Schwarz/SchwarzNotCP.lean` (line 286): in the proof of `wolfExample53_not_cp`, replace `Complex.nonneg_iff` with `RCLike.nonneg_iff`.
- One line changed; no mathematical statement is altered.
- The conclusion — that the Choi matrix of the transpose-trace map has a negative entry, hence the map is not completely positive — is unchanged.

### Testing

- `lake build TNLean.Channel.Schwarz.SchwarzNotCP -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `lake exe checkdecls blueprint/lean_decls`
- Added-line scan: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced.
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Full build reports only pre-existing style warnings and the pre-existing `sorry` in `TNLean/MPS/Periodic/Overlap/Case3.lean`; this PR introduces no new placeholders.

---
No linked issue identified; see PR comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5d4e7033f36f53a15f00079e0859ec8b7fd791da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->