### PR TITLE
refactor(Channel/Schwarz): inline Kraus map wrappers

### DIFF
--- a/TNLean/Channel/Schwarz/KadisonSchwarz.lean
+++ b/TNLean/Channel/Schwarz/KadisonSchwarz.lean
@@ -81,28 +81,17 @@ theorem trace_krausMap_of_tp (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
   rw [← trace_sum, ← Finset.sum_mul, show ∑ i : Fin d, (K i)ᴴ * K i = 1 from h_tp,
     one_mul]
 
-/-- The finite-index Kadison-Schwarz Kraus map is the general Kraus map. -/
-theorem krausMap_eq_map (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    krausMap K X = Kraus.map K X :=
-  rfl
-
 /-- The Kadison-Schwarz Kraus map commutes with conjugate transpose. -/
 theorem krausMap_conjTranspose (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     krausMap K Xᴴ = (krausMap K X)ᴴ := by
-  simpa [krausMap_eq_map] using (Kraus.map_conjTranspose (K := K) X).symm
+  simpa [krausMap, Kraus.map] using (Kraus.map_conjTranspose (K := K) X).symm
 
 /-- The conjugate transpose of a Kadison-Schwarz Kraus map. -/
 theorem conjTranspose_krausMap (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     (krausMap K X)ᴴ = krausMap K Xᴴ := by
-  simpa [krausMap_eq_map] using Kraus.map_conjTranspose (K := K) X
-
-/-- The adjoint Kraus map equals the Kraus map with conjugate-transposed operators. -/
-private theorem krausAdjointMap_eq (K : Fin d → Matrix (Fin D) (Fin D) ℂ) (Y) :
-    krausAdjointMap K Y = krausMap (fun i => (K i)ᴴ) Y := by
-  simp [krausAdjointMap, krausMap, conjTranspose_conjTranspose]
+  simpa [krausMap, Kraus.map] using Kraus.map_conjTranspose (K := K) X
 
 /-- The conjugate-transposed operators of a TP family form a unital family. -/
 theorem isUnitalKraus_conjTranspose {K : Fin d → Matrix (Fin D) (Fin D) ℂ}
@@ -192,8 +181,8 @@ theorem kadison_schwarz_adjoint (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
     (h_tp : IsTPKraus K)
     (X : Matrix (Fin D) (Fin D) ℂ) :
     (krausAdjointMap K (Xᴴ * X) - (krausAdjointMap K X)ᴴ * krausAdjointMap K X).PosSemidef := by
-  simp only [krausAdjointMap_eq]
-  exact kadison_schwarz _ (isUnitalKraus_conjTranspose h_tp) X
+  simpa [krausAdjointMap, krausMap, conjTranspose_conjTranspose] using
+    kadison_schwarz (fun i => (K i)ᴴ) (isUnitalKraus_conjTranspose h_tp) X
 
 /-- **Kadison-Schwarz in Loewner order** (≤ formulation).
 


### PR DESCRIPTION
### Motivation

- `krausMap_eq_map` was a public lemma in `KadisonSchwarz.lean` that held by `rfl`, merely restating that the local finite-index map equals `Kraus.map`; it added no mathematical content.
- `krausAdjointMap_eq` was a private lemma that only unfolded the adjoint Kraus map to `Kraus.map` applied to conjugate-transposed operators; `Kraus.map_conjTranspose` provides this directly.
- Removing these pass-through restatements is part of the Mathlib 4.31 native-pass cleanup.

### Description

- Modified `TNLean/Channel/Schwarz/KadisonSchwarz.lean`: removed the public lemma `krausMap_eq_map` and the private lemma `krausAdjointMap_eq`. Call sites now invoke `Kraus.map_conjTranspose` directly or simplify from the definitions at the proof site.
- No mathematical statement is weakened or strengthened.

### Testing

- `lake build TNLean.Channel.Schwarz.KadisonSchwarz -q --log-level=info`
- `lake build TNLean.Channel.Schwarz.SchwarzNormal TNLean.Channel.Schwarz.MultiplicativeDomainFull -q --log-level=info`
- Proof-integrity scan (added lines): no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Builds report only pre-existing style warnings: short copyright headers in the Schwarz import chain and a long line in `TNLean/Channel/Schwarz/PositiveOnAbelian/Basic.lean`.

---
No linked issue identified — this is a self-contained internal refactor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit daf5fc92e1637fbf0ac2ce1c154ce1938923d6e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->