### PR TITLE
refactor(Channel/FixedPoint): inline adjoint unitality conversion

### DIFF
--- a/TNLean/Channel/FixedPoint/Algebra.lean
+++ b/TNLean/Channel/FixedPoint/Algebra.lean
@@ -67,10 +67,6 @@ section AuxiliaryLemmas
     adjointMap K (1 : Mat) = 1 := by
   simpa [adjointMap, IsTP, Matrix.mul_one] using h_tp
 
-private theorem isUnital_conjTranspose_of_isTP (K : Fin d → Mat) (h_tp : IsTP K) :
-    IsUnital (fun i => (K i)ᴴ) := by
-  simpa [IsUnital, IsTP] using h_tp
-
 end AuxiliaryLemmas
 
 section FixedPoints
@@ -234,7 +230,7 @@ noncomputable def adjointFixedPointsStarSubalgebra
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : map K ρ = ρ) :
     StarSubalgebra ℂ Mat :=
   fixedPointsStarSubalgebra (K := fun i => (K i)ᴴ)
-    (h_unital := isUnital_conjTranspose_of_isTP K h_tp) hρ
+    (h_unital := by simpa [IsUnital, IsTP] using h_tp) hρ
     (by simpa [adjointMap, map] using hρ_fix)
 
 @[simp] theorem mem_adjointFixedPointsStarSubalgebra
@@ -262,7 +258,7 @@ theorem fixedPoints_in_multiplicativeDomain
     {X : Mat} (hX : X ∈ adjointFixedPoints K) :
     X ∈ KadisonSchwarz.multiplicativeDomain (fun i => (K i)ᴴ) := by
   have h_unital : IsUnital (fun i => (K i)ᴴ) :=
-    isUnital_conjTranspose_of_isTP K h_tp
+    by simpa [IsUnital, IsTP] using h_tp
   exact mem_multiplicativeDomain_of_mem_fixedPoints (K := fun i => (K i)ᴴ) h_unital hρ
     (by simpa [adjointMap, map] using hρ_fix)
     (by simpa [fixedPoints, adjointFixedPoints, map, adjointMap] using hX)
@@ -293,7 +289,7 @@ theorem fixedPoint_commutes_kraus
     (hXX : Xᴴ * X ∈ adjointFixedPoints K) :
     ∀ i : Fin d, X * K i = K i * X := by
   have h_unital : IsUnital (fun i => (K i)ᴴ) :=
-    isUnital_conjTranspose_of_isTP K h_tp
+    by simpa [IsUnital, IsTP] using h_tp
   have hX' : map (fun i => (K i)ᴴ) X = X := by
     simpa [adjointFixedPoints, adjointMap, map] using hX
   have hXX' : map (fun i => (K i)ᴴ) (Xᴴ * X) = Xᴴ * X := by


### PR DESCRIPTION
### Motivation

- `TNLean/Channel/FixedPoint/Algebra.lean` contained a private auxiliary lemma (`isUnital_conjTranspose_of_isTP`) whose sole purpose was to unfold the definitions of `IsTP` and `IsUnital` for the conjugate-transposed Kraus family. Having a named private lemma for a one-line definitional unfolding adds indirection without mathematical value.
- Removing it reduces the internal surface of the file and keeps proof steps local to the theorems that require them.

### Description

- Modified `TNLean/Channel/FixedPoint/Algebra.lean` only.
- Deleted the private lemma `isUnital_conjTranspose_of_isTP`, which stated that `IsTP K` implies `IsUnital (fun i => (K i)ᴴ)`.
- The three former call sites — proofs of `adjointFixedPointsStarSubalgebra`, `fixedPoints_in_multiplicativeDomain`, and `fixedPoint_commutes_kraus` — now supply the definitional conversion directly using `simpa [IsUnital, IsTP]`.
- No public mathematical statement is changed; no `sorry` introduced.

### Testing

- `lake build TNLean.Channel.FixedPoint.Algebra -q --log-level=info`
- `lake build TNLean.Channel.FixedPoint.WedderburnDecomp TNLean.Channel.FixedPoint.ConditionalExpectation TNLean.MPS.MPDO.AlgebraStructure TNLean.Channel.FixedPoint.Corollaries TNLean.Channel.FixedPoint.ChoiEffros TNLean.Channel.WolfChapter6Index TNLean.Channel.Semigroup.LiouvillianKernel -q --log-level=info`
- Proof-integrity scan: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` on added lines.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean builds report only pre-existing warnings (copyright-header and module-docstring style, plus existing `Gametheory` dependency warnings).

---

_No linked issue found. The PR author should add `Addresses #N` or `Closes #N` once a tracking issue is identified._

---

> [!NOTE]
> **Low Risk**
> Small proof-structure cleanup in one file with no behavioral or API changes.
> 
> **Overview**
> **Refactors** `TNLean/Channel/FixedPoint/Algebra.lean` by deleting the private lemma `isUnital_conjTranspose_of_isTP`, which only unfolded that `IsTP K` means `IsUnital (fun i => (K i)ᴴ)`.
> 
> The three places that needed that unitality hypothesis—`adjointFixedPointsStarSubalgebra`, `fixedPoints_in_multiplicativeDomain`, and `fixedPoint_commutes_kraus`—now supply `by simpa [IsUnital, IsTP] using h_tp` directly instead of calling the helper.
> 
> No change to statements or proof strategy beyond this inlining; public API and mathematics stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496242882d4b47576cb6322c3f90742b3ef96a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>