### PR TITLE
refactor(Channel/Semigroup): inline trace evaluation bridge

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean
@@ -36,12 +36,6 @@ private def traceEvalCLM (ρ : Matrix (Fin D) (Fin D) ℂ) :
   ((LinearMap.toContinuousLinearMap (Matrix.traceLinearMap (Fin D) ℂ ℂ)).restrictScalars ℝ).comp
     ((ContinuousLinearMap.apply ℂ (Matrix (Fin D) (Fin D) ℂ) ρ).restrictScalars ℝ)
 
-private lemma traceEvalCLM_apply
-    (T : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) :
-    traceEvalCLM ρ T = trace (T ρ) := by
-  rfl
-
 /-- `exp(tL) * L = L * exp(tL)` in the CLM algebra, because `L` commutes with `tL`. -/
 private lemma expSemigroupCLM_mul_comm_local
     (L_CLM : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -63,9 +57,10 @@ private lemma trace_expSemigroupCLM_eq
   set f : ℝ → ℂ := g ∘ fun s => expSemigroupCLM L_CLM s
   suffices hsuff : ∀ x y : ℝ, f x = f y by
     have h0 : f 0 = trace ρ := by
-      change (g ∘ fun s => expSemigroupCLM L_CLM s) 0 = trace ρ
-      simp [Function.comp, g, traceEvalCLM_apply, expSemigroupCLM_zero]
-    simpa [f, g, traceEvalCLM_apply] using (hsuff t 0).trans h0
+      change trace ((expSemigroupCLM L_CLM 0) ρ) = trace ρ
+      simp [expSemigroupCLM_zero]
+    change trace ((expSemigroupCLM L_CLM t) ρ) = trace ρ
+    exact (hsuff t 0).trans h0
   apply is_const_of_deriv_eq_zero
   · -- Differentiable
     intro s
@@ -88,7 +83,7 @@ private lemma trace_expSemigroupCLM_eq
       change deriv (g ∘ fun u => expSemigroupCLM L_CLM u) s =
         g (expSemigroupCLM L_CLM s * L_CLM)
       exact hd.deriv
-    rw [hderiv, traceEvalCLM_apply, expSemigroupCLM_mul_comm_local]
+    rw [hderiv, expSemigroupCLM_mul_comm_local]
     change trace (L_CLM ((expSemigroupCLM L_CLM s) ρ)) = 0
     exact hTA _
 
@@ -137,12 +132,12 @@ theorem isTraceAnnihilating_of_isTracePreservingMap_semigroup
       (f' := expSemigroupCLM L_CLM 0 * L_CLM) hg0
       (hasDerivAt_expSemigroupCLM L_CLM 0)
   simp only [expSemigroupCLM_zero, one_mul] at hd0
-  have hg_L : g L_CLM = trace (L ρ) := by rw [traceEvalCLM_apply]; rfl
+  have hg_L : g L_CLM = trace (L ρ) := by
+    rfl
   rw [hg_L] at hd0
   -- For t ≥ 0: g(exp(tL)) = trace(ρ) (constant from TP hypothesis)
   have hconst : ∀ t : ℝ, 0 ≤ t → g (expSemigroupCLM L_CLM t) = trace ρ :=
     fun t ht => by
-      rw [traceEvalCLM_apply]
       change trace ((expSemigroupCLM (endEquiv L) t) ρ) = trace ρ
       rw [← expSemigroup_toCLM L t]
       change trace ((expSemigroup L t) ρ) = trace ρ


### PR DESCRIPTION
### Motivation

- The private lemma `traceEvalCLM_apply` was a definitional pass-through of the form `traceEvalCLM ρ T = trace (T ρ)`, adding an extra rewrite step in the Lindblad semigroup trace-preservation proofs without contributing any mathematical content.
- Removing it and using `change` steps in its place makes the two affected proof blocks self-contained.

### Description

- Modified `TNLean/Channel/Semigroup/LindbladForm/TraceBridge.lean`.
- Removed the private lemma `traceEvalCLM_apply` (`traceEvalCLM ρ T = trace (T ρ)`).
- In `trace_expSemigroupCLM_eq`: the constant-trace argument now uses `change` to state the goal as `trace ((expSemigroupCLM L_CLM …) ρ)` directly; the derivative step rewrites with `expSemigroupCLM_mul_comm_local` without the intermediate `traceEvalCLM_apply` rewrite.
- In `isTraceAnnihilating_of_isTracePreservingMap_semigroup`: the trace-preserving hypothesis is unfolded via `change` rather than `rw [traceEvalCLM_apply]`.
- The definition `traceEvalCLM` and all public theorems are unchanged; no mathematical statement is altered.

### Testing

- `lake build TNLean.Channel.Semigroup.LindbladForm.TraceBridge TNLean.Channel.Semigroup.LindbladForm.GKSLTheorem -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single Lean file with no API or mathematical statement changes.
>
> **Overview**
> Removes the private lemma **`traceEvalCLM_apply`** (`traceEvalCLM ρ T = trace (T ρ)`) and stops routing trace evaluations through that helper.
>
> In **`trace_expSemigroupCLM_eq`**, the constant-trace argument now uses **`change`** to state goals as `trace ((expSemigroupCLM L_CLM …) ρ)` directly, and the derivative step rewrites with **`expSemigroupCLM_mul_comm_local`** without an intermediate `traceEvalCLM_apply` rewrite. In **`isTraceAnnihilating_of_isTracePreservingMap_semigroup`**, `g L_CLM = trace (L ρ)` is proved by **`rfl`**, and the trace-preserving hypothesis is unfolded with **`change`** instead of **`rw [traceEvalCLM_apply]`**.
>
> **`traceEvalCLM`** and the stated theorems are unchanged; this is proof-style cleanup only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fdc24060765399f7e0ccf3757f9edffa7066dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- /CURSOR_SUMMARY -->