### PR TITLE
refactor(Channel): use native linear map expansions

### DIFF
--- a/TNLean/Channel/KrausFreedom.lean
+++ b/TNLean/Channel/KrausFreedom.lean
@@ -106,14 +106,6 @@ private noncomputable abbrev euclideanFiniteDimensional (ι : Type*) [Fintype ι
   Module.Basis.finiteDimensional_of_finite
     ((Pi.basisFun ℂ ι).map (EuclideanSpace.equiv ι ℂ).symm.toLinearEquiv)
 
-/-- Rewrite a `toEuclideanLin` composition as matrix multiplication. -/
-private lemma toEuclideanLin_conjTranspose_mul_apply
-    {m n : Type*} [Fintype m] [Fintype n] [DecidableEq m] [DecidableEq n]
-    (M : Matrix m n ℂ) (w : EuclideanSpace ℂ n) :
-    Mᴴ.toEuclideanLin (M.toEuclideanLin w) = (Mᴴ * M).toEuclideanLin w := by
-  change (Mᴴ.toEuclideanLin.comp M.toEuclideanLin) w = _
-  rw [← toLpLin_mul_same]
-
 set_option maxHeartbeats 1600000 in
 -- The partial-isometry extension passes through several nested finite-dimensional choices.
 /-- **Rectangular Kraus freedom** (Wolf Theorem 2.1 item 4, necessary direction):
@@ -201,8 +193,9 @@ theorem kraus_rectangular_freedom
     show fB.adjoint (fB w) = fA'.adjoint (fA' w)
     rw [← Matrix.toEuclideanLin_conjTranspose_eq_adjoint MB,
         ← Matrix.toEuclideanLin_conjTranspose_eq_adjoint MA']
-    rw [toEuclideanLin_conjTranspose_mul_apply MB,
-      toEuclideanLin_conjTranspose_mul_apply MA', hGram]
+    change (MBᴴ.toEuclideanLin.comp MB.toEuclideanLin) w =
+      (MA'ᴴ.toEuclideanLin.comp MA'.toEuclideanLin) w
+    rw [← toLpLin_mul_same, ← toLpLin_mul_same, hGram]
   -- Kernel inclusion
   have hker : LinearMap.ker fA' ≤ LinearMap.ker fB := by
     intro v hv; rw [LinearMap.mem_ker] at hv ⊢

--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -248,10 +248,6 @@ private def quadMap (G : GeneratorDecomp D) : sgLM D :=
 private def eulerStep (G : GeneratorDecomp D) (s : ℝ) : sgLM D :=
   Kraus.mapLM (fun _ : Fin 1 => (1 : sgMat D) - (s : ℂ) • G.κ) + (s : ℂ) • G.φ
 
-private theorem quadMap_apply (G : GeneratorDecomp D) (ρ : sgMat D) :
-    quadMap G ρ = G.κ * ρ * G.κᴴ := by
-  simp [quadMap, Kraus.mapLM_apply, Kraus.map_apply]
-
 private theorem eulerStep_apply (G : GeneratorDecomp D) (s : ℝ) (ρ : sgMat D) :
     eulerStep G s ρ =
       ρ + s • (G.φ ρ + -(G.κ * ρ) + -(ρ * G.κᴴ)) + (s * s) • (G.κ * ρ * G.κᴴ) := by
@@ -300,7 +296,9 @@ private theorem eulerStep_toCLM_eq (G : GeneratorDecomp D) (s : ℝ) :
   change (eulerStep G s ρ) i j =
     (ρ + (s : ℂ) • G.toLinearMap ρ + ((s ^ 2 : ℝ) : ℂ) • quadMap G ρ) i j
   rw [eulerStep_apply]
-  rw [quadMap_apply, GeneratorDecomp.toLinearMap_apply]
+  rw [GeneratorDecomp.toLinearMap_apply]
+  simp only [quadMap, Kraus.mapLM_apply, Kraus.map_apply, Finset.univ_unique,
+    Fin.default_eq_zero, Fin.isValue, Finset.sum_const, Finset.card_singleton, one_smul]
   simp only [Matrix.add_apply, Matrix.smul_apply, Matrix.neg_apply, Complex.real_smul,
     Complex.ofReal_mul, Complex.coe_smul, smul_eq_mul, sub_eq_add_neg, pow_two]
 


### PR DESCRIPTION
### Motivation

- Two private lemmas in `Channel/KrausFreedom` and `Channel/Semigroup/LindbladForm/EulerStep` repackaged existing Mathlib linear-map expansions without adding mathematical content.
- Removing them and expanding the goals directly at the use site aligns with the style already used in `Channel/POVM/Uniqueness`.

### Description

- `TNLean/Channel/KrausFreedom.lean`: removed the private lemma `toEuclideanLin_conjTranspose_mul_apply`; the inner-product preservation proof now rewrites `Mᴴ.toEuclideanLin ∘ M.toEuclideanLin` and closes with Mathlib's `toLpLin_mul_same` directly.
- `TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean`: removed the private lemma `quadMap_apply`; `eulerStep_toCLM_eq` now expands the one-Kraus `quadMap` directly via `Kraus.mapLM_apply` and `Kraus.map_apply` at the use site.
- No theorem statements are changed; proof structure only.

### Testing

- `lake build TNLean.Channel.Semigroup.LindbladForm.EulerStep -q --log-level=info`
- `lake build TNLean.Channel.KrausFreedom -q --log-level=info`
- `lake build TNLean.Channel.RadonNikodym TNLean.Channel.POVM.Uniqueness TNLean.Channel.KrausUnitaryFreedom TNLean.Channel.WolfProps TNLean.MPS.RFP.Defs TNLean.MPS.Symmetry.StringOrderDefs TNLean.Channel.Semigroup.LindbladForm TNLean.Channel.Semigroup.LindbladForm.GKSLTheorem -q --log-level=info`
- Added-line scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged statements; no API or runtime behavior changes.
> 
> **Overview**
> Removes two private lemmas that only repackaged existing Mathlib or Kraus expansions, and proves the same goals inline.
> 
> In **`KrausFreedom`**, the inner-product step for rectangular Kraus freedom no longer goes through `toEuclideanLin_conjTranspose_mul_apply`; it rewrites `Mᴴ.toEuclideanLin ∘ M.toEuclideanLin` and closes with **`toLpLin_mul_same`**, aligned with **`POVM/Uniqueness`**.
> 
> In **`EulerStep`**, **`quadMap_apply`** is deleted; **`eulerStep_toCLM_eq`** expands the one-Kraus **`quadMap`** via **`Kraus.mapLM_apply`** / **`Kraus.map_apply`** at the use site.
> 
> **No theorem statements change**—proof structure only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad997b437b97969e775167e23d80f52549d89345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->