### PR TITLE
refactor(Channel): inline block diagonal evaluations

### DIFF
--- a/TNLean/Channel/CompletelyPositiveBridge.lean
+++ b/TNLean/Channel/CompletelyPositiveBridge.lean
@@ -51,17 +51,6 @@ private def blockDiagConst (k : ℕ) (W : Matrix (Fin D) (Fin D) ℂ) :
     CStarMatrix (Fin k) (Fin k) (CStarMatrix (Fin D) (Fin D) ℂ) :=
   Matrix.diagonal (fun _ : Fin k => CStarMatrix.ofMatrix W)
 
-private lemma blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin D) ℂ) (a b : Fin k) :
-    blockDiagConst k W a b = if a = b then CStarMatrix.ofMatrix W else 0 := by
-  simp [blockDiagConst, Matrix.diagonal_apply]
-
-private lemma star_blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin D) ℂ) (a b : Fin k) :
-    star (blockDiagConst k W) a b = if a = b then star (CStarMatrix.ofMatrix W) else 0 := by
-  rw [CStarMatrix.star_apply, blockDiagConst_apply]
-  by_cases h : a = b
-  · subst h; simp
-  · rw [if_neg (fun h' => h h'.symm), if_neg h, star_zero]
-
 /-- Conjugating a block matrix `M` by `blockDiagConst k W` acts entrywise as the
 single Kraus term `X ↦ W * X * Wᴴ`. -/
 private lemma conjugate_blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin D) ℂ)
@@ -69,9 +58,15 @@ private lemma conjugate_blockDiagConst_apply (k : ℕ) (W : Matrix (Fin D) (Fin 
     (blockDiagConst k W * M * star (blockDiagConst k W)) a b
       = CStarMatrix.ofMatrix W * M a b * star (CStarMatrix.ofMatrix W) := by
   classical
-  simp only [CStarMatrix.mul_apply, blockDiagConst_apply, star_blockDiagConst_apply,
-    ite_mul, zero_mul, mul_ite, mul_zero, Finset.sum_ite_eq, Finset.sum_ite_eq',
-    Finset.mem_univ, if_true]
+  simp only [CStarMatrix.mul_apply, CStarMatrix.star_apply, blockDiagConst,
+    Matrix.diagonal_apply, ite_mul, zero_mul, Finset.sum_ite_eq, Finset.mem_univ,
+    if_true]
+  rw [Finset.sum_eq_single b]
+  · simp
+  · intro x _ hx
+    simp [Ne.symm hx]
+  · intro hb
+    exact False.elim (hb (Finset.mem_univ b))
 
 /-- A linear self-map of `M_D(ℂ)`, identified with a linear self-map of the
 C⋆-algebra `CStarMatrix (Fin D) (Fin D) ℂ` (the two types are definitionally


### PR DESCRIPTION
### Motivation

- `Channel/CompletelyPositiveBridge.lean` contained two private pass-through
  lemmas (`blockDiagConst_apply` and `star_blockDiagConst_apply`) that served
  only as stepping stones inside a single proof and added no reusable content.
- Inlining the unfolding steps removes the indirection and simplifies the
  proof of the block-diagonal conjugation identity.

### Description

- Modified `TNLean/Channel/CompletelyPositiveBridge.lean`:
  - Removed private helpers `blockDiagConst_apply` and `star_blockDiagConst_apply`.
  - Rewrote the proof of `conjugate_blockDiagConst_apply` to unfold
    `blockDiagConst` directly via `Matrix.diagonal_apply` and
    `CStarMatrix.star_apply`, then close the remaining finite sum with
    `Finset.sum_eq_single`.
  - The statement of `conjugate_blockDiagConst_apply`, `map_eq_sum_conjugate`,
    and all public Kraus-to-`CompletelyPositiveMap` API are unchanged.

### Testing

- `lake build TNLean.Channel.CompletelyPositiveBridge -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a private lemma; no changes to statements, definitions, or exported theorems.
>
> **Overview**
> Refactors the proof of **`conjugate_blockDiagConst_apply`** in `CompletelyPositiveBridge.lean` by dropping the private helpers **`blockDiagConst_apply`** and **`star_blockDiagConst_apply`**.
>
> The conjugation identity is now proved by unfolding **`blockDiagConst`** with **`Matrix.diagonal_apply`** and **`CStarMatrix.star_apply`**, then finishing with **`Finset.sum_eq_single`** instead of a longer **`simp`**/`ite` chain. **`conjugate_blockDiagConst_apply`**, **`map_eq_sum_conjugate`**, and the public Kraus→**`CompletelyPositiveMap`** API are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911d4f352e4f789f58cbe0528a3e437806133c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>