### PR TITLE
refactor(Wielandt): use native wordSpan zero lemma

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean
@@ -47,28 +47,11 @@ variable {d D : ℕ}
 
 /-! ### Part 1: Initial dimension of rectSpan -/
 
-/-- `wordSpan A 0 = span{1}`: words of length 0 consist only of the identity. -/
-private theorem wordSpan_zero_eq (A : MPSTensor d D) :
-    wordSpan A 0 = Submodule.span ℂ {(1 : Matrix (Fin D) (Fin D) ℂ)} := by
-  -- wordSpan A 0 = span of {evalWord A (List.ofFn σ) : σ : Fin 0 → Fin d}
-  -- There is exactly one function Fin 0 → Fin d (the empty function),
-  -- and evalWord of an empty list is 1.
-  apply le_antisymm
-  · apply Submodule.span_le.mpr
-    rintro M ⟨σ, rfl⟩
-    have hempty : List.ofFn σ = ([] : List (Fin d)) := List.ofFn_eq_nil_iff.mpr rfl
-    simp only [hempty, evalWord]
-    exact Submodule.subset_span rfl
-  · apply Submodule.span_le.mpr
-    rintro M (rfl : M = 1)
-    have := evalWord_mem_wordSpan A ([] : List (Fin d))
-    simpa [evalWord] using this
-
 /-- `rectSpan P A 0 = span{P}`: the level-0 rectangular span is just the 1-D subspace
 spanned by `P` (since `wordSpan A 0 = span{1}`). -/
 theorem rectSpan_zero_eq_span (P : Matrix (Fin D) (Fin D) ℂ) (A : MPSTensor d D) :
     rectSpan P A 0 = Submodule.span ℂ {P} := by
-  simp only [rectSpan, wordSpan_zero_eq]
+  simp only [rectSpan, wordSpan_zero]
   rw [Submodule.map_span]
   congr 1
   ext M


### PR DESCRIPTION
### Motivation

- `TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean` contained a private lemma `wordSpan_zero_eq` restating the identity `wordSpan A 0 = span (range (A i))`, already established as the public `wordSpan_zero` in the span-growth layer. Removing the duplicate reduces redundancy and ensures the proof of `rectSpan_zero_eq_span` cites the shared public result.

### Description

- Modified `TNLean/Wielandt/RectangularSpan/UniversalityAux/Quantitative.lean`:
  - Removed the private lemma `wordSpan_zero_eq`.
  - Updated the proof of `rectSpan_zero_eq_span` to apply the public `wordSpan_zero` directly via `simp only [rectSpan, wordSpan_zero]`.
- No theorem statements or downstream results are changed; this is proof deduplication only.

### Testing

- `lake build TNLean.Wielandt.RectangularSpan.UniversalityAux.Quantitative -q --log-level=info`
- `lake build TNLean.Wielandt.RectangularSpan.UniversalityAux.NilpIndex TNLean.Wielandt.RectangularSpan.UniversalityAux -q --log-level=info`
- Added-line scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` introduced.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
_No linked issue identified. Please link the relevant issue manually._

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or statement changes; behavior is unchanged if `wordSpan_zero` is already trusted elsewhere.
> 
> **Overview**
> Removes the private duplicate `wordSpan_zero_eq` proof in `UniversalityAux/Quantitative.lean` and wires **`rectSpan_zero_eq_span`** through the existing public **`wordSpan_zero`** from the span-growth layer (`simp only [rectSpan, wordSpan_zero]`).
> 
> **Theorem statements and downstream results are unchanged**—this is proof deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b1d29356046f844df0efe1ce9e89de1210b74ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>