### PR TITLE
refactor(Wielandt): inline dimension-one index helper

### DIFF
--- a/TNLean/Wielandt/Inequality/Bounds.lean
+++ b/TNLean/Wielandt/Inequality/Bounds.lean
@@ -348,26 +348,6 @@ directly. This transfers to `wordSpan A (D² · n) = ⊤`.
 
 Paper: arXiv:0909.5347, Theorem 1 case (1); Wolf, Theorem 6.9. -/
 
-/-- Auxiliary: for D = 1, `wordSpan A 0 = ⊤`. The span of `{1}` in the
-1×1 matrix algebra is the whole space. -/
-private theorem wordSpan_zero_eq_top_of_D_eq_one
-    (A : MPSTensor d 1) : wordSpan A 0 = ⊤ := by
-  rw [eq_top_iff]
-  -- Every 1×1 matrix is a scalar multiple of the identity
-  intro M _
-  have : M = M 0 0 • (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
-    ext i j; fin_cases i; fin_cases j; simp
-  rw [this]
-  have h1 : (1 : Matrix (Fin 1) (Fin 1) ℂ) ∈ wordSpan A 0 := by
-    have := evalWord_mem_wordSpan A ([] : List (Fin d))
-    simpa [evalWord] using this
-  exact Submodule.smul_mem _ _ h1
-
-/-- Auxiliary: for D = 1, `iIndex A = 0`. -/
-private theorem iIndex_eq_zero_of_D_eq_one
-    (A : MPSTensor d 1) : iIndex A = 0 :=
-  Nat.eq_zero_of_le_zero (Nat.sInf_le (wordSpan_zero_eq_top_of_D_eq_one A))
-
 /-- **Theorem 1, case (1)**: the general Wielandt bound
 `iIndex A ≤ (D² − krausRank A + 1) · D²`.
 
@@ -395,7 +375,20 @@ theorem iIndex_le_general_of_isPrimitivePaper [NeZero D]
   have hD_pos : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
   -- Case 1: D = 1 — trivial since iIndex = 0
   by_cases hD1 : D = 1
-  · subst hD1; simp [iIndex_eq_zero_of_D_eq_one]
+  · subst hD1
+    have htop : wordSpan A 0 = ⊤ := by
+      rw [wordSpan_zero, eq_top_iff]
+      intro M _
+      have hM : M = M 0 0 • (1 : Matrix (Fin 1) (Fin 1) ℂ) := by
+        ext i j
+        fin_cases i
+        fin_cases j
+        simp
+      rw [hM]
+      exact Submodule.smul_mem _ _ (Submodule.subset_span rfl)
+    have hiIndex : iIndex A = 0 :=
+      Nat.eq_zero_of_le_zero (Nat.sInf_le htop)
+    simp [hiIndex]
   · -- Case 2: D ≥ 2 — use positive-length trace word + blocking argument
     have hD2 : 2 ≤ D := by omega
     -- Get a **positive-length** sharp nonzero-trace word


### PR DESCRIPTION
### Motivation

- The two private helpers `wordSpan_zero_eq_top_of_D_eq_one` and `iIndex_eq_zero_of_D_eq_one` in `TNLean/Wielandt/Inequality/Bounds.lean` were single-use auxiliaries for the `D = 1` branch of `iIndex_le_general_of_isPrimitivePaper`; inlining them removes unnecessary indirection without changing any theorem statements.

### Description

- `TNLean/Wielandt/Inequality/Bounds.lean`: removes two private one-use lemmas (`wordSpan_zero_eq_top_of_D_eq_one` and `iIndex_eq_zero_of_D_eq_one`) and proves the `D = 1` branch of `iIndex_le_general_of_isPrimitivePaper` inline using the public `wordSpan_zero` lemma.
- No theorem statements or blueprint declarations are changed; no `sorry` introduced.

### Testing

- `lake build TNLean.Wielandt.Inequality.Bounds -q --log-level=info`
- `lake build TNLean.MPS.CanonicalForm.SectorComparison.NormalityChain -q --log-level=info`
- Added-line proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` introduced.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
No linked issue found — see PR comment.

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one file with no API or statement changes; behavior is unchanged if the build passes.
>
> **Overview**
> Removes two private one-off lemmas (`wordSpan_zero_eq_top_of_D_eq_one` and `iIndex_eq_zero_of_D_eq_one`) from `Bounds.lean`.
>
> The **`D = 1`** branch of **`iIndex_le_general_of_isPrimitivePaper`** is proved inline: it rewrites with the public **`wordSpan_zero`** lemma, shows every 1×1 matrix lies in that span, derives **`iIndex A = 0`**, and closes with **`simp`**. Theorem statements and downstream imports are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2a3090b1e324935c97bd5a6d7063254e1f4e41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- /CURSOR_SUMMARY -->