### PR TITLE
refactor(Wielandt/SpanGrowth): remove private span-growth lemmas

### DIFF
--- a/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean
@@ -507,18 +507,6 @@ theorem wordSpan_finrank_strict_mono_of_isUnit_of_isNormal
     exact hconst
   omega
 
-private theorem wordSpan_eq_top_of_finrank_eq_sq
-    (A : MPSTensor d D) (n : ℕ)
-    (hfin : Module.finrank ℂ (wordSpan A n) = D ^ 2) :
-    wordSpan A n = ⊤ := by
-  apply Submodule.eq_of_le_of_finrank_eq (le_top : wordSpan A n ≤ ⊤)
-  calc
-    Module.finrank ℂ (wordSpan A n) = D ^ 2 := hfin
-    _ = Module.finrank ℂ
-          (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) := by
-          symm
-          simp [Module.finrank_matrix, Fintype.card_fin, pow_two]
-
 private theorem wordSpan_finrank_lt_of_ne_top
     (A : MPSTensor d D) (n : ℕ) (hneq : wordSpan A n ≠ ⊤) :
     Module.finrank ℂ (wordSpan A n) < D ^ 2 := by
@@ -526,7 +514,9 @@ private theorem wordSpan_finrank_lt_of_ne_top
   by_contra h
   have hfin : Module.finrank ℂ (wordSpan A n) = D ^ 2 := by
     omega
-  exact hneq (wordSpan_eq_top_of_finrank_eq_sq A n hfin)
+  exact hneq (Submodule.eq_top_of_finrank_eq (by
+    rw [hfin]
+    simp [Module.finrank_matrix, Fintype.card_fin, pow_two]))
 
 /-- **Sharp invertible-case bound**: if some Kraus operator is invertible and
 `A` is normal, then the exact word span at level `D² - krausRank(A) + 1` is
@@ -588,7 +578,9 @@ theorem wordSpan_eq_top_of_isNormal_of_isUnit (A : MPSTensor d D)
     wordSpan_finrank_le A k
   have hfin : Module.finrank ℂ (wordSpan A k) = D ^ 2 := by
     omega
-  exact htop (wordSpan_eq_top_of_finrank_eq_sq A k hfin)
+  exact htop (Submodule.eq_top_of_finrank_eq (by
+    rw [hfin]
+    simp [Module.finrank_matrix, Fintype.card_fin, pow_two]))
 
 /-- The invertible-case sharp numerical bound on the full-Kraus-rank index.
 

--- a/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
+++ b/TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean
@@ -102,17 +102,6 @@ theorem wordSpan_mul_le (A : MPSTensor d D) (m n : ℕ) :
   -- Rewrite the product using `evalWord_append`.
   simpa [wordSpan, evalWord_append] using hmem
 
-/-- The product of two full matrix-algebra submodules is full. -/
-private theorem top_mul_top_eq_top :
-    (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) *
-      (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) = ⊤ := by
-  apply eq_top_iff.mpr
-  intro M _
-  simpa using
-    (Submodule.mul_mem_mul (show M ∈ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) from
-        Submodule.mem_top)
-      (show (1 : Matrix (Fin D) (Fin D) ℂ) ∈ ⊤ from Submodule.mem_top))
-
 /-- If `wordSpan A N = ⊤`, then `wordSpan A (k * N) = ⊤` for any `k ≥ 1`. -/
 theorem wordSpan_top_of_mul (A : MPSTensor d D) {N : ℕ}
     (htop : wordSpan A N = ⊤) :
@@ -129,7 +118,15 @@ theorem wordSpan_top_of_mul (A : MPSTensor d D) {N : ℕ}
           wordSpan_mul_le A (k * N) N
         have htoptop : wordSpan A (k * N) * wordSpan A N = ⊤ := by
           rw [hih, htop]
-          exact top_mul_top_eq_top
+          apply eq_top_iff.mpr
+          intro M _
+          simpa using
+            (Submodule.mul_mem_mul
+              (show M ∈ (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) from
+                Submodule.mem_top)
+              (show (1 : Matrix (Fin D) (Fin D) ℂ) ∈
+                  (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) from
+                Submodule.mem_top))
         have hle : (⊤ : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) ≤
             wordSpan A (k * N + N) := by
           rw [← htoptop]


### PR DESCRIPTION
### Motivation

- Two private lemmas in the Wielandt span-growth development (`wordSpan_eq_top_of_finrank_eq_sq` and `top_mul_top_eq_top`) duplicated Mathlib results without adding independent mathematical content.
- Removing them reduces indirection and calls `Submodule.eq_top_of_finrank_eq` and `Submodule.mul_mem_mul` directly, following the Mathlib 4.31 upgrade.

### Description

- `TNLean/Wielandt/SpanGrowth/InvertibleWordSpan.lean`: removes `wordSpan_eq_top_of_finrank_eq_sq`; proofs that finrank $D^2$ implies `wordSpan = ⊤` now use `Submodule.eq_top_of_finrank_eq` with the matrix finrank simp block inlined in `wordSpan_finrank_lt_of_ne_top` and `wordSpan_eq_top_of_isNormal_of_isUnit`.
- `TNLean/Wielandt/SpanGrowth/VectorToMatrixSpan.lean`: removes `top_mul_top_eq_top`; `wordSpan_top_of_mul` now inlines the `M = M * 1` step via `Submodule.mul_mem_mul` when showing $\top \cdot \top = \top$.
- No public theorem statements, blueprint declarations, or proof assumptions are changed.

### Testing

- `lake build TNLean.Wielandt.SpanGrowth.VectorToMatrixSpan -q --log-level=info`
- `lake build TNLean.Wielandt.SpanGrowth.InvertibleWordSpan -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
_No linked issue found — no open issue matches the changed files or the `codex/mathlib-4-31-native-pass-56` branch. Please link one manually if applicable._

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or statement changes; logic is preserved by standard Mathlib lemmas.
> 
> **Overview**
> Removes two private helper lemmas in the Wielandt span-growth development and calls Mathlib directly at the former use sites.
> 
> In **`InvertibleWordSpan`**, `wordSpan_eq_top_of_finrank_eq_sq` is deleted; proofs that finrank `D²` implies `wordSpan = ⊤` now use **`Submodule.eq_top_of_finrank_eq`** with the matrix finrank `simp` block inlined in `wordSpan_finrank_lt_of_ne_top` and `wordSpan_eq_top_of_isNormal_of_isUnit`.
> 
> In **`VectorToMatrixSpan`**, `top_mul_top_eq_top` is removed; **`wordSpan_top_of_mul`** inlines the `M = M * 1` argument via `Submodule.mul_mem_mul` when showing `⊤ * ⊤ = ⊤`.
> 
> No public theorem statements or blueprint declarations change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb83fbc75a715fd9d7cf45785d2aea1110ac7ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>