### PR TITLE
refactor(Spectral): use native Fin.cons reindexing

### DIFF
--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -101,15 +101,6 @@ over all words of length `N` of products of word evaluations.
 
 section IteratedTransfer
 
-/-- Reindex a sum over `Fin (n+1) → Fin d` as a double sum via `Fin.cons`. -/
-lemma sum_fin_succ_eq {n d : ℕ} {M : Type*} [AddCommMonoid M]
-    (f : (Fin (n + 1) → Fin d) → M) :
-    ∑ σ : Fin (n + 1) → Fin d, f σ =
-    ∑ i : Fin d, ∑ τ : Fin n → Fin d, f (Fin.cons i τ) := by
-  rw [← Fintype.sum_prod_type']
-  exact Fintype.sum_equiv (Fin.consEquiv (fun _ => Fin d)).symm _ _
-    (fun σ => by simp [Fin.consEquiv, Fin.cons_self_tail])
-
 /-- Iterating the mixed transfer operator `N` times gives:
 $$F_{AB}^N(X) = \sum_{\sigma : \mathrm{Fin}\,N \to \mathrm{Fin}\,d}
   \mathrm{evalWord}(A, \sigma) \cdot X \cdot \mathrm{evalWord}(B, \sigma)^\dagger$$ -/
@@ -125,7 +116,9 @@ theorem mixedTransferMap_pow_apply (A B : MPSTensor d D) (N : ℕ) :
     rw [pow_succ']
     change mixedTransferMap A B (((mixedTransferMap A B) ^ n) X) = _
     rw [ih]; simp only [mixedTransferMap_apply, map_sum]
-    rw [Finset.sum_comm, sum_fin_succ_eq]
+    rw [Finset.sum_comm]
+    rw [← (Fin.consEquiv (fun _ : Fin (n + 1) => Fin d)).sum_comp]
+    rw [Fintype.sum_prod_type]
     congr 1; funext i
     apply Finset.sum_congr rfl; intro τ _
     simp [Matrix.conjTranspose_mul, Matrix.mul_assoc]
@@ -197,7 +190,9 @@ theorem mixedTransferMap₂_pow_apply {d D₁ D₂ : ℕ}
       -- Push `mixedTransferMap₂` through the σ-sum, then expand the definition.
       simp only [map_sum, mixedTransferMap₂_apply]
       -- Reindex words of length `n+1` by head+tail.
-      rw [Finset.sum_comm, sum_fin_succ_eq]
+      rw [Finset.sum_comm]
+      rw [← (Fin.consEquiv (fun _ : Fin (n + 1) => Fin d)).sum_comp]
+      rw [Fintype.sum_prod_type]
       -- Now it suffices to show the summand matches the recursive word evaluation.
       congr 1
       funext i

--- a/TNLean/Spectral/TransferOperatorGap.lean
+++ b/TNLean/Spectral/TransferOperatorGap.lean
@@ -108,13 +108,23 @@ lemma word_conjTranspose_mul_sum (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
   induction n with
   | zero => simp [Finset.univ_unique]
   | succ n ih =>
-    rw [sum_fin_succ_eq]
-    simp_rw [List.ofFn_cons, evalWord, Matrix.conjTranspose_mul,
-      show ∀ A B C D : Matrix (Fin D) (Fin D) ℂ,
-        A * B * (C * D) = A * (B * C) * D from fun _ _ _ _ => by simp [Matrix.mul_assoc]]
+    rw [← (Fin.consEquiv (fun _ : Fin (n + 1) => Fin d)).sum_comp]
+    rw [Fintype.sum_prod_type]
     rw [Finset.sum_comm]
-    simp_rw [← Matrix.sum_mul, ← Matrix.mul_sum, hK, Matrix.mul_one]
-    exact ih
+    exact (Finset.sum_congr rfl (fun τ _ => by
+      have hsum :
+          (∑ a : Fin d, (K a)ᴴ * (K a * evalWord K (List.ofFn τ))) =
+            evalWord K (List.ofFn τ) := by
+        calc
+          (∑ a : Fin d, (K a)ᴴ * (K a * evalWord K (List.ofFn τ)))
+              = (∑ a : Fin d, (K a)ᴴ * K a) * evalWord K (List.ofFn τ) := by
+                simp_rw [← Matrix.mul_assoc]
+                rw [← Matrix.sum_mul]
+          _ = evalWord K (List.ofFn τ) := by
+                rw [hK, Matrix.one_mul]
+      simpa [Fin.consEquiv_apply, List.ofFn_cons, evalWord_cons,
+        Matrix.conjTranspose_mul, Matrix.mul_assoc, ← Matrix.mul_sum] using
+        congrArg (fun M => (evalWord K (List.ofFn τ))ᴴ * M) hsum)).trans ih
 
 /-- The standard transfer map preserves trace (for TP tensors). -/
 lemma trace_transferMap (A : MPSTensor d D) (Z : Matrix (Fin D) (Fin D) ℂ)

--- a/docs/audits/2026-02-19_proof_structure_audit_memo.md
+++ b/docs/audits/2026-02-19_proof_structure_audit_memo.md
@@ -208,7 +208,7 @@ mixedTransferMap₂_pow_apply :
 
 **Sorry**: None.
 
-**Key proof technique**: Induction on N; `sum_fin_succ_eq` for head+tail reindexing of
+**Key proof technique**: Induction on N; `Fin.consEquiv` for head+tail reindexing of
 word-length-N+1 paths; relies on `Mathlib.Data.Matrix.Bilinear` for rectangular matrix
 multiplication linear maps (`mulLeftLinearMap`, `mulRightLinearMap`).
 

--- a/docs/audits/block_separation_rect_mixed_transfer_plan.txt
+++ b/docs/audits/block_separation_rect_mixed_transfer_plan.txt
@@ -163,7 +163,7 @@ New theorem (analogue of `mixedTransferMap_pow_apply`):
             evalWord A (List.ofFn σ) * X * (evalWord B (List.ofFn σ))ᴴ.
 
 Proof skeleton: identical induction to the square proof; only requires matrix associativity and the
-reindexing lemma `sum_fin_succ_eq` (already in `Spectral/MixedTransfer.lean`, can be copied/reused).
+native `Fin.consEquiv` reindexing of word functions by their head and tail.
 
 ----------------------------------------
 D3. Operator-trace identity = mpvOverlap (rectangular)


### PR DESCRIPTION
### Motivation

- `TNLean/Spectral/MixedTransfer.lean` contained a local `sum_fin_succ_eq` helper for reindexing sums over `Fin (n+1)` by head–tail decomposition. Mathlib's `Fin.consEquiv.sum_comp` together with `Fintype.sum_prod_type` provide the same reindexing directly, making the local wrapper redundant.
- Removing the local declaration reduces maintenance burden and keeps the spectral module aligned with upstream Mathlib 4.31.

### Description

- Removes the local lemma `sum_fin_succ_eq` from `TNLean/Spectral/MixedTransfer.lean`.
- Updates three proof sites to use `Fin.consEquiv.sum_comp` and `Fintype.sum_prod_type` directly:
  - `mixedTransferMap_pow_apply` and `mixedTransferMap₂_pow_apply` in `MixedTransfer.lean` (succ-step reindexing in the inductive step).
  - `word_conjTranspose_mul_sum` in `TNLean/Spectral/TransferOperatorGap.lean` (inner sum calculation made more explicit in place of the previous `simp_rw` one-liner).
- Updates rectangular transfer audit notes (`docs/audits/2026-02-19_proof_structure_audit_memo.md`, `docs/audits/block_separation_rect_mixed_transfer_plan.txt`) to reference `Fin.consEquiv` instead of the removed helper.
- No theorem statements or blueprint declarations are changed.

### Testing

- `lake build TNLean.Spectral.MixedTransfer -q --log-level=info`
- `lake build TNLean.Spectral.TransferOperatorGap -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` (no new occurrences).
- `rg -n "sum_fin_succ_eq" TNLean docs blueprint -g '*'` returns no matches.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
No linked issue identified; the PR author should add `Addresses #N` once an issue is created or found.

> [!NOTE]
> **Low Risk**
> Proof-only refactor with equivalent reindexing; no API or statement changes, limited to spectral transfer lemmas and documentation.
> 
> **Overview**
> Removes the local **`sum_fin_succ_eq`** lemma from `MixedTransfer.lean` and rewrites the three induction proofs that depended on it to use Mathlib's **`Fin.consEquiv.sum_comp`** with **`Fintype.sum_prod_type`** for head+tail reindexing of `Fin (n+1) → Fin d` sums.
> 
> **`mixedTransferMap_pow_apply`** and **`mixedTransferMap₂_pow_apply`** keep the same statements; only the succ-step reindexing steps change. **`word_conjTranspose_mul_sum`** in `TransferOperatorGap.lean` is refactored the same way, with a more explicit inner sum calculation where the old one-liner used `simp_rw`.
> 
> Audit docs (`2026-02-19_proof_structure_audit_memo.md`, `block_separation_rect_mixed_transfer_plan.txt`) now describe **`Fin.consEquiv`** instead of the removed helper. No theorem statements or blueprint declarations change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e24b6927d0b9062c137eb51aec53bfd5c1fb085b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>