### PR TITLE
refactor(MPS): inline Euclidean coordinate expansion

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -225,16 +225,13 @@ private theorem replaceWindow_commute_of_cyclic_windows_disjoint {N L : ℕ}
     · simp [replaceWindow, hi, hj]
     · simp [replaceWindow, hi, hj]
 
-private theorem euclideanSpace_eq_sum_single {α : Type*} [Fintype α] [DecidableEq α]
-    (x : EuclideanSpace ℂ α) :
-    x = ∑ a : α, x a • EuclideanSpace.single a (1 : ℂ) := by
-  simpa using ((EuclideanSpace.basisFun α ℂ).sum_repr x).symm
-
 private theorem linearMap_apply_eq_sum {α : Type*} [Fintype α] [DecidableEq α]
     (P : EuclideanSpace ℂ α →ₗ[ℂ] EuclideanSpace ℂ α)
     (x : EuclideanSpace ℂ α) (a : α) :
     P x a = ∑ a' : α, x a' * P (EuclideanSpace.single a' (1 : ℂ)) a := by
-  conv_lhs => rw [euclideanSpace_eq_sum_single x]
+  conv_lhs =>
+    rw [show x = ∑ a' : α, x a' • EuclideanSpace.single a' (1 : ℂ) by
+      simpa using ((EuclideanSpace.basisFun α ℂ).sum_repr x).symm]
   simp [Finset.sum_apply]
 
 private theorem scalar_sum_comm {α β : Type*} [Fintype α] [Fintype β]


### PR DESCRIPTION
### Motivation

- The private lemma `euclideanSpace_eq_sum_single` in `TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean` duplicated the coordinate expansion already provided by `EuclideanSpace.basisFun`, adding unnecessary code to the file.
- Inlining the expansion directly inside `linearMap_apply_eq_sum` removes the redundant private lemma without changing any statement or the subsequent proof structure.

### Description

- `TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean`: removes the private lemma `euclideanSpace_eq_sum_single` (6 lines deleted) and replaces its single call site in the `conv_lhs` block of `linearMap_apply_eq_sum` with the equivalent `EuclideanSpace.basisFun` expansion directly (3 lines added).
- The statement of `linearMap_apply_eq_sum` and the downstream lemma `separateLinearMap_apply_commute` are unchanged.
- No linked issue has been identified for this change; the author should link one if applicable.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.Martingale.Transport -q --log-level=info`
- `rg -n "euclideanSpace_eq_sum_single" TNLean -g "*.lean"` (no matches — private lemma fully removed)
- Added-line blocker scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` (no matches)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a private lemma with no API or runtime impact; build validation was run per the PR description.
> 
> **Overview**
> Removes the private helper `euclideanSpace_eq_sum_single` from the martingale transport file and **inlines** the same `EuclideanSpace.basisFun` coordinate expansion inside `linearMap_apply_eq_sum`'s `conv_lhs` proof.
> 
> `linearMap_apply_eq_sum` is unchanged as a lemma and still feeds `separateLinearMap_apply_commute`; only the proof structure is slightly shorter with no behavioral change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b8eef7a1cfced87dfdbf97c945c1e5894db056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>