### PR TITLE
refactor(Algebra): inline diagonal shift helpers

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -62,26 +62,6 @@ theorem maxEigenvalue_achieved [Nonempty (Fin D)]
   obtain ⟨i, _, hi⟩ := Finset.mem_image.mp (Finset.max'_mem _ hne)
   exact ⟨i, hi⟩
 
-/-- Diagonal form of `diag(v) - c • 1`. -/
-theorem diagonal_sub_smul_one (v : Fin D → ℝ) (c : ℝ) :
-    Matrix.diagonal (fun j => (↑(v j) : ℂ)) -
-        (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) =
-      Matrix.diagonal (fun j => (↑(v j - c) : ℂ)) := by
-  rw [← Matrix.diagonal_one, ← Matrix.diagonal_smul, Matrix.diagonal_sub]
-  congr 1
-  ext i
-  simp [Pi.smul_apply, Complex.ofReal_sub]
-
-/-- Diagonal form of `c • 1 - diag(v)`. -/
-theorem diagonal_smul_one_sub (v : Fin D → ℝ) (c : ℝ) :
-    (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) -
-        Matrix.diagonal (fun j => (↑(v j) : ℂ)) =
-      Matrix.diagonal (fun j => (↑(c - v j) : ℂ)) := by
-  rw [← Matrix.diagonal_one, ← Matrix.diagonal_smul, Matrix.diagonal_sub]
-  congr 1
-  ext i
-  simp [Pi.smul_apply, Complex.ofReal_sub]
-
 /-- Spectral form of subtracting a scalar multiple of the identity from a Hermitian matrix. -/
 theorem hermitian_sub_scalar_spectral
     {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (c : ℝ) :
@@ -116,7 +96,10 @@ theorem hermitian_sub_scalar_spectral
     _ = U * Matrix.diagonal (fun j => (↑(hM.eigenvalues j - c) : ℂ)) * Uᴴ := by
           congr 1
           congr 1
-          exact diagonal_sub_smul_one hM.eigenvalues c
+          rw [Matrix.smul_one_eq_diagonal, Matrix.diagonal_sub]
+          congr 1
+          ext i
+          simp [Complex.ofReal_sub]
 
 /-- Spectral form of subtracting a Hermitian matrix from a scalar multiple of the identity. -/
 theorem smul_one_sub_hermitian_spectral
@@ -153,7 +136,10 @@ theorem smul_one_sub_hermitian_spectral
     _ = U * Matrix.diagonal (fun j => ↑(c - hM.eigenvalues j)) * Uᴴ := by
           congr 1
           congr 1
-          exact diagonal_smul_one_sub hM.eigenvalues c
+          rw [Matrix.smul_one_eq_diagonal, Matrix.diagonal_sub]
+          congr 1
+          ext i
+          simp [Complex.ofReal_sub]
 
 namespace HermitianHelpers
 


### PR DESCRIPTION
### Motivation

- The private helper lemmas `diagonal_sub_smul_one` and `diagonal_smul_one_sub` in `TNLean/Algebra/HermitianHelpers.lean` were introduced to simplify two diagonal-form steps in the Hermitian spectral-shift proofs, but Mathlib already provides `Matrix.smul_one_eq_diagonal` and `Matrix.diagonal_sub` for this purpose.
- Removing these wrappers reduces the file size and eliminates unnecessary indirection.

### Description

- Modified `TNLean/Algebra/HermitianHelpers.lean`: removed the private lemmas `diagonal_sub_smul_one` and `diagonal_smul_one_sub`.
- The public theorems `hermitian_sub_scalar_spectral` and `smul_one_sub_hermitian_spectral` are unchanged in statement; their diagonal simplification steps are now proved directly via Mathlib's `Matrix.smul_one_eq_diagonal` and `Matrix.diagonal_sub`.

### Testing

- `lake build TNLean.Algebra.HermitianHelpers -q --log-level=info`
- `rg -n "diagonal_sub_smul_one|diagonal_smul_one_sub" TNLean docs blueprint -g "*"` (no matches — removed names are not referenced elsewhere)
- No `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in added lines.
- Blueprint sync validation passed (`python3 scripts/blueprint_lean_sync.py --root . --ci`).

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single algebra helper file with no API or behavioral changes.
>
> **Overview**
> Removes the local lemmas `diagonal_sub_smul_one` and `diagonal_smul_one_sub` from `HermitianHelpers.lean` and proves the diagonal simplification steps inside `hermitian_sub_scalar_spectral` and `smul_one_sub_hermitian_spectral` directly via Mathlib's `Matrix.smul_one_eq_diagonal` and `Matrix.diagonal_sub`.
>
> The two public spectral-shift theorems are unchanged in statement; only the proof structure is simplified with a small net reduction in file size.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28e0dff7370342e94632d3936bcd2d2df0113dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>