### PR TITLE
refactor(MPS): use native block-diagonal unit map

### DIFF
--- a/TNLean/MPS/SharedInfra/BlockGauge.lean
+++ b/TNLean/MPS/SharedInfra/BlockGauge.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.SharedInfra.BlockAssembly
 
 import Mathlib.Algebra.BigOperators.Fin
+import Mathlib.Algebra.Group.Pi.Units
 
 /-!
 # Shared block-diagonal gauge infrastructure
@@ -44,20 +45,11 @@ section BlockDiagonalGL
 
 variable {r : ℕ} {dim : Fin r → ℕ}
 
-private theorem blockDiagonal'_mul_one
-    (f g : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
-    (hfg : ∀ k, f k * g k = 1) :
-    Matrix.blockDiagonal' f * Matrix.blockDiagonal' g = 1 := by
-  rw [← Matrix.blockDiagonal'_mul, show (fun k => f k * g k) = 1 from funext hfg,
-    Matrix.blockDiagonal'_one]
-
 /-- Form a block-diagonal element of `GL` from a family of invertible matrices. -/
 noncomputable def blockDiagonalGL (X : (k : Fin r) → GL (Fin (dim k)) ℂ) :
     GL ((k : Fin r) × Fin (dim k)) ℂ :=
-  ⟨Matrix.blockDiagonal' (fun k => (X k : Matrix _ _ ℂ)),
-   Matrix.blockDiagonal' (fun k => ((X k)⁻¹ : Matrix _ _ ℂ)),
-   blockDiagonal'_mul_one _ _ (fun k => by simp),
-   blockDiagonal'_mul_one _ _ (fun k => by simp)⟩
+  Units.map (Matrix.blockDiagonal'RingHom (fun k : Fin r => Fin (dim k)) ℂ).toMonoidHom
+    ((MulEquiv.piUnits).symm X)
 
 /-- Assemble per-block gauges into the flattened global `GL` element used by
 `toTensorFromBlocks`.  This is the reindexed block-diagonal matrix `⊕ₖ X k` on the
@@ -128,11 +120,25 @@ theorem toTensorFromBlocks_eq_globalGaugeOfBlocks_conj
   have hXfin :
       (globalGaugeOfBlocks X : Matrix (Fin (∑ k : Fin r, dim k))
         (Fin (∑ k : Fin r, dim k)) ℂ) = f XBD := by
-    simp [globalGaugeOfBlocks, XBD, blockDiagonalGL, f, e]
+    have hblock :
+        Matrix.blockDiagonal'
+            ((↑((MulEquiv.piUnits).symm X)) :
+              (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) = XBD := by
+      apply congrArg Matrix.blockDiagonal'
+      funext k
+      exact MulEquiv.val_piUnits_symm_apply X k
+    simpa [globalGaugeOfBlocks, XBD, blockDiagonalGL, f, e] using congrArg f hblock
   have hXfin_inv :
       (((globalGaugeOfBlocks X)⁻¹ : GL (Fin (∑ k : Fin r, dim k)) ℂ) :
         Matrix (Fin (∑ k : Fin r, dim k)) (Fin (∑ k : Fin r, dim k)) ℂ) = f XBDinv := by
-    simp [globalGaugeOfBlocks, XBDinv, blockDiagonalGL, f, e]
+    have hblock :
+        Matrix.blockDiagonal'
+            ((↑(((MulEquiv.piUnits).symm X)⁻¹)) :
+              (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ) = XBDinv := by
+      apply congrArg Matrix.blockDiagonal'
+      funext k
+      simp
+    simpa [globalGaugeOfBlocks, XBDinv, blockDiagonalGL, f, e] using congrArg f hblock
   rw [htoB, htoA, hBD]
   simp [map_mul, hXfin, hXfin_inv, Matrix.mul_assoc]
 


### PR DESCRIPTION
### Motivation

- The private helper `blockDiagonal'_mul_one` duplicated reasoning already available in Mathlib: the ring homomorphism `Matrix.blockDiagonal'RingHom` and the units-product equivalence `MulEquiv.piUnits` together produce a block-diagonal `GL` element without an explicit mul-one proof.
- Removing the helper reduces local proof code and makes the invertibility of block-diagonal matrices transparent via Mathlib's unit-lifting infrastructure.

### Description

- Modified `TNLean/MPS/SharedInfra/BlockGauge.lean`.
- Added import `Mathlib.Algebra.Group.Pi.Units`.
- Removed private lemma `blockDiagonal'_mul_one`, which established `Matrix.blockDiagonal' f * Matrix.blockDiagonal' g = 1` from pointwise inverses.
- Rewrote `blockDiagonalGL` to construct the `GL` element via `Units.map (Matrix.blockDiagonal'RingHom ...).toMonoidHom ((MulEquiv.piUnits).symm X)` in place of the explicit matrix/inverse pair construction.
- The statement of `toTensorFromBlocks_eq_globalGaugeOfBlocks_conj` is unchanged. The proofs of `hXfin` and `hXfin_inv` now establish equality with the explicit block family using `MulEquiv.val_piUnits_symm_apply` and `simpa`, replacing the earlier single `simp` call that relied on the old definition of `blockDiagonalGL`.

### Testing

- `lake build TNLean.MPS.SharedInfra.BlockGauge` passed.
- `rg -n "blockDiagonal'_mul_one" TNLean docs blueprint` returned no matches (helper fully removed).
- Added-line blocker scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` returned no matches.
- Reader-facing prose check (`scripts/check_reader_facing_prose.py`) passed.
- Blueprint–Lean sync check (`scripts/blueprint_lean_sync.py --ci`) passed.

---

> [!NOTE]
> **Low Risk**
> Localized proof refactor in shared MPS linear-algebra infrastructure; public definitions and theorem statements are preserved.
>
> **Overview**
> **`blockDiagonalGL`** is no longer built from explicit block-diagonal matrix/inverse pairs plus a private **`blockDiagonal'_mul_one`** lemma. It now uses **`Units.map`** on Mathlib's **`Matrix.blockDiagonal'RingHom`** applied to **`MulEquiv.piUnits`**, with a new import from **`Mathlib.Algebra.Group.Pi.Units`**.
>
> The conjugation theorem **`toTensorFromBlocks_eq_globalGaugeOfBlocks_conj`** is unchanged in statement; **`hXfin`** and **`hXfin_inv`** now prove equality with the explicit block family via **`MulEquiv.val_piUnits_symm_apply`** and **`simp`** instead of **`simp`** alone on the old definition.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59096ef2604ee8bfff1d92dc80202678deb9e574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>