### PR TITLE
refactor(Wielandt): inline mulLeft mulRight commutation

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Universality.lean
+++ b/TNLean/Wielandt/RectangularSpan/Universality.lean
@@ -498,20 +498,6 @@ theorem rectSpan_succ_eq_iSup_mulRight
 
 /-! ### Part 3: Permanence of finrank stabilization -/
 
-/-- Left-multiplication and right-multiplication commute on image submodules. -/
-private theorem map_mulRight_map_mulLeft_comm
-    (a b : Matrix (Fin D) (Fin D) ℂ)
-    (S : Submodule ℂ (Matrix (Fin D) (Fin D) ℂ)) :
-    Submodule.map (LinearMap.mulRight ℂ b)
-      (Submodule.map (LinearMap.mulLeft ℂ a) S) =
-    Submodule.map (LinearMap.mulLeft ℂ a)
-      (Submodule.map (LinearMap.mulRight ℂ b) S) := by
-  simp only [← Submodule.map_comp]
-  rw [show LinearMap.mulRight ℂ b ∘ₗ LinearMap.mulLeft ℂ a =
-      LinearMap.mulLeft ℂ a ∘ₗ LinearMap.mulRight ℂ b by
-    simpa [Module.End.mul_eq_comp] using
-      (LinearMap.commute_mulLeft_right (R := ℂ) a b).eq.symm]
-
 /-- **Structural permanence**: if `finrank(R_n) = finrank(R_{n+1})` then
 `R_{n+2} = (A i₀) · R_{n+1}`. -/
 theorem rectSpan_nilpIndex_succ2_eq_mulLeft_of_finrank_eq
@@ -531,7 +517,17 @@ theorem rectSpan_nilpIndex_succ2_eq_mulLeft_of_finrank_eq
   have hexp2 := rectSpan_succ_eq_iSup_mulRight P A (n + 1)
   have hexp1 := rectSpan_succ_eq_iSup_mulRight P A n
   rw [hstab] at hexp2
-  simp_rw [map_mulRight_map_mulLeft_comm (A i₀) _ (rectSpan P A n)] at hexp2
+  have hmap_comm (j : Fin d) :
+      Submodule.map (LinearMap.mulRight ℂ (A j))
+        (Submodule.map (LinearMap.mulLeft ℂ (A i₀)) (rectSpan P A n)) =
+      Submodule.map (LinearMap.mulLeft ℂ (A i₀))
+        (Submodule.map (LinearMap.mulRight ℂ (A j)) (rectSpan P A n)) := by
+    simp only [← Submodule.map_comp]
+    rw [show LinearMap.mulRight ℂ (A j) ∘ₗ LinearMap.mulLeft ℂ (A i₀) =
+        LinearMap.mulLeft ℂ (A i₀) ∘ₗ LinearMap.mulRight ℂ (A j) by
+      simpa [Module.End.mul_eq_comp] using
+        (LinearMap.commute_mulLeft_right (R := ℂ) (A i₀) (A j)).eq.symm]
+  simp_rw [hmap_comm] at hexp2
   rw [← Submodule.map_iSup, ← hexp1] at hexp2
   exact hexp2
 


### PR DESCRIPTION
### Motivation

- `map_mulRight_map_mulLeft_comm` is a private, single-use lemma in `TNLean/Wielandt/RectangularSpan/Universality.lean` that duplicates Mathlib's `LinearMap.commute_mulLeft_right`. Inlining it removes the duplication and makes the dependency on Mathlib's native result explicit at the use site.

### Description

- Removed `map_mulRight_map_mulLeft_comm` (private) from `TNLean/Wielandt/RectangularSpan/Universality.lean`.
- The proof of `rectSpan_nilpIndex_succ2_eq_mulLeft_of_finrank_eq` now establishes the commutation of `map (mulRight (A j))` and `map (mulLeft (A i₀))` on `rectSpan P A n` locally as `hmap_comm`, appealing to `Submodule.map_comp` and Mathlib's `LinearMap.commute_mulLeft_right` directly.
- No theorem statement or mathematical argument is changed.

### Testing

- `lake build TNLean.Wielandt.RectangularSpan.Universality -q --log-level=info`
- `rg -n "map_mulRight_map_mulLeft_comm" TNLean -g "*.lean"` returned no matches (complete removal confirmed).
- Blocker scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` on added lines returned no matches.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
_No linked issue found — the branch `codex/mathlib-4-31-native-pass-62` carries no issue number and the PR body contains no `Refs`/`Closes`/`Addresses` reference. Please link the relevant issue manually if one exists._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in Wielandt rectangular-span theory with no API or behavioral changes; risk is limited to Lean proof maintenance.
> 
> **Overview**
> Removes the private helper `map_mulRight_map_mulLeft_comm` from **RectangularSpan Universality** and applies the same commutation step inside `rectSpan_nilpIndex_succ2_eq_mulLeft_of_finrank_eq`.
> 
> The structural permanence proof (`R_{n+2} = (A i₀) · R_{n+1}` from finrank stabilization) still rewrites the right-expansion `hexp2` by swapping `map(mulRight (A j))` and `map(mulLeft (A i₀))` on `rectSpan P A n`. That rewrite is now a local `hmap_comm` per `j : Fin d`, proved with `Submodule.map_comp` and Mathlib's `LinearMap.commute_mulLeft_right` instead of a shared lemma.
> 
> **No change** to theorem statements or the finrank-permanence chain; this is proof cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d4f96bb9b45d6855d7b570052951c722c36e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>