### PR TITLE
refactor(Algebra): inline block projection entry lemmas

### DIFF
--- a/TNLean/Algebra/ScalarCommutant.lean
+++ b/TNLean/Algebra/ScalarCommutant.lean
@@ -95,48 +95,6 @@ section Semiring
 
 variable {R : Type*} [Semiring R]
 
-/-- Right multiplication by a block projection keeps the corresponding column block. -/
-@[simp] private theorem mul_blockProjection_apply_col
-    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
-    (X : Matrix ((i : ι) × n i) ((i : ι) × n i) R)
-    (j i : ι) (a : n i) (b : n j) :
-    (X * blockProjection (n := n) (R := R) j) ⟨i, a⟩ ⟨j, b⟩ = X ⟨i, a⟩ ⟨j, b⟩ := by
-  classical
-  rw [Matrix.mul_apply]
-  rw [Finset.sum_eq_single ⟨j, b⟩]
-  · simp [blockProjection]
-  · rintro ⟨k, c⟩ _ hkc
-    by_cases hkj : k = j
-    · subst k
-      have hcb : c ≠ b := by
-        intro hcb
-        apply hkc
-        subst hcb
-        rfl
-      simp [blockProjection, hcb]
-    · rw [show blockProjection (n := n) (R := R) j ⟨k, c⟩ ⟨j, b⟩ = 0 from by
-        exact Matrix.blockDiagonal'_apply_ne _ c b hkj]
-      simp
-  · intro hmem
-    simp at hmem
-
-/-- Left multiplication by a block projection kills rows in all other blocks. -/
-@[simp] private theorem blockProjection_mul_apply_of_ne
-    [Fintype ι] [(i : ι) → Fintype (n i)] [(i : ι) → DecidableEq (n i)]
-    (X : Matrix ((i : ι) × n i) ((i : ι) × n i) R)
-    {i j : ι} (hij : i ≠ j) (a : n i) (b : n j) :
-    (blockProjection (n := n) (R := R) j * X) ⟨i, a⟩ ⟨j, b⟩ = 0 := by
-  classical
-  rw [Matrix.mul_apply]
-  apply Finset.sum_eq_zero
-  rintro ⟨k, c⟩ _
-  by_cases hik : i = k
-  · subst k
-    simp [blockProjection, hij]
-  · rw [show blockProjection (n := n) (R := R) j ⟨i, a⟩ ⟨k, c⟩ = 0 from by
-      exact Matrix.blockDiagonal'_apply_ne _ a c hik]
-    simp
-
 /-- If a matrix commutes with every block projection, then it is block diagonal.
 
 This is the algebraic off-block-zero step needed in block-decomposition
@@ -152,7 +110,37 @@ theorem isBlockDiagonal'_of_commutes_blockProjection
   rw [isBlockDiagonal'_iff_offBlock_zero]
   intro i j hij a b
   have hentry := congrFun (congrFun (hComm j) ⟨i, a⟩) ⟨j, b⟩
-  simpa [hij] using hentry
+  have hleft :
+      (X * blockProjection (n := n) (R := R) j) ⟨i, a⟩ ⟨j, b⟩ =
+        X ⟨i, a⟩ ⟨j, b⟩ := by
+    rw [Matrix.mul_apply, Finset.sum_eq_single ⟨j, b⟩]
+    · simp [blockProjection]
+    · rintro ⟨k, c⟩ _ hkc
+      by_cases hkj : k = j
+      · subst k
+        have hcb : c ≠ b := by
+          intro hcb
+          apply hkc
+          subst hcb
+          rfl
+        simp [blockProjection, hcb]
+      · rw [show blockProjection (n := n) (R := R) j ⟨k, c⟩ ⟨j, b⟩ = 0 from by
+          exact Matrix.blockDiagonal'_apply_ne _ c b hkj]
+        simp
+    · intro hmem
+      simp at hmem
+  have hright :
+      (blockProjection (n := n) (R := R) j * X) ⟨i, a⟩ ⟨j, b⟩ = 0 := by
+    rw [Matrix.mul_apply]
+    apply Finset.sum_eq_zero
+    rintro ⟨k, c⟩ _
+    by_cases hik : i = k
+    · subst k
+      simp [blockProjection, hij]
+    · rw [show blockProjection (n := n) (R := R) j ⟨i, a⟩ ⟨k, c⟩ = 0 from by
+        exact Matrix.blockDiagonal'_apply_ne _ a c hik]
+      simp
+  simpa [hleft, hright] using hentry
 
 end Semiring
 


### PR DESCRIPTION
### Motivation

- Removes two private auxiliary lemmas (`mul_blockProjection_apply_col` and `blockProjection_mul_apply_of_ne`) from `TNLean.Algebra.ScalarCommutant`, each used only once, reducing the set of private declarations in the module.
- The theorem statement and mathematical content of `Matrix.isBlockDiagonal'_of_commutes_blockProjection` are unchanged; only its internal proof structure is reorganized.

### Description

- Modified `TNLean/Algebra/ScalarCommutant.lean`: removed private lemmas `mul_blockProjection_apply_col` and `blockProjection_mul_apply_of_ne`.
- Their matrix-entry computations are now local to the proof of `Matrix.isBlockDiagonal'_of_commutes_blockProjection`, using `Matrix.mul_apply` and Mathlib's `Matrix.blockDiagonal'_apply_eq` / `Matrix.blockDiagonal'_apply_ne` directly via simplification.
- No new declarations are introduced; the statement of `isBlockDiagonal'_of_commutes_blockProjection` is unchanged.

### Testing

- `lake build TNLean.Algebra.ScalarCommutant -q --log-level=info`
- `rg -n "mul_blockProjection_apply_col|blockProjection_mul_apply_of_ne" TNLean docs blueprint -g "*"` returned no matches, confirming removal of all call sites.
- Added-line blocker scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` returned no matches.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in algebra with no API or behavioral change beyond removing unused private declarations.
>
> **Overview**
> Removes the private helpers `mul_blockProjection_apply_col` and `blockProjection_mul_apply_of_ne` from `ScalarCommutant.lean` and folds their matrix-entry reasoning into `isBlockDiagonal'_of_commutes_blockProjection` as local `hleft` / `hright` goals before closing with `simpa [hleft, hright] using hentry`.
>
> The theorem statement and proof strategy are unchanged; only proof structure and API surface shrink (no new lemmas, same use of `Matrix.mul_apply` and `blockDiagonal'_apply_ne`).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72e297f12fc3e79fa991101be0543336172d0e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->