### PR TITLE
refactor(Algebra): inline projection invariance rearrangement

### DIFF
--- a/TNLean/Algebra/BurnsideMatrix.lean
+++ b/TNLean/Algebra/BurnsideMatrix.lean
@@ -195,18 +195,6 @@ lemma exists_cumulativeSpan_eq_top_of_algSpan_eq_top (A : MPSTensor d D)
 
 /-! ## Part 2: Invariant submodule characterization -/
 
-
-/-- If `(1 - P) * M * P = 0`, then `M * P = P * (M * P)`. -/
-private theorem mul_proj_eq {P M : Matrix (Fin D) (Fin D) ℂ}
-    (hinv : (1 - P) * M * P = 0) :
-    M * P = P * (M * P) := by
-  -- (1 - P) * M * P = ((1 - P) * M) * P = (M - P * M) * P
-  --   = M * P - P * M * P = M * P - P * (M * P)
-  have h1 : (M - P * M) * P = 0 := by rwa [sub_mul, one_mul] at hinv
-  have h2 : M * P - P * M * P = 0 := by rwa [sub_mul] at h1
-  have h3 : M * P - P * (M * P) = 0 := by rwa [mul_assoc] at h2
-  exact sub_eq_zero.mp h3
-
 /-- `IsIrreducibleAction` implies `IsIrreducibleTensor`.
 
 If there are no nontrivial invariant submodules, then there are no
@@ -221,7 +209,15 @@ lemma isIrreducibleTensor_of_isIrreducibleAction
   set W : Submodule ℂ V := LinearMap.range f
   have hW_inv : IsInvariantSubmodule A W := by
     intro i v ⟨u, hu⟩
-    have hAP : A i * P = P * (A i * P) := mul_proj_eq (hinv i)
+    have hAP : A i * P = P * (A i * P) := by
+      have hinvi : (1 - P) * A i * P = 0 := hinv i
+      have h1 : (A i - P * A i) * P = 0 := by
+        rwa [sub_mul, one_mul] at hinvi
+      have h2 : A i * P - P * A i * P = 0 := by
+        rwa [sub_mul] at h1
+      have h3 : A i * P - P * (A i * P) = 0 := by
+        rwa [mul_assoc] at h2
+      exact sub_eq_zero.mp h3
     refine ⟨(A i * P).mulVec u, ?_⟩
     simp only [V, f, Matrix.toLin'_apply] at hu ⊢
     rw [Matrix.mulVec_mulVec, ← hAP, ← Matrix.mulVec_mulVec, hu]


### PR DESCRIPTION
### Motivation

- The private lemma `mul_proj_eq` in `TNLean.Algebra.BurnsideMatrix` was used exactly once as a pass-through around two standard ring rewrites (`sub_mul`, `mul_assoc`), adding a named layer with no independent mathematical content.
- Inlining the step eliminates the one-use helper and reduces indirection at the invariant-submodule construction inside `isIrreducibleTensor_of_isIrreducibleAction`.

### Description

- Modified `TNLean/Algebra/BurnsideMatrix.lean`: removed the private lemma `mul_proj_eq` (which derived `A i * P = P * (A i * P)` from `(1 - P) * A i * P = 0`) and proved the same algebraic step directly at the point of use with the same `sub_mul` / `mul_assoc` rewrites.
- The statement and proof structure of `isIrreducibleTensor_of_isIrreducibleAction` are unchanged; only the proof organisation is simplified (9 additions, 13 deletions).
- No new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced.

### Testing

- `lake build TNLean.Algebra.BurnsideMatrix -q --log-level=info`
- Added-line blocker scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` passed.

---
<!-- No issue linked — please add "Addresses #N" here. Closest candidates: #1026 (helper language cleanup in BurnsideMatrix), #326 (BurnsideMatrix audit). -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma; no API or mathematical content changes.
> 
> **Overview**
> Removes the single-use private lemma `mul_proj_eq` from `BurnsideMatrix.lean` and proves the same matrix identity **inline** inside `isIrreducibleTensor_of_isIrreducibleAction` when showing the range of an invariant orthogonal projection is an invariant submodule.
> 
> The step `(1 - P) * A i * P = 0 ⇒ A i * P = P * (A i * P)` is unchanged mathematically; only the proof is localized with the same `sub_mul` / `mul_assoc` rewrites instead of going through a helper theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e16414e0a56f5e322f72721d4e58305631e2b09f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>