### PR TITLE
refactor(Schwarz): remove normality commutation wrappers

### DIFF
--- a/TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean
+++ b/TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean
@@ -34,29 +34,6 @@ namespace PositiveOnAbelian
 
 variable {D : ℕ}
 
-section NormalGenerators
-
-variable {A : Matrix (Fin D) (Fin D) ℂ}
-
-/-- A normal matrix commutes with its adjoint. -/
-private lemma commute_conjTranspose_of_normal
-    (hA : Aᴴ * A = A * Aᴴ) : Commute A Aᴴ := by
-  exact (commute_iff_eq A Aᴴ).mpr hA.symm
-
-/-- For a normal matrix `A`, the generator `A` commutes with `Aᴴ * A`. -/
-private lemma commute_conjTranspose_mul_self_of_normal
-    (hA : Aᴴ * A = A * Aᴴ) : Commute A (Aᴴ * A) :=
-  (commute_conjTranspose_of_normal (A := A) hA).mul_right (Commute.refl A)
-
-/-- For a normal matrix `A`, the generator `Aᴴ` commutes with `Aᴴ * A`. -/
-private lemma conjTranspose_commute_conjTranspose_mul_self_of_normal
-    (hA : Aᴴ * A = A * Aᴴ) : Commute Aᴴ (Aᴴ * A) :=
-  (Commute.refl Aᴴ).mul_right
-    (Commute.symm (commute_conjTranspose_of_normal (A := A) hA))
-
-
-end NormalGenerators
-
 section NormalDiagonalization
 
 local notation "E" => EuclideanSpace ℂ (Fin D)
@@ -89,7 +66,7 @@ private lemma linearMap_eq_sum_rankOne_of_orthonormalBasis
 private lemma commute_parts_of_normal
     (A : Mat) (hA : Aᴴ * A = A * Aᴴ) :
     Commute ((1 / 2 : ℂ) • (A + Aᴴ)) ((Complex.I / 2 : ℂ) • (Aᴴ - A)) := by
-  have hAA : Commute A Aᴴ := commute_conjTranspose_of_normal (A := A) hA
+  have hAA : Commute A Aᴴ := (commute_iff_eq A Aᴴ).mpr hA.symm
   -- Commute (A + Aᴴ) with (Aᴴ - A) by combining the individual commutators.
   have hsum_sub : Commute (A + Aᴴ) (Aᴴ - A) :=
     (hAA.add_left (Commute.refl Aᴴ)).sub_right ((Commute.refl A).add_left hAA.symm)


### PR DESCRIPTION
### Motivation

- Three private lemmas in `TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean` converted the commutativity identity $A^* A = A A^*$ into `Commute` facts; two had no call sites and the third was used at exactly one point.
- Removing these lemmas and the surrounding `NormalGenerators` section reduces the file by 23 lines with no change to any mathematical statement or public declaration.

### Description

- Modified `TNLean/Channel/Schwarz/PositiveOnAbelian/Consequences.lean`: removed the private `NormalGenerators` section and its three lemmas.
- The proof of `commute_parts_of_normal` now uses Mathlib's `commute_iff_eq` directly (via `hA.symm`) in place of the deleted lemmas; the simultaneous-diagonalization argument is otherwise unchanged.
- No public API or mathematical statement is affected.

### Testing

- `lake build TNLean.Channel.Schwarz.PositiveOnAbelian.Consequences -q --log-level=info`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` on added lines: none found.

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof refactor only; no API or mathematical statement changes beyond removing dead code.
> 
> **Overview**
> Removes the **`NormalGenerators`** section and three private lemmas that only wrapped `Aᴴ * A = A * Aᴴ` into `Commute` facts; two had no call sites.
> 
> **`commute_parts_of_normal`** now obtains `Commute A Aᴴ` via Mathlib's **`commute_iff_eq`** directly (`hA.symm`), with the rest of the simultaneous-diagonalization proof unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7714d504a4700298a45e2f74e87cd364c8ed02db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->