### PR TITLE
refactor(Irreducible): use Mathlib kernel criteria

### DIFF
--- a/TNLean/Channel/Irreducible/Growth/KernelDescent.lean
+++ b/TNLean/Channel/Irreducible/Growth/KernelDescent.lean
@@ -90,33 +90,6 @@ end KernelDecrease
 
 section Growth
 
-/-- PSD with trivial kernel implies PosDef. -/
-private lemma posDef_of_psd_ker_bot
-    {B : Matrix (Fin D) (Fin D) ℂ} (hB : B.PosSemidef)
-    (hker : B.mulVecLin.ker = ⊥) : B.PosDef := by
-  rw [Matrix.posDef_iff_dotProduct_mulVec]
-  refine ⟨hB.isHermitian, fun v hv => ?_⟩
-  have h_nonneg := hB.dotProduct_mulVec_nonneg v
-  suffices star v ⬝ᵥ (B *ᵥ v) ≠ 0 from lt_of_le_of_ne h_nonneg (Ne.symm this)
-  intro h0
-  have hBv : B *ᵥ v = 0 := (hB.dotProduct_mulVec_zero_iff v).mp h0
-  have hmem : v ∈ B.mulVecLin.ker := by rw [LinearMap.mem_ker]; exact hBv
-  rw [hker] at hmem
-  exact hv ((Submodule.mem_bot ℂ).mp hmem)
-
-/-- PosDef implies kernel is trivial. -/
-private lemma ker_bot_of_posDef
-    {B : Matrix (Fin D) (Fin D) ℂ} (hB : B.PosDef) : B.mulVecLin.ker = ⊥ := by
-  rw [Submodule.eq_bot_iff]
-  intro v hv
-  rw [LinearMap.mem_ker] at hv
-  change B *ᵥ v = 0 at hv
-  by_contra hne
-  obtain ⟨_, hpd⟩ := Matrix.posDef_iff_dotProduct_mulVec.mp hB
-  have h_pos : (0 : ℂ) < star v ⬝ᵥ (B *ᵥ v) := hpd hne
-  have h_zero : star v ⬝ᵥ (B *ᵥ v) = 0 := by simp [hv]
-  linarith
-
 /-- **Wolf Theorem 6.2, item 2 (Growth condition for irreducible CP maps)**:
 If `E` is an irreducible completely positive map on `M_D(ℂ)` and `A ≥ 0` is
 nonzero, then `(id + E)^{D-1}(A)` is positive definite.
@@ -171,7 +144,16 @@ theorem growth_posDef_of_irreducible_cp
   | zero =>
     intro B hB _ hkd
     have hk0 : Module.finrank ℂ (LinearMap.ker B.mulVecLin) = 0 := Nat.le_zero.mp hkd
-    simpa [pow_zero] using posDef_of_psd_ker_bot hB (Submodule.finrank_eq_zero.mp hk0)
+    have hker : B.mulVecLin.ker = ⊥ := Submodule.finrank_eq_zero.mp hk0
+    have hdet : B.det ≠ 0 := by
+      intro hdet
+      obtain ⟨v, hvne, hv⟩ := Matrix.exists_mulVec_eq_zero_iff.mpr hdet
+      have hvker : v ∈ B.mulVecLin.ker := by
+        rw [LinearMap.mem_ker]
+        exact hv
+      rw [hker] at hvker
+      exact hvne ((Submodule.mem_bot ℂ).mp hvker)
+    simpa [pow_zero] using hB.posDef_iff_det_ne_zero.mpr hdet
   | succ n ih =>
     intro B hB hBne hkd
     rw [pow_succ, Module.End.mul_apply]
@@ -179,7 +161,10 @@ theorem growth_posDef_of_irreducible_cp
     · apply ih (T B) (hT_psd hB) (hT_ne hB hBne)
       have hTBpd : (T B).PosDef := by
         simpa [hT_eq B] using idPlusE_posDef hPos hBpd
-      rw [ker_bot_of_posDef hTBpd]
+      rw [(Matrix.ker_mulVecLin_eq_bot_iff).mpr fun v hv => by
+        by_contra hne
+        have h_pos := hTBpd.dotProduct_mulVec_pos hne
+        simp [hv] at h_pos]
       simp
     · apply ih (T B) (hT_psd hB) (hT_ne hB hBne)
       have h_lt : (B + E B).mulVecLin.ker < B.mulVecLin.ker :=


### PR DESCRIPTION
### Motivation
- Private bridge lemmas `posDef_of_psd_ker_bot` and `ker_bot_of_posDef` in `KernelDescent.lean` duplicate results now available in Mathlib 4.31 (`Matrix.PosSemidef.posDef_iff_det_ne_zero`, `Matrix.exists_mulVec_eq_zero_iff`, `Matrix.ker_mulVecLin_eq_bot_iff`).
- Removing local duplicates reduces proof debt and aligns with the project's policy of using upstream Mathlib lemmas over local reproof.

### Description
- Modifies `TNLean/Channel/Irreducible/Growth/KernelDescent.lean`.
- Removes private lemmas `posDef_of_psd_ker_bot` and `ker_bot_of_posDef`.
- Rewires `growth_posDef_of_irreducible_cp` to use Mathlib 4.31 criteria directly:
  - Base case: positive definiteness goes through `Matrix.PosSemidef.posDef_iff_det_ne_zero` with `Matrix.exists_mulVec_eq_zero_iff`.
  - Inductive step (PosDef branch): kernel triviality uses `Matrix.ker_mulVecLin_eq_bot_iff` and `dotProduct_mulVec_pos`.
- The Wolf growth theorem statement and overall kernel-dimension induction are unchanged.

### Testing
- `lake build TNLean.Channel.Irreducible.Growth.KernelDescent -q --log-level=info` succeeded (2963/2963 files replayed).
- `rg -n "sorry|axiom" TNLean/Channel/Irreducible/Growth/KernelDescent.lean || true` — no matches.
- Lean CI (`lean_action_ci.yml`) validates the full build on merge.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one file; no API or runtime behavior changes, only Mathlib lemma substitution in an existing induction.
>
> **Overview**
> Removes the local PSD/kernel bridge lemmas `posDef_of_psd_ker_bot` and `ker_bot_of_posDef` from `KernelDescent.lean` and wires **`growth_posDef_of_irreducible_cp`** to Mathlib 4.31 matrix criteria instead.
>
> In the **base case** (`n = 0`), trivial kernel is still derived from `finrank = 0`, but positive definiteness now goes through **`det ≠ 0`** (`posDef_iff_det_ne_zero`) with a short argument from `exists_mulVec_eq_zero_iff`. In the **PosDef branch** of the inductive step, showing `ker (T B) = ⊥` uses **`ker_mulVecLin_eq_bot_iff`** and `dotProduct_mulVec_pos` rather than the deleted `ker_bot_of_posDef` lemma.
>
> The Wolf growth theorem statement and overall kernel-dimension induction are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3398231b399009fb9b94bbe4af98f8ab21bc1d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>