### PR TITLE
refactor(Channel/FixedPoint): use Mathlib corner membership directly

### DIFF
--- a/TNLean/Channel/FixedPoint/CornerAlgebra.lean
+++ b/TNLean/Channel/FixedPoint/CornerAlgebra.lean
@@ -32,17 +32,12 @@ namespace MatrixCorner
 
 variable {D : ℕ} {P : Matrix (Fin D) (Fin D) ℂ}
 
-private lemma mem_corner_iff_matrix (hP : IsIdempotentElem P)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    X ∈ Subsemigroup.corner P ↔ P * X = X ∧ X * P = X :=
-  Subsemigroup.mem_corner_iff hP
-
 /-! ### `ℂ`-linear structure -/
 
 instance instSMulComplexCorner (hP : IsIdempotentElem P) : SMul ℂ hP.Corner where
   smul c X := ⟨c • X.1, by
-    obtain ⟨hL, hR⟩ := (mem_corner_iff_matrix hP X.1).mp X.2
-    refine (mem_corner_iff_matrix hP _).mpr ⟨?_, ?_⟩
+    obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hP).mp X.2
+    refine (Subsemigroup.mem_corner_iff hP).mpr ⟨?_, ?_⟩
     · rw [Matrix.mul_smul, hL]
     · rw [smul_mul_assoc, hR]⟩
 
@@ -65,7 +60,7 @@ instance instModuleComplexCorner (hP : IsIdempotentElem P) : Module ℂ hP.Corne
 /-- The algebra map `ℂ → hP.Corner` sending `c` to `c • P`. -/
 noncomputable def cornerAlgebraMap (hP : IsIdempotentElem P) : ℂ →+* hP.Corner where
   toFun c := ⟨c • P, by
-    refine (mem_corner_iff_matrix hP _).mpr ⟨?_, ?_⟩
+    refine (Subsemigroup.mem_corner_iff hP).mpr ⟨?_, ?_⟩
     · rw [Matrix.mul_smul, hP.eq]
     · rw [smul_mul_assoc, hP.eq]⟩
   map_one' := Subtype.ext (one_smul ℂ P)
@@ -83,12 +78,12 @@ noncomputable instance instAlgebraComplexCorner (hP : IsIdempotentElem P) :
   algebraMap := cornerAlgebraMap hP
   commutes' c X := by
     apply Subtype.ext
-    obtain ⟨hL, hR⟩ := (mem_corner_iff_matrix hP X.1).mp X.2
+    obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hP).mp X.2
     change (c • P) * X.1 = X.1 * (c • P)
     rw [smul_mul_assoc, Matrix.mul_smul, hL, hR]
   smul_def' c X := by
     apply Subtype.ext
-    obtain ⟨hL, _⟩ := (mem_corner_iff_matrix hP X.1).mp X.2
+    obtain ⟨hL, _⟩ := (Subsemigroup.mem_corner_iff hP).mp X.2
     change c • X.1 = (c • P) * X.1
     rw [smul_mul_assoc, hL]
 
@@ -107,8 +102,8 @@ variable (hP : IsIdempotentElem P) (hPstar : Pᴴ = P)
 /-- Star on `hP.Corner` given self-adjointness of `P`. -/
 @[reducible] noncomputable def cornerStar : Star hP.Corner where
   star X := ⟨X.1ᴴ, by
-    obtain ⟨hL, hR⟩ := (mem_corner_iff_matrix hP X.1).mp X.2
-    refine (mem_corner_iff_matrix hP _).mpr ⟨?_, ?_⟩
+    obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hP).mp X.2
+    refine (Subsemigroup.mem_corner_iff hP).mpr ⟨?_, ?_⟩
     · calc P * X.1ᴴ = Pᴴ * X.1ᴴ := by rw [hPstar]
         _ = (X.1 * P)ᴴ := by rw [← Matrix.conjTranspose_mul]
         _ = X.1ᴴ := by rw [hR]
@@ -173,7 +168,7 @@ lemma cornerSubmodule_mem_iff_mem_corner
     have h' : P * X * P = X := h
     exact ⟨X, by simp [h']⟩
   · intro h
-    obtain ⟨hL, hR⟩ := (mem_corner_iff_matrix hP X).mp h
+    obtain ⟨hL, hR⟩ := (Subsemigroup.mem_corner_iff hP).mp h
     change P * X * P = X
     rw [Matrix.mul_assoc, hR, hL]
 


### PR DESCRIPTION
### Motivation

- `CornerAlgebra.lean` contained a private auxiliary lemma `mem_corner_iff_matrix`
  that reproduced the corner-membership characterization already provided by
  Mathlib's `Subsemigroup.mem_corner_iff`. Removing it in favour of the Mathlib
  lemma eliminates redundant code without altering any mathematical statement.
- Part of the Mathlib 4.31 native-replacement pass across the Channel/FixedPoint
  layer.

### Description

- Modified `TNLean/Channel/FixedPoint/CornerAlgebra.lean`: removed the private
  lemma `mem_corner_iff_matrix` and replaced every call site with Mathlib's
  `Subsemigroup.mem_corner_iff` (Mathlib 4.31).
- The complex-algebra structure, star identification, and `cornerSubmodule` ↔ corner
  identifications are unchanged in statement and proof; only the membership
  characterisation is inlined.
- No new `sorry`, `axiom`, or `native_decide` introduced.

### Testing

- `lake build TNLean.Channel.FixedPoint.CornerAlgebra -q --log-level=info`
- `git diff -U0 -- TNLean docs blueprint | rg '^\+.*\b(sorry|axiom|admit|native_decide|unsafeCast)\b'` (no matches)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no new logic; corner algebra behavior and API stay the same.
>
> **Overview**
> **Removes** the private lemma `mem_corner_iff_matrix` and **replaces** every use with Mathlib's `Subsemigroup.mem_corner_iff` (Mathlib 4.31).
>
> Proof obligations in the `ℂ`-module/algebra, star, and `cornerSubmodule` ↔ corner identifications are unchanged; only the membership characterization is inlined.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42fbdd2d9a97fb007297f413cb132e330d1ac46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>