### PR TITLE
refactor(Wielandt): use Mathlib projection range API

### DIFF
--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean
@@ -469,36 +469,6 @@ private lemma evalWord_mulVec_mem_range_of_proj {P : Matrix (Fin D) (Fin D) ℂ}
   rw [Matrix.mul_assoc] at h
   exact h.symm
 
-/-- If an idempotent square matrix `P` over `ℂ` has range = ⊤ (as mulVecLin), then `P = 1`. -/
-private lemma eq_one_of_idempotent_range_eq_top
-    {P : Matrix (Fin D) (Fin D) ℂ}
-    (hP_idem : P * P = P)
-    (hP_range : LinearMap.range (Matrix.mulVecLin P) = ⊤) :
-    P = 1 := by
-  -- From surjectivity + idempotence: P *ᵥ v = v for all v
-  have hP_surj := (LinearMap.range_eq_top (f := Matrix.mulVecLin P)).mp hP_range
-  have h_fix : ∀ v : Fin D → ℂ, P *ᵥ v = v := by
-    intro v
-    obtain ⟨w, hw⟩ := hP_surj v
-    rw [Matrix.mulVecLin_apply] at hw
-    calc P *ᵥ v = P *ᵥ (P *ᵥ w) := by rw [hw]
-      _ = (P * P) *ᵥ w := by rw [Matrix.mulVec_mulVec]
-      _ = P *ᵥ w := by rw [hP_idem]
-      _ = v := hw
-  -- From P *ᵥ v = v for all v, we get P = 1
-  -- Use P * M = M for all M, then take M = 1
-  have h_mul_eq : ∀ (M : Matrix (Fin D) (Fin D) ℂ), P * M = M := by
-    intro M
-    ext i j
-    -- (P * M) i j = ∑ k, P i k * M k j
-    -- M i j = (h_fix (M · j)) says P *ᵥ (M · j) = M · j
-    have := congr_fun (h_fix (fun k => M k j)) i
-    simp only [Matrix.mulVec, dotProduct] at this
-    simp only [Matrix.mul_apply]
-    exact this
-  have := h_mul_eq 1
-  rwa [mul_one] at this
-
 /-- A nontrivial invariant projection witnesses failure of paper-primitivity. -/
 private lemma vectorSpreadSpan_ne_top_of_hasInvariantProj
     (A : MPSTensor d D)
@@ -525,16 +495,31 @@ private lemma vectorSpreadSpan_ne_top_of_hasInvariantProj
   refine ⟨φ, hφ_ne, ?_⟩
   -- Show vectorSpreadSpan A φ q ≤ range(P·) < ⊤
   intro h_eq_top
+  have hP_range : LinearMap.range (Matrix.mulVecLin P) = ⊤ := by
+    apply le_antisymm le_top
+    -- ⊤ ≤ range(P·), using vectorSpreadSpan ⊆ range(P·) and vectorSpreadSpan = ⊤
+    rw [← h_eq_top, vectorSpreadSpan, Submodule.span_le]
+    intro v hv
+    obtain ⟨σ, rfl⟩ := hv
+    exact evalWord_mulVec_mem_range_of_proj hP_idem A hinv φ hφ_range (List.ofFn σ)
+  have hP_proj :
+      LinearMap.IsProj (LinearMap.range (Matrix.mulVecLin P)) (Matrix.mulVecLin P) := by
+    refine ⟨LinearMap.mem_range_self _, ?_⟩
+    intro v hv
+    obtain ⟨w, hw⟩ := LinearMap.mem_range.mp hv
+    rw [← hw]
+    change P *ᵥ (P *ᵥ w) = P *ᵥ w
+    rw [Matrix.mulVec_mulVec, hP_idem]
   apply hP_ne1
-  -- From h_eq_top: range(P·) = ⊤, so P is surjective, so P = 1
-  apply eq_one_of_idempotent_range_eq_top hP_idem
-  -- Show range(P *ᵥ ·) = ⊤
-  apply le_antisymm (le_top)
-  -- ⊤ ≤ range(P·), using vectorSpreadSpan ⊆ range(P·) and vectorSpreadSpan = ⊤
-  rw [← h_eq_top, vectorSpreadSpan, Submodule.span_le]
-  intro v hv
-  obtain ⟨σ, rfl⟩ := hv
-  exact evalWord_mulVec_mem_range_of_proj hP_idem A hinv φ hφ_range (List.ofFn σ)
+  ext i j
+  have hj :
+      Pi.single j (1 : ℂ) ∈ LinearMap.range (Matrix.mulVecLin P) := by
+    rw [hP_range]
+    exact Submodule.mem_top
+  have hfix := (LinearMap.IsProj.mem_iff_map_id hP_proj).mp hj
+  have := congr_fun hfix i
+  simpa [Matrix.mulVec, dotProduct, Pi.single_apply, Finset.sum_ite_eq',
+    Finset.mem_univ, Matrix.one_apply] using this
 
 /-- **Paper-primitivity implies irreducibility of the tensor.**
 


### PR DESCRIPTION
### Motivation

- `TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean` contained a one-use private helper `eq_one_of_idempotent_range_eq_top` that reproduced reasoning already present in Mathlib 4.31 as `LinearMap.IsProj.mem_iff_map_id`.
- Removing the private lemma reduces proof duplication and uses the upstream Mathlib API directly.

### Description

- Removes the private helper `eq_one_of_idempotent_range_eq_top` from `TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducible.lean`.
- Replaces it with a direct call to `LinearMap.IsProj.mem_iff_map_id` in the proof of `vectorSpreadSpan_ne_top_of_hasInvariantProj`: when `vectorSpreadSpan A φ q = ⊤`, the proof derives `range (mulVecLin P) = ⊤`, packages `mulVecLin P` as a `LinearMap.IsProj` on that range, and applies `mem_iff_map_id` on standard basis vectors to conclude `P = 1`, contradicting `P ≠ 1`.
- The paper-primitivity to strong-irreducibility direction (`IsPrimitivePaper A → IsStronglyIrreduciblePaper A`, Prop. 3 of arXiv:0909.5347 / Wolf §6.4) is mathematically unchanged.

### Testing

- `lake build TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducible -q --log-level=info`
- `git diff -U0 -- TNLean docs blueprint | rg '^\+.*\b(sorry|axiom|admit|native_decide|unsafeCast)\b'` (no matches)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
<!-- No linked issue identified; please link one manually if one exists. -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single Lean file; no API or runtime behavior changes, only a shorter Mathlib-based argument.
>
> **Overview**
> Removes the private helper **`eq_one_of_idempotent_range_eq_top`** and finishes the "nontrivial invariant projection ⇒ not full spread" step in **`vectorSpreadSpan_ne_top_of_hasInvariantProj`** with Mathlib's **`LinearMap.IsProj`** API instead.
>
> When **`vectorSpreadSpan A φ q = ⊤`**, the proof still derives **`range (mulVecLin P) = ⊤`**, then packages **`mulVecLin P`** as a projection on that range and uses **`LinearMap.IsProj.mem_iff_map_id`** on standard basis vectors to conclude **`P = 1`**, contradicting **`P ≠ 1`**. The paper-primitivity ⇒ irreducibility theorem and its overall argument are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc9a6b5072f587d5f31ab2c8dcf43c78563149bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>