### PR TITLE
refactor(Channel/Irreducible): inline density nonzero witnesses

### DIFF
--- a/TNLean/Channel/Irreducible/Ergodicity.lean
+++ b/TNLean/Channel/Irreducible/Ergodicity.lean
@@ -42,15 +42,6 @@ section Ergodicity
 
 variable (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
 
-/-- A density matrix is nonzero. -/
-private lemma ne_zero_of_mem_densityMatrices {ρ : Matrix (Fin D) (Fin D) ℂ}
-    (hρ : ρ ∈ densityMatrices D) :
-    ρ ≠ 0 := by
-  intro hρ0
-  have htr : Matrix.trace ρ = 1 := hρ.2
-  rw [hρ0, Matrix.trace_zero (Fin D) ℂ] at htr
-  exact zero_ne_one htr
-
 /-- Iterates of a channel preserve the set of density matrices. -/
 private lemma IsChannel.iter_mem_densityMatrices
     (hE : IsChannel E) {ρ : Matrix (Fin D) (Fin D) ℂ}
@@ -158,7 +149,11 @@ theorem IsChannel.exists_unique_density_fixedPoint_of_irreducible
         exact hφ_tendsto)
   have hσ_mem : σ ∈ densityMatrices D := hσ_lim.1
   have hσ_fix : E σ = σ := hσ_lim.2
-  have hσ_ne : σ ≠ 0 := ne_zero_of_mem_densityMatrices (D := D) hσ_mem
+  have hσ_ne : σ ≠ 0 := by
+    intro hσ0
+    have htr : Matrix.trace σ = 1 := hσ_mem.2
+    rw [hσ0, Matrix.trace_zero (Fin D) ℂ] at htr
+    exact zero_ne_one htr
   have hσ_pd : σ.PosDef :=
     posDef_of_posSemidef_eigenvector_irreducible_cp E hE.cp hIrr σ 1
       hσ_mem.1 hσ_ne zero_lt_one (by simpa using hσ_fix)

--- a/TNLean/Channel/Irreducible/FromSpectral.lean
+++ b/TNLean/Channel/Irreducible/FromSpectral.lean
@@ -79,15 +79,6 @@ private lemma trace_ne_zero_of_orthogonalProjection_ne_zero
   intro htr
   exact hP_ne ((hP_psd.trace_eq_zero_iff).1 htr)
 
-private lemma ne_zero_of_mem_densityMatrices
-    {ρ : Matrix (Fin D) (Fin D) ℂ}
-    (hρ : ρ ∈ densityMatrices D) :
-    ρ ≠ 0 := by
-  intro hρ0
-  have htr : Matrix.trace ρ = 1 := hρ.2
-  rw [hρ0, Matrix.trace_zero (Fin D) ℂ] at htr
-  exact zero_ne_one htr
-
 private lemma normalizedProjection_mem_densityMatrices
     {P : Matrix (Fin D) (Fin D) ℂ}
     (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
@@ -321,7 +312,11 @@ theorem isIrreducibleMap_of_channel_posDef_fixedPoint_unique
     IsChannel.cesaroMean_subseq_limit_fixedPoint (E := E) hE hρ₀_mem
       hφ_mono.tendsto_atTop hσ_tendsto
   have hσ_fix : E σ = σ := hσ_lim.2
-  have hσ_ne : σ ≠ 0 := ne_zero_of_mem_densityMatrices (D := D) hσ_lim.1
+  have hσ_ne : σ ≠ 0 := by
+    intro hσ0
+    have htr : Matrix.trace σ = 1 := hσ_lim.1.2
+    rw [hσ0, Matrix.trace_zero (Fin D) ℂ] at htr
+    exact zero_ne_one htr
   have hcorner_tendsto : Filter.Tendsto
       (fun k => P * cesaroMean E ρ₀ (φ k + 1) * P)
       Filter.atTop (nhds (P * σ * P)) := by


### PR DESCRIPTION
### Motivation

- Two one-use private copies of `ne_zero_of_mem_densityMatrices` existed in `Channel/Irreducible/Ergodicity.lean` and `Channel/Irreducible/FromSpectral.lean`, duplicating reasoning already available in `Channel/Semigroup/Primitivity/Helpers.lean`.
- Removing these local copies reduces duplication without altering any irreducible-channel argument.

### Description

- Modified `TNLean/Channel/Irreducible/Ergodicity.lean`: removed private `ne_zero_of_mem_densityMatrices` helper and inlined the trace-one contradiction at its single call site.
- Modified `TNLean/Channel/Irreducible/FromSpectral.lean`: same change.
- At both call sites the proof runs: assume `σ = 0`, use `trace σ = 1` from membership in `densityMatrices`, rewrite with `Matrix.trace_zero`, and derive `zero_ne_one`.
- Irreducible-channel and spectral arguments are unchanged. A shared variant of the lemma remains in `Channel/Semigroup/Primitivity/Helpers.lean` for use by other modules.
- No `sorry` or `axiom` introduced.

### Testing

- `lake build TNLean.Channel.Irreducible.Ergodicity TNLean.Channel.Irreducible.FromSpectral -q --log-level=info`
- `git diff -U0 -- TNLean docs blueprint | rg '^\+.*\b(sorry|axiom|admit|native_decide|unsafeCast)\b'` (no matches)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

<!-- No linked issue identified. The author should add `Addresses #N` or `Closes #N` referencing the relevant issue. -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavioral changes; logic is duplicated locally instead of via private lemmas.
>
> **Overview**
> Removes duplicate private `ne_zero_of_mem_densityMatrices` helpers from **`Ergodicity.lean`** and **`FromSpectral.lean`**, where each was only used once.
>
> At both call sites, the proof that a Cesàro-limit density matrix `σ` is nonzero is now written inline: assume `σ = 0`, use `trace σ = 1` from membership in `densityMatrices`, rewrite with `Matrix.trace_zero`, and derive `zero_ne_one`. **Irreducible-channel and spectral arguments are unchanged**; this is deduplication only (a shared variant still lives in `Semigroup/Primitivity/Helpers.lean` for other modules).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de10171152e44d37a73ffde92e18d31817ff0a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>