### PR TITLE
refactor(Channel/Schwarz): use Mathlib positive-definite sum

### DIFF
--- a/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
+++ b/TNLean/Channel/Schwarz/SchwarzSubnormal.lean
@@ -150,17 +150,6 @@ private lemma commuting_dominant_right_bound_posDef
 
 /-! ### General PSD case -/
 
-/-- `Dom.PosSemidef` implies `(Dom + ε • 1).PosDef` for `ε > 0`. -/
-private lemma posDef_add_pos_smul_one (Dom : Mat) (hPSD : Dom.PosSemidef)
-    (ε : ℝ) (hε : 0 < ε) :
-    (Dom + (ε : ℂ) • (1 : Mat)).PosDef := by
-  rw [add_comm]
-  apply Matrix.PosDef.add_posSemidef _ hPSD
-  have h1 : (ε : ℂ) • (1 : Mat) = (ε : ℝ) • (1 : Mat) := by
-    ext i j; simp [Matrix.smul_apply, smul_eq_mul, Complex.real_smul]
-  rw [h1]
-  exact Matrix.PosDef.one.smul hε
-
 /-- If `B ≤ D + ε • 1` for all `ε > 0`, then `B ≤ D`.
 This is the closedness of the PSD cone, applied to the differences
 `D - B + ε • 1`. -/
@@ -427,8 +416,12 @@ theorem commuting_dominant_right_bound
     A * Aᴴ ≤ Dom := by
   apply le_of_forall_le_add_pos_smul_one _ _
   intro ε hε
-  have hPD : (Dom + (ε : ℂ) • (1 : Mat)).PosDef :=
-    posDef_add_pos_smul_one Dom hDomPos ε hε
+  have hPD : (Dom + (ε : ℂ) • (1 : Mat)).PosDef := by
+    apply Matrix.PosDef.posSemidef_add hDomPos
+    have h1 : (ε : ℂ) • (1 : Mat) = (ε : ℝ) • (1 : Mat) := by
+      ext i j; simp [Matrix.smul_apply, smul_eq_mul, Complex.real_smul]
+    rw [h1]
+    exact Matrix.PosDef.one.smul hε
   have hComm' : Commute (Dom + (ε : ℂ) • (1 : Mat)) A :=
     hComm.add_left ((Commute.one_left A).smul_left (ε : ℂ))
   have hDom' : Aᴴ * A ≤ Dom + (ε : ℂ) • (1 : Mat) :=
@@ -687,22 +680,23 @@ theorem schwarz_inequality_commuting_dominant_operator
       T Aᴴ * T A ≤ T Dom + (ε : ℂ) • 1 ∧
         T A * T Aᴴ ≤ T Dom + (ε : ℂ) • 1 := by
     intro ε hε
-    have hPD := posDef_add_pos_smul_one Dom hDomPos ε hε
+    have hPD : (Dom + (ε : ℂ) • (1 : Mat)).PosDef := by
+      apply Matrix.PosDef.posSemidef_add hDomPos
+      have h1 : (ε : ℂ) • (1 : Mat) = (ε : ℝ) • (1 : Mat) := by
+        ext i j; simp [Matrix.smul_apply, smul_eq_mul, Complex.real_smul]
+      rw [h1]
+      exact Matrix.PosDef.one.smul hε
     have hPD_result :=
       schwarz_commuting_dominant_posDef T hPos hSub A _ hPD (hComm_add (ε : ℂ))
         (hDom_add ε hε.le)
     refine ⟨?_, ?_⟩
     · calc T Aᴴ * T A ≤ T (Dom + (ε : ℂ) • 1) := hPD_result.1
         _ = T Dom + (ε : ℂ) • T 1 := by
-            simpa only [Complex.coe_smul, map_add, LinearMap.map_smul_of_tower,
-              add_right_inj] using
-              congrArg (fun X => T Dom + X) (T.map_smul (ε : ℂ) (1 : Mat))
+            simp only [Complex.coe_smul, map_add, LinearMap.map_smul_of_tower]
         _ ≤ T Dom + (ε : ℂ) • 1 := by gcongr
     · calc T A * T Aᴴ ≤ T (Dom + (ε : ℂ) • 1) := hPD_result.2
         _ = T Dom + (ε : ℂ) • T 1 := by
-            simpa only [Complex.coe_smul, map_add, LinearMap.map_smul_of_tower,
-              add_right_inj] using
-              congrArg (fun X => T Dom + X) (T.map_smul (ε : ℂ) (1 : Mat))
+            simp only [Complex.coe_smul, map_add, LinearMap.map_smul_of_tower]
         _ ≤ T Dom + (ε : ℂ) • 1 := by gcongr
   exact ⟨le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).1,
          le_of_forall_le_add_pos_smul_one _ _ fun ε hε => (hApprox ε hε).2⟩


### PR DESCRIPTION
### Motivation
- The private helper `posDef_add_pos_smul_one` in `SchwarzSubnormal.lean` duplicates functionality already available in Mathlib as `Matrix.PosDef.posSemidef_add`; removing it reduces local proof overhead in the Wolf Ch5 Schwarz subnormality argument.
- Two nearby linear-map equality proofs produced unnecessary `simpa` linter warnings that can be resolved with `simp only` directly.

### Description
- `TNLean/Channel/Schwarz/SchwarzSubnormal.lean`: removes the private lemma `posDef_add_pos_smul_one` and replaces its two call sites with `Matrix.PosDef.posSemidef_add`, keeping only the inline real-to-complex scalar coercion at each point of use.
- Simplifies two linear-map equality proofs from generated congruence proofs to `simp only`, eliminating the corresponding unnecessary-`simpa` linter warnings in this region.
- The mathematical argument is unchanged: a positive semidefinite dominant matrix becomes positive definite after adding a positive scalar multiple of the identity, and the Schwarz subnormality estimates proceed via the same approximation by positive definite dominants.

### Testing
- `lake build TNLean.Channel.Schwarz.SchwarzSubnormal -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses LionSR/QICLean#30

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Proof-only refactor in `SchwarzSubnormal.lean` with no API or runtime behavior changes; mathematical steps are preserved.
>
> **Overview**
> Removes the local helper **`posDef_add_pos_smul_one`** and proves **`Dom + ε•I` is positive definite** at the two Schwarz subnormality call sites via Mathlib's **`Matrix.PosDef.posSemidef_add`**, keeping only the inline real-to-complex identity coercion step.
>
> The ε-approximation argument for commuting-dominant bounds is unchanged; two **`T(Dom + ε•1)`** linear-map rewrites in the approximation calc are shortened from congruence/`simpa` proofs to **`simp only`**.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea2dc9385437cac95ba93ebcfeee38a795db0a36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->