### PR TITLE
refactor(Wielandt): use Mathlib kernel composition lemma

### DIFF
--- a/TNLean/Wielandt/FittingDecomposition.lean
+++ b/TNLean/Wielandt/FittingDecomposition.lean
@@ -205,22 +205,6 @@ theorem ker_pow_nilpIndex_eq_ker_pow_finrank
   rw [← maxGenEigenspace_zero_eq_ker_pow_nilpIndex f,
       End.maxGenEigenspace_eq_genEigenspace_finrank f 0, End.genEigenspace_zero_nat]
 
-/-- Kernel monotonicity: if `n ≤ m`, then `ker(f^n) ≤ ker(f^m)`. -/
-private theorem ker_pow_mono
-    {K : Type*} {V : Type*}
-    [CommRing K] [AddCommGroup V] [Module K V]
-    (f : End K V) {n m : ℕ} (h : n ≤ m) :
-    LinearMap.ker (f ^ n) ≤ LinearMap.ker (f ^ m) := by
-  intro v hv
-  rw [LinearMap.mem_ker] at hv ⊢
-  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le h
-  -- f^(n+d) v = (f^n * f^d) v = f^n (f^d v)... wrong direction
-  -- We need: f^(n+d) v = f^d (f^n v) = f^d 0 = 0
-  -- Use: n+d = d+n, then f^(d+n) = f^d * f^n, so f^(d+n) v = f^d (f^n v)
-  rw [show n + d = d + n from by omega, pow_add]
-  change (f ^ d) ((f ^ n) v) = 0
-  rw [hv, map_zero]
-
 /-- Kernel stabilization at nilpIndex: `ker(f^k) = ker(f^(nilpIndex f))` for `k ≥ nilpIndex f`. -/
 theorem ker_pow_eq_of_nilpIndex_le
     {K : Type*} {V : Type*}
@@ -234,7 +218,9 @@ theorem ker_pow_eq_of_nilpIndex_le
     rw [End.mem_maxGenEigenspace]
     exact ⟨k, by simp only [zero_smul, sub_zero]; exact LinearMap.mem_ker.mp hv⟩
   · -- ker(f^(nilpIndex f)) ≤ ker(f^k): kernel monotonicity
-    exact ker_pow_mono f hk
+    obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hk
+    rw [show nilpIndex f + d = d + nilpIndex f from by omega, pow_add]
+    exact LinearMap.ker_le_ker_comp (f ^ nilpIndex f) (f ^ d)
 
 /-- Range anti-monotonicity: if `n ≤ m`, then `range(f^m) ≤ range(f^n)`. -/
 theorem range_pow_antitone
@@ -342,7 +328,8 @@ theorem nilpIndex_le_finrank_maxGenEigenspace_zero
   -- Step 3: ker(f^s) = ker(f^(s+1))
   have hstab : LinearMap.ker (f ^ s) = LinearMap.ker (f ^ s.succ) := by
     apply le_antisymm
-    · exact ker_pow_mono f (Nat.le_succ s)
+    · rw [show s.succ = 1 + s from by omega, pow_add]
+      exact LinearMap.ker_le_ker_comp (f ^ s) (f ^ 1)
     · calc LinearMap.ker (f ^ s.succ)
           ≤ f.maxGenEigenspace 0 := by
             rw [End.maxGenEigenspace_eq_genEigenspace_finrank f 0, End.genEigenspace_zero_nat]


### PR DESCRIPTION
### Motivation

- Removes the private kernel-monotonicity helper `ker_pow_mono` from `TNLean/Wielandt/FittingDecomposition.lean`, which restated Mathlib's `LinearMap.ker_le_ker_comp` without adding mathematical content.
- Aligns the Fitting-decomposition kernel-stabilization arguments with the standard Mathlib linear-map API.

### Description

- `TNLean/Wielandt/FittingDecomposition.lean`: deleted `ker_pow_mono`; its two call sites in `ker_pow_eq_of_nilpIndex_le` and the `ker(f^s) = ker(f^(s+1))` stabilization step of `nilpIndex_le_finrank_maxGenEigenspace_zero` now decompose the larger power via `Nat.exists_eq_add_of_le` and `pow_add`, then apply `LinearMap.ker_le_ker_comp` directly.
- No mathematical content is changed; the nilpotent-kernel stabilization arguments remain intact.

### Testing

- `lake build TNLean.Wielandt.FittingDecomposition -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
No linked issue identified; author should link one if applicable.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in Wielandt Fitting decomposition; no API or runtime behavior changes.
>
> **Overview**
> Removes the local **`ker_pow_mono`** proof and routes kernel-monotonicity steps through Mathlib's **`LinearMap.ker_le_ker_comp`**.
>
> In **`ker_pow_eq_of_nilpIndex_le`** and the **`ker(f^s) = ker(f^(s+1))`** step of **`nilpIndex_le_finrank_maxGenEigenspace_zero`**, the code now splits `k` or `s.succ` with **`Nat.exists_eq_add_of_le`**, rewrites the larger power via **`pow_add`**, and applies **`ker_le_ker_comp`** on the matching factors. The stabilization arguments are unchanged; only the proof plumbing is leaner and aligned with the standard linear-map API.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de47c9b18067bb8567a03503b4c667b6cc1ab66d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>