### PR TITLE
refactor(Semigroup): inline normalized projection witness

### DIFF
--- a/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
@@ -40,22 +40,6 @@ local instance instSubsequenceNormOneClassMatrixCLM [NeZero D] :
 
 /-! ## (4) → (2): Block-upper-triangular → rank-deficient kernel element -/
 
-/-- A nonzero orthogonal projection has nonzero trace. -/
-private lemma trace_ne_zero_of_proj_ne_zero'
-    {P : Mat} (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
-    Matrix.trace P ≠ 0 := by
-  intro htr
-  exact hP_ne ((isOrthogonalProjection_posSemidef hP).trace_eq_zero_iff.1 htr)
-
-/-- `P / tr(P)` is a density matrix. -/
-private lemma normalizedProj_mem_densityMatrices'
-    {P : Mat} (hP : IsOrthogonalProjection P) (hP_ne : P ≠ 0) :
-    ((trace P)⁻¹ • P) ∈ densityMatrices D := by
-  have hP_psd := isOrthogonalProjection_posSemidef hP
-  have htrP_ne := trace_ne_zero_of_proj_ne_zero' hP hP_ne
-  exact ⟨hP_psd.smul (inv_nonneg_of_nonneg hP_psd.trace_nonneg),
-    by simp [Matrix.trace_smul, htrP_ne]⟩
-
 /-- `P * (P/tr(P)) * P = P/tr(P)` (the normalized projection is in `PMP`). -/
 private lemma normalizedProj_in_PMP'
     {P : Mat} (hP : IsOrthogonalProjection P) :
@@ -83,7 +67,14 @@ private theorem channel_fixedPoint_in_PMP
       P * ρ * P = ρ ∧ E ρ = ρ := by
   -- Set up initial state
   set σ₀ := (trace P)⁻¹ • P with hσ₀_def
-  have hσ₀_mem : σ₀ ∈ densityMatrices D := normalizedProj_mem_densityMatrices' hP hP_ne
+  have hP_psd := isOrthogonalProjection_posSemidef hP
+  have htrP_ne : Matrix.trace P ≠ 0 := by
+    intro htr
+    exact hP_ne (hP_psd.trace_eq_zero_iff.1 htr)
+  have hσ₀_mem : σ₀ ∈ densityMatrices D := by
+    rw [hσ₀_def]
+    exact ⟨hP_psd.smul (inv_nonneg_of_nonneg hP_psd.trace_nonneg),
+      by simp [Matrix.trace_smul, htrP_ne]⟩
   have hσ₀_PMP : P * σ₀ * P = σ₀ := normalizedProj_in_PMP' hP
   -- Iterates stay in PMP ∩ DM
   have h_iter_mem : ∀ n : ℕ, (E ^ n) σ₀ ∈ densityMatrices D := by


### PR DESCRIPTION
### Motivation

- `TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean` contained two private auxiliary lemmas — `trace_ne_zero_of_proj_ne_zero'` and `normalizedProj_mem_densityMatrices'` — whose sole role was to restate existing Mathlib positivity and trace facts (`Matrix.PosSemidef.trace_eq_zero_iff` via `isOrthogonalProjection_posSemidef`) at the call site.
- Placing these steps directly in the Cesàro initial-state construction removes the unnecessary private names and keeps the argument local, without altering the mathematical content.

### Description

- Modified: `TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean`
- Removed private auxiliary lemmas `trace_ne_zero_of_proj_ne_zero'` and `normalizedProj_mem_densityMatrices'`.
- The nonzero-trace step and the membership of the normalized projection $\sigma_0 := (\operatorname{tr} P)^{-1} P$ in `densityMatrices D` are now established inline within `channel_fixedPoint_in_PMP`, using `isOrthogonalProjection_posSemidef` and `Matrix.PosSemidef.trace_eq_zero_iff` directly.
- The mathematical argument in the reducible-QDS subsequence analysis is unchanged; no downstream theorems are affected.

### Testing

- `lake build TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis -q --log-level=info`
- Proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` on added lines.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one Lean file with logic inlined unchanged; no API or runtime impact.
> 
> **Overview**
> **Refactors** the reducible-QDS subsequence file by deleting private lemmas `trace_ne_zero_of_proj_ne_zero'` and `normalizedProj_mem_densityMatrices'`.
> 
> The **nonzero trace** and **σ₀ ∈ densityMatrices D** steps now live directly in `channel_fixedPoint_in_PMP` when defining the Cesàro initial state `σ₀ := (trace P)⁻¹ • P`, still using `isOrthogonalProjection_posSemidef` and `Matrix.trace_smul` as before.
> 
> No change to the mathematical argument or downstream theorems—only proof locality and fewer pass-through names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a71d288fd05aaed007ccb8c661ef68f92094f5fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- /CURSOR_SUMMARY -->