### PR TITLE
refactor(Wielandt): inline trace-one nonzero proof

### DIFF
--- a/TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
+++ b/TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean
@@ -153,14 +153,6 @@ private theorem trace_one_eq_zero_of_all_traces_zero
     LinearMap.zero_apply] at this
   exact this
 
-/-- `tr(1 : Matrix (Fin D) (Fin D) ℂ) = D`, and `D ≠ 0` when
-`NeZero D`. -/
-private theorem trace_one_ne_zero [NeZero D] :
-    Matrix.trace (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
-  rw [Matrix.trace_one]
-  simp only [Fintype.card_fin, ne_eq, Nat.cast_eq_zero]
-  exact NeZero.ne D
-
 /-- **Lemma 1** (arXiv:0909.5347), part (a):
 Under `IsNormal` (eventually full word span), the cumulative span
 T_n must reach ⊤ = M_D(ℂ) by step D².
@@ -193,7 +185,9 @@ theorem exists_nonzero_trace_word [NeZero D]
   push Not at hall
   have htop := cumulativeSpan_eq_top A hN
   have := trace_one_eq_zero_of_all_traces_zero A htop hall
-  exact trace_one_ne_zero this
+  rw [Matrix.trace_one] at this
+  simp only [Fintype.card_fin, Nat.cast_eq_zero] at this
+  exact NeZero.ne D this
 
 /-! ### Sharp bound: D² − dim(S₁) + 1
 
@@ -377,7 +371,9 @@ theorem exists_nonzero_trace_word_sharp [NeZero D]
   push Not at hall
   have htop := cumulativeSpan_eq_top_of_isNormal_sharp A hN
   have := trace_one_eq_zero_of_all_traces_zero A htop hall
-  exact trace_one_ne_zero this
+  rw [Matrix.trace_one] at this
+  simp only [Fintype.card_fin, Nat.cast_eq_zero] at this
+  exact NeZero.ne D this
 
 
 /-! ### Positive-length nonzero trace word
@@ -628,6 +624,8 @@ theorem exists_nonzero_trace_word_sharp_pos [NeZero D]
     exact hall w hw1 hw2
   have htr1 := LinearMap.eqOn_span hvanish h1mem
   simp only [Matrix.traceLinearMap_apply, LinearMap.zero_apply] at htr1
-  exact trace_one_ne_zero htr1
+  rw [Matrix.trace_one] at htr1
+  simp only [Fintype.card_fin, Nat.cast_eq_zero] at htr1
+  exact NeZero.ne D htr1
 
 end MPSTensor


### PR DESCRIPTION
### Motivation

- The private helper `trace_one_ne_zero` in `NonzeroTraceProduct.lean` was a named pass-through for the elementary fact that the identity matrix has trace equal to the bond dimension `D`, which is nonzero. Naming such a trivial intermediate obscures the proof without adding mathematical content.
- Mathlib already provides this fact directly via `Matrix.trace_one`, `Fintype.card_fin`, and `NeZero.ne`, making the helper redundant.

### Description

- Modified `TNLean/Wielandt/SpanGrowth/NonzeroTraceProduct.lean`: deleted the private helper `trace_one_ne_zero`.
- The three former call sites now rewrite with `Matrix.trace_one`, simplify with `Fintype.card_fin` / `Nat.cast_eq_zero`, and close the contradiction via `NeZero.ne D`.
- No change to the span-growth or nonzero-trace-product statements — only how the identity-trace nonzero fact is established internally.

### Testing

- `lake build TNLean.Wielandt.SpanGrowth.NonzeroTraceProduct -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with identical mathematical steps; no API or runtime behavior changes.
> 
> **Overview**
> Removes the private helper `trace_one_ne_zero` from `NonzeroTraceProduct.lean` and inlines the same contradiction step at its three call sites.
> 
> Each proof that assumed all relevant word traces vanish now rewrites with `Matrix.trace_one`, simplifies with `Fintype.card_fin` / `Nat.cast_eq_zero`, and closes with `NeZero.ne D` instead of calling the deleted lemma. No change to the span-growth or nonzero-trace statements—only how the identity trace `≠ 0` fact is applied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9f7579bc88bb9b56992c30fa8055b4b6f17b1a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>