### PR TITLE
refactor(MPS/ParentHamiltonian): inline cyclic trace step

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -39,13 +39,6 @@ lemma parentInteraction_apply_mem_groundSpace (A : MPSTensor d D) (L : ℕ)
       ((WithLp.linearEquiv 2 ℂ (NSiteSpace d L)).symm v)) = 0
   rw [hkill, map_zero]
 
-/-! ### Cyclic trace invariance -/
-
-/-- Trace of evalWord is invariant under cyclic swap of concatenated words. -/
-private lemma trace_evalWord_append_comm (A : MPSTensor d D) (w₁ w₂ : List (Fin d)) :
-    Matrix.trace (evalWord A (w₁ ++ w₂)) = Matrix.trace (evalWord A (w₂ ++ w₁)) := by
-  rw [evalWord_append, evalWord_append, Matrix.trace_mul_comm]
-
 /-! ### Periodic MPS vector window membership -/
 
 /-- The periodic MPS vector restricted to any window of \(L\) sites lies in
@@ -76,7 +69,7 @@ lemma mpv_window_mem_groundSpace (A : MPSTensor d D) (L N : ℕ) (hLN : L ≤ N)
     have hle : i.val ≤ (List.ofFn (replaceWindow L hLN i σ τ)).length := by
       simp [List.length_ofFn]
     rw [← hlist, List.rotate_eq_drop_append_take hle,
-        trace_evalWord_append_comm, List.take_append_drop]
+        evalWord_append, Matrix.trace_mul_comm, ← evalWord_append, List.take_append_drop]
   -- Prove the rotated list equals τ ++ complement elementwise
   apply List.ext_getElem
   · have : compList.length = N - L := by simp [compList, List.length_ofFn]


### PR DESCRIPTION
### Motivation

- The private lemma `trace_evalWord_append_comm` had a single call site in `mpv_window_mem_groundSpace`; inlining the argument removes the indirection and keeps the cyclic-trace reasoning at the call site.

### Description

- Modified `TNLean/MPS/ParentHamiltonian/Basic.lean`.
- Removed the private lemma `trace_evalWord_append_comm`.
- In `mpv_window_mem_groundSpace`, the cyclic trace rotation step now expands the rotated product using `evalWord_append`, applies `Matrix.trace_mul_comm`, and folds back using `evalWord_append` before `List.take_append_drop`. The mathematical content is unchanged.
- No `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.Basic -q --log-level=info`
- `git diff --check`
- Proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast` on added lines.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

_No linked issue found — the branch name does not follow the `issue-{N}` pattern and no issue reference appears in the PR body or commits. Please link a relevant issue manually if applicable._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in ParentHamiltonian.Basic with no API or runtime behavior changes.
>
> **Overview**
> Removes the private one-off lemma **`trace_evalWord_append_comm`** from `TNLean/MPS/ParentHamiltonian/Basic.lean`.
>
> In **`mpv_window_mem_groundSpace`**, the cyclic trace rotation step no longer goes through that lemma. The proof now expands with **`evalWord_append`**, applies Mathlib's **`Matrix.trace_mul_comm`**, and folds back with **`evalWord_append`** before **`List.take_append_drop`**—same argument, kept at the call site.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe382f5ed5984ce07989e52192544b94ffa79cf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>