### PR TITLE
refactor(CanonicalForm): inline Frobenius trace reduction

### DIFF
--- a/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean
@@ -218,14 +218,6 @@ local instance : InnerProductSpace ℂ (Matrix (Fin D) (Fin D) ℂ) :=
   Matrix.toMatrixInnerProductSpace (n := Fin D) (𝕜 := ℂ) 1
     (Matrix.PosDef.one (n := Fin D) (R := ℂ)).posSemidef
 
-/-- Under the Frobenius inner product induced by the weight matrix `1`, we have
-`⟪X, Y⟫ = trace (Y * Xᴴ)`. -/
-private lemma inner_eq_trace (X Y : Matrix (Fin D) (Fin D) ℂ) :
-    inner ℂ X Y = Matrix.trace (Y * Xᴴ) := by
-  -- `rfl` gives `trace (Y * 1 * Xᴴ)`.
-  simpa only [mul_one] using
-    (show inner ℂ X Y = Matrix.trace (Y * (1 : Matrix (Fin D) (Fin D) ℂ) * Xᴴ) from rfl)
-
 /-- The adjoint of `transferMap A` (Frobenius inner product) is the transfer map of the
 conjugate-transposed Kraus family. -/
 lemma transferMap_conjTranspose_eq_adjoint (A : MPSTensor d D) :
@@ -237,8 +229,11 @@ lemma transferMap_conjTranspose_eq_adjoint (A : MPSTensor d D) :
       (B := transferMap (d := d) (D := D) A)).2 ?_
   intro X Y
   -- Reduce to a trace identity using the definition of the Frobenius inner product.
-  -- `simp only [inner_eq_trace]` rewrites ⟪·,·⟫ to Matrix.trace without unfolding transferMap.
-  simp only [inner_eq_trace]
+  change Matrix.trace (Y * (1 : Matrix (Fin D) (Fin D) ℂ) *
+      (transferMap (d := d) (D := D) K X)ᴴ) =
+    Matrix.trace (transferMap (d := d) (D := D) A Y *
+      (1 : Matrix (Fin D) (Fin D) ℂ) * Xᴴ)
+  simp only [mul_one]
   -- Rewrite the conjugate transpose of a Kraus map.
   have hconj : (transferMap (d := d) (D := D) K X)ᴴ = transferMap (d := d) (D := D) K (Xᴴ) := by
     classical


### PR DESCRIPTION
### Motivation

- The private auxiliary lemma `inner_eq_trace` in `TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean` existed solely to restate the definitional trace form of the Frobenius inner product at a single call site within the proof of `transferMap_conjTranspose_eq_adjoint`.
- Inlining eliminates the indirection and reduces the proof to its essential steps without changing the mathematical content.

### Description

- Modified `TNLean/MPS/CanonicalForm/BlockingViaAdjoint.lean`: removed the private lemma `inner_eq_trace` and inlined the Frobenius trace identity directly in the proof of `transferMap_conjTranspose_eq_adjoint`, applying `mul_one` to discharge the weight-matrix step. The Kraus-sum trace computation is unchanged.

### Testing

- `lake build TNLean.MPS.CanonicalForm.BlockingViaAdjoint -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses # <!-- No linked issue found; please add the relevant issue number. -->

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1951bddbee15d9b048d542e7bdc1b8cf7239ea63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>