### PR TITLE
refactor(Wielandt): inline Hermitian trace witnesses

### DIFF
--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -162,21 +162,6 @@ theorem trace_eigenvector_eq_zero
   · exact absurd (sub_eq_zero.mp h) hμ_ne
   · exact h
 
-/-- Trace of `X + X†` vanishes when trace of `X` vanishes. -/
-private lemma trace_hermitianPart_eq_zero
-    {X : Matrix (Fin D) (Fin D) ℂ}
-    (htr : Matrix.trace X = 0) :
-    Matrix.trace (X + Xᴴ) = 0 := by
-  rw [Matrix.trace_add, Matrix.trace_conjTranspose, htr, star_zero, add_zero]
-
-/-- Trace of `i(X† - X)` vanishes when trace of `X` vanishes. -/
-private lemma trace_antiHermitianPart_eq_zero
-    {X : Matrix (Fin D) (Fin D) ℂ}
-    (htr : Matrix.trace X = 0) :
-    Matrix.trace (Complex.I • (Xᴴ - X)) = 0 := by
-  rw [Matrix.trace_smul, Matrix.trace_sub, Matrix.trace_conjTranspose, htr, star_zero,
-    sub_zero, smul_zero]
-
 /-- At least one of `X + X†` and `i(X† - X)` is nonzero when `X ≠ 0`. -/
 private lemma hermitianParts_not_both_zero
     {X : Matrix (Fin D) (Fin D) ℂ} (hne : X ≠ 0) :
@@ -244,18 +229,23 @@ theorem exists_hermitian_ne_zero_trace_zero_pow_fixedPoint
       ¬H.PosSemidef := by
   have htr := trace_eigenvector_eq_zero A hNorm hEig hμ_ne
   rcases hermitianParts_not_both_zero hX_ne with h | h
-  · exact ⟨X + Xᴴ,
+  · have htrH : Matrix.trace (X + Xᴴ) = 0 := by
+      rw [Matrix.trace_add, Matrix.trace_conjTranspose, htr, star_zero, add_zero]
+    exact ⟨X + Xᴴ,
       Matrix.isHermitian_add_transpose_self X, h,
-      trace_hermitianPart_eq_zero htr,
+      htrH,
       transferMap_pow_hermitianPart_fixedPoint A hEig hroot,
       not_posSemidef_of_hermitian_ne_zero_trace_eq_zero
-        (Matrix.isHermitian_add_transpose_self X) h (trace_hermitianPart_eq_zero htr)⟩
-  · exact ⟨Complex.I • (Xᴴ - X),
+        (Matrix.isHermitian_add_transpose_self X) h htrH⟩
+  · have htrH : Matrix.trace (Complex.I • (Xᴴ - X)) = 0 := by
+      rw [Matrix.trace_smul, Matrix.trace_sub, Matrix.trace_conjTranspose, htr, star_zero,
+        sub_zero, smul_zero]
+    exact ⟨Complex.I • (Xᴴ - X),
       isHermitian_smul_I_sub_conjTranspose X, h,
-      trace_antiHermitianPart_eq_zero htr,
+      htrH,
       transferMap_pow_antiHermitianPart_fixedPoint A hEig hroot,
       not_posSemidef_of_hermitian_ne_zero_trace_eq_zero
-        (isHermitian_smul_I_sub_conjTranspose X) h (trace_antiHermitianPart_eq_zero htr)⟩
+        (isHermitian_smul_I_sub_conjTranspose X) h htrH⟩
 
 /-! ### Step 7: Auxiliary lemmas for the perturbation construction -/
 


### PR DESCRIPTION
### Motivation

- Two private pass-through helpers in `ImpliesStronglyIrreducibleAux.lean` — `trace_hermitianPart_eq_zero` and `trace_antiHermitianPart_eq_zero` — wrapped standard trace linearity (`Matrix.trace_add`, `Matrix.trace_sub`, `Matrix.trace_smul`, `Matrix.trace_conjTranspose`) without adding mathematical content.
- Inlining them removes named intermediaries for facts that Mathlib provides directly, keeping the proof local to the branches where the witnesses are needed.

### Description

- `TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean` (modified): removes the private helpers `trace_hermitianPart_eq_zero` and `trace_antiHermitianPart_eq_zero`; the proof of `exists_hermitian_ne_zero_trace_zero_pow_fixedPoint` now computes the trace-zero witnesses inline in each branch using the same `Matrix.trace_add` / `Matrix.trace_smul` / `Matrix.trace_conjTranspose` steps.
- No change to the mathematical statement, theorem signatures, or downstream callers.

### Testing

- `lake build TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducibleAux -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
*(No linked issue found — no `Closes`/`Fixes`/`Refs` reference in the branch name, commit messages, or PR body. The author may wish to link one manually.)*

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one auxiliary file; no API or logic changes beyond inlining standard trace linearity.
> 
> **Overview**
> Removes the private helpers `trace_hermitianPart_eq_zero` and `trace_antiHermitianPart_eq_zero` from `ImpliesStronglyIrreducibleAux.lean`.
> 
> In `exists_hermitian_ne_zero_trace_zero_pow_fixedPoint`, each branch now proves `htrH : Matrix.trace … = 0` inline (same `Matrix.trace_add` / `trace_smul` / `trace_conjTranspose` steps as before) and passes `htrH` into the witness tuple and `not_posSemidef_of_hermitian_ne_zero_trace_eq_zero`. **No change to the mathematical statement or downstream callers**—only proof locality and fewer named lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b189282a62412b58fe1ba26e69b65e2fc5f8edb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>