### PR TITLE
refactor(Semigroup): inline dissipator trace proof

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm/Basic.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/Basic.lean
@@ -88,22 +88,6 @@ def LindbladForm.toLinearMap (F : LindbladForm D) :
     congr 1
     congr 1 <;> ring_nf
 
-/-- Each dissipator term has trace zero. -/
-private lemma trace_dissipator_eq_zero (Lop : Matrix (Fin D) (Fin D) ℂ)
-    (ρ : Matrix (Fin D) (Fin D) ℂ) :
-    trace (dissipator Lop ρ) = 0 := by
-  simp only [dissipator]
-  rw [trace_sub, trace_sub, trace_smul, trace_smul]
-  -- tr(L ρ L†) = tr(L† L ρ) by cyclic property
-  have h1 : trace (Lop * ρ * Lopᴴ) = trace (Lopᴴ * Lop * ρ) := by
-    rw [Matrix.trace_mul_cycle, Matrix.mul_assoc]
-  -- tr(L† L ρ) = tr(ρ L† L) by cyclic property
-  have h2 : trace (Lopᴴ * Lop * ρ) = trace (ρ * (Lopᴴ * Lop)) := by
-    rw [Matrix.trace_mul_comm]
-  rw [h1, h2]
-  simp only [one_div, smul_eq_mul]
-  ring
-
 /-- The Lindblad form is trace-annihilating (Wolf Equation 7.21 preserves trace). -/
 theorem LindbladForm.isTraceAnnihilating (F : LindbladForm D) :
     IsTraceAnnihilating F.toLinearMap := by
@@ -117,7 +101,16 @@ theorem LindbladForm.isTraceAnnihilating (F : LindbladForm D) :
   rw [hH, zero_add]
   -- Dissipative part
   rw [Matrix.trace_sum]
-  exact Finset.sum_eq_zero (fun j _ => trace_dissipator_eq_zero (F.L j) ρ)
+  exact Finset.sum_eq_zero fun j _ => by
+    simp only [dissipator]
+    rw [trace_sub, trace_sub, trace_smul, trace_smul]
+    have h1 : trace (F.L j * ρ * (F.L j)ᴴ) = trace ((F.L j)ᴴ * F.L j * ρ) := by
+      rw [Matrix.trace_mul_cycle, Matrix.mul_assoc]
+    have h2 : trace ((F.L j)ᴴ * F.L j * ρ) = trace (ρ * ((F.L j)ᴴ * F.L j)) := by
+      rw [Matrix.trace_mul_comm]
+    rw [h1, h2]
+    simp only [one_div, smul_eq_mul]
+    ring
 
 /-! ## Lindblad form ↔ generator decomposition (Wolf Equation 7.20–7.21) -/
 


### PR DESCRIPTION
### Motivation
- The private lemma `trace_dissipator_eq_zero` in `Channel/Semigroup/LindbladForm/Basic.lean` was a single-use auxiliary whose body duplicated a short trace computation already available via Mathlib lemmas.
- Removing it keeps the trace-zero argument local to `LindbladForm.isTraceAnnihilating` and avoids a named intermediate declaration for a standard calculation.

### Description
- Modified `TNLean/Channel/Semigroup/LindbladForm/Basic.lean`:
  - Removed the private lemma `trace_dissipator_eq_zero` (10 lines).
  - Placed its proof directly as the summand argument in the `Finset.sum_eq_zero` call inside `LindbladForm.isTraceAnnihilating`, using `trace_sub`, `trace_smul`, `Matrix.trace_mul_cycle`, and `Matrix.trace_mul_comm` followed by scalar cancellation via `ring`.
- The statement of `LindbladForm.isTraceAnnihilating` and all mathematical content are unchanged.

### Testing
- `lake build TNLean.Channel.Semigroup.LindbladForm.Basic -q --log-level=info`
- Proof-integrity scan: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` in added lines.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
No linked issue found; see PR for scope.

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavioral change; trace-annihilation logic is unchanged.
>
> **Overview**
> Removes the private one-off lemma `trace_dissipator_eq_zero` from `TNLean/Channel/Semigroup/LindbladForm/Basic.lean`.
>
> The proof that each dissipator term has trace zero is now placed directly in the `Finset.sum_eq_zero` summand inside **`LindbladForm.isTraceAnnihilating`**. The argument is the same: unfold `dissipator`, use trace linearity, cycle/commute factors with `Matrix.trace_mul_cycle` and `Matrix.trace_mul_comm`, then cancel with `ring`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f58515e701c066d0ae82eefa316883b7b9829c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>