### PR TITLE
refactor(Periodic): inline unitary entry orthogonality

### DIFF
--- a/TNLean/MPS/Periodic/Applications.lean
+++ b/TNLean/MPS/Periodic/Applications.lean
@@ -106,13 +106,6 @@ theorem transferMap_rotatePhysical (A : MPSTensor d D) (u : Matrix (Fin d) (Fin 
 
 /-! ### Left-canonical preservation under rotation -/
 
-/-- Extract the orthogonality relation from `uᴴ * u = 1`. -/
-private lemma unitary_orth_entry (u : Matrix (Fin d) (Fin d) ℂ) (hu : uᴴ * u = 1)
-    (j k : Fin d) :
-    ∑ i : Fin d, starRingEnd ℂ (u i j) * u i k = if j = k then 1 else 0 := by
-  have h := congrArg (fun M : Matrix (Fin d) (Fin d) ℂ => M j k) hu
-  simpa [Matrix.mul_apply, Matrix.one_apply, Matrix.conjTranspose_apply] using h
-
 /-- Left-canonical normalization is preserved by unitary rotation of the physical
 index. The proof mirrors `kraus_same_map_of_unitary_combination` for the adjoint
 channel: expand, swap sums, apply orthogonality, collapse. -/
@@ -122,7 +115,11 @@ theorem isLeftCanonical_rotatePhysical (A : MPSTensor d D) (u : Matrix (Fin d) (
   unfold IsLeftCanonical at *
   simp only [rotatePhysical_apply]
   have hu' : uᴴ * u = 1 := mul_eq_one_comm.mp hu
-  have hU := unitary_orth_entry u hu'
+  have hU : ∀ j k : Fin d,
+      ∑ i : Fin d, starRingEnd ℂ (u i j) * u i k = if j = k then 1 else 0 := by
+    intro j k
+    have h := congrArg (fun M : Matrix (Fin d) (Fin d) ℂ => M j k) hu'
+    simpa [Matrix.mul_apply, Matrix.one_apply, Matrix.conjTranspose_apply] using h
   have star_eq : ∀ (c : ℂ), star c = starRingEnd ℂ c := fun _ => rfl
   -- Suffices: show the expanded sum equals ∑_j A_j† A_j
   suffices h : ∑ i : Fin d, (∑ j : Fin d, u i j • A j)ᴴ * (∑ k : Fin d, u i k • A k) =
@@ -157,7 +154,11 @@ theorem isIrreducibleTensor_rotatePhysical (A : MPSTensor d D) (u : Matrix (Fin 
   refine ⟨P, hProj, hNe0, hNe1, ?_⟩
   intro k
   have hu' : uᴴ * u = 1 := mul_eq_one_comm.mp hu
-  have hU := unitary_orth_entry u hu'
+  have hU : ∀ j k : Fin d,
+      ∑ i : Fin d, starRingEnd ℂ (u i j) * u i k = if j = k then 1 else 0 := by
+    intro j k
+    have h := congrArg (fun M : Matrix (Fin d) (Fin d) ℂ => M j k) hu'
+    simpa [Matrix.mul_apply, Matrix.one_apply, Matrix.conjTranspose_apply] using h
   -- Distribute (1-P)*_*P through the sum in the invariance condition
   have hInv' : ∀ i : Fin d, ∑ j : Fin d, u i j • ((1 - P) * A j * P) = 0 := by
     intro i


### PR DESCRIPTION
### Motivation

- `TNLean/MPS/Periodic/Applications.lean` contained a private auxiliary lemma `unitary_orth_entry` whose sole role was to state the entrywise form of unitarity: for a unitary matrix `u`, the `(j, k)` entry of `uᴴ * u = 1` equals `δ_{j,k}`.
- Removing this one-use lemma and deriving the same identity inline at each call site reduces the local proof infrastructure without changing any mathematical content.

### Description

- Deleted the private lemma `unitary_orth_entry` from `TNLean/MPS/Periodic/Applications.lean`.
- The two former call sites now derive the matrix-entry orthogonality relation directly by taking the `(j, k)` entry of `uᴴ * u = 1` and simplifying with Mathlib's matrix multiplication, identity, and conjugate-transpose lemmas.
- No theorem statement or mathematical content is changed; no `sorry`, `axiom`, or proof-integrity concern is introduced.

### Testing

- `lake build TNLean.MPS.Periodic.Applications -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 246b347db184c58abbf71ff1d4dc3ead2675ee15. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->