### PR TITLE
refactor(Spectral): use native complex norm-square lemma

### DIFF
--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -94,9 +94,9 @@ lemma norm_matToES_sq (M : Matrix (Fin m) (Fin n) ℂ) :
     ∑ i, ∑ j, star (M i j) * M i j from Fintype.sum_prod_type _]
   simp only [Complex.re_sum, RCLike.re_to_complex]
   congr 1; ext i; congr 1; ext j
-  rw [mul_comm, show M i j * star (M i j) = (↑(‖M i j‖ ^ 2) : ℂ) from by
-    rw [show star (M i j) = starRingEnd ℂ (M i j) from rfl, Complex.mul_conj',
-      ← Complex.ofReal_pow]]
+  rw [show star (M i j) * M i j = (↑(‖M i j‖ ^ 2) : ℂ) from by
+    simpa [Complex.normSq_eq_norm_sq] using
+      (Complex.normSq_eq_conj_mul_self (z := M i j)).symm]
   exact Complex.ofReal_re _
 
 /-- The Euclidean-space norm of a flattened matrix is the Frobenius norm. -/


### PR DESCRIPTION
### Motivation

- Mathlib 4.31 provides `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq`, which directly express the identity `star z * z = ‖z‖²` without manual rewriting through an intermediate `starRingEnd` bridge. Replacing the local proof steps with these native lemmas reduces the proof term and aligns with norm-square patterns used elsewhere in the project.
- Continues the Mathlib 4.31 proof-refactor series initiated in PR #3011.

### Description

- Modified `TNLean/Spectral/FrobeniusNorm.lean` (3 lines changed): in the proof of `norm_matToES_sq`, the entrywise step computing `star (M i j) * M i j = ‖M i j‖²` no longer passes through `mul_comm`, an explicit `starRingEnd` identification, `Complex.mul_conj'`, and `Complex.ofReal_pow`. It now uses `Complex.normSq_eq_conj_mul_self.symm` and `Complex.normSq_eq_norm_sq` from Mathlib.
- The statement of `norm_matToES_sq` and the surrounding Frobenius-norm argument for `matToES` are unchanged.

### Testing

- `lake build TNLean.Spectral.FrobeniusNorm -q --log-level=info`
- Added-line proof-integrity scan: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`.
- Lean CI (`lean_action_ci.yml`) validates the full build on merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor inside one lemma; no API or runtime behavior changes.
>
> **Overview**
> In **`norm_matToES_sq`**, the entrywise step that rewrites `star (M i j) * M i j` as a real squared norm no longer goes through `mul_comm`, an explicit `starRingEnd` identification, `Complex.mul_conj'`, and `Complex.ofReal_pow`.
>
> It now uses Mathlib's **`Complex.normSq_eq_conj_mul_self`** (with **`.symm`**) and **`Complex.normSq_eq_norm_sq`**, matching the norm-square pattern used elsewhere in the repo. The lemma statement and the rest of the Frobenius / `matToES` argument are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4b8883e51ce0bcc2ac6de9c0ebc270add37684f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->