### PR TITLE
refactor(MPS/SharedInfra): use complex norm-square for scaling phases

### DIFF
--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -33,7 +33,8 @@ theorem leftCanonical_smul_of_norm_one (c : ℂ) (hc : ‖c‖ = 1)
   simp_rw [smul_mul_smul_comm]
   rw [← Finset.smul_sum, hA]
   have hsc : (star c : ℂ) * c = 1 := by
-    rw [← starRingEnd_apply, Complex.conj_mul', hc]; simp
+    simpa [Complex.normSq_eq_norm_sq, hc] using
+      (Complex.normSq_eq_conj_mul_self (z := c)).symm
   rw [hsc, one_smul]
 
 /-- Unit-norm scaling preserves periodicity data. -/
@@ -49,7 +50,7 @@ theorem isPeriodic_smul_of_norm_one
     ext X : 1
     rw [transferMap_smul]
     have hsc : c * starRingEnd ℂ c = 1 := by
-      rw [Complex.mul_conj', hc]; simp
+      simpa [Complex.normSq_eq_norm_sq, hc] using Complex.mul_conj c
     simp [hsc]
   refine ⟨isIrreducibleTensor_smul hc_ne A hA.irreducible,
     leftCanonical_smul_of_norm_one c hc A hA.leftCanonical,


### PR DESCRIPTION
### Motivation

- The unit-norm phase proofs in `leftCanonical_smul_of_norm_one` and `isPeriodic_smul_of_norm_one` previously used manual conjugation bridge steps (`starRingEnd_apply` / `Complex.conj_mul'`, `Complex.mul_conj'`) to establish that a unit-norm complex scalar satisfies `star c * c = 1` and `c * starRingEnd ℂ c = 1`.
- Mathlib's `Complex.normSq_eq_conj_mul_self`, `Complex.mul_conj`, and `Complex.normSq_eq_norm_sq` derive these identities directly from `‖c‖ = 1`, removing the intermediate bridge steps.

### Description

- Modified `TNLean/MPS/SharedInfra/Scaling.lean` (3 additions, 2 deletions):
  - `leftCanonical_smul_of_norm_one`: the step `star c * c = 1` is now derived via `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq`, replacing the previous `starRingEnd_apply` / `Complex.conj_mul'` path.
  - `isPeriodic_smul_of_norm_one`: the step `c * starRingEnd ℂ c = 1` now uses `Complex.mul_conj` with a norm-square simp lemma, replacing `Complex.mul_conj'` plus simp.
- Theorem statements and all downstream uses are unchanged; this is a proof-internal change only.

### Testing

- `lake build TNLean.MPS.SharedInfra.Scaling -q --log-level=info`
- Added-line proof-integrity blocker scan: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
_No linked issue found. Please link a corresponding issue manually._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in MPS scaling lemmas; no changes to theorem statements or runtime behavior.
>
> **Overview**
> Refactors two proof steps in **`TNLean/MPS/SharedInfra/Scaling.lean`** so unit-norm phase arguments use Mathlib's **norm-square** API instead of manual conjugation rewrites.
>
> In **`leftCanonical_smul_of_norm_one`**, showing `(star c) * c = 1` now goes through **`Complex.normSq_eq_conj_mul_self`** and **`Complex.normSq_eq_norm_sq`** with `‖c‖ = 1`, instead of **`starRingEnd_apply`** / **`Complex.conj_mul'`**.
>
> In **`isPeriodic_smul_of_norm_one`**, the transfer-map step uses **`Complex.mul_conj`** with the same norm-square simp, replacing **`Complex.mul_conj'`** plus simp.
>
> **Theorem statements and downstream uses are unchanged**—only proof style.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e81084d97e164305ab7d52e3debd4bec6c9a9f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>