### PR TITLE
refactor(Algebra): use native complex norm-square identities

### DIFF
--- a/TNLean/Algebra/UnitModulusPowerSum.lean
+++ b/TNLean/Algebra/UnitModulusPowerSum.lean
@@ -174,9 +174,8 @@ theorem unitModulus_power_sum_not_tendsto_zero
         = ∑ p : Fin r × Fin r, (μ p.1 * star (μ p.2)) ^ N := by
     intro N
     have hnormSq : ((‖S N‖ ^ 2 : ℝ) : ℂ) = S N * star (S N) := by
-      rw [show star (S N) = (starRingEnd ℂ) (S N) from rfl]
-      push_cast
-      exact (Complex.mul_conj' (S N)).symm
+      rw [← Complex.normSq_eq_norm_sq (S N)]
+      simpa using (Complex.mul_conj (S N)).symm
     rw [hnormSq, hS_def]
     -- S N = ∑_q μ_q^N; star (S N) = ∑_q' star (μ_q')^N
     have hStar : star (∑ q : Fin r, (μ q) ^ N)
@@ -208,7 +207,7 @@ theorem unitModulus_power_sum_not_tendsto_zero
     intro p hp
     rcases Finset.mem_image.mp hp with ⟨q, _, rfl⟩
     have hμq_sq : μ q * star (μ q) = 1 := by
-      rw [show star (μ q) = (starRingEnd ℂ) (μ q) from rfl, Complex.mul_conj', hμ q]; simp
+      simpa [Complex.normSq_eq_norm_sq, hμ q] using Complex.mul_conj (μ q)
     exact Finset.mem_filter.mpr ⟨Finset.mem_univ _, hμq_sq⟩
   have hDiag_card : (Finset.univ.image (fun q : Fin r => (q, q))).card = r := by
     rw [Finset.card_image_of_injective _ (fun a b h => (Prod.mk.inj h).1)]


### PR DESCRIPTION
### Motivation

- The Cesaro power-sum proof in `TNLean/Algebra/UnitModulusPowerSum.lean` used
  `starRingEnd` and `Complex.mul_conj'` bridge steps to relate ‖S N‖² to
  `S N * star (S N)` and conclude `μ q * star (μ q) = 1`. These intermediate
  steps are subsumed by Mathlib lemmas `Complex.normSq_eq_norm_sq` and
  `Complex.mul_conj`, which express the same identities directly and are
  already used elsewhere in MPS overlap code.

### Description

- Modified `TNLean/Algebra/UnitModulusPowerSum.lean` (+3 / −4 lines): replaced
  two explicit conjugation-to-norm-square steps in the proof of
  `unitModulus_power_sum_not_tendsto_zero` with `simpa` applications of
  `Complex.mul_conj` and `Complex.normSq_eq_norm_sq`. The `hnormSq` step
  (relating ‖S N‖² to `S N * star (S N)`) and the diagonal
  `μ q * star (μ q) = 1` fact are now derived from these Mathlib lemmas.
  The theorem statement and overall Cesaro analytic argument are unchanged.

### Testing

- `lake build TNLean.Algebra.UnitModulusPowerSum -q --log-level=info`
- `git diff --check`
- Proof-integrity blocker scan for `sorry`, `axiom`, `admit`, `native_decide`,
  `unsafeCast` on added lines.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one analytic lemma with no API or behavioral changes; risk is limited to whether the new rewrites remain Mathlib-compatible.
>
> **Overview**
> In **`TNLean/Algebra/UnitModulusPowerSum.lean`**, two proof steps in the Cesaro argument for **`unitModulus_power_sum_not_tendsto_zero`** are rewritten to use Mathlib's **`Complex.normSq_eq_norm_sq`** and **`Complex.mul_conj`** instead of explicit **`starRingEnd`** / **`Complex.mul_conj'`** rewrites.
>
> The **`hnormSq`** step (linking **`‖S N‖²`** to **`S N * star (S N)`**) and the diagonal **`μ q * star (μ q) = 1`** fact now **`simpa`** from those lemmas. The theorem statement and overall proof structure are unchanged; this matches how other MPS overlap code already handles conjugate–norm-square identities.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5bc096a8e0e4591b3950f855ca60f69f2c099d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->