### PR TITLE
refactor(Peripheral): use norm-square for primitive roots

### DIFF
--- a/TNLean/Channel/Peripheral/CyclicDecomposition/CyclicProjections.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/CyclicProjections.lean
@@ -41,7 +41,8 @@ private lemma star_mul_self_of_primitiveRoot {γ : ℂ} (hγprim : IsPrimitiveRo
     star γ * γ = 1 := by
   have hγ_norm : ‖γ‖ = 1 :=
     Complex.norm_eq_one_of_pow_eq_one hγprim.pow_eq_one (NeZero.ne m)
-  rw [← starRingEnd_apply, Complex.conj_mul', hγ_norm]; simp
+  simpa [Complex.normSq_eq_norm_sq, hγ_norm] using
+    (Complex.normSq_eq_conj_mul_self (z := γ)).symm
 
 /-- A primitive root has unit modulus, written as `γ * star γ = 1`. -/
 private lemma self_mul_star_of_primitiveRoot {γ : ℂ} (hγprim : IsPrimitiveRoot γ m) :


### PR DESCRIPTION
### Motivation
- The proof of `star_mul_self_of_primitiveRoot` established `star γ * γ = 1` for a complex primitive root `γ` with `‖γ‖ = 1` by passing through `starRingEnd` and `Complex.conj_mul'`. Mathlib's `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq` provide a more direct path via the norm-square identity, eliminating the intermediate conjugation step.

### Description
- Modified `TNLean/Channel/Peripheral/CyclicDecomposition/CyclicProjections.lean` (proof of `star_mul_self_of_primitiveRoot`).
- After deriving `‖γ‖ = 1` from `Complex.norm_eq_one_of_pow_eq_one`, the conclusion `star γ * γ = 1` is now obtained by `simpa` on `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq` in place of the former path through `starRingEnd` and `Complex.conj_mul'`.
- No statement changes; the type signature of `star_mul_self_of_primitiveRoot` and all downstream lemmas are unchanged.

### Testing
- `lake build TNLean.Channel.Peripheral.CyclicDecomposition.CyclicProjections -q --log-level=info`
- Proof-integrity blocker scan on added lines for `sorry`, `axiom`, `admit`, `native_decide`, and `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
<!-- No linked issue identified — author should add `Addresses #N` once the relevant issue is known. -->

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor of a private helper with no statement or API changes.
>
> **Overview**
> The proof of **`star_mul_self_of_primitiveRoot`** in `CyclicProjections.lean` is refactored to use Mathlib's complex norm-square identities instead of a hand-rolled conjugation argument.
>
> After `‖γ‖ = 1` from `Complex.norm_eq_one_of_pow_eq_one`, the old step via `starRingEnd` and `Complex.conj_mul'` is replaced by `simpa` on `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq`. The lemma still concludes `star γ * γ = 1`; downstream lemmas are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b59101338fa894aa6f7b7d44efc2d3fd6b9cb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->