### PR TITLE
refactor(Peripheral): use norm-square in eigenvector closure

### DIFF
--- a/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
+++ b/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
@@ -76,8 +76,9 @@ theorem isUnit_peripheral_eigenvector
         = (KadisonSchwarz.krausMap (d := d) (D := D) K X)ᴴ
             * KadisonSchwarz.krausMap (d := d) (D := D) K X := by
     simpa [Kraus.map, KadisonSchwarz.krausMap] using hKS_map
-  have hμ_star_mul : star μ * μ = 1 := by
-    rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp
+  have hμ_starRingEnd_mul : ((starRingEnd ℂ) μ) * μ = 1 := by
+    simpa [Complex.normSq_eq_norm_sq, hμ] using
+      (Complex.normSq_eq_conj_mul_self (z := μ)).symm
   have hfix_kraus : KadisonSchwarz.krausMap (d := d) (D := D) K (Xᴴ * X) = Xᴴ * X := by
     calc
       KadisonSchwarz.krausMap (d := d) (D := D) K (Xᴴ * X)
@@ -87,8 +88,6 @@ theorem isUnit_peripheral_eigenvector
       _ = (star μ * μ) • (Xᴴ * X) := by
             simp [conjTranspose_smul, smul_smul, mul_comm]
       _ = Xᴴ * X := by
-            have hμ_starRingEnd_mul : ((starRingEnd ℂ) μ) * μ = 1 := by
-              simpa [Complex.star_def] using hμ_star_mul
             simp [hμ_starRingEnd_mul]
   have hfix_transfer : MPSTensor.transferMap (d := d) (D := D) K (Xᴴ * X) = Xᴴ * X := by
     simpa [MPSTensor.transferMap_apply, KadisonSchwarz.krausMap] using hfix_kraus


### PR DESCRIPTION
### Motivation
- The proof of `isUnit_peripheral_eigenvector` in `Channel/Peripheral/ClosureFixedPoint.lean` used a local witness for `conj(μ) * μ = 1` derived via `conj_mul'` and `starRingEnd_apply`. Mathlib's `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq` supply this identity directly from `‖μ‖ = 1`, making the local derivation redundant.

### Description
- Modified `TNLean/Channel/Peripheral/ClosureFixedPoint.lean` (3 additions, 4 deletions).
- In `isUnit_peripheral_eigenvector`: introduces `((starRingEnd ℂ) μ) * μ = 1` once before the fixed-point `calc` using `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq` together with `‖μ‖ = 1`, replacing the nested inner proof in the final simplification step that used `conj_mul'` and `starRingEnd_apply`.
- The theorem statement and channel-theoretic argument are unchanged.

### Testing
- `lake build TNLean.Channel.Peripheral.ClosureFixedPoint -q --log-level=info`
- Proof-integrity scan on added lines: no `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single lemma; no API or behavioral changes.
>
> **Overview**
> In **`isUnit_peripheral_eigenvector`** (`ClosureFixedPoint.lean`), the step that peripheral eigenvalues on the unit circle give **`conj(μ) * μ = 1`** is reworked to use Mathlib's **`Complex.normSq_eq_conj_mul_self`** and **`Complex.normSq_eq_norm_sq`** with **`‖μ‖ = 1`**, instead of a local **`star μ * μ`** argument via **`conj_mul'`** and **`starRingEnd_apply`**.
>
> The witness is introduced once as **`((starRingEnd ℂ) μ) * μ = 1`** before the fixed-point **`calc`**, and the inner nested proof in the last simplification step is removed. **Theorem statements and the channel argument are unchanged.**
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b6ea273fd29b1282fa2387a72137d7be32c2c24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->