### PR TITLE
refactor(Spectral): use Complex.norm_conj directly

### DIFF
--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -170,11 +170,6 @@ theorem isInjective_conjugate {D : ℕ}
       _ = ⊤ := by rw [Submodule.map_top]; exact LinearMap.range_eq_top.2 hφ_surj
   exact this
 
-/-- Complex conjugation preserves unit modulus. -/
-lemma norm_starRingEnd_eq_one {μ : ℂ} (hμ : ‖μ‖ = 1) :
-    ‖(starRingEnd ℂ) μ‖ = 1 := by
-  simpa [Complex.norm_conj] using hμ
-
 /-- Scalar multiplication by a unit-modulus complex number preserves `N * Nᴴ`. -/
 lemma smul_mul_conjTranspose_of_norm_eq_one {m n : ℕ}
     (μ : ℂ) (hμ : ‖μ‖ = 1) (N : Matrix (Fin m) (Fin n) ℂ) :
@@ -375,7 +370,8 @@ theorem gauged_intertwining_core
         Matrix.fromBlocks_smul]
     have h_eq := hL ▸ hR ▸ h'
     exact (Matrix.fromBlocks_inj.1 h_eq).2.1
-  have hμ_conj : ‖(starRingEnd ℂ) μ‖ = 1 := norm_starRingEnd_eq_one hμ
+  have hμ_conj : ‖(starRingEnd ℂ) μ‖ = 1 := by
+    simpa [Complex.norm_conj] using hμ
   have hEigMstar : Kraus.map K Mᴴ = (starRingEnd ℂ μ) • Mᴴ := by
     calc
       Kraus.map K Mᴴ = (Kraus.map K M)ᴴ := by

--- a/TNLean/Spectral/GaugeConstruction.lean
+++ b/TNLean/Spectral/GaugeConstruction.lean
@@ -170,19 +170,6 @@ theorem isInjective_conjugate {D : ℕ}
       _ = ⊤ := by rw [Submodule.map_top]; exact LinearMap.range_eq_top.2 hφ_surj
   exact this
 
-/-- Scalar multiplication by a unit-modulus complex number preserves `N * Nᴴ`. -/
-lemma smul_mul_conjTranspose_of_norm_eq_one {m n : ℕ}
-    (μ : ℂ) (hμ : ‖μ‖ = 1) (N : Matrix (Fin m) (Fin n) ℂ) :
-    (μ • N) * (μ • N)ᴴ = N * Nᴴ := by
-  have hμ_star_mul : star μ * μ = 1 := by
-    rw [← starRingEnd_apply, Complex.conj_mul', hμ]; simp
-  calc
-    (μ • N) * (μ • N)ᴴ = (star μ * μ) • (N * Nᴴ) := by
-      simp only [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul]
-    _ = N * Nᴴ := by
-      rw [hμ_star_mul]
-      simp only [one_smul]
-
 /-- Shared block-KS core: transporting a modulus-one mixed-transfer eigenvector to canonical
 gauges produces Kraus-level intertwining relations for the gauged tensors. -/
 theorem gauged_intertwining_core
@@ -422,6 +409,9 @@ theorem self_mul_conjTranspose_fixed_of_intertwining
     (hInter : ∀ i : Fin d, A i * X = μ • X * B i)
     (hμ : ‖μ‖ = 1) :
     transferMap A (X * Xᴴ) = X * Xᴴ := by
+  have hμ_star_mul : star μ * μ = 1 := by
+    simpa [Complex.normSq_eq_norm_sq, hμ] using
+      (Complex.normSq_eq_conj_mul_self (z := μ)).symm
   have hterm :
       ∀ i : Fin d, A i * (X * Xᴴ) * (A i)ᴴ = X * (B i * (B i)ᴴ) * Xᴴ := by
     intro i
@@ -433,7 +423,14 @@ theorem self_mul_conjTranspose_fixed_of_intertwining
       _ = (μ • (X * B i)) * (μ • (X * B i))ᴴ := by
         simp only [hAX]
       _ = (X * B i) * (X * B i)ᴴ := by
-        simpa using smul_mul_conjTranspose_of_norm_eq_one μ hμ (X * B i)
+        calc
+          (μ • (X * B i)) * (μ • (X * B i))ᴴ =
+              (star μ * μ) • ((X * B i) * (X * B i)ᴴ) := by
+                simp only [Matrix.conjTranspose_smul, Matrix.smul_mul, Matrix.mul_smul,
+                  smul_smul]
+          _ = (X * B i) * (X * B i)ᴴ := by
+                rw [hμ_star_mul]
+                simp only [one_smul]
       _ = X * (B i * (B i)ᴴ) * Xᴴ := by
         simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
   calc

--- a/TNLean/Spectral/TransferOperatorGapNT.lean
+++ b/TNLean/Spectral/TransferOperatorGapNT.lean
@@ -401,7 +401,8 @@ private lemma exists_gram_fixedPoints_of_gauged_rectangular_intertwiner
       transferMap (d := d) (D := D₁) A' σA = σA ∧
       transferMap (d := d) (D := D₂) B' σB = σB := by
   classical
-  have hμ_conj : ‖(starRingEnd ℂ) μ‖ = 1 := norm_starRingEnd_eq_one hμ
+  have hμ_conj : ‖(starRingEnd ℂ) μ‖ = 1 := by
+    simpa [Complex.norm_conj] using hμ
   have hInter1c : ∀ i : Fin d, B' i * X'ᴴ = (starRingEnd ℂ μ) • X'ᴴ * A' i := by
     intro i
     have h22 := congrArg Matrix.conjTranspose (hInter1 i)


### PR DESCRIPTION
## Summary

This PR removes two local pass-through lemmas whose proofs are now clearer when expressed directly with Mathlib complex-conjugation and norm-square lemmas.

- remove `norm_starRingEnd_eq_one` and use `Complex.norm_conj` at the two call sites
- remove the one-use `smul_mul_conjTranspose_of_norm_eq_one` wrapper and inline the unit-modulus scalar calculation through `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq`

The mathematical statements are unchanged; the local proofs now expose the standard complex identities being used.

## Checks

- `lake build TNLean.Spectral.GaugeConstruction TNLean.Spectral.TransferOperatorGapNT -q --log-level=info`
- `rg -n "norm_starRingEnd_eq_one|smul_mul_conjTranspose_of_norm_eq_one" TNLean`
- `git diff --check`
- `git diff -U0 -- TNLean docs blueprint | rg "^\+.*\b(sorry|axiom|admit|native_decide|unsafeCast)\b"`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in spectral gauge construction; no API or mathematical statement changes.
> 
> **Overview**
> **GaugeConstruction** drops the local lemmas `norm_starRingEnd_eq_one` and `smul_mul_conjTranspose_of_norm_eq_one`. Where proofs needed `‖(starRingEnd ℂ) μ‖ = 1`, they now use `simpa [Complex.norm_conj] using hμ`. In `self_mul_conjTranspose_fixed_of_intertwining`, the scalar conjugate-transpose collapse is inlined via `Complex.normSq_eq_conj_mul_self` and a short `calc` instead of the removed helper.
> 
> **TransferOperatorGapNT** applies the same inline `Complex.norm_conj` pattern for the conjugate eigenvalue norm in `exists_gram_fixedPoints_of_gauged_rectangular_intertwiner`.
> 
> No theorem statements or hypotheses change—only proof paths and less duplicated Mathlib facts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752d68c36b069be5209a2f42a8af8a0543a9b5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->