### PR TITLE
refactor(Determinant): use native complex norm-square identity

### DIFF
--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -156,8 +156,8 @@ private lemma matrix_det_norm_one_trace_conjTranspose_mul_self_ge [NeZero d]
     change Matrix.det (Aᴴ * A) = 1
     rw [Matrix.det_mul, Matrix.det_conjTranspose]
     have hconj : star A.det * A.det = ((‖A.det‖ ^ 2 : ℝ) : ℂ) := by
-      simpa only [show star A.det = starRingEnd ℂ A.det from rfl, ← Complex.ofReal_pow] using
-        (Complex.conj_mul' A.det)
+      simpa [Complex.star_def, Complex.normSq_eq_norm_sq] using
+        (Complex.normSq_eq_conj_mul_self (z := A.det)).symm
     rw [hconj, hdet]
     norm_num
   have hprod_eq : ∏ i, hBherm.eigenvalues i = 1 := by


### PR DESCRIPTION
### Motivation

- The proof of `channelDet_norm_one_hs_norm_ge` (the AM–GM lower bound on the Hilbert–Schmidt norm under determinant saturation) rewrote `star A.det * A.det` as `‖A.det‖²` via `starRingEnd` and `Complex.conj_mul'`.
- Mathlib 4.31 provides `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq`, which express the same identity more directly and consistently with the norm-square style used elsewhere in TNLean.

### Description

- `TNLean/Channel/Determinant/HilbertSchmidt.lean`: 2-line proof edit in the internal auxiliary lemma `channelDet_norm_one_hs_norm_ge`.
- The rewrite path through `starRingEnd` / `Complex.conj_mul'` is replaced by `Complex.normSq_eq_conj_mul_self` (symmetrized) together with `Complex.normSq_eq_norm_sq`.
- No definitions, lemma statements, or mathematical content are changed.

### Testing

- `lake build TNLean.Channel.Determinant.HilbertSchmidt -q --log-level=info`
- Diff scanned for new `sorry`/`axiom`/`admit`/`native_decide`/`unsafeCast` — none introduced.
- Lean CI (`lean_action_ci.yml`) validates the full build on merge.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a private auxiliary lemma; no API or mathematical statement changes.
> 
> **Overview**
> In **`matrix_det_norm_one_trace_conjTranspose_mul_self_ge`**, the step that rewrites **`star A.det * A.det`** as **`‖A.det‖²`** no longer goes through **`starRingEnd`** and **`Complex.conj_mul'`**.
> 
> It now closes via **`Complex.normSq_eq_conj_mul_self`** (symmetrized) and **`Complex.normSq_eq_norm_sq`**, matching the norm-square style used elsewhere in TNLean. The rest of the AM–GM / trace argument is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8c754b683bc64f3ae27bd4ff5abf60d8aa2a112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>