### PR TITLE
refactor(Channel): use native norm-square in ordered CP

### DIFF
--- a/TNLean/Channel/OrderedCP.lean
+++ b/TNLean/Channel/OrderedCP.lean
@@ -223,8 +223,8 @@ theorem Matrix.blockTopRows_conjTranspose_mul_le_one (r s : ℕ) :
     · simp only [hjr, if_false]
       change 0 ≤ star (x j) * x j
       have hsq : star (x j) * x j = ((‖x j‖ : ℝ) ^ 2 : ℂ) := by
-        rw [show star (x j) = starRingEnd ℂ (x j) from rfl, RCLike.conj_mul]
-        norm_cast
+        simpa [Complex.star_def, Complex.normSq_eq_norm_sq] using
+          (Complex.normSq_eq_conj_mul_self (z := x j)).symm
       rw [hsq]
       exact_mod_cast sq_nonneg ‖x j‖
 


### PR DESCRIPTION
### Motivation
- The proof of `Matrix.blockTopRows_conjTranspose_mul_le_one` in `Channel/OrderedCP.lean` showed `star (x j) * x j` is nonneg by rewriting through `starRingEnd` then applying `RCLike.conj_mul`, which is indirect.
- Mathlib 4.31 provides `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq` as direct identities for complex norm-squares, making the intent explicit and consistent with how other channel proofs handle this step.

### Description
- `TNLean/Channel/OrderedCP.lean` (2 lines changed): in the ordered-CP auxiliary proof, replace the `starRingEnd`/`RCLike.conj_mul` rewrite sequence with `Complex.normSq_eq_conj_mul_self` and `Complex.normSq_eq_norm_sq`.
- The lemma statement and all surrounding ordered-CP development are unchanged; this is a proof-only refactor.

### Testing
- `lake build TNLean.Channel.OrderedCP -q --log-level=info`
- `git diff -U0 -- TNLean docs blueprint | rg "^\+.*\b(sorry|axiom|admit|native_decide|unsafeCast)\b"` (no new proof-integrity blockers)
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
No linked issue identified — the branch name `codex/mathlib-4-31-native-pass-88` does not match a GitHub issue number. Please link an issue manually if one exists.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a PSD auxiliary lemma; no API or mathematical statement changes.
> 
> **Overview**
> In **`Matrix.blockTopRows_conjTranspose_mul_le_one`**, the step that shows `star (x j) * x j` is nonnegative no longer goes through `starRingEnd` and **`RCLike.conj_mul`**.
> 
> The proof now derives the same equality via **`Complex.normSq_eq_conj_mul_self`** and **`Complex.normSq_eq_norm_sq`**, matching how other channel proofs handle complex norm squares. The lemma statement and the rest of the ordered-CP development are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3951959f6fc6914fb0dde3adbb9c6c17312db5ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>