### PR TITLE
refactor(MPS): share cross-overlap phase scaling

### DIFF
--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -321,8 +321,8 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
     have hCross_eq : ∀ N : ℕ,
         mpvOverlap (d := d) (B j1) (B j2) N =
         (ζ1 * star ζ2) ^ N *
-          mpvOverlap (d := d) (A (f j1)) (A (f j1)) N := by
-      exact mpvOverlap_cross_scale_of_mpv_eq_pow_mul
+          mpvOverlap (d := d) (A (f j1)) (A (f j1)) N :=
+      mpvOverlap_cross_scale_of_mpv_eq_pow_mul
         (A := A (f j1)) (B1 := B j1) (B2 := B j2) (ζ1 := ζ1) (ζ2 := ζ2)
         hmpv1 hmpv2
     --

--- a/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
+++ b/TNLean/MPS/BNT/PermutationRigidityPrimitive.lean
@@ -320,29 +320,25 @@ theorem exists_perm_dimEq_gaugePhaseEquiv_of_overlapOrtho
     -- Cross overlap.
     have hCross_eq : ∀ N : ℕ,
         mpvOverlap (d := d) (B j1) (B j2) N =
-        (ζ1 * starRingEnd ℂ ζ2) ^ N *
+        (ζ1 * star ζ2) ^ N *
           mpvOverlap (d := d) (A (f j1)) (A (f j1)) N := by
-      intro N
-      simp only [mpvOverlap]
-      simp_rw [hmpv1 N, hmpv2 N, star_mul, star_pow]
-      simp_rw [show star ζ2 = starRingEnd ℂ ζ2 from rfl]
-      simp_rw [show ∀ (x : Cfg d N),
-        ζ1 ^ N * mpv (A (f j1)) x * (star (mpv (A (f j1)) x) * (starRingEnd ℂ ζ2) ^ N) =
-        ζ1 ^ N * (starRingEnd ℂ ζ2) ^ N * (mpv (A (f j1)) x * star (mpv (A (f j1)) x)) from
-        fun x => by ring]
-      rw [← Finset.mul_sum, mul_pow]
+      exact mpvOverlap_cross_scale_of_mpv_eq_pow_mul
+        (A := A (f j1)) (B1 := B j1) (B2 := B j2) (ζ1 := ζ1) (ζ2 := ζ2)
+        hmpv1 hmpv2
     --
-    have hNormζ : ‖ζ1 * starRingEnd ℂ ζ2‖ = 1 := by
-      rw [norm_mul, RCLike.norm_conj, hζ1_norm, hζ2_norm, mul_one]
+    have hNormζ : ‖ζ1 * star ζ2‖ = 1 := by
+      have hζ2_star : ‖star ζ2‖ = ‖ζ2‖ := by
+        simp
+      rw [norm_mul, hζ2_star, hζ1_norm, hζ2_norm, mul_one]
     --
     have hCross_norm_one :
         Tendsto (fun N => ‖mpvOverlap (d := d) (B j1) (B j2) N‖) atTop (nhds 1) := by
       have heq : (fun N => ‖mpvOverlap (d := d) (B j1) (B j2) N‖) =
-          fun N => ‖(ζ1 * starRingEnd ℂ ζ2) ^ N‖ *
+          fun N => ‖(ζ1 * star ζ2) ^ N‖ *
             ‖mpvOverlap (d := d) (A (f j1)) (A (f j1)) N‖ := by
         ext N; rw [hCross_eq, norm_mul]
       rw [heq]
-      have : (fun N => ‖(ζ1 * starRingEnd ℂ ζ2) ^ N‖ *
+      have : (fun N => ‖(ζ1 * star ζ2) ^ N‖ *
           ‖mpvOverlap (d := d) (A (f j1)) (A (f j1)) N‖) =
           fun N => 1 * ‖mpvOverlap (d := d) (A (f j1)) (A (f j1)) N‖ := by
         ext N; rw [norm_pow, hNormζ, one_pow]

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -84,6 +84,27 @@ theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul
       fun x => by ring]
   rw [← Finset.mul_sum, mul_pow]
 
+/-- If two matrix-product vector families are obtained from a common family by
+length-dependent phases, then their mixed overlap scales by the corresponding
+relative phase. -/
+theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul
+    {D D1 D2 : ℕ} {A : MPSTensor d D} {B1 : MPSTensor d D1} {B2 : MPSTensor d D2}
+    {ζ1 ζ2 : ℂ}
+    (hmpv1 : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B1 σ = ζ1 ^ N * mpv A σ)
+    (hmpv2 : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B2 σ = ζ2 ^ N * mpv A σ) :
+    ∀ N : ℕ,
+      mpvOverlap (d := d) B1 B2 N =
+        (ζ1 * star ζ2) ^ N * mpvOverlap (d := d) A A N := by
+  intro N
+  classical
+  simp only [mpvOverlap]
+  simp_rw [hmpv1 N, hmpv2 N, star_mul, star_pow]
+  simp_rw [show ∀ x : Cfg d N,
+      ζ1 ^ N * mpv A x * (star (mpv A x) * (star ζ2) ^ N) =
+        ζ1 ^ N * (star ζ2) ^ N * (mpv A x * star (mpv A x)) from
+      fun x => by ring]
+  rw [← Finset.mul_sum, mul_pow]
+
 /-- If all matrix-product amplitudes of `B` are obtained from those of `A` by the
 length-dependent phase `ζ ^ N`, then the mixed overlap with `A` is
 `(conj ζ) ^ N` times the self-overlap of `A`. -/

--- a/TNLean/MPS/SharedInfra/GaugePhase.lean
+++ b/TNLean/MPS/SharedInfra/GaugePhase.lean
@@ -65,28 +65,9 @@ theorem mpv_eq_pow_mul_of_gaugePhase
     _ = ζ ^ N * mpv A σ := by
           simp [mpv, coeff, w, hwlen]
 
-/-- If `mpv B σ = ζ ^ N * mpv A σ` for every system size `N` and configuration `σ`, then the
-self-overlap of `B` scales by `(ζ * conj ζ) ^ N` times the self-overlap of `A`. -/
-theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul
-    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
-    (hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ) :
-    ∀ N : ℕ,
-      mpvOverlap (d := d) B B N =
-        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N := by
-  intro N
-  classical
-  simp only [mpvOverlap]
-  simp_rw [hmpv N, star_mul, star_pow]
-  simp_rw [show star ζ = starRingEnd ℂ ζ from rfl]
-  simp_rw [show ∀ x : Cfg d N,
-      ζ ^ N * mpv A x * (star (mpv A x) * (starRingEnd ℂ ζ) ^ N) =
-        ζ ^ N * (starRingEnd ℂ ζ) ^ N * (mpv A x * star (mpv A x)) from
-      fun x => by ring]
-  rw [← Finset.mul_sum, mul_pow]
-
 /-- If two matrix-product vector families are obtained from a common family by
-length-dependent phases, then their mixed overlap scales by the corresponding
-relative phase. -/
+length-dependent phases `ζ1 ^ N` and `ζ2 ^ N`, then their mixed overlap is
+`(ζ1 * conj ζ2) ^ N` times the self-overlap of the common family. -/
 theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul
     {D D1 D2 : ℕ} {A : MPSTensor d D} {B1 : MPSTensor d D1} {B2 : MPSTensor d D2}
     {ζ1 ζ2 : ℂ}
@@ -104,6 +85,18 @@ theorem mpvOverlap_cross_scale_of_mpv_eq_pow_mul
         ζ1 ^ N * (star ζ2) ^ N * (mpv A x * star (mpv A x)) from
       fun x => by ring]
   rw [← Finset.mul_sum, mul_pow]
+
+/-- If `mpv B σ = ζ ^ N * mpv A σ` for every system size `N` and configuration `σ`, then the
+self-overlap of `B` scales by `(ζ * conj ζ) ^ N` times the self-overlap of `A`. -/
+theorem mpvOverlap_self_scale_of_mpv_eq_pow_mul
+    {D D' : ℕ} {A : MPSTensor d D} {B : MPSTensor d D'} {ζ : ℂ}
+    (hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv B σ = ζ ^ N * mpv A σ) :
+    ∀ N : ℕ,
+      mpvOverlap (d := d) B B N =
+        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) A A N := by
+  simpa using
+    (mpvOverlap_cross_scale_of_mpv_eq_pow_mul
+      (A := A) (B1 := B) (B2 := B) (ζ1 := ζ) (ζ2 := ζ) hmpv hmpv)
 
 /-- If all matrix-product amplitudes of `B` are obtained from those of `A` by the
 length-dependent phase `ζ ^ N`, then the mixed overlap with `A` is


### PR DESCRIPTION
### Motivation

- The primitive BNT permutation-rigidity proof contained an inline scalar expansion for the mixed-overlap phase that duplicated the self-overlap scaling pattern already present in `GaugePhase.lean`.
- Consolidating this into a shared lemma keeps the phase-scaling identity in one location.

### Description

- `TNLean/MPS/SharedInfra/GaugePhase.lean`: adds `MPSTensor.mpvOverlap_cross_scale_of_mpv_eq_pow_mul`, the mixed-overlap analogue of the existing self-overlap phase-scaling lemma. When two families satisfy `mpv A = ζ₁^N · v` and `mpv B = ζ₂^N · v` for a common amplitude vector `v`, the cross-overlap scales as `(ζ₁ · star ζ₂)^N` times the reference self-overlap.
- `TNLean/MPS/BNT/PermutationRigidityPrimitive.lean`: replaces the inline expansion in the injectivity step with a call to the new shared lemma; the local phase is now stated using `star ζ` instead of `starRingEnd`.
- Mathematical statements are unchanged.

### Testing

- `lake build TNLean.MPS.SharedInfra.GaugePhase TNLean.MPS.BNT.PermutationRigidityPrimitive -q --log-level=info`
- No new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced (verified via `git diff -U0 -- TNLean docs blueprint | rg "^\+.*\b(sorry|axiom|admit|native_decide|unsafeCast)\b"`).
- Reader-facing prose and blueprint–Lean sync checked via project scripts.
- Lean CI (`lean_action_ci.yml`) validates the full build on push.

---
No linked issue identified — the PR author should link one manually.

> [!NOTE]
> **Low Risk**
> Proof refactor only: logic is moved to a shared lemma with equivalent statements; no auth, data, or runtime behavior changes.
> 
> **Overview**
> Extracts the **mixed MPV overlap** phase-scaling identity into shared gauge-phase infrastructure and reuses it in primitive BNT permutation rigidity.
> 
> Adds `mpvOverlap_cross_scale_of_mpv_eq_pow_mul` in `GaugePhase.lean`: when two families are `ζ1^N` and `ζ2^N` times the same underlying amplitudes, their overlap is `(ζ1 * star ζ2)^N` times the common self-overlap. The injectivity step in `PermutationRigidityPrimitive.lean` now calls this lemma instead of an inline `simp`/`ring` block.
> 
> The local cross-overlap and unit-norm arguments use **`star ζ2`** rather than spelling conjugation via `starRingEnd`. **No change to the mathematical statements.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b924e87b657cb4e7ed7aceb64ff361dfdf5cc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with equivalent statements; no runtime, auth, or data-path changes.
> 
> **Overview**
> Moves the **mixed MPV overlap** phase-scaling identity into `GaugePhase.lean` and reuses it in primitive BNT permutation rigidity.
> 
> Adds **`mpvOverlap_cross_scale_of_mpv_eq_pow_mul`**: when two families are `ζ₁^N` and `ζ₂^N` times the same underlying amplitudes, their cross-overlap is `(ζ₁ * star ζ₂)^N` times the reference self-overlap. **`mpvOverlap_self_scale_of_mpv_eq_pow_mul`** is now a one-line specialization of that lemma instead of duplicating the `simp`/`ring` proof.
> 
> In **`PermutationRigidityPrimitive.lean`**, the injectivity step’s cross-overlap identity and unit-norm argument call the shared lemma and use **`star ζ₂`** rather than `starRingEnd`. **Mathematical content is unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424e8ec8d3d5ba0c2f31ba4c0b1fa231f72e6f4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->