### PR TITLE
refactor(Semigroup): inline scalar norm rewrite

### DIFF
--- a/TNLean/Channel/Semigroup/ProductFormula.lean
+++ b/TNLean/Channel/Semigroup/ProductFormula.lean
@@ -87,9 +87,9 @@ theorem norm_expSemigroupCLM_le [NeZero D]
     (((t : ℂ) • A))
   have habs : |t| = t := abs_of_nonneg ht
   change ‖NormedSpace.exp (((t : ℂ) • A))‖ ≤ Real.exp (t * ‖A‖)
-  have hnorm : ‖((t : ℂ) • A)‖ = t * ‖A‖ := by
-    simp [norm_smul, Real.norm_eq_abs, habs]
-  rwa [← hnorm]
+  rw [show ‖((t : ℂ) • A)‖ = t * ‖A‖ by
+    simp [norm_smul, Real.norm_eq_abs, habs]] at h
+  exact h
 
 /-- A single Lie--Trotter step has the expected operator-norm bound. -/
 theorem norm_trotter_step_le [NeZero D]


### PR DESCRIPTION
### Motivation

- The proof of `norm_expSemigroupCLM_le` in `TNLean/Channel/Semigroup/ProductFormula.lean` introduced an intermediate hypothesis `hnorm : ‖(t : ℂ) • A‖ = t * ‖A‖` whose sole purpose was a single `rwa` rewrite.
- Applying the scalar norm equality inline reduces a separate `have` step to a `rw [...] at h` followed by `exact h`, eliminating the named auxiliary without altering the exponential norm bound `‖exp ((t : ℂ) • A)‖ ≤ Real.exp (t * ‖A‖)`.

### Description

- Modified `TNLean/Channel/Semigroup/ProductFormula.lean`: in the proof of `norm_expSemigroupCLM_le`, removed the intermediate `have hnorm` and the corresponding `rwa [← hnorm]`. The scalar norm identity `‖(t : ℂ) • A‖ = t * ‖A‖` is now established inline via `norm_smul`, `Real.norm_eq_abs`, and `abs_of_nonneg ht`.
- The statement of `norm_expSemigroupCLM_le` and the bound are unchanged.

### Testing

- `lake build TNLean.Channel.Semigroup.ProductFormula -q --log-level=info`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/Channel/Semigroup/ProductFormula.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
No linked issue found; see PR for scope.

> [!NOTE]
> **Low Risk**
> Single proof refactor in an analytic bound lemma; no API, logic, or runtime behavior changes.
>
> **Overview**
> **Proof cleanup only** in `norm_expSemigroupCLM_le` (`ProductFormula.lean`): the one-off equality `‖(t : ℂ) • A‖ = t * ‖A‖` is no longer a separate `have hnorm` followed by `rwa [← hnorm]`.
>
> The same `norm_smul` / `Real.norm_eq_abs` / `abs_of_nonneg ht` rewrite is applied **inline** with `rw [show … by simp …] at h` and `exact h`. The theorem statement and bound are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0a319f885535b0cb307f3abf2e4e92c197f4d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>