### PR TITLE
refactor(SectorBNT): inline phase norm proof inputs

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean
@@ -98,25 +98,17 @@ lemma norm_choose_MPVBlockPhaseEquiv_eq_one
   classical
   have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d),
       mpv Y σ = h.choose ^ N * mpv X σ := h.choose_spec.2
-  have hScale :
-      ∀ N : ℕ,
-        mpvOverlap (d := d) Y Y N =
-          (h.choose * starRingEnd ℂ h.choose) ^ N * mpvOverlap (d := d) X X N :=
-    mpvOverlap_self_scale_of_mpv_eq_pow_mul
-      (A := X) (B := Y) (ζ := h.choose) hmpv
-  have hXX_c : Tendsto (fun N => mpvOverlap (d := d) X X N) atTop (𝓝 (1 : ℂ)) :=
-    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
-      (d := d) (D := DX) X hIrrX hTPX hPrimX
-  have hYY_c : Tendsto (fun N => mpvOverlap (d := d) Y Y N) atTop (𝓝 (1 : ℂ)) :=
-    overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
-      (d := d) (D := DY) Y hIrrY hTPY hPrimY
-  have hXX : Tendsto (fun N => ‖mpvOverlap (d := d) X X N‖) atTop (𝓝 (1 : ℝ)) := by
-    have h1 := hXX_c.norm
-    simpa using h1
-  have hYY : Tendsto (fun N => ‖mpvOverlap (d := d) Y Y N‖) atTop (𝓝 (1 : ℝ)) := by
-    have h1 := hYY_c.norm
-    simpa using h1
-  exact norm_eq_one_of_selfOverlap_scale hXX hYY hScale
+  exact norm_eq_one_of_selfOverlap_scale
+    (by
+      simpa using
+        (overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+          (d := d) (D := DX) X hIrrX hTPX hPrimX).norm)
+    (by
+      simpa using
+        (overlap_tendsto_one_of_peripheralPrimitive_of_irreducible
+          (d := d) (D := DY) Y hIrrY hTPY hPrimY).norm)
+    (mpvOverlap_self_scale_of_mpv_eq_pow_mul
+      (A := X) (B := Y) (ζ := h.choose) hmpv)
 
 /-!
 ### Bond dimensions inside a prepared phase class


### PR DESCRIPTION
### Motivation
- The proof of `norm_choose_MPVBlockPhaseEquiv_eq_one` introduced three named intermediate hypotheses (`hScale`, `hXX_c`/`hYY_c`, `hXX`/`hYY`) that served only to pass the self-overlap limits and the MPV scaling identity to `norm_eq_one_of_selfOverlap_scale`. These bindings added no mathematical content.

### Description
- Modified `TNLean/MPS/FundamentalTheorem/SectorBNT/Supplier.lean`.
- The proof of `norm_choose_MPVBlockPhaseEquiv_eq_one` is reorganized: the self-overlap limits (`.norm` on `overlap_tendsto_one_of_peripheralPrimitive_of_irreducible`) and the MPV scaling identity (`mpvOverlap_self_scale_of_mpv_eq_pow_mul`) are now applied directly to `norm_eq_one_of_selfOverlap_scale`.
- The statement — `‖h.choose‖ = 1` — and all downstream dependencies are unchanged. No new `sorry` or axioms introduced.

### Testing
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.Supplier -q --log-level=info`
- `git diff --check`
- `git diff -U0 -- TNLean docs blueprint | rg "^\+.*\b(sorry|axiom|admit|native_decide|unsafeCast)\b"` (no new proof-integrity violations)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only restructuring in one lemma; no new axioms or behavioral changes.
> 
> **Overview**
> **Refactors** the proof of `norm_choose_MPVBlockPhaseEquiv_eq_one` in `Supplier.lean` so the three inputs to `norm_eq_one_of_selfOverlap_scale` are supplied inline instead of via intermediate `have` bindings (`hScale`, `hXX_c`/`hYY_c`, `hXX`/`hYY`).
> 
> The lemma still concludes `‖h.choose‖ = 1` from the same MPV scaling relation, self-overlap limits (via `.norm` on `overlap_tendsto_one_of_peripheralPrimitive_of_irreducible`), and `mpvOverlap_self_scale_of_mpv_eq_pow_mul`. **No statement or downstream API change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec648bb50e628796dd0b37d27271abf14ca129a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->