### PR TITLE
refactor(MPS/Periodic/Overlap): inline phase norm proof inputs

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -167,17 +167,13 @@ private theorem gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic
   have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin (blockPhysDim d m)),
       mpv Bblk σ = ζ ^ N * mpv Ablk σ :=
     mpv_eq_pow_mul_of_gaugePhase Ablk Bblk X ζ hX
-  have hSelfScale : ∀ N : ℕ,
-      mpvOverlap (d := blockPhysDim d m) Bblk Bblk N =
-        (ζ * starRingEnd ℂ ζ) ^ N *
-          mpvOverlap (d := blockPhysDim d m) Ablk Ablk N :=
-    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := Ablk) (B := Bblk) (ζ := ζ) hmpv
   have hm_norm_ne : ‖(m : ℂ)‖ ≠ 0 := by
     simpa using (Nat.cast_ne_zero.mpr (NeZero.ne m) : (m : ℂ) ≠ 0)
   have hζnorm : ‖ζ‖ = 1 := by
     exact norm_eq_one_of_selfOverlap_scale_at_nonzero_limit
       (A := Ablk) (B := Bblk) (ζ := ζ) hm_norm_ne
-      hA_self.norm hB_self.norm hSelfScale
+      hA_self.norm hB_self.norm
+      (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := Ablk) (B := Bblk) (ζ := ζ) hmpv)
   have hCrossNormEq : ∀ N,
       ‖mpvOverlap (d := blockPhysDim d m) Ablk Bblk N‖ =
         ‖mpvOverlap (d := blockPhysDim d m) Ablk Ablk N‖ := by

--- a/TNLean/MPS/Periodic/Overlap/Case3.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case3.lean
@@ -75,13 +75,10 @@ private lemma overlap_norm_tendsto_one_of_gaugePhase_cast
   obtain ⟨X, ζ, _hζ, hX⟩ := hMatch
   have hmpv : ∀ (N : ℕ) (σ : Fin N → Fin d), mpv CB σ = ζ ^ N * mpv CA σ :=
     mpv_eq_pow_mul_of_gaugePhase CA CB X ζ hX
-  have hSelfScale : ∀ N : ℕ,
-      mpvOverlap (d := d) CB CB N =
-        (ζ * starRingEnd ℂ ζ) ^ N * mpvOverlap (d := d) CA CA N :=
-    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := CA) (B := CB) (ζ := ζ) hmpv
   have hζnorm : ‖ζ‖ = 1 :=
     norm_eq_one_of_selfOverlap_scale (A := CA) (B := CB) (ζ := ζ)
-      (by simpa using hCA_self.norm) (by simpa using hCB_self.norm) hSelfScale
+      (by simpa using hCA_self.norm) (by simpa using hCB_self.norm)
+      (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := CA) (B := CB) (ζ := ζ) hmpv)
   have hCrossNormEq : ∀ N,
       ‖mpvOverlap (d := d) CA CB N‖ = ‖mpvOverlap (d := d) CA CA N‖ := by
     intro N


### PR DESCRIPTION
### Motivation

- The proofs of the Case 2 lemma `gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic`
  and the Case 3 lemma `overlap_norm_tendsto_one_of_gaugePhase_cast` each introduced a
  one-use local hypothesis (`hSelfScale`) to name the self-overlap scaling identity
  `mpvOverlap_self_scale_of_mpv_eq_pow_mul`, then immediately passed it to the corresponding
  phase-norm lemma. Passing the lemma application directly removes this one-use binding.
- No mathematical statements or proof dependencies are changed. This matches the
  direct-argument style already used in the BNT permutation rigidity proofs.

### Description

- `TNLean/MPS/Periodic/Overlap/Case2.lean`: removed the local `hSelfScale` binding in the
  proof of `gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic`; the self-overlap
  scaling lemma `mpvOverlap_self_scale_of_mpv_eq_pow_mul` is now passed directly to
  `norm_eq_one_of_selfOverlap_scale`.
- `TNLean/MPS/Periodic/Overlap/Case3.lean`: removed the local `hSelfScale` binding in the
  proof of `overlap_norm_tendsto_one_of_gaugePhase_cast`; the self-overlap scaling lemma is
  now passed directly to `norm_eq_one_of_selfOverlap_scale_at_nonzero_limit`.
- All lemma signatures, hypotheses, and conclusions are unchanged.
- No new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` markers are introduced.

### Testing

- `lake build TNLean.MPS.Periodic.Overlap.Case2 TNLean.MPS.Periodic.Overlap.Case3 -q --log-level=info`
- `git diff --check`
- No new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` markers in the diff.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-structure refactor only in two Lean lemmas; no API or mathematical statement changes.
>
> **Overview**
> In **Case 2** (`gaugePhase_blockTensor_overlap_not_tendsto_zero_of_periodic`) and **Case 3** (`overlap_norm_tendsto_one_of_gaugePhase_cast`), the proofs no longer introduce a local `hSelfScale` hypothesis for the self-overlap scaling identity. They call **`mpvOverlap_self_scale_of_mpv_eq_pow_mul`** directly as the third argument to **`norm_eq_one_of_selfOverlap_scale`** / **`norm_eq_one_of_selfOverlap_scale_at_nonzero_limit`**.
>
> Behavior and lemma dependencies are unchanged; this only drops a one-use intermediate binding and matches the inline pattern already used elsewhere (e.g. BNT permutation rigidity).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a5a4461c3b621284c7c6529daa50140cc1d9e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>