### PR TITLE
refactor(Semigroup): use scalar commutativity directly

### DIFF
--- a/TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean
@@ -54,9 +54,9 @@ theorem generator_shift_invariance
     simp only [star_mul', Complex.star_def, Complex.conj_I, Complex.conj_ofReal]
   simp only [hmu, RCLike.star_def, one_div, RingHomCompTriple.comp_apply,
     RingHom.id_apply, star_mul', neg_mul, neg_smul, star_inv₀, star_ofNat]
-  have hnorm : ∀ i : Fin r, c i * starRingEnd ℂ (c i) = starRingEnd ℂ (c i) * c i := by
-    intro i; ring
-  simp_rw [hnorm]
+  simp_rw [show ∀ i : Fin r,
+      c i * starRingEnd ℂ (c i) = starRingEnd ℂ (c i) * c i from
+    fun i => mul_comm _ _]
   simp only [smul_smul]
   set A : Matrix (Fin D) (Fin D) ℂ := ∑ x, c x • (ρ * (K x)ᴴ)
   set B : Matrix (Fin D) (Fin D) ℂ := ∑ x, (starRingEnd ℂ (c x)) • (K x * ρ)


### PR DESCRIPTION
### Motivation

- The proof of `generator_shift_invariance` in `TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean` introduced a named auxiliary `hnorm` to hold the identity `∀ i, c i * starRingEnd ℂ (c i) = starRingEnd ℂ (c i) * c i`, proved by `ring`, whose only role was a single `simp_rw [hnorm]` step.
- Applying the commutativity identity inline removes the named intermediate without altering the theorem statement or the surrounding algebraic normalization.

### Description

- Modified `TNLean/Channel/Semigroup/LindbladForm/GKSLTheorem.lean` (3 lines changed): in the proof of `generator_shift_invariance`, replaced the `have hnorm … by intro i; ring` block and `simp_rw [hnorm]` with `simp_rw [show ∀ i : Fin r, c i * starRingEnd ℂ (c i) = starRingEnd ℂ (c i) * c i from fun i => mul_comm _ _]`.
- The statement of `generator_shift_invariance` and the surrounding normalization (`hmu`, `A`/`B`/`S`/`X`, `hScancel`) are unchanged.

### Testing

- `lake build TNLean.Channel.Semigroup.LindbladForm.GKSLTheorem -q --log-level=info`
- `git diff --check`
- No newly added `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` markers in the diff.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
No linked issue found; see PR for scope.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one theorem; no API or runtime behavior changes.
>
> **Overview**
> In **`generator_shift_invariance`** (`GKSLTheorem.lean`), the proof no longer introduces a local **`hnorm`** lemma (`ring` on `c i * star c i = star c i * c i`). That step is folded into **`simp_rw`** with an inline **`show … from fun i => mul_comm _ _`**.
>
> The statement of **`generator_shift_invariance`** and the rest of the normalization ( **`hmu`**, **`A`/`B`/`S`/`X`**, **`hScancel`**, etc.) are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 681475efa45fc2e8b1b21dad769a51ce40a4ea58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>