### PR TITLE
refactor(SectorBNT): inline matched phase scaling

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -58,10 +58,9 @@ theorem IsBNTCanonicalForm.norm_phase_of_matched_mpv
       atTop (𝓝 (1 : ℝ)) := by
     have h1 := (hQ.basis_normalized_self_overlap k).norm
     simpa using h1
-  have hScale :=
-    mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis j) (B := Q.basis k)
-      (ζ := ζ) hmpv
-  exact norm_eq_one_of_selfOverlap_scale (ζ := ζ) hAA hBB hScale
+  exact norm_eq_one_of_selfOverlap_scale (ζ := ζ) hAA hBB
+    (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis j) (B := Q.basis k)
+      (ζ := ζ) hmpv)
 
 /-- **Auxiliary lemma: gauge-phase data gives an MPV-level scalar-power identity with unit phase.**
 

--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean
@@ -412,10 +412,9 @@ theorem ft_sector_bnt_equal_matched_copy_weight_witnessesPos
         atTop (𝓝 (1 : ℝ)) := by
       have h1 := (hQ.basis_normalized_self_overlap k).norm
       simpa using h1
-    have hScale :=
-      mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis (β k)) (B := Q.basis k)
-        (ζ := ζ k) (hMpv k)
-    exact norm_eq_one_of_selfOverlap_scale (ζ := ζ k) hAA hBB hScale
+    exact norm_eq_one_of_selfOverlap_scale (ζ := ζ k) hAA hBB
+      (mpvOverlap_self_scale_of_mpv_eq_pow_mul (A := P.basis (β k)) (B := Q.basis k)
+        (ζ := ζ k) (hMpv k))
   have hζ_ne : ∀ k : Fin Q.basisCount, ζ k ≠ 0 := by
     intro k hzero
     have hnorm := hζ_norm k


### PR DESCRIPTION
### Motivation

- The phase-normalization proofs in `SectorBNT` introduce one-use `hScale` hypothesis bindings that pass `mpvOverlap_self_scale_of_mpv_eq_pow_mul` to `norm_eq_one_of_selfOverlap_scale` via an intermediate local name. These pass-through bindings add indirection without changing the mathematical argument.
- Removing them makes the call pattern consistent with other call sites such as `PermutationRigidityPrimitive`.

### Description

- `TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean`: removes one-use `hScale` binding in `IsBNTCanonicalForm.norm_phase_of_matched_mpv`; `mpvOverlap_self_scale_of_mpv_eq_pow_mul` is now passed directly as the third argument to `norm_eq_one_of_selfOverlap_scale`.
- `TNLean/MPS/FundamentalTheorem/SectorBNT/Fundamental.lean`: removes one-use `hScale` binding in the per-block `hζ_norm` step inside `ft_sector_bnt_equal_matched_copy_weight_witnessesPos`; same direct-argument pattern applied.
- Mathematical statements and phase-normalization arguments are unchanged; no new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` markers introduced.

### Testing

- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.CoeffIdentity TNLean.MPS.FundamentalTheorem.SectorBNT.Fundamental -q --log-level=info`
- `git diff --check`
- Prose check: `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Blueprint sync: `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
_No linked issue found — the branch name `codex/mathlib-4-31-native-pass-94` does not encode an issue number. Please add an `Addresses #N` reference manually._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or mathematical statement changes; behavior is unchanged if the build passes.
>
> **Overview**
> SectorBNT proofs that **‖ζ‖ = 1** from matched MPV scaling no longer introduce a local `hScale` binding. They now call **`norm_eq_one_of_selfOverlap_scale`** with **`mpvOverlap_self_scale_of_mpv_eq_pow_mul`** passed directly as the third argument.
>
> This is done in **`IsBNTCanonicalForm.norm_phase_of_matched_mpv`** (`CoeffIdentity.lean`) and in the per-block **`hζ_norm`** loop inside **`ft_sector_bnt_equal_matched_copy_weight_witnessesPos`** (`Fundamental.lean`). The lemmas and math are unchanged; only the proof layout is flattened to match other call sites (e.g. `PermutationRigidityPrimitive`).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d40d43cd476fb9d3789ad3145fb5053bf171481. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->