### PR TITLE
refactor(Semigroup): use native power lemmas

### DIFF
--- a/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
@@ -38,20 +38,6 @@ theorem semigroup_pow
     rw [hcast, hcomp, ih]
     exact (pow_succ (T t) n).symm
 
-/-- Eigenvector equation for powers of a linear map: if `f v = μ • v` then
-`(f ^ n) v = μ ^ n • v`. -/
-theorem pow_apply_eigenvector
-    {V : Type*} [AddCommGroup V] [Module ℂ V]
-    (f : V →ₗ[ℂ] V) (v : V) (μ : ℂ) (n : ℕ) (hv : f v = μ • v) :
-    (f ^ n) v = μ ^ n • v := by
-  induction n with
-  | zero => simp [pow_zero]
-  | succ n ih =>
-    have hstep : (f ^ (n + 1)) v = (f ^ n) (f v) := by
-      change (f ^ n * f) v = (f ^ n) (f v)
-      rfl
-    rw [hstep, hv, map_smul, ih, smul_smul, pow_succ']
-
 /-- A density matrix is nonzero. -/
 lemma ne_zero_of_mem_densityMatrices' {ρ : Matrix (Fin D) (Fin D) ℂ}
     (hρ : ρ ∈ densityMatrices D) : ρ ≠ 0 := by

--- a/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/Helpers.lean
@@ -382,16 +382,6 @@ theorem peripheral_powers_closed_of_irreducible_channel_with_fixed [NeZero D]
   obtain ⟨hpow_eig, hpow_norm⟩ := hpow n
   exact ⟨heig_bwd (μ ^ n) hpow_eig, hpow_norm⟩
 
-/-- Evaluation of powers after bundling an endomorphism as a continuous linear map. -/
-theorem toContinuousLinearMap_pow_apply [NeZero D]
-    (F : Mat →ₗ[ℂ] Mat) (X : Mat) (n : ℕ) :
-    (((Module.End.toContinuousLinearMap Mat) F) ^ n) X = (F ^ n) X := by
-  have hpowEq : ((Module.End.toContinuousLinearMap Mat) F) ^ n =
-      (Module.End.toContinuousLinearMap Mat) (F ^ n) :=
-    (map_pow (Module.End.toContinuousLinearMap Mat) F n).symm
-  rw [hpowEq]
-  rfl
-
 /-- In finite dimensions, a strict modulus bound on every eigenvalue gives a spectral-radius gap. -/
 theorem spectralRadius_lt_one_of_eigenvalues_lt_one [NeZero D]
     (F : Mat →ₗ[ℂ] Mat)

--- a/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
@@ -43,7 +43,8 @@ theorem primitive_channel_pow_tendsto_zero_of_trace_zero [NeZero D]
       (hEval.tendsto 0).comp hpow0
     refine hEvalT.congr' ?_
     filter_upwards [] with n
-    exact toContinuousLinearMap_pow_apply (D := D) (E - P) X n
+    rw [(map_pow (Module.End.toContinuousLinearMap Mat) (E - P) n).symm]
+    rfl
   have hPX : P X = 0 := by
     simp [P, fixedPointProj, htrX]
   refine hNpow0.congr' ?_

--- a/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
+++ b/TNLean/Channel/Semigroup/Primitivity/IrreducibleAnalysis.lean
@@ -122,7 +122,7 @@ theorem exists_power_fixed_eigenvector_of_peripheral
   have hpt_eq : T (↑p * t) = (T t) ^ p :=
     semigroup_pow T hT.semigroup.semigroup t (le_of_lt ht) p
   refine ⟨p, hp_pos, V, hV_ne, hEV, ?_⟩
-  rw [hpt_eq, pow_apply_eigenvector (T t) V μ p hEV, hμp, one_smul]
+  rw [hpt_eq, hV.pow_apply p, hμp, one_smul]
 
 /-- A trace-nonzero eigenvector exists for peripheral eigenvalues of an irreducible QDS. -/
 theorem exists_trace_ne_zero_eigenvector_of_peripheral
@@ -408,7 +408,7 @@ theorem exists_trace_ne_zero_eigenvector_of_fraction_slice
     calc
       T t₀ X = ((T u) ^ Nat.factorial (Module.finrank ℂ Mat)) X := by rw [hTt₀_eq_pow]
       _ = μ ^ Nat.factorial (Module.finrank ℂ Mat) • X :=
-        pow_apply_eigenvector (T u) X μ (Nat.factorial (Module.finrank ℂ Mat)) hX_eig
+        hXev.pow_apply (Nat.factorial (Module.finrank ℂ Mat))
       _ = X := by simp [hμN]
   have hX_span : X = Matrix.trace X • σ := hfixed_1d X hX_fix_t₀
   have : X = 0 := by simpa [htrX] using hX_span

--- a/blueprint/src/chapter/ch17_semigroup.tex
+++ b/blueprint/src/chapter/ch17_semigroup.tex
@@ -1037,12 +1037,6 @@ which shows that such generators have the standard Lindblad form.
     peripheral eigenvalue is again peripheral.
 \end{theorem}
 
-\begin{theorem}[Continuous-linear-map power evaluation]
-    \lean{toContinuousLinearMap_pow_apply}\leanok
-    Evaluating powers of a linear map agrees with powers in its continuous
-    linear realization.
-\end{theorem}
-
 \begin{theorem}[Spectral-radius criterion from eigenvalue bounds]
     \lean{spectralRadius_lt_one_of_eigenvalues_lt_one}\leanok
     If all eigenvalues satisfy $|\lambda|<1$, then the spectral radius is $<1$.

--- a/blueprint/src/chapter/ch17_semigroup.tex
+++ b/blueprint/src/chapter/ch17_semigroup.tex
@@ -982,11 +982,6 @@ which shows that such generators have the standard Lindblad form.
     $T_{nt} = (T_t)^n$.
 \end{theorem}
 
-\begin{theorem}[Eigenvector propagation under powers]
-    \lean{pow_apply_eigenvector}\leanok
-    If $E(v)=\mu v$, then $E^n(v)=\mu^n v$ for all $n\in\N$.
-\end{theorem}
-
 \begin{lemma}[Density matrices are nonzero]
     \lean{ne_zero_of_mem_densityMatrices'}\leanok
     Every density matrix is nonzero.


### PR DESCRIPTION
## Summary

This PR removes two local power-evaluation helper lemmas in the semigroup primitivity proof and replaces their uses by native mathlib lemmas.

- `toContinuousLinearMap_pow_apply` was only `map_pow` for `Module.End.toContinuousLinearMap`; its single caller now uses `map_pow` directly.
- `pow_apply_eigenvector` is now subsumed by mathlib's `Module.End.HasEigenvector.pow_apply`; the two callers already had `HasEigenvector` witnesses, so they use `hV.pow_apply` and `hXev.pow_apply` directly.

The corresponding Chapter 17 blueprint helper entries are removed because they recorded implementation-level power transport facts rather than separate mathematical steps in the semigroup argument.

## Validation

- `lake build TNLean.Channel.Semigroup.Primitivity.IrreducibleAnalysis`
- `leanblueprint checkdecls`
- `git diff --check`
- `git diff -U0 -- TNLean docs blueprint | rg '^\\+.*\\b(sorry|axiom|admit|native_decide|unsafeCast)\\b' || true`\n- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`\n- `python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or mathematical change; behavior is unchanged aside from relying on existing Mathlib identities.
> 
> **Overview**
> **Removes** local helper lemmas in semigroup primitivity that duplicated Mathlib: `pow_apply_eigenvector` and `toContinuousLinearMap_pow_apply` from `Helpers.lean`.
> 
> **Proof updates** in `IrreducibleAnalysis.lean`: eigenvector-under-powers steps now use `HasEigenvector.pow_apply` (`hV.pow_apply` / `hXev.pow_apply`); the `(E - P)` power congruence in `primitive_channel_pow_tendsto_zero_of_trace_zero` inlines `(map_pow (Module.End.toContinuousLinearMap Mat) (E - P) n).symm` and `rfl`.
> 
> **Blueprint** (`ch17_semigroup.tex`): drops the matching “Eigenvector propagation under powers” and “Continuous-linear-map power evaluation” entries; fixes a missing newline after `\end{proof}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d845eb9a82741d9f55b0412ca84efe7d8e58f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->