### PR TITLE
refactor(Peripheral): inline power-closure root proof

### DIFF
--- a/TNLean/Channel/Peripheral/Powers.lean
+++ b/TNLean/Channel/Peripheral/Powers.lean
@@ -14,8 +14,8 @@ The core root-of-unity statement already lives in
 `TNLean/Channel/PeripheralSpectrum.lean` as
 `peripheral_isRootOfUnity_of_pow_eigenvalue`.
 
-Here we state the common hypothesis “the peripheral eigenvalue set is closed
-under powers” into a form that can be fed into that theorem.
+Here we feed the common hypothesis “the peripheral eigenvalue set is closed
+under powers” directly into that theorem.
 -/
 
 open scoped BigOperators
@@ -24,50 +24,19 @@ section
 
 variable {V : Type*} [AddCommGroup V] [Module ℂ V]
 
-/-- If `μ` is a peripheral eigenvalue and peripheral eigenvalues are closed under powers,
-then every `μ^n` is an eigenvalue of `E`.
-
-This is the exact hypothesis needed for `peripheral_isRootOfUnity_of_pow_eigenvalue`. -/
-theorem hasEigenvalue_pow_of_mem_peripheralEigenvalues
-    (E : V →ₗ[ℂ] V) (μ : ℂ)
-    (_hμ : μ ∈ peripheralEigenvalues E)
-    (hpow : ∀ n : ℕ, μ ^ n ∈ peripheralEigenvalues E) :
-    ∀ n : ℕ, Module.End.HasEigenvalue E (μ ^ n) := by
-  intro n
-  exact (hpow n).1
-
-/-- **Finite + closed under powers ⇒ root of unity** (via
-`peripheral_isRootOfUnity_of_pow_eigenvalue`).
-
-This is a convenient formulation: if one can show that peripheral eigenvalues are
-closed under powers (typically using multiplicative-domain theory), then every
-peripheral eigenvalue must be a root of unity. -/
-theorem peripheral_isRootOfUnity_of_pow_mem_peripheralEigenvalues
-    [FiniteDimensional ℂ V]
-    (E : V →ₗ[ℂ] V) (μ : ℂ)
-    (hμ : μ ∈ peripheralEigenvalues E)
-    (hpow : ∀ n : ℕ, μ ^ n ∈ peripheralEigenvalues E) :
-    ∃ p : ℕ, 0 < p ∧ μ ^ p = 1 := by
-  have hμ_norm : ‖μ‖ = 1 := hμ.2
-  have hpow' : ∀ n : ℕ, Module.End.HasEigenvalue E (μ ^ n) :=
-    hasEigenvalue_pow_of_mem_peripheralEigenvalues E μ hμ hpow
-  exact peripheral_isRootOfUnity_of_pow_eigenvalue E μ hμ_norm hpow'
-
 /-- **Finite peripheral eigenvalue set + global closure under powers ⇒ root of unity**.
 
 This is the “set-level” version: assuming
 `∀ μ ∈ peripheralEigenvalues E, ∀ n, μ^n ∈ peripheralEigenvalues E`, any
 `μ ∈ peripheralEigenvalues E` is a root of unity.
-
-We keep the proof as a direct formulation around
-`peripheral_isRootOfUnity_of_pow_mem_peripheralEigenvalues`. -/
+It is a direct application of `peripheral_isRootOfUnity_of_pow_eigenvalue`. -/
 theorem peripheral_isRootOfUnity_of_closed_powers
     [FiniteDimensional ℂ V]
     (E : V →ₗ[ℂ] V)
     (hclosed : ∀ μ : ℂ, μ ∈ peripheralEigenvalues E → ∀ n : ℕ,
       μ ^ n ∈ peripheralEigenvalues E)
     (μ : ℂ) (hμ : μ ∈ peripheralEigenvalues E) :
-    ∃ p : ℕ, 0 < p ∧ μ ^ p = 1 :=
-  peripheral_isRootOfUnity_of_pow_mem_peripheralEigenvalues E μ hμ (hclosed μ hμ)
+    ∃ p : ℕ, 0 < p ∧ μ ^ p = 1 := by
+  exact peripheral_isRootOfUnity_of_pow_eigenvalue E μ hμ.2 fun n => (hclosed μ hμ n).1
 
 end


### PR DESCRIPTION
### Motivation

- The proof of `peripheral_isRootOfUnity_of_closed_powers` previously passed through two internal auxiliary theorems, `hasEigenvalue_pow_of_mem_peripheralEigenvalues` and `peripheral_isRootOfUnity_of_pow_mem_peripheralEigenvalues`, which converted the "closed under powers" hypothesis into the `HasEigenvalue`-family form required by `peripheral_isRootOfUnity_of_pow_eigenvalue`.
- Both intermediate steps are unnecessary: `peripheral_isRootOfUnity_of_pow_eigenvalue` can be applied directly, with `hμ.2` supplying unit modulus and `(hclosed μ hμ n).1` supplying `HasEigenvalue` for each power.
- Removing them eliminates dead declarations with no callers and simplifies the proof chain.

### Description

- Modified `TNLean/Channel/Peripheral/Powers.lean`.
- Removed `hasEigenvalue_pow_of_mem_peripheralEigenvalues` and `peripheral_isRootOfUnity_of_pow_mem_peripheralEigenvalues`, which only converted between two equivalent forms of the peripheral-eigenvalue closure hypothesis.
- The proof of `peripheral_isRootOfUnity_of_closed_powers` now applies `peripheral_isRootOfUnity_of_pow_eigenvalue` in one line.
- The public theorem `peripheral_isRootOfUnity_of_closed_powers` and all blueprint references are unchanged.

### Testing

- `lake build TNLean.Channel.Peripheral.Powers`
- `lake build TNLean.Channel.Peripheral.ClosureFixedPoint`
- No new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced (verified by diff grep).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-structure refactor in a small bridging file; the public theorem and downstream uses are unchanged.
>
> **Overview**
> **`TNLean/Channel/Peripheral/Powers.lean`** drops two internal bridge lemmas (`hasEigenvalue_pow_of_mem_peripheralEigenvalues` and `peripheral_isRootOfUnity_of_pow_mem_peripheralEigenvalues`) that only repackaged "closed under powers" into the eigenvalue-family hypothesis for `peripheral_isRootOfUnity_of_pow_eigenvalue`.
>
> The blueprint-facing theorem **`peripheral_isRootOfUnity_of_closed_powers`** is unchanged at the API level; its proof now calls **`peripheral_isRootOfUnity_of_pow_eigenvalue`** in one step (`hμ.2` for unit modulus, `(hclosed μ hμ n).1` for `HasEigenvalue` on each power). Module doc text is updated to match.
>
> No callers referenced the removed names; **`ClosureFixedPoint`** and the blueprint still target **`peripheral_isRootOfUnity_of_closed_powers`** only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df55aba7b14d5ff8e03b6046b62b7e8884b5e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->