### PR TITLE
refactor(Schwarz): remove unused Kraus map linearization

### DIFF
--- a/TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean
@@ -3,7 +3,6 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Schwarz.MultiplicativeDomain
-import Mathlib.LinearAlgebra.Eigenspace.Basic
 
 /-!
 # Multiplicative domain: right version and powers

--- a/TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean
+++ b/TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean
@@ -15,9 +15,6 @@ used in the “periodicity removal / peripheral spectrum” reduction:
   if KS equality holds at `X`, then `E(Y * X) = E(Y) * E(X)` for all `Y`.
 * `krausMap_pow_of_peripheral_eigenvector`:
   if `E(X) = μ • X` with `‖μ‖ = 1`, then `E(X^n) = μ^n • X^n` for all `n`.
-
-We also provide a small `LinearMap` formulation `krausMapL` and an eigenvalue
-corollary `hasEigenvalue_pow_of_peripheral_eigenvector` assuming `X^n ≠ 0`.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -107,41 +104,5 @@ theorem krausMap_pow_of_peripheral_eigenvector (K : Fin d → Matrix (Fin D) (Fi
   exact krausMap_pow_of_ks_equality (K := K) h_unital X μ hEig hKS
 
 end Powers
-
-/-! ## Optional: eigenvalue corollary via a `LinearMap` formulation -/
-
-section Eigenvalue
-
-/-- The Kraus map stated as a `ℂ`-linear endomorphism. -/
-noncomputable def krausMapL (K : Fin d → Matrix (Fin D) (Fin D) ℂ) :
-    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
-  toFun := krausMap K
-  map_add' X Y := by
-    simp [krausMap, mul_add, add_mul, Finset.sum_add_distrib, mul_assoc]
-  map_smul' μ X := by
-    simp [krausMap, Finset.smul_sum, mul_assoc]
-
-@[simp] lemma krausMapL_apply (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
-    krausMapL (d := d) (D := D) K X = krausMap K X := rfl
-
-/-- **Powers stay eigenvalues** under an explicit nonvanishing condition.
-
-If `E(X)=μX` with `‖μ‖=1` and `X^n ≠ 0`, then `μ^n` is an eigenvalue of the
-linear map `krausMapL K`. -/
-theorem hasEigenvalue_pow_of_peripheral_eigenvector (K : Fin d → Matrix (Fin D) (Fin D) ℂ)
-    (h_unital : IsUnitalKraus K) (h_tp : IsTPKraus K)
-    (X : Matrix (Fin D) (Fin D) ℂ) (μ : ℂ)
-    (hEig : krausMap K X = μ • X) (hμ : ‖μ‖ = 1)
-    (n : ℕ) (hXpow : X ^ n ≠ 0) :
-    Module.End.HasEigenvalue (krausMapL (d := d) (D := D) K) (μ ^ n) := by
-  have hpow : krausMap K (X ^ n) = μ ^ n • X ^ n :=
-    krausMap_pow_of_peripheral_eigenvector (K := K) h_unital h_tp X μ hEig hμ n
-  have hpowL : krausMapL (d := d) (D := D) K (X ^ n) = μ ^ n • X ^ n := by
-    simpa using hpow
-  exact Module.End.hasEigenvalue_of_hasEigenvector
-    (Module.End.hasEigenvector_iff.mpr ⟨Module.End.mem_eigenspace_iff.mpr hpowL, hXpow⟩)
-
-end Eigenvalue
 
 end KadisonSchwarz


### PR DESCRIPTION
### Motivation
- `TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean` contained two declarations with no callers in either the Lean source or the blueprint: the `ℂ`-linear endomorphism `krausMapL` and the corollary `hasEigenvalue_pow_of_peripheral_eigenvector`, which restates the power result as a `Module.End.HasEigenvalue` assertion.
- The matrix-level power result `krausMap_pow_of_peripheral_eigenvector` already covers all peripheral-spectrum arguments; the `HasEigenvalue` reformulation was redundant.
- Removing these unused declarations keeps the file header accurate and reduces the surface area of `Channel.Schwarz`.

### Description
- `TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean` (39 lines deleted): removes `krausMapL` (the `ℂ`-linear reformulation of `krausMap`) and the `Eigenvalue` section containing `hasEigenvalue_pow_of_peripheral_eigenvector`.
- The module header is updated to document only `multiplicative_domain_right` and `krausMap_pow_of_peripheral_eigenvector`, which remain unchanged.
- No blueprint `\lean{}` tags referenced the removed declarations; downstream peripheral-spectrum files are unaffected.

### Testing
- `lake build TNLean.Channel.Schwarz.MultiplicativeDomainPowers`
- `lake build TNLean.Channel.Peripheral.ClosureFixedPoint`
- `lake build TNLean.Channel.Peripheral.CyclicGroup`
- `lake build TNLean.Channel.Peripheral.CyclicDecomposition.PeripheralUnitary`
- `git diff --check`
- No new `sorry`, `axiom`, `admit`, `native_decide`, or `unsafeCast` introduced (verified by diff grep).
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
No linked issue found — standalone removal of unused declarations. If this addresses a tracked issue, please add `Addresses #N` manually.

> [!NOTE]
> **Low Risk**
> Pure deletion of unused lemmas with no callers; retained theorems and downstream peripheral builds are unchanged in intent.
>
> **Overview**
> Removes dead API from **`TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean`**: the `krausMapL` `ℂ`-linear endomorphism packaging `krausMap`, plus the **`Eigenvalue`** section theorem `hasEigenvalue_pow_of_peripheral_eigenvector` (powers as `Module.End.HasEigenvalue` when `X^n ≠ 0`).
>
> The file header is trimmed to document only **`multiplicative_domain_right`** and **`krausMap_pow_of_peripheral_eigenvector`**. Peripheral-spectrum callers keep using the existing matrix-level power lemma; nothing in the repo referenced the removed names.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bffb74b7ae13950cd33e911d8e3b4887b81ea4f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletion of lemmas with no repo callers; retained theorems and downstream peripheral builds are unchanged in intent.
> 
> **Overview**
> Deletes unused API from **`MultiplicativeDomainPowers.lean`**: the `krausMapL` `ℂ`-linear packaging of `krausMap`, the **`Eigenvalue`** section, and **`hasEigenvalue_pow_of_peripheral_eigenvector`** (powers as `Module.End.HasEigenvalue` when `X^n ≠ 0`). Drops the **`Mathlib.LinearAlgebra.Eigenspace.Basic`** import that only served that section.
> 
> The module docstring now lists only **`multiplicative_domain_right`** and **`krausMap_pow_of_peripheral_eigenvector`**. **`krausMap_pow_of_ks_equality`** and **`krausMap_pow_of_peripheral_eigenvector`** are unchanged; peripheral-spectrum proofs keep using the matrix-level power lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a307decaabe0eefd269f15d96e3d512e0c17b9b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->