### PR TITLE
refactor(Wielandt): use native invariant submodule power lemma

### DIFF
--- a/TNLean/Wielandt/RankOne/Element.lean
+++ b/TNLean/Wielandt/RankOne/Element.lean
@@ -88,23 +88,6 @@ lemma pow_mulVec_eq_smul_of_mulVec_eq_smul
 
 namespace WielandtRankOne
 
-/-- If a linear map preserves a submodule, then all powers preserve it. -/
-private lemma pow_apply_mem_of_mapsTo
-    {V : Type*} [AddCommGroup V] [Module ℂ V]
-    (f : End ℂ V) (U : Submodule ℂ V)
-    (hf : Set.MapsTo f (↑U : Set V) (↑U : Set V)) :
-    ∀ n : ℕ, ∀ {v : V}, v ∈ U → (f ^ n) v ∈ U := by
-  intro n
-  induction n with
-  | zero =>
-      intro v hv
-      simpa [pow_zero] using hv
-  | succ n ih =>
-      intro v hv
-      have hv' : f v ∈ U := hf hv
-      -- `f^(n+1) v = f^n (f v)`.
-      simpa [pow_succ, Module.End.mul_apply] using ih (v := f v) hv'
-
 /-- On `V = Fin D → ℂ`, the zero generalized eigenspace is the kernel of `f ^ D`. -/
 private lemma maxGenEigenspace_zero_eq_ker_pow
     (f : End ℂ (Fin D → ℂ)) :
@@ -163,7 +146,8 @@ theorem range_pow_le_iSup_maxGenEigenspace_ne_zero
           (↑(f.maxGenEigenspace μ) : Set (Fin D → ℂ)) :=
         Wielandt.mapsTo_maxGenEigenspace_self f μ
       have hpow : (f ^ D) v ∈ f.maxGenEigenspace μ :=
-        pow_apply_mem_of_mapsTo (f := f) (U := f.maxGenEigenspace μ) hmaps D hv
+        Module.End.pow_apply_mem_of_forall_mem (f' := f) (p := f.maxGenEigenspace μ)
+          D (fun _ hx => hmaps hx) v hv
       have hle : f.maxGenEigenspace μ ≤ W :=
         le_iSup₂_of_le μ hμ0 (le_rfl : f.maxGenEigenspace μ ≤ f.maxGenEigenspace μ)
       exact hle hpow


### PR DESCRIPTION
### Motivation

- `TNLean/Wielandt/RankOne/Element.lean` contained a private induction lemma `pow_apply_mem_of_mapsTo` that reproduced a standard linear-algebra result: if an endomorphism preserves a submodule, then every power of the endomorphism preserves that submodule. Mathlib 4.31 provides this as `Module.End.pow_apply_mem_of_forall_mem`, making the local copy redundant.
- Replacing the local lemma with the upstream statement eliminates duplicated linear-algebra infrastructure in the bounded rank-one construction.

### Description

- Removed the private lemma `pow_apply_mem_of_mapsTo` (induction on powers) from `TNLean/Wielandt/RankOne/Element.lean` (−18 lines, +2 lines).
- The "powers preserve the generalized eigenspace" step in `range_pow_le_iSup_maxGenEigenspace_ne_zero` now calls `Module.End.pow_apply_mem_of_forall_mem` directly, with the existing `Set.MapsTo` invariance witness from `Wielandt.mapsTo_maxGenEigenspace_self` passed at the call site.
- No change to the bounded rank-one construction or nilpotent-block argument; no new `sorry` introduced.

### Testing

- `lake build TNLean.Wielandt.RankOne.Element -q --log-level=info`
- `lake build TNLean.Wielandt.RankOne.Extraction -q --log-level=info`
- `lake build TNLean.Wielandt.RectangularSpan.Basic -q --log-level=info`
- Proof-integrity scan (diff against `origin/main`): no newly introduced `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with equivalent logic; no API or runtime behavior changes.
> 
> **Overview**
> Removes the private **`pow_apply_mem_of_mapsTo`** induction from `TNLean.Wielandt.RankOne.Element` and wires the "powers preserve the generalized eigenspace" step in **`range_pow_le_iSup_maxGenEigenspace_ne_zero`** through Mathlib's **`Module.End.pow_apply_mem_of_forall_mem`**, with the existing **`Set.MapsTo`** witness from **`Wielandt.mapsTo_maxGenEigenspace_self`** passed at the call site.
> 
> No change to the bounded rank-one / nilpotent-block argument—only less duplicated linear-algebra scaffolding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8651f558c1b5801a7da87e2bb92241d97d6dd937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->