### PR TITLE
refactor(Algebra): use native scalar cancellation

### DIFF
--- a/TNLean/Algebra/ProjectiveRepresentation.lean
+++ b/TNLean/Algebra/ProjectiveRepresentation.lean
@@ -93,14 +93,8 @@ lemma mul_assoc_right_scalar (g h k : G) :
 /-- Scalar cancellation on an invertible matrix (requires a nonempty index set). -/
 lemma smul_eq_smul_cancel {a b : ℂ} {M : Matrix (Fin D) (Fin D) ℂ}
     (hD : 0 < D) (hM : IsUnit M) (h : a • M = b • M) : a = b := by
-  rcases Nat.exists_eq_succ_of_ne_zero (Nat.ne_of_gt hD) with ⟨n, rfl⟩
-  rcases hM with ⟨U, rfl⟩
-  have h' : a • (1 : Matrix (Fin (Nat.succ n)) (Fin (Nat.succ n)) ℂ) =
-      b • (1 : Matrix (Fin (Nat.succ n)) (Fin (Nat.succ n)) ℂ) := by
-    simpa [smul_mul_assoc, Matrix.mul_smul, Matrix.mul_assoc] using
-      congrArg (fun T => T * ((↑U⁻¹ : Matrix (Fin (Nat.succ n)) (Fin (Nat.succ n)) ℂ))) h
-  have h00 := congrArg (fun T => T 0 0) h'
-  simpa using h00
+  haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+  exact smul_left_injective ℂ hM.ne_zero h
 
 /-- Associativity forces the cocycle condition (for `D > 0`). -/
 theorem cocycle_of_assoc (ρ : ProjectiveRepresentation (D := D) ω) (hD : 0 < D) (g h k : G) :


### PR DESCRIPTION
### Motivation

- The lemma `smul_eq_smul_cancel` in `TNLean/Algebra/ProjectiveRepresentation.lean` is used to extract the scalar cocycle identity from associativity of a projective representation.
- Mathlib already contains `smul_left_injective`, a torsion-free scalar-action cancellation theorem, making the previous hand-built matrix-entry argument redundant.

### Description

- `TNLean/Algebra/ProjectiveRepresentation.lean` — rewrites the proof of `smul_eq_smul_cancel` to invoke `smul_left_injective` directly. The previous proof performed a succ case on `D`, multiplied by the inverse matrix `U⁻¹`, reduced to the identity, and read off the `(0,0)` entry. The new proof derives `Nonempty (Fin D)` from `0 < D` and `hM.ne_zero` from invertibility of `M`, then applies `smul_left_injective` in one step.
- The statement of `smul_eq_smul_cancel` and its downstream callers (`cocycle_of_assoc`, cocycle coboundary code) are unchanged; only the proof body is shortened.
- No new `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` introduced.

### Testing

- `lake build TNLean.Algebra.ProjectiveRepresentation -q --log-level=info`
- `lake build TNLean.Algebra.CocycleCohomology -q --log-level=info`
- `lake build TNLean.MPS.Symmetry.CocycleCoboundary -q --log-level=info`
- `lake build TNLean.MPS.Periodic.ProjectiveRep -q --log-level=info`
- `git diff --check`
- Proof-integrity diff scan: no newly introduced `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or behavior change; logic is delegated to an existing Mathlib lemma.
> 
> **Overview**
> **`smul_eq_smul_cancel`** in `ProjectiveRepresentation.lean` is rewritten to delegate to Mathlib's **`smul_left_injective`** instead of a hand-built argument (succ case on `D`, multiply by `U⁻¹`, reduce to the identity matrix, read off the `(0,0)` entry).
> 
> The lemma's statement and its use in **`cocycle_of_assoc`** (and downstream callers such as cocycle coboundary code) are unchanged; only the proof body shrinks. **`Nonempty (Fin D)`** is still obtained from **`0 < D`** so the scalar-action injectivity hypothesis applies, with **`hM.ne_zero`** from invertibility of `M`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d87d8a5417d110bcd46d25e79ec41f7c615556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>