### PR TITLE
refactor(Algebra): use native polynomial root multiset

### DIFF
--- a/TNLean/Algebra/ScalarPowerSumIdentity.lean
+++ b/TNLean/Algebra/ScalarPowerSumIdentity.lean
@@ -109,14 +109,6 @@ theorem sum_pow_eq_implies_charpoly_diagonal_eq_of_le_card
   rw [trace_diagonal_pow, trace_diagonal_pow]
   exact h k hk hkcard
 
-private lemma roots_prod_X_sub_C (f : n → ℂ) :
-    (∏ i : n, (X - C (f i))).roots = Finset.univ.val.map f := by
-  have hne : (∏ i : n, (X - C (f i))) ≠ 0 := by
-    rw [Finset.prod_ne_zero_iff]
-    exact fun i _ => X_sub_C_ne_zero (f i)
-  rw [roots_prod _ _ hne]
-  simp
-
 /-- Equal power sums through `card n` determine the same multiset of values for
 two families indexed by the same finite type.
 
@@ -132,7 +124,11 @@ theorem sum_pow_eq_implies_multiset_eq_of_le_card
   rw [charpoly_diagonal, charpoly_diagonal] at hcp
   have hroots : (∏ i : n, (X - C (a i))).roots = (∏ i : n, (X - C (b i))).roots :=
     congrArg Polynomial.roots hcp
-  simpa [roots_prod_X_sub_C] using hroots
+  have hroots_a : (∏ i : n, (X - C (a i))).roots = Finset.univ.val.map a := by
+    simpa using Polynomial.roots_multiset_prod_X_sub_C (Finset.univ.val.map a)
+  have hroots_b : (∏ i : n, (X - C (b i))).roots = Finset.univ.val.map b := by
+    simpa using Polynomial.roots_multiset_prod_X_sub_C (Finset.univ.val.map b)
+  rwa [hroots_a, hroots_b] at hroots
 
 /-- Equal power sums of two families indexed by the same finite type imply that the families
 give rise to the same multiset of values.


### PR DESCRIPTION
### Motivation

- Mathlib 4.31 provides `Polynomial.roots_multiset_prod_X_sub_C` directly, making the
  private lemma `roots_prod_X_sub_C` in `TNLean.Algebra.ScalarPowerSumIdentity` a
  redundant reformulation of that result.

### Description

- Removed the private lemma `roots_prod_X_sub_C` from
  `TNLean/Algebra/ScalarPowerSumIdentity.lean`.
- Replaced its single call site in `sum_pow_eq_implies_multiset_eq_of_le_card` with a
  direct application of `Polynomial.roots_multiset_prod_X_sub_C`.
- The statements of all public theorems in this file are unchanged; this is a
  proof-internal reorganization only.

### Testing

- `lake build TNLean.Algebra.ScalarPowerSumIdentity`
- `lake build TNLean.MPS.FundamentalTheorem.SectorWeightComparison`
- `lake build TNLean.MPS.FundamentalTheorem.SectorBNT.WeightEquiv`
- `lake build TNLean.MPS.Periodic.FundamentalTheorem`
- Proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`
  introduced.
- Blueprint and reader-facing prose scripts ran with no new violations.

---
<!-- No linked issue found; author should link one if applicable. -->

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8d89e62006ee15b8cd9060101c90a070dbd7e330. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>