### PR TITLE
refactor(Wielandt): use native map range containment

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Growth.lean
+++ b/TNLean/Wielandt/RectangularSpan/Growth.lean
@@ -104,14 +104,6 @@ noncomputable def rectSpanLeftStep (n : ℕ) :
   map_add' x y := by ext; simp [Matrix.mul_add]
   map_smul' a x := by ext; simp
 
-/-- Every element of `rectSpan ((A i₀)^D) A n` lies in the range of `mulLeft ((A i₀)^D)`. -/
-private theorem mem_range_mulLeft_pow_of_mem_rectSpan
-    {n : ℕ} {X : Matrix (Fin D) (Fin D) ℂ}
-    (hX : X ∈ rectSpan ((A i₀) ^ D) A n) :
-    X ∈ LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D)) := by
-  obtain ⟨M, _, rfl⟩ := Submodule.mem_map.mp hX
-  exact ⟨M, by simp [LinearMap.mulLeft_apply]⟩
-
 /-! ### Injectivity of the left-step
 
 The proof uses the Fitting-decomposition disjointness: `ker(A i₀)` is disjoint from
@@ -174,10 +166,14 @@ theorem rectSpanLeftStep_injective (n : ℕ) :
   have hmat : (A i₀) * x.1 = (A i₀) * y.1 := congrArg Subtype.val hxy
   have hz : (A i₀) * (x.1 - y.1) = 0 := by
     simpa [Matrix.mul_sub, sub_eq_zero] using hmat
+  have hrect_le_range :
+      rectSpan ((A i₀) ^ D) A n ≤ LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D)) := by
+    rw [rectSpan]
+    exact LinearMap.map_le_range
   have hzRange : (x.1 - y.1) ∈ LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D)) :=
     Submodule.sub_mem _
-      (mem_range_mulLeft_pow_of_mem_rectSpan A i₀ x.2)
-      (mem_range_mulLeft_pow_of_mem_rectSpan A i₀ y.2)
+      (hrect_le_range x.2)
+      (hrect_le_range y.2)
   have hzero : x.1 - y.1 = 0 :=
     matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow' A i₀ hzRange hz
   exact Subtype.ext (by simpa [sub_eq_zero] using hzero)


### PR DESCRIPTION
### Motivation
- `rectSpan P A n` is defined as the image of `wordSpan A n` under `LinearMap.mulLeft ℂ P`. The private helper `mem_range_mulLeft_pow_of_mem_rectSpan` proved that such an image lies in the range of the map — a fact Mathlib already provides as `LinearMap.map_le_range`.
- Removing this private helper reduces local proof complexity without altering any mathematical statement.

### Description
- Modified `TNLean/Wielandt/RectangularSpan/Growth.lean` (6 additions, 10 deletions).
- Deleted the private lemma `mem_range_mulLeft_pow_of_mem_rectSpan` from `TNLean.Wielandt.RectangularSpan.Growth`.
- Replaced its use with Mathlib's `LinearMap.map_le_range` after unfolding `rectSpan`.

### Testing
- `lake build TNLean.Wielandt.RectangularSpan.Growth -q --log-level=info`
- `lake build TNLean.Wielandt.RectangularSpan.UniversalityAux.Basic -q --log-level=info`
- Proof-integrity scan confirmed no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in changed files.
- Focused Lean builds emit only pre-existing style warnings in imported modules.
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---
No linked issue — this is a self-contained internal refactor in the native-Mathlib-API cleanup series.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0f8c4ce6d2f193c8d24ae8804f7bf30ec9657602. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->