### PR TITLE
refactor(Wielandt): use native bi-rectangular range containment

### DIFF
--- a/TNLean/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Wielandt/RankOne/BoundedWord.lean
@@ -73,11 +73,8 @@ theorem biRectSpan_le_range
     (P Q : Matrix (Fin D) (Fin D) ℂ) (B : MPSTensor d D) (n : ℕ) :
     biRectSpan (d := d) (D := D) P Q B n ≤
       LinearMap.range ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) := by
-  intro M hM
-  rcases (mem_biRectSpan_iff (d := d) (D := D) P Q B).mp hM with ⟨X, _, hX⟩
-  exact ⟨X, by
-    simpa only [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply,
-      Matrix.mul_assoc] using hX⟩
+  rw [biRectSpan]
+  exact LinearMap.map_le_range
 
 /-- Converting a bi-rectangular span element back into a bounded word span,
 assuming `P` and `Q` themselves lie in bounded word spans. -/


### PR DESCRIPTION
### Motivation

- Part of a systematic pass through `TNLean/Wielandt/` to replace local proof scripts for general linear-algebra facts with native Mathlib 4.31 statements when available.
- The previous proof of `MPSTensor.biRectSpan_le_range` manually unpacked membership in `biRectSpan`, extracted a preimage, and reconstructed range membership by hand. The mathematical content is simply that the image of a linear map lies in its range (`LinearMap.map_le_range`).

### Description

- Modified `TNLean/Wielandt/RankOne/BoundedWord.lean`.
- Replaces the manual membership proof for `MPSTensor.biRectSpan_le_range` with a two-line proof that unfolds `biRectSpan` (defined as a `Submodule.map` of the two-sided multiplication map) and closes via Mathlib's `LinearMap.map_le_range`.
- No change to the theorem statement or its mathematical content.

### Testing

- `lake build TNLean.Wielandt.RankOne.BoundedWord TNLean.Wielandt.RankOne.ExtractionFull -q --log-level=info`
- Proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` on added lines.
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged statement and no runtime or API impact.
> 
> **Overview**
> **`biRectSpan_le_range`** in `BoundedWord.lean` no longer unpacks `biRectSpan` membership via `mem_biRectSpan_iff` and rebuilds range membership by hand.
> 
> The proof now unfolds **`biRectSpan`** (a `Submodule.map` of the two-sided multiply map) and closes with Mathlib's **`LinearMap.map_le_range`**, matching the PR's Mathlib 4.31 goal of using the library fact that any linear map's image lies in its range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fd43b0ae5c7ddf31aa2327e3047b79d8f753f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>