### PR TITLE
refactor(Wielandt): use native rank-one range witness

### DIFF
--- a/TNLean/Wielandt/RankOne/Manufacture.lean
+++ b/TNLean/Wielandt/RankOne/Manufacture.lean
@@ -40,18 +40,8 @@ theorem vecMulVec_mem_range_mulLeft_mulRight
   have hz' : z ᵥ* Q = ψ := by
     simpa [Matrix.vecMulLinear_apply] using hz
   -- Witness `X := Matrix.vecMulVec y z`.
-  refine (LinearMap.mem_range).2 ?_
-  refine ⟨Matrix.vecMulVec y z, ?_⟩
-  -- Compute `P * (X * Q)` as a rank-one matrix.
-  calc
-    ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) (Matrix.vecMulVec y z)
-        = P * (Matrix.vecMulVec y z * Q) := by
-          simp [LinearMap.comp_apply]
-    _ = P * Matrix.vecMulVec y (z ᵥ* Q) := by
-          simp [Matrix.vecMulVec_mul]
-    _ = Matrix.vecMulVec (P *ᵥ y) (z ᵥ* Q) := by
-          simp [Matrix.mul_vecMulVec]
-    _ = Matrix.vecMulVec φ ψ := by
-          simp [hy', hz']
+  simpa [LinearMap.comp_apply, Matrix.vecMulVec_mul, Matrix.mul_vecMulVec, hy', hz'] using
+    LinearMap.mem_range_self
+      ((LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)) (Matrix.vecMulVec y z)
 
 end MPSTensor


### PR DESCRIPTION
### Motivation

- Part of the Mathlib 4.31 cleanup: replace hand-written proofs of general
  linear-algebra facts with native Mathlib statements.
- `LinearMap.mem_range_self` directly provides membership of `f x` in
  `LinearMap.range f`; the previous proof reproduced this by explicit
  witness construction.

### Description

- `TNLean/Wielandt/RankOne/Manufacture.lean`: simplifies the proof of
  `MPSTensor.vecMulVec_mem_range_mulLeft_mulRight`.
- The theorem statement is unchanged: given vectors `y`, `z` and matrices
  `P`, `Q` with `P *ᵥ y = φ` and `z ᵥ* Q = ψ`, the rank-one matrix
  `Matrix.vecMulVec y z` lies in the range of
  `(LinearMap.mulLeft ℂ P).comp (LinearMap.mulRight ℂ Q)`.
- The previous proof used a four-step `calc` chain to compute
  `P * (vecMulVec y z * Q)` and identify the witness explicitly.
  The new proof applies `LinearMap.mem_range_self` and closes with `simp`.

### Testing

- `lake build TNLean.Wielandt.RankOne.Manufacture TNLean.Wielandt.RankOne.ExtractionFull`
- Proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or
  `unsafeCast` in added lines.
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0c6b748674477b42f323c02d7ca3004acc82ca58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>