### PR TITLE
refactor(Wielandt): use native rectangular range witness

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean
@@ -55,8 +55,8 @@ theorem vecMulVec_mem_range_mulLeft_of_mem_range_toLin
     (hφ : φ ∈ LinearMap.range (Matrix.toLin' P)) (ψ : Fin D → ℂ) :
     vecMulVec φ ψ ∈ LinearMap.range (LinearMap.mulLeft ℂ P) := by
   obtain ⟨v, rfl⟩ := LinearMap.mem_range.mp hφ
-  refine ⟨vecMulVec v ψ, ?_⟩
-  simp only [Matrix.toLin'_apply, LinearMap.mulLeft_apply, mul_vecMulVec]
+  simpa only [Matrix.toLin'_apply, LinearMap.mulLeft_apply, mul_vecMulVec] using
+    LinearMap.mem_range_self (LinearMap.mulLeft ℂ P) (vecMulVec v ψ)
 
 /-- **Rank-one universality from stabilized rectangular span.**
 


### PR DESCRIPTION
### Motivation

- Replaces a hand-written existential witness for range membership with Mathlib's `LinearMap.mem_range_self` in the proof of `vecMulVec_mem_range_mulLeft_of_mem_range_toLin`.
- Part of the Mathlib 4.31 cleanup: systematically replace ad hoc witness constructions with native Mathlib lemmas where they are available.

### Description

- Modified `TNLean/Wielandt/RectangularSpan/UniversalityAux/Basic.lean`.
- After unpacking the vector preimage `φ = P *ᵥ v`, the proof now uses `LinearMap.mem_range_self` to witness that `P * vecMulVec v ψ` lies in the range of left multiplication by `P`. The remaining steps use the existing rank-one matrix simplification.
- The statement and mathematical content of `vecMulVec_mem_range_mulLeft_of_mem_range_toLin` are unchanged.

### Testing

- `lake build TNLean.Wielandt.RectangularSpan.UniversalityAux.Basic TNLean.Wielandt.RectangularSpan.UniversalityAux TNLean.Wielandt.RectangularSpan.Universality -q --log-level=info`
- Added-line proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` introduced.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9a8e7171332c4f519a5aa12ae8d87f6c323a0564. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>