### PR TITLE
refactor(Wielandt): remove rank-one range pass-through

### DIFF
--- a/TNLean/Wielandt/RankOne/ExtractionFull.lean
+++ b/TNLean/Wielandt/RankOne/ExtractionFull.lean
@@ -147,15 +147,6 @@ private noncomputable def blockedTensorRangeData
       (mem_range_vecMulLinear_pow_of_transpose_eigenvector
         (M := evalWord A (List.ofFn τ₀)) (ψ := ψ) (ν := ν) hν heigψ)
 
-private theorem BlockedTensorRangeData.rankOne_mem_range
-    {A : MPSTensor d D} {L : ℕ} {σ₀ τ₀ : Fin L → Fin d}
-    {φ ψ : Fin D → ℂ}
-    (data : BlockedTensorRangeData (d := d) (D := D) A L σ₀ τ₀ φ ψ) :
-    Matrix.vecMulVec φ ψ ∈
-      LinearMap.range ((LinearMap.mulLeft ℂ data.P).comp (LinearMap.mulRight ℂ data.Q)) := by
-  exact vecMulVec_mem_range_mulLeft_mulRight
-    data.P data.Q φ ψ data.hφ_range data.hψ_range
-
 private theorem BlockedTensorRangeData.rankOne_mem_cumulativeSpan_of_cumulativeSpan_eq_top
     {A : MPSTensor d D} {L : ℕ} {σ₀ τ₀ : Fin L → Fin d}
     {φ ψ : Fin D → ℂ}
@@ -179,7 +170,8 @@ private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_wordSpan_eq_top
       (d := blockPhysDim d L) (D := D) data.P data.Q data.B htop]
     exact biRectSpan_le_wordSpan (d := blockPhysDim d L) (D := D)
       data.B data.P data.Q data.hP data.hQ
-  exact hrange_le data.rankOne_mem_range
+  exact hrange_le (vecMulVec_mem_range_mulLeft_mulRight
+    data.P data.Q φ ψ data.hφ_range data.hψ_range)
 
 private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_cumulativeSpan_eq_top_of_aperiodic
     {A : MPSTensor d D} {L : ℕ} {σ₀ τ₀ : Fin L → Fin d}
@@ -190,7 +182,9 @@ private theorem BlockedTensorRangeData.rankOne_mem_wordSpan_of_cumulativeSpan_eq
     Matrix.vecMulVec φ ψ ∈ wordSpan data.B (D + N + D) := by
   exact (range_comp_le_wordSpan_of_cumulativeSpan_eq_top_of_aperiodic
     (d := blockPhysDim d L) (D := D)
-    data.B data.P data.Q data.hP data.hQ hcs hone) data.rankOne_mem_range
+    data.B data.P data.Q data.hP data.hQ hcs hone)
+    (vecMulVec_mem_range_mulLeft_mulRight
+      data.P data.Q φ ψ data.hφ_range data.hψ_range)
 
 end LinearAlgebraLemmas
 


### PR DESCRIPTION
### Motivation

- `BlockedTensorRangeData.rankOne_mem_range` in `TNLean/Wielandt/RankOne/ExtractionFull.lean` was a private auxiliary theorem that did not assert a new mathematical statement: it restated `vecMulVec_mem_range_mulLeft_mulRight` through the `BlockedTensorRangeData` structure without adding mathematical content.
- Part of the Mathlib 4.31 cleanup: removing auxiliary theorems that are equivalent reformulations of existing lemmas.

### Description

- Modified `TNLean/Wielandt/RankOne/ExtractionFull.lean` (11 lines deleted, 5 lines added).
- Removed the private theorem `BlockedTensorRangeData.rankOne_mem_range`.
- The two former call sites now invoke `vecMulVec_mem_range_mulLeft_mulRight` directly, placing the range-membership reasoning at its source.
- No mathematical content changed; the Wielandt rank-one extraction proofs are unaffected.

### Testing

- `lake build TNLean.Wielandt.RankOne.ExtractionFull -q --log-level=info`
- `git diff --check`
- Proof-integrity scan on added lines: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no new statements or API changes; behavior of the Wielandt rank-one extraction proofs is unchanged.
>
> **Overview**
> Removes the private wrapper `BlockedTensorRangeData.rankOne_mem_range` in `ExtractionFull.lean` and wires its two former call sites to **`vecMulVec_mem_range_mulLeft_mulRight`** directly.
>
> Proof obligations are unchanged; this is Mathlib 4.31-style cleanup that drops a redundant local theorem around an existing range-membership lemma.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a603ccca70eec14512a74da3df4c1dbce2404296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>