### PR TITLE
refactor(MPS/Chain): use native range witness

### DIFF
--- a/TNLean/MPS/Chain/AlgebraIsomorphism.lean
+++ b/TNLean/MPS/Chain/AlgebraIsomorphism.lean
@@ -54,7 +54,8 @@ theorem chainCombinedTensor_isInjective {n : ℕ} (A : Fin n → MPSTensor d D)
   refine Submodule.span_mono ?_ hM
   intro x hx
   obtain ⟨σ, rfl⟩ := hx
-  exact Set.mem_range.mpr ⟨finProdFinEquiv (k, σ), by simp [chainCombinedTensor]⟩
+  rw [← chainCombinedTensor_apply A k σ]
+  exact Set.mem_range_self (finProdFinEquiv (k, σ))
 
 /-! ### The main theorem -/
 


### PR DESCRIPTION
### Motivation

- The proof of `chainCombinedTensor_isInjective` in `TNLean/MPS/Chain/AlgebraIsomorphism.lean`
  previously constructed range membership manually using `Set.mem_range.mpr`. Mathlib 4.31
  provides `Set.mem_range_self`, which closes this goal directly without an explicit existential
  witness.
- Part of the Mathlib 4.31 native-replacement pass: prefer native range-membership lemmas over
  ad hoc witnesses across the library.

### Description

- Modified `TNLean/MPS/Chain/AlgebraIsomorphism.lean`: simplified the proof body of
  `MPSTensor.chainCombinedTensor_isInjective`.
- After obtaining `x = A k σ`, the proof now rewrites via `chainCombinedTensor_apply` and
  closes with `Set.mem_range_self (finProdFinEquiv (k, σ))`, replacing the prior
  `Set.mem_range.mpr` construction.
- The theorem statement and all mathematical content are unchanged.
- No new `sorry`, `axiom`, or `native_decide` introduced.

### Testing

- `lake build TNLean.MPS.Chain.AlgebraIsomorphism -q --log-level=info`
- `git diff --check`
- Proof-integrity scan: no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` introduced.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one lemma; no API or runtime behavior changes.
> 
> **Overview**
> Refactors the proof of **`chainCombinedTensor_isInjective`** so range membership no longer uses an ad hoc `Set.mem_range.mpr` witness with a `simp` on `chainCombinedTensor`.
> 
> After obtaining `x = A k σ`, the proof now rewrites via **`chainCombinedTensor_apply`** and closes with Mathlib's **`Set.mem_range_self`** and `finProdFinEquiv (k, σ)`. The theorem statement and mathematical content are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 667eea4c0d3c31cb0862cb0dee3c7d769bb35644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>