### PR TITLE
refactor(MPS): use native range witness

### DIFF
--- a/TNLean/MPS/Defs.lean
+++ b/TNLean/MPS/Defs.lean
@@ -405,7 +405,7 @@ theorem isInjective_of_gaugeEquiv {A B : MPSTensor d D}
     | mem x hx =>
       obtain ⟨i, rfl⟩ := hx
       rw [← hX i]
-      exact Submodule.subset_span (Set.mem_range.mpr ⟨i, rfl⟩)
+      exact Submodule.subset_span (Set.mem_range_self i)
     | zero => simp
     | add x y _ _ hx hy =>
       simp only [Matrix.mul_add, Matrix.add_mul]


### PR DESCRIPTION
### Motivation

- The proof of `MPSTensor.isInjective_of_gaugeEquiv` in `TNLean/MPS/Defs.lean` constructed a `Set.range` membership witness by hand: `Set.mem_range.mpr ⟨i, rfl⟩`.
- Mathlib 4.31 provides `Set.mem_range_self`, which directly establishes membership for elements of the form `B i`; using it eliminates the hand-constructed existential.
- Part of the Mathlib 4.31 native-pass series (`codex/mathlib-4-31-native-pass-111`); no mathematical declarations or blueprint statements change.

### Description

- `TNLean/MPS/Defs.lean`: in the proof of `isInjective_of_gaugeEquiv`, replaces `Submodule.subset_span (Set.mem_range.mpr ⟨i, rfl⟩)` with `Submodule.subset_span (Set.mem_range_self i)`.
- The theorem statement — gauge equivalence preserves injectivity of MPS tensors — and all downstream proof obligations are unchanged.
- **Mathlib 4.31 replacement**: `Set.mem_range_self`

### Testing

- `lake build TNLean.MPS.Defs -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast` (no matches)
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
_No linked issue found — no open issue matches the changed files or the `codex/mathlib-4-31-native-pass-111` branch. Please link one manually if applicable._

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 646932fba50406f74c7e161f3d6ce7b9428f61e7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>