### PR TITLE
refactor(Wielandt): use column range identity in sharp route

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
@@ -94,26 +94,19 @@ theorem range_mulLeft_pow_nilpIndex_eq
       (LinearMap.mulLeft ℂ ((A i₀) ^ D)) := by
   set f := toLin' (A i₀)
   set r := nilpIndex f
-  have hfr := finrank_range_mulLeft ((A i₀) ^ r)
-  have hfD := finrank_range_mulLeft ((A i₀) ^ D)
-  rw [rank_pow_nilpIndex_eq A i₀] at hfr
-  apply Submodule.eq_of_le_of_finrank_eq
-  · intro X hX
-    obtain ⟨M, rfl⟩ := LinearMap.mem_range.mp hX
-    simp only [LinearMap.mulLeft_apply]
-    rw [mem_range_mulLeft_iff_cols]
-    intro j; rw [col_mul]
-    have hrange_eq :
-        LinearMap.range (toLin' ((A i₀) ^ r)) =
-          LinearMap.range (toLin' ((A i₀) ^ D)) := by
-      rw [toLin'_pow, toLin'_pow]
-      exact (range_pow_eq_of_nilpIndex_le f
-        (nilpIndex_le_D' f)).symm
-    exact hrange_eq ▸
-      (⟨M.col j, by rw [toLin'_apply]⟩ :
-        ((A i₀) ^ r) *ᵥ (M.col j) ∈
-          LinearMap.range (toLin' ((A i₀) ^ r)))
-  · omega
+  have hrange_eq :
+      LinearMap.range (toLin' ((A i₀) ^ r)) =
+        LinearMap.range (toLin' ((A i₀) ^ D)) := by
+    rw [toLin'_pow, toLin'_pow]
+    exact (range_pow_eq_of_nilpIndex_le f
+      (nilpIndex_le_D' f)).symm
+  rw [range_mulLeft_eq_pi, range_mulLeft_eq_pi]
+  ext M
+  change (∀ j : Fin D,
+      M.col j ∈ LinearMap.range (toLin' ((A i₀) ^ r))) ↔
+    ∀ j : Fin D,
+      M.col j ∈ LinearMap.range (toLin' ((A i₀) ^ D))
+  rw [hrange_eq]
 
 /-- Eigenvector in range of `toLin' ((A i₀)^r)`. -/
 theorem eigenvector_mem_range_toLin_pow_nilpIndex


### PR DESCRIPTION
### Motivation

- The proof of `range_mulLeft_pow_nilpIndex_eq` used a finite-rank comparison and a manual range witness; the existing identity `range_mulLeft_eq_pi` makes those steps redundant and shortens the argument.
- The structural reduction is more direct: it derives the matrix left-multiplication range equality from the vector range equality at the nilpotent index without an intermediate finrank argument.

### Description

- Modified `TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean` (13 additions, 20 deletions).
- Replaces the elementwise proof of `range_mulLeft_pow_nilpIndex_eq` with the structural identity `range_mulLeft_eq_pi`.
- Derives the matrix left-multiplication range equality directly from the vector range equality at the nilpotent index.
- Removes the auxiliary finite-rank comparison (`finrank_range_mulLeft` / `Submodule.eq_of_le_of_finrank_eq`) and the manual range witness in the sharp Wielandt route.
- The stated theorem is unchanged; only the proof technique is replaced.

### Testing

- `lake exe cache get`
- `lake build TNLean.Wielandt.RectangularSpan.UniversalityAux.Sharp -q --log-level=info`
- `git diff --check`
- Added-line scan for `sorry|admit|axiom|native_decide|unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

No linked issue identified: the branch name does not encode an issue number and the PR body contains no `Addresses #N` reference. Consider linking the relevant tracking issue (e.g. #324 or #334) manually.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single Lean lemma; the stated theorem is unchanged and there is no runtime or security impact.
> 
> **Overview**
> **`range_mulLeft_pow_nilpIndex_eq`** is proved by structural reduction instead of a finite-rank argument.
> 
> The proof first records that **`toLin' ((A i₀)^r)`** and **`toLin' ((A i₀)^D)`** have the same range at the nilpotent index, then rewrites both **`LinearMap.mulLeft`** ranges with **`range_mulLeft_eq_pi`** and compares membership column-by-column. The old **`finrank_range_mulLeft` / `Submodule.eq_of_le_of_finrank_eq`** inclusion and manual range witness are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5688cedf11659157c4c4327801ba2a997e3d786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>