### PR TITLE
refactor(Wielandt): use range composition for power invariance

### DIFF
--- a/TNLean/Wielandt/RankOne/SpanGrowth.lean
+++ b/TNLean/Wielandt/RankOne/SpanGrowth.lean
@@ -46,17 +46,15 @@ theorem mapsTo_range_pow (f : End ℂ (Fin D → ℂ)) :
     Set.MapsTo f (↑(LinearMap.range (f ^ D)) : Set (Fin D → ℂ))
       (↑(LinearMap.range (f ^ D)) : Set (Fin D → ℂ)) := by
   intro x hx
-  rcases (LinearMap.mem_range.mp hx) with ⟨y, rfl⟩
-  -- `f ((f^D) y) = (f^D) (f y)`.
-  refine (LinearMap.mem_range).2 ⟨f y, ?_⟩
-  -- Reassociate everything to the same power `f^(D+1)`.
-  calc
-    (f ^ D) (f y) = (f ^ (D + 1)) y := by
-      simp [pow_succ, Module.End.mul_apply]
-    _ = (f ^ (1 + D)) y := by
-      simp [Nat.add_comm]
-    _ = f ((f ^ D) y) := by
-      simp [pow_add, Module.End.mul_apply]
+  have hmap : Submodule.map f (LinearMap.range (f ^ D)) ≤
+      LinearMap.range (f ^ D) := by
+    rw [← LinearMap.range_comp]
+    have hcomp : f.comp (f ^ D) = (f ^ D).comp f := by
+      rw [← Module.End.iterate_succ' (f' := f) D,
+        ← Module.End.iterate_succ (f' := f) D]
+    rw [hcomp]
+    exact LinearMap.range_comp_le_range f (f ^ D)
+  exact hmap (Submodule.mem_map_of_mem hx)
 
 /-! ## The kernel of `f` lies in the 0-generalized eigenspace -/
 


### PR DESCRIPTION
### Motivation

- `TNLean/Wielandt/RankOne/SpanGrowth.lean` contained a proof of `mapsTo_range_pow` that unpacked a range witness and reassociated `f^(D+1)` on elements; Mathlib 4.31 provides `LinearMap.range_comp_le_range` and `Module.End.iterate_succ` / `iterate_succ'` which make this element-level argument redundant.
- Removing the witness-unpacking in favour of a submodule image inclusion reduces the proof to a two-step range comparison and eliminates manual power reassociation from the Wielandt span-growth argument.

### Description

- Modified `TNLean/Wielandt/RankOne/SpanGrowth.lean` (−11 lines, +9 lines): rewrites the proof body of `mapsTo_range_pow` through a submodule image inclusion.
- The new proof shows `Submodule.map f (range (f^D)) ≤ range (f^D)` via `LinearMap.range_comp`, commuting `f ∘ f^D` and `f^D ∘ f` using `Module.End.iterate_succ` / `iterate_succ'`, then applies `LinearMap.range_comp_le_range`.
- No change to the statement of `mapsTo_range_pow` or its downstream uses (`ker_restrict_range_pow_eq_bot`, `isUnit_restrict_range_pow`); no new `sorry` introduced.

### Testing

- `lake exe cache get`
- `lake build TNLean.Wielandt.RankOne.SpanGrowth -q --log-level=info`
- `git diff --check`
- Proof-integrity scan (diff against `origin/main`): no newly introduced `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.
- Prose and blueprint scripts: `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`, `python3 scripts/blueprint_lean_sync.py --root . --ci`.
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor of a single lemma; no API or behavioral changes beyond Lean proof structure.
>
> **Overview**
> Refactors the proof of **`mapsTo_range_pow`** in `SpanGrowth.lean` without changing its statement or downstream uses (`ker_restrict_range_pow_eq_bot`, `isUnit_restrict_range_pow`, etc.).
>
> Instead of unpacking a range witness and reassociating `f^(D+1)` on elements, the proof shows **`Submodule.map f (range (f^D)) ≤ range (f^D)`** via `LinearMap.range_comp`, commuting **`f ∘ f^D`** and **`f^D ∘ f`** with `Module.End.iterate_succ` / `iterate_succ'`, and **`LinearMap.range_comp_le_range`**.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a9dd5b057aa71fdfc31efe77e4f42f41f477bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>