### PR TITLE
refactor(Wielandt): reuse D-power rectangular injectivity

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/Growth.lean
+++ b/TNLean/Wielandt/RectangularSpan/Growth.lean
@@ -133,7 +133,7 @@ private theorem vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow'
 /-- Matrix-level injectivity on the range of left multiplication by `(A i₀)^D`.
 
 If `X ∈ range(mulLeft ((A i₀)^D))` and `(A i₀) * X = 0`, then `X = 0`. -/
-private theorem matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow'
+theorem matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
     {X : Matrix (Fin D) (Fin D) ℂ}
     (hX : X ∈ LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D)))
     (hMX : (A i₀) * X = 0) : X = 0 := by
@@ -175,7 +175,7 @@ theorem rectSpanLeftStep_injective (n : ℕ) :
       (hrect_le_range x.2)
       (hrect_le_range y.2)
   have hzero : x.1 - y.1 = 0 :=
-    matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow' A i₀ hzRange hz
+    matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow A i₀ hzRange hz
   exact Subtype.ext (by simpa [sub_eq_zero] using hzero)
 
 /-- Finrank is non-decreasing along the sequence

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
@@ -83,52 +83,10 @@ private theorem matrix_eq_zero_of_mul_nilpIndex
     (hX : X ∈ LinearMap.range (LinearMap.mulLeft ℂ
       ((A i₀) ^ nilpIndex (toLin' (A i₀)))))
     (hMX : (A i₀) * X = 0) : X = 0 := by
-  -- X ∈ range(mulLeft ((A i₀)^r)) = range(mulLeft ((A i₀)^D))
   have hXD : X ∈ LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D)) :=
     range_mulLeft_pow_nilpIndex_eq A i₀ ▸ hX
-  -- Now use the column-based injectivity from the D-th power
-  -- Same proof as matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow'
-  classical
-  have hcols : ∀ j : Fin D, X.col j ∈
-      LinearMap.range (Matrix.toLin' ((A i₀) ^ D)) := by
-    have := (mem_range_mulLeft_iff_cols (D := D) (P := (A i₀) ^ D) (M := X)).1 hXD
-    simpa using this
-  set f : End ℂ (Fin D → ℂ) := toLin' (A i₀)
-  have hdisj : Disjoint (LinearMap.ker f)
-      (LinearMap.range (f ^ D)) := by
-    have hker_le : LinearMap.ker f ≤
-        End.maxGenEigenspace f (0 : ℂ) := by
-      intro x hx
-      refine (End.mem_maxGenEigenspace f (0 : ℂ) x).2 ⟨1, ?_⟩
-      simpa using (LinearMap.mem_ker.mp hx)
-    have hindep : iSupIndep (End.maxGenEigenspace f) :=
-      independent_maxGenEigenspace f
-    have hdisj0 : Disjoint (End.maxGenEigenspace f (0 : ℂ))
-        (⨆ (μ : ℂ) (_ : μ ≠ (0 : ℂ)), End.maxGenEigenspace f μ) := hindep 0
-    simpa [WielandtRankOne.range_pow_eq_iSup_maxGenEigenspace_ne_zero
-      (D := D) f] using Disjoint.mono_left hker_le hdisj0
-  have hcol0 : ∀ j : Fin D, X.col j = 0 := by
-    intro j
-    have hcolKilled : (A i₀) *ᵥ (X.col j) = 0 := by
-      have : ((A i₀) * X).col j = 0 := by
-        have hzero : (0 : Matrix (Fin D) (Fin D) ℂ).col j = (0 : Fin D → ℂ) := by
-          ext i
-          simp [Matrix.col_apply]
-        simpa [hzero] using congrArg (fun Z : Matrix (Fin D) (Fin D) ℂ => Z.col j) hMX
-      simpa [col_mul (P := A i₀) (X := X) (j := j)] using this
-    have hv : X.col j ∈ LinearMap.range (f ^ D) := by
-      simpa [f, Matrix.toLin'_pow] using hcols j
-    have hker : X.col j ∈ LinearMap.ker f := by
-      refine LinearMap.mem_ker.mpr ?_
-      simpa [f, Matrix.toLin'_apply] using hcolKilled
-    have : X.col j ∈ (⊥ : Submodule ℂ (Fin D → ℂ)) :=
-      hdisj.eq_bot ▸ ⟨hker, hv⟩
-    simpa using this
-  apply Matrix.ext_col
-  intro j
-  have hzero : (0 : Matrix (Fin D) (Fin D) ℂ).col j = (0 : Fin D → ℂ) := by
-    ext i; simp [Matrix.col_apply]
-  simp [hcol0 j, hzero]
+  exact RectSpanGrowth.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+    A i₀ hXD hMX
 
 /-- Linear map sending `rectSpan ((A i₀)^r) A n` to `rectSpan ((A i₀)^r) A (n+1)`
 by left-multiplication with `A i₀`, where `r = nilpIndex`. -/


### PR DESCRIPTION
### Motivation

- `UniversalityAux/NilpIndex.lean` proved the nilpIndex injectivity lemma by repeating a 44-line columnwise Fitting-disjointness argument already present in `RectangularSpan/Growth.lean`.
- The D-power injectivity lemma in `Growth.lean` was `private`, preventing reuse; making it public allows the duplicated argument to be replaced by a two-step appeal to that lemma.

### Description

- `TNLean/Wielandt/RectangularSpan/Growth.lean`: promoted `matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow'` from `private` to a public declaration (renamed `matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow`). The lemma states: if $X \in \operatorname{range}(\mu_{(A_{i_0})^D})$ and $(A_{i_0}) X = 0$, then $X = 0$, where $\mu_M$ denotes left multiplication by $M$.
- `TNLean/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean`: replaced the duplicated columnwise Fitting-disjointness argument with a two-step proof — rewrite the range of left multiplication by $(A_{i_0})^r$ as the range of $(A_{i_0})^D$ via `range_mulLeft_pow_nilpIndex_eq`, then delegate to the now-public D-power lemma (net: −44 lines, +2 lines).

### Testing

- `lake build TNLean.Wielandt.RectangularSpan.UniversalityAux.NilpIndex -q --log-level=info`
- Added-line proof-integrity scan for `sorry|admit|axiom|native_decide|unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.