### PR TITLE
fix(Wielandt): repair rectangular range equality proof

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
@@ -100,13 +100,22 @@ theorem range_mulLeft_pow_nilpIndex_eq
     rw [toLin'_pow, toLin'_pow]
     exact (range_pow_eq_of_nilpIndex_le f
       (nilpIndex_le_D' f)).symm
+  have hrange_pow_eq :
+      LinearMap.range (f ^ r) =
+        LinearMap.range (f ^ D) := by
+    simpa [f, toLin'_pow] using hrange_eq
   rw [range_mulLeft_eq_pi, range_mulLeft_eq_pi]
   ext M
-  change (∀ j : Fin D,
-      M.col j ∈ LinearMap.range (toLin' ((A i₀) ^ r))) ↔
-    ∀ j : Fin D,
-      M.col j ∈ LinearMap.range (toLin' ((A i₀) ^ D))
-  rw [hrange_eq]
+  simp only [colRangeSubmodule, Submodule.mem_comap]
+  constructor
+  · intro h j hj
+    have hjr : Mᵀ j ∈ LinearMap.range (f ^ r) := by
+      simpa [f] using h j hj
+    simpa [f, hrange_pow_eq] using hjr
+  · intro h j hj
+    have hjD : Mᵀ j ∈ LinearMap.range (f ^ D) := by
+      simpa [f] using h j hj
+    simpa [f, hrange_pow_eq.symm] using hjD
 
 /-- Eigenvector in range of `toLin' ((A i₀)^r)`. -/
 theorem eigenvector_mem_range_toLin_pow_nilpIndex


### PR DESCRIPTION
### Motivation
- `range_mulLeft_pow_nilpIndex_eq` in `TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean` stopped typechecking after the rectangular column-range refactor in #3239, which changed the definitional shape of `colRangeSubmodule` and `range_mulLeft_eq_pi`.
- The previous proof relied on a single `hrange_eq` rewrite on `toLin'` powers that no longer applied, causing a full-build failure.

### Description
- `TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean` (14 additions, 5 deletions): repairs the proof of `range_mulLeft_pow_nilpIndex_eq`.
- The new proof introduces `hrange_pow_eq` on `LinearMap.range (f ^ r)` vs `(f ^ D)`, rewrites both sides via `range_mulLeft_eq_pi`, and establishes `colRangeSubmodule` membership by `ext` with `Submodule.mem_comap`, swapping `r` and `D` column-wise via transpose columns `Mᵀ j`.
- No change to the theorem statement or downstream sharp-route lemmas — proof strategy only.

### Testing
- `lake build TNLean.Wielandt.RectangularSpan.UniversalityAux.Sharp -q --log-level=info`
- `git diff --check origin/main...HEAD`
- Added-line proof-integrity scan confirmed no new `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
No linked issue found. If this addresses a tracked issue, add `Addresses #N` manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only repair in one Lean theorem with no API or runtime behavior changes.
> 
> **Overview**
> Repairs **`range_mulLeft_pow_nilpIndex_eq`** so it still typechecks after the rectangular **`colRangeSubmodule`** / **`range_mulLeft_eq_pi`** refactor.
> 
> The proof no longer rewrites column membership with a single **`hrange_eq`** on **`toLin'`** powers. It introduces **`hrange_pow_eq`** on **`LinearMap.range (f ^ r)`** vs **`(f ^ D)`**, rewrites both sides through **`range_mulLeft_eq_pi`**, and shows **`colRangeSubmodule`** membership by **`ext`** with **`Submodule.mem_comap`**, swapping **`r`** and **`D`** column-wise via transpose columns **`Mᵀ j`**.
> 
> No change to the theorem statement or downstream sharp-route lemmas—only the proof strategy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef225ac18f68ff5c493527c7110a50b0b077d9bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->