### PR TITLE
fix(Peripheral): restrict power closure to positive exponents

### DIFF
--- a/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
+++ b/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
@@ -200,6 +200,7 @@ theorem peripheral_isRootOfUnity_of_irreducible_unital_of_adjoint_fixedPoint
     peripheralEigenvalues_pow_mem_of_irreducible_unital_of_adjoint_fixedPoint
       (K := K) h_unital ρ hρ hfix hIrr
   exact peripheral_isRootOfUnity_of_closed_powers
-    (E := MPSTensor.transferMap (d := d) (D := D) K) hclosed μ hμ
+    (E := MPSTensor.transferMap (d := d) (D := D) K)
+    (fun ν hν n _hn => hclosed ν hν n) μ hμ
 
 end MPSTensor

--- a/TNLean/Channel/Peripheral/Powers.lean
+++ b/TNLean/Channel/Peripheral/Powers.lean
@@ -24,19 +24,20 @@ section
 
 variable {V : Type*} [AddCommGroup V] [Module ℂ V]
 
-/-- **Finite peripheral eigenvalue set + global closure under powers ⇒ root of unity**.
+/-- **Finite peripheral eigenvalue set + positive-power closure ⇒ root of unity**.
 
 This is the “set-level” version: assuming
-`∀ μ ∈ peripheralEigenvalues E, ∀ n, μ^n ∈ peripheralEigenvalues E`, any
+`∀ μ ∈ peripheralEigenvalues E, ∀ n, 0 < n → μ^n ∈ peripheralEigenvalues E`, any
 `μ ∈ peripheralEigenvalues E` is a root of unity.
 It is a direct application of `peripheral_isRootOfUnity_of_pow_eigenvalue`. -/
 theorem peripheral_isRootOfUnity_of_closed_powers
     [FiniteDimensional ℂ V]
     (E : V →ₗ[ℂ] V)
-    (hclosed : ∀ μ : ℂ, μ ∈ peripheralEigenvalues E → ∀ n : ℕ,
+    (hclosed : ∀ μ : ℂ, μ ∈ peripheralEigenvalues E → ∀ n : ℕ, 0 < n →
       μ ^ n ∈ peripheralEigenvalues E)
     (μ : ℂ) (hμ : μ ∈ peripheralEigenvalues E) :
     ∃ p : ℕ, 0 < p ∧ μ ^ p = 1 := by
-  exact peripheral_isRootOfUnity_of_pow_eigenvalue E μ hμ.2 fun n => (hclosed μ hμ n).1
+  exact peripheral_isRootOfUnity_of_pow_eigenvalue E μ hμ.2
+    fun n hn => (hclosed μ hμ n hn).1
 
 end

--- a/TNLean/Channel/Peripheral/Spectrum.lean
+++ b/TNLean/Channel/Peripheral/Spectrum.lean
@@ -120,20 +120,32 @@ theorem isRootOfUnity_of_finite_powers (μ : ℂ) (hμ : ‖μ‖ = 1)
       mul_left_cancel₀ (pow_ne_zero _ hμ_ne) (by
         rw [← pow_add, Nat.add_sub_cancel' h.le, mul_one]; exact heq)⟩
 
-/-- **Peripheral eigenvalues with powers-are-eigenvalues property are roots of unity.**
+/-- **Peripheral eigenvalues with positive powers that are eigenvalues are roots of unity.**
 This is the combinatorial core of **Wolf Theorem 6.6** (Peripheral spectrum of
 irreducible Schwarz maps), item 1: the peripheral spectrum forms a cyclic group
 `{exp(2πik/m)}_{k ∈ ℤ_m}`. For irreducible CPTP maps, the multiplicative domain
-theory ensures that powers of peripheral eigenvalues remain eigenvalues. -/
+theory ensures that positive powers of peripheral eigenvalues remain eigenvalues. -/
 theorem peripheral_isRootOfUnity_of_pow_eigenvalue
     {V : Type*} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
     (E : V →ₗ[ℂ] V)
     (μ : ℂ) (hμ_norm : ‖μ‖ = 1)
-    (hpow : ∀ n : ℕ, Module.End.HasEigenvalue E (μ ^ n)) :
+    (hpow : ∀ n : ℕ, 0 < n → Module.End.HasEigenvalue E (μ ^ n)) :
     ∃ p : ℕ, 0 < p ∧ μ ^ p = 1 := by
+  have hfin_pos : Set.Finite {z : ℂ | ∃ n : ℕ, z = μ ^ (n + 1)} := by
+    apply Set.Finite.subset (Module.End.finite_hasEigenvalue E)
+    intro z hz
+    rcases hz with ⟨n, rfl⟩
+    exact hpow (n + 1) (Nat.succ_pos n)
   apply isRootOfUnity_of_finite_powers μ hμ_norm
-  apply Set.Finite.subset (Module.End.finite_hasEigenvalue E)
-  intro z ⟨n, hz⟩; rw [hz]; exact hpow n
+  refine (hfin_pos.insert 1).subset ?_
+  intro z hz
+  rcases hz with ⟨n, rfl⟩
+  cases n with
+  | zero => simp
+  | succ n =>
+      simp only [Set.mem_insert_iff, Set.mem_setOf_eq]
+      right
+      exact ⟨n, rfl⟩
 
 /-- **Explicit bound**: among `μ^0, ..., μ^n`, a repeat gives a root of unity. -/
 theorem isRootOfUnity_of_norm_one_of_finite_orbit (μ : ℂ) (hμ : ‖μ‖ = 1)

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
@@ -100,13 +100,13 @@ theorem range_mulLeft_pow_nilpIndex_eq
     rw [toLin'_pow, toLin'_pow]
     exact (range_pow_eq_of_nilpIndex_le f
       (nilpIndex_le_D' f)).symm
+  have hrange_eq' :
+      LinearMap.range ((toLin' (A i₀)) ^ r) =
+        LinearMap.range ((toLin' (A i₀)) ^ D) := by
+    simpa [← toLin'_pow] using hrange_eq
   rw [range_mulLeft_eq_pi, range_mulLeft_eq_pi]
   ext M
-  change (∀ j : Fin D,
-      M.col j ∈ LinearMap.range (toLin' ((A i₀) ^ r))) ↔
-    ∀ j : Fin D,
-      M.col j ∈ LinearMap.range (toLin' ((A i₀) ^ D))
-  rw [hrange_eq]
+  simp [colRangeSubmodule, hrange_eq']
 
 /-- Eigenvector in range of `toLin' ((A i₀)^r)`. -/
 theorem eigenvector_mem_range_toLin_pow_nilpIndex

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -503,7 +503,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 
 \begin{proof}
     \leanok
-    Since $\mu^n$ is an eigenvalue for every~$n$,
+    Since $\mu^n$ is an eigenvalue for every positive~$n$,
     the pigeonhole principle on the finite eigenvalue set gives
     $\mu^a = \mu^b$ for some $a \neq b$, hence $\mu^{|a-b|} = 1$.
 \end{proof}
@@ -525,7 +525,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \leanok
     \uses{thm:peripheral_roots_of_unity}
     The closure hypothesis provides
-    $\mu^n \in \mathrm{peripheral}(E)$ for all $n$,
+    $\mu^n \in \mathrm{peripheral}(E)$ for all positive~$n$,
     which in particular means $\mu^n$ is an eigenvalue.
     Theorem~\ref{thm:peripheral_roots_of_unity} then gives
     $\mu^p = 1$ for some $p > 0$.


### PR DESCRIPTION
### Motivation

- The blueprint theorem `thm:peripheral_powers` (`blueprint/src/chapter/ch04_channels.tex:511–522`) requires eigenvalue power-closure only for exponents `n ≥ 1`, but the Lean signature of `peripheral_isRootOfUnity_of_closed_powers` previously quantified over `∀ n : ℕ` (including `n = 0`), making the hypothesis strictly stronger than the source theorem.
- Under the faithfulness rule, the `\leanok` tag at ch04_channels.tex:513 was therefore inaccurate; this PR restores faithfulness.
- Continues paper-realignment work from LionSR/TNLean#3238; see tracking issue LionSR/QICLean#42 (Wolf Ch6 spectral properties).

### Description

- `TNLean/Channel/Peripheral/Powers.lean`: restricted `hclosed` to `0 < n` in `peripheral_isRootOfUnity_of_closed_powers` and adjusted the proof of `peripheral_isRootOfUnity_of_pow_eigenvalue` accordingly.
- `TNLean/Channel/Peripheral/Spectrum.lean`: reworked the pigeonhole argument to use finiteness of `{μ^(n+1)}` and handle `μ^0 = 1` separately under the positive-exponent hypothesis.
- `TNLean/Channel/Peripheral/ClosureFixedPoint.lean`: updated the existing caller (which has all-power closure from irreducibility) to pass a positivity witness when invoking the now-weaker lemma.
- `TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean`: fixed a brittle range rewrite (`hrange_eq'` + `colRangeSubmodule`) in `range_mulLeft_pow_nilpIndex_eq` that prevented the full root build from completing on current main.
- `blueprint/src/chapter/ch04_channels.tex`: updated proof prose to reflect the positive-exponent restriction.

### Testing

- Built `TNLean.Channel.Peripheral.Spectrum`, `TNLean.Channel.Peripheral.Powers`, and `TNLean.Channel.Peripheral.ClosureFixedPoint` individually.
- Built `TNLean.Wielandt.RectangularSpan.UniversalityAux.Sharp` individually.
- Verified blueprint sync: `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && python3 scripts/blueprint_lean_sync.py --root . --ci`.
- Full build: `lake build TNLean -q --log-level=info`.
- Blueprint declaration check: `lake exe checkdecls blueprint/lean_decls`.
- Whitespace check: `git diff --check`.

---
Closes LionSR/QICLean#159

> [!NOTE]
> **Low Risk**
> Changes are localized spectral formalization and a proof refactor in Wielandt auxiliaries; no runtime, auth, or data paths. Main risk is a subtle Mathlib hypothesis mismatch if another caller still assumed all `n : ℕ`.
>
> **Overview**
> Aligns the peripheral **root-of-unity** chain with the blueprint by requiring eigenvalue closure only for **positive** exponents `n > 0`, not for `n = 0`.
>
> In `peripheral_isRootOfUnity_of_pow_eigenvalue` and `peripheral_isRootOfUnity_of_closed_powers`, the hypotheses now take `0 < n` witnesses; the pigeonhole proof in `Spectrum.lean` is reworked to use finiteness of `{μ^(n+1)}` and treat `μ^0 = 1` separately. `ClosureFixedPoint.lean` still has full power closure from irreducibility but passes a lambda that supplies the positivity proof into the weaker lemma.
>
> Blueprint proof text in `ch04_channels.tex` is updated to match. Separately, `range_mulLeft_pow_nilpIndex_eq` in `Sharp.lean` fixes a brittle range rewrite (`hrange_eq'` + `colRangeSubmodule`) so the full TNLean build completes.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef0b35d5f955b9a45981467fb12d54835d1f0b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>