### PR TITLE
refactor(Wielandt): inline nilpotent range comparison

### DIFF
--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/Sharp.lean
@@ -95,18 +95,13 @@ theorem range_mulLeft_pow_nilpIndex_eq
   set f := toLin' (A i₀)
   set r := nilpIndex f
   have hrange_eq :
-      LinearMap.range (toLin' ((A i₀) ^ r)) =
-        LinearMap.range (toLin' ((A i₀) ^ D)) := by
-    rw [toLin'_pow, toLin'_pow]
-    exact (range_pow_eq_of_nilpIndex_le f
+      LinearMap.range (f ^ r) =
+        LinearMap.range (f ^ D) :=
+    (range_pow_eq_of_nilpIndex_le f
       (nilpIndex_le_D' f)).symm
-  have hrange_eq' :
-      LinearMap.range ((toLin' (A i₀)) ^ r) =
-        LinearMap.range ((toLin' (A i₀)) ^ D) := by
-    simpa [← toLin'_pow] using hrange_eq
   rw [range_mulLeft_eq_pi, range_mulLeft_eq_pi]
   ext M
-  simp [colRangeSubmodule, hrange_eq']
+  simp [colRangeSubmodule, f, toLin'_pow, hrange_eq]
 
 /-- Eigenvector in range of `toLin' ((A i₀)^r)`. -/
 theorem eigenvector_mem_range_toLin_pow_nilpIndex


### PR DESCRIPTION
## Summary

- streamline `range_mulLeft_pow_nilpIndex_eq` after #3257 by keeping the nilpotent-index range equality directly in the `f ^ r` and `f ^ D` form
- remove the intermediate `hrange_eq'` comparison through `toLin' (A i₀)` powers
- leave all theorem statements unchanged

## Validation

- `lake build TNLean.Wielandt.RectangularSpan.UniversalityAux.Sharp -q --log-level=info`
- `git diff --check origin/main...HEAD`
- added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No API or theorem statement changes; only a localized proof refactor in Wielandt universality auxiliary code.
> 
> **Overview**
> Repairs the Lean proof of **`range_mulLeft_pow_nilpIndex_eq`** so CI passes again; the theorem statement is unchanged.
> 
> The proof now states nilpotent-index range equality directly on endomorphism powers, **`range (f ^ r) = range (f ^ D)`**, via **`range_pow_eq_of_nilpIndex_le`** (with **`.symm`**), instead of a two-step route through **`toLin'_pow`** and an extra **`hrange_eq'`** lemma. After **`range_mulLeft_eq_pi`**, column-range membership is closed with **`simp [colRangeSubmodule, f, toLin'_pow, hrange_eq]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e8e6d89acee7f558e848b312a3ac684396fcf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->