### PR TITLE
refactor(Wielandt): use native max generalized eigenspace lemmas

### DIFF
--- a/TNLean/Wielandt/FittingDecomposition.lean
+++ b/TNLean/Wielandt/FittingDecomposition.lean
@@ -116,21 +116,6 @@ theorem nilpotent_pow_eq_zero_of_finrank
 
 /-! ### Part 4–5: Eigenspace decomposition and structure -/
 
-theorem iSup_maxGenEigenspace_eq_top
-    {K : Type*} {V : Type*}
-    [Field K] [AddCommGroup V] [Module K V]
-    [IsAlgClosed K] [FiniteDimensional K V]
-    (f : End K V) :
-    ⨆ μ, f.maxGenEigenspace μ = ⊤ :=
-  End.iSup_maxGenEigenspace_eq_top f
-
-theorem independent_maxGenEigenspace
-    {K : Type*} {V : Type*}
-    [Field K] [AddCommGroup V] [Module K V]
-    (f : End K V) :
-    iSupIndep f.maxGenEigenspace :=
-  End.independent_maxGenEigenspace f
-
 structure FittingDecomposition
     {K : Type*} {V : Type*}
     [Field K] [AddCommGroup V] [Module K V]
@@ -149,8 +134,8 @@ theorem fittingDecomposition
     (f : End K V) : FittingDecomposition f where
   hNilpNilpotent := isNilpotent_restrict_maxGenEigenspace_zero f
   hInvertible μ hμ := isUnit_restrict_maxGenEigenspace_of_ne_zero f μ hμ
-  hSpan := iSup_maxGenEigenspace_eq_top f
-  hIndep := independent_maxGenEigenspace f
+  hSpan := End.iSup_maxGenEigenspace_eq_top f
+  hIndep := End.independent_maxGenEigenspace f
 
 theorem nilpotent_pow_eq_zero_on_maxGenEigenspace_zero
     {K : Type*} {V : Type*}

--- a/TNLean/Wielandt/RankOne/Element.lean
+++ b/TNLean/Wielandt/RankOne/Element.lean
@@ -125,7 +125,7 @@ theorem range_pow_le_iSup_maxGenEigenspace_ne_zero
   -- Use `⨆ μ, maxGenEigenspace f μ = ⊤` to write `x` as a sum of generalized-eigen pieces.
   have hx : x ∈ ⨆ μ : ℂ, f.maxGenEigenspace μ := by
     have htop : (⨆ μ : ℂ, f.maxGenEigenspace μ) = ⊤ :=
-      Wielandt.iSup_maxGenEigenspace_eq_top f
+      End.iSup_maxGenEigenspace_eq_top f
     simp [htop]
   -- Prove the desired membership by induction on `x ∈ ⨆ μ, maxGenEigenspace μ`.
   refine Submodule.iSup_induction (p := fun μ : ℂ => f.maxGenEigenspace μ)

--- a/TNLean/Wielandt/RankOne/SpanGrowth.lean
+++ b/TNLean/Wielandt/RankOne/SpanGrowth.lean
@@ -76,7 +76,7 @@ theorem disjoint_ker_iSup_maxGenEigenspace_ne_zero (f : End ℂ (Fin D → ℂ))
       (⨆ (μ : ℂ) (_ : μ ≠ 0), f.maxGenEigenspace μ) := by
   -- First: `maxGenEigenspace 0` is disjoint from the supremum of the others.
   have hindep : iSupIndep f.maxGenEigenspace :=
-    Wielandt.independent_maxGenEigenspace f
+    End.independent_maxGenEigenspace f
   have hdisj0 : Disjoint (f.maxGenEigenspace (0 : ℂ))
       (⨆ (μ : ℂ) (_ : μ ≠ (0 : ℂ)), f.maxGenEigenspace μ) :=
     hindep 0


### PR DESCRIPTION
### Motivation

- Local pass-through aliases for Mathlib's maximal generalized-eigenspace results (`End.iSup_maxGenEigenspace_eq_top` and `End.independent_maxGenEigenspace`) in `FittingDecomposition.lean` are pure indirection with no added mathematical content; removing them reduces the local declaration surface and makes call sites self-documenting.

### Description

- Removed two thin local theorems in `TNLean/Wielandt/FittingDecomposition.lean` that only forwarded to Mathlib's maximal generalized-eigenspace span and independence lemmas.
- Updated three call sites to invoke `End.iSup_maxGenEigenspace_eq_top` and `End.independent_maxGenEigenspace` directly: `fittingDecomposition` (in `FittingDecomposition.lean`), `range_pow_le_iSup_maxGenEigenspace_ne_zero` (in `RankOne/Element.lean`), and `disjoint_ker_iSup_maxGenEigenspace_ne_zero` (in `RankOne/SpanGrowth.lean`).
- All public theorem statements and `FittingDecomposition` structure fields are unchanged.

### Testing

- `lake exe cache get` (pre-build Mathlib cache)
- `lake build TNLean.Wielandt.RankOne.SpanGrowth TNLean.Wielandt.RankOne.Element -q --log-level=info`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast` returned no matches.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Pure indirection removal with no new logic; only proof-term references change in Wielandt linear-algebra files.
>
> **Overview**
> **Removes** two thin `Wielandt` theorems in `FittingDecomposition.lean` that only forwarded to Mathlib's maximal generalized-eigenspace **span** and **independence** results.
>
> **Call sites** now invoke `End.iSup_maxGenEigenspace_eq_top` and `End.independent_maxGenEigenspace` directly: in `fittingDecomposition`, in `range_pow_le_iSup_maxGenEigenspace_ne_zero` (`RankOne/Element.lean`), and in `disjoint_ker_iSup_maxGenEigenspace_ne_zero` (`RankOne/SpanGrowth.lean`). Public theorem statements and the `FittingDecomposition` structure fields are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49fe0127f971e618852c41666b5a73a34d6e63c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>