### PR TITLE
ci(docs): stop reporting blueprint sync engine failures as issues

### DIFF
--- a/.github/workflows/docs-blueprint-sync.lock.yml
+++ b/.github/workflows/docs-blueprint-sync.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"585aa5330a8ff1a4f9dffeb1489f832d6aeb5056d71de2a42fe298c0643d6562","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"0d75058492cc63da12236f8f685134b9c8e0515c4d23f821d1c1dec72e7aeb05","compiler_version":"v0.74.4","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"d3abfe96a194bce3a523ed2093ddedd5704cdf62","version":"v0.74.4"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.46"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.46"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -1098,7 +1098,7 @@ jobs:
           GH_AW_LOCKDOWN_CHECK_FAILED: ${{ needs.activation.outputs.lockdown_check_failed }}
           GH_AW_STALE_LOCK_FILE_FAILED: ${{ needs.activation.outputs.stale_lock_file_failed }}
           GH_AW_GROUP_REPORTS: "false"
-          GH_AW_FAILURE_REPORT_AS_ISSUE: "true"
+          GH_AW_FAILURE_REPORT_AS_ISSUE: "false"
           GH_AW_MISSING_TOOL_REPORT_AS_FAILURE: "true"
           GH_AW_MISSING_DATA_REPORT_AS_FAILURE: "true"
           GH_AW_TIMEOUT_MINUTES: "25"

--- a/.github/workflows/docs-blueprint-sync.md
+++ b/.github/workflows/docs-blueprint-sync.md
@@ -40,6 +40,7 @@ tools:
   edit:
 
 safe-outputs:
+  report-failure-as-issue: false
   create-pull-request:
     title-prefix: "doc(blueprint): "
     labels: [documentation, automation]


### PR DESCRIPTION
### Motivation

- The Docs & Blueprint Sync agentic workflow has been repeatedly creating GitHub issues (see #2366) due to Copilot engine quota failures (HTTP 429), not mathematical blueprint defects.
- These repeated failure issues add noise without actionable information about the blueprint state; the fix stops issue creation for this engine-level condition while keeping the failure visible in Actions.

### Description

- Set `safe-outputs.report-failure-as-issue: false` in `.github/workflows/docs-blueprint-sync.md`.
- Recompiled `.github/workflows/docs-blueprint-sync.lock.yml` so the deployed workflow passes `GH_AW_FAILURE_REPORT_AS_ISSUE: "false"` in the Handle agent failure step (previously `"true"`); updated lock metadata frontmatter hash accordingly.
- Failed runs remain visible in GitHub Actions; only the repeated failure-to-issue behavior is disabled. Other safe-output paths are unchanged.

### Testing

- `gh aw compile .github/workflows/docs-blueprint-sync.md`
- `gh aw validate .github/workflows/docs-blueprint-sync.md`
- `gh aw hash-frontmatter .github/workflows/docs-blueprint-sync.md` matches the lock metadata
- `git diff --check`

---
Closes #2366

> [!NOTE]
> **Low Risk**
> CI-only gh-aw workflow tuning with no application or auth changes; reduces issue spam while preserving Actions failure visibility.
> 
> **Overview**
> Disables **automatic GitHub issue creation** when the **Docs & Blueprint Sync** agentic workflow fails at the engine level.
> 
> The workflow source sets `safe-outputs.report-failure-as-issue: false`, and the compiled `docs-blueprint-sync.lock.yml` now passes `GH_AW_FAILURE_REPORT_AS_ISSUE: "false"` into the **Handle agent failure** step (previously `"true"`). Lock metadata frontmatter hash is updated to match the recompiled workflow.
> 
> Failed runs remain visible in Actions; only the repeated failure-to-issue behavior is turned off. Other safe-output paths (e.g. missing tool / incomplete reporting, protected-file fallback) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1bdcc17535421382239d378c7aa35c79d7d57d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>