### PR TITLE
refactor(Peripheral): use native power norm

### DIFF
--- a/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
+++ b/TNLean/Channel/Peripheral/ClosureFixedPoint.lean
@@ -174,7 +174,8 @@ theorem peripheralEigenvalues_pow_mem_of_irreducible_unital_of_adjoint_fixedPoin
     refine Module.End.hasEigenvalue_of_hasEigenvector (x := X ^ n) ?_
     refine (Module.End.hasEigenvector_iff.mpr ?_)
     exact ⟨(Module.End.mem_eigenspace_iff).2 hpow_transfer, hXpow_ne⟩
-  refine ⟨hEigPow_transfer, norm_pow_eq_one_of_norm_eq_one hμ_norm n⟩
+  refine ⟨hEigPow_transfer, ?_⟩
+  simp [norm_pow, hμ_norm]
 
 /-- For irreducible unital Kraus maps with a positive definite adjoint fixed point,
 all peripheral eigenvalues are roots of unity.

--- a/TNLean/Channel/Peripheral/IrreducibleChannel.lean
+++ b/TNLean/Channel/Peripheral/IrreducibleChannel.lean
@@ -175,7 +175,8 @@ theorem peripheral_isRootOfUnity_of_irreducible_channel [NeZero D]
   have hμp_eig : Module.End.HasEigenvalue
       ((MPSTensor.transferMap (d := r) (D := D) K) ^ p) (μ ^ p) := by
     simpa [hE_eq] using hμ_eig.pow p
-  have hμp_norm : ‖μ ^ p‖ = 1 := norm_pow_eq_one_of_norm_eq_one hμ_norm p
+  have hμp_norm : ‖μ ^ p‖ = 1 := by
+    simp [norm_pow, hμ_norm]
   exact ⟨p, hp_pos, hPrimP.unique_peripheral (μ ^ p) hμp_eig hμp_norm⟩
 
 /-- Channel-level formulation for `compl_eigenvalue_norm_lt_one_of_primitive`.

--- a/TNLean/Channel/Peripheral/Spectrum.lean
+++ b/TNLean/Channel/Peripheral/Spectrum.lean
@@ -79,10 +79,6 @@ theorem one_mem_peripheralEigenvalues
     (1 : ℂ) ∈ peripheralEigenvalues E :=
   ⟨hasEigenvalue_of_eigenvector_eq E 1 ρ (by simp [hfix]) hne, by simp⟩
 
-/-- Powers of a unit-norm complex number have norm 1. -/
-theorem norm_pow_eq_one_of_norm_eq_one {μ : ℂ} (hμ : ‖μ‖ = 1) (n : ℕ) :
-    ‖μ ^ n‖ = 1 := by rw [norm_pow, hμ, one_pow]
-
 /-- In finite dimensions, the peripheral eigenvalue set is finite. -/
 theorem peripheralEigenvalues_finite
     {V : Type*} [AddCommGroup V] [Module ℂ V]

--- a/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
+++ b/TNLean/Wielandt/Primitivity/ImpliesStronglyIrreducibleAux.lean
@@ -615,7 +615,8 @@ theorem isPeripherallyPrimitive_of_isPrimitivePaper [NeZero D]
         ((Module.End.hasEigenvector_iff.mpr
           ⟨Module.End.mem_eigenspace_iff.mpr hEigP, hX_ne⟩))
     -- ‖μ^p‖ = 1
-    have hμp_norm : ‖μ ^ p‖ = 1 := norm_pow_eq_one_of_norm_eq_one hμ_norm p
+    have hμp_norm : ‖μ ^ p‖ = 1 := by
+      simp [norm_pow, hμ_norm]
     -- By IsPrimitive (E^p): μ^p = 1
     have hμp_eq : μ ^ p = 1 := hPrimP.unique_peripheral (μ ^ p) hμp_eig hμp_norm
     -- If μ ≠ 1, get contradiction via Part 13


### PR DESCRIPTION
### Motivation

- Mathlib 4.31 already supplies the norm-of-a-power identity as `norm_pow`.
- The local theorem `norm_pow_eq_one_of_norm_eq_one` in `TNLean/Channel/Peripheral/Spectrum.lean` only rewrote by `norm_pow`, then by the hypothesis `‖μ‖ = 1`.
- Keeping this as a named local theorem added an unnecessary pass-through layer in the peripheral-spectrum development.

### Description

- Remove `norm_pow_eq_one_of_norm_eq_one`.
- Replace its three internal uses in peripheral-spectrum and Wielandt primitivity proofs by direct `simp [norm_pow, hμ_norm]` proofs at the point where `‖μ ^ n‖ = 1` is needed.
- No theorem statements, blueprint tags, or mathematical hypotheses change.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Peripheral.ClosureFixedPoint TNLean.Channel.Peripheral.IrreducibleChannel TNLean.Wielandt.Primitivity.ImpliesStronglyIrreducibleAux -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
_(No linked issue found — please add `Addresses #N` to this footer once an issue is created or identified.)_

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or mathematical statement changes; behavior is unchanged aside from shorter proofs.
>
> **Overview**
> Drops the pass-through lemma **`norm_pow_eq_one_of_norm_eq_one`** from `TNLean/Channel/Peripheral/Spectrum.lean` now that Mathlib's **`norm_pow`** covers the same step.
>
> At the three former call sites—peripheral closure under powers (`ClosureFixedPoint`), irreducible channel roots-of-unity (`IrreducibleChannel`), and Wielandt primitivity (`ImpliesStronglyIrreducibleAux`)—proofs that **`‖μ ^ n‖ = 1`** from **`‖μ‖ = 1`** are written directly with **`simp [norm_pow, hμ_norm]`** instead of invoking the local theorem.
>
> No theorem statements, hypotheses, or blueprint-facing API change.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87f207e2f44420ca996097a8d7f51a9e89590b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>