### PR TITLE
refactor(MPS/Irreducible): inline unitary support identities

### DIFF
--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -75,21 +75,6 @@ private lemma supportProj_eq : supportProj (D := D) ρ hρ = supportU (D := D) �
     Matrix.diagonal (sgnEig (D := D) ρ hρ) * (supportU (D := D) ρ hρ)ᴴ := by
   rfl
 
-private lemma supportU_star_mul_self : (supportU (D := D) ρ hρ)ᴴ * supportU (D := D) ρ hρ = 1 := by
-  -- `Uᴴ * U = 1` for a unitary matrix.
-  classical
-  -- rewrite `ᴴ` as `star` to use the `UnitaryGroup` lemma.
-  rw [← Matrix.star_eq_conjTranspose]
-  simp [supportU]
-
-private lemma supportU_mul_star_self : supportU (D := D) ρ hρ * (supportU (D := D) ρ hρ)ᴴ = 1 := by
-  classical
-  -- The unitary group lemma is phrased with `star`.
-  have : (supportU (D := D) ρ hρ) * star (supportU (D := D) ρ hρ) = 1 := by
-    -- `U * star U = 1` for a unitary.
-    simp [supportU]
-  simpa [Matrix.star_eq_conjTranspose] using this
-
 private lemma sgnEig_star : star (sgnEig (D := D) ρ hρ) = sgnEig (D := D) ρ hρ := by
   classical
   ext i
@@ -121,8 +106,11 @@ lemma supportProj_idem :
     supportProj (D := D) ρ hρ * supportProj (D := D) ρ hρ = supportProj (D := D) ρ hρ := by
   classical
   -- Write `P = U * diag(s) * Uᴴ`.
-  have hUU : (supportU (D := D) ρ hρ)ᴴ * supportU (D := D) ρ hρ = 1 :=
-    supportU_star_mul_self (D := D) (ρ := ρ) (hρ := hρ)
+  have hUU : (supportU (D := D) ρ hρ)ᴴ * supportU (D := D) ρ hρ = 1 := by
+    rw [← Matrix.star_eq_conjTranspose]
+    change star (↑hρ.isHermitian.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
+        (↑hρ.isHermitian.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) = 1
+    exact Matrix.UnitaryGroup.star_mul_self hρ.isHermitian.eigenvectorUnitary
   rw [supportProj_eq (D := D) (ρ := ρ) (hρ := hρ)]
   -- Expand `P * P` using `Uᴴ * U = 1` and `diag(s) * diag(s) = diag(s)`.
   change supportU (D := D) ρ hρ * Matrix.diagonal (sgnEig (D := D) ρ hρ) *


### PR DESCRIPTION
### Motivation

- Mathlib 4.31 provides the unitary identity `Matrix.UnitaryGroup.star_mul_self`.
- `TNLean/MPS/Irreducible/FixedPointProjection.lean` had two private support-unitary lemmas that only repackaged the same unitary-group calculation; one of them was unused, and the other was used once in the idempotence proof for the support projection.
- Removing these private pass-through lemmas makes the support-projection proof cite the native unitary-group fact directly.

### Description

- Delete `supportU_star_mul_self` and the unused `supportU_mul_star_self`.
- In `supportProj_idem`, prove the needed `Uᴴ * U = 1` identity directly from `Matrix.UnitaryGroup.star_mul_self`, after rewriting conjugate transpose to `star`.
- No public theorem statement, hypothesis, or blueprint entry changes.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
No linked issue identified; author should add an `Addresses #N` reference manually.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a private lemma section; behavior and exported theorems are unchanged.
>
> **Overview**
> Removes two private lemmas (`supportU_star_mul_self` and unused `supportU_mul_star_self`) that only repackaged unitary-matrix identities now available as **`Matrix.UnitaryGroup.star_mul_self`** in Mathlib 4.31.
>
> In **`supportProj_idem`**, the needed **`Uᴴ * U = 1`** step is proved inline by rewriting conjugate transpose to **`star`** and applying that unitary-group lemma directly on the Hermitian eigenvector unitary.
>
> No changes to public theorem statements, hypotheses, or blueprint entries.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809b241b0fea775561ed82e2feb29588ed2b1419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>