### PR TITLE
refactor(MPS/Irreducible): reuse Hermitian dot-product helper

### DIFF
--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -232,19 +232,6 @@ end SupportProjLemmas
 
 section FixedPointInvariant
 
-/-- Adjoint identity for dot product: `star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y`.
-
-This auxiliary lemma is intentionally kept local to this file: unlike
-`orthogonalProjection_posSemidef` in `Irreducible/Basic`, this is a small linear-algebra
-rewrite used only in the fixed-point support-projection argument below, and there is no
-second in-repo call site.
--/
-private lemma dotProduct_mulVec_conjTranspose
-    (M : Matrix (Fin D) (Fin D) ℂ)
-    (x y : Fin D → ℂ) :
-    star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y := by
-  rw [Matrix.dotProduct_mulVec, Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
-
 /-- If `ρ` is PSD and `E_A(ρ)=ρ`, then `ker ρ` is invariant under each adjoint Kraus operator.
 
 Formally, `ρ *ᵥ x = 0` implies `ρ *ᵥ ((A i)ᴴ *ᵥ x) = 0`.
@@ -269,7 +256,7 @@ private lemma ker_invariant_under_adjoint
     -- reassociate and use the adjoint identity
     have : (A i * ρ * (A i)ᴴ) *ᵥ x = A i *ᵥ (ρ *ᵥ ((A i)ᴴ *ᵥ x)) := by
       simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]
-    rw [this, dotProduct_mulVec_conjTranspose]
+    rw [this, HermitianHelpers.dotProduct_mulVec_conjTranspose]
   have h_each_zero : ∀ i : Fin d,
       star ((A i)ᴴ *ᵥ x) ⬝ᵥ (ρ *ᵥ ((A i)ᴴ *ᵥ x)) = 0 := by
     intro i


### PR DESCRIPTION
### Motivation

- `FixedPointProjection` carried a private copy of the adjoint dot-product identity even though the file already imports the shared Hermitian helper exposing the same identity.
- The local comment also claimed there was no second in-repository call site, which is no longer true.

### Description

- Delete the private `dotProduct_mulVec_conjTranspose` lemma from `TNLean.MPS.Irreducible.FixedPointProjection`.
- Wire the support-projection proof in `ker_invariant_under_adjoint` to use `HermitianHelpers.dotProduct_mulVec_conjTranspose` from the already-imported `TNLean.Algebra.HermitianHelpers` instead.
- Theorem statements, hypotheses, and blueprint-facing declarations are unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
No linked issue found for this PR.

> [!NOTE]
> **Low Risk**
> Proof-only refactor with a one-line rewrite; no API or behavioral changes beyond removing dead duplicate code.
>
> **Overview**
> Removes the **private duplicate** of the adjoint dot-product identity (`star x ⬝ᵥ (M *ᵥ y) = …`) from `FixedPointProjection` and wires the existing proof in `ker_invariant_under_adjoint` to **`HermitianHelpers.dotProduct_mulVec_conjTranspose`** instead.
>
> No changes to theorem statements, hypotheses, or blueprint-facing declarations—only consolidation onto the shared helper already imported from `TNLean.Algebra.HermitianHelpers`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beafd327fe55f11f5492c956a92d1293039d6eb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>