### PR TITLE
refactor(Algebra): generalize adjoint dot-product helper

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -145,7 +145,7 @@ namespace HermitianHelpers
 
 /-- Adjoint identity for the matrix-vector dot-product pairing. -/
 theorem dotProduct_mulVec_conjTranspose
-    (M : Matrix (Fin D) (Fin D) ℂ) (x y : Fin D → ℂ) :
+    {m n : ℕ} (M : Matrix (Fin m) (Fin n) ℂ) (x : Fin m → ℂ) (y : Fin n → ℂ) :
     star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y := by
   rw [Matrix.dotProduct_mulVec, Matrix.star_mulVec,
     Matrix.conjTranspose_conjTranspose]

--- a/TNLean/Channel/Spectral/Support.lean
+++ b/TNLean/Channel/Spectral/Support.lean
@@ -87,7 +87,7 @@ theorem compression_on_support_posDef
   have h_quadform : star w ⬝ᵥ ((V * ρ * Vᴴ) *ᵥ w) = star u ⬝ᵥ (ρ *ᵥ u) := by
     have h1 : (V * ρ * Vᴴ) *ᵥ w = V *ᵥ (ρ *ᵥ u) := by
       simp [u, Matrix.mulVec_mulVec, Matrix.mul_assoc]
-    rw [h1, Matrix.dotProduct_mulVec, Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
+    rw [h1, HermitianHelpers.dotProduct_mulVec_conjTranspose (M := V)]
   rw [h_quadform]
   -- Apply the pointwise strict positivity lemma.
   exact hρ.dotProduct_mulVec_pos_of_supportProj_fixed hu_ne hPu


### PR DESCRIPTION
### Motivation

- `HermitianHelpers.dotProduct_mulVec_conjTranspose` is the adjoint identity for the matrix-vector dot-product pairing. Its proof already used Mathlib's rectangular `Matrix.dotProduct_mulVec`, but the statement was specialized to square `Fin D` matrices.
- The support-compression proof in `Channel.Spectral.Support` therefore expanded the rectangular case by hand, duplicating what the helper could provide directly.

### Description

- Generalize `HermitianHelpers.dotProduct_mulVec_conjTranspose` from square `Matrix (Fin D) (Fin D) ℂ` to rectangular `Matrix (Fin m) (Fin n) ℂ`, with `x : Fin m → ℂ` and `y : Fin n → ℂ`; the proof is unchanged (same Mathlib rewrites).
- Use the generalized helper in `Matrix.PosSemidef.compression_on_support_posDef` to replace the inline expansion of `Matrix.dotProduct_mulVec` / `star_mulVec` / `conjTranspose_conjTranspose` for the rectangular compression matrix `V`.
- Public theorem conclusions and blueprint declarations are unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Spectral.Support -q --log-level=info`
- `lake build TNLean.QPF.PosDef TNLean.Channel.Irreducible.Growth.OneStep TNLean.MPS.Irreducible.FixedPointProjection TNLean.Channel.Spectral.Support -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses LionSR/QICLean#138

> [!NOTE]
> **Low Risk**
> Proof-only refactor in algebra helpers and one spectral proof step; no behavioral or API changes to public results.
>
> **Overview**
> **`HermitianHelpers.dotProduct_mulVec_conjTranspose`** is generalized from square `Matrix (Fin D) (Fin D)` to rectangular **`Matrix (Fin m) (Fin n) ℂ`** with `x : Fin m → ℂ` and `y : Fin n → ℂ`; the proof is unchanged (same Mathlib rewrites).
>
> In **`compression_on_support_posDef`**, the quadratic-form rewrite no longer inlines `Matrix.dotProduct_mulVec` / `star_mulVec` / `conjTranspose_conjTranspose` for the rectangular compression matrix `V`; it calls the helper with `(M := V)` instead. Stated theorem conclusions and blueprint-facing APIs are untouched.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1190f81a53c6a5de33e2cbafffdf32c1c75641. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>