### PR TITLE
refactor(Wielandt): reuse adjoint dot-product helper

### DIFF
--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -3,10 +3,11 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
+import TNLean.Algebra.HermitianHelpers
 import TNLean.Spectral.MixedTransfer
 import TNLean.Spectral.TraceExpansion
-import TNLean.Wielandt.Primitivity.TracePairing
 import TNLean.Wielandt.Primitivity.PrimitiveBridge
+import TNLean.Wielandt.Primitivity.TracePairing
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Data.Complex.BigOperators
 import Mathlib.LinearAlgebra.Matrix.Trace
@@ -180,8 +181,20 @@ private theorem eq_zero_of_trace_conjTranspose_mul_posDef_mul_eq_zero
   -- But star(Bv) ⬝ᵥ ρ(Bv) = v†(B†ρB)v = 0
   have : star (B *ᵥ Pi.single j 1) ⬝ᵥ ρ.mulVec (B *ᵥ Pi.single j 1) =
       star (Pi.single j (1 : ℂ)) ⬝ᵥ (Bᴴ * ρ * B).mulVec (Pi.single j 1) := by
-    simp only [star_mulVec, Matrix.dotProduct_mulVec, Matrix.vecMul_vecMul,
-      Matrix.mulVec_mulVec, Matrix.mul_assoc]
+    have hvec : (Bᴴ * ρ * B).mulVec (Pi.single j 1) =
+        Bᴴ *ᵥ (ρ *ᵥ (B *ᵥ Pi.single j 1)) := by
+      rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec]
+    calc
+      star (B *ᵥ Pi.single j 1) ⬝ᵥ ρ.mulVec (B *ᵥ Pi.single j 1)
+          = star (Pi.single j (1 : ℂ)) ⬝ᵥ
+              Bᴴ *ᵥ (ρ *ᵥ (B *ᵥ Pi.single j 1)) := by
+                simpa [Matrix.conjTranspose_conjTranspose] using
+                  (HermitianHelpers.dotProduct_mulVec_conjTranspose (M := Bᴴ)
+                    (x := Pi.single j (1 : ℂ))
+                    (y := ρ *ᵥ (B *ᵥ Pi.single j 1))).symm
+      _ = star (Pi.single j (1 : ℂ)) ⬝ᵥ
+            (Bᴴ * ρ * B).mulVec (Pi.single j 1) := by
+              rw [hvec]
   rw [this, hBρB] at hpos
   simp at hpos
 


### PR DESCRIPTION
### Motivation

The nondegeneracy proof in `StronglyIrreducibleToFullRank` still expanded the adjoint movement in the matrix-vector dot-product pairing by hand. After `HermitianHelpers.dotProduct_mulVec_conjTranspose` was generalized to rectangular matrices, this local expansion can use the shared lemma.

### Description

- Import `TNLean.Algebra.HermitianHelpers` explicitly in `TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank`.
- Replace the local `star_mulVec`/`dotProduct_mulVec` expansion with a short calculation using `HermitianHelpers.dotProduct_mulVec_conjTranspose` plus an explicit matrix-vector reassociation.
- Theorem statements, hypotheses, and blueprint declarations are unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
<!-- No linked issue identified. Please add an `Addresses #N` or `Closes #N` footer to link a related issue. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one private lemma; no API or hypothesis changes, only a different route to the same equality.
>
> **Overview**
> **Refactors** the adjoint step in `eq_zero_of_trace_conjTranspose_mul_posDef_mul_eq_zero` so it no longer hand-expands `star_mulVec` / `dotProduct_mulVec` identities.
>
> The proof now uses a short `calc` chain: `HermitianHelpers.dotProduct_mulVec_conjTranspose` (with `Bᴴ` and the standard basis vector) plus an explicit `mulVec` reassociation lemma, then the same contradiction with `hBρB`. **`TNLean.Algebra.HermitianHelpers`** is imported explicitly; theorem statements and the rest of the file are unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 606040aaa95ce90190fa1312c6483365f0cb9b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->