### PR TITLE
refactor(Channel/Semigroup/ReducibleQDS): remove unused sum-of-squares reformulation

### DIFF
--- a/TNLean/Channel/Semigroup/ReducibleQDS/Equivalence.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/Equivalence.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Channel.Semigroup.ReducibleQDS.FixedDensity
 import TNLean.Channel.Semigroup.ReducibleQDS.GeneratorCompression
 import TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis
-import TNLean.Algebra.MatrixAux
 
 /-!
 # Reducibility Definition and Full Equivalence (Wolf Proposition 7.6)
@@ -109,17 +108,5 @@ theorem wolf_prop_7_6_full_equivalence
         (hasRankDeficientKernelElement_of_hasRankDeficientFixedDensity h1)
   · intro h1234
     exact hasRankDeficientFixedDensity_of_hasRankDeficientKernelElement h1234.1
-
-/-! ## Sum-of-squares vanishing lemma -/
-
-/-- If `∑ⱼ Bⱼ Bⱼ† = 0` for square matrices, then each `Bⱼ = 0`.
-
-This is the key algebraic fact needed for the (3) → (4) direction of
-Wolf Proposition 7.6. -/
-theorem sum_conjTranspose_mul_self_eq_zero_imp
-    {r : ℕ} (B : Fin r → Mat)
-    (h : ∑ j, B j * (B j)ᴴ = 0) :
-    ∀ j, B j = 0 :=
-  Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero B h
 
 end -- noncomputable section


### PR DESCRIPTION
### Motivation

- `sum_conjTranspose_mul_self_eq_zero_imp` in `TNLean/Channel/Semigroup/ReducibleQDS/Equivalence.lean` was an unused local theorem that merely restated `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero` from `TNLean.Algebra.MatrixAux` without additional content. Removing it eliminates the redundancy and allows dropping the `MatrixAux` import, which was only needed by that local theorem.

### Description

- Deleted `sum_conjTranspose_mul_self_eq_zero_imp` from `TNLean/Channel/Semigroup/ReducibleQDS/Equivalence.lean` (13 lines).
- Removed the now-unused `import TNLean.Algebra.MatrixAux` from that file.
- No callers used the local theorem; the Wolf Proposition 7.6 equivalence proofs in the file are unchanged.

### Testing

- `lake exe cache get` and `lake build TNLean.Channel.Semigroup.ReducibleQDS.Equivalence -q --log-level=info` pass.
- Added-line proof-integrity scan for `sorry|admit|axiom|native_decide|unsafeCast` is clean.
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Deletion of an unused alias and an import only; Wolf Proposition 7.6 equivalence proofs in the file are unchanged.
>
> **Overview**
> Removes the unused local wrapper `sum_conjTranspose_mul_self_eq_zero_imp` from `Equivalence.lean`, which only forwarded to `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero` in `TNLean.Algebra.MatrixAux`.
>
> Also drops the `TNLean.Algebra.MatrixAux` import from that file now that nothing in it references the shared matrix lemma directly.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ddaf874743492356ce381bdf8e1f0704270fa54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->