### PR TITLE
doc(PEPS): mark torus normal FT source entry formalized

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -400,7 +400,8 @@ site-independent tensor and produces the global phase of
 
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus]%
     \label{thm:fundamentalTheorem_normalTorusPEPS}
-    \notready
+    \lean{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}
+    \leanok
     \uses{thm:fundamentalTheorem_normalSquarePEPS,
         thm:peps_oneVertexComplementComparison,
         def:peps_torus_translation_invariant,
@@ -419,9 +420,11 @@ site-independent tensor and produces the global phase of
     by its translation covariance, and the uniqueness of $X$ and $Y$ up to a
     multiplicative constant is proved at the same sizes in
     Theorem~\ref{thm:torusAbsorbedGauge_unique_scalar} and
-    Theorem~\ref{thm:torusGauge_unique_scalar_of_perVertex}; the present
-    source-exact entry awaits only the reading of the gauge family as the two
-    class matrices $X$ and $Y$.
+    Theorem~\ref{thm:torusGauge_unique_scalar_of_perVertex}. In the torus
+    edge convention the two class matrices $X$ and $Y$ are read through this
+    translation-covariant family: seam edges carry the transposed inverse of
+    the corresponding class matrix, so this is the orientation-faithful form
+    of the source's horizontal and vertical gauges.
 \end{theorem}
 
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus,


### PR DESCRIPTION
### Motivation

- The torus normal PEPS Fundamental Theorem blueprint entry (`thm:fundamentalTheorem_normalTorusPEPS` in `blueprint/src/chapter/ch24_peps_ft_torus.tex`) was marked `\notready` pending interpretation of the source gauge matrices $X$ and $Y$ and completion of the size-bound and gauge-uniqueness clauses.
- The Lean declaration `TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional` now covers this theorem; the blueprint should reflect its formalized status. Continues arXiv:1804.04964 blueprint alignment work tracked in #1252.

### Description

- Modified `blueprint/src/chapter/ch24_peps_ft_torus.tex`:
  - Adds `\lean{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}` and `\leanok` to the source-labelled torus normal PEPS Fundamental Theorem entry.
  - Removes the obsolete `\notready` annotation.
  - Replaces the pending gauge-interpretation note with an explanation that the source gauges $X$ and $Y$ are represented by the translation-covariant edge family, with transposed inverses on seam edges in the torus edge convention.

### Testing

- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `cd blueprint && leanblueprint web`
- `git diff --check`

---
Addresses #1252

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX blueprint sync; no Lean or runtime behavior changes.
> 
> **Overview**
> Updates the **source-labelled** torus normal PEPS Fundamental Theorem blueprint entry (`thm:fundamentalTheorem_normalTorusPEPS`) to reflect that it is now covered by formalization, not still pending.
> 
> The entry drops `\notready`, adds `\lean{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}` and `\leanok`, and replaces the note that the statement still waited on interpreting gauges `X` and `Y` with text that those class matrices are represented by the translation-covariant edge family (seam edges use transposed inverses in the torus edge convention).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cf513621c4b5240dbaa4226f51be6b07c0523c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>