### PR TITLE
doc(PEPS): cite torus gauge uniqueness in source FT entry

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_torus.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_torus.tex
@@ -401,6 +401,9 @@ site-independent tensor and produces the global phase of
 \begin{theorem}[Fundamental Theorem for normal PEPS on the torus]%
     \label{thm:fundamentalTheorem_normalTorusPEPS}
     \lean{TNLean.PEPS.fundamentalTheorem_normalTorusPEPS_unconditional}
+    \lean{TNLean.PEPS.torusAbsorbedGauge_unique_scalar}
+    \lean{TNLean.PEPS.torusCovariantAbsorbedGauge_unique_classScalar}
+    \lean{TNLean.PEPS.torusGauge_unique_scalar_of_perVertex}
     \leanok
     \uses{thm:fundamentalTheorem_normalSquarePEPS,
         thm:peps_oneVertexComplementComparison,
@@ -419,8 +422,11 @@ site-independent tensor and produces the global phase of
     this at the source's sizes $n,m\geq 7$ with the gauge family described
     by its translation covariance, and the uniqueness of $X$ and $Y$ up to a
     multiplicative constant is proved at the same sizes in
-    Theorem~\ref{thm:torusAbsorbedGauge_unique_scalar} and
-    Theorem~\ref{thm:torusGauge_unique_scalar_of_perVertex}. In the torus
+    Theorem~\ref{thm:torusAbsorbedGauge_unique_scalar} per edge,
+    Theorem~\ref{thm:torusCovariantAbsorbedGauge_unique_classScalar} on the
+    two orientation classes, and
+    Theorem~\ref{thm:torusGauge_unique_scalar_of_perVertex} against the
+    per-vertex relation. In the torus
     edge convention the two class matrices $X$ and $Y$ are read through this
     translation-covariant family: seam edges carry the transposed inverse of
     the corresponding class matrix, so this is the orientation-faithful form


### PR DESCRIPTION
### Motivation

- PR #3268 marked the source-labelled torus normal PEPS Fundamental Theorem entry as formalized, but the review correctly noted that the entry cited only the existence theorem while the source statement also includes uniqueness of the gauges.
- This follow-up makes the source-labelled entry point to the Lean declarations covering both existence and uniqueness.

### Description

- Adds `TNLean.PEPS.torusAbsorbedGauge_unique_scalar`, `TNLean.PEPS.torusCovariantAbsorbedGauge_unique_classScalar`, and `TNLean.PEPS.torusGauge_unique_scalar_of_perVertex` to the `\lean{}` tags on `thm:fundamentalTheorem_normalTorusPEPS`.
- Refines the prose to say explicitly which uniqueness theorem proves the per-edge, orientation-class, and per-vertex forms.

### Testing

- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Addresses #1252. Follow-up to #3268.

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint/LaTeX and Lean sync tags; no Lean or runtime code changes.
>
> **Overview**
> **Aligns the blueprint with the full Molnár et al. torus statement** by wiring gauge uniqueness into the source-labelled Fundamental Theorem entry, not only existence.
>
> On `thm:fundamentalTheorem_normalTorusPEPS`, the PR adds `\lean{}` links to `torusAbsorbedGauge_unique_scalar`, `torusCovariantAbsorbedGauge_unique_classScalar`, and `torusGauge_unique_scalar_of_perVertex`, and updates the prose so uniqueness is attributed **per edge**, on the **two orientation classes**, and against the **per-vertex** relation—matching the separate theorems already in the chapter.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68614db47199556bc65c085d3483074531c89f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>