### PR TITLE
refactor(Channel): inline fixed-point projection relays

### DIFF
--- a/TNLean/Channel/Primitive.lean
+++ b/TNLean/Channel/Primitive.lean
@@ -84,27 +84,6 @@ theorem fixedPointProj_trace (ρ : Matrix (Fin D) (Fin D) ℂ) (htr : trace ρ �
 
 end FixedPointProjection
 
-section TracePreservingInteraction
-
-variable (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
-variable {ρ : Matrix (Fin D) (Fin D) ℂ} (htr : trace ρ ≠ 0)
-
-/-- If `E(ρ) = ρ`, then `E ∘ fixedPointProj(ρ) = fixedPointProj(ρ)`.
-
-This does not use trace-preservation. -/
-theorem E_comp_fixedPointProj (hρ : E ρ = ρ) :
-    E.comp (fixedPointProj ρ htr) = fixedPointProj ρ htr := by
-  ext X
-  simp [fixedPointProj, hρ]
-
-/-- If `E` is trace-preserving, then `fixedPointProj(ρ) ∘ E = fixedPointProj(ρ)`. -/
-theorem fixedPointProj_comp_E (hTP : IsTracePreservingMap E) :
-    (fixedPointProj ρ htr).comp E = fixedPointProj ρ htr := by
-  ext X
-  simp [fixedPointProj, hTP X]
-
-end TracePreservingInteraction
-
 section ComplementaryDecomposition
 
 variable (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
@@ -119,26 +98,6 @@ theorem fixedPointProj_mul_self : P * P = P := by
   ext X
   simp [Module.End.mul_apply, fixedPointProj_idempotent]
 
-/-- `P ∘ N = 0` for `P := fixedPointProj ρ` and `N := E - P`. -/
-theorem fixedPointProj_mul_compl (hTP : IsTracePreservingMap E) : P * N = 0 := by
-  ext X
-  have hPE : P (E X) = P X :=
-    LinearMap.congr_fun (fixedPointProj_comp_E (E := E) (ρ := ρ) (htr := htr) hTP) X
-  simp [Module.End.mul_apply, hPE, fixedPointProj_idempotent]
-
-/-- `N ∘ P = 0` for `P := fixedPointProj ρ` and `N := E - P`. -/
-theorem compl_mul_fixedPointProj (hρ : E ρ = ρ) : N * P = 0 := by
-  ext X
-  have hEP : E (P X) = P X :=
-    LinearMap.congr_fun (E_comp_fixedPointProj (E := E) (ρ := ρ) (htr := htr) hρ) X
-  simp [Module.End.mul_apply, hEP, fixedPointProj_idempotent]
-
-/-- `N^(n+1) ∘ P = 0` for all `n`. -/
-theorem compl_pow_succ_mul_fixedPointProj (hρ : E ρ = ρ) (n : ℕ) :
-    N ^ (n + 1) * P = 0 := by
-  have hNP : N * P = 0 := compl_mul_fixedPointProj (E := E) (ρ := ρ) (htr := htr) hρ
-  simp only [pow_succ, mul_assoc, hNP, mul_zero]
-
 /-- For `P := fixedPointProj ρ` and `N := E - P`, we have `E^(n+1) = P + N^(n+1)`.
 
 This is the algebraic core of primitive convergence: the dynamics splits into the fixed-point
@@ -151,9 +110,19 @@ theorem pow_succ_eq_fixedPointProj_add_compl_pow
   | zero => simp only [Nat.zero_add, pow_one, add_sub_cancel]
   | succ n ih =>
       have hPP : P * P = P := fixedPointProj_mul_self (ρ := ρ) (htr := htr)
-      have hPN : P * N = 0 := fixedPointProj_mul_compl (E := E) (ρ := ρ) (htr := htr) hTP
+      have hPN : P * N = 0 := by
+        ext X
+        have hPE : P (E X) = P X := by
+          simp [fixedPointProj, hTP X]
+        simp [Module.End.mul_apply, hPE, fixedPointProj_idempotent]
       have hNpowP : N ^ (n + 1) * P = 0 :=
-        compl_pow_succ_mul_fixedPointProj (E := E) (ρ := ρ) (htr := htr) hρ n
+        have hNP : N * P = 0 := by
+          ext X
+          have hEP : E (P X) = P X := by
+            simp [fixedPointProj, hρ]
+          simp [Module.End.mul_apply, hEP, fixedPointProj_idempotent]
+        by
+          simp only [pow_succ, mul_assoc, hNP, mul_zero]
       -- Rewrite E^(n+2) = (P + N^(n+1)) * E, then substitute E = P + N on the right factor.
       rw [pow_succ, ih]
       conv_lhs => rhs; rw [show E = P + N from (add_sub_cancel P E).symm]


### PR DESCRIPTION
### Motivation

- The five relay lemmas `E_comp_fixedPointProj`, `fixedPointProj_comp_E`, `fixedPointProj_mul_compl`, `compl_mul_fixedPointProj`, and `compl_pow_succ_mul_fixedPointProj` in `Channel/Primitive.lean` were consumed only inside the proof of `pow_succ_eq_fixedPointProj_add_compl_pow` and had no external callers.
- Exposing them as public declarations inflated the module API without providing reusable mathematical results; removing them reduces the surface to externally meaningful declarations.

### Description

- Modified `TNLean/Channel/Primitive.lean` (−43/+12 lines): removed the five relay lemmas listed above and inlined their content as `have` assertions inside `pow_succ_eq_fixedPointProj_add_compl_pow`.
- The annihilation identities `P * N = 0`, `N * P = 0`, and `N^(n+1) * P = 0` (where `P = fixedPointProj ρ htr` and `N = E − P`) are now proved inline in the induction step.
- Public API unchanged: `fixedPointProj`, `fixedPointProj_idempotent`, `fixedPointProj_apply_rho`, `fixedPointProj_trace`, `fixedPointProj_mul_self`, `pow_succ_eq_fixedPointProj_add_compl_pow`, and `pow_eq_fixedPointProj_add_compl_pow` all remain.

### Testing

- `lake exe cache get`, `lake build TNLean.Channel.Primitive`, and `lake build TNLean.MPS.RFP.Convergence` passed.
- Added-line scan for `sorry|admit|axiom|native_decide|unsafeCast` returned no hits.
- Reader-facing prose check (`scripts/check_reader_facing_prose.py`) and blueprint-sync check (`scripts/blueprint_lean_sync.py`) passed.
- Full build validated by Lean CI (`lean_action_ci.yml`).

---
_No linked issue identified — author should add an `Addresses #N` footer manually._

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one file with no API or behavior changes; downstream builds were validated in the PR description.
>
> **Overview**
> Removes the standalone **`TracePreservingInteraction`** section and five relay lemmas (`E_comp_fixedPointProj`, `fixedPointProj_comp_E`, `fixedPointProj_mul_compl`, `compl_mul_fixedPointProj`, `compl_pow_succ_mul_fixedPointProj`) that were only used inside the power decomposition proof.
>
> The annihilation facts **`P * N = 0`**, **`N * P = 0`**, and **`N^(n+1) * P = 0`** are now proved inline in `pow_succ_eq_fixedPointProj_add_compl_pow` instead of calling those lemmas. Public API unchanged: **`fixedPointProj_mul_self`**, **`pow_succ_eq_fixedPointProj_add_compl_pow`**, and **`pow_eq_fixedPointProj_add_compl_pow`** remain.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8efa484ff1232d68f24885505150d1c24a18af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>