### PR TITLE
refactor(MPS/RFP): use native commute algebra for complements

### DIFF
--- a/TNLean/MPS/RFP/Decorrelation.lean
+++ b/TNLean/MPS/RFP/Decorrelation.lean
@@ -32,7 +32,6 @@ All results are fully proved (no `sorry`).
 * `comm_idem_cross_absorb_left` — `(P ∘ Q) ∘ P = P ∘ Q` when `[P, Q] = 0`
 * `comm_idem_cross_absorb_right` — `Q ∘ (P ∘ Q) = P ∘ Q` when `[P, Q] = 0`
 * `complement_comm_of_comm` — `[P, Q] = 0 → [1 − P, 1 − Q] = 0`
-* `comm_of_complement_comm` — `[1 − P, 1 − Q] = 0 → [P, Q] = 0`
 * `frustration_free_ham_eq` — `(1−P) + (1−Q) − (1−P)∘(1−Q) = 1 − P∘Q`
 
 ### `Decorrelation.HasCommutingParentHam` properties
@@ -104,23 +103,13 @@ theorem comm_idem_cross_absorb_right
 theorem complement_comm_of_comm
     {P Q : E →ₗ[ℂ] E} (hcomm : P ∘ₗ Q = Q ∘ₗ P) :
     (id - P) ∘ₗ (id - Q) = (id - Q) ∘ₗ (id - P) := by
-  simp only [comp_sub, sub_comp, comp_id, id_comp, hcomm]
-  abel
-
-/-- Commuting complements imply commuting originals:
-`[1 − P, 1 − Q] = 0 → [P, Q] = 0`. -/
-theorem comm_of_complement_comm
-    {P Q : E →ₗ[ℂ] E}
-    (hcomm : (id - P) ∘ₗ (id - Q) = (id - Q) ∘ₗ (id - P)) :
-    P ∘ₗ Q = Q ∘ₗ P := by
-  have expand_l : (id - P) ∘ₗ (id - Q) = id - P - Q + P ∘ₗ Q := by
-    simp only [comp_sub, sub_comp, comp_id, id_comp]; abel
-  have expand_r : (id - Q) ∘ₗ (id - P) = id - Q - P + Q ∘ₗ P := by
-    simp only [comp_sub, sub_comp, comp_id, id_comp]; abel
-  rw [expand_l, expand_r] at hcomm
-  have key : (id : E →ₗ[ℂ] E) - P - Q = id - Q - P := by abel
-  rw [key] at hcomm
-  exact add_left_cancel hcomm
+  have hPQ : Commute P Q := by
+    change P * Q = Q * P
+    simpa [Module.End.mul_eq_comp] using hcomm
+  have hP_comp : Commute P (id - Q) := (Commute.one_right P).sub_right hPQ
+  have hcomp : Commute (id - P) (id - Q) :=
+    (Commute.one_left (id - Q)).sub_left hP_comp
+  simpa [Module.End.mul_eq_comp] using hcomp.eq
 
 /-- The frustration-free Hamiltonian identity (pure algebra, no commutativity
 needed): `(1 − P) + (1 − Q) − (1 − P) ∘ (1 − Q) = 1 − P ∘ Q`.


### PR DESCRIPTION
### Motivation

- `comm_of_complement_comm` was a public wrapper with no callers outside `TNLean/MPS/RFP/Decorrelation.lean`.
- The forward complement-commutation result can be proved directly using the native `Commute` algebra for endomorphisms.
- Continues formalization of the decorrelation ↔ commuting parent Hamiltonian equivalence (arXiv:1606.00608, Appendix D, Proposition D.3); see #234.

### Description

- Removes the unused reverse complement-commutation lemma `comm_of_complement_comm` from `TNLean/MPS/RFP/Decorrelation.lean`.
- Rewrites `complement_comm_of_comm` through `Commute.sub_left` and `Commute.sub_right`, then translates back to composition notation.
- Updates the module overview so it lists only the remaining public declarations.
- Mathematical content is unchanged: `[P, Q] = 0 → [1 − P, 1 − Q] = 0` remains as `complement_comm_of_comm`, and `HasCommutingParentHam.complement_comm` still calls the same forward lemma.

### Testing

- `lake env lean TNLean/MPS/RFP/Decorrelation.lean`
- `lake build TNLean.MPS.RFP.Decorrelation`
- `git diff --check`
- `scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py` was run; it reports pre-existing issue-number references outside this file.
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/RFP/Decorrelation.lean || true`

---
Addresses #234

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local proof refactor in one Lean file; the removed theorem had no callers and the forward result's statement is unchanged.
> 
> **Overview**
> Removes the unused reverse lemma **`comm_of_complement_comm`** and drops it from the module overview.
> 
> **`complement_comm_of_comm`** is re-proved via Mathlib's **`Commute`** API (`sub_right` / `sub_left` on complements) instead of expanding `(1−P)(1−Q)` with `simp`/`abel`. **`HasCommutingParentHam.complement_comm`** still calls the same forward lemma; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42edbd5945cf694b05aa5cb2d0ccf304972ae217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->