### PR TITLE
refactor(Channel): use native idempotent complement facts

### DIFF
--- a/TNLean/Channel/ChoiJamiolkowski.lean
+++ b/TNLean/Channel/ChoiJamiolkowski.lean
@@ -354,7 +354,7 @@ theorem projectedChoiPosSemidef_of_cp
   have hchoi : (choiMatrix T).PosSemidef :=
     choiMatrix_of_kraus_posSemidef K T hK
   simpa [IsProjectedChoiPosSemidef, projectedChoiMatrix,
-    Matrix.one_sub_omegaProj_conjTranspose (d := D)] using
+    Matrix.omegaProj_conjTranspose (d := D)] using
     hchoi.mul_mul_conjTranspose_same
       ((1 : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) - Matrix.omegaProj D)
 

--- a/TNLean/Channel/MaximallyEntangled.lean
+++ b/TNLean/Channel/MaximallyEntangled.lean
@@ -175,25 +175,6 @@ theorem omegaProj_mul_self :
     subst hd0
     exact Subsingleton.elim _ _
 
-theorem one_sub_omegaProj_conjTranspose :
-    (((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d)ᴴ) =
-      (1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d := by
-  simp [omegaProj_conjTranspose]
-
-theorem one_sub_omegaProj_mul_omegaProj :
-    ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d) * omegaProj d = 0 := by
-  exact IsIdempotentElem.one_sub_mul_self (omegaProj_mul_self (d := d))
-
-theorem omegaProj_mul_one_sub_omegaProj :
-    omegaProj d * ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d) = 0 := by
-  exact IsIdempotentElem.mul_one_sub_self (omegaProj_mul_self (d := d))
-
-theorem one_sub_omegaProj_mul_self :
-    ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d) *
-        ((1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d) =
-      (1 : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) - omegaProj d := by
-  exact IsIdempotentElem.one_sub (omegaProj_mul_self (d := d))
-
 theorem omegaProj_mulVec_omegaVec :
     omegaProj d *ᵥ omegaVec d = omegaVec d := by
   by_cases hd : 0 < d

--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -161,7 +161,8 @@ theorem cp_semigroup_implies_ccp_generator
       rw [hgp_sandwich 0, hg0]
       change P * Matrix.omegaProj D * P = 0
       have hPω : P * Matrix.omegaProj D = 0 := by
-        simpa [P] using Matrix.one_sub_omegaProj_mul_omegaProj (d := D)
+        simpa [P] using
+          IsIdempotentElem.one_sub_mul_self (Matrix.omegaProj_mul_self (d := D))
       simp [hPω]
     have hg_slope :
         Filter.Tendsto (slope g 0) (nhdsWithin 0 (Set.Ioi 0))


### PR DESCRIPTION
### Motivation

- The four projection-complement lemmas around `omegaProj` duplicate native idempotent-complement facts.
- Their only live uses can call the native facts directly, reducing the local API surface.

### Description

- Removes `one_sub_omegaProj_conjTranspose`, `one_sub_omegaProj_mul_omegaProj`, `omegaProj_mul_one_sub_omegaProj`, and `one_sub_omegaProj_mul_self` from `TNLean/Channel/MaximallyEntangled.lean`.
- Replaces the two live source uses with `Matrix.omegaProj_conjTranspose` and `IsIdempotentElem.one_sub_mul_self`.
- Leaves the older audit snapshot untouched.

### Testing

- `lake env lean TNLean/Channel/ChoiJamiolkowski.lean`
- `lake env lean TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean`
- `git diff --check`
- `rg -n "one_sub_omegaProj_conjTranspose|one_sub_omegaProj_mul_omegaProj|omegaProj_mul_one_sub_omegaProj|one_sub_omegaProj_mul_self" TNLean blueprint docs || true`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/Channel/ChoiJamiolkowski.lean TNLean/Channel/MaximallyEntangled.lean TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean || true`

---
No linked issue identified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or runtime behavior change; mathematical content is unchanged.
> 
> **Overview**
> Removes four local lemmas in `MaximallyEntangled.lean` about `(1 - omegaProj)`—Hermiticity, multiplication with `omegaProj`, and squaring—that repeated Mathlib’s `IsIdempotentElem` facts for complements of idempotents.
> 
> **`projectedChoiPosSemidef_of_cp`** now cites `Matrix.omegaProj_conjTranspose` instead of the removed `one_sub_omegaProj_conjTranspose`. In **`EulerStep`**, the step `P * omegaProj = 0` for `P = 1 - omegaProj` uses `IsIdempotentElem.one_sub_mul_self` with `omegaProj_mul_self` instead of `one_sub_omegaProj_mul_omegaProj`.
> 
> The vec-mul lemmas `one_sub_omegaProj_mulVec_omegaVec` and `omegaVec_vecMul_one_sub_omegaProj` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd74076c00054a3ed284b10862b347dc1e8479f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->