### PR TITLE
refactor(Algebra): use native Fin.castLE order isomorphism

### DIFF
--- a/TNLean/Algebra/FinSum.lean
+++ b/TNLean/Algebra/FinSum.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Data.Fintype.Basic
-import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Order.Fin.Tuple
 
 /-!
 # Finite initial-segment sums
@@ -26,49 +26,26 @@ theorem sum_castLE_extend_zero {r s : ℕ} {β : Type*} [AddCommMonoid β]
   calc
     ∑ j : Fin r, f j =
         ∑ α : { i : Fin s // (i : ℕ) < r }, f ⟨α.1.val, α.2⟩ := by
-          refine Fintype.sum_equiv (Fin.castLEquiv h) f
+          refine Fintype.sum_equiv (Fin.castLEOrderIso h).toEquiv f
             (fun α : { i : Fin s // (i : ℕ) < r } => f ⟨α.1.val, α.2⟩) ?_
           intro j
-          simp [Fin.castLEquiv]
+          simp
     _ = ∑ α ∈ (Finset.univ.filter fun α : Fin s => α.val < r),
           if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
-          rw [show (Finset.univ : Finset { i : Fin s // (i : ℕ) < r }) =
-              (Finset.univ : Finset (Fin s)).subtype (fun i : Fin s => (i : ℕ) < r) by
-                ext α
-                simp]
-          have hsub :=
-            Finset.sum_subtype_eq_sum_filter
-              (s := (Finset.univ : Finset (Fin s)))
-              (p := fun i : Fin s => (i : ℕ) < r)
-              (f := fun α : Fin s =>
-                if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0)
-          have hleft :
-              (∑ α ∈ (Finset.univ : Finset (Fin s)).subtype
-                    (fun i : Fin s => (i : ℕ) < r),
-                  (if hlt : (α : Fin s).val < r then f ⟨(α : Fin s).val, hlt⟩ else 0)) =
-                ∑ α ∈ (Finset.univ : Finset (Fin s)).subtype
-                    (fun i : Fin s => (i : ℕ) < r),
-                  f ⟨(α : Fin s).val, α.2⟩ := by
-            refine Finset.sum_congr rfl ?_
-            intro α _
-            simp [α.2]
-          exact hleft.symm.trans hsub
+          rw [← Finset.sum_subtype_eq_sum_filter
+            (s := (Finset.univ : Finset (Fin s)))
+            (p := fun i : Fin s => (i : ℕ) < r)
+            (f := fun α : Fin s =>
+              if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0)]
+          refine Finset.sum_congr ?_ ?_
+          · ext α
+            simp
+          intro α _
+          simp [α.2]
     _ = ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
-          have hfilter :=
-            Finset.sum_filter
-              (s := (Finset.univ : Finset (Fin s)))
-              (p := fun α : Fin s => α.val < r)
-              (f := fun α : Fin s =>
-                if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0)
-          have hright :
-              (∑ α : Fin s,
-                if α.val < r then
-                  (if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0)
-                else 0) =
-                ∑ α : Fin s, if hlt : α.val < r then f ⟨α.val, hlt⟩ else 0 := by
-            refine Finset.sum_congr rfl ?_
-            intro α _
-            by_cases hlt : α.val < r <;> simp [hlt]
-          exact hfilter.trans hright
+          rw [Finset.sum_filter]
+          refine Finset.sum_congr rfl ?_
+          intro α _
+          by_cases hlt : α.val < r <;> simp [hlt]
 
 end Fin


### PR DESCRIPTION
### Motivation

- `sum_castLE_extend_zero` previously reindexed finite sums via `Fin.castLEquiv` from `Mathlib.Logic.Equiv.Fin.Basic`; the native `Fin.castLEOrderIso` from `Mathlib.Order.Fin.Tuple` is the canonical order-isomorphism for this purpose and is more idiomatic.
- The subtype-to-filter and filter-to-universe sum comparison steps used explicit transitivity chains; direct `rw` calls shorten the proof without altering the result.

### Description

- `TNLean/Algebra/FinSum.lean`: replaces the finite-index equivalence in `sum_castLE_extend_zero` with `(Fin.castLEOrderIso h).toEquiv`, importing from `Mathlib.Order.Fin.Tuple` instead of `Mathlib.Logic.Equiv.Fin.Basic`. Shortens the subtype-sum and filtered-sum comparison steps to direct `rw` calls on `Finset.sum_subtype_eq_sum_filter` and `Finset.sum_filter`, replacing explicit `Finset.sum_congr` transitivity chains. The theorem statement and all call sites are unchanged.

### Testing

- `lake env lean TNLean/Algebra/FinSum.lean`
- `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the full build.

---

> [!NOTE]
> **Low Risk**
> Only the Lean proof and imports in `FinSum.lean` change; the theorem statement and call sites are unchanged.
>
> **Overview**
> Refactors the proof of **`sum_castLE_extend_zero`** without changing its statement or downstream uses (e.g. Kraus padding arguments).
>
> The first step now reindexes via **`Fin.castLEOrderIso h).toEquiv`** instead of **`Fin.castLEquiv`**, with **`Mathlib.Order.Fin.Tuple`** replacing **`Mathlib.Logic.Equiv.Fin.Basic`**. The subtype-to-filter and filter-to-universe sum steps are shortened to direct **`rw`** calls on **`Finset.sum_subtype_eq_sum_filter`** and **`Finset.sum_filter`**, with smaller **`Finset.sum_congr`** blocks instead of explicit transitivity chains.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8666bbfb68519f2dbe9a8f2a90b54d731e344901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>