### PR TITLE
refactor(Algebra): use native trace zero criterion

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -92,15 +92,12 @@ theorem eq_zero_of_sum_mul_conjTranspose_eq_zero
     rw [← Complex.re_sum, ← Matrix.trace_sum, h]
     simp
   have htrace_re : ((B i * (B i)ᴴ).trace).re = 0 :=
-    le_antisymm
-      (by
-        linarith [Finset.sum_eq_zero_iff_of_nonneg (fun j _ => htrace_nonneg j)
-          |>.mp htrace_sum i (Finset.mem_univ i)])
-      (htrace_nonneg i)
-  have hpsd := Matrix.posSemidef_self_mul_conjTranspose (B i)
+    Finset.sum_eq_zero_iff_of_nonneg (fun j _ => htrace_nonneg j)
+      |>.mp htrace_sum i (Finset.mem_univ i)
   have htrace_zero : (B i * (B i)ᴴ).trace = 0 :=
-    Complex.ext htrace_re (Complex.le_def.mp hpsd.trace_nonneg).2.symm
-  exact Matrix.self_mul_conjTranspose_eq_zero.mp (hpsd.trace_eq_zero_iff.mp htrace_zero)
+    Complex.ext htrace_re
+      (Complex.le_def.mp (Matrix.posSemidef_self_mul_conjTranspose (B i)).trace_nonneg).2.symm
+  exact Matrix.trace_mul_conjTranspose_self_eq_zero_iff.mp htrace_zero
 
 /-- If `∑ᵢ Bᵢ† * Bᵢ = 0`, then every `Bᵢ` is zero. -/
 theorem eq_zero_of_sum_conjTranspose_mul_self_eq_zero


### PR DESCRIPTION
### Motivation

The proof of `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero` in `TNLean/Algebra/MatrixAux.lean` contained a hand-written final step: after extracting that one nonnegative trace summand vanishes, it rebuilt the matrix-zero conclusion through positivity of `B i * (B i)ᴴ`.

### Description

- Uses `Finset.sum_eq_zero_iff_of_nonneg` directly to extract the vanishing trace summand.
- Uses Mathlib's `Matrix.trace_mul_conjTranspose_self_eq_zero_iff` for the final one-matrix zero criterion.
- Leaves the public helper theorem and all callers unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.Algebra.MatrixAux -q --log-level=info`
- `git diff --check`
- Added-line proof-integrity scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
*(No linked issue identified — please link one manually if this closes or addresses an open issue.)*

> [!NOTE]
> **Low Risk**
> Local proof simplification in an auxiliary lemma; no API or behavioral changes.
>
> **Overview**
> Refactors the proof of **`Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`** in `TNLean/Algebra/MatrixAux.lean` without changing its statement or callers.
>
> After showing each summand trace is nonnegative and their real parts sum to zero, the vanishing real part for index `i` is obtained **directly** from `Finset.sum_eq_zero_iff_of_nonneg` instead of a `le_antisymm` / `linarith` step. The conclusion that `B i = 0` now goes through mathlib's **`Matrix.trace_mul_conjTranspose_self_eq_zero_iff`** (trace of `B i * (B i)ᴴ` is zero) rather than the previous `self_mul_conjTranspose_eq_zero` route via a separate `hpsd` and `trace_eq_zero_iff`. The conjugate-transpose variant theorem is untouched.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c465d4cc0c2c8c9173133ead3d055698a4bdea21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>