### PR TITLE
refactor(Channel/Determinant): use Fintype sum zero criterion

### DIFF
--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -138,11 +138,8 @@ theorem sum_stdBasis_mul_conjTranspose :
 lemma eq_zero_of_nonneg_of_sum_le_zero {ι : Type*} [Fintype ι]
     (f : ι → ℝ) (hf : ∀ i, 0 ≤ f i) (hsum : ∑ i, f i ≤ 0) :
     ∀ i, f i = 0 := by
-  intro i
-  have h1 : ∑ i, f i ≥ 0 := Finset.sum_nonneg (fun i _ => hf i)
-  have h2 : ∑ i, f i = 0 := le_antisymm hsum h1
-  have h3 := Finset.sum_eq_zero_iff_of_nonneg (fun i _ => hf i) |>.mp h2
-  exact h3 i (Finset.mem_univ i)
+  have hsum_zero : ∑ i, f i = 0 := le_antisymm hsum (Fintype.sum_nonneg hf)
+  exact fun i => congrFun ((Fintype.sum_eq_zero_iff_of_nonneg hf).mp hsum_zero) i
 
 private lemma matrix_det_norm_one_trace_conjTranspose_mul_self_ge [NeZero d]
     (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (hdet : ‖A.det‖ = 1) :


### PR DESCRIPTION
### Motivation

The determinant-saturation auxiliary lemma `eq_zero_of_nonneg_of_sum_le_zero` was still written through the `Finset` form of the finite-sum nonnegativity and zero-sum criteria. The statement is over an arbitrary `Fintype`, so the corresponding `Fintype` lemmas state the same argument more directly.

### Description

- Replaces the local `Finset.sum_nonneg` and `Finset.sum_eq_zero_iff_of_nonneg` steps with `Fintype.sum_nonneg` and `Fintype.sum_eq_zero_iff_of_nonneg`.
- Leaves the public statement and all callers unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Determinant.HilbertSchmidt -q`
- `git diff --check`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/Channel/Determinant/HilbertSchmidt.lean || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses LionSR/QICLean#42

> [!NOTE]
> **Low Risk**
> Proof refactor only; no API or behavioral change to the lemma or its callers.
>
> **Overview**
> Refactors the proof of **`eq_zero_of_nonneg_of_sum_le_zero`** in `HilbertSchmidt.lean` so the argument uses **`Fintype.sum_nonneg`** and **`Fintype.sum_eq_zero_iff_of_nonneg`** instead of the **`Finset`** versions (`Finset.sum_nonneg`, `Finset.sum_eq_zero_iff_of_nonneg`, and explicit `Finset.mem_univ`).
>
> The lemma's statement and its use in **`HeisenbergDual.lean`** are unchanged; only the internal proof steps are shortened and aligned with the `[Fintype ι]` hypothesis.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ad891949c4a2be8c9e93312c40fee97eed6f1aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>