### PR TITLE
refactor(Channel): use general right partial trace theorem

### DIFF
--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -30,7 +30,6 @@ Proposition 2.1) and for reduced states on contiguous tensor factors.
 * `Matrix.trace_partialTraceRight`: the full trace is preserved by the general
   right partial trace
 * `Matrix.trace_eq_trace_traceLeft`: `tr(X) = tr(tr_A(X))`
-* `Matrix.trace_eq_trace_traceRight`: `tr(X) = tr(tr_B(X))`
 * `Matrix.traceLeft_kronecker`: `tr_A(A ⊗ B) = tr(A) • B`
 * `Matrix.traceRight_kronecker`: `tr_B(A ⊗ B) = A • tr(B)`
 * `Matrix.traceLeft_one`: `tr_A(1) = d • 1`
@@ -175,12 +174,6 @@ theorem trace_eq_trace_traceLeft (X : Matrix (Fin d × Fin d') (Fin d × Fin d')
   rw [show ∑ i : Fin d × Fin d', X i i =
     ∑ k : Fin d, ∑ j : Fin d', X (k, j) (k, j) from Fintype.sum_prod_type _]
   exact Finset.sum_comm
-
-/-- The full trace equals the trace of the right partial trace: `tr(X) = tr(tr_B(X))`. -/
-theorem trace_eq_trace_traceRight (X : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
-    X.trace = (traceRight X).trace := by
-  simp only [Matrix.trace, Matrix.diag, traceRight_apply]
-  exact Fintype.sum_prod_type _
 
 /-- `traceLeft` is additive. -/
 theorem traceLeft_add (X Y : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :

--- a/TNLean/Entropy/MutualInformation.lean
+++ b/TNLean/Entropy/MutualInformation.lean
@@ -266,7 +266,7 @@ theorem mutualInformation_le_log_dim_add_log_dim
       ≤ Real.log dA + Real.log dB := by
   have h_A_dm : Matrix.traceRight ρ_AB ∈ densityMatrices dA := by
     exact ⟨hρ_AB.1.traceRight, by
-      rw [← Matrix.trace_eq_trace_traceRight ρ_AB]
+      rw [Matrix.traceRight, Matrix.trace_partialTraceRight]
       exact hρ_AB.2⟩
   have h_B_dm : Matrix.traceLeft ρ_AB ∈ densityMatrices dB := by
     exact ⟨hρ_AB.1.traceLeft, by

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -288,7 +288,7 @@ rank-one trace matrix (the all-ones matrix). -/
     (hη : EtaStructure ρ_ABC) (k h : Fin hη.m) :
     (ofHayashiMarkov hη).traceMatrix k h = 1 := by
   have hR : (Matrix.traceRight (hη.ρ_right k)).trace = 1 := by
-    rw [← Matrix.trace_eq_trace_traceRight]
+    rw [Matrix.traceRight, Matrix.trace_partialTraceRight]
     exact (hη.hρ_right_dm k).2
   have hL : (Matrix.traceLeft (hη.ρ_left h)).trace = 1 := by
     rw [← Matrix.trace_eq_trace_traceLeft]


### PR DESCRIPTION
### Motivation

- `Matrix.trace_eq_trace_traceRight` was a specialized lemma for preserving trace under the right partial trace, duplicating what `Matrix.trace_partialTraceRight` already provides after unfolding `Matrix.traceRight` as `partialTraceRight`.
- Removing it reduces redundancy in `TNLean/Channel/PartialTrace` and routes callers directly to the general theorem.

### Description

- Deleted `Matrix.trace_eq_trace_traceRight` from `TNLean/Channel/PartialTrace.lean` (7 lines); updated the module docstring accordingly.
- `MutualInformation.mutualInformation_le_log_dim_add_log_dim` in `TNLean/Entropy/MutualInformation.lean` now rewrites with `[Matrix.traceRight, Matrix.trace_partialTraceRight]` in place of the deleted lemma.
- `traceMatrix_ofHayashiMarkov` in `TNLean/MPS/MPDO/SimpleLocalStructure.lean` likewise; the left partial trace still uses the retained `trace_eq_trace_traceLeft` lemma.

### Testing

- `lake build TNLean.Channel.PartialTrace TNLean.Entropy.MutualInformation TNLean.MPS.MPDO.SimpleLocalStructure -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- Proof-integrity scan: no new `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` in added lines.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

_No linked issue found. Please manually link the relevant issue if one exists._

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no change to definitions or runtime behavior; left partial trace still uses the retained `trace_eq_trace_traceLeft` wrapper.
>
> **Overview**
> Removes the bipartite-only lemma **`Matrix.trace_eq_trace_traceRight`** and routes right-partial-trace trace preservation through **`Matrix.trace_partialTraceRight`**, after unfolding **`Matrix.traceRight`** as **`partialTraceRight`**.
>
> **`MutualInformation.mutualInformation_le_log_dim_add_log_dim`** and **`traceMatrix_ofHayashiMarkov`** now rewrite with `[Matrix.traceRight, Matrix.trace_partialTraceRight]` instead of the deleted wrapper. The module doc for partial traces no longer lists the removed theorem.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b5c5aec64f4e92490767cb4b68aa8e22fc971e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>