### PR TITLE
doc(parent): align source-facing prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -373,8 +373,8 @@ theorem
     have hpow : (μ j) ^ N ≠ 0 := pow_ne_zero N (hμ j)
     simpa [X, hY j, hpow] using hφ j
 
-/-- The current normalized BNT formalization gives two inclusions for the
-block-diagonal periodic chain space.
+/-- For normalized BNT blocks, the block-diagonal periodic chain space satisfies
+two inclusions.
 
 Let
 \[

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -607,7 +607,7 @@ proof lines 1446--1451.
 
 **Local fix (adjoint correction):** The source line writes
 \(E^j=\sum_k C^j_kA^j_k\), while the normalization step uses
-\(\sum_k A^j_kA^{j\dagger}_k=I\). The formal statement uses the adjointed
+\(\sum_k A^j_kA^{j\dagger}_k=I\). The local identity uses the adjointed
 matrix \(E^j=\sum_k C^j_kA^{j\dagger}_k\), as recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem pgvwc07_complementary_word_boundary_identities_of_trace_decomposition

--- a/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
+++ b/TNLean/MPS/ParentHamiltonian/Decorrelation.lean
@@ -98,10 +98,9 @@ end CommutingProjectors
 We work in an abstract setting with finite-dimensional Hilbert spaces
 \(H_A\), \(H_X\), \(H_B\) and a subspace \(K ≤ H_A ⊗ H_X ⊗ H_B\).
 
-Since the full formalization of the tensor product of Hilbert spaces is
-not yet available in Mathlib, we state the main definitions and the
-equivalence theorem using abstract idempotent endomorphisms on a
-finite-dimensional inner product space.
+Rather than choosing a tensor-product model for finite-dimensional Hilbert
+spaces, we state the main definitions and the equivalence theorem using
+abstract idempotent endomorphisms on a finite-dimensional inner product space.
 -/
 
 section AbstractDecorrelation

--- a/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
+++ b/TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean
@@ -56,7 +56,7 @@ coordinates used here to state the same identity for an opened cyclic interval.
 
 **Local fix (adjoint correction):** The source line writes
 \(E^j=\sum_k C^j_kA^j_k\), while the normalization step uses
-\(\sum_k A^j_kA^{j\dagger}_k=I\). The formal statement uses the adjointed
+\(\sum_k A^j_kA^{j\dagger}_k=I\). The local identity uses the adjointed
 matrix \(E^j=\sum_k C^j_kA^{j\dagger}_k\), as recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem pgvwc07_complementary_word_cde_identities_of_trace_decomposition

--- a/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
+++ b/TNLean/MPS/ParentHamiltonian/WrappingWindow.lean
@@ -40,7 +40,7 @@ proceeds as follows:
 
 ## Main results
 
-The main formal statements show that the two identities
+The main statements show that the two identities
 \[
   A^\mu A^j X = Y_\mu A^j,
   \qquad

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -35,8 +35,8 @@ $A^i = \bigoplus_j \mu_j A_j^i$ with a basis of normal tensors $\{A_j\}$,
 and \cite[Theorem~12]{PerezGarcia2007Matrix} state that the periodic
 parent-Hamiltonian ground space is spanned by the vectors
 $\{V^{(N)}(A_j)\}$. The sections below record the open-segment recursion and the
-conditional reductions for the boundary-condition comparison in the periodic
-ring.
+intersection and closure steps, together with separate conditional statements
+for the block-diagonal boundary-condition comparison in the periodic ring.
 
 \input{chapter/ch13_parent_hamiltonian_injective_ground_spaces}
 \input{chapter/ch13_parent_hamiltonian_injective_boundary}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -139,7 +139,7 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     $\bigoplus_kX_k$ is $X_j$, giving the displayed sum.
 \end{proof}
 
-\begin{lemma}[One block in a block-diagonal local ground space]
+\begin{lemma}[One block lies in the local parent space of the direct-sum tensor]
     \label{lem:local_ground_space_block_le_assembled}
     \lean{MPSTensor.groundSpace_block_le_toTensorFromBlocks}
     \leanok
@@ -336,7 +336,7 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     \]
 \end{proof}
 
-\begin{lemma}[Periodic chain vectors decompose in the local block spaces]
+\begin{lemma}[Periodic parent-space vectors decompose in the local block spaces]
     \label{lem:bnt_block_diagonal_open_boundary_decomposition}
     \lean{MPSTensor.exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
     \leanok
@@ -377,7 +377,7 @@ by \cite[Theorem~IV.16]{Cirac2021Matrix}.
     decomposition $\psi=\sum_j\psi_j$ with $\psi_j\in G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[Block-diagonal boundary conditions for periodic chain vectors]
+\begin{lemma}[Block-diagonal boundary conditions for periodic parent-space vectors]
     \label{lem:bnt_block_diagonal_open_boundary_matrices}
     \lean{MPSTensor.exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1}
     \leanok
@@ -427,15 +427,15 @@ The lemma gives
 \[
     \Gamma_N^{A_j}(\mu_j^NX_j)\in G_N(A_j).
 \]
-This is not enough for periodic-boundary membership when a local window crosses
-the chosen cut. The boundary-crossing comparison of
+This is not enough for periodic-boundary membership when a cyclic window crosses
+the chosen cut. The boundary-cut comparison of
 Lemma~\ref{lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
 concerns the separate assertion
 \[
     \Gamma_N^{A_j}(\mu_j^N X_j)\in\mathcal G_{N,L}(A_j).
 \]
 
-\subsection{Boundary-crossing component constraints}\label{subsec:block_diagonal_boundary_crossing}
+\subsection{Cyclic windows at the boundary cut}\label{subsec:block_diagonal_boundary_crossing}
 
 A cyclic length-$L$ window either stays inside the chosen linear interval
 ($i+L\le N$) or crosses the boundary cut ($N<i+L$). The non-wrapping case is
@@ -1228,8 +1228,12 @@ in both cases.
         =
         \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
     \]
-    This is the formal word-coordinate counterpart of the source $C^j,D^j$
-    comparison, with $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
+    This is the cut-adapted form of the source comparison
+    \[
+        A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1},
+        \qquad
+        D^j_\beta=(\mu_j^NX_j)A^j_\beta .
+    \]
     Then, for every block $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -19,7 +19,7 @@ cut. In these coordinates the source comparison becomes
     =
     \bigl(\mu_j^N X_j A^j_\beta\bigr)A^j_\rho,
 \]
-which is the blocked-word form of
+which is the cut-adapted form of
 $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$ with
 $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -55,7 +55,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         h_i h_j = h_j h_i,\qquad
         h_i V^{(N)}(A)=0.
     \]
-    This is the ground-vector part of the condition appearing in
+    This is the zero-energy part of the condition appearing in
     \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}: the MPS vector has zero
     energy for the translated two-site parent terms, and those terms commute.
     The missing source assertion is that the whole parent-Hamiltonian ground
@@ -217,9 +217,8 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     This implication is cited here from the structural characterization theorem
     for renormalization fixed points in~\cite{Cirac2016MPDO_arXiv}; the source
     proof says that RFP $\Rightarrow$ NNCPH is immediate from that theorem.
-    The present formalization still supplies this implication through the axiom
-    tagged above; the source derivation from the Appendix~B product-of-pairs
-    form remains to be proved.
+    At present this implication remains an unproved hypothesis; the source
+    derivation from the Appendix~B product-of-pairs form remains to be proved.
 \end{theorem}
 
 \begin{theorem}[Renormalization fixed points satisfy the NNCPH commutation and zero-energy equations]%
@@ -339,8 +338,8 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}.
     \]
     Then $B$ is a renormalization fixed point.
-    The present formalization still supplies this reverse implication through
-    the axiom tagged above, which stands for Beigi's one-dimensional
+    At present this reverse implication remains an unproved hypothesis,
+    representing Beigi's one-dimensional
     nearest-neighbor commuting-Hamiltonian ground-space theorem and the
     identification of the resulting locally orthogonal states with the BNT of
     $B$.

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -111,7 +111,7 @@ is
   \ker(H_N)=\operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}.
 \end{align}
 The sentence preceding the theorem restricts the proof to block-diagonal
-boundary conditions.  In the coordinate form used in this formalization, this
+boundary conditions.  In the cut-adapted boundary coordinates used below, this
 means boundary matrices of the form
 \begin{align}
   X=\bigoplus_{j=1}^g X_j,


### PR DESCRIPTION
### Motivation

- The parent-Hamiltonian blueprint entries and Lean docstrings described the PGVWC07 boundary comparison in process terms rather than through the displayed $C^j, D^j$ matrix identity from arXiv:quant-ph/0608197, Theorem 12, and used reader-facing meta-language that did not reflect the source-level boundary (see #2971).
- The NNCPH section characterized the axiom-backed RFP–NNCPH equivalence as a completed formalization; the prose should instead state this as an unproved hypothesis, naming the zero-energy condition and the two unproved directions explicitly (see #2633).

### Description

Prose-only alignment; no theorem statements, proof terms, or `\lean{}` tags are changed.

- `TNLean/MPS/ParentHamiltonian/PGVWCCDEIdentities.lean`: restate the PGVWC07 comparison through the $C^j, D^j$ matrix identity and cut-adapted boundary coordinates.
- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`, `BlockIntersectionProperty.lean`, `Decorrelation.lean`, `WrappingWindow.lean`: replace remaining reader-facing meta-language with source-mathematical wording.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex`: rewrite PGVWC07 comparison entry to display the $C^j, D^j$ identity and introduce cut-adapted boundary coordinates.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: rewrite NNCPH prose to state the zero-energy condition as an unproved hypothesis rather than a completed formalization.
- `blueprint/src/chapter/ch13_parent_hamiltonian.tex`, `ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`: minor prose alignment.
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: minor prose alignment.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint web` (existing bibliography/template warnings; no new errors)
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty TNLean.MPS.ParentHamiltonian.Decorrelation TNLean.MPS.ParentHamiltonian.PGVWCCDEIdentities TNLean.MPS.ParentHamiltonian.WrappingWindow` (existing style warnings; no build errors)

---
Addresses #2971
Refs #2633
Refs #190
Refs #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 38eaa396f545ee66d23d255f1d7f8b92f1337993. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->