### PR TITLE
doc(MPS/Periodic): use 1708.00029 terminology for periodic bases

### DIFF
--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -17,7 +17,7 @@ open scoped Matrix BigOperators
 This file formalizes the periodic fundamental theorem of arXiv:1708.00029 Section 3 and the
 Z-gauge theory used in its equal-case strengthening:
 
-* **Theorem 3.4** (`fundamentalTheorem_periodic_proportional`): If two non-repeating
+* **Theorem 3.4** (`fundamentalTheorem_periodic_proportional`): If two non-repeated
   block families satisfy the periodic overlap dichotomy, their bases of periodic tensors
   match up to a bijection with per-block `RepeatedBlocks` equivalence. (In the paper,
   proportional MPVs imply the dichotomy; here it is a direct hypothesis.)
@@ -274,7 +274,7 @@ theorem peripheralProportionalCase_periodicFT_of_rootFromRescaling
 
 /-- **Theorem 3.4 (Proportional case, arXiv:1708.00029).**
 
-If two non-repeating block families satisfy the periodic overlap dichotomy, then
+If two non-repeated block families satisfy the periodic overlap dichotomy, then
 their bases of periodic tensors match: equal block counts, a bijection, and per-block
 `HetRepeatedBlocks` equivalence.
 
@@ -504,7 +504,7 @@ variable {D₁ D₂ : ℕ}
 
 /-- **Theorem 3.8, Step 1: Block matching.**
 
-If two tensors in irreducible form with non-repeating blocks satisfy the periodic overlap
+If two tensors in irreducible form with non-repeated blocks satisfy the periodic overlap
 dichotomy, their bases of periodic tensors match: equal block counts, a bijection, and
 per-block `HetRepeatedBlocks` equivalence.
 
@@ -527,7 +527,7 @@ theorem fundamentalTheorem_periodic_equalCase_matching
 
 /-- **Scalar component of the equal-case periodic FT (arXiv:1708.00029).**
 
-If two MPS tensors in irreducible form with non-repeating blocks satisfy the periodic
+If two MPS tensors in irreducible form with non-repeated blocks satisfy the periodic
 overlap dichotomy and per-block multiplicity-entry power equality, then:
 
 1. **Block matching**: equal block counts, a bijection, and per-block `HetRepeatedBlocks`.

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -466,7 +466,7 @@ unconditional result.
     Newton--Girard power-sum identity to recover the multiplicity multiset.
 \end{proof}
 
-\begin{theorem}[Conditional matching of periodic bases]
+\begin{theorem}[Conditional matching of bases of periodic tensors]
     \label{thm:periodic_equalcase_matching}
     \lean{MPSTensor.fundamentalTheorem_periodic_equalCase_matching}
     \leanok
@@ -504,7 +504,7 @@ unconditional result.
 
 \begin{proof}\leanok
     First use Theorem~\ref{thm:periodic_equalcase_matching} to match the
-    periodic bases. For each matched block, apply
+    bases of periodic tensors. For each matched block, apply
     Theorem~\ref{thm:equalcase_zgauge_power_sums} to the singleton list of
     multiplicity entries.
 \end{proof}


### PR DESCRIPTION
### Motivation

- arXiv:1708.00029 (De las Cuevas et al.) uses "non-repeated blocks" and "basis/bases of periodic tensors" in Section 3. The existing docstrings and blueprint entries used "non-repeating" and "periodic bases", which do not match the paper's terminology.
- Aligns reader-facing prose with the source-discipline requirement for arXiv:1708.00029 formalization (see #619).

### Description

- `TNLean/MPS/Periodic/FundamentalTheorem.lean`: replaced "non-repeating" with "non-repeated" in docstrings for the periodic Fundamental Theorem results (Theorem 3.4 and equal-case matching/scalar statements); mathematical content and theorem names are unchanged.
- `blueprint/src/chapter/ch22_periodic_ft.tex`: retitled the conditional matching theorem to "Conditional matching of bases of periodic tensors"; updated proof text to say "bases of periodic tensors" instead of "periodic bases".
- No Lean proofs, definitions, or blueprint chapter visibility are modified; chapters 20--24 remain commented out in `blueprint/src/content.tex`.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.Periodic.FundamentalTheorem -q`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Refs #619

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and LaTeX title tweaks only; no formal statements, proofs, or runtime behavior change.
> 
> **Overview**
> **Documentation-only terminology alignment** with arXiv:1708.00029 Section 3 wording.
> 
> In `TNLean/MPS/Periodic/FundamentalTheorem.lean`, reader-facing docstrings for Theorem 3.4 and the equal-case matching/scalar statements now say **non-repeated** blocks instead of **non-repeating**; mathematical content and theorem names are unchanged.
> 
> In `blueprint/src/chapter/ch22_periodic_ft.tex`, the conditional matching theorem is retitled to **Conditional matching of bases of periodic tensors**, and its proof text refers to matching **bases of periodic tensors** rather than **periodic bases**.
> 
> No Lean proofs, definitions, or blueprint chapter visibility are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d2dafca11d4281693f3a2a157c70e5180b7f624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->