### PR TITLE
refactor(algebra): use Fintype sum zero criterion

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -92,8 +92,8 @@ theorem eq_zero_of_sum_mul_conjTranspose_eq_zero
     rw [← Complex.re_sum, ← Matrix.trace_sum, h]
     simp
   have htrace_re : ((B i * (B i)ᴴ).trace).re = 0 :=
-    Finset.sum_eq_zero_iff_of_nonneg (fun j _ => htrace_nonneg j)
-      |>.mp htrace_sum i (Finset.mem_univ i)
+    congrFun (Fintype.sum_eq_zero_iff_of_nonneg (fun j => htrace_nonneg j) |>.mp
+      htrace_sum) i
   have htrace_zero : (B i * (B i)ᴴ).trace = 0 :=
     Complex.ext htrace_re
       (Complex.le_def.mp (Matrix.posSemidef_self_mul_conjTranspose (B i)).trace_nonneg).2.symm

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -86,8 +86,8 @@ private lemma exists_eq_one_of_sum_eq_one_sum_sq_eq_one_nonneg
       _ = 0 := by rw [h_sum, h_sq]; norm_num
   have hterm_zero : ∀ i, lam i * (1 - lam i) = 0 := by
     intro i
-    exact (Finset.sum_eq_zero_iff_of_nonneg
-      (fun j _ => hterm_nonneg j)).mp hsum_term i (Finset.mem_univ i)
+    exact congrFun (Fintype.sum_eq_zero_iff_of_nonneg
+      (fun j => hterm_nonneg j) |>.mp hsum_term) i
   have hex : ∃ i, lam i = 1 := by
     by_contra hno
     have hall_zero : ∀ i, lam i = 0 := by

--- a/TNLean/Channel/FixedPoint/Cesaro.lean
+++ b/TNLean/Channel/FixedPoint/Cesaro.lean
@@ -106,8 +106,9 @@ private theorem psd_orthogonal_difference_eq_zero
     have hre_sum : ∑ j, (star (e j) ⬝ᵥ Y.mulVec (e j)).re = 0 := by
       have h1 := map_sum Complex.reAddGroupHom (fun j => star (e j) ⬝ᵥ Y.mulVec (e j)) Finset.univ
       rw [← hY_tr_sum, hY_tr] at h1; exact h1.symm
-    have hre_zero := (Finset.sum_eq_zero_iff_of_nonneg (fun j _ => hre_nonneg j)).mp hre_sum
-    intro j; exact Complex.ext (hre_zero j (Finset.mem_univ _)) (him j)
+    have hre_zero := congrFun
+      (Fintype.sum_eq_zero_iff_of_nonneg (fun j => hre_nonneg j) |>.mp hre_sum)
+    intro j; exact Complex.ext (hre_zero j) (him j)
   -- Y.mulVec(e_j) = 0 via dotProduct_mulVec_zero_iff for (A+Y) or (B+Y)
   have hY_mulVec_zero : ∀ j, Y.mulVec (e j) = 0 := by
     intro j; rcases he_ker j with hA_ker | hB_ker

--- a/TNLean/Channel/Irreducible/Growth/OneStep.lean
+++ b/TNLean/Channel/Irreducible/Growth/OneStep.lean
@@ -88,8 +88,8 @@ theorem posDef_of_ker_subset_irreducible_cp
             star ((K j')ᴴ *ᵥ v) ⬝ᵥ (A *ᵥ ((K j')ᴴ *ᵥ v))).re = 0 := by
           rw [← hsum]; simp [hqf_EA]
         rwa [Complex.re_sum] at this
-      have hre := (Finset.sum_eq_zero_iff_of_nonneg
-        (fun j' _ => hA_psd.re_dotProduct_nonneg _)).mp h_sum_re j (Finset.mem_univ _)
+      have hre := congrFun (Fintype.sum_eq_zero_iff_of_nonneg
+        (fun j' => hA_psd.re_dotProduct_nonneg _) |>.mp h_sum_re) j
       exact Complex.ext hre (hA_psd.isHermitian.im_star_dotProduct_mulVec_self _)
     exact (hA_psd.dotProduct_mulVec_zero_iff _).mp (h_each i)
   -- Step 2: Construct support projection Q = U * diag(sgn(λ)) * U†

--- a/TNLean/Channel/Semigroup/LiouvillianKernel.lean
+++ b/TNLean/Channel/Semigroup/LiouvillianKernel.lean
@@ -384,8 +384,8 @@ private theorem each_commutator_eq_zero_of_sum_eq_zero
     have h_tr_re :
         ((A * F.L j - F.L j * A)ᴴ * (A * F.L j - F.L j * A)).trace.re = 0 :=
       le_antisymm
-        (by linarith [Finset.sum_eq_zero_iff_of_nonneg (fun k _ => h_each_nonneg k)
-            |>.mp h_tr_sum_re j (Finset.mem_univ j)])
+        (le_of_eq <| congrFun (Fintype.sum_eq_zero_iff_of_nonneg
+          (fun k => h_each_nonneg k) |>.mp h_tr_sum_re) j)
         (h_each_nonneg j)
     have h_tr_zero :
         ((A * F.L j - F.L j * A)ᴴ * (A * F.L j - F.L j * A)).trace = 0 :=

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -266,8 +266,8 @@ private lemma ker_invariant_under_adjoint
       rw [← map_sum, ← hsum, hqf]
       exact Complex.zero_re
     have hre :=
-        (Finset.sum_eq_zero_iff_of_nonneg (fun j _ => hρ_psd.re_dotProduct_nonneg _)).mp
-          h_sum_zero i (Finset.mem_univ _)
+        congrFun (Fintype.sum_eq_zero_iff_of_nonneg
+          (fun j => hρ_psd.re_dotProduct_nonneg _) |>.mp h_sum_zero) i
     exact Complex.ext hre (hρ_psd.isHermitian.im_star_dotProduct_mulVec_self _)
   intro i
   exact (hρ_psd.dotProduct_mulVec_zero_iff _).mp (h_each_zero i)

--- a/TNLean/QPF/PosDef.lean
+++ b/TNLean/QPF/PosDef.lean
@@ -79,8 +79,9 @@ private lemma ker_invariant_under_adjoint
     have h_sum_zero :
         ∑ j, RCLike.re (star ((A j)ᴴ *ᵥ x) ⬝ᵥ (ρ *ᵥ ((A j)ᴴ *ᵥ x))) = 0 := by
       rw [← map_sum, ← hsum, hqf]; simp
-    have hre := (Finset.sum_eq_zero_iff_of_nonneg (fun j _ => hρ_psd.re_dotProduct_nonneg _)).mp
-      h_sum_zero i (Finset.mem_univ _)
+    have hre := congrFun
+      (Fintype.sum_eq_zero_iff_of_nonneg (fun j => hρ_psd.re_dotProduct_nonneg _) |>.mp
+        h_sum_zero) i
     exact Complex.ext hre (hρ_psd.isHermitian.im_star_dotProduct_mulVec_self _)
   intro i
   exact (hρ_psd.dotProduct_mulVec_zero_iff _).mp (h_each_zero i)


### PR DESCRIPTION
### Motivation

- Mathlib provides `Fintype.sum_eq_zero_iff_of_nonneg` as a ready-made theorem for the case where the index set is the whole finite type; the manual specialisation `Finset.sum_eq_zero_iff_of_nonneg ... Finset.univ` in proof scripts is replaced to align with Mathlib idioms and reduce internal boilerplate.

### Description

- In seven modules, proof-internal applications of `Finset.sum_eq_zero_iff_of_nonneg` specialised to `Finset.univ` are replaced by `Fintype.sum_eq_zero_iff_of_nonneg`.
- Affected files: `TNLean/Algebra/MatrixAux.lean`, `TNLean/Algebra/PerronFrobenius/RankOne.lean`, `TNLean/Channel/FixedPoint/Cesaro.lean`, `TNLean/Channel/Irreducible/Growth/OneStep.lean`, `TNLean/Channel/Semigroup/LiouvillianKernel.lean`, `TNLean/MPS/Irreducible/FixedPointProjection.lean`, `TNLean/QPF/PosDef.lean`.
- Sums over proper subsets (e.g., `Finset.univ.erase i` in `RankOne.lean`) retain the `Finset` variant.
- No theorem statements, public names, or mathematical conclusions change.

### Testing

- `lake exe cache get`
- `lake build TNLean.Algebra.MatrixAux TNLean.Algebra.PerronFrobenius.RankOne TNLean.Channel.FixedPoint.Cesaro TNLean.Channel.Irreducible.Growth.OneStep TNLean.QPF.PosDef TNLean.Channel.Semigroup.LiouvillianKernel TNLean.MPS.Irreducible.FixedPointProjection -q --log-level=info`
- `git diff --check`; added-line scan for `sorry`, `admit`, `axiom`, `native_decide`, `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
<!-- No linked issue identified; author should add `Addresses #N` when one is created. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical proof refactor with no API or mathematical changes; only affects internal proof scripts in algebra/channel/MPS/QPF files.
>
> **Overview**
> Proofs that deduce **each summand is zero** from a **sum of nonnegative terms equals zero** now call Mathlib's `Fintype.sum_eq_zero_iff_of_nonneg` with `congrFun`, instead of manually instantiating `Finset.sum_eq_zero_iff_of_nonneg` on `Finset.univ` with `Finset.mem_univ`.
>
> The pattern is updated in seven modules (matrix sums, Perron–Frobenius rank-one, Cesàro fixed points, irreducible growth, Liouvillian kernel, MPS fixed-point projection, QPF positive definiteness). **Sums over proper subsets** (e.g. `Finset.univ.erase i` in `RankOne.lean`) still use the `Finset` lemma.
>
> No theorem statements, names, or proof conclusions change—only the Mathlib entry point for whole-`Fintype` sums.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fd6d0e101a1fbb611088be37a5932846c4b9e42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->