### PR TITLE
doc(periodic): clarify remaining basis independence gap

### DIFF
--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1345,6 +1345,55 @@ unconditional result.
 \begin{proof}
     \notready
     \uses{thm:periodic_overlap_dichotomy, thm:periodic_self_overlap_tendsto}
+    The missing point is not the Gram-matrix argument itself.  It is the
+    sector-match alternative in
+    Theorem~\ref{thm:periodic_overlap_dichotomy}.  In the notation of
+    Appendix~A of \cite{DeLasCuevas2017Irreducible}, after choosing inverses
+    $\Omega_u$ for the injective words $F_u$, the required contraction is
+    \[
+        A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots
+        \otimes A_{u+m-1}^{i_m}
+        =
+        e^{i\eta_v}
+        B_v^{i_1}\otimes B_{v+1}^{i_2}\otimes\cdots
+        \otimes B_{v+m-1}^{i_m}.
+    \]
+    Applying the same identity after a cyclic translation gives
+    \[
+        e^{i\eta_{v+\ell}}=e^{i\eta_v}
+        \qquad
+        (\ell=0,\ldots,m-1),
+    \]
+    so we write the common phase as $e^{i\eta}$.  The product-tensor identity
+    then gives scalars $\kappa_v$ with
+    \[
+        A_u^i=\kappa_v e^{i\eta/m}B_v^i,
+        \qquad
+        \prod_{v=1}^{m}\kappa_v=1.
+    \]
+    The left-canonical normalization gives $|\kappa_v|=1$; writing
+    $\kappa_v=e^{i(\phi_v-\phi_{v+1})}$ gives, where $q$ is the cyclic
+    offset between the matched sector labels and $v=u+q$,
+    \[
+        P_u A^i P_{u+1}
+        =
+        e^{i\eta/m} e^{i\phi_v}
+        U_v Q_v B^i Q_{v+1} U_{v+1}^{\dagger} e^{-i\phi_{v+1}}.
+    \]
+    Hence, for
+    \[
+        U=\sum_{u=1}^{m}e^{i\phi_{u+q}}P_uU_{u+q}Q_{u+q},
+        \qquad
+        \xi=\eta/m,
+    \]
+    one obtains the global relation
+    \[
+        A^i=e^{i\xi}UB^iU^\dagger.
+    \]
+    % Remaining step: see
+    % docs/paper-gaps/1708_periodic_overlap_route_alignment.tex,
+    % Section ``Remaining Case-3 input''.
+
     Let
     \[
         G_N(j,k)


### PR DESCRIPTION
### Motivation
The proof of eventual linear independence uses the periodic overlap dichotomy. Review correctly noted that the sector-match alternative still depends on the remaining Appendix A cyclic contraction and phase-normalization argument, so the proof must remain `\notready`.

### Description
This adds a mathematical note at the start of the blueprint proof explaining that the Gram-matrix argument is not the missing part. The note displays the Appendix A product-tensor identity, the cyclic phase equality, the scalar normalization equations, and the final global gauge relation before referring to `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.

### Testing
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

Refs #81
Refs #619
Refs #873

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint prose only in `ch22_periodic_ft.tex`; no Lean or runtime behavior changes.
> 
> **Overview**
> The proof of **eventual linear independence of periodic vectors** (`thm:periodic_basis_eventually_li`) stays `\notready`; this PR adds an upfront note in that proof so reviewers see **what** is still missing.
> 
> The note states the gap is **not** the Gram-matrix / positive-definiteness step, but the **sector-match alternative** in `thm:periodic_overlap_dichotomy`. It spells out the Appendix A chain: the \(\Omega_u\)-contraction product-tensor identity, cyclic equality of the \(\eta_v\) phases, scalar \(\kappa_v\) with \(\prod_v \kappa_v=1\), unit-modulus normalization and coboundary phases, and the assembled global relation \(A^i=e^{i\xi}UB^iU^\dagger\). A comment points to `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex` (**Remaining Case-3 input**) for the step not yet written in the blueprint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd30a37376fd67f0b654e8557e5555f5f2e1591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->