### PR TITLE
refactor(Channel/Determinant): remove finite-sum-zero auxiliary lemma

### DIFF
--- a/TNLean/Channel/Determinant/HeisenbergDual.lean
+++ b/TNLean/Channel/Determinant/HeisenbergDual.lean
@@ -175,9 +175,13 @@ private theorem heisenberg_dual_ks_eq_stdBasis [NeZero d]
       simp only [Matrix.trace_sub, Complex.sub_re, Finset.sum_sub_distrib]
     rw [hsum_eq]
     nlinarith [hfirst, hsecond_ge]
+  have hgap_trace_sum_zero : ∑ ij : Fin d × Fin d,
+      (Matrix.trace (Td (e ij * (e ij)ᴴ) - Td (e ij) * (Td (e ij))ᴴ)).re = 0 :=
+    le_antisymm hgap_trace_sum_le (Fintype.sum_nonneg hgap_trace_nonneg)
   have hgap_trace_zero : ∀ ij : Fin d × Fin d,
       (Matrix.trace (Td (e ij * (e ij)ᴴ) - Td (e ij) * (Td (e ij))ᴴ)).re = 0 :=
-    eq_zero_of_nonneg_of_sum_le_zero _ hgap_trace_nonneg hgap_trace_sum_le
+    fun ij => congrFun
+      ((Fintype.sum_eq_zero_iff_of_nonneg hgap_trace_nonneg).mp hgap_trace_sum_zero) ij
   intro ij
   have hpsd := hgap_psd ij
   have htr_re := hgap_trace_zero ij

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -29,8 +29,6 @@ Hilbert--Schmidt norm computations; and an AM--GM argument upgrades
   transpose swaps the indices of a matrix-unit basis element.
 * `ChannelDeterminant.Internal.sum_stdBasis_mul_conjTranspose` — the standard
   basis satisfies `∑_{ij} E_{ij} E_{ij}^† = d • 1`.
-* `ChannelDeterminant.Internal.eq_zero_of_nonneg_of_sum_le_zero` — a finite
-  nonnegative family with total sum at most `0` vanishes termwise.
 * `ChannelDeterminant.Internal.channelDet_norm_one_hs_norm_ge` — determinant
   saturation gives the AM--GM lower bound on the Hilbert--Schmidt norm.
 
@@ -133,13 +131,6 @@ theorem sum_stdBasis_mul_conjTranspose :
             nsmul_eq_mul, mul_one, smul_eq_mul]
     _ = (d : ℂ) • ∑ i : Fin d, Matrix.single i i (1 : ℂ) := by rw [Finset.smul_sum]
     _ = (d : ℂ) • (1 : MatrixAlg d) := by rw [Matrix.sum_single_one]
-
-/-- If a finite family of nonnegative reals has total sum at most `0`, then every term is `0`. -/
-lemma eq_zero_of_nonneg_of_sum_le_zero {ι : Type*} [Fintype ι]
-    (f : ι → ℝ) (hf : ∀ i, 0 ≤ f i) (hsum : ∑ i, f i ≤ 0) :
-    ∀ i, f i = 0 := by
-  have hsum_zero : ∑ i, f i = 0 := le_antisymm hsum (Fintype.sum_nonneg hf)
-  exact fun i => congrFun ((Fintype.sum_eq_zero_iff_of_nonneg hf).mp hsum_zero) i
 
 private lemma matrix_det_norm_one_trace_conjTranspose_mul_self_ge [NeZero d]
     (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (hdet : ‖A.det‖ = 1) :


### PR DESCRIPTION
### Motivation

- The local lemma `ChannelDeterminant.Internal.eq_zero_of_nonneg_of_sum_le_zero` — asserting that a finite family of nonneg reals with sum at most 0 vanishes termwise — duplicates functionality available directly in Mathlib via `Fintype.sum_nonneg` and `Fintype.sum_eq_zero_iff_of_nonneg`.
- Removing it reduces the internal declaration surface of `Channel/Determinant` without altering any theorem statement.

### Description

- `TNLean/Channel/Determinant/HilbertSchmidt.lean`: removed `ChannelDeterminant.Internal.eq_zero_of_nonneg_of_sum_le_zero` and its module docstring entry.
- `TNLean/Channel/Determinant/HeisenbergDual.lean`: in the proof of `heisenberg_dual_ks_eq_stdBasis`, replaced the call to the removed lemma with a two-step Mathlib argument — `le_antisymm` with `Fintype.sum_nonneg` gives `∑ = 0`, then `Fintype.sum_eq_zero_iff_of_nonneg` gives termwise equality.
- All theorem statements are unchanged; no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast` introduced.

### Testing

- `lake exe cache get` and `lake build TNLean.Channel.Determinant.HilbertSchmidt TNLean.Channel.Determinant.HeisenbergDual -q --log-level=info`
- Full `lake build`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
No linked issue identified — the PR author should link one manually if applicable.

> [!NOTE]
> **Low Risk**
> Proof-only refactor in determinant channel lemmas; no API or runtime behavior changes.
>
> **Overview**
> Removes the internal helper **`eq_zero_of_nonneg_of_sum_le_zero`** from `HilbertSchmidt.lean` and drops it from the module doc list.
>
> In **`heisenberg_dual_ks_eq_stdBasis`** (`HeisenbergDual.lean`), the step that each Kadison–Schwarz gap trace is zero now first shows the summed real traces are **0** via `le_antisymm` with `Fintype.sum_nonneg`, then uses **`Fintype.sum_eq_zero_iff_of_nonneg`** for termwise equality. The downstream PSD/trace argument is unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6049d077c8ca93cb529cfd236e066d708a59bd95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>