### PR TITLE
feat(MPS/ParentHamiltonian): derive all-chain NNCPH from Appendix B data

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -50,6 +50,9 @@ clause from Definition 3.9.
   `Axioms.rfp_to_nncph_commute`.
 * `MPSTensor.rfp_implies_nncph_ground_state_of_appendixBExtraction` — the same
   conditional theorem with the zero-energy equation for \(V^{(N)}(A)\) included.
+* `MPSTensor.rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning` —
+  the same Appendix B conditional theorem upgraded to the full all-chain
+  Definition 3.9 condition once the ground-space spanning equation is supplied.
 * `MPSTensor.rfp_implies_nncph` — construction of the length-two commutation
   equations in the RFP \(\Longrightarrow\) NNCPH direction, using the
   structural characterization theorem of arXiv:1606.00608, source lines
@@ -322,6 +325,23 @@ theorem ProductPairBridge.isNNCPH {A : MPSTensor d D} (hBridge : ProductPairBrid
     IsNNCPH A N :=
   (hBridge.localProjectors N).isNNCPH
 
+/-- Product-of-pairs data and the ground-space spanning equation give the full
+all-chain nearest-neighbor parent-Hamiltonian condition.
+
+The product-of-pairs data supply the translated length-two commutation
+equations. The usual parent-Hamiltonian frustration-free equation gives
+zero energy of \(V^{(N)}(B)\). The separate hypothesis
+`HasParentHamiltonianGroundSpaceSpanning B 2 A` supplies the remaining
+Definition 3.9 ground-space spanning clause from arXiv:1606.00608,
+source lines 522--524. -/
+theorem ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning
+    {B : MPSTensor d D} (hBridge : ProductPairBridge B)
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    (hSpan : HasParentHamiltonianGroundSpaceSpanning B 2 A) :
+    HasNNCPHGroundSpaces B A := by
+  intro N hN
+  exact ⟨(hBridge.isNNCPH N).isNNCPHGroundState (le_of_lt hN), hSpan N hN⟩
+
 /-- Conditional internal theorem for Theorem 3.10(i)⟹(iii).
 
 A normal left-canonical RFP tensor has the Appendix B structural form
@@ -363,6 +383,26 @@ theorem rfp_implies_nncph_ground_state_of_appendixBExtraction
     IsNNCPHGroundState A N :=
   (rfp_implies_nncph_of_appendixBExtraction A hRFP hNT hLeft hExtract N).isNNCPHGroundState
     hN
+
+/-- Conditional full source form of Theorem 3.10(i)⟹(iii).
+
+Under the Appendix B product-of-pairs extraction used above, a normal
+left-canonical RFP tensor has the all-chain commutation and zero-energy
+equations for nearest-neighbor parent terms. If, in addition, the
+Definition 3.9 ground-space spanning equation is supplied for a chosen BNT
+family \(A_j\), then the full all-chain NNCPH ground-space condition holds.
+
+This theorem does not use `Axioms.rfp_to_nncph_commute`; the remaining input is
+exactly the source ground-space spanning clause. -/
+theorem rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning
+    (B : MPSTensor d D) [NeZero D]
+    (hRFP : IsRFP B) (hNT : IsNormal B) (hLeft : IsLeftCanonical B)
+    (hExtract : AppendixBProductPairExtraction
+      (AppendixBStructuralData.ofRFP B hNT hRFP hLeft))
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
+    (hSpan : HasParentHamiltonianGroundSpaceSpanning B 2 A) :
+    HasNNCPHGroundSpaces B A :=
+  hExtract.toProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning hSpan
 
 /-- The commuting condition is symmetric: if `h i j` holds, then `h j i` holds. -/
 theorem IsCommutingParentHam.symm {A : MPSTensor d D} {L N : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -393,7 +393,12 @@ Definition 3.9 ground-space spanning equation is supplied for a chosen BNT
 family \(A_j\), then the full all-chain NNCPH ground-space condition holds.
 
 This theorem does not use `Axioms.rfp_to_nncph_commute`; the remaining input is
-exactly the source ground-space spanning clause. -/
+exactly the source ground-space spanning clause.
+
+**Scope restriction (spanning clause assumed):** The source implication proves
+the ground-space spanning equation; this theorem assumes it via
+`HasParentHamiltonianGroundSpaceSpanning`. Documented in
+`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`. -/
 theorem rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning
     (B : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP B) (hNT : IsNormal B) (hLeft : IsLeftCanonical B)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -317,6 +317,41 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     asserting the source ground-space spanning condition.
 \end{remark}
 
+\begin{theorem}[Product-pair data and ground-space spanning give all-chain NNCPH]%
+    \label{thm:appendixB_product_pair_has_nncph_ground_spaces}
+    \lean{MPSTensor.ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning}
+    \lean{MPSTensor.rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning}
+    \leanok
+    \uses{rem:product_pair_projectors, def:has_nncph_ground_spaces,
+        def:parent_hamiltonian_ground_space_spanning}
+    Suppose the Appendix~B product-of-pairs data give commuting two-site parent
+    terms for a tensor \(B\). If the nearest-neighbor parent Hamiltonian also
+    satisfies the Definition~\ref{def:parent_hamiltonian_ground_space_spanning}
+    spanning equation with BNT components \(A_1,\ldots,A_g\), then \(B\) satisfies
+    the all-chain nearest-neighbor commuting parent-Hamiltonian ground-space
+    condition of Definition~\ref{def:has_nncph_ground_spaces}.
+
+    In particular, if a normal left-canonical RFP tensor has nonzero bond
+    dimension, the Appendix~B product-of-pairs extraction, and the same
+    ground-space spanning equation, then it satisfies the full all-chain condition in
+    \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \uses{lem:parent_hamiltonian_ff, def:has_nncph_ground_space}
+    \leanok
+    The product-of-pairs equations give \(h_i h_j=h_j h_i\) for all translated
+    two-site parent terms. Lemma~\ref{lem:parent_hamiltonian_ff} gives
+    \(h_iV^{(N)}(B)=0\). For every \(N>2\), the spanning hypothesis supplies
+    \[
+        \ker H_2^{(N)}(B)
+        =
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
+    \]
+    These are exactly the three clauses in
+    Definition~\ref{def:has_nncph_ground_space}, uniformly in \(N\).
+\end{proof}
+
 \begin{theorem}[All-chain nearest-neighbor commuting parent-Hamiltonian ground spaces imply a renormalization fixed point]\label{thm:nncph_implies_rfp}
     \lean{MPSTensor.nncph_implies_rfp}
     \lean{Axioms.beigi_nncph_to_rfp}


### PR DESCRIPTION
### Motivation
- Continues the formalization of the pure-state RFP = ZCL = NNCPH equivalence (arXiv:1606.00608, main theorem, line 534), tracked in #2633.
- The product-of-pairs form from Appendix B of arXiv:1606.00608 already yields commutation and zero-energy conditions; the ground-space spanning clause from Definition 3.9 is the remaining input needed to conclude the all-chain nearest-neighbor commuting parent-Hamiltonian ground-space condition.
- Addresses part of the open work itemized in #2633 and the coverage gaps in #2380; relates to the parent-Hamiltonian tracking issue #190.

### Description
- **`TNLean/MPS/ParentHamiltonian/Commuting.lean`**: adds two theorems.
  - `MPSTensor.ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning`: given product-pair commutation, frustration-free zero energy of $V^{(N)}(B)$, and the ground-space spanning hypothesis (`HasParentHamiltonianGroundSpaceSpanning`), the all-chain condition `HasNNCPHGroundSpaces` holds for every $N > 2$.
  - `MPSTensor.rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning`: specializes the above to the RFP + normal left-canonical + Appendix B extraction setting.
- **`blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`**: records the theorem `thm:appendixB_product_pair_has_nncph_ground_spaces` with a short proof and `\leanok` links to the two declarations.
- Neither theorem invokes `Axioms.rfp_to_nncph_commute`; the ground-space spanning clause remains an explicit hypothesis. The full RFP = ZCL = NNCPH equivalence is not yet established.

### Testing
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.Commuting -q`
- `lake build TNLean -q`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `cd blueprint && leanblueprint web`

---
Refs #2633

> [!NOTE]
> **Low Risk**
> Pure formal proof and documentation extensions in parent-Hamiltonian theory; no runtime, auth, or data-path changes, and the hard spanning clause is still assumed rather than proved.
> 
> **Overview**
> This PR closes the gap between **commutation/zero-energy** (already from Appendix B product-of-pairs data) and the **full Definition 3.9 / Theorem 3.10(iii)** all-chain condition by explicitly adding the **ground-space spanning** hypothesis.
> 
> In Lean, **`ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning`** packages product-pair commutation, frustration-free zero energy of \(V^{(N)}(B)\), and **`HasParentHamiltonianGroundSpaceSpanning`** into **`HasNNCPHGroundSpaces`** for every \(N>2\). **`rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning`** is the RFP + normal left-canonical + Appendix B extraction specialization. Neither step uses **`Axioms.rfp_to_nncph_commute`**; spanning remains an explicit input.
> 
> The blueprint adds **`thm:appendixB_product_pair_has_nncph_ground_spaces`** with a short proof and **`leanok`** links to those declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b44c4c242d57268affa1b3de976c68bd2f79168b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only extensions to parent-Hamiltonian formalization and blueprint sync; the hard ground-space spanning input stays an explicit hypothesis rather than being derived.
> 
> **Overview**
> Adds Lean theorems that assemble **commutation**, **zero energy of** `V^{(N)}(B)`, and an explicit **`HasParentHamiltonianGroundSpaceSpanning`** hypothesis into the full all-chain **`HasNNCPHGroundSpaces`** condition (Definition 3.9 / Theorem 3.10(iii)), without using **`Axioms.rfp_to_nncph_commute`**.
> 
> **`ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning`** combines product-of-pairs data with spanning for every `N > 2`. **`rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning`** is the RFP + normal left-canonical + Appendix B extraction specialization. Module docs note the spanning clause remains assumed, with scope documented in **`docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`**.
> 
> The blueprint chapter adds **`thm:appendixB_product_pair_has_nncph_ground_spaces`** with a short proof and **`leanok`** links to both declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94c20673c71a10320f8da57a36604ed5eb2e8fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->