### PR TITLE
refactor(Semigroup): inline right multiplication hom

### DIFF
--- a/TNLean/Channel/Semigroup/Dissipative.lean
+++ b/TNLean/Channel/Semigroup/Dissipative.lean
@@ -63,19 +63,13 @@ private def clmExpD (T : MatrixCLM (Fin D)) : MatrixCLM (Fin D) :=
   letI : NormedRing (MatrixCLM (Fin D)) := ContinuousLinearMap.toNormedRing
   NormedSpace.exp T
 
-private abbrev rightMulAlgHom (D : ℕ) : (Mat D)ᵐᵒᵖ →ₐ[ℂ] LM D :=
-  (AlgHom.mulLeftRight ℂ (Mat D)).comp
-    (Algebra.TensorProduct.includeRight (R := ℂ) (A := Mat D) (B := (Mat D)ᵐᵒᵖ))
-
-private theorem rightMulAlgHom_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
-    rightMulAlgHom D A ρ = ρ * MulOpposite.unop A := by
-  simp [rightMulAlgHom]
-
 private abbrev leftMulCLMAlgHom (D : ℕ) : Mat D →ₐ[ℂ] MatrixCLM (Fin D) :=
   (endEquiv (D := D)).toAlgHom.comp (Algebra.lmul ℂ (Mat D))
 
 private abbrev rightMulCLMAlgHom (D : ℕ) : (Mat D)ᵐᵒᵖ →ₐ[ℂ] MatrixCLM (Fin D) :=
-  (endEquiv (D := D)).toAlgHom.comp (rightMulAlgHom D)
+  (endEquiv (D := D)).toAlgHom.comp
+    ((AlgHom.mulLeftRight ℂ (Mat D)).comp
+      (Algebra.TensorProduct.includeRight (R := ℂ) (A := Mat D) (B := (Mat D)ᵐᵒᵖ)))
 
 private theorem leftMulCLM_apply (A ρ : Mat D) :
     leftMulCLMAlgHom D A ρ = A * ρ := by
@@ -83,8 +77,8 @@ private theorem leftMulCLM_apply (A ρ : Mat D) :
 
 private theorem rightMulCLM_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
     rightMulCLMAlgHom D A ρ = ρ * MulOpposite.unop A := by
-  change rightMulAlgHom D A ρ = ρ * MulOpposite.unop A
-  exact rightMulAlgHom_apply A ρ
+  change ((AlgHom.mulLeftRight ℂ (Mat D)) (1 ⊗ₜ[ℂ] A)) ρ = ρ * MulOpposite.unop A
+  simp [AlgHom.mulLeftRight_apply]
 
 private lemma continuous_leftMulCLMAlgHom :
     Continuous (leftMulCLMAlgHom D) := by
@@ -113,20 +107,16 @@ private lemma continuous_rightMulCLMAlgHom :
   rw [h_eq]
   exact (ContinuousLinearMap.mul ℂ (Mat D)).flip.continuous.comp hunop
 
-private theorem mulRight_eq_rightMulAlgHom (A : Mat D) :
-    LinearMap.mulRight ℂ A = rightMulAlgHom D (MulOpposite.op A) := by
-  ext ρ i j
-  rw [rightMulAlgHom_apply]
-  simp
-
 private theorem endEquiv_mulLeft (A : Mat D) :
     endEquiv (D := D) (LinearMap.mulLeft ℂ A) = leftMulCLMAlgHom D A := by
   rfl
 
 private theorem endEquiv_mulRight (A : Mat D) :
     endEquiv (D := D) (LinearMap.mulRight ℂ A) = rightMulCLMAlgHom D (MulOpposite.op A) := by
-  simpa [rightMulCLMAlgHom] using
-    congrArg (endEquiv (D := D)) (mulRight_eq_rightMulAlgHom (D := D) A)
+  ext ρ i j
+  change (LinearMap.mulRight ℂ A) ρ i j =
+    ((AlgHom.mulLeftRight ℂ (Mat D)) (1 ⊗ₜ[ℂ] MulOpposite.op A)) ρ i j
+  simp [AlgHom.mulLeftRight_apply, LinearMap.mulRight_apply]
 
 private theorem left_right_commute (A B : Mat D) :
     Commute (leftMulCLMAlgHom D A) (rightMulCLMAlgHom D (MulOpposite.op B)) := by


### PR DESCRIPTION
### Motivation

- `TNLean/Channel/Semigroup/Dissipative.lean` contained a private indirection layer — `rightMulAlgHom`, `rightMulAlgHom_apply`, and `mulRight_eq_rightMulAlgHom` — that proxied right-multiplication through an intermediate algebra homomorphism.
- Mathlib 4.31 provides `AlgHom.mulLeftRight` and `Algebra.TensorProduct.includeRight` directly, making the private pass-through layer redundant.

### Description

- Modified `TNLean/Channel/Semigroup/Dissipative.lean`:
  - Removed private declarations `rightMulAlgHom`, `rightMulAlgHom_apply`, and `mulRight_eq_rightMulAlgHom`.
  - `rightMulCLMAlgHom` is now defined directly from `AlgHom.mulLeftRight` and `Algebra.TensorProduct.includeRight`.
  - `rightMulCLM_apply` and `endEquiv_mulRight` prove the same matrix identities using `simp` on those definitions instead of routing through the removed layer.
  - Public API and dissipative-drift statements (`dissipativeDrift`, `expSemigroup_dissipativeDrift_apply`) are unchanged.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.Semigroup.Dissipative -q --log-level=info`
- Proof-integrity scan (added lines): no `sorry`, `admit`, `axiom`, `native_decide`, or `unsafeCast`.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---

> [!NOTE]
> **Low Risk**
> Private helper removal and proof rewrites only; no changes to `dissipativeDrift`, `expSemigroup_dissipativeDrift_apply`, or public theorems.
> 
> **Overview**
> Removes the private **`rightMulAlgHom`**, **`rightMulAlgHom_apply`**, and **`mulRight_eq_rightMulAlgHom`** indirection in `Dissipative.lean`.
> 
> **`rightMulCLMAlgHom`** is now built directly from Mathlib's **`AlgHom.mulLeftRight`** and **`Algebra.TensorProduct.includeRight`**. **`rightMulCLM_apply`** and **`endEquiv_mulRight`** prove the same matrix identities with **`simp`** on those definitions instead of routing through the old algebra hom layer.
> 
> Dissipative-drift lemmas and the public API are unchanged; this is proof-structure cleanup only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5074895ad992f30ac347a1336d8b71c1789e9c71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>