### PR TITLE
refactor(Channel/TransferMatrix): use Mathlib matrix-unit expansions

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -119,6 +119,11 @@ theorem transferMatrix_apply
     (i j k l : Fin D) :
     transferMatrix T (j, i) (l, k) = (T (Matrix.single k l 1)) i j := rfl
 
+private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 := by
+  simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+    (Matrix.matrix_eq_sum_single ρ)
+
 /-! ### Fundamental property: T̂ represents T in the vectorized picture -/
 
 /-- **Key property**: the transfer matrix faithfully represents `T`:
@@ -135,9 +140,7 @@ theorem transferMatrix_mulVec_eq
     Matrix.vec, Fintype.sum_prod_type]
   have key : T ρ = ∑ k, ∑ l, ρ k l • T (Matrix.single k l 1) := by
     conv_lhs =>
-      rw [show ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 by
-        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-          (Matrix.matrix_eq_sum_single ρ)]
+      rw [sum_smul_single_eq ρ]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
@@ -156,10 +159,7 @@ theorem transferMatrix_comp
   have key : S (T (Matrix.single k l 1)) =
       ∑ a, ∑ b, (T (Matrix.single k l 1)) a b • S (Matrix.single a b 1) := by
     conv_lhs =>
-      rw [show T (Matrix.single k l 1) =
-          ∑ a : Fin D, ∑ b : Fin D, (T (Matrix.single k l 1)) a b • Matrix.single a b 1 by
-        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-          (Matrix.matrix_eq_sum_single (T (Matrix.single k l 1)))]
+      rw [sum_smul_single_eq (T (Matrix.single k l 1))]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
@@ -278,19 +278,14 @@ theorem transferMatrix_tp_iff
     calc Matrix.trace (T X)
         = Matrix.trace (T (∑ k, ∑ l, X k l • Matrix.single k l 1)) := by
             conv_lhs =>
-              rw [show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
-                simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-                  (Matrix.matrix_eq_sum_single X)]
+              rw [sum_smul_single_eq X]
       _ = ∑ k, ∑ l, X k l • Matrix.trace (T (Matrix.single k l 1)) := by
             simp_rw [map_sum, LinearMap.map_smul, Matrix.trace_sum, Matrix.trace_smul]
       _ = ∑ k, ∑ l, X k l • Matrix.trace (Matrix.single k l (1 : ℂ)) := by
             simp_rw [key]
       _ = Matrix.trace X := by
             simp_rw [← Matrix.trace_smul, ← Matrix.trace_sum]
-            rw [← (show X =
-                ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
-              simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-                (Matrix.matrix_eq_sum_single X))]
+            rw [← sum_smul_single_eq X]
 
 /-- **Proposition 2.6 (Unital via transfer matrix)**: `T` is unital (`T 1 = 1`) iff
 the row-diagonal sums of the transfer matrix give `δ_{ij}`:
@@ -337,18 +332,13 @@ theorem transferMatrix_hermiticityPreserving_iff
       -- this : (T (single k l 1)) j i = starRingEnd ℂ ((T (single l k 1)) i j)
       rw [this, starRingEnd_apply, star_star]
     conv_lhs =>
-      rw [show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
-        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-          (Matrix.matrix_eq_sum_single X)]
+      rw [sum_smul_single_eq X]
     simp_rw [map_sum, LinearMap.map_smul, Matrix.conjTranspose_sum,
       Matrix.conjTranspose_smul, basis_eq]
     have hXconj : Xᴴ = ∑ k : Fin D, ∑ l : Fin D,
         star (X l k) • Matrix.single k l 1 := by
       conv_lhs =>
-        rw [show Xᴴ =
-            ∑ k : Fin D, ∑ l : Fin D, (Xᴴ) k l • Matrix.single k l 1 by
-          simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-            (Matrix.matrix_eq_sum_single Xᴴ)]
+        rw [sum_smul_single_eq Xᴴ]
       simp_rw [Matrix.conjTranspose_apply]
     rw [hXconj]; simp_rw [map_sum, LinearMap.map_smul]
     rw [Finset.sum_comm]

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -119,11 +119,6 @@ theorem transferMatrix_apply
     (i j k l : Fin D) :
     transferMatrix T (j, i) (l, k) = (T (Matrix.single k l 1)) i j := rfl
 
-private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
-    ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 := by
-  simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-    (Matrix.matrix_eq_sum_single ρ)
-
 /-! ### Fundamental property: T̂ represents T in the vectorized picture -/
 
 /-- **Key property**: the transfer matrix faithfully represents `T`:
@@ -139,7 +134,10 @@ theorem transferMatrix_mulVec_eq
   simp only [Matrix.mulVec, dotProduct, transferMatrix_apply,
     Matrix.vec, Fintype.sum_prod_type]
   have key : T ρ = ∑ k, ∑ l, ρ k l • T (Matrix.single k l 1) := by
-    conv_lhs => rw [sum_smul_single_eq ρ]
+    conv_lhs =>
+      rw [show ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 by
+        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+          (Matrix.matrix_eq_sum_single ρ)]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
@@ -157,7 +155,11 @@ theorem transferMatrix_comp
     Fintype.sum_prod_type]
   have key : S (T (Matrix.single k l 1)) =
       ∑ a, ∑ b, (T (Matrix.single k l 1)) a b • S (Matrix.single a b 1) := by
-    conv_lhs => rw [sum_smul_single_eq (T (Matrix.single k l 1))]
+    conv_lhs =>
+      rw [show T (Matrix.single k l 1) =
+          ∑ a : Fin D, ∑ b : Fin D, (T (Matrix.single k l 1)) a b • Matrix.single a b 1 by
+        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+          (Matrix.matrix_eq_sum_single (T (Matrix.single k l 1)))]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
@@ -275,14 +277,20 @@ theorem transferMatrix_tp_iff
         · rw [if_neg hkl, Matrix.trace_single_eq_of_ne k l (1 : ℂ) hkl]
     calc Matrix.trace (T X)
         = Matrix.trace (T (∑ k, ∑ l, X k l • Matrix.single k l 1)) := by
-            conv_lhs => rw [sum_smul_single_eq X]
+            conv_lhs =>
+              rw [show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
+                simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+                  (Matrix.matrix_eq_sum_single X)]
       _ = ∑ k, ∑ l, X k l • Matrix.trace (T (Matrix.single k l 1)) := by
             simp_rw [map_sum, LinearMap.map_smul, Matrix.trace_sum, Matrix.trace_smul]
       _ = ∑ k, ∑ l, X k l • Matrix.trace (Matrix.single k l (1 : ℂ)) := by
             simp_rw [key]
       _ = Matrix.trace X := by
             simp_rw [← Matrix.trace_smul, ← Matrix.trace_sum]
-            rw [← sum_smul_single_eq X]
+            rw [← (show X =
+                ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
+              simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+                (Matrix.matrix_eq_sum_single X))]
 
 /-- **Proposition 2.6 (Unital via transfer matrix)**: `T` is unital (`T 1 = 1`) iff
 the row-diagonal sums of the transfer matrix give `δ_{ij}`:
@@ -293,12 +301,7 @@ theorem transferMatrix_unital_iff
       ∀ i j : Fin D, ∑ k : Fin D, transferMatrix T (j, i) (k, k) =
         if i = j then 1 else 0 := by
   have one_eq : (1 : Matrix (Fin D) (Fin D) ℂ) = ∑ k, Matrix.single k k 1 := by
-    ext i j
-    simp only [Matrix.one_apply, Matrix.sum_apply, Matrix.single_apply]
-    by_cases hij : i = j
-    · subst hij; simp [Finset.sum_ite_eq']
-    · rw [if_neg hij]; symm; exact Finset.sum_eq_zero fun k _ => by
-        rw [if_neg]; exact fun ⟨h1, h2⟩ => hij (h1.symm.trans h2)
+    simpa using (Matrix.sum_single_one (m := Fin D) (α := ℂ)).symm
   constructor
   · intro hunit i j
     simp only [transferMatrix_apply]
@@ -333,12 +336,19 @@ theorem transferMatrix_hermiticityPreserving_iff
       have := h j i l k; simp only [transferMatrix_apply] at this
       -- this : (T (single k l 1)) j i = starRingEnd ℂ ((T (single l k 1)) i j)
       rw [this, starRingEnd_apply, star_star]
-    conv_lhs => rw [sum_smul_single_eq X]
+    conv_lhs =>
+      rw [show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
+        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+          (Matrix.matrix_eq_sum_single X)]
     simp_rw [map_sum, LinearMap.map_smul, Matrix.conjTranspose_sum,
       Matrix.conjTranspose_smul, basis_eq]
     have hXconj : Xᴴ = ∑ k : Fin D, ∑ l : Fin D,
         star (X l k) • Matrix.single k l 1 := by
-      conv_lhs => rw [sum_smul_single_eq Xᴴ]
+      conv_lhs =>
+        rw [show Xᴴ =
+            ∑ k : Fin D, ∑ l : Fin D, (Xᴴ) k l • Matrix.single k l 1 by
+          simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+            (Matrix.matrix_eq_sum_single Xᴴ)]
       simp_rw [Matrix.conjTranspose_apply]
     rw [hXconj]; simp_rw [map_sum, LinearMap.map_smul]
     rw [Finset.sum_comm]

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1912,12 +1912,13 @@ times the corresponding matrix units.  Mathlib 4.31 already provides this
 statement as `Matrix.matrix_eq_sum_single`; the only local difference was the
 choice to write the summands as `ρ k l • Matrix.single k l 1`.
 
-The private helper has now been removed.  The transfer-matrix proof sites use
-`Matrix.matrix_eq_sum_single` directly, simplifying by `Matrix.smul_single`,
-`smul_eq_mul`, and `mul_one` only where the local scalar-multiple notation is
-needed.  In the same file, the hand proof of the diagonal expansion of the
-identity matrix was replaced by `Matrix.sum_single_one`.  The transfer-matrix
-statements are unchanged.
+The private helper has now been retained as the local notation adapter.  Its
+proof cites `Matrix.matrix_eq_sum_single` directly, simplifying by
+`Matrix.smul_single`, `smul_eq_mul`, and `mul_one` to match the local
+scalar-multiple notation.  The transfer-matrix proof sites share this adapter.
+In the same file, the hand proof of the diagonal expansion of the identity
+matrix was replaced by `Matrix.sum_single_one`.  The transfer-matrix statements
+are unchanged.
 
 ## PSD kernel-zero wrapper cleanup, 2026-06-19
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1912,10 +1912,12 @@ times the corresponding matrix units.  Mathlib 4.31 already provides this
 statement as `Matrix.matrix_eq_sum_single`; the only local difference was the
 choice to write the summands as `ρ k l • Matrix.single k l 1`.
 
-The private helper remains as the shared expansion used by the transfer-matrix
-proof sites, but its proof now cites `Matrix.matrix_eq_sum_single` directly and
-simplifies by `Matrix.smul_single`, `smul_eq_mul`, and `mul_one` to recover the
-local notation.  The transfer-matrix statements are unchanged.
+The private helper has now been removed.  The transfer-matrix proof sites use
+`Matrix.matrix_eq_sum_single` directly, simplifying by `Matrix.smul_single`,
+`smul_eq_mul`, and `mul_one` only where the local scalar-multiple notation is
+needed.  In the same file, the hand proof of the diagonal expansion of the
+identity matrix was replaced by `Matrix.sum_single_one`.  The transfer-matrix
+statements are unchanged.
 
 ## PSD kernel-zero wrapper cleanup, 2026-06-19
 


### PR DESCRIPTION
### Motivation
- The transfer-matrix file used a local coordinate-expansion adapter over Mathlib 4.31's `Matrix.matrix_eq_sum_single`.
- Review correctly pointed out that inlining this adapter at each call site only duplicated the same proof.
- The separate hand proof that the identity matrix is the sum of its diagonal matrix units is still replaceable directly by Mathlib's `Matrix.sum_single_one`.

### Description
- **`TNLean/Channel/TransferMatrix.lean`**: retains the private lemma `sum_smul_single_eq` as the single local adapter from `Matrix.matrix_eq_sum_single` to the file's scalar-multiple notation `ρ i j • Matrix.single i j 1`; rewrites the affected proofs to use that helper; replaces the manual identity-as-sum-of-diagonal-units proof in `transferMatrix_unital_iff` with `Matrix.sum_single_one`. No theorem statements change.
- **`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`**: records that the coordinate-expansion adapter is intentionally retained, while the identity expansion now uses the native Mathlib lemma.

### Testing
- `lake build TNLean.Channel.TransferMatrix -q`
- `git diff --check origin/main...HEAD`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

### Review response
- Addresses the requested-change thread by collapsing the six inlined coordinate-expansion proofs back to the shared private adapter.