### PR TITLE
doc(periodic): name Omega contraction step

### DIFF
--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1245,6 +1245,17 @@ unconditional result.
         =
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
+    Let $\widetilde F_{u+q}^{\mathbf i}$ denote the same cyclic repeated product
+    formed from the matrices $\widetilde B_{u+q},\ldots,\widetilde B_{u+q+m-1}$.
+    The block identity gives
+    \[
+        F_u^{\mathbf i}
+        =
+        e^{iN_0\lambda_{u+q}}\widetilde F_{u+q}^{\mathbf i}.
+    \]
+    % Local fix (docs/paper-gaps/1708_periodic_overlap_route_alignment.tex):
+    % arXiv:1708.00029, lines 1041--1060, displays $m-1$ inverses although the
+    % repetition count and phase formula require one inverse for each inserted product.
     Apply one right inverse to each inserted repeated product. The contraction is
     \[
         A_u^{i_1}F_{u+1}^{\mathbf i_1}
@@ -1255,13 +1266,35 @@ unconditional result.
             \otimes\Omega_u\ }
         A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}.
     \]
-    Applying the same contraction to the $\widetilde B$ side gives
+    The block identity applied to the word with inserted repeated products gives
     \[
-        A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}
+        A_u^{i_1}F_{u+1}^{\mathbf i_1}
+        A_{u+1}^{i_2}F_{u+2}^{\mathbf i_2}
+        \cdots
+        A_{u+m-1}^{i_m}F_u^{\mathbf i_m}
         =
+        e^{i\lambda_{u+q}(mN_0+1)}
+        \widetilde B_{u+q}^{i_1}\widetilde F_{u+q+1}^{\mathbf i_1}
+        \widetilde B_{u+q+1}^{i_2}\widetilde F_{u+q+2}^{\mathbf i_2}
+        \cdots
+        \widetilde B_{u+q+m-1}^{i_m}\widetilde F_{u+q}^{\mathbf i_m}.
+    \]
+    Since each $\Omega_{u+r}$ contraction of $\widetilde F_{u+q+r}$ contributes
+    $e^{-iN_0\lambda_{u+q+r}}$, applying
+    $\Omega_{u+1}\otimes\cdots\otimes\Omega_{u+m-1}\otimes\Omega_u$ to both
+    sides gives
+    \[
+        \begin{aligned}
+        A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}
+        &=
+        e^{i\lambda_{u+q}(mN_0+1)-iN_0\sum_{r\in\mathbb Z_m}\lambda_r}
+        \widetilde B_{u+q}^{i_1}\otimes\widetilde B_{u+q+1}^{i_2}
+        \otimes\cdots\otimes\widetilde B_{u+q+m-1}^{i_m} \\
+        &=
         e^{i\eta_{u+q}}
         \widetilde B_{u+q}^{i_1}\otimes\widetilde B_{u+q+1}^{i_2}
         \otimes\cdots\otimes\widetilde B_{u+q+m-1}^{i_m}.
+        \end{aligned}
     \]
     Here
     \[

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1273,8 +1273,13 @@ unconditional result.
             \otimes\Omega_u\ }
         A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}.
     \]
-    The interleaved word is an $(mN_0+1)$-fold product of $m$-site blocks
-    beginning at the sector $u$:
+    Expand the words $\mathbf i_1,\ldots,\mathbf i_m$, and write $j_{s,t}$ for
+    the physical index in the $t$th sector of the $s$th consecutive $m$-site
+    block of the expanded word, where $0\leq s\leq mN_0$ and $1\leq t\leq m$.
+    Since each inserted product $F_{u+r}^{\mathbf i_r}$ has length $mN_0$,
+    insertion shifts the cyclic sector position by $mN_0\equiv 0\pmod m$.
+    Hence every consecutive $m$-site block begins at the sector $u$, and the
+    interleaved word is
     \[
         \begin{aligned}
         A_u^{i_1}F_{u+1}^{\mathbf i_1}
@@ -1288,8 +1293,8 @@ unconditional result.
         (A_u^{j_{mN_0,1}}\cdots A_{u+m-1}^{j_{mN_0,m}})
         \end{aligned}
     \]
-    for the corresponding physical indices $j_{s,t}$. Applying the block identity
-    at the sector $u$ to each of these $m$-site blocks gives
+    Applying the block identity at the sector $u$ to each of these $m$-site
+    blocks gives
     \[
         A_u^{i_1}F_{u+1}^{\mathbf i_1}
         A_{u+1}^{i_2}F_{u+2}^{\mathbf i_2}

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1186,7 +1186,7 @@ unconditional result.
     \]
 \end{proof}
 
-\begin{lemma}[Per-site proportionality from blocked sector match]%
+\begin{lemma}[Cyclic $\Omega_u$-contraction for blocked sector gauges]%
     \label{lem:sector_tensor_proportional_blocked_match}
     \lean{MPSTensor.sectorTensor_proportional_of_blockedMatch}
     % The source conclusion below is unitary. The tagged Lean declaration currently
@@ -1226,6 +1226,47 @@ unconditional result.
         e^{i\lambda_{u+q}}
         \widetilde B_{u+q}^{i_1}\widetilde B_{u+q+1}^{i_2}
         \cdots\widetilde B_{u+q+m-1}^{i_m}.
+    \]
+    % arXiv:1708.00029 Appendix A: eq:Fu, eq:Omegauprop, eq:resultprop.
+    Choose $N_0$ so that the $N_0$-fold repetition of each cyclic
+    $m$-site sector product is injective. For
+    $\mathbf i=(i_1,\ldots,i_{mN_0})$, form the repeated product
+    \[
+        F_u^{\mathbf i}
+        =
+        \bigl(A_u^{i_1}\cdots A_{u+m-1}^{i_m}\bigr)
+        \cdots
+        \bigl(A_u^{i_{m(N_0-1)+1}}\cdots A_{u+m-1}^{i_{mN_0}}\bigr),
+    \]
+    and choose right inverses $\Omega_u$ satisfying
+    \[
+        \sum_{\mathbf i}(\Omega_u^{\mathbf i})_{\alpha,\beta}
+        (F_u^{\mathbf i})_{\alpha',\beta'}
+        =
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+    \]
+    Apply one right inverse to each inserted repeated product. The contraction is
+    \[
+        A_u^{i_1}F_{u+1}^{\mathbf i_1}
+        A_{u+1}^{i_2}F_{u+2}^{\mathbf i_2}
+        \cdots
+        A_{u+m-1}^{i_m}F_u^{\mathbf i_m}
+        \xrightarrow{\ \Omega_{u+1}\otimes\cdots\otimes\Omega_{u+m-1}
+            \otimes\Omega_u\ }
+        A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}.
+    \]
+    Applying the same contraction to the $\widetilde B$ side gives
+    \[
+        A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}
+        =
+        e^{i\eta_{u+q}}
+        \widetilde B_{u+q}^{i_1}\otimes\widetilde B_{u+q+1}^{i_2}
+        \otimes\cdots\otimes\widetilde B_{u+q+m-1}^{i_m}.
+    \]
+    Here
+    \[
+        \eta_{u+q}=\lambda_{u+q}(mN_0+1)
+            -N_0\sum_{r\in\mathbb Z_m}\lambda_r.
     \]
     Then there are a phase $\xi$ and a unitary matrix $U$ such that
     $A^i=e^{i\xi}UB^iU^{\dagger}$ for every physical index $i$.

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1319,6 +1319,12 @@ unconditional result.
         e^{-iN_0\lambda_{u+q+r}}
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
+    Since $r\mapsto u+q+r$ is a permutation of $\mathbb Z_m$,
+    \[
+        \sum_{r\in\mathbb Z_m}\lambda_{u+q+r}
+        =
+        \sum_{r\in\mathbb Z_m}\lambda_r.
+    \]
     Applying
     $\Omega_{u+1}\otimes\cdots\otimes\Omega_{u+m-1}\otimes\Omega_u$ to both
     sides of the intermediate block-identity equation above and collecting the

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1245,13 +1245,18 @@ unconditional result.
         =
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
-    Let $\widetilde F_{u+q}^{\mathbf i}$ denote the same cyclic repeated product
-    formed from the matrices $\widetilde B_{u+q},\ldots,\widetilde B_{u+q+m-1}$.
-    The block identity gives
+    Let $\widetilde F_{u+q+r}^{\mathbf i}$ denote the same cyclic repeated
+    product formed from
+    $\widetilde B_{u+q+r},\ldots,\widetilde B_{u+q+r+m-1}$. For every
+    $r\in\mathbb Z_m$, the block identity gives
     \[
-        F_u^{\mathbf i}
+        F_{u+r}^{\mathbf i}
         =
-        e^{iN_0\lambda_{u+q}}\widetilde F_{u+q}^{\mathbf i}.
+        e^{iN_0\lambda_{u+q+r}}\widetilde F_{u+q+r}^{\mathbf i},
+        \qquad
+        \widetilde F_{u+q+r}^{\mathbf i}
+        =
+        e^{-iN_0\lambda_{u+q+r}}F_{u+r}^{\mathbf i}.
     \]
     % Local fix (docs/paper-gaps/1708_periodic_overlap_route_alignment.tex):
     % arXiv:1708.00029, lines 1041--1060, displays $m-1$ inverses although the
@@ -1266,7 +1271,23 @@ unconditional result.
             \otimes\Omega_u\ }
         A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}.
     \]
-    The block identity applied to the word with inserted repeated products gives
+    The interleaved word is an $(mN_0+1)$-fold product of $m$-site blocks
+    beginning at the sector $u$:
+    \[
+        \begin{aligned}
+        A_u^{i_1}F_{u+1}^{\mathbf i_1}
+        A_{u+1}^{i_2}F_{u+2}^{\mathbf i_2}
+        \cdots
+        A_{u+m-1}^{i_m}F_u^{\mathbf i_m}
+        &=
+        (A_u^{j_{0,1}}\cdots A_{u+m-1}^{j_{0,m}})
+        \cdots \\
+        &\quad\cdot
+        (A_u^{j_{mN_0,1}}\cdots A_{u+m-1}^{j_{mN_0,m}})
+        \end{aligned}
+    \]
+    for the corresponding physical indices $j_{s,t}$. Applying the block identity
+    at the sector $u$ to each of these $m$-site blocks gives
     \[
         A_u^{i_1}F_{u+1}^{\mathbf i_1}
         A_{u+1}^{i_2}F_{u+2}^{\mathbf i_2}
@@ -1279,10 +1300,10 @@ unconditional result.
         \cdots
         \widetilde B_{u+q+m-1}^{i_m}\widetilde F_{u+q}^{\mathbf i_m}.
     \]
-    Since each $\Omega_{u+r}$ contraction of $\widetilde F_{u+q+r}$ contributes
-    $e^{-iN_0\lambda_{u+q+r}}$, applying
-    $\Omega_{u+1}\otimes\cdots\otimes\Omega_{u+m-1}\otimes\Omega_u$ to both
-    sides gives
+    The displayed identity for $\widetilde F_{u+q+r}^{\mathbf i}$ supplies the
+    phase factor $e^{-iN_0\lambda_{u+q+r}}$ when $\Omega_{u+r}$ collapses
+    $F_{u+r}^{\mathbf i}$. Tensoring these identities over $r$ and applying
+    $\Omega_{u+1}\otimes\cdots\otimes\Omega_{u+m-1}\otimes\Omega_u$ gives
     \[
         \begin{aligned}
         A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1261,7 +1261,9 @@ unconditional result.
     % Local fix (docs/paper-gaps/1708_periodic_overlap_route_alignment.tex):
     % arXiv:1708.00029, lines 1041--1060, displays $m-1$ inverses although the
     % repetition count and phase formula require one inverse for each inserted product.
-    Apply one right inverse to each inserted repeated product. The contraction is
+    Let $\mathbf i_1,\ldots,\mathbf i_m$ be independent words of length $mN_0$,
+    one for each inserted repeated product. Sum each $\mathbf i_r$ in the
+    contraction by the right-inverse relation for $\Omega_{u+r}$:
     \[
         A_u^{i_1}F_{u+1}^{\mathbf i_1}
         A_{u+1}^{i_2}F_{u+2}^{\mathbf i_2}
@@ -1300,9 +1302,10 @@ unconditional result.
         \cdots
         \widetilde B_{u+q+m-1}^{i_m}\widetilde F_{u+q}^{\mathbf i_m}.
     \]
-    The displayed identity for $\widetilde F_{u+q+r}^{\mathbf i}$ supplies the
-    phase factor $e^{-iN_0\lambda_{u+q+r}}$ when $\Omega_{u+r}$ collapses
-    $F_{u+r}^{\mathbf i}$. Tensoring these identities over $r$ and applying
+    Using the displayed identity with $\mathbf i=\mathbf i_r$, the factor
+    $\widetilde F_{u+q+r}^{\mathbf i_r}$ supplies the phase factor
+    $e^{-iN_0\lambda_{u+q+r}}$ when $\Omega_{u+r}$ collapses
+    $F_{u+r}^{\mathbf i_r}$. Tensoring these identities over $r$ and applying
     $\Omega_{u+1}\otimes\cdots\otimes\Omega_{u+m-1}\otimes\Omega_u$ gives
     \[
         \begin{aligned}

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1302,11 +1302,27 @@ unconditional result.
         \cdots
         \widetilde B_{u+q+m-1}^{i_m}\widetilde F_{u+q}^{\mathbf i_m}.
     \]
-    Using the displayed identity with $\mathbf i=\mathbf i_r$, the factor
-    $\widetilde F_{u+q+r}^{\mathbf i_r}$ supplies the phase factor
-    $e^{-iN_0\lambda_{u+q+r}}$ when $\Omega_{u+r}$ collapses
-    $F_{u+r}^{\mathbf i_r}$. Tensoring these identities over $r$ and applying
-    $\Omega_{u+1}\otimes\cdots\otimes\Omega_{u+m-1}\otimes\Omega_u$ gives
+    For each $r\in\mathbb Z_m$, substituting $\mathbf i=\mathbf i_r$ in the
+    displayed identity gives
+    \[
+        \widetilde F_{u+q+r}^{\mathbf i_r}
+        =
+        e^{-iN_0\lambda_{u+q+r}}F_{u+r}^{\mathbf i_r}.
+    \]
+    Therefore the right-inverse relation gives the per-sector contraction
+    identity
+    \[
+        \sum_{\mathbf i_r}
+        (\Omega_{u+r}^{\mathbf i_r})_{\alpha,\beta}
+        (\widetilde F_{u+q+r}^{\mathbf i_r})_{\alpha',\beta'}
+        =
+        e^{-iN_0\lambda_{u+q+r}}
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+    \]
+    Applying
+    $\Omega_{u+1}\otimes\cdots\otimes\Omega_{u+m-1}\otimes\Omega_u$ to both
+    sides of the intermediate block-identity equation above and collecting the
+    sector phases gives
     \[
         \begin{aligned}
         A_u^{i_1}\otimes A_{u+1}^{i_2}\otimes\cdots\otimes A_{u+m-1}^{i_m}

--- a/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
+++ b/docs/paper-gaps/1708_periodic_overlap_route_alignment.tex
@@ -204,7 +204,10 @@ Case-3 leaf is the contraction and gauge construction:
   \item The $m$-factor cyclic $\Omega_u$-contraction with the $\eta$ bookkeeping:
     starting from the common right inverses for the injective tensors $F_u$,
     contract the cyclic product in lines~1041--1068 to obtain the uniform
-    product-tensor identity \emph{eq:resultprop}.
+    product-tensor identity \emph{eq:resultprop}. The displayed inverse list
+    in lines~1049--1052 has only $m-1$ factors, but the displayed
+    concatenation, the $(mN_0+1)$ repetition count, and the definition of
+    $\eta_v$ require one inverse for each of the $m$ inserted $F$-factors.
   \item The final normalization and gauge construction: use the proved scalar
     extraction theorem to obtain $\kappa_v$ with $\prod_v\kappa_v=1$, prove
     $|\kappa_v|=1$ from the left-canonical normalization, apply the finite-cycle


### PR DESCRIPTION
### Motivation

The not-ready periodic Case-3 blueprint entry was still titled by the later per-site proportionality conclusion. Appendix A of arXiv:1708.00029 first uses the repeated products $F_u$, the right inverses $\Omega_u$, and the cyclic contraction that produces the tensor-product identity before the final phase construction.

### Description

Modified `blueprint/src/chapter/ch22_periodic_ft.tex`:

- Retitled the Case-3 entry around the cyclic $\Omega_u$-contraction, matching the order of steps in arXiv:1708.00029 Appendix A (lines 1023--1117).
- Added displayed formulas for: the repeated product $F_u^{\mathbf{i}}$; the right-inverse relation for $\Omega_u$; and the tensor-product proportionality obtained before extracting the final phases.
- The `\notready` status and Lean tags are unchanged.

### Testing

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses #873
Addresses #619

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and blueprint prose only; no Lean or runtime code changes.
> 
> **Overview**
> Aligns the **not-ready** Case-3 blueprint lemma with arXiv:1708.00029 Appendix A by naming and documenting the **cyclic \(\Omega_u\)-contraction** (repeated products \(F_u\), right inverses \(\Omega_u\), and \(\eta_{u+q}\) bookkeeping) **before** the final unitary gauge conclusion. The lemma title changes from per-site proportionality to this intermediate contraction step; `\notready` and Lean tags are unchanged.
> 
> Adds the full displayed derivation in `ch22_periodic_ft.tex`: block identities for \(F\) vs \(\widetilde F\), contraction with \(\Omega_{u+1}\otimes\cdots\otimes\Omega_u\), and the tensor-product identity with phase \(\eta_{u+q}\).
> 
> Updates `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex` to note a **source typo**: lines 1049–1052 list only \(m-1\) \(\Omega\) factors while the concatenation, \((mN_0+1)\) count, and \(\eta_v\) need **one inverse per inserted \(F\)-factor**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2021c0bd1b87c43afd8d017801399e8855fbef73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->