### PR TITLE
refactor(Algebra): use Mathlib trace-zero matrix criterion

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -97,9 +97,7 @@ theorem eq_zero_of_sum_mul_conjTranspose_eq_zero
   have htrace_zero : (B i * (B i)ᴴ).trace = 0 :=
     Complex.ext htrace_re
       (Complex.le_def.mp (Matrix.posSemidef_self_mul_conjTranspose (B i)).trace_nonneg).2.symm
-  have hmul_zero : B i * (B i)ᴴ = 0 :=
-    (Matrix.posSemidef_self_mul_conjTranspose (B i)).trace_eq_zero_iff.mp htrace_zero
-  exact Matrix.self_mul_conjTranspose_eq_zero.mp hmul_zero
+  exact Matrix.trace_mul_conjTranspose_self_eq_zero_iff.mp htrace_zero
 
 /-- If `∑ᵢ Bᵢ† * Bᵢ = 0`, then every `Bᵢ` is zero. -/
 theorem eq_zero_of_sum_conjTranspose_mul_self_eq_zero

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -880,7 +880,9 @@ Completed replacements:
 Keep for now:
 
 - Positive-semidefinite kernel lemmas for sums, unless a direct Mathlib theorem
-  is found.
+  is found.  The finite-family zero-sum helper still remains local, but its
+  final pointwise zero conclusion now uses Mathlib's
+  `Matrix.trace_mul_conjTranspose_self_eq_zero_iff` directly.
 - Trace-pairing wrappers only when they are part of TNLean's public
   mathematical vocabulary.  Private equality-form wrappers should use
   `Matrix.ext_iff_trace_mul_left` and `Matrix.ext_iff_trace_mul_right`

--- a/docs/audits/lean_spaghetti_channel_spectral_wielandt.md
+++ b/docs/audits/lean_spaghetti_channel_spectral_wielandt.md
@@ -36,7 +36,10 @@ Date: 2026-04-08
 
 ## Redundancy / Mathlib Overlap
 
-- The clearest "already in Mathlib" wrappers are in `TNLean/Channel/Schwarz/OperatorMonotone.lean`: `matrix_rpow_le_rpow` is just a specialization of `CFC.rpow_le_rpow`, and `matrix_log_le_log` is a specialization of `CFC.log_le_log`. They are harmless wrappers, but they are not adding new mathematics.
+- The former "already in Mathlib" wrappers in `TNLean/Channel/Schwarz/OperatorMonotone.lean`
+  (`matrix_rpow_le_rpow`, `matrix_log_le_log`) have been removed; the remaining file records
+  Jensen-dependent corollaries rather than exact aliases for `CFC.rpow_le_rpow` or
+  `CFC.log_le_log`.
 - I did not find obvious large re-proofs of existing Mathlib theorems beyond those thin wrappers. Most local linearity lemmas are for project-specific maps, so they are duplication inside TNLean more than duplication of Mathlib.
 
 ## Closable `sorry`s
@@ -106,7 +109,7 @@ Date: 2026-04-08
 | `TNLean/Channel/Schwarz/MultiplicativeDomainFull.lean` | 382 | 0 | 0 | - | 0 | 25 | Repeats basic Kraus-map linearity lemmas already present elsewhere. |
 | `TNLean/Channel/Schwarz/MultiplicativeDomainPowers.lean` | 147 | 0 | 0 | - | 0 | 6 |  |
 | `TNLean/Channel/Schwarz/OperatorConvexity.lean` | 137 | 3 | 0 | - | 9 | 0 | actual sorry TODOs 3 actual `sorry`s; blocked on Mathlib TODOs plus a missing general Jensen theorem for positive maps. |
-| `TNLean/Channel/Schwarz/OperatorMonotone.lean` | 151 | 0 | 0 | - | 0 | 0 | imports actual-sorry module Imports an actual-sorry module. Split the proven wrappers (`matrix_rpow_le_rpow`, `matrix_log_le_log`) into a clean file and quarantine the Jensen-dependent corollaries. |
+| `TNLean/Channel/Schwarz/OperatorMonotone.lean` | 151 | 0 | 0 | - | 0 | 0 | imports actual-sorry module The former exact CFC monotonicity aliases are gone; the remaining issue is quarantine of Jensen-dependent corollaries imported from `OperatorConvexity`. |
 | `TNLean/Channel/Schwarz/PositiveMapProperties.lean` | 195 | 0 | 0 | - | 0 | 11 |  |
 | `TNLean/Channel/Schwarz/PositiveOnAbelian.lean` | 1039 | 0 | 6 | `blockForm_nonneg_of_scalarPSD_of_commuting` 458-731 (274l) | 0 | 59 | split candidate 1k+ lines and one 274-line private lemma. Split diagonal-family machinery from normal-diagonalization/application lemmas. |
 | `TNLean/Channel/Schwarz/SchwarzNormal.lean` | 82 | 0 | 0 | - | 0 | 0 |  |


### PR DESCRIPTION
### Motivation

- Continue the Mathlib 4.31 replacement pass by shortening the retained matrix sum-of-squares auxiliary lemma using a Mathlib trace-zero criterion, and keep the scouting notes accurate for subsequent batches.

### Description

- `TNLean/Algebra/MatrixAux.lean`: In `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`, the proof now applies `Matrix.trace_mul_conjTranspose_self_eq_zero_iff` from Mathlib directly, replacing the previous chain of local positive-semidefinite lemmas (`trace_eq_zero_iff` and `self_mul_conjTranspose_eq_zero`).
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: Records that the finite-family lemma remains local, but its pointwise zero conclusion now uses the Mathlib trace-zero criterion.
- `docs/audits/lean_spaghetti_channel_spectral_wielandt.md`: Corrects the Schwarz audit to note that the former `matrix_rpow_le_rpow` and `matrix_log_le_log` aliases are no longer present in `OperatorMonotone.lean`; the remaining concern is the Jensen-dependent import.

### Testing

- `lake exe cache get`
- `lake build TNLean.Algebra.MatrixAux -q --log-level=info`
- `git diff --check`
- `git diff -U0 -- '*.lean' | rg '^\+.*\b(sorry|admit|axiom|native_decide|unsafeCast)\b' || true`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

The focused Lean build reports only the existing short-copyright style warning in `MatrixAux.lean`.

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in a single matrix lemma plus audit markdown; no API or behavior change beyond delegating to an existing Mathlib equivalence.
> 
> **Overview**
> Continues the Mathlib 4.31 replacement pass by shortening the **sum-of-squares vanishing** auxiliary lemma in `MatrixAux.lean`.
> 
> In `eq_zero_of_sum_mul_conjTranspose_eq_zero`, the proof no longer chains local positive-semidefinite lemmas (`trace_eq_zero_iff` and `self_mul_conjTranspose_eq_zero`). After showing `(B i * (B i)ᴴ).trace = 0`, it applies **`Matrix.trace_mul_conjTranspose_self_eq_zero_iff`** to conclude `B i = 0`. The conjugate-transpose variant and the rest of the file are unchanged.
> 
> **Docs:** the Mathlib 4.31 audit notes that the finite-family auxiliary lemma stays local but its pointwise zero step now uses that Mathlib criterion. The channel/spectral spaghetti audit is corrected to say the old `matrix_rpow_le_rpow` / `matrix_log_le_log` CFC aliases are already gone from `OperatorMonotone.lean`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af0868f9ae9fc362bec8a6e300cc0e44678bd1e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->