### PR TITLE
refactor(Spectral): use Mathlib Euclidean norm-square formula

### DIFF
--- a/TNLean/Spectral/FrobeniusNorm.lean
+++ b/TNLean/Spectral/FrobeniusNorm.lean
@@ -86,18 +86,8 @@ lemma matToES_finset_sum {ι : Type*} (s : Finset ι)
 
 lemma norm_matToES_sq (M : Matrix (Fin m) (Fin n) ℂ) :
     ‖matToES M‖ ^ 2 = frobSq M := by
-  rw [frobSq_eq_sum]
-  rw [sq, ← @inner_self_eq_norm_mul_norm ℂ]
-  change RCLike.re (@inner ℂ _ _ (matToES M) (matToES M)) = _
-  simp only [PiLp.inner_apply, RCLike.inner_apply', matToES_apply, starRingEnd_apply]
-  rw [show (∑ x : Fin m × Fin n, star (M x.1 x.2) * M x.1 x.2) =
-    ∑ i, ∑ j, star (M i j) * M i j from Fintype.sum_prod_type _]
-  simp only [Complex.re_sum, RCLike.re_to_complex]
-  congr 1; ext i; congr 1; ext j
-  rw [show star (M i j) * M i j = (↑(‖M i j‖ ^ 2) : ℂ) from by
-    simpa [Complex.normSq_eq_norm_sq] using
-      (Complex.normSq_eq_conj_mul_self (z := M i j)).symm]
-  exact Complex.ofReal_re _
+  rw [EuclideanSpace.norm_sq_eq, frobSq_eq_sum]
+  exact Fintype.sum_prod_type fun p : Fin m × Fin n => ‖M p.1 p.2‖ ^ 2
 
 /-- The Euclidean-space norm of a flattened matrix is the Frobenius norm. -/
 lemma norm_matToES_eq_frobenius_norm (M : Matrix (Fin m) (Fin n) ℂ) :

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -550,6 +550,7 @@ notation:
 - `Matrix.frobenius_norm_conjTranspose`
 - `Matrix.frobeniusNormedRing`
 - `Matrix.frobeniusNormedAlgebra`
+- `EuclideanSpace.norm_sq_eq`
 
 TNLean has local Frobenius-norm infrastructure in:
 
@@ -913,6 +914,9 @@ Frobenius norm is now the foundation for matrix Hilbert-Schmidt arguments:
 `frobSq` is a squared Mathlib Frobenius norm, and the entrywise sum formula is
 kept as `frobSq_eq_sum` for trace and finite-sum arguments.  The local squared
 norm remains only as a convenience wrapper for downstream transfer estimates.
+The flattening identity `norm_matToES_sq` now uses Mathlib's
+`EuclideanSpace.norm_sq_eq`; the former proof by expanding the inner product
+over all matrix coordinates has been removed.
 The separate nonnegativity wrapper `MPSTensor.frobSq_nonneg` has been removed:
 the needed fact is exactly `sq_nonneg ‖X‖` after unfolding `frobSq`.
 


### PR DESCRIPTION
### Motivation

- `MPSTensor.norm_matToES_sq` in `TNLean/Spectral/FrobeniusNorm.lean` previously expanded the Euclidean inner product over matrix coordinates by hand, which was verbose and fragile against future Mathlib changes.
- Mathlib 4.31 provides `EuclideanSpace.norm_sq_eq`, which directly expresses the squared norm as a sum of squared absolute values, allowing a shorter, more maintainable derivation.
- The Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`) tracks which native Mathlib lemmas have been applied to clean up local proofs; this change is recorded there.

### Description

- `TNLean/Spectral/FrobeniusNorm.lean`: shortened the proof of `MPSTensor.norm_matToES_sq` by chaining `EuclideanSpace.norm_sq_eq` with `frobSq_eq_sum` and `Fintype.sum_prod_type`, replacing the former step-by-step coordinate unfolding of the PiLp inner product.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records `EuclideanSpace.norm_sq_eq` as relevant Frobenius infrastructure and notes the cleanup is applied for `norm_matToES_sq`.
- The lemma statement is unchanged; no new `sorry` introduced; downstream transfer-operator gap proofs are unaffected.

### Testing

- `lake build TNLean.Spectral.FrobeniusNorm -q --log-level=info`
- `lake build TNLean.Spectral.TransferOperatorGap -q --log-level=info`
- `lake build TNLean.Spectral.TransferOperatorGapRect -q --log-level=info`
- `git diff --check` — clean
- No new `sorry`/`admit`/`axiom`/`native_decide`/`unsafeCast` in Lean diff
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor of a single spectral lemma with no API or behavioral changes; downstream files were validated by build.
> 
> **Overview**
> **`MPSTensor.norm_matToES_sq`** in `FrobeniusNorm.lean` now chains **`EuclideanSpace.norm_sq_eq`** with the existing **`frobSq_eq_sum`** and **`Fintype.sum_prod_type`**, replacing the former proof that unfolded the PiLp inner product and rewrote complex entry norms coordinate by coordinate. The lemma's statement is unchanged, so transfer-operator gap proofs that rewrite **`frobSq`** through **`matToES`** are unaffected.
> 
> The Mathlib 4.31 replacement audit records **`EuclideanSpace.norm_sq_eq`** as relevant Frobenius infrastructure and notes that this flattening cleanup is applied for **`norm_matToES_sq`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677b8761f5f3fea45af3bd6045b2dfff96af0fd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>