### PR TITLE
refactor(Channel): inline Kraus Euclidean instances

### DIFF
--- a/TNLean/Channel/KrausFreedom.lean
+++ b/TNLean/Channel/KrausFreedom.lean
@@ -95,17 +95,6 @@ private abbrev KrausCoeffSpace (r : ℕ) := EuclideanSpace ℂ (Fin r)
 
 private abbrev KrausEntrySpace (D : ℕ) := EuclideanSpace ℂ (Fin D × Fin D)
 
-/-- The standard inner-product structure on finite-dimensional Euclidean space. -/
-private noncomputable abbrev euclideanIPS (ι : Type*) [Fintype ι] :
-    InnerProductSpace ℂ (EuclideanSpace ℂ ι) :=
-  PiLp.innerProductSpace (fun _ : ι => ℂ)
-
-/-- `EuclideanSpace` is finite-dimensional via its standard basis. -/
-private noncomputable abbrev euclideanFiniteDimensional (ι : Type*) [Fintype ι] :
-    FiniteDimensional ℂ (EuclideanSpace ℂ ι) :=
-  Module.Basis.finiteDimensional_of_finite
-    ((Pi.basisFun ℂ ι).map (EuclideanSpace.equiv ι ℂ).symm.toLinearEquiv)
-
 set_option maxHeartbeats 1600000 in
 -- The partial-isometry extension passes through several nested finite-dimensional choices.
 /-- **Rectangular Kraus freedom** (Wolf Theorem 2.1 item 4, necessary direction):
@@ -177,10 +166,14 @@ theorem kraus_rectangular_freedom
     rw [collapse, collapse] at h_entry
     exact h_entry
   -- ===== Phase 3: Construct the isometry =====
-  letI : InnerProductSpace ℂ (KrausCoeffSpace r₁) := euclideanIPS (Fin r₁)
-  letI : InnerProductSpace ℂ (KrausEntrySpace D) := euclideanIPS (Fin D × Fin D)
-  letI : FiniteDimensional ℂ (KrausCoeffSpace r₁) := euclideanFiniteDimensional (Fin r₁)
-  letI : FiniteDimensional ℂ (KrausEntrySpace D) := euclideanFiniteDimensional (Fin D × Fin D)
+  letI : InnerProductSpace ℂ (KrausCoeffSpace r₁) :=
+    PiLp.innerProductSpace (fun _ : Fin r₁ => ℂ)
+  letI : InnerProductSpace ℂ (KrausEntrySpace D) :=
+    PiLp.innerProductSpace (fun _ : Fin D × Fin D => ℂ)
+  letI : FiniteDimensional ℂ (KrausCoeffSpace r₁) :=
+    (EuclideanSpace.basisFun (Fin r₁) ℂ).toBasis.finiteDimensional_of_finite
+  letI : FiniteDimensional ℂ (KrausEntrySpace D) :=
+    (EuclideanSpace.basisFun (Fin D × Fin D) ℂ).toBasis.finiteDimensional_of_finite
   let fB : KrausEntrySpace D →ₗ[ℂ] KrausCoeffSpace r₁ := Matrix.toEuclideanLin MB
   let fA' : KrausEntrySpace D →ₗ[ℂ] KrausCoeffSpace r₁ := Matrix.toEuclideanLin MA'
   -- Inner product preservation from Gram equality

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -1216,7 +1216,10 @@ In `TNLean.Channel.KrausFreedom`, the Euclidean-space inner-product instance is
 now given explicitly by `PiLp.innerProductSpace (fun _ : ι => ℂ)`.  This removes
 the former large local synthesis budget around the cached instance and makes the
 finite-dimensional Hilbert-space structure used in the rectangular isometry
-argument explicit.  The remaining local `maxHeartbeats` bound around the
+argument explicit.  A later pass removed the private pass-through abbreviations
+for the Euclidean-space inner-product and finite-dimensional structures; the
+proof now names `PiLp.innerProductSpace` and `EuclideanSpace.basisFun` directly
+at the instance site.  The remaining local `maxHeartbeats` bound around the
 partial-isometry extension theorem was retested under Lean 4.31 and is still
 needed for elaboration.
 


### PR DESCRIPTION
### Motivation

- `TNLean/Channel/KrausFreedom.lean` contained two private local abbreviations (`euclideanIPS`, `euclideanFiniteDimensional`) that re-stated Mathlib instances already provided by `PiLp.innerProductSpace` and `EuclideanSpace.basisFun`. Removing them reduces indirection in the proof of `kraus_rectangular_freedom` (Wolf Theorem 2.1, item 4).
- Continues the Mathlib 4.31 instance-inventory cleanup recorded in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`.

### Description

- `TNLean/Channel/KrausFreedom.lean`: removed private abbreviations `euclideanIPS` and `euclideanFiniteDimensional`; replaced their four `letI` usage sites in `kraus_rectangular_freedom` (Phase 3) with direct references to `PiLp.innerProductSpace` and `EuclideanSpace.basisFun`. No mathematical content changed.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: extended the existing `TNLean.Channel.KrausFreedom` entry to record that the private abbreviations have been removed.
- No new `sorry`, `axiom`, or proof-integrity blockers introduced.

### Testing

- `lake build TNLean.Channel.KrausFreedom -q --log-level=info` passes.
- `git diff --check` passes.
- No new `sorry`/`admit`/`axiom`/`native_decide`/`unsafeCast` in Lean diff.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` passes.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passes.

---

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit a5eb0d066f855303d7959e8f7715ccf20002353b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->