### PR TITLE
refactor(Channel/TransferMatrix): inline matrix-basis expansion

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -119,11 +119,6 @@ theorem transferMatrix_apply
     (i j k l : Fin D) :
     transferMatrix T (j, i) (l, k) = (T (Matrix.single k l 1)) i j := rfl
 
-private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
-    ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 := by
-  simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-    (Matrix.matrix_eq_sum_single ρ)
-
 /-! ### Fundamental property: T̂ represents T in the vectorized picture -/
 
 /-- **Key property**: the transfer matrix faithfully represents `T`:
@@ -140,7 +135,9 @@ theorem transferMatrix_mulVec_eq
     Matrix.vec, Fintype.sum_prod_type]
   have key : T ρ = ∑ k, ∑ l, ρ k l • T (Matrix.single k l 1) := by
     conv_lhs =>
-      rw [sum_smul_single_eq ρ]
+      rw [show ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 by
+        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+          (Matrix.matrix_eq_sum_single ρ)]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
@@ -159,7 +156,11 @@ theorem transferMatrix_comp
   have key : S (T (Matrix.single k l 1)) =
       ∑ a, ∑ b, (T (Matrix.single k l 1)) a b • S (Matrix.single a b 1) := by
     conv_lhs =>
-      rw [sum_smul_single_eq (T (Matrix.single k l 1))]
+      rw [show T (Matrix.single k l 1) =
+          ∑ a : Fin D, ∑ b : Fin D,
+            (T (Matrix.single k l 1)) a b • Matrix.single a b 1 by
+        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+          (Matrix.matrix_eq_sum_single (T (Matrix.single k l 1)))]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
@@ -278,14 +279,18 @@ theorem transferMatrix_tp_iff
     calc Matrix.trace (T X)
         = Matrix.trace (T (∑ k, ∑ l, X k l • Matrix.single k l 1)) := by
             conv_lhs =>
-              rw [sum_smul_single_eq X]
+              rw [show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
+                simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+                  (Matrix.matrix_eq_sum_single X)]
       _ = ∑ k, ∑ l, X k l • Matrix.trace (T (Matrix.single k l 1)) := by
             simp_rw [map_sum, LinearMap.map_smul, Matrix.trace_sum, Matrix.trace_smul]
       _ = ∑ k, ∑ l, X k l • Matrix.trace (Matrix.single k l (1 : ℂ)) := by
             simp_rw [key]
       _ = Matrix.trace X := by
             simp_rw [← Matrix.trace_smul, ← Matrix.trace_sum]
-            rw [← sum_smul_single_eq X]
+            rw [← show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
+              simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+                (Matrix.matrix_eq_sum_single X)]
 
 /-- **Proposition 2.6 (Unital via transfer matrix)**: `T` is unital (`T 1 = 1`) iff
 the row-diagonal sums of the transfer matrix give `δ_{ij}`:
@@ -332,13 +337,18 @@ theorem transferMatrix_hermiticityPreserving_iff
       -- this : (T (single k l 1)) j i = starRingEnd ℂ ((T (single l k 1)) i j)
       rw [this, starRingEnd_apply, star_star]
     conv_lhs =>
-      rw [sum_smul_single_eq X]
+      rw [show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
+        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+          (Matrix.matrix_eq_sum_single X)]
     simp_rw [map_sum, LinearMap.map_smul, Matrix.conjTranspose_sum,
       Matrix.conjTranspose_smul, basis_eq]
     have hXconj : Xᴴ = ∑ k : Fin D, ∑ l : Fin D,
         star (X l k) • Matrix.single k l 1 := by
       conv_lhs =>
-        rw [sum_smul_single_eq Xᴴ]
+        rw [show Xᴴ = ∑ k : Fin D, ∑ l : Fin D,
+            Xᴴ k l • Matrix.single k l 1 by
+          simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+            (Matrix.matrix_eq_sum_single Xᴴ)]
       simp_rw [Matrix.conjTranspose_apply]
     rw [hXconj]; simp_rw [map_sum, LinearMap.map_smul]
     rw [Finset.sum_comm]

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -101,10 +101,9 @@ The clearest replacements are:
   finite sum directly at the proof site using `Matrix.one_apply`,
   `Finset.sum_add_distrib`, and Mathlib's if-supported finite-sum
   simplification.  The private lemma `sum_one_smul_eq` was removed.
-- The transfer-matrix coordinate-expansion helper now cites Mathlib's
-  `Matrix.matrix_eq_sum_single` directly, with `Matrix.smul_single` used only
-  to match the local scalar-matrix-unit notation.  The private helper remains
-  as the shared statement used at the transfer-matrix proof sites.
+- The transfer-matrix coordinate-expansion helper was removed.  The proof
+  sites now cite Mathlib's `Matrix.matrix_eq_sum_single` directly, using
+  `Matrix.smul_single` only to match the local scalar-matrix-unit notation.
 - The dissipative-drift right-multiplication algebra hom now comes from
   Mathlib's `AlgHom.mulLeftRight`, composed with
   `Algebra.TensorProduct.includeRight`.  The former hand-written algebra-hom
@@ -1913,7 +1912,7 @@ Those proofs now call `tendsto_nhds_unique` directly, and the helper file was
 removed.  Future proofs that need this limit-uniqueness fact should use the
 Mathlib theorem rather than reintroducing the wrapper.
 
-## Transfer-matrix coordinate expansion cleanup, 2026-06-19
+## Transfer-matrix coordinate expansion cleanup, 2026-06-19; completed 2026-06-21
 
 `TNLean/Channel/TransferMatrix.lean` had a private lemma
 `sum_smul_single_eq` stating that a matrix is the finite sum of its entries
@@ -1921,13 +1920,13 @@ times the corresponding matrix units.  Mathlib 4.31 already provides this
 statement as `Matrix.matrix_eq_sum_single`; the only local difference was the
 choice to write the summands as `ρ k l • Matrix.single k l 1`.
 
-The private helper has now been retained as the local notation adapter.  Its
-proof cites `Matrix.matrix_eq_sum_single` directly, simplifying by
-`Matrix.smul_single`, `smul_eq_mul`, and `mul_one` to match the local
-scalar-multiple notation.  The transfer-matrix proof sites share this adapter.
-In the same file, the hand proof of the diagonal expansion of the identity
-matrix was replaced by `Matrix.sum_single_one`.  The transfer-matrix statements
-are unchanged.
+The private helper was first reduced to a local notation adapter and then
+removed.  The transfer-matrix proof sites now cite
+`Matrix.matrix_eq_sum_single` directly, simplifying by `Matrix.smul_single`,
+`smul_eq_mul`, and `mul_one` to match the local scalar-multiple notation.  In
+the same file, the hand proof of the diagonal expansion of the identity matrix
+was replaced by `Matrix.sum_single_one`.  The transfer-matrix statements are
+unchanged.
 
 ## PSD kernel-zero wrapper cleanup, 2026-06-19
 


### PR DESCRIPTION
### Motivation
- The private lemma `sum_smul_single_eq` in `Channel/TransferMatrix.lean` wrapped
  `Matrix.matrix_eq_sum_single` from Mathlib with no additional content, creating an
  unnecessary indirection at four call sites.
- Removing it reduces the proof footprint and makes the dependency on
  `Matrix.matrix_eq_sum_single` explicit at each use.

### Description
- Removed private lemma `sum_smul_single_eq` (`TNLean/Channel/TransferMatrix.lean`).
- Replaced all four call sites with an inline `show ... by simpa [Matrix.smul_single,
  smul_eq_mul, mul_one] using Matrix.matrix_eq_sum_single` rewrite.
- No mathematical content changed; only the internal proof structure is affected.

### Testing
- `lake env lean TNLean/Channel/TransferMatrix.lean`
- `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
<!-- No linked issue found; add `Addresses #N` once an issue is opened for Channel cleanup. -->

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1db72024a6912408a09caff6d99824b5077967b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or theorem statement changes; behavior is unchanged aside from inlined Mathlib citations.
> 
> **Overview**
> Completes the Mathlib 4.31 pass-through cleanup for transfer-matrix proofs by **deleting** the private `sum_smul_single_eq` lemma and expanding matrices **inline** with `Matrix.matrix_eq_sum_single`, plus `Matrix.smul_single` / `smul_eq_mul` / `mul_one` so summands stay in the form `ρ k l • Matrix.single k l 1`.
> 
> **Affected proofs** (statements unchanged): `transferMatrix_mulVec_eq`, `transferMatrix_comp`, trace-preserving and Hermiticity-preserving characterizations in `TransferMatrixChar`.
> 
> The **mathlib replacement audit** is updated to record that the adapter was removed (completed 2026-06-21) and that sites cite Mathlib directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef94002f0d6cae2da6607274d7ce9ce5f1c82b1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->