### PR TITLE
feat: Wolf Ch5: operator Jensen package for Corollary 5.2

### DIFF
--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -26,13 +26,19 @@ Wolf Corollary 5.2, but the final Löwner-integral packaging is still absent.
 - `povm_sum_add_defect`: the POVM family plus defect block sums to the identity.
 - `povmDiagonal_posDef`: positivity of the scalar block-diagonal matrix used in
   the resolvent step.
+- `povmDiagonal_inv`: the inverse of the scalar block-diagonal matrix is again
+  block-diagonal with pointwise-inverted entries.
+- `povm_resolvent_compression_le`: the resolvent Hansen-compression bound
+  combining the dilation isometry with `inverse_compression_le`.
 
 ## Status
 
 These lemmas formalize the compression / finite-POVM half of the direct proof
-route for the concave real-power Jensen inequality. The remaining unfinished
-step is the explicit diagonal-inverse rewrite together with the final algebraic
-rearrangement to the resolvent inequality.
+route for the concave real-power Jensen inequality, up to the resolvent
+Hansen-compression endpoint. The remaining unfinished step is the Löwner
+integral representation of `rpow` (blocked on Mathlib
+`CFC.Rpow.IntegralRepresentation`), which is required to lift the resolvent
+bound to the concave real-power Jensen inequality.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -234,6 +240,78 @@ lemma povmDiagonal_posDef (w : ι → ℝ) {t : ℝ}
     | inr p =>
         simpa [d, Complex.lt_def] using ht
   simpa [povmDiagonal, d] using hdiag
+
+/-- Under strict positivity of every weight, the inverse of the scalar
+block-diagonal matrix `povmDiagonal w t` is obtained by inverting each scalar
+entry pointwise. -/
+lemma povmDiagonal_inv (w : ι → ℝ) {t : ℝ}
+    (ht : 0 < t) (hw : ∀ i, 0 < w i) :
+    (povmDiagonal (D := D) w t)⁻¹ =
+      povmDiagonal (D := D) (fun i => (w i)⁻¹) t⁻¹ := by
+  refine Matrix.inv_eq_right_inv ?_
+  rw [povmDiagonal, povmDiagonal, Matrix.diagonal_mul_diagonal,
+      show (1 : AuxMat) = Matrix.diagonal (fun _ : AuxIx => (1 : ℂ)) from
+        Matrix.diagonal_one.symm]
+  congr 1
+  funext a
+  cases a with
+  | inl ip =>
+      change ((w ip.1 : ℝ) : ℂ) * (((w ip.1)⁻¹ : ℝ) : ℂ) = 1
+      rw [← Complex.ofReal_mul, mul_inv_cancel₀ (ne_of_gt (hw ip.1)),
+          Complex.ofReal_one]
+  | inr _ =>
+      change ((t : ℝ) : ℂ) * ((t⁻¹ : ℝ) : ℂ) = 1
+      rw [← Complex.ofReal_mul, mul_inv_cancel₀ (ne_of_gt ht),
+          Complex.ofReal_one]
+
+omit [DecidableEq ι] in
+/-- **Resolvent Hansen-compression bound.** For a finite PSD family
+`C i * (C i)ᴴ` that, together with the defect block `S * Sᴴ`, sums to the
+identity, any choice of strictly positive weights `w i` and `t` yields the
+Loewner inequality
+
+  `(∑ i, w i • (C i * (C i)ᴴ) + t • (S * Sᴴ))⁻¹ ≤`
+  `  ∑ i, (w i)⁻¹ • (C i * (C i)ᴴ) + t⁻¹ • (S * Sᴴ)`.
+
+This is the explicit resolvent form of the POVM compression inequality used as
+an intermediate step toward the Hansen--Pedersen operator Jensen inequality.
+
+It combines four ingredients:
+
+* `povmIsometry_star_mul` — the POVM dilation is an isometry;
+* `povmIsometry_compress_diagonal` — compression of `povmDiagonal w t` by the
+  dilation recovers the weighted POVM sum on both sides;
+* `povmDiagonal_inv` — the inverse of `povmDiagonal w t` is
+  `povmDiagonal w⁻¹ t⁻¹`;
+* `Matrix.PosDef.inverse_compression_le` — inverse-of-compression is
+  pointwise below compression-of-inverse. -/
+lemma povm_resolvent_compression_le
+    {C : ι → MatD} {S : MatD}
+    (hdef : S * Sᴴ = 1 - ∑ i, C i * (C i)ᴴ)
+    {w : ι → ℝ} {t : ℝ} (ht : 0 < t) (hw : ∀ i, 0 < w i) :
+    ((∑ i, w i • (C i * (C i)ᴴ)) + t • (S * Sᴴ))⁻¹ ≤
+      (∑ i, (w i)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ) := by
+  classical
+  set W : IsoMat := povmIsometry C S with hW
+  have hWiso : Wᴴ * W = (1 : MatD) := povmIsometry_star_mul (C := C) (S := S) hdef
+  have hYpd : Matrix.PosDef (povmDiagonal (D := D) w t) :=
+    povmDiagonal_posDef (ι := ι) (D := D) w ht hw
+  have hcompress :
+      Wᴴ * povmDiagonal (D := D) w t * W =
+        (∑ i, w i • (C i * (C i)ᴴ)) + t • (S * Sᴴ) := by
+    simpa [hW] using povmIsometry_compress_diagonal (C := C) (S := S) w t
+  have hcompress_inv :
+      Wᴴ * povmDiagonal (D := D) (fun i => (w i)⁻¹) t⁻¹ * W =
+        (∑ i, (w i)⁻¹ • (C i * (C i)ᴴ)) + t⁻¹ • (S * Sᴴ) := by
+    simpa [hW] using
+      povmIsometry_compress_diagonal (C := C) (S := S) (fun i => (w i)⁻¹) t⁻¹
+  have hbound :
+      (Wᴴ * povmDiagonal (D := D) w t * W)⁻¹ ≤
+        Wᴴ * (povmDiagonal (D := D) w t)⁻¹ * W :=
+    Matrix.PosDef.inverse_compression_le hYpd hWiso
+  rw [povmDiagonal_inv (ι := ι) (D := D) w ht hw] at hbound
+  rw [hcompress, hcompress_inv] at hbound
+  exact hbound
 
 end POVM
 

--- a/audits/2026-04-24_issue778_resolvent_compression_endpoint.md
+++ b/audits/2026-04-24_issue778_resolvent_compression_endpoint.md
@@ -1,0 +1,93 @@
+# Issue #778 — resolvent Hansen-compression endpoint
+
+## Scope
+
+Follow-up to `audits/2026-04-22_issue138_op_convexity_blocker.md` for issue
+#778 (operator Jensen package for Wolf Corollary 5.2). This pass adds the
+explicit *diagonal-inverse rewrite* and the *resolvent Hansen-compression
+bound* flagged by the earlier audit as the remaining unfinished algebraic
+step on the finite-POVM compression side.
+
+No change was made to the three Cor. 5.2 declarations in
+`TNLean/Channel/Schwarz/OperatorMonotone.lean`; they still depend on the
+three axioms in `TNLean/Axioms/OperatorConvexity.lean`.
+
+## What landed
+
+Two new lemmas in `TNLean/Channel/Schwarz/OperatorJensenAux.lean`:
+
+* `TNLean.OperatorJensen.povmDiagonal_inv` — the pointwise inverse identity
+  $(\operatorname{diag}(w_i, t))^{-1} = \operatorname{diag}(w_i^{-1}, t^{-1})$
+  for strictly positive weights.
+* `TNLean.OperatorJensen.povm_resolvent_compression_le` — the resolvent
+  bound
+  $$
+  \Bigl(\sum_i w_i\, C_i C_i^{\dagger} + t\, S S^{\dagger}\Bigr)^{-1}
+  \le
+  \sum_i w_i^{-1}\, C_i C_i^{\dagger} + t^{-1}\, S S^{\dagger},
+  $$
+  valid whenever $\sum_i C_i C_i^{\dagger} + S S^{\dagger} = 1$ and all
+  weights are strictly positive. The proof combines the four existing
+  ingredients: `povmIsometry_star_mul`, `povmIsometry_compress_diagonal`,
+  `povmDiagonal_inv`, and `Matrix.PosDef.inverse_compression_le`.
+
+Both lemmas are honest proofs. No new `sorry`, `admit`, `axiom`,
+`native_decide`, or proof-integrity workaround was introduced.
+
+## What remains blocked
+
+The three target declarations
+
+* `IsPositiveMap.cor52_item1_rpow_of_subunital`
+* `IsPositiveMap.cor52_item2_rpow_of_subunital`
+* `IsPositiveMap.cor52_item3_log_of_subunital`
+
+are still gated by the three axioms
+
+* `posMap_rpow_concave_jensen`
+* `posMap_rpow_convex_jensen`
+* `posMap_log_concave_jensen`
+
+in `TNLean/Axioms/OperatorConvexity.lean`. Upstream Mathlib v4.29 still
+carries the TODOs that block a genuine discharge:
+
+* operator concavity of `rpow` on $[0,1]$ and operator convexity of `rpow`
+  on $[1,2]$ are flagged as TODOs in
+  `Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/Order.lean`;
+* operator concavity of `log` is flagged as a TODO in
+  `Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Order.lean`;
+* a general operator Jensen theorem for positive (sub)unital maps is
+  absent from Mathlib.
+
+## How the new endpoint fits the proof plan
+
+The Hansen--Pedersen operator Jensen inequality factors through a
+compression/resolvent step. The finite-POVM side of that compression is now
+closed modulo the Löwner integral representation of `rpow`:
+
+1. Reduce the operator Jensen inequality for a positive subunital map to the
+   Hansen compression inequality via the POVM dilation `povmIsometry`
+   (already in `OperatorJensenAux.lean`).
+2. Reduce the Hansen compression inequality on `rpow` to the resolvent
+   Hansen-compression bound via the Löwner integral representation
+   $x^p = C_p \int_0^\infty t^{p-1}\, x(x+t)^{-1}\,dt$.
+   This step is the remaining Mathlib gap
+   (`CFC.Rpow.IntegralRepresentation`).
+3. Verify the resolvent bound by combining the POVM dilation with the
+   inverse-of-compression/compression-of-inverse inequality.
+   This is now `povm_resolvent_compression_le`.
+
+## Recommended next step
+
+Either
+
+* move upstream and contribute the missing `CFC.Rpow.IntegralRepresentation`
+  concavity lemmas to Mathlib, so that step (2) above becomes available; or
+* prove a finite-POVM Löwner-integral variant directly at the matrix level,
+  using only `Matrix.PosDef.inverse_compression_le` and the new
+  `povm_resolvent_compression_le`, which sidesteps the Mathlib TODO at the
+  cost of duplicating the integral representation locally.
+
+The three Cor. 5.2 declarations should continue to reference the axioms in
+`TNLean/Axioms/OperatorConvexity.lean` until one of the two routes above
+lands.

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -874,6 +874,53 @@ logarithm are not developed in this chapter.
     is immediate from positivity of its diagonal entries.
 \end{proof}
 
+\begin{lemma}[Inverse of the finite-POVM scalar block diagonal]\label{lem:operator_jensen_povm_diagonal_inv}
+    \lean{TNLean.OperatorJensen.povmDiagonal_inv}
+    \leanok
+    If every weight on the $\iota$-blocks and the defect scalar are strictly
+    positive, then the inverse of the scalar block-diagonal matrix is the
+    scalar block-diagonal matrix built from the pointwise-inverted weights
+    and defect scalar.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Multiply the two scalar block-diagonal matrices and use the fact that
+    diagonal matrices multiply entrywise. Strict positivity implies each
+    scalar entry is nonzero, so the pointwise product is identically one.
+    Conclude by uniqueness of the right inverse of a square matrix.
+\end{proof}
+
+\begin{lemma}[Resolvent Hansen-compression bound]\label{lem:operator_jensen_povm_resolvent_compression}
+    \lean{TNLean.OperatorJensen.povm_resolvent_compression_le}
+    \leanok
+    \uses{lem:operator_jensen_inverse_compression, lem:operator_jensen_povm_compression, lem:operator_jensen_povm_diagonal_inv}
+    Suppose that
+    \[
+        S S^\ast = \Id - \sum_{i \in \iota} C_i C_i^\ast,
+    \]
+    and that the weights $w_i$ and the defect scalar $t$ are strictly
+    positive. Then
+    \[
+        \Bigl(\sum_{i \in \iota} w_i\, C_i C_i^\ast + t\, S S^\ast\Bigr)^{-1}
+        \le
+        \sum_{i \in \iota} w_i^{-1}\, C_i C_i^\ast + t^{-1}\, S S^\ast.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:operator_jensen_inverse_compression, lem:operator_jensen_povm_compression, lem:operator_jensen_povm_diagonal_inv}
+    Apply the compression auxiliary
+    (Lemma~\ref{lem:operator_jensen_inverse_compression}) to the scalar
+    block-diagonal matrix with weights $w_i$ and defect $t$ and to the
+    finite-POVM dilation, which is an isometry by
+    Lemma~\ref{lem:operator_jensen_povm_compression}. Rewrite the inverse
+    using Lemma~\ref{lem:operator_jensen_povm_diagonal_inv} and identify both
+    compressions via
+    Lemma~\ref{lem:operator_jensen_povm_compression}.
+\end{proof}
+
 \begin{theorem}[Jensen for concave real powers]\label{thm:posMap_rpow_concave_jensen}
     \lean{posMap_rpow_concave_jensen}
     \notready


### PR DESCRIPTION
### Motivation
- Addresses LionSR/QICLean#135: Wolf Ch5: operator Jensen package for Corollary 5.2.
- Source issue: https://github.com/LionSR/QICLean/issues/135

### Description
- This PR was opened from `claude/issue-778-formalizationwolf-ch5-operator-jensen-package` by Claude Code action.
- Changed files:
- See the commits on `claude/issue-778-formalizationwolf-ch5-operator-jensen-package`.

### Testing
- CI should run the configured checks for this branch.

---
Addresses LionSR/QICLean#135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained formal proofs and documentation in the operator-Jensen auxiliary layer; no changes to axioms, Cor. 5.2 APIs, or runtime behavior.
> 
> **Overview**
> Closes the **finite-POVM compression algebra** for the Hansen–Pedersen route to operator Jensen (issue LionSR/QICLean#135 follow-up): adds **`povmDiagonal_inv`** (pointwise inverse of weighted scalar block-diagonal `povmDiagonal`) and **`povm_resolvent_compression_le`** (Loewner bound comparing inverse of a weighted POVM sum to the inverse-weighted sum), wired from existing dilation/compression lemmas plus `Matrix.PosDef.inverse_compression_le`.
> 
> Module docs, blueprint **Ch. 5** (`lem:operator_jensen_povm_diagonal_inv`, `lem:operator_jensen_povm_resolvent_compression`), and an audit note document the endpoint and that **Cor. 5.2** theorems still depend on **`OperatorConvexity`** axioms until Mathlib’s `rpow` Löwner integral representation is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d5912b0467e527c852ffb2fa129eece2e018d2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->