### PR TITLE
doc(Spectral): update norm-to-Euclidean blueprint proof

### DIFF
--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -209,7 +209,9 @@ Euclidean space.
 \end{lemma}
 
 \begin{proof}\leanok
-    Expand both sides as sums over entries and use $|z|^2 = \bar{z}z$.
+    Both sides equal $\sum_{i,j}\|X_{ij}\|^2$: the left side by the
+    Euclidean entry-norm formula, and the right side by the definition of the
+    Frobenius norm.
 \end{proof}
 
 \section{Eigenvalue bound and transfer-operator gap}


### PR DESCRIPTION
### Motivation

- The blueprint proof sketch for `lem:norm_mat_to_es` (`blueprint/src/chapter/ch07_spectral.tex`, lines 211–213) describes an old proof that no longer matches the current Lean implementation, following PR #3292 (`refactor(Spectral): use Mathlib Euclidean norm-square formula`).
- The stale sketch reads "Expand both sides as sums over entries and use $|z|^2 = \bar{z}z$", describing the old coordinate-by-coordinate argument. The current Lean proof uses `EuclideanSpace.norm_sq_eq` directly, making the $|z|^2 = \bar{z}z$ step obsolete.
- The lemma asserts $\|\mathrm{vec}(X)\|^2 = \|X\|_F^2$ (label `lem:norm_mat_to_es`, `blueprint/src/chapter/ch07_spectral.tex`). See #3293.

### Description

- Rewrites the `\begin{proof}...\end{proof}` block of `lem:norm_mat_to_es` in `blueprint/src/chapter/ch07_spectral.tex` (approximately lines 211–213) to reflect the current two-step Lean proof.
- The new sketch states that both sides equal $\sum_{i,j}\|X_{ij}\|^2$: the left by the Euclidean entry-norm formula (`EuclideanSpace.norm_sq_eq`), and the right by `frobSq_eq_sum` together with `Fintype.sum_prod_type`.
- The statement and `\lean{MPSTensor.norm_matToES_sq}` / `\leanok` tags are unchanged.

### Testing

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean CI (`lean_action_ci.yml`) validates the build.

---
Closes #3293

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2ca28aab7981aceff765c150b0c39893f78f96db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in the spectral chapter blueprint; no Lean or runtime behavior changes.
> 
> **Overview**
> Updates the **proof sketch** for Lemma `lem:norm_mat_to_es` (`\|\mathrm{vec}(X)\|^2 = \|X\|_F^2`) in `ch07_spectral.tex` so it matches the formal proof `MPSTensor.norm_matToES_sq`.
> 
> The old sketch cited expanding both sides and using \(|z|^2 = \bar{z}z\). The new text states that **both sides are the same entry sum** \(\sum_{i,j}\|X_{ij}\|^2\): the Euclidean norm on the flattened vector vs. the Frobenius norm from Definition `def:frob_sq`. The lemma statement and `\lean{MPSTensor.norm_matToES_sq}` / `\leanok` tags are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ca28aab7981aceff765c150b0c39893f78f96db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->