### PR TITLE
refactor(Channel/Semigroup): inline multiplication action wrappers

### DIFF
--- a/TNLean/Channel/Semigroup/Dissipative.lean
+++ b/TNLean/Channel/Semigroup/Dissipative.lean
@@ -71,15 +71,6 @@ private abbrev rightMulCLMAlgHom (D : ℕ) : (Mat D)ᵐᵒᵖ →ₐ[ℂ] Matrix
     ((AlgHom.mulLeftRight ℂ (Mat D)).comp
       (Algebra.TensorProduct.includeRight (R := ℂ) (A := Mat D) (B := (Mat D)ᵐᵒᵖ)))
 
-private theorem leftMulCLM_apply (A ρ : Mat D) :
-    leftMulCLMAlgHom D A ρ = A * ρ := by
-  rfl
-
-private theorem rightMulCLM_apply (A : (Mat D)ᵐᵒᵖ) (ρ : Mat D) :
-    rightMulCLMAlgHom D A ρ = ρ * MulOpposite.unop A := by
-  change ((AlgHom.mulLeftRight ℂ (Mat D)) (1 ⊗ₜ[ℂ] A)) ρ = ρ * MulOpposite.unop A
-  simp [AlgHom.mulLeftRight_apply]
-
 private lemma continuous_leftMulCLMAlgHom :
     Continuous (leftMulCLMAlgHom D) := by
   have h_eq : (leftMulCLMAlgHom D : Mat D → MatrixCLM (Fin D)) =
@@ -87,7 +78,6 @@ private lemma continuous_leftMulCLMAlgHom :
     funext A
     apply ContinuousLinearMap.ext
     intro ρ
-    rw [leftMulCLM_apply]
     rfl
   rw [h_eq]
   exact (ContinuousLinearMap.mul ℂ (Mat D)).continuous
@@ -102,8 +92,9 @@ private lemma continuous_rightMulCLMAlgHom :
     funext A
     apply ContinuousLinearMap.ext
     intro ρ
-    rw [rightMulCLM_apply]
-    rfl
+    change ((AlgHom.mulLeftRight ℂ (Mat D)) (1 ⊗ₜ[ℂ] A)) ρ =
+      ρ * MulOpposite.unop A
+    simp [AlgHom.mulLeftRight_apply]
   rw [h_eq]
   exact (ContinuousLinearMap.mul ℂ (Mat D)).flip.continuous.comp hunop
 
@@ -220,19 +211,25 @@ theorem expSemigroup_dissipativeDrift_apply
     rw [expSemigroupCLM, hsplit, hsum, exp_leftMulCLM, exp_rightMulCLM]
   change expSemigroupCLM (endEquiv (D := D) (dissipativeDrift κ)) t ρ = _
   rw [hκ]
+  let E := NormedSpace.exp (-(t : ℂ) • κ)
   have hconj : NormedSpace.exp (-(t : ℂ) • κᴴ) =
-      (NormedSpace.exp (-(t : ℂ) • κ))ᴴ := by
+      Eᴴ := by
     calc
       NormedSpace.exp (-(t : ℂ) • κᴴ) = NormedSpace.exp (((-(t : ℂ)) • κ)ᴴ) := by
         rw [Matrix.conjTranspose_smul]
         simp
-      _ = (NormedSpace.exp (-(t : ℂ) • κ))ᴴ := Matrix.exp_conjTranspose (A := (-(t : ℂ)) • κ)
+      _ = Eᴴ := Matrix.exp_conjTranspose (A := (-(t : ℂ)) • κ)
   rw [hconj]
   change
-    leftMulCLMAlgHom D (NormedSpace.exp (-(t : ℂ) • κ))
+    leftMulCLMAlgHom D E
       ((rightMulCLMAlgHom D
-        (MulOpposite.op ((NormedSpace.exp (-(t : ℂ) • κ))ᴴ))) ρ) = _
-  rw [rightMulCLM_apply, leftMulCLM_apply]
+        (MulOpposite.op Eᴴ)) ρ) = E * ρ * Eᴴ
+  have hright : (rightMulCLMAlgHom D (MulOpposite.op Eᴴ)) ρ = ρ * Eᴴ := by
+    change ((AlgHom.mulLeftRight ℂ (Mat D)) (1 ⊗ₜ[ℂ] MulOpposite.op Eᴴ)) ρ =
+      ρ * Eᴴ
+    simp [AlgHom.mulLeftRight_apply]
+  rw [hright]
+  change E * (ρ * Eᴴ) = E * ρ * Eᴴ
   simp [Matrix.mul_assoc]
 
 /-- The dissipative drift semigroup is completely positive, with a single Kraus operator

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -109,6 +109,8 @@ The clearest replacements are:
   `Algebra.TensorProduct.includeRight`.  The former hand-written algebra-hom
   fields for right multiplication were removed, and the left-right
   multiplication commutation proof now cites `LinearMap.commute_mulLeft_right`.
+  The two private left- and right-multiplication application wrappers were
+  also removed.
 - Further Lean 4.31 elaboration checks removed local heartbeat bounds from the
   POVM unitary-comparison proof, the irreducible-channel spectral-radius scalar
   proof, the semigroup perturbation derivative proof, and the common
@@ -2010,12 +2012,12 @@ as
   (Mat D ⊗[ℂ] (Mat D)ᵐᵒᵖ) →ₐ[ℂ] Module.End ℂ (Mat D)`.
 
 The local right-action hom is now the composition of this Mathlib hom with
-`Algebra.TensorProduct.includeRight`.  The proof keeps the local shaped
-application lemma `rightMulAlgHom_apply`, but that lemma is now a `simp`
-consequence of `AlgHom.mulLeftRight_apply`.  The proof that left and right
+`Algebra.TensorProduct.includeRight`.  The proof that left and right
 multiplication commute now maps Mathlib's `LinearMap.commute_mulLeft_right`
 through `endEquivD`, rather than reproving associativity pointwise on matrix
-entries.
+entries.  A later pass removed the private left- and right-multiplication
+application wrappers; the remaining proof sites use definitional reduction or
+`AlgHom.mulLeftRight_apply` directly.
 
 Focused check:
 


### PR DESCRIPTION
### Motivation

- The private lemmas `leftMulCLM_apply` and `rightMulCLM_apply` in the dissipative drift proof duplicated functionality available directly via `AlgHom.mulLeftRight_apply` in Mathlib 4.31; removing them reduces local auxiliary overhead.
- The Mathlib 4.31 replacement audit (initiated in PR #3006) identified `AlgHom.mulLeftRight` as a direct Mathlib replacement for the multiplication-action wrappers in `Channel/Semigroup/Dissipative.lean`.

### Description

- `TNLean/Channel/Semigroup/Dissipative.lean`: removes private lemmas `leftMulCLM_apply` and `rightMulCLM_apply`; closes multiplication facts at the remaining proof sites using definitional `rfl`, `AlgHom.mulLeftRight_apply`, and a short `hright` lemma for right action on states; introduces `E := NormedSpace.exp (-(t : ℂ) • κ)` so that conjugate-transpose and associativity steps read as `E * ρ * Eᴴ` without repeating the exponential expression.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: updated to record that the application wrappers were removed after switching to `AlgHom.mulLeftRight`.
- No theorem statements are changed; this is a proof-term refactor only.

### Testing

- `lake env lean TNLean/Channel/Semigroup/Dissipative.lean`
- `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---

<!-- CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one semigroup file plus audit documentation; no API or theorem statement changes.
> 
> **Overview**
> This PR **drops** the private lemmas `leftMulCLM_apply` and `rightMulCLM_apply` from `TNLean/Channel/Semigroup/Dissipative.lean`. Continuity and `expSemigroup_dissipativeDrift_apply` now close multiplication facts with **definitional `rfl`**, **`AlgHom.mulLeftRight_apply`**, and a short **`hright`** lemma for right action on states.
> 
> The final semigroup identity step introduces **`E := NormedSpace.exp (-(t : ℂ) • κ)`** so conjugate-transpose and associativity steps read as `E * ρ * Eᴴ` without repeating the exponential.
> 
> The Mathlib 4.31 replacement audit doc is updated to note that these application wrappers were removed after switching to `AlgHom.mulLeftRight`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da19c8983ac3ec2c058ede2998da7f4f0e5bc44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->