### PR TITLE
refactor(Channel/TransferMatrix): restore matrix-unit adapter

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -119,6 +119,11 @@ theorem transferMatrix_apply
     (i j k l : Fin D) :
     transferMatrix T (j, i) (l, k) = (T (Matrix.single k l 1)) i j := rfl
 
+private lemma sum_smul_single_eq (ρ : Matrix (Fin D) (Fin D) ℂ) :
+    ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 := by
+  simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
+    (Matrix.matrix_eq_sum_single ρ)
+
 /-! ### Fundamental property: T̂ represents T in the vectorized picture -/
 
 /-- **Key property**: the transfer matrix faithfully represents `T`:
@@ -135,9 +140,7 @@ theorem transferMatrix_mulVec_eq
     Matrix.vec, Fintype.sum_prod_type]
   have key : T ρ = ∑ k, ∑ l, ρ k l • T (Matrix.single k l 1) := by
     conv_lhs =>
-      rw [show ρ = ∑ k : Fin D, ∑ l : Fin D, ρ k l • Matrix.single k l 1 by
-        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-          (Matrix.matrix_eq_sum_single ρ)]
+      rw [sum_smul_single_eq ρ]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
@@ -156,11 +159,7 @@ theorem transferMatrix_comp
   have key : S (T (Matrix.single k l 1)) =
       ∑ a, ∑ b, (T (Matrix.single k l 1)) a b • S (Matrix.single a b 1) := by
     conv_lhs =>
-      rw [show T (Matrix.single k l 1) =
-          ∑ a : Fin D, ∑ b : Fin D,
-            (T (Matrix.single k l 1)) a b • Matrix.single a b 1 by
-        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-          (Matrix.matrix_eq_sum_single (T (Matrix.single k l 1)))]
+      rw [sum_smul_single_eq (T (Matrix.single k l 1))]
     simp_rw [map_sum, LinearMap.map_smul]
   rw [key]
   simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
@@ -279,18 +278,14 @@ theorem transferMatrix_tp_iff
     calc Matrix.trace (T X)
         = Matrix.trace (T (∑ k, ∑ l, X k l • Matrix.single k l 1)) := by
             conv_lhs =>
-              rw [show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
-                simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-                  (Matrix.matrix_eq_sum_single X)]
+              rw [sum_smul_single_eq X]
       _ = ∑ k, ∑ l, X k l • Matrix.trace (T (Matrix.single k l 1)) := by
             simp_rw [map_sum, LinearMap.map_smul, Matrix.trace_sum, Matrix.trace_smul]
       _ = ∑ k, ∑ l, X k l • Matrix.trace (Matrix.single k l (1 : ℂ)) := by
             simp_rw [key]
       _ = Matrix.trace X := by
             simp_rw [← Matrix.trace_smul, ← Matrix.trace_sum]
-            rw [← show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
-              simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-                (Matrix.matrix_eq_sum_single X)]
+            rw [← sum_smul_single_eq X]
 
 /-- **Proposition 2.6 (Unital via transfer matrix)**: `T` is unital (`T 1 = 1`) iff
 the row-diagonal sums of the transfer matrix give `δ_{ij}`:
@@ -337,18 +332,13 @@ theorem transferMatrix_hermiticityPreserving_iff
       -- this : (T (single k l 1)) j i = starRingEnd ℂ ((T (single l k 1)) i j)
       rw [this, starRingEnd_apply, star_star]
     conv_lhs =>
-      rw [show X = ∑ k : Fin D, ∑ l : Fin D, X k l • Matrix.single k l 1 by
-        simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-          (Matrix.matrix_eq_sum_single X)]
+      rw [sum_smul_single_eq X]
     simp_rw [map_sum, LinearMap.map_smul, Matrix.conjTranspose_sum,
       Matrix.conjTranspose_smul, basis_eq]
     have hXconj : Xᴴ = ∑ k : Fin D, ∑ l : Fin D,
         star (X l k) • Matrix.single k l 1 := by
       conv_lhs =>
-        rw [show Xᴴ = ∑ k : Fin D, ∑ l : Fin D,
-            Xᴴ k l • Matrix.single k l 1 by
-          simpa [Matrix.smul_single, smul_eq_mul, mul_one] using
-            (Matrix.matrix_eq_sum_single Xᴴ)]
+        rw [sum_smul_single_eq Xᴴ]
       simp_rw [Matrix.conjTranspose_apply]
     rw [hXconj]; simp_rw [map_sum, LinearMap.map_smul]
     rw [Finset.sum_comm]

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -101,9 +101,10 @@ The clearest replacements are:
   finite sum directly at the proof site using `Matrix.one_apply`,
   `Finset.sum_add_distrib`, and Mathlib's if-supported finite-sum
   simplification.  The private lemma `sum_one_smul_eq` was removed.
-- The transfer-matrix coordinate-expansion helper was removed.  The proof
-  sites now cite Mathlib's `Matrix.matrix_eq_sum_single` directly, using
-  `Matrix.smul_single` only to match the local scalar-matrix-unit notation.
+- The transfer-matrix coordinate-expansion helper now cites Mathlib's
+  `Matrix.matrix_eq_sum_single` directly, with `Matrix.smul_single` used only
+  to match the local scalar-matrix-unit notation.  The private helper remains
+  as the shared statement used at the transfer-matrix proof sites.
 - The dissipative-drift right-multiplication algebra hom now comes from
   Mathlib's `AlgHom.mulLeftRight`, composed with
   `Algebra.TensorProduct.includeRight`.  The former hand-written algebra-hom
@@ -1912,7 +1913,7 @@ Those proofs now call `tendsto_nhds_unique` directly, and the helper file was
 removed.  Future proofs that need this limit-uniqueness fact should use the
 Mathlib theorem rather than reintroducing the wrapper.
 
-## Transfer-matrix coordinate expansion cleanup, 2026-06-19; completed 2026-06-21
+## Transfer-matrix coordinate expansion cleanup, 2026-06-19
 
 `TNLean/Channel/TransferMatrix.lean` had a private lemma
 `sum_smul_single_eq` stating that a matrix is the finite sum of its entries
@@ -1920,13 +1921,13 @@ times the corresponding matrix units.  Mathlib 4.31 already provides this
 statement as `Matrix.matrix_eq_sum_single`; the only local difference was the
 choice to write the summands as `ρ k l • Matrix.single k l 1`.
 
-The private helper was first reduced to a local notation adapter and then
-removed.  The transfer-matrix proof sites now cite
-`Matrix.matrix_eq_sum_single` directly, simplifying by `Matrix.smul_single`,
-`smul_eq_mul`, and `mul_one` to match the local scalar-multiple notation.  In
-the same file, the hand proof of the diagonal expansion of the identity matrix
-was replaced by `Matrix.sum_single_one`.  The transfer-matrix statements are
-unchanged.
+The private helper has now been retained as the local notation adapter.  Its
+proof cites `Matrix.matrix_eq_sum_single` directly, simplifying by
+`Matrix.smul_single`, `smul_eq_mul`, and `mul_one` to match the local
+scalar-multiple notation.  The transfer-matrix proof sites share this adapter.
+In the same file, the hand proof of the diagonal expansion of the identity
+matrix was replaced by `Matrix.sum_single_one`.  The transfer-matrix statements
+are unchanged.
 
 ## PSD kernel-zero wrapper cleanup, 2026-06-19
 


### PR DESCRIPTION
### Motivation
- Follow-up to the post-merge review discussion on #3295, which inlined `Matrix.matrix_eq_sum_single` at call sites and removed the shared adapter.
- The deleted `sum_smul_single_eq` helper was not a mere pass-through: it records the scalar-multiple form of Mathlib's `Matrix.matrix_eq_sum_single` used at six transfer-matrix proof sites.

### Description
- Restored the private `sum_smul_single_eq` adapter in `TNLean/Channel/TransferMatrix.lean`.
- Replaced the six duplicated inline `Matrix.matrix_eq_sum_single` bridges with calls to the shared adapter.
- Updated `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md` to record that the helper is retained as a local notation adapter.

### Testing
- `lake exe cache get`
- `lake build TNLean.Channel.TransferMatrix -q --log-level=info`
- `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate full build.

---
Follow-up to #3295. No linked issue found; the author should open a Channel cleanup issue and add `Addresses #N` to this PR.

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0091101468fdef5654a2e6f8f9209d25033f34c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>