### PR TITLE
doc(periodic): mark Thm 4.1 equivalence conditional

### DIFF
--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean
@@ -26,8 +26,14 @@ variable {d D : ℕ}
 Let `B` be an MPS tensor in irreducible form II and let `p ≥ 1`. Under both the forward
 canonicalization hypothesis `PRefinementCanonicalization` and the inverse canonicalization
 hypothesis `PRefinementInverseCanonicalization`, `p`-refinability of `B` is equivalent to
-`p`-divisibility of its transfer map. This bundles
-`thm_4_1_p_refinement_forward` and `thm_4_1_p_refinement_reverse` into a single iff. -/
+`p`-divisibility of its transfer map.
+
+This is a conditional version of arXiv:1708.00029, Theorem 4.1; the source
+statement, lines 728--731, does not assume the two canonicalization hypotheses.
+The converse root/Kraus-rank gap is recorded in
+`docs/paper-gaps/periodic_thm41_root_kraus_rank.tex`. This theorem combines
+`thm_4_1_p_refinement_forward` and `thm_4_1_p_refinement_reverse` into a
+single biconditional. -/
 theorem thm_4_1_p_refinement
     (B : MPSTensor d D) (hB : IsIrreducibleForm B)
     (p : ℕ) (hp : 0 < p)

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -2013,6 +2013,12 @@ The following conditional statements separate the refinability--divisibility
 equivalence of \cite[Theorem~4.1]{DeLasCuevas2017Irreducible} from the
 root-construction assumptions used below.
 
+% Source comparison: arXiv:1708.00029, Theorem 4.1, lines 728--731 asserts
+% the same refinability--divisibility equivalence without additional root
+% hypotheses. The forward left-canonical root construction corresponds to
+% lines 735--810, while the reverse transfer-map root construction corresponds
+% to lines 812--818. The Lean theorem below packages the two proved one-way
+% implications and is therefore conditional on those two root hypotheses.
 \begin{theorem}[$p$-refinability iff transfer-map $p$-divisibility, conditional]%
     \label{thm:thm_4_1_p_refinement}
     \lean{MPSTensor.thm_4_1_p_refinement}
@@ -2021,14 +2027,10 @@ root-construction assumptions used below.
         thm:periodic_ft, thm:thm_4_1_p_refinement_forward,
         thm:thm_4_1_p_refinement_reverse}
     Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
-    The source theorem asserts the same equivalence with no further hypotheses.
-    In the present conditional form, assume the two root hypotheses used in the
-    one-way statements: the forward left-canonical root hypothesis for
-    refinability $\Rightarrow$ divisibility, corresponding to the construction
-    in source lines 735--810, and the reverse transfer-map root hypothesis for
-    divisibility $\Rightarrow$ refinability, corresponding to the converse step
-    in source lines 812--818. Then $B$ is $p$-refinable iff its transfer map
-    $\mathcal{E}_B$ is $p$-divisible.
+    Assume the forward left-canonical root hypothesis for
+    refinability $\Rightarrow$ divisibility and the reverse transfer-map root
+    hypothesis for divisibility $\Rightarrow$ refinability. Then $B$ is
+    $p$-refinable iff its transfer map $\mathcal{E}_B$ is $p$-divisible.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -2009,10 +2009,11 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     gives $\mathcal E_B = (\mathcal E_{A'})^p$.
 \end{proof}
 
-The following conditional statements isolate the refinability--divisibility
-equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
+The following conditional statements separate the refinability--divisibility
+equivalence of \cite[Theorem~4.1]{DeLasCuevas2017Irreducible} from the
+root-construction assumptions used below.
 
-\begin{theorem}[$p$-refinability iff transfer-map $p$-divisibility]%
+\begin{theorem}[$p$-refinability iff transfer-map $p$-divisibility, conditional]%
     \label{thm:thm_4_1_p_refinement}
     \lean{MPSTensor.thm_4_1_p_refinement}
     \leanok
@@ -2020,16 +2021,19 @@ equivalence from \cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
         thm:periodic_ft, thm:thm_4_1_p_refinement_forward,
         thm:thm_4_1_p_refinement_reverse}
     Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
-    Assume the two root hypotheses used in the one-way statements: the forward
-    left-canonical root hypothesis for refinability $\Rightarrow$ divisibility
-    and the reverse transfer-map root hypothesis for divisibility
-    $\Rightarrow$ refinability. Then $B$ is $p$-refinable iff its transfer
-    map $\mathcal{E}_B$ is $p$-divisible.
+    The source theorem asserts the same equivalence with no further hypotheses.
+    In the present conditional form, assume the two root hypotheses used in the
+    one-way statements: the forward left-canonical root hypothesis for
+    refinability $\Rightarrow$ divisibility, corresponding to the construction
+    in source lines 735--810, and the reverse transfer-map root hypothesis for
+    divisibility $\Rightarrow$ refinability, corresponding to the converse step
+    in source lines 812--818. Then $B$ is $p$-refinable iff its transfer map
+    $\mathcal{E}_B$ is $p$-divisible.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{thm:thm_4_1_p_refinement_forward, thm:thm_4_1_p_refinement_reverse}
-    Bundle the forward implication
+    Combine the forward implication
     (Theorem~\ref{thm:thm_4_1_p_refinement_forward}) with the reverse
     implication (Theorem~\ref{thm:thm_4_1_p_refinement_reverse}) into a
     single biconditional. The forward direction assumes the left-canonical root

--- a/docs/paper-gaps/periodic_thm41_root_kraus_rank.tex
+++ b/docs/paper-gaps/periodic_thm41_root_kraus_rank.tex
@@ -117,8 +117,10 @@ $W:\mathbb C^d\to(\mathbb C^d)^{\otimes p}$ needed for refinement.
 \footnote{The inverse canonicalization hypothesis is
 \texttt{MPSTensor.PRefinementInverseCanonicalization} in
 \path{TNLean/MPS/Periodic/Symmetry/Theorem41Reverse.lean:26--42}. The blueprint
-records the corresponding conditional statement in
-\path{blueprint/src/chapter/ch22_periodic_ft.tex:1076--1103}.}
+records the bundled conditional equivalence and the reverse conditional
+implication in
+\path{blueprint/src/chapter/ch22_periodic_ft.tex:2012--2042} and
+\path{blueprint/src/chapter/ch22_periodic_ft.tex:2096--2122}.}
 
 The formal theorem also isolates a sufficient channel-theoretic hypothesis for
 the missing step: if every trace-preserving completely positive root


### PR DESCRIPTION
### Motivation

- The bundled `MPSTensor.thm_4_1_p_refinement` biconditional (arXiv:1708.00029 Theorem 4.1, lines 728–731) was proved in PRs #635 and #656 under two canonicalization hypotheses (`PRefinementCanonicalization` and `PRefinementInverseCanonicalization`) that have not yet been discharged; the blueprint entry did not reflect this conditional structure.
- The paper-gap note `docs/paper-gaps/periodic_thm41_root_kraus_rank.tex` referenced stale blueprint line ranges that need to point to the current entries in `ch22_periodic_ft.tex`.

### Description

- `blueprint/src/chapter/ch22_periodic_ft.tex`: retitled the bundled Theorem 4.1 entry as conditional; separated the literature equivalence from the root-construction assumptions; mapped the two root hypotheses to arXiv:1708.00029 forward (lines 735–810) and converse (lines 812–818) steps.
- `TNLean/MPS/Periodic/Symmetry/Theorem41Bundle.lean`: added a docstring to `thm_4_1_p_refinement` comparing the Lean statement (conditional on both canonicalization hypotheses) to the unconditional arXiv:1708.00029 Theorem 4.1; links the gap to `docs/paper-gaps/periodic_thm41_root_kraus_rank.tex`.
- `docs/paper-gaps/periodic_thm41_root_kraus_rank.tex`: updated footnote to cite current blueprint line ranges for the bundled equivalence and reverse implication entries.

### Testing

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe cache get`
- `lake build TNLean.MPS.Periodic.Symmetry.Theorem41Bundle`

---
Addresses #622
Addresses #664

> [!NOTE]
> **Low Risk**
> Prose and cross-reference edits only; no changes to theorem statements, proofs, or formal logic.
>
> **Overview**
> Clarifies that the **bundled** `thm_4_1_p_refinement` biconditional is **conditional** on the forward and inverse canonicalization hypotheses, unlike arXiv:1708.00029 Theorem 4.1 (lines 728–731).
>
> The **Lean** docstring for `thm_4_1_p_refinement` now states that source comparison, links the converse **root/Kraus-rank** gap to `docs/paper-gaps/periodic_thm41_root_kraus_rank.tex`, and notes that the theorem only combines the existing one-way results.
>
> The **blueprint** (`ch22_periodic_ft.tex`) retitles the bundled theorem as conditional, separates the literature equivalence from the root-construction assumptions, and maps the two root hypotheses to the paper's forward (735–810) and converse (812–818) steps. The **paper-gap** note's footnote now cites the updated blueprint line ranges for the bundled equivalence and reverse implication.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb76b7e020127c23088faf102ccd852166e307a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose, docstrings, and LaTeX cross-references only; theorem statements and proofs are unchanged.
> 
> **Overview**
> **Documentation and cross-reference updates** so the formalization matches how Theorem 4.1 is actually proved: the bundled biconditional still assumes `PRefinementCanonicalization` and `PRefinementInverseCanonicalization`, unlike the unconditional statement in arXiv:1708.00029 (lines 728–731).
> 
> The **Lean** docstring on `thm_4_1_p_refinement` in `Theorem41Bundle.lean` now states that conditional status, points the converse **root/Kraus-rank** gap to `docs/paper-gaps/periodic_thm41_root_kraus_rank.tex`, and notes the theorem only combines the existing forward/reverse results—**no change** to the theorem signature or proof terms.
> 
> The **blueprint** (`ch22_periodic_ft.tex`) retitles the bundled entry as conditional, adds inline mapping of the two root hypotheses to the paper’s forward (735–810) and converse (812–818) steps, and tightens the surrounding prose/proof wording. The **paper-gap** note’s footnote now cites the updated blueprint line ranges for the bundled equivalence and reverse implication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 606364bf64984797907484fc80987629c90f9e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->