### PR TITLE
feat(MPS/ParentHamiltonian): reformulate NNCPH ground spaces

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -62,7 +62,8 @@ clause from Definition 3.9.
   the source ground-space spanning assertion.
 * `MPSTensor.hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning` —
   the all-chain source condition is equivalently all-chain nearest-neighbor
-  commutation together with the Definition 3.9 ground-space spanning clause.
+  commutation together with the ground-space spanning clause of
+  arXiv:1606.00608, Definition 3.9.
 * `MPSTensor.nncph_implies_rfp` — axiom-backed reverse implication from the
   all-chain NNCPH ground-space condition to RFP.
 
@@ -283,7 +284,7 @@ spanning clause.
 For \(N>2\), the zero-energy equation for \(V^{(N)}(B)\) is an unconditional
 consequence of the parent-Hamiltonian construction. It therefore need not be
 assumed separately; the remaining data are the length-two commuting condition
-and the Definition 3.9 spanning equation.
+and the spanning equation of arXiv:1606.00608, Definition 3.9.
 
 See arXiv:1606.00608, Definition 3.9 and Theorem 3.10(iii). -/
 theorem hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -60,6 +60,9 @@ clause from Definition 3.9.
 * `MPSTensor.rfp_implies_nncph_ground_state` — the same direction with the
   zero-energy ground-vector equation for the MPS vector included, but without
   the source ground-space spanning assertion.
+* `MPSTensor.hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning` —
+  the all-chain source condition is equivalently all-chain nearest-neighbor
+  commutation together with the Definition 3.9 ground-space spanning clause.
 * `MPSTensor.nncph_implies_rfp` — axiom-backed reverse implication from the
   all-chain NNCPH ground-space condition to RFP.
 
@@ -272,6 +275,29 @@ theorem hasNNCPHGroundSpaces_iff_forall_isNNCPHGroundState_and_groundSpaceSpanni
         h.hasParentHamiltonianGroundSpaceSpanning⟩
   · rintro ⟨hGround, hSpan⟩ N hN
     exact ⟨hGround N hN, hSpan N hN⟩
+
+/-- The all-chain NNCPH ground-space condition is equivalently the all-chain
+nearest-neighbor commutation equations together with the source ground-space
+spanning clause.
+
+For \(N>2\), the zero-energy equation for \(V^{(N)}(B)\) follows from the
+parent-Hamiltonian construction, so it need not be assumed separately once the
+length-two commuting condition and Definition 3.9 spanning equation are given.
+
+See arXiv:1606.00608, Definition 3.9 and Theorem 3.10(iii). -/
+theorem hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning
+    {B : MPSTensor d D}
+    {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)} :
+    HasNNCPHGroundSpaces B A ↔
+      (∀ N : ℕ, 2 < N → IsNNCPH B N) ∧
+        HasParentHamiltonianGroundSpaceSpanning B 2 A := by
+  constructor
+  · intro h
+    exact
+      ⟨fun N hN => (h N hN).isNNCPH,
+        h.hasParentHamiltonianGroundSpaceSpanning⟩
+  · rintro ⟨hComm, hSpan⟩ N hN
+    exact ⟨(hComm N hN).isNNCPHGroundState (le_of_lt hN), hSpan N hN⟩
 
 /-- If each BNT vector is killed by the parent Hamiltonian, then their span is
 contained in the parent-Hamiltonian kernel.

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -280,9 +280,10 @@ theorem hasNNCPHGroundSpaces_iff_forall_isNNCPHGroundState_and_groundSpaceSpanni
 nearest-neighbor commutation equations together with the source ground-space
 spanning clause.
 
-For \(N>2\), the zero-energy equation for \(V^{(N)}(B)\) follows from the
-parent-Hamiltonian construction, so it need not be assumed separately once the
-length-two commuting condition and Definition 3.9 spanning equation are given.
+For \(N>2\), the zero-energy equation for \(V^{(N)}(B)\) is an unconditional
+consequence of the parent-Hamiltonian construction. It therefore need not be
+assumed separately; the remaining data are the length-two commuting condition
+and the Definition 3.9 spanning equation.
 
 See arXiv:1606.00608, Definition 3.9 and Theorem 3.10(iii). -/
 theorem hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning

--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -283,8 +283,8 @@ spanning clause.
 
 For \(N>2\), the zero-energy equation for \(V^{(N)}(B)\) is an unconditional
 consequence of the parent-Hamiltonian construction. It therefore need not be
-assumed separately; the remaining data are the length-two commuting condition
-and the spanning equation of arXiv:1606.00608, Definition 3.9.
+assumed separately; the remaining conditions are the length-two commuting
+condition and the spanning equation of arXiv:1606.00608, Definition 3.9.
 
 See arXiv:1606.00608, Definition 3.9 and Theorem 3.10(iii). -/
 theorem hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -165,7 +165,8 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     spanning condition above. This is precisely the condition named in
     Definition~\ref{def:has_nncph_ground_spaces}.
     Since the displayed zero-energy equation follows from the
-    parent-Hamiltonian construction for $N>2$, this is also equivalent to
+    parent-Hamiltonian construction for $N>2$, independently of the
+    commutation and spanning equations, this is also equivalent to
     asking for the length-$2$ commutation equations for every $N>2$ together
     with the same nearest-neighbor ground-space spanning condition.
 \end{remark}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -138,6 +138,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \lean{MPSTensor.HasNNCPHGroundSpaces.hasNNCPHGroundSpace}
     \lean{MPSTensor.HasNNCPHGroundSpaces.hasParentHamiltonianGroundSpaceSpanning}
     \lean{MPSTensor.hasNNCPHGroundSpaces_iff_forall_isNNCPHGroundState_and_groundSpaceSpanning}
+    \lean{MPSTensor.hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning}
     \lean{MPSTensor.IsCommutingParentHam.symm}
     \lean{MPSTensor.IsCommutingParentHam.ham_comm_localTerm}
     \leanok
@@ -163,6 +164,10 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     all-chain ground-vector equations and the nearest-neighbor instance of the
     spanning condition above. This is precisely the condition named in
     Definition~\ref{def:has_nncph_ground_spaces}.
+    Since the displayed zero-energy equation follows from the
+    parent-Hamiltonian construction for $N>2$, this is also equivalent to
+    asking for the length-$2$ commutation equations for every $N>2$ together
+    with the same nearest-neighbor ground-space spanning condition.
 \end{remark}
 
 \begin{lemma}[Zero-energy BNT vectors lie in the parent-Hamiltonian kernel]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -172,10 +172,10 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         &\forall N>2,\quad
         \left[
         \begin{array}{l}
-        h_i^{(N)}h_j^{(N)}=h_j^{(N)}h_i^{(N)}
-            \quad\text{for all } i,j,\\
-        h_i^{(N)}V^{(N)}(B)=0
-            \quad\text{for all } i,\\
+        \forall\, i,j,\quad
+        h_i^{(N)}h_j^{(N)}=h_j^{(N)}h_i^{(N)},\\
+        \forall\, i,\quad
+        h_i^{(N)}V^{(N)}(B)=0,\\
         \ker H_2^{(N)}(B)
             =
             \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
@@ -185,8 +185,8 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         \left[
         \begin{array}{l}
         \forall N>2,\quad
-        h_i^{(N)}h_j^{(N)}=h_j^{(N)}h_i^{(N)}
-            \quad\text{for all } i,j,\\
+        \forall\, i,j,\quad
+        h_i^{(N)}h_j^{(N)}=h_j^{(N)}h_i^{(N)},\\
         \forall N>2,\quad
         \ker H_2^{(N)}(B)
             =

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -166,9 +166,35 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     Definition~\ref{def:has_nncph_ground_spaces}.
     Since the displayed zero-energy equation follows from the
     parent-Hamiltonian construction for $N>2$, independently of the
-    commutation and spanning equations, this is also equivalent to
-    asking for the length-$2$ commutation equations for every $N>2$ together
-    with the same nearest-neighbor ground-space spanning condition.
+    commutation and spanning equations, this is equivalently
+    \[
+        \begin{aligned}
+        &\forall N>2,\quad
+        \left[
+        \begin{array}{l}
+        h_i^{(N)}h_j^{(N)}=h_j^{(N)}h_i^{(N)}
+            \quad\text{for all } i,j,\\
+        h_i^{(N)}V^{(N)}(B)=0
+            \quad\text{for all } i,\\
+        \ker H_2^{(N)}(B)
+            =
+            \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
+        \end{array}
+        \right]\\
+        &\qquad\Longleftrightarrow\qquad
+        \left[
+        \begin{array}{l}
+        \forall N>2,\quad
+        h_i^{(N)}h_j^{(N)}=h_j^{(N)}h_i^{(N)}
+            \quad\text{for all } i,j,\\
+        \forall N>2,\quad
+        \ker H_2^{(N)}(B)
+            =
+            \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
+        \end{array}
+        \right]
+        \end{aligned}
+    \]
 \end{remark}
 
 \begin{lemma}[Zero-energy BNT vectors lie in the parent-Hamiltonian kernel]


### PR DESCRIPTION
### Motivation

- Continues formalization of the pure-state RFP = ZCL = NNCPH equivalence (arXiv:1606.00608, `thm:main-MPS`), tracked in #2633.
- The all-chain condition `HasNNCPHGroundSpaces` lacked an axiom-free characterization tying it to the per-chain commutation and ground-space spanning data separately; this PR supplies that characterization.
- The blueprint remark in `ch13_parent_hamiltonian_commuting_gap.tex` is updated to record the new equivalence and to note that for chain lengths \(N > 2\) frustration-freeness follows from the parent-Hamiltonian construction.

### Description

- `TNLean/MPS/ParentHamiltonian/Commuting.lean`: adds `hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning`, an axiom-free biconditional. It states that `HasNNCPHGroundSpaces B A` holds if and only if `(∀ N > 2, IsNNCPH B N)` (all-chain length-two commutation) together with the Definition 3.9 ground-space spanning predicate. The reverse direction derives the zero-energy equation via `IsNNCPH.isNNCPHGroundState` rather than assuming it, so no new axioms are introduced.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: records the new theorem in the blueprint remark and notes that for \(N > 2\), commutation plus spanning is sufficient to match the full source condition.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.Commuting -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Lean CI (`lean_action_ci.yml`) validates the full build on push.

---
Addresses #2633

> [!NOTE]
> **Low Risk**
> Small additive formalization and blueprint sync; no axiom or API changes beyond a new equivalence theorem parallel to the existing ground-state unpacking.
>
> **Overview**
> Adds an axiom-free equivalence **`hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning`**: the all-chain `HasNNCPHGroundSpaces` condition is the same as **all-chain length-two commutation** (`∀ N > 2, IsNNCPH B N`) together with the **Definition 3.9 ground-space spanning** predicate. The reverse direction uses `IsNNCPH.isNNCPHGroundState` so the MPS zero-energy clause is derived rather than assumed when `N > 2`.
>
> The module doc and the parent-Hamiltonian blueprint remark are updated to cite the new theorem and to note that, for `N > 2`, frustration-freeness follows from the parent-Hamiltonian construction—so commutation plus spanning is enough to match the full source condition.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34210b97ca35dc50d7c31476000ec47a1ca18fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint sync only; no axiom or API changes beyond a new equivalence parallel to the existing ground-state unpacking.
> 
> **Overview**
> Adds an axiom-free equivalence **`hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning`**: the all-chain `HasNNCPHGroundSpaces` predicate matches **∀ N > 2, `IsNNCPH`** (length-two commutation only) together with **`HasParentHamiltonianGroundSpaceSpanning`**. The reverse direction rebuilds `HasNNCPHGroundSpace` via **`IsNNCPH.isNNCPHGroundState`**, so the MPS zero-energy clause is not assumed when N > 2.
> 
> The `Commuting.lean` module doc lists the new theorem. The blueprint remark in **`ch13_parent_hamiltonian_commuting_gap.tex`** links it and states the displayed biconditional: commutation plus spanning suffices in place of explicitly quantifying frustration-freeness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a74c4f3619e4ab2e1f28c9222a6780077049bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->