### PR TITLE
doc(MPS/Periodic/Overlap): correct off-diagonal equation reference

### DIFF
--- a/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
+++ b/TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean
@@ -22,7 +22,7 @@ projections fixed by the adjoint transfer map.
 ## References
 
 * [Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Appendix A]
-* [De las Cuevas–Cirac–Schuch–Pérez-García, arXiv:1708.00029, eq:Aoffdiag/eq:Auprop]
+* [De las Cuevas–Cirac–Schuch–Pérez-García, arXiv:1708.00029, eq:Aoffdiag]
 * [Wolf, *Quantum Channels & Operations*, Chapter 6]
 -/
 
@@ -180,8 +180,8 @@ shifted by the adjoint transfer map, `𝓔^*(P_{k+1}) = P_k`, the Kraus operator
 `P_{k+1} · A_i = A_i · P_k`.  Summing over the orthogonal grading then gives the
 off-diagonal reconstruction `A_i = ∑_u P_{u+1} · A_i · P_u`.  This is the
 single-site off-diagonal decomposition of a periodic block in arXiv:1708.00029,
-eq:Aoffdiag/eq:Auprop: the compressed-to-global bridge that the cyclic transport
-step contracts.
+eq:Aoffdiag, in inverse-indexed form: the compressed-to-global bridge that the
+cyclic transport step contracts.
 -/
 
 variable {m : ℕ}
@@ -192,7 +192,7 @@ If the orthogonal projections `P` are shifted by the adjoint transfer map,
 `𝓔^*(P_{k+1}) = P_k`, then each Kraus operator carries index `k` to `k+1`:
 `P_{k+1} · A_i = A_i · P_k`.  This is the single-site analogue of the
 fixed-projection commutation `commutes_letters_of_adjoint_fixed_projection`;
-see arXiv:1708.00029, eq:Auprop. -/
+see arXiv:1708.00029, eq:Aoffdiag, in inverse-indexed form. -/
 theorem offDiag_shift_of_adjoint_cyclic_shift [NeZero m]
     (A : MPSTensor d D)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlapNonrep.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlapNonrep.lean
@@ -52,7 +52,8 @@ same conclusion without the eigenspace-structure theorem:
   $\mathcal E_A^m(U)=U$) of trace zero ($\mathcal E_A$ is trace preserving), so
   `W = 0` by the trace-zero fixed-point vanishing lemma for irreducible transfer
   maps.
-* The single-site shift `P (k+1) * A i = A i * P k` (eq:Auprop) makes
+* The single-site shift `P (k+1) * A i = A i * P k` is the inverse-indexed form
+  of arXiv:1708.00029, eq:Aoffdiag; it makes
   $\mathcal E_A^t(U)$ supported on the `(u + t, v + t)` block, whence
   $P_u\mathcal E_A^t(U)P_v=0$ for $0<t<m$ and $P_uUP_v=U$ at $t=0$; therefore
   $U=P_uWP_v=0$. -/

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
@@ -121,8 +121,9 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
 /-- The single-site off-diagonal grading carried by a cyclic sector decomposition:
 each unblocked Kraus operator carries the cyclic projection index `k` to `k + 1`,
 P_{k+1} · A^i = A^i · P_k.  This is the single-site shift of arXiv:1708.00029,
-eq:Auprop, obtained from the cyclic relation 𝓔^*(P_{k+1}) = P_k stored in
-`IsCyclicSectorDecomp`. -/
+eq:Aoffdiag, in inverse-indexed form; the later eq:Auprop only defines the
+sector letters \(A_u^i = P_u A^i P_{u+1}\).  The relation used here is obtained
+from the cyclic relation 𝓔^*(P_{k+1}) = P_k stored in `IsCyclicSectorDecomp`. -/
 theorem IsCyclicSectorDecomp.offDiag_shift [NeZero D] [NeZero m]
     {A : MPSTensor d D} (hP : IsPeriodic m A) {dim : Fin m → ℕ}
     {blocks : (k : Fin m) → MPSTensor (blockPhysDim d m) (dim k)}


### PR DESCRIPTION
### Motivation

- Several docstrings incorrectly attributed the single-site cyclic shift
  $P_{k+1} \cdot A^i = A^i \cdot P_k$ to arXiv:1708.00029, eq:Auprop.
- The correct source is eq:Aoffdiag, in inverse-indexed form. The later eq:Auprop only defines the sector letters $A_u^i = P_u A^i P_{u+1}$.
- This keeps the canonical-form source lemma and the periodic-overlap consumers aligned with the paper notation used in Proposition 3.3 and Appendix A.

### Description

- `TNLean/MPS/CanonicalForm/CyclicSectors/FixedAdjoint.lean`: cite eq:Aoffdiag for the theorem deriving the single-site off-diagonal grading from the adjoint cyclic shift.
- `TNLean/MPS/Periodic/Overlap/SelfOverlapNonrep.lean`: cite eq:Aoffdiag in the proof-sketch step using the shift to control block support.
- `TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean`: cite eq:Aoffdiag for `IsCyclicSectorDecomp.offDiag_shift` and clarify the distinct role of eq:Auprop.
- No Lean declarations, proof terms, or type signatures are changed.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.CanonicalForm.CyclicSectors.FixedAdjoint TNLean.MPS.Periodic.Overlap.SelfOverlapSetup TNLean.MPS.Periodic.Overlap.SelfOverlapNonrep`

Addresses #81