### PR TITLE
refactor(Wielandt): share range-power injectivity lemma

### DIFF
--- a/TNLean/Wielandt/RankOne/BoundedWord.lean
+++ b/TNLean/Wielandt/RankOne/BoundedWord.lean
@@ -265,65 +265,6 @@ namespace WielandtRankOne
 
 open Module
 
-/-- Vector-level injectivity: if `v ∈ range (M^D)` and `M *ᵥ v = 0`, then `v = 0`.
-
-This is a direct consequence of `disjoint_ker_range_pow` for `Matrix.toLin' M`. -/
-lemma vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
-    (M : Matrix (Fin D) (Fin D) ℂ) {v : Fin D → ℂ}
-    (hv : v ∈ LinearMap.range (Matrix.toLin' (M ^ D)))
-    (hMv : M *ᵥ v = 0) : v = 0 := by
-  classical
-  -- Convert to the endomorphism formulation.
-  let f : End ℂ (Fin D → ℂ) := Matrix.toLin' M
-  have hdisj : Disjoint (LinearMap.ker f) (LinearMap.range (f ^ D)) :=
-    disjoint_ker_range_pow (D := D) (f := f)
-  have hv' : v ∈ LinearMap.range (f ^ D) := by
-    -- `Matrix.toLin' (M^D) = (Matrix.toLin' M)^D`.
-    simpa only [f, Matrix.toLin'_pow] using hv
-  have hker : v ∈ LinearMap.ker f := by
-    -- `M *ᵥ v = 0` means `f v = 0`.
-    refine LinearMap.mem_ker.mpr ?_
-    simpa only [f, Matrix.toLin'_apply] using hMv
-  -- Use disjointness: `ker f ⊓ range (f^D) = ⊥`.
-  have hinter : (LinearMap.ker f ⊓ LinearMap.range (f ^ D)) = ⊥ := hdisj.eq_bot
-  have hvInf : v ∈ (LinearMap.ker f ⊓ LinearMap.range (f ^ D)) := ⟨hker, hv'⟩
-  have : v ∈ (⊥ : Submodule ℂ (Fin D → ℂ)) := by
-    simpa only [hinter] using hvInf
-  simpa using this
-
-/-- Matrix-level injectivity on the range of left multiplication by `M^D`.
-
-If `X ∈ range (mulLeft (M^D))` and `M * X = 0`, then `X = 0`. -/
-lemma matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
-    (M : Matrix (Fin D) (Fin D) ℂ) {X : Matrix (Fin D) (Fin D) ℂ}
-    (hX : X ∈ LinearMap.range (LinearMap.mulLeft ℂ (M ^ D)))
-    (hMX : M * X = 0) : X = 0 := by
-  classical
-  -- Use the column characterization of `range (mulLeft _)`.
-  have hcols : ∀ j : Fin D, X.col j ∈ LinearMap.range (Matrix.toLin' (M ^ D)) := by
-    have := (mem_range_mulLeft_iff_cols (D := D) (P := M ^ D) (M := X)).1 hX
-    simpa using this
-  -- Each column is killed by `M`.
-  have hcol0 : ∀ j : Fin D, X.col j = 0 := by
-    intro j
-    have hcolKilled : M *ᵥ (X.col j) = 0 := by
-      have : (M * X).col j = 0 := by
-        have hzeroCol : (0 : Matrix (Fin D) (Fin D) ℂ).col j = (0 : Fin D → ℂ) := by
-          ext i
-          rfl
-        simpa [hzeroCol] using
-          congrArg (fun Z : Matrix (Fin D) (Fin D) ℂ => Z.col j) hMX
-      -- Rewrite the column as a matrix-vector product.
-      simpa [col_mul (P := M) (X := X) (j := j)] using this
-    exact vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow (D := D) M (hcols j) hcolKilled
-  -- If all columns are zero, the matrix is zero.
-  apply Matrix.ext_col
-  intro j
-  have hzero : (0 : Matrix (Fin D) (Fin D) ℂ).col j = (0 : Fin D → ℂ) := by
-    ext i
-    simp [Matrix.col_apply]
-  simp [hcol0 j, hzero]
-
 /-- Matrix-level injectivity on the range of right multiplication by `M^D`.
 
 If `X ∈ range (mulRight (M^D))` and `X * M = 0`, then `X = 0`.

--- a/TNLean/Wielandt/RankOne/SpanGrowth.lean
+++ b/TNLean/Wielandt/RankOne/SpanGrowth.lean
@@ -130,6 +130,65 @@ theorem isUnit_restrict_range_toLin'_pow (M : Matrix (Fin D) (Fin D) ℂ) :
   simpa [Matrix.toLin'_pow] using
     (isUnit_restrict_range_pow (D := D) (f := Matrix.toLin' M))
 
+/-! ## Pointwise matrix injectivity -/
+
+/-- Vector-level injectivity: if `v ∈ range (M^D)` and `M *ᵥ v = 0`, then `v = 0`.
+
+This is a direct consequence of `disjoint_ker_range_pow` for `Matrix.toLin' M`. -/
+theorem vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow
+    (M : Matrix (Fin D) (Fin D) ℂ) {v : Fin D → ℂ}
+    (hv : v ∈ LinearMap.range (Matrix.toLin' (M ^ D)))
+    (hMv : M *ᵥ v = 0) : v = 0 := by
+  classical
+  let f : End ℂ (Fin D → ℂ) := Matrix.toLin' M
+  have hdisj : Disjoint (LinearMap.ker f) (LinearMap.range (f ^ D)) :=
+    disjoint_ker_range_pow (D := D) (f := f)
+  have hv' : v ∈ LinearMap.range (f ^ D) := by
+    simpa only [f, Matrix.toLin'_pow] using hv
+  have hker : v ∈ LinearMap.ker f := by
+    refine LinearMap.mem_ker.mpr ?_
+    simpa only [f, Matrix.toLin'_apply] using hMv
+  have hinter : (LinearMap.ker f ⊓ LinearMap.range (f ^ D)) = ⊥ := hdisj.eq_bot
+  have hvInf : v ∈ (LinearMap.ker f ⊓ LinearMap.range (f ^ D)) := ⟨hker, hv'⟩
+  have : v ∈ (⊥ : Submodule ℂ (Fin D → ℂ)) := by
+    simpa only [hinter] using hvInf
+  simpa using this
+
+/-- Matrix-level injectivity on the range of left multiplication by `M^D`.
+
+If `X ∈ range (mulLeft (M^D))` and `M * X = 0`, then `X = 0`. -/
+theorem matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+    (M : Matrix (Fin D) (Fin D) ℂ) {X : Matrix (Fin D) (Fin D) ℂ}
+    (hX : X ∈ LinearMap.range (LinearMap.mulLeft ℂ (M ^ D)))
+    (hMX : M * X = 0) : X = 0 := by
+  classical
+  rcases (LinearMap.mem_range).1 hX with ⟨Y, rfl⟩
+  have hMY : M * ((M ^ D) * Y) = 0 := by
+    simpa only [LinearMap.mulLeft_apply] using hMX
+  have hcol0 : ∀ j : Fin D, ((M ^ D) * Y).col j = 0 := by
+    intro j
+    have hvRange :
+        ((M ^ D) * Y).col j ∈ LinearMap.range (Matrix.toLin' (M ^ D)) := by
+      refine (LinearMap.mem_range).2 ?_
+      refine ⟨Y.col j, ?_⟩
+      rw [Matrix.toLin'_apply]
+      ext i
+      simp [Matrix.mulVec, Matrix.col_apply, Matrix.mul_apply, dotProduct]
+    have hcolKilled : M *ᵥ (((M ^ D) * Y).col j) = 0 := by
+      have hcol :
+          (M * ((M ^ D) * Y)).col j = (0 : Matrix (Fin D) (Fin D) ℂ).col j := by
+        simpa using congrArg (fun Z : Matrix (Fin D) (Fin D) ℂ => Z.col j) hMY
+      ext i
+      simpa [Matrix.mulVec, Matrix.col_apply, Matrix.mul_apply, dotProduct] using
+        congrFun hcol i
+    exact vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow (D := D) M hvRange hcolKilled
+  apply Matrix.ext_col
+  intro j
+  have hzero : (0 : Matrix (Fin D) (Fin D) ℂ).col j = (0 : Fin D → ℂ) := by
+    ext i
+    rfl
+  simpa [hzero] using hcol0 j
+
 end WielandtRankOne
 
 end MPSTensor

--- a/TNLean/Wielandt/RectangularSpan/Growth.lean
+++ b/TNLean/Wielandt/RectangularSpan/Growth.lean
@@ -106,56 +106,10 @@ noncomputable def rectSpanLeftStep (n : ℕ) :
 
 /-! ### Injectivity of the left-step
 
-The proof uses the Fitting-decomposition disjointness: `ker(A i₀)` is disjoint from
-`range((A i₀)^D)`. Since every element of `rectSpan ((A i₀)^D) A n` lies in that range,
-left-multiplication by `A i₀` is injective on it. -/
-
-/-- Vector-level injectivity: if `v ∈ range((A i₀)^D)` and `(A i₀) *ᵥ v = 0`, then `v = 0`.
-
-This uses the Fitting-decomposition disjointness between `ker(f)` and `range(f^D)`. -/
-private theorem vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow'
-    {v : Fin D → ℂ}
-    (hv : v ∈ LinearMap.range (Matrix.toLin' ((A i₀) ^ D)))
-    (hMv : (A i₀) *ᵥ v = 0) : v = 0 := by
-  classical
-  let f : End ℂ (Fin D → ℂ) := Matrix.toLin' (A i₀)
-  have hdisj : Disjoint (LinearMap.ker f) (LinearMap.range (f ^ D)) :=
-    WielandtRankOne.disjoint_ker_range_pow (D := D) f
-  have hv' : v ∈ LinearMap.range (f ^ D) := by
-    simpa [f, Matrix.toLin'_pow] using hv
-  have hker : v ∈ LinearMap.ker f := by
-    refine LinearMap.mem_ker.mpr ?_
-    simpa [f, Matrix.toLin'_apply] using hMv
-  have hinter : (LinearMap.ker f ⊓ LinearMap.range (f ^ D)) = ⊥ := hdisj.eq_bot
-  have : v ∈ (⊥ : Submodule ℂ (Fin D → ℂ)) := hinter ▸ ⟨hker, hv'⟩
-  simpa using this
-
-/-- Matrix-level injectivity on the range of left multiplication by `(A i₀)^D`.
-
-If `X ∈ range(mulLeft ((A i₀)^D))` and `(A i₀) * X = 0`, then `X = 0`. -/
-theorem matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
-    {X : Matrix (Fin D) (Fin D) ℂ}
-    (hX : X ∈ LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D)))
-    (hMX : (A i₀) * X = 0) : X = 0 := by
-  classical
-  have hcols : ∀ j : Fin D, X.col j ∈ LinearMap.range (Matrix.toLin' ((A i₀) ^ D)) := by
-    have := (mem_range_mulLeft_iff_cols (D := D) (P := (A i₀) ^ D) (M := X)).1 hX
-    simpa using this
-  have hcol0 : ∀ j : Fin D, X.col j = 0 := by
-    intro j
-    have hcolKilled : (A i₀) *ᵥ (X.col j) = 0 := by
-      have : ((A i₀) * X).col j = 0 := by
-        have hzero : (0 : Matrix (Fin D) (Fin D) ℂ).col j = (0 : Fin D → ℂ) := by
-          ext i
-          simp [Matrix.col_apply]
-        simpa [hzero] using congrArg (fun Z : Matrix (Fin D) (Fin D) ℂ => Z.col j) hMX
-      simpa [col_mul (P := A i₀) (X := X) (j := j)] using this
-    exact vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow' A i₀ (hcols j) hcolKilled
-  apply Matrix.ext_col
-  intro j
-  have hzero : (0 : Matrix (Fin D) (Fin D) ℂ).col j = (0 : Fin D → ℂ) := by
-    ext i; simp [Matrix.col_apply]
-  simp [hcol0 j, hzero]
+The proof uses the shared Fitting-decomposition consequence
+`WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow`: every element of
+`rectSpan ((A i₀)^D) A n` lies in `range (mulLeft ((A i₀)^D))`, where left-multiplication
+by `A i₀` is injective. -/
 
 /-- **The left-step map is injective**: multiplication by `A i₀` is injective on
 `rectSpan ((A i₀)^D) A n`, because every element lies in the range of `mulLeft ((A i₀)^D)`
@@ -175,7 +129,8 @@ theorem rectSpanLeftStep_injective (n : ℕ) :
       (hrect_le_range x.2)
       (hrect_le_range y.2)
   have hzero : x.1 - y.1 = 0 :=
-    matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow A i₀ hzRange hz
+    WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+      (D := D) (M := A i₀) (X := x.1 - y.1) hzRange hz
   exact Subtype.ext (by simpa [sub_eq_zero] using hzero)
 
 /-- Finrank is non-decreasing along the sequence

--- a/TNLean/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
+++ b/TNLean/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean
@@ -75,8 +75,8 @@ theorem mulLeft_mem_rectSpan_nilpIndex_succ
 and `(A i₀) * X = 0`, then `X = 0`.
 
 Proof: `range(mulLeft ((A i₀)^r)) = range(mulLeft ((A i₀)^D))` by
-`range_mulLeft_pow_nilpIndex_eq`, and the D-th power version is already proved
-in `RectSpanGrowth`. -/
+`range_mulLeft_pow_nilpIndex_eq`, and the D-th power version is the shared
+Fitting-disjointness consequence from `WielandtRankOne`. -/
 private theorem matrix_eq_zero_of_mul_nilpIndex
     (A : MPSTensor d D) (i₀ : Fin d)
     {X : Matrix (Fin D) (Fin D) ℂ}
@@ -85,8 +85,8 @@ private theorem matrix_eq_zero_of_mul_nilpIndex
     (hMX : (A i₀) * X = 0) : X = 0 := by
   have hXD : X ∈ LinearMap.range (LinearMap.mulLeft ℂ ((A i₀) ^ D)) :=
     range_mulLeft_pow_nilpIndex_eq A i₀ ▸ hX
-  exact RectSpanGrowth.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
-    A i₀ hXD hMX
+  exact WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow
+    (D := D) (M := A i₀) (X := X) hXD hMX
 
 /-- Linear map sending `rectSpan ((A i₀)^r) A n` to `rectSpan ((A i₀)^r) A (n+1)`
 by left-multiplication with `A i₀`, where `r = nilpIndex`. -/

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -186,6 +186,11 @@ The clearest replacements are:
 - The two private Kraus zero-padding sum lemmas are replaced by the shared
   `Fin.sum_castLE_extend_zero`, proved from Mathlib's `Fin.castLEquiv` and the
   standard subtype/filter finite-sum identities.
+- The two Fitting-disjointness consequences for left multiplication by `M^D`
+  in the rank-one and rectangular-span Wielandt files have been consolidated.
+  The vector and matrix injectivity statements now live once in
+  `TNLean.Wielandt.RankOne.SpanGrowth`, and the rectangular-span proof calls
+  that shared statement directly.
 
 There are also important non-replacements.
 
@@ -2126,6 +2131,34 @@ Focused check:
 lake build TNLean.Algebra.FinSum \
   TNLean.Channel.KrausRank \
   TNLean.Channel.KrausFreedom -q --log-level=info
+```
+
+## Wielandt range-power injectivity consolidation, 2026-06-21
+
+`TNLean/Wielandt/RankOne/BoundedWord.lean` and
+`TNLean/Wielandt/RectangularSpan/Growth.lean` both proved the same consequence
+of the Fitting disjointness theorem: if
+`X ∈ range (LinearMap.mulLeft ℂ (M ^ D))` and `M * X = 0`, then `X = 0`.
+The rectangular-span file also carried a private vector form of the same
+argument.
+
+The shared vector statement
+`WielandtRankOne.vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow` and the shared
+matrix statement
+`WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow` now
+live in `TNLean.Wielandt.RankOne.SpanGrowth`, next to
+`WielandtRankOne.disjoint_ker_range_pow`.  The bi-rectangular and rectangular
+growth arguments use this single source.  This is not a new Mathlib 4.31
+replacement, but it removes a duplicated local proof layer exposed during the
+Mathlib-replacement pass.
+
+Focused check:
+
+```bash
+lake build TNLean.Wielandt.RankOne.SpanGrowth \
+  TNLean.Wielandt.RankOne.BoundedWord \
+  TNLean.Wielandt.RectangularSpan.Growth \
+  TNLean.Wielandt.RectangularSpan.UniversalityAux.NilpIndex -q
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- `BoundedWord.lean` and `RectangularSpan/Growth.lean` both carried private proofs of the same Fitting-disjointness consequence: if `X ∈ range (LinearMap.mulLeft ℂ (M ^ D))` and either `M * X = 0` (matrix form) or `M *ᵥ X = 0` (vector form), then `X = 0`. The duplication was exposed during the Mathlib 4.31 replacement pass.
- Consolidating these into `SpanGrowth.lean`, adjacent to the existing `WielandtRankOne.disjoint_ker_range_pow`, removes redundant proof maintenance and makes the shared mathematical fact explicit.

### Description

- `TNLean/Wielandt/RankOne/SpanGrowth.lean`: added `WielandtRankOne.vec_eq_zero_of_mulVec_eq_zero_of_mem_range_pow` (vector form) and `WielandtRankOne.matrix_eq_zero_of_mul_eq_zero_of_mem_range_mulLeft_pow` (matrix form) as shared lemmas next to `WielandtRankOne.disjoint_ker_range_pow` (+59 lines).
- `TNLean/Wielandt/RankOne/BoundedWord.lean`: removed duplicate private proofs of the above (−59 lines); replaced by calls to the shared lemmas in `SpanGrowth`.
- `TNLean/Wielandt/RectangularSpan/Growth.lean`: removed duplicate private proofs of both forms (−51 lines); now calls the shared lemmas from `SpanGrowth` (+6 lines for import/call sites).
- `TNLean/Wielandt/RectangularSpan/UniversalityAux/NilpIndex.lean`: updated call sites to match the renamed shared lemmas (+4/−4 lines).
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records this consolidation as a local duplication cleanup found during the Mathlib 4.31 replacement pass (not a new Mathlib theorem replacement).

### Testing

- `lake build TNLean.Wielandt.RankOne.SpanGrowth TNLean.Wielandt.RankOne.BoundedWord TNLean.Wielandt.RectangularSpan.Growth TNLean.Wielandt.RectangularSpan.UniversalityAux.NilpIndex -q` passes; pre-existing style-header and module-doc warnings in imported files are unrelated to this change.
- `rg -n "\bsorry\b|\baxiom\b|native_decide|unsafeCast|admit"` returns no matches in the four changed Lean files.
- Relies on Lean CI (`lean_action_ci.yml`) for full build validation.

---
<!-- No linked issue found. Author should add `Addresses #N` once the relevant tracking issue is identified. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 620cab45f2d0399fb20e366cd56c8af3d937bf3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->