### PR TITLE
feat(MPS/ParentHamiltonian): expose trace boundary comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -213,10 +213,11 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-discharge the currently assumed
-trace-decomposition equality. -/
+derive the source boundary-condition comparison for \(C^j\), the specialized
+matrices \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\), and the auxiliary
+\(E^j\)-identities from arXiv:quant-ph/0608197, Theorem 12, proof lines
+1446--1456; then use it to discharge the currently assumed trace-decomposition
+equality. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -365,10 +366,11 @@ which transitively uses the boundary-condition comparison at boundary-crossing
 windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
 2126--2128. Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
-derive the \(C^j,D^j,E^j\) boundary-condition comparison from
-arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
-discharge the currently assumed
-trace-decomposition equality. -/
+derive the source boundary-condition comparison for \(C^j\), the specialized
+matrices \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\), and the auxiliary
+\(E^j\)-identities from arXiv:quant-ph/0608197, Theorem 12, proof lines
+1446--1456; then use it to discharge the currently assumed trace-decomposition
+equality. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -110,6 +110,78 @@ theorem
     _ = evalWord (A j) (List.ofFn β) *
         (E * evalWord (A j) (List.ofFn ρ)) := by rw [Matrix.mul_assoc]
 
+/-- Source trace decompositions and an explicit block-diagonal boundary
+representation give periodic single-block states.
+
+Assume the vector has already been written with block-diagonal boundary
+conditions \(X_j\). If, for those boundary conditions, the boundary-crossing
+trace decompositions of arXiv:quant-ph/0608197, Theorem 12, proof lines
+1436--1456 hold at a simultaneous product-spanning middle-word length, then the
+trace comparison gives
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
+\]
+for every block \(j\). In the notation of the source proof, the boundary matrix
+\(D^j_\beta\) has already been specialized to \((\mu_j^NX_j)A^j_\beta\).
+
+This is the explicit-boundary form of the block-diagonal boundary-condition
+step in arXiv:2011.12127, Section IV.C, lines 2126--2128. It does not use the
+simultaneous block-word span at the short boundary-crossing tail length \(N-i\);
+the only span hypothesis is the middle-word product span used to separate the
+trace decompositions.
+
+**Scope restriction (boundary representation and trace decomposition):** The
+block-diagonal boundary representation of \(\psi\) and the displayed trace
+decompositions are hypotheses here. Removing these remaining inputs is tracked
+in issue 2971 and documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    {m L₀ L N : ℕ}
+    (hTraceSpan : WordTupleSpanTop A m)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hN : 0 < N) (hLN : L ≤ N)
+    (hNlarge : L + L₀ ≤ N)
+    {ψ : NSiteSpace d N}
+    (hBoundary :
+      ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)))
+    (hTrace :
+      ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+          ∃ C : ∀ (j : Fin r) (_ : Fin N),
+            (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+            ∀ i : Fin N,
+              N < i.val + L →
+                ∀ ρ : Fin (N - L) → Fin d,
+                  ∀ β : Fin (i.val + L - N) → Fin d,
+                    ∀ w : Fin m → Fin d,
+                      (∑ j : Fin r,
+                        Matrix.trace
+                          ((evalWord (A j) (List.ofFn β) * C j i ρ) *
+                            evalWord (A j) (List.ofFn w))) =
+                      (∑ j : Fin r,
+                        Matrix.trace
+                          ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                              evalWord (A j) (List.ofFn ρ)) *
+                            evalWord (A j) (List.ofFn w)))) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  classical
+  obtain ⟨X, hψX⟩ := hBoundary
+  obtain ⟨C, hCoeff⟩ := hTrace X hψX
+  refine ⟨X, hψX, ?_⟩
+  exact
+    blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
+      μ A hN hLN X hTraceSpan hBlk hUnital hNlarge C hCoeff
+
 /-- Source trace decompositions upgrade a block-diagonal boundary representation
 to periodic single-block states.
 
@@ -194,11 +266,9 @@ theorem
   obtain ⟨X, hψX, _hOpen⟩ :=
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange hψ
-  obtain ⟨C, hCoeff⟩ := hTrace X hψX
-  refine ⟨X, hψX, ?_⟩
   exact
-    blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
-      μ A hN hLN X hTraceSpan hBlk hUnital hNlarge C hCoeff
+    exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary
+      μ A hTraceSpan hBlk hUnital hN hLN hNlarge ⟨X, hψX⟩ hTrace
 
 /-- BNT normalization gives the common middle-word product span.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -594,8 +594,8 @@ in both cases.
         \rho=\tau_a\cdots\tau_{i-1},\qquad
         \alpha=\sigma_0\cdots\sigma_{N-i-1}.
     \]
-    These are the formal cut-adapted word coordinates used to compare with
-    the source decompositions involving $C^j_{i_1}$ and $D^j_{i_{m+1}}$.
+    These are the cut-adapted word coordinates used to compare with the source
+    decompositions involving $C^j_{i_1}$ and $D^j_{i_{m+1}}$.
     If
     \[
         \sum_j
@@ -1360,12 +1360,60 @@ in both cases.
     which gives the periodic-boundary constraint for each block.
 \end{proof}
 
+\begin{lemma}[Trace decompositions with a block-diagonal boundary representation]
+    \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary}
+    \leanok
+    \uses{lem:block_diagonal_boundary_component_trace_decomposition_injective}
+    Assume $0<N$, $L\le N$, and $L+L_0\le N$. Suppose each block $A_j$
+    is $L_0$-block-injective and satisfies
+    \[
+        \sum_a A^j_aA^{j\dagger}_a=I .
+    \]
+    Assume also that the simultaneous tuples $w\mapsto(A^1_w,\ldots,A^g_w)$
+    at the middle-word length $m$ span the full product algebra
+    $\prod_j\MN{D_j}$. Let
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    for some block-diagonal boundary conditions $X_j$. Suppose that whenever
+    $\psi$ has such a representation, there are matrices $C^j_{i,\rho}$
+    such that, for every boundary-crossing interval $i$, every outside word
+    $\rho$ of length $N-L$, every word $\beta$ of length $i+L-N$ before the
+    cut, and every word $w$ of length $m$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    Then there are block-diagonal boundary conditions $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_component_trace_decomposition_injective}
+    Choose a block-diagonal boundary representation of $\psi$. For that
+    representation, the trace-decomposition comparison supplies the matrices
+    $C^j_{i,\rho}$. Applying
+    Lemma~\ref{lem:block_diagonal_boundary_component_trace_decomposition_injective}
+    gives the desired containment
+    $\Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)$ for every block $j$.
+\end{proof}
+
 \begin{lemma}[Trace-decomposition comparisons give periodic-boundary single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1}
     \leanok
     \uses{lem:bnt_block_diagonal_open_boundary_matrices,
-        lem:block_diagonal_boundary_component_trace_decomposition_injective}
+        lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices}, assume in
     addition that $L+L_0\le N$. Assume also that, for some middle-word length
@@ -1402,17 +1450,15 @@ in both cases.
 \begin{proof}
     \leanok
     \uses{lem:bnt_block_diagonal_open_boundary_matrices,
-        lem:block_diagonal_boundary_component_trace_decomposition_injective}
+        lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
     By Lemma~\ref{lem:bnt_block_diagonal_open_boundary_matrices} there are
     matrices $X_j$ with
     \[
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
     \]
-    For this representation, the assumed trace-decomposition comparison gives
-    matrices $C^j_{i,\rho}$; here the source matrix $D^j_\beta$ has already
-    been specialized to $(\mu_j^NX_j)A^j_\beta$.
-    Lemma~\ref{lem:block_diagonal_boundary_component_trace_decomposition_injective}
-    then gives, for every $j$,
+    Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
+    applies to this representation and the assumed trace-decomposition
+    comparison. Thus, for every $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
     \]

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -474,6 +474,15 @@ then
 \end{align}
 for every block $j$ in the block-injective range.\footnote{Lean declaration:
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}.}
+There is also an explicit-boundary version: once
+\(\psi=\Gamma_N^{\widehat A}(\bigoplus_jX_j)\) is fixed, the same
+trace-decomposition comparison gives
+\begin{align}
+  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j)
+\end{align}
+for every block \(j\), without using any span assumption at the short
+boundary-crossing tail length \(N-i\).\footnote{Lean declaration:
+\leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary}.}
 
 In the normalized BNT finite range, this common middle-word span is no longer an
 external assumption. If


### PR DESCRIPTION
### Motivation

- Issue #2971 tracks removal of the external comparison hypotheses from the block-diagonal parent-Hamiltonian reductions. The source comparison is in arXiv:quant-ph/0608197, Theorem 12, proof lines 1446–1456, and arXiv:2011.12127, Section IV.C, lines 2126–2128.
- Factoring the explicit-boundary step into a standalone lemma removes the inline proof obligation from the BNT theorem and makes the step available for reuse within the parent-Hamiltonian argument.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`: adds a new lemma showing that each periodic component Γ_N^{A_j}(μ_j^N X_j) lies in the chain ground space G_{N,L}(A_j), given block-diagonal X_j, middle-word product span, and boundary-crossing trace equalities, without requiring a span hypothesis at length N − i. The BNT theorem `exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1` is updated to apply this lemma.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex`: adds the blueprint entry for the new lemma `block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary` and updates the BNT trace-decomposition entry to reference it.
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: records the new Lean entry; the block-diagonal boundary representation and trace comparison remain as open hypotheses (see #2971).

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`

---
Refs #2971

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof refactor and documentation only; no runtime, auth, or data-path changes, and mathematical conclusions are unchanged aside from clearer factoring.
> 
> **Overview**
> Factors the **trace-decomposition → periodic single-block** step into a reusable lemma when \(\psi\) is already written with block-diagonal boundary matrices \(X_j\), so the BNT theorem no longer inlines that argument.
> 
> The new Lean theorem `exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary` assumes an explicit boundary representation plus middle-word product span and boundary-crossing trace equalities (with \(D^j_\beta\) specialized to \((\mu_j^N X_j)A^j_\beta\)), and concludes \(\Gamma_N^{A_j}(\mu_j^N X_j) \in \mathcal G_{N,L}(A_j)\) for each block **without** a span hypothesis at the short tail length \(N-i\). `exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1` now obtains \(X_j\) from the existing BNT boundary lemma and delegates to this factor.
> 
> The blueprint adds matching lemma `block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary` and rewires the BNT trace-decomposition proof to cite it. The paper-gap note records the explicit-boundary Lean entry; boundary representation and trace comparison remain open (#2971).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c2a3e36cb6ca3f273e27083a4ff9e37645018f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->