### PR TITLE
refactor(Algebra): use native matrix dot-product adjoint

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -5,11 +5,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.Analysis.Matrix.PosDef
 
 /-!
-# Hermitian matrix extremal eigenvalues and adjoint identities
+# Hermitian matrix extremal eigenvalues
 
 This file provides lemmas for Hermitian complex matrices over `Fin D`: the
-extremal eigenvalue lemmas, scalar-shift spectral formulae, and the adjoint
-identity for the matrix-vector dot-product pairing.
+extremal eigenvalue lemmas and scalar-shift spectral formulae.
 -/
 
 open scoped Matrix ComplexOrder
@@ -140,14 +139,3 @@ theorem smul_one_sub_hermitian_spectral
           congr 1
           ext i
           simp [Complex.ofReal_sub]
-
-namespace HermitianHelpers
-
-/-- Adjoint identity for the matrix-vector dot-product pairing. -/
-theorem dotProduct_mulVec_conjTranspose
-    {m n : ℕ} (M : Matrix (Fin m) (Fin n) ℂ) (x : Fin m → ℂ) (y : Fin n → ℂ) :
-    star x ⬝ᵥ (M *ᵥ y) = star (Mᴴ *ᵥ x) ⬝ᵥ y := by
-  rw [Matrix.dotProduct_mulVec, Matrix.star_mulVec,
-    Matrix.conjTranspose_conjTranspose]
-
-end HermitianHelpers

--- a/TNLean/Channel/Irreducible/Growth/OneStep.lean
+++ b/TNLean/Channel/Irreducible/Growth/OneStep.lean
@@ -2,7 +2,6 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Schwarz.Basic
 import Mathlib.Tactic.NoncommRing

--- a/TNLean/Channel/Irreducible/Growth/OneStep.lean
+++ b/TNLean/Channel/Irreducible/Growth/OneStep.lean
@@ -78,7 +78,8 @@ theorem posDef_of_ker_subset_irreducible_cp
       congr 1; ext j
       have : (K j * A * (K j)ᴴ) *ᵥ v = K j *ᵥ (A *ᵥ ((K j)ᴴ *ᵥ v)) := by
         simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]
-      rw [this, HermitianHelpers.dotProduct_mulVec_conjTranspose]
+      rw [this, Matrix.dotProduct_mulVec, Matrix.star_mulVec,
+        Matrix.conjTranspose_conjTranspose]
     have h_each : ∀ j : Fin r,
         star ((K j)ᴴ *ᵥ v) ⬝ᵥ (A *ᵥ ((K j)ᴴ *ᵥ v)) = 0 := by
       intro j

--- a/TNLean/Channel/Spectral/Support.lean
+++ b/TNLean/Channel/Spectral/Support.lean
@@ -87,7 +87,8 @@ theorem compression_on_support_posDef
   have h_quadform : star w ⬝ᵥ ((V * ρ * Vᴴ) *ᵥ w) = star u ⬝ᵥ (ρ *ᵥ u) := by
     have h1 : (V * ρ * Vᴴ) *ᵥ w = V *ᵥ (ρ *ᵥ u) := by
       simp [u, Matrix.mulVec_mulVec, Matrix.mul_assoc]
-    rw [h1, HermitianHelpers.dotProduct_mulVec_conjTranspose (M := V)]
+    rw [h1, Matrix.dotProduct_mulVec, Matrix.star_mulVec,
+      Matrix.conjTranspose_conjTranspose]
   rw [h_quadform]
   -- Apply the pointwise strict positivity lemma.
   exact hρ.dotProduct_mulVec_pos_of_supportProj_fixed hu_ne hPu

--- a/TNLean/MPS/Irreducible/FixedPointProjection.lean
+++ b/TNLean/MPS/Irreducible/FixedPointProjection.lean
@@ -253,10 +253,11 @@ private lemma ker_invariant_under_adjoint
     rw [dotProduct_sum]
     congr 1
     ext i
-    -- reassociate and use the adjoint identity
+    -- Reassociate the products and move the left factor across the dot product.
     have : (A i * ρ * (A i)ᴴ) *ᵥ x = A i *ᵥ (ρ *ᵥ ((A i)ᴴ *ᵥ x)) := by
       simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]
-    rw [this, HermitianHelpers.dotProduct_mulVec_conjTranspose]
+    rw [this, Matrix.dotProduct_mulVec, Matrix.star_mulVec,
+      Matrix.conjTranspose_conjTranspose]
   have h_each_zero : ∀ i : Fin d,
       star ((A i)ᴴ *ᵥ x) ⬝ᵥ (ρ *ᵥ ((A i)ᴴ *ᵥ x)) = 0 := by
     intro i

--- a/TNLean/QPF/PosDef.lean
+++ b/TNLean/QPF/PosDef.lean
@@ -3,13 +3,11 @@ Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 -- Keep these dependencies explicit here for readability:
--- • `TNLean.Algebra.HermitianHelpers` for shared spectral decomposition helpers
 -- • `TNLean.Channel.Basic` for positive-definiteness results
 -- • `TNLean.Channel.Irreducible.Basic` for irreducibility/projection lemmas
 -- The channel imports are already transitively available through
 -- `TNLean.MPS.CPPrimitive`, but listing them directly makes the local proof
 -- dependencies explicit.
-import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.Irreducible.Basic
 import TNLean.Channel.Basic
 import TNLean.MPS.Core.CPPrimitive

--- a/TNLean/QPF/PosDef.lean
+++ b/TNLean/QPF/PosDef.lean
@@ -72,7 +72,8 @@ private lemma ker_invariant_under_adjoint
     congr 1; ext i
     rw [show (A i * ρ * (A i)ᴴ) *ᵥ x = A i *ᵥ (ρ *ᵥ ((A i)ᴴ *ᵥ x)) from by
       simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]]
-    rw [HermitianHelpers.dotProduct_mulVec_conjTranspose]
+    rw [Matrix.dotProduct_mulVec, Matrix.star_mulVec,
+      Matrix.conjTranspose_conjTranspose]
   have h_each_zero : ∀ i : Fin d,
       star ((A i)ᴴ *ᵥ x) ⬝ᵥ (ρ *ᵥ ((A i)ᴴ *ᵥ x)) = 0 := by
     intro i

--- a/TNLean/QPF/Uniqueness.lean
+++ b/TNLean/QPF/Uniqueness.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Algebra.HermitianHelpers
 import TNLean.QPF.PosDef
 
 /-!

--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -188,10 +188,10 @@ private theorem eq_zero_of_trace_conjTranspose_mul_posDef_mul_eq_zero
       star (B *ᵥ Pi.single j 1) ⬝ᵥ ρ.mulVec (B *ᵥ Pi.single j 1)
           = star (Pi.single j (1 : ℂ)) ⬝ᵥ
               Bᴴ *ᵥ (ρ *ᵥ (B *ᵥ Pi.single j 1)) := by
-                simpa [Matrix.conjTranspose_conjTranspose] using
-                  (HermitianHelpers.dotProduct_mulVec_conjTranspose (M := Bᴴ)
-                    (x := Pi.single j (1 : ℂ))
-                    (y := ρ *ᵥ (B *ᵥ Pi.single j 1))).symm
+                rw [Matrix.dotProduct_mulVec, Matrix.star_mulVec]
+                conv_rhs =>
+                  rw [Matrix.dotProduct_mulVec]
+                  rw [Matrix.dotProduct_mulVec]
       _ = star (Pi.single j (1 : ℂ)) ⬝ᵥ
             (Bᴴ * ρ * B).mulVec (Pi.single j 1) := by
               rw [hvec]

--- a/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
+++ b/TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean
@@ -3,7 +3,6 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
-import TNLean.Algebra.HermitianHelpers
 import TNLean.Spectral.MixedTransfer
 import TNLean.Spectral.TraceExpansion
 import TNLean.Wielandt.Primitivity.PrimitiveBridge

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -191,6 +191,11 @@ The clearest replacements are:
   The vector and matrix injectivity statements now live once in
   `TNLean.Wielandt.RankOne.SpanGrowth`, and the rectangular-span proof calls
   that shared statement directly.
+- The adjoint identity for the matrix-vector dot-product pairing was removed
+  from `TNLean.Algebra.HermitianHelpers`.  Its call sites now invoke Mathlib's
+  `Matrix.dotProduct_mulVec`, `Matrix.star_mulVec`, and
+  `Matrix.conjTranspose_conjTranspose` directly, with local right-hand-side
+  rewrites where the proof needs the fully associated vector-matrix product.
 
 There are also important non-replacements.
 
@@ -483,6 +488,18 @@ Recommended action:
 - Prefer local one-line invocations of `Matrix.IsHermitian.spectral_theorem`
   over shared pass-through lemmas for the shaped spectral decomposition.
 - Do not add new local aliases for elementary unitary identities.
+
+Applied dot-product follow-up:
+
+- The local theorem `HermitianHelpers.dotProduct_mulVec_conjTranspose` was
+  removed from `TNLean/Algebra/HermitianHelpers.lean`.  It was an exact
+  pass-through proof by Mathlib's `Matrix.dotProduct_mulVec`,
+  `Matrix.star_mulVec`, and `Matrix.conjTranspose_conjTranspose`.
+- The affected support, fixed-point projection, QPF, irreducibility-growth, and
+  Wielandt primitivity proofs now perform those rewrites at the proof sites.
+  The last of these also uses a local right-hand-side conversion to associate
+  the vector-matrix products in the same order as the positive-definite
+  quadratic-form argument.
 
 ### Determinants, kernels, and characteristic polynomials
 


### PR DESCRIPTION
### Motivation

- `HermitianHelpers.dotProduct_mulVec_conjTranspose` in `TNLean/Algebra/HermitianHelpers.lean`
  was a pass-through reformulation of three Mathlib identities (`Matrix.dotProduct_mulVec`,
  `Matrix.star_mulVec`, `Matrix.conjTranspose_conjTranspose`) that added no mathematical content
  beyond the Mathlib statements.
- Removing it continues the Mathlib 4.31 replacement audit
  (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`), which identified this helper as
  one of the remaining exact pass-through layers.

### Description

- `TNLean/Algebra/HermitianHelpers.lean`: removes `HermitianHelpers.dotProduct_mulVec_conjTranspose`
  and the enclosing `HermitianHelpers` namespace block; the module docstring no longer advertises
  the adjoint dot-product identity.
- `TNLean/Channel/Irreducible/Growth/OneStep.lean`, `TNLean/Channel/Spectral/Support.lean`,
  `TNLean/MPS/Irreducible/FixedPointProjection.lean`, `TNLean/QPF/PosDef.lean`: each proof now
  rewrites using `Matrix.dotProduct_mulVec`, `Matrix.star_mulVec`, and
  `Matrix.conjTranspose_conjTranspose` from Mathlib directly.
- `TNLean/Wielandt/Primitivity/StronglyIrreducibleToFullRank.lean`: uses the same Mathlib
  identities with a `conv_rhs` rewrite to associate vector–matrix products in the order required
  by the positive-definite quadratic-form argument.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records this removal as part of
  the Mathlib 4.31 batch.
- No mathematical content changes; all affected proofs establish the same results.

### Testing

- `lake build TNLean.Algebra.HermitianHelpers TNLean.Channel.Spectral.Support TNLean.MPS.Irreducible.FixedPointProjection TNLean.QPF.PosDef TNLean.Channel.Irreducible.Growth.OneStep TNLean.Wielandt.Primitivity.StronglyIrreducibleToFullRank -q`
- `git diff --check`
- `rg -n "dotProduct_mulVec_conjTranspose|namespace HermitianHelpers|HermitianHelpers\." TNLean -g'*.lean'` (confirms all references removed)
- `rg -n "\bsorry\b|\baxiom\b|native_decide|unsafeCast|admit"` on the changed Lean files (no new instances)
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
No linked issue found — author should link one manually if a tracking issue exists.

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or runtime behavior change; mathematical content is unchanged aside from inlined Mathlib identities.
>
> **Overview**
> This PR drops another Mathlib 4.31 pass-through layer: **`HermitianHelpers.dotProduct_mulVec_conjTranspose`** and its `HermitianHelpers` namespace block are removed from `TNLean/Algebra/HermitianHelpers.lean`, and that file's module doc no longer advertises the adjoint dot-product identity.
>
> **Five proofs** that relied on the helper now rewrite locally with **`Matrix.dotProduct_mulVec`**, **`Matrix.star_mulVec`**, and **`Matrix.conjTranspose_conjTranspose`**: channel irreducible growth (`OneStep`), spectral support compression, MPS fixed-point projection, QPF positive definiteness, and Wielandt strong-irreducibility primitivity. The Wielandt step adds a **`conv_rhs`** chain so vector–matrix products associate the way the positive-definite quadratic-form argument needs.
>
> The Mathlib 4.31 replacement audit documents this batch.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433fc14c9c480ffd0709f4891ed2d4f6a475e505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged statements; risk is limited to Lean elaboration at the inlined rewrite sites, not runtime or security-sensitive behavior.
> 
> **Overview**
> This PR continues the Mathlib 4.31 replacement audit by **dropping** `HermitianHelpers.dotProduct_mulVec_conjTranspose` and the `HermitianHelpers` namespace from `TNLean/Algebra/HermitianHelpers.lean`; that module now documents only extremal eigenvalue / scalar-shift spectral lemmas.
> 
> **Five proofs** that moved Kraus or compression terms across a dot product now rewrite locally with **`Matrix.dotProduct_mulVec`**, **`Matrix.star_mulVec`**, and **`Matrix.conjTranspose_conjTranspose`**: channel irreducible growth (`OneStep`), spectral support compression, MPS fixed-point projection, QPF positive definiteness, and Wielandt strong-irreducibility primitivity. The Wielandt step adds a **`conv_rhs`** chain so vector–matrix products associate the way the positive-definite quadratic-form argument needs.
> 
> Imports are trimmed where the helper was the only reason to pull in `HermitianHelpers` (`OneStep`, `PosDef`, `StronglyIrreducibleToFullRank`); **`TNLean/QPF/Uniqueness.lean`** now imports `HermitianHelpers` directly for spectral-shift lemmas. The audit doc records this batch. **No theorem statements or mathematical conclusions change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ea913311af533993920c9ac74144f416f06f1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->