### PR TITLE
refactor(PEPS): use native nonzero matrix facts

### DIFF
--- a/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
@@ -58,14 +58,6 @@ variable {d D n : ℕ}
 
 /-! ### Spanning helpers -/
 
-/-- A nonzero-size identity matrix is nonzero. -/
-private theorem matrix_one_ne_zero' (hD : 0 < D) :
-    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
-  intro h
-  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
-  rw [Matrix.one_apply_eq] at hentry
-  exact one_ne_zero hentry
-
 /-- Right multiplication by an invertible matrix preserves spanning. -/
 private theorem span_range_mul_right_unit {ι : Type*}
     {W : ι → Matrix (Fin D) (Fin D) ℂ}
@@ -185,7 +177,8 @@ private theorem exists_arcEval_ne_zero [NeZero n] {A : MPSChainTensor d D n}
       (Set.range fun ρ : Fin m → Fin d => arcEval A s (List.ofFn ρ)) :=
     hspan ▸ Submodule.mem_top
   obtain ⟨c, hc⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
-  apply matrix_one_ne_zero' hD
+  haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+  apply (show (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 from one_ne_zero)
   rw [← hc]
   exact Finset.sum_eq_zero fun ρ _ => by rw [hall ρ, smul_zero]
 
@@ -379,7 +372,8 @@ private theorem exists_window_covariance [NeZero n] {A B : MPSChainTensor d D n}
     rw [← hc, Matrix.scalar_apply, Matrix.smul_one_eq_diagonal]
   have hc0 : c ≠ 0 := by
     intro h0
-    apply matrix_one_ne_zero' hD
+    haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+    apply (show (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 from one_ne_zero)
     have hzero : ((Xu : (Matrix (Fin D) (Fin D) ℂ)ˣ) : Matrix (Fin D) (Fin D) ℂ) *
         (Z (p + m) : Matrix (Fin D) (Fin D) ℂ) = 0 := by
       rw [hXZ, h0, zero_smul]

--- a/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
@@ -354,14 +354,6 @@ private theorem exists_ofFn_of_length {l : List (Fin d)} {k : ℕ}
   subst hl
   exact ⟨l.get, List.ofFn_get l⟩
 
-/-- A nonzero-size identity matrix is nonzero. -/
-private theorem matrix_one_ne_zero (hD : 0 < D) :
-    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
-  intro h
-  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
-  rw [Matrix.one_apply_eq] at hentry
-  exact one_ne_zero hentry
-
 /-- **The insertion correspondence is an algebra homomorphism**
 (arXiv:1804.04964, Lemma 5, the closing clause at line 2253 of
 `Papers/1804.04964/paper_normal.tex`: the maps `O_1 ↦ X` and `O_3^T ↦ X`
@@ -590,7 +582,8 @@ theorem exists_conjugation_of_sameState [NeZero n] {L : ℕ} (hL : 0 < L)
   -- `Φ` is unital, hence nonzero, hence an automorphism, hence inner.
   have hΦne : Φ ≠ 0 := by
     intro h0
-    apply matrix_one_ne_zero hD
+    haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+    apply (show (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 from one_ne_zero)
     rw [← hΦone, h0]
     rfl
   have hBij := MPSTensor.linear_mul_endomorphism_bijective Φ hΦmul hΦne

--- a/TNLean/PEPS/CycleMPSOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSOverlapCapstone.lean
@@ -49,14 +49,6 @@ variable {d D : ℕ}
 
 /-! ### Rigidity: equal word products at one length force proportional letters -/
 
-/-- A nonzero-size identity matrix is nonzero. -/
-private theorem matrix_one_ne_zero' (hD : 0 < D) :
-    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
-  intro h
-  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
-  rw [Matrix.one_apply_eq] at hentry
-  exact one_ne_zero hentry
-
 /-- **The transport of the identity is a nonzero scalar.**  For two tensors
 with matched word transports at lengths `k` and `k + 1`, the transported
 identity commutes with every letter of `C` — its two one-letter extensions
@@ -149,7 +141,8 @@ private theorem transport_one_eq_smul_one {A C : MPSTensor d D} {L k : ℕ}
           exact ⟨evalWord A (List.ofFn τ), hΛk τ⟩
   have hinj : Function.Injective Λk := LinearMap.injective_iff_surjective.mpr hsurj
   refine ⟨c, fun hc0 => ?_, hV⟩
-  apply matrix_one_ne_zero' hD
+  haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+  apply (show (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 from one_ne_zero)
   apply hinj
   rw [hV, hc0, zero_smul, map_zero]
 
@@ -165,7 +158,8 @@ private theorem exists_evalWord_ne_zero {A : MPSTensor d D} {L n : ℕ}
       (Set.range fun σ : Fin n → Fin d => evalWord A (List.ofFn σ)) :=
     hspan ▸ Submodule.mem_top
   obtain ⟨c, hc⟩ := Submodule.mem_span_range_iff_exists_fun ℂ |>.mp h1
-  apply matrix_one_ne_zero' hD
+  haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+  apply (show (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 from one_ne_zero)
   rw [← hc]
   exact Finset.sum_eq_zero fun σ _ => by rw [hall σ, smul_zero]
 

--- a/TNLean/PEPS/CycleMPSOverlapInsertion.lean
+++ b/TNLean/PEPS/CycleMPSOverlapInsertion.lean
@@ -239,14 +239,6 @@ private theorem exists_insertion_image {A B : MPSTensor d D} {n L : ℕ}
 
 /-! ### Assembling the conjugation -/
 
-/-- A nonzero-size identity matrix is nonzero. -/
-private theorem matrix_one_ne_zero (hD : 0 < D) :
-    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
-  intro h
-  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
-  rw [Matrix.one_apply_eq] at hentry
-  exact one_ne_zero hentry
-
 /-- Any list of declared length is the word of a tuple. -/
 private theorem exists_ofFn_of_length {l : List (Fin d)} {k : ℕ}
     (hl : l.length = k) : ∃ a : Fin k → Fin d, List.ofFn a = l := by
@@ -367,7 +359,8 @@ theorem exists_conjugation_of_mpv_eq {n L : ℕ} (hL : 0 < L) (hn : 2 * L + 1 �
       _ = evalWord B (List.ofFn a) * 1 := (Matrix.mul_one _).symm
   have hΦne : Φ ≠ 0 := by
     intro h0
-    apply matrix_one_ne_zero hD
+    haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+    apply (show (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 from one_ne_zero)
     rw [← hΦone, h0]
     rfl
   have hBij := linear_mul_endomorphism_bijective Φ hΦmul hΦne

--- a/TNLean/PEPS/CycleMPSTranslationInvariant.lean
+++ b/TNLean/PEPS/CycleMPSTranslationInvariant.lean
@@ -90,25 +90,6 @@ private theorem gl_proportional_of_conj_eq {D : ℕ} (Z Z' : GL (Fin D) ℂ)
   rw [inv_inv, inv_inv] at hflip
   exact ⟨c⁻¹, hflip⟩
 
-/-- A nonzero-size identity matrix is nonzero. -/
-private theorem one_ne_zero_of_pos {D : ℕ} (hD : 0 < D) :
-    (1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
-  intro h
-  have hentry := congrFun (congrFun h ⟨0, hD⟩) ⟨0, hD⟩
-  rw [Matrix.one_apply_eq] at hentry
-  exact one_ne_zero hentry
-
-/-- An invertible matrix of positive size is nonzero. -/
-private theorem gl_coe_ne_zero {D : ℕ} (hD : 0 < D) (Z : GL (Fin D) ℂ) :
-    (Z : Matrix (Fin D) (Fin D) ℂ) ≠ 0 := by
-  intro h
-  apply one_ne_zero_of_pos hD
-  calc (1 : Matrix (Fin D) (Fin D) ℂ)
-      = (Z : Matrix (Fin D) (Fin D) ℂ) *
-          ((Z⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) :=
-        (Units.mul_inv Z).symm
-    _ = 0 := by rw [h, Matrix.zero_mul]
-
 /-! ### Iterating the per-bond relation along a word -/
 
 /-- **The per-bond gauge relation iterated along a word.**  If
@@ -358,7 +339,8 @@ theorem fundamentalTheorem_normalMPS_translationInvariant {n L d D : ℕ} [NeZer
       rw [sub_smul, one_smul, ← hcycle, sub_self]
     rcases smul_eq_zero.mp hzero with h | h
     · exact (sub_eq_zero.mp h).symm
-    · exact absurd h (gl_coe_ne_zero hD (Z 0))
+    · haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+      exact absurd h (Units.ne_zero (Z 0))
   refine ⟨Z 0, (c 0 : ℂ), hroot, fun i => ?_⟩
   have h0 := hZ 0 i
   rw [hc 0] at h0

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -78,6 +78,9 @@ The clearest replacements are:
   `ContinuousLinearMap.toNormedRing`, `ContinuousLinearMap.toNormedAlgebra`,
   and local finite-dimensional completeness proofs directly; the former
   finite-dimensional witness was removed with the other exact local wrappers.
+- Several PEPS proofs no longer inspect the `(0, 0)` entry of the identity
+  matrix to prove nonvanishing.  They use Mathlib's nontrivial matrix-space
+  instance and `Units.ne_zero` for invertible matrices.
 - Two one-use Frobenius submultiplicativity wrappers in the transfer-operator
   gap files were removed.  The proofs now call Mathlib's
   `Matrix.frobenius_norm_mul` directly at the Hilbert-Schmidt estimate.
@@ -2176,6 +2179,37 @@ lake build TNLean.Wielandt.RankOne.SpanGrowth \
   TNLean.Wielandt.RankOne.BoundedWord \
   TNLean.Wielandt.RectangularSpan.Growth \
   TNLean.Wielandt.RectangularSpan.UniversalityAux.NilpIndex -q
+```
+
+## Matrix identity nonzero wrapper cleanup, 2026-06-21
+
+Several PEPS files carried private lemmas proving
+`(1 : Matrix (Fin D) (Fin D) ℂ) ≠ 0` from `0 < D` by evaluating the identity
+matrix at the `(0, 0)` entry.  These were exact local proofs of facts already
+available through Mathlib: once `Fin D` is inhabited, Mathlib gives
+`Nontrivial (Matrix (Fin D) (Fin D) ℂ)`, so `one_ne_zero` proves the identity
+matrix is nonzero.
+
+The removed private wrappers were in:
+
+- `TNLean/PEPS/CycleMPSOverlapCapstone.lean`;
+- `TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`;
+- `TNLean/PEPS/CycleMPSOverlapInsertion.lean`;
+- `TNLean/PEPS/CycleMPSChainOverlapInsertion.lean`;
+- `TNLean/PEPS/CycleMPSTranslationInvariant.lean`.
+
+In the translation-invariant argument, the corresponding nonzero fact for an
+invertible matrix is now `Units.ne_zero` applied to the gauge matrix, again
+after supplying the inhabited `Fin D` instance.
+
+Focused checks:
+
+```bash
+lake env lean TNLean/PEPS/CycleMPSOverlapCapstone.lean
+lake env lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+lake env lean TNLean/PEPS/CycleMPSOverlapInsertion.lean
+lake env lean TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
+lake env lean TNLean/PEPS/CycleMPSTranslationInvariant.lean
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

Several PEPS proofs carried private lemmas proving that the identity matrix in positive dimension is nonzero by inspecting its `(0, 0)` entry. Mathlib already supplies this conclusion through the `Nontrivial (Matrix m n α)` instance once the row and column types are inhabited. In the translation-invariant argument, the corresponding fact for an invertible matrix is `Units.ne_zero`.

### Description

- Removes the duplicated private identity-nonzero lemmas from the cycle-MPS overlap and insertion files.
- Replaces each former call site by an inhabited `Fin D` instance obtained from the existing hypothesis `0 < D`, followed by `one_ne_zero`.
- Replaces the local nonzero proof for a gauge matrix by `Units.ne_zero`.
- Records this batch in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`.

No theorem statement changes.

### Validation

- `lake env lean TNLean/PEPS/CycleMPSOverlapCapstone.lean`
- `lake env lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`
- `lake env lean TNLean/PEPS/CycleMPSOverlapInsertion.lean`
- `lake env lean TNLean/PEPS/CycleMPSChainOverlapInsertion.lean`
- `lake env lean TNLean/PEPS/CycleMPSTranslationInvariant.lean`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
