### PR TITLE
doc(periodic): use tensor-matrix Z-gauge terminology

### DIFF
--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -272,7 +272,7 @@ The following compatibility theorems are proved in the present chapter.
     A global finite-order intertwining relation is given by a matrix
     $Z \in \MN{D}$ satisfying:
     \begin{enumerate}
-        \item $Z$ commutes with every Kraus operator: $[A^i, Z] = 0$
+        \item $Z$ commutes with every tensor matrix: $[A^i, Z] = 0$
               for all physical indices $i$, and
         \item $Z^m = \Id_D$.
     \end{enumerate}


### PR DESCRIPTION
### Motivation

The $Z$-gauge definition in the periodic-FT blueprint should follow the notation of arXiv:1708.00029. The source writes the relation as commutation with the tensor matrices $A^i$, for example $[A^i,Z]=0$, rather than as a statement about channel Kraus operators.

### Description

Replaces "Kraus operator" by "tensor matrix" in the blueprint definition of $Z$-gauge equivalence in `ch22_periodic_ft.tex`.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main`

---
Addresses #829

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-word prose change in LaTeX with no Lean or mathematical edits.
>
> **Overview**
> Aligns the blueprint **$Z$-gauge equivalence** definition (`def:z_gauge_equiv` in `ch22_periodic_ft.tex`) with arXiv:1708.00029 by describing the commutation condition as **$Z$ commutes with every tensor matrix** $[A^i, Z] = 0$, instead of "Kraus operator."
>
> The displayed relation and the linked Lean declaration `MPSTensor.ZGaugeEquiv` are unchanged; this is reader-facing terminology only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65659d33cbf6c9deaa629edd5a28c7a211b9b1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->