### PR TITLE
refactor(PEPS): use native right-multiplication span map

### DIFF
--- a/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
@@ -58,31 +58,6 @@ variable {d D n : ℕ}
 
 /-! ### Spanning helpers -/
 
-/-- Right multiplication by an invertible matrix preserves spanning. -/
-private theorem span_range_mul_right_unit {ι : Type*}
-    {W : ι → Matrix (Fin D) (Fin D) ℂ}
-    (hW : Submodule.span ℂ (Set.range W) = ⊤) (U : GL (Fin D) ℂ) :
-    Submodule.span ℂ (Set.range fun i =>
-      W i * (U : Matrix (Fin D) (Fin D) ℂ)) = ⊤ := by
-  rw [eq_top_iff]
-  intro M _
-  have key : ∀ N ∈ Submodule.span ℂ (Set.range W),
-      N * (U : Matrix (Fin D) (Fin D) ℂ) ∈ Submodule.span ℂ
-        (Set.range fun i => W i * (U : Matrix (Fin D) (Fin D) ℂ)) := by
-    intro N hN
-    induction hN using Submodule.span_induction with
-    | mem x hx =>
-        obtain ⟨i, rfl⟩ := hx
-        exact Submodule.subset_span ⟨i, rfl⟩
-    | zero => rw [Matrix.zero_mul]; exact Submodule.zero_mem _
-    | add x y _ _ hx hy => rw [Matrix.add_mul]; exact Submodule.add_mem _ hx hy
-    | smul c x _ hx => rw [Matrix.smul_mul]; exact Submodule.smul_mem _ c hx
-  have hM : M * ((U⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) ∈
-      Submodule.span ℂ (Set.range W) := hW ▸ Submodule.mem_top
-  have := key _ hM
-  rwa [Matrix.mul_assoc, ← Units.val_mul, inv_mul_cancel, Units.val_one,
-    Matrix.mul_one] at this
-
 /-- A matrix whose left multiples of some family span the matrix algebra is
 invertible. -/
 private theorem isUnit_of_mul_span {ι : Type*} {X : Matrix (Fin D) (Fin D) ℂ}
@@ -240,9 +215,27 @@ private theorem exists_window_covariance [NeZero n] {A B : MPSChainTensor d D n}
       _ = arcEval A p (List.ofFn u) * arcEval A (p + m) (List.ofFn v) := by
           rw [hword, hcancel]
   -- The bond operator at the far end.
+  have hBspan_right : Submodule.span ℂ (Set.range fun v : Fin (n - m) → Fin d =>
+      arcEval B (p + m) (List.ofFn v) * (Z p : Matrix (Fin D) (Fin D) ℂ)) = ⊤ := by
+    let e : Matrix (Fin D) (Fin D) ℂ ≃ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+      (Z p).mulRightLinearEquiv ℂ
+    have hmap :
+        (Submodule.span ℂ (Set.range fun v : Fin (n - m) → Fin d =>
+          arcEval B (p + m) (List.ofFn v))).map (e : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ]
+            Matrix (Fin D) (Fin D) ℂ) =
+          Submodule.span ℂ (Set.range fun v : Fin (n - m) → Fin d =>
+            arcEval B (p + m) (List.ofFn v) * (Z p : Matrix (Fin D) (Fin D) ℂ)) := by
+      rw [Submodule.map_span]
+      congr 1
+      ext M
+      simp [e]
+    rw [← hmap]
+    exact (Submodule.map_eq_top_iff
+      (p := Submodule.span ℂ (Set.range fun v : Fin (n - m) → Fin d =>
+        arcEval B (p + m) (List.ofFn v))) (e := e)).2 (hB.arc_span hL hq (p + m))
   obtain ⟨X, hX1, hX2⟩ := exists_bondOperator_of_intertwine_span
     (hA.arc_span hL hm p)
-    (span_range_mul_right_unit (hB.arc_span hL hq (p + m)) (Z p))
+    hBspan_right
     (fun u : Fin m → Fin d =>
       (((Z p)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
         arcEval B p (List.ofFn u))

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -81,6 +81,9 @@ The clearest replacements are:
 - Several PEPS proofs no longer inspect the `(0, 0)` entry of the identity
   matrix to prove nonvanishing.  They use Mathlib's nontrivial matrix-space
   instance and `Units.ne_zero` for invertible matrices.
+- A site-dependent PEPS span-preservation helper was removed.  Its only use now
+  applies Mathlib's `Units.mulRightLinearEquiv`, `Submodule.map_span`, and
+  `Submodule.map_eq_top_iff` directly.
 - Two one-use Frobenius submultiplicativity wrappers in the transfer-operator
   gap files were removed.  The proofs now call Mathlib's
   `Matrix.frobenius_norm_mul` directly at the Hilbert-Schmidt estimate.
@@ -2210,6 +2213,29 @@ lake env lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
 lake env lean TNLean/PEPS/CycleMPSOverlapInsertion.lean
 lake env lean TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
 lake env lean TNLean/PEPS/CycleMPSTranslationInvariant.lean
+```
+
+## PEPS right-multiplication span cleanup, 2026-06-21
+
+`TNLean/PEPS/CycleMPSChainOverlapCapstone.lean` had a private helper
+`span_range_mul_right_unit`, proving by induction over spans that right
+multiplication by an invertible matrix preserves a spanning family of square
+matrices.  The helper had a single use in the window-covariance proof.
+
+That use now works directly with Mathlib's linear equivalence for right
+multiplication by a unit:
+
+- `Units.mulRightLinearEquiv`;
+- `Submodule.map_span`;
+- `Submodule.map_eq_top_iff`.
+
+This removes the handwritten span induction and keeps the span transport
+visible at the point where the bond-operator argument needs it.
+
+Focused check:
+
+```bash
+lake env lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

The site-dependent PEPS overlap capstone had a private helper proving that right multiplication by an invertible matrix preserves a spanning family of square matrices. The proof was a hand induction over the span. Mathlib already has the appropriate linear equivalence: right multiplication by a unit.

### Description

- Removes the one-use private helper `span_range_mul_right_unit` from `TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`.
- Replaces its only use by a local span-transport proof using `Units.mulRightLinearEquiv`, `Submodule.map_span`, and `Submodule.map_eq_top_iff`.
- Records the replacement in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`.

No theorem statement changes.

### Testing

- `lake env lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in one PEPS file with no API or theorem changes; risk is limited to whether the new span-transport argument is correct, which is covered by the focused Lean check.
>
> **Overview**
> Removes the private helper **`span_range_mul_right_unit`** from `CycleMPSChainOverlapCapstone.lean` and replaces its single use in the window-covariance / bond-operator step with a local **`hBspan_right`** argument.
>
> That proof now transports spanning of the `B`-arc family through right multiplication by the gauge **`Z p`** via Mathlib's **`Units.mulRightLinearEquiv`**, **`Submodule.map_span`**, and **`Submodule.map_eq_top_iff`**, instead of a hand span induction. **No theorem statements change.** The Mathlib 4.31 replacement audit documents the cleanup.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9166dcf3d1bcfe7257bf49dbac97d1e05e4d446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>