### PR TITLE
doc(PEPS): track TI MPS description corollary

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1376,6 +1376,44 @@ recorded in the route note
     telescope the resulting bond gauges around the chain.
 \end{proof}
 
+\begin{corollary}[Translation-invariant description of an injective closed MPS chain,
+        uniform bond dimension]%
+    \label{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
+    \notready
+    \uses{cor:exists_gauge_to_first_of_cyclicShiftInvariantState,
+        def:mps_chain_cyclic_shift}
+    Let \(A_0,\ldots,A_{n-1}\) be an injective site-dependent closed chain on
+    \(n\ge 3\) sites, with one physical dimension \(d\) and one bond dimension
+    \(D\).  If the closed-chain state is invariant under the cyclic shift
+    \(A_v\mapsto A_{v+1}\), then there is an injective tensor \(B\), with bond
+    dimension \(D\), such that for every physical configuration \(\sigma\),
+    \[
+        \operatorname{tr}\!\left(
+            A_0^{\sigma_0}\cdots A_{n-1}^{\sigma_{n-1}}\right)
+        =
+        \operatorname{tr}\!\left(
+            B^{\sigma_0}\cdots B^{\sigma_{n-1}}\right).
+    \]
+
+    This is the uniform-bond-dimension target corresponding to the
+    Applications-section corollary of
+    \cite[lines~1803--1890]{Molnar2018NormalPEPS}.  The source also concludes
+    that all bond dimensions of the original site-dependent representation are
+    equal; in the present uniform-dimension statement that clause has already
+    been built into the setting.
+\end{corollary}
+\begin{proof}
+    Apply Corollary~\ref{cor:fundamentalTheorem_injectiveMPSChain_cyclicShift}
+    to compare the chain with its cyclic shift.  The resulting gauges give the
+    \(L_v,R_v\) expression of
+    Corollary~\ref{cor:exists_gauge_to_first_of_cyclicShiftInvariantState}.
+    The source then uses the identities
+    \(R_vL_{v+1}^{-1}=Z_0^{-1}\) and the cyclic boundary condition to rewrite
+    the whole closed-chain contraction as the contraction of one repeated
+    tensor.  This final repeated-tensor construction is the remaining
+    formalization step.
+\end{proof}
+
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%
     \label{thm:fundamentalTheorem_injectiveMPSChain_gauge_unique}
     \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_gauge_unique}
@@ -1418,11 +1456,6 @@ stated for one physical dimension $d$ and one bond dimension $D$ around the
 chain, while \cite{Molnar2018NormalPEPS} places no restriction on the local
 dimensions; this uniform-dimension restriction is the only narrowing.
 % Paper-gap note: docs/paper-gaps/peps_normal_ft_section3_route.tex
-The translation-symmetry corollary in \cite{Molnar2018NormalPEPS}, that a
-non-translation-invariant injective chain whose state is translation invariant
-admits a translation-invariant description with the same bond dimension, is a
-statement about a single chain rather than a comparison of two, and is not part
-of this section.
 
 \section{The vertex-injective case and the residual edge scalars}
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2757,6 +2757,10 @@ initial restricted statement is only
     \Psi(A_1,\ldots,A_n)=\Psi(B,\ldots,B),
 \]
 under a prior uniform bond-dimension hypothesis on the family \(A_i\).
+The blueprint records this restricted target as
+\path{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState};
+the cyclic-shift comparison and the \(L_i,R_i\) expression are formalized, but
+the final repeated-tensor construction remains open.
 
 \emph{Verdict: scope restriction.} The uniform-\(D\) theorem can record the
 existence of the repeated injective tensor \(B\), but it cannot express the


### PR DESCRIPTION
### Motivation

- Issue #2920 identifies the Applications-section corollary of arXiv:1804.04964, lines 1803–1890: a single site-dependent injective MPS whose state is cyclic-shift invariant should admit a translation-invariant MPS description.
- The current blueprint already contains the cyclic-shift comparison and the gauge-to-first telescoping step, but it did not record the remaining repeated-tensor target in the PEPS chapter.

### Description

- Adds a `\notready` blueprint corollary (`cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState`) for the uniform-bond-dimension version of the Applications translation-invariant MPS description corollary in `blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex`.
- Places the entry after the existing cyclic-shift and gauge-to-first corollaries, where the proof route naturally continues.
- Updates `docs/paper-gaps/peps_normal_ft_section3_route.tex` to point to the new blueprint target and to record that the final repeated-tensor construction remains open.
- Does not claim the full source corollary is formalized. The source also proves equality of the original bond dimensions; in the present uniform-`D` chain vocabulary that clause is a scope restriction, not a theorem with content.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main`
- `cd blueprint && leanblueprint web`
- `leanblueprint checkdecls` was not applicable in this worktree because `blueprint/lean_decls` had not been generated there.

---
Addresses #2920

> [!NOTE]
> **Low Risk**
> Documentation and blueprint tracking only; no Lean or runtime behavior changes.
>
> **Overview**
> Adds a **`\notready` blueprint corollary** (`cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState`) for the uniform-bond-dimension Applications-section target: a cyclic-shift-invariant injective closed MPS should have the same trace as a single repeated injective tensor \(B\). It sits after the existing cyclic-shift and gauge-to-first corollaries; the proof sketch points at those steps and marks the **repeated-tensor rewrite** as still open.
>
> Updates **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** to cite the new label and to record that comparison/telescoping are in place while the final construction is not.
>
> Removes the closing remark that the translation-symmetry corollary was **not** part of the section, since it is now tracked (still incomplete).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d711b0226fdfd7d4a29a5200fc482e05d5c8cfcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>