### PR TITLE
doc(parent): align blueprint terminology with sources

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex
@@ -594,8 +594,9 @@ in both cases.
         \rho=\tau_a\cdots\tau_{i-1},\qquad
         \alpha=\sigma_0\cdots\sigma_{N-i-1}.
     \]
-    These are the cut-adapted word coordinates used to compare with the source
-    decompositions involving $C^j_{i_1}$ and $D^j_{i_{m+1}}$.
+    These are the word coordinates obtained by opening the periodic boundary at
+    the chosen cut, in the comparison with the source expressions involving
+    $C^j_{i_1}$ and $D^j_{i_{m+1}}$.
     If
     \[
         \sum_j
@@ -1228,7 +1229,8 @@ in both cases.
         =
         \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
     \]
-    This is the cut-adapted form of the source comparison
+    After opening the periodic boundary at the chosen cut, this is the source
+    comparison
     \[
         A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1},
         \qquad
@@ -1307,7 +1309,7 @@ in both cases.
     then gives the single-block periodic constraints.
 \end{proof}
 
-\begin{lemma}[Trace-decomposition comparisons give single-block constraints]
+\begin{lemma}[Boundary trace comparisons give single-block constraints]
     \label{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}
     \leanok
@@ -1360,7 +1362,7 @@ in both cases.
     which gives the periodic-boundary constraint for each block.
 \end{proof}
 
-\begin{lemma}[Trace decompositions with a block-diagonal boundary representation]
+\begin{lemma}[Boundary trace comparisons with a block-diagonal representation]
     \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary}
     \leanok
@@ -1401,14 +1403,14 @@ in both cases.
     \leanok
     \uses{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     Choose a block-diagonal boundary representation of $\psi$. For that
-    representation, the trace-decomposition comparison supplies the matrices
+    representation, the boundary trace comparison supplies the matrices
     $C^j_{i,\rho}$. Applying
     Lemma~\ref{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     gives the desired containment
     $\Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)$ for every block $j$.
 \end{proof}
 
-\begin{lemma}[Trace-decomposition comparisons give periodic-boundary single-block states]
+\begin{lemma}[Boundary trace comparisons give periodic-boundary single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1}
     \leanok
@@ -1457,14 +1459,14 @@ in both cases.
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
     \]
     Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
-    applies to this representation and the assumed trace-decomposition
-    comparison. Thus, for every $j$,
+    applies to this representation and the assumed equality of boundary trace
+    expressions. Thus, for every $j$,
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
     \]
 \end{proof}
 
-\begin{lemma}[BNT product span gives trace-decomposition periodic components]
+\begin{lemma}[Basis-of-normal-tensors product span gives boundary-trace periodic components]
     \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_bnt_span}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -4,7 +4,7 @@
 The periodic ground-space theorem states that, for sufficiently long periodic
 systems, the periodic-boundary ground space of a parent Hamiltonian is generated
 by a basis of normal tensors of the initial tensor
-\(A\)~\cite[Theorem~IV.16]{Cirac2021Matrix}. The lemmas in this subsection are
+$A$~\cite[Theorem~IV.16]{Cirac2021Matrix}. The lemmas in this subsection are
 conditional reductions toward that statement. Their
 hypotheses explicitly include a boundary inclusion, a block-diagonal boundary
 representation, or periodic-boundary membership for the single-block states; in
@@ -12,14 +12,14 @@ the source theorem these conditions are obtained from the boundary-condition
 comparison in the periodic ring. The source proof
 \cite{PerezGarcia2007Matrix} writes this comparison with $C^j_{i_1}$,
 $D^j_{i_{m+1}}$, and the normalized matrix $E^j$; the symbols $\beta$ and
-$\rho$ below are the cut-adapted words obtained after opening the periodic
-cut. In these coordinates the source comparison becomes
+$\rho$ below are the words obtained after opening the periodic boundary at the
+chosen cut. In these coordinates the source comparison becomes
 \[
     A^j_\beta C^j_{i,\rho}
     =
     \bigl(\mu_j^N X_j A^j_\beta\bigr)A^j_\rho,
 \]
-which is the cut-adapted form of
+which is the opened-boundary form of
 $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$ with
 $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
 
@@ -453,7 +453,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
 \end{proof}
 
-\begin{lemma}[Trace-decomposition comparisons reduce to periodic-boundary equality]
+\begin{lemma}[Boundary trace comparisons reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_trace_decomposition_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition}
     \leanok
@@ -517,7 +517,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     and the internality of the sum of the $G_N(A_j)$.
 \end{proof}
 
-\begin{lemma}[BNT product span gives trace-decomposition ground-space equality]
+\begin{lemma}[Basis-of-normal-tensors product span gives boundary-trace ground-space equality]
     \label{lem:bnt_block_diagonal_trace_decomposition_bnt_span_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span}
     \leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -693,7 +693,8 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
 
 \begin{proof}
     \leanok
-    The trace-decomposition equality and the common word-span hypothesis give
+    The equality of the two boundary trace expressions and the common word-span
+    hypothesis give
     \[
         A^j_bC^j_a=D^j_bA^j_a
     \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -121,7 +121,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
     \]
-    This is a named condition. It does not prove the ground-space spanning
+    This is the definition below. It does not prove the ground-space spanning
     equation for a concrete canonical-form tensor.
 \end{definition}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -661,7 +661,7 @@ sufficient stronger hypotheses.
     $\gamma\le1$. Suppose an overlap predicate on local windows has at most $m$
     overlapping off-diagonal windows in each row. If non-overlapping local terms
     have non-negative ordered cross terms, and overlapping local terms satisfy
-    the finite-overlap principal-angle estimate
+    the one-sided ordered cross-term estimate
     \[
         \operatorname{Re}\langle h_{i,\mathrm{ES}}v,h_{j,\mathrm{ES}}v\rangle
         \ge -(1-\gamma)\frac{1}{m}
@@ -1114,7 +1114,7 @@ sufficient stronger hypotheses.
         +\operatorname{Re}\langle h_j v,v\rangle\bigr),
     \]
     with row-summable coefficients. Lemma~\ref{lem:parent_hamiltonian_anticommutator_rowsum_gap}
-    records the formal reduction from this estimate to the spectral gap. A
+    gives the implication from this anticommutator estimate to the spectral gap. A
     directed norm-compression estimate, independent of $N$, such as
     \[
         \|h_i h_j v\|\le \eta\|h_i v\|,

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -111,7 +111,7 @@ is
   \ker(H_N)=\operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}.
 \end{align}
 The sentence preceding the theorem restricts the proof to block-diagonal
-boundary conditions.  In the cut-adapted boundary coordinates used below, this
+boundary conditions.  After opening the periodic boundary at the chosen cut, this
 means boundary matrices of the form
 \begin{align}
   X=\bigoplus_{j=1}^g X_j,
@@ -244,8 +244,8 @@ vector in the periodic-boundary space $\mathcal K_{N,L}(\widehat A)$, produce
 block-diagonal boundary matrices whose block components again belong to the
 blockwise periodic-boundary spaces.
 
-The present boundary isolates the remaining source comparison in cut-adapted
-coordinates for boundary-crossing windows.  Suppose
+The present boundary isolates the remaining source comparison in the coordinates
+obtained by opening the periodic boundary for boundary-crossing windows.  Suppose
 \begin{align}
   \psi
   =
@@ -283,7 +283,7 @@ as an unconditional hypothesis-free equality theorem in the source range.\footno
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}.}
 
 The live blueprint records that larger source statement with explicit citations
-and separates the cut-adapted coordinates from the paper's boundary indices,
+and separates these opened-boundary coordinates from the paper's boundary indices,
 without claiming that the source statement is proved.\footnote{Blueprint locations:
 \path{def:parent_hamiltonian_ground_space_bnt} for the block-diagonal
 periodic-boundary ground space,
@@ -456,12 +456,12 @@ every block $j$,
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
 This is the conditional reduction recorded by pull request~\#2724.  There are
-now two formal routes to the boundary-condition comparison. The
-trace-decomposition route records the following implication. Assume the common
+now two proved conditional routes to the boundary-condition comparison. The
+boundary-trace route records the following implication. Assume the common
 word-span property for the middle-word length \(m\). If, for every
 boundary-crossing interval, word
 $\beta$ before the cut, outside word $\rho$, and middle word $w$ of length \(m\),
-the two trace comparisons from \cite[Theorem~12]{PerezGarcia2007MPSReps}
+the two boundary trace expressions from \cite[Theorem~12]{PerezGarcia2007MPSReps}
 satisfy
 \begin{align}
   \sum_j\tr\!\left(A^j_\beta C^j_\rho A^j_w\right)
@@ -475,8 +475,8 @@ then
 for every block $j$ in the block-injective range.\footnote{Lean declaration:
 \leanid{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}.}
 There is also an explicit-boundary version: once
-\(\psi=\Gamma_N^{\widehat A}(\bigoplus_jX_j)\) is fixed, the same
-trace-decomposition comparison gives
+\(\psi=\Gamma_N^{\widehat A}(\bigoplus_jX_j)\) is fixed, the same equality of
+boundary trace expressions gives
 \begin{align}
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j)
 \end{align}
@@ -497,14 +497,14 @@ then the normalized block-separation theorem gives
   =
   \prod_j M_{D_j}(\mathbb C).
 \end{align}
-Consequently the trace-decomposition implication in the finite range only keeps
-the displayed trace comparison and the block-diagonal boundary representation
+Consequently the boundary-trace implication in the finite range only keeps
+the displayed trace equality and the block-diagonal boundary representation
 as external inputs.\footnote{Lean declarations:
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span}
 and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span}.}
 
-The cut-adapted \(C^j,D^j\) route is closer to the proof of
+The \(C^j,D^j\) opened-boundary route is closer to the proof of
 \cite[Theorem~12]{PerezGarcia2007MPSReps}.
 The words \(\beta\) and \(\rho\) are local word coordinates introduced after
 opening and blocking the cyclic boundary comparison; they reindex the source

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -113,9 +113,9 @@ projection estimates inherited from Fannes--Nachtergaele--Werner
 convert one of these source estimates to the cyclic-window inequality used
 below, with constants in the same blocking convention.
 
-\section{The formal reduction}
+\section{Finite-row martingale reduction}
 
-The formal development has separated the finite-row martingale algebra from the
+The current development separates the finite-row martingale algebra from the
 remaining MPS-specific principal-angle estimate. Fix an interaction range
 $L>1$ and an $N$-site periodic chain with $N\ge 2L$. Let $p_i$ denote the
 Hilbert-space representative of the length-$L$ local parent-Hamiltonian
@@ -125,14 +125,14 @@ For each fixed $i$, the number of indices $j$ with $i\sim_L j$ is at most
 \[
     m=2(L-1).
 \]
-The formal row-sum reduction specializes the source coefficients to
+The row-sum reduction specializes the source coefficients to
 \[
     c_{ij}=\frac{1}{2(L-1)}
 \]
 for overlapping cyclic windows and to $0$ otherwise. The row-cardinality bound
 then gives $\sum_j c_{ij}\le 1$.
 
-With this choice, the constant in the formal statement is
+With this choice, the constant in the local statement is
 \[
     \gamma_L=\frac{1}{4L}.
 \]
@@ -150,7 +150,7 @@ formalized row-sum argument proves $H_{N,L}^2\ge \gamma_L H_{N,L}$, and hence a
 norm lower bound with constant $\gamma_L$ on the orthogonal complement of the
 ground space.
 
-The formal proof also isolates a sufficient norm-compression form of the same
+The proof also isolates a sufficient norm-compression form of the same
 input:
 \begin{equation}
     \|p_i p_j v\|
@@ -167,9 +167,9 @@ For a symmetric projection $p_i$ one has
 \]
 Thus (N), together with $\operatorname{Re}\langle p_i v,v\rangle=\|p_i v\|^2$,
 implies (F). This is a sufficient projection-geometry comparison used in the
-formal proof: a norm-compression estimate for each overlapping pair is converted
+proof: a norm-compression estimate for each overlapping pair is converted
 by Cauchy--Schwarz to the ordered cross-term estimate, and the finite row-sum
-argument converts those ordered estimates into the global gap bound. The formal
+argument converts those ordered estimates into the global gap bound. The Lean
 development also records the source anticommutator row-sum reduction directly,
 without passing through this stronger one-sided estimate.\footnote{The
     current formal anchors include the anticommutator row-sum reductions


### PR DESCRIPTION
### Motivation

- The original sources (PGVWC07 / arXiv:quant-ph/0608197, Theorem 12, lines 1446–1456; arXiv:2011.12127 §IV.C) do not use the terms "trace-decomposition route" or "cut-adapted" condition; those local shorthands should not appear in the blueprint as if they were source terminology.
- Blueprint entries for the martingale spectral gap (see #952) describe the finite-overlap hypothesis as a "principal-angle theorem"; the source presents it as an anticommutator or ordered cross-term estimate.
- Blueprint entries for the block-diagonal PGVWC07 comparison (see #2971) should be stated through the boundary trace expressions involving the source matrices $C^j$, $D^j$, and $E^j$, as in arXiv:quant-ph/0608197, Theorem 12.

### Description

- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal.tex`: replace "cut-adapted" and "trace-decomposition route" with "opening the periodic boundary at the chosen cut", "opened-boundary coordinates", and equalities of boundary trace expressions stated via $C^j$, $D^j$, $E^j$.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`: update chain-equality intro to `$A$`-style math mode; rename lemma titles to "boundary trace comparisons" and "basis-of-normal-tensors product span".
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex`: minor terminology alignment.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: clarify that the all-chain NNCPH block is the definition below, not a named condition that proves spanning for a concrete tensor.
- `blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex`: describe the finite-overlap hypothesis as a one-sided ordered cross-term estimate rather than a "principal-angle theorem" or "formal reduction".
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: align terminology with the revised blueprint.
- `docs/paper-gaps/cpgsv21_martingale_overlap.tex`: retitle section to "Finite-row martingale reduction"; remove "formal" where it implied a proved theorem.
- No Lean files are changed; this is a documentation-only PR.

### Testing

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake build TNLean` (passes with pre-existing warnings, including the existing periodic-overlap `sorry` warning)
- `lake exe checkdecls blueprint/lean_decls`

---
Refs #190
Refs #2971
Refs #952
Refs #2633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and terminology only in LaTeX/docs; no Lean, scripts, or runtime behavior changes.
>
> **Overview**
> Documentation-only edits in the parent-Hamiltonian **blueprint** and two **paper-gap** notes replace local shorthand with language tied to the cited papers.
>
> **Block-diagonal periodic ground space (PGVWC07 / Cirac2021):** Phrases like "cut-adapted" and "trace-decomposition route" give way to **opening the periodic boundary at the chosen cut**, **opened-boundary coordinates**, and comparisons stated as **equalities of boundary trace expressions** (with source matrices \(C^j\), \(D^j\), \(E^j\)). Several lemma titles and proof wording are renamed accordingly (e.g. boundary trace comparisons, basis-of-normal-tensors product span). Math mode uses `$A$` instead of `\(A\)` in one chain-equality intro.
>
> **Martingale / spectral gap:** The finite-overlap hypothesis is described as a **one-sided ordered cross-term estimate**, not a "principal-angle" or "formal reduction" framing; the martingale paper-gap section is retitled **Finite-row martingale reduction** and prose drops "formal" where it implied a proved theorem.
>
> **Commuting parent Hamiltonian:** A single clarification that the all-chain NNCPH block is **the definition below**, not a named condition that proves spanning for a concrete tensor.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600686f15f8372de20fcfdbc733ae11d551dedee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->