### PR TITLE
doc(periodic): use tensor-matrix off-diagonal terminology

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
@@ -119,9 +119,9 @@ def IsCyclicSectorDecomp [NeZero D] [NeZero m] (A : MPSTensor d D)
     IsCyclicSectorDecompWith A blocks P φ
 
 /-- The single-site off-diagonal grading carried by a cyclic sector decomposition:
-each unblocked Kraus operator carries the cyclic projection index `k` to `k + 1`,
-P_{k+1} · A^i = A^i · P_k.  This is the single-site shift of arXiv:1708.00029,
-eq:Aoffdiag, in inverse-indexed form; the later eq:Auprop only defines the
+each one-site tensor matrix carries the cyclic projection index `k` to `k + 1`,
+P_{k+1} · A^i = A^i · P_k.  This is the single-site shift for tensor matrices in
+arXiv:1708.00029, eq:Aoffdiag, in inverse-indexed form; the later eq:Auprop only defines the
 sector letters \(A_u^i = P_u A^i P_{u+1}\).  The relation used here is obtained
 from the cyclic relation 𝓔^*(P_{k+1}) = P_k stored in `IsCyclicSectorDecomp`. -/
 theorem IsCyclicSectorDecomp.offDiag_shift [NeZero D] [NeZero m]


### PR DESCRIPTION
### Motivation

- The docstring for `IsCyclicSectorDecomp.offDiag_shift` in `TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean` described the off-diagonal shift using Kraus-operator framing rather than the one-site tensor matrix framing of the source.
- arXiv:1708.00029, eq:Aoffdiag states the cyclic projection shift $P_{k+1} \cdot A^i = A^i \cdot P_k$ for one-site tensor matrices $A^i$; the docstring now matches that terminology.
- Continues formalization tracking for arXiv:1708.00029; see #619.

### Description

- Updated the docstring for `IsCyclicSectorDecomp.offDiag_shift` in `TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean`: text now states that each one-site tensor matrix $A^i$ carries the cyclic projection index from $k$ to $k+1$, i.e., $P_{k+1} \cdot A^i = A^i \cdot P_k$, matching arXiv:1708.00029, eq:Aoffdiag.
- No Lean definitions, theorem statements, proofs, imports, or blueprint status are changed.

### Testing

- `lake build TNLean.MPS.Periodic.Overlap.SelfOverlapSetup`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses #619

> [!NOTE]
> **Low Risk**
> Documentation-only wording in a single docstring; no executable or formal statement changes.
> 
> **Overview**
> Updates the docstring for **`IsCyclicSectorDecomp.offDiag_shift`** so it matches arXiv:1708.00029 **eq:Aoffdiag**, which is stated for one-site **tensor matrices** \(A^i\), not Kraus operators.
> 
> The text now says each one-site tensor matrix shifts the cyclic projection index from `k` to `k + 1` (\(P_{k+1} \cdot A^i = A^i \cdot P_k\)), and frames the citation as the single-site shift **for tensor matrices**. **No Lean definitions, proofs, or imports change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b051fda52f4d3c4a26f5a2f00c8284acde94bd7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>