### PR TITLE
refactor(PEPS): use native ext on spanning sets

### DIFF
--- a/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
@@ -93,18 +93,15 @@ private theorem conj_eq_conj_of_span_range {ι : Sort*}
     {P Q P' Q' : Matrix (Fin D) (Fin D) ℂ}
     (h : ∀ i, P * F i * Q = P' * F i * Q') (M : Matrix (Fin D) (Fin D) ℂ) :
     P * M * Q = P' * M * Q' := by
-  have hM : M ∈ Submodule.span ℂ (Set.range F) := hF ▸ Submodule.mem_top
-  induction hM using Submodule.span_induction with
-  | mem x hx =>
-      obtain ⟨i, rfl⟩ := hx
-      exact h i
-  | zero => simp only [Matrix.mul_zero, Matrix.zero_mul]
-  | add x y _ _ hx hy =>
-      rw [Matrix.mul_add, Matrix.add_mul, Matrix.mul_add, Matrix.add_mul,
-        hx, hy]
-  | smul c x _ hx =>
-      rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_smul, Matrix.smul_mul,
-        hx]
+  have hmaps :
+      (LinearMap.mulRight ℂ Q).comp (LinearMap.mulLeft ℂ P) =
+        (LinearMap.mulRight ℂ Q').comp (LinearMap.mulLeft ℂ P') := by
+    apply LinearMap.ext_on_range (v := F) hF
+    intro i
+    simpa [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
+      using h i
+  simpa [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
+    using congrArg (fun f => f M) hmaps
 
 /-- Some arc product of a spanning arc family is nonzero. -/
 private theorem exists_arcEval_ne_zero [NeZero n] {A : MPSChainTensor d D n}

--- a/TNLean/PEPS/CycleMPSTranslationInvariant.lean
+++ b/TNLean/PEPS/CycleMPSTranslationInvariant.lean
@@ -61,14 +61,15 @@ private theorem conj_eq_conj_of_span {D : ℕ} {S : Set (Matrix (Fin D) (Fin D) 
     (hS : Submodule.span ℂ S = ⊤) {P Q P' Q' : Matrix (Fin D) (Fin D) ℂ}
     (h : ∀ M ∈ S, P * M * Q = P' * M * Q') (M : Matrix (Fin D) (Fin D) ℂ) :
     P * M * Q = P' * M * Q' := by
-  have hM : M ∈ Submodule.span ℂ S := hS ▸ Submodule.mem_top
-  induction hM using Submodule.span_induction with
-  | mem x hx => exact h x hx
-  | zero => simp only [Matrix.mul_zero, Matrix.zero_mul]
-  | add x y _ _ hx hy =>
-      rw [Matrix.mul_add, Matrix.add_mul, Matrix.mul_add, Matrix.add_mul, hx, hy]
-  | smul r x _ hx =>
-      rw [Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_smul, Matrix.smul_mul, hx]
+  have hmaps :
+      (LinearMap.mulRight ℂ Q).comp (LinearMap.mulLeft ℂ P) =
+        (LinearMap.mulRight ℂ Q').comp (LinearMap.mulLeft ℂ P') := by
+    apply LinearMap.ext_on hS
+    intro N hN
+    simpa [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
+      using h N hN
+  simpa [LinearMap.comp_apply, LinearMap.mulLeft_apply, LinearMap.mulRight_apply]
+    using congrArg (fun f => f M) hmaps
 
 /-- **Proportionality from a shared two-sided conjugation.**  Two invertible
 matrices `Z`, `Z'` with `Z⁻¹ W Z = Z'⁻¹ W Z'` for every matrix `W` differ by

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -91,6 +91,9 @@ The clearest replacements are:
   span inductions over the left and right word families.  It now packages
   `(R, S) ↦ R * X * S` as a bilinear map and applies
   `Submodule.map₂_span_span`.
+- Two PEPS conjugation-extension helpers no longer prove linear-map equality
+  by hand over a spanning set.  They use Mathlib's `LinearMap.ext_on` and
+  `LinearMap.ext_on_range` for equality on a spanning set or range.
 - Two one-use Frobenius submultiplicativity wrappers in the transfer-operator
   gap files were removed.  The proofs now call Mathlib's
   `Matrix.frobenius_norm_mul` directly at the Hilbert-Schmidt estimate.
@@ -2283,6 +2286,30 @@ Focused check:
 
 ```bash
 lake env lean TNLean/Algebra/TracePairing.lean
+```
+
+## PEPS conjugation extension cleanup, 2026-06-21
+
+Two PEPS helpers used explicit `Submodule.span_induction` proofs to extend
+equality of two-sided multiplication maps from a spanning family to every
+matrix:
+
+- `PEPS.conj_eq_conj_of_span` in
+  `TNLean/PEPS/CycleMPSTranslationInvariant.lean`;
+- `MPSChainTensor.conj_eq_conj_of_span_range` in
+  `TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`.
+
+Both helpers now regard `M ↦ P * M * Q` as a linear map and apply Mathlib's
+native extension principles:
+
+- `LinearMap.ext_on` for equality on a spanning set;
+- `LinearMap.ext_on_range` for equality on the range of a spanning family.
+
+Focused checks:
+
+```bash
+lake env lean TNLean/PEPS/CycleMPSTranslationInvariant.lean
+lake env lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

Two PEPS conjugation-extension helpers manually propagated equality of two-sided multiplication maps from a spanning set by `Submodule.span_induction`. Mathlib provides the appropriate linear-map extension principles directly.

### Description

- Replaces the span induction in `PEPS.conj_eq_conj_of_span` with `LinearMap.ext_on`.
- Replaces the span induction in `MPSChainTensor.conj_eq_conj_of_span_range` with `LinearMap.ext_on_range`.
- Records the replacement in `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`.

No theorem statement changes.

### Testing

- `lake env lean TNLean/PEPS/CycleMPSTranslationInvariant.lean`
- `lake env lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_oversized_lean_files.py`

---
No linked issue identified; this is a standalone Mathlib 4.31 replacement cleanup.

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no API or theorem statement changes; behavior of PEPS gauge arguments is unchanged.
>
> **Overview**
> Replaces hand-written `Submodule.span_induction` proofs in two PEPS helpers that extend equality of two-sided multiplication maps `M ↦ P * M * Q` from a spanning family to all matrices.
>
> **`conj_eq_conj_of_span`** (`CycleMPSTranslationInvariant.lean`) and **`conj_eq_conj_of_span_range`** (`CycleMPSChainOverlapCapstone.lean`) now package conjugation as `LinearMap.mulLeft` / `mulRight` composition and close with **`LinearMap.ext_on`** and **`LinearMap.ext_on_range`**. Theorem statements and downstream uses (gauge collapse, window covariance) are unchanged.
>
> The Mathlib 4.31 replacement audit documents this cleanup.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76ef25f3f067c7932d9e359c038ed68084ce4e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>