### PR TITLE
doc(periodic): cite 1708 source labels

### DIFF
--- a/TNLean/MPS/Periodic/FundamentalTheorem.lean
+++ b/TNLean/MPS/Periodic/FundamentalTheorem.lean
@@ -17,20 +17,20 @@ open scoped Matrix BigOperators
 This file formalizes the periodic fundamental theorem of arXiv:1708.00029 Section 3 and the
 Z-gauge theory used in its equal-case strengthening:
 
-* **Theorem 3.4** (`fundamentalTheorem_periodic_proportional`): If two non-repeated
-  block families satisfy the periodic overlap dichotomy, their bases of periodic tensors
-  match up to a bijection with per-block `RepeatedBlocks` equivalence. (In the paper,
-  proportional MPVs imply the dichotomy; here it is a direct hypothesis.)
+* **Proportional theorem `thm:bd`** (`fundamentalTheorem_periodic_proportional`):
+  If two non-repeated block families satisfy the periodic overlap dichotomy, their bases
+  of periodic tensors match up to a bijection with per-block `RepeatedBlocks` equivalence.
+  (In the paper, proportional MPVs imply the dichotomy; here it is a direct hypothesis.)
 
-* **Supporting lemmas for Theorem 3.8**: The equal-case strengthening produces per-block
-  Z-gauge data (diagonal Z with Z^m = 1) from the Newton–Girard identity on
-  multiplicity entries.
+* **Supporting lemmas for the equal-case theorem `thm:bdequal`**: The equal-case
+  strengthening produces per-block Z-gauge data (diagonal Z with Z^m = 1) from the
+  Newton–Girard identity on multiplicity entries.
   The Z-gauge construction is packaged in `zgauge_construction` and
   `perBlock_zgauge_of_power_eq`.
 
 ## Periodic overlap dichotomy
 
-Theorem 3.4 is stated in two forms:
+The proportional theorem `thm:bd` is stated in two forms:
 
 * `fundamentalTheorem_periodic_proportional` takes a `PeriodicOverlapHypothesis` directly,
   leaving callers free to supply the dichotomy from any source.
@@ -43,13 +43,13 @@ Theorem 3.4 is stated in two forms:
   which encode the paper's proportional-MPV assumption.
 
   **Caveat**: `periodicOverlapDichotomy` is stated and callable, but its proof still
-  depends on the remaining Case-3 contraction and phase-assembly theorem
-  `repeatedBlocks_of_blockedSectorGaugePhase` in
-  `TNLean.MPS.Periodic.Overlap.Case3`. Subsequent results using the
-  `_of_isPeriodic` variant therefore inherit that obligation and should not be
-  treated as unconditional.
+  depends on the remaining Case-3 contraction with \(F_u\), \(\Omega_u\), and the
+  phases \(\kappa_v\) from arXiv:1708.00029, Appendix A, lines 1023--1117,
+  formalized as `repeatedBlocks_of_blockedSectorGaugePhase` in
+  `TNLean.MPS.Periodic.Overlap.Case3`. Subsequent results using the `_of_isPeriodic`
+  variant therefore inherit that obligation and should not be treated as unconditional.
 
-The Z-gauge construction (Theorem 3.8 steps 5–7) is fully proved.
+The Z-gauge construction (the scalar-entry part of `thm:bdequal`) is fully proved.
 
 ## Key references
 
@@ -111,12 +111,14 @@ abbrev PeriodicBlockMatchingWitness
 
 /-! ## Periodic overlap dichotomy hypothesis -/
 
-/-- Hypothesis giving the periodic overlap dichotomy (Proposition 3.3 of 1708.00029).
+/-- Hypothesis giving the periodic overlap dichotomy
+(arXiv:1708.00029, proposition `equal-or-orthogonal-generalized`).
 
 The `hetRepeatedBlocks_of_nondecaying` field can be filled via `periodicOverlapDichotomy`
 (see `PeriodicOverlapHypothesis.ofIsPeriodic`), though that dichotomy still relies on
-admitted sub-lemmas in the split `TNLean.MPS.Periodic.Overlap.*` modules. The fields
-capture the essential results:
+the remaining Case-3 contraction with \(F_u\), \(\Omega_u\), and the phases
+\(\kappa_v\) from arXiv:1708.00029, Appendix A, lines 1023--1117, formalized as
+`repeatedBlocks_of_blockedSectorGaugePhase`. The fields capture the essential results:
 1. For each block in one family, a non-decaying overlap partner exists in the other.
 2. Non-decaying overlap forces `HetRepeatedBlocks`.
 
@@ -183,7 +185,7 @@ def PeriodicOverlapHypothesis.ofIsPeriodic
     · exact absurd hdecay hnd
     · exact hrep
 
-/-! ## Theorem 3.4 — Proportional case -/
+/-! ## Proportional theorem `thm:bd` -/
 
 section ProportionalCase
 
@@ -194,7 +196,7 @@ variable {rA rB : ℕ}
 
 If two periodic tensors generate the same MPV family, then their bond dimensions
 agree and they are repeated blocks after identifying those bond spaces. This is
-the single-block uniqueness direction behind Theorem 3.4 once the
+the single-block uniqueness direction behind the source theorem `thm:bd` once the
 proportionality scalar has been absorbed into one side.
 
 The proof combines `periodicOverlapDichotomy` with `periodicSelfOverlap_tendsto`:
@@ -250,7 +252,8 @@ def PeripheralProportionalCaseRootFromRescaling (d D₁ D₂ : ℕ) : Prop :=
 Assuming `PeripheralProportionalCaseRootFromRescaling`, the exact-equality theorem
 `peripheralProportionalCase_periodicFT_of_sameMPV` upgrades proportional periodic
 MPVs to `HetRepeatedBlocks`. Thus the remaining single-block proportional gap in
-Theorem 3.4 is exactly the phase-rescaling step provided by that hypothesis. -/
+the source theorem `thm:bd` is exactly the phase-rescaling step provided by that
+hypothesis. -/
 theorem peripheralProportionalCase_periodicFT_of_rootFromRescaling
     {D₁ D₂ : ℕ} [NeZero D₁] [NeZero D₂]
     (hRescale : PeripheralProportionalCaseRootFromRescaling d D₁ D₂)
@@ -272,7 +275,7 @@ theorem peripheralProportionalCase_periodicFT_of_rootFromRescaling
     peripheralProportionalCase_periodicFT_of_sameMPV A' B hA' hB hSame
   exact hScale.trans hRepeated
 
-/-- **Theorem 3.4 (Proportional case, arXiv:1708.00029).**
+/-- **Proportional theorem `thm:bd` (arXiv:1708.00029, lines 613--623).**
 
 If two non-repeated block families satisfy the periodic overlap dichotomy, then
 their bases of periodic tensors match: equal block counts, a bijection, and per-block
@@ -301,9 +304,11 @@ The `PeriodicOverlapHypothesis` parameter can be supplied via
 `PeriodicOverlapHypothesis.ofIsPeriodic`, which uses `periodicOverlapDichotomy`
 to fill the `hetRepeatedBlocks_of_nondecaying` field; see
 `fundamentalTheorem_periodic_proportional_of_isPeriodic`. Note that
-`periodicOverlapDichotomy` still relies on the remaining Case-3 contraction and
-phase-assembly theorem `repeatedBlocks_of_blockedSectorGaugePhase`, so callers
-going through that route inherit that obligation. -/
+`periodicOverlapDichotomy` still relies on the remaining Case-3 contraction with
+\(F_u\), \(\Omega_u\), and the phases \(\kappa_v\) from arXiv:1708.00029,
+Appendix A, lines 1023--1117, formalized as
+`repeatedBlocks_of_blockedSectorGaugePhase`; callers going through that route inherit
+that obligation. -/
 theorem fundamentalTheorem_periodic_proportional
     (A : (j : Fin rA) → MPSTensor d (dimA j))
     (B : (k : Fin rB) → MPSTensor d (dimB k))
@@ -365,7 +370,7 @@ theorem fundamentalTheorem_periodic_proportional
     change HetRepeatedBlocks (A j) (B (fA j))
     exact hfA_rep j⟩
 
-/-- **Theorem 3.4 (Periodic FT, proportional case) from `IsPeriodic` data.**
+/-- **Proportional theorem `thm:bd` from `IsPeriodic` data.**
 
 variant of `fundamentalTheorem_periodic_proportional` that no longer takes
 `PeriodicOverlapHypothesis` as a parameter; instead, the dichotomy field is filled via
@@ -376,12 +381,13 @@ This is the form intended by the paper: two families of periodic blocks whose cr
 overlaps do not all vanish must match up to bijection and per-block `HetRepeatedBlocks`
 equivalence.
 
-**Remaining proof obligations.** `periodicOverlapDichotomy` is stated and callable, but
-its proof still uses the remaining Case-3 contraction and phase-assembly theorem
-`repeatedBlocks_of_blockedSectorGaugePhase` from
-`TNLean.MPS.Periodic.Overlap.Case3`. Subsequent users of this theorem inherit
-that obligation: this variant is a convenience reformulation, not an
-unconditional strengthening. -/
+**Remaining proof obligation.** `periodicOverlapDichotomy` is stated and callable, but
+its proof still uses the remaining Case-3 contraction with \(F_u\), \(\Omega_u\), and
+the phases \(\kappa_v\) from arXiv:1708.00029, Appendix A, lines 1023--1117,
+formalized as `repeatedBlocks_of_blockedSectorGaugePhase` in
+`TNLean.MPS.Periodic.Overlap.Case3`. Subsequent users of this theorem inherit that
+obligation: this variant is a convenience reformulation, not an unconditional
+strengthening. -/
 theorem fundamentalTheorem_periodic_proportional_of_isPeriodic
     (A : (j : Fin rA) → MPSTensor d (dimA j))
     (B : (k : Fin rB) → MPSTensor d (dimB k))
@@ -405,11 +411,11 @@ theorem fundamentalTheorem_periodic_proportional_of_isPeriodic
 
 end ProportionalCase
 
-/-! ## Multiplicity-entry Z-gauge construction (Theorem 3.8, steps 5–7) -/
+/-! ## Multiplicity-entry Z-gauge construction from `thm:bdequal` -/
 
 section ZGaugeConstruction
 
-/-- **Multiplicity-entry Z-gauge from matched m-th powers (Theorem 3.8, step 7).**
+/-- **Multiplicity-entry Z-gauge from matched m-th powers.**
 
 If two lists of multiplicity entries have equal `m`-th powers and the denominator
 entries are nonzero, the diagonal matrix `Z = diag(μ_i / ν_i)` satisfies
@@ -430,7 +436,7 @@ theorem zgauge_construction
    zGaugeDiagonal_pow_eq_one m μ ν hpow hν,
    zGaugeDiagonal_mul_diagonal μ ν hν⟩
 
-/-- **Per-block multiplicity-entry Z-gauge (Theorem 3.8, step 7 for `Fin r`).**
+/-- **Per-block multiplicity-entry Z-gauge for `Fin r`.**
 
 Convenience reformulation: given matched multiplicity entries indexed by `Fin r`
 whose `m`-th powers agree and whose denominator entries are nonzero, produces the
@@ -444,7 +450,7 @@ theorem perBlock_zgauge_of_power_eq
       Z * Matrix.diagonal ν = Matrix.diagonal μ :=
   zgauge_construction m μ ν hpow hν
 
-/-- **Multiplicity-entry multiset recovery via Newton-Girard (Theorem 3.8, step 6).**
+/-- **Multiplicity-entry multiset recovery via Newton-Girard.**
 
 If two finite lists of multiplicity entries have equal power sums for all positive
 exponents, they determine the same multiset. Direct reformulation of
@@ -455,7 +461,7 @@ theorem weight_multisets_eq_of_power_sums_eq
     Finset.univ.val.map μ = Finset.univ.val.map ν :=
   Matrix.sum_pow_eq_implies_multiset_eq μ ν h
 
-/-- **Scalar multiplicity-entry Z-gauge construction (Theorem 3.8, steps 5–7).**
+/-- **Scalar multiplicity-entry Z-gauge construction.**
 
 Given two multiplicity-entry families where:
 1. The `m`-th powers agree pointwise,
@@ -465,11 +471,11 @@ Given two multiplicity-entry families where:
 produces: multiplicity-entry multiset equality, a diagonal Z with `Z^m = 1`, and
 `Z · diag(ν) = diag(μ)`.
 
-In the full Theorem 3.8 proof, hypothesis (3) follows from BNT linear independence + equal
-MPVs (via `power_sums_eq_of_eventually_eq_hetero`), and hypothesis (1) is the Newton-Girard
-consequence of (3) restricted to multiples of `m`. The source theorem uses
-matrix-valued multiplicities `R_j` and `S_j`; this theorem is the scalar-entry
-component used by the current Lean statement. -/
+In the source theorem `thm:bdequal`, hypothesis (3) follows from BNT linear
+independence + equal MPVs (via `power_sums_eq_of_eventually_eq_hetero`), and
+hypothesis (1) is the Newton-Girard consequence of (3) restricted to multiples of `m`.
+The source theorem uses matrix-valued multiplicities `R_j` and `S_j`; this theorem is
+the scalar-entry component used by the current Lean statement. -/
 theorem equalCase_zgauge_of_power_sums
     {r : ℕ} (m : ℕ) (μ ν : Fin r → ℂ)
     (hν : ∀ i, ν i ≠ 0)
@@ -484,17 +490,19 @@ theorem equalCase_zgauge_of_power_sums
 
 end ZGaugeConstruction
 
-/-! ## Theorem 3.8 — Equal case (arXiv:1708.00029)
+/-! ## Equal-case theorem `thm:bdequal` (arXiv:1708.00029, lines 643--656)
 
 The equal-case Fundamental Theorem of MPS in irreducible form combines:
 
-1. **Theorem 3.4** (`fundamentalTheorem_periodic_proportional`): block matching.
+1. **Proportional theorem `thm:bd`** (`fundamentalTheorem_periodic_proportional`):
+   block matching.
 2. **Z-gauge construction** (`equalCase_zgauge_of_power_sums`):
    Newton–Girard plus a scalar multiplicity-entry Z-gauge diagonal.
 
 **Remaining source hypotheses:** The `PeriodicOverlapHypothesis` and per-block
 multiplicity-entry power equality hypotheses remain to be discharged from the
-periodic overlap dichotomy (Proposition 3.3) and the coefficient extraction theory.
+periodic overlap dichotomy (`equal-or-orthogonal-generalized`) and the coefficient
+extraction theory.
 The Z-gauge construction itself is fully proved.
 -/
 
@@ -502,7 +510,7 @@ section EqualCase
 
 variable {D₁ D₂ : ℕ}
 
-/-- **Theorem 3.8, Step 1: Block matching.**
+/-- **Equal-case theorem `thm:bdequal`, block-matching component.**
 
 If two tensors in irreducible form with non-repeated blocks satisfy the periodic overlap
 dichotomy, their bases of periodic tensors match: equal block counts, a bijection, and
@@ -512,7 +520,7 @@ Convenience reformulation of `fundamentalTheorem_periodic_proportional` that ext
 families from `IsIrreducibleForm`.
 
 **Remaining source hypothesis:** The `PeriodicOverlapHypothesis` parameter remains to be
-discharged from the periodic overlap dichotomy (Proposition 3.3). -/
+discharged from the periodic overlap dichotomy (`equal-or-orthogonal-generalized`). -/
 theorem fundamentalTheorem_periodic_equalCase_matching
     (A : MPSTensor d D₁) (B : MPSTensor d D₂)
     (hA : IsIrreducibleForm A) (hB : IsIrreducibleForm B)
@@ -537,7 +545,7 @@ overlap dichotomy and per-block multiplicity-entry power equality, then:
 3. **Multiplicity-entry equality**: `μA_j` and `μB_{perm j}` determine the same
    singleton multiset.
 
-This composes Theorem 3.4 with the Z-gauge construction.
+This composes the proportional theorem `thm:bd` with the Z-gauge construction.
 
 **Remaining source hypotheses:** The `PeriodicOverlapHypothesis` and `hPowEq` hypotheses
 remain to be discharged from the periodic overlap dichotomy and coefficient extraction
@@ -566,7 +574,7 @@ theorem fundamentalTheorem_periodic_equalCase
         Z * Matrix.diagonal (fun _ : Fin 1 => hA.μ j) =
           Matrix.diagonal (fun _ : Fin 1 => hB.μ (perm j)) ∧
         ({hA.μ j} : Multiset ℂ) = {hB.μ (perm j)}) := by
-  -- Step 1: Block matching via Theorem 3.4.
+  -- Step 1: block matching via the proportional theorem `thm:bd`.
   obtain ⟨hrAB, perm, hRep⟩ :=
     fundamentalTheorem_periodic_equalCase_matching A B hA hB hNonRepA hNonRepB hOverlap
   refine ⟨hrAB, perm, hRep, fun j => ?_⟩

--- a/TNLean/MPS/Periodic/Overlap.lean
+++ b/TNLean/MPS/Periodic/Overlap.lean
@@ -26,12 +26,13 @@ The supporting modules are:
   implies orthogonality.
 * `TNLean.MPS.Periodic.Overlap.Case3` — equal period with a sector match yields
   repeated blocks.
-* `TNLean.MPS.Periodic.Overlap.Dichotomy` — Proposition 3.3 and eventual
-  linear independence.
+* `TNLean.MPS.Periodic.Overlap.Dichotomy` — the source proposition
+  `equal-or-orthogonal-generalized` and eventual linear independence.
 
 ## References
 
 * De las Cuevas, Cirac, Schuch, Perez-Garcia,
   *Irreducible forms of Matrix Product States: Theory and Applications*,
-  arXiv:1708.00029, Proposition 3.3 and Appendix A.
+  arXiv:1708.00029, proposition `equal-or-orthogonal-generalized`
+  and Appendix A.
 -/

--- a/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
+++ b/TNLean/MPS/Periodic/Overlap/Dichotomy.lean
@@ -7,8 +7,8 @@ import TNLean.MPS.Periodic.Overlap.Case3
 /-!
 # Periodic overlap dichotomy: main statement
 
-This module contains the final Proposition 3.3 statement and its eventual
-linear-independence corollary.
+This module contains the statement of the source proposition
+`equal-or-orthogonal-generalized` and its eventual linear-independence corollary.
 
 ## Main declarations
 
@@ -19,7 +19,8 @@ linear-independence corollary.
 
 * De las Cuevas, Cirac, Schuch, Perez-Garcia,
   *Irreducible forms of Matrix Product States: Theory and Applications*,
-  arXiv:1708.00029, Proposition 3.3 and Appendix A.
+  arXiv:1708.00029, proposition `equal-or-orthogonal-generalized`
+  and Appendix A.
 -/
 
 open scoped Matrix BigOperators ComplexOrder InnerProductSpace
@@ -29,9 +30,10 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ## Main dichotomy (Proposition 3.3) -/
+/-! ## Main dichotomy from `equal-or-orthogonal-generalized` -/
 
-/-- **Periodic overlap dichotomy** (Proposition 3.3 of arXiv:1708.00029).
+/-- **Periodic overlap dichotomy** (arXiv:1708.00029,
+proposition `equal-or-orthogonal-generalized`).
 
 For two periodic tensors `A` and `B` with periods `m_a` and `m_b` in
 irreducible form II, either their overlap decays to zero, or `D_a = D_b` and

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean
@@ -625,7 +625,8 @@ private lemma adjointTransferMap_primitive_and_irreducible_sectorBlock_of_cyclic
       A blocks (φ := φ) hPproj hIntertwine hMul hStar u hNonzero
       hInv hCornerPrim hCornerIrr
 
-/-- **Structural step** for Case 3 of Proposition 3.3 (arXiv:1708.00029):
+/-- **Structural step** for Case 3 of the source proposition
+`equal-or-orthogonal-generalized` (arXiv:1708.00029):
 each nonzero compressed sector block `blocks u` arising from a cyclic sector
 decomposition of a periodic irreducible tensor has both a primitive transfer
 map and is tensor-irreducible.

--- a/TNLean/MPS/Periodic/Symmetry/EqualCaseFTHyp.lean
+++ b/TNLean/MPS/Periodic/Symmetry/EqualCaseFTHyp.lean
@@ -31,8 +31,8 @@ section PeriodicEqualCaseFTHyp
 variable {d D : ℕ}
 
 /-- Coarse abstract form of the periodic equal-case Fundamental Theorem of MPS,
-motivated by Theorem 3.8 of arXiv:1708.00029 and stated as a Prop for use as
-an explicit hypothesis.
+motivated by the source theorem `thm:bdequal` (arXiv:1708.00029, lines 643--656)
+and stated as a Prop for use as an explicit hypothesis.
 
 Given two tensors of the same physical/bond dimensions in irreducible form that
 generate the same matrix-product-vector family, this hypothesis asserts the existence

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -389,8 +389,8 @@ irreducible-form blocked tensor `C` has the same MPV family as a blocked root
 same blocked transfer map, `E_C = E_{A'^{[p]}}`.
 
 In the paper this is the point where the blocked equal-case Fundamental Theorem
-(Theorem 3.8 of arXiv:1708.00029) is combined with the blocked-to-root
-reconstruction that distributes the resulting `Z`-gauge across the cyclic
+(source theorem `thm:bdequal`, arXiv:1708.00029, lines 643--656) is combined
+with the blocked-to-root reconstruction that distributes the resulting `Z`-gauge across the cyclic
 sectors of `A`. Formalizing that existence step is the remaining forward
 obstruction, so we keep the resulting existence statement as a separate
 hypothesis. The theorem `peripheralEqualCase_periodicFT_of_sameMPV` below
@@ -437,8 +437,9 @@ Morally, the canonicalization is produced as follows. Given a witness
 `pRefinementCanonicalization_pullback_of_irreducibleForm` now cover this
 first stage, giving `E_C = E_B`, `SameMPV C (blockTensor A p)`, and preserving
 irreducible form II when `B` already has it. The periodic equal-case
-Fundamental Theorem (Theorem 3.8 of arXiv:1708.00029, available here as the
-hypothesis `PeriodicEqualCaseFT`) then supplies a `Z`-gauge equivalence
+Fundamental Theorem (source theorem `thm:bdequal`, arXiv:1708.00029,
+lines 643--656, available here as the hypothesis `PeriodicEqualCaseFT`) then
+supplies a `Z`-gauge equivalence
 between `C` and `blockTensor A p`, which — combined with a unitary
 canonical-form reduction for irreducible form II and Wolf Theorem 2.18 —
 produces the sought left-canonical witness. Formalizing this remaining second

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -375,7 +375,8 @@ directly to periodic tensors.
 
 \subsection{Statement of the periodic Fundamental Theorem}
 
-The following is Theorem~3.8 (``equal case'') of \cite{DeLasCuevas2017Irreducible}.
+The following is the equal-case theorem of
+\cite[lines~643--656]{DeLasCuevas2017Irreducible}.
 The statements recorded here are conditional components of that theorem: the
 final comparison still assumes periodic-overlap and power-equality hypotheses,
 so the literature theorem has not yet been obtained here as a single
@@ -419,8 +420,8 @@ unconditional result.
     with $[A^i, Z] = 0$ and $\mathcal{V}(A) = \mathcal{V}(ZA)$.
 
     \noindent\emph{Remark.}
-    The proof is conditional on the periodic-overlap dichotomy
-    \cite[Proposition~3.3]{DeLasCuevas2017Irreducible},
+    The proof is conditional on the periodic-overlap dichotomy of
+    \cite[lines~589--609]{DeLasCuevas2017Irreducible},
     which is left here as a separate hypothesis.
 \end{theorem}
 
@@ -1460,8 +1461,9 @@ unconditional result.
         \ker \Phi_N=\{0\}.
     \]
 
-    \emph{Scope restriction.}  The source consequence following
-    \cite[Proposition~3.3]{DeLasCuevas2017Irreducible} also states that
+    \emph{Scope restriction.}  The source consequence following the
+    periodic-overlap dichotomy
+    \cite[lines~589--609]{DeLasCuevas2017Irreducible} also states that
     the non-zero vectors $\ket{V_N(A_j)}$ span the vector $\ket{V_N(A)}$;
     this spanning assertion is what the paper cites as justification for
     the phrase ``basis of periodic vectors''.  The theorem recorded here
@@ -1672,7 +1674,7 @@ unconditional result.
 \begin{remark}[Proportional periodic FT]\notready
     \label{rem:periodic_ft_proportional}
     There is also a proportional periodic Fundamental Theorem
-    (Theorem~3.4, ``proportional case'', in \cite{DeLasCuevas2017Irreducible}).
+    \cite[lines~613--623]{DeLasCuevas2017Irreducible}.
     The former formulation of this theorem assumed externally supplied
     coefficient arrays with nonzero limits as hypotheses. That is not the
     hypothesis set of the source theorem.


### PR DESCRIPTION
### Motivation

- Blueprint prose and Lean docstrings for the periodic overlap dichotomy (arXiv:1708.00029, Proposition 3.3 / Appendix A) and for the proportional and equal periodic Fundamental Theorems (Theorems 3.4 and 3.8) referenced source positions by stale section-number prose rather than by the actual source labels and line anchors in the paper.
- The status note for the overlap dichotomy did not identify the remaining live proof obligation; the Case 3 contraction using the sector maps $F_u$, the $\Omega_u$ contraction, and the phases $\kappa_v$ (Appendix A, lines 1023–1117) requires an explicit citation, tracked in #873.

### Description

- `TNLean/MPS/Periodic/FundamentalTheorem.lean`, `TNLean/MPS/Periodic/Overlap.lean`, `TNLean/MPS/Periodic/Overlap/Dichotomy.lean`, `TNLean/MPS/Periodic/Overlap/SelfOverlapSetup.lean`, `TNLean/MPS/Periodic/Symmetry/EqualCaseFTHyp.lean`, `TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`: replace stale section-number prose in docstrings with the actual arXiv:1708.00029 source labels (`equal-or-orthogonal-generalized`, `thm:bd`, `thm:bdequal`) and line-range anchors.
- `blueprint/src/chapter/ch22_periodic_ft.tex`: update source citations to paper labels and line references; visible blueprint prose uses mathematical descriptions rather than displaying source labels as theorem content.
- Tightens the overlap-dichotomy status note: the remaining obligation is `repeatedBlocks_of_blockedSectorGaugePhase`, corresponding to Appendix A, lines 1023–1117.

### Testing

- `lake build TNLean.MPS.Periodic.FundamentalTheorem TNLean.MPS.Periodic.Overlap TNLean.MPS.Periodic.Symmetry.EqualCaseFTHyp TNLean.MPS.Periodic.Symmetry.Theorem41Forward`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Refs #619.
Refs #81.
Refs #873.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 08209e8b65da555289268d29228cac42eb1abb6a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->