### PR TITLE
feat(MPS/ParentHamiltonian): add block-diagonal kernel inclusion

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -19,38 +19,6 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- A vector in the periodic chain ground space is annihilated by every local
-parent-Hamiltonian term.
-
-This is the local constraint direction in the parent-Hamiltonian construction:
-membership in every cyclic \(L\)-site ground-space window implies the
-frustration-free equations for the translated parent interactions. -/
-theorem isFrustrationFree_of_mem_chainGroundSpace {D : ℕ} (A : MPSTensor d D)
-    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
-    {ψ : NSiteSpace d N} (hψ : ψ ∈ chainGroundSpace A L N) :
-    IsFrustrationFree A L N ψ := by
-  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ
-  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
-  intro i
-  ext σ
-  simp only [localTerm, hLN, ↓reduceDIte, LinearMap.pi_apply, LinearMap.comp_apply,
-    LinearMap.proj_apply, Pi.zero_apply]
-  have hrestrict :
-      (fun τ => ψ (replaceWindow L hLN i σ τ)) =
-        cyclicRestrictₗ hN L i σ ψ := by
-    ext τ
-    rw [cyclicRestrictₗ_apply]
-    have hcfg : replaceWindow L hLN i σ τ = cyclicCfg hN L i τ σ := rfl
-    rw [hcfg]
-  have hmem : (fun τ => ψ (replaceWindow L hLN i σ τ)) ∈ groundSpace A L := by
-    rw [hrestrict]
-    exact hψ i σ
-  have hkill := parentInteraction_apply_mem_groundSpace A L _ hmem
-  change (parentInteraction A L (fun τ => ψ (replaceWindow L hLN i σ τ)))
-    (extractWindow L i σ) = 0
-  rw [hkill]
-  rfl
-
 /-- The periodic chain ground space of a single block is contained in the
 periodic chain ground space of the block-diagonal tensor.
 

--- a/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean
@@ -19,6 +19,38 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+/-- A vector in the periodic chain ground space is annihilated by every local
+parent-Hamiltonian term.
+
+This is the local constraint direction in the parent-Hamiltonian construction:
+membership in every cyclic \(L\)-site ground-space window implies the
+frustration-free equations for the translated parent interactions. -/
+theorem isFrustrationFree_of_mem_chainGroundSpace {D : ℕ} (A : MPSTensor d D)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    {ψ : NSiteSpace d N} (hψ : ψ ∈ chainGroundSpace A L N) :
+    IsFrustrationFree A L N ψ := by
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
+  intro i
+  ext σ
+  simp only [localTerm, hLN, ↓reduceDIte, LinearMap.pi_apply, LinearMap.comp_apply,
+    LinearMap.proj_apply, Pi.zero_apply]
+  have hrestrict :
+      (fun τ => ψ (replaceWindow L hLN i σ τ)) =
+        cyclicRestrictₗ hN L i σ ψ := by
+    ext τ
+    rw [cyclicRestrictₗ_apply]
+    have hcfg : replaceWindow L hLN i σ τ = cyclicCfg hN L i τ σ := rfl
+    rw [hcfg]
+  have hmem : (fun τ => ψ (replaceWindow L hLN i σ τ)) ∈ groundSpace A L := by
+    rw [hrestrict]
+    exact hψ i σ
+  have hkill := parentInteraction_apply_mem_groundSpace A L _ hmem
+  change (parentInteraction A L (fun τ => ψ (replaceWindow L hLN i σ τ)))
+    (extractWindow L i σ) = 0
+  rw [hkill]
+  rfl
+
 /-- The periodic chain ground space of a single block is contained in the
 periodic chain ground space of the block-diagonal tensor.
 
@@ -55,6 +87,33 @@ theorem iSup_chainGroundSpace_block_le_toTensorFromBlocks
       chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N := by
   exact iSup_le fun j =>
     chainGroundSpace_block_le_toTensorFromBlocks μ A (hμ j) hN hLN
+
+/-- The block MPS vectors have zero energy for the block-diagonal parent
+Hamiltonian.
+
+Let \(B=\bigoplus_j\mu_jA_j\), with every \(\mu_j\ne0\). Since every
+\(V^{(N)}(A_j)\) satisfies the cyclic \(A_j\)-constraints, and the local
+spaces \(G_L(A_j)\) are contained in \(G_L(B)\), the span of the block MPS
+vectors is contained in the kernel of the \(B\)-parent Hamiltonian. This is only
+the easy inclusion in the parent-Hamiltonian ground-space spanning equation;
+the reverse inclusion is the periodic-boundary comparison. -/
+theorem bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :
+    bntMPSVectorSpan A N ≤
+      LinearMap.ker (parentHamiltonian (toTensorFromBlocks (d := d) (μ := μ) A) L N) := by
+  rw [bntMPSVectorSpan]
+  refine Submodule.span_le.mpr ?_
+  rintro _ ⟨j, rfl⟩
+  refine LinearMap.mem_ker.mpr ?_
+  simp only [parentHamiltonian, LinearMap.sum_apply]
+  refine Finset.sum_eq_zero fun i _ => ?_
+  exact isFrustrationFree_of_mem_chainGroundSpace
+    (toTensorFromBlocks (d := d) (μ := μ) A) hN hLN
+    ((chainGroundSpace_block_le_toTensorFromBlocks μ A (hμ j) hN hLN)
+      (mpv_mem_chainGroundSpace (A j) L N hN hLN)) i
 
 /-- Boundary-condition equality for the block-diagonal periodic chain.
 

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -13,65 +13,35 @@ import TNLean.MPS.ParentHamiltonian.RestrictTransport
 /-!
 # Unique ground state for injective MPS parent Hamiltonians
 
-For an injective MPS tensor \(A\) on a periodic chain, the expected parent-Hamiltonian
-ground space is spanned by the MPS vector
+For an injective MPS tensor \(A\) on a periodic chain, the parent-Hamiltonian
+ground space is expected to be spanned by the MPS vector
 \(\sigma \mapsto \operatorname{tr}(A^{\sigma_0} \cdots A^{\sigma_{N-1}})\).
 
 ## Proof outline
 
-For injective \(A\) and lengths \(2 \le N\), \(1<L\le N\), the periodic-chain
-ground space is one-dimensional, spanned by the MPS vector, via open-chain
-build-up and the closure-property step at the periodic boundary:
-
-1. **Open chain**: By iterated application of the intersection property,
-   any state satisfying all local ground-space conditions has the form
-   \(\psi(\sigma)=\operatorname{tr}(A^\sigma X)\) for some boundary
-   matrix \(X \in M_D(\mathbb C)\). This yields a \(D^2\)-dimensional space.
-
-2. **Periodic chain**: The boundary condition obtained when closing the
-   periodic chain constrains \(X\). For injective \(A\), the one-site matrices
-   span \(M_D(\mathbb C)\), so the commutation condition forces \(X\) to be
-   scalar, yielding a one-dimensional ground space spanned by the MPS vector.
-
-## Main results
-
-The periodic-chain ground space `chainGroundSpace A L N` is the intersection of
-the cyclic-window constraints, which the MPS vector satisfies. Reducing those to
-a boundary matrix \(X\) with \(\psi=\Gamma_N(X)\), the closure-property
-comparison at the periodic boundary forces \(X\) scalar: the ground space is
-\(\mathbb C\,V^{(N)}(A)\), also at window length \(L_0+1\) for normal tensors.
-
-## References
-
-* [Cirac--Perez-Garcia--Schuch--Verstraete 2021] arXiv:2011.12127,
-  Section IV.C, lines 1976--2094 (parent Hamiltonian definition and uniqueness
-  argument)
-* [FNW92] Sections 3–4
-* [PGVWC07] arXiv:quant-ph/0608197, Sections 5–6
-
-## Periodic-boundary comparison
-
-The coordinate form of the closure-property ingredient at the periodic boundary
-is the passage from
+The periodic-chain ground space is the intersection of cyclic-window local
+constraints. The open-chain intersection property first gives
+\(\psi(\sigma)=\operatorname{tr}(A^\sigma X)\) for some boundary matrix \(X\).
+Closing the chain then imposes the periodic-boundary comparison
 \[
   A^\mu A^j X=Y^+_{\tau^+_\eta(\mu)}A^j,\qquad
   X A^j A^\mu=A^jY^-_{\tau^-_\eta(\mu)}
 \]
-to
+and hence
 \[
   Y^+_{\tau^+_\eta(\mu)}=Y^-_{\tau^-_\eta(\mu)}
 \]
-for the same complementary-site word \(\mu\). The source states the
-closure-property step in arXiv:2011.12127, Section IV.C, lines 2078--2079; the
-displayed equations are the local coordinate form used here.
-The boundary block-window identity supplies the commutation relation for
-\(X\), and the one-sided products then identify the two boundary matrices.
+for the same complementary-site word. If \(A\) is injective, the resulting
+commutation relation forces \(X\) to be scalar. The normal case uses the
+Wielandt span-growth theorem to reach the same fixed-length word-span
+conclusion after blocking.
 
-The open-chain build-up follows the inverting-and-growing-back argument from
-arXiv:2011.12127, Section IV.C, lines 2049--2078.  The normal case also uses the
-Wielandt span-growth theorem to pass from a cumulative span conclusion to the
-fixed-length word-span theorem used to make the open-chain boundary matrix
-scalar.
+## References
+
+* Cirac--Perez-Garcia--Schuch--Verstraete, arXiv:2011.12127, Section IV.C,
+  lines 1976--2094.
+* [FNW92] Sections 3–4.
+* [PGVWC07] arXiv:quant-ph/0608197, Sections 5–6.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
+++ b/TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean
@@ -146,6 +146,38 @@ theorem mpv_mem_chainGroundSpace (A : MPSTensor d D) (L N : ℕ)
   rw [hrestrict]
   exact mpv_window_mem_groundSpace A L N hLN i τ
 
+/-- A vector in the periodic chain ground space is annihilated by every local
+parent-Hamiltonian term.
+
+This is the local constraint direction in the parent-Hamiltonian construction:
+membership in every cyclic \(L\)-site ground-space window implies the
+frustration-free equations for the translated parent interactions. -/
+theorem isFrustrationFree_of_mem_chainGroundSpace (A : MPSTensor d D)
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    {ψ : NSiteSpace d N} (hψ : ψ ∈ chainGroundSpace A L N) :
+    IsFrustrationFree A L N ψ := by
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩] at hψ
+  simp only [Submodule.mem_iInf, Submodule.mem_comap] at hψ
+  intro i
+  ext σ
+  simp only [localTerm, hLN, ↓reduceDIte, LinearMap.pi_apply, LinearMap.comp_apply,
+    LinearMap.proj_apply, Pi.zero_apply]
+  have hrestrict :
+      (fun τ => ψ (replaceWindow L hLN i σ τ)) =
+        cyclicRestrictₗ hN L i σ ψ := by
+    ext τ
+    rw [cyclicRestrictₗ_apply]
+    have hcfg : replaceWindow L hLN i σ τ = cyclicCfg hN L i τ σ := rfl
+    rw [hcfg]
+  have hmem : (fun τ => ψ (replaceWindow L hLN i σ τ)) ∈ groundSpace A L := by
+    rw [hrestrict]
+    exact hψ i σ
+  have hkill := parentInteraction_apply_mem_groundSpace A L _ hmem
+  change (parentInteraction A L (fun τ => ψ (replaceWindow L hLN i σ τ)))
+    (extractWindow L i σ) = 0
+  rw [hkill]
+  rfl
+
 /-- Every constrained cyclic window of a chain-ground-space vector has a boundary
 matrix representation in the local MPS ground space. -/
 theorem chainGroundSpace_window_witnesses (A : MPSTensor d D)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -197,13 +197,35 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \]
 \end{remark}
 
+\begin{theorem}[Chain ground-space vectors are frustration-free]
+    \label{thm:chain_ground_space_implies_frustration_free}
+    \lean{MPSTensor.isFrustrationFree_of_mem_chainGroundSpace}
+    \leanok
+    \uses{def:chain_ground_space, def:is_frustration_free}
+    Let $\psi$ be a vector in the periodic chain ground space
+    $G_L^{(N)}(A)$. Then $\psi$ satisfies all local zero-energy equations:
+    for every site $i$,
+    \[
+        h_i(A,L)\psi=0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Membership in $G_L^{(N)}(A)$ means that every cyclic $L$-site window of
+    $\psi$ lies in the corresponding local ground space. Hence each translated
+    parent term annihilates $\psi$, which is precisely the frustration-free
+    condition.
+\end{proof}
+
 \begin{lemma}[Zero-energy BNT vectors lie in the parent-Hamiltonian kernel]
     \label{lem:bnt_span_le_parent_hamiltonian_kernel}
     \lean{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_annihilates}
     \lean{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_frustrationFree}
     \lean{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks}
     \leanok
-    \uses{def:bnt_span, def:is_frustration_free, def:parent_hamiltonian}
+    \uses{def:bnt_span, def:is_frustration_free, def:parent_hamiltonian,
+        thm:chain_ground_space_implies_frustration_free}
     Let $B$ be a canonical-form tensor with BNT components
     $A_1,\ldots,A_g$. If every component vector has zero energy for the
     parent Hamiltonian,
@@ -220,8 +242,8 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     It is enough to assume the local frustration-free equations
     $h_iV^{(N)}(A_j)=0$ for every $i$ and $j$.
     In the block-diagonal case
-    \(B=\bigoplus_j\mu_jA_j\), with every \(\mu_j\ne0\), the same inclusion
-    follows because each local space \(G_L(A_j)\) is contained in \(G_L(B)\).
+    $B=\bigoplus_j\mu_jA_j$, with every $\mu_j\ne0$, the same inclusion
+    follows because each local space $G_L(A_j)$ is contained in $G_L(B)$.
     This is the easy inclusion in the source ground-space spanning equation of
     \cite[Definition~3.9]{Cirac2016MPDO_arXiv}; the reverse inclusion is the
     remaining spanning direction.
@@ -239,9 +261,14 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         0.
     \]
-    For a block-diagonal tensor, the \(A_j\)-chain constraints of
-    \(V^{(N)}(A_j)\) imply the \(B\)-chain constraints, and hence the same
-    local equations.
+    For a block-diagonal tensor,
+    \[
+        G_L(A_j)\subseteq G_L(B),
+        \qquad
+        V^{(N)}(A_j)\in G_L(A_j)\subseteq G_L(B),
+        \qquad
+        h_iV^{(N)}(A_j)=0.
+    \]
 \end{proof}
 
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -261,14 +261,14 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         0.
     \]
-    For a block-diagonal tensor, write \(R_{i,\tau}\) for the cyclic
-    length-\(L\) restriction at site \(i\), with the outside configuration
-    fixed by \(\tau\). Then
+    For a block-diagonal tensor, write $R_{i,\tau}$ for the cyclic
+    length-$L$ restriction at site $i$, with the outside configuration
+    fixed by $\tau$. Then
     \[
         R_{i,\tau}V^{(N)}(A_j)\in G_L(A_j)\subseteq G_L(B).
     \]
     The preceding theorem therefore gives
-    \(h_i(B,L)V^{(N)}(A_j)=0\) for every \(i\).
+    $h_i(B,L)V^{(N)}(A_j)=0$ for every $i$.
 \end{proof}
 
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -212,19 +212,27 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
 
 \begin{proof}
     \leanok
-    Write $R_{i,\tau}$ for the cyclic length-$L$ restriction at site $i$,
-    with the outside configuration fixed by $\tau$. Membership in
-    $G_L^{(N)}(A)$ gives, for every $i$ and $\tau$,
+    Write $R_{i,\eta}\psi$ for the cyclic length-$L$ restriction of $\psi$ at
+    site $i$, with the outside configuration fixed by $\eta$. Membership in
+    $G_L^{(N)}(A)$ gives, for every $i$ and $\eta$,
     \[
-        R_{i,\tau}\psi\in G_L(A).
+        R_{i,\eta}\psi\in G_L(A)=\ker h_L(A).
     \]
-    The local ground-space equation then gives
+    Hence
     \[
-        R_{i,\tau}\psi\in G_L(A)
-        \Longrightarrow
-        h_i(A,L)\psi=0.
+        h_L(A)R_{i,\eta}\psi=0.
     \]
-    These equations for all $i$ are exactly the frustration-free condition.
+    For a full configuration $\sigma$, taking
+    $\eta=\sigma|_{\{i,\ldots,i+L-1\}^c}$ gives
+    \[
+        \bigl(h_i(A,L)\psi\bigr)(\sigma)
+        =
+        \bigl(h_L(A)R_{i,\eta}\psi\bigr)
+            \bigl(\sigma|_{\{i,\ldots,i+L-1\}}\bigr)
+        =
+        0.
+    \]
+    Thus $h_i(A,L)\psi=0$ for every $i$.
 \end{proof}
 
 \begin{lemma}[Zero-energy BNT vectors lie in the parent-Hamiltonian kernel]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -261,14 +261,14 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         0.
     \]
-    For a block-diagonal tensor,
+    For a block-diagonal tensor, write \(R_{i,\tau}\) for the cyclic
+    length-\(L\) restriction at site \(i\), with the outside configuration
+    fixed by \(\tau\). Then
     \[
-        G_L(A_j)\subseteq G_L(B),
-        \qquad
-        V^{(N)}(A_j)\in G_L(A_j)\subseteq G_L(B),
-        \qquad
-        h_iV^{(N)}(A_j)=0.
+        R_{i,\tau}V^{(N)}(A_j)\in G_L(A_j)\subseteq G_L(B).
     \]
+    The preceding theorem therefore gives
+    \(h_i(B,L)V^{(N)}(A_j)=0\) for every \(i\).
 \end{proof}
 
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -201,6 +201,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \label{lem:bnt_span_le_parent_hamiltonian_kernel}
     \lean{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_annihilates}
     \lean{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_frustrationFree}
+    \lean{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks}
     \leanok
     \uses{def:bnt_span, def:is_frustration_free, def:parent_hamiltonian}
     Let $B$ be a canonical-form tensor with BNT components
@@ -218,6 +219,9 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \]
     It is enough to assume the local frustration-free equations
     $h_iV^{(N)}(A_j)=0$ for every $i$ and $j$.
+    In the block-diagonal case
+    \(B=\bigoplus_j\mu_jA_j\), with every \(\mu_j\ne0\), the same inclusion
+    follows because each local space \(G_L(A_j)\) is contained in \(G_L(B)\).
     This is the easy inclusion in the source ground-space spanning equation of
     \cite[Definition~3.9]{Cirac2016MPDO_arXiv}; the reverse inclusion is the
     remaining spanning direction.
@@ -235,6 +239,9 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         0.
     \]
+    For a block-diagonal tensor, the \(A_j\)-chain constraints of
+    \(V^{(N)}(A_j)\) imply the \(B\)-chain constraints, and hence the same
+    local equations.
 \end{proof}
 
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -202,7 +202,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \lean{MPSTensor.isFrustrationFree_of_mem_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, def:is_frustration_free}
-    Let $\psi$ be a vector in the periodic chain ground space
+    Assume $N>0$ and $L\le N$. Let $\psi$ be a vector in the periodic chain ground space
     $G_L^{(N)}(A)$. Then $\psi$ satisfies all local zero-energy equations:
     for every site $i$,
     \[
@@ -212,10 +212,19 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
 
 \begin{proof}
     \leanok
-    Membership in $G_L^{(N)}(A)$ means that every cyclic $L$-site window of
-    $\psi$ lies in the corresponding local ground space. Hence each translated
-    parent term annihilates $\psi$, which is precisely the frustration-free
-    condition.
+    Write $R_{i,\tau}$ for the cyclic length-$L$ restriction at site $i$,
+    with the outside configuration fixed by $\tau$. Membership in
+    $G_L^{(N)}(A)$ gives, for every $i$ and $\tau$,
+    \[
+        R_{i,\tau}\psi\in G_L(A).
+    \]
+    The local ground-space equation then gives
+    \[
+        R_{i,\tau}\psi\in G_L(A)
+        \Longrightarrow
+        h_i(A,L)\psi=0.
+    \]
+    These equations for all $i$ are exactly the frustration-free condition.
 \end{proof}
 
 \begin{lemma}[Zero-energy BNT vectors lie in the parent-Hamiltonian kernel]
@@ -241,7 +250,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \]
     It is enough to assume the local frustration-free equations
     $h_iV^{(N)}(A_j)=0$ for every $i$ and $j$.
-    In the block-diagonal case
+    For $N>0$ and $L\le N$, in the block-diagonal case
     $B=\bigoplus_j\mu_jA_j$, with every $\mu_j\ne0$, the same inclusion
     follows because each local space $G_L(A_j)$ is contained in $G_L(B)$.
     This is the easy inclusion in the source ground-space spanning equation of

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -202,9 +202,9 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \lean{MPSTensor.isFrustrationFree_of_mem_chainGroundSpace}
     \leanok
     \uses{def:chain_ground_space, def:is_frustration_free}
-    Assume $N>0$ and $L\le N$. Let $\psi$ be a vector in the periodic chain ground space
-    $G_L^{(N)}(A)$. Then $\psi$ satisfies all local zero-energy equations:
-    for every site $i$,
+    Assume $N>0$ and $L\le N$. Let $\psi$ be a vector in the periodic chain
+    ground space $G_L^{(N)}(A)$. Then $\psi$ satisfies all local zero-energy
+    equations: for every site $i$,
     \[
         h_i(A,L)\psi=0.
     \]


### PR DESCRIPTION
### Motivation

- The nearest-neighbor commuting parent Hamiltonian theory for canonical-form MPS (arXiv:1606.00608) requires proving that block MPS vectors lie in the zero-energy ground space of the block-diagonal parent Hamiltonian, and that ground-space membership implies the local frustration-free equations.
- This establishes the easy (forward) inclusion half of the ground-space characterisation; the reverse inclusion — that the span of block MPS vectors equals the full ground space — remains open and is tracked in #2633.
- Continues formalization of the parent Hamiltonian material in `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`.

### Description

- `TNLean/MPS/ParentHamiltonian/BlockDiagonalChainGroundSpace.lean`: adds lemmas proving that the span of block MPS vectors lies in the kernel of the block-diagonal parent Hamiltonian (the easy/forward kernel inclusion).
- `TNLean/MPS/ParentHamiltonian/UniqueGroundState.lean`: adds lemmas proving that membership in the periodic chain ground space implies the local frustration-free equations.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: updates the parent-Hamiltonian blueprint lemma with `\lean{}` and `\leanok` tags for the block-diagonal kernel inclusion; the reverse ground-space spanning entry does not yet carry `\leanok`.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace TNLean.MPS.ParentHamiltonian.UniqueGroundState -q --log-level=info`
- `lake exe checkdecls blueprint/lean_decls`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses #2633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only additions in MPS parent-Hamiltonian theory and blueprint sync; no runtime, auth, or data-path changes.
> 
> **Overview**
> Formalizes the **easy forward inclusion** for block-diagonal parent Hamiltonians: periodic chain ground-space membership implies local frustration-free equations, and block MPS vectors therefore lie in the kernel of \(H_L^{(N)}(B)\) when \(B=\bigoplus_j \mu_j A_j\) with \(\mu_j\ne 0\).
> 
> **Lean:** `isFrustrationFree_of_mem_chainGroundSpace` shows every cyclic \(L\)-window restriction in \(G_L(A)\) forces each translated parent term to vanish. `bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks` combines blockwise `chainGroundSpace` inclusion with `mpv_mem_chainGroundSpace` and sums local terms to zero. The `UniqueGroundState` module doc is shortened; proof logic is unchanged.
> 
> **Blueprint:** New theorem *Chain ground-space vectors are frustration-free* (`\leanok`); the BNT-span/kernel lemma gains the block-diagonal `\lean` tag and a proof step via \(G_L(A_j)\subseteq G_L(B)\). Reverse ground-space spanning remains open (#2633).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f3f7e2a7581a15c39e6e16ac7da134db1bf7e26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->