### PR TITLE
doc(parent): clarify boundary-crossing proof prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -87,9 +87,9 @@ in both cases.
     \leanok
     \uses{def:ground_space_parent, rem:cyclic_window_operators}
     When the window stays inside the chosen linear interval, the boundary matrix
-    remains outside the window. Let $A_{\rm left}$ be the product on the sites
-    before the window and $A_{\rm right}$ the product on the sites after the
-    window. Trace cyclicity
+    remains outside the window. Write
+    $A_{\rm left}=A^j_{\tau_0}\cdots A^j_{\tau_{i-1}}$ and
+    $A_{\rm right}=A^j_{\tau_{i+L}}\cdots A^j_{\tau_{N-1}}$. Trace cyclicity
     gives
     \[
         R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
@@ -211,10 +211,10 @@ in both cases.
         =
         \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
     \]
-    This theorem is the fixed cyclic-interval coordinate form of the
-    Perez-Garcia--Verstraete--Wolf--Cirac comparison
-    $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$; it does not assert
-    the full periodic-boundary ground-space statement.
+    % Coordinate form of the Perez-Garcia--Verstraete--Wolf--Cirac comparison
+    % $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$ from
+    % \cite[Theorem~12]{PerezGarcia2007Matrix}; this theorem does not assert
+    % the full periodic-boundary ground-space statement.
 \end{theorem}
 
 \begin{proof}
@@ -254,8 +254,7 @@ in both cases.
         R_{i,\tau}\!\left(\Gamma_N^{A_j}(\mu_j^NX_j)\right)
         \in G_L(A_j).
     \]
-    This is the corresponding fixed-interval block-diagonal boundary-condition
-    consequence.
+    % Fixed-window local-membership consequence of the preceding comparison.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
### Motivation

- PR #3320 (*doc(parent-hamiltonian): split block-diagonal boundary-crossing blueprint*) created `ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex` but left a local prose cleanup in the worktree; this PR carries that cleanup forward instead of discarding it.
- Continues blueprint prose improvements for the PGVWC07 block-diagonal parent-Hamiltonian boundary comparison; see #2971.

### Description

- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex`:
  - Makes $A_{\rm left} = A^j_{\tau_0}\cdots A^j_{\tau_{i-1}}$ and $A_{\rm right} = A^j_{\tau_{i+L}}\cdots A^j_{\tau_{N-1}}$ explicit around non-crossing cyclic windows.
  - Converts two explanatory sentences in the boundary-crossing theorem block into source comments, keeping the reader-facing statement formula-led.
- No Lean declarations, blueprint labels, or `\lean{}` tags are changed.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`

---
Addresses #2971

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 462bee153e8a26c8003c8215a256bfd180efaf69. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>