### PR TITLE
refactor(PEPS): use native ext for trace pairings

### DIFF
--- a/TNLean/PEPS/CycleMPSChainArc.lean
+++ b/TNLean/PEPS/CycleMPSChainArc.lean
@@ -384,16 +384,17 @@ theorem eq_of_trace_pairing_span {ι : Sort*} {F : ι → Matrix (Fin D) (Fin D)
     (hspan : Submodule.span ℂ (Set.range F) = ⊤)
     {M N : Matrix (Fin D) (Fin D) ℂ}
     (h : ∀ i, Matrix.trace (M * F i) = Matrix.trace (N * F i)) : M = N := by
+  have hmaps :
+      (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulLeft ℂ M) =
+        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulLeft ℂ N) := by
+    apply LinearMap.ext_on_range (v := F) (hv := hspan)
+    intro i
+    simpa only [Matrix.traceLinearMap_apply, LinearMap.comp_apply,
+      LinearMap.mulLeft_apply] using h i
   apply (Matrix.ext_iff_trace_mul_right).2
   intro Q
-  have hQ : Q ∈ Submodule.span ℂ (Set.range F) := hspan ▸ Submodule.mem_top
-  induction hQ using Submodule.span_induction with
-  | mem x hx =>
-      obtain ⟨i, rfl⟩ := hx
-      exact h i
-  | zero => simp
-  | add x y _ _ hx hy => simp [Matrix.mul_add, Matrix.trace_add, hx, hy]
-  | smul c x _ hx => simp [Matrix.trace_smul, hx]
+  simpa only [Matrix.traceLinearMap_apply, LinearMap.comp_apply,
+    LinearMap.mulLeft_apply] using congrArg (fun f => f Q) hmaps
 
 /-- **Uniqueness of a right factor against a spanning family** — the
 spanning-family form of the uniqueness of the bond operator

--- a/TNLean/PEPS/CycleMPSWordTransport.lean
+++ b/TNLean/PEPS/CycleMPSWordTransport.lean
@@ -129,17 +129,18 @@ theorem eq_of_trace_mul_evalWord_eq {B : MPSTensor d D} {m : ℕ}
     (h : ∀ ρ : Fin m → Fin d,
       Matrix.trace (M * evalWord B (List.ofFn ρ)) =
         Matrix.trace (N * evalWord B (List.ofFn ρ))) : M = N := by
+  have hmaps :
+      (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulLeft ℂ M) =
+        (Matrix.traceLinearMap (Fin D) ℂ ℂ).comp (LinearMap.mulLeft ℂ N) := by
+    apply LinearMap.ext_on_range
+      (v := fun ρ : Fin m → Fin d => evalWord B (List.ofFn ρ)) (hv := hspan)
+    intro ρ
+    simpa only [Matrix.traceLinearMap_apply, LinearMap.comp_apply,
+      LinearMap.mulLeft_apply] using h ρ
   apply (Matrix.ext_iff_trace_mul_right).2
   intro Q
-  have hQ : Q ∈ Submodule.span ℂ (Set.range fun ρ : Fin m → Fin d =>
-      evalWord B (List.ofFn ρ)) := hspan ▸ Submodule.mem_top
-  induction hQ using Submodule.span_induction with
-  | mem x hx =>
-      obtain ⟨ρ, rfl⟩ := hx
-      exact h ρ
-  | zero => simp
-  | add x y _ _ hx hy => simp [Matrix.mul_add, Matrix.trace_add, hx, hy]
-  | smul c x _ hx => simp [Matrix.trace_smul, hx]
+  simpa only [Matrix.traceLinearMap_apply, LinearMap.comp_apply,
+    LinearMap.mulLeft_apply] using congrArg (fun f => f Q) hmaps
 
 /-! ### The generic transport construction -/
 

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -94,6 +94,10 @@ The clearest replacements are:
 - Two PEPS conjugation-extension helpers no longer prove linear-map equality
   by hand over a spanning set.  They use Mathlib's `LinearMap.ext_on` and
   `LinearMap.ext_on_range` for equality on a spanning set or range.
+- Two PEPS trace-pairing extension lemmas no longer perform explicit
+  `Submodule.span_induction` over a spanning word family.  They use
+  `LinearMap.ext_on_range` to extend equality of the trace-linear functionals
+  to all matrices.
 - Two one-use Frobenius submultiplicativity wrappers in the transfer-operator
   gap files were removed.  The proofs now call Mathlib's
   `Matrix.frobenius_norm_mul` directly at the Hilbert-Schmidt estimate.
@@ -2310,6 +2314,29 @@ Focused checks:
 ```bash
 lake env lean TNLean/PEPS/CycleMPSTranslationInvariant.lean
 lake env lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+```
+
+## PEPS trace-pairing extension cleanup, 2026-06-21
+
+Two trace-pairing uniqueness lemmas used explicit `Submodule.span_induction`
+proofs to extend equality from a spanning family of word products to every
+matrix:
+
+- `MPSTensor.eq_of_trace_mul_evalWord_eq` in
+  `TNLean/PEPS/CycleMPSWordTransport.lean`;
+- `MPSChainTensor.eq_of_trace_pairing_span` in
+  `TNLean/PEPS/CycleMPSChainArc.lean`.
+
+Both proofs now regard `Q ↦ trace (M * Q)` and `Q ↦ trace (N * Q)` as
+linear functionals, use `LinearMap.ext_on_range` on the spanning word family,
+and then apply the native trace-pairing extensionality theorem
+`Matrix.ext_iff_trace_mul_right`.
+
+Focused checks:
+
+```bash
+lake build TNLean.PEPS.CycleMPSChainArc -q --log-level=info
+lake build TNLean.PEPS.CycleMPSWordTransport -q --log-level=info
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- The proofs of `eq_of_trace_pairing_span` (`CycleMPSChainArc.lean`) and
  `eq_of_trace_mul_evalWord_eq` (`CycleMPSWordTransport.lean`) established matrix
  equality from matching trace pairings on a spanning family via explicit
  `Submodule.span_induction` recursion.
- Mathlib 4.31 provides `LinearMap.ext_on_range`, which derives linear-map
  extensionality directly from agreement on a spanning set, and
  `Matrix.ext_iff_trace_mul_right`, which reduces matrix equality to matching
  traces against all test matrices; together they make the span-induction
  unrolling unnecessary.
- The Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`)
  records this cleanup as part of the ongoing PEPS linear-map extension replacement work.

### Description

- `TNLean/PEPS/CycleMPSChainArc.lean`: refactors `eq_of_trace_pairing_span` to show
  that the composed maps `trace ∘ mulLeft M` and `trace ∘ mulLeft N` agree on the
  spanning range via `LinearMap.ext_on_range`, then closes with
  `Matrix.ext_iff_trace_mul_right` on an arbitrary test matrix.
- `TNLean/PEPS/CycleMPSWordTransport.lean`: same refactoring applied to
  `eq_of_trace_mul_evalWord_eq`.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records the replacement
  of explicit span induction by `LinearMap.ext_on_range` in both files.
- Theorem statements are unchanged; no `sorry` or `axiom` introduced.

### Testing

- `lake build TNLean.PEPS.CycleMPSChainArc TNLean.PEPS.CycleMPSWordTransport -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py`
- `rg -n "\bsorry\b|\baxiom\b|native_decide|unsafeCast|\badmit\b" TNLean/PEPS/CycleMPSWordTransport.lean TNLean/PEPS/CycleMPSChainArc.lean` returned no matches

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged theorem statements; no API, auth, or runtime behavior changes.
>
> **Overview**
> **Refactors** `eq_of_trace_pairing_span` (`CycleMPSChainArc.lean`) and `eq_of_trace_mul_evalWord_eq` (`CycleMPSWordTransport.lean`) so matrix equality from matching trace pairings on a spanning family no longer uses explicit `Submodule.span_induction`.
>
> Each proof now shows the composed maps `trace ∘ mulLeft M` and `trace ∘ mulLeft N` agree on the spanning range via **`LinearMap.ext_on_range`**, then closes with **`Matrix.ext_iff_trace_mul_right`** on an arbitrary test matrix `Q`.
>
> The Mathlib 4.31 replacement audit documents this as part of the ongoing PEPS linear-map extension cleanup (alongside earlier `LinearMap.ext_on` conjugation helpers).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a32153672946f5138ee8f25ab179445de10305b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>