### PR TITLE
feat(MPS/ParentHamiltonian): isolate reverse spanning inclusion

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -221,6 +221,7 @@ import TNLean.MPS.ParentHamiltonian.BNTBlockIntersection
 import TNLean.MPS.ParentHamiltonian.CyclicSubmoduleIteration
 import TNLean.MPS.ParentHamiltonian.BlockSumGroundSpace
 import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalChain
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossing
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.Commuting
+
+/-!
+# Ground-space spanning for block-diagonal parent Hamiltonians
+
+This file packages the source ground-space spanning clause from
+arXiv:1606.00608, Definition 3.9, for block-diagonal tensors.  The easy
+inclusion of the BNT span into the parent-Hamiltonian kernel is already proved;
+therefore the source spanning condition is equivalent to the reverse inclusion.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-- For a block-diagonal tensor with nonzero weights, the source parent-Hamiltonian
+ground-space spanning clause is equivalent to the reverse inclusion.
+
+Let \(B=\bigoplus_j\mu_jA_j\), with every \(\mu_j\ne0\).  The inclusion
+\[
+  \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}
+  \subseteq \ker H_L^{(N)}(B)
+\]
+is the easy direction, already proved by
+`bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks`. Hence the
+Definition 3.9 spanning equation is reduced to proving, for every \(N>L\),
+\[
+  \ker H_L^{(N)}(B)
+  \subseteq
+  \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}.
+\]
+See arXiv:1606.00608, Definition 3.9, source lines 522--524. -/
+theorem hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0) {L : ℕ} :
+    HasParentHamiltonianGroundSpaceSpanning
+        (toTensorFromBlocks (d := d) (μ := μ) A) L A ↔
+      ∀ N : ℕ, L < N →
+        LinearMap.ker (parentHamiltonian
+          (toTensorFromBlocks (d := d) (μ := μ) A) L N) ≤
+          bntMPSVectorSpan A N := by
+  constructor
+  · intro hSpan N hN
+    rw [hSpan N hN]
+  · intro hReverse N hN
+    refine le_antisymm (hReverse N hN) ?_
+    have hNpos : 0 < N := lt_of_le_of_lt (Nat.zero_le L) hN
+    exact bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks
+      μ A hμ hNpos (le_of_lt hN)
+
+/-- For block-diagonal nearest-neighbor parent Hamiltonians, the all-chain
+source condition is equivalent to all-chain translated parent-term commutation
+together with the reverse ground-space inclusion.
+
+This is the nearest-neighbor specialization of
+`hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan`.
+It isolates the remaining spanning direction in arXiv:1606.00608,
+Theorem 3.10(iii), after the easy inclusion for the BNT vectors. -/
+theorem hasNNCPHGroundSpaces_toTensorFromBlocks_iff_forall_isNNCPH_and_ker_le_bntMPSVectorSpan
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0) :
+    HasNNCPHGroundSpaces (toTensorFromBlocks (d := d) (μ := μ) A) A ↔
+      (∀ N : ℕ, 2 < N →
+        IsNNCPH (toTensorFromBlocks (d := d) (μ := μ) A) N) ∧
+      ∀ N : ℕ, 2 < N →
+        LinearMap.ker (parentHamiltonian
+          (toTensorFromBlocks (d := d) (μ := μ) A) 2 N) ≤
+          bntMPSVectorSpan A N := by
+  rw [hasNNCPHGroundSpaces_iff_forall_isNNCPH_and_groundSpaceSpanning,
+    hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan
+      μ A hμ]
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
@@ -9,10 +9,11 @@ import TNLean.MPS.ParentHamiltonian.Commuting
 /-!
 # Ground-space spanning for block-diagonal parent Hamiltonians
 
-This file packages the source ground-space spanning clause from
-arXiv:1606.00608, Definition 3.9, for block-diagonal tensors.  The easy
-inclusion of the BNT span into the parent-Hamiltonian kernel is already proved;
-therefore the source spanning condition is equivalent to the reverse inclusion.
+This file reduces the source ground-space spanning clause from
+arXiv:1606.00608, Definition 3.9, for block-diagonal tensors to the reverse
+inclusion. The easy inclusion of the BNT span into the parent-Hamiltonian kernel
+is already proved; therefore the source spanning condition is equivalent to the
+reverse inclusion.
 -/
 
 open scoped Matrix BigOperators
@@ -24,9 +25,9 @@ variable {d : ℕ}
 /-- For a block-diagonal tensor with nonzero weights, the source parent-Hamiltonian
 ground-space spanning clause is equivalent to the reverse inclusion.
 
-Let \(B=\bigoplus_j\mu_jA_j\), with every \(\mu_j\ne0\).  The inclusion
+Let \(B=\bigoplus_{j=0}^{r-1}\mu_jA_j\), with every \(\mu_j\ne0\). The inclusion
 \[
-  \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}
+  \operatorname{span}\{V^{(N)}(A_j):j=0,\ldots,r-1\}
   \subseteq \ker H_L^{(N)}(B)
 \]
 is the easy direction, already proved by
@@ -35,7 +36,7 @@ Definition 3.9 spanning equation is reduced to proving, for every \(N>L\),
 \[
   \ker H_L^{(N)}(B)
   \subseteq
-  \operatorname{span}\{V^{(N)}(A_j):j=1,\ldots,g\}.
+  \operatorname{span}\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
 \]
 See arXiv:1606.00608, Definition 3.9, source lines 522--524. -/
 theorem hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -295,24 +295,33 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \leanok
     \uses{def:parent_hamiltonian_ground_space_spanning,
         lem:bnt_span_le_parent_hamiltonian_kernel, def:has_nncph_ground_spaces}
-    Let $B=\bigoplus_j\mu_jA_j$, with every $\mu_j\ne0$. Then the source
-    parent-Hamiltonian spanning condition
+    Let $B=\bigoplus_{j=0}^{r-1}\mu_jA_j$, with every $\mu_j\ne0$. Then, for
+    every $N>L$, the source parent-Hamiltonian spanning condition
     \[
         \ker H_L^{(N)}(B)
         =
-        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
-        \qquad (N>L)
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}
     \]
-    is equivalent to the reverse containment
+    is equivalent to the reverse containment, for the same $N$:
     \[
         \ker H_L^{(N)}(B)
         \subseteq
-        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
-        \qquad (N>L).
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
     \]
-    In the nearest-neighbor case, the all-chain source condition is therefore
-    equivalent to the translated two-site commutation equations together with
-    this reverse containment for every $N>2$.
+    In the nearest-neighbor case, the all-chain source condition is equivalent
+    to
+    \[
+        \begin{aligned}
+        \operatorname{HasNNCPHGroundSpaces}(B,A)
+        \Longleftrightarrow
+        &\left(\forall N>2,\ \operatorname{IsNNCPH}(B,N)\right)\\
+        &{}\land
+        \left(\forall N>2,\;
+        \ker H_2^{(N)}(B)
+        \subseteq
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}\right).
+        \end{aligned}
+    \]
 \end{lemma}
 
 \begin{proof}
@@ -320,14 +329,26 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     The forward direction of the displayed equality gives the containment by
     rewriting the kernel. Conversely, for $N>L$ the easy inclusion above gives
     \[
-        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}
         \subseteq
         \ker H_L^{(N)}(B),
     \]
-    and the assumed reverse containment gives equality. For $L=2$, combine
-    this equivalence with the decomposition of the all-chain NNCPH
-    ground-space condition into two-site commutation and the source spanning
-    clause.
+    and the assumed reverse containment gives equality. For $L=2$, the
+    all-chain nearest-neighbor condition decomposes as
+    \[
+        \begin{aligned}
+        \operatorname{HasNNCPHGroundSpaces}(B,A)
+        \Longleftrightarrow
+        &\left(\forall N>2,\ \operatorname{IsNNCPH}(B,N)\right)\\
+        &{}\land
+        \left(\forall N>2,\;
+        \ker H_2^{(N)}(B)
+        \subseteq
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}\right).
+        \end{aligned}
+    \]
+    The second conjunct is the reverse containment just identified with the
+    source spanning clause.
 \end{proof}
 
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -288,6 +288,48 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     $h_i(B,L)V^{(N)}(A_j)=0$ for every $i$.
 \end{proof}
 
+\begin{lemma}[Block-diagonal spanning is equivalent to the reverse inclusion]
+    \label{lem:block_diagonal_parent_spanning_reverse_inclusion}
+    \lean{MPSTensor.hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan}
+    \lean{MPSTensor.hasNNCPHGroundSpaces_toTensorFromBlocks_iff_forall_isNNCPH_and_ker_le_bntMPSVectorSpan}
+    \leanok
+    \uses{def:parent_hamiltonian_ground_space_spanning,
+        lem:bnt_span_le_parent_hamiltonian_kernel, def:has_nncph_ground_spaces}
+    Let $B=\bigoplus_j\mu_jA_j$, with every $\mu_j\ne0$. Then the source
+    parent-Hamiltonian spanning condition
+    \[
+        \ker H_L^{(N)}(B)
+        =
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
+        \qquad (N>L)
+    \]
+    is equivalent to the reverse containment
+    \[
+        \ker H_L^{(N)}(B)
+        \subseteq
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
+        \qquad (N>L).
+    \]
+    In the nearest-neighbor case, the all-chain source condition is therefore
+    equivalent to the translated two-site commutation equations together with
+    this reverse containment for every $N>2$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The forward direction of the displayed equality gives the containment by
+    rewriting the kernel. Conversely, for $N>L$ the easy inclusion above gives
+    \[
+        \spn\{V^{(N)}(A_j):j=1,\ldots,g\}
+        \subseteq
+        \ker H_L^{(N)}(B),
+    \]
+    and the assumed reverse containment gives equality. For $L=2$, combine
+    this equivalence with the decomposition of the all-chain NNCPH
+    ground-space condition into two-site commutation and the source spanning
+    clause.
+\end{proof}
+
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}
     \lean{MPSTensor.rfp_implies_nncph}
     \lean{Axioms.rfp_to_nncph_commute}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -308,13 +308,13 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         \subseteq
         \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
     \]
-    In the nearest-neighbor case, the all-chain source condition is equivalent
-    to
+    In the nearest-neighbor case \(L=2\), the all-chain source condition of
+    Definition~\ref{def:has_nncph_ground_spaces} is equivalent to the
+    conjunction
     \[
         \begin{aligned}
-        \operatorname{HasNNCPHGroundSpaces}(B,A)
-        \Longleftrightarrow
-        &\left(\forall N>2,\ \operatorname{IsNNCPH}(B,N)\right)\\
+        &\left(\forall N>2,\ \forall i,j\in\{0,\ldots,N-1\},\;
+        h_i(B,2)h_j(B,2)=h_j(B,2)h_i(B,2)\right)\\
         &{}\land
         \left(\forall N>2,\;
         \ker H_2^{(N)}(B)
@@ -334,12 +334,12 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         \ker H_L^{(N)}(B),
     \]
     and the assumed reverse containment gives equality. For $L=2$, the
-    all-chain nearest-neighbor condition decomposes as
+    all-chain nearest-neighbor condition of
+    Definition~\ref{def:has_nncph_ground_spaces} decomposes as the conjunction
     \[
         \begin{aligned}
-        \operatorname{HasNNCPHGroundSpaces}(B,A)
-        \Longleftrightarrow
-        &\left(\forall N>2,\ \operatorname{IsNNCPH}(B,N)\right)\\
+        &\left(\forall N>2,\ \forall i,j\in\{0,\ldots,N-1\},\;
+        h_i(B,2)h_j(B,2)=h_j(B,2)h_i(B,2)\right)\\
         &{}\land
         \left(\forall N>2,\;
         \ker H_2^{(N)}(B)

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -98,7 +98,14 @@ strongly by every local term, then
 \leanid{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_annihilates}
 and
 \leanid{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_frustrationFree}.}
-This does not prove the reverse inclusion.
+For a block-diagonal tensor with nonzero weights,
+\leanid{MPSTensor.hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan}
+now packages the source spanning equation as exactly the reverse containment,
+using this easy inclusion.  Its nearest-neighbor specialization,
+\leanid{MPSTensor.hasNNCPHGroundSpaces_toTensorFromBlocks_iff_forall_isNNCPH_and_ker_le_bntMPSVectorSpan},
+states the all-chain condition as translated two-site commutation together with
+the same reverse containment for every \(N>2\).  The reverse containment itself
+is not proved here.
 
 This still does not prove the full source theorem.  The present declarations do
 not yet prove the named ground-space spanning condition, the three-way

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -100,7 +100,7 @@ and
 \leanid{MPSTensor.bntMPSVectorSpan_le_ker_parentHamiltonian_of_forall_frustrationFree}.}
 For a block-diagonal tensor with nonzero weights,
 \leanid{MPSTensor.hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan}
-now packages the source spanning equation as exactly the reverse containment,
+now reduces the source spanning equation to exactly the reverse containment,
 using this easy inclusion.  Its nearest-neighbor specialization,
 \leanid{MPSTensor.hasNNCPHGroundSpaces_toTensorFromBlocks_iff_forall_isNNCPH_and_ker_le_bntMPSVectorSpan},
 states the all-chain condition as translated two-site commutation together with


### PR DESCRIPTION
### Motivation
- Continues formalization of the pure-state RFP = ZCL = NNCPH ground-space equivalence (arXiv:1606.00608, thm:main-MPS, line 534), tracked in #2633.
- The source spanning equality for \(B = \bigoplus_j \mu_j A_j\) with nonzero weights requires a kernel inclusion in both directions. The easy BNT-span ⊆ kernel direction is already proved; this PR isolates the remaining reverse containment as the exact outstanding condition.
- Records the nearest-neighbor all-chain specialization, connecting `HasNNCPHGroundSpaces` to the reverse kernel containment for every \(N > 2\).

### Description
- New file `TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean` (83 lines): introduces `hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan`, showing that for block-diagonal \(B = \bigoplus_j \mu_j A_j\) with nonzero weights, the spanning equality \(\ker H_L^{(N)}(B) = \mathrm{span}\{V^{(N)}(A_j)\}\) is equivalent to the reverse inclusion \(\ker \subseteq \mathrm{span}\), because the easy forward direction is already available. A nearest-neighbor specialization rewrites the all-chain `HasNNCPHGroundSpaces` predicate as translated two-site commutation together with the reverse containment for every \(N > 2\).
- `TNLean.lean`: adds the new module to the root import list.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: adds the corresponding blueprint lemma entry.
- `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`: updates the paper-gap note to link the new declarations.
- The reverse containment itself is not proved in this PR; it remains the outstanding gap documented in the paper-gap note.

### Testing
- `lake env lean TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- Staged added-line scan for `sorry`/`admit`/`axiom`/`native_decide`/`unsafeCast`.

---
Refs #2633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only formalization and documentation with no runtime or security impact; the hard spanning direction remains explicitly unproved.
> 
> **Overview**
> For block-diagonal \(B=\bigoplus_j \mu_j A_j\) with nonzero weights, this PR **formalizes that the Definition 3.9 ground-space spanning equality is equivalent to the reverse kernel containment** \(\ker H_L^{(N)}(B) \subseteq \mathrm{span}\{V^{(N)}(A_j)\}\), because the span ⊆ kernel direction is already proved.
> 
> It adds `GroundSpaceSpanning.lean` with `hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan` and a nearest-neighbor rewrite of `HasNNCPHGroundSpaces` as **all-chain `IsNNCPH` plus that reverse inclusion for every \(N>2\)**. The root import, blueprint ch13 lemma, and the CPSV16 paper-gap note are updated to point at these declarations.
> 
> **The reverse inclusion is still not proved**; the change only names and documents the remaining gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b533570853c4016dcebb35dee4c78ac357d3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->