### PR TITLE
doc(periodic): align Section 4 source prose

### DIFF
--- a/TNLean/MPS/Periodic/ProjectiveRep.lean
+++ b/TNLean/MPS/Periodic/ProjectiveRep.lean
@@ -7,15 +7,16 @@ import TNLean.Algebra.ProjectiveRepresentation
 import TNLean.Algebra.CocycleCohomology
 
 /-!
-# Periodic MPS — conditional projective data after Corollary 4.1
+# Periodic MPS — conditional projective representation after the symmetry corollary
 
-This file starts from `MPSTensor.cor_4_1_physical_symmetry_zgauge_explicit`
-(obtained in `MPS/Periodic/Symmetry.lean`) and, under an additional coherence
-hypothesis, constructs a projective representation of the symmetry group `G`
-on the bond space.
-The source paper arXiv:1708.00029, Section 4.2 proves the symmetry-to-`Z`-gauge
-corollary and then says that its consequences will be explored elsewhere; it does not
-prove the scalar cocycle or cohomological interpretation recorded below.
+This file starts from the conditional group-action reformulation
+`MPSTensor.cor_4_1_physical_symmetry_zgauge_explicit`. The source paper
+arXiv:1708.00029, Section 4.2, lines 834--845, proves a symmetry-to-`Z`-gauge
+corollary for a single local unitary and then says that its consequences will be
+explored elsewhere. It does not choose the virtual gauges coherently over a
+group, prove a scalar cocycle, or prove the cohomological interpretation
+recorded below. Under an additional coherence hypothesis, this file constructs
+a projective representation of the symmetry group `G` on the bond space.
 
 The injective analogue is `MPSTensor.virtual_rep_of_symmetric_injective`
 (in `MPS/Symmetry/VirtualRepresentation.lean`): there, gauge uniqueness
@@ -25,17 +26,17 @@ there is a non-trivial `Z`-gauge ambiguity (`Z_g^{m_g} = 1`), so an additional
 analytic input is required to reduce the full rigidity back to a scalar
 cocycle. Following the established repository
 pattern (see `PeriodicEqualCaseFT`), that input is exposed as an explicit
-hypothesis `PeriodicProjectiveRigidity`. The remainder of the projective-
-representation data - the cocycle identity and the construction of a
-`ProjectiveRepresentation` on the bond space - is formalised here.
+hypothesis `PeriodicProjectiveRigidity`. The remaining projective-representation
+conclusions - the cocycle identity and the construction of a
+`ProjectiveRepresentation` on the bond space - are formalized here.
 
 ## Main definitions and results
 
 * `MPSTensor.PeriodicProjectiveRigidity` — the analytic hypothesis recording
   the existence of a compatible family `Y : G → GL (Fin D) ℂ` together with a
   scalar 2-cochain `u : G × G → ℂˣ` satisfying the projective law on the
-  bond space while every `Y g` realises the Corollary-4.1 intertwining with
-  the twisted tensor.
+  bond space, while every `Y g` realizes the pointwise `Z`-gauge intertwining
+  modeled on the symmetry corollary.
 * `MPSTensor.cor_4_1_projective_rep` — the conditional projective-representation
   construction:
   from `PeriodicProjectiveRigidity`, produce a
@@ -68,13 +69,13 @@ variable {d D : ℕ} {G : Type*} [Group G]
 /-- **Periodic projective-representation rigidity hypothesis.**
 
 For an on-site symmetry `U : G →* Mat_d(ℂ)` of a periodic tensor `A`,
-`PeriodicProjectiveRigidity A U` records the coherent choice of the
-`Y`-gauges obtained from Corollary 4.1: there is a family
+`PeriodicProjectiveRigidity A U` records a coherent choice extending the
+pointwise `Z`-gauge conclusion modeled on the source symmetry corollary: there is a family
 `Y : G → GL (Fin D) ℂ` and a scalar 2-cochain `u : G × G → ℂˣ` such that
 
 1. Each `Y g`, together with some `Z`-matrix (satisfying the period, commutation
-   and gauge-intertwining data of Corollary 4.1), realises the `Z`-gauge
-   equivalence of Corollary 4.1 between `A` and the `g`-twisted tensor.
+   and gauge-intertwining conditions), realizes the pointwise `Z`-gauge
+   intertwining between `A` and the `g`-twisted tensor.
 2. The family satisfies the projective multiplication law on the bond space:
    `(Y h) · (Y g) = u(g, h) • Y (g * h)` as matrices.
 
@@ -98,18 +99,18 @@ def PeriodicProjectiveRigidity
 
 /-! ## Projective representation from the rigidity hypothesis -/
 
-/-- **Conditional projective representation from the Corollary 4.1 data.**
+/-- **Conditional projective representation from the group-action reformulation.**
 
-If the `Y_g` family from `cor_4_1_physical_symmetry_zgauge_explicit` can be chosen
-to satisfy the periodic projective-representation rigidity hypothesis, then the
-bond-space gauges assemble into a projective representation of `G`:
-there exist a scalar 2-cochain `ω : G × G → ℂˣ` and a
+If the pointwise virtual gauges in `PeriodicProjectiveRigidity` can be chosen
+coherently, then the bond-space gauges assemble into a projective representation
+of `G`: there exist a scalar 2-cochain `ω : G × G → ℂˣ` and a
 `TNLean.Algebra.ProjectiveRepresentation` on the bond space whose virtual gauges
-still realise the Corollary-4.1 intertwining with the twisted tensors.
+still realize the pointwise `Z`-gauge intertwining with the twisted tensors.
 
-The source paper arXiv:1708.00029, Section 4.2 supplies the per-element
-`Z`-gauge conclusion; the coherence of the family `(Y_g)_{g ∈ G}` is the
-extra hypothesis `PeriodicProjectiveRigidity`.
+The source paper arXiv:1708.00029, Section 4.2, lines 834--845, supplies only
+the `Z`-gauge conclusion for a single local unitary. The coherent family
+`(Y_g)_{g ∈ G}` and the scalar projective law are the extra content of
+`PeriodicProjectiveRigidity`.
 
 The construction uses the *inversion convention* of
 `MPS/Symmetry/VirtualRepresentation.lean`: the virtual representation is
@@ -160,9 +161,9 @@ theorem cor_4_1_projective_rep_cocycle
 
 High-level consequence of `cor_4_1_projective_rep` together with the cocycle
 condition of `cor_4_1_projective_rep_cocycle`: the explicit rigidity hypothesis
-turns the bond-space symmetry data supplied by Corollary 4.1 into a coherent
-projective representation of `G` on the bond space, with factor system satisfying
-the 2-cocycle identity whenever `D > 0`.
+turns the assumed bond-space gauges into a coherent projective representation
+of `G` on the bond space, with factor system satisfying the 2-cocycle identity
+whenever `D > 0`.
 
 The irreducible-form and unitarity hypotheses belong to the theorem producing
 `PeriodicProjectiveRigidity A U`; this theorem records only the resulting

--- a/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
@@ -41,15 +41,15 @@ In paper notation, for each `g` there exist matrices `Z_g, Y_g` with `Z_g^{m_g} 
 
 **Source comparison.** The source corollary in arXiv:1708.00029, lines 834--845,
 is stated for a single local unitary \(u\). It concludes that there are a diagonal
-unitary \(Z\) and a unitary \(U\) satisfying
+unitary \(Z\) and a unitary \(U\) satisfying, for every \(i'\),
 \[
   \sum_i u^{i',i} A^i = Z U A^{i'} U^\dagger
 \]
-for every \(i'\) (eq:symm). The statement here is not that corollary verbatim: it
+The statement here is not that corollary verbatim: it
 applies the same idea pointwise to a group representation, assumes the periodic equal-case
-Fundamental Theorem (`thm:bdequal`, lines 643--656) through `PeriodicEqualCaseFT`, and records
-the conclusion in `ZGaugeEquiv` form. The diagonal normalization of \(Z\) and the exact
-eq:symm display are not asserted by this theorem.
+Fundamental Theorem (arXiv:1708.00029, lines 643--656) through `PeriodicEqualCaseFT`, and
+records the conclusion in `ZGaugeEquiv` form. The diagonal normalization of \(Z\) and the
+exact displayed source equation are not asserted by this theorem.
 
 The single-`u` specialization is obtained via
 `zGaugeEquiv_of_isIrreducibleForm_sameMPV_rotatePhysical`.

--- a/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Corollary41.lean
@@ -7,8 +7,8 @@ import TNLean.MPS.Periodic.Symmetry.EqualCaseFTHyp
 /-!
 # Corollary 4.1 for periodic MPS
 
-This module contains the physical-symmetry-to-virtual-`Z`-gauge statements from
-Section 4.2 of arXiv:1708.00029.
+This module contains conditional reformulations of the physical-symmetry-to-virtual
+\(Z\)-gauge corollary from arXiv:1708.00029, Section 4.2, lines 828--845.
 -/
 
 open scoped Matrix BigOperators
@@ -27,8 +27,7 @@ lemma twistedTensor_eq_rotatePhysical
     (A : MPSTensor d D) (U : G →* Matrix (Fin d) (Fin d) ℂ) (g : G) :
     twistedTensor A U g = rotatePhysical (U g) A := rfl
 
-/-- **Group-representation generalization of the Symmetries corollary
-(arXiv:1708.00029, §"Characterization of symmetries").**
+/-- **Conditional group-action reformulation of the symmetry corollary.**
 
 Let `A` be in irreducible form II and let `U : G →* Mat_d ℂ` be a representation of a
 group `G` on the physical leg, acting unitarily. If `A` is on-site symmetric under `U`
@@ -40,21 +39,22 @@ In paper notation, for each `g` there exist matrices `Z_g, Y_g` with `Z_g^{m_g} 
 `[A^i, Z_g] = 0`, and
 `Z_g · A^i = Y_g · (twistedTensor A U g)^i · Y_g⁻¹`.
 
-**Faithfulness note (generalization + restated conclusion).** The source corollary is
-stated for a *single* local unitary `u` and concludes with a **diagonal** unitary `Z`
-satisfying the explicit relation `∑_i u^{i',i} A^i = Z U A^{i'} U†` (eq:symm). This
-statement (i) *generalizes* the input to an arbitrary group representation `U : G →* …`
-(the single-`u` case is the cyclic-subgroup instance), and (ii) *restates the conclusion*
-in `Z`-gauge-equivalence form with `Z_g` only required periodic (`Z_g^{m_g}=1`) and
-commuting with `A^i`, not literally diagonal, and with the relation written via the gauge
-`Y_g` rather than verbatim eq:symm. It is therefore a faithful generalization, not the
-source corollary verbatim; the diagonal-`Z` normalization and the exact eq:symm form are
-recoverable in the irreducible-form basis but are not part of this statement.
+**Source comparison.** The source corollary in arXiv:1708.00029, lines 834--845,
+is stated for a single local unitary \(u\). It concludes that there are a diagonal
+unitary \(Z\) and a unitary \(U\) satisfying
+\[
+  \sum_i u^{i',i} A^i = Z U A^{i'} U^\dagger
+\]
+for every \(i'\) (eq:symm). The statement here is not that corollary verbatim: it
+applies the same idea pointwise to a group representation, assumes the periodic equal-case
+Fundamental Theorem (`thm:bdequal`, lines 643--656) through `PeriodicEqualCaseFT`, and records
+the conclusion in `ZGaugeEquiv` form. The diagonal normalization of \(Z\) and the exact
+eq:symm display are not asserted by this theorem.
 
 The single-`u` specialization is obtained via
 `zGaugeEquiv_of_isIrreducibleForm_sameMPV_rotatePhysical`.
 The projective-representation question (a joint factor system on the family `(Y_g)_{g∈G}`)
-is an external downstream problem not supplied by arXiv:1708.00029; see
+is an external mathematical problem not supplied by arXiv:1708.00029; see
 `MPS/Symmetry/VirtualRepresentation.lean` for the analogous injective construction.
 
 The periodic equal-case FT is taken as an explicit hypothesis `hPeriodicEq` (see file
@@ -83,7 +83,7 @@ theorem cor_4_1_physical_symmetry_zgauge
   exact ⟨m, hm_pos, by rw [hRotEq]; exact hZGauge⟩
 
 /-- **A convenient reformulation of `cor_4_1_physical_symmetry_zgauge`** in the form most
-useful for conditional downstream projective-representation arguments: extract the gauge
+useful for conditional projective-representation arguments: extract the gauge
 `Y(g)` and matrix `Z(g)` explicitly. -/
 theorem cor_4_1_physical_symmetry_zgauge_explicit
     (A : MPSTensor d D)

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Defs.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Defs.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.Periodic.Symmetry.EqualCaseFTHyp
 # Theorem 4.1 definitions
 
 This module contains the \(p\)-divisibility and \(p\)-refinement definitions used in
-arXiv:1708.00029, Theorem 4.1 (`thm:div`), lines 717--731.
+arXiv:1708.00029, Theorem 4.1, lines 717--731.
 -/
 
 open scoped Matrix BigOperators
@@ -31,13 +31,13 @@ def IsPDivisibleChannel
   ∃ E' : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
     IsChannel E' ∧ E = E' ^ p
 
-/-- **\(p\)-refinement of an MPS family (arXiv:1708.00029, eq:fine).**
+/-- **\(p\)-refinement of an MPS family.**
 
-The matrix product vector family of \(B\) can be \(p\)-refined if there exists another
-tensor \(A\) and an isometry \(W : \mathbb C^d \to (\mathbb C^d)^{\otimes p}\)
-(encoded as a matrix with \(W^\dagger W = 1\)) such that the \(p\)-blocked tensor
-\(A^{[p]}\) matches the \(W^{\otimes N}\)-image of \(B\) at the level of MPV
-coefficients:
+The matrix product vector family of \(B\) can be \(p\)-refined, in this same-bond
+version, if there exists another tensor \(A\) with the same bond dimension as \(B\)
+and an isometry \(W : \mathbb C^d \to (\mathbb C^d)^{\otimes p}\) (encoded as a
+matrix with \(W^\dagger W = 1\)) such that the \(p\)-blocked tensor \(A^{[p]}\)
+matches the \(W^{\otimes N}\)-image of \(B\) at the level of MPV coefficients:
 `coeff (blockTensor A p) (List.ofFn τ) = ∑_σ (∏_k W (τ k) (σ k)) · coeff B (List.ofFn σ)`
 for every length `N` and every `τ : Fin N → Fin (blockPhysDim d p)`.
 

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Defs.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Defs.lean
@@ -7,8 +7,8 @@ import TNLean.MPS.Periodic.Symmetry.EqualCaseFTHyp
 /-!
 # Theorem 4.1 definitions
 
-This module contains the `p`-divisibility and `p`-refinement definitions used in
-Theorem 4.1 of arXiv:1708.00029.
+This module contains the \(p\)-divisibility and \(p\)-refinement definitions used in
+arXiv:1708.00029, Theorem 4.1 (`thm:div`), lines 717--731.
 -/
 
 open scoped Matrix BigOperators
@@ -21,26 +21,28 @@ section Theorem41
 
 variable {d D : ℕ}
 
-/-- **`p`-divisibility of a CP linear endomorphism.**
+/-- **\(p\)-divisibility of a transfer map.**
 
-A linear endomorphism `E` of `Mat_D ℂ` is *`p`-divisible* if it equals the `p`-fold
-composition of some CPTP map `E'`. This is the channel-theoretic notion appearing in
-arXiv:1708.00029, Section 4.1. -/
+A linear endomorphism \(E\) of \(M_D(\mathbb C)\) is \(p\)-divisible if it equals the
+\(p\)-fold composition of some trace-preserving completely positive map \(E'\). This is
+the definition in arXiv:1708.00029, lines 717--718. -/
 def IsPDivisibleChannel
     (E : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) (p : ℕ) : Prop :=
   ∃ E' : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
     IsChannel E' ∧ E = E' ^ p
 
-/-- **`p`-refinement of an MPS tensor (arXiv:1708.00029, Section 4.1, Equation (4.1)).**
+/-- **\(p\)-refinement of an MPS family (arXiv:1708.00029, eq:fine).**
 
-`B : MPSTensor d D` admits a `p`-refinement if there exists another tensor
-`A : MPSTensor d D` and an isometry `W : ℂ^d → (ℂ^d)^{⊗p}` (encoded as a matrix
-`Matrix (Fin (blockPhysDim d p)) (Fin d) ℂ` with `Wᴴ * W = 1`) such that the `p`-blocked
-`A` matches the `W`-image of `B` at the level of MPV coefficients:
+The matrix product vector family of \(B\) can be \(p\)-refined if there exists another
+tensor \(A\) and an isometry \(W : \mathbb C^d \to (\mathbb C^d)^{\otimes p}\)
+(encoded as a matrix with \(W^\dagger W = 1\)) such that the \(p\)-blocked tensor
+\(A^{[p]}\) matches the \(W^{\otimes N}\)-image of \(B\) at the level of MPV
+coefficients:
 `coeff (blockTensor A p) (List.ofFn τ) = ∑_σ (∏_k W (τ k) (σ k)) · coeff B (List.ofFn σ)`
 for every length `N` and every `τ : Fin N → Fin (blockPhysDim d p)`.
 
-In paper notation, this encodes `|V_{pN}(A)⟩ = W^{⊗N} |V_N(B)⟩` for every `N`. -/
+In the paper notation of arXiv:1708.00029, lines 719--724, this encodes
+\(|V_{pN}(A)\rangle = W^{\otimes N}|V_N(B)\rangle\) for every \(N\). -/
 def IsPRefinable (B : MPSTensor d D) (p : ℕ) : Prop :=
   ∃ (A : MPSTensor d D)
     (W : Matrix (Fin (blockPhysDim d p)) (Fin d) ℂ),

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -7,9 +7,8 @@ import TNLean.MPS.Periodic.Symmetry.Theorem41Defs
 /-!
 # Theorem 4.1, forward direction
 
-This module contains the forward half of arXiv:1708.00029, Theorem 4.1
-(`thm:div`), together with the formal pullback tensor \(C\) introduced in
-lines 735--743 of the paper.
+This module contains the forward half of arXiv:1708.00029, Theorem 4.1, together
+with the formal pullback tensor \(C\) introduced in lines 735--743 of the paper.
 -/
 
 open scoped Matrix BigOperators

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -7,8 +7,9 @@ import TNLean.MPS.Periodic.Symmetry.Theorem41Defs
 /-!
 # Theorem 4.1, forward direction
 
-This module contains the forward half of Theorem 4.1 together with the pullback
-lemmas used in its current conditional formalization.
+This module contains the forward half of arXiv:1708.00029, Theorem 4.1
+(`thm:div`), together with the formal pullback tensor \(C\) introduced in
+lines 735--743 of the paper.
 -/
 
 open scoped Matrix BigOperators
@@ -266,18 +267,18 @@ noncomputable def isIrreducibleForm_kraus_isometry
     intro N τ
     exact (hPullbackSame N τ).trans (hBlocksSame N τ)
 
-/-- **Pullback stage of the forward canonicalization roadmap for Theorem 4.1.**
+/-- **Pullback tensor in the forward proof of Theorem 4.1.**
 
 From a `p`-refinement witness `(A, W)` for `B`, the `W`-pullback tensor
 `C τ := ∑_σ W(τ, σ) • B σ` has the same transfer map as `B` and the same MPV
 family as `blockTensor A p`.
 
-This proves the first three steps of the forward-direction condition
-`PRefinementCanonicalization`: construct the pullback, identify its transfer map
-using `transferMap_kraus_isometry`, and rewrite the coefficient-level refinement
-identity as a `SameMPV` statement. The remaining gap is therefore exactly the
-periodic equal-case / canonical-gauge reduction from this `SameMPV` statement to
-a left-canonical root witness. -/
+This is the tensor \(C\) of arXiv:1708.00029, lines 735--743:
+\[
+  C^{i_1,\ldots,i_p}=\sum_i W^{(i_1,\ldots,i_p),i}B^i .
+\]
+The theorem records the formal consequences of this definition before the
+paper applies the equal-case periodic Fundamental Theorem. -/
 theorem pRefinementCanonicalization_pullback
     (B : MPSTensor d D) (p : ℕ)
     (hRefine : IsPRefinable B p) :
@@ -299,15 +300,14 @@ theorem pRefinementCanonicalization_pullback
     _ = mpv (blockTensor A p) τ := by
           simpa [mpv_eq] using (hCoeff N τ).symm
 
-/-- **Pullback stage with irreducible-form input for Theorem 4.1.**
+/-- **The pullback tensor is still in irreducible form II.**
 
 If the refined tensor `B` is already in irreducible form II, then the pullback
 `C τ := ∑_σ W(τ, σ) • B σ` coming from a `p`-refinement witness is again in
 irreducible form II, has the same transfer map as `B`, and has the same MPV
-family as `blockTensor A p`. This isolates the genuinely new input now
-available on `main`: the first stage of the paper's proof preserves the
-periodic block structure of `B`; the remaining forward-direction gap is the
-blocked equal-case / root-reconstruction stage after this theorem. -/
+family as `blockTensor A p`. This formalizes the sentence in arXiv:1708.00029,
+lines 744--745, that \(C\), viewed with \((i_1,\ldots,i_p)\) as one physical
+index, is again in irreducible form II. -/
 theorem pRefinementCanonicalization_pullback_of_irreducibleForm
     (B : MPSTensor d D) (hB : IsIrreducibleForm B) (p : ℕ)
     (hRefine : IsPRefinable B p) :
@@ -380,7 +380,7 @@ def PeripheralEqualCaseRootFromZGauge (d D p : ℕ) : Prop :=
         (∑ i : Fin d, (A' i)ᴴ * A' i = 1) ∧
         transferMap C = transferMap (blockTensor A' p)
 
-/-- **Blocked equal-case/root-reconstruction hypothesis for Theorem 4.1.**
+/-- **Blocked equal-case root hypothesis for Theorem 4.1.**
 
 This Prop isolates exactly the remaining forward input after
 `pRefinementCanonicalization_pullback_of_irreducibleForm`: whenever an
@@ -390,12 +390,10 @@ same blocked transfer map, `E_C = E_{A'^{[p]}}`.
 
 In the paper this is the point where the blocked equal-case Fundamental Theorem
 (source theorem `thm:bdequal`, arXiv:1708.00029, lines 643--656) is combined
-with the blocked-to-root reconstruction that distributes the resulting `Z`-gauge across the cyclic
-sectors of `A`. Formalizing that existence step is the remaining forward
-obstruction, so we keep the resulting existence statement as a separate
-hypothesis. The theorem `peripheralEqualCase_periodicFT_of_sameMPV` below
-shows that this statement follows from the sharper split into blocked
-`Z`-gauge extraction and blocked-to-root reconstruction. -/
+with the phase-distribution construction in lines 765--810, where the scalars
+\(c_{j,\alpha}\) are redistributed to form \(A'_j\) and then
+\(\widetilde A = U^\dagger A' U\). The formal statement is kept as a separate
+hypothesis until that source argument is fully formalized. -/
 def PeripheralEqualCasePeriodicFTOfSameMPV (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D},
     IsIrreducibleForm C →
@@ -422,7 +420,7 @@ theorem peripheralEqualCase_periodicFT_of_sameMPV
   obtain ⟨m, hm, hZ⟩ := hZGauge (A := A) (C := C) hC hSame
   exact hRoot (A := A) (C := C) (m := m) hC hm hZ
 
-/-- **Canonicalization hypothesis for the forward direction of Theorem 4.1.**
+/-- **Forward root hypothesis for Theorem 4.1.**
 
 This Prop states the analytic content that remains between the
 coefficient-level `IsPRefinable B p` (a trace-level MPV identity) and the
@@ -430,23 +428,20 @@ channel-level conclusion needed to exhibit `E_B` as a `p`-th power: any
 `p`-refinement of `B` can be *canonicalized* to a witness that is both
 left-canonical and produces a matching transfer map under `p`-blocking.
 
-Morally, the canonicalization is produced as follows. Given a witness
-`(A, W)` from `IsPRefinable B p`, form the `W`-pullback tensor
-`C τ := ∑_σ W(τ, σ) · B σ`. The theorems
+In the source proof, this begins with the \(W\)-pullback tensor
+\(C^{i_1,\ldots,i_p}=\sum_i W^{(i_1,\ldots,i_p),i}B^i\)
+from arXiv:1708.00029, lines 735--743. The theorems
 `pRefinementCanonicalization_pullback` and
 `pRefinementCanonicalization_pullback_of_irreducibleForm` now cover this
 first stage, giving `E_C = E_B`, `SameMPV C (blockTensor A p)`, and preserving
 irreducible form II when `B` already has it. The periodic equal-case
 Fundamental Theorem (source theorem `thm:bdequal`, arXiv:1708.00029,
 lines 643--656, available here as the hypothesis `PeriodicEqualCaseFT`) then
-supplies a `Z`-gauge equivalence
-between `C` and `blockTensor A p`, which — combined with a unitary
-canonical-form reduction for irreducible form II and Wolf Theorem 2.18 —
-produces the sought left-canonical witness. Formalizing this remaining second
-stage in Lean still requires supporting theory (canonical unitary gauge, Kraus
-uniqueness), so we expose the end-result predicate as a hypothesis. The theorem
+supplies a `Z`-gauge relation between `C` and `blockTensor A p`. The remaining
+source step is the distribution of this blocked `Z`-phase across the cyclic
+blocks of `A` in lines 765--810. The theorem
 `pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`
-below shows that this coarse hypothesis follows from the sharper blocked-stage
+shows that this hypothesis follows from the sharper blocked equal-case root
 hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
 def PRefinementCanonicalization (d D p : ℕ) : Prop :=
   ∀ {B : MPSTensor d D}, IsIrreducibleForm B → IsPRefinable B p →

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1709,17 +1709,18 @@ unconditional result.
         Z_g\, A^i = Y_g\, \widetilde{A}_g^{\,i}\, Y_g^{-1}
     \]
 
-    The source corollary in
-    \cite[lines~834--845]{DeLasCuevas2017Irreducible} is a
-    statement about a single local unitary. It concludes that, for a local
-    unitary $u$, there are a diagonal unitary $Z$ and a virtual unitary $Y$ such that
-    \[
-        \sum_i u^{i',i} A^i = Z\,Y\,A^{i'}Y^{\dagger}
-    \]
-    for every $i'$. The statement here is a pointwise group-action
-    reformulation using the periodic equal-case Fundamental Theorem as an
-    explicit hypothesis. It does not assert the diagonal normalization of
-    $Z_g$ or the exact displayed source equation.
+    % Source comparison: the source corollary in
+    % \cite[lines~834--845]{DeLasCuevas2017Irreducible} is stated for a single
+    % local unitary. It concludes that, for a local unitary $u$, there are a
+    % diagonal unitary $Z$ and a virtual unitary $Y$ satisfying, for every
+    % physical index $i'$,
+    % \[
+    %     \sum_i u^{i',i} A^i = Z\,Y\,A^{i'}Y^{\dagger}.
+    % \]
+    % The statement here is a pointwise group-action reformulation using the
+    % periodic equal-case Fundamental Theorem as an explicit hypothesis. It does
+    % not assert the diagonal normalization of $Z_g$ or the exact displayed
+    % source equation.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1770,27 +1771,24 @@ unconditional result.
     \label{thm:cor_4_1_projective_rep}
     \lean{MPSTensor.cor_4_1_projective_rep}
     \leanok
-    \uses{cor:cor_4_1_physical_symmetry_zgauge,
-        def:periodic_projective_rigidity}
-    Under the hypotheses of Corollary~\ref{cor:cor_4_1_physical_symmetry_zgauge}
-    together with the periodic projective-rigidity hypothesis
-    (Definition~\ref{def:periodic_projective_rigidity}), the $Y_g$
-    family defines a projective representation of $G$ on the
-    bond space: there exist a scalar $2$-cochain
+    \uses{def:periodic_projective_rigidity}
+    Assume the periodic projective-rigidity hypothesis
+    (Definition~\ref{def:periodic_projective_rigidity}) for the tensor $A$ and
+    the physical action $U$. Then the virtual gauge family supplied by that
+    hypothesis defines a projective representation of $G$ on the bond space:
+    there exist a scalar $2$-cochain
     $\omega : G \times G \to \C^{\times}$ and virtual gauges
     $X : G \to \GL_D(\C)$ satisfying
     \[
         X(g)\, X(h) =  \omega(g, h)\, X(g h),
     \]
     while for each $g$ the matrix $X(g^{-1})$ still realizes the pointwise
-    $\Z_{m_g}$-intertwining of
-    Corollary~\ref{cor:cor_4_1_physical_symmetry_zgauge} between $A$ and the
-    twisted tensor $\widetilde{A}_g$.
+    $\Z_{m_g}$-intertwining, encoded in the rigidity hypothesis, between $A$
+    and the twisted tensor $\widetilde{A}_g$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{cor:cor_4_1_physical_symmetry_zgauge,
-        def:periodic_projective_rigidity}
+    \uses{def:periodic_projective_rigidity}
     Unpack the rigidity hypothesis to extract the family $(Y, u)$ together
     with the pointwise $Z$-gauge intertwiners. Set
     $X(g) := Y(g^{-1})$ and $\omega(g, h) := u(h^{-1}, g^{-1})$. The

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1685,7 +1685,7 @@ unconditional result.
 
 \section{Physical symmetries on periodic MPS}\label{sec:periodic_symmetry}
 
-\begin{theorem}[Physical symmetry yields a virtual $Z$-gauge]%
+\begin{theorem}[Conditional group-action $Z$-gauge reformulation of the symmetry corollary]%
     \label{cor:cor_4_1_physical_symmetry_zgauge}
     \lean{MPSTensor.cor_4_1_physical_symmetry_zgauge}
     \leanok
@@ -1708,6 +1708,18 @@ unconditional result.
     \[
         Z_g\, A^i = Y_g\, \widetilde{A}_g^{\,i}\, Y_g^{-1}
     \]
+
+    The source corollary in
+    \cite[lines~834--845]{DeLasCuevas2017Irreducible} is a
+    statement about a single local unitary. It concludes that, for a local
+    unitary $u$, there are a diagonal unitary $Z$ and a virtual unitary $Y$ such that
+    \[
+        \sum_i u^{i',i} A^i = Z\,Y\,A^{i'}Y^{\dagger}
+    \]
+    for every $i'$. The statement here is a pointwise group-action
+    reformulation using the periodic equal-case Fundamental Theorem as an
+    explicit hypothesis. It does not assert the diagonal normalization of
+    $Z_g$ or the exact displayed source equation.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -1736,26 +1748,25 @@ unconditional result.
     $2$-cochain $u : G \times G \to \C^{\times}$ such that
 
     \begin{enumerate}
-        \item every $Y_g$ realises the intertwining from
-              \cite[Corollary~4.1]{DeLasCuevas2017Irreducible} with
-              the twisted tensor $\widetilde{A}_g$ for some accompanying
+        \item every $Y_g$ realizes the pointwise $Z$-gauge intertwining
+              modeled on the symmetry corollary with the twisted tensor
+              $\widetilde{A}_g$ for some accompanying
               $Z_g$ (with $Z_g^{m_g} = \Id$ and $[A^i, Z_g] = 0$); and
         \item the family obeys the projective multiplication law on the
               bond space: $Y_h\, Y_g = u(g, h)\, Y_{gh}$.
     \end{enumerate}
 
-    The first item is the conclusion supplied by
-    \cite[Corollary~4.1]{DeLasCuevas2017Irreducible}. The second item is
-    an additional downstream assumption: after proving the symmetry
-    corollary, the source paper says that its consequences will be
-    explored elsewhere. The injective case reduces this coherence to
-    scalar uniqueness of gauges (cf.~\S\ref{sec:injective_symmetry_cocycle});
-    in the genuinely periodic setting there is a non-trivial
-    $\Z_m$-gauge ambiguity, so coherence of the factor system $u$ is an
-    independent analytic assumption.
+    The source supplies the corresponding intertwining for a single local unitary.
+    The group-indexed coherent choice and the projective multiplication law are
+    additional assumptions: after proving the symmetry corollary, the source
+    paper says that its consequences will be explored elsewhere. The injective
+    case reduces this coherence to scalar uniqueness of gauges
+    (cf.~\S\ref{sec:injective_symmetry_cocycle}); in the genuinely periodic
+    setting there is a non-trivial $\Z_m$-gauge ambiguity, so coherence of the
+    factor system $u$ is an independent analytic assumption.
 \end{definition}
 
-\begin{theorem}[Conditional projective representation from symmetry data]%
+\begin{theorem}[Conditional projective representation from symmetry gauges]%
     \label{thm:cor_4_1_projective_rep}
     \lean{MPSTensor.cor_4_1_projective_rep}
     \leanok
@@ -1771,18 +1782,17 @@ unconditional result.
     \[
         X(g)\, X(h) =  \omega(g, h)\, X(g h),
     \]
-    while for each $g$ the matrix $X(g^{-1})$ still realises the
-    $\Z_{m_g}$-intertwining from
-    \cite[Corollary~4.1]{DeLasCuevas2017Irreducible} between $A$ and
-    the twisted tensor $\widetilde{A}_g$.
+    while for each $g$ the matrix $X(g^{-1})$ still realizes the pointwise
+    $\Z_{m_g}$-intertwining of
+    Corollary~\ref{cor:cor_4_1_physical_symmetry_zgauge} between $A$ and the
+    twisted tensor $\widetilde{A}_g$.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{cor:cor_4_1_physical_symmetry_zgauge,
         def:periodic_projective_rigidity}
-    Unpack the rigidity hypothesis to extract the family
-    $(Y, u)$ together with the intertwiners from
-    \cite[Corollary~4.1]{DeLasCuevas2017Irreducible}. Set
+    Unpack the rigidity hypothesis to extract the family $(Y, u)$ together
+    with the pointwise $Z$-gauge intertwiners. Set
     $X(g) := Y(g^{-1})$ and $\omega(g, h) := u(h^{-1}, g^{-1})$. The
     projective multiplication law $X(g)\, X(h) = \omega(g, h)\, X(gh)$
     is then exactly the $(h^{-1}, g^{-1})$-instance of the factor-system
@@ -1851,10 +1861,9 @@ unconditional result.
 
 \section{Refinement and divisibility}\label{sec:periodic_refinement}
 
-The next theorem characterises when the matrix-product-vector family of a
-periodic tensor admits a finer description in terms of a smaller-period
-tensor whose blocks have been merged. This was the original motivation
-for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
+The next theorem relates refinement of a matrix-product-vector family to
+divisibility of its transfer map, following
+\cite[Theorem~4.1]{DeLasCuevas2017Irreducible}.
 
 \begin{definition}[$p$-divisible CP map]
     \label{def:p_divisible_channel}
@@ -1870,12 +1879,14 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.IsPRefinable}
     \leanok
     \uses{def:mps_tensor, def:blocked_tensor}
-    An MPS tensor $B$ with physical dimension $d$ and bond dimension $D$ is
-    \emph{$p$-refinable} if there exist another such tensor $A$ and an
-    isometry $W : \C^d \to (\C^d)^{\otimes p}$ (encoded as a matrix
-    $W \in M_{d^p \times d}(\C)$ with $W^{\dagger} W = \Id$) such that the
-    $p$-blocked tensor $A^{[p]}$ matches the $W$-image of $B$ at the level
-    of MPV coefficients:
+    Given a tensor $B$, the family $\mc V(B)$ can be \emph{$p$-refined} if
+    there exist another tensor $A$ and an isometry
+    $W : \C^d \to (\C^d)^{\otimes p}$ such that, for every $N$,
+    \[
+        \ket{V_{pN}(A)} = W^{\otimes N}\ket{V_N(B)}.
+    \]
+    Equivalently, after identifying a $p$-letter with an element of
+    $\{0,\ldots,d^p-1\}$, the $p$-blocked tensor $A^{[p]}$ satisfies
     \[
         V^{(N)}(A^{[p]})_\tau
         =
@@ -1885,9 +1896,6 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \]
     for every $N \in \N$ and every
     $\tau \in \{0,\ldots,d^p-1\}^N$.
-
-    In Dirac notation, this encodes
-    $\ket{V_{pN}(A)} = W^{\otimes N}\, \ket{V_N(B)}$ for all~$N$.
 \end{definition}
 
 \begin{theorem}[Pullback of a refinement witness]
@@ -1895,13 +1903,13 @@ for the irreducible-form framework in \cite{DeLasCuevas2017Irreducible}.
     \lean{MPSTensor.pRefinementCanonicalization_pullback_of_irreducibleForm}
     \leanok
     \uses{def:irreducible_form, def:p_refinable}
-    Let $B$ be an MPS tensor in irreducible form~II. If $B$ is
-    $p$-refinable, then there exist a tensor $A$, an isometry
+    Let $B$ be an MPS tensor in irreducible form~II. If $\mc V(B)$ can be
+    $p$-refined, then there exist a tensor $A$, an isometry
     $W : \C^d \to (\C^d)^{\otimes p}$, and the pullback tensor
-    $$
+    \[
         C^{\alpha} := \sum_{i=0}^{d-1} W_{\alpha,i} B^i
-        \qquad (\alpha \in \{0,\ldots,d^p-1\})
-    $$
+    \]
+    for $\alpha \in \{0,\ldots,d^p-1\}$,
     such that $C$ is again in irreducible form~II, $\mathcal E_C = \mathcal E_B$,
     and $C$ has the same MPV family as $A^{[p]}$.
 \end{theorem}


### PR DESCRIPTION
### Motivation

Section 4 of arXiv:1708.00029 separates two topics: refinement/divisibility in Theorem 4.1, and the physical-symmetry corollary in Section 4.2. The local Lean and blueprint prose blurred two distinctions:

- the paper's p-refinement statement is about refining the matrix-product-vector family, not merely a blocked tensor formula;
- the paper's symmetry corollary is a statement about a single local unitary, while the formalized result is a conditional pointwise group-action reformulation using `PeriodicEqualCaseFT`.

### Description

- Cites the relevant arXiv:1708.00029 theorem labels and line ranges in the Lean docstrings for p-divisibility, p-refinement, the forward pullback tensor, and the blocked equal-case root hypothesis.
- Rewrites the Section 4.1 blueprint prose so p-refinement is stated first in the paper's matrix-product-vector form, then by the coefficient formula.
- Marks the Section 4.2 symmetry theorem as a conditional group-action reformulation rather than the source corollary verbatim.
- Clarifies that `PeriodicProjectiveRigidity` assumes a coherent group-indexed family of virtual gauges and a scalar projective law; these are not supplied by the source corollary.

No theorem statements, proofs, blueprint labels, or `\lean{}` tags are changed.

### Testing

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `lake exe cache get`
- `lake build TNLean.MPS.Periodic.Symmetry.Theorem41Defs`
- `lake build TNLean.MPS.Periodic.Symmetry.Theorem41Forward`
- `lake build TNLean.MPS.Periodic.Symmetry.Corollary41`
- `lake build TNLean.MPS.Periodic.ProjectiveRep`

---
Addresses #619
Addresses #622
Addresses #664
Addresses #829

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no formal statements or executable Lean logic changed.
> 
> **Overview**
> **Documentation-only** changes to periodic MPS **Section 4** (Lean module headers/docstrings and `ch22_periodic_ft.tex`). **No** theorem statements, proofs, `\lean{}` tags, or definitions are modified.
> 
> **Theorem 4.1 / refinement:** Prose now cites arXiv:1708.00029 **Theorem 4.1** line ranges; **\(p\)-refinement** is described as refining the **matrix-product-vector family** \(|V_{pN}(A)\rangle = W^{\otimes N}|V_N(B)\rangle\) (coefficient form as equivalent); **\(p\)-divisibility** is framed as a **transfer map** notion; forward-proof comments name the paper’s **pullback tensor \(C\)** and the remaining **phase-distribution** step (lines 765–810).
> 
> **Section 4.2 / symmetry:** The symmetry result is labeled a **conditional group-action \(Z\)-gauge reformulation**, not the source corollary verbatim (single local unitary, diagonal \(Z\), exact displayed equation); **`PeriodicEqualCaseFT`** is called out as explicit extra input. **`PeriodicProjectiveRigidity`** and projective-representation docs stress that **coherent \((Y_g)\)** and a **scalar projective law** are **not** in the paper’s corollary; blueprint theorem titles/proofs drop overclaiming `\uses` on the corollary where only rigidity is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69e99d635d2f5c068f5fdafae28008c2b712a2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->