### PR TITLE
refactor(PEPS): use native span maps

### DIFF
--- a/TNLean/PEPS/CycleMPSChainArc.lean
+++ b/TNLean/PEPS/CycleMPSChainArc.lean
@@ -227,20 +227,27 @@ private theorem mul_left_letter_mem_arc_span [NeZero n]
     (i : Fin d) (Q : Matrix (Fin D) (Fin D) ℂ) :
     A (s : Fin n) i * Q ∈ Submodule.span ℂ
       (Set.range fun w : Fin (m + 1) → Fin d => arcEval A s (List.ofFn w)) := by
+  have hmap :
+      Submodule.map (LinearMap.mulLeft ℂ (A (s : Fin n) i))
+          (Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
+            arcEval A (s + 1) (List.ofFn u))) ≤
+        Submodule.span ℂ
+          (Set.range fun w : Fin (m + 1) → Fin d => arcEval A s (List.ofFn w)) := by
+    rw [Submodule.map_span]
+    refine Submodule.span_le.2 ?_
+    rintro _ ⟨_, ⟨u, rfl⟩, rfl⟩
+    change A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) ∈
+      Submodule.span ℂ
+        (Set.range fun w : Fin (m + 1) → Fin d => arcEval A s (List.ofFn w))
+    have hcons : arcEval A s (List.ofFn (Fin.cons i u)) =
+        A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) := by
+      rw [List.ofFn_succ, arcEval_cons, Fin.cons_zero]
+      simp only [Fin.cons_succ]
+    exact hcons ▸ Submodule.subset_span ⟨Fin.cons i u, rfl⟩
   have hQ : Q ∈ Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
       arcEval A (s + 1) (List.ofFn u)) := hm ▸ Submodule.mem_top
-  induction hQ using Submodule.span_induction with
-  | mem x hx =>
-      obtain ⟨u, rfl⟩ := hx
-      change A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) ∈ _
-      have hcons : arcEval A s (List.ofFn (Fin.cons i u)) =
-          A (s : Fin n) i * arcEval A (s + 1) (List.ofFn u) := by
-        rw [List.ofFn_succ, arcEval_cons, Fin.cons_zero]
-        simp only [Fin.cons_succ]
-      exact Submodule.subset_span ⟨Fin.cons i u, hcons⟩
-  | zero => rw [Matrix.mul_zero]; exact Submodule.zero_mem _
-  | add x y _ _ hx hy => rw [Matrix.mul_add]; exact Submodule.add_mem _ hx hy
-  | smul c x _ hx => rw [mul_smul_comm]; exact Submodule.smul_mem _ c hx
+  simpa only [LinearMap.mulLeft_apply] using
+    hmap (Submodule.mem_map.mpr ⟨Q, hQ, rfl⟩)
 
 /-- **Arc spanning from window injectivity** (arXiv:1804.04964, Section
 `normal_alt`, line 1940 of `Papers/1804.04964/paper_normal.tex`: "any region

--- a/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSChainOverlapCapstone.lean
@@ -64,26 +64,18 @@ private theorem isUnit_of_mul_span {ι : Type*} {X : Matrix (Fin D) (Fin D) ℂ}
     {G : ι → Matrix (Fin D) (Fin D) ℂ}
     (hspan : Submodule.span ℂ (Set.range fun v => X * G v) = ⊤) :
     IsUnit X := by
+  have hspan_le :
+      Submodule.span ℂ (Set.range fun v => X * G v) ≤
+        LinearMap.range (LinearMap.mulLeft ℂ X) := by
+    rw [Submodule.span_le]
+    rintro _ ⟨v, rfl⟩
+    exact LinearMap.mem_range_self (LinearMap.mulLeft ℂ X) (G v)
   have h1 : (1 : Matrix (Fin D) (Fin D) ℂ) ∈
-      Submodule.span ℂ (Set.range fun v => X * G v) :=
-    hspan ▸ Submodule.mem_top
-  have key : ∀ N ∈ Submodule.span ℂ (Set.range fun v => X * G v),
-      ∃ M, N = X * M := by
-    intro N hN
-    induction hN using Submodule.span_induction with
-    | mem x hx =>
-        obtain ⟨v, rfl⟩ := hx
-        exact ⟨G v, rfl⟩
-    | zero => exact ⟨0, (Matrix.mul_zero X).symm⟩
-    | add x y _ _ hx hy =>
-        obtain ⟨Mx, rfl⟩ := hx
-        obtain ⟨My, rfl⟩ := hy
-        exact ⟨Mx + My, (Matrix.mul_add X Mx My).symm⟩
-    | smul c x _ hx =>
-        obtain ⟨Mx, rfl⟩ := hx
-        exact ⟨c • Mx, (Matrix.mul_smul X c Mx).symm⟩
-  obtain ⟨M, hM⟩ := key 1 h1
-  exact IsUnit.of_mul_eq_one M hM.symm
+      LinearMap.range (LinearMap.mulLeft ℂ X) :=
+    hspan_le (hspan ▸ Submodule.mem_top)
+  obtain ⟨M, hM⟩ := h1
+  rw [LinearMap.mulLeft_apply] at hM
+  exact IsUnit.of_mul_eq_one M hM
 
 /-- Two two-sided multiplications agreeing on a spanning family agree on
 every matrix. -/

--- a/TNLean/PEPS/CycleMPSOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSOverlapCapstone.lean
@@ -109,21 +109,18 @@ private theorem transport_one_eq_smul_one {A C : MPSTensor d D} {L k : ℕ}
     induction w with
     | nil => exact Commute.one_left (Λk 1)
     | cons i w ih => exact (hcomm_letter i).mul_left ih
+  have hcomm_maps :
+      LinearMap.mulRight ℂ (Λk 1) = LinearMap.mulLeft ℂ (Λk 1) := by
+    apply LinearMap.ext_on_range
+      (v := fun τ : Fin L → Fin d => evalWord C (List.ofFn τ)) (hv := hCL)
+    intro τ
+    simpa only [LinearMap.mulRight_apply, LinearMap.mulLeft_apply] using
+      (hcomm_word (List.ofFn τ)).eq
   have hcomm : ∀ M : Matrix (Fin D) (Fin D) ℂ, Commute M (Λk 1) := by
     intro M
-    have hM : M ∈ Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
-        evalWord C (List.ofFn τ)) := by
-      have hspan : Submodule.span ℂ (Set.range fun τ : Fin L → Fin d =>
-          evalWord C (List.ofFn τ)) = ⊤ := hCL
-      rw [hspan]
-      exact Submodule.mem_top
-    induction hM using Submodule.span_induction with
-    | mem x hx =>
-        obtain ⟨τ, rfl⟩ := hx
-        exact hcomm_word (List.ofFn τ)
-    | zero => exact Commute.zero_left _
-    | add x y _ _ hx hy => exact Commute.add_left hx hy
-    | smul a x _ hx => exact Commute.smul_left hx a
+    exact (commute_iff_eq M (Λk 1)).mpr (by
+      simpa only [LinearMap.mulRight_apply, LinearMap.mulLeft_apply] using
+        congrArg (fun f => f M) hcomm_maps)
   -- A matrix commuting with everything is a scalar.
   obtain ⟨c, hc⟩ := Matrix.mem_range_scalar_iff_commute_single'.mpr
     (fun i j => hcomm (Matrix.single i j 1))

--- a/TNLean/PEPS/CycleMPSWordTransport.lean
+++ b/TNLean/PEPS/CycleMPSWordTransport.lean
@@ -59,16 +59,24 @@ private theorem mul_left_letter_mem_span {A : MPSTensor d D} {m : ℕ}
     (i : Fin d) (Q : Matrix (Fin D) (Fin D) ℂ) :
     A i * Q ∈ Submodule.span ℂ (Set.range fun w : Fin (m + 1) → Fin d =>
       evalWord A (List.ofFn w)) := by
+  have hmap :
+      Submodule.map (LinearMap.mulLeft ℂ (A i))
+          (Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
+            evalWord A (List.ofFn u))) ≤
+        Submodule.span ℂ (Set.range fun w : Fin (m + 1) → Fin d =>
+          evalWord A (List.ofFn w)) := by
+    rw [Submodule.map_span]
+    refine Submodule.span_le.2 ?_
+    rintro _ ⟨_, ⟨u, rfl⟩, rfl⟩
+    change A i * evalWord A (List.ofFn u) ∈
+      Submodule.span ℂ (Set.range fun w : Fin (m + 1) → Fin d =>
+        evalWord A (List.ofFn w))
+    rw [← evalWord_ofFn_cons]
+    exact Submodule.subset_span ⟨Fin.cons i u, rfl⟩
   have hQ : Q ∈ Submodule.span ℂ (Set.range fun u : Fin m → Fin d =>
       evalWord A (List.ofFn u)) := hm ▸ Submodule.mem_top
-  induction hQ using Submodule.span_induction with
-  | mem x hx =>
-      obtain ⟨u, rfl⟩ := hx
-      rw [← evalWord_ofFn_cons]
-      exact Submodule.subset_span ⟨Fin.cons i u, rfl⟩
-  | zero => rw [Matrix.mul_zero]; exact Submodule.zero_mem _
-  | add x y _ _ hx hy => rw [Matrix.mul_add]; exact Submodule.add_mem _ hx hy
-  | smul c x _ hx => rw [mul_smul_comm]; exact Submodule.smul_mem _ c hx
+  simpa only [LinearMap.mulLeft_apply] using
+    hmap (Submodule.mem_map.mpr ⟨Q, hQ, rfl⟩)
 
 /-- **Block injectivity extends to longer blocks.**  If the word products of
 length `L > 0` span the full matrix algebra, so do the word products of any
@@ -294,20 +302,17 @@ theorem exists_evalWordTransport {A C : MPSTensor d D} {n k q : ℕ} (hkq : k + 
     -- family on the right annihilates the identity.
     rw [LinearMap.ker_eq_bot']
     intro M hM
-    have hQ : ∀ Q : Matrix (Fin D) (Fin D) ℂ, M * Q = 0 := by
-      intro Q
-      have hQmem : Q ∈ Submodule.span ℂ (Set.range fun ρ : Fin q → Fin d =>
-          evalWord A (List.ofFn ρ)) := hAq ▸ Submodule.mem_top
-      induction hQmem using Submodule.span_induction with
-      | mem x hx =>
-          obtain ⟨ρ, rfl⟩ := hx
-          rw [← hΨA_apply]
-          exact congrArg (· ρ) hM
-      | zero => rw [Matrix.mul_zero]
-      | add x y _ _ hx hy => rw [Matrix.mul_add, hx, hy, add_zero]
-      | smul c x _ hx => rw [Matrix.mul_smul, hx, smul_zero]
+    have hmul : LinearMap.mulLeft ℂ M = 0 := by
+      apply LinearMap.ext_on_range
+        (v := fun ρ : Fin q → Fin d => evalWord A (List.ofFn ρ)) (hv := hAq)
+      intro ρ
+      have hρ := congrArg (fun f => f ρ) hM
+      simpa only [hΨA_apply, LinearMap.mulLeft_apply, LinearMap.zero_apply,
+        Pi.zero_apply] using hρ
     calc M = M * 1 := (Matrix.mul_one M).symm
-      _ = 0 := hQ 1
+      _ = 0 := by
+        simpa only [LinearMap.mulLeft_apply, LinearMap.zero_apply] using
+          congrArg (fun f => f 1) hmul
   · -- The two pairings match on the spanning window family: both compute the
     -- length-`n` matrix product of the concatenated word.
     intro τ

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -98,6 +98,10 @@ The clearest replacements are:
   `Submodule.span_induction` over a spanning word family.  They use
   `LinearMap.ext_on_range` to extend equality of the trace-linear functionals
   to all matrices.
+- Four PEPS cycle-MPS transport and capstone proofs now use Mathlib's
+  submodule image and range API, especially `Submodule.map_span`,
+  `LinearMap.range`, and `LinearMap.ext_on_range`, instead of repeating
+  one-use span inductions.
 - Two one-use Frobenius submultiplicativity wrappers in the transfer-operator
   gap files were removed.  The proofs now call Mathlib's
   `Matrix.frobenius_norm_mul` directly at the Hilbert-Schmidt estimate.
@@ -2337,6 +2341,35 @@ Focused checks:
 ```bash
 lake build TNLean.PEPS.CycleMPSChainArc -q --log-level=info
 lake build TNLean.PEPS.CycleMPSWordTransport -q --log-level=info
+```
+
+## PEPS span-map cleanup, 2026-06-21
+
+Four cycle-MPS PEPS proofs used local span inductions only to express simple
+linear images of spanning families:
+
+- `mul_left_letter_mem_span` in
+  `TNLean/PEPS/CycleMPSWordTransport.lean`;
+- `mul_left_letter_mem_arc_span` in
+  `TNLean/PEPS/CycleMPSChainArc.lean`;
+- `isUnit_of_mul_span` in
+  `TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`;
+- the commutation extension inside `transport_one_eq_smul_one` in
+  `TNLean/PEPS/CycleMPSOverlapCapstone.lean`.
+
+The first two now map the length-`m` word span through left multiplication and
+use `Submodule.map_span`.  The invertibility helper now observes that the
+whole span lies in `LinearMap.range (LinearMap.mulLeft ℂ X)`.  The scalarity
+argument extends commutation from a spanning word family by
+`LinearMap.ext_on_range`, then converts the resulting multiplication equality
+with `commute_iff_eq`.
+
+Focused check:
+
+```bash
+lake build TNLean.PEPS.CycleMPSWordTransport TNLean.PEPS.CycleMPSChainArc \
+  TNLean.PEPS.CycleMPSChainOverlapCapstone TNLean.PEPS.CycleMPSOverlapCapstone \
+  -q --log-level=info
 ```
 
 ## Conclusions


### PR DESCRIPTION
### Motivation

- Four cycle-MPS PEPS proofs in `TNLean/PEPS/` used explicit `Submodule.span_induction` to establish results that Mathlib 4.31 supports directly: linear images of spanning sets (`Submodule.map_span`), range membership (`LinearMap.range`), and extension from a spanning family (`LinearMap.ext_on_range`, `commute_iff_eq`).
- Replacing these one-use inductions with standard Mathlib infrastructure shortens the proofs and brings them in line with the Mathlib 4.31 replacement audit (`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`, "PEPS span-map cleanup" section).
- No mathematical statements are changed.

### Description

Modified files:

- `TNLean/PEPS/CycleMPSWordTransport.lean`: `mul_left_letter_mem_span` now uses `Submodule.map_span` for left-multiplication membership; the scalarity step in `transport_one_eq_smul_one` extends commutation from the spanning word family via `LinearMap.ext_on_range` and `commute_iff_eq` instead of span induction.
- `TNLean/PEPS/CycleMPSChainArc.lean`: `mul_left_letter_mem_arc_span` replaced by `Submodule.map_span`.
- `TNLean/PEPS/CycleMPSChainOverlapCapstone.lean`: `isUnit_of_mul_span` now uses `1 ∈ LinearMap.range (LinearMap.mulLeft ℂ X)` instead of inductively factoring every span element as `X * M`.
- `TNLean/PEPS/CycleMPSOverlapCapstone.lean`: corresponding span-map cleanup for commutation extension.
- `docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`: records this batch under "PEPS span-map cleanup, 2026-06-21".

### Testing

- `lake build TNLean.PEPS.CycleMPSWordTransport TNLean.PEPS.CycleMPSChainArc TNLean.PEPS.CycleMPSChainOverlapCapstone TNLean.PEPS.CycleMPSOverlapCapstone -q --log-level=info`
- `rg -n "\bsorry\b|\baxiom\b|native_decide|unsafeCast|\badmit\b" TNLean/PEPS/CycleMPSWordTransport.lean TNLean/PEPS/CycleMPSChainArc.lean TNLean/PEPS/CycleMPSChainOverlapCapstone.lean TNLean/PEPS/CycleMPSOverlapCapstone.lean`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor in PEPS transport/capstone files; mathematical claims and public interfaces are unchanged.
>
> **Overview**
> Replaces **one-off `Submodule.span_induction` proofs** in four cycle-MPS PEPS lemmas with Mathlib 4.31 **submodule image / linear-map range** API (`Submodule.map_span`, `LinearMap.range`, `LinearMap.ext_on_range`, `commute_iff_eq`). **No theorem statements change.**
>
> **Left-multiplication membership** (`mul_left_letter_mem_span`, `mul_left_letter_mem_arc_span`): show the downstream word/arc span contains the image of the shorter span under `LinearMap.mulLeft`, then apply `Submodule.mem_map`.
>
> **Invertibility** (`isUnit_of_mul_span`): use `1 ∈ range (mulLeft X)` instead of inductively factoring every span element as `X * M`.
>
> **Scalar transport** (`transport_one_eq_smul_one`): extend commutation from a spanning word family via `ext_on_range`, then `commute_iff_eq`, instead of span induction on all matrices.
>
> The Mathlib 4.31 replacement audit documents this batch and the focused `lake build` targets.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57a6870b052dab2c356cca12b0f0a76aceedbc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>