### PR TITLE
doc(MPS/Periodic): align 1708 source prose

### DIFF
--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -37,7 +37,7 @@ variable {d D : ℕ}
 
 /-- Case-2 normality lemma for the compressed blocked sector tensors.
 
-The intended mathematical content is arXiv:1708.00029, lemma `lem:bdcf`,
+The intended mathematical content is arXiv:1708.00029, lemma lem:bdcf,
 lines 377--384: after blocking by the period, each cyclic sector is a normal
 tensor. The statement uses the compressed sector tensor on the corner bond
 space, as produced by `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`.

--- a/TNLean/MPS/Periodic/Overlap/Case2.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case2.lean
@@ -37,10 +37,10 @@ variable {d D : ℕ}
 
 /-- Case-2 normality lemma for the compressed blocked sector tensors.
 
-The intended mathematical content is Lemma 2.4: after blocking by the period,
-each cyclic sector is a normal tensor. The statement uses the compressed sector
-tensor on the corner bond space, as produced by
-`exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`.
+The intended mathematical content is arXiv:1708.00029, lemma `lem:bdcf`,
+lines 377--384: after blocking by the period, each cyclic sector is a normal
+tensor. The statement uses the compressed sector tensor on the corner bond
+space, as produced by `exists_cyclic_sector_decomp_after_blocking_of_isPeriodic`.
 
 The nontriviality hypothesis `dim u ≠ 0` excludes the degenerate
 zero-dimensional "missing sector" case. An `MPSTensor _ 0` may satisfy

--- a/TNLean/MPS/Periodic/Overlap/SelfOverlapNonrep.lean
+++ b/TNLean/MPS/Periodic/Overlap/SelfOverlapNonrep.lean
@@ -129,7 +129,7 @@ lemma offDiag_eigenvector_eq_zero_of_isPeriodic
       have hc := congrArg Matrix.conjTranspose (hShiftLetter b i)
       simp only [Matrix.conjTranspose_mul, (hPproj b).1.eq, (hPproj (b + 1)).1.eq] at hc
       exact hc.symm
-    -- Each Kraus term already carries the projectors: `A i (P a X P b) A iᴴ` is
+    -- Each matrix summand already carries the projectors: `A i (P a X P b) A iᴴ` is
     -- supported on the `(a + 1, b + 1)` block.
     have hterm : ∀ i : Fin d,
         A i * (P a * X * P b) * (A i)ᴴ =

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -2096,8 +2096,9 @@ root-construction assumptions used below.
 \end{theorem}
 
 \begin{proof}\leanok
-    Choose a tensor $A'$ realizing the bounded Kraus family of the root channel.
-    Because the channel is trace-preserving, the Kraus operators of $A'$ satisfy
+    Choose a tensor $A'$ whose matrix family realizes the root channel with at
+    most $d$ nonzero terms. Since this channel is trace-preserving, the matrices
+    of $A'$ satisfy
     $\sum_i (A'^i)^\dagger A'^i = \Id$. The identity
     $\mathcal E_C = (\mathcal E_{A'})^p$ is then equivalent to
     $\mathcal E_C = \mathcal E_{A'^{[p]}}$ by the blocking formula.


### PR DESCRIPTION
### Motivation

- Align reader-facing documentation in `MPS/Periodic` with arXiv:1708.00029; no proof or API changes.
- The `Case2.lean` docstring referenced "Lemma 2.4", which is a stale label; the source lemma is `lem:bdcf` (arXiv:1708.00029, lines 377–384).
- Comments in `SelfOverlapNonrep.lean` and the blueprint proof sketch for `thm:peripheral_equalcase_root_from_root_channel` used "Kraus operators" / "Kraus terms" where the objects are matrix summands in the transfer map expansion indexed by tensor matrices $A^i$; the source paper does not use this phrasing.

### Description

- `TNLean/MPS/Periodic/Overlap/Case2.lean`: updated docstring for `sectorBlocked_isNormal_of_isPeriodic` to cite `lem:bdcf` (arXiv:1708.00029, lines 377–384) in place of the stale "Lemma 2.4" label.
- `TNLean/MPS/Periodic/Overlap/SelfOverlapNonrep.lean`: replaced "Kraus term" phrasing in the `hE_block` proof comment with matrix-summand language (each summand is a projector on $A^i$).
- `blueprint/src/chapter/ch22_periodic_ft.tex`: softened the proof sketch for `thm:peripheral_equalcase_root_from_root_channel` to describe the chosen tensor $A'$ by its matrix family (at most $d$ nonzero terms realizing the root channel, left-canonical via $\sum_i (A'^i)^\dagger A'^i = \mathrm{Id}$) rather than as "Kraus operators of $A'$".
- No new proof obligations; no definitions or theorem statements changed.

### Testing

- `lake build TNLean.MPS.Periodic.Overlap.Case2 TNLean.MPS.Periodic.Overlap.SelfOverlapNonrep`
- `lake build TNLean`
- `leanblueprint checkdecls` from `blueprint/`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- Existing style warnings and the known `Overlap/Case3.lean` sorry warning are unchanged; no new proof obligations introduced.

---
Refs #619, #664

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose edits only; validation reports no new proof obligations.
> 
> **Overview**
> Aligns **reader-facing documentation** with arXiv:1708.00029; no proof or API changes.
> 
> In **`Case2.lean`**, the `sectorBlocked_isNormal_of_isPeriodic` docstring now cites lemma **`lem:bdcf`** (lines 377–384) instead of the outdated "Lemma 2.4" label.
> 
> In **`SelfOverlapNonrep.lean`**, a comment in the `hE_block` proof describes each **matrix summand** in the transfer map sum (with projectors on `A i`) rather than calling them "Kraus terms."
> 
> In **`ch22_periodic_ft.tex`**, the proof sketch for **`thm:peripheral_equalcase_root_from_root_channel`** says we pick a tensor `A'` whose **matrix family** realizes the root channel with at most `d` nonzero terms, then states left-canonicality via **`∑_i (A'^i)† A'^i = Id`**—avoiding "Kraus operators of `A'`" phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc44bc1d712e1edf1b1e1164bd5863bcf6b171f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose only; no Lean API or proof obligations changed.
> 
> **Overview**
> Aligns **reader-facing documentation** with arXiv:1708.00029; **no theorem statements, definitions, or proofs change.**
> 
> In **`Case2.lean`**, the `sectorBlocked_isNormal_of_isPeriodic` docstring now cites lemma **`lem:bdcf`** (lines 377–384) instead of the outdated **"Lemma 2.4"** label.
> 
> In **`SelfOverlapNonrep.lean`**, a comment in the `hE_block` proof calls each indexed **`A i`** term a **matrix summand** in the transfer map sum, not a **"Kraus term."**
> 
> In **`ch22_periodic_ft.tex`**, the proof sketch for **`thm:peripheral_equalcase_root_from_root_channel`** picks **`A'`** via its **matrix family** (at most **`d`** nonzero terms realizing the root channel) and states left-canonicality as **`∑_i (A'^i)† A'^i = Id`**, avoiding **"Kraus operators of `A'`."**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20181bb6913f35866be160c8dc3d924e7a927b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->