### PR TITLE
feat(MPS/SharedInfra): normalize scalar phases

### DIFF
--- a/TNLean/MPS/SharedInfra/Scaling.lean
+++ b/TNLean/MPS/SharedInfra/Scaling.lean
@@ -37,6 +37,58 @@ theorem leftCanonical_smul_of_norm_one (c : ℂ) (hc : ‖c‖ = 1)
       (Complex.normSq_eq_conj_mul_self (z := c)).symm
   rw [hsc, one_smul]
 
+/-- If both `A` and its scalar multiple are left-canonical, then the scalar has
+unit norm.
+
+This is the scalar normalization used in arXiv:1708.00029, Appendix A,
+lines 1082--1084: once sectorwise proportionality has been extracted, the
+left-canonical equations force the proportionality scalar to be a phase. -/
+theorem norm_eq_one_of_leftCanonical_smul [NeZero D] (c : ℂ) (A : MPSTensor d D)
+    (hA : IsLeftCanonical A) (hcA : IsLeftCanonical (fun i => c • A i)) :
+    ‖c‖ = 1 := by
+  unfold IsLeftCanonical at hA hcA
+  have hscaled : (star c * c) • (1 : Matrix (Fin D) (Fin D) ℂ) = 1 := by
+    calc
+      (star c * c) • (1 : Matrix (Fin D) (Fin D) ℂ)
+          = (star c * c) • ∑ i : Fin d, (A i)ᴴ * A i := by rw [hA]
+      _ = ∑ i : Fin d, (c • A i)ᴴ * (c • A i) := by
+        simp only [Matrix.conjTranspose_smul]
+        simp_rw [smul_mul_smul_comm]
+        rw [← Finset.smul_sum]
+      _ = 1 := hcA
+  have hentry :=
+    congrArg (fun M : Matrix (Fin D) (Fin D) ℂ => M 0 0) hscaled
+  have hstar_mul : star c * c = 1 := by
+    simpa [Matrix.smul_apply] using hentry
+  have hnormSq : star c * c = (↑(‖c‖ ^ 2) : ℂ) := by
+    simpa [Complex.normSq_eq_norm_sq] using
+      (Complex.normSq_eq_conj_mul_self (z := c)).symm
+  have hsq_complex : ((‖c‖ ^ 2 : ℝ) : ℂ) = 1 := by
+    rw [← hnormSq, hstar_mul]
+  have hsq_real : ‖c‖ ^ 2 = 1 := by
+    exact Complex.ofReal_injective hsq_complex
+  nlinarith [norm_nonneg c]
+
+/-- Appendix-A scalar normalization in the form used after product-one phase
+extraction.
+
+If \(A^i=(\kappa\xi)B^i\), both tensor families are left-canonical, and
+\(\xi\) already has unit norm, then \(\kappa\) has unit norm.  This isolates
+the normalization step in arXiv:1708.00029, Appendix A, lines 1082--1084, after
+the \(\Omega_u\)-contraction and scalar extraction have produced the sector
+relation. -/
+theorem kappa_norm_eq_one_of_leftCanonical_smul [NeZero D]
+    {κ ξ : ℂ} (hξ : ‖ξ‖ = 1) (A B : MPSTensor d D)
+    (hA : IsLeftCanonical A) (hB : IsLeftCanonical B)
+    (hAB : ∀ i : Fin d, A i = (κ * ξ) • B i) :
+    ‖κ‖ = 1 := by
+  have hscaled : IsLeftCanonical (fun i : Fin d => (κ * ξ) • B i) := by
+    unfold IsLeftCanonical at hA ⊢
+    simpa [hAB] using hA
+  have hκξ : ‖κ * ξ‖ = 1 :=
+    norm_eq_one_of_leftCanonical_smul (κ * ξ) B hB hscaled
+  simpa [norm_mul, hξ] using hκξ
+
 /-- Unit-norm scaling preserves periodicity data. -/
 theorem isPeriodic_smul_of_norm_one
     {m : ℕ} {c : ℂ} (hc : ‖c‖ = 1)

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -623,11 +623,11 @@ unconditional result.
     \leanok
     \uses{thm:left_canonical_scalar_normalization}
     Let $A$ and $B$ be left-canonical tensors with the same positive bond
-    dimension. Suppose that $|\xi|=1$ and
+    dimension. Suppose that $|\xi|=1$ and that, for every physical index~$i$,
     \[
         A^i=(\kappa\xi)B^i
     \]
-    for every physical index $i$. Then $|\kappa|=1$.
+    Then $|\kappa|=1$.
 
     This is the scalar normalization in
     \cite[Appendix~A, lines~1082--1084]{DeLasCuevas2017Irreducible}, after the

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -597,6 +597,49 @@ unconditional result.
     and $A_v^i=(\kappa_v\xi)B_v^i$.
 \end{proof}
 
+\begin{theorem}[Left-canonical scalar normalization]
+    \label{thm:left_canonical_scalar_normalization}
+    \lean{MPSTensor.norm_eq_one_of_leftCanonical_smul}
+    \leanok
+    Let $A$ have positive bond dimension, and let $c\in\C$. If both $A$ and
+    the scalar multiple $cA$ are left-canonical, then $|c|=1$.
+\end{theorem}
+
+\begin{proof}\leanok
+    The two left-canonical equations give
+    \[
+        \sum_i (A^i)^\dagger A^i=\Id,
+        \qquad
+        \sum_i (cA^i)^\dagger(cA^i)=\Id.
+    \]
+    Substituting the first equation into the second gives
+    $(\bar c c)\Id=\Id$. Since the bond dimension is positive, comparison of
+    any diagonal entry gives $\bar c c=1$, hence $|c|=1$.
+\end{proof}
+
+\begin{theorem}[Left-canonical sector scalar normalization]
+    \label{thm:left_canonical_sector_scalar_normalization}
+    \lean{MPSTensor.kappa_norm_eq_one_of_leftCanonical_smul}
+    \leanok
+    \uses{thm:left_canonical_scalar_normalization}
+    Let $A$ and $B$ be left-canonical tensors with the same positive bond
+    dimension. Suppose that $|\xi|=1$ and
+    \[
+        A^i=(\kappa\xi)B^i
+    \]
+    for every physical index $i$. Then $|\kappa|=1$.
+
+    This is the scalar normalization in
+    \cite[Appendix~A, lines~1082--1084]{DeLasCuevas2017Irreducible}, after the
+    sectorwise proportionality relation has been obtained.
+\end{theorem}
+
+\begin{proof}\leanok
+    By Theorem~\ref{thm:left_canonical_scalar_normalization}, applied to $B$
+    and the scalar $\kappa\xi$, one has $|\kappa\xi|=1$. Since $|\xi|=1$, the
+    multiplicativity of the complex norm gives $|\kappa|=1$.
+\end{proof}
+
 \begin{definition}[Off-diagonal sector decomposition]%
     \label{def:cyclic_sector_decomp}
     \lean{MPSTensor.IsCyclicSectorDecomp, MPSTensor.IsCyclicSectorDecompWith}
@@ -1196,7 +1239,8 @@ unconditional result.
     % gap in docs/paper-gaps/1708_periodic_overlap_route_alignment.tex.
     \notready
     \uses{lem:sector_match_propagation, def:cyclic_sector_decomp,
-        thm:periodic_product_one_phase_extraction, lem:finite_cycle_coboundary}
+        thm:periodic_product_one_phase_extraction,
+        thm:left_canonical_sector_scalar_normalization, lem:finite_cycle_coboundary}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let
     $\bar A\sim\bigoplus_u A_u$ and $\bar B\sim\bigoplus_v B_v$ be unit-weight
     cyclic sector decompositions whose sectors are left-canonical. Let the


### PR DESCRIPTION
### Motivation

- The `m`-factor cyclic contraction in issue #873 (arXiv:1708.00029, Appendix A) requires that per-sector proportionality scalars `κ_v` have unit modulus, derived from the left-canonical normalization equations. The source passage is arXiv:1708.00029, Appendix A, lines 1082–1084.
- Continues the Appendix A proof route toward `repeatedBlocks_of_blockedSectorGaugePhase` in `TNLean/MPS/Periodic/Overlap/Case3.lean`.

### Description

- `TNLean/MPS/SharedInfra/Scaling.lean`: adds two theorems.
  - `norm_eq_one_of_leftCanonical_smul`: if `A` and `c • A` are both left-canonical (with `[NeZero D]`), then `‖c‖ = 1`. This is the unit-modulus constraint from the left-canonical equations in arXiv:1708.00029, Appendix A, lines 1082–1084.
  - `kappa_norm_eq_one_of_leftCanonical_smul`: sector form — if `A i = (κ * ξ) • B i`, both `A` and `B` are left-canonical, and `‖ξ‖ = 1`, then `‖κ‖ = 1`. This isolates the normalization step after the Ω_u-contraction and scalar extraction.
- `blueprint/src/chapter/ch22_periodic_ft.tex`: records both declarations with `\lean{}` and `\leanok` tags in the periodic FT blueprint.

### Testing

- `lake env lean TNLean/MPS/SharedInfra/Scaling.lean`
- `lake build TNLean.MPS.SharedInfra.Scaling -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check`
- `rg -n "sorry|axiom" TNLean/MPS/SharedInfra/Scaling.lean`

---
Addresses #873

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4597f2d487d523be3dacb40c72e1c09eedd85d0f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style lemmas in shared scaling infrastructure plus blueprint sync; no auth, runtime, or API surface changes.
> 
> **Overview**
> Adds Lean proofs that **left-canonical normalization forces proportionality scalars to have unit modulus**, matching arXiv:1708.00029 Appendix A (lines 1082–1084) for the cyclic **Ω_u** contraction route (#873).
> 
> In **`TNLean/MPS/SharedInfra/Scaling.lean`**, **`norm_eq_one_of_leftCanonical_smul`** shows that if both `A` and `c • A` are left-canonical (with positive bond dimension), then `‖c‖ = 1`. **`kappa_norm_eq_one_of_leftCanonical_smul`** is the sector form: when `A i = (κ * ξ) • B i`, both families are left-canonical, and `‖ξ‖ = 1`, then `‖κ‖ = 1`.
> 
> The periodic FT **blueprint** (`ch22_periodic_ft.tex`) records both results with `\lean{}` / `\leanok` proofs and cites them from **`thm:left_canonical_sector_scalar_normalization`** in the not-yet-ready lemma **`lem:sector_tensor_proportional_blocked_match`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c1668b6b9f5f09c7b32be4056f9a92b783ba105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->