### PR TITLE
feat(MPS/ParentHamiltonian): identify BNT vector span

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/ChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/ChainGroundSpace.lean
@@ -32,6 +32,16 @@ noncomputable def mpvSubmodule (A : MPSTensor d D) (N : ℕ) :
     Submodule ℂ (NSiteSpace d N) :=
   Submodule.span ℂ {mpv A}
 
+/-- The BNT span of component MPS vectors is the supremum of the corresponding
+one-vector submodules. -/
+theorem iSup_mpvSubmodule_eq_bntMPSVectorSpan
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j)) (N : ℕ) :
+    (⨆ j : Fin r, mpvSubmodule (A j) N) = bntMPSVectorSpan A N := by
+  simpa [bntMPSVectorSpan, mpvSubmodule] using
+    (Submodule.span_range_eq_iSup (R := ℂ)
+      (v := fun j : Fin r => (mpv (A j) : NSiteSpace d N))).symm
+
 /-- The MPS vector is the ground-space map applied to the identity matrix. -/
 theorem mpv_eq_groundSpaceMap_one (A : MPSTensor d D) (N : ℕ) :
     (mpv A : NSiteSpace d N) = groundSpaceMap A N 1 := by


### PR DESCRIPTION
### Motivation

- The ground-space spanning argument in the parent-Hamiltonian chain-ground-space interface (arXiv:1606.00608, nearest-neighbor commuting parent-Hamiltonian theorem) requires the identity between two span representations of the BNT component MPS vectors; see #2633.
- `bntMPSVectorSpan` and `mpvSubmodule` appear on different sides of the RFP/ZCL/NNCPH equivalence argument; this identity shows the two are equal.

### Description

- Modified `TNLean/MPS/ParentHamiltonian/ChainGroundSpace.lean` (+10 lines).
- Adds `iSup_mpvSubmodule_eq_bntMPSVectorSpan`: for a finite BNT family `A` and chain length `N`, the submodule equality
  ```
  (⨆ j : Fin r, mpvSubmodule (A j) N) = bntMPSVectorSpan A N
  ```
  holds. The proof rewrites through `Submodule.span_range_eq_iSup`, making the two span representations interchangeable in ground-space arguments.
- Does not prove either axiom-backed direction of the RFP/ZCL/NNCPH equivalence (those remain open in #2633).

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.ChainGroundSpace TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py`
- `git diff --check origin/main...HEAD`
- Added-line scan for `sorry`, `admit`, `axiom`, `native_decide`, and `unsafeCast`.

---
Addresses #2633

> [!NOTE]
> **Low Risk**
> Adds a single definitional bridge lemma with no runtime or axiom changes.
> 
> **Overview**
> Adds **`iSup_mpvSubmodule_eq_bntMPSVectorSpan`**, showing that for a finite BNT family `A`, the supremum `⨆ j, mpvSubmodule (A j) N` equals **`bntMPSVectorSpan A N`**.
> 
> The proof is a direct rewrite through **`Submodule.span_range_eq_iSup`**, so the existing BNT span definition is interchangeable with the supremum of one-vector **`mpv`** submodules—useful when ground-space arguments are phrased in terms of **`mpvSubmodule`** rather than **`bntMPSVectorSpan`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f191f347694352580da94165f424c6fc33d0626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>