### PR TITLE
doc(parent): add BNT span equality blueprint entry

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -70,6 +70,28 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
 \end{definition}
 
+\begin{lemma}[BNT span as the sum of one-vector spaces]
+    \label{lem:bnt_span_eq_sum_mpv_submodules}
+    \lean{MPSTensor.iSup_mpvSubmodule_eq_bntMPSVectorSpan}
+    \leanok
+    \uses{def:bnt_span, def:mpv_submodule}
+    For a family $A_0,\ldots,A_{r-1}$ and a chain length $N$, let
+    \[
+        M_j=\spn\{V^{(N)}(A_j)\}.
+    \]
+    Then
+    \[
+        \bigvee_{j=0}^{r-1} M_j
+        =
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Both sides are the span of the same family of vectors.
+\end{proof}
+
 \begin{definition}[Fixed-length block-injective canonical-form condition]
     \label{def:blockwise_product_word_span}
     \lean{MPSTensor.WordTupleSpanTop}


### PR DESCRIPTION
### Motivation

PR #3329 added the Lean identity identifying the supremum of the one-vector MPS submodules with the BNT vector span. This follow-up records that identity in the parent-Hamiltonian blueprint where the block-intersection chapter already defines the BNT span.

### Description

Adds a blueprint lemma `lem:bnt_span_eq_sum_mpv_submodules` with `\lean{MPSTensor.iSup_mpvSubmodule_eq_bntMPSVectorSpan}` and `\leanok`. The statement is purely the equality between the span of the component vectors and the supremum of the corresponding one-vector spaces.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main...HEAD`

---
Addresses #2633

> [!NOTE]
> **Low Risk**
> Documentation-only blueprint/LaTeX sync with no runtime or proof logic changes in this diff.
>
> **Overview**
> Adds blueprint lemma **`lem:bnt_span_eq_sum_mpv_submodules`** in the parent-Hamiltonian block-intersections chapter, placed right after **`def:bnt_span`**.
>
> The statement records that the supremum of the per-tensor one-vector spaces \(M_j=\spn\{V^{(N)}(A_j)\}\) equals the BNT vector span \(\spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}\), with `\lean{MPSTensor.iSup_mpvSubmodule_eq_bntMPSVectorSpan}` and `\leanok`. The proof is a one-line observation that both sides are the span of the same vectors. This documents in TeX the Lean identity from PR #3329.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 218942afe0cb0a44043934f96183770d7bb596e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>