### PR TITLE
doc(parent): add BNT span equality blueprint entry

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex
@@ -70,6 +70,28 @@ formulation; the passage to $\ker H_N$ is kept separate.
     \]
 \end{definition}
 
+\begin{lemma}[BNT span as the sum of one-vector spaces]
+    \label{lem:bnt_span_eq_sum_mpv_submodules}
+    \lean{MPSTensor.iSup_mpvSubmodule_eq_bntMPSVectorSpan}
+    \leanok
+    \uses{def:bnt_span, def:mpv_submodule}
+    For a family $A_0,\ldots,A_{r-1}$ and a chain length $N$, let
+    \[
+        M_j=\spn\{V^{(N)}(A_j)\}.
+    \]
+    Then
+    \[
+        \bigvee_{j=0}^{r-1} M_j
+        =
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Both sides are the span of the same family of vectors.
+\end{proof}
+
 \begin{definition}[Fixed-length block-injective canonical-form condition]
     \label{def:blockwise_product_word_span}
     \lean{MPSTensor.WordTupleSpanTop}


### PR DESCRIPTION
### Motivation

- The Lean lemma `MPSTensor.iSup_mpvSubmodule_eq_bntMPSVectorSpan` (merged in #3329) records that the supremum of the one-vector submodules for a finite BNT family equals the BNT MPS vector span; the blueprint had no corresponding entry.
- This adds `\lean{MPSTensor.iSup_mpvSubmodule_eq_bntMPSVectorSpan}` and `\leanok` to the parent-Hamiltonian block-intersections chapter to keep blueprint and Lean in sync. Continues formalization of the parent-Hamiltonian material, see #2633.

### Description

- Modified `blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections.tex`:
  - Added lemma `lem:bnt_span_eq_sum_mpv_submodules` (22 lines) stating that the join of the one-vector subspaces over a BNT family equals the BNT MPS vector span.
  - Tagged with `\leanok`, `\lean{MPSTensor.iSup_mpvSubmodule_eq_bntMPSVectorSpan}`, and `\uses{def:bnt_span, def:mpv_submodule}`.
- No Lean declarations or theorem statements change.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check origin/main...HEAD`
- `cd blueprint && leanblueprint checkdecls`

---
Addresses #2633

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX addition with no runtime or proof changes.
>
> **Overview**
> Adds blueprint documentation for the existing Lean bridge **`MPSTensor.iSup_mpvSubmodule_eq_bntMPSVectorSpan`**, placed after the BNT span definition in `ch13_parent_hamiltonian_block_intersections.tex`.
>
> The new lemma **`lem:bnt_span_eq_sum_mpv_submodules`** states that the join of the one-vector spaces \(\spn\{V^{(N)}(A_j)\}\) equals \(\spn\{V^{(N)}(A_j): j=0,\ldots,r-1\}\), with `\leanok` and `\uses{def:bnt_span, def:mpv_submodule}`. The proof is a one-line observation that both sides are spans of the same vectors.
>
> **No Lean code or theorem statements change**—this is blueprint–Lean sync only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 218942afe0cb0a44043934f96183770d7bb596e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>