### PR TITLE
feat(MPS/ParentHamiltonian): relate kernels to chain constraints

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -196,6 +196,7 @@ import TNLean.Axioms.Beigi
 import TNLean.MPS.ParentHamiltonian.Commuting
 import TNLean.MPS.ParentHamiltonian.Decorrelation
 import TNLean.MPS.ParentHamiltonian.Martingale
+import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
 -- The finite-chain uniqueness capstone is not part of this foundational layer.
 -- Downstream files may import it when they need the periodic-chain definitions.
 

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -121,6 +121,28 @@ theorem re_inner_sum_apply_left (P : ι → E →ₗ[𝕜] E) (v : E) :
   simp only [LinearMap.sum_apply, sum_inner]
   exact map_sum (RCLike.re : 𝕜 →+ ℝ) (fun i => ⟪P i v, v⟫_𝕜) Finset.univ
 
+/-- If a finite sum of symmetric projections annihilates a vector, then each
+projection in the sum annihilates that vector. -/
+theorem apply_eq_zero_of_sum_apply_eq_zero
+    (P : ι → E →ₗ[𝕜] E) (hP : ∀ i, (P i).IsSymmetricProjection)
+    {v : E} (hsum : (∑ i, P i) v = 0) (i : ι) :
+    P i v = 0 := by
+  have hsum_re :
+      (∑ i, RCLike.re (⟪P i v, v⟫_𝕜)) = 0 := by
+    rw [← re_inner_sum_apply_left P v, hsum]
+    simp
+  have hterm_zero :
+      (fun i => RCLike.re (⟪P i v, v⟫_𝕜)) = 0 :=
+    (Fintype.sum_eq_zero_iff_of_nonneg
+      (fun i => (hP i).isPositive.re_inner_nonneg_left v)).mp hsum_re
+  have hterm : RCLike.re (⟪P i v, v⟫_𝕜) = 0 := by
+    simpa using congrFun hterm_zero i
+  have hdiag : RCLike.re (⟪P i v, v⟫_𝕜) = ‖P i v‖ ^ 2 := by
+    rw [← (hP i).re_inner_apply_apply_self v, inner_self_eq_norm_sq]
+  have hnorm_sq : ‖P i v‖ ^ 2 = 0 := by
+    rwa [← hdiag]
+  exact norm_eq_zero.mp (sq_eq_zero_iff.mp hnorm_sq)
+
 /-- The norm-square quadratic form of a finite sum expands into all ordered
 cross terms. -/
 theorem re_inner_sum_apply_apply (P : ι → E →ₗ[𝕜] E) (v : E) :

--- a/TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
+import TNLean.MPS.ParentHamiltonian.Martingale.Transport
+
+/-!
+# Kernels of finite parent Hamiltonians and chain constraints
+
+This file records the elementary frustration-free direction for the periodic
+parent Hamiltonian: since the finite parent Hamiltonian is a sum of local
+orthogonal projections, a vector in its kernel satisfies every local cyclic
+constraint. Hence the kernel of \(H_L^{(N)}(A)\) lies in the periodic
+chain-ground-space submodule.
+-/
+
+open scoped BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The kernel of the finite periodic parent Hamiltonian is contained in the
+periodic chain ground space.
+
+Equivalently, a zero-energy vector for \(H_L^{(N)}(A)\) satisfies every cyclic
+\(L\)-site local MPS constraint. -/
+theorem ker_parentHamiltonian_le_chainGroundSpace
+    (A : MPSTensor d D) {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :
+    LinearMap.ker (parentHamiltonian A L N) ≤ chainGroundSpace A L N := by
+  intro ψ hψ
+  rw [chainGroundSpace, dif_pos ⟨hN, hLN⟩]
+  simp only [Submodule.mem_iInf, Submodule.mem_comap]
+  intro i τ
+  let eN := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  have hES : parentHamiltonianES A L N (eN.symm ψ) = 0 := by
+    rw [LinearMap.mem_ker] at hψ
+    simpa [parentHamiltonianES, eN] using congrArg eN.symm hψ
+  have hlocal :
+      localTermES A L i (eN.symm ψ) = 0 := by
+    rw [parentHamiltonianES_eq_sum_localTermES A L N] at hES
+    exact ProjectionGeometry.apply_eq_zero_of_sum_apply_eq_zero
+      (fun i : Fin N => localTermES A L i)
+      (fun i : Fin N => localTermES_isSymmetricProjection A L i) hES i
+  have hrestrictES :
+      cyclicRestrictES (d := d) hN L i τ (eN.symm ψ) ∈ groundSpaceES A L :=
+    cyclicRestrictES_mem_groundSpaceES_of_localTermES_eq_zero A hLN i hlocal τ
+  let eL := WithLp.linearEquiv 2 ℂ (NSiteSpace d L)
+  have hrestrictNS :
+      eL (cyclicRestrictES (d := d) hN L i τ (eN.symm ψ)) ∈ groundSpace A L :=
+    (mem_groundSpaceES_iff A L
+      (cyclicRestrictES (d := d) hN L i τ (eN.symm ψ))).1 hrestrictES
+  simpa [cyclicRestrictES, eN, eL] using hrestrictNS
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.ParentHamiltonian.Martingale.Transport
 This file records the elementary frustration-free direction for the periodic
 parent Hamiltonian: since the finite parent Hamiltonian is a sum of local
 orthogonal projections, a vector in its kernel satisfies every local cyclic
-constraint. Hence the kernel of \(H_L^{(N)}(A)\) lies in the periodic
+constraint. Hence the kernel of \(H_N(A,L)\) lies in the periodic
 chain-ground-space submodule.
 -/
 
@@ -25,7 +25,7 @@ variable {d D : ℕ}
 /-- The kernel of the finite periodic parent Hamiltonian is contained in the
 periodic chain ground space.
 
-Equivalently, a zero-energy vector for \(H_L^{(N)}(A)\) satisfies every cyclic
+Equivalently, a zero-energy vector for \(H_N(A,L)\) satisfies every cyclic
 \(L\)-site local MPS constraint. -/
 theorem ker_parentHamiltonian_le_chainGroundSpace
     (A : MPSTensor d D) {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -205,6 +205,49 @@ sufficient stronger hypotheses.
     local projector with membership in $G_L^{\mathrm{ES}}(A)$.
 \end{proof}
 
+\begin{theorem}[Zero energy gives the cyclic local constraints]
+    \label{thm:parent_hamiltonian_kernel_le_chain_ground_space}
+    \lean{MPSTensor.ker_parentHamiltonian_le_chainGroundSpace}
+    \leanok
+    \uses{def:parent_hamiltonian, def:parent_hamiltonian_es,
+        def:chain_ground_space, lem:transported_es_local_projections,
+        lem:local_term_es_kernel_restrictions, rem:projection_geometry_rowsum_identities}
+    Assume $N>0$ and $L\le N$. If a vector $\psi$ has zero energy for the
+    finite periodic parent Hamiltonian,
+    \[
+        H_N(A,L)\psi=0,
+    \]
+    then every cyclic length-$L$ restriction of $\psi$ lies in the local MPS
+    ground space. Equivalently,
+    \[
+        \ker H_N(A,L) \subseteq G_L^{(N)}(A).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Put $P_i=h_{i,\mathrm{ES}}$ and $H=\sum_iP_i$. If $Hv=0$, then
+    \[
+        0
+        =
+        \operatorname{Re}\langle Hv,v\rangle
+        =
+        \sum_i\operatorname{Re}\langle P_i v,v\rangle
+        =
+        \sum_i\|P_i v\|^2 .
+    \]
+    Each summand is nonnegative; hence $\|P_i v\|^2=0$ and therefore
+    $P_i v=0$ for every $i$. Applying this to
+    $H_{N,L}^{\mathrm{ES}}(A)=\sum_i h_{i,\mathrm{ES}}$ gives the vanishing of
+    every Hilbert-space local term. Lemma~\ref{lem:local_term_es_kernel_restrictions}
+    identifies these equations with the conditions: for all $i$ and $\tau$,
+    \[
+        R_{i,\tau}\psi\in G_L(A),
+    \]
+    which are exactly the cyclic-window defining equations of
+    $G_L^{(N)}(A)$.
+\end{proof}
+
 \begin{theorem}[Intersection property for two adjacent local kernels]
     \label{thm:adjacent_local_kernels_ground_space_es}
     \lean{MPSTensor.mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero}
@@ -348,6 +391,7 @@ sufficient stronger hypotheses.
     \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_nonneg_of_commute}
     \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_ge_neg_of_norm_apply_le}
     \lean{ProjectionGeometry.re_inner_sum_apply_left}
+    \lean{ProjectionGeometry.apply_eq_zero_of_sum_apply_eq_zero}
     \lean{ProjectionGeometry.re_inner_sum_apply_apply}
     \lean{ProjectionGeometry.sum_sum_eq_diag_add_offdiag}
     \lean{ProjectionGeometry.crossTerm_sum_bound_of_ordered_rowSum}
@@ -365,10 +409,11 @@ sufficient stronger hypotheses.
     finite-sum expansions of
     $\operatorname{Re}\langle (\sum_i P_i)v,v\rangle$ and
     $\operatorname{Re}\langle (\sum_i P_i)v,(\sum_i P_i)v\rangle$; the
-    diagonal/off-diagonal split of the ordered double sum; the aggregate
-    off-diagonal estimate obtained from row sums $\sum_{j\ne i}c_{ij}\le1$; and
-    the corresponding aggregate estimate for the anticommutator martingale
-    condition.
+    conclusion that a vector annihilated by a finite sum of symmetric projections
+    is annihilated by each projection; the diagonal/off-diagonal split of the
+    ordered double sum; the aggregate off-diagonal estimate obtained from row
+    sums $\sum_{j\ne i}c_{ij}\le1$; and the corresponding aggregate estimate for
+    the anticommutator martingale condition.
 \end{remark}
 
 \begin{lemma}[Ordered projection row-sum quadratic-form reduction]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -226,6 +226,16 @@ sufficient stronger hypotheses.
 
 \begin{proof}
     \leanok
+    Let $e_N$ be the canonical $\ell^2$ identification of the $N$-site space.
+    Since $H_N(A,L)$ is the $e_N$-conjugate of $H_{N,L}^{\mathrm{ES}}(A)$, the
+    hypothesis gives
+    \[
+        H_{N,L}^{\mathrm{ES}}(A)(e_N^{-1}\psi)
+        =
+        e_N^{-1}\bigl(H_N(A,L)\psi\bigr)
+        =
+        0.
+    \]
     Put $P_i=h_{i,\mathrm{ES}}$ and $H=\sum_iP_i$. If $Hv=0$, then
     \[
         0


### PR DESCRIPTION
## Summary

- add a projection-geometry lemma: a vector annihilated by a finite sum of symmetric projections is annihilated by each summand
- apply it to the finite periodic parent Hamiltonian to prove
  \[
    \ker H_N(A,L) \subseteq G_L^{(N)}(A)
  \]
  for \(N>0\) and \(L\le N\)
- record the containment and the auxiliary projection argument in the spectral-gap blueprint chapter

This is a preparatory parent-Hamiltonian step. It does not prove the overlapping-window principal-angle estimate or the full block-diagonal ground-space spanning theorem.

Refs #2633
Refs #952
Refs #460
Refs #190

## Validation

- `lake env lean TNLean/Analysis/ProjectionGeometry.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean`
- `lake build TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake exe checkdecls blueprint/lean_decls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized formal proofs and blueprint sync in parent-Hamiltonian infrastructure; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`ProjectionGeometry.apply_eq_zero_of_sum_apply_eq_zero`**: if a finite sum of symmetric projections kills a vector, each summand does too (via nonnegative diagonal quadratic forms).
> 
> Uses that on **`parentHamiltonianES`** as a sum of local symmetric projections to prove **`ker_parentHamiltonian_le_chainGroundSpace`**: for \(N>0\), \(L\le N\), zero energy for \(H_N(A,L)\) implies every cyclic length-\(L\) window lies in the local MPS ground space, i.e. \(\ker H_N(A,L) \subseteq G_L^{(N)}(A)\). Exposes the module via **`TNLean.lean`** and records the theorem plus the new identity in the ch.13 spectral-gap blueprint.
> 
> Explicitly preparatory—no overlapping-window principal-angle or block-diagonal spanning results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcefa9c178a68bbf777386e36b4291f5806aa8cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->