### PR TITLE
feat(channel): formalize unitary open-system representation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -24,6 +24,7 @@ import TNLean.Algebra.GramMatrixLI
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Algebra.MatrixAux
+import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.FinSum
 import TNLean.Algebra.ScalarPowerSumIdentity
 import TNLean.Algebra.UnitModulusPowerSum

--- a/TNLean.lean
+++ b/TNLean.lean
@@ -60,6 +60,7 @@ import TNLean.Channel.Stinespring
 import TNLean.Channel.OrderedCP
 import TNLean.Channel.CompletelyPositiveBridge
 import TNLean.Channel.RadonNikodym
+import TNLean.Channel.OpenSystem
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.POVM
 import TNLean.Channel.POVM.Uniqueness

--- a/TNLean/Algebra/MatrixGramUnitary.lean
+++ b/TNLean/Algebra/MatrixGramUnitary.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Analysis.InnerProductSpace.PiL2
+
+/-!
+# Gram equality and unitary extension for rectangular matrices
+
+This file records a finite-dimensional Hilbert-space consequence for complex
+matrices: two rectangular matrices with the same Gram matrix differ by a
+unitary matrix on the codomain.  The proof passes through the corresponding
+linear maps on Euclidean spaces and extends the induced isometry between their
+ranges to the ambient finite-dimensional Hilbert space.
+-/
+
+open scoped Matrix InnerProductSpace
+open Matrix
+
+namespace Matrix
+
+/-- If two rectangular matrices have the same Gram matrix, then they differ by
+left multiplication by a unitary matrix on the codomain. -/
+theorem exists_unitary_mul_eq_of_conjTranspose_mul_eq
+    {m n : Type*} [Fintype m] [DecidableEq m] [Finite n]
+    (B A : Matrix m n ℂ)
+    (hGram : Bᴴ * B = Aᴴ * A) :
+    ∃ U : Matrix.unitaryGroup m ℂ, B = (U : Matrix m m ℂ) * A := by
+  classical
+  letI : Fintype n := Fintype.ofFinite n
+  letI : InnerProductSpace ℂ (EuclideanSpace ℂ m) :=
+    PiLp.innerProductSpace (fun _ : m => ℂ)
+  letI : FiniteDimensional ℂ (EuclideanSpace ℂ m) :=
+    (EuclideanSpace.basisFun m ℂ).toBasis.finiteDimensional_of_finite
+  let fB : EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m :=
+    Matrix.toEuclideanLin B
+  let fA : EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m :=
+    Matrix.toEuclideanLin A
+  have hinner : ∀ v w : EuclideanSpace ℂ n,
+      ⟪fB v, fB w⟫_ℂ = ⟪fA v, fA w⟫_ℂ := by
+    intro v w
+    rw [← LinearMap.adjoint_inner_right fB v (fB w),
+        ← LinearMap.adjoint_inner_right fA v (fA w)]
+    congr 1
+    change fB.adjoint (fB w) = fA.adjoint (fA w)
+    rw [← Matrix.toEuclideanLin_conjTranspose_eq_adjoint B,
+        ← Matrix.toEuclideanLin_conjTranspose_eq_adjoint A]
+    change (Bᴴ.toEuclideanLin.comp B.toEuclideanLin) w =
+      (Aᴴ.toEuclideanLin.comp A.toEuclideanLin) w
+    rw [← toLpLin_mul_same, ← toLpLin_mul_same, hGram]
+  have hker : LinearMap.ker fA ≤ LinearMap.ker fB := by
+    intro v hv
+    rw [LinearMap.mem_ker] at hv ⊢
+    have h0 := hinner v v
+    simp only [hv, inner_zero_left] at h0
+    exact inner_self_eq_zero.mp h0
+  let L_lm : LinearMap.range fA →ₗ[ℂ] EuclideanSpace ℂ m :=
+    ((LinearMap.ker fA).liftQ fB hker).comp
+      fA.quotKerEquivRange.symm.toLinearMap
+  have hL_apply : ∀ v, L_lm ⟨fA v, LinearMap.mem_range_self fA v⟩ = fB v := by
+    intro v
+    change ((LinearMap.ker fA).liftQ fB hker)
+        (fA.quotKerEquivRange.symm ⟨fA v, LinearMap.mem_range_self fA v⟩) =
+      fB v
+    rw [fA.quotKerEquivRange_symm_apply_image]
+    exact Submodule.liftQ_apply _ _ _
+  have hL_inner : ∀ x y : LinearMap.range fA,
+      ⟪L_lm x, L_lm y⟫_ℂ = ⟪x, y⟫_ℂ := by
+    intro ⟨_, hx⟩ ⟨_, hy⟩
+    obtain ⟨v, rfl⟩ := hx
+    obtain ⟨w, rfl⟩ := hy
+    rw [hL_apply, hL_apply, hinner, Submodule.coe_inner]
+  let L_iso : LinearMap.range fA →ₗᵢ[ℂ] EuclideanSpace ℂ m :=
+    LinearMap.isometryOfInner L_lm hL_inner
+  let U := L_iso.extend
+  have hU_eq : ∀ v, U (fA v) = fB v := by
+    intro v
+    have : U (fA v) = L_iso ⟨fA v, LinearMap.mem_range_self fA v⟩ :=
+      LinearIsometry.extend_apply L_iso ⟨fA v, LinearMap.mem_range_self fA v⟩
+    rw [this]
+    simpa [L_iso] using hL_apply v
+  let U_mat : Matrix m m ℂ :=
+    Matrix.toEuclideanLin.symm U.toLinearMap
+  have h_U_lin : Matrix.toEuclideanLin U_mat = U.toLinearMap :=
+    LinearEquiv.apply_symm_apply Matrix.toEuclideanLin U.toLinearMap
+  have hU_unitary : U_matᴴ * U_mat = 1 := by
+    apply Matrix.toEuclideanLin.injective
+    ext1 v
+    have hadj : U.toLinearMap.adjoint (U.toLinearMap v) = v :=
+      ext_inner_right ℂ fun y => by
+        rw [LinearMap.adjoint_inner_left]
+        exact LinearIsometry.inner_map_map U v y
+    rw [toLpLin_mul_same, LinearMap.comp_apply,
+      Matrix.toEuclideanLin_conjTranspose_eq_adjoint, h_U_lin, hadj]
+    simp only [toLpLin_one, LinearMap.id_apply]
+  have hU_mat_eq : U_mat * A = B := by
+    apply Matrix.toEuclideanLin.injective
+    ext1 v
+    rw [toLpLin_mul_same, LinearMap.comp_apply, h_U_lin]
+    exact hU_eq v
+  refine ⟨⟨U_mat, Matrix.mem_unitaryGroup_iff'.2 hU_unitary⟩, ?_⟩
+  exact hU_mat_eq.symm
+
+end Matrix

--- a/TNLean/Channel/KrausFreedom.lean
+++ b/TNLean/Channel/KrausFreedom.lean
@@ -6,6 +6,7 @@ import TNLean.Channel.Basic
 import TNLean.Channel.KrausRepresentation
 import TNLean.Channel.Stinespring
 import TNLean.Algebra.FinSum
+import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Algebra.TracePairing
 
 /-!
@@ -91,10 +92,6 @@ theorem kraus_conjTranspose_mul_eq_of_map_eq
 
 /-! ### Rectangular Kraus freedom -/
 
-private abbrev KrausCoeffSpace (r : ℕ) := EuclideanSpace ℂ (Fin r)
-
-private abbrev KrausEntrySpace (D : ℕ) := EuclideanSpace ℂ (Fin D × Fin D)
-
 set_option maxHeartbeats 1600000 in
 -- The partial-isometry extension passes through several nested finite-dimensional choices.
 /-- **Rectangular Kraus freedom** (Wolf Theorem 2.1 item 4, necessary direction):
@@ -165,88 +162,16 @@ theorem kraus_rectangular_freedom
       simp_rw [step₁]; simp [Finset.sum_ite_eq, Finset.mem_univ]
     rw [collapse, collapse] at h_entry
     exact h_entry
-  -- ===== Phase 3: Construct the isometry =====
-  letI : InnerProductSpace ℂ (KrausCoeffSpace r₁) :=
-    PiLp.innerProductSpace (fun _ : Fin r₁ => ℂ)
-  letI : InnerProductSpace ℂ (KrausEntrySpace D) :=
-    PiLp.innerProductSpace (fun _ : Fin D × Fin D => ℂ)
-  letI : FiniteDimensional ℂ (KrausCoeffSpace r₁) :=
-    (EuclideanSpace.basisFun (Fin r₁) ℂ).toBasis.finiteDimensional_of_finite
-  letI : FiniteDimensional ℂ (KrausEntrySpace D) :=
-    (EuclideanSpace.basisFun (Fin D × Fin D) ℂ).toBasis.finiteDimensional_of_finite
-  let fB : KrausEntrySpace D →ₗ[ℂ] KrausCoeffSpace r₁ := Matrix.toEuclideanLin MB
-  let fA' : KrausEntrySpace D →ₗ[ℂ] KrausCoeffSpace r₁ := Matrix.toEuclideanLin MA'
-  -- Inner product preservation from Gram equality
-  have hinner : ∀ v w : KrausEntrySpace D,
-      ⟪fB v, fB w⟫_ℂ = ⟪fA' v, fA' w⟫_ℂ := by
-    intro v w
-    rw [← LinearMap.adjoint_inner_right fB v (fB w),
-        ← LinearMap.adjoint_inner_right fA' v (fA' w)]
-    congr 1
-    show fB.adjoint (fB w) = fA'.adjoint (fA' w)
-    rw [← Matrix.toEuclideanLin_conjTranspose_eq_adjoint MB,
-        ← Matrix.toEuclideanLin_conjTranspose_eq_adjoint MA']
-    change (MBᴴ.toEuclideanLin.comp MB.toEuclideanLin) w =
-      (MA'ᴴ.toEuclideanLin.comp MA'.toEuclideanLin) w
-    rw [← toLpLin_mul_same, ← toLpLin_mul_same, hGram]
-  -- Kernel inclusion
-  have hker : LinearMap.ker fA' ≤ LinearMap.ker fB := by
-    intro v hv; rw [LinearMap.mem_ker] at hv ⊢
-    have h0 := hinner v v
-    simp only [hv, inner_zero_left] at h0
-    exact inner_self_eq_zero.mp h0
-  -- Construct partial isometry L on range(fA')
-  let L_lm : LinearMap.range fA' →ₗ[ℂ] KrausCoeffSpace r₁ :=
-    ((LinearMap.ker fA').liftQ fB hker).comp
-      fA'.quotKerEquivRange.symm.toLinearMap
-  -- Key: L sends fA'(v) to fB(v)
-  have hL_apply : ∀ v, L_lm ⟨fA' v, LinearMap.mem_range_self fA' v⟩ = fB v := by
-    intro v
-    change ((LinearMap.ker fA').liftQ fB hker)
-        (fA'.quotKerEquivRange.symm ⟨fA' v, LinearMap.mem_range_self fA' v⟩) =
-      fB v
-    rw [fA'.quotKerEquivRange_symm_apply_image]
-    exact Submodule.liftQ_apply _ _ _
-  -- L preserves inner products
-  have hL_inner : ∀ x y : LinearMap.range fA',
-      ⟪L_lm x, L_lm y⟫_ℂ = ⟪x, y⟫_ℂ := by
-    intro ⟨_, hx⟩ ⟨_, hy⟩
-    obtain ⟨v, rfl⟩ := hx; obtain ⟨w, rfl⟩ := hy
-    rw [hL_apply, hL_apply, hinner, Submodule.coe_inner]
-  -- Extend to full isometry
-  let L_iso : LinearMap.range fA' →ₗᵢ[ℂ] KrausCoeffSpace r₁ :=
-    by
-      exact LinearMap.isometryOfInner L_lm hL_inner
-  let U := L_iso.extend
-  -- U ∘ fA' = fB
-  have hU_eq : ∀ v, U (fA' v) = fB v := by
-    intro v
-    have : U (fA' v) = L_iso ⟨fA' v, LinearMap.mem_range_self fA' v⟩ :=
-      LinearIsometry.extend_apply L_iso ⟨fA' v, LinearMap.mem_range_self fA' v⟩
-    rw [this]
-    simpa [L_iso] using hL_apply v
-  -- ===== Phase 4: Extract V =====
-  let U_mat : Matrix (Fin r₁) (Fin r₁) ℂ :=
-    Matrix.toEuclideanLin.symm U.toLinearMap
-  -- Key: toEuclideanLin U_mat = U.toLinearMap
-  have h_U_lin : Matrix.toEuclideanLin U_mat = U.toLinearMap :=
-    LinearEquiv.apply_symm_apply Matrix.toEuclideanLin U.toLinearMap
-  -- U_mat† U_mat = 1 (U is an isometry on a f.d. space)
-  have hU_unitary : U_matᴴ * U_mat = 1 := by
-    apply Matrix.toEuclideanLin.injective; ext1 v
-    have hadj : U.toLinearMap.adjoint (U.toLinearMap v) = v :=
-      ext_inner_right ℂ fun y => by
-        rw [LinearMap.adjoint_inner_left]
-        exact LinearIsometry.inner_map_map U v y
-    rw [toLpLin_mul_same, LinearMap.comp_apply,
-      Matrix.toEuclideanLin_conjTranspose_eq_adjoint, h_U_lin, hadj]
-    simp only [toLpLin_one, LinearMap.id_apply]
-  -- U_mat * MA' = MB (from U ∘ fA' = fB)
-  have hU_mat_eq : U_mat * MA' = MB := by
-    apply Matrix.toEuclideanLin.injective; ext1 v
-    rw [toLpLin_mul_same, LinearMap.comp_apply, h_U_lin]; exact hU_eq v
+  -- ===== Phase 3: Extract the ambient unitary from Gram equality =====
+  obtain ⟨U, hU⟩ := Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq
+    (B := MB) (A := MA') hGram
+  have hU_unitary :
+      (U : Matrix (Fin r₁) (Fin r₁) ℂ)ᴴ *
+          (U : Matrix (Fin r₁) (Fin r₁) ℂ) = 1 := by
+    simpa [Matrix.star_eq_conjTranspose] using Matrix.UnitaryGroup.star_mul_self U
+  have hU_mat_eq : (U : Matrix (Fin r₁) (Fin r₁) ℂ) * MA' = MB := hU.symm
   -- Define V as first r₂ columns of U_mat
-  refine ⟨fun α j => U_mat α (Fin.castLE hCard j), ?_, ?_⟩
+  refine ⟨fun α j => (U : Matrix (Fin r₁) (Fin r₁) ℂ) α (Fin.castLE hCard j), ?_, ?_⟩
   · -- V†V = 1
     ext j k
     simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Matrix.one_apply]
@@ -256,12 +181,13 @@ theorem kraus_rectangular_freedom
   · -- B α = ∑ j, V(α,j) • A j
     intro α; ext a b
     have h_entry : (B α) a b =
-        ∑ β : Fin r₁, U_mat α β * (A' β) a b := by
+        ∑ β : Fin r₁, (U : Matrix (Fin r₁) (Fin r₁) ℂ) α β * (A' β) a b := by
       have := congr_fun (congr_fun hU_mat_eq α) (a, b)
       simpa [Matrix.mul_apply, MB, MA'] using this.symm
     rw [h_entry]; simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul]
     rw [Fin.sum_castLE_extend_zero
-      (fun j => U_mat α (Fin.castLE hCard j) * (A j) a b) hCard]
+      (fun j => (U : Matrix (Fin r₁) (Fin r₁) ℂ) α (Fin.castLE hCard j) *
+        (A j) a b) hCard]
     apply Finset.sum_congr rfl; intro β _
     simp only [A']; split_ifs with hlt
     · simp only [Fin.eta, Fin.castLE]

--- a/TNLean/Channel/KrausFreedom.lean
+++ b/TNLean/Channel/KrausFreedom.lean
@@ -92,8 +92,6 @@ theorem kraus_conjTranspose_mul_eq_of_map_eq
 
 /-! ### Rectangular Kraus freedom -/
 
-set_option maxHeartbeats 1600000 in
--- The partial-isometry extension passes through several nested finite-dimensional choices.
 /-- **Rectangular Kraus freedom** (Wolf Theorem 2.1 item 4, necessary direction):
 if two Kraus families of sizes `r₁` and `r₂` define the same CPM, then the
 first family is a linear combination of the second via a rectangular isometry

--- a/TNLean/Channel/OpenSystem.lean
+++ b/TNLean/Channel/OpenSystem.lean
@@ -3,22 +3,19 @@ Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
-import Mathlib.LinearAlgebra.UnitaryGroup
+import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Channel.RadonNikodym
 
 /-!
 # Unitary open-system representation
 
 This file proves the unitary form of Wolf's open-system representation theorem
-from the isometric Stinespring form.  The linear-algebra step is the following
-rectangular Gram theorem: two maps with the same Gram matrix differ by a
-unitary on the codomain.  Its proof extends the induced isometry between the
-ranges to the ambient finite-dimensional Hilbert space.
+from the isometric Stinespring form.  The linear-algebra step is the rectangular
+Gram theorem from `TNLean.Algebra.MatrixGramUnitary`: two maps with the same
+Gram matrix differ by a unitary on the codomain.
 
 ## Main results
 
-* `Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq` — rectangular matrices
-  with equal Gram matrices differ by left multiplication by a unitary matrix.
 * `Matrix.firstEnvEmbedding` — the embedding of the system into the first
   coordinate of an environment.
 * `IsChannel.exists_stinespring_open_system_unitary` — Wolf Theorem 2.5 in
@@ -30,101 +27,20 @@ ranges to the ambient finite-dimensional Hilbert space.
   [Wolf2012QChannels]
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder InnerProductSpace
-open Matrix Finset BigOperators
+open scoped Matrix
+open Matrix
 
 variable {D : ℕ}
 
 namespace Matrix
 
-/-- If two rectangular matrices have the same Gram matrix, then they differ by
-left multiplication by a unitary matrix on the codomain. -/
-theorem exists_unitary_mul_eq_of_conjTranspose_mul_eq
-    {m n : Type*} [Fintype m] [DecidableEq m] [Finite n]
-    (B A : Matrix m n ℂ)
-    (hGram : Bᴴ * B = Aᴴ * A) :
-    ∃ U : Matrix.unitaryGroup m ℂ, B = (U : Matrix m m ℂ) * A := by
-  classical
-  letI : Fintype n := Fintype.ofFinite n
-  letI : InnerProductSpace ℂ (EuclideanSpace ℂ m) :=
-    PiLp.innerProductSpace (fun _ : m => ℂ)
-  letI : FiniteDimensional ℂ (EuclideanSpace ℂ m) :=
-    (EuclideanSpace.basisFun m ℂ).toBasis.finiteDimensional_of_finite
-  let fB : EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m :=
-    Matrix.toEuclideanLin B
-  let fA : EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m :=
-    Matrix.toEuclideanLin A
-  have hinner : ∀ v w : EuclideanSpace ℂ n,
-      ⟪fB v, fB w⟫_ℂ = ⟪fA v, fA w⟫_ℂ := by
-    intro v w
-    rw [← LinearMap.adjoint_inner_right fB v (fB w),
-        ← LinearMap.adjoint_inner_right fA v (fA w)]
-    congr 1
-    change fB.adjoint (fB w) = fA.adjoint (fA w)
-    rw [← Matrix.toEuclideanLin_conjTranspose_eq_adjoint B,
-        ← Matrix.toEuclideanLin_conjTranspose_eq_adjoint A]
-    change (Bᴴ.toEuclideanLin.comp B.toEuclideanLin) w =
-      (Aᴴ.toEuclideanLin.comp A.toEuclideanLin) w
-    rw [← toLpLin_mul_same, ← toLpLin_mul_same, hGram]
-  have hker : LinearMap.ker fA ≤ LinearMap.ker fB := by
-    intro v hv
-    rw [LinearMap.mem_ker] at hv ⊢
-    have h0 := hinner v v
-    simp only [hv, inner_zero_left] at h0
-    exact inner_self_eq_zero.mp h0
-  let L_lm : LinearMap.range fA →ₗ[ℂ] EuclideanSpace ℂ m :=
-    ((LinearMap.ker fA).liftQ fB hker).comp
-      fA.quotKerEquivRange.symm.toLinearMap
-  have hL_apply : ∀ v, L_lm ⟨fA v, LinearMap.mem_range_self fA v⟩ = fB v := by
-    intro v
-    change ((LinearMap.ker fA).liftQ fB hker)
-        (fA.quotKerEquivRange.symm ⟨fA v, LinearMap.mem_range_self fA v⟩) =
-      fB v
-    rw [fA.quotKerEquivRange_symm_apply_image]
-    exact Submodule.liftQ_apply _ _ _
-  have hL_inner : ∀ x y : LinearMap.range fA,
-      ⟪L_lm x, L_lm y⟫_ℂ = ⟪x, y⟫_ℂ := by
-    intro ⟨_, hx⟩ ⟨_, hy⟩
-    obtain ⟨v, rfl⟩ := hx
-    obtain ⟨w, rfl⟩ := hy
-    rw [hL_apply, hL_apply, hinner, Submodule.coe_inner]
-  let L_iso : LinearMap.range fA →ₗᵢ[ℂ] EuclideanSpace ℂ m :=
-    LinearMap.isometryOfInner L_lm hL_inner
-  let U := L_iso.extend
-  have hU_eq : ∀ v, U (fA v) = fB v := by
-    intro v
-    have : U (fA v) = L_iso ⟨fA v, LinearMap.mem_range_self fA v⟩ :=
-      LinearIsometry.extend_apply L_iso ⟨fA v, LinearMap.mem_range_self fA v⟩
-    rw [this]
-    simpa [L_iso] using hL_apply v
-  let U_mat : Matrix m m ℂ :=
-    Matrix.toEuclideanLin.symm U.toLinearMap
-  have h_U_lin : Matrix.toEuclideanLin U_mat = U.toLinearMap :=
-    LinearEquiv.apply_symm_apply Matrix.toEuclideanLin U.toLinearMap
-  have hU_unitary : U_matᴴ * U_mat = 1 := by
-    apply Matrix.toEuclideanLin.injective
-    ext1 v
-    have hadj : U.toLinearMap.adjoint (U.toLinearMap v) = v :=
-      ext_inner_right ℂ fun y => by
-        rw [LinearMap.adjoint_inner_left]
-        exact LinearIsometry.inner_map_map U v y
-    rw [toLpLin_mul_same, LinearMap.comp_apply,
-      Matrix.toEuclideanLin_conjTranspose_eq_adjoint, h_U_lin, hadj]
-    simp only [toLpLin_one, LinearMap.id_apply]
-  have hU_mat_eq : U_mat * A = B := by
-    apply Matrix.toEuclideanLin.injective
-    ext1 v
-    rw [toLpLin_mul_same, LinearMap.comp_apply, h_U_lin]
-    exact hU_eq v
-  refine ⟨⟨U_mat, Matrix.mem_unitaryGroup_iff'.2 hU_unitary⟩, ?_⟩
-  exact hU_mat_eq.symm
-
 /-- The embedding `x ↦ x ⊗ e₀` into the first coordinate of an environment. -/
-noncomputable def firstEnvEmbedding (D r : ℕ) (hr : 0 < r) :
+def firstEnvEmbedding (D r : ℕ) (hr : 0 < r) :
     Matrix (Fin D × Fin r) (Fin D) ℂ :=
   fun ik j =>
     if ik.2 = ⟨0, hr⟩ then (1 : Matrix (Fin D) (Fin D) ℂ) ik.1 j else 0
 
+/-- `firstEnvEmbedding` embeds into the zero environment coordinate as the identity. -/
 @[simp]
 theorem firstEnvEmbedding_apply_zero (D r : ℕ) (hr : 0 < r)
     (i j : Fin D) :
@@ -132,6 +48,7 @@ theorem firstEnvEmbedding_apply_zero (D r : ℕ) (hr : 0 < r)
       (1 : Matrix (Fin D) (Fin D) ℂ) i j := by
   simp [firstEnvEmbedding]
 
+/-- `firstEnvEmbedding` is zero away from the zero environment coordinate. -/
 @[simp]
 theorem firstEnvEmbedding_apply_ne (D r : ℕ) (hr : 0 < r)
     (i j : Fin D) {k : Fin r} (hk : k ≠ ⟨0, hr⟩) :

--- a/TNLean/Channel/OpenSystem.lean
+++ b/TNLean/Channel/OpenSystem.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import Mathlib.LinearAlgebra.UnitaryGroup
+import TNLean.Channel.RadonNikodym
+
+/-!
+# Unitary open-system representation
+
+This file proves the unitary form of Wolf's open-system representation theorem
+from the isometric Stinespring form.  The linear-algebra step is the following
+rectangular Gram theorem: two maps with the same Gram matrix differ by a
+unitary on the codomain.  Its proof extends the induced isometry between the
+ranges to the ambient finite-dimensional Hilbert space.
+
+## Main results
+
+* `Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq` — rectangular matrices
+  with equal Gram matrices differ by left multiplication by a unitary matrix.
+* `Matrix.firstEnvEmbedding` — the embedding of the system into the first
+  coordinate of an environment.
+* `IsChannel.exists_stinespring_open_system_unitary` — Wolf Theorem 2.5 in
+  unitary open-system form.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Theorem 2.5]
+  [Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder InnerProductSpace
+open Matrix Finset BigOperators
+
+variable {D : ℕ}
+
+namespace Matrix
+
+/-- If two rectangular matrices have the same Gram matrix, then they differ by
+left multiplication by a unitary matrix on the codomain. -/
+theorem exists_unitary_mul_eq_of_conjTranspose_mul_eq
+    {m n : Type*} [Fintype m] [DecidableEq m] [Finite n]
+    (B A : Matrix m n ℂ)
+    (hGram : Bᴴ * B = Aᴴ * A) :
+    ∃ U : Matrix.unitaryGroup m ℂ, B = (U : Matrix m m ℂ) * A := by
+  classical
+  letI : Fintype n := Fintype.ofFinite n
+  letI : InnerProductSpace ℂ (EuclideanSpace ℂ m) :=
+    PiLp.innerProductSpace (fun _ : m => ℂ)
+  letI : FiniteDimensional ℂ (EuclideanSpace ℂ m) :=
+    (EuclideanSpace.basisFun m ℂ).toBasis.finiteDimensional_of_finite
+  let fB : EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m :=
+    Matrix.toEuclideanLin B
+  let fA : EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m :=
+    Matrix.toEuclideanLin A
+  have hinner : ∀ v w : EuclideanSpace ℂ n,
+      ⟪fB v, fB w⟫_ℂ = ⟪fA v, fA w⟫_ℂ := by
+    intro v w
+    rw [← LinearMap.adjoint_inner_right fB v (fB w),
+        ← LinearMap.adjoint_inner_right fA v (fA w)]
+    congr 1
+    change fB.adjoint (fB w) = fA.adjoint (fA w)
+    rw [← Matrix.toEuclideanLin_conjTranspose_eq_adjoint B,
+        ← Matrix.toEuclideanLin_conjTranspose_eq_adjoint A]
+    change (Bᴴ.toEuclideanLin.comp B.toEuclideanLin) w =
+      (Aᴴ.toEuclideanLin.comp A.toEuclideanLin) w
+    rw [← toLpLin_mul_same, ← toLpLin_mul_same, hGram]
+  have hker : LinearMap.ker fA ≤ LinearMap.ker fB := by
+    intro v hv
+    rw [LinearMap.mem_ker] at hv ⊢
+    have h0 := hinner v v
+    simp only [hv, inner_zero_left] at h0
+    exact inner_self_eq_zero.mp h0
+  let L_lm : LinearMap.range fA →ₗ[ℂ] EuclideanSpace ℂ m :=
+    ((LinearMap.ker fA).liftQ fB hker).comp
+      fA.quotKerEquivRange.symm.toLinearMap
+  have hL_apply : ∀ v, L_lm ⟨fA v, LinearMap.mem_range_self fA v⟩ = fB v := by
+    intro v
+    change ((LinearMap.ker fA).liftQ fB hker)
+        (fA.quotKerEquivRange.symm ⟨fA v, LinearMap.mem_range_self fA v⟩) =
+      fB v
+    rw [fA.quotKerEquivRange_symm_apply_image]
+    exact Submodule.liftQ_apply _ _ _
+  have hL_inner : ∀ x y : LinearMap.range fA,
+      ⟪L_lm x, L_lm y⟫_ℂ = ⟪x, y⟫_ℂ := by
+    intro ⟨_, hx⟩ ⟨_, hy⟩
+    obtain ⟨v, rfl⟩ := hx
+    obtain ⟨w, rfl⟩ := hy
+    rw [hL_apply, hL_apply, hinner, Submodule.coe_inner]
+  let L_iso : LinearMap.range fA →ₗᵢ[ℂ] EuclideanSpace ℂ m :=
+    LinearMap.isometryOfInner L_lm hL_inner
+  let U := L_iso.extend
+  have hU_eq : ∀ v, U (fA v) = fB v := by
+    intro v
+    have : U (fA v) = L_iso ⟨fA v, LinearMap.mem_range_self fA v⟩ :=
+      LinearIsometry.extend_apply L_iso ⟨fA v, LinearMap.mem_range_self fA v⟩
+    rw [this]
+    simpa [L_iso] using hL_apply v
+  let U_mat : Matrix m m ℂ :=
+    Matrix.toEuclideanLin.symm U.toLinearMap
+  have h_U_lin : Matrix.toEuclideanLin U_mat = U.toLinearMap :=
+    LinearEquiv.apply_symm_apply Matrix.toEuclideanLin U.toLinearMap
+  have hU_unitary : U_matᴴ * U_mat = 1 := by
+    apply Matrix.toEuclideanLin.injective
+    ext1 v
+    have hadj : U.toLinearMap.adjoint (U.toLinearMap v) = v :=
+      ext_inner_right ℂ fun y => by
+        rw [LinearMap.adjoint_inner_left]
+        exact LinearIsometry.inner_map_map U v y
+    rw [toLpLin_mul_same, LinearMap.comp_apply,
+      Matrix.toEuclideanLin_conjTranspose_eq_adjoint, h_U_lin, hadj]
+    simp only [toLpLin_one, LinearMap.id_apply]
+  have hU_mat_eq : U_mat * A = B := by
+    apply Matrix.toEuclideanLin.injective
+    ext1 v
+    rw [toLpLin_mul_same, LinearMap.comp_apply, h_U_lin]
+    exact hU_eq v
+  refine ⟨⟨U_mat, Matrix.mem_unitaryGroup_iff'.2 hU_unitary⟩, ?_⟩
+  exact hU_mat_eq.symm
+
+/-- The embedding `x ↦ x ⊗ e₀` into the first coordinate of an environment. -/
+noncomputable def firstEnvEmbedding (D r : ℕ) (hr : 0 < r) :
+    Matrix (Fin D × Fin r) (Fin D) ℂ :=
+  fun ik j =>
+    if ik.2 = ⟨0, hr⟩ then (1 : Matrix (Fin D) (Fin D) ℂ) ik.1 j else 0
+
+@[simp]
+theorem firstEnvEmbedding_apply_zero (D r : ℕ) (hr : 0 < r)
+    (i j : Fin D) :
+    firstEnvEmbedding D r hr (i, ⟨0, hr⟩) j =
+      (1 : Matrix (Fin D) (Fin D) ℂ) i j := by
+  simp [firstEnvEmbedding]
+
+@[simp]
+theorem firstEnvEmbedding_apply_ne (D r : ℕ) (hr : 0 < r)
+    (i j : Fin D) {k : Fin r} (hk : k ≠ ⟨0, hr⟩) :
+    firstEnvEmbedding D r hr (i, k) j = 0 := by
+  simp [firstEnvEmbedding, hk]
+
+/-- The first-coordinate environment embedding is an isometry. -/
+theorem firstEnvEmbedding_conjTranspose_mul_self (D r : ℕ) (hr : 0 < r) :
+    (firstEnvEmbedding D r hr)ᴴ * firstEnvEmbedding D r hr = 1 := by
+  ext i j
+  simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Fintype.sum_prod_type]
+  rw [Finset.sum_comm]
+  by_cases hij : i = j
+  · simp [firstEnvEmbedding, Matrix.one_apply, hij]
+  · have hji : j ≠ i := fun h => hij h.symm
+    simp [firstEnvEmbedding, Matrix.one_apply, hij, hji]
+
+end Matrix
+
+namespace IsChannel
+
+private theorem stinespring_environment_pos [NeZero D]
+    {r : ℕ} {V : Matrix (Fin D × Fin r) (Fin D) ℂ}
+    (hV : Vᴴ * V = 1) :
+    0 < r := by
+  by_contra hr
+  have hr0 : r = 0 := Nat.eq_zero_of_not_pos hr
+  let j : Fin D := ⟨0, NeZero.pos D⟩
+  have hdiag := congr_fun (congr_fun hV j) j
+  subst r
+  simp [Matrix.mul_apply] at hdiag
+
+/-- **Wolf Theorem 2.5 (unitary open-system representation).**
+
+For a nonzero finite-dimensional system, every quantum channel has a
+system-plus-environment unitary realization.  The matrix
+`Matrix.firstEnvEmbedding D r hr` inserts the system into the first
+environment coordinate, so the middle factor is `ρ ⊗ |0⟩⟨0|` in matrix form. -/
+theorem exists_stinespring_open_system_unitary [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsChannel T) :
+    ∃ (r : ℕ) (hr : 0 < r) (U : Matrix.unitaryGroup (Fin D × Fin r) ℂ),
+      ∀ ρ : Matrix (Fin D) (Fin D) ℂ,
+        T ρ =
+          ((U : Matrix (Fin D × Fin r) (Fin D × Fin r) ℂ) *
+            (Matrix.firstEnvEmbedding D r hr * ρ *
+              (Matrix.firstEnvEmbedding D r hr)ᴴ) *
+            (U : Matrix (Fin D × Fin r) (Fin D × Fin r) ℂ)ᴴ).traceRight := by
+  obtain ⟨r, V, hV, htrace⟩ := hT.exists_stinespring_open_system_traceRight
+  have hr : 0 < r := stinespring_environment_pos (D := D) (V := V) hV
+  let W : Matrix (Fin D × Fin r) (Fin D) ℂ := Matrix.firstEnvEmbedding D r hr
+  have hW : Wᴴ * W = 1 :=
+    Matrix.firstEnvEmbedding_conjTranspose_mul_self D r hr
+  obtain ⟨U, hU⟩ := Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq
+    (B := V) (A := W) (by rw [hV, hW])
+  refine ⟨r, hr, U, ?_⟩
+  intro ρ
+  rw [htrace ρ, hU]
+  simp [W, Matrix.conjTranspose_mul, Matrix.mul_assoc]
+
+end IsChannel

--- a/TNLean/Channel/POVM/Uniqueness.lean
+++ b/TNLean/Channel/POVM/Uniqueness.lean
@@ -42,78 +42,7 @@ private theorem exists_unitary_mul_eq_of_conjTranspose_mul_eq
     (hGram : Bᴴ * B = Aᴴ * A) :
     ∃ U : Matrix.unitaryGroup (Fin D) ℂ,
       B = (U : Matrix (Fin D) (Fin D) ℂ) * A := by
-  letI : InnerProductSpace ℂ (EuclideanSpace ℂ (Fin D)) :=
-    PiLp.innerProductSpace (fun _ : Fin D => ℂ)
-  letI : FiniteDimensional ℂ (EuclideanSpace ℂ (Fin D)) :=
-    (EuclideanSpace.basisFun (Fin D) ℂ).toBasis.finiteDimensional_of_finite
-  let fB : EuclideanSpace ℂ (Fin D) →ₗ[ℂ] EuclideanSpace ℂ (Fin D) :=
-    Matrix.toEuclideanLin B
-  let fA : EuclideanSpace ℂ (Fin D) →ₗ[ℂ] EuclideanSpace ℂ (Fin D) :=
-    Matrix.toEuclideanLin A
-  have hinner : ∀ v w : EuclideanSpace ℂ (Fin D),
-      ⟪fB v, fB w⟫_ℂ = ⟪fA v, fA w⟫_ℂ := by
-    intro v w
-    rw [← LinearMap.adjoint_inner_right fB v (fB w),
-        ← LinearMap.adjoint_inner_right fA v (fA w)]
-    congr 1
-    show fB.adjoint (fB w) = fA.adjoint (fA w)
-    rw [← Matrix.toEuclideanLin_conjTranspose_eq_adjoint B,
-        ← Matrix.toEuclideanLin_conjTranspose_eq_adjoint A]
-    change (Bᴴ.toEuclideanLin.comp B.toEuclideanLin) w =
-      (Aᴴ.toEuclideanLin.comp A.toEuclideanLin) w
-    rw [← toLpLin_mul_same, ← toLpLin_mul_same, hGram]
-  have hker : LinearMap.ker fA ≤ LinearMap.ker fB := by
-    intro v hv
-    rw [LinearMap.mem_ker] at hv ⊢
-    have h0 := hinner v v
-    simp only [hv, inner_zero_left] at h0
-    exact inner_self_eq_zero.mp h0
-  let L_lm : LinearMap.range fA →ₗ[ℂ] EuclideanSpace ℂ (Fin D) :=
-    ((LinearMap.ker fA).liftQ fB hker).comp
-      fA.quotKerEquivRange.symm.toLinearMap
-  have hL_apply : ∀ v, L_lm ⟨fA v, LinearMap.mem_range_self fA v⟩ = fB v := by
-    intro v
-    change ((LinearMap.ker fA).liftQ fB hker)
-        (fA.quotKerEquivRange.symm ⟨fA v, LinearMap.mem_range_self fA v⟩) =
-      fB v
-    rw [fA.quotKerEquivRange_symm_apply_image]
-    exact Submodule.liftQ_apply _ _ _
-  have hL_inner : ∀ x y : LinearMap.range fA,
-      ⟪L_lm x, L_lm y⟫_ℂ = ⟪x, y⟫_ℂ := by
-    intro ⟨_, hx⟩ ⟨_, hy⟩
-    obtain ⟨v, rfl⟩ := hx
-    obtain ⟨w, rfl⟩ := hy
-    rw [hL_apply, hL_apply, hinner, Submodule.coe_inner]
-  let L_iso : LinearMap.range fA →ₗᵢ[ℂ] EuclideanSpace ℂ (Fin D) :=
-    LinearMap.isometryOfInner L_lm hL_inner
-  let U := L_iso.extend
-  have hU_eq : ∀ v, U (fA v) = fB v := by
-    intro v
-    have : U (fA v) = L_iso ⟨fA v, LinearMap.mem_range_self fA v⟩ :=
-      LinearIsometry.extend_apply L_iso ⟨fA v, LinearMap.mem_range_self fA v⟩
-    rw [this]
-    simpa [L_iso] using hL_apply v
-  let U_mat : Matrix (Fin D) (Fin D) ℂ :=
-    Matrix.toEuclideanLin.symm U.toLinearMap
-  have h_U_lin : Matrix.toEuclideanLin U_mat = U.toLinearMap :=
-    LinearEquiv.apply_symm_apply Matrix.toEuclideanLin U.toLinearMap
-  have hU_unitary : U_matᴴ * U_mat = 1 := by
-    apply Matrix.toEuclideanLin.injective
-    ext1 v
-    have hadj : U.toLinearMap.adjoint (U.toLinearMap v) = v :=
-      ext_inner_right ℂ fun y => by
-        rw [LinearMap.adjoint_inner_left]
-        exact LinearIsometry.inner_map_map U v y
-    rw [toLpLin_mul_same, LinearMap.comp_apply,
-      Matrix.toEuclideanLin_conjTranspose_eq_adjoint, h_U_lin, hadj]
-    simp only [toLpLin_one, LinearMap.id_apply]
-  have hU_mat_eq : U_mat * A = B := by
-    apply Matrix.toEuclideanLin.injective
-    ext1 v
-    rw [toLpLin_mul_same, LinearMap.comp_apply, h_U_lin]
-    exact hU_eq v
-  refine ⟨⟨U_mat, Matrix.mem_unitaryGroup_iff'.2 hU_unitary⟩, ?_⟩
-  exact hU_mat_eq.symm
+  exact Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq B A hGram
 
 /-- Predicate saying that `V` together with the projective measurement `P`
 realizes `E` as a Naimark dilation. -/

--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -12,6 +12,7 @@ import TNLean.Channel.KrausUnitaryFreedom
 import TNLean.Channel.Stinespring
 import TNLean.Channel.OrderedCP
 import TNLean.Channel.RadonNikodym
+import TNLean.Channel.OpenSystem
 import TNLean.Channel.POVM
 import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
@@ -101,6 +102,9 @@ default root.
     `T(ρ)_{ij} = ∑ₖ (V ρ V†)_{(i,k),(j,k)}` for an isometric `V` ✓
   - `IsChannel.exists_stinespring_open_system_traceRight` — equivalent
     form via `Matrix.traceRight`: `T(ρ) = tr_E[V ρ V†]` ✓
+  - `IsChannel.exists_stinespring_open_system_unitary` — unitary form
+    `T(ρ) = tr_E[U W₀ ρ W₀† U†]`, where `W₀` inserts the system into the
+    first environment coordinate ✓
 
 * **Theorem 2.6** (Naimark / Neumark dilation for POVMs):
   - `POVM` — positive operator-valued measure structure ✓
@@ -237,8 +241,6 @@ default root.
 
 | Result | Notes |
 |--------|-------|
-| Theorem 2.5 (unitary form) | Reduced isometric form formalized;
-  unitary form needs basis extension |
 | Section 2.3 Lorentz normal form (full proof) | Statement formalised
   (`exists_lorentz_normal_form_qubit`);
   proof blocked on compactness of bounded SL(n, ℂ) sets (`infimum_is_attained`) —

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1034,14 +1034,37 @@ a common dilation space.
     trace over the ancilla factor.
 \end{proof}
 
-\begin{remark}[Unitary form]
-    The fully unitary open-system form
-    $T(\rho) = \tr_E(U (\rho \otimes \ketbra{\phi}{\phi})
-        U^\dagger)$ of~\cite[Theorem~2.5]{Wolf2012Quantum} follows from the
-    isometric form by extending the Stinespring isometry $V$ to a unitary
-    $U$ on $\C^D \otimes \C^r$; this uses orthonormal basis extension and
-    is left to a later theorem.
-\end{remark}
+\begin{definition}[First environment embedding]
+    \label{def:first_env_embedding}
+    \lean{Matrix.firstEnvEmbedding}
+    \leanok
+    For $r \geq 1$, let $W_0 : \C^D \to \C^D \otimes \C^r$ be the isometry
+    $W_0 x = x \otimes e_0$.
+\end{definition}
+
+\begin{theorem}[Open-system representation, unitary form]
+    \label{thm:channel_exists_stinespring_open_system_unitary}
+    \lean{IsChannel.exists_stinespring_open_system_unitary}
+    \leanok
+    \uses{def:channel, def:partial_trace, def:first_env_embedding}
+    For $D \geq 1$, every quantum channel $T$ on $\C^D$ admits an
+    environment dimension $r \geq 1$ and a unitary
+    $U$ on $\C^D \otimes \C^r$ such that
+    \[
+        T(\rho) =
+        \tr_E\!\left(U W_0 \rho W_0^\dagger U^\dagger\right)
+    \]
+    for every matrix $\rho$ on $\C^D$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:channel_exists_stinespring_open_system_traceRight}
+    Take the isometric open-system representation
+    $T(\rho)=\tr_E(V\rho V^\dagger)$.  Since $V^\dagger V=W_0^\dagger W_0$,
+    finite-dimensional isometry extension gives a unitary $U$ on the
+    system-environment space with $V=UW_0$.  Substituting this identity into
+    the partial trace formula gives the displayed expression.
+\end{proof}
 
 %% =========================================================
 \section{POVMs and Naimark dilation}

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1034,6 +1034,16 @@ a common dilation space.
     trace over the ancilla factor.
 \end{proof}
 
+\begin{lemma}[Rectangular Gram equality gives a unitary]
+    \label{lem:exists_unitary_mul_eq_of_gram_eq}
+    \lean{Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq}
+    \leanok
+    \uses{}
+    Let $A,B:\C^n\to\C^m$ be linear maps with
+    $B^\dagger B=A^\dagger A$.  Then there is a unitary
+    $U$ on $\C^m$ such that $B=UA$.
+\end{lemma}
+
 \begin{definition}[First environment embedding]
     \label{def:first_env_embedding}
     \lean{Matrix.firstEnvEmbedding}
@@ -1049,21 +1059,22 @@ a common dilation space.
     \uses{def:channel, def:partial_trace, def:first_env_embedding}
     For $D \geq 1$, every quantum channel $T$ on $\C^D$ admits an
     environment dimension $r \geq 1$ and a unitary
-    $U$ on $\C^D \otimes \C^r$ such that
+    $U$ on $\C^D \otimes \C^r$ such that, for every matrix
+    $\rho$ on $\C^D$,
     \[
         T(\rho) =
-        \tr_E\!\left(U W_0 \rho W_0^\dagger U^\dagger\right)
+        \tr_E\!\left(U W_0 \rho W_0^\dagger U^\dagger\right).
     \]
-    for every matrix $\rho$ on $\C^D$.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:channel_exists_stinespring_open_system_traceRight}
+    \uses{thm:channel_exists_stinespring_open_system_traceRight,
+        lem:exists_unitary_mul_eq_of_gram_eq}
     Take the isometric open-system representation
-    $T(\rho)=\tr_E(V\rho V^\dagger)$.  Since $V^\dagger V=W_0^\dagger W_0$,
-    finite-dimensional isometry extension gives a unitary $U$ on the
-    system-environment space with $V=UW_0$.  Substituting this identity into
-    the partial trace formula gives the displayed expression.
+    $T(\rho)=\tr_E(V\rho V^\dagger)$.  Since
+    $V^\dagger V=\Id=W_0^\dagger W_0$, Lemma~\ref{lem:exists_unitary_mul_eq_of_gram_eq}
+    gives a unitary $U$ with $V=UW_0$.  Substituting this identity into the
+    partial trace formula gives the displayed expression.
 \end{proof}
 
 %% =========================================================


### PR DESCRIPTION
### Motivation
- Wolf *Quantum Channels & Operations*, Thm 2.5 states that every finite-dimensional quantum channel admits a fully unitary open-system representation $T(\rho) = \mathrm{tr}_E[U(\rho \otimes |0\rangle\langle 0|)U^\dagger]$. The isometric form was formalized in LionSR/TNLean#890; the fully unitary form was deferred pending an isometry-extension lemma (see LionSR/QICLean#142).
- The key ingredient — extending any isometry $V : \mathbb{C}^n \to \mathbb{C}^m$ to a unitary on $\mathbb{C}^m$ by completing its columns to an orthonormal basis — is now supplied via Mathlib's finite-dimensional isometry extension API.

### Description
- **New file** `TNLean/Channel/OpenSystem.lean`:
  - `Matrix.gramToUnitary`: a rectangular Gram-to-unitary theorem proved by passing to Euclidean spaces and applying Mathlib's finite-dimensional isometry extension.
  - `Matrix.firstEnvEmbedding`: the first-environment-coordinate embedding $\mathbb{C}^D \to \mathbb{C}^D \otimes \mathbb{C}^r$, together with its isometry identity.
  - `IsChannel.exists_stinespring_open_system_unitary`: the fully unitary open-system representation, derived from the existing partial-trace Stinespring form `IsChannel.exists_stinespring_open_system`.
- **Modified** `TNLean/Channel/WolfChapter2Index.lean`: removes "Thm 2.5 (unitary form)" from the "Not yet formalized" table.
- **Modified** `blueprint/src/chapter/ch16_channel_representations.tex`: promotes the unitary open-system result to a theorem entry and adds `\lean{}` and `\leanok` tags.
- **Modified** `TNLean.lean`: adds the import for the new module.

### Testing
- `lake build TNLean.Channel.OpenSystem -q --log-level=info`
- `lake build TNLean.Channel.WolfChapter2Index -q --log-level=info`
- `lake build`
- `leanblueprint checkdecls`

---
Closes LionSR/QICLean#142

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7c55be804fb8c28173c8e9d10c4693c50f66316f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are Mathlib-style formal proofs and deduplication in channel theory; no runtime, security, or data-handling impact.
> 
> **Overview**
> Formalizes **Wolf Theorem 2.5’s fully unitary** open-system form \(T(\rho)=\mathrm{tr}_E[U W_0 \rho W_0^\dagger U^\dagger]\), closing the gap left after the isometric Stinespring representation.
> 
> A new algebra module proves **`Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq`**: equal Gram matrices \(B^\dagger B = A^\dagger A\) imply \(B = UA\) for some unitary \(U\) on the codomain (via finite-dimensional isometry extension). **`TNLean/Channel/OpenSystem.lean`** defines **`Matrix.firstEnvEmbedding`** (\(x \mapsto x \otimes e_0\)) and **`IsChannel.exists_stinespring_open_system_unitary`**, obtained by matching an isometric Stinespring \(V\) to \(W_0\) and substituting into the existing partial-trace open-system theorem.
> 
> **Refactors** replace duplicated Hilbert-space proofs in **`kraus_rectangular_freedom`** and **`POVM.Uniqueness`** with calls to the shared lemma (large deletion in Kraus freedom). Root/chapter **imports and blueprint** are updated; Wolf Ch. 2 index marks the unitary form as formalized and drops it from “not yet formalized.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34c47663cf133bf8327ddeebdab888049e7895c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->