### PR TITLE
fix(blueprint): complete open-system declaration sync

### DIFF
--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1044,6 +1044,9 @@ a common dilation space.
     $U$ on $\C^m$ such that $B=UA$.
 \end{lemma}
 
+\begin{proof}\leanok
+\end{proof}
+
 \begin{definition}[First environment embedding]
     \label{def:first_env_embedding}
     \lean{Matrix.firstEnvEmbedding}
@@ -1051,6 +1054,17 @@ a common dilation space.
     For $r \geq 1$, let $W_0 : \C^D \to \C^D \otimes \C^r$ be the isometry
     $W_0 x = x \otimes e_0$.
 \end{definition}
+
+\begin{lemma}[First environment embedding is an isometry]
+    \label{lem:first_env_embedding_conjTranspose_mul_self}
+    \lean{Matrix.firstEnvEmbedding_conjTranspose_mul_self}
+    \leanok
+    \uses{def:first_env_embedding}
+    The first-environment embedding satisfies $W_0^\dagger W_0=\Id$.
+\end{lemma}
+
+\begin{proof}\leanok
+\end{proof}
 
 \begin{theorem}[Open-system representation, unitary form]
     \label{thm:channel_exists_stinespring_open_system_unitary}
@@ -1069,7 +1083,8 @@ a common dilation space.
 
 \begin{proof}\leanok
     \uses{thm:channel_exists_stinespring_open_system_traceRight,
-        lem:exists_unitary_mul_eq_of_gram_eq}
+        lem:exists_unitary_mul_eq_of_gram_eq,
+        lem:first_env_embedding_conjTranspose_mul_self}
     Take the isometric open-system representation
     $T(\rho)=\tr_E(V\rho V^\dagger)$.  Since
     $V^\dagger V=\Id=W_0^\dagger W_0$, Lemma~\ref{lem:exists_unitary_mul_eq_of_gram_eq}


### PR DESCRIPTION
### Motivation

- The blueprint (`blueprint/src/chapter/ch16_channel_representations.tex`) was missing two annotations for the unitary open-system Stinespring representation added in LionSR/TNLean#3334.
- `lem:exists_unitary_mul_eq_of_gram_eq` had a statement `\leanok` tag but no `\begin{proof}\leanok\end{proof}` block, despite the Lean proof in `TNLean/Algebra/MatrixGramUnitary.lean` being complete and sorry-free.
- The isometry identity $W_0^\dagger W_0 = \mathrm{Id}$ (`Matrix.firstEnvEmbedding_conjTranspose_mul_self`), called directly in the Lean proof of `IsChannel.exists_stinespring_open_system_unitary` (Wolf Thm 2.5), had no blueprint entry, leaving the `\uses{}` block of `thm:channel_exists_stinespring_open_system_unitary` incomplete.

### Description

- Added `\begin{proof}\leanok\end{proof}` after `\end{lemma}` for `lem:exists_unitary_mul_eq_of_gram_eq` in `blueprint/src/chapter/ch16_channel_representations.tex`.
- Added a new `\begin{lemma}` entry for `Matrix.firstEnvEmbedding_conjTranspose_mul_self` with `\lean{Matrix.firstEnvEmbedding_conjTranspose_mul_self}`, `\leanok`, and `\begin{proof}\leanok\end{proof}` tags, stating $W_0^\dagger W_0 = \mathrm{Id}$.
- Updated `\uses{}` in the proof of `thm:channel_exists_stinespring_open_system_unitary` to cite the new isometry lemma alongside `lem:exists_unitary_mul_eq_of_gram_eq`.
- No Lean declarations are changed.

### Testing

- `lake build TNLean -q --log-level=info`
- `leanblueprint checkdecls`
- `git diff --check`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Closes LionSR/QICLean#160

> [!NOTE]
> **Low Risk**
> Documentation and blueprint–Lean sync only; no runtime or proof code changes.
>
> **Overview**
> Blueprint-only bookkeeping for the **unitary open-system** Stinespring representation: no Lean declarations change.
>
> Adds a **`\leanok` proof stub** for the rectangular Gram-equality lemma (`lem:exists_unitary_mul_eq_of_gram_eq`) and a new blueprint lemma **`lem:first_env_embedding_conjTranspose_mul_self`** stating $W_0^\dagger W_0 = \mathrm{Id}$, linked to `Matrix.firstEnvEmbedding_conjTranspose_mul_self`.
>
> The proof of **`thm:channel_exists_stinespring_open_system_unitary`** now **`\uses`** that isometry identity alongside the Gram-equality lemma, matching how the Lean proof compares $V^\dagger V$ with $W_0^\dagger W_0$ before invoking the unitary factorization.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dccdc9939c67b199e3bd0c6f91353516dd7030c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>