### PR TITLE
feat(MPS/ParentHamiltonian): identify chain kernels

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.Commuting
+import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
 
 /-!
 # Ground-space spanning for block-diagonal parent Hamiltonians
@@ -57,6 +58,68 @@ theorem hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bn
     have hNpos : 0 < N := lt_of_le_of_lt (Nat.zero_le L) hN
     exact bntMPSVectorSpan_le_ker_parentHamiltonian_toTensorFromBlocks
       μ A hμ hNpos (le_of_lt hN)
+
+/-- If the periodic chain constraints for the block-diagonal tensor are already
+the span of the component periodic MPS vectors, then the source
+parent-Hamiltonian ground-space spanning clause follows.
+
+Let \(B=\bigoplus_j\mu_jA_j\), with every \(\mu_j\ne0\). The new input is the
+periodic chain-space equality
+\[
+  \mathcal G_{N,L}(B)=\bigvee_j \mathbb C V^{(N)}(A_j)
+\]
+for every \(N>L\). The finite-volume identity
+\(\ker H_L^{(N)}(B)=\mathcal G_{N,L}(B)\), together with the easy inclusion of
+the BNT span in the kernel, gives the parent-Hamiltonian spanning equation. -/
+theorem hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_mpv
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0) {L : ℕ}
+    (hChain : ∀ N : ℕ, L < N →
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, mpvSubmodule (A j) N) :
+    HasParentHamiltonianGroundSpaceSpanning
+      (toTensorFromBlocks (d := d) (μ := μ) A) L A := by
+  rw [hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan
+    μ A hμ]
+  intro N hN
+  have hNpos : 0 < N := lt_of_le_of_lt (Nat.zero_le L) hN
+  have hLN : L ≤ N := le_of_lt hN
+  rw [ker_parentHamiltonian_eq_chainGroundSpace
+    (toTensorFromBlocks (d := d) (μ := μ) A) hNpos hLN]
+  rw [hChain N hN, iSup_mpvSubmodule_eq_bntMPSVectorSpan]
+
+/-- It is enough to prove the periodic block-diagonal chain-space equality and
+the single-block chain-space equalities.
+
+This theorem isolates the two geometric inputs normally supplied by the
+block-injective parent-Hamiltonian argument:
+\[
+  \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j),
+  \qquad
+  \mathcal G_{N,L}(A_j)=\mathbb C V^{(N)}(A_j).
+\]
+Together they imply the source parent-Hamiltonian ground-space spanning
+equation for \(B=\bigoplus_j\mu_jA_j\). -/
+theorem hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_chain
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0) {L : ℕ}
+    (hChain : ∀ N : ℕ, L < N →
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N)
+    (hBlock : ∀ N : ℕ, L < N → ∀ j : Fin r,
+      chainGroundSpace (A j) L N = mpvSubmodule (A j) N) :
+    HasParentHamiltonianGroundSpaceSpanning
+      (toTensorFromBlocks (d := d) (μ := μ) A) L A := by
+  refine hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_mpv
+    μ A hμ ?_
+  intro N hN
+  calc
+    chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N =
+        ⨆ j : Fin r, chainGroundSpace (A j) L N := hChain N hN
+    _ = ⨆ j : Fin r, mpvSubmodule (A j) N := by
+      simp [hBlock N hN]
 
 /-- For block-diagonal nearest-neighbor parent Hamiltonians, the all-chain
 source condition is equivalent to all-chain translated parent-term commutation

--- a/TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean
@@ -13,7 +13,9 @@ This file records the elementary frustration-free direction for the periodic
 parent Hamiltonian: since the finite parent Hamiltonian is a sum of local
 orthogonal projections, a vector in its kernel satisfies every local cyclic
 constraint. Hence the kernel of \(H_N(A,L)\) lies in the periodic
-chain-ground-space submodule.
+chain-ground-space submodule. The converse is the defining frustration-free
+direction of the parent-Hamiltonian construction, so in the nondegenerate range
+these two submodules are equal.
 -/
 
 open scoped BigOperators
@@ -53,5 +55,42 @@ theorem ker_parentHamiltonian_le_chainGroundSpace
     (mem_groundSpaceES_iff A L
       (cyclicRestrictES (d := d) hN L i τ (eN.symm ψ))).1 hrestrictES
   simpa [cyclicRestrictES, eN, eL] using hrestrictNS
+
+/-- The periodic chain ground space is contained in the kernel of the finite
+periodic parent Hamiltonian.
+
+Equivalently, imposing every cyclic \(L\)-site local MPS constraint makes every
+translated parent interaction vanish, and hence gives zero total energy. -/
+theorem chainGroundSpace_le_ker_parentHamiltonian
+    (A : MPSTensor d D) {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :
+    chainGroundSpace A L N ≤ LinearMap.ker (parentHamiltonian A L N) := by
+  intro ψ hψ
+  rw [LinearMap.mem_ker]
+  have hff : IsFrustrationFree A L N ψ :=
+    isFrustrationFree_of_mem_chainGroundSpace A hN hLN hψ
+  rw [parentHamiltonian, LinearMap.sum_apply]
+  exact Finset.sum_eq_zero fun i _ => hff i
+
+/-- In the nondegenerate range, the finite periodic parent-Hamiltonian kernel is
+exactly the cyclic chain ground space. -/
+theorem ker_parentHamiltonian_eq_chainGroundSpace
+    (A : MPSTensor d D) {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :
+    LinearMap.ker (parentHamiltonian A L N) = chainGroundSpace A L N :=
+  le_antisymm (ker_parentHamiltonian_le_chainGroundSpace A hN hLN)
+    (chainGroundSpace_le_ker_parentHamiltonian A hN hLN)
+
+/-- The cyclic chain ground space transported to the Euclidean-space model. -/
+noncomputable def chainGroundSpaceES (A : MPSTensor d D) (L N : ℕ) :
+    Submodule ℂ (EuclideanSpace ℂ (Cfg d N)) :=
+  (chainGroundSpace A L N).map
+    (WithLp.linearEquiv 2 ℂ (NSiteSpace d N)).symm.toLinearMap
+
+/-- In the nondegenerate range, the Euclidean-space finite parent-Hamiltonian
+ground space is the transported cyclic chain ground space. -/
+theorem parentHamiltonianGroundSpaceES_eq_chainGroundSpaceES
+    (A : MPSTensor d D) {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N) :
+    parentHamiltonianGroundSpaceES A L N = chainGroundSpaceES A L N := by
+  simp [parentHamiltonianGroundSpaceES, chainGroundSpaceES,
+    ker_parentHamiltonian_eq_chainGroundSpace A hN hLN]
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -351,6 +351,61 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     source spanning clause.
 \end{proof}
 
+\begin{lemma}[Chain-space comparison gives the block-diagonal spanning equation]
+    \label{lem:block_diagonal_chain_space_comparison_parent_spanning}
+    \lean{MPSTensor.hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_mpv}
+    \lean{MPSTensor.hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_of_chain_eq_iSup_chain}
+    \leanok
+    \uses{def:parent_hamiltonian_ground_space_spanning,
+        thm:parent_hamiltonian_kernel_eq_chain_ground_space,
+        lem:block_diagonal_parent_spanning_reverse_inclusion,
+        lem:bnt_span_eq_sum_mpv_submodules}
+    Let
+    \[
+        B=\bigoplus_{j=0}^{r-1}\mu_jA_j,
+        \qquad \mu_j\ne0.
+    \]
+    Suppose that, for every \(N>L\),
+    \[
+        G_L^{(N)}(B)
+        =
+        \bigvee_{j=0}^{r-1}\spn\{V^{(N)}(A_j)\}.
+    \]
+    Then the source parent-Hamiltonian spanning equation holds:
+    \[
+        \ker H_N(B,L)
+        =
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+    \]
+    It is enough to prove the two equations
+    \[
+        G_L^{(N)}(B)=\bigvee_{j=0}^{r-1}G_L^{(N)}(A_j),
+        \qquad
+        G_L^{(N)}(A_j)=\spn\{V^{(N)}(A_j)\}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The finite-volume identity gives
+    \[
+        \ker H_N(B,L)=G_L^{(N)}(B).
+    \]
+    The assumed chain-space comparison therefore rewrites the kernel as
+    \[
+        \bigvee_{j=0}^{r-1}\spn\{V^{(N)}(A_j)\}.
+    \]
+    The latter supremum is the BNT vector span. Conversely, the easy inclusion
+    of Lemma~\ref{lem:bnt_span_le_parent_hamiltonian_kernel} gives
+    \[
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}\subseteq\ker H_N(B,L),
+    \]
+    so the displayed equation is the source spanning clause. If the comparison
+    is first stated as
+    \(G_L^{(N)}(B)=\bigvee_jG_L^{(N)}(A_j)\), the single-block equations
+    \(G_L^{(N)}(A_j)=\spn\{V^{(N)}(A_j)\}\) give the previous hypothesis.
+\end{proof}
+
 \begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}
     \lean{MPSTensor.rfp_implies_nncph}
     \lean{Axioms.rfp_to_nncph_commute}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -258,6 +258,45 @@ sufficient stronger hypotheses.
     $G_L^{(N)}(A)$.
 \end{proof}
 
+\begin{theorem}[The finite-volume kernel is the cyclic constraint space]
+    \label{thm:parent_hamiltonian_kernel_eq_chain_ground_space}
+    \lean{MPSTensor.chainGroundSpace_le_ker_parentHamiltonian}
+    \lean{MPSTensor.ker_parentHamiltonian_eq_chainGroundSpace}
+    \lean{MPSTensor.chainGroundSpaceES}
+    \lean{MPSTensor.parentHamiltonianGroundSpaceES_eq_chainGroundSpaceES}
+    \leanok
+    \uses{def:parent_hamiltonian, def:parent_hamiltonian_es,
+        def:chain_ground_space, thm:parent_hamiltonian_kernel_le_chain_ground_space,
+        thm:chain_ground_space_implies_frustration_free}
+    Assume $N>0$ and $L\le N$. Then
+    \[
+        \ker H_N(A,L)=G_L^{(N)}(A).
+    \]
+    Equivalently, after the canonical Hilbert-space identification,
+    \[
+        \mathcal K_N^{\mathrm{ES}}(A,L)
+        =
+        e_N^{-1}G_L^{(N)}(A),
+    \]
+    where \(\mathcal K_N^{\mathrm{ES}}(A,L)\) is the zero-energy space of
+    \(H_{N,L}^{\mathrm{ES}}(A)\).
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The inclusion
+    \[
+        \ker H_N(A,L)\subseteq G_L^{(N)}(A)
+    \]
+    is Theorem~\ref{thm:parent_hamiltonian_kernel_le_chain_ground_space}. For
+    the converse, a vector in \(G_L^{(N)}(A)\) satisfies all local equations
+    \(h_i(A,L)\psi=0\). Therefore
+    \[
+        H_N(A,L)\psi=\sum_i h_i(A,L)\psi=0.
+    \]
+    The Hilbert-space statement is the same equality transported by \(e_N^{-1}\).
+\end{proof}
+
 \begin{theorem}[Intersection property for two adjacent local kernels]
     \label{thm:adjacent_local_kernels_ground_space_es}
     \lean{MPSTensor.mem_groundSpaceES_succ_of_adjacent_localTermES_eq_zero}


### PR DESCRIPTION
### Motivation

- The parent-Hamiltonian kernel identification `ker H_N(A,L) = G_L^{(N)}(A)` for finite periodic chains was previously established only in one direction: zero-energy states satisfy cyclic chain constraints. The reverse inclusion — cyclic chain constraints imply zero energy — was missing, leaving the equality unproved. This PR closes that gap, continuing formalization of arXiv:1606.00608 parent-Hamiltonian theory (see #2633).
- Block-diagonal ground-space spanning requires reducing to periodic chain-space comparison equations corresponding to Definition 3.9 of arXiv:1606.00608.

### Description

- `TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean`: proves the reverse inclusion (cyclic chain constraints imply zero energy) and packages the resulting equality `ker H_N(A,L) = G_L^{(N)}(A)`. Adds `chainGroundSpaceES` and `parentHamiltonianGroundSpaceES_eq_chainGroundSpaceES` for the Euclidean-space transported form.
- `TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean`: reduces block-diagonal parent-Hamiltonian ground-space spanning to periodic chain-space hypotheses; assuming `G_L^{(N)}(B)` equals the supremum of component MPS-vector spans (or the weaker split into block chain spaces plus per-block `G_L^{(N)}(A_j) = span V^{(N)}(A_j)`), the spanning clause from arXiv:1606.00608 Definition 3.9 follows by rewriting the kernel through the new identity.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`, `ch13_parent_hamiltonian_spectral_gap.tex`: add matching lemma and theorem entries with `\lean{}` and `\leanok` tags.

### Testing

- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace`
- `lake build TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci` and `--update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/KernelChainGroundSpace.lean TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean`

---
Addresses #2633
Refs #2971
Refs #952
Refs #190
Refs #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs and blueprint sync in MPS parent-Hamiltonian formalization; no runtime, auth, or data-path changes.
> 
> **Overview**
> This PR **closes the kernel ↔ cyclic chain-ground-space identification** for finite periodic parent Hamiltonians: it proves the reverse inclusion (chain constraints imply zero energy), packages **`ker H_N(A,L) = G_L^{(N)}(A)`**, and records the same equality after transport to the Euclidean-space model via new `chainGroundSpaceES` / `parentHamiltonianGroundSpaceES_eq_chainGroundSpaceES`.
> 
> **Block-diagonal ground-space spanning** is then reduced to periodic chain-space hypotheses: assuming `G_L^{(N)}(B)` equals the supremum of component MPS-vector spans (or the weaker split into block chain spaces plus per-block `G_L^{(N)}(A_j) = span V^{(N)}(A_j)`), the source Definition 3.9 spanning clause follows by rewriting the kernel through the new identity. Matching **blueprint** lemma/theorem entries are added in the commuting-gap and spectral-gap chapters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc5cea801aa2aa6f50c5aab5f638151687cf056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->