### PR TITLE
feat(MPS/ParentHamiltonian): reduce kernel spanning to chain splitting

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
@@ -5,6 +5,7 @@ Authors: TNLean contributors
 -/
 import TNLean.MPS.ParentHamiltonian.BlockDiagonalChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.Commuting
+import TNLean.MPS.ParentHamiltonian.KernelChainGroundSpace
 
 /-!
 # Ground-space spanning for block-diagonal parent Hamiltonians
@@ -21,6 +22,49 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d : ℕ}
+
+/-- Zero energy for a block-diagonal parent Hamiltonian lies in the BNT vector
+span once the periodic chain constraints split into the block constraints and
+each block constraint is one-dimensional.
+
+Let \(B=\bigoplus_{j=0}^{r-1}\mu_jA_j\). If
+\[
+  \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j)
+\]
+and each \(\mathcal G_{N,L}(A_j)\) is contained in
+\(\mathbb C V^{(N)}(A_j)\), then
+\[
+  \ker H_L^{(N)}(B)
+  \subseteq
+  \operatorname{span}\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+\]
+This is the reduction needed by arXiv:1606.00608, Definition 3.9, after the
+periodic-boundary comparison has supplied the chain-space splitting. -/
+theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {L N : ℕ} (hN : 0 < N) (hLN : L ≤ N)
+    (hClose :
+      chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N ≤
+        ⨆ j : Fin r, chainGroundSpace (A j) L N)
+    (hBlock :
+      ∀ j : Fin r, chainGroundSpace (A j) L N ≤ mpvSubmodule (A j) N) :
+    LinearMap.ker (parentHamiltonian
+      (toTensorFromBlocks (d := d) (μ := μ) A) L N) ≤
+      bntMPSVectorSpan A N := by
+  intro ψ hψ
+  have hChain :
+      ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N :=
+    ker_parentHamiltonian_le_chainGroundSpace
+      (toTensorFromBlocks (d := d) (μ := μ) A) hN hLN hψ
+  have hSum : ψ ∈ ⨆ j : Fin r, chainGroundSpace (A j) L N :=
+    hClose hChain
+  have hToMpv :
+      (⨆ j : Fin r, chainGroundSpace (A j) L N) ≤
+        ⨆ j : Fin r, mpvSubmodule (A j) N :=
+    iSup_mono hBlock
+  rw [iSup_mpvSubmodule_eq_bntMPSVectorSpan A N] at hToMpv
+  exact hToMpv hSum
 
 /-- For a block-diagonal tensor with nonzero weights, the source parent-Hamiltonian
 ground-space spanning clause is equivalent to the reverse inclusion.

--- a/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean
@@ -25,7 +25,7 @@ variable {d : ℕ}
 
 /-- Zero energy for a block-diagonal parent Hamiltonian lies in the BNT vector
 span once the periodic chain constraints split into the block constraints and
-each block constraint is one-dimensional.
+each block chain space is contained in its periodic MPS line.
 
 Let \(B=\bigoplus_{j=0}^{r-1}\mu_jA_j\). If
 \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -288,6 +288,51 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     $h_i(B,L)V^{(N)}(A_j)=0$ for every $i$.
 \end{proof}
 
+\begin{lemma}[Kernel containment from chain-space splitting]
+    \label{lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan}
+    \leanok
+    \uses{thm:parent_hamiltonian_kernel_le_chain_ground_space,
+        def:parent_hamiltonian, def:chain_ground_space, def:bnt_span,
+        def:mpv_submodule, lem:bnt_span_eq_sum_mpv_submodules}
+    Let $B=\bigoplus_{j=0}^{r-1}\mu_jA_j$. Suppose $N>0$, $L\le N$, and
+    the periodic chain constraints for $B$ split into the block constraints:
+    \[
+        \mathcal G_{N,L}(B)
+        \subseteq
+        \bigvee_{j=0}^{r-1}\mathcal G_{N,L}(A_j).
+    \]
+    If every block chain space is contained in its periodic MPS line,
+    \[
+        \mathcal G_{N,L}(A_j)\subseteq \mathbb C V^{(N)}(A_j)
+        \qquad (0\le j<r),
+    \]
+    then the zero-energy space of the parent Hamiltonian is contained in the
+    BNT vector span:
+    \[
+        \ker H_L^{(N)}(B)
+        \subseteq
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Theorem~\ref{thm:parent_hamiltonian_kernel_le_chain_ground_space} gives
+    \[
+        \ker H_L^{(N)}(B)\subseteq \mathcal G_{N,L}(B).
+    \]
+    The assumed splitting therefore places every zero-energy vector in
+    $\bigvee_j\mathcal G_{N,L}(A_j)$. The blockwise containments give
+    \[
+        \bigvee_j\mathcal G_{N,L}(A_j)
+        \subseteq
+        \bigvee_j\mathbb C V^{(N)}(A_j),
+    \]
+    and Lemma~\ref{lem:bnt_span_eq_sum_mpv_submodules} identifies the last
+    space with the BNT vector span.
+\end{proof}
+
 \begin{lemma}[Block-diagonal spanning is equivalent to the reverse inclusion]
     \label{lem:block_diagonal_parent_spanning_reverse_inclusion}
     \lean{MPSTensor.hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -322,15 +322,26 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \[
         \ker H_L^{(N)}(B)\subseteq \mathcal G_{N,L}(B).
     \]
-    The assumed splitting therefore places every zero-energy vector in
-    $\bigvee_j\mathcal G_{N,L}(A_j)$. The blockwise containments give
+    Together with the splitting hypothesis,
+    \[
+        \ker H_L^{(N)}(B)
+        \subseteq
+        \mathcal G_{N,L}(B)
+        \subseteq
+        \bigvee_j\mathcal G_{N,L}(A_j).
+    \]
+    The blockwise containments give
     \[
         \bigvee_j\mathcal G_{N,L}(A_j)
         \subseteq
         \bigvee_j\mathbb C V^{(N)}(A_j),
     \]
-    and Lemma~\ref{lem:bnt_span_eq_sum_mpv_submodules} identifies the last
-    space with the BNT vector span.
+    and Lemma~\ref{lem:bnt_span_eq_sum_mpv_submodules} gives
+    \[
+        \bigvee_j\mathbb C V^{(N)}(A_j)
+        =
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+    \]
 \end{proof}
 
 \begin{lemma}[Block-diagonal spanning is equivalent to the reverse inclusion]


### PR DESCRIPTION
### Motivation
- Reduces the parent-Hamiltonian kernel containment $\ker H_L^{(N)}(\bigoplus_j \mu_j A_j) \subseteq \operatorname{span}\{V^{(N)}(A_j)\}$ to two structural hypotheses on the block-diagonal tensor, enabling downstream proofs to establish spanning by proving chain-space splitting rather than attacking the kernel directly.
- Continues formalization of the pure-state RFP/ZCL/NNCPH equivalence from arXiv:1606.00608; see #2633.

### Description
- `TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean`: adds `ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan`, showing that for block-diagonal $B = \bigoplus_j \mu_j A_j$, $\ker H_L^{(N)}(B) \subseteq \operatorname{span}\{V^{(N)}(A_j)\}$ follows from (i) the periodic chain ground space for $B$ splitting into block chain spaces, and (ii) each block chain space lying in its periodic MPS line. The proof chains `ker_parentHamiltonian_le_chainGroundSpace` (imported from `KernelChainGroundSpace`) with `iSup_mpvSubmodule_eq_bntMPSVectorSpan`.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: adds Lemma "Kernel containment from chain-space splitting" synced to the new theorem, placed before the existing equivalence between the source spanning condition and the reverse inclusion.

### Testing
- `lake build TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/GroundSpaceSpanning.lean || true`

---
Addresses #2633

> [!NOTE]
> **Low Risk**
> Formal proof and documentation only; no runtime or security surface, building on existing lemmas.
>
> **Overview**
> Adds **`ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan`**, showing that for block-diagonal \(B=\bigoplus_j \mu_j A_j\), **\(\ker H_L^{(N)}(B) \subseteq \operatorname{span}\{V^{(N)}(A_j)\}\)** follows from (i) periodic chain ground space for \(B\) splitting into block chain spaces, and (ii) each block chain space lying in its periodic MPS line. The proof chains the existing **kernel \(\subseteq\) chain ground space** step with **`iSup_mpvSubmodule_eq_bntMPSVectorSpan`**.
>
> The blueprint gains **Lemma "Kernel containment from chain-space splitting"** (synced to that theorem), placed **before** the existing equivalence between full spanning and the reverse inclusion—so later work can discharge spanning by proving splitting plus one-dimensional block constraints instead of attacking the kernel directly.
>
> Imports **`KernelChainGroundSpace`** for **`ker_parentHamiltonian_le_chainGroundSpace`**.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 764d10e699140f746991adc730894a16163df4d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean proof and blueprint documentation only; no runtime, auth, or data-handling changes.
> 
> **Overview**
> Adds **`ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan`**, which shows that for block-diagonal \(B=\bigoplus_j \mu_j A_j\), **\(\ker H_L^{(N)}(B) \subseteq \operatorname{span}\{V^{(N)}(A_j)\}\)** follows from periodic chain ground space for \(B\) splitting into block chain spaces and each block chain space lying in its periodic MPS line. The proof chains **`ker_parentHamiltonian_le_chainGroundSpace`** (new import from `KernelChainGroundSpace`) with **`iSup_mpvSubmodule_eq_bntMPSVectorSpan`**.
> 
> The blueprint adds **Lemma “Kernel containment from chain-space splitting”** (synced to that theorem), placed **before** the existing equivalence between full spanning and the reverse inclusion—so later work can discharge spanning via splitting plus one-dimensional block constraints instead of attacking the kernel directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479ac5dfbaf57ee94e138a3fe950c8afe35dd68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->