### PR TITLE
refactor(Channel/POVM): use shared Gram theorem in Naimark uniqueness

### DIFF
--- a/TNLean/Channel/POVM/Uniqueness.lean
+++ b/TNLean/Channel/POVM/Uniqueness.lean
@@ -3,8 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.LinearAlgebra.UnitaryGroup
+import TNLean.Algebra.MatrixGramUnitary
 import TNLean.Channel.POVM
-import TNLean.Channel.KrausFreedom
 
 /-!
 # Uniqueness properties of concrete Naimark dilations
@@ -34,15 +34,6 @@ open Matrix Finset BigOperators
 variable {D n : ℕ}
 
 namespace POVM
-
-/-- If two square matrices have the same Gram matrix, then they differ by left
-multiplication by a unitary matrix. -/
-private theorem exists_unitary_mul_eq_of_conjTranspose_mul_eq
-    (B A : Matrix (Fin D) (Fin D) ℂ)
-    (hGram : Bᴴ * B = Aᴴ * A) :
-    ∃ U : Matrix.unitaryGroup (Fin D) ℂ,
-      B = (U : Matrix (Fin D) (Fin D) ℂ) * A := by
-  exact Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq B A hGram
 
 /-- Predicate saying that `V` together with the projective measurement `P`
 realizes `E` as a Naimark dilation. -/
@@ -240,7 +231,7 @@ theorem exists_isometry_mul_naimarkIsometry_of_recovery
       _ = E.ops i := hV i
       _ = (E.naimarkKraus i)ᴴ * E.naimarkKraus i := E.naimarkKraus_spec i
   choose U hU using fun i : Fin n =>
-    exists_unitary_mul_eq_of_conjTranspose_mul_eq
+    Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq
       (B := naimarkBlock (D := D) (n := n) V i) (A := E.naimarkKraus i) (hGram i)
   refine ⟨sectorwiseUnitary (D := D) U, sectorwiseUnitary_isometry (D := D) U, ?_⟩
   calc

--- a/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
+++ b/docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md
@@ -2233,6 +2233,30 @@ lake env lean TNLean/PEPS/CycleMPSChainOverlapInsertion.lean
 lake env lean TNLean/PEPS/CycleMPSTranslationInvariant.lean
 ```
 
+## Naimark square-Gram adapter cleanup, 2026-06-21
+
+`TNLean/Channel/POVM/Uniqueness.lean` still had a private square-matrix
+specialization of the shared Gram theorem
+`Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq`.  The private theorem
+was an exact pass-through:
+
+```lean
+private theorem exists_unitary_mul_eq_of_conjTranspose_mul_eq
+```
+
+It has now been removed.  The Naimark uniqueness proof calls
+`Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq` directly at the `choose`
+site, matching the style already used in `TNLean.Channel.KrausFreedom` and
+`TNLean.Channel.OpenSystem`.  Since the file no longer needs any theorem from
+`TNLean.Channel.KrausFreedom`, its import was narrowed to
+`TNLean.Algebra.MatrixGramUnitary`.
+
+Focused check:
+
+```bash
+lake build TNLean.Channel.POVM.Uniqueness -q --log-level=info
+```
+
 ## PEPS right-multiplication span cleanup, 2026-06-21
 
 `TNLean/PEPS/CycleMPSChainOverlapCapstone.lean` had a private helper


### PR DESCRIPTION
### Motivation

- `TNLean/Channel/POVM/Uniqueness.lean` contained a private theorem `POVM.exists_unitary_mul_eq_of_conjTranspose_mul_eq` that was an exact pass-through to the shared theorem `Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq` (in `TNLean/Algebra/MatrixGramUnitary.lean`). The adapter added no mathematical content.
- Removing it and calling the shared theorem directly at the `choose` site aligns the file with the style already used in `TNLean.Channel.KrausFreedom` and `TNLean.Channel.OpenSystem`.
- Narrowing the import from `TNLean.Channel.KrausFreedom` to `TNLean.Algebra.MatrixGramUnitary` reduces the dependency footprint of `Channel/POVM/Uniqueness`.

### Description

- **`TNLean/Channel/POVM/Uniqueness.lean`**: removed private `POVM.exists_unitary_mul_eq_of_conjTranspose_mul_eq` (a square-matrix specialization that forwarded to `Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq`); updated the `choose` call in `POVM.exists_isometry_mul_naimarkIsometry_of_recovery` to invoke `Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq` directly; replaced import `TNLean.Channel.KrausFreedom` with `TNLean.Algebra.MatrixGramUnitary`.
- **`docs/audits/2026-06-18_mathlib_4_31_replacement_audit.md`**: records the cleanup so future Mathlib 4.31 replacement-audit passes do not rediscover the same pass-through layer.
- No mathematical statements are added or changed; no `sorry` is introduced.

### Testing

- `lake exe cache get`
- `lake build TNLean.Channel.POVM.Uniqueness -q --log-level=info`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`

---
No linked issue found — please link one manually if applicable.

> [!NOTE]
> **Low Risk**
> Proof-only refactor with no statement changes; behavior matches other channel files that already use the shared Gram theorem.
>
> **Overview**
> Removes a **private pass-through** in `TNLean/Channel/POVM/Uniqueness.lean` that only forwarded to `Matrix.exists_unitary_mul_eq_of_conjTranspose_mul_eq`. The Naimark uniqueness proof now calls that shared Gram theorem **directly** at the `choose` site, consistent with `KrausFreedom` and `OpenSystem`.
>
> **Imports** are narrowed: add `TNLean.Algebra.MatrixGramUnitary`, drop `TNLean.Channel.KrausFreedom`. The Mathlib 4.31 replacement audit documents the cleanup so later passes do not reintroduce the same layer.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ebd257a6df9b9c98fe90dbffb2c61cf6cfe4e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>