### PR TITLE
doc(MPS/ParentHamiltonian): separate chain kernel blueprint entries

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -258,16 +258,52 @@ sufficient stronger hypotheses.
     $G_L^{(N)}(A)$.
 \end{proof}
 
+\begin{lemma}[Cyclic constraints give zero energy]
+    \label{lem:chain_ground_space_le_parent_hamiltonian_kernel}
+    \lean{MPSTensor.chainGroundSpace_le_ker_parentHamiltonian}
+    \leanok
+    \uses{def:parent_hamiltonian, def:chain_ground_space,
+        thm:chain_ground_space_implies_frustration_free}
+    Assume $N>0$ and $L\le N$. Then
+    \[
+        G_L^{(N)}(A)\subseteq \ker H_N(A,L).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    If \(\psi\in G_L^{(N)}(A)\), then every local parent interaction
+    annihilates \(\psi\):
+    \[
+        h_i(A,L)\psi=0\qquad\text{for all }i.
+    \]
+    Summing over all sites gives
+    \[
+        H_N(A,L)\psi=\sum_i h_i(A,L)\psi=0.
+    \]
+\end{proof}
+
+\begin{definition}[Hilbert-space cyclic constraint space]
+    \label{def:chain_ground_space_es}
+    \lean{MPSTensor.chainGroundSpaceES}
+    \leanok
+    \uses{def:chain_ground_space}
+    The Hilbert-space cyclic constraint space is the transport of
+    \(G_L^{(N)}(A)\) by the canonical \(\ell^2\)-identification:
+    \[
+        G_{L,\mathrm{ES}}^{(N)}(A)=e_N^{-1}G_L^{(N)}(A).
+    \]
+\end{definition}
+
 \begin{theorem}[The finite-volume kernel is the cyclic constraint space]
     \label{thm:parent_hamiltonian_kernel_eq_chain_ground_space}
-    \lean{MPSTensor.chainGroundSpace_le_ker_parentHamiltonian}
     \lean{MPSTensor.ker_parentHamiltonian_eq_chainGroundSpace}
-    \lean{MPSTensor.chainGroundSpaceES}
     \lean{MPSTensor.parentHamiltonianGroundSpaceES_eq_chainGroundSpaceES}
     \leanok
     \uses{def:parent_hamiltonian, def:parent_hamiltonian_es,
         def:chain_ground_space, thm:parent_hamiltonian_kernel_le_chain_ground_space,
-        thm:chain_ground_space_implies_frustration_free}
+        lem:chain_ground_space_le_parent_hamiltonian_kernel,
+        def:chain_ground_space_es}
     Assume $N>0$ and $L\le N$. Then
     \[
         \ker H_N(A,L)=G_L^{(N)}(A).


### PR DESCRIPTION
### Motivation
- The theorem block `thm:parent_hamiltonian_kernel_eq_chain_ground_space` in the parent Hamiltonian spectral gap chapter incorrectly tagged auxiliary declarations as formalizing the kernel equality `ker H_N(A,L) = G_L^{(N)}(A)` (see #3340).
- `MPSTensor.chainGroundSpace_le_ker_parentHamiltonian` (which proves only the inclusion `chainGroundSpace A L N ≤ ker H_N(A,L)`) was listed as a `\lean{}` tag on the equality theorem; it belongs in its own `\begin{lemma}` entry.
- `MPSTensor.chainGroundSpaceES` (a `noncomputable def`) was embedded inside the theorem block rather than having its own `\begin{definition}` entry.

### Description
- `blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex`:
  - Adds a `\begin{lemma}` block for the reverse inclusion `chainGroundSpace A L N ≤ ker H_N(A,L)`, tagged with `\lean{MPSTensor.chainGroundSpace_le_ker_parentHamiltonian}` and `\leanok`.
  - Adds a `\begin{definition}` block for the Euclidean-space transport of the chain ground space, tagged with `\lean{MPSTensor.chainGroundSpaceES}` and `\leanok`.
  - Leaves the finite-volume kernel equality theorem (`thm:parent_hamiltonian_kernel_eq_chain_ground_space`) tagged only by the equality declarations.

### Testing
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- Relies on Lean CI (`lean_action_ci.yml`) to validate the build; `leanblueprint checkdecls` requires a built `TNLean.olean` not present in this worktree.

---
Closes #3340
Refs #2633
Refs #190

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 97110a9f2b2ab606a67fd4c86017c4e8ef17c1b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>