### PR TITLE
feat(MPS/ParentHamiltonian): add kernel-spanning theorem via PGVWC comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalCrossingTrace
+import TNLean.MPS.ParentHamiltonian.GroundSpaceSpanning
 
 /-!
 # Boundary-condition comparisons for block-diagonal parent spaces
@@ -573,5 +574,72 @@ theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
     (chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
       hNlarge hComparison).1
+
+/-- The PGVWC boundary-condition comparison gives the fixed-chain kernel
+containment needed for the block-diagonal parent-Hamiltonian spanning clause,
+provided each block chain space is already contained in its MPS line.
+
+Let \(B=\bigoplus_j\mu_jA_j\).  The cut-adapted \(C^j,D^j\) comparison gives
+\[
+  \mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j).
+\]
+If the single-block periodic chain spaces satisfy
+\(\mathcal G_{N,L}(A_j)\subseteq \mathbb C V^{(N)}(A_j)\), then
+\[
+  \ker H_L^{(N)}(B)\subseteq
+  \operatorname{span}\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+\]
+
+**Unfaithful:** This proof relies on
+`chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison`, whose proof
+transitively uses the boundary-condition comparison at boundary-crossing
+windows rather than deriving it from arXiv:2011.12127, Section IV.C, lines
+2126--2128. Documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. Elimination:
+derive the \(C^j,D^j,E^j\) boundary-condition comparison from
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and use it to
+discharge the currently assumed comparison; tracked in issue 2971. -/
+theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hComparison :
+      ∀ {ψ : NSiteSpace d N},
+        ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N →
+        ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+            ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+          ∃ C : ∀ (j : Fin r) (_ : Fin N),
+            (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+            ∀ (j : Fin r) (i : Fin N),
+              N < i.val + L →
+                ∀ ρ : Fin (N - L) → Fin d,
+                  ∀ β : Fin (i.val + L - N) → Fin d,
+                    evalWord (A j) (List.ofFn β) * C j i ρ =
+                      (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                        evalWord (A j) (List.ofFn ρ))
+    (hBlock :
+      ∀ j : Fin r, chainGroundSpace (A j) L N ≤ mpvSubmodule (A j) N) :
+    LinearMap.ker (parentHamiltonian
+      (toTensorFromBlocks (d := d) (μ := μ) A) L N) ≤
+      bntMPSVectorSpan A N := by
+  refine ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan
+    μ A hN hLN ?_ hBlock
+  exact le_of_eq
+    (chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+      hNlarge hComparison)
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -291,7 +291,6 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
 \begin{lemma}[Kernel containment from chain-space splitting]
     \label{lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan}
-    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison}
     \leanok
     \uses{thm:parent_hamiltonian_kernel_le_chain_ground_space,
         def:parent_hamiltonian, def:chain_ground_space, def:bnt_span,
@@ -315,11 +314,6 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         \subseteq
         \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
     \]
-    In the finite-length range where the \(C^j,D^j\) comparison of
-    Perez-Garcia, Verstraete, Wolf, and Cirac gives
-    \(\mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j)\), the same
-    containment follows with the splitting hypothesis supplied by that
-    comparison.
 \end{lemma}
 
 \begin{proof}
@@ -348,6 +342,62 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
     \]
+\end{proof}
+
+\begin{lemma}[Kernel containment from the PGVWC block comparison]
+    \label{lem:block_diagonal_kernel_to_bnt_span_from_pgvwc_comparison}
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison}
+    \leanok
+    \uses{lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting,
+        lem:bnt_block_diagonal_pgvwc_comparison_ground_space}
+    Let \(B=\bigoplus_{j=0}^{r-1}\mu_jA_j\), with every \(\mu_j\ne0\).
+    Suppose the physical alphabet and all block dimensions are nonempty. Assume
+    that the block family is irreducible, left-canonical, has normalized
+    self-overlap, and has no two blocks gauge-phase equivalent. Suppose also
+    that each \(A_j\) is \(L_0\)-block-injective, that \(L_0>0\), and that
+    \[
+        \sum_a A^j_a(A^j_a)^\dagger=I
+        \qquad (0\le j<r).
+    \]
+    Let \(N>0\), \(L>0\), \(L\le N\), \(L+L_0\le N\), and
+    \[
+        (L_0+1)
+        +(r-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr)+1
+        \le L.
+    \]
+    Assume the opened-boundary \(C^j,D^j\) comparison: whenever
+    \(\psi\in\mathcal G_{N,L}(B)\) and
+    \(\psi=\Gamma_N^B(\bigoplus_j X_j)\), there are matrices
+    \(C^j_{i,\rho}\) such that, for every boundary-crossing interval \(i\),
+    every \(\rho\), and every \(\beta\),
+    \[
+        A^j_\beta C^j_{i,\rho}
+        =
+        \bigl((\mu_j^N X_j)A^j_\beta\bigr)A^j_\rho .
+    \]
+    If every block chain space is contained in its periodic MPS line,
+    \[
+        \mathcal G_{N,L}(A_j)\subseteq \mathbb C V^{(N)}(A_j)
+        \qquad (0\le j<r),
+    \]
+    then
+    \[
+        \ker H_L^{(N)}(B)
+        \subseteq
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:bnt_block_diagonal_pgvwc_comparison_ground_space} gives
+    \[
+        \mathcal G_{N,L}(B)=
+        \bigvee_{j=0}^{r-1}\mathcal G_{N,L}(A_j)
+    \]
+    from the stated block hypotheses and the opened-boundary comparison.
+    Lemma~\ref{lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
+    then applies to this equality and to the blockwise containments.
 \end{proof}
 
 \begin{lemma}[Block-diagonal spanning is equivalent to the reverse inclusion]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -291,6 +291,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
 \begin{lemma}[Kernel containment from chain-space splitting]
     \label{lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan}
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison}
     \leanok
     \uses{thm:parent_hamiltonian_kernel_le_chain_ground_space,
         def:parent_hamiltonian, def:chain_ground_space, def:bnt_span,
@@ -314,6 +315,11 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         \subseteq
         \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
     \]
+    In the finite-length range where the \(C^j,D^j\) comparison of
+    Perez-Garcia, Verstraete, Wolf, and Cirac gives
+    \(\mathcal G_{N,L}(B)=\bigvee_j\mathcal G_{N,L}(A_j)\), the same
+    containment follows with the splitting hypothesis supplied by that
+    comparison.
 \end{lemma}
 
 \begin{proof}


### PR DESCRIPTION
### Motivation

- Continues the formalization of the pure-state RFP/ZCL/NNCPH equivalence (arXiv:1606.00608, thm:main-MPS); see #2633.
- The block-diagonal parent-Hamiltonian kernel containment requires the PGVWC ground-space comparison as an ingredient. This PR adds the fixed-chain theorem that combines these two results: given that the PGVWC comparison supplies the chain-space equality $\mathcal{G}_{N,L}(B) = \bigvee_j \mathcal{G}_{N,L}(A_j)$, the new theorem yields $\ker H_L^{(N)}(B) \subseteq \operatorname{span}\{V^{(N)}(A_j) : j = 0, \ldots, r{-}1\}$.
- The corresponding Chapter 13 blueprint entry (`ch13_parent_hamiltonian_commuting_gap`) is updated to record this finite-length consequence.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean` (+68): adds a fixed-chain theorem composing the PGVWC chain-space equality with the existing block-diagonal parent-Hamiltonian kernel containment. The unfaithful boundary-condition dependency is marked in the Lean docstring, citing `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex` (+6): records the new result in the finite-length range of the commuting-gap chapter.
- This PR does not prove the PGVWC boundary-condition comparison itself; it derives the kernel-spanning consequence given that comparison. Remaining sorrys are inherited from the unfaithful dependency already present on `main`.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls` after regenerating `blueprint/lean_decls`

---
Addresses #2633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the formal parent-Hamiltonian ground-space spanning chain for block-diagonal tensors; logic is delegated to existing lemmas but still depends on the documented unfaithful PGVWC comparison hypothesis.
> 
> **Overview**
> Adds a **fixed-chain Lean theorem** and matching **Chapter 13 blueprint lemma** that derive the block-diagonal parent-Hamiltonian **reverse spanning inclusion** \(\ker H_L^{(N)}(B) \subseteq \operatorname{span}\{V^{(N)}(A_j)\}\) when the assumed **PGVWC \(C^j,D^j\) boundary comparison** supplies \(\mathcal G_{N,L}(B)=\bigvee_j \mathcal G_{N,L}(A_j)\) and each block chain space already sits in its MPS line.
> 
> The new proof is a short composition: `chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison` feeds the existing `ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan` from `GroundSpaceSpanning.lean`. The docstring marks the result **unfaithful** (same boundary-comparison gap as related PGVWC lemmas; issue 2971). This PR does **not** prove the comparison itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7fe4b4c5d20616b39c9d078afd0fb71ff263297. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->