### PR TITLE
feat(MPS/ParentHamiltonian): expose PGVWC trace decompositions

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -273,8 +273,11 @@ theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_
   obtain ⟨hLe, hIndep⟩ :=
     chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
-  obtain ⟨φ, hφ, hψφ⟩ :=
-    exists_sum_mem_of_mem_iSup_fin (fun j : Fin r => groundSpace (A j) N) (hLe hψ)
+  obtain ⟨φ, hφ, hφsum⟩ :=
+    (Submodule.mem_iSup_iff_exists_finsupp
+      (fun j : Fin r => groundSpace (A j) N) ψ).mp (hLe hψ)
+  have hψφ : ψ = ∑ j : Fin r, φ j := by
+    simpa [Finsupp.sum_fintype] using hφsum.symm
   refine ⟨φ, hφ, hψφ, ?_⟩
   intro φ' hφ' hψφ'
   apply funext

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean
@@ -76,7 +76,17 @@ theorem blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
               evalWord (A j) tailWord)) := by
   classical
   obtain ⟨φ, hφmem, hφsum⟩ :=
-    exists_sum_mem_of_mem_iSup_fin (fun j : Fin r => groundSpace (A j) L) hmem
+    (Submodule.mem_iSup_iff_exists_finsupp
+      (fun j : Fin r => groundSpace (A j) L)
+      (∑ j : Fin r,
+        cyclicRestrictₗ hN L i τ
+          (groundSpaceMap (A j) N ((μ j) ^ N • X j)))).mp hmem
+  have hφsum_univ :
+      (∑ j : Fin r, φ j) =
+        ∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j)) := by
+    simpa [Finsupp.sum_fintype] using hφsum
   have hMatrix : ∀ j : Fin r,
       ∃ Cj : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
         φ j = groundSpaceMap (A j) L Cj := by
@@ -159,7 +169,7 @@ theorem blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
         (∑ j : Fin r,
           cyclicRestrictₗ hN L i τ
             (groundSpaceMap (A j) N ((μ j) ^ N • X j))) σ := by
-            rw [← hφsum]
+            rw [hφsum_univ]
       _ =
         ∑ j : Fin r,
           cyclicRestrictₗ hN L i τ

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -658,8 +658,8 @@ theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
       (A j) (C j) (Dmat j) (hUnital j) (hCompat j)).2
   exact pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace A C E n hACE
 
-/-- The two block-ground-space restrictions produce boundary matrices with the
-left-boundary expansion
+/-- The two block-ground-space restrictions produce boundary matrices \(C^j_a\)
+and \(D^j_b\) with the left-boundary expansion
 \[
   \psi=\sum_j \alpha_j,\qquad
   \alpha_j(i_1,\ldots,i_{n+2})

--- a/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
+++ b/TNLean/MPS/ParentHamiltonian/BlockIntersectionProperty.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.LinearAlgebra.DFinsupp
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.BoundaryMatrixIdentities
 import TNLean.MPS.MPDO.BiCFDerivation.Selectors
@@ -27,39 +28,6 @@ open scoped Matrix BigOperators
 namespace MPSTensor
 
 variable {d D : ℕ}
-
-/-- A vector in the linear sum of finitely many subspaces can be written as a
-sum of vectors from those subspaces. -/
-theorem exists_sum_mem_of_mem_iSup_fin
-    {ι V : Type*} [Fintype ι]
-    [AddCommMonoid V] [Module ℂ V]
-    (p : ι → Submodule ℂ V) {v : V}
-    (hv : v ∈ ⨆ i, p i) :
-    ∃ x : ι → V, (∀ i, x i ∈ p i) ∧ v = ∑ i, x i := by
-  classical
-  refine Submodule.iSup_induction (p := p) (x := v) hv ?_ ?_ ?_
-  · intro i y hy
-    refine ⟨fun k => if k = i then y else 0, ?_, ?_⟩
-    · intro k
-      by_cases h : k = i
-      · subst k
-        simpa using hy
-      · simp [h]
-    · rw [Finset.sum_eq_single i]
-      · simp
-      · intro k _ hk
-        simp [hk]
-      · intro hi
-        exact (hi (Finset.mem_univ i)).elim
-  · refine ⟨fun _ => 0, ?_, by simp⟩
-    intro i
-    exact Submodule.zero_mem _
-  · intro y z hy hz
-    rcases hy with ⟨fy, hfy, rfl⟩
-    rcases hz with ⟨fz, hfz, rfl⟩
-    refine ⟨fun i => fy i + fz i, ?_, by simp [Finset.sum_add_distrib]⟩
-    intro i
-    exact Submodule.add_mem _ (hfy i) (hfz i)
 
 /-- The left-boundary summand in the source block-diagonal intersection proof:
 \[
@@ -364,8 +332,10 @@ theorem pgvwc07_boundary_identities_of_leftBoundaryComponent_mem_iSup
       ∀ j : Fin r, ∀ a b : Fin d, A j b * C j a = A j b * E j * A j a := by
   classical
   obtain ⟨φ, hφmem, hφsum⟩ :=
-    exists_sum_mem_of_mem_iSup_fin
-      (fun j : Fin r => groundSpace (A j) (n + 2)) hmem
+    (Submodule.mem_iSup_iff_exists_finsupp
+      (fun j : Fin r => groundSpace (A j) (n + 2)) ψ).mp hmem
+  have hφsum_univ : ψ = ∑ j : Fin r, φ j := by
+    simpa [Finsupp.sum_fintype] using hφsum.symm
   have hMatrix : ∀ j : Fin r,
       ∃ E : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
         φ j = groundSpaceMap (A j) (n + 2) E := by
@@ -417,7 +387,7 @@ theorem pgvwc07_boundary_identities_of_leftBoundaryComponent_mem_iSup
       calc
         ψ (Fin.cons a (Fin.snoc w b))
             = (∑ k : Fin r, φ k) (Fin.cons a (Fin.snoc w b)) := by
-              rw [hφsum]
+              rw [hφsum_univ]
         _ = ∑ k : Fin r, φ k (Fin.cons a (Fin.snoc w b)) := by
               simp
         _ = ∑ k : Fin r,
@@ -688,42 +658,51 @@ theorem pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
       (A j) (C j) (Dmat j) (hUnital j) (hCompat j)).2
   exact pgvwc07_sum_leftBoundaryComponents_mem_iSup_groundSpace A C E n hACE
 
-/-- One-step block intersection from block-ground-space restrictions.
-
-Let \(\psi\) be an \((n+2)\)-site vector.  Suppose that fixing the first
-physical index or the last physical index always gives a vector in
+/-- The two block-ground-space restrictions produce boundary matrices with the
+left-boundary expansion
 \[
-  \bigvee_j G_{n+1}(A^j).
+  \psi=\sum_j \alpha_j,\qquad
+  \alpha_j(i_1,\ldots,i_{n+2})
+  =
+  \operatorname{tr}(A^j_{i_{n+2}} C^j_{i_1}
+    A^j_{i_2}\cdots A^j_{i_{n+1}}),
 \]
-Under the common word-span hypothesis and the normalization
+and whose trace decompositions agree:
 \[
-  \sum_a A^j_a A^{j\dagger}_a=I,
+  \sum_j\operatorname{tr}(A^j_b C^j_a A^j_w)
+  =
+  \sum_j\operatorname{tr}(D^j_b A^j_a A^j_w).
 \]
-the vector itself lies in
-\[
-  \bigvee_j G_{n+2}(A^j).
-\]
-This is the restriction form of the open-segment step in
-Theorem 12 of arXiv:quant-ph/0608197, proof lines 1442--1452. -/
-theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
+This is the corresponding step in arXiv:quant-ph/0608197, Theorem 12,
+proof lines 1442--1452. -/
+theorem pgvwc07_trace_decompositions_of_iSup_restrictions
     {r : ℕ} {dim : Fin r → ℕ}
     (A : (j : Fin r) → MPSTensor d (dim j))
-    {n : ℕ} (hSpan : WordTupleSpanTop A n)
-    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
-    (ψ : NSiteSpace d (n + 2))
+    {n : ℕ} (ψ : NSiteSpace d (n + 2))
     (hLeft : ∀ b : Fin d,
       restrictLast ψ b ∈ ⨆ j : Fin r, groundSpace (A j) (n + 1))
     (hRight : ∀ a : Fin d,
       restrictFirst ψ a ∈ ⨆ j : Fin r, groundSpace (A j) (n + 1)) :
-    ψ ∈ ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+    ∃ C : (j : Fin r) → Fin d → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+    ∃ Dmat : (j : Fin r) → Fin d → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = ∑ j : Fin r, pgvwc07LeftBoundaryComponent (A j) (C j) n ∧
+      ∀ a b : Fin d, ∀ w : Fin n → Fin d,
+        (∑ j : Fin r,
+          Matrix.trace ((A j b * C j a) * evalWord (A j) (List.ofFn w))) =
+        (∑ j : Fin r,
+          Matrix.trace ((Dmat j b * A j a) * evalWord (A j) (List.ofFn w))) := by
   classical
   have hRightDecomp : ∀ a : Fin d,
       ∃ φ : (j : Fin r) → NSiteSpace d (n + 1),
         (∀ j : Fin r, φ j ∈ groundSpace (A j) (n + 1)) ∧
           restrictFirst ψ a = ∑ j : Fin r, φ j := by
     intro a
-    exact exists_sum_mem_of_mem_iSup_fin
-      (fun j : Fin r => groundSpace (A j) (n + 1)) (hRight a)
+    obtain ⟨φ, hφmem, hφsum⟩ :=
+      (Submodule.mem_iSup_iff_exists_finsupp
+        (fun j : Fin r => groundSpace (A j) (n + 1)) (restrictFirst ψ a)).mp
+        (hRight a)
+    refine ⟨fun j => φ j, hφmem, ?_⟩
+    simpa [Finsupp.sum_fintype] using hφsum.symm
   choose φ hφmem hφsum using hRightDecomp
   have hRightMatrix : ∀ j : Fin r, ∀ a : Fin d,
       ∃ C : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
@@ -739,8 +718,12 @@ theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
         (∀ j : Fin r, χ j ∈ groundSpace (A j) (n + 1)) ∧
           restrictLast ψ b = ∑ j : Fin r, χ j := by
     intro b
-    exact exists_sum_mem_of_mem_iSup_fin
-      (fun j : Fin r => groundSpace (A j) (n + 1)) (hLeft b)
+    obtain ⟨χ, hχmem, hχsum⟩ :=
+      (Submodule.mem_iSup_iff_exists_finsupp
+        (fun j : Fin r => groundSpace (A j) (n + 1)) (restrictLast ψ b)).mp
+        (hLeft b)
+    refine ⟨fun j => χ j, hχmem, ?_⟩
+    simpa [Finsupp.sum_fintype] using hχsum.symm
   choose χ hχmem hχsum using hLeftDecomp
   have hLeftMatrix : ∀ j : Fin r, ∀ b : Fin d,
       ∃ Dmat : Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
@@ -816,6 +799,27 @@ theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
             rw [Fin.cons_snoc_eq_snoc_cons]
       _ = ∑ j : Fin r,
         Matrix.trace ((Dmat j b * A j a) * evalWord (A j) (List.ofFn w)) := hLeftEval
+  exact ⟨C, Dmat, hψ, hCoeff⟩
+
+/-- One-step block intersection from block-ground-space restrictions:
+if both one-boundary restrictions of \(\psi\) lie in
+\(\bigvee_j G_{n+1}(A^j)\), then, under the common word-span and unital
+hypotheses, \(\psi\in\bigvee_j G_{n+2}(A^j)\).  This is the restriction form of
+the open-segment step in arXiv:quant-ph/0608197, Theorem 12, proof lines
+1442--1452. -/
+theorem pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions
+    {r : ℕ} {dim : Fin r → ℕ}
+    (A : (j : Fin r) → MPSTensor d (dim j))
+    {n : ℕ} (hSpan : WordTupleSpanTop A n)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (ψ : NSiteSpace d (n + 2))
+    (hLeft : ∀ b : Fin d,
+      restrictLast ψ b ∈ ⨆ j : Fin r, groundSpace (A j) (n + 1))
+    (hRight : ∀ a : Fin d,
+      restrictFirst ψ a ∈ ⨆ j : Fin r, groundSpace (A j) (n + 1)) :
+    ψ ∈ ⨆ j : Fin r, groundSpace (A j) (n + 2) := by
+  rcases pgvwc07_trace_decompositions_of_iSup_restrictions A ψ hLeft hRight with
+    ⟨C, Dmat, hψ, hCoeff⟩
   exact pgvwc07_mem_iSup_groundSpace_of_trace_decomposition
     A hSpan C Dmat hUnital hCoeff ψ hψ
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -717,11 +717,98 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
     \]
 \end{proof}
 
+\begin{lemma}[Trace decompositions from fixed-boundary restrictions]
+    \label{lem:pgvwc07_trace_decompositions_from_block_restrictions}
+    \lean{MPSTensor.pgvwc07_trace_decompositions_of_iSup_restrictions}
+    \leanok
+    Let $A^1,\ldots,A^g$ be block tensors.  If
+    $\psi\in(\C^d)^{\otimes(n+2)}$ satisfies
+    \[
+        \psi(a,-)\in\bigvee_jG_{n+1}(A^j),
+        \qquad
+        \psi(-,b)\in\bigvee_jG_{n+1}(A^j)
+    \]
+    for every physical index $a,b$, then there are matrices
+    $C^j_a$ and $D^j_b$ such that
+    \[
+        \psi=\sum_j\alpha_j,
+        \qquad
+        \alpha_j(i_1,\ldots,i_{n+2})
+        =
+        \tr\!\left(
+        A^j_{i_{n+2}}C^j_{i_1}
+        A^j_{i_2}\cdots A^j_{i_{n+1}}
+        \right),
+    \]
+    and, for every middle word $w$ of length $n$,
+    \[
+        \sum_j\tr\!\left(A^j_bC^j_aA^j_w\right)
+        =
+        \sum_j\tr\!\left(D^j_bA^j_aA^j_w\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Choose finite decompositions of the fixed-boundary vectors:
+    \[
+        \psi(a,i_2,\ldots,i_{n+2})
+        =
+        \sum_j
+        \tr\!\left(
+        A^j_{i_2}\cdots A^j_{i_{n+2}}C^j_a
+        \right),
+    \]
+    and
+    \[
+        \psi(i_1,\ldots,i_{n+1},b)
+        =
+        \sum_j
+        \tr\!\left(
+        A^j_{i_1}\cdots A^j_{i_{n+1}}D^j_b
+        \right).
+    \]
+    For every middle word $w$,
+    \[
+        \psi(a,w,b)
+        =
+        \sum_j\tr\!\left(A^j_wA^j_bC^j_a\right)
+        =
+        \sum_j\tr\!\left(A^j_bC^j_aA^j_w\right),
+    \]
+    and the second decomposition gives
+    \[
+        \psi(a,w,b)
+        =
+        \sum_j\tr\!\left(A^j_aA^j_wD^j_b\right)
+        =
+        \sum_j\tr\!\left(D^j_bA^j_aA^j_w\right).
+    \]
+    These two formulas give the displayed equality of trace expressions. The
+    first decomposition also gives
+    \[
+        \psi(i_1,\ldots,i_{n+2})
+        =
+        \sum_j
+        \tr\!\left(
+        A^j_{i_2}\cdots A^j_{i_{n+2}}C^j_{i_1}
+        \right)
+        =
+        \sum_j
+        \tr\!\left(
+        A^j_{i_{n+2}}C^j_{i_1}
+        A^j_{i_2}\cdots A^j_{i_{n+1}}
+        \right),
+    \]
+    by cyclicity of the trace.
+\end{proof}
+
 \begin{lemma}[One-step block intersection from block restrictions]
     \label{lem:block_restrictions_mem_block_ground_spaces}
     \lean{MPSTensor.pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions}
     \leanok
-    \uses{lem:left_boundary_trace_decomposition_mem_block_ground_spaces}
+    \uses{lem:pgvwc07_trace_decompositions_from_block_restrictions,
+        lem:left_boundary_trace_decomposition_mem_block_ground_spaces}
     Let $A^1,\ldots,A^g$ be block tensors with common word-span separation at
     length $n$, and suppose
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences.tex
@@ -784,8 +784,13 @@ $\bigvee_jG_{n+2}(A^j)$ and to obtain the one-step block-intersection identity.
         =
         \sum_j\tr\!\left(D^j_bA^j_aA^j_w\right).
     \]
-    These two formulas give the displayed equality of trace expressions. The
-    first decomposition also gives
+    Hence
+    \[
+        \sum_j\tr\!\left(A^j_bC^j_aA^j_w\right)
+        =
+        \sum_j\tr\!\left(D^j_bA^j_aA^j_w\right).
+    \]
+    For an arbitrary word \((i_1,\ldots,i_{n+2})\), the first decomposition gives
     \[
         \psi(i_1,\ldots,i_{n+2})
         =


### PR DESCRIPTION
### Motivation

The one-step block-intersection proof already constructs the two trace decompositions appearing in the PGVWC07 argument, but that construction was internal to `pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions`. Exposing it as a named theorem gives the boundary-comparison work a precise intermediate statement to cite without claiming the full #2971 gap is closed.

### Description

- Add `MPSTensor.pgvwc07_trace_decompositions_of_iSup_restrictions`, producing the matrices `C^j_a` and `D^j_b`, the left-boundary expansion of `ψ`, and the equality of the two boundary trace expressions from fixed-boundary block-ground-space restrictions.
- Reorganize `pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions` to use the new theorem before applying the existing trace-decomposition membership lemma.
- Replace the temporary finite-supremum helper by Mathlib's `Submodule.mem_iSup_iff_exists_finsupp`, keeping `BlockIntersectionProperty.lean` below the 1000-line Lean file limit.
- Add the matching blueprint lemma `lem:pgvwc07_trace_decompositions_from_block_restrictions` and display the coefficient comparison equations in its proof.

Addresses #2971.

### Testing

- `python3 scripts/check_oversized_lean_files.py --root .`
- `lake build TNLean.MPS.ParentHamiltonian.BlockIntersectionProperty -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof refactor and API extraction in formal Lean parent-Hamiltonian theory; Mathlib replacement is behavior-preserving at the mathematical level, with no runtime or security surface.
> 
> **Overview**
> Adds **`MPSTensor.pgvwc07_trace_decompositions_of_iSup_restrictions`**, a named intermediate theorem that builds boundary matrices `C^j_a` and `D^j_b`, the left-boundary expansion of `ψ`, and equality of the two boundary trace sums from fixed-boundary block-ground-space restrictions—without yet claiming full ground-space membership.
> 
> **`pgvwc07_mem_iSup_groundSpace_of_iSup_restrictions`** is refactored to obtain those decompositions via the new theorem, then apply the existing trace-decomposition membership lemma.
> 
> The local **`exists_sum_mem_of_mem_iSup_fin`** helper is removed in favor of Mathlib’s **`Submodule.mem_iSup_iff_exists_finsupp`** (with `Finsupp.sum_fintype` for finset sums) in chain, crossing-trace, and block-intersection proofs, trimming **`BlockIntersectionProperty.lean`**.
> 
> The blueprint gains **`lem:pgvwc07_trace_decompositions_from_block_restrictions`**; the one-step block-intersection lemma cites it before the membership step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96770495f169fd49e49c1ac2ff05cde508744fcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->