### PR TITLE
feat(MPS/ParentHamiltonian): derive boundary trace comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -28,6 +28,54 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+/-- The \(C^j\) comparison with the boundary expression implies the corresponding
+boundary trace comparison.
+
+For fixed block-diagonal boundary matrices \(X_j\), suppose the opened-boundary
+matrices \(C^j_{i,\rho}\) satisfy
+\[
+  A^j_\beta C^j_{i,\rho}
+  =
+  ((\mu_j^NX_j)A^j_\beta)A^j_\rho
+\]
+at every boundary-crossing interval. Multiplying by the middle word \(A^j_w\),
+taking traces, and summing over \(j\) gives the boundary trace comparison used
+in arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1451. Here
+\((\mu_j^NX_j)A^j_\beta\) plays the role of \(D^j_\beta\) in the source
+proof. -/
+theorem blockDiagonal_boundary_trace_decomposition_of_pgvwc_comparison
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    {m L N : ℕ}
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (C : ∀ (j : Fin r) (_ : Fin N),
+      (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hComparison : ∀ (j : Fin r) (i : Fin N),
+      N < i.val + L →
+        ∀ ρ : Fin (N - L) → Fin d,
+          ∀ β : Fin (i.val + L - N) → Fin d,
+            evalWord (A j) (List.ofFn β) * C j i ρ =
+              (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                evalWord (A j) (List.ofFn ρ)) :
+    ∀ i : Fin N,
+      N < i.val + L →
+        ∀ ρ : Fin (N - L) → Fin d,
+          ∀ β : Fin (i.val + L - N) → Fin d,
+            ∀ w : Fin m → Fin d,
+              (∑ j : Fin r,
+                Matrix.trace
+                  ((evalWord (A j) (List.ofFn β) * C j i ρ) *
+                    evalWord (A j) (List.ofFn w))) =
+              (∑ j : Fin r,
+                Matrix.trace
+                  ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                      evalWord (A j) (List.ofFn ρ)) *
+                    evalWord (A j) (List.ofFn w))) := by
+  intro i hi ρ β w
+  refine Finset.sum_congr rfl ?_
+  intro j _hj
+  rw [hComparison j i hi ρ β]
+
 /-- Source trace decompositions give the periodic constraints for each block
 under block injectivity.
 

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -28,8 +28,8 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-- The \(C^j\) comparison with the boundary expression implies the corresponding
-boundary trace comparison.
+/-- The opened-boundary \(C^j\)-comparison with the block boundary expression
+implies the corresponding boundary trace comparison.
 
 For fixed block-diagonal boundary matrices \(X_j\), suppose the opened-boundary
 matrices \(C^j_{i,\rho}\) satisfy

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -871,6 +871,38 @@ in both cases.
     then gives the single-block periodic constraints.
 \end{proof}
 
+\begin{lemma}[Boundary comparison implies trace comparison]
+    \label{lem:block_diagonal_boundary_trace_decomposition_from_pgvwc_comparison}
+    \lean{MPSTensor.blockDiagonal_boundary_trace_decomposition_of_pgvwc_comparison}
+    \leanok
+    Fix block-diagonal boundary matrices $X_j$. Suppose the opened-boundary
+    matrices $C^j_{i,\rho}$ satisfy, for every boundary-crossing interval $i$,
+    every outside word $\rho$, and every word $\beta$ before the cut,
+    \[
+        A^j_\beta C^j_{i,\rho}
+        =
+        ((\mu_j^NX_j)A^j_\beta)A^j_\rho .
+    \]
+    Then for every middle word $w$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Substituting the comparison identity in each summand gives
+    \[
+        \tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    Summing over \(j\) gives the conclusion.
+\end{proof}
+
 \begin{lemma}[Boundary trace comparisons give single-block constraints]
     \label{lem:block_diagonal_boundary_component_trace_decomposition_injective}
     \lean{MPSTensor.blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -894,7 +894,7 @@ in both cases.
 
 \begin{proof}
     \leanok
-    Substituting the comparison identity in each summand gives
+    Substituting the displayed comparison identity in each summand gives
     \[
         \tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
         =


### PR DESCRIPTION
### Motivation
- Issue #2971 tracks removal of residual external PGVWC07 boundary-comparison hypotheses.
- One local algebraic substep is that the pointwise opened-boundary comparison
  `A^j_β C^j_{i,ρ} = ((μ_j^N X_j)A^j_β)A^j_ρ` already implies the corresponding summed boundary trace comparison after multiplying by the middle word and summing over blocks.

### Description
- Adds `MPSTensor.blockDiagonal_boundary_trace_decomposition_of_pgvwc_comparison`.
- Records the matching blueprint lemma `lem:block_diagonal_boundary_trace_decomposition_from_pgvwc_comparison` with `\leanok`.
- This is a partial step only: it does not remove the boundary-representation hypothesis or finish that issue.

### Testing
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`

---
Refs #2971
Refs #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive proof (algebraic substitution in a sum) in MPS parent-Hamiltonian formalization; no behavior or API changes outside Lean/blueprint docs.
> 
> **Overview**
> Adds a formal bridge from the **opened-boundary matrix comparison** \(A^j_\beta C^j_{i,\rho} = ((\mu_j^N X_j)A^j_\beta)A^j_\rho\) to the **summed boundary trace equality** used in PGVWC07 Theorem 12 (after inserting the middle word \(A^j_w\) and summing over blocks).
> 
> **Lean:** new theorem `MPSTensor.blockDiagonal_boundary_trace_decomposition_of_pgvwc_comparison` in `BNTBlockDiagonalTraceDecomposition.lean`, proved by rewriting each summand with `hComparison` via `Finset.sum_congr`.
> 
> **Blueprint:** matching lemma `lem:block_diagonal_boundary_trace_decomposition_from_pgvwc_comparison` with `\leanok`, placed before the trace-decomposition-to-constraints lemma chain.
> 
> This is an incremental formalization step toward dropping assumed PGVWC boundary-comparison hypotheses (#2971); it does not yet wire the result into downstream theorems or remove the trace-decomposition hypothesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b71e955f09571b1bd8707c4c50513063cc646ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->