### PR TITLE
feat(MPS/ParentHamiltonian): derive boundary components from comparison

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -230,6 +230,81 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of
     blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
       μ A hN hLN X hTraceSpan hBlk hUnital hNlarge C hCoeff
 
+/-- The \(C^j,D^j\) boundary comparison gives periodic single-block states
+from an explicit block-diagonal boundary representation.
+
+Assume the vector has already been written with block-diagonal boundary
+conditions \(X_j\). If, for those same boundary conditions, the source
+boundary comparison
+\[
+  A^j_\beta C^j_{i,\rho}
+  =
+  ((\mu_j^NX_j)A^j_\beta)A^j_\rho
+\]
+holds at each boundary-crossing interval, then the comparison identity implies,
+for every boundary-crossing interval \(i\), outside word \(\rho\), word
+\(\beta\) before the cut, and middle word \(w\),
+\[
+  \sum_j\operatorname{tr}\!\bigl(A^j_\beta C^j_{i,\rho}A^j_w\bigr)
+  =
+  \sum_j\operatorname{tr}\!\bigl(((\mu_j^NX_j)A^j_\beta)
+    A^j_\rho A^j_w\bigr).
+\]
+The trace-decomposition theorem then gives
+\[
+  \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
+\]
+for every block \(j\).
+
+This is the explicit-boundary form of the block-diagonal boundary-condition
+step in arXiv:2011.12127, Section IV.C, lines 2126--2128, using the
+specialization \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) from
+arXiv:quant-ph/0608197, Theorem 12, lines 1446--1451.
+
+**Scope restriction (boundary representation):** The block-diagonal boundary
+representation of \(\psi\) is a hypothesis here. Removing this remaining input
+is tracked in issue 2971 and documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_of_boundary
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    {m L₀ L N : ℕ}
+    (hTraceSpan : WordTupleSpanTop A m)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    (hN : 0 < N) (hLN : L ≤ N)
+    (hNlarge : L + L₀ ≤ N)
+    {ψ : NSiteSpace d N}
+    (hBoundary :
+      ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)))
+    (hComparison :
+      ∀ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+        ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+          ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) →
+          ∃ C : ∀ (j : Fin r) (_ : Fin N),
+            (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+            ∀ (j : Fin r) (i : Fin N),
+              N < i.val + L →
+                ∀ ρ : Fin (N - L) → Fin d,
+                  ∀ β : Fin (i.val + L - N) → Fin d,
+                    evalWord (A j) (List.ofFn β) * C j i ρ =
+                      (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                        evalWord (A j) (List.ofFn ρ)) :
+    ∃ X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)) ∧
+      ∀ j : Fin r,
+        groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
+  refine
+    exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary
+      μ A hTraceSpan hBlk hUnital hN hLN hNlarge hBoundary ?_
+  intro X hψX
+  obtain ⟨C, hCompat⟩ := hComparison X hψX
+  refine ⟨C, ?_⟩
+  exact blockDiagonal_boundary_trace_decomposition_of_pgvwc_comparison μ A X C hCompat
+
 /-- Source trace decompositions upgrade a block-diagonal boundary representation
 to periodic single-block states.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1004,6 +1004,65 @@ in both cases.
     $\Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)$ for every block $j$.
 \end{proof}
 
+\begin{lemma}[$C^j$ boundary comparison with a block-diagonal representation]
+    \label{lem:block_diagonal_boundary_periodic_components_from_pgvwc_comparison_boundary}
+    \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_of_boundary}
+    \leanok
+    \uses{lem:block_diagonal_boundary_trace_decomposition_from_pgvwc_comparison,
+        lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
+    Assume $0<N$, $L\le N$, and $L+L_0\le N$. Suppose each block $A_j$
+    is $L_0$-block-injective and satisfies
+    \[
+        \sum_a A^j_aA^{j\dagger}_a=I .
+    \]
+    Assume also that the simultaneous tuples $w\mapsto(A^1_w,\ldots,A^g_w)$
+    at the middle-word length $m$ span the full product algebra
+    $\prod_j\MN{D_j}$. Let
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    for some block-diagonal boundary conditions $X_j$. Suppose that whenever
+    $\psi$ has such a representation, there are matrices $C^j_{i,\rho}$
+    such that, for every boundary-crossing interval $i$, every outside word
+    $\rho$ of length $N-L$, and every word $\beta$ of length $i+L-N$ before
+    the cut,
+    \[
+        A^j_\beta C^j_{i,\rho}
+        =
+        \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+    \]
+    Then there are block-diagonal boundary conditions $X_j$ with
+    \[
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+    \]
+    and, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_trace_decomposition_from_pgvwc_comparison,
+        lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
+    Choose a block-diagonal boundary representation of $\psi$. For that
+    representation,
+    Lemma~\ref{lem:block_diagonal_boundary_trace_decomposition_from_pgvwc_comparison}
+    gives, for every boundary-crossing interval $i$, outside word $\rho$,
+    word $\beta$ before the cut, and middle word $w$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_w\right)
+        =
+        \sum_j\tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\right).
+    \]
+    Applying
+    Lemma~\ref{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition_boundary}
+    to these trace comparisons gives, for every $j$,
+    \[
+        \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j).
+    \]
+\end{proof}
+
 \begin{lemma}[Boundary trace comparisons give periodic-boundary single-block states]
     \label{lem:block_diagonal_boundary_periodic_components_from_trace_decomposition}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1}


### PR DESCRIPTION
### Motivation

- Continues the formalization of block-diagonal parent-Hamiltonian reductions for MPS, tracked in #2971.
- The source step is the Pérez-García–Verstraete–Wolf–Cirac comparison (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446–1456) together with the block-diagonal boundary-condition discussion in arXiv:2011.12127, Section IV.C, lines 2126–2128.
- Provides the next partial step: composing the PGVWC boundary comparison lemma with the explicit-boundary trace-decomposition theorem to place single-block periodic components in the corresponding finite-chain ground spaces.

### Description

- Modified `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`: adds lemma `MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_of_boundary`, which proves that given a vector with an explicit block-diagonal boundary representation and the PGVWC `C^j` boundary comparison for that representation, the resulting single-block periodic components lie in the corresponding finite-chain ground spaces.
- Modified `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex`: adds the corresponding blueprint lemma for the explicit block-diagonal boundary representation case.
- The remaining source-faithful boundary-representation step is deliberately not claimed; the hypothesis is marked as a scope restriction and tracked in #2971 and `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/check_oversized_lean_files.py --root .`

---
Addresses #2971

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit de22c82e2da195603b4fe9e0c7c7c05104125e2f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only formalization with no runtime, auth, or data paths; changes compose existing lemmas under documented scope restrictions.
> 
> **Overview**
> Adds **`exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_of_boundary`**, which shows that when a state already has an explicit block-diagonal boundary representation, the PGVWC **matrix** identity \(A^j_\beta C^j_{i,\rho} = ((\mu_j^N X_j)A^j_\beta)A^j_\rho\) is enough to place each \(\Gamma_N^{A_j}(\mu_j^N X_j)\) in the finite-chain ground space \(\mathcal G_{N,L}(A_j)\).
> 
> The proof **reuses** the existing trace-decomposition boundary theorem: it obtains \(C\) from the comparison hypothesis and passes **`blockDiagonal_boundary_trace_decomposition_of_pgvwc_comparison`** to supply the trace equalities. The block-diagonal boundary representation remains an explicit hypothesis (issue **#2971**).
> 
> The blueprint chapter gains the matching lemma **`block_diagonal_boundary_periodic_components_from_pgvwc_comparison_boundary`**, wired to the same Lean declaration and proof chain (comparison → trace decomposition → periodic components).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de1e77fbf5d507848d73ec5c64c7b12bc9c69cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->