### PR TITLE
refactor(Channel/Semigroup): use native MatrixCLM instances

### DIFF
--- a/TNLean/Algebra/MatrixOperatorSpace.lean
+++ b/TNLean/Algebra/MatrixOperatorSpace.lean
@@ -40,6 +40,8 @@ attribute [scoped instance]
   Matrix.linftyOpNormedRing
   Matrix.linftyOpNormedAlgebra
 
+open scoped TNOperatorSpace
+
 section MatrixInstances
 
 variable (n : Type*) [Fintype n] [DecidableEq n]
@@ -82,27 +84,20 @@ instance : LinearMap.CompatibleSMul (Matrix n n ℂ) ℂ ℝ ℂ where
 
 end MatrixInstances
 
-@[implicit_reducible] def instNormedAddCommGroupMatrixCLM
-    (n : Type*) [Fintype n] [DecidableEq n] :
-    NormedAddCommGroup (TNLean.MatrixCLM n) :=
-  ContinuousLinearMap.toNormedAddCommGroup
-
-instance instENormedAddCommMonoidMatrixCLM
-    (n : Type*) [Fintype n] [DecidableEq n] :
-    ENormedAddCommMonoid (TNLean.MatrixCLM n) := by
-  letI : NormedAddCommGroup (TNLean.MatrixCLM n) :=
-    instNormedAddCommGroupMatrixCLM n
-  exact NormedAddCommGroup.toENormedAddCommMonoid
-
 @[implicit_reducible] instance (priority := 100) instNormedRingMatrixCLM
     (n : Type*) [Fintype n] [DecidableEq n] :
     NormedRing (TNLean.MatrixCLM n) :=
   ContinuousLinearMap.toNormedRing
 
-instance instIsUniformAddGroupMatrixCLM
+@[implicit_reducible] instance instNormedAlgebraComplexMatrixCLM
     (n : Type*) [Fintype n] [DecidableEq n] :
-    IsUniformAddGroup (TNLean.MatrixCLM n) :=
-  ContinuousLinearMap.isUniformAddGroup
+    NormedAlgebra ℂ (TNLean.MatrixCLM n) :=
+  ContinuousLinearMap.toNormedAlgebra
+
+instance instENormedAddCommMonoidMatrixCLM
+    (n : Type*) [Fintype n] [DecidableEq n] :
+    ENormedAddCommMonoid (TNLean.MatrixCLM n) :=
+  NormedAddCommGroup.toENormedAddCommMonoid
 
 instance instPseudoMetrizableSpaceMatrixCLM
     (n : Type*) [Fintype n] [DecidableEq n] :
@@ -113,55 +108,6 @@ instance instIsTopologicalRingMatrixCLM
     (n : Type*) [Fintype n] [DecidableEq n] :
     IsTopologicalRing (TNLean.MatrixCLM n) :=
   NonUnitalSeminormedRing.toIsTopologicalRing
-
-@[implicit_reducible] instance instNormedSpaceComplexMatrixCLM
-    (n : Type*) [Fintype n] [DecidableEq n] :
-    NormedSpace ℂ (TNLean.MatrixCLM n) :=
-  ContinuousLinearMap.toNormedSpace
-
-instance instIsBoundedSMulComplexMatrixCLM
-    (n : Type*) [Fintype n] [DecidableEq n] :
-    IsBoundedSMul ℂ (TNLean.MatrixCLM n) :=
-  IsBoundedSMul.of_norm_smul_le (fun z T =>
-    (instNormedSpaceComplexMatrixCLM n).norm_smul_le z T)
-
-instance instContinuousSMulComplexMatrixCLM
-    (n : Type*) [Fintype n] [DecidableEq n] :
-    @ContinuousSMul ℂ (TNLean.MatrixCLM n) _ _
-      (@UniformSpace.toTopologicalSpace (TNLean.MatrixCLM n) inferInstance) where
-  continuous_smul := by
-    refine (@ContinuousSMul.of_nhds_zero ℂ (TNLean.MatrixCLM n) _ _ _ _ _ _ _
-      ?_ ?_ ?_).continuous_smul
-    · exact Filter.Tendsto.zero_smul_isBoundedUnder_le
-        (show Tendsto (fun p : ℂ × TNLean.MatrixCLM n => p.1)
-          (𝓝 (0 : ℂ) ×ˢ 𝓝 (0 : TNLean.MatrixCLM n)) (𝓝 (0 : ℂ)) from
-          tendsto_fst)
-        ((show Tendsto (fun p : ℂ × TNLean.MatrixCLM n => p.2)
-          (𝓝 (0 : ℂ) ×ˢ 𝓝 (0 : TNLean.MatrixCLM n))
-          (𝓝 (0 : TNLean.MatrixCLM n)) from tendsto_snd).norm.isBoundedUnder_le)
-    · intro T
-      exact Filter.Tendsto.zero_smul_isBoundedUnder_le
-        (show Tendsto (fun z : ℂ => z) (𝓝 (0 : ℂ)) (𝓝 (0 : ℂ)) from tendsto_id)
-        ((show Tendsto (fun _ : ℂ => T) (𝓝 (0 : ℂ)) (𝓝 T) from
-          tendsto_const_nhds).norm.isBoundedUnder_le)
-    · intro z
-      exact Filter.IsBoundedUnder.smul_tendsto_zero
-        ((show Tendsto (fun _ : TNLean.MatrixCLM n => z)
-          (𝓝 (0 : TNLean.MatrixCLM n)) (𝓝 z) from
-          tendsto_const_nhds).norm.isBoundedUnder_le)
-        (show Tendsto (fun T : TNLean.MatrixCLM n => T)
-          (𝓝 (0 : TNLean.MatrixCLM n)) (𝓝 (0 : TNLean.MatrixCLM n)) from tendsto_id)
-
-@[implicit_reducible] instance instNormedAlgebraComplexMatrixCLM
-    (n : Type*) [Fintype n] [DecidableEq n] :
-    NormedAlgebra ℂ (TNLean.MatrixCLM n) :=
-  ContinuousLinearMap.toNormedAlgebra
-
-@[implicit_reducible] instance instNormedSpaceRealMatrixCLM
-    (n : Type*) [Fintype n] [DecidableEq n] :
-    @NormedSpace ℝ (TNLean.MatrixCLM n) _
-      ContinuousLinearMap.toNormedAddCommGroup.toSeminormedAddCommGroup :=
-  ContinuousLinearMap.toNormedSpace
 
 instance (n : Type*) [Fintype n] [DecidableEq n] :
     ContinuousSMul ℝ (TNLean.MatrixCLM n) where
@@ -201,6 +147,37 @@ instance (n : Type*) [Fintype n] [DecidableEq n] :
 instance (n : Type*) [Fintype n] [DecidableEq n] :
     FiniteDimensional ℂ (TNLean.MatrixCLM n) :=
   (Module.End.toContinuousLinearMap (Matrix n n ℂ)).toLinearEquiv.finiteDimensional
+
+instance (n : Type*) [Fintype n] [DecidableEq n] :
+    IsUniformAddGroup (TNLean.MatrixCLM n) :=
+  ContinuousLinearMap.isUniformAddGroup
+
+instance instContinuousSMulComplexMatrixCLM
+    (n : Type*) [Fintype n] [DecidableEq n] :
+    @ContinuousSMul ℂ (TNLean.MatrixCLM n) _ _
+      (@UniformSpace.toTopologicalSpace (TNLean.MatrixCLM n) inferInstance) where
+  continuous_smul := by
+    refine (@ContinuousSMul.of_nhds_zero ℂ (TNLean.MatrixCLM n) _ _ _ _ _ _ _
+      ?_ ?_ ?_).continuous_smul
+    · exact Filter.Tendsto.zero_smul_isBoundedUnder_le
+        (show Tendsto (fun p : ℂ × TNLean.MatrixCLM n => p.1)
+          (𝓝 (0 : ℂ) ×ˢ 𝓝 (0 : TNLean.MatrixCLM n)) (𝓝 (0 : ℂ)) from
+          tendsto_fst)
+        ((show Tendsto (fun p : ℂ × TNLean.MatrixCLM n => p.2)
+          (𝓝 (0 : ℂ) ×ˢ 𝓝 (0 : TNLean.MatrixCLM n))
+          (𝓝 (0 : TNLean.MatrixCLM n)) from tendsto_snd).norm.isBoundedUnder_le)
+    · intro T
+      exact Filter.Tendsto.zero_smul_isBoundedUnder_le
+        (show Tendsto (fun z : ℂ => z) (𝓝 (0 : ℂ)) (𝓝 (0 : ℂ)) from tendsto_id)
+        ((show Tendsto (fun _ : ℂ => T) (𝓝 (0 : ℂ)) (𝓝 T) from
+          tendsto_const_nhds).norm.isBoundedUnder_le)
+    · intro z
+      exact Filter.IsBoundedUnder.smul_tendsto_zero
+        ((show Tendsto (fun _ : TNLean.MatrixCLM n => z)
+          (𝓝 (0 : TNLean.MatrixCLM n)) (𝓝 z) from
+          tendsto_const_nhds).norm.isBoundedUnder_le)
+        (show Tendsto (fun T : TNLean.MatrixCLM n => T)
+          (𝓝 (0 : TNLean.MatrixCLM n)) (𝓝 (0 : TNLean.MatrixCLM n)) from tendsto_id)
 
 instance (n : Type*) [Fintype n] [DecidableEq n] :
     CompleteSpace (TNLean.MatrixCLM n) :=

--- a/TNLean/Channel/Semigroup/CPClosure.lean
+++ b/TNLean/Channel/Semigroup/CPClosure.lean
@@ -265,7 +265,7 @@ private theorem hasSum_expSemigroup_series
     _ _ _
     ContinuousLinearMap.toNormedRing
     ContinuousLinearMap.toNormedAlgebra
-    (TNOperatorSpace.instCompleteSpaceMatrixCLM (Fin D))
+    inferInstance
     (((t : ℂ) • endEquiv (D := D) L))
 
 /-- If `L` itself is completely positive, then `exp(tL)` is completely positive for all `t ≥ 0`. -/

--- a/TNLean/Channel/Semigroup/Dissipative.lean
+++ b/TNLean/Channel/Semigroup/Dissipative.lean
@@ -204,7 +204,7 @@ theorem expSemigroup_dissipativeDrift_apply
       exact @NormedSpace.exp_add_of_commute (MatrixCLM (Fin D))
         ContinuousLinearMap.toNormedRing
         inferInstance
-        (TNOperatorSpace.instCompleteSpaceMatrixCLM (Fin D))
+        inferInstance
         (x := leftMulCLMAlgHom D (-(t : ℂ) • κ))
         (y := rightMulCLMAlgHom D (MulOpposite.op (-(t : ℂ) • κᴴ)))
         hcomm

--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -42,8 +42,7 @@ noncomputable section
 variable {D : ℕ}
 
 local instance instEulerNormOneClassMatrixCLM [NeZero D] :
-    @NormOneClass (MatrixCLM (Fin D))
-      (TNOperatorSpace.instNormedRingMatrixCLM (Fin D)).toNorm _ := by
+    NormOneClass (MatrixCLM (Fin D)) := by
   constructor
   change ‖(ContinuousLinearMap.id ℂ (Matrix (Fin D) (Fin D) ℂ))‖ = 1
   exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := Matrix (Fin D) (Fin D) ℂ)
@@ -307,10 +306,7 @@ private theorem norm_expSemigroupCLM_sub_one_add_smul_le [NeZero D]
     (A : sgCLM D) {s : ℝ} (hs : 0 ≤ s) :
     ‖expSemigroupCLM A s - (1 + (s : ℂ) • A)‖ ≤ s ^ 2 * ‖A‖ ^ 2 * Real.exp (s * ‖A‖) := by
   have hrem := @norm_exp_sub_one_sub_self_le (sgCLM D)
-    (TNOperatorSpace.instNormedRingMatrixCLM (Fin D))
-    (TNOperatorSpace.instNormedAlgebraComplexMatrixCLM (Fin D))
-    (TNOperatorSpace.instCompleteSpaceMatrixCLM (Fin D))
-    (instNormOneClassSgCLM (D := D))
+    inferInstance inferInstance inferInstance (instNormOneClassSgCLM (D := D))
     (((s : ℂ) • A))
   have hnorm :
       expSemigroupCLM A s - (1 + (s : ℂ) • A) =

--- a/TNLean/Channel/Semigroup/ProductFormula.lean
+++ b/TNLean/Channel/Semigroup/ProductFormula.lean
@@ -39,8 +39,7 @@ section TrotterEstimates
 variable {D : ℕ}
 
 local instance instNormOneClassMatrixCLM [NeZero D] :
-    @NormOneClass (MatrixCLM (Fin D))
-      (TNOperatorSpace.instNormedRingMatrixCLM (Fin D)).toNorm _ := by
+    NormOneClass (MatrixCLM (Fin D)) := by
   constructor
   change ‖(ContinuousLinearMap.id ℂ (Matrix (Fin D) (Fin D) ℂ))‖ = 1
   exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := Matrix (Fin D) (Fin D) ℂ)
@@ -80,10 +79,7 @@ theorem norm_expSemigroupCLM_le [NeZero D]
     ‖expSemigroupCLM A t‖ ≤ Real.exp (t * ‖A‖) := by
   haveI := instNormOneClassMatrixCLM (D := D)
   have h := @norm_exp_le_real_exp_norm (MatrixCLM (Fin D))
-    (TNOperatorSpace.instNormedRingMatrixCLM (Fin D))
-    (TNOperatorSpace.instNormedAlgebraComplexMatrixCLM (Fin D))
-    (TNOperatorSpace.instCompleteSpaceMatrixCLM (Fin D))
-    (instNormOneClassMatrixCLM (D := D))
+    inferInstance inferInstance inferInstance (instNormOneClassMatrixCLM (D := D))
     (((t : ℂ) • A))
   have habs : |t| = t := abs_of_nonneg ht
   change ‖NormedSpace.exp (((t : ℂ) • A))‖ ≤ Real.exp (t * ‖A‖)
@@ -148,8 +144,7 @@ theorem norm_pow_sub_pow_le_of_norm_le [NeZero D]
         _ ≤ M ^ m * ‖A - B‖ + ((m : ℝ) * M ^ m * ‖A - B‖) * M := by
               gcongr
               · haveI := instNormOneClassMatrixCLM (D := D)
-                exact (@norm_pow_le (MatrixCLM (Fin D))
-                  (TNOperatorSpace.instNormedRingMatrixCLM (Fin D)).toSeminormedRing
+                exact (@norm_pow_le (MatrixCLM (Fin D)) inferInstance
                   (instNormOneClassMatrixCLM (D := D)) A m).trans <|
                   pow_le_pow_left₀ (show 0 ≤ ‖A‖ from norm_nonneg _) hA _
         _ = M ^ m * ‖A - B‖ + (m : ℝ) * M ^ (m + 1) * ‖A - B‖ := by

--- a/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
@@ -32,8 +32,7 @@ variable {D : ℕ}
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
 local instance instSubsequenceNormOneClassMatrixCLM [NeZero D] :
-    @NormOneClass (Mat →L[ℂ] Mat)
-      (TNOperatorSpace.instNormedRingMatrixCLM (Fin D)).toNorm _ := by
+    NormOneClass (Mat →L[ℂ] Mat) := by
   constructor
   change ‖(ContinuousLinearMap.id ℂ Mat)‖ = 1
   exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := Mat)
@@ -170,10 +169,7 @@ private theorem norm_expSemigroupCLM_taylor_bound [NeZero D]
       ‖NormedSpace.exp ((s : ℂ) • E) - 1 - (s : ℂ) • E‖ ≤
         ‖((s : ℂ) • E)‖ ^ 2 * Real.exp ‖((s : ℂ) • E)‖ :=
     @norm_exp_sub_one_sub_self_le (Mat →L[ℂ] Mat)
-      (TNOperatorSpace.instNormedRingMatrixCLM (Fin D))
-      (TNOperatorSpace.instNormedAlgebraComplexMatrixCLM (Fin D))
-      (TNOperatorSpace.instCompleteSpaceMatrixCLM (Fin D))
-      (instSubsequenceNormOneClassMatrixCLM (D := D))
+      inferInstance inferInstance inferInstance (instSubsequenceNormOneClassMatrixCLM (D := D))
       ((s : ℂ) • E)
   simp only [expSemigroupCLM] at h ⊢
   have hnorm_smul : ‖(s : ℂ) • E‖ = s * ‖E‖ := by

--- a/TNLean/Channel/Semigroup/Resolvent.lean
+++ b/TNLean/Channel/Semigroup/Resolvent.lean
@@ -23,8 +23,9 @@ if `‖L‖ < 1`, then `R(1,L) = ∑ₙ L^n`. -/
 theorem resolvent_one_neumann
     (L : MatrixCLM (Fin D)) (hL : ‖L‖ < 1) :
     resolvent L (1 : ℂ) = ∑' n : ℕ, L ^ n := by
-  simpa [resolvent, Algebra.algebraMap_eq_smul_one, one_smul] using
-    (NormedRing.inverse_one_sub L hL)
+  rw [resolvent, Algebra.algebraMap_eq_smul_one, one_smul]
+  change Ring.inverse (1 - L) = ∑' n : ℕ, L ^ n
+  exact (hasSum_geom_series_inverse L hL).tsum_eq.symm
 
 /-- Euler resolvent step `(λ R(λ,L))`. -/
 def eulerResolventStep (L : MatrixCLM (Fin D)) (lam : ℂ) : MatrixCLM (Fin D) :=


### PR DESCRIPTION
### Motivation
- Mathlib 4.31 provides native instances for normed add-comm group, complex normed space, bounded complex scalar multiplication, and real normed space on `MatrixCLM` endomorphisms; the TNLean-local pass-through declarations duplicating these are no longer needed.
- Redundant instance declarations create unnecessary typeclass resolution overhead and can interfere with typeclass search in the semigroup estimates.

### Description
- `Algebra/MatrixOperatorSpace.lean`: removed pass-through instance declarations for `MatrixCLM` normed-add-comm-group, complex-normed-space, bounded-complex-scalar-multiplication, and real-normed-space that Mathlib 4.31 already covers; retained instances still required to expose Mathlib structures to typeclass search for this endomorphism type.
- `Channel/Semigroup/Resolvent.lean`: replaced a manual Neumann-series resolvent construction with the Mathlib 4.31 `hasSum_geom_series_inverse` lemma directly.
- `Channel/Semigroup/{CPClosure,Dissipative,LindbladForm/EulerStep,ProductFormula,ReducibleQDS/SubsequenceAnalysis}.lean`: removed explicit TNLean-named `MatrixCLM` instance references, allowing Mathlib instances to be inferred.
- No mathematical content changed; no sorrys introduced.

### Testing
- `lake env lean TNLean/Algebra/MatrixOperatorSpace.lean`
- `lake build TNLean.Channel.Semigroup.ProductFormula -q --log-level=info`
- `lake build TNLean.Channel.Semigroup.LindbladForm.EulerStep TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis TNLean.Channel.Semigroup.CPClosure TNLean.Channel.Semigroup.Dissipative -q --log-level=info`
- `lake build TNLean.Channel.Semigroup.Resolvent -q --log-level=info`
- Full `Channel.Schwarz` and `Channel.Semigroup` build including `KossakowskiForm`, `Perturbation`, `ReducibleQDS`, `Irreducible.SpectralRadius`, and `Irreducible.FromSpectral` passes.
- `git diff --check` and prose/oversized-file scripts pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7abc2a2a345b73f738b9b34292d9f7d085b0f175. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->