### PR TITLE
feat(Analysis/Entropy): add vonNeumannEntropy_zero and centralize congr lemma

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -85,6 +85,22 @@ noncomputable def vonNeumannEntropy
     (ρ : Matrix n n ℂ) (hρ : ρ.IsHermitian) : ℝ :=
   ∑ i, negMulLog (hρ.eigenvalues i)
 
+/-- Von Neumann entropy is congruent in the matrix argument. -/
+theorem vonNeumannEntropy_congr {ρ₁ ρ₂ : Matrix n n ℂ} (h : ρ₁ = ρ₂)
+    (hρ₁ : ρ₁.IsHermitian) (hρ₂ : ρ₂.IsHermitian) :
+    vonNeumannEntropy ρ₁ hρ₁ = vonNeumannEntropy ρ₂ hρ₂ := by
+  subst h
+  rfl
+
+/-- The zero matrix has zero von Neumann entropy. -/
+@[simp] theorem vonNeumannEntropy_zero :
+    vonNeumannEntropy (0 : Matrix n n ℂ) Matrix.isHermitian_zero = 0 := by
+  rw [vonNeumannEntropy]
+  have hzero : (Matrix.isHermitian_zero (n := n) (α := ℂ)).eigenvalues = 0 := by
+    exact (Matrix.isHermitian_zero (n := n) (α := ℂ)).eigenvalues_eq_zero_iff.mpr rfl
+  rw [hzero]
+  simp [Real.negMulLog_zero]
+
 /-- The von Neumann entropy depends only on the characteristic polynomial: it is
 the `negMulLog`-sum of the (real parts of the) roots of `charpoly`. -/
 theorem vonNeumannEntropy_eq_charpoly_roots (ρ : Matrix n n ℂ) (hρ : ρ.IsHermitian) :

--- a/TNLean/Entropy/VonNeumann.lean
+++ b/TNLean/Entropy/VonNeumann.lean
@@ -24,6 +24,11 @@ with trivial unfolding `@[simp]` lemmas.
 
 * `Entropy.vonNeumannEntropy` — alias of `_root_.vonNeumannEntropy`,
   the entropy `S(ρ) = -tr(ρ log ρ)` of a Hermitian matrix.
+* `Entropy.vonNeumannEntropy_congr` — alias of
+  `_root_.vonNeumannEntropy_congr`: entropy is congruent in the matrix
+  argument.
+* `Entropy.vonNeumannEntropy_zero` — alias of
+  `_root_.vonNeumannEntropy_zero`: `S(0) = 0`.
 * `Entropy.vonNeumannEntropy_nonneg` — alias of
   `_root_.vonNeumannEntropy_nonneg`: `S(ρ) ≥ 0` for density matrices.
 * `Entropy.vonNeumannEntropy_le_log_dim` — alias of
@@ -52,6 +57,14 @@ equal to `_root_.vonNeumannEntropy`.
 
 Source: blueprint `def:entropy_von_neumann_entropy`. -/
 noncomputable alias vonNeumannEntropy := _root_.vonNeumannEntropy
+
+/-- **Von Neumann entropy is congruent in the matrix argument**, namespaced
+alias of `_root_.vonNeumannEntropy_congr`. -/
+alias vonNeumannEntropy_congr := _root_.vonNeumannEntropy_congr
+
+/-- **The zero matrix has zero von Neumann entropy**, namespaced alias of
+`_root_.vonNeumannEntropy_zero`. -/
+alias vonNeumannEntropy_zero := _root_.vonNeumannEntropy_zero
 
 /-- **Von Neumann entropy is nonneg for density matrices**, namespaced
 alias of `_root_.vonNeumannEntropy_nonneg`. -/

--- a/TNLean/MPS/MPDO/MutualInfoMonotone.lean
+++ b/TNLean/MPS/MPDO/MutualInfoMonotone.lean
@@ -285,13 +285,6 @@ theorem traceA_mat {d D : ℕ} (M : MPOTensor d D) {N a b c : ℕ} (h3 : a + b +
       append_assoc_cast, append_assoc_cast])]
   rw [collapse_first M (a := a) (b := b + c) (by omega)]
 
-/-- von Neumann entropy congruence in the matrix argument (proof-irrelevant in the
-Hermiticity witness). -/
-theorem vonNeumannEntropy_congr {n : Type*} [Fintype n] [DecidableEq n]
-    {ρ₁ ρ₂ : Matrix n n ℂ} (h : ρ₁ = ρ₂) (hρ₁ : ρ₁.IsHermitian) (hρ₂ : ρ₂.IsHermitian) :
-    vonNeumannEntropy ρ₁ hρ₁ = vonNeumannEntropy ρ₂ hρ₂ := by
-  subst h; rfl
-
 /-- Block entropy is congruent in the block length. -/
 theorem blockEntropy_congr {d D : ℕ} (M : MPOTensor d D) (N : ℕ) {j k : ℕ} (h : j = k)
     (hj : j ≤ N) (hk : k ≤ N) (hM : (mpo M N).PosSemidef) :

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -21,6 +21,32 @@ finite-dimensional quantum systems.
     where $0 \log 0 := 0$.
 \end{definition}
 
+\begin{lemma}[Entropy respects equality]\label{lem:entropy_congr}
+    \lean{vonNeumannEntropy_congr}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    If two Hermitian matrices are equal, then their von Neumann entropies are
+    equal.
+\end{lemma}
+
+\begin{proof}\leanok
+    Substitute the equality of the matrices in the defining eigenvalue sum.
+\end{proof}
+
+\begin{lemma}[Entropy of the zero matrix]\label{lem:entropy_zero}
+    \lean{vonNeumannEntropy_zero}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    The zero matrix has zero von Neumann entropy:
+    \[
+        S(0)=0.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    All eigenvalues of the zero matrix are zero, and $0\log 0=0$.
+\end{proof}
+
 \begin{theorem}[Entropy is non-negative]\label{thm:entropy_nonneg}
     \lean{vonNeumannEntropy_nonneg}
     \leanok


### PR DESCRIPTION
### Motivation
- Issue #784 tracks the remaining von Neumann entropy core needed for downstream proofs (strong subadditivity, Klein-inequality-facing constructions). This PR provides two preparatory lemmas: centralization of the congruence property of von Neumann entropy and the boundary case $S(0) = 0$.
- `vonNeumannEntropy_congr` was locally duplicated in `TNLean/MPS/MPDO/MutualInfoMonotone.lean`; centralizing it in the entropy API removes the duplication and makes it available to all modules importing the entropy API without pulling in MPDO files.
- This PR does not attempt to discharge the SSA or Hayashi axioms; those require quantum relative entropy, Klein/Lieb, and data-processing infrastructure.

### Description
- `TNLean/Analysis/Entropy.lean`: adds `vonNeumannEntropy_congr` (von Neumann entropy is preserved under definitional equality of states) and `@[simp] theorem vonNeumannEntropy_zero` ($S(0) = 0$, proved via the zero-eigenvalue property and `Real.negMulLog_zero`).
- `TNLean/Entropy/VonNeumann.lean`: exposes both lemmas via `alias` declarations in the public `TNLean.Entropy.VonNeumann` namespace.
- `TNLean/MPS/MPDO/MutualInfoMonotone.lean`: removes the local duplicate of `vonNeumannEntropy_congr`.
- `blueprint/src/chapter/ch19_entropy.tex`: adds blueprint entries for both lemmas.
- No new `sorry`, `admit`, `axiom`, or `native_decide` introduced.

### Testing
- `lake build TNLean.Analysis.Entropy TNLean.Entropy.VonNeumann TNLean.MPS.MPDO.MutualInfoMonotone TNLean.MPS.MPDO.PureAreaLaw`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Addresses #784

> [!NOTE]
> **Low Risk**
> Pure Lean refactor and documentation with no runtime, auth, or data-path changes; behavior of downstream proofs is unchanged aside from lemma location.
>
> **Overview**
> **Centralizes** two small von Neumann entropy lemmas in `TNLean.Analysis.Entropy` and wires them through the public `Entropy` API and blueprint.
>
> `vonNeumannEntropy_congr` moves out of `TNLean/MPS/MPDO/MutualInfoMonotone.lean` into the main entropy module (same `subst`/`rfl` proof). A new `@[simp] vonNeumannEntropy_zero` shows **S(0) = 0** via zero eigenvalues and `Real.negMulLog_zero`. `TNLean.Entropy.VonNeumann` gains matching `alias` declarations, and `ch19_entropy.tex` documents the two lemmas.
>
> The MPDO mutual-information file drops its local duplicate and keeps using the root lemma through the existing import chain.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f730b73e8288b543de50385ac14f6c037bf248f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lemma relocation and small proved facts only; no axioms, runtime, or proof-logic changes beyond deduplication.
> 
> **Overview**
> Adds two **core von Neumann entropy lemmas** to the main analysis API and drops a duplicate in MPDO code.
> 
> **`TNLean/Analysis/Entropy.lean`** now defines `vonNeumannEntropy_congr` (equal Hermitian matrices have equal entropy) and `@[simp] vonNeumannEntropy_zero` (**S(0) = 0** via zero eigenvalues and `Real.negMulLog_zero`). **`TNLean/Entropy/VonNeumann.lean`** exposes both through `Entropy` namespace **aliases**. **`TNLean/MPS/MPDO/MutualInfoMonotone.lean`** removes its local `vonNeumannEntropy_congr` and keeps calling the centralized lemma. **`blueprint/src/chapter/ch19_entropy.tex`** documents the two lemmas for blueprint sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5076d2846699565fbc02039d3b3a1389a2cb5a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->