### PR TITLE
feat(MPS/ParentHamiltonian): record boundary trace restrictions

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -230,6 +230,125 @@ theorem exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of
     blockDiagonal_boundary_component_chainGroundSpace_of_trace_decomposition_of_injective
       μ A hN hLN X hTraceSpan hBlk hUnital hNlarge C hCoeff
 
+/-- A boundary-crossing local constraint gives the fixed-tail boundary trace
+comparison once a block-diagonal boundary representation is fixed.
+
+Assume
+\[
+  \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+\]
+and \(\psi\in\mathcal G_{N,L}(\oplus_j\mu_jA_j)\). For a cyclic interval
+starting at \(i\) and crossing the boundary cut, the local constraint on
+\(\psi\) says that the corresponding sum of block restrictions lies in
+\(\bigvee_jG_L(A_j)\). Opening the interval with outside word \(\rho\), the
+fixed-interval trace-decomposition lemma supplies matrices \(C^j_{i,\rho}\)
+such that, for every word \(\beta\) before the cut and every wrapped tail word
+\(w\) of length \(N-i\),
+\[
+  \sum_j\operatorname{tr}(A^j_\beta C^j_{i,\rho}A^j_w)
+  =
+  \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr).
+\]
+
+This is the explicit-boundary trace-decomposition step in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1451, specialized to
+the block-diagonal boundary conditions in arXiv:2011.12127, Section IV.C,
+lines 2126--2128. It records only the fixed wrapped-tail length \(N-i\)
+provided by the local cyclic-window constraint; the separate common-middle-word
+trace theorem keeps its common length \(m\) as an explicit hypothesis.
+
+**Scope restriction (boundary representation):** The block-diagonal boundary
+representation of \(\psi\) is a hypothesis here. Removing this remaining input
+is tracked in issue 2971 and documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem blockDiagonal_boundary_crossing_trace_decomposition_of_boundary
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L N : ℕ} [NeZero d] (hN : 0 < N) (hLN : L ≤ N)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hψX :
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X)))
+    (i : Fin N) (hi : N < i.val + L)
+    (ρ : Fin (N - L) → Fin d) :
+    ∃ C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ∀ β : Fin (i.val + L - N) → Fin d,
+        ∀ w : Fin (N - i.val) → Fin d,
+          (∑ j : Fin r,
+            Matrix.trace
+              ((evalWord (A j) (List.ofFn β) * C j) *
+                evalWord (A j) (List.ofFn w))) =
+          (∑ j : Fin r,
+            Matrix.trace
+              ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                  evalWord (A j) (List.ofFn ρ)) *
+                evalWord (A j) (List.ofFn w))) := by
+  classical
+  let τ : Fin N → Fin d := fun t =>
+    if htail : i.val + L - N ≤ t.val ∧ t.val < i.val then
+      ρ ⟨t.val - (i.val + L - N), by omega⟩
+    else
+      (0 : Fin d)
+  have hρ : (List.ofFn fun k : Fin (N - L) =>
+      τ ⟨i.val + L - N + k.val, by omega⟩) = List.ofFn ρ := by
+    apply List.ext_getElem
+    · simp
+    · intro n hn₁ hn₂
+      simp only [List.getElem_ofFn]
+      have hn : n < N - L := by
+        simpa using hn₂
+      have htail :
+          i.val + L ≤ i.val + L - N + n + N ∧
+            (⟨i.val + L - N + n, by omega⟩ : Fin N) < i := by
+        constructor
+        · omega
+        · change i.val + L - N + n < i.val
+          omega
+      simp [τ, htail]
+  have hmem :
+      (∑ j : Fin r,
+          cyclicRestrictₗ hN L i τ
+            (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
+        ⨆ j : Fin r, groundSpace (A j) L :=
+    blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
+      μ A hμ hN hLN hψ X hψX i τ
+  obtain ⟨C, hTrace⟩ :=
+    blockDiagonal_boundary_crossing_trace_decomposition_of_sum_mem_iSup
+      μ A hN hLN X i τ hi hmem
+  refine ⟨C, ?_⟩
+  intro β w
+  let σ : Fin L → Fin d := fun k =>
+    if hk : k.val < N - i.val then
+      w ⟨k.val, hk⟩
+    else
+      β ⟨k.val - (N - i.val), by omega⟩
+  have hHead :
+      (List.ofFn fun k : Fin (i.val + L - N) =>
+        σ ⟨N - i.val + k.val, by omega⟩) = List.ofFn β := by
+    apply List.ext_getElem
+    · simp
+    · intro n hn₁ hn₂
+      simp only [List.getElem_ofFn]
+      have hnot : ¬N - i.val + n < N - i.val := by omega
+      simp [σ, hnot]
+  have hMiddle :
+      (List.ofFn fun k : Fin (N - L) =>
+        τ ⟨i.val + L - N + k.val, by omega⟩) = List.ofFn ρ := hρ
+  have hTail :
+      (List.ofFn fun k : Fin (N - i.val) =>
+        σ ⟨k.val, by omega⟩) = List.ofFn w := by
+    apply List.ext_getElem
+    · simp
+    · intro n hn₁ hn₂
+      simp only [List.getElem_ofFn]
+      have hlt : n < N - i.val := by
+        simpa using hn₁
+      simp [σ, hlt]
+  simpa [hHead, hMiddle, hTail, Matrix.mul_assoc] using hTrace σ
+
 /-- The \(C^j,D^j\) boundary comparison gives periodic single-block states
 from an explicit block-diagonal boundary representation.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -189,6 +189,44 @@ in both cases.
     gives the second trace expression for the same local coefficient sum.
 \end{proof}
 
+\begin{lemma}[Boundary representation gives fixed-tail boundary traces]
+    \label{lem:block_diagonal_boundary_crossing_trace_decomposition_boundary}
+    \lean{MPSTensor.blockDiagonal_boundary_crossing_trace_decomposition_of_boundary}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        lem:block_diagonal_boundary_crossing_trace_decomposition}
+    Assume $0<N$, $L\le N$, and $\mu_j\ne0$ for every block $j$. Let the
+    cyclic interval beginning at $i$ cross the boundary cut, so $N<i+L$. Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right),
+        \qquad
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
+    \]
+    For every outside word $\rho$ of length $N-L$, there are matrices
+    $C^j_{i,\rho}$ such that, for every word $\beta$ of length $i+L-N$ before
+    the cut and every wrapped tail word $\alpha$ of length $N-i$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_\alpha\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_\alpha\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        lem:block_diagonal_boundary_crossing_trace_decomposition}
+    Choose an outside configuration $\tau$ whose entries between the end of the
+    interval and the cut are the word $\rho$. By the nonzero-weight hypothesis,
+    Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem} applies and puts the
+    sum of the corresponding block restrictions in $\bigvee_jG_L(A_j)$. Applying
+    Lemma~\ref{lem:block_diagonal_boundary_crossing_trace_decomposition} gives
+    the displayed trace equality after rewriting the opened cyclic word as
+    $\beta\rho\alpha$.
+\end{proof}
+
 \begin{theorem}[Fixed boundary-crossing $C^j,D^j$ comparison from the local block-sum constraint]
     \label{thm:block_diagonal_boundary_crossing_pgvwc_comparison}
     \lean{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup}

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -483,6 +483,22 @@ boundary trace expressions gives
 for every block \(j\), without using any span assumption at the short
 boundary-crossing tail length \(N-i\).\footnote{Lean declaration:
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary}.}
+At the fixed wrapped-tail length supplied by a single boundary-crossing cyclic
+window, the boundary trace expressions are now derived from the local
+constraint once the block-diagonal boundary representation is fixed: for
+\(N<i+L\), outside word \(\rho\) of length \(N-L\), and wrapped tail word
+\(\alpha\) of length \(N-i\), there are matrices \(C^j_{i,\rho}\) such that
+\begin{align}
+  \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_\alpha\right)
+  =
+  \sum_j\tr\!\left((\mu_j^NX_jA^j_\beta)A^j_\rho A^j_\alpha\right).
+\end{align}
+This fixed-tail statement is recorded as
+\leanid{MPSTensor.blockDiagonal_boundary_crossing_trace_decomposition_of_boundary}.
+It should not be read as the common-middle-word trace hypothesis above: the
+fixed cyclic window gives the wrapped tail length \(N-i\), whereas the
+separating trace-decomposition implication is stated at a common product-span
+length \(m\).
 
 In the normalized BNT finite range, this common middle-word span is no longer an
 external assumption. If


### PR DESCRIPTION
## Summary
- derive the fixed-tail boundary trace comparison from the local cyclic-window constraint once a block-diagonal boundary representation is fixed
- add the corresponding blueprint lemma and update the paper-gap note
- clarify that this gives tail length `N - i`, while the common-middle-word trace-decomposition route still keeps the middle length `m` as a separate hypothesis

## Source
- arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1451
- arXiv:2011.12127, Section IV.C, lines 2126--2128

Refs #2971

## Verification
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_oversized_lean_files.py --root .`
- `git diff --check`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a formal Lean theorem and synchronized blueprint/paper-gap documentation in the MPS parent-Hamiltonian formalization; no changes to auth, I/O, or production runtime behavior.
> 
> **Overview**
> Adds **`blockDiagonal_boundary_crossing_trace_decomposition_of_boundary`**, showing that once \(\psi\) is in the block-diagonal chain ground space and written with fixed block-diagonal boundary matrices \(X_j\), a boundary-crossing cyclic window yields the **fixed wrapped-tail length \(N-i\)** boundary trace identity (matrices \(C^j_{i,\rho}\) matching the block-boundary side), without assuming a separate common middle-word span at that tail length.
> 
> The proof wires the existing local block-sum membership lemma into the fixed-interval trace decomposition, then reindexes cyclic words \(\beta\), \(\rho\), and the tail \(w\) to match the \(\beta\rho\alpha\) split. The blueprint gains the matching lemma, and the paper-gap note records this step and **separates it** from the common-middle-word trace route (length \(m\)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45a67a41ba91d63c73b0f339e74d9794444e599. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->