### PR TITLE
feat(Algebra/MatrixAux): add PSD trace-product nonnegativity

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -21,6 +21,8 @@ Extracted from various files for reusability.
   trace identity
 - `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`: the Hilbert--Schmidt
   trace form of the Frobenius norm
+- `Matrix.PosSemidef.trace_mul_nonneg`: the trace product of two positive
+  semidefinite matrices is nonnegative
 - `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`: a positive sum of squares
   vanishes only if every summand vanishes
 - `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
@@ -72,6 +74,56 @@ theorem trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq
   · positivity
 
 end FrobeniusTrace
+
+section PosSemidefTrace
+
+variable {n : Type*} [Fintype n]
+
+namespace PosSemidef
+
+/-- The trace product of two positive semidefinite matrices is nonnegative. -/
+theorem trace_mul_nonneg {A B : Matrix n n ℂ}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    0 ≤ trace (A * B) := by
+  classical
+  let U : Matrix n n ℂ := ↑hB.isHermitian.eigenvectorUnitary
+  let Λ : n → ℂ := fun i => ↑(hB.isHermitian.eigenvalues i)
+  have hspec : B = U * diagonal Λ * Uᴴ := by
+    simpa [U, Λ, Unitary.conjStarAlgAut_apply, star_eq_conjTranspose,
+      Function.comp_def] using hB.isHermitian.spectral_theorem
+  have hUAU_psd : (Uᴴ * A * U).PosSemidef := by
+    simpa only [mul_assoc, conjTranspose_conjTranspose] using
+      hA.mul_mul_conjTranspose_same (B := Uᴴ)
+  have hΛ_nonneg : ∀ i, 0 ≤ Λ i := by
+    intro i
+    change (0 : ℂ) ≤ ↑(hB.isHermitian.eigenvalues i)
+    exact_mod_cast (hB.isHermitian.posSemidef_iff_eigenvalues_nonneg.mp hB i)
+  have htrace_eq :
+      trace (A * B) = trace ((Uᴴ * A * U) * diagonal Λ) := by
+    rw [hspec]
+    calc
+      trace (A * (U * diagonal Λ * Uᴴ))
+          = trace ((A * U) * diagonal Λ * Uᴴ) := by
+              simp [mul_assoc]
+      _ = trace (Uᴴ * (A * U) * diagonal Λ) := by
+              simpa only using (trace_mul_cycle (A * U) (diagonal Λ) Uᴴ)
+      _ = trace ((Uᴴ * A * U) * diagonal Λ) := by
+              simp [mul_assoc]
+  rw [htrace_eq, trace]
+  refine Finset.sum_nonneg ?_
+  intro i _hi
+  have hdiag_nonneg : 0 ≤ (Uᴴ * A * U) i i := hUAU_psd.diag_nonneg
+  change 0 ≤ (((Uᴴ * A * U) * diagonal Λ) i i)
+  have hentry :
+      (((Uᴴ * A * U) * diagonal Λ) i i) = (Uᴴ * A * U) i i * Λ i := by
+    rw [mul_apply]
+    simp [diagonal_apply]
+  rw [hentry]
+  exact mul_nonneg hdiag_nonneg (hΛ_nonneg i)
+
+end PosSemidef
+
+end PosSemidefTrace
 
 section SumSquaresZero
 

--- a/TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean
+++ b/TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean
@@ -39,52 +39,12 @@ variable {D : ℕ}
 
 section OrthogonalTrace
 
-private theorem trace_mul_nonneg_of_posSemidef
-    {A B : Matrix (Fin D) (Fin D) ℂ}
-    (hA : A.PosSemidef) (hB : B.PosSemidef) :
-    0 ≤ Matrix.trace (A * B) := by
-  classical
-  let U : Matrix (Fin D) (Fin D) ℂ := ↑hB.isHermitian.eigenvectorUnitary
-  let Λ : Fin D → ℂ := fun i => ↑(hB.isHermitian.eigenvalues i)
-  have hspec : B = U * Matrix.diagonal Λ * Uᴴ := by
-    simpa [U, Λ, Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
-      Function.comp_def] using hB.isHermitian.spectral_theorem
-  have hUAU_psd : (Uᴴ * A * U).PosSemidef := by
-    simpa only [Matrix.mul_assoc, conjTranspose_conjTranspose] using
-      hA.mul_mul_conjTranspose_same (B := Uᴴ)
-  have hΛ_nonneg : ∀ i, 0 ≤ Λ i := by
-    intro i
-    change (0 : ℂ) ≤ ↑(hB.isHermitian.eigenvalues i)
-    exact_mod_cast (hB.isHermitian.posSemidef_iff_eigenvalues_nonneg.mp hB i)
-  have htrace_eq :
-      Matrix.trace (A * B) = Matrix.trace ((Uᴴ * A * U) * Matrix.diagonal Λ) := by
-    rw [hspec]
-    calc
-      Matrix.trace (A * (U * Matrix.diagonal Λ * Uᴴ))
-          = Matrix.trace ((A * U) * Matrix.diagonal Λ * Uᴴ) := by
-              simp [Matrix.mul_assoc]
-      _ = Matrix.trace (Uᴴ * (A * U) * Matrix.diagonal Λ) := by
-              simpa only using (Matrix.trace_mul_cycle (A * U) (Matrix.diagonal Λ) Uᴴ)
-      _ = Matrix.trace ((Uᴴ * A * U) * Matrix.diagonal Λ) := by
-              simp [Matrix.mul_assoc]
-  rw [htrace_eq, Matrix.trace]
-  refine Finset.sum_nonneg ?_
-  intro i hi
-  have hdiag_nonneg : 0 ≤ (Uᴴ * A * U) i i := hUAU_psd.diag_nonneg
-  change 0 ≤ (((Uᴴ * A * U) * Matrix.diagonal Λ) i i)
-  have hentry :
-      (((Uᴴ * A * U) * Matrix.diagonal Λ) i i) = (Uᴴ * A * U) i i * Λ i := by
-    rw [Matrix.mul_apply]
-    simp [Matrix.diagonal_apply]
-  rw [hentry]
-  exact mul_nonneg hdiag_nonneg (hΛ_nonneg i)
-
 private theorem trace_mul_pos_of_posDef_posSemidef_ne_zero
     {A B : Matrix (Fin D) (Fin D) ℂ}
     (hA : A.PosDef) (hB : B.PosSemidef) (hB_ne : B ≠ 0) :
     0 < Matrix.trace (B * A) := by
   have hnonneg : 0 ≤ Matrix.trace (B * A) :=
-    trace_mul_nonneg_of_posSemidef hB hA.posSemidef
+    Matrix.PosSemidef.trace_mul_nonneg hB hA.posSemidef
   have hne : Matrix.trace (B * A) ≠ 0 := by
     intro hzero
     have hzero' : Matrix.trace (A * B) = 0 :=
@@ -141,7 +101,7 @@ theorem orthogonal_trace_pos_of_irreducible_cp
     · have ht_pos : 0 < t := Nat.pos_iff_ne_zero.mpr ht0
       have ht_le : t ≤ n := Nat.lt_succ_iff.mp (Finset.mem_range.mp ht)
       have hterm_nonneg : 0 ≤ Matrix.trace (B * ((E ^ t) A)) :=
-        trace_mul_nonneg_of_posSemidef hB (iterate_posSemidef hCP.isPositiveMap hA t)
+        Matrix.PosSemidef.trace_mul_nonneg hB (iterate_posSemidef hCP.isPositiveMap hA t)
       have hterm_not_pos : ¬ 0 < Matrix.trace (B * ((E ^ t) A)) := by
         intro hpos
         exact hno ⟨t, ht_pos, ht_le, hpos⟩

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -202,9 +202,16 @@ Euclidean space.
 \end{lemma}
 
 \begin{proof}\leanok
-    Diagonalize $B$ by a unitary basis. Then
-    $\tr(AB)=\tr((U^\dagger A U)\Lambda)$, where $U^\dagger A U$ is positive
-    semidefinite and the diagonal entries of $\Lambda$ are non-negative.
+    Write $B=U\Lambda U^\dagger$ with $U$ unitary and $\Lambda$ diagonal. Then
+    \[
+        \tr(AB)
+        =
+        \tr\!\left((U^\dagger A U)\Lambda\right)
+        =
+        \sum_i (U^\dagger A U)_{ii}\Lambda_{ii}
+        \geq 0,
+    \]
+    since $U^\dagger A U\geq 0$ and $\Lambda_{ii}\geq 0$ for every $i$.
 \end{proof}
 
 \begin{definition}[Euclidean-space embedding]\label{def:mat_to_es}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -184,6 +184,7 @@ Euclidean space.
 
 \begin{lemma}[Trace formula for Frobenius norm]\label{lem:frob_sq_trace}
     \lean{MPSTensor.frobSq_trace}
+    \lean{Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq}
     \leanok
     \uses{def:frob_sq}
     $\|X\|_F^2 = \operatorname{Re}\tr(X^\dagger X)$.
@@ -191,6 +192,19 @@ Euclidean space.
 
 \begin{proof}\leanok
     Expand the matrix product and trace entry by entry.
+\end{proof}
+
+\begin{lemma}[Trace product of positive semidefinite matrices]
+    \label{lem:psd_trace_product_nonneg}
+    \lean{Matrix.PosSemidef.trace_mul_nonneg}
+    \leanok
+    If $A,B \geq 0$, then $\tr(AB) \geq 0$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Diagonalize $B$ by a unitary basis. Then
+    $\tr(AB)=\tr((U^\dagger A U)\Lambda)$, where $U^\dagger A U$ is positive
+    semidefinite and the diagonal entries of $\Lambda$ are non-negative.
 \end{proof}
 
 \begin{definition}[Euclidean-space embedding]\label{def:mat_to_es}


### PR DESCRIPTION
### Motivation

- The Lorentz/coercivity route requires the fact `0 ≤ trace (A * B)` for two positive semidefinite matrices. This was previously proved by a private spectral-decomposition in `Channel/Irreducible/Growth/OrthogonalTrace.lean`. Mathlib 4.31 provides `Matrix.PosSemidef.trace_nonneg` but not the trace-product form.
- Extracting this as a shared lemma in `Algebra/MatrixAux` removes an ad hoc private proof layer and makes the result reusable for the compactness/minimisation argument in LionSR/QICLean#143.

### Description

- `TNLean/Algebra/MatrixAux.lean`: adds `Matrix.PosSemidef.trace_mul_nonneg`, proving `0 ≤ trace (A * B)` for positive semidefinite matrices `A` and `B` via spectral diagonalization of `B` followed by a sum of nonnegative diagonal terms.
- `TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean`: removes the private `trace_mul_nonneg_of_posSemidef` (~40 lines) and replaces it with a call to the new shared lemma via the existing `KernelDescent → MatrixAux` import chain.
- `blueprint/src/chapter/ch07_spectral.tex`: adds blueprint coverage for `Matrix.PosSemidef.trace_mul_nonneg` and links the Frobenius trace formula to `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`.
- No new `sorry`, `admit`, `axiom`, or `native_decide` is introduced.

### Testing

- `lake build TNLean.Algebra.MatrixAux TNLean.Channel.Irreducible.Growth.OrthogonalTrace`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --warn-missing-blueprint --changed-files TNLean/Algebra/MatrixAux.lean TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean blueprint/src/chapter/ch07_spectral.tex`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `cd blueprint && leanblueprint checkdecls`
- `rg -n "sorry|admit|native_decide|\baxiom\b|trace_mul_nonneg_of_posSemidef" TNLean/Algebra/MatrixAux.lean TNLean/Channel/Irreducible/Growth/OrthogonalTrace.lean || true`

---
Addresses LionSR/QICLean#143

> [!NOTE]
> **Low Risk**
> Proof refactor with no API or runtime behavior change; logic is relocated unchanged and only consumed in existing channel growth proofs.
>
> **Overview**
> Introduces **`Matrix.PosSemidef.trace_mul_nonneg`** in `TNLean/Algebra/MatrixAux.lean` as the shared fact that **0 ≤ trace(A * B)** when both matrices are positive semidefinite (spectral diagonalization of **B**, then a sum of nonneg diagonal terms).
>
> **`OrthogonalTrace.lean`** drops its private `trace_mul_nonneg_of_posSemidef` (~40 lines) and calls the new lemma in the Wolf orthogonal-trace argument (via the existing `KernelDescent` → `MatrixAux` import chain).
>
> **Blueprint** (`ch07_spectral.tex`): documents the PSD trace-product lemma and links the Frobenius trace formula to `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8961aa27490e56f6925e056678041b10c9dbad75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof relocation with no API or runtime change; the same spectral argument is now a public lemma consumed only where it was used before.
> 
> **Overview**
> Adds **`Matrix.PosSemidef.trace_mul_nonneg`** in `TNLean/Algebra/MatrixAux.lean`, proving **0 ≤ trace(A·B)** when both matrices are positive semidefinite (spectral diagonalization of **B**, then a sum of nonnegative diagonal terms).
> 
> **`OrthogonalTrace.lean`** drops its private `trace_mul_nonneg_of_posSemidef` (~40 lines) and calls the shared lemma in the Wolf orthogonal-trace argument (via the existing `KernelDescent` → `MatrixAux` import chain).
> 
> **Blueprint** (`ch07_spectral.tex`): documents the PSD trace-product lemma and links the Frobenius trace formula to `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef480cb44f1b77ad44aee548e0a33b93b9199dbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->