### PR TITLE
doc(MPS/ParentHamiltonian): state positive physical dimension in boundary trace lemma

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -195,8 +195,9 @@ in both cases.
     \leanok
     \uses{lem:block_diagonal_boundary_local_sum_mem,
         lem:block_diagonal_boundary_crossing_trace_decomposition}
-    Assume $0<N$, $L\le N$, and $\mu_j\ne0$ for every block $j$. Let the
-    cyclic interval beginning at $i$ cross the boundary cut, so $N<i+L$. Let
+    Assume that the physical dimension $d$ is positive, $0<N$, $L\le N$, and
+    $\mu_j\ne0$ for every block $j$. Let the cyclic interval beginning at $i$
+    cross the boundary cut, so $N<i+L$. Let
     \[
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right),
@@ -218,8 +219,9 @@ in both cases.
     \leanok
     \uses{lem:block_diagonal_boundary_local_sum_mem,
         lem:block_diagonal_boundary_crossing_trace_decomposition}
-    Choose an outside configuration $\tau$ whose entries between the end of the
-    interval and the cut are the word $\rho$. By the nonzero-weight hypothesis,
+    Since $d>0$, extend the outside word $\rho$ to a full outside configuration
+    $\tau$ whose entries between the end of the interval and the cut are the
+    word $\rho$. By the nonzero-weight hypothesis,
     Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem} applies and puts the
     sum of the corresponding block restrictions in $\bigvee_jG_L(A_j)$. Applying
     Lemma~\ref{lem:block_diagonal_boundary_crossing_trace_decomposition} gives


### PR DESCRIPTION
## Summary
- state the positive physical-dimension hypothesis in the fixed-tail boundary trace blueprint lemma
- record in the proof text that this hypothesis is used to extend the outside word to a full outside configuration

## Context
This is the follow-up to the Codex review on #3350 after that PR merged. It keeps the blueprint statement faithful to `MPSTensor.blockDiagonal_boundary_crossing_trace_decomposition_of_boundary`, whose Lean statement has `[NeZero d]`.

Refs #3350
Refs #2971

## Verification
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `cd blueprint && leanblueprint checkdecls` passed for the same correction in the already-built parent-Hamiltonian worktree; in this fresh worktree the redundant command was stopped because it began recloning Mathlib

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to a single blueprint lemma and its proof; no Lean or runtime behavior changes.
> 
> **Overview**
> Aligns the blueprint lemma **Boundary representation gives fixed-tail boundary traces** with Lean `MPSTensor.blockDiagonal_boundary_crossing_trace_decomposition_of_boundary`, which assumes `[NeZero d]`.
> 
> The lemma statement now explicitly requires **positive physical dimension** \(d>0\) alongside the existing \(0<N\), \(L\le N\), and nonzero block weights \(\mu_j\). The proof text is updated to say that \(d>0\) is what justifies extending a fixed outside word \(\rho\) to a full outside configuration \(\tau\) before invoking the local sum and trace-decomposition lemmas (replacing vaguer wording about choosing \(\tau\)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b968edb1ffd9c4babc5c6e307485bed8092231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->