### PR TITLE
fix(blueprint): state boundary physical dimension hypothesis

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -195,8 +195,9 @@ in both cases.
     \leanok
     \uses{lem:block_diagonal_boundary_local_sum_mem,
         lem:block_diagonal_boundary_crossing_trace_decomposition}
-    Assume $0<N$, $L\le N$, and $\mu_j\ne0$ for every block $j$. Let the
-    cyclic interval beginning at $i$ cross the boundary cut, so $N<i+L$. Let
+    Assume that the physical dimension $d$ is positive, $0<N$, $L\le N$, and
+    $\mu_j\ne0$ for every block $j$. Let the cyclic interval beginning at $i$
+    cross the boundary cut, so $N<i+L$. Let
     \[
         \psi\in
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right),
@@ -218,8 +219,9 @@ in both cases.
     \leanok
     \uses{lem:block_diagonal_boundary_local_sum_mem,
         lem:block_diagonal_boundary_crossing_trace_decomposition}
-    Choose an outside configuration $\tau$ whose entries between the end of the
-    interval and the cut are the word $\rho$. By the nonzero-weight hypothesis,
+    Since $d>0$, extend the outside word $\rho$ to a full outside configuration
+    $\tau$ whose entries between the end of the interval and the cut are the
+    word $\rho$. By the nonzero-weight hypothesis,
     Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem} applies and puts the
     sum of the corresponding block restrictions in $\bigvee_jG_L(A_j)$. Applying
     Lemma~\ref{lem:block_diagonal_boundary_crossing_trace_decomposition} gives


### PR DESCRIPTION
### Motivation

- Blueprint lemma `lem:block_diagonal_boundary_crossing_trace_decomposition_boundary` in `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex` was missing the positive physical-dimension hypothesis `d > 0`, which appears in the Lean theorem as `[NeZero d]`.
- The dimension positivity is used in the proof to extend an outside word to a full outside configuration; omitting it from the blueprint makes the lemma statement unfaithful to the Lean formalization.
- Continues alignment of the block-diagonal boundary-condition blueprint with the Lean development; see #2971.

### Description

- Added `d > 0` to the hypotheses of `lem:block_diagonal_boundary_crossing_trace_decomposition_boundary` in `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex`, matching the `[NeZero d]` assumption in the corresponding Lean theorem `MPSTensor.blockDiagonal_boundary_crossing_trace_decomposition_of_boundary`.
- Updated the proof prose to state that `d > 0` justifies extending an outside word ρ to a full outside configuration τ before applying the local-sum and trace-decomposition lemmas.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --warn-missing-blueprint --changed-files blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Addresses #2971

> [!NOTE]
> **Low Risk**
> Blueprint prose-only change; no Lean or runtime behavior is modified.
>
> **Overview**
> Aligns blueprint lemma **`lem:block_diagonal_boundary_crossing_trace_decomposition_boundary`** with the Lean theorem `MPSTensor.blockDiagonal_boundary_crossing_trace_decomposition_of_boundary` by adding **positive physical dimension** \(d>0\) to the assumptions (alongside \(0<N\), \(L\le N\), and nonzero block weights).
>
> The proof text is updated to say that **\(d>0\)** is what justifies extending an outside word \(\rho\) to a full outside configuration \(\tau\) before applying the local-sum and trace-decomposition lemmas.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7798684cbe61acc412604d9bf562be4020bb80d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>