### PR TITLE
feat(Algebra): add positive-definite trace lower bound

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.Matrix.PosDef
+import TNLean.Algebra.MatrixAux
 
 /-!
 # Hermitian matrix extremal eigenvalues
@@ -99,6 +100,59 @@ theorem hermitian_sub_scalar_spectral
           congr 1
           ext i
           simp [Complex.ofReal_sub]
+
+/-- Subtracting the smallest Hermitian eigenvalue leaves a positive semidefinite matrix. -/
+theorem sub_minEigenvalue_smul_one_posSemidef [Nonempty (Fin D)]
+    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
+    (M - (↑(minEigenvalue hM) : ℂ) • 1).PosSemidef := by
+  classical
+  let U : Matrix (Fin D) (Fin D) ℂ := ↑hM.eigenvectorUnitary
+  let Λ : Fin D → ℂ := fun j => ↑(hM.eigenvalues j - minEigenvalue hM)
+  have hdiag : (Matrix.diagonal Λ).PosSemidef := by
+    refine Matrix.PosSemidef.diagonal ?_
+    intro j
+    change (0 : ℂ) ≤ ↑(hM.eigenvalues j - minEigenvalue hM)
+    exact_mod_cast sub_nonneg.mpr (minEigenvalue_le hM j)
+  have hconj : (U * Matrix.diagonal Λ * Uᴴ).PosSemidef := by
+    simpa only [mul_assoc, Matrix.conjTranspose_conjTranspose] using
+      hdiag.mul_mul_conjTranspose_same (B := U)
+  rw [hermitian_sub_scalar_spectral hM (minEigenvalue hM)]
+  simpa [U, Λ] using hconj
+
+/-- Positive-definite trace lower bound by the smallest eigenvalue.
+
+This is the matrix estimate used in Wolf's compactness argument for the Lorentz
+normal form: the filtered Choi trace is bounded below by the smallest
+eigenvalue times the Hilbert--Schmidt trace form. -/
+theorem posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le
+    [Nonempty (Fin D)] {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.PosDef)
+    (X : Matrix (Fin D) (Fin D) ℂ) :
+    (↑(minEigenvalue hM.isHermitian) : ℂ) * Matrix.trace (Xᴴ * X) ≤
+      Matrix.trace (X * M * Xᴴ) := by
+  classical
+  let lam : ℂ := ↑(minEigenvalue hM.isHermitian)
+  have hleft : (Xᴴ * X).PosSemidef :=
+    Matrix.posSemidef_conjTranspose_mul_self X
+  have hdiff : (M - lam • (1 : Matrix (Fin D) (Fin D) ℂ)).PosSemidef := by
+    simpa [lam] using sub_minEigenvalue_smul_one_posSemidef hM.isHermitian
+  have hnonneg : 0 ≤ Matrix.trace ((Xᴴ * X) * (M - lam • 1)) :=
+    Matrix.PosSemidef.trace_mul_nonneg hleft hdiff
+  have hcycle :
+      Matrix.trace ((Xᴴ * X) * M) = Matrix.trace (X * M * Xᴴ) := by
+    simpa [mul_assoc] using (Matrix.trace_mul_cycle X M Xᴴ).symm
+  have htrace :
+      Matrix.trace ((Xᴴ * X) * (M - lam • 1)) =
+        Matrix.trace (X * M * Xᴴ) - lam * Matrix.trace (Xᴴ * X) := by
+    calc
+      Matrix.trace ((Xᴴ * X) * (M - lam • 1))
+          = Matrix.trace ((Xᴴ * X) * M) -
+              Matrix.trace ((Xᴴ * X) * (lam • 1)) := by
+                rw [mul_sub, Matrix.trace_sub]
+      _ = Matrix.trace (X * M * Xᴴ) - lam * Matrix.trace (Xᴴ * X) := by
+                rw [hcycle]
+                simp [mul_assoc]
+  rw [htrace] at hnonneg
+  exact sub_nonneg.mp hnonneg
 
 /-- Spectral form of subtracting a Hermitian matrix from a scalar multiple of the identity. -/
 theorem smul_one_sub_hermitian_spectral

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1528,8 +1528,34 @@ This section states the existence theorems from
     \cite[Proposition~2.8]{Wolf2012Quantum}.
 \end{definition}
 
+\begin{lemma}[Positive-definite trace lower bound]\label{lem:posdef_trace_lower_bound}
+    \lean{posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le,
+        sub_minEigenvalue_smul_one_posSemidef}
+    \leanok
+    Let $D\geq 1$, let $M\in \MN{D}$ be positive-definite, and let
+    $\lambda_{\min}(M)$ be its smallest Hermitian eigenvalue. For every
+    $X\in \MN{D}$,
+    \[
+        \lambda_{\min}(M)\,\tr(X^{\dagger}X)
+        \leq
+        \tr(XMX^{\dagger}).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The matrix $M-\lambda_{\min}(M)\Id$ is positive semidefinite by the
+    spectral theorem. Since $X^{\dagger}X$ is also positive semidefinite, the
+    trace product of these two matrices is non-negative. Expanding
+    \[
+        \tr\!\left(X^{\dagger}X(M-\lambda_{\min}(M)\Id)\right)
+    \]
+    and cycling the trace gives the displayed inequality.
+\end{proof}
+
 % Lean: Wolf.infimum_is_attained
 \begin{lemma}[Infimum attainment for SL-filterings]\label{lem:infimum_is_attained}
+    \uses{lem:posdef_trace_lower_bound}
     For a positive-definite Choi matrix $\tau$, the infimum of
     $\tr\![(S_{2} \otimes_{k} S_{1}) \tau (S_{2} \otimes_{k} S_{1})^{\dagger}]$
     over $S_{1}, S_{2} \in \MN{D}$ with $\det S_{1} = \det S_{2} = 1$


### PR DESCRIPTION
## Summary
- prove that subtracting the smallest Hermitian eigenvalue leaves a positive semidefinite matrix
- prove the positive-definite lower bound `lambda_min(M) * trace (X^* X) <= trace (X M X^*)`
- add blueprint coverage and record this as a prerequisite for the Lorentz-normal-form infimum argument

## Issue
Advances LionSR/QICLean#143. This proves prerequisite (2) from the corrected issue analysis, using the PSD trace-product lemma merged in LionSR/TNLean#3351. It does not yet prove `Wolf.infimum_is_attained`.

## Verification
- `lake build TNLean.Algebra.HermitianHelpers`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --warn-missing-blueprint --changed-files TNLean/Algebra/HermitianHelpers.lean blueprint/src/chapter/ch16_channel_representations.tex`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `leanblueprint checkdecls`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained linear-algebra proofs in HermitianHelpers plus blueprint sync; no runtime, auth, or API surface changes.
> 
> **Overview**
> Adds two Lean lemmas in `HermitianHelpers` (with `MatrixAux` imported) and documents them in the Lorentz normal-form chapter of the blueprint.
> 
> **`sub_minEigenvalue_smul_one_posSemidef`** shows `M - λ_min(M)·I` is positive semidefinite via the existing spectral shift formula and nonnegativity of shifted eigenvalues.
> 
> **`posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le`** derives `λ_min(M) · tr(X†X) ≤ tr(X M X†)` for positive-definite `M`, using PSD of `X†X`, the shift lemma, `PosSemidef.trace_mul_nonneg`, and trace cycling—intended for Wolf’s filtered Choi trace lower bound in the compactness argument.
> 
> The blueprint gains **Lemma `posdef_trace_lower_bound`** (`\leanok`) with a short proof sketch, and **`lem:infimum_is_attained`** now `\uses` that lemma as a documented prerequisite (the infimum itself remains unproved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c7bff134ab0eeb3713fd41f67c7fe256527dfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->