### PR TITLE
feat(MPS/ParentHamiltonian): add boundary trace decomposition for all crossing pairs

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -350,6 +350,91 @@ theorem blockDiagonal_boundary_crossing_trace_decomposition_of_boundary
       simp [σ, hlt]
   simpa [hHead, hMiddle, hTail, Matrix.mul_assoc] using hTrace σ
 
+/-- A fixed block-diagonal boundary representation gives fixed-tail boundary
+trace comparisons for all boundary-crossing intervals.
+
+The preceding fixed-interval construction may be chosen for every crossing
+start \(i\) and every outside word \(\rho\) at once. Thus, under the same
+explicit boundary representation
+\[
+  \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
+\]
+there are matrices \(C^j_{i,\rho}\) such that, whenever \(N<i+L\),
+\[
+  \sum_j\operatorname{tr}(A^j_\beta C^j_{i,\rho}A^j_w)
+  =
+  \sum_j\operatorname{tr}\bigl(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_w\bigr)
+\]
+for every word \(\beta\) before the cut and every wrapped tail word \(w\) of
+length \(N-i\).
+
+This is the family form of the explicit-boundary trace-decomposition step in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1451, specialized to
+the block-diagonal boundary conditions in arXiv:2011.12127, Section IV.C,
+lines 2126--2128. It is still a fixed wrapped-tail statement; it does not
+replace the separate common product-spanning length hypothesis.
+
+**Scope restriction (boundary representation):** The block-diagonal boundary
+representation of \(\psi\) is a hypothesis here. Removing this remaining input
+is tracked in issue 2971 and documented in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem blockDiagonal_boundary_crossing_trace_decompositions_of_boundary
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L N : ℕ} [NeZero d] (hN : 0 < N) (hLN : L ≤ N)
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hψX :
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X))) :
+    ∃ C : ∀ (j : Fin r) (_ : Fin N),
+        (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ∀ i : Fin N,
+        N < i.val + L →
+          ∀ ρ : Fin (N - L) → Fin d,
+            ∀ β : Fin (i.val + L - N) → Fin d,
+              ∀ w : Fin (N - i.val) → Fin d,
+                (∑ j : Fin r,
+                  Matrix.trace
+                    ((evalWord (A j) (List.ofFn β) * C j i ρ) *
+                      evalWord (A j) (List.ofFn w))) =
+                (∑ j : Fin r,
+                  Matrix.trace
+                    ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                        evalWord (A j) (List.ofFn ρ)) *
+                      evalWord (A j) (List.ofFn w))) := by
+  classical
+  have hExists :
+      ∀ i : Fin N, ∀ ρ : Fin (N - L) → Fin d,
+        ∃ C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          N < i.val + L →
+            ∀ β : Fin (i.val + L - N) → Fin d,
+              ∀ w : Fin (N - i.val) → Fin d,
+                (∑ j : Fin r,
+                  Matrix.trace
+                    ((evalWord (A j) (List.ofFn β) * C j) *
+                      evalWord (A j) (List.ofFn w))) =
+                (∑ j : Fin r,
+                  Matrix.trace
+                    ((((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β) *
+                        evalWord (A j) (List.ofFn ρ)) *
+                      evalWord (A j) (List.ofFn w))) := by
+    intro i ρ
+    by_cases hi : N < i.val + L
+    · obtain ⟨C, hC⟩ :=
+        blockDiagonal_boundary_crossing_trace_decomposition_of_boundary
+          μ A hμ hN hLN hψ X hψX i hi ρ
+      exact ⟨C, fun _ => hC⟩
+    · refine ⟨fun _ => 0, ?_⟩
+      intro hcross
+      exact False.elim (hi hcross)
+  choose C hC using hExists
+  refine ⟨fun j i ρ => C i ρ j, ?_⟩
+  intro i hi ρ β w
+  exact hC i ρ hi β w
+
 /-- The \(C^j,D^j\) boundary comparison gives periodic single-block states
 from an explicit block-diagonal boundary representation.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -229,6 +229,41 @@ in both cases.
     $\beta\rho\alpha$.
 \end{proof}
 
+\begin{lemma}[Boundary representation gives all fixed-tail boundary traces]
+    \label{lem:block_diagonal_boundary_crossing_trace_decompositions_boundary}
+    \lean{MPSTensor.blockDiagonal_boundary_crossing_trace_decompositions_of_boundary}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_trace_decomposition_boundary}
+    Assume that the physical dimension $d$ is positive, $0<N$, $L\le N$, and
+    $\mu_j\ne0$ for every block $j$. Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right),
+        \qquad
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
+    \]
+    Then there are matrices $C^j_{i,\rho}$, indexed by the boundary-crossing
+    start $i$ and by an outside word $\rho$ of length $N-L$, such that whenever
+    $N<i+L$,
+    \[
+        \sum_j\tr\!\left(A^j_\beta C^j_{i,\rho}A^j_\alpha\right)
+        =
+        \sum_j
+        \tr\!\left(((\mu_j^NX_j)A^j_\beta)A^j_\rho A^j_\alpha\right)
+    \]
+    for every word $\beta$ of length $i+L-N$ before the cut and every wrapped
+    tail word $\alpha$ of length $N-i$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_crossing_trace_decomposition_boundary}
+    Apply
+    Lemma~\ref{lem:block_diagonal_boundary_crossing_trace_decomposition_boundary}
+    to each boundary-crossing start $i$ and each outside word $\rho$, and choose
+    the resulting matrices $C^j_{i,\rho}$.
+\end{proof}
+
 \begin{theorem}[Fixed boundary-crossing $C^j,D^j$ comparison from the local block-sum constraint]
     \label{thm:block_diagonal_boundary_crossing_pgvwc_comparison}
     \lean{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup}


### PR DESCRIPTION
### Motivation

- The block-diagonal parent-Hamiltonian argument requires matrices $C^j_{i,\rho}$ satisfying the fixed wrapped-tail trace identity for every boundary-crossing start $i$ and outside word $\rho$ simultaneously, under a single block-diagonal boundary representation of $\psi$.
- The existing theorem `blockDiagonal_boundary_crossing_trace_decomposition_of_boundary` provides such matrices for a fixed pair $(i, \rho)$; the family form is needed for the argument to proceed uniformly across all pairs.
- Continues the formalization of the PGVWC07 boundary-comparison identity (arXiv:quant-ph/0608197, Theorem 12) and arXiv:2011.12127 §IV.C; see #2971.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`: adds theorem `blockDiagonal_boundary_crossing_trace_decompositions_of_boundary`. Under one explicit block-diagonal boundary representation of $\psi$, this chooses matrices $C^j_{i,\rho}$ simultaneously for all boundary-crossing starts $i$ and outside words $\rho$, satisfying the fixed wrapped-tail trace identity. Derived by applying the single-interval theorem pointwise and collecting via `choose`.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex`: adds lemma `lem:block_diagonal_boundary_crossing_trace_decompositions_boundary` with `\leanok` in the boundary-crossing subsection.
- This remains a fixed-tail statement: the block-diagonal boundary representation is still a hypothesis, and the separate common product-spanning length input is unchanged.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalTraceDecomposition`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Refs #2971

> [!NOTE]
> **Low Risk**
> Pure formalization and blueprint sync in the parent-Hamiltonian MPS layer; no runtime, security, or data-path changes.
>
> **Overview**
> Adds the **family form** of the fixed wrapped-tail boundary trace comparison: under one explicit block-diagonal boundary representation of \(\psi\), matrices \(C^j_{i,\rho}\) are chosen **simultaneously** for every boundary-crossing start \(i\) and outside word \(\rho\), not just for a fixed pair \((i,\rho)\).
>
> Lean introduces `blockDiagonal_boundary_crossing_trace_decompositions_of_boundary`, proved by applying the existing single-interval theorem `blockDiagonal_boundary_crossing_trace_decomposition_of_boundary` pointwise and collecting with `choose`. The blueprint subsection gains the matching lemma `lem:block_diagonal_boundary_crossing_trace_decompositions_boundary` with `\leanok`.
>
> This remains a **fixed-tail** step only: the block-diagonal boundary representation is still a hypothesis (issue 2971), and the separate common product-spanning length input is unchanged.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eafc856093e2eebe24f37b16dc7d8cb1abfd569d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
