### PR TITLE
doc(MPS/ParentHamiltonian): use hypothesis wording

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -375,8 +375,8 @@ lines 2126--2128. It is still a fixed wrapped-tail statement; it does not
 replace the separate common product-spanning length hypothesis.
 
 **Scope restriction (boundary representation):** The block-diagonal boundary
-representation of \(\psi\) is a hypothesis here. Removing this remaining input
-is tracked in issue 2971 and documented in
+representation of \(\psi\) is a hypothesis here. Removing this remaining
+hypothesis is tracked in issue 2971 and documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem blockDiagonal_boundary_crossing_trace_decompositions_of_boundary
     {r : ℕ} {dim : Fin r → ℕ}


### PR DESCRIPTION
### Motivation

- PR #3357 added a scope note to `blockDiagonal_boundary_crossing_trace_decompositions_of_boundary` stating that the block-diagonal boundary representation is a hypothesis, but the following sentence referred to the same item as an "input" — inconsistent terminology within the same note.
- Consistent prose is required so the scope marker reads coherently; this is a prose follow-up to #3357.
- Continues incremental cleanup toward #2971 (PGVWC07 boundary comparison for block-diagonal parent spaces).

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`: replaces "input" with "hypothesis" in the second sentence of the scope note for `blockDiagonal_boundary_crossing_trace_decompositions_of_boundary`, making the wording consistent with the first sentence.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Refs #2971

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0c1e2c6bed421853a797c85c35e2e03f123b5131. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
