### PR TITLE
feat(Algebra): extract determinant Hilbert-Schmidt bound

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -8,6 +8,8 @@ import Mathlib.Analysis.Matrix.Normed
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.CStarAlgebra.Matrix
+import Mathlib.Analysis.MeanInequalities
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 
 /-!
 # Auxiliary matrix lemmas
@@ -21,6 +23,8 @@ Extracted from various files for reusability.
   trace identity
 - `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`: the Hilbert--Schmidt
   trace form of the Frobenius norm
+- `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one`: determinant
+  AM--GM lower bound for the Hilbert--Schmidt trace form
 - `Matrix.PosSemidef.trace_mul_nonneg`: the trace product of two positive
   semidefinite matrices is nonnegative
 - `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`: a positive sum of squares
@@ -74,6 +78,67 @@ theorem trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq
   · positivity
 
 end FrobeniusTrace
+
+section FrobeniusDeterminant
+
+variable {n : Type*} [Fintype n] [DecidableEq n] [Nonempty n]
+
+/-- **Determinant AM--GM lower bound for the Hilbert--Schmidt trace form.**
+
+If a square complex matrix has determinant of norm one, then the square of its
+Frobenius norm is at least the dimension.  Equivalently,
+`(Fintype.card n : ℝ) ≤ (trace (Aᴴ * A)).re`.
+
+This is the singular-value AM--GM estimate used in Wolf's compactness argument
+for Lorentz normal forms. -/
+theorem card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one
+    (A : Matrix n n ℂ) (hdet : ‖A.det‖ = 1) :
+    (Fintype.card n : ℝ) ≤ (trace (Aᴴ * A)).re := by
+  classical
+  let B : Matrix n n ℂ := Aᴴ * A
+  have hBherm : B.IsHermitian := by
+    simpa only [B] using Matrix.isHermitian_conjTranspose_mul_self A
+  have hBpsd : B.PosSemidef := by
+    simpa only [B] using Matrix.posSemidef_conjTranspose_mul_self A
+  have hdetB : Matrix.det B = 1 := by
+    change Matrix.det (Aᴴ * A) = 1
+    rw [Matrix.det_mul, Matrix.det_conjTranspose]
+    have hconj : star A.det * A.det = ((‖A.det‖ ^ 2 : ℝ) : ℂ) := by
+      simpa [Complex.star_def, Complex.normSq_eq_norm_sq] using
+        (Complex.normSq_eq_conj_mul_self (z := A.det)).symm
+    rw [hconj, hdet]
+    norm_num
+  have hprod_eq : ∏ i, hBherm.eigenvalues i = 1 := by
+    have h : Matrix.det B = ∏ i, (hBherm.eigenvalues i : ℂ) :=
+      hBherm.det_eq_prod_eigenvalues
+    rw [hdetB] at h
+    have h' : ((∏ i, hBherm.eigenvalues i : ℝ) : ℂ) = 1 := by
+      simpa only [Complex.ofReal_prod] using h.symm
+    exact_mod_cast h'
+  have hcard_pos : 0 < (Fintype.card n : ℝ) := by
+    exact_mod_cast Fintype.card_pos (α := n)
+  have hamgm : 1 ≤ (∑ i, hBherm.eigenvalues i) / (Fintype.card n : ℝ) := by
+    have hweights_pos : 0 < ∑ _i : n, (1 : ℝ) := by
+      simpa only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one] using
+        hcard_pos
+    have h :=
+      Real.geom_mean_le_arith_mean
+        (s := Finset.univ) (w := fun _ => (1 : ℝ))
+        (z := fun i => hBherm.eigenvalues i)
+        (by intro i hi; positivity)
+        hweights_pos
+        (by intro i hi; simpa only using hBpsd.eigenvalues_nonneg i)
+    simpa only [ge_iff_le, Real.rpow_one, hprod_eq, Finset.sum_const,
+      Finset.card_univ, nsmul_eq_mul, mul_one, _root_.mul_inv_rev, Real.one_rpow,
+      one_mul] using h
+  have hsum_ge : (Fintype.card n : ℝ) ≤ ∑ i, hBherm.eigenvalues i :=
+    (one_le_div hcard_pos).mp hamgm
+  have htrace_eq : (trace B).re = ∑ i, hBherm.eigenvalues i := by
+    simpa only [Complex.coe_algebraMap, Complex.re_sum, Complex.ofReal_re] using
+      congrArg Complex.re hBherm.trace_eq_sum_eigenvalues
+  simpa only [B] using hsum_ge.trans_eq htrace_eq.symm
+
+end FrobeniusDeterminant
 
 section PosSemidefTrace
 

--- a/TNLean/Channel/Determinant/HilbertSchmidt.lean
+++ b/TNLean/Channel/Determinant/HilbertSchmidt.lean
@@ -7,7 +7,6 @@ import TNLean.Algebra.MatrixAux
 import Mathlib.Analysis.Complex.Polynomial.Basic
 import Mathlib.Analysis.InnerProductSpace.Positive
 import Mathlib.Analysis.InnerProductSpace.Trace
-import Mathlib.Analysis.MeanInequalities
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
 
 /-!
@@ -135,46 +134,8 @@ theorem sum_stdBasis_mul_conjTranspose :
 private lemma matrix_det_norm_one_trace_conjTranspose_mul_self_ge [NeZero d]
     (A : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ) (hdet : ‖A.det‖ = 1) :
     (d : ℝ) ^ 2 ≤ (Matrix.trace (Aᴴ * A)).re := by
-  let B : Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ := Aᴴ * A
-  have hBherm : B.IsHermitian := by
-    simpa only using Matrix.isHermitian_conjTranspose_mul_self A
-  have hBpsd : B.PosSemidef := by
-    simpa only using Matrix.posSemidef_conjTranspose_mul_self A
-  have hdetB : Matrix.det B = 1 := by
-    change Matrix.det (Aᴴ * A) = 1
-    rw [Matrix.det_mul, Matrix.det_conjTranspose]
-    have hconj : star A.det * A.det = ((‖A.det‖ ^ 2 : ℝ) : ℂ) := by
-      simpa [Complex.star_def, Complex.normSq_eq_norm_sq] using
-        (Complex.normSq_eq_conj_mul_self (z := A.det)).symm
-    rw [hconj, hdet]
-    norm_num
-  have hprod_eq : ∏ i, hBherm.eigenvalues i = 1 := by
-    have h : Matrix.det B = ∏ i, (hBherm.eigenvalues i : ℂ) := hBherm.det_eq_prod_eigenvalues
-    rw [hdetB] at h
-    have h' : ((∏ i, hBherm.eigenvalues i : ℝ) : ℂ) = 1 := by
-      simpa only [Complex.ofReal_prod] using h.symm
-    exact_mod_cast h'
-  have hd_pos : 0 < (d : ℝ) := by
-    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne d)
-  have hamgm : 1 ≤ (∑ i, hBherm.eigenvalues i) / ((d : ℝ) * d) := by
-    have := Real.geom_mean_le_arith_mean (s := Finset.univ) (w := fun _ => (1 : ℝ))
-      (z := fun i => hBherm.eigenvalues i)
-      (by intro i hi; positivity)
-      (by
-        simp only [Finset.sum_const, Finset.card_univ, Fintype.card_prod,
-          Fintype.card_fin, nsmul_eq_mul, Nat.cast_mul, mul_one, mul_self_pos,
-          ne_eq, Nat.cast_eq_zero, NeZero.ne d, not_false_eq_true])
-      (by intro i hi; simpa only using hBpsd.eigenvalues_nonneg i)
-    simpa only [ge_iff_le, Real.rpow_one, hprod_eq, Finset.sum_const,
-      Finset.card_univ, Fintype.card_prod, Fintype.card_fin, nsmul_eq_mul,
-      Nat.cast_mul, mul_one, _root_.mul_inv_rev, Real.one_rpow, one_mul] using this
-  have hmul_pos : 0 < (d : ℝ) * d := mul_pos hd_pos hd_pos
-  have hsum_ge : (d : ℝ) * d ≤ ∑ i, hBherm.eigenvalues i :=
-    (one_le_div hmul_pos).mp hamgm
-  have htrace_eq : (Matrix.trace B).re = ∑ i, hBherm.eigenvalues i := by
-    simpa only [Complex.coe_algebraMap, Complex.re_sum, Complex.ofReal_re] using
-      congrArg Complex.re hBherm.trace_eq_sum_eigenvalues
-  simpa only [pow_two, ge_iff_le] using hsum_ge.trans_eq htrace_eq.symm
+  have h := Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one A hdet
+  simpa only [Fintype.card_prod, Fintype.card_fin, Nat.cast_mul, pow_two] using h
 
 /-- **AM-GM lower bound on Hilbert-Schmidt norm via determinant.**
 

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1553,9 +1553,33 @@ This section states the existence theorems from
     and cycling the trace gives the displayed inequality.
 \end{proof}
 
+\begin{lemma}[Determinant AM--GM Hilbert--Schmidt bound]
+\label{lem:det_amgm_hilbert_schmidt_bound}
+    \lean{Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one}
+    \leanok
+    Let $A\in \MN{D}$ with $D\geq 1$. If $|\det A|=1$, then
+    \[
+        D \leq \tr(A^{\dagger}A).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The matrix $A^{\dagger}A$ is positive semidefinite and has determinant
+    $|\det A|^{2}=1$. Thus the product of its Hermitian eigenvalues is one.
+    Denoting the eigenvalues of $A^{\dagger}A$ by
+    $\lambda_{1},\ldots,\lambda_{D}\geq 0$, the arithmetic-geometric mean
+    inequality gives
+    \[
+        \frac{\lambda_{1}+\cdots+\lambda_{D}}{D}
+        \geq(\lambda_{1}\cdots\lambda_{D})^{1/D}=1,
+    \]
+    so $\tr(A^{\dagger}A)=\lambda_{1}+\cdots+\lambda_{D}\geq D$.
+\end{proof}
+
 % Lean: Wolf.infimum_is_attained
 \begin{lemma}[Infimum attainment for SL-filterings]\label{lem:infimum_is_attained}
-    \uses{lem:posdef_trace_lower_bound}
+    \uses{lem:posdef_trace_lower_bound, lem:det_amgm_hilbert_schmidt_bound}
     For a positive-definite Choi matrix $\tau$, the infimum of
     $\tr\![(S_{2} \otimes_{k} S_{1}) \tau (S_{2} \otimes_{k} S_{1})^{\dagger}]$
     over $S_{1}, S_{2} \in \MN{D}$ with $\det S_{1} = \det S_{2} = 1$


### PR DESCRIPTION
### Motivation

- Issue LionSR/QICLean#143 concerns proving `Wolf.infimum_is_attained` in `TNLean/Channel/LorentzNormalForm.lean`: the infimum of $\mathrm{tr}[(S_2 \otimes_k S_1)\tau(S_2 \otimes_k S_1)^\dagger]$ over $S_1, S_2 \in M_D(\mathbb{C})$ with $\det S_1 = \det S_2 = 1$ is attained (Wolf §2.3, Prop. 2.8). One ingredient is a coercivity lower bound: matrices with unit determinant norm have Hilbert--Schmidt norm at least the matrix dimension.
- This bound was previously proved inside a private context in `TNLean/Channel/Determinant/HilbertSchmidt.lean`. Extracting it to `TNLean/Algebra/MatrixAux` makes it reusable for the coercivity argument in LionSR/QICLean#143, and documents it in the blueprint.

### Description

- **New lemma** `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one` in `TNLean/Algebra/MatrixAux.lean`: for a nonempty finite matrix index type `n`, if $\|\det A\| = 1$ then $|n| \le \mathrm{Re}\,\mathrm{tr}(A^\dagger A)$. The proof applies AM--GM to the Hermitian eigenvalues of $A^\dagger A$; their product equals $|\det A|^2 = 1$ and their sum equals the trace.
- `TNLean/Channel/Determinant/HilbertSchmidt.lean`: the private AM--GM auxiliary lemma (41 lines) is replaced by a two-line call to the new shared lemma; the local `MeanInequalities` import is removed.
- `blueprint/src/chapter/ch16_channel_representations.tex`: adds Lemma `det_amgm_hilbert_schmidt_bound` with `\lean{}` and `\leanok` tags; the statement is cited in the not-yet-proved `lem:infimum_is_attained` entry.
- No `sorry`, `admit`, `native_decide`, or `axiom` introduced.
- This PR addresses the determinant/AM--GM Hilbert--Schmidt component of LionSR/QICLean#143; the remaining ingredients are the Kronecker--Frobenius multiplicativity lemma and the compactness and extreme-value argument in `LorentzNormalForm.lean`.

### Testing

- `lake build TNLean.Algebra.MatrixAux TNLean.Channel.Determinant.HilbertSchmidt`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Refs LionSR/QICLean#143

> [!NOTE]
> **Low Risk**
> Proof extraction and blueprint sync only; channel Hilbert–Schmidt behavior is unchanged and the new lemma is standard matrix analysis.
> 
> **Overview**
> **Adds** shared lemma `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one` in `TNLean/Algebra/MatrixAux`: when `‖det A‖ = 1`, `Re tr(Aᴴ A)` is at least the matrix dimension (AM–GM on eigenvalues of `Aᴴ A`).
> 
> **Replaces** the long private AM–GM proof in `TNLean/Channel/Determinant/HilbertSchmidt` with a short call to that lemma (still yielding `d²` for `Fin d × Fin d` matrices). Drops the local `MeanInequalities` import there.
> 
> **Documents** the same statement in the blueprint as Lemma `det_amgm_hilbert_schmidt_bound` and cites it in the not-yet-proved SL-filtering infimum lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf130e42ed2debde6c3b06adceb9dc2ac683a4e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof relocation and blueprint sync only; channel Hilbert–Schmidt behavior is unchanged and no new axioms or admits are introduced.
> 
> **Overview**
> **Extracts** a reusable lemma `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one` into `TNLean/Algebra/MatrixAux`: when `‖det A‖ = 1`, `Re tr(Aᴴ A)` is at least `Fintype.card n` (AM–GM on PSD eigenvalues of `Aᴴ A`).
> 
> **Replaces** the ~40-line private proof in `TNLean/Channel/Determinant/HilbertSchmidt` with a short call to that lemma (still yielding `d²` for `Fin d × Fin d` endomorphisms). Drops the local `MeanInequalities` import from the channel file.
> 
> **Adds** blueprint Lemma `det_amgm_hilbert_schmidt_bound` with Lean sync tags and cites it in the not-yet-proved `lem:infimum_is_attained` entry for Wolf SL-filtering compactness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7b629b9dfde89096f4b17aa2a677d9674afd670. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->