### PR TITLE
feat(Algebra): add Kronecker Hilbert-Schmidt trace lemma

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -23,6 +23,8 @@ Extracted from various files for reusability.
   trace identity
 - `Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq`: the Hilbert--Schmidt
   trace form of the Frobenius norm
+- `Matrix.trace_conjTranspose_mul_self_kronecker`: Hilbert--Schmidt trace-form
+  multiplicativity for Kronecker products
 - `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one`: determinant
   AM--GM lower bound for the Hilbert--Schmidt trace form
 - `Matrix.PosSemidef.trace_mul_nonneg`: the trace product of two positive
@@ -34,7 +36,7 @@ Extracted from various files for reusability.
 - `Matrix.PosSemidef.mulVec_eq_zero_left/right`: kernel containment for PSD matrix sums
 -/
 
-open scoped Matrix BigOperators ComplexOrder Matrix.Norms.Frobenius
+open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius
 
 namespace Matrix
 
@@ -78,6 +80,36 @@ theorem trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq
   · positivity
 
 end FrobeniusTrace
+
+section FrobeniusKronecker
+
+variable {m n p q : Type*} [Fintype m] [Fintype n] [Fintype p] [Fintype q]
+
+/-- The Hilbert--Schmidt trace form is multiplicative under Kronecker products. -/
+theorem trace_conjTranspose_mul_self_kronecker
+    (A : Matrix m n ℂ) (B : Matrix p q ℂ) :
+    trace ((A ⊗ₖ B)ᴴ * (A ⊗ₖ B)) = trace (Aᴴ * A) * trace (Bᴴ * B) := by
+  rw [conjTranspose_kronecker]
+  rw [← mul_kronecker_mul (A := Aᴴ) (B := A) (A' := Bᴴ) (B' := B)]
+  rw [trace_kronecker]
+
+/-- The real Hilbert--Schmidt trace form is multiplicative under Kronecker products. -/
+theorem trace_conjTranspose_mul_self_re_kronecker
+    (A : Matrix m n ℂ) (B : Matrix p q ℂ) :
+    (trace ((A ⊗ₖ B)ᴴ * (A ⊗ₖ B))).re =
+      (trace (Aᴴ * A)).re * (trace (Bᴴ * B)).re := by
+  have hA_im : (trace (Aᴴ * A)).im = 0 :=
+    (RCLike.nonneg_iff.mp (posSemidef_conjTranspose_mul_self A).trace_nonneg).2
+  have hB_im : (trace (Bᴴ * B)).im = 0 :=
+    (RCLike.nonneg_iff.mp (posSemidef_conjTranspose_mul_self B).trace_nonneg).2
+  calc
+    (trace ((A ⊗ₖ B)ᴴ * (A ⊗ₖ B))).re =
+        (trace (Aᴴ * A) * trace (Bᴴ * B)).re := by
+          rw [trace_conjTranspose_mul_self_kronecker]
+    _ = (trace (Aᴴ * A)).re * (trace (Bᴴ * B)).re := by
+          rw [Complex.mul_re, hA_im, hB_im, mul_zero, sub_zero]
+
+end FrobeniusKronecker
 
 section FrobeniusDeterminant
 

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -182,10 +182,10 @@ minimisation over `det = 1` to a compact sublevel set, namely
 Hilbert–Schmidt multiplicativity `‖S₂ ⊗ₖ S₁‖² = ‖S₂‖² · ‖S₁‖²` and the AM–GM
 determinant bound `det S = 1 ⟹ ‖S‖² ≥ n` (singular values of `S` have product
 `|det S| = 1`, so their squares average at least `1`; hence the value tends to
-`∞` with `‖S‖`).  Elementary positive-definite spectral facts such as
-`Matrix.PosDef.eigenvalues_pos` are available; what remains is the packaged
-matrix-analysis estimate combining the filtered Choi trace, Frobenius
-multiplicativity, and the determinant AM--GM bound. -/
+`∞` with `‖S‖`).  The positive-definite trace lower bound, Kronecker
+Hilbert--Schmidt multiplicativity, and determinant AM--GM estimate are now
+separate lemmas; what remains is the matrix-analysis estimate combining them
+with the compactness and extreme-value argument. -/
 lemma infimum_is_attained
     {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
     (_hτ_posDef : τ.PosDef) :

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1577,9 +1577,31 @@ This section states the existence theorems from
     so $\tr(A^{\dagger}A)=\lambda_{1}+\cdots+\lambda_{D}\geq D$.
 \end{proof}
 
+\begin{lemma}[Kronecker Hilbert--Schmidt trace multiplicativity]
+\label{lem:kronecker_hilbert_schmidt_trace}
+    \lean{Matrix.trace_conjTranspose_mul_self_kronecker}
+    \leanok
+    For complex matrices $A$ and $B$ of compatible rectangular sizes,
+    \[
+        \tr\!\left((A\otimes_{k}B)^{\dagger}(A\otimes_{k}B)\right)
+        =
+        \tr(A^{\dagger}A)\,\tr(B^{\dagger}B).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Use
+    $(A\otimes_{k}B)^{\dagger}=A^{\dagger}\otimes_{k}B^{\dagger}$, the mixed
+    product identity for Kronecker products, and
+    $\tr(C\otimes_{k}D)=\tr(C)\tr(D)$. With
+    $C=A^{\dagger}A$ and $D=B^{\dagger}B$, these identities give the equality.
+\end{proof}
+
 % Lean: Wolf.infimum_is_attained
 \begin{lemma}[Infimum attainment for SL-filterings]\label{lem:infimum_is_attained}
-    \uses{lem:posdef_trace_lower_bound, lem:det_amgm_hilbert_schmidt_bound}
+    \uses{lem:posdef_trace_lower_bound, lem:det_amgm_hilbert_schmidt_bound,
+    lem:kronecker_hilbert_schmidt_trace}
     For a positive-definite Choi matrix $\tau$, the infimum of
     $\tr\![(S_{2} \otimes_{k} S_{1}) \tau (S_{2} \otimes_{k} S_{1})^{\dagger}]$
     over $S_{1}, S_{2} \in \MN{D}$ with $\det S_{1} = \det S_{2} = 1$


### PR DESCRIPTION
### Motivation
- The Hilbert--Schmidt trace-form multiplicativity for Kronecker products is an algebraic prerequisite for the infimum-attainment argument in Wolf §2.3, Proposition 2.8 (`blueprint/src/chapter/ch16_channel_representations.tex`, `lem:infimum_is_attained`), tracked in LionSR/QICLean#143.
- Separating this identity in `Algebra/MatrixAux.lean` gives the compactness and extreme-value argument in `LorentzNormalForm.lean` a named lemma for the Kronecker component.

### Description
- `TNLean/Algebra/MatrixAux.lean`: adds `Matrix.trace_conjTranspose_mul_self_kronecker`, the identity
  $$\operatorname{tr}\!\bigl((A \otimes_k B)^\dagger(A \otimes_k B)\bigr)
    = \operatorname{tr}(A^\dagger A)\operatorname{tr}(B^\dagger B)$$
  for complex rectangular matrices `A`, `B`; the proof uses Mathlib lemmas `conjTranspose_kronecker`, `mul_kronecker_mul`, and `trace_kronecker`.
- Keeps `Matrix.trace_conjTranspose_mul_self_re_kronecker` as the real-valued corollary used by later Hilbert--Schmidt estimates.
- `TNLean/Channel/LorentzNormalForm.lean`: updates the comment above `Wolf.infimum_is_attained`; the statement and its pre-existing `sorry` are unchanged.
- `blueprint/src/chapter/ch16_channel_representations.tex`: adds the corresponding blueprint lemma with `\lean{Matrix.trace_conjTranspose_mul_self_kronecker}` and `\leanok`, and records it in the `\uses` list for `lem:infimum_is_attained`.
- Pre-existing `sorry` declarations in `LorentzNormalForm.lean` remain tracked by LionSR/QICLean#143.

### Testing
- `lake env lean TNLean/Algebra/MatrixAux.lean`
- `lake env lean TNLean/Channel/LorentzNormalForm.lean`
- `lake build TNLean.Algebra.MatrixAux TNLean.Channel.LorentzNormalForm`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

Addresses LionSR/QICLean#143
