### PR TITLE
doc(PEPS): track 2D TI PEPS description corollary

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1414,6 +1414,59 @@ recorded in the route note
     formalization step.
 \end{proof}
 
+\begin{corollary}[Translation-invariant description of an injective 2D PEPS,
+        uniform bond dimension]%
+    \label{cor:exists_constant_injectivePEPS_of_translationInvariantState}
+    \notready
+    \uses{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState,
+        thm:fundamentalTheorem_PEPS, def:peps_torus_translation_invariant,
+        def:peps_torus_uniform_bond_dim,
+        thm:peps_stateCoeff_translationInvariant}
+    Let \(A\) be an injective PEPS on the discrete torus with orientation-uniform
+    bond dimensions, horizontal dimension \(D_h\) and vertical dimension \(D_v\),
+    and positive bond dimensions.  If the generated state is invariant under all
+    lattice translations \(\tau_{a,b}\), that is, for every translation and every
+    physical configuration \(\sigma\),
+    \[
+        \operatorname{Coeff}_{A}(\sigma\circ\tau_{a,b})
+        =
+        \operatorname{Coeff}_{A}(\sigma),
+    \]
+    then there is an injective torus tensor \(B\), with the same orientation-uniform
+    bond dimensions \(D_h\) and \(D_v\), whose constant (site-independent) family
+    generates the same state:
+    \[
+        \operatorname{Coeff}_{A}(\sigma)
+        =
+        \operatorname{Coeff}_{B}(\sigma)
+        \qquad\text{for every }\sigma.
+    \]
+
+    This is the uniform-bond-dimension target corresponding to the
+    Applications-section 2D corollary of
+    \cite[lines~1892--1894]{Molnar2018NormalPEPS}.  The source additionally
+    concludes that all vertical bond dimensions agree and all horizontal bond
+    dimensions agree; in the present orientation-uniform setting those two
+    clauses have already been built into the bond-dimension type, so they carry
+    no content here.
+\end{corollary}
+\begin{proof}
+    The argument is the one-dimensional construction of
+    Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
+    applied independently along the horizontal and the vertical lattice
+    translations.  Translation invariance of the state lets one compare \(A\)
+    with each of its translates through the injective PEPS Fundamental Theorem
+    (Theorem~\ref{thm:fundamentalTheorem_PEPS}), producing per-edge gauges along
+    each direction.  Telescoping the horizontal gauges around a row and the
+    vertical gauges around a column, and closing each with the periodic boundary
+    condition, collapses the per-edge gauges to a single virtual operation in
+    each orientation; absorbing them into one site gives the repeated tensor
+    \(B\).  Both the one-dimensional telescoping closure
+    (Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState})
+    and its two-directional assembly into a single repeated 2D tensor remain to
+    be formalized.
+\end{proof}
+
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%
     \label{thm:fundamentalTheorem_injectiveMPSChain_gauge_unique}
     \lean{TNLean.PEPS.fundamentalTheorem_injectiveMPSChain_gauge_unique}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1434,12 +1434,11 @@ recorded in the route note
     \]
     then there is an injective torus tensor \(B\), with the same orientation-uniform
     bond dimensions \(D_h\) and \(D_v\), whose constant (site-independent) family
-    generates the same state:
+    generates the same state: for every physical configuration \(\sigma\),
     \[
         \operatorname{Coeff}_{A}(\sigma)
         =
-        \operatorname{Coeff}_{B}(\sigma)
-        \qquad\text{for every }\sigma.
+        \operatorname{Coeff}_{B}(\sigma).
     \]
 
     This is the uniform-bond-dimension target corresponding to the
@@ -1451,20 +1450,49 @@ recorded in the route note
     no content here.
 \end{corollary}
 \begin{proof}
-    The argument is the one-dimensional construction of
-    Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}
-    applied independently along the horizontal and the vertical lattice
-    translations.  Translation invariance of the state lets one compare \(A\)
-    with each of its translates through the injective PEPS Fundamental Theorem
-    (Theorem~\ref{thm:fundamentalTheorem_PEPS}), producing per-edge gauges along
-    each direction.  Telescoping the horizontal gauges around a row and the
-    vertical gauges around a column, and closing each with the periodic boundary
-    condition, collapses the per-edge gauges to a single virtual operation in
-    each orientation; absorbing them into one site gives the repeated tensor
-    \(B\).  Both the one-dimensional telescoping closure
+    The source states this corollary without proof, remarking only that the
+    one-dimensional argument extends; the route below is that intended
+    extension.  Write \(A^{(j,k)}\) for the site tensor at lattice position
+    \((j,k)\), with horizontal virtual legs of dimension \(D_h\) and vertical
+    virtual legs of dimension \(D_v\).  Comparing the state with its
+    \(\tau_{1,0}\)-translate through the injective PEPS Fundamental Theorem
+    (Theorem~\ref{thm:fundamentalTheorem_PEPS}) produces, on each horizontal
+    edge, invertible \(D_h\times D_h\) gauges \(X^{(j,k)}_h\) with
+    \[
+        A^{(j+1,k)} = \bigl(X^{(j,k)}_h\bigr)^{-1}\, A^{(j,k)}\, X^{(j+1,k)}_h,
+    \]
+    acting on the two horizontal virtual legs, and comparing with the
+    \(\tau_{0,1}\)-translate produces, on each vertical edge, invertible
+    \(D_v\times D_v\) gauges \(X^{(j,k)}_v\) with
+    \[
+        A^{(j,k+1)} = \bigl(X^{(j,k)}_v\bigr)^{-1}\, A^{(j,k)}\, X^{(j,k+1)}_v.
+    \]
+    Telescoping the horizontal gauges along a row reduces each site to the
+    leftmost one,
+    \[
+        A^{(j,k)} = \bigl(L^{(j,k)}_h\bigr)^{-1}\, A^{(0,k)}\, R^{(j,k)}_h,
+        \qquad
+        L^{(j,k)}_h = X^{(0,k)}_h\cdots X^{(j-1,k)}_h,
+        \quad
+        R^{(j,k)}_h = X^{(1,k)}_h\cdots X^{(j,k)}_h,
+    \]
+    and the periodic boundary condition closes the row product into a single
+    residual virtual operation, the 2D analogue of the one-dimensional identity
+    \(R_vL_{v+1}^{-1}=Z_0^{-1}\):
+    \[
+        R^{(j,k)}_h\,\bigl(L^{(j+1,k)}_h\bigr)^{-1} = \bigl(X^{(0,k)}_h\bigr)^{-1}.
+    \]
+    The same telescoping closes each column, yielding one residual vertical
+    operation.  Absorbing the two residual gauges into the corner site gives a
+    single repeated tensor
+    \[
+        B = \bigl(X^{(0,0)}_v\bigr)^{-1}\,\bigl(X^{(0,0)}_h\bigr)^{-1}\, A^{(0,0)},
+    \]
+    whose constant family generates the same state.  Both the one-dimensional
+    telescoping closure
     (Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState})
-    and its two-directional assembly into a single repeated 2D tensor remain to
-    be formalized.
+    and its two-directional assembly into this single repeated 2D tensor remain
+    to be formalized.
 \end{proof}
 
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2767,6 +2767,40 @@ existence of the repeated injective tensor \(B\), but it cannot express the
 source's equal-bond-dimension conclusion as a theorem with mathematical
 content. The per-bond rectangular version remains open.
 
+\subsection*{The 2D analogue}
+
+The Applications section states the same corollary in two dimensions
+immediately after the one-dimensional version (lines 1892--1894 of
+\path{Papers/1804.04964/paper_normal.tex}), tracked by \ghissue{2921}. Its
+input is an injective 2D PEPS whose generated state is invariant under the
+lattice translations; its conclusion is that all vertical bond dimensions
+agree, all horizontal bond dimensions agree, and the state has a
+translation-invariant 2D PEPS description with a single injective tensor \(B\)
+of the same horizontal and vertical bond dimensions. The source proves it by
+applying the one-dimensional argument separately along the horizontal and the
+vertical lattice translations: comparing the tensor with each translate through
+the injective PEPS Fundamental Theorem produces per-edge gauges, which telescope
+around each row and each column and close under the periodic boundary condition.
+
+The load-bearing dependency, the injective PEPS Fundamental Theorem
+(\path{TNLean.PEPS.fundamentalTheorem_PEPS}, blueprint
+\path{thm:fundamentalTheorem_PEPS}), is formalized. The remaining work is the
+two-directional telescoping closure, which is the 2D form of the
+still-open one-dimensional repeated-tensor construction discussed above; it is
+not yet formalized. The blueprint records the restricted target as
+\path{cor:exists_constant_injectivePEPS_of_translationInvariantState}, marked
+not ready.
+
+\emph{Verdict: scope restriction.} As in the one-dimensional case, the
+orientation-uniform torus bond-dimension type fixes the horizontal dimension
+\(D_h\) and the vertical dimension \(D_v\) in advance, so the source's
+``all vertical (resp. horizontal) bond dimensions are equal'' clauses are
+vacuous in the uniform-dimension statement. A fully faithful version requires a
+per-edge, rectangular bond model in which the adjacent invertible gauges along
+each orientation first force equality of the bond dimensions; that variant
+inherits the same uniform-dimension restriction recorded for the
+one-dimensional corollary and remains a separate follow-up.
+
 \section*{The strengthening to $n \ge 2L+1$ via overlapping windows}
 
 The plan recorded in the previous section is carried out: the source's

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2776,11 +2776,16 @@ input is an injective 2D PEPS whose generated state is invariant under the
 lattice translations; its conclusion is that all vertical bond dimensions
 agree, all horizontal bond dimensions agree, and the state has a
 translation-invariant 2D PEPS description with a single injective tensor \(B\)
-of the same horizontal and vertical bond dimensions. The source proves it by
-applying the one-dimensional argument separately along the horizontal and the
-vertical lattice translations: comparing the tensor with each translate through
-the injective PEPS Fundamental Theorem produces per-edge gauges, which telescope
-around each row and each column and close under the periodic boundary condition.
+of the same horizontal and vertical bond dimensions. The source states this
+corollary without proof (lines 1892--1894); it gives a proof only for the
+one-dimensional case (lines 1807--1890) and remarks at line 1801 that ``below we
+provide the proof for injective MPS, but the proof can easily be extended to the
+other cases as well.'' The intended extension applies the one-dimensional
+argument separately along the horizontal and the vertical lattice translations:
+comparing the tensor with each translate through the injective PEPS Fundamental
+Theorem would produce per-edge gauges, which telescope around each row and each
+column and close under the periodic boundary condition. This route is the
+expected one, not a proof the source carries out.
 
 The load-bearing dependency, the injective PEPS Fundamental Theorem
 (\path{TNLean.PEPS.fundamentalTheorem_PEPS}, blueprint


### PR DESCRIPTION
### Motivation
- Adds blueprint and paper-gap tracking for the 2D applications corollary of arXiv:1804.04964, lines 1892–1894: an injective 2D PEPS whose generated state is translation-invariant admits a TI PEPS description by a single injective tensor with the same bond dimensions (see #2921).
- The load-bearing Lean dependency (`fundamentalTheorem_PEPS`) is already formalized; the two-directional telescoping proof requires the 1D constructive counterpart from #2920 first.

### Description
- `blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex`: adds `\notready` corollary `cor:exists_constant_injectivePEPS_of_translationInvariantState` (arXiv:1804.04964, lines 1892–1894) with a proof sketch via horizontal/vertical 1D telescoping from `fundamentalTheorem_PEPS`.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: extends the existing 1D paper-gap note with the 2D analogue, recording the scope restriction (orientation-uniform torus bond-dimension type makes the source's equal-bond-dimension clauses vacuous) and the open dependency on #2920.
- No Lean changes; this is non-blocked tracking preparation only.

### Testing
- Documentation-only changes (`.tex` files); no Lean proofs modified.
- Relies on Blueprint Lint CI (`lint-blueprint.yml`) to validate LaTeX labels and references.

---
Addresses #2921

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX blueprint and paper-gap notes only; no proofs or runtime code.
> 
> **Overview**
> Adds **documentation-only** tracking for the Molnar 2018 Applications **2D corollary** (lines 1892–1894): a translation-invariant injective torus PEPS should admit the same state from a **single repeated injective tensor** with fixed horizontal/vertical bond dimensions.
> 
> In **`ch24_peps_ft_normal_capstone.tex`**, introduces a `\notready` blueprint corollary `cor:exists_constant_injectivePEPS_of_translationInvariantState` with a proof sketch—compare horizontal and vertical translates via `fundamentalTheorem_PEPS`, telescope row/column gauges, absorb residuals into one tensor `B`—and notes that the **1D repeated-tensor step** and the **2D assembly** are still open.
> 
> In **`peps_normal_ft_section3_route.tex`**, adds a **“2D analogue”** subsection mirroring the existing 1D gap note: intended proof route, dependency on formalized `fundamentalTheorem_PEPS`, open two-directional telescoping (blocked on **#2920**), and the **scope restriction** that orientation-uniform torus bond types make the source’s “all bonds equal” clauses vacuous.
> 
> **No Lean changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bda112338fa52f52ee51e5bc330301eb83218612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->