### PR TITLE
feat(Channel): prove `Wolf.infimum_is_attained`

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -8,75 +8,75 @@ import TNLean.Algebra.MatrixAux
 /-!
 # Hermitian matrix extremal eigenvalues
 
-This file provides lemmas for Hermitian complex matrices over `Fin D`: the
-extremal eigenvalue lemmas and scalar-shift spectral formulae.
+This file provides lemmas for Hermitian complex matrices over an arbitrary finite
+index type: the extremal eigenvalue lemmas and scalar-shift spectral formulae.
 -/
 
 open scoped Matrix ComplexOrder
 
-variable {D : ℕ}
+variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- Smallest eigenvalue of a Hermitian matrix on a nonempty finite space. -/
-noncomputable def minEigenvalue [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) : ℝ :=
+noncomputable def minEigenvalue [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) : ℝ :=
   (Finset.univ.image hM.eigenvalues).min' (Finset.Nonempty.image Finset.univ_nonempty _)
 
 /-- The smallest eigenvalue is bounded above by every eigenvalue. -/
-theorem minEigenvalue_le [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (i : Fin D) :
+theorem minEigenvalue_le [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (i : n) :
     minEigenvalue hM ≤ hM.eigenvalues i :=
   Finset.min'_le _ _ (Finset.mem_image.mpr ⟨i, Finset.mem_univ _, rfl⟩)
 
 /-- The smallest eigenvalue is attained by some eigenvector. -/
-theorem minEigenvalue_achieved [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
-    ∃ i : Fin D, hM.eigenvalues i = minEigenvalue hM := by
+theorem minEigenvalue_achieved [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
+    ∃ i : n, hM.eigenvalues i = minEigenvalue hM := by
   have hne := Finset.Nonempty.image Finset.univ_nonempty hM.eigenvalues
   obtain ⟨i, _, hi⟩ := Finset.mem_image.mp (Finset.min'_mem _ hne)
   exact ⟨i, hi⟩
 
 /-- A positive definite Hermitian matrix has positive smallest eigenvalue. -/
-theorem minEigenvalue_pos_of_posDef [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (hPD : M.PosDef) :
+theorem minEigenvalue_pos_of_posDef [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (hPD : M.PosDef) :
     (0 : ℝ) < minEigenvalue hM := by
   simp only [minEigenvalue, Finset.lt_min'_iff, Finset.mem_image, Finset.mem_univ, true_and]
   rintro _ ⟨i, rfl⟩
   exact hM.posDef_iff_eigenvalues_pos.mp hPD i
 
 /-- Largest eigenvalue of a Hermitian matrix on a nonempty finite space. -/
-noncomputable def maxEigenvalue [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) : ℝ :=
+noncomputable def maxEigenvalue [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) : ℝ :=
   (Finset.univ.image hM.eigenvalues).max' (Finset.Nonempty.image Finset.univ_nonempty _)
 
 /-- Every eigenvalue is bounded above by the largest eigenvalue. -/
-theorem le_maxEigenvalue [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (i : Fin D) :
+theorem le_maxEigenvalue [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (i : n) :
     hM.eigenvalues i ≤ maxEigenvalue hM :=
   Finset.le_max' _ _ (Finset.mem_image.mpr ⟨i, Finset.mem_univ _, rfl⟩)
 
 /-- The largest eigenvalue is attained by some eigenvector. -/
-theorem maxEigenvalue_achieved [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
-    ∃ i : Fin D, hM.eigenvalues i = maxEigenvalue hM := by
+theorem maxEigenvalue_achieved [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
+    ∃ i : n, hM.eigenvalues i = maxEigenvalue hM := by
   have hne := Finset.Nonempty.image Finset.univ_nonempty hM.eigenvalues
   obtain ⟨i, _, hi⟩ := Finset.mem_image.mp (Finset.max'_mem _ hne)
   exact ⟨i, hi⟩
 
 /-- Spectral form of subtracting a scalar multiple of the identity from a Hermitian matrix. -/
 theorem hermitian_sub_scalar_spectral
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (c : ℝ) :
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (c : ℝ) :
     M - (↑c : ℂ) • 1 =
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ) *
       Matrix.diagonal (fun j => (↑(hM.eigenvalues j - c) : ℂ)) *
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-  set U : Matrix (Fin D) (Fin D) ℂ := ↑hM.eigenvectorUnitary
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ)ᴴ := by
+  set U : Matrix n n ℂ := ↑hM.eigenvectorUnitary
   have hUU : U * Uᴴ = 1 := by
     simpa [U, Matrix.star_eq_conjTranspose] using
       (Unitary.mul_star_self_of_mem hM.eigenvectorUnitary.prop)
-  have h_cI : (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) =
+  have h_cI : (↑c : ℂ) • (1 : Matrix n n ℂ) =
       U * ((↑c : ℂ) • 1) * Uᴴ := by
     calc
-      (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
+      (↑c : ℂ) • (1 : Matrix n n ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
         rw [hUU]
       _ = U * ((↑c : ℂ) • 1) * Uᴴ := by
           rw [Matrix.mul_smul, Matrix.mul_one, smul_mul_assoc]
@@ -102,12 +102,12 @@ theorem hermitian_sub_scalar_spectral
           simp [Complex.ofReal_sub]
 
 /-- Subtracting the smallest Hermitian eigenvalue leaves a positive semidefinite matrix. -/
-theorem sub_minEigenvalue_smul_one_posSemidef [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
+theorem sub_minEigenvalue_smul_one_posSemidef [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
     (M - (↑(minEigenvalue hM) : ℂ) • 1).PosSemidef := by
   classical
-  let U : Matrix (Fin D) (Fin D) ℂ := ↑hM.eigenvectorUnitary
-  let Λ : Fin D → ℂ := fun j => ↑(hM.eigenvalues j - minEigenvalue hM)
+  let U : Matrix n n ℂ := ↑hM.eigenvectorUnitary
+  let Λ : n → ℂ := fun j => ↑(hM.eigenvalues j - minEigenvalue hM)
   have hdiag : (Matrix.diagonal Λ).PosSemidef := by
     refine Matrix.PosSemidef.diagonal ?_
     intro j
@@ -125,15 +125,15 @@ This is the matrix estimate used in Wolf's compactness argument for the Lorentz
 normal form: the filtered Choi trace is bounded below by the smallest
 eigenvalue times the Hilbert--Schmidt trace form. -/
 theorem posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le
-    [Nonempty (Fin D)] {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.PosDef)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
+    [Nonempty n] {M : Matrix n n ℂ} (hM : M.PosDef)
+    (X : Matrix n n ℂ) :
     (↑(minEigenvalue hM.isHermitian) : ℂ) * Matrix.trace (Xᴴ * X) ≤
       Matrix.trace (X * M * Xᴴ) := by
   classical
   let lam : ℂ := ↑(minEigenvalue hM.isHermitian)
   have hleft : (Xᴴ * X).PosSemidef :=
     Matrix.posSemidef_conjTranspose_mul_self X
-  have hdiff : (M - lam • (1 : Matrix (Fin D) (Fin D) ℂ)).PosSemidef := by
+  have hdiff : (M - lam • (1 : Matrix n n ℂ)).PosSemidef := by
     simpa [lam] using sub_minEigenvalue_smul_one_posSemidef hM.isHermitian
   have hnonneg : 0 ≤ Matrix.trace ((Xᴴ * X) * (M - lam • 1)) :=
     Matrix.PosSemidef.trace_mul_nonneg hleft hdiff
@@ -156,19 +156,19 @@ theorem posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le
 
 /-- Spectral form of subtracting a Hermitian matrix from a scalar multiple of the identity. -/
 theorem smul_one_sub_hermitian_spectral
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (c : ℝ) :
-    (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) - M =
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (c : ℝ) :
+    (↑c : ℂ) • (1 : Matrix n n ℂ) - M =
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ) *
       Matrix.diagonal (fun j => (↑(c - hM.eigenvalues j) : ℂ)) *
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-  set U : Matrix (Fin D) (Fin D) ℂ := ↑hM.eigenvectorUnitary
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ)ᴴ := by
+  set U : Matrix n n ℂ := ↑hM.eigenvectorUnitary
   have hUU : U * Uᴴ = 1 := by
     simpa [U, Matrix.star_eq_conjTranspose] using
       (Unitary.mul_star_self_of_mem hM.eigenvectorUnitary.prop)
-  have h_cI : (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) =
+  have h_cI : (↑c : ℂ) • (1 : Matrix n n ℂ) =
       U * ((↑c : ℂ) • 1) * Uᴴ := by
     calc
-      (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
+      (↑c : ℂ) • (1 : Matrix n n ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
         rw [hUU]
       _ = U * ((↑c : ℂ) • 1) * Uᴴ := by
           rw [Matrix.mul_smul, Matrix.mul_one, smul_mul_assoc]
@@ -177,7 +177,7 @@ theorem smul_one_sub_hermitian_spectral
     simpa [U, Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
       Function.comp_def] using hM.spectral_theorem
   calc
-    (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) - M
+    (↑c : ℂ) • (1 : Matrix n n ℂ) - M
         = U * ((↑c : ℂ) • 1) * Uᴴ -
             U * Matrix.diagonal (fun j => (↑(hM.eigenvalues j) : ℂ)) * Uᴴ := by
               conv_lhs =>

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -10,6 +10,7 @@ import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.MeanInequalities
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
+import Mathlib.Topology.Instances.Matrix
 
 /-!
 # Auxiliary matrix lemmas
@@ -34,6 +35,7 @@ Extracted from various files for reusability.
 - `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
   variant
 - `Matrix.PosSemidef.mulVec_eq_zero_left/right`: kernel containment for PSD matrix sums
+- `Continuous.matrix_kronecker`: joint continuity of the Kronecker product in both factors
 -/
 
 open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius
@@ -304,3 +306,15 @@ theorem mulVec_eq_zero_right
 end Matrix.PosSemidef
 
 end KernelPSD
+
+/-- The Kronecker product is jointly continuous in both of its matrix factors.
+
+This is the entrywise statement: each entry of `A x ⊗ₖ B x` is a product of one
+entry of `A x` and one entry of `B x`, both continuous in `x`. -/
+theorem Continuous.matrix_kronecker {X l m p q : Type*} [TopologicalSpace X]
+    {α : Type*} [TopologicalSpace α] [Mul α] [ContinuousMul α]
+    {A : X → Matrix l m α} {B : X → Matrix p q α}
+    (hA : Continuous A) (hB : Continuous B) :
+    Continuous fun x => (A x) ⊗ₖ (B x) := by
+  refine continuous_matrix fun i j => ?_
+  exact (hA.matrix_elem i.1 j.1).mul (hB.matrix_elem i.2 j.2)

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -6,8 +6,13 @@ import TNLean.Channel.Basic
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.NormalForm
+import TNLean.Algebra.HermitianHelpers
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
+import Mathlib.Topology.Instances.Matrix
+import Mathlib.Topology.Algebra.Module.FiniteDimension
+import Mathlib.Topology.Order.Compact
+import Mathlib.Topology.MetricSpace.Bounded
 
 /-!
 # Lorentz normal form for quantum channels (Wolf Section 2.3, Propositions 2.8–2.11)
@@ -40,21 +45,34 @@ normal form* — with three canonical representatives.
    Pauli-basis transfer matrix takes one of three canonical forms: diagonal,
    non-diagonal, or singular.
 
-## Dependencies on missing Mathlib infrastructure
+## Compactness / minimisation argument
 
 The compactness / minimisation argument used in the proof of Proposition 2.8 and 2.9
-(over SL(n, ℂ) filterings) is not yet formalised in Mathlib or TNLean.  The
-relevant theorems are therefore stated with `sorry` for the minimisation core.
-See the documentation of `infimum_is_attained` for the precise missing fact.
+(over SL(n, ℂ) filterings) is formalised in `infimum_is_attained`: the trace
+functional is coercive on `{det = 1}`, so a global minimiser exists by the
+extreme value theorem on a compact Frobenius ball.  See the documentation of
+`infimum_is_attained` for the proof outline.
 
 ## References
 
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3][Wolf2012QChannels]
 -/
 
-open scoped Matrix BigOperators ComplexOrder Kronecker
+open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius
 open Matrix Finset
 open ChoiJamiolkowski
+
+/-- The Kronecker product is jointly continuous in both of its matrix factors.
+
+This is the entrywise statement: each entry of `A x ⊗ₖ B x` is a product of one
+entry of `A x` and one entry of `B x`, both continuous in `x`. -/
+theorem Continuous.matrix_kronecker {X l m p q : Type*} [TopologicalSpace X]
+    {α : Type*} [TopologicalSpace α] [Mul α] [ContinuousMul α]
+    {A : X → Matrix l m α} {B : X → Matrix p q α}
+    (hA : Continuous A) (hB : Continuous B) :
+    Continuous fun x => (A x) ⊗ₖ (B x) := by
+  refine continuous_matrix fun i j => ?_
+  exact (hA.matrix_elem i.1 j.1).mul (hB.matrix_elem i.2 j.2)
 
 namespace Wolf
 
@@ -147,55 +165,159 @@ The proof idea (see Wolf Section 2.3):
 5. At the optimum, both partial traces of τ' are proportional to identity,
    giving doubly-stochastic T'.
 
-Step 4 is the compactness/minimisation argument that is **not yet formalised**
-in Mathlib or TNLean.  We state the lemma as `infimum_is_attained` with a
-`sorry` filler.  Step 5 follows from the optimality condition (AGM iteration),
-stated below. -/
+Step 4 is the compactness/minimisation argument, formalised in
+`infimum_is_attained` below.  Step 5 follows from the optimality condition (AGM
+iteration), and is not yet formalised. -/
 
 section GenericNormalForm
 
 variable {D : ℕ}
 
-/-- **Key lemma (not yet formalised).**  For a positive-definite Choi matrix τ,
-the infimum of `tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` over `S₁, S₂` with `det = 1`
-is attained.  That is, the continuous function
-`(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
-achieves its minimum on the domain of SL(n, ℂ) × SL(n, ℂ).
+/-- **Key lemma.**  For a positive-definite Choi matrix τ, the infimum of
+`tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` over `S₁, S₂` with `det = 1` is attained.  That
+is, the continuous function `(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` achieves
+its minimum on the domain of SL(n, ℂ) × SL(n, ℂ).
 
-**Proof sketch** (Wolf Section 2.3).  Throughout, `‖·‖` denotes the Frobenius
+**Proof** (Wolf Section 2.3).  Throughout, `‖·‖` denotes the Frobenius
 (Hilbert–Schmidt) norm `‖M‖² = tr[M M†]`; the coercivity bounds below are false
-for the operator norm (e.g. `‖I‖_op² = 1 < n`).  There exist bounds
-  `0 < λ_min(τ) · ‖S₂ ⊗ₖ S₁‖² ≤ tr[τ'] ≤ tr[τ]`,
-so we may restrict to a bounded subset `{S_i | ‖S_i‖ ≤ C}` inside
-`{S | det S = 1}`.  In finite dimensions this set is compact, and the
-continuous trace functional attains its infimum by the extreme value theorem.
-
-**Available Mathlib facts:** the extreme value theorem is
-`IsCompact.exists_isMinOn` (`Mathlib.Topology.Order.Compact`); finite-dimensional
-Heine–Borel is `Metric.isCompact_of_isClosed_isBounded` (the matrix space is a
-proper space); and `det S = 1` is closed as the preimage of `{1}` under the
-continuous determinant.
-
-**Remaining gap:** the **coercivity bound** that reduces the unbounded
-minimisation over `det = 1` to a compact sublevel set, namely
-`tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] ≥ λ_min(τ) · ‖S₂ ⊗ₖ S₁‖²` together with the
-Hilbert–Schmidt multiplicativity `‖S₂ ⊗ₖ S₁‖² = ‖S₂‖² · ‖S₁‖²` and the AM–GM
-determinant bound `det S = 1 ⟹ ‖S‖² ≥ n` (singular values of `S` have product
-`|det S| = 1`, so their squares average at least `1`; hence the value tends to
-`∞` with `‖S‖`).  The positive-definite trace lower bound, Kronecker
-Hilbert--Schmidt multiplicativity, and determinant AM--GM estimate are now
-separate lemmas; what remains is the matrix-analysis estimate combining them
-with the compactness and extreme-value argument. -/
+for the operator norm (e.g. `‖I‖_op² = 1 < n`).  Writing `X = S₂ ⊗ₖ S₁`, the
+smallest-eigenvalue bound `posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le`
+gives `λ_min(τ) · tr[Xᴴ X] ≤ tr[X τ Xᴴ]`, Hilbert–Schmidt multiplicativity
+`trace_conjTranspose_mul_self_re_kronecker` gives
+`tr[Xᴴ X] = tr[S₂ᴴ S₂] · tr[S₁ᴴ S₁]`, and the determinant AM–GM estimate
+`card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one` gives
+`tr[Sᵢᴴ Sᵢ] = ‖Sᵢ‖² ≥ n` whenever `det Sᵢ = 1`.  Combining these,
+`tr[X τ Xᴴ] ≥ λ_min(τ) · n · ‖Sᵢ‖²` for each factor, so any minimiser is confined
+to the bounded set `{S | ‖S‖ ≤ C}`.  Intersecting with the closed set `det S = 1`
+gives a compact set on which the continuous trace functional attains its minimum
+(`IsCompact.exists_isMinOn`); a value outside the sublevel set is automatically
+larger than the value at the identity, so this minimiser is global. -/
 lemma infimum_is_attained
     {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
-    (_hτ_posDef : τ.PosDef) :
+    (hτ_posDef : τ.PosDef) :
     ∃ (S₁ S₂ : Matrix (Fin D) (Fin D) ℂ),
       S₁.det = 1 ∧ S₂.det = 1 ∧
       ∀ (T₁ T₂ : Matrix (Fin D) (Fin D) ℂ),
         T₁.det = 1 → T₂.det = 1 →
         (Matrix.trace (((T₂ ⊗ₖ T₁) * τ * ((T₂ ⊗ₖ T₁)ᴴ)))).re ≥
           (Matrix.trace (((S₂ ⊗ₖ S₁) * τ * ((S₂ ⊗ₖ S₁)ᴴ)))).re := by
-  sorry
+  classical
+  -- The degenerate case `D = 0`: all matrices are `0 × 0`, every trace vanishes.
+  rcases Nat.eq_zero_or_pos D with hD | hD
+  · subst hD
+    refine ⟨1, 1, Matrix.det_one, Matrix.det_one, ?_⟩
+    intro T₁ T₂ _ _
+    simp [Matrix.trace, Matrix.diag]
+  haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
+  haveI : Nonempty (Fin D × Fin D) := ⟨(⟨0, hD⟩, ⟨0, hD⟩)⟩
+  haveI : ProperSpace
+      (Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ) :=
+    FiniteDimensional.proper_rclike ℂ _
+  -- The functional to minimise, as a function of the pair `(S₁, S₂)`.
+  let g : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ → ℝ :=
+    fun p => (Matrix.trace ((p.2 ⊗ₖ p.1) * τ * ((p.2 ⊗ₖ p.1)ᴴ))).re
+  set lam : ℝ := minEigenvalue hτ_posDef.isHermitian with hlam_def
+  have hlam : 0 < lam := minEigenvalue_pos_of_posDef hτ_posDef.isHermitian hτ_posDef
+  set cardR : ℝ := (Fintype.card (Fin D) : ℝ) with hcardR
+  have hcardR_pos : 0 < cardR := by
+    rw [hcardR]; exact_mod_cast Fintype.card_pos
+  -- Coercivity: the value dominates `λ · ‖S₂‖² · ‖S₁‖²`.
+  have key : ∀ S₁ S₂ : Matrix (Fin D) (Fin D) ℂ,
+      lam * ((Matrix.trace (S₂ᴴ * S₂)).re * (Matrix.trace (S₁ᴴ * S₁)).re) ≤
+        g (S₁, S₂) := by
+    intro S₁ S₂
+    have hle := (Complex.le_def.mp
+      (posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le hτ_posDef (S₂ ⊗ₖ S₁))).1
+    rw [Complex.re_ofReal_mul, trace_conjTranspose_mul_self_re_kronecker] at hle
+    exact hle
+  -- The bound at the identity confines minimisers to a Frobenius ball.
+  set B : ℝ := g (1, 1) with hB
+  set C : ℝ := Real.sqrt (B / (lam * cardR)) with hC
+  have hbound : ∀ S₁ S₂ : Matrix (Fin D) (Fin D) ℂ, S₁.det = 1 → S₂.det = 1 →
+      g (S₁, S₂) ≤ B → ‖S₁‖ ≤ C ∧ ‖S₂‖ ≤ C := by
+    intro S₁ S₂ h1 h2 hgB
+    have hd1 : ‖S₁.det‖ = 1 := by rw [h1]; simp
+    have hd2 : ‖S₂.det‖ = 1 := by rw [h2]; simp
+    have hn1 : cardR ≤ (Matrix.trace (S₁ᴴ * S₁)).re :=
+      card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one S₁ hd1
+    have hn2 : cardR ≤ (Matrix.trace (S₂ᴴ * S₂)).re :=
+      card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one S₂ hd2
+    have ht1 : 0 ≤ (Matrix.trace (S₁ᴴ * S₁)).re := hcardR_pos.le.trans hn1
+    have ht2 : 0 ≤ (Matrix.trace (S₂ᴴ * S₂)).re := hcardR_pos.le.trans hn2
+    have hδ : 0 < lam * cardR := mul_pos hlam hcardR_pos
+    -- Bound on `‖S₁‖`.
+    have hsq1 : ‖S₁‖ ^ 2 ≤ B / (lam * cardR) := by
+      have hchain : (lam * cardR) * (Matrix.trace (S₁ᴴ * S₁)).re ≤ B := by
+        calc (lam * cardR) * (Matrix.trace (S₁ᴴ * S₁)).re
+            = lam * (cardR * (Matrix.trace (S₁ᴴ * S₁)).re) := by ring
+          _ ≤ lam * ((Matrix.trace (S₂ᴴ * S₂)).re * (Matrix.trace (S₁ᴴ * S₁)).re) := by
+                exact mul_le_mul_of_nonneg_left
+                  (mul_le_mul_of_nonneg_right hn2 ht1) hlam.le
+          _ ≤ g (S₁, S₂) := key S₁ S₂
+          _ ≤ B := hgB
+      rw [← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq, le_div_iff₀ hδ, mul_comm]
+      exact hchain
+    have hsq2 : ‖S₂‖ ^ 2 ≤ B / (lam * cardR) := by
+      have hchain : (lam * cardR) * (Matrix.trace (S₂ᴴ * S₂)).re ≤ B := by
+        calc (lam * cardR) * (Matrix.trace (S₂ᴴ * S₂)).re
+            = lam * ((Matrix.trace (S₂ᴴ * S₂)).re * cardR) := by ring
+          _ ≤ lam * ((Matrix.trace (S₂ᴴ * S₂)).re * (Matrix.trace (S₁ᴴ * S₁)).re) := by
+                exact mul_le_mul_of_nonneg_left
+                  (mul_le_mul_of_nonneg_left hn1 ht2) hlam.le
+          _ ≤ g (S₁, S₂) := key S₁ S₂
+          _ ≤ B := hgB
+      rw [← trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq, le_div_iff₀ hδ, mul_comm]
+      exact hchain
+    refine ⟨?_, ?_⟩
+    · rw [hC, ← Real.sqrt_sq (norm_nonneg S₁)]; exact Real.sqrt_le_sqrt hsq1
+    · rw [hC, ← Real.sqrt_sq (norm_nonneg S₂)]; exact Real.sqrt_le_sqrt hsq2
+  -- The compact constraint set.
+  set Kc : Set (Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ) :=
+    {p | p.1.det = 1 ∧ p.2.det = 1 ∧ ‖p.1‖ ≤ C ∧ ‖p.2‖ ≤ C} with hKc
+  have hgcont : Continuous g := by
+    have hk : Continuous fun p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ =>
+        p.2 ⊗ₖ p.1 := Continuous.matrix_kronecker continuous_snd continuous_fst
+    exact Complex.continuous_re.comp
+      ((hk.matrix_mul continuous_const).matrix_mul hk.matrix_conjTranspose).matrix_trace
+  have hclosed : IsClosed Kc := by
+    have c1 : IsClosed {p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ | p.1.det = 1} :=
+      isClosed_eq continuous_fst.matrix_det continuous_const
+    have c2 : IsClosed {p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ | p.2.det = 1} :=
+      isClosed_eq continuous_snd.matrix_det continuous_const
+    have c3 : IsClosed {p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ | ‖p.1‖ ≤ C} :=
+      isClosed_le (continuous_norm.comp continuous_fst) continuous_const
+    have c4 : IsClosed {p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ | ‖p.2‖ ≤ C} :=
+      isClosed_le (continuous_norm.comp continuous_snd) continuous_const
+    have hset : Kc = {p | p.1.det = 1} ∩ {p | p.2.det = 1} ∩ {p | ‖p.1‖ ≤ C} ∩ {p | ‖p.2‖ ≤ C} := by
+      rw [hKc]; ext p; simp only [Set.mem_inter_iff, Set.mem_setOf_eq]; tauto
+    rw [hset]; exact ((c1.inter c2).inter c3).inter c4
+  have hbdd : Bornology.IsBounded Kc := by
+    refine (Metric.isBounded_closedBall (x := (0 : Matrix (Fin D) (Fin D) ℂ ×
+      Matrix (Fin D) (Fin D) ℂ)) (r := C)).subset ?_
+    intro p hp
+    rw [hKc, Set.mem_setOf_eq] at hp
+    rw [Metric.mem_closedBall]
+    calc dist p 0 = max (dist p.1 0) (dist p.2 0) := Prod.dist_eq
+      _ = max ‖p.1‖ ‖p.2‖ := by rw [dist_zero_right, dist_zero_right]
+      _ ≤ C := max_le hp.2.2.1 hp.2.2.2
+  have hKcompact : IsCompact Kc := Metric.isCompact_of_isClosed_isBounded hclosed hbdd
+  have h11mem : (1, 1) ∈ Kc := by
+    rw [hKc, Set.mem_setOf_eq]
+    obtain ⟨hc1, hc2⟩ := hbound 1 1 Matrix.det_one Matrix.det_one (le_of_eq hB.symm)
+    exact ⟨Matrix.det_one, Matrix.det_one, hc1, hc2⟩
+  obtain ⟨pmin, hpmin_mem, hpmin_min⟩ :=
+    hKcompact.exists_isMinOn ⟨(1, 1), h11mem⟩ hgcont.continuousOn
+  rw [hKc, Set.mem_setOf_eq] at hpmin_mem
+  refine ⟨pmin.1, pmin.2, hpmin_mem.1, hpmin_mem.2.1, ?_⟩
+  intro T₁ T₂ hT₁ hT₂
+  by_cases hcase : g (T₁, T₂) ≤ B
+  · have hmem : (T₁, T₂) ∈ Kc := by
+      rw [hKc, Set.mem_setOf_eq]
+      obtain ⟨hc1, hc2⟩ := hbound T₁ T₂ hT₁ hT₂ hcase
+      exact ⟨hT₁, hT₂, hc1, hc2⟩
+    exact isMinOn_iff.mp hpmin_min (T₁, T₂) hmem
+  · have hpB : g pmin ≤ B := isMinOn_iff.mp hpmin_min (1, 1) h11mem
+    exact le_trans hpB (le_of_lt (not_le.mp hcase))
 
 /-- **Wolf Proposition 2.9: generic normal form for CP maps with full Kraus rank.**
 

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -62,18 +62,6 @@ open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius
 open Matrix Finset
 open ChoiJamiolkowski
 
-/-- The Kronecker product is jointly continuous in both of its matrix factors.
-
-This is the entrywise statement: each entry of `A x ⊗ₖ B x` is a product of one
-entry of `A x` and one entry of `B x`, both continuous in `x`. -/
-theorem Continuous.matrix_kronecker {X l m p q : Type*} [TopologicalSpace X]
-    {α : Type*} [TopologicalSpace α] [Mul α] [ContinuousMul α]
-    {A : X → Matrix l m α} {B : X → Matrix p q α}
-    (hA : Continuous A) (hB : Continuous B) :
-    Continuous fun x => (A x) ⊗ₖ (B x) := by
-  refine continuous_matrix fun i j => ?_
-  exact (hA.matrix_elem i.1 j.1).mul (hB.matrix_elem i.2 j.2)
-
 namespace Wolf
 
 section FilteringOperations
@@ -181,17 +169,16 @@ its minimum on the domain of SL(n, ℂ) × SL(n, ℂ).
 **Proof** (Wolf Section 2.3).  Throughout, `‖·‖` denotes the Frobenius
 (Hilbert–Schmidt) norm `‖M‖² = tr[M M†]`; the coercivity bounds below are false
 for the operator norm (e.g. `‖I‖_op² = 1 < n`).  Writing `X = S₂ ⊗ₖ S₁`, the
-smallest-eigenvalue bound `posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le`
-gives `λ_min(τ) · tr[Xᴴ X] ≤ tr[X τ Xᴴ]`, Hilbert–Schmidt multiplicativity
-`trace_conjTranspose_mul_self_re_kronecker` gives
-`tr[Xᴴ X] = tr[S₂ᴴ S₂] · tr[S₁ᴴ S₁]`, and the determinant AM–GM estimate
-`card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one` gives
-`tr[Sᵢᴴ Sᵢ] = ‖Sᵢ‖² ≥ n` whenever `det Sᵢ = 1`.  Combining these,
-`tr[X τ Xᴴ] ≥ λ_min(τ) · n · ‖Sᵢ‖²` for each factor, so any minimiser is confined
-to the bounded set `{S | ‖S‖ ≤ C}`.  Intersecting with the closed set `det S = 1`
-gives a compact set on which the continuous trace functional attains its minimum
-(`IsCompact.exists_isMinOn`); a value outside the sublevel set is automatically
-larger than the value at the identity, so this minimiser is global. -/
+smallest-eigenvalue bound for a positive-definite matrix gives
+`λ_min(τ) · tr[Xᴴ X] ≤ tr[X τ Xᴴ]`, Hilbert–Schmidt multiplicativity of the
+Kronecker product gives `tr[Xᴴ X] = tr[S₂ᴴ S₂] · tr[S₁ᴴ S₁]`, and the determinant
+AM–GM estimate gives `tr[Sᵢᴴ Sᵢ] = ‖Sᵢ‖² ≥ n` whenever `det Sᵢ = 1`.  Combining
+these, `tr[X τ Xᴴ] ≥ λ_min(τ) · n · ‖Sᵢ‖²` for each factor, so any minimiser is
+confined to the bounded set `{S | ‖S‖ ≤ C}`.  Intersecting with the closed set
+`det S = 1` gives a compact set on which the continuous trace functional attains
+its minimum by the extreme value theorem; a value outside the sublevel set is
+automatically larger than the value at the identity, so this minimiser is
+global. -/
 lemma infimum_is_attained
     {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
     (hτ_posDef : τ.PosDef) :

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1600,14 +1600,35 @@ This section states the existence theorems from
 
 % Lean: Wolf.infimum_is_attained
 \begin{lemma}[Infimum attainment for SL-filterings]\label{lem:infimum_is_attained}
+    \lean{Wolf.infimum_is_attained}\leanok
     \uses{lem:posdef_trace_lower_bound, lem:det_amgm_hilbert_schmidt_bound,
     lem:kronecker_hilbert_schmidt_trace}
     For a positive-definite Choi matrix $\tau$, the infimum of
     $\tr\![(S_{2} \otimes_{k} S_{1}) \tau (S_{2} \otimes_{k} S_{1})^{\dagger}]$
     over $S_{1}, S_{2} \in \MN{D}$ with $\det S_{1} = \det S_{2} = 1$
-    is attained. \textbf{Not yet proved}---requires compactness of bounded
-    subsets of $\SL(D, \C)$ and the extreme-value theorem.
+    is attained.
 \end{lemma}
+\begin{proof}\leanok
+    \uses{lem:posdef_trace_lower_bound, lem:det_amgm_hilbert_schmidt_bound,
+    lem:kronecker_hilbert_schmidt_trace}
+    Write $X = S_{2} \otimes_{k} S_{1}$. By the positive-definite trace lower
+    bound (Lemma~\ref{lem:posdef_trace_lower_bound}),
+    $\tr[X \tau X^{\dagger}] \ge \lambda_{\min}(\tau)\,\tr[X^{\dagger}X]$, and
+    by Hilbert--Schmidt multiplicativity
+    (Lemma~\ref{lem:kronecker_hilbert_schmidt_trace}),
+    $\tr[X^{\dagger}X] = \tr[S_{2}^{\dagger}S_{2}]\,\tr[S_{1}^{\dagger}S_{1}]$.
+    The determinant AM--GM estimate
+    (Lemma~\ref{lem:det_amgm_hilbert_schmidt_bound}) gives
+    $\tr[S_{i}^{\dagger}S_{i}] = \|S_{i}\|^{2} \ge D$ whenever
+    $\det S_{i} = 1$. Combining, the value dominates
+    $\lambda_{\min}(\tau)\,D\,\|S_{i}\|^{2}$ for each factor, so any point
+    whose value is at most the value at the identity lies in a fixed
+    Frobenius ball $\{\,\|S\| \le C\,\}$. Intersecting with the closed set
+    $\det S = 1$ produces a compact set, on which the continuous trace
+    functional attains its minimum by the extreme-value theorem. A point
+    outside the sublevel set has value larger than the value at the identity,
+    so the minimiser on the compact set is a global minimiser.
+\end{proof}
 
 % Lean: Wolf.exists_normal_form_generic
 \begin{theorem}[Generic normal form for CP maps]\label{thm:exists_normal_form_generic}


### PR DESCRIPTION
### Motivation
- Discharges the foundational sorry in `Wolf.infimum_is_attained`, which blocks the Lorentz/SVD normal-form existence proofs (`Wolf.exists_normal_form_generic`, `Wolf.exists_lorentz_normal_form_qubit`); follows from LionSR/TNLean#1109.
- Source: Wolf §2.3 (Prop 2.8), blueprint label `lem:infimum_is_attained` in `blueprint/src/chapter/ch16_channel_representations.tex`.
- Mathematical statement: for a positive-definite Choi matrix τ, the infimum of tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] over det S₁ = det S₂ = 1 is attained.

### Description
- `TNLean/Channel/LorentzNormalForm.lean`: proves `Wolf.infimum_is_attained` by (i) bounding tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] from below via the smallest eigenvalue of τ and the Kronecker Hilbert–Schmidt identity, combined with the determinant AM–GM bound to obtain a coercivity estimate confining minimisers to a Frobenius ball; (ii) intersecting with the closed set {det = 1} to obtain a compact set; (iii) applying the extreme value theorem (`IsCompact.exists_isMinOn`). Downstream `sorry` in `exists_normal_form_generic` and `exists_lorentz_normal_form_qubit` remain (AGM optimality and Lorentz classification respectively).
- `TNLean/Algebra/HermitianHelpers.lean`: generalises eigenvalue/trace infrastructure from `Fin D` to an arbitrary finite index type so the same lemmas apply to the `Fin D × Fin D`-indexed Choi matrix; existing consumers are unaffected.
- `blueprint/src/chapter/ch16_channel_representations.tex`: marks `lem:infimum_is_attained` with `\lean{Wolf.infimum_is_attained}` and `\leanok`.

### Testing
- `rg -n "sorry|axiom" TNLean/Channel/LorentzNormalForm.lean || true` — remaining sorrys in `exists_normal_form_generic` and `exists_lorentz_normal_form_qubit` are expected and noted above.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/QICLean#143

> [!NOTE]
> **Low Risk**
> Formal mathematics only: no runtime, auth, or data paths. Risk is mainly proof maintenance and whether the generalized `HermitianHelpers` API still matches all call sites.
>
> **Overview**
> **Proves** `Wolf.infimum_is_attained`: for a positive-definite Choi matrix τ, the real trace of filtered conjugations `(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†` over `det S₁ = det S₂ = 1` attains a global minimum (replacing `sorry`).
>
> The proof confines candidates to a compact set `det = 1` ∩ bounded Frobenius norm using coercivity from `posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le`, Kronecker Hilbert–Schmidt trace identities, and the determinant AM–GM bound, then applies the extreme value theorem on a closed bounded product set in finite dimensions.
>
> **Generalizes** `HermitianHelpers` from `Fin D` to an arbitrary finite index type `n` so the same eigenvalue/trace lemmas apply to the Choi index `Fin D × Fin D`.
>
> Adds `Continuous.matrix_kronecker`, topology imports, and wires in `HermitianHelpers`; the blueprint lemma `lem:infimum_is_attained` is marked proved with a matching proof. Downstream results (`exists_normal_form_generic`, qubit Lorentz classification) remain incomplete beyond this lemma.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70c95254beab70df40e2af9ef32601caa7ac68ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal Lean proofs only—no runtime or security surface. Residual risk is proof correctness and whether the generalized `HermitianHelpers` API still matches all consumers (currently mainly this lemma).
> 
> **Overview**
> **Replaces the `sorry` in `Wolf.infimum_is_attained`** with a full proof that the real trace of Choi filtering `(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†` over `det S₁ = det S₂ = 1` has a global minimizer. The argument uses a coercivity bound (smallest eigenvalue of τ × Kronecker Hilbert–Schmidt trace × determinant AM–GM), restricts to `det = 1` ∩ a Frobenius ball, and applies the extreme value theorem; continuity of the trace functional uses new **`Continuous.matrix_kronecker`** in `MatrixAux` plus topology imports.
> 
> **`HermitianHelpers`** is generalized from `Fin D` to any finite index type `n` so `minEigenvalue` and `posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le` apply to the `Fin D × Fin D` Choi index. **`LorentzNormalForm`** imports `HermitianHelpers` and updates module docs to describe the formalized compactness step.
> 
> The blueprint **`lem:infimum_is_attained`** is marked `\leanok` with a proof; **`exists_normal_form_generic`** and qubit Lorentz classification still depend on later `sorry` steps (AGM optimality / classification).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c246c8671df77e6cbf4522bbee3fca9be22cf5e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->