### PR TITLE
feat(MPS/ParentHamiltonian/Martingale): add operator-product anticommutator route

### DIFF
--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -101,8 +101,7 @@ differ only in which kernel is left free — the directional bound forces `Q` to
 preserve `ker P`, while this bound does not — but neither is the easier of the
 two, and whenever `range P` and `range Q` share a nonzero vector both force
 `c ≥ 1`.  Its conclusion is exactly the anticommutator quadratic form
-`P Q + Q P ≥ -c (P + Q)` of arXiv:2011.12127, Section IV.C, equation
-eq:4:martingale-2. -/
+`P Q + Q P ≥ -c (P + Q)` of arXiv:2011.12127, Section IV.C, equation (4). -/
 theorem re_inner_anticommutator_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {c : ℝ}
     (hc : 0 ≤ c) (hNorm : ∀ v : E, ‖P (Q v)‖ ≤ c * ‖Q v‖) (v : E) :

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -82,6 +82,62 @@ theorem re_inner_apply_apply_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
     _ ≤ RCLike.re (⟪P v, P (Q v)⟫_𝕜) := hre_lower
     _ = RCLike.re (⟪P v, Q v⟫_𝕜) := by rw [← hcompress]
 
+/-- Symmetric anticommutator lower bound from an operator-product norm estimate.
+
+For symmetric projections `P` and `Q`, the ordered cross term satisfies
+`Re ⟪P v, Q v⟫ = Re ⟪P v, P (Q v)⟫`.  Hence Cauchy--Schwarz applied with a bound
+`‖P (Q v)‖ ≤ c ‖Q v‖` gives `Re ⟪P v, Q v⟫ ≥ -c ‖P v‖ ‖Q v‖`, and the
+arithmetic--geometric mean inequality `2 ‖P v‖ ‖Q v‖ ≤ ‖P v‖² + ‖Q v‖²`
+(using `0 ≤ c`) turns this into the symmetric anticommutator estimate
+`Re ⟪P v, Q v⟫ + Re ⟪Q v, P v⟫ ≥ -c (Re ⟪P v, v⟫ + Re ⟪Q v, v⟫)`.
+
+This is the symmetric counterpart of
+`re_inner_apply_apply_ge_neg_of_norm_apply_le`.  Its hypothesis
+`‖P (Q v)‖ ≤ c ‖Q v‖` is the operator-product norm form of the principal-angle
+quantity (a bound on `‖P Q‖`).  Unlike the directional bound, it does not force
+`Q` to preserve `ker P`: the constraint is vacuous on `ker Q`.  Its conclusion is
+exactly the anticommutator quadratic form `P Q + Q P ≥ -c (P + Q)` of
+arXiv:2011.12127, Section IV.C, equation eq:4:martingale-2. -/
+theorem re_inner_anticommutator_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
+    (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {c : ℝ}
+    (hc : 0 ≤ c) (hNorm : ∀ v : E, ‖P (Q v)‖ ≤ c * ‖Q v‖) (v : E) :
+    -c * (RCLike.re (⟪P v, v⟫_𝕜) + RCLike.re (⟪Q v, v⟫_𝕜)) ≤
+      RCLike.re (⟪P v, Q v⟫_𝕜) + RCLike.re (⟪Q v, P v⟫_𝕜) := by
+  have hdiagP : RCLike.re (⟪P v, v⟫_𝕜) = ‖P v‖ ^ 2 := by
+    rw [← hP.re_inner_apply_apply_self v, inner_self_eq_norm_sq]
+  have hdiagQ : RCLike.re (⟪Q v, v⟫_𝕜) = ‖Q v‖ ^ 2 := by
+    rw [← hQ.re_inner_apply_apply_self v, inner_self_eq_norm_sq]
+  have hconj : RCLike.re (⟪Q v, P v⟫_𝕜) = RCLike.re (⟪P v, Q v⟫_𝕜) := by
+    rw [← inner_conj_symm (P v) (Q v), RCLike.conj_re]
+  have hPidem : P (P v) = P v := by
+    simpa [Module.End.mul_apply] using congrArg (fun T : E →ₗ[𝕜] E => T v)
+      hP.isIdempotentElem.eq
+  have hcompress : ⟪P v, Q v⟫_𝕜 = ⟪P v, P (Q v)⟫_𝕜 := by
+    calc
+      ⟪P v, Q v⟫_𝕜 = ⟪P (P v), Q v⟫_𝕜 := by rw [hPidem]
+      _ = ⟪P v, P (Q v)⟫_𝕜 := hP.isSymmetric (P v) (Q v)
+  have hre_lower : -‖⟪P v, P (Q v)⟫_𝕜‖ ≤ RCLike.re (⟪P v, P (Q v)⟫_𝕜) := by
+    have h := RCLike.re_le_norm (-(⟪P v, P (Q v)⟫_𝕜))
+    have h' : -RCLike.re (⟪P v, P (Q v)⟫_𝕜) ≤ ‖⟪P v, P (Q v)⟫_𝕜‖ := by
+      simpa using h
+    exact neg_le.mp h'
+  have hnorm_inner : ‖⟪P v, P (Q v)⟫_𝕜‖ ≤ c * (‖P v‖ * ‖Q v‖) := by
+    calc
+      ‖⟪P v, P (Q v)⟫_𝕜‖ ≤ ‖P v‖ * ‖P (Q v)‖ := norm_inner_le_norm (P v) (P (Q v))
+      _ ≤ ‖P v‖ * (c * ‖Q v‖) :=
+          mul_le_mul_of_nonneg_left (hNorm v) (norm_nonneg (P v))
+      _ = c * (‖P v‖ * ‖Q v‖) := by ring
+  have hcross_lb : -(c * (‖P v‖ * ‖Q v‖)) ≤ RCLike.re (⟪P v, Q v⟫_𝕜) := by
+    calc
+      -(c * (‖P v‖ * ‖Q v‖)) ≤ -‖⟪P v, P (Q v)⟫_𝕜‖ := neg_le_neg hnorm_inner
+      _ ≤ RCLike.re (⟪P v, P (Q v)⟫_𝕜) := hre_lower
+      _ = RCLike.re (⟪P v, Q v⟫_𝕜) := by rw [← hcompress]
+  have hamgm : 2 * (‖P v‖ * ‖Q v‖) ≤ ‖P v‖ ^ 2 + ‖Q v‖ ^ 2 := by
+    nlinarith [sq_nonneg (‖P v‖ - ‖Q v‖)]
+  rw [hconj, hdiagP, hdiagQ]
+  nlinarith [hcross_lb, hamgm, hc,
+    mul_nonneg (norm_nonneg (P v)) (norm_nonneg (Q v))]
+
 /-- Commuting symmetric projections have nonnegative ordered cross terms.
 
 If `P` and `Q` are symmetric projections that commute pointwise, then

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -93,11 +93,16 @@ arithmetic--geometric mean inequality `2 ‖P v‖ ‖Q v‖ ≤ ‖P v‖² + �
 
 This is the symmetric counterpart of
 `re_inner_apply_apply_ge_neg_of_norm_apply_le`.  Its hypothesis
-`‖P (Q v)‖ ≤ c ‖Q v‖` is the operator-product norm form of the principal-angle
-quantity (a bound on `‖P Q‖`).  Unlike the directional bound, it does not force
-`Q` to preserve `ker P`: the constraint is vacuous on `ker Q`.  Its conclusion is
-exactly the anticommutator quadratic form `P Q + Q P ≥ -c (P + Q)` of
-arXiv:2011.12127, Section IV.C, equation eq:4:martingale-2. -/
+`‖P (Q v)‖ ≤ c ‖Q v‖` is the operator-product norm form of a bound on `‖P Q‖`.
+Imposed for every `v`, it is equivalent to the operator-norm bound `‖P Q‖ ≤ c`
+(using idempotence of `Q`), so it is not a weaker condition than the directional
+bound: it is exactly as strong as requiring `‖P Q‖ ≤ c`.  The two hypotheses
+differ only in which kernel is left free — the directional bound forces `Q` to
+preserve `ker P`, while this bound does not — but neither is the easier of the
+two, and whenever `range P` and `range Q` share a nonzero vector both force
+`c ≥ 1`.  Its conclusion is exactly the anticommutator quadratic form
+`P Q + Q P ≥ -c (P + Q)` of arXiv:2011.12127, Section IV.C, equation
+eq:4:martingale-2. -/
 theorem re_inner_anticommutator_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {c : ℝ}
     (hc : 0 ≤ c) (hNorm : ∀ v : E, ‖P (Q v)‖ ≤ c * ‖Q v‖) (v : E) :

--- a/TNLean/Analysis/ProjectionGeometry.lean
+++ b/TNLean/Analysis/ProjectionGeometry.lean
@@ -101,7 +101,8 @@ differ only in which kernel is left free — the directional bound forces `Q` to
 preserve `ker P`, while this bound does not — but neither is the easier of the
 two, and whenever `range P` and `range Q` share a nonzero vector both force
 `c ≥ 1`.  Its conclusion is exactly the anticommutator quadratic form
-`P Q + Q P ≥ -c (P + Q)` of arXiv:2011.12127, Section IV.C, equation (4). -/
+`P Q + Q P ≥ -c (P + Q)` of arXiv:2011.12127, Section IV.C,
+lines 2176-2179. -/
 theorem re_inner_anticommutator_ge_neg_of_norm_apply_le {P Q : E →ₗ[𝕜] E}
     (hP : P.IsSymmetricProjection) (hQ : Q.IsSymmetricProjection) {c : ℝ}
     (hc : 0 ≤ c) (hNorm : ∀ v : E, ‖P (Q v)‖ ≤ c * ‖Q v‖) (v : E) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -281,7 +281,7 @@ coefficient.**
 
 For an MPS tensor \(A\) and interaction range \(L > 1\), any uniform
 overlapping cyclic-window estimate
-\(‖p_i p_j v‖ ≤ η ‖p_i v‖\) with \(0 ≤ η\) and \(η * 2(L-1) < 1\) gives a uniform
+\(‖p_i p_j v‖ ≤ η ‖p_i v‖\) with \(0 ≤ η\) and \(η · 2(L-1) < 1\) gives a uniform
 positive lower bound on the parent Hamiltonian, independent of the chain length.
 
 This is the version of `parentHamiltonian_gapped` with an arbitrary compression

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -310,23 +310,29 @@ theorem parentHamiltonian_gapped_of_overlap_norm_constant
 /-- Gap bound from a strict overlapping cyclic-window operator-product norm
 coefficient for the MPS parent Hamiltonian.
 
-This is the symmetric, source-faithful counterpart of
+This is the symmetric counterpart of
 `parentHamiltonianES_gap_bound_of_overlap_norm_constant`.  The hypothesis is the
 operator-product norm bound
 \[
   \|p_i (p_j v)\| \le \eta\,\|p_j v\|,
 \]
-i.e. a bound on \(\|p_i p_j\|\), the principal-angle quantity between the two
-overlapping excitation ranges, rather than the directional compression bound
+i.e. a bound on \(\|p_i p_j\|\) for the two overlapping excitation projections,
+rather than the directional compression bound
 \(\|p_i (p_j v)\| \le \eta\,\|p_i v\|\) used by
 `parentHamiltonianES_gap_bound_of_overlap_norm_constant`.  The directional bound,
 required to hold for every \(v\), forces \(p_j\) to preserve \(\ker p_i\); the
 operator-product bound carries no such constraint.  Through the symmetric
-anticommutator reduction
-`re_inner_anticommutator_ge_neg_of_norm_apply_le`, any such bound with
-\(\eta\,2(L-1) < 1\) yields the positive gap constant \(1 - \eta\,2(L-1)\).  The
-comparison with the cited FNW--Nachtergaele--Kastoryano principal-angle estimates
-is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+anticommutator reduction `re_inner_anticommutator_ge_neg_of_norm_apply_le`, any
+such bound with \(\eta\,2(L-1) < 1\) yields the positive gap constant
+\(1 - \eta\,2(L-1)\).
+
+Like `parentHamiltonianES_gap_bound_of_principal_angle_compression`, this is a
+conditional reduction, not an achievable MPS estimate: \(p_i, p_j\) are the
+excitation projections, so when the overlapping excitation ranges share a vector
+one has \(\|p_i p_j\| = 1\) and the hypothesis is unsatisfiable for
+\(\eta < 1\).  The cited FNW--Nachtergaele--Kastoryano estimates control the
+ground-space principal angle \(\|q_i q_j - P\|\), a different quantity; the
+comparison is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)
@@ -351,14 +357,17 @@ coefficient.**
 
 For an MPS tensor \(A\) and interaction range \(L > 1\), any uniform overlapping
 cyclic-window estimate \(\|p_i (p_j v)\| \le \eta\,\|p_j v\|\) (a bound on
-\(\|p_i p_j\|\)) with \(0 ≤ η\) and \(η * 2(L-1) < 1\) gives a uniform positive
-lower bound on the parent Hamiltonian, independent of the chain length.
+\(\|p_i p_j\|\)) with \(0 \le \eta\) and \(\eta \cdot 2(L-1) < 1\) gives a uniform
+positive lower bound on the parent Hamiltonian, independent of the chain length.
 
-This is the operator-product (symmetric principal-angle) analogue of
-`parentHamiltonian_gapped_of_overlap_norm_constant`.  Its hypothesis matches the
-symmetric anticommutator estimate of arXiv:2011.12127, Section IV.C, equation
-eq:4:martingale-2, and is the appropriate target when the cited principal-angle
-estimates bound \(\|p_i p_j\|\) for overlapping windows. -/
+This is the operator-product (symmetric) analogue of
+`parentHamiltonian_gapped_of_overlap_norm_constant`.  Its conclusion is the
+anticommutator estimate of arXiv:2011.12127, Section IV.C, equation
+eq:4:martingale-2 with coefficient \(\eta\).  Like
+`parentHamiltonian_gapped_of_overlap_norm_constant`, it is a conditional
+reduction whose hypothesis is unsatisfiable for the overlapping excitation
+projections (\(\|p_i p_j\| = 1\) when the ranges intersect), not an achievable
+MPS target; see `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonian_gapped_of_overlap_operator_norm_constant
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -307,4 +307,74 @@ theorem parentHamiltonian_gapped_of_overlap_norm_constant
       hηlt hOverlapNorm
   exact ⟨1 - η * (((2 * (L - 1) : ℕ) : ℝ)), hγ, hgap⟩
 
+/-- Gap bound from a strict overlapping cyclic-window operator-product norm
+coefficient for the MPS parent Hamiltonian.
+
+This is the symmetric, source-faithful counterpart of
+`parentHamiltonianES_gap_bound_of_overlap_norm_constant`.  The hypothesis is the
+operator-product norm bound
+\[
+  \|p_i (p_j v)\| \le \eta\,\|p_j v\|,
+\]
+i.e. a bound on \(\|p_i p_j\|\), the principal-angle quantity between the two
+overlapping excitation ranges, rather than the directional compression bound
+\(\|p_i (p_j v)\| \le \eta\,\|p_i v\|\) used by
+`parentHamiltonianES_gap_bound_of_overlap_norm_constant`.  The directional bound,
+required to hold for every \(v\), forces \(p_j\) to preserve \(\ker p_i\); the
+operator-product bound carries no such constraint.  Through the symmetric
+anticommutator reduction
+`re_inner_anticommutator_ge_neg_of_norm_apply_le`, any such bound with
+\(\eta\,2(L-1) < 1\) yields the positive gap constant \(1 - \eta\,2(L-1)\).  The
+comparison with the cited FNW--Nachtergaele--Kastoryano principal-angle estimates
+is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+theorem parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
+    (hηnonneg : 0 ≤ η)
+    (hηlt : η * (((2 * (L - 1) : ℕ) : ℝ)) < 1)
+    (hOpNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L j v‖) :
+    0 < 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        (1 - η * (((2 * (L - 1) : ℕ) : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt
+    A L hL hηnonneg hηlt hOpNorm
+
+/--
+**Conditional spectral gap from a strict overlapping-window operator-product
+coefficient.**
+
+For an MPS tensor \(A\) and interaction range \(L > 1\), any uniform overlapping
+cyclic-window estimate \(\|p_i (p_j v)\| \le \eta\,\|p_j v\|\) (a bound on
+\(\|p_i p_j\|\)) with \(0 ≤ η\) and \(η * 2(L-1) < 1\) gives a uniform positive
+lower bound on the parent Hamiltonian, independent of the chain length.
+
+This is the operator-product (symmetric principal-angle) analogue of
+`parentHamiltonian_gapped_of_overlap_norm_constant`.  Its hypothesis matches the
+symmetric anticommutator estimate of arXiv:2011.12127, Section IV.C, equation
+eq:4:martingale-2, and is the appropriate target when the cited principal-angle
+estimates bound \(\|p_i p_j\|\) for overlapping windows. -/
+theorem parentHamiltonian_gapped_of_overlap_operator_norm_constant
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
+    (hηnonneg : 0 ≤ η)
+    (hηlt : η * (((2 * (L - 1) : ℕ) : ℝ)) < 1)
+    (hOpNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L j v‖) :
+    ∃ γ > 0, ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
+  obtain ⟨hγ, hgap⟩ :=
+    parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant A L hL hηnonneg
+      hηlt hOpNorm
+  exact ⟨1 - η * (((2 * (L - 1) : ℕ) : ℝ)), hγ, hgap⟩
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -41,7 +41,7 @@ variable {d D : ℕ}
 
 This is the source-matching form of the MPS parent-Hamiltonian gap reduction.  The
 hypothesis is the anticommutator lower bound appearing in arXiv:2011.12127,
-Section IV.C, equation (4), specialized to overlapping cyclic windows:
+Section IV.C, lines 2176-2179, specialized to overlapping cyclic windows:
 \[
   h_i h_j+h_j h_i
   \ge
@@ -253,7 +253,7 @@ for overlapping off-diagonal pairs implies a uniform gap \(γ>0\), independent
 of the chain length.
 
 This is the public gapped theorem matching the martingale condition in
-arXiv:2011.12127, Section IV.C, equation (4). The MPS-specific proof of the
+arXiv:2011.12127, Section IV.C, lines 2176-2179. The MPS-specific proof of the
 anticommutator estimate remains the open input. -/
 theorem parentHamiltonian_gapped_of_anticommutator
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
@@ -363,7 +363,7 @@ positive lower bound on the parent Hamiltonian, independent of the chain length.
 
 This is the operator-product (symmetric) analogue of
 `parentHamiltonian_gapped_of_overlap_norm_constant`.  Its proof passes through
-the anticommutator estimate of arXiv:2011.12127, Section IV.C, equation (4),
+the anticommutator estimate of arXiv:2011.12127, Section IV.C, lines 2176-2179,
 with coefficient \(\eta\), before applying the finite-overlap martingale
 reduction.  Like
 `parentHamiltonian_gapped_of_overlap_norm_constant`, it is a conditional

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -327,12 +327,14 @@ such bound with \(\eta\,2(L-1) < 1\) yields the positive gap constant
 \(1 - \eta\,2(L-1)\).
 
 Like `parentHamiltonianES_gap_bound_of_principal_angle_compression`, this is a
-conditional reduction, not an achievable MPS estimate: \(p_i, p_j\) are the
-excitation projections, so when the overlapping excitation ranges share a vector
-one has \(\|p_i p_j\| = 1\) and the hypothesis is unsatisfiable for
-\(\eta < 1\).  The cited FNW--Nachtergaele--Kastoryano estimates control the
-ground-space principal angle \(\|q_i q_j - P\|\), a different quantity; the
-comparison is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+conditional reduction, not an achievable MPS estimate in the generic overlapping
+case: \(p_i, p_j\) are the excitation projections, and when their ranges share a
+nonzero vector one has \(\|p_i p_j\| = 1\), making the hypothesis unsatisfiable
+for \(\eta < 1\).  In degenerate cases, for instance when an excitation
+projection is zero, the product norm can be smaller.  The cited
+FNW--Nachtergaele--Kastoryano estimates control the ground-space principal angle
+\(\|q_i q_j - P\|\), a different quantity; the comparison is recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)
@@ -365,9 +367,10 @@ This is the operator-product (symmetric) analogue of
 anticommutator estimate of arXiv:2011.12127, Section IV.C, equation
 eq:4:martingale-2 with coefficient \(\eta\).  Like
 `parentHamiltonian_gapped_of_overlap_norm_constant`, it is a conditional
-reduction whose hypothesis is unsatisfiable for the overlapping excitation
-projections (\(\|p_i p_j\| = 1\) when the ranges intersect), not an achievable
-MPS target; see `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+reduction whose hypothesis is unsatisfiable when the overlapping excitation
+ranges have a common nonzero vector, since then \(\|p_i p_j\| = 1\).  It is not
+an achievable MPS target in such cases; see
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonian_gapped_of_overlap_operator_norm_constant
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean
@@ -41,8 +41,7 @@ variable {d D : ℕ}
 
 This is the source-matching form of the MPS parent-Hamiltonian gap reduction.  The
 hypothesis is the anticommutator lower bound appearing in arXiv:2011.12127,
-Section IV.C, equation eq:4:martingale-2, specialized to overlapping cyclic
-windows:
+Section IV.C, equation (4), specialized to overlapping cyclic windows:
 \[
   h_i h_j+h_j h_i
   \ge
@@ -254,8 +253,8 @@ for overlapping off-diagonal pairs implies a uniform gap \(γ>0\), independent
 of the chain length.
 
 This is the public gapped theorem matching the martingale condition in
-arXiv:2011.12127, Section IV.C, equation eq:4:martingale-2. The
-MPS-specific proof of the anticommutator estimate remains the open input. -/
+arXiv:2011.12127, Section IV.C, equation (4). The MPS-specific proof of the
+anticommutator estimate remains the open input. -/
 theorem parentHamiltonian_gapped_of_anticommutator
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L)
     (hAnti : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
@@ -363,9 +362,10 @@ cyclic-window estimate \(\|p_i (p_j v)\| \le \eta\,\|p_j v\|\) (a bound on
 positive lower bound on the parent Hamiltonian, independent of the chain length.
 
 This is the operator-product (symmetric) analogue of
-`parentHamiltonian_gapped_of_overlap_norm_constant`.  Its conclusion is the
-anticommutator estimate of arXiv:2011.12127, Section IV.C, equation
-eq:4:martingale-2 with coefficient \(\eta\).  Like
+`parentHamiltonian_gapped_of_overlap_norm_constant`.  Its proof passes through
+the anticommutator estimate of arXiv:2011.12127, Section IV.C, equation (4),
+with coefficient \(\eta\), before applying the finite-overlap martingale
+reduction.  Like
 `parentHamiltonian_gapped_of_overlap_norm_constant`, it is a conditional
 reduction whose hypothesis is unsatisfiable when the overlapping excitation
 ranges have a common nonzero vector, since then \(\|p_i p_j\| = 1\).  It is not

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -754,4 +754,137 @@ theorem parentHamiltonianES_gap_bound_of_principal_angle_compression
   parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
     A L hL hηnonneg hηlt hOverlapNorm
 
+/-- Uniform gap-bound reduction from an overlap operator-product norm estimate
+with a separate coefficient.
+
+This is the symmetric, source-faithful counterpart of
+`parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le`.  The
+hypothesis is the operator-product norm bound
+\[
+  \|h_i (h_j v)\| \le \eta\,\|h_j v\|,
+\]
+that is, a bound on \(\|h_i h_j\|\), rather than the directional compression
+bound \(\|h_i (h_j v)\| \le \eta\,\|h_i v\|\).  The directional bound, holding for
+every \(v\), forces \(h_j\) to preserve \(\ker h_i\); the operator-product bound
+imposes no such constraint, and is the natural form of the principal-angle
+quantity.  Through `re_inner_anticommutator_ge_neg_of_norm_apply_le` it yields the
+symmetric anticommutator estimate of arXiv:2011.12127, Section IV.C, equation
+eq:4:martingale-2, with per-pair coefficient \(\eta\), and hence the same
+finite-overlap martingale gap as the anticommutator route. -/
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {γ η : ℝ}
+    (hγpos : 0 < γ) (hγle : γ ≤ 1)
+    (hηle : η ≤ (1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹))
+    (hOpNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L j v‖) :
+    0 < γ ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        γ * ‖v‖ ≤ ‖parentHamiltonianES A L N v‖ := by
+  refine ⟨hγpos, ?_⟩
+  refine parentHamiltonianES_norm_bound_of_quadratic_form A L hγpos ?_
+  intro N hLN v
+  have hm : 0 < 2 * (L - 1) :=
+    Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
+  have hcoeff_nonneg : 0 ≤ (1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹) :=
+    mul_nonneg (by linarith) (by positivity)
+  refine parentHamiltonianES_quadratic_form_of_finite_overlap_anticommutator
+    A L N hγle (cyclicWindowsOverlap N L) hm
+    (fun i => cyclicWindowsOverlap_card_le hLN hL i) ?_ ?_ ?_ v
+  · intro j
+    have hset :
+        ((Finset.univ.erase j).filter (fun i => cyclicWindowsOverlap N L i j)) =
+          ((Finset.univ.erase j).filter (fun i => cyclicWindowsOverlap N L j i)) := by
+      ext i
+      simp only [Finset.mem_filter, Finset.mem_erase, Finset.mem_univ, and_true]
+      rw [cyclicWindowsOverlap_comm N L i j]
+    rw [hset]
+    exact cyclicWindowsOverlap_card_le hLN hL j
+  · intro i j _hij hnot w
+    have hnonneg₁ :
+        0 ≤ (⟪localTermES A L i w, localTermES A L j w⟫_ℂ).re :=
+      localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A (by omega) hnot w
+    have hnot_symm : ¬ cyclicWindowsOverlap N L j i := by
+      intro hji
+      exact hnot ((cyclicWindowsOverlap_comm N L i j).mpr hji)
+    have hnonneg₂ :
+        0 ≤ (⟪localTermES A L j w, localTermES A L i w⟫_ℂ).re :=
+      localTermES_re_inner_nonneg_of_not_cyclicWindowsOverlap A (by omega) hnot_symm w
+    linarith
+  · intro i j hij hoverlap w
+    have hNorm' : ∀ w' : EuclideanSpace ℂ (Cfg d N),
+        ‖localTermES A L i (localTermES A L j w')‖ ≤
+          ((1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) * ‖localTermES A L j w'‖ := by
+      intro w'
+      exact le_trans (hOpNorm N hLN i j hij hoverlap w')
+        (mul_le_mul_of_nonneg_right hηle (norm_nonneg _))
+    have hanti :=
+      (localTermES_isSymmetricProjection A L i).re_inner_anticommutator_ge_neg_of_norm_apply_le
+        (localTermES_isSymmetricProjection A L j) hcoeff_nonneg hNorm' w
+    calc
+      -(1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹) *
+            ((⟪localTermES A L i w, w⟫_ℂ).re +
+              (⟪localTermES A L j w, w⟫_ℂ).re)
+          = -((1 - γ) * (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) *
+              ((⟪localTermES A L i w, w⟫_ℂ).re +
+                (⟪localTermES A L j w, w⟫_ℂ).re) := by ring
+      _ ≤ (⟪localTermES A L i w, localTermES A L j w⟫_ℂ).re +
+            (⟪localTermES A L j w, localTermES A L i w⟫_ℂ).re := hanti
+
+/-- Uniform gap-bound reduction from a strict overlap operator-product norm
+constant.
+
+If every overlapping off-diagonal cyclic pair satisfies the operator-product norm
+estimate \(\|h_i (h_j v)\| \le \eta\,\|h_j v\|\) and \(\eta\,2(L-1) < 1\), then the
+Euclidean-space parent Hamiltonians have gap constant \(1 - \eta\,2(L-1)\).  This is
+the symmetric (operator-product) analogue of
+`parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt`, and the
+direct conditional entry point for the principal-angle estimate
+\(\|h_i h_j\| < 1/(2(L-1))\). -/
+theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt
+    (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
+    (hηnonneg : 0 ≤ η)
+    (hηlt : η * (((2 * (L - 1) : ℕ) : ℝ)) < 1)
+    (hOpNorm : ∀ (N : ℕ) (_hLN : 2 * L ≤ N) (i j : Fin N),
+      j ∈ Finset.univ.erase i → cyclicWindowsOverlap N L i j →
+        ∀ v : EuclideanSpace ℂ (Cfg d N),
+          ‖localTermES A L i (localTermES A L j v)‖ ≤
+            η * ‖localTermES A L j v‖) :
+    0 < 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) ∧
+    ∀ (N : ℕ) (_hLN : 2 * L ≤ N)
+      (v : EuclideanSpace ℂ (Cfg d N)),
+      v ∈ (parentHamiltonianGroundSpaceES A L N)ᗮ →
+        (1 - η * (((2 * (L - 1) : ℕ) : ℝ))) * ‖v‖ ≤
+          ‖parentHamiltonianES A L N v‖ := by
+  have hm : 0 < 2 * (L - 1) :=
+    Nat.mul_pos (by decide) (Nat.sub_pos_of_lt hL)
+  have hmRpos : 0 < (((2 * (L - 1) : ℕ) : ℝ)) := by
+    exact_mod_cast hm
+  have hγpos : 0 < 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) := by
+    linarith
+  have hγle : 1 - η * (((2 * (L - 1) : ℕ) : ℝ)) ≤ 1 := by
+    have hmul_nonneg : 0 ≤ η * (((2 * (L - 1) : ℕ) : ℝ)) :=
+      mul_nonneg hηnonneg hmRpos.le
+    linarith
+  have hηle :
+      η ≤ (1 - (1 - η * (((2 * (L - 1) : ℕ) : ℝ)))) *
+        (((2 * (L - 1) : ℕ) : ℝ)⁻¹) := by
+    have hmne : (((2 * (L - 1) : ℕ) : ℝ)) ≠ 0 := ne_of_gt hmRpos
+    have hηeq :
+        η = (1 - (1 - η * (((2 * (L - 1) : ℕ) : ℝ)))) *
+          (((2 * (L - 1) : ℕ) : ℝ)⁻¹) := by
+      calc
+        η = η * (((2 * (L - 1) : ℕ) : ℝ) *
+            (((2 * (L - 1) : ℕ) : ℝ)⁻¹)) := by
+              rw [mul_inv_cancel₀ hmne, mul_one]
+        _ = (1 - (1 - η * (((2 * (L - 1) : ℕ) : ℝ)))) *
+            (((2 * (L - 1) : ℕ) : ℝ)⁻¹) := by ring
+    exact le_of_eq hηeq
+  exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le
+    A L hL hγpos hγle hηle hOpNorm
+
 end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -772,8 +772,10 @@ IV.C, equation eq:4:martingale-2, with per-pair coefficient \(\eta\), and hence
 the same finite-overlap martingale gap as the anticommutator route.  Both this
 operator-product bound and the directional bound are conditional reductions: for
 the overlapping excitation projections \(h_i, h_j\) one has \(\|h_i h_j\| = 1\)
-when the ranges intersect, so neither hypothesis is satisfiable for
-\(\eta < 1\).  See `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+when their ranges have a common nonzero vector, so neither hypothesis is
+satisfiable for \(\eta < 1\) in that case.  Degenerate cases, such as a zero
+excitation projection, are not ruled out by the combinatorics alone.  See
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {γ η : ℝ}
     (hγpos : 0 < γ) (hγle : γ ≤ 1)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -757,7 +757,7 @@ theorem parentHamiltonianES_gap_bound_of_principal_angle_compression
 /-- Uniform gap-bound reduction from an overlap operator-product norm estimate
 with a separate coefficient.
 
-This is the symmetric, source-faithful counterpart of
+This is the symmetric counterpart of
 `parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le`.  The
 hypothesis is the operator-product norm bound
 \[
@@ -766,11 +766,14 @@ hypothesis is the operator-product norm bound
 that is, a bound on \(\|h_i h_j\|\), rather than the directional compression
 bound \(\|h_i (h_j v)\| \le \eta\,\|h_i v\|\).  The directional bound, holding for
 every \(v\), forces \(h_j\) to preserve \(\ker h_i\); the operator-product bound
-imposes no such constraint, and is the natural form of the principal-angle
-quantity.  Through `re_inner_anticommutator_ge_neg_of_norm_apply_le` it yields the
-symmetric anticommutator estimate of arXiv:2011.12127, Section IV.C, equation
-eq:4:martingale-2, with per-pair coefficient \(\eta\), and hence the same
-finite-overlap martingale gap as the anticommutator route. -/
+imposes no such constraint.  Through `re_inner_anticommutator_ge_neg_of_norm_apply_le`
+it yields the symmetric anticommutator estimate of arXiv:2011.12127, Section
+IV.C, equation eq:4:martingale-2, with per-pair coefficient \(\eta\), and hence
+the same finite-overlap martingale gap as the anticommutator route.  Both this
+operator-product bound and the directional bound are conditional reductions: for
+the overlapping excitation projections \(h_i, h_j\) one has \(\|h_i h_j\| = 1\)
+when the ranges intersect, so neither hypothesis is satisfiable for
+\(\eta < 1\).  See `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {γ η : ℝ}
     (hγpos : 0 < γ) (hγle : γ ≤ 1)
@@ -842,9 +845,11 @@ If every overlapping off-diagonal cyclic pair satisfies the operator-product nor
 estimate \(\|h_i (h_j v)\| \le \eta\,\|h_j v\|\) and \(\eta\,2(L-1) < 1\), then the
 Euclidean-space parent Hamiltonians have gap constant \(1 - \eta\,2(L-1)\).  This is
 the symmetric (operator-product) analogue of
-`parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt`, and the
-direct conditional entry point for the principal-angle estimate
-\(\|h_i h_j\| < 1/(2(L-1))\). -/
+`parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt`.  Like
+that directional reduction, it is conditional: for the overlapping excitation
+projections \(\|h_i h_j\| = 1\) when the ranges intersect, so the hypothesis is
+unsatisfiable for \(\eta < 1\).  See
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -136,8 +136,7 @@ theorem parentHamiltonianES_quadratic_form_of_ordered_local_term_bounds
 /-- Fixed-chain martingale quadratic-form estimate from source anticommutator
 row bounds.
 
-arXiv:2011.12127, Section IV.C, equation \(4:\mathrm{martingale}\text{-}2\),
-uses the local estimate
+arXiv:2011.12127, Section IV.C, lines 2176-2179, use the local estimate
 \[
   h_i h_j+h_j h_i \ge -c_{ij}(1-\gamma)(h_i+h_j)
 \]
@@ -208,8 +207,8 @@ theorem parentHamiltonianES_gap_bound_of_ordered_local_term_bounds
 
 /-- Uniform explicit gap-bound reduction from source anticommutator row bounds.
 
-arXiv:2011.12127, Section IV.C, equation \(4:\mathrm{martingale}\text{-}2\),
-states the martingale condition in the anticommutator form
+arXiv:2011.12127, Section IV.C, lines 2176-2179, state the martingale
+condition in the anticommutator form
 \[
   h_i h_j+h_jh_i\ge -c_{ij}(1-\gamma)(h_i+h_j).
 \]
@@ -766,10 +765,11 @@ hypothesis is the operator-product norm bound
 that is, a bound on \(\|h_i h_j\|\), rather than the directional compression
 bound \(\|h_i (h_j v)\| \le \eta\,\|h_i v\|\).  The directional bound, holding for
 every \(v\), forces \(h_j\) to preserve \(\ker h_i\); the operator-product bound
-imposes no such constraint.  Through `re_inner_anticommutator_ge_neg_of_norm_apply_le`
-it yields the symmetric anticommutator estimate of arXiv:2011.12127, Section
-IV.C, equation (4), with per-pair coefficient \(\eta\), and hence the same
-finite-overlap martingale gap as the anticommutator route.  Both this
+imposes no such constraint.  Together with \(\eta \le (1-\gamma)/m\), it gives
+the symmetric anticommutator estimate of arXiv:2011.12127, Section IV.C,
+lines 2176-2179, with per-pair coefficient \((1-\gamma)/m\), and hence the
+same finite-overlap martingale gap as the anticommutator route.  In the strict
+specialization this coefficient is \(\eta\).  Both this
 operator-product bound and the directional bound are conditional reductions: for
 the overlapping excitation projections \(h_i, h_j\) one has \(\|h_i h_j\| = 1\)
 when their ranges have a common nonzero vector, so neither hypothesis is

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -768,8 +768,8 @@ bound \(\|h_i (h_j v)\| \le \eta\,\|h_i v\|\).  The directional bound, holding f
 every \(v\), forces \(h_j\) to preserve \(\ker h_i\); the operator-product bound
 imposes no such constraint.  Through `re_inner_anticommutator_ge_neg_of_norm_apply_le`
 it yields the symmetric anticommutator estimate of arXiv:2011.12127, Section
-IV.C, equation eq:4:martingale-2, with per-pair coefficient \(\eta\), and hence
-the same finite-overlap martingale gap as the anticommutator route.  Both this
+IV.C, equation (4), with per-pair coefficient \(\eta\), and hence the same
+finite-overlap martingale gap as the anticommutator route.  Both this
 operator-product bound and the directional bound are conditional reductions: for
 the overlapping excitation projections \(h_i, h_j\) one has \(\|h_i h_j\| = 1\)
 when their ranges have a common nonzero vector, so neither hypothesis is

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -1201,8 +1201,9 @@ sufficient stronger hypotheses.
     handles disjoint supports. The symmetric anticommutator conversion of
     Remark~\ref{rem:projection_geometry_rowsum_identities} turns the
     operator-product bound into the per-pair anticommutator estimate with
-    coefficient $\eta$; the anticommutator finite-overlap reduction then gives the
-    quadratic-form estimate with the chosen $\gamma$, and the positive
+    coefficient $(1-\gamma)/m$, using the hypothesis
+    $\eta \le (1-\gamma)/m$; the anticommutator finite-overlap reduction then
+    gives the quadratic-form estimate with the chosen $\gamma$, and the positive
     quadratic-form criterion converts it to the norm lower bound. The strict form
     is the same statement with $\gamma=1-\eta m$.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -475,6 +475,7 @@ sufficient stronger hypotheses.
     \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_self}
     \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_nonneg_of_commute}
     \lean{LinearMap.IsSymmetricProjection.re_inner_apply_apply_ge_neg_of_norm_apply_le}
+    \lean{LinearMap.IsSymmetricProjection.re_inner_anticommutator_ge_neg_of_norm_apply_le}
     \lean{ProjectionGeometry.re_inner_sum_apply_left}
     \lean{ProjectionGeometry.apply_eq_zero_of_sum_apply_eq_zero}
     \lean{ProjectionGeometry.re_inner_sum_apply_apply}
@@ -491,6 +492,11 @@ sufficient stronger hypotheses.
     $P,Q$; the Cauchy--Schwarz conversion from
     $\|P Q v\|\le c\|Pv\|$ to
     $\operatorname{Re}\langle Pv,Qv\rangle\ge -c\operatorname{Re}\langle Pv,v\rangle$;
+    the symmetric variant converting the operator-product bound
+    $\|P Q v\|\le c\|Qv\|$ to the anticommutator estimate
+    $\operatorname{Re}\langle Pv,Qv\rangle+\operatorname{Re}\langle Qv,Pv\rangle
+    \ge -c\bigl(\operatorname{Re}\langle Pv,v\rangle
+    +\operatorname{Re}\langle Qv,v\rangle\bigr)$;
     finite-sum expansions of
     $\operatorname{Re}\langle (\sum_i P_i)v,v\rangle$ and
     $\operatorname{Re}\langle (\sum_i P_i)v,(\sum_i P_i)v\rangle$; the
@@ -1143,6 +1149,60 @@ sufficient stronger hypotheses.
     off-diagonal neighbours in each row, while the non-overlap positivity lemma
     handles disjoint supports. The finite-overlap norm-compression reduction gives
     the quadratic-form estimate with the chosen $\gamma$, and the positive
+    quadratic-form criterion converts it to the norm lower bound. The strict form
+    is the same statement with $\gamma=1-\eta m$.
+\end{proof}
+
+\begin{lemma}[Parent-Hamiltonian gap from a cyclic operator-product norm constant]
+    \label{lem:parent_hamiltonian_cyclic_overlap_operator_norm_constant_gap}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt}
+    \leanok
+    \uses{rem:projection_geometry_rowsum_identities,
+        lem:parent_hamiltonian_finite_overlap_anticommutator_gap,
+        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive,
+        lem:parent_hamiltonian_es_quadratic_reduction}
+    Fix $L>1$, and let $m=2(L-1)$. Suppose uniformly for every $N\ge2L$ and every
+    overlapping off-diagonal pair that
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le \eta\,\|h_{j,\mathrm{ES}}v\|,
+    \]
+    that is, a bound $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|\le\eta$ on the
+    operator-product norm. If $\gamma>0$, $\gamma\le1$, and $\eta\le(1-\gamma)/m$,
+    then $0<\gamma$ and, for every admissible $N$ and every
+    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
+    \[
+        \gamma\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+    In particular, if $\eta\ge0$ and $\eta m<1$, then $0<1-\eta m$ and the same
+    norm bound holds with $\gamma=1-\eta m$.
+
+    This is the symmetric (operator-product) counterpart of
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_norm_constant_gap}, obtained
+    from the anticommutator conversion recorded in
+    Remark~\ref{rem:projection_geometry_rowsum_identities}. Like that lemma it is a
+    conditional reduction: the excitation projections satisfy
+    $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|=1$ whenever the overlapping ranges
+    intersect, so the hypothesis is unsatisfiable for $\eta<1$. It isolates the
+    finite-row martingale argument once such a bound is supplied; the gap with the
+    cited principal-angle estimates is documented in the paper-gap note
+    \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{rem:projection_geometry_rowsum_identities,
+        lem:parent_hamiltonian_finite_overlap_anticommutator_gap,
+        lem:cyclic_window_overlap_cardinality, lem:cyclic_window_nonoverlap_positive,
+        lem:parent_hamiltonian_es_quadratic_reduction}
+    The overlap-cardinality lemma gives at most $m=2(L-1)$ overlapping
+    off-diagonal neighbours in each row, while the non-overlap positivity lemma
+    handles disjoint supports. The symmetric anticommutator conversion of
+    Remark~\ref{rem:projection_geometry_rowsum_identities} turns the
+    operator-product bound into the per-pair anticommutator estimate with
+    coefficient $\eta$; the anticommutator finite-overlap reduction then gives the
+    quadratic-form estimate with the chosen $\gamma$, and the positive
     quadratic-form criterion converts it to the norm lower bound. The strict form
     is the same statement with $\gamma=1-\eta m$.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -1184,7 +1184,8 @@ sufficient stronger hypotheses.
     Remark~\ref{rem:projection_geometry_rowsum_identities}. Like that lemma it is a
     conditional reduction: the excitation projections satisfy
     $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|=1$ whenever the overlapping ranges
-    intersect, so the hypothesis is unsatisfiable for $\eta<1$. It isolates the
+    share a common nonzero vector, so the hypothesis is unsatisfiable for
+    $\eta<1$ in that case. It isolates the
     finite-row martingale argument once such a bound is supplied; the gap with the
     cited principal-angle estimates is documented in the paper-gap note
     \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex}.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -492,7 +492,7 @@ sufficient stronger hypotheses.
     $P,Q$; the Cauchy--Schwarz conversion from
     $\|P Q v\|\le c\|Pv\|$ to
     $\operatorname{Re}\langle Pv,Qv\rangle\ge -c\operatorname{Re}\langle Pv,v\rangle$;
-    the symmetric variant converting the operator-product bound
+    the symmetric variant which, for $c\ge0$, converts the operator-product bound
     $\|P Q v\|\le c\|Qv\|$ to the anticommutator estimate
     $\operatorname{Re}\langle Pv,Qv\rangle+\operatorname{Re}\langle Qv,Pv\rangle
     \ge -c\bigl(\operatorname{Re}\langle Pv,v\rangle

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -1205,7 +1205,8 @@ sufficient stronger hypotheses.
     $\eta \le (1-\gamma)/m$; the anticommutator finite-overlap reduction then
     gives the quadratic-form estimate with the chosen $\gamma$, and the positive
     quadratic-form criterion converts it to the norm lower bound. The strict form
-    is the same statement with $\gamma=1-\eta m$.
+    is the same statement with $\gamma=1-\eta m$, so the coefficient is then
+    $\eta$.
 \end{proof}
 
 \input{chapter/ch13_parent_hamiltonian_spectral_gap_martingale}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -338,6 +338,42 @@
     $\eta=(1-1/(4L))/(2(L-1))$.
 \end{proof}
 
+\begin{theorem}[Gap bound from a cyclic operator-product norm constant]
+    \label{thm:overlap_operator_norm_gap_bound_constant}
+    \lean{MPSTensor.parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant}
+    \leanok
+    \uses{lem:parent_hamiltonian_cyclic_overlap_operator_norm_constant_gap}
+    Let $L>1$. Put $m=2(L-1)$. Suppose there is a constant $\eta\ge0$ with
+    $\eta m<1$ and that, for every $N\ge2L$ and every overlapping off-diagonal pair
+    of cyclic length-$L$ windows,
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le
+        \eta\,\|h_{j,\mathrm{ES}}v\|,
+    \]
+    that is, a bound $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|\le\eta$ on the
+    operator-product norm rather than the directional bound of
+    Theorem~\ref{thm:overlap_norm_gap_bound_constant}. Then the parent Hamiltonian
+    has the gap constant $1-\eta m>0$. Concretely, if $N\ge2L$ and
+    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$, then
+    \[
+        (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+    This is a conditional reduction. The local terms
+    $h_{i,\mathrm{ES}}=p_i$ are the \emph{excitation} projections, so
+    $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|=1$ whenever the overlapping ranges
+    intersect; the hypothesis is then unsatisfiable for $\eta<1$, and it is not the
+    quantity controlled by the cited principal-angle estimates. The comparison is
+    documented in \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:parent_hamiltonian_cyclic_overlap_operator_norm_constant_gap},
+    with $\gamma=1-\eta m$, applies to the displayed operator-product hypothesis and
+    gives $0<1-\eta m$ together with the stated norm lower bound.
+\end{proof}
+
 \begin{theorem}[Conditional spectral gap for MPS parent Hamiltonians]
     \label{thm:parent_hamiltonian_gapped}
     \lean{MPSTensor.parentHamiltonian_gapped}
@@ -386,5 +422,36 @@
 \begin{proof}
     \leanok
     This follows from Theorem~\ref{thm:overlap_norm_gap_bound_constant} by taking
+    $\gamma=1-\eta\,2(L-1)$.
+\end{proof}
+
+\begin{theorem}[Conditional spectral gap from an operator-product norm constant]
+    \label{thm:parent_hamiltonian_gapped_operator_norm_constant}
+    \lean{MPSTensor.parentHamiltonian_gapped_of_overlap_operator_norm_constant}
+    \leanok
+    \uses{thm:overlap_operator_norm_gap_bound_constant}
+    For a tensor $A$ and a range $L>1$, suppose there is a constant
+    $\eta\ge0$ such that $\eta\,2(L-1)<1$ and, for every $N\ge2L$ and every
+    overlapping off-diagonal pair of cyclic length-$L$ windows,
+    \[
+        \|h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)\|
+        \le
+        \eta\,\|h_{j,\mathrm{ES}}v\|.
+    \]
+    Then there exists $\gamma>0$ such that, for every $N\ge2L$ and every vector
+    $v\in(\mathcal G_{N,L}^{\mathrm{ES}}(A))^\perp$,
+    \[
+        \gamma\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
+    \]
+    As in Theorem~\ref{thm:overlap_operator_norm_gap_bound_constant} this is a
+    conditional reduction: the operator-product hypothesis is unsatisfiable for the
+    overlapping excitation projections, where
+    $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|=1$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    This follows from
+    Theorem~\ref{thm:overlap_operator_norm_gap_bound_constant} by taking
     $\gamma=1-\eta\,2(L-1)$.
 \end{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap_martingale.tex
@@ -360,11 +360,14 @@
         (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
     \]
     This is a conditional reduction. The local terms
-    $h_{i,\mathrm{ES}}=p_i$ are the \emph{excitation} projections, so
-    $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|=1$ whenever the overlapping ranges
-    intersect; the hypothesis is then unsatisfiable for $\eta<1$, and it is not the
-    quantity controlled by the cited principal-angle estimates. The comparison is
-    documented in \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex}.
+    $h_{i,\mathrm{ES}}=p_i$ are the \emph{excitation} projections. If their
+    overlapping ranges have a common nonzero vector, then
+    $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|=1$, so the hypothesis is
+    unsatisfiable for $\eta<1$ in that case. In degenerate cases, such as a
+    zero excitation projection, the operator-product norm can be smaller. In any
+    case this is not the quantity controlled by the cited principal-angle
+    estimates. The comparison is documented in
+    \path{docs/paper-gaps/cpgsv21_martingale_overlap.tex}.
 \end{theorem}
 
 \begin{proof}
@@ -444,9 +447,10 @@
         \gamma\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
     \]
     As in Theorem~\ref{thm:overlap_operator_norm_gap_bound_constant} this is a
-    conditional reduction: the operator-product hypothesis is unsatisfiable for the
-    overlapping excitation projections, where
-    $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|=1$.
+    conditional reduction: the operator-product hypothesis is unsatisfiable for
+    any overlapping pair whose excitation ranges have a common nonzero vector,
+    since then $\|h_{i,\mathrm{ES}}h_{j,\mathrm{ES}}\|=1$. The statement does not
+    assert this norm identity in degenerate cases.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -326,9 +326,10 @@ with public reformulations
 MPS-specific task is unchanged: to produce a uniform anticommutator (or
 ground-space principal-angle) estimate for overlapping cyclic windows, using the
 intersection identity $\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
-\leanid{adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}; bounding
-$\|p_ip_j\|$ itself is not available, since that norm is $1$ on overlapping
-windows.
+\leanid{adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}; a uniform
+small bound on $\|p_ip_j\|$ itself is not available in the generic overlapping
+case, since that norm is $1$ whenever the two excitation ranges have a common
+nonzero vector.
 
 \section{Relation to the blueprint}
 

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -279,6 +279,43 @@ proof can instead target the anticommutator form
 \]
 used in \cite[Section~IV.C]{Cirac2021Matrix}.
 
+The development now also records the symmetric operator-product route, which
+removes the directional point above. Instead of the directed bound (N$_\eta$),
+suppose the operator-product bound
+\[
+    \|p_i (p_j v)\|\le\eta\,\|p_j v\|
+    \tag{O$_\eta$}
+\]
+holds for all $v$, that is, a bound $\|p_i p_j\|\le\eta$ on the norm of the
+product. This is the cosine of the smallest principal angle between the
+overlapping excitation ranges, and it is the quantity the cited principal-angle
+estimates control. The identity
+$\operatorname{Re}\langle p_i v,p_j v\rangle
+=\operatorname{Re}\langle p_i v,p_i p_j v\rangle$, Cauchy--Schwarz, and the
+arithmetic--geometric mean inequality give, for $0\le\eta$,
+\[
+    \operatorname{Re}\langle p_i v,p_j v\rangle
+    +\operatorname{Re}\langle p_j v,p_i v\rangle
+    \ge -\eta\bigl(\|p_i v\|^2+\|p_j v\|^2\bigr),
+\]
+which is exactly the symmetric anticommutator estimate with coefficient $\eta$.
+Unlike (N$_\eta$), the hypothesis (O$_\eta$) imposes no constraint on
+$\ker p_j$: when $p_j v=0$ both sides vanish. Thus (O$_\eta$) with
+$\eta\,2(L-1)<1$ is a satisfiable, source-faithful target, and it yields the
+same positive gap $1-\eta\,2(L-1)$ through the formalized reduction. The abstract
+conversion is \leanid{re_inner_anticommutator_ge_neg_of_norm_apply_le}; the
+cyclic-window entry points are
+\leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le}
+and
+\leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt},
+with public wrappers
+\leanid{parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant} and
+\leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. The
+remaining MPS-specific task is then to bound $\|p_i p_j\|$ uniformly below
+$1/(2(L-1))$ for overlapping cyclic windows, using the intersection identity
+$\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
+\leanid{adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}.
+
 \section{Relation to the blueprint}
 
 The blueprint item labelled \path{lem:martingale_mps} in

--- a/docs/paper-gaps/cpgsv21_martingale_overlap.tex
+++ b/docs/paper-gaps/cpgsv21_martingale_overlap.tex
@@ -279,17 +279,14 @@ proof can instead target the anticommutator form
 \]
 used in \cite[Section~IV.C]{Cirac2021Matrix}.
 
-The development now also records the symmetric operator-product route, which
-removes the directional point above. Instead of the directed bound (N$_\eta$),
-suppose the operator-product bound
+The development now also records the symmetric operator-product route. Instead of
+the directed bound (N$_\eta$), suppose the operator-product bound
 \[
     \|p_i (p_j v)\|\le\eta\,\|p_j v\|
     \tag{O$_\eta$}
 \]
 holds for all $v$, that is, a bound $\|p_i p_j\|\le\eta$ on the norm of the
-product. This is the cosine of the smallest principal angle between the
-overlapping excitation ranges, and it is the quantity the cited principal-angle
-estimates control. The identity
+product. The identity
 $\operatorname{Re}\langle p_i v,p_j v\rangle
 =\operatorname{Re}\langle p_i v,p_i p_j v\rangle$, Cauchy--Schwarz, and the
 arithmetic--geometric mean inequality give, for $0\le\eta$,
@@ -299,22 +296,39 @@ arithmetic--geometric mean inequality give, for $0\le\eta$,
     \ge -\eta\bigl(\|p_i v\|^2+\|p_j v\|^2\bigr),
 \]
 which is exactly the symmetric anticommutator estimate with coefficient $\eta$.
-Unlike (N$_\eta$), the hypothesis (O$_\eta$) imposes no constraint on
-$\ker p_j$: when $p_j v=0$ both sides vanish. Thus (O$_\eta$) with
-$\eta\,2(L-1)<1$ is a satisfiable, source-faithful target, and it yields the
-same positive gap $1-\eta\,2(L-1)$ through the formalized reduction. The abstract
+The difference from (N$_\eta$) is which kernel the hypothesis constrains: imposed
+for all $v$, (N$_\eta$) forces $p_j(\ker p_i)\subseteq\ker p_i$, whereas (O$_\eta$)
+imposes no such preservation of $\ker p_i$. Through this conversion any (O$_\eta$)
+with $\eta\,2(L-1)<1$ yields the same positive gap $1-\eta\,2(L-1)$.
+
+This removes the kernel-preservation artefact of (N$_\eta$), but it does not make
+the hypothesis achievable for the MPS application, and (O$_\eta$) must not be
+identified with the cited principal-angle estimate. The symbols $p_i=h_i$ here are
+the \emph{excitation} projections (the local parent-Hamiltonian terms), not the
+ground-space projectors $q_i$ of \S1. The Kastoryano--Lucia quantity
+$\delta(\ell)=\|q_iq_j-P\|$ bounds the principal angle between the two local
+\emph{ground} spaces, while $\|p_ip_j\|$ is the cosine of the smallest principal
+angle between the two \emph{excitation} ranges; these are different quantities. If
+the two overlapping excitation ranges share any nonzero vector then
+$\|p_ip_j\|=1$, so (O$_\eta$) with $\eta<1$ is unsatisfiable, and the target
+$\eta<1/(2(L-1))$ cannot follow from the ground-space intersection estimate without
+an additional quotient or disjointness argument. Like (N$_\eta$), the
+operator-product bound is therefore a \emph{conditional} reduction recorded in the
+formal development, not an achievable source-faithful estimate. The abstract
 conversion is \leanid{re_inner_anticommutator_ge_neg_of_norm_apply_le}; the
 cyclic-window entry points are
 \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_le}
 and
 \leanid{parentHamiltonianES_gap_bound_of_cyclic_window_overlap_operator_norm_of_lt},
-with public wrappers
+with public reformulations
 \leanid{parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant} and
-\leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. The
-remaining MPS-specific task is then to bound $\|p_i p_j\|$ uniformly below
-$1/(2(L-1))$ for overlapping cyclic windows, using the intersection identity
-$\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
-\leanid{adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}.
+\leanid{parentHamiltonian_gapped_of_overlap_operator_norm_constant}. The remaining
+MPS-specific task is unchanged: to produce a uniform anticommutator (or
+ground-space principal-angle) estimate for overlapping cyclic windows, using the
+intersection identity $\ker h_i\cap\ker h_j=\ker(h_i+h_j)$ or its restatement
+\leanid{adjacent_localTermES_eq_zero_iff_mem_groundSpaceES_succ}; bounding
+$\|p_ip_j\|$ itself is not available, since that norm is $1$ on overlapping
+windows.
 
 \section{Relation to the blueprint}
 


### PR DESCRIPTION
### Motivation

- Adds the operator-product symmetric anticommutator route to the martingale spectral-gap reduction, corresponding to the anticommutator estimate
  \(h_i h_j + h_j h_i \ge -c_{ij}(1 - \gamma)(h_i + h_j)\) from arXiv:2011.12127 Section IV.C, equation (4:martingale-2).
- The new hypothesis is an excitation-projection operator-product bound \(\|p_i p_j\| \le \eta\). This is a useful conditional reduction, but it is not the ground-space principal-angle quantity controlled by the FNW/Kastoryano estimates; for overlapping excitation ranges with a common nonzero vector, \(\|p_i p_j\| = 1\).
- Continues the formalization of the MPS parent-Hamiltonian spectral gap; see #952 and Refs #190, #460.

### Description

- `TNLean/Analysis/ProjectionGeometry.lean`: adds `re_inner_anticommutator_ge_neg_of_norm_apply_le`, converting the operator-product bound for symmetric projections into the anticommutator quadratic-form estimate by compression, Cauchy-Schwarz, and AM-GM.
- `TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean`: adds cyclic-window reductions for the overlap operator-product norm hypothesis.
- `TNLean/MPS/ParentHamiltonian/Martingale/Gap.lean`: adds the public gap-bound and gappedness reformulations.
- `docs/paper-gaps/cpgsv21_martingale_overlap.tex` and the blueprint record that this is a conditional route, not yet the MPS-specific ground-space principal-angle estimate.

### Testing

- Lean Action CI validates the build.
- Blueprint/prose and file-length checks are required on CI.

---
Refs #952

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in Lean/analysis with no runtime, auth, or data-path changes; main risk is mathematical misstatement in docs, not production regressions.
> 
> **Overview**
> Adds a **symmetric operator-product** martingale route parallel to the existing directional norm-compression bound: hypothesis \(\|p_i(p_j v)\| \le \eta \|p_j v\|\) (bound on \(\|p_i p_j\|\)) instead of \(\|p_i(p_j v)\| \le \eta \|p_i v\|\).
> 
> **`ProjectionGeometry.lean`** introduces `re_inner_anticommutator_ge_neg_of_norm_apply_le`, turning that operator-product estimate for symmetric projections into the source anticommutator quadratic form (Cauchy–Schwarz + AM-GM).
> 
> **`Martingale/Reduction.lean`** and **`Gap.lean`** wire cyclic-window finite-overlap reductions and public gap/gappedness theorems (`parentHamiltonianES_gap_bound_of_overlap_operator_norm_constant`, `parentHamiltonian_gapped_of_overlap_operator_norm_constant`), yielding gap \(1 - \eta \cdot 2(L-1)\) when \(\eta \cdot 2(L-1) < 1\).
> 
> Doc/blueprint updates retarget arXiv:2011.12127 Section IV.C citations to lines 2176–2179 and stress this is a **conditional** reduction—not the FNW/Kastoryano ground-space principal-angle quantity; overlapping excitation ranges with a common vector force \(\|p_i p_j\| = 1\) (`docs/paper-gaps/cpgsv21_martingale_overlap.tex`, blueprint ch13).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be3da4375eb8a93d4eb440a87097de39695cff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->