### PR TITLE
feat(Channel): prove Wolf.infimum_is_attained

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -8,75 +8,76 @@ import TNLean.Algebra.MatrixAux
 /-!
 # Hermitian matrix extremal eigenvalues
 
-This file provides lemmas for Hermitian complex matrices over `Fin D`: the
-extremal eigenvalue lemmas and scalar-shift spectral formulae.
+This file provides lemmas for Hermitian complex matrices over an arbitrary
+finite index type `n`: the extremal eigenvalue lemmas and scalar-shift spectral
+formulae.
 -/
 
 open scoped Matrix ComplexOrder
 
-variable {D : ℕ}
+variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- Smallest eigenvalue of a Hermitian matrix on a nonempty finite space. -/
-noncomputable def minEigenvalue [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) : ℝ :=
+noncomputable def minEigenvalue [Nonempty (n)]
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) : ℝ :=
   (Finset.univ.image hM.eigenvalues).min' (Finset.Nonempty.image Finset.univ_nonempty _)
 
 /-- The smallest eigenvalue is bounded above by every eigenvalue. -/
-theorem minEigenvalue_le [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (i : Fin D) :
+theorem minEigenvalue_le [Nonempty (n)]
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (i : n) :
     minEigenvalue hM ≤ hM.eigenvalues i :=
   Finset.min'_le _ _ (Finset.mem_image.mpr ⟨i, Finset.mem_univ _, rfl⟩)
 
 /-- The smallest eigenvalue is attained by some eigenvector. -/
-theorem minEigenvalue_achieved [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
-    ∃ i : Fin D, hM.eigenvalues i = minEigenvalue hM := by
+theorem minEigenvalue_achieved [Nonempty (n)]
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) :
+    ∃ i : n, hM.eigenvalues i = minEigenvalue hM := by
   have hne := Finset.Nonempty.image Finset.univ_nonempty hM.eigenvalues
   obtain ⟨i, _, hi⟩ := Finset.mem_image.mp (Finset.min'_mem _ hne)
   exact ⟨i, hi⟩
 
 /-- A positive definite Hermitian matrix has positive smallest eigenvalue. -/
-theorem minEigenvalue_pos_of_posDef [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (hPD : M.PosDef) :
+theorem minEigenvalue_pos_of_posDef [Nonempty (n)]
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (hPD : M.PosDef) :
     (0 : ℝ) < minEigenvalue hM := by
   simp only [minEigenvalue, Finset.lt_min'_iff, Finset.mem_image, Finset.mem_univ, true_and]
   rintro _ ⟨i, rfl⟩
   exact hM.posDef_iff_eigenvalues_pos.mp hPD i
 
 /-- Largest eigenvalue of a Hermitian matrix on a nonempty finite space. -/
-noncomputable def maxEigenvalue [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) : ℝ :=
+noncomputable def maxEigenvalue [Nonempty (n)]
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) : ℝ :=
   (Finset.univ.image hM.eigenvalues).max' (Finset.Nonempty.image Finset.univ_nonempty _)
 
 /-- Every eigenvalue is bounded above by the largest eigenvalue. -/
-theorem le_maxEigenvalue [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (i : Fin D) :
+theorem le_maxEigenvalue [Nonempty (n)]
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (i : n) :
     hM.eigenvalues i ≤ maxEigenvalue hM :=
   Finset.le_max' _ _ (Finset.mem_image.mpr ⟨i, Finset.mem_univ _, rfl⟩)
 
 /-- The largest eigenvalue is attained by some eigenvector. -/
-theorem maxEigenvalue_achieved [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
-    ∃ i : Fin D, hM.eigenvalues i = maxEigenvalue hM := by
+theorem maxEigenvalue_achieved [Nonempty (n)]
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) :
+    ∃ i : n, hM.eigenvalues i = maxEigenvalue hM := by
   have hne := Finset.Nonempty.image Finset.univ_nonempty hM.eigenvalues
   obtain ⟨i, _, hi⟩ := Finset.mem_image.mp (Finset.max'_mem _ hne)
   exact ⟨i, hi⟩
 
 /-- Spectral form of subtracting a scalar multiple of the identity from a Hermitian matrix. -/
 theorem hermitian_sub_scalar_spectral
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (c : ℝ) :
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (c : ℝ) :
     M - (↑c : ℂ) • 1 =
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
+      (↑hM.eigenvectorUnitary : Matrix (n) (n) ℂ) *
       Matrix.diagonal (fun j => (↑(hM.eigenvalues j - c) : ℂ)) *
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-  set U : Matrix (Fin D) (Fin D) ℂ := ↑hM.eigenvectorUnitary
+      (↑hM.eigenvectorUnitary : Matrix (n) (n) ℂ)ᴴ := by
+  set U : Matrix (n) (n) ℂ := ↑hM.eigenvectorUnitary
   have hUU : U * Uᴴ = 1 := by
     simpa [U, Matrix.star_eq_conjTranspose] using
       (Unitary.mul_star_self_of_mem hM.eigenvectorUnitary.prop)
-  have h_cI : (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) =
+  have h_cI : (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) =
       U * ((↑c : ℂ) • 1) * Uᴴ := by
     calc
-      (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
+      (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
         rw [hUU]
       _ = U * ((↑c : ℂ) • 1) * Uᴴ := by
           rw [Matrix.mul_smul, Matrix.mul_one, smul_mul_assoc]
@@ -102,12 +103,12 @@ theorem hermitian_sub_scalar_spectral
           simp [Complex.ofReal_sub]
 
 /-- Subtracting the smallest Hermitian eigenvalue leaves a positive semidefinite matrix. -/
-theorem sub_minEigenvalue_smul_one_posSemidef [Nonempty (Fin D)]
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) :
+theorem sub_minEigenvalue_smul_one_posSemidef [Nonempty (n)]
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) :
     (M - (↑(minEigenvalue hM) : ℂ) • 1).PosSemidef := by
   classical
-  let U : Matrix (Fin D) (Fin D) ℂ := ↑hM.eigenvectorUnitary
-  let Λ : Fin D → ℂ := fun j => ↑(hM.eigenvalues j - minEigenvalue hM)
+  let U : Matrix (n) (n) ℂ := ↑hM.eigenvectorUnitary
+  let Λ : n → ℂ := fun j => ↑(hM.eigenvalues j - minEigenvalue hM)
   have hdiag : (Matrix.diagonal Λ).PosSemidef := by
     refine Matrix.PosSemidef.diagonal ?_
     intro j
@@ -125,15 +126,15 @@ This is the matrix estimate used in Wolf's compactness argument for the Lorentz
 normal form: the filtered Choi trace is bounded below by the smallest
 eigenvalue times the Hilbert--Schmidt trace form. -/
 theorem posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le
-    [Nonempty (Fin D)] {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.PosDef)
-    (X : Matrix (Fin D) (Fin D) ℂ) :
+    [Nonempty (n)] {M : Matrix (n) (n) ℂ} (hM : M.PosDef)
+    (X : Matrix (n) (n) ℂ) :
     (↑(minEigenvalue hM.isHermitian) : ℂ) * Matrix.trace (Xᴴ * X) ≤
       Matrix.trace (X * M * Xᴴ) := by
   classical
   let lam : ℂ := ↑(minEigenvalue hM.isHermitian)
   have hleft : (Xᴴ * X).PosSemidef :=
     Matrix.posSemidef_conjTranspose_mul_self X
-  have hdiff : (M - lam • (1 : Matrix (Fin D) (Fin D) ℂ)).PosSemidef := by
+  have hdiff : (M - lam • (1 : Matrix (n) (n) ℂ)).PosSemidef := by
     simpa [lam] using sub_minEigenvalue_smul_one_posSemidef hM.isHermitian
   have hnonneg : 0 ≤ Matrix.trace ((Xᴴ * X) * (M - lam • 1)) :=
     Matrix.PosSemidef.trace_mul_nonneg hleft hdiff
@@ -156,19 +157,19 @@ theorem posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le
 
 /-- Spectral form of subtracting a Hermitian matrix from a scalar multiple of the identity. -/
 theorem smul_one_sub_hermitian_spectral
-    {M : Matrix (Fin D) (Fin D) ℂ} (hM : M.IsHermitian) (c : ℝ) :
-    (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) - M =
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ) *
+    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (c : ℝ) :
+    (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) - M =
+      (↑hM.eigenvectorUnitary : Matrix (n) (n) ℂ) *
       Matrix.diagonal (fun j => (↑(c - hM.eigenvalues j) : ℂ)) *
-      (↑hM.eigenvectorUnitary : Matrix (Fin D) (Fin D) ℂ)ᴴ := by
-  set U : Matrix (Fin D) (Fin D) ℂ := ↑hM.eigenvectorUnitary
+      (↑hM.eigenvectorUnitary : Matrix (n) (n) ℂ)ᴴ := by
+  set U : Matrix (n) (n) ℂ := ↑hM.eigenvectorUnitary
   have hUU : U * Uᴴ = 1 := by
     simpa [U, Matrix.star_eq_conjTranspose] using
       (Unitary.mul_star_self_of_mem hM.eigenvectorUnitary.prop)
-  have h_cI : (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) =
+  have h_cI : (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) =
       U * ((↑c : ℂ) • 1) * Uᴴ := by
     calc
-      (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
+      (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
         rw [hUU]
       _ = U * ((↑c : ℂ) • 1) * Uᴴ := by
           rw [Matrix.mul_smul, Matrix.mul_one, smul_mul_assoc]
@@ -177,7 +178,7 @@ theorem smul_one_sub_hermitian_spectral
     simpa [U, Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
       Function.comp_def] using hM.spectral_theorem
   calc
-    (↑c : ℂ) • (1 : Matrix (Fin D) (Fin D) ℂ) - M
+    (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) - M
         = U * ((↑c : ℂ) • 1) * Uᴴ -
             U * Matrix.diagonal (fun j => (↑(hM.eigenvalues j) : ℂ)) * Uᴴ := by
               conv_lhs =>

--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -18,46 +18,46 @@ open scoped Matrix ComplexOrder
 variable {n : Type*} [Fintype n] [DecidableEq n]
 
 /-- Smallest eigenvalue of a Hermitian matrix on a nonempty finite space. -/
-noncomputable def minEigenvalue [Nonempty (n)]
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) : ℝ :=
+noncomputable def minEigenvalue [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) : ℝ :=
   (Finset.univ.image hM.eigenvalues).min' (Finset.Nonempty.image Finset.univ_nonempty _)
 
 /-- The smallest eigenvalue is bounded above by every eigenvalue. -/
-theorem minEigenvalue_le [Nonempty (n)]
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (i : n) :
+theorem minEigenvalue_le [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (i : n) :
     minEigenvalue hM ≤ hM.eigenvalues i :=
   Finset.min'_le _ _ (Finset.mem_image.mpr ⟨i, Finset.mem_univ _, rfl⟩)
 
 /-- The smallest eigenvalue is attained by some eigenvector. -/
-theorem minEigenvalue_achieved [Nonempty (n)]
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) :
+theorem minEigenvalue_achieved [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
     ∃ i : n, hM.eigenvalues i = minEigenvalue hM := by
   have hne := Finset.Nonempty.image Finset.univ_nonempty hM.eigenvalues
   obtain ⟨i, _, hi⟩ := Finset.mem_image.mp (Finset.min'_mem _ hne)
   exact ⟨i, hi⟩
 
 /-- A positive definite Hermitian matrix has positive smallest eigenvalue. -/
-theorem minEigenvalue_pos_of_posDef [Nonempty (n)]
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (hPD : M.PosDef) :
+theorem minEigenvalue_pos_of_posDef [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (hPD : M.PosDef) :
     (0 : ℝ) < minEigenvalue hM := by
   simp only [minEigenvalue, Finset.lt_min'_iff, Finset.mem_image, Finset.mem_univ, true_and]
   rintro _ ⟨i, rfl⟩
   exact hM.posDef_iff_eigenvalues_pos.mp hPD i
 
 /-- Largest eigenvalue of a Hermitian matrix on a nonempty finite space. -/
-noncomputable def maxEigenvalue [Nonempty (n)]
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) : ℝ :=
+noncomputable def maxEigenvalue [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) : ℝ :=
   (Finset.univ.image hM.eigenvalues).max' (Finset.Nonempty.image Finset.univ_nonempty _)
 
 /-- Every eigenvalue is bounded above by the largest eigenvalue. -/
-theorem le_maxEigenvalue [Nonempty (n)]
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (i : n) :
+theorem le_maxEigenvalue [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (i : n) :
     hM.eigenvalues i ≤ maxEigenvalue hM :=
   Finset.le_max' _ _ (Finset.mem_image.mpr ⟨i, Finset.mem_univ _, rfl⟩)
 
 /-- The largest eigenvalue is attained by some eigenvector. -/
-theorem maxEigenvalue_achieved [Nonempty (n)]
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) :
+theorem maxEigenvalue_achieved [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
     ∃ i : n, hM.eigenvalues i = maxEigenvalue hM := by
   have hne := Finset.Nonempty.image Finset.univ_nonempty hM.eigenvalues
   obtain ⟨i, _, hi⟩ := Finset.mem_image.mp (Finset.max'_mem _ hne)
@@ -65,19 +65,19 @@ theorem maxEigenvalue_achieved [Nonempty (n)]
 
 /-- Spectral form of subtracting a scalar multiple of the identity from a Hermitian matrix. -/
 theorem hermitian_sub_scalar_spectral
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (c : ℝ) :
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (c : ℝ) :
     M - (↑c : ℂ) • 1 =
-      (↑hM.eigenvectorUnitary : Matrix (n) (n) ℂ) *
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ) *
       Matrix.diagonal (fun j => (↑(hM.eigenvalues j - c) : ℂ)) *
-      (↑hM.eigenvectorUnitary : Matrix (n) (n) ℂ)ᴴ := by
-  set U : Matrix (n) (n) ℂ := ↑hM.eigenvectorUnitary
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ)ᴴ := by
+  set U : Matrix n n ℂ := ↑hM.eigenvectorUnitary
   have hUU : U * Uᴴ = 1 := by
     simpa [U, Matrix.star_eq_conjTranspose] using
       (Unitary.mul_star_self_of_mem hM.eigenvectorUnitary.prop)
-  have h_cI : (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) =
+  have h_cI : (↑c : ℂ) • (1 : Matrix n n ℂ) =
       U * ((↑c : ℂ) • 1) * Uᴴ := by
     calc
-      (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
+      (↑c : ℂ) • (1 : Matrix n n ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
         rw [hUU]
       _ = U * ((↑c : ℂ) • 1) * Uᴴ := by
           rw [Matrix.mul_smul, Matrix.mul_one, smul_mul_assoc]
@@ -103,11 +103,11 @@ theorem hermitian_sub_scalar_spectral
           simp [Complex.ofReal_sub]
 
 /-- Subtracting the smallest Hermitian eigenvalue leaves a positive semidefinite matrix. -/
-theorem sub_minEigenvalue_smul_one_posSemidef [Nonempty (n)]
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) :
+theorem sub_minEigenvalue_smul_one_posSemidef [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
     (M - (↑(minEigenvalue hM) : ℂ) • 1).PosSemidef := by
   classical
-  let U : Matrix (n) (n) ℂ := ↑hM.eigenvectorUnitary
+  let U : Matrix n n ℂ := ↑hM.eigenvectorUnitary
   let Λ : n → ℂ := fun j => ↑(hM.eigenvalues j - minEigenvalue hM)
   have hdiag : (Matrix.diagonal Λ).PosSemidef := by
     refine Matrix.PosSemidef.diagonal ?_
@@ -126,15 +126,15 @@ This is the matrix estimate used in Wolf's compactness argument for the Lorentz
 normal form: the filtered Choi trace is bounded below by the smallest
 eigenvalue times the Hilbert--Schmidt trace form. -/
 theorem posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le
-    [Nonempty (n)] {M : Matrix (n) (n) ℂ} (hM : M.PosDef)
-    (X : Matrix (n) (n) ℂ) :
+    [Nonempty n] {M : Matrix n n ℂ} (hM : M.PosDef)
+    (X : Matrix n n ℂ) :
     (↑(minEigenvalue hM.isHermitian) : ℂ) * Matrix.trace (Xᴴ * X) ≤
       Matrix.trace (X * M * Xᴴ) := by
   classical
   let lam : ℂ := ↑(minEigenvalue hM.isHermitian)
   have hleft : (Xᴴ * X).PosSemidef :=
     Matrix.posSemidef_conjTranspose_mul_self X
-  have hdiff : (M - lam • (1 : Matrix (n) (n) ℂ)).PosSemidef := by
+  have hdiff : (M - lam • (1 : Matrix n n ℂ)).PosSemidef := by
     simpa [lam] using sub_minEigenvalue_smul_one_posSemidef hM.isHermitian
   have hnonneg : 0 ≤ Matrix.trace ((Xᴴ * X) * (M - lam • 1)) :=
     Matrix.PosSemidef.trace_mul_nonneg hleft hdiff
@@ -157,19 +157,19 @@ theorem posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le
 
 /-- Spectral form of subtracting a Hermitian matrix from a scalar multiple of the identity. -/
 theorem smul_one_sub_hermitian_spectral
-    {M : Matrix (n) (n) ℂ} (hM : M.IsHermitian) (c : ℝ) :
-    (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) - M =
-      (↑hM.eigenvectorUnitary : Matrix (n) (n) ℂ) *
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) (c : ℝ) :
+    (↑c : ℂ) • (1 : Matrix n n ℂ) - M =
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ) *
       Matrix.diagonal (fun j => (↑(c - hM.eigenvalues j) : ℂ)) *
-      (↑hM.eigenvectorUnitary : Matrix (n) (n) ℂ)ᴴ := by
-  set U : Matrix (n) (n) ℂ := ↑hM.eigenvectorUnitary
+      (↑hM.eigenvectorUnitary : Matrix n n ℂ)ᴴ := by
+  set U : Matrix n n ℂ := ↑hM.eigenvectorUnitary
   have hUU : U * Uᴴ = 1 := by
     simpa [U, Matrix.star_eq_conjTranspose] using
       (Unitary.mul_star_self_of_mem hM.eigenvectorUnitary.prop)
-  have h_cI : (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) =
+  have h_cI : (↑c : ℂ) • (1 : Matrix n n ℂ) =
       U * ((↑c : ℂ) • 1) * Uᴴ := by
     calc
-      (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
+      (↑c : ℂ) • (1 : Matrix n n ℂ) = (↑c : ℂ) • (U * Uᴴ) := by
         rw [hUU]
       _ = U * ((↑c : ℂ) • 1) * Uᴴ := by
           rw [Matrix.mul_smul, Matrix.mul_one, smul_mul_assoc]
@@ -178,7 +178,7 @@ theorem smul_one_sub_hermitian_spectral
     simpa [U, Unitary.conjStarAlgAut_apply, Matrix.star_eq_conjTranspose,
       Function.comp_def] using hM.spectral_theorem
   calc
-    (↑c : ℂ) • (1 : Matrix (n) (n) ℂ) - M
+    (↑c : ℂ) • (1 : Matrix n n ℂ) - M
         = U * ((↑c : ℂ) • 1) * Uᴴ -
             U * Matrix.diagonal (fun j => (↑(hM.eigenvalues j) : ℂ)) * Uᴴ := by
               conv_lhs =>

--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -10,6 +10,8 @@ import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.MeanInequalities
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+import Mathlib.Topology.Instances.Matrix
 
 /-!
 # Auxiliary matrix lemmas
@@ -110,6 +112,22 @@ theorem trace_conjTranspose_mul_self_re_kronecker
           rw [Complex.mul_re, hA_im, hB_im, mul_zero, sub_zero]
 
 end FrobeniusKronecker
+
+section KroneckerContinuity
+
+variable {X R : Type*} [TopologicalSpace X] [TopologicalSpace R] [Mul R] [ContinuousMul R]
+  {m n p q : Type*}
+
+/-- The Kronecker product is jointly continuous in its two arguments. -/
+theorem _root_.Continuous.matrix_kronecker {A : X → Matrix m n R} {B : X → Matrix p q R}
+    (hA : Continuous A) (hB : Continuous B) :
+    Continuous fun x => (A x) ⊗ₖ (B x) := by
+  refine continuous_matrix fun r c => ?_
+  obtain ⟨i₁, i₂⟩ := r
+  obtain ⟨j₁, j₂⟩ := c
+  exact (hA.matrix_elem i₁ j₁).mul (hB.matrix_elem i₂ j₂)
+
+end KroneckerContinuity
 
 section FrobeniusDeterminant
 

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -6,8 +6,12 @@ import TNLean.Channel.Basic
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.ChoiJamiolkowski
 import TNLean.Channel.NormalForm
+import TNLean.Algebra.HermitianHelpers
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.Normed.Module.FiniteDimension
+import Mathlib.Topology.MetricSpace.Bounded
+import Mathlib.Topology.Order.Compact
 
 /-!
 # Lorentz normal form for quantum channels (Wolf Section 2.3, Propositions 2.8–2.11)
@@ -52,7 +56,7 @@ See the documentation of `infimum_is_attained` for the precise missing fact.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.3][Wolf2012QChannels]
 -/
 
-open scoped Matrix BigOperators ComplexOrder Kronecker
+open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius
 open Matrix Finset
 open ChoiJamiolkowski
 
@@ -156,46 +160,174 @@ section GenericNormalForm
 
 variable {D : ℕ}
 
-/-- **Key lemma (not yet formalised).**  For a positive-definite Choi matrix τ,
-the infimum of `tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]` over `S₁, S₂` with `det = 1`
-is attained.  That is, the continuous function
+/-- **Key lemma (Wolf Section 2.3, compactness/minimisation core).**  For a
+positive-definite Choi matrix τ, the infimum of `tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
+over `S₁, S₂` with `det = 1` is attained.  That is, the continuous function
 `(S₁, S₂) ↦ tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†]`
-achieves its minimum on the domain of SL(n, ℂ) × SL(n, ℂ).
+achieves its minimum on `SL(D, ℂ) × SL(D, ℂ)`.
 
-**Proof sketch** (Wolf Section 2.3).  Throughout, `‖·‖` denotes the Frobenius
-(Hilbert–Schmidt) norm `‖M‖² = tr[M M†]`; the coercivity bounds below are false
-for the operator norm (e.g. `‖I‖_op² = 1 < n`).  There exist bounds
-  `0 < λ_min(τ) · ‖S₂ ⊗ₖ S₁‖² ≤ tr[τ'] ≤ tr[τ]`,
-so we may restrict to a bounded subset `{S_i | ‖S_i‖ ≤ C}` inside
-`{S | det S = 1}`.  In finite dimensions this set is compact, and the
-continuous trace functional attains its infimum by the extreme value theorem.
+**Proof** (Wolf Section 2.3).  Throughout, `‖·‖` denotes the Frobenius
+(Hilbert–Schmidt) norm `‖M‖² = tr[M M†]`; the coercivity bound below is false
+for the operator norm (e.g. `‖I‖_op² = 1 < D`).  With `X = S₂ ⊗ₖ S₁`:
 
-**Available Mathlib facts:** the extreme value theorem is
-`IsCompact.exists_isMinOn` (`Mathlib.Topology.Order.Compact`); finite-dimensional
-Heine–Borel is `Metric.isCompact_of_isClosed_isBounded` (the matrix space is a
-proper space); and `det S = 1` is closed as the preimage of `{1}` under the
-continuous determinant.
+* the smallest-eigenvalue bound
+  `posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le` gives
+  `λ_min(τ) · tr[X† X] ≤ tr[X τ X†]`;
+* `Matrix.trace_conjTranspose_mul_self_re_kronecker` gives
+  `tr[X† X] = ‖S₂‖² · ‖S₁‖²`;
+* `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one` gives
+  `‖S_i‖² ≥ D` for `det S_i = 1` (singular-value AM–GM).
 
-**Remaining gap:** the **coercivity bound** that reduces the unbounded
-minimisation over `det = 1` to a compact sublevel set, namely
-`tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] ≥ λ_min(τ) · ‖S₂ ⊗ₖ S₁‖²` together with the
-Hilbert–Schmidt multiplicativity `‖S₂ ⊗ₖ S₁‖² = ‖S₂‖² · ‖S₁‖²` and the AM–GM
-determinant bound `det S = 1 ⟹ ‖S‖² ≥ n` (singular values of `S` have product
-`|det S| = 1`, so their squares average at least `1`; hence the value tends to
-`∞` with `‖S‖`).  The positive-definite trace lower bound, Kronecker
-Hilbert--Schmidt multiplicativity, and determinant AM--GM estimate are now
-separate lemmas; what remains is the matrix-analysis estimate combining them
-with the compactness and extreme-value argument. -/
+Together these yield `tr[X τ X†] ≥ λ_min(τ) · D · ‖S_i‖²`, so any pair whose
+value is at most the value at the identity lies in a fixed Frobenius ball
+`{‖S‖² ≤ R}`.  Intersecting that ball with `{det S = 1}` gives a closed and
+bounded — hence compact, by finite-dimensional Heine–Borel
+`Metric.isCompact_of_isClosed_isBounded` — set on which the continuous trace
+functional attains its minimum (`IsCompact.exists_isMinOn`); any pair outside
+the ball has value exceeding the value at the identity, so this minimiser is
+global.  The degenerate case `D = 0` is handled separately (all traces
+vanish). -/
 lemma infimum_is_attained
     {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
-    (_hτ_posDef : τ.PosDef) :
+    (hτ_posDef : τ.PosDef) :
     ∃ (S₁ S₂ : Matrix (Fin D) (Fin D) ℂ),
       S₁.det = 1 ∧ S₂.det = 1 ∧
       ∀ (T₁ T₂ : Matrix (Fin D) (Fin D) ℂ),
         T₁.det = 1 → T₂.det = 1 →
         (Matrix.trace (((T₂ ⊗ₖ T₁) * τ * ((T₂ ⊗ₖ T₁)ᴴ)))).re ≥
           (Matrix.trace (((S₂ ⊗ₖ S₁) * τ * ((S₂ ⊗ₖ S₁)ᴴ)))).re := by
-  sorry
+  classical
+  -- Degenerate dimension: over `Fin 0` every matrix is empty and all traces vanish.
+  rcases Nat.eq_zero_or_pos D with hD0 | hDpos
+  · subst hD0
+    refine ⟨1, 1, by simp, by simp, ?_⟩
+    intro T₁ T₂ _ _
+    simp [Matrix.trace]
+  haveI : Nonempty (Fin D) := ⟨⟨0, hDpos⟩⟩
+  have hDR : (0 : ℝ) < (D : ℝ) := by exact_mod_cast hDpos
+  -- Smallest eigenvalue of `τ`, positive by positive-definiteness.
+  set lam : ℝ := minEigenvalue hτ_posDef.isHermitian with hlam
+  have hlam_pos : 0 < lam := minEigenvalue_pos_of_posDef hτ_posDef.isHermitian hτ_posDef
+  -- The trace functional on pairs `(S₁, S₂)`.
+  set f : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ → ℝ :=
+    fun p => (Matrix.trace ((p.2 ⊗ₖ p.1) * τ * ((p.2 ⊗ₖ p.1)ᴴ))).re with hf
+  -- Coercivity: `tr[(B ⊗ₖ A) τ (B ⊗ₖ A)†] ≥ λ_min(τ) · ‖B‖² · ‖A‖²`.
+  have hcoer : ∀ A B : Matrix (Fin D) (Fin D) ℂ,
+      lam * (‖B‖ ^ 2 * ‖A‖ ^ 2) ≤
+        (Matrix.trace ((B ⊗ₖ A) * τ * ((B ⊗ₖ A)ᴴ))).re := by
+    intro A B
+    have h1 := posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le hτ_posDef (B ⊗ₖ A)
+    have h2 := (Complex.le_def.mp h1).1
+    rw [Complex.re_ofReal_mul, Matrix.trace_conjTranspose_mul_self_re_kronecker,
+      Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq,
+      Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq] at h2
+    exact h2
+  -- Unit determinant forces the Frobenius norm squared to be at least the dimension.
+  have hamgm : ∀ S : Matrix (Fin D) (Fin D) ℂ, S.det = 1 → (D : ℝ) ≤ ‖S‖ ^ 2 := by
+    intro S hS
+    have hnorm : ‖S.det‖ = 1 := by rw [hS]; exact norm_one
+    have h := Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one S hnorm
+    rwa [Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq, Fintype.card_fin] at h
+  -- The trace of `τ` is the value of `f` at the identity pair.
+  set v₀ : ℝ := (Matrix.trace τ).re with hv₀
+  have hf11 : f (1, 1) = v₀ := by
+    change (Matrix.trace (((1 : Matrix (Fin D) (Fin D) ℂ) ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) *
+      τ * (((1 : Matrix (Fin D) (Fin D) ℂ) ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ))ᴴ))).re = v₀
+    rw [Matrix.one_kronecker_one, Matrix.conjTranspose_one, Matrix.mul_one, Matrix.one_mul]
+  have hone_norm : ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ ^ 2 = (D : ℝ) := by
+    rw [← Matrix.trace_conjTranspose_mul_self_re_eq_frobenius_norm_sq,
+      Matrix.conjTranspose_one, Matrix.one_mul, Matrix.trace_one, Fintype.card_fin]
+    simp
+  -- Hence `λ_min(τ) · D² ≤ v₀`.
+  have hlamDD : lam * ((D : ℝ) * (D : ℝ)) ≤ v₀ := by
+    have h := hcoer 1 1
+    rw [hone_norm] at h
+    calc lam * ((D : ℝ) * (D : ℝ)) ≤ _ := h
+      _ = v₀ := hf11
+  -- Search radius `R = v₀ / (λ_min(τ) · D)`.
+  have hlamD_pos : 0 < lam * (D : ℝ) := mul_pos hlam_pos hDR
+  have hlamD_ne : lam * (D : ℝ) ≠ 0 := ne_of_gt hlamD_pos
+  have hv₀_pos : 0 < v₀ := lt_of_lt_of_le (mul_pos hlam_pos (mul_pos hDR hDR)) hlamDD
+  set R : ℝ := v₀ / (lam * (D : ℝ)) with hR
+  have hR_pos : 0 < R := div_pos hv₀_pos hlamD_pos
+  have hkey : lam * (D : ℝ) * R = v₀ := by
+    rw [hR, ← mul_div_assoc, mul_div_cancel_left₀ v₀ hlamD_ne]
+  have hD_le_R : (D : ℝ) ≤ R := by
+    rw [hR, le_div_iff₀ hlamD_pos]
+    have h : (D : ℝ) * (lam * (D : ℝ)) = lam * ((D : ℝ) * (D : ℝ)) := by ring
+    rw [h]; exact hlamDD
+  -- The compact search set: unit determinants inside a Frobenius ball.
+  set K : Set (Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ) :=
+    {p | p.1.det = 1 ∧ p.2.det = 1 ∧ ‖p.1‖ ^ 2 ≤ R ∧ ‖p.2‖ ^ 2 ≤ R} with hKdef
+  have h11K : ((1 : Matrix (Fin D) (Fin D) ℂ), (1 : Matrix (Fin D) (Fin D) ℂ)) ∈ K := by
+    rw [hKdef, Set.mem_setOf_eq]
+    refine ⟨Matrix.det_one, Matrix.det_one, ?_, ?_⟩
+    · change ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ ^ 2 ≤ R
+      rw [hone_norm]; exact hD_le_R
+    · change ‖(1 : Matrix (Fin D) (Fin D) ℂ)‖ ^ 2 ≤ R
+      rw [hone_norm]; exact hD_le_R
+  -- Continuity of `f`.
+  have hf_cont : Continuous f := by
+    have hk : Continuous fun p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ =>
+        (p.2 ⊗ₖ p.1) := continuous_snd.matrix_kronecker continuous_fst
+    exact Complex.continuous_re.comp
+      ((hk.matrix_mul continuous_const).matrix_mul hk.matrix_conjTranspose).matrix_trace
+  -- `K` is closed and bounded, hence compact.
+  have hK_closed : IsClosed K := by
+    have c1 : Continuous fun p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ =>
+        p.1.det := continuous_fst.matrix_det
+    have c2 : Continuous fun p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ =>
+        p.2.det := continuous_snd.matrix_det
+    have c3 : Continuous fun p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ =>
+        ‖p.1‖ ^ 2 := continuous_fst.norm.pow 2
+    have c4 : Continuous fun p : Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ =>
+        ‖p.2‖ ^ 2 := continuous_snd.norm.pow 2
+    rw [hKdef]
+    simp only [Set.setOf_and]
+    exact (isClosed_eq c1 continuous_const).inter ((isClosed_eq c2 continuous_const).inter
+      ((isClosed_le c3 continuous_const).inter (isClosed_le c4 continuous_const)))
+  have hsub : K ⊆ Metric.closedBall (0 : Matrix (Fin D) (Fin D) ℂ ×
+      Matrix (Fin D) (Fin D) ℂ) (Real.sqrt R) := by
+    intro p hp
+    rw [hKdef, Set.mem_setOf_eq] at hp
+    rw [Metric.mem_closedBall, dist_zero_right, Prod.norm_def]
+    exact max_le ((Real.le_sqrt (norm_nonneg _) hR_pos.le).mpr hp.2.2.1)
+      ((Real.le_sqrt (norm_nonneg _) hR_pos.le).mpr hp.2.2.2)
+  have hK_compact : IsCompact K :=
+    Metric.isCompact_of_isClosed_isBounded hK_closed (Metric.isBounded_closedBall.subset hsub)
+  -- Extreme value theorem on `K`.
+  obtain ⟨q, hqK, hq_min⟩ := hK_compact.exists_isMinOn ⟨_, h11K⟩ hf_cont.continuousOn
+  rw [hKdef, Set.mem_setOf_eq] at hqK
+  have hmin := isMinOn_iff.mp hq_min
+  refine ⟨q.1, q.2, hqK.1, hqK.2.1, ?_⟩
+  intro T₁ T₂ hT₁ hT₂
+  change f q ≤ f (T₁, T₂)
+  by_cases hmem : ‖T₁‖ ^ 2 ≤ R ∧ ‖T₂‖ ^ 2 ≤ R
+  · apply hmin
+    rw [hKdef, Set.mem_setOf_eq]
+    exact ⟨hT₁, hT₂, hmem.1, hmem.2⟩
+  · -- One factor escapes the ball, so the value exceeds `v₀ ≥ f q`.
+    have hqv : f q ≤ v₀ := by
+      have hh := hmin (1, 1) h11K
+      rwa [hf11] at hh
+    have hT₁D : (D : ℝ) ≤ ‖T₁‖ ^ 2 := hamgm T₁ hT₁
+    have hT₂D : (D : ℝ) ≤ ‖T₂‖ ^ 2 := hamgm T₂ hT₂
+    rw [not_and_or] at hmem
+    have hprod : (D : ℝ) * R < ‖T₂‖ ^ 2 * ‖T₁‖ ^ 2 := by
+      rcases hmem with h | h
+      · rw [not_le] at h
+        calc (D : ℝ) * R < (D : ℝ) * ‖T₁‖ ^ 2 := mul_lt_mul_of_pos_left h hDR
+          _ ≤ ‖T₂‖ ^ 2 * ‖T₁‖ ^ 2 := mul_le_mul_of_nonneg_right hT₂D (by positivity)
+      · rw [not_le] at h
+        calc (D : ℝ) * R = R * (D : ℝ) := by ring
+          _ < ‖T₂‖ ^ 2 * (D : ℝ) := mul_lt_mul_of_pos_right h hDR
+          _ ≤ ‖T₂‖ ^ 2 * ‖T₁‖ ^ 2 := mul_le_mul_of_nonneg_left hT₁D (by positivity)
+    have hbig : v₀ < f (T₁, T₂) := by
+      have hlt : v₀ < lam * (‖T₂‖ ^ 2 * ‖T₁‖ ^ 2) := by
+        rw [← hkey, mul_assoc]
+        exact mul_lt_mul_of_pos_left hprod hlam_pos
+      exact lt_of_lt_of_le hlt (hcoer T₁ T₂)
+    exact le_of_lt (lt_of_le_of_lt hqv hbig)
 
 /-- **Wolf Proposition 2.9: generic normal form for CP maps with full Kraus rank.**
 

--- a/TNLean/Channel/LorentzNormalForm.lean
+++ b/TNLean/Channel/LorentzNormalForm.lean
@@ -46,10 +46,11 @@ normal form* — with three canonical representatives.
 
 ## Dependencies on missing Mathlib infrastructure
 
-The compactness / minimisation argument used in the proof of Proposition 2.8 and 2.9
-(over SL(n, ℂ) filterings) is not yet formalised in Mathlib or TNLean.  The
-relevant theorems are therefore stated with `sorry` for the minimisation core.
-See the documentation of `infimum_is_attained` for the precise missing fact.
+The compactness / minimisation core (the infimum over SL(n, ℂ) filterings is
+attained) is now formalised as `infimum_is_attained`.  The remaining gap is the
+AM–GM optimality iteration (Step 5 below) that turns a minimiser into a
+doubly-stochastic normal form; it is still `sorry` inside
+`exists_normal_form_generic`.
 
 ## References
 
@@ -151,10 +152,9 @@ The proof idea (see Wolf Section 2.3):
 5. At the optimum, both partial traces of τ' are proportional to identity,
    giving doubly-stochastic T'.
 
-Step 4 is the compactness/minimisation argument that is **not yet formalised**
-in Mathlib or TNLean.  We state the lemma as `infimum_is_attained` with a
-`sorry` filler.  Step 5 follows from the optimality condition (AGM iteration),
-stated below. -/
+Step 4 is the compactness/minimisation argument, now formalised as
+`infimum_is_attained` below.  Step 5 follows from the optimality condition
+(AM–GM iteration) and is the remaining `sorry` in `exists_normal_form_generic`. -/
 
 section GenericNormalForm
 
@@ -170,23 +170,19 @@ achieves its minimum on `SL(D, ℂ) × SL(D, ℂ)`.
 (Hilbert–Schmidt) norm `‖M‖² = tr[M M†]`; the coercivity bound below is false
 for the operator norm (e.g. `‖I‖_op² = 1 < D`).  With `X = S₂ ⊗ₖ S₁`:
 
-* the smallest-eigenvalue bound
-  `posDef_minEigenvalue_mul_trace_conjTranspose_mul_self_le` gives
-  `λ_min(τ) · tr[X† X] ≤ tr[X τ X†]`;
-* `Matrix.trace_conjTranspose_mul_self_re_kronecker` gives
+* positive-semidefiniteness of `τ - λ_min(τ)·I` gives the smallest-eigenvalue
+  bound `λ_min(τ) · tr[X† X] ≤ tr[X τ X†]`;
+* the Kronecker factorisation of the Hilbert–Schmidt norm gives
   `tr[X† X] = ‖S₂‖² · ‖S₁‖²`;
-* `Matrix.card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one` gives
-  `‖S_i‖² ≥ D` for `det S_i = 1` (singular-value AM–GM).
+* the singular-value AM–GM inequality gives `‖S_i‖² ≥ D` whenever `det S_i = 1`.
 
 Together these yield `tr[X τ X†] ≥ λ_min(τ) · D · ‖S_i‖²`, so any pair whose
 value is at most the value at the identity lies in a fixed Frobenius ball
 `{‖S‖² ≤ R}`.  Intersecting that ball with `{det S = 1}` gives a closed and
-bounded — hence compact, by finite-dimensional Heine–Borel
-`Metric.isCompact_of_isClosed_isBounded` — set on which the continuous trace
-functional attains its minimum (`IsCompact.exists_isMinOn`); any pair outside
-the ball has value exceeding the value at the identity, so this minimiser is
-global.  The degenerate case `D = 0` is handled separately (all traces
-vanish). -/
+bounded — hence compact, by finite-dimensional Heine–Borel — set on which the
+continuous trace functional attains its minimum; any pair outside the ball has
+value exceeding the value at the identity, so this minimiser is global.  The
+degenerate case `D = 0` is handled separately (all traces vanish). -/
 lemma infimum_is_attained
     {τ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ}
     (hτ_posDef : τ.PosDef) :

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1600,14 +1600,35 @@ This section states the existence theorems from
 
 % Lean: Wolf.infimum_is_attained
 \begin{lemma}[Infimum attainment for SL-filterings]\label{lem:infimum_is_attained}
+    \lean{Wolf.infimum_is_attained}\leanok
     \uses{lem:posdef_trace_lower_bound, lem:det_amgm_hilbert_schmidt_bound,
     lem:kronecker_hilbert_schmidt_trace}
     For a positive-definite Choi matrix $\tau$, the infimum of
     $\tr\![(S_{2} \otimes_{k} S_{1}) \tau (S_{2} \otimes_{k} S_{1})^{\dagger}]$
     over $S_{1}, S_{2} \in \MN{D}$ with $\det S_{1} = \det S_{2} = 1$
-    is attained. \textbf{Not yet proved}---requires compactness of bounded
-    subsets of $\SL(D, \C)$ and the extreme-value theorem.
+    is attained.
 \end{lemma}
+\begin{proof}\leanok
+    \uses{lem:posdef_trace_lower_bound, lem:det_amgm_hilbert_schmidt_bound,
+    lem:kronecker_hilbert_schmidt_trace}
+    Write $X = S_{2} \otimes_{k} S_{1}$ and let $\lambda_{\min}(\tau) > 0$ be the
+    smallest eigenvalue of $\tau$. The positive-definite trace lower bound
+    (Lemma~\ref{lem:posdef_trace_lower_bound}) gives
+    $\tr[X \tau X^{\dagger}] \ge \lambda_{\min}(\tau)\,\tr[X^{\dagger}X]$; the
+    Kronecker Hilbert--Schmidt identity
+    (Lemma~\ref{lem:kronecker_hilbert_schmidt_trace}) gives
+    $\tr[X^{\dagger}X] = \tr[S_{2}^{\dagger}S_{2}]\,\tr[S_{1}^{\dagger}S_{1}]$; and
+    the singular-value AM--GM bound (Lemma~\ref{lem:det_amgm_hilbert_schmidt_bound})
+    gives $\tr[S_{i}^{\dagger}S_{i}] \ge D$ for $\det S_{i} = 1$. Combining,
+    $\tr[X \tau X^{\dagger}] \ge \lambda_{\min}(\tau)\,D\,\tr[S_{i}^{\dagger}S_{i}]$,
+    so any pair whose value is at most the value at the identity lies in a fixed
+    Frobenius ball $\{\tr[S^{\dagger}S] \le R\}$. Intersecting that ball with
+    $\{\det S = 1\}$ yields a closed and bounded, hence compact (finite-dimensional
+    Heine--Borel), subset on which the continuous trace functional attains its
+    minimum by the extreme-value theorem; any pair outside the ball has value
+    exceeding the value at the identity, so the minimiser is global. The
+    degenerate case $D = 0$ is immediate, all traces being zero.
+\end{proof}
 
 % Lean: Wolf.exists_normal_form_generic
 \begin{theorem}[Generic normal form for CP maps]\label{thm:exists_normal_form_generic}


### PR DESCRIPTION
### Motivation
- Discharges the foundational sorry blocking the Lorentz/SVD normal-form existence proofs
  (`Wolf.exists_normal_form_generic`, `Wolf.exists_lorentz_normal_form_qubit`); continues
  the work from LionSR/TNLean#1109. See LionSR/QICLean#143.
- **Blueprint source:** `blueprint/src/chapter/ch16_channel_representations.tex`,
  label `lem:infimum_is_attained` (Wolf §2.3 Prop 2.8). The lemma states: for a
  positive-definite Choi matrix τ ∈ M_{D²}(ℂ), the infimum of
  tr[(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†] over S₁, S₂ ∈ M_D(ℂ) with det S₁ = det S₂ = 1 is
  attained.

### Description
- `TNLean/Channel/LorentzNormalForm.lean`: proves `Wolf.infimum_is_attained` without sorry.
  The coercivity estimate tr[X τ Xᴴ] ≥ λ_min(τ)·D·‖Sᵢ‖² confines minimisers to a fixed
  Frobenius ball; `Metric.isCompact_of_isClosed_isBounded` and `IsCompact.exists_isMinOn`
  then give existence. The degenerate case D = 0 is handled separately.
- `TNLean/Algebra/HermitianHelpers.lean`: generalizes eigenvalue infrastructure from `Fin D`
  to an arbitrary finite index type, so the smallest-eigenvalue bound applies to the
  `Fin D × Fin D`-indexed Choi matrix.
- `TNLean/Algebra/MatrixAux.lean`: adds `Continuous.matrix_kronecker` (joint continuity of
  the Kronecker product).
- `blueprint/src/chapter/ch16_channel_representations.tex`: marks `lem:infimum_is_attained`
  with `\lean{Wolf.infimum_is_attained}` and `\leanok`.

### Testing
- Lean CI (`lean_action_ci.yml`) runs `lake build` on push.
- `rg -n "sorry|axiom" TNLean/Channel/LorentzNormalForm.lean || true` should show no new
  sorrys in the proved section.

---
Addresses LionSR/QICLean#143

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The new proof is a long matrix-analysis and topology argument in channel normal-form theory; mistakes could affect downstream Wolf formalization, though scope is localized and higher theorems still use `sorry` where incomplete.
> 
> **Overview**
> **Proves** `Wolf.infimum_is_attained`: for a positive-definite Choi matrix τ, the real trace of filtered conjugations `(S₂ ⊗ₖ S₁) τ (S₂ ⊗ₖ S₁)†` over unit-determinant pairs attains a global minimum. The former `sorry` is replaced by a coercivity argument (smallest eigenvalue × Kronecker Frobenius norms × det–AM–GM), restriction to a closed bounded `{det = 1}` set, and the extreme value theorem; `D = 0` is handled separately.
> 
> **Supporting changes:** `HermitianHelpers` is generalized from `Fin D` to arbitrary finite index types so `minEigenvalue` and the pos-def trace bound apply to `Fin D × Fin D` Choi matrices; `MatrixAux` adds `Continuous.matrix_kronecker` for continuity of the trace objective; `LorentzNormalForm` imports Hermitian helpers and topology lemmas and updates module docs to record that compactness is done while the AM–GM optimality step in `exists_normal_form_generic` remains `sorry`.
> 
> **Blueprint:** `lem:infimum_is_attained` is marked `\leanok` with a full proof sketch; the generic normal form theorem text still notes it is not fully proved (Step 5).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802d4979dee07f4a20065760ec322fb419c6744a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->