### PR TITLE
feat(Analysis/Entropy): bridge eigenvalue and trace-log entropy forms

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -39,6 +39,8 @@ import TNLean.Algebra.CocycleCohomology
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ProjectionGeometry
+-- Layer 0b: Trace of the Hermitian functional calculus (Mathlib-only matrix lemma)
+import TNLean.Analysis.TraceCFC
 
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection
@@ -103,7 +105,6 @@ import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull
-import TNLean.Channel.Schwarz.TraceCFC
 import TNLean.Channel.FixedPoint.Algebra
 import TNLean.Channel.FixedPoint.ChoiEffros
 import TNLean.Channel.FixedPoint.Cesaro

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -5,8 +5,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Spectrum
 import Mathlib.Analysis.SpecialFunctions.Log.NegMulLog
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Basic
+import Mathlib.Analysis.CStarAlgebra.Matrix
 import TNLean.Channel.Basic
 import TNLean.Channel.PartialTrace
+import TNLean.Channel.Schwarz.TraceCFC
 
 /-!
 # Von Neumann entropy, partial traces, and mutual information
@@ -100,6 +103,63 @@ theorem vonNeumannEntropy_congr {ρ₁ ρ₂ : Matrix n n ℂ} (h : ρ₁ = ρ�
     exact (Matrix.isHermitian_zero (n := n) (α := ℂ)).eigenvalues_eq_zero_iff.mpr rfl
   rw [hzero]
   simp [Real.negMulLog_zero]
+
+/-- The Hermitian functional calculus is multiplicative: `cfc (f · g) = cfc f · cfc g`.
+On a Hermitian matrix the calculus is realized by simultaneous diagonalization, so
+this holds for arbitrary `f, g` (no continuity hypothesis is needed because the
+spectrum is finite). -/
+private theorem isHermitian_cfc_mul {A : Matrix n n ℂ} (hA : A.IsHermitian)
+    (f g : ℝ → ℝ) : hA.cfc (fun x => f x * g x) = hA.cfc f * hA.cfc g := by
+  have hdiag : (RCLike.ofReal ∘ (fun x => f x * g x) ∘ hA.eigenvalues)
+      = (fun i => (RCLike.ofReal ∘ f ∘ hA.eigenvalues) i
+          * ((RCLike.ofReal : ℝ → ℂ) ∘ g ∘ hA.eigenvalues) i) := by
+    funext i; simp [Function.comp_apply]
+  simp only [Matrix.IsHermitian.cfc]
+  rw [← map_mul, diagonal_mul_diagonal, hdiag]
+
+/-- The Hermitian functional calculus of the identity recovers the matrix. -/
+private theorem isHermitian_cfc_id {A : Matrix n n ℂ} (hA : A.IsHermitian) :
+    hA.cfc id = A := by
+  rw [Matrix.IsHermitian.cfc]
+  conv_rhs => rw [hA.spectral_theorem]
+  rw [Function.id_comp]
+
+/-- Left multiplication by the matrix absorbs into the functional calculus:
+`A · cfc g = cfc (fun x ↦ x · g x)`. -/
+private theorem isHermitian_self_mul_cfc {A : Matrix n n ℂ} (hA : A.IsHermitian)
+    (g : ℝ → ℝ) : A * hA.cfc g = hA.cfc (fun x => x * g x) := by
+  nth_rewrite 1 [← isHermitian_cfc_id hA]
+  exact (isHermitian_cfc_mul hA id g).symm
+
+open scoped Matrix.Norms.L2Operator in
+/-- **Bridge between the eigenvalue-based and trace-`log` forms of the von
+Neumann entropy.** For a Hermitian matrix `ρ`,
+`S(ρ) = -(tr(ρ · log ρ)).re`, where `log` is the matrix logarithm `CFC.log`
+from the continuous functional calculus. This connects the spectral definition
+`vonNeumannEntropy ρ = ∑ᵢ negMulLog(λᵢ)` with the trace-`log` form used in the
+quantum relative-entropy / strong-subadditivity development.
+
+On a matrix the spectrum is finite, so the functional calculus is multiplicative
+without any continuity hypothesis: `ρ · CFC.log ρ = cfc (fun x ↦ x · log x) ρ`.
+Taking the trace of the latter yields the spectral sum `∑ᵢ λᵢ log λᵢ`, the
+negative of `∑ᵢ negMulLog λᵢ`. The zero eigenvalues are handled by the
+convention `0 · log 0 = 0 = negMulLog 0`, so the identity holds for density
+matrices in particular (positive semidefinite, trace `1`).
+
+Source: standard; blueprint `thm:entropy_eq_neg_trace_mul_log`. -/
+theorem vonNeumannEntropy_eq_neg_trace_mul_log
+    {ρ : Matrix n n ℂ} (hρ : ρ.IsHermitian) :
+    vonNeumannEntropy ρ hρ = -(Matrix.trace (ρ * CFC.log ρ)).re := by
+  -- Simultaneous diagonalization turns `ρ · log ρ` into `cfc (fun x ↦ x · log x)`.
+  have key : ρ * CFC.log ρ = hρ.cfc (fun x => x * Real.log x) := by
+    rw [show CFC.log ρ = hρ.cfc Real.log from by
+          rw [CFC.log]; exact Matrix.IsHermitian.cfc_eq hρ Real.log]
+    exact isHermitian_self_mul_cfc hρ Real.log
+  rw [vonNeumannEntropy, key]
+  have htr := hρ.trace_cfc_eq_sum_re (fun x => x * Real.log x)
+  rw [RCLike.re_eq_complex_re] at htr
+  rw [htr, ← Finset.sum_neg_distrib]
+  exact Finset.sum_congr rfl fun i _ => by simp only [Real.negMulLog]; ring
 
 /-- The von Neumann entropy depends only on the characteristic polynomial: it is
 the `negMulLog`-sum of the (real parts of the) roots of `charpoly`. -/

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -132,10 +132,10 @@ private theorem isHermitian_self_mul_cfc {A : Matrix n n ℂ} (hA : A.IsHermitia
   exact (isHermitian_cfc_mul hA id g).symm
 
 open scoped Matrix.Norms.L2Operator in
-/-- **Bridge between the eigenvalue-based and trace-`log` forms of the von
-Neumann entropy.** For a Hermitian matrix `ρ`,
+/-- **Equality of the eigenvalue-sum and trace-`log` forms of the von Neumann
+entropy.** For a Hermitian matrix `ρ`,
 `S(ρ) = -(tr(ρ · log ρ)).re`, where `log` is the matrix logarithm `CFC.log`
-from the continuous functional calculus. This connects the spectral definition
+from the continuous functional calculus. This identifies the spectral definition
 `vonNeumannEntropy ρ = ∑ᵢ negMulLog(λᵢ)` with the trace-`log` form used in the
 quantum relative-entropy / strong-subadditivity development.
 

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -9,7 +9,7 @@ import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Bas
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import TNLean.Channel.Basic
 import TNLean.Channel.PartialTrace
-import TNLean.Channel.Schwarz.TraceCFC
+import TNLean.Analysis.TraceCFC
 
 /-!
 # Von Neumann entropy, partial traces, and mutual information
@@ -145,6 +145,15 @@ Taking the trace of the latter yields the spectral sum `∑ᵢ λᵢ log λᵢ`,
 negative of `∑ᵢ negMulLog λᵢ`. The zero eigenvalues are handled by the
 convention `0 · log 0 = 0 = negMulLog 0`, so the identity holds for density
 matrices in particular (positive semidefinite, trace `1`).
+
+Both `CFC.log ρ` and `vonNeumannEntropy ρ` are built from Mathlib's `Real.log`,
+which is the *totalized* logarithm: `Real.log x = Real.log |x|` and
+`Real.log 0 = 0`. The two sides therefore use the same convention on every
+eigenvalue, so the equality is an honest identity for an arbitrary Hermitian
+matrix. It coincides with the physical von Neumann entropy `-tr(ρ log ρ)`
+precisely when `ρ` is positive semidefinite, where every eigenvalue is
+nonnegative; for a Hermitian matrix with a negative eigenvalue both sides
+evaluate the totalized log and the common value is not the physical entropy.
 
 Source: standard; blueprint `thm:entropy_eq_neg_trace_mul_log`. -/
 theorem vonNeumannEntropy_eq_neg_trace_mul_log

--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -104,33 +104,6 @@ theorem vonNeumannEntropy_congr {ρ₁ ρ₂ : Matrix n n ℂ} (h : ρ₁ = ρ�
   rw [hzero]
   simp [Real.negMulLog_zero]
 
-/-- The Hermitian functional calculus is multiplicative: `cfc (f · g) = cfc f · cfc g`.
-On a Hermitian matrix the calculus is realized by simultaneous diagonalization, so
-this holds for arbitrary `f, g` (no continuity hypothesis is needed because the
-spectrum is finite). -/
-private theorem isHermitian_cfc_mul {A : Matrix n n ℂ} (hA : A.IsHermitian)
-    (f g : ℝ → ℝ) : hA.cfc (fun x => f x * g x) = hA.cfc f * hA.cfc g := by
-  have hdiag : (RCLike.ofReal ∘ (fun x => f x * g x) ∘ hA.eigenvalues)
-      = (fun i => (RCLike.ofReal ∘ f ∘ hA.eigenvalues) i
-          * ((RCLike.ofReal : ℝ → ℂ) ∘ g ∘ hA.eigenvalues) i) := by
-    funext i; simp [Function.comp_apply]
-  simp only [Matrix.IsHermitian.cfc]
-  rw [← map_mul, diagonal_mul_diagonal, hdiag]
-
-/-- The Hermitian functional calculus of the identity recovers the matrix. -/
-private theorem isHermitian_cfc_id {A : Matrix n n ℂ} (hA : A.IsHermitian) :
-    hA.cfc id = A := by
-  rw [Matrix.IsHermitian.cfc]
-  conv_rhs => rw [hA.spectral_theorem]
-  rw [Function.id_comp]
-
-/-- Left multiplication by the matrix absorbs into the functional calculus:
-`A · cfc g = cfc (fun x ↦ x · g x)`. -/
-private theorem isHermitian_self_mul_cfc {A : Matrix n n ℂ} (hA : A.IsHermitian)
-    (g : ℝ → ℝ) : A * hA.cfc g = hA.cfc (fun x => x * g x) := by
-  nth_rewrite 1 [← isHermitian_cfc_id hA]
-  exact (isHermitian_cfc_mul hA id g).symm
-
 open scoped Matrix.Norms.L2Operator in
 /-- **Equality of the eigenvalue-sum and trace-`log` forms of the von Neumann
 entropy.** For a Hermitian matrix `ρ`,
@@ -163,7 +136,7 @@ theorem vonNeumannEntropy_eq_neg_trace_mul_log
   have key : ρ * CFC.log ρ = hρ.cfc (fun x => x * Real.log x) := by
     rw [show CFC.log ρ = hρ.cfc Real.log from by
           rw [CFC.log]; exact Matrix.IsHermitian.cfc_eq hρ Real.log]
-    exact isHermitian_self_mul_cfc hρ Real.log
+    exact hρ.self_mul_cfc Real.log
   rw [vonNeumannEntropy, key]
   have htr := hρ.trace_cfc_eq_sum_re (fun x => x * Real.log x)
   rw [RCLike.re_eq_complex_re] at htr

--- a/TNLean/Analysis/OperatorConvexity.lean
+++ b/TNLean/Analysis/OperatorConvexity.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Schwarz.DiagonalJensen
-import TNLean.Channel.Schwarz.TraceCFC
+import TNLean.Analysis.TraceCFC
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
@@ -22,7 +22,7 @@ This module proves the trace convexity and concavity of the map
 Both statements were previously axiomatized in `TNLean.Axioms.OperatorConvexity`
 (as `trace_rpow_concave_axiom` / `trace_rpow_convex_axiom`); this module
 discharges them using the matrix-analysis lemmas
-`Matrix.IsHermitian.trace_cfc_eq_sum_re` (from `TNLean/Channel/Schwarz/TraceCFC.lean`)
+`Matrix.IsHermitian.trace_cfc_eq_sum_re` (from `TNLean/Analysis/TraceCFC.lean`)
 and `Matrix.diagonal_jensen_of_convexOn`
 (from `TNLean/Channel/Schwarz/DiagonalJensen.lean`).
 

--- a/TNLean/Analysis/TraceCFC.lean
+++ b/TNLean/Analysis/TraceCFC.lean
@@ -10,7 +10,10 @@ import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
 Small auxiliary lemmas about the trace of the Hermitian functional calculus: the
 trace of `hA.cfc f` equals the sum of `f` over the eigenvalues of `A`. These are
 used in the `trace_rpow_*` convexity/concavity proofs and in the trace-`log` form
-of the von Neumann entropy. The file imports only Mathlib, so it sits in the
+of the von Neumann entropy. Alongside them sit the algebraic identities
+`cfc_mul`, `cfc_id`, and `self_mul_cfc` for the Hermitian functional calculus,
+which hold for arbitrary functions because the spectrum of a matrix is finite.
+The file imports only Mathlib, so it sits in the
 matrix-analysis layer below both the entropy and operator-convexity modules.
 
 The proof combines the unitary-diagonal form of `Matrix.IsHermitian.cfc`
@@ -23,6 +26,32 @@ namespace Matrix
 namespace IsHermitian
 
 variable {n 𝕜 : Type*} [RCLike 𝕜] [Fintype n] [DecidableEq n]
+
+/-- The Hermitian functional calculus is multiplicative: `cfc (f · g) = cfc f · cfc g`.
+On a Hermitian matrix the calculus is realized by simultaneous diagonalization, so
+this holds for arbitrary `f, g` (no continuity hypothesis is needed because the
+spectrum is finite). -/
+theorem cfc_mul {A : Matrix n n 𝕜} (hA : A.IsHermitian) (f g : ℝ → ℝ) :
+    hA.cfc (fun x => f x * g x) = hA.cfc f * hA.cfc g := by
+  have hdiag : (RCLike.ofReal ∘ (fun x => f x * g x) ∘ hA.eigenvalues)
+      = (fun i => ((RCLike.ofReal : ℝ → 𝕜) ∘ f ∘ hA.eigenvalues) i
+          * ((RCLike.ofReal : ℝ → 𝕜) ∘ g ∘ hA.eigenvalues) i) := by
+    funext i; simp [Function.comp_apply]
+  simp only [Matrix.IsHermitian.cfc]
+  rw [← map_mul, diagonal_mul_diagonal, hdiag]
+
+/-- The Hermitian functional calculus of the identity recovers the matrix. -/
+theorem cfc_id {A : Matrix n n 𝕜} (hA : A.IsHermitian) : hA.cfc id = A := by
+  rw [Matrix.IsHermitian.cfc]
+  conv_rhs => rw [hA.spectral_theorem]
+  rw [Function.id_comp]
+
+/-- Left multiplication by the matrix absorbs into the functional calculus:
+`A · cfc g = cfc (fun x ↦ x · g x)`. -/
+theorem self_mul_cfc {A : Matrix n n 𝕜} (hA : A.IsHermitian) (g : ℝ → ℝ) :
+    A * hA.cfc g = hA.cfc (fun x => x * g x) := by
+  nth_rewrite 1 [← cfc_id hA]
+  exact (cfc_mul hA id g).symm
 
 /-- The trace of `hA.cfc f` is the sum of `f` over the eigenvalues of `A`.
 

--- a/TNLean/Analysis/TraceCFC.lean
+++ b/TNLean/Analysis/TraceCFC.lean
@@ -7,8 +7,11 @@ import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
 /-!
 # Trace of the continuous functional calculus on a Hermitian matrix
 
-Small auxiliary lemmas used in the `trace_rpow_*` convexity/concavity proofs: the
-trace of `hA.cfc f` equals the sum of `f` over the eigenvalues of `A`.
+Small auxiliary lemmas about the trace of the Hermitian functional calculus: the
+trace of `hA.cfc f` equals the sum of `f` over the eigenvalues of `A`. These are
+used in the `trace_rpow_*` convexity/concavity proofs and in the trace-`log` form
+of the von Neumann entropy. The file imports only Mathlib, so it sits in the
+matrix-analysis layer below both the entropy and operator-convexity modules.
 
 The proof combines the unitary-diagonal form of `Matrix.IsHermitian.cfc`
 (see `Mathlib.Analysis.Matrix.HermitianFunctionalCalculus`) with

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -149,19 +149,28 @@ finite-dimensional quantum systems.
     \[
         S(\rho) = -\operatorname{Re}\bigl(\operatorname{tr}(\rho\,\log\rho)\bigr).
     \]
-    For a density matrix this is the standard expression
-    $S(\rho) = -\operatorname{tr}(\rho\log\rho)$.
 \end{theorem}
 
 \begin{proof}\leanok
     \uses{def:von_neumann_entropy}
-    A Hermitian matrix and its logarithm are simultaneously diagonalized, so the
-    product $\rho\,\log\rho$ has eigenvalues $\lambda_i\log\lambda_i$. Its trace
-    is therefore the spectral sum $\sum_i \lambda_i\log\lambda_i$, and its
-    negative is $\sum_i\bigl({-}\lambda_i\log\lambda_i\bigr) = S(\rho)$. Zero
+    A Hermitian matrix and its logarithm are simultaneously diagonalized by a
+    unitary $U$ with $\rho = U\operatorname{diag}(\lambda_i)U^*$, so
+    \[
+        \operatorname{tr}(\rho\,\log\rho)
+            = \operatorname{tr}\!\bigl(U\operatorname{diag}(\lambda_i\log\lambda_i)U^*\bigr)
+            = \sum_i \lambda_i\log\lambda_i.
+    \]
+    Its negative is $\sum_i\bigl({-}\lambda_i\log\lambda_i\bigr) = S(\rho)$. Zero
     eigenvalues contribute nothing under the convention $0\log 0 = 0$, so no
     full-support assumption is required.
 \end{proof}
+
+\begin{remark}
+    For a density matrix $\rho$ (positive semidefinite with unit trace) the
+    eigenvalues $\lambda_i$ are nonnegative, so $\rho\,\log\rho$ is Hermitian
+    with real trace and the real-part extraction is superfluous: the identity
+    reduces to the standard expression $S(\rho) = -\operatorname{tr}(\rho\log\rho)$.
+\end{remark}
 
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -139,6 +139,30 @@ finite-dimensional quantum systems.
     defining $S(\rho)$ equals the displayed sum over roots.
 \end{proof}
 
+\begin{theorem}[Trace-logarithm form of the entropy]
+    \label{thm:entropy_eq_neg_trace_mul_log}
+    \lean{vonNeumannEntropy_eq_neg_trace_mul_log}
+    \leanok
+    \uses{def:von_neumann_entropy}
+    Let $\rho$ be a Hermitian matrix and let $\log\rho$ be its logarithm defined
+    through the functional calculus. Then
+    \[
+        S(\rho) = -\operatorname{Re}\bigl(\operatorname{tr}(\rho\,\log\rho)\bigr).
+    \]
+    For a density matrix this is the standard expression
+    $S(\rho) = -\operatorname{tr}(\rho\log\rho)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:von_neumann_entropy}
+    A Hermitian matrix and its logarithm are simultaneously diagonalized, so the
+    product $\rho\,\log\rho$ has eigenvalues $\lambda_i\log\lambda_i$. Its trace
+    is therefore the spectral sum $\sum_i \lambda_i\log\lambda_i$, and its
+    negative is $\sum_i\bigl({-}\lambda_i\log\lambda_i\bigr) = S(\rho)$. Zero
+    eigenvalues contribute nothing under the convention $0\log 0 = 0$, so no
+    full-support assumption is required.
+\end{proof}
+
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}
     \lean{vonNeumannEntropy_submatrix_equiv}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -166,10 +166,15 @@ finite-dimensional quantum systems.
 \end{proof}
 
 \begin{remark}
-    For a density matrix $\rho$ (positive semidefinite with unit trace) the
-    eigenvalues $\lambda_i$ are nonnegative, so $\rho\,\log\rho$ is Hermitian
-    with real trace and the real-part extraction is superfluous: the identity
-    reduces to the standard expression $S(\rho) = -\operatorname{tr}(\rho\log\rho)$.
+    The logarithm is the totalized real logarithm, with
+    $\log x = \log\lvert x\rvert$ and $\log 0 = 0$; both sides of the identity
+    use it on every eigenvalue, so the equality holds for an arbitrary Hermitian
+    matrix. It coincides with the physical entropy $-\operatorname{tr}(\rho\log\rho)$
+    precisely when $\rho$ is positive semidefinite. In that case (a density
+    matrix $\rho$, positive semidefinite with unit trace) the eigenvalues
+    $\lambda_i$ are nonnegative, $\rho\,\log\rho$ is Hermitian with real trace,
+    and the real-part extraction is superfluous: the identity reduces to the
+    standard expression $S(\rho) = -\operatorname{tr}(\rho\log\rho)$.
 \end{remark}
 
 \begin{theorem}[Entropy is invariant under reindexing]


### PR DESCRIPTION
### Motivation

- Continues formalization of von Neumann entropy toward the honest core needed by downstream proofs (see #784, #239).
- The existing `vonNeumannEntropy` definition is eigenvalue-based; a bridge lemma `S(ρ) = -(tr(ρ · log ρ)).re` is required to define quantum relative entropy and make entropy inequalities provable without the axiomatised `strong_subadditivity` bootstrap.
- Provides the first step toward removing the standalone `strong_subadditivity` axiom (refs #784, #239, #613).

### Description

- Adds `vonNeumannEntropy_eq_neg_trace_mul_log` in `TNLean/Analysis/Entropy.lean`, proving `S(ρ) = -(tr(ρ · log ρ)).re` for any Hermitian matrix `ρ`, where `log` is the matrix logarithm `CFC.log` from the continuous functional calculus.
- The proof uses the Hermitian functional calculus `Matrix.IsHermitian.cfc`; three private auxiliary lemmas establish multiplicativity of `cfc`, `cfc id = A`, and `A · cfc g = cfc (fun x ↦ x · g x)`. The trace is evaluated via the existing `Matrix.IsHermitian.trace_cfc_eq_sum_re`.
- Zero eigenvalues are handled by the convention `0 · log 0 = 0 = negMulLog 0`, so the identity holds for every Hermitian matrix without a full-support assumption.
- Adds the matching blueprint entry `thm:entropy_eq_neg_trace_mul_log` in `blueprint/src/chapter/ch19_entropy.tex`.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate `lake build`.
- Blueprint label `thm:entropy_eq_neg_trace_mul_log` should be checked with `leanblueprint checkdecls` after build succeeds.

---
Addresses #784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib matrix analysis and entropy infrastructure; no auth, runtime, or behavioral API changes beyond import graph and new proved lemmas.
> 
> **Overview**
> **Hermitian CFC lemmas** move from `TNLean/Channel/Schwarz/TraceCFC.lean` into a new Mathlib-only module `TNLean/Analysis/TraceCFC.lean`, with added `cfc_mul`, `cfc_id`, and `self_mul_cfc`. Root imports and `OperatorConvexity` follow the new path; the Schwarz file is removed.
> 
> **`vonNeumannEntropy_eq_neg_trace_mul_log`** in `TNLean/Analysis/Entropy.lean` proves the spectral definition matches `-(tr(ρ · CFC.log ρ)).re` for any Hermitian `ρ`, using simultaneous diagonalization and `trace_cfc_eq_sum_re`. Blueprint **`thm:entropy_eq_neg_trace_mul_log`** is added in `ch19_entropy.tex`.
> 
> This is groundwork for quantum relative entropy and eventual SSA without relying only on the axiomatized bootstrap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d600160a1a11355dfee1efa80d3426f960f8152a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->