### PR TITLE
refactor(Semigroup): share MatrixCLM norm-one instance

### DIFF
--- a/TNLean/Algebra/MatrixOperatorSpace.lean
+++ b/TNLean/Algebra/MatrixOperatorSpace.lean
@@ -94,6 +94,18 @@ end MatrixInstances
     NormedAlgebra ℂ (TNLean.MatrixCLM n) :=
   ContinuousLinearMap.toNormedAlgebra
 
+instance instNormOneClassMatrixCLM
+    (n : Type*) [Fintype n] [DecidableEq n] [Nonempty n] :
+    NormOneClass (TNLean.MatrixCLM n) := by
+  constructor
+  change ‖(ContinuousLinearMap.id ℂ (Matrix n n ℂ))‖ = 1
+  exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := Matrix n n ℂ)
+
+instance instNormOneClassMatrixCLMFin
+    (D : ℕ) [NeZero D] : NormOneClass (TNLean.MatrixCLM (Fin D)) := by
+  haveI : Nonempty (Fin D) := Fin.pos_iff_nonempty.mp (NeZero.pos D)
+  infer_instance
+
 instance instENormedAddCommMonoidMatrixCLM
     (n : Type*) [Fintype n] [DecidableEq n] :
     ENormedAddCommMonoid (TNLean.MatrixCLM n) :=

--- a/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
+++ b/TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean
@@ -41,12 +41,6 @@ noncomputable section
 
 variable {D : ℕ}
 
-local instance instEulerNormOneClassMatrixCLM [NeZero D] :
-    NormOneClass (MatrixCLM (Fin D)) := by
-  constructor
-  change ‖(ContinuousLinearMap.id ℂ (Matrix (Fin D) (Fin D) ℂ))‖ = 1
-  exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := Matrix (Fin D) (Fin D) ℂ)
-
 section LindbladForms
 
 private abbrev MatChoi (D : ℕ) :=
@@ -232,28 +226,24 @@ theorem cp_semigroup_implies_ccp_generator
 
 /-! ### Euler approximation auxiliary lemmas for CCP → CP -/
 
-private abbrev sgMat (D : ℕ) := Matrix (Fin D) (Fin D) ℂ
-private abbrev sgLM (D : ℕ) := sgMat D →ₗ[ℂ] sgMat D
-private abbrev sgCLM (D : ℕ) := sgMat D →L[ℂ] sgMat D
-
-local instance (priority := 1001) instNormOneClassSgCLM [NeZero D] :
-    NormOneClass (sgCLM D) := by
-  constructor
-  change ‖(ContinuousLinearMap.id ℂ (sgMat D))‖ = 1
-  exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := sgMat D)
-
-private def quadMap (G : GeneratorDecomp D) : sgLM D :=
+private def quadMap (G : GeneratorDecomp D) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
   Kraus.mapLM (fun _ : Fin 1 => G.κ)
 
-private def eulerStep (G : GeneratorDecomp D) (s : ℝ) : sgLM D :=
-  Kraus.mapLM (fun _ : Fin 1 => (1 : sgMat D) - (s : ℂ) • G.κ) + (s : ℂ) • G.φ
+private def eulerStep (G : GeneratorDecomp D) (s : ℝ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+  Kraus.mapLM (fun _ : Fin 1 => (1 : Matrix (Fin D) (Fin D) ℂ) - (s : ℂ) • G.κ) +
+    (s : ℂ) • G.φ
 
-private theorem eulerStep_apply (G : GeneratorDecomp D) (s : ℝ) (ρ : sgMat D) :
+private theorem eulerStep_apply (G : GeneratorDecomp D) (s : ℝ)
+    (ρ : Matrix (Fin D) (Fin D) ℂ) :
     eulerStep G s ρ =
       ρ + s • (G.φ ρ + -(G.κ * ρ) + -(ρ * G.κᴴ)) + (s * s) • (G.κ * ρ * G.κᴴ) := by
-  change Kraus.mapLM (fun _ : Fin 1 => (1 : sgMat D) - (s : ℂ) • G.κ) ρ + (s : ℂ) • G.φ ρ =
-    ρ + s • (G.φ ρ + -(G.κ * ρ) + -(ρ * G.κᴴ)) + (s * s) • (G.κ * ρ * G.κᴴ)
-  simp only [Complex.coe_smul, Kraus.mapLM_apply, Kraus.map_apply, Finset.univ_unique,
+  let K : Matrix (Fin D) (Fin D) ℂ := 1 - (s : ℂ) • G.κ
+  change Kraus.mapLM (fun _ : Fin 1 => K) ρ + (s : ℂ) • G.φ ρ =
+    ρ + s • (G.φ ρ + -(G.κ * ρ) + -(ρ * G.κᴴ)) +
+      (s * s) • (G.κ * ρ * G.κᴴ)
+  simp only [K, Complex.coe_smul, Kraus.mapLM_apply, Kraus.map_apply, Finset.univ_unique,
     Fin.default_eq_zero, Fin.isValue, Finset.sum_const, Finset.card_singleton, one_smul,
     sub_eq_add_neg]
   have hconj : (1 + -(s • G.κ))ᴴ = 1 + -(s • G.κᴴ) := by
@@ -285,7 +275,8 @@ private theorem eulerStep_apply (G : GeneratorDecomp D) (s : ℝ) (ρ : sgMat D)
 
 private theorem eulerStep_cp (G : GeneratorDecomp D) {s : ℝ} (hs : 0 ≤ s) :
     IsCPMap (eulerStep G s) := by
-  refine (isCPMap_of_krausMapLM (fun _ : Fin 1 => (1 : sgMat D) - (s : ℂ) • G.κ)).add ?_
+  refine (isCPMap_of_krausMapLM
+    (fun _ : Fin 1 => (1 : Matrix (Fin D) (Fin D) ℂ) - (s : ℂ) • G.κ)).add ?_
   exact G.φ_cp.smul_nonneg hs
 
 private theorem eulerStep_toCLM_eq (G : GeneratorDecomp D) (s : ℝ) :
@@ -303,10 +294,11 @@ private theorem eulerStep_toCLM_eq (G : GeneratorDecomp D) (s : ℝ) :
     Complex.ofReal_mul, Complex.coe_smul, smul_eq_mul, sub_eq_add_neg, pow_two]
 
 private theorem norm_expSemigroupCLM_sub_one_add_smul_le [NeZero D]
-    (A : sgCLM D) {s : ℝ} (hs : 0 ≤ s) :
+    (A : MatrixCLM (Fin D)) {s : ℝ} (hs : 0 ≤ s) :
     ‖expSemigroupCLM A s - (1 + (s : ℂ) • A)‖ ≤ s ^ 2 * ‖A‖ ^ 2 * Real.exp (s * ‖A‖) := by
-  have hrem := @norm_exp_sub_one_sub_self_le (sgCLM D)
-    inferInstance inferInstance inferInstance (instNormOneClassSgCLM (D := D))
+  have hrem := @norm_exp_sub_one_sub_self_le (MatrixCLM (Fin D))
+    inferInstance inferInstance inferInstance
+    (TNOperatorSpace.instNormOneClassMatrixCLMFin D)
     (((s : ℂ) • A))
   have hnorm :
       expSemigroupCLM A s - (1 + (s : ℂ) • A) =
@@ -369,10 +361,6 @@ private theorem norm_eulerStep_toCLM_le [NeZero D]
       Real.exp
         (s * (‖(endEquiv (D := D)) G.toLinearMap‖ +
           T * ‖(endEquiv (D := D)) (quadMap G)‖)) := by
-  haveI : NormOneClass (sgCLM D) := by
-    constructor
-    change ‖(ContinuousLinearMap.id ℂ (sgMat D))‖ = 1
-    exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := sgMat D)
   rw [eulerStep_toCLM_eq]
   have hbasic : ‖1 + (s : ℂ) • (endEquiv (D := D)) G.toLinearMap + ((s ^ 2 : ℝ) : ℂ) •
       (endEquiv (D := D)) (quadMap G)‖ ≤
@@ -383,7 +371,7 @@ private theorem norm_eulerStep_toCLM_le [NeZero D]
           (endEquiv (D := D)) (quadMap G)‖ ≤
           ‖1 + (s : ℂ) • (endEquiv (D := D)) G.toLinearMap‖ +
             ‖((s ^ 2 : ℝ) : ℂ) • (endEquiv (D := D)) (quadMap G)‖ := norm_add_le _ _
-      _ ≤ (‖(1 : sgCLM D)‖ + ‖(s : ℂ) • (endEquiv (D := D)) G.toLinearMap‖) +
+      _ ≤ (‖(1 : MatrixCLM (Fin D))‖ + ‖(s : ℂ) • (endEquiv (D := D)) G.toLinearMap‖) +
             ‖((s ^ 2 : ℝ) : ℂ) • (endEquiv (D := D)) (quadMap G)‖ := by
             gcongr
             exact norm_add_le _ _
@@ -425,13 +413,14 @@ private theorem generatorDecomp_cp_semigroup (G : GeneratorDecomp D) :
   · subst hD
     exact isCPMap_finZero _
   · haveI : NeZero D := ⟨hD⟩
-    let approx : ℕ → sgLM D := fun n => (eulerStep G (t / (n + 1))) ^ (n + 1)
+    let approx : ℕ → Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
+      fun n => (eulerStep G (t / (n + 1))) ^ (n + 1)
     have happrox_cp : ∀ n : ℕ, IsCPMap (approx n) := by
       intro n
       have hs : 0 ≤ t / (n + 1) := by positivity
       exact (eulerStep_cp G hs).pow (n + 1)
-    let Lc : sgCLM D := (endEquiv (D := D)) G.toLinearMap
-    let Qc : sgCLM D := (endEquiv (D := D)) (quadMap G)
+    let Lc : MatrixCLM (Fin D) := (endEquiv (D := D)) G.toLinearMap
+    let Qc : MatrixCLM (Fin D) := (endEquiv (D := D)) (quadMap G)
     let C0 : ℝ := ‖Lc‖ + t * ‖Qc‖
     let C1 : ℝ := ‖Lc‖ ^ 2 * Real.exp (t * ‖Lc‖) + ‖Qc‖
     have hbound : ∀ n : ℕ,
@@ -440,8 +429,8 @@ private theorem generatorDecomp_cp_semigroup (G : GeneratorDecomp D) :
           t ^ 2 * Real.exp (t * C0) * C1 / (n + 1) := by
       intro n
       let s : ℝ := t / (n + 1)
-      let F : sgCLM D := (endEquiv (D := D)) (eulerStep G s)
-      let S : sgCLM D := expSemigroupCLM Lc s
+      let F : MatrixCLM (Fin D) := (endEquiv (D := D)) (eulerStep G s)
+      let S : MatrixCLM (Fin D) := expSemigroupCLM Lc s
       have hs_nonneg : 0 ≤ s := by
         dsimp [s]
         positivity

--- a/TNLean/Channel/Semigroup/ProductFormula.lean
+++ b/TNLean/Channel/Semigroup/ProductFormula.lean
@@ -38,12 +38,6 @@ section TrotterEstimates
 
 variable {D : ℕ}
 
-local instance instNormOneClassMatrixCLM [NeZero D] :
-    NormOneClass (MatrixCLM (Fin D)) := by
-  constructor
-  change ‖(ContinuousLinearMap.id ℂ (Matrix (Fin D) (Fin D) ℂ))‖ = 1
-  exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := Matrix (Fin D) (Fin D) ℂ)
-
 /-- The norm of an operator exponential is bounded by the scalar exponential of the norm. -/
 theorem norm_exp_le_real_exp_norm {A : Type*}
     [NormedRing A] [NormedAlgebra ℂ A] [CompleteSpace A] [NormOneClass A]
@@ -77,9 +71,9 @@ theorem norm_exp_le_real_exp_norm {A : Type*}
 theorem norm_expSemigroupCLM_le [NeZero D]
     (A : MatrixCLM (Fin D)) (t : ℝ) (ht : 0 ≤ t) :
     ‖expSemigroupCLM A t‖ ≤ Real.exp (t * ‖A‖) := by
-  haveI := instNormOneClassMatrixCLM (D := D)
   have h := @norm_exp_le_real_exp_norm (MatrixCLM (Fin D))
-    inferInstance inferInstance inferInstance (instNormOneClassMatrixCLM (D := D))
+    inferInstance inferInstance inferInstance
+    (TNOperatorSpace.instNormOneClassMatrixCLMFin D)
     (((t : ℂ) • A))
   have habs : |t| = t := abs_of_nonneg ht
   change ‖NormedSpace.exp (((t : ℂ) • A))‖ ≤ Real.exp (t * ‖A‖)
@@ -143,9 +137,8 @@ theorem norm_pow_sub_pow_le_of_norm_le [NeZero D]
               gcongr <;> exact norm_mul_le _ _
         _ ≤ M ^ m * ‖A - B‖ + ((m : ℝ) * M ^ m * ‖A - B‖) * M := by
               gcongr
-              · haveI := instNormOneClassMatrixCLM (D := D)
-                exact (@norm_pow_le (MatrixCLM (Fin D)) inferInstance
-                  (instNormOneClassMatrixCLM (D := D)) A m).trans <|
+              · exact (@norm_pow_le (MatrixCLM (Fin D)) inferInstance
+                    (TNOperatorSpace.instNormOneClassMatrixCLMFin D) A m).trans <|
                   pow_le_pow_left₀ (show 0 ≤ ‖A‖ from norm_nonneg _) hA _
         _ = M ^ m * ‖A - B‖ + (m : ℝ) * M ^ (m + 1) * ‖A - B‖ := by
               ring_nf

--- a/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
+++ b/TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean
@@ -31,12 +31,6 @@ variable {D : ℕ}
 
 local notation "Mat" => Matrix (Fin D) (Fin D) ℂ
 
-local instance instSubsequenceNormOneClassMatrixCLM [NeZero D] :
-    NormOneClass (Mat →L[ℂ] Mat) := by
-  constructor
-  change ‖(ContinuousLinearMap.id ℂ Mat)‖ = 1
-  exact ContinuousLinearMap.norm_id (𝕜 := ℂ) (E := Mat)
-
 /-! ## (4) → (2): Block-upper-triangular → rank-deficient kernel element -/
 
 /-- `P * (P/tr(P)) * P = P/tr(P)` (the normalized projection is in `PMP`). -/
@@ -169,7 +163,8 @@ private theorem norm_expSemigroupCLM_taylor_bound [NeZero D]
       ‖NormedSpace.exp ((s : ℂ) • E) - 1 - (s : ℂ) • E‖ ≤
         ‖((s : ℂ) • E)‖ ^ 2 * Real.exp ‖((s : ℂ) • E)‖ :=
     @norm_exp_sub_one_sub_self_le (Mat →L[ℂ] Mat)
-      inferInstance inferInstance inferInstance (instSubsequenceNormOneClassMatrixCLM (D := D))
+      inferInstance inferInstance inferInstance
+      (TNOperatorSpace.instNormOneClassMatrixCLMFin D)
       ((s : ℂ) • E)
   simp only [expSemigroupCLM] at h ⊢
   have hnorm_smul : ‖(s : ℂ) • E‖ = s * ‖E‖ := by


### PR DESCRIPTION
### Motivation
- Duplicate local `NormOneClass` instances for `MatrixCLM` existed independently in
  `ProductFormula.lean`, `EulerStep.lean`, and `SubsequenceAnalysis.lean`; centralizing the
  instance in `MatrixOperatorSpace.lean` removes the duplication.
- Private pass-through aliases `sgMat`, `sgLM`, `sgCLM` in `EulerStep.lean` obscured the
  canonical types and were not used outside that file; removing them makes the types explicit
  throughout the Euler approximation and CP semigroup limit proof.

### Description
- `TNLean/Algebra/MatrixOperatorSpace.lean`: added a general `NormOneClass` instance for
  `MatrixCLM n` under `[Nonempty n]`, and a specialized instance
  `instNormOneClassMatrixCLMFin` for `MatrixCLM (Fin D)` under `[NeZero D]`.
- `TNLean/Channel/Semigroup/ProductFormula.lean`: removed duplicate local `NormOneClass`
  proof; the shared instance from `MatrixOperatorSpace` is used instead.
- `TNLean/Channel/Semigroup/LindbladForm/EulerStep.lean`: removed duplicate local
  `NormOneClass` block and the redundant inline `NormOneClass` proof in
  `norm_eulerStep_toCLM_le`; replaced private aliases `sgMat`, `sgLM`, `sgCLM` with
  explicit `Matrix (Fin D) (Fin D) ℂ` and `MatrixCLM (Fin D)` types.
- `TNLean/Channel/Semigroup/ReducibleQDS/SubsequenceAnalysis.lean`: removed duplicate local
  `NormOneClass` proof; the shared instance is used instead.
- No theorem statements are changed.

### Testing
- `lake build` — full build passed with only pre-existing warnings before rebasing onto
  `origin/main`.
- `lake build TNLean.Algebra.MatrixOperatorSpace TNLean.Channel.Semigroup.ProductFormula TNLean.Channel.Semigroup.LindbladForm.EulerStep TNLean.Channel.Semigroup.ReducibleQDS.SubsequenceAnalysis`
  — passed after rebase.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `git diff --check`

---

> [!NOTE]
> **Low Risk**
> Proof-only refactor with unchanged theorem statements; risk is limited to type-class resolution and definitional alignment between `Mat →L[ℂ] Mat` and `MatrixCLM (Fin D)`.
>
> **Overview**
> Centralizes **`NormOneClass` for `MatrixCLM`** in `MatrixOperatorSpace`: a general instance under `[Nonempty n]`, plus **`instNormOneClassMatrixCLMFin`** for `Fin D` when `[NeZero D]`.
>
> **ProductFormula**, **EulerStep**, and **ReducibleQDS/SubsequenceAnalysis** drop their duplicate local `NormOneClass` proofs and instead pass **`TNOperatorSpace.instNormOneClassMatrixCLMFin D`** into exponential and `norm_pow_le` arguments.
>
> In **EulerStep**, the private `sgMat` / `sgLM` / `sgCLM` aliases are removed in favor of explicit `Matrix (Fin D) (Fin D) ℂ` and **`MatrixCLM (Fin D)`** types, including the Euler approximation and CP semigroup limit proof; a redundant inline `NormOneClass` block in `norm_eulerStep_toCLM_le` is deleted.
>
> No theorem statements change—this is instance and naming cleanup only.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29335e4092921ef82dec1930e5acc24ca7e2a5e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>