### PR TITLE
doc(Channel): refresh Lorentz normal-form status

### DIFF
--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -27,10 +27,12 @@ This file indexes the formalization of Chapter 2 of Wolf's
 representations of quantum channels.
 
 The Lorentz-normal-form statements are recorded in
-`TNLean.Channel.LorentzNormalForm`, but that file contains the compactness and
-classification proof obligations for Wolf Proposition 2.9. The index mentions
-those statements by name without importing the unfinished file into the
-default root.
+`TNLean.Channel.LorentzNormalForm`, but the generic normal-form and qubit
+classification proofs are not yet complete.  The compactness/minimisation
+lemma is proved there; the remaining proof obligations are the optimality
+step at the minimiser and the `SL(2, ℂ)` Lorentz-orbit classification.  The
+index mentions those statements by name without importing the unfinished file
+into the default root.
 
 ## Coverage summary
 
@@ -198,15 +200,15 @@ default root.
 * `IsLorentzNonDiagonal` — non-diagonal Lorentz normal form (case 2) ✓
 * `IsLorentzSingular` — singular Lorentz normal form (case 3) ✓
 * `Wolf.infimum_is_attained` — **key compactness lemma**: trace minimisation
-  over SL(d, ℂ) filterings attains its infimum ⚠ (stated with `sorry`;
-  requires compactness of bounded SL(n, ℂ) sets)
+  over SL(d, ℂ) filterings attains its infimum ✓
 * `Wolf.exists_normal_form_generic` — **Wolf Proposition 2.9 (generic normal form)**:
   every CP map with full Kraus rank admits SL-filterings making it
-  doubly-stochastic ⚠ (depends on `infimum_is_attained`)
+  doubly-stochastic ⚠ (compactness is proved; the remaining step is the
+  AGM/first-order optimality argument at the minimiser)
 * `Wolf.exists_lorentz_normal_form_qubit` — **Wolf Proposition 2.9/2.11 (Lorentz
   normal form for qubit channels)**: conclusion is a three-way disjunction
   `IsLorentzDiagonal ∨ IsLorentzNonDiagonal ∨ IsLorentzSingular` ⚠
-  (depends on `infimum_is_attained` and Lorentz group classification)
+  (depends on the generic normal form and Lorentz group classification)
 
 ### Formalization
 
@@ -243,11 +245,12 @@ default root.
 |--------|-------|
 | Section 2.3 Lorentz normal form (full proof) | Statement formalised
   (`exists_lorentz_normal_form_qubit`);
-  proof blocked on compactness of bounded SL(n, ℂ) sets (`infimum_is_attained`) —
-  see `LorentzNormalForm.lean` for details |
+  compactness/minimisation is proved; proof still needs the generic optimality
+  step and the `SL(2, ℂ)` Lorentz-orbit classification |
 | Section 2.3 Generic normal form (full proof) | Statement formalised
   (`exists_normal_form_generic`);
-  proof blocked on same compactness lemma |
+  compactness/minimisation is proved; proof still needs the AGM/first-order
+  optimality argument showing the minimiser is doubly-stochastic |
 | Section 2.3 Sorted singular values | Current SVD is unsorted; later uses want sorted values |
 
 ## References

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1506,10 +1506,10 @@ Section~\ref{sec:lorentz_normal_form}.
 This section states the existence theorems from
 \cite[Section~2.3]{Wolf2012Quantum}.
 % The Wolf.* declarations referenced in this section live in
-% TNLean/Channel/LorentzNormalForm.lean, which is not in the root import
-% graph because its core minimisation lemma is still on `sorry`. Declaration
-% tags are omitted here so that checkdecls passes; the Lean names are listed in
-% the per-entry comments below.
+% TNLean/Channel/LorentzNormalForm.lean.  Only the compactness/minimisation
+% lemma is proved at present; declaration tags for the remaining existence
+% theorems are omitted until their proofs are complete.  The Lean names are
+% listed in the per-entry comments below.
 
 % Lean: Wolf.SLFiltering
 \begin{definition}[SL-filtering operation]\label{def:sl_filtering}
@@ -1637,7 +1637,9 @@ This section states the existence theorems from
     is positive-definite (equivalently, $T$ has full Kraus rank). Then there
     exist SL-filterings $\Phi_{1}, \Phi_{2}$ such that
     $\Phi_{2} \circ T \circ \Phi_{1}$ is doubly-stochastic.
-    \textbf{Not yet proved}---proof blocked on Lemma~\ref{lem:infimum_is_attained}.
+    \textbf{Not yet proved}---the compactness/minimisation lemma is proved;
+    the remaining step is the AGM or first-order optimality argument showing
+    that the minimiser is doubly-stochastic.
 \end{theorem}
 
 % Lean: Wolf.IsLorentzDiagonal
@@ -1695,9 +1697,8 @@ This section states the existence theorems from
     there exist $\SL(2, \C)$-filterings $\Phi_{1}, \Phi_{2}$ such that
     the filtered channel $T' = \Phi_{2} \circ T \circ \Phi_{1}$ is in one of
     the three Lorentz normal forms: diagonal, non-diagonal, or singular.
-    \textbf{Not yet proved}---proof blocked on
-    Lemma~\ref{lem:infimum_is_attained} and the Lorentz group classification
-    of $\SL(2, \C)$ orbits.
+    \textbf{Not yet proved}---proof still needs the generic normal form and
+    the Lorentz group classification of $\SL(2, \C)$ orbits.
 \end{theorem}
 
 %% The following sections will not be needed for the fundamental theorem of the matrix product states.


### PR DESCRIPTION
### Motivation
- PR LionSR/TNLean#3363 proved `Wolf.infimum_is_attained`, the compactness/minimisation lemma for the Lorentz normal form of quantum channels. The Wolf Chapter 2 index and blueprint commentary must be updated to reflect this result.
- The remaining open steps in the normal-form existence arguments are now stated precisely: the generic normal form still requires the AGM/first-order optimality argument showing the minimiser is doubly-stochastic, and the qubit Lorentz normal form still requires the SL(2,ℂ) orbit classification; see LionSR/QICLean#12.

### Description
- `TNLean/Channel/WolfChapter2Index.lean`: removes the sorry/blocker annotation for the compactness lemma; states the remaining gaps for `exists_normal_form_generic` (AGM/first-order optimality at the minimiser) and `exists_lorentz_normal_form_qubit` (SL(2,ℂ) Lorentz-orbit classification).
- `blueprint/src/chapter/ch16_channel_representations.tex`: updates commentary to reflect that only the compactness lemma is proved in `LorentzNormalForm.lean`; `\lean{}` tags for the existence theorems remain omitted until those proofs land.

### Testing
- `lake exe cache get && lake build TNLean.Channel.WolfChapter2Index`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `git diff --check`

---
Addresses LionSR/QICLean#12

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose changes with no Lean proof or runtime behavior changes.
>
> **Overview**
> Updates **Wolf Chapter 2** documentation (`WolfChapter2Index.lean` and `ch16_channel_representations.tex`) to match the proved **`Wolf.infimum_is_attained`** compactness/minimisation lemma (no longer marked ⚠/`sorry` or described as blocking the generic normal form).
>
> **Remaining work** is spelled out explicitly: **`exists_normal_form_generic`** still needs the AGM/first-order optimality step at the minimiser to show doubly-stochastic form; **`exists_lorentz_normal_form_qubit`** still needs that generic step plus **`SL(2, ℂ)`** Lorentz-orbit classification. Blueprint comments note that only the compactness lemma is proved in `LorentzNormalForm.lean`; existence theorem `\lean` tags stay omitted until those proofs land.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3bd81c8bdc870ea4708f0be0734c1f12348e2db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>