### PR TITLE
doc(Channel): clarify Lorentz normal-form dependency

### DIFF
--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -29,10 +29,10 @@ representations of quantum channels.
 The Lorentz-normal-form statements are recorded in
 `TNLean.Channel.LorentzNormalForm`, but the generic normal-form and qubit
 classification proofs are not yet complete.  The compactness/minimisation
-lemma is proved there; the remaining proof obligations are the optimality
-step at the minimiser and the `SL(2, ℂ)` Lorentz-orbit classification.  The
-index mentions those statements by name without importing the unfinished file
-into the default root.
+result is proved there; the remaining proof obligations are the optimality step
+at the minimiser and the SL(2, ℂ) Lorentz-orbit classification.  The index
+mentions those statements by name without importing the unfinished file into the
+default root.
 
 ## Coverage summary
 
@@ -246,7 +246,7 @@ into the default root.
 | Section 2.3 Lorentz normal form (full proof) | Statement formalised
   (`exists_lorentz_normal_form_qubit`);
   compactness/minimisation is proved; proof still needs the generic optimality
-  step and the `SL(2, ℂ)` Lorentz-orbit classification |
+  step and the SL(2, ℂ) Lorentz-orbit classification |
 | Section 2.3 Generic normal form (full proof) | Statement formalised
   (`exists_normal_form_generic`);
   compactness/minimisation is proved; proof still needs the AGM/first-order

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -1691,8 +1691,8 @@ This section states the existence theorems from
 
 % Lean: Wolf.exists_lorentz_normal_form_qubit
 \begin{theorem}[Lorentz normal form for qubit channels]\label{thm:lorentz_normal_form_qubit}
-    \uses{def:sl_filtering, lem:infimum_is_attained, def:lorentz_diagonal,
-        def:lorentz_non_diagonal, def:lorentz_singular}
+    \uses{def:sl_filtering, thm:exists_normal_form_generic,
+        def:lorentz_diagonal, def:lorentz_non_diagonal, def:lorentz_singular}
     For every qubit channel $T : \MN{2} \to \MN{2}$,
     there exist $\SL(2, \C)$-filterings $\Phi_{1}, \Phi_{2}$ such that
     the filtered channel $T' = \Phi_{2} \circ T \circ \Phi_{1}$ is in one of


### PR DESCRIPTION
### Motivation

- Follow-up to LionSR/TNLean#3378, continuing the alignment of Wolf Chapter 2 index prose with the project's mathematical-language conventions (see LionSR/QICLean#12).
- `TNLean/Channel/WolfChapter2Index.lean` previously described an outstanding formalization target using a Lean identifier name in reader-facing text; this replaces it with SL(2, ℂ) Lorentz-orbit classification stated in mathematical language.
- The qubit Lorentz normal-form blueprint entry (`ch16_channel_representations.tex`) listed an incorrect proof dependency: `lem:infimum_is_attained` (compactness/minimisation only) rather than the generic normal-form theorem `thm:exists_normal_form_generic`.

### Description

- `TNLean/Channel/WolfChapter2Index.lean`: tightens reader-facing prose so the compactness/minimisation result is described as a proved result rather than a "lemma" mid-sentence, and the remaining outstanding work is identified as the optimality step at the minimiser plus SL(2, ℂ) Lorentz-orbit classification, without Lean identifier names.
- `blueprint/src/chapter/ch16_channel_representations.tex`: updates the `\uses` list for the qubit Lorentz normal-form theorem to cite `thm:exists_normal_form_generic` and the three Lorentz-form definitions instead of `lem:infimum_is_attained`, so the documented proof dependency matches "generic normal form + orbit classification" rather than stopping at compactness/minimisation.
- Prose and blueprint `\uses` metadata only; no Lean proofs or runtime behaviour changed.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `git diff --check`
- `lake build TNLean.Channel.WolfChapter2Index`

---
Addresses LionSR/QICLean#12

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Prose and blueprint `\uses` metadata only; no Lean proofs or runtime behavior change.
>
> **Overview**
> Documentation-only alignment for Wolf Chapter 2 Lorentz normal-form status.
>
> **`WolfChapter2Index.lean`** tightens reader-facing prose: the compactness/minimisation piece is described as a proved *result* (not a "lemma" in that sentence), and the outstanding work is named as the optimality step at the minimiser plus **SL(2, ℂ) Lorentz-orbit classification** in mathematical language rather than as a Lean symbol. The "not yet formalized" table uses the same **SL(2, ℂ)** wording.
>
> **Blueprint** (`ch16_channel_representations.tex`): the qubit Lorentz normal-form theorem's `\uses` list now cites **`thm:exists_normal_form_generic`** and the three Lorentz-form definitions, instead of **`lem:infimum_is_attained`**, so the documented proof dependency matches "generic normal form + orbit classification" rather than stopping at compactness/minimisation.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b22b9e03af410a779a1da801d4d2d4749b2d192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->