### PR TITLE
feat(Analysis/RpowConvexity): operator convexity of a ↦ a^p on [1,2]

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -88,6 +88,8 @@ import TNLean.Entropy.MutualInformation
 import TNLean.Axioms.OperatorConvexity
 -- Layer 2b: Trace convexity/concavity of matrix real powers (proved)
 import TNLean.Analysis.OperatorConvexity
+-- Layer 2b: Operator (Loewner) convexity of `a ↦ a^p` for `p ∈ [1,2]` (proved)
+import TNLean.Analysis.RpowConvexity
 -- Layer 2b: Quantum channels (general theory)
 import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties

--- a/TNLean/Analysis/RpowConvexity.lean
+++ b/TNLean/Analysis/RpowConvexity.lean
@@ -117,9 +117,11 @@ lemma convexOn_cfc_rpowIntegrand₁₂ {p t : ℝ} (ht : 0 < t) :
     have hcont_inv : ContinuousOn (fun z : ℝ => t ^ p * (t + z)⁻¹ - t ^ (p - 1))
         (spectrum ℝ x) := (continuousOn_const.mul hg).sub continuousOn_const
     rw [cfc_add (a := x) (f := fun z : ℝ => t ^ (p - 2) * z)
-        (g := fun z : ℝ => t ^ p * (t + z)⁻¹ - t ^ (p - 1)) (hf := hcont_lin) (hg := hcont_inv)]
+        (g := fun z : ℝ => t ^ p * (t + z)⁻¹ - t ^ (p - 1))
+        (hf := hcont_lin) (hg := hcont_inv)]
     rw [cfc_const_mul (t ^ (p - 2)) (fun z : ℝ => z) x, cfc_id' (R := ℝ) (a := x)]
-    rw [cfc_sub (a := x) (f := fun z : ℝ => t ^ p * (t + z)⁻¹) (g := fun z : ℝ => t ^ (p - 1))]
+    rw [cfc_sub (a := x) (f := fun z : ℝ => t ^ p * (t + z)⁻¹)
+        (g := fun z : ℝ => t ^ (p - 1))]
     rw [cfc_const_mul (t ^ p) (fun z : ℝ => (t + z)⁻¹) x]
     rw [cfc_inv (f := fun z : ℝ => t + z) (a := x) hspectrum]
     rw [cfc_const_add t (fun z : ℝ => z) x, cfc_id' (R := ℝ) (a := x)]

--- a/TNLean/Analysis/RpowConvexity.lean
+++ b/TNLean/Analysis/RpowConvexity.lean
@@ -92,7 +92,6 @@ lemma convexOn_cfc_rpowIntegrand₁₂ {p t : ℝ} (ht : 0 < t) :
         + (t ^ p • Ring.inverse (algebraMap ℝ A t + x) - algebraMap ℝ A (t ^ (p - 1)))) := by
     intro x hx
     have hxnn : (0 : A) ≤ x := hx
-    have hsa : IsSelfAdjoint x := hxnn.isSelfAdjoint
     have hscalar : rpowIntegrand₁₂ p t
         = fun z => t ^ (p - 2) * z + (t ^ p * (t + z)⁻¹ - t ^ (p - 1)) := by
       funext z

--- a/TNLean/Analysis/RpowConvexity.lean
+++ b/TNLean/Analysis/RpowConvexity.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
+
+/-!
+# Operator convexity of `a ↦ a ^ p` for `p ∈ [1, 2]`
+
+For an element `a` of a unital C⋆-algebra, the map `a ↦ a ^ p` is operator
+convex (convex for the Löwner order) when `p ∈ [1, 2]`. This complements
+Mathlib's `CFC.concaveOn_rpow`, which proves operator concavity for
+`p ∈ [0, 1]`, and discharges the TODO recorded in
+`Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order`
+("Show operator convexity of `rpow` over `Icc 1 2`").
+
+The proof mirrors the concave case. It uses the integral representation of
+`x ↦ x ^ p` on `(1, 2)` already in Mathlib
+(`CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₁₂`,
+Carlen 2010 Lemma 2.8), together with the operator convexity of the
+integrand `rpowIntegrand₁₂`, which decomposes into a linear term, a scalar
+multiple of the resolvent `x ↦ (t • 1 + x)⁻¹` (operator convex by
+`CStarAlgebra.convexOn_ringInverse_algebraMap_add`), and a constant. Operator
+convexity is propagated through the Bochner integral by
+`integral_convexOn_of_integrand_ae`.
+
+The endpoint `p = 2` is handled separately: `a ^ (2 : ℝ≥0) = a * a`, and
+`a ↦ a * a` is operator convex because for `0 ≤ x, y` and a convex
+combination with weights `s, r`,
+`s • (x*x) + r • (y*y) - (s•x + r•y) * (s•x + r•y) = (s*r) • (x - y) * (x - y)`,
+whose right-hand side is positive since `x - y` is self-adjoint.
+
+## Main declarations
+
+* `CFC.convexOn_mul_self` — `a ↦ a * a` is operator convex on `Ici 0`.
+* `CFC.convexOn_cfc_rpowIntegrand₁₂` / `CFC.convexOn_cfcₙ_rpowIntegrand₁₂` —
+  operator convexity of the `(1, 2)` integrand.
+* `CFC.convexOn_nnrpow`, `CFC.convexOn_rpow` — operator convexity of
+  `a ↦ a ^ p` for `p ∈ [1, 2]`.
+
+## References
+
+* [Bhatia, *Matrix Analysis*, Chapter V]
+* [carlen2010] Eric A. Carlen, "Trace inequalities and quantum entropies: An
+  introductory course" (Lemma 2.8)
+-/
+
+open Set
+open scoped NNReal
+
+namespace CFC
+
+open Real MeasureTheory CStarAlgebra
+
+section UnitalCStarAlgebra
+
+variable {A : Type*} [CStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+/-- `a ↦ a * a` is operator convex on the positive elements of a unital
+C⋆-algebra. -/
+lemma convexOn_mul_self : ConvexOn ℝ (Ici (0 : A)) (fun a : A => a * a) := by
+  refine ⟨convex_Ici 0, fun x hx y hy s r hs hr hsr => ?_⟩
+  dsimp only
+  have e1 : (s • x + r • y) * (s • x + r • y)
+      = (s * s) • (x * x) + (s * r) • (x * y) + (r * s) • (y * x)
+        + (r * r) • (y * y) := by
+    simp only [add_mul, mul_add, smul_mul_smul_comm]
+    abel
+  have e2 : (x - y) * (x - y) = x * x - x * y - y * x + y * y := by noncomm_ring
+  have key : s • (x * x) + r • (y * y) - (s • x + r • y) * (s • x + r • y)
+      = (s * r) • ((x - y) * (x - y)) := by
+    rw [e1, e2]
+    have hr' : r = 1 - s := by linarith
+    subst hr'
+    match_scalars <;> ring
+  have hnn : (0 : A) ≤ (s * r) • ((x - y) * (x - y)) := by
+    refine smul_nonneg (mul_nonneg hs hr) ?_
+    have hsa : IsSelfAdjoint (x - y) := (hx.isSelfAdjoint).sub (hy.isSelfAdjoint)
+    have h := mul_star_self_nonneg (x - y)
+    rwa [hsa.star_eq] at h
+  rw [← key] at hnn
+  exact sub_nonneg.mp hnn
+
+/-- The `(1, 2)` integrand `rpowIntegrand₁₂ p t` is operator convex on the
+positive elements of a unital C⋆-algebra, for any `p` and `0 < t`. The convexity
+of the integrand does not use `p ∈ (1, 2)`; that constraint is only needed for
+the integral representation in `convexOn_nnrpow_Ioo`. -/
+lemma convexOn_cfc_rpowIntegrand₁₂ {p t : ℝ} (ht : 0 < t) :
+    ConvexOn ℝ (Ici (0 : A)) (cfc (rpowIntegrand₁₂ p t)) := by
+  have h₁ : (Ici (0 : A)).EqOn (cfc (rpowIntegrand₁₂ p t))
+      (fun x : A => t ^ (p - 2) • x
+        + (t ^ p • Ring.inverse (algebraMap ℝ A t + x) - algebraMap ℝ A (t ^ (p - 1)))) := by
+    intro x hx
+    have hxnn : (0 : A) ≤ x := hx
+    have hsa : IsSelfAdjoint x := hxnn.isSelfAdjoint
+    have hscalar : rpowIntegrand₁₂ p t
+        = fun z => t ^ (p - 2) * z + (t ^ p * (t + z)⁻¹ - t ^ (p - 1)) := by
+      funext z
+      simp only [rpowIntegrand₁₂]
+      have e1 : t ^ (p - 1) * t⁻¹ = t ^ (p - 2) := by
+        rw [← Real.rpow_neg_one t, ← Real.rpow_add ht]; congr 1; ring
+      have e2 : t ^ (p - 1) * t = t ^ p := by
+        nth_rewrite 2 [← Real.rpow_one t]
+        rw [← Real.rpow_add ht]; congr 1; ring
+      rw [mul_sub, mul_add, mul_one,
+        show t ^ (p - 1) * (t⁻¹ * z) = (t ^ (p - 1) * t⁻¹) * z by ring, e1,
+        show t ^ (p - 1) * (t * (t + z)⁻¹) = (t ^ (p - 1) * t) * (t + z)⁻¹ by ring, e2]
+      ring
+    rw [hscalar]
+    have hspectrum : ∀ r ∈ spectrum ℝ x, t + r ≠ 0 := by
+      intro r hr
+      have hr0 : 0 ≤ r := spectrum_nonneg_of_nonneg hxnn hr
+      positivity
+    have hcont_lin : ContinuousOn (fun z : ℝ => t ^ (p - 2) * z) (spectrum ℝ x) := by
+      fun_prop
+    have hg : ContinuousOn (fun z : ℝ => (t + z)⁻¹) (spectrum ℝ x) :=
+      (continuousOn_const.add continuousOn_id).inv₀ (fun r hr => hspectrum r hr)
+    have hcont_inv : ContinuousOn (fun z : ℝ => t ^ p * (t + z)⁻¹ - t ^ (p - 1))
+        (spectrum ℝ x) := (continuousOn_const.mul hg).sub continuousOn_const
+    rw [cfc_add (a := x) (f := fun z : ℝ => t ^ (p - 2) * z)
+        (g := fun z : ℝ => t ^ p * (t + z)⁻¹ - t ^ (p - 1)) (hf := hcont_lin) (hg := hcont_inv)]
+    rw [cfc_const_mul (t ^ (p - 2)) (fun z : ℝ => z) x, cfc_id' (R := ℝ) (a := x)]
+    rw [cfc_sub (a := x) (f := fun z : ℝ => t ^ p * (t + z)⁻¹) (g := fun z : ℝ => t ^ (p - 1))]
+    rw [cfc_const_mul (t ^ p) (fun z : ℝ => (t + z)⁻¹) x]
+    rw [cfc_inv (f := fun z : ℝ => t + z) (a := x) hspectrum]
+    rw [cfc_const_add t (fun z : ℝ => z) x, cfc_id' (R := ℝ) (a := x)]
+    rw [cfc_const (t ^ (p - 1)) x]
+  refine ConvexOn.congr ?_ h₁.symm
+  refine ConvexOn.add ?_ ?_
+  · exact (convexOn_id (convex_Ici 0)).smul (by positivity)
+  · refine ConvexOn.sub ?_ (concaveOn_const _ (convex_Ici 0))
+    exact ConvexOn.smul (by positivity) (CStarAlgebra.convexOn_ringInverse_algebraMap_add ht)
+
+end UnitalCStarAlgebra
+
+section NonUnitalCStarAlgebra
+
+variable {A : Type*} [NonUnitalCStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+/-- The non-unital form of `convexOn_cfc_rpowIntegrand₁₂`. -/
+lemma convexOn_cfcₙ_rpowIntegrand₁₂ {p t : ℝ} (ht : 0 < t) :
+    ConvexOn ℝ (Ici (0 : A)) (cfcₙ (rpowIntegrand₁₂ p t)) := by
+  apply convexOn_cfcₙ_of_convexOn_cfc
+  refine ConvexOn.subset (convexOn_cfc_rpowIntegrand₁₂ ht) inr_map_Ici_zero ?_
+  exact Convex.linear_image (convex_Ici _) (Unitization.inrHom ℝ ℂ A)
+
+/-- This is an intermediate result; use the more general `CFC.convexOn_nnrpow` instead. -/
+private lemma convexOn_nnrpow_Ioo {p : ℝ≥0} (hp : p ∈ Ioo 1 2) :
+    ConvexOn ℝ (Ici (0 : A)) (fun a : A => a ^ p) := by
+  obtain ⟨μ, hμ⟩ := CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₁₂ A hp
+  have h₃' : (Ici 0).EqOn (fun a : A => a ^ p)
+      (fun a : A => ∫ t in Ioi 0, cfcₙ (rpowIntegrand₁₂ p t) a ∂μ) :=
+    fun a ha => (hμ a ha).2
+  refine ConvexOn.congr ?_ h₃'.symm
+  refine integral_convexOn_of_integrand_ae (convex_Ici _) ?_ fun a ha => (hμ a ha).1
+  filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+  exact convexOn_cfcₙ_rpowIntegrand₁₂ ht
+
+end NonUnitalCStarAlgebra
+
+section UnitalCStarAlgebra
+
+variable {A : Type*} [CStarAlgebra A] [PartialOrder A] [StarOrderedRing A]
+
+/-- `a ↦ a ^ p` is operator convex for `p ∈ [1, 2]` (nonnegative real exponent). -/
+lemma convexOn_nnrpow {p : ℝ≥0} (hp : p ∈ Icc 1 2) :
+    ConvexOn ℝ (Ici (0 : A)) (fun a : A => a ^ p) := by
+  obtain ⟨h1, h2⟩ := hp
+  rcases eq_or_lt_of_le h1 with rfl | h1'
+  · exact ConvexOn.congr (convexOn_id (convex_Ici _)) (fun a ha => (nnrpow_one a ha).symm)
+  rcases eq_or_lt_of_le h2 with rfl | h2'
+  · exact ConvexOn.congr convexOn_mul_self (fun a ha => (nnrpow_two a ha).symm)
+  · exact convexOn_nnrpow_Ioo ⟨h1', h2'⟩
+
+/-- **Operator convexity of `a ↦ a ^ p` for `p ∈ [1, 2]`.**
+
+For an element `a` of a unital C⋆-algebra, the map `a ↦ a ^ p` is convex for
+the Löwner order when `1 ≤ p ≤ 2`. This is the convex counterpart of
+`CFC.concaveOn_rpow` (which covers `p ∈ [0, 1]`). -/
+lemma convexOn_rpow {p : ℝ} (hp : p ∈ Icc 1 2) :
+    ConvexOn ℝ (Ici (0 : A)) (fun a : A => a ^ p) := by
+  have hp0 : (0 : ℝ) < p := by have := hp.1; linarith
+  let q : ℝ≥0 := ⟨p, hp0.le⟩
+  have hq0 : 0 < q := by exact_mod_cast hp0
+  change ConvexOn ℝ (Ici (0 : A)) (fun a : A => a ^ (q : ℝ))
+  simp_rw [← CFC.nnrpow_eq_rpow hq0]
+  exact convexOn_nnrpow ⟨by exact_mod_cast hp.1, by exact_mod_cast hp.2⟩
+
+end UnitalCStarAlgebra
+
+end CFC

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -93,6 +93,36 @@ are not developed elsewhere in this document.
     $p\ge 1$ and the convex form of the diagonal Jensen inequality.
 \end{proof}
 
+\section{Operator convexity of real powers}
+
+\begin{theorem}[Operator convexity of $x\mapsto x^p$ on $[1,2]$]%
+    \label{thm:operator_convexOn_rpow}
+    \lean{CFC.convexOn_rpow}
+    \leanok
+    For an element $a$ of a unital C${}^\ast$-algebra and $p\in[1,2]$, the map
+    $a\mapsto a^p$ is convex for the Loewner order on the positive cone:
+    \[
+        (t a+(1-t) b)^p \le t\,a^p+(1-t)\,b^p,
+        \qquad 0\le a,b,\ t\in[0,1].
+    \]
+    This is the convex counterpart of the operator concavity of $x\mapsto x^p$
+    on $[0,1]$.
+\end{theorem}
+
+\begin{proof}\leanok
+    For $p\in(1,2)$ one uses the integral representation
+    $a^p=\int_0^\infty f_{p,s}(a)\,d\mu(s)$ of Carlen
+    \cite[Lemma~2.8]{carlen2010}, whose integrand
+    $f_{p,s}(x)=s^{p-1}\bigl(s^{-1}x+s(s+x)^{-1}-1\bigr)$ is operator convex:
+    it decomposes into a linear term, a nonnegative multiple of the operator
+    convex resolvent $x\mapsto(s\cdot 1+x)^{-1}$, and a constant. Operator
+    convexity is preserved under the Loewner-order Bochner integral. The
+    endpoint $p=1$ is the identity, and $p=2$ is $a\mapsto a^2$, operator
+    convex because
+    $t\,a^2+(1-t)b^2-(ta+(1-t)b)^2=t(1-t)(a-b)^2\ge 0$.
+    See \cite[Chapter~V]{Bhatia1997Matrix}.
+\end{proof}
+
 \section{Operator Jensen inequality for positive maps}
 
 \begin{definition}[Finite-POVM dilation construction]\label{def:operator_jensen_povm_aux}

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -95,7 +95,7 @@ are not developed elsewhere in this document.
 
 \section{Operator convexity of real powers}
 
-\begin{theorem}[Operator convexity of $x\mapsto x^p$ on $[1,2]$]%
+\begin{theorem}[Operator convexity of real powers between one and two]%
     \label{thm:operator_convexOn_rpow}
     \lean{CFC.convexOn_rpow}
     \leanok

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -125,8 +125,7 @@ are not developed elsewhere in this document.
             +(1-t)\int_0^\infty f_{p,s}(b)\,d\mu(s)
         = t\,a^p+(1-t)\,b^p.
     \]
-    The
-    endpoint $p=1$ is the identity, and $p=2$ is $a\mapsto a^2$, operator
+    The endpoint $p=1$ is the identity, and $p=2$ is $a\mapsto a^2$, operator
     convex because
     $t\,a^2+(1-t)b^2-(ta+(1-t)b)^2=t(1-t)(a-b)^2\ge 0$.
     See \cite[Chapter~V]{Bhatia1997Matrix}.

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -99,9 +99,9 @@ are not developed elsewhere in this document.
     \label{thm:operator_convexOn_rpow}
     \lean{CFC.convexOn_rpow}
     \leanok
-    For $p\in[1,2]$, the map $a\mapsto a^p$ is convex for the Loewner order on
-    the positive cone of a unital C${}^\ast$-algebra: if $a,b\ge 0$ and
-    $t\in[0,1]$, then
+    For elements $a,b$ of a unital C${}^\ast$-algebra with $0\le a,b$, an
+    exponent $p\in[1,2]$, and $t\in[0,1]$, the map $a\mapsto a^p$ is convex for
+    the Loewner order on the positive cone:
     \[
         (t a+(1-t) b)^p \le t\,a^p+(1-t)\,b^p.
     \]
@@ -115,21 +115,18 @@ are not developed elsewhere in this document.
     \cite[Lemma~2.8]{carlen2010}, whose integrand
     $f_{p,s}(x)=s^{p-1}\bigl(s^{-1}x+s(s+x)^{-1}-1\bigr)$ is operator convex:
     it decomposes into a linear term, a nonnegative multiple of the operator
-    convex resolvent $x\mapsto(s\cdot 1+x)^{-1}$, and a constant. Thus
+    convex resolvent $x\mapsto(s\cdot 1+x)^{-1}$, and a constant.
+    Since $f_{p,s}(ta+(1-t)b)\le t\,f_{p,s}(a)+(1-t)\,f_{p,s}(b)$ for every
+    $s>0$, integrating this pointwise Loewner inequality against $\mu$ gives
     \[
-        f_{p,s}(t a+(1-t)b)
-        \le
-        t f_{p,s}(a)+(1-t)f_{p,s}(b).
+        (ta+(1-t)b)^p
+        =\int_0^\infty f_{p,s}(ta+(1-t)b)\,d\mu(s)
+        \le t\int_0^\infty f_{p,s}(a)\,d\mu(s)
+            +(1-t)\int_0^\infty f_{p,s}(b)\,d\mu(s)
+        = t\,a^p+(1-t)\,b^p.
     \]
-    Since $\mu$ is positive, integration preserves the Loewner inequality:
-    \[
-        (t a+(1-t)b)^p
-        =\int f_{p,s}(t a+(1-t)b)\,d\mu(s)
-        \le
-        t\int f_{p,s}(a)\,d\mu(s)+(1-t)\int f_{p,s}(b)\,d\mu(s)
-        =t\,a^p+(1-t)b^p.
-    \]
-    The endpoint $p=1$ is the identity, and $p=2$ is $a\mapsto a^2$, operator
+    The
+    endpoint $p=1$ is the identity, and $p=2$ is $a\mapsto a^2$, operator
     convex because
     $t\,a^2+(1-t)b^2-(ta+(1-t)b)^2=t(1-t)(a-b)^2\ge 0$.
     See \cite[Chapter~V]{Bhatia1997Matrix}.

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -99,11 +99,11 @@ are not developed elsewhere in this document.
     \label{thm:operator_convexOn_rpow}
     \lean{CFC.convexOn_rpow}
     \leanok
-    For an element $a$ of a unital C${}^\ast$-algebra and $p\in[1,2]$, the map
-    $a\mapsto a^p$ is convex for the Loewner order on the positive cone:
+    For $p\in[1,2]$, the map $a\mapsto a^p$ is convex for the Loewner order on
+    the positive cone of a unital C${}^\ast$-algebra: if $a,b\ge 0$ and
+    $t\in[0,1]$, then
     \[
-        (t a+(1-t) b)^p \le t\,a^p+(1-t)\,b^p,
-        \qquad 0\le a,b,\ t\in[0,1].
+        (t a+(1-t) b)^p \le t\,a^p+(1-t)\,b^p.
     \]
     This is the convex counterpart of the operator concavity of $x\mapsto x^p$
     on $[0,1]$.
@@ -115,9 +115,21 @@ are not developed elsewhere in this document.
     \cite[Lemma~2.8]{carlen2010}, whose integrand
     $f_{p,s}(x)=s^{p-1}\bigl(s^{-1}x+s(s+x)^{-1}-1\bigr)$ is operator convex:
     it decomposes into a linear term, a nonnegative multiple of the operator
-    convex resolvent $x\mapsto(s\cdot 1+x)^{-1}$, and a constant. Operator
-    convexity is preserved under the Loewner-order Bochner integral. The
-    endpoint $p=1$ is the identity, and $p=2$ is $a\mapsto a^2$, operator
+    convex resolvent $x\mapsto(s\cdot 1+x)^{-1}$, and a constant. Thus
+    \[
+        f_{p,s}(t a+(1-t)b)
+        \le
+        t f_{p,s}(a)+(1-t)f_{p,s}(b).
+    \]
+    Since $\mu$ is positive, integration preserves the Loewner inequality:
+    \[
+        (t a+(1-t)b)^p
+        =\int f_{p,s}(t a+(1-t)b)\,d\mu(s)
+        \le
+        t\int f_{p,s}(a)\,d\mu(s)+(1-t)\int f_{p,s}(b)\,d\mu(s)
+        =t\,a^p+(1-t)b^p.
+    \]
+    The endpoint $p=1$ is the identity, and $p=2$ is $a\mapsto a^2$, operator
     convex because
     $t\,a^2+(1-t)b^2-(ta+(1-t)b)^2=t(1-t)(a-b)^2\ge 0$.
     See \cite[Chapter~V]{Bhatia1997Matrix}.

--- a/blueprint/src/references.bib
+++ b/blueprint/src/references.bib
@@ -61,6 +61,18 @@
   isbn         = {9780387948461},
 }
 
+@incollection{carlen2010,
+  author       = {Carlen, Eric A.},
+  title        = {Trace inequalities and quantum entropies: an introductory course},
+  booktitle    = {Entropy and the quantum},
+  series       = {Contemporary Mathematics},
+  volume       = {529},
+  pages        = {73--140},
+  publisher    = {American Mathematical Society},
+  address      = {Providence, RI},
+  year         = {2010},
+}
+
 @article{Sanz2010Quantum,
   author       = {Sanz, M. and P{\'e}rez-Garc{\'i}a, D. and Wolf, M. M. and Cirac, J. I.},
   title        = {A Quantum Version of {Wielandt}'s Inequality},


### PR DESCRIPTION
### Motivation

- Refs LionSR/QICLean#135: formalizes the operator convexity ingredient for the Wolf Ch. 5 Jensen package for positive maps.
- The Loewner-order convexity of `a ↦ a^p` for `p ∈ [1,2]` is the missing analytic counterpart to Mathlib's `CFC.concaveOn_rpow` (covering `p ∈ [0,1]`), and is the analytic prerequisite toward discharging `posMap_rpow_convex_jensen` (currently axiomatized in `TNLean/Axioms/OperatorConvexity.lean`).
- Blueprint chapter 18 (`ch18_operator_convexity.tex`) tracks this result; `references.bib` adds Carlen 2010.

### Description

- Adds `TNLean/Analysis/RpowConvexity.lean` with the main theorem `CFC.convexOn_rpow`: for an element `a` of a unital C⋆-algebra, the map `a ↦ a^p` is convex for the Loewner order when `p ∈ [1,2]`.
- Proof strategy: endpoints `p = 1` (linearity) and `p = 2` (`convexOn_mul_self`) are handled directly; for `p ∈ (1,2)` the proof uses Carlen's integral representation, establishing operator convexity of the `rpowIntegrand₁₂` integrand (linear term + resolvent + constant) and propagating through the Bochner integral via `integral_convexOn_of_integrand_ae`.
- Exports the new module via `TNLean.lean`.
- Adds `\lean{CFC.convexOn_rpow}` and `\leanok` to blueprint theorem `thm:operator_convexOn_rpow` in `blueprint/src/chapter/ch18_operator_convexity.tex`.
- No new `sorry` or `axiom`; `posMap_rpow_convex_jensen` remains axiomatized (the Choi–Davis Jensen step is not yet discharged by this PR).

### Testing

- No new `sorry`/`axiom` (confirmed by commit message).
- Lean CI (`lean_action_ci.yml`) validates the full `lake build`.
- Blueprint lint (`lint-blueprint.yml`) validates the updated `.tex` file.

---
Refs LionSR/QICLean#135

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained new analysis proofs and documentation with no changes to axioms, auth, or runtime behavior; downstream Jensen discharge is still future work.
> 
> **Overview**
> Adds a **proved** Lean formalization of **operator (Löwner) convexity** of `a ↦ a^p` for `p ∈ [1, 2]` on positive elements of unital C⋆-algebras, via new module `TNLean/Analysis/RpowConvexity.lean` and main lemma **`CFC.convexOn_rpow`**.
> 
> The proof treats **`p = 1`** (identity), **`p = 2`** (`convexOn_mul_self`), and **`p ∈ (1, 2)`** using Carlen’s integral representation and operator convexity of the `rpowIntegrand₁₂` integrand, pushed through a Bochner integral. The module is wired into the public import surface in **`TNLean.lean`**.
> 
> Blueprint **chapter 18** gains a dedicated section and **`thm:operator_convexOn_rpow`** with `\lean{CFC.convexOn_rpow}` and `\leanok`, plus a proof sketch citing Carlen; **`references.bib`** adds **`carlen2010`**. **`posMap_rpow_convex_jensen`** stays axiomatized—this PR supplies the analytic convexity step, not the positive-map Jensen corollary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2576fd3dbaeb4f31beaf016be80e5f39d9f86e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->