### PR TITLE
doc(PEPS): refresh 2D TI description dependency

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1493,11 +1493,12 @@ recorded in the route note
     \[
         B = \bigl(X^{(0,0)}_v\bigr)^{-1}\,\bigl(X^{(0,0)}_h\bigr)^{-1}\, A^{(0,0)},
     \]
-    whose constant family generates the same state.  Both the one-dimensional
-    telescoping closure
-    (Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState})
-    and its two-directional assembly into this single repeated 2D tensor remain
-    to be formalized.
+    whose constant family generates the same state.  The one-dimensional
+    telescoping closure is now formalized in
+    Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}.
+    What remains is the two-directional PEPS assembly: the horizontal and
+    vertical telescopings must be made compatible around plaquettes and periodic
+    seams, then absorbed into this single repeated 2D tensor.
 \end{proof}
 
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2800,10 +2800,13 @@ expected one, not a proof the source carries out.
 
 The load-bearing dependency, the injective PEPS Fundamental Theorem
 (\path{TNLean.PEPS.fundamentalTheorem_PEPS}, blueprint
-\path{thm:fundamentalTheorem_PEPS}), is formalized. The remaining work is the
-two-directional telescoping closure, which is the 2D form of the
-still-open one-dimensional repeated-tensor construction discussed above; it is
-not yet formalized. The blueprint records the restricted target as
+\path{thm:fundamentalTheorem_PEPS}), is formalized. The one-dimensional
+repeated-tensor construction discussed above is also formalized as
+\leanid{TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState}.
+The remaining work is the PEPS-specific two-directional closure: the horizontal
+and vertical gauge telescopings must be made compatible around plaquettes and
+periodic seams, and their residual virtual operations must be absorbed into one
+site-independent 2D tensor. The blueprint records the restricted target as
 \path{cor:exists_constant_injectivePEPS_of_translationInvariantState}, marked
 not ready.
 


### PR DESCRIPTION
### Motivation

- The blueprint proof sketch for the 2D translation-invariant PEPS corollary (`cor:exists_constant_injectivePEPS_of_translationInvariantState`, source: arXiv:1804.04964, lines 1892–1894) treated the 1D telescoping closure as still open. The 1D repeated-tensor corollary is now formalized (see #2920, #3364, and #3362), so this description was outdated.
- The paper-gaps route note (`docs/paper-gaps/peps_normal_ft_section3_route.tex`) similarly listed the 1D step as incomplete; it needs to reflect that the injective-PEPS fundamental theorem and the 1D construction are done, with the remaining gap being the 2D-specific two-directional closure.

### Description

- `blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex`: updated the proof sketch for `cor:exists_constant_injectivePEPS_of_translationInvariantState` to record the 1D closure as proved and state the remaining 2D work: compatibility of horizontal and vertical gauge telescopings at plaquettes and periodic seams, followed by absorption of residuals into a single site-independent 2D tensor. The 2D corollary remains marked `\notready`; no Lean declarations or `\leanok` tags changed.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: aligned to state that the injective-PEPS fundamental theorem is formalized and the 1D construction is complete; the open gap is now identified as the 2D PEPS-specific two-directional closure rather than an unfinished 1D step.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `cd blueprint/src && chktex -q -l ../.chktexrc chapter/ch24_peps_ft_normal_capstone.tex`
- `git diff --check`

---
Addresses #2921

> [!NOTE]
> **Low Risk**
> Prose-only edits in blueprint and gap notes; no Lean, `\leanok`, or formal status changes.
> 
> **Overview**
> Updates **documentation only** for the translation-invariant injective PEPS route now that the **1D** repeated-tensor corollary `cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState` is formalized (`TNLean.PEPS.exists_constant_injectiveMPS_of_cyclicShiftInvariantState`).
> 
> In the blueprint proof sketch for `cor:exists_constant_injectivePEPS_of_translationInvariantState`, the text no longer treats the 1D telescoping closure as open; it points to that corollary and states that **remaining work** is the **2D PEPS assembly**—making horizontal and vertical gauge telescopings compatible at plaquettes and periodic seams, then absorbing residuals into one site-independent 2D tensor. The 2D corollary stays `\notready`.
> 
> The paper-gaps route note (`peps_normal_ft_section3_route.tex`) is aligned: injective PEPS FT is formalized, the 1D construction is cited as done, and the gap is described as PEPS-specific two-directional closure rather than an still-open 1D step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c46c49753972768834107afd20f14ab028d74a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>