### PR TITLE
doc(PEPS): spell out 2D plaquette compatibility

### DIFF
--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1502,15 +1502,25 @@ recorded in the route note
         \qquad
         V_{j,k}=R^{(j,k)}_v\bigl(L^{(j,k+1)}_v\bigr)^{-1},
     \]
-    are the residual horizontal and vertical operations, the missing plaquette
-    flatness identity is
+    are the residual horizontal and vertical operations, the horizontal residual
+    acts on \(\mathbb C^{D_h}\) and the vertical residual acts on
+    \(\mathbb C^{D_v}\).  The missing plaquette flatness identity must therefore
+    be stated after placing them on the corner space
+    \(\mathbb C^{D_h}\otimes\mathbb C^{D_v}\).  Equivalently, after the row and
+    column telescopings make \(H_{j,k}=H_k\) and \(V_{j,k}=V_j\), one must prove
     \[
-        H_{j,k}V_{j+1,k}
-        =\lambda_{j,k}\,V_{j,k}H_{j,k+1}
+        (H_k\otimes I_{D_v})(I_{D_h}\otimes V_{j+1})
+        =
+        \lambda_{j,k}\,(I_{D_h}\otimes V_j)(H_{k+1}\otimes I_{D_v})
     \]
-    for nonzero scalars \(\lambda_{j,k}\), together with the analogous scalar
-    closure of the row and column loop products at the periodic seams.  These
-    identities are then absorbed into this single repeated 2D tensor.
+    for nonzero scalars \(\lambda_{j,k}\).  The scalar phases must also close
+    around the two periodic seams,
+    \[
+        \prod_{k\in\mathbb Z/N_v\mathbb Z}\lambda_{j,k}=1,
+        \qquad
+        \prod_{j\in\mathbb Z/N_h\mathbb Z}\lambda_{j,k}=1.
+    \]
+    These identities are then absorbed into this single repeated 2D tensor.
 \end{proof}
 
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -1496,9 +1496,21 @@ recorded in the route note
     whose constant family generates the same state.  The one-dimensional
     telescoping closure is now formalized in
     Corollary~\ref{cor:exists_constant_injectiveMPS_of_cyclicShiftInvariantState}.
-    What remains is the two-directional PEPS assembly: the horizontal and
-    vertical telescopings must be made compatible around plaquettes and periodic
-    seams, then absorbed into this single repeated 2D tensor.
+    What remains is the two-directional PEPS assembly.  If
+    \[
+        H_{j,k}=R^{(j,k)}_h\bigl(L^{(j+1,k)}_h\bigr)^{-1},
+        \qquad
+        V_{j,k}=R^{(j,k)}_v\bigl(L^{(j,k+1)}_v\bigr)^{-1},
+    \]
+    are the residual horizontal and vertical operations, the missing plaquette
+    flatness identity is
+    \[
+        H_{j,k}V_{j+1,k}
+        =\lambda_{j,k}\,V_{j,k}H_{j,k+1}
+    \]
+    for nonzero scalars \(\lambda_{j,k}\), together with the analogous scalar
+    closure of the row and column loop products at the periodic seams.  These
+    identities are then absorbed into this single repeated 2D tensor.
 \end{proof}
 
 \begin{theorem}[Uniqueness of the injective closed-chain gauge]%

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2806,7 +2806,21 @@ repeated-tensor construction discussed above is also formalized as
 The remaining work is the PEPS-specific two-directional closure: the horizontal
 and vertical gauge telescopings must be made compatible around plaquettes and
 periodic seams, and their residual virtual operations must be absorbed into one
-site-independent 2D tensor. The blueprint records the restricted target as
+site-independent 2D tensor. In the notation of the blueprint proof sketch,
+writing
+\[
+    H_{j,k}=R^{(j,k)}_h\bigl(L^{(j+1,k)}_h\bigr)^{-1},
+    \qquad
+    V_{j,k}=R^{(j,k)}_v\bigl(L^{(j,k+1)}_v\bigr)^{-1},
+\]
+the missing plaquette flatness relation is the scalar commutation condition
+\[
+    H_{j,k}V_{j+1,k}
+    =\lambda_{j,k}\,V_{j,k}H_{j,k+1}
+\]
+for nonzero scalars \(\lambda_{j,k}\), together with the analogous scalar
+closure of the horizontal and vertical loop products at the periodic seams.
+The blueprint records the restricted target as
 \path{cor:exists_constant_injectivePEPS_of_translationInvariantState}, marked
 not ready.
 

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2813,13 +2813,26 @@ writing
     \qquad
     V_{j,k}=R^{(j,k)}_v\bigl(L^{(j,k+1)}_v\bigr)^{-1},
 \]
-the missing plaquette flatness relation is the scalar commutation condition
+the residual \(H_{j,k}\) acts on the horizontal virtual leg
+\(\mathbb C^{D_h}\), while \(V_{j,k}\) acts on the vertical virtual leg
+\(\mathbb C^{D_v}\).  Thus the plaquette condition is not an ordinary product
+of a \(D_h\times D_h\) matrix with a \(D_v\times D_v\) matrix.  It must be
+stated on the corner virtual space
+\(\mathbb C^{D_h}\otimes\mathbb C^{D_v}\): after the row and column
+telescopings make \(H_{j,k}=H_k\) and \(V_{j,k}=V_j\), the missing scalar
+plaquette flatness relation is
 \[
-    H_{j,k}V_{j+1,k}
-    =\lambda_{j,k}\,V_{j,k}H_{j,k+1}
+    (H_k\otimes I_{D_v})(I_{D_h}\otimes V_{j+1})
+    =
+    \lambda_{j,k}\,(I_{D_h}\otimes V_j)(H_{k+1}\otimes I_{D_v})
 \]
-for nonzero scalars \(\lambda_{j,k}\), together with the analogous scalar
-closure of the horizontal and vertical loop products at the periodic seams.
+for nonzero scalars \(\lambda_{j,k}\).  These scalars must also satisfy the
+periodic seam closures
+\[
+    \prod_{k\in\mathbb Z/N_v\mathbb Z}\lambda_{j,k}=1,
+    \qquad
+    \prod_{j\in\mathbb Z/N_h\mathbb Z}\lambda_{j,k}=1.
+\]
 The blueprint records the restricted target as
 \path{cor:exists_constant_injectivePEPS_of_translationInvariantState}, marked
 not ready.


### PR DESCRIPTION
### Motivation

- The blueprint proof sketch for the 2D translation-invariant PEPS corollary (arXiv:1804.04964, Corollary at lines 1892–1894 of `Papers/1804.04964/paper_normal.tex`) described the 2D plaquette compatibility step only in vague prose; replacing it with the explicit scalar plaquette flatness relation records the remaining proof obligation precisely. Continues #2921.
- The matching paper-gap route note (`docs/paper-gaps/peps_normal_ft_section3_route.tex`) is updated to mirror the same identity.
- Follow-up to #3382.

### Description

- `blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex`: in the proof sketch for `cor:exists_constant_injectivePEPS_of_translationInvariantState` (still marked `\notready`), the vague "compatible around plaquettes and periodic seams" step is replaced with explicit residual operators $H_{j,k}$, $V_{j,k}$ and the scalar plaquette flatness relation $H_{j,k} V_{j+1,k} = \lambda_{j,k} V_{j,k} H_{j,k+1}$, together with seam loop closures before absorption into the repeated 2D tensor $B$.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex`: mirrors the same scalar flatness identity.
- No formalization status change: the corollary remains `\notready`; this only records the remaining proof target precisely.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `cd blueprint/src && chktex -q -l ../.chktexrc chapter/ch24_peps_ft_normal_capstone.tex`
- `git diff --check origin/main`

---
Addresses #2921

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose-only updates to blueprint and paper-gap notes; no Lean or runtime behavior changes.
> 
> **Overview**
> Replaces vague “compatible around plaquettes and periodic seams” wording with an explicit **remaining proof obligation** for the `\notready` translation-invariant PEPS corollary (`cor:exists_constant_injectivePEPS_of_translationInvariantState`).
> 
> The blueprint proof sketch and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** now define residual horizontal/vertical operators \(H_{j,k}\), \(V_{j,k}\), explain that plaquette compatibility lives on \(\mathbb C^{D_h}\otimes\mathbb C^{D_v}\) (not a naive \(D_h\times D_v\) matrix product), and state the **scalar plaquette flatness** identity \((H_k\otimes I_{D_v})(I_{D_h}\otimes V_{j+1})=\lambda_{j,k}(I_{D_h}\otimes V_j)(H_{k+1}\otimes I_{D_v})\) plus **torus seam loop closures** on \(\prod\lambda_{j,k}\) before absorbing into the repeated 2D tensor \(B\).
> 
> **No formalization status change**—only records the target precisely for future proof work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f283ce383396d9ed0f0f815d017312a22b42783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->