### PR TITLE
feat(MPS/ParentHamiltonian): add overlapping local support lifts

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -183,6 +183,7 @@ import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.Nonvanishing
 import TNLean.MPS.ParentHamiltonian.IntersectionProperty
 import TNLean.MPS.ParentHamiltonian.CyclicWindow
+import TNLean.MPS.ParentHamiltonian.LocalSupport
 import TNLean.MPS.ParentHamiltonian.ChainGroundSpace
 import TNLean.MPS.ParentHamiltonian.SuffixWindow
 import TNLean.MPS.ParentHamiltonian.BoundaryOverlap

--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.CyclicWindow
+
+/-!
+# Local support maps for overlapping nearest-neighbor parent terms
+
+This file records the three-site support maps needed for the nearest-neighbor
+commuting parent-Hamiltonian condition in arXiv:1606.00608, Definition D.2.
+The source uses a tripartite Hilbert space \(H_A \otimes H_X \otimes H_B\) and
+two local projectors \(Q_{AX}\) and \(Q_{XB}\).  The definitions below express
+the corresponding two embeddings of a two-site operator into the uniform
+three-site coefficient space used by the parent-Hamiltonian development.
+
+These declarations are only the support layer.  They do not prove the
+product-of-entangled-pairs commutation relation for any tensor.
+-/
+
+open scoped BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-! ### The two overlapping two-site faces of a three-site window -/
+
+/-- The \(AX\) two-site face of a three-site configuration \((A,X,B)\). -/
+def axPairCfg (σ : Cfg d 3) : Cfg d 2 :=
+  fun j => σ ⟨j.val, by
+    have hj : j.val < 2 := j.isLt
+    omega⟩
+
+/-- The \(XB\) two-site face of a three-site configuration \((A,X,B)\). -/
+def xbPairCfg (σ : Cfg d 3) : Cfg d 2 :=
+  fun j => σ ⟨j.val + 1, by
+    have hj : j.val < 2 := j.isLt
+    omega⟩
+
+/-- Replace the \(AX\) face of a three-site configuration and leave \(B\) fixed. -/
+def replaceAXCfg (σ : Cfg d 3) (α : Cfg d 2) : Cfg d 3 :=
+  fun k => if h : k.val < 2 then α ⟨k.val, h⟩ else σ k
+
+/-- Replace the \(XB\) face of a three-site configuration and leave \(A\) fixed. -/
+def replaceXBCfg (σ : Cfg d 3) (β : Cfg d 2) : Cfg d 3 :=
+  fun k => if h : 0 < k.val then β ⟨k.val - 1, by
+    have hk : k.val < 3 := k.isLt
+    omega⟩ else σ k
+
+@[simp] theorem axPairCfg_replaceAXCfg (σ : Cfg d 3) (α : Cfg d 2) :
+    axPairCfg (replaceAXCfg σ α) = α := by
+  funext j
+  fin_cases j <;> rfl
+
+@[simp] theorem xbPairCfg_replaceXBCfg (σ : Cfg d 3) (β : Cfg d 2) :
+    xbPairCfg (replaceXBCfg σ β) = β := by
+  funext j
+  fin_cases j <;> rfl
+
+@[simp] theorem replaceAXCfg_axPairCfg (σ : Cfg d 3) :
+    replaceAXCfg σ (axPairCfg σ) = σ := by
+  funext k
+  fin_cases k <;> rfl
+
+@[simp] theorem replaceXBCfg_xbPairCfg (σ : Cfg d 3) :
+    replaceXBCfg σ (xbPairCfg σ) = σ := by
+  funext k
+  fin_cases k <;> rfl
+
+@[simp] theorem replaceAXCfg_replaceAXCfg
+    (σ : Cfg d 3) (α α' : Cfg d 2) :
+    replaceAXCfg (replaceAXCfg σ α) α' = replaceAXCfg σ α' := by
+  funext k
+  fin_cases k <;> rfl
+
+@[simp] theorem replaceXBCfg_replaceXBCfg
+    (σ : Cfg d 3) (β β' : Cfg d 2) :
+    replaceXBCfg (replaceXBCfg σ β) β' = replaceXBCfg σ β' := by
+  funext k
+  fin_cases k <;> rfl
+
+/-! ### Lifting two-site operators to the overlapping three-site window -/
+
+/-- Embed a two-site operator as acting on the \(AX\) face of \(A,X,B\). -/
+def leftPairLift (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    NSiteSpace d 3 →ₗ[ℂ] NSiteSpace d 3 where
+  toFun ψ σ := Q (fun α => ψ (replaceAXCfg σ α)) (axPairCfg σ)
+  map_add' ψ φ := by
+    funext σ
+    change Q ((fun α => ψ (replaceAXCfg σ α)) +
+        (fun α => φ (replaceAXCfg σ α))) (axPairCfg σ) =
+      (Q (fun α => ψ (replaceAXCfg σ α)) +
+        Q (fun α => φ (replaceAXCfg σ α))) (axPairCfg σ)
+    exact congr_fun
+      (Q.map_add (fun α => ψ (replaceAXCfg σ α)) (fun α => φ (replaceAXCfg σ α)))
+      (axPairCfg σ)
+  map_smul' c ψ := by
+    funext σ
+    change Q (c • (fun α => ψ (replaceAXCfg σ α))) (axPairCfg σ) =
+      (c • Q (fun α => ψ (replaceAXCfg σ α))) (axPairCfg σ)
+    exact congr_fun
+      (Q.map_smul c (fun α => ψ (replaceAXCfg σ α)))
+      (axPairCfg σ)
+
+/-- Embed a two-site operator as acting on the \(XB\) face of \(A,X,B\). -/
+def rightPairLift (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    NSiteSpace d 3 →ₗ[ℂ] NSiteSpace d 3 where
+  toFun ψ σ := Q (fun β => ψ (replaceXBCfg σ β)) (xbPairCfg σ)
+  map_add' ψ φ := by
+    funext σ
+    change Q ((fun β => ψ (replaceXBCfg σ β)) +
+        (fun β => φ (replaceXBCfg σ β))) (xbPairCfg σ) =
+      (Q (fun β => ψ (replaceXBCfg σ β)) +
+        Q (fun β => φ (replaceXBCfg σ β))) (xbPairCfg σ)
+    exact congr_fun
+      (Q.map_add (fun β => ψ (replaceXBCfg σ β)) (fun β => φ (replaceXBCfg σ β)))
+      (xbPairCfg σ)
+  map_smul' c ψ := by
+    funext σ
+    change Q (c • (fun β => ψ (replaceXBCfg σ β))) (xbPairCfg σ) =
+      (c • Q (fun β => ψ (replaceXBCfg σ β))) (xbPairCfg σ)
+    exact congr_fun
+      (Q.map_smul c (fun β => ψ (replaceXBCfg σ β)))
+      (xbPairCfg σ)
+
+@[simp] theorem leftPairLift_apply
+    (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) (ψ : NSiteSpace d 3) (σ : Cfg d 3) :
+    leftPairLift Q ψ σ = Q (fun α => ψ (replaceAXCfg σ α)) (axPairCfg σ) :=
+  rfl
+
+@[simp] theorem rightPairLift_apply
+    (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) (ψ : NSiteSpace d 3) (σ : Cfg d 3) :
+    rightPairLift Q ψ σ = Q (fun β => ψ (replaceXBCfg σ β)) (xbPairCfg σ) :=
+  rfl
+
+@[simp] theorem leftPairLift_one :
+    leftPairLift (d := d) (1 : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) = 1 := by
+  ext ψ σ
+  simp
+
+@[simp] theorem rightPairLift_one :
+    rightPairLift (d := d) (1 : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) = 1 := by
+  ext ψ σ
+  simp
+
+@[simp] theorem leftPairLift_mul
+    (Q R : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    leftPairLift (Q * R) = leftPairLift Q * leftPairLift R := by
+  ext ψ σ
+  simp [Module.End.mul_apply]
+
+@[simp] theorem rightPairLift_mul
+    (Q R : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    rightPairLift (Q * R) = rightPairLift Q * rightPairLift R := by
+  ext ψ σ
+  simp [Module.End.mul_apply]
+
+/-- The algebraic part of the source nearest-neighbor parent-commuting condition
+on one tripartite window.
+
+In arXiv:1606.00608, Definition D.2, the projectors \(Q_{AX}\) and \(Q_{XB}\)
+act on the two overlapping tensor factors \(AX\) and \(XB\).  Here the two
+projectors are represented as two-site endomorphisms and then lifted to the
+three-site coefficient space.  Orthogonality and the kernel-intersection
+condition are separate source hypotheses, not included in this algebraic
+commutation predicate. -/
+structure HasOverlappingTwoSiteCommutation
+    (QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) : Prop where
+  left_idempotent : QAX * QAX = QAX
+  right_idempotent : QXB * QXB = QXB
+  commute_lifts :
+    leftPairLift QAX * rightPairLift QXB =
+      rightPairLift QXB * leftPairLift QAX
+
+theorem HasOverlappingTwoSiteCommutation.commute_apply
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB)
+    (ψ : NSiteSpace d 3) :
+    leftPairLift QAX (rightPairLift QXB ψ) =
+      rightPairLift QXB (leftPairLift QAX ψ) := by
+  simpa [Module.End.mul_apply] using LinearMap.congr_fun h.commute_lifts ψ
+
+theorem HasOverlappingTwoSiteCommutation.left_lift_idempotent
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB) :
+    leftPairLift QAX * leftPairLift QAX = leftPairLift QAX := by
+  rw [← leftPairLift_mul, h.left_idempotent]
+
+theorem HasOverlappingTwoSiteCommutation.right_lift_idempotent
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB) :
+    rightPairLift QXB * rightPairLift QXB = rightPairLift QXB := by
+  rw [← rightPairLift_mul, h.right_idempotent]
+
+/-! ### Adjacent cyclic two-site supports -/
+
+/-- The left two-site support \(AX\) of the three-site window starting at `i`. -/
+def axCyclicSupport (N : ℕ) (i : Fin N) : Finset (Fin N) :=
+  cyclicWindowSupport N 2 i
+
+/-- The right two-site support \(XB\) of the three-site window starting at `i`. -/
+def xbCyclicSupport (N : ℕ) (i : Fin N) : Finset (Fin N) :=
+  cyclicWindowSupport N 2 (cyclicForwardSite i 1)
+
+/-- The two adjacent nearest-neighbor windows share their middle site. -/
+theorem adjacent_twoSite_cyclicWindowsOverlap {N : ℕ} (i : Fin N) :
+    cyclicWindowsOverlap N 2 i (cyclicForwardSite i 1) := by
+  refine ⟨cyclicForwardSite i 1, ?_, ?_⟩
+  · rw [cyclicWindowSupport]
+    exact Finset.mem_image.mpr ⟨1, by simp, rfl⟩
+  · rw [cyclicWindowSupport]
+    refine Finset.mem_image.mpr ⟨0, by simp, ?_⟩
+    ext
+    simp [cyclicForwardSite]
+
+end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -15,6 +15,47 @@ In Definition~3.9 the parent-Hamiltonian condition also says that, for
 $N>L$, the ground space is spanned by the periodic MPS vectors associated to
 the BNT components; nearest-neighbor means the specialization $L=2$.
 
+\begin{definition}[Overlapping two-site supports]\label{def:overlapping_two_site_supports}
+    \lean{MPSTensor.axPairCfg}
+    \lean{MPSTensor.xbPairCfg}
+    \lean{MPSTensor.replaceAXCfg}
+    \lean{MPSTensor.replaceXBCfg}
+    \lean{MPSTensor.leftPairLift}
+    \lean{MPSTensor.rightPairLift}
+    \lean{MPSTensor.HasOverlappingTwoSiteCommutation}
+    \lean{MPSTensor.adjacent_twoSite_cyclicWindowsOverlap}
+    \leanok
+    \uses{def:nsite_space_parent, def:cyclic_window_support,
+        def:cyclic_windows_overlap}
+    On a three-site space
+    $\mathcal H_A\otimes\mathcal H_X\otimes\mathcal H_B$, let
+    $Q_{AX}$ and $Q_{XB}$ be two-site projectors. Their local actions on the
+    three-site space are the operators
+    \[
+        (Q_{AX}\psi)(a,x,b)
+        =
+        Q_{AX}\bigl(\alpha,\xi\mapsto\psi(\alpha,\xi,b)\bigr)(a,x),
+    \]
+    and
+    \[
+        (Q_{XB}\psi)(a,x,b)
+        =
+        Q_{XB}\bigl(\xi,\beta\mapsto\psi(a,\xi,\beta)\bigr)(x,b).
+    \]
+    The algebraic part of the overlapping nearest-neighbor commutation
+    condition is
+    \[
+        Q_{AX}^2=Q_{AX},\qquad
+        Q_{XB}^2=Q_{XB},\qquad
+        Q_{AX}Q_{XB}=Q_{XB}Q_{AX}
+    \]
+    after these two local actions are viewed on the common three-site space.
+    This is the local-support part of the parent commuting Hamiltonian condition
+    in \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  The cyclic windows beginning
+    at $i$ and $i+1$ realize the two supports $AX$ and $XB$, and hence overlap at
+    the middle site.
+\end{definition}
+
 \begin{definition}[Translated parent-term commutation]\label{def:is_commuting_parent_ham}
     \lean{MPSTensor.IsCommutingParentHam}
     \leanok


### PR DESCRIPTION
### Motivation
- Prerequisite for eliminating the axiom `Axioms.rfp_to_nncph_commute` (`TNLean/Axioms/Beigi.lean:121`), identified in the 2026-06-22 axiom audit; sub-task of #2633.
- The forward RFP ⟹ NNCPH elimination route requires nearest-neighbor parent projectors to commute for all index pairs, including overlapping adjacent windows \(`[τ₁(P₂), P₂] = 0`\); the disjoint-window case is already proven but adjacent windows share a site and are not covered.
- arXiv:1606.00608, Definition D.2 provides the local-support decomposition needed to state the overlapping commutation relation; this PR formalizes that definition layer.

### Description
- Add `TNLean/MPS/ParentHamiltonian/LocalSupport.lean` (new file): defines the two overlapping two-site faces of a three-site `NSiteSpace` window and their lifted endomorphisms, following arXiv:1606.00608, Definition D.2.
- Introduce the structure `MPSTensor.HasOverlappingTwoSiteCommutation` collecting the local idempotent and lifted-commutation hypotheses.
- Extend `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex` with the blueprint entry for the local-support layer.
- Register the new module in `TNLean.lean`.
- Does not prove product-of-entangled-pairs commutation; does not discharge the Beigi/RFP axioms tracked in the axiom inventory.

### Testing
- `lake env lean TNLean/MPS/ParentHamiltonian/LocalSupport.lean`
- `lake build TNLean.MPS.ParentHamiltonian.LocalSupport`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`
- `rg -n "sorry|admit|native_decide|unsafeCast|\baxiom\b" TNLean/MPS/ParentHamiltonian/LocalSupport.lean`

---
Addresses #3373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 681558a9edcef16bd46d747ae598748bd1d10a30. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->