### PR TITLE
fix(Channel): expose Lorentz declarations to blueprint

### DIFF
--- a/TNLean/Channel/WolfChapter2Index.lean
+++ b/TNLean/Channel/WolfChapter2Index.lean
@@ -18,6 +18,7 @@ import TNLean.Channel.POVM.Uniqueness
 import TNLean.Channel.TransferMatrix
 import TNLean.Channel.WolfProps
 import TNLean.Channel.NormalForm
+import TNLean.Channel.LorentzNormalForm
 
 /-!
 # Wolf Lecture Notes — Chapter 2: Representations
@@ -27,12 +28,11 @@ This file indexes the formalization of Chapter 2 of Wolf's
 representations of quantum channels.
 
 The Lorentz-normal-form statements are recorded in
-`TNLean.Channel.LorentzNormalForm`, but the generic normal-form and qubit
-classification proofs are not yet complete.  The compactness/minimisation
-result is proved there; the remaining proof obligations are the optimality step
-at the minimiser and the SL(2, ℂ) Lorentz-orbit classification.  The index
-mentions those statements by name without importing the unfinished file into the
-default root.
+`TNLean.Channel.LorentzNormalForm`.  The compactness/minimisation result is
+proved there; the remaining proof obligations are the optimality step at the
+minimiser and the SL(2, ℂ) Lorentz-orbit classification.  This index imports
+that file so that the cited formal statements are available from the main
+project import.
 
 ## Coverage summary
 


### PR DESCRIPTION
### Motivation

- `TNLean.Channel.LorentzNormalForm` was not imported in the Wolf Chapter 2 index, so the blueprint declaration checker could not locate `Wolf.infimum_is_attained` and related Lorentz normal-form declarations.
- The compactness/minimisation result is proved in that file and should be visible to `leanblueprint checkdecls`; the missing import was the only obstacle.
- Continues formalization of Wolf §2.3 Lorentz normal form; see LionSR/QICLean#12.

### Description

- Modified `TNLean/Channel/WolfChapter2Index.lean`: added `import TNLean.Channel.LorentzNormalForm` so that the cited Lorentz normal-form statements are accessible from the main project import.
- Updated the index prose to remove the caveat that `LorentzNormalForm` is excluded from the default root; the remaining open obligations (optimality step at the minimiser and the SL(2, ℂ) Lorentz-orbit classification) are noted inline.

### Testing

- `lake build TNLean -q --log-level=info`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/QICLean#12

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and documentation only; no changes to proofs or channel semantics.
> 
> **Overview**
> **Wires Lorentz normal-form declarations into the main Chapter 2 import path** so blueprint tools (e.g. `leanblueprint checkdecls`) can find names such as `Wolf.infimum_is_attained` that the index already cites.
> 
> `WolfChapter2Index.lean` gains `import TNLean.Channel.LorentzNormalForm`. The module doc no longer says `LorentzNormalForm` is kept out of the default root; it now states that the index imports that file so cited statements are available from the main project import. Open proof obligations (optimality at the minimiser, SL(2, ℂ) orbit classification) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca3337431d743e4e214fe31e5f227d654ae3b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->