### PR TITLE
refactor(MPS/Periodic): rename scoped Z-gauge extraction

### DIFF
--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -369,10 +369,13 @@ already known to be in irreducible form. The irreducible-form hypothesis for
 the \(p\)-blocked root is an explicit input here; it is not obtained from
 equality of MPV families.
 
-This theorem is therefore only the equal-case FT application step. The remaining
-canonicalization problem is to prove that the blocked root appearing in the
-refinement argument is in irreducible form. -/
-theorem peripheralEqualCaseZGaugeOfSameMPV_of_periodicEqualCaseFT
+This theorem is therefore only the equal-case FT application step. It does not
+prove the full `PeripheralEqualCaseZGaugeOfSameMPV` hypothesis, since that
+hypothesis does not assume irreducible form for the blocked root. The remaining
+canonicalization work is to prove the missing irreducible-form input for the
+blocked root, and then to distribute the resulting blocked `Z`-phase back to a
+left-canonical root. -/
+theorem zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm
     (p : ℕ) (hFT : PeriodicEqualCaseFT (blockPhysDim d p) D)
     {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D}
     (hC : IsIrreducibleForm C)

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1990,9 +1990,9 @@ divisibility of its transfer map, following
     both in irreducible form~II, and suppose that they have the same MPV family.
     Then there exists an integer $m \ge 1$ and a $\mathbb Z_m$-gauge equivalence
     between $C$ and $A^{[p]}$.
-    This is only the equal-case application of the periodic Fundamental
-    Theorem; the irreducible-form hypothesis on $A^{[p]}$ is an explicit
-    assumption, not a consequence of equality of MPV families.
+    % Scope restriction: this is only the equal-case application of the periodic
+    % Fundamental Theorem; the irreducible-form hypothesis on $A^{[p]}$ is an
+    % explicit assumption, not a consequence of equality of MPV families.
 \end{theorem}
 
 \begin{definition}[Blocked-to-root reconstruction hypothesis from Z-gauge]

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1979,9 +1979,9 @@ divisibility of its transfer map, following
     between $C$ and $A^{[p]}$.
 \end{definition}
 
-\begin{theorem}[Blocked equal-case Z-gauge extraction from the periodic theorem]
-    \label{thm:peripheral_equalcase_zgauge_sameMPV_of_periodicFT}
-    \lean{MPSTensor.peripheralEqualCaseZGaugeOfSameMPV_of_periodicEqualCaseFT}
+\begin{theorem}[Z-gauge equivalence from the periodic theorem]
+    \label{thm:zgauge_equiv_periodicFT_irreducible_form}
+    \lean{MPSTensor.zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm}
     \leanok
     \uses{thm:periodic_ft, def:irreducible_form, def:blocked_tensor,
         def:same_mpv, def:z_gauge_equiv}
@@ -1990,9 +1990,9 @@ divisibility of its transfer map, following
     both in irreducible form~II, and suppose that they have the same MPV family.
     Then there exists an integer $m \ge 1$ and a $\mathbb Z_m$-gauge equivalence
     between $C$ and $A^{[p]}$.
-    % Scope note: this is only the equal-case application of the periodic
-    % Fundamental Theorem; the irreducible-form hypothesis on $A^{[p]}$ is an
-    % explicit assumption, not a consequence of equality of MPV families.
+    This is only the equal-case application of the periodic Fundamental
+    Theorem; the irreducible-form hypothesis on $A^{[p]}$ is an explicit
+    assumption, not a consequence of equality of MPV families.
 \end{theorem}
 
 \begin{definition}[Blocked-to-root reconstruction hypothesis from Z-gauge]


### PR DESCRIPTION
### Motivation
- The declaration `MPSTensor.peripheralEqualCaseZGaugeOfSameMPV_of_periodicEqualCaseFT` misleadingly suggests the full `PeripheralEqualCaseZGaugeOfSameMPV` conclusion rather than the narrower Z-gauge equivalence extracted as an intermediate step from the periodic equal-case Fundamental Theorem. Continues the discharge plan in #664 (canonicalization hypotheses for the unconditional Thm. 4.1).
- Source: arXiv:1708.00029 §4.1, periodic equal-case Fundamental Theorem.

### Description
- Renamed `MPSTensor.peripheralEqualCaseZGaugeOfSameMPV_of_periodicEqualCaseFT` to `MPSTensor.zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm` in `TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`.
- Updated the Lean docstring to state explicitly that the theorem assumes irreducible form for the blocked root (`blockTensor A p`) and does not prove the full `PeripheralEqualCaseZGaugeOfSameMPV` hypothesis.
- Updated the blueprint theorem label to `thm:zgauge_equiv_periodicFT_irreducible_form` and revised the corresponding prose in `blueprint/src/chapter/ch22_periodic_ft.tex` to make the irreducible-form restriction visible to readers.
- Proof body is unchanged (`hFT hC hBlock hSame`).
- **No compatibility alias is provided.** The old name misleadingly encoded the full peripheral equal-case Z-gauge conclusion as the theorem name, obscuring the narrower scope (see [`docs/CONTRIBUTING.md` Section Mathematical-language renames](../blob/main/docs/CONTRIBUTING.md#mathematical-language-renames)).

### Testing
- `lake build TNLean.MPS.Periodic.Symmetry.Theorem41Forward -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- Blueprint sync and prose review scripts pass (`blueprint_lean_sync.py`, `check_reader_facing_prose.py`).
- Builds report only pre-existing warnings (known unfinished periodic Case-3 statement and style warnings in imported files).

---
Addresses #664

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and naming only; mathematical content and proof term are unchanged, with blueprint Lean decl sync updated accordingly.
> 
> **Overview**
> Renames the Lean theorem from `peripheralEqualCaseZGaugeOfSameMPV_of_periodicEqualCaseFT` to **`zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm`** so the name matches what it actually proves (blocked **Z-gauge equivalence** under explicit irreducible-form hypotheses), not the broader **`PeripheralEqualCaseZGaugeOfSameMPV`** Prop.
> 
> The **docstring** now states that this step only applies the periodic equal-case FT and does **not** discharge the full peripheral Z-gauge hypothesis, which omits irreducible form on the blocked root; remaining work is irreducible-form for `blockTensor A p` and blocked-to-root phase distribution.
> 
> **Blueprint** (`ch22_periodic_ft.tex`): theorem label **`thm:zgauge_equiv_periodicFT_irreducible_form`**, title/prose aligned with the narrower scope; `\lean` link updated. **Proof unchanged** (`hFT hC hBlock hSame`); **no** compatibility alias for the old name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed40137b45b6c8e489d4c998733f6c710d55eb7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->