### PR TITLE
feat(Analysis/Entropy): add quantum relative entropy

### DIFF
--- a/TNLean/Analysis/Entropy.lean
+++ b/TNLean/Analysis/Entropy.lean
@@ -20,6 +20,7 @@ the basic quantum entropy infrastructure needed for MPDO / RFP applications.
 ## Main definitions
 
 * `vonNeumannEntropy`: `S(ρ) = ∑ᵢ negMulLog(λᵢ)` where `λᵢ` are eigenvalues
+* `quantumRelativeEntropy`: `D(ρ‖σ) = Re tr(ρ(log ρ - log σ))`
 * `traceA_ABC`, `traceC_ABC`, `traceAC_ABC`: tripartite partial traces
 * `mutualInformation`: `I(A:B) = S(ρ_A) + S(ρ_B) - S(ρ_AB)`
 * `IsSSAEquality`: predicate for equality in strong subadditivity
@@ -142,6 +143,64 @@ theorem vonNeumannEntropy_eq_neg_trace_mul_log
   rw [RCLike.re_eq_complex_re] at htr
   rw [htr, ← Finset.sum_neg_distrib]
   exact Finset.sum_congr rfl fun i _ => by simp only [Real.negMulLog]; ring
+
+open scoped Matrix.Norms.L2Operator in
+/-- **Quantum relative entropy**, in trace-log form.
+
+For matrices `ρ` and `σ` of the same finite dimension, this is the totalized
+trace-log expression
+`D(ρ‖σ) = Re tr(ρ · (log ρ - log σ))`, where the logarithm is `CFC.log`.
+When `ρ` is a density matrix and `σ` is positive definite, this is the usual
+finite-dimensional Umegaki relative entropy.
+
+The definition is total because Mathlib's `CFC.log` is total. The physical
+relative entropy domain is the positive semidefinite / positive definite one;
+outside that domain this declaration is only the algebraic trace-log expression.
+
+Source: standard; blueprint `def:quantum_relative_entropy`. -/
+noncomputable def quantumRelativeEntropy
+    (ρ σ : Matrix n n ℂ) : ℝ :=
+  (Matrix.trace (ρ * (CFC.log ρ - CFC.log σ))).re
+
+open scoped Matrix.Norms.L2Operator in
+/-- The trace-log form of relative entropy split into its two trace terms. -/
+theorem quantumRelativeEntropy_eq_trace_mul_log_sub
+    (ρ σ : Matrix n n ℂ) :
+    quantumRelativeEntropy ρ σ
+      = (Matrix.trace (ρ * CFC.log ρ)).re
+        - (Matrix.trace (ρ * CFC.log σ)).re := by
+  simp [quantumRelativeEntropy, Matrix.mul_sub, Matrix.trace_sub]
+
+open scoped Matrix.Norms.L2Operator in
+/-- A matrix has zero relative entropy with itself. -/
+@[simp] theorem quantumRelativeEntropy_self
+    (ρ : Matrix n n ℂ) :
+    quantumRelativeEntropy ρ ρ = 0 := by
+  simp [quantumRelativeEntropy]
+
+open scoped Matrix.Norms.L2Operator in
+/-- The zero left input has zero trace-log relative entropy. -/
+@[simp] theorem quantumRelativeEntropy_zero_left
+    (σ : Matrix n n ℂ) :
+    quantumRelativeEntropy 0 σ = 0 := by
+  simp [quantumRelativeEntropy]
+
+open scoped Matrix.Norms.L2Operator in
+/-- Relative entropy rewritten using the von Neumann entropy of the first
+argument.
+
+For Hermitian `ρ`,
+`D(ρ‖σ) = -S(ρ) - Re tr(ρ log σ)`. This is the representation used when
+relating the trace-log relative-entropy layer to the eigenvalue definition of
+von Neumann entropy. -/
+theorem quantumRelativeEntropy_eq_neg_entropy_sub_trace_mul_log
+    {ρ σ : Matrix n n ℂ} (hρ : ρ.IsHermitian) :
+    quantumRelativeEntropy ρ σ
+      = -vonNeumannEntropy ρ hρ - (Matrix.trace (ρ * CFC.log σ)).re := by
+  rw [quantumRelativeEntropy_eq_trace_mul_log_sub]
+  have htrace : (Matrix.trace (ρ * CFC.log ρ)).re = -vonNeumannEntropy ρ hρ := by
+    linarith [vonNeumannEntropy_eq_neg_trace_mul_log hρ]
+  rw [htrace]
 
 /-- The von Neumann entropy depends only on the characteristic polynomial: it is
 the `negMulLog`-sum of the (real parts of the) roots of `charpoly`. -/
@@ -337,7 +396,8 @@ theorem vonNeumannEntropy_le_log_rank
   rw [hLHS] at hJensen
   -- `k⁻¹ · S ≤ negMulLog(k⁻¹) = k⁻¹ · log k`, multiply by `k`
   have hrhs : (k : ℝ) * Real.negMulLog ((k : ℝ)⁻¹) = Real.log k := by
-    rw [Real.negMulLog, Real.log_inv, neg_mul_neg, ← mul_assoc, mul_inv_cancel₀ hkR.ne', one_mul]
+    rw [Real.negMulLog, Real.log_inv, neg_mul_neg, ← mul_assoc,
+      mul_inv_cancel₀ hkR.ne', one_mul]
   have hlhs : (k : ℝ) * ((k : ℝ)⁻¹ * vonNeumannEntropy ρ hρ.isHermitian)
       = vonNeumannEntropy ρ hρ.isHermitian := by
     rw [← mul_assoc, mul_inv_cancel₀ hkR.ne', one_mul]

--- a/TNLean/Entropy/StrongSubadditivity.lean
+++ b/TNLean/Entropy/StrongSubadditivity.lean
@@ -47,7 +47,9 @@ Replace the sanctioned axiom `_root_.strong_subadditivity` (in
 `TNLean/Axioms/Entropy.lean`) with a proof along the classical route:
 1. Use `Entropy.quantumRelativeEntropy`, the trace-log relative entropy
    `D(ρ‖σ) = Re tr(ρ(log ρ − log σ))`.
-2. Establish Klein's inequality: `D(ρ‖σ) ≥ 0` for density matrices.
+2. Establish Klein's inequality: `D(ρ‖σ) ≥ 0` for density matrices with
+   positive definite reference state `σ` (and later the usual support condition
+   for singular `σ`).
 3. Lieb's joint concavity of `(A, B) ↦ tr(Kᴴ Aᵗ K B^{1-t})`.
 4. Monotonicity of the relative entropy under partial trace
    (the "data-processing inequality").

--- a/TNLean/Entropy/StrongSubadditivity.lean
+++ b/TNLean/Entropy/StrongSubadditivity.lean
@@ -45,7 +45,8 @@ no duplicate axiomatization of SSA is introduced.
 
 Replace the sanctioned axiom `_root_.strong_subadditivity` (in
 `TNLean/Axioms/Entropy.lean`) with a proof along the classical route:
-1. Define quantum relative entropy `D(ρ‖σ) = tr(ρ(log ρ − log σ))`.
+1. Use `Entropy.quantumRelativeEntropy`, the trace-log relative entropy
+   `D(ρ‖σ) = Re tr(ρ(log ρ − log σ))`.
 2. Establish Klein's inequality: `D(ρ‖σ) ≥ 0` for density matrices.
 3. Lieb's joint concavity of `(A, B) ↦ tr(Kᴴ Aᵗ K B^{1-t})`.
 4. Monotonicity of the relative entropy under partial trace

--- a/TNLean/Entropy/VonNeumann.lean
+++ b/TNLean/Entropy/VonNeumann.lean
@@ -34,6 +34,9 @@ with trivial unfolding `@[simp]` lemmas.
 * `Entropy.vonNeumannEntropy_le_log_dim` — alias of
   `_root_.vonNeumannEntropy_le_log_dim`: `S(ρ) ≤ log D` for density
   matrices on a `D`-dimensional system.
+* `Entropy.quantumRelativeEntropy` — alias of
+  `_root_.quantumRelativeEntropy`, the trace-log relative entropy
+  `D(ρ‖σ) = Re tr(ρ(log ρ - log σ))`.
 
 The aliases are definitionally equal to their `_root_` targets, so the
 two spellings are interchangeable in tactics; in particular no
@@ -74,5 +77,28 @@ alias vonNeumannEntropy_nonneg := _root_.vonNeumannEntropy_nonneg
 `D`-dimensional system, namespaced alias of
 `_root_.vonNeumannEntropy_le_log_dim`. -/
 alias vonNeumannEntropy_le_log_dim := _root_.vonNeumannEntropy_le_log_dim
+
+/-- **Quantum relative entropy**, namespaced alias of
+`_root_.quantumRelativeEntropy`. -/
+noncomputable alias quantumRelativeEntropy := _root_.quantumRelativeEntropy
+
+/-- Trace-log splitting formula for quantum relative entropy, namespaced alias
+of `_root_.quantumRelativeEntropy_eq_trace_mul_log_sub`. -/
+alias quantumRelativeEntropy_eq_trace_mul_log_sub :=
+  _root_.quantumRelativeEntropy_eq_trace_mul_log_sub
+
+/-- A matrix has zero relative entropy with itself, namespaced alias of
+`_root_.quantumRelativeEntropy_self`. -/
+alias quantumRelativeEntropy_self := _root_.quantumRelativeEntropy_self
+
+/-- The zero left input has zero trace-log relative entropy, namespaced alias of
+`_root_.quantumRelativeEntropy_zero_left`. -/
+alias quantumRelativeEntropy_zero_left := _root_.quantumRelativeEntropy_zero_left
+
+/-- Relative entropy rewritten using the von Neumann entropy of the first
+argument, namespaced alias of
+`_root_.quantumRelativeEntropy_eq_neg_entropy_sub_trace_mul_log`. -/
+alias quantumRelativeEntropy_eq_neg_entropy_sub_trace_mul_log :=
+  _root_.quantumRelativeEntropy_eq_neg_entropy_sub_trace_mul_log
 
 end Entropy

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -241,7 +241,8 @@ finite-dimensional quantum systems.
     \label{thm:quantum_relative_entropy_entropy_form}
     \lean{quantumRelativeEntropy_eq_neg_entropy_sub_trace_mul_log}
     \leanok
-    \uses{def:quantum_relative_entropy, thm:entropy_eq_neg_trace_mul_log}
+    \uses{def:quantum_relative_entropy, lem:quantum_relative_entropy_trace_split,
+        thm:entropy_eq_neg_trace_mul_log}
     If $\rho$ is Hermitian, then
     \[
         D(\rho\Vert\sigma)
@@ -250,9 +251,17 @@ finite-dimensional quantum systems.
 \end{theorem}
 
 \begin{proof}\leanok
-    Split the definition of $D(\rho\Vert\sigma)$ into its two trace terms and
-    replace the first term by $-S(\rho)$ using the trace-logarithm form of the
-    von Neumann entropy.
+    Apply Lemma~\ref{lem:quantum_relative_entropy_trace_split} to write
+    \[
+        D(\rho\Vert\sigma)
+            = \operatorname{Re}\operatorname{tr}(\rho\log\rho)
+              - \operatorname{Re}\operatorname{tr}(\rho\log\sigma).
+    \]
+    The trace-logarithm identity
+    \[
+        \operatorname{Re}\operatorname{tr}(\rho\log\rho)=-S(\rho)
+    \]
+    then gives the result.
 \end{proof}
 
 \begin{theorem}[Entropy is invariant under reindexing]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -177,6 +177,84 @@ finite-dimensional quantum systems.
     standard expression $S(\rho) = -\operatorname{tr}(\rho\log\rho)$.
 \end{remark}
 
+\begin{definition}[Quantum relative entropy]\label{def:quantum_relative_entropy}
+    \lean{quantumRelativeEntropy}
+    \leanok
+    For matrices $\rho,\sigma\in \MN{D}$, define the trace-log expression
+    \[
+        D(\rho\Vert\sigma)
+            = \operatorname{Re}\operatorname{tr}\bigl(\rho(\log\rho-\log\sigma)\bigr).
+    \]
+    On the physical domain where $\rho$ is a density matrix and $\sigma$ is
+    positive definite, this is the Umegaki relative entropy.
+\end{definition}
+
+\begin{lemma}[Trace-log splitting for relative entropy]
+    \label{lem:quantum_relative_entropy_trace_split}
+    \lean{quantumRelativeEntropy_eq_trace_mul_log_sub}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    For matrices $\rho,\sigma\in \MN{D}$,
+    \[
+        D(\rho\Vert\sigma)
+            = \operatorname{Re}\operatorname{tr}(\rho\log\rho)
+              - \operatorname{Re}\operatorname{tr}(\rho\log\sigma).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Expand the matrix product over the difference $\log\rho-\log\sigma$ and use
+    linearity of the trace and of the real part.
+\end{proof}
+
+\begin{lemma}[Relative entropy with identical arguments]
+    \label{lem:quantum_relative_entropy_self}
+    \lean{quantumRelativeEntropy_self}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    For every matrix $\rho\in \MN{D}$,
+    \[
+        D(\rho\Vert\rho)=0.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The logarithmic difference $\log\rho-\log\rho$ vanishes.
+\end{proof}
+
+\begin{lemma}[Relative entropy with zero first argument]
+    \label{lem:quantum_relative_entropy_zero_left}
+    \lean{quantumRelativeEntropy_zero_left}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    For every matrix $\sigma\in \MN{D}$,
+    \[
+        D(0\Vert\sigma)=0.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The trace-log expression is multiplied on the left by the zero matrix.
+\end{proof}
+
+\begin{theorem}[Relative entropy in entropy form]
+    \label{thm:quantum_relative_entropy_entropy_form}
+    \lean{quantumRelativeEntropy_eq_neg_entropy_sub_trace_mul_log}
+    \leanok
+    \uses{def:quantum_relative_entropy, thm:entropy_eq_neg_trace_mul_log}
+    If $\rho$ is Hermitian, then
+    \[
+        D(\rho\Vert\sigma)
+            = -S(\rho)-\operatorname{Re}\operatorname{tr}(\rho\log\sigma).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Split the definition of $D(\rho\Vert\sigma)$ into its two trace terms and
+    replace the first term by $-S(\rho)$ using the trace-logarithm form of the
+    von Neumann entropy.
+\end{proof}
+
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}
     \lean{vonNeumannEntropy_submatrix_equiv}
@@ -398,7 +476,8 @@ decomposition, and mutual information. These statements are cited from the
 standard entropy literature and supply the entropy-theoretic input for the
 later MPDO arguments.
 
-\begin{definition}[Entropy formulation of von Neumann entropy]\label{def:entropy_von_neumann_entropy}
+\begin{definition}[Entropy formulation of von Neumann entropy]
+    \label{def:entropy_von_neumann_entropy}
     \lean{Entropy.vonNeumannEntropy}
     \leanok
     \uses{def:von_neumann_entropy}


### PR DESCRIPTION
### Motivation

- Issue #784 requires a von Neumann entropy and SSA core beyond the existing axiomatised bootstrap (#613); the quantum relative entropy $D(\rho \| \sigma) = \operatorname{Re} \operatorname{tr}(\rho(\log \rho - \log \sigma))$ is a prerequisite for the Klein inequality, data-processing, and strong-subadditivity route.
- Continues the entropy infrastructure tracked in #239.

### Description

- `TNLean/Analysis/Entropy.lean`: introduces `quantumRelativeEntropy` as the finite-dimensional trace-log expression $\operatorname{Re}\operatorname{tr}(\rho(\log\rho - \log\sigma))$, totalized via `CFC.log`; adds lemmas `quantumRelativeEntropy_eq_trace_mul_log_sub`, `quantumRelativeEntropy_self`, `quantumRelativeEntropy_zero_left`, and `quantumRelativeEntropy_eq_neg_entropy_sub_trace_mul_log` (using the bridge `vonNeumannEntropy_eq_neg_trace_mul_log`).
- `TNLean/Entropy/VonNeumann.lean`: exposes the new declarations through the `Entropy` namespace.
- `TNLean/Entropy/StrongSubadditivity.lean`: minor update for the new API.
- `blueprint/src/chapter/ch19_entropy.tex`: adds blueprint entries with `\lean{...}` and `\leanok` tags for the new declarations.
- This PR does not prove Klein's inequality, data processing, or strong subadditivity, and does not remove any sanctioned axiom by itself.

### Testing

- `lake build TNLean.Analysis.Entropy`
- `lake build TNLean.Entropy.VonNeumann`
- `lake build TNLean.Entropy.StrongSubadditivity`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- Added-line proof-integrity scan: no `sorry`, `admit`, `native_decide`, `unsafeCast`, or `axiom`.

---
Addresses #784

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive entropy infrastructure (definitions and elementary lemmas); sanctioned SSA axioms and proof obligations are unchanged.
> 
> **Overview**
> Adds **quantum relative entropy** \(D(\rho\Vert\sigma) = \operatorname{Re}\operatorname{tr}(\rho(\log\rho-\log\sigma))\) as a totalized trace-log definition using `CFC.log`, plus lemmas for trace splitting, \(D(\rho\Vert\rho)=0\), \(D(0\Vert\sigma)=0\), and rewriting \(D\) as \(-S(\rho)-\operatorname{Re}\operatorname{tr}(\rho\log\sigma)\) for Hermitian \(\rho\) via the existing von Neumann trace-log bridge.
> 
> The `Entropy` namespace re-exports the definition and lemmas; the strong-subadditivity module TODO now points at `Entropy.quantumRelativeEntropy` as step one toward Klein/Lieb instead of an informal definition. Blueprint chapter 19 documents the new declarations with `\leanok` tags. **No** Klein inequality, data processing, or axiom removal in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a866168a9595e8bae6c5d96be34ddbb35db020. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->