### PR TITLE
feat(MPS/RFP): add unit pair-index structural form

### DIFF
--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -443,7 +443,8 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
         simp [L, Matrix.mul_assoc]
 
 /-- **Unit pair-index form of Lemma B.1.**  This is the same structural
-decomposition as `rfp_nt_structural_full`, rewritten in the source convention
+decomposition as the isometry theorem above
+(Theorem~\ref{thm:rfp_nt_structural_full}), rewritten in the source convention
 for the pair-index isometry equation
 \[
   \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
@@ -452,11 +453,16 @@ for the pair-index isometry equation
 \]
 
 The theorem is only a normalization comparison: the diagonal factor is rescaled by
-\(D^{-1/2}\), and the residual tensor by \(D^{1/2}\).  It does not prove the
-source trace condition \(\operatorname{tr}\Lambda=1\), nor the cross-block
-\(\delta_{j,j'}\) orthogonality in arXiv:1606.00608, equation
-`eq:III_isometry`; those are recorded in
-`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+\(D^{-1/2}\), and the residual tensor by \(D^{1/2}\).
+
+**Scope restriction (source isometry):** Corollary III.cor3 and the joint
+isometry equation in arXiv:1606.00608, lines 550--554, also include the source
+trace condition \(\operatorname{tr}\Lambda=1\) and cross-block
+\(\delta_{j,j'}\) orthogonality.  Those conclusions are not proved here; this
+theorem only compares the scalar normalization for a single block.  This
+restriction is recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
+Elimination: prove a whole-family isometry form with trace-normalized diagonal
+weights and orthogonality between distinct blocks. -/
 theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
@@ -469,7 +475,7 @@ theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
           if p = q then 1 else 0) ∧
       (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
   classical
-  obtain ⟨X, Λ₀, U₀, hX_det, hΛ₀_pos, hU₀_left, hU₀_pair, hA_eq⟩ :=
+  obtain ⟨X, Λ₀, U₀, hX_det, hΛ₀_pos, _, hU₀_pair, hA_eq⟩ :=
     rfp_nt_structural_full A hNT hRFP hLeft
   let sR : ℝ := Real.sqrt (D : ℝ)
   let s : ℂ := (sR : ℂ)
@@ -590,11 +596,20 @@ theorem rfp_nt_structural_full_blocks {r : ℕ} {dim : Fin r → ℕ}
       (∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) * U i * X⁻¹) :=
   fun k => rfp_nt_structural_full (A k) (hNT k) (hRFP k) (hLeft k)
 
-/-- Per-block unit pair-index version of `rfp_nt_structural_full_blocks`.
+/-- Per-block unit pair-index form of the isometry canonical form
+(Theorem~\ref{thm:rfp_nt_structural_full_blocks}).
 
-This only changes the pair-index normalization convention; it does not add the
-trace-normalization of the diagonal factors or the cross-block orthogonality
-required by the source theorem. -/
+This only changes the pair-index normalization convention.  In this convention
+the contracted identity is \(D_k I\), not \(I\), so the conclusion records the
+unit pair-index equation and the decomposition but not a contracted-isometry
+equation.
+
+**Scope restriction (source isometry):** Corollary III.cor3 and the joint
+isometry equation in arXiv:1606.00608, lines 550--554, also require
+\(\operatorname{tr}\Lambda_k=1\) and cross-block \(\delta_{j,j'}\)
+orthogonality.  This theorem is only the per-block normalization comparison;
+the full source assertion is recorded as a remaining gap in
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
 theorem rfp_nt_structural_full_blocks_unit_pair {r : ℕ} {dim : Fin r → ℕ}
     [∀ k, NeZero (dim k)] (A : (k : Fin r) → MPSTensor d (dim k))
     (hNT : ∀ k, IsNormal (A k)) (hRFP : ∀ k, IsRFP (A k))

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -442,6 +442,117 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
       _ = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹ := by
         simp [L, Matrix.mul_assoc]
 
+/-- **Unit pair-index form of Lemma B.1.**  This is the same structural
+decomposition as `rfp_nt_structural_full`, rewritten in the source convention
+for the pair-index isometry equation
+\[
+  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+  =
+  \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+\]
+
+The theorem is only a normalization comparison: the diagonal factor is rescaled by
+\(D^{-1/2}\), and the residual tensor by \(D^{1/2}\).  It does not prove the
+source trace condition \(\operatorname{tr}\Lambda=1\), nor the cross-block
+\(\delta_{j,j'}\) orthogonality in arXiv:1606.00608, equation
+`eq:III_isometry`; those are recorded in
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
+    (hNT : IsNormal A) (hRFP : IsRFP A)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ)
+      (U : MPSTensor d D),
+      X.det ≠ 0 ∧
+      (∀ k, 0 < Λ k) ∧
+      (∀ p q : Fin D × Fin D,
+        ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+          if p = q then 1 else 0) ∧
+      (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
+  classical
+  obtain ⟨X, Λ₀, U₀, hX_det, hΛ₀_pos, hU₀_left, hU₀_pair, hA_eq⟩ :=
+    rfp_nt_structural_full A hNT hRFP hLeft
+  let sR : ℝ := Real.sqrt (D : ℝ)
+  let s : ℂ := (sR : ℂ)
+  let Λ : Fin D → ℝ := fun k => Λ₀ k / sR
+  let U : MPSTensor d D := fun i => s • U₀ i
+  have hDpos_nat : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
+  have hDpos : 0 < (D : ℝ) := by
+    exact_mod_cast hDpos_nat
+  have hsR_ne : sR ≠ 0 := by
+    exact Real.sqrt_ne_zero'.2 hDpos
+  have hsR_pos : 0 < sR := by
+    exact Real.sqrt_pos.2 hDpos
+  have hs_ne : s ≠ 0 := by
+    simpa [s] using Complex.ofReal_ne_zero.mpr hsR_ne
+  have hs_star : star s * s = (D : ℂ) := by
+    have hs_sq : sR * sR = (D : ℝ) := by
+      have hnn : 0 ≤ (D : ℝ) := by positivity
+      change Real.sqrt (D : ℝ) * Real.sqrt (D : ℝ) = (D : ℝ)
+      rw [← pow_two]
+      exact Real.sq_sqrt hnn
+    have hs_sq_c := congrArg (fun x : ℝ => (x : ℂ)) hs_sq
+    simpa [s, Complex.ofReal_mul] using hs_sq_c
+  have hD_ne : (D : ℂ) ≠ 0 := by
+    exact_mod_cast (NeZero.ne D)
+  have hdiag :
+      Matrix.diagonal (fun k => (Λ k : ℂ)) =
+        s⁻¹ • Matrix.diagonal (fun k => (Λ₀ k : ℂ)) := by
+    ext a b
+    by_cases hab : a = b
+    · subst hab
+      calc
+        Matrix.diagonal (fun k => (Λ k : ℂ)) a a = ((Λ₀ a / sR : ℝ) : ℂ) := by
+            simp [Λ, Matrix.diagonal]
+        _ = s⁻¹ * (Λ₀ a : ℂ) := by
+            rw [Complex.ofReal_div]
+            simp [s, div_eq_mul_inv, mul_comm]
+        _ = (s⁻¹ • Matrix.diagonal (fun k => (Λ₀ k : ℂ))) a a := by
+            simp [Matrix.diagonal]
+    · simp [Matrix.diagonal, hab]
+  refine ⟨X, Λ, U, hX_det, ?_, ?_, ?_⟩
+  · intro k
+    exact div_pos (hΛ₀_pos k) hsR_pos
+  · intro p q
+    calc
+      ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2
+          = ∑ i : Fin d,
+              (star s * s) * (star (U₀ i p.1 p.2) * U₀ i q.1 q.2) := by
+              refine Finset.sum_congr rfl ?_
+              intro i _
+              simp [U, s, mul_assoc, mul_left_comm, mul_comm]
+      _ = (star s * s) *
+            ∑ i : Fin d, star (U₀ i p.1 p.2) * U₀ i q.1 q.2 := by
+              rw [Finset.mul_sum]
+      _ = (D : ℂ) * (if p = q then (D : ℂ)⁻¹ else 0) := by
+              rw [hs_star, hU₀_pair p q]
+      _ = if p = q then 1 else 0 := by
+              by_cases hpq : p = q
+              · simp [hpq, hD_ne]
+              · simp [hpq]
+  · intro i
+    rw [hA_eq i]
+    let L : Matrix (Fin D) (Fin D) ℂ := Matrix.diagonal (fun k => (Λ k : ℂ))
+    have hdiag' : Matrix.diagonal (fun k => (Λ₀ k : ℂ)) = s • L := by
+      calc
+        Matrix.diagonal (fun k => (Λ₀ k : ℂ)) =
+            (s * s⁻¹) • Matrix.diagonal (fun k => (Λ₀ k : ℂ)) := by
+            simp [hs_ne]
+        _ = s • (s⁻¹ • Matrix.diagonal (fun k => (Λ₀ k : ℂ))) := by
+            simp [smul_smul]
+        _ = s • L := by
+            rw [← hdiag]
+    have hmove : (s • L) * U₀ i = L * (s • U₀ i) := by
+      rw [Matrix.smul_mul, Matrix.mul_smul]
+    calc
+      X * Matrix.diagonal (fun k => (Λ₀ k : ℂ)) * U₀ i * X⁻¹
+          = X * (s • L) * U₀ i * X⁻¹ := by
+              rw [hdiag']
+      _ = X * L * (s • U₀ i) * X⁻¹ := by
+          rw [Matrix.mul_assoc X (s • L) (U₀ i), hmove,
+            ← Matrix.mul_assoc X L (s • U₀ i)]
+      _ = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹ := by
+          simp [L, U]
+
 /-- **Per-block isometry canonical form.** When each block of a multi-block tensor
 is a normal, left-canonical renormalization fixed point, that block admits an
 isometry decomposition A_k^i = X diag(Λ) U^i X⁻¹ with X invertible, Λ positive,
@@ -478,5 +589,23 @@ theorem rfp_nt_structural_full_blocks {r : ℕ} {dim : Fin r → ℕ}
           if p = q then (dim k : ℂ)⁻¹ else 0) ∧
       (∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) * U i * X⁻¹) :=
   fun k => rfp_nt_structural_full (A k) (hNT k) (hRFP k) (hLeft k)
+
+/-- Per-block unit pair-index version of `rfp_nt_structural_full_blocks`.
+
+This only changes the pair-index normalization convention; it does not add the
+trace-normalization of the diagonal factors or the cross-block orthogonality
+required by the source theorem. -/
+theorem rfp_nt_structural_full_blocks_unit_pair {r : ℕ} {dim : Fin r → ℕ}
+    [∀ k, NeZero (dim k)] (A : (k : Fin r) → MPSTensor d (dim k))
+    (hNT : ∀ k, IsNormal (A k)) (hRFP : ∀ k, IsRFP (A k))
+    (hLeft : ∀ k, ∑ i : Fin d, (A k i)ᴴ * (A k i) = 1) :
+    ∀ k, ∃ (X : Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+      (Λ : Fin (dim k) → ℝ) (U : MPSTensor d (dim k)),
+      X.det ≠ 0 ∧ (∀ j, 0 < Λ j) ∧
+      (∀ p q : Fin (dim k) × Fin (dim k),
+        ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+          if p = q then 1 else 0) ∧
+      (∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) * U i * X⁻¹) :=
+  fun k => rfp_nt_structural_full_unit_pair (A k) (hNT k) (hRFP k) (hLeft k)
 
 end MPSTensor

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -506,10 +506,22 @@ and rates for the single-tensor transfer map $\E_A$.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:rfp_nt_structural_full}
-    Apply Theorem~\ref{thm:rfp_nt_structural_full}, then replace
-    $U^i$ by $\sqrt D\,U^i$ and $\Lambda$ by $D^{-1/2}\Lambda$.  The product
-    $\Lambda U^i$ is unchanged, while the pair-index equation loses the factor
-    $D^{-1}$.
+    Apply Theorem~\ref{thm:rfp_nt_structural_full}, then set
+    $\widetilde U^i=\sqrt D\,U^i$ and
+    $\widetilde\Lambda=D^{-1/2}\Lambda$.  Since
+    $\widetilde\Lambda\widetilde U^i=\Lambda U^i$, the decomposition
+    $A^i=X\widetilde\Lambda\widetilde U^iX^{-1}$ still holds.  The
+    pair-index contraction becomes
+    \[
+        \sum_i
+        \overline{(\widetilde U^i)_{\alpha,\beta}}\,
+        (\widetilde U^i)_{\alpha',\beta'}
+        =
+        D\cdot D^{-1}
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}
+        =
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
+    \]
 \end{proof}
 
 \begin{theorem}[Per-block isometry canonical form]%

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -486,6 +486,32 @@ and rates for the single-tensor transfer map $\E_A$.
     normalization contributes the factor $D^{-1}$ in the pair-index equation.
 \end{proof}
 
+\begin{theorem}[Unit pair-index form for RFP tensors]%
+    \label{thm:rfp_nt_structural_full_unit_pair}
+    \lean{MPSTensor.rfp_nt_structural_full_unit_pair}
+    \leanok
+    \uses{thm:rfp_nt_structural_full}
+    A normal tensor $A$ in canonical form~II that is a renormalization fixed
+    point admits a decomposition $A^i = X \Lambda U^i X^{-1}$, where
+    $\Lambda$ is diagonal positive and
+    \[
+        \sum_i \overline{(U^i)_{\alpha,\beta}}\,
+        (U^i)_{\alpha',\beta'}
+        =
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
+    \]
+    This is the unit pair-index convention of
+    \cite[Section~3]{Cirac2016MPDO_arXiv}.  The statement still does not impose
+    the trace-normalization $\tr(\Lambda)=1$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:rfp_nt_structural_full}
+    Apply Theorem~\ref{thm:rfp_nt_structural_full}, then replace
+    $U^i$ by $\sqrt D\,U^i$ and $\Lambda$ by $D^{-1/2}\Lambda$.  The product
+    $\Lambda U^i$ is unchanged, while the pair-index equation loses the factor
+    $D^{-1}$.
+\end{proof}
+
 \begin{theorem}[Per-block isometry canonical form]%
     \label{thm:rfp_nt_structural_full_blocks}
     \lean{MPSTensor.rfp_nt_structural_full_blocks}
@@ -531,6 +557,30 @@ and rates for the single-tensor transfer map $\E_A$.
 \begin{proof}\leanok
     \uses{thm:rfp_nt_structural_full}
     Apply Theorem~\ref{thm:rfp_nt_structural_full} to each block.
+\end{proof}
+
+\begin{theorem}[Per-block unit pair-index form]%
+    \label{thm:rfp_nt_structural_full_blocks_unit_pair}
+    \lean{MPSTensor.rfp_nt_structural_full_blocks_unit_pair}
+    \leanok
+    \uses{thm:rfp_nt_structural_full_unit_pair}
+    Under the hypotheses of
+    Theorem~\ref{thm:rfp_nt_structural_full_blocks}, each block admits a
+    decomposition $A_k^i = X_k \Lambda_k U_k^i X_k^{-1}$ with
+    $\Lambda_k$ diagonal positive and
+    \[
+        \sum_i \overline{(U_k^i)_{\alpha,\beta}}\,
+        (U_k^i)_{\alpha',\beta'}
+        =
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
+    \]
+    This is a blockwise unit pair-index comparison. It still does not impose
+    the source trace-normalization of $\Lambda_k$ or the cross-block
+    orthogonality equations for distinct blocks.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:rfp_nt_structural_full_unit_pair}
+    Apply Theorem~\ref{thm:rfp_nt_structural_full_unit_pair} to each block.
 \end{proof}
 
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -139,10 +139,25 @@ content that the block-pair spaces fit orthogonally inside the physical space.
 The current theorem is a scope restriction.  It is a useful per-block
 consequence of the single-block RFP isometry form, but it is not the full
 isometry assertion of Corollary~III.cor3.  The formal development now exposes
-both the contracted per-block identity $\sum_i (U_k^i)^\dagger U_k^i=I$ and the
-diagonal pair-index orthonormality in the unit source convention.  It still
-omits the source trace-normalization and the cross-block $\delta_{j,j'}$
-orthogonality equations.
+two normalization conventions.  In the $D_k^{-1/2}$ convention the residual
+tensor satisfies the contracted per-block identity
+\[
+  \sum_i (U_k^i)^\dagger U_k^i=I
+\]
+and its pair-index equation has right-hand side
+$D_k^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}$.  In the rescaled
+unit pair-index convention the residual tensor satisfies
+\[
+  \sum_i
+  \overline{(U_k^i)_{\alpha,\beta}}\,
+  (U_k^i)_{\alpha',\beta'}
+  =
+  \delta_{\alpha,\alpha'}\delta_{\beta,\beta'},
+\]
+while the contracted identity is instead
+$\sum_i (U_k^i)^\dagger U_k^i=D_k I$.  Thus the scalar normalization comparison
+is explicit, but the formal statements still omit the source trace-normalization
+and the cross-block $\delta_{j,j'}$ orthogonality equations.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -85,9 +85,27 @@ therefore the compatible pair-index equation is
 The remaining normalization comparison with the source equation
 \eqref{eq:III_isometry} is therefore explicit rather than hidden.
 
+A subsequent comparison theorem rescales the same single-block decomposition by
+$U_k^i\mapsto D_k^{1/2}U_k^i$ and
+$\Lambda_k\mapsto D_k^{-1/2}\Lambda_k$.\footnote{Formal declarations:
+\leanid{MPSTensor.rfp_nt_structural_full_unit_pair} and
+\leanid{MPSTensor.rfp_nt_structural_full_blocks_unit_pair} in
+\doclink{TNLean/MPS/RFP/StructuralFull}.}  This leaves the product
+$\Lambda_k U_k^i$ unchanged and gives the diagonal pair-index equation in the
+source unit convention
+\begin{align}
+  \sum_i
+  \overline{(U_k^i)_{\alpha,\beta}}\,
+  (U_k^i)_{\alpha',\beta'}
+  =
+  \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+\end{align}
+Thus the scalar normalization mismatch is no longer hidden in the formal
+statement: both conventions are available, and their comparison is explicit.
+
 There is still no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus
-the formal theorem records only a separate normalized isometry condition for
-each block; it does not record the cross-block equations
+the formal theorems record only a separate isometry condition for each block;
+they do not record the cross-block equations
 \begin{align}
   \sum_i
   (U_k^i)_{\alpha,\beta}\,
@@ -120,9 +138,9 @@ content that the block-pair spaces fit orthogonally inside the physical space.
 
 The current theorem is a scope restriction.  It is a useful per-block
 consequence of the single-block RFP isometry form, but it is not the full
-isometry assertion of Corollary~III.cor3.  It exposes the contracted
-per-block identity $\sum_i (U_k^i)^\dagger U_k^i=I$ and the diagonal
-pair-index orthonormality in the normalized single-block convention.  It still
+isometry assertion of Corollary~III.cor3.  The formal development now exposes
+both the contracted per-block identity $\sum_i (U_k^i)^\dagger U_k^i=I$ and the
+diagonal pair-index orthonormality in the unit source convention.  It still
 omits the source trace-normalization and the cross-block $\delta_{j,j'}$
 orthogonality equations.
 


### PR DESCRIPTION
### Motivation

- `rfp_nt_structural_full` (arXiv:1606.00608, Appendix B, lines 543-555) carries a `(D : ℂ)⁻¹`-scaled pair-index orthonormality, whereas the source states the unit Kronecker-delta condition. This mismatch is documented in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` and blocks elimination of the `rfp_to_nncph_commute` axiom via the `AppendixBProductPairExtraction` route; see #3372 as a sub-task of #2633.

### Description

- Added `MPSTensor.rfp_nt_structural_full_unit_pair` (`TNLean/MPS/RFP/StructuralFull.lean`): derives from `rfp_nt_structural_full` by rescaling Λ ↦ Λ / √D and U ↦ √D · U, preserving the decomposition A^i = XΛU^iX⁻¹ while expressing the pair-index sum as δ_{α,α'}δ_{β,β'}.
- Added `rfp_nt_structural_full_blocks_unit_pair`: per-block companion theorem.
- Updated `blueprint/src/chapter/ch14_correlations.tex` with matching blueprint entries in Chapter 14.
- Updated `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` to record that the scalar normalization comparison is now explicit; trace normalization (tr Λ = 1) and cross-block orthogonality (arXiv:1606.00608, eq. III_isometry) remain open.
- This PR does not close #3372: the general even-chain product-of-entangled-pairs factorization for `hCore` (N >= 2) is a follow-up.

### Testing

- `lake build TNLean.MPS.RFP.StructuralFull TNLean.MPS.RFP.CommutingBridge`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `git diff --check origin/main...HEAD`
- `rg -n '\bsorry\b|\badmit\b|\bnative_decide\b|\bunsafeCast\b|\baxiom\b' TNLean/MPS/RFP/StructuralFull.lean TNLean/MPS/RFP/CommutingBridge.lean || true`

Refs #3372

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib rescaling proofs and doc/blueprint sync on top of an existing theorem; no runtime or security-sensitive code.
> 
> **Overview**
> Adds **unit pair-index** variants of the RFP structural isometry theorems so the formal statements match the Cirac et al. convention where the pair-index sum equals Kronecker deltas (not scaled by \(D^{-1}\)).
> 
> In Lean, `rfp_nt_structural_full_unit_pair` is proved from `rfp_nt_structural_full` by rescaling \(\Lambda \mapsto \Lambda/\sqrt{D}\) and \(U \mapsto \sqrt{D}\,U\), keeping \(A^i = X\Lambda U^i X^{-1}\) while rewriting the pair-index orthonormality. `rfp_nt_structural_full_blocks_unit_pair` applies the same per block. Chapter 14 blueprint entries and `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` now document both normalization conventions explicitly; **trace normalization** and **cross-block** isometry remain out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bb994966fcf68f8c363bd3d55dc25522ec366c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->