### PR TITLE
doc(MPS/Periodic): align Theorem 4.1 source prose

### DIFF
--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -351,10 +351,10 @@ theorem thm_4_1_p_refinement_forward_witness
 This Prop isolates the existence half of the blocked equal-case argument needed
 for Theorem 4.1: whenever an irreducible-form blocked tensor `C` has the same
 MPV family as the \(p\)-blocked tensor `blockTensor A p`, one can extract a
-periodic `Z`-gauge witness between `C` and `blockTensor A p`.
+periodic \(Z\)-gauge witness between `C` and `blockTensor A p`.
 
 Compared with `PeripheralEqualCasePeriodicFTOfSameMPV`, this does **not** yet
-construct the tensor \(\widetilde A\) from arXiv:1708.00029, lines 760--810.
+construct the tensor \(\widetilde A\) from arXiv:1708.00029, lines 765--810.
 It only asserts the blocked equal-case Fundamental Theorem step producing the
 finite-order \(Z\)-factor. -/
 def PeripheralEqualCaseZGaugeOfSameMPV (d D p : ℕ) : Prop :=
@@ -363,10 +363,10 @@ def PeripheralEqualCaseZGaugeOfSameMPV (d D p : ℕ) : Prop :=
     SameMPV C (blockTensor A p) →
       ∃ m : ℕ, 0 < m ∧ ZGaugeEquiv m C (blockTensor A p)
 
-/-- **Scope-restricted blocked `Z`-gauge extraction from the periodic equal-case FT.**
+/-- **Scope-restricted blocked \(Z\)-gauge extraction from the periodic equal-case FT.**
 
 Applying the periodic equal-case Fundamental Theorem at the blocked physical
-dimension `blockPhysDim d p` gives the blocked `Z`-gauge once both tensors are
+dimension `blockPhysDim d p` gives the blocked \(Z\)-gauge once both tensors are
 already known to be in irreducible form. The irreducible-form hypothesis for
 the \(p\)-blocked tensor is an explicit input here; it is not obtained from
 equality of MPV families.
@@ -387,19 +387,21 @@ theorem zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm
     ∃ m : ℕ, 0 < m ∧ ZGaugeEquiv m C (blockTensor A p) :=
   hFT hC hBlock hSame
 
-/-- **Construction of \(\widetilde A\) from a periodic `Z`-gauge witness.**
+/-- **Construction of \(\widetilde A\) from a periodic \(Z\)-gauge witness.**
 
 This Prop isolates the second half of the blocked equal-case argument: once a
-blocked tensor `C` is related to `blockTensor A p` by a periodic `Z`-gauge,
+blocked tensor `C` is related to `blockTensor A p` by a periodic \(Z\)-gauge,
 one can distribute the scalar factors \(c_{j,\alpha}\) across the cyclic
 sectors of `A`, producing a left-canonical tensor whose \(p\)-blocked transfer
 map equals that of `C`.
 
-In the paper this is arXiv:1708.00029, lines 765--810: define
+In the irreducible-form subcase treated in arXiv:1708.00029, lines 765--810, define
 \(A'_j{}^i = \sum_u d_{j,u} P_{j,u} A_j^i\), obtain
 \(A'^{(p)} = Z A^{(p)}\), and then set
 \(\widetilde A = U^\dagger A' U\). The witness called `A'` below is this final
-tensor \(\widetilde A\). -/
+tensor \(\widetilde A\). The formal statement keeps this construction as a
+conditional input for arbitrary `A`; it does not assert the irreducible block
+data of `A` as hypotheses. -/
 def PeripheralEqualCaseRootFromZGauge (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D} {m : ℕ},
     IsIrreducibleForm C →
@@ -434,14 +436,14 @@ def PeripheralEqualCasePeriodicFTOfSameMPV (d D p : ℕ) : Prop :=
 
 /-- **From \(Z\)-gauge extraction to the \(\widetilde A\) construction.**
 
-If we can first extract a blocked periodic `Z`-gauge from
+If we can first extract a blocked periodic \(Z\)-gauge from
 `SameMPV C (blockTensor A p)` and then carry out the construction of
 \(\widetilde A\) from the corresponding scalars \(c_{j,\alpha}\), then the
 continuation hypothesis
 `PeripheralEqualCasePeriodicFTOfSameMPV` holds.
 
 This splits the blocked equal-case part of the forward proof into two explicit
-obligations: the equal-case `Z`-gauge existence step and the construction of
+obligations: the equal-case \(Z\)-gauge existence step and the construction of
 \(\widetilde A\) described in arXiv:1708.00029, lines 765--810. -/
 theorem peripheralEqualCase_periodicFT_of_sameMPV
     (hZGauge : PeripheralEqualCaseZGaugeOfSameMPV d D p)
@@ -468,7 +470,7 @@ first stage, giving `E_C = E_B`, `SameMPV C (blockTensor A p)`, and preserving
 irreducible form II when `B` already has it. The periodic equal-case
 Fundamental Theorem (source theorem `thm:bdequal`, arXiv:1708.00029,
 lines 643--656, available here as the hypothesis `PeriodicEqualCaseFT`) then
-supplies a `Z`-gauge relation between `C` and `blockTensor A p`. The remaining
+supplies a \(Z\)-gauge relation between `C` and `blockTensor A p`. The remaining
 source step is the construction of \(A'_j\) and
 \(\widetilde A=U^\dagger A' U\) from the scalars \(c_{j,\alpha}\) in
 lines 765--810. The theorem

--- a/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
+++ b/TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean
@@ -7,8 +7,9 @@ import TNLean.MPS.Periodic.Symmetry.Theorem41Defs
 /-!
 # Theorem 4.1, forward direction
 
-This module contains the forward half of arXiv:1708.00029, Theorem 4.1, together
-with the formal pullback tensor \(C\) introduced in lines 735--743 of the paper.
+This module contains the forward half of arXiv:1708.00029, Theorem 4.1,
+together with the tensor \(C\) defined from the refinement isometry \(W\) in
+lines 735--743 of the paper.
 -/
 
 open scoped Matrix BigOperators
@@ -24,7 +25,7 @@ variable {d D : ℕ}
 /-- **Rectangular Kraus isometry mixing.**
 
 For a (possibly rectangular) isometry `W : Fin m → Fin d` with `Wᴴ · W = 1`,
-the `W`-pullback family `C τ := ∑_σ W(τ, σ) · B σ` has the same transfer map
+the family `C τ := ∑_σ W(τ, σ) · B σ` has the same transfer map
 as `B`. This is an adapter from
 `kraus_same_map_of_isometry_combination` to the `MPSTensor.transferMap` interface. -/
 theorem transferMap_kraus_isometry
@@ -37,7 +38,7 @@ theorem transferMap_kraus_isometry
       (K := fun τ : Fin m => ∑ σ : Fin d, W τ σ • B σ)
       (K' := B) W hW (fun _ => rfl) X
 
-/-- Evaluation of a `W`-pulled-back tensor on a blocked word is a `W`-weighted sum
+/-- Evaluation of the tensor \(C\) defined from \(W\) on a blocked word is a \(W\)-weighted sum
 of evaluations of the original tensor.
 
 If `C τ = ∑_σ W(τ, σ) • B σ` is the isometric mixing of an MPS tensor
@@ -47,7 +48,7 @@ every `τ : Fin N → Fin m`,
 
 This is the coefficient-expansion identity used in both directions of Theorem 4.1:
 in the forward direction it rewrites a refinement witness as `SameMPV` for the
-`W`-pullback tensor, and in the reverse direction it expands the blocked witness
+tensor \(C\), and in the reverse direction it expands the blocked witness
 produced by Wolf Theorem 2.18. -/
 theorem evalWord_sum_smul_ofFn
     {m : ℕ} (B : MPSTensor d D) (W : Matrix (Fin m) (Fin d) ℂ) :
@@ -266,9 +267,9 @@ noncomputable def isIrreducibleForm_kraus_isometry
     intro N τ
     exact (hPullbackSame N τ).trans (hBlocksSame N τ)
 
-/-- **Pullback tensor in the forward proof of Theorem 4.1.**
+/-- **The tensor \(C\) in the forward proof of Theorem 4.1.**
 
-From a `p`-refinement witness `(A, W)` for `B`, the `W`-pullback tensor
+From a `p`-refinement witness `(A, W)` for `B`, the tensor
 `C τ := ∑_σ W(τ, σ) • B σ` has the same transfer map as `B` and the same MPV
 family as `blockTensor A p`.
 
@@ -299,9 +300,9 @@ theorem pRefinementCanonicalization_pullback
     _ = mpv (blockTensor A p) τ := by
           simpa [mpv_eq] using (hCoeff N τ).symm
 
-/-- **The pullback tensor is still in irreducible form II.**
+/-- **The tensor \(C\) is still in irreducible form II.**
 
-If the refined tensor `B` is already in irreducible form II, then the pullback
+If the refined tensor `B` is already in irreducible form II, then the tensor
 `C τ := ∑_σ W(τ, σ) • B σ` coming from a `p`-refinement witness is again in
 irreducible form II, has the same transfer map as `B`, and has the same MPV
 family as `blockTensor A p`. This formalizes the sentence in arXiv:1708.00029,
@@ -345,16 +346,17 @@ theorem thm_4_1_p_refinement_forward_witness
   ⟨transferMap A, transferMap_isChannel A hA_norm, by
     rw [hTransferEq, transferMap_blockTensor]⟩
 
-/-- **Blocked Z-gauge extraction for the periodic equal-case stage.**
+/-- **Blocked \(Z\)-gauge extraction for the periodic equal-case step.**
 
 This Prop isolates the existence half of the blocked equal-case argument needed
 for Theorem 4.1: whenever an irreducible-form blocked tensor `C` has the same
-MPV family as a blocked root `blockTensor A p`, one can extract a periodic
-`Z`-gauge witness between `C` and `blockTensor A p`.
+MPV family as the \(p\)-blocked tensor `blockTensor A p`, one can extract a
+periodic `Z`-gauge witness between `C` and `blockTensor A p`.
 
 Compared with `PeripheralEqualCasePeriodicFTOfSameMPV`, this does **not** yet
-recover a left-canonical root. It only asserts the blocked equal-case
-Fundamental Theorem / Z-phase existence step. -/
+construct the tensor \(\widetilde A\) from arXiv:1708.00029, lines 760--810.
+It only asserts the blocked equal-case Fundamental Theorem step producing the
+finite-order \(Z\)-factor. -/
 def PeripheralEqualCaseZGaugeOfSameMPV (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D},
     IsIrreducibleForm C →
@@ -366,15 +368,16 @@ def PeripheralEqualCaseZGaugeOfSameMPV (d D p : ℕ) : Prop :=
 Applying the periodic equal-case Fundamental Theorem at the blocked physical
 dimension `blockPhysDim d p` gives the blocked `Z`-gauge once both tensors are
 already known to be in irreducible form. The irreducible-form hypothesis for
-the \(p\)-blocked root is an explicit input here; it is not obtained from
+the \(p\)-blocked tensor is an explicit input here; it is not obtained from
 equality of MPV families.
 
 This theorem is therefore only the equal-case FT application step. It does not
 prove the full `PeripheralEqualCaseZGaugeOfSameMPV` hypothesis, since that
-hypothesis does not assume irreducible form for the blocked root. The remaining
+hypothesis does not assume irreducible form for `blockTensor A p`. The remaining
 canonicalization work is to prove the missing irreducible-form input for the
-blocked root, and then to distribute the resulting blocked `Z`-phase back to a
-left-canonical root. -/
+\(p\)-blocked tensor, and then to carry out the construction of
+\(\widetilde A\) from the matrix \(Z\) and the scalars \(c_{j,\alpha}\) in
+arXiv:1708.00029, lines 765--810. -/
 theorem zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm
     (p : ℕ) (hFT : PeriodicEqualCaseFT (blockPhysDim d p) D)
     {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D}
@@ -384,15 +387,19 @@ theorem zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm
     ∃ m : ℕ, 0 < m ∧ ZGaugeEquiv m C (blockTensor A p) :=
   hFT hC hBlock hSame
 
-/-- **Blocked-to-root reconstruction from a periodic `Z`-gauge witness.**
+/-- **Construction of \(\widetilde A\) from a periodic `Z`-gauge witness.**
 
 This Prop isolates the second half of the blocked equal-case argument: once a
 blocked tensor `C` is related to `blockTensor A p` by a periodic `Z`-gauge,
-one can distribute that blocked phase data across a root tensor `A'` so that
-`A'` is left-canonical and `E_C = E_{A'^{[p]}}`.
+one can distribute the scalar factors \(c_{j,\alpha}\) across the cyclic
+sectors of `A`, producing a left-canonical tensor whose \(p\)-blocked transfer
+map equals that of `C`.
 
-In the paper this is the blocked-to-root phase-distribution step after the
-periodic equal-case Fundamental Theorem. -/
+In the paper this is arXiv:1708.00029, lines 765--810: define
+\(A'_j{}^i = \sum_u d_{j,u} P_{j,u} A_j^i\), obtain
+\(A'^{(p)} = Z A^{(p)}\), and then set
+\(\widetilde A = U^\dagger A' U\). The witness called `A'` below is this final
+tensor \(\widetilde A\). -/
 def PeripheralEqualCaseRootFromZGauge (d D p : ℕ) : Prop :=
   ∀ {A : MPSTensor d D} {C : MPSTensor (blockPhysDim d p) D} {m : ℕ},
     IsIrreducibleForm C →
@@ -402,13 +409,14 @@ def PeripheralEqualCaseRootFromZGauge (d D p : ℕ) : Prop :=
         (∑ i : Fin d, (A' i)ᴴ * A' i = 1) ∧
         transferMap C = transferMap (blockTensor A' p)
 
-/-- **Blocked equal-case root hypothesis for Theorem 4.1.**
+/-- **The \(\widetilde A\) construction after the blocked equal-case step.**
 
 This Prop isolates exactly the remaining forward input after
 `pRefinementCanonicalization_pullback_of_irreducibleForm`: whenever an
-irreducible-form blocked tensor `C` has the same MPV family as a blocked root
-`blockTensor A p`, one can replace `A` by a left-canonical root `A'` with the
-same blocked transfer map, `E_C = E_{A'^{[p]}}`.
+irreducible-form blocked tensor `C` has the same MPV family as the
+\(p\)-blocked tensor `blockTensor A p`, one can construct a left-canonical
+tensor \(\widetilde A\) with the same \(p\)-blocked transfer map,
+`E_C = E_{\widetilde A^{[p]}}`.
 
 In the paper this is the point where the blocked equal-case Fundamental Theorem
 (source theorem `thm:bdequal`, arXiv:1708.00029, lines 643--656) is combined
@@ -424,16 +432,17 @@ def PeripheralEqualCasePeriodicFTOfSameMPV (d D p : ℕ) : Prop :=
         (∑ i : Fin d, (A' i)ᴴ * A' i = 1) ∧
         transferMap C = transferMap (blockTensor A' p)
 
-/-- **Blocked equal-case continuation from Z-gauge extraction and reconstruction.**
+/-- **From \(Z\)-gauge extraction to the \(\widetilde A\) construction.**
 
 If we can first extract a blocked periodic `Z`-gauge from
-`SameMPV C (blockTensor A p)` and then distribute that blocked `Z`-phase back
-to a left-canonical root, then the continuation hypothesis
+`SameMPV C (blockTensor A p)` and then carry out the construction of
+\(\widetilde A\) from the corresponding scalars \(c_{j,\alpha}\), then the
+continuation hypothesis
 `PeripheralEqualCasePeriodicFTOfSameMPV` holds.
 
-This splits the blocked equal-case continuation into two explicit obligations:
-the blocked equal-case `Z`-gauge existence step and the subsequent
-blocked-to-root reconstruction. -/
+This splits the blocked equal-case part of the forward proof into two explicit
+obligations: the equal-case `Z`-gauge existence step and the construction of
+\(\widetilde A\) described in arXiv:1708.00029, lines 765--810. -/
 theorem peripheralEqualCase_periodicFT_of_sameMPV
     (hZGauge : PeripheralEqualCaseZGaugeOfSameMPV d D p)
     (hRoot : PeripheralEqualCaseRootFromZGauge d D p) :
@@ -442,15 +451,15 @@ theorem peripheralEqualCase_periodicFT_of_sameMPV
   obtain ⟨m, hm, hZ⟩ := hZGauge (A := A) (C := C) hC hSame
   exact hRoot (A := A) (C := C) (m := m) hC hm hZ
 
-/-- **Forward root hypothesis for Theorem 4.1.**
+/-- **Forward construction hypothesis for Theorem 4.1.**
 
 This Prop states the analytic content that remains between the
 coefficient-level `IsPRefinable B p` (a trace-level MPV identity) and the
 channel-level conclusion needed to exhibit `E_B` as a `p`-th power: any
-`p`-refinement of `B` can be *canonicalized* to a witness that is both
-left-canonical and produces a matching transfer map under `p`-blocking.
+`p`-refinement of `B` can be replaced by a left-canonical tensor
+\(\widetilde A\) whose \(p\)-blocked transfer map agrees with `E_B`.
 
-In the source proof, this begins with the \(W\)-pullback tensor
+In the source proof, this begins with the tensor \(C\) defined by
 \(C^{i_1,\ldots,i_p}=\sum_i W^{(i_1,\ldots,i_p),i}B^i\)
 from arXiv:1708.00029, lines 735--743. The theorems
 `pRefinementCanonicalization_pullback` and
@@ -460,10 +469,11 @@ irreducible form II when `B` already has it. The periodic equal-case
 Fundamental Theorem (source theorem `thm:bdequal`, arXiv:1708.00029,
 lines 643--656, available here as the hypothesis `PeriodicEqualCaseFT`) then
 supplies a `Z`-gauge relation between `C` and `blockTensor A p`. The remaining
-source step is the distribution of this blocked `Z`-phase across the cyclic
-blocks of `A` in lines 765--810. The theorem
+source step is the construction of \(A'_j\) and
+\(\widetilde A=U^\dagger A' U\) from the scalars \(c_{j,\alpha}\) in
+lines 765--810. The theorem
 `pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV`
-shows that this hypothesis follows from the sharper blocked equal-case root
+shows that this hypothesis follows from the more precise blocked equal-case
 hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
 def PRefinementCanonicalization (d D p : ℕ) : Prop :=
   ∀ {B : MPSTensor d D}, IsIrreducibleForm B → IsPRefinable B p →
@@ -471,13 +481,13 @@ def PRefinementCanonicalization (d D p : ℕ) : Prop :=
       (∑ i : Fin d, (A i)ᴴ * A i = 1) ∧
       transferMap B = transferMap (blockTensor A p)
 
-/-- **Reduction of forward canonicalization to the blocked equal-case stage.**
+/-- **Reduction of the forward construction to the blocked equal-case step.**
 
-Assuming `PeripheralEqualCasePeriodicFTOfSameMPV`, the pullback theorem
+Assuming `PeripheralEqualCasePeriodicFTOfSameMPV`, the theorem
 `pRefinementCanonicalization_pullback_of_irreducibleForm` already yields the
 full forward-side canonicalization hypothesis `PRefinementCanonicalization`.
 Thus the remaining forward gap in Theorem 4.1 is exactly the blocked
-equal-case/root-reconstruction step captured by
+equal-case construction of \(\widetilde A\) captured by
 `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
 theorem pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV
     (hPeripheralEq : PeripheralEqualCasePeriodicFTOfSameMPV d D p) :
@@ -499,10 +509,10 @@ theorem pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV
     transferMap B = transferMap C := hTransfer'.symm
     _ = transferMap (blockTensor A' p) := hTransferA'
 
-/-- **Forward direction of Theorem 4.1 from the blocked equal-case stage.**
+/-- **Forward direction of Theorem 4.1 from the blocked equal-case step.**
 
-This restates `thm_4_1_p_refinement_forward` after replacing the coarse
-hypothesis `PRefinementCanonicalization` by the sharper blocked-stage
+This restates `thm_4_1_p_refinement_forward` after replacing the broader
+hypothesis `PRefinementCanonicalization` by the more precise blocked-stage
 hypothesis `PeripheralEqualCasePeriodicFTOfSameMPV`. -/
 theorem thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV
     (B : MPSTensor d D) (hB : IsIrreducibleForm B)
@@ -523,8 +533,8 @@ Let `B` be an MPS tensor in irreducible form II. Assume
 `IsPRefinable B p` implies `IsPDivisibleChannel (transferMap B) p`.
 
 This follows the same conditional pattern as
-`MPSTensor.cor_4_1_physical_symmetry_zgauge`: analytic inputs beyond the
-repository's current reach are exposed as explicit hypotheses, while the
+`MPSTensor.cor_4_1_physical_symmetry_zgauge`: inputs not yet formalized are
+exposed as explicit hypotheses, while the
 algebraic structure — the blocking-commutes-with-power identity and the
 left-canonical-channel lemma — is formalized here. -/
 theorem thm_4_1_p_refinement_forward

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -2084,8 +2084,8 @@ divisibility of its transfer map, following
 \begin{proof}\leanok
     Combine Theorem~\ref{thm:p_refinement_forward_equalcase_reduction} with the
     witness-level forward implication: once $\mathcal E_B$ is identified with
-    $\mathcal E_{A'^{[p]}}$ for a left-canonical $A'$, the blocking identity
-    gives $\mathcal E_B = (\mathcal E_{A'})^p$.
+    $\mathcal E_{\widetilde A^{[p]}}$ for a left-canonical $\widetilde A$, the
+    blocking identity gives $\mathcal E_B = (\mathcal E_{\widetilde A})^p$.
 \end{proof}
 
 The following conditional statements separate the refinability--divisibility

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1940,14 +1940,14 @@ divisibility of its transfer map, following
     $\tau \in \{0,\ldots,d^p-1\}^N$.
 \end{definition}
 
-\begin{theorem}[Pullback of a refinement witness]
+\begin{theorem}[The tensor \(C\) associated to a refinement witness]
     \label{thm:p_refinement_pullback_irreducible_form}
     \lean{MPSTensor.pRefinementCanonicalization_pullback_of_irreducibleForm}
     \leanok
     \uses{def:irreducible_form, def:p_refinable}
     Let $B$ be an MPS tensor in irreducible form~II. If $\mc V(B)$ can be
     $p$-refined, then there exist a tensor $A$, an isometry
-    $W : \C^d \to (\C^d)^{\otimes p}$, and the pullback tensor
+    $W : \C^d \to (\C^d)^{\otimes p}$, and a tensor $C$ defined by
     \[
         C^{\alpha} := \sum_{i=0}^{d-1} W_{\alpha,i} B^i
     \]
@@ -1957,7 +1957,7 @@ divisibility of its transfer map, following
 \end{theorem}
 
 \begin{proof}\leanok
-    Choose $(A,W)$ from the refinement data. The pullback construction gives
+    Choose $(A,W)$ from the refinement data. The definition of $C$ gives
     $\mathcal E_C = \mathcal E_B$ and equality of MPV families between $C$
     and $A^{[p]}$. To see that $C$ is still in irreducible form~II, transport
     each periodic block $B_j$ of $B$ through the same physical isometry $W$.
@@ -1968,13 +1968,14 @@ divisibility of its transfer map, following
     irreducible-form decomposition of $C$.
 \end{proof}
 
-\begin{definition}[Blocked equal-case Z-gauge extraction hypothesis]
+\begin{definition}[$Z$-gauge after applying the blocked equal-case theorem]
     \label{def:peripheral_equalcase_zgauge_sameMPV}
     \lean{MPSTensor.PeripheralEqualCaseZGaugeOfSameMPV}
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv, def:z_gauge_equiv}
     Fix $(d,D,p)$. This hypothesis says that whenever a blocked tensor $C$ in
-    irreducible form~II has the same MPV family as a blocked root $A^{[p]}$,
+    irreducible form~II has the same MPV family as the $p$-blocked tensor
+    $A^{[p]}$,
     there exists an integer $m \ge 1$ and a $\mathbb Z_m$-gauge equivalence
     between $C$ and $A^{[p]}$.
 \end{definition}
@@ -1995,77 +1996,84 @@ divisibility of its transfer map, following
     % explicit assumption, not a consequence of equality of MPV families.
 \end{theorem}
 
-\begin{definition}[Blocked-to-root reconstruction hypothesis from Z-gauge]
+\begin{definition}[Construction of $\widetilde A$ from the $Z$-gauge]
     \label{def:peripheral_equalcase_root_from_zgauge}
     \lean{MPSTensor.PeripheralEqualCaseRootFromZGauge}
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:z_gauge_equiv}
     Fix $(d,D,p)$. This hypothesis says that if $m \ge 1$ and a blocked tensor
     $C$ in irreducible form~II is $\mathbb Z_m$-gauge equivalent to $A^{[p]}$,
-    then there exists a tensor $A'$ with
-    $\sum_i (A'^i)^\dagger A'^i = \Id$ and
-    $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
+    then one can construct a tensor $\widetilde A$ with
+    $\sum_i (\widetilde A^i)^\dagger \widetilde A^i = \Id$ and
+    $\mathcal E_C = \mathcal E_{\widetilde A^{[p]}}$.
+    This is the construction in
+    \cite[lines~765--810]{DeLasCuevas2017Irreducible}: for each periodic block
+    $A_j$, the scalars $c_{j,\alpha}$ define matrices $A'_j$, and then
+    $\widetilde A=U^\dagger A' U$.
 \end{definition}
 
-\begin{definition}[Blocked equal-case root hypothesis]
+\begin{definition}[Construction of $\widetilde A$ after the equal-case theorem]
     \label{def:peripheral_equalcase_periodicFT_sameMPV}
     \lean{MPSTensor.PeripheralEqualCasePeriodicFTOfSameMPV}
     \leanok
     \uses{def:irreducible_form, def:blocked_tensor, def:same_mpv}
-    Fix $(d,D,p)$. This states the combined root-existence statement: whenever a
+    Fix $(d,D,p)$. This states the combined construction: whenever a
     blocked tensor $C$ in irreducible form~II has the same MPV family as a
-    blocked root $A^{[p]}$, one can replace $A$ by a left-canonical tensor $A'$
-    with $\mathcal E_C = \mathcal E_{A'^{[p]}}$.
+    $p$-blocked tensor $A^{[p]}$, one can replace $A$ by a left-canonical
+    tensor $\widetilde A$ with
+    $\mathcal E_C = \mathcal E_{\widetilde A^{[p]}}$.
 \end{definition}
 
-\begin{theorem}[Blocked equal-case root from Z-gauge extraction]
+\begin{theorem}[Construction of $\widetilde A$ from $Z$-gauge extraction]
     \label{thm:peripheral_equalcase_sameMPV_zgauge_reduction}
     \lean{MPSTensor.peripheralEqualCase_periodicFT_of_sameMPV}
     \leanok
     \uses{def:peripheral_equalcase_zgauge_sameMPV,
         def:peripheral_equalcase_root_from_zgauge,
         def:peripheral_equalcase_periodicFT_sameMPV}
-    If the blocked equal-case Z-gauge extraction hypothesis and the
-    blocked-to-root reconstruction hypothesis both hold, then the combined
-    blocked equal-case root hypothesis holds.
+    If the blocked equal-case $Z$-gauge extraction hypothesis and the
+    construction of $\widetilde A$ from that $Z$-gauge both hold, then the
+    combined equal-case construction holds.
 \end{theorem}
 
 \begin{proof}\leanok
     Apply the Z-gauge extraction hypothesis to obtain a blocked
     $\mathbb Z_m$-gauge witness between $C$ and $A^{[p]}$, and then apply the
-    reconstruction hypothesis to that witness.
+    construction of $\widetilde A$ to that witness.
 \end{proof}
 
-\begin{theorem}[Reduction to the blocked equal-case root hypothesis]
+\begin{theorem}[Reduction to the blocked equal-case construction]
     \label{thm:p_refinement_forward_equalcase_reduction}
     \lean{MPSTensor.pRefinementCanonicalization_of_peripheralEqualCase_periodicFT_of_sameMPV}
     \leanok
     \uses{def:peripheral_equalcase_periodicFT_sameMPV,
         def:irreducible_form, def:p_refinable,
         thm:p_refinement_pullback_irreducible_form}
-    Assume the blocked equal-case root hypothesis. Then every
-    $p$-refinable tensor $B$ in irreducible form~II admits a left-canonical root
-    $A'$ with $\mathcal E_B = \mathcal E_{A'^{[p]}}$.
+    Assume the blocked equal-case construction. Then every
+    $p$-refinable tensor $B$ in irreducible form~II admits a left-canonical
+    tensor $\widetilde A$ with
+    $\mathcal E_B = \mathcal E_{\widetilde A^{[p]}}$.
 \end{theorem}
 
 \begin{proof}\leanok
     Apply Theorem~\ref{thm:p_refinement_pullback_irreducible_form} to the
     refinement witness of $B$. This produces a blocked tensor $C$ in
     irreducible form~II with $\mathcal E_C = \mathcal E_B$ and the same MPV
-    family as $A^{[p]}$. The blocked equal-case root hypothesis then
-    gives a left-canonical tensor $A'$ with
-    $\mathcal E_C = \mathcal E_{A'^{[p]}}$. Combining the two transfer-map
-    identities yields $\mathcal E_B = \mathcal E_{A'^{[p]}}$.
+    family as $A^{[p]}$. The blocked equal-case construction then
+    gives a left-canonical tensor $\widetilde A$ with
+    $\mathcal E_C = \mathcal E_{\widetilde A^{[p]}}$. Combining the two
+    transfer-map identities yields
+    $\mathcal E_B = \mathcal E_{\widetilde A^{[p]}}$.
 \end{proof}
 
-\begin{theorem}[Forward direction from the blocked equal-case root hypothesis]
+\begin{theorem}[Forward direction from the blocked equal-case construction]
     \label{thm:thm_4_1_p_refinement_forward_blocked_equalcase}
     \lean{MPSTensor.thm_4_1_p_refinement_forward_of_peripheralEqualCase_periodicFT_of_sameMPV}
     \leanok
     \uses{def:peripheral_equalcase_periodicFT_sameMPV,
         def:irreducible_form, def:p_refinable, def:p_divisible_channel,
         thm:p_refinement_forward_equalcase_reduction}
-    Assume the blocked equal-case root hypothesis. Then for every tensor
+    Assume the blocked equal-case construction. Then for every tensor
     $B$ in irreducible form~II, $p$-refinability of $B$ implies
     $p$-divisibility of $\mathcal E_B$.
 \end{theorem}
@@ -2079,14 +2087,14 @@ divisibility of its transfer map, following
 
 The following conditional statements separate the refinability--divisibility
 equivalence of \cite[Theorem~4.1]{DeLasCuevas2017Irreducible} from the
-root-construction assumptions used below.
+additional constructions used below.
 
 % Source comparison: arXiv:1708.00029, Theorem 4.1, lines 728--731 asserts
-% the same refinability--divisibility equivalence without additional root
-% hypotheses. The forward left-canonical root construction corresponds to
-% lines 735--810, while the reverse transfer-map root construction corresponds
-% to lines 812--818. The Lean theorem below packages the two proved one-way
-% implications and is therefore conditional on those two root hypotheses.
+% the same refinability--divisibility equivalence without additional
+% hypotheses. The forward construction of \widetilde A corresponds to
+% lines 735--810, while the reverse transfer-map construction corresponds
+% to lines 812--818. The Lean theorem below combines the two proved one-way
+% implications and is therefore conditional on those two hypotheses.
 \begin{theorem}[$p$-refinability iff transfer-map $p$-divisibility, conditional]%
     \label{thm:thm_4_1_p_refinement}
     \lean{MPSTensor.thm_4_1_p_refinement}
@@ -2095,9 +2103,9 @@ root-construction assumptions used below.
         thm:periodic_ft, thm:thm_4_1_p_refinement_forward,
         thm:thm_4_1_p_refinement_reverse}
     Let $B$ be an MPS tensor in irreducible form~II and let $p \ge 1$.
-    Assume the forward left-canonical root hypothesis for
-    refinability $\Rightarrow$ divisibility and the reverse transfer-map root
-    hypothesis for divisibility $\Rightarrow$ refinability. Then $B$ is
+    Assume the forward construction of $\widetilde A$ for
+    refinability $\Rightarrow$ divisibility and the reverse transfer-map
+    construction for divisibility $\Rightarrow$ refinability. Then $B$ is
     $p$-refinable iff its transfer map $\mathcal{E}_B$ is $p$-divisible.
 \end{theorem}
 
@@ -2106,9 +2114,9 @@ root-construction assumptions used below.
     Combine the forward implication
     (Theorem~\ref{thm:thm_4_1_p_refinement_forward}) with the reverse
     implication (Theorem~\ref{thm:thm_4_1_p_refinement_reverse}) into a
-    single biconditional. The forward direction assumes the left-canonical root
-    hypothesis; the reverse direction assumes only the transfer-map root
-    hypothesis. Together they give the full equivalence under those hypotheses.
+    single biconditional. The forward direction assumes the construction of
+    $\widetilde A$; the reverse direction assumes the transfer-map construction.
+    Together they give the full equivalence under those hypotheses.
 \end{proof}
 
 \begin{theorem}[$p$-refinability implies transfer-map $p$-divisibility]%
@@ -2116,20 +2124,22 @@ root-construction assumptions used below.
     \lean{MPSTensor.thm_4_1_p_refinement_forward}
     \leanok
     \uses{def:irreducible_form, def:p_refinable, def:p_divisible_channel}
-    Let $B$ be an MPS tensor in irreducible form~II. Assume a left-canonical
-    root hypothesis: every refinement witness gives a tensor $A$ with
-    $\sum_i (A^i)^\dagger A^i = \Id$ and
-    $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$. Then
+    Let $B$ be an MPS tensor in irreducible form~II. Assume that every
+    refinement witness gives a tensor $\widetilde A$ with
+    $\sum_i (\widetilde A^i)^\dagger \widetilde A^i = \Id$ and
+    $\mathcal{E}_B = \mathcal{E}_{\widetilde A^{[p]}}$. Then
     $p$-refinability of $B$ implies $p$-divisibility of $\mathcal{E}_B$.
 \end{theorem}
 
 \begin{proof}\leanok
-    The left-canonical root hypothesis supplies a witness $A$ with
-    $\sum_i (A^i)^\dagger A^i = \Id$ (left-canonical) and
-    $\mathcal{E}_B = \mathcal{E}_{A^{[p]}}$. The left-canonical property makes
-    $\mathcal{E}_A$ a CPTP channel, and the blocking identity
-    $\mathcal{E}_{A^{[p]}} = (\mathcal{E}_A)^p$ then identifies
-    $\mathcal{E}_B$ with the $p$-th power of the channel $\mathcal{E}_A$.
+    The construction supplies $\widetilde A$ with
+    $\sum_i (\widetilde A^i)^\dagger \widetilde A^i = \Id$ and
+    $\mathcal{E}_B = \mathcal{E}_{\widetilde A^{[p]}}$. The left-canonical
+    property makes $\mathcal{E}_{\widetilde A}$ a CPTP channel, and the
+    blocking identity
+    $\mathcal{E}_{\widetilde A^{[p]}} = (\mathcal{E}_{\widetilde A})^p$
+    then identifies $\mathcal{E}_B$ with the $p$-th power of the channel
+    $\mathcal{E}_{\widetilde A}$.
 \end{proof}
 
 \begin{definition}[Blocked-to-root channel-root hypothesis from Z-gauge]

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -2013,6 +2013,12 @@ divisibility of its transfer map, following
     This source description is the intended irreducible-form subcase of the
     hypothesis; the definition above keeps the construction as a conditional
     input and does not assert these block data for arbitrary $A$.
+    The cited source moreover obtains the blocked-tensor identity
+    $\widetilde A^{[p]} = C$, whereas the formal hypothesis above records only
+    its channel-level consequence $\mathcal E_C = \mathcal E_{\widetilde A^{[p]}}$
+    (equality of $p$-blocked transfer maps). This conditional input is therefore
+    the transfer-map weakening of the source construction, not the full blocked
+    tensor equality.
 \end{definition}
 
 \begin{definition}[Construction of $\widetilde A$ after the equal-case theorem]

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -2006,14 +2006,15 @@ divisibility of its transfer map, following
     then one can construct a tensor $\widetilde A$ with
     $\sum_i (\widetilde A^i)^\dagger \widetilde A^i = \Id$ and
     $\mathcal E_C = \mathcal E_{\widetilde A^{[p]}}$.
-    This is the construction in
+    This channel-level hypothesis is the transfer-map reading of the
+    construction in
     \cite[lines~765--810]{DeLasCuevas2017Irreducible}: for each periodic block
     $A_j$, the scalars $c_{j,\alpha}$ define matrices $A'_j$, and then
     $\widetilde A=U^\dagger A' U$.
     This source description is the intended irreducible-form subcase of the
     hypothesis; the definition above keeps the construction as a conditional
-    input and does not assert the blocks $A_j$, scalars $c_{j,\alpha}$, or
-    matrices $A'_j$ for arbitrary $A$.
+    input and does not assert these block scalars $c_{j,\alpha}$ and matrices
+    $A'_j$ for arbitrary $A$.
     The cited source moreover obtains the blocked-tensor identity
     $\widetilde A^{[p]} = C$, whereas the formal hypothesis above records only
     its channel-level consequence $\mathcal E_C = \mathcal E_{\widetilde A^{[p]}}$

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -1980,7 +1980,7 @@ divisibility of its transfer map, following
     between $C$ and $A^{[p]}$.
 \end{definition}
 
-\begin{theorem}[Z-gauge equivalence from the periodic theorem]
+\begin{theorem}[$Z$-gauge equivalence from the periodic theorem]
     \label{thm:zgauge_equiv_periodicFT_irreducible_form}
     \lean{MPSTensor.zGaugeEquiv_of_periodicEqualCaseFT_of_irreducibleForm}
     \leanok
@@ -2010,6 +2010,9 @@ divisibility of its transfer map, following
     \cite[lines~765--810]{DeLasCuevas2017Irreducible}: for each periodic block
     $A_j$, the scalars $c_{j,\alpha}$ define matrices $A'_j$, and then
     $\widetilde A=U^\dagger A' U$.
+    This source description is the intended irreducible-form subcase of the
+    hypothesis; the definition above keeps the construction as a conditional
+    input and does not assert these block data for arbitrary $A$.
 \end{definition}
 
 \begin{definition}[Construction of $\widetilde A$ after the equal-case theorem]
@@ -2037,7 +2040,7 @@ divisibility of its transfer map, following
 \end{theorem}
 
 \begin{proof}\leanok
-    Apply the Z-gauge extraction hypothesis to obtain a blocked
+    Apply the $Z$-gauge extraction hypothesis to obtain a blocked
     $\mathbb Z_m$-gauge witness between $C$ and $A^{[p]}$, and then apply the
     construction of $\widetilde A$ to that witness.
 \end{proof}

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -2012,7 +2012,8 @@ divisibility of its transfer map, following
     $\widetilde A=U^\dagger A' U$.
     This source description is the intended irreducible-form subcase of the
     hypothesis; the definition above keeps the construction as a conditional
-    input and does not assert these block data for arbitrary $A$.
+    input and does not assert the blocks $A_j$, scalars $c_{j,\alpha}$, or
+    matrices $A'_j$ for arbitrary $A$.
     The cited source moreover obtains the blocked-tensor identity
     $\widetilde A^{[p]} = C$, whereas the formal hypothesis above records only
     its channel-level consequence $\mathcal E_C = \mathcal E_{\widetilde A^{[p]}}$


### PR DESCRIPTION
### Motivation

- The forward Theorem 4.1 section in `TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean`
  and `blueprint/src/chapter/ch22_periodic_ft.tex` used local "pullback/root hypothesis"
  language that diverges from the source terminology in arXiv:1708.00029, lines 735–810.
- Aligning the prose to the source paper is a prerequisite for the full unconditional
  formalization of Theorem 4.1 tracked in #664.
- The paper source (arXiv:1708.00029, §4.1) constructs the tensor $C$ from the refinement
  isometry $W$, applies a blocked $Z$-gauge step, and obtains $\widetilde{A}$ from scalars
  $c_{j,\alpha}$ (lines 765–810); these objects had no names in the existing prose.

### Description

- Modified `TNLean/MPS/Periodic/Symmetry/Theorem41Forward.lean` and
  `blueprint/src/chapter/ch22_periodic_ft.tex` (prose only; no Lean statements or proofs
  are changed).
- Replaces "W-pullback", "blocked root / root hypothesis / reconstruction" language with
  source terminology: the tensor $C$ defined from the refinement isometry $W$, the
  $p$-blocked `blockTensor A p`, the blocked $Z$-gauge step, and the $\widetilde{A}$
  construction from scalars $c_{j,\alpha}$ (arXiv:1708.00029, lines 765–810).
- Docstrings for `PeripheralEqualCase*` and `PRefinementCanonicalization` updated to
  describe the two-step split explicitly rather than "blocked-to-root" language.

### Testing

- `lake build TNLean.MPS.Periodic.Symmetry.Theorem41Forward` passed.
- `lake build TNLean` passed.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` passed.
- `python3 scripts/blueprint_lean_sync.py --root . --ci` passed.
- `lake exe checkdecls blueprint/lean_decls` passed.

---
Refs #664

> [!NOTE]
> **Low Risk**
> Comment and blueprint text only; no executable Lean or proof logic changes.
>
> **Overview**
> **Documentation-only** alignment of the forward Theorem 4.1 narrative with arXiv:1708.00029 (lines 735–810). Lean **theorem names, statements, and proofs are unchanged**.
>
> In `Theorem41Forward.lean` and `ch22_periodic_ft.tex`, local wording is updated in parallel: **"W-pullback"** → the refinement-isometry tensor **\(C\)**, **"blocked root / root hypothesis / reconstruction"** → **\(p\)-blocked** `blockTensor A p`, the blocked **\(Z\)-gauge** step, and the paper's **\(\widetilde A\)** construction from \(c_{j,\alpha}\) (lines 765–810). Docstrings for `PeripheralEqualCase*` and `PRefinementCanonicalization` now describe that two-step split explicitly instead of "blocked-to-root" language.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2308049ce9c877c0e50bfc82e503c437d66cd3dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX blueprint text only; no executable Lean or proof logic changes.
> 
> **Overview**
> **Documentation-only** update to the forward Theorem 4.1 narrative in `Theorem41Forward.lean` and `ch22_periodic_ft.tex`. **No Lean theorem names, statements, or proofs change.**
> 
> Prose is retitled and rewritten to match arXiv:1708.00029 (§4.1, lines 735–810): **W-pullback** language becomes the refinement-isometry tensor **\(C\)**, and **blocked root / root hypothesis / reconstruction** becomes **\(p\)-blocked** `blockTensor A p`, the blocked **\(Z\)-gauge** step, and **\(\widetilde A\)** built from scalars \(c_{j,\alpha}\). Docstrings for `PeripheralEqualCase*` and `PRefinementCanonicalization` now spell out the two-step split (equal-case \(Z\)-gauge, then \(\widetilde A\) construction) instead of “blocked-to-root” wording.
> 
> The blueprint definition `PeripheralEqualCaseRootFromZGauge` gains an explicit note that the formal hypothesis records only **transfer-map** equality \(\mathcal E_C = \mathcal E_{\widetilde A^{[p]}}\), weaker than the source’s blocked-tensor identity \(\widetilde A^{[p]} = C\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4656ca26482181de8fff120288515a5e6137d98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->