### PR TITLE
fix(MPS/RFP): omit empty chain from product-pair bridge

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -92,18 +92,18 @@ def productPairState (ψ₂ : NSiteSpace d 2) (N : ℕ) : NSiteSpace d (2 * N) :
 
 /-- An MPS tensor has adjacent product-pair MPVs when every positive
 even-length coefficient factors as a repeated copy of one fixed two-site
-amplitude on the pairs `(0,1), (2,3), ...`.
+amplitude on the pairs \((0,1),(2,3),\ldots\).
 
 This is a generic factorization predicate: it does not assert that the two-site
 amplitude is entangled. The zero-pair case is omitted because the empty-chain
 MPV coefficient is the bond dimension, whereas the empty product-pair amplitude
-is \(1\). Odd chain lengths are omitted because this bridge is used only to
+is \(1\). Odd chain lengths are omitted because this predicate is used only to
 identify the translated two-site parent terms in the RFP-to-NNCPH direction of
 arXiv:1606.00608, Theorem 3.10.
 
 **Scope restriction:** Appendix B first produces a cyclic virtual-pair network.
-This predicate is the later adjacent-pair input consumed by the current bridge;
-it is not, by itself, the full Appendix B factorization theorem. -/
+This predicate is the later adjacent-pair input used by the present formal
+statement; it is not, by itself, the full Appendix B factorization theorem. -/
 def HasProductPairMPV (A : MPSTensor d D) : Prop :=
   ∃ ψ₂ : NSiteSpace d 2, ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState ψ₂ N σ
@@ -119,7 +119,7 @@ theorem HasProductPairMPV.exists_twoSiteAmplitude {A : MPSTensor d D}
 \(p_i p_j=p_j p_i\).
 
 **Scope restriction (local projectors):** The three-site \(AX/XB\) support maps
-for adjacent windows give the local support data. This structure does not
+for adjacent windows give the local support maps. This structure does not
 construct, from the Appendix-B product-of-entangled-pairs form, the chain-level
 projectors that equal the translated length-two parent terms. The projectors are
 therefore stated directly as endomorphisms of the full \(N\)-site space. -/
@@ -150,7 +150,7 @@ theorem HasProductPairLocalProjectors.commuting_twoSite_localTerms
   rw [hPair.hlocal i, hPair.hlocal j]
   exact hPair.hcomm i j
 
-/-- Product-of-entangled-pairs bridge data for a tensor whose positive
+/-- Product-of-entangled-pairs hypotheses for a tensor whose positive
 even-chain MPVs factor through one adjacent two-site amplitude and whose
 nearest-neighbor parent projectors are commuting idempotents on every finite
 chain. -/

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -90,21 +90,27 @@ def productPairState (ψ₂ : NSiteSpace d 2) (N : ℕ) : NSiteSpace d (2 * N) :
     productPairState ψ₂ 1 σ = ψ₂ σ := by
   simp [productPairState]
 
-/-- An MPS tensor has product-pair MPVs when every even-length coefficient
-factors as a repeated copy of one fixed two-site amplitude.
+/-- An MPS tensor has adjacent product-pair MPVs when every positive
+even-length coefficient factors as a repeated copy of one fixed two-site
+amplitude on the pairs `(0,1), (2,3), ...`.
 
 This is a generic factorization predicate: it does not assert that the two-site
-amplitude is entangled. Odd chain lengths are omitted here because the Appendix B
-product-of-entangled-pairs argument is used only to identify the translated
-two-site parent terms in the RFP-to-NNCPH direction of arXiv:1606.00608,
-Theorem 3.10. -/
+amplitude is entangled. The zero-pair case is omitted because the empty-chain
+MPV coefficient is the bond dimension, whereas the empty product-pair amplitude
+is \(1\). Odd chain lengths are omitted because this bridge is used only to
+identify the translated two-site parent terms in the RFP-to-NNCPH direction of
+arXiv:1606.00608, Theorem 3.10.
+
+**Scope restriction:** Appendix B first produces a cyclic virtual-pair network.
+This predicate is the later adjacent-pair input consumed by the current bridge;
+it is not, by itself, the full Appendix B factorization theorem. -/
 def HasProductPairMPV (A : MPSTensor d D) : Prop :=
-  ∃ ψ₂ : NSiteSpace d 2, ∀ N (σ : Cfg d (2 * N)),
+  ∃ ψ₂ : NSiteSpace d 2, ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState ψ₂ N σ
 
 theorem HasProductPairMPV.exists_twoSiteAmplitude {A : MPSTensor d D}
     (hA : HasProductPairMPV A) :
-    ∃ ψ₂ : NSiteSpace d 2, ∀ N (σ : Cfg d (2 * N)),
+    ∃ ψ₂ : NSiteSpace d 2, ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv A σ = productPairState ψ₂ N σ :=
   hA
 
@@ -144,18 +150,19 @@ theorem HasProductPairLocalProjectors.commuting_twoSite_localTerms
   rw [hPair.hlocal i, hPair.hlocal j]
   exact hPair.hcomm i j
 
-/-- Product-of-entangled-pairs equations for a tensor whose even-chain MPVs
-factor through one two-site amplitude and whose nearest-neighbor parent
-projectors are commuting idempotents on every finite chain. -/
+/-- Product-of-entangled-pairs bridge data for a tensor whose positive
+even-chain MPVs factor through one adjacent two-site amplitude and whose
+nearest-neighbor parent projectors are commuting idempotents on every finite
+chain. -/
 structure ProductPairBridge (A : MPSTensor d D) where
   pairAmplitude : NSiteSpace d 2
-  hmpv : ∀ N (σ : Cfg d (2 * N)),
+  hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState pairAmplitude N σ
   localProjectors : ∀ N, HasProductPairLocalProjectors A N
 
 theorem ProductPairBridge.mpv_eq_productPairState {A : MPSTensor d D}
     (hBridge : ProductPairBridge A) :
-    ∀ N (σ : Cfg d (2 * N)),
+    ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv A σ = productPairState hBridge.pairAmplitude N σ :=
   hBridge.hmpv
 
@@ -303,17 +310,17 @@ theorem AppendixBStructuralData.mpv_eq_productPairState_one {A : MPSTensor d D}
     mpv A σ = productPairState hStruct.twoSiteAmplitude 1 σ := by
   rw [productPairState_one, hStruct.twoSiteAmplitude_eq_mpv]
 
-/-- The remaining product-of-entangled-pairs input needed after Appendix B.
+/-- The remaining adjacent product-pair input needed after Appendix B.
 
 For a fixed structural form, this captures the two facts that are still not
-produced by the Appendix-B structural datum: the even-chain MPV must be a
-repeated copy of the two-site amplitude determined by that same witness, and the
-nearest-neighbor parent projectors on each finite chain must be identified with a
-commuting family attached to these adjacent two-site factors. -/
+produced by the Appendix-B structural datum: the positive even-chain MPV must be
+a repeated copy of the two-site amplitude determined by that same witness, and
+the nearest-neighbor parent projectors on each finite chain must be identified
+with a commuting family attached to these adjacent two-site factors. -/
 structure AppendixBProductPairExtraction {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) where
-  /-- Even-chain coefficient factorization through the structural two-site amplitude. -/
-  hmpv : ∀ N (σ : Cfg d (2 * N)),
+  /-- Positive even-chain coefficient factorization through the structural two-site amplitude. -/
+  hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState hStruct.twoSiteAmplitude N σ
   /-- Local projectors realizing the nearest-neighbor parent terms. -/
   localProjectors : ∀ N, HasProductPairLocalProjectors A N
@@ -324,14 +331,14 @@ This reduces the coefficient computation to the core tensor `Λ U_i`; the local
 projector identities remain a separate input. -/
 noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
-    (hCore : ∀ N (σ : Cfg d (2 * N)),
+    (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
     (hProj : ∀ N, HasProductPairLocalProjectors A N) :
     AppendixBProductPairExtraction hStruct where
   hmpv := by
-    intro N σ
+    intro N hN σ
     rw [hStruct.mpv_eq_coreTensor σ]
-    exact hCore N σ
+    exact hCore N hN σ
   localProjectors := hProj
 
 /-- The product-of-entangled-pairs input yields the established

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -655,19 +655,19 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         V^{(2)}(\Lambda U)(a,b).
     \]
-    The adjacent-pair input presently consumed by the bridge is the
-    even-chain factorization, for a positive number \(n\) of adjacent pairs,
+    The adjacent-pair input presently used in the formal statement is the
+    even-chain factorization, for a positive number $n$ of adjacent pairs,
     \[
         V^{(2n)}(A)(\sigma)
         =
         \prod_{p=0}^{n-1}
         \phi_2\bigl(\sigma_{2p},\sigma_{2p+1}\bigr).
     \]
-    The case \(n=0\) is not part of this source input: the empty-chain MPV
+    The case $n=0$ is not part of this source input: the empty-chain MPV
     coefficient is the virtual bond dimension, whereas the empty product on the
-    right-hand side is \(1\).
+    right-hand side is $1$.
     Appendix~B first gives a cyclic virtual-pair expression; identifying that
-    expression with this adjacent-pair bridge input is part of the remaining
+    expression with this adjacent-pair formal input is part of the remaining
     factorization theorem.
     The two-site parent projectors must also be identified with
     idempotents $p_i$ satisfying

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -655,13 +655,20 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         V^{(2)}(\Lambda U)(a,b).
     \]
-    The product-of-pairs input is the even-chain factorization
+    The adjacent-pair input presently consumed by the bridge is the
+    even-chain factorization, for a positive number \(n\) of adjacent pairs,
     \[
         V^{(2n)}(A)(\sigma)
         =
         \prod_{p=0}^{n-1}
         \phi_2\bigl(\sigma_{2p},\sigma_{2p+1}\bigr).
     \]
+    The case \(n=0\) is not part of this source input: the empty-chain MPV
+    coefficient is the virtual bond dimension, whereas the empty product on the
+    right-hand side is \(1\).
+    Appendix~B first gives a cyclic virtual-pair expression; identifying that
+    expression with this adjacent-pair bridge input is part of the remaining
+    factorization theorem.
     The two-site parent projectors must also be identified with
     idempotents $p_i$ satisfying
     \[

--- a/docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
+++ b/docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md
@@ -112,7 +112,7 @@ into
 
 This is a genuine chain-space construction problem on `NSiteSpace d N`; it is **not** a remaining
 issue about the NNCPH definition itself. The present `AppendixBStructuralData` record now exposes
-the unit pair-index isometry for `U` in the source convention. A proof of the all-even-length
+the unit pair-index isometry for `U` in the source convention. A proof of the positive-even-length
 factorization still has to turn that matrix-entry isometry into the repeated two-site amplitude on
 the cyclic chain, or give an equivalent local-support description of the product-pair state.
 

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -144,7 +144,7 @@ basis of normal tensors of $A$.\footnote{Tracked by \ghissue{2633}.}
 The present formal boundary is therefore: the reverse implication has the
 source ground-space hypothesis, but its proof is still the Beigi axiom; the
 forward implication has the source-unit Appendix~B structural datum and the
-three-site \(AX/XB\) support maps, but still lacks the even-chain
+three-site \(AX/XB\) support maps, but still lacks the positive-even-chain
 product-of-pairs factorization and the local-projector commutation theorem.
 The axiom-backed theorem still supplies the commutation direction used by the
 unconditional statements.

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -102,8 +102,8 @@ source unit convention
 \end{align}
 Thus the scalar normalization mismatch is no longer hidden in the formal
 statement: both conventions are available, and their comparison is explicit.
-The Appendix~B structural datum used in the parent-Hamiltonian bridge now
-chooses the unit pair-index convention, so the remaining even-chain
+The Appendix~B structural datum used in the parent-Hamiltonian bridge chooses
+the unit pair-index convention, so the remaining positive-even-chain
 factorization problem starts from the source normalization.
 
 There is still no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus


### PR DESCRIPTION
### Motivation
- The product-pair bridge predicate incorrectly admitted an empty chain (`N = 0`), where the MPS coefficient equals the bond dimension while the empty adjacent-pair product evaluates to `1`. The two expressions disagree, making the `N = 0` case a false statement.
- The correct source statement in arXiv:1606.00608, Appendix B applies only for a positive number of pairs; the `0 < N` hypothesis makes the Lean predicate faithful to this boundary.
- The remaining open task — identifying Appendix B's cyclic virtual-pair expression with the adjacent-pair bridge input for all `N ≥ 1` — is tracked in #3372.

### Description
- `TNLean/MPS/RFP/CommutingBridge.lean`: added `0 < N` hypothesis to `HasProductPairMPV`, `ProductPairBridge`, `AppendixBProductPairExtraction`, and core-tensor factorization field; docstrings updated to explain the exclusion of the empty chain.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: blueprint prose aligned to the tightened adjacent-pair bridge statement.
- `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`, `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`: gap notes updated to record the remaining source boundary.
- `docs/audits/2026-04-21_issue234_commuting_parent_hamiltonian_gap.md`: audit note updated.

### Testing
- `lake build TNLean.MPS.RFP.CommutingBridge TNLean.MPS.ParentHamiltonian.Commuting`
- `lake env lean TNLean/MPS/RFP/CommutingBridge.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `rg -n '\bsorry\b|\badmit\b|\bnative_decide\b|\bunsafeCast\b|^\s*axiom\b' TNLean/MPS/RFP/CommutingBridge.lean TNLean/MPS/ParentHamiltonian/Commuting.lean || true`

---
Refs #3372

> [!NOTE]
> **Low Risk**
> Predicate and documentation tightening only; no proof logic or axiom changes beyond excluding an incorrect `N = 0` case.
> 
> **Overview**
> The **adjacent product-pair bridge** now requires a **positive** number of pairs (`0 < N`) in every even-chain MPV factorization hypothesis (`HasProductPairMPV`, `ProductPairBridge`, `AppendixBProductPairExtraction`, and core-tensor factorization). That drops the **`N = 0`** case, where the empty-chain MPV is bond dimension but `productPairState` is constantly `1`.
> 
> Docstrings and blueprint/audit/gap prose are aligned: wording shifts to **adjacent** product-pair input, explains why the empty chain is excluded, and notes that **Appendix B's cyclic virtual-pair form** still has to be identified with this bridge input—the open factorization theorem is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b4492aa2470e0c13b2c021acc72bdb6133a648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Predicate and documentation tightening only; no axiom or proof-path changes beyond dropping an unsound `N = 0` case.
> 
> **Overview**
> The **adjacent product-pair bridge** predicates now require **`0 < N`** (a positive number of adjacent pairs) in every even-chain MPV factorization hypothesis: `HasProductPairMPV`, `ProductPairBridge`, `AppendixBProductPairExtraction`, and `ofCoreTensorFactorization`. That removes **`N = 0`**, where the empty-chain MPV is bond dimension but `productPairState` is constantly `1`, so the old universal quantifier was unsound.
> 
> Lean docstrings and blueprint/audit/gap prose are aligned: wording emphasizes **adjacent** pairs, explains the empty-chain exclusion, and notes that matching **Appendix B’s cyclic virtual-pair form** to this bridge input remains the open factorization step (unchanged scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437e068a23b5ec1ffb9998609678e9a22e37a386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->