### PR TITLE
feat(Channel): formalize positive trace-preserving transposition

### DIFF
--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -86,7 +86,7 @@ namespace Matrix
 
 variable (n : Type*)
 
-/-- Matrix transposition as a complex-linear map on $M_n(\mathbb C)$. -/
+/-- Matrix transposition as a complex-linear map on `Matrix n n ℂ`. -/
 def transposeLinearMapComplex : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ :=
   (Matrix.transposeLinearEquiv n n ℂ ℂ).toLinearMap
 

--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -86,7 +86,7 @@ namespace Matrix
 
 variable (n : Type*)
 
-/-- Matrix transposition as a complex-linear map on `Matrix n n ℂ`. -/
+/-- Matrix transposition as a complex-linear map on `M_n(ℂ)`. -/
 def transposeLinearMapComplex : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ :=
   (Matrix.transposeLinearEquiv n n ℂ ℂ).toLinearMap
 

--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -19,7 +19,7 @@ import Mathlib.Topology.Instances.Matrix
 This file defines positive maps, completely positive (CP) maps,
 trace-preserving maps, and quantum channels on `M_D(ℂ)`, together with the
 basic theory of density matrices (compactness, convexity), following
-Chapter 6 of Wolf's lecture notes.
+Chapters 3 and 6 of Wolf's lecture notes.
 
 ## Main results
 
@@ -27,6 +27,9 @@ Chapter 6 of Wolf's lecture notes.
 * `IsCPMap`: a linear map that admits a Kraus representation
 * `IsCPMap.isPositiveMap`: completely positive maps are positive
 * `IsChannel`: completely positive + trace-preserving (CPTP)
+* `Matrix.transposeLinearMapComplex_isPositiveMap`: matrix transposition is positive
+* `Matrix.transposeLinearMapComplex_isTracePreservingMap`: matrix transposition is
+  trace-preserving
 * `IsPositiveMap.map_isHermitian`: positive maps preserve Hermiticity
 * `matrix_isClosed_posSemidef`: the positive semidefinite cone is closed
 * `densityMatrices_isCompact`: the set of density matrices is compact
@@ -35,7 +38,7 @@ Chapter 6 of Wolf's lecture notes.
 
 ## References
 
-* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 6][Wolf2012QChannels]
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapters 3 and 6][Wolf2012QChannels]
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -78,6 +81,30 @@ structure IsChannel (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop where
   tp : IsTracePreservingMap E
 
 end PositiveMap
+
+namespace Matrix
+
+variable (n : Type*)
+
+/-- Matrix transposition as a complex-linear map on \(M_n(\mathbb C)\). -/
+def transposeLinearMapComplex : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ :=
+  (Matrix.transposeLinearEquiv n n ℂ ℂ).toLinearMap
+
+variable {n : Type*}
+
+/-- Matrix transposition preserves positive semidefinite matrices. -/
+theorem transposeLinearMapComplex_isPositiveMap :
+    IsPositiveMap (transposeLinearMapComplex n) := by
+  intro A hA
+  simpa [transposeLinearMapComplex] using hA.transpose
+
+/-- Matrix transposition preserves the trace. -/
+theorem transposeLinearMapComplex_isTracePreservingMap [Fintype n] :
+    IsTracePreservingMap (transposeLinearMapComplex n) := by
+  intro A
+  simp [transposeLinearMapComplex]
+
+end Matrix
 
 section PositiveMap
 

--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -86,7 +86,7 @@ namespace Matrix
 
 variable (n : Type*)
 
-/-- Matrix transposition as a complex-linear map on \(M_n(\mathbb C)\). -/
+/-- Matrix transposition as a complex-linear map on $M_n(\mathbb C)$. -/
 def transposeLinearMapComplex : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ :=
   (Matrix.transposeLinearEquiv n n ℂ ℂ).toLinearMap
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -46,8 +46,9 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    If $X \ge 0$, then $X^T \ge 0$ because transposition preserves positive
-    semidefiniteness. Trace preservation is the identity $\tr(X^T)=\tr(X)$.
+    If $X \ge 0$, write $X=C^\dagger C$. Then
+    $X^T=C^T\overline C=\overline C^\dagger\overline C$, so $X^T \ge 0$.
+    Trace preservation is the identity $\tr(X^T)=\tr(X)$.
 \end{proof}
 
 \begin{definition}[Completely positive map]\label{def:cp_map}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -35,6 +35,21 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     if $\tr(E(X)) = \tr(X)$ for all $X$.
 \end{definition}
 
+\begin{theorem}[Transposition is positive and trace-preserving]
+    \label{thm:transpose_positive_trace_preserving}
+    \lean{Matrix.transposeLinearMapComplex_isPositiveMap,
+        Matrix.transposeLinearMapComplex_isTracePreservingMap}
+    \leanok
+    \uses{def:positive_map, def:trace_preserving}
+    The matrix transposition map $\theta(X)=X^T$ on $\MN{D}$ is positive
+    and trace-preserving.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $X \ge 0$, then $X^T \ge 0$ because transposition preserves positive
+    semidefiniteness. Trace preservation is the identity $\tr(X^T)=\tr(X)$.
+\end{proof}
+
 \begin{definition}[Completely positive map]\label{def:cp_map}
     \lean{IsCPMap}
     \leanok


### PR DESCRIPTION
### Motivation
- Addresses Wolf Ch. 3, §3.1 (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~32–37): ordinary matrix transposition $\theta(A) = A^\top$ is the standard example of a positive trace-preserving map that is not completely positive.
- Uses the Mathlib 4.31 transpose API directly rather than introducing an ad hoc linear map.
- Part of LionSR/QICLean#25 (Wolf Ch. 3 formalization); see LionSR/QICLean#162 for the precise statement and source citation.

### Description
- Adds `Matrix.transposeLinearMapComplex` on `M_n(ℂ)` via `Matrix.transposeLinearEquiv`.
- Proves `Matrix.transposeLinearMapComplex_isPositiveMap` (positivity: PSD is preserved under transposition) using `PosSemidef.transpose`.
- Proves `Matrix.transposeLinearMapComplex_isTracePreservingMap` (trace invariance) using `trace_transpose` through `simp`.
- Adds blueprint theorem `thm:transpose_positive_trace_preserving` in `blueprint/src/chapter/ch04_channels.tex` with `\lean{}` tags for both new declarations, establishing transposition as the standard positive-but-not-CP example.

### Testing
- `lake env lean TNLean/Channel/Basic.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch04_channels.tex`
- `git diff --check`

---
Closes LionSR/QICLean#162

> [!NOTE]
> **Low Risk**
> Small, localized additions to channel foundations and blueprint sync; proofs are short and use existing Mathlib transpose facts.
>
> **Overview**
> Adds **`Matrix.transposeLinearMapComplex`** on `M_n(ℂ)` via Mathlib's `transposeLinearEquiv`, and proves it is **`IsPositiveMap`** (PSD preserved under transpose) and **`IsTracePreservingMap`** (trace unchanged).
>
> **`TNLean/Channel/Basic.lean`** module docs now cite Wolf Ch. 3 as well as Ch. 6 and list the new lemmas. **Blueprint Ch. 4** gains Theorem "Transposition is positive and trace-preserving" (`thm:transpose_positive_trace_preserving`) linked to those Lean names—setting up transposition as the standard positive, trace-preserving map that is not CP.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4b18a56d6b9035c78978c6b86a44a7913e1cd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive lemmas and blueprint sync; proofs delegate to existing Mathlib transpose/PSD facts with no changes to channel or density-matrix core logic.
> 
> **Overview**
> Formalizes **matrix transposition** on `M_n(ℂ)` as the standard **positive, trace-preserving** linear map (Wolf Ch. 3 example), wired into Lean and the blueprint.
> 
> Adds **`Matrix.transposeLinearMapComplex`** via Mathlib’s `transposeLinearEquiv`, with short proofs that it is **`IsPositiveMap`** (`PosSemidef.transpose`) and **`IsTracePreservingMap`** (`simp` on trace). **`TNLean/Channel/Basic.lean`** module docs now cite Wolf Ch. 3 and list these lemmas.
> 
> **Blueprint Ch. 4** gains Theorem **`thm:transpose_positive_trace_preserving`** (proof sketch + `\lean{}` links) immediately after the trace-preserving definition, before completely positive maps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e67ab2e446aa32dea95c9111de66a5a9567bd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->