### PR TITLE
feat(Channel): prove transposition map is positive and trace-preserving

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -49,6 +49,7 @@ import TNLean.Topology.CompactRetractFixedPoint
 
 -- Layer 2: Quantum channels (general theory)
 import TNLean.Channel.Basic
+import TNLean.Channel.Transposition
 import TNLean.Channel.DensityRetract
 
 -- Layer 2 (Ch. 2 infrastructure): Choi–Jamiolkowski, Kraus, Stinespring

--- a/TNLean/Channel/Transposition.lean
+++ b/TNLean/Channel/Transposition.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Channel.Basic
+
+/-!
+# Transposition is a positive, trace-preserving map
+
+This file introduces the matrix transposition `θ : M_d(ℂ) → M_d(ℂ)`, `θ(A) = Aᵀ`,
+as a linear map and proves that it is positive and trace preserving.
+
+Positivity follows from the fact that transposition preserves positive
+semidefiniteness: if `A = U D U†` is the spectral decomposition of a Hermitian
+matrix, then `Aᵀ = Ū D Uᵀ` has the same eigenvalues `D`.  Transposition is the
+paradigmatic example of a positive map which is not completely positive
+(Wolf, Chapter 3, §3.1).
+
+## Main declarations
+
+* `transpositionMap`: matrix transposition as a `ℂ`-linear map on `M_d(ℂ)`
+* `transpositionMap_isPositiveMap`: transposition is a positive map
+* `transpositionMap_isTracePreservingMap`: transposition is trace preserving
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+section Transposition
+
+variable (d : ℕ)
+
+/-- Matrix transposition `θ(A) = Aᵀ` as a `ℂ`-linear map on `M_d(ℂ)`. -/
+def transpositionMap : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ :=
+  (Matrix.transposeLinearEquiv (Fin d) (Fin d) ℂ ℂ).toLinearMap
+
+variable {d}
+
+@[simp] theorem transpositionMap_apply (A : Matrix (Fin d) (Fin d) ℂ) :
+    transpositionMap d A = Aᵀ := rfl
+
+/-- Transposition is a positive map: it preserves positive semidefiniteness.
+
+For a positive semidefinite `A`, the transpose `Aᵀ` shares the eigenvalues of
+`A` (Wolf, Chapter 3, §3.1), so it is again positive semidefinite. -/
+theorem transpositionMap_isPositiveMap : IsPositiveMap (transpositionMap d) :=
+  fun _ hA => by simpa using hA.transpose
+
+/-- Transposition is trace preserving: `Tr(Aᵀ) = Tr(A)`. -/
+theorem transpositionMap_isTracePreservingMap : IsTracePreservingMap (transpositionMap d) :=
+  fun A => by simp
+
+end Transposition

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -129,6 +129,40 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     $E(X)^\dagger=E(X)^\ast=E(X^\ast)=E(X)$.
 \end{proof}
 
+\begin{definition}[Transposition map]\label{def:transposition_map}
+    \lean{transpositionMap}
+    \leanok
+    The \emph{transposition map} $\theta : \MN{D} \to \MN{D}$ sends a matrix to
+    its transpose, $\theta(A) = A^{T}$, where $A^{T}$ is taken with respect to a
+    fixed orthonormal basis, $\langle i | A^{T} | j \rangle = \langle j | A | i
+    \rangle$.
+\end{definition}
+
+\begin{theorem}[Transposition is positive]\label{thm:transposition_positive}
+    \lean{transpositionMap_isPositiveMap}
+    \leanok
+    \uses{def:transposition_map, def:positive_map}
+    The transposition map is positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $A \ge 0$ then $A$ is Hermitian with spectral decomposition $A = U D
+    U^\dagger$, where $U$ is unitary and $D$ is diagonal with nonnegative
+    entries. Hence $A^{T} = \overline{U} D U^{T}$, which has the same
+    eigenvalues $D$, so $A^{T} \ge 0$.
+\end{proof}
+
+\begin{theorem}[Transposition is trace-preserving]\label{thm:transposition_trace_preserving}
+    \lean{transpositionMap_isTracePreservingMap}
+    \leanok
+    \uses{def:transposition_map, def:trace_preserving}
+    The transposition map is trace-preserving: $\tr(A^{T}) = \tr(A)$.
+\end{theorem}
+
+\begin{proof}\leanok
+    Transposition fixes the diagonal entries of $A$, hence preserves their sum.
+\end{proof}
+
 \begin{definition}[Quantum channel]\label{def:channel}
     \lean{IsChannel}
     \leanok


### PR DESCRIPTION
### Motivation

- Formalizes Wolf, *Quantum Channels & Operations*, Ch. 3, §3.1 (lines ~32–37 of `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`): the matrix transposition map θ : M_d(ℂ) → M_d(ℂ), θ(A) = Aᵀ, is positive and trace-preserving.
- Continues formalization of Wolf Ch. 3, tracked in LionSR/QICLean#25.

### Description

- Adds `TNLean/Channel/Transposition.lean` with:
  - `transpositionMap`: the matrix transposition θ(A) = Aᵀ on M_d(ℂ) as a ℂ-linear map.
  - `transpositionMap_isPositiveMap`: θ is positive; proof reduces to `Matrix.PosSemidef.transpose`.
  - `transpositionMap_isTracePreservingMap`: θ is trace-preserving; proof uses `Matrix.trace_transpose`.
  - Both results are stated for general d with no extra hypotheses beyond the matrix algebra.
- Registers the module in `TNLean.lean`.
- Adds blueprint entries in `blueprint/src/chapter/ch04_channels.tex` with the transposition definition and the positivity and trace-preservation theorems linked via `\lean{}` tags.

### Testing

- Relies on Lean CI (`lean_action_ci.yml`) to validate `lake build`.

---
Addresses LionSR/QICLean#162

> [!NOTE]
> **Low Risk**
> Additive Lean and blueprint content only; proofs are short and reuse existing `Channel.Basic` predicates with no changes to channel or auth-critical paths.
>
> **Overview**
> Adds **`transpositionMap`** on `M_d(ℂ)` (matrix transpose as a `ℂ`-linear map) and proves it is **`IsPositiveMap`** and **`IsTracePreservingMap`**, using Mathlib's PSD transpose lemma and `simp` for trace.
>
> Exposes the module via **`TNLean.lean`** and extends **blueprint ch. 4** with the transposition definition and linked positivity / trace-preserving theorems before the quantum-channel definition.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd291271b76d29816cc689250e1bef9b932de3bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>