### PR TITLE
feat(Analysis): add Lorentz cone trace inequality

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -41,6 +41,7 @@ import TNLean.Algebra.CocycleCohomology
 import TNLean.Analysis.ProjectionGeometry
 -- Layer 0b: Trace of the Hermitian functional calculus (Mathlib-only matrix lemma)
 import TNLean.Analysis.TraceCFC
+import TNLean.Analysis.MatrixTraceInequalities
 
 -- Layer 1: Generic convex/topological infrastructure
 import TNLean.Topology.ConvexProjection

--- a/TNLean/Analysis/MatrixTraceInequalities.lean
+++ b/TNLean/Analysis/MatrixTraceInequalities.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Algebra.PerronFrobenius.RankOne
+
+/-!
+# Trace inequalities for positive semidefinite matrices
+
+This module records finite-dimensional matrix trace inequalities used in
+Wolf's discussion of Lorentz cones for positive maps. The first result is the
+forward implication in Wolf, Chapter 3, Proposition 3.9: if `A ≥ 0`, then
+`tr(A^2) ≤ tr(A)^2`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3][Wolf2012QChannels]
+-/
+
+open scoped BigOperators Matrix ComplexOrder
+open Matrix Finset
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+private lemma ofReal_sq_re (r : ℝ) : Complex.re ((r : ℂ) ^ 2) = r ^ 2 := by
+  have hpow : ((r : ℂ) ^ 2) = ((r ^ 2 : ℝ) : ℂ) := (Complex.ofReal_pow r 2).symm
+  calc
+    Complex.re ((r : ℂ) ^ 2) = Complex.re (((r ^ 2 : ℝ) : ℂ)) :=
+      congrArg Complex.re hpow
+    _ = r ^ 2 := Complex.ofReal_re _
+
+/-- Wolf Chapter 3, Proposition 3.9, forward implication.
+
+If `A` is positive semidefinite, then the real trace of `A ^ 2` is bounded by
+the square of the real trace of `A`. In eigenvalues this is
+`∑ᵢ λᵢ^2 ≤ (∑ᵢ λᵢ)^2`, with all `λᵢ ≥ 0`. -/
+theorem PosSemidef.trace_sq_re_le_trace_re_sq
+    {A : Matrix n n ℂ} (hA : A.PosSemidef) :
+    (Matrix.trace (A ^ 2)).re ≤ (Matrix.trace A).re ^ 2 := by
+  let hH := hA.isHermitian
+  set lam : n → ℝ := hH.eigenvalues with hlam
+  have htrace : (Matrix.trace A).re = ∑ i, lam i := by
+    have h := hH.trace_eq_sum_eigenvalues
+    change Matrix.trace A = ∑ i, (lam i : ℂ) at h
+    rw [h]
+    simp
+  have htrace2 : (Matrix.trace (A ^ 2)).re = ∑ i, lam i ^ 2 := by
+    have h := hH.trace_sq_eq_sum_eigenvalues_sq
+    change Matrix.trace (A ^ 2) = ∑ i, (lam i : ℂ) ^ 2 at h
+    rw [h]
+    rw [Complex.re_sum]
+    exact Finset.sum_congr rfl (fun i _ => ofReal_sq_re (lam i))
+  rw [htrace, htrace2]
+  exact Finset.sum_sq_le_sq_sum_of_nonneg (s := Finset.univ) (f := lam)
+    (fun i _ => by
+      rw [hlam]
+      exact hA.eigenvalues_nonneg i)
+
+end Matrix

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -57,7 +57,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \leanok
     If $A \in \MN{D}$ is positive semidefinite, then
     \[
-        \tr(A^2) \le \tr(A)^2 .
+        \operatorname{Re}\tr(A^2) \le \left(\operatorname{Re}\tr(A)\right)^2 .
     \]
 \end{theorem}
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -51,6 +51,26 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     Trace preservation is the identity $\tr(X^T)=\tr(X)$.
 \end{proof}
 
+\begin{theorem}[Forward Lorentz-cone trace inequality]
+    \label{thm:psd_trace_square_le_square_trace}
+    \lean{Matrix.PosSemidef.trace_sq_re_le_trace_re_sq}
+    \leanok
+    If $A \in \MN{D}$ is positive semidefinite, then
+    \[
+        \tr(A^2) \le \tr(A)^2 .
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Diagonalize $A$ with nonnegative eigenvalues $\lambda_i$. Then
+    $\tr(A^2)=\sum_i \lambda_i^2$ and $\tr(A)=\sum_i \lambda_i$, so the
+    desired inequality is
+    \[
+        \sum_i \lambda_i^2 \le \left(\sum_i \lambda_i\right)^2 ,
+    \]
+    which follows because all mixed products are nonnegative.
+\end{proof}
+
 \begin{definition}[Completely positive map]\label{def:cp_map}
     \lean{IsCPMap}
     \leanok


### PR DESCRIPTION
### Motivation
- Wolf Ch. 3, Proposition 3.9 (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~650–736) states: for Hermitian $A \in M_d$, $A \geq 0 \Rightarrow \operatorname{tr}[A]^2 \geq \operatorname{tr}[A^2]$. This PR formalizes the forward implication, as part of the open formalization task in LionSR/QICLean#20.

### Description
- Adds `TNLean/Analysis/MatrixTraceInequalities.lean` with `Matrix.PosSemidef.trace_sq_re_le_trace_re_sq`: for positive semidefinite `A`, `Re(tr(A²)) ≤ (Re tr A)²`. The proof proceeds by diagonalizing `A` to nonneg eigenvalues and applying `Finset.sum_sq_le_sq_sum_of_nonneg`.
- Adds the new module to the root `TNLean.lean` import.
- Adds a blueprint theorem entry in `blueprint/src/chapter/ch04_channels.tex` for the forward Lorentz-cone trace inequality, with `\leanok`.
- The converse in Prop. 3.9, the automorphism/rank classification (Prop. 3.8), and the trace-preserving rescaling lemma remain open in LionSR/QICLean#20.

### Testing
- `lake build TNLean.Analysis.MatrixTraceInequalities`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch04_channels.tex`
- `git diff --check`

---
Addresses LionSR/QICLean#20

> [!NOTE]
> **Low Risk**
> Small, self-contained analysis lemma with no changes to channels, auth, or core infrastructure; only a new module, one root import, and blueprint text.
>
> **Overview**
> Adds **`Matrix.PosSemidef.trace_sq_re_le_trace_re_sq`**, the forward half of Wolf Ch. 3 Prop. 3.9: for PSD `A`, **Re(tr(A²)) ≤ (Re tr A)²**, proved by diagonalizing to nonneg eigenvalues and closing with **`Finset.sum_sq_le_sq_sum_of_nonneg`**.
>
> Introduces **`TNLean.Analysis.MatrixTraceInequalities`**, wires it into the root **`TNLean`** import surface, and documents the result in **`ch04_channels.tex`** as the forward Lorentz-cone trace inequality (blueprint `\leanok`).
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34672671fc78117485006c123fc74a49d1a3b4e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained analysis lemma plus root import and blueprint text; no changes to channels, auth, or core infrastructure.
> 
> **Overview**
> Formalizes the **forward implication** of Wolf Ch. 3, Prop. 3.9: for PSD `A`, **Re(tr(A²)) ≤ (Re tr A)²**, as progress on LionSR/QICLean#20.
> 
> Adds **`TNLean.Analysis.MatrixTraceInequalities`** with **`Matrix.PosSemidef.trace_sq_re_le_trace_re_sq`**, proved by Hermitian diagonalization to nonnegative eigenvalues and **`Finset.sum_sq_le_sq_sum_of_nonneg`**. The module is imported from **`TNLean.lean`**, and **`ch04_channels.tex`** gains a `\leanok` blueprint theorem linking the forward Lorentz-cone trace inequality to that lemma.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b80edc1f46e8b3ba76bec6c6d7a91a04a2498ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->