### PR TITLE
feat(Channel): prove transposition is not completely positive

### DIFF
--- a/TNLean/Channel/ChoiJamiolkowski.lean
+++ b/TNLean/Channel/ChoiJamiolkowski.lean
@@ -663,17 +663,14 @@ private noncomputable def finTwoAntisymmVec : Fin 2 × Fin 2 → ℂ
   | (1, 0) => -1
   | _ => 0
 
-private def finTwoToFin {D : ℕ} (hD : 2 ≤ D) : Fin 2 → Fin D :=
-  fun i => ⟨i, by omega⟩
-
 private theorem scaled_swap_submatrix_finTwo {D : ℕ} (hD : 2 ≤ D) :
     (((1 / (D : ℂ)) • Matrix.swapMatrix D).submatrix
-      (fun p : Fin 2 × Fin 2 => (finTwoToFin hD p.1, finTwoToFin hD p.2))
-      (fun p : Fin 2 × Fin 2 => (finTwoToFin hD p.1, finTwoToFin hD p.2))) =
+      (fun p : Fin 2 × Fin 2 => (Fin.castLE hD p.1, Fin.castLE hD p.2))
+      (fun p : Fin 2 × Fin 2 => (Fin.castLE hD p.1, Fin.castLE hD p.2))) =
         (1 / (D : ℂ)) • Matrix.swapMatrix 2 := by
   ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
   fin_cases i₁ <;> fin_cases i₂ <;> fin_cases j₁ <;> fin_cases j₂ <;>
-    simp [finTwoToFin, Matrix.swapMatrix_apply]
+    simp [Matrix.swapMatrix_apply]
 
 private theorem scaled_swap_negative {D : ℕ} :
     star finTwoAntisymmVec ⬝ᵥ
@@ -683,10 +680,10 @@ private theorem scaled_swap_negative {D : ℕ} :
     Matrix.swapMatrix_apply]
   ring
 
-/-- **Wolf Chapter 3, Equation (3.1).** In dimension at least two, matrix
-transposition is not completely positive. The obstruction is the negative
-expectation of the normalized flip operator on the antisymmetric vector
-\(|01\rangle-|10\rangle\). -/
+/-- As a consequence of Wolf Chapter 3, Equation (3.1), matrix transposition is
+not completely positive in dimension at least two. The obstruction is the
+negative expectation of the normalized flip operator on the antisymmetric
+vector \(|01\rangle-|10\rangle\). -/
 theorem transposeLinearMapComplex_not_isCPMap {D : ℕ} (hD : 2 ≤ D) :
     ¬ IsCPMap (Matrix.transposeLinearMapComplex (Fin D)) := by
   intro hcp
@@ -697,7 +694,7 @@ theorem transposeLinearMapComplex_not_isCPMap {D : ℕ} (hD : 2 ≤ D) :
       (T := Matrix.transposeLinearMapComplex (Fin D))).mp hcp
   have hpsd₂ : (((1 / (D : ℂ)) • Matrix.swapMatrix 2)).PosSemidef := by
     have hsub := hpsd.submatrix
-      (fun p : Fin 2 × Fin 2 => (finTwoToFin hD p.1, finTwoToFin hD p.2))
+      (fun p : Fin 2 × Fin 2 => (Fin.castLE hD p.1, Fin.castLE hD p.2))
     rw [choiMatrix_transposeLinearMapComplex_eq_swap hDpos,
       scaled_swap_submatrix_finTwo hD] at hsub
     exact hsub

--- a/TNLean/Channel/ChoiJamiolkowski.lean
+++ b/TNLean/Channel/ChoiJamiolkowski.lean
@@ -658,11 +658,6 @@ theorem choiMatrix_transposeLinearMapComplex_eq_swap (hD : 0 < D) :
     rw [hsingle]
     simp [Matrix.swapMatrix_apply, h]
 
-private noncomputable def finTwoAntisymmVec : Fin 2 × Fin 2 → ℂ
-  | (0, 1) => 1
-  | (1, 0) => -1
-  | _ => 0
-
 private theorem scaled_swap_submatrix_finTwo {D : ℕ} (hD : 2 ≤ D) :
     (((1 / (D : ℂ)) • Matrix.swapMatrix D).submatrix
       (fun p : Fin 2 × Fin 2 => (Fin.castLE hD p.1, Fin.castLE hD p.2))
@@ -673,10 +668,10 @@ private theorem scaled_swap_submatrix_finTwo {D : ℕ} (hD : 2 ≤ D) :
     simp [Matrix.swapMatrix_apply]
 
 private theorem scaled_swap_negative {D : ℕ} :
-    star finTwoAntisymmVec ⬝ᵥ
-        (((1 / (D : ℂ)) • Matrix.swapMatrix 2).mulVec finTwoAntisymmVec) =
+    star Matrix.finTwoAntisymmVec ⬝ᵥ
+        (((1 / (D : ℂ)) • Matrix.swapMatrix 2).mulVec Matrix.finTwoAntisymmVec) =
       (-(2 / (D : ℂ)) : ℂ) := by
-  simp [dotProduct, Matrix.mulVec, Fintype.sum_prod_type, finTwoAntisymmVec,
+  simp [dotProduct, Matrix.mulVec, Fintype.sum_prod_type, Matrix.finTwoAntisymmVec,
     Matrix.swapMatrix_apply]
   ring
 
@@ -698,10 +693,11 @@ theorem transposeLinearMapComplex_not_isCPMap {D : ℕ} (hD : 2 ≤ D) :
     rw [choiMatrix_transposeLinearMapComplex_eq_swap hDpos,
       scaled_swap_submatrix_finTwo hD] at hsub
     exact hsub
-  have hnonneg := (Matrix.posSemidef_iff_dotProduct_mulVec.mp hpsd₂).2 finTwoAntisymmVec
+  have hnonneg := (Matrix.posSemidef_iff_dotProduct_mulVec.mp hpsd₂).2
+    Matrix.finTwoAntisymmVec
   have hneg : ¬ (0 : ℂ) ≤
-      star finTwoAntisymmVec ⬝ᵥ
-        (((1 / (D : ℂ)) • Matrix.swapMatrix 2).mulVec finTwoAntisymmVec) := by
+      star Matrix.finTwoAntisymmVec ⬝ᵥ
+        (((1 / (D : ℂ)) • Matrix.swapMatrix 2).mulVec Matrix.finTwoAntisymmVec) := by
     rw [scaled_swap_negative, RCLike.nonneg_iff]
     norm_num
     have hDreal : (0 : ℝ) < (D : ℝ) := Nat.cast_pos.mpr hDpos

--- a/TNLean/Channel/ChoiJamiolkowski.lean
+++ b/TNLean/Channel/ChoiJamiolkowski.lean
@@ -626,6 +626,91 @@ theorem choiMatrix_id :
   ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
   simp [choiMatrix, Matrix.tensorMapId_apply, Matrix.bipartiteSlice]
 
+/-! ### Transposition and the flip operator -/
+
+/-- **Wolf Chapter 3, Equation (3.1).** The Choi matrix of transposition is the
+normalized flip operator:
+\[
+  (\theta \otimes \mathrm{id})(|\Omega\rangle\langle\Omega|) = D^{-1}F.
+\] -/
+theorem choiMatrix_transposeLinearMapComplex_eq_swap (hD : 0 < D) :
+    choiMatrix (Matrix.transposeLinearMapComplex (Fin D)) =
+      (1 / (D : ℂ)) • Matrix.swapMatrix D := by
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rw [choiMatrix_apply, omegaSlice_eq_single]
+  let c : ℂ := (((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) *
+      star ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)))
+  have hc : c = 1 / (D : ℂ) := omegaCoeff_eq_inv hD
+  change (Matrix.transposeLinearMapComplex (Fin D) (Matrix.single i₂ j₂ c)) i₁ j₁ =
+    ((1 / (D : ℂ)) • Matrix.swapMatrix D) (i₁, i₂) (j₁, j₂)
+  rw [hc]
+  change Matrix.single i₂ j₂ (1 / (D : ℂ)) j₁ i₁ =
+    ((1 / (D : ℂ)) • Matrix.swapMatrix D) (i₁, i₂) (j₁, j₂)
+  by_cases h : i₁ = j₂ ∧ i₂ = j₁
+  · rcases h with ⟨h₁, h₂⟩
+    subst h₁
+    subst h₂
+    simp [Matrix.swapMatrix_apply]
+  · have hsingle : Matrix.single i₂ j₂ (1 / (D : ℂ)) j₁ i₁ = 0 := by
+      rw [Matrix.single_apply, if_neg]
+      intro hcond
+      exact h ⟨hcond.2.symm, hcond.1⟩
+    rw [hsingle]
+    simp [Matrix.swapMatrix_apply, h]
+
+private noncomputable def finTwoAntisymmVec : Fin 2 × Fin 2 → ℂ
+  | (0, 1) => 1
+  | (1, 0) => -1
+  | _ => 0
+
+private def finTwoToFin {D : ℕ} (hD : 2 ≤ D) : Fin 2 → Fin D :=
+  fun i => ⟨i, by omega⟩
+
+private theorem scaled_swap_submatrix_finTwo {D : ℕ} (hD : 2 ≤ D) :
+    (((1 / (D : ℂ)) • Matrix.swapMatrix D).submatrix
+      (fun p : Fin 2 × Fin 2 => (finTwoToFin hD p.1, finTwoToFin hD p.2))
+      (fun p : Fin 2 × Fin 2 => (finTwoToFin hD p.1, finTwoToFin hD p.2))) =
+        (1 / (D : ℂ)) • Matrix.swapMatrix 2 := by
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  fin_cases i₁ <;> fin_cases i₂ <;> fin_cases j₁ <;> fin_cases j₂ <;>
+    simp [finTwoToFin, Matrix.swapMatrix_apply]
+
+private theorem scaled_swap_negative {D : ℕ} :
+    star finTwoAntisymmVec ⬝ᵥ
+        (((1 / (D : ℂ)) • Matrix.swapMatrix 2).mulVec finTwoAntisymmVec) =
+      (-(2 / (D : ℂ)) : ℂ) := by
+  simp [dotProduct, Matrix.mulVec, Fintype.sum_prod_type, finTwoAntisymmVec,
+    Matrix.swapMatrix_apply]
+  ring
+
+/-- **Wolf Chapter 3, Equation (3.1).** In dimension at least two, matrix
+transposition is not completely positive. The obstruction is the negative
+expectation of the normalized flip operator on the antisymmetric vector
+\(|01\rangle-|10\rangle\). -/
+theorem transposeLinearMapComplex_not_isCPMap {D : ℕ} (hD : 2 ≤ D) :
+    ¬ IsCPMap (Matrix.transposeLinearMapComplex (Fin D)) := by
+  intro hcp
+  have hDpos : 0 < D := lt_of_lt_of_le (by norm_num) hD
+  letI : NeZero D := ⟨Nat.ne_of_gt hDpos⟩
+  have hpsd : (choiMatrix (Matrix.transposeLinearMapComplex (Fin D))).PosSemidef :=
+    (cp_iff_choi_posSemidef (D := D)
+      (T := Matrix.transposeLinearMapComplex (Fin D))).mp hcp
+  have hpsd₂ : (((1 / (D : ℂ)) • Matrix.swapMatrix 2)).PosSemidef := by
+    have hsub := hpsd.submatrix
+      (fun p : Fin 2 × Fin 2 => (finTwoToFin hD p.1, finTwoToFin hD p.2))
+    rw [choiMatrix_transposeLinearMapComplex_eq_swap hDpos,
+      scaled_swap_submatrix_finTwo hD] at hsub
+    exact hsub
+  have hnonneg := (Matrix.posSemidef_iff_dotProduct_mulVec.mp hpsd₂).2 finTwoAntisymmVec
+  have hneg : ¬ (0 : ℂ) ≤
+      star finTwoAntisymmVec ⬝ᵥ
+        (((1 / (D : ℂ)) • Matrix.swapMatrix 2).mulVec finTwoAntisymmVec) := by
+    rw [scaled_swap_negative, RCLike.nonneg_iff]
+    norm_num
+    have hDreal : (0 : ℝ) < (D : ℝ) := Nat.cast_pos.mpr hDpos
+    positivity
+  exact hneg hnonneg
+
 /-! ### Normalization and trace -/
 
 /-- **Proposition 2.1, trace normalization** (Wolf):

--- a/TNLean/Channel/MaximallyEntangled.lean
+++ b/TNLean/Channel/MaximallyEntangled.lean
@@ -21,6 +21,7 @@ as needed for the Choi–Jamiolkowski isomorphism (Wolf Chapter 2).
   as a function `Fin d × Fin d → ℂ`
 * `Matrix.omegaProj d`: the projector `|Ω⟩⟨Ω|` as a matrix on `Fin d × Fin d`
 * `Matrix.swapMatrix d`: the SWAP operator `F` on `ℂ^d ⊗ ℂ^d`
+* `Matrix.finTwoAntisymmVec`: the antisymmetric vector `|01⟩ - |10⟩`
 
 ## Main results
 
@@ -84,6 +85,13 @@ noncomputable def swapMatrix (d : ℕ) :
 @[simp]
 theorem swapMatrix_apply (i₁ i₂ j₁ j₂ : Fin d) :
     swapMatrix d (i₁, i₂) (j₁, j₂) = if i₁ = j₂ ∧ i₂ = j₁ then 1 else 0 := rfl
+
+/-- The antisymmetric vector `|01⟩ - |10⟩` in `ℂ^2 ⊗ ℂ^2`. -/
+def finTwoAntisymmVec : Fin 2 × Fin 2 → ℂ :=
+  fun
+    | (0, 1) => 1
+    | (1, 0) => -1
+    | _ => 0
 
 /-- `F² = 1`: the SWAP operator is an involution. -/
 theorem swapMatrix_mul_self :

--- a/TNLean/Channel/Schwarz/SchwarzNotCP.lean
+++ b/TNLean/Channel/Schwarz/SchwarzNotCP.lean
@@ -212,12 +212,6 @@ theorem wolfExample53_satisfies_schwarz (A : M2) :
     simpa [htranslate] using hB
   simpa [wolfExample53Gap] using hA'
 
-/-- A concrete antisymmetric witness for the non-CP statement. -/
-noncomputable def wolfExample53AntisymmVec : Fin 2 × Fin 2 → ℂ
-  | (0, 1) => 1
-  | (1, 0) => -1
-  | _ => 0
-
 private lemma omegaCoeff_fin2 :
     (((1 : ℂ) / ((2 : ℝ).sqrt : ℂ)) * star ((1 : ℂ) / ((2 : ℝ).sqrt : ℂ))) =
       (1 / 2 : ℂ) := by
@@ -267,10 +261,10 @@ private lemma wolfExample53_choi_apply (i1 i2 j1 j2 : Fin 2) :
 /-- The Choi matrix of `wolfExample53` has a negative expectation value on the
 antisymmetric vector `|01⟩ - |10⟩`, hence is not positive semidefinite. -/
 theorem wolfExample53_choi_negative_antisymm :
-    star wolfExample53AntisymmVec ⬝ᵥ
-        (ChoiJamiolkowski.choiMatrix wolfExample53).mulVec wolfExample53AntisymmVec =
+    star Matrix.finTwoAntisymmVec ⬝ᵥ
+        (ChoiJamiolkowski.choiMatrix wolfExample53).mulVec Matrix.finTwoAntisymmVec =
       (- (1 / 4 : ℂ)) := by
-  simp [dotProduct, Matrix.mulVec, Fintype.sum_prod_type, wolfExample53AntisymmVec,
+  simp [dotProduct, Matrix.mulVec, Fintype.sum_prod_type, Matrix.finTwoAntisymmVec,
     wolfExample53_choi_apply]
   ring
 
@@ -279,10 +273,11 @@ theorem wolfExample53_not_cp : ¬ IsCPMap wolfExample53 := by
   intro hcp
   have hpsd : (ChoiJamiolkowski.choiMatrix wolfExample53).PosSemidef :=
     (ChoiJamiolkowski.cp_iff_choi_posSemidef (D := 2) (T := wolfExample53)).mp hcp
-  have hnonneg := (Matrix.posSemidef_iff_dotProduct_mulVec.mp hpsd).2 wolfExample53AntisymmVec
+  have hnonneg := (Matrix.posSemidef_iff_dotProduct_mulVec.mp hpsd).2
+    Matrix.finTwoAntisymmVec
   have hneg : ¬ (0 : ℂ) ≤
-      star wolfExample53AntisymmVec ⬝ᵥ
-        (ChoiJamiolkowski.choiMatrix wolfExample53).mulVec wolfExample53AntisymmVec := by
+      star Matrix.finTwoAntisymmVec ⬝ᵥ
+        (ChoiJamiolkowski.choiMatrix wolfExample53).mulVec Matrix.finTwoAntisymmVec := by
     rw [wolfExample53_choi_negative_antisymm, RCLike.nonneg_iff]
     norm_num
   exact hneg hnonneg

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -65,6 +65,29 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     to $E \otimes \id_n$ being positive for all~$n$.
 \end{definition}
 
+\begin{theorem}[Transposition is not completely positive]
+    \label{thm:transpose_not_completely_positive}
+    \lean{ChoiJamiolkowski.transposeLinearMapComplex_not_isCPMap}
+    \leanok
+    \uses{def:cp_map, def:flip_operator, thm:choi_transpose_flip,
+        thm:cp_iff_choi_posSemidef}
+    If $D \ge 2$, the matrix transposition map $\theta(X)=X^T$ on $\MN{D}$
+    is not completely positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:flip_operator, thm:choi_transpose_flip,
+        thm:cp_iff_choi_posSemidef}
+    If $\theta$ were completely positive, its Choi matrix would be positive
+    semidefinite. By Theorem~\ref{thm:choi_transpose_flip}, this Choi matrix is
+    $D^{-1}F$. For the antisymmetric vector
+    $v=\ket{01}-\ket{10}$,
+    \[
+        \bra{v}\,D^{-1}F\,\ket{v} = -\frac{2}{D} < 0,
+    \]
+    contradicting positive semidefiniteness.
+\end{proof}
+
 \begin{theorem}[Entrywise complete positivity from a Kraus representation]
     \label{thm:cp_map_entrywise_complete_positive}
     \lean{IsCPMap.map_cstarMatrix_nonneg}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -69,14 +69,14 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \label{thm:transpose_not_completely_positive}
     \lean{ChoiJamiolkowski.transposeLinearMapComplex_not_isCPMap}
     \leanok
-    \uses{def:cp_map, def:flip_operator, thm:choi_transpose_flip,
-        thm:cp_iff_choi_posSemidef}
+    \uses{def:cp_map, def:flip_operator, def:fin_two_antisymm_vec,
+        thm:choi_transpose_flip, thm:cp_iff_choi_posSemidef}
     If $D \ge 2$, the matrix transposition map $\theta(X)=X^T$ on $\MN{D}$
     is not completely positive.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{def:flip_operator, thm:choi_transpose_flip,
+    \uses{def:flip_operator, def:fin_two_antisymm_vec, thm:choi_transpose_flip,
         thm:cp_iff_choi_posSemidef}
     If $\theta$ were completely positive, its Choi matrix would be positive
     semidefinite. By Theorem~\ref{thm:choi_transpose_flip}, this Choi matrix is

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -130,8 +130,7 @@ matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space:
 \begin{theorem}[Choi matrix of transposition]\label{thm:choi_transpose_flip}
     \lean{ChoiJamiolkowski.choiMatrix_transposeLinearMapComplex_eq_swap}
     \leanok
-    \uses{def:choi_matrix, def:flip_operator, def:maximally_entangled,
-        thm:transpose_positive_trace_preserving}
+    \uses{def:choi_matrix, def:flip_operator, def:maximally_entangled}
     Let $\theta(X)=X^T$ be matrix transposition on $\MN{D}$, with $D \ge 1$.
     Then
     \[

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -70,6 +70,18 @@ of~\cite[Chapter~2]{Wolf2012Quantum}.
     \]
 \end{definition}
 
+\begin{definition}[Two-dimensional antisymmetric vector]
+    \label{def:fin_two_antisymm_vec}
+    \lean{Matrix.finTwoAntisymmVec}
+    \leanok
+    In $\C^2 \otimes \C^2$, let
+    \[
+        v = \ket{01} - \ket{10}.
+    \]
+    Equivalently, $v_{(0,1)}=1$, $v_{(1,0)}=-1$, and all other coefficients
+    are zero.
+\end{definition}
+
 \begin{definition}[Tensor product of a map with identity]\label{def:tensor_map_id}
     \lean{Matrix.tensorMapId}
     \leanok

--- a/blueprint/src/chapter/ch16_channel_representations.tex
+++ b/blueprint/src/chapter/ch16_channel_representations.tex
@@ -52,6 +52,24 @@ of~\cite[Chapter~2]{Wolf2012Quantum}.
     and $\tr(\ketbra{\Omega}{\Omega}) = 1$.
 \end{definition}
 
+\begin{definition}[Flip operator]\label{def:flip_operator}
+    \lean{Matrix.swapMatrix}
+    \leanok
+    The \emph{flip operator} $F$ on $\C^d \otimes \C^d$ is
+    \[
+        F = \sum_{i,j=0}^{d-1} \ket{ij}\!\bra{ji}.
+    \]
+    Its matrix entries are
+    \[
+        F_{(i_1,i_2),(j_1,j_2)}
+        =
+        \begin{cases}
+            1, & i_1=j_2 \text{ and } i_2=j_1,\\
+            0, & \text{otherwise}.
+        \end{cases}
+    \]
+\end{definition}
+
 \begin{definition}[Tensor product of a map with identity]\label{def:tensor_map_id}
     \lean{Matrix.tensorMapId}
     \leanok
@@ -107,6 +125,29 @@ matrix $\tau=(T\otimes\id)\ketbra{\Omega}{\Omega}$ on the doubled space:
 
 \begin{proof}\leanok
     Apply the identity map in the definition of the Choi matrix.
+\end{proof}
+
+\begin{theorem}[Choi matrix of transposition]\label{thm:choi_transpose_flip}
+    \lean{ChoiJamiolkowski.choiMatrix_transposeLinearMapComplex_eq_swap}
+    \leanok
+    \uses{def:choi_matrix, def:flip_operator, def:maximally_entangled,
+        thm:transpose_positive_trace_preserving}
+    Let $\theta(X)=X^T$ be matrix transposition on $\MN{D}$, with $D \ge 1$.
+    Then
+    \[
+        (\theta\otimes\id)(\ketbra{\Omega}{\Omega})
+        =
+        \frac{1}{D}F.
+    \]
+    This is \cite[Equation~3.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:choi_matrix, def:flip_operator}
+    The $(i_2,j_2)$ slice of $\ketbra{\Omega}{\Omega}$ is
+    $D^{-1}E_{i_2j_2}$. Transposition sends this matrix unit to
+    $D^{-1}E_{j_2i_2}$, whose $(i_1,j_1)$ entry is $D^{-1}$ exactly when
+    $i_1=j_2$ and $i_2=j_1$.
 \end{proof}
 
 \begin{theorem}[Complete positivity iff the Choi matrix is positive semidefinite]\label{thm:cp_iff_choi_posSemidef}


### PR DESCRIPTION
### Motivation

- Wolf Eq. (3.1) (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, eq. (3.1), lines ~38–48): the Choi matrix of transposition satisfies `(θ ⊗ id)(|Ω⟩⟨Ω|) = (1/D) F`, where the flip operator `F = Σ_{i,j} |ij⟩⟨ji|` has eigenvalues `±1` and is therefore indefinite for `D ≥ 2`.
- The indefiniteness of the Choi matrix shows that transposition is not completely positive.
- Continues the Wolf Ch. 3 formalization; part of tracking issue LionSR/QICLean#25 (§3.1).

### Description

- `TNLean/Channel/ChoiJamiolkowski.lean` (+85 lines):
  - `choiMatrix_transposeLinearMapComplex_eq_swap`: the Choi matrix of `transposeLinearMapComplex` equals `(1/D) • Matrix.swapMatrix` (Wolf Eq. 3.1).
  - `transposeLinearMapComplex_not_isCPMap`: for `2 ≤ D`, transposition is not completely positive; the proof assumes complete positivity, applies `cp_iff_choi_posSemidef`, restricts to a 2×2 block, and derives a contradiction via the antisymmetric vector `|01⟩ − |10⟩`, which yields quadratic form `−2/D < 0`.
- `blueprint/src/chapter/ch04_channels.tex` (+23 lines): blueprint entries for the flip operator definition and the Choi–flip identity with `\lean` and `\leanok` tags.
- `blueprint/src/chapter/ch16_channel_representations.tex` (+41 lines): blueprint entry for the non-CP theorem with `\lean` and `\leanok` tags.

### Testing

- `lake build TNLean.Channel.ChoiJamiolkowski -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`

---
Closes LionSR/QICLean#163

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds formal proofs and blueprint tags in channel theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Formalizes Wolf Eq. (3.1) and shows **matrix transposition is not completely positive** for dimension \(D \ge 2\).
> 
> **Lean:** `choiMatrix_transposeLinearMapComplex_eq_swap` identifies the Choi matrix of `transposeLinearMapComplex` with \((1/D)\,\texttt{swapMatrix}\). `transposeLinearMapComplex_not_isCPMap` assumes CP, applies `cp_iff_choi_posSemidef`, restricts to a \(2\times 2\) block, and contradicts PSD via quadratic form \(-2/D\) on the antisymmetric witness. **`Matrix.finTwoAntisymmVec`** (`|01\rangle - |10\rangle`) is added in `MaximallyEntangled.lean` and reused in `SchwarzNotCP.lean` (replacing a local duplicate).
> 
> **Blueprint:** `ch16` documents the flip operator, antisymmetric vector, and Choi–flip identity; `ch04` adds the non-CP transposition theorem with `\lean`/`\leanok` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78de093af2b981848f28716cbdad40f71823f027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->