### PR TITLE
feat(Channel/Schwarz): prove general n-positivity monotonicity

### DIFF
--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -310,6 +310,36 @@ theorem IsNPositiveMap.mono_of_le {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ
     (fun h => h)
     (fun _ _ ih hk => ih (IsNPositiveMap.mono hk)) k hmk h
 
+omit [DecidableEq n] [Fintype n] in
+/-- The zero map is `k`-positive. -/
+theorem IsNPositiveMap.zero (k : ℕ) :
+    IsNPositiveMap k (0 : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) := by
+  intro X hX
+  convert (Matrix.PosSemidef.zero : (0 : Matrix (n × Fin k) (n × Fin k) ℂ).PosSemidef)
+    using 1
+  ext ip jq
+  simp
+
+omit [DecidableEq n] [Fintype n] in
+/-- The sum of two `k`-positive maps is `k`-positive. -/
+theorem IsNPositiveMap.add {E F : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k : ℕ}
+    (hE : IsNPositiveMap k E) (hF : IsNPositiveMap k F) : IsNPositiveMap k (E + F) := by
+  intro X hX
+  convert Matrix.PosSemidef.add (hE X hX) (hF X hX) using 1
+  ext ip jq
+  simp
+
+omit [DecidableEq n] [Fintype n] in
+/-- A nonnegative real multiple of a `k`-positive map is `k`-positive. -/
+theorem IsNPositiveMap.smul_nonneg {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k : ℕ}
+    {c : ℝ} (hc : 0 ≤ c) (hE : IsNPositiveMap k E) : IsNPositiveMap k ((c : ℂ) • E) := by
+  intro X hX
+  have hcC : 0 ≤ (c : ℂ) := by
+    exact_mod_cast hc
+  convert (hE X hX).smul hcC using 1
+  ext ip jq
+  simp
+
 omit [DecidableEq n] in
 /-- CP maps are 2-positive. -/
 theorem IsCPMap.is2PositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -298,6 +298,18 @@ theorem IsNPositiveMap.mono {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {k :
   ext ip jq
   simp [emb, X', Matrix.reindex_apply, he_castSucc]
 
+omit [DecidableEq n] [Fintype n] in
+/-- If `m ≤ k`, then `k`-positivity implies `m`-positivity.
+
+This is the inclusion direction in Wolf Chapter 3, Equation (3.3):
+the cones of positive maps become larger as the amplification dimension
+decreases. -/
+theorem IsNPositiveMap.mono_of_le {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} {m k : ℕ}
+    (hmk : m ≤ k) (h : IsNPositiveMap k E) : IsNPositiveMap m E := by
+  exact Nat.le_induction (P := fun k _ => IsNPositiveMap k E → IsNPositiveMap m E)
+    (fun h => h)
+    (fun _ _ ih hk => ih (IsNPositiveMap.mono hk)) k hmk h
+
 omit [DecidableEq n] in
 /-- CP maps are 2-positive. -/
 theorem IsCPMap.is2PositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -134,6 +134,13 @@ maps.
     Positivity under amplification is monotone in $k$.
 \end{theorem}
 
+\begin{theorem}[$k$-positive implies $m$-positive for $m \le k$]
+    \lean{IsNPositiveMap.mono_of_le}
+    \leanok
+    If a linear map is positive after amplification by $k$ and $m \le k$, then
+    it is positive after amplification by $m$.
+\end{theorem}
+
 \begin{theorem}[Completely positive implies two-positive]
     \lean{IsCPMap.is2PositiveMap}
     \leanok

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -141,6 +141,24 @@ maps.
     it is positive after amplification by $m$.
 \end{theorem}
 
+\begin{theorem}[Zero map is $k$-positive]
+    \lean{IsNPositiveMap.zero}
+    \leanok
+    The zero map is $k$-positive.
+\end{theorem}
+
+\begin{theorem}[Sums of $k$-positive maps]
+    \lean{IsNPositiveMap.add}
+    \leanok
+    If $E$ and $F$ are $k$-positive, then $E+F$ is $k$-positive.
+\end{theorem}
+
+\begin{theorem}[Nonnegative multiples of $k$-positive maps]
+    \lean{IsNPositiveMap.smul_nonneg}
+    \leanok
+    If $E$ is $k$-positive and $c \ge 0$, then $cE$ is $k$-positive.
+\end{theorem}
+
 \begin{theorem}[Completely positive implies two-positive]
     \lean{IsCPMap.is2PositiveMap}
     \leanok

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -137,8 +137,7 @@ maps.
 \begin{theorem}[$k$-positive implies $m$-positive for $m \le k$]
     \lean{IsNPositiveMap.mono_of_le}
     \leanok
-    If a linear map is positive after amplification by $k$ and $m \le k$, then
-    it is positive after amplification by $m$.
+    If a linear map is $k$-positive and $m \le k$, then it is $m$-positive.
 \end{theorem}
 
 \begin{theorem}[Zero map is $k$-positive]


### PR DESCRIPTION
Refs LionSR/QICLean#164.

## Summary
- add `IsNPositiveMap.mono_of_le`, proving that `k`-positivity implies `m`-positivity whenever `m ≤ k`;
- add the basic cone-operation lemmas `IsNPositiveMap.zero`, `IsNPositiveMap.add`, and `IsNPositiveMap.smul_nonneg`;
- add the corresponding blueprint statements for the inclusion and algebraic cone directions of the n-positivity chain.

## Scope
This PR proves the algebraic monotonicity and cone-operation pieces of Wolf Chapter 3, equation (3.3). Closedness, duality, the completely-positive endpoint, and strictness of the chain remain open in LionSR/QICLean#164 and related issues.

## Verification
- `lake build TNLean.Channel.Schwarz.TwoPositive`
- `python3 scripts/blueprint_lean_sync.py --root . --diff-base origin/main --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `chktex -q -l blueprint/.chktexrc blueprint/src/chapter/ch05_schwarz.tex`
- `git diff --check`