### PR TITLE
feat(Channel/Schwarz): prove n-positive cone closedness

### DIFF
--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -340,13 +340,14 @@ theorem IsNPositiveMap.smul_nonneg {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n �
   ext ip jq
   simp
 
-omit [DecidableEq n] [Fintype n] in
+set_option linter.unusedFintypeInType false in
+set_option linter.unusedDecidableInType false in
 /-- The set of `k`-positive maps is closed.
 
 Wolf Chapter 3, Equation (3.3), treats the `k`-positive maps as closed convex
 cones.  This proves the closedness part for the topology inherited from the
 finite-dimensional space of linear maps. -/
-theorem isClosed_setOf_isNPositiveMap [Finite n] (k : ℕ) :
+theorem isClosed_setOf_isNPositiveMap (k : ℕ) :
     IsClosed {E : Matrix n n ℂ →L[ℂ] Matrix n n ℂ |
       IsNPositiveMap k E.toLinearMap} := by
   classical

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -340,6 +340,40 @@ theorem IsNPositiveMap.smul_nonneg {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n �
   ext ip jq
   simp
 
+omit [DecidableEq n] [Fintype n] in
+/-- The set of `k`-positive maps is closed.
+
+Wolf Chapter 3, Equation (3.3), treats the `k`-positive maps as closed convex
+cones.  This proves the closedness part for the topology inherited from the
+finite-dimensional space of linear maps. -/
+theorem isClosed_setOf_isNPositiveMap (D k : ℕ) :
+    IsClosed {E : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ |
+      IsNPositiveMap k E.toLinearMap} := by
+  classical
+  let ampEval (X : Matrix (Fin D × Fin k) (Fin D × Fin k) ℂ) :
+      (Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ) →ₗ[ℂ]
+        Matrix (Fin D × Fin k) (Fin D × Fin k) ℂ :=
+    { toFun := fun E => Matrix.of fun (ip : Fin D × Fin k) (jq : Fin D × Fin k) =>
+        (E (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1
+      map_add' := by
+        intro E F
+        ext ip jq
+        simp
+      map_smul' := by
+        intro c E
+        ext ip jq
+        simp }
+  have hset :
+      {E : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ |
+        IsNPositiveMap k E.toLinearMap}
+        = ⋂ (X : Matrix (Fin D × Fin k) (Fin D × Fin k) ℂ),
+          ⋂ (_hX : X.PosSemidef), {E | (ampEval X E).PosSemidef} := by
+    ext E
+    simp [IsNPositiveMap, ampEval]
+  rw [hset]
+  exact isClosed_iInter fun X => isClosed_iInter fun _hX =>
+    matrix_isClosed_posSemidef.preimage ((ampEval X).continuous_of_finiteDimensional)
+
 omit [DecidableEq n] in
 /-- CP maps are 2-positive. -/
 theorem IsCPMap.is2PositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -346,14 +346,14 @@ omit [DecidableEq n] [Fintype n] in
 Wolf Chapter 3, Equation (3.3), treats the `k`-positive maps as closed convex
 cones.  This proves the closedness part for the topology inherited from the
 finite-dimensional space of linear maps. -/
-theorem isClosed_setOf_isNPositiveMap (D k : ℕ) :
-    IsClosed {E : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ |
+theorem isClosed_setOf_isNPositiveMap [Finite n] (k : ℕ) :
+    IsClosed {E : Matrix n n ℂ →L[ℂ] Matrix n n ℂ |
       IsNPositiveMap k E.toLinearMap} := by
   classical
-  let ampEval (X : Matrix (Fin D × Fin k) (Fin D × Fin k) ℂ) :
-      (Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ) →ₗ[ℂ]
-        Matrix (Fin D × Fin k) (Fin D × Fin k) ℂ :=
-    { toFun := fun E => Matrix.of fun (ip : Fin D × Fin k) (jq : Fin D × Fin k) =>
+  let ampEval (X : Matrix (n × Fin k) (n × Fin k) ℂ) :
+      (Matrix n n ℂ →L[ℂ] Matrix n n ℂ) →ₗ[ℂ]
+        Matrix (n × Fin k) (n × Fin k) ℂ :=
+    { toFun := fun E => Matrix.of fun (ip : n × Fin k) (jq : n × Fin k) =>
         (E (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1
       map_add' := by
         intro E F
@@ -364,9 +364,9 @@ theorem isClosed_setOf_isNPositiveMap (D k : ℕ) :
         ext ip jq
         simp }
   have hset :
-      {E : Matrix (Fin D) (Fin D) ℂ →L[ℂ] Matrix (Fin D) (Fin D) ℂ |
+      {E : Matrix n n ℂ →L[ℂ] Matrix n n ℂ |
         IsNPositiveMap k E.toLinearMap}
-        = ⋂ (X : Matrix (Fin D × Fin k) (Fin D × Fin k) ℂ),
+        = ⋂ (X : Matrix (n × Fin k) (n × Fin k) ℂ),
           ⋂ (_hX : X.PosSemidef), {E | (ampEval X E).PosSemidef} := by
     ext E
     simp [IsNPositiveMap, ampEval]

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -340,14 +340,13 @@ theorem IsNPositiveMap.smul_nonneg {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n �
   ext ip jq
   simp
 
-set_option linter.unusedFintypeInType false in
-set_option linter.unusedDecidableInType false in
+omit [DecidableEq n] [Fintype n] in
 /-- The set of `k`-positive maps is closed.
 
 Wolf Chapter 3, Equation (3.3), treats the `k`-positive maps as closed convex
 cones.  This proves the closedness part for the topology inherited from the
 finite-dimensional space of linear maps. -/
-theorem isClosed_setOf_isNPositiveMap (k : ℕ) :
+theorem isClosed_setOf_isNPositiveMap [Finite n] (k : ℕ) :
     IsClosed {E : Matrix n n ℂ →L[ℂ] Matrix n n ℂ |
       IsNPositiveMap k E.toLinearMap} := by
   classical

--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -343,9 +343,10 @@ theorem IsNPositiveMap.smul_nonneg {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n �
 omit [DecidableEq n] [Fintype n] in
 /-- The set of `k`-positive maps is closed.
 
-Wolf Chapter 3, Equation (3.3), treats the `k`-positive maps as closed convex
-cones.  This proves the closedness part for the topology inherited from the
-finite-dimensional space of linear maps. -/
+Wolf Chapter 3, §3.1, lines 75--79 of
+`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, treats the
+`k`-positive maps as closed convex cones.  This proves the closedness part for
+the topology inherited from the finite-dimensional space of linear maps. -/
 theorem isClosed_setOf_isNPositiveMap [Finite n] (k : ℕ) :
     IsClosed {E : Matrix n n ℂ →L[ℂ] Matrix n n ℂ |
       IsNPositiveMap k E.toLinearMap} := by

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -158,7 +158,7 @@ maps.
     If $E$ is $k$-positive and $c \ge 0$, then $cE$ is $k$-positive.
 \end{theorem}
 
-\begin{theorem}[Closed cone of $k$-positive maps]
+\begin{theorem}[Closedness of $k$-positive maps]
     \lean{isClosed_setOf_isNPositiveMap}
     \leanok
     For each $k$, the set of $k$-positive linear maps is closed in the

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -158,6 +158,13 @@ maps.
     If $E$ is $k$-positive and $c \ge 0$, then $cE$ is $k$-positive.
 \end{theorem}
 
+\begin{theorem}[Closed cone of $k$-positive maps]
+    \lean{isClosed_setOf_isNPositiveMap}
+    \leanok
+    For each $k$, the set of $k$-positive linear maps is closed in the
+    finite-dimensional space of linear maps.
+\end{theorem}
+
 \begin{theorem}[Completely positive implies two-positive]
     \lean{IsCPMap.is2PositiveMap}
     \leanok


### PR DESCRIPTION
### Motivation

Wolf Chapter 3 states, in Equation (3.3), that the classes of n-positive maps form closed convex cones. The preceding PR established the elementary cone operations and monotonicity. This PR adds the closedness assertion.

Source: `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, §3.1, Equation (3.3), lines approximately 73-87.

### Description

- Adds `isClosed_setOf_isNPositiveMap` in `TNLean/Channel/Schwarz/TwoPositive.lean`.
- The proof writes k-positivity as the intersection, over positive semidefinite block matrices `X`, of inverse images of the closed positive semidefinite cone under the continuous amplified evaluation map.
- Adds the matching blueprint entry in `blueprint/src/chapter/ch05_schwarz.tex`.

Closedness is one part of LionSR/QICLean#164. The adjoint-duality statement, the endpoint identification with complete positivity, and the strictness results remain separate tasks.

### Testing

- `lake build TNLean.Channel.Schwarz.TwoPositive`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/Channel/Schwarz/TwoPositive.lean`

Addresses LionSR/QICLean#164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib topology on operator spaces with no runtime, auth, or data-path changes; pattern matches existing closed-PSD-cone proofs elsewhere in the repo.
> 
> **Overview**
> Adds **`isClosed_setOf_isNPositiveMap`**, showing that for fixed amplification dimension `k`, the set of `k`-positive continuous linear maps is **closed** in the finite-dimensional operator topology—one piece of Wolf’s closed convex cone picture for n-positivity (#3393).
> 
> The proof rewrites `k`-positivity as an intersection over PSD block matrices `X` of conditions “amplified evaluation output is PSD,” using a linear **`ampEval`** map on operators; each fiber is the preimage of the closed PSD cone under a continuous map, so **`isClosed_iInter`** finishes the argument. The blueprint chapter **`ch05_schwarz.tex`** gets a matching theorem entry wired to this Lean name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93679af89dfb0e7429464b50a26084bcdc7ad303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->