### PR TITLE
feat(Algebra): add trace-pairing adjoint

### DIFF
--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -79,6 +79,37 @@ theorem trace_mul_right_eq_zero_iff {n : Type*} [Fintype n]
       simpa using h N)
   · intro h N; simp [h]
 
+/-- The trace-pairing adjoint of a linear map on matrices.
+
+It is characterized by `trace (traceAdjointMap E ρ * X) = trace (ρ * E X)`. -/
+noncomputable def traceAdjointMap {n : Type*} [Fintype n] [DecidableEq n]
+    (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ where
+  toFun ρ := Matrix.of fun i j => Matrix.trace (ρ * E (Matrix.single j i 1))
+  map_add' ρ σ := by
+    ext i j
+    simp [Matrix.add_mul]
+  map_smul' c ρ := by
+    ext i j
+    simp
+
+/-- The trace-pairing adjoint satisfies the expected bilinear trace identity. -/
+theorem trace_traceAdjointMap_mul {n : Type*} [Fintype n] [DecidableEq n]
+    (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ)
+    (ρ X : Matrix n n ℂ) :
+    Matrix.trace (traceAdjointMap E ρ * X) = Matrix.trace (ρ * E X) := by
+  classical
+  refine Matrix.induction_on' X ?_ ?_ ?_
+  · simp [traceAdjointMap]
+  · intro X Y hX hY
+    simp [Matrix.mul_add, map_add, hX, hY]
+  · intro i j c
+    have hsingle : Matrix.single i j c = c • Matrix.single i j (1 : ℂ) := by
+      ext a b
+      simp [Matrix.single, smul_eq_mul]
+    rw [hsingle, map_smul, Matrix.mul_smul, Matrix.trace_smul]
+    simp [traceAdjointMap, Matrix.trace_mul_single]
+
 end Matrix
 
 namespace MPSTensor

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -81,7 +81,8 @@ theorem trace_mul_right_eq_zero_iff {n : Type*} [Fintype n]
 
 /-- The trace-pairing adjoint of a linear map on matrices.
 
-It is characterized by `trace (traceAdjointMap E ρ * X) = trace (ρ * E X)`. -/
+It is characterized by the identity
+tr(E^*(ρ) X) = tr(ρ E(X)) for the bilinear trace pairing. -/
 noncomputable def traceAdjointMap {n : Type*} [Fintype n] [DecidableEq n]
     (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
     Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ where

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -83,19 +83,23 @@ theorem trace_mul_right_eq_zero_iff {n : Type*} [Fintype n]
 
 It is characterized by the identity
 tr(E^*(ρ) X) = tr(ρ E(X)) for the bilinear trace pairing. -/
-noncomputable def traceAdjointMap {n : Type*} [Fintype n] [DecidableEq n]
+noncomputable def traceAdjointMap {n : Type*} [Fintype n]
     (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
-    Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ where
-  toFun ρ := Matrix.of fun i j => Matrix.trace (ρ * E (Matrix.single j i 1))
-  map_add' ρ σ := by
-    ext i j
-    simp [Matrix.add_mul]
-  map_smul' c ρ := by
-    ext i j
-    simp
+    Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ := by
+  classical
+  exact
+    { toFun := fun ρ => Matrix.of fun i j => Matrix.trace (ρ * E (Matrix.single j i 1))
+      map_add' := by
+        intro ρ σ
+        ext i j
+        simp [Matrix.add_mul]
+      map_smul' := by
+        intro c ρ
+        ext i j
+        simp }
 
 /-- The trace-pairing adjoint satisfies the expected bilinear trace identity. -/
-theorem trace_traceAdjointMap_mul {n : Type*} [Fintype n] [DecidableEq n]
+theorem trace_traceAdjointMap_mul {n : Type*} [Fintype n]
     (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ)
     (ρ X : Matrix n n ℂ) :
     Matrix.trace (traceAdjointMap E ρ * X) = Matrix.trace (ρ * E X) := by
@@ -109,7 +113,7 @@ theorem trace_traceAdjointMap_mul {n : Type*} [Fintype n] [DecidableEq n]
       ext a b
       simp [Matrix.single, smul_eq_mul]
     rw [hsingle, map_smul, Matrix.mul_smul, Matrix.trace_smul]
-    simp [traceAdjointMap, Matrix.trace_mul_single]
+    simp [traceAdjointMap, Matrix.trace_mul_single, MulOpposite.op_one, one_smul]
 
 end Matrix
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -141,7 +141,11 @@ maps.
 
 \begin{proof}
     \leanok
-    This is the defining trace-pairing identity of $E^*$.
+    Write $X=\sum_{i,j} X_{ij}e_{ij}$ in the standard matrix units and use
+    linearity in $X$.  For $X=e_{ij}$ one has
+    $\operatorname{tr}(E^*(\rho)e_{ij})=(E^*(\rho))_{ji}$, while the definition
+    of $E^*$ gives
+    $(E^*(\rho))_{ji}=\operatorname{tr}(\rho E(e_{ij}))$.
 \end{proof}
 
 \begin{theorem}[Completely positive maps are $k$-positive]

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -121,6 +121,22 @@ maps.
     A linear map is \emph{two-positive} if it is $2$-positive.
 \end{definition}
 
+\begin{definition}[Trace-pairing adjoint]
+    \lean{Matrix.traceAdjointMap}
+    \leanok
+    The trace-pairing adjoint $E^*$ of a linear map on matrices is the
+    adjoint for the bilinear pairing $(A,B)\mapsto \operatorname{tr}(AB)$.
+\end{definition}
+
+\begin{theorem}[Trace-pairing adjoint identity]
+    \lean{Matrix.trace_traceAdjointMap_mul}
+    \leanok
+    For all matrices $\rho$ and $X$, one has
+    \[
+        \operatorname{tr}(E^*(\rho)X)=\operatorname{tr}(\rho E(X)).
+    \]
+\end{theorem}
+
 \begin{theorem}[Completely positive maps are $k$-positive]
     \lean{IsCPMap.isNPositiveMap}
     \leanok

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -121,7 +121,7 @@ maps.
     A linear map is \emph{two-positive} if it is $2$-positive.
 \end{definition}
 
-\begin{definition}[Trace-pairing adjoint]
+\begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}
     \lean{Matrix.traceAdjointMap}
     \leanok
     The trace-pairing adjoint $E^*$ of a linear map on matrices is the
@@ -131,11 +131,18 @@ maps.
 \begin{theorem}[Trace-pairing adjoint identity]
     \lean{Matrix.trace_traceAdjointMap_mul}
     \leanok
-    For all matrices $\rho$ and $X$, one has
+    \uses{def:trace_pairing_adjoint}
+    For every linear map $E : \MN{D} \to \MN{D}$ and all matrices $\rho$
+    and $X$, one has
     \[
         \operatorname{tr}(E^*(\rho)X)=\operatorname{tr}(\rho E(X)).
     \]
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    This is the defining trace-pairing identity of $E^*$.
+\end{proof}
 
 \begin{theorem}[Completely positive maps are $k$-positive]
     \lean{IsCPMap.isNPositiveMap}


### PR DESCRIPTION
### Motivation

Wolf Chapter 3 uses the trace-pairing adjoint when stating the duality of the k-positive cones. The project already had Kraus-family adjoints, but not a general trace-pairing adjoint for an arbitrary linear map on matrices.

### Description

This adds `Matrix.traceAdjointMap`, the bilinear trace-pairing adjoint of a matrix linear map, together with `Matrix.trace_traceAdjointMap_mul`, its defining trace identity. The blueprint now records both entries in the two-positive maps section.

This is an infrastructure step toward the adjoint-duality part of LionSR/QICLean#164; it does not yet prove that k-positivity is invariant under this adjoint.

### Testing

- `lake build TNLean.Algebra.TracePairing -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `rg -n "sorry|axiom|admit|native_decide|unsafeCast" TNLean/Algebra/TracePairing.lean`

Refs LionSR/QICLean#164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained new definitions and proofs in `TracePairing.lean` plus blueprint sync; no changes to existing map or channel logic.
> 
> **Overview**
> Adds **`Matrix.traceAdjointMap`**, the trace-pairing adjoint of an arbitrary `ℂ`-linear map on square matrices, defined entrywise via standard matrix units and `tr(ρ · E(e_{ji}))`. **`Matrix.trace_traceAdjointMap_mul`** proves the defining identity `tr(E^*(ρ) X) = tr(ρ E(X))` by induction on `X`.
> 
> The blueprint’s two-positive maps section now records the definition and theorem (with a matrix-unit proof sketch), generalizing the existing Kraus-specific trace adjoint lemmas. No downstream duality or k-positivity invariance results are included yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028f043db7df92e009c6e358941f38ac5e94b583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->