### PR TITLE
feat(Algebra): add trace-pairing duality lemmas

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -30,6 +30,8 @@ Extracted from various files for reusability.
   AM--GM lower bound for the Hilbert--Schmidt trace form
 - `Matrix.PosSemidef.trace_mul_nonneg`: the trace product of two positive
   semidefinite matrices is nonnegative
+- `Matrix.PosSemidef.of_forall_trace_mul_nonneg`: self-duality of the positive
+  semidefinite cone for the trace pairing
 - `Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero`: a positive sum of squares
   vanishes only if every summand vanishes
 - `Matrix.eq_zero_of_sum_conjTranspose_mul_self_eq_zero`: the conjugate-transpose
@@ -219,6 +221,19 @@ theorem trace_mul_nonneg {A B : Matrix n n ℂ}
     simp [diagonal_apply]
   rw [hentry]
   exact mul_nonneg hdiag_nonneg (hΛ_nonneg i)
+
+/-- The positive semidefinite cone is self-dual for the trace pairing. -/
+theorem of_forall_trace_mul_nonneg {A : Matrix n n ℂ}
+    (hA : A.IsHermitian)
+    (h : ∀ B : Matrix n n ℂ, B.PosSemidef → 0 ≤ trace (A * B)) :
+    A.PosSemidef := by
+  classical
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg hA ?_
+  intro x
+  have hB : (Matrix.vecMulVec x (star x)).PosSemidef :=
+    Matrix.posSemidef_vecMulVec_self_star x
+  have htrace := h (Matrix.vecMulVec x (star x)) hB
+  simpa [Matrix.mul_vecMulVec, Matrix.trace_vecMulVec, dotProduct_comm] using htrace
 
 end PosSemidef
 

--- a/TNLean/Algebra/TracePairing.lean
+++ b/TNLean/Algebra/TracePairing.lean
@@ -18,6 +18,7 @@ on square matrices that are used throughout the proof of the Fundamental Theorem
 ## Main definitions and results
 
 * `Matrix.trace_mul_right_eq_zero_iff` — nondegeneracy of the trace pairing over `ℂ`
+* `Matrix.traceAdjointMap_traceAdjointMap` — the trace-pairing adjoint is involutive
 * `MPSTensor.traceMulRightPi` — the linear map `M ↦ (i ↦ trace (M * A i))`
 * `MPSTensor.SameMPV.trace_evalWord` — `SameMPV` implies trace agreement on all words
 * `MPSTensor.sameMPV_trace_word2` — auxiliary length-2 specialisation
@@ -114,6 +115,31 @@ theorem trace_traceAdjointMap_mul {n : Type*} [Fintype n]
       simp [Matrix.single, smul_eq_mul]
     rw [hsingle, map_smul, Matrix.mul_smul, Matrix.trace_smul]
     simp [traceAdjointMap, Matrix.trace_mul_single, MulOpposite.op_one, one_smul]
+
+/-- The trace-pairing adjoint is involutive. -/
+theorem traceAdjointMap_traceAdjointMap {n : Type*} [Fintype n]
+    (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    traceAdjointMap (traceAdjointMap E) = E := by
+  classical
+  apply LinearMap.ext
+  intro X
+  refine sub_eq_zero.mp ((trace_mul_right_eq_zero_iff
+    (M := traceAdjointMap (traceAdjointMap E) X - E X)).1 ?_)
+  intro N
+  have htrace :
+      Matrix.trace (traceAdjointMap (traceAdjointMap E) X * N) =
+        Matrix.trace (E X * N) := by
+    calc
+      Matrix.trace (traceAdjointMap (traceAdjointMap E) X * N)
+          = Matrix.trace (X * traceAdjointMap E N) :=
+            trace_traceAdjointMap_mul (traceAdjointMap E) X N
+      _ = Matrix.trace (traceAdjointMap E N * X) := by
+            rw [Matrix.trace_mul_comm]
+      _ = Matrix.trace (N * E X) :=
+            trace_traceAdjointMap_mul E N X
+      _ = Matrix.trace (E X * N) := by
+            rw [Matrix.trace_mul_comm]
+  simp [Matrix.sub_mul, Matrix.trace_sub, htrace]
 
 end Matrix
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -148,6 +148,37 @@ maps.
     $(E^*(\rho))_{ji}=\operatorname{tr}(\rho E(e_{ij}))$.
 \end{proof}
 
+\begin{theorem}[Trace-pairing adjoint is involutive]
+    \lean{Matrix.traceAdjointMap_traceAdjointMap}
+    \leanok
+    \uses{def:trace_pairing_adjoint, thm:trace_nondeg}
+    For every linear map $E : \MN{D} \to \MN{D}$, the trace-pairing adjoint
+    of $E^*$ is $E$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Pair both sides with an arbitrary matrix under the trace pairing.  The
+    defining adjoint identity, applied twice, gives the same trace pairing with
+    every test matrix, and nondegeneracy of the trace pairing gives equality.
+\end{proof}
+
+\begin{theorem}[Self-duality of the positive semidefinite cone]
+    \label{thm:psd_trace_pairing_self_dual}
+    \lean{Matrix.PosSemidef.of_forall_trace_mul_nonneg}
+    \leanok
+    Let $A \in \MN{D}$ be Hermitian.  If $\operatorname{tr}(AB)\geq 0$ for every
+    positive semidefinite matrix $B$, then $A\geq 0$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Test the hypothesis on rank-one positive semidefinite matrices
+    $B=xx^\dagger$.  The trace identity gives
+    $x^\dagger A x\geq 0$ for every vector $x$, so the Hermitian matrix $A$ is
+    positive semidefinite.
+\end{proof}
+
 \begin{theorem}[Completely positive maps are $k$-positive]
     \lean{IsCPMap.isNPositiveMap}
     \leanok

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -158,9 +158,18 @@ maps.
 
 \begin{proof}
     \leanok
-    Pair both sides with an arbitrary matrix under the trace pairing.  The
-    defining adjoint identity, applied twice, gives the same trace pairing with
-    every test matrix, and nondegeneracy of the trace pairing gives equality.
+    Fix an arbitrary matrix $N\in\MN{D}$.  The adjoint identity
+    $\operatorname{tr}(E^*(\rho)X)=\operatorname{tr}(\rho E(X))$, applied first
+    to $E^*$ and then to $E$, gives
+    \[
+        \operatorname{tr}((E^*)^*(X)N)
+        = \operatorname{tr}(X E^*(N))
+        = \operatorname{tr}(E^*(N)X)
+        = \operatorname{tr}(N E(X))
+        = \operatorname{tr}(E(X)N).
+    \]
+    Since this holds for every $N$ and the trace pairing is nondegenerate,
+    $(E^*)^*=E$.
 \end{proof}
 
 \begin{theorem}[Self-duality of the positive semidefinite cone]
@@ -174,7 +183,8 @@ maps.
 \begin{proof}
     \leanok
     Test the hypothesis on rank-one positive semidefinite matrices
-    $B=xx^\dagger$.  The trace identity gives
+    $B=xx^\dagger$.  The identity
+    $\operatorname{tr}(Axx^\dagger)=x^\dagger A x$ and the hypothesis give
     $x^\dagger A x\geq 0$ for every vector $x$, so the Hermitian matrix $A$ is
     positive semidefinite.
 \end{proof}


### PR DESCRIPTION
### Motivation

- Wolf §3.1 n-positivity duality requires two scalar trace-pairing facts before the block-amplification trace-adjoint identity for `IsNPositiveMap` can be established. This is a partial step for issue 3393, within the Chapter 3 tracker.
- Needed: (1) the trace-pairing adjoint is involutive; (2) a Hermitian matrix whose trace pairing with every positive semidefinite matrix is nonnegative is itself positive semidefinite.

### Description

- `TNLean/Algebra/TracePairing.lean`: adds `Matrix.traceAdjointMap_traceAdjointMap`, showing the trace-pairing adjoint is involutive, proved by pairing with arbitrary matrices and using nondegeneracy of the trace pairing.
- `TNLean/Algebra/MatrixAux.lean`: adds `Matrix.PosSemidef.of_forall_trace_mul_nonneg`, showing a Hermitian matrix with nonnegative trace product against every positive semidefinite matrix is itself positive semidefinite, by testing rank-one matrices `xx†` and reducing to quadratic forms.
- `blueprint/src/chapter/ch05_schwarz.tex`: updates the Chapter 5 trace-pairing-adjoint section with both statements and formula-level proof sketches.
- This is a partial step only; the remaining issue-3393 task is the block-amplification trace-adjoint identity for `IsNPositiveMap`.

### Testing

- `lake env lean TNLean/Algebra/MatrixAux.lean`
- `lake env lean TNLean/Algebra/TracePairing.lean`
- `lake build TNLean.Algebra.MatrixAux TNLean.Algebra.TracePairing`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
