### PR TITLE
feat(Analysis): add Lorentz cone converse

### DIFF
--- a/TNLean/Analysis/MatrixTraceInequalities.lean
+++ b/TNLean/Analysis/MatrixTraceInequalities.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
+import Mathlib.Algebra.Order.Chebyshev
 import TNLean.Algebra.PerronFrobenius.RankOne
 
 /-!
@@ -12,6 +13,11 @@ This module records finite-dimensional matrix trace inequalities used in
 Wolf's discussion of Lorentz cones for positive maps. The first result is the
 forward implication in Wolf, Chapter 3, Proposition 3.9: if `A ≥ 0`, then
 `tr(A^2) ≤ tr(A)^2`.
+
+The converse recorded here is the trace-nonnegative form.  The printed squared
+condition in Wolf, Chapter 3, Proposition 3.9 needs this sign condition; a
+negative scalar matrix satisfies the squared inequality but is not positive
+semidefinite.
 
 ## References
 
@@ -58,5 +64,88 @@ theorem PosSemidef.trace_sq_re_le_trace_re_sq
     (fun i _ => by
       rw [hlam]
       exact hA.eigenvalues_nonneg i)
+
+/-- Wolf Chapter 3, Proposition 3.9, trace-nonnegative converse.
+
+Let `A` be Hermitian with nonnegative real trace. If
+`(d - 1) Re tr(A ^ 2) ≤ (Re tr A)^2`, then `A` is positive semidefinite.
+
+**Local fix (trace sign):** The printed squared converse omits a sign condition:
+negative scalar matrices satisfy the squared inequality but are not positive
+semidefinite.  This declaration proves the future-cone form with nonnegative
+real trace; see `docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex`. -/
+theorem IsHermitian.posSemidef_of_trace_re_nonneg_of_card_sub_one_mul_trace_sq_re_le
+    {A : Matrix n n ℂ} (hA : A.IsHermitian)
+    (htrace_nonneg : 0 ≤ (Matrix.trace A).re)
+    (hineq :
+      (Fintype.card n - 1 : ℝ) * (Matrix.trace (A ^ 2)).re ≤
+        (Matrix.trace A).re ^ 2) :
+    A.PosSemidef := by
+  set lam : n → ℝ := hA.eigenvalues with hlam
+  have htrace : (Matrix.trace A).re = ∑ i, lam i := by
+    have h := hA.trace_eq_sum_eigenvalues
+    change Matrix.trace A = ∑ i, (lam i : ℂ) at h
+    rw [h]
+    simp
+  have htrace2 : (Matrix.trace (A ^ 2)).re = ∑ i, lam i ^ 2 := by
+    have h := hA.trace_sq_eq_sum_eigenvalues_sq
+    change Matrix.trace (A ^ 2) = ∑ i, (lam i : ℂ) ^ 2 at h
+    rw [h]
+    rw [Complex.re_sum]
+    exact Finset.sum_congr rfl (fun i _ => ofReal_sq_re (lam i))
+  refine hA.posSemidef_iff_eigenvalues_nonneg.mpr ?_
+  rw [Pi.le_def]
+  intro i
+  by_contra hnonneg
+  have hi_neg : lam i < 0 := by
+    rw [hlam]
+    exact lt_of_not_ge hnonneg
+  let total : ℝ := ∑ j, lam j
+  let rest : ℝ := ∑ j ∈ Finset.univ.erase i, lam j
+  have htotal_nonneg : 0 ≤ total := by
+    simpa [total, htrace] using htrace_nonneg
+  have hsplit : total = lam i + rest := by
+    dsimp [total, rest]
+    exact (Finset.add_sum_erase Finset.univ lam (Finset.mem_univ i)).symm
+  have htotal_lt_rest : total < rest := by
+    nlinarith
+  have htotal_sq_lt_rest_sq : total ^ 2 < rest ^ 2 := by
+    nlinarith
+  have hcauchy :
+      rest ^ 2 ≤ ((Finset.univ.erase i).card : ℝ) *
+        ∑ j ∈ Finset.univ.erase i, lam j ^ 2 := by
+    dsimp [rest]
+    simpa using
+      (sq_sum_le_card_mul_sum_sq (s := Finset.univ.erase i) (f := lam))
+  have hcard_one : 1 ≤ Fintype.card n :=
+    Fintype.card_pos_iff.mpr ⟨i⟩
+  have hcard :
+      ((Finset.univ.erase i).card : ℝ) = (Fintype.card n : ℝ) - 1 := by
+    rw [Finset.card_erase_of_mem (Finset.mem_univ i), Finset.card_univ]
+    norm_num [Nat.cast_sub hcard_one]
+  have hcard_nonneg : 0 ≤ (Fintype.card n - 1 : ℝ) := by
+    rw [← hcard]
+    positivity
+  have hsumsq_le :
+      (∑ j ∈ Finset.univ.erase i, lam j ^ 2) ≤ ∑ j, lam j ^ 2 := by
+    exact Finset.sum_le_sum_of_subset_of_nonneg
+      (by intro j _; exact Finset.mem_univ j)
+      (by intro j _ _; exact sq_nonneg (lam j))
+  have hrest_sq_le_all :
+      rest ^ 2 ≤ (Fintype.card n - 1 : ℝ) * ∑ j, lam j ^ 2 := by
+    have hmul_le :
+        ((Finset.univ.erase i).card : ℝ) *
+            ∑ j ∈ Finset.univ.erase i, lam j ^ 2 ≤
+          (Fintype.card n - 1 : ℝ) * ∑ j, lam j ^ 2 := by
+      rw [hcard]
+      exact mul_le_mul_of_nonneg_left hsumsq_le hcard_nonneg
+    exact hcauchy.trans hmul_le
+  have hstrict :
+      total ^ 2 < (Fintype.card n - 1 : ℝ) * ∑ j, lam j ^ 2 :=
+    htotal_sq_lt_rest_sq.trans_le hrest_sq_le_all
+  have hineq_eig :
+      (Fintype.card n - 1 : ℝ) * ∑ j, lam j ^ 2 ≤ total ^ 2 := by
+    simpa [total, htrace, htrace2] using hineq
+  exact (not_lt_of_ge hineq_eig hstrict).elim
 
 end Matrix

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -71,6 +71,41 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     which follows because all mixed products are nonnegative.
 \end{proof}
 
+\begin{theorem}[Trace-nonnegative Lorentz-cone converse]
+    \label{thm:trace_nonnegative_lorentz_cone_converse}
+    \lean{Matrix.IsHermitian.posSemidef_of_trace_re_nonneg_of_card_sub_one_mul_trace_sq_re_le}
+    \leanok
+    Let $A\in\MN{D}$ be Hermitian and suppose that
+    $\operatorname{Re}\tr(A)\ge0$. If
+    \[
+        (D-1)\operatorname{Re}\tr(A^2)
+        \le \left(\operatorname{Re}\tr(A)\right)^2 ,
+    \]
+    then $A$ is positive semidefinite.
+
+    This is the trace-nonnegative form of the converse in
+    \cite[Proposition~3.9]{Wolf2012Quantum}. The unrestricted squared
+    implication printed there is false without a trace sign condition; this is
+    recorded in
+    \path{docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex}.
+\end{theorem}
+
+\begin{proof}\leanok
+    Diagonalize $A$ with real eigenvalues $\lambda_i$. Suppose that some
+    eigenvalue $\lambda_0$ is negative. Let
+    \[
+        T=\sum_i\lambda_i,\qquad R=\sum_{i\ne 0}\lambda_i .
+    \]
+    Since $T\ge0$ and $T=\lambda_0+R$, one has $T<R$, and hence $T^2<R^2$.
+    Cauchy's inequality gives
+    \[
+        R^2\le (D-1)\sum_{i\ne 0}\lambda_i^2
+            \le (D-1)\sum_i\lambda_i^2,
+    \]
+    contradicting the assumed Lorentz inequality. Thus all eigenvalues are
+    nonnegative.
+\end{proof}
+
 \begin{definition}[Completely positive map]\label{def:cp_map}
     \lean{IsCPMap}
     \leanok

--- a/docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex
+++ b/docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex
@@ -1,0 +1,93 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Trace Sign in Wolf's Lorentz-Cone Converse}
+\author{}
+\date{2026-06-23}
+
+\begin{document}
+\maketitle
+
+\section{The assertion}
+
+Wolf's Proposition~3.9 states two elementary trace inequalities for Hermitian
+matrices.\footnote{\cite[Proposition~3.9]{Wolf2012Quantum};
+local source \path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
+lines 693--722.}  The forward implication says that a positive semidefinite
+matrix satisfies
+\begin{align}
+  \tr(A^2) \le \tr(A)^2.
+\end{align}
+The converse is printed as
+\begin{align}
+  \tr(A)^2 \ge (d-1)\tr(A^2) \Longrightarrow A \ge 0.
+  \tag{\path{Wolf Prop. 3.9 converse}}
+\end{align}
+
+\section{The point at issue}
+
+The printed converse cannot be true without a sign condition on the trace.  For
+example, if \(A=-I_d\) and \(d\geq 1\), then \(A\) is Hermitian and not positive
+semidefinite, while
+\begin{align}
+  \tr(A)^2=d^2 \ge d(d-1)=(d-1)\tr(A^2).
+\end{align}
+Thus the squared inequality only controls the Lorentz cone up to time
+orientation; it does not distinguish the positive and negative trace sheets.
+
+This is also visible in the proof printed after the proposition.  The argument
+decomposes \(A=A_+-A_-\) and uses the estimate
+\begin{align}
+  \tr(A) \le \tr(A_+).
+\end{align}
+To contradict the squared inequality one needs the left hand side to have the
+same orientation as the nonnegative quantity being bounded.  A nonnegative
+trace hypothesis supplies exactly this orientation.
+
+\section{Corrected statement}
+
+The formal theorem proves the trace-nonnegative version:
+\begin{align}
+  A=A^\dagger,\qquad
+  \tr(A)\ge 0,\qquad
+  (d-1)\tr(A^2)\le \tr(A)^2
+  \Longrightarrow A\ge 0.
+\end{align}
+In the complex matrix formalization the traces are written with real parts,
+which agrees with the displayed real quantities for Hermitian \(A\).\footnote{
+Formal declaration
+\leanid{Matrix.IsHermitian.posSemidef_of_trace_re_nonneg_of_card_sub_one_mul_trace_sq_re_le}
+in \doclink{TNLean/Analysis/MatrixTraceInequalities}; tracked by
+\ghissue{3402}.}
+
+The proof is a finite eigenvalue argument.  If some eigenvalue \(\lambda_0\) is
+negative, write
+\begin{align}
+  T=\sum_i\lambda_i,\qquad
+  R=\sum_{i\ne 0}\lambda_i .
+\end{align}
+Since \(T\ge0\) and \(T=\lambda_0+R\), one has \(T<R\), and hence
+\(T^2<R^2\).  Cauchy's inequality for the remaining \(d-1\) eigenvalues gives
+\begin{align}
+  R^2\le (d-1)\sum_{i\ne 0}\lambda_i^2
+       \le (d-1)\sum_i\lambda_i^2,
+\end{align}
+contradicting the assumed Lorentz inequality.  Therefore all eigenvalues are
+nonnegative.
+
+\section{Conclusion}
+
+The unrestricted printed converse should not be marked as formalized.  The
+formal development records the future-cone, trace-nonnegative converse as the
+mathematically valid statement used in the positive-map discussion.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation

- Wolf Lecture Notes, Chapter 3, Proposition 3.9 (confining Lorentz cones) states that
  for Hermitian $A \in M_d$, $(d-1)\operatorname{tr}(A^2) \le \operatorname{tr}(A)^2$
  implies $A \ge 0$. The source (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`,
  lines ~700–720) omits a trace-sign condition, which is necessary: negative scalar
  matrices satisfy the squared inequality but are not positive semidefinite.
- This PR formalizes the corrected (trace-nonnegative) form of Proposition 3.9 and
  records the paper gap. The rank-preserving automorphism classification (Prop 3.8)
  and the trace-preserving rescaling lemma remain open in LionSR/QICLean#20.

### Description

- **`TNLean/Analysis/MatrixTraceInequalities.lean`**: adds
  `Matrix.IsHermitian.posSemidef_of_trace_re_nonneg_of_card_sub_one_mul_trace_sq_re_le`,
  proving that a Hermitian matrix $A$ is positive semidefinite whenever
  $\operatorname{Re}\operatorname{tr}(A) \ge 0$ and
  $(d-1)\operatorname{Re}\operatorname{tr}(A^2) \le (\operatorname{Re}\operatorname{tr}(A))^2$.
  The proof diagonalizes $A$ via eigenvalues and contradicts a hypothetical negative
  eigenvalue using `sq_sum_le_card_mul_sum_sq`.
- **`docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex`**: new paper-gap note documenting
  the missing trace-sign condition in Wolf's printed Proposition 3.9.
- **`blueprint/src/chapter/ch04_channels.tex`**: adds the trace-nonnegative form with
  `\leanok`; the unsigned converse is not marked formalized.

### Testing

- `lake env lean TNLean/Analysis/MatrixTraceInequalities.lean`
- `lake build TNLean.Analysis.MatrixTraceInequalities`
- `lake build` (full build succeeds with pre-existing warnings in unrelated files)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`

---
Addresses LionSR/QICLean#20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure analysis formalization and blueprint/docs alignment; no auth, runtime, or data-path changes.
>
> **Overview**
> Adds the **trace-nonnegative converse** of Wolf Ch. 3 Prop. 3.9: for Hermitian `A` with `Re tr(A) ≥ 0`, the Lorentz inequality `(d−1) Re tr(A²) ≤ (Re tr A)²` implies `A` is positive semidefinite. The new Lean theorem `Matrix.IsHermitian.posSemidef_of_trace_re_nonneg_of_card_sub_one_mul_trace_sq_re_le` diagonalizes via eigenvalues and contradicts a hypothetical negative eigenvalue using **`sq_sum_le_card_mul_sum_sq`** (new `Mathlib.Algebra.Order.Chebyshev` import).
>
> Documentation clarifies that Wolf's **unrestricted** squared converse is false (e.g. `A = −I`) and records only the corrected form as `\leanok` in the blueprint, plus **`docs/paper-gaps/wolf_ch3_lorentz_cone_trace_sign.tex`** explaining the trace-sign gap.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f309283c638bb260bc9a57ba875dcc7791ac8867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->