### PR TITLE
feat(MPS/ParentHamiltonian): transport overlapping commutation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -245,6 +245,23 @@ theorem HasOverlappingTwoSiteCommutation.right_lift_idempotent
     rightPairLift QXB * rightPairLift QXB = rightPairLift QXB := by
   rw [← rightPairLift_mul, h.right_idempotent]
 
+/-- If the canonical two-site parent interaction satisfies the overlapping
+two-site commutation predicate on the \(AX\) and \(XB\) faces, then the first two
+translated parent terms on the three-site chain commute.
+
+This is the local transport from the source projectors of arXiv:1606.00608,
+Definition D.2, to the translated parent terms. It does not construct those
+source projectors from the Appendix B product-of-pairs form. -/
+theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation
+    (A : MPSTensor d D)
+    (h : HasOverlappingTwoSiteCommutation (d := d)
+      (parentInteraction A 2) (parentInteraction A 2)) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) := by
+  rw [localTerm_two_three_zero_eq_leftPairLift_parentInteraction,
+    localTerm_two_three_one_eq_rightPairLift_parentInteraction]
+  exact h.commute_lifts
+
 /-! ### Adjacent cyclic two-site supports -/
 
 /-- The left two-site support \(AX\) of the three-site window starting at `i`. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian.tex
@@ -46,6 +46,7 @@ for the block-diagonal boundary-condition comparison in the periodic ring.
 \input{chapter/ch13_parent_hamiltonian_commuting_gap}
 \input{chapter/ch13_parent_hamiltonian_decorrelation}
 \input{chapter/ch13_parent_hamiltonian_spectral_gap}
+\input{chapter/ch13_parent_hamiltonian_spectral_gap_martingale}
 \input{chapter/ch13_parent_hamiltonian_block_intersections}
 \input{chapter/ch13_parent_hamiltonian_block_intersections_trace_consequences}
 \input{chapter/ch13_parent_hamiltonian_block_diagonal}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -112,8 +112,8 @@ the specialization $L=2$.
         h^{(3)}_1(A,2)h^{(3)}_0(A,2).
     \]
     This is only the local transport from the \(AX/XB\) condition to translated
-    parent terms; the construction of the Appendix~B projectors is a separate
-    step.
+    parent terms; the construction of the Appendix~B projectors of
+    \cite{Cirac2016MPDO_arXiv} is a separate step.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -8,12 +8,13 @@ to a renormalization fixed point uses a left-canonical normalization.
 
 The nearest-neighbor commuting parent Hamiltonian condition in
 \cite[Definition~3.9 and Theorem~3.10]{Cirac2016MPDO_arXiv} is distinct from
-the parent commuting Hamiltonian condition of Appendix~D.2, which is stated for
-local projectors $Q_{AX}$ and $Q_{XB}$. The latter appears in the decorrelation
-section that follows.
-In Definition~3.9 the parent-Hamiltonian condition also says that, for
-$N>L$, the ground space is spanned by the periodic MPS vectors associated to
-the BNT components; nearest-neighbor means the specialization $L=2$.
+the parent commuting Hamiltonian condition of
+\cite[Appendix~D.2]{Cirac2016MPDO_arXiv}, which is stated for local projectors
+$Q_{AX}$ and $Q_{XB}$. The latter appears in the decorrelation section that
+follows. In \cite[Definition~3.9]{Cirac2016MPDO_arXiv} the parent-Hamiltonian
+condition also says that, for $N>L$, the ground space is spanned by the
+periodic MPS vectors associated to the BNT components; nearest-neighbor means
+the specialization $L=2$.
 
 \begin{definition}[Overlapping two-site supports]\label{def:overlapping_two_site_supports}
     \lean{MPSTensor.axPairCfg}
@@ -93,6 +94,33 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \]
     Substituting these two pairs of identities into the definition of the
     translated parent term gives the two displayed equations.
+\end{proof}
+
+\begin{theorem}[Three-site commutation from overlapping supports]
+    \label{thm:local_term_two_three_commute_from_ax_xb}
+    \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation}
+    \leanok
+    \uses{def:overlapping_two_site_supports,
+        thm:local_term_two_three_ax_xb_lifts}
+    Suppose the canonical two-site parent interaction \(q(A)=1-P_{G_2(A)}\)
+    satisfies the overlapping \(AX/XB\) commutation condition of
+    Definition~\ref{def:overlapping_two_site_supports}. Then, on the three-site
+    chain,
+    \[
+        h^{(3)}_0(A,2)h^{(3)}_1(A,2)
+        =
+        h^{(3)}_1(A,2)h^{(3)}_0(A,2).
+    \]
+    This is only the local transport from the \(AX/XB\) condition to translated
+    parent terms; the construction of the Appendix~B projectors is a separate
+    step.
+\end{theorem}
+
+\begin{proof}\leanok
+    By Theorem~\ref{thm:local_term_two_three_ax_xb_lifts}, the two translated
+    parent interactions are \(q(A)_{AX}\) and \(q(A)_{XB}\). The assumed
+    overlapping support condition says exactly that these two lifted
+    endomorphisms commute.
 \end{proof}
 
 \begin{definition}[Translated parent-term commutation]\label{def:is_commuting_parent_ham}
@@ -201,8 +229,8 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         =
         \spn\{V^{(N)}(A_j):j=1,\ldots,g\}.
     \]
-    This is the definition below. It does not prove the ground-space spanning
-    equation for a concrete canonical-form tensor.
+    This condition records the ground-space spanning equation, but does not
+    prove it for a concrete canonical-form tensor.
 \end{definition}
 
 \begin{remark}[Elementary consequences of the commuting definition]
@@ -424,7 +452,7 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
     \]
 \end{proof}
 
-\begin{lemma}[Kernel containment from the PGVWC block comparison]
+\begin{lemma}[Kernel containment from the block-diagonal boundary comparison]
     \label{lem:block_diagonal_kernel_to_bnt_span_from_pgvwc_comparison}
     \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison}
     \leanok
@@ -799,10 +827,11 @@ the BNT components; nearest-neighbor means the specialization $L=2$.
         def:parent_hamiltonian_ground_space_spanning}
     Suppose the Appendix~B product-of-pairs data give commuting two-site parent
     terms for a tensor \(B\). If the nearest-neighbor parent Hamiltonian also
-    satisfies the Definition~\ref{def:parent_hamiltonian_ground_space_spanning}
-    spanning equation with BNT components \(A_1,\ldots,A_g\), then \(B\) satisfies
-    the all-chain nearest-neighbor commuting parent-Hamiltonian ground-space
-    condition of Definition~\ref{def:has_nncph_ground_spaces}.
+    satisfies the ground-space spanning equation of
+    Definition~\ref{def:parent_hamiltonian_ground_space_spanning}, with BNT
+    components \(A_1,\ldots,A_g\), then \(B\) satisfies the all-chain
+    nearest-neighbor commuting parent-Hamiltonian ground-space condition of
+    Definition~\ref{def:has_nncph_ground_spaces}.
 
     In particular, if a normal left-canonical RFP tensor has nonzero bond
     dimension, the Appendix~B product-of-pairs extraction, and the same

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -112,8 +112,8 @@ the specialization $L=2$.
         h^{(3)}_1(A,2)h^{(3)}_0(A,2).
     \]
     This is only the local transport from the \(AX/XB\) condition to translated
-    parent terms; the construction of the Appendix~B projectors of
-    \cite{Cirac2016MPDO_arXiv} is a separate step.
+    parent terms; the construction of the projectors of
+    \cite[Appendix~B]{Cirac2016MPDO_arXiv} is a separate step.
 \end{theorem}
 
 \begin{proof}\leanok

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -3,16 +3,15 @@
 
 This section develops the idempotent-product formulation used for the
 decorrelation implication from Appendix~D. It is not the full source condition.
-In Appendix~D.2 of
-\cite{Cirac2016MPDO_arXiv}, the parent commuting Hamiltonian condition is stated
-for local projectors $Q_{AX}$ and $Q_{XB}$ with
+In \cite[Appendix~D.2]{Cirac2016MPDO_arXiv}, the parent commuting Hamiltonian
+condition is stated for local projectors $Q_{AX}$ and $Q_{XB}$ with
 \[
     [Q_{AX},Q_{XB}]=0,\qquad
     K_{AXB}=(K_{AX}\otimes H_B)\cap(H_A\otimes K_{XB}).
 \]
 Writing $P_{AX}=1-Q_{AX}$ and $P_{XB}=1-Q_{XB}$ gives, for the idempotent
-$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$. The definition below records
-this idempotent-product consequence, not the tensor-product locality,
+$P_K$ used below, the identity $P_{AX}P_{XB}=P_K$. The following definition
+records this idempotent-product consequence, not the tensor-product locality,
 orthogonal-projector, or ground-space-intersection hypotheses of Appendix~D.2.
 % Scope restriction: this section keeps the idempotent-product consequence
 % and not the tensor-product locality or orthogonal-projector hypotheses of the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -273,9 +273,9 @@ sufficient stronger hypotheses.
 \begin{proof}
     \leanok
     If \(\psi\in G_L^{(N)}(A)\), then every local parent interaction
-    annihilates \(\psi\):
+    annihilates \(\psi\), for every site \(i\):
     \[
-        h_i(A,L)\psi=0\qquad\text{for all }i.
+        h_i(A,L)\psi=0.
     \]
     Summing over all sites gives
     \[
@@ -1209,5 +1209,3 @@ sufficient stronger hypotheses.
     is the same statement with $\gamma=1-\eta m$, so the coefficient is then
     $\eta$.
 \end{proof}
-
-\input{chapter/ch13_parent_hamiltonian_spectral_gap_martingale}


### PR DESCRIPTION
### Motivation

- Partial progress toward eliminating `Axioms.rfp_to_nncph_commute` (`TNLean/Axioms/Beigi.lean:121`); see #3373, which is a sub-task of #2633.
- The local three-site support maps exist after PRs #3384 and #3389; this PR provides the transport step: given `HasOverlappingTwoSiteCommutation` on the AX/XB faces, the first two translated length-two parent terms on a three-site window commute (arXiv:1606.00608, §3.3 and Appendix B).
- The Appendix B source projectors and the all-chain `HasProductPairLocalProjectors` witness remain to be constructed and are not addressed here.

### Description

- `TNLean/MPS/ParentHamiltonian/LocalSupport.lean`: adds `localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation`, proving that when the canonical two-site parent interaction satisfies `HasOverlappingTwoSiteCommutation` on the AX/XB faces, the first two translated length-two parent terms on a three-site window commute; the proof rewrites those terms as `leftPairLift` / `rightPairLift` of `parentInteraction A 2` and applies the predicate's `commute_lifts` field.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: adds theorem `thm:local_term_two_three_commute_from_ax_xb` with proof text, explicitly scoped as transport only; tightens Cirac2016 source citations.
- `blueprint/src/chapter/ch13_parent_hamiltonian.tex`: routes the martingale spectral-gap `\input` to the parent-Hamiltonian chapter driver so it sits after the main spectral-gap section.
- `blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex`, `ch13_parent_hamiltonian_spectral_gap.tex`: minor prose cleanup and source-citation corrections.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.LocalSupport`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `rg -n "sorry|admit|native_decide|unsafeCast|axiom" TNLean/MPS/ParentHamiltonian/LocalSupport.lean || true`

---
Refs #3373

> [!NOTE]
> **Low Risk**
> New formal proof and blueprint sync with no auth, runtime, or API surface changes; remaining NNCPH gaps (Appendix B projectors) are unchanged and called out in comments.
>
> **Overview**
> Adds a **local transport lemma**: when the canonical two-site parent interaction satisfies `HasOverlappingTwoSiteCommutation` on the AX/XB faces, the first two translated length-two parent terms on a three-site window commute (`localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation` in `LocalSupport.lean`). The proof rewrites those terms as `leftPairLift` / `rightPairLift` of `parentInteraction A 2` and applies the predicate's `commute_lifts` field.
>
> The blueprint **commuting-gap** section gains the matching theorem `thm:local_term_two_three_commute_from_ax_xb`, explicitly scoped as transport only—not construction of Appendix B projectors.
>
> **Documentation housekeeping:** tighter Cirac2016 citations in commuting-gap and decorrelation prose; a lemma title tweak (block-diagonal boundary comparison); minor spectral-gap proof wording; the martingale spectral-gap `\input` moves from `ch13_parent_hamiltonian_spectral_gap.tex` to the parent-Hamiltonian chapter driver so it sits after the main spectral-gap section.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed32e14e8d736352f2595d4afacb9033612bab83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal proof and blueprint documentation only; no runtime, auth, or API changes. Remaining NNCPH gaps (Appendix B projector construction) are unchanged and explicitly out of scope.
> 
> **Overview**
> Adds a **local transport step** toward NNCPH: assuming the canonical two-site parent interaction satisfies `HasOverlappingTwoSiteCommutation` on the AX/XB faces, the first two translated length-two parent terms on a three-site window commute.
> 
> In `LocalSupport.lean`, `localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation` rewrites those terms as `leftPairLift` / `rightPairLift` of `parentInteraction A 2` and applies `commute_lifts`. Comments stress this does **not** build Appendix B projectors or the full all-chain witness.
> 
> The blueprint **commuting-gap** section gains matching theorem `thm:local_term_two_three_commute_from_ax_xb` with the same transport-only scope, plus tighter Cirac2016 citations, a lemma rename (block-diagonal boundary comparison), and small spectral-gap / decorrelation wording fixes. The martingale spectral-gap `\input` moves from `ch13_parent_hamiltonian_spectral_gap.tex` to the parent-Hamiltonian chapter driver so it follows the main spectral-gap section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330cdb8be5fa54a7dc8e0d1adb0c8c521a8b93bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
