### PR TITLE
feat(Channel): add trace-normalization criterion

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -35,6 +35,8 @@ with composition. We also relate it to the Kraus representation.
 * `transferMatrix_id`: the transfer matrix of the identity is the identity
 * `transferMatrix_kraus`: for a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer
   matrix is `∑ᵢ K'ᵢ ⊗ₖ Kᵢ`
+* `IsPositiveMap.comp_unitaryConjLM`: positive maps remain positive after
+  precomposition with a conjugation map
 * `IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one`: a
   trace-normalization criterion for filtered maps `ρ ↦ T(XρX†)`
 * `MPSTensor.transferMatrix_eq`: the MPS transfer map `E_A` has transfer
@@ -398,6 +400,14 @@ theorem unitaryConjLM_isPositiveMap (U : Matrix (Fin D) (Fin D) ℂ) :
     IsPositiveMap (unitaryConjLM U) :=
   (unitaryConjLM_isCPMap U).isPositiveMap
 
+/-- Precomposing a positive map with conjugation by an arbitrary matrix preserves
+positivity. -/
+theorem IsPositiveMap.comp_unitaryConjLM
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (X : Matrix (Fin D) (Fin D) ℂ) :
+    IsPositiveMap (T.comp (unitaryConjLM X)) :=
+  fun ρ hρ => hT (unitaryConjLM X ρ) (unitaryConjLM_isPositiveMap X ρ hρ)
+
 /-- Unitary conjugation by a unitary matrix is trace-preserving. -/
 theorem unitaryConjLM_isTP_of_unitary (U : Matrix (Fin D) (Fin D) ℂ)
     (hU : Uᴴ * U = 1) :
@@ -451,11 +461,9 @@ theorem IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving
     (hT : IsPositiveMap T) (X : Matrix (Fin D) (Fin D) ℂ)
     (hX : Xᴴ * Matrix.traceAdjointMap T 1 * X = 1) :
     IsPositiveMap (T.comp (unitaryConjLM X)) ∧
-      IsTracePreservingMap (T.comp (unitaryConjLM X)) := by
-  constructor
-  · intro ρ hρ
-    exact hT (unitaryConjLM X ρ) (unitaryConjLM_isPositiveMap X ρ hρ)
-  · exact IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one T X hX
+      IsTracePreservingMap (T.comp (unitaryConjLM X)) :=
+  ⟨hT.comp_unitaryConjLM X,
+    IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one T X hX⟩
 
 end UnitaryConjugation
 

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
 import TNLean.MPS.Core.Transfer
+import TNLean.Algebra.TracePairing
 import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Data.Matrix.Basis
@@ -34,6 +35,8 @@ with composition. We also relate it to the Kraus representation.
 * `transferMatrix_id`: the transfer matrix of the identity is the identity
 * `transferMatrix_kraus`: for a Kraus map `T(X) = ∑ᵢ Kᵢ X Kᵢ†`, the transfer
   matrix is `∑ᵢ K'ᵢ ⊗ₖ Kᵢ`
+* `IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one`: a
+  trace-normalization criterion for filtered maps `ρ ↦ T(XρX†)`
 * `MPSTensor.transferMatrix_eq`: the MPS transfer map `E_A` has transfer
   matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ`
 
@@ -390,6 +393,11 @@ theorem unitaryConjLM_isCPMap (U : Matrix (Fin D) (Fin D) ℂ) :
     change U * X * Uᴴ = _
     simp only [Fin.sum_univ_one]⟩
 
+/-- Conjugation by an arbitrary matrix preserves positive semidefiniteness. -/
+theorem unitaryConjLM_isPositiveMap (U : Matrix (Fin D) (Fin D) ℂ) :
+    IsPositiveMap (unitaryConjLM U) :=
+  (unitaryConjLM_isCPMap U).isPositiveMap
+
 /-- Unitary conjugation by a unitary matrix is trace-preserving. -/
 theorem unitaryConjLM_isTP_of_unitary (U : Matrix (Fin D) (Fin D) ℂ)
     (hU : Uᴴ * U = 1) :
@@ -403,6 +411,51 @@ theorem unitaryConjLM_isChannel_of_unitary (U : Matrix (Fin D) (Fin D) ℂ)
     (hU : Uᴴ * U = 1) :
     IsChannel (unitaryConjLM U) :=
   ⟨unitaryConjLM_isCPMap U, unitaryConjLM_isTP_of_unitary U hU⟩
+
+/-- Trace-normalization criterion for a filtered map.
+
+If `X† T*(1) X = 1`, where `T*` is the trace-pairing adjoint, then
+`ρ ↦ T(XρX†)` is trace preserving.  This is the trace calculation in Wolf
+Chapter 3's construction making a positive map trace preserving by choosing
+`X = T*(1)^{-1/2}`. -/
+theorem IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ)
+    (hX : Xᴴ * Matrix.traceAdjointMap T 1 * X = 1) :
+    IsTracePreservingMap (T.comp (unitaryConjLM X)) := by
+  intro ρ
+  change Matrix.trace (T (X * ρ * Xᴴ)) = Matrix.trace ρ
+  have hcycle :
+      Matrix.trace (Matrix.traceAdjointMap T 1 * (X * ρ * Xᴴ)) =
+        Matrix.trace ((Xᴴ * Matrix.traceAdjointMap T 1 * X) * ρ) := by
+    calc
+      Matrix.trace (Matrix.traceAdjointMap T 1 * (X * ρ * Xᴴ))
+          = Matrix.trace ((Matrix.traceAdjointMap T 1 * X) * ρ * Xᴴ) := by
+              simp [Matrix.mul_assoc]
+      _ = Matrix.trace (Xᴴ * (Matrix.traceAdjointMap T 1 * X) * ρ) := by
+              rw [Matrix.trace_mul_cycle]
+      _ = Matrix.trace ((Xᴴ * Matrix.traceAdjointMap T 1 * X) * ρ) := by
+              simp [Matrix.mul_assoc]
+  calc
+    Matrix.trace (T (X * ρ * Xᴴ))
+        = Matrix.trace (1 * T (X * ρ * Xᴴ)) := by simp
+    _ = Matrix.trace (Matrix.traceAdjointMap T 1 * (X * ρ * Xᴴ)) := by
+          rw [Matrix.trace_traceAdjointMap_mul]
+    _ = Matrix.trace ((Xᴴ * Matrix.traceAdjointMap T 1 * X) * ρ) := hcycle
+    _ = Matrix.trace ρ := by rw [hX, Matrix.one_mul]
+
+/-- A filtered positive map is again positive, and is trace preserving under
+the corresponding trace-adjoint normalization. -/
+theorem IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (X : Matrix (Fin D) (Fin D) ℂ)
+    (hX : Xᴴ * Matrix.traceAdjointMap T 1 * X = 1) :
+    IsPositiveMap (T.comp (unitaryConjLM X)) ∧
+      IsTracePreservingMap (T.comp (unitaryConjLM X)) := by
+  constructor
+  · intro ρ hρ
+    exact hT (unitaryConjLM X ρ) (unitaryConjLM_isPositiveMap X ρ hρ)
+  · exact IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one T X hX
 
 end UnitaryConjugation
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -51,16 +51,43 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     Trace preservation is the identity $\tr(X^T)=\tr(X)$.
 \end{proof}
 
+\begin{theorem}[Conjugation filters preserve positivity]
+    \label{thm:conjugation_filters_preserve_positivity}
+    \lean{unitaryConjLM_isCPMap, unitaryConjLM_isPositiveMap,
+        IsPositiveMap.comp_unitaryConjLM, unitaryConjLM_isTP_of_unitary,
+        unitaryConjLM_isChannel_of_unitary}
+    \leanok
+    \uses{def:cp_map, def:positive_map, def:trace_preserving, def:channel}
+    For every $X\in\MN{D}$, the conjugation filter
+    \[
+        \rho\longmapsto X\rho X^\dagger
+    \]
+    is completely positive, hence positive.  Therefore, if
+    $T:\MN{D}\to\MN{D}$ is positive, then
+    $\rho\mapsto T(X\rho X^\dagger)$ is positive.  If in addition
+    $X^\dagger X=\Id$, then the conjugation filter is trace-preserving and
+    hence is a quantum channel.
+\end{theorem}
+
+\begin{proof}\leanok
+    Complete positivity follows from the single Kraus operator $X$.
+    Positivity follows immediately.  If $X^\dagger X=\Id$, cyclicity of trace
+    gives
+    \[
+        \tr(X\rho X^\dagger)=\tr(X^\dagger X\rho)=\tr(\rho).
+    \]
+\end{proof}
+
 \begin{theorem}[Filtered trace-normalization criterion]
     \label{thm:filtered_trace_normalization_criterion}
-    \lean{unitaryConjLM_isPositiveMap,
-        IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one,
+    \lean{IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one,
         IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving}
     \leanok
-    \uses{def:positive_map, def:trace_preserving, def:trace_pairing_adjoint}
+    \uses{def:positive_map, def:trace_preserving, def:trace_pairing_adjoint,
+        thm:conjugation_filters_preserve_positivity}
     Let $T:\MN{D}\to\MN{D}$ be a positive map, and let $X\in\MN{D}$ satisfy
     \[
-        X^\dagger T^*(\one)X=\one,
+        X^\dagger T^*(\Id)X=\Id,
     \]
     where $T^*$ is the trace-pairing adjoint.  Then
     \[
@@ -71,7 +98,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     This is the algebraic trace-normalization step in the proof of
     \cite[Chapter~3, Lemma ``Making positive maps trace preserving'']
     {Wolf2012Quantum}.  The existence of such an $X$ from
-    $T^*(\one)>0$ requires the inverse-square-root theorem and remains
+    $T^*(\Id)>0$ requires the inverse-square-root theorem and remains
     separate.
 \end{theorem}
 
@@ -81,8 +108,8 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     trace-pairing adjoint identity and cyclicity of trace:
     \[
         \tr(T(X\rho X^\dagger))
-        =\tr(T^*(\one)X\rho X^\dagger)
-        =\tr(X^\dagger T^*(\one)X\rho)
+        =\tr(T^*(\Id)X\rho X^\dagger)
+        =\tr(X^\dagger T^*(\Id)X\rho)
         =\tr(\rho).
     \]
 \end{proof}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -51,6 +51,42 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     Trace preservation is the identity $\tr(X^T)=\tr(X)$.
 \end{proof}
 
+\begin{theorem}[Filtered trace-normalization criterion]
+    \label{thm:filtered_trace_normalization_criterion}
+    \lean{unitaryConjLM_isPositiveMap,
+        IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one,
+        IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving}
+    \leanok
+    \uses{def:positive_map, def:trace_preserving, def:trace_pairing_adjoint}
+    Let $T:\MN{D}\to\MN{D}$ be a positive map, and let $X\in\MN{D}$ satisfy
+    \[
+        X^\dagger T^*(\one)X=\one,
+    \]
+    where $T^*$ is the trace-pairing adjoint.  Then
+    \[
+        \rho\longmapsto T(X\rho X^\dagger)
+    \]
+    is positive and trace-preserving.
+
+    This is the algebraic trace-normalization step in the proof of
+    \cite[Chapter~3, Lemma ``Making positive maps trace preserving'']
+    {Wolf2012Quantum}.  The existence of such an $X$ from
+    $T^*(\one)>0$ requires the inverse-square-root theorem and remains
+    separate.
+\end{theorem}
+
+\begin{proof}\leanok
+    Positivity follows because $X\rho X^\dagger$ is positive whenever
+    $\rho$ is positive, and $T$ is positive.  For trace preservation, use the
+    trace-pairing adjoint identity and cyclicity of trace:
+    \[
+        \tr(T(X\rho X^\dagger))
+        =\tr(T^*(\one)X\rho X^\dagger)
+        =\tr(X^\dagger T^*(\one)X\rho)
+        =\tr(\rho).
+    \]
+\end{proof}
+
 \begin{theorem}[Forward Lorentz-cone trace inequality]
     \label{thm:psd_trace_square_le_square_trace}
     \lean{Matrix.PosSemidef.trace_sq_re_le_trace_re_sq}


### PR DESCRIPTION
### Motivation

- Wolf Ch3 §3.5 (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~700–736) includes a lemma: if a positive map `T` satisfies `T*(1) > 0`, then the map `ρ ↦ T(X ρ Xᴴ)` with `X = (T*(1))^{-1/2}` is trace preserving. Advances LionSR/QICLean#20, which tracks formalization of Prop 3.8–3.9 and this lemma.
- The algebraic criterion — that `Xᴴ · T*(1) · X = 1` implies `ρ ↦ T(X ρ Xᴴ)` is trace preserving — is the load-bearing structural step; the inverse-square-root construction producing `X` from `T*(1) > 0` is the remaining step.

### Description

- `TNLean/Channel/TransferMatrix.lean`: adds a lemma that if `Xᴴ * traceAdjointMap T 1 * X = 1` then the map `ρ ↦ T (X * ρ * Xᴴ)` is trace preserving; adds a lemma that conjugation by a matrix preserves positivity.
- `blueprint/src/chapter/ch04_channels.tex`: adds a blueprint entry for this restricted trace-normalization criterion with `\lean{...}` and `\leanok` tags.
- Wolf's full existence lemma (producing `X = (T*(1))^{-1/2}`) is not marked complete; the inverse-square-root step remains open in LionSR/QICLean#20.

### Testing

- `lake build TNLean.Channel.TransferMatrix` and `lake build` succeed.
- `lake exe checkdecls blueprint/lean_decls` passes.
- Blueprint sync (`python3 scripts/blueprint_lean_sync.py --root . --ci`) and prose check (`python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`) pass against `origin/main`.
- Pre-existing `sorry` and style warnings in unrelated files are unchanged.

---
Addresses LionSR/QICLean#20

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 275923e782d8ceb73afba88bad76adf018aabf89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and blueprint prose only; no changes to existing channel definitions or runtime behavior.
> 
> **Overview**
> Adds Lean lemmas in `TNLean/Channel/TransferMatrix.lean` (with `TNLean.Algebra.TracePairing`) showing **conjugation** \(\rho\mapsto X\rho X^\dagger\) is positive, that **precomposing a positive map** with conjugation stays positive, and the **algebraic trace-normalization** step: if \(X^\dagger T^*(\mathrm{Id})X = \mathrm{Id}\) for the trace-pairing adjoint \(T^*\), then \(\rho\mapsto T(X\rho X^\dagger)\) is trace-preserving (Wolf Ch.3 “making positive maps trace preserving,” before choosing \(X=(T^*(\mathrm{Id}))^{-1/2}\)).
> 
> Documents the same facts in `blueprint/src/chapter/ch04_channels.tex` as `\leanok` theorems with `\lean{...}` links to the new declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783d52b3d02780c2be263502f5ecc582bcbfd18e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->