### PR TITLE
feat(Channel/Schwarz): add trace-adjoint positivity

### DIFF
--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.Basic
+import TNLean.Algebra.MatrixAux
+import TNLean.Algebra.TracePairing
 import TNLean.Channel.Schwarz.KadisonSchwarz
 import TNLean.Channel.Schwarz.PositiveMapProperties
 import Mathlib.Analysis.CStarAlgebra.Matrix
@@ -19,10 +21,12 @@ the existing result which is restricted to completely positive maps.
 
 * `IsNPositiveMap` — a linear map `E` is n-positive if `E ⊗ id_n` is positive
 * `Is2PositiveMap` — 2-positive maps (the case n = 2)
+* `nPositiveAmpliation` — the explicit blockwise ampliation `E ⊗ id_k`
 
 ## Main results
 
 * `IsCPMap.isNPositiveMap` — CP maps are n-positive for all n
+* `IsPositiveMap.traceAdjointMap` — the trace-pairing adjoint of a positive map is positive
 * `IsCPMap.is2PositiveMap` — CP maps are 2-positive
 * `kadison_schwarz_2positive` — Kadison–Schwarz for unital 2-positive maps
 
@@ -117,6 +121,78 @@ def IsNPositiveMap (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : P
 /-- A linear map is **2-positive** if `E ⊗ id₂` is positive. -/
 def Is2PositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
   IsNPositiveMap 2 E
+
+/-- The explicit blockwise ampliation `E ⊗ id_k` used in the definition of
+`k`-positivity. -/
+def nPositiveAmpliation (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    Matrix (n × Fin k) (n × Fin k) ℂ →ₗ[ℂ]
+      Matrix (n × Fin k) (n × Fin k) ℂ where
+  toFun X := Matrix.of fun (ip : n × Fin k) (jq : n × Fin k) =>
+    (E (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1
+  map_add' X Y := by
+    ext ip jq
+    change E ((Matrix.of fun i j => X (i, ip.2) (j, jq.2)) +
+        (Matrix.of fun i j => Y (i, ip.2) (j, jq.2))) ip.1 jq.1 =
+      (E (Matrix.of fun i j => X (i, ip.2) (j, jq.2)) +
+        E (Matrix.of fun i j => Y (i, ip.2) (j, jq.2))) ip.1 jq.1
+    rw [map_add]
+  map_smul' c X := by
+    ext ip jq
+    change E (c • (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1 =
+      (c • E (Matrix.of fun i j => X (i, ip.2) (j, jq.2))) ip.1 jq.1
+    rw [map_smul]
+
+omit [Fintype n] [DecidableEq n] in
+/-- The definition of `k`-positivity is positivity of the blockwise ampliation. -/
+theorem isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation
+    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    IsNPositiveMap k E ↔ IsPositiveMap (nPositiveAmpliation k E) := by
+  rfl
+
+omit [DecidableEq n] in
+private theorem traceAdjointMap_map_isHermitian_of_isPositiveMap
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (hE : IsPositiveMap E) {X : Matrix n n ℂ} (hX : X.IsHermitian) :
+    (Matrix.traceAdjointMap E X).IsHermitian := by
+  classical
+  rw [Matrix.IsHermitian]
+  ext i j
+  simp only [Matrix.conjTranspose_apply, RCLike.star_def]
+  calc
+    (starRingEnd ℂ) (Matrix.trace (X * E (Matrix.single i j 1)))
+        = Matrix.trace ((X * E (Matrix.single i j 1))ᴴ) := by
+          simpa using (Matrix.trace_conjTranspose (X * E (Matrix.single i j 1))).symm
+    _ = Matrix.trace ((E (Matrix.single i j 1))ᴴ * Xᴴ) := by
+          rw [Matrix.conjTranspose_mul]
+    _ = Matrix.trace (E (Matrix.single j i 1) * X) := by
+          rw [hX.eq, ← hE.map_conjTranspose]
+          simp
+    _ = Matrix.trace (X * E (Matrix.single j i 1)) := by
+          rw [Matrix.trace_mul_comm]
+
+omit [DecidableEq n] in
+/-- The trace-pairing adjoint of a positive map is positive. -/
+theorem IsPositiveMap.traceAdjointMap
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (hE : IsPositiveMap E) : IsPositiveMap (Matrix.traceAdjointMap E) := by
+  intro X hX
+  refine Matrix.PosSemidef.of_forall_trace_mul_nonneg
+    (traceAdjointMap_map_isHermitian_of_isPositiveMap hE hX.1) ?_
+  intro B hB
+  rw [Matrix.trace_traceAdjointMap_mul]
+  exact Matrix.PosSemidef.trace_mul_nonneg hX (hE B hB)
+
+omit [DecidableEq n] in
+/-- Positivity is invariant under the trace-pairing adjoint. -/
+theorem isPositiveMap_traceAdjointMap_iff
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :
+    IsPositiveMap (Matrix.traceAdjointMap E) ↔ IsPositiveMap E := by
+  constructor
+  · intro h
+    have h' := h.traceAdjointMap
+    simpa [Matrix.traceAdjointMap_traceAdjointMap] using h'
+  · intro h
+    exact h.traceAdjointMap
 
 private theorem posSemidef_fromBlocks_zero_zero
     {m o : Type*} {A : Matrix m m ℂ} (hA : A.PosSemidef) :

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -121,7 +121,7 @@ maps.
     A linear map is \emph{two-positive} if it is $2$-positive.
 \end{definition}
 
-\begin{definition}[Blockwise ampliation]
+\begin{definition}[Blockwise ampliation]\label{def:blockwise_ampliation}
     \lean{nPositiveAmpliation}
     \leanok
     For a linear map $E : \MN{D}\to\MN{D}$, its $k$-fold ampliation acts on
@@ -135,10 +135,15 @@ maps.
 \begin{theorem}[$k$-positivity as positivity of the ampliation]
     \lean{isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation}
     \leanok
-    \uses{def:k_positive_map}
+    \uses{def:k_positive_map, def:blockwise_ampliation}
     A linear map is $k$-positive if and only if its blockwise ampliation is
     positive on $\MN{D}\otimes\MN{k}$.
 \end{theorem}
+
+\begin{proof}
+    \leanok
+    This is precisely the preceding definition of the ampliation.
+\end{proof}
 
 \begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}
     \lean{Matrix.traceAdjointMap}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -108,7 +108,7 @@ maps.
 
 \subsection{Two-positive maps and the generalized Schwarz inequality}
 
-\begin{definition}[$k$-positive map]
+\begin{definition}[$k$-positive map]\label{def:k_positive_map}
     \lean{IsNPositiveMap}
     \leanok
     A linear map $E : \MN{D} \to \MN{D}$ is $k$-positive if
@@ -120,6 +120,25 @@ maps.
     \leanok
     A linear map is \emph{two-positive} if it is $2$-positive.
 \end{definition}
+
+\begin{definition}[Blockwise ampliation]
+    \lean{nPositiveAmpliation}
+    \leanok
+    For a linear map $E : \MN{D}\to\MN{D}$, its $k$-fold ampliation acts on
+    block matrices by
+    \[
+        E^{(k)}(X)_{(i,p),(j,q)}
+        = E\bigl((X_{(a,p),(b,q)})_{a,b}\bigr)_{i,j}.
+    \]
+\end{definition}
+
+\begin{theorem}[$k$-positivity as positivity of the ampliation]
+    \lean{isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation}
+    \leanok
+    \uses{def:k_positive_map}
+    A linear map is $k$-positive if and only if its blockwise ampliation is
+    positive on $\MN{D}\otimes\MN{k}$.
+\end{theorem}
 
 \begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}
     \lean{Matrix.traceAdjointMap}
@@ -148,7 +167,7 @@ maps.
     $(E^*(\rho))_{ji}=\operatorname{tr}(\rho E(e_{ij}))$.
 \end{proof}
 
-\begin{theorem}[Trace-pairing adjoint is involutive]
+\begin{theorem}[Trace-pairing adjoint is involutive]\label{thm:trace_pairing_adjoint_involutive}
     \lean{Matrix.traceAdjointMap_traceAdjointMap}
     \leanok
     \uses{def:trace_pairing_adjoint, thm:trace_nondeg}
@@ -187,6 +206,48 @@ maps.
     $\operatorname{tr}(Axx^\dagger)=x^\dagger A x$ and the hypothesis give
     $x^\dagger A x\geq 0$ for every vector $x$, so the Hermitian matrix $A$ is
     positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Trace-pairing adjoint of a positive map]\label{thm:trace_pairing_adjoint_positive}
+    \lean{IsPositiveMap.traceAdjointMap}
+    \leanok
+    \uses{def:trace_pairing_adjoint, thm:psd_trace_pairing_self_dual}
+    If $E : \MN{D}\to\MN{D}$ is positive, then its trace-pairing adjoint $E^*$
+    is positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Let $\rho\geq 0$.  First $E^*(\rho)$ is Hermitian.  Indeed,
+    positivity of $E$ gives $E(A^\dagger)=E(A)^\dagger$, and hence for matrix
+    units $e_{ij}$,
+    \[
+        \overline{\operatorname{tr}(\rho E(e_{ij}))}
+        =\operatorname{tr}(E(e_{ij})^\dagger\rho)
+        =\operatorname{tr}(E(e_{ji})\rho)
+        =\operatorname{tr}(\rho E(e_{ji})).
+    \]
+    For every $B\geq 0$, the adjoint identity gives
+    \[
+        \operatorname{tr}(E^*(\rho)B)=\operatorname{tr}(\rho E(B)).
+    \]
+    Since $E(B)\geq 0$, the right side is nonnegative by positivity of the
+    trace product of two positive semidefinite matrices.  Self-duality of the
+    positive semidefinite cone therefore gives $E^*(\rho)\geq 0$.
+\end{proof}
+
+\begin{theorem}[Trace-pairing adjoints preserve positivity exactly]
+    \lean{isPositiveMap_traceAdjointMap_iff}
+    \leanok
+    \uses{thm:trace_pairing_adjoint_positive, thm:trace_pairing_adjoint_involutive}
+    A linear map is positive if and only if its trace-pairing adjoint is
+    positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    One direction is the preceding theorem.  The other follows by applying the
+    same theorem to $E^*$ and using $(E^*)^*=E$.
 \end{proof}
 
 \begin{theorem}[Completely positive maps are $k$-positive]


### PR DESCRIPTION
### Motivation

- Wolf §3.1 treats the cones of n-positive maps and states that the dual map is n-positive if and only if the original map is.
- Source: `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines 75-80, especially the statement that the dual map preserves n-positivity exactly.
- This PR supplies the positive-map trace-adjoint step and names the blockwise ampliation needed for the remaining amplified trace-adjoint identity in LionSR/QICLean#164.

### Description

- `TNLean/Channel/Schwarz/TwoPositive.lean`: adds `nPositiveAmpliation`, the explicit blockwise map `E ⊗ id_k`, and `isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation`.
- Proves `IsPositiveMap.traceAdjointMap`: if `E` is positive, then its trace-pairing adjoint is positive, using Hermiticity preservation, the trace-adjoint identity, trace-product nonnegativity, and self-duality of the positive semidefinite cone.
- Proves `isPositiveMap_traceAdjointMap_iff`, using involutivity of the trace-pairing adjoint.
- `blueprint/src/chapter/ch05_schwarz.tex`: adds the matching entries and proof sketches.

### Testing

- `lake env lean TNLean/Channel/Schwarz/TwoPositive.lean`
- `lake build TNLean.Channel.Schwarz.TwoPositive`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `rg -n "sorry|admit|native_decide|unsafeCast|axiom" TNLean/Channel/Schwarz/TwoPositive.lean || true`

---
Refs LionSR/QICLean#164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized formal math and blueprint documentation in Schwarz/TwoPositive; no runtime or security-sensitive paths.
> 
> **Overview**
> Introduces **`nPositiveAmpliation`** as the named blockwise map behind \(k\)-positivity, with **`isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation`** stating that \(k\)-positivity is exactly positivity of that ampliation.
> 
> Proves that for positive maps **`Matrix.traceAdjointMap`** is positive (**`IsPositiveMap.traceAdjointMap`**) via Hermiticity, the trace-adjoint identity, and PSD self-duality, and that positivity is **equivalent** under taking the trace adjoint (**`isPositiveMap_traceAdjointMap_iff`**, using involutivity).
> 
> **`ch05_schwarz.tex`** is updated with matching definitions, theorems, and proof sketches (including a label on the involutivity theorem).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c365084950dda10f18e0a6bdc7cbe2c24ef1e2c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->