### PR TITLE
feat(MPS/RFP): record one-pair core factorization

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -360,6 +360,14 @@ theorem AppendixBStructuralData.twoSiteAmplitude_eq_coreTensor_mpv {A : MPSTenso
     hStruct.twoSiteAmplitude σ = mpv hStruct.coreTensor σ := by
   rw [hStruct.twoSiteAmplitude_eq_mpv σ, hStruct.mpv_eq_coreTensor σ]
 
+/-- The length-two case of the core-tensor factorization required by the
+Appendix B extraction input. -/
+theorem AppendixBStructuralData.mpv_coreTensor_eq_productPairState_one {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) (σ : Cfg d (2 * 1)) :
+    mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude 1 σ := by
+  rw [productPairState_one]
+  exact (hStruct.twoSiteAmplitude_eq_coreTensor_mpv σ).symm
+
 /-- The length-two case of the requested even-chain factorization is automatic
 from the definition of the structural two-site amplitude. -/
 theorem AppendixBStructuralData.mpv_eq_productPairState_one {A : MPSTensor d D}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -730,6 +730,7 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.mpv_eq_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_mpv}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_coreTensor_mpv}
+    \lean{MPSTensor.AppendixBStructuralData.mpv_coreTensor_eq_productPairState_one}
     \lean{MPSTensor.AppendixBStructuralData.mpv_eq_productPairState_one}
     \lean{MPSTensor.AppendixBProductPairExtraction}
     \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorization}
@@ -779,6 +780,13 @@ the specialization $L=2$.
         V^{(2)}(A)(a,b)
         =
         V^{(2)}(\Lambda U)(a,b).
+    \]
+    Thus the adjacent-pair factorization is already verified for one physical
+    pair in the core tensor:
+    \[
+        V^{(2)}(\Lambda U)(\sigma)
+        =
+        \phi_2(\sigma_0,\sigma_1).
     \]
     The adjacent-pair input presently used in the formal statement is the
     even-chain factorization, for a positive number $n$ of adjacent pairs,


### PR DESCRIPTION
### Motivation

- Issue #3372 asks for the Appendix B positive even-chain product-pair factorization for the core tensor.
- The general statement remains open, but the one-pair case is an exact and useful boundary case for the `hCore` field shape.

### Description

- Adds `MPSTensor.AppendixBStructuralData.mpv_coreTensor_eq_productPairState_one`, showing that for one physical pair the core-tensor MPV equals the adjacent two-site product-pair amplitude.
- Records the theorem in the Appendix B product-pair paragraph of the blueprint, with the displayed one-pair equation.

### Testing

- `lake build TNLean.MPS.RFP.CommutingBridge`
- `lake build TNLean.Channel.TransferMatrix` after rebasing onto the merged channel PR
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main..HEAD`
- `rg -n "sorry|admit|native_decide|unsafeCast|axiom" TNLean/MPS/RFP/CommutingBridge.lean || true`

---
Refs #3372

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive Lean proof and blueprint sync with no changes to axioms, runtime behavior, or extraction APIs beyond documenting an already-implied identity.
> 
> **Overview**
> Formalizes the **N = 1** boundary case of Appendix B's core-tensor product-pair factorization: for one adjacent physical pair, the MPV of `Λ U` equals the structural two-site amplitude via `productPairState` (proved from `productPairState_one` and `twoSiteAmplitude_eq_coreTensor_mpv`).
> 
> The blueprint's product-pair remark now cites `mpv_coreTensor_eq_productPairState_one` and states the displayed one-pair equation for `V^{(2)}(Λ U)` before the general even-chain factorization input. The full positive even-chain statement for the core tensor remains open (#3372).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918f659aefa67379efeb72002976c1d8dcb0434f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
