### PR TITLE
fix(Channel): align trace-normalization blueprint tag

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -38,7 +38,7 @@ with composition. We also relate it to the Kraus representation.
 * `IsPositiveMap.comp_unitaryConjLM`: positive maps remain positive after
   precomposition with a conjugation map
 * `IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one`: a
-  trace-normalization criterion for filtered maps `ρ ↦ T(XρX†)`
+  trace-normalization criterion for conjugated-input maps ρ ↦ T(XρX†)
 * `MPSTensor.transferMatrix_eq`: the MPS transfer map `E_A` has transfer
   matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ`
 
@@ -422,12 +422,12 @@ theorem unitaryConjLM_isChannel_of_unitary (U : Matrix (Fin D) (Fin D) ℂ)
     IsChannel (unitaryConjLM U) :=
   ⟨unitaryConjLM_isCPMap U, unitaryConjLM_isTP_of_unitary U hU⟩
 
-/-- Trace-normalization criterion for a filtered map.
+/-- Trace-normalization criterion for a map with conjugated input.
 
-If `X† T*(1) X = 1`, where `T*` is the trace-pairing adjoint, then
-`ρ ↦ T(XρX†)` is trace preserving.  This is the trace calculation in Wolf
+If X† T*(1) X = 1, where T* is the trace-pairing adjoint, then
+ρ ↦ T(XρX†) is trace preserving. This is the trace calculation in Wolf
 Chapter 3's construction making a positive map trace preserving by choosing
-`X = T*(1)^{-1/2}`. -/
+X = T*(1)^{-1/2}. -/
 theorem IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin D) ℂ)
@@ -454,8 +454,9 @@ theorem IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one
     _ = Matrix.trace ((Xᴴ * Matrix.traceAdjointMap T 1 * X) * ρ) := hcycle
     _ = Matrix.trace ρ := by rw [hX, Matrix.one_mul]
 
-/-- A filtered positive map is again positive, and is trace preserving under
-the corresponding trace-adjoint normalization. -/
+/-- If T is positive, then ρ ↦ T(XρX†) is positive. If moreover
+X† T*(1) X = 1, where T* is the trace-pairing adjoint, then the same map is
+trace preserving. -/
 theorem IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving
     {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
     (hT : IsPositiveMap T) (X : Matrix (Fin D) (Fin D) ℂ)

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -80,8 +80,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 
 \begin{theorem}[Filtered trace-normalization criterion]
     \label{thm:filtered_trace_normalization_criterion}
-    \lean{IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one,
-        IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving}
+    \lean{IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving}
     \leanok
     \uses{def:positive_map, def:trace_preserving, def:trace_pairing_adjoint,
         thm:conjugation_filters_preserve_positivity}


### PR DESCRIPTION
### Motivation

Follow-up to LionSR/TNLean#3417. A later review comment on the merged PR pointed out that the filtered trace-normalization blueprint entry listed both the combined positivity-and-trace-preservation theorem and the trace-preserving-only lemma. The theorem statement is the combined assertion, so the blueprint tag should point only to the combined Lean declaration. Continues the Wolf Ch. 3 §3.5 formalization tracked in LionSR/QICLean#20.

### Description

- Restrict the blueprint lean tag for the filtered trace-normalization criterion to `IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving`.
- Reword the nearby Lean docstrings so mathematical notation is written as prose rather than as Lean syntax.

### Testing

- `lake build TNLean.Channel.TransferMatrix`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check origin/main..HEAD`

---
Refs LionSR/QICLean#20

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and blueprint tagging only; no changes to proofs or APIs.
>
> **Overview**
> **Blueprint ↔ Lean sync:** The filtered trace-normalization criterion in `ch04_channels.tex` now points only at `IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving`, which matches the theorem statement (positive **and** trace-preserving). The trace-only lemma `IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one` is no longer listed on that entry.
>
> **Docstrings in `TransferMatrix.lean`:** Wording shifts from "filtered map" to "map with conjugated input" / "conjugated-input maps," and math is described in prose (e.g. ρ ↦ T(XρX†), X† T*(1) X = 1) instead of heavy Lean syntax in comments. The combined theorem's docstring explicitly states positivity and trace preservation under the normalization hypothesis.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b70d091ae2f2e08cf9acef9bb75cbc80dc41862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->