### PR TITLE
feat(Channel): add inverse-square-root trace normalization

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Channel.Basic
 import TNLean.MPS.Core.Transfer
 import TNLean.Algebra.TracePairing
+import Mathlib.Analysis.Matrix.Order
 import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.LinearAlgebra.Matrix.Trace
 import Mathlib.Data.Matrix.Basis
@@ -39,6 +40,8 @@ with composition. We also relate it to the Kraus representation.
   precomposition with a conjugation map
 * `IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one`: a
   trace-normalization criterion for conjugated-input maps ρ ↦ T(XρX†)
+* `IsPositiveMap.comp_unitaryConjLM_inv_cfc_sqrt_traceAdjointMap_one`: the same
+  normalization with X = T*(1)^{-1/2} when T*(1) is positive definite
 * `MPSTensor.transferMatrix_eq`: the MPS transfer map `E_A` has transfer
   matrix `∑ᵢ Āᵢ ⊗ₖ Aᵢ`
 
@@ -47,7 +50,7 @@ with composition. We also relate it to the Kraus representation.
 * [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Section 2.2][Wolf2012QChannels]
 -/
 
-open scoped Matrix BigOperators Kronecker
+open scoped Matrix BigOperators Kronecker MatrixOrder ComplexOrder
 open Matrix Finset
 
 variable {D : ℕ}
@@ -465,6 +468,49 @@ theorem IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving
       IsTracePreservingMap (T.comp (unitaryConjLM X)) :=
   ⟨hT.comp_unitaryConjLM X,
     IsTracePreservingMap.comp_unitaryConjLM_of_conj_traceAdjointMap_one T X hX⟩
+
+/-- If A is positive definite, conjugation by its inverse square root
+normalizes A to the identity. -/
+theorem Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef
+    (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosDef) :
+    ((CFC.sqrt A)⁻¹)ᴴ * A * (CFC.sqrt A)⁻¹ = 1 := by
+  set S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt A
+  have hA_nonneg : (0 : Matrix (Fin D) (Fin D) ℂ) ≤ A := hA.posSemidef.nonneg
+  have hS_sq : S * S = A := by
+    simpa [S] using CFC.sqrt_mul_sqrt_self A hA_nonneg
+  have hS_herm : Sᴴ = S := by
+    have hpsd : S.PosSemidef := by
+      simpa [S] using (Matrix.nonneg_iff_posSemidef).1 (CFC.sqrt_nonneg A)
+    simpa using hpsd.isHermitian.eq
+  have hS_det : IsUnit S.det := by
+    have hA_unit : IsUnit A := Matrix.PosDef.isUnit hA
+    have hS_unit : IsUnit S := by
+      simpa [S] using (CFC.isUnit_sqrt_iff A hA_nonneg).2 hA_unit
+    exact (Matrix.isUnit_iff_isUnit_det S).1 hS_unit
+  have hSinv_mul : S⁻¹ * S = 1 := Matrix.nonsing_inv_mul S hS_det
+  have hSmul_inv : S * S⁻¹ = 1 := Matrix.mul_nonsing_inv S hS_det
+  have hSinv_herm : (S⁻¹)ᴴ = S⁻¹ := by
+    rw [Matrix.conjTranspose_nonsing_inv, hS_herm]
+  calc
+    ((CFC.sqrt A)⁻¹)ᴴ * A * (CFC.sqrt A)⁻¹
+        = (S⁻¹)ᴴ * A * S⁻¹ := by simp [S]
+    _ = S⁻¹ * (S * S) * S⁻¹ := by rw [hSinv_herm, hS_sq]
+    _ = 1 := by simp [Matrix.mul_assoc, hSinv_mul, hSmul_inv]
+
+/-- **Wolf Chapter 3 trace normalization by inverse square root.**
+
+If T is positive and T*(1) is positive definite, then choosing
+X = T*(1)^{-1/2} makes ρ ↦ T(XρX†) positive and trace-preserving. -/
+theorem IsPositiveMap.comp_unitaryConjLM_inv_cfc_sqrt_traceAdjointMap_one
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsPositiveMap T) (hTstar : (Matrix.traceAdjointMap T 1).PosDef) :
+    IsPositiveMap
+        (T.comp (unitaryConjLM ((CFC.sqrt (Matrix.traceAdjointMap T 1))⁻¹))) ∧
+      IsTracePreservingMap
+        (T.comp (unitaryConjLM ((CFC.sqrt (Matrix.traceAdjointMap T 1))⁻¹))) := by
+  exact hT.comp_unitaryConjLM_positive_tracePreserving _
+    (Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef
+      (Matrix.traceAdjointMap T 1) hTstar)
 
 end UnitaryConjugation
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -96,9 +96,8 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 
     This is the algebraic trace-normalization step in the proof of
     \cite[Chapter~3, Lemma ``Making positive maps trace preserving'']
-    {Wolf2012Quantum}.  The existence of such an $X$ from
-    $T^*(\Id)>0$ requires the inverse-square-root theorem and remains
-    separate.
+    {Wolf2012Quantum}.  The inverse-square-root choice is recorded in the
+    next theorem.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -111,6 +110,37 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
         =\tr(X^\dagger T^*(\Id)X\rho)
         =\tr(\rho).
     \]
+\end{proof}
+
+\begin{theorem}[Trace normalization by inverse square root]
+    \label{thm:trace_normalization_inverse_square_root}
+    \lean{IsPositiveMap.comp_unitaryConjLM_inv_cfc_sqrt_traceAdjointMap_one}
+    \leanok
+    \uses{def:positive_map, def:trace_preserving, def:trace_pairing_adjoint,
+        thm:filtered_trace_normalization_criterion}
+    Let $T:\MN{D}\to\MN{D}$ be a positive map such that $T^*(\Id)$ is positive
+    definite.  Put
+    \[
+        X=(T^*(\Id))^{-1/2}.
+    \]
+    Then
+    \[
+        \rho\longmapsto T(X\rho X^\dagger)
+    \]
+    is positive and trace-preserving.
+\end{theorem}
+
+\begin{proof}\leanok
+    Let $S=(T^*(\Id))^{1/2}$.  Since $T^*(\Id)$ is positive definite, $S$ is
+    invertible and self-adjoint, and $S^2=T^*(\Id)$.  For $X=S^{-1}$,
+    \[
+        X^\dagger T^*(\Id)X
+        =
+        S^{-1}S^2S^{-1}
+        =
+        \Id .
+    \]
+    The preceding trace-normalization criterion applies.
 \end{proof}
 
 \begin{theorem}[Forward Lorentz-cone trace inequality]

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -112,12 +112,35 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \]
 \end{proof}
 
+\begin{lemma}[Normalizing conjugation by inverse square root]
+    \label{lem:conj_inv_sqrt_normalizes}
+    \lean{Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef}
+    \leanok
+    \uses{}
+    Let $A\in\MN{D}$ be positive definite and set $S=A^{1/2}$.  Then
+    \[
+        (S^{-1})^\dagger A S^{-1}=\Id .
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Since $A$ is positive definite, $S$ is invertible and self-adjoint.
+    Moreover $S^2=A$.  Therefore
+    \[
+        (S^{-1})^\dagger A S^{-1}
+        =
+        S^{-1}S^2S^{-1}
+        =
+        \Id .
+    \]
+\end{proof}
+
 \begin{theorem}[Trace normalization by inverse square root]
     \label{thm:trace_normalization_inverse_square_root}
     \lean{IsPositiveMap.comp_unitaryConjLM_inv_cfc_sqrt_traceAdjointMap_one}
     \leanok
     \uses{def:positive_map, def:trace_preserving, def:trace_pairing_adjoint,
-        thm:filtered_trace_normalization_criterion}
+        thm:filtered_trace_normalization_criterion, lem:conj_inv_sqrt_normalizes}
     Let $T:\MN{D}\to\MN{D}$ be a positive map such that $T^*(\Id)$ is positive
     definite.  Put
     \[


### PR DESCRIPTION
### Motivation

This PR advances LionSR/QICLean#20 by completing the trace-preserving rescaling lemma from Wolf Chapter 3. PR LionSR/TNLean#3417 established the algebraic normalization criterion; this PR supplies the inverse-square-root choice using Mathlib v4.31 matrix order and continuous functional calculus facts.

### Description

- Proves that for a positive definite matrix A, conjugation by `(CFC.sqrt A)⁻¹` normalizes A to the identity.
- Applies that matrix lemma to `Matrix.traceAdjointMap T 1` to show that if T is positive and T*(1) is positive definite, then `T(X rho X†)` with `X = T*(1)^{-1/2}` is positive and trace-preserving.
- Modifies `TNLean/Channel/TransferMatrix.lean` and `blueprint/src/chapter/ch04_channels.tex` to add the theorem and link it to the algebraic trace-normalization criterion.
- Issue LionSR/QICLean#20 also tracks Prop. 3.8 and Prop. 3.9, so this PR is not intended to close it.

### Testing

- `lake build TNLean.Channel.TransferMatrix`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Refs LionSR/QICLean#20

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained formal proofs and blueprint sync on top of existing trace-normalization infrastructure; no auth, runtime, or data-path changes.
> 
> **Overview**
> Completes Wolf Chapter 3’s “making positive maps trace preserving” step by proving the concrete choice **X = (T*(1))^{-1/2}** when **T*(1)** is positive definite.
> 
> In **`TransferMatrix.lean`**, a new matrix lemma shows that for positive definite **A**, conjugation by **(A^{1/2})^{-1}** sends **A** to the identity, using **CFC.sqrt** and matrix order facts from Mathlib. A channel theorem then plugs **A = T*(1)** into the existing algebraic criterion **X† T*(1) X = 1**, so **ρ ↦ T(XρX†)** is positive and trace-preserving. The file also imports **`Mathlib.Analysis.Matrix.Order`** and extends scoped notation for matrix order.
> 
> The **blueprint** (`ch04_channels.tex`) adds matching lemma and theorem statements with Lean links, and the filtered trace-normalization theorem now points forward to this inverse-square-root result instead of leaving that step open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b37d6e9cc3cd8c1c514572b6156fbc267b41d2c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->