### PR TITLE
feat(Channel/Schwarz): prove n-positive adjoint duality

### DIFF
--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -27,6 +27,8 @@ the existing result which is restricted to completely positive maps.
 
 * `IsCPMap.isNPositiveMap` — CP maps are n-positive for all n
 * `IsPositiveMap.traceAdjointMap` — the trace-pairing adjoint of a positive map is positive
+* `IsNPositiveMap.traceAdjointMap` — the trace-pairing adjoint of a `k`-positive
+  map is `k`-positive
 * `IsCPMap.is2PositiveMap` — CP maps are 2-positive
 * `kadison_schwarz_2positive` — Kadison–Schwarz for unital 2-positive maps
 
@@ -187,6 +189,75 @@ omit [DecidableEq n] in
 theorem isPositiveMap_traceAdjointMap_iff
     {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :
     IsPositiveMap (Matrix.traceAdjointMap E) ↔ IsPositiveMap E := by
+  constructor
+  · intro h
+    have h' := h.traceAdjointMap
+    simpa [Matrix.traceAdjointMap_traceAdjointMap] using h'
+  · intro h
+    exact h.traceAdjointMap
+
+omit [DecidableEq n] in
+private theorem trace_mul_eq_sum_trace_blocks
+    (k : ℕ) (A B : Matrix (n × Fin k) (n × Fin k) ℂ) :
+    Matrix.trace (A * B) =
+      ∑ p : Fin k, ∑ q : Fin k,
+        Matrix.trace
+          ((Matrix.of fun i j => A (i, p) (j, q)) *
+            (Matrix.of fun i j => B (i, q) (j, p))) := by
+  classical
+  simp only [Matrix.trace, Matrix.diag, Matrix.mul_apply, Matrix.of_apply,
+    Fintype.sum_prod_type]
+  rw [Finset.sum_comm]
+  congr 1
+  ext p
+  conv_lhs =>
+    enter [2, i]
+    rw [Finset.sum_comm]
+  rw [Finset.sum_comm]
+
+omit [DecidableEq n] in
+/-- The trace-pairing adjoint commutes with the blockwise ampliation:
+`(E^{(k)})^* = (E^*)^{(k)}`. -/
+theorem nPositiveAmpliation_traceAdjointMap
+    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    nPositiveAmpliation k (Matrix.traceAdjointMap E) =
+      Matrix.traceAdjointMap (nPositiveAmpliation k E) := by
+  classical
+  apply LinearMap.ext
+  intro ρ
+  refine (Matrix.ext_iff_trace_mul_right
+    (A := nPositiveAmpliation k (Matrix.traceAdjointMap E) ρ)
+    (B := Matrix.traceAdjointMap (nPositiveAmpliation k E) ρ)).2 ?_
+  intro X
+  rw [Matrix.trace_traceAdjointMap_mul]
+  rw [trace_mul_eq_sum_trace_blocks, trace_mul_eq_sum_trace_blocks]
+  congr 1
+  ext p
+  congr 1
+  ext q
+  simp only [nPositiveAmpliation, Matrix.of_apply, LinearMap.coe_mk, AddHom.coe_mk]
+  change Matrix.trace
+      (Matrix.traceAdjointMap E (Matrix.of fun i j => ρ (i, p) (j, q)) *
+        (Matrix.of fun i j => X (i, q) (j, p))) =
+    Matrix.trace
+      ((Matrix.of fun i j => ρ (i, p) (j, q)) *
+        E (Matrix.of fun i j => X (i, q) (j, p)))
+  rw [Matrix.trace_traceAdjointMap_mul]
+
+omit [DecidableEq n] in
+/-- The trace-pairing adjoint of a `k`-positive map is `k`-positive. -/
+theorem IsNPositiveMap.traceAdjointMap
+    {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (hE : IsNPositiveMap k E) : IsNPositiveMap k (Matrix.traceAdjointMap E) := by
+  rw [isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation] at hE ⊢
+  rw [nPositiveAmpliation_traceAdjointMap]
+  exact hE.traceAdjointMap
+
+omit [DecidableEq n] in
+/-- `k`-positivity is invariant under the trace-pairing adjoint. -/
+theorem isNPositiveMap_traceAdjointMap_iff
+    {k : ℕ} {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :
+    IsNPositiveMap k (Matrix.traceAdjointMap E) ↔ IsNPositiveMap k E := by
   constructor
   · intro h
     have h' := h.traceAdjointMap

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -152,7 +152,7 @@ maps.
     adjoint for the bilinear pairing $(A,B)\mapsto \operatorname{tr}(AB)$.
 \end{definition}
 
-\begin{theorem}[Trace-pairing adjoint identity]
+\begin{theorem}[Trace-pairing adjoint identity]\label{thm:trace_pairing_adjoint_identity}
     \lean{Matrix.trace_traceAdjointMap_mul}
     \leanok
     \uses{def:trace_pairing_adjoint}
@@ -241,12 +241,71 @@ maps.
     positive semidefinite cone therefore gives $E^*(\rho)\geq 0$.
 \end{proof}
 
-\begin{theorem}[Trace-pairing adjoints preserve positivity exactly]
+\begin{theorem}[Trace-pairing adjoints preserve positivity exactly]\label{thm:trace_pairing_adjoint_positive_iff}
     \lean{isPositiveMap_traceAdjointMap_iff}
     \leanok
     \uses{thm:trace_pairing_adjoint_positive, thm:trace_pairing_adjoint_involutive}
     A linear map is positive if and only if its trace-pairing adjoint is
     positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    One direction is the preceding theorem.  The other follows by applying the
+    same theorem to $E^*$ and using $(E^*)^*=E$.
+\end{proof}
+
+\begin{theorem}[Trace-pairing adjoint of an ampliation]
+    \label{thm:trace_pairing_adjoint_ampliation}
+    \lean{nPositiveAmpliation_traceAdjointMap}
+    \leanok
+    \uses{def:blockwise_ampliation, def:trace_pairing_adjoint,
+        thm:trace_pairing_adjoint_identity}
+    For every linear map $E : \MN{D}\to\MN{D}$, the trace-pairing adjoint
+    commutes with ampliation:
+    \[
+        (E^{(k)})^*=(E^*)^{(k)}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For block matrices write $\rho_{pq}$ and $X_{pq}$ for their
+    $\MN{D}$-valued blocks.  Expanding the trace by blocks gives
+    \[
+        \operatorname{tr}((E^*)^{(k)}(\rho)X)
+        =\sum_{p,q}\operatorname{tr}(E^*(\rho_{pq})X_{qp}).
+    \]
+    The trace-adjoint identity changes each summand to
+    $\operatorname{tr}(\rho_{pq}E(X_{qp}))$, and summing the blocks back gives
+    $\operatorname{tr}(\rho E^{(k)}(X))$.  Nondegeneracy of the trace pairing
+    identifies the two adjoints.
+\end{proof}
+
+\begin{theorem}[Trace-pairing adjoint of a $k$-positive map]
+    \label{thm:k_positive_trace_pairing_adjoint}
+    \lean{IsNPositiveMap.traceAdjointMap}
+    \leanok
+    \uses{def:k_positive_map, thm:trace_pairing_adjoint_ampliation,
+        thm:trace_pairing_adjoint_positive}
+    If $E$ is $k$-positive, then $E^*$ is $k$-positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $E$ is $k$-positive, its ampliation $E^{(k)}$ is positive.  The
+    trace-pairing adjoint of this positive map is positive, and the preceding
+    theorem identifies that adjoint with $(E^*)^{(k)}$.
+\end{proof}
+
+\begin{theorem}[$k$-positivity is trace-adjoint invariant]
+    \label{thm:k_positive_trace_pairing_adjoint_iff}
+    \lean{isNPositiveMap_traceAdjointMap_iff}
+    \leanok
+    \uses{thm:k_positive_trace_pairing_adjoint,
+        thm:trace_pairing_adjoint_involutive}
+    A linear map is $k$-positive if and only if its trace-pairing adjoint is
+    $k$-positive.
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
### Motivation

This PR formalizes the adjoint-duality statement for n-positive maps from Wolf Ch. 3, §3.1: the trace-pairing adjoint T* is n-positive if and only if T is n-positive.

This closes the duality component of issue LionSR/QICLean#164. The issue also contains the convex-cone and inclusion-chain components, so this PR is not intended to close it.

### Description

- `TNLean/Channel/Schwarz/TwoPositive.lean`: adds a block trace expansion for matrices indexed by `n × Fin k`; proves `nPositiveAmpliation_traceAdjointMap`, the identity `(E^(k))* = (E*)^(k)`; proves `IsNPositiveMap.traceAdjointMap` and `isNPositiveMap_traceAdjointMap_iff`.
- `blueprint/src/chapter/ch05_schwarz.tex`: adds corresponding blueprint entries with `\lean{}` and `\leanok` tags for the new declarations.

### Testing

- `lake env lean TNLean/Channel/Schwarz/TwoPositive.lean`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `rg -n "sorry|admit|native_decide|unsafeCast|axiom" TNLean/Channel/Schwarz/TwoPositive.lean || true`

---
Refs LionSR/QICLean#164
