### PR TITLE
fix(Channel): rename inverse-square-root normalization lemma

### DIFF
--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -497,6 +497,10 @@ theorem Matrix.conjTranspose_inv_sqrt_mul_self_mul_inv_sqrt_eq_one_of_posDef
     _ = S⁻¹ * (S * S) * S⁻¹ := by rw [hSinv_herm, hS_sq]
     _ = 1 := by simp [Matrix.mul_assoc, hSinv_mul, hSmul_inv]
 
+@[deprecated (since := "2026-06-23")] alias
+  Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef :=
+    Matrix.conjTranspose_inv_sqrt_mul_self_mul_inv_sqrt_eq_one_of_posDef
+
 /-- **Wolf Chapter 3 trace normalization by inverse square root.**
 
 If T is positive and T*(1) is positive definite, then choosing

--- a/TNLean/Channel/TransferMatrix.lean
+++ b/TNLean/Channel/TransferMatrix.lean
@@ -471,7 +471,7 @@ theorem IsPositiveMap.comp_unitaryConjLM_positive_tracePreserving
 
 /-- If A is positive definite, conjugation by its inverse square root
 normalizes A to the identity. -/
-theorem Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef
+theorem Matrix.conjTranspose_inv_sqrt_mul_self_mul_inv_sqrt_eq_one_of_posDef
     (A : Matrix (Fin D) (Fin D) ℂ) (hA : A.PosDef) :
     ((CFC.sqrt A)⁻¹)ᴴ * A * (CFC.sqrt A)⁻¹ = 1 := by
   set S : Matrix (Fin D) (Fin D) ℂ := CFC.sqrt A
@@ -509,7 +509,7 @@ theorem IsPositiveMap.comp_unitaryConjLM_inv_cfc_sqrt_traceAdjointMap_one
       IsTracePreservingMap
         (T.comp (unitaryConjLM ((CFC.sqrt (Matrix.traceAdjointMap T 1))⁻¹))) := by
   exact hT.comp_unitaryConjLM_positive_tracePreserving _
-    (Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef
+    (Matrix.conjTranspose_inv_sqrt_mul_self_mul_inv_sqrt_eq_one_of_posDef
       (Matrix.traceAdjointMap T 1) hTstar)
 
 end UnitaryConjugation

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -114,7 +114,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 
 \begin{lemma}[Normalizing conjugation by inverse square root]
     \label{lem:conj_inv_sqrt_normalizes}
-    \lean{Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef}
+    \lean{Matrix.conjTranspose_inv_sqrt_mul_self_mul_inv_sqrt_eq_one_of_posDef}
     \leanok
     \uses{}
     Let $A\in\MN{D}$ be positive definite and set $S=A^{1/2}$.  Then


### PR DESCRIPTION
### Motivation

- Late-review follow-up to PR LionSR/TNLean#3421 (`feat(Channel): add inverse-square-root trace normalization`): the lemma name `Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef` omitted the right multiplication factor and the equality to the identity from the name, embedding the Mathlib implementation prefix `cfc` rather than the full mathematical content.
- Continues formalization of the trace-preserving rescaling lemma from Wolf Chapter 3, §3.5 (issue LionSR/QICLean#20, `blueprint/src/chapter/ch04_channels.tex` `lem:conj_inv_sqrt_normalizes`).

### Description

- Renames `Matrix.conjTranspose_inv_cfc_sqrt_mul_self_of_posDef` to `Matrix.conjTranspose_inv_sqrt_mul_self_mul_inv_sqrt_eq_one_of_posDef` in `TNLean/Channel/TransferMatrix.lean`; the new name records the full expression proved: `((A^{1/2})⁻¹)ᴴ * A * (A^{1/2})⁻¹ = 1` for positive definite `A`.
- Adds a deprecated alias from the old theorem name to the new theorem name, since the old name is mathematically meaningful but less precise.
- Updates the `\lean{}` blueprint tag in `blueprint/src/chapter/ch04_channels.tex` to the new declaration name.
- No mathematical statement or proof is changed.

### Testing

- `lake env lean TNLean/Channel/TransferMatrix.lean`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

---
Addresses LionSR/QICLean#20