### PR TITLE
doc(blueprint): add nonzero hypothesis to D-positive endpoint

### DIFF
--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -336,22 +336,22 @@ maps.
     $E\otimes\id_1$ is exactly positivity of $E$.
 \end{proof}
 
-\begin{theorem}[$D$-positive maps on $\MN{D}$ are completely positive]
+\begin{theorem}[$D$-positive maps on nonzero $\MN{D}$ are completely positive]
     \label{thm:d_positive_iff_completely_positive}
     \lean{isCPMap_iff_isNPositiveMap_card}
     \leanok
     \uses{def:k_positive_map, def:cp_map, thm:cp_iff_choi_posSemidef}
-    For maps $E:\MN{D}\to\MN{D}$, complete positivity is equivalent to
-    $D$-positivity.
+    For maps $E:\MN{D}\to\MN{D}$ with $D\ge 1$, complete positivity is
+    equivalent to $D$-positivity.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Complete positivity implies $k$-positivity for every $k$. Conversely, if
-    $E$ is $D$-positive, apply $E\otimes\id_D$ to the maximally entangled
-    projector $|\Omega\rangle\langle\Omega|$. The result is the Choi matrix of
-    $E$, hence it is positive semidefinite. Choi's theorem then gives complete
-    positivity.
+    Complete positivity implies $k$-positivity for every $k$. Conversely,
+    assume $D\ge 1$. If $E$ is $D$-positive, apply $E\otimes\id_D$ to the
+    maximally entangled projector $|\Omega\rangle\langle\Omega|$. The result is
+    the Choi matrix of $E$, hence it is positive semidefinite. Choi's theorem
+    then gives complete positivity.
 \end{proof}
 
 \begin{theorem}[$(k\!+\!1)$-positive implies $k$-positive]


### PR DESCRIPTION
### Motivation

- The blueprint entry `thm:d_positive_iff_completely_positive` (`blueprint/src/chapter/ch05_schwarz.tex`, lines 341–358) stated the equivalence between complete positivity and $D$-positivity for maps $E \colon M_D(\mathbb{C}) \to M_D(\mathbb{C})$ with no restriction on $D$. The Lean theorem `isCPMap_iff_isNPositiveMap_card` carries the typeclass hypothesis `[NeZero D]`, asserting $D \geq 1$.
- Under the faithfulness rule, the `\leanok` tag on this blueprint entry was invalid: the Lean signature imposes a stricter hypothesis than the blueprint statement as written.
- Continues blueprint alignment for the n-positivity inclusion chain (Wolf §3.1, chain $\mathcal{T}_\mathrm{CP} = \mathcal{T}_D \subseteq \cdots \subseteq \mathcal{T}_1 = \mathrm{Pos}$); see LionSR/QICLean#164.

### Description

- Modified `blueprint/src/chapter/ch05_schwarz.tex`: added the hypothesis $D \geq 1$ to the statement and proof of `thm:d_positive_iff_completely_positive`, aligning it with the `[NeZero D]` typeclass in `isCPMap_iff_isNPositiveMap_card`.
- The `\leanok` tag is preserved; it is now faithful to the Lean signature.

### Testing

- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

---
Closes LionSR/QICLean#169
Refs LionSR/QICLean#164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits in the blueprint; no runtime or formal proof code changes.
> 
> **Overview**
> The blueprint theorem **`thm:d_positive_iff_completely_positive`** now states that on **nonzero** \(\MN{D}\) (via **\(D \ge 1\)**), complete positivity and **\(D\)-positivity** are equivalent. The title and statement were tightened accordingly.
> 
> The converse proof explicitly assumes **\(D \ge 1\)** before applying **\(E \otimes \id_D\)** to the maximally entangled projector, matching Lean **`isCPMap_iff_isNPositiveMap_card`** and its **`[NeZero D]`** hypothesis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844b35cfa656eb28928e9581eee50842aa07c20a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->