### PR TITLE
feat(Channel): add reduction map positivity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -50,6 +50,7 @@ import TNLean.Topology.CompactRetractFixedPoint
 
 -- Layer 2: Quantum channels (general theory)
 import TNLean.Channel.Basic
+import TNLean.Channel.PositiveExamples
 import TNLean.Channel.DensityRetract
 
 -- Layer 2 (Ch. 2 infrastructure): Choi–Jamiolkowski, Kraus, Stinespring

--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -193,3 +193,73 @@ theorem smul_one_sub_hermitian_spectral
           congr 1
           ext i
           simp [Complex.ofReal_sub]
+
+/-- A Hermitian matrix is bounded above by its largest eigenvalue times the
+identity. -/
+theorem maxEigenvalue_smul_one_sub_posSemidef [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.IsHermitian) :
+    ((↑(maxEigenvalue hM) : ℂ) • (1 : Matrix n n ℂ) - M).PosSemidef := by
+  classical
+  let U : Matrix n n ℂ := ↑hM.eigenvectorUnitary
+  let Λ : n → ℂ := fun j => ↑(maxEigenvalue hM - hM.eigenvalues j)
+  have hdiag : (Matrix.diagonal Λ).PosSemidef := by
+    refine Matrix.PosSemidef.diagonal ?_
+    intro j
+    change (0 : ℂ) ≤ ↑(maxEigenvalue hM - hM.eigenvalues j)
+    exact_mod_cast sub_nonneg.mpr (le_maxEigenvalue hM j)
+  have hconj : (U * Matrix.diagonal Λ * Uᴴ).PosSemidef := by
+    simpa only [mul_assoc, Matrix.conjTranspose_conjTranspose] using
+      hdiag.mul_mul_conjTranspose_same (B := U)
+  rw [smul_one_sub_hermitian_spectral hM (maxEigenvalue hM)]
+  simpa [U, Λ] using hconj
+
+namespace Matrix.PosSemidef
+
+/-- The largest eigenvalue of a positive semidefinite matrix is bounded by its
+trace. -/
+theorem maxEigenvalue_le_trace_re [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    maxEigenvalue hM.isHermitian ≤ (Matrix.trace M).re := by
+  classical
+  obtain ⟨i, hi⟩ := maxEigenvalue_achieved hM.isHermitian
+  have htrace : (Matrix.trace M).re = ∑ j : n, hM.isHermitian.eigenvalues j := by
+    have h := hM.isHermitian.trace_eq_sum_eigenvalues
+    exact_mod_cast congrArg Complex.re h
+  calc
+    maxEigenvalue hM.isHermitian = hM.isHermitian.eigenvalues i := hi.symm
+    _ ≤ ∑ j : n, hM.isHermitian.eigenvalues j :=
+        Finset.single_le_sum (fun j _ => hM.eigenvalues_nonneg j) (Finset.mem_univ i)
+    _ = (Matrix.trace M).re := htrace.symm
+
+/-- For a positive semidefinite matrix, `tr(A) I - A` is positive semidefinite.
+
+This is the matrix inequality behind the reduction criterion in Wolf Chapter 3,
+Example 3.1. -/
+theorem trace_smul_one_sub_self_posSemidef [Nonempty n]
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) :
+    (Matrix.trace M • (1 : Matrix n n ℂ) - M).PosSemidef := by
+  classical
+  let c : ℝ := (Matrix.trace M).re
+  have htrace_eq : Matrix.trace M = (c : ℂ) := by
+    have h := hM.isHermitian.trace_eq_sum_eigenvalues
+    rw [h]
+    apply Complex.ext
+    · simp [c, h]
+    · simp
+  have hshift : ((↑(maxEigenvalue hM.isHermitian) : ℂ) •
+      (1 : Matrix n n ℂ) - M).PosSemidef :=
+    maxEigenvalue_smul_one_sub_posSemidef hM.isHermitian
+  have hextra : (((c - maxEigenvalue hM.isHermitian : ℝ) : ℂ) •
+      (1 : Matrix n n ℂ)).PosSemidef := by
+    exact Matrix.PosSemidef.one.smul
+      (by exact_mod_cast sub_nonneg.mpr hM.maxEigenvalue_le_trace_re)
+  have hdecomp :
+      Matrix.trace M • (1 : Matrix n n ℂ) - M =
+        ((c - maxEigenvalue hM.isHermitian : ℝ) : ℂ) • (1 : Matrix n n ℂ) +
+          ((↑(maxEigenvalue hM.isHermitian) : ℂ) • (1 : Matrix n n ℂ) - M) := by
+    rw [htrace_eq]
+    module
+  rw [hdecomp]
+  exact hextra.add hshift
+
+end Matrix.PosSemidef

--- a/TNLean/Channel/PositiveExamples.lean
+++ b/TNLean/Channel/PositiveExamples.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.HermitianHelpers
+import TNLean.Channel.Basic
+
+/-!
+# Examples of positive maps
+
+This file records elementary positive maps from Wolf Chapter 3.
+
+## Main declarations
+
+* `Matrix.reductionMap`: the reduction map
+  \(X \mapsto \operatorname{tr}(X) I - k^{-1}X\).
+* `Matrix.reductionMap_one_isPositiveMap`: the case \(k=1\) is positive.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Example 3.1][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+namespace Matrix
+
+/-- **Wolf Chapter 3, Example 3.1.** The reduction map
+\(T_k(X)=\operatorname{tr}(X)I-k^{-1}X\) on \(M_D(\mathbb C)\). -/
+noncomputable def reductionMap (D k : ℕ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
+  toFun X := Matrix.trace X • (1 : Matrix (Fin D) (Fin D) ℂ) - ((k : ℂ)⁻¹) • X
+  map_add' := by
+    intro X Y
+    ext i j
+    simp [Matrix.trace_add, add_smul, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]
+  map_smul' := by
+    intro c X
+    ext i j
+    simp [Matrix.trace_smul, smul_smul, mul_comm, mul_left_comm, mul_assoc]
+    ring
+
+@[simp]
+theorem reductionMap_apply (D k : ℕ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    reductionMap D k X =
+      Matrix.trace X • (1 : Matrix (Fin D) (Fin D) ℂ) - ((k : ℂ)⁻¹) • X :=
+  rfl
+
+/-- The reduction map \(T_1(X)=\operatorname{tr}(X)I-X\) is positive. -/
+theorem reductionMap_one_isPositiveMap {D : ℕ} [NeZero D] :
+    IsPositiveMap (reductionMap D 1) := by
+  haveI : Nonempty (Fin D) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero (NeZero.ne D))
+  intro X hX
+  simpa [reductionMap] using
+    (Matrix.PosSemidef.trace_smul_one_sub_self_posSemidef hX)
+
+end Matrix

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -55,7 +55,7 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     \label{def:reduction_map}
     \lean{Matrix.reductionMap}
     \leanok
-    The reduction map on $\MN{D}$ is
+    The reduction map on $\MN{D}$, for $k\in\N$, is
     \[
         T_k(X)=\tr(X)\Id-k^{-1}X.
     \]
@@ -70,9 +70,12 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}\leanok
-    If $X\ge 0$, diagonalize $X$.  Its eigenvalues are nonnegative, and each
-    eigenvalue is bounded by their sum $\tr(X)$.  Therefore all eigenvalues of
-    $\tr(X)\Id-X$ are nonnegative.
+    If $X\ge 0$, diagonalize $X$.  Its eigenvalues
+    $\lambda_1,\ldots,\lambda_D$ are nonnegative, and for each $j$,
+    \[
+        \lambda_j\le \sum_{i=1}^D \lambda_i=\tr(X).
+    \]
+    Therefore all eigenvalues of $\tr(X)\Id-X$ are nonnegative.
 \end{proof}
 
 \begin{theorem}[Conjugation filters preserve positivity]

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -51,6 +51,30 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     Trace preservation is the identity $\tr(X^T)=\tr(X)$.
 \end{proof}
 
+\begin{definition}[Reduction map]
+    \label{def:reduction_map}
+    \lean{Matrix.reductionMap}
+    \leanok
+    The reduction map on $\MN{D}$ is
+    \[
+        T_k(X)=\tr(X)\Id-k^{-1}X.
+    \]
+\end{definition}
+
+\begin{theorem}[The first reduction map is positive]
+    \label{thm:reduction_map_one_positive}
+    \lean{Matrix.reductionMap_one_isPositiveMap}
+    \leanok
+    \uses{def:positive_map, def:reduction_map}
+    For $D\ge 1$, the map $T_1(X)=\tr(X)\Id-X$ on $\MN{D}$ is positive.
+\end{theorem}
+
+\begin{proof}\leanok
+    If $X\ge 0$, diagonalize $X$.  Its eigenvalues are nonnegative, and each
+    eigenvalue is bounded by their sum $\tr(X)$.  Therefore all eigenvalues of
+    $\tr(X)\Id-X$ are nonnegative.
+\end{proof}
+
 \begin{theorem}[Conjugation filters preserve positivity]
     \label{thm:conjugation_filters_preserve_positivity}
     \lean{unitaryConjLM_isCPMap, unitaryConjLM_isPositiveMap,


### PR DESCRIPTION
### Motivation

- Wolf Ch. 3, Example 3.1 (source: `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, eq. 3.18, lines ~307–400) introduces the reduction maps $T_k(X) = \operatorname{tr}(X)\,I - k^{-1}X$.
- The case $k = 1$ is the first reduction criterion and provides an entry point toward the strictness example tracked in LionSR/QICLean#21.

### Description

- Adds `maxEigenvalue_smul_one_sub_posSemidef` (Hermitian spectral estimate) and `Matrix.PosSemidef.trace_smul_one_sub_self_posSemidef` (positive-semidefinite consequence) to `TNLean/Algebra/HermitianHelpers.lean`.
- Adds `Matrix.reductionMap` in the new `TNLean/Channel/PositiveExamples.lean` module, defining $T_k(X) = \operatorname{tr}(X)\,I - k^{-1}X$.
- Proves `Matrix.reductionMap_one_isPositiveMap`: $T_1$ is a positive map for nonzero matrix dimension, via the spectral estimate above.
- Adds blueprint entries in `blueprint/src/chapter/ch04_channels.tex` for the reduction map definition and the positivity of $T_1$, linked to the Lean declarations.
- Wires `TNLean/Channel/PositiveExamples.lean` into the root `TNLean.lean` import.

### Testing

- `lake build TNLean.Channel.PositiveExamples`
- `lake env lean TNLean.lean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `lake build`

---
Addresses LionSR/QICLean#21

> [!NOTE]
> **Low Risk**
> Self-contained formal math and documentation; no changes to runtime, auth, or existing channel APIs beyond a new import and lemmas.
>
> **Overview**
> Adds **Hermitian / PSD spectral lemmas** in `HermitianHelpers`: `maxEigenvalue_smul_one_sub_posSemidef`, `maxEigenvalue_le_trace_re`, and `trace_smul_one_sub_self_posSemidef` (the matrix inequality behind Wolf's reduction criterion).
>
> Introduces **`TNLean/Channel/PositiveExamples.lean`** with `Matrix.reductionMap` \(T_k(X)=\mathrm{tr}(X)I-k^{-1}X\) and a proof that **`T_1` is a positive map** when \(D\neq 0\), via the new trace-shift lemma. The module is wired into **`TNLean.lean`**.
>
> **Blueprint** (`ch04_channels.tex`) gains the reduction map definition and the positivity theorem for \(T_1\), linked to the Lean declarations.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 685386c1765430eaa8e85ec62f04a4b81af5a73f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained formal math and blueprint wiring; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds **Hermitian/PSD spectral lemmas** in `HermitianHelpers`: `maxEigenvalue_smul_one_sub_posSemidef`, `maxEigenvalue_le_trace_re`, and `trace_smul_one_sub_self_posSemidef` (the inequality \(\mathrm{tr}(A)I - A \succeq 0\) for PSD \(A\)).
> 
> Introduces **`TNLean/Channel/PositiveExamples.lean`** with `Matrix.reductionMap` \(T_k(X)=\mathrm{tr}(X)I-k^{-1}X\) and **`reductionMap_one_isPositiveMap`**, showing \(T_1\) is positive when \(D\neq 0\), via the new trace-shift lemma. The module is imported from **`TNLean.lean`**.
> 
> **Blueprint** `ch04_channels.tex` documents the reduction map definition and positivity of \(T_1\), linked to the Lean declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915583d062d2734535ba075c1f2337e304e99157. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->