### PR TITLE
doc(MPS/RFP): align Appendix B coefficient boundary

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -45,8 +45,8 @@ clause from Definition 3.9.
   \(hᵢhⱼ = hⱼhᵢ\).
 * `MPSTensor.rfp_implies_nncph_of_appendixBExtraction` — a conditional theorem
   deriving NNCPH from the Appendix B structural form
-  \(Aᵢ = XΛUᵢX⁻¹\), the even-chain product-of-pairs factorization, and the
-  two-site projector identities, without invoking
+  \(A^i = X\Lambda U^iX^{-1}\), the disjoint adjacent-pair coefficient
+  condition, and the two-site projector identities, without invoking
   `Axioms.rfp_to_nncph_commute`.
 * `MPSTensor.rfp_implies_nncph_ground_state_of_appendixBExtraction` — the same
   conditional theorem with the zero-energy equation for \(V^{(N)}(A)\) included.
@@ -346,17 +346,17 @@ theorem HasProductPairLocalProjectors.isNNCPH {A : MPSTensor d D} {N : ℕ}
     IsNNCPH A N :=
   hPair.commuting_twoSite_localTerms
 
-/-- The product-of-pairs equations and the two-site projector identities give
-NNCPH on each finite chain. -/
+/-- The disjoint adjacent-pair coefficient condition and the two-site projector
+identities give NNCPH on each finite chain. -/
 theorem ProductPairBridge.isNNCPH {A : MPSTensor d D} (hBridge : ProductPairBridge A)
     (N : ℕ) :
     IsNNCPH A N :=
   (hBridge.localProjectors N).isNNCPH
 
-/-- Product-of-pairs data and the ground-space spanning equation give the full
-all-chain nearest-neighbor parent-Hamiltonian condition.
+/-- The conditional adjacent-pair hypotheses and the ground-space spanning
+equation give the full all-chain nearest-neighbor parent-Hamiltonian condition.
 
-The product-of-pairs data supply the translated length-two commutation
+The adjacent-pair hypotheses supply the translated length-two commutation
 equations. The usual parent-Hamiltonian frustration-free equation gives
 zero energy of \(V^{(N)}(B)\). The separate hypothesis
 `HasParentHamiltonianGroundSpaceSpanning B 2 A` supplies the remaining
@@ -373,10 +373,11 @@ theorem ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning
 /-- Conditional internal theorem for Theorem 3.10(i)⟹(iii).
 
 A normal left-canonical RFP tensor has the Appendix B structural form
-\(Aᵢ = XΛUᵢX⁻¹\) by `AppendixBStructuralData.ofRFP`. If the associated two-site
-amplitude gives the even-chain factorization and the two-site parent terms are
-identified with commuting idempotents, then the nearest-neighbor parent
-Hamiltonian is commuting on every finite chain.
+\(A^i = X\Lambda U^iX^{-1}\) by `AppendixBStructuralData.ofRFP`. If the
+associated two-site amplitude gives the disjoint adjacent-pair coefficient
+condition and the two-site parent terms are identified with commuting
+idempotents, then the nearest-neighbor parent Hamiltonian is commuting on every
+finite chain.
 
 This theorem does not use `Axioms.rfp_to_nncph_commute`; it states the precise
 conditional theorem left after the structural form has been internalized. -/
@@ -391,7 +392,7 @@ theorem rfp_implies_nncph_of_appendixBExtraction (A : MPSTensor d D) [NeZero D]
 
 /-- Conditional ground-vector form of Theorem 3.10(i)⟹(iii).
 
-Under the same Appendix B product-of-pairs extraction used for
+Under the same Appendix B conditional hypotheses used for
 `rfp_implies_nncph_of_appendixBExtraction`, the nearest-neighbor parent terms
 commute and the periodic MPS vector \(V^{(N)}(A)\) has zero energy. This adds
 only the standard parent-Hamiltonian frustration-free equation; it does not
@@ -414,14 +415,14 @@ theorem rfp_implies_nncph_ground_state_of_appendixBExtraction
 
 /-- Conditional full source form of Theorem 3.10(i)⟹(iii).
 
-Under the Appendix B product-of-pairs extraction used above, a normal
+Under the Appendix B conditional hypotheses used above, a normal
 left-canonical RFP tensor has the all-chain commutation and zero-energy
 equations for nearest-neighbor parent terms. If, in addition, the
 Definition 3.9 ground-space spanning equation is supplied for a chosen BNT
 family \(A_j\), then the full all-chain NNCPH ground-space condition holds.
 
-This theorem does not use `Axioms.rfp_to_nncph_commute`; the remaining input is
-exactly the source ground-space spanning clause.
+This theorem does not use `Axioms.rfp_to_nncph_commute`; beyond the conditional
+Appendix B hypotheses, it assumes the source ground-space spanning clause.
 
 **Scope restriction (spanning clause assumed):** The source implication proves
 the ground-space spanning equation; this theorem assumes it via

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -8,7 +8,7 @@ import TNLean.MPS.RFP.StructuralFull
 import Mathlib.Data.Fin.Basic
 
 /-!
-# Product-of-entangled-pairs form and translated two-site parent terms
+# Basic-vector form and translated two-site parent terms
 
 This file isolates the source ingredients used for the forward direction
 \(\mathrm{RFP}\Rightarrow\mathrm{NNCPH}\) in arXiv:1606.00608, Theorem 3.10.
@@ -20,16 +20,21 @@ the structural characterization theorem. That theorem, stated at source lines
     \bigoplus_{j=1}^{g}\bigoplus_{q=1}^{r_j}
       \mu_{j,q}X_{j,q}\Lambda_jU^i_jX_{j,q}^{-1}.
 \]
-Appendix B proves the corresponding normal-tensor form and identifies the
-isometry \(U\). The remaining parent-Hamiltonian step is the passage from this
-product-of-entangled-pairs form to commutativity of the translated two-site
-terms \(h_i=\tau_i(P_2^\perp)\).
+The source then writes the corresponding basic vectors as
+\[
+  |V^{(N)}(A_j)\rangle=U^{\otimes N}|\varphi_j\rangle^{\otimes N},
+  \qquad
+  |\varphi_j\rangle=\sum_m\lambda_m|m,m\rangle,
+\]
+where \(\varphi_j\) is shared by \(b_n\) and \(a_{n+1}\), and \(U\) acts on
+\((a_n,b_n)\). The remaining parent-Hamiltonian step is to pass from this
+basic-vector form to commutativity of the translated two-site terms
+\(h_i=\tau_i(P_2^\perp)\).
 
 The declarations below separate four mathematical statements:
 
-* the cyclic virtual-pair expression for the coefficients of \(\Lambda U^i\);
-* the adjacent even-chain coefficient factorization as a repeated two-site
-  amplitude;
+* the coefficient expression for \(U^{\otimes L}\varphi_j^{\otimes L}\);
+* the disjoint adjacent-pair coefficient condition used later in this file;
 * the identification of the translated two-site parent terms with commuting
   idempotents on each finite chain;
 * the already formalized Appendix B structural form.
@@ -37,11 +42,11 @@ The declarations below separate four mathematical statements:
 **Scope restriction (overlapping two-site terms):** The three-site support maps
 for the source \(AX\) and \(XB\) windows are represented in
 `TNLean.MPS.ParentHamiltonian.LocalSupport`. The remaining Appendix-B step is to
-identify the product-of-entangled-pairs parent projectors with the translated
+identify the source projectors \(Q_{AX}\) and \(Q_{XB}\) with the translated
 length-two parent terms and prove their overlapping commutation. For this reason
 commutativity of the translated idempotents is an explicit hypothesis in
-`HasProductPairLocalProjectors`. Eliminating this hypothesis is the
-product-of-entangled-pairs locality step recorded in
+`HasProductPairLocalProjectors`. Eliminating this hypothesis is the source
+projector-identification step recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 
@@ -73,13 +78,14 @@ def productPairWindow (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N) : Cfg d 2 :=
   simp [productPairWindow]
 
 /-- The even-chain state obtained by repeating a fixed two-site amplitude on
-adjacent pairs.
+disjoint adjacent pairs.
 
-This is the adjacent-pair expression used by the present nearest-neighbor
-parent-term input. Appendix B first gives a cyclic virtual-pair expression in
-which the vector \(\varphi_j\) is shared between \(b_n\) and \(a_{n+1}\), while
-the isometry \(U\) acts on \((a_n,b_n)\). Identifying that cyclic expression
-with this adjacent physical-pair expression is a separate mathematical step. -/
+This is the disjoint adjacent-pair expression used by the conditional
+nearest-neighbor parent-term theorem below. It is not the basic-vector formula
+of arXiv:1606.00608, lines 570--578, by itself: the source formula first puts
+\(\varphi_j\) between \(b_n\) and \(a_{n+1}\) and then applies \(U\) to
+\((a_n,b_n)\) at every site. Any use of this disjoint adjacent-pair expression
+therefore has to be justified separately from the source formula. -/
 def productPairState (ψ₂ : NSiteSpace d 2) (N : ℕ) : NSiteSpace d (2 * N) :=
   fun σ => ∏ p : Fin N, ψ₂ (productPairWindow N σ p)
 
@@ -93,20 +99,21 @@ def productPairState (ψ₂ : NSiteSpace d 2) (N : ℕ) : NSiteSpace d (2 * N) :
     productPairState ψ₂ 1 σ = ψ₂ σ := by
   simp [productPairState]
 
-/-- An MPS tensor has adjacent product-pair MPVs when every positive
+/-- An MPS tensor has disjoint adjacent-pair MPVs when every positive
 even-length coefficient factors as a repeated copy of one fixed two-site
 amplitude on the pairs \((0,1),(2,3),\ldots\).
 
 This is a generic factorization predicate: it does not assert that the two-site
 amplitude is entangled. The zero-pair case is omitted because the empty-chain
-MPV coefficient is the bond dimension, whereas the empty product-pair amplitude
+MPV coefficient is the bond dimension, whereas the empty disjoint-pair amplitude
 is \(1\). Odd chain lengths are omitted because this predicate is used only to
 identify the translated two-site parent terms in the RFP-to-NNCPH direction of
 arXiv:1606.00608, Theorem 3.10.
 
-**Scope restriction:** Appendix B first produces a cyclic virtual-pair network.
-This predicate is the later adjacent-pair input used by the present formal
-statement; it is not, by itself, the full Appendix B factorization theorem. -/
+**Scope restriction:** Appendix B first produces the basic-vector expression
+\(U^{\otimes N}\varphi_j^{\otimes N}\). This predicate is the later disjoint
+adjacent-pair condition used by the present formal statement; it is not, by
+itself, the full Appendix B factorization theorem. -/
 def HasProductPairMPV (A : MPSTensor d D) : Prop :=
   ∃ ψ₂ : NSiteSpace d 2, ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState ψ₂ N σ
@@ -123,9 +130,9 @@ theorem HasProductPairMPV.exists_twoSiteAmplitude {A : MPSTensor d D}
 
 **Scope restriction (local projectors):** The three-site \(AX/XB\) support maps
 for adjacent windows give the local support maps. This structure does not
-construct, from the Appendix-B product-of-entangled-pairs form, the chain-level
-projectors that equal the translated length-two parent terms. The projectors are
-therefore stated directly as endomorphisms of the full \(N\)-site space. -/
+construct the source projectors \(Q_{AX}\) and \(Q_{XB}\), nor does it identify
+them with the translated length-two parent terms. The projectors are therefore
+stated directly as endomorphisms of the full \(N\)-site space. -/
 structure HasProductPairLocalProjectors (A : MPSTensor d D) (N : ℕ) where
   proj : Fin N → NSiteSpace d N →ₗ[ℂ] NSiteSpace d N
   hidem : ∀ i, proj i * proj i = proj i
@@ -138,7 +145,7 @@ theorem HasProductPairLocalProjectors.localTerm_idempotent
     localTerm A 2 N i * localTerm A 2 N i = localTerm A 2 N i := by
   rw [hPair.hlocal i, hPair.hidem i]
 
-/-- The product-of-entangled-pairs locality witness implies commutativity of the
+/-- The stated local projector hypotheses imply commutativity of the
 nearest-neighbor parent-Hamiltonian local terms.
 
 This is exactly the body of `IsCommutingParentHam A 2 N` after unfolding the
@@ -153,10 +160,9 @@ theorem HasProductPairLocalProjectors.commuting_twoSite_localTerms
   rw [hPair.hlocal i, hPair.hlocal j]
   exact hPair.hcomm i j
 
-/-- Product-of-entangled-pairs hypotheses for a tensor whose positive
-even-chain MPVs factor through one adjacent two-site amplitude and whose
-nearest-neighbor parent projectors are commuting idempotents on every finite
-chain. -/
+/-- Conditional hypotheses for a tensor whose positive even-chain coefficients
+factor through one disjoint adjacent two-site amplitude and whose
+nearest-neighbor parent terms are commuting idempotents on every finite chain. -/
 structure ProductPairBridge (A : MPSTensor d D) where
   pairAmplitude : NSiteSpace d 2
   hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
@@ -174,8 +180,8 @@ theorem ProductPairBridge.hasProductPairMPV {A : MPSTensor d D}
     HasProductPairMPV A :=
   ⟨hBridge.pairAmplitude, hBridge.hmpv⟩
 
-/-- The `ProductPairBridge` witness yields the unfolded `IsNNCPH` conclusion:
-all two-site local terms commute on every finite chain.
+/-- The conditional adjacent-pair hypotheses yield the unfolded `IsNNCPH`
+conclusion: all two-site local terms commute on every finite chain.
 
 The statement is written as the commutation equation for the translated
 two-site parent terms, which is the nearest-neighbor commutation condition in
@@ -192,15 +198,15 @@ theorem ProductPairBridge.localTerm_idempotent
     localTerm A 2 N i * localTerm A 2 N i = localTerm A 2 N i :=
   (hBridge.localProjectors N).localTerm_idempotent i
 
-/-! ### Appendix B structural form as the preceding input -/
+/-! ### Appendix B structural form used below -/
 
 /-- Structure recording the Appendix B normal-tensor decomposition
 \(A^i=X\Lambda U^iX^{-1}\) in the source unit pair-index convention.
 
 The theorem `rfp_nt_structural_full_unit_pair` proves existence of this
 structural form from the RFP, normality, and left-canonical hypotheses. The
-remaining product-of-entangled-pairs factorization and parent-term identities
-must use the same \(X,\Lambda,U\). -/
+remaining coefficient condition and parent-term identities must use the same
+\(X,\Lambda,U\). -/
 structure AppendixBStructuralData (A : MPSTensor d D) where
   /-- The virtual-bond change of basis. -/
   X : Matrix (Fin D) (Fin D) ℂ
@@ -277,15 +283,14 @@ noncomputable def AppendixBStructuralData.coreTensor {A : MPSTensor d D}
     hStruct.coreTensor i = Matrix.diagonal (fun k => (hStruct.Λ k : ℂ)) * hStruct.U i :=
   rfl
 
-/-! ### The cyclic virtual-pair expression from Appendix B -/
+/-! ### Coefficients of the source basic-vector expression -/
 
 /-- The next virtual bond in the cyclic chain of length \(L\). -/
 def cyclicVirtualSucc {L : ℕ} (hL : 0 < L) (t : Fin L) : Fin L :=
   letI : NeZero L := ⟨Nat.ne_of_gt hL⟩
   t + 1
 
-/-- The coefficient expression obtained by putting the Appendix B virtual pairs
-on a cycle.
+/-- The coefficient expression obtained from the source basic-vector formula.
 
 For a chain of length \(L\), choose a virtual index \(\alpha_t\) at each site.
 The factor at site \(t\) is
@@ -309,8 +314,8 @@ noncomputable def AppendixBStructuralData.cyclicVirtualPairState
       (hStruct.Λ (α t) : ℂ) *
         hStruct.U (σ t) (α t) (α (cyclicVirtualSucc hL t))
 
-/-- The coefficient of the Appendix B core tensor is the cyclic virtual-pair
-expression.
+/-- The coefficient of the Appendix B core tensor is the coefficient form of
+the source basic-vector expression.
 
 This is the coefficient form of
 \[
@@ -319,7 +324,7 @@ This is the coefficient form of
   |\varphi_j\rangle=\sum_m\lambda_m|m,m\rangle,
 \]
 with \(\varphi_j\) shared between \(b_t\) and \(a_{t+1}\). It is not the
-adjacent physical-pair factorization used later for nearest-neighbor
+disjoint adjacent physical-pair condition used later for nearest-neighbor
 parent-term commutation. -/
 theorem AppendixBStructuralData.mpv_coreTensor_eq_cyclicVirtualPairState
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
@@ -360,8 +365,7 @@ theorem AppendixBStructuralData.twoSiteAmplitude_eq_coreTensor_mpv {A : MPSTenso
     hStruct.twoSiteAmplitude σ = mpv hStruct.coreTensor σ := by
   rw [hStruct.twoSiteAmplitude_eq_mpv σ, hStruct.mpv_eq_coreTensor σ]
 
-/-- The length-two case of the core-tensor factorization required by the
-Appendix B extraction input. -/
+/-- The length-two case of the disjoint adjacent-pair coefficient condition. -/
 theorem AppendixBStructuralData.mpv_coreTensor_eq_productPairState_one {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) (σ : Cfg d (2 * 1)) :
     mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude 1 σ := by
@@ -375,15 +379,15 @@ theorem AppendixBStructuralData.mpv_eq_productPairState_one {A : MPSTensor d D}
     mpv A σ = productPairState hStruct.twoSiteAmplitude 1 σ := by
   rw [productPairState_one, hStruct.twoSiteAmplitude_eq_mpv]
 
-/-- The remaining adjacent product-pair input needed after the cyclic
-Appendix B expression.
+/-- The remaining disjoint adjacent-pair condition needed after the source
+basic-vector expression.
 
 For a fixed structural form, this captures the two facts that are still not
-produced by the Appendix B structural datum: the cyclic virtual-pair coefficient
-formula must be identified with a repeated adjacent two-site amplitude
-determined by the same witness, and the nearest-neighbor parent projectors on
-each finite chain must be identified with a commuting family attached to these
-adjacent two-site factors. -/
+produced by the Appendix B structural datum: the coefficient formula for
+\(U^{\otimes N}\varphi_j^{\otimes N}\) must be related to the repeated
+disjoint adjacent two-site amplitude stated here, and the nearest-neighbor
+parent projectors on each finite chain must be identified with a commuting
+family attached to the source projectors \(Q_{AX}\) and \(Q_{XB}\). -/
 structure AppendixBProductPairExtraction {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) where
   /-- Positive even-chain adjacent-pair factorization through the structural
@@ -393,10 +397,11 @@ structure AppendixBProductPairExtraction {A : MPSTensor d D}
   /-- Local projectors realizing the nearest-neighbor parent terms. -/
   localProjectors : ∀ N, HasProductPairLocalProjectors A N
 
-/-- Construct the MPV part of the extraction from the Appendix B core tensor.
+/-- Construct the coefficient part of the conditional structure from the
+Appendix B core tensor.
 
-This reduces the coefficient computation to the core tensor `Λ U_i`; the local
-projector identities remain a separate input. -/
+This reduces the coefficient computation to the core tensor \(\Lambda U^i\);
+the local projector identities remain a separate hypothesis. -/
 noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
@@ -409,8 +414,8 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
     exact hCore N hN σ
   localProjectors := hProj
 
-/-- The product-of-entangled-pairs input yields the established
-`ProductPairBridge`. -/
+/-- The conditional Appendix B hypotheses yield the `ProductPairBridge`
+structure used by the parent-Hamiltonian statements. -/
 noncomputable def AppendixBProductPairExtraction.toProductPairBridge
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hExtract : AppendixBProductPairExtraction hStruct) :
@@ -419,8 +424,8 @@ noncomputable def AppendixBProductPairExtraction.toProductPairBridge
   hmpv := hExtract.hmpv
   localProjectors := hExtract.localProjectors
 
-/-- The product-of-entangled-pairs input gives the unfolded nearest-neighbor commutation
-statement on every finite chain. -/
+/-- The conditional Appendix B hypotheses give the unfolded nearest-neighbor
+commutation statement on every finite chain. -/
 theorem AppendixBProductPairExtraction.commuting_twoSite_localTerms
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hExtract : AppendixBProductPairExtraction hStruct) (N : ℕ) :
@@ -432,11 +437,12 @@ theorem AppendixBProductPairExtraction.commuting_twoSite_localTerms
 /-- Conditional form of the forward implication in arXiv:1606.00608,
 Theorem 3.10:
 RFP plus the proved Appendix B structural theorem implies the nearest-neighbor
-commutation equation as soon as the product-of-entangled-pairs factorization and
-two-site projector identities are supplied for the resulting structural form.
+commutation equation as soon as the disjoint adjacent-pair coefficient condition
+and the two-site projector identities are supplied for the resulting structural
+form.
 
 This theorem deliberately stops short of claiming the full Beigi-independent
-`rfp_implies_nncph`: the missing input is exactly
+`rfp_implies_nncph`: the missing hypothesis is exactly
 `AppendixBProductPairExtraction` for the structural form produced by
 `AppendixBStructuralData.ofRFP`. -/
 theorem commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -638,8 +638,10 @@ the specialization $L=2$.
     This implication is cited here from the structural characterization theorem
     for renormalization fixed points in~\cite{Cirac2016MPDO_arXiv}; the source
     proof says that RFP $\Rightarrow$ NNCPH is immediate from that theorem.
-    At present this implication remains an unproved hypothesis; the source
-    derivation from the Appendix~B product-of-pairs form remains to be proved.
+    At present this implication remains an unproved hypothesis. The source
+    derivation from the basic-vector formula
+    $V^{(N)}(A_j)=U^{\otimes N}\varphi_j^{\otimes N}$ and the corresponding
+    two-site projectors remains to be proved.
 \end{theorem}
 
 \begin{theorem}[Renormalization fixed points satisfy the NNCPH commutation and zero-energy equations]%
@@ -704,7 +706,7 @@ the specialization $L=2$.
     Substituting $\alpha_L=\alpha_0$ in the trace gives the cyclic formula.
 \end{proof}
 
-\begin{remark}[Product-of-pairs equations for nearest-neighbor parent-term commutation]%
+\begin{remark}[Basic-vector coefficients and nearest-neighbor parent-term commutation]%
     \label{rem:product_pair_projectors}
     \lean{MPSTensor.productPairWindow}
     \lean{MPSTensor.productPairWindow_one}
@@ -753,7 +755,7 @@ the specialization $L=2$.
         =
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
-    The cyclic virtual-pair coefficient associated to this structural form is
+    The coefficient associated to the source basic-vector formula is
     \[
         C_L(\sigma)
         =
@@ -788,25 +790,27 @@ the specialization $L=2$.
         =
         \phi_2(\sigma_0,\sigma_1).
     \]
-    The adjacent-pair input presently used in the formal statement is the
-    even-chain factorization, for a positive number $n$ of adjacent pairs,
+    The disjoint adjacent-pair condition presently used in the formal statement
+    is the even-chain factorization, for a positive number $n$ of adjacent
+    pairs,
     \[
         V^{(2n)}(A)(\sigma)
         =
         \prod_{p=0}^{n-1}
         \phi_2\bigl(\sigma_{2p},\sigma_{2p+1}\bigr).
     \]
-    The case $n=0$ is not part of this source input: the empty-chain MPV
+    The case $n=0$ is not part of this condition: the empty-chain MPV
     coefficient is the virtual bond dimension, whereas the empty product on the
     right-hand side is $1$.
     The first equality, $V^{(L)}(\Lambda U)_\sigma=C_L(\sigma)$, is the trace
-    expansion of the closed matrix product. The remaining coefficient step is
-    to identify this cyclic virtual-pair expression with the adjacent-pair input
-    above when that identification is justified.
+    expansion of the closed matrix product and is the coefficient form of
+    $U^{\otimes L}\varphi_j^{\otimes L}$. The remaining coefficient step is
+    to relate this source expression to the disjoint adjacent-pair condition
+    above when that relation is justified.
     On a three-site chain, the two adjacent length-two parent terms are the
     \(AX\) and \(XB\) actions of the canonical two-site parent interaction.
-    What remains from Appendix~B is to identify the projectors determined by the
-    product-of-pairs form with these canonical parent interactions and to prove
+    What remains from Appendix~B is to identify the source projectors with
+    these canonical parent interactions and to prove
     \(Q_{AX}Q_{XB}=Q_{XB}Q_{AX}\). For the all-chain statement, the resulting
     two-site parent projectors must be identified with idempotents \(p_i\)
     satisfying
@@ -818,23 +822,25 @@ the specialization $L=2$.
         h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2),
     \]
     which is the nearest-neighbor commuting conclusion for every finite chain.
-    The even-chain factorization and the two-site projector identification are
-    the inputs supplied by Appendix~B of \cite{Cirac2016MPDO_arXiv}; given them,
+    The source projector identification and the justification of any passage
+    from the source coefficients to this adjacent-pair condition are the
+    remaining obligations before the conditional theorem can be applied; once
+    they are proved,
     the local terms commute. Together with
-    Lemma~\ref{lem:parent_hamiltonian_ff}, the product-pair input also gives the
+    Lemma~\ref{lem:parent_hamiltonian_ff}, the adjacent-pair condition also gives the
     zero-energy equation for $V^{(N)}(A)$, still without asserting the source
     ground-space spanning condition.
 \end{remark}
 
-\begin{theorem}[Product-pair data and ground-space spanning give all-chain NNCPH]%
+\begin{theorem}[Adjacent-pair condition and ground-space spanning give all-chain NNCPH]%
     \label{thm:appendixB_product_pair_has_nncph_ground_spaces}
     \lean{MPSTensor.ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning}
     \lean{MPSTensor.rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning}
     \leanok
     \uses{rem:product_pair_projectors, def:has_nncph_ground_spaces,
         def:parent_hamiltonian_ground_space_spanning}
-    Suppose the Appendix~B product-of-pairs data give commuting two-site parent
-    terms for a tensor \(B\). If the nearest-neighbor parent Hamiltonian also
+    Suppose the conditional adjacent-pair hypotheses give commuting two-site
+    parent terms for a tensor \(B\). If the nearest-neighbor parent Hamiltonian also
     satisfies the ground-space spanning equation of
     Definition~\ref{def:parent_hamiltonian_ground_space_spanning}, with BNT
     components \(A_1,\ldots,A_g\), then \(B\) satisfies the all-chain
@@ -842,7 +848,7 @@ the specialization $L=2$.
     Definition~\ref{def:has_nncph_ground_spaces}.
 
     In particular, if a normal left-canonical RFP tensor has nonzero bond
-    dimension, the Appendix~B product-of-pairs extraction, and the same
+    dimension, the same conditional Appendix~B hypotheses, and the same
     ground-space spanning equation, then it satisfies the full all-chain condition in
     \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}.
 \end{theorem}
@@ -850,7 +856,7 @@ the specialization $L=2$.
 \begin{proof}
     \uses{lem:parent_hamiltonian_ff, def:has_nncph_ground_space}
     \leanok
-    The product-of-pairs equations give \(h_i h_j=h_j h_i\) for all translated
+    The adjacent-pair hypotheses give \(h_i h_j=h_j h_i\) for all translated
     two-site parent terms. Lemma~\ref{lem:parent_hamiltonian_ff} gives
     \(h_iV^{(N)}(B)=0\). For every \(N>2\), the spanning hypothesis supplies
     \[

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -115,11 +115,12 @@ For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
 the remaining local step is to identify the Appendix~B local projectors with
 the translated two-site parent terms and prove the overlapping commutation
-relation for them.  Before this can be turned into the adjacent-chain input,
-the coefficient side passes through the cyclic virtual-pair expression
-obtained from
+relation for them.  On the coefficient side, the source statement is the
+basic-vector formula
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), where
-\(\varphi_j\) is shared between neighboring virtual spins.
+\(\varphi_j\) is shared between neighboring virtual spins.  The current
+disjoint adjacent-pair condition is a separate conditional statement and should
+not be read as the source formula itself.
 The reverse theorem now consumes both the explicit BNT relation
 \leanid{MPSTensor.IsBNT} and the named all-chain condition
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, but the implication still depends on
@@ -139,8 +140,8 @@ including the spanning condition in the parent-Hamiltonian ground-space clause:
   \forall N>2,\; |V^{(N)}(A)\rangle
   \text{ is a ground state of a NNCPH}.
 \end{align}
-The forward implication can use the product-of-entangled-pairs form in the proof
-of Theorem~3.11.  The reverse implication must internalize Beigi's
+The forward implication must use the basic-vector form in Theorem~3.11 and the
+corresponding local projectors.  The reverse implication must internalize Beigi's
 one-dimensional nearest-neighbor commuting-Hamiltonian ground-space
 classification and identify the resulting locally orthogonal states with the
 basis of normal tensors of $A$.\footnote{Tracked by \ghissue{2633}.}
@@ -148,9 +149,10 @@ basis of normal tensors of $A$.\footnote{Tracked by \ghissue{2633}.}
 The present formal boundary is therefore: the reverse implication has the
 source ground-space hypothesis, but its proof is still the Beigi axiom; the
 forward implication has the source-unit Appendix~B structural datum, the
-three-site \(AX/XB\) support maps, and the cyclic virtual-pair coefficient
-formula.  It still lacks the justified adjacent-pair specialization and the
-local-projector commutation theorem.
+three-site \(AX/XB\) support maps, and the coefficient form of
+\(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks the source projector
+identification and a justified relation between the source formula and any
+disjoint adjacent-pair condition used by the conditional theorem.
 The axiom-backed theorem still supplies the commutation direction used by the
 unconditional statements.
 

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -102,10 +102,10 @@ source unit convention
 \end{align}
 Thus the scalar normalization mismatch is no longer hidden in the formal
 statement: both conventions are available, and their comparison is explicit.
-The Appendix~B structural datum used in the parent-Hamiltonian bridge chooses
-the unit pair-index convention, so the remaining positive-even-chain
-factorization problem starts from the source normalization.
-Appendix~B first gives the cyclic virtual-pair coefficient
+The Appendix~B structural datum used in the conditional parent-Hamiltonian
+theorem chooses the unit pair-index convention, so the remaining coefficient
+problem starts from the source normalization.
+Appendix~B first gives the coefficient form of the basic-vector expression
 \begin{align}
   C_L(\sigma)
   =
@@ -117,9 +117,9 @@ Appendix~B first gives the cyclic virtual-pair coefficient
 \end{align}
 which is the coefficient form of
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), with
-\(\varphi_j\) shared between \(b_t\) and \(a_{t+1}\).  The adjacent physical-pair
-factorization used by the current parent-Hamiltonian condition is therefore a
-separate identification, not the cyclic expression itself.
+\(\varphi_j\) shared between \(b_t\) and \(a_{t+1}\).  The disjoint adjacent
+physical-pair condition used by the current conditional parent-Hamiltonian
+theorem is therefore a separate statement, not the source expression itself.
 
 There is still no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus
 the formal theorems record only a separate isometry condition for each block;


### PR DESCRIPTION
### Motivation

The prose in `TNLean/MPS/RFP/CommutingBridge.lean` and the blueprint chapter
`ch13_parent_hamiltonian_commuting_gap.tex` was reading the current disjoint
adjacent-pair coefficient condition as if it were the Appendix B source formula.
Appendix B (arXiv:1606.00608, lines 543–555) gives the basic-vector expression
\[
  |V^{(N)}(A_j)\rangle = U^{\otimes N}|\varphi_j\rangle^{\otimes N},
  \qquad |\varphi_j\rangle = \sum_m \lambda_m |m,m\rangle,
\]
with \(\varphi_j\) shared between adjacent virtual spins and \(U\) acting on each
physical site. This misidentification caused the blueprint and paper-gap notes to
appear source-complete while #3372 (even-chain product-pair factorization) and
#3373 (source projector identification for \(Q_{AX}\) and \(Q_{XB}\)) remain
open obligations. See also #2633 for the parent RFP = ZCL = NNCPH equivalence task.

### Description

- `TNLean/MPS/RFP/CommutingBridge.lean`: rewrites docstrings to distinguish the
  Appendix B basic-vector coefficient expression from the current disjoint
  adjacent-pair conditional hypothesis.
- `TNLean/MPS/ParentHamiltonian/Commuting.lean`: aligns prose to record that the
  source projector identification (\(Q_{AX}\), \(Q_{XB}\)) is not yet supplied as
  a product-pair projector family.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: updates
  blueprint entries so that #3372 and #3373 remain marked as open obligations
  rather than falsely source-complete statements.
- `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`,
  `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`: updated to record the
  alignment boundary more precisely.

### Testing

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main..HEAD`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean.MPS.RFP.CommutingBridge TNLean.MPS.ParentHamiltonian.Commuting`
- `lake build TNLean.Channel.TransferMatrix TNLean.Channel.Schwarz.TwoPositive`
- `leanblueprint checkdecls`

---
Addresses #3372
Addresses #3373
Addresses #2633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and documentation edits only; no Lean proofs, APIs, or runtime behavior change.
> 
> **Overview**
> Documentation now **separates** the Appendix B source basic-vector coefficients \(U^{\otimes N}\varphi_j^{\otimes N}\) from the formal **disjoint adjacent-pair** conditional hypothesis (`HasProductPairMPV`, `AppendixBProductPairExtraction`, etc.), and states that **\(Q_{AX}\)/\(Q_{XB}\)** projector identification is still an open obligation rather than supplied by `HasProductPairLocalProjectors`.
> 
> **Lean** (`CommutingBridge.lean`, `ParentHamiltonian/Commuting.lean`): module and theorem docstrings retitled and rewritten; **no proof or definition changes**.
> 
> **Blueprint** `ch13_parent_hamiltonian_commuting_gap.tex` and **paper-gap** notes (`cpsv16_nncph_ground_state_scope.tex`, `cpsv16_rfp_isometry_scope.tex`) use the same vocabulary so the RFP→NNCPH bridge is not described as source-complete while #3372/#3373 remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b825f0657f41b1b2ad57c3233ad77aadfba4d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->