### PR TITLE
feat(Channel/Schwarz): add rank-one n-positivity test

### DIFF
--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -155,6 +155,31 @@ theorem isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation
   rfl
 
 omit [Fintype n] [DecidableEq n] in
+/-- Proposition 3.1 in Wolf, *Quantum Channels & Operations*: `k`-positivity
+can be tested on pure states of the ampliated system. -/
+theorem isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef
+    [Finite n]
+    (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :
+    IsNPositiveMap k E ↔
+      ∀ φ : n × Fin k → ℂ,
+        (nPositiveAmpliation k E (Matrix.vecMulVec φ (star φ))).PosSemidef := by
+  letI := Fintype.ofFinite n
+  constructor
+  · intro hE φ
+    exact hE _ (Matrix.posSemidef_vecMulVec_self_star φ)
+  · intro hE
+    rw [isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation]
+    intro X hX
+    classical
+    obtain ⟨r, v, hXeq⟩ := (Matrix.posSemidef_iff_eq_sum_vecMulVec).mp hX
+    have hmap :
+        nPositiveAmpliation k E X =
+          ∑ i : Fin r, nPositiveAmpliation k E (Matrix.vecMulVec (v i) (star (v i))) := by
+      rw [hXeq, map_sum]
+    rw [hmap]
+    exact Matrix.posSemidef_sum _ fun i _ => hE (v i)
+
+omit [Fintype n] [DecidableEq n] in
 /-- One-positive maps are exactly positive maps. -/
 theorem isNPositiveMap_one_iff_isPositiveMap
     {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ} :

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -145,6 +145,33 @@ maps.
     This is precisely the preceding definition of the ampliation.
 \end{proof}
 
+\begin{theorem}[Rank-one test for $k$-positivity]\label{thm:k_positive_rank_one_test}
+    \lean{isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef}
+    \leanok
+    \uses{def:k_positive_map, def:blockwise_ampliation}
+    A linear map $E:\MN{D}\to\MN{D}$ is $k$-positive if and only if,
+    for every vector $\phi\in\C^D\otimes\C^k$,
+    \[
+        E^{(k)}(|\phi\rangle\langle\phi|)\geq 0.
+    \]
+    This is the pure-state reduction used in
+    \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The forward implication is the definition of $k$-positivity, since
+    $|\phi\rangle\langle\phi|$ is positive semidefinite.  Conversely, every
+    positive semidefinite matrix on $\C^D\otimes\C^k$ is a finite sum
+    $\sum_i |\phi_i\rangle\langle\phi_i|$, and
+    \[
+        E^{(k)}\!\left(\sum_i |\phi_i\rangle\langle\phi_i|\right)
+        = \sum_i E^{(k)}(|\phi_i\rangle\langle\phi_i|) \geq 0
+    \]
+    by linearity of $E^{(k)}$, the hypothesis, and closure of the positive
+    semidefinite cone under finite sums.
+\end{proof}
+
 \begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}
     \lean{Matrix.traceAdjointMap}
     \leanok


### PR DESCRIPTION
### Motivation

Wolf Chapter 3, Proposition 3.1 begins by reducing `k`-positivity to a pure-state test for the blockwise ampliation. This PR formalizes that first reduction toward LionSR/QICLean#24.

Source: `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, Proposition 3.1, lines around 89--115.

### Description

- Adds `isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef` in `TNLean/Channel/Schwarz/TwoPositive.lean`.
- The theorem states that a linear map is `k`-positive if and only if its blockwise ampliation sends every rank-one bipartite projector `|phi><phi|` to a positive semidefinite matrix.
- The forward direction is immediate from the definition. The converse decomposes an arbitrary positive semidefinite matrix as a finite sum of rank-one projectors and uses linearity of the ampliation together with closure of the positive semidefinite cone under finite sums.
- Adds the matching blueprint entry `thm:k_positive_rank_one_test` with `\leanok`, citing Wolf Chapter 3, Proposition 3.1.

This does not claim the full Choi--Jamiolkowski characterization in LionSR/QICLean#24. The Choi compression equation (3.4), the projection formulation, and the Schmidt-rank formulation remain follow-up work.

### Issue scout

The live issue scan found this as the best small target: LionSR/QICLean#21's general reduction-map `n`-positivity depends on the Choi/n-positive characterization, while LionSR/QICLean#165 and LionSR/QICLean#166 need Schmidt-rank and Ky-Fan infrastructure. The open axiom tracker LionSR/TNLean#3375 still has no axiom directly removable by a small local PR.

### Verification

- `lake build TNLean.Channel.Schwarz.TwoPositive`
- `lake build TNLean` (completed; only pre-existing warnings, including unrelated existing `sorry` warnings in `LorentzNormalForm.lean` and `MPS/Periodic/Overlap/Case3.lean`)
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `cd blueprint && leanblueprint checkdecls`
- `rg -n "sorry|admit|native_decide|\\baxiom\\b" TNLean/Channel/Schwarz/TwoPositive.lean || true`

Refs LionSR/QICLean#24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive proof and documentation only; no changes to existing definitions or theorems beyond the new equivalence.
> 
> **Overview**
> Formalizes Wolf Ch. 3, Prop. 3.1’s **pure-state reduction**: `k`-positivity is equivalent to checking that the blockwise ampliation `nPositiveAmpliation k E` sends every rank-one projector `vecMulVec φ (star φ)` to a PSD matrix.
> 
> The forward direction is definition plus `posSemidef_vecMulVec_self_star`. The converse rewrites `k`-positivity as positivity of the ampliation, decomposes an arbitrary PSD input via `posSemidef_iff_eq_sum_vecMulVec`, and closes with linearity and `posSemidef_sum`.
> 
> Blueprint adds **`thm:k_positive_rank_one_test`** (`\leanok`) in `ch05_schwarz.tex`, linked to the new Lean theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e36e1b47d1342442db5c18e4aeffe81ae33aef1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->