### PR TITLE
feat(MPS/ParentHamiltonian): add complement support commutation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -156,6 +156,28 @@ def rightPairLift (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
   ext ψ σ
   simp [Module.End.mul_apply]
 
+@[simp] theorem leftPairLift_sub
+    (Q R : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    leftPairLift (Q - R) = leftPairLift Q - leftPairLift R := by
+  ext ψ σ
+  simp
+
+@[simp] theorem rightPairLift_sub
+    (Q R : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    rightPairLift (Q - R) = rightPairLift Q - rightPairLift R := by
+  ext ψ σ
+  simp
+
+@[simp] theorem leftPairLift_one_sub
+    (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    leftPairLift (1 - Q) = 1 - leftPairLift Q := by
+  rw [leftPairLift_sub, leftPairLift_one]
+
+@[simp] theorem rightPairLift_one_sub
+    (Q : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) :
+    rightPairLift (1 - Q) = 1 - rightPairLift Q := by
+  rw [rightPairLift_sub, rightPairLift_one]
+
 variable {D : ℕ}
 
 /-- On a three-site window, the translated length-two parent interaction at
@@ -245,13 +267,26 @@ theorem HasOverlappingTwoSiteCommutation.right_lift_idempotent
     rightPairLift QXB * rightPairLift QXB = rightPairLift QXB := by
   rw [← rightPairLift_mul, h.right_idempotent]
 
+/-- Commutation of the Appendix D.2 projectors of arXiv:1606.00608 passes to
+the complementary ground-space projectors.
+
+In the source notation, after \(Q_{AX}\) and \(Q_{XB}\) commute, the
+complements \(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\) commute as well. -/
+theorem HasOverlappingTwoSiteCommutation.commute_complement_lifts
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB) :
+    leftPairLift (1 - QAX) * rightPairLift (1 - QXB) =
+      rightPairLift (1 - QXB) * leftPairLift (1 - QAX) := by
+  rw [leftPairLift_one_sub, rightPairLift_one_sub]
+  noncomm_ring [h.commute_lifts]
+
 /-- If the canonical two-site parent interaction satisfies the overlapping
 two-site commutation predicate on the \(AX\) and \(XB\) faces, then the first two
 translated parent terms on the three-site chain commute.
 
-This is the local transport from the source projectors of arXiv:1606.00608,
-Definition D.2, to the translated parent terms. It does not construct those
-source projectors from the Appendix B product-of-pairs form. -/
+This is the local transport from the Appendix D.2 projectors of
+arXiv:1606.00608 to the translated parent terms. It does not construct those
+source projectors associated with the Appendix B basic-vector form. -/
 theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation
     (A : MPSTensor d D)
     (h : HasOverlappingTwoSiteCommutation (d := d)

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -41,8 +41,10 @@ The declarations below separate four mathematical statements:
 
 **Scope restriction (overlapping two-site terms):** The three-site support maps
 for the source \(AX\) and \(XB\) windows are represented in
-`TNLean.MPS.ParentHamiltonian.LocalSupport`. The remaining Appendix-B step is to
-identify the source projectors \(Q_{AX}\) and \(Q_{XB}\) with the translated
+`TNLean.MPS.ParentHamiltonian.LocalSupport`. Appendix B supplies the
+basic-vector form, while Appendix D.2 of arXiv:1606.00608 supplies the
+parent-commuting condition for the \(Q_{AX}\) and \(Q_{XB}\) projectors. The
+remaining local step is to identify those projectors with the translated
 length-two parent terms and prove their overlapping commutation. For this reason
 commutativity of the translated idempotents is an explicit hypothesis in
 `HasProductPairLocalProjectors`. Eliminating this hypothesis is the source

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -23,7 +23,12 @@ the specialization $L=2$.
     \lean{MPSTensor.replaceXBCfg}
     \lean{MPSTensor.leftPairLift}
     \lean{MPSTensor.rightPairLift}
+    \lean{MPSTensor.leftPairLift_sub}
+    \lean{MPSTensor.rightPairLift_sub}
+    \lean{MPSTensor.leftPairLift_one_sub}
+    \lean{MPSTensor.rightPairLift_one_sub}
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation}
+    \lean{MPSTensor.HasOverlappingTwoSiteCommutation.commute_complement_lifts}
     \lean{MPSTensor.adjacent_twoSite_cyclicWindowsOverlap}
     \leanok
     \uses{def:nsite_space_parent, def:cyclic_window_support,
@@ -55,6 +60,21 @@ the specialization $L=2$.
     in \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  The cyclic windows beginning
     at $i$ and $i+1$ realize the two supports $AX$ and $XB$, and hence overlap at
     the middle site.
+
+    The two lift maps also distribute over complementary projectors:
+    \[
+        (1-Q_{AX})_{AX}=1-(Q_{AX})_{AX},\qquad
+        (1-Q_{XB})_{XB}=1-(Q_{XB})_{XB}.
+    \]
+    Consequently, if the projectors $Q_{AX}$ and $Q_{XB}$ commute on the
+    three-site space, then their complementary projectors
+    \[
+        P_{AX}=1-Q_{AX},\qquad P_{XB}=1-Q_{XB}
+    \]
+    commute after the same lifts. This is the elementary algebraic passage used
+    when one moves between the $Q$-projectors of
+    \cite[Appendix~D.2]{Cirac2016MPDO_arXiv} and the complementary ground-space
+    projectors $P$.
 \end{definition}
 
 \begin{theorem}[Three-site translated parent terms]
@@ -112,8 +132,9 @@ the specialization $L=2$.
         h^{(3)}_1(A,2)h^{(3)}_0(A,2).
     \]
     This is only the local transport from the \(AX/XB\) condition to translated
-    parent terms; the construction of the projectors of
-    \cite[Appendix~B]{Cirac2016MPDO_arXiv} is a separate step.
+    parent terms; the construction of the
+    \cite[Appendix~D.2]{Cirac2016MPDO_arXiv} projectors associated with the
+    \cite[Appendix~B]{Cirac2016MPDO_arXiv} basic-vector form is a separate step.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -809,8 +830,10 @@ the specialization $L=2$.
     above when that relation is justified.
     On a three-site chain, the two adjacent length-two parent terms are the
     \(AX\) and \(XB\) actions of the canonical two-site parent interaction.
-    What remains from Appendix~B is to identify the source projectors with
-    these canonical parent interactions and to prove
+    Appendix~B supplies the basic-vector expression, while Appendix~D.2 supplies
+    the parent-commuting projector condition. What remains is to identify the
+    corresponding source projectors with these canonical parent interactions and
+    to prove
     \(Q_{AX}Q_{XB}=Q_{XB}Q_{AX}\). For the all-chain statement, the resulting
     two-site parent projectors must be identified with idempotents \(p_i\)
     satisfying

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -113,10 +113,11 @@ equivalence with ZCL, the complete canonical-form hypotheses from the source
 statement, or the Beigi ground-space characterization as an internal theorem.
 For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
-the remaining local step is to identify the Appendix~B local projectors with
-the translated two-site parent terms and prove the overlapping commutation
-relation for them.  On the coefficient side, the source statement is the
-basic-vector formula
+Appendix~B supplies the basic-vector form, while the projectors
+\(Q_{AX}\) and \(Q_{XB}\) belong to the Appendix~D.2 parent-commuting
+condition.  The remaining local step is to identify those projectors with the
+translated two-site parent terms and prove the overlapping commutation relation
+for them.  On the coefficient side, the source statement is the basic-vector formula
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), where
 \(\varphi_j\) is shared between neighboring virtual spins.  The current
 disjoint adjacent-pair condition is a separate conditional statement and should


### PR DESCRIPTION
### Motivation
Refs #3373.

Cirac Appendix D.2 states the parent-commuting condition using projectors \(Q_{AX}\) and \(Q_{XB}\), while local parent terms are often expressed through complementary ground-space projectors. The source-facing prose also needs to keep Appendix B's basic-vector form separate from Appendix D.2's projector condition.

### Description
- prove that the AX/XB support lifts preserve subtraction and complements;
- prove that overlapping commutation for \(Q_{AX}\), \(Q_{XB}\) passes to the complementary lifted projectors \(P_{AX}=1-Q_{AX}\), \(P_{XB}=1-Q_{XB}\);
- update blueprint and gap prose to distinguish the Appendix B basic-vector formula from the Appendix D.2 projector condition.

This is a partial source-faithful step for #3373. It does not construct the source projectors or close the issue.

### Testing
- `lake build TNLean.MPS.ParentHamiltonian.LocalSupport`
- `lake build TNLean.MPS.RFP.CommutingBridge TNLean.MPS.ParentHamiltonian.Commuting`
- `git diff --check origin/main..HEAD`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake build TNLean`
- `leanblueprint checkdecls`

---
Addresses #3373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive Lean proofs and documentation only; no changes to axioms, APIs, or runtime behavior.
> 
> **Overview**
> Adds **algebra on overlapping AX/XB lifts** so complements behave like the paper: `leftPairLift` / `rightPairLift` preserve subtraction and satisfy `(1-Q)_{AX} = 1 - Q_{AX}` (and the XB analogue).
> 
> Proves **`HasOverlappingTwoSiteCommutation.commute_complement_lifts`**: when lifted \(Q_{AX}\) and \(Q_{XB}\) commute (Appendix D.2), the lifted complements \(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\) commute as well—via `noncomm_ring` after rewriting with the new `one_sub` lemmas.
> 
> **Blueprint and gap docs** are updated to wire the new Lean names into ch13, and to separate **Appendix B** (basic-vector / structural form) from **Appendix D.2** (parent-commuting \(Q\) projectors). Comments in `LocalSupport` and `CommutingBridge` follow the same split. This does not construct source projectors or close the identification gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 959bc051b40b484a75e034047f2db8e4b76fde2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->