### PR TITLE
doc(Channel/Schwarz): clarify rank-one test attribution

### DIFF
--- a/TNLean/Channel/Schwarz/TwoPositive.lean
+++ b/TNLean/Channel/Schwarz/TwoPositive.lean
@@ -155,8 +155,9 @@ theorem isNPositiveMap_iff_isPositiveMap_nPositiveAmpliation
   rfl
 
 omit [Fintype n] [DecidableEq n] in
-/-- Proposition 3.1 in Wolf, *Quantum Channels & Operations*: `k`-positivity
-can be tested on pure states of the ampliated system. -/
+/-- The pure-state reduction used in the proof of Wolf, *Quantum Channels &
+Operations*, Proposition 3.1: `k`-positivity can be tested on pure states of the
+ampliated system. -/
 theorem isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef
     [Finite n]
     (k : ℕ) (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) :


### PR DESCRIPTION
### Motivation
- PR LionSR/TNLean#3429 added the pure-state rank-one reduction used at the start of the proof of Wolf, *Quantum Channels & Operations*, Proposition 3.1.
- A post-merge review found that the Lean docstring for `isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef` described the result as Proposition 3.1 in full, while the complete proposition also includes Choi-compression, projection, and Schmidt-rank formulations that remain open in LionSR/QICLean#24.

### Description
- Reword the docstring for `isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef` so it identifies the result as the pure-state reduction used in the proof of Proposition 3.1, not as the full proposition.
- Leave the theorem statement, proof, and blueprint entry unchanged.

### Testing
- `lake build TNLean.Channel.Schwarz.TwoPositive -q --log-level=info`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Refs LionSR/QICLean#24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only docstring edit with no executable or proof changes.
> 
> **Overview**
> Updates the docstring on `isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef` so it no longer reads as Wolf Proposition 3.1 in full.
> 
> The new text states that the theorem is the **pure-state reduction** used in the proof of that proposition (test `k`-positivity on pure states of the ampliated system), matching the blueprint wording and leaving room for the other Prop 3.1 formulations still tracked in LionSR/QICLean#24.
> 
> No changes to the statement, proof, or blueprint link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2686b3ff5349e50746f6361453d632cf2f91be3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
