### PR TITLE
feat(MPS/ParentHamiltonian): add complement projector idempotency and commutation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -267,6 +267,22 @@ theorem HasOverlappingTwoSiteCommutation.right_lift_idempotent
     rightPairLift QXB * rightPairLift QXB = rightPairLift QXB := by
   rw [← rightPairLift_mul, h.right_idempotent]
 
+/-- The left complementary projector in arXiv:1606.00608, Appendix D.2, is
+idempotent. -/
+theorem HasOverlappingTwoSiteCommutation.left_complement_idempotent
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB) :
+    (1 - QAX) * (1 - QAX) = 1 - QAX := by
+  noncomm_ring [h.left_idempotent]
+
+/-- The right complementary projector in arXiv:1606.00608, Appendix D.2, is
+idempotent. -/
+theorem HasOverlappingTwoSiteCommutation.right_complement_idempotent
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB) :
+    (1 - QXB) * (1 - QXB) = 1 - QXB := by
+  noncomm_ring [h.right_idempotent]
+
 /-- Commutation of the Appendix D.2 projectors of arXiv:1606.00608 passes to
 the complementary ground-space projectors.
 
@@ -279,6 +295,17 @@ theorem HasOverlappingTwoSiteCommutation.commute_complement_lifts
       rightPairLift (1 - QXB) * leftPairLift (1 - QAX) := by
   rw [leftPairLift_one_sub, rightPairLift_one_sub]
   noncomm_ring [h.commute_lifts]
+
+/-- The complementary projectors \(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\)
+of arXiv:1606.00608, Appendix D.2, satisfy the same
+idempotent-and-commutation condition. -/
+theorem HasOverlappingTwoSiteCommutation.complement
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB) :
+    HasOverlappingTwoSiteCommutation (d := d) (1 - QAX) (1 - QXB) where
+  left_idempotent := h.left_complement_idempotent
+  right_idempotent := h.right_complement_idempotent
+  commute_lifts := h.commute_complement_lifts
 
 /-- If the canonical two-site parent interaction satisfies the overlapping
 two-site commutation predicate on the \(AX\) and \(XB\) faces, then the first two

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -28,7 +28,10 @@ the specialization $L=2$.
     \lean{MPSTensor.leftPairLift_one_sub}
     \lean{MPSTensor.rightPairLift_one_sub}
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation}
+    \lean{MPSTensor.HasOverlappingTwoSiteCommutation.left_complement_idempotent}
+    \lean{MPSTensor.HasOverlappingTwoSiteCommutation.right_complement_idempotent}
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation.commute_complement_lifts}
+    \lean{MPSTensor.HasOverlappingTwoSiteCommutation.complement}
     \lean{MPSTensor.adjacent_twoSite_cyclicWindowsOverlap}
     \leanok
     \uses{def:nsite_space_parent, def:cyclic_window_support,
@@ -74,7 +77,10 @@ the specialization $L=2$.
     commute after the same lifts. This is the elementary algebraic passage used
     when one moves between the $Q$-projectors of
     \cite[Appendix~D.2]{Cirac2016MPDO_arXiv} and the complementary ground-space
-    projectors $P$.
+    projectors $P$.  Since the original two projectors are idempotent, the
+    complementary projectors are idempotent as well; hence the pair
+    \(P_{AX},P_{XB}\) satisfies the same idempotent-and-commutation condition on
+    the three-site space.
 \end{definition}
 
 \begin{theorem}[Three-site translated parent terms]

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -67,7 +67,9 @@ three-site support layer for the \(AX\) and \(XB\) faces:
 \leanid{MPSTensor.HasOverlappingTwoSiteCommutation}.  This records the local
 action and commutation equation on the common three-site space, but it still
 does not include the kernel-intersection condition or the orthogonal-projector
-identification required by Definition~D.2.
+identification required by Definition~D.2.  The elementary passage from
+\(Q_{AX},Q_{XB}\) to their complements \(1-Q_{AX},1-Q_{XB}\) is now recorded by
+\leanid{MPSTensor.HasOverlappingTwoSiteCommutation.complement}.
 
 \section{Elimination plan}
 


### PR DESCRIPTION
### Motivation

- Continues the formalization of the local commutation structure for the parent Hamiltonian of renormalization fixed points (arXiv:1606.00608, §3.3, Appendix B, Definition D.2), tracked in #3373.
- Idempotency of the complementary projectors \`1 - Q_AX\` and \`1 - Q_XB\` is needed before the pair can satisfy \`HasOverlappingTwoSiteCommutation\`; the complement lift commutation was already established in #3430.

### Description

- \`TNLean/MPS/ParentHamiltonian/LocalSupport.lean\`: adds idempotency lemmas for the complementary Appendix D.2 projectors \`1 - QAX\` and \`1 - QXB\`; introduces \`HasOverlappingTwoSiteCommutation.complement\` combining the complement lift commutation from #3430 with the new idempotency results.
- \`blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex\`: updates the overlapping two-site commutation blueprint entry to cite the idempotency results.
- \`docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex\`: extends the gap note to record the algebraic Q → P step without claiming the missing source-projector construction.
- The source projectors \`Q_AX\`, \`Q_XB\`, their Appendix B identification, and the all-chain \`HasProductPairLocalProjectors\` witness remain unformalized.

### Testing

- \`lake build TNLean.MPS.ParentHamiltonian.LocalSupport\`
- \`lake build TNLean\`
- \`python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main\`
- \`python3 scripts/blueprint_lean_sync.py --root . --ci\`
- \`python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls\`
- \`lake exe checkdecls blueprint/lean_decls\`

---
Refs #3373

> [!NOTE]
> **Low Risk**
> Proof-only additions and documentation/blueprint sync in the parent-Hamiltonian support layer; no runtime or security impact.
> 
> **Overview**
> Adds Lean lemmas showing that complementary Appendix D.2 projectors **\`1 - QAX\`** and **\`1 - QXB\`** are idempotent and that **\`HasOverlappingTwoSiteCommutation.complement\`** packages them into the same **\`HasOverlappingTwoSiteCommutation\`** predicate (reusing the existing complement lift commutation from #3430).
> 
> The blueprint overlapping two-site definition and **\`docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex\`** now cite these results so the **Q → P** algebraic step is formalized without claiming construction of the source **\`Q_AX\`**, **\`Q_XB\`**, or kernel-intersection hypotheses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f5b405b9f774777ac0d1f5f7a67fbbfaa6e209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
