### PR TITLE
feat(Channel/Schwarz): add Choi compression identity

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -107,6 +107,7 @@ import TNLean.Channel.Schwarz.SchwarzNormal
 import TNLean.Channel.Schwarz.SchwarzSubnormal
 import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.TwoPositive
+import TNLean.Channel.Schwarz.ChoiCompression
 import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -20,6 +20,8 @@ the pair $(i,p)$.
 
 * `ChoiJamiolkowski.rightCompression`: the right-factor Choi compression,
   written in the index convention of the blockwise ampliation.
+* `ChoiJamiolkowski.compressedOmegaVector`: the vector with component
+  $D^{-1/2}X_{i,p}$ at the pair $(i,p)$.
 
 ## Main results
 
@@ -71,8 +73,9 @@ noncomputable def compressedOmegaVector (X : Matrix (Fin D) (Fin k) ℂ) :
     Fin D × Fin k → ℂ :=
   fun ip => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * X ip.1 ip.2
 
-/-- The rank-one matrix used by the ampliation test agrees with the right-factor
-compression of the Choi matrix. -/
+/-- For the vector `compressedOmegaVector X`, the `k`-fold ampliation of the
+rank-one matrix $|\psi\rangle\langle\psi|$ by `T` is the right-factor Choi
+compression by `X`. -/
 theorem nPositiveAmpliation_rankOne_eq_rightCompression
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin k) ℂ) :
@@ -101,7 +104,7 @@ theorem nPositiveAmpliation_rankOne_eq_rightCompression
             rw [Matrix.matrix_eq_sum_single
               (Matrix.of fun a b => (X a p * star (X b q)) * (c * star c))]
             simp [ChoiJamiolkowski.omegaSlice_eq_single, c, Matrix.smul_single,
-              smul_eq_mul, mul_assoc, mul_left_comm, mul_comm]
+              smul_eq_mul]
   calc
     nPositiveAmpliation k T
         (Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X)))

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -13,8 +13,8 @@ for `k`-positivity with the Choi-matrix compression appearing in Wolf Chapter 3,
 Proposition 3.1, equation (3.4).
 
 The Choi matrix is normalized using `Matrix.omegaVec`, so the vector attached to
-an operator `X : Matrix (Fin D) (Fin k) ℂ` is
-`(i,p) ↦ D^{-1/2} X i p`.
+a matrix $X\in M_{D\times k}(\mathbb{C})$ has component $D^{-1/2}X_{i,p}$ at
+the pair $(i,p)$.
 
 ## Main definitions
 

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -69,8 +69,8 @@ noncomputable def compressedOmegaVector (X : Matrix (Fin D) (Fin k) ℂ) :
     Fin D × Fin k → ℂ :=
   fun ip => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * X ip.1 ip.2
 
-/-- The rank-one positive semidefinite matrix used by the ampliation test agrees
-with the right-factor compression of the Choi matrix. -/
+/-- The rank-one matrix used by the ampliation test agrees with the right-factor
+compression of the Choi matrix. -/
 theorem nPositiveAmpliation_rankOne_eq_rightCompression
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin k) ℂ) :

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.Schwarz.TwoPositive
+
+/-!
+# Choi compression for the rank-one test
+
+This file records the matrix identity connecting the pure-state ampliation test
+for `k`-positivity with the Choi-matrix compression appearing in Wolf Chapter 3,
+Proposition 3.1, equation (3.4).
+
+The Choi matrix is normalized using `Matrix.omegaVec`, so the vector attached to
+an operator `X : Matrix (Fin D) (Fin k) ℂ` is
+`(i,p) ↦ D^{-1/2} X i p`.
+
+## Main definitions
+
+* `ChoiJamiolkowski.rightCompression`: the right-factor Choi compression,
+  written in the index convention of the blockwise ampliation.
+
+## Main results
+
+* `ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression`: the
+  ampliation of the associated rank-one matrix is exactly that compression.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Proposition 3.1, equation (3.4)][Wolf2012QChannels]
+-/
+
+open scoped Matrix BigOperators
+open Matrix Finset
+
+namespace ChoiJamiolkowski
+
+variable {D k : ℕ}
+
+/-- The right-factor Choi compression, written in the index convention of the
+blockwise ampliation.  Here `X : Matrix (Fin D) (Fin k) ℂ` carries the original
+Choi auxiliary index and the `k`-dimensional ampliation index; the entry formula
+is given by `rightCompression_apply`. -/
+noncomputable def rightCompression
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) :
+    Matrix (Fin D × Fin k) (Fin D × Fin k) ℂ :=
+  Matrix.of fun ip jq =>
+    ∑ a : Fin D, ∑ b : Fin D,
+      X a ip.2 * choiMatrix T (ip.1, a) (jq.1, b) * star (X b jq.2)
+
+/-- The entry formula for the right-factor compression of the Choi matrix.  The
+`(i,p),(j,q)` entry is
+`∑ a, ∑ b, X a p * τ (i,a) (j,b) * star (X b q)`, where `τ` is the Choi
+matrix of `T`. -/
+theorem rightCompression_apply
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) (i j : Fin D) (p q : Fin k) :
+    rightCompression T X (i, p) (j, q) =
+      ∑ a : Fin D, ∑ b : Fin D,
+        X a p * choiMatrix T (i, a) (j, b) * star (X b q) :=
+  rfl
+
+/-- The coefficient vector obtained from the normalized maximally entangled
+vector by applying `X` on the right tensor factor. -/
+noncomputable def compressedOmegaVector (X : Matrix (Fin D) (Fin k) ℂ) :
+    Fin D × Fin k → ℂ :=
+  fun ip => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * X ip.1 ip.2
+
+/-- The rank-one matrix used by the ampliation test agrees with the
+right-factor compression of the Choi matrix. -/
+theorem nPositiveAmpliation_rankOne_eq_rightCompression
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) :
+    nPositiveAmpliation k T
+        (Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X))) =
+      rightCompression T X := by
+  classical
+  ext ⟨i, p⟩ ⟨j, q⟩
+  let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
+  have hblock :
+      (Matrix.of fun a b =>
+          Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X))
+            (a, p) (b, q)) =
+        ∑ a : Fin D, ∑ b : Fin D,
+          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj D) a b := by
+    calc
+      (Matrix.of fun a b =>
+          Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X))
+            (a, p) (b, q))
+          = Matrix.of fun a b => (X a p * star (X b q)) * (c * star c) := by
+            ext a b
+            simp [compressedOmegaVector, c, Matrix.vecMulVec_apply]
+            ring
+      _ = ∑ a : Fin D, ∑ b : Fin D,
+          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj D) a b := by
+            rw [Matrix.matrix_eq_sum_single
+              (Matrix.of fun a b => (X a p * star (X b q)) * (c * star c))]
+            simp [ChoiJamiolkowski.omegaSlice_eq_single, c, Matrix.smul_single,
+              smul_eq_mul, mul_assoc, mul_left_comm, mul_comm]
+  calc
+    nPositiveAmpliation k T
+        (Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X)))
+        (i, p) (j, q)
+        = T (Matrix.of fun a b =>
+            Matrix.vecMulVec (compressedOmegaVector X) (star (compressedOmegaVector X))
+              (a, p) (b, q)) i j := rfl
+    _ = T (∑ a : Fin D, ∑ b : Fin D,
+          (X a p * star (X b q)) • Matrix.bipartiteSlice (Matrix.omegaProj D) a b) i j := by
+        rw [hblock]
+    _ = (∑ a : Fin D, ∑ b : Fin D,
+          (X a p * star (X b q)) • T (Matrix.bipartiteSlice (Matrix.omegaProj D) a b)) i j := by
+        simp [map_sum]
+    _ = rightCompression T X (i, p) (j, q) := by
+        rw [rightCompression_apply]
+        simp only [Matrix.sum_apply, Matrix.smul_apply, smul_eq_mul, choiMatrix_apply]
+        apply Finset.sum_congr rfl
+        intro a _
+        apply Finset.sum_congr rfl
+        intro b _
+        ring_nf
+
+end ChoiJamiolkowski

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -41,8 +41,10 @@ variable {D k : ℕ}
 
 /-- The right-factor Choi compression, written in the index convention of the
 blockwise ampliation.  Here `X : Matrix (Fin D) (Fin k) ℂ` carries the original
-Choi auxiliary index and the `k`-dimensional ampliation index; the entry formula
-is given by `rightCompression_apply`. -/
+Choi auxiliary index and the `k`-dimensional ampliation index.  The
+$(i,p),(j,q)$ entry is
+$\sum_{a,b} X_{a,p}\,\tau_{(i,a),(j,b)}\,\overline{X_{b,q}}$, where $\tau$ is
+the Choi matrix of `T`. -/
 noncomputable def rightCompression
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin k) ℂ) :
@@ -52,9 +54,9 @@ noncomputable def rightCompression
       X a ip.2 * choiMatrix T (ip.1, a) (jq.1, b) * star (X b jq.2)
 
 /-- The entry formula for the right-factor compression of the Choi matrix.  The
-`(i,p),(j,q)` entry is
-`∑ a, ∑ b, X a p * τ (i,a) (j,b) * star (X b q)`, where `τ` is the Choi
-matrix of `T`. -/
+$(i,p),(j,q)$ entry is
+$\sum_{a,b} X_{a,p}\,\tau_{(i,a),(j,b)}\,\overline{X_{b,q}}$, where $\tau$ is
+the Choi matrix of `T`. -/
 theorem rightCompression_apply
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin k) ℂ) (i j : Fin D) (p q : Fin k) :

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -69,8 +69,8 @@ noncomputable def compressedOmegaVector (X : Matrix (Fin D) (Fin k) ℂ) :
     Fin D × Fin k → ℂ :=
   fun ip => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * X ip.1 ip.2
 
-/-- The rank-one matrix used by the ampliation test agrees with the
-right-factor compression of the Choi matrix. -/
+/-- The rank-one positive semidefinite matrix used by the ampliation test agrees
+with the right-factor compression of the Choi matrix. -/
 theorem nPositiveAmpliation_rankOne_eq_rightCompression
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D) (Fin k) ℂ) :

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -237,10 +237,9 @@ maps.
     \lean{ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression}
     \leanok
     \uses{def:blockwise_ampliation, def:choi_right_compression}
-    Applying the $k$-fold ampliation of $T$ to the rank-one positive
-    semidefinite matrix $|\psi\rangle\langle\psi|$, where
-    $\psi_{(a,p)}=D^{-1/2}X_{a,p}$, is exactly the right-factor compression of
-    the Choi matrix of $T$ by $X$.
+    Applying the $k$-fold ampliation of $T$ to the rank-one matrix
+    $|\psi\rangle\langle\psi|$, where $\psi_{(a,p)}=D^{-1/2}X_{a,p}$, is
+    exactly the right-factor compression of the Choi matrix of $T$ by $X$.
 \end{lemma}
 
 \begin{proof}
@@ -260,9 +259,8 @@ maps.
     \[
       T\!\left(D^{-1}\sum_{a,b}
           X_{a,p}\,\overline{X_{b,q}}\,E_{a,b}\right)_{i,j}
-      = \sum_{a,b}
-          X_{a,p}\,\overline{X_{b,q}}\,
-          D^{-1}\bigl(T(E_{a,b})\bigr)_{i,j}
+      = D^{-1}\sum_{a,b}
+          X_{a,p}\,\overline{X_{b,q}}\,\bigl(T(E_{a,b})\bigr)_{i,j}
       = \sum_{a,b}
           X_{a,p}\,\tau_{(i,a),(j,b)}\,\overline{X_{b,q}},
     \]

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -237,9 +237,10 @@ maps.
     \lean{ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression}
     \leanok
     \uses{def:blockwise_ampliation, def:choi_right_compression}
-    Applying the $k$-fold ampliation of $T$ to the rank-one matrix
-    $|\psi\rangle\langle\psi|$, where $\psi_{(a,p)}=D^{-1/2}X_{a,p}$, is
-    exactly the right-factor compression of the Choi matrix of $T$ by $X$.
+    Applying the $k$-fold ampliation of $T$ to the rank-one positive
+    semidefinite matrix $|\psi\rangle\langle\psi|$, where
+    $\psi_{(a,p)}=D^{-1/2}X_{a,p}$, is exactly the right-factor compression of
+    the Choi matrix of $T$ by $X$.
 \end{lemma}
 
 \begin{proof}
@@ -259,8 +260,9 @@ maps.
     \[
       T\!\left(D^{-1}\sum_{a,b}
           X_{a,p}\,\overline{X_{b,q}}\,E_{a,b}\right)_{i,j}
-      = D^{-1}\sum_{a,b}
-          X_{a,p}\,\overline{X_{b,q}}\,\bigl(T(E_{a,b})\bigr)_{i,j}
+      = \sum_{a,b}
+          X_{a,p}\,\overline{X_{b,q}}\,
+          D^{-1}\bigl(T(E_{a,b})\bigr)_{i,j}
       = \sum_{a,b}
           X_{a,p}\,\tau_{(i,a),(j,b)}\,\overline{X_{b,q}},
     \]

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -216,6 +216,58 @@ maps.
     semidefinite cone under finite sums.
 \end{proof}
 
+\begin{definition}[Right compression of the Choi matrix]\label{def:choi_right_compression}
+    \lean{ChoiJamiolkowski.rightCompression,
+        ChoiJamiolkowski.rightCompression_apply,
+        ChoiJamiolkowski.compressedOmegaVector}
+    \leanok
+    \uses{def:blockwise_ampliation}
+    For $X\in\MN{D,k}(\C)$ and a Choi matrix $\tau$, the right-factor
+    compression in the blockwise ampliation index convention has entries
+    \[
+      C_{(i,p),(j,q)}
+      = \sum_{a,b} X_{a,p}\,\tau_{(i,a),(j,b)}\,\overline{X_{b,q}}.
+    \]
+    The associated vector is the normalized vector with coefficients
+    $D^{-1/2}X_{i,p}$.
+\end{definition}
+
+\begin{lemma}[Rank-one ampliation as Choi compression]
+    \label{lem:rank_one_ampliation_choi_compression}
+    \lean{ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression}
+    \leanok
+    \uses{def:blockwise_ampliation, def:choi_right_compression}
+    Applying the $k$-fold ampliation of $T$ to the rank-one matrix
+    $|\psi\rangle\langle\psi|$, where $\psi_{(a,p)}=D^{-1/2}X_{a,p}$, is
+    exactly the right-factor compression of the Choi matrix of $T$ by $X$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    In entries, both sides are
+    \[
+      \sum_{a,b} X_{a,p}\,
+        T\!\left(D^{-1}E_{a,b}\right)_{i,j}\,\overline{X_{b,q}}.
+    \]
+    If $\psi_{(a,p)}=D^{-1/2}X_{a,p}$, then for fixed $p,q$ the corresponding
+    block of $|\psi\rangle\langle\psi|$ is
+    \[
+      \bigl(|\psi\rangle\langle\psi|\bigr)_{(\cdot,p),(\cdot,q)}
+      = D^{-1}\sum_{a,b} X_{a,p}\,\overline{X_{b,q}}\,E_{a,b}.
+    \]
+    Hence
+    \[
+      T\!\left(D^{-1}\sum_{a,b}
+          X_{a,p}\,\overline{X_{b,q}}\,E_{a,b}\right)_{i,j}
+      = D^{-1}\sum_{a,b}
+          X_{a,p}\,\overline{X_{b,q}}\,\bigl(T(E_{a,b})\bigr)_{i,j}
+      = \sum_{a,b}
+          X_{a,p}\,\tau_{(i,a),(j,b)}\,\overline{X_{b,q}},
+    \]
+    where the second equality uses
+    $\tau_{(i,a),(j,b)}=D^{-1}\bigl(T(E_{a,b})\bigr)_{i,j}$.
+\end{proof}
+
 \begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}
     \lean{Matrix.traceAdjointMap}
     \leanok


### PR DESCRIPTION
### Motivation

Wolf, *Quantum Channels & Operations*, Chapter 3, Proposition 3.1 characterizes n-positive maps by positivity conditions on compressions of the Choi-Jamiolkowski operator. This PR formalizes the coefficient identity connecting the pure-state ampliation test to the corresponding right-factor Choi compression. It is a prerequisite for the full proposition, not a proof of the whole equivalence.

### Description

- Add `TNLean/Channel/Schwarz/ChoiCompression.lean` with `ChoiJamiolkowski.rightCompression`, its entry formula, `compressedOmegaVector`, and `nPositiveAmpliation_rankOne_eq_rightCompression`.
- Record the matching blueprint definition and lemma in `blueprint/src/chapter/ch05_schwarz.tex`.
- Import the new module from `TNLean.lean`.

### Testing

- `lake build TNLean.Channel.Schwarz.ChoiCompression`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check origin/main...HEAD`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`

---
Refs LionSR/QICLean#24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Mathlib/blueprint formalization on top of existing `TwoPositive` infrastructure; no changes to runtime behavior or security-sensitive code.
> 
> **Overview**
> Adds **`TNLean.Channel.Schwarz.ChoiCompression`** and wires it into the root import and the Schwarz blueprint chapter.
> 
> The new Lean layer defines **`ChoiJamiolkowski.rightCompression`**, **`compressedOmegaVector`** (coefficients \(D^{-1/2}X_{i,p}\)), and proves **`nPositiveAmpliation_rankOne_eq_rightCompression`**: for a rank-one input built from that vector, the \(k\)-fold blockwise ampliation equals the right-factor Choi compression (Wolf Ch. 3, Prop. 3.1 / eq. (3.4)). **`blueprint/src/chapter/ch05_schwarz.tex`** gains the matching definition and lemma immediately after the rank-one \(k\)-positivity test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01fccacc6e7d078893c0ae033db58730f41a0bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->