### PR TITLE
feat(MPS/RFP): add core tensor pair orthogonality

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -285,6 +285,31 @@ noncomputable def AppendixBStructuralData.coreTensor {A : MPSTensor d D}
     hStruct.coreTensor i = Matrix.diagonal (fun k => (hStruct.Λ k : ℂ)) * hStruct.U i :=
   rfl
 
+/-- The Appendix B pair-index orthogonality for the core tensor \(\Lambda U^i\).
+
+Source: arXiv:1606.00608, lines 543--555, especially the source unit
+pair-index isometry equation.  Multiplication by \(\Lambda\) on the left
+weights the two virtual left indices. -/
+theorem AppendixBStructuralData.coreTensor_pair_orthogonality
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (p q : Fin D × Fin D) :
+    ∑ i : Fin d, star (hStruct.coreTensor i p.1 p.2) *
+        hStruct.coreTensor i q.1 q.2 =
+      (hStruct.Λ p.1 : ℂ) * (hStruct.Λ q.1 : ℂ) *
+        (if p = q then 1 else 0) := by
+  classical
+  calc
+    ∑ i : Fin d, star (hStruct.coreTensor i p.1 p.2) *
+        hStruct.coreTensor i q.1 q.2 =
+      (hStruct.Λ p.1 : ℂ) * (hStruct.Λ q.1 : ℂ) *
+        (∑ i : Fin d, star (hStruct.U i p.1 p.2) *
+          hStruct.U i q.1 q.2) := by
+        simp [AppendixBStructuralData.coreTensor, Matrix.diagonal_mul,
+          Finset.mul_sum, mul_assoc, mul_left_comm, mul_comm]
+    _ = (hStruct.Λ p.1 : ℂ) * (hStruct.Λ q.1 : ℂ) *
+        (if p = q then 1 else 0) := by
+        rw [hStruct.hU_pair p q]
+
 /-! ### Coefficients of the source basic-vector expression -/
 
 /-- The next virtual bond in the cyclic chain of length \(L\). -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -752,6 +752,7 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude}
     \lean{MPSTensor.AppendixBStructuralData.coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.coreTensor_apply}
+    \lean{MPSTensor.AppendixBStructuralData.coreTensor_pair_orthogonality}
     \lean{MPSTensor.cyclicVirtualSucc}
     \lean{MPSTensor.AppendixBStructuralData.cyclicVirtualPairState}
     \lean{MPSTensor.AppendixBStructuralData.mpv_coreTensor_eq_cyclicVirtualPairState}
@@ -780,6 +781,16 @@ the specialization $L=2$.
         \overline{(U^i)_{\alpha,\beta}}\,
         (U^i)_{\alpha',\beta'}
         =
+        \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+    \]
+    Therefore the residual core tensor \(\Lambda U^i\) satisfies the weighted
+    pair-index relation
+    \[
+        \sum_i
+        \overline{(\Lambda U^i)_{\alpha,\beta}}\,
+        (\Lambda U^i)_{\alpha',\beta'}
+        =
+        \lambda_\alpha\lambda_{\alpha'}
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
     The coefficient associated to the source basic-vector formula is


### PR DESCRIPTION
### Motivation

- Proves the weighted pair-index orthogonality relation for the Appendix B core tensor `Λ U`, a supporting algebraic step toward the positive even-chain product-pair factorization (arXiv:1606.00608, Appendix B and structural characterization lines 543–555).
- Continues formalization of the RFP Appendix B structural characterization; see #3372.

### Description

- `TNLean/MPS/RFP/CommutingBridge.lean`: proves `MPSTensor.AppendixBStructuralData.coreTensor_pair_orthogonality`, the weighted pair-index orthogonality relation for the core tensor `Λ U`.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: records the new relation in the parent-Hamiltonian/RFP blueprint discussion.
- Does not prove the general even-chain factorization, trace normalization, cross-block orthogonality, or the source projector construction for #3373.

### Testing

- `lake build TNLean.MPS.RFP.CommutingBridge`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `rg -n "sorry|axiom|native_decide|unsafeCast|admit" TNLean/MPS/RFP/CommutingBridge.lean`
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
Addresses #3372