### PR TITLE
style(blueprint): use inline math dollars in RFP core relation

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -783,7 +783,7 @@ the specialization $L=2$.
         =
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
-    Therefore the residual core tensor \(\Lambda U^i\) satisfies the weighted
+    Therefore the residual core tensor $\Lambda U^i$ satisfies the weighted
     pair-index relation
     \[
         \sum_i


### PR DESCRIPTION
### Motivation
- The blueprint style guide requires `$...$` for inline mathematics and explicitly discourages mixing `$...$` with `\(...\)` in the same paragraph; see `docs/blueprint_style_guide.md` §Notation Consistency.
- One occurrence of `\( ... \)` remained in the RFP core-pair orthogonality remark in `ch13_parent_hamiltonian_commuting_gap.tex`, inconsistent with the surrounding prose.

### Description
- In `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`, one inline math delimiter is changed from `\(\Lambda U^i\)` to `$\Lambda U^i$` in the Appendix B RFP core-pair orthogonality remark.
- No mathematical content, Lean references, or formalization behavior is affected.

### Testing
- Blueprint sync validated locally: `python3 scripts/blueprint_lean_sync.py --root . --ci` (2969/2980 entries, 99.6%; no new prose violations).
- Prose check: `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main` (no violations found).
- Relies on Lean CI (`lean_action_ci.yml`) and Blueprint Lint (`lint-blueprint.yml`) to validate the build.

---

_No linked issue found; this is a standalone style fix. If a blueprint-cleanup tracking issue exists, please link it manually._

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX delimiter change with no code or proof impact.
>
> **Overview**
> In `ch13_parent_hamiltonian_commuting_gap.tex`, the sentence about the residual core tensor in the Appendix B / RFP core-pair orthogonality remark now uses **dollar-delimited** inline math (`$\Lambda U^i$`) instead of `\(...\)` for that symbol.
>
> No mathematical content, Lean references, or formalization behavior changes—only blueprint prose formatting aligned with the preferred inline-math style.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2ead35ba11e01e3c347919c93864d33cdbc2648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>