### PR TITLE
feat(Channel/Schwarz): add Choi compression positivity criterion

### DIFF
--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -27,6 +27,9 @@ the pair $(i,p)$.
 
 * `ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression`: the
   ampliation of the associated rank-one matrix is exactly that compression.
+* `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`:
+  `k`-positivity is equivalent to positivity of all rectangular right-factor
+  Choi compressions.
 
 ## References
 
@@ -34,7 +37,7 @@ the pair $(i,p)$.
   Proposition 3.1, equation (3.4)][Wolf2012QChannels]
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators ComplexOrder
 open Matrix Finset
 
 namespace ChoiJamiolkowski
@@ -126,5 +129,36 @@ theorem nPositiveAmpliation_rankOne_eq_rightCompression
         apply Finset.sum_congr rfl
         intro b _
         ring_nf
+
+/-- Rectangular compression form of Wolf, Proposition 3.1, equation (3.4), for
+endomorphisms of matrix algebras: when `D > 0`, `k`-positivity is equivalent to
+positivity of every right-factor compression of the Choi matrix by a matrix in
+`M_{D,k}`. -/
+theorem isNPositiveMap_iff_forall_rightCompression_posSemidef [NeZero D]
+    (k : ℕ) (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ) :
+    IsNPositiveMap k T ↔
+      ∀ X : Matrix (Fin D) (Fin k) ℂ, (rightCompression T X).PosSemidef := by
+  constructor
+  · intro hT X
+    rw [← nPositiveAmpliation_rankOne_eq_rightCompression (T := T) (X := X)]
+    exact (isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef k T).mp hT
+      (compressedOmegaVector X)
+  · intro hX
+    rw [isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef]
+    intro φ
+    let X : Matrix (Fin D) (Fin k) ℂ :=
+      fun a p => (((D : ℝ).sqrt : ℂ)) * φ (a, p)
+    have hvec : compressedOmegaVector X = φ := by
+      have hDpos : 0 < (D : ℝ) := by
+        exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+      have hsqrt_ne : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
+        exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
+      ext ip
+      rcases ip with ⟨i, p⟩
+      simp only [compressedOmegaVector, X]
+      field_simp [hsqrt_ne]
+    rw [← hvec]
+    rw [nPositiveAmpliation_rankOne_eq_rightCompression]
+    exact hX X
 
 end ChoiJamiolkowski

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -268,6 +268,35 @@ maps.
     $\tau_{(i,a),(j,b)}=D^{-1}\bigl(T(E_{a,b})\bigr)_{i,j}$.
 \end{proof}
 
+\begin{theorem}[Rectangular Choi-compression test for $k$-positivity]
+    \label{thm:k_positive_iff_right_choi_compressions}
+    \lean{ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef}
+    \leanok
+    \uses{thm:k_positive_rank_one_test, def:choi_right_compression,
+        lem:rank_one_ampliation_choi_compression}
+    Assume $D>0$.  A linear map $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ is
+    $k$-positive if and only if, for every $X\in\MN{D,k}(\C)$, the
+    right-factor compression of the Choi matrix of $T$ by $X$ is positive
+    semidefinite.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The forward direction applies the rank-one $k$-positivity test to the
+    normalized vector with coefficients $D^{-1/2}X_{i,p}$, then uses
+    Lemma~\ref{lem:rank_one_ampliation_choi_compression}.  Conversely, given a
+    vector $\psi$ on the ampliated space, take
+    $X_{i,p}=D^{1/2}\psi_{(i,p)}$.  Since $D>0$, this choice satisfies
+    $D^{-1/2}X_{i,p}=\psi_{(i,p)}$.  Lemma~\ref{lem:rank_one_ampliation_choi_compression}
+    gives
+    \[
+      (T\otimes \id_k)(|\psi\rangle\langle\psi|)=C_T(X),
+    \]
+    where $C_T(X)$ is the right-factor Choi compression.  Positivity of
+    $C_T(X)$ is therefore positivity of the ampliation on the rank-one matrix
+    $|\psi\rangle\langle\psi|$, and the rank-one test gives $k$-positivity.
+\end{proof}
+
 \begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}
     \lean{Matrix.traceAdjointMap}
     \leanok

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -283,12 +283,15 @@ maps.
 \begin{proof}
     \leanok
     The forward direction applies the rank-one $k$-positivity test to the
-    normalized vector with coefficients $D^{-1/2}X_{i,p}$, then uses
-    Lemma~\ref{lem:rank_one_ampliation_choi_compression}.  Conversely, given a
-    vector $\psi$ on the ampliated space, take
+    normalized vector $\psi_X$ with coefficients
+    $(\psi_X)_{(i,p)}=D^{-1/2}X_{i,p}$, then uses
+    Lemma~\ref{lem:rank_one_ampliation_choi_compression} in the form
+    \[
+      (T\otimes \id_k)(|\psi_X\rangle\langle\psi_X|)=C_T(X).
+    \]
+    Conversely, given a vector $\psi$ on the ampliated space, take
     $X_{i,p}=D^{1/2}\psi_{(i,p)}$.  Since $D>0$, this choice satisfies
-    $D^{-1/2}X_{i,p}=\psi_{(i,p)}$.  Lemma~\ref{lem:rank_one_ampliation_choi_compression}
-    gives
+    $D^{-1/2}X_{i,p}=\psi_{(i,p)}$.  The same compression identity gives
     \[
       (T\otimes \id_k)(|\psi\rangle\langle\psi|)=C_T(X),
     \]


### PR DESCRIPTION
### Motivation

- Wolf Proposition 3.1 characterizes n-positive maps via the Choi–Jamiolkowski formalism (Wolf Ch. 3, §3.1, eq. 3.4). The rectangular Choi-compression test is a key step: k-positivity of T is equivalent to positive semidefiniteness of every right-factor Choi compression by X : Matrix (Fin D) (Fin k) ℂ.
- Continues formalization of the Choi–Jamiolkowski characterization of n-positive maps; see LionSR/QICLean#24.
- The Choi-compression identity from LionSR/TNLean#3435 provides the main supporting lemma.

### Description

- Modified `TNLean/Channel/Schwarz/ChoiCompression.lean`: adds theorem `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`, which establishes that for D > 0, k-positivity of T is equivalent to positive semidefiniteness of `rightCompression T X` for every `X : Matrix (Fin D) (Fin k) ℂ` (Wolf Prop. 3.1 / eq. 3.4).
- Modified `blueprint/src/chapter/ch05_schwarz.tex`: adds a "Rectangular Choi-compression test" blueprint entry.
- The projection and Schmidt-rank formulations of Wolf Proposition 3.1 remain separate work.

### Testing

- `lake build TNLean.Channel.Schwarz.ChoiCompression`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `rg -n "sorry|admit|axiom|native_decide|unsafeCast" TNLean/Channel/Schwarz/ChoiCompression.lean || true`
- Lean CI (`lean_action_ci.yml`) validates the full build on push.

---
Addresses LionSR/QICLean#24

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization in channel/Schwarz theory with no runtime, security, or data-path changes; logic composes existing lemmas only.
> 
> **Overview**
> Adds Wolf Prop. 3.1 (eq. 3.4): for **D > 0**, a map **T** is **k**-positive iff every rectangular right-factor Choi compression `rightCompression T X` (for `X : Matrix (Fin D) (Fin k) ℂ`) is positive semidefinite.
> 
> The Lean proof is a short biconditional that reuses the existing rank-one ampliation test and `nPositiveAmpliation_rankOne_eq_rightCompression`, with the reverse direction built by scaling ampliation vectors φ by **D^{1/2}** so `compressedOmegaVector X = φ`. The module header documents the new theorem; `ComplexOrder` is opened for the sqrt/field_simp steps.
> 
> The Schwarz blueprint chapter gains a matching **Rectangular Choi-compression test for k-positivity** theorem and proof, linked to the Lean name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f845eb0556e725eda7e91d7c1f9e426962695c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->