### PR TITLE
feat(MPS/ParentHamiltonian): add Appendix D.2 local parent commutation condition

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
+++ b/TNLean/MPS/ParentHamiltonian/GroundSpace.lean
@@ -41,6 +41,44 @@ noncomputable def groundSpace (A : MPSTensor d D) (L : ℕ) :
     Submodule ℂ (NSiteSpace d L) :=
   (groundSpaceMap A L).range
 
+lemma trace_gauge_boundary (X : GL (Fin D) ℂ) (E Y : Matrix (Fin D) (Fin D) ℂ) :
+    Matrix.trace (((X : Matrix (Fin D) (Fin D) ℂ) * E *
+        ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)) * Y) =
+      Matrix.trace (E * (((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
+        Y * (X : Matrix (Fin D) (Fin D) ℂ))) := by
+  set Xmat : Matrix (Fin D) (Fin D) ℂ := (X : Matrix (Fin D) (Fin D) ℂ)
+  set Xinv : Matrix (Fin D) (Fin D) ℂ :=
+    ((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ)
+  calc
+    Matrix.trace ((Xmat * E * Xinv) * Y)
+        = Matrix.trace (Xmat * E * (Xinv * Y)) := by simp [Matrix.mul_assoc]
+    _ = Matrix.trace ((Xinv * Y) * Xmat * E) := by
+        simpa using Matrix.trace_mul_cycle Xmat E (Xinv * Y)
+    _ = Matrix.trace (E * (Xinv * Y * Xmat)) := by
+        simpa [Matrix.mul_assoc] using Matrix.trace_mul_comm ((Xinv * Y) * Xmat) E
+
+/-- A virtual gauge change does not change the local ground space. -/
+theorem GaugeEquiv.groundSpace_le {A B : MPSTensor d D}
+    (h : GaugeEquiv A B) (L : ℕ) :
+    groundSpace B L ≤ groundSpace A L := by
+  rcases h with ⟨X, hX⟩
+  rintro ψ ⟨Y, rfl⟩
+  refine ⟨((X⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) * Y *
+      (X : Matrix (Fin D) (Fin D) ℂ), ?_⟩
+  ext σ
+  rw [groundSpaceMap_apply, groundSpaceMap_apply]
+  rw [evalWord_gauge X hX]
+  exact (trace_gauge_boundary X (evalWord A (List.ofFn σ)) Y).symm
+
+/-- Gauge-equivalent tensors have identical local ground spaces at every
+length. -/
+theorem GaugeEquiv.groundSpace_eq {A B : MPSTensor d D}
+    (h : GaugeEquiv A B) (L : ℕ) :
+    groundSpace A L = groundSpace B L := by
+  apply le_antisymm
+  · exact h.symm.groundSpace_le L
+  · exact h.groundSpace_le L
+
 /-- The span of the periodic MPS vectors associated to a finite family of BNT
 components.
 

--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -247,6 +247,37 @@ structure HasOverlappingTwoSiteCommutation
     leftPairLift QAX * rightPairLift QXB =
       rightPairLift QXB * leftPairLift QAX
 
+/-- The local projector condition of arXiv:1606.00608, Definition D.2, on one
+three-site window.
+
+The source writes two local projectors \(Q_{AX}\) and \(Q_{XB}\) on the
+overlapping pairs \(AX\) and \(XB\). Besides idempotence and commutation after
+lifting them to \(A X B\), Definition D.2 includes the local ground-space
+condition that the three-site subspace is the intersection of their two lifted
+kernels. Orthogonality and the construction of these projectors from the
+Appendix B basic-vector form are still separate obligations. -/
+structure HasAppendixD2ParentCommutingHamiltonian
+    (KAXB : Submodule ℂ (NSiteSpace d 3))
+    (QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2) : Prop where
+  left_idempotent : QAX * QAX = QAX
+  right_idempotent : QXB * QXB = QXB
+  commute_lifts :
+    leftPairLift QAX * rightPairLift QXB =
+      rightPairLift QXB * leftPairLift QAX
+  kernel_intersection :
+    KAXB = LinearMap.ker (leftPairLift QAX) ⊓ LinearMap.ker (rightPairLift QXB)
+
+/-- Forgetting the kernel-intersection part of arXiv:1606.00608, Definition D.2,
+leaves the algebraic overlapping two-site commutation predicate. -/
+theorem HasAppendixD2ParentCommutingHamiltonian.to_overlapping
+    {KAXB : Submodule ℂ (NSiteSpace d 3)}
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasAppendixD2ParentCommutingHamiltonian (d := d) KAXB QAX QXB) :
+    HasOverlappingTwoSiteCommutation (d := d) QAX QXB where
+  left_idempotent := h.left_idempotent
+  right_idempotent := h.right_idempotent
+  commute_lifts := h.commute_lifts
+
 theorem HasOverlappingTwoSiteCommutation.commute_apply
     {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
     (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB)
@@ -323,6 +354,39 @@ theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation
   rw [localTerm_two_three_zero_eq_leftPairLift_parentInteraction,
     localTerm_two_three_one_eq_rightPairLift_parentInteraction]
   exact h.commute_lifts
+
+/-- If the two-site parent interaction is identified with the complementary
+Appendix D.2 projectors \(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\), then the
+first two translated parent terms on the three-site chain commute. -/
+theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_complement
+    (A : MPSTensor d D) {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB)
+    (hAX : parentInteraction A 2 = 1 - QAX)
+    (hXB : parentInteraction A 2 = 1 - QXB) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) := by
+  rw [localTerm_two_three_zero_eq_leftPairLift_parentInteraction,
+    localTerm_two_three_one_eq_rightPairLift_parentInteraction]
+  have hLeft : leftPairLift (parentInteraction A 2) = leftPairLift (1 - QAX) := by
+    rw [hAX]
+  have hRight : rightPairLift (parentInteraction A 2) = rightPairLift (1 - QXB) := by
+    rw [hXB]
+  rw [hLeft, hRight]
+  exact h.commute_complement_lifts
+
+/-- The Definition D.2 local projector condition gives commutation of the first
+two translated parent terms, once the canonical two-site parent interaction is
+identified with the complementary projectors \(1-Q_{AX}\) and \(1-Q_{XB}\). -/
+theorem localTerm_two_three_zero_one_commute_of_appendixD2_complement
+    (A : MPSTensor d D) {KAXB : Submodule ℂ (NSiteSpace d 3)}
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasAppendixD2ParentCommutingHamiltonian (d := d) KAXB QAX QXB)
+    (hAX : parentInteraction A 2 = 1 - QAX)
+    (hXB : parentInteraction A 2 = 1 - QXB) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) :=
+  localTerm_two_three_zero_one_commute_of_overlapping_two_site_complement A
+    h.to_overlapping hAX hXB
 
 /-! ### Adjacent cyclic two-site supports -/
 

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -372,6 +372,12 @@ theorem AppendixBStructuralData.gaugeEquiv_coreTensor {A : MPSTensor d D}
   intro i
   simp [Xg, AppendixBStructuralData.coreTensor, hStruct.hA_eq i, Matrix.mul_assoc]
 
+/-- The Appendix B basis change leaves every local ground space unchanged. -/
+theorem AppendixBStructuralData.groundSpace_eq_coreTensor {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) (L : ℕ) :
+    groundSpace A L = groundSpace hStruct.coreTensor L :=
+  (hStruct.gaugeEquiv_coreTensor.groundSpace_eq L).symm
+
 /-- The Appendix B basis change does not change any MPV coefficient. -/
 theorem AppendixBStructuralData.mpv_eq_coreTensor {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) {N : ℕ} (σ : Cfg d N) :
@@ -391,6 +397,15 @@ theorem AppendixBStructuralData.twoSiteAmplitude_eq_coreTensor_mpv {A : MPSTenso
     (hStruct : AppendixBStructuralData A) (σ : Cfg d 2) :
     hStruct.twoSiteAmplitude σ = mpv hStruct.coreTensor σ := by
   rw [hStruct.twoSiteAmplitude_eq_mpv σ, hStruct.mpv_eq_coreTensor σ]
+
+/-- On two sites, the Appendix B cyclic basic-vector coefficient is the
+structural two-site amplitude. -/
+theorem AppendixBStructuralData.cyclicVirtualPairState_two_eq_twoSiteAmplitude
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (σ : Cfg d 2) :
+    hStruct.cyclicVirtualPairState (by decide : 0 < 2) σ =
+      hStruct.twoSiteAmplitude σ := by
+  rw [← hStruct.mpv_coreTensor_eq_cyclicVirtualPairState (by decide : 0 < 2) σ,
+    hStruct.twoSiteAmplitude_eq_coreTensor_mpv]
 
 /-- The length-two case of the disjoint adjacent-pair coefficient condition. -/
 theorem AppendixBStructuralData.mpv_coreTensor_eq_productPairState_one {A : MPSTensor d D}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -28,6 +28,8 @@ the specialization $L=2$.
     \lean{MPSTensor.leftPairLift_one_sub}
     \lean{MPSTensor.rightPairLift_one_sub}
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation}
+    \lean{MPSTensor.HasAppendixD2ParentCommutingHamiltonian}
+    \lean{MPSTensor.HasAppendixD2ParentCommutingHamiltonian.to_overlapping}
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation.left_complement_idempotent}
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation.right_complement_idempotent}
     \lean{MPSTensor.HasOverlappingTwoSiteCommutation.commute_complement_lifts}
@@ -63,6 +65,17 @@ the specialization $L=2$.
     in \cite[Definition~D.2]{Cirac2016MPDO_arXiv}.  The cyclic windows beginning
     at $i$ and $i+1$ realize the two supports $AX$ and $XB$, and hence overlap at
     the middle site.
+
+    The source local condition also fixes a three-site subspace $K_{AXB}$ and
+    imposes the kernel-intersection equation
+    \[
+        K_{AXB}=
+        \ker\bigl((Q_{AX})_{AX}\bigr)
+        \cap
+        \ker\bigl((Q_{XB})_{XB}\bigr).
+    \]
+    Forgetting this intersection equation gives the algebraic overlapping
+    two-site commutation condition displayed above.
 
     The two lift maps also distribute over complementary projectors:
     \[
@@ -148,6 +161,38 @@ the specialization $L=2$.
     parent interactions are \(q(A)_{AX}\) and \(q(A)_{XB}\). The assumed
     overlapping support condition says exactly that these two lifted
     endomorphisms commute.
+\end{proof}
+
+\begin{theorem}[Three-site commutation from complementary Appendix projectors]
+    \label{thm:local_term_two_three_commute_from_complement_ax_xb}
+    \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_overlapping_two_site_complement}
+    \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2_complement}
+    \leanok
+    \uses{def:overlapping_two_site_supports,
+        thm:local_term_two_three_ax_xb_lifts}
+    Suppose the Appendix~D.2 projectors \(Q_{AX}\) and \(Q_{XB}\) satisfy the
+    local parent-commuting condition on \(A X B\), and suppose that the canonical
+    two-site parent interaction is their complement on both faces:
+    \[
+        q(A)=1-Q_{AX}=1-Q_{XB}.
+    \]
+    Then the first two translated length-two parent terms on the three-site
+    chain commute,
+    \[
+        h^{(3)}_0(A,2)h^{(3)}_1(A,2)
+        =
+        h^{(3)}_1(A,2)h^{(3)}_0(A,2).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    The lift identities of Theorem~\ref{thm:local_term_two_three_ax_xb_lifts}
+    identify the translated terms with \((1-Q_{AX})_{AX}\) and
+    \((1-Q_{XB})_{XB}\). The Appendix~D.2 condition implies the overlapping
+    two-site commutation condition after forgetting the kernel-intersection
+    equation. Definition~\ref{def:overlapping_two_site_supports} then gives
+    commutation of the complementary lifted projectors, hence the displayed
+    commutation relation.
 \end{proof}
 
 \begin{definition}[Translated parent-term commutation]\label{def:is_commuting_parent_ham}
@@ -756,7 +801,12 @@ the specialization $L=2$.
     \lean{MPSTensor.cyclicVirtualSucc}
     \lean{MPSTensor.AppendixBStructuralData.cyclicVirtualPairState}
     \lean{MPSTensor.AppendixBStructuralData.mpv_coreTensor_eq_cyclicVirtualPairState}
+    \lean{MPSTensor.AppendixBStructuralData.cyclicVirtualPairState_two_eq_twoSiteAmplitude}
+    \lean{MPSTensor.trace_gauge_boundary}
+    \lean{MPSTensor.GaugeEquiv.groundSpace_le}
+    \lean{MPSTensor.GaugeEquiv.groundSpace_eq}
     \lean{MPSTensor.AppendixBStructuralData.gaugeEquiv_coreTensor}
+    \lean{MPSTensor.AppendixBStructuralData.groundSpace_eq_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.mpv_eq_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_mpv}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_coreTensor_mpv}
@@ -812,8 +862,16 @@ the specialization $L=2$.
     \]
     where $\varphi_j$ is shared by $b_t$ and $a_{t+1}$ and $U$ acts on
     $(a_t,b_t)$.
-    The change of basis does not alter periodic MPS coefficients, so the
-    corresponding two-site amplitude is
+    At length two, this cyclic coefficient is the structural two-site amplitude:
+    \[
+        C_2(\sigma)=\phi_2(\sigma).
+    \]
+    The change of basis does not alter either the local spaces \(G_L\) or the
+    periodic MPS coefficients:
+    \[
+        G_L(A)=G_L(\Lambda U).
+    \]
+    In particular, the corresponding two-site amplitude is
     \[
         \phi_2(a,b)
         =

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -65,19 +65,28 @@ The nearest-neighbor parent-Hamiltonian development now also has a separate
 three-site support layer for the \(AX\) and \(XB\) faces:
 \leanid{MPSTensor.leftPairLift}, \leanid{MPSTensor.rightPairLift}, and
 \leanid{MPSTensor.HasOverlappingTwoSiteCommutation}.  This records the local
-action and commutation equation on the common three-site space, but it still
-does not include the kernel-intersection condition or the orthogonal-projector
-identification required by Definition~D.2.  The elementary passage from
-\(Q_{AX},Q_{XB}\) to their complements \(1-Q_{AX},1-Q_{XB}\) is now recorded by
+action and commutation equation on the common three-site space.  The source
+kernel-intersection equation
+\[
+  K_{AXB}=\ker((Q_{AX})_{AX})\cap\ker((Q_{XB})_{XB})
+\]
+is now recorded by
+\leanid{MPSTensor.HasAppendixD2ParentCommutingHamiltonian}, whose forgetful
+projection gives the algebraic overlapping-commutation predicate.  What remains
+outside this local package is the orthogonal-projector identification and the
+construction of \(Q_{AX}\) and \(Q_{XB}\) from the Appendix~B basic-vector form.
+The elementary passage from \(Q_{AX},Q_{XB}\) to their complements
+\(1-Q_{AX},1-Q_{XB}\) is recorded by
 \leanid{MPSTensor.HasOverlappingTwoSiteCommutation.complement}.
 
 \section{Elimination plan}
 
 A source-faithful version should build on the existing \(AX/XB\) support layer
-by adding the local subspaces \(K_{AX}\) and \(K_{XB}\), the corresponding
+by constructing the local subspaces \(K_{AX}\) and \(K_{XB}\), the corresponding
 orthogonal projectors \(Q_{AX}\) and \(Q_{XB}\), and the source
-kernel-intersection equation.  From those hypotheses it should derive the
-idempotent-product declaration above as a lemma, with \(P_K=P_{AXB}\).
+orthogonal-projector hypotheses from the Appendix~B data.  From those
+hypotheses it should derive the idempotent-product declaration above as a
+lemma, with \(P_K=P_{AXB}\).
 
 After that source-level version is available, the blueprint entry for the source
 parent commuting Hamiltonian condition should point to that statement.  The


### PR DESCRIPTION
### Motivation
Appendix D.2 of arXiv:1606.00608 states the local parent-commuting condition using projectors Q_AX and Q_XB, while the nearest-neighbor parent terms are the complementary projectors. This PR records the formal bridge between those formulations and updates the paper-gap ledger accordingly.

### Description
- Add the three-site Appendix D.2 local condition, including idempotence, lifted commutation, and the kernel-intersection equation.
- Derive the overlapping two-site commutation predicate by forgetting the kernel-intersection equation.
- Prove commutation of the first two translated length-two parent terms when the canonical two-site interaction is identified with 1 - Q_AX and 1 - Q_XB.
- Record that the Appendix B gauge change preserves local ground spaces and identify the length-two cyclic virtual-pair coefficient with the structural two-site amplitude.
- Update the parent-Hamiltonian commuting-gap blueprint chapter and the cpsv16_parent_commuting_hamiltonian_scope paper-gap note.

### Testing
- lake build TNLean.MPS.RFP.CommutingBridge
- lake build TNLean.MPS.ParentHamiltonian.LocalSupport
- lake build TNLean
- leanblueprint checkdecls
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean/MPS/ParentHamiltonian/GroundSpace.lean TNLean/MPS/ParentHamiltonian/LocalSupport.lean TNLean/MPS/RFP/CommutingBridge.lean
- git diff --check

---
Addresses #3372
Refs #3373
Refs #3375

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and documentation with no runtime or security surface; changes are localized to MPS parent-Hamiltonian theory files.
> 
> **Overview**
> Formalizes more of **arXiv:1606.00608 Definition D.2** on overlapping \(AX/XB\) windows and ties it to translated length-two parent terms and Appendix B gauge data.
> 
> **Local D.2 condition:** Adds `HasAppendixD2ParentCommutingHamiltonian` (idempotence, lifted commutation, and **kernel intersection** \(K_{AXB} = \ker(Q_{AX}) \cap \ker(Q_{XB})\) on the three-site space), with `to_overlapping` projecting to the existing `HasOverlappingTwoSiteCommutation` predicate.
> 
> **Complement bridge:** Proves that when the canonical two-site parent interaction is **\(1 - Q_{AX}\)** and **\(1 - Q_{XB}\)** on both faces, the first two translated parent terms on a three-site chain commute—via new lemmas chaining D.2 → overlapping commutation → complement lifts.
> 
> **Gauge / Appendix B:** Shows **gauge equivalence preserves local ground spaces** (`trace_gauge_boundary`, `GaugeEquiv.groundSpace_eq`), that Appendix B basis change leaves \(G_L\) unchanged (`groundSpace_eq_coreTensor`), and that the **length-two cyclic basic-vector coefficient** equals the structural two-site amplitude.
> 
> Blueprint chapter 13 and `cpsv16_parent_commuting_hamiltonian_scope.tex` are updated to document the kernel-intersection layer and remaining gaps (projector construction from Appendix B).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efdcc68cce5ad6f357d2275cffe329720bbc2cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->