### PR TITLE
feat(Channel/Schwarz): add Choi right tensor sandwich

### DIFF
--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
+import TNLean.Channel.SchmidtRank
 import TNLean.Channel.Schwarz.TwoPositive
 
 /-!
@@ -20,6 +21,8 @@ the pair $(i,p)$.
 
 * `ChoiJamiolkowski.rightCompression`: the right-factor Choi compression,
   written in the index convention of the blockwise ampliation.
+* `ChoiJamiolkowski.rightTensorMatrix`: the matrix form of the right tensor
+  factor acting on the Choi auxiliary index.
 * `ChoiJamiolkowski.compressedOmegaVector`: the vector with component
   $D^{-1/2}X_{i,p}$ at the pair $(i,p)$.
 
@@ -27,6 +30,10 @@ the pair $(i,p)$.
 
 * `ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression`: the
   ampliation of the associated rank-one matrix is exactly that compression.
+* `ChoiJamiolkowski.rightTensorMatrix_mul_choiMatrix_mul_conjTranspose`: the
+  same compression is the sandwich by the right tensor factor.
+* `ChoiJamiolkowski.compressedOmegaVector_hasSchmidtRankLE`: the compressed
+  maximally entangled vector has Schmidt rank at most the compression dimension.
 * `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`:
   `k`-positivity is equivalent to positivity of all rectangular right-factor
   Choi compressions.
@@ -70,11 +77,49 @@ theorem rightCompression_apply
         X a p * choiMatrix T (i, a) (j, b) * star (X b q) :=
   rfl
 
+/-- The matrix representing the right tensor factor in the Choi-compression
+index convention.  Its entry from the Choi index `(j,a)` to the compressed
+index `(i,p)` is $\delta_{ij}X_{a,p}$.  This is the matrix form used in
+Wolf, Chapter 3, Proposition 3.1, item 2. -/
+noncomputable def rightTensorMatrix (X : Matrix (Fin D) (Fin k) ℂ) :
+    Matrix (Fin D × Fin k) (Fin D × Fin D) ℂ :=
+  Matrix.of fun ip ja => if ip.1 = ja.1 then X ja.2 ip.2 else 0
+
+/-- Sandwiching the Choi matrix by the right tensor factor gives exactly the
+right-factor compression entries.  In Wolf's notation this is the identity
+between $(\mathbf{1}\otimes X)\tau(\mathbf{1}\otimes X)^\dagger$ and the
+matrix with entries
+$\sum_{a,b} X_{a,p}\tau_{(i,a),(j,b)}\overline{X_{b,q}}$. -/
+theorem rightTensorMatrix_mul_choiMatrix_mul_conjTranspose
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) :
+    rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ =
+      rightCompression T X := by
+  classical
+  ext ⟨i, p⟩ ⟨j, q⟩
+  simp only [rightTensorMatrix, rightCompression, Matrix.mul_apply, Matrix.of_apply,
+    Matrix.conjTranspose_apply, Fintype.sum_prod_type]
+  rw [Finset.sum_eq_single j]
+  · rw [Finset.sum_comm]
+    simp [Finset.mul_sum, mul_assoc, mul_comm]
+  · intro x _ hx
+    simp [Ne.symm hx]
+  · simp
+
 /-- The coefficient vector obtained from the normalized maximally entangled
 vector by applying `X` on the right tensor factor. -/
 noncomputable def compressedOmegaVector (X : Matrix (Fin D) (Fin k) ℂ) :
     Fin D × Fin k → ℂ :=
   fun ip => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * X ip.1 ip.2
+
+/-- The vector obtained by applying a `D × k` matrix on the right tensor factor
+of the maximally entangled vector has Schmidt rank at most `k`. -/
+theorem compressedOmegaVector_hasSchmidtRankLE
+    (X : Matrix (Fin D) (Fin k) ℂ) :
+    Matrix.HasSchmidtRankLE k (compressedOmegaVector X) := by
+  simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank, Matrix.schmidtCoeffMatrix,
+    compressedOmegaVector] using
+    Matrix.rank_le_card_width (Matrix.schmidtCoeffMatrix (compressedOmegaVector X))
 
 /-- For the vector `compressedOmegaVector X`, the `k`-fold ampliation of the
 rank-one matrix $|\psi\rangle\langle\psi|$ by `T` is the right-factor Choi
@@ -160,5 +205,16 @@ theorem isNPositiveMap_iff_forall_rightCompression_posSemidef [NeZero D]
     rw [← hvec]
     rw [nPositiveAmpliation_rankOne_eq_rightCompression]
     exact hX X
+
+/-- A `k`-positive map has positive Choi sandwiches by every right tensor
+factor `X : M_{D,k}(\mathbb{C})`.  This is the forward implication of the
+projection-compression formulation before requiring that `X` comes from a
+rank-`k` Hermitian projection. -/
+theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsNPositiveMap k T) (X : Matrix (Fin D) (Fin k) ℂ) :
+    (rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ).PosSemidef := by
+  rw [rightTensorMatrix_mul_choiMatrix_mul_conjTranspose]
+  exact (isNPositiveMap_iff_forall_rightCompression_posSemidef k T).mp hT X
 
 end ChoiJamiolkowski

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -232,6 +232,63 @@ maps.
     $D^{-1/2}X_{i,p}$.
 \end{definition}
 
+\begin{definition}[Right tensor factor for Choi compression]
+    \label{def:choi_right_tensor_factor}
+    \lean{ChoiJamiolkowski.rightTensorMatrix}
+    \leanok
+    For $X\in\MN{D,k}(\C)$, let $R_X$ be the matrix from
+    $\C^D\otimes\C^D$ to $\C^D\otimes\C^k$ with entries
+    \[
+      (R_X)_{(i,p),(j,a)}=\delta_{i,j}X_{a,p}.
+    \]
+\end{definition}
+
+\begin{theorem}[Right tensor sandwich formula]
+    \label{thm:choi_right_tensor_sandwich}
+    \lean{ChoiJamiolkowski.rightTensorMatrix_mul_choiMatrix_mul_conjTranspose}
+    \leanok
+    \uses{def:choi_right_compression, def:choi_right_tensor_factor}
+    If $\tau$ is the Choi matrix of $T$, then
+    \[
+      R_X\tau R_X^\dagger = C_T(X),
+    \]
+    where $C_T(X)$ is the right-factor Choi compression by $X$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The $(i,p),(j,q)$ entry of $R_X\tau R_X^\dagger$ is
+    \[
+      \sum_{r,s,a,b}
+        \delta_{i,r}X_{a,p}\,
+        \tau_{(r,a),(s,b)}\,
+        \delta_{j,s}\overline{X_{b,q}}
+      =
+      \sum_{a,b} X_{a,p}\,
+        \tau_{(i,a),(j,b)}\,\overline{X_{b,q}},
+    \]
+    which is the defining entry of $C_T(X)$.
+\end{proof}
+
+\begin{lemma}[Compressed maximally entangled vectors have bounded Schmidt rank]
+    \label{lem:compressed_omega_schmidt_rank}
+    \lean{ChoiJamiolkowski.compressedOmegaVector_hasSchmidtRankLE}
+    \leanok
+    \uses{def:schmidt_rank, def:choi_right_compression}
+    For $X\in\MN{D,k}(\C)$, the vector
+    \[
+      \psi_X=\left(D^{-1/2}X_{i,p}\right)_{(i,p)}
+      \in \C^D\otimes\C^k
+    \]
+    has Schmidt rank at most $k$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The coefficient matrix of $\psi_X$ is a scalar multiple of $X$.  Therefore
+    its rank is bounded by the number of columns, which is $k$.
+\end{proof}
+
 \begin{lemma}[Rank-one ampliation as Choi compression]
     \label{lem:rank_one_ampliation_choi_compression}
     \lean{ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression}
@@ -298,6 +355,28 @@ maps.
     where $C_T(X)$ is the right-factor Choi compression.  Positivity of
     $C_T(X)$ is therefore positivity of the ampliation on the rank-one matrix
     $|\psi\rangle\langle\psi|$, and the rank-one test gives $k$-positivity.
+\end{proof}
+
+\begin{theorem}[Right tensor Choi sandwiches of a $k$-positive map]
+    \label{thm:k_positive_right_tensor_choi_sandwiches}
+    \lean{ChoiJamiolkowski.IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef}
+    \leanok
+    \uses{thm:k_positive_iff_right_choi_compressions,
+        thm:choi_right_tensor_sandwich}
+    Assume $D>0$.  If $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ is $k$-positive, then
+    for every $X\in\MN{D,k}(\C)$,
+    \[
+      R_X\tau R_X^\dagger\geq 0,
+    \]
+    where $\tau$ is the Choi matrix of $T$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By Theorem~\ref{thm:k_positive_iff_right_choi_compressions},
+    $C_T(X)\geq0$ for every $X\in\MN{D,k}(\C)$.  The sandwich formula
+    Theorem~\ref{thm:choi_right_tensor_sandwich} identifies
+    $R_X\tau R_X^\dagger$ with $C_T(X)$.
 \end{proof}
 
 \begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}


### PR DESCRIPTION
### Motivation

- Adds the explicit right-tensor matrix form of the rectangular Choi compression used in Wolf Proposition 3.1 (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~89–115), providing infrastructure for the projection formulation (#3439) and the Schmidt-rank formulation (#3440) of that result.
- The right-tensor matrix `R_X` makes the sandwich identity `R_X τ R_X† = C_T(X)` explicit, connecting the maximally entangled vector parametrization to the rectangular right-factor compression proved in LionSR/TNLean#3438.

### Description

- `TNLean/Channel/Schwarz/ChoiCompression.lean`: adds four declarations:
  - `ChoiJamiolkowski.rightTensorMatrix` — for `X : Matrix (Fin D) (Fin k) ℂ`, the matrix `R_X` with entries `(R_X)_{(i,p),(j,a)} = δ_{i,j} X_{a,p}`.
  - `ChoiJamiolkowski.rightTensorMatrix_mul_choiMatrix_mul_conjTranspose` — proves `R_X τ R_X† = C_T(X)`, where `τ` is the Choi matrix of `T` and `C_T(X)` is the rectangular right-factor compression.
  - `ChoiJamiolkowski.compressedOmegaVector_hasSchmidtRankLE` — the vector with coefficients `D^{-1/2} X_{i,p}` has Schmidt rank at most `k`, via the Mathlib column-rank bound.
  - `ChoiJamiolkowski.IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef` — the sandwich `R_X τ R_X†` is positive semidefinite when `T` is k-positive.
- `blueprint/src/chapter/ch05_schwarz.tex`: blueprint entries added for the four declarations above.
- This PR is infrastructure for LionSR/QICLean#171 and LionSR/QICLean#172 and does not close either.

### Testing

- `lake build TNLean.Channel.Schwarz.ChoiCompression`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|unsafeCast|admit" TNLean/Channel/Schwarz/ChoiCompression.lean` returned no matches.

---
Addresses LionSR/QICLean#171

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style formalization and blueprint documentation in the Schwarz/Choi channel layer; no runtime, auth, or data-path changes.
>
> **Overview**
> Adds **Wolf Prop. 3.1** infrastructure linking rectangular Choi compression to an explicit right-tensor matrix `R_X` and records a Schmidt-rank bound for compressed maximally entangled vectors.
>
> In `ChoiCompression.lean`, **`rightTensorMatrix`** encodes the factor with entries `δ_{i,j} X_{a,p}`, and **`rightTensorMatrix_mul_choiMatrix_mul_conjTranspose`** proves `R_X τ R_X†` equals the existing **`rightCompression`**. **`compressedOmegaVector_hasSchmidtRankLE`** shows vectors with coefficients `D^{-1/2} X_{i,p}` have Schmidt rank ≤ `k` (via column-rank / `SchmidtRank` import). **`IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef`** derives PSD of those sandwiches from the rectangular compression criterion.
>
> The blueprint chapter **`ch05_schwarz.tex`** is synced with matching definitions, the sandwich theorem, the Schmidt lemma, and the forward `k`-positive sandwich theorem.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b0c07cf498ae58e3e2f09c14dcab44fca8d885c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->