### PR TITLE
feat(Channel/Schwarz): add Schmidt-rank parametrization

### DIFF
--- a/TNLean/Channel/SchmidtRank.lean
+++ b/TNLean/Channel/SchmidtRank.lean
@@ -29,6 +29,7 @@ bounded Schmidt rank.
 * `Matrix.schmidtRank_le_left`, `Matrix.schmidtRank_le_right`: dimension bounds.
 * `Matrix.schmidtRank_zero`: the zero vector has Schmidt rank zero.
 * `Matrix.schmidtRank_product_le_one`: product vectors have Schmidt rank at most one.
+* `Matrix.rank_smul_of_ne_zero`: nonzero complex rescaling preserves matrix rank.
 
 ## References
 
@@ -52,6 +53,20 @@ theorem schmidtCoeffMatrix_apply (ψ : m × n → ℂ) (i : m) (j : n) :
   rfl
 
 variable [Fintype n]
+
+/-- Multiplication by a nonzero complex scalar does not change the rank of a
+matrix. -/
+theorem rank_smul_of_ne_zero {c : ℂ} (hc : c ≠ 0) (A : Matrix m n ℂ) :
+    (c • A).rank = A.rank := by
+  have hrange :
+      LinearMap.range (c • A).mulVecLin = LinearMap.range A.mulVecLin := by
+    ext v
+    constructor
+    · rintro ⟨x, rfl⟩
+      exact ⟨c • x, by simp⟩
+    · rintro ⟨x, rfl⟩
+      exact ⟨c⁻¹ • x, by simp [hc]⟩
+  rw [Matrix.rank, Matrix.rank, hrange]
 
 /-- The Schmidt rank of a finite bipartite vector. -/
 noncomputable def schmidtRank (ψ : m × n → ℂ) : ℕ :=

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -34,6 +34,8 @@ the pair $(i,p)$.
   same compression is the sandwich by the right tensor factor.
 * `ChoiJamiolkowski.compressedOmegaVector_hasSchmidtRankLE`: the compressed
   maximally entangled vector has Schmidt rank at most the compression dimension.
+* `ChoiJamiolkowski.hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector`:
+  Wolf's square-matrix parametrization of vectors of bounded Schmidt rank.
 * `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`:
   `k`-positivity is equivalent to positivity of all rectangular right-factor
   Choi compressions.
@@ -120,6 +122,60 @@ theorem compressedOmegaVector_hasSchmidtRankLE
   simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank, Matrix.schmidtCoeffMatrix,
     compressedOmegaVector] using
     Matrix.rank_le_card_width (Matrix.schmidtCoeffMatrix (compressedOmegaVector X))
+
+/-- If the square compression matrix has rank at most k, then the associated
+compressed maximally entangled vector has Schmidt rank at most k. -/
+theorem compressedOmegaVector_hasSchmidtRankLE_of_rank_le [NeZero D]
+    {X : Matrix (Fin D) (Fin D) ℂ} {k : ℕ} (hX : X.rank ≤ k) :
+    Matrix.HasSchmidtRankLE k (compressedOmegaVector X) := by
+  let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
+  have hDpos : 0 < (D : ℝ) := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hsqrt_ne : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
+    exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
+  have hc_ne : c ≠ 0 := by
+    simp [c, hsqrt_ne]
+  have hcoeff :
+      Matrix.schmidtCoeffMatrix (compressedOmegaVector X) = c • X := by
+    ext i j
+    simp [Matrix.schmidtCoeffMatrix, compressedOmegaVector, c]
+  have hrank :
+      (Matrix.schmidtCoeffMatrix (compressedOmegaVector X)).rank = X.rank := by
+    rw [hcoeff]
+    exact Matrix.rank_smul_of_ne_zero hc_ne X
+  simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank, hrank] using hX
+
+/-- Wolf's square-matrix parametrization of bounded Schmidt-rank vectors.
+When D is positive, a vector in $\mathbb{C}^D \otimes \mathbb{C}^D$ has Schmidt
+rank at most k if and only if it is obtained from the normalized maximally
+entangled vector by applying a square matrix of rank at most k on the right
+tensor factor. -/
+theorem hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector [NeZero D]
+    {k : ℕ} {ψ : Fin D × Fin D → ℂ} :
+    Matrix.HasSchmidtRankLE k ψ ↔
+      ∃ X : Matrix (Fin D) (Fin D) ℂ, X.rank ≤ k ∧ compressedOmegaVector X = ψ := by
+  constructor
+  · intro hψ
+    let c : ℂ := ((D : ℝ).sqrt : ℂ)
+    have hDpos : 0 < (D : ℝ) := by
+      exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+    have hc_ne : c ≠ 0 := by
+      dsimp [c]
+      exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
+    refine ⟨c • Matrix.schmidtCoeffMatrix ψ, ?_, ?_⟩
+    · have hrank :
+          (c • Matrix.schmidtCoeffMatrix ψ).rank =
+            (Matrix.schmidtCoeffMatrix ψ).rank :=
+        Matrix.rank_smul_of_ne_zero hc_ne (Matrix.schmidtCoeffMatrix ψ)
+      simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank, hrank] using hψ
+    · ext ip
+      rcases ip with ⟨i, j⟩
+      simp only [compressedOmegaVector, Matrix.smul_apply, Matrix.schmidtCoeffMatrix_apply,
+        smul_eq_mul]
+      field_simp [c, hc_ne]
+      simp [c]
+  · rintro ⟨X, hX, rfl⟩
+    exact compressedOmegaVector_hasSchmidtRankLE_of_rank_le hX
 
 /-- For the vector `compressedOmegaVector X`, the `k`-fold ampliation of the
 rank-one matrix $|\psi\rangle\langle\psi|$ by `T` is the right-factor Choi

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -289,6 +289,30 @@ maps.
     its rank is bounded by the number of columns, which is $k$.
 \end{proof}
 
+\begin{lemma}[Square parametrization of bounded Schmidt rank]
+    \label{lem:schmidt_rank_square_compressed_omega}
+    \lean{ChoiJamiolkowski.hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector}
+    \leanok
+    \uses{def:schmidt_rank, def:choi_right_compression}
+    Assume $D>0$.  A vector $\psi\in\C^D\otimes\C^D$ has Schmidt rank at most
+    $k$ if and only if there is a matrix $X\in\MD(\C)$ of rank at most $k$
+    such that
+    \[
+      \psi_{(i,j)}=D^{-1/2}X_{i,j}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The forward direction takes $X=D^{1/2}C_\psi$, where $C_\psi$ is the
+    coefficient matrix of $\psi$.  The reverse direction notes that
+    \[
+      C_\psi = D^{-1/2}X,
+    \]
+    so $\operatorname{rank}(C_\psi)=\operatorname{rank}(X)$, since
+    multiplication by a nonzero scalar preserves rank.
+\end{proof}
+
 \begin{lemma}[Rank-one ampliation as Choi compression]
     \label{lem:rank_one_ampliation_choi_compression}
     \lean{ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression}


### PR DESCRIPTION
### Motivation

Wolf Lecture Notes, Proposition 3.1, item 3 (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines about 101-114) uses the following parametrization step: a vector in `ℂ^D ⊗ ℂ^D` has Schmidt rank at most `k` exactly when it is obtained from the normalized maximally entangled vector by applying a square matrix of rank at most `k` on the right tensor factor.

This PR formalizes that parametrization step. It prepares the later proof of the full Schmidt-rank expectation criterion, but it does not prove that criterion.

### Description

- `TNLean/Channel/SchmidtRank.lean`: adds `Matrix.rank_smul_of_ne_zero`, proving that nonzero complex scalar multiplication preserves matrix rank.
- `TNLean/Channel/Schwarz/ChoiCompression.lean`: proves the square-matrix parametrization equivalence: for `D > 0`, `Matrix.HasSchmidtRankLE k ψ` iff there exists `X : Matrix (Fin D) (Fin D) ℂ` with `X.rank ≤ k` and `ψ = compressedOmegaVector X`.
- `blueprint/src/chapter/ch05_schwarz.tex`: records the parametrization as a blueprint lemma with a source-faithful proof sketch.

Refs LionSR/QICLean#172. The remaining theorem is still tracked there.

### Testing

- `lake env lean TNLean/Channel/SchmidtRank.lean`
- `lake env lean TNLean/Channel/Schwarz/ChoiCompression.lean`
- `lake build TNLean.Channel.Schwarz.ChoiCompression`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls` followed by `lake exe checkdecls blueprint/lean_decls`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|unsafeCast|admit" TNLean/Channel/SchmidtRank.lean TNLean/Channel/Schwarz/ChoiCompression.lean`