### PR TITLE
feat(Channel/Schwarz): add Schmidt-rank compression parametrization

### DIFF
--- a/TNLean/Channel/SchmidtRank.lean
+++ b/TNLean/Channel/SchmidtRank.lean
@@ -53,6 +53,30 @@ theorem schmidtCoeffMatrix_apply (ψ : m × n → ℂ) (i : m) (j : n) :
 
 variable [Fintype n]
 
+/-- Multiplying every entry of a matrix by a scalar cannot increase rank. -/
+theorem rank_smul_le (c : ℂ) (A : Matrix m n ℂ) : (c • A).rank ≤ A.rank := by
+  rw [Matrix.rank_eq_finrank_span_cols, Matrix.rank_eq_finrank_span_cols]
+  haveI : Module.Finite ℂ ↥(Submodule.span ℂ (Set.range A.col)) :=
+    Module.Finite.span_of_finite ℂ (Set.finite_range A.col)
+  refine Submodule.finrank_mono ?_
+  refine Submodule.span_le.mpr ?_
+  rintro _ ⟨j, rfl⟩
+  have hcol : (c • A).col j = c • A.col j := by
+    ext i
+    simp [Matrix.col_apply]
+  rw [hcol]
+  exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨j, rfl⟩)
+
+/-- Multiplying every entry of a matrix by a nonzero scalar preserves rank. -/
+theorem rank_smul_of_ne_zero {c : ℂ} (hc : c ≠ 0) (A : Matrix m n ℂ) :
+    (c • A).rank = A.rank := by
+  refine le_antisymm (rank_smul_le c A) ?_
+  have hle := rank_smul_le c⁻¹ (c • A)
+  have hmat : c⁻¹ • c • A = A := by
+    ext i j
+    simp [hc]
+  simpa [hmat] using hle
+
 /-- The Schmidt rank of a finite bipartite vector. -/
 noncomputable def schmidtRank (ψ : m × n → ℂ) : ℕ :=
   (schmidtCoeffMatrix ψ).rank

--- a/TNLean/Channel/SchmidtRank.lean
+++ b/TNLean/Channel/SchmidtRank.lean
@@ -54,10 +54,11 @@ theorem schmidtCoeffMatrix_apply (ψ : m × n → ℂ) (i : m) (j : n) :
 variable [Fintype n]
 
 /-- Multiplying every entry of a matrix by a scalar cannot increase rank. -/
-theorem rank_smul_le (c : ℂ) (A : Matrix m n ℂ) : (c • A).rank ≤ A.rank := by
+theorem rank_smul_le {K : Type*} [Field K] (c : K) (A : Matrix m n K) :
+    (c • A).rank ≤ A.rank := by
   rw [Matrix.rank_eq_finrank_span_cols, Matrix.rank_eq_finrank_span_cols]
-  haveI : Module.Finite ℂ ↥(Submodule.span ℂ (Set.range A.col)) :=
-    Module.Finite.span_of_finite ℂ (Set.finite_range A.col)
+  haveI : Module.Finite K ↥(Submodule.span K (Set.range A.col)) :=
+    Module.Finite.span_of_finite K (Set.finite_range A.col)
   refine Submodule.finrank_mono ?_
   refine Submodule.span_le.mpr ?_
   rintro _ ⟨j, rfl⟩
@@ -68,7 +69,8 @@ theorem rank_smul_le (c : ℂ) (A : Matrix m n ℂ) : (c • A).rank ≤ A.rank 
   exact Submodule.smul_mem _ _ (Submodule.subset_span ⟨j, rfl⟩)
 
 /-- Multiplying every entry of a matrix by a nonzero scalar preserves rank. -/
-theorem rank_smul_of_ne_zero {c : ℂ} (hc : c ≠ 0) (A : Matrix m n ℂ) :
+theorem rank_smul_of_ne_zero {K : Type*} [Field K] {c : K} (hc : c ≠ 0)
+    (A : Matrix m n K) :
     (c • A).rank = A.rank := by
   refine le_antisymm (rank_smul_le c A) ?_
   have hle := rank_smul_le c⁻¹ (c • A)

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -156,17 +156,13 @@ theorem exists_squareCompression_of_vector [NeZero D]
     exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
   have hsqrt_ne : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
     exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
-  refine ⟨X, ?_, ?_⟩
-  · ext ip
-    rcases ip with ⟨i, p⟩
-    simp only [compressedOmegaVector, X]
-    field_simp [hsqrt_ne]
-  · rw [← compressedOmegaVector_schmidtRank_eq_rank (X := X)]
-    congr
+  have hvec : compressedOmegaVector X = ψ := by
     ext ip
     rcases ip with ⟨i, p⟩
     simp only [compressedOmegaVector, X]
     field_simp [hsqrt_ne]
+  refine ⟨X, hvec, ?_⟩
+  simpa [hvec] using (compressedOmegaVector_schmidtRank_eq_rank (X := X)).symm
 
 /-- For `D > 0`, a square bipartite vector with Schmidt rank at most `r` has a
 square right-factor matrix representative of rank at most `r`. -/

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -34,6 +34,9 @@ the pair $(i,p)$.
   same compression is the sandwich by the right tensor factor.
 * `ChoiJamiolkowski.compressedOmegaVector_hasSchmidtRankLE`: the compressed
   maximally entangled vector has Schmidt rank at most the compression dimension.
+* `ChoiJamiolkowski.exists_squareCompression_of_hasSchmidtRankLE`: every
+  square bipartite vector of bounded Schmidt rank comes from a square
+  right-factor compression with the same rank bound.
 * `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`:
   `k`-positivity is equivalent to positivity of all rectangular right-factor
   Choi compressions.
@@ -112,6 +115,25 @@ noncomputable def compressedOmegaVector (X : Matrix (Fin D) (Fin k) ℂ) :
     Fin D × Fin k → ℂ :=
   fun ip => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * X ip.1 ip.2
 
+/-- For `D > 0`, the compressed maximally entangled vector has Schmidt rank
+equal to the rank of the right-factor matrix. -/
+theorem compressedOmegaVector_schmidtRank_eq_rank [NeZero D]
+    (X : Matrix (Fin D) (Fin k) ℂ) :
+    Matrix.schmidtRank (compressedOmegaVector X) = X.rank := by
+  have hDpos : 0 < (D : ℝ) := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hc : ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) ≠ 0 := by
+    have hsqrt_ne : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
+      exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
+    exact div_ne_zero one_ne_zero hsqrt_ne
+  have hcoeff :
+      Matrix.schmidtCoeffMatrix (compressedOmegaVector X) =
+        ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) • X := by
+    ext i p
+    simp [Matrix.schmidtCoeffMatrix, compressedOmegaVector]
+  rw [Matrix.schmidtRank, hcoeff]
+  exact Matrix.rank_smul_of_ne_zero hc X
+
 /-- The vector obtained by applying a `D × k` matrix on the right tensor factor
 of the maximally entangled vector has Schmidt rank at most `k`. -/
 theorem compressedOmegaVector_hasSchmidtRankLE
@@ -120,6 +142,40 @@ theorem compressedOmegaVector_hasSchmidtRankLE
   simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank, Matrix.schmidtCoeffMatrix,
     compressedOmegaVector] using
     Matrix.rank_le_card_width (Matrix.schmidtCoeffMatrix (compressedOmegaVector X))
+
+/-- For `D > 0`, every vector in $\mathbb{C}^D\otimes\mathbb{C}^D$ is obtained
+from the maximally entangled vector by applying a square right-factor matrix,
+and the matrix rank agrees with the Schmidt rank of the vector. -/
+theorem exists_squareCompression_of_vector [NeZero D]
+    (ψ : Fin D × Fin D → ℂ) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      compressedOmegaVector X = ψ ∧ X.rank = Matrix.schmidtRank ψ := by
+  let X : Matrix (Fin D) (Fin D) ℂ :=
+    fun a p => (((D : ℝ).sqrt : ℂ)) * ψ (a, p)
+  have hDpos : 0 < (D : ℝ) := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hsqrt_ne : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
+    exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
+  refine ⟨X, ?_, ?_⟩
+  · ext ip
+    rcases ip with ⟨i, p⟩
+    simp only [compressedOmegaVector, X]
+    field_simp [hsqrt_ne]
+  · rw [← compressedOmegaVector_schmidtRank_eq_rank (X := X)]
+    congr
+    ext ip
+    rcases ip with ⟨i, p⟩
+    simp only [compressedOmegaVector, X]
+    field_simp [hsqrt_ne]
+
+/-- For `D > 0`, a square bipartite vector with Schmidt rank at most `r` has a
+square right-factor matrix representative of rank at most `r`. -/
+theorem exists_squareCompression_of_hasSchmidtRankLE [NeZero D]
+    {r : ℕ} {ψ : Fin D × Fin D → ℂ} (hψ : Matrix.HasSchmidtRankLE r ψ) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      compressedOmegaVector X = ψ ∧ X.rank ≤ r := by
+  obtain ⟨X, hXvec, hXrank⟩ := exists_squareCompression_of_vector (D := D) ψ
+  exact ⟨X, hXvec, hXrank.trans_le hψ⟩
 
 /-- For the vector `compressedOmegaVector X`, the `k`-fold ampliation of the
 rank-one matrix $|\psi\rangle\langle\psi|$ by `T` is the right-factor Choi

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -289,6 +289,55 @@ maps.
     its rank is bounded by the number of columns, which is $k$.
 \end{proof}
 
+\begin{theorem}[Rank of a compressed maximally entangled vector]
+    \label{thm:compressed_omega_schmidt_rank_eq_rank}
+    \lean{ChoiJamiolkowski.compressedOmegaVector_schmidtRank_eq_rank}
+    \leanok
+    \uses{def:schmidt_rank, def:choi_right_compression}
+    Assume $D>0$.  For $X\in\MN{D,k}(\C)$, the vector
+    \[
+      \psi_X=\left(D^{-1/2}X_{i,p}\right)_{(i,p)}
+      \in \C^D\otimes\C^k
+    \]
+    satisfies
+    \[
+      \operatorname{SR}(\psi_X)=\rank X.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The coefficient matrix of $\psi_X$ is $D^{-1/2}X$.  Since $D>0$, the
+    scalar $D^{-1/2}$ is nonzero, and multiplication by this scalar preserves
+    rank.
+\end{proof}
+
+\begin{theorem}[Square Schmidt-rank parametrization]
+    \label{thm:square_schmidt_rank_parametrization}
+    \lean{ChoiJamiolkowski.exists_squareCompression_of_vector,
+        ChoiJamiolkowski.exists_squareCompression_of_hasSchmidtRankLE}
+    \leanok
+    \uses{def:schmidt_rank, def:choi_right_compression,
+        thm:compressed_omega_schmidt_rank_eq_rank}
+    Assume $D>0$.  For every $\psi\in\C^D\otimes\C^D$ there is
+    $X\in\MN{D}(\C)$ such that
+    \[
+      \psi_{(i,p)}=D^{-1/2}X_{i,p}
+      \quad\text{and}\quad
+      \rank X=\operatorname{SR}(\psi).
+    \]
+    In particular, if $\operatorname{SR}(\psi)\le r$, then $X$ may be chosen
+    with $\rank X\le r$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take $X_{i,p}=D^{1/2}\psi_{(i,p)}$.  Since $D>0$, this gives
+    $D^{-1/2}X_{i,p}=\psi_{(i,p)}$.  The rank identity follows from
+    Theorem~\ref{thm:compressed_omega_schmidt_rank_eq_rank}.  The bounded-rank
+    statement follows by comparison with the assumed Schmidt-rank bound.
+\end{proof}
+
 \begin{lemma}[Rank-one ampliation as Choi compression]
     \label{lem:rank_one_ampliation_choi_compression}
     \lean{ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression}


### PR DESCRIPTION
### Motivation

- Wolf Proposition 3.1 (item 3; `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~89-115) characterizes k-positivity by the condition ⟨ψ|τ|ψ⟩ ≥ 0 for all ψ ∈ ℂ^D ⊗ ℂ^D of Schmidt rank at most k, where τ is the Choi-Jamiolkowski operator.
- This PR proves the rank parametrization step used in that argument: a square bipartite vector can be written in the normalized form `D^{-1/2}X`, with the matrix rank matching its Schmidt rank.
- The scalar expectation equivalence with the Choi matrix is still a later theorem.

### Description

- `TNLean/Channel/SchmidtRank.lean`: added scalar-rank lemmas for complex matrices.
- `TNLean/Channel/Schwarz/ChoiCompression.lean`: proved that the compressed maximally entangled vector associated to `X` has Schmidt rank equal to `rank X`; proved that every square bipartite vector is represented by a square right-factor matrix with matching rank and rank bounded by any Schmidt-rank bound.
- `blueprint/src/chapter/ch05_schwarz.tex`: added blueprint entries for these two results in the Schwarz chapter.

### Testing

- `lake build TNLean.Channel.Schwarz.ChoiCompression`
- `lake build`
- `leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

---
Refs LionSR/QICLean#172.
Refs LionSR/QICLean#24.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and blueprint only; no runtime, auth, or API surface—localized to Schmidt rank and Choi compression proofs.
> 
> **Overview**
> Adds **Schmidt rank ↔ matrix rank** identities for Wolf’s `D^{-1/2}X` right-factor compression, plus generalized scalar rank lemmas and matching blueprint text.
> 
> **`Matrix.rank_smul_le`** and a refactored **`rank_smul_of_ne_zero`** now work over any field `K`, not only `ℂ`, via column-span monotonicity instead of the old `mulVecLin` range argument.
> 
> **Choi compression:** **`compressedOmegaVector_schmidtRank_eq_rank`** shows Schmidt rank equals `X.rank` when `D > 0`. **`exists_squareCompression_of_vector`** and **`exists_squareCompression_of_hasSchmidtRankLE`** build a square `X` with `D^{1/2}ψ` so vector and rank match (bounded case included). **`hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector`** and rank-le corollaries are shortened to call these lemmas.
> 
> **Blueprint (`ch05_schwarz.tex`):** new theorems for exact compressed-ω Schmidt rank and square parametrization; the bounded Schmidt-rank lemma proof now cites them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58df38713f9a4058051b4a9145be5b6e330ff114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

