### PR TITLE
feat(Channel/Schwarz): add exact Schmidt-rank compression

### DIFF
--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -34,6 +34,9 @@ the pair $(i,p)$.
   same compression is the sandwich by the right tensor factor.
 * `ChoiJamiolkowski.compressedOmegaVector_hasSchmidtRankLE`: the compressed
   maximally entangled vector has Schmidt rank at most the compression dimension.
+* `ChoiJamiolkowski.compressedOmegaVector_schmidtRank_eq_rank`: the compressed
+  maximally entangled vector has Schmidt rank equal to the rank of the
+  right-factor matrix.
 * `ChoiJamiolkowski.hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector`:
   Wolf's square-matrix parametrization of vectors of bounded Schmidt rank.
 * `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`:
@@ -114,6 +117,25 @@ noncomputable def compressedOmegaVector (X : Matrix (Fin D) (Fin k) ℂ) :
     Fin D × Fin k → ℂ :=
   fun ip => ((1 : ℂ) / ((D : ℝ).sqrt : ℂ)) * X ip.1 ip.2
 
+/-- For `D > 0`, the compressed maximally entangled vector has Schmidt rank
+equal to the rank of the right-factor matrix. -/
+theorem compressedOmegaVector_schmidtRank_eq_rank [NeZero D]
+    (X : Matrix (Fin D) (Fin k) ℂ) :
+    Matrix.schmidtRank (compressedOmegaVector X) = X.rank := by
+  let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
+  have hDpos : 0 < (D : ℝ) := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hsqrt_ne : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
+    exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
+  have hc_ne : c ≠ 0 := by
+    simp [c, hsqrt_ne]
+  have hcoeff :
+      Matrix.schmidtCoeffMatrix (compressedOmegaVector X) = c • X := by
+    ext i p
+    simp [Matrix.schmidtCoeffMatrix, compressedOmegaVector, c]
+  rw [Matrix.schmidtRank, hcoeff]
+  exact Matrix.rank_smul_of_ne_zero hc_ne X
+
 /-- The vector obtained by applying a `D × k` matrix on the right tensor factor
 of the maximally entangled vector has Schmidt rank at most `k`. -/
 theorem compressedOmegaVector_hasSchmidtRankLE
@@ -128,22 +150,37 @@ compressed maximally entangled vector has Schmidt rank at most k. -/
 theorem compressedOmegaVector_hasSchmidtRankLE_of_rank_le [NeZero D]
     {X : Matrix (Fin D) (Fin D) ℂ} {k : ℕ} (hX : X.rank ≤ k) :
     Matrix.HasSchmidtRankLE k (compressedOmegaVector X) := by
-  let c : ℂ := (1 : ℂ) / ((D : ℝ).sqrt : ℂ)
+  simpa [Matrix.HasSchmidtRankLE, compressedOmegaVector_schmidtRank_eq_rank] using hX
+
+/-- For `D > 0`, every vector in $\mathbb{C}^D\otimes\mathbb{C}^D$ is obtained
+from the maximally entangled vector by applying a square right-factor matrix,
+and the matrix rank agrees with the Schmidt rank of the vector. -/
+theorem exists_squareCompression_of_vector [NeZero D]
+    (ψ : Fin D × Fin D → ℂ) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      compressedOmegaVector X = ψ ∧ X.rank = Matrix.schmidtRank ψ := by
+  let X : Matrix (Fin D) (Fin D) ℂ :=
+    fun a p => (((D : ℝ).sqrt : ℂ)) * ψ (a, p)
   have hDpos : 0 < (D : ℝ) := by
     exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
   have hsqrt_ne : ((D : ℝ).sqrt : ℂ) ≠ 0 := by
     exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
-  have hc_ne : c ≠ 0 := by
-    simp [c, hsqrt_ne]
-  have hcoeff :
-      Matrix.schmidtCoeffMatrix (compressedOmegaVector X) = c • X := by
-    ext i j
-    simp [Matrix.schmidtCoeffMatrix, compressedOmegaVector, c]
-  have hrank :
-      (Matrix.schmidtCoeffMatrix (compressedOmegaVector X)).rank = X.rank := by
-    rw [hcoeff]
-    exact Matrix.rank_smul_of_ne_zero hc_ne X
-  simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank, hrank] using hX
+  have hvec : compressedOmegaVector X = ψ := by
+    ext ip
+    rcases ip with ⟨i, p⟩
+    simp only [compressedOmegaVector, X]
+    field_simp [hsqrt_ne]
+  refine ⟨X, hvec, ?_⟩
+  simpa [hvec] using (compressedOmegaVector_schmidtRank_eq_rank (X := X)).symm
+
+/-- For `D > 0`, a square bipartite vector with Schmidt rank at most `r` has a
+square right-factor matrix representative of rank at most `r`. -/
+theorem exists_squareCompression_of_hasSchmidtRankLE [NeZero D]
+    {r : ℕ} {ψ : Fin D × Fin D → ℂ} (hψ : Matrix.HasSchmidtRankLE r ψ) :
+    ∃ X : Matrix (Fin D) (Fin D) ℂ,
+      compressedOmegaVector X = ψ ∧ X.rank ≤ r := by
+  obtain ⟨X, hXvec, hXrank⟩ := exists_squareCompression_of_vector (D := D) ψ
+  exact ⟨X, hXvec, hXrank.trans_le hψ⟩
 
 /-- Wolf's square-matrix parametrization of bounded Schmidt-rank vectors.
 When D is positive, a vector in $\mathbb{C}^D \otimes \mathbb{C}^D$ has Schmidt
@@ -156,24 +193,9 @@ theorem hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector [NeZero D]
       ∃ X : Matrix (Fin D) (Fin D) ℂ, X.rank ≤ k ∧ compressedOmegaVector X = ψ := by
   constructor
   · intro hψ
-    let c : ℂ := ((D : ℝ).sqrt : ℂ)
-    have hDpos : 0 < (D : ℝ) := by
-      exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
-    have hc_ne : c ≠ 0 := by
-      dsimp [c]
-      exact_mod_cast (Real.sqrt_ne_zero'.mpr hDpos)
-    refine ⟨c • Matrix.schmidtCoeffMatrix ψ, ?_, ?_⟩
-    · have hrank :
-          (c • Matrix.schmidtCoeffMatrix ψ).rank =
-            (Matrix.schmidtCoeffMatrix ψ).rank :=
-        Matrix.rank_smul_of_ne_zero hc_ne (Matrix.schmidtCoeffMatrix ψ)
-      simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank, hrank] using hψ
-    · ext ip
-      rcases ip with ⟨i, j⟩
-      simp only [compressedOmegaVector, Matrix.smul_apply, Matrix.schmidtCoeffMatrix_apply,
-        smul_eq_mul]
-      field_simp [c, hc_ne]
-      simp [c]
+    obtain ⟨X, hXvec, hXrank⟩ := exists_squareCompression_of_hasSchmidtRankLE
+      (D := D) hψ
+    exact ⟨X, hXrank, hXvec⟩
   · rintro ⟨X, hX, rfl⟩
     exact compressedOmegaVector_hasSchmidtRankLE_of_rank_le hX
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -289,11 +289,61 @@ maps.
     its rank is bounded by the number of columns, which is $k$.
 \end{proof}
 
+\begin{theorem}[Rank of a compressed maximally entangled vector]
+    \label{thm:compressed_omega_schmidt_rank_eq_rank}
+    \lean{ChoiJamiolkowski.compressedOmegaVector_schmidtRank_eq_rank}
+    \leanok
+    \uses{def:schmidt_rank, def:choi_right_compression}
+    Assume $D>0$.  For $X\in\MN{D,k}(\C)$, the vector
+    \[
+      \psi_X=\left(D^{-1/2}X_{i,p}\right)_{(i,p)}
+      \in \C^D\otimes\C^k
+    \]
+    satisfies
+    \[
+      \operatorname{SR}(\psi_X)=\rank X.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The coefficient matrix of $\psi_X$ is $D^{-1/2}X$.  Since $D>0$, the
+    scalar $D^{-1/2}$ is nonzero, and multiplication by this scalar preserves
+    rank.
+\end{proof}
+
+\begin{theorem}[Square representative with exact Schmidt rank]
+    \label{thm:square_schmidt_rank_exact_parametrization}
+    \lean{ChoiJamiolkowski.exists_squareCompression_of_vector,
+        ChoiJamiolkowski.exists_squareCompression_of_hasSchmidtRankLE}
+    \leanok
+    \uses{def:schmidt_rank, def:choi_right_compression,
+        thm:compressed_omega_schmidt_rank_eq_rank}
+    Assume $D>0$.  For every $\psi\in\C^D\otimes\C^D$ there is
+    $X\in\MN{D}(\C)$ such that
+    \[
+      \psi_{(i,p)}=D^{-1/2}X_{i,p}
+      \quad\text{and}\quad
+      \rank X=\operatorname{SR}(\psi).
+    \]
+    In particular, if $\operatorname{SR}(\psi)\le r$, then $X$ may be chosen
+    with $\rank X\le r$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Take $X_{i,p}=D^{1/2}\psi_{(i,p)}$.  Since $D>0$, this gives
+    $D^{-1/2}X_{i,p}=\psi_{(i,p)}$.  The rank identity follows from
+    Theorem~\ref{thm:compressed_omega_schmidt_rank_eq_rank}.  The bounded-rank
+    statement follows by comparison with the assumed Schmidt-rank bound.
+\end{proof}
+
 \begin{lemma}[Square parametrization of bounded Schmidt rank]
     \label{lem:schmidt_rank_square_compressed_omega}
     \lean{ChoiJamiolkowski.hasSchmidtRankLE_iff_exists_rank_le_compressedOmegaVector}
     \leanok
-    \uses{def:schmidt_rank, def:choi_right_compression}
+    \uses{def:schmidt_rank, def:choi_right_compression,
+        thm:square_schmidt_rank_exact_parametrization}
     Assume $D>0$.  A vector $\psi\in\C^D\otimes\C^D$ has Schmidt rank at most
     $k$ if and only if there is a matrix $X\in\MD(\C)$ of rank at most $k$
     such that
@@ -304,8 +354,9 @@ maps.
 
 \begin{proof}
     \leanok
-    The forward direction takes $X=D^{1/2}C_\psi$, where $C_\psi$ is the
-    coefficient matrix of $\psi$.  The reverse direction notes that
+    The forward direction is the bounded-rank part of
+    Theorem~\ref{thm:square_schmidt_rank_exact_parametrization}.  Conversely,
+    if $\psi_{(i,j)}=D^{-1/2}X_{i,j}$, then the coefficient matrix of $\psi$ is
     \[
       C_\psi = D^{-1/2}X,
     \]


### PR DESCRIPTION
### Motivation

- Wolf Proposition 3.1 (`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~89-115) parametrizes bounded-Schmidt-rank vectors by right-factor compressions of the normalized maximally entangled vector: $\psi$ has Schmidt rank at most $k$ if and only if $\psi = (1 \otimes X)|\Omega\rangle$ for some $X \in M_D(\mathbb{C})$ of rank at most $k$.
- PR LionSR/TNLean#3443 formalized the bounded-rank existence equivalence; this PR adds the sharper rank computation: the compressed vector has Schmidt rank exactly equal to the rank of the right-factor matrix $X$.
- The full scalar expectation criterion in Wolf Proposition 3.1 remains a separate step: one still has to identify $\langle \psi,\tau\psi\rangle$ with the corresponding Choi-compression quadratic form and combine this with the positivity criterion.

### Description

- Adds `ChoiJamiolkowski.compressedOmegaVector_schmidtRank_eq_rank`: for `D > 0`, the vector with coefficients `D^{-1/2} X_{i,p}` has Schmidt rank `X.rank`.
- Adds exact square representatives for arbitrary square bipartite vectors, including a bounded-rank corollary.
- Reformulates the existing square bounded-rank parametrization theorem to use the exact representative.
- Updates `blueprint/src/chapter/ch05_schwarz.tex` with the exact-rank theorem and exact representative theorem.
- Supersedes PR LionSR/TNLean#3444, which was a stale duplicate based before LionSR/TNLean#3443.

### Testing

- `lake exe cache get && lake build TNLean.Channel.Schwarz.ChoiCompression`
- `lake env lean TNLean/Channel/Schwarz/ChoiCompression.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `rg -n "sorry|axiom|native_decide|unsafeCast|admit" TNLean/Channel/Schwarz/ChoiCompression.lean || true`

---
Refs LionSR/QICLean#172.
Refs LionSR/QICLean#24.
