### PR TITLE
feat(Channel/Schwarz): add Schmidt-rank Choi expectation test

### DIFF
--- a/TNLean/Channel/SchmidtRank.lean
+++ b/TNLean/Channel/SchmidtRank.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
 import Mathlib.Data.Complex.Basic
+import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.LinearAlgebra.Matrix.Rank
 
 /-!
@@ -29,6 +30,8 @@ bounded Schmidt rank.
 * `Matrix.schmidtRank_le_left`, `Matrix.schmidtRank_le_right`: dimension bounds.
 * `Matrix.schmidtRank_zero`: the zero vector has Schmidt rank zero.
 * `Matrix.schmidtRank_product_le_one`: product vectors have Schmidt rank at most one.
+* `Matrix.exists_mul_eq_of_rank_le`: a matrix of rank at most `k` factors
+  through a `k`-dimensional coordinate space.
 * `Matrix.rank_smul_of_ne_zero`: nonzero complex rescaling preserves matrix rank.
 
 ## References
@@ -67,6 +70,30 @@ theorem rank_smul_of_ne_zero {c : ℂ} (hc : c ≠ 0) (A : Matrix m n ℂ) :
     · rintro ⟨x, rfl⟩
       exact ⟨c⁻¹ • x, by simp [hc]⟩
   rw [Matrix.rank, Matrix.rank, hrange]
+
+/-- A matrix whose rank is at most `k` factors through `ℂ^k`. -/
+theorem exists_mul_eq_of_rank_le
+    (A : Matrix m n ℂ) {k : ℕ}
+    (hA : A.rank ≤ k) :
+    ∃ B : Matrix m (Fin k) ℂ, ∃ C : Matrix (Fin k) n ℂ, B * C = A := by
+  classical
+  let f : (n → ℂ) →ₗ[ℂ] m → ℂ := Matrix.toLin' A
+  have hrange_dim : Module.finrank ℂ (LinearMap.range f) ≤ Module.finrank ℂ (Fin k → ℂ) := by
+    have hf : f = A.mulVecLin := rfl
+    rw [hf]
+    simpa [Matrix.rank, Module.finrank_pi] using hA
+  obtain ⟨e, he⟩ := (finrank_le_iff_exists_linearMap
+    (R := ℂ) (M := LinearMap.range f) (M' := Fin k → ℂ)).mp hrange_dim
+  have heker : LinearMap.ker e = ⊥ := LinearMap.ker_eq_bot.mpr he
+  let g : (n → ℂ) →ₗ[ℂ] Fin k → ℂ := e.comp f.rangeRestrict
+  let h : (Fin k → ℂ) →ₗ[ℂ] m → ℂ := (LinearMap.range f).subtype.comp e.leftInverse
+  refine ⟨LinearMap.toMatrix' h, LinearMap.toMatrix' g, ?_⟩
+  rw [← LinearMap.toMatrix'_comp]
+  suffices h.comp g = Matrix.toLin' A by
+    simpa using congrArg LinearMap.toMatrix' this
+  change h.comp g = f
+  ext x i
+  simp [f, g, h, LinearMap.leftInverse_apply_of_inj heker]
 
 /-- The Schmidt rank of a finite bipartite vector. -/
 noncomputable def schmidtRank (ψ : m × n → ℂ) : ℕ :=

--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -5,6 +5,7 @@ Authors: Sirui Lu
 -/
 import TNLean.Channel.SchmidtRank
 import TNLean.Channel.Schwarz.TwoPositive
+import Mathlib.Analysis.InnerProductSpace.Positive
 
 /-!
 # Choi compression for the rank-one test
@@ -51,6 +52,43 @@ the pair $(i,p)$.
 
 open scoped Matrix BigOperators ComplexOrder
 open Matrix Finset
+
+namespace Matrix
+
+/-- Over a finite complex coordinate space, nonnegativity of all matrix
+quadratic forms already implies positive semidefiniteness.  The Hermitian part
+is recovered by the complex polarization identity. -/
+theorem posSemidef_of_dotProduct_mulVec_nonneg_complex
+    {n : Type*} [Fintype n] {M : Matrix n n ℂ}
+    (hM : ∀ x : n → ℂ, (0 : ℂ) ≤ star x ⬝ᵥ (M *ᵥ x)) : M.PosSemidef := by
+  classical
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ hM
+  rw [← Matrix.isSymmetric_toEuclideanLin_iff]
+  have hpos : (Matrix.toEuclideanLin M).IsPositive := by
+    rw [LinearMap.isPositive_iff_complex]
+    intro x
+    have hx_nonneg : (0 : ℂ) ≤ star x.ofLp ⬝ᵥ (M *ᵥ x.ofLp) := hM x.ofLp
+    have hx_real :
+        star (star x.ofLp ⬝ᵥ (M *ᵥ x.ofLp)) =
+          star x.ofLp ⬝ᵥ (M *ᵥ x.ofLp) := by
+      rw [RCLike.star_def]
+      exact RCLike.conj_eq_iff_im.mpr (RCLike.nonneg_iff.mp hx_nonneg).2
+    have hinner :
+        inner ℂ ((Matrix.toEuclideanLin M) x) x =
+          star (star x.ofLp ⬝ᵥ (M *ᵥ x.ofLp)) := by
+      change inner ℂ (((Matrix.toLpLin 2 2) M) x) x =
+        star (star x.ofLp ⬝ᵥ (M *ᵥ x.ofLp))
+      rw [Matrix.toLpLin_apply, EuclideanSpace.inner_eq_star_dotProduct]
+      rw [dotProduct_comm]
+      simp [dotProduct, mul_comm]
+    constructor
+    · rw [hinner, hx_real]
+      exact RCLike.conj_eq_iff_re.mp (by simpa [RCLike.star_def] using hx_real)
+    · rw [hinner, hx_real]
+      exact (RCLike.nonneg_iff.mp hx_nonneg).1
+  exact hpos.isSymmetric
+
+end Matrix
 
 namespace ChoiJamiolkowski
 
@@ -110,6 +148,98 @@ theorem rightTensorMatrix_mul_choiMatrix_mul_conjTranspose
   · intro x _ hx
     simp [Ne.symm hx]
   · simp
+
+/-- The quadratic form of the Choi sandwich by the right tensor factor is the
+Choi quadratic form evaluated on the pulled-back vector. -/
+theorem rightTensor_choiMatrix_quadraticForm_eq
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+    star η ⬝ᵥ
+        ((rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ) *ᵥ η) =
+      star ((rightTensorMatrix X)ᴴ *ᵥ η) ⬝ᵥ
+        (choiMatrix T *ᵥ ((rightTensorMatrix X)ᴴ *ᵥ η)) := by
+  have hmul :
+      ((rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ) *ᵥ η) =
+        rightTensorMatrix X *ᵥ
+          (choiMatrix T *ᵥ ((rightTensorMatrix X)ᴴ *ᵥ η)) := by
+    simp [Matrix.mulVec_mulVec, Matrix.mul_assoc]
+  have hstar :
+      star ((rightTensorMatrix X)ᴴ *ᵥ η) = star η ᵥ* rightTensorMatrix X := by
+    rw [Matrix.star_mulVec, Matrix.conjTranspose_conjTranspose]
+  rw [hmul, Matrix.dotProduct_mulVec, ← hstar]
+
+/-- The quadratic form of the right-factor compression is the Choi quadratic
+form evaluated on the vector pulled back by the adjoint right tensor factor. -/
+theorem rightCompression_quadraticForm_eq_choiMatrix_quadraticForm
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+    star η ⬝ᵥ (rightCompression T X *ᵥ η) =
+      star ((rightTensorMatrix X)ᴴ *ᵥ η) ⬝ᵥ
+        (choiMatrix T *ᵥ ((rightTensorMatrix X)ᴴ *ᵥ η)) := by
+  rw [← rightTensorMatrix_mul_choiMatrix_mul_conjTranspose (T := T) (X := X)]
+  exact rightTensor_choiMatrix_quadraticForm_eq T X η
+
+/-- The coefficient matrix of the vector pulled back by the adjoint right
+tensor factor is the product of the coefficient matrix of the compressed vector
+with the adjoint of the right-factor matrix. -/
+theorem schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec
+    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+    Matrix.schmidtCoeffMatrix ((rightTensorMatrix X)ᴴ *ᵥ η) =
+      Matrix.schmidtCoeffMatrix η * Xᴴ := by
+  classical
+  ext j a
+  simp only [Matrix.schmidtCoeffMatrix, Matrix.mulVec, dotProduct, Matrix.mul_apply,
+    rightTensorMatrix, Matrix.conjTranspose_apply, Fintype.sum_prod_type]
+  rw [Finset.sum_eq_single j]
+  · simp [mul_comm]
+  · intro i _ hij
+    simp [hij]
+  · simp
+
+/-- Pulling a vector back by the adjoint right tensor factor gives a vector of
+Schmidt rank at most the compression dimension. -/
+theorem rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE
+    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+    Matrix.HasSchmidtRankLE k ((rightTensorMatrix X)ᴴ *ᵥ η) := by
+  have hrank : (Matrix.schmidtCoeffMatrix ((rightTensorMatrix X)ᴴ *ᵥ η)).rank ≤ k := by
+    rw [schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec]
+    calc
+      (Matrix.schmidtCoeffMatrix η * Xᴴ).rank ≤ (Xᴴ).rank :=
+        Matrix.rank_mul_le_right (Matrix.schmidtCoeffMatrix η) Xᴴ
+      _ = X.rank := Matrix.rank_conjTranspose X
+      _ ≤ Fintype.card (Fin k) := Matrix.rank_le_card_width X
+      _ = k := by simp
+  simpa [Matrix.HasSchmidtRankLE, Matrix.schmidtRank] using hrank
+
+/-- Every vector of Schmidt rank at most `k` is obtained by pulling back a
+vector in the `D × k` compressed space through the adjoint of a right tensor
+factor. -/
+theorem exists_rightTensorMatrix_conjTranspose_mulVec_of_hasSchmidtRankLE
+    {ψ : Fin D × Fin D → ℂ} (hψ : Matrix.HasSchmidtRankLE k ψ) :
+    ∃ X : Matrix (Fin D) (Fin k) ℂ, ∃ η : Fin D × Fin k → ℂ,
+      (rightTensorMatrix X)ᴴ *ᵥ η = ψ := by
+  classical
+  let A : Matrix (Fin D) (Fin D) ℂ := Matrix.schmidtCoeffMatrix ψ
+  have hA : A.rank ≤ k := by
+    simpa [A, Matrix.HasSchmidtRankLE, Matrix.schmidtRank] using hψ
+  obtain ⟨B, C, hBC⟩ := Matrix.exists_mul_eq_of_rank_le A hA
+  let X : Matrix (Fin D) (Fin k) ℂ := Cᴴ
+  let η : Fin D × Fin k → ℂ := fun ip => B ip.1 ip.2
+  refine ⟨X, η, ?_⟩
+  ext ip
+  rcases ip with ⟨j, a⟩
+  calc
+    ((rightTensorMatrix X)ᴴ *ᵥ η) (j, a)
+        = Matrix.schmidtCoeffMatrix ((rightTensorMatrix X)ᴴ *ᵥ η) j a := rfl
+    _ = (B * C) j a := by
+        rw [schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec]
+        have hηcoeff : Matrix.schmidtCoeffMatrix η = B := by
+          ext i p
+          rfl
+        rw [hηcoeff]
+        simp only [X, Matrix.conjTranspose_conjTranspose]
+    _ = A j a := by rw [hBC]
+    _ = ψ (j, a) := rfl
 
 /-- The coefficient vector obtained from the normalized maximally entangled
 vector by applying `X` on the right tensor factor. -/
@@ -284,6 +414,21 @@ theorem isNPositiveMap_iff_forall_rightCompression_posSemidef [NeZero D]
     rw [nPositiveAmpliation_rankOne_eq_rightCompression]
     exact hX X
 
+/-- Converse Schmidt-rank test for Wolf's Choi criterion.  If all
+Schmidt-rank-`≤ k` vectors have nonnegative Choi quadratic form, then the map
+is `k`-positive. -/
+theorem isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hψ : ∀ ψ : Fin D × Fin D → ℂ, Matrix.HasSchmidtRankLE k ψ →
+      (0 : ℂ) ≤ star ψ ⬝ᵥ (choiMatrix T *ᵥ ψ)) :
+    IsNPositiveMap k T := by
+  rw [isNPositiveMap_iff_forall_rightCompression_posSemidef]
+  intro X
+  refine Matrix.posSemidef_of_dotProduct_mulVec_nonneg_complex ?_
+  intro η
+  rw [rightCompression_quadraticForm_eq_choiMatrix_quadraticForm (T := T) (X := X) (η := η)]
+  exact hψ _ (rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE X η)
+
 /-- A `k`-positive map has positive Choi sandwiches by every right tensor
 factor `X : M_{D,k}(\mathbb{C})`.  This is the forward implication of the
 projection-compression formulation before requiring that `X` comes from a
@@ -294,5 +439,36 @@ theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef [NeZero D]
     (rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ).PosSemidef := by
   rw [rightTensorMatrix_mul_choiMatrix_mul_conjTranspose]
   exact (isNPositiveMap_iff_forall_rightCompression_posSemidef k T).mp hT X
+
+/-- Forward direction of Wolf's Schmidt-rank expectation criterion.  If `T` is
+`k`-positive, then the Choi quadratic form is nonnegative on every vector of
+Schmidt rank at most `k`. -/
+theorem IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsNPositiveMap k T) {ψ : Fin D × Fin D → ℂ}
+    (hψ : Matrix.HasSchmidtRankLE k ψ) :
+    0 ≤ star ψ ⬝ᵥ (choiMatrix T *ᵥ ψ) := by
+  obtain ⟨X, η, hη⟩ :=
+    exists_rightTensorMatrix_conjTranspose_mulVec_of_hasSchmidtRankLE (D := D) hψ
+  have hcomp : (rightCompression T X).PosSemidef :=
+    (isNPositiveMap_iff_forall_rightCompression_posSemidef k T).mp hT X
+  have hq := hcomp.dotProduct_mulVec_nonneg η
+  rw [rightCompression_quadraticForm_eq_choiMatrix_quadraticForm] at hq
+  simpa [hη] using hq
+
+/-- Schmidt-rank expectation criterion for Wolf's Choi matrix:
+`k`-positivity is equivalent to nonnegativity of the Choi quadratic form on all
+vectors of Schmidt rank at most `k`. -/
+theorem isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} :
+    IsNPositiveMap k T ↔
+      ∀ ψ : Fin D × Fin D → ℂ, Matrix.HasSchmidtRankLE k ψ →
+        (0 : ℂ) ≤ star ψ ⬝ᵥ (choiMatrix T *ᵥ ψ) := by
+  constructor
+  · intro hT ψ hψ
+    exact IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE hT hψ
+  · intro hψ
+    exact isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg hψ
 
 end ChoiJamiolkowski

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -189,6 +189,22 @@ maps.
     $\operatorname{SR}(\psi)\le l$.
 \end{lemma}
 
+\begin{lemma}[Rank factorization through a coordinate space]
+    \label{lem:matrix_rank_factorization_coordinate}
+    \lean{Matrix.exists_mul_eq_of_rank_le}
+    \leanok
+    If $A\in\MN{m,n}(\C)$ has rank at most $k$, then there are matrices
+    $B\in\MN{m,k}(\C)$ and $C\in\MN{k,n}(\C)$ such that $BC=A$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The range of the linear map represented by $A$ has dimension at most $k$.
+    Embed this range into $\C^k$, compose with the range map, and then map
+    back to the ambient codomain.  The corresponding matrices give the desired
+    factorization.
+\end{proof}
+
 \begin{theorem}[Rank-one test for $k$-positivity]\label{thm:k_positive_rank_one_test}
     \lean{isNPositiveMap_iff_forall_ampliation_rank_one_posSemidef}
     \leanok
@@ -362,6 +378,147 @@ maps.
     \]
     so $\operatorname{rank}(C_\psi)=\operatorname{rank}(X)$, since
     multiplication by a nonzero scalar preserves rank.
+\end{proof}
+
+\begin{lemma}[Schmidt rank under the adjoint right tensor factor]
+    \label{lem:right_tensor_adjoint_schmidt_rank}
+    \lean{ChoiJamiolkowski.schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec,
+        ChoiJamiolkowski.rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE}
+    \leanok
+    \uses{def:schmidt_rank, def:choi_right_tensor_factor}
+    Let $X\in\MN{D,k}(\C)$ and let $\eta\in\C^D\otimes\C^k$.  Then
+    $R_X^\dagger\eta\in\C^D\otimes\C^D$ has Schmidt rank at most $k$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    If $\eta$ is read as a $D\times k$ coefficient matrix $E$, then the
+    coefficient matrix of $R_X^\dagger\eta$ is $EX^\dagger$.  Therefore
+    \[
+        \rank(EX^\dagger)\le \rank(X^\dagger)=\rank(X)\le k.
+    \]
+\end{proof}
+
+\begin{lemma}[Right-tensor representatives of bounded Schmidt rank]
+    \label{lem:right_tensor_adjoint_schmidt_rank_representatives}
+    \lean{ChoiJamiolkowski.exists_rightTensorMatrix_conjTranspose_mulVec_of_hasSchmidtRankLE}
+    \leanok
+    \uses{def:schmidt_rank, def:choi_right_tensor_factor,
+        lem:matrix_rank_factorization_coordinate}
+    If $\psi\in\C^D\otimes\C^D$ has Schmidt rank at most $k$, then there
+    exist $X\in\MN{D,k}(\C)$ and $\eta\in\C^D\otimes\C^k$ such that
+    \[
+      \psi=R_X^\dagger\eta .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Let $C_\psi$ be the coefficient matrix of $\psi$.  The rank assumption
+    gives a factorisation $C_\psi=BC$ through $\C^k$.  Taking
+    $X=C^\dagger$ and reading $B$ as the coefficient matrix of $\eta$ gives
+    the required identity, because the coefficient matrix of
+    $R_X^\dagger\eta$ is $BX^\dagger=BC$.
+\end{proof}
+
+\begin{theorem}[Quadratic form of a right Choi compression]
+    \label{thm:choi_right_compression_quadratic_form}
+    \lean{ChoiJamiolkowski.rightTensor_choiMatrix_quadraticForm_eq,
+        ChoiJamiolkowski.rightCompression_quadraticForm_eq_choiMatrix_quadraticForm}
+    \leanok
+    \uses{def:choi_right_compression, def:choi_right_tensor_factor,
+        thm:choi_right_tensor_sandwich}
+    For $X\in\MN{D,k}(\C)$ and $\eta\in\C^D\otimes\C^k$,
+    \[
+      \langle \eta, C_T(X)\eta\rangle
+      =
+      \langle R_X^\dagger\eta,\tau_T R_X^\dagger\eta\rangle .
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The sandwich identity gives $C_T(X)=R_X\tau_T R_X^\dagger$.  Hence
+    \[
+      \langle\eta,R_X\tau_T R_X^\dagger\eta\rangle
+      =
+      \langle R_X^\dagger\eta,\tau_T R_X^\dagger\eta\rangle .
+    \]
+\end{proof}
+
+\begin{theorem}[Schmidt-rank Choi expectation from \(k\)-positivity]
+    \label{thm:k_positive_schmidt_rank_choi_expectation}
+    \lean{ChoiJamiolkowski.IsNPositiveMap.choiMatrix_quadraticForm_nonneg_of_hasSchmidtRankLE}
+    \leanok
+    \uses{lem:right_tensor_adjoint_schmidt_rank_representatives,
+        thm:choi_right_compression_quadratic_form,
+        thm:k_positive_iff_right_choi_compressions}
+    Assume $D>0$.  If $T$ is $k$-positive, then
+    \[
+      \langle\psi,\tau_T\psi\rangle\ge 0
+    \]
+    for every $\psi\in\C^D\otimes\C^D$ with
+    $\operatorname{SR}(\psi)\le k$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write $\psi=R_X^\dagger\eta$ using
+    Lemma~\ref{lem:right_tensor_adjoint_schmidt_rank_representatives}.  By
+    Theorem~\ref{thm:k_positive_iff_right_choi_compressions}, the
+    compression $C_T(X)$ is positive semidefinite.  Its quadratic form at
+    $\eta$ is therefore nonnegative, and
+    Theorem~\ref{thm:choi_right_compression_quadratic_form} identifies this
+    number with $\langle\psi,\tau_T\psi\rangle$.
+\end{proof}
+
+\begin{theorem}[Converse Schmidt-rank Choi test]
+    \label{thm:schmidt_rank_choi_test_converse}
+    \lean{ChoiJamiolkowski.isNPositiveMap_of_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg}
+    \leanok
+    \uses{lem:right_tensor_adjoint_schmidt_rank,
+        thm:choi_right_compression_quadratic_form,
+        thm:k_positive_iff_right_choi_compressions}
+    Assume $D>0$.  If
+    \[
+      \langle\psi,\tau_T\psi\rangle\ge 0
+    \]
+    for every $\psi\in\C^D\otimes\C^D$ with
+    $\operatorname{SR}(\psi)\le k$, then $T$ is $k$-positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By Theorem~\ref{thm:k_positive_iff_right_choi_compressions}, it is enough
+    to prove that $C_T(X)$ is positive semidefinite for each
+    $X\in\MN{D,k}(\C)$.  For any $\eta$, the quadratic-form identity identifies
+    $\langle\eta,C_T(X)\eta\rangle$ with
+    $\langle R_X^\dagger\eta,\tau_T R_X^\dagger\eta\rangle$, and
+    Lemma~\ref{lem:right_tensor_adjoint_schmidt_rank} gives
+    $\operatorname{SR}(R_X^\dagger\eta)\le k$.  Thus every quadratic form of
+    $C_T(X)$ is nonnegative.  Over a complex finite-dimensional space,
+    polarization recovers Hermiticity from this real nonnegative quadratic
+    form condition, so $C_T(X)$ is positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Schmidt-rank Choi criterion]
+    \label{thm:schmidt_rank_choi_test_iff}
+    \lean{ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg}
+    \leanok
+    \uses{thm:k_positive_schmidt_rank_choi_expectation,
+        thm:schmidt_rank_choi_test_converse}
+    Assume $D>0$.  Then $T$ is $k$-positive if and only if
+    \[
+      \langle\psi,\tau_T\psi\rangle\ge 0
+    \]
+    for every $\psi\in\C^D\otimes\C^D$ with
+    $\operatorname{SR}(\psi)\le k$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Combine Theorem~\ref{thm:k_positive_schmidt_rank_choi_expectation} with
+    Theorem~\ref{thm:schmidt_rank_choi_test_converse}.
 \end{proof}
 
 \begin{lemma}[Rank-one ampliation as Choi compression]


### PR DESCRIPTION
### Motivation

- Formalizes the Schmidt-rank expectation characterization in Wolf Proposition 3.1: a map `T` is `k`-positive if and only if the Choi quadratic form is nonnegative on every vector of Schmidt rank at most `k`.
- Continues the Choi-compression formalization after LionSR/TNLean#3438 and the Schmidt-rank infrastructure from LionSR/TNLean#3432.

### Description

- `TNLean/Channel/SchmidtRank.lean`: adds a rank factorization lemma showing that any matrix of rank at most `k` factors through `ℂ^k`.
- `TNLean/Channel/Schwarz/ChoiCompression.lean`: proves the right-tensor adjoint coefficient computation, the bounded-Schmidt-rank pullback representation, and the right-compression Choi quadratic-form identity.
- Uses the complex polarization criterion for positivity to prove the converse direction without an extra Hermiticity hypothesis, giving the full Schmidt-rank Choi criterion.
- `blueprint/src/chapter/ch05_schwarz.tex`: records the new statements with `\lean{}` and `\leanok` tags.

### Testing

- `lake build TNLean.Channel.SchmidtRank TNLean.Channel.Schwarz.ChoiCompression`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|unsafeCast|admit" TNLean/Channel/SchmidtRank.lean TNLean/Channel/Schwarz/ChoiCompression.lean || true`

---
Addresses LionSR/QICLean#172

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib formalization and LaTeX blueprint sync; no runtime, auth, or data-path changes. Risk is limited to proof correctness in existing channel theory modules.
> 
> **Overview**
> Adds Wolf Proposition 3.1’s **Schmidt-rank Choi test**: for `D > 0`, `k`-positivity is equivalent to nonnegativity of the Choi quadratic form on every bipartite vector with Schmidt rank ≤ `k`.
> 
> **Lean:** `Matrix.exists_mul_eq_of_rank_le` factors low-rank matrices through `ℂ^k`. In `ChoiCompression.lean`, new lemmas tie right-tensor pullback to Schmidt coefficients (`schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec`), bound pullback rank, and represent any bounded–Schmidt-rank vector as `R_X† η`. Quadratic-form identities link right Choi compression to the full Choi matrix. The converse direction uses new `Matrix.posSemidef_of_dotProduct_mulVec_nonneg_complex` (polarization, no extra Hermiticity hypothesis). The biconditional is `isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg`.
> 
> **Blueprint:** `ch05_schwarz.tex` documents rank factorization, adjoint right-tensor Schmidt lemmas, compression quadratic forms, and the forward/converse/iff Schmidt-rank Choi theorems with `\leanok` tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73677e51326a7ccd1528e2503a96344203567250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->