### PR TITLE
doc(parent): retire stale normal range tracker references

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -122,7 +122,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -220,7 +220,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -284,7 +284,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -381,7 +381,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -512,7 +512,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -940,7 +940,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
@@ -56,7 +56,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -833,7 +833,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -911,7 +911,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -82,7 +82,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -288,7 +288,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -390,7 +390,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -472,7 +472,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -545,7 +545,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -628,7 +628,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -703,7 +703,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -559,7 +559,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -648,7 +648,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -740,7 +740,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -824,7 +824,7 @@ Elimination: derive the normalized BNT product-span input
 coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
 (per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
 `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency; tracked in issue 2405. -/
+dependency. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
+++ b/docs/paper-gaps/cpgsv21_normal_range_reduction.tex
@@ -24,9 +24,9 @@ range-reduction comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/588}{issue \#588}; the
 periodic-boundary comparison is recorded in
 \href{https://github.com/LionSR/TNLean/issues/2368}{issue \#2368}; its current
-coordinate form is recorded in
-\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}; the
-length-$L_0$ trace-probe step was isolated in
+coordinate form was tracked by
+\href{https://github.com/LionSR/TNLean/issues/2405}{issue \#2405}, now closed
+after the length-$L_0$ trace-probe step isolated in
 \href{https://github.com/LionSR/TNLean/issues/2929}{issue \#2929};
 and the parent-Hamiltonian consequences are recorded in
 \href{https://github.com/LionSR/TNLean/issues/460}{issue \#460}.}


### PR DESCRIPTION
### Motivation

- Issue #2405 (periodic-boundary closure-property comparison for the normal range-reduction branch) closed on main, but **Unfaithful** docstring markers in the block-diagonal parent-Hamiltonian files still cited it as an active dependency, creating a misleading tracking reference.
- The paper-gap note `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` described #2405 as the active elimination route; the length-$L_0$ trace-probe work is complete and credited to #2929.
- These markers are updated to point at the paper-gap note directly rather than the closed issue. The PGVWC07 boundary-comparison problem tracked by #2971 remains open.

### Description

- In five block-diagonal parent-Hamiltonian files, updated **Unfaithful** docstring elimination text to remove `#2405` as an active dependency and redirect to `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`:
  - `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`
  - `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean`
  - `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`
  - `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`
  - `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`
- Updated `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` to record #2405 as a closed historical route (length-$L_0$ trace-probe step in #2929) rather than the active tracker.
- No proofs, types, or Lean APIs change; all edits are docstring and paper-gap prose only.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

---
Addresses #2971
Refs #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and paper-gap prose only; no Lean proofs or APIs change.
> 
> **Overview**
> Documentation-only alignment after **issue #2405** closed: **Unfaithful** docstrings on block-diagonal parent-Hamiltonian theorems no longer say that discharging `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1` is **tracked in issue 2405**. The elimination text still points at deriving `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the paper-gap note `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`.
> 
> The same one-line edit appears across **BNTBlockDiagonalChain**, **Boundary**, **Crossing**, **PGVWCComparison**, and **TraceDecomposition** (many theorem doc blocks; no proof or type changes).
> 
> `docs/paper-gaps/cpgsv21_normal_range_reduction.tex` now describes #2405 as a **closed** historical route, tied to the length-\(L_0\) trace-probe work in **#2929**, instead of listing it as the active coordinate-form tracker.
> 
> Open **#2971** periodic-boundary / PGVWC comparison markers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc37743ccfcf17c62b248730a6aaee1f0fa5d224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->