### PR TITLE
feat(MPS/RFP): expose Appendix B cyclic coefficient

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -384,6 +384,19 @@ theorem AppendixBStructuralData.mpv_eq_coreTensor {A : MPSTensor d D}
     mpv A σ = mpv hStruct.coreTensor σ :=
   (GaugeEquiv.sameMPV hStruct.gaugeEquiv_coreTensor N σ).symm
 
+/-- The original tensor has the Appendix B cyclic basic-vector coefficient.
+
+Source: arXiv:1606.00608, lines 543--555.
+
+This combines the gauge-invariance of MPV coefficients with the coefficient
+formula for the core tensor \(\Lambda U^i\).  The conclusion is the source
+cyclic virtual-pair expression, not the disjoint adjacent physical-pair
+condition used later in the conditional parent-Hamiltonian theorem. -/
+theorem AppendixBStructuralData.mpv_eq_cyclicVirtualPairState {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) {L : ℕ} (hL : 0 < L) (σ : Cfg d L) :
+    mpv A σ = hStruct.cyclicVirtualPairState hL σ := by
+  rw [hStruct.mpv_eq_coreTensor σ, hStruct.mpv_coreTensor_eq_cyclicVirtualPairState hL σ]
+
 /-- The structural two-site amplitude is exactly the two-site MPV coefficient. -/
 theorem AppendixBStructuralData.twoSiteAmplitude_eq_mpv {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) (σ : Cfg d 2) :

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -808,6 +808,7 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.gaugeEquiv_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.groundSpace_eq_coreTensor}
     \lean{MPSTensor.AppendixBStructuralData.mpv_eq_coreTensor}
+    \lean{MPSTensor.AppendixBStructuralData.mpv_eq_cyclicVirtualPairState}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_mpv}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteAmplitude_eq_coreTensor_mpv}
     \lean{MPSTensor.AppendixBStructuralData.mpv_coreTensor_eq_productPairState_one}
@@ -870,6 +871,11 @@ the specialization $L=2$.
     periodic MPS coefficients:
     \[
         G_L(A)=G_L(\Lambda U).
+    \]
+    Consequently, for every chain length \(L\geq1\), the original tensor has
+    the same cyclic coefficient formula:
+    \[
+        V^{(L)}(A)_\sigma=C_L(\sigma).
     \]
     In particular, the corresponding two-site amplitude is
     \[

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -120,6 +120,15 @@ which is the coefficient form of
 \(\varphi_j\) shared between \(b_t\) and \(a_{t+1}\).  The disjoint adjacent
 physical-pair condition used by the current conditional parent-Hamiltonian
 theorem is therefore a separate statement, not the source expression itself.
+The formal development proves this cyclic coefficient formula for the original
+tensor after the Appendix~B change of basis, for every nonempty chain length
+and a chosen structural datum:
+\[
+  V^{(L)}(A)_\sigma=C_L(\sigma).
+\]
+This is the declaration
+\leanid{MPSTensor.AppendixBStructuralData.mpv_eq_cyclicVirtualPairState}.  It
+does not prove the disjoint adjacent physical-pair condition.
 
 There is still no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus
 the formal theorems record only a separate isometry condition for each block;


### PR DESCRIPTION
### Motivation
- Continues the Appendix B source formalization (arXiv:1606.00608, lines 543–555) by transporting the cyclic virtual-pair coefficient formula from the core tensor $\Lambda U$ to the original tensor $A$; the equation $V^{(L)}(A)_\sigma = C_L(\sigma)$ was missing from the parent-Hamiltonian blueprint entry (see #3372).
- The CPSV16 RFP isometry gap note requires updating to distinguish the proved cyclic source coefficient from the disjoint adjacent physical-pair condition, which is a separate obligation.

### Description
- `TNLean/MPS/RFP/CommutingBridge.lean`: adds `MPSTensor.AppendixBStructuralData.mpv_eq_cyclicVirtualPairState`, proving that the periodic MPS coefficients of the original tensor $A$ equal the cyclic virtual-pair expression, via gauge invariance and the existing core-tensor formula.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: records the equation $V^{(L)}(A)_\sigma = C_L(\sigma)$ in the parent-Hamiltonian blueprint.
- `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`: updates the CPSV16 RFP isometry gap note to separate the proved cyclic source coefficient from the disjoint adjacent physical-pair factorization condition.
- Does not prove the positive even-chain adjacent-pair factorization and does not construct the Appendix D.2 projectors $Q_{AX}$ and $Q_{XB}$; those remain separate mathematical obligations.

### Testing
- `lake env lean TNLean/MPS/RFP/CommutingBridge.lean`
- `lake build TNLean.MPS.RFP.CommutingBridge`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `git diff --check`

---
Addresses #3372

> [!NOTE]
> **Low Risk**
> Small additive formal lemma plus blueprint and gap-note prose; no changes to auth, data paths, or the conditional extraction hypotheses.
>
> **Overview**
> Adds **`MPSTensor.AppendixBStructuralData.mpv_eq_cyclicVirtualPairState`**, showing that after choosing Appendix B structural data, periodic coefficients of the **original** tensor `A` equal the source **cyclic virtual-pair** expression `cyclicVirtualPairState` (via gauge invariance and the existing core-tensor formula).
>
> The parent-Hamiltonian blueprint and the CPSV16 RFP isometry scope note now record **`V^{(L)}(A)_\sigma = C_L(\sigma)`** and stress that this is **not** the disjoint adjacent physical-pair factorization used in the conditional NNCPH bridge.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d031b11aa2e063a820b280ac67d6777163d3b8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal lemma and documentation only; no changes to extraction hypotheses, auth, or runtime behavior.
> 
> **Overview**
> Adds **`AppendixBStructuralData.mpv_eq_cyclicVirtualPairState`**, showing that for chosen Appendix B structural data and any **nonempty** chain length, periodic MPS coefficients of the **original** tensor `A` equal the source **cyclic virtual-pair** expression (via `mpv_eq_coreTensor` and the existing core-tensor formula).
> 
> The parent-Hamiltonian blueprint now states **`V^{(L)}(A)_\sigma = C_L(\sigma)`** and links the new Lean declaration. The CPSV16 RFP isometry scope note records the same proved fact and reiterates that it is **not** the disjoint adjacent physical-pair factorization used in the conditional NNCPH bridge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f82e60c2fa8f9f2d3230604dba32c6a264cb6fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->