### PR TITLE
feat(Channel/Schwarz): add factorized Choi projections

### DIFF
--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -128,6 +128,24 @@ noncomputable def rightTensorMatrix (X : Matrix (Fin D) (Fin k) ℂ) :
     Matrix (Fin D × Fin k) (Fin D × Fin D) ℂ :=
   Matrix.of fun ip ja => if ip.1 = ja.1 then X ja.2 ip.2 else 0
 
+/-- The right-tensor matrix for `X * Xᴴ` factors as `R_Xᴴ * R_X` in the
+index convention used for Choi compression. -/
+theorem rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self
+    (X : Matrix (Fin D) (Fin k) ℂ) :
+    rightTensorMatrix (X * Xᴴ) = (rightTensorMatrix X)ᴴ * rightTensorMatrix X := by
+  classical
+  ext ⟨i, a⟩ ⟨j, b⟩
+  by_cases hij : i = j
+  · subst j
+    simp only [rightTensorMatrix, Matrix.of_apply, Matrix.mul_apply, Matrix.conjTranspose_apply,
+      if_true]
+    rw [Fintype.sum_prod_type]
+    simp [mul_comm]
+  · simp only [rightTensorMatrix, Matrix.of_apply, Matrix.mul_apply, Matrix.conjTranspose_apply]
+    rw [Fintype.sum_prod_type]
+    have hji : ¬j = i := fun hji => hij hji.symm
+    simp [hij, hji]
+
 /-- Sandwiching the Choi matrix by the right tensor factor gives exactly the
 right-factor compression entries.  In Wolf's notation this is the identity
 between $(\mathbf{1}\otimes X)\tau(\mathbf{1}\otimes X)^\dagger$ and the
@@ -439,6 +457,33 @@ theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef [NeZero D]
     (rightTensorMatrix X * choiMatrix T * (rightTensorMatrix X)ᴴ).PosSemidef := by
   rw [rightTensorMatrix_mul_choiMatrix_mul_conjTranspose]
   exact (isNPositiveMap_iff_forall_rightCompression_posSemidef k T).mp hT X
+
+/-- If a right-factor matrix `P` is presented as `V * Vᴴ`, then its Choi
+sandwich is a compression of the rectangular Choi sandwich for `V`. -/
+theorem rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (V : Matrix (Fin D) (Fin k) ℂ) :
+    rightTensorMatrix (V * Vᴴ) * choiMatrix T * (rightTensorMatrix (V * Vᴴ))ᴴ =
+      (rightTensorMatrix V)ᴴ *
+        (rightTensorMatrix V * choiMatrix T * (rightTensorMatrix V)ᴴ) *
+          rightTensorMatrix V := by
+  rw [rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self]
+  simp [Matrix.mul_assoc]
+
+/-- If a right-factor matrix has the form `V * Vᴴ`, then the corresponding
+Choi sandwich is positive semidefinite. To recover the full statement of Wolf,
+Proposition 3.1, item 2, for an arbitrary rank-`k` orthogonal projection `P`,
+one additionally needs a factorization `P = V * Vᴴ`. -/
+theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hT : IsNPositiveMap k T) (V : Matrix (Fin D) (Fin k) ℂ) :
+    (rightTensorMatrix (V * Vᴴ) * choiMatrix T *
+      (rightTensorMatrix (V * Vᴴ))ᴴ).PosSemidef := by
+  rw [rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq]
+  exact
+    (IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef hT V).conjTranspose_mul_mul_same
+      (rightTensorMatrix V)
 
 /-- Forward direction of Wolf's Schmidt-rank expectation criterion.  If `T` is
 `k`-positive, then the Choi quadratic form is nonnegative on every vector of

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -611,6 +611,77 @@ maps.
     $R_X\tau R_X^\dagger$ with $C_T(X)$.
 \end{proof}
 
+\begin{lemma}[Right-tensor factorization for $VV^\dagger$]
+    \label{lem:right_tensor_factorization_mul_adjoint}
+    \lean{ChoiJamiolkowski.rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self}
+    \leanok
+    \uses{def:choi_right_tensor_factor}
+    For every $V\in\MN{D,k}(\C)$, the right-tensor factor satisfies
+    \[
+      R_{VV^\dagger}=R_V^\dagger R_V.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is the entrywise calculation obtained by expanding the definition of
+    $R_V$ and summing over the middle physical index.
+\end{proof}
+
+\begin{lemma}[Factorized right-tensor Choi sandwich]
+    \label{lem:factorized_right_tensor_choi_sandwich}
+    \lean{ChoiJamiolkowski.rightTensorMatrix_mul_conjTranspose_choi_sandwich_eq}
+    \leanok
+    \uses{def:choi_right_tensor_factor,
+        lem:right_tensor_factorization_mul_adjoint}
+    Let $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ have Choi matrix $\tau$.  For every
+    $V\in\MN{D,k}(\C)$,
+    \[
+      R_{VV^\dagger}\tau R_{VV^\dagger}^\dagger
+      =
+      R_V^\dagger(R_V\tau R_V^\dagger)R_V.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Substitute Lemma~\ref{lem:right_tensor_factorization_mul_adjoint} on the
+    left and reassociate the three matrix products.
+\end{proof}
+
+\begin{theorem}[Factorized right projections in the Choi criterion]
+    \label{thm:factorized_right_projection_choi_sandwich}
+    \lean{ChoiJamiolkowski.IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose}
+    \leanok
+    \uses{lem:factorized_right_tensor_choi_sandwich,
+        thm:k_positive_right_tensor_choi_sandwiches}
+    Assume $D>0$.  Let $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ be $k$-positive,
+    with Choi matrix $\tau$.  If a right-factor matrix has the form
+    $P=VV^\dagger$ with $V\in\MN{D,k}(\C)$, then
+    \[
+      R_P\tau R_P^\dagger\geq0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    In the right-tensor convention one has
+    \[
+      R_{VV^\dagger}=R_V^\dagger R_V.
+    \]
+    Therefore
+    \[
+      R_{VV^\dagger}\tau R_{VV^\dagger}^\dagger
+      =R_V^\dagger(R_V\tau R_V^\dagger)R_V.
+    \]
+    The middle factor is positive by
+    Theorem~\ref{thm:k_positive_right_tensor_choi_sandwiches}, and positive
+    semidefiniteness is preserved under compression by $R_V$.
+    % The full rank-$k$ projection form of
+    % \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum} requires a separate
+    % factorization of arbitrary rank-$k$ orthogonal projections.
+\end{proof}
+
 \begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}
     \lean{Matrix.traceAdjointMap}
     \leanok


### PR DESCRIPTION
### Motivation

- Formalizes the factorized-projection case of Wolf Proposition 3.1, item 2 (source: `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~89–115): a map $T : M_D(\mathbb{C}) \to M_D(\mathbb{C})$ is $k$-positive if and only if $(\mathbf{1} \otimes P)\,\tau\,(\mathbf{1} \otimes P) \geq 0$ for every rank-$k$ Hermitian projection $P$.
- When $P = VV^\dagger$ for a partial isometry $V$ with $V^\dagger V = I_k$, the right-tensor Choi factor satisfies $R_{VV^\dagger} = R_V^\dagger R_V$, so the sandwich reduces to the rectangular compression already covered by `isNPositiveMap_iff_forall_rightCompression_posSemidef` (PR LionSR/TNLean#3438).
- Continues formalization of Wolf Chapter 3 positivity criteria; see LionSR/QICLean#171.

### Description

- `TNLean/Channel/Schwarz/ChoiCompression.lean`: adds lemmas proving $R_{VV^\dagger} = R_V^\dagger R_V$ in the Choi-compression index convention and the sandwich identity $R_{VV^\dagger}\,\tau\,R_{VV^\dagger}^\dagger = R_V^\dagger(R_V\,\tau\,R_V^\dagger)R_V$; deduces positive semidefiniteness of the factorized sandwich from `PosSemidef.conjTranspose_mul_mul_same`.
- `blueprint/src/chapter/ch05_schwarz.tex`: adds blueprint entry for the factorized case, noting that factoring an arbitrary rank-$k$ Hermitian projection as $P = VV^\dagger$ remains the open step for the full projection formulation of LionSR/QICLean#171.
- Does not close LionSR/QICLean#171: the polar-decomposition direction (arbitrary $X : M_{D,k}(\mathbb{C})$ factors through a rank-$k$ projection) is the remaining step.

### Testing

- `lake env lean TNLean/Channel/Schwarz/ChoiCompression.lean`
- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `git diff --check`

---
Addresses LionSR/QICLean#171

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization in Choi compression theory with no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Formalizes the **factorized projection** case of Wolf Choi criterion (Prop. 3.1, item 2): when the right factor is **P = VV†** instead of a general rectangular **X**, the Choi sandwich is still positive for **k**-positive **T**.
> 
> New Lean lemmas show **R_{VV†} = R_V† R_V** and rewrite **R_P τ R_P†** as **R_V† (R_V τ R_V†) R_V**, then obtain PSD from the existing rectangular sandwich theorem plus **PosSemidef.conjTranspose_mul_mul_same**. Docstrings note that an arbitrary rank-**k** Hermitian projection still needs a separate **P = VV†** factorization to match Wolf fully.
> 
> The Schwarz chapter blueprint gains matching lemma/theorem entries and states that the general rank-**k** projection form remains open (#3439).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 320a7131c29ddc7ac7fc78e0ab8690d8c9a81491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->