### PR TITLE
doc(blueprint/examples): add Majumdar-Ghosh dimer ground-space theorem target

### DIFF
--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -687,8 +687,8 @@ formalized, and it is not asserted here independently of that machinery.
     On an even periodic chain of length $N = 2m$ the parent Hamiltonian of the
     Majumdar--Ghosh tensor has a two-dimensional ground space, spanned by the two
     nearest-neighbour singlet coverings $(1,2)(3,4)\cdots(N-1,N)$ and
-    $(2,3)(4,5)\cdots(N,1)$.  The two-fold degeneracy is the symmetry-broken
-    dimerization of the spin-$\tfrac12$ chain
+    $(2,3)(4,5)\cdots(N,1)$.  This two-fold degeneracy reflects the
+    symmetry-broken dimerization of the spin-$\tfrac12$ chain
     $H=\sum \boldsymbol{S}_i\cdot\boldsymbol{S}_{i+1}
     +\tfrac12\sum\boldsymbol{S}_i\cdot\boldsymbol{S}_{i+2}$
     of \cite{Cirac2021Matrix}.
@@ -696,9 +696,9 @@ formalized, and it is not asserted here independently of that machinery.
 
 \begin{remark}\label{rem:majumdar_ghosh_ground_space_dependency}
     Theorem~\ref{thm:majumdar_ghosh_ground_space} is marked
-    \verb|\notready| and carries no \lean{} or \leanok tag: it depends on the
-    periodic block-diagonal ground-space description for non-normal tensors,
-    whose general form is developed in
+    \verb|\notready| and carries no \verb|\lean| or \verb|\leanok| tag: it
+    depends on the periodic block-diagonal ground-space description for
+    non-normal tensors, whose general form is developed in
     Section~\ref{sec:block_diagonal_boundary_closing} and is not yet specialized
     to the two-periodic Majumdar--Ghosh grading.  The degeneracy count must be
     derived from that description; it is recorded here as a target only and is not

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -698,13 +698,6 @@ periodic ground-space statement.
     of \cite{Cirac2021Matrix}.
 \end{theorem}
 
-\begin{remark}\label{rem:majumdar_ghosh_ground_space_dependency}
-    The theorem is a target statement.  Its proof should specialize the periodic
-    block-diagonal ground-space description from
-    Section~\ref{sec:block_diagonal_boundary_closing} to the two-periodic
-    Majumdar--Ghosh grading.
-\end{remark}
-
 %% ===================================================================
 \section{The W state}\label{sec:w_state}
 %% ===================================================================

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -681,6 +681,7 @@ formalized, and it is not asserted here independently of that machinery.
 
 \begin{theorem}[Two-fold dimer degeneracy of the Majumdar--Ghosh ground space]%
 \label{thm:majumdar_ghosh_ground_space}
+    \notready
     \uses{def:majumdar_ghosh_tensor, thm:majumdar_ghosh_not_normal,
         def:ground_space_parent}
     On an even periodic chain of length $N = 2m$ the parent Hamiltonian of the
@@ -694,9 +695,10 @@ formalized, and it is not asserted here independently of that machinery.
 \end{theorem}
 
 \begin{remark}\label{rem:majumdar_ghosh_ground_space_dependency}
-    Theorem~\ref{thm:majumdar_ghosh_ground_space} carries no \lean{} or \leanok
-    tag: it depends on the periodic block-diagonal ground-space description for
-    non-normal tensors, whose general form is developed in
+    Theorem~\ref{thm:majumdar_ghosh_ground_space} is marked
+    \verb|\notready| and carries no \lean{} or \leanok tag: it depends on the
+    periodic block-diagonal ground-space description for non-normal tensors,
+    whose general form is developed in
     Section~\ref{sec:block_diagonal_boundary_closing} and is not yet specialized
     to the two-periodic Majumdar--Ghosh grading.  The degeneracy count must be
     derived from that description; it is recorded here as a target only and is not

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -698,10 +698,12 @@ periodic ground-space statement.
     of \cite{Cirac2021Matrix}.
 \end{theorem}
 
-% This target is deliberately marked \notready and carries no \lean or \leanok
-% tag.  The proof should specialize the periodic block-diagonal ground-space
-% description from Section~\ref{sec:block_diagonal_boundary_closing} to the
-% two-periodic Majumdar--Ghosh grading.
+\begin{remark}\label{rem:majumdar_ghosh_ground_space_dependency}
+    The theorem is a target statement.  Its proof should specialize the periodic
+    block-diagonal ground-space description from
+    Section~\ref{sec:block_diagonal_boundary_closing} to the two-periodic
+    Majumdar--Ghosh grading.
+\end{remark}
 
 %% ===================================================================
 \section{The W state}\label{sec:w_state}

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -670,6 +670,39 @@ resonating valence-bond state.
     recorded in \path{docs/paper-gaps/rmp_majumdar_ghosh_tensor_gap.tex}.
 \end{remark}
 
+The remaining target for the Majumdar--Ghosh example is the ground-space
+description of its parent Hamiltonian.  Because the tensor is non-normal
+(Theorem~\ref{thm:majumdar_ghosh_not_normal}) with a two-periodic bond grading,
+its periodic ground space is governed by the block-diagonal boundary-condition
+machinery for non-normal tensors
+(Section~\ref{sec:block_diagonal_boundary_closing}) rather than by the injective
+single-state result.  The statement below is the expected target; it is not yet
+formalized, and it is not asserted here independently of that machinery.
+
+\begin{theorem}[Two-fold dimer degeneracy of the Majumdar--Ghosh ground space]%
+\label{thm:majumdar_ghosh_ground_space}
+    \uses{def:majumdar_ghosh_tensor, thm:majumdar_ghosh_not_normal,
+        def:ground_space_parent}
+    On an even periodic chain of length $N = 2m$ the parent Hamiltonian of the
+    Majumdar--Ghosh tensor has a two-dimensional ground space, spanned by the two
+    nearest-neighbour singlet coverings $(1,2)(3,4)\cdots(N-1,N)$ and
+    $(2,3)(4,5)\cdots(N,1)$.  The two-fold degeneracy is the symmetry-broken
+    dimerization of the spin-$\tfrac12$ chain
+    $H=\sum \boldsymbol{S}_i\cdot\boldsymbol{S}_{i+1}
+    +\tfrac12\sum\boldsymbol{S}_i\cdot\boldsymbol{S}_{i+2}$
+    of \cite{Cirac2021Matrix}.
+\end{theorem}
+
+\begin{remark}\label{rem:majumdar_ghosh_ground_space_dependency}
+    Theorem~\ref{thm:majumdar_ghosh_ground_space} carries no \lean{} or \leanok
+    tag: it depends on the periodic block-diagonal ground-space description for
+    non-normal tensors, whose general form is developed in
+    Section~\ref{sec:block_diagonal_boundary_closing} and is not yet specialized
+    to the two-periodic Majumdar--Ghosh grading.  The degeneracy count must be
+    derived from that description; it is recorded here as a target only and is not
+    asserted until the parent-Hamiltonian ground space supports it.
+\end{remark}
+
 %% ===================================================================
 \section{The W state}\label{sec:w_state}
 %% ===================================================================

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -676,34 +676,32 @@ description of its parent Hamiltonian.  Because the tensor is non-normal
 its periodic ground space is governed by the block-diagonal boundary-condition
 machinery for non-normal tensors
 (Section~\ref{sec:block_diagonal_boundary_closing}) rather than by the injective
-single-state result.  The statement below is the expected target; it is not yet
-formalized, and it is not asserted here independently of that machinery.
+single-state result.  Thus the relevant target is the following range-three
+periodic ground-space statement.
 
 \begin{theorem}[Two-fold dimer degeneracy of the Majumdar--Ghosh ground space]%
 \label{thm:majumdar_ghosh_ground_space}
     \notready
     \uses{def:majumdar_ghosh_tensor, thm:majumdar_ghosh_not_normal,
         def:ground_space_parent}
-    On an even periodic chain of length $N = 2m$ the parent Hamiltonian of the
-    Majumdar--Ghosh tensor has a two-dimensional ground space, spanned by the two
-    nearest-neighbour singlet coverings $(1,2)(3,4)\cdots(N-1,N)$ and
-    $(2,3)(4,5)\cdots(N,1)$.  This two-fold degeneracy reflects the
-    symmetry-broken dimerization of the spin-$\tfrac12$ chain
+    On an even periodic chain of length $N = 2m\ge4$, let
+    $H_{N,\mathrm{MG}}^{(3)}$ be the range-three parent Hamiltonian of the
+    Majumdar--Ghosh tensor, the periodic sum of translates of the local
+    projector with kernel $\mathcal G_3(A_{\mathrm{MG}})$.  Then
+    $H_{N,\mathrm{MG}}^{(3)}$ has a two-dimensional ground space, spanned by
+    the two nearest-neighbour singlet coverings
+    $(1,2)(3,4)\cdots(N-1,N)$ and $(2,3)(4,5)\cdots(N,1)$.
+    This two-fold degeneracy reflects the spontaneous breaking of the one-site
+    translation symmetry of the spin-$\tfrac12$ chain
     $H=\sum \boldsymbol{S}_i\cdot\boldsymbol{S}_{i+1}
     +\tfrac12\sum\boldsymbol{S}_i\cdot\boldsymbol{S}_{i+2}$
     of \cite{Cirac2021Matrix}.
 \end{theorem}
 
-\begin{remark}\label{rem:majumdar_ghosh_ground_space_dependency}
-    Theorem~\ref{thm:majumdar_ghosh_ground_space} is marked
-    \verb|\notready| and carries no \verb|\lean| or \verb|\leanok| tag: it
-    depends on the periodic block-diagonal ground-space description for
-    non-normal tensors, whose general form is developed in
-    Section~\ref{sec:block_diagonal_boundary_closing} and is not yet specialized
-    to the two-periodic Majumdar--Ghosh grading.  The degeneracy count must be
-    derived from that description; it is recorded here as a target only and is not
-    asserted until the parent-Hamiltonian ground space supports it.
-\end{remark}
+% This target is deliberately marked \notready and carries no \lean or \leanok
+% tag.  The proof should specialize the periodic block-diagonal ground-space
+% description from Section~\ref{sec:block_diagonal_boundary_closing} to the
+% two-periodic Majumdar--Ghosh grading.
 
 %% ===================================================================
 \section{The W state}\label{sec:w_state}


### PR DESCRIPTION
### Motivation
Refs #2319.

This records the intended Majumdar--Ghosh periodic ground-space theorem as a blueprint target, without asserting that the theorem is formalized. The mathematical target depends on specializing the block-diagonal boundary-closing machinery to the two-periodic grading of the tensor.

### Description
- state the range-three periodic parent-Hamiltonian ground-space target for even chains `N = 2m >= 4`
- identify the two staggered nearest-neighbour singlet coverings as the expected spanning vectors
- keep proof-status discussion out of the reader-facing blueprint prose

### Testing
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

Note: local `leanblueprint checkdecls` was not completed because this clean worktree lacked the root `TNLean.olean` cache and began rebuilding Mathlib from source; PR CI runs the authoritative blueprint checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition to `ch15_examples.tex` with no Lean or runtime code changes.
> 
> **Overview**
> Adds blueprint documentation for the **remaining Majumdar–Ghosh parent-Hamiltonian goal**: a `\notready` theorem (`thm:majumdar_ghosh_ground_space`) stating that on even periodic chains \(N=2m\ge4\), the range-three parent Hamiltonian \(H_{N,\mathrm{MG}}^{(3)}\) has a **two-dimensional ground space** spanned by the two staggered nearest-neighbour singlet coverings.
> 
> New reader-facing prose ties this target to **non-normality** and the **two-periodic bond grading** (`thm:majumdar_ghosh_not_normal`), pointing to **block-diagonal boundary closing** (`sec:block_diagonal_boundary_closing`) instead of the injective single-state ground-space route. The statement is explicitly a formalization target (no `\lean{}` tag); `\uses` links it to `def:majumdar_ghosh_tensor` and `def:ground_space_parent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b73304be83e2ec50c19ebd90d4811c4f1f471995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->