### PR TITLE
feat: Proportional coefficient comparison for BNT copy weights

### DIFF
--- a/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
+++ b/TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean
@@ -230,6 +230,161 @@ theorem coeff_identity_via_matched_mpv_phase
   coeff_identity_via_matched_mpv_phasePos
     (P := P) (Q := Q) hP hEqual.toSameMPV₂Pos β ζ hζ_mpv
 
+/-- **Proportional matched-phase coefficient identity (scalar-threaded).**
+
+This is the proportional analogue of `coeff_identity_via_matched_mpv_phasePos`.
+Assume a full matched-basis bijection `β` equipped with phases `ζ k` satisfying
+
+`mpv (Q.basis k) σ = (ζ k)^N * mpv (P.basis (β k)) σ`,
+
+as produced by `ft_sector_bnt_proportional_sector_match_witnesses`.  Substituting
+these per-sector phase relations into `EventuallyNonzeroProportionalMPV₂` and
+applying the BNT linear independence of the `P`-basis (`hP.bnt_data`) forces, for
+a single eventually-nonzero length-dependent scalar `c N`, the eventual
+coefficient identities
+
+`P.coeff N (β k) = c N * (ζ k)^N * Q.coeff N k`
+
+for every matched sector `k`.
+
+The scalar `c N` is the global proportionality constant of CPSV16 Theorem `thm1`
+(arXiv:1606.00608, lines 1167--1170) at length `N`: it is the *same* scalar for
+every sector `k`, because it comes from the single MPV proportionality of
+`P.toTensor` and `Q.toTensor`.  Because every sector is matched (not only the
+leading one), the off-diagonal contributions that obstructed the one-copy
+peeling argument vanish exactly here, and the comparison is the clean
+full-basis linear-independence identity.
+
+This identity is *not* the `SectorBNTCopyWeightMatching.of_coeff_identity` input:
+that lemma needs the scalar-free identity `P.coeff N (β k) = (ζ k)^N * Q.coeff N
+k`.  Eliminating `c N` — equivalently, showing `c N = ξ^N` for a single fixed
+phase `ξ`, so the power can be absorbed into `ζ` — is the residual
+length-scalar control step that the present lemma isolates.  It is documented in
+`docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex`; until it is
+discharged, the proportional global gauge remains the conditional theorem
+`ft_sector_bnt_proportional_global_gauge_of_coeff_identity`. -/
+theorem coeff_identity_via_matched_mpv_phase_proportional
+    {P Q : SectorDecomposition d}
+    (hP : IsBNTCanonicalForm P)
+    (hProp : EventuallyNonzeroProportionalMPV₂ P.toTensor Q.toTensor)
+    (β : Fin Q.basisCount ≃ Fin P.basisCount)
+    (ζ : Fin Q.basisCount → ℂ)
+    (hζ_mpv : ∀ (k : Fin Q.basisCount) (N : ℕ) (σ : Fin N → Fin d),
+      mpv (Q.basis k) σ = (ζ k) ^ N * mpv (P.basis (β k)) σ) :
+    ∃ c : ℕ → ℂ, (∀ᶠ N in atTop, c N ≠ 0) ∧
+      ∃ N₀, ∀ N > N₀, ∀ k : Fin Q.basisCount,
+        P.coeff N (β k) = c N * (ζ k) ^ N * Q.coeff N k := by
+  classical
+  -- The global proportionality scalar at each length, with a junk value off the
+  -- proportionality tail.
+  obtain ⟨c, hc_ne, hc_prop⟩ :
+      ∃ c : ℕ → ℂ, (∀ᶠ N in atTop, c N ≠ 0) ∧
+        (∀ᶠ N in atTop, ∀ σ : Fin N → Fin d,
+          mpv P.toTensor σ = c N * mpv Q.toTensor σ) := by
+    refine ⟨fun N => if h : ∃ c : ℂ, c ≠ 0 ∧ ∀ σ : Fin N → Fin d,
+        mpv P.toTensor σ = c * mpv Q.toTensor σ then h.choose else 1, ?_, ?_⟩
+    · refine hProp.mono ?_
+      intro N hN
+      simp only [dif_pos hN]
+      exact hN.choose_spec.1
+    · refine hProp.mono ?_
+      intro N hN
+      simp only [dif_pos hN]
+      exact hN.choose_spec.2
+  refine ⟨c, hc_ne, ?_⟩
+  let a : ℕ → Fin P.basisCount → ℂ := fun N j => P.coeff N j
+  let b : ℕ → Fin P.basisCount → ℂ := fun N j =>
+    c N * (ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)
+  have hLI : ∀ᶠ N in atTop,
+      LinearIndependent ℂ (fun j : Fin P.basisCount => mpvState (d := d) (P.basis j) N) := by
+    obtain ⟨N₀, hN₀⟩ := hP.bnt_data
+    rw [Filter.eventually_atTop]
+    refine ⟨N₀ + 1, ?_⟩
+    intro N hN
+    exact hN₀ N (Nat.lt_of_succ_le hN)
+  have hEq : ∀ᶠ N in atTop,
+      ∑ j : Fin P.basisCount, a N j • mpvState (d := d) (P.basis j) N =
+        ∑ j : Fin P.basisCount, b N j • mpvState (d := d) (P.basis j) N := by
+    refine hc_prop.mono ?_
+    intro N hNprop
+    have hPstate :
+        mpvState (d := d) P.toTensor N =
+          ∑ j : Fin P.basisCount, P.coeff N j •
+            mpvState (d := d) (P.basis j) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) P.toTensor P.basis
+        (N := N) (fun j => P.coeff N j) ?_
+      intro σ
+      simpa [smul_eq_mul] using P.mpv_toTensor_eq_sum_coeff (N := N) σ
+    have hQstate :
+        mpvState (d := d) Q.toTensor N =
+          ∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N := by
+      refine mpvState_eq_sum_of_decomp (d := d) Q.toTensor Q.basis
+        (N := N) (fun k => Q.coeff N k) ?_
+      intro σ
+      simpa [smul_eq_mul] using Q.mpv_toTensor_eq_sum_coeff (N := N) σ
+    have hStateEq :
+        mpvState (d := d) P.toTensor N = c N • mpvState (d := d) Q.toTensor N := by
+      apply PiLp.ext
+      intro σ
+      simpa [mpvState_apply, mpv, Pi.smul_apply, smul_eq_mul] using hNprop σ
+    have hQsubst :
+        c N • (∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N) =
+          ∑ k : Fin Q.basisCount,
+            (c N * (ζ k) ^ N * Q.coeff N k) •
+              mpvState (d := d) (P.basis (β k)) N := by
+      rw [Finset.smul_sum]
+      refine Finset.sum_congr rfl ?_
+      intro k _
+      have hState_k : mpvState (d := d) (Q.basis k) N =
+          ((ζ k) ^ N) • mpvState (d := d) (P.basis (β k)) N := by
+        apply PiLp.ext
+        intro σ
+        simpa [mpvState_apply, smul_eq_mul] using hζ_mpv k N σ
+      rw [hState_k, smul_smul, smul_smul]
+      congr 1
+      ring
+    have hReindex :
+        (∑ k : Fin Q.basisCount,
+            (c N * (ζ k) ^ N * Q.coeff N k) •
+              mpvState (d := d) (P.basis (β k)) N) =
+          ∑ j : Fin P.basisCount,
+            ((c N * (ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)) •
+              mpvState (d := d) (P.basis j) N) := by
+      let f : Fin Q.basisCount → MPVSpace d N := fun k =>
+        (c N * (ζ k) ^ N * Q.coeff N k) • mpvState (d := d) (P.basis (β k)) N
+      let g : Fin P.basisCount → MPVSpace d N := fun j =>
+        (c N * (ζ (β.symm j)) ^ N * Q.coeff N (β.symm j)) •
+          mpvState (d := d) (P.basis j) N
+      have hfg : ∀ k, f k = g (β k) := by
+        intro k
+        simp [f, g]
+      simpa [f, g] using (Fintype.sum_equiv β f g hfg)
+    calc
+      ∑ j : Fin P.basisCount, a N j • mpvState (d := d) (P.basis j) N
+          = mpvState (d := d) P.toTensor N := by
+              simpa [a] using hPstate.symm
+      _ = c N • mpvState (d := d) Q.toTensor N := hStateEq
+      _ = c N • ∑ k : Fin Q.basisCount, Q.coeff N k •
+            mpvState (d := d) (Q.basis k) N := by rw [hQstate]
+      _ = ∑ k : Fin Q.basisCount,
+            (c N * (ζ k) ^ N * Q.coeff N k) •
+              mpvState (d := d) (P.basis (β k)) N := hQsubst
+      _ = ∑ j : Fin P.basisCount, b N j •
+            mpvState (d := d) (P.basis j) N := by
+              simpa [b] using hReindex
+  have hCoeff : ∀ᶠ N in atTop, ∀ j : Fin P.basisCount, a N j = b N j := by
+    set_option maxRecDepth 1024 in
+    exact coefficient_eventually_eq_of_eventually_linearIndependent
+      (v := fun N j => mpvState (d := d) (P.basis j) N) (a := a) (b := b) hLI hEq
+  rw [Filter.eventually_atTop] at hCoeff
+  obtain ⟨N₀, hN₀⟩ := hCoeff
+  refine ⟨N₀, ?_⟩
+  intro N hN k
+  have h := hN₀ N (le_of_lt hN) (β k)
+  simpa [a, b] using h
+
 /-- **Full-basis coefficient identity.**
 
 Assume a full matched-basis equivalence `β : Fin Q.basisCount ≃

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -398,6 +398,69 @@ matching and then from the coefficient identities that produce one.
     then applies to this copy-weight matching.
 \end{proof}
 
+The coefficient-identity hypothesis of
+Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_coeff_identity} is the
+scalar-free identity~(\ref{eq:ft_coeff_identity}). From the proportional MPV
+hypothesis alone one obtains the same identity carrying the global length-scalar
+of the proportionality, recorded next.
+
+\begin{lemma}[Proportional matched-phase coefficient identity, scalar-threaded]%
+    \label{lem:sector_bnt_coeff_identity_via_matched_mpv_phase_proportional}
+    \lean{MPSTensor.coeff_identity_via_matched_mpv_phase_proportional}
+    \leanok
+    \uses{def:sector_bnt_cf, lem:eventual_coeff_eq_of_eventual_li}
+    Let $P$ be a BNT canonical form and $Q$ a sector decomposition whose total
+    tensors generate eventually nonzero proportional MPV families. Suppose a
+    bijection $\beta:J(Q)\simeq J(P)$ and scalars $\zeta_k$ satisfy the matched
+    MPV phase identities~(\ref{eq:ft_phase_relation_hyp}) for every sector $k$.
+    Then there is a single eventually-nonzero scalar sequence $c_N$ and a
+    threshold $N_0$ such that, for all $N>N_0$ and every $k\in J(Q)$,
+    \begin{equation}\label{eq:ft_coeff_identity_threaded}
+        c_N^{(\beta(k))}(P)=c_N\,\zeta_k^N\,c_N^{(k)}(Q).
+    \end{equation}
+    The scalar $c_N$ is the same for every sector $k$: it is the single global
+    proportionality scalar of \cite[Theorem~\texttt{thm1}, lines~1167--1170]%
+    {Cirac2016MPDO_arXiv} at length $N$.
+\end{lemma}
+
+\begin{proof}\leanok
+    For each $N$ on the proportionality tail, expand both total MPVs in their
+    sector bases and use the global proportionality scalar $c_N$:
+    \[
+        \sum_{j\in J(P)} c_N^{(j)}(P)\ket{V^{(N)}(P_j)}
+        =
+        c_N\sum_{k\in J(Q)} c_N^{(k)}(Q)\ket{V^{(N)}(Q_k)}.
+    \]
+    The matched phase identities~(\ref{eq:ft_phase_relation_hyp}) give
+    $\ket{V^{(N)}(Q_k)}=\zeta_k^N\ket{V^{(N)}(P_{\beta(k)})}$; because every
+    sector is matched, reindexing the $Q$-sum by $\beta$ rewrites the right-hand
+    side entirely in the $P$-basis. The BNT eventual linear independence of the
+    $P$-basis and Lemma~\ref{lem:eventual_coeff_eq_of_eventual_li} then extract
+    the coefficient identities~(\ref{eq:ft_coeff_identity_threaded}) for all
+    sufficiently large $N$.
+\end{proof}
+
+\begin{remark}[Residual length-scalar control]%
+    \label{rem:proportional_length_scalar_gap}
+    The identity~(\ref{eq:ft_coeff_identity_threaded}) discharges the hypothesis
+    of Theorem~\ref{thm:sector_bnt_proportional_global_gauge_of_coeff_identity}
+    --- equivalently~(\ref{eq:ft_coeff_identity}) --- precisely when $c_N\equiv1$,
+    which holds if and only if $c_N=\xi^N$ for a single fixed phase $\xi$ (the
+    power $\xi^N$ is then absorbed into the sector phases $\zeta_k$). The
+    gauge-phase conclusion of \cite[Theorem~\texttt{thm1}]{Cirac2016MPDO_arXiv}
+    itself forces $c_N=\xi^N$, so this is the necessary form. Proving that the
+    global proportionality scalar of two BNT canonical forms is a pure phase
+    power is a length-scalar control statement requiring peripheral-spectrum /
+    almost-periodicity analysis of the bounded power sums $c_N^{(j)}(\cdot)$; it
+    is not derivable from~(\ref{eq:ft_coeff_identity_threaded}) alone. The
+    obstruction is recorded in
+    \texttt{docs/paper-gaps/cpsv16\_proportional\_length\_scalar\_gap.tex}. Until
+    it is discharged, the unconditional full-tensor proportional gauge
+    equivalence is not stated; the unconditional per-normal-tensor proportional
+    fundamental theorem is
+    Theorem~\ref{thm:cpgsv_multiblock_ft_source}.
+\end{remark}
+
 In the equal-MPV case all ingredients are unconditional.
 
 \begin{lemma}[Equal-MPV matched copy-weight witnesses]%

--- a/docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex
+++ b/docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex
@@ -1,0 +1,155 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[colorlinks=true,linkcolor=blue,citecolor=blue,urlcolor=blue]{hyperref}
+
+\input{./command}
+
+\title{The Length-Dependent Proportionality Scalar in the CPSV16 Proportional
+BNT Coefficient Comparison}
+\author{}
+\date{2026-06-23}
+
+\begin{document}
+\maketitle
+
+\section{The source statement}
+
+Cirac--Perez-Garcia--Schuch--Verstraete 2016 (arXiv:1606.00608), Theorem
+\texttt{thm1} (lines 1167--1170), assumes that two translationally invariant
+matrix product states generate \emph{proportional} matrix product vectors: for
+every length \(N\) there is a nonzero scalar \(c_N\) with
+\[
+  V^{(N)}(P_{\mathrm{tot}})_\sigma = c_N\, V^{(N)}(Q_{\mathrm{tot}})_\sigma
+  \qquad \text{for all } \sigma \in \{1,\dots,d\}^N .
+\]
+The formal predicate is \texttt{EventuallyNonzeroProportionalMPV\textsubscript{2}}
+(the eventual form used in the proof, after the linear-independence Lemma
+\texttt{Lem1} at line 1182).  The conclusion of Theorem \texttt{thm1} is a global
+gauge equivalence \emph{up to a single phase}.
+
+\section{What the new BNT surface already proves}
+
+On the \texttt{SectorDecomposition} / \texttt{IsBNTCanonicalForm} surface the
+proportional sector-matching theorem
+(\texttt{ft\_sector\_bnt\_proportional\_sector\_match\_witnesses}) already
+supplies, for two BNT canonical forms \(P\) and \(Q\):
+\begin{itemize}
+  \item a bijection \(\beta : J(Q) \simeq J(P)\) between the normal-tensor
+        sectors;
+  \item per-sector bond-dimension equalities \(\dim P_{\beta(k)} = \dim Q_k\);
+  \item per-sector unit-modulus phases \(\zeta_k\), \(|\zeta_k| = 1\), and block
+        gauges \(X_k\) with
+        \[
+          Q_k^i = \zeta_k\, X_k\, P_{\beta(k)}^i\, X_k^{-1};
+        \]
+  \item the matched MPV power identities, for \emph{every} sector \(k\),
+        \[
+          V^{(N)}(Q_k)_\sigma = \zeta_k^N\, V^{(N)}(P_{\beta(k)})_\sigma .
+        \]
+\end{itemize}
+
+Because every sector --- not only the leading pair --- is matched with its own
+phase identity, the off-diagonal contributions that obstructed the one-copy
+peeling argument of the 2026-05-13 probe
+(\texttt{docs/audits/2026-05-13\_cpsv16\_ft\_exact\_leading\_coeff.md}) vanish
+\emph{exactly}, not merely asymptotically.  The full-basis linear-independence
+coefficient comparison therefore goes through cleanly.  Writing
+\[
+  c_N^{(j)}(P) = \sum_{q} \mu_{j,q}^N, \qquad
+  c_N^{(k)}(Q) = \sum_{q} \nu_{k,q}^N,
+\]
+substituting the per-sector phase identities into the proportional MPV identity,
+reindexing the \(Q\)-sum by \(\beta\), and applying the BNT eventual linear
+independence of the \(P\)-basis gives, for a single eventually-nonzero scalar
+sequence \(c_N\) shared across all sectors and all sufficiently large \(N\),
+\begin{equation}\label{eq:threaded}
+  c_N^{(\beta(k))}(P) = c_N \,\zeta_k^N\, c_N^{(k)}(Q)
+  \qquad \text{for every } k \in J(Q).
+\end{equation}
+This is the content of
+\texttt{MPSTensor.coeff\_identity\_via\_matched\_mpv\_phase\_proportional}.  The
+scalar \(c_N\) is the \emph{same} for every sector \(k\) because it is the single
+global proportionality scalar of Theorem \texttt{thm1}.
+
+\section{The residual obstruction}
+
+The copy-weight recovery step
+(\texttt{SectorBNTCopyWeightMatching.of\_coeff\_identity}, Appendix MPV proof
+line 1188) compares the per-copy power-sum multisets through
+\[
+  \sum_q \mu_{\beta(k),q}^N = \zeta_k^N \sum_q \nu_{k,q}^N
+  = \sum_q (\zeta_k \nu_{k,q})^N ,
+\]
+and extracts the copy permutation by finite power-sum uniqueness.  This requires
+the \emph{scalar-free} identity
+\begin{equation}\label{eq:scalarfree}
+  c_N^{(\beta(k))}(P) = \zeta_k^N\, c_N^{(k)}(Q),
+\end{equation}
+i.e.\ exactly~(\ref{eq:threaded}) with \(c_N \equiv 1\).  A length-dependent
+factor \(c_N\) breaks the multiset comparison: distinct lengths would impose
+incompatible scalings.
+
+Equation~(\ref{eq:threaded}) holds with \(c_N \equiv 1\) if and only if
+\(c_N = \xi^N\) for a single fixed phase \(\xi\): then the power \(\xi^N\) is
+absorbed into the sector phases by replacing \(\zeta_k\) with \(\xi^{-1}\zeta_k\),
+recovering~(\ref{eq:scalarfree}).  (The gauge-phase conclusion of Theorem
+\texttt{thm1}, \(Q^i = \xi\, Y\, P^i\, Y^{-1}\), itself \emph{forces}
+\(c_N = \xi^N\) on the trace, so this is the necessary and sufficient form.)
+
+The missing step is therefore:
+\begin{quote}
+  the global proportionality scalar \(c_N\) of two BNT canonical forms is a pure
+  phase power \(\xi^N\) with \(|\xi| = 1\).
+\end{quote}
+This is a length-scalar control statement.  Under the BNT normalization
+\(|\mu_{j,q}| \le 1\), \(|\nu_{k,q}| \le 1\), with a global unit witness on each
+side, the sector coefficients \(c_N^{(j)}(\cdot)\) are bounded almost-periodic
+power sums that do not decay.  Pinning \(c_N\) to a single geometric phase
+sequence requires peripheral-spectrum / almost-periodicity analysis of these
+power sums that is not currently available in the library; it cannot be derived
+from~(\ref{eq:threaded}) alone, since~(\ref{eq:threaded}) determines \(c_N\) only
+up to the joint scaling of the matched coefficient pairs.
+
+\section{Status and elimination plan}
+
+\begin{itemize}
+  \item \textbf{Proved (faithful, sorry-free):} the threaded identity
+        (\ref{eq:threaded}),
+        \texttt{coeff\_identity\_via\_matched\_mpv\_phase\_proportional} in
+        \path{TNLean/MPS/FundamentalTheorem/SectorBNT/CoeffIdentity.lean}.  No
+        hypothesis absent from Theorem \texttt{thm1} is added.
+  \item \textbf{Conditional (already on \texttt{main}):}
+        \texttt{ft\_sector\_bnt\_proportional\_global\_gauge\_of\_coeff\_identity}
+        takes the scalar-free identity~(\ref{eq:scalarfree}) as an explicit
+        hypothesis and concludes the direct-sum global gauge.
+  \item \textbf{Open:} prove \(c_N = \xi^N\) for a fixed phase \(\xi\), discharge
+        the hypothesis of the conditional theorem, and hence obtain the
+        unconditional proportional global-gauge theorem at the full-tensor level
+        (the literal Theorem \texttt{thm1}).
+\end{itemize}
+
+Until the length-scalar control statement is proved, the unconditional
+full-tensor proportional gauge equivalence cannot be stated faithfully: omitting
+the control would require either a \texttt{sorry} or a hypothesis absent from
+Theorem \texttt{thm1}.  The per-sector (basis-level) proportional fundamental
+theorem,
+\texttt{MPSTensor.fundamentalTheorem\_proportional\_canonicalForm}, is
+unconditional and records the per-normal-tensor gauge-phase conclusion that does
+not need the copy-weight comparison.
+
+\section{References}
+
+\begin{itemize}
+  \item arXiv:1606.00608, Theorem \texttt{thm1}, lines 1167--1170 (statement),
+        line 1182 (matching), lines 1184--1192 (Appendix MPV coefficient
+        comparison and global gauge).
+  \item arXiv:2011.12127, Definition 4.2 (two-layer BNT canonical form).
+  \item \path{docs/audits/2026-05-13_cpsv16_ft_exact_leading_coeff.md}
+        (the one-copy-surface obstruction superseded by full sector matching).
+  \item \path{docs/paper-gaps/cpsv16_global_vs_persector_unit_witness.tex}
+        (the BNT weight normalization used above).
+\end{itemize}
+
+\end{document}


### PR DESCRIPTION
### Motivation
Refs #1749.

This proves the proportional full-basis coefficient comparison available from matched per-sector MPV phases, while keeping the remaining length-scalar control obstruction explicit.

### Description
- add `coeff_identity_via_matched_mpv_phase_proportional` in `CoeffIdentity.lean`
- add the corresponding blueprint lemma in `ch11_fundamental_theorem_proof.tex`
- add `docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex` for the residual scalar-control step

The PR does not prove scalar-free copy-weight matching or the final proportional global gauge theorem.

### Testing
- CI runs the configured Lean, blueprint, prose, and file-length checks for this branch