### PR TITLE
feat(Channel/Schwarz): add fixed rectangular Choi compression step

### DIFF
--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -46,6 +46,12 @@ the pair $(i,p)$.
 * `ChoiJamiolkowski.isNPositiveMap_iff_forall_rightCompression_posSemidef`:
   `k`-positivity is equivalent to positivity of all rectangular right-factor
   Choi compressions.
+* `ChoiJamiolkowski.rightTensorMatrix_mul_rightTensorMatrix`: right tensor
+  factors multiply by multiplying the corresponding right-factor matrices.
+* Fixed-column compression lemma:
+  a square right-factor sandwich controls each rectangular compression whose
+  columns it fixes; see
+  `rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self`.
 * `Matrix.exists_mul_conjTranspose_of_isHermitian_idempotent_rank`: a Hermitian
   idempotent matrix of rank `k` factors as `P = V * Vᴴ`.
 * `IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_isHermitian_idempotent_rank`:
@@ -225,6 +231,19 @@ theorem rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self
     rw [Fintype.sum_prod_type]
     have hji : ¬j = i := fun hji => hij hji.symm
     simp [hij, hji]
+
+/-- Multiplication by a square right tensor factor corresponds to multiplication
+of the underlying right-factor matrices. -/
+theorem rightTensorMatrix_mul_rightTensorMatrix
+    (X : Matrix (Fin D) (Fin k) ℂ) (P : Matrix (Fin D) (Fin D) ℂ) :
+    rightTensorMatrix X * rightTensorMatrix P = rightTensorMatrix (P * X) := by
+  classical
+  ext ⟨i, p⟩ ⟨j, a⟩
+  simp only [rightTensorMatrix, Matrix.of_apply, Matrix.mul_apply, Fintype.sum_prod_type]
+  by_cases hij : i = j
+  · subst j
+    simp [mul_comm]
+  · simp [hij]
 
 /-- Sandwiching the Choi matrix by the right tensor factor gives exactly the
 right-factor compression entries.  In Wolf's notation this is the identity
@@ -577,6 +596,25 @@ theorem IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_isHermitian
   obtain ⟨V, rfl⟩ :=
     Matrix.exists_mul_conjTranspose_of_isHermitian_idempotent_rank P hP hP_idem hrank
   exact IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_mul_conjTranspose hT V
+
+/-- If a square right factor `P` fixes the columns of `X`, then
+positivity of the Choi sandwich by `P` implies positivity of the rectangular
+right compression by `X`.  This is the algebraic half of the converse direction
+in Wolf, Proposition 3.1, item 2; the remaining geometric step is to choose a
+rank-`k` projection `P` with `P * X = X`.
+
+Source: Wolf, Chapter 3, Proposition 3.1 proof, lines 110--111. -/
+theorem rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    {P : Matrix (Fin D) (Fin D) ℂ} {X : Matrix (Fin D) (Fin k) ℂ}
+    (hPX : P * X = X)
+    (hP : (rightTensorMatrix P * choiMatrix T * (rightTensorMatrix P)ᴴ).PosSemidef) :
+    (rightCompression T X).PosSemidef := by
+  rw [← rightTensorMatrix_mul_choiMatrix_mul_conjTranspose]
+  have hR : rightTensorMatrix X * rightTensorMatrix P = rightTensorMatrix X := by
+    rw [rightTensorMatrix_mul_rightTensorMatrix, hPX]
+  rw [← hR]
+  simpa [Matrix.mul_assoc] using hP.conjTranspose_mul_mul_same (rightTensorMatrix X)ᴴ
 
 /-- Forward direction of Wolf's Schmidt-rank expectation criterion.  If `T` is
 `k`-positive, then the Choi quadratic form is nonnegative on every vector of

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -611,6 +611,53 @@ maps.
     $R_X\tau R_X^\dagger$ with $C_T(X)$.
 \end{proof}
 
+\begin{lemma}[Right-tensor multiplication]
+    \label{lem:right_tensor_multiplication}
+    \lean{ChoiJamiolkowski.rightTensorMatrix_mul_rightTensorMatrix}
+    \leanok
+    \uses{def:choi_right_tensor_factor}
+    Let $X\in\MN{D,k}(\C)$ and $P\in\MN{D,D}(\C)$.  Then the right-tensor
+    factors satisfy
+    \[
+      R_XR_P=R_{PX}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is an entrywise calculation: the Kronecker delta in the physical
+    index forces the two right-tensor factors to have the same physical
+    coordinate, and the remaining sum is the matrix product $PX$.
+\end{proof}
+
+\begin{lemma}[Square sandwich implies fixed rectangular compression]
+    \label{lem:square_sandwich_fixed_rectangular_compression}
+    \lean{ChoiJamiolkowski.rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self}
+    \leanok
+    \uses{thm:choi_right_tensor_sandwich, lem:right_tensor_multiplication}
+    Let $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ have Choi matrix $\tau$.  Suppose
+    $P\in\MN{D,D}(\C)$ and $X\in\MN{D,k}(\C)$ satisfy $PX=X$.  If
+    \[
+      R_P\tau R_P^\dagger\geq0,
+    \]
+    then the rectangular right compression of $\tau$ by $X$ is positive
+    semidefinite.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Since $PX=X$, Lemma~\ref{lem:right_tensor_multiplication} gives
+    $R_XR_P=R_X$.  Therefore
+    \[
+      R_X\tau R_X^\dagger
+      =
+      R_X(R_P\tau R_P^\dagger)R_X^\dagger,
+    \]
+    which is positive because positive semidefiniteness is preserved under
+    compression.  The right-hand side is the rectangular compression by
+    Theorem~\ref{thm:choi_right_tensor_sandwich}.
+\end{proof}
+
 \begin{lemma}[Right-tensor factorization for $VV^\dagger$]
     \label{lem:right_tensor_factorization_mul_adjoint}
     \lean{ChoiJamiolkowski.rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self}


### PR DESCRIPTION
Refs LionSR/QICLean#171.

## Summary

This PR adds the algebraic fixed-column step in the converse direction of Wolf, Chapter 3, Proposition 3.1, item 2.

- Proves the right-tensor multiplication identity \(R_XR_P=R_{PX}\).
- Proves that, when \(PX=X\), positivity of the square Choi sandwich \(R_P\tau R_P^\dagger\) implies positive semidefiniteness of the rectangular compression by \(X\).
- Adds the corresponding Chapter 5 blueprint entries.

This is a partial step toward LionSR/QICLean#171. The remaining geometric step is to construct, for a rectangular matrix \(X\), a rank-\(k\) Hermitian idempotent projection \(P\) whose range contains the columns of \(X\), so that \(PX=X\). That step should also record the necessary dimensional hypothesis.

## Verification

- `lake build TNLean.Channel.Schwarz.ChoiCompression`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`