### PR TITLE
doc(parent): retarget block-diagonal boundary comparison note

### DIFF
--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -55,9 +55,7 @@ canonical form notation, while $b$ follows
 Cirac et al. describe the degenerate parent-Hamiltonian ground space for a
 matrix product state with more than one block in canonical form in Section~IV.C
 of \cite{Cirac2021Matrix}.\footnote{For
-	traceability, the periodic-boundary block-component comparison was tracked by
-	\href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651}, which is
-	now closed. The remaining derivation of the source comparison currently
+	traceability, the remaining derivation of the source comparison currently
 	assumed by the conditional theorems is tracked by
 	\href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}. Pull
 	request~\#2724 records the conditional reduction on the main branch, reducing
@@ -565,8 +563,7 @@ product-span input, whose derivation is the normal-range reduction recorded in
 \path{Papers/2011.12127/TN-Review-main.tex}); that gap is independent of the
 periodic-boundary comparison tracked here.
 
-After \href{https://github.com/LionSR/TNLean/issues/2651}{issue \#2651} was
-closed, the remaining source-comparison target is tracked by
+The remaining source-comparison target is tracked by
 \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}: remove the
 remaining external boundary-representation input, and replace the
 span-dependent crossing-tail route by the \(C^j,D^j,E^j\) comparison from


### PR DESCRIPTION
Refs #2971.

## Summary

This PR updates the block-diagonal parent-Hamiltonian paper-gap note after the earlier boundary-comparison issue was closed.

- Points the active periodic-boundary comparison target directly to #2971.
- Removes stale prose that made the note read as if the current target were primarily organized around the closed predecessor issue.
- Leaves the mathematical boundary unchanged: the remaining task is still the PGVWC07 \(C^j,D^j,E^j\) comparison for the block-diagonal parent-space argument.

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `rg -n "2651|issue \\#2651|#2651" docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex TNLean/MPS/ParentHamiltonian blueprint/src/chapter/ch13_parent_hamiltonian*.tex -S`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to issue cross-references and wording in a paper-gap note; no code or formal proof changes.
> 
> **Overview**
> Updates traceability prose in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` now that the earlier periodic-boundary comparison issue is closed.
> 
> The opening footnote no longer cites closed issue **#2651** or frames the note around that predecessor; it points the remaining conditional comparison work at **#2971** and keeps the other reduction/issue references unchanged. The conclusion section drops the “after #2651 was closed” wording and states directly that the live target is **#2971** (PGVWC07 \(C^j,D^j,E^j\) comparison, same parameter range). **No mathematical claims or Lean declarations are modified.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd83e2b079da11ae1467364b141b71560284e2d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->