### PR TITLE
doc(parent): clarify Appendix B coefficient boundary

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -844,6 +844,9 @@ the specialization $L=2$.
         \lambda_\alpha\lambda_{\alpha'}
         \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
     \]
+    This is an orthogonality relation after summing over the physical letter
+    $i$. It is not a coefficient identity for a fixed physical word
+    $\sigma$.
     The coefficient associated to the source basic-vector formula is
     \[
         C_L(\sigma)
@@ -907,8 +910,8 @@ the specialization $L=2$.
     The first equality, $V^{(L)}(\Lambda U)_\sigma=C_L(\sigma)$, is the trace
     expansion of the closed matrix product and is the coefficient form of
     $U^{\otimes L}\varphi_j^{\otimes L}$. The remaining coefficient step is
-    to relate this source expression to the disjoint adjacent-pair condition
-    above when that relation is justified.
+    to relate this source expression, with the physical word $\sigma$ fixed, to
+    the disjoint adjacent-pair condition above.
     On a three-site chain, the two adjacent length-two parent terms are the
     \(AX\) and \(XB\) actions of the canonical two-site parent interaction.
     Appendix~B supplies the basic-vector expression, while Appendix~D.2 supplies

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -129,6 +129,34 @@ and a chosen structural datum:
 This is the declaration
 \leanid{MPSTensor.AppendixBStructuralData.mpv_eq_cyclicVirtualPairState}.  It
 does not prove the disjoint adjacent physical-pair condition.
+The pair-index isometry above is an orthogonality equation after summing over
+the physical letter \(i\).  It is therefore not, by itself, a coefficient
+identity for a fixed physical word \(\sigma\).  Any proof of a fixed-word
+adjacent-pair factorization must use the source basic-vector expression
+\(U^{\otimes L}\varphi_j^{\otimes L}\), or an equivalent construction of the
+corresponding local projectors, rather than applying the summed isometry as if
+the physical labels were also summed in \(C_L(\sigma)\).
+This obstruction is genuine, not merely a missing formal proof.  For example,
+take two virtual indices and physical labels \(i=(a,b)\), with
+\[
+  (U^{(a,b)})_{x,y}=\delta_{x,a}\delta_{y,b},
+  \qquad
+  A^{(a,b)}=\lambda_a E_{a,b},
+\]
+where \(\lambda_0,\lambda_1>0\).  The unit pair-index isometry holds.  For the
+length-four word
+\[
+  \sigma=((0,1),(1,0),(1,0),(0,1)),
+\]
+the cyclic coefficient \(C_4(\sigma)\) vanishes, because the middle virtual
+matching condition fails.  The disjoint adjacent-pair product is instead
+\[
+  (\lambda_0\lambda_1)(\lambda_1\lambda_0)
+  =
+  \lambda_0^2\lambda_1^2\ne 0.
+\]
+Thus the adjacent physical-pair coefficient identity is not a consequence of
+the unit pair-index isometry alone.
 
 There is still no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus
 the formal theorems record only a separate isometry condition for each block;


### PR DESCRIPTION
Refs #3372.

This PR records the source boundary for the Appendix B coefficient step:

- The pair-index isometry in arXiv:1606.00608, lines 549-553 is an equation after summing over the physical letter i.
- The proved cyclic coefficient formula is a fixed-word expression, so the summed isometry is not by itself a fixed-word adjacent-pair factorization.
- The gap note now includes a D=2 four-site counterexample showing that this implication fails without an additional source basic-vector or projector argument.

This is a documentation/source-realignment correction only. It keeps the product-pair factorization obligation open.

Verification:
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main
- python3 scripts/blueprint_lean_sync.py --root . --ci
- git diff --check origin/main...HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and gap-note edits only; no Lean or runtime behavior changes.
> 
> **Overview**
> Documentation-only realignment for the **Appendix B coefficient step**: the **pair-index isometry** (sum over physical letter `i`) is distinguished from **fixed-word** identities such as `C_L(σ)` and the disjoint adjacent-pair factorization.
> 
> **Blueprint ch13** (`rem:product_pair_projectors`) now states explicitly that the weighted pair-index relation is orthogonality **after summing over `i`**, not a coefficient identity for a fixed word `σ`, and that the open step is to relate the source expression with **`σ` fixed** to the adjacent-pair condition.
> 
> **Gap note** `cpsv16_rfp_isometry_scope.tex` adds the same boundary, requires projector/basic-vector arguments for fixed-word factorization, and gives a **D=2, length-four counterexample** where the unit isometry holds but `C_4(σ)=0` while the disjoint pair product is nonzero—so the adjacent-pair identity does **not** follow from isometry alone. The product-pair obligation stays open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68cf7f340446692cbb48636679dd4901944ccf8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->