### PR TITLE
feat(Channel/Schwarz): complete rank-k Choi projection criterion

### DIFF
--- a/TNLean/Channel/Schwarz/ChoiCompression.lean
+++ b/TNLean/Channel/Schwarz/ChoiCompression.lean
@@ -54,9 +54,14 @@ the pair $(i,p)$.
   `rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self`.
 * `Matrix.exists_mul_conjTranspose_of_isHermitian_idempotent_rank`: a Hermitian
   idempotent matrix of rank `k` factors as `P = V * Vᴴ`.
+* `Matrix.exists_isHermitian_idempotent_rank_mul_eq_self`: every rectangular
+  right factor with `k ≤ D` is fixed by some Hermitian idempotent rank-`k`
+  projection.
 * `IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_isHermitian_idempotent_rank`:
   `k`-positivity implies positivity of the Choi sandwich compressed by a
   Hermitian idempotent of rank `k`.
+* `isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef`:
+  Wolf's rank-`k` projection form of the Choi criterion.
 
 ## References
 
@@ -103,6 +108,47 @@ theorem posSemidef_of_dotProduct_mulVec_nonneg_complex
   exact hpos.isSymmetric
 
 end Matrix
+
+namespace Submodule
+
+/-- In a finite-dimensional vector space, any subspace of dimension at most `r`
+is contained in a subspace of dimension exactly `r`, provided `r` is no larger
+than the ambient dimension. -/
+theorem exists_le_finrank_eq {K V : Type*} [Field K] [AddCommGroup V] [Module K V]
+    [Module.Finite K V] (W : Submodule K V) {r : ℕ}
+    (hW : Module.finrank K W ≤ r) (hr : r ≤ Module.finrank K V) :
+    ∃ U : Submodule K V, W ≤ U ∧ Module.finrank K U = r := by
+  classical
+  let P : ℕ → Prop := fun n => ∀ W : Submodule K V,
+    r - Module.finrank K W = n → Module.finrank K W ≤ r →
+      ∃ U : Submodule K V, W ≤ U ∧ Module.finrank K U = r
+  have hP : ∀ n, P n := by
+    intro n
+    induction n with
+    | zero =>
+        intro W hdiff hWle
+        refine ⟨W, le_rfl, ?_⟩
+        omega
+    | succ n ih =>
+        intro W hdiff hWle
+        have hlt : Module.finrank K W < r := by omega
+        have hWV : Module.finrank K W < Module.finrank K V := lt_of_lt_of_le hlt hr
+        obtain ⟨v, hv⟩ := Submodule.exists_of_finrank_lt W hWV
+        let W' : Submodule K V := W ⊔ Submodule.span K ({v} : Set V)
+        have hWleW' : W ≤ W' := le_sup_left
+        have hvnot : v ∉ W := by
+          intro hvW
+          exact hv 1 one_ne_zero (by simpa using hvW)
+        have hfinW' : Module.finrank K W' = Module.finrank K W + 1 := by
+          simpa [W'] using
+            (Submodule.finrank_sup_span_singleton (K := K) (V := V) (p := W) hvnot)
+        have hW'le : Module.finrank K W' ≤ r := by omega
+        have hdiff' : r - Module.finrank K W' = n := by omega
+        obtain ⟨U, hW'U, hUfin⟩ := ih W' hdiff' hW'le
+        exact ⟨U, hWleW'.trans hW'U, hUfin⟩
+  exact hP (r - Module.finrank K W) W rfl hW
+
+end Submodule
 
 namespace Matrix
 
@@ -173,6 +219,89 @@ theorem exists_mul_conjTranspose_of_isHermitian_idempotent_rank
     _ = ∑ j : Fin k, (InnerProductSpace.rankOne ℂ (b j : E) (b j : E) : E →ₗ[ℂ] E) :=
       hstar_linear
     _ = Matrix.toEuclideanLin (V * Vᴴ) := hsum_rankOne.symm
+
+/-- The linear map represented by a rectangular product is the composition of
+the two represented linear maps. -/
+lemma toEuclideanLin_mul_rect {D k : ℕ}
+    (P : Matrix (Fin D) (Fin D) ℂ) (X : Matrix (Fin D) (Fin k) ℂ) :
+    Matrix.toEuclideanLin (P * X) =
+      (Matrix.toEuclideanLin P).comp (Matrix.toEuclideanLin X) := by
+  change Matrix.toLin (EuclideanSpace.basisFun (Fin k) ℂ).toBasis
+      (EuclideanSpace.basisFun (Fin D) ℂ).toBasis (P * X) =
+    (Matrix.toLin (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
+      (EuclideanSpace.basisFun (Fin D) ℂ).toBasis P).comp
+      (Matrix.toLin (EuclideanSpace.basisFun (Fin k) ℂ).toBasis
+        (EuclideanSpace.basisFun (Fin D) ℂ).toBasis X)
+  exact Matrix.toLin_mul (EuclideanSpace.basisFun (Fin k) ℂ).toBasis
+    (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
+    (EuclideanSpace.basisFun (Fin D) ℂ).toBasis P X
+
+/-- If `k ≤ D`, then every rectangular matrix `X : M_{D,k}(ℂ)` is fixed by
+some rank-`k` Hermitian idempotent on the left.  The projection is the
+orthogonal projection onto a `k`-dimensional subspace containing the column
+space of `X`.
+
+This is the geometric converse step in Wolf, Proposition 3.1, item 2. -/
+theorem exists_isHermitian_idempotent_rank_mul_eq_self
+    {D k : ℕ} (hkD : k ≤ D) (X : Matrix (Fin D) (Fin k) ℂ) :
+    ∃ P : Matrix (Fin D) (Fin D) ℂ,
+      P.IsHermitian ∧ P * P = P ∧ P.rank = k ∧ P * X = X := by
+  classical
+  let W : Submodule ℂ (EuclideanSpace ℂ (Fin D)) :=
+    LinearMap.range (Matrix.toEuclideanLin X : EuclideanSpace ℂ (Fin k) →ₗ[ℂ]
+      EuclideanSpace ℂ (Fin D))
+  have hWfin : Module.finrank ℂ W ≤ k := by
+    have hrank_range0 : X.rank = Module.finrank ℂ W := by
+      change X.rank = Module.finrank ℂ (LinearMap.range
+        ((Matrix.toLin (EuclideanSpace.basisFun (Fin k) ℂ).toBasis
+          (EuclideanSpace.basisFun (Fin D) ℂ).toBasis) X))
+      exact Matrix.rank_eq_finrank_range_toLin X
+        (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
+        (EuclideanSpace.basisFun (Fin k) ℂ).toBasis
+    rw [← hrank_range0]
+    exact Matrix.rank_le_width X
+  have hkE : k ≤ Module.finrank ℂ (EuclideanSpace ℂ (Fin D)) := by
+    simpa using hkD
+  obtain ⟨U, hWU, hUfin⟩ := Submodule.exists_le_finrank_eq W hWfin hkE
+  letI : U.HasOrthogonalProjection := inferInstance
+  let p : EuclideanSpace ℂ (Fin D) →ₗ[ℂ] EuclideanSpace ℂ (Fin D) :=
+    (U.starProjection : EuclideanSpace ℂ (Fin D) →ₗ[ℂ] EuclideanSpace ℂ (Fin D))
+  let P : Matrix (Fin D) (Fin D) ℂ := Matrix.toEuclideanLin.symm p
+  refine ⟨P, ?_, ?_, ?_, ?_⟩
+  · exact (Matrix.isSymmetric_toEuclideanLin_iff (A := P)).mp
+      (by simpa [P, p] using U.starProjection_isSymmetric)
+  · apply Matrix.toEuclideanLin.injective
+    rw [toEuclideanLin_mul_rect]
+    have hp : p.IsSymmetricProjection := by
+      dsimp [p]
+      exact Submodule.isSymmetricProjection_starProjection U
+    simpa [P, p, Module.End.mul_eq_comp] using hp.isIdempotentElem.eq
+  · have hrank_range0 :
+        P.rank = Module.finrank ℂ
+          (LinearMap.range (Matrix.toEuclideanLin P : EuclideanSpace ℂ (Fin D) →ₗ[ℂ]
+            EuclideanSpace ℂ (Fin D))) := by
+      change P.rank = Module.finrank ℂ (LinearMap.range
+        ((Matrix.toLin (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
+          (EuclideanSpace.basisFun (Fin D) ℂ).toBasis) P))
+      exact Matrix.rank_eq_finrank_range_toLin P
+        (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
+        (EuclideanSpace.basisFun (Fin D) ℂ).toBasis
+    have hrange :
+        LinearMap.range (Matrix.toEuclideanLin P : EuclideanSpace ℂ (Fin D) →ₗ[ℂ]
+          EuclideanSpace ℂ (Fin D)) = U := by
+      calc
+        LinearMap.range (Matrix.toEuclideanLin P : EuclideanSpace ℂ (Fin D) →ₗ[ℂ]
+            EuclideanSpace ℂ (Fin D))
+            = LinearMap.range p := by simp [P]
+        _ = U := by simp [p, Submodule.range_starProjection U]
+    rw [hrank_range0, hrange, hUfin]
+  · apply Matrix.toEuclideanLin.injective
+    rw [toEuclideanLin_mul_rect]
+    ext v
+    have hvW : Matrix.toEuclideanLin X v ∈ W := by
+      exact ⟨v, rfl⟩
+    have hvU : Matrix.toEuclideanLin X v ∈ U := hWU hvW
+    simp [P, p, Submodule.starProjection_eq_self_iff.mpr hvU]
 
 end Matrix
 
@@ -615,6 +744,43 @@ theorem rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_
     rw [rightTensorMatrix_mul_rightTensorMatrix, hPX]
   rw [← hR]
   simpa [Matrix.mul_assoc] using hP.conjTranspose_mul_mul_same (rightTensorMatrix X)ᴴ
+
+/-- Converse projection-compression implication in Wolf, Proposition 3.1,
+item 2.  If every rank-`k` Hermitian projection gives a positive Choi sandwich
+and `k ≤ D`, then `T` is `k`-positive. -/
+theorem isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hkD : k ≤ D)
+    (hP : ∀ P : Matrix (Fin D) (Fin D) ℂ,
+      P.IsHermitian → P * P = P → P.rank = k →
+        (rightTensorMatrix P * choiMatrix T * (rightTensorMatrix P)ᴴ).PosSemidef) :
+    IsNPositiveMap k T := by
+  rw [isNPositiveMap_iff_forall_rightCompression_posSemidef]
+  intro X
+  obtain ⟨P, hHerm, hIdem, hrank, hPX⟩ :=
+    Matrix.exists_isHermitian_idempotent_rank_mul_eq_self hkD X
+  exact rightCompression_posSemidef_of_rightTensorMatrix_sandwich_posSemidef_of_mul_eq_self
+    hPX (hP P hHerm hIdem hrank)
+
+/-- Wolf's rank-`k` projection form of the Choi criterion: under `D > 0` and
+`k ≤ D`, `k`-positivity is equivalent to positivity of all Choi sandwiches by
+rank-`k` Hermitian idempotent right projections. -/
+theorem isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef
+    [NeZero D]
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ} (hkD : k ≤ D) :
+    IsNPositiveMap k T ↔
+      ∀ P : Matrix (Fin D) (Fin D) ℂ,
+        P.IsHermitian → P * P = P → P.rank = k →
+          (rightTensorMatrix P * choiMatrix T * (rightTensorMatrix P)ᴴ).PosSemidef := by
+  constructor
+  · intro hT P hHerm hIdem hrank
+    exact
+      IsNPositiveMap.rightTensor_choiMatrix_sandwich_posSemidef_of_isHermitian_idempotent_rank
+        hT hHerm hIdem hrank
+  · exact
+      isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef
+        hkD
 
 /-- Forward direction of Wolf's Schmidt-rank expectation criterion.  If `T` is
 `k`-positive, then the Choi quadratic form is nonnegative on every vector of

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -658,6 +658,25 @@ maps.
     Theorem~\ref{thm:choi_right_tensor_sandwich}.
 \end{proof}
 
+\begin{lemma}[Rank-$k$ projection fixing a rectangular right factor]
+    \label{lem:rank_k_projection_fixing_rectangular_factor}
+    \lean{Matrix.exists_isHermitian_idempotent_rank_mul_eq_self}
+    \leanok
+    Let $X\in\MN{D,k}(\C)$ and suppose $k\le D$.  Then there exists a
+    Hermitian projection $P\in\MN{D,D}(\C)$ of rank $k$ such that
+    \[
+      PX=X.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The column space of $X$ has dimension at most $k$.  Since $k\le D$, extend
+    this column space to a $k$-dimensional subspace $U\subseteq\C^D$.  Let $P$
+    be the orthogonal projection onto $U$.  Then $P$ is Hermitian and
+    idempotent, its rank is $\dim U=k$, and it fixes each column of $X$.
+\end{proof}
+
 \begin{lemma}[Right-tensor factorization for $VV^\dagger$]
     \label{lem:right_tensor_factorization_mul_adjoint}
     \lean{ChoiJamiolkowski.rightTensorMatrix_mul_conjTranspose_eq_conjTranspose_mul_self}
@@ -724,9 +743,6 @@ maps.
     The middle factor is positive by
     Theorem~\ref{thm:k_positive_right_tensor_choi_sandwiches}, and positive
     semidefiniteness is preserved under compression by $R_V$.
-    % The full rank-$k$ projection form of
-    % \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum} requires a separate
-    % factorization of arbitrary rank-$k$ orthogonal projections.
 \end{proof}
 
 \begin{lemma}[Rank-$k$ Hermitian projection factorization]
@@ -772,9 +788,57 @@ maps.
     By Lemma~\ref{lem:rank_k_hermitian_projection_factorization}, write
     $P=VV^\dagger$ with $V\in\MN{D,k}(\C)$.  The conclusion is then exactly
     Theorem~\ref{thm:factorized_right_projection_choi_sandwich}.
-    % The reverse implication in the full equivalence of
-    % \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum} is a separate
-    % rectangular-compression reconstruction step.
+\end{proof}
+
+\begin{theorem}[Projection-compression converse for the Choi criterion]
+    \label{thm:rank_k_right_projection_choi_sandwich_converse}
+    \lean{ChoiJamiolkowski.isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef}
+    \leanok
+    \uses{thm:k_positive_iff_right_choi_compressions,
+        lem:square_sandwich_fixed_rectangular_compression,
+        lem:rank_k_projection_fixing_rectangular_factor}
+    Assume $D>0$ and $k\le D$.  Let $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ have
+    Choi matrix $\tau$.  Suppose that
+    \[
+      R_P\tau R_P^\dagger\geq0
+    \]
+    for every Hermitian projection $P\in\MN{D,D}(\C)$ of rank $k$.  Then $T$
+    is $k$-positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By the rectangular compression criterion, it is enough to prove positivity
+    of the right-factor compression by an arbitrary $X\in\MN{D,k}(\C)$.  Choose
+    a rank-$k$ Hermitian projection $P$ with $PX=X$ using
+    Lemma~\ref{lem:rank_k_projection_fixing_rectangular_factor}.  The assumed
+    positivity of $R_P\tau R_P^\dagger$, together with
+    Lemma~\ref{lem:square_sandwich_fixed_rectangular_compression}, gives
+    positivity of the rectangular compression by $X$.
+\end{proof}
+
+\begin{theorem}[Rank-$k$ projection form of the Choi criterion]
+    \label{thm:rank_k_right_projection_choi_criterion}
+    \lean{ChoiJamiolkowski.isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef}
+    \leanok
+    \uses{thm:rank_k_right_projection_choi_sandwich_forward,
+        thm:rank_k_right_projection_choi_sandwich_converse}
+    Assume $D>0$ and $k\le D$.  A linear map
+    $T:\MN{D,D}(\C)\to\MN{D,D}(\C)$ is $k$-positive if and only if, for every
+    Hermitian projection $P\in\MN{D,D}(\C)$ of rank $k$,
+    \[
+      R_P\tau R_P^\dagger\geq0,
+    \]
+    where $\tau$ is the Choi matrix of $T$.  This is the rank-$k$ projection
+    formulation of \cite[Chapter~3, Proposition~3.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The forward direction is
+    Theorem~\ref{thm:rank_k_right_projection_choi_sandwich_forward}.  The
+    reverse direction is
+    Theorem~\ref{thm:rank_k_right_projection_choi_sandwich_converse}.
 \end{proof}
 
 \begin{definition}[Trace-pairing adjoint]\label{def:trace_pairing_adjoint}


### PR DESCRIPTION
Closes LionSR/QICLean#171.

## Summary

This PR completes the rank-`k` projection formulation of Wolf Proposition 3.1, item 2, in `TNLean/Channel/Schwarz/ChoiCompression.lean`.

The new Lean statements are:

- `Submodule.exists_le_finrank_eq`: a finite-dimensional subspace of dimension at most `r` sits inside one of dimension exactly `r`, when `r` is at most the ambient dimension.
- `Matrix.exists_isHermitian_idempotent_rank_mul_eq_self`: for `X : Matrix (Fin D) (Fin k) ℂ` and `k ≤ D`, there is a rank-`k` Hermitian idempotent `P` with `P * X = X`.
- `ChoiJamiolkowski.isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef`: the projection-compression converse.
- `ChoiJamiolkowski.isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef`: the full rank-`k` projection Choi criterion.

The proof uses the column space of `X`, extends it to a `k`-dimensional subspace, takes the orthogonal projection onto that subspace, and combines it with the existing fixed-column compression lemma.

## Blueprint

`blueprint/src/chapter/ch05_schwarz.tex` now records:

- the geometric projection fixing lemma;
- the projection-compression converse;
- the full rank-`k` projection criterion.

## Verification

- `lake env lean TNLean/Channel/Schwarz/ChoiCompression.lean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `lake build TNLean`
- `git diff --check`
- `rg -n "sorry|admit|native_decide|\\baxiom\\b" TNLean/Channel/Schwarz/ChoiCompression.lean` returned no matches

The full build reports only pre-existing warnings in unrelated modules, including existing `sorry` warnings outside the touched file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs in an existing Choi-compression module and matching blueprint text; no runtime, auth, or data-path changes.
> 
> **Overview**
> Completes **Wolf Proposition 3.1, item 2**: $k$-positivity is equivalent to positivity of Choi sandwiches by every rank-$k$ Hermitian idempotent projection, not only the forward direction that was already formalized.
> 
> New Lean infrastructure includes `Submodule.exists_le_finrank_eq` (extend a subspace to exact dimension $r$), `Matrix.exists_isHermitian_idempotent_rank_mul_eq_self` (each rectangular right factor $X$ is fixed on the left by some rank-$k$ projection when $k \le D$), and `toEuclideanLin_mul_rect` for rectangular matrix products. The **converse** `isNPositiveMap_of_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef` picks such a $P$ for each $X$ and combines it with the existing fixed-column compression lemma; `isNPositiveMap_iff_forall_rankProjection_rightTensor_choiMatrix_sandwich_posSemidef` packages the full equivalence.
> 
> The Schwarz blueprint (`ch05_schwarz.tex`) now states the projection-fixing lemma, the converse, and the full criterion, and drops comments that the reverse implication was still missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501c550b2a82ccb8820c2a9d0099a37f7047daec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->