### PR TITLE
feat(parent): add direct Appendix D.2 projector transport

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -355,6 +355,39 @@ theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation
     localTerm_two_three_one_eq_rightPairLift_parentInteraction]
   exact h.commute_lifts
 
+/-- If the two-site parent interaction is identified with the Appendix D.2
+projectors \(Q_{AX}\) and \(Q_{XB}\) on the two faces, then the first two
+translated parent terms on the three-site chain commute. -/
+theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors
+    (A : MPSTensor d D) {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasOverlappingTwoSiteCommutation (d := d) QAX QXB)
+    (hAX : parentInteraction A 2 = QAX)
+    (hXB : parentInteraction A 2 = QXB) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) := by
+  rw [localTerm_two_three_zero_eq_leftPairLift_parentInteraction,
+    localTerm_two_three_one_eq_rightPairLift_parentInteraction]
+  have hLeft : leftPairLift (parentInteraction A 2) = leftPairLift QAX := by
+    rw [hAX]
+  have hRight : rightPairLift (parentInteraction A 2) = rightPairLift QXB := by
+    rw [hXB]
+  rw [hLeft, hRight]
+  exact h.commute_lifts
+
+/-- The Definition D.2 local projector condition gives commutation of the first
+two translated parent terms, once the canonical two-site parent interaction is
+identified with the projectors \(Q_{AX}\) and \(Q_{XB}\) themselves. -/
+theorem localTerm_two_three_zero_one_commute_of_appendixD2
+    (A : MPSTensor d D) {KAXB : Submodule ℂ (NSiteSpace d 3)}
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (h : HasAppendixD2ParentCommutingHamiltonian (d := d) KAXB QAX QXB)
+    (hAX : parentInteraction A 2 = QAX)
+    (hXB : parentInteraction A 2 = QXB) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) :=
+  localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors A
+    h.to_overlapping hAX hXB
+
 /-- If the two-site parent interaction is identified with the complementary
 Appendix D.2 projectors \(P_{AX}=1-Q_{AX}\) and \(P_{XB}=1-Q_{XB}\), then the
 first two translated parent terms on the three-site chain commute. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -163,6 +163,39 @@ the specialization $L=2$.
     endomorphisms commute.
 \end{proof}
 
+\begin{theorem}[Three-site commutation from source projectors]
+    \label{thm:local_term_two_three_commute_from_source_q}
+    \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors}
+    \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2}
+    \leanok
+    \uses{def:overlapping_two_site_supports,
+        thm:local_term_two_three_ax_xb_lifts}
+    Suppose the projectors $Q_{AX}$ and $Q_{XB}$ satisfy the
+    \cite[Definition~D.2]{Cirac2016MPDO_arXiv} local parent-commuting
+    condition on $A X B$, and suppose that the canonical two-site parent
+    interaction is identified with these projectors after lifting to the two
+    faces:
+    \[
+        q(A)_{AX}=(Q_{AX})_{AX},\qquad
+        q(A)_{XB}=(Q_{XB})_{XB}.
+    \]
+    Then the first two translated length-two parent terms on the three-site
+    chain commute,
+    \[
+        h^{(3)}_0(A,2)h^{(3)}_1(A,2)
+        =
+        h^{(3)}_1(A,2)h^{(3)}_0(A,2).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    The lift identities of Theorem~\ref{thm:local_term_two_three_ax_xb_lifts}
+    identify the translated terms with $(Q_{AX})_{AX}$ and $(Q_{XB})_{XB}$.
+    After forgetting the kernel-intersection equation, the
+    \cite[Definition~D.2]{Cirac2016MPDO_arXiv} condition says exactly that
+    these two lifted projectors commute.
+\end{proof}
+
 \begin{theorem}[Three-site commutation from complementary Appendix projectors]
     \label{thm:local_term_two_three_commute_from_complement_ax_xb}
     \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_overlapping_two_site_complement}

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -77,7 +77,12 @@ outside this local package is the orthogonal-projector identification and the
 construction of \(Q_{AX}\) and \(Q_{XB}\) from the Appendix~B basic-vector form.
 The elementary passage from \(Q_{AX},Q_{XB}\) to their complements
 \(1-Q_{AX},1-Q_{XB}\) is recorded by
-\leanid{MPSTensor.HasOverlappingTwoSiteCommutation.complement}.
+\leanid{MPSTensor.HasOverlappingTwoSiteCommutation.complement}.  The
+three-site transport from these local projectors to translated parent terms is
+available in both conventions: directly for \(Q_{AX},Q_{XB}\) through
+\leanid{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2}, and for
+their complements through
+\leanid{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2_complement}.
 
 \section{Elimination plan}
 


### PR DESCRIPTION
## Summary

This PR adds the direct source-projector transport for the local parent-commuting condition in arXiv:1606.00608, Definition D.2. If the two-site parent interaction is identified with the source projectors Q_AX and Q_XB on the two faces of a three-site window, the first two translated length-two parent terms commute.

The existing complementary statement for 1 - Q_AX and 1 - Q_XB remains unchanged. The blueprint now records both conventions separately, and the parent-commuting gap note records that the construction of Q_AX and Q_XB from the Appendix B basic-vector form remains open.

Refs #3373.

## Verification

- lake build TNLean.MPS.ParentHamiltonian.LocalSupport
- lake build TNLean
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main
- python3 scripts/blueprint_lean_sync.py --root . --ci
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; no changes to existing complement theorems or runtime behavior.
> 
> **Overview**
> Adds **direct Appendix D.2 transport** for source projectors \(Q_{AX}\) and \(Q_{XB}\): when `parentInteraction` matches those projectors on the \(AX\) and \(XB\) faces and the overlapping commutation predicate holds, the first two translated length-two parent terms on a three-site window commute.
> 
> New Lean lemmas `localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors` and `localTerm_two_three_zero_one_commute_of_appendixD2` mirror the existing complement path (`…_complement` / `…_appendixD2_complement`) but use `Q` identifications and `commute_lifts` instead of \(1-Q\) and `commute_complement_lifts`.
> 
> The blueprint gains theorem **“Three-site commutation from source projectors”** with `\lean` links to those declarations. The parent-commuting Hamiltonian scope note now states that three-site transport is documented for **both** the \(Q\) and \(1-Q\) conventions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7710f62de08db5f0118d05daa10d8606de8f9327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->