### PR TITLE
feat(Channel): add reduction map Choi formula

### DIFF
--- a/TNLean/Channel/PositiveExamples.lean
+++ b/TNLean/Channel/PositiveExamples.lean
@@ -1,9 +1,11 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.Basic
+import TNLean.Channel.ChoiJamiolkowski
 
 /-!
 # Examples of positive maps
@@ -15,6 +17,7 @@ This file records elementary positive maps from Wolf Chapter 3.
 * `Matrix.reductionMap`: the reduction map
   \(X \mapsto \operatorname{tr}(X) I - k^{-1}X\).
 * `Matrix.reductionMap_one_isPositiveMap`: the case \(k=1\) is positive.
+* `ChoiJamiolkowski.choiMatrix_reductionMap`: Choi matrix of the reduction map.
 
 ## References
 
@@ -57,3 +60,36 @@ theorem reductionMap_one_isPositiveMap {D : ℕ} [NeZero D] :
     (Matrix.PosSemidef.trace_smul_one_sub_self_posSemidef hX)
 
 end Matrix
+
+namespace ChoiJamiolkowski
+
+variable {D : ℕ}
+
+/-- The Choi matrix of the reduction map
+\(T_k(X)=\operatorname{tr}(X)I-k^{-1}X\) is
+\(D^{-1}I-k^{-1}|\Omega\rangle\langle\Omega|\). -/
+theorem choiMatrix_reductionMap [NeZero D] (k : ℕ) :
+    choiMatrix (Matrix.reductionMap D k) =
+      ((D : ℂ)⁻¹) • (1 : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) -
+        ((k : ℂ)⁻¹) • Matrix.omegaProj D := by
+  classical
+  have hDpos : (0 : ℝ) < D := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hcoeff :
+      (D : ℂ)⁻¹ = (((D : ℝ).sqrt : ℂ)⁻¹ * (((D : ℝ).sqrt : ℂ)⁻¹)) := by
+    rw [← _root_.mul_inv_rev]
+    congr
+    have hsqrt : (D : ℝ) = (D : ℝ).sqrt * (D : ℝ).sqrt := by
+      exact (by
+        nth_rw 1 [← Real.sq_sqrt hDpos.le]
+        ring)
+    exact_mod_cast hsqrt
+  ext x y
+  rcases x with ⟨i, a⟩
+  rcases y with ⟨j, b⟩
+  by_cases hij : i = j <;> by_cases hab : a = b <;>
+    by_cases hia : i = a <;> by_cases hjb : j = b <;>
+      simp_all [choiMatrix_apply, Matrix.reductionMap, omegaSlice_eq_single,
+        Matrix.omegaProj_apply, Matrix.omegaVec_apply, eq_comm]
+
+end ChoiJamiolkowski

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -78,6 +78,26 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     Therefore all eigenvalues of $\tr(X)\Id-X$ are nonnegative.
 \end{proof}
 
+\begin{theorem}[Choi matrix of the reduction map]
+    \label{thm:choi_matrix_reduction_map}
+    \lean{ChoiJamiolkowski.choiMatrix_reductionMap}
+    \leanok
+    \uses{def:reduction_map}
+    For $D\ge 1$, the Choi matrix of
+    $T_k(X)=\tr(X)\Id-k^{-1}X$ is
+    \[
+        \tau(T_k)=D^{-1}\Id-k^{-1}\ket{\Omega}\bra{\Omega}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    The trace term sends the $(a,b)$ slice of
+    $\ket{\Omega}\bra{\Omega}$ to its trace times the identity, giving
+    the contribution $D^{-1}\Id$.  The second term is the Choi matrix of
+    $k^{-1}$ times the identity map, namely
+    $k^{-1}\ket{\Omega}\bra{\Omega}$.
+\end{proof}
+
 \begin{theorem}[Conjugation filters preserve positivity]
     \label{thm:conjugation_filters_preserve_positivity}
     \lean{unitaryConjLM_isCPMap, unitaryConjLM_isPositiveMap,


### PR DESCRIPTION
## Summary

This PR adds the Choi-matrix computation for Wolf Chapter 3, Example 3.1, for the reduction-map family `T_k(X) = tr(X) I - k^{-1} X`.

The new theorem is:

- `ChoiJamiolkowski.choiMatrix_reductionMap`: `choiMatrix (Matrix.reductionMap D k) = D^{-1} I - k^{-1} |Omega><Omega|` for `D > 0`.

The blueprint chapter records this as `thm:choi_matrix_reduction_map` with `\leanok`.

## Issue Scouting

This addresses a self-contained algebraic part of LionSR/QICLean#21 and supplies the witness matrix used by the reduction criterion. It does not claim the full `n`-positivity result: the remaining proof needs the Schmidt-rank overlap/Ky-Fan estimate tracked in LionSR/QICLean#165. The spectral criterion LionSR/QICLean#166 and the strictness of the `n`-positivity chain LionSR/QICLean#167 sit downstream of that estimate. Issue LionSR/QICLean#20 remains a separate Skolem-Noether/rank-preserver classification problem.

## Validation

- `lake build TNLean.Channel.PositiveExamples`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake build TNLean`
- `lake exe checkdecls blueprint/lean_decls`

The full build passes with existing repository warnings outside this PR, including the pre-existing periodic-overlap `sorry` warning in `TNLean/MPS/Periodic/Overlap/Case3.lean`.
