### PR TITLE
feat(Channel): add Schmidt singular values

### DIFF
--- a/TNLean/Channel/SchmidtRank.lean
+++ b/TNLean/Channel/SchmidtRank.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
 import Mathlib.Data.Complex.Basic
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import Mathlib.Analysis.InnerProductSpace.SingularValues
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.LinearAlgebra.Matrix.Rank
 
@@ -24,12 +26,17 @@ bounded Schmidt rank.
 * `Matrix.schmidtCoeffMatrix`: the coefficient matrix of a bipartite vector.
 * `Matrix.schmidtRank`: the Schmidt rank of a bipartite vector.
 * `Matrix.HasSchmidtRankLE`: predicate that the Schmidt rank is at most `k`.
+* `Matrix.schmidtSingularValues`: singular values of the coefficient matrix.
 
 ## Main results
 
 * `Matrix.schmidtRank_le_left`, `Matrix.schmidtRank_le_right`: dimension bounds.
 * `Matrix.schmidtRank_zero`: the zero vector has Schmidt rank zero.
 * `Matrix.schmidtRank_product_le_one`: product vectors have Schmidt rank at most one.
+* `Matrix.support_schmidtSingularValues`: the nonzero Schmidt singular values
+  are indexed by the Schmidt rank.
+* `Matrix.hasSchmidtRankLE_iff_schmidtSingularValues_eq_zero`: bounded
+  Schmidt rank is equivalent to vanishing of the corresponding singular value.
 * `Matrix.exists_mul_eq_of_rank_le`: a matrix of rank at most `k` factors
   through a `k`-dimensional coordinate space.
 * `Matrix.rank_smul_of_ne_zero`: nonzero complex rescaling preserves matrix rank.
@@ -168,5 +175,79 @@ theorem schmidtRank_product_le_one (u : m → ℂ) (v : n → ℂ) :
 theorem hasSchmidtRankLE_one_product (u : m → ℂ) (v : n → ℂ) :
     HasSchmidtRankLE 1 (fun p : m × n => u p.1 * v p.2) :=
   schmidtRank_product_le_one u v
+
+/-! ## Schmidt singular values -/
+
+/-- The Schmidt singular values of a bipartite vector, defined as the singular
+values of its coefficient matrix as a map between finite Euclidean spaces. -/
+noncomputable def schmidtSingularValues [Fintype m] (ψ : m × n → ℂ) : ℕ →₀ ℝ := by
+  classical
+  exact
+    (Matrix.toEuclideanLin (schmidtCoeffMatrix ψ) :
+      EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m).singularValues
+
+/-- The matrix rank defining the Schmidt rank is the range dimension of the
+corresponding Euclidean linear map. -/
+theorem schmidtRank_eq_finrank_range_toEuclideanLin [Finite m] [DecidableEq n]
+    (ψ : m × n → ℂ) :
+    schmidtRank ψ =
+      Module.finrank ℂ (LinearMap.range
+        (Matrix.toEuclideanLin (schmidtCoeffMatrix ψ) :
+          EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m)) := by
+  classical
+  letI := Fintype.ofFinite m
+  rw [schmidtRank, Matrix.toEuclideanLin_eq_toLin_orthonormal]
+  exact Matrix.rank_eq_finrank_range_toLin (schmidtCoeffMatrix ψ)
+    (EuclideanSpace.basisFun m ℂ).toBasis
+    (EuclideanSpace.basisFun n ℂ).toBasis
+
+/-- The Schmidt singular values are nonnegative. -/
+theorem schmidtSingularValues_nonneg [Fintype m] (ψ : m × n → ℂ) (k : ℕ) :
+    0 ≤ schmidtSingularValues ψ k := by
+  classical
+  exact
+    ((Matrix.toEuclideanLin (schmidtCoeffMatrix ψ) :
+      EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m).singularValues_nonneg k)
+
+/-- The Schmidt singular values are weakly decreasing. -/
+theorem schmidtSingularValues_antitone [Fintype m] (ψ : m × n → ℂ) :
+    Antitone (schmidtSingularValues ψ) := by
+  classical
+  exact
+    ((Matrix.toEuclideanLin (schmidtCoeffMatrix ψ) :
+      EuclideanSpace ℂ n →ₗ[ℂ] EuclideanSpace ℂ m).singularValues_antitone)
+
+/-- The support of the Schmidt singular values has size exactly the Schmidt
+rank. -/
+@[simp]
+theorem support_schmidtSingularValues [Fintype m] (ψ : m × n → ℂ) :
+    (schmidtSingularValues ψ).support = Finset.range (schmidtRank ψ) := by
+  classical
+  rw [schmidtSingularValues, LinearMap.support_singularValues,
+    schmidtRank_eq_finrank_range_toEuclideanLin]
+
+/-- The `k`-th Schmidt singular value vanishes exactly when the Schmidt rank is
+at most `k`. -/
+theorem schmidtSingularValues_eq_zero_iff [Fintype m] (ψ : m × n → ℂ) {k : ℕ} :
+    schmidtSingularValues ψ k = 0 ↔ schmidtRank ψ ≤ k := by
+  classical
+  rw [schmidtSingularValues, LinearMap.singularValues_eq_zero_iff_le_finrank_range,
+    schmidtRank_eq_finrank_range_toEuclideanLin]
+
+/-- The `k`-th Schmidt singular value is positive exactly below the Schmidt
+rank. -/
+theorem schmidtSingularValues_pos_iff_lt_schmidtRank [Fintype m] (ψ : m × n → ℂ)
+    {k : ℕ} :
+    0 < schmidtSingularValues ψ k ↔ k < schmidtRank ψ := by
+  classical
+  rw [schmidtSingularValues, LinearMap.singularValues_pos_iff_lt_finrank_range,
+    schmidtRank_eq_finrank_range_toEuclideanLin]
+
+/-- Bounded Schmidt rank is equivalent to vanishing of the corresponding
+Schmidt singular value. -/
+theorem hasSchmidtRankLE_iff_schmidtSingularValues_eq_zero [Fintype m]
+    {k : ℕ} {ψ : m × n → ℂ} :
+    HasSchmidtRankLE k ψ ↔ schmidtSingularValues ψ k = 0 :=
+  (schmidtSingularValues_eq_zero_iff ψ).symm
 
 end Matrix

--- a/TNLean/Channel/SchmidtRank.lean
+++ b/TNLean/Channel/SchmidtRank.lean
@@ -3,9 +3,9 @@ Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
-import Mathlib.Data.Complex.Basic
 import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.InnerProductSpace.SingularValues
+import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Basis.VectorSpace
 import Mathlib.LinearAlgebra.Matrix.Rank
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -198,8 +198,9 @@ maps.
         Matrix.hasSchmidtRankLE_iff_schmidtSingularValues_eq_zero}
     \leanok
     \uses{def:schmidt_rank, def:schmidt_singular_values}
-    The nonzero Schmidt singular values of $\psi$ are exactly those with index
-    below $\operatorname{SR}(\psi)$.  Equivalently,
+    The Schmidt singular values are indexed from zero.  The nonzero Schmidt
+    singular values of $\psi$ are exactly those with index below
+    $\operatorname{SR}(\psi)$.  Equivalently, for zero-based indexing,
     \[
         s_k(\psi)=0 \quad\Longleftrightarrow\quad
         \operatorname{SR}(\psi)\le k .

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -181,6 +181,39 @@ maps.
     dimension at most one.
 \end{proof}
 
+\begin{definition}[Schmidt singular values]\label{def:schmidt_singular_values}
+    \lean{Matrix.schmidtSingularValues}
+    \leanok
+    \uses{def:schmidt_rank}
+    The Schmidt singular values of a vector
+    $\psi\in\C^{D}\otimes\C^k$ are the singular values of the coefficient
+    matrix $C_\psi$, viewed as a linear map $\C^k\to\C^D$.
+\end{definition}
+
+\begin{theorem}[Schmidt singular values and Schmidt rank]
+    \label{thm:schmidt_singular_values_support}
+    \lean{Matrix.support_schmidtSingularValues,
+        Matrix.schmidtSingularValues_eq_zero_iff,
+        Matrix.schmidtSingularValues_pos_iff_lt_schmidtRank,
+        Matrix.hasSchmidtRankLE_iff_schmidtSingularValues_eq_zero}
+    \leanok
+    \uses{def:schmidt_rank, def:schmidt_singular_values}
+    The nonzero Schmidt singular values of $\psi$ are exactly those with index
+    below $\operatorname{SR}(\psi)$.  Equivalently,
+    \[
+        s_k(\psi)=0 \quad\Longleftrightarrow\quad
+        \operatorname{SR}(\psi)\le k .
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For a finite-dimensional linear map, the support of the singular-value
+    sequence is the initial interval whose length is the dimension of the
+    range.  The coefficient matrix $C_\psi$ represents the corresponding map
+    $\C^k\to\C^D$, and this range dimension is $\rank(C_\psi)$.
+\end{proof}
+
 \begin{lemma}[Monotonicity of bounded Schmidt rank]\label{lem:schmidt_rank_mono}
     \lean{Matrix.HasSchmidtRankLE.mono}
     \leanok


### PR DESCRIPTION
## Summary

This PR adds a Mathlib-native singular-value layer for Schmidt rank.

* Defines `Matrix.schmidtSingularValues` as the singular values of the coefficient matrix of a bipartite vector, viewed as a Euclidean linear map.
* Proves that the support of these singular values is exactly the initial interval of length `schmidtRank ψ`.
* Proves the corresponding zero and positivity criteria, including
  `Matrix.hasSchmidtRankLE_iff_schmidtSingularValues_eq_zero`.
* Records the definition and support criterion in the Schmidt-rank part of the blueprint.

This advances LionSR/QICLean#165 by replacing the rank-only Schmidt interface with Mathlib 4.31's `LinearMap.singularValues`. It does not claim the full Ky-Fan overlap theorem from Wolf Lemma 3.1; that still needs the Ky-Fan/eigenvalue optimization layer.

## Verification

* `lake build TNLean.Channel.SchmidtRank`
* `lake build TNLean.Channel.Schwarz.ChoiCompression`
* `python3 scripts/blueprint_lean_sync.py --root . --ci`
* `rg -n "sorry|admit|native_decide|\\baxiom\\b" TNLean/Channel/SchmidtRank.lean`
* `lake build TNLean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive formalization in `SchmidtRank.lean` and blueprint text; no changes to runtime logic or security-sensitive code.
> 
> **Overview**
> Introduces **Schmidt singular values** for bipartite vectors by pulling Mathlib’s `LinearMap.singularValues` through `Matrix.toEuclideanLin` on the coefficient matrix, and wires that layer to the existing rank-based Schmidt API.
> 
> New lemmas show the singular-value support is `Finset.range (schmidtRank ψ)`, that `s_k(ψ) = 0` iff `schmidtRank ψ ≤ k`, and that `HasSchmidtRankLE k ψ` is equivalent to the `k`-th Schmidt singular value vanishing. The blueprint chapter on Schmidt rank adds the matching definition and support/zero criterion, linked to the new Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1f3847b6aa7f92728120e6709c2e4248f23478a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->