### PR TITLE
feat(Channel/Schwarz): add positive-map rpow integrand Jensen

### DIFF
--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -62,9 +62,10 @@ The remaining Mathlib or local formalization gaps are:
 * General operator Jensen inequality for positive maps (the
   Hansen--Pedersen / Davis--Choi inequality `T(f A) ≤ f(T A)` for operator
   concave `f` with `f 0 ≥ 0` and positive subunital `T`): absent from Mathlib.
-  For the concave `rpow` case the per-resolvent core is already available in
-  `TNLean.Channel.Schwarz.OperatorJensenAux` (`povm_resolvent_inv_le`); see the
-  proof plan below.
+  For the concave `rpow` case the pointwise Löwner-integrand inequality is now
+  available in `TNLean.Channel.Schwarz.OperatorJensenAux` as
+  `TNLean.OperatorJensen.positiveMap_rpowIntegrand₀₁_jensen`; see the proof
+  plan below.
 * Monotonicity of the matrix-valued Bochner integral in the Loewner order is
   now available: `TNLean.Channel.Basic` supplies the closed Loewner-order
   topology on finite matrices, Mathlib supplies the ordered Bochner theorem
@@ -75,10 +76,10 @@ The remaining Mathlib or local formalization gaps are:
   finite-dimensional map as a continuous linear map.  The pointwise
   positive-map resolvent estimate and its spectral reduction to
   `povm_resolvent_inv_le` are available as
-  `TNLean.OperatorJensen.positiveMap_resolvent_inv_le`, using `CFC.sqrt` to
-  package each `T(P i)` and the subunital defect as square-root factors.  The
-  remaining proof work is the CFC-integrand rewrite and the Löwner-integral
-  assembly.
+  `TNLean.OperatorJensen.positiveMap_resolvent_inv_le`, and the corresponding
+  single-integrand Jensen inequality is
+  `TNLean.OperatorJensen.positiveMap_rpowIntegrand₀₁_jensen`.  The remaining
+  proof work for the concave power case is the Löwner-integral assembly.
 * Operator convexity of `rpow` over `[1, 2]`, the scalar input of
   `posMap_rpow_convex_jensen`, is now available as `CFC.convexOn_rpow` in
   `TNLean.Analysis.RpowConvexity`; the convex axiom therefore shares the single
@@ -100,10 +101,11 @@ The remaining Mathlib or local formalization gaps are:
    positive subunital map `T`.  Diagonalizing `A = ∑ i, λ i • P i` over its
    spectral projections and setting `B i = T (P i)` (positive semidefinite,
    with `∑ i, B i = T 1 ≤ 1`), this resolvent inequality is now proved as
-   `TNLean.OperatorJensen.positiveMap_resolvent_inv_le`.  What remains is to
-   rewrite the CFC integrand through the displayed resolvent formula and then
-   integrate this pointwise bound using Mathlib's ordered Bochner monotonicity
-   theorem, the local positive-semidefinite integral specialization in
+   `TNLean.OperatorJensen.positiveMap_resolvent_inv_le`; the displayed
+   integrand inequality itself is now
+   `TNLean.OperatorJensen.positiveMap_rpowIntegrand₀₁_jensen`.  What remains is
+   to integrate this pointwise bound using Mathlib's ordered Bochner
+   monotonicity theorem, the local positive-semidefinite integral specialization in
    `TNLean.Channel.Schwarz.OperatorJensenAux`, and the commutation of `T` with
    the integral.
 2. **Operator convexity of `rpow` for `p ∈ [1, 2]`**: use the
@@ -116,9 +118,9 @@ The remaining Mathlib or local formalization gaps are:
    `A^s B^{1-s} = (sin πs/π) ∫₀^∞ t^{s-1} A(A+tB)⁻¹ B dt` and
    resolvent monotonicity.
 
-The single missing reusable theorem for items 1--3 is the operator Jensen
-inequality for positive subunital (resp. unital) maps; once it is available,
-the three `rpow`/`log` axioms collapse via the steps above.
+The concave `rpow` case has now been reduced to the Löwner-integral assembly
+from the pointwise integrand inequality.  The convex `rpow` and logarithmic
+cases still need the corresponding positive-map Jensen input.
 
 ## References
 

--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -8,6 +8,7 @@ import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.LinearAlgebra.Matrix.PosDef
 import Mathlib.MeasureTheory.Integral.Bochner.Basic
+import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.IntegralRepresentation
 
 /-!
 # Finite-POVM compression lemmas for operator Jensen
@@ -41,6 +42,8 @@ representation; see the status note below.
 - `positiveMap_resolvent_inv_le`: the corresponding resolvent inequality for
   a positive subunital map, obtained from the spectral projections of the input
   matrix and `povm_resolvent_inv_le`.
+- `positiveMap_rpowIntegrand₀₁_jensen`: Jensen's inequality for a single
+  Löwner-integral real-power integrand under a positive subunital map.
 - `integral_nonneg_matrix_of_ae`: matrix-valued Bochner integrals preserve
   almost-everywhere positive semidefiniteness.
 
@@ -59,15 +62,16 @@ integrand together with the resolvent form
 `cfc (Real.rpowIntegrand₀₁ p t) a = t ^ (p - 1) • 1 - t ^ p • (t • 1 + a)⁻¹`.
 
 This file now also proves the positive-map resolvent estimate obtained from
-the spectral projections of the input matrix and `povm_resolvent_inv_le`.  The
-remaining unfinished step is therefore to rewrite the single-integrand Jensen
-difference
+the spectral projections of the input matrix and `povm_resolvent_inv_le`, and
+uses it to prove the single-integrand Jensen inequality
+`T(cfc (Real.rpowIntegrand₀₁ p t) A) ≤ cfc (Real.rpowIntegrand₀₁ p t) (T A)`.
+The remaining unfinished step is therefore to integrate the pointwise
+positive-semidefinite bound obtained from
 `cfc (Real.rpowIntegrand₀₁ p t) (T A) - T(cfc (Real.rpowIntegrand₀₁ p t) A)`
-using that resolvent estimate and then integrate the resulting pointwise
-positive-semidefinite bound.  The matrix-valued positive-integral step is
-packaged below from Mathlib's ordered Bochner integral API and the local closed
-Loewner-order topology on finite matrices; order monotonicity itself is
-Mathlib's `integral_mono_ae`.
+through Mathlib's Löwner integral representation.  The matrix-valued
+positive-integral step is packaged below from Mathlib's ordered Bochner
+integral API and the local closed Loewner-order topology on finite matrices;
+order monotonicity itself is Mathlib's `integral_mono_ae`.
 -/
 
 open scoped Matrix ComplexOrder MatrixOrder
@@ -690,6 +694,72 @@ lemma positiveMap_resolvent_inv_le
     (C := C) (S := S) (wgt := hA.1.eigenvalues)
     (fun i => hA.eigenvalues_nonneg i) t ht hdef
   simpa [hTA_c, hTInv_c, hS_def_T] using hpovm
+
+/-- Resolvent form of the Löwner-integral integrand
+`Real.rpowIntegrand₀₁ p t` under the continuous functional calculus. -/
+private lemma cfc_rpowIntegrand₀₁_eq_resolvent
+    {A : MatD} (hA : A.PosSemidef) {p t : ℝ}
+    (hp : p ∈ Set.Ioo (0 : ℝ) 1) (ht : 0 < t) :
+    cfc (Real.rpowIntegrand₀₁ p t) A =
+      t ^ (p - 1) • (1 : MatD) - t ^ p • ((t • (1 : MatD)) + A)⁻¹ := by
+  have hEq : ({A | (0 : MatD) ≤ A}.EqOn (cfc (Real.rpowIntegrand₀₁ p t))
+      (fun X : MatD =>
+        algebraMap ℝ MatD (t ^ (p - 1)) -
+          t ^ p • Ring.inverse (algebraMap ℝ MatD t + X))) := by
+    intro X hX
+    rw [Real.rpowIntegrand₀₁_eq_sub (by grind) ht]
+    have hg : ContinuousOn (fun z : ℝ => (t + z)⁻¹) (spectrum ℝ X) := by
+      fun_prop (disch := grind -abstractProof)
+    have hf : ContinuousOn (fun z : ℝ => (1 + z)) (spectrum ℝ X) := by fun_prop
+    have hspectrum : ∀ r ∈ spectrum ℝ X, t + r ≠ 0 := by grind
+    have := cfc_sub (fun _ : ℝ => t ^ (p - 1))
+      (fun z : ℝ => t ^ p * (t + z)⁻¹) X
+    rw [this, cfc_const .., cfc_const_mul .., cfc_inv _ _ hspectrum ..,
+      cfc_const_add .., cfc_id' ..]
+  have hA_nonneg : (0 : MatD) ≤ A := Matrix.nonneg_iff_posSemidef.mpr hA
+  have hcalc := hEq hA_nonneg
+  simpa [Algebra.algebraMap_eq_smul_one, ← Matrix.nonsing_inv_eq_ringInverse] using hcalc
+
+/-- Jensen's inequality for a single Löwner-integral real-power integrand under
+a positive subunital map.
+
+For `p ∈ (0, 1)` and `t > 0`, this proves the pointwise inequality
+`T(cfc (Real.rpowIntegrand₀₁ p t) A) ≤ cfc (Real.rpowIntegrand₀₁ p t) (T A)`.
+It is the integrand-level input for the Löwner-integral proof of the concave
+real-power operator Jensen inequality. -/
+lemma positiveMap_rpowIntegrand₀₁_jensen
+    {T : MatD →ₗ[ℂ] MatD} (hT : IsPositiveMap T)
+    (hSub : T 1 ≤ (1 : MatD)) {A : MatD} (hA : A.PosSemidef)
+    {p t : ℝ} (hp : p ∈ Set.Ioo (0 : ℝ) 1) (ht : 0 < t) :
+    T (cfc (Real.rpowIntegrand₀₁ p t) A) ≤
+      cfc (Real.rpowIntegrand₀₁ p t) (T A) := by
+  classical
+  have hTA : (T A).PosSemidef := hT A hA
+  have hAeq := cfc_rpowIntegrand₀₁_eq_resolvent hA hp ht
+  have hTAeq := cfc_rpowIntegrand₀₁_eq_resolvent hTA hp ht
+  rw [hAeq, hTAeq]
+  rw [Matrix.le_iff]
+  have hres := positiveMap_resolvent_inv_le hT hSub hA ht
+  rw [Matrix.le_iff] at hres
+  have hscale_nonneg : 0 ≤ t ^ p := Real.rpow_nonneg (le_of_lt ht) p
+  have hscaled := hres.smul hscale_nonneg
+  have ht_pow : t ^ (p - 1) = t ^ p * t⁻¹ := by
+    rw [Real.rpow_sub_one ht.ne']
+    ring
+  have ht_pow' : t ^ (-1 + p) = t ^ p * t⁻¹ := by
+    rw [show -1 + p = p - 1 by ring, ht_pow]
+  have ht_powC :
+      ((t ^ (-1 + p) : ℝ) : ℂ) = ((t ^ p : ℝ) : ℂ) * (t : ℂ)⁻¹ := by
+    rw [ht_pow', Complex.ofReal_mul, Complex.ofReal_inv]
+  have ht_powC₂ :
+      ((t ^ (p + -1) : ℝ) : ℂ) = ((t ^ p : ℝ) : ℂ) * (t : ℂ)⁻¹ := by
+    rw [show p + -1 = -1 + p by ring, ht_powC]
+  convert hscaled using 1
+  ext i j
+  simp [LinearMap.map_smul_of_tower, sub_eq_add_neg, smul_add, add_comm,
+    add_left_comm, add_assoc]
+  simp [ht_powC₂]
+  ring_nf
 
 end PositiveMapResolvent
 

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -272,6 +272,35 @@ are not developed elsewhere in this document.
     formula for $(A+t\Id)^{-1}$.
 \end{proof}
 
+\begin{lemma}[Positive-map real-power integrand inequality]
+    \label{lem:operator_jensen_positive_map_rpow_integrand}
+    \lean{TNLean.OperatorJensen.positiveMap_rpowIntegrand₀₁_jensen}
+    \leanok
+    \uses{lem:operator_jensen_positive_map_resolvent}
+    Let $T$ be a positive subunital map, let $A\ge0$, let
+    $p\in(0,1)$, and let $t>0$. Then
+    \[
+        T\!\left(f_{p,t}(A)\right)
+        \le
+        f_{p,t}(TA),
+        \qquad
+        f_{p,t}(x)=t^p\left(t^{-1}-(t+x)^{-1}\right).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:operator_jensen_positive_map_resolvent}
+    Rewrite the continuous functional calculus for $f_{p,t}$ in resolvent
+    form,
+    \[
+        f_{p,t}(X)=t^{p-1}\Id-t^p(t\Id+X)^{-1}.
+    \]
+    After applying the linear map $T$, the difference
+    $f_{p,t}(TA)-T(f_{p,t}(A))$ is exactly $t^p$ times the positive matrix
+    supplied by the positive-map resolvent inequality.
+\end{proof}
+
 \begin{lemma}[Positive matrix-valued integrals]\label{lem:operator_jensen_integral_order}
     \lean{TNLean.OperatorJensen.integral_nonneg_matrix_of_ae}
     \leanok
@@ -291,7 +320,7 @@ are not developed elsewhere in this document.
 \begin{theorem}[Jensen for concave real powers]\label{thm:posMap_rpow_concave_jensen}
     \lean{posMap_rpow_concave_jensen}
     \notready
-    \uses{def:positive_map, lem:operator_jensen_positive_map_resolvent,
+    \uses{def:positive_map, lem:operator_jensen_positive_map_rpow_integrand,
         lem:operator_jensen_integral_order}
     For a positive subunital map $T$, a positive semidefinite matrix~$A$,
     and $p\in[0,1]$:


### PR DESCRIPTION
Refs LionSR/QICLean#135, LionSR/QICLean#29, LionSR/TNLean#3375.

Summary:
- Adds `TNLean.OperatorJensen.positiveMap_rpowIntegrand₀₁_jensen` for `p ∈ (0,1)` and `t > 0`.
- Proves the CFC resolvent form of `Real.rpowIntegrand₀₁` and combines it with the existing positive-map resolvent inequality.
- Updates the operator-convexity axiom-status note and the Chapter 18 blueprint: the concave real-power Jensen axiom is now reduced to the Loewner-integral assembly step.

Scope:
- Does not remove `posMap_rpow_concave_jensen` yet.
- Does not touch the convex real-power or logarithmic Jensen axioms.

Validation:
- `lake env lean TNLean/Channel/Schwarz/OperatorJensenAux.lean`
- `lake env lean TNLean/Axioms/OperatorConvexity.lean`
- `lake build TNLean` passed, with only pre-existing warnings including the known periodic Case3 sorry warning.
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `git diff --check`
- `rg -n "sorry|admit|native_decide|\\baxiom\\b" TNLean/Channel/Schwarz/OperatorJensenAux.lean` found no matches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New proved lemmas and documentation only; no changes to axioms, APIs, or runtime behavior beyond the formalization layer.
> 
> **Overview**
> Adds **`TNLean.OperatorJensen.positiveMap_rpowIntegrand₀₁_jensen`**, showing that for a positive subunital map `T`, PSD `A`, `p ∈ (0,1)`, and `t > 0`, the Löwner-integral integrand satisfies `T(cfc (Real.rpowIntegrand₀₁ p t) A) ≤ cfc (Real.rpowIntegrand₀₁ p t) (T A)`.
> 
> The proof introduces a private **CFC resolvent rewrite** for `Real.rpowIntegrand₀₁` and combines it with the existing **`positiveMap_resolvent_inv_le`** estimate. **`OperatorJensenAux`** gains an import from Mathlib’s rpow integral representation module.
> 
> **`OperatorConvexity`** status notes and the Chapter 18 **blueprint** are updated: the concave real-power Jensen route now treats the per-integrand step as proved and leaves **Löwner-integral assembly** as the remaining work toward **`posMap_rpow_concave_jensen`** (still an axiom). The blueprint adds lemma `lem:operator_jensen_positive_map_rpow_integrand` and wires it into the not-yet-ready concave Jensen theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3fa6749e6f2513de03b795a20c398c91d1033d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->