### PR TITLE
feat(Channel): record reduction map self-duality

### DIFF
--- a/TNLean/Channel/PositiveExamples.lean
+++ b/TNLean/Channel/PositiveExamples.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.Algebra.HermitianHelpers
+import TNLean.Algebra.TracePairing
 import TNLean.Channel.Basic
 import TNLean.Channel.ChoiJamiolkowski
 
@@ -17,6 +18,8 @@ This file records elementary positive maps from Wolf Chapter 3.
 * `Matrix.reductionMap`: the reduction map
   \(X \mapsto \operatorname{tr}(X) I - k^{-1}X\).
 * `Matrix.reductionMap_one_isPositiveMap`: the case \(k=1\) is positive.
+* `Matrix.traceAdjointMap_reductionMap`: the reduction map is self-dual for
+  the trace pairing.
 * `ChoiJamiolkowski.choiMatrix_reductionMap`: Choi matrix of the reduction map.
 
 ## References
@@ -58,6 +61,29 @@ theorem reductionMap_one_isPositiveMap {D : ℕ} [NeZero D] :
   intro X hX
   simpa [reductionMap] using
     (Matrix.PosSemidef.trace_smul_one_sub_self_posSemidef hX)
+
+/-- **Wolf Chapter 3, Example 3.1, equation (3.18).** The reduction map is
+self-dual for the bilinear trace pairing:
+\[
+  \operatorname{tr}(T_k(\rho)X)=\operatorname{tr}(\rho T_k(X)).
+\]
+-/
+theorem traceAdjointMap_reductionMap (D k : ℕ) :
+    Matrix.traceAdjointMap (reductionMap D k) = reductionMap D k := by
+  classical
+  apply LinearMap.ext
+  intro ρ
+  refine sub_eq_zero.mp ((Matrix.trace_mul_right_eq_zero_iff
+    (M := Matrix.traceAdjointMap (reductionMap D k) ρ - reductionMap D k ρ)).1 ?_)
+  intro X
+  rw [Matrix.sub_mul, Matrix.trace_sub]
+  have hleft :
+      Matrix.trace (Matrix.traceAdjointMap (reductionMap D k) ρ * X) =
+        Matrix.trace (ρ * reductionMap D k X) :=
+    Matrix.trace_traceAdjointMap_mul (reductionMap D k) ρ X
+  rw [hleft, sub_eq_zero]
+  simp [reductionMap, Matrix.mul_sub, Matrix.sub_mul, Matrix.trace_sub,
+    Matrix.trace_smul, mul_comm]
 
 end Matrix
 

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -78,6 +78,25 @@ on matrix algebras, following~\cite{Wolf2012Quantum}.
     Therefore all eigenvalues of $\tr(X)\Id-X$ are nonnegative.
 \end{proof}
 
+\begin{theorem}[Self-duality of the reduction map]
+    \label{thm:reduction_map_self_dual}
+    \lean{Matrix.traceAdjointMap_reductionMap}
+    \leanok
+    \uses{def:reduction_map}
+    The reduction map is self-dual for the trace pairing:
+    \[
+        \tr(T_k(\rho)X)=\tr(\rho T_k(X)).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    Expand both sides using
+    $T_k(Y)=\tr(Y)\Id-k^{-1}Y$ and bilinearity of the trace.  Both sides are
+    \[
+        \tr(\rho)\tr(X)-k^{-1}\tr(\rho X).
+    \]
+\end{proof}
+
 \begin{theorem}[Choi matrix of the reduction map]
     \label{thm:choi_matrix_reduction_map}
     \lean{ChoiJamiolkowski.choiMatrix_reductionMap}


### PR DESCRIPTION
## Summary

This PR records the self-duality part of Wolf Chapter 3, Example 3.1, equation (3.18), for the reduction map
\[
  T_k(X)=\operatorname{tr}(X)I-k^{-1}X.
\]

It adds `Matrix.traceAdjointMap_reductionMap`, showing that the trace-pairing adjoint of `T_k` is again `T_k`. Equivalently,
\[
  \operatorname{tr}(T_k(\rho)X)=\operatorname{tr}(\rho T_k(X)).
\]
The proof is the direct bilinear trace calculation after expanding the definition of `T_k`.

The blueprint now contains `thm:reduction_map_self_dual`.

This is progress on LionSR/QICLean#21. It does not prove the `k`-positivity criterion or the witness statement; those still require the Ky-Fan / spectral-criterion layer.

## Validation

- `lake exe cache get`
- `lake build TNLean.Channel.PositiveExamples -q --log-level=info`
- `lake build TNLean -q --log-level=info`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`, then `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- no proof-integrity markers in `TNLean/Channel/PositiveExamples.lean`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Mathlib-style proof and blueprint sync in channel examples; no auth, runtime, or broad API changes.
> 
> **Overview**
> Adds **`Matrix.traceAdjointMap_reductionMap`**, showing the trace-pairing adjoint of the reduction map \(T_k\) equals \(T_k\) itself—i.e. \(\operatorname{tr}(T_k(\rho)X)=\operatorname{tr}(\rho T_k(X))\) (Wolf Ch. 3, Ex. 3.1, eq. 3.18). The proof uses nondegeneracy of the trace pairing via `trace_mul_right_eq_zero_iff` and `trace_traceAdjointMap_mul`, after expanding `reductionMap`.
> 
> **`PositiveExamples.lean`** now imports `TNLean.Algebra.TracePairing` and documents the new result in the module header.
> 
> The blueprint gains **`thm:reduction_map_self_dual`** (`ch04_channels.tex`) with a `\leanok` proof sketch matching the bilinear trace expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9b4702d982100c819ffcc7f7db3514327e265d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->