### PR TITLE
feat(Algebra): add filtering-minimum scalarity lemma

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -10,6 +10,7 @@ import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.MeanInequalities
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Eigs
+import Mathlib.LinearAlgebra.Matrix.Transvection
 import Mathlib.Topology.Instances.Matrix
 
 /-!
@@ -175,6 +176,250 @@ theorem card_le_trace_conjTranspose_mul_self_re_of_det_norm_eq_one
   simpa only [B] using hsum_ge.trans_eq htrace_eq.symm
 
 end FrobeniusDeterminant
+
+section FilteringMinimum
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+private lemma linear_coeff_eq_zero_of_forall_quadratic_nonneg {a b : ℝ} (ha : 0 ≤ a)
+    (h : ∀ t : ℝ, 0 ≤ a * t ^ 2 + b * t) :
+    b = 0 := by
+  by_contra hb
+  have hden : (2 * (a + 1) : ℝ) ≠ 0 := by positivity
+  have htest := h (-b / (2 * (a + 1)))
+  have hbpos : 0 < b ^ 2 := sq_pos_of_ne_zero hb
+  have hcalc : a * (-b / (2 * (a + 1))) ^ 2 + b * (-b / (2 * (a + 1))) < 0 := by
+    field_simp [hden]
+    nlinarith [hbpos, ha]
+  exact not_le_of_gt hcalc htest
+
+private lemma not_lt_of_forall_pos_sq_inv_sq_nonneg {a b : ℝ} (ha : 0 ≤ a)
+    (h : ∀ y : ℝ, 0 < y → 0 ≤ (y ^ 2 - 1) * a + (y⁻¹ ^ 2 - 1) * b) :
+    ¬ a < b := by
+  intro hab
+  by_cases ha0 : a = 0
+  · have h2 := h 2 (by norm_num)
+    norm_num [ha0] at h2
+    nlinarith
+  · have hapos : 0 < a := lt_of_le_of_ne ha (Ne.symm ha0)
+    let s : ℝ := (1 + b / a) / 2
+    have hspos : 0 < s := by
+      dsimp [s]
+      field_simp [ha0]
+      nlinarith
+    have hs1 : 1 < s := by
+      dsimp [s]
+      field_simp [ha0]
+      nlinarith
+    have hslt : a * s < b := by
+      dsimp [s]
+      field_simp [ha0]
+      nlinarith
+    let y : ℝ := Real.sqrt s
+    have hypos : 0 < y := Real.sqrt_pos.mpr hspos
+    have hy2 : y ^ 2 = s := by
+      dsimp [y]
+      rw [Real.sq_sqrt (le_of_lt hspos)]
+    have hyinv2 : y⁻¹ ^ 2 = s⁻¹ := by
+      rw [inv_pow, hy2]
+    have hy := h y hypos
+    rw [hy2, hyinv2] at hy
+    have hsne : s ≠ 0 := ne_of_gt hspos
+    have hneg : (s - 1) * a + (s⁻¹ - 1) * b < 0 := by
+      have hmulneg : s * ((s - 1) * a + (s⁻¹ - 1) * b) < 0 := by
+        field_simp [hsne]
+        nlinarith [hspos, hs1, hslt]
+      exact neg_of_mul_neg_right hmulneg (le_of_lt hspos)
+    exact not_le_of_gt hneg hy
+
+private lemma transvection_trace_filter (i j : n) (z : ℂ) (R : Matrix n n ℂ) :
+    trace (((transvection i j z)ᴴ * transvection i j z) * R) =
+      trace R + (z * R j i + star z * R i j + (star z * z) * R j j) := by
+  have hAA : ((transvection i j z)ᴴ * transvection i j z) =
+      (1 : Matrix n n ℂ) + single i j z + single j i (star z) +
+        single j j (star z * z) := by
+    simp [transvection, Matrix.conjTranspose_add, Matrix.conjTranspose_single, Matrix.add_mul,
+      Matrix.mul_add, Matrix.single_mul_single_same, add_assoc, add_comm, add_left_comm]
+  rw [hAA]
+  simp [Matrix.add_mul, Matrix.trace_add, Matrix.trace_single_mul, add_assoc, add_comm,
+    add_left_comm]
+
+private lemma diagonal_two_filter_det (i j : n) (hij : i ≠ j) {y : ℝ} (hy : y ≠ 0) :
+    (diagonal (fun k : n => if k = i then (y : ℂ) else if k = j then ((y : ℂ)⁻¹)
+      else 1)).det = 1 := by
+  classical
+  rw [Matrix.det_diagonal]
+  have hprod := Finset.prod_eq_mul_of_mem (s := Finset.univ)
+    (f := fun k : n => if k = i then (y : ℂ) else if k = j then ((y : ℂ)⁻¹)
+      else 1)
+    i j (Finset.mem_univ i) (Finset.mem_univ j) hij ?_
+  · simpa [hij.symm, hy] using hprod
+  · intro c hc hcij
+    simp [hcij.1, hcij.2]
+
+private lemma diagonal_two_filter_trace (i j : n) (hij : i ≠ j) (y : ℝ)
+    (R : Matrix n n ℂ) :
+    let d : n → ℂ := fun k => if k = i then (y : ℂ) else if k = j then ((y : ℂ)⁻¹)
+      else 1
+    trace ((diagonal d)ᴴ * diagonal d * R) =
+      trace R + (((y ^ 2 : ℝ) - 1 : ℝ) : ℂ) * R i i +
+        ((((y⁻¹) ^ 2 : ℝ) - 1 : ℝ) : ℂ) * R j j := by
+  classical
+  intro d
+  have htrace : trace ((diagonal d)ᴴ * diagonal d * R) =
+      ∑ x : n, (star (d x) * d x) * R x x := by
+    simp [Matrix.trace, Matrix.mul_apply, Matrix.diagonal_apply]
+  rw [htrace]
+  have hdecomp : (∑ x : n, (star (d x) * d x) * R x x) =
+      ∑ x : n, (R x x + ((star (d x) * d x - 1) * R x x)) := by
+    refine Finset.sum_congr rfl ?_
+    intro x hx
+    ring
+  rw [hdecomp, Finset.sum_add_distrib]
+  have hsum := Finset.sum_eq_add_of_mem (s := Finset.univ)
+    (f := fun x : n => (star (d x) * d x - 1) * R x x)
+    i j (Finset.mem_univ i) (Finset.mem_univ j) hij ?_
+  · rw [hsum]
+    simp [Matrix.trace, d, hij.symm, pow_two]
+    ring
+  · intro c hc hcij
+    simp [d, hcij.1, hcij.2]
+
+private lemma ofReal_mul_re (a b : ℝ) :
+    (((a : ℂ) * (b : ℂ)).re) = a * b := by
+  rw [Complex.mul_re]
+  rw [Complex.ofReal_re, Complex.ofReal_im, Complex.ofReal_re, Complex.ofReal_im]
+  ring
+
+private lemma offdiag_re_eq_zero_of_filtering_min {R : Matrix n n ℂ} (hR : R.PosSemidef)
+    (hmin : ∀ A : Matrix n n ℂ, A.det = 1 →
+      (trace (Aᴴ * A * R)).re ≥ (trace R).re)
+    {i j : n} (hij : i ≠ j) :
+    (R i j).re = 0 := by
+  have hdiag_nonneg : 0 ≤ (R j j).re := by
+    exact (RCLike.nonneg_iff.mp hR.diag_nonneg).1
+  have hquad : ∀ t : ℝ, 0 ≤ (R j j).re * t ^ 2 + (2 * (R i j).re) * t := by
+    intro t
+    have hineq := hmin (transvection i j (t : ℂ))
+      (det_transvection_of_ne i j hij (t : ℂ))
+    rw [transvection_trace_filter] at hineq
+    rw [Complex.add_re] at hineq
+    have hq : 0 ≤ ((t : ℂ) * R j i + star (t : ℂ) * R i j +
+        (star (t : ℂ) * (t : ℂ)) * R j j).re := by
+      linarith
+    convert hq using 1
+    · rw [← hR.isHermitian.apply j i]
+      have hdiag : ((R j j).re : ℂ) = R j j := hR.isHermitian.coe_re_apply_self j
+      rw [← hdiag]
+      simp [Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, pow_two]
+      ring
+  have hb := linear_coeff_eq_zero_of_forall_quadratic_nonneg hdiag_nonneg hquad
+  nlinarith
+
+private lemma offdiag_im_eq_zero_of_filtering_min {R : Matrix n n ℂ} (hR : R.PosSemidef)
+    (hmin : ∀ A : Matrix n n ℂ, A.det = 1 →
+      (trace (Aᴴ * A * R)).re ≥ (trace R).re)
+    {i j : n} (hij : i ≠ j) :
+    (R i j).im = 0 := by
+  have hdiag_nonneg : 0 ≤ (R j j).re := by
+    exact (RCLike.nonneg_iff.mp hR.diag_nonneg).1
+  have hquad : ∀ t : ℝ, 0 ≤ (R j j).re * t ^ 2 + (2 * (R i j).im) * t := by
+    intro t
+    have hineq := hmin (transvection i j ((t : ℂ) * Complex.I))
+      (det_transvection_of_ne i j hij ((t : ℂ) * Complex.I))
+    rw [transvection_trace_filter] at hineq
+    rw [Complex.add_re] at hineq
+    have hq : 0 ≤ (((t : ℂ) * Complex.I) * R j i +
+        star ((t : ℂ) * Complex.I) * R i j +
+        (star ((t : ℂ) * Complex.I) * ((t : ℂ) * Complex.I)) * R j j).re := by
+      linarith
+    convert hq using 1
+    · rw [← hR.isHermitian.apply j i]
+      have hdiag : ((R j j).re : ℂ) = R j j := hR.isHermitian.coe_re_apply_self j
+      rw [← hdiag]
+      simp [Complex.mul_re, Complex.ofReal_re, Complex.ofReal_im, pow_two]
+      ring
+  have hb := linear_coeff_eq_zero_of_forall_quadratic_nonneg hdiag_nonneg hquad
+  nlinarith
+
+private lemma diag_re_eq_of_filtering_min {R : Matrix n n ℂ} (hR : R.PosSemidef)
+    (hmin : ∀ A : Matrix n n ℂ, A.det = 1 →
+      (trace (Aᴴ * A * R)).re ≥ (trace R).re)
+    (i j : n) :
+    (R i i).re = (R j j).re := by
+  by_cases hij_eq : i = j
+  · subst j
+    rfl
+  · have hij : i ≠ j := hij_eq
+    have hdiag_nonneg_i : 0 ≤ (R i i).re := by
+      exact (RCLike.nonneg_iff.mp hR.diag_nonneg).1
+    have hdiag_nonneg_j : 0 ≤ (R j j).re := by
+      exact (RCLike.nonneg_iff.mp hR.diag_nonneg).1
+    have hineq_order : ∀ p q : n, p ≠ q → ∀ y : ℝ, 0 < y →
+        0 ≤ (y ^ 2 - 1) * (R p p).re + (y⁻¹ ^ 2 - 1) * (R q q).re := by
+      intro p q hpq y hy
+      let d : n → ℂ := fun k => if k = p then (y : ℂ) else if k = q then
+        ((y : ℂ)⁻¹) else 1
+      have hineq := hmin (diagonal d) (diagonal_two_filter_det p q hpq (ne_of_gt hy))
+      rw [diagonal_two_filter_trace p q hpq y R] at hineq
+      rw [Complex.add_re, Complex.add_re] at hineq
+      have hq : 0 ≤ ((((y ^ 2 : ℝ) - 1 : ℝ) : ℂ) * R p p).re +
+          (((((y⁻¹) ^ 2 : ℝ) - 1 : ℝ) : ℂ) * R q q).re := by
+        linarith
+      have hpp : ((R p p).re : ℂ) = R p p := hR.isHermitian.coe_re_apply_self p
+      have hqq : ((R q q).re : ℂ) = R q q := hR.isHermitian.coe_re_apply_self q
+      have hpterm : (((((y ^ 2 : ℝ) - 1 : ℝ) : ℂ) * R p p).re) =
+          (y ^ 2 - 1) * (R p p).re := by
+        rw [← hpp]
+        exact ofReal_mul_re _ _
+      have hqterm : ((((((y⁻¹) ^ 2 : ℝ) - 1 : ℝ) : ℂ) * R q q).re) =
+          (y⁻¹ ^ 2 - 1) * (R q q).re := by
+        rw [← hqq]
+        exact ofReal_mul_re _ _
+      rw [hpterm, hqterm] at hq
+      exact hq
+    have hnot_lt_ij : ¬ (R i i).re < (R j j).re :=
+      not_lt_of_forall_pos_sq_inv_sq_nonneg hdiag_nonneg_i (hineq_order i j hij)
+    have hnot_lt_ji : ¬ (R j j).re < (R i i).re :=
+      not_lt_of_forall_pos_sq_inv_sq_nonneg hdiag_nonneg_j (hineq_order j i hij.symm)
+    exact le_antisymm (le_of_not_gt hnot_lt_ji) (le_of_not_gt hnot_lt_ij)
+
+/-- If determinant-one filters cannot decrease the real trace pairing with a positive semidefinite
+matrix, then the matrix is scalar. -/
+theorem scalar_of_filtering_min {R : Matrix n n ℂ} (hR : R.PosSemidef)
+    (hmin : ∀ A : Matrix n n ℂ, A.det = 1 →
+      (trace (Aᴴ * A * R)).re ≥ (trace R).re) :
+    ∃ c : ℂ, R = c • (1 : Matrix n n ℂ) := by
+  classical
+  cases isEmpty_or_nonempty n with
+  | inl _ =>
+      exact ⟨0, Subsingleton.elim _ _⟩
+  | inr hNonempty =>
+      obtain ⟨i0⟩ := hNonempty
+      refine ⟨R i0 i0, ?_⟩
+      ext i j
+      by_cases hij : i = j
+      · subst j
+        have hre := diag_re_eq_of_filtering_min hR hmin i i0
+        have hii : ((R i i).re : ℂ) = R i i := hR.isHermitian.coe_re_apply_self i
+        have hi0 : ((R i0 i0).re : ℂ) = R i0 i0 := hR.isHermitian.coe_re_apply_self i0
+        rw [← hii, ← hi0, hre]
+        simp
+      · have hre := offdiag_re_eq_zero_of_filtering_min hR hmin hij
+        have him := offdiag_im_eq_zero_of_filtering_min hR hmin hij
+        have hzero : R i j = 0 := Complex.ext hre him
+        simp [hij, hzero]
+
+/-- Wolf §2.3 AM--GM stationarity core: a positive semidefinite matrix whose real trace
+pairing is minimized by the identity among determinant-one filters is scalar. -/
+theorem posDef_scalar_of_filtering_min {D : ℕ} {R : Matrix (Fin D) (Fin D) ℂ}
+    (hR : R.PosSemidef)
+    (hmin : ∀ A : Matrix (Fin D) (Fin D) ℂ, A.det = 1 →
+      (trace (Aᴴ * A * R)).re ≥ (trace R).re) :
+    ∃ c : ℂ, R = c • (1 : Matrix (Fin D) (Fin D) ℂ) :=
+  scalar_of_filtering_min hR hmin
+
+end FilteringMinimum
 
 section PosSemidefTrace
 


### PR DESCRIPTION
## Summary

This PR adds the standalone AM--GM stationarity core requested in LionSR/QICLean#12.  The new theorem `Matrix.posDef_scalar_of_filtering_min` states that a positive semidefinite matrix `R : Matrix (Fin D) (Fin D) ℂ` is scalar if the identity minimizes the real trace pairing

`Re (trace (Aᴴ * A * R)) ≥ Re (trace R)`

among all determinant-one filters `A`.

The proof is calculus-free.  Determinant-one transvections force all off-diagonal entries of `R` to vanish, and determinant-one two-coordinate diagonal filters force all diagonal entries to agree.  A finite-index general theorem `Matrix.scalar_of_filtering_min` is also provided, with the requested `Fin D` theorem as a wrapper.

This is only the spectral stationarity core for LionSR/QICLean#12.  It does not modify `Wolf.exists_normal_form_generic`, and it does not add the Choi-conjugation bridge or partial-trace adjunction.

## Validation

- `lake build TNLean.Algebra.MatrixAux -q --log-level=info`
- `lake build TNLean.Channel.LorentzNormalForm -q --log-level=info`
- `lake build TNLean -q --log-level=error`
- `git diff --check`
- `rg -n "sorry|admit|native_decide|unsafeCast|axiom" TNLean/Algebra/MatrixAux.lean || true`

The broader build still reports existing warnings in unrelated files, including the known Lorentz-normal-form `sorry` declarations and other pre-existing linter warnings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization in one file with no changes to existing theorems or runtime behavior; main risk is proof maintenance in dense matrix algebra, not production regressions.
> 
> **Overview**
> Adds a new **`FilteringMinimum`** section in `MatrixAux.lean` (plus `Matrix.Transvection`) that proves PSD matrices are **scalar** when the identity is optimal among **det = 1** filters for the real trace functional `Re (trace (Aᴴ * A * R))`.
> 
> The proof is built from small real inequalities and explicit **transvection** / **two-coordinate diagonal** filters: off-diagonals vanish via quadratics in a real parameter, and diagonal reals are forced equal via `y²` / `y⁻²` comparisons. **`scalar_of_filtering_min`** is the general `Fintype` index theorem; **`posDef_scalar_of_filtering_min`** is the `Fin D` wrapper cited for Wolf §2.3 / issue LionSR/QICLean#12.
> 
> No other TNLean modules are wired to these names yet—this is standalone spectral stationarity infrastructure ahead of Lorentz normal-form work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6585543606a14b2bdf0e332fcc51d5b92cf3eb89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->