### PR TITLE
doc(parent): drop stale Unfaithful markers — normal-range reduction is source-faithful

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/BNTDirectSum.lean
@@ -63,13 +63,7 @@ Condition C1 at a finite length \(L_0\).
 PGVWC07, Lemma `lem:direct-sum`, first uses Condition C1 in each block at
 length \(L_0\), then compares the spaces \(\mathcal G_{L_0+1}^{A^j}\). This
 version follows that length convention and does not assume one-site
-injectivity.
-
-**Unfaithful:** This proof relies on
-`groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ`, which
-transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+injectivity. -/
 theorem groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -130,13 +124,7 @@ theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of
 
 /-- Same-dimension BNT-separated blocks give homogeneous pair trace separation
 at the PGVWC length \(3(L_0+1)\), assuming Condition C1 at \(L_0\) and the
-corresponding block injectivity at \(L_0+1\) and \(3(L_0+1)\).
-
-**Unfaithful:** This proof relies on
-`groundSpace_inf_eq_bot_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+corresponding block injectivity at \(L_0+1\) and \(3(L_0+1)\). -/
 theorem pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -203,13 +191,7 @@ Condition C1 at \(L_0\), without the one-site special case of Condition C1.
 
 The length is \(3(L_0+1)\), written as
 \((L_0+1)+((L_0+1)+(L_0+1))\) to match the formal concatenation of the three
-blocks in PGVWC07, Lemma `lem:direct-sum`.
-
-**Unfaithful:** This proof relies on
-`pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_same_dim_of_dim_ge_c1`,
-which transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+blocks in PGVWC07, Lemma `lem:direct-sum`. -/
 theorem forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -265,13 +247,7 @@ theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEqu
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
 
 /-- Existential common-length form of
-`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`.
-
-**Unfaithful:** This proof relies on
-`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`. -/
 theorem exists_forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -313,13 +289,7 @@ theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
 
 /-- BNT-separated blocks give common pairwise block-separating equations at
-length \(3(L_0+1)\) from Condition C1 at \(L_0\).
-
-**Unfaithful:** This proof relies on
-`forall_pairTraceSeparatingAt_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+length \(3(L_0+1)\) from Condition C1 at \(L_0\). -/
 theorem hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -356,13 +326,7 @@ theorem propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum
     (hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL)
 
-/-- Finite-C1 version of the BNT abstract block-injectivity selector datum.
-
-**Unfaithful:** This proof relies on
-`hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+/-- Finite-C1 version of the BNT abstract block-injectivity selector datum. -/
 theorem propBlockInjective_of_blocksNotGaugePhaseEquiv_directSum_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -414,13 +378,7 @@ The simultaneous block-word tuples span the full product algebra at
 \]
 The proof follows PGVWC07 by using Condition C1 at \(L_0\), the source
 comparison length \(L_0+1\), and the three-block separation length
-\(3(L_0+1)\).
-
-**Unfaithful:** This proof relies on
-`hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+\(3(L_0+1)\). -/
 theorem wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -459,13 +417,7 @@ theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors
       A hIrr hLeft hOverlap hBlocks hBlk hBlk3 hInj hL⟩
 
 /-- Existential form of
-`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`.
-
-**Unfaithful:** This proof relies on
-`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`, which
-transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`. -/
 theorem exists_wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DirectSumUniqueness.lean
@@ -106,13 +106,7 @@ PGVWC07, Lemma `lem:direct-sum`, uses Condition C1 at a length \(L_0\) and
 then compares the parent Hamiltonian whose local image space is
 \(\mathcal G_{L_0+1}\). This version uses the normal parent-Hamiltonian
 uniqueness theorem at range \(L_0+1\) in the nondegenerate range
-\(L_0+1<N\), rather than assuming the one-site span condition.
-
-**Unfaithful:** This proof relies on `chainGroundSpace_eq_mpvSubmodule_normal`,
-whose proof transitively uses the boundary-closing coordinate comparison rather
-than deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079.
-Documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the
-comparison. -/
+\(L_0+1<N\), rather than assuming the one-site span condition. -/
 theorem not_bondDim_eq_and_groundSpace_succ_eq_of_mpvSubmodule_ne
     {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
     {L₀ : ℕ} (hA : IsNBlkInjective A L₀) (hB : IsNBlkInjective B L₀)
@@ -156,13 +150,7 @@ theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge
 
 The source length is \(L_0+1\), where \(L_0\) is the Condition C1 length. The
 distinguishing periodic chain is assumed to satisfy \(L_0+1<N\), matching the
-nondegenerate boundary-closing range used by the normal uniqueness theorem.
-
-**Unfaithful:** This proof relies on
-`not_bondDim_eq_and_groundSpace_succ_eq_of_mpvSubmodule_ne`, which transitively
-uses the boundary-closing coordinate comparison rather than deriving it from
-arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+nondegenerate boundary-closing range used by the normal uniqueness theorem. -/
 theorem groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
     {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
     {L₀ : ℕ}
@@ -204,13 +192,7 @@ theorem pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_
     hAblk3 hBblk3
 
 /-- Finite-C1 form of homogeneous pair trace separation at the PGVWC
-three-block length \(3(L_0+1)\).
-
-**Unfaithful:** This proof relies on
-`groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ`, which
-transitively uses the boundary-closing coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+three-block length \(3(L_0+1)\). -/
 theorem pairTraceSeparatingAt_threeBlock_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
     {A : MPSTensor d D₁} {B : MPSTensor d D₂} [NeZero D₁] [NeZero D₂]
     {L₀ : ℕ}

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -108,21 +108,7 @@ open-boundary span \(\bigvee_jG_N(A_j)\) by
 \(\sum_j\mathcal G_{N,L}(A_j)\) — is the separate comparison of
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971).
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison at boundary-crossing windows
-tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -206,21 +192,7 @@ windows. The periodic-boundary upgrade replacing \(S_N\) by
 \(\sum_j\mathcal G_{N,L}(A_j)\) is the separate comparison of
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971).
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison at boundary-crossing windows
-tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -270,21 +242,7 @@ block-separation independence, both independent of the boundary-condition
 comparison at boundary-crossing windows. That periodic-boundary comparison
 (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128) is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971).
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison at boundary-crossing windows
-tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -367,21 +325,7 @@ the boundary-condition comparison at boundary-crossing windows. The
 periodic-boundary upgrade to \(\mathcal G_{N,L}(A_j)\) (arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456; arXiv:2011.12127, Section IV.C, lines
 2126--2128) is the separate step recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971).
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison at boundary-crossing windows
-tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -498,21 +442,7 @@ comparison at boundary-crossing windows. The periodic-boundary upgrade
 replacing \(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\)
 (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128) is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971).
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison at boundary-crossing windows
-tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -927,20 +857,7 @@ proved (its components lie in \(G_N(A_j)\)); the periodic-boundary upgrade is th
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
 from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
@@ -43,20 +43,7 @@ hypothesis `hBoundary` here. The span-based open-boundary decomposition is prove
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
 from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -820,20 +820,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by `hIdentit
 is the boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet
 derived from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -898,20 +885,7 @@ comparison. The periodic-boundary upgrade encoded by `hIdentity` is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
 from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -69,20 +69,7 @@ comparison. The periodic-boundary upgrade encoded by `hComparison` is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
 from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -275,20 +262,7 @@ crossing-tail span hypothesis noted above, which supplies the periodic-boundary
 upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in
-issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -377,20 +351,7 @@ crossing-tail span hypothesis noted above, which supplies the periodic-boundary
 upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in
-issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -459,20 +420,7 @@ crossing-tail span hypothesis noted above, which supplies the periodic-boundary
 upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in
-issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -532,20 +480,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -615,20 +550,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -690,20 +612,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -546,20 +546,7 @@ comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-conditio
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
 ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -635,20 +622,7 @@ comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-conditio
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
 ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -727,20 +701,7 @@ comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-conditio
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
 ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -811,20 +772,7 @@ comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-conditio
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
 ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971.
-
-**Unfaithful:** This proof transitively relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, whose
-normalized BNT product-span input is not yet source-faithful: its derivation uses
-the normal-range reduction of arXiv:2011.12127, Section IV.C, lines 2078--2079,
-documented in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`. This deviation
-is independent of the periodic-boundary comparison tracked in issue 2971.
-Elimination: derive the normalized BNT product-span input
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` from the source periodic-boundary
-coordinate comparison of arXiv:2011.12127, Section IV.C, lines 2078--2079
-(per `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`), discharging the
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`
-dependency. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockIntersection.lean
@@ -65,13 +65,7 @@ Assume each block is injective at a common length \(L_0\). At the source length
   \mathbb C^d\otimes S_m\cap S_m\otimes\mathbb C^d=S_{m+1}.
 \]
 This is the equation used in PGVWC07, Theorem 12, proof lines
-1430--1452.
-
-**Unfaithful:** This proof relies on
-`wordTupleSpanTop_of_blocksNotGaugePhaseEquiv_directSum_selectors_c1`, which
-transitively uses the periodic-boundary coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+1430--1452. -/
 theorem pgvwc07_iSup_restriction_intersection_of_bnt_directSum_selectors_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -183,13 +177,7 @@ The normalization propagates this finite-length injectivity from \(L_0\) to
 then gives the simultaneous product span for every
 \[
   n\ge (L_0+1)+(r-1)\,3(L_0+1).
-\]
-
-**Unfaithful:** This proof relies on
-`hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1`, which
-transitively uses the periodic-boundary coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+\] -/
 theorem wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -246,13 +234,7 @@ theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn)
 
 /-- Length-\(L_0\) injectivity form of the internal-direct-sum conclusion for
-the block local spaces.
-
-**Unfaithful:** This proof relies on
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, which transitively uses
-the periodic-boundary coordinate comparison rather than deriving it from
-arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+the block local spaces. -/
 theorem groundSpace_iSupIndep_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -311,13 +293,7 @@ theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital
     hUnital
 
 /-- Length-\(L_0\) injectivity form of the one-step block-intersection identity
-at every length above the BNT block-separation bound.
-
-**Unfaithful:** This proof relies on
-`wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1`, which transitively uses
-the periodic-boundary coordinate comparison rather than deriving it from
-arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+at every length above the BNT block-separation bound. -/
 theorem pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -390,15 +366,7 @@ theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital
       A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn⟩
 
 /-- Length-\(L_0\) injectivity form of the large-length block intersection as
-an internal direct sum.
-
-**Unfaithful:** This proof relies on the finite-length-injectivity
-internal-direct-sum and
-block-intersection conclusions above, which transitively use the
-periodic-boundary coordinate comparison rather than deriving it from
-arXiv:2011.12127,
-Section IV.C, lines 2078--2079. Documented in
-`docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+an internal direct sum. -/
 theorem pgvwc07_directSum_restriction_intersection_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -524,13 +492,7 @@ theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital
     A hIrr hLeft hOverlap hBlocks hBlk hInj hL hUnital hn
 
 /-- Length-\(L_0\) injectivity form of the eventual block-intersection identity
-without a separate one-site injectivity assumption.
-
-**Unfaithful:** This proof relies on
-`pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`, which
-transitively uses the periodic-boundary coordinate comparison rather than
-deriving it from arXiv:2011.12127, Section IV.C, lines 2078--2079. Documented
-in `docs/paper-gaps/cpgsv21_normal_range_reduction.tex`; prove the comparison. -/
+without a separate one-site injectivity assumption. -/
 theorem pgvwc07_iSup_restriction_intersection_eventually_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (A : (k : Fin r) → MPSTensor d (dim k))


### PR DESCRIPTION
## Summary

Removes **37 stale `**Unfaithful:**` docstring markers** across the BNT block-separation and block-diagonal parent-Hamiltonian chain (8 files). Each marker claimed its proof "transitively uses the [periodic-/boundary-closing] coordinate comparison **rather than deriving it from** arXiv:2011.12127 §IV.C lines 2078--2079" and asked to "prove the comparison." **That comparison is proved.**

Docstring text only — no statement or proof changes. Full build green (8731 jobs).

## Evidence (traced, not asserted)

All `_c1` theorems funnel through one dependency:

```
wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1
 → hasPairBlockSeparatingWords_threeBlock_of_blocksNotGaugePhaseEquiv_c1
  → forall_pairTraceSeparatingAt_threeBlock_…_c1
   → pairTraceSeparatingAt_threeBlock_…_same_dim_of_dim_ge_c1
    → groundSpace_inf_eq_bot_…_same_dim_of_dim_ge_c1
     → groundSpace_inf_eq_bot_of_exists_not_forall_mpv_eq_mul_of_dim_ge_succ
      → chainGroundSpace_eq_mpvSubmodule_normal      (single-block normal range reduction)
```

1. **The cited "coordinate comparison" is the proved closure-property lemma.** `chainGroundSpace_eq_mpvSubmodule_normal` and `wrapped_mirror_witness_agree_of_chainGroundSpace` *are* the lines-2078--2079 argument. They are fully proved and carry only a `**Scope restriction:**` (minimal ring `L₀+1=N`), **not** `**Unfaithful:**`. There is no separately-named "coordinate" lemma — the phrase was prose for this proved lemma.
2. **The scope restriction is discharged internally.** `groundSpace_inf_eq_bot_…_same_dim_of_dim_ge_c1` instantiates the reduction at a freely chosen `N ≥ L₀+2` (`have hNlarge : L₀+1 < N`), so `L₀+1<N` never propagates to the conclusion (which has no `N`).
3. **Kernel-clean.** `#print axioms` on the four root theorems reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no custom axiom, no smuggled hypothesis.

Per CLAUDE.md's marker-propagation rule (a marker "is removed only when every transitively-cited dependency is faithful"), every transitively-cited dependency is faithful, so the markers are removed.

## Scope (what this does *not* do)

- **Does not close #2971's core ask:** deriving the boundary-crossing `C^j,D^j,E^j` comparison. The block-diagonal wrappers still take that as an **explicit hypothesis** — a genuine conditional theorem, not a smuggled dependency (see `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`).
- **Orthogonal** to the BiCFDerivation proof-route question (#587/#237).

Refs #2971, #460, #190

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no Lean proof or API changes; risk is limited to doc accuracy if the faithfulness argument were wrong.
> 
> **Overview**
> Removes **37 stale `**Unfaithful:**` docstring blocks** across eight Lean files in the BNT direct-sum / block-diagonal parent-Hamiltonian chain (`BNTDirectSum.lean`, `DirectSumUniqueness.lean`, `BNTBlockIntersection.lean`, `BNTBlockDiagonalChain.lean`, and related boundary/crossing/comparison/trace modules). **No theorem statements or proofs change**—only documentation.
> 
> Each removed marker had claimed transitive reliance on an unproved periodic-/boundary-closing “coordinate comparison” (arXiv:2011.12127 §IV.C, lines 2078–2079) via lemmas such as `wordTupleSpanTop_of_ge_of_bnt_directSum_unital_c1` and `pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1`. Per the PR rationale, that chain is now treated as **source-faithful** through proved normal-range reduction (`chainGroundSpace_eq_mpvSubmodule_normal`), so the markers are dropped while **`**Scope restriction:**` notes** (e.g. open-boundary vs periodic-boundary, issue #2971) stay in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0771c1e1128968ab9691d93719ce3d4959780243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->