### PR TITLE
feat(PEPS): strengthen closed-chain normal MPS FT to n ≥ 2L+1 (#2706)

### DIFF
--- a/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
+++ b/TNLean/PEPS/CycleMPSFundamentalTheorem.lean
@@ -1,6 +1,7 @@
 import TNLean.PEPS.CycleMPSInjectivity
 import TNLean.PEPS.CycleFundamentalTheorem
 import TNLean.PEPS.TorusAbsorbedCovariance
+import TNLean.PEPS.CycleMPSOverlapCapstone
 
 /-!
 # The Fundamental Theorem for translation-invariant normal MPS on a closed chain
@@ -10,10 +11,9 @@ Fundamental Theorem for normal PEPS (arXiv:1804.04964, Section 3, first
 corollary after the theorem labelled `normal`, lines 1585--1631 of
 `Papers/1804.04964/paper_normal.tex`), specialized to one site-independent
 tensor: two matrix tensors `A, B`, each `L`-block injective, generating the
-same closed-chain state on `n ≥ 3L` sites, are related by invertible matrices
-`Z_v` (one per bond, `n + 1 ≡ 1`) with `B = Z_v⁻¹ A Z_{v+1}` at every site
-(`fundamentalTheorem_normalMPS`), and the `Z_v` are unique up to one
-multiplicative constant (`fundamentalTheorem_normalMPS_gauge_unique`).
+same closed-chain state on `n ≥ 2L + 1` sites, are related by invertible
+matrices `Z_v` (one per bond, `n + 1 ≡ 1`) with `B = Z_v⁻¹ A Z_{v+1}` at
+every site (`fundamentalTheorem_normalMPS`).
 
 The statement is the source corollary's conclusion — a family of per-bond
 gauges — with the source's site-dependent families `{A_i}`, `{B_i}`
@@ -21,30 +21,36 @@ specialized to a single repeated tensor; the source's translation-invariant
 corollary (lines 1624--1661: a single gauge `Z` and a constant `λ` with
 `λ^n = 1`) refines this output and is not delivered here.
 
-The derivation goes through the cycle-graph corollary
-(`fundamentalTheorem_normalMPS_cycle`): the cycle tensors of `A` and `B`
-generate the same state since their coefficients are the matrix-product
+The existence clause carries the optimal system size `n ≥ 2L + 1` of the
+source's alternative proof (line 1623 and Section `normal_alt`, the corollary
+after Lemma 5): `fundamentalTheorem_normalMPS` delegates to the
+overlapping-window corollary `fundamentalTheorem_normalMPS_of_overlap`.
+
+The uniqueness clause `fundamentalTheorem_normalMPS_gauge_unique` still uses
+the `n ≥ 3L` route through the cycle-graph corollary
+(`fundamentalTheorem_normalMPS_cycle`).  There the cycle tensors of `A` and
+`B` generate the same state since their coefficients are the matrix-product
 traces, every arc of `L` consecutive sites is blocked-injective by `L`-block
 injectivity of the matrix tensors, and the graph-level gauge equivalence
-hands back one invertible matrix per edge.  The per-edge
-matrices convert to per-bond gauges through the stored-edge orientation: away
-from the seam the gauge of the bond entering site `v` is the transpose of the
-edge matrix, while on the seam edge — stored with its endpoints in the
-opposite order — it is the inverse (`cycleGaugeOfEdgeGauge`).  The per-vertex
-component identity of the graph-level gauge equivalence is equivalent to the
-matrix identity `B = Z_v⁻¹ A Z_{v+1}` (`cycleGauge_component_iff_matrix`).
-The uniqueness clause converts a per-bond family back into a per-edge family
+hands back one invertible matrix per edge.  The per-edge matrices convert to
+per-bond gauges through the stored-edge orientation: away from the seam the
+gauge of the bond entering site `v` is the transpose of the edge matrix,
+while on the seam edge — stored with its endpoints in the opposite order — it
+is the inverse (`cycleGaugeOfEdgeGauge`).  The per-vertex component identity
+of the graph-level gauge equivalence is equivalent to the matrix identity
+`B = Z_v⁻¹ A Z_{v+1}` (`cycleGauge_component_iff_matrix`).  The uniqueness
+clause converts a per-bond family back into a per-edge family
 (`edgeGaugeOfCycleGauge`), invokes the graph-level uniqueness for a constant
 per edge, and merges the constants into one because the relation
 `B = Z_v⁻¹ A Z_{v+1}` pins the ratio of consecutive constants against the
 nonzero tensor `B`.
 
 The matrix-level hypotheses match the source corollary: `0 < L` (implicit in
-blocking `L` consecutive sites), `3L ≤ n`, `L`-block injectivity of both
-tensors, and equality of the closed-chain coefficients at the single size `n`.
-The positivity side conditions of the graph-level corollary are discharged
-here, not assumed: a vanishing bond dimension makes the conclusion trivial,
-and a vanishing physical dimension contradicts block injectivity.
+blocking `L` consecutive sites), `L`-block injectivity of both tensors, and
+equality of the closed-chain coefficients at the single size `n`.  The
+positivity side conditions of the graph-level corollary are discharged here,
+not assumed: a vanishing bond dimension makes the conclusion trivial, and a
+vanishing physical dimension contradicts block injectivity.
 
 ## References
 
@@ -408,11 +414,13 @@ theorem pos_d_of_isNBlkInjective {L : ℕ} (hL : 0 < L) (hD : 0 < D)
 
 /-- **Fundamental Theorem for translation-invariant normal MPS on a closed
 chain** (arXiv:1804.04964, Section 3, first corollary after the theorem
-labelled `normal`, specialized to one site-independent tensor).
+labelled `normal`, specialized to one site-independent tensor; strengthened
+to the optimal system size of the alternative proof of its Section
+`normal_alt`).
 
-Two matrix tensors `A` and `B` on `n ≥ 3L` sites, each `L`-block injective —
-the matrix form of "blocking any `L` consecutive sites results in an
-injective tensor" for a site-independent family — generating the same
+Two matrix tensors `A` and `B` on `n ≥ 2L + 1` sites, each `L`-block
+injective — the matrix form of "blocking any `L` consecutive sites results
+in an injective tensor" for a site-independent family — generating the same
 closed-chain state at the single size `n`, are related by invertible matrices
 `Z_v`, one per bond of the closed chain (`n + 1 ≡ 1`), with
 `B = Z_v⁻¹ A Z_{v+1}` at every site.
@@ -423,38 +431,23 @@ statement is its specialization to one repeated tensor, and the source's
 translation-invariant corollary (lines 1624--1661, a single gauge `Z` with a
 constant `λ`, `λ^n = 1`) is the follow-up refinement, not delivered here.
 
+The system size is the optimal `n ≥ 2L + 1` of the source's alternative
+proof (line 1623 and Section `normal_alt`, the corollary after Lemma 5),
+rather than the `n ≥ 3L` of the Section-`normal` blocking route: the proof
+delegates to the overlapping-window corollary
+`fundamentalTheorem_normalMPS_of_overlap`.
+
 Source: arXiv:1804.04964, Section 3, first corollary after the theorem
-labelled `normal`, lines 1585--1631 of
-`Papers/1804.04964/paper_normal.tex`. -/
+labelled `normal`, lines 1585--1631 of `Papers/1804.04964/paper_normal.tex`,
+strengthened to `n ≥ 2L + 1` per line 1623 and Section `normal_alt`. -/
 theorem fundamentalTheorem_normalMPS {n L d D : ℕ} [NeZero n] (hL : 0 < L)
-    (hn : 3 * L ≤ n)
+    (hn : 2 * L + 1 ≤ n)
     (A B : MPSTensor d D) (hA : MPSTensor.IsNBlkInjective A L)
     (hB : MPSTensor.IsNBlkInjective B L)
     (hAB : ∀ σ : Fin n → Fin d, MPSTensor.mpv A σ = MPSTensor.mpv B σ) :
     ∃ Z : Fin n → GL (Fin D) ℂ, ∀ (v : Fin n) (i : Fin d),
-      B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ) := by
-  -- A vanishing bond dimension makes all matrices equal and the claim trivial.
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · subst hD0
-    refine ⟨fun _ => 1, fun v i => ?_⟩
-    apply Matrix.ext
-    intro a b
-    exact a.elim0
-  have hn3 : 3 ≤ n := by omega
-  have hLn : L < n := by omega
-  have hd : 0 < d := pos_d_of_isNBlkInjective hL hD hA
-  -- The cycle tensors generate the same state and have injective arcs.
-  have hstate : SameState (cycleTensorOfMPS hn3 A) (cycleTensorOfMPS hn3 B) := fun σ => by
-    rw [stateCoeff_cycleTensorOfMPS, stateCoeff_cycleTensorOfMPS]
-    exact hAB σ
-  obtain ⟨hDim, X, hX⟩ := fundamentalTheorem_normalMPS_cycle hL hn
-    (cycleTensorOfMPS hn3 A) (cycleTensorOfMPS hn3 B)
-    (fun s => regionBlockedTensorInjective_cycleTensorOfMPS hn3 hL hLn hD hA s)
-    (fun s => regionBlockedTensorInjective_cycleTensorOfMPS hn3 hL hLn hD hB s)
-    hstate hd (fun _ => hD) (fun _ => hD)
-  -- Convert the per-edge gauges to per-bond gauges.
-  refine ⟨cycleGaugeOfEdgeGauge hn3 X, fun v => ?_⟩
-  exact (cycleGauge_component_iff_matrix hn3 A B X v).mp (fun η σ => hX v η σ)
+      B i = ((Z v)⁻¹ : GL (Fin D) ℂ) * A i * (Z (v + 1) : GL (Fin D) ℂ) :=
+  fundamentalTheorem_normalMPS_of_overlap hL hn A B hA hB hAB
 
 /-- **Uniqueness clause of the Fundamental Theorem for translation-invariant
 normal MPS on a closed chain** (arXiv:1804.04964, Section 3, first corollary
@@ -466,6 +459,14 @@ at every site of the closed chain of `n ≥ 3L` sites are proportional by a
 single constant.  The per-edge constants come from the graph-level uniqueness
 clause; the relation itself pins the ratio of consecutive constants against
 the nonzero tensor `B`, merging them into one.
+
+The source's uniqueness clause carries no system-size constraint, while this
+proof keeps the `n ≥ 3L` of the graph-level uniqueness route it invokes; the
+existence clause `fundamentalTheorem_normalMPS` already holds at the optimal
+`n ≥ 2L + 1`.  The size-free single-gauge uniqueness is
+`fundamentalTheorem_normalMPS_translationInvariant_gauge_unique`; lowering
+this per-bond clause to `n ≥ 2L + 1` is tracked as a follow-up to
+`docs/paper-gaps/peps_normal_ft_section3_route.tex`.
 
 Source: arXiv:1804.04964, Section 3, first corollary after the theorem
 labelled `normal`, lines 1585--1631 of

--- a/TNLean/PEPS/CycleMPSOverlapCapstone.lean
+++ b/TNLean/PEPS/CycleMPSOverlapCapstone.lean
@@ -1,5 +1,5 @@
 import TNLean.PEPS.CycleMPSOverlapInsertion
-import TNLean.PEPS.CycleMPSFundamentalTheorem
+import TNLean.PEPS.CycleArcRegion
 
 /-!
 # The closed-chain corollaries at `n ≥ 2L + 1` via overlapping windows
@@ -15,8 +15,9 @@ translation-invariant MPS on `n ≥ 2L + 1` sites — two matrix tensors, each
   `B^i = λ · Z⁻¹ A^i Z`
   (`fundamentalTheorem_normalMPS_translationInvariant_of_overlap`), and
 * equivalently a per-bond gauge family `Z_v` with `B^i = Z_v⁻¹ A^i Z_{v+1}`
-  (`fundamentalTheorem_normalMPS_of_overlap`), the form delivered at
-  `n ≥ 3L` by `fundamentalTheorem_normalMPS` through the three-arc cover.
+  (`fundamentalTheorem_normalMPS_of_overlap`), the per-bond form of the
+  closed-chain corollary; the named matrix-level corollary
+  `fundamentalTheorem_normalMPS` delegates to it for its `n ≥ 2L + 1` bound.
 
 The uniqueness clause of the source corollary — the gauge `Z` is unique up
 to a multiplicative constant — needs no system size and is already delivered

--- a/TNLean/PEPS/CycleMPSTranslationInvariant.lean
+++ b/TNLean/PEPS/CycleMPSTranslationInvariant.lean
@@ -211,141 +211,32 @@ theorem gaugeFamily_succ_proportional {n L d D : ℕ} [NeZero n] {A B : MPSTenso
 /-! ### The translation-invariant corollary -/
 
 /-- **Fundamental Theorem for translation-invariant normal MPS, single-gauge
-form** (arXiv:1804.04964, Section 3, the corollary for TI MPS).
+form** (arXiv:1804.04964, Section 3, the corollary for TI MPS; strengthened
+to the optimal system size of the alternative proof of its Section
+`normal_alt`).
 
-Two matrix tensors `A` and `B` on `n ≥ 3L` sites, each `L`-block injective —
-the matrix form of "blocking `L` consecutive sites results in an injective
-tensor" — generating the same closed-chain state at the single size `n`, are
-related by one invertible matrix `Z` and a constant `λ` with `λ^n = 1`
-through `B^i = λ · Z⁻¹ A^i Z` for every `i`.
+Two matrix tensors `A` and `B` on `n ≥ 2L + 1` sites, each `L`-block
+injective — the matrix form of "blocking `L` consecutive sites results in an
+injective tensor" — generating the same closed-chain state at the single
+size `n`, are related by one invertible matrix `Z` and a constant `λ` with
+`λ^n = 1` through `B^i = λ · Z⁻¹ A^i Z` for every `i`.
 
-The per-bond family of the matrix-form corollary
-(`fundamentalTheorem_normalMPS`) collapses: consecutive gauges are
-proportional (`gaugeFamily_succ_proportional`), the same-state relation pins
-consecutive scalars against the nonzero tensor `B`, and following the bonds
-once around the closed chain forces the common scalar's `n`-th power to be
-one.
+The system size is the optimal `n ≥ 2L + 1` of the source's alternative
+proof (line 1623 and Section `normal_alt`, the corollary after Lemma 5),
+rather than the `n ≥ 3L` of the Section-`normal` blocking route: the proof
+delegates to the overlapping-window corollary
+`fundamentalTheorem_normalMPS_translationInvariant_of_overlap`.
 
 Source: arXiv:1804.04964, Section 3, the corollary for TI MPS, lines
-1624--1661 of `Papers/1804.04964/paper_normal.tex`. -/
+1624--1661 of `Papers/1804.04964/paper_normal.tex`, strengthened to
+`n ≥ 2L + 1` per line 1623 and Section `normal_alt`. -/
 theorem fundamentalTheorem_normalMPS_translationInvariant {n L d D : ℕ} [NeZero n]
-    (hL : 0 < L) (hn : 3 * L ≤ n) (A B : MPSTensor d D)
+    (hL : 0 < L) (hn : 2 * L + 1 ≤ n) (A B : MPSTensor d D)
     (hA : MPSTensor.IsNBlkInjective A L) (hB : MPSTensor.IsNBlkInjective B L)
     (hAB : ∀ σ : Fin n → Fin d, MPSTensor.mpv A σ = MPSTensor.mpv B σ) :
     ∃ (Z : GL (Fin D) ℂ) (lam : ℂ), lam ^ n = 1 ∧
-      ∀ i : Fin d, B i = lam • ((Z⁻¹ : GL (Fin D) ℂ) * A i * (Z : GL (Fin D) ℂ)) := by
-  -- A vanishing bond dimension makes all matrices equal and the claim trivial.
-  rcases Nat.eq_zero_or_pos D with hD0 | hD
-  · subst hD0
-    refine ⟨1, 1, one_pow n, fun i => ?_⟩
-    apply Matrix.ext
-    intro a b
-    exact a.elim0
-  obtain ⟨Z, hZ⟩ := fundamentalTheorem_normalMPS hL hn A B hA hB hAB
-  obtain ⟨i₀, hi₀⟩ := exists_ne_zero_of_isNBlkInjective hL hD hB
-  -- Consecutive bond gauges differ by a nonzero scalar.
-  choose c hc using fun v => gaugeFamily_succ_proportional hA hZ v
-  -- The relation rewritten without inverses, for pinning the scalars.
-  have hstar : ∀ (v : Fin n) (i : Fin d),
-      (Z v : Matrix (Fin D) (Fin D) ℂ) * B i =
-        A i * (Z (v + 1) : Matrix (Fin D) (Fin D) ℂ) := by
-    intro v i
-    rw [hZ v i]
-    simp only [Matrix.mul_assoc, Units.mul_inv_cancel_left]
-  have hN : ∀ v : Fin n, (Z v : Matrix (Fin D) (Fin D) ℂ) * B i₀ ≠ 0 := by
-    intro v h0
-    apply hi₀
-    have hrec : B i₀ =
-        (((Z v)⁻¹ : GL (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ) *
-          ((Z v : Matrix (Fin D) (Fin D) ℂ) * B i₀) := (Units.inv_mul_cancel_left _ _).symm
-    rw [h0, Matrix.mul_zero] at hrec
-    exact hrec
-  -- The same-state relation pins consecutive scalars to agree.
-  have hstep : ∀ v : Fin n, c (v + 1) = c v := by
-    intro v
-    have hkey : ((c v : ℂ)) • ((Z v : Matrix (Fin D) (Fin D) ℂ) * B i₀) =
-        ((c (v + 1) : ℂ)) • ((Z v : Matrix (Fin D) (Fin D) ℂ) * B i₀) := by
-      calc ((c v : ℂ)) • ((Z v : Matrix (Fin D) (Fin D) ℂ) * B i₀)
-          = (((c v : ℂ)) • (Z v : Matrix (Fin D) (Fin D) ℂ)) * B i₀ :=
-            (Matrix.smul_mul _ _ _).symm
-        _ = (Z (v + 1) : Matrix (Fin D) (Fin D) ℂ) * B i₀ := by rw [← hc v]
-        _ = A i₀ * (Z (v + 1 + 1) : Matrix (Fin D) (Fin D) ℂ) := hstar (v + 1) i₀
-        _ = A i₀ * (((c (v + 1) : ℂ)) • (Z (v + 1) : Matrix (Fin D) (Fin D) ℂ)) := by
-            rw [← hc (v + 1)]
-        _ = ((c (v + 1) : ℂ)) • (A i₀ * (Z (v + 1) : Matrix (Fin D) (Fin D) ℂ)) :=
-            Matrix.mul_smul _ _ _
-        _ = ((c (v + 1) : ℂ)) • ((Z v : Matrix (Fin D) (Fin D) ℂ) * B i₀) := by
-            rw [← hstar v i₀]
-    have hzero : (((c v : ℂ)) - ((c (v + 1) : ℂ))) •
-        ((Z v : Matrix (Fin D) (Fin D) ℂ) * B i₀) = 0 := by
-      rw [sub_smul, hkey, sub_self]
-    rcases smul_eq_zero.mp hzero with h | h
-    · exact (Units.ext (sub_eq_zero.mp h)).symm
-    · exact absurd h (hN v)
-  -- All scalars agree around the chain.
-  have hconst : ∀ v : Fin n, c v = c 0 := by
-    intro v
-    obtain ⟨k, hk⟩ := v
-    induction k with
-    | zero => exact congrArg c (Fin.ext (by simp))
-    | succ k IH =>
-      have hk' : k < n := by omega
-      have hsucc : (⟨k, hk'⟩ : Fin n) + 1 = ⟨k + 1, hk⟩ := by
-        apply Fin.ext
-        have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
-        rw [Fin.val_add_eq_ite, h1]
-        change (if n ≤ k + 1 then k + 1 - n else k + 1) = k + 1
-        split_ifs <;> omega
-      rw [← hsucc, hstep ⟨k, hk'⟩, IH hk']
-  -- The gauge at site `k` is the starting gauge scaled by the `k`-th power.
-  have hpow : ∀ (k : ℕ) (hk : k < n),
-      (Z (⟨k, hk⟩ : Fin n) : Matrix (Fin D) (Fin D) ℂ) =
-        ((c 0 : ℂ)) ^ k • (Z 0 : Matrix (Fin D) (Fin D) ℂ) := by
-    intro k
-    induction k with
-    | zero =>
-      intro hk
-      rw [show (⟨0, hk⟩ : Fin n) = 0 from Fin.ext (by simp), pow_zero, one_smul]
-    | succ k IH =>
-      intro hk
-      have hk' : k < n := by omega
-      have hsucc : (⟨k, hk'⟩ : Fin n) + 1 = ⟨k + 1, hk⟩ := by
-        apply Fin.ext
-        have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
-        rw [Fin.val_add_eq_ite, h1]
-        change (if n ≤ k + 1 then k + 1 - n else k + 1) = k + 1
-        split_ifs <;> omega
-      rw [← hsucc, hc ⟨k, hk'⟩, hconst ⟨k, hk'⟩, IH hk', smul_smul, ← pow_succ']
-  -- Following the bonds once around the chain forces `λ^n = 1`.
-  have hn1 : n - 1 < n := by omega
-  have hwrap : (⟨n - 1, hn1⟩ : Fin n) + 1 = 0 := by
-    apply Fin.ext
-    have h1 : ((1 : Fin n) : ℕ) = 1 := val_one_of_two_le (by omega)
-    rw [Fin.val_add_eq_ite, h1]
-    simp only [Fin.val_zero]
-    split_ifs <;> omega
-  have hcycle : (Z 0 : Matrix (Fin D) (Fin D) ℂ) =
-      ((c 0 : ℂ)) ^ n • (Z 0 : Matrix (Fin D) (Fin D) ℂ) := by
-    calc (Z 0 : Matrix (Fin D) (Fin D) ℂ)
-        = (Z ((⟨n - 1, hn1⟩ : Fin n) + 1) : Matrix (Fin D) (Fin D) ℂ) := by rw [hwrap]
-      _ = ((c ⟨n - 1, hn1⟩ : ℂ)) •
-            (Z (⟨n - 1, hn1⟩ : Fin n) : Matrix (Fin D) (Fin D) ℂ) :=
-          hc ⟨n - 1, hn1⟩
-      _ = ((c 0 : ℂ)) • (((c 0 : ℂ)) ^ (n - 1) • (Z 0 : Matrix (Fin D) (Fin D) ℂ)) := by
-          rw [hconst ⟨n - 1, hn1⟩, hpow (n - 1) hn1]
-      _ = ((c 0 : ℂ)) ^ n • (Z 0 : Matrix (Fin D) (Fin D) ℂ) := by
-          rw [smul_smul, ← pow_succ', Nat.sub_add_cancel (by omega : 1 ≤ n)]
-  have hroot : ((c 0 : ℂ)) ^ n = 1 := by
-    have hzero : (1 - ((c 0 : ℂ)) ^ n) • (Z 0 : Matrix (Fin D) (Fin D) ℂ) = 0 := by
-      rw [sub_smul, one_smul, ← hcycle, sub_self]
-    rcases smul_eq_zero.mp hzero with h | h
-    · exact (sub_eq_zero.mp h).symm
-    · haveI : Nonempty (Fin D) := ⟨⟨0, hD⟩⟩
-      exact absurd h (Units.ne_zero (Z 0))
-  refine ⟨Z 0, (c 0 : ℂ), hroot, fun i => ?_⟩
-  have h0 := hZ 0 i
-  rw [hc 0] at h0
-  rw [h0, Matrix.mul_smul]
+      ∀ i : Fin d, B i = lam • ((Z⁻¹ : GL (Fin D) ℂ) * A i * (Z : GL (Fin D) ℂ)) :=
+  fundamentalTheorem_normalMPS_translationInvariant_of_overlap hL hn A B hA hB hAB
 
 /-- **Uniqueness clause of the Fundamental Theorem for translation-invariant
 normal MPS, single-gauge form** (arXiv:1804.04964, Section 3, the corollary

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -521,8 +521,8 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS}
     \leanok
     \uses{def:l_blk_injective, def:mpv}
-    Let $n$ be positive, let $0 < L$ with $3L \le n$, and let $A$ and $B$ be
-    tensors of $D \times D$ matrices over physical dimension $d$, each
+    Let $n$ be positive, let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$
+    be tensors of $D \times D$ matrices over physical dimension $d$, each
     $L$-block injective, whose matrix product vectors agree at system size
     $n$: $V^{(n)}(A)_\sigma = V^{(n)}(B)_\sigma$ for every configuration
     $\sigma$.  Then there are invertible matrices $Z_v$, one per bond of the
@@ -535,32 +535,21 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \cite[Section~4]{Molnar2018NormalPEPS} specialized to one
     site-independent tensor: the source states the corollary for
     site-dependent families, and its conclusion is the per-bond gauge family
-    delivered here.  The source's translation-invariant corollary (a single
-    gauge $Z$ and a constant $\lambda$ with $\lambda^n = 1$) refines this
-    conclusion and is not part of this statement.  Positivity of the
-    physical and bond dimensions is not assumed: a vanishing bond dimension
-    makes the conclusion trivial, and a vanishing physical dimension
-    contradicts block injectivity.
+    delivered here.  The system size is the optimal $n \ge 2L + 1$ of the
+    source's alternative proof (its Section ``Normal MPS: alternative
+    proof''), rather than the $n \ge 3L$ of the blocking route.  The source's
+    translation-invariant corollary (a single gauge $Z$ and a constant
+    $\lambda$ with $\lambda^n = 1$) refines this conclusion and is not part
+    of this statement.  Positivity of the physical and bond dimensions is not
+    assumed: a vanishing bond dimension makes the conclusion trivial, and a
+    vanishing physical dimension contradicts block injectivity.
 \end{corollary}
 \begin{proof}\leanok
-    \uses{cor:fundamentalTheorem_normalMPS_cycle,
-        lem:stateCoeff_cycleTensorOfMPS,
-        lem:regionBlockedTensorInjective_cycleTensorOfMPS,
-        def:cycleTensorOfMPS, def:gaugeVertex}
-    The cycle tensors of $A$ and $B$ generate the same state by
-    Lemma~\ref{lem:stateCoeff_cycleTensorOfMPS}, and every arc of
-    $L$ consecutive sites is injective for each by
-    Lemma~\ref{lem:regionBlockedTensorInjective_cycleTensorOfMPS}, so the
-    closed-chain corollary
-    (Corollary~\ref{cor:fundamentalTheorem_normalMPS_cycle}) produces one
-    invertible matrix per edge relating the two cycle tensors.  At each site
-    the gauge action contracts the two incident matrices against the site
-    matrix, with the matrix of the entering bond acting by its
-    transposed inverse when the site is the stored second endpoint; reading
-    the per-site identity through the two incident bonds turns the per-edge
-    family into per-bond gauges, the transpose of the edge matrix away from
-    the seam and the inverse on the seam edge, whose conjugation relation is
-    exactly $B^i = Z_v^{-1} A^i Z_{v+1}$.
+    \uses{cor:fundamentalTheorem_normalMPS_of_overlap}
+    The per-bond form of the strengthened closed-chain corollary
+    (Corollary~\ref{cor:fundamentalTheorem_normalMPS_of_overlap}), proved
+    through the overlapping windows at $n \ge 2L + 1$, gives the per-bond
+    gauge family directly.
 \end{proof}
 
 \begin{corollary}[Uniqueness of the per-bond gauges up to one constant,
@@ -628,8 +617,8 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \lean{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant}
     \leanok
     \uses{def:l_blk_injective, def:mpv}
-    Let $n$ be positive, let $0 < L$ with $3L \le n$, and let $A$ and $B$ be
-    tensors of $D \times D$ matrices over physical dimension $d$, each
+    Let $n$ be positive, let $0 < L$ with $2L + 1 \le n$, and let $A$ and $B$
+    be tensors of $D \times D$ matrices over physical dimension $d$, each
     $L$-block injective, whose matrix product vectors agree at system size
     $n$: $V^{(n)}(A)_\sigma = V^{(n)}(B)_\sigma$ for every configuration
     $\sigma$.  Then there are an invertible matrix $Z$ and a constant
@@ -639,27 +628,16 @@ translation-invariant corollary of \cite[Section~4]{Molnar2018NormalPEPS}.
     \]
     This is the translation-invariant corollary of
     \cite[Section~4]{Molnar2018NormalPEPS}, the statement for TI MPS
-    following the first corollary after the general normal-PEPS theorem.
-    Positivity of the bond dimension is not assumed: a vanishing bond
+    following the first corollary after the general normal-PEPS theorem.  The
+    system size is the optimal $n \ge 2L + 1$ of the source's alternative
+    proof.  Positivity of the bond dimension is not assumed: a vanishing bond
     dimension makes the conclusion trivial.
 \end{corollary}
 \begin{proof}\leanok
-    \uses{cor:fundamentalTheorem_normalMPS, lem:gaugeFamily_succ_proportional}
-    The matrix-form corollary
-    (Corollary~\ref{cor:fundamentalTheorem_normalMPS}) gives per-bond gauges
-    $Z_v$ with $B^i = Z_v^{-1} A^i Z_{v+1}$, and consecutive gauges are
-    proportional (Lemma~\ref{lem:gaugeFamily_succ_proportional}):
-    $Z_{v+1} = c_v Z_v$ with $c_v$ nonzero.  Multiplying the relation by
-    $Z_v$ on the left gives $Z_v B^i = A^i Z_{v+1}$ at every site; comparing
-    this at sites $v$ and $v+1$ through the proportionalities yields
-    $c_v\,(Z_v B^i) = c_{v+1}\,(Z_v B^i)$, and $Z_v B^{i_0} \neq 0$ for some
-    $i_0$ because $B$ is $L$-block injective with positive bond dimension,
-    so all the scalars equal a single constant $\lambda := c_0$.  Iterating
-    $Z_{v+1} = \lambda Z_v$ from the starting bond gives
-    $Z_k = \lambda^k Z_0$, and after $n$ steps the closed chain returns to
-    the starting bond: $Z_0 = \lambda^n Z_0$, so $\lambda^n = 1$ since
-    $Z_0 \neq 0$.  The relation at the starting site then reads
-    $B^i = \lambda\, Z_0^{-1} A^i Z_0$.
+    \uses{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
+    This is the single-gauge form of the strengthened closed-chain corollary
+    (Corollary~\ref{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}),
+    proved through the overlapping windows at $n \ge 2L + 1$.
 \end{proof}
 
 \begin{corollary}[Uniqueness of the translation-invariant gauge up to a
@@ -914,10 +892,11 @@ to $n \ge 2L + 1$.
     \]
     This is the strengthened closed-chain corollary of
     \cite{Molnar2018NormalPEPS} (the corollary after Lemma~5 in its closing
-    section ``Normal MPS: alternative proof''), improving the system-size
-    bound of
-    Corollary~\ref{cor:fundamentalTheorem_normalMPS_translationInvariant}
-    from $n \ge 3L$ to $n \ge 2L + 1$.  The uniqueness clause of the source
+    section ``Normal MPS: alternative proof''), proved through the
+    overlapping windows at the optimal $n \ge 2L + 1$ rather than the
+    $n \ge 3L$ of the blocking route; the single-gauge corollary
+    \ref{cor:fundamentalTheorem_normalMPS_translationInvariant} delegates to
+    it.  The uniqueness clause of the source
     corollary — the gauge $Z$ is unique up to a multiplicative constant —
     needs no system size and is
     Corollary~\ref{cor:fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}.
@@ -950,11 +929,11 @@ to $n \ge 2L + 1$.
         B^i = Z_v^{-1}\, A^i\, Z_{v+1}
         \qquad\text{for every site } v \text{ and every } i .
     \]
-    This is the per-bond gauge family of
-    Corollary~\ref{cor:fundamentalTheorem_normalMPS}, delivered at the
-    source's strengthened bound $n \ge 2L + 1$ in place of $n \ge 3L$
+    This is the per-bond gauge family of the closed-chain corollary, proved
+    at the source's strengthened bound $n \ge 2L + 1$
     (\cite{Molnar2018NormalPEPS}, the corollary after Lemma~5 in its
-    closing section ``Normal MPS: alternative proof'').
+    closing section ``Normal MPS: alternative proof'').  The named matrix-level
+    corollary~\ref{cor:fundamentalTheorem_normalMPS} delegates to it.
 \end{corollary}
 \begin{proof}\leanok
     \uses{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}

--- a/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_capstone.tex
@@ -933,7 +933,7 @@ to $n \ge 2L + 1$.
     at the source's strengthened bound $n \ge 2L + 1$
     (\cite{Molnar2018NormalPEPS}, the corollary after Lemma~5 in its
     closing section ``Normal MPS: alternative proof'').  The named matrix-level
-    corollary~\ref{cor:fundamentalTheorem_normalMPS} delegates to it.
+    Corollary~\ref{cor:fundamentalTheorem_normalMPS} delegates to it.
 \end{corollary}
 \begin{proof}\leanok
     \uses{cor:fundamentalTheorem_normalMPS_translationInvariant_of_overlap}

--- a/docs/paper-gaps/peps_normal_ft_section3_route.tex
+++ b/docs/paper-gaps/peps_normal_ft_section3_route.tex
@@ -2636,11 +2636,19 @@ Feeding the bridges into the closed-chain corollary and unpacking the
 per-edge gauges yields the matrix form
 (\path{fundamentalTheorem_normalMPS}, blueprint
 \path{cor:fundamentalTheorem_normalMPS}): two $L$-block-injective matrix
-tensors on $n \ge 3L$ sites whose matrix product vectors agree at size $n$
-are related by invertible per-bond matrices $Z_v$ with
-$B^i = Z_v^{-1} A^i Z_{v+1}$, and two such families differ by a single
-constant (\path{fundamentalTheorem_normalMPS_gauge_unique}, blueprint
-\path{cor:fundamentalTheorem_normalMPS_gauge_unique}).  The unpacking
+tensors whose matrix product vectors agree at size $n$ are related by
+invertible per-bond matrices $Z_v$ with $B^i = Z_v^{-1} A^i Z_{v+1}$, and
+two such families differ by a single constant
+(\path{fundamentalTheorem_normalMPS_gauge_unique}, blueprint
+\path{cor:fundamentalTheorem_normalMPS_gauge_unique}).  The existence
+clause now carries the optimal $n \ge 2L + 1$ of the source's alternative
+proof: \path{fundamentalTheorem_normalMPS} delegates to the
+overlapping-window corollary \path{fundamentalTheorem_normalMPS_of_overlap}
+(documented in the section ``The strengthening to $n \ge 2L+1$ via
+overlapping windows'' below).  The uniqueness clause keeps the $n \ge 3L$
+of the graph-level per-edge route it invokes; lowering it to $n \ge 2L + 1$
+is the remaining follow-up for the closed-chain corollary, the source's
+uniqueness needing no system size.  The unpacking
 meets the same seam convention as on the torus: the ordered-edge normal
 form stores the wraparound edge with its endpoints swapped, so the per-bond
 gauge is the transpose of the per-edge matrix away from the seam and its
@@ -2659,9 +2667,10 @@ counterexample-backed positivity corrections of the graph-level corollary
 are discharged rather than assumed.  The statements specialize the source's
 site-dependent families to one repeated tensor; the source's
 translation-invariant corollary (lines 1624--1661: a single gauge $Z$ and a
-constant $\lambda$ with $\lambda^n = 1$) remains the follow-up refinement,
-as does the strengthening to $n \ge 2L + 1$ (line 1623, proved in the
-source's Section \path{normal_alt}).
+constant $\lambda$ with $\lambda^n = 1$) is delivered in single-gauge form
+in the next section, and the strengthening of the existence clause to
+$n \ge 2L + 1$ (line 1623, proved in the source's Section
+\path{normal_alt}) is now in place via the overlapping-window route below.
 
 \section*{The translation-invariant corollary in single-gauge form}
 
@@ -2673,43 +2682,22 @@ constant) is now delivered
 \path{fundamentalTheorem_normalMPS_translationInvariant_gauge_unique},
 blueprint \path{cor:fundamentalTheorem_normalMPS_translationInvariant},
 \path{cor:fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}).
-The route is a matrix-level collapse of the per-bond family of
-\path{fundamentalTheorem_normalMPS}, with no further graph-level input.
-Iterating the per-bond relation $B^i = Z_v^{-1} A^i Z_{v+1}$ along a word
-conjugates the word products of $B$ by the gauges at the two ends of the
-word (\path{evalWord_eq_conj_of_gaugeFamily}); comparing the iterations
-from starting sites $v$ and $v+1$ over the spanning length-$L$ word
-products of $A$ and pinning the bond transports with the empty word shows
-that conjugation by $Z_v$ and by $Z_{v+1}$ agree on the full matrix
-algebra, so consecutive gauges are proportional by the centralizer step
-(\path{gaugeFamily_succ_proportional}, through the per-edge scalar lemma
-\path{gl_conj_unique_scalar}).  The same-state relation pins consecutive
-scalars against the nonzero tensor $B$, and one circuit of the closed chain
-returns to the starting bond, forcing $\lambda^n = 1$.  The uniqueness
-clause needs no system size at all: two single-gauge realizations, iterated
-along the spanning words (\path{evalWord_eq_smul_conj_of_gauge}), give two
-equal conjugations of the full matrix algebra after the empty word pins
+The existence clause carries the optimal $n \ge 2L + 1$ of the source's
+alternative proof: it delegates to the overlapping-window single-gauge
+corollary \path{fundamentalTheorem_normalMPS_translationInvariant_of_overlap}
+(documented in the section ``The strengthening to $n \ge 2L+1$ via
+overlapping windows'' below).  The same collapse of the per-bond family is
+available size-independently — iterating the per-bond relation
+$B^i = Z_v^{-1} A^i Z_{v+1}$ along a word conjugates the word products of
+$B$ by the gauges at the two ends, consecutive gauges are proportional by
+the centralizer step (\path{gaugeFamily_succ_proportional}), the same-state
+relation pins consecutive scalars against the nonzero tensor $B$, and one
+circuit of the closed chain forces $\lambda^n = 1$.  The uniqueness clause
+needs no system size at all: two single-gauge realizations, iterated along
+the spanning words (\path{evalWord_eq_smul_conj_of_gauge}), give two equal
+conjugations of the full matrix algebra after the empty word pins
 $\lambda^L = \lambda'^L$, so the gauges are proportional; neither equality
 of states nor the root-of-unity conditions enter.
-
-The strengthening to $n \ge 2L + 1$ (line 2258, proved in the source's
-Section \path{normal_alt}) remains unformalized, and it is not a
-re-derivation of the blocking bundle alone.  The source's alternative proof
-routes through its Lemma~5 (lines 2045--2255): a virtual operation on a
-single bond is interpreted as a physical operation on each of the
-overlapping injective windows containing that bond, the operators pushed
-through the windows define algebra homomorphisms $O_1 \mapsto X$ and
-$O_3 \mapsto X^{\mathsf T}$, and comparing the states they generate
-identifies the two.  This apparatus — operator pushing through overlapping
-windows rather than three disjoint arcs — replaces the three-arc cover
-behind \path{fundamentalTheorem_normalMPS_cycle}, so the $2L+1$ bound
-cascades into the closed-chain corollary itself rather than only its
-blocking hypotheses.  The plan, if taken up: formalize the bond-operator
-pushing of Lemma~5 for matrix tensors (the two algebra homomorphisms and
-their identification against the state), derive the per-bond family on
-$n \ge 2L + 1$ sites from it, and reuse the matrix-level collapse above
-verbatim — the collapse itself nowhere uses $3L \le n$ beyond consuming the
-per-bond family.
 
 \section*{The Applications translation-invariant description corollary}
 
@@ -2925,9 +2913,22 @@ and the per-bond family $B^i = Z_v^{-1} A^i Z_{v+1}$ at $n \ge 2L+1$
 the single gauge with powers of the root of unity, $Z_v = \lambda^v Z$.
 The single-gauge form arrives directly, so the matrix-level collapse of the
 per-bond family recorded in the previous sections is not needed on this
-route; the landed $n \ge 3L$ statements remain in place unchanged.  The
-uniqueness clause of the source corollary needs no system size and was
-already delivered by
+route.  The named matrix-level existence corollaries now carry this optimal
+bound: \leanid{TNLean.PEPS.fundamentalTheorem_normalMPS} and
+\leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant}
+delegate to \path{fundamentalTheorem_normalMPS_of_overlap} and
+\path{fundamentalTheorem_normalMPS_translationInvariant_of_overlap}, so
+their hypothesis is $n \ge 2L + 1$ rather than the $n \ge 3L$ of the
+blocking route.  The graph-level closed-chain corollary
+\leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_cycle} keeps the $n \ge 3L$
+of its three-disjoint-arc cover, which the overlapping-window apparatus
+replaces rather than reuses; the matrix-level existence clauses no longer
+route through it.  The per-bond uniqueness clause
+\leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_gauge_unique} still invokes
+the graph-level per-edge uniqueness and so keeps $n \ge 3L$; lowering it to
+$n \ge 2L + 1$ is the remaining follow-up, the source's uniqueness needing
+no system size.  The translation-invariant single-gauge uniqueness clause of
+the source corollary needs no system size and was already delivered by
 \leanid{TNLean.PEPS.fundamentalTheorem_normalMPS_translationInvariant_gauge_unique}.
 With this, every numbered claim of the source's Section \path{normal_alt}
 for matrix-product states is formalized for one site-independent tensor;


### PR DESCRIPTION
Closes #2706.

## Summary

The matrix-level closed-chain corollaries of the normal-MPS Fundamental Theorem now carry the **optimal system size `n ≥ 2L+1`** of the source's alternative proof, in place of the `n ≥ 3L` of the Section-`normal` three-disjoint-arc blocking route.

Source: arXiv:1804.04964, `Papers/1804.04964/paper_normal.tex` **line 1623** (the `n ≥ 2L+1` strengthening announced) and **Section `normal_alt`** / **Lemma 5** (lines 2045–2255), where the overlapping-window argument replaces the three-arc cover.

## What changed

The overlapping-window route already proves the `n ≥ 2L+1` closed-chain corollaries via the matrix-tensor formalization of Lemma 5 (`fundamentalTheorem_normalMPS_of_overlap`, `fundamentalTheorem_normalMPS_translationInvariant_of_overlap`, both sorry/axiom-clean and in the root build). This PR makes the **named** matrix-level existence corollaries carry the optimal bound by delegating to them:

- `fundamentalTheorem_normalMPS` (per-bond form): `hn : 3 * L ≤ n` → `hn : 2 * L + 1 ≤ n`, body now `fundamentalTheorem_normalMPS_of_overlap hL hn A B hA hB hAB`.
- `fundamentalTheorem_normalMPS_translationInvariant` (single-gauge form): `hn : 3 * L ≤ n` → `hn : 2 * L + 1 ≤ n`, body now `fundamentalTheorem_normalMPS_translationInvariant_of_overlap hL hn A B hA hB hAB` (orphaned `3L` collapse proof removed).

**Import untangle (to break the cycle):** `CycleMPSOverlapCapstone` imported `CycleMPSFundamentalTheorem` only in docstrings; it now imports `CycleArcRegion` (for `val_one_of_two_le`) instead. `CycleMPSFundamentalTheorem` then imports the overlap capstone to delegate. No import cycle; verified by import-DAG analysis.

## Scope notes (source-faithful)

- The **graph-level** `fundamentalTheorem_normalMPS_cycle` (on `Tensor (cycleGraph n) d`) keeps `n ≥ 3L`. Its proof routes through `fundamentalTheorem_normalPEPS`, which requires three *pairwise-disjoint* injective regions per edge covering the graph (`cycleNormalPEPSBlockingHypotheses`); at `2L+1 ≤ n < 3L` the complement of the two `L`-arcs has size `n − 2L < L` and is not injective, and the arcs would have to overlap. The source's `normal_alt` route deliberately abandons this three-partite structure — it cannot be reached by adapting the arc geometry. The overlapping-window apparatus replaces, rather than reuses, this cover.
- The **per-bond uniqueness** clause `fundamentalTheorem_normalMPS_gauge_unique` keeps `n ≥ 3L` (it invokes the graph-level per-edge uniqueness). The source's uniqueness needs no system size; the size-free single-gauge uniqueness `fundamentalTheorem_normalMPS_translationInvariant_gauge_unique` already covers the TI form. Lowering the per-bond clause to `2L+1` (via the size-independent `gaugeFamily_succ_proportional` engine) is noted as a follow-up in the docstring and the paper-gap note.

## Blueprint + docs

- `cor:fundamentalTheorem_normalMPS` and `cor:fundamentalTheorem_normalMPS_translationInvariant` flipped to `2L+1`; their proofs now `\uses` the `_of_overlap` corollaries.
- `docs/paper-gaps/peps_normal_ft_section3_route.tex` updated: the `2L+1` strengthening of the existence clauses is now landed, with the remaining per-bond-uniqueness follow-up recorded.

## Verification

- Full root `lake build` green (9211 jobs); no new `sorry`/`axiom`/`native_decide`.
- `#print axioms`: `fundamentalTheorem_normalMPS`, `fundamentalTheorem_normalMPS_translationInvariant` depend only on `[propext, Classical.choice, Quot.sound]`.
- `lake exe lint-style` clean on edited files; `check_reader_facing_prose.py --diff-base` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theorem statement strengthening and proof delegation only; no new axioms or auth/data paths; uniqueness bound unchanged at 3L.
> 
> **Overview**
> The **named** closed-chain Fundamental Theorem corollaries for translation-invariant normal MPS now use the optimal system size **`n ≥ 2L + 1`** (source `normal_alt`) instead of **`n ≥ 3L`**.
> 
> **`fundamentalTheorem_normalMPS`** and **`fundamentalTheorem_normalMPS_translationInvariant`** no longer prove existence via the cycle-graph / three-arc blocking route; they **delegate** to **`fundamentalTheorem_normalMPS_of_overlap`** and **`fundamentalTheorem_normalMPS_translationInvariant_of_overlap`**, dropping large inline proofs. **`fundamentalTheorem_normalMPS_gauge_unique`** still assumes **`n ≥ 3L`** (graph-level uniqueness); docs note lowering that bound as follow-up.
> 
> **Imports:** `CycleMPSOverlapCapstone` drops `CycleMPSFundamentalTheorem` (uses `CycleArcRegion` instead); `CycleMPSFundamentalTheorem` imports the overlap capstone for delegation.
> 
> Blueprint corollaries and **`docs/paper-gaps/peps_normal_ft_section3_route.tex`** are updated to match the new bounds and proof routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af930b433ebe89a3cb2384416a32b90ace47f5b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->