### PR TITLE
feat(Axioms/OperatorConvexity): prove convex rpow Jensen

### DIFF
--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -35,10 +35,10 @@ Jensen inequality is then obtained as the right limit of
 `p⁻¹ • (A ^ p - 1)` as `p → 0+`, using
 `CFC.tendsto_cfc_rpow_sub_one_log`.  The convex real-power Jensen inequality is
 proved analogously, by integrating the reversed pointwise positive-map
-inequality for the convex Löwner integrand `Real.rpowIntegrand₁₂` over the
-interior interval `(1, 2)` and passing to the endpoint `p = 2` by continuity of
-`M ^ ·` in the exponent.  Only the Lieb statement remains an axiom, because the
-joint-concavity integral representation is not yet formalized.
+inequality for the convex Löwner integrand `g p t` over the interior interval
+`(1, 2)` and passing to the endpoint `p = 2` by continuity of the matrix power
+`q ↦ M ^ q` in the exponent.  Only the Lieb statement remains an axiom, because
+the joint-concavity integral representation is not yet formalized.
 Operator convexity of `x ↦ x ^ p` for `1 ≤ p ≤ 2`, the scalar input of the
 convex case, is available as `CFC.convexOn_rpow` in
 `TNLean.Analysis.RpowConvexity`.
@@ -124,14 +124,13 @@ The remaining Mathlib or local formalization gaps are:
    `TNLean.Channel.Schwarz.OperatorJensenAux`, and the commutation of `T` with
    the integral.
 2. **Operator convexity of `rpow` for `p ∈ [1, 2]`**: use Mathlib's convex
-   Löwner integrand `rpowIntegrand₁₂`, whose resolvent form
-   `cfc (rpowIntegrand₁₂ p t) a = t ^ (p - 2) • a + t ^ p • (t • 1 + a)⁻¹
-     - t ^ (p - 1) • 1`
-   yields the reversed pointwise inequality
-   `cfc (rpowIntegrand₁₂ p t) (T A) ≤ T (cfc (rpowIntegrand₁₂ p t) A)` from the
-   same resolvent estimate `positiveMap_resolvent_inv_le`.  Integrating over the
-   interior `p ∈ (1, 2)` and taking the left limit `p → 2⁻`, using continuity of
-   `M ^ ·` in the exponent, gives the result on the closed interval `[1, 2]`.
+   Löwner integrand `g p t`, whose resolvent form
+   `g p t A = t ^ (p - 2) • A + t ^ p • (t • I + A)⁻¹ - t ^ (p - 1) • I`
+   yields the reversed pointwise inequality `g p t (T A) ≤ T (g p t A)` from the
+   positive-map resolvent inequality.  Integrating over the interior
+   `p ∈ (1, 2)` and taking the left limit `p → 2⁻`, using continuity of the
+   matrix power `q ↦ M ^ q` in the exponent, gives the result on the closed
+   interval `[1, 2]`.
 3. **Concave Jensen for `log`**: derive it from the right-limit formula
    `CFC.tendsto_cfc_rpow_sub_one_log` and the concave real-power theorem,
    using unitality to rewrite `T(1)=1`.

--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -453,9 +453,8 @@ theorem posMap_rpow_convex_jensen
     intro p hpIoo
     let q : ℝ≥0 := ⟨p, by linarith [hpIoo.1]⟩
     have hqcoe : (q : ℝ) = p := rfl
-    have hq1 : (1 : ℝ) < q := by exact_mod_cast hpIoo.1
     have hqpos : 0 < q := by
-      have : (0 : ℝ) < q := by linarith
+      have : (0 : ℝ) < q := by rw [hqcoe]; linarith [hpIoo.1]
       exact_mod_cast this
     have hqIoo : q ∈ Set.Ioo (1 : ℝ≥0) 2 := by
       constructor

--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -17,8 +17,9 @@ import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 
 This module collects the remaining axioms for the **operator Jensen
 inequalities** for matrix powers and logarithms under positive maps, and the
-**Lieb concavity theorem**.  It also contains the now-proved concave real-power
-Jensen theorem, since downstream files already import this boundary module.
+**Lieb concavity theorem**.  It also contains the now-proved concave and convex
+real-power Jensen theorems, since downstream files already import this boundary
+module.
 
 Mathlib 4.31 proves the operator concavity inputs for `x ↦ x ^ p`,
 `0 ≤ p ≤ 1`, and for `log`, via `CFC.concaveOn_rpow` and
@@ -32,9 +33,12 @@ The concave real-power Jensen inequality is proved below by integrating the
 pointwise positive-map inequality for the Löwner integrand.  The logarithmic
 Jensen inequality is then obtained as the right limit of
 `p⁻¹ • (A ^ p - 1)` as `p → 0+`, using
-`CFC.tendsto_cfc_rpow_sub_one_log`.  The convex real-power Jensen and Lieb
-statements remain axioms because the corresponding positive-map Jensen or
-joint-concavity arguments are not yet formalized.
+`CFC.tendsto_cfc_rpow_sub_one_log`.  The convex real-power Jensen inequality is
+proved analogously, by integrating the reversed pointwise positive-map
+inequality for the convex Löwner integrand `Real.rpowIntegrand₁₂` over the
+interior interval `(1, 2)` and passing to the endpoint `p = 2` by continuity of
+`M ^ ·` in the exponent.  Only the Lieb statement remains an axiom, because the
+joint-concavity integral representation is not yet formalized.
 Operator convexity of `x ↦ x ^ p` for `1 ≤ p ≤ 2`, the scalar input of the
 convex case, is available as `CFC.convexOn_rpow` in
 `TNLean.Analysis.RpowConvexity`.
@@ -45,7 +49,8 @@ The following results are standard in matrix analysis:
 
 * `posMap_rpow_concave_jensen` — Jensen inequality for concave `rpow`,
   now a theorem.
-* `posMap_rpow_convex_jensen` — Jensen inequality for convex `rpow`.
+* `posMap_rpow_convex_jensen` — Jensen inequality for convex `rpow`,
+  now a theorem.
 * `posMap_log_concave_jensen` — Jensen inequality for concave `log`,
   now a theorem.
 * `lieb_concavity_axiom` — Lieb concavity theorem.
@@ -57,11 +62,10 @@ via the spectral theorem and the scalar Jensen inequality.
 
 ## Status
 
-The concave real-power and logarithmic declarations are now proved.  Two
-declarations remain axioms: the convex real-power Jensen inequality and Lieb's
-joint concavity theorem.  Mathlib 4.31 supplies the
-C-star functional-calculus concavity inputs and the Löwner integral
-representation for the power case.  Earlier status notes recorded the integral
+The concave real-power, convex real-power, and logarithmic declarations are now
+proved.  Only Lieb's joint concavity theorem remains an axiom.  Mathlib 4.31
+supplies the C-star functional-calculus concavity inputs and the Löwner integral
+representation for both power cases.  Earlier status notes recorded the integral
 representation as missing; that is no longer accurate.
 
 The remaining Mathlib or local formalization gaps are:
@@ -91,9 +95,10 @@ The remaining Mathlib or local formalization gaps are:
   follows by taking the right limit `p → 0+` in the concave real-power
   inequality.
 * Operator convexity of `rpow` over `[1, 2]`, the scalar input of
-  `posMap_rpow_convex_jensen`, is now available as `CFC.convexOn_rpow` in
-  `TNLean.Analysis.RpowConvexity`; the convex axiom therefore shares the single
-  remaining positive-map Jensen obstruction with the concave one.
+  `posMap_rpow_convex_jensen`, is available as `CFC.convexOn_rpow` in
+  `TNLean.Analysis.RpowConvexity`; the convex case is now proved directly from
+  the reversed Löwner integrand inequality
+  `TNLean.OperatorJensen.positiveMap_rpowIntegrand₁₂_jensen`.
 * Lieb concavity integral representation: absent from Mathlib.
 
 ## Proof plan
@@ -118,10 +123,15 @@ The remaining Mathlib or local formalization gaps are:
    theorem, the local positive-semidefinite integral specialization in
    `TNLean.Channel.Schwarz.OperatorJensenAux`, and the commutation of `T` with
    the integral.
-2. **Operator convexity of `rpow` for `p ∈ [1, 2]`**: use the
-   decomposition `x^p = x · x^{p-1}` for `p ∈ [1, 2]` (Mathlib's
-   `rpowIntegrand₁₂`), reducing to concavity of `x^{p-1}` for
-   `p - 1 ∈ [0, 1]` and the same operator Jensen step.
+2. **Operator convexity of `rpow` for `p ∈ [1, 2]`**: use Mathlib's convex
+   Löwner integrand `rpowIntegrand₁₂`, whose resolvent form
+   `cfc (rpowIntegrand₁₂ p t) a = t ^ (p - 2) • a + t ^ p • (t • 1 + a)⁻¹
+     - t ^ (p - 1) • 1`
+   yields the reversed pointwise inequality
+   `cfc (rpowIntegrand₁₂ p t) (T A) ≤ T (cfc (rpowIntegrand₁₂ p t) A)` from the
+   same resolvent estimate `positiveMap_resolvent_inv_le`.  Integrating over the
+   interior `p ∈ (1, 2)` and taking the left limit `p → 2⁻`, using continuity of
+   `M ^ ·` in the exponent, gives the result on the closed interval `[1, 2]`.
 3. **Concave Jensen for `log`**: derive it from the right-limit formula
    `CFC.tendsto_cfc_rpow_sub_one_log` and the concave real-power theorem,
    using unitality to rewrite `T(1)=1`.
@@ -129,8 +139,7 @@ The remaining Mathlib or local formalization gaps are:
    `A^s B^{1-s} = (sin πs/π) ∫₀^∞ t^{s-1} A(A+tB)⁻¹ B dt` and
    resolvent monotonicity.
 
-The convex `rpow` case still needs the corresponding positive-map Jensen
-input.  Lieb concavity remains a separate integral representation problem.
+Lieb concavity remains a separate integral representation problem.
 
 ## References
 
@@ -237,6 +246,34 @@ private lemma positiveMap_rpowIntegrand₀₁_cfcₙ_jensen
   simpa [cfcₙ_rpowIntegrand₀₁_eq_cfc hA hp ht,
     cfcₙ_rpowIntegrand₀₁_eq_cfc hTA hp ht] using hpoint
 
+private lemma continuousOn_rpowIntegrand₁₂_Ici {p t : ℝ}
+    (hp : 1 < p) (ht : 0 < t) :
+    ContinuousOn (Real.rpowIntegrand₁₂ p t) (Set.Ici 0) :=
+  (Real.continuousOn_rpowIntegrand₁₂_uncurry hp (Set.Ici 0) fun _ a => a).uncurry_left t ht
+
+private lemma cfcₙ_rpowIntegrand₁₂_eq_cfc
+    {B : Mat} (hB : 0 ≤ B) {p t : ℝ}
+    (hp : p ∈ Set.Ioo (1 : ℝ) 2) (ht : 0 < t) :
+    cfcₙ (Real.rpowIntegrand₁₂ p t) B =
+      cfc (Real.rpowIntegrand₁₂ p t) B := by
+  rw [cfcₙ_eq_cfc (hf := ?_) (hf0 := Real.rpowIntegrand₁₂_zero ht)]
+  exact (continuousOn_rpowIntegrand₁₂_Ici hp.1 ht).mono (by grind)
+
+private lemma positiveMap_rpowIntegrand₁₂_cfcₙ_jensen
+    {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T)
+    (hSub : T 1 ≤ (1 : Mat)) {A : Mat} (hA : 0 ≤ A)
+    {p t : ℝ} (hp : p ∈ Set.Ioo (1 : ℝ) 2) (ht : 0 < t) :
+    cfcₙ (Real.rpowIntegrand₁₂ p t) (T A) ≤
+      T (cfcₙ (Real.rpowIntegrand₁₂ p t) A) := by
+  have hApsd : A.PosSemidef := Matrix.nonneg_iff_posSemidef.mp hA
+  have hTApsd : (T A).PosSemidef := hT A hApsd
+  have hTA : 0 ≤ T A := Matrix.nonneg_iff_posSemidef.mpr hTApsd
+  have hpoint :=
+    TNLean.OperatorJensen.positiveMap_rpowIntegrand₁₂_jensen
+      hT hSub hApsd hp ht
+  simpa [cfcₙ_rpowIntegrand₁₂_eq_cfc hA hp ht,
+    cfcₙ_rpowIntegrand₁₂_eq_cfc hTA hp ht] using hpoint
+
 /-- **Operator Jensen for concave `rpow`** (Wolf Theorem 5.1, `p ∈ [0, 1]`).
 
 For a positive subunital map `T` and `p ∈ [0, 1]`:
@@ -324,6 +361,75 @@ theorem posMap_rpow_concave_jensen
       rw [hTAint.2]
     _ = (T A) ^ p := hTA_rpow
 
+/-- On a compact set, `x ↦ x ^ q` converges uniformly to `x ↦ x ^ 2` as the
+exponent `q` tends to `2` from the left.  This is the scalar input for passing
+the convex real-power Jensen inequality to the endpoint `p = 2`.
+
+The family is replaced by `x ↦ x ^ max q (1 / 2)`, which has a strictly positive
+exponent for every `q` and is therefore jointly continuous; the two families
+agree near `q = 2`, where `q ≥ 1 / 2`. -/
+private lemma tendstoUniformlyOn_rpow_exponent_two
+    (s : Set ℝ) (hs : IsCompact s) :
+    TendstoUniformlyOn (fun q : ℝ => fun x : ℝ => x ^ q) (fun x : ℝ => x ^ (2 : ℝ))
+      (𝓝[<] (2 : ℝ)) s := by
+  haveI : CompactSpace s := isCompact_iff_compactSpace.mp hs
+  set G : ℝ → ℝ → ℝ := fun q x => x ^ (max q (1 / 2 : ℝ)) with hG
+  have hGcont : ∀ q : ℝ, ContinuousOn (G q) s := by
+    intro q
+    apply ContinuousOn.rpow continuousOn_id continuousOn_const
+    intro x hx
+    exact Or.inr (lt_of_lt_of_le (by norm_num) (le_max_right _ _))
+  have hf : ContinuousOn (fun x : ℝ => x ^ (2 : ℝ)) s := by
+    apply ContinuousOn.rpow continuousOn_id continuousOn_const
+    intro x hx
+    exact Or.inr (by norm_num)
+  have key : TendstoUniformlyOn G (fun x : ℝ => x ^ (2 : ℝ)) (𝓝[<] (2 : ℝ)) s := by
+    rw [← (hf.tendsto_restrict_iff_tendstoUniformlyOn hGcont)]
+    have hjoint : Continuous (Function.uncurry G) := by
+      rw [hG]
+      apply Continuous.rpow continuous_snd
+        (continuous_id.comp continuous_fst |>.max continuous_const)
+      intro x
+      exact Or.inr (lt_of_lt_of_le (by norm_num) (le_max_right _ _))
+    have hΦcont : Continuous (fun q : ℝ => (⟨_, (hGcont q).restrict⟩ : C(s, ℝ))) := by
+      apply ContinuousMap.continuous_of_continuous_uncurry
+      exact hjoint.comp (continuous_id.prodMap continuous_subtype_val)
+    have hΦ2 : (⟨_, (hGcont 2).restrict⟩ : C(s, ℝ)) = ⟨_, hf.restrict⟩ := by
+      ext x
+      simp only [ContinuousMap.coe_mk, Set.restrict_apply, hG]
+      congr 1
+      norm_num
+    rw [← hΦ2]
+    exact (hΦcont.tendsto 2).mono_left nhdsWithin_le_nhds
+  apply key.congr
+  have hhalf : ∀ᶠ q : ℝ in 𝓝[<] (2 : ℝ), (1 / 2 : ℝ) ≤ q := by
+    have : ∀ᶠ q : ℝ in 𝓝 (2 : ℝ), (1 / 2 : ℝ) ≤ q := eventually_ge_nhds (by norm_num)
+    exact this.filter_mono nhdsWithin_le_nhds
+  filter_upwards [hhalf] with q hq
+  intro x hx
+  simp only [hG]
+  congr 1
+  exact max_eq_left hq
+
+/-- Right-continuity of `M ^ ·` at the exponent `2`, used to pass the convex
+real-power Jensen inequality from the open interval `(1, 2)` to the endpoint
+`p = 2`.  For positive semidefinite `M`, `M ^ q → M ^ 2` as `q → 2⁻`. -/
+private lemma tendsto_rpow_exponent_two {M : Mat} (hM : 0 ≤ M) :
+    Tendsto (fun q : ℝ => M ^ q) (𝓝[<] (2 : ℝ)) (𝓝 (M ^ (2 : ℝ))) := by
+  have hcfc : ∀ q : ℝ, M ^ q = cfc (fun x : ℝ => x ^ q) M := fun q =>
+    CFC.rpow_eq_cfc_real (a := M) hM
+  simp only [hcfc]
+  have hspec_compact : IsCompact (spectrum ℝ M) := spectrum.isCompact M
+  refine tendsto_cfc_fun ?tendsto ?cont
+  case cont =>
+    have hnear : ∀ᶠ q : ℝ in 𝓝[<] (2 : ℝ), (0 : ℝ) ≤ q := by
+      filter_upwards [eventually_nhdsWithin_of_eventually_nhds
+        (eventually_ge_nhds (by norm_num : (0 : ℝ) < 2))] with q hq using hq
+    filter_upwards [hnear] with q hq
+    exact ContinuousOn.rpow_const (by fun_prop) fun x _ => Or.inr hq
+  case tendsto =>
+    exact tendstoUniformlyOn_rpow_exponent_two (spectrum ℝ M) hspec_compact
+
 /-- **Operator Jensen for convex `rpow`** (Wolf Theorem 5.1, `p ∈ [1, 2]`).
 
 For a positive subunital map `T` and `p ∈ [1, 2]`:
@@ -335,10 +441,94 @@ the Hansen--Pedersen operator Jensen inequality for positive subunital maps.
 References:
 * Wolf, Theorem 5.1
 * Hansen--Pedersen, *Jensen's operator inequality*, 2003 -/
-axiom posMap_rpow_convex_jensen
+theorem posMap_rpow_convex_jensen
     {T : Mat →ₗ[ℂ] Mat} (hT : IsPositiveMap T) (hSub : T 1 ≤ (1 : Mat))
     {p : ℝ} (hp : p ∈ Set.Icc (1 : ℝ) 2) {A : Mat} (hA : 0 ≤ A) :
-    (T A) ^ p ≤ T (A ^ p)
+    (T A) ^ p ≤ T (A ^ p) := by
+  classical
+  have hApsd : A.PosSemidef := Matrix.nonneg_iff_posSemidef.mp hA
+  have hTApsd : (T A).PosSemidef := hT A hApsd
+  have hTA : 0 ≤ T A := Matrix.nonneg_iff_posSemidef.mpr hTApsd
+  -- The interior case `p ∈ (1, 2)` via the Löwner integral representation.
+  have hcore : ∀ q : ℝ, q ∈ Set.Ioo (1 : ℝ) 2 → (T A) ^ q ≤ T (A ^ q) := by
+    intro p hpIoo
+    let q : ℝ≥0 := ⟨p, by linarith [hpIoo.1]⟩
+    have hqcoe : (q : ℝ) = p := rfl
+    have hq1 : (1 : ℝ) < q := by exact_mod_cast hpIoo.1
+    have hqpos : 0 < q := by
+      have : (0 : ℝ) < q := by linarith
+      exact_mod_cast this
+    have hqIoo : q ∈ Set.Ioo (1 : ℝ≥0) 2 := by
+      constructor
+      · exact_mod_cast hpIoo.1
+      · exact_mod_cast hpIoo.2
+    obtain ⟨μ, hμ⟩ :=
+      CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₁₂ Mat hqIoo
+    let ν := μ.restrict (Set.Ioi (0 : ℝ))
+    have hAint := hμ A (by simpa using hA)
+    have hTAint := hμ (T A) (by simpa using hTA)
+    have hAintν :
+        Integrable (fun t => cfcₙ (Real.rpowIntegrand₁₂ q t) A) ν := by
+      simpa [ν, MeasureTheory.IntegrableOn] using hAint.1
+    have hTAintν :
+        Integrable (fun t => cfcₙ (Real.rpowIntegrand₁₂ q t) (T A)) ν := by
+      simpa [ν, MeasureTheory.IntegrableOn] using hTAint.1
+    have hT_Aintν :
+        Integrable (fun t => T (cfcₙ (Real.rpowIntegrand₁₂ q t) A)) ν := by
+      simpa [LinearMap.coe_toContinuousLinearMap'] using
+        (LinearMap.toContinuousLinearMap T).integrable_comp hAintν
+    have hmono :
+        (fun t => cfcₙ (Real.rpowIntegrand₁₂ q t) (T A)) ≤ᵐ[ν]
+          fun t => T (cfcₙ (Real.rpowIntegrand₁₂ q t) A) := by
+      filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+      have htpos : 0 < t := ht
+      have hpoint :=
+        positiveMap_rpowIntegrand₁₂_cfcₙ_jensen hT hSub hA hpIoo htpos
+      convert hpoint using 2 <;> simp [hqcoe]
+    have hintegral_mono :
+        (∫ t, cfcₙ (Real.rpowIntegrand₁₂ q t) (T A) ∂ν) ≤
+          ∫ t, T (cfcₙ (Real.rpowIntegrand₁₂ q t) A) ∂ν :=
+      integral_mono_ae hTAintν hT_Aintν hmono
+    have hT_integral :
+        T (∫ t, cfcₙ (Real.rpowIntegrand₁₂ q t) A ∂ν) =
+          ∫ t, T (cfcₙ (Real.rpowIntegrand₁₂ q t) A) ∂ν := by
+      simpa [LinearMap.coe_toContinuousLinearMap'] using
+        ((LinearMap.toContinuousLinearMap T).integral_comp_comm hAintν).symm
+    have hA_rpow : A ^ p = A ^ q := by
+      have h := CFC.nnrpow_eq_rpow (a := A) hqpos
+      rw [hqcoe] at h
+      exact h.symm
+    have hTA_rpow : (T A) ^ q = (T A) ^ p := by
+      have h := CFC.nnrpow_eq_rpow (a := T A) hqpos
+      rw [hqcoe] at h
+      exact h
+    calc
+      (T A) ^ p = (T A) ^ q := hTA_rpow.symm
+      _ = ∫ t, cfcₙ (Real.rpowIntegrand₁₂ q t) (T A) ∂ν := by rw [hTAint.2]
+      _ ≤ ∫ t, T (cfcₙ (Real.rpowIntegrand₁₂ q t) A) ∂ν := hintegral_mono
+      _ = T (∫ t, cfcₙ (Real.rpowIntegrand₁₂ q t) A ∂ν) := hT_integral.symm
+      _ = T (A ^ q) := by rw [hAint.2]
+      _ = T (A ^ p) := by rw [hA_rpow]
+  -- Endpoints `p = 1` and `p = 2`.
+  rcases eq_or_lt_of_le hp.1 with hp1 | hp1
+  · rw [← hp1]
+    simp [CFC.rpow_one A hA, CFC.rpow_one (T A) hTA]
+  rcases eq_or_lt_of_le hp.2 with hp2 | hp2
+  · -- `p = 2`: pass the inequality to the left limit `q → 2⁻`.
+    subst hp2
+    have hlimF : Tendsto (fun q : ℝ => (T A) ^ q) (𝓝[<] (2 : ℝ)) (𝓝 ((T A) ^ (2 : ℝ))) :=
+      tendsto_rpow_exponent_two hTA
+    have hlimG : Tendsto (fun q : ℝ => T (A ^ q)) (𝓝[<] (2 : ℝ)) (𝓝 (T (A ^ (2 : ℝ)))) :=
+      ((LinearMap.toContinuousLinearMap T).continuous.tendsto (A ^ (2 : ℝ))).comp
+        (tendsto_rpow_exponent_two hA)
+    have hle : ∀ᶠ q : ℝ in 𝓝[<] (2 : ℝ), (T A) ^ q ≤ T (A ^ q) := by
+      have hnear : ∀ᶠ q : ℝ in 𝓝[<] (2 : ℝ), (1 : ℝ) < q := by
+        filter_upwards [eventually_nhdsWithin_of_eventually_nhds
+          (eventually_gt_nhds (by norm_num : (1 : ℝ) < 2))] with q hq using hq
+      filter_upwards [hnear, self_mem_nhdsWithin] with q hq1 hq2
+      exact hcore q ⟨hq1, hq2⟩
+    exact le_of_tendsto_of_tendsto hlimF hlimG hle
+  · exact hcore p ⟨hp1, hp2⟩
 
 /-- **Operator Jensen for concave `log`** (Wolf Theorem 5.1, log case).
 

--- a/TNLean/Channel/Schwarz/OperatorJensenAux.lean
+++ b/TNLean/Channel/Schwarz/OperatorJensenAux.lean
@@ -44,6 +44,9 @@ representation; see the status note below.
   matrix and `povm_resolvent_inv_le`.
 - `positiveMap_rpowIntegrand₀₁_jensen`: Jensen's inequality for a single
   Löwner-integral real-power integrand under a positive subunital map.
+- `positiveMap_rpowIntegrand₁₂_jensen`: the analogous reversed inequality for
+  the convex real-power integrand `Real.rpowIntegrand₁₂`, used for the convex
+  Jensen inequality over `[1, 2]`.
 - `integral_nonneg_matrix_of_ae`: matrix-valued Bochner integrals preserve
   almost-everywhere positive semidefiniteness.
 
@@ -760,6 +763,109 @@ lemma positiveMap_rpowIntegrand₀₁_jensen
     add_left_comm, add_assoc]
   simp [ht_powC₂]
   ring_nf
+
+/-- Scalar resolvent expansion of the convex Löwner-integral integrand
+`Real.rpowIntegrand₁₂ p t`: for `t > 0`,
+`rpowIntegrand₁₂ p t x = t ^ (p - 2) * x + t ^ p * (t + x)⁻¹ - t ^ (p - 1)`. -/
+private lemma rpowIntegrand₁₂_eq_resolvent_scalar {p t : ℝ} (ht : 0 < t) :
+    Real.rpowIntegrand₁₂ p t =
+      fun x => t ^ (p - 2) * x + t ^ p * (t + x)⁻¹ - t ^ (p - 1) := by
+  ext x
+  unfold Real.rpowIntegrand₁₂
+  have h1 : t ^ (p - 1) * t⁻¹ = t ^ (p - 2) := by
+    rw [← Real.rpow_neg_one t, ← Real.rpow_add ht]
+    ring_nf
+  have h2 : t ^ (p - 1) * t = t ^ p := by
+    have := Real.rpow_add ht (p - 1) 1
+    rw [Real.rpow_one] at this
+    rw [← this]
+    ring_nf
+  rw [mul_sub, mul_add]
+  rw [show t ^ (p - 1) * (t⁻¹ * x) = t ^ (p - 1) * t⁻¹ * x by ring, h1]
+  rw [show t ^ (p - 1) * (t * (t + x)⁻¹) = t ^ (p - 1) * t * (t + x)⁻¹ by ring, h2]
+  ring
+
+/-- Resolvent form of the convex Löwner-integral integrand
+`Real.rpowIntegrand₁₂ p t` under the continuous functional calculus. -/
+private lemma cfc_rpowIntegrand₁₂_eq_resolvent
+    {A : MatD} (hA : A.PosSemidef) {p t : ℝ}
+    (hp : p ∈ Set.Ioo (1 : ℝ) 2) (ht : 0 < t) :
+    cfc (Real.rpowIntegrand₁₂ p t) A =
+      t ^ (p - 2) • A + t ^ p • ((t • (1 : MatD)) + A)⁻¹ - t ^ (p - 1) • (1 : MatD) := by
+  have hEq : ({A | (0 : MatD) ≤ A}.EqOn (cfc (Real.rpowIntegrand₁₂ p t))
+      (fun X : MatD =>
+        t ^ (p - 2) • X +
+          t ^ p • Ring.inverse (algebraMap ℝ MatD t + X) -
+          algebraMap ℝ MatD (t ^ (p - 1)))) := by
+    intro X hX
+    rw [rpowIntegrand₁₂_eq_resolvent_scalar ht]
+    have hg : ContinuousOn (fun z : ℝ => (t + z)⁻¹) (spectrum ℝ X) := by
+      fun_prop (disch := grind -abstractProof)
+    have hspectrum : ∀ r ∈ spectrum ℝ X, t + r ≠ 0 := by grind
+    have hcont1 : ContinuousOn (fun z : ℝ => t ^ (p - 2) * z) (spectrum ℝ X) := by fun_prop
+    have hcont2 : ContinuousOn (fun z : ℝ => t ^ p * (t + z)⁻¹) (spectrum ℝ X) :=
+      continuousOn_const.mul hg
+    have hcontsum :
+        ContinuousOn (fun z : ℝ => t ^ (p - 2) * z + t ^ p * (t + z)⁻¹) (spectrum ℝ X) :=
+      hcont1.add hcont2
+    rw [cfc_sub (a := X) (fun z : ℝ => t ^ (p - 2) * z + t ^ p * (t + z)⁻¹)
+      (fun _ : ℝ => t ^ (p - 1)) hcontsum continuousOn_const]
+    rw [cfc_add (a := X) (fun z : ℝ => t ^ (p - 2) * z) (fun z : ℝ => t ^ p * (t + z)⁻¹)
+      hcont1 hcont2]
+    rw [cfc_const .., cfc_const_mul (t ^ (p - 2)) (fun z : ℝ => z) X (hf := by fun_prop),
+      cfc_const_mul (t ^ p) (fun z : ℝ => (t + z)⁻¹) X (hf := hg),
+      cfc_inv _ _ hspectrum .., cfc_const_add .., cfc_id' ..]
+  have hA_nonneg : (0 : MatD) ≤ A := Matrix.nonneg_iff_posSemidef.mpr hA
+  have hcalc := hEq hA_nonneg
+  simpa [Algebra.algebraMap_eq_smul_one, ← Matrix.nonsing_inv_eq_ringInverse] using hcalc
+
+/-- Jensen's inequality for a single convex Löwner-integral real-power integrand
+under a positive subunital map.
+
+For `p ∈ (1, 2)` and `t > 0`, this proves the pointwise inequality
+`cfc (Real.rpowIntegrand₁₂ p t) (T A) ≤ T (cfc (Real.rpowIntegrand₁₂ p t) A)`.
+The inequality direction is reversed relative to the concave integrand, since
+`Real.rpowIntegrand₁₂` is operator convex. It is the integrand-level input for
+the Löwner-integral proof of the convex real-power operator Jensen inequality. -/
+lemma positiveMap_rpowIntegrand₁₂_jensen
+    {T : MatD →ₗ[ℂ] MatD} (hT : IsPositiveMap T)
+    (hSub : T 1 ≤ (1 : MatD)) {A : MatD} (hA : A.PosSemidef)
+    {p t : ℝ} (hp : p ∈ Set.Ioo (1 : ℝ) 2) (ht : 0 < t) :
+    cfc (Real.rpowIntegrand₁₂ p t) (T A) ≤
+      T (cfc (Real.rpowIntegrand₁₂ p t) A) := by
+  classical
+  have hTA : (T A).PosSemidef := hT A hA
+  have hAeq := cfc_rpowIntegrand₁₂_eq_resolvent hA hp ht
+  have hTAeq := cfc_rpowIntegrand₁₂_eq_resolvent hTA hp ht
+  rw [hAeq, hTAeq]
+  have hres := positiveMap_resolvent_inv_le hT hSub hA ht
+  have hscale_nonneg : 0 ≤ t ^ p := Real.rpow_nonneg (le_of_lt ht) p
+  have hsub :
+      0 ≤ (T ((A + t • (1 : MatD))⁻¹) + t⁻¹ • (1 - T 1)) - ((T A) + t • (1 : MatD))⁻¹ :=
+    sub_nonneg.mpr hres
+  have hscaled :
+      (0 : MatD) ≤ t ^ p •
+        ((T ((A + t • (1 : MatD))⁻¹) + t⁻¹ • (1 - T 1)) - ((T A) + t • (1 : MatD))⁻¹) := by
+    rw [Matrix.le_iff] at hsub ⊢
+    simpa using hsub.smul hscale_nonneg
+  have ht_powR : t ^ (p - 1) = t ^ p * t⁻¹ := by
+    rw [Real.rpow_sub_one ht.ne']
+    ring
+  have hgoal :
+      (T (t ^ (p - 2) • A + t ^ p • ((t • (1 : MatD)) + A)⁻¹ - t ^ (p - 1) • (1 : MatD))) -
+          (t ^ (p - 2) • (T A) + t ^ p • ((t • (1 : MatD)) + T A)⁻¹ -
+            t ^ (p - 1) • (1 : MatD)) =
+        t ^ p • ((T ((A + t • (1 : MatD))⁻¹) + t⁻¹ • (1 - T 1)) -
+          ((T A) + t • (1 : MatD))⁻¹) := by
+    simp only [map_sub, map_add, LinearMap.map_smul_of_tower]
+    rw [add_comm (t • (1 : MatD)) A, add_comm (t • (1 : MatD)) (T A)]
+    rw [smul_sub, smul_add, smul_smul, smul_sub,
+      show (t : ℝ) ^ (p - 1) = t ^ p * t⁻¹ from ht_powR]
+    match_scalars <;> ring
+  rw [Matrix.le_iff]
+  rw [hgoal]
+  rw [Matrix.le_iff] at hscaled
+  simpa using hscaled
 
 end PositiveMapResolvent
 

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -301,6 +301,38 @@ are not developed elsewhere in this document.
     supplied by the positive-map resolvent inequality.
 \end{proof}
 
+\begin{lemma}[Positive-map convex real-power integrand inequality]
+    \label{lem:operator_jensen_positive_map_rpow_integrand_convex}
+    \lean{TNLean.OperatorJensen.positiveMap_rpowIntegrand₁₂_jensen}
+    \leanok
+    \uses{lem:operator_jensen_positive_map_resolvent}
+    Let $T$ be a positive subunital map, let $A\ge0$, let
+    $p\in(1,2)$, and let $t>0$. Then
+    \[
+        g_{p,t}(TA)
+        \le
+        T\!\left(g_{p,t}(A)\right),
+        \qquad
+        g_{p,t}(x)=t^{p-2}x+t^p(t+x)^{-1}-t^{p-1}.
+    \]
+    The inequality is reversed relative to the concave integrand, since
+    $g_{p,t}$ is operator convex.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:operator_jensen_positive_map_resolvent}
+    Rewrite the continuous functional calculus for $g_{p,t}$ in resolvent form,
+    \[
+        g_{p,t}(X)=t^{p-2}X+t^p(t\Id+X)^{-1}-t^{p-1}\Id.
+    \]
+    Under the linear map $T$ the leading $t^{p-2}$ terms cancel and the constant
+    $t^{p-1}$ terms combine, so the difference
+    $T(g_{p,t}(A))-g_{p,t}(TA)$ is exactly $t^p$ times the positive matrix
+    supplied by the positive-map resolvent inequality (using
+    $t^p\,t^{-1}=t^{p-1}$).
+\end{proof}
+
 \begin{lemma}[Positive matrix-valued integrals]\label{lem:operator_jensen_integral_order}
     \lean{TNLean.OperatorJensen.integral_nonneg_matrix_of_ae}
     \leanok
@@ -357,7 +389,8 @@ are not developed elsewhere in this document.
 \begin{theorem}[Jensen for convex real powers]\label{thm:posMap_rpow_convex_jensen}
     \lean{posMap_rpow_convex_jensen}
     \leanok
-    \uses{def:positive_map, lem:operator_jensen_positive_map_rpow_integrand,
+    \uses{def:positive_map,
+        lem:operator_jensen_positive_map_rpow_integrand_convex,
         lem:operator_jensen_integral_order}
     For a positive subunital map $T$, a positive semidefinite matrix~$A$,
     and $p\in[1,2]$:
@@ -372,14 +405,15 @@ are not developed elsewhere in this document.
     For $p=1$ the assertion is an equality.  For $1<p<2$, use Carlen's
     integral representation of $A^p$ by the convex integrands
     $g_{p,t}(x)=t^{p-2}x+t^p(t+x)^{-1}-t^{p-1}$.  The pointwise inequality
-    $g_{p,t}(TA)\le T(g_{p,t}(A))$ is the reversed form of the resolvent
-    estimate underlying Lemma~\ref{lem:operator_jensen_positive_map_rpow_integrand},
-    scaled by $t^p\ge0$.  Integrating this inequality with respect to the
-    representing measure and using
-    Lemma~\ref{lem:operator_jensen_integral_order} together with linearity of
-    the Bochner integral under $T$ gives the inequality for $1<p<2$.  The
-    endpoint $p=2$ follows by continuity of $M\mapsto M^q$ in the exponent, as
-    the limit of the open-interval inequality as $q\to2^-$.
+    $g_{p,t}(TA)\le T(g_{p,t}(A))$ is
+    Lemma~\ref{lem:operator_jensen_positive_map_rpow_integrand_convex}.
+    Integrating this inequality with respect to the representing measure and
+    using Lemma~\ref{lem:operator_jensen_integral_order} together with linearity
+    of the Bochner integral under $T$ gives the inequality for $1<p<2$.  The
+    endpoint $p=2$ follows by taking the limit $q\to2^-$ in
+    $(TA)^q\le T(A^q)$: since $M^q\to M^2$ in the operator norm as $q\to2^-$ for
+    any positive semidefinite $M$, and the Loewner order is closed, this gives
+    $(TA)^2\le T(A^2)$.
 \end{proof}
 
 \begin{theorem}[Map form of Jensen for convex real powers]\label{thm:rpow_convex_jensen}

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -356,8 +356,9 @@ are not developed elsewhere in this document.
 
 \begin{theorem}[Jensen for convex real powers]\label{thm:posMap_rpow_convex_jensen}
     \lean{posMap_rpow_convex_jensen}
-    \notready
-    \uses{def:positive_map}
+    \leanok
+    \uses{def:positive_map, lem:operator_jensen_positive_map_rpow_integrand,
+        lem:operator_jensen_integral_order}
     For a positive subunital map $T$, a positive semidefinite matrix~$A$,
     and $p\in[1,2]$:
     \[
@@ -366,6 +367,20 @@ are not developed elsewhere in this document.
     This is \cite[Theorem~5.11]{Wolf2012Quantum} for the subunital
     operator-convex case $f(x)=x^p$.
 \end{theorem}
+
+\begin{proof}\leanok
+    For $p=1$ the assertion is an equality.  For $1<p<2$, use Carlen's
+    integral representation of $A^p$ by the convex integrands
+    $g_{p,t}(x)=t^{p-2}x+t^p(t+x)^{-1}-t^{p-1}$.  The pointwise inequality
+    $g_{p,t}(TA)\le T(g_{p,t}(A))$ is the reversed form of the resolvent
+    estimate underlying Lemma~\ref{lem:operator_jensen_positive_map_rpow_integrand},
+    scaled by $t^p\ge0$.  Integrating this inequality with respect to the
+    representing measure and using
+    Lemma~\ref{lem:operator_jensen_integral_order} together with linearity of
+    the Bochner integral under $T$ gives the inequality for $1<p<2$.  The
+    endpoint $p=2$ follows by continuity of $M\mapsto M^q$ in the exponent, as
+    the limit of the open-interval inequality as $q\to2^-$.
+\end{proof}
 
 \begin{theorem}[Map form of Jensen for convex real powers]\label{thm:rpow_convex_jensen}
     \lean{IsPositiveMap.rpow_convex_jensen}
@@ -377,7 +392,7 @@ are not developed elsewhere in this document.
 \end{theorem}
 
 \begin{proof}\leanok
-    Direct application of the axiom.
+    Direct application of the theorem.
 \end{proof}
 
 \begin{theorem}[Jensen for concave log]\label{thm:posMap_log_concave_jensen}


### PR DESCRIPTION
### Motivation

- Discharges the `posMap_rpow_convex_jensen` axiom in `TNLean/Axioms/OperatorConvexity.lean`, establishing the operator Jensen inequality $(T(A))^p \le T(A^p)$ for positive subunital maps $T$ and exponents $p \in [1,2]$ as a kernel-verified theorem.
- The proof follows the Löwner integral representation route (Wolf Theorem 5.1, Hansen–Pedersen), mirroring the already-proven concave case with the inequality direction reversed for operator-convex $x^p$ with $p \in [1,2]$. This discharges the smallest remaining Chapter 5 blocker for Wolf Corollary 5.2 (see LionSR/QICLean#135).

### Description

- **`TNLean/Axioms/OperatorConvexity.lean`**: Removes the `posMap_rpow_convex_jensen` axiom and replaces it with a full proof. For $p \in (1,2)$, the proof uses Mathlib's Löwner representation via `rpowIntegrand₁₂`, derives the reversed pointwise integrand inequality `cfc (rpowIntegrand₁₂ p t) (T A) ≤ T (cfc (rpowIntegrand₁₂ p t) A)` by scaling `positiveMap_resolvent_inv_le`, integrates against the representing measure with `integral_mono_ae`, and commutes $T$ through the integral. The endpoint $p = 1$ reduces to `T A ≤ T A` via `CFC.rpow_one`; the endpoint $p = 2$ is handled by a left-limit argument (`tendsto_rpow_exponent_two`) using uniform convergence of $x \mapsto x^q$ on the compact matrix spectrum. Private lemmas added: `continuousOn_rpowIntegrand₁₂_Ici`, `cfcₙ_rpowIntegrand₁₂_eq_cfc`, `positiveMap_rpowIntegrand₁₂_cfcₙ_jensen`, `tendstoUniformlyOn_rpow_exponent_two`, `tendsto_rpow_exponent_two`.
- **`TNLean/Channel/Schwarz/OperatorJensenAux.lean`**: Adds two lemmas in namespace `TNLean.OperatorJensen`: `cfc_rpowIntegrand₁₂_eq_resolvent` (the resolvent expression for the convex integrand under the continuous functional calculus) and `positiveMap_rpowIntegrand₁₂_jensen` (the reversed per-integrand inequality).
- **`blueprint/src/chapter/ch18_operator_convexity.tex`**: Updates `thm:posMap_rpow_convex_jensen` to remove `\notready` and add `\leanok` with a mathematical proof sketch; `thm:rpow_convex_jensen` proof updated to reference the new result.
- No compatibility aliases omitted; no declarations renamed.

### Testing

- `lake build` succeeded (full repository, 9211 jobs).
- No new `sorry`, `admit`, or `native_decide` introduced; the convex axiom is removed.
- `#print axioms posMap_rpow_convex_jensen` reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `lieb_concavity_axiom`.
- `lieb_concavity_axiom` and all other axioms are untouched.

---
Addresses LionSR/QICLean#135

> [!NOTE]
> **Medium Risk**
> The change is a large formal proof in operator Jensen / matrix order theory (integrals, limits, resolvents) relied on by downstream channel and convexity imports; incorrect inequalities would break dependent results, but scope is confined to discharging one axiom without altering Lieb or API signatures.
> 
> **Overview**
> **Replaces the sanctioned axiom** `posMap_rpow_convex_jensen` with a full proof of `(T A)^p ≤ T(A^p)` for positive subunital maps and `p ∈ [1, 2]`, mirroring the existing concave Jensen pipeline with the inequality direction reversed for operator-convex `Real.rpowIntegrand₁₂`.
> 
> For **`1 < p < 2`**, the proof uses Mathlib's Löwner representation (`rpowIntegrand₁₂`), the new pointwise lemma `positiveMap_rpowIntegrand₁₂_jensen` (resolvent form + `positiveMap_resolvent_inv_le`), ordered Bochner integration, and commuting `T` through the integral. **`p = 1`** is trivial; **`p = 2`** is obtained by a left limit `q → 2⁻` using new continuity lemmas `tendsto_rpow_exponent_two` / uniform scalar convergence on the spectrum.
> 
> `TNLean/Channel/Schwarz/OperatorJensenAux.lean` gains the convex integrand resolvent identity and `positiveMap_rpowIntegrand₁₂_jensen`. Module docs and **blueprint ch18** mark the convex Jensen theorem `\leanok` with a proof sketch; `lieb_concavity_axiom` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c28246f3cdf0c30ce6413d3b88e49fbae673277. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proof in operator Jensen / matrix order theory (integrals, limits, resolvents) relied on by channel and convexity imports; a mistake would break dependents, but scope is confined to discharging one axiom without API renames.
> 
> **Overview**
> **Discharges** the `posMap_rpow_convex_jensen` axiom: for positive subunital `T`, PSD `A`, and `p ∈ [1, 2]`, the proof now gives `(T A)^p ≤ T(A^p)` as a theorem. `lieb_concavity_axiom` is unchanged.
> 
> For **`1 < p < 2`**, the argument parallels the concave case but uses Mathlib’s convex Löwner representation (`Real.rpowIntegrand₁₂`), the new pointwise lemma `positiveMap_rpowIntegrand₁₂_jensen`, ordered Bochner integration, and commuting `T` through the integral. **`p = 1`** is trivial; **`p = 2`** uses a left limit `q → 2⁻` via `tendsto_rpow_exponent_two` and uniform scalar power convergence on the spectrum.
> 
> **`OperatorJensenAux`** adds the convex integrand resolvent identity and `positiveMap_rpowIntegrand₁₂_jensen`. Module docs and **blueprint ch18** mark the convex Jensen theorem `\leanok` and document the proof sketch; downstream `IsPositiveMap.rpow_convex_jensen` still wraps the same statement, now as a theorem rather than an axiom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1887b4ae21a98b1e802d3635ae2b0fe4c373dcf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->