### PR TITLE
feat(Channel/Peripheral): primitivity of the corner restriction (#2634)

### DIFF
--- a/TNLean/Channel/Peripheral/CyclicDecomposition/Primitivity.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/Primitivity.lean
@@ -14,6 +14,7 @@ peripheral-spectrum development.
 
 ## Main statements
 
+* `isPrimitive_cornerRestriction_of_isPrimitive`
 * `preserves_corner_pow_of_cyclic_decomp`
 * `isIrreducible_restriction_of_cyclic_decomp`
 * `isPrimitive_restriction_of_cyclic_decomp`
@@ -26,6 +27,62 @@ peripheral-spectrum development.
 
 open scoped Matrix ComplexOrder MatrixOrder BigOperators
 open Matrix Finset Complex
+
+/-- **Primitivity of the corner restriction.**
+
+If a linear map `T : M_D(ℂ) →ₗ M_D(ℂ)` preserves the corner `P · M_D(ℂ) · P`
+(`hInv`), is primitive on the ambient algebra (`hPrim`), and fixes the corner
+projection `P` (`hPfix : T P = P`) where `P` is a nonzero idempotent (`hPidem`,
+`hPne`), then the restriction of `T` to the corner is again primitive.
+
+This is the reusable foundational step toward Wolf Theorem 6.6: every eigenvalue
+of the corner restriction lifts through the corner inclusion to an eigenvalue of
+`T`, so the peripheral spectrum of the restriction is contained in `{1}`, while
+`P` itself exhibits `1` as a peripheral eigenvalue of the restriction. -/
+theorem isPrimitive_cornerRestriction_of_isPrimitive
+    {D : ℕ} (P : MatrixAlg D) (T : MatrixEnd D)
+    (hInv : PreservesCorner P T) (hPidem : P * P = P) (hPfix : T P = P)
+    (hPne : P ≠ 0) (hPrim : IsPrimitive T) :
+    IsPrimitive (cornerRestriction P T hInv) := by
+  -- `P` lies in its own corner.
+  have hPmem : P ∈ cornerSubmodule P := by
+    change P * P * P = P
+    rw [hPidem, hPidem]
+  -- `P` is a nonzero fixed point of the corner restriction.
+  have hcorner_fix :
+      cornerRestriction P T hInv ⟨P, hPmem⟩ = ⟨P, hPmem⟩ := by
+    apply Subtype.ext
+    change T P = P
+    exact hPfix
+  have hcorner_ne : (⟨P, hPmem⟩ : cornerSubmodule P) ≠ 0 := by
+    intro hzero
+    apply hPne
+    have hval := congrArg Subtype.val hzero
+    simpa using hval
+  -- Any norm-1 eigenvalue of the restriction lifts to a peripheral eigenvalue of `T`.
+  have huniq : ∀ μ : ℂ,
+      Module.End.HasEigenvalue (cornerRestriction P T hInv) μ →
+      ‖μ‖ = 1 → μ = 1 := by
+    intro μ hμeig hμnorm
+    rcases hμeig.exists_hasEigenvector with ⟨X, hX⟩
+    have hX_mem : X ∈ Module.End.eigenspace (cornerRestriction P T hInv) μ :=
+      (Module.End.hasEigenvector_iff.mp hX).1
+    have hX_ne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
+    have hX_eq : cornerRestriction P T hInv X = μ • X :=
+      (Module.End.mem_eigenspace_iff).1 hX_mem
+    have hX_eq_val : T X.1 = μ • X.1 := congrArg Subtype.val hX_eq
+    have hX_ne_ambient : X.1 ≠ 0 := by
+      intro h0
+      apply hX_ne
+      apply Subtype.ext
+      simpa using h0
+    have hX_eig_ambient : Module.End.HasEigenvalue T μ :=
+      hasEigenvalue_of_eigenvector_eq T μ X.1 hX_eq_val hX_ne_ambient
+    have hμ_ambient : μ ∈ peripheralEigenvalues T := ⟨hX_eig_ambient, hμnorm⟩
+    rw [hPrim] at hμ_ambient
+    exact hμ_ambient
+  exact isPrimitive_of_unique_norm_one
+    (cornerRestriction P T hInv) ⟨P, hPmem⟩ hcorner_fix hcorner_ne huniq
 
 section PrimitivityOfSectors
 

--- a/TNLean/Channel/Peripheral/CyclicDecomposition/Primitivity.lean
+++ b/TNLean/Channel/Peripheral/CyclicDecomposition/Primitivity.lean
@@ -253,52 +253,9 @@ theorem isPrimitive_restriction_of_cyclic_decomp
   have hPk_fix : ∀ k : Fin m, (T ^ m) (P k) = P k := by
     intro k
     simpa using hcyclic_pow m k
-  have hPk_corner : ∀ k : Fin m, P k ∈ cornerSubmodule (P k) := by
-    intro k
-    change P k * P k * P k = P k
-    rw [Matrix.mul_assoc, (hPproj k).2, (hPproj k).2]
-  have hcorner_fix : ∀ k : Fin m,
-      cornerRestriction (P k) (T ^ m) (hInv k) ⟨P k, hPk_corner k⟩ = ⟨P k, hPk_corner k⟩ := by
-    intro k
-    apply Subtype.ext
-    change (T ^ m) (P k) = P k
-    exact hPk_fix k
-  have hcorner_ne : ∀ k : Fin m, (⟨P k, hPk_corner k⟩ : cornerSubmodule (P k)) ≠ 0 := by
-    intro k hzero
-    apply hPne k
-    have hval := congrArg Subtype.val hzero
-    simpa using hval
-  have huniq : ∀ k : Fin m, ∀ μ : ℂ,
-      Module.End.HasEigenvalue (cornerRestriction (P k) (T ^ m) (hInv k)) μ →
-      ‖μ‖ = 1 → μ = 1 := by
-    intro k μ hμeig hμnorm
-    rcases hμeig.exists_hasEigenvector with ⟨X, hX⟩
-    have hX_mem : X ∈ Module.End.eigenspace (cornerRestriction (P k) (T ^ m) (hInv k)) μ :=
-      (Module.End.hasEigenvector_iff.mp hX).1
-    have hX_ne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
-    have hX_eq : cornerRestriction (P k) (T ^ m) (hInv k) X = μ • X :=
-      (Module.End.mem_eigenspace_iff).1 hX_mem
-    have hX_eq_val : (T ^ m) X.1 = μ • X.1 := congrArg Subtype.val hX_eq
-    have hX_mem_ambient : X.1 ∈ Module.End.eigenspace (T ^ m) μ :=
-      (Module.End.mem_eigenspace_iff).2 hX_eq_val
-    have hX_ne_ambient : X.1 ≠ 0 := by
-      intro h0
-      apply hX_ne
-      apply Subtype.ext
-      simpa using h0
-    have hX_eig_ambient : Module.End.HasEigenvector (T ^ m) μ X.1 :=
-      (Module.End.hasEigenvector_iff).2 ⟨hX_mem_ambient, hX_ne_ambient⟩
-    have hμ_ambient : μ ∈ peripheralEigenvalues (T ^ m) :=
-      ⟨Module.End.hasEigenvalue_of_hasEigenvector hX_eig_ambient, hμnorm⟩
-    rw [hperiph_pow] at hμ_ambient
-    exact hμ_ambient
   intro k
-  exact isPrimitive_of_unique_norm_one
-    (cornerRestriction (P k) (T ^ m) (hInv k))
-    ⟨P k, hPk_corner k⟩
-    (hcorner_fix k)
-    (hcorner_ne k)
-    (huniq k)
+  exact isPrimitive_cornerRestriction_of_isPrimitive
+    (P k) (T ^ m) (hInv k) (hPproj k).2 (hPk_fix k) (hPne k) hperiph_pow
 
 section PermutationBlockStructure
 


### PR DESCRIPTION
## Summary

Adds one clean, self-contained, reusable foundational lemma:

```lean
theorem isPrimitive_cornerRestriction_of_isPrimitive
    {D : ℕ} (P : MatrixAlg D) (T : MatrixEnd D)
    (hInv : PreservesCorner P T) (hPidem : P * P = P) (hPfix : T P = P)
    (hPne : P ≠ 0) (hPrim : IsPrimitive T) :
    IsPrimitive (cornerRestriction P T hInv)
```

If a linear map `T : M_D(ℂ) →ₗ M_D(ℂ)` preserves the corner `P · M_D(ℂ) · P`, is
primitive on the ambient algebra, and fixes the nonzero idempotent `P`, then the
restriction of `T` to that corner is again primitive.

## Proof

- **`⊆ {1}`:** any norm-1 eigenvalue `μ` of `cornerRestriction P T hInv` lifts —
  through the corner inclusion `cornerSubmodule P → M_D(ℂ)` — to a norm-1
  eigenvalue of `T`, i.e. a peripheral eigenvalue of `T`. Ambient primitivity
  (`peripheralEigenvalues T = {1}`) forces `μ = 1`.
- **`{1} ⊆`:** `P` itself is a nonzero element of its own corner
  (`P * P * P = P` from idempotence) and is fixed by the restriction
  (`hPfix : T P = P`), so `1` is a peripheral eigenvalue of the restriction.

It reuses the existing helpers `hasEigenvalue_of_eigenvector_eq` and
`isPrimitive_of_unique_norm_one` from `Channel/Peripheral/Spectrum.lean`; the
eigenvalue-lifting step mirrors the inner argument already used inside
`isPrimitive_restriction_of_cyclic_decomp` in this same file, now factored out
as a standalone, hypothesis-minimal statement.

## Why this is useful (advances #2634)

This is the reusable foundational step that produces the
`IsPrimitive (cornerRestriction P T hInv)` hypothesis consumed by
`compressedTensor_adjointTransferMap_cornerBridge`
(`MPS/CanonicalForm/CyclicSectors/CornerBridge.lean`) and the cyclic-sector
decomposition machinery — directly relevant to the projector-closure /
canonical-form program tracked in #2634.

## Faithfulness / hypotheses

The three hypotheses on `P` (`hPidem`, `hPfix`, `hPne`) are genuine
mathematical requirements, not smuggled assumptions:

- `hPidem : P * P = P` is what places `P` into `cornerSubmodule P` (the corner
  is otherwise potentially empty of a canonical fixed point); every call site
  carries `IsOrthogonalProjection P`, whose `.2` is exactly this.
- `hPfix` / `hPne` provide the nonzero fixed point witnessing `1` in the
  restriction's peripheral spectrum.

Without them the `{1} ⊆` direction can genuinely fail, so the statement is the
minimal honest form.

## Verification

- `lake build TNLean.Channel.Peripheral.CyclicDecomposition.Primitivity` — green.
- `lake exe lint-style` on the file — no violations.
- `#print axioms isPrimitive_cornerRestriction_of_isPrimitive` →
  `[propext, Classical.choice, Quot.sound]` (no `sorry`, no custom axiom).
- All lines ≤ 100 chars.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lean-only proof refactor in peripheral channel theory; behavior is unchanged aside from factoring, with no runtime or security surface.
> 
> **Overview**
> Introduces **`isPrimitive_cornerRestriction_of_isPrimitive`**, a standalone lemma: if `T` preserves a nonzero idempotent corner `P`, fixes `P`, and is primitive on the full matrix algebra, then **`cornerRestriction P T`** is primitive. The proof reuses eigenvalue lifting (`hasEigenvalue_of_eigenvector_eq`) and `isPrimitive_of_unique_norm_one` from the peripheral spectrum layer.
> 
> **`isPrimitive_restriction_of_cyclic_decomp`** is shortened by replacing a large inlined block (corner membership, fixed `P k`, uniqueness of norm-1 eigenvalues) with a single call to the new lemma, supplying cyclic-sector hypotheses (`hInv`, idempotence, `(T^m)(P k) = P k`, `hperiph_pow`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65215330db77b62a9efbc5ee9d00321474862946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->