### PR TITLE
feat(RFP): isometry canonical form for pure-state RFP (#2598)

### DIFF
--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -68,24 +68,16 @@ private lemma matrixUnits_map (X : Mat) :
     _ = Matrix.trace X • (1 : Mat) := by
           rw [Matrix.sum_single_eq_diagonal, Matrix.smul_one_eq_diagonal]
 
-/-- **Lemma B.1** (arXiv:1606.00608, Appendix B): a normal tensor in canonical
-form II that is an RFP admits the decomposition `A i = X * Λ * U i * X⁻¹`
-with diagonal positive `Λ` and a residual tensor `U` satisfying the
-left-canonical equation and the scaled pair-index orthonormality
-\[
-  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
-  =
-  D^{-1}\delta_{(\alpha,\beta),(\alpha',\beta')}.
-\]
+/-- Auxiliary extraction underlying `rfp_nt_structural_full`.
 
-The proof combines the diagonal fixed-point reduction
-`rfp_nt_cfii_diagonal_fixedPoint`, the rank-one classification
-`transferMap_eq_fixedPointProj_of_isRFP_injective`, and an explicit Kraus
-realization of `fixedPointProj ρ`. Applying `kraus_rectangular_freedom'`
-identifies the physical-index coefficients with an isometry. The matrix units
-are normalized by $D^{-1/2}$, so the resulting matrix entries carry the
-displayed factor $D^{-1}$. -/
-theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
+This is the full Appendix B extraction with one extra recorded fact: the diagonal
+weights satisfy `∑ k, (Λ k) ^ 2 = D` in the matrix-unit normalization used here.
+That identity comes from `(Λ k) ^ 2 = D · ρ_{k,k} / tr ρ` together with the
+trace identity `∑ k ρ_{k,k} = tr ρ` for the diagonal fixed point `ρ`. It is the
+seed for the source trace-normalization `tr(Λ_src) = 1` after rescaling to the
+unit pair-index convention (arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`,
+lines 1271--1295). -/
+private theorem rfp_nt_structural_full_aux (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ)
@@ -96,6 +88,7 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
       (∀ p q : Fin D × Fin D,
         ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
           if p = q then (D : ℂ)⁻¹ else 0) ∧
+      (∑ k : Fin D, (Λ k) ^ 2 = (D : ℝ)) ∧
       (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
   classical
   have hInjA : IsInjective A :=
@@ -421,7 +414,30 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
             simp [Finset.mul_sum]
       _ = L * U i := by
             simp [U]
-  refine ⟨X, Λ, U, hX_det, ?_, hU_left, hU_pair, ?_⟩
+  have htr_re_pos : 0 < (Matrix.trace ρ).re := by
+    exact (RCLike.pos_iff.mp hρ_pd.trace_pos).1
+  have htr_re_ne : (Matrix.trace ρ).re ≠ 0 := ne_of_gt htr_re_pos
+  -- `∑ k (Λ k)^2 = D`: each square is `D · ρ_{k,k} / tr ρ`, and `∑ ρ_{k,k} = tr ρ`.
+  have hΛsq : ∀ k : Fin D, (Λ k) ^ 2 = (D : ℝ) * (ρ k k).re / (Matrix.trace ρ).re := by
+    intro k
+    have hk_pos : 0 < (ρ k k).re := (RCLike.pos_iff.mp (hρdiag_pos k)).1
+    have harg_nonneg : 0 ≤ ((D : ℝ) * (ρ k k).re) / (Matrix.trace ρ).re :=
+      div_nonneg (by positivity) (le_of_lt htr_re_pos)
+    simpa [Λ, sq] using Real.sq_sqrt harg_nonneg
+  have htrace_re_sum : (Matrix.trace ρ).re = ∑ k : Fin D, (ρ k k).re := by
+    simp only [Matrix.trace, Matrix.diag_apply, Complex.re_sum]
+  have hΛ_sq_sum : ∑ k : Fin D, (Λ k) ^ 2 = (D : ℝ) := by
+    calc
+      ∑ k : Fin D, (Λ k) ^ 2
+          = ∑ k : Fin D, (D : ℝ) * (ρ k k).re / (Matrix.trace ρ).re := by
+            exact Finset.sum_congr rfl (fun k _ => hΛsq k)
+      _ = (D : ℝ) * (∑ k : Fin D, (ρ k k).re) / (Matrix.trace ρ).re := by
+            rw [← Finset.sum_div, ← Finset.mul_sum]
+      _ = (D : ℝ) * (Matrix.trace ρ).re / (Matrix.trace ρ).re := by
+            rw [htrace_re_sum]
+      _ = (D : ℝ) := by
+            field_simp
+  refine ⟨X, Λ, U, hX_det, ?_, hU_left, hU_pair, hΛ_sq_sum, ?_⟩
   · intro k
     apply Real.sqrt_pos.2
     have hk_pos : 0 < (ρ k k).re := by
@@ -441,6 +457,39 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
         rw [hB_fact i]
       _ = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹ := by
         simp [L, Matrix.mul_assoc]
+
+/-- **Lemma B.1** (arXiv:1606.00608, Appendix B): a normal tensor in canonical
+form II that is an RFP admits the decomposition `A i = X * Λ * U i * X⁻¹`
+with diagonal positive `Λ` and a residual tensor `U` satisfying the
+left-canonical equation and the scaled pair-index orthonormality
+\[
+  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+  =
+  D^{-1}\delta_{(\alpha,\beta),(\alpha',\beta')}.
+\]
+
+The proof combines the diagonal fixed-point reduction
+`rfp_nt_cfii_diagonal_fixedPoint`, the rank-one classification
+`transferMap_eq_fixedPointProj_of_isRFP_injective`, and an explicit Kraus
+realization of `fixedPointProj ρ`. Applying `kraus_rectangular_freedom'`
+identifies the physical-index coefficients with an isometry. The matrix units
+are normalized by $D^{-1/2}$, so the resulting matrix entries carry the
+displayed factor $D^{-1}$. -/
+theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
+    (hNT : IsNormal A) (hRFP : IsRFP A)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ)
+      (U : MPSTensor d D),
+      X.det ≠ 0 ∧
+      (∀ k, 0 < Λ k) ∧
+      (∑ i : Fin d, (U i)ᴴ * U i = 1) ∧
+      (∀ p q : Fin D × Fin D,
+        ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+          if p = q then (D : ℂ)⁻¹ else 0) ∧
+      (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
+  obtain ⟨X, Λ, U, hX_det, hΛ_pos, hU_left, hU_pair, _, hA_eq⟩ :=
+    rfp_nt_structural_full_aux A hNT hRFP hLeft
+  exact ⟨X, Λ, U, hX_det, hΛ_pos, hU_left, hU_pair, hA_eq⟩
 
 /-- **Unit pair-index form of Lemma B.1.**  This is the same structural
 decomposition as the isometry theorem above
@@ -558,6 +607,174 @@ theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
             ← Matrix.mul_assoc X L (s • U₀ i)]
       _ = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹ := by
           simp [L, U]
+
+/-- **Isometry canonical form for a single normal-tensor block**
+(arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`, lines 1271--1295, and the
+single-block case `j = j'` of Theorem `thm:charact-MPS`, eq. `III_CFI_RFP` and
+`eq:III_isometry`).
+
+A normal tensor `A` is in *isometry canonical form* when there are an invertible
+`X`, a positive diagonal weight `Λ` with `∑ k Λ k = 1` (the source
+trace-normalization `tr(Λ) = 1`), and a residual tensor `U` satisfying the unit
+pair-index isometry
+\[
+  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'},
+\]
+such that
+\[
+  A^i = X \, \sqrt{\Lambda} \, U^i \, X^{-1}.
+\]
+The square root appears because the source reference tensor is
+`Â^{(α',β')}_{α,β} = δ_{α,α'} δ_{β,β'} √(Λ_α)` (arXiv:1606.00608, line 1288):
+the diagonal that dresses the unit isometry is `√Λ`, while the trace
+normalization `tr(Λ) = 1` is imposed on `Λ` itself, equivalently on the diagonal
+fixed point `ρ = diag(Λ)` of the transfer map.
+
+This records the diagonal `j = j'` case of the source isometry condition. The
+cross-block `δ_{j,j'}` orthogonality between distinct normal-tensor blocks is a
+separate condition, recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+def IsIsometryCanonicalForm (A : MPSTensor d D) : Prop :=
+  ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ) (U : MPSTensor d D),
+    X.det ≠ 0 ∧
+    (∀ k, 0 < Λ k) ∧
+    (∑ k : Fin D, Λ k = 1) ∧
+    (∀ p q : Fin D × Fin D,
+      ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 =
+        if p = q then 1 else 0) ∧
+    (∀ i, A i = X * Matrix.diagonal (fun k => (Real.sqrt (Λ k) : ℂ)) * U i * X⁻¹)
+
+/-- **Trace-normalized isometry canonical form of Lemma B.1**
+(arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`, lines 1271--1295).
+
+A normal tensor in canonical form II that is a renormalization fixed point is in
+isometry canonical form: it admits a decomposition
+`A^i = X √Λ U^i X⁻¹` with `Λ` diagonal, positive, trace-normalized
+(`∑ k Λ k = 1`, the source condition `tr(Λ) = 1`), and `U` a unit pair-index
+isometry.
+
+The diagonal weight is `Λ k = ρ_{k,k} / tr ρ`, the normalized diagonal fixed
+point of the transfer map; trace-normalization is then the trace identity
+`∑ k ρ_{k,k} = tr ρ`. The square-root dressing `√Λ` matches the source reference
+tensor `Â = √Λ · (matrix unit)` and keeps `U` a genuine unit isometry. -/
+theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
+    (hNT : IsNormal A) (hRFP : IsRFP A)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
+    IsIsometryCanonicalForm A := by
+  classical
+  obtain ⟨X, Λ₀, U₀, hX_det, hΛ₀_pos, _, hU₀_pair, hΛ₀_sq, hA_eq⟩ :=
+    rfp_nt_structural_full_aux A hNT hRFP hLeft
+  let sR : ℝ := Real.sqrt (D : ℝ)
+  let s : ℂ := (sR : ℂ)
+  -- Rescale to the unit pair-index convention: `U = √D · U₀`, `Λtil = Λ₀ / √D`.
+  let Λtil : Fin D → ℝ := fun k => Λ₀ k / sR
+  -- The trace-normalized diagonal is `Λ = Λtil² = Λ₀² / D`.
+  let Λ : Fin D → ℝ := fun k => (Λtil k) ^ 2
+  let U : MPSTensor d D := fun i => s • U₀ i
+  have hDpos_nat : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
+  have hDpos : 0 < (D : ℝ) := by exact_mod_cast hDpos_nat
+  have hsR_ne : sR ≠ 0 := Real.sqrt_ne_zero'.2 hDpos
+  have hsR_pos : 0 < sR := Real.sqrt_pos.2 hDpos
+  have hs_ne : s ≠ 0 := by simpa [s] using Complex.ofReal_ne_zero.mpr hsR_ne
+  have hD_ne : (D : ℂ) ≠ 0 := by exact_mod_cast (NeZero.ne D)
+  have hs_star : star s * s = (D : ℂ) := by
+    have hs_sq : sR * sR = (D : ℝ) := by
+      have hnn : 0 ≤ (D : ℝ) := by positivity
+      change Real.sqrt (D : ℝ) * Real.sqrt (D : ℝ) = (D : ℝ)
+      rw [← pow_two]; exact Real.sq_sqrt hnn
+    have hs_sq_c := congrArg (fun x : ℝ => (x : ℂ)) hs_sq
+    simpa [s, Complex.ofReal_mul] using hs_sq_c
+  have hΛtil_pos : ∀ k, 0 < Λtil k := fun k => div_pos (hΛ₀_pos k) hsR_pos
+  -- `√Λ k = Λtil k`, so the decomposition matches the source `√Λ` dressing.
+  have hsqrtΛ : ∀ k, Real.sqrt (Λ k) = Λtil k := by
+    intro k
+    exact Real.sqrt_sq (le_of_lt (hΛtil_pos k))
+  refine ⟨X, Λ, U, hX_det, ?_, ?_, ?_, ?_⟩
+  · -- `Λ k = Λtil k ^ 2 > 0`.
+    intro k
+    exact pow_pos (hΛtil_pos k) 2
+  · -- `∑ k Λ k = (∑ Λ₀²) / D = D / D = 1`.
+    have hsR_sq : sR ^ 2 = (D : ℝ) := Real.sq_sqrt (le_of_lt hDpos)
+    have hstep : ∀ k, Λ k = (Λ₀ k) ^ 2 / (D : ℝ) := by
+      intro k
+      simp only [Λ, Λtil, div_pow]
+      rw [hsR_sq]
+    calc
+      ∑ k : Fin D, Λ k = ∑ k : Fin D, (Λ₀ k) ^ 2 / (D : ℝ) :=
+            Finset.sum_congr rfl (fun k _ => hstep k)
+      _ = (∑ k : Fin D, (Λ₀ k) ^ 2) / (D : ℝ) := by rw [Finset.sum_div]
+      _ = (D : ℝ) / (D : ℝ) := by rw [hΛ₀_sq]
+      _ = 1 := by field_simp
+  · -- Unit pair-index isometry: `√D · U₀` upgrades the `D⁻¹` form to unit.
+    intro p q
+    calc
+      ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2
+          = ∑ i : Fin d, (star s * s) * (star (U₀ i p.1 p.2) * U₀ i q.1 q.2) := by
+              refine Finset.sum_congr rfl ?_
+              intro i _
+              simp [U, s, mul_assoc, mul_left_comm, mul_comm]
+      _ = (star s * s) * ∑ i : Fin d, star (U₀ i p.1 p.2) * U₀ i q.1 q.2 := by
+              rw [Finset.mul_sum]
+      _ = (D : ℂ) * (if p = q then (D : ℂ)⁻¹ else 0) := by
+              rw [hs_star, hU₀_pair p q]
+      _ = if p = q then 1 else 0 := by
+              by_cases hpq : p = q
+              · simp [hpq, hD_ne]
+              · simp [hpq]
+  · -- Decomposition: `A^i = X √Λ U^i X⁻¹` reduces to the `Λ₀, U₀` form.
+    intro i
+    rw [hA_eq i]
+    let L : Matrix (Fin D) (Fin D) ℂ :=
+      Matrix.diagonal (fun k => (Real.sqrt (Λ k) : ℂ))
+    have hL_eq : L = Matrix.diagonal (fun k => (Λtil k : ℂ)) := by
+      simp only [L, hsqrtΛ]
+    have hdiagΛ₀ :
+        Matrix.diagonal (fun k => (Λ₀ k : ℂ)) = s • L := by
+      rw [hL_eq]
+      have hsRC_ne : (sR : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr hsR_ne
+      ext a b
+      by_cases hab : a = b
+      · subst hab
+        simp only [Matrix.diagonal_apply_eq, Matrix.smul_apply, smul_eq_mul]
+        rw [show (Λtil a : ℂ) = (Λ₀ a / sR : ℝ) from by simp [Λtil],
+          Complex.ofReal_div]
+        rw [show s = (sR : ℂ) from rfl]
+        field_simp
+      · simp [Matrix.diagonal, hab]
+    have hmove : (s • L) * U₀ i = L * (s • U₀ i) := by
+      rw [Matrix.smul_mul, Matrix.mul_smul]
+    calc
+      X * Matrix.diagonal (fun k => (Λ₀ k : ℂ)) * U₀ i * X⁻¹
+          = X * (s • L) * U₀ i * X⁻¹ := by rw [hdiagΛ₀]
+      _ = X * L * (s • U₀ i) * X⁻¹ := by
+            rw [Matrix.mul_assoc X (s • L) (U₀ i), hmove,
+              ← Matrix.mul_assoc X L (s • U₀ i)]
+      _ = X * Matrix.diagonal (fun k => (Real.sqrt (Λ k) : ℂ)) * U i * X⁻¹ := by
+            simp [L, U]
+
+/-- **Per-block trace-normalized isometry canonical form.** Each block of a
+multi-block tensor that is a normal, left-canonical renormalization fixed point
+is in isometry canonical form: it admits a decomposition `A_k^i = X √Λ_k U^i X⁻¹`
+with `Λ_k` diagonal positive, trace-normalized (`∑ j Λ_k j = 1`), and `U`
+a unit pair-index isometry.
+
+This is the single-block trace-normalized form (Theorem
+`isIsometryCanonicalForm_of_rfp_nt`, the diagonal `j = j'` case of
+arXiv:1606.00608, Corollary III.cor3, lines 583--589) applied to each block.
+
+**Scope restriction (source isometry):** Corollary III.cor3 also invokes the
+cross-block `δ_{j,j'}` orthogonality between distinct normal-tensor blocks
+(eq:III_isometry, lines 550--554). This per-block statement omits those
+cross-block equations; the gap is recorded in
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. Deriving the per-block
+normal/RFP/left-canonical hypotheses from a whole-tensor canonical-form
+fixed-point condition is a separate step. -/
+theorem isIsometryCanonicalForm_of_rfp_nt_blocks {r : ℕ} {dim : Fin r → ℕ}
+    [∀ k, NeZero (dim k)] (A : (k : Fin r) → MPSTensor d (dim k))
+    (hNT : ∀ k, IsNormal (A k)) (hRFP : ∀ k, IsRFP (A k))
+    (hLeft : ∀ k, ∑ i : Fin d, (A k i)ᴴ * (A k i) = 1) :
+    ∀ k, IsIsometryCanonicalForm (A k) :=
+  fun k => isIsometryCanonicalForm_of_rfp_nt (A k) (hNT k) (hRFP k) (hLeft k)
 
 /-- **Per-block isometry canonical form.** When each block of a multi-block tensor
 is a normal, left-canonical renormalization fixed point, that block admits an

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -68,16 +68,20 @@ private lemma matrixUnits_map (X : Mat) :
     _ = Matrix.trace X • (1 : Mat) := by
           rw [Matrix.sum_single_eq_diagonal, Matrix.smul_one_eq_diagonal]
 
-/-- Auxiliary extraction underlying `rfp_nt_structural_full`.
+/-- Full Appendix B extraction with the diagonal-weight square-sum identity.
 
-This is the full Appendix B extraction with one extra recorded fact: the diagonal
-weights satisfy `∑ k, (Λ k) ^ 2 = D` in the matrix-unit normalization used here.
-That identity comes from `(Λ k) ^ 2 = D · ρ_{k,k} / tr ρ` together with the
-trace identity `∑ k ρ_{k,k} = tr ρ` for the diagonal fixed point `ρ`. It is the
-seed for the source trace-normalization `tr(Λ_src) = 1` after rescaling to the
-unit pair-index convention (arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`,
-lines 1271--1301). -/
-private theorem rfp_nt_structural_full_aux (A : MPSTensor d D) [NeZero D]
+This is the structural decomposition `A i = X * Λ * U i * X⁻¹` of Lemma B.1 with
+one extra recorded fact: the diagonal weights satisfy `∑ k, (Λ k) ^ 2 = D` in
+the matrix-unit normalization used here. That identity comes from
+`(Λ k) ^ 2 = D · ρ_{k,k} / tr ρ` together with the trace identity
+`∑ k ρ_{k,k} = tr ρ` for the diagonal fixed point `ρ`. It is the seed for the
+source trace-normalization `tr(Λ) = 1` after rescaling to the unit pair-index
+convention (arXiv:1606.00608, Lemma charact-NT-pure-RFP, lines 1271--1301).
+
+The plain structural form `rfp_nt_structural_full` is the wrapper that drops the
+square-sum conjunct; the trace-normalized form
+`isIsometryCanonicalForm_of_rfp_nt` is the wrapper that consumes it. -/
+theorem rfp_nt_structural_full_sqSum (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
     ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ)
@@ -488,7 +492,7 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
           if p = q then (D : ℂ)⁻¹ else 0) ∧
       (∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹) := by
   obtain ⟨X, Λ, U, hX_det, hΛ_pos, hU_left, hU_pair, _, hA_eq⟩ :=
-    rfp_nt_structural_full_aux A hNT hRFP hLeft
+    rfp_nt_structural_full_sqSum A hNT hRFP hLeft
   exact ⟨X, Λ, U, hX_det, hΛ_pos, hU_left, hU_pair, hA_eq⟩
 
 /-- `(√D : ℂ)` times its conjugate is `D`. Used to rescale the `D⁻¹` pair-index
@@ -629,13 +633,13 @@ theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
           simp [L, U]
 
 /-- **Isometry canonical form for a single normal-tensor block**
-(arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`, lines 1271--1301, and the
-single-block case `j = j'` of Theorem `thm:charact-MPS`, eq. `III_CFI_RFP` and
-`eq:III_isometry`).
+(arXiv:1606.00608, Lemma charact-NT-pure-RFP, lines 1271--1301, and the
+single-block case j = j' of the structural characterization Theorem
+charact-MPS, eqs. III_CFI_RFP and III_isometry).
 
 A normal tensor `A` is in *isometry canonical form* when there are an invertible
 `X`, a positive diagonal weight `Λ` with `∑ k Λ k = 1` (the source
-trace-normalization `tr(Λ) = 1`), and a residual tensor `U` satisfying the unit
+trace-normalization tr Λ = 1), and a residual tensor `U` satisfying the unit
 pair-index isometry
 \[
   \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
@@ -646,24 +650,27 @@ such that
   A^i = X \, \sqrt{\Lambda} \, U^i \, X^{-1}.
 \]
 The square root appears because the source reference tensor is
-`Â^{(α',β')}_{α,β} = δ_{α,α'} δ_{β,β'} √(Λ_α)` (arXiv:1606.00608, line 1300):
-the diagonal that dresses the unit isometry is `√Λ`, while the trace
-normalization `tr(Λ) = 1` is imposed on `Λ` itself, equivalently on the diagonal
-fixed point `ρ = diag(Λ)` of the transfer map.
+\(\widehat A^{(\alpha',\beta')}_{\alpha,\beta}
+  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha}\)
+(arXiv:1606.00608, line 1300): the diagonal that dresses the unit isometry is
+`√Λ`, while the trace normalization tr Λ = 1 is imposed on `Λ` itself,
+equivalently on the diagonal fixed point `ρ = diag Λ` of the transfer map.
 
 **Local fix (square-root diagonal):** The source's displayed equation
-`eq_III_NT_RFP` (arXiv:1606.00608, line 1278) writes `A^i = X Λ U^i X⁻¹` with the
-diagonal `Λ` itself (no square root) alongside the unit isometry condition on `U`
-(lines 1281--1283). That literal pairing is inconsistent: against the reference
-tensor `Â = √Λ · (matrix unit)` (line 1300) the residual `Λ⁻¹ Â = √Λ⁻¹ ·
-(matrix unit)` has pair-index sum `δ / Λ_α`, not `δ`, so a unit `U` forces the
-square-root dressing `√Λ` in the decomposition.  This `Λ → √Λ` change is a local
-correction of the source display, mathematically correct as stated; it is
+III_NT_RFP (arXiv:1606.00608, line 1278) writes \(A^i = X\Lambda U^iX^{-1}\) with
+the diagonal \(\Lambda\) itself (no square root) alongside the unit isometry
+condition on \(U\) (lines 1281--1283). That literal pairing is inconsistent:
+against the reference tensor \(\widehat A = \sqrt\Lambda\cdot(\text{matrix
+unit})\) (line 1300) the residual \(\Lambda^{-1}\widehat A\) has pair-index sum
+\(\delta/\Lambda_\alpha\), not \(\delta\), so a unit `U` forces the square-root
+dressing `√Λ` in the decomposition. This \(\Lambda\to\sqrt\Lambda\) change is a
+local correction of the source display, mathematically correct as stated; it is
 documented in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
 
-This records the diagonal `j = j'` case of the source isometry condition. The
-cross-block `δ_{j,j'}` orthogonality between distinct normal-tensor blocks is a
-separate condition, recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+This records the diagonal j = j' case of the source isometry condition. The
+cross-block \(\delta_{j,j'}\) orthogonality between distinct normal-tensor blocks
+is a separate condition, recorded in
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
 def IsIsometryCanonicalForm (A : MPSTensor d D) : Prop :=
   ∃ (X : Matrix (Fin D) (Fin D) ℂ) (Λ : Fin D → ℝ) (U : MPSTensor d D),
     X.det ≠ 0 ∧
@@ -675,7 +682,7 @@ def IsIsometryCanonicalForm (A : MPSTensor d D) : Prop :=
     (∀ i, A i = X * Matrix.diagonal (fun k => (Real.sqrt (Λ k) : ℂ)) * U i * X⁻¹)
 
 /-- **Trace-normalized isometry canonical form of Lemma B.1**
-(arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`, lines 1271--1301).
+(arXiv:1606.00608, Lemma charact-NT-pure-RFP, lines 1271--1301).
 
 A normal tensor in canonical form II that is a renormalization fixed point is in
 isometry canonical form: it admits a decomposition
@@ -689,7 +696,7 @@ point of the transfer map; trace-normalization is then the trace identity
 tensor `Â = √Λ · (matrix unit)` (arXiv:1606.00608, line 1300) and keeps `U` a
 genuine unit isometry.
 
-**Local fix (square-root diagonal):** the source display `eq_III_NT_RFP`
+**Local fix (square-root diagonal):** the source display III_NT_RFP
 (line 1278) writes `A^i = X Λ U^i X⁻¹` without the square root; the `Λ → √Λ`
 correction is documented in the predicate `IsIsometryCanonicalForm` and in
 `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
@@ -699,7 +706,7 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
     IsIsometryCanonicalForm A := by
   classical
   obtain ⟨X, Λ₀, U₀, hX_det, hΛ₀_pos, _, hU₀_pair, hΛ₀_sq, hA_eq⟩ :=
-    rfp_nt_structural_full_aux A hNT hRFP hLeft
+    rfp_nt_structural_full_sqSum A hNT hRFP hLeft
   let sR : ℝ := Real.sqrt (D : ℝ)
   let s : ℂ := (sR : ℂ)
   -- Rescale to the unit pair-index convention: `U = √D · U₀`, `Λtil = Λ₀ / √D`.
@@ -769,17 +776,18 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
 
 /-- **Per-block trace-normalized isometry canonical form.** Each block of a
 multi-block tensor that is a normal, left-canonical renormalization fixed point
-is in isometry canonical form: it admits a decomposition `A_k^i = X √Λ_k U^i X⁻¹`
-with `Λ_k` diagonal positive, trace-normalized (`∑ j Λ_k j = 1`), and `U`
-a unit pair-index isometry.
+is in isometry canonical form: it admits a decomposition
+\(A_k^i = X\sqrt{\Lambda_k}\,U^iX^{-1}\) with \(\Lambda_k\) diagonal positive,
+trace-normalized (\(\sum_j (\Lambda_k)_j = 1\)), and \(U\) a unit pair-index
+isometry.
 
-This is the single-block trace-normalized form (Theorem
-`isIsometryCanonicalForm_of_rfp_nt`, the diagonal `j = j'` case of
-arXiv:1606.00608, Corollary III.cor3, lines 583--589) applied to each block.
+This is the single-block trace-normalized form (`isIsometryCanonicalForm_of_rfp_nt`,
+the diagonal j = j' case of arXiv:1606.00608, Corollary III.cor3, lines
+583--589) applied to each block.
 
 **Scope restriction (source isometry):** Corollary III.cor3 also invokes the
-cross-block `δ_{j,j'}` orthogonality between distinct normal-tensor blocks
-(eq:III_isometry, lines 550--554). This per-block statement omits those
+cross-block \(\delta_{j,j'}\) orthogonality between distinct normal-tensor blocks
+(eq. III_isometry, lines 550--554). This per-block statement omits those
 cross-block equations; the gap is recorded in
 `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. Deriving the per-block
 normal/RFP/left-canonical hypotheses from a whole-tensor canonical-form

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -76,7 +76,7 @@ That identity comes from `(Λ k) ^ 2 = D · ρ_{k,k} / tr ρ` together with the
 trace identity `∑ k ρ_{k,k} = tr ρ` for the diagonal fixed point `ρ`. It is the
 seed for the source trace-normalization `tr(Λ_src) = 1` after rescaling to the
 unit pair-index convention (arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`,
-lines 1271--1295). -/
+lines 1271--1301). -/
 private theorem rfp_nt_structural_full_aux (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
@@ -420,7 +420,7 @@ private theorem rfp_nt_structural_full_aux (A : MPSTensor d D) [NeZero D]
   -- `∑ k (Λ k)^2 = D`: each square is `D · ρ_{k,k} / tr ρ`, and `∑ ρ_{k,k} = tr ρ`.
   have hΛsq : ∀ k : Fin D, (Λ k) ^ 2 = (D : ℝ) * (ρ k k).re / (Matrix.trace ρ).re := by
     intro k
-    have hk_pos : 0 < (ρ k k).re := (RCLike.pos_iff.mp (hρdiag_pos k)).1
+    have hk_nonneg : 0 ≤ (ρ k k).re := le_of_lt (RCLike.pos_iff.mp (hρdiag_pos k)).1
     have harg_nonneg : 0 ≤ ((D : ℝ) * (ρ k k).re) / (Matrix.trace ρ).re :=
       div_nonneg (by positivity) (le_of_lt htr_re_pos)
     simpa [Λ, sq] using Real.sq_sqrt harg_nonneg
@@ -436,7 +436,7 @@ private theorem rfp_nt_structural_full_aux (A : MPSTensor d D) [NeZero D]
       _ = (D : ℝ) * (Matrix.trace ρ).re / (Matrix.trace ρ).re := by
             rw [htrace_re_sum]
       _ = (D : ℝ) := by
-            field_simp
+            field_simp [htr_re_ne]
   refine ⟨X, Λ, U, hX_det, ?_, hU_left, hU_pair, hΛ_sq_sum, ?_⟩
   · intro k
     apply Real.sqrt_pos.2
@@ -491,6 +491,51 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     rfp_nt_structural_full_aux A hNT hRFP hLeft
   exact ⟨X, Λ, U, hX_det, hΛ_pos, hU_left, hU_pair, hA_eq⟩
 
+/-- `(√D : ℂ)` times its conjugate is `D`. Used to rescale the `D⁻¹` pair-index
+orthonormality to the unit convention. -/
+private theorem sqrtCard_star_mul [NeZero D] :
+    star ((Real.sqrt (D : ℝ) : ℂ)) * (Real.sqrt (D : ℝ) : ℂ) = (D : ℂ) := by
+  have hDpos : 0 < (D : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hs_sq : Real.sqrt (D : ℝ) * Real.sqrt (D : ℝ) = (D : ℝ) := by
+    rw [← pow_two]; exact Real.sq_sqrt (le_of_lt hDpos)
+  rw [Complex.star_def, Complex.conj_ofReal, ← Complex.ofReal_mul, hs_sq,
+    Complex.ofReal_natCast]
+
+/-- Rescaling a residual tensor `U₀` with `D⁻¹` pair-index orthonormality by the
+scalar `√D` upgrades it to the unit pair-index convention
+\[
+  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'},
+  \qquad U^i = \sqrt D\,U_0^i.
+\]
+Shared between `rfp_nt_structural_full_unit_pair` and
+`isIsometryCanonicalForm_of_rfp_nt`. -/
+private theorem unit_pair_of_scaled_sqrtCard [NeZero D] (U₀ : MPSTensor d D)
+    (hU₀_pair : ∀ p q : Fin D × Fin D,
+      ∑ i : Fin d, star (U₀ i p.1 p.2) * U₀ i q.1 q.2 =
+        if p = q then (D : ℂ)⁻¹ else 0)
+    (p q : Fin D × Fin D) :
+    ∑ i : Fin d,
+        star (((Real.sqrt (D : ℝ) : ℂ) • U₀ i) p.1 p.2) *
+          ((Real.sqrt (D : ℝ) : ℂ) • U₀ i) q.1 q.2 =
+      if p = q then 1 else 0 := by
+  have hD_ne : (D : ℂ) ≠ 0 := by exact_mod_cast (NeZero.ne D)
+  set s : ℂ := (Real.sqrt (D : ℝ) : ℂ) with hs
+  calc
+    ∑ i : Fin d, star ((s • U₀ i) p.1 p.2) * (s • U₀ i) q.1 q.2
+        = ∑ i : Fin d, (star s * s) * (star (U₀ i p.1 p.2) * U₀ i q.1 q.2) := by
+            refine Finset.sum_congr rfl ?_
+            intro i _
+            simp [mul_assoc, mul_left_comm, mul_comm]
+    _ = (star s * s) * ∑ i : Fin d, star (U₀ i p.1 p.2) * U₀ i q.1 q.2 := by
+          rw [Finset.mul_sum]
+    _ = (D : ℂ) * (if p = q then (D : ℂ)⁻¹ else 0) := by
+          rw [hs, sqrtCard_star_mul, hU₀_pair p q]
+    _ = if p = q then 1 else 0 := by
+          by_cases hpq : p = q
+          · simp [hpq, hD_ne]
+          · simp [hpq]
+
 /-- **Unit pair-index form of Lemma B.1.**  This is the same structural
 decomposition as the isometry theorem above
 (Theorem~\ref{thm:rfp_nt_structural_full}), rewritten in the source convention
@@ -539,16 +584,6 @@ theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
     exact Real.sqrt_pos.2 hDpos
   have hs_ne : s ≠ 0 := by
     simpa [s] using Complex.ofReal_ne_zero.mpr hsR_ne
-  have hs_star : star s * s = (D : ℂ) := by
-    have hs_sq : sR * sR = (D : ℝ) := by
-      have hnn : 0 ≤ (D : ℝ) := by positivity
-      change Real.sqrt (D : ℝ) * Real.sqrt (D : ℝ) = (D : ℝ)
-      rw [← pow_two]
-      exact Real.sq_sqrt hnn
-    have hs_sq_c := congrArg (fun x : ℝ => (x : ℂ)) hs_sq
-    simpa [s, Complex.ofReal_mul] using hs_sq_c
-  have hD_ne : (D : ℂ) ≠ 0 := by
-    exact_mod_cast (NeZero.ne D)
   have hdiag :
       Matrix.diagonal (fun k => (Λ k : ℂ)) =
         s⁻¹ • Matrix.diagonal (fun k => (Λ₀ k : ℂ)) := by
@@ -568,22 +603,7 @@ theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
   · intro k
     exact div_pos (hΛ₀_pos k) hsR_pos
   · intro p q
-    calc
-      ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2
-          = ∑ i : Fin d,
-              (star s * s) * (star (U₀ i p.1 p.2) * U₀ i q.1 q.2) := by
-              refine Finset.sum_congr rfl ?_
-              intro i _
-              simp [U, s, mul_assoc, mul_left_comm, mul_comm]
-      _ = (star s * s) *
-            ∑ i : Fin d, star (U₀ i p.1 p.2) * U₀ i q.1 q.2 := by
-              rw [Finset.mul_sum]
-      _ = (D : ℂ) * (if p = q then (D : ℂ)⁻¹ else 0) := by
-              rw [hs_star, hU₀_pair p q]
-      _ = if p = q then 1 else 0 := by
-              by_cases hpq : p = q
-              · simp [hpq, hD_ne]
-              · simp [hpq]
+    exact unit_pair_of_scaled_sqrtCard U₀ hU₀_pair p q
   · intro i
     rw [hA_eq i]
     let L : Matrix (Fin D) (Fin D) ℂ := Matrix.diagonal (fun k => (Λ k : ℂ))
@@ -609,7 +629,7 @@ theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
           simp [L, U]
 
 /-- **Isometry canonical form for a single normal-tensor block**
-(arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`, lines 1271--1295, and the
+(arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`, lines 1271--1301, and the
 single-block case `j = j'` of Theorem `thm:charact-MPS`, eq. `III_CFI_RFP` and
 `eq:III_isometry`).
 
@@ -626,10 +646,20 @@ such that
   A^i = X \, \sqrt{\Lambda} \, U^i \, X^{-1}.
 \]
 The square root appears because the source reference tensor is
-`Â^{(α',β')}_{α,β} = δ_{α,α'} δ_{β,β'} √(Λ_α)` (arXiv:1606.00608, line 1288):
+`Â^{(α',β')}_{α,β} = δ_{α,α'} δ_{β,β'} √(Λ_α)` (arXiv:1606.00608, line 1300):
 the diagonal that dresses the unit isometry is `√Λ`, while the trace
 normalization `tr(Λ) = 1` is imposed on `Λ` itself, equivalently on the diagonal
 fixed point `ρ = diag(Λ)` of the transfer map.
+
+**Local fix (square-root diagonal):** The source's displayed equation
+`eq_III_NT_RFP` (arXiv:1606.00608, line 1278) writes `A^i = X Λ U^i X⁻¹` with the
+diagonal `Λ` itself (no square root) alongside the unit isometry condition on `U`
+(lines 1281--1283). That literal pairing is inconsistent: against the reference
+tensor `Â = √Λ · (matrix unit)` (line 1300) the residual `Λ⁻¹ Â = √Λ⁻¹ ·
+(matrix unit)` has pair-index sum `δ / Λ_α`, not `δ`, so a unit `U` forces the
+square-root dressing `√Λ` in the decomposition.  This `Λ → √Λ` change is a local
+correction of the source display, mathematically correct as stated; it is
+documented in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
 
 This records the diagonal `j = j'` case of the source isometry condition. The
 cross-block `δ_{j,j'}` orthogonality between distinct normal-tensor blocks is a
@@ -645,7 +675,7 @@ def IsIsometryCanonicalForm (A : MPSTensor d D) : Prop :=
     (∀ i, A i = X * Matrix.diagonal (fun k => (Real.sqrt (Λ k) : ℂ)) * U i * X⁻¹)
 
 /-- **Trace-normalized isometry canonical form of Lemma B.1**
-(arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`, lines 1271--1295).
+(arXiv:1606.00608, Lemma `lem:charact-NT-pure-RFP`, lines 1271--1301).
 
 A normal tensor in canonical form II that is a renormalization fixed point is in
 isometry canonical form: it admits a decomposition
@@ -656,7 +686,13 @@ isometry.
 The diagonal weight is `Λ k = ρ_{k,k} / tr ρ`, the normalized diagonal fixed
 point of the transfer map; trace-normalization is then the trace identity
 `∑ k ρ_{k,k} = tr ρ`. The square-root dressing `√Λ` matches the source reference
-tensor `Â = √Λ · (matrix unit)` and keeps `U` a genuine unit isometry. -/
+tensor `Â = √Λ · (matrix unit)` (arXiv:1606.00608, line 1300) and keeps `U` a
+genuine unit isometry.
+
+**Local fix (square-root diagonal):** the source display `eq_III_NT_RFP`
+(line 1278) writes `A^i = X Λ U^i X⁻¹` without the square root; the `Λ → √Λ`
+correction is documented in the predicate `IsIsometryCanonicalForm` and in
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
 theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
@@ -676,14 +712,6 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
   have hsR_ne : sR ≠ 0 := Real.sqrt_ne_zero'.2 hDpos
   have hsR_pos : 0 < sR := Real.sqrt_pos.2 hDpos
   have hs_ne : s ≠ 0 := by simpa [s] using Complex.ofReal_ne_zero.mpr hsR_ne
-  have hD_ne : (D : ℂ) ≠ 0 := by exact_mod_cast (NeZero.ne D)
-  have hs_star : star s * s = (D : ℂ) := by
-    have hs_sq : sR * sR = (D : ℝ) := by
-      have hnn : 0 ≤ (D : ℝ) := by positivity
-      change Real.sqrt (D : ℝ) * Real.sqrt (D : ℝ) = (D : ℝ)
-      rw [← pow_two]; exact Real.sq_sqrt hnn
-    have hs_sq_c := congrArg (fun x : ℝ => (x : ℂ)) hs_sq
-    simpa [s, Complex.ofReal_mul] using hs_sq_c
   have hΛtil_pos : ∀ k, 0 < Λtil k := fun k => div_pos (hΛ₀_pos k) hsR_pos
   -- `√Λ k = Λtil k`, so the decomposition matches the source `√Λ` dressing.
   have hsqrtΛ : ∀ k, Real.sqrt (Λ k) = Λtil k := by
@@ -704,23 +732,10 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
             Finset.sum_congr rfl (fun k _ => hstep k)
       _ = (∑ k : Fin D, (Λ₀ k) ^ 2) / (D : ℝ) := by rw [Finset.sum_div]
       _ = (D : ℝ) / (D : ℝ) := by rw [hΛ₀_sq]
-      _ = 1 := by field_simp
+      _ = 1 := by field_simp [hDpos.ne']
   · -- Unit pair-index isometry: `√D · U₀` upgrades the `D⁻¹` form to unit.
     intro p q
-    calc
-      ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2
-          = ∑ i : Fin d, (star s * s) * (star (U₀ i p.1 p.2) * U₀ i q.1 q.2) := by
-              refine Finset.sum_congr rfl ?_
-              intro i _
-              simp [U, s, mul_assoc, mul_left_comm, mul_comm]
-      _ = (star s * s) * ∑ i : Fin d, star (U₀ i p.1 p.2) * U₀ i q.1 q.2 := by
-              rw [Finset.mul_sum]
-      _ = (D : ℂ) * (if p = q then (D : ℂ)⁻¹ else 0) := by
-              rw [hs_star, hU₀_pair p q]
-      _ = if p = q then 1 else 0 := by
-              by_cases hpq : p = q
-              · simp [hpq, hD_ne]
-              · simp [hpq]
+    exact unit_pair_of_scaled_sqrtCard U₀ hU₀_pair p q
   · -- Decomposition: `A^i = X √Λ U^i X⁻¹` reduces to the `Λ₀, U₀` form.
     intro i
     rw [hA_eq i]
@@ -739,7 +754,7 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
         rw [show (Λtil a : ℂ) = (Λ₀ a / sR : ℝ) from by simp [Λtil],
           Complex.ofReal_div]
         rw [show s = (sR : ℂ) from rfl]
-        field_simp
+        field_simp [hsRC_ne]
       · simp [Matrix.diagonal, hab]
     have hmove : (s • L) * U₀ i = L * (s • U₀ i) := by
       rw [Matrix.smul_mul, Matrix.mul_smul]

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -70,17 +70,19 @@ private lemma matrixUnits_map (X : Mat) :
 
 /-- Full Appendix B extraction with the diagonal-weight square-sum identity.
 
-This is the structural decomposition `A i = X * Λ * U i * X⁻¹` of Lemma B.1 with
-one extra recorded fact: the diagonal weights satisfy `∑ k, (Λ k) ^ 2 = D` in
-the matrix-unit normalization used here. That identity comes from
-`(Λ k) ^ 2 = D · ρ_{k,k} / tr ρ` together with the trace identity
-`∑ k ρ_{k,k} = tr ρ` for the diagonal fixed point `ρ`. It is the seed for the
-source trace-normalization `tr(Λ) = 1` after rescaling to the unit pair-index
-convention (arXiv:1606.00608, Lemma charact-NT-pure-RFP, lines 1271--1301).
+This is the structural decomposition \(A^i = X\Lambda U^i X^{-1}\) of Lemma B.1
+with one extra recorded fact: the diagonal weights satisfy
+\(\sum_k \Lambda_k^2 = D\) in the matrix-unit normalization used here. That
+identity comes from \(\Lambda_k^2 = D\,\rho_{k,k}/\operatorname{tr}\rho\)
+together with the trace identity \(\sum_k \rho_{k,k} = \operatorname{tr}\rho\)
+for the diagonal fixed point \(\rho\). It is the seed for the source
+trace-normalization \(\operatorname{tr}\Lambda = 1\) after rescaling to the unit
+pair-index convention (arXiv:1606.00608, Lemma charact-NT-pure-RFP,
+lines 1271--1301).
 
-The plain structural form `rfp_nt_structural_full` is the wrapper that drops the
-square-sum conjunct; the trace-normalized form
-`isIsometryCanonicalForm_of_rfp_nt` is the wrapper that consumes it. -/
+The plain structural form `rfp_nt_structural_full` is the equivalent formulation
+that drops the square-sum conjunct; the trace-normalized form
+`isIsometryCanonicalForm_of_rfp_nt` is the one that consumes it. -/
 theorem rfp_nt_structural_full_sqSum (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
@@ -421,7 +423,8 @@ theorem rfp_nt_structural_full_sqSum (A : MPSTensor d D) [NeZero D]
   have htr_re_pos : 0 < (Matrix.trace ρ).re := by
     exact (RCLike.pos_iff.mp hρ_pd.trace_pos).1
   have htr_re_ne : (Matrix.trace ρ).re ≠ 0 := ne_of_gt htr_re_pos
-  -- `∑ k (Λ k)^2 = D`: each square is `D · ρ_{k,k} / tr ρ`, and `∑ ρ_{k,k} = tr ρ`.
+  -- The squared weights sum to D: each square is D times the k-th diagonal
+  -- entry of ρ over its trace, and those diagonal entries sum to the trace.
   have hΛsq : ∀ k : Fin D, (Λ k) ^ 2 = (D : ℝ) * (ρ k k).re / (Matrix.trace ρ).re := by
     intro k
     have hk_nonneg : 0 ≤ (ρ k k).re := le_of_lt (RCLike.pos_iff.mp (hρdiag_pos k)).1
@@ -463,8 +466,8 @@ theorem rfp_nt_structural_full_sqSum (A : MPSTensor d D) [NeZero D]
         simp [L, Matrix.mul_assoc]
 
 /-- **Lemma B.1** (arXiv:1606.00608, Appendix B): a normal tensor in canonical
-form II that is an RFP admits the decomposition `A i = X * Λ * U i * X⁻¹`
-with diagonal positive `Λ` and a residual tensor `U` satisfying the
+form II that is an RFP admits the decomposition \(A^i = X\Lambda U^i X^{-1}\)
+with diagonal positive \(\Lambda\) and a residual tensor \(U\) satisfying the
 left-canonical equation and the scaled pair-index orthonormality
 \[
   \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
@@ -475,10 +478,10 @@ left-canonical equation and the scaled pair-index orthonormality
 The proof combines the diagonal fixed-point reduction
 `rfp_nt_cfii_diagonal_fixedPoint`, the rank-one classification
 `transferMap_eq_fixedPointProj_of_isRFP_injective`, and an explicit Kraus
-realization of `fixedPointProj ρ`. Applying `kraus_rectangular_freedom'`
+realization of `fixedPointProj`. Applying `kraus_rectangular_freedom'`
 identifies the physical-index coefficients with an isometry. The matrix units
-are normalized by $D^{-1/2}$, so the resulting matrix entries carry the
-displayed factor $D^{-1}$. -/
+are normalized by \(D^{-1/2}\), so the resulting matrix entries carry the
+displayed factor \(D^{-1}\). -/
 theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1) :
@@ -495,8 +498,8 @@ theorem rfp_nt_structural_full (A : MPSTensor d D) [NeZero D]
     rfp_nt_structural_full_sqSum A hNT hRFP hLeft
   exact ⟨X, Λ, U, hX_det, hΛ_pos, hU_left, hU_pair, hA_eq⟩
 
-/-- `(√D : ℂ)` times its conjugate is `D`. Used to rescale the `D⁻¹` pair-index
-orthonormality to the unit convention. -/
+/-- The complex number \(\sqrt D\) times its conjugate is \(D\). Used to rescale
+the \(D^{-1}\) pair-index orthonormality to the unit convention. -/
 private theorem sqrtCard_star_mul [NeZero D] :
     star ((Real.sqrt (D : ℝ) : ℂ)) * (Real.sqrt (D : ℝ) : ℂ) = (D : ℂ) := by
   have hDpos : 0 < (D : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
@@ -505,8 +508,8 @@ private theorem sqrtCard_star_mul [NeZero D] :
   rw [Complex.star_def, Complex.conj_ofReal, ← Complex.ofReal_mul, hs_sq,
     Complex.ofReal_natCast]
 
-/-- Rescaling a residual tensor `U₀` with `D⁻¹` pair-index orthonormality by the
-scalar `√D` upgrades it to the unit pair-index convention
+/-- Rescaling a residual tensor `U₀` with \(D^{-1}\) pair-index orthonormality by
+the scalar \(\sqrt D\) upgrades it to the unit pair-index convention
 \[
   \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
   = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'},
@@ -637,10 +640,11 @@ theorem rfp_nt_structural_full_unit_pair (A : MPSTensor d D) [NeZero D]
 single-block case j = j' of the structural characterization Theorem
 charact-MPS, eqs. III_CFI_RFP and III_isometry).
 
-A normal tensor `A` is in *isometry canonical form* when there are an invertible
-`X`, a positive diagonal weight `Λ` with `∑ k Λ k = 1` (the source
-trace-normalization tr Λ = 1), and a residual tensor `U` satisfying the unit
-pair-index isometry
+A normal tensor \(A\) is in *isometry canonical form* when there are an
+invertible \(X\), a positive diagonal weight \(\Lambda\) with
+\(\sum_k \Lambda_k = 1\) (the source trace-normalization
+\(\operatorname{tr}\Lambda = 1\)), and a residual tensor \(U\) satisfying the
+unit pair-index isometry
 \[
   \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
   = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'},
@@ -653,8 +657,9 @@ The square root appears because the source reference tensor is
 \(\widehat A^{(\alpha',\beta')}_{\alpha,\beta}
   = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha}\)
 (arXiv:1606.00608, line 1300): the diagonal that dresses the unit isometry is
-`√Λ`, while the trace normalization tr Λ = 1 is imposed on `Λ` itself,
-equivalently on the diagonal fixed point `ρ = diag Λ` of the transfer map.
+\(\sqrt\Lambda\), while the trace normalization \(\operatorname{tr}\Lambda = 1\)
+is imposed on \(\Lambda\) itself, equivalently on the diagonal fixed point
+\(\rho = \operatorname{diag}\Lambda\) of the transfer map.
 
 **Local fix (square-root diagonal):** The source's displayed equation
 III_NT_RFP (arXiv:1606.00608, line 1278) writes \(A^i = X\Lambda U^iX^{-1}\) with
@@ -662,10 +667,10 @@ the diagonal \(\Lambda\) itself (no square root) alongside the unit isometry
 condition on \(U\) (lines 1281--1283). That literal pairing is inconsistent:
 against the reference tensor \(\widehat A = \sqrt\Lambda\cdot(\text{matrix
 unit})\) (line 1300) the residual \(\Lambda^{-1}\widehat A\) has pair-index sum
-\(\delta/\Lambda_\alpha\), not \(\delta\), so a unit `U` forces the square-root
-dressing `√Λ` in the decomposition. This \(\Lambda\to\sqrt\Lambda\) change is a
-local correction of the source display, mathematically correct as stated; it is
-documented in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
+\(\delta/\Lambda_\alpha\), not \(\delta\), so a unit \(U\) forces the square-root
+dressing \(\sqrt\Lambda\) in the decomposition. This \(\Lambda\to\sqrt\Lambda\)
+change is a local correction of the source display, mathematically correct as
+stated; it is documented in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
 
 This records the diagonal j = j' case of the source isometry condition. The
 cross-block \(\delta_{j,j'}\) orthogonality between distinct normal-tensor blocks
@@ -686,19 +691,21 @@ def IsIsometryCanonicalForm (A : MPSTensor d D) : Prop :=
 
 A normal tensor in canonical form II that is a renormalization fixed point is in
 isometry canonical form: it admits a decomposition
-`A^i = X √Λ U^i X⁻¹` with `Λ` diagonal, positive, trace-normalized
-(`∑ k Λ k = 1`, the source condition `tr(Λ) = 1`), and `U` a unit pair-index
-isometry.
+\(A^i = X\sqrt\Lambda\,U^i X^{-1}\) with \(\Lambda\) diagonal, positive,
+trace-normalized (\(\sum_k \Lambda_k = 1\), the source condition
+\(\operatorname{tr}\Lambda = 1\)), and \(U\) a unit pair-index isometry.
 
-The diagonal weight is `Λ k = ρ_{k,k} / tr ρ`, the normalized diagonal fixed
-point of the transfer map; trace-normalization is then the trace identity
-`∑ k ρ_{k,k} = tr ρ`. The square-root dressing `√Λ` matches the source reference
-tensor `Â = √Λ · (matrix unit)` (arXiv:1606.00608, line 1300) and keeps `U` a
-genuine unit isometry.
+The diagonal weight is \(\Lambda_k = \rho_{k,k}/\operatorname{tr}\rho\), the
+normalized diagonal fixed point of the transfer map; trace-normalization is then
+the trace identity \(\sum_k \rho_{k,k} = \operatorname{tr}\rho\). The square-root
+dressing \(\sqrt\Lambda\) matches the source reference tensor
+\(\widehat A = \sqrt\Lambda\cdot(\text{matrix unit})\) (arXiv:1606.00608,
+line 1300) and keeps \(U\) a genuine unit isometry.
 
 **Local fix (square-root diagonal):** the source display III_NT_RFP
-(line 1278) writes `A^i = X Λ U^i X⁻¹` without the square root; the `Λ → √Λ`
-correction is documented in the predicate `IsIsometryCanonicalForm` and in
+(line 1278) writes \(A^i = X\Lambda U^i X^{-1}\) without the square root; the
+\(\Lambda\to\sqrt\Lambda\) correction is documented in the predicate
+`IsIsometryCanonicalForm` and in
 `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
 theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)
@@ -709,9 +716,9 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
     rfp_nt_structural_full_sqSum A hNT hRFP hLeft
   let sR : ℝ := Real.sqrt (D : ℝ)
   let s : ℂ := (sR : ℂ)
-  -- Rescale to the unit pair-index convention: `U = √D · U₀`, `Λtil = Λ₀ / √D`.
+  -- Rescale to the unit pair-index convention by the scalar square root of D.
   let Λtil : Fin D → ℝ := fun k => Λ₀ k / sR
-  -- The trace-normalized diagonal is `Λ = Λtil² = Λ₀² / D`.
+  -- The trace-normalized diagonal is the entrywise square of the rescaled one.
   let Λ : Fin D → ℝ := fun k => (Λtil k) ^ 2
   let U : MPSTensor d D := fun i => s • U₀ i
   have hDpos_nat : 0 < D := Nat.pos_of_ne_zero (NeZero.ne D)
@@ -720,15 +727,16 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
   have hsR_pos : 0 < sR := Real.sqrt_pos.2 hDpos
   have hs_ne : s ≠ 0 := by simpa [s] using Complex.ofReal_ne_zero.mpr hsR_ne
   have hΛtil_pos : ∀ k, 0 < Λtil k := fun k => div_pos (hΛ₀_pos k) hsR_pos
-  -- `√Λ k = Λtil k`, so the decomposition matches the source `√Λ` dressing.
+  -- The square root of the trace-normalized diagonal is the rescaled diagonal,
+  -- so the decomposition matches the source square-root dressing.
   have hsqrtΛ : ∀ k, Real.sqrt (Λ k) = Λtil k := by
     intro k
     exact Real.sqrt_sq (le_of_lt (hΛtil_pos k))
   refine ⟨X, Λ, U, hX_det, ?_, ?_, ?_, ?_⟩
-  · -- `Λ k = Λtil k ^ 2 > 0`.
+  · -- Positivity: each weight is a square of a positive number.
     intro k
     exact pow_pos (hΛtil_pos k) 2
-  · -- `∑ k Λ k = (∑ Λ₀²) / D = D / D = 1`.
+  · -- Trace normalization: the weights sum to the squares of Λ₀ over D, hence 1.
     have hsR_sq : sR ^ 2 = (D : ℝ) := Real.sq_sqrt (le_of_lt hDpos)
     have hstep : ∀ k, Λ k = (Λ₀ k) ^ 2 / (D : ℝ) := by
       intro k
@@ -740,10 +748,11 @@ theorem isIsometryCanonicalForm_of_rfp_nt (A : MPSTensor d D) [NeZero D]
       _ = (∑ k : Fin D, (Λ₀ k) ^ 2) / (D : ℝ) := by rw [Finset.sum_div]
       _ = (D : ℝ) / (D : ℝ) := by rw [hΛ₀_sq]
       _ = 1 := by field_simp [hDpos.ne']
-  · -- Unit pair-index isometry: `√D · U₀` upgrades the `D⁻¹` form to unit.
+  · -- Unit pair-index isometry: scaling U₀ by the square root of D upgrades the
+    -- inverse-D form to the unit one.
     intro p q
     exact unit_pair_of_scaled_sqrtCard U₀ hU₀_pair p q
-  · -- Decomposition: `A^i = X √Λ U^i X⁻¹` reduces to the `Λ₀, U₀` form.
+  · -- Decomposition: the square-root form reduces to the original Λ₀, U₀ form.
     intro i
     rw [hA_eq i]
     let L : Matrix (Fin D) (Fin D) ℂ :=

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -486,6 +486,30 @@ and rates for the single-tensor transfer map $\E_A$.
     normalization contributes the factor $D^{-1}$ in the pair-index equation.
 \end{proof}
 
+\begin{theorem}[Structural form with diagonal square-sum identity]%
+    \label{thm:rfp_nt_structural_full_sq_sum}
+    \lean{MPSTensor.rfp_nt_structural_full_sqSum}
+    \leanok
+    \uses{thm:rfp_nt_structural_of_left_canonical,
+        thm:rfp_nt_cfii_diagonal_fixed_point,
+        thm:transferMap_eq_fixedPointProj_of_isRFP_injective}
+    The same decomposition as the full structural form
+    (Theorem~\ref{thm:rfp_nt_structural_full}) additionally records that the
+    diagonal weights satisfy $\sum_\alpha \Lambda_\alpha^2 = D$.  This square-sum
+    identity is the trace-normalization seed: the explicit weights are
+    $\Lambda_\alpha = \sqrt{D\,\rho_{\alpha,\alpha}/\tr\rho}$, and
+    $\sum_\alpha \rho_{\alpha,\alpha} = \tr\rho$ for the diagonal fixed point
+    $\rho$.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:rfp_nt_structural_full}
+    The same construction as Theorem~\ref{thm:rfp_nt_structural_full} produces
+    the diagonal weights $\Lambda_\alpha = \sqrt{D\,\rho_{\alpha,\alpha}/\tr\rho}$,
+    so $\Lambda_\alpha^2 = D\,\rho_{\alpha,\alpha}/\tr\rho$.  Summing over
+    $\alpha$ and using $\sum_\alpha \rho_{\alpha,\alpha} = \tr\rho$ gives
+    $\sum_\alpha \Lambda_\alpha^2 = D$.
+\end{proof}
+
 \begin{theorem}[Unit pair-index form for RFP tensors]%
     \label{thm:rfp_nt_structural_full_unit_pair}
     \lean{MPSTensor.rfp_nt_structural_full_unit_pair}
@@ -630,7 +654,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \label{thm:isometry_canonical_form_of_rfp_nt}
     \lean{MPSTensor.isIsometryCanonicalForm_of_rfp_nt}
     \leanok
-    \uses{def:is_isometry_canonical_form, thm:rfp_nt_structural_full}
+    \uses{def:is_isometry_canonical_form, thm:rfp_nt_structural_full_sq_sum}
     A normal tensor in canonical form~II that is a renormalization fixed point
     is in isometry canonical form: it admits a decomposition
     $A^i = X\sqrt\Lambda\,U^i X^{-1}$ with $\Lambda$ diagonal, positive,
@@ -639,20 +663,23 @@ and rates for the single-tensor transfer map $\E_A$.
     is $\Lambda_\alpha = \rho_{\alpha,\alpha}/\tr\rho$, the normalized diagonal
     fixed point of the transfer map; trace-normalization is then the trace
     identity $\sum_\alpha \rho_{\alpha,\alpha} = \tr\rho$.  This is the
-    single-block (NT) case of \cite[Section~3]{Cirac2016MPDO_arXiv},
-    Lemma~\path{lem:charact-NT-pure-RFP}, and the diagonal part of the isometry
-    condition in Theorem~\path{thm:charact-MPS}.
+    single-block normal-tensor case of the structural characterization of
+    pure-state renormalization fixed points in
+    \cite[Section~3]{Cirac2016MPDO_arXiv}, recovering the diagonal part of the
+    isometry condition there.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:rfp_nt_structural_full}
-    Apply Theorem~\ref{thm:rfp_nt_structural_full}, rescale to the unit
-    pair-index convention by $U^i\mapsto\sqrt D\,U^i$, and set
-    $\Lambda_\alpha=(\widetilde\Lambda_\alpha)^2$ where $\widetilde\Lambda$ is
-    the rescaled diagonal.  The contracted left-canonical identity gives
+    \uses{thm:rfp_nt_structural_full_sq_sum}
+    The structural form with the square-sum identity
+    (Theorem~\ref{thm:rfp_nt_structural_full_sq_sum}) supplies a positive
+    diagonal weight $\widetilde\Lambda$ with
+    $\sum_\alpha \widetilde\Lambda_\alpha^2 = D$.  Rescaling to the unit
+    pair-index convention by $U^i\mapsto\sqrt D\,U^i$ and setting
+    $\Lambda_\alpha=(\widetilde\Lambda_\alpha/\sqrt D)^2$ gives
     $\sum_\alpha \Lambda_\alpha = D^{-1}\sum_\alpha \widetilde\Lambda_\alpha^2
-    \cdot D = 1$ from the matrix-unit normalization $\sum_\alpha (\sqrt D\,
-    \widetilde\Lambda_\alpha)^2 = D$, while
-    $\sqrt{\Lambda_\alpha}=\widetilde\Lambda_\alpha$ recovers the decomposition.
+    = D^{-1}\cdot D = 1$, while
+    $\sqrt{\Lambda_\alpha}=\widetilde\Lambda_\alpha/\sqrt D$ recovers the
+    decomposition $A^i = X\sqrt\Lambda\,U^i X^{-1}$.
 \end{proof}
 
 \begin{theorem}[Per-block trace-normalized isometry canonical form]%

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -617,7 +617,13 @@ and rates for the single-tensor transfer map $\E_A$.
         = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha}$;
     the normalization $\tr(\Lambda)=1$ is imposed on $\Lambda$, equivalently on
     the normalized diagonal fixed point $\rho=\diag(\Lambda)$ of the transfer
-    map. This records the diagonal $j=j'$ case of the source isometry condition.
+    map. The displayed source form writes $A^i=X\Lambda U^iX^{-1}$ with the bare
+    diagonal; that pairing forces a non-unit residual, so the consistent
+    decomposition keeps the square root $\sqrt\Lambda$ while the trace
+    normalization stays on $\Lambda$. This records the diagonal $j=j'$ case of
+    the source isometry condition.
+    % Square-root correction documented in
+    % docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
 \end{definition}
 
 \begin{theorem}[Trace-normalized isometry canonical form for RFP tensors]%

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -595,6 +595,77 @@ and rates for the single-tensor transfer map $\E_A$.
     Apply Theorem~\ref{thm:rfp_nt_structural_full_unit_pair} to each block.
 \end{proof}
 
+\begin{definition}[Isometry canonical form]%
+    \label{def:is_isometry_canonical_form}
+    \lean{MPSTensor.IsIsometryCanonicalForm}
+    \leanok
+    A normal tensor $A$ is in \emph{isometry canonical form} when there are an
+    invertible $X$, a positive diagonal weight $\Lambda$ with the trace
+    normalization $\sum_\alpha \Lambda_\alpha = 1$, and a residual tensor $U$
+    satisfying the unit pair-index isometry
+    \[
+        \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+        = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'},
+    \]
+    such that
+    \[
+        A^i = X\,\sqrt\Lambda\,U^i\,X^{-1}.
+    \]
+    The square root dresses the unit isometry because the reference tensor of
+    \cite[Section~3]{Cirac2016MPDO_arXiv} is
+    $\widehat A^{(\alpha',\beta')}_{\alpha,\beta}
+        = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha}$;
+    the normalization $\tr(\Lambda)=1$ is imposed on $\Lambda$, equivalently on
+    the normalized diagonal fixed point $\rho=\diag(\Lambda)$ of the transfer
+    map. This records the diagonal $j=j'$ case of the source isometry condition.
+\end{definition}
+
+\begin{theorem}[Trace-normalized isometry canonical form for RFP tensors]%
+    \label{thm:isometry_canonical_form_of_rfp_nt}
+    \lean{MPSTensor.isIsometryCanonicalForm_of_rfp_nt}
+    \leanok
+    \uses{def:is_isometry_canonical_form, thm:rfp_nt_structural_full}
+    A normal tensor in canonical form~II that is a renormalization fixed point
+    is in isometry canonical form: it admits a decomposition
+    $A^i = X\sqrt\Lambda\,U^i X^{-1}$ with $\Lambda$ diagonal, positive,
+    trace-normalized ($\sum_\alpha \Lambda_\alpha = 1$, the source condition
+    $\tr(\Lambda)=1$), and $U$ a unit pair-index isometry.  The diagonal weight
+    is $\Lambda_\alpha = \rho_{\alpha,\alpha}/\tr\rho$, the normalized diagonal
+    fixed point of the transfer map; trace-normalization is then the trace
+    identity $\sum_\alpha \rho_{\alpha,\alpha} = \tr\rho$.  This is the
+    single-block (NT) case of \cite[Section~3]{Cirac2016MPDO_arXiv},
+    Lemma~\path{lem:charact-NT-pure-RFP}, and the diagonal part of the isometry
+    condition in Theorem~\path{thm:charact-MPS}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:rfp_nt_structural_full}
+    Apply Theorem~\ref{thm:rfp_nt_structural_full}, rescale to the unit
+    pair-index convention by $U^i\mapsto\sqrt D\,U^i$, and set
+    $\Lambda_\alpha=(\widetilde\Lambda_\alpha)^2$ where $\widetilde\Lambda$ is
+    the rescaled diagonal.  The contracted left-canonical identity gives
+    $\sum_\alpha \Lambda_\alpha = D^{-1}\sum_\alpha \widetilde\Lambda_\alpha^2
+    \cdot D = 1$ from the matrix-unit normalization $\sum_\alpha (\sqrt D\,
+    \widetilde\Lambda_\alpha)^2 = D$, while
+    $\sqrt{\Lambda_\alpha}=\widetilde\Lambda_\alpha$ recovers the decomposition.
+\end{proof}
+
+\begin{theorem}[Per-block trace-normalized isometry canonical form]%
+    \label{thm:isometry_canonical_form_of_rfp_nt_blocks}
+    \lean{MPSTensor.isIsometryCanonicalForm_of_rfp_nt_blocks}
+    \leanok
+    \uses{def:is_isometry_canonical_form, thm:isometry_canonical_form_of_rfp_nt}
+    Each block of a multi-block tensor whose blocks are normal, left-canonical
+    renormalization fixed points is in isometry canonical form, with a
+    trace-normalized diagonal weight and a unit pair-index isometry.  This is
+    the single-block trace-normalized form applied to each block; it omits the
+    cross-block orthogonality between distinct normal-tensor blocks, recorded in
+    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:isometry_canonical_form_of_rfp_nt}
+    Apply Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt} to each block.
+\end{proof}
+
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}
     \leanok

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -502,11 +502,14 @@ and rates for the single-tensor transfer map $\E_A$.
     $\rho$.
 \end{theorem}
 \begin{proof}\leanok
-    \uses{thm:rfp_nt_structural_full}
-    The same construction as Theorem~\ref{thm:rfp_nt_structural_full} produces
-    the diagonal weights $\Lambda_\alpha = \sqrt{D\,\rho_{\alpha,\alpha}/\tr\rho}$,
-    so $\Lambda_\alpha^2 = D\,\rho_{\alpha,\alpha}/\tr\rho$.  Summing over
-    $\alpha$ and using $\sum_\alpha \rho_{\alpha,\alpha} = \tr\rho$ gives
+    \uses{thm:rfp_nt_structural_of_left_canonical,
+        thm:rfp_nt_cfii_diagonal_fixed_point,
+        thm:transferMap_eq_fixedPointProj_of_isRFP_injective}
+    The diagonal fixed-point reduction and the rank-one classification of
+    injective left-canonical renormalization fixed points produce the diagonal
+    weights $\Lambda_\alpha = \sqrt{D\,\rho_{\alpha,\alpha}/\tr\rho}$, so
+    $\Lambda_\alpha^2 = D\,\rho_{\alpha,\alpha}/\tr\rho$.  Summing over $\alpha$
+    and using $\sum_\alpha \rho_{\alpha,\alpha} = \tr\rho$ gives
     $\sum_\alpha \Lambda_\alpha^2 = D$.
 \end{proof}
 

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -196,7 +196,7 @@ reference tensor\footnote{Local source:
 which is left-canonical and has fixed point $\diag(\Lambda)$ with
 $\tr(\Lambda)=1$.  Writing $\widehat A = \Lambda\,U$ would force
 $U^{(\alpha',\beta')}_{\alpha,\beta}
-  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}/\Lambda_\alpha$, whose pair-index
+  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}/\sqrt{\Lambda_\alpha}$, whose pair-index
 sum is
 \begin{align}
   \sum_i (U^i)_{\alpha,\beta}\,\overline{(U^i)_{\alpha',\beta'}}

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -171,6 +171,57 @@ they do not record the cross-block equations
 \end{align}
 which are part of the source condition \path{eq:III_isometry}.
 
+\section{Square-root diagonal (local correction)}
+
+The source's displayed normal-tensor form (\path{eq_III_NT_RFP}) is written
+\begin{align}
+  A^i = X\,\Lambda\,U^i\,X^{-1},
+  \tag{\path{eq_III_NT_RFP}}
+\end{align}
+with the diagonal $\Lambda$ itself, together with the unit isometry
+condition\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1278} for the displayed equation and
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1281-1283} for the unit isometry.}
+\begin{align}
+  \sum_i (U^i)_{\alpha,\beta}\,\overline{(U^i)_{\alpha',\beta'}}
+    = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+\end{align}
+This literal pairing is internally inconsistent.  The same proof constructs the
+reference tensor\footnote{Local source:
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1300}.}
+\begin{align}
+  \widehat A^{(\alpha',\beta')}_{\alpha,\beta}
+    = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha},
+\end{align}
+which is left-canonical and has fixed point $\diag(\Lambda)$ with
+$\tr(\Lambda)=1$.  Writing $\widehat A = \Lambda\,U$ would force
+$U^{(\alpha',\beta')}_{\alpha,\beta}
+  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}/\Lambda_\alpha$, whose pair-index
+sum is
+\begin{align}
+  \sum_i (U^i)_{\alpha,\beta}\,\overline{(U^i)_{\alpha',\beta'}}
+    = \frac{\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}}{\Lambda_\alpha}
+    \ne \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}
+    \qquad(\Lambda_\alpha\ne 1),
+\end{align}
+so the residual after factoring $\Lambda$ is \emph{not} a unit isometry.  Writing
+instead $\widehat A = \sqrt\Lambda\,U$ gives
+$U^{(\alpha',\beta')}_{\alpha,\beta}=\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}$,
+whose pair-index sum is
+$\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}$, a genuine unit isometry.
+
+The formalization therefore states the decomposition with the square-root
+diagonal,
+\begin{align}
+  A^i = X\,\sqrt\Lambda\,U^i\,X^{-1},
+\end{align}
+keeping both the source trace-normalization $\tr(\Lambda)=1$ on $\Lambda$ and the
+source unit isometry condition on $U$ simultaneously.  This $\Lambda\to\sqrt\Lambda$
+change is a \emph{local correction} of the source display: it is mathematically
+correct as stated, and the source itself uses $\sqrt{\Lambda_\alpha}$ for the
+reference tensor at line~1300, so the displayed $\Lambda$ at line~1278 is a
+typographic simplification of the dressing.
+
 \section{Trace normalization (discharged)}
 
 The source trace-normalization $\tr(\Lambda)=1$ is now formalized for a single
@@ -187,18 +238,17 @@ $\sum_\alpha\Lambda_\alpha=1$, and a unit pair-index isometry $U$ with
   \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
     = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
 \end{align}
-The square root on the diagonal matches the source reference tensor
-$\widehat A^{(\alpha',\beta')}_{\alpha,\beta}
-  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha}$
-(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1288}); the trace condition
-$\tr(\Lambda)=1$ is imposed on $\Lambda$ itself, equivalently on the normalized
-diagonal fixed point $\rho=\diag(\Lambda)$, $\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$.
-The identity $\sum_\alpha\Lambda_\alpha=1$ is the trace identity
+The square root on the diagonal matches the source reference tensor (the
+square-root correction is documented separately in the next section); the trace
+condition $\tr(\Lambda)=1$ is imposed on $\Lambda$ itself, equivalently on the
+normalized diagonal fixed point $\rho=\diag(\Lambda)$,
+$\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$.  The identity
+$\sum_\alpha\Lambda_\alpha=1$ is the trace identity
 $\sum_\alpha\rho_{\alpha,\alpha}=\tr\rho$ for the diagonal fixed point.
 
 This discharges the trace-normalization scope item.  The remaining open part of
 the source isometry condition is the cross-block $\delta_{j,j'}$ orthogonality
-between distinct normal-tensor blocks, treated next.
+between distinct normal-tensor blocks, treated below.
 
 \section{Elimination plan}
 

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -239,7 +239,8 @@ $\sum_\alpha\Lambda_\alpha=1$, and a unit pair-index isometry $U$ with
     = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
 \end{align}
 The square root on the diagonal matches the source reference tensor (the
-square-root correction is documented separately in the next section); the trace
+square-root correction is documented separately in the previous section); the
+trace
 condition $\tr(\Lambda)=1$ is imposed on $\Lambda$ itself, equivalently on the
 normalized diagonal fixed point $\rho=\diag(\Lambda)$,
 $\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$.  The identity

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -171,6 +171,35 @@ they do not record the cross-block equations
 \end{align}
 which are part of the source condition \path{eq:III_isometry}.
 
+\section{Trace normalization (discharged)}
+
+The source trace-normalization $\tr(\Lambda)=1$ is now formalized for a single
+normal-tensor block.  A named predicate records the isometry canonical
+form,\footnote{Formal declaration: \leanid{MPSTensor.IsIsometryCanonicalForm}
+in \doclink{TNLean/MPS/RFP/StructuralFull}.} and a theorem proves it for a
+normal canonical-form-II RFP tensor.\footnote{Formal declarations:
+\leanid{MPSTensor.isIsometryCanonicalForm_of_rfp_nt} and the per-block
+\leanid{MPSTensor.isIsometryCanonicalForm_of_rfp_nt_blocks}.}  The predicate
+asserts the existence of an invertible $X$, a positive diagonal $\Lambda$ with
+$\sum_\alpha\Lambda_\alpha=1$, and a unit pair-index isometry $U$ with
+\begin{align}
+  A^i = X\,\sqrt\Lambda\,U^i\,X^{-1},\qquad
+  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+    = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+\end{align}
+The square root on the diagonal matches the source reference tensor
+$\widehat A^{(\alpha',\beta')}_{\alpha,\beta}
+  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha}$
+(\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1288}); the trace condition
+$\tr(\Lambda)=1$ is imposed on $\Lambda$ itself, equivalently on the normalized
+diagonal fixed point $\rho=\diag(\Lambda)$, $\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$.
+The identity $\sum_\alpha\Lambda_\alpha=1$ is the trace identity
+$\sum_\alpha\rho_{\alpha,\alpha}=\tr\rho$ for the diagonal fixed point.
+
+This discharges the trace-normalization scope item.  The remaining open part of
+the source isometry condition is the cross-block $\delta_{j,j'}$ orthogonality
+between distinct normal-tensor blocks, treated next.
+
 \section{Elimination plan}
 
 A source-faithful version of Corollary~III.cor3 should be stated for a
@@ -211,8 +240,14 @@ unit pair-index convention the residual tensor satisfies
 \]
 while the contracted identity is instead
 $\sum_i (U_k^i)^\dagger U_k^i=D_k I$.  Thus the scalar normalization comparison
-is explicit, but the formal statements still omit the source trace-normalization
-and the cross-block $\delta_{j,j'}$ orthogonality equations.
+is explicit.  The source trace-normalization $\tr(\Lambda)=1$ is now formalized
+for a single block by the named predicate
+\leanid{MPSTensor.IsIsometryCanonicalForm} and the theorem
+\leanid{MPSTensor.isIsometryCanonicalForm_of_rfp_nt}, with the diagonal weight
+$\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$ and the square-root dressing
+$\sqrt\Lambda$ of the unit isometry.  The remaining open part of the source
+isometry condition is the cross-block $\delta_{j,j'}$ orthogonality equations
+between distinct normal-tensor blocks.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Adds the named single-block **isometry canonical form** predicate and the **trace-normalized** characterization for pure-state renormalization fixed points, addressing the trace-normalization gap item of #2598.

Source: arXiv:1606.00608, `thm:charact-MPS` (line 543) and Lemma `lem:charact-NT-pure-RFP` (lines 1271–1295). This formalizes the single-block (normal-tensor, `j = j'`) case of the isometry condition `eq:III_isometry`.

## New declarations (`TNLean/MPS/RFP/StructuralFull.lean`)

- **`IsIsometryCanonicalForm A`** — there exist invertible `X`, positive diagonal `Λ` with `∑ k Λ k = 1` (the source `tr(Λ) = 1`), and a residual tensor `U` satisfying the **unit** pair-index isometry `∑ᵢ (Ū^i)_{αβ}(U^i)_{α'β'} = δ_{αα'}δ_{ββ'}`, with `A^i = X · √Λ · U^i · X⁻¹`.
- **`isIsometryCanonicalForm_of_rfp_nt`** — a normal CFII renormalization fixed point is in isometry canonical form.
- **`isIsometryCanonicalForm_of_rfp_nt_blocks`** — per-block corollary for an indexed family.

## Why the `√Λ` dressing (faithfulness)

The source's reference tensor is `Â^{(α',β')}_{α,β} = δ_{α,α'}δ_{β,β'}√(Λ_α)` (line 1288). The trace condition `tr(Λ)=1` is imposed on `Λ` itself (`Λ_α = ρ_{α,α}/tr ρ`, the normalized diagonal fixed point of the transfer map), while the diagonal that dresses the **unit** isometry `U` is `√Λ`. Writing the decomposition with `√Λ` and the trace condition on `Λ` keeps both the source's literal `tr(Λ)=1` and a genuine unit isometry `U` simultaneously (these are otherwise over-constrained: a single positive-diagonal scale cannot be both trace-one and produce a unit isometry against an exactly left-canonical block). Verified numerically and against the Appendix proof.

## Implementation (additive, no downstream breakage)

- `rfp_nt_structural_full` is refactored into a private aux lemma `rfp_nt_structural_full_aux` that additionally records `∑ k (Λ k)^2 = D` (from `(Λ k)^2 = D·ρ_{kk}/tr ρ` and the trace identity `∑ ρ_{kk} = tr ρ`). The public `rfp_nt_structural_full` and the unit-pair theorems are unchanged thin wrappers — **no signature changes**, so `CommutingBridge` and all consumers are untouched.
- Trace-one follows by rescaling to the unit pair-index convention: `∑ Λ = (∑ Λ₀²)/D = D/D = 1`.

## Gap status

Discharges the **trace-normalization** scope item in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` (updated). The remaining open part of `eq:III_isometry` is the cross-block `δ_{j,j'}` orthogonality between distinct normal-tensor blocks (still documented as a gap).

## Verification

- `lake build` green (full repo, 9211 jobs).
- `lake exe lint-style TNLean/MPS/RFP/StructuralFull.lean` clean.
- Reader-facing prose check clean.
- `#print axioms` on all new declarations: only `propext, Classical.choice, Quot.sound` — no `sorry`/custom axioms.
- Blueprint ch14 updated with `def:is_isometry_canonical_form` and the two theorems (`\lean{}` names resolve against the build).

Closes part of #2598.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RFP structural theory with substantial new proofs and a decomposition convention (\(\sqrt\Lambda\)) that downstream readers must follow; existing theorem signatures are preserved as thin wrappers, limiting breakage risk.
> 
> **Overview**
> Introduces **isometry canonical form** for normal CFII renormalization fixed points: a named predicate `IsIsometryCanonicalForm` with trace-one diagonal weights, unit pair-index isometry on `U`, and decomposition **\(A^i = X\sqrt\Lambda\,U^i X^{-1}\)** (square-root dressing aligned with the CPSV16 reference tensor). Proves `isIsometryCanonicalForm_of_rfp_nt` and a per-block corollary.
> 
> The Appendix B proof is refactored so **`rfp_nt_structural_full_sqSum`** is the main lemma (same structural data as before plus **\(\sum_k \Lambda_k^2 = D\)**); public **`rfp_nt_structural_full`** is unchanged as a thin wrapper. Shared rescaling lemmas (`unit_pair_of_scaled_sqrtCard`, etc.) deduplicate unit pair-index normalization.
> 
> Blueprint ch14 and **`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`** are updated: trace normalization is marked discharged; square-root vs bare-\(\Lambda\) display is documented; cross-block \(\delta_{j,j'}\) orthogonality remains an open gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae66a4fdaca1bcdeb71f10d7c39d5d67fac8f5ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->