### PR TITLE
doc(paper-gaps): fix Lemma 3.1 scope-note dimension D', policy compliance

### DIFF
--- a/docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex
@@ -5,6 +5,8 @@
 \usepackage[hidelinks]{hyperref}
 \setlength{\emergencystretch}{2em}
 
+\input{command}
+
 \title{Top-index scope of the maximal-overlap lemma (Wolf Lemma 3.1)}
 \author{}
 \date{2026-06-24}
@@ -18,40 +20,55 @@ Lemma~3.1 of Wolf's \emph{Quantum Channels \& Operations}
 (\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
 119--128) states that, for a normalized vector
 $\phi\in\mathbb{C}^{D'}\otimes\mathbb{C}^{D}$ with reduced density matrix
-$\rho=\operatorname{tr}_2|\phi\rangle\langle\phi|$,
-\[
+$\rho=\tr_2|\phi\rangle\langle\phi|$ on the first factor $\mathbb{C}^{D'}$,
+\begin{align}
   \sup_{\psi}|\langle\phi|\psi\rangle|^2 = \|\rho\|_{(n)},
-\]
+\end{align}
 where the supremum runs over normalized vectors $\psi$ of Schmidt rank $n$ and
-$\|\cdot\|_{(n)}$ is the Ky-Fan $n$-norm. In the application (n-positivity, Wolf
-Prop.~3.1) the Schmidt rank $n$ ranges over $1\le n\le D$, so the value $n=D$ is
-within the source's scope.
+$\|\cdot\|_{(n)}$ is the Ky-Fan $n$-norm. Since $\rho$ acts on the first factor
+$\mathbb{C}^{D'}$, its Ky-Fan $n$-norm is meaningful for $1\le n\le D'$. In the
+application (n-positivity, Wolf Prop.~3.2) the Schmidt rank $n$ ranges over
+$1\le n\le D'$, so the top value $n=D'$ is within the source's scope.
 
 \section{Formalized statement}
 
-The Lean theorem
-\path{Matrix.maximalSchmidtOverlap_eq_kyFanNorm} establishes the same
-identity, strengthened to attainment (\texttt{IsGreatest}), under the hypotheses
-$1\le n$ and $n<D$, where $D$ is the dimension of the first tensor factor.
+The formal theorem\footnote{Formal declaration:
+    \leanid{Matrix.maximalSchmidtOverlap_eq_kyFanNorm} in
+    \doclink{TNLean/Channel/MaximalOverlap}.} establishes the same identity,
+strengthened to attainment (the \Lean{} \texttt{IsGreatest} predicate), under
+the hypotheses $1\le n$ and $n<D'$, where $D'$ is the dimension of the first
+tensor factor on which $\rho$ acts.
 
 \section{The gap}
 
-The formalization omits the top index $n=D$. At $n=D$ the Schmidt-rank constraint
-is vacuous and $\|\rho\|_{(D)}=\operatorname{tr}\rho=1$; the supremum equals $1$
+The formalization omits the top index $n=D'$. At $n=D'$ the Schmidt-rank
+constraint is vacuous and $\|\rho\|_{(D')}=\tr\rho=1$; the supremum equals $1$
 and is attained at $\psi=\phi$.
 
-The restriction is inherited from the underlying maximum principle
-\path{Matrix.IsHermitian.kyFanNorm_eq_sup_trace}, which characterizes the Ky-Fan
-$k$-norm as a maximum over rank-exactly-$k$ orthogonal projections only for
-$k<D$. At $k=D$ the only rank-$D$ projection is the identity, and the eigenvalue
-sum already equals the trace; the variational statement degenerates rather than
-fails.
+The restriction is inherited from the underlying maximum principle,\footnote{Formal
+    declaration: \leanid{Matrix.IsHermitian.kyFanNorm_eq_sup_trace}.} which
+characterizes the Ky-Fan $k$-norm as a maximum over rank-exactly-$k$ orthogonal
+projections only for $k<D'$. At $k=D'$ the only rank-$D'$ projection is the
+identity, and the eigenvalue sum already equals the trace; the variational
+statement degenerates rather than fails.
 
 \section{Elimination plan}
 
-Add a top-index case to \path{Matrix.IsHermitian.kyFanNorm_eq_sup_trace} (or a
-companion lemma) covering $k=D$, where the maximizing projection is the identity
-and the value is $\operatorname{Re}\operatorname{tr}(A)$. The overlap lemma then
-extends to $1\le n\le D$ by feeding that case into the same transfer argument.
+Add a top-index case to the Ky-Fan maximum principle (or a companion lemma)
+covering $k=D'$, where the maximizing projection is the identity and the value
+is $\operatorname{Re}\tr(A)$. The overlap lemma then extends to $1\le n\le D'$
+by feeding that case into the same transfer argument.
+
+\section{Classification}
+
+\emph{Scope restriction.} The formal theorem proves the source identity for
+Schmidt ranks $1\le n<D'$, a special case of the source's full range
+$1\le n\le D'$. The conclusion matches the source on that range; only the top
+index $n=D'$ is omitted, and there the supremum degenerates to the trivial value
+$\|\rho\|_{(D')}=\tr\rho=1$. No hypothesis foreign to the source is used, so the
+deviation is a scope restriction rather than an unfaithful theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
 
 \end{document}


### PR DESCRIPTION
### Motivation
- The paper-gap note `docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex` (Wolf Lemma 3.1 top-index scope) contained a dimension mislabel: the Ky-Fan top-index scope was stated with bound $D$ instead of $D'$, where $D'$ is the first-factor dimension of $\mathbb{C}^{D'} \otimes \mathbb{C}^D$. Discovered while making the sibling Prop 3.2 note compliant (#3484).
- The note was also out of conformance with the shared policy in `docs/paper-gaps/policy.tex` (missing `\input{command}`, missing Classification section, inconsistent macro use).
- Source: Wolf Lecture Notes, Lemma 3.1, `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~119–146.

### Description
- **`docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex`** (modified):
  - Corrects every scope-statement index from $D$ to $D'$, matching the tensor notation ($\tau$, $\phi$ on $\mathbb{C}^{D'} \otimes \mathbb{C}^D$), the blueprint `MaximalOverlap` entry ($1 \le n < D'$), and the Lean theorem bound (`k < Fintype.card m`, where `m` is the first factor). The second-factor bound remains $D$.
  - Adds `\input{command}` to load shared macros; replaces bare `\path{...}` and `\operatorname{tr}` with `\leanid{...}` and `\tr`.
  - Adds a **Classification** section: this is a scope restriction (formalization covers $1 \le n < D'$; source states $1 \le n \le D'$), not an unfaithful theorem.
  - Adds `\bibliographystyle{alpha}` / `\bibliography{references}` to match sibling notes.
- The described gap is unchanged: a faithful scope restriction.

### Testing
- Documentation-only change (`.tex` file only); no Lean build required.
- Relies on Blueprint Lint CI (`lint-blueprint.yml`) to validate LaTeX references.

---
Addresses LionSR/QICLean#165

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX edits with no runtime, security, or data-handling impact.
> 
> **Overview**
> Doc-only update to **`wolf_lemma_3_1_top_index_scope.tex`** so the Lemma 3.1 top-index scope note matches tensor notation, Lean bounds, and **`docs/paper-gaps/policy.tex`**.
> 
> **Notation:** Ky-Fan / formal scope indices are relabeled from **`D` to `D'`** wherever they refer to the first tensor factor (reduced state **`ρ`**); the second factor stays **`D`**. The n-positivity cross-reference is corrected to **Wolf Prop. 3.2**.
> 
> **Policy:** Adds **`\input{command}`**, **`\leanid` / `\doclink` / `\tr`** instead of bare paths and **`\operatorname{tr}`**, a **Classification** section (scope restriction verdict), and bibliography hooks like sibling notes.
> 
> The described gap is unchanged—formal **`1 ≤ n < D'`** vs source **`1 ≤ n ≤ D'`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec7b917290458e1b96864322658f6306e325e9d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>