### PR TITLE
feat(Channel): Wolf T_η and strictness of the n-positivity chain

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -113,6 +113,7 @@ import TNLean.Channel.Schwarz.SchwarzSubnormal
 import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.ChoiCompression
+import TNLean.Channel.NPositivityChainStrict
 import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull

--- a/TNLean/Channel/NPositivityChainStrict.lean
+++ b/TNLean/Channel/NPositivityChainStrict.lean
@@ -12,7 +12,10 @@ import TNLean.Channel.Schwarz.ChoiCompression
 
 Wolf's Chapter 3 closes the discussion of the n-positivity hierarchy with the
 one-parameter family of maps
-`T_η(ρ) = tr(ρ) • 1 − ρ / η`, `η ∈ ℝ₊`, on `M_D(ℂ)` (Wolf eq. (3.11)).  Its
+`T_η(ρ) = tr(ρ) • 1 − η⁻¹ • ρ` on `M_D(ℂ)` (Wolf eq. (3.11)).  The map `tEta` is
+defined for every real `η` (at `η = 0` it reduces to `ρ ↦ tr(ρ) • 1`); the
+n-positivity threshold theorems below assume `0 < η`, matching Wolf's
+`η ∈ ℝ₊`.  Its
 Choi–Jamiolkowski operator is `τ_η = D⁻¹ • 1 − η⁻¹ • |Ω⟩⟨Ω|`, whose positive
 eigenvalues all equal `1/D` and whose single negative eigenvalue is
 `ν₋ = 1/D − 1/η` (present when `η < D`), with reduced density `1/D • 1` on the
@@ -36,7 +39,7 @@ Choi criterion converts the resulting sign condition into `k`-positivity.
 
 ## Main definitions
 
-* `Matrix.tEta` -- Wolf's map `T_η(ρ) = tr(ρ) • 1 − ρ / η`.
+* `Matrix.tEta` -- Wolf's map `T_η(ρ) = tr(ρ) • 1 − η⁻¹ • ρ`.
 
 ## Main results
 
@@ -46,10 +49,9 @@ Choi criterion converts the resulting sign condition into `k`-positivity.
   nonnegative scalar multiple `c • 1` of the identity is `k • c` for `k < card`.
 * `Matrix.isNPositiveMap_tEta_iff` -- **Wolf eq. (3.11):** for `0 < η` and
   `1 ≤ k < D`, the map `T_η` is `k`-positive if and only if `η ≥ k`.
-* `Matrix.tEta_not_isNPositiveMap_succ_of_isNPositiveMap` and
-  `Matrix.exists_isNPositiveMap_not_isNPositiveMap_succ` -- the strictness
-  witness: a `k`-positive map that is not `(k+1)`-positive, for `1 ≤ k` with
-  `k + 1 < D`.
+* `Matrix.tEta_isNPositiveMap_not_succ` and
+  `Matrix.exists_isNPositiveMap_not_succ` -- the strictness witness: a
+  `k`-positive map that is not `(k+1)`-positive, for `1 ≤ k` with `k + 1 < D`.
 
 ## References
 
@@ -336,8 +338,8 @@ theorem normSq_omega_overlap_le [NeZero D] {k : ℕ} (hk1 : 1 ≤ k) (hk : k < D
     linarith [hφbound]
 
 /-- **Wolf eq. (3.11), `n`-positivity threshold of `T_η`.** For `0 < η` and
-`1 ≤ k < D`, the map `T_η(ρ) = tr(ρ) • 1 − ρ / η` on `M_D(ℂ)` is `k`-positive if
-and only if `η ≥ k`.
+`1 ≤ k < D`, the map `T_η(ρ) = tr(ρ) • 1 − η⁻¹ • ρ` on `M_D(ℂ)` is `k`-positive
+if and only if `η ≥ k`.
 
 The Choi operator of `T_η` is `D⁻¹ • 1 − η⁻¹ • |Ω⟩⟨Ω|`, whose expectation in a
 normalized Schmidt-rank-`k` vector `ψ` is `D⁻¹ − η⁻¹ |⟨Ω|ψ⟩|²`.  The

--- a/TNLean/Channel/NPositivityChainStrict.lean
+++ b/TNLean/Channel/NPositivityChainStrict.lean
@@ -1,0 +1,437 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.PositiveExamples
+import TNLean.Channel.MaximalOverlap
+import TNLean.Channel.Schwarz.ChoiCompression
+
+/-!
+# The map `T_η` and strictness of the n-positivity chain
+
+Wolf's Chapter 3 closes the discussion of the n-positivity hierarchy with the
+one-parameter family of maps
+`T_η(ρ) = tr(ρ) • 1 − ρ / η`, `η ∈ ℝ₊`, on `M_D(ℂ)` (Wolf eq. (3.11)).  Its
+Choi–Jamiolkowski operator is `τ_η = D⁻¹ • 1 − η⁻¹ • |Ω⟩⟨Ω|`, whose positive
+eigenvalues all equal `1/D` and whose single negative eigenvalue is
+`ν₋ = 1/D − 1/η` (present when `η < D`), with reduced density `1/D • 1` on the
+first factor.  The expectation of `τ_η` in a normalized vector `ψ` of Schmidt
+rank at most `k` is `1/D − η⁻¹ |⟨Ω|ψ⟩|²`, and the maximal-overlap principle
+(Wolf Lemma 3.1) gives `sup_ψ |⟨Ω|ψ⟩|² = ‖1/D • 1‖₍ₖ₎ = k/D`.  The two bounds
+of Wolf's Proposition 3.2 therefore coincide at `1/D − (k/D)/η`, which is
+nonnegative exactly when `η ≥ k`.  Hence `T_η` is `k`-positive if and only if
+`η ≥ k`.
+
+Because the threshold is the parameter `η` itself, choosing `η` strictly between
+two successive integers produces a map that is `k`-positive but not
+`(k+1)`-positive.  This witnesses that every inclusion in Wolf's chain (3.3)
+`T_cp = T_D ⊆ T_{D-1} ⊆ ⋯ ⊆ T_1` is strict.
+
+The argument here follows the maximal-overlap route directly rather than the
+abstract spectral decomposition: for normalized `ψ` the Choi quadratic form is
+the elementary expression `1/D − η⁻¹ |⟨Ω|ψ⟩|²`, the overlap bound and its
+attainment are supplied by the maximal-overlap principle, and the Schmidt-rank
+Choi criterion converts the resulting sign condition into `k`-positivity.
+
+## Main definitions
+
+* `Matrix.tEta` -- Wolf's map `T_η(ρ) = tr(ρ) • 1 − ρ / η`.
+
+## Main results
+
+* `ChoiJamiolkowski.choiMatrix_tEta` -- the Choi operator of `T_η` is
+  `D⁻¹ • 1 − η⁻¹ • |Ω⟩⟨Ω|`.
+* `Matrix.IsHermitian.kyFanNorm_smul_one` -- the Ky-Fan `k`-norm of a
+  nonnegative scalar multiple `c • 1` of the identity is `k • c` for `k < card`.
+* `Matrix.isNPositiveMap_tEta_iff` -- **Wolf eq. (3.11):** for `0 < η` and
+  `1 ≤ k < D`, the map `T_η` is `k`-positive if and only if `η ≥ k`.
+* `Matrix.tEta_not_isNPositiveMap_succ_of_isNPositiveMap` and
+  `Matrix.exists_isNPositiveMap_not_isNPositiveMap_succ` -- the strictness
+  witness: a `k`-positive map that is not `(k+1)`-positive, for `1 ≤ k` with
+  `k + 1 < D`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  equation (3.11)][Wolf2012QChannels]
+* [K. Fan, *On a theorem of Weyl concerning eigenvalues of linear
+  transformations*][Fan1949Theorem]
+-/
+
+open scoped BigOperators Matrix ComplexOrder MatrixOrder
+open Matrix
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- **Wolf Chapter 3, equation (3.11).** The map
+`T_η(ρ) = tr(ρ) • 1 − η⁻¹ • ρ` on `M_D(ℂ)`, with real parameter `η`. -/
+noncomputable def tEta (D : ℕ) (η : ℝ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ where
+  toFun X := Matrix.trace X • (1 : Matrix (Fin D) (Fin D) ℂ) - ((η : ℂ)⁻¹) • X
+  map_add' X Y := by
+    ext i j
+    simp [Matrix.trace_add, add_smul, sub_eq_add_neg, add_assoc, add_left_comm, add_comm]
+  map_smul' c X := by
+    ext i j
+    simp only [Matrix.trace_smul, smul_smul, smul_sub, smul_eq_mul, RingHom.id_apply]
+    ring_nf
+
+@[simp]
+theorem tEta_apply (η : ℝ) (X : Matrix (Fin D) (Fin D) ℂ) :
+    tEta D η X = Matrix.trace X • (1 : Matrix (Fin D) (Fin D) ℂ) - ((η : ℂ)⁻¹) • X :=
+  rfl
+
+end Matrix
+
+namespace ChoiJamiolkowski
+
+variable {D : ℕ}
+
+/-- The Choi operator of `T_η(X) = tr(X) • 1 − η⁻¹ • X` is
+`D⁻¹ • 1 − η⁻¹ • |Ω⟩⟨Ω|`. -/
+theorem choiMatrix_tEta [NeZero D] (η : ℝ) :
+    choiMatrix (Matrix.tEta D η) =
+      ((D : ℂ)⁻¹) • (1 : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) -
+        ((η : ℂ)⁻¹) • Matrix.omegaProj D := by
+  classical
+  have hDpos : (0 : ℝ) < D := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hcoeff :
+      (D : ℂ)⁻¹ = (((D : ℝ).sqrt : ℂ)⁻¹ * (((D : ℝ).sqrt : ℂ)⁻¹)) := by
+    rw [← _root_.mul_inv_rev]
+    congr
+    have hsqrt : (D : ℝ) = (D : ℝ).sqrt * (D : ℝ).sqrt := by
+      exact (by
+        nth_rw 1 [← Real.sq_sqrt hDpos.le]
+        ring)
+    exact_mod_cast hsqrt
+  ext x y
+  rcases x with ⟨i, a⟩
+  rcases y with ⟨j, b⟩
+  by_cases hij : i = j <;> by_cases hab : a = b <;>
+    by_cases hia : i = a <;> by_cases hjb : j = b <;>
+      simp_all [choiMatrix_apply, Matrix.tEta, omegaSlice_eq_single,
+        Matrix.omegaProj_apply, Matrix.omegaVec_apply, eq_comm]
+
+end ChoiJamiolkowski
+
+namespace Matrix.IsHermitian
+
+variable {N : Type*} [Fintype N] [DecidableEq N]
+
+omit [Fintype N] in
+/-- A real scalar multiple of the identity is Hermitian. -/
+theorem isHermitian_smul_one (c : ℝ) :
+    ((c : ℂ) • (1 : Matrix N N ℂ)).IsHermitian := by
+  refine isHermitian_one.smul ?_
+  rw [isSelfAdjoint_iff, Complex.star_def, Complex.conj_ofReal]
+
+/-- **Ky-Fan norm of a scalar multiple of the identity.** For `k < card N` the
+Ky-Fan `k`-norm of `c • 1` equals `k · c`: every rank-`k` orthogonal projection
+realizes the trace `c · k`, so the maximum principle pins the norm to that
+value. -/
+theorem kyFanNorm_smul_one (c : ℝ) {k : ℕ} (hk : k < Fintype.card N) :
+    (isHermitian_smul_one (N := N) c).kyFanNorm k = (k : ℝ) * c := by
+  classical
+  set A : Matrix N N ℂ := (c : ℂ) • (1 : Matrix N N ℂ) with hA
+  have hAh : A.IsHermitian := isHermitian_smul_one (N := N) c
+  -- The maximum principle gives a rank-`k` projection realizing the norm.
+  obtain ⟨P, _hPh, _hPi, _hPr, hPt⟩ := hAh.exists_isProj_trace_eq_kyFanNorm k
+  -- For that projection, `tr(P · A) = c · tr P = c · k`.
+  have htrPA : (Matrix.trace (P * A)).re = c * (Matrix.trace P).re := by
+    have hmul : P * A = (c : ℂ) • P := by
+      rw [hA, Matrix.mul_smul, Matrix.mul_one]
+    rw [hmul, Matrix.trace_smul, smul_eq_mul, Complex.re_ofReal_mul]
+  have hPr' : (Matrix.trace P).re = (k : ℝ) := by
+    rw [_hPr, min_eq_left (by exact_mod_cast le_of_lt hk)]
+  rw [← hPt, htrPA, hPr', mul_comm]
+
+end Matrix.IsHermitian
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- The Schmidt coefficient matrix of the maximally entangled vector is
+`(√D)⁻¹ • 1`. -/
+theorem schmidtCoeffMatrix_omegaVec :
+    schmidtCoeffMatrix (omegaVec D)
+      = (((D : ℝ).sqrt : ℂ)⁻¹) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  ext i j
+  by_cases hij : i = j
+  · subst hij; simp [schmidtCoeffMatrix, omegaVec, one_div]
+  · simp [schmidtCoeffMatrix, omegaVec, hij, Matrix.one_apply_ne hij]
+
+/-- The reduced density `C C†` of the maximally entangled vector is `D⁻¹ • 1`. -/
+theorem omega_reducedDensity_eq [NeZero D] :
+    schmidtCoeffMatrix (omegaVec D) * (schmidtCoeffMatrix (omegaVec D))ᴴ =
+      ((D : ℂ)⁻¹) • (1 : Matrix (Fin D) (Fin D) ℂ) := by
+  have hDpos : (0 : ℝ) < D := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  rw [schmidtCoeffMatrix_omegaVec, Matrix.smul_mul, Matrix.one_mul,
+    Matrix.conjTranspose_smul, Matrix.conjTranspose_one, smul_smul]
+  congr 1
+  have hstar : star (((D : ℝ).sqrt : ℂ)⁻¹) = ((D : ℝ).sqrt : ℂ)⁻¹ := by
+    rw [Complex.star_def, map_inv₀, Complex.conj_ofReal]
+  rw [hstar, ← _root_.mul_inv_rev]
+  congr 1
+  have hsqrt : (D : ℝ).sqrt * (D : ℝ).sqrt = (D : ℝ) := Real.mul_self_sqrt hDpos.le
+  rw [← Complex.ofReal_mul, hsqrt, Complex.ofReal_natCast]
+
+/-- The Ky-Fan `k`-norm of the reduced density of the maximally entangled
+vector is `k/D`. -/
+theorem omega_kyFanNorm_eq [NeZero D] {k : ℕ} (hk : k < D) :
+    (posSemidef_self_mul_conjTranspose (schmidtCoeffMatrix (omegaVec D))).isHermitian.kyFanNorm k
+      = (k : ℝ) / D := by
+  have hDpos : (0 : ℝ) < D := by
+    exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  -- Both Hermitian witnesses are for the same matrix `D⁻¹ • 1`.
+  have hmat := omega_reducedDensity_eq (D := D)
+  have hcard : k < Fintype.card (Fin D) := by simpa using hk
+  have hkfn :
+      (posSemidef_self_mul_conjTranspose (schmidtCoeffMatrix (omegaVec D))).isHermitian.kyFanNorm k
+        = (IsHermitian.isHermitian_smul_one (N := Fin D) ((D : ℝ)⁻¹)).kyFanNorm k := by
+    congr 1
+    · rw [hmat]; push_cast; rfl
+  rw [hkfn, IsHermitian.kyFanNorm_smul_one ((D : ℝ)⁻¹) hcard]
+  rw [div_eq_mul_inv]
+
+/-- The real part of the self inner product `star ψ ⬝ᵥ ψ` is the sum of the
+squared moduli of the entries; in particular it is nonnegative. -/
+theorem dotProduct_star_self_re {ι : Type*} [Fintype ι] (ψ : ι → ℂ) :
+    (star ψ ⬝ᵥ ψ).re = ∑ p, ‖ψ p‖ ^ 2 := by
+  rw [dotProduct, Complex.re_sum]
+  refine Finset.sum_congr rfl fun p _ => ?_
+  rw [Pi.star_apply, Complex.star_def, ← Complex.normSq_eq_conj_mul_self,
+    Complex.ofReal_re, Complex.normSq_eq_norm_sq]
+
+/-- The self inner product `star ψ ⬝ᵥ ψ` is a nonnegative real number. -/
+theorem dotProduct_star_self_ofReal {ι : Type*} [Fintype ι] (ψ : ι → ℂ) :
+    star ψ ⬝ᵥ ψ = (((star ψ ⬝ᵥ ψ).re : ℝ) : ℂ) := by
+  rw [Complex.ext_iff]
+  refine ⟨by rw [Complex.ofReal_re], ?_⟩
+  rw [Complex.ofReal_im, dotProduct, Complex.im_sum]
+  refine Finset.sum_eq_zero fun p _ => ?_
+  rw [Pi.star_apply, Complex.star_def, ← Complex.normSq_eq_conj_mul_self, Complex.ofReal_im]
+
+/-- Scaling a vector by a complex constant scales its self inner product by the
+squared modulus of the constant. -/
+theorem dotProduct_star_self_smul {ι : Type*} [Fintype ι] (c : ℂ) (ψ : ι → ℂ) :
+    star (c • ψ) ⬝ᵥ (c • ψ) = ((‖c‖ ^ 2 : ℝ) : ℂ) * (star ψ ⬝ᵥ ψ) := by
+  rw [star_smul, dotProduct_smul, smul_dotProduct, smul_eq_mul, smul_eq_mul,
+    ← mul_assoc]
+  congr 1
+  rw [Complex.star_def, mul_comm, ← Complex.normSq_eq_conj_mul_self, Complex.normSq_eq_norm_sq]
+
+/-- The expectation of `|Ω⟩⟨Ω|` in `ψ` is the squared overlap `|⟨Ω|ψ⟩|²`. -/
+theorem omegaProj_quadraticForm (ψ : Fin D × Fin D → ℂ) :
+    star ψ ⬝ᵥ (omegaProj D *ᵥ ψ)
+      = ((‖star (omegaVec D) ⬝ᵥ ψ‖ ^ 2 : ℝ) : ℂ) := by
+  -- `omegaProj *ᵥ ψ = (star omegaVec ⬝ᵥ ψ) • omegaVec` (right action on the vector).
+  have hmv : omegaProj D *ᵥ ψ
+      = MulOpposite.op (star (omegaVec D) ⬝ᵥ ψ) • omegaVec D := by
+    rw [omegaProj, vecMulVec_mulVec]
+  rw [hmv]
+  -- The op-scalar pulls out of the dot product as right multiplication.
+  have hdp : star ψ ⬝ᵥ (MulOpposite.op (star (omegaVec D) ⬝ᵥ ψ) • omegaVec D)
+      = (star ψ ⬝ᵥ omegaVec D) * (star (omegaVec D) ⬝ᵥ ψ) := by
+    simp only [dotProduct, Pi.smul_apply, op_smul_eq_mul, Finset.sum_mul]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    ring
+  rw [hdp]
+  -- `(star ψ ⬝ᵥ omegaVec) = star (star omegaVec ⬝ᵥ ψ)` and `star omegaVec = omegaVec`.
+  set z : ℂ := star (omegaVec D) ⬝ᵥ ψ with hz
+  have h2 : star ψ ⬝ᵥ omegaVec D = star z := by
+    rw [hz, dotProduct_comm, ← star_omegaVec (d := D)]
+    simp [dotProduct, Pi.star_apply, mul_comm]
+  rw [h2, Complex.star_def, ← Complex.normSq_eq_conj_mul_self,
+    Complex.normSq_eq_norm_sq]
+
+/-- The Choi quadratic form of `T_η` in a vector `ψ` is
+`D⁻¹ ‖ψ‖² − η⁻¹ |⟨Ω|ψ⟩|²`. -/
+theorem choiMatrix_tEta_quadraticForm [NeZero D] (η : ℝ) (ψ : Fin D × Fin D → ℂ) :
+    star ψ ⬝ᵥ (ChoiJamiolkowski.choiMatrix (tEta D η) *ᵥ ψ)
+      = (((D : ℝ)⁻¹ * (star ψ ⬝ᵥ ψ).re
+          - η⁻¹ * ‖star (omegaVec D) ⬝ᵥ ψ‖ ^ 2 : ℝ) : ℂ) := by
+  rw [ChoiJamiolkowski.choiMatrix_tEta, Matrix.sub_mulVec, dotProduct_sub,
+    smul_mulVec, smul_mulVec, Matrix.one_mulVec,
+    dotProduct_smul, dotProduct_smul, smul_eq_mul, smul_eq_mul,
+    omegaProj_quadraticForm, dotProduct_star_self_ofReal]
+  rw [Complex.ofReal_re]
+  push_cast
+  ring
+
+/-- **Homogeneous maximal-overlap bound.** For a vector `ψ` of Schmidt rank at
+most `k` (with `1 ≤ k < D`), the squared overlap with the maximally entangled
+vector is bounded by `(k/D)` times the squared norm of `ψ`.  This is the
+maximal-overlap principle (Wolf Lemma 3.1) made degree-`2` homogeneous, so it
+applies to vectors that are not normalized. -/
+theorem normSq_omega_overlap_le [NeZero D] {k : ℕ} (hk1 : 1 ≤ k) (hk : k < D)
+    {ψ : Fin D × Fin D → ℂ} (hrank : HasSchmidtRankLE k ψ) :
+    ‖star (omegaVec D) ⬝ᵥ ψ‖ ^ 2 ≤ ((k : ℝ) / D) * (star ψ ⬝ᵥ ψ).re := by
+  classical
+  have hDpos : (0 : ℝ) < D := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hcard : k < Fintype.card (Fin D) := by simpa using hk
+  -- The squared norm `(star ψ ⬝ᵥ ψ).re = Σ |ψ p|² ≥ 0`.
+  have hresum : (star ψ ⬝ᵥ ψ).re = ∑ p, ‖ψ p‖ ^ 2 := dotProduct_star_self_re ψ
+  have hsnn : 0 ≤ (star ψ ⬝ᵥ ψ).re := by rw [hresum]; positivity
+  rcases eq_or_lt_of_le hsnn with hzero | hpos
+  · -- `ψ = 0`: both sides vanish.
+    have hψ0 : ∀ p, ψ p = 0 := by
+      have hsum : (∑ p, ‖ψ p‖ ^ 2) = 0 := by rw [← hresum, ← hzero]
+      intro p
+      have := (Finset.sum_eq_zero_iff_of_nonneg (fun q _ => by positivity)).mp hsum p
+        (Finset.mem_univ p)
+      simpa using this
+    have hoverlap : star (omegaVec D) ⬝ᵥ ψ = 0 := by
+      rw [dotProduct]; exact Finset.sum_eq_zero fun p _ => by rw [hψ0 p, mul_zero]
+    rw [hoverlap, ← hzero]; simp
+  · -- Nonzero `ψ`: normalize and apply the maximal-overlap bound.
+    set s : ℝ := Real.sqrt ((star ψ ⬝ᵥ ψ).re) with hs
+    have hspos : 0 < s := Real.sqrt_pos.mpr hpos
+    have hssq : s ^ 2 = (star ψ ⬝ᵥ ψ).re := by rw [hs, Real.sq_sqrt hsnn]
+    set φ : Fin D × Fin D → ℂ := (s : ℂ)⁻¹ • ψ with hφ
+    -- `φ` is normalized: scaling by `s⁻¹` scales the squared norm by `s⁻²`.
+    have hnorms : (‖(s : ℂ)⁻¹‖ ^ 2 : ℝ) = ((star ψ ⬝ᵥ ψ).re)⁻¹ := by
+      rw [norm_inv, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hspos, inv_pow, hssq]
+    have hφnorm : star φ ⬝ᵥ φ = 1 := by
+      rw [hφ, dotProduct_star_self_smul, dotProduct_star_self_ofReal, hnorms,
+        ← Complex.ofReal_mul, inv_mul_cancel₀ (ne_of_gt hpos), Complex.ofReal_one]
+    -- `φ` has Schmidt rank at most `k`.
+    have hφrank : HasSchmidtRankLE k φ := by
+      rw [HasSchmidtRankLE, schmidtRank] at hrank ⊢
+      rw [hφ, show schmidtCoeffMatrix ((s : ℂ)⁻¹ • ψ)
+          = (s : ℂ)⁻¹ • schmidtCoeffMatrix ψ from rfl,
+        rank_smul_of_ne_zero (by simp [ne_of_gt hspos])]
+      exact hrank
+    -- The maximal-overlap bound for the normalized `φ` (Wolf Lemma 3.1).
+    have hΩnorm : star (omegaVec D) ⬝ᵥ (omegaVec D) = 1 := by
+      rw [star_omegaVec]; exact omegaVec_dotProduct_self (Nat.pos_of_ne_zero (NeZero.ne D))
+    have hgreat := maximalSchmidtOverlap_eq_kyFanNorm (omegaVec D) hΩnorm hk1 hcard
+    have hmem : ‖star (omegaVec D) ⬝ᵥ φ‖ ^ 2 ∈
+        {r : ℝ | ∃ ψ' : Fin D × Fin D → ℂ, star ψ' ⬝ᵥ ψ' = 1 ∧
+          HasSchmidtRankLE k ψ' ∧ ‖star (omegaVec D) ⬝ᵥ ψ'‖ ^ 2 = r} :=
+      ⟨φ, hφnorm, hφrank, rfl⟩
+    have hφbound := hgreat.2 hmem
+    -- Translate the normalized bound into the homogeneous one.
+    have hkfn : (posSemidef_self_mul_conjTranspose
+        (schmidtCoeffMatrix (omegaVec D))).isHermitian.kyFanNorm k = (k : ℝ) / D :=
+      omega_kyFanNorm_eq hk
+    rw [hkfn] at hφbound
+    -- `‖⟨Ω|φ⟩‖² = ‖⟨Ω|ψ⟩‖² / s²`.
+    have hoverlapφ :
+        star (omegaVec D) ⬝ᵥ φ = (s : ℂ)⁻¹ * (star (omegaVec D) ⬝ᵥ ψ) := by
+      rw [hφ, dotProduct_smul, smul_eq_mul]
+    have hsq :
+        ‖star (omegaVec D) ⬝ᵥ φ‖ ^ 2 = ‖star (omegaVec D) ⬝ᵥ ψ‖ ^ 2 / s ^ 2 := by
+      rw [hoverlapφ, norm_mul, mul_pow, norm_inv, Complex.norm_real, Real.norm_eq_abs,
+        abs_of_pos hspos]
+      rw [div_eq_inv_mul, inv_pow]
+    rw [hsq] at hφbound
+    rw [div_le_iff₀ (by positivity)] at hφbound
+    rw [← hssq]
+    linarith [hφbound]
+
+/-- **Wolf eq. (3.11), `n`-positivity threshold of `T_η`.** For `0 < η` and
+`1 ≤ k < D`, the map `T_η(ρ) = tr(ρ) • 1 − ρ / η` on `M_D(ℂ)` is `k`-positive if
+and only if `η ≥ k`.
+
+The Choi operator of `T_η` is `D⁻¹ • 1 − η⁻¹ • |Ω⟩⟨Ω|`, whose expectation in a
+normalized Schmidt-rank-`k` vector `ψ` is `D⁻¹ − η⁻¹ |⟨Ω|ψ⟩|²`.  The
+maximal-overlap principle gives `sup_ψ |⟨Ω|ψ⟩|² = k/D`, so the infimum
+expectation is `D⁻¹(1 − k/η)`, nonnegative exactly when `η ≥ k`.
+
+**Scope restriction (k < D):** the threshold is stated for Schmidt rank
+`1 ≤ k < D`.  The omitted top index `k = D` (where `k`-positivity is complete
+positivity) is inherited from the maximal-overlap principle (Wolf Lemma 3.1) and
+is documented in `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+theorem isNPositiveMap_tEta_iff [NeZero D] {η : ℝ} (hη : 0 < η) {k : ℕ}
+    (hk1 : 1 ≤ k) (hk : k < D) :
+    IsNPositiveMap k (tEta D η) ↔ (k : ℝ) ≤ η := by
+  classical
+  have hDpos : (0 : ℝ) < D := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hcard : k < Fintype.card (Fin D) := by simpa using hk
+  rw [ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg]
+  constructor
+  · -- `k`-positive ⟹ `k ≤ η`, via the overlap-attaining normalized vector.
+    intro hpos
+    by_contra hlt
+    rw [not_le] at hlt
+    -- A normalized Schmidt-rank-`k` vector with `|⟨Ω|ψ⟩|² = k/D`.
+    have hΩnorm : star (omegaVec D) ⬝ᵥ (omegaVec D) = 1 := by
+      rw [star_omegaVec]; exact omegaVec_dotProduct_self (Nat.pos_of_ne_zero (NeZero.ne D))
+    obtain ⟨ψ, hψnorm, hψrank, hψeq⟩ :=
+      (maximalSchmidtOverlap_eq_kyFanNorm (omegaVec D) hΩnorm hk1 hcard).1
+    rw [omega_kyFanNorm_eq hk] at hψeq
+    -- Its Choi expectation is `D⁻¹(1 − k/η) < 0`, contradicting nonnegativity.
+    have hquad := choiMatrix_tEta_quadraticForm (D := D) η ψ
+    rw [hψeq, hψnorm, Complex.one_re] at hquad
+    have hval := hpos ψ hψrank
+    rw [hquad, ← Complex.ofReal_zero, Complex.real_le_real, mul_one,
+      div_eq_mul_inv] at hval
+    -- `D⁻¹ − η⁻¹ · k · D⁻¹ ≥ 0` forces `k ≤ η`.
+    have hηinv : 0 < η⁻¹ := inv_pos.mpr hη
+    have hDinv : 0 < (D : ℝ)⁻¹ := inv_pos.mpr hDpos
+    have hcancelD : (D : ℝ)⁻¹ * D = 1 := inv_mul_cancel₀ (ne_of_gt hDpos)
+    have hcancelη : η⁻¹ * η = 1 := inv_mul_cancel₀ (ne_of_gt hη)
+    -- Multiply `hval` by `D > 0`: `1 − η⁻¹ k ≥ 0`; then by `η > 0`: `η − k ≥ 0`.
+    have hstep : 0 ≤ 1 - η⁻¹ * (k : ℝ) := by
+      have := mul_le_mul_of_nonneg_right hval (le_of_lt hDpos)
+      nlinarith [this, hcancelD, hDpos]
+    have hkη : (k : ℝ) ≤ η := by nlinarith [hstep, hη, hcancelη]
+    exact absurd hkη (not_le.mpr hlt)
+  · -- `k ≤ η` ⟹ `k`-positive, via the homogeneous overlap bound.
+    intro hkη ψ hψrank
+    have hquad := choiMatrix_tEta_quadraticForm (D := D) η ψ
+    rw [hquad, ← Complex.ofReal_zero, Complex.real_le_real]
+    -- The bound `|⟨Ω|ψ⟩|² ≤ (k/D) ‖ψ‖²` makes the quadratic form nonnegative.
+    have hbound := normSq_omega_overlap_le (D := D) hk1 hk hψrank
+    have hnormnn : 0 ≤ (star ψ ⬝ᵥ ψ).re := by
+      rw [dotProduct_star_self_re]; positivity
+    have hηinv : 0 < η⁻¹ := inv_pos.mpr hη
+    have hDinv : 0 < (D : ℝ)⁻¹ := inv_pos.mpr hDpos
+    set w : ℝ := (star ψ ⬝ᵥ ψ).re with hw
+    set q : ℝ := ‖star (omegaVec D) ⬝ᵥ ψ‖ ^ 2 with hq
+    rw [div_eq_mul_inv] at hbound
+    have hcancelD : (D : ℝ)⁻¹ * D = 1 := inv_mul_cancel₀ (ne_of_gt hDpos)
+    have hkw : η⁻¹ * (k : ℝ) ≤ 1 := by
+      rw [← div_eq_inv_mul, div_le_one hη]; exact hkη
+    -- `η⁻¹ q ≤ η⁻¹ (k D⁻¹) w` and `η⁻¹ k ≤ 1` give `η⁻¹ q ≤ D⁻¹ w`.
+    have h1 : η⁻¹ * q ≤ η⁻¹ * ((k : ℝ) * (D : ℝ)⁻¹ * w) :=
+      mul_le_mul_of_nonneg_left hbound (le_of_lt hηinv)
+    have hwD : 0 ≤ (D : ℝ)⁻¹ * w := mul_nonneg (le_of_lt hDinv) hnormnn
+    -- `η⁻¹ (k D⁻¹) w = (η⁻¹ k) (D⁻¹ w) ≤ 1 · (D⁻¹ w) = D⁻¹ w`.
+    have h2 : η⁻¹ * ((k : ℝ) * (D : ℝ)⁻¹ * w) ≤ (D : ℝ)⁻¹ * w := by
+      have hrw : η⁻¹ * ((k : ℝ) * (D : ℝ)⁻¹ * w)
+          = (η⁻¹ * (k : ℝ)) * ((D : ℝ)⁻¹ * w) := by ring
+      rw [hrw]
+      calc (η⁻¹ * (k : ℝ)) * ((D : ℝ)⁻¹ * w)
+          ≤ 1 * ((D : ℝ)⁻¹ * w) := mul_le_mul_of_nonneg_right hkw hwD
+        _ = (D : ℝ)⁻¹ * w := one_mul _
+    linarith [h1, h2]
+
+/-- **Strictness witness for Wolf's chain (3.3).** For `1 ≤ k` with `k + 1 < D`,
+the map `T_η` with `k ≤ η < k + 1` is `k`-positive but not `(k+1)`-positive. -/
+theorem tEta_isNPositiveMap_not_succ [NeZero D] {η : ℝ} {k : ℕ}
+    (hk1 : 1 ≤ k) (hk : k + 1 < D) (hηlb : (k : ℝ) ≤ η) (hηub : η < (k : ℝ) + 1) :
+    IsNPositiveMap k (tEta D η) ∧ ¬ IsNPositiveMap (k + 1) (tEta D η) := by
+  have hη : 0 < η := lt_of_lt_of_le (by exact_mod_cast hk1) hηlb
+  refine ⟨(isNPositiveMap_tEta_iff hη hk1 (by omega)).mpr hηlb, ?_⟩
+  rw [isNPositiveMap_tEta_iff hη (by omega) hk]
+  push_cast
+  exact not_le.mpr hηub
+
+/-- **Strictness of every inclusion in Wolf's chain (3.3).** For `1 ≤ k` with
+`k + 1 < D`, there is a map on `M_D(ℂ)` that is `k`-positive but not
+`(k+1)`-positive; hence the cone of `k`-positive maps strictly contains the cone
+of `(k+1)`-positive maps. -/
+theorem exists_isNPositiveMap_not_succ [NeZero D] {k : ℕ}
+    (hk1 : 1 ≤ k) (hk : k + 1 < D) :
+    ∃ T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ,
+      IsNPositiveMap k T ∧ ¬ IsNPositiveMap (k + 1) T :=
+  ⟨tEta D (k : ℝ), tEta_isNPositiveMap_not_succ hk1 hk le_rfl (by linarith)⟩
+
+end Matrix

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1360,8 +1360,11 @@ adjacent cones.
     \leanok
     For a real parameter $\eta$, the map $T_\eta$ on $\MN{D}$ is
     \[
-        T_\eta(\rho)=\operatorname{tr}(\rho)\,\Id-\frac{\rho}{\eta}.
+        T_\eta(\rho)=\tr(\rho)\,\Id-\eta^{-1}\rho.
     \]
+    The map is defined for every real $\eta$; at $\eta=0$ it reduces to
+    $\rho\mapsto\tr(\rho)\,\Id$, and the positivity threshold below
+    assumes $\eta>0$.
 \end{definition}
 
 \begin{theorem}[Choi matrix of $T_\eta$]
@@ -1377,10 +1380,20 @@ adjacent cones.
 
 \begin{proof}
     \leanok
-    The trace term sends each elementary slice of $\ket{\Omega}\bra{\Omega}$ to
-    its trace times the identity, giving $D^{-1}\Id$; the second term is
-    $\eta^{-1}$ times the Choi matrix of the identity map, namely
-    $\eta^{-1}\ket{\Omega}\bra{\Omega}$.
+    The Choi matrix is linear in the map, so it splits over the two terms of
+    $T_\eta$.  The trace term contributes
+    \[
+        \tau\bigl(\rho\mapsto\tr(\rho)\,\Id\bigr)=D^{-1}\Id,
+    \]
+    since each elementary slice of $\ket{\Omega}\bra{\Omega}$ contributes its
+    trace times the identity.  The identity map contributes
+    \[
+        \tau(\id)=\ket{\Omega}\bra{\Omega}.
+    \]
+    Subtracting $\eta^{-1}$ times the second from the first gives
+    \[
+        \tau_\eta=D^{-1}\Id-\eta^{-1}\ket{\Omega}\bra{\Omega}.
+    \]
 \end{proof}
 
 \begin{theorem}[Positivity threshold of $T_\eta$]

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1344,6 +1344,94 @@ maps.
     finite-dimensional space of linear maps.
 \end{theorem}
 
+\subsection{The map \texorpdfstring{$T_\eta$}{T eta} and strictness of the chain}
+
+The cones of $k$-positive maps form a decreasing chain from the completely
+positive maps, at the top amplification dimension, down to the merely positive
+maps.  This subsection shows that every inclusion between consecutive
+dimensions, below the top one, is strict.  The witnesses come from a
+one-parameter family of maps whose positivity threshold is the parameter
+itself, so that tuning the parameter between two integers separates the two
+adjacent cones.
+
+\begin{definition}[The family $T_\eta$]
+    \label{def:t_eta}
+    \lean{Matrix.tEta}
+    \leanok
+    For a real parameter $\eta$, the map $T_\eta$ on $\MN{D}$ is
+    \[
+        T_\eta(\rho)=\operatorname{tr}(\rho)\,\Id-\frac{\rho}{\eta}.
+    \]
+\end{definition}
+
+\begin{theorem}[Choi matrix of $T_\eta$]
+    \label{thm:choi_matrix_t_eta}
+    \lean{ChoiJamiolkowski.choiMatrix_tEta}
+    \leanok
+    \uses{def:t_eta, thm:choi_matrix_reduction_map}
+    For $D\ge 1$, the Choi matrix of $T_\eta$ is
+    \[
+        \tau_\eta=D^{-1}\Id-\eta^{-1}\ket{\Omega}\bra{\Omega}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The trace term sends each elementary slice of $\ket{\Omega}\bra{\Omega}$ to
+    its trace times the identity, giving $D^{-1}\Id$; the second term is
+    $\eta^{-1}$ times the Choi matrix of the identity map, namely
+    $\eta^{-1}\ket{\Omega}\bra{\Omega}$.
+\end{proof}
+
+\begin{theorem}[Positivity threshold of $T_\eta$]
+    \label{thm:t_eta_threshold}
+    \lean{Matrix.isNPositiveMap_tEta_iff}
+    \leanok
+    \uses{def:t_eta, thm:choi_matrix_t_eta, thm:schmidt_rank_choi_test_iff,
+        thm:maximal_overlap_schmidt_rank}
+    Let $\eta>0$ and $1\le k<D$.  Then $T_\eta$ is $k$-positive if and only if
+    $\eta\ge k$.  This is \cite[Equation~(3.11)]{Wolf2012Quantum}, stated here for
+    $1\le k<D$; the top index $k=D$, where $k$-positivity is complete positivity,
+    lies outside the range of the maximal-overlap principle in
+    Theorem~\ref{thm:maximal_overlap_schmidt_rank}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By the Schmidt-rank Choi criterion, $k$-positivity is the nonnegativity of
+    the Choi quadratic form on all vectors of Schmidt rank at most $k$.  For a
+    normalized such vector $\psi$, the Choi matrix
+    $\tau_\eta=D^{-1}\Id-\eta^{-1}\ket{\Omega}\bra{\Omega}$ gives
+    \[
+        \bra{\psi}\tau_\eta\ket{\psi}
+        =D^{-1}-\eta^{-1}|\braket{\Omega}{\psi}|^2.
+    \]
+    The reduced density of $\ket\Omega$ on the first factor is $\Id/D$, so by the
+    maximal-overlap principle the supremum of $|\braket{\Omega}{\psi}|^2$ over
+    Schmidt-rank-$k$ normalized vectors is $\|\Id/D\|_{(k)}=k/D$.  The infimum of
+    the quadratic form is therefore $D^{-1}-\eta^{-1}(k/D)=D^{-1}(1-k/\eta)$,
+    which is nonnegative precisely when $\eta\ge k$.  Degree-two homogeneity
+    extends the bound from normalized vectors to all vectors of Schmidt rank at
+    most $k$.
+\end{proof}
+
+\begin{corollary}[Strictness of the positivity chain]
+    \label{cor:positivity_chain_strict}
+    \lean{Matrix.exists_isNPositiveMap_not_succ}
+    \leanok
+    \uses{thm:t_eta_threshold}
+    Let $1\le k$ with $k+1<D$.  Then there is a map on $\MN{D}$ that is
+    $k$-positive but not $(k+1)$-positive; the cone of $k$-positive maps strictly
+    contains the cone of $(k+1)$-positive maps.  Every inclusion between
+    consecutive amplification dimensions below the top one is therefore strict.
+\end{corollary}
+
+\begin{proof}
+    \leanok
+    Take $T_\eta$ at $\eta=k$.  By the threshold equivalence it is $k$-positive,
+    since $\eta=k\ge k$, but not $(k+1)$-positive, since $\eta=k<k+1$.
+\end{proof}
+
 \begin{theorem}[Completely positive implies two-positive]
     \lean{IsCPMap.is2PositiveMap}
     \leanok

--- a/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
@@ -1,0 +1,89 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Top Schmidt-rank index in the $n$-positivity threshold of $T_\eta$
+(Wolf Chapter 3)}
+\author{}
+\date{2026-06-24}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+In Chapter~3 of Wolf's lecture notes \cite{Wolf2012Quantum}, the one-parameter
+family
+\begin{align}
+  T_\eta(\rho)=\operatorname{tr}(\rho)\,\mathbf 1-\frac{\rho}{\eta},
+  \qquad \eta\in\mathbb R_+,
+  \tag{3.11}
+\end{align}
+on $M_D(\mathbb C)$ is analyzed through its Choi--Jamiolkowski operator
+$\tau_\eta=D^{-1}\mathbf 1-\eta^{-1}\ket\Omega\bra\Omega$.  All positive
+eigenvalues of $\tau_\eta$ equal $1/D$, and the single non-positive eigenvalue
+is $\nu_-=1/D-1/\eta$ with reduced density $\rho_-=\mathbf 1/D$, so its
+Ky--Fan $n$-norm is $\|\rho_-\|_{(n)}=n/D$.  The source concludes:
+\begin{align}
+  T_\eta\ \text{is $n$-positive}\iff \eta\ge n,
+  \qquad n=1,\dots,D,
+\end{align}
+where the range of $n$ runs up to the dimension $D$, in which case
+$n$-positivity is complete positivity.  This proves that every inclusion in
+Wolf's chain
+\begin{align}
+  \mathcal T_{\mathrm{cp}}=\mathcal T_D\subseteq
+  \mathcal T_{D-1}\subseteq\cdots\subseteq\mathcal T_2\subseteq\mathcal T_1
+  \tag{3.3}
+\end{align}
+is strict.\footnote{Local source:
+\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex:181--193},
+equation label \path{eq:ch3:3.11}.}
+
+\section{Point at issue}
+
+The formal statement establishes the equivalence
+\begin{align}
+  T_\eta\ \text{is $k$-positive}\iff \eta\ge k
+\end{align}
+for Schmidt-rank index $1\le k<D$, omitting the top index $k=D$.  The
+restriction is inherited, not introduced here: the equivalence is derived from
+the maximal-overlap principle (Wolf Lemma~3.1), whose formal version
+$\sup_\psi|\braket{\Omega}{\psi}|^2=\|\rho\|_{(k)}$ over Schmidt-rank-$k$
+normalized vectors is available only for $1\le k<D$.  That bound in turn rests
+on the Ky--Fan maximum principle, stated for orthogonal projections of rank
+exactly $k$ with $k<D$.  At the top index $k=D$ the Ky--Fan $D$-norm is the
+full trace and the maximizing projection is the identity; the present
+formalization of the maximum principle does not cover that boundary case.
+
+Consequently the strictness witness produced here, a $k$-positive map that fails
+to be $(k+1)$-positive, is available for $1\le k$ with $k+1<D$.  This covers
+every inclusion in the chain~(3.3) except the topmost one,
+$\mathcal T_D\subseteq\mathcal T_{D-1}$, which compares complete positivity with
+$(D-1)$-positivity and requires the $k=D$ index.
+
+\section{Status}
+
+The deviation is a scope restriction, not a mathematical error: the formal
+equivalence and the strictness witnesses are correct as stated for the indices
+they cover.  The omitted boundary case $k=D$ is mathematically true in the
+source and would follow once the maximal-overlap principle and the Ky--Fan
+maximum principle are extended to the top index $k=D$ (where the bound reads
+$\|\rho\|_{(D)}=\operatorname{tr}\rho=1$ and the optimizing projection is the
+identity).  Extending those two principles to $k=D$ removes this restriction and
+supplies the top inclusion $\mathcal T_D\subseteq\mathcal T_{D-1}$.
+
+The formal declarations are
+\leanid{Matrix.isNPositiveMap_tEta_iff} for the threshold equivalence and
+\leanid{Matrix.exists_isNPositiveMap_not_succ} for the strictness witness, in
+\doclink{TNLean/Channel/NPositivityChainStrict}.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}

--- a/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
@@ -20,11 +20,13 @@
 In Chapter~3 of Wolf's lecture notes \cite{Wolf2012Quantum}, the one-parameter
 family
 \begin{align}
-  T_\eta(\rho)=\operatorname{tr}(\rho)\,\mathbf 1-\frac{\rho}{\eta},
+  T_\eta(\rho)=\tr(\rho)\,\mathbf 1-\frac{\rho}{\eta},
   \qquad \eta\in\mathbb R_+,
   \tag{3.11}
 \end{align}
-on $M_D(\mathbb C)$ is analyzed through its Choi--Jamiolkowski operator
+on $M_D(\mathbb C)$ (the formal map is written $\tr(\rho)\,\mathbf 1-\eta^{-1}\rho$,
+which agrees on $\eta>0$ and is moreover defined at $\eta=0$) is analyzed
+through its Choi--Jamiolkowski operator
 $\tau_\eta=D^{-1}\mathbf 1-\eta^{-1}\ket\Omega\bra\Omega$.  All positive
 eigenvalues of $\tau_\eta$ equal $1/D$, and the single non-positive eigenvalue
 is $\nu_-=1/D-1/\eta$ with reduced density $\rho_-=\mathbf 1/D$, so its
@@ -74,7 +76,7 @@ equivalence and the strictness witnesses are correct as stated for the indices
 they cover.  The omitted boundary case $k=D$ is mathematically true in the
 source and would follow once the maximal-overlap principle and the Ky--Fan
 maximum principle are extended to the top index $k=D$ (where the bound reads
-$\|\rho\|_{(D)}=\operatorname{tr}\rho=1$ and the optimizing projection is the
+$\|\rho\|_{(D)}=\tr\rho=1$ and the optimizing projection is the
 identity).  Extending those two principles to $k=D$ removes this restriction and
 supplies the top inclusion $\mathcal T_D\subseteq\mathcal T_{D-1}$.
 
@@ -82,6 +84,19 @@ The formal declarations are
 \leanid{Matrix.isNPositiveMap_tEta_iff} for the threshold equivalence and
 \leanid{Matrix.exists_isNPositiveMap_not_succ} for the strictness witness, in
 \doclink{TNLean/Channel/NPositivityChainStrict}.
+
+\section{Classification}
+
+\emph{Scope restriction.} The formal threshold proves the source
+equivalence~(3.11) for Schmidt ranks $1\le k<D$, a special case of the source's
+full range $1\le k\le D$. For $T_\eta$ both tensor factors of the Choi operator
+have dimension $D$ (the maximally entangled vector lies in
+$\mathbb C^{D}\otimes\mathbb C^{D}$), so the first-factor dimension that bounds
+the Ky--Fan index coincides with $D$; no separate $D'$ enters. The conclusion
+matches the source on $1\le k<D$, and only the top index $k=D$ is omitted, where
+the bound degenerates to complete positivity. No hypothesis foreign to the
+source is used, so the deviation is a scope restriction rather than an
+unfaithful theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- Formalizes Wolf Ch. 3, eq. (3.11): the one-parameter family $T_\eta(\rho) = \operatorname{tr}(\rho) \cdot 1 - \rho/\eta$ on $M_D(\mathbb{C})$, and the resulting strictness of the $n$-positivity chain (3.3). Continues the Wolf Chapter 3 formalization tracked in LionSR/QICLean#25.
- The positivity threshold `IsNPositiveMap k (tEta D η) ↔ (k : ℝ) ≤ η` for `1 ≤ k < D` establishes Wolf's assertion that $T_\eta$ is $n$-positive if and only if $\eta \geq n$.
- The strictness witness `exists_isNPositiveMap_not_succ` shows each inclusion in chain (3.3) between consecutive amplification dimensions below the top index is strict.

### Description

New file `TNLean/Channel/NPositivityChainStrict.lean`:
- `Matrix.tEta` — the map $T_\eta$ with real parameter $\eta \in \mathbb{R}_{>0}$.
- `ChoiJamiolkowski.choiMatrix_tEta` — Choi operator $\tau_\eta = D^{-1} \cdot 1 - \eta^{-1} |\Omega\rangle\langle\Omega|$.
- `Matrix.choiMatrix_tEta_quadraticForm` — $\langle\psi|\tau_\eta|\psi\rangle = D^{-1}\|\psi\|^2 - \eta^{-1}|\langle\Omega|\psi\rangle|^2$.
- `Matrix.IsHermitian.kyFanNorm_smul_one` — Ky-Fan $k$-norm of $c \cdot 1$ equals $k \cdot c$.
- `Matrix.omega_kyFanNorm_eq` — reduced density of $|\Omega\rangle$ is $I/D$, so its Ky-Fan $k$-norm is $k/D$.
- `Matrix.normSq_omega_overlap_le` — maximal-overlap bound $|\langle\Omega|\psi\rangle|^2 \leq (k/D)\|\psi\|^2$ for Schmidt-rank-$\leq k$ vectors.
- `Matrix.isNPositiveMap_tEta_iff` — $T_\eta$ is $k$-positive if and only if $\eta \geq k$, for $1 \leq k < D$.
- `Matrix.exists_isNPositiveMap_not_succ` — for $1 \leq k$ with $k+1 < D$, there exists a map that is $k$-positive but not $(k+1)$-positive.

Proof route: via the maximal-overlap principle (Wolf Lemma 3.1) rather than the spectral decomposition. The Choi quadratic form on a Schmidt-rank-$\leq k$ vector equals $D^{-1}\|\psi\|^2 - \eta^{-1}|\langle\Omega|\psi\rangle|^2$; the maximal-overlap bound pins the infimum to $D^{-1}(1 - k/\eta)$, nonnegative iff $\eta \geq k$. The Schmidt-rank Choi criterion (merged in LionSR/TNLean#3489) and both halves of Lemma 3.1 (`maximalSchmidtOverlap_eq_kyFanNorm`, LionSR/TNLean#3484) are used.

**Scope restriction (k < D):** Threshold and strictness are proven for $1 \leq k < D$. The top index $k = D$ is omitted because the maximal-overlap lemma is not formalized at $k = \operatorname{card}$. Documented in `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. Blueprint entries `thm:t_eta_threshold` and `cor:positivity_chain_strict` carry the scope-restriction marker; blueprint statements state the restriction explicitly.

Also modified: `TNLean.lean` (import), `blueprint/src/chapter/ch05_schwarz.tex` (new subsection on $T_\eta$ and chain strictness with Lean links), `docs/paper-gaps/wolf_t_eta_top_index_scope.tex` (new paper-gap note).

### Testing

- `lake env lean TNLean/Channel/NPositivityChainStrict.lean` — exit 0, no errors.
- `lake build TNLean.Channel.NPositivityChainStrict` — built successfully (3007 jobs green).
- `rg -n "sorry|admit|native_decide|axiom" TNLean/Channel/NPositivityChainStrict.lean` — clean.
- `lake exe lint-style TNLean/Channel/NPositivityChainStrict.lean` — exit 0.
- Full `lake build` and `leanblueprint checkdecls` run in CI (not run locally due to disk-space constraints on the shared build host).

---
Closes LionSR/QICLean#167

Part of LionSR/QICLean#25.

> [!NOTE]
> **Low Risk**
> New Mathlib-style proofs and documentation only; no changes to auth, runtime, or critical infrastructure. The k < D scope is explicit and inherited from existing lemmas.
> 
> **Overview**
> Adds a Lean formalization of Wolf's map **T_η(ρ) = tr(ρ)•1 − ρ/η** and shows that for **1 ≤ k < D**, **k-positivity** of **T_η** is equivalent to **η ≥ k**, via the Choi operator and the maximal-overlap route (not the spectral decomposition).
> 
> The new module **`TNLean/Channel/NPositivityChainStrict`** supplies the Choi matrix **`τ_η`**, the Choi quadratic form, Ky-Fan **`k/D`** for **|Ω⟩**, a homogeneous overlap bound, and **`exists_isNPositiveMap_not_succ`** (witness **T_η** at **η = k**) so consecutive inclusions in Wolf's chain are **strict** when **k + 1 < D**. Results are stated only for **k < D** because the maximal-overlap lemma is not formalized at **k = D**; **`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`** and matching blueprint text document that gap.
> 
> **`TNLean.lean`** imports the module; **`blueprint/src/chapter/ch05_schwarz.tex`** gains a subsection on **T_η** and chain strictness with Lean links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7338a069a88d44d1ee94c1a2ca8259d919a9ec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Lean proofs and documentation only; no runtime or security-sensitive changes. The k < D scope is explicit and inherited from existing lemmas.
> 
> **Overview**
> Adds **`TNLean/Channel/NPositivityChainStrict`**, formalizing Wolf’s map **T_η(ρ) = tr(ρ)·1 − η⁻¹ρ** and showing that for **0 < η** and **1 ≤ k < D**, **k-positivity** of **T_η** is equivalent to **η ≥ k** (Wolf eq. (3.11)).
> 
> The proof uses the Choi operator **τ_η = D⁻¹·1 − η⁻¹|Ω⟩⟨Ω|**, an explicit Choi quadratic form, Ky-Fan **k/D** for **|Ω⟩**, a homogeneous maximal-overlap bound, and the Schmidt-rank Choi criterion—not the spectral route. **`exists_isNPositiveMap_not_succ`** witnesses strict inclusions in Wolf’s chain via **T_η** at **η = k** when **k + 1 < D**.
> 
> Results are stated only for **k < D** because the maximal-overlap lemma is not formalized at **k = D**; **`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`** and a new blueprint subsection in **`ch05_schwarz.tex`** document that gap. **`TNLean.lean`** imports the new module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b031ab093c64697141dc401c20e87facaf4b17f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->