### PR TITLE
feat(Channel): Wolf reduction criterion and reductionMap/tEta bridge

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -115,6 +115,7 @@ import TNLean.Channel.Schwarz.SchwarzNotCP
 import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.ChoiCompression
 import TNLean.Channel.NPositivityChainStrict
+import TNLean.Channel.ReductionCriterion
 import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull

--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.NPositivityChainStrict
+import TNLean.Channel.PartialTrace
+import TNLean.Channel.TensorMap
+
+/-!
+# Wolf's reduction criterion
+
+Wolf's Chapter 3, Example 3.1 records the one-parameter family of `n`-positive
+maps `T_n(X) = tr(X) • 1 − n⁻¹ • X` on `M_d(ℂ)` and derives the **reduction
+criterion** (Wolf eq. (3.18)): for a bipartite state `ρ` of Schmidt number at
+most `n` one has
+`n • (ρ₁ ⊗ 1) ≥ ρ` and `n • (1 ⊗ ρ₂) ≥ ρ`,
+where `ρ₁` and `ρ₂` are the two reduced density matrices.  The witness operator
+attached to `T_n` is `W_n = d⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|`.
+
+This file collects the reduction-criterion content that is provable from the
+foundations already in the development.
+
+## Reconciliation of the two reduction maps
+
+The development carries two definitions of the same map: `Matrix.reductionMap D
+k` (parametrized by `k : ℕ`) in `PositiveExamples.lean`, and the later
+`Matrix.tEta D η` (parametrized by `η : ℝ`) in `NPositivityChainStrict.lean`.
+They agree at `η = k`: `reductionMap D k = tEta D (k : ℝ)`, since the only
+difference is the scalar `(k : ℂ)⁻¹` versus `((k : ℝ) : ℂ)⁻¹`, and the natural
+and real casts of `k` into `ℂ` coincide.  The bridge lemma
+`Matrix.reductionMap_eq_tEta` makes this identification, so the `n`-positivity
+threshold (`Matrix.isNPositiveMap_tEta_iff`), the Choi formula
+(`ChoiJamiolkowski.choiMatrix_tEta`), and the self-duality
+(`Matrix.traceAdjointMap_reductionMap`) all describe one object.  No third
+definition of the map is introduced.
+
+## The operator implication
+
+The core of Wolf eq. (3.18) is the elementary identity
+`(T_n ⊗ id)(ρ) = (1 ⊗ ρ₂) − n⁻¹ • ρ`,
+where the partial trace over the first factor produces `ρ₂`.  Positivity of the
+left-hand side is therefore equivalent, after scaling by `n > 0`, to
+`n • (1 ⊗ ρ₂) ≥ ρ`; applying the map to the second factor instead gives the
+symmetric bound `n • (ρ₁ ⊗ 1) ≥ ρ`.  The implications are recorded as
+`Matrix.reductionCriterion_left` and `Matrix.reductionCriterion_right`.
+
+## Main definitions
+
+* `Matrix.reductionWitness` -- Wolf's witness `W_n = d⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|`.
+
+## Main results
+
+* `Matrix.reductionMap_eq_tEta` -- the bridge `reductionMap D k = tEta D (k : ℝ)`.
+* `ChoiJamiolkowski.choiMatrix_reductionMap_eq_reductionWitness` -- the Choi
+  operator of `T_n` is the witness `W_n`.
+* `Matrix.tensorMapId_tEta_eq` -- `(T_n ⊗ id)(ρ) = (1 ⊗ ρ₂) − n⁻¹ • ρ`.
+* `Matrix.reductionCriterion_left` and `Matrix.reductionCriterion_right` --
+  **Wolf eq. (3.18):** positivity of `(T_n ⊗ id)(ρ)` (resp. `(id ⊗ T_n)(ρ)`)
+  yields `n • (1 ⊗ ρ₂) ≥ ρ` (resp. `n • (ρ₁ ⊗ 1) ≥ ρ`).
+
+## Scope
+
+The *entanglement* form of the reduction criterion (a separable state satisfies
+eq. (3.18)) requires a separable-state predicate, which is not yet part of the
+development; the operator implication above is the separability-free content.
+The other entanglement criteria of Example 3.1 (PPT / partial transpose, the
+Breuer–Hall map, the Choi-type maps) need a bipartite partial-transpose object
+and indecomposability, which are likewise absent.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Example 3.1, equation (3.18)][Wolf2012QChannels]
+-/
+
+open scoped BigOperators Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- **Reconciliation of the two reduction maps.** The natural-parameter
+reduction map `reductionMap D k` coincides with the real-parameter map
+`tEta D (k : ℝ)`: the two definitions differ only by the scalar `(k : ℂ)⁻¹`
+versus `((k : ℝ) : ℂ)⁻¹`, and the natural and real casts of `k` into `ℂ` agree.
+-/
+theorem reductionMap_eq_tEta (D k : ℕ) : reductionMap D k = tEta D (k : ℝ) := by
+  apply LinearMap.ext
+  intro X
+  rw [reductionMap_apply, tEta_apply, Complex.ofReal_natCast]
+
+end Matrix
+
+namespace ChoiJamiolkowski
+
+variable {D : ℕ}
+
+/-- The Choi operator of `reductionMap D k` is the same matrix as that of
+`tEta D k`, since the two maps coincide. -/
+theorem choiMatrix_reductionMap_eq_choiMatrix_tEta [NeZero D] (k : ℕ) :
+    choiMatrix (Matrix.reductionMap D k) = choiMatrix (Matrix.tEta D (k : ℝ)) := by
+  rw [Matrix.reductionMap_eq_tEta]
+
+end ChoiJamiolkowski
+
+namespace Matrix
+
+variable {D : ℕ}
+
+/-- **Wolf's reduction witness.** The entanglement witness attached to `T_n` is
+`W_n = D⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|` on `M_D(ℂ) ⊗ M_D(ℂ)`.  It is exactly the Choi
+operator of `T_n`. -/
+noncomputable def reductionWitness (D n : ℕ) :
+    Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ :=
+  ((D : ℂ)⁻¹) • (1 : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) -
+    ((n : ℂ)⁻¹) • Matrix.omegaProj D
+
+@[simp]
+theorem reductionWitness_apply (D n : ℕ) (x y : Fin D × Fin D) :
+    reductionWitness D n x y =
+      ((D : ℂ)⁻¹) • (1 : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) x y -
+        ((n : ℂ)⁻¹) • Matrix.omegaProj D x y := rfl
+
+end Matrix
+
+namespace ChoiJamiolkowski
+
+variable {D : ℕ}
+
+/-- **Wolf Chapter 3, Example 3.1.** The Choi operator of the reduction map
+`T_n(X) = tr(X) • 1 − n⁻¹ • X` is the reduction witness
+`W_n = D⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|`. -/
+theorem choiMatrix_reductionMap_eq_reductionWitness [NeZero D] (n : ℕ) :
+    choiMatrix (Matrix.reductionMap D n) = Matrix.reductionWitness D n := by
+  rw [Matrix.reductionMap_eq_tEta, ChoiJamiolkowski.choiMatrix_tEta]
+  ext x y
+  rw [Matrix.reductionWitness, Complex.ofReal_natCast]
+
+end ChoiJamiolkowski
+
+namespace Matrix
+
+variable {D D' : ℕ}
+
+/-- The trace of the `(i₂, j₂)`-slice of a bipartite matrix is the `(i₂, j₂)`
+entry of the partial trace over the first factor: `tr(ρ_{·,i₂,·,j₂}) = (ρ₂)_{i₂ j₂}`.
+-/
+theorem trace_bipartiteSlice (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
+    (i₂ j₂ : Fin D') :
+    Matrix.trace (bipartiteSlice ρ i₂ j₂) = traceLeft ρ i₂ j₂ := by
+  simp only [Matrix.trace, Matrix.diag, bipartiteSlice_apply, traceLeft_apply]
+
+/-- **The reduction-criterion identity (Wolf eq. (3.18)).** Applying `T_n` to the
+first tensor factor of a bipartite matrix gives
+`(T_n ⊗ id)(ρ) = (1 ⊗ ρ₂) − n⁻¹ • ρ`,
+where `ρ₂ = traceLeft ρ` is the reduced density on the second factor. -/
+theorem tensorMapId_tEta_eq (η : ℝ) (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ) :
+    tensorMapId (tEta D η) ρ
+      = (1 : Matrix (Fin D) (Fin D) ℂ) ⊗ₖ traceLeft ρ - ((η : ℂ)⁻¹) • ρ := by
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  rw [tensorMapId_apply, tEta_apply]
+  simp only [Matrix.sub_apply, Matrix.smul_apply, Matrix.one_apply, bipartiteSlice_apply,
+    trace_bipartiteSlice, kroneckerMap_apply, smul_eq_mul]
+  by_cases hij : i₁ = j₁ <;> simp [hij]
+
+/-- **Wolf's reduction criterion, equation (3.18), first form.** If applying
+`T_n` to the first tensor factor of a bipartite matrix `ρ` yields a positive
+semidefinite operator, then `n • (1 ⊗ ρ₂) ≥ ρ`, where `ρ₂ = traceLeft ρ` is the
+reduced density on the second factor.
+
+This is the separability-free operator content of the reduction criterion: it
+takes positivity of `(T_n ⊗ id)(ρ)` as a hypothesis rather than deriving it from
+a separability assumption on `ρ`. -/
+theorem reductionCriterion_left {n : ℕ} (hn : 0 < n)
+    (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
+    (hpos : (tensorMapId (tEta D (n : ℝ)) ρ).PosSemidef) :
+    ρ ≤ (n : ℂ) • ((1 : Matrix (Fin D) (Fin D) ℂ) ⊗ₖ traceLeft ρ) := by
+  rw [Matrix.le_iff]
+  have hnC : (0 : ℂ) ≤ (n : ℂ) := by exact_mod_cast Nat.zero_le n
+  have hscaled := hpos.smul hnC
+  have hrw :
+      (n : ℂ) • tensorMapId (tEta D (n : ℝ)) ρ
+        = (n : ℂ) • ((1 : Matrix (Fin D) (Fin D) ℂ) ⊗ₖ traceLeft ρ) - ρ := by
+    rw [tensorMapId_tEta_eq, smul_sub, smul_smul]
+    have hcancel : (n : ℂ) * ((n : ℝ) : ℂ)⁻¹ = 1 := by
+      rw [Complex.ofReal_natCast, mul_inv_cancel₀]
+      exact_mod_cast hn.ne'
+    rw [hcancel, one_smul]
+  rwa [hrw] at hscaled
+
+/-- **Wolf's reduction criterion, equation (3.18), second form.** If applying
+`T_n` to the second tensor factor of a bipartite matrix `ρ` yields a positive
+semidefinite operator, then `n • (ρ₁ ⊗ 1) ≥ ρ`, where `ρ₁ = traceRight ρ` is the
+reduced density on the first factor.
+
+The second factor is handled by reindexing to the first, applying the first
+form, and reindexing back; positive semidefiniteness and the order are invariant
+under the simultaneous index swap. -/
+theorem reductionCriterion_right {n : ℕ} (hn : 0 < n)
+    (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
+    (hpos : (tensorMapId (tEta D' (n : ℝ))
+        (ρ.submatrix Prod.swap Prod.swap)).PosSemidef) :
+    ρ ≤ (n : ℂ) • (traceRight ρ ⊗ₖ (1 : Matrix (Fin D') (Fin D') ℂ)) := by
+  -- Swap the two tensor factors and apply the first form, then swap back.
+  set σ : Matrix (Fin D' × Fin D) (Fin D' × Fin D) ℂ :=
+    ρ.submatrix Prod.swap Prod.swap with hσ
+  have hleft := reductionCriterion_left (D := D') (D' := D) hn σ hpos
+  rw [Matrix.le_iff] at hleft ⊢
+  -- Reindex the inequality witness back through the factor swap.
+  have hsub :
+      ((n : ℂ) • (traceRight ρ ⊗ₖ (1 : Matrix (Fin D') (Fin D') ℂ)) - ρ)
+        = ((n : ℂ) • ((1 : Matrix (Fin D') (Fin D') ℂ) ⊗ₖ traceLeft σ) - σ).submatrix
+            Prod.swap Prod.swap := by
+    ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+    simp only [Matrix.sub_apply, Matrix.smul_apply, Matrix.submatrix_apply, smul_eq_mul,
+      kroneckerMap_apply, Matrix.one_apply, Prod.swap_prod_mk, hσ,
+      traceLeft_apply, traceRight_apply]
+    by_cases hi : i₂ = j₂ <;> by_cases hj : i₁ = j₁ <;>
+      simp [hi, hj, mul_comm]
+  rw [hsub]
+  exact hleft.submatrix Prod.swap
+
+end Matrix

--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -93,18 +93,6 @@ theorem reductionMap_eq_tEta (D k : ℕ) : reductionMap D k = tEta D (k : ℝ) :
 
 end Matrix
 
-namespace ChoiJamiolkowski
-
-variable {D : ℕ}
-
-/-- The Choi operator of `reductionMap D k` is the same matrix as that of
-`tEta D k`, since the two maps coincide. -/
-theorem choiMatrix_reductionMap_eq_choiMatrix_tEta [NeZero D] (k : ℕ) :
-    choiMatrix (Matrix.reductionMap D k) = choiMatrix (Matrix.tEta D (k : ℝ)) := by
-  rw [Matrix.reductionMap_eq_tEta]
-
-end ChoiJamiolkowski
-
 namespace Matrix
 
 variable {D : ℕ}

--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -35,15 +35,20 @@ threshold (`Matrix.isNPositiveMap_tEta_iff`), the Choi formula
 (`Matrix.traceAdjointMap_reductionMap`) all describe one object.  No third
 definition of the map is introduced.
 
-## The operator implication
+## The operator-implication step
 
-The core of Wolf eq. (3.18) is the elementary identity
+Wolf reaches eq. (3.18) in two steps:
+`Schmidt-number(ρ) ≤ n ⟹ (T_n ⊗ id)(ρ) ≥ 0 ⟹ n • (1 ⊗ ρ₂) ≥ ρ`,
+the first step by `n`-positivity of `T_n` and the second by the elementary
+identity
 `(T_n ⊗ id)(ρ) = (1 ⊗ ρ₂) − n⁻¹ • ρ`,
-where the partial trace over the first factor produces `ρ₂`.  Positivity of the
-left-hand side is therefore equivalent, after scaling by `n > 0`, to
-`n • (1 ⊗ ρ₂) ≥ ρ`; applying the map to the second factor instead gives the
-symmetric bound `n • (ρ₁ ⊗ 1) ≥ ρ`.  The implications are recorded as
-`Matrix.reductionCriterion_left` and `Matrix.reductionCriterion_right`.
+where the partial trace over the first factor produces `ρ₂`.  This file
+formalizes the **second step**: positivity of `(T_n ⊗ id)(ρ)` is equivalent,
+after scaling by `n > 0`, to `n • (1 ⊗ ρ₂) ≥ ρ`; applying the map to the second
+factor instead gives the symmetric bound `n • (ρ₁ ⊗ 1) ≥ ρ`.  The implications
+are recorded as `Matrix.reductionCriterion_left` and
+`Matrix.reductionCriterion_right`.  The first step (the Schmidt-number premise)
+is not yet formalized; see the scope section.
 
 ## Main definitions
 
@@ -55,19 +60,29 @@ symmetric bound `n • (ρ₁ ⊗ 1) ≥ ρ`.  The implications are recorded as
 * `ChoiJamiolkowski.choiMatrix_reductionMap_eq_reductionWitness` -- the Choi
   operator of `T_n` is the witness `W_n`.
 * `Matrix.tensorMapId_tEta_eq` -- `(T_n ⊗ id)(ρ) = (1 ⊗ ρ₂) − n⁻¹ • ρ`.
-* `Matrix.reductionCriterion_left` and `Matrix.reductionCriterion_right` --
-  **Wolf eq. (3.18):** positivity of `(T_n ⊗ id)(ρ)` yields `n • (1 ⊗ ρ₂) ≥ ρ`,
-  and positivity of `(T_n ⊗ id)(ρ^swap)` -- equivalently Wolf's symmetric
-  condition `(id ⊗ T_n)(ρ) ≥ 0` -- yields `n • (ρ₁ ⊗ 1) ≥ ρ`.
+* `Matrix.reductionCriterion_left` and `Matrix.reductionCriterion_right` -- the
+  **operator-implication step of Wolf eq. (3.18):** positivity of `(T_n ⊗ id)(ρ)`
+  yields `n • (1 ⊗ ρ₂) ≥ ρ`, and positivity of `(T_n ⊗ id)(ρ^swap)` --
+  equivalently Wolf's symmetric condition `(id ⊗ T_n)(ρ) ≥ 0` -- yields
+  `n • (ρ₁ ⊗ 1) ≥ ρ`.  Wolf's Schmidt-number premise is not yet wired in; see
+  the scope note below.
 
 ## Scope
 
-The *entanglement* form of the reduction criterion (a separable state satisfies
-eq. (3.18)) requires a separable-state predicate, which is not yet part of the
-development; the operator implication above is the separability-free content.
-The other entanglement criteria of Example 3.1 (PPT / partial transpose, the
-Breuer–Hall map, the Choi-type maps) need a bipartite partial-transpose object
-and indecomposability, which are likewise absent.
+**Scope restriction (operator-implication half of eq. (3.18)):** Wolf's
+eq. (3.18) has the premise `Schmidt-number(ρ) ≤ n`.  The theorems here drop that
+premise and assume its consequence `(T_n ⊗ id)(ρ) ≥ 0` instead, so they
+formalize only the second of Wolf's two steps.  Deriving the first step needs a
+Schmidt-number predicate for mixed states, equivalently a separable-state
+predicate, which is absent from the development.  Documented in
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`.
+
+The same missing foundation blocks the *entanglement* form of the reduction
+criterion (a separable state satisfies eq. (3.18)): the operator implication
+above is the separability-free content.  The other entanglement criteria of
+Example 3.1 (PPT / partial transpose, the Breuer–Hall map, the Choi-type maps)
+need a bipartite partial-transpose object and indecomposability, which are
+likewise absent.
 
 ## References
 
@@ -100,12 +115,6 @@ noncomputable def reductionWitness (D n : ℕ) :
   ((D : ℂ)⁻¹) • (1 : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) -
     ((n : ℂ)⁻¹) • Matrix.omegaProj D
 
-@[simp]
-theorem reductionWitness_apply (D n : ℕ) (x y : Fin D × Fin D) :
-    reductionWitness D n x y =
-      ((D : ℂ)⁻¹) • (1 : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) x y -
-        ((n : ℂ)⁻¹) • Matrix.omegaProj D x y := rfl
-
 end Matrix
 
 namespace ChoiJamiolkowski
@@ -129,8 +138,10 @@ variable {D D' : ℕ}
 
 /-- The trace of the `(i₂, j₂)`-slice of a bipartite matrix is the `(i₂, j₂)`
 entry of the partial trace over the first factor: `tr(ρ_{·,i₂,·,j₂}) = (ρ₂)_{i₂ j₂}`.
--/
-theorem trace_bipartiteSlice (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
+
+This is an internal auxiliary fact relating `bipartiteSlice` and `traceLeft`,
+used only to prove `tensorMapId_tEta_eq` below. -/
+private theorem trace_bipartiteSlice (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
     (i₂ j₂ : Fin D') :
     Matrix.trace (bipartiteSlice ρ i₂ j₂) = traceLeft ρ i₂ j₂ := by
   simp only [Matrix.trace, Matrix.diag, bipartiteSlice_apply, traceLeft_apply]
@@ -148,14 +159,18 @@ theorem tensorMapId_tEta_eq (η : ℝ) (ρ : Matrix (Fin D × Fin D') (Fin D × 
     trace_bipartiteSlice, kroneckerMap_apply, smul_eq_mul]
   by_cases hij : i₁ = j₁ <;> simp [hij]
 
-/-- **Wolf's reduction criterion, equation (3.18), first form.** If applying
-`T_n` to the first tensor factor of a bipartite matrix `ρ` yields a positive
-semidefinite operator, then `n • (1 ⊗ ρ₂) ≥ ρ`, where `ρ₂ = traceLeft ρ` is the
-reduced density on the second factor.
+/-- **Operator-implication step of Wolf's reduction criterion (eq. (3.18)), first
+form.** If applying `T_n` to the first tensor factor of a bipartite matrix `ρ`
+yields a positive semidefinite operator, then `n • (1 ⊗ ρ₂) ≥ ρ`, where
+`ρ₂ = traceLeft ρ` is the reduced density on the second factor.
 
-This is the separability-free operator content of the reduction criterion: it
-takes positivity of `(T_n ⊗ id)(ρ)` as a hypothesis rather than deriving it from
-a separability assumption on `ρ`. -/
+**Scope restriction (operator-implication half of eq. (3.18)):** Wolf states
+eq. (3.18) with the premise that `ρ` has Schmidt number at most `n`; the path to
+the inequality is `Schmidt-number(ρ) ≤ n ⟹ (T_n ⊗ id)(ρ) ≥ 0 ⟹ n • (1 ⊗ ρ₂) ≥ ρ`.
+This theorem formalizes only the second step, taking `(T_n ⊗ id)(ρ) ≥ 0` as a
+hypothesis; the first step is unformalized because no Schmidt-number /
+separable-state predicate exists in the development.  Documented in
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
 theorem reductionCriterion_left {n : ℕ} (hn : 0 < n)
     (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
     (hpos : (tensorMapId (tEta D (n : ℝ)) ρ).PosSemidef) :
@@ -173,17 +188,24 @@ theorem reductionCriterion_left {n : ℕ} (hn : 0 < n)
     rw [hcancel, one_smul]
   rwa [hrw] at hscaled
 
-/-- **Wolf's reduction criterion, equation (3.18), second form.** Let `ρ` be a
-bipartite matrix and `ρ^swap = ρ.submatrix Prod.swap Prod.swap` its image under
-the factor swap.  If `(T_n ⊗ id)(ρ^swap)` is positive semidefinite, then
-`n • (ρ₁ ⊗ 1) ≥ ρ`, where `ρ₁ = traceRight ρ` is the reduced density on the
-first factor.
+/-- **Operator-implication step of Wolf's reduction criterion (eq. (3.18)),
+second form.** Let `ρ` be a bipartite matrix and
+`ρ^swap = ρ.submatrix Prod.swap Prod.swap` its image under the factor swap.  If
+`(T_n ⊗ id)(ρ^swap)` is positive semidefinite, then `n • (ρ₁ ⊗ 1) ≥ ρ`, where
+`ρ₁ = traceRight ρ` is the reduced density on the first factor.
 
 Because the factor swap is a unitary reindexing, `(T_n ⊗ id)(ρ^swap) ≥ 0` is
 equivalent to Wolf's symmetric condition `(id ⊗ T_n)(ρ) ≥ 0`, which applies
 `T_n` to the second factor.  The proof reindexes to the first factor, applies
 the first form, and reindexes back; positive semidefiniteness and the order are
-invariant under the swap. -/
+invariant under the swap.
+
+**Scope restriction (operator-implication half of eq. (3.18)):** as with the
+first form, the source premise is `Schmidt-number(ρ) ≤ n`; this theorem
+formalizes only the step from `(T_n ⊗ id)(ρ^swap) ≥ 0` to the inequality, the
+Schmidt-number step being unformalized for want of a Schmidt-number /
+separable-state predicate.  Documented in
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
 theorem reductionCriterion_right {n : ℕ} (hn : 0 < n)
     (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
     (hpos : (tensorMapId (tEta D' (n : ℝ))

--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -28,8 +28,8 @@ k` (parametrized by `k : ℕ`) in `PositiveExamples.lean`, and the later
 `Matrix.tEta D η` (parametrized by `η : ℝ`) in `NPositivityChainStrict.lean`.
 They agree at `η = k`: `reductionMap D k = tEta D (k : ℝ)`, since the only
 difference is the scalar `(k : ℂ)⁻¹` versus `((k : ℝ) : ℂ)⁻¹`, and the natural
-and real casts of `k` into `ℂ` coincide.  The bridge lemma
-`Matrix.reductionMap_eq_tEta` makes this identification, so the `n`-positivity
+and real casts of `k` into `ℂ` coincide.  The identification lemma
+`Matrix.reductionMap_eq_tEta` records this, so the `n`-positivity
 threshold (`Matrix.isNPositiveMap_tEta_iff`), the Choi formula
 (`ChoiJamiolkowski.choiMatrix_tEta`), and the self-duality
 (`Matrix.traceAdjointMap_reductionMap`) all describe one object.  No third
@@ -51,13 +51,14 @@ symmetric bound `n • (ρ₁ ⊗ 1) ≥ ρ`.  The implications are recorded as
 
 ## Main results
 
-* `Matrix.reductionMap_eq_tEta` -- the bridge `reductionMap D k = tEta D (k : ℝ)`.
+* `Matrix.reductionMap_eq_tEta` -- the identification `reductionMap D k = tEta D (k : ℝ)`.
 * `ChoiJamiolkowski.choiMatrix_reductionMap_eq_reductionWitness` -- the Choi
   operator of `T_n` is the witness `W_n`.
 * `Matrix.tensorMapId_tEta_eq` -- `(T_n ⊗ id)(ρ) = (1 ⊗ ρ₂) − n⁻¹ • ρ`.
 * `Matrix.reductionCriterion_left` and `Matrix.reductionCriterion_right` --
-  **Wolf eq. (3.18):** positivity of `(T_n ⊗ id)(ρ)` (resp. `(id ⊗ T_n)(ρ)`)
-  yields `n • (1 ⊗ ρ₂) ≥ ρ` (resp. `n • (ρ₁ ⊗ 1) ≥ ρ`).
+  **Wolf eq. (3.18):** positivity of `(T_n ⊗ id)(ρ)` yields `n • (1 ⊗ ρ₂) ≥ ρ`,
+  and positivity of `(T_n ⊗ id)(ρ^swap)` -- equivalently Wolf's symmetric
+  condition `(id ⊗ T_n)(ρ) ≥ 0` -- yields `n • (ρ₁ ⊗ 1) ≥ ρ`.
 
 ## Scope
 
@@ -90,12 +91,6 @@ theorem reductionMap_eq_tEta (D k : ℕ) : reductionMap D k = tEta D (k : ℝ) :
   apply LinearMap.ext
   intro X
   rw [reductionMap_apply, tEta_apply, Complex.ofReal_natCast]
-
-end Matrix
-
-namespace Matrix
-
-variable {D : ℕ}
 
 /-- **Wolf's reduction witness.** The entanglement witness attached to `T_n` is
 `W_n = D⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|` on `M_D(ℂ) ⊗ M_D(ℂ)`.  It is exactly the Choi
@@ -178,14 +173,17 @@ theorem reductionCriterion_left {n : ℕ} (hn : 0 < n)
     rw [hcancel, one_smul]
   rwa [hrw] at hscaled
 
-/-- **Wolf's reduction criterion, equation (3.18), second form.** If applying
-`T_n` to the second tensor factor of a bipartite matrix `ρ` yields a positive
-semidefinite operator, then `n • (ρ₁ ⊗ 1) ≥ ρ`, where `ρ₁ = traceRight ρ` is the
-reduced density on the first factor.
+/-- **Wolf's reduction criterion, equation (3.18), second form.** Let `ρ` be a
+bipartite matrix and `ρ^swap = ρ.submatrix Prod.swap Prod.swap` its image under
+the factor swap.  If `(T_n ⊗ id)(ρ^swap)` is positive semidefinite, then
+`n • (ρ₁ ⊗ 1) ≥ ρ`, where `ρ₁ = traceRight ρ` is the reduced density on the
+first factor.
 
-The second factor is handled by reindexing to the first, applying the first
-form, and reindexing back; positive semidefiniteness and the order are invariant
-under the simultaneous index swap. -/
+Because the factor swap is a unitary reindexing, `(T_n ⊗ id)(ρ^swap) ≥ 0` is
+equivalent to Wolf's symmetric condition `(id ⊗ T_n)(ρ) ≥ 0`, which applies
+`T_n` to the second factor.  The proof reindexes to the first factor, applies
+the first form, and reindexes back; positive semidefiniteness and the order are
+invariant under the swap. -/
 theorem reductionCriterion_right {n : ℕ} (hn : 0 < n)
     (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
     (hpos : (tensorMapId (tEta D' (n : ℝ))

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1445,6 +1445,114 @@ adjacent cones.
     since $\eta=k\ge k$, but not $(k+1)$-positive, since $\eta=k<k+1$.
 \end{proof}
 
+\subsection{The reduction criterion}
+
+The reduction map and the family $T_\eta$ are the same map under two
+parametrizations: the natural-number parameter $k$ and the real parameter
+$\eta$ agree at $\eta=k$.  Identifying them lets the positivity threshold and
+the Choi formula carry over to the reduction map without restating them.  Wolf
+attaches to this map the entanglement witness
+$W_n=D^{-1}\Id-n^{-1}\ket{\Omega}\bra{\Omega}$ and the operator inequality
+\cite[Equation~(3.18)]{Wolf2012Quantum} that constrains the reduced densities
+of a bipartite state whose Schmidt number is at most $n$.
+
+\begin{theorem}[The reduction map is the family $T_\eta$ at integer parameter]
+    \label{thm:reduction_map_eq_t_eta}
+    \lean{Matrix.reductionMap_eq_tEta}
+    \leanok
+    \uses{def:reduction_map, def:t_eta}
+    For every $k\in\N$ the reduction map $T_k$ equals the family map $T_\eta$ at
+    $\eta=k$:
+    \[
+        T_k=T_{\eta=k}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The two maps differ only in the scalar coefficient of $X$, namely $k^{-1}$
+    against $\eta^{-1}$ at $\eta=k$.  The natural-number and real casts of $k$
+    into the complex scalars coincide, so the coefficients agree and the maps
+    are equal.
+\end{proof}
+
+\begin{definition}[Reduction witness]
+    \label{def:reduction_witness}
+    \lean{Matrix.reductionWitness}
+    \leanok
+    The reduction witness on $\MN{D}\otimes\MN{D}$, for $n\in\N$, is
+    \[
+        W_n=D^{-1}\Id-n^{-1}\ket{\Omega}\bra{\Omega}.
+    \]
+\end{definition}
+
+\begin{theorem}[The Choi matrix of the reduction map is the witness]
+    \label{thm:choi_matrix_reduction_witness}
+    \lean{ChoiJamiolkowski.choiMatrix_reductionMap_eq_reductionWitness}
+    \leanok
+    \uses{def:reduction_map, def:reduction_witness, thm:reduction_map_eq_t_eta,
+        thm:choi_matrix_t_eta}
+    For $D\ge 1$ the Choi matrix of $T_n$ is the reduction witness:
+    \[
+        \tau(T_n)=W_n=D^{-1}\Id-n^{-1}\ket{\Omega}\bra{\Omega}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The reduction map is $T_\eta$ at $\eta=n$, whose Choi matrix is
+    $D^{-1}\Id-n^{-1}\ket{\Omega}\bra{\Omega}$, which is exactly $W_n$.
+\end{proof}
+
+\begin{theorem}[Reduction-criterion identity]
+    \label{thm:tensor_map_id_t_eta}
+    \lean{Matrix.tensorMapId_tEta_eq}
+    \leanok
+    \uses{def:t_eta}
+    Applying $T_\eta$ to the first factor of a bipartite matrix $\rho$ gives
+    \[
+        (T_\eta\otimes\id)(\rho)=\Id\otimes\rho_2-\eta^{-1}\rho,
+    \]
+    where $\rho_2$ is the reduced density of $\rho$ on the second factor.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The $(i_2,j_2)$ slice of $\rho$ on the first factor has trace equal to the
+    $(i_2,j_2)$ entry of $\rho_2$.  Applying $T_\eta$ to each slice replaces the
+    trace term by that entry times the identity on the first factor, which is
+    the $\Id\otimes\rho_2$ term, and the second term is $\eta^{-1}\rho$.
+\end{proof}
+
+\begin{theorem}[Reduction criterion]
+    \label{thm:reduction_criterion}
+    \lean{Matrix.reductionCriterion_left, Matrix.reductionCriterion_right}
+    \leanok
+    \uses{def:t_eta, thm:tensor_map_id_t_eta}
+    Let $n\ge 1$ and let $\rho$ be a bipartite matrix.  If
+    $(T_n\otimes\id)(\rho)\ge 0$ then
+    \[
+        n\,\Id\otimes\rho_2\ge\rho,
+    \]
+    and if $(\id\otimes T_n)(\rho)\ge 0$ then
+    \[
+        n\,\rho_1\otimes\Id\ge\rho,
+    \]
+    where $\rho_1$ and $\rho_2$ are the reduced densities of $\rho$ on the first
+    and second factors.  This is the operator inequality
+    \cite[Equation~(3.18)]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By the reduction-criterion identity, $(T_n\otimes\id)(\rho)$ equals
+    $\Id\otimes\rho_2-n^{-1}\rho$.  Scaling a positive semidefinite operator by
+    $n>0$ preserves positivity, so $n\,\Id\otimes\rho_2-\rho\ge 0$, which is the
+    first inequality.  The second follows by swapping the two factors, applying
+    the first form, and swapping back, since positivity and the order are
+    invariant under the simultaneous factor swap.
+\end{proof}
+
 \begin{theorem}[Completely positive implies two-positive]
     \lean{IsCPMap.is2PositiveMap}
     \leanok

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1464,7 +1464,7 @@ of a bipartite state whose Schmidt number is at most $n$.
     For every $k\in\N$ the reduction map $T_k$ equals the family map $T_\eta$ at
     $\eta=k$:
     \[
-        T_k=T_{\eta=k}.
+        T_k=T_\eta\big|_{\eta=k}.
     \]
 \end{theorem}
 
@@ -1538,7 +1538,7 @@ of a bipartite state whose Schmidt number is at most $n$.
     $\Id\otimes\rho_2$.
 \end{proof}
 
-\begin{theorem}[Reduction criterion]
+\begin{theorem}[Operator-implication step of the reduction criterion]
     \label{thm:reduction_criterion}
     \lean{Matrix.reductionCriterion_left, Matrix.reductionCriterion_right}
     \leanok
@@ -1561,8 +1561,16 @@ of a bipartite state whose Schmidt number is at most $n$.
         (T_n\otimes\id)(\rho^{F})\ge 0,
     \]
     so the second hypothesis is Wolf's symmetric condition
-    $(\id\otimes T_n)(\rho)\ge 0$ expressed through the swap.  Together the two
-    inequalities are \cite[Equation~(3.18)]{Wolf2012Quantum}.
+    $(\id\otimes T_n)(\rho)\ge 0$ expressed through the swap.
+
+    This is the second step of Wolf's two-step argument for
+    \cite[Equation~(3.18)]{Wolf2012Quantum}.  The source states the inequalities
+    under the premise that $\rho$ has Schmidt number at most $n$, and reaches
+    $(T_n\otimes\id)(\rho)\ge 0$ from that premise by the $n$-positivity of
+    $T_n$; that first step is taken here as the hypothesis rather than derived,
+    because a Schmidt-number predicate is not yet available.  The deviation is
+    recorded in
+    \path{docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1518,10 +1518,24 @@ of a bipartite state whose Schmidt number is at most $n$.
 
 \begin{proof}
     \leanok
-    The $(i_2,j_2)$ slice of $\rho$ on the first factor has trace equal to the
-    $(i_2,j_2)$ entry of $\rho_2$.  Applying $T_\eta$ to each slice replaces the
-    trace term by that entry times the identity on the first factor, which is
-    the $\Id\otimes\rho_2$ term, and the second term is $\eta^{-1}\rho$.
+    Fix block indices $i_2,j_2$ on the second factor and write $\rho^{(i_2,j_2)}$
+    for the $D\times D$ slice $\rho^{(i_2,j_2)}_{i_1 j_1}=\rho_{(i_1,i_2),(j_1,j_2)}$
+    on the first factor.  Its trace is the corresponding entry of $\rho_2$:
+    \[
+        \tr\bigl(\rho^{(i_2,j_2)}\bigr)
+        =\sum_{i_1}\rho_{(i_1,i_2),(i_1,j_2)}
+        =(\rho_2)_{i_2 j_2}.
+    \]
+    Applying $T_\eta$ entry by entry gives
+    \[
+        \bigl((T_\eta\otimes\id)(\rho)\bigr)_{(i_1,i_2),(j_1,j_2)}
+        =\tr\bigl(\rho^{(i_2,j_2)}\bigr)\,\delta_{i_1 j_1}
+            -\eta^{-1}\rho_{(i_1,i_2),(j_1,j_2)}
+        =(\rho_2)_{i_2 j_2}\,\delta_{i_1 j_1}
+            -\eta^{-1}\rho_{(i_1,i_2),(j_1,j_2)},
+    \]
+    and the first term is exactly the $(i_1,i_2),(j_1,j_2)$ entry of
+    $\Id\otimes\rho_2$.
 \end{proof}
 
 \begin{theorem}[Reduction criterion]
@@ -1529,18 +1543,26 @@ of a bipartite state whose Schmidt number is at most $n$.
     \lean{Matrix.reductionCriterion_left, Matrix.reductionCriterion_right}
     \leanok
     \uses{def:t_eta, thm:tensor_map_id_t_eta}
-    Let $n\ge 1$ and let $\rho$ be a bipartite matrix.  If
-    $(T_n\otimes\id)(\rho)\ge 0$ then
+    Let $n\ge 1$ and let $\rho$ be a bipartite matrix, with $\rho^{F}$ its image
+    under the factor swap $\rho^{F}_{(i_2,i_1),(j_2,j_1)}=\rho_{(i_1,i_2),(j_1,j_2)}$.
+    If $(T_n\otimes\id)(\rho)\ge 0$ then
     \[
         n\,\Id\otimes\rho_2\ge\rho,
     \]
-    and if $(\id\otimes T_n)(\rho)\ge 0$ then
+    and if $(T_n\otimes\id)(\rho^{F})\ge 0$ then
     \[
         n\,\rho_1\otimes\Id\ge\rho,
     \]
     where $\rho_1$ and $\rho_2$ are the reduced densities of $\rho$ on the first
-    and second factors.  This is the operator inequality
-    \cite[Equation~(3.18)]{Wolf2012Quantum}.
+    and second factors.  Because the factor swap is a unitary reindexing,
+    \[
+        (\id\otimes T_n)(\rho)\ge 0
+        \iff
+        (T_n\otimes\id)(\rho^{F})\ge 0,
+    \]
+    so the second hypothesis is Wolf's symmetric condition
+    $(\id\otimes T_n)(\rho)\ge 0$ expressed through the swap.  Together the two
+    inequalities are \cite[Equation~(3.18)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}
@@ -1548,9 +1570,18 @@ of a bipartite state whose Schmidt number is at most $n$.
     By the reduction-criterion identity, $(T_n\otimes\id)(\rho)$ equals
     $\Id\otimes\rho_2-n^{-1}\rho$.  Scaling a positive semidefinite operator by
     $n>0$ preserves positivity, so $n\,\Id\otimes\rho_2-\rho\ge 0$, which is the
-    first inequality.  The second follows by swapping the two factors, applying
-    the first form, and swapping back, since positivity and the order are
-    invariant under the simultaneous factor swap.
+    first inequality.  For the second, the factor swap $F$ satisfies $F^2=\id$
+    and is a unitary reindexing, so it preserves positive semidefiniteness and
+    the order, and it exchanges the reduced densities and the two tensor slots:
+    \[
+        (\rho^{F})_2=\rho_1,
+        \qquad
+        \bigl(\Id\otimes(\rho^{F})_2-n^{-1}\rho^{F}\bigr)^{F}
+        =\rho_1\otimes\Id-n^{-1}\rho.
+    \]
+    Applying the first form to $\rho^{F}$ gives
+    $n\,\Id\otimes(\rho^{F})_2-\rho^{F}\ge 0$; conjugating by $F$ turns this into
+    $n\,\rho_1\otimes\Id-\rho\ge 0$.
 \end{proof}
 
 \begin{theorem}[Completely positive implies two-positive]

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -1,0 +1,122 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Schmidt-number premise of Wolf's reduction criterion (Wolf eq.~(3.18))}
+\author{}
+\date{2026-06-24}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+The reduction-criterion paragraph of Wolf's \emph{Quantum Channels \&
+Operations} (\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex},
+lines 329--338) introduces the maps $T_n(X)=\tr(X)\,\mathbf 1-X/n$, notes that
+each is $n$-positive and self-dual, and concludes that
+\begin{align}
+  n\,\rho_1\otimes\mathbf 1\ge\rho
+  \qquad\text{and}\qquad
+  n\,\mathbf 1\otimes\rho_2\ge\rho
+  \tag{3.18}
+\end{align}
+is \emph{necessary for a bipartite state $\rho$ to have Schmidt number $n$},
+with $\rho_1$ and $\rho_2$ the two reduced density matrices. The source assertion
+is the implication
+\begin{align}
+  \operatorname{sn}(\rho)\le n
+  \;\Longrightarrow\;
+  \bigl(n\,\rho_1\otimes\mathbf 1\ge\rho\ \text{and}\
+  n\,\mathbf 1\otimes\rho_2\ge\rho\bigr),
+  \tag{\path{source}}
+\end{align}
+where $\operatorname{sn}(\rho)$ is the Schmidt number of $\rho$. Its proof has
+two steps. A state of Schmidt number at most $n$ is a convex combination of
+pure states of Schmidt rank at most $n$, so $n$-positivity of $T_n$ gives
+\begin{align}
+  \operatorname{sn}(\rho)\le n
+  \;\Longrightarrow\;
+  (T_n\otimes\operatorname{id})(\rho)\ge 0,
+  \tag{step 1}
+\end{align}
+and the algebraic identity $(T_n\otimes\operatorname{id})(\rho)=\mathbf 1\otimes\rho_2-n^{-1}\rho$
+then yields
+\begin{align}
+  (T_n\otimes\operatorname{id})(\rho)\ge 0
+  \;\Longrightarrow\;
+  n\,\mathbf 1\otimes\rho_2\ge\rho,
+  \tag{step 2}
+\end{align}
+with the companion inequality obtained from the swapped state.
+
+\section{Formalized statement}
+
+The formal theorems\footnote{Formal declarations:
+    \leanid{Matrix.reductionCriterion_left} and
+    \leanid{Matrix.reductionCriterion_right} in
+    \doclink{TNLean/Channel/ReductionCriterion}.} establish step~2 only. For a
+bipartite matrix $\rho$ and $n\ge 1$,
+\begin{align}
+  (T_n\otimes\operatorname{id})(\rho)\ge 0
+  &\;\Longrightarrow\;
+  n\,\mathbf 1\otimes\rho_2\ge\rho,\\
+  (T_n\otimes\operatorname{id})(\rho^{F})\ge 0
+  &\;\Longrightarrow\;
+  n\,\rho_1\otimes\mathbf 1\ge\rho,
+\end{align}
+where $\rho^{F}$ is the image of $\rho$ under the factor swap and the second
+hypothesis equals Wolf's symmetric condition $(\operatorname{id}\otimes T_n)(\rho)\ge 0$. The
+underlying identity $(T_n\otimes\operatorname{id})(\rho)=\mathbf 1\otimes\rho_2-n^{-1}\rho$ is
+also formalized.\footnote{Formal declaration:
+    \leanid{Matrix.tensorMapId_tEta_eq}.}
+
+\section{The gap}
+
+The formalized statement carries the hypothesis $(T_n\otimes\operatorname{id})(\rho)\ge 0$,
+which is the intermediate produced by step~1 rather than the source premise
+$\operatorname{sn}(\rho)\le n$. Step~1 is not yet formalized because the
+repository has no Schmidt-number predicate for mixed states, equivalently no
+separable-state predicate from which the Schmidt-number filtration is built. The
+same missing foundation is the obstruction to the separability extension of the
+reduction criterion as an entanglement criterion.
+
+The $n$-positivity content needed for step~1 is itself available: the map $T_n$
+is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
+    \leanid{Matrix.isNPositiveMap_tEta_iff} in
+    \doclink{TNLean/Channel/NPositivityChainStrict}, the reduction map being
+    $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.} What is
+absent is the predicate $\operatorname{sn}(\rho)\le n$ and the lemma that it
+implies $\rho$ lies in the cone on which the $n$-positive ampliation acts
+positively.
+
+\section{Elimination plan}
+
+Introduce a Schmidt-number predicate for bipartite matrices, built from a
+separable-state predicate, and prove step~1: a state of Schmidt number at most
+$n$ has $(T_n\otimes\operatorname{id})(\rho)\ge 0$, by writing it as a convex combination of
+Schmidt-rank-$\le n$ pure states and applying the $n$-positivity already
+formalized. Composing step~1 with the formalized step~2 recovers Wolf's
+eq.~(3.18) with its Schmidt-number premise. The separability foundation is
+shared with the entanglement-criterion extension and is tracked alongside the
+PPT and Schmidt-number formalization tasks.
+
+\section{Classification}
+
+\emph{Scope restriction.} The formal theorems prove the second step of Wolf's
+two-step argument: the operator implication from $(T_n\otimes\operatorname{id})(\rho)\ge 0$ to
+the inequalities of eq.~(3.18). The conclusions match the source exactly; the
+hypothesis is the derived intermediate of step~1, so the formalized statement is
+strictly weaker than, and is a sub-step of, the source implication. No
+hypothesis foreign to the source is introduced, so the deviation is a scope
+restriction rather than an unfaithful theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation

- Wolf Chapter 3, Example 3.1 (eq. (3.18)) identifies the reduction map `T_n(X) = tr[X]·1 − X/n` as an `n`-positive map satisfying the operator implications `n·(1 ⊗ ρ₂) ≥ ρ` and `n·(ρ₁ ⊗ 1) ≥ ρ`. This PR formalizes the separability-free content of eq. (3.18), addressing the reduction-criterion sub-task of LionSR/QICLean#21. Source: `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, Example 3.1, lines ~307–400.
- The existing development contained two definitionally equal maps (`Matrix.reductionMap` in `PositiveExamples.lean` and `Matrix.tEta` in `NPositivityChainStrict.lean`) in separate files; a bridge lemma is needed to unify the n-positivity threshold, Choi formula, and self-duality theory under a single object.

### Description

- New module `TNLean/Channel/ReductionCriterion.lean` (225 lines, sorry-free and axiom-free):
  - `Matrix.reductionMap_eq_tEta`: bridge proving `reductionMap D k = tEta D (k : ℝ)`, identifying the two prior definitions as the same map.
  - `ChoiJamiolkowski.choiMatrix_reductionMap_eq_choiMatrix_tEta`: corollary at the Choi matrix level.
  - `Matrix.reductionWitness D n` defined as `D⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|`; `ChoiJamiolkowski.choiMatrix_reductionMap_eq_reductionWitness` proves `τ(T_n) = W_n`.
  - `Matrix.tensorMapId_tEta_eq`: exact bipartite identity `(T_η ⊗ id)(ρ) = (1 ⊗ ρ₂) − η⁻¹ · ρ` (Wolf eq. (3.18)).
  - `Matrix.reductionCriterion_left` and `Matrix.reductionCriterion_right`: operator implications `(T_n ⊗ id)(ρ) ≥ 0 ⟹ n·(1 ⊗ ρ₂) ≥ ρ` and the symmetric `n·(ρ₁ ⊗ 1) ≥ ρ`, where `ρ₁ = traceRight ρ`, `ρ₂ = traceLeft ρ` (`PartialTrace.lean`); Loewner order via Mathlib `MatrixOrder`.
- `TNLean.lean`: imports `TNLean.Channel.ReductionCriterion`.
- `blueprint/src/chapter/ch05_schwarz.tex`: new subsection "The reduction criterion" citing Wolf eq. (3.18), with `\lean{}` and `\leanok` tags for each headline declaration.
- The separability-based entanglement criterion (`ρ separable ⟹` eq. (3.18)) is out of scope pending a separable-state predicate; PPT, Breuer–Hall, and Choi-type maps remain as sub-tasks of LionSR/QICLean#21.

### Testing

- `lake build TNLean.Channel.ReductionCriterion` — green (3008 jobs).
- `rg -nw "sorry|admit|native_decide|axiom"` on the new file — clean.
- Blueprint sync (`blueprint_lean_sync.py --ci`) — "Blueprint and Lean in sync"; `--warn-missing-blueprint` reports no changed declaration missing a blueprint entry.
- `check_reader_facing_prose.py --diff-base origin/main` — no violations.
- Lean CI (`lean_action_ci.yml`) will validate the full build on merge.

---
Addresses LionSR/QICLean#21

> [!NOTE]
> **Low Risk**
> Additive formal proofs on existing channel/tensor infrastructure; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **Wolf Chapter 3 reduction criterion** (eq. 3.18) as a new Lean module and matching blueprint subsection, wired into the public import surface.
> 
> The new file proves that `reductionMap` and `tEta` are the same map at integer parameters (`reductionMap_eq_tEta`), introduces **`reductionWitness`** \(W_n = D^{-1}1 - n^{-1}|\Omega\rangle\langle\Omega|\) and shows it is the Choi operator of the reduction map. It proves the bipartite identity **`(T_\eta \otimes \mathrm{id})(\rho) = 1 \otimes \rho_2 - \eta^{-1}\rho`** and the operator implications **`reductionCriterion_left`** / **`reductionCriterion_right`**: positivity of the tensor-extended map yields \(n \cdot (1 \otimes \rho_2) \ge \rho\) and the symmetric bound on the other factor (via factor swap). Separability-based entanglement wording is explicitly out of scope.
> 
> `TNLean.lean` imports `TNLean.Channel.ReductionCriterion`; `ch05_schwarz.tex` gains subsection *The reduction criterion* with `\lean{}` links for each headline result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46f96087aaa7104d416fab0ba274b17856b30c38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proofs and documentation on existing channel infrastructure; no runtime, security, or data-path changes.
> 
> **Overview**
> Adds **Wolf’s reduction criterion** (eq. 3.18) as a new Lean module and a matching blueprint subsection, wired into the public import surface.
> 
> The new **`TNLean/Channel/ReductionCriterion`** file proves **`reductionMap_eq_tEta`**, so existing **`reductionMap`** and **`tEta`** theory is one object; it introduces **`reductionWitness`** \(W_n\) and shows it is the Choi operator of the reduction map. It proves **`tensorMapId_tEta_eq`** and the operator implications **`reductionCriterion_left`** / **`reductionCriterion_right`** (positivity of the tensor-extended map yields the reduced-density Loewner bounds; the symmetric case uses a factor swap). The Schmidt-number premise of Wolf’s full statement is **not** derived—only the algebraic “step 2” is formalized, with scope documented in **`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`**.
> 
> **`TNLean.lean`** imports the new module; **`ch05_schwarz.tex`** gains subsection *The reduction criterion* with `\lean{}` links for each headline result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c2bf1828d88567deddcc44a3d35f1671c93d6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->