### PR TITLE
feat(Channel/Schwarz): unitary invariance of quantum relative entropy (#784)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -109,6 +109,7 @@ import TNLean.Channel.Schwarz.OperatorConvexity
 import TNLean.Channel.Schwarz.OperatorMonotone
 import TNLean.Channel.Schwarz.AndoLieb
 import TNLean.Channel.Schwarz.RelativeEntropyConvexity
+import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
 import TNLean.Channel.Schwarz.PositiveOnAbelian
 import TNLean.Channel.Schwarz.SchwarzNormal
 import TNLean.Channel.Schwarz.SchwarzSubnormal

--- a/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Analysis.KleinInequality
+
+/-!
+# Unitary invariance of the quantum relative entropy
+
+This file proves the **unitary invariance** of the quantum relative entropy
+$D(\rho\|\sigma) = \operatorname{Re}\operatorname{tr}(\rho(\log\rho - \log\sigma))$:
+for every unitary $U$,
+$D(U\rho U^\dagger \,\|\, U\sigma U^\dagger) = D(\rho\|\sigma)$.
+
+Unitary invariance is one of the three ingredients of the data-processing
+inequality under the partial trace (layer 5 of the route note), alongside joint
+convexity (layer 4, `convexOn_quantumRelativeEntropy`) and ancilla additivity.
+
+## Main results
+
+* `Matrix.cfc_conj_unitary` — covariance of the continuous functional calculus
+  under conjugation by a unitary: $f(U A U^\dagger) = U\,f(A)\,U^\dagger$. This is
+  the matrix instance of the fact that the continuous functional calculus
+  commutes with the star-algebra automorphism $x \mapsto U x U^\dagger$.
+* `Matrix.log_conj_unitary` — the special case $f = \log$:
+  $\log(U A U^\dagger) = U\,(\log A)\,U^\dagger$.
+* `quantumRelativeEntropy_conj_unitary` — unitary invariance of the relative
+  entropy: $D(U\rho U^\dagger \,\|\, U\sigma U^\dagger) = D(\rho\|\sigma)$.
+
+## Proof outline
+
+The functional calculus covariance is the general lemma that a continuous
+star-algebra homomorphism commutes with the continuous functional calculus,
+specialized to the conjugation automorphism $x \mapsto U x U^\dagger$ on the
+finite-dimensional matrix algebra; the four side conditions (continuity of $f$
+on the finite spectrum, continuity of the automorphism on a finite-dimensional
+space, and self-adjointness of $A$ and of its conjugate) are all dispatched
+directly. The relative-entropy invariance then follows by applying the
+covariance to $\log\rho$ and $\log\sigma$ and using trace cyclicity to cancel the
+conjugating unitaries.
+
+## References
+
+* Layer 5 (data processing) of the relative-entropy elimination route for strong
+  subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
+  (Distance Measures)][Wolf2012QChannels].
+-/
+
+open scoped Matrix ComplexOrder Matrix.Norms.L2Operator
+open Matrix Finset
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Covariance of the continuous functional calculus under unitary
+conjugation.** For a Hermitian matrix $A$, a real function $f$, and a unitary
+$U$, the continuous functional calculus satisfies
+$f(U A U^\dagger) = U\,f(A)\,U^\dagger$.
+
+This is the matrix instance of the general fact that the continuous functional
+calculus commutes with the continuous star-algebra automorphism
+$x \mapsto U x U^\dagger$ (`Unitary.conjStarAlgAut`). -/
+theorem cfc_conj_unitary {A : Matrix n n ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ)
+    (U : unitary (Matrix n n ℂ)) :
+    cfc f ((U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ))
+      = (U : Matrix n n ℂ) * cfc f A * star (U : Matrix n n ℂ) := by
+  set φ := Unitary.conjStarAlgAut ℂ (Matrix n n ℂ) U with hφ
+  have hcont : ContinuousOn f (spectrum ℝ A) := A.finite_real_spectrum |>.continuousOn f
+  have hcontφ : Continuous φ :=
+    LinearMap.continuous_of_finiteDimensional ((φ : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ))
+  have hsa : IsSelfAdjoint A := hA
+  have happ : ∀ x, φ x = (U : Matrix n n ℂ) * x * star (U : Matrix n n ℂ) :=
+    fun x => Unitary.conjStarAlgAut_apply U x
+  have hsa' : IsSelfAdjoint (φ A) := by rw [happ]; exact hsa.conjugate (U : Matrix n n ℂ)
+  have hconj := StarAlgHomClass.map_cfc φ f A hcont hcontφ hsa hsa'
+  rw [happ, happ] at hconj
+  exact hconj.symm
+
+/-- **The matrix logarithm is covariant under unitary conjugation.** For a
+Hermitian matrix $A$ and a unitary $U$,
+$\log(U A U^\dagger) = U\,(\log A)\,U^\dagger$. The special case $f = \log$ of
+`cfc_conj_unitary`. -/
+theorem log_conj_unitary {A : Matrix n n ℂ} (hA : A.IsHermitian)
+    (U : unitary (Matrix n n ℂ)) :
+    CFC.log ((U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ))
+      = (U : Matrix n n ℂ) * CFC.log A * star (U : Matrix n n ℂ) := by
+  rw [CFC.log, CFC.log, cfc_conj_unitary hA Real.log U]
+
+end Matrix
+
+/-- **Unitary invariance of the quantum relative entropy.** For Hermitian
+matrices $\rho, \sigma$ and a unitary $U$,
+$D(U\rho U^\dagger \,\|\, U\sigma U^\dagger) = D(\rho\|\sigma)$.
+
+The logarithms are carried through the conjugation by `Matrix.log_conj_unitary`,
+and the conjugating unitaries cancel under trace cyclicity. This is one of the
+three ingredients of the data-processing inequality under the partial trace
+(layer 5 of `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`). -/
+theorem quantumRelativeEntropy_conj_unitary {n : Type*} [Fintype n] [DecidableEq n]
+    {ρ σ : Matrix n n ℂ} (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian)
+    (U : unitary (Matrix n n ℂ)) :
+    quantumRelativeEntropy ((U : Matrix n n ℂ) * ρ * star (U : Matrix n n ℂ))
+        ((U : Matrix n n ℂ) * σ * star (U : Matrix n n ℂ))
+      = quantumRelativeEntropy ρ σ := by
+  set Um : Matrix n n ℂ := (U : Matrix n n ℂ) with hUm
+  have hUstarU : star Um * Um = 1 := Unitary.star_mul_self_of_mem U.prop
+  rw [quantumRelativeEntropy, quantumRelativeEntropy,
+    Matrix.log_conj_unitary hρ U, Matrix.log_conj_unitary hσ U]
+  congr 1
+  have key : Um * ρ * star Um * (Um * CFC.log ρ * star Um - Um * CFC.log σ * star Um)
+      = Um * (ρ * (CFC.log ρ - CFC.log σ)) * star Um := by
+    rw [Matrix.mul_sub, Matrix.mul_sub,
+      show Um * ρ * star Um * (Um * CFC.log ρ * star Um)
+          = Um * ρ * (star Um * Um) * CFC.log ρ * star Um by noncomm_ring,
+      show Um * ρ * star Um * (Um * CFC.log σ * star Um)
+          = Um * ρ * (star Um * Um) * CFC.log σ * star Um by noncomm_ring,
+      hUstarU]
+    noncomm_ring
+  rw [key, Matrix.trace_mul_cycle, ← Matrix.mul_assoc, hUstarU, Matrix.one_mul]

--- a/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
@@ -49,7 +49,7 @@ conjugating unitaries.
 -/
 
 open scoped Matrix ComplexOrder Matrix.Norms.L2Operator
-open Matrix Finset
+open Matrix
 
 namespace Matrix
 

--- a/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
@@ -48,8 +48,7 @@ conjugating unitaries.
   (Distance Measures)][Wolf2012QChannels].
 -/
 
-open scoped Matrix ComplexOrder Matrix.Norms.L2Operator
-open Matrix
+open scoped Matrix.Norms.L2Operator
 
 namespace Matrix
 

--- a/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
@@ -13,7 +13,8 @@ for every unitary $U$,
 $D(U\rho U^\dagger \,\|\, U\sigma U^\dagger) = D(\rho\|\sigma)$.
 
 Unitary invariance is one of the three ingredients of the data-processing
-inequality under the partial trace (layer 5 of the route note), alongside joint
+inequality under the partial trace (layer 5 of the SSA-from-Lieb elimination
+route, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`), alongside joint
 convexity (layer 4, `convexOn_quantumRelativeEntropy`) and ancilla additivity.
 
 ## Main results
@@ -34,7 +35,7 @@ star-algebra homomorphism commutes with the continuous functional calculus,
 specialized to the conjugation automorphism $x \mapsto U x U^\dagger$ on the
 finite-dimensional matrix algebra; the four side conditions (continuity of $f$
 on the finite spectrum, continuity of the automorphism on a finite-dimensional
-space, and self-adjointness of $A$ and of its conjugate) are all dispatched
+space, and self-adjointness of $A$ and of its conjugate) are all verified
 directly. The relative-entropy invariance then follows by applying the
 covariance to $\log\rho$ and $\log\sigma$ and using trace cyclicity to cancel the
 conjugating unitaries.
@@ -94,9 +95,14 @@ end Matrix
 matrices $\rho, \sigma$ and a unitary $U$,
 $D(U\rho U^\dagger \,\|\, U\sigma U^\dagger) = D(\rho\|\sigma)$.
 
-The logarithms are carried through the conjugation by `Matrix.log_conj_unitary`,
-and the conjugating unitaries cancel under trace cyclicity. This is one of the
-three ingredients of the data-processing inequality under the partial trace
+The logarithms conjugate as $\log(U\rho U^\dagger) = U(\log\rho)U^\dagger$
+(`Matrix.log_conj_unitary`, applied to $\rho$ and $\sigma$), giving
+$$D(U\rho U^\dagger \,\|\, U\sigma U^\dagger)
+  = \operatorname{Re}\operatorname{tr}\!\bigl(U\rho(\log\rho-\log\sigma)U^\dagger\bigr)
+  = \operatorname{Re}\operatorname{tr}\!\bigl(\rho(\log\rho-\log\sigma)\bigr)
+  = D(\rho\|\sigma),$$
+where the middle equality is trace cyclicity ($U^\dagger U = 1$). This is one of
+the three ingredients of the data-processing inequality under the partial trace
 (layer 5 of `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`). -/
 theorem quantumRelativeEntropy_conj_unitary {n : Type*} [Fintype n] [DecidableEq n]
     {ρ σ : Matrix n n ℂ} (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian)

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -336,6 +336,48 @@ finite-dimensional quantum systems.
     convex.
 \end{proof}
 
+\begin{lemma}[Matrix logarithm under unitary conjugation]
+    \label{lem:log_conj_unitary}
+    \lean{Matrix.log_conj_unitary}
+    \leanok
+    For a Hermitian matrix $A$ and a unitary $U$,
+    \[
+        \log(U A U^\dagger) = U\,(\log A)\,U^\dagger.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The conjugation $x \mapsto U x U^\dagger$ is a star-algebra automorphism of
+    the matrix algebra, and the continuous functional calculus commutes with such
+    automorphisms; applying this with the real logarithm gives the identity.
+\end{proof}
+
+\begin{theorem}[Unitary invariance of the quantum relative entropy]
+    \label{thm:relative_entropy_unitary_invariance}
+    \lean{quantumRelativeEntropy_conj_unitary}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    For Hermitian matrices $\rho, \sigma$ and a unitary $U$,
+    \[
+        D(U\rho U^\dagger \,\Vert\, U\sigma U^\dagger) = D(\rho\Vert\sigma).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:log_conj_unitary}
+    Carry the two logarithms through the conjugation by
+    Lemma~\ref{lem:log_conj_unitary}, so that
+    \[
+        D(U\rho U^\dagger \,\Vert\, U\sigma U^\dagger)
+            = \operatorname{Re}\operatorname{tr}\!\bigl(
+                U\rho(\log\rho-\log\sigma)U^\dagger\bigr)
+            = \operatorname{Re}\operatorname{tr}\!\bigl(
+                \rho(\log\rho-\log\sigma)\bigr)
+            = D(\rho\Vert\sigma),
+    \]
+    where the middle equality is trace cyclicity together with $U^\dagger U = 1$.
+\end{proof}
+
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}
     \lean{vonNeumannEntropy_submatrix_equiv}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -336,6 +336,24 @@ finite-dimensional quantum systems.
     convex.
 \end{proof}
 
+\begin{lemma}[Functional calculus under unitary conjugation]
+    \label{lem:cfc_conj_unitary}
+    \lean{Matrix.cfc_conj_unitary}
+    \leanok
+    For a Hermitian matrix $A$, a real function $f$, and a unitary $U$, the
+    continuous functional calculus satisfies
+    \[
+        f(U A U^\dagger) = U\,f(A)\,U^\dagger.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    The conjugation $\varphi : x \mapsto U x U^\dagger$ is a star-algebra
+    automorphism of the matrix algebra, and the continuous functional calculus
+    commutes with such automorphisms, $\varphi(f(A)) = f(\varphi(A))$; since
+    $\varphi(A) = U A U^\dagger$, this is the claim.
+\end{proof}
+
 \begin{lemma}[Matrix logarithm under unitary conjugation]
     \label{lem:log_conj_unitary}
     \lean{Matrix.log_conj_unitary}
@@ -347,9 +365,12 @@ finite-dimensional quantum systems.
 \end{lemma}
 
 \begin{proof}\leanok
-    The conjugation $x \mapsto U x U^\dagger$ is a star-algebra automorphism of
-    the matrix algebra, and the continuous functional calculus commutes with such
-    automorphisms; applying this with the real logarithm gives the identity.
+    \uses{lem:cfc_conj_unitary}
+    This is the $f = \log$ case of Lemma~\ref{lem:cfc_conj_unitary}: with
+    $f(U A U^\dagger) = U\,f(A)\,U^\dagger$ specialized to the real logarithm,
+    \[
+        \log(U A U^\dagger) = U\,(\log A)\,U^\dagger.
+    \]
 \end{proof}
 
 \begin{theorem}[Unitary invariance of the quantum relative entropy]

--- a/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
+++ b/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
@@ -49,9 +49,11 @@ layers that are missing.
 \section{The point at issue}
 
 The standard derivation of~\eqref{eq:ssa} factors through the quantum relative
-entropy and its behaviour under coarse-graining. None of the intermediate
-objects is currently available, so the gap is not a single missing lemma but a
-chain of them. In source order the chain is the following.
+entropy and its behaviour under coarse-graining. Several of the intermediate
+objects are now formalized and several are still missing, so the gap is not a
+single missing lemma but a chain of them; the per-layer status is recorded below
+and summarized under \emph{Current formal status}. In source order the chain is
+the following.
 
 \begin{enumerate}
   \item \emph{Entropy bridge.} The identity
@@ -265,12 +267,15 @@ in place. Concretely:
 \paragraph{Current formal status.} Layers (1)--(4) and the layer-(6) marginal
 support prerequisite are formalized; layer (4) on the positive-definite domain
 (\leanid{convexOn_quantumRelativeEntropy}). Layer (5), data-processing
-(monotonicity of $D$ under the partial trace), remains open: it combines the
-layer-(4) joint convexity with unitary invariance and ancilla-additivity
+(monotonicity of $D$ under the partial trace), is partly formalized. It combines
+the layer-(4) joint convexity with unitary invariance and ancilla-additivity
 $D(\rho\otimes\tau\,\|\,\sigma\otimes\tau) = D(\rho\,\|\,\sigma)$ via the
-twirling representation of $\tr_C$, none of which is yet formalized. Until
-layer (5) and the layer-(6) instantiation are in place the standalone axiom
-\leanid{strong_subadditivity} stands.
+twirling representation of $\tr_C$. Joint convexity (layer 4, on the
+positive-definite domain) and unitary invariance
+(\leanid{quantumRelativeEntropy_conj_unitary}, for arbitrary Hermitian
+arguments) are formalized; ancilla-additivity and the twirling representation of
+$\tr_C$ remain open. Until those two ingredients and the layer-(6) instantiation
+are in place the standalone axiom \leanid{strong_subadditivity} stands.
 
 After layer (6) the inequality is a theorem, the standalone axiom is removed, and
 the only remaining entropy-side axiom on this route is the Lieb-concavity axiom.

--- a/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
+++ b/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
@@ -217,10 +217,32 @@ in place. Concretely:
     Lieb input. The extension from the positive-definite case to singular
     reference states under $\ker\sigma\subseteq\ker\rho$ (the regularization
     step described above) remains open.
-  \item Layer (5) packages joint convexity, unitary invariance, and
+  \item Layer (5) combines joint convexity, unitary invariance, and
     ancilla-additivity $D(\rho\otimes\tau\,\|\,\sigma\otimes\tau)
     = D(\rho\,\|\,\sigma)$ into the partial-trace monotonicity statement via the
-    twirling representation of $\tr_C$.
+    twirling representation of $\tr_C$. The unitary-invariance ingredient is now
+    formalized for arbitrary Hermitian arguments:
+    \leanid{quantumRelativeEntropy_conj_unitary} in
+    \doclink{TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance}
+    (\path{TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean}) proves
+    $D(U\rho U^\dagger\,\|\,U\sigma U^\dagger) = D(\rho\,\|\,\sigma)$ for every
+    unitary $U$, by the covariance of the matrix logarithm under unitary
+    conjugation (\leanid{Matrix.log_conj_unitary}, itself the $f=\log$ case of the
+    functional-calculus covariance \leanid{Matrix.cfc_conj_unitary}) followed by
+    trace cyclicity. This ingredient needs no Lieb input. The remaining
+    ingredients of layer (5) are open: ancilla-additivity, which reduces to the
+    logarithm of a tensor product
+    $\log(\rho\otimes\tau) = \log\rho\otimes\mathbf 1 + \mathbf 1\otimes\log\tau$
+    --- the one-sided splits $\log(A\otimes\mathbf 1) = \log A\otimes\mathbf 1$ and
+    $\log(\mathbf 1\otimes B) = \mathbf 1\otimes\log B$ follow from the same
+    functional-calculus covariance applied to the unital tensor embeddings, but
+    recombining them needs the logarithm of a commuting product
+    $\log(XY) = \log X + \log Y$ for commuting positive definite $X,Y$, a lemma
+    not yet available; and the twirling identity itself, which writes
+    $\tr_C\rho\otimes(\mathbf 1_C/d_C)$ as a uniform average of conjugations by a
+    unitary $1$-design on $C$ and requires either a Haar measure on the unitary
+    group (absent from the matrix unitary group in the current dependency) or a
+    finite $1$-design averaged by a finite sum.
   \item Layer (6) instantiates layer (5) at the tripartite splitting to
     recover~\eqref{eq:ssa}; it additionally needs the marginal support
     lemma~\eqref{eq:marginal-support}, which puts the singular reference state
@@ -270,10 +292,13 @@ assembly at the tripartite splitting. Layers (2) and (3) are formalized (the
 latter for full-rank $\sigma$), and layer (4) is formalized on the
 positive-definite domain (\leanid{convexOn_quantumRelativeEntropy}), so the
 Lieb-concavity axiom is now connected to the joint convexity of the relative
-entropy. The remaining work is the singular-$\sigma$ extension of layers (3) and
-(4) and the data-processing and assembly layers (5)--(6); until those are
-formalized, the standalone axiom records a result the development assumes but
-does not yet derive from its operator-convexity input.
+entropy. The unitary-invariance ingredient of layer (5) is formalized for
+arbitrary Hermitian arguments (\leanid{quantumRelativeEntropy_conj_unitary}). The
+remaining work is the singular-$\sigma$ extension of layers (3) and (4), the
+ancilla-additivity and twirling ingredients of the data-processing layer (5),
+and the assembly layer (6); until those are formalized, the standalone axiom
+records a result the development assumes but does not yet derive from its
+operator-convexity input.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
## What landed

Toward discharging the sanctioned `strong_subadditivity` axiom (#784, #3375) via
the relative-entropy / Lieb-concavity route, this PR formalizes the
**unitary-invariance** ingredient of layer 5 (data processing) of
`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.

New file `TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean`:

- `Matrix.cfc_conj_unitary` — covariance of the continuous functional calculus
  under conjugation by a unitary: `cfc f (U * A * star U) = U * cfc f A * star U`
  for Hermitian `A`. Proved by specializing `StarAlgHomClass.map_cfc` to the
  conjugation star-algebra automorphism `Unitary.conjStarAlgAut`, dispatching the
  four side conditions directly (continuity of `f` on the finite matrix spectrum,
  continuity of the automorphism on a finite-dimensional space, self-adjointness
  of `A` and of its conjugate).
- `Matrix.log_conj_unitary` — the `f = Real.log` case:
  `CFC.log (U * A * star U) = U * CFC.log A * star U`.
- `quantumRelativeEntropy_conj_unitary` — **unitary invariance of the quantum
  relative entropy**: `D(U ρ U† ‖ U σ U†) = D(ρ ‖ σ)` for arbitrary Hermitian
  `ρ, σ` and any unitary `U`. Proved by carrying the two logarithms through the
  conjugation and cancelling the conjugating unitaries under trace cyclicity.

The relative-entropy statement is **fully general** (any Hermitian arguments, no
positive-definite restriction), so it carries no scope-restriction marker.

Also updates the route note to record the landed ingredient and the remaining
layer-5 blockers.

## Layers landed vs remaining

- Layers 2, 3 (full-rank σ), 4 (PD domain): already in `main` (#3490 et al.).
- **Layer 5, unitary invariance: landed here.**
- Layer 5 remaining: **ancilla additivity** and the **twirling identity** — both
  precisely blocked (see below).
- Layer 6: needs layer 5.

`strong_subadditivity` is **not** yet recovered as a theorem — this PR lands one
of the three named ingredients of the data-processing layer.

## `#print axioms`

```
'quantumRelativeEntropy_conj_unitary' depends on axioms: [propext, Classical.choice, Quot.sound]
'Matrix.log_conj_unitary'             depends on axioms: [propext, Classical.choice, Quot.sound]
'Matrix.cfc_conj_unitary'             depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `sorry`, no `native_decide`, no new axiom, no `lieb_concavity_axiom`, no
`strong_subadditivity`.

## Precise remaining blockers for full layer 5 (for #784)

1. **Ancilla additivity** `D(ρ⊗τ ‖ σ⊗τ) = D(ρ ‖ σ)`. The one-sided functional
   calculus splits `cfc f (A ⊗ₖ 1) = (cfc f A) ⊗ₖ 1` and
   `cfc f (1 ⊗ₖ B) = 1 ⊗ₖ (cfc f B)` are reachable by the same
   `StarAlgHomClass.map_cfc` route applied to the unital tensor embeddings
   `A ↦ A ⊗ₖ 1` and `B ↦ 1 ⊗ₖ B` as continuous `StarAlgHom`s (verified to compile
   in a prototype). The missing piece is the **logarithm of a commuting product**
   `CFC.log (X * Y) = CFC.log X + CFC.log Y` for commuting positive definite
   `X, Y` — needed to recombine `log(ρ⊗1)` and `log(1⊗τ)` into `log(ρ⊗τ)`. This is
   an explicitly listed TODO in Mathlib's
   `Analysis/SpecialFunctions/ContinuousFunctionalCalculus/ExpLog/Basic.lean`
   ("Show that `log (a * b) = log a + log b` whenever `a` and `b` commute").
2. **Twirling identity** `tr_C(ρ) ⊗ (1_C/d_C) = average over a unitary 1-design`.
   `Matrix.unitaryGroup` has **no `TopologicalSpace`/Haar-measure instance** in
   Mathlib v4.31.0, so the Haar-average form is unavailable. The feasible
   substitute is a **finite** unitary 1-design (e.g. the Heisenberg–Weyl group)
   averaged by a finite sum, which requires constructing the design and proving
   the averaging identity entrywise — not yet present in the repo or Mathlib.

Closest existing infrastructure used / surveyed: `StarAlgHomClass.map_cfc`,
`Unitary.conjStarAlgAut`, `LinearMap.continuous_of_finiteDimensional`,
`IsSelfAdjoint.conjugate`, `Matrix.trace_mul_cycle`; partial-trace lemmas in
`TNLean/Channel/PartialTrace.lean` (`traceLeft_kronecker`, `traceRight_kronecker`,
`traceLeft_one`, `traceRight_one`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib-style matrix/entropy lemmas with no auth, IO, or axiom changes beyond standard Lean foundations; scope is additive documentation and one new proof file.
> 
> **Overview**
> Adds **unitary invariance** of quantum relative entropy as a proved Lean layer toward SSA-from-Lieb layer 5 (data processing): `D(UρU† ‖ UσU†) = D(ρ ‖ σ)` for Hermitian `ρ, σ` and any unitary `U`.
> 
> New module `RelativeEntropyUnitaryInvariance.lean` proves `Matrix.cfc_conj_unitary` and `Matrix.log_conj_unitary` via `StarAlgHomClass.map_cfc` on the conjugation automorphism, then `quantumRelativeEntropy_conj_unitary` by pushing logs through conjugation and using trace cyclicity. The module is wired into the root import `TNLean.lean`.
> 
> The blueprint chapter 19 gains matching lemmas and `thm:relative_entropy_unitary_invariance` with `\leanok` links. The route note `cpsv16_ssa_from_lieb_route.tex` is updated to mark layer-(5) **unitary invariance** as formalized and to leave **ancilla additivity** and the **twirling** step as open blockers; `strong_subadditivity` remains an axiom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b85391e5d692db0a91fc09e5758557d5e26fde38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->