### PR TITLE
feat(Channel): bipartite partial transpose and PPT criterion

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -117,6 +117,7 @@ import TNLean.Channel.Schwarz.TwoPositive
 import TNLean.Channel.Schwarz.ChoiCompression
 import TNLean.Channel.NPositivityChainStrict
 import TNLean.Channel.ReductionCriterion
+import TNLean.Channel.PartialTranspose
 import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers
 import TNLean.Channel.Schwarz.MultiplicativeDomainFull

--- a/TNLean/Channel/PartialTranspose.lean
+++ b/TNLean/Channel/PartialTranspose.lean
@@ -1,0 +1,339 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.MaximallyEntangled
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.Analysis.Matrix.PosDef
+
+/-!
+# Bipartite partial transpose and the PPT property
+
+Wolf's Chapter 3, Example 3.1 introduces the **partial transpose** `ρ^{T₁}` of a
+bipartite operator `ρ ∈ M_d ⊗ M_{d'}` and the associated **PPT (positive partial
+transpose)** property `ρ^{T₁} ≥ 0`.  The partial transpose transposes the first
+tensor factor while leaving the second untouched:
+
+  `(ρ^{T₁})_{(i,k),(j,l)} = ρ_{(j,k),(i,l)}`.
+
+This file formalizes the separability-free content of the PPT material of
+Wolf eq. (3.16)--(3.17): the partial transpose itself, its basic algebraic
+properties (involution, trace preservation, Hermiticity preservation), the
+second-factor variant and its relation to the first-factor one through a global
+transposition, the PPT property as a predicate, its equivalence between the two
+factors, and the transposition witnesses `W = (A ⊗ B) F (A ⊗ B)†` of
+Wolf eq. (3.16).
+
+## Main definitions
+
+* `Matrix.partialTransposeLeft` (`ρ^{T₁}`): transpose of the first tensor factor.
+* `Matrix.partialTransposeRight` (`ρ^{T₂}`): transpose of the second tensor
+  factor.
+* `Matrix.IsPPT`: the property that the first-factor partial transpose is
+  positive semidefinite.
+* `Matrix.transpositionWitness`: Wolf's witness `W = (A ⊗ B) F (A ⊗ B)†`.
+
+## Main results
+
+* `Matrix.partialTransposeLeft_partialTransposeLeft`: the first-factor partial
+  transpose is an involution.
+* `Matrix.trace_partialTransposeLeft`: the partial transpose preserves the trace.
+* `Matrix.IsHermitian.partialTransposeLeft`: the partial transpose of a Hermitian
+  matrix is Hermitian.
+* `Matrix.partialTransposeRight_eq_transpose_partialTransposeLeft`: the two
+  partial transposes differ by a global transposition,
+  `ρ^{T₂} = (ρ^{T₁})ᵀ`.
+* `Matrix.isPPT_iff_partialTransposeRight_posSemidef`: the PPT property is
+  equivalent to positivity of the second-factor partial transpose (Wolf's
+  remark that `ρ^{T₁} ≥ 0 ↔ ρ^{T₂} ≥ 0`).
+* `Matrix.transpositionWitness_isHermitian`: the transposition witnesses are
+  Hermitian.
+
+## Scope
+
+The **PPT criterion** as an *entanglement* criterion — that a separable state
+has positive partial transpose, so a negative partial transpose certifies
+entanglement — needs a separable-state predicate, which is absent from the
+development.  This file formalizes the partial-transpose object, the PPT
+property, and the witnesses; the separability implication is not formalized.
+The same missing foundation blocks the reduction-criterion entanglement
+implication, recorded in
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Example 3.1, equations (3.16)--(3.17)][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+variable {d d' : ℕ}
+
+/-! ## The partial transpose -/
+
+/-- **Partial transpose over the first factor** (`ρ^{T₁}`).  For a bipartite
+matrix `ρ` on `Fin d × Fin d'`, this transposes the first tensor factor while
+fixing the second:
+
+  `(partialTransposeLeft ρ) (i, k) (j, l) = ρ (j, k) (i, l)`.
+
+This is Wolf's `ρ^{T₁} = (θ ⊗ id)(ρ)`, where `θ` is matrix transposition. -/
+def partialTransposeLeft (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ :=
+  fun p q => ρ (q.1, p.2) (p.1, q.2)
+
+/-- **Partial transpose over the second factor** (`ρ^{T₂}`).  For a bipartite
+matrix `ρ` on `Fin d × Fin d'`, this transposes the second tensor factor while
+fixing the first:
+
+  `(partialTransposeRight ρ) (i, k) (j, l) = ρ (i, l) (j, k)`.
+
+This is Wolf's `ρ^{T₂} = (id ⊗ θ)(ρ)`. -/
+def partialTransposeRight (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ :=
+  fun p q => ρ (p.1, q.2) (q.1, p.2)
+
+theorem partialTransposeLeft_apply (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ)
+    (p q : Fin d × Fin d') :
+    partialTransposeLeft ρ p q = ρ (q.1, p.2) (p.1, q.2) := rfl
+
+theorem partialTransposeRight_apply (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ)
+    (p q : Fin d × Fin d') :
+    partialTransposeRight ρ p q = ρ (p.1, q.2) (q.1, p.2) := rfl
+
+/-! ### Involution -/
+
+/-- The first-factor partial transpose is an involution: `(ρ^{T₁})^{T₁} = ρ`. -/
+@[simp]
+theorem partialTransposeLeft_partialTransposeLeft
+    (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    partialTransposeLeft (partialTransposeLeft ρ) = ρ := by
+  ext p q
+  simp only [partialTransposeLeft_apply]
+
+/-- The second-factor partial transpose is an involution: `(ρ^{T₂})^{T₂} = ρ`. -/
+@[simp]
+theorem partialTransposeRight_partialTransposeRight
+    (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    partialTransposeRight (partialTransposeRight ρ) = ρ := by
+  ext p q
+  simp only [partialTransposeRight_apply]
+
+/-! ### Action on Kronecker products -/
+
+/-- **The first-factor partial transpose realizes `θ ⊗ id`.** On a Kronecker
+product it transposes the first factor and fixes the second:
+`(A ⊗ B)^{T₁} = Aᵀ ⊗ B`. -/
+@[simp]
+theorem partialTransposeLeft_kronecker (A : Matrix (Fin d) (Fin d) ℂ)
+    (B : Matrix (Fin d') (Fin d') ℂ) :
+    partialTransposeLeft (A ⊗ₖ B) = Aᵀ ⊗ₖ B := by
+  ext ⟨p₁, p₂⟩ ⟨q₁, q₂⟩
+  simp only [partialTransposeLeft_apply, kronecker_apply, Matrix.transpose_apply]
+
+/-- **The second-factor partial transpose realizes `id ⊗ θ`.** On a Kronecker
+product it transposes the second factor and fixes the first:
+`(A ⊗ B)^{T₂} = A ⊗ Bᵀ`. -/
+@[simp]
+theorem partialTransposeRight_kronecker (A : Matrix (Fin d) (Fin d) ℂ)
+    (B : Matrix (Fin d') (Fin d') ℂ) :
+    partialTransposeRight (A ⊗ₖ B) = A ⊗ₖ Bᵀ := by
+  ext ⟨p₁, p₂⟩ ⟨q₁, q₂⟩
+  simp only [partialTransposeRight_apply, kronecker_apply, Matrix.transpose_apply]
+
+/-! ### Relation to the full transpose -/
+
+/-- Transposing the first factor and then the second equals the full transpose:
+`(ρ^{T₁})^{T₂} = ρᵀ`.  Equivalently, the two partial transposes differ by a
+global transposition. -/
+theorem partialTransposeRight_partialTransposeLeft
+    (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    partialTransposeRight (partialTransposeLeft ρ) = ρᵀ := by
+  ext p q
+  simp only [partialTransposeRight_apply, partialTransposeLeft_apply, Matrix.transpose_apply]
+
+/-- **Wolf eq. (3.17), `ρ^{T₂}` form.** The two partial transposes differ by a
+global transposition: `ρ^{T₂} = (ρ^{T₁})ᵀ`. -/
+theorem partialTransposeRight_eq_transpose_partialTransposeLeft
+    (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    partialTransposeRight ρ = (partialTransposeLeft ρ)ᵀ := by
+  ext p q
+  simp only [partialTransposeRight_apply, partialTransposeLeft_apply, Matrix.transpose_apply]
+
+/-- The two partial transposes differ by a global transposition, `ρ^{T₁}` form:
+`ρ^{T₁} = (ρ^{T₂})ᵀ`. -/
+theorem partialTransposeLeft_eq_transpose_partialTransposeRight
+    (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    partialTransposeLeft ρ = (partialTransposeRight ρ)ᵀ := by
+  rw [partialTransposeRight_eq_transpose_partialTransposeLeft, Matrix.transpose_transpose]
+
+/-! ### Trace preservation -/
+
+/-- The first-factor partial transpose preserves the trace. -/
+@[simp]
+theorem trace_partialTransposeLeft (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    (partialTransposeLeft ρ).trace = ρ.trace := by
+  simp only [Matrix.trace, Matrix.diag, partialTransposeLeft_apply]
+
+/-- The second-factor partial transpose preserves the trace. -/
+@[simp]
+theorem trace_partialTransposeRight (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    (partialTransposeRight ρ).trace = ρ.trace := by
+  rw [partialTransposeRight_eq_transpose_partialTransposeLeft, Matrix.trace_transpose,
+    trace_partialTransposeLeft]
+
+/-! ### Hermiticity preservation -/
+
+/-- The first-factor partial transpose of a Hermitian matrix is Hermitian. -/
+theorem IsHermitian.partialTransposeLeft {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hρ : ρ.IsHermitian) : (partialTransposeLeft ρ).IsHermitian := by
+  apply Matrix.IsHermitian.ext
+  intro p q
+  rw [partialTransposeLeft_apply, partialTransposeLeft_apply]
+  exact hρ.apply (q.1, p.2) (p.1, q.2)
+
+/-- The second-factor partial transpose of a Hermitian matrix is Hermitian. -/
+theorem IsHermitian.partialTransposeRight {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hρ : ρ.IsHermitian) : (partialTransposeRight ρ).IsHermitian := by
+  rw [partialTransposeRight_eq_transpose_partialTransposeLeft]
+  exact (hρ.partialTransposeLeft).transpose
+
+/-! ## The PPT property -/
+
+/-- **Positive partial transpose (PPT)**.  A bipartite matrix `ρ` has the PPT
+property when its first-factor partial transpose is positive semidefinite.  This
+is Wolf's separability criterion `(θ ⊗ id)(ρ) = ρ^{T₁} ≥ 0`. -/
+def IsPPT (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) : Prop :=
+  (partialTransposeLeft ρ).PosSemidef
+
+/-- **Wolf's remark after eq. (3.17).** The PPT property is equivalent to
+positivity of the second-factor partial transpose, since `ρ^{T₁}` and `ρ^{T₂}`
+differ only by a global transposition, which preserves positive
+semidefiniteness:
+
+  `ρ^{T₁} ≥ 0 ↔ ρ^{T₂} ≥ 0`. -/
+theorem isPPT_iff_partialTransposeRight_posSemidef
+    (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    IsPPT ρ ↔ (partialTransposeRight ρ).PosSemidef := by
+  rw [IsPPT, partialTransposeRight_eq_transpose_partialTransposeLeft,
+    Matrix.posSemidef_transpose_iff]
+
+/-! ## Basis independence of the PPT property (Wolf eq. (3.16)--(3.17)) -/
+
+/-- **Local-conjugation law for the partial transpose (Wolf eq. (3.17)).**
+Conjugating the first factor by `C` on the left and `G` on the right and then
+taking the first-factor partial transpose equals taking the partial transpose
+first and conjugating by the transposed factors in the opposite order:
+
+  `((C ⊗ 1) ρ (G ⊗ 1))^{T₁} = (Gᵀ ⊗ 1) ρ^{T₁} (Cᵀ ⊗ 1)`.
+
+The second tensor factor is untouched throughout. -/
+theorem partialTransposeLeft_conj_kronecker_one
+    (C G : Matrix (Fin d) (Fin d) ℂ) (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    partialTransposeLeft ((C ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * ρ *
+        (G ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)))
+      = (Gᵀ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * partialTransposeLeft ρ *
+          (Cᵀ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) := by
+  ext ⟨a, b⟩ ⟨c, e⟩
+  -- Expand both sides into double sums over the first tensor factor and match.
+  simp only [partialTransposeLeft_apply, Matrix.mul_apply, Fintype.sum_prod_type,
+    kronecker_apply, Matrix.one_apply, Matrix.transpose_apply]
+  -- Collapse the Kronecker deltas on the second factor.
+  simp only [mul_ite, ite_mul, mul_zero, zero_mul, Finset.sum_ite_eq, Finset.sum_ite_eq',
+    Finset.mem_univ, if_true]
+  -- Push the outer column factor inside each inner sum, then swap the two sums.
+  simp only [Finset.sum_mul]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun u _ => Finset.sum_congr rfl fun s _ => ?_
+  ring
+
+/-- **Wolf eq. (3.16)--(3.17), basis-change form.** Take the partial transpose of
+`ρ` in a different local basis on the first factor: conjugate by `V` on the left
+and `U` on the right inside, take the first-factor partial transpose, then
+conjugate by `U` on the left and `V` on the right outside.  The result is the
+original partial transpose conjugated by `(U Uᵀ) ⊗ 1` and `(Vᵀ V) ⊗ 1`:
+
+  `(U ⊗ 1) [((V ⊗ 1) ρ (U ⊗ 1))^{T₁}] (V ⊗ 1) = ((U Uᵀ) ⊗ 1) ρ^{T₁} ((Vᵀ V) ⊗ 1)`.
+
+Specializing `V = Uᴴ` for a unitary basis change gives Wolf eq. (3.17); there the
+conjugating factors are unitaries, so the eigenvalues of `ρ^{T₁}` — and hence the
+positivity of the partial transpose — do not depend on the local basis. -/
+theorem partialTransposeLeft_basis_change
+    (U V : Matrix (Fin d) (Fin d) ℂ) (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    (U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) *
+        partialTransposeLeft ((V ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * ρ *
+          (U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))) *
+        (V ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))
+      = ((U * Uᵀ) ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * partialTransposeLeft ρ *
+          ((Vᵀ * V) ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) := by
+  rw [partialTransposeLeft_conj_kronecker_one V U ρ]
+  have hUU : (U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * (Uᵀ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))
+      = (U * Uᵀ) ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ) := by
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul]
+  have hVV : (Vᵀ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * (V ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))
+      = (Vᵀ * V) ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ) := by
+    rw [← Matrix.mul_kronecker_mul, Matrix.one_mul]
+  -- Fully right-associate both products, merge the two outer Kronecker pairs.
+  simp only [Matrix.mul_assoc]
+  rw [hVV, ← Matrix.mul_assoc (U ⊗ₖ _) (Uᵀ ⊗ₖ _), hUU]
+
+/-- **Wolf eq. (3.17).** Taking the partial transpose in the basis changed by a
+unitary `U` on the first factor — conjugating by `Uᴴ` inside, then by `U`
+outside — yields the original partial transpose conjugated by `(U Uᵀ) ⊗ 1`:
+
+  `(U ⊗ 1) [((Uᴴ ⊗ 1) ρ (U ⊗ 1))^{T₁}] (Uᴴ ⊗ 1)
+     = ((U Uᵀ) ⊗ 1) ρ^{T₁} ((U Uᵀ)ᴴ ⊗ 1)`.
+
+The conjugating matrix `M = (U Uᵀ) ⊗ 1` is the same on both ends, so the partial
+transpose in the new basis is a similarity transform of `ρ^{T₁}` by `M`. -/
+theorem partialTransposeLeft_unitary_basis_change
+    (U : Matrix (Fin d) (Fin d) ℂ) (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :
+    (U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) *
+        partialTransposeLeft ((Uᴴ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * ρ *
+          (U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))) *
+        (Uᴴ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))
+      = ((U * Uᵀ) ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * partialTransposeLeft ρ *
+          ((U * Uᵀ)ᴴ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) := by
+  rw [partialTransposeLeft_basis_change U Uᴴ ρ, Matrix.conjTranspose_mul]
+  rfl
+
+/-- **Basis independence of the PPT property (Wolf eq. (3.17)).** If a bipartite
+matrix `ρ` is PPT, then the partial transpose taken in the local basis changed by
+a unitary `U` on the first factor is again positive semidefinite.  By
+`partialTransposeLeft_unitary_basis_change` the new-basis partial transpose is the
+similarity transform `((U Uᵀ) ⊗ 1) ρ^{T₁} ((U Uᵀ)ᴴ ⊗ 1)`, and conjugation by a
+matrix preserves positive semidefiniteness, so the positivity of the partial
+transpose does not depend on the local basis. -/
+theorem isPPT_basis_change {U : Matrix (Fin d) (Fin d) ℂ}
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : IsPPT ρ) :
+    ((U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) *
+        partialTransposeLeft ((Uᴴ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * ρ *
+          (U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))) *
+        (Uᴴ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))).PosSemidef := by
+  rw [partialTransposeLeft_unitary_basis_change U ρ]
+  have hM := hρ.mul_mul_conjTranspose_same ((U * Uᵀ) ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))
+  rwa [Matrix.conjTranspose_kronecker, Matrix.conjTranspose_one] at hM
+
+/-! ## Transposition witnesses (Wolf eq. (3.16)) -/
+
+/-- **Wolf's transposition witness** `W = (A ⊗ B) F (A ⊗ B)†`, where `F` is the
+SWAP operator on `ℂ^d ⊗ ℂ^d` and `A, B` are arbitrary `d × d` matrices.  These
+are exactly the witnesses that correspond to the transposition map. -/
+noncomputable def transpositionWitness (A B : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin d × Fin d) (Fin d × Fin d) ℂ :=
+  (A ⊗ₖ B) * Matrix.swapMatrix d * (A ⊗ₖ B)ᴴ
+
+/-- The transposition witnesses are Hermitian, since `F† = F`. -/
+theorem transpositionWitness_isHermitian (A B : Matrix (Fin d) (Fin d) ℂ) :
+    (transpositionWitness A B).IsHermitian := by
+  unfold transpositionWitness Matrix.IsHermitian
+  rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul, Matrix.conjTranspose_conjTranspose,
+    Matrix.swapMatrix_conjTranspose, Matrix.mul_assoc]
+
+end Matrix

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1592,6 +1592,212 @@ of a bipartite state whose Schmidt number is at most $n$.
     $n\,\rho_1\otimes\Id-\rho\ge 0$.
 \end{proof}
 
+\subsection{The partial transpose and the PPT property}
+
+Transposition is a positive map that is not completely positive, so applying it
+to one factor of a bipartite operator can break positivity.  The resulting
+operation, the partial transpose
+\cite[Equation~(3.16)]{Wolf2012Quantum}, sends $\rho\in\MN{d}\otimes\MN{d'}$ to
+the operator $\rho^{T_1}$ obtained by transposing the first tensor factor while
+leaving the second untouched, and the property $\rho^{T_1}\ge 0$ — positive
+partial transpose, or PPT — is the criterion
+\cite[Equation~(3.17)]{Wolf2012Quantum} that separates many entangled states
+from the separable ones.
+
+\begin{definition}[Partial transpose over the first factor]
+    \label{def:partial_transpose_left}
+    \lean{Matrix.partialTransposeLeft}
+    \leanok
+    For a bipartite matrix $\rho$ on $\MN{d}\otimes\MN{d'}$, the partial transpose
+    over the first factor is the matrix $\rho^{T_1}$ with entries
+    \[
+        \bigl(\rho^{T_1}\bigr)_{(i,k),(j,l)}=\rho_{(j,k),(i,l)},
+    \]
+    transposing the first index pair $i,j$ and fixing the second pair $k,l$.
+\end{definition}
+
+\begin{definition}[Partial transpose over the second factor]
+    \label{def:partial_transpose_right}
+    \lean{Matrix.partialTransposeRight}
+    \leanok
+    For a bipartite matrix $\rho$ on $\MN{d}\otimes\MN{d'}$, the partial transpose
+    over the second factor is the matrix $\rho^{T_2}$ with entries
+    \[
+        \bigl(\rho^{T_2}\bigr)_{(i,k),(j,l)}=\rho_{(i,l),(j,k)},
+    \]
+    transposing the second index pair $k,l$ and fixing the first pair $i,j$.
+\end{definition}
+
+\begin{theorem}[The partial transpose is an involution]
+    \label{thm:partial_transpose_left_involution}
+    \lean{Matrix.partialTransposeLeft_partialTransposeLeft}
+    \leanok
+    \uses{def:partial_transpose_left}
+    Applying the first-factor partial transpose twice returns the original matrix:
+    $\bigl(\rho^{T_1}\bigr)^{T_1}=\rho$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Both entries equal $\rho_{(i,k),(j,l)}$: the first transposition exchanges the
+    first index pair, the second restores it.
+\end{proof}
+
+\begin{theorem}[The partial transpose preserves the trace]
+    \label{thm:trace_partial_transpose_left}
+    \lean{Matrix.trace_partialTransposeLeft}
+    \leanok
+    \uses{def:partial_transpose_left}
+    The first-factor partial transpose preserves the trace:
+    $\tr\bigl(\rho^{T_1}\bigr)=\tr(\rho)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    On the diagonal the row and column indices coincide, so the index exchange in
+    the definition is the identity and each diagonal entry is unchanged.
+\end{proof}
+
+\begin{theorem}[The partial transpose preserves Hermiticity]
+    \label{thm:partial_transpose_left_hermitian}
+    \lean{Matrix.IsHermitian.partialTransposeLeft}
+    \leanok
+    \uses{def:partial_transpose_left}
+    If $\rho$ is Hermitian then so is its first-factor partial transpose
+    $\rho^{T_1}$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The entry $\bigl(\rho^{T_1}\bigr)_{(i,k),(j,l)}=\rho_{(j,k),(i,l)}$ has complex
+    conjugate $\overline{\rho_{(j,k),(i,l)}}=\rho_{(i,l),(j,k)}$ by Hermiticity of
+    $\rho$, which is the $((j,l),(i,k))$ entry of $\rho^{T_1}$.
+\end{proof}
+
+\begin{theorem}[The two partial transposes differ by a global transposition]
+    \label{thm:partial_transpose_right_eq_transpose_left}
+    \lean{Matrix.partialTransposeRight_eq_transpose_partialTransposeLeft}
+    \leanok
+    \uses{def:partial_transpose_left, def:partial_transpose_right}
+    The second-factor partial transpose is the full transpose of the first-factor
+    one:
+    \[
+        \rho^{T_2}=\bigl(\rho^{T_1}\bigr)^{\mathsf T}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Transposing both factors is the full transpose, so transposing the first
+    factor and then the whole operator transposes only the second factor.
+\end{proof}
+
+\begin{definition}[Positive partial transpose property]
+    \label{def:is_ppt}
+    \lean{Matrix.IsPPT}
+    \leanok
+    \uses{def:partial_transpose_left}
+    A bipartite matrix $\rho$ has the positive-partial-transpose (PPT) property when
+    its first-factor partial transpose is positive semidefinite, $\rho^{T_1}\ge 0$.
+\end{definition}
+
+\begin{theorem}[The PPT property is symmetric in the two factors]
+    \label{thm:is_ppt_iff_right}
+    \lean{Matrix.isPPT_iff_partialTransposeRight_posSemidef}
+    \leanok
+    \uses{def:is_ppt, def:partial_transpose_right,
+        thm:partial_transpose_right_eq_transpose_left}
+    A bipartite matrix has the PPT property if and only if its second-factor
+    partial transpose is positive semidefinite:
+    \[
+        \rho^{T_1}\ge 0\iff\rho^{T_2}\ge 0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The two partial transposes differ by a global transposition, and transposition
+    preserves positive semidefiniteness, so one is positive exactly when the other
+    is.
+\end{proof}
+
+\begin{theorem}[Basis-change law for the partial transpose]
+    \label{thm:partial_transpose_left_basis_change}
+    \lean{Matrix.partialTransposeLeft_basis_change}
+    \leanok
+    \uses{def:partial_transpose_left}
+    For matrices $U,V$ on the first factor and a bipartite matrix $\rho$,
+    conjugating inside by $V$ and $U$, taking the first-factor partial transpose,
+    and conjugating outside by $U$ and $V$ produces the original partial transpose
+    conjugated by $U U^{\mathsf T}$ and $V^{\mathsf T}V$:
+    \[
+        \bigl(U\otimes\Id\bigr)
+        \Bigl[\bigl((V\otimes\Id)\,\rho\,(U\otimes\Id)\bigr)^{T_1}\Bigr]
+        \bigl(V\otimes\Id\bigr)
+        =\bigl((U U^{\mathsf T})\otimes\Id\bigr)\,\rho^{T_1}\,
+            \bigl((V^{\mathsf T}V)\otimes\Id\bigr).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Expanding the conjugated operator entry by entry as a double sum over the first
+    factor, the partial transpose exchanges the two summation indices and reverses
+    the roles of the left and right conjugating matrices, leaving them transposed;
+    collecting the Kronecker factors gives the stated form.
+\end{proof}
+
+\begin{theorem}[Basis independence of the PPT property]
+    \label{thm:is_ppt_basis_change}
+    \lean{Matrix.isPPT_basis_change}
+    \leanok
+    \uses{def:is_ppt, thm:partial_transpose_left_basis_change}
+    Let $U$ be a unitary on the first factor.  If $\rho$ has the PPT property then
+    the partial transpose taken in the basis changed by $U$,
+    \[
+        \bigl(U\otimes\Id\bigr)
+        \Bigl[\bigl((U^\dagger\otimes\Id)\,\rho\,(U\otimes\Id)\bigr)^{T_1}\Bigr]
+        \bigl(U^\dagger\otimes\Id\bigr),
+    \]
+    is again positive semidefinite.  The positivity of the partial transpose is
+    therefore independent of the local basis.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    By the basis-change law with $V=U^\dagger$, the new-basis partial transpose
+    equals $\bigl((U U^{\mathsf T})\otimes\Id\bigr)\,\rho^{T_1}\,
+    \bigl((U U^{\mathsf T})\otimes\Id\bigr)^\dagger$, a conjugation of $\rho^{T_1}$
+    that preserves positive semidefiniteness.
+\end{proof}
+
+\begin{definition}[Transposition witness]
+    \label{def:transposition_witness}
+    \lean{Matrix.transpositionWitness}
+    \leanok
+    For matrices $A,B$ on $\MN{d}$ and the SWAP operator $F$ on
+    $\MN{d}\otimes\MN{d}$, the transposition witness is
+    \[
+        W=(A\otimes B)\,F\,(A\otimes B)^\dagger.
+    \]
+    These are the entanglement witnesses associated with the transposition map.
+\end{definition}
+
+\begin{theorem}[Transposition witnesses are Hermitian]
+    \label{thm:transposition_witness_hermitian}
+    \lean{Matrix.transpositionWitness_isHermitian}
+    \leanok
+    \uses{def:transposition_witness}
+    Every transposition witness $W=(A\otimes B)\,F\,(A\otimes B)^\dagger$ is
+    Hermitian.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The SWAP operator is self-adjoint, $F^\dagger=F$, so taking the adjoint of
+    $(A\otimes B)\,F\,(A\otimes B)^\dagger$ returns the same operator.
+\end{proof}
+
 \begin{theorem}[Completely positive implies two-positive]
     \lean{IsCPMap.is2PositiveMap}
     \leanok


### PR DESCRIPTION
### Motivation
- Formalizes the partial transpose and the PPT (positive partial transpose) property from Wolf's *Quantum Channels & Operations*, Chapter 3, Example 3.1, eq. (3.16)–(3.17).
- Provides the foundational bipartite-transpose object required for the PPT entanglement criterion; unblocks the separability implication (#3400) once a separable-state predicate exists; part of the entanglement-criterion program (#995).

### Description
New module `TNLean/Channel/PartialTranspose.lean` added to the root import list. New blueprint subsection "The partial transpose and the PPT property" added in `blueprint/src/chapter/ch05_schwarz.tex` after the reduction criterion, with `\lean{}`/`\leanok` tags for every new declaration citing Wolf eq. (3.16)–(3.17).

Definitions:
- `Matrix.partialTransposeLeft` (`ρ^{T₁}`): transposes the first tensor factor, `(ρ^{T₁})_{(i,k),(j,l)} = ρ_{(j,k),(i,l)}`; realizes Wolf's `(θ ⊗ id)(ρ)` (eq. (3.16)).
- `Matrix.partialTransposeRight` (`ρ^{T₂}`): second-factor version.
- `Matrix.IsPPT ρ := (partialTransposeLeft ρ).PosSemidef`.
- `Matrix.transpositionWitness A B := (A ⊗ B) F (A ⊗ B)†` (Wolf eq. (3.16)), using `Matrix.swapMatrix`.

Properties proved:
- Involution: `ρ^{T₁}` applied twice is the identity (and right-factor form).
- Kronecker action: `(A ⊗ B)^{T₁} = Aᵀ ⊗ B` (and right-factor form), realizing `θ ⊗ id`.
- Trace preservation and Hermiticity preservation under partial transpose.
- Factor symmetry: `ρ^{T₂} = (ρ^{T₁})ᵀ` (Wolf's "differ by a global transposition").
- `isPPT_iff_partialTransposeRight_posSemidef`: `ρ^{T₁} ≥ 0 ↔ ρ^{T₂} ≥ 0`.
- Local-conjugation law: `((C ⊗ 1) ρ (G ⊗ 1))^{T₁} = (Gᵀ ⊗ 1) ρ^{T₁} (Cᵀ ⊗ 1)`.
- Basis independence: PPT is preserved under local unitary basis changes (`isPPT_basis_change`).
- `transpositionWitness_isHermitian`: transposition witnesses `(A ⊗ B) F (A ⊗ B)†` are Hermitian.

The separability implication ("ρ separable ⟹ ρ^{T₁} ≥ 0") is intentionally omitted — no separable-state predicate exists in the development. This matches the existing gap documented in `docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. Every proved theorem matches its blueprint statement exactly; no new paper-gap note is required.

### Testing
- `lake build TNLean.Channel.PartialTranspose` — success (2598 jobs).
- `lake build TNLean` (full root) — success (9222 jobs).
- `rg -n "sorry|admit|native_decide|axiom" TNLean/Channel/PartialTranspose.lean` — clean.
- `lake exe lint-style TNLean/Channel/PartialTranspose.lean` — clean.
- `lake exe checkdecls blueprint/lean_decls` — clean (all blueprint declarations resolve).

---
Addresses LionSR/QICLean#21

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; no changes to auth, runtime behavior, or existing channel proofs beyond a new import.
>
> **Overview**
> Adds **`TNLean/Channel/PartialTranspose.lean`** and wires it into the root import list, formalizing Wolf Ch. 3 (3.16)–(3.17): left/right **partial transpose** on bipartite matrices, **`IsPPT`**, Kronecker laws, involution/trace/Hermiticity, factor symmetry via full transpose, **local conjugation / unitary basis-change** laws, and **`transpositionWitness`** Hermiticity (reusing `swapMatrix`).
>
> The blueprint gains a new subsection **"The partial transpose and the PPT property"** in `ch05_schwarz.tex` with `\lean{}`/`\leanok` tags aligned to the new declarations.
>
> **Separable ⟹ PPT** (entanglement criterion) is intentionally **not** proved—no separable-state predicate yet—matching the documented gap for the reduction criterion.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bfd6490ca541a0a7f021ed495f8ae1382c31a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>