### PR TITLE
feat(Channel): Schmidt-number predicate and the full reduction criterion

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -120,6 +120,7 @@ import TNLean.Channel.Schwarz.ChoiCompression
 import TNLean.Channel.NPositivityChainStrict
 import TNLean.Channel.ReductionCriterion
 import TNLean.Channel.PartialTranspose
+import TNLean.Channel.SchmidtNumber
 import TNLean.Channel.Separable
 import TNLean.Channel.Schwarz.MultiplicativeDomain
 import TNLean.Channel.Schwarz.MultiplicativeDomainPowers

--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -48,7 +48,9 @@ after scaling by `n > 0`, to `n • (1 ⊗ ρ₂) ≥ ρ`; applying the map to t
 factor instead gives the symmetric bound `n • (ρ₁ ⊗ 1) ≥ ρ`.  The implications
 are recorded as `Matrix.reductionCriterion_left` and
 `Matrix.reductionCriterion_right`.  The first step (the Schmidt-number premise)
-is not yet formalized; see the scope section.
+is formalized in `SchmidtNumber.lean`, where the two steps are composed into the
+full criterion `Matrix.reductionCriterion_left_of_hasSchmidtNumberLE` and
+`Matrix.reductionCriterion_right_of_hasSchmidtNumberLE`.
 
 ## Main definitions
 
@@ -64,25 +66,21 @@ is not yet formalized; see the scope section.
   **operator-implication step of Wolf eq. (3.18):** positivity of `(T_n ⊗ id)(ρ)`
   yields `n • (1 ⊗ ρ₂) ≥ ρ`, and positivity of `(T_n ⊗ id)(ρ^swap)` --
   equivalently Wolf's symmetric condition `(id ⊗ T_n)(ρ) ≥ 0` -- yields
-  `n • (ρ₁ ⊗ 1) ≥ ρ`.  Wolf's Schmidt-number premise is not yet wired in; see
-  the scope note below.
+  `n • (ρ₁ ⊗ 1) ≥ ρ`.  Wolf's Schmidt-number premise is supplied in
+  `SchmidtNumber.lean`, which composes these with the first step into the full
+  criterion.
 
 ## Scope
 
-**Scope restriction (operator-implication half of eq. (3.18)):** Wolf's
-eq. (3.18) has the premise `Schmidt-number(ρ) ≤ n`.  The theorems here drop that
-premise and assume its consequence `(T_n ⊗ id)(ρ) ≥ 0` instead, so they
-formalize only the second of Wolf's two steps.  Deriving the first step needs a
-Schmidt-number predicate for mixed states, equivalently a separable-state
-predicate, which is absent from the development.  Documented in
-`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`.
+These theorems isolate the second of Wolf's two steps: the operator implication
+from `(T_n ⊗ id)(ρ) ≥ 0` to the inequalities of eq. (3.18), with no premise on
+the Schmidt number.  The first step (a state of Schmidt number at most `n` has
+`(T_n ⊗ id)(ρ) ≥ 0`) and the resulting full criterion with its Schmidt-number
+premise are formalized in `SchmidtNumber.lean`.
 
-The same missing foundation blocks the *entanglement* form of the reduction
-criterion (a separable state satisfies eq. (3.18)): the operator implication
-above is the separability-free content.  The other entanglement criteria of
-Example 3.1 (PPT / partial transpose, the Breuer–Hall map, the Choi-type maps)
-need a bipartite partial-transpose object and indecomposability, which are
-likewise absent.
+The other entanglement criteria of Example 3.1 (the Breuer–Hall map, the
+Choi-type maps, indecomposability) are a further step and are not part of this
+file.
 
 ## References
 
@@ -164,13 +162,11 @@ form.** If applying `T_n` to the first tensor factor of a bipartite matrix `ρ`
 yields a positive semidefinite operator, then `n • (1 ⊗ ρ₂) ≥ ρ`, where
 `ρ₂ = traceLeft ρ` is the reduced density on the second factor.
 
-**Scope restriction (operator-implication half of eq. (3.18)):** Wolf states
-eq. (3.18) with the premise that `ρ` has Schmidt number at most `n`; the path to
-the inequality is `Schmidt-number(ρ) ≤ n ⟹ (T_n ⊗ id)(ρ) ≥ 0 ⟹ n • (1 ⊗ ρ₂) ≥ ρ`.
-This theorem formalizes only the second step, taking `(T_n ⊗ id)(ρ) ≥ 0` as a
-hypothesis; the first step is unformalized because no Schmidt-number /
-separable-state predicate exists in the development.  Documented in
-`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
+This is the second of Wolf's two steps: the path to the inequality is
+`Schmidt-number(ρ) ≤ n ⟹ (T_n ⊗ id)(ρ) ≥ 0 ⟹ n • (1 ⊗ ρ₂) ≥ ρ`, and this
+theorem takes `(T_n ⊗ id)(ρ) ≥ 0` as a hypothesis.  The first step and the
+composed full criterion with its Schmidt-number premise are
+`Matrix.reductionCriterion_left_of_hasSchmidtNumberLE` in `SchmidtNumber.lean`. -/
 theorem reductionCriterion_left {n : ℕ} (hn : 0 < n)
     (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
     (hpos : (tensorMapId (tEta D (n : ℝ)) ρ).PosSemidef) :
@@ -200,12 +196,11 @@ equivalent to Wolf's symmetric condition `(id ⊗ T_n)(ρ) ≥ 0`, which applies
 the first form, and reindexes back; positive semidefiniteness and the order are
 invariant under the swap.
 
-**Scope restriction (operator-implication half of eq. (3.18)):** as with the
-first form, the source premise is `Schmidt-number(ρ) ≤ n`; this theorem
-formalizes only the step from `(T_n ⊗ id)(ρ^swap) ≥ 0` to the inequality, the
-Schmidt-number step being unformalized for want of a Schmidt-number /
-separable-state predicate.  Documented in
-`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
+As with the first form, this is the second of Wolf's two steps, taking
+`(T_n ⊗ id)(ρ^swap) ≥ 0` as a hypothesis.  The first step and the composed full
+criterion with its Schmidt-number premise are
+`Matrix.reductionCriterion_right_of_hasSchmidtNumberLE` in
+`SchmidtNumber.lean`. -/
 theorem reductionCriterion_right {n : ℕ} (hn : 0 < n)
     (ρ : Matrix (Fin D × Fin D') (Fin D × Fin D') ℂ)
     (hpos : (tensorMapId (tEta D' (n : ℝ))

--- a/TNLean/Channel/SchmidtNumber.lean
+++ b/TNLean/Channel/SchmidtNumber.lean
@@ -1,0 +1,423 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.NPositivityChainStrict
+import TNLean.Channel.ReductionCriterion
+import TNLean.Channel.Separable
+import TNLean.Channel.Schwarz.ChoiCompression
+
+/-!
+# The Schmidt number and the full reduction criterion
+
+Wolf's Chapter 3, Section 3.2 (the paragraph *Detecting entanglement*) defines the
+**Schmidt number** of a bipartite state ρ as the smallest `n` such that ρ has a
+convex decomposition into pure states each of Schmidt rank at most `n`; separable
+states are exactly those of Schmidt number one.  Using the maps
+`T_n(X) = tr(X) • 1 − n⁻¹ • X`, which are `n`-positive, Wolf concludes the
+**reduction criterion** (eq. (3.18)): a state of Schmidt number at most `n`
+satisfies `n • (ρ₁ ⊗ 1) ≥ ρ` and `n • (1 ⊗ ρ₂) ≥ ρ`, with `ρ₁` and `ρ₂` the two
+reduced density matrices.
+
+This file introduces the Schmidt-number predicate for mixed states and completes
+Wolf's two-step derivation of eq. (3.18), supplying the first step that the
+operator-implication lemmas of `ReductionCriterion.lean` previously assumed.
+
+## The Schmidt-number predicate
+
+A bound on the Schmidt number is recorded by `Matrix.HasSchmidtNumberLE n ρ`:
+the state ρ is a finite sum of pure-state projectors `|ψᵢ⟩⟨ψᵢ|`, each of Schmidt
+rank at most `n`.  Up to normalization this is Wolf's "ρ has a convex
+decomposition into pure states of Schmidt rank at most `n`": a positive coefficient
+is absorbed into the vector by rescaling, which scales the Schmidt coefficient
+matrix and so preserves the Schmidt rank.
+
+At `n = 1` every pure summand `|ψᵢ⟩⟨ψᵢ|` has Schmidt rank at most one, hence ψᵢ is a
+product vector and `|ψᵢ⟩⟨ψᵢ|` is a product of two positive semidefinite rank-one
+matrices.  Thus Schmidt number one coincides with separability.
+
+## The forward reduction step
+
+The technical core is the **pure-state step**: for a pure state `|ψ⟩⟨ψ|` with ψ of
+Schmidt rank at most `n`, the ampliation `(T_n ⊗ id)(|ψ⟩⟨ψ|)` is positive
+semidefinite.  Writing ψ through the maximally entangled vector as
+`ψ = (1 ⊗ X)|Ω⟩√D` with X of rank equal to the Schmidt rank of ψ, the ampliation
+becomes the right-factor Choi compression of `T_n` by X, whose quadratic form is the
+Choi quadratic form of `T_n` evaluated on a vector of Schmidt rank at most the rank
+of X, hence at most `n`.  The `n`-positivity of `T_n` makes that Choi quadratic form
+nonnegative, so the compression is positive semidefinite.  Summing over the pure
+terms gives `(T_n ⊗ id)(ρ) ≥ 0` for any state of Schmidt number at most `n`.
+Composing with the operator-implication lemmas of `ReductionCriterion.lean` yields
+Wolf eq. (3.18) with its Schmidt-number premise.
+
+## Main definitions
+
+* `Matrix.HasSchmidtNumberLE`: a bipartite matrix is a finite sum of pure-state
+  projectors of Schmidt rank at most `n`.
+
+## Main results
+
+* `Matrix.HasSchmidtNumberLE.posSemidef`: a state of bounded Schmidt number is
+  positive semidefinite.
+* `Matrix.HasSchmidtNumberLE.add`, `Matrix.HasSchmidtNumberLE.mono`: closure under
+  addition and monotonicity in the bound.
+* `Matrix.hasSchmidtNumberLE_one_iff_isSeparable`: **Schmidt number one is exactly
+  separability** (Wolf §3.2).
+* `Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE`: the **pure-state step** —
+  for ψ of Schmidt rank at most `n` (with `1 ≤ n < D`), `(T_n ⊗ id)(|ψ⟩⟨ψ|) ≥ 0`.
+* `Matrix.HasSchmidtNumberLE.tensorMapId_tEta_posSemidef`: **step 1 of Wolf
+  eq. (3.18)** — a state of Schmidt number at most `n` has `(T_n ⊗ id)(ρ) ≥ 0`.
+* `Matrix.reductionCriterion_left_of_hasSchmidtNumberLE` and
+  `Matrix.reductionCriterion_right_of_hasSchmidtNumberLE`: **the full Wolf reduction
+  criterion (eq. (3.18))** with its Schmidt-number premise: a state of Schmidt
+  number at most `n` satisfies `n • (1 ⊗ ρ₂) ≥ ρ` and `n • (ρ₁ ⊗ 1) ≥ ρ`.
+
+## Scope
+
+**Scope restriction (1 ≤ n < D):** the forward reduction step uses the
+`n`-positivity threshold of `T_η` (Wolf eq. (3.11)), which is formalized for
+`1 ≤ n < D` where `D` is the first-factor dimension; the omitted top index `n = D`
+(complete positivity) is inherited through the maximal-overlap principle and is
+documented in `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`.  The Schmidt-number
+predicate itself and its equivalence with separability carry no such restriction.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Section 3.2, the *Detecting entanglement* paragraph and Example 3.1,
+  equation (3.18)][Wolf2012QChannels]
+-/
+
+open scoped BigOperators Matrix ComplexOrder MatrixOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+variable {d d' D : ℕ}
+
+/-! ## The Schmidt-number predicate -/
+
+/-- **Bounded Schmidt number** (Wolf §3.2).  A bipartite matrix ρ on
+`Fin d × Fin d'` has Schmidt number at most `n` when it is a finite sum of
+pure-state projectors of Schmidt rank at most `n`,
+
+  ρ = Σ_i |ψ_i⟩⟨ψ_i|,   Schmidt rank of ψ_i ≤ n.
+
+Up to normalization this is Wolf's "ρ has a convex decomposition into pure states of
+Schmidt rank at most `n`": a positive coefficient `p_i` is absorbed by rescaling
+`ψ_i ↦ √p_i ψ_i`, which scales the Schmidt coefficient matrix and so leaves the
+Schmidt rank unchanged.  The smallest such `n` is the Schmidt number; at `n = 1`
+this is separability. -/
+def HasSchmidtNumberLE (n : ℕ) (ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) : Prop :=
+  ∃ (ι : Type) (_ : Fintype ι) (ψ : ι → (Fin d × Fin d' → ℂ)),
+    (∀ i, HasSchmidtRankLE n (ψ i)) ∧ ρ = ∑ i, vecMulVec (ψ i) (star (ψ i))
+
+/-! ## Basic properties -/
+
+/-- A pure-state projector of Schmidt rank at most `n` has Schmidt number at most
+`n`: it is the one-term sum with a single index. -/
+theorem hasSchmidtNumberLE_vecMulVec {n : ℕ} {ψ : Fin d × Fin d' → ℂ}
+    (hψ : HasSchmidtRankLE n ψ) : HasSchmidtNumberLE n (vecMulVec ψ (star ψ)) := by
+  refine ⟨PUnit, inferInstance, fun _ => ψ, fun _ => hψ, ?_⟩
+  simp
+
+/-- **A state of bounded Schmidt number is positive semidefinite.**  Each summand
+`|ψ_i⟩⟨ψ_i|` is a rank-one positive semidefinite matrix, and a finite sum of
+positive semidefinite matrices is positive semidefinite. -/
+theorem HasSchmidtNumberLE.posSemidef {n : ℕ}
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : HasSchmidtNumberLE n ρ) :
+    ρ.PosSemidef := by
+  obtain ⟨ι, _, ψ, _, rfl⟩ := hρ
+  exact posSemidef_sum Finset.univ fun i _ => posSemidef_vecMulVec_self_star (ψ i)
+
+/-- **States of bounded Schmidt number are closed under addition.** Concatenating
+the two pure-state families realizes the sum as a single sum of pure-state
+projectors of Schmidt rank at most `n`. -/
+theorem HasSchmidtNumberLE.add {n : ℕ} {ρ σ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hρ : HasSchmidtNumberLE n ρ) (hσ : HasSchmidtNumberLE n σ) :
+    HasSchmidtNumberLE n (ρ + σ) := by
+  obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
+  obtain ⟨κ, _, φ, hφ, rfl⟩ := hσ
+  refine ⟨ι ⊕ κ, inferInstance, Sum.elim ψ φ, ?_, ?_⟩
+  · rintro (i | j)
+    · exact hψ i
+    · exact hφ j
+  · rw [Fintype.sum_sum_type]
+    simp [Sum.elim_inl, Sum.elim_inr]
+
+/-- **A bound on the Schmidt number relaxes to any larger bound.** Each pure summand
+of Schmidt rank at most `n` also has Schmidt rank at most `m` when `n ≤ m`. -/
+theorem HasSchmidtNumberLE.mono {n m : ℕ}
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : HasSchmidtNumberLE n ρ)
+    (hnm : n ≤ m) : HasSchmidtNumberLE m ρ := by
+  obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
+  exact ⟨ι, inferInstance, ψ, fun i => (hψ i).mono hnm, rfl⟩
+
+/-! ## Schmidt number one is separability -/
+
+/-- A pure state of Schmidt rank at most one is a product state, so its projector
+`|ψ⟩⟨ψ|` is a Kronecker product of two positive semidefinite rank-one matrices and
+hence separable. -/
+theorem isSeparable_vecMulVec_of_hasSchmidtRankLE_one {ψ : Fin d × Fin d' → ℂ}
+    (hψ : HasSchmidtRankLE 1 ψ) : IsSeparable (vecMulVec ψ (star ψ)) := by
+  classical
+  -- A Schmidt rank ≤ 1 coefficient matrix factors as a product `u vᵀ`.
+  have hrank : (schmidtCoeffMatrix ψ).rank ≤ 1 := hψ
+  obtain ⟨B, C, hBC⟩ := exists_mul_eq_of_rank_le (schmidtCoeffMatrix ψ) hrank
+  -- The factorization yields ψ (i, j) = u i * v j with u = B(·,0), v = C(0,·).
+  set u : Fin d → ℂ := fun i => B i 0 with hu
+  set v : Fin d' → ℂ := fun j => C 0 j with hv
+  have hψuv : ∀ i j, ψ (i, j) = u i * v j := by
+    intro i j
+    have hentry : schmidtCoeffMatrix ψ i j = (B * C) i j := by rw [hBC]
+    rw [schmidtCoeffMatrix_apply] at hentry
+    rw [hentry, Matrix.mul_apply, Fin.sum_univ_one, hu, hv]
+  -- |ψ⟩⟨ψ| = (|u⟩⟨u|) ⊗ (|v⟩⟨v|), a Kronecker product of PSD matrices.
+  have hkron : vecMulVec ψ (star ψ)
+      = vecMulVec u (star u) ⊗ₖ vecMulVec v (star v) := by
+    ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+    simp only [vecMulVec_apply, kroneckerMap_apply, Pi.star_apply, hψuv]
+    rw [star_mul']
+    ring
+  rw [hkron]
+  exact isSeparable_kronecker (posSemidef_vecMulVec_self_star u) (posSemidef_vecMulVec_self_star v)
+
+/-- A finite sum of separable matrices is separable: the empty sum is the zero
+Kronecker product and the inductive step is the additive closure of separability. -/
+theorem isSeparable_sum {ι : Type*} (s : Finset ι)
+    {f : ι → Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hf : ∀ i ∈ s, IsSeparable (f i)) : IsSeparable (∑ i ∈ s, f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty =>
+      simp only [Finset.sum_empty]
+      simpa using isSeparable_kronecker (d := d) (d' := d')
+        (A := (0 : Matrix (Fin d) (Fin d) ℂ)) (B := (0 : Matrix (Fin d') (Fin d') ℂ))
+        PosSemidef.zero PosSemidef.zero
+  | insert a s ha ih =>
+      rw [Finset.sum_insert ha]
+      exact (hf a (Finset.mem_insert_self a s)).add
+        (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
+
+/-- **Schmidt number one implies separability** (Wolf §3.2).  A state of Schmidt
+number at most one is a finite sum of pure-state projectors of Schmidt rank at most
+one; each is a product state, hence separable, and separable matrices are closed
+under addition. -/
+theorem HasSchmidtNumberLE.isSeparable
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : HasSchmidtNumberLE 1 ρ) :
+    IsSeparable ρ := by
+  obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
+  exact isSeparable_sum Finset.univ fun i _ =>
+    isSeparable_vecMulVec_of_hasSchmidtRankLE_one (hψ i)
+
+/-- A finite sum of states of Schmidt number at most `n` itself has Schmidt number
+at most `n`. -/
+theorem hasSchmidtNumberLE_sum {n : ℕ} {ι : Type*} (s : Finset ι)
+    {f : ι → Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hf : ∀ i ∈ s, HasSchmidtNumberLE n (f i)) :
+    HasSchmidtNumberLE n (∑ i ∈ s, f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty =>
+      simp only [Finset.sum_empty]
+      exact ⟨PEmpty, inferInstance, fun i => i.elim, fun i => i.elim, by simp⟩
+  | insert a s ha ih =>
+      rw [Finset.sum_insert ha]
+      exact (hf a (Finset.mem_insert_self a s)).add
+        (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
+
+/-- The Kronecker product of two pure-state projectors is the pure-state projector
+of the product vector, which has Schmidt rank at most one. -/
+theorem vecMulVec_kronecker_vecMulVec (a : Fin d → ℂ) (b : Fin d' → ℂ) :
+    vecMulVec a (star a) ⊗ₖ vecMulVec b (star b)
+      = vecMulVec (fun p : Fin d × Fin d' => a p.1 * b p.2)
+          (star (fun p : Fin d × Fin d' => a p.1 * b p.2)) := by
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  simp only [kroneckerMap_apply, vecMulVec_apply, Pi.star_apply]
+  rw [star_mul']
+  ring
+
+/-- The Kronecker product distributes over a double finite sum entrywise. -/
+theorem sum_kronecker_sum {ιa ιb : Type*} [Fintype ιa] [Fintype ιb]
+    (A : ιa → Matrix (Fin d) (Fin d) ℂ) (B : ιb → Matrix (Fin d') (Fin d') ℂ) :
+    (∑ i, A i) ⊗ₖ (∑ j, B j) = ∑ i, ∑ j, A i ⊗ₖ B j := by
+  ext ⟨p₁, p₂⟩ ⟨q₁, q₂⟩
+  simp only [kroneckerMap_apply, Matrix.sum_apply, Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
+
+/-- A Kronecker product of two positive semidefinite matrices has Schmidt number at
+most one.  Each factor is a finite sum of rank-one projectors, the Kronecker product
+distributes into a double sum of product-vector projectors, and a product vector has
+Schmidt rank at most one. -/
+theorem hasSchmidtNumberLE_one_kronecker {A : Matrix (Fin d) (Fin d) ℂ}
+    {B : Matrix (Fin d') (Fin d') ℂ} (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    HasSchmidtNumberLE 1 (A ⊗ₖ B) := by
+  classical
+  obtain ⟨p, a, rfl⟩ := posSemidef_iff_eq_sum_vecMulVec.mp hA
+  obtain ⟨q, b, rfl⟩ := posSemidef_iff_eq_sum_vecMulVec.mp hB
+  rw [sum_kronecker_sum]
+  refine hasSchmidtNumberLE_sum Finset.univ fun i _ => ?_
+  refine hasSchmidtNumberLE_sum Finset.univ fun j _ => ?_
+  rw [vecMulVec_kronecker_vecMulVec]
+  exact hasSchmidtNumberLE_vecMulVec (hasSchmidtRankLE_one_product (a i) (b j))
+
+/-- **Separability implies Schmidt number one** (Wolf §3.2).  A separable state is a
+finite sum of Kronecker products of positive semidefinite matrices, each of which
+has Schmidt number at most one, and that bound is closed under addition. -/
+theorem IsSeparable.hasSchmidtNumberLE_one
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : IsSeparable ρ) :
+    HasSchmidtNumberLE 1 ρ := by
+  obtain ⟨ι, _, A, B, hAB, rfl⟩ := hρ
+  exact hasSchmidtNumberLE_sum Finset.univ fun i _ =>
+    hasSchmidtNumberLE_one_kronecker (hAB i).1 (hAB i).2
+
+/-- **Schmidt number one is exactly separability** (Wolf §3.2).  The two
+formulations of the lowest level of the Schmidt-number filtration coincide: a
+bipartite state is a sum of product-vector projectors if and only if it is a sum of
+Kronecker products of positive semidefinite matrices. -/
+theorem hasSchmidtNumberLE_one_iff_isSeparable
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} :
+    HasSchmidtNumberLE 1 ρ ↔ IsSeparable ρ :=
+  ⟨HasSchmidtNumberLE.isSeparable, IsSeparable.hasSchmidtNumberLE_one⟩
+
+/-! ## The forward reduction step -/
+
+/-- The full `id`-ampliation `tensorMapId T` on `M_D ⊗ M_D` coincides with the
+`D`-fold blockwise ampliation `nPositiveAmpliation D T`: both apply `T` to the
+`(i₂, j₂)` block and read off the `(i₁, j₁)` entry. -/
+theorem tensorMapId_eq_nPositiveAmpliation
+    (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
+    (X : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) :
+    tensorMapId T X = nPositiveAmpliation D T X := by
+  rfl
+
+/-- A sharper Schmidt-rank bound for the pull-back through the adjoint right tensor
+factor: the pulled-back vector has Schmidt rank at most the rank of the right-factor
+matrix `X` (not merely at most the number of its columns). -/
+theorem rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE_rank {k : ℕ}
+    (X : Matrix (Fin D) (Fin k) ℂ) (η : Fin D × Fin k → ℂ) :
+    HasSchmidtRankLE X.rank
+      ((ChoiJamiolkowski.rightTensorMatrix X)ᴴ *ᵥ η) := by
+  have hrank :
+      (schmidtCoeffMatrix ((ChoiJamiolkowski.rightTensorMatrix X)ᴴ *ᵥ η)).rank
+        ≤ X.rank := by
+    rw [ChoiJamiolkowski.schmidtCoeffMatrix_rightTensorMatrix_conjTranspose_mulVec]
+    calc
+      (schmidtCoeffMatrix η * Xᴴ).rank ≤ (Xᴴ).rank :=
+        Matrix.rank_mul_le_right (schmidtCoeffMatrix η) Xᴴ
+      _ = X.rank := Matrix.rank_conjTranspose X
+  simpa [HasSchmidtRankLE, schmidtRank] using hrank
+
+/-- **The pure-state step of the reduction criterion (Wolf eq. (3.18), step 1).**
+For a pure state `|ψ⟩⟨ψ|` with ψ of Schmidt rank at most `n` (and `1 ≤ n < D`),
+the ampliation `(T_n ⊗ id)(|ψ⟩⟨ψ|)` is positive semidefinite.
+
+Writing ψ through the maximally entangled vector as a square right-factor matrix `X`
+of rank equal to the Schmidt rank of ψ, the ampliation is the right-factor Choi
+compression of `T_n` by `X`.  Its quadratic form on any vector is the Choi quadratic
+form of `T_n` on a vector of Schmidt rank at most the rank of `X`, hence at most `n`;
+the `n`-positivity of `T_n` (Wolf eq. (3.11)) makes that form nonnegative.
+
+**Scope restriction (1 ≤ n < D):** the `n`-positivity threshold of `T_η` is
+formalized for `1 ≤ n < D`.  The omitted top index `n = D` (complete positivity) is
+inherited through the maximal-overlap principle and documented in
+`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+theorem tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE [NeZero D] {n : ℕ}
+    (hn1 : 1 ≤ n) (hnD : n < D) {ψ : Fin D × Fin D → ℂ} (hψ : HasSchmidtRankLE n ψ) :
+    (tensorMapId (tEta D (n : ℝ)) (vecMulVec ψ (star ψ))).PosSemidef := by
+  classical
+  set T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ := tEta D (n : ℝ) with hT
+  -- `T_n` is `n`-positive (Wolf eq. (3.11)).
+  have hTpos : IsNPositiveMap n T :=
+    (isNPositiveMap_tEta_iff (by positivity) hn1 hnD).mpr (le_refl _)
+  -- Express ψ as a square compression of the maximally entangled vector.
+  obtain ⟨X, hXvec, hXrank⟩ :=
+    ChoiJamiolkowski.exists_squareCompression_of_vector (D := D) ψ
+  have hXrank_le : X.rank ≤ n := by rw [hXrank]; exact hψ
+  -- The ampliation of the pure state is the right-factor Choi compression.
+  have hcomp :
+      tensorMapId T (vecMulVec ψ (star ψ)) = ChoiJamiolkowski.rightCompression T X := by
+    rw [tensorMapId_eq_nPositiveAmpliation, ← hXvec,
+      ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression]
+  rw [hcomp]
+  -- Positivity via the Choi quadratic form on Schmidt-rank-≤n vectors.
+  refine posSemidef_of_dotProduct_mulVec_nonneg_complex ?_
+  intro η
+  rw [ChoiJamiolkowski.rightCompression_quadraticForm_eq_choiMatrix_quadraticForm]
+  have hrank :
+      HasSchmidtRankLE n ((ChoiJamiolkowski.rightTensorMatrix X)ᴴ *ᵥ η) :=
+    (rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE_rank X η).mono hXrank_le
+  exact
+    ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg.mp
+      hTpos _ hrank
+
+/-- **Step 1 of Wolf's reduction criterion (eq. (3.18)).**  A bipartite state of
+Schmidt number at most `n` (with `1 ≤ n < D`) has `(T_n ⊗ id)(ρ) ≥ 0`.
+
+The state is a finite sum of pure-state projectors of Schmidt rank at most `n`; the
+ampliation is linear, the pure-state step makes each summand positive semidefinite,
+and a finite sum of positive semidefinite matrices is positive semidefinite.
+
+**Scope restriction (1 ≤ n < D):** inherited from the pure-state step; see
+`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+theorem HasSchmidtNumberLE.tensorMapId_tEta_posSemidef [NeZero D] {n : ℕ}
+    (hn1 : 1 ≤ n) (hnD : n < D)
+    {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
+    (tensorMapId (tEta D (n : ℝ)) ρ).PosSemidef := by
+  obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
+  rw [tensorMapId_sum]
+  exact posSemidef_sum Finset.univ fun i _ =>
+    tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE hn1 hnD (hψ i)
+
+/-! ## The full reduction criterion (Wolf eq. (3.18)) -/
+
+/-- **Wolf's reduction criterion (eq. (3.18)), second form, with the Schmidt-number
+premise.**  A bipartite state of Schmidt number at most `n` (with `1 ≤ n < D`)
+satisfies `n • (1 ⊗ ρ₂) ≥ ρ`, where `ρ₂ = traceLeft ρ` is the reduced density on the
+second factor.
+
+This is Wolf's full two-step argument: the Schmidt-number premise gives
+`(T_n ⊗ id)(ρ) ≥ 0` (step 1), and the operator inequality then yields the bound
+(step 2).
+
+**Scope restriction (1 ≤ n < D):** inherited from step 1; see
+`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+theorem reductionCriterion_left_of_hasSchmidtNumberLE [NeZero D] {n : ℕ}
+    (hn1 : 1 ≤ n) (hnD : n < D)
+    {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
+    ρ ≤ (n : ℂ) • ((1 : Matrix (Fin D) (Fin D) ℂ) ⊗ₖ traceLeft ρ) :=
+  reductionCriterion_left (by omega) ρ (hρ.tensorMapId_tEta_posSemidef hn1 hnD)
+
+/-- **Wolf's reduction criterion (eq. (3.18)), first form, with the Schmidt-number
+premise.**  A bipartite state of Schmidt number at most `n` (with `1 ≤ n < D`)
+satisfies `n • (ρ₁ ⊗ 1) ≥ ρ`, where `ρ₁ = traceRight ρ` is the reduced density on the
+first factor.
+
+The factor swap of a state of Schmidt number at most `n` again has Schmidt number at
+most `n`, since the swap reindexes each pure summand to a vector with the transposed
+coefficient matrix, of the same rank.  Applying step 1 to the swapped state supplies
+the symmetric hypothesis of the operator-implication lemma.
+
+**Scope restriction (1 ≤ n < D):** inherited from step 1; see
+`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+theorem reductionCriterion_right_of_hasSchmidtNumberLE [NeZero D] {n : ℕ}
+    (hn1 : 1 ≤ n) (hnD : n < D)
+    {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
+    ρ ≤ (n : ℂ) • (traceRight ρ ⊗ₖ (1 : Matrix (Fin D) (Fin D) ℂ)) := by
+  -- The factor swap of ρ again has Schmidt number at most n.
+  have hswap : HasSchmidtNumberLE n (ρ.submatrix Prod.swap Prod.swap) := by
+    obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
+    refine ⟨ι, inferInstance, fun i => (ψ i) ∘ Prod.swap, fun i => ?_, ?_⟩
+    · -- The swapped vector has the transposed coefficient matrix, of equal rank.
+      have hcoeff :
+          schmidtCoeffMatrix ((ψ i) ∘ Prod.swap) = (schmidtCoeffMatrix (ψ i))ᵀ := by
+        ext a b; simp [schmidtCoeffMatrix, Function.comp]
+      rw [HasSchmidtRankLE, schmidtRank, hcoeff, Matrix.rank_transpose]
+      exact hψ i
+    · ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+      simp only [Matrix.submatrix_apply, Matrix.sum_apply, vecMulVec_apply, Pi.star_apply,
+        Prod.swap_prod_mk, Function.comp_apply]
+  exact reductionCriterion_right (by omega) ρ (hswap.tensorMapId_tEta_posSemidef hn1 hnD)
+
+end Matrix

--- a/TNLean/Channel/SchmidtNumber.lean
+++ b/TNLean/Channel/SchmidtNumber.lean
@@ -79,7 +79,13 @@ Wolf eq. (3.18) with its Schmidt-number premise.
 `n`-positivity threshold of `T_η` (Wolf eq. (3.11)), which is formalized for
 `1 ≤ n < D` where `D` is the first-factor dimension; the omitted top index `n = D`
 (complete positivity) is inherited through the maximal-overlap principle and is
-documented in `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`.  The Schmidt-number
+documented in `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`.
+
+**Scope restriction (square system d = d' = D):** the forward reduction step fixes
+both tensor factors to a common dimension `D`, because the pure state is parametrized
+through the square maximally entangled vector; Wolf states eq. (3.18) for a general
+bipartite system `ℂ^d ⊗ ℂ^{d'}`, and the non-square case is documented in
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`.  The Schmidt-number
 predicate itself and its equivalence with separability carry no such restriction.
 
 ## References
@@ -254,6 +260,9 @@ theorem tensorMapId_eq_nPositiveAmpliation
     (T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ)
     (X : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ) :
     tensorMapId T X = nPositiveAmpliation D T X := by
+  -- Both sides unfold to `T` applied entrywise to the second tensor block while the
+  -- first block index is carried through, so the two ampliations are definitionally
+  -- the same matrix and the equality holds by `rfl`.
   rfl
 
 /-- A sharper Schmidt-rank bound for the pull-back through the adjoint right tensor
@@ -286,7 +295,14 @@ the `n`-positivity of `T_n` (Wolf eq. (3.11)) makes that form nonnegative.
 **Scope restriction (1 ≤ n < D):** the `n`-positivity threshold of `T_η` is
 formalized for `1 ≤ n < D`.  The omitted top index `n = D` (complete positivity) is
 inherited through the maximal-overlap principle and documented in
-`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`.
+
+**Scope restriction (square system d = d' = D):** both tensor factors are fixed to a
+common dimension `D`, because the pure state is parametrized through the square
+maximally entangled vector (`ChoiJamiolkowski.exists_squareCompression_of_vector`).
+Wolf states the criterion for a general bipartite system `ℂ^d ⊗ ℂ^{d'}`; the
+non-square case is documented in
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
 theorem tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE [NeZero D] {n : ℕ}
     (hn1 : 1 ≤ n) (hnD : n < D) {ψ : Fin D × Fin D → ℂ} (hψ : HasSchmidtRankLE n ψ) :
     (tensorMapId (tEta D (n : ℝ)) (vecMulVec ψ (star ψ))).PosSemidef := by
@@ -323,8 +339,9 @@ The state is a finite sum of pure-state projectors of Schmidt rank at most `n`; 
 ampliation is linear, the pure-state step makes each summand positive semidefinite,
 and a finite sum of positive semidefinite matrices is positive semidefinite.
 
-**Scope restriction (1 ≤ n < D):** inherited from the pure-state step; see
-`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+**Scope restriction (1 ≤ n < D; square system d = d' = D):** inherited from the
+pure-state step; see `docs/paper-gaps/wolf_t_eta_top_index_scope.tex` and
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
 theorem HasSchmidtNumberLE.tensorMapId_tEta_posSemidef [NeZero D] {n : ℕ}
     (hn1 : 1 ≤ n) (hnD : n < D)
     {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
@@ -345,8 +362,9 @@ This is Wolf's full two-step argument: the Schmidt-number premise gives
 `(T_n ⊗ id)(ρ) ≥ 0` (step 1), and the operator inequality then yields the bound
 (step 2).
 
-**Scope restriction (1 ≤ n < D):** inherited from step 1; see
-`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+**Scope restriction (1 ≤ n < D; square system d = d' = D):** inherited from step 1;
+see `docs/paper-gaps/wolf_t_eta_top_index_scope.tex` and
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
 theorem reductionCriterion_left_of_hasSchmidtNumberLE [NeZero D] {n : ℕ}
     (hn1 : 1 ≤ n) (hnD : n < D)
     {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
@@ -363,8 +381,9 @@ most `n`, since the swap reindexes each pure summand to a vector with the transp
 coefficient matrix, of the same rank.  Applying step 1 to the swapped state supplies
 the symmetric hypothesis of the operator-implication lemma.
 
-**Scope restriction (1 ≤ n < D):** inherited from step 1; see
-`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`. -/
+**Scope restriction (1 ≤ n < D; square system d = d' = D):** inherited from step 1;
+see `docs/paper-gaps/wolf_t_eta_top_index_scope.tex` and
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
 theorem reductionCriterion_right_of_hasSchmidtNumberLE [NeZero D] {n : ℕ}
     (hn1 : 1 ≤ n) (hnD : n < D)
     {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :

--- a/TNLean/Channel/SchmidtNumber.lean
+++ b/TNLean/Channel/SchmidtNumber.lean
@@ -183,23 +183,6 @@ theorem isSeparable_vecMulVec_of_hasSchmidtRankLE_one {ψ : Fin d × Fin d' → 
   rw [hkron]
   exact isSeparable_kronecker (posSemidef_vecMulVec_self_star u) (posSemidef_vecMulVec_self_star v)
 
-/-- A finite sum of separable matrices is separable: the empty sum is the zero
-Kronecker product and the inductive step is the additive closure of separability. -/
-theorem isSeparable_sum {ι : Type*} (s : Finset ι)
-    {f : ι → Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
-    (hf : ∀ i ∈ s, IsSeparable (f i)) : IsSeparable (∑ i ∈ s, f i) := by
-  classical
-  induction s using Finset.induction with
-  | empty =>
-      simp only [Finset.sum_empty]
-      simpa using isSeparable_kronecker (d := d) (d' := d')
-        (A := (0 : Matrix (Fin d) (Fin d) ℂ)) (B := (0 : Matrix (Fin d') (Fin d') ℂ))
-        PosSemidef.zero PosSemidef.zero
-  | insert a s ha ih =>
-      rw [Finset.sum_insert ha]
-      exact (hf a (Finset.mem_insert_self a s)).add
-        (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
-
 /-- **Schmidt number one implies separability** (Wolf §3.2).  A state of Schmidt
 number at most one is a finite sum of pure-state projectors of Schmidt rank at most
 one; each is a product state, hence separable, and separable matrices are closed
@@ -226,25 +209,6 @@ theorem hasSchmidtNumberLE_sum {n : ℕ} {ι : Type*} (s : Finset ι)
       rw [Finset.sum_insert ha]
       exact (hf a (Finset.mem_insert_self a s)).add
         (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
-
-/-- The Kronecker product of two pure-state projectors is the pure-state projector
-of the product vector, which has Schmidt rank at most one. -/
-theorem vecMulVec_kronecker_vecMulVec (a : Fin d → ℂ) (b : Fin d' → ℂ) :
-    vecMulVec a (star a) ⊗ₖ vecMulVec b (star b)
-      = vecMulVec (fun p : Fin d × Fin d' => a p.1 * b p.2)
-          (star (fun p : Fin d × Fin d' => a p.1 * b p.2)) := by
-  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
-  simp only [kroneckerMap_apply, vecMulVec_apply, Pi.star_apply]
-  rw [star_mul']
-  ring
-
-/-- The Kronecker product distributes over a double finite sum entrywise. -/
-theorem sum_kronecker_sum {ιa ιb : Type*} [Fintype ιa] [Fintype ιb]
-    (A : ιa → Matrix (Fin d) (Fin d) ℂ) (B : ιb → Matrix (Fin d') (Fin d') ℂ) :
-    (∑ i, A i) ⊗ₖ (∑ j, B j) = ∑ i, ∑ j, A i ⊗ₖ B j := by
-  ext ⟨p₁, p₂⟩ ⟨q₁, q₂⟩
-  simp only [kroneckerMap_apply, Matrix.sum_apply, Finset.sum_mul, Finset.mul_sum]
-  rw [Finset.sum_comm]
 
 /-- A Kronecker product of two positive semidefinite matrices has Schmidt number at
 most one.  Each factor is a finite sum of rank-one projectors, the Kronecker product

--- a/TNLean/Channel/Separable.lean
+++ b/TNLean/Channel/Separable.lean
@@ -136,6 +136,23 @@ theorem IsSeparable.smul {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
   · rw [Finset.smul_sum]
     exact Finset.sum_congr rfl fun i _ => (smul_kronecker (c : ℂ) (A i) (B i)).symm
 
+/-- A finite sum of separable matrices is separable: the empty sum is the zero
+Kronecker product and the inductive step is the additive closure of separability. -/
+theorem isSeparable_sum {ι : Type*} (s : Finset ι)
+    {f : ι → Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hf : ∀ i ∈ s, IsSeparable (f i)) : IsSeparable (∑ i ∈ s, f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty =>
+      simp only [Finset.sum_empty]
+      simpa using isSeparable_kronecker (d := d) (d' := d')
+        (A := (0 : Matrix (Fin d) (Fin d) ℂ)) (B := (0 : Matrix (Fin d') (Fin d') ℂ))
+        PosSemidef.zero PosSemidef.zero
+  | insert a s ha ih =>
+      rw [Finset.sum_insert ha]
+      exact (hf a (Finset.mem_insert_self a s)).add
+        (ih fun i hi => hf i (Finset.mem_insert_of_mem hi))
+
 /-! ## Separable matrices are positive semidefinite -/
 
 /-- **A separable matrix is positive semidefinite** (Wolf §3.2).  Each summand
@@ -173,6 +190,27 @@ theorem IsSeparable.isPPT {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
   refine posSemidef_sum Finset.univ fun i _ => ?_
   rw [partialTransposeLeft_kronecker]
   exact PosSemidef.kronecker (posSemidef_transpose_iff.mpr (hAB i).1) (hAB i).2
+
+/-! ## Kronecker-product identities -/
+
+/-- The Kronecker product of two pure-state projectors is the pure-state projector
+of the product vector. -/
+theorem vecMulVec_kronecker_vecMulVec (a : Fin d → ℂ) (b : Fin d' → ℂ) :
+    vecMulVec a (star a) ⊗ₖ vecMulVec b (star b)
+      = vecMulVec (fun p : Fin d × Fin d' => a p.1 * b p.2)
+          (star (fun p : Fin d × Fin d' => a p.1 * b p.2)) := by
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  simp only [kroneckerMap_apply, vecMulVec_apply, Pi.star_apply]
+  rw [star_mul']
+  ring
+
+/-- The Kronecker product distributes over a double finite sum entrywise. -/
+theorem sum_kronecker_sum {ιa ιb : Type*} [Fintype ιa] [Fintype ιb]
+    (A : ιa → Matrix (Fin d) (Fin d) ℂ) (B : ιb → Matrix (Fin d') (Fin d') ℂ) :
+    (∑ i, A i) ⊗ₖ (∑ j, B j) = ∑ i, ∑ j, A i ⊗ₖ B j := by
+  ext ⟨p₁, p₂⟩ ⟨q₁, q₂⟩
+  simp only [kroneckerMap_apply, Matrix.sum_apply, Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
 
 /-! ## The reduction map on a separable state (Wolf eq. (3.18) at n = 1) -/
 

--- a/TNLean/Channel/Separable.lean
+++ b/TNLean/Channel/Separable.lean
@@ -50,6 +50,8 @@ positive semidefinite operators.
 * `Matrix.IsSeparable.add`: separable matrices are closed under addition.
 * `Matrix.IsSeparable.smul`: separable matrices are closed under multiplication by
   a nonnegative real scalar.
+* `Matrix.isSeparable_sum`: separable matrices are closed under arbitrary finite
+  sums.
 * `Matrix.IsSeparable.isPPT`: **the PPT criterion, forward direction** — every
   separable matrix has the positive-partial-transpose property, ρ^{T₁} ≥ 0.
 * `Matrix.IsSeparable.tensorMapId_tEta_one_posSemidef`: the reduction map at n = 1
@@ -191,27 +193,6 @@ theorem IsSeparable.isPPT {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
   rw [partialTransposeLeft_kronecker]
   exact PosSemidef.kronecker (posSemidef_transpose_iff.mpr (hAB i).1) (hAB i).2
 
-/-! ## Kronecker-product identities -/
-
-/-- The Kronecker product of two pure-state projectors is the pure-state projector
-of the product vector. -/
-theorem vecMulVec_kronecker_vecMulVec (a : Fin d → ℂ) (b : Fin d' → ℂ) :
-    vecMulVec a (star a) ⊗ₖ vecMulVec b (star b)
-      = vecMulVec (fun p : Fin d × Fin d' => a p.1 * b p.2)
-          (star (fun p : Fin d × Fin d' => a p.1 * b p.2)) := by
-  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
-  simp only [kroneckerMap_apply, vecMulVec_apply, Pi.star_apply]
-  rw [star_mul']
-  ring
-
-/-- The Kronecker product distributes over a double finite sum entrywise. -/
-theorem sum_kronecker_sum {ιa ιb : Type*} [Fintype ιa] [Fintype ιb]
-    (A : ιa → Matrix (Fin d) (Fin d) ℂ) (B : ιb → Matrix (Fin d') (Fin d') ℂ) :
-    (∑ i, A i) ⊗ₖ (∑ j, B j) = ∑ i, ∑ j, A i ⊗ₖ B j := by
-  ext ⟨p₁, p₂⟩ ⟨q₁, q₂⟩
-  simp only [kroneckerMap_apply, Matrix.sum_apply, Finset.sum_mul, Finset.mul_sum]
-  rw [Finset.sum_comm]
-
 /-! ## The reduction map on a separable state (Wolf eq. (3.18) at n = 1) -/
 
 /-- Applying a map to the first factor distributes over a finite sum of bipartite
@@ -243,5 +224,26 @@ theorem IsSeparable.tensorMapId_tEta_one_posSemidef [NeZero d]
   refine posSemidef_sum Finset.univ fun i _ => ?_
   rw [tensorMapId_kronecker]
   exact PosSemidef.kronecker (hpos (A i) (hAB i).1) (hAB i).2
+
+/-! ## Kronecker-product identities -/
+
+/-- The Kronecker product of two pure-state projectors is the pure-state projector
+of the product vector, which has Schmidt rank at most one. -/
+theorem vecMulVec_kronecker_vecMulVec (a : Fin d → ℂ) (b : Fin d' → ℂ) :
+    vecMulVec a (star a) ⊗ₖ vecMulVec b (star b)
+      = vecMulVec (fun p : Fin d × Fin d' => a p.1 * b p.2)
+          (star (fun p : Fin d × Fin d' => a p.1 * b p.2)) := by
+  ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+  simp only [kroneckerMap_apply, vecMulVec_apply, Pi.star_apply]
+  rw [star_mul']
+  ring
+
+/-- The Kronecker product distributes over a double finite sum entrywise. -/
+theorem sum_kronecker_sum {ιa ιb : Type*} [Fintype ιa] [Fintype ιb]
+    (A : ιa → Matrix (Fin d) (Fin d) ℂ) (B : ιb → Matrix (Fin d') (Fin d') ℂ) :
+    (∑ i, A i) ⊗ₖ (∑ j, B j) = ∑ i, ∑ j, A i ⊗ₖ B j := by
+  ext ⟨p₁, p₂⟩ ⟨q₁, q₂⟩
+  simp only [kroneckerMap_apply, Matrix.sum_apply, Finset.sum_mul, Finset.mul_sum]
+  rw [Finset.sum_comm]
 
 end Matrix

--- a/TNLean/Channel/Separable.lean
+++ b/TNLean/Channel/Separable.lean
@@ -66,10 +66,9 @@ with positive partial transpose exist once the dimension exceeds ℂ² ⊗ ℂ²
 The reduction-map positivity recorded here is the n = 1 instance: a separable
 state is exactly a state of Schmidt number one.  The Schmidt-number filtration for
 general n — of which separability is the lowest level — and the resulting general
-reduction criterion of Wolf eq. (3.18) with its Schmidt-number premise are a
-further step built on the predicate introduced here; they are recorded in
-`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex` and are not
-formalized in this file.
+reduction criterion of Wolf eq. (3.18) with its Schmidt-number premise are
+formalized in `SchmidtNumber.lean`, which proves that Schmidt number one coincides
+with separability.
 
 ## References
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -2042,7 +2042,7 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
         lem:rank_one_ampliation_choi_compression,
         thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
     For a pure state $\ket{\psi}\bra{\psi}$ on the square bipartite system
-    $\mathbb{C}^D\otimes\mathbb{C}^D$ with $\operatorname{SR}(\psi)\le n$ and
+    $\MN{D}\otimes\MN{D}$ with $\operatorname{SR}(\psi)\le n$ and
     $1\le n<D$, applying $T_n$ to the first factor keeps the result positive
     semidefinite:
     \[
@@ -2068,8 +2068,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \leanok
     \uses{def:has_schmidt_number_le, def:t_eta, def:tensor_map_id,
         thm:tensor_map_id_sum, thm:tensor_map_id_t_eta_posSemidef_pure}
-    For $1\le n<D$, a bipartite state on the square system
-    $\mathbb{C}^D\otimes\mathbb{C}^D$ of Schmidt number at most $n$ satisfies
+    For $1\le n<D$, a bipartite state on the square system $\MN{D}\otimes\MN{D}$ of
+    Schmidt number at most $n$ satisfies
     \[
         (T_n\otimes\id)(\rho)\ge 0.
     \]
@@ -2090,8 +2090,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \leanok
     \uses{def:has_schmidt_number_le, def:t_eta,
         thm:has_schmidt_number_le_tensor_map_id_t_eta, thm:reduction_criterion}
-    For $1\le n<D$, a bipartite state on the square system
-    $\mathbb{C}^D\otimes\mathbb{C}^D$ of Schmidt number at most $n$ satisfies the
+    For $1\le n<D$, a bipartite state on the square system $\MN{D}\otimes\MN{D}$ of
+    Schmidt number at most $n$ satisfies the
     reduction criterion
     \[
         n\,\rho_1\otimes\Id\ge\rho
@@ -2099,9 +2099,6 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
         n\,\Id\otimes\rho_2\ge\rho,
     \]
     with $\rho_1$ and $\rho_2$ the reduced densities on the first and second factors.
-    Wolf states the criterion for a general bipartite system
-    $\mathbb{C}^d\otimes\mathbb{C}^{d'}$; the formalization covers the square case
-    $d=d'=D$.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1567,10 +1567,10 @@ of a bipartite state whose Schmidt number is at most $n$.
     \cite[Equation~(3.18)]{Wolf2012Quantum}.  The source states the inequalities
     under the premise that $\rho$ has Schmidt number at most $n$, and reaches
     $(T_n\otimes\id)(\rho)\ge 0$ from that premise by the $n$-positivity of
-    $T_n$; that first step is taken here as the hypothesis rather than derived,
-    because a Schmidt-number predicate is not yet available.  The deviation is
-    recorded in
-    \path{docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex}.
+    $T_n$; that first step is taken here as the hypothesis rather than derived.
+    The first step and the composed full criterion with the Schmidt-number
+    premise are
+    Theorem~\ref{thm:reduction_criterion_of_schmidt_number}.
 \end{theorem}
 
 \begin{proof}
@@ -1959,6 +1959,154 @@ the product positive operators, which is the form used below.
     The ampliation acts by $(T_1\otimes\id)(A_i\otimes B_i)=T_1(A_i)\otimes B_i$, each
     summand is a Kronecker product of positive semidefinite matrices, and the sum is
     positive semidefinite.
+\end{proof}
+
+\subsection{The Schmidt number and the full reduction criterion}
+
+The Schmidt number of a bipartite state is the smallest $n$ for which the state has
+a convex decomposition into pure states each of Schmidt rank at most $n$.  Separable
+states are precisely those of Schmidt number one, and a state of Schmidt number at
+most $n$ satisfies the reduction criterion
+\[
+    n\,\rho_1\otimes\Id\ge\rho
+    \qquad\text{and}\qquad
+    n\,\Id\otimes\rho_2\ge\rho,
+\]
+which is \cite[Equation~(3.18)]{Wolf2012Quantum}.  The bound on the Schmidt number is
+recorded as a finite sum of pure-state projectors of Schmidt rank at most $n$, the
+unnormalized form of the convex decomposition; rescaling a vector by the square root
+of its weight scales its coefficient matrix and so leaves the Schmidt rank unchanged.
+
+\begin{definition}[Bounded Schmidt number]
+    \label{def:has_schmidt_number_le}
+    \lean{Matrix.HasSchmidtNumberLE}
+    \leanok
+    \uses{def:schmidt_rank}
+    A bipartite matrix $\rho$ on $\MN{d}\otimes\MN{d'}$ has Schmidt number at most $n$
+    when it is a finite sum of pure-state projectors of Schmidt rank at most $n$,
+    \[
+        \rho=\sum_i\ket{\psi_i}\bra{\psi_i},
+        \qquad \operatorname{SR}(\psi_i)\le n.
+    \]
+\end{definition}
+
+\begin{theorem}[Basic properties of bounded Schmidt number]
+    \label{thm:has_schmidt_number_le_basic}
+    \lean{Matrix.HasSchmidtNumberLE.posSemidef, Matrix.HasSchmidtNumberLE.add,
+        Matrix.HasSchmidtNumberLE.mono}
+    \leanok
+    \uses{def:has_schmidt_number_le}
+    A matrix of Schmidt number at most $n$ is positive semidefinite.  States of
+    Schmidt number at most $n$ are closed under addition, and a bound on the Schmidt
+    number relaxes to any larger bound.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Each summand $\ket{\psi_i}\bra{\psi_i}$ is a rank-one positive semidefinite
+    matrix, and a finite sum of positive semidefinite matrices is positive
+    semidefinite.  Concatenating two pure-state families realizes a sum as a single
+    finite sum of pure-state projectors of Schmidt rank at most $n$, and a pure
+    summand of Schmidt rank at most $n$ also has Schmidt rank at most any larger
+    bound.
+\end{proof}
+
+\begin{theorem}[Schmidt number one is separability]
+    \label{thm:has_schmidt_number_le_one_iff_separable}
+    \lean{Matrix.hasSchmidtNumberLE_one_iff_isSeparable}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:is_separable, def:schmidt_rank,
+        lem:matrix_rank_factorization_coordinate, thm:schmidt_rank_basic_bounds,
+        thm:is_separable_kronecker, thm:is_separable_add}
+    A bipartite matrix has Schmidt number at most one if and only if it is separable.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    A pure state of Schmidt rank at most one has a coefficient matrix of rank at most
+    one, which factors as $\psi(i,j)=u_i v_j$; its projector is the Kronecker product
+    $\ket{u}\bra{u}\otimes\ket{v}\bra{v}$ of two rank-one positive semidefinite
+    matrices, hence separable, and separable matrices are closed under addition.
+    Conversely a Kronecker product $A\otimes B$ of positive semidefinite matrices,
+    after expanding each factor into rank-one projectors, is a double sum of
+    product-vector projectors, each of Schmidt rank at most one, so it has Schmidt
+    number at most one; a separable matrix is a finite sum of such products.
+\end{proof}
+
+\begin{theorem}[Pure-state step of the reduction criterion]
+    \label{thm:tensor_map_id_t_eta_posSemidef_pure}
+    \lean{Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE}
+    \leanok
+    \uses{def:schmidt_rank, def:t_eta, def:tensor_map_id, thm:t_eta_threshold,
+        thm:reduction_map_eq_t_eta, thm:square_schmidt_rank_exact_parametrization,
+        lem:rank_one_ampliation_choi_compression,
+        thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
+    For a pure state $\ket{\psi}\bra{\psi}$ with $\operatorname{SR}(\psi)\le n$ and
+    $1\le n<D$, applying $T_n$ to the first factor keeps the result positive
+    semidefinite:
+    \[
+        (T_n\otimes\id)(\ket{\psi}\bra{\psi})\ge 0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The map $T_n$ is $n$-positive for $1\le n<D$.  Write $\psi$ through the maximally
+    entangled vector as $\psi=\psi_X$ for a square matrix $X$ on the right factor with
+    $\operatorname{rank}(X)=\operatorname{SR}(\psi)\le n$.  Then
+    $(T_n\otimes\id)(\ket{\psi}\bra{\psi})$ is the right-factor Choi compression of
+    $T_n$ by $X$.  Its quadratic form on any vector $\eta$ is the Choi quadratic form
+    of $T_n$ on $R_X^\dagger\eta$, whose Schmidt rank is at most
+    $\operatorname{rank}(X)\le n$.  The Schmidt-rank Choi criterion makes that form
+    nonnegative, so the compression is positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Reduction step from the Schmidt-number premise]
+    \label{thm:has_schmidt_number_le_tensor_map_id_t_eta}
+    \lean{Matrix.HasSchmidtNumberLE.tensorMapId_tEta_posSemidef}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:t_eta, def:tensor_map_id,
+        thm:tensor_map_id_sum, thm:tensor_map_id_t_eta_posSemidef_pure}
+    For $1\le n<D$, a bipartite state of Schmidt number at most $n$ satisfies
+    \[
+        (T_n\otimes\id)(\rho)\ge 0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The state is a finite sum of pure-state projectors of Schmidt rank at most $n$.
+    Applying $T_n$ to the first factor is linear, so it distributes over the sum; the
+    pure-state step makes each summand positive semidefinite, and a finite sum of
+    positive semidefinite matrices is positive semidefinite.
+\end{proof}
+
+\begin{theorem}[Reduction criterion with the Schmidt-number premise]
+    \label{thm:reduction_criterion_of_schmidt_number}
+    \lean{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE,
+        Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:t_eta,
+        thm:has_schmidt_number_le_tensor_map_id_t_eta, thm:reduction_criterion}
+    For $1\le n<D$, a bipartite state of Schmidt number at most $n$ satisfies the
+    reduction criterion
+    \[
+        n\,\rho_1\otimes\Id\ge\rho
+        \qquad\text{and}\qquad
+        n\,\Id\otimes\rho_2\ge\rho,
+    \]
+    with $\rho_1$ and $\rho_2$ the reduced densities on the first and second factors.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The Schmidt-number premise gives $(T_n\otimes\id)(\rho)\ge 0$, which is the first
+    step.  The operator implication then yields $n\,\Id\otimes\rho_2\ge\rho$.  The
+    factor swap of a state of Schmidt number at most $n$ again has Schmidt number at
+    most $n$, since the swap reindexes each pure summand to a vector with the
+    transposed coefficient matrix, of the same rank; applying the first step to the
+    swapped state and the operator implication in its symmetric form gives
+    $n\,\rho_1\otimes\Id\ge\rho$.
 \end{proof}
 
 \begin{theorem}[Completely positive implies two-positive]

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -2041,7 +2041,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
         thm:reduction_map_eq_t_eta, thm:square_schmidt_rank_exact_parametrization,
         lem:rank_one_ampliation_choi_compression,
         thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
-    For a pure state $\ket{\psi}\bra{\psi}$ with $\operatorname{SR}(\psi)\le n$ and
+    For a pure state $\ket{\psi}\bra{\psi}$ on the square bipartite system
+    $\MN{D}\otimes\MN{D}$ with $\operatorname{SR}(\psi)\le n$ and
     $1\le n<D$, applying $T_n$ to the first factor keeps the result positive
     semidefinite:
     \[
@@ -2067,7 +2068,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \leanok
     \uses{def:has_schmidt_number_le, def:t_eta, def:tensor_map_id,
         thm:tensor_map_id_sum, thm:tensor_map_id_t_eta_posSemidef_pure}
-    For $1\le n<D$, a bipartite state of Schmidt number at most $n$ satisfies
+    For $1\le n<D$, a bipartite state on the square system $\MN{D}\otimes\MN{D}$ of
+    Schmidt number at most $n$ satisfies
     \[
         (T_n\otimes\id)(\rho)\ge 0.
     \]
@@ -2088,7 +2090,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \leanok
     \uses{def:has_schmidt_number_le, def:t_eta,
         thm:has_schmidt_number_le_tensor_map_id_t_eta, thm:reduction_criterion}
-    For $1\le n<D$, a bipartite state of Schmidt number at most $n$ satisfies the
+    For $1\le n<D$, a bipartite state on the square system $\MN{D}\otimes\MN{D}$ of
+    Schmidt number at most $n$ satisfies the
     reduction criterion
     \[
         n\,\rho_1\otimes\Id\ge\rho

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -2042,7 +2042,7 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
         lem:rank_one_ampliation_choi_compression,
         thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
     For a pure state $\ket{\psi}\bra{\psi}$ on the square bipartite system
-    $\MN{D}\otimes\MN{D}$ with $\operatorname{SR}(\psi)\le n$ and
+    $\mathbb{C}^D\otimes\mathbb{C}^D$ with $\operatorname{SR}(\psi)\le n$ and
     $1\le n<D$, applying $T_n$ to the first factor keeps the result positive
     semidefinite:
     \[
@@ -2068,8 +2068,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \leanok
     \uses{def:has_schmidt_number_le, def:t_eta, def:tensor_map_id,
         thm:tensor_map_id_sum, thm:tensor_map_id_t_eta_posSemidef_pure}
-    For $1\le n<D$, a bipartite state on the square system $\MN{D}\otimes\MN{D}$ of
-    Schmidt number at most $n$ satisfies
+    For $1\le n<D$, a bipartite state on the square system
+    $\mathbb{C}^D\otimes\mathbb{C}^D$ of Schmidt number at most $n$ satisfies
     \[
         (T_n\otimes\id)(\rho)\ge 0.
     \]
@@ -2090,8 +2090,8 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \leanok
     \uses{def:has_schmidt_number_le, def:t_eta,
         thm:has_schmidt_number_le_tensor_map_id_t_eta, thm:reduction_criterion}
-    For $1\le n<D$, a bipartite state on the square system $\MN{D}\otimes\MN{D}$ of
-    Schmidt number at most $n$ satisfies the
+    For $1\le n<D$, a bipartite state on the square system
+    $\mathbb{C}^D\otimes\mathbb{C}^D$ of Schmidt number at most $n$ satisfies the
     reduction criterion
     \[
         n\,\rho_1\otimes\Id\ge\rho
@@ -2099,6 +2099,9 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
         n\,\Id\otimes\rho_2\ge\rho,
     \]
     with $\rho_1$ and $\rho_2$ the reduced densities on the first and second factors.
+    Wolf states the criterion for a general bipartite system
+    $\mathbb{C}^d\otimes\mathbb{C}^{d'}$; the formalization covers the square case
+    $d=d'=D$.
 \end{theorem}
 
 \begin{proof}

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -108,11 +108,28 @@ the map $T_n$ is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
     \doclink{TNLean/Channel/NPositivityChainStrict}, the reduction map being
     $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.}
 
+The pure-state step writes $\psi$ through the maximally entangled vector as a
+\emph{square} right-factor matrix, so the formalized statements fix the two tensor
+factors to a common dimension $D$: they live on the square bipartite system
+$\mathbb{C}^D\otimes\mathbb{C}^D$ rather than on Wolf's general
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$. The restriction enters through the square
+parametrization of a bipartite vector by a maximally-entangled-vector compression,
+which is currently available only for equal-dimension factors. Eliminating it
+requires the rectangular form of that parametrization (a vector on
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$ written as a $d\times d'$ right-factor matrix);
+once that is formalized, the three headline statements generalize verbatim to
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$.
+
 \section{Classification}
 
-\emph{Resolved}, with a residual scope restriction $1\le n<D$ inherited from the
+\emph{Resolved on the square bipartite system $\mathbb{C}^D\otimes\mathbb{C}^D$},
+with two residual scope restrictions. The first, $1\le n<D$, is inherited from the
 $n$-positivity threshold of $T_\eta$, whose top index $n=D$ (complete positivity)
-is documented in \path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The full
+is documented in \path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The second,
+the equal-dimension condition $d=d'=D$, comes from the square maximally-entangled-vector
+parametrization in the pure-state step; Wolf's eq.~(3.18) is stated for a general
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$, and its rectangular case awaits the rectangular
+form of that parametrization (elimination plan above). The square-system full
 criterion with Wolf's Schmidt-number premise is now available at
 \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
 \leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}. The operator-half

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -76,45 +76,49 @@ underlying identity $(T_n\otimes\operatorname{id})(\rho)=\mathbf 1\otimes\rho_2-
 also formalized.\footnote{Formal declaration:
     \leanid{Matrix.tensorMapId_tEta_eq}.}
 
-\section{The gap}
+\section{Resolution}
 
-The formalized statement carries the hypothesis $(T_n\otimes\operatorname{id})(\rho)\ge 0$,
-which is the intermediate produced by step~1 rather than the source premise
-$\operatorname{sn}(\rho)\le n$. Step~1 is not yet formalized because the
-repository has no Schmidt-number predicate for mixed states, equivalently no
-separable-state predicate from which the Schmidt-number filtration is built. The
-same missing foundation is the obstruction to the separability extension of the
-reduction criterion as an entanglement criterion.
+Step~1 is now formalized. A Schmidt-number predicate for mixed
+states\footnote{Formal declaration: \leanid{Matrix.HasSchmidtNumberLE} in
+    \doclink{TNLean/Channel/SchmidtNumber}.} records that $\rho$ is a finite sum
+of pure-state projectors of Schmidt rank at most $n$, which is Wolf's convex
+decomposition up to normalization. At $n=1$ this predicate coincides with
+separability.\footnote{Formal declaration:
+    \leanid{Matrix.hasSchmidtNumberLE_one_iff_isSeparable}.}
 
-The $n$-positivity content needed for step~1 is itself available: the map $T_n$
-is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
+The pure-state step shows that for a vector $\psi$ of Schmidt rank at most $n$
+(with $1\le n<D$) the ampliation $(T_n\otimes\operatorname{id})(\ketbra\psi\psi)$ is positive
+semidefinite,\footnote{Formal declaration:
+    \leanid{Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE}.} by writing
+$\psi$ through the maximally entangled vector as a square right-factor matrix of
+rank equal to the Schmidt rank of $\psi$, identifying the ampliation with the
+right-factor Choi compression, and using the $n$-positivity of $T_n$ on the
+resulting Schmidt-rank-$\le n$ vector. Summing over the pure terms gives step~1:
+a state of Schmidt number at most $n$ has
+$(T_n\otimes\operatorname{id})(\rho)\ge 0$.\footnote{Formal declaration:
+    \leanid{Matrix.HasSchmidtNumberLE.tensorMapId_tEta_posSemidef}.} Composing
+step~1 with the formalized step~2 yields Wolf's eq.~(3.18) with its
+Schmidt-number premise.\footnote{Formal declarations:
+    \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
+    \leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}.}
+
+The $n$-positivity content used in the pure-state step is the threshold theorem:
+the map $T_n$ is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
     \leanid{Matrix.isNPositiveMap_tEta_iff} in
     \doclink{TNLean/Channel/NPositivityChainStrict}, the reduction map being
-    $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.} What is
-absent is the predicate $\operatorname{sn}(\rho)\le n$ and the lemma that it
-implies $\rho$ lies in the cone on which the $n$-positive ampliation acts
-positively.
-
-\section{Elimination plan}
-
-Introduce a Schmidt-number predicate for bipartite matrices, built from a
-separable-state predicate, and prove step~1: a state of Schmidt number at most
-$n$ has $(T_n\otimes\operatorname{id})(\rho)\ge 0$, by writing it as a convex combination of
-Schmidt-rank-$\le n$ pure states and applying the $n$-positivity already
-formalized. Composing step~1 with the formalized step~2 recovers Wolf's
-eq.~(3.18) with its Schmidt-number premise. The separability foundation is
-shared with the entanglement-criterion extension and is tracked alongside the
-PPT and Schmidt-number formalization tasks.
+    $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.}
 
 \section{Classification}
 
-\emph{Scope restriction.} The formal theorems prove the second step of Wolf's
-two-step argument: the operator implication from $(T_n\otimes\operatorname{id})(\rho)\ge 0$ to
-the inequalities of eq.~(3.18). The conclusions match the source exactly; the
-hypothesis is the derived intermediate of step~1, so the formalized statement is
-strictly weaker than, and is a sub-step of, the source implication. No
-hypothesis foreign to the source is introduced, so the deviation is a scope
-restriction rather than an unfaithful theorem.
+\emph{Resolved}, with a residual scope restriction $1\le n<D$ inherited from the
+$n$-positivity threshold of $T_\eta$, whose top index $n=D$ (complete positivity)
+is documented in \path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The full
+criterion with Wolf's Schmidt-number premise is now available at
+\leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
+\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}. The operator-half
+theorems \leanid{Matrix.reductionCriterion_left} and
+\leanid{Matrix.reductionCriterion_right} remain as the separability-free
+sub-step, no longer the limit of what is formalized.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -108,33 +108,34 @@ the map $T_n$ is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
     \doclink{TNLean/Channel/NPositivityChainStrict}, the reduction map being
     $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.}
 
+The pure-state step writes $\psi$ through the maximally entangled vector as a
+\emph{square} right-factor matrix, so the formalized statements fix the two tensor
+factors to a common dimension $D$: they live on the square bipartite system
+$\mathbb{C}^D\otimes\mathbb{C}^D$ rather than on Wolf's general
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$. The restriction enters through the square
+parametrization of a bipartite vector by a maximally-entangled-vector compression,
+which is currently available only for equal-dimension factors. Eliminating it
+requires the rectangular form of that parametrization (a vector on
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$ written as a $d\times d'$ right-factor matrix);
+once that is formalized, the three headline statements generalize verbatim to
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$.
+
 \section{Classification}
 
-\emph{Resolved for the square bipartite system $d=d'=D$}, with two residual scope
-restrictions.
-
-First, the formalized step-1 theorems fix both tensor factors to a common dimension
-$D$: the pure-state step parametrizes $\psi$ through the \emph{square} maximally
-entangled vector\footnote{Formal declaration:
-    \leanid{ChoiJamiolkowski.exists_squareCompression_of_vector} in
-    \doclink{TNLean/Channel/Schwarz/ChoiCompression}.} on
-$\mathbb C^D\otimes\mathbb C^D$, whereas Wolf states eq.~(3.18) for a general
-bipartite state on $\mathbb C^d\otimes\mathbb C^{d'}$. The non-square case
-$d\ne d'$ remains unformalized; its elimination requires a rectangular maximally
-entangled parametrization in place of the square one. The operator-half (step~2)
+\emph{Resolved on the square bipartite system $\mathbb{C}^D\otimes\mathbb{C}^D$},
+with two residual scope restrictions. The first, $1\le n<D$, is inherited from the
+$n$-positivity threshold of $T_\eta$, whose top index $n=D$ (complete positivity)
+is documented in \path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The second,
+the equal-dimension condition $d=d'=D$, comes from the square maximally-entangled-vector
+parametrization in the pure-state step; Wolf's eq.~(3.18) is stated for a general
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$, and its rectangular case awaits the rectangular
+form of that parametrization (elimination plan above). The square-system full
+criterion with Wolf's Schmidt-number premise is now available at
+\leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
+\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}. The operator-half
 theorems \leanid{Matrix.reductionCriterion_left} and
-\leanid{Matrix.reductionCriterion_right} already hold for separate dimensions
-$D,D'$, so only step~1 carries the square restriction.
-
-Second, the bound $1\le n<D$ is inherited from the $n$-positivity threshold of
-$T_\eta$, whose top index $n=D$ (complete positivity) is documented in
-\path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}.
-
-Within these two restrictions the full criterion with Wolf's Schmidt-number premise
-is available at \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
-\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}; the operator-half
-theorems remain as the separability-free sub-step, no longer the limit of what is
-formalized.
+\leanid{Matrix.reductionCriterion_right} remain as the separability-free
+sub-step, no longer the limit of what is formalized.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -108,34 +108,33 @@ the map $T_n$ is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
     \doclink{TNLean/Channel/NPositivityChainStrict}, the reduction map being
     $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.}
 
-The pure-state step writes $\psi$ through the maximally entangled vector as a
-\emph{square} right-factor matrix, so the formalized statements fix the two tensor
-factors to a common dimension $D$: they live on the square bipartite system
-$\mathbb{C}^D\otimes\mathbb{C}^D$ rather than on Wolf's general
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$. The restriction enters through the square
-parametrization of a bipartite vector by a maximally-entangled-vector compression,
-which is currently available only for equal-dimension factors. Eliminating it
-requires the rectangular form of that parametrization (a vector on
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$ written as a $d\times d'$ right-factor matrix);
-once that is formalized, the three headline statements generalize verbatim to
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$.
-
 \section{Classification}
 
-\emph{Resolved on the square bipartite system $\mathbb{C}^D\otimes\mathbb{C}^D$},
-with two residual scope restrictions. The first, $1\le n<D$, is inherited from the
-$n$-positivity threshold of $T_\eta$, whose top index $n=D$ (complete positivity)
-is documented in \path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The second,
-the equal-dimension condition $d=d'=D$, comes from the square maximally-entangled-vector
-parametrization in the pure-state step; Wolf's eq.~(3.18) is stated for a general
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$, and its rectangular case awaits the rectangular
-form of that parametrization (elimination plan above). The square-system full
-criterion with Wolf's Schmidt-number premise is now available at
-\leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
-\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}. The operator-half
+\emph{Resolved for the square bipartite system $d=d'=D$}, with two residual scope
+restrictions.
+
+First, the formalized step-1 theorems fix both tensor factors to a common dimension
+$D$: the pure-state step parametrizes $\psi$ through the \emph{square} maximally
+entangled vector\footnote{Formal declaration:
+    \leanid{ChoiJamiolkowski.exists_squareCompression_of_vector} in
+    \doclink{TNLean/Channel/Schwarz/ChoiCompression}.} on
+$\mathbb C^D\otimes\mathbb C^D$, whereas Wolf states eq.~(3.18) for a general
+bipartite state on $\mathbb C^d\otimes\mathbb C^{d'}$. The non-square case
+$d\ne d'$ remains unformalized; its elimination requires a rectangular maximally
+entangled parametrization in place of the square one. The operator-half (step~2)
 theorems \leanid{Matrix.reductionCriterion_left} and
-\leanid{Matrix.reductionCriterion_right} remain as the separability-free
-sub-step, no longer the limit of what is formalized.
+\leanid{Matrix.reductionCriterion_right} already hold for separate dimensions
+$D,D'$, so only step~1 carries the square restriction.
+
+Second, the bound $1\le n<D$ is inherited from the $n$-positivity threshold of
+$T_\eta$, whose top index $n=D$ (complete positivity) is documented in
+\path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}.
+
+Within these two restrictions the full criterion with Wolf's Schmidt-number premise
+is available at \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
+\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}; the operator-half
+theorems remain as the separability-free sub-step, no longer the limit of what is
+formalized.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- Wolf eq. (3.18) (§3.2) gives a necessary condition for a bipartite state with Schmidt number at most $n$: it satisfies $n(\rho_1 \otimes 1) \geq \rho$ and $n(1 \otimes \rho_2) \geq \rho$. The operator-implication lemmas in `ReductionCriterion.lean` required Schmidt number as a hypothesis but no formalized predicate supplied it; this PR closes that premise gap.
- Advances the formalization of entanglement detection by positive maps (#3398) and resolves the Schmidt-premise scope restriction documented for LionSR/QICLean#21.
- Source: `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, §3.2, eq. (3.18).

### Description

New module `TNLean/Channel/SchmidtNumber.lean`:

- `Matrix.HasSchmidtNumberLE n ρ`: `ρ` is a finite sum of pure-state projectors each of Schmidt rank ≤ `n`; basic closure under `posSemidef`, `add`, `mono`.
- `Matrix.hasSchmidtNumberLE_one_iff_isSeparable`: Schmidt number ≤ 1 ↔ separable (connects to `Separable.lean`).
- `Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE`: for a pure state `ψ` of Schmidt rank ≤ `n` (1 ≤ n < D), `(T_n ⊗ id)(|ψ⟩⟨ψ|) ≥ 0`.
- `HasSchmidtNumberLE.tensorMapId_tEta_posSemidef`: sums the pure-state step over the decomposition to obtain `(T_n ⊗ id)(ρ) ≥ 0`.
- `reductionCriterion_left_of_hasSchmidtNumberLE`, `reductionCriterion_right_of_hasSchmidtNumberLE`: Wolf eq. (3.18) with the actual Schmidt-number premise (residual hypothesis 1 ≤ n < D from the T_η n-positivity threshold).

Modified files:

- `TNLean/Channel/ReductionCriterion.lean`, `TNLean/Channel/Separable.lean`: scope markers updated to reference the full-criterion wrappers rather than treating the Schmidt premise as the formalization boundary.
- `blueprint/src/chapter/ch05_schwarz.tex`: new subsection with `\lean{}`/`\leanok` tags for all 9 new declarations.
- `docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`: reclassified to Resolved; residual 1 ≤ n < D restriction documented in `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`.
- `TNLean.lean`: root import for the new module.

### Testing

- `lake build` (root + module): 9226 jobs green.
- `rg "sorry|admit|native_decide|axiom"` over new/changed files: clean.
- `#print axioms` on four headline theorems: standard axioms only (`propext`, `Classical.choice`, `Quot.sound`).
- `lake exe checkdecls blueprint/lean_decls`: all 9 new declarations resolve.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---
Addresses LionSR/QICLean#168

> [!NOTE]
> **Medium Risk**
> New ~400-line formal module wires entanglement predicates to `n`-positivity and order theory; scope is mathematical correctness and the inherited `1 ≤ n < D` restriction, not runtime/security.
>
> **Overview**
> Adds **`TNLean/Channel/SchmidtNumber.lean`** with `Matrix.HasSchmidtNumberLE` (finite sums of pure projectors with Schmidt rank ≤ `n`), basic closure, and **`hasSchmidtNumberLE_one_iff_isSeparable`**.
>
> Completes **Wolf eq. (3.18)** by proving step 1: pure-state **`tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE`** (Choi compression + `n`-positivity of `T_n`), summed to **`HasSchmidtNumberLE.tensorMapId_tEta_posSemidef`**, then composed with existing **`reductionCriterion_left/right`** as **`reductionCriterion_*_of_hasSchmidtNumberLE`**. Residual hypothesis **`1 ≤ n < D`** from the `T_η` threshold.
>
> **`ReductionCriterion.lean`** and **`Separable.lean`** docs now point here instead of treating the Schmidt premise as missing; root import and blueprint subsection added; **`wolf_reduction_criterion_schmidt_premise.tex`** marked **resolved**.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a149b6c579229f33ab5f069ae7586cb2943ac8f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New formal proofs wire entanglement predicates to `n`-positivity and matrix order theory; risk is mathematical correctness and the inherited `1 ≤ n < D` / square-system scope, not runtime or security.
> 
> **Overview**
> Introduces **`TNLean/Channel/SchmidtNumber.lean`** with **`Matrix.HasSchmidtNumberLE`** (finite sums of pure projectors with Schmidt rank ≤ `n`), closure lemmas, and **`hasSchmidtNumberLE_one_iff_isSeparable`** linking the filtration to **`IsSeparable`**.
> 
> Completes **Wolf eq. (3.18)** by proving step 1—pure-state **`tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE`** via Choi compression and `n`-positivity of `T_n`, summed to **`HasSchmidtNumberLE.tensorMapId_tEta_posSemidef`**, then composed with existing **`reductionCriterion_left`/`right`** as **`reductionCriterion_*_of_hasSchmidtNumberLE`**. Residual hypotheses **`1 ≤ n < D`** and square **`d = d' = D`** for the forward step are documented.
> 
> **`Separable.lean`** gains **`isSeparable_sum`** and Kronecker identities used in the equivalence proof; **`ReductionCriterion.lean`** and related docs no longer treat the Schmidt premise as missing. Blueprint subsection, root import, and **`wolf_reduction_criterion_schmidt_premise.tex`** are updated to **resolved** with noted scope limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f5ee9104a9a3696a103c7e6727ab0306cedd0cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->