### PR TITLE
feat(Channel/Schwarz): data-processing inequality for quantum relative entropy (SSA route layer 5) (#784)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -112,6 +112,7 @@ import TNLean.Channel.Schwarz.AndoLieb
 import TNLean.Channel.Schwarz.RelativeEntropyConvexity
 import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
 import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
+import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
 import TNLean.Channel.Schwarz.WeylTwirl
 import TNLean.Channel.Schwarz.PositiveOnAbelian
 import TNLean.Channel.Schwarz.SchwarzNormal

--- a/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
@@ -1,0 +1,485 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.PartialTrace
+import TNLean.Channel.Schwarz.WeylTwirl
+import TNLean.Channel.Schwarz.RelativeEntropyConvexity
+import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
+import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
+import Mathlib.LinearAlgebra.Matrix.Reindex
+import Mathlib.LinearAlgebra.UnitaryGroup
+
+/-!
+# Data-processing inequality under the partial trace
+
+This file proves the **data-processing inequality** for the quantum relative
+entropy under the partial trace: for positive definite matrices $\rho, \sigma$ on
+a tensor product of a system factor and an ancilla factor,
+$D(\operatorname{tr}_C \rho \,\|\, \operatorname{tr}_C \sigma)
+  \le D(\rho \,\|\, \sigma)$,
+where $\operatorname{tr}_C$ is the partial trace over the ancilla factor. This is
+layer 5 of the SSA-from-Lieb elimination route,
+`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`; all of its ingredients are now
+formalized, leaving only the layer-6 tripartite instantiation to discharge the
+standalone strong-subadditivity axiom.
+
+## Main results
+
+* `Matrix.sum_kronecker_one_weyl_conj` — the twirl identity: the uniform average
+  of the conjugations by the $d_C^2$ unitaries $\mathbf 1_S \otimes W(a,b)$ on the
+  ancilla factor equals the partial trace tensored with the maximally mixed
+  ancilla state.
+* `quantumRelativeEntropy_submatrix_equiv` — invariance of the relative entropy
+  under reindexing both arguments by a bijection of the index set.
+* `TNLean.RelativeEntropyConvexity.convexOn_quantumRelativeEntropy_index` — joint
+  convexity of the relative entropy on an arbitrary finite index, transported from
+  the canonical finite index.
+* `Matrix.quantumRelativeEntropy_partialTraceRight_le` — the data-processing
+  inequality $D(\operatorname{tr}_C \rho \,\|\, \operatorname{tr}_C \sigma)
+  \le D(\rho \,\|\, \sigma)$.
+
+## Proof outline
+
+The partial trace tensored with the maximally mixed ancilla is realized as a
+unitary $1$-design twirl on the ancilla factor: averaging the conjugations by the
+$d_C^2$ operators $\mathbf 1_S \otimes W(a,b)$ over the Heisenberg--Weyl operators
+$W(a,b)$ collapses each ancilla block to the depolarizing channel
+(`Matrix.sum_weyl_conj`), leaving the partial trace on the system factor and the
+maximally mixed state on the ancilla. The relative entropy of the reduced states
+then expands by ancilla additivity (`quantumRelativeEntropy_kronecker`) into the
+relative entropy of the twirled pair, which is the relative entropy of a convex
+combination of the conjugated pairs. Joint convexity
+(`convexOn_quantumRelativeEntropy`, transported to the product index) bounds it by
+the convex combination of the per-term relative entropies, each of which equals
+$D(\rho \,\|\, \sigma)$ by unitary invariance
+(`quantumRelativeEntropy_conj_unitary`); the weights sum to one, leaving
+$D(\rho \,\|\, \sigma)$.
+
+**Scope restriction (positive-definite domain):** the source data-processing
+inequality holds for density operators with $\ker \sigma \subseteq \ker \rho$,
+whereas this development restricts $\rho, \sigma$ to positive definite matrices,
+the domain on which joint convexity and ancilla additivity are available. The
+restriction is recorded in `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`,
+layer 5.
+
+## References
+
+* Layer 5 (data processing) of the relative-entropy elimination route for strong
+  subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
+  (Distance Measures)][Wolf2012QChannels].
+-/
+
+open scoped Matrix Matrix.Norms.L2Operator MatrixOrder ComplexOrder Kronecker
+open Matrix
+
+namespace Matrix
+
+/-! ## Invariance of the relative entropy under reindexing -/
+
+section Reindex
+
+variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+
+/-- Reindexing the rows and columns by a bijection, as a star algebra
+homomorphism of complex matrix algebras. -/
+noncomputable def reindexStarAlgHom (e : m ≃ n) :
+    Matrix m m ℂ →⋆ₐ[ℂ] Matrix n n ℂ where
+  toFun M := M.submatrix e.symm e.symm
+  map_one' := by simp [Matrix.submatrix_one_equiv]
+  map_mul' A B := by rw [← Matrix.submatrix_mul_equiv A B e.symm e.symm e.symm]
+  map_zero' := by simp
+  map_add' A B := by simp [Matrix.submatrix_add]
+  commutes' r := by
+    rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one,
+      show (r • (1 : Matrix m m ℂ)).submatrix e.symm e.symm
+          = r • ((1 : Matrix m m ℂ).submatrix e.symm e.symm) from rfl,
+      Matrix.submatrix_one_equiv]
+  map_star' A := by
+    rw [star_eq_conjTranspose, star_eq_conjTranspose, Matrix.conjTranspose_submatrix]
+
+@[simp] theorem reindexStarAlgHom_apply (e : m ≃ n) (M : Matrix m m ℂ) :
+    reindexStarAlgHom e M = M.submatrix e.symm e.symm := rfl
+
+/-- **Functional calculus through a reindexing.** For a Hermitian matrix $A$, a
+real function $f$, and a bijection $e$ of the index set,
+$f(A_{e^{-1},\,e^{-1}}) = (f(A))_{e^{-1},\,e^{-1}}$. This is the instance of
+`StarAlgHomClass.map_cfc` at the reindexing homomorphism `reindexStarAlgHom`. -/
+theorem cfc_submatrix_equiv {A : Matrix m m ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ) (e : m ≃ n) :
+    cfc f (A.submatrix e.symm e.symm) = (cfc f A).submatrix e.symm e.symm := by
+  have hcont : ContinuousOn f (spectrum ℝ A) := A.finite_real_spectrum.continuousOn f
+  have hcontφ : Continuous (reindexStarAlgHom (m := m) (n := n) e) :=
+    LinearMap.continuous_of_finiteDimensional
+      ((reindexStarAlgHom (m := m) (n := n) e : Matrix m m ℂ →ₗ[ℂ] Matrix n n ℂ))
+  have hsa : IsSelfAdjoint A := hA
+  have hsa' : IsSelfAdjoint (reindexStarAlgHom e A) := by
+    rw [reindexStarAlgHom_apply, IsSelfAdjoint, star_eq_conjTranspose,
+      Matrix.conjTranspose_submatrix, hA.eq]
+  simpa [reindexStarAlgHom_apply] using
+    (StarAlgHomClass.map_cfc (reindexStarAlgHom (m := m) (n := n) e) f A
+      hcont hcontφ hsa hsa').symm
+
+/-- **The matrix logarithm is covariant under a reindexing.** For a Hermitian
+matrix $A$ and a bijection $e$ of the index set,
+$\log(A_{e^{-1},\,e^{-1}}) = (\log A)_{e^{-1},\,e^{-1}}$. The special case
+$f = \log$ of `cfc_submatrix_equiv`. -/
+theorem log_submatrix_equiv {A : Matrix m m ℂ} (hA : A.IsHermitian) (e : m ≃ n) :
+    CFC.log (A.submatrix e.symm e.symm) = (CFC.log A).submatrix e.symm e.symm := by
+  rw [CFC.log, CFC.log, cfc_submatrix_equiv hA Real.log e]
+
+/-- **Reindexing invariance of the quantum relative entropy.** For Hermitian
+matrices $\rho, \sigma$ and a bijection $e$ of the index set,
+$D(\rho_{e^{-1},\,e^{-1}} \,\|\, \sigma_{e^{-1},\,e^{-1}}) = D(\rho \,\|\, \sigma)$.
+The logarithms reindex by `log_submatrix_equiv`, and trace cyclicity through the
+reindexing leaves the trace unchanged. -/
+theorem quantumRelativeEntropy_submatrix_equiv {ρ σ : Matrix m m ℂ}
+    (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian) (e : m ≃ n) :
+    quantumRelativeEntropy (ρ.submatrix e.symm e.symm) (σ.submatrix e.symm e.symm)
+      = quantumRelativeEntropy ρ σ := by
+  rw [quantumRelativeEntropy, quantumRelativeEntropy, log_submatrix_equiv hρ e,
+    log_submatrix_equiv hσ e]
+  congr 2
+  rw [show ((CFC.log ρ).submatrix e.symm e.symm - (CFC.log σ).submatrix e.symm e.symm)
+        = (CFC.log ρ - CFC.log σ).submatrix e.symm e.symm from rfl,
+    Matrix.submatrix_mul_equiv ρ (CFC.log ρ - CFC.log σ) e.symm e.symm e.symm,
+    Matrix.trace_submatrix_equiv]
+
+end Reindex
+
+end Matrix
+
+/-! ## Joint convexity on an arbitrary finite index -/
+
+namespace TNLean.RelativeEntropyConvexity
+
+open Matrix
+
+variable {N : Type*} [Fintype N] [DecidableEq N]
+
+omit [DecidableEq N] in
+/-- Positive definiteness is preserved and reflected by reindexing with a
+bijection to the canonical finite index. -/
+theorem posDef_submatrix_equiv_iff (e : N ≃ Fin (Fintype.card N))
+    (A : Matrix N N ℂ) :
+    (A.submatrix e.symm e.symm).PosDef ↔ A.PosDef := by
+  constructor
+  · intro h
+    have hsub := h.submatrix (e := (e : N → Fin (Fintype.card N))) e.injective
+    rwa [Matrix.submatrix_submatrix, Equiv.symm_comp_self, Matrix.submatrix_id_id] at hsub
+  · intro h; exact h.submatrix e.symm.injective
+
+/-- The set of positive definite matrices on an arbitrary finite index, the
+faithful domain of the quantum relative entropy. -/
+def posDefSetN (N : Type*) [Fintype N] [DecidableEq N] : Set (Matrix N N ℂ) :=
+  {A : Matrix N N ℂ | A.PosDef}
+
+/-- **Joint convexity of the quantum relative entropy on an arbitrary finite
+index.** The map $(\rho, \sigma) \mapsto D(\rho \,\|\, \sigma)$ is jointly convex
+on pairs of positive definite matrices over any finite index. It is transported
+from `convexOn_quantumRelativeEntropy` through the componentwise reindexing to the
+canonical finite index, which is an affine map preserving the positive definite
+product domain and the relative entropy. -/
+theorem convexOn_quantumRelativeEntropy_index :
+    ConvexOn ℝ (posDefSetN N ×ˢ posDefSetN N)
+      (fun p : Matrix N N ℂ × Matrix N N ℂ => quantumRelativeEntropy p.1 p.2) := by
+  set D := Fintype.card N
+  set e : N ≃ Fin D := Fintype.equivFin N
+  set Φ :
+      (Matrix N N ℂ × Matrix N N ℂ) →ₗ[ℝ]
+        (Matrix (Fin D) (Fin D) ℂ × Matrix (Fin D) (Fin D) ℂ) :=
+    (Matrix.reindexLinearEquiv ℝ ℂ e e : Matrix N N ℂ →ₗ[ℝ] Matrix (Fin D) (Fin D) ℂ).prodMap
+      (Matrix.reindexLinearEquiv ℝ ℂ e e : Matrix N N ℂ →ₗ[ℝ] Matrix (Fin D) (Fin D) ℂ) with hΦ
+  have hΦ_apply : ∀ p : Matrix N N ℂ × Matrix N N ℂ,
+      Φ p = (p.1.submatrix e.symm e.symm, p.2.submatrix e.symm e.symm) := fun p => rfl
+  have hcomp := (convexOn_quantumRelativeEntropy (D := D)).comp_affineMap Φ.toAffineMap
+  have hpre : (Φ.toAffineMap) ⁻¹' (posDefSet (D := D) ×ˢ posDefSet (D := D))
+      = posDefSetN N ×ˢ posDefSetN N := by
+    ext p
+    simp only [Set.mem_preimage, Set.mem_prod, LinearMap.coe_toAffineMap, hΦ_apply, posDefSet,
+      posDefSetN, Set.mem_setOf_eq]
+    rw [posDef_submatrix_equiv_iff e, posDef_submatrix_equiv_iff e]
+  rw [hpre] at hcomp
+  refine hcomp.congr ?_
+  intro p hp
+  obtain ⟨hp1, hp2⟩ := Set.mem_prod.mp hp
+  simp only [Function.comp_apply, LinearMap.coe_toAffineMap, hΦ_apply]
+  exact quantumRelativeEntropy_submatrix_equiv (m := N) hp1.isHermitian hp2.isHermitian e
+
+end TNLean.RelativeEntropyConvexity
+
+namespace Matrix
+
+/-! ## Unitarity of the Weyl operators -/
+
+section WeylUnitary
+
+variable {d : ℕ} [NeZero d]
+
+/-- The cyclic shift operator is unitary. -/
+theorem weylShift_mem_unitary :
+    (weylShift : Matrix (ZMod d) (ZMod d) ℂ) ∈ unitary (Matrix (ZMod d) (ZMod d) ℂ) := by
+  rw [Unitary.mem_iff, star_eq_conjTranspose, weylShift, conjTranspose_permMatrix]
+  refine ⟨?_, ?_⟩
+  · rw [← permMatrix_mul, mul_inv_cancel, permMatrix_one]
+  · rw [← permMatrix_mul, inv_mul_cancel, permMatrix_one]
+
+/-- The clock operator is unitary, because every clock phase lies on the unit
+circle. -/
+theorem weylClock_mem_unitary {ζ : ℂ} (hζ : IsPrimitiveRoot ζ d) :
+    (weylClock ζ : Matrix (ZMod d) (ZMod d) ℂ) ∈ unitary (Matrix (ZMod d) (ZMod d) ℂ) := by
+  have hnorm : ∀ i : ZMod d, ζ ^ i.val * (starRingEnd ℂ) (ζ ^ i.val) = 1 := by
+    intro i
+    rw [map_pow, starRingEnd_eq_inv_of_isPrimitiveRoot hζ, ← mul_pow,
+      mul_inv_cancel₀ (hζ.ne_zero (NeZero.ne d)), one_pow]
+  have hnorm' : ∀ i : ZMod d, (starRingEnd ℂ) (ζ ^ i.val) * ζ ^ i.val = 1 := by
+    intro i; rw [mul_comm]; exact hnorm i
+  rw [Unitary.mem_iff, star_eq_conjTranspose, weylClock, diagonal_conjTranspose,
+    diagonal_mul_diagonal, diagonal_mul_diagonal, ← diagonal_one]
+  refine ⟨?_, ?_⟩ <;>
+  · congr 1
+    funext i
+    simp only [Pi.star_apply, RCLike.star_def]
+    first | exact hnorm i | exact hnorm' i
+
+/-- The Weyl operator is unitary, being a product of a power of the shift and a
+power of the clock. -/
+theorem weyl_mem_unitary {ζ : ℂ} (hζ : IsPrimitiveRoot ζ d) (a b : ZMod d) :
+    (weyl ζ a b : Matrix (ZMod d) (ZMod d) ℂ) ∈ unitary (Matrix (ZMod d) (ZMod d) ℂ) := by
+  rw [weyl]
+  exact mul_mem (pow_mem weylShift_mem_unitary a.val)
+    (pow_mem (weylClock_mem_unitary hζ) b.val)
+
+end WeylUnitary
+
+/-! ## The twirl as partial trace tensored with the maximally mixed ancilla -/
+
+section Twirl
+
+variable {S : Type*} [Fintype S] [DecidableEq S] {dC : ℕ} [NeZero dC]
+
+/-- The conjugation by an identity-on-$S$ lift of a Weyl operator reduces, on each
+$S$-block, to the Weyl conjugation of that block of the conjugated matrix. -/
+theorem kronecker_one_weyl_conj_block {ζ : ℂ} (a b : ZMod dC)
+    (M : Matrix (S × ZMod dC) (S × ZMod dC) ℂ) (s₁ s₂ : S) (c₁ c₂ : ZMod dC) :
+    ((((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b) * M * ((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b)ᴴ)
+        (s₁, c₁) (s₂, c₂))
+      = (weyl ζ a b
+          * M.submatrix (fun c => (s₁, c)) (fun c => (s₂, c))
+          * (weyl ζ a b)ᴴ) c₁ c₂ := by
+  rw [conjTranspose_kronecker, conjTranspose_one]
+  simp only [Matrix.mul_apply, Matrix.submatrix_apply, Fintype.sum_prod_type, kronecker_apply,
+    Matrix.one_apply]
+  rw [Finset.sum_eq_single s₂]
+  · refine Finset.sum_congr rfl fun c _ => ?_
+    rw [if_pos rfl, one_mul]
+    congr 1
+    rw [Finset.sum_eq_single s₁]
+    · refine Finset.sum_congr rfl fun c' _ => ?_
+      rw [if_pos rfl, one_mul]
+    · intro s' _ hs'; simp [Ne.symm hs']
+    · intro h; exact absurd (Finset.mem_univ s₁) h
+  · intro s' _ hs'; simp [hs']
+  · intro h; exact absurd (Finset.mem_univ s₂) h
+
+omit [Fintype S] [DecidableEq S] in
+/-- The trace of an $S$-block of a matrix is the corresponding entry of its
+partial trace over the ancilla factor. -/
+theorem trace_submatrix_block_eq_partialTraceRight
+    (M : Matrix (S × ZMod dC) (S × ZMod dC) ℂ) (s₁ s₂ : S) :
+    (M.submatrix (fun c => (s₁, c)) (fun c => (s₂, c))).trace
+      = partialTraceRight M s₁ s₂ := by
+  simp only [Matrix.trace, Matrix.diag_apply, Matrix.submatrix_apply, partialTraceRight_apply]
+
+/-- **The twirl is the partial trace tensored with the maximally mixed ancilla.**
+For a primitive $d_C$-th root of unity, the uniform average of the conjugations by
+the $d_C^2$ unitaries $\mathbf 1_S \otimes W(a,b)$ equals the partial trace over
+the ancilla factor tensored with the maximally mixed ancilla state
+$\mathbf 1_C / d_C$:
+\[
+  \frac{1}{d_C^2} \sum_{a,b}
+    (\mathbf 1_S \otimes W(a,b))\, M\, (\mathbf 1_S \otimes W(a,b))^{\dagger}
+    = (\operatorname{tr}_C M) \otimes (\mathbf 1_C / d_C).
+\]
+On each $S$-block the conjugation reduces to a Weyl conjugation
+(`kronecker_one_weyl_conj_block`), whose average is the depolarizing channel
+(`sum_weyl_conj`), and the block trace is the partial-trace entry
+(`trace_submatrix_block_eq_partialTraceRight`). -/
+theorem sum_kronecker_one_weyl_conj {ζ : ℂ} (hζ : IsPrimitiveRoot ζ dC)
+    (M : Matrix (S × ZMod dC) (S × ZMod dC) ℂ) :
+    ((dC : ℂ) ^ 2)⁻¹ • ∑ a : ZMod dC, ∑ b : ZMod dC,
+        ((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b) * M * ((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b)ᴴ
+      = partialTraceRight M ⊗ₖ ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ)) := by
+  ext ⟨s₁, c₁⟩ ⟨s₂, c₂⟩
+  rw [Matrix.smul_apply, kronecker_apply, Matrix.smul_apply, smul_eq_mul, smul_eq_mul]
+  simp only [Matrix.sum_apply]
+  have hblock : ∀ a b : ZMod dC,
+      (((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b) * M * ((1 : Matrix S S ℂ) ⊗ₖ weyl ζ a b)ᴴ)
+          (s₁, c₁) (s₂, c₂)
+        = (weyl ζ a b * M.submatrix (fun c => (s₁, c)) (fun c => (s₂, c))
+            * (weyl ζ a b)ᴴ) c₁ c₂ :=
+    fun a b => kronecker_one_weyl_conj_block a b M s₁ s₂ c₁ c₂
+  rw [Finset.sum_congr rfl fun a _ => Finset.sum_congr rfl fun b _ => hblock a b]
+  have htwirl := congrArg (fun X : Matrix (ZMod dC) (ZMod dC) ℂ => X c₁ c₂)
+    (sum_weyl_conj hζ (M.submatrix (fun c => (s₁, c)) (fun c => (s₂, c))))
+  simp only [Matrix.smul_apply, Matrix.sum_apply, smul_eq_mul] at htwirl
+  rw [htwirl, trace_submatrix_block_eq_partialTraceRight, div_eq_mul_inv, mul_assoc]
+
+end Twirl
+
+/-! ## The data-processing inequality -/
+
+section DataProcessing
+
+variable {dS dC : ℕ} [NeZero dC]
+
+open TNLean.RelativeEntropyConvexity
+
+/-- The maximally mixed ancilla state on the traced factor is positive definite. -/
+theorem maximallyMixed_posDef :
+    ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ)).PosDef := by
+  refine Matrix.PosDef.smul Matrix.PosDef.one ?_
+  rw [inv_pos]
+  exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+
+/-- The maximally mixed ancilla state has unit trace. -/
+theorem maximallyMixed_trace :
+    ((dC : ℂ)⁻¹ • (1 : Matrix (ZMod dC) (ZMod dC) ℂ)).trace = 1 := by
+  rw [Matrix.trace_smul, Matrix.trace_one, smul_eq_mul, Fintype.card_eq_nat_card,
+    Nat.card_eq_fintype_card, ZMod.card dC, inv_mul_cancel₀]
+  exact_mod_cast NeZero.ne dC
+
+/-- **The reduced state of a positive definite state is positive definite.** The
+partial trace over the ancilla factor of a positive definite matrix is a sum, over
+the ancilla index, of principal submatrices that are each positive definite, hence
+itself positive definite. -/
+theorem partialTraceRight_posDef {ρ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) : (partialTraceRight ρ).PosDef := by
+  have hblock : ∀ c : ZMod dC,
+      (ρ.submatrix (fun s : Fin dS => (s, c)) (fun s => (s, c))).PosDef :=
+    fun c => hρ.submatrix (fun s₁ s₂ h => (Prod.ext_iff.mp h).1)
+  have heq : partialTraceRight ρ
+      = ∑ c : ZMod dC, ρ.submatrix (fun s : Fin dS => (s, c)) (fun s => (s, c)) := by
+    ext s₁ s₂
+    simp only [partialTraceRight_apply, Matrix.sum_apply, Matrix.submatrix_apply]
+  rw [heq]
+  exact Matrix.posDef_sum Finset.univ_nonempty fun c _ => hblock c
+
+variable {N : Type*} [Fintype N] [DecidableEq N]
+
+/-- Conjugation by a unitary preserves positive definiteness. -/
+theorem posDef_conj_unitary {ρ : Matrix N N ℂ} (hρ : ρ.PosDef)
+    (U : unitary (Matrix N N ℂ)) :
+    ((U : Matrix N N ℂ) * ρ * star (U : Matrix N N ℂ)).PosDef := by
+  have hU : IsUnit (U : Matrix N N ℂ) := ⟨Unitary.toUnits U, rfl⟩
+  have hinj : Function.Injective (U : Matrix N N ℂ).vecMul :=
+    Matrix.vecMul_injective_iff_isUnit.mpr hU
+  have hpd := hρ.mul_mul_conjTranspose_same hinj
+  rwa [star_eq_conjTranspose]
+
+/-- **Data-processing inequality under the partial trace.** For positive definite
+matrices $\rho, \sigma$ on a tensor product of a system factor and an ancilla
+factor,
+\[
+  D(\operatorname{tr}_C \rho \,\|\, \operatorname{tr}_C \sigma)
+    \le D(\rho \,\|\, \sigma),
+\]
+where $\operatorname{tr}_C$ is the partial trace over the ancilla factor.
+
+The reduced-state relative entropy expands by ancilla additivity
+(`quantumRelativeEntropy_kronecker`) into the relative entropy of the twirled
+pair, which is the relative entropy of a convex combination of the conjugated
+pairs (`sum_kronecker_one_weyl_conj`). Joint convexity
+(`convexOn_quantumRelativeEntropy_index`) bounds it by the convex combination of
+the per-term relative entropies, each equal to $D(\rho \,\|\, \sigma)$ by unitary
+invariance (`quantumRelativeEntropy_conj_unitary`); the weights sum to one.
+
+**Scope restriction (positive-definite domain):** the source inequality holds for
+density operators with $\ker \sigma \subseteq \ker \rho$; here $\rho, \sigma$ are
+restricted to positive definite matrices. Recorded in
+`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 5. -/
+theorem quantumRelativeEntropy_partialTraceRight_le
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef) :
+    quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)
+      ≤ quantumRelativeEntropy ρ σ := by
+  classical
+  obtain ⟨ζ, hζ⟩ : ∃ ζ : ℂ, IsPrimitiveRoot ζ dC :=
+    ⟨_, Complex.isPrimitiveRoot_exp dC (NeZero.ne dC)⟩
+  set τ : Matrix (ZMod dC) (ZMod dC) ℂ := (dC : ℂ)⁻¹ • 1 with hτdef
+  set U : ZMod dC → ZMod dC → unitary (Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ) :=
+    fun a b => ⟨(1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b,
+      Matrix.kronecker_mem_unitary (Submonoid.one_mem _) (weyl_mem_unitary hζ a b)⟩ with hUdef
+  have hUcoe : ∀ a b, ((U a b : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ))
+      = (1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b := fun a b => rfl
+  set w : ZMod dC × ZMod dC → ℝ := fun _ => ((dC : ℝ) ^ 2)⁻¹ with hwdef
+  set P : ZMod dC × ZMod dC → Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ
+      × Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ :=
+    fun p => ((U p.1 p.2 : _) * ρ * star (U p.1 p.2 : _),
+      (U p.1 p.2 : _) * σ * star (U p.1 p.2 : _)) with hPdef
+  have hdCpos : 0 < (dC : ℝ) := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dC)
+  have hcard : (Finset.univ : Finset (ZMod dC × ZMod dC)).card = dC ^ 2 := by
+    rw [Finset.card_univ, Fintype.card_prod, ZMod.card, sq]
+  have hwsum : ∑ p : ZMod dC × ZMod dC, w p = 1 := by
+    rw [hwdef, Finset.sum_const, hcard, nsmul_eq_mul]
+    push_cast
+    rw [mul_inv_cancel₀ (by positivity)]
+  have hPmem : ∀ p : ZMod dC × ZMod dC, P p ∈ posDefSetN (Fin dS × ZMod dC)
+      ×ˢ posDefSetN (Fin dS × ZMod dC) := fun p =>
+    ⟨posDef_conj_unitary hρ (U p.1 p.2), posDef_conj_unitary hσ (U p.1 p.2)⟩
+  have hjensen := (convexOn_quantumRelativeEntropy_index
+    (N := Fin dS × ZMod dC)).map_sum_le
+    (fun p _ => by positivity) hwsum (fun p _ => hPmem p)
+  -- The twirl of a state is the reduced state tensored with the maximally mixed
+  -- ancilla, via the unitary 1-design identity.
+  have htwirl : ∀ X : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ,
+      (((dC : ℝ) ^ 2)⁻¹ : ℝ) • ∑ p : ZMod dC × ZMod dC,
+          (U p.1 p.2 : _) * X * star (U p.1 p.2 : _)
+        = partialTraceRight X ⊗ₖ τ := by
+    intro X
+    rw [Fintype.sum_prod_type]
+    simp only [Unitary.coe_star, hUcoe, star_eq_conjTranspose]
+    rw [show (((dC : ℝ) ^ 2)⁻¹ : ℝ)
+          • ∑ a : ZMod dC, ∑ b : ZMod dC,
+              ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * X
+                * ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ
+            = ((dC : ℂ) ^ 2)⁻¹
+              • ∑ a : ZMod dC, ∑ b : ZMod dC,
+                ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b) * X
+                  * ((1 : Matrix (Fin dS) (Fin dS) ℂ) ⊗ₖ weyl ζ a b)ᴴ from by
+        rw [← Complex.coe_smul]; norm_num]
+    exact sum_kronecker_one_weyl_conj hζ X
+  -- The Jensen left-hand side is the reduced-state relative entropy, by ancilla
+  -- additivity applied to the twirled pair.
+  have hLHS : quantumRelativeEntropy (∑ p, w p • P p).1 (∑ p, w p • P p).2
+      = quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ) := by
+    have hfst : (∑ p : ZMod dC × ZMod dC, w p • P p).1 = partialTraceRight ρ ⊗ₖ τ := by
+      rw [Prod.fst_sum, ← htwirl ρ, Finset.smul_sum]; rfl
+    have hsnd : (∑ p : ZMod dC × ZMod dC, w p • P p).2 = partialTraceRight σ ⊗ₖ τ := by
+      rw [Prod.snd_sum, ← htwirl σ, Finset.smul_sum]; rfl
+    rw [hfst, hsnd]
+    exact quantumRelativeEntropy_kronecker (partialTraceRight_posDef hρ)
+      (partialTraceRight_posDef hσ) maximallyMixed_posDef maximallyMixed_trace
+  -- The Jensen right-hand side collapses to a single relative entropy by unitary
+  -- invariance, the weights summing to one.
+  have hRHS : ∑ p : ZMod dC × ZMod dC,
+        w p • (fun q : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ
+          × Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ =>
+          quantumRelativeEntropy q.1 q.2) (P p)
+      = quantumRelativeEntropy ρ σ := by
+    have hterm : ∀ p : ZMod dC × ZMod dC,
+        (fun q : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ
+          × Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ =>
+          quantumRelativeEntropy q.1 q.2) (P p) = quantumRelativeEntropy ρ σ := by
+      intro p
+      simp only [hPdef]
+      exact quantumRelativeEntropy_conj_unitary hρ.isHermitian hσ.isHermitian (U p.1 p.2)
+    simp_rw [hterm]
+    rw [← Finset.sum_smul, hwsum, one_smul]
+  rw [← hLHS, ← hRHS]
+  exact hjensen
+
+end DataProcessing
+
+end Matrix

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -505,6 +505,74 @@ finite-dimensional quantum systems.
     prefactor $d^{-2}$ leaves $(\operatorname{tr} M / d)\,\mathbf 1$.
 \end{proof}
 
+\begin{lemma}[Twirl as partial trace tensored with the maximally mixed ancilla]
+    \label{lem:twirl_partial_trace}
+    \lean{Matrix.sum_kronecker_one_weyl_conj}
+    \leanok
+    \uses{thm:weyl_twirl}
+    Fix a dimension $d_C \ge 1$ and a primitive $d_C$-th root of unity $\zeta$.
+    For every matrix $M$ on $\mathcal H_S \otimes \mathbb{C}^{d_C}$, the uniform
+    average of the conjugations by the $d_C^2$ unitaries
+    $\mathbf 1_S \otimes W(a,b)$ on the second factor is the partial trace over
+    that factor tensored with the maximally mixed state $\mathbf 1_C / d_C$:
+    \[
+        \frac{1}{d_C^2} \sum_{a,b}
+            (\mathbf 1_S \otimes W(a,b))\, M\, (\mathbf 1_S \otimes W(a,b))^{\dagger}
+            = (\tr_C M) \otimes (\mathbf 1_C / d_C).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{thm:weyl_twirl}
+    On each pair of blocks indexed by the first factor, the conjugation by
+    $\mathbf 1_S \otimes W(a,b)$ acts as the Weyl conjugation $W(a,b)\,(\cdot)\,
+    W(a,b)^{\dagger}$ of the corresponding block of $M$. Averaging over the $d_C^2$
+    Weyl operators sends each block to the depolarizing channel by
+    Theorem~\ref{thm:weyl_twirl}, replacing it by its trace times
+    $\mathbf 1_C / d_C$. The block trace is exactly the corresponding entry of the
+    partial trace $\tr_C M$, so the average is $(\tr_C M) \otimes
+    (\mathbf 1_C / d_C)$.
+\end{proof}
+
+\begin{theorem}[Data-processing inequality under the partial trace]
+    \label{thm:relative_entropy_data_processing}
+    \lean{Matrix.quantumRelativeEntropy_partialTraceRight_le}
+    \leanok
+    \uses{def:quantum_relative_entropy, thm:relative_entropy_ancilla_additivity,
+        thm:relative_entropy_unitary_invariance, thm:relative_entropy_joint_convexity,
+        lem:twirl_partial_trace}
+    For positive definite matrices $\rho, \sigma$ on a tensor product of a system
+    factor and an ancilla factor,
+    \[
+        D(\tr_C \rho \,\Vert\, \tr_C \sigma) \le D(\rho \,\Vert\, \sigma),
+    \]
+    where $\tr_C$ is the partial trace over the ancilla factor. (Scope
+    restriction: the source inequality holds for density operators with
+    $\ker \sigma \subseteq \ker \rho$; here both arguments are positive definite.
+    Recorded in the relative-entropy elimination route note for strong
+    subadditivity.)
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:relative_entropy_ancilla_additivity,
+        thm:relative_entropy_unitary_invariance, thm:relative_entropy_joint_convexity,
+        lem:twirl_partial_trace}
+    By ancilla additivity (Theorem~\ref{thm:relative_entropy_ancilla_additivity})
+    the reduced-state relative entropy equals
+    $D\bigl((\tr_C \rho) \otimes (\mathbf 1_C / d_C) \,\Vert\,
+    (\tr_C \sigma) \otimes (\mathbf 1_C / d_C)\bigr)$. By
+    Lemma~\ref{lem:twirl_partial_trace} each tensored reduced state is the uniform
+    average of the conjugations by the $d_C^2$ unitaries
+    $U_{ab} = \mathbf 1_S \otimes W(a,b)$, so this is the relative entropy of a
+    convex combination of the conjugated pairs
+    $(U_{ab}\,\rho\,U_{ab}^{\dagger}, U_{ab}\,\sigma\,U_{ab}^{\dagger})$ with equal
+    weights $d_C^{-2}$. Joint convexity bounds it above by the same convex
+    combination of the per-term relative entropies, each of which equals
+    $D(\rho \,\Vert\, \sigma)$ by unitary invariance
+    (Theorem~\ref{thm:relative_entropy_unitary_invariance}). As the weights sum to
+    one, the bound is $D(\rho \,\Vert\, \sigma)$.
+\end{proof}
+
 \begin{theorem}[Entropy is invariant under reindexing]
     \label{thm:entropy_submatrix_equiv}
     \lean{vonNeumannEntropy_submatrix_equiv}

--- a/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
+++ b/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
@@ -267,10 +267,22 @@ in place. Concretely:
     operators $W(a,b) = X^a Z^b$ equals the completely depolarizing channel
     $M \mapsto (\tr M / d)\,\mathbf 1$, via the root-of-unity character-sum
     orthogonality (\leanid{Matrix.sum_rootOfUnity_pow_eq}). This result depends
-    only on the standard Lean axioms and needs no Lieb input. The remaining
-    layer-(5) work is to present $\tr_C$ through this average, applied on $C$ after
-    appending the maximally mixed ancilla, and so derive the partial-trace
-    monotonicity of $D$.
+    only on the standard Lean axioms and needs no Lieb input. Lifting that
+    design property to the ancilla factor presents $\tr_C$ through the average:
+    \leanid{Matrix.sum_kronecker_one_weyl_conj} in
+    \doclink{TNLean/Channel/Schwarz/RelativeEntropyDataProcessing}
+    (\path{TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean}) proves that
+    the uniform average of the conjugations by the $d_C^2$ unitaries
+    $\mathbf 1_S \otimes W(a,b)$ equals $(\tr_C M)\otimes(\mathbf 1_C/d_C)$. With
+    all three ingredients in place, layer (5) is now formalized on the
+    positive-definite domain: \leanid{quantumRelativeEntropy_partialTraceRight_le}
+    in the same file proves
+    $D(\tr_C\rho\,\|\,\tr_C\sigma)\le D(\rho\,\|\,\sigma)$ for positive definite
+    $\rho,\sigma$, via the ancilla-additivity expansion of the reduced-state
+    relative entropy, the twirling identity, joint convexity over the $d_C^2$
+    equally weighted conjugated pairs, and unitary invariance of each term. The
+    transport of joint convexity to the product index uses the reindexing
+    invariance \leanid{quantumRelativeEntropy_submatrix_equiv}.
   \item Layer (6) instantiates layer (5) at the tripartite splitting to
     recover~\eqref{eq:ssa}; it additionally needs the marginal support
     lemma~\eqref{eq:marginal-support}, which puts the singular reference state
@@ -290,22 +302,23 @@ in place. Concretely:
     layer-(6) work is the instantiation, which is gated on layer (5).
 \end{itemize}
 
-\paragraph{Current formal status.} Layers (1)--(4) and the layer-(6) marginal
-support prerequisite are formalized; layer (4) on the positive-definite domain
-(\leanid{convexOn_quantumRelativeEntropy}). Layer (5), data-processing
-(monotonicity of $D$ under the partial trace), is partly formalized. It combines
-the layer-(4) joint convexity with unitary invariance and ancilla-additivity
-$D(\rho\otimes\tau\,\|\,\sigma\otimes\tau) = D(\rho\,\|\,\sigma)$ via the
-twirling representation of $\tr_C$. Joint convexity (layer 4, on the
-positive-definite domain), unitary invariance
+\paragraph{Current formal status.} Layers (1)--(5) and the layer-(6) marginal
+support prerequisite are formalized; layers (4) and (5) on the positive-definite
+domain. Layer (5), data-processing (monotonicity of $D$ under the partial trace),
+combines the layer-(4) joint convexity with unitary invariance and
+ancilla-additivity $D(\rho\otimes\tau\,\|\,\sigma\otimes\tau) =
+D(\rho\,\|\,\sigma)$ via the twirling representation of $\tr_C$. Joint convexity
+(layer 4, on the positive-definite domain), unitary invariance
 (\leanid{quantumRelativeEntropy_conj_unitary}, for arbitrary Hermitian
 arguments), ancilla-additivity
-(\leanid{quantumRelativeEntropy_kronecker}, on the positive-definite domain), and
-the finite Heisenberg--Weyl $1$-design twirl
-(\leanid{Matrix.sum_weyl_conj}) are formalized; presenting $\tr_C$ through that
-twirl, and so the partial-trace monotonicity of $D$, remains open. Until that
-representation and the layer-(6) instantiation are in place the standalone axiom
-\leanid{strong_subadditivity} stands.
+(\leanid{quantumRelativeEntropy_kronecker}, on the positive-definite domain), the
+finite Heisenberg--Weyl $1$-design twirl (\leanid{Matrix.sum_weyl_conj}), and its
+ancilla-factor lift presenting $\tr_C$ through the twirl
+(\leanid{Matrix.sum_kronecker_one_weyl_conj}) are formalized, and combine into the
+partial-trace monotonicity
+\leanid{quantumRelativeEntropy_partialTraceRight_le} on the positive-definite
+domain. Only the layer-(6) instantiation remains; until it is in place the
+standalone axiom \leanid{strong_subadditivity} stands.
 
 After layer (6) the inequality is a theorem, the standalone axiom is removed, and
 the only remaining entropy-side axiom on this route is the Lieb-concavity axiom.
@@ -327,16 +340,17 @@ assembly at the tripartite splitting. Layers (2) and (3) are formalized (the
 latter for full-rank $\sigma$), and layer (4) is formalized on the
 positive-definite domain (\leanid{convexOn_quantumRelativeEntropy}), so the
 Lieb-concavity axiom is now connected to the joint convexity of the relative
-entropy. The unitary-invariance ingredient of layer (5) is formalized for
-arbitrary Hermitian arguments (\leanid{quantumRelativeEntropy_conj_unitary}), the
-ancilla-additivity ingredient is formalized on the positive-definite domain
-(\leanid{quantumRelativeEntropy_kronecker}), and the finite Heisenberg--Weyl
-$1$-design twirl is formalized (\leanid{Matrix.sum_weyl_conj}). The remaining work
-is the singular-$\sigma$ extension of layers (3) and (4), presenting $\tr_C$
-through the $1$-design twirl to obtain the partial-trace monotonicity of layer
-(5), and the assembly layer (6); until those are formalized, the standalone axiom
-records a result the development assumes but does not yet derive from its
-operator-convexity input.
+entropy. Layer (5), data-processing, is formalized on the positive-definite
+domain (\leanid{quantumRelativeEntropy_partialTraceRight_le}): its unitary
+invariance (\leanid{quantumRelativeEntropy_conj_unitary}), ancilla additivity
+(\leanid{quantumRelativeEntropy_kronecker}), finite Heisenberg--Weyl $1$-design
+twirl (\leanid{Matrix.sum_weyl_conj}), and the ancilla-factor lift presenting
+$\tr_C$ through the twirl (\leanid{Matrix.sum_kronecker_one_weyl_conj}) combine
+through joint convexity into the partial-trace monotonicity
+$D(\tr_C\rho\,\|\,\tr_C\sigma)\le D(\rho\,\|\,\sigma)$. The remaining work is the
+singular-$\sigma$ extension of layers (3)--(5) and the instantiation layer (6);
+until those are formalized, the standalone axiom records a result the development
+assumes but does not yet derive from its operator-convexity input.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
Proves the **data-processing inequality** for the quantum relative entropy under
the partial trace, layer 5 of the SSA-from-Lieb elimination route
(`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, #784):

`Matrix.quantumRelativeEntropy_partialTraceRight_le` — for positive definite
`ρ, σ` on `Matrix (Fin dS × ZMod dC)`,
`D(tr_C ρ ‖ tr_C σ) ≤ D(ρ ‖ σ)`, where `tr_C = partialTraceRight` traces the
ancilla factor.

## What lands

- `Matrix.sum_kronecker_one_weyl_conj` — the genuine new lemma: the uniform
  average of conjugations by the `dC²` unitaries `1_S ⊗ W(a,b)` equals
  `(tr_C M) ⊗ (1_C / dC)`, lifting `Matrix.sum_weyl_conj` (#3508) to the ancilla
  factor blockwise.
- `quantumRelativeEntropy_submatrix_equiv` — reindexing invariance of `D`, used
  to transport joint convexity to the product index.
- `TNLean.RelativeEntropyConvexity.convexOn_quantumRelativeEntropy_index` — joint
  convexity on an arbitrary finite index, transported from
  `convexOn_quantumRelativeEntropy` (#3490) via the reindexing affine map.
- `weyl_mem_unitary` (and `weylShift_mem_unitary`, `weylClock_mem_unitary`) —
  unitarity of the Weyl operators, so `quantumRelativeEntropy_conj_unitary`
  (#3499) applies to each twirl term.

The DPI chain: ancilla additivity (#3506) expands the reduced-state relative
entropy into the relative entropy of the twirled pair; the twirl identity
rewrites it as a convex combination of the conjugated pairs; joint convexity
(finite Jensen, `ConvexOn.map_sum_le`) bounds it by the combination of per-term
relative entropies, each `= D(ρ ‖ σ)` by unitary invariance; the weights sum to
one.

## Scope

`**Scope restriction (positive-definite domain):**` carried in the docstring,
referencing `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 5. The source
inequality holds for density operators with `ker σ ⊆ ker ρ`; here both arguments
are positive definite (the domain on which joint convexity and ancilla additivity
are available).

## Status

**Layer 5 (data processing) is now complete** — all ingredients are merged. Only
layer 6 (tripartite SSA instantiation via `Matrix.marginal_support`) remains to
discharge the standalone `strong_subadditivity` axiom. The route note is updated
accordingly.

## Axioms

```
'Matrix.quantumRelativeEntropy_partialTraceRight_le' depends on axioms:
 [lieb_concavity_axiom, propext, Classical.choice, Quot.sound]
'Matrix.sum_kronecker_one_weyl_conj' depends on axioms:
 [propext, Classical.choice, Quot.sound]
```

Standard Lean axioms plus the sanctioned `lieb_concavity_axiom` (layer 4 input).
No `sorry`, no `native_decide`, no new axiom. Blueprint entry added in
`ch19_entropy.tex` (`thm:relative_entropy_data_processing`,
`lem:twirl_partial_trace`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New formal mathematics on the entropy/SSA critical path; the main DPI theorem still depends on `lieb_concavity_axiom` via joint convexity, and the positive-definite domain restriction is narrower than the full density-operator statement.
> 
> **Overview**
> **Completes layer 5** of the SSA-from-Lieb elimination route: the **data-processing inequality** for quantum relative entropy under `partialTraceRight`, `Matrix.quantumRelativeEntropy_partialTraceRight_le`, for **positive definite** ρ and σ on a system×ancilla product.
> 
> New module `TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean` (wired into `TNLean.lean`) proves the main inequality by expressing partial trace ⊗ maximally mixed ancilla as a **Heisenberg–Weyl twirl** (`sum_kronecker_one_weyl_conj`), then **ancilla additivity**, **joint convexity** (transported via `convexOn_quantumRelativeEntropy_index` and `quantumRelativeEntropy_submatrix_equiv`), and **unitary invariance** on each twirl term. Supporting lemmas include Weyl operator unitarity and reindexing invariance of D.
> 
> **Blueprint** (`ch19_entropy.tex`) gains `lem:twirl_partial_trace` and `thm:relative_entropy_data_processing`. **`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`** now records layers (1)–(5) as formalized on the positive-definite domain; **layer 6** (tripartite SSA instantiation) is the remaining step before dropping the `strong_subadditivity` axiom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf73470eba39e691434e071a3e92e43cbe4d5ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->