### PR TITLE
feat(Channel/Schwarz): strong subadditivity on the positive definite domain (SSA route layer 6)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -113,6 +113,7 @@ import TNLean.Channel.Schwarz.RelativeEntropyConvexity
 import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
 import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
 import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
+import TNLean.Channel.Schwarz.StrongSubadditivityPosDef
 import TNLean.Channel.Schwarz.WeylTwirl
 import TNLean.Channel.Schwarz.PositiveOnAbelian
 import TNLean.Channel.Schwarz.SchwarzNormal

--- a/TNLean/Analysis/MarginalSupport.lean
+++ b/TNLean/Analysis/MarginalSupport.lean
@@ -28,10 +28,11 @@ $A$, annihilates the full state.
   vanishing $\operatorname{tr}(Q \rho) = 0$ forces $Q \rho = 0$. This is the
   operator form of "a projection with zero expectation against a positive
   semidefinite state annihilates it".
-* `Matrix.traceA_ABC_lift_trace` — the partial-trace adjoint identity
-  $\operatorname{tr}((\mathbf 1_A \otimes M) \rho_{ABC})
-  = \operatorname{tr}(M \operatorname{tr}_A \rho_{ABC})$ for a matrix $M$ on the
-  $B \otimes C$ factor lifted by the identity on $A$.
+* `Matrix.traceLeftA_lift_trace` — the partial-trace adjoint identity
+  $\operatorname{tr}((\mathbf 1_A \otimes M) \rho)
+  = \operatorname{tr}(M \operatorname{tr}_A \rho)$ for a matrix $M$ on a general
+  retained factor lifted by the identity on $A$, and `Matrix.traceA_ABC_lift_trace`,
+  its special case for the $B \otimes C$ factor.
 * `Matrix.marginal_support` — the marginal support lemma: if a Hermitian
   idempotent $Q$ on $B \otimes C$ annihilates the marginal
   $\operatorname{tr}_A \rho_{ABC}$, then its identity-on-$A$ lift annihilates
@@ -61,7 +62,7 @@ annihilates the marginal, so the core lemma applies to the lifted projection.
   (Distance Measures)][Wolf2012QChannels].
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix ComplexOrder Kronecker
 open Matrix Finset
 
 namespace Matrix
@@ -152,6 +153,61 @@ theorem PosSemidef.proj_mul_eq_zero_of_trace_eq_zero {ρ Q : Matrix n n ℂ}
 
 end Core
 
+/-! ## Partial trace over the retained factor and its adjoint -/
+
+section RetainedFactor
+
+variable {dA : ℕ} {R : Type*} [Fintype R] [DecidableEq R]
+
+/-- Partial trace over the first factor $A$ of $A \otimes R$, the retained factor
+of the tripartite splitting. The marginal `traceA_ABC` is the special case
+$R = B \otimes C$. -/
+noncomputable def traceLeftA (ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ) : Matrix R R ℂ :=
+  fun i j => ∑ a : Fin dA, ρ (a, i) (a, j)
+
+/-- The identity-on-$A$ lift $\mathbf 1_A \otimes M$ of a matrix on the retained
+factor. The lift `liftA` is the special case $R = B \otimes C$. -/
+noncomputable def liftLeftA (M : Matrix R R ℂ) : Matrix (Fin dA × R) (Fin dA × R) ℂ :=
+  (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ M
+
+omit [Fintype R] [DecidableEq R] in
+/-- The partial trace over the first factor of a positive definite matrix is
+positive definite, being a nonempty sum of positive definite principal
+submatrices. -/
+theorem traceLeftA_posDef [NeZero dA] {ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ} (hρ : ρ.PosDef) :
+    (traceLeftA ρ).PosDef := by
+  have hblock : ∀ a : Fin dA, (ρ.submatrix (fun r : R => (a, r)) (fun r => (a, r))).PosDef :=
+    fun a => hρ.submatrix (fun i j h => (Prod.ext_iff.mp h).2)
+  have heq : traceLeftA ρ = ∑ a : Fin dA, ρ.submatrix (fun r : R => (a, r)) (fun r => (a, r)) := by
+    ext i j; simp only [traceLeftA, Matrix.sum_apply, Matrix.submatrix_apply]
+  rw [heq]
+  exact Matrix.posDef_sum Finset.univ_nonempty fun a _ => hblock a
+
+omit [DecidableEq R] in
+/-- **Partial-trace adjoint identity.** The trace of an identity-on-$A$ lift
+against a matrix equals the trace of the matrix against the partial trace over the
+first factor: $\operatorname{tr}((\mathbf 1_A \otimes M) \rho)
+= \operatorname{tr}(M \operatorname{tr}_A \rho)$. The marginal version
+`traceA_ABC_lift_trace` is the special case $R = B \otimes C$. -/
+theorem traceLeftA_lift_trace (M : Matrix R R ℂ) (ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ) :
+    (liftLeftA (dA := dA) M * ρ).trace = (M * traceLeftA ρ).trace := by
+  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Fintype.sum_prod_type,
+    liftLeftA, kroneckerMap_apply, Matrix.one_apply, traceLeftA, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  have hL : ∀ a : Fin dA, (∑ a₂, ∑ j, (if a = a₂ then (1 : ℂ) else 0) * M i j * ρ (a₂, j) (a, i))
+      = ∑ j, M i j * ρ (a, j) (a, i) := by
+    intro a
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [Finset.sum_eq_single a]
+    · simp
+    · intro a₂ _ hne; simp [Ne.symm hne]
+    · intro h; exact absurd (Finset.mem_univ a) h
+  rw [Finset.sum_congr rfl fun a _ => hL a, Finset.sum_comm]
+
+end RetainedFactor
+
 /-! ## Marginal support lemma for the tripartite partial trace -/
 
 section Marginal
@@ -214,38 +270,14 @@ theorem liftA_mul_self {Q : Matrix (Fin dB × Fin dC) (Fin dB × Fin dC) ℂ}
 against a tripartite matrix equals the trace of the matrix against the
 $A$-partial trace:
 $\operatorname{tr}((\mathbf 1_A \otimes M) \rho_{ABC})
-= \operatorname{tr}(M \operatorname{tr}_A \rho_{ABC})$. -/
+= \operatorname{tr}(M \operatorname{tr}_A \rho_{ABC})$. The special case
+$R = B \otimes C$ of `traceLeftA_lift_trace`, with which `liftA` and
+`traceA_ABC` agree definitionally. -/
 theorem traceA_ABC_lift_trace
     (M : Matrix (Fin dB × Fin dC) (Fin dB × Fin dC) ℂ)
     (ρ : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ) :
-    (liftA (dA := dA) M * ρ).trace = (M * traceA_ABC ρ).trace := by
-  -- Expand both traces fully into scalar nested sums.
-  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Fintype.sum_prod_type, liftA,
-    Matrix.one_apply, traceA_ABC, Finset.mul_sum]
-  -- Move the row-`A` index inward past the `b₁, c₁` row sums.
-  rw [Finset.sum_comm]
-  refine Finset.sum_congr rfl fun b₁ _ => ?_
-  rw [Finset.sum_comm]
-  refine Finset.sum_congr rfl fun c₁ _ => ?_
-  -- Collapse the inner double sum over the two A-indices, with their equality
-  -- indicator, to a single diagonal sum over one A-index.
-  have hL : ∀ a : Fin dA, (∑ a₂, ∑ b₂, ∑ c₂, (if a = a₂ then (1 : ℂ) else 0)
-        * M (b₁, c₁) (b₂, c₂) * ρ (a₂, b₂, c₂) (a, b₁, c₁))
-      = ∑ b₂, ∑ c₂, M (b₁, c₁) (b₂, c₂) * ρ (a, b₂, c₂) (a, b₁, c₁) := by
-    intro a
-    rw [Finset.sum_comm]
-    refine Finset.sum_congr rfl fun b₂ _ => ?_
-    rw [Finset.sum_comm]
-    refine Finset.sum_congr rfl fun c₂ _ => ?_
-    rw [Finset.sum_eq_single a]
-    · simp
-    · intro a₂ _ hne; simp [Ne.symm hne]
-    · intro h; exact absurd (Finset.mem_univ a) h
-  rw [Finset.sum_congr rfl fun a _ => hL a]
-  -- Reorder `∑ a ∑ b₂ ∑ c₂` into the RHS layout `∑ b₂ ∑ c₂ ∑ a`.
-  rw [Finset.sum_comm]
-  refine Finset.sum_congr rfl fun b₂ _ => ?_
-  rw [Finset.sum_comm]
+    (liftA (dA := dA) M * ρ).trace = (M * traceA_ABC ρ).trace :=
+  traceLeftA_lift_trace (R := Fin dB × Fin dC) M ρ
 
 /-- **Marginal support lemma.**
 

--- a/TNLean/Analysis/MarginalSupport.lean
+++ b/TNLean/Analysis/MarginalSupport.lean
@@ -153,7 +153,7 @@ theorem PosSemidef.proj_mul_eq_zero_of_trace_eq_zero {ρ Q : Matrix n n ℂ}
 
 end Core
 
-/-! ## Partial trace over the retained factor and its adjoint -/
+/-! ## Partial trace over the first factor and its adjoint -/
 
 section RetainedFactor
 

--- a/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -21,7 +21,7 @@ where the reduced states are the tripartite partial traces.
 
 ## Main results
 
-* `SSAPosDef.relEntropy_eval` — the relative entropy against the maximally mixed
+* `SSAPosDef.rel_entropy_eval` — the relative entropy against the maximally mixed
   reference on the retained factor evaluates to an entropy difference:
   $D(\rho \,\|\, (\mathbf 1_A / d_A) \otimes \rho_R)
     = \log d_A + S(\rho_R) - S(\rho)$, where $\rho_R$ is the partial trace over
@@ -37,7 +37,7 @@ Read strong subadditivity as one instance of the data-processing inequality unde
 the partial trace over $C$, with reference state $(\mathbf 1_A / d_A) \otimes
 \rho_{BC}$. The relative entropy of the full pair evaluates to
 $\log d_A + S(\rho_{BC}) - S(\rho_{ABC})$ and that of the partial-trace image to
-$\log d_A + S(\rho_B) - S(\rho_{AB})$, both by `relEntropy_eval`; data processing
+$\log d_A + S(\rho_B) - S(\rho_{AB})$, both by `rel_entropy_eval`; data processing
 between the two leaves $S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC})$
 after the common $\log d_A$ cancels. The two evaluations use the partial-trace
 adjoint identity `traceLeftA_lift_trace` and the tensor logarithm split
@@ -101,7 +101,7 @@ $\log(\mathbf 1_A / d_A) \otimes \mathbf 1 = -(\log d_A) \cdot \mathbf 1$ and a
 retained term $\mathbf 1_A \otimes \log \rho_R$; the first contributes
 $\log d_A$ after pairing with the unit-trace $\rho$, and the second contributes
 $S(\rho_R)$ through the partial-trace adjoint identity `traceLeftA_lift_trace`. -/
-theorem relEntropy_eval [NeZero dA]
+theorem rel_entropy_eval [NeZero dA]
     {ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ}
     (hρ : ρ.PosDef) (hρtr : ρ.trace = 1)
     (hρR : (traceLeftA ρ).PosDef) :
@@ -263,7 +263,7 @@ inequality is read as one instance of the data-processing inequality under the
 partial trace over $C$, with reference state $(\mathbf 1_A / d_A) \otimes
 \rho_{BC}$: the relative entropy of the full pair is
 $\log d_A + S(\rho_{BC}) - S(\rho_{ABC})$ and that of the partial-trace image is
-$\log d_A + S(\rho_B) - S(\rho_{AB})$ (`relEntropy_eval`), and data processing
+$\log d_A + S(\rho_B) - S(\rho_{AB})$ (`rel_entropy_eval`), and data processing
 (`quantumRelativeEntropy_traceC_le`) between them is the claim.
 
 **Scope restriction (positive-definite domain):** the source inequality holds for
@@ -308,10 +308,10 @@ theorem strong_subadditivity_posDef
     simp only [hρB, hρAB, traceLeftA, traceC_ABC, traceAC_ABC]
   have hρB_pd : ρB.PosDef := hρB_eq ▸ traceLeftA_posDef hρAB_pd
   -- Relative entropy of the full pair.
-  have hfull := relEntropy_eval (ρ := ρ_ABC) hρ hρtr (hρBC_eq ▸ hρBC_pd)
+  have hfull := rel_entropy_eval (ρ := ρ_ABC) hρ hρtr (hρBC_eq ▸ hρBC_pd)
   -- Relative entropy of the partial-trace image.
   have hABtr : ρAB.trace = 1 := by rw [hρAB, ← Matrix.trace_eq_trace_traceC_ABC]; exact hρtr
-  have himg := relEntropy_eval (ρ := ρAB) hρAB_pd hABtr (hρB_eq ▸ hρB_pd)
+  have himg := rel_entropy_eval (ρ := ρAB) hρAB_pd hABtr (hρB_eq ▸ hρB_pd)
   -- Data processing between the two pairs, tracing out the third factor.
   -- The reference state of the image pair is the partial trace of the full one.
   have hσtrace : traceC_ABC (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC)

--- a/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -1,0 +1,409 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.Schwarz.RelativeEntropyDataProcessing
+import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
+import TNLean.Analysis.MarginalSupport
+import TNLean.Entropy.TripartiteTrace
+
+/-!
+# Strong subadditivity on the positive definite domain
+
+This file proves **strong subadditivity** of the von Neumann entropy for a
+positive definite tripartite density matrix, as the layer-6 instantiation of the
+relative-entropy elimination route,
+`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`. For a positive definite density
+matrix $\rho_{ABC}$ on $A \otimes B \otimes C$,
+$$S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC}),$$
+where the reduced states are the tripartite partial traces.
+
+## Main results
+
+* `SSAPosDef.relEntropy_eval` — the relative entropy against the maximally mixed
+  reference on the retained factor evaluates to an entropy difference:
+  $D(\rho \,\|\, (\mathbf 1_A / d_A) \otimes \rho_R)
+    = \log d_A + S(\rho_R) - S(\rho)$, where $\rho_R$ is the partial trace over
+  $A$ and the retained factor $A$ carries the maximally mixed state.
+* `SSAPosDef.quantumRelativeEntropy_traceC_le` — the data-processing inequality
+  specialized to the partial trace over the third factor of the tripartite index.
+* `strong_subadditivity_posDef` — strong subadditivity for a positive definite
+  tripartite density matrix.
+
+## Proof outline
+
+Read strong subadditivity as one instance of the data-processing inequality under
+the partial trace over $C$, with reference state $(\mathbf 1_A / d_A) \otimes
+\rho_{BC}$. The relative entropy of the full pair evaluates to
+$\log d_A + S(\rho_{BC}) - S(\rho_{ABC})$ and that of the partial-trace image to
+$\log d_A + S(\rho_B) - S(\rho_{AB})$, both by `relEntropy_eval`; data processing
+between the two leaves $S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC})$
+after the common $\log d_A$ cancels. The two evaluations use the partial-trace
+adjoint identity `traceLeftA_lift_trace` and the tensor logarithm split
+`Matrix.log_kronecker`; the data-processing step transports the partial-trace
+data-processing inequality `quantumRelativeEntropy_partialTraceRight_le` to the
+tripartite index by reassociation and reindexing.
+
+**Scope restriction (positive-definite domain):** the source inequality holds for
+every tripartite density matrix, whereas this development restricts $\rho_{ABC}$
+to positive definite matrices, the domain on which the relative-entropy
+ingredients (joint convexity, ancilla additivity, data processing, and the
+logarithm split) are available. The standalone axiom `strong_subadditivity`
+remains in force for the general density-matrix domain. The restriction and its
+elimination plan are recorded in
+`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 6.
+
+## References
+
+* Lieb, Ruskai, "Proof of the strong subadditivity of quantum-mechanical
+  entropy", JMP 14, 1938 (1973) — source of strong subadditivity.
+* Layer 6 (instantiation) of the relative-entropy elimination route for strong
+  subadditivity, `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`.
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 8
+  (Distance Measures)][Wolf2012QChannels].
+-/
+
+open scoped Matrix Kronecker ComplexOrder Matrix.Norms.L2Operator
+open Matrix
+
+namespace SSAPosDef
+
+/-! ## Partial trace over the retained factor and its adjoint -/
+
+section RetainedFactor
+
+variable {dA : ℕ} {R : Type*} [Fintype R] [DecidableEq R]
+
+/-- Partial trace over the first factor $A$ of $A \otimes R$, the retained factor
+of the tripartite splitting. -/
+noncomputable def traceLeftA (ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ) : Matrix R R ℂ :=
+  fun i j => ∑ a : Fin dA, ρ (a, i) (a, j)
+
+/-- The identity-on-$A$ lift $\mathbf 1_A \otimes M$ of a matrix on the retained
+factor. -/
+noncomputable def liftLeftA (M : Matrix R R ℂ) : Matrix (Fin dA × R) (Fin dA × R) ℂ :=
+  (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ M
+
+omit [Fintype R] [DecidableEq R] in
+/-- The partial trace over the first factor of a positive definite matrix is
+positive definite, being a nonempty sum of positive definite principal
+submatrices. -/
+theorem traceLeftA_posDef [NeZero dA] {ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ} (hρ : ρ.PosDef) :
+    (traceLeftA ρ).PosDef := by
+  have hblock : ∀ a : Fin dA, (ρ.submatrix (fun r : R => (a, r)) (fun r => (a, r))).PosDef :=
+    fun a => hρ.submatrix (fun i j h => (Prod.ext_iff.mp h).2)
+  have heq : traceLeftA ρ = ∑ a : Fin dA, ρ.submatrix (fun r : R => (a, r)) (fun r => (a, r)) := by
+    ext i j; simp only [traceLeftA, Matrix.sum_apply, Matrix.submatrix_apply]
+  rw [heq]
+  exact Matrix.posDef_sum Finset.univ_nonempty fun a _ => hblock a
+
+omit [DecidableEq R] in
+/-- **Partial-trace adjoint identity.** The trace of an identity-on-$A$ lift
+against a matrix equals the trace of the matrix against the partial trace over the
+first factor: $\operatorname{tr}((\mathbf 1_A \otimes M) \rho)
+= \operatorname{tr}(M \operatorname{tr}_A \rho)$. -/
+theorem traceLeftA_lift_trace (M : Matrix R R ℂ) (ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ) :
+    (liftLeftA (dA := dA) M * ρ).trace = (M * traceLeftA ρ).trace := by
+  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Fintype.sum_prod_type,
+    liftLeftA, kroneckerMap_apply, Matrix.one_apply, traceLeftA, Finset.mul_sum]
+  rw [Finset.sum_comm]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  have hL : ∀ a : Fin dA, (∑ a₂, ∑ j, (if a = a₂ then (1 : ℂ) else 0) * M i j * ρ (a₂, j) (a, i))
+      = ∑ j, M i j * ρ (a, j) (a, i) := by
+    intro a
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [Finset.sum_eq_single a]
+    · simp
+    · intro a₂ _ hne; simp [Ne.symm hne]
+    · intro h; exact absurd (Finset.mem_univ a) h
+  rw [Finset.sum_congr rfl fun a _ => hL a, Finset.sum_comm]
+
+end RetainedFactor
+
+/-! ## The logarithm of a positive scalar multiple of the identity -/
+
+/-- **Logarithm of a positive scalar multiple of the identity.** For a real
+scalar $c$, $\log(c \cdot \mathbf 1) = (\log c) \cdot \mathbf 1$. The scalar
+multiple is the algebra map of $c$, so the logarithm reduces to the scalar
+logarithm `CFC.log_algebraMap`. -/
+theorem cfc_log_smul_one {n : Type*} [Fintype n] [DecidableEq n] (c : ℝ) :
+    CFC.log (((c : ℝ) : ℂ) • (1 : Matrix n n ℂ)) = ((Real.log c : ℝ) : ℂ) • (1 : Matrix n n ℂ) := by
+  have hcoe : ∀ (r : ℝ) (M : Matrix n n ℂ), ((r : ℂ)) • M = r • M := fun r M => by
+    rw [← algebraMap_smul ℂ (r : ℝ) M, Complex.coe_algebraMap]
+  rw [hcoe, hcoe]
+  have he : (c • (1 : Matrix n n ℂ)) = algebraMap ℝ (Matrix n n ℂ) c := by
+    rw [Algebra.algebraMap_eq_smul_one]
+  rw [he, CFC.log_algebraMap, Algebra.algebraMap_eq_smul_one]
+
+/-! ## The relative entropy against the maximally mixed retained factor -/
+
+section RelEntropyEval
+
+variable {dA : ℕ} {R : Type*} [Fintype R] [DecidableEq R]
+
+/-- **The relative entropy against the maximally mixed reference on the retained
+factor.** For a positive definite density matrix $\rho$ on $A \otimes R$ with
+partial trace $\rho_R = \operatorname{tr}_A \rho$,
+$$D\bigl(\rho \,\|\, (\mathbf 1_A / d_A) \otimes \rho_R\bigr)
+  = \log d_A + S(\rho_R) - S(\rho).$$
+
+The tensor logarithm splits (`Matrix.log_kronecker`) into a scalar term
+$\log(\mathbf 1_A / d_A) \otimes \mathbf 1 = -(\log d_A) \cdot \mathbf 1$ and a
+retained term $\mathbf 1_A \otimes \log \rho_R$; the first contributes
+$\log d_A$ after pairing with the unit-trace $\rho$, and the second contributes
+$S(\rho_R)$ through the partial-trace adjoint identity `traceLeftA_lift_trace`. -/
+theorem relEntropy_eval [NeZero dA]
+    {ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ}
+    (hρ : ρ.PosDef) (hρtr : ρ.trace = 1)
+    (hρR : (traceLeftA ρ).PosDef) :
+    quantumRelativeEntropy ρ
+        (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ)
+      = Real.log dA + vonNeumannEntropy (traceLeftA ρ) hρR.isHermitian
+        - vonNeumannEntropy ρ hρ.isHermitian := by
+  set ρR := traceLeftA ρ with hρRdef
+  set σA : Matrix (Fin dA) (Fin dA) ℂ := (dA : ℂ)⁻¹ • 1 with hσAdef
+  have hdApos : (0 : ℝ) < dA := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dA)
+  have hσA : σA.PosDef := by
+    refine Matrix.PosDef.smul Matrix.PosDef.one ?_
+    rw [inv_pos]; exact_mod_cast hdApos
+  rw [quantumRelativeEntropy_eq_neg_entropy_sub_trace_mul_log hρ.isHermitian]
+  rw [Matrix.log_kronecker hσA hρR]
+  have hinvcast : ((dA : ℂ))⁻¹ = (((dA : ℝ)⁻¹ : ℝ) : ℂ) := by push_cast; ring
+  have hlogσA : CFC.log σA = ((-Real.log dA : ℝ) : ℂ) • (1 : Matrix (Fin dA) (Fin dA) ℂ) := by
+    rw [hσAdef, hinvcast, cfc_log_smul_one]
+    congr 2
+    rw [Real.log_inv]
+  have hterm1 : (CFC.log σA) ⊗ₖ (1 : Matrix R R ℂ)
+      = ((-Real.log dA : ℝ) : ℂ)
+        • (1 : Matrix (Fin dA × R) (Fin dA × R) ℂ) := by
+    rw [hlogσA, smul_kronecker, one_kronecker_one]
+  have hterm2 : (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ CFC.log ρR
+      = liftLeftA (dA := dA) (CFC.log ρR) := rfl
+  rw [hterm1, hterm2]
+  rw [Matrix.mul_add, Matrix.trace_add, Complex.add_re]
+  have htr1 : (Matrix.trace (ρ * (((-Real.log dA : ℝ) : ℂ)
+        • (1 : Matrix (Fin dA × R) (Fin dA × R) ℂ)))).re = -Real.log dA := by
+    rw [Matrix.mul_smul, Matrix.mul_one, Matrix.trace_smul, smul_eq_mul, hρtr, mul_one,
+      Complex.ofReal_re]
+  have htr2 : (Matrix.trace (ρ * liftLeftA (dA := dA) (CFC.log ρR))).re
+      = -vonNeumannEntropy ρR hρR.isHermitian := by
+    rw [Matrix.trace_mul_comm, traceLeftA_lift_trace, ← hρRdef, Matrix.trace_mul_comm]
+    rw [show (Matrix.trace (ρR * CFC.log ρR)).re = -vonNeumannEntropy ρR hρR.isHermitian from by
+      linarith [vonNeumannEntropy_eq_neg_trace_mul_log hρR.isHermitian]]
+  rw [htr1, htr2]
+  ring
+
+end RelEntropyEval
+
+/-! ## Data processing on an arbitrary product index -/
+
+section DataProcessingGeneral
+
+/-- **Data-processing inequality on an arbitrary product index.** For positive
+definite matrices $\rho, \sigma$ on $S \times T$ with $T$ nonempty,
+$D(\operatorname{tr}_T \rho \,\|\, \operatorname{tr}_T \sigma)
+  \le D(\rho \,\|\, \sigma)$, where $\operatorname{tr}_T$ is the partial trace over
+the second factor.
+
+The pair is reindexed to a canonical product index, where
+`quantumRelativeEntropy_partialTraceRight_le` applies; the relative entropy
+is invariant under reindexing (`quantumRelativeEntropy_submatrix_equiv`) and the
+partial trace commutes with reindexing the kept and traced factors
+(`partialTraceRight_submatrix_left`, `partialTraceRight_submatrix_right`). -/
+theorem quantumRelativeEntropy_partialTraceRight_le_general
+    {S T : Type*} [Fintype S] [DecidableEq S] [Fintype T] [DecidableEq T] [Nonempty T]
+    {ρ σ : Matrix (S × T) (S × T) ℂ} (hρ : ρ.PosDef) (hσ : σ.PosDef) :
+    quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)
+      ≤ quantumRelativeEntropy ρ σ := by
+  classical
+  set dS := Fintype.card S with hdS
+  set dT := Fintype.card T with hdT
+  have hNZ : NeZero dT := ⟨by simp [hdT, Fintype.card_ne_zero (α := T)]⟩
+  set eS : S ≃ Fin dS := Fintype.equivFin S with heS
+  set eT : T ≃ ZMod dT := (Fintype.equivFin T).trans (ZMod.finEquiv dT).toEquiv with heT
+  set e : (S × T) ≃ (Fin dS × ZMod dT) := eS.prodCongr eT with hedef
+  have hρ' : (ρ.submatrix e.symm e.symm).PosDef := hρ.submatrix e.symm.injective
+  have hσ' : (σ.submatrix e.symm e.symm).PosDef := hσ.submatrix e.symm.injective
+  have hbase := quantumRelativeEntropy_partialTraceRight_le (dS := dS) (dC := dT)
+    (ρ := ρ.submatrix e.symm e.symm) (σ := σ.submatrix e.symm e.symm) hρ' hσ'
+  rw [quantumRelativeEntropy_submatrix_equiv hρ.isHermitian hσ.isHermitian e] at hbase
+  have hptr : ∀ X : Matrix (S × T) (S × T) ℂ,
+      partialTraceRight (X.submatrix e.symm e.symm)
+        = (partialTraceRight X).submatrix eS.symm eS.symm := by
+    intro X
+    rw [partialTraceRight_submatrix_left eS.symm X,
+      partialTraceRight_submatrix_right eT.symm
+        (X.submatrix (Prod.map eS.symm id) (Prod.map eS.symm id)),
+      Matrix.submatrix_submatrix]
+    congr 1
+  rw [hptr ρ, hptr σ,
+    quantumRelativeEntropy_submatrix_equiv
+      (partialTraceRight_isHermitian hρ.isHermitian)
+      (partialTraceRight_isHermitian hσ.isHermitian) eS] at hbase
+  exact hbase
+
+variable {dA dB dC : ℕ}
+
+/-- **Data processing for the partial trace over the third factor.** For positive
+definite matrices on the tripartite index, the relative entropy of the partial
+traces over $C$ is bounded by the relative entropy of the originals. The
+tripartite index is reassociated to $(A \times B) \times C$, where
+`quantumRelativeEntropy_partialTraceRight_le_general` applies, and the
+partial-trace image is identified with `traceC_ABC`. -/
+theorem quantumRelativeEntropy_traceC_le [NeZero dC]
+    {ρ σ : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ}
+    (hρ : ρ.PosDef) (hσ : σ.PosDef) :
+    quantumRelativeEntropy (traceC_ABC ρ) (traceC_ABC σ) ≤ quantumRelativeEntropy ρ σ := by
+  classical
+  set r : (Fin dA × Fin dB × Fin dC) ≃ ((Fin dA × Fin dB) × Fin dC) :=
+    (Equiv.prodAssoc (Fin dA) (Fin dB) (Fin dC)).symm with hr
+  have hρr : (ρ.submatrix r.symm r.symm).PosDef := hρ.submatrix r.symm.injective
+  have hσr : (σ.submatrix r.symm r.symm).PosDef := hσ.submatrix r.symm.injective
+  have hbase := quantumRelativeEntropy_partialTraceRight_le_general
+    (S := Fin dA × Fin dB) (T := Fin dC)
+    (ρ := ρ.submatrix r.symm r.symm) (σ := σ.submatrix r.symm r.symm) hρr hσr
+  rw [quantumRelativeEntropy_submatrix_equiv hρ.isHermitian hσ.isHermitian r] at hbase
+  have hImage : ∀ X : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ,
+      partialTraceRight (X.submatrix r.symm r.symm) = traceC_ABC X := by
+    intro X
+    ext q₁ q₂
+    simp only [partialTraceRight_apply, Matrix.submatrix_apply, traceC_ABC, hr,
+      Equiv.symm_symm, Equiv.prodAssoc_apply]
+  rw [hImage ρ, hImage σ] at hbase
+  exact hbase
+
+/-- The partial trace over the third factor of a positive definite tripartite
+matrix is positive definite, being a nonempty sum of positive definite principal
+submatrices. -/
+theorem traceC_ABC_posDef [NeZero dC]
+    {ρ : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ} (hρ : ρ.PosDef) :
+    (traceC_ABC ρ).PosDef := by
+  have hblock : ∀ c : Fin dC,
+      (ρ.submatrix (fun q : Fin dA × Fin dB => (q.1, q.2, c)) (fun q => (q.1, q.2, c))).PosDef :=
+    fun c => hρ.submatrix (fun q₁ q₂ h => by
+      obtain ⟨h1, h2, _⟩ := Prod.ext_iff.mp h |>.imp id Prod.ext_iff.mp
+      exact Prod.ext h1 h2)
+  have heq : traceC_ABC ρ
+      = ∑ c : Fin dC, ρ.submatrix (fun q : Fin dA × Fin dB => (q.1, q.2, c))
+          (fun q => (q.1, q.2, c)) := by
+    ext q₁ q₂; simp only [traceC_ABC, Matrix.sum_apply, Matrix.submatrix_apply]
+  rw [heq]
+  exact Matrix.posDef_sum Finset.univ_nonempty fun c _ => hblock c
+
+end DataProcessingGeneral
+
+end SSAPosDef
+
+/-! ## Strong subadditivity on the positive definite domain -/
+
+section StrongSubadditivityPosDef
+
+open SSAPosDef
+
+variable {dA dB dC : ℕ}
+
+/-- **Strong subadditivity** (Lieb–Ruskai 1973) for a positive definite tripartite
+density matrix. For a positive definite density matrix $\rho_{ABC}$ on
+$A \otimes B \otimes C$,
+$$S(\rho_{ABC}) + S(\rho_B) \le S(\rho_{AB}) + S(\rho_{BC}),$$
+with the reduced states the tripartite partial traces `traceAC_ABC`,
+`traceC_ABC`, `traceA_ABC`.
+
+This is the layer-6 instantiation of the relative-entropy elimination route. The
+inequality is read as one instance of the data-processing inequality under the
+partial trace over $C$, with reference state $(\mathbf 1_A / d_A) \otimes
+\rho_{BC}$: the relative entropy of the full pair is
+$\log d_A + S(\rho_{BC}) - S(\rho_{ABC})$ and that of the partial-trace image is
+$\log d_A + S(\rho_B) - S(\rho_{AB})$ (`relEntropy_eval`), and data processing
+(`quantumRelativeEntropy_traceC_le`) between them is the claim.
+
+**Scope restriction (positive-definite domain):** the source inequality holds for
+every tripartite density matrix; this version restricts $\rho_{ABC}$ to positive
+definite matrices, the domain on which the relative-entropy ingredients are
+available. The standalone axiom `strong_subadditivity` remains in force for the
+general density-matrix domain. Recorded in
+`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 6.
+
+Source: Lieb, Ruskai, JMP 14, 1938 (1973);
+blueprint `thm:strong_subadditivity_posdef`. -/
+theorem strong_subadditivity_posDef
+    (ρ_ABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hρ : ρ_ABC.PosDef) (hρtr : ρ_ABC.trace = 1) :
+    vonNeumannEntropy ρ_ABC hρ.isHermitian
+        + vonNeumannEntropy (traceAC_ABC ρ_ABC) (traceAC_ABC_isHermitian hρ.isHermitian)
+      ≤ vonNeumannEntropy (traceC_ABC ρ_ABC) (traceC_ABC_isHermitian hρ.isHermitian)
+        + vonNeumannEntropy (traceA_ABC ρ_ABC) (traceA_ABC_isHermitian hρ.isHermitian) := by
+  classical
+  -- Positivity of the dimensions, from the unit trace on the index.
+  have hAne : NeZero dA := by
+    refine ⟨fun h => ?_⟩
+    subst h
+    rw [Matrix.trace_eq_zero_of_isEmpty] at hρtr
+    exact zero_ne_one hρtr
+  have hCne : NeZero dC := by
+    refine ⟨fun h => ?_⟩
+    subst h
+    rw [Matrix.trace_eq_zero_of_isEmpty] at hρtr
+    exact zero_ne_one hρtr
+  -- Reduced states and their positive definiteness.
+  set ρBC := traceA_ABC ρ_ABC with hρBC
+  set ρAB := traceC_ABC ρ_ABC with hρAB
+  set ρB := traceAC_ABC ρ_ABC with hρB
+  -- The reduced state on the last two factors is the retained-factor partial trace.
+  have hρBC_eq : ρBC = traceLeftA ρ_ABC := rfl
+  have hρBC_pd : ρBC.PosDef := hρBC_eq ▸ traceLeftA_posDef hρ
+  have hρAB_pd : ρAB.PosDef := traceC_ABC_posDef hρ
+  -- The middle reduced state is the retained-factor partial trace of the image.
+  have hρB_eq : ρB = traceLeftA ρAB := by
+    ext b₁ b₂
+    simp only [hρB, hρAB, traceLeftA, traceC_ABC, traceAC_ABC]
+  have hρB_pd : ρB.PosDef := hρB_eq ▸ traceLeftA_posDef hρAB_pd
+  -- Relative entropy of the full pair.
+  have hfull := relEntropy_eval (ρ := ρ_ABC) hρ hρtr (hρBC_eq ▸ hρBC_pd)
+  -- Relative entropy of the partial-trace image.
+  have hABtr : ρAB.trace = 1 := by rw [hρAB, ← Matrix.trace_eq_trace_traceC_ABC]; exact hρtr
+  have himg := relEntropy_eval (ρ := ρAB) hρAB_pd hABtr (hρB_eq ▸ hρB_pd)
+  -- Data processing between the two pairs, tracing out the third factor.
+  -- The reference state of the image pair is the partial trace of the full one.
+  have hσtrace : traceC_ABC (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC)
+      = ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρAB := by
+    have hkron : traceC_ABC
+        (((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC)
+        = ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ))
+          ⊗ₖ partialTraceRight (traceLeftA ρ_ABC) := by
+      ext ab₁ ab₂
+      simp only [traceC_ABC, kroneckerMap_apply, partialTraceRight_apply, Finset.mul_sum]
+    rw [hkron]
+    congr 1
+    ext b₁ b₂
+    simp only [partialTraceRight_apply, traceLeftA, hρAB, traceC_ABC]
+    rw [Finset.sum_comm]
+  set σfull : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ :=
+    ((dA : ℂ)⁻¹ • (1 : Matrix (Fin dA) (Fin dA) ℂ)) ⊗ₖ traceLeftA ρ_ABC with hσfull
+  have hσfull_pd : σfull.PosDef := by
+    refine Matrix.PosDef.kronecker ?_ (hρBC_eq ▸ hρBC_pd)
+    refine Matrix.PosDef.smul Matrix.PosDef.one ?_
+    rw [inv_pos]; exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne dA)
+  have hdpi := quantumRelativeEntropy_traceC_le hρ hσfull_pd
+  -- Identify the traced reference state with the image reference.
+  rw [hσfull, hσtrace] at hdpi
+  rw [show traceC_ABC ρ_ABC = ρAB from rfl] at hdpi
+  -- Combine the two evaluations through data processing.
+  rw [hfull] at hdpi
+  rw [himg] at hdpi
+  -- Match the entropy proof terms (they depend only on the matrices).
+  have hSρBC : vonNeumannEntropy (traceLeftA ρ_ABC) (hρBC_eq ▸ hρBC_pd).isHermitian
+      = vonNeumannEntropy (traceA_ABC ρ_ABC) (traceA_ABC_isHermitian hρ.isHermitian) :=
+    vonNeumannEntropy_congr rfl _ _
+  have hSρB : vonNeumannEntropy (traceLeftA ρAB) (hρB_eq ▸ hρB_pd).isHermitian
+      = vonNeumannEntropy (traceAC_ABC ρ_ABC) (traceAC_ABC_isHermitian hρ.isHermitian) :=
+    vonNeumannEntropy_congr hρB_eq.symm _ _
+  have hSρAB : vonNeumannEntropy ρAB hρAB_pd.isHermitian
+      = vonNeumannEntropy (traceC_ABC ρ_ABC) (traceC_ABC_isHermitian hρ.isHermitian) :=
+    vonNeumannEntropy_congr rfl _ _
+  rw [hSρBC, hSρB, hSρAB] at hdpi
+  linarith
+
+end StrongSubadditivityPosDef

--- a/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -69,59 +69,6 @@ open Matrix
 
 namespace SSAPosDef
 
-/-! ## Partial trace over the retained factor and its adjoint -/
-
-section RetainedFactor
-
-variable {dA : ℕ} {R : Type*} [Fintype R] [DecidableEq R]
-
-/-- Partial trace over the first factor $A$ of $A \otimes R$, the retained factor
-of the tripartite splitting. -/
-noncomputable def traceLeftA (ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ) : Matrix R R ℂ :=
-  fun i j => ∑ a : Fin dA, ρ (a, i) (a, j)
-
-/-- The identity-on-$A$ lift $\mathbf 1_A \otimes M$ of a matrix on the retained
-factor. -/
-noncomputable def liftLeftA (M : Matrix R R ℂ) : Matrix (Fin dA × R) (Fin dA × R) ℂ :=
-  (1 : Matrix (Fin dA) (Fin dA) ℂ) ⊗ₖ M
-
-omit [Fintype R] [DecidableEq R] in
-/-- The partial trace over the first factor of a positive definite matrix is
-positive definite, being a nonempty sum of positive definite principal
-submatrices. -/
-theorem traceLeftA_posDef [NeZero dA] {ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ} (hρ : ρ.PosDef) :
-    (traceLeftA ρ).PosDef := by
-  have hblock : ∀ a : Fin dA, (ρ.submatrix (fun r : R => (a, r)) (fun r => (a, r))).PosDef :=
-    fun a => hρ.submatrix (fun i j h => (Prod.ext_iff.mp h).2)
-  have heq : traceLeftA ρ = ∑ a : Fin dA, ρ.submatrix (fun r : R => (a, r)) (fun r => (a, r)) := by
-    ext i j; simp only [traceLeftA, Matrix.sum_apply, Matrix.submatrix_apply]
-  rw [heq]
-  exact Matrix.posDef_sum Finset.univ_nonempty fun a _ => hblock a
-
-omit [DecidableEq R] in
-/-- **Partial-trace adjoint identity.** The trace of an identity-on-$A$ lift
-against a matrix equals the trace of the matrix against the partial trace over the
-first factor: $\operatorname{tr}((\mathbf 1_A \otimes M) \rho)
-= \operatorname{tr}(M \operatorname{tr}_A \rho)$. -/
-theorem traceLeftA_lift_trace (M : Matrix R R ℂ) (ρ : Matrix (Fin dA × R) (Fin dA × R) ℂ) :
-    (liftLeftA (dA := dA) M * ρ).trace = (M * traceLeftA ρ).trace := by
-  simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply, Fintype.sum_prod_type,
-    liftLeftA, kroneckerMap_apply, Matrix.one_apply, traceLeftA, Finset.mul_sum]
-  rw [Finset.sum_comm]
-  refine Finset.sum_congr rfl fun i _ => ?_
-  have hL : ∀ a : Fin dA, (∑ a₂, ∑ j, (if a = a₂ then (1 : ℂ) else 0) * M i j * ρ (a₂, j) (a, i))
-      = ∑ j, M i j * ρ (a, j) (a, i) := by
-    intro a
-    rw [Finset.sum_comm]
-    refine Finset.sum_congr rfl fun j _ => ?_
-    rw [Finset.sum_eq_single a]
-    · simp
-    · intro a₂ _ hne; simp [Ne.symm hne]
-    · intro h; exact absurd (Finset.mem_univ a) h
-  rw [Finset.sum_congr rfl fun a _ => hL a, Finset.sum_comm]
-
-end RetainedFactor
-
 /-! ## The logarithm of a positive scalar multiple of the identity -/
 
 /-- **Logarithm of a positive scalar multiple of the identity.** For a real

--- a/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -21,8 +21,8 @@ where the reduced states are the tripartite partial traces.
 
 ## Main results
 
-* `SSAPosDef.rel_entropy_eval` — the relative entropy against the maximally mixed
-  reference on the retained factor evaluates to an entropy difference:
+* `SSAPosDef.rel_entropy_eval` — the relative entropy against the reference state
+  maximally mixed on the traced-out factor evaluates to an entropy difference:
   $D(\rho \,\|\, (\mathbf 1_A / d_A) \otimes \rho_R)
     = \log d_A + S(\rho_R) - S(\rho)$, where $\rho_R$ is the partial trace over
   $A$ and the traced-out factor $A$ carries the maximally mixed state.
@@ -84,13 +84,13 @@ theorem cfc_log_smul_one {n : Type*} [Fintype n] [DecidableEq n] (c : ℝ) :
     rw [Algebra.algebraMap_eq_smul_one]
   rw [he, CFC.log_algebraMap, Algebra.algebraMap_eq_smul_one]
 
-/-! ## The relative entropy against the maximally mixed retained factor -/
+/-! ## The relative entropy against a reference maximally mixed on the traced-out factor -/
 
 section RelEntropyEval
 
 variable {dA : ℕ} {R : Type*} [Fintype R] [DecidableEq R]
 
-/-- **The relative entropy against the maximally mixed reference on the retained
+/-- **The relative entropy against a reference maximally mixed on the traced-out
 factor.** For a positive definite density matrix $\rho$ on $A \otimes R$ with
 partial trace $\rho_R = \operatorname{tr}_A \rho$,
 $$D\bigl(\rho \,\|\, (\mathbf 1_A / d_A) \otimes \rho_R\bigr)

--- a/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
+++ b/TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean
@@ -25,7 +25,7 @@ where the reduced states are the tripartite partial traces.
   reference on the retained factor evaluates to an entropy difference:
   $D(\rho \,\|\, (\mathbf 1_A / d_A) \otimes \rho_R)
     = \log d_A + S(\rho_R) - S(\rho)$, where $\rho_R$ is the partial trace over
-  $A$ and the retained factor $A$ carries the maximally mixed state.
+  $A$ and the traced-out factor $A$ carries the maximally mixed state.
 * `SSAPosDef.quantumRelativeEntropy_traceC_le` — the data-processing inequality
   specialized to the partial trace over the third factor of the tripartite index.
 * `strong_subadditivity_posDef` — strong subadditivity for a positive definite

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -708,8 +708,7 @@ finite-dimensional quantum systems.
     \label{thm:strong_subadditivity_posdef}
     \lean{strong_subadditivity_posDef}
     \leanok
-    \uses{def:von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC,
-        def:quantum_relative_entropy, thm:relative_entropy_data_processing}
+    \uses{def:von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC}
     For a positive definite tripartite density matrix $\rho_{ABC}$,
     \[
         S(\rho_{ABC}) + S(\rho_B)
@@ -721,14 +720,29 @@ finite-dimensional quantum systems.
 \begin{proof}\leanok
     \uses{def:quantum_relative_entropy, thm:relative_entropy_data_processing}
     Read the inequality as one instance of data processing under the partial
-    trace over $C$, with reference state $(\mathbf 1_A / d_A) \otimes \rho_{BC}$.
-    The relative entropy of the full pair is
-    $\log d_A + S(\rho_{BC}) - S(\rho_{ABC})$ and that of the partial-trace image
-    is $\log d_A + S(\rho_B) - S(\rho_{AB})$; data processing between the two
-    cancels the common $\log d_A$ and rearranges to the inequality. Each
-    evaluation uses the tensor logarithm split and the adjoint of the partial
-    trace; the reference state is positive definite because $\rho_{BC}$ is, which
-    holds on the positive definite domain.
+    trace over $C$, with reference state
+    $\sigma_{ABC} = (\mathbf 1_A / d_A) \otimes \rho_{BC}$, which is positive
+    definite because $\rho_{BC}$ is. Against this reference the relative entropy of
+    each pair evaluates to an entropy difference,
+    \[
+        D\bigl(\rho_{ABC} \,\big\|\, (\mathbf 1_A / d_A) \otimes \rho_{BC}\bigr)
+            = \log d_A + S(\rho_{BC}) - S(\rho_{ABC}),
+    \]
+    \[
+        D\bigl(\rho_{AB} \,\big\|\, (\mathbf 1_A / d_A) \otimes \rho_{B}\bigr)
+            = \log d_A + S(\rho_{B}) - S(\rho_{AB}),
+    \]
+    each by the tensor logarithm split and the adjoint of the partial trace. Data
+    processing under the partial trace over $C$, which sends
+    $\rho_{ABC} \mapsto \rho_{AB}$ and
+    $(\mathbf 1_A / d_A) \otimes \rho_{BC} \mapsto
+    (\mathbf 1_A / d_A) \otimes \rho_{B}$, reads
+    \[
+        D\bigl(\rho_{AB} \,\big\|\, (\mathbf 1_A / d_A) \otimes \rho_{B}\bigr)
+            \le D\bigl(\rho_{ABC} \,\big\|\, (\mathbf 1_A / d_A) \otimes \rho_{BC}\bigr).
+    \]
+    Substituting the two evaluations cancels the common $\log d_A$ and rearranges
+    to the claimed inequality.
 \end{proof}
 
 \begin{definition}[SSA equality]\label{def:ssa_equality}

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -704,6 +704,33 @@ finite-dimensional quantum systems.
     \]
 \end{theorem}
 
+\begin{theorem}[Strong subadditivity, positive definite case]
+    \label{thm:strong_subadditivity_posdef}
+    \lean{strong_subadditivity_posDef}
+    \leanok
+    \uses{def:von_neumann_entropy, def:traceA_ABC, def:traceC_ABC, def:traceAC_ABC,
+        def:quantum_relative_entropy, thm:relative_entropy_data_processing}
+    For a positive definite tripartite density matrix $\rho_{ABC}$,
+    \[
+        S(\rho_{ABC}) + S(\rho_B)
+        \le S(\rho_{AB}) + S(\rho_{BC}).
+    \]
+    This is the positive definite case of Theorem~\ref{thm:strong_subadditivity}.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{def:quantum_relative_entropy, thm:relative_entropy_data_processing}
+    Read the inequality as one instance of data processing under the partial
+    trace over $C$, with reference state $(\mathbf 1_A / d_A) \otimes \rho_{BC}$.
+    The relative entropy of the full pair is
+    $\log d_A + S(\rho_{BC}) - S(\rho_{ABC})$ and that of the partial-trace image
+    is $\log d_A + S(\rho_B) - S(\rho_{AB})$; data processing between the two
+    cancels the common $\log d_A$ and rearranges to the inequality. Each
+    evaluation uses the tensor logarithm split and the adjoint of the partial
+    trace; the reference state is positive definite because $\rho_{BC}$ is, which
+    holds on the positive definite domain.
+\end{proof}
+
 \begin{definition}[SSA equality]\label{def:ssa_equality}
     \lean{IsSSAEquality}
     \leanok

--- a/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
+++ b/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
@@ -298,8 +298,20 @@ in place. Concretely:
     (\leanid{Matrix.PosSemidef.proj_mul_eq_zero_of_trace_eq_zero}) --- and the
     partial-trace adjoint identity it uses
     (\leanid{Matrix.traceA_ABC_lift_trace}) are independent of Lieb concavity.
-    These three results depend only on the standard Lean axioms; the remaining
-    layer-(6) work is the instantiation, which is gated on layer (5).
+    These three results depend only on the standard Lean axioms. On the
+    positive-definite domain the instantiation is now formalized:
+    \leanid{strong_subadditivity_posDef} in
+    \doclink{TNLean/Channel/Schwarz/StrongSubadditivityPosDef}
+    (\path{TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean}) proves the
+    inequality~\eqref{eq:ssa} for a positive definite $\rho_{ABC}$. There the
+    reference state $(\mathbf 1_A/d_A)\otimes\rho_{BC}$ is itself positive
+    definite, so the marginal support lemma is not invoked and the layer-(2)
+    domain condition holds outright; the relative entropy of each pair evaluates
+    to the displayed entropy difference through the tensor logarithm split and the
+    partial-trace adjoint, and layer (5) data processing between the two pairs
+    yields~\eqref{eq:ssa}. The marginal support lemma is the prerequisite of the
+    singular-reference extension of this instantiation to the general
+    density-matrix domain, which remains open.
 \end{itemize}
 
 \paragraph{Current formal status.} Layers (1)--(5) and the layer-(6) marginal
@@ -317,11 +329,18 @@ ancilla-factor lift presenting $\tr_C$ through the twirl
 (\leanid{Matrix.sum_kronecker_one_weyl_conj}) are formalized, and combine into the
 partial-trace monotonicity
 \leanid{quantumRelativeEntropy_partialTraceRight_le} on the positive-definite
-domain. Only the layer-(6) instantiation remains; until it is in place the
-standalone axiom \leanid{strong_subadditivity} stands.
+domain. The layer-(6) instantiation is now formalized on the positive-definite
+domain (\leanid{strong_subadditivity_posDef}): for a positive definite
+$\rho_{ABC}$ the inequality~\eqref{eq:ssa} is a theorem whose only entropy-side
+axiom is the Lieb-concavity axiom. The standalone axiom
+\leanid{strong_subadditivity} stands for the general density-matrix domain,
+because the positive-definite version is a strictly stronger hypothesis and does
+not discharge the unrestricted axiom; closing that gap needs the
+singular-reference extension of layers (3)--(5) and of the instantiation.
 
-After layer (6) the inequality is a theorem, the standalone axiom is removed, and
-the only remaining entropy-side axiom on this route is the Lieb-concavity axiom.
+After the singular-reference extension the inequality is a theorem on the full
+density-matrix domain, the standalone axiom is removed, and the only remaining
+entropy-side axiom on this route is the Lieb-concavity axiom.
 The downstream consumers in the stable entropy interface
 \footnote{The stable interface re-exports the inequality from
 \doclink{TNLean/Entropy/StrongSubadditivity}; consumers import it from there and
@@ -347,10 +366,16 @@ invariance (\leanid{quantumRelativeEntropy_conj_unitary}), ancilla additivity
 twirl (\leanid{Matrix.sum_weyl_conj}), and the ancilla-factor lift presenting
 $\tr_C$ through the twirl (\leanid{Matrix.sum_kronecker_one_weyl_conj}) combine
 through joint convexity into the partial-trace monotonicity
-$D(\tr_C\rho\,\|\,\tr_C\sigma)\le D(\rho\,\|\,\sigma)$. The remaining work is the
-singular-$\sigma$ extension of layers (3)--(5) and the instantiation layer (6);
-until those are formalized, the standalone axiom records a result the development
-assumes but does not yet derive from its operator-convexity input.
+$D(\tr_C\rho\,\|\,\tr_C\sigma)\le D(\rho\,\|\,\sigma)$. The layer-(6)
+instantiation is formalized on the positive-definite domain
+(\leanid{strong_subadditivity_posDef}): for a positive definite $\rho_{ABC}$ the
+inequality follows from data processing alone, with the positive-definite
+reference state $(\mathbf 1_A/d_A)\otimes\rho_{BC}$ sidestepping the marginal
+support lemma. The remaining work is the singular-$\sigma$ extension of layers
+(3)--(5) and of the instantiation, which lifts the result from positive definite
+$\rho_{ABC}$ to a general density matrix; until that is formalized, the standalone
+axiom records the unrestricted statement that the development assumes but does not
+yet derive from its operator-convexity input.
 
 \begin{thebibliography}{9}
 


### PR DESCRIPTION
## Summary

Proves **strong subadditivity (SSA) of the von Neumann entropy on the positive definite domain** as a theorem, completing layer 6 of the SSA-from-Lieb elimination route (`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`) on top of the just-merged data-processing inequality (#3509).

For a positive definite tripartite density matrix `ρ_ABC`:
```
S(ρ_ABC) + S(ρ_B) ≤ S(ρ_AB) + S(ρ_BC)
```

`#print axioms strong_subadditivity_posDef`:
```
[lieb_concavity_axiom, propext, Classical.choice, Quot.sound]
```
The positive-definite SSA is derived from **Lieb concavity alone** — the standalone `strong_subadditivity` axiom is **not** in its closure. Sorry-free, no new axiom, `lake exe lint-style` clean, full `lake build` green (9229 jobs).

## This is a PARTIAL discharge (axiom kept)

The standalone axiom `strong_subadditivity` is stated for general density matrices (`PosSemidef ∧ trace = 1`). The new theorem requires the **strictly stronger** `ρ_ABC.PosDef`, so it does **not** discharge the axiom — per the faithfulness rule, the axiom stays. The general-PSD extension needs the singular-reference extension of layers (3)–(5) (the relative-entropy ingredients are positive-definite-only); that gap is documented in the route note. The new theorem carries a `**Scope restriction (positive-definite domain):**` marker.

## Proof route

Read SSA as one instance of data processing under the partial trace over `C`, with reference state `(1_A/d_A) ⊗ ρ_BC`:
- The relative entropy of the full pair evaluates to `log d_A + S(ρ_BC) − S(ρ_ABC)`, and of the partial-trace image to `log d_A + S(ρ_B) − S(ρ_AB)`, via the tensor logarithm split (`Matrix.log_kronecker`) and the partial-trace adjoint identity (`traceLeftA_lift_trace`). The positive-definite reference state sidesteps the marginal support lemma.
- Data processing between the two pairs (`quantumRelativeEntropy_traceC_le`, transported from the merged `quantumRelativeEntropy_partialTraceRight_le` by reassociation/reindexing) cancels the common `log d_A` and rearranges to the inequality.

## Changes
- **New** `TNLean/Channel/Schwarz/StrongSubadditivityPosDef.lean` — supporting partial-trace infrastructure on the retained factor, the relative-entropy evaluation `relEntropy_eval`, a general-index data-processing wrapper, and `strong_subadditivity_posDef`.
- `TNLean.lean` — root import.
- `blueprint/src/chapter/ch19_entropy.tex` — adds `thm:strong_subadditivity_posdef` (`\leanok`) next to the still-`\notready` `thm:strong_subadditivity`.
- `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex` — layer-6 bullet, formal status, and verdict updated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New formal entropy theorem on a restricted domain; correctness hinges on reindexing/partial-trace identifications and relative-entropy lemmas already in the Schwarz stack, not on removing the general SSA axiom yet.
> 
> **Overview**
> Adds **`strong_subadditivity_posDef`**, a theorem proving tripartite von Neumann entropy strong subadditivity when **`ρ_ABC` is positive definite** (layer 6 of the Lieb–relative-entropy route). The proof is data processing under partial trace over `C` with reference **`(1_A/d_A) ⊗ ρ_BC`**, using **`rel_entropy_eval`** (tensor log split + **`traceLeftA_lift_trace`**) and **`quantumRelativeEntropy_traceC_le`** (reindexing to the existing partial-trace DPI).
> 
> **`MarginalSupport.lean`** gains generic **`traceLeftA`**, **`liftLeftA`**, **`traceLeftA_posDef`**, and **`traceLeftA_lift_trace`**; **`traceA_ABC_lift_trace`** is now a thin delegate instead of a long standalone proof.
> 
> **`StrongSubadditivityPosDef.lean`** is new (~350 lines): supporting DPI on general product indices, tripartite trace-`C` DPI, and the main SSA theorem. Root import in **`TNLean.lean`**. Blueprint **`thm:strong_subadditivity_posdef`** is **`\leanok`**; the general **`strong_subadditivity`** axiom stays **`\notready`**. Route note **`cpsv16_ssa_from_lieb_route.tex`** documents layer-6 completion on the pos-def domain and that the unrestricted axiom remains until singular-reference extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f4db25a5faa4219e9e33609fb9478b0b1b1b99b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->