### PR TITLE
fix(Channel): remove spurious unitary restriction from isPPT_basis_change blueprint and docstring

### DIFF
--- a/TNLean/Channel/PartialTranspose.lean
+++ b/TNLean/Channel/PartialTranspose.lean
@@ -305,7 +305,7 @@ theorem partialTransposeLeft_unitary_basis_change
 
 /-- **Basis independence of the PPT property (Wolf eq. (3.17)).** If a bipartite
 matrix `ρ` is PPT, then the partial transpose taken in the local basis changed by
-a unitary `U` on the first factor is again positive semidefinite.  By
+any matrix `U` on the first factor is again positive semidefinite.  By
 `partialTransposeLeft_unitary_basis_change` the new-basis partial transpose is the
 similarity transform `((U Uᵀ) ⊗ 1) ρ^{T₁} ((U Uᵀ)ᴴ ⊗ 1)`, and conjugation by a
 matrix preserves positive semidefiniteness, so the positivity of the partial

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1752,7 +1752,7 @@ from the separable ones.
     \lean{Matrix.isPPT_basis_change}
     \leanok
     \uses{def:is_ppt, thm:partial_transpose_left_basis_change}
-    Let $U$ be a unitary on the first factor.  If $\rho$ has the PPT property then
+    Let $U$ be any matrix on the first factor.  If $\rho$ has the PPT property then
     the partial transpose taken in the basis changed by $U$,
     \[
         \bigl(U\otimes\Id\bigr)


### PR DESCRIPTION
## Summary

`Matrix.isPPT_basis_change` in `TNLean/Channel/PartialTranspose.lean` holds for **any** matrix `U` on the first factor — there is no unitarity (or invertibility) hypothesis. The blueprint entry `thm:is_ppt_basis_change` and the Lean docstring both wrongly described `U` as "a unitary on the first factor", stating a strictly stronger hypothesis and therefore a weaker theorem than what is actually proved.

## The actual Lean signature

```lean
theorem isPPT_basis_change {U : Matrix (Fin d) (Fin d) ℂ}
    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : IsPPT ρ) :
    ((U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) *
        partialTransposeLeft ((Uᴴ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) * ρ *
          (U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))) *
        (Uᴴ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ))).PosSemidef
```

`U` is an arbitrary matrix. The proof rewrites the new-basis partial transpose as the conjugation `((U Uᵀ) ⊗ 1) ρ^{T₁} ((U Uᵀ)ᴴ ⊗ 1)` and applies `PosSemidef.mul_mul_conjTranspose_same`, which preserves positive semidefiniteness under conjugation by any matrix — no invertibility or unitarity is used.

## Changes

- Blueprint (`blueprint/src/chapter/ch05_schwarz.tex`): "Let $U$ be a unitary on the first factor." → "Let $U$ be any matrix on the first factor." The displayed formula and the proof block were already correct and are unchanged.
- Docstring (`TNLean/Channel/PartialTranspose.lean`): "a unitary `U` on the first factor" → "any matrix `U` on the first factor".

The `\lean{Matrix.isPPT_basis_change}` and `\leanok` tags are untouched and remain valid (the Lean statement is unchanged; only the prose hypothesis description was over-restricted). The blueprint now faithfully describes the theorem that is actually proved.

This is a prose/comment-only change with no compilation impact. The reader-facing prose check passes.

Closes LionSR/QICLean#175

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX prose only; no executable Lean or proof changes.
> 
> **Overview**
> **Documentation-only fix** for `Matrix.isPPT_basis_change`: the Lean statement already allows an arbitrary first-factor matrix `U`, but the blueprint theorem and Lean docstring incorrectly required `U` to be unitary.
> 
> The blueprint (`thm:is_ppt_basis_change` in `ch05_schwarz.tex`) now says “any matrix on the first factor” instead of “a unitary.” The docstring on `isPPT_basis_change` in `PartialTranspose.lean` is updated the same way. **No Lean types, proofs, or formulas change**—only prose so the written hypothesis matches the proof (conjugation preserves positive semidefiniteness for general `U`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf6ea0b296da0e638923f03c562be6087dde2af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->