### PR TITLE
feat(blueprint): add reindexing invariance entry for quantum relative entropy

### DIFF
--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -399,6 +399,56 @@ finite-dimensional quantum systems.
     where the middle equality is trace cyclicity together with $U^\dagger U = 1$.
 \end{proof}
 
+\begin{lemma}[Logarithm is covariant under reindexing]
+    \label{lem:log_submatrix_equiv}
+    \lean{Matrix.log_submatrix_equiv}
+    \leanok
+    Let $A$ be a Hermitian matrix indexed by a finite set $J$, and let
+    $e : I \to J$ be a bijection from a finite set $I$. Writing $A_e$ for the
+    reindexed matrix on $I$ with entries $A_{e(i)\,e(j)}$,
+    \[
+        \log(A_e) = (\log A)_e.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    Reindexing both indices by a bijection is the conjugation $A_e = P^\dagger A P$
+    by the permutation matrix $P$ of $e$, which is a unitary star-algebra
+    isomorphism. The functional calculus commutes with such an isomorphism, so the
+    logarithm of the reindexed matrix is the reindexing of the logarithm.
+\end{proof}
+
+\begin{theorem}[Reindexing invariance of the quantum relative entropy]
+    \label{thm:relative_entropy_submatrix_equiv}
+    \lean{Matrix.quantumRelativeEntropy_submatrix_equiv}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    Let $\rho, \sigma$ be Hermitian matrices indexed by a finite set $J$, and let
+    $e : I \to J$ be a bijection from a finite set $I$. Writing $\rho_e, \sigma_e$
+    for the matrices on $I$ with entries $\rho_{e(i)\,e(j)}$ and
+    $\sigma_{e(i)\,e(j)}$,
+    \[
+        D(\rho_e \,\Vert\, \sigma_e) = D(\rho\Vert\sigma).
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{lem:log_submatrix_equiv}
+    Carry the two logarithms through the reindexing by
+    Lemma~\ref{lem:log_submatrix_equiv}, so that $\log\rho_e - \log\sigma_e$ is the
+    reindexing of $\log\rho - \log\sigma$. The relative entropy is the real trace of
+    $\rho$ against this difference, and reindexing both factors by the same
+    bijection leaves the trace of the product unchanged, hence
+    \[
+        D(\rho_e \,\Vert\, \sigma_e)
+            = \operatorname{Re}\operatorname{tr}\!\bigl(
+                \rho_e\,((\log\rho - \log\sigma)_e)\bigr)
+            = \operatorname{Re}\operatorname{tr}\!\bigl(
+                \rho\,(\log\rho - \log\sigma)\bigr)
+            = D(\rho\Vert\sigma).
+    \]
+\end{proof}
+
 \begin{lemma}[Logarithm of a tensor product of positive definite matrices]
     \label{lem:log_kronecker}
     \lean{Matrix.log_kronecker}


### PR DESCRIPTION
Adds a blueprint entry for the reindexing (relabeling) invariance of the quantum relative entropy in `blueprint/src/chapter/ch19_entropy.tex`.

## Declaration

`Matrix.quantumRelativeEntropy_submatrix_equiv`, proved on `main` in `TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean`:

```lean
theorem quantumRelativeEntropy_submatrix_equiv {ρ σ : Matrix m m ℂ}
    (hρ : ρ.IsHermitian) (hσ : σ.IsHermitian) (e : m ≃ n) :
    quantumRelativeEntropy (ρ.submatrix e.symm e.symm) (σ.submatrix e.symm e.symm)
      = quantumRelativeEntropy ρ σ
```

For Hermitian matrices `ρ, σ` and a bijection `e` of the index set, the relative entropy of the reindexed pair equals `D(ρ ‖ σ)`. The reindexing is expressed as `submatrix e.symm e.symm` (relabeling both indices by the bijection).

## What this adds

- A theorem block `thm:relative_entropy_submatrix_equiv` tagged `\lean{Matrix.quantumRelativeEntropy_submatrix_equiv}` with statement-level `\leanok` (proved on main), plus a short proof with `\leanok`.
- A supporting lemma block `lem:log_submatrix_equiv` tagged `\lean{Matrix.log_submatrix_equiv}` for the logarithm's covariance under reindexing, which the theorem's proof `\uses`.

This mirrors the existing von Neumann entropy reindexing entry (`thm:entropy_submatrix_equiv`, `\lean{vonNeumannEntropy_submatrix_equiv}`) for structure, and sits next to the unitary-invariance entry (`thm:relative_entropy_unitary_invariance`), which it parallels: a `log_*` covariance lemma feeding the entropy-invariance theorem.

## Validation

- Reader-facing prose check passes: no newly added violations.
- `leanblueprint checkdecls` requires the build-time artifact `blueprint/lean_decls` (gitignored, produced by the blueprint extraction over a built Lean project); it is not present in a fresh worktree and a full `lake build` was out of scope here. The two `\lean{}` tags name declarations that provably exist on `main` with those exact fully-qualified names, following the same `Matrix.`-prefixed convention as neighboring working tags in the chapter. CI runs the full build and `checkdecls` against the real `lean_decls`.

Closes #3511

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX blueprint entries with no runtime or proof changes in this PR.
> 
> **Overview**
> Adds blueprint documentation in `ch19_entropy.tex` for **reindexing invariance** of quantum relative entropy, placed after the unitary-invariance block and before the Kronecker/log tensor lemmas.
> 
> A new lemma **`lem:log_submatrix_equiv`** (`Matrix.log_submatrix_equiv`) states that the matrix logarithm commutes with relabeling both indices by a bijection (via permutation-matrix conjugation and functional calculus). A new theorem **`thm:relative_entropy_submatrix_equiv`** (`Matrix.quantumRelativeEntropy_submatrix_equiv`) proves \(D(\rho_e \Vert \sigma_e) = D(\rho \Vert \sigma)\), using that lemma and trace invariance under simultaneous reindexing. Both entries are tagged `\leanok` and mirror the existing von Neumann entropy reindexing entry and the unitary-invariance proof pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89dd75a97f9481a99d2a61bd144749876183d274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->