### PR TITLE
feat(blueprint): add entry for isPrimitive_cornerRestriction_of_isPrimitive

### DIFF
--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1507,6 +1507,7 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
 \end{definition}
 
 \begin{definition}[Restricted corner map]
+    \label{def:corner_restriction}
     \lean{cornerRestriction}
     \leanok
     The restriction of $E$ to an invariant corner $P\MN{D}P$.
@@ -1622,6 +1623,29 @@ Theorem~\ref{thm:peripheral_cyclic_group}.
     \leanok
     Appropriate powers of the channel preserve each sector corner.
 \end{lemma}
+
+\begin{lemma}[Primitivity passes to a fixed corner]
+    \label{lem:primitivity_corner_restriction}
+    \lean{isPrimitive_cornerRestriction_of_isPrimitive}
+    \leanok
+    \uses{def:corner_restriction}
+    Let $P\in\MN{D}$ be a nonzero idempotent and let $E$ be a linear map on
+    $\MN{D}$ that preserves the corner $P\MN{D}P$, is primitive, and fixes the
+    corner projection, $E(P)=P$. Then the restriction of $E$ to the corner
+    $P\MN{D}P$ is again primitive.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:corner_restriction}
+    The corner projection $P$ lies in its own corner and is fixed by the
+    restriction, so $1$ is a peripheral eigenvalue of the restriction. Conversely,
+    every eigenvalue of the restriction of unit modulus arises from a nonzero
+    corner element $X$ with $E(X)=\mu X$; viewing $X$ as an element of $\MN{D}$
+    exhibits $\mu$ as a peripheral eigenvalue of $E$. Primitivity of $E$ forces
+    $\mu=1$, so the peripheral spectrum of the restriction is exactly $\{1\}$ and
+    the restriction is primitive.
+\end{proof}
 
 \begin{lemma}[Irreducibility of restricted sector dynamics]
     \lean{isIrreducible_restriction_of_cyclic_decomp}


### PR DESCRIPTION
Adds the missing blueprint entry for the Lean theorem `isPrimitive_cornerRestriction_of_isPrimitive`, proved on main in `TNLean/Channel/Peripheral/CyclicDecomposition/Primitivity.lean`.

Signature:

```lean
theorem isPrimitive_cornerRestriction_of_isPrimitive
    {D : ℕ} (P : MatrixAlg D) (T : MatrixEnd D)
    (hInv : PreservesCorner P T) (hPidem : P * P = P) (hPfix : T P = P)
    (hPne : P ≠ 0) (hPrim : IsPrimitive T) :
    IsPrimitive (cornerRestriction P T hInv)
```

The new entry sits in `blueprint/src/chapter/ch07_spectral.tex` alongside the existing corner-restriction entries (`cornerRestriction`, `IsIrreducibleOnCorner`, `isPrimitive_restriction_of_cyclic_decomp`), styled like its neighbors: `\lean{}` plus statement-level `\leanok` (proved on main), and a short pure-mathematics proof sketch with `\leanok`. The statement matches the Lean hypotheses exactly: `P` a nonzero idempotent, `T` preserving the corner `P M_D P`, fixing the corner projection `T P = P`, and primitive; the restriction to the corner is then primitive.

A `\label{def:corner_restriction}` was added to the restricted-corner-map definition so the new lemma and its proof can wire `\uses{def:corner_restriction}`.

This is the reusable foundational step toward Wolf Theorem 6.6 (corner/sector dynamics for cyclic decompositions), consistent with the chapter's existing references.

Closes LionSR/QICLean#173

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint/LaTeX-only documentation aligned with an existing main-branch Lean proof; no runtime or application code changes.
> 
> **Overview**
> Documents the Lean theorem **`isPrimitive_cornerRestriction_of_isPrimitive`** in the spectral chapter’s cyclic-decomposition subsection, as a reusable step toward sector/corner dynamics (Wolf 6.6-style arguments).
> 
> The new **Lemma [Primitivity passes to a fixed corner]** states that if a primitive map preserves a nonzero idempotent corner and fixes the corner projection, then **`cornerRestriction`** on that corner is still primitive, with a short proof sketch (peripheral eigenvalue \(1\) on the corner; other unit-modulus eigenvalues lift to the ambient map).
> 
> Adds **`\label{def:corner_restriction}`** on the restricted-corner-map definition so the lemma and its proof can use **`\uses{def:corner_restriction}`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb132f6b4f822e25bf86f6899cea75e9e94cf469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->