### PR TITLE
doc(Channel/Schwarz): blueprint entry for relative-entropy reindexing invariance

### DIFF
--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -549,11 +549,17 @@ finite-dimensional quantum systems.
 \begin{proof}\leanok
     \uses{def:quantum_relative_entropy}
     Write $D(\rho \,\Vert\, \sigma) = \tr\bigl(\rho(\log\rho - \log\sigma)\bigr)$.
-    The matrix logarithm is covariant under reindexing, $\log(\rho_{e^{-1},e^{-1}})
-    = (\log\rho)_{e^{-1},e^{-1}}$, because reindexing is a star-algebra
-    isomorphism and so commutes with the continuous functional calculus; the trace
-    is invariant under reindexing. Hence every factor of the trace expression is
-    relabelled by $e$ without changing its value.
+    The matrix logarithm is covariant under reindexing,
+    $\log(\rho_{e^{-1},e^{-1}}) = (\log\rho)_{e^{-1},e^{-1}}$, because reindexing is a
+    star-algebra isomorphism and so commutes with the continuous functional calculus.
+    The same isomorphism preserves products and the trace,
+    \[
+        (\rho\,M)_{e^{-1},e^{-1}} = \rho_{e^{-1},e^{-1}}\,M_{e^{-1},e^{-1}},
+        \qquad
+        \tr\bigl(M_{e^{-1},e^{-1}}\bigr) = \tr(M).
+    \]
+    Taking $M = \log\rho - \log\sigma$ and applying these three identities gives
+    $D(\rho_{e^{-1},e^{-1}} \,\Vert\, \sigma_{e^{-1},e^{-1}}) = D(\rho \,\Vert\, \sigma)$.
 \end{proof}
 
 \begin{theorem}[Data-processing inequality under the partial trace]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -534,13 +534,35 @@ finite-dimensional quantum systems.
     (\mathbf 1_C / d_C)$.
 \end{proof}
 
+\begin{lemma}[Reindexing invariance of the quantum relative entropy]
+    \label{lem:relative_entropy_submatrix_equiv}
+    \lean{Matrix.quantumRelativeEntropy_submatrix_equiv}
+    \leanok
+    \uses{def:quantum_relative_entropy}
+    For Hermitian matrices $\rho, \sigma$ on a finite index set and any bijection
+    $e$ from that set onto another finite set,
+    \[
+        D(\rho_{e^{-1},e^{-1}} \,\Vert\, \sigma_{e^{-1},e^{-1}}) = D(\rho \,\Vert\, \sigma).
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:quantum_relative_entropy}
+    Write $D(\rho \,\Vert\, \sigma) = \tr\bigl(\rho(\log\rho - \log\sigma)\bigr)$.
+    The matrix logarithm is covariant under reindexing, $\log(\rho_{e^{-1},e^{-1}})
+    = (\log\rho)_{e^{-1},e^{-1}}$, because reindexing is a star-algebra
+    isomorphism and so commutes with the continuous functional calculus; the trace
+    is invariant under reindexing. Hence every factor of the trace expression is
+    relabelled by $e$ without changing its value.
+\end{proof}
+
 \begin{theorem}[Data-processing inequality under the partial trace]
     \label{thm:relative_entropy_data_processing}
     \lean{Matrix.quantumRelativeEntropy_partialTraceRight_le}
     \leanok
     \uses{def:quantum_relative_entropy, thm:relative_entropy_ancilla_additivity,
         thm:relative_entropy_unitary_invariance, thm:relative_entropy_joint_convexity,
-        lem:twirl_partial_trace}
+        lem:relative_entropy_submatrix_equiv, lem:twirl_partial_trace}
     For positive definite matrices $\rho, \sigma$ on a tensor product of a system
     factor and an ancilla factor,
     \[


### PR DESCRIPTION
Adds the missing blueprint entry for `Matrix.quantumRelativeEntropy_submatrix_equiv` (reindexing invariance of the quantum relative entropy), which is proved and used internally by the data-processing inequality but had no blueprint block — while its von Neumann analog `thm:entropy_submatrix_equiv` does.

- New `lem:relative_entropy_submatrix_equiv` in `ch19_entropy.tex`; statement matches the Lean signature (Hermitian `ρ, σ`; bijection `e : m ≃ n`).
- Proof block gives the mechanism: `D = tr(ρ(log ρ − log σ))`, log covariance under reindexing (reindexing is a star-algebra iso, commutes with the CFC), and trace invariance.
- Wired into `thm:relative_entropy_data_processing`'s `\uses`.

Rebased onto current `main`. (Originally also bundled LionSR/QICLean#175 and LionSR/QICLean#173; both were resolved by concurrent PRs — LionSR/QICLean#175 by LionSR/TNLean#3518, LionSR/QICLean#173 by the PR adding `lem:primitivity_corner_restriction` — so this PR is now scoped to LionSR/TNLean#3511 only.)

Closes LionSR/TNLean#3511.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX blueprint changes with no Lean or runtime behavior modifications.
> 
> **Overview**
> Adds the missing blueprint entry for **`lem:relative_entropy_submatrix_equiv`**, documenting that quantum relative entropy is unchanged when both Hermitian arguments are reindexed by the same bijection—aligned with Lean’s `Matrix.quantumRelativeEntropy_submatrix_equiv` and parallel to the existing von Neumann **`thm:entropy_submatrix_equiv`** entry.
> 
> The proof sketch records the trace-log definition, covariance of the matrix logarithm under reindexing (star-algebra isomorphism + functional calculus), and invariance of products and trace. **`thm:relative_entropy_data_processing`** now lists this lemma in `\uses` so the blueprint dependency graph matches how reindexing is used on the relative-entropy / data-processing route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c7ea9bf42be629569f34e6dc6d3c5fd2291db5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->