### PR TITLE
doc(Channel): correct isPPT_basis_change to any matrix U (#3504)

### DIFF
--- a/TNLean/Channel/PartialTranspose.lean
+++ b/TNLean/Channel/PartialTranspose.lean
@@ -303,13 +303,15 @@ theorem partialTransposeLeft_unitary_basis_change
   rw [partialTransposeLeft_basis_change U Uᴴ ρ, Matrix.conjTranspose_mul]
   rfl
 
-/-- **Basis independence of the PPT property (Wolf eq. (3.17)).** If a bipartite
-matrix `ρ` is PPT, then the partial transpose taken in the local basis changed by
-a unitary `U` on the first factor is again positive semidefinite.  By
-`partialTransposeLeft_unitary_basis_change` the new-basis partial transpose is the
-similarity transform `((U Uᵀ) ⊗ 1) ρ^{T₁} ((U Uᵀ)ᴴ ⊗ 1)`, and conjugation by a
-matrix preserves positive semidefiniteness, so the positivity of the partial
-transpose does not depend on the local basis. -/
+/-- **Conjugation invariance of the partial transpose (Wolf eq. (3.17)).** For
+*any* matrix `U` on the first factor (no invertibility or unitarity required), if a
+bipartite matrix `ρ` is PPT then
+`(U ⊗ 1) [((Uᴴ ⊗ 1) ρ (U ⊗ 1))^{T₁}] (Uᴴ ⊗ 1)` is positive semidefinite.  By
+`partialTransposeLeft_unitary_basis_change` this operator equals the conjugate
+`((U Uᵀ) ⊗ 1) ρ^{T₁} ((U Uᵀ)ᴴ ⊗ 1)`, and conjugation by a matrix preserves positive
+semidefiniteness.  Specializing to a unitary `U` gives the partial transpose taken
+in the basis changed by `U`, so the positivity of the partial transpose is
+independent of the local basis (Wolf's basis-independence statement). -/
 theorem isPPT_basis_change {U : Matrix (Fin d) (Fin d) ℂ}
     {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : IsPPT ρ) :
     ((U ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) *

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1761,7 +1761,8 @@ from the separable ones.
     is positive semidefinite; no invertibility or unitarity of $U$ is required.
     Specializing to a unitary $U$ this is the partial transpose taken in the basis
     changed by $U$, so the positivity of the partial transpose is independent of the
-    local basis, recovering Wolf's basis-independence statement (eq.~(3.17)).
+    local basis, recovering Wolf's basis-independence statement
+    \cite[Equation~(3.17)]{Wolf2012Quantum}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1747,20 +1747,21 @@ from the separable ones.
     collecting the Kronecker factors gives the stated form.
 \end{proof}
 
-\begin{theorem}[Basis independence of the PPT property]
+\begin{theorem}[Conjugation invariance of the partial transpose]
     \label{thm:is_ppt_basis_change}
     \lean{Matrix.isPPT_basis_change}
     \leanok
     \uses{def:is_ppt, thm:partial_transpose_left_basis_change}
-    Let $U$ be a unitary on the first factor.  If $\rho$ has the PPT property then
-    the partial transpose taken in the basis changed by $U$,
+    Let $U$ be any matrix on the first factor.  If $\rho$ has the PPT property then
     \[
         \bigl(U\otimes\Id\bigr)
         \Bigl[\bigl((U^\dagger\otimes\Id)\,\rho\,(U\otimes\Id)\bigr)^{T_1}\Bigr]
-        \bigl(U^\dagger\otimes\Id\bigr),
+        \bigl(U^\dagger\otimes\Id\bigr)
     \]
-    is again positive semidefinite.  The positivity of the partial transpose is
-    therefore independent of the local basis.
+    is positive semidefinite; no invertibility or unitarity of $U$ is required.
+    Specializing to a unitary $U$ this is the partial transpose taken in the basis
+    changed by $U$, so the positivity of the partial transpose is independent of the
+    local basis, recovering Wolf's basis-independence statement (eq.~(3.17)).
 \end{theorem}
 
 \begin{proof}


### PR DESCRIPTION
Closes LionSR/QICLean#175.

## Problem

`Matrix.isPPT_basis_change` and its proof (`PosSemidef.mul_mul_conjTranspose_same` with $M=(U U^{\mathsf T})\otimes\mathbf 1$) use **no** invertibility or unitarity of $U$ — the result holds for any matrix $U$. But the blueprint entry `thm:is_ppt_basis_change` and the Lean docstring both described $U$ as "a unitary", stating a strictly weaker proposition than what is formalized (a reader would conclude it applies only to unitaries).

## Fix (docs only, no proof changes)

- **Blueprint** `ch05_schwarz.tex` (`thm:is_ppt_basis_change`): restated for any matrix $U$ as conjugation invariance of the partial transpose, retitled accordingly, with a remark that specializing to a unitary $U$ recovers Wolf's basis-independence statement (eq. (3.17)). The statement now matches the `Fin d`-matrix Lean signature, so the `\leanok` tag is valid.
- **Lean docstring** `PartialTranspose.lean` (`isPPT_basis_change`): restated for any matrix $U$, noting no invertibility/unitarity is used and that the unitary case is Wolf's basis independence.

## Verification

- No Lean proof changes; the existing proof is already general.
- Reader-facing prose check and blueprint–Lean sync pass; no `sorry`/`axiom`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX prose only; no changes to proofs, definitions, or executable code.
> 
> **Overview**
> **Documentation-only** fix for `Matrix.isPPT_basis_change` and blueprint `thm:is_ppt_basis_change`: the formalization already holds for **any** `U` on the first factor (via conjugation of `ρ^{T₁}` by `(U Uᵀ) ⊗ 1`), but the Lean docstring and blueprint still called `U` a unitary and framed the result only as basis independence.
> 
> The Lean docstring is retitled to **conjugation invariance of the partial transpose**, explicitly drops invertibility/unitarity, and notes that a unitary `U` recovers Wolf’s basis-independence (eq. (3.17)). The blueprint theorem is retitled and restated the same way, with a citation to Wolf for the unitary specialization. **No proof or statement changes** in Lean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa2c9544c0dd617fadc535f703a1030c461db95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->