### PR TITLE
doc: faithfulness-labelling clean-ups from the 1708.00029 audit (periodic route + Gram Lem1)

### DIFF
--- a/TNLean/Algebra/GramMatrixLI.lean
+++ b/TNLean/Algebra/GramMatrixLI.lean
@@ -47,13 +47,20 @@ theorem eventually_linearIndependent_of_gram_tendsto_nondegenerate
     (Matrix.det_gram_ne_zero_iff_linearIndependent (𝕜 := ℂ) (v := fun i => v i N)).mp hN
 
 /--
-**Lem1 (arXiv:1606.00608 / arXiv:1708.00029)**: eventual linear independence from
-Gram-matrix convergence to the identity.
+**Convergence form of the eventual-independence criterion**, the limit form in
+which Lemma `Lem1` of arXiv:1606.00608 / arXiv:1708.00029 is applied: eventual
+linear independence from Gram-matrix convergence to the identity.
 
 Special case of `eventually_linearIndependent_of_gram_tendsto_nondegenerate`
 where the limit matrix is the identity. For a finite family of vectors
 `v i N` in a complex inner product space, if `⟪v i N, v j N⟫_ℂ → δ_{ij}`,
 then for `N` large enough the vectors are linearly independent.
+
+The source `Lem1` (arXiv:1708.00029, `Lem1`/`Lem1t`) is the uniform-`ε` statement:
+given `g`, a single `ε > 0` makes any `g` vectors with `|⟪wᵢ, wⱼ⟫| ≤ ε` (`i ≠ j`)
+and `|⟪wᵢ, wᵢ⟫| ≥ 1 − ε` linearly independent for every `m ≥ g`. This declaration
+is the convergence corollary in which that lemma is used, not the uniform-`ε`
+statement itself.
 -/
 theorem eventually_linearIndependent_of_gram_tendsto_id
     {ι : Type*} [Finite ι] [DecidableEq ι]

--- a/TNLean/Algebra/GramMatrixLI.lean
+++ b/TNLean/Algebra/GramMatrixLI.lean
@@ -48,7 +48,7 @@ theorem eventually_linearIndependent_of_gram_tendsto_nondegenerate
 
 /--
 **Convergence form of the eventual-independence criterion**, the limit form in
-which Lemma `Lem1` of arXiv:1606.00608 / arXiv:1708.00029 is applied: eventual
+which Lemma Lem1 of arXiv:1606.00608 / arXiv:1708.00029 is applied: eventual
 linear independence from Gram-matrix convergence to the identity.
 
 Special case of `eventually_linearIndependent_of_gram_tendsto_nondegenerate`
@@ -56,10 +56,10 @@ where the limit matrix is the identity. For a finite family of vectors
 `v i N` in a complex inner product space, if `⟪v i N, v j N⟫_ℂ → δ_{ij}`,
 then for `N` large enough the vectors are linearly independent.
 
-The source `Lem1` (arXiv:1708.00029, `Lem1`/`Lem1t`) is the uniform-`ε` statement:
-given `g`, a single `ε > 0` makes any `g` vectors with `|⟪wᵢ, wⱼ⟫| ≤ ε` (`i ≠ j`)
-and `|⟪wᵢ, wᵢ⟫| ≥ 1 − ε` linearly independent for every `m ≥ g`. This declaration
-is the convergence corollary in which that lemma is used, not the uniform-`ε`
+The source Lem1 (arXiv:1708.00029, labels Lem1/Lem1t) is the uniform-ε statement:
+given g, a single ε > 0 makes any g vectors with |⟪wᵢ, wⱼ⟫| ≤ ε (for i ≠ j)
+and |⟪wᵢ, wᵢ⟫| ≥ 1 − ε linearly independent for every m ≥ g. This declaration
+is the convergence corollary in which that lemma is used, not the uniform-ε
 statement itself.
 -/
 theorem eventually_linearIndependent_of_gram_tendsto_id

--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -44,7 +44,9 @@ private noncomputable def glConjEquiv (X : GL (Fin D) ℂ) :
 If two periodic tensors (same bond dimension) are gauge-phase equivalent,
 they must have the same period.
 
-arXiv:0909.5347, via eigenvalue uniqueness (Wolf Theorem 6.3). -/
+arXiv:0909.5347, via eigenvalue uniqueness (Wolf Theorem 6.3). This is the
+load-bearing step of the different-period decay route substitution documented in
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
 private theorem period_eq_of_gaugePhaseEquiv_of_isPeriodic
     [NeZero D] {A B : MPSTensor d D}
     {m_a m_b : ℕ} (hA : IsPeriodic m_a A) (hB : IsPeriodic m_b B)
@@ -103,9 +105,10 @@ Lemma bdcf, the blocks P_u A^{(p)} and Q_v B^{(p)} are non-repeated normal
 tensors, so that applying the one-site translation operator to Q_v B^{(p)}
 versus Q_{v+1} B^{(p)} yields a contradiction unless the overlap vanishes.
 
-**Different-period decay via the peripheral spectrum:** the Lean
-proof realizes the *same* obstruction through the peripheral-spectrum form rather
-than the paper's lcm-blocking + translation argument. If D₁ = D₂ and
+**Local fix (route substitution, different-period decay via the peripheral
+spectrum):** the Lean proof realizes the *same* obstruction through the
+peripheral-spectrum form rather than the paper's lcm-blocking + translation
+argument. If D₁ = D₂ and
 B i = ζ X (A i) X⁻¹, then
 𝓔_B(Y) = ζ · (conj ζ) · X 𝓔_A(X⁻¹ Y X⁻ᴴ) Xᴴ. Eigenvalue uniqueness for an irreducible CP
 map (Wolf, *Quantum Channels & Operations*, Thm 6.3) forces |ζ| = 1, so the

--- a/TNLean/MPS/Periodic/Overlap/Case1.lean
+++ b/TNLean/MPS/Periodic/Overlap/Case1.lean
@@ -45,8 +45,9 @@ If two periodic tensors (same bond dimension) are gauge-phase equivalent,
 they must have the same period.
 
 arXiv:0909.5347, via eigenvalue uniqueness (Wolf Theorem 6.3). This is the
-load-bearing step of the different-period decay route substitution documented in
-`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`. -/
+load-bearing step of the substitute proof route for different-period decay — the
+peripheral spectrum in place of the paper's lcm-blocking and one-site translation
+argument — documented in docs/paper-gaps/1708_periodic_overlap_route_alignment.tex. -/
 private theorem period_eq_of_gaugePhaseEquiv_of_isPeriodic
     [NeZero D] {A B : MPSTensor d D}
     {m_a m_b : ℕ} (hA : IsPeriodic m_a A) (hB : IsPeriodic m_b B)


### PR DESCRIPTION
Two docstring-only faithfulness clean-ups surfaced by an audit of every Lean module citing arXiv:1708.00029 against the local source `Papers/1708.00029/main.tex`. The audit otherwise found the development faithful (real labels, no invented routes lacking markers).

## 1. `MPS/Periodic/Overlap/Case1.lean` — canonical marker keyword
The Case1 different-period overlap decay proves the paper's result via the **peripheral-spectrum** form instead of the source's lcm-blocking + one-site translation argument (Appendix A, lines 917–950). The route substitution is correct and was already documented with a paper-gap reference, but used a bespoke heading, so the standard marker grep (`Local fix` / `Scope restriction` / `Unfaithful`) did not surface it.
- `periodicOverlap_tendsto_zero_of_ne_period`: prefix with the canonical `**Local fix (route substitution, ...):**` keyword (descriptive text + paper-gap reference unchanged).
- `period_eq_of_gaugePhaseEquiv_of_isPeriodic` (load-bearing helper): add the paper-gap cross-reference.

## 2. `Algebra/GramMatrixLI.lean` — correct `Lem1` labelling
`eventually_linearIndependent_of_gram_tendsto_id` was labelled as the paper's `Lem1`, but `Lem1`/`Lem1t` (main.tex:511–518) is the **uniform-ε** statement (a single ε forces independence for all m ≥ g), whereas the Lean states the **convergence corollary** (Gram → identity ⟹ eventually LI). Relabelled as the convergence form used to apply `Lem1`, with `Lem1`'s actual statement spelled out.

Docstring/comment-only; no proof, statement, or hypothesis change. Refs #873.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no executable or proof impact.
> 
> **Overview**
> Docstring-only updates from an arXiv:1708.00029 faithfulness audit; **no theorem statements, proofs, or hypotheses change.**
> 
> In **`GramMatrixLI.lean`**, `eventually_linearIndependent_of_gram_tendsto_id` is relabelled as the **convergence corollary** used to apply paper **Lem1**, with Lem1’s actual **uniform-ε** formulation spelled out so it is not mistaken for the lemma itself.
> 
> In **`MPS/Periodic/Overlap/Case1.lean`**, the peripheral-spectrum substitute for Appendix A different-period decay is tagged with the canonical **`Local fix (route substitution, …)`** marker on `periodicOverlap_tendsto_zero_of_ne_period`, and `period_eq_of_gaugePhaseEquiv_of_isPeriodic` notes its role in that route plus the existing paper-gap doc reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d94dabb7e4044efbdc2347326fc3975ae5c1438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->