### PR TITLE
feat(Channel): Wolf Prop 3.4 only-if — n-positive maps detect Schmidt number (#3399)

### DIFF
--- a/TNLean/Channel/SchmidtNumber.lean
+++ b/TNLean/Channel/SchmidtNumber.lean
@@ -64,8 +64,15 @@ Wolf eq. (3.18) with its Schmidt-number premise.
   addition and monotonicity in the bound.
 * `Matrix.hasSchmidtNumberLE_one_iff_isSeparable`: **Schmidt number one is exactly
   separability** (Wolf §3.2).
-* `Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE`: the **pure-state step** —
-  for ψ of Schmidt rank at most `n` (with `1 ≤ n < D`), `(T_n ⊗ id)(|ψ⟩⟨ψ|) ≥ 0`.
+* `Matrix.tensorMapId_posSemidef_of_hasSchmidtRankLE`: the **pure-state step of Wolf
+  Prop 3.4 (only if)** — for ψ of Schmidt rank at most `n` and any `n`-positive map
+  `T`, `(T ⊗ id)(|ψ⟩⟨ψ|) ≥ 0`.
+* `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef`: **Wolf Prop 3.4 (only if)** — a
+  state of Schmidt number at most `n` has `(T ⊗ id)(ρ) ≥ 0` for every `n`-positive
+  map `T`.
+* `Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE`: the **pure-state step** at
+  `T = T_n` — for ψ of Schmidt rank at most `n` (with `1 ≤ n < D`),
+  `(T_n ⊗ id)(|ψ⟩⟨ψ|) ≥ 0`.
 * `Matrix.HasSchmidtNumberLE.tensorMapId_tEta_posSemidef`: **step 1 of Wolf
   eq. (3.18)** — a state of Schmidt number at most `n` has `(T_n ⊗ id)(ρ) ≥ 0`.
 * `Matrix.reductionCriterion_left_of_hasSchmidtNumberLE` and
@@ -282,6 +289,69 @@ theorem rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE_rank {k : ℕ}
       _ = X.rank := Matrix.rank_conjTranspose X
   simpa [HasSchmidtRankLE, schmidtRank] using hrank
 
+/-- **Positive maps and entanglement, only-if direction, pure-state step**
+(Wolf §3.2, Prop 3.4).  For a pure state `|ψ⟩⟨ψ|` with ψ of Schmidt rank at most `n`
+and any `n`-positive map `T`, the ampliation `(T ⊗ id)(|ψ⟩⟨ψ|)` is positive
+semidefinite.
+
+Writing ψ through the maximally entangled vector as a square right-factor matrix `X`
+of rank equal to the Schmidt rank of ψ, the ampliation is the right-factor Choi
+compression of `T` by `X`.  Its quadratic form on any vector is the Choi quadratic
+form of `T` on a vector of Schmidt rank at most the rank of `X`, hence at most `n`;
+the `n`-positivity of `T` makes that form nonnegative.
+
+**Scope restriction (square system d = d' = D):** both tensor factors are fixed to a
+common dimension `D`, because the pure state is parametrized through the square
+maximally entangled vector (`ChoiJamiolkowski.exists_squareCompression_of_vector`).
+Wolf states the criterion for a general bipartite system `ℂ^d ⊗ ℂ^{d'}`; the
+non-square case is documented in
+`docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
+theorem tensorMapId_posSemidef_of_hasSchmidtRankLE [NeZero D] {n : ℕ}
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hTpos : IsNPositiveMap n T) {ψ : Fin D × Fin D → ℂ} (hψ : HasSchmidtRankLE n ψ) :
+    (tensorMapId T (vecMulVec ψ (star ψ))).PosSemidef := by
+  classical
+  -- Express ψ as a square compression of the maximally entangled vector.
+  obtain ⟨X, hXvec, hXrank⟩ :=
+    ChoiJamiolkowski.exists_squareCompression_of_vector (D := D) ψ
+  have hXrank_le : X.rank ≤ n := by rw [hXrank]; exact hψ
+  -- The ampliation of the pure state is the right-factor Choi compression.
+  have hcomp :
+      tensorMapId T (vecMulVec ψ (star ψ)) = ChoiJamiolkowski.rightCompression T X := by
+    rw [tensorMapId_eq_nPositiveAmpliation, ← hXvec,
+      ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression]
+  rw [hcomp]
+  -- Positivity via the Choi quadratic form on Schmidt-rank-≤n vectors.
+  refine posSemidef_of_dotProduct_mulVec_nonneg_complex ?_
+  intro η
+  rw [ChoiJamiolkowski.rightCompression_quadraticForm_eq_choiMatrix_quadraticForm]
+  have hrank :
+      HasSchmidtRankLE n ((ChoiJamiolkowski.rightTensorMatrix X)ᴴ *ᵥ η) :=
+    (rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE_rank X η).mono hXrank_le
+  exact
+    ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg.mp
+      hTpos _ hrank
+
+/-- **Positive maps and entanglement, only-if direction** (Wolf §3.2, Prop 3.4).  A
+bipartite state of Schmidt number at most `n` satisfies `(T ⊗ id)(ρ) ≥ 0` for every
+`n`-positive map `T`.
+
+The state is a finite sum of pure-state projectors of Schmidt rank at most `n`; the
+ampliation is linear, the pure-state step makes each summand positive semidefinite,
+and a finite sum of positive semidefinite matrices is positive semidefinite.
+
+**Scope restriction (square system d = d' = D):** inherited from the pure-state step;
+see `docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
+theorem HasSchmidtNumberLE.tensorMapId_posSemidef [NeZero D] {n : ℕ}
+    {T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ}
+    (hTpos : IsNPositiveMap n T)
+    {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
+    (tensorMapId T ρ).PosSemidef := by
+  obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
+  rw [tensorMapId_sum]
+  exact posSemidef_sum Finset.univ fun i _ =>
+    tensorMapId_posSemidef_of_hasSchmidtRankLE hTpos (hψ i)
+
 /-- **The pure-state step of the reduction criterion (Wolf eq. (3.18), step 1).**
 For a pure state `|ψ⟩⟨ψ|` with ψ of Schmidt rank at most `n` (and `1 ≤ n < D`),
 the ampliation `(T_n ⊗ id)(|ψ⟩⟨ψ|)` is positive semidefinite.
@@ -305,32 +375,10 @@ non-square case is documented in
 `docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. -/
 theorem tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE [NeZero D] {n : ℕ}
     (hn1 : 1 ≤ n) (hnD : n < D) {ψ : Fin D × Fin D → ℂ} (hψ : HasSchmidtRankLE n ψ) :
-    (tensorMapId (tEta D (n : ℝ)) (vecMulVec ψ (star ψ))).PosSemidef := by
-  classical
-  set T : Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ := tEta D (n : ℝ) with hT
-  -- `T_n` is `n`-positive (Wolf eq. (3.11)).
-  have hTpos : IsNPositiveMap n T :=
-    (isNPositiveMap_tEta_iff (by positivity) hn1 hnD).mpr (le_refl _)
-  -- Express ψ as a square compression of the maximally entangled vector.
-  obtain ⟨X, hXvec, hXrank⟩ :=
-    ChoiJamiolkowski.exists_squareCompression_of_vector (D := D) ψ
-  have hXrank_le : X.rank ≤ n := by rw [hXrank]; exact hψ
-  -- The ampliation of the pure state is the right-factor Choi compression.
-  have hcomp :
-      tensorMapId T (vecMulVec ψ (star ψ)) = ChoiJamiolkowski.rightCompression T X := by
-    rw [tensorMapId_eq_nPositiveAmpliation, ← hXvec,
-      ChoiJamiolkowski.nPositiveAmpliation_rankOne_eq_rightCompression]
-  rw [hcomp]
-  -- Positivity via the Choi quadratic form on Schmidt-rank-≤n vectors.
-  refine posSemidef_of_dotProduct_mulVec_nonneg_complex ?_
-  intro η
-  rw [ChoiJamiolkowski.rightCompression_quadraticForm_eq_choiMatrix_quadraticForm]
-  have hrank :
-      HasSchmidtRankLE n ((ChoiJamiolkowski.rightTensorMatrix X)ᴴ *ᵥ η) :=
-    (rightTensorMatrix_conjTranspose_mulVec_hasSchmidtRankLE_rank X η).mono hXrank_le
-  exact
-    ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg.mp
-      hTpos _ hrank
+    (tensorMapId (tEta D (n : ℝ)) (vecMulVec ψ (star ψ))).PosSemidef :=
+  -- `T_n` is `n`-positive (Wolf eq. (3.11)); the general only-if step applies.
+  tensorMapId_posSemidef_of_hasSchmidtRankLE
+    ((isNPositiveMap_tEta_iff (by positivity) hn1 hnD).mpr (le_refl _)) hψ
 
 /-- **Step 1 of Wolf's reduction criterion (eq. (3.18)).**  A bipartite state of
 Schmidt number at most `n` (with `1 ≤ n < D`) has `(T_n ⊗ id)(ρ) ≥ 0`.
@@ -345,11 +393,10 @@ pure-state step; see `docs/paper-gaps/wolf_t_eta_top_index_scope.tex` and
 theorem HasSchmidtNumberLE.tensorMapId_tEta_posSemidef [NeZero D] {n : ℕ}
     (hn1 : 1 ≤ n) (hnD : n < D)
     {ρ : Matrix (Fin D × Fin D) (Fin D × Fin D) ℂ} (hρ : HasSchmidtNumberLE n ρ) :
-    (tensorMapId (tEta D (n : ℝ)) ρ).PosSemidef := by
-  obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
-  rw [tensorMapId_sum]
-  exact posSemidef_sum Finset.univ fun i _ =>
-    tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE hn1 hnD (hψ i)
+    (tensorMapId (tEta D (n : ℝ)) ρ).PosSemidef :=
+  -- `T_n` is `n`-positive (Wolf eq. (3.11)); the general only-if direction applies.
+  hρ.tensorMapId_posSemidef
+    ((isNPositiveMap_tEta_iff (by positivity) hn1 hnD).mpr (le_refl _))
 
 /-! ## The full reduction criterion (Wolf eq. (3.18)) -/
 

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -2064,15 +2064,43 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     nonnegative, so the compression is positive semidefinite.
 \end{proof}
 
+\begin{theorem}[Pure-state step for a general positive map]
+    \label{thm:tensor_map_id_posSemidef_pure}
+    \lean{Matrix.tensorMapId_posSemidef_of_hasSchmidtRankLE}
+    \leanok
+    \uses{def:schmidt_rank, def:tensor_map_id, def:k_positive_map,
+        def:choi_right_compression, thm:square_schmidt_rank_exact_parametrization,
+        lem:rank_one_ampliation_choi_compression,
+        thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
+    For a pure state $\ket{\psi}\bra{\psi}$ on the square bipartite system
+    $\MN{D}\otimes\MN{D}$ with $\operatorname{SR}(\psi)\le n$ and any $n$-positive map
+    $T$, applying $T$ to the first factor keeps the result positive semidefinite:
+    \[
+        (T\otimes\id)(\ket{\psi}\bra{\psi})\ge 0.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Write $\psi$ through the maximally entangled vector as $\psi=\psi_X$ for a square
+    matrix $X$ on the right factor with
+    $\operatorname{rank}(X)=\operatorname{SR}(\psi)\le n$.  Then
+    $(T\otimes\id)(\ket{\psi}\bra{\psi})$ is the right-factor Choi compression of $T$
+    by $X$, and its quadratic form on a vector $\eta$ equals the Choi quadratic form
+    $C_T$ of $T$ evaluated on $R_X^\dagger\eta$, a vector of Schmidt rank at most
+    $\operatorname{rank}(X)\le n$.  Because $T$ is $n$-positive,
+    \[
+        \langle R_X^\dagger\eta,\, C_T\, R_X^\dagger\eta\rangle\ge 0,
+    \]
+    so the compression is positive semidefinite.
+\end{proof}
+
 \begin{theorem}[Positive maps and entanglement, only-if direction]
     \label{thm:has_schmidt_number_le_tensor_map_id}
     \lean{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef}
     \leanok
     \uses{def:has_schmidt_number_le, def:tensor_map_id, def:k_positive_map,
-        def:schmidt_rank, def:choi_right_compression, thm:tensor_map_id_sum,
-        thm:square_schmidt_rank_exact_parametrization,
-        lem:rank_one_ampliation_choi_compression,
-        thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
+        thm:tensor_map_id_sum, thm:tensor_map_id_posSemidef_pure}
     A bipartite state on the square system $\MN{D}\otimes\MN{D}$ of Schmidt number at
     most $n$ satisfies
     \[
@@ -2085,17 +2113,10 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
 
 \begin{proof}
     \leanok
-    The state is a finite sum of pure-state projectors of Schmidt rank at most $n$, so
-    it suffices to treat one such projector $\ket{\psi}\bra{\psi}$.  Write $\psi$
-    through the maximally entangled vector as $\psi=\psi_X$ for a square matrix $X$ on
-    the right factor with $\operatorname{rank}(X)=\operatorname{SR}(\psi)\le n$.  Then
-    $(T\otimes\id)(\ket{\psi}\bra{\psi})$ is the right-factor Choi compression of $T$
-    by $X$, and its quadratic form on any vector $\eta$ is the Choi quadratic form of
-    $T$ on $R_X^\dagger\eta$, whose Schmidt rank is at most
-    $\operatorname{rank}(X)\le n$.  The Schmidt-rank Choi criterion makes that form
-    nonnegative for an $n$-positive map, so each summand is positive semidefinite;
-    applying $T$ to the first factor is linear, hence distributes over the sum, and a
-    finite sum of positive semidefinite matrices is positive semidefinite.
+    The state is a finite sum of pure-state projectors of Schmidt rank at most $n$.
+    Applying $T$ to the first factor is linear, so it distributes over the sum; the
+    pure-state step makes each summand positive semidefinite, and a finite sum of
+    positive semidefinite matrices is positive semidefinite.
 \end{proof}
 
 \begin{theorem}[Reduction step from the Schmidt-number premise]

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -2064,6 +2064,40 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     nonnegative, so the compression is positive semidefinite.
 \end{proof}
 
+\begin{theorem}[Positive maps and entanglement, only-if direction]
+    \label{thm:has_schmidt_number_le_tensor_map_id}
+    \lean{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:tensor_map_id, def:k_positive_map,
+        def:schmidt_rank, def:choi_right_compression, thm:tensor_map_id_sum,
+        thm:square_schmidt_rank_exact_parametrization,
+        lem:rank_one_ampliation_choi_compression,
+        thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
+    A bipartite state on the square system $\MN{D}\otimes\MN{D}$ of Schmidt number at
+    most $n$ satisfies
+    \[
+        (T\otimes\id)(\rho)\ge 0
+    \]
+    for every $n$-positive map $T$.  This is the square case $d=d'=D$ of the only-if
+    direction of Wolf's Proposition~3.4 for a general bipartite system
+    $\MN{d}\otimes\MN{d'}$ \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The state is a finite sum of pure-state projectors of Schmidt rank at most $n$, so
+    it suffices to treat one such projector $\ket{\psi}\bra{\psi}$.  Write $\psi$
+    through the maximally entangled vector as $\psi=\psi_X$ for a square matrix $X$ on
+    the right factor with $\operatorname{rank}(X)=\operatorname{SR}(\psi)\le n$.  Then
+    $(T\otimes\id)(\ket{\psi}\bra{\psi})$ is the right-factor Choi compression of $T$
+    by $X$, and its quadratic form on any vector $\eta$ is the Choi quadratic form of
+    $T$ on $R_X^\dagger\eta$, whose Schmidt rank is at most
+    $\operatorname{rank}(X)\le n$.  The Schmidt-rank Choi criterion makes that form
+    nonnegative for an $n$-positive map, so each summand is positive semidefinite;
+    applying $T$ to the first factor is linear, hence distributes over the sum, and a
+    finite sum of positive semidefinite matrices is positive semidefinite.
+\end{proof}
+
 \begin{theorem}[Reduction step from the Schmidt-number premise]
     \label{thm:has_schmidt_number_le_tensor_map_id_t_eta}
     \lean{Matrix.HasSchmidtNumberLE.tensorMapId_tEta_posSemidef}


### PR DESCRIPTION
## Summary

Formalizes the **only-if direction of Wolf's Proposition 3.4** (*Quantum Channels
& Operations*, Ch. 3, §3.2, "Positive maps and entanglement"): a bipartite state of
Schmidt number at most `n` satisfies `(T ⊗ id)(ρ) ≥ 0` for **every** `n`-positive
map `T`.

This generalizes the merged result (#3507), which proved only the specialized
`T = T_n` (reduction-map) instance. There, `tEta`/`hn1`/`hnD` were used solely to
derive `IsNPositiveMap n T`; here `n`-positivity is taken as a hypothesis, so the
entire Choi-compression argument carries over verbatim.

## What was added (`TNLean/Channel/SchmidtNumber.lean`, namespace `Matrix`)

- `tensorMapId_posSemidef_of_hasSchmidtRankLE` — the **pure-state step** for an
  arbitrary `n`-positive map `T`: for `ψ` of Schmidt rank `≤ n`,
  `(T ⊗ id)(|ψ⟩⟨ψ|) ≥ 0`.
- `HasSchmidtNumberLE.tensorMapId_posSemidef` — the **summed (only-if) version**: a
  state of Schmidt number `≤ n` satisfies `(T ⊗ id)(ρ) ≥ 0` for every `n`-positive
  `T`.
- Refactored the two existing `..._tEta_...` theorems (signatures unchanged) to
  delegate to the new general lemmas, deriving `IsNPositiveMap n (T_n)` from
  `isNPositiveMap_tEta_iff`. Nothing downstream changes.

The new lemmas take `IsNPositiveMap n T` as a hypothesis, so the `1 ≤ n < D` bound
(specific to `T_n`'s `n`-positivity threshold) is **not** carried on them.

## Scope

**Square system `d = d' = D`.** The route through
`ChoiJamiolkowski.exists_squareCompression_of_vector` keeps both factors at `Fin D`.
Wolf states Prop 3.4 for a general bipartite `ℂ^d ⊗ ℂ^{d'}`; the non-square case is
documented in `docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex`. The
new lemmas carry the same `**Scope restriction (square system d = d' = D):**` marker
the existing `_tEta_` theorems carry.

## Blueprint

Added one entry (`thm:has_schmidt_number_le_tensor_map_id`) to
`blueprint/src/chapter/ch05_schwarz.tex` §3.2, tagged
`\lean{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef}` + `\leanok`, noting it is
the square case `d = d' = D` of Wolf's general Prop 3.4.

## Relation to LionSR/QICLean#23

This is a **partial** of LionSR/QICLean#23; it does **not** close it. Only the **only-if**
direction (general `n`-positive `T`) is formalized. The **if** direction
(`(T ⊗ id)(ρ) ≥ 0` for all `n`-positive `T` implies Schmidt number `≤ n`) needs the
Prop 3.3 separating-hyperplane machinery, which is out of scope here.

## Verification

- `lake build TNLean.Channel.SchmidtNumber` → Build completed successfully (3011 jobs).
- `rg "sorry|admit|axiom|native_decide|maxHeartbeats" TNLean/Channel/SchmidtNumber.lean` → empty.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` → no violations.
- `python3 scripts/blueprint_lean_sync.py --ci` → Blueprint and Lean code are in sync.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal lemmas in channel theory with no auth, security, or runtime impact; existing T_n API unchanged via thin wrappers.
> 
> **Overview**
> Formalizes the **only-if direction of Wolf Proposition 3.4**: on the square bipartite system, a state with Schmidt number at most `n` has `(T ⊗ id)(ρ) ≥ 0` for **every** `n`-positive map `T`, not only for the reduction map `T_n`.
> 
> **Lean (`SchmidtNumber.lean`):** Adds `tensorMapId_posSemidef_of_hasSchmidtRankLE` (pure-state step with `IsNPositiveMap n T` as hypothesis) and `HasSchmidtNumberLE.tensorMapId_posSemidef` (sum over pure terms). The existing `T_n` results keep the same statements but now call these lemmas after deriving `n`-positivity of `T_n` from `isNPositiveMap_tEta_iff`.
> 
> **Blueprint:** New theorems for the general pure-state step and the summed only-if result, with `\leanok` links to the new lemmas.
> 
> Scope stays **square** `d = d' = D`; the **if** direction (Prop 3.3 / separating hyperplanes) is out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2876d8d5be80d7d08e8eb210f9ba8dfe2c42c1ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


---

**Closes LionSR/QICLean#168** — its scope is the Schmidt-number definition (landed in LionSR/TNLean#3507) plus the n-positive-map detection criterion added here; together they fully formalize LionSR/QICLean#168. This remains a **partial of LionSR/QICLean#23**: the witness / Prop 3.3 separating-hyperplane direction is separate and not addressed here.
