### PR TITLE
doc(Channel/Schwarz): drop spurious \uses on thm:tensor_map_id_t_eta_posSemidef_pure

### DIFF
--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -2040,7 +2040,7 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     \lean{Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE}
     \leanok
     \uses{def:schmidt_rank, def:t_eta, def:tensor_map_id, thm:t_eta_threshold,
-        thm:reduction_map_eq_t_eta, thm:square_schmidt_rank_exact_parametrization,
+        thm:square_schmidt_rank_exact_parametrization,
         lem:rank_one_ampliation_choi_compression,
         thm:choi_right_compression_quadratic_form, thm:schmidt_rank_choi_test_iff}
     For a pure state $\ket{\psi}\bra{\psi}$ on the square bipartite system


### PR DESCRIPTION
Closes LionSR/QICLean#176.

The `\uses` of `thm:tensor_map_id_t_eta_posSemidef_pure` lists `thm:reduction_map_eq_t_eta`, but the Lean proof `Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE` sets `T := tEta D n` directly and gets `n`-positivity via `isNPositiveMap_tEta_iff` — it never invokes `reductionMap_eq_tEta`. The edge is a false dependency in the blueprint graph.

This fix was originally pushed to the LionSR/TNLean#3507 branch but landed after that PR merged, so it is re-applied here against current `main`. Blueprint-only, single-line `\uses` removal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to blueprint `\uses` metadata; no executable or proof code is modified.
> 
> **Overview**
> **Blueprint dependency fix only** — no Lean or runtime code changes.
> 
> Removes `thm:reduction_map_eq_t_eta` from the `\uses` list on **`thm:tensor_map_id_t_eta_posSemidef_pure`** (`Matrix.tensorMapId_tEta_posSemidef_of_hasSchmidtRankLE`) in `ch05_schwarz.tex`. That edge wrongly implied the pure-state reduction step depends on identifying `T_k` with `T_\eta` at integer parameter; the formal proof sets `T := tEta D n` and uses `isNPositiveMap_tEta_iff` plus Choi/Schmidt-rank machinery instead.
> 
> Aligns the blueprint graph with the actual proof and closes LionSR/QICLean#176.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 724a357cef3f3e9c7be1cb569a79616ca0cae381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->