### PR TITLE
feat(Channel): Wolf Lemma 3.1 at the top Schmidt-rank index n = D

### DIFF
--- a/TNLean/Channel/MaximalOverlap.lean
+++ b/TNLean/Channel/MaximalOverlap.lean
@@ -482,12 +482,12 @@ Schmidt rank at most n equals the Ky-Fan n-norm ‖ρ‖₍ₙ₎ -- the sum of 
 largest eigenvalues, which coincide with its singular values since ρ is positive
 semidefinite.
 
-**Scope (1 ≤ n < D):** this version covers `1 ≤ n < D`, where the bound is the
-Ky-Fan `n`-norm and the underlying maximum principle
-`Matrix.IsHermitian.kyFanNorm_eq_sup_trace` applies (rank-exactly-`k` projections
-with `k < D`).  The top index `n = D` — where the constraint is vacuous and the
-value is `‖ρ‖₍D₎ = tr ρ = 1` — is `maximalSchmidtOverlap_eq_kyFanNorm_top`; the two
-theorems together cover the full range `1 ≤ n ≤ D` of the source lemma. -/
+**Scope (1 ≤ n < D):** this version covers 1 ≤ n < D, where the bound is the
+Ky-Fan n-norm and the underlying maximum principle
+`Matrix.IsHermitian.kyFanNorm_eq_sup_trace` applies (rank-exactly-k projections
+with k < D).  The top index n = D — where the constraint is vacuous and the
+value is ‖ρ‖₍D₎ = tr ρ = 1 — is `maximalSchmidtOverlap_eq_kyFanNorm_top`; the two
+theorems together cover the full range 1 ≤ n ≤ D of the source lemma. -/
 theorem maximalSchmidtOverlap_eq_kyFanNorm (φ : m × n → ℂ)
     (hφ : star φ ⬝ᵥ φ = 1) {k : ℕ} (hk1 : 1 ≤ k) (hk : k < Fintype.card m) :
     IsGreatest {r : ℝ | ∃ ψ : m × n → ℂ, star ψ ⬝ᵥ ψ = 1 ∧
@@ -521,13 +521,13 @@ theorem maximalSchmidtOverlap_eq_kyFanNorm (φ : m × n → ℂ)
     · rw [hC, ← star_dotProduct_eq_trace_conjTranspose_mul]
 
 omit [DecidableEq n] in
-/-- **Wolf's Lemma 3.1 at the top index `n = D = card m`.**  At the largest
-Schmidt-rank index `k = D` the constraint `SR(ψ) ≤ D` is vacuous, the Ky-Fan
-`D`-norm of `ρ = C Cᴴ` collapses to its trace `tr ρ = ‖φ‖² = 1`, and the value
-`1` is attained at `ψ = φ` (with the upper bound supplied by Cauchy–Schwarz).
-Together with `maximalSchmidtOverlap_eq_kyFanNorm` (the case `1 ≤ n < D`) this
-covers the full range `1 ≤ n ≤ D` of Wolf eq. (3.5)
-(`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~119–128). -/
+/-- **Wolf's Lemma 3.1 at the top index n = D = card m.**  At the largest
+Schmidt-rank index the constraint SR(ψ) ≤ D is vacuous, the Ky-Fan D-norm of the
+reduced density ρ collapses to its trace tr ρ = ‖φ‖² = 1, and the value 1 is
+attained at ψ = φ (with the upper bound supplied by Cauchy–Schwarz).  Together
+with `maximalSchmidtOverlap_eq_kyFanNorm` (the case 1 ≤ n < D) this covers the
+full range 1 ≤ n ≤ D of Wolf eq. (3.5)
+(Notes/WolfNoteTexSource/ch03_positive_not_completely.tex, lines ~119–128). -/
 theorem maximalSchmidtOverlap_eq_kyFanNorm_top (φ : m × n → ℂ)
     (hφ : star φ ⬝ᵥ φ = 1) :
     IsGreatest {r : ℝ | ∃ ψ : m × n → ℂ, star ψ ⬝ᵥ ψ = 1 ∧

--- a/TNLean/Channel/MaximalOverlap.lean
+++ b/TNLean/Channel/MaximalOverlap.lean
@@ -482,12 +482,12 @@ Schmidt rank at most n equals the Ky-Fan n-norm ‖ρ‖₍ₙ₎ -- the sum of 
 largest eigenvalues, which coincide with its singular values since ρ is positive
 semidefinite.
 
-**Scope restriction (n < D):** the source allows n up to the dimension D
-of the first factor, where the bound reads ‖ρ‖₍D₎ = tr ρ = 1; this version
-covers 1 ≤ n < D.  The omitted top index n = D is documented in
-`docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex`; it is inherited from the
-underlying maximum principle `Matrix.IsHermitian.kyFanNorm_eq_sup_trace`, stated
-for rank-exactly-k orthogonal projections with k < D. -/
+**Scope (1 ≤ n < D):** this version covers `1 ≤ n < D`, where the bound is the
+Ky-Fan `n`-norm and the underlying maximum principle
+`Matrix.IsHermitian.kyFanNorm_eq_sup_trace` applies (rank-exactly-`k` projections
+with `k < D`).  The top index `n = D` — where the constraint is vacuous and the
+value is `‖ρ‖₍D₎ = tr ρ = 1` — is `maximalSchmidtOverlap_eq_kyFanNorm_top`; the two
+theorems together cover the full range `1 ≤ n ≤ D` of the source lemma. -/
 theorem maximalSchmidtOverlap_eq_kyFanNorm (φ : m × n → ℂ)
     (hφ : star φ ⬝ᵥ φ = 1) {k : ℕ} (hk1 : 1 ≤ k) (hk : k < Fintype.card m) :
     IsGreatest {r : ℝ | ∃ ψ : m × n → ℂ, star ψ ⬝ᵥ ψ = 1 ∧
@@ -519,5 +519,52 @@ theorem maximalSchmidtOverlap_eq_kyFanNorm (φ : m × n → ℂ)
     · rw [← star_dotProduct_self_eq_trace_conjTranspose_mul, hψnorm]
     · exact hψrank
     · rw [hC, ← star_dotProduct_eq_trace_conjTranspose_mul]
+
+omit [DecidableEq n] in
+/-- **Wolf's Lemma 3.1 at the top index `n = D = card m`.**  At the largest
+Schmidt-rank index `k = D` the constraint `SR(ψ) ≤ D` is vacuous, the Ky-Fan
+`D`-norm of `ρ = C Cᴴ` collapses to its trace `tr ρ = ‖φ‖² = 1`, and the value
+`1` is attained at `ψ = φ` (with the upper bound supplied by Cauchy–Schwarz).
+Together with `maximalSchmidtOverlap_eq_kyFanNorm` (the case `1 ≤ n < D`) this
+covers the full range `1 ≤ n ≤ D` of Wolf eq. (3.5)
+(`Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, lines ~119–128). -/
+theorem maximalSchmidtOverlap_eq_kyFanNorm_top (φ : m × n → ℂ)
+    (hφ : star φ ⬝ᵥ φ = 1) :
+    IsGreatest {r : ℝ | ∃ ψ : m × n → ℂ, star ψ ⬝ᵥ ψ = 1 ∧
+        HasSchmidtRankLE (Fintype.card m) ψ ∧ ‖star φ ⬝ᵥ ψ‖ ^ 2 = r}
+      ((Matrix.posSemidef_self_mul_conjTranspose (schmidtCoeffMatrix φ)).isHermitian.kyFanNorm
+        (Fintype.card m)) := by
+  set C := schmidtCoeffMatrix φ with hC
+  have htrace : (C * Cᴴ).trace = star φ ⬝ᵥ φ := by
+    rw [Matrix.trace_mul_comm, ← star_dotProduct_self_eq_trace_conjTranspose_mul]
+  have htarget :
+      (Matrix.posSemidef_self_mul_conjTranspose C).isHermitian.kyFanNorm (Fintype.card m) = 1 := by
+    rw [Matrix.IsHermitian.kyFanNorm_card_eq_trace_re, htrace, hφ, Complex.one_re]
+  rw [htarget]
+  -- Each unit vector maps to a unit Euclidean vector, so Cauchy–Schwarz bounds
+  -- the overlap by `1`.
+  have hinner : ∀ ψ : m × n → ℂ,
+      (inner (𝕜 := ℂ) (WithLp.toLp 2 φ) (WithLp.toLp 2 ψ : EuclideanSpace ℂ (m × n)) : ℂ)
+        = star φ ⬝ᵥ ψ := by
+    intro ψ; rw [EuclideanSpace.inner_eq_star_dotProduct]; exact dotProduct_comm _ _
+  have hunit : ∀ ψ : m × n → ℂ, star ψ ⬝ᵥ ψ = 1 →
+      ‖(WithLp.toLp 2 ψ : EuclideanSpace ℂ (m × n))‖ = 1 := by
+    intro ψ hψ
+    have h2 : ‖(WithLp.toLp 2 ψ : EuclideanSpace ℂ (m × n))‖ ^ 2 = 1 := by
+      rw [← @inner_self_eq_norm_sq ℂ]
+      have hii : (inner (𝕜 := ℂ) (WithLp.toLp 2 ψ) (WithLp.toLp 2 ψ : EuclideanSpace ℂ (m × n)) : ℂ)
+          = star ψ ⬝ᵥ ψ := by
+        rw [EuclideanSpace.inner_eq_star_dotProduct]; exact dotProduct_comm _ _
+      rw [hii, hψ]; simp
+    nlinarith [norm_nonneg (WithLp.toLp 2 ψ : EuclideanSpace ℂ (m × n)), h2]
+  refine ⟨⟨φ, hφ, schmidtRank_le_left φ, by rw [hφ, norm_one, one_pow]⟩, ?_⟩
+  rintro r ⟨ψ, hψnorm, _, rfl⟩
+  have hcs : ‖star φ ⬝ᵥ ψ‖ ≤ 1 := by
+    rw [← hinner ψ]
+    calc ‖(inner (𝕜 := ℂ) (WithLp.toLp 2 φ) (WithLp.toLp 2 ψ : EuclideanSpace ℂ (m × n)) : ℂ)‖
+        ≤ ‖(WithLp.toLp 2 φ : EuclideanSpace ℂ (m × n))‖ *
+            ‖(WithLp.toLp 2 ψ : EuclideanSpace ℂ (m × n))‖ := norm_inner_le_norm _ _
+      _ = 1 := by rw [hunit φ hφ, hunit ψ hψnorm, mul_one]
+  nlinarith [hcs, norm_nonneg (star φ ⬝ᵥ ψ)]
 
 end Matrix

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -255,9 +255,8 @@ maps.
     \]
     Because $\rho$ is positive semidefinite, this norm is the sum of its $n$
     largest eigenvalues, which coincide there with its singular values. This is
-    \cite[Lemma~3.1]{Wolf2012Quantum}, stated here for $n<D$; the top index
-    $n=D$, where the value is $\tr\rho=1$, lies outside the range of the
-    maximum principle in Theorem~\ref{thm:ky_fan_maximum_principle}.
+    \cite[Lemma~3.1]{Wolf2012Quantum} for $1\le n<D$; the top index $n=D$, where
+    the value is $\tr\rho=1$, is Theorem~\ref{thm:maximal_overlap_schmidt_rank_top}.
 \end{theorem}
 
 \begin{proof}
@@ -299,6 +298,32 @@ maps.
     so the bound is attained. (For a normalized $\phi$ with $1\le n$ one has
     $\|\rho\|_{(n)}\ge\|\rho\|_{(1)}>0$, since $\tr\rho=1$, which justifies the
     normalization.)
+\end{proof}
+
+\begin{theorem}[Maximal overlap at the top Schmidt rank]
+    \label{thm:maximal_overlap_schmidt_rank_top}
+    \lean{Matrix.maximalSchmidtOverlap_eq_kyFanNorm_top}
+    \leanok
+    \uses{def:schmidt_rank, def:ky_fan_norm, thm:maximal_overlap_schmidt_rank}
+    At the top index $n=D$ the Schmidt-rank constraint $\operatorname{SR}(\psi)\le D$
+    is vacuous, and the Ky-Fan $D$-norm of $\rho$ collapses to its trace. For a
+    normalized $\phi$ the identity of
+    Theorem~\ref{thm:maximal_overlap_schmidt_rank} then reads
+    \[
+        \max_{\|\psi\|=1} |\braket{\phi}{\psi}|^2 = \|\rho\|_{(D)} = \tr\rho = 1 ,
+    \]
+    attained at $\psi=\phi$. Together with
+    Theorem~\ref{thm:maximal_overlap_schmidt_rank} this covers the full range
+    $1\le n\le D$ of \cite[Lemma~3.1]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The Ky-Fan $D$-norm sums all eigenvalues of $\rho$, so
+    $\|\rho\|_{(D)}=\tr\rho=\|\phi\|^2=1$. The bound $1$ is attained at $\psi=\phi$,
+    whose Schmidt rank is at most $D$; and for any normalized $\psi$ the
+    Cauchy--Schwarz inequality gives
+    $|\braket{\phi}{\psi}|^2\le\|\phi\|^2\|\psi\|^2=1$.
 \end{proof}
 
 \begin{definition}[Reduced density of an eigenvector]

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -304,15 +304,14 @@ maps.
     \label{thm:maximal_overlap_schmidt_rank_top}
     \lean{Matrix.maximalSchmidtOverlap_eq_kyFanNorm_top}
     \leanok
-    \uses{def:schmidt_rank, def:ky_fan_norm, thm:maximal_overlap_schmidt_rank}
+    \uses{def:schmidt_rank, def:ky_fan_norm}
     At the top index $n=D$ the Schmidt-rank constraint $\operatorname{SR}(\psi)\le D$
-    is vacuous, and the Ky-Fan $D$-norm of $\rho$ collapses to its trace. For a
-    normalized $\phi$ the identity of
-    Theorem~\ref{thm:maximal_overlap_schmidt_rank} then reads
+    is vacuous, so the largest squared overlap is the Ky-Fan $D$-norm of $\rho$,
     \[
-        \max_{\|\psi\|=1} |\braket{\phi}{\psi}|^2 = \|\rho\|_{(D)} = \tr\rho = 1 ,
+        \max_{\|\psi\|=1} |\braket{\phi}{\psi}|^2 = \|\rho\|_{(D)} ,
     \]
-    attained at $\psi=\phi$. Together with
+    attained at $\psi=\phi$. The Ky-Fan $D$-norm sums all eigenvalues, so for a
+    normalized $\phi$ it collapses to $\|\rho\|_{(D)}=\tr\rho=1$. Together with
     Theorem~\ref{thm:maximal_overlap_schmidt_rank} this covers the full range
     $1\le n\le D$ of \cite[Lemma~3.1]{Wolf2012Quantum}.
 \end{theorem}

--- a/docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex
@@ -61,12 +61,14 @@ by feeding that case into the same transfer argument.
 
 \section{Classification}
 
-\emph{Scope restriction.} The formal theorem proves the source identity for
-Schmidt ranks $1\le n<D'$, a special case of the source's full range
-$1\le n\le D'$. The conclusion matches the source on that range; only the top
-index $n=D'$ is omitted, and there the supremum degenerates to the trivial value
-$\|\rho\|_{(D')}=\tr\rho=1$. No hypothesis foreign to the source is used, so the
-deviation is a scope restriction rather than an unfaithful theorem.
+\emph{Resolved.} The top index $n=D'$ is now formalized as the companion theorem
+\leanid{Matrix.maximalSchmidtOverlap_eq_kyFanNorm_top}: there the Schmidt-rank
+constraint is vacuous, the Ky-Fan $D'$-norm collapses to the trace
+$\|\rho\|_{(D')}=\tr\rho=1$, and the value is attained at $\psi=\phi$ with the
+upper bound supplied by Cauchy--Schwarz. Together with
+\leanid{Matrix.maximalSchmidtOverlap_eq_kyFanNorm} (the range $1\le n<D'$) this
+covers the full source range $1\le n\le D'$ of Wolf's Lemma~3.1, exactly as the
+elimination plan above anticipated.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Closes LionSR/QICLean#174.

Adds `Matrix.maximalSchmidtOverlap_eq_kyFanNorm_top`, the top-index `n = D = card m` case of Wolf's Lemma 3.1 (eq. (3.5)), completing the **full range `1 ≤ n ≤ D`** together with the existing `maximalSchmidtOverlap_eq_kyFanNorm` (which covers `1 ≤ n < D`).

## Proof
At `n = D`:
- the Schmidt-rank constraint `SR(ψ) ≤ D` is **vacuous** — `schmidtRank_le_left` gives `schmidtRank ψ ≤ card m` for every `ψ`;
- the **Ky-Fan `D`-norm collapses to the trace** — `IsHermitian.kyFanNorm_card_eq_trace_re`, and `tr(CCᴴ) = star φ ⬝ᵥ φ = 1`;
- the value `1` is **attained at `ψ = φ`**;
- the **upper bound** is Cauchy–Schwarz (`norm_inner_le_norm`) through the Euclidean embedding `EuclideanSpace.inner_eq_star_dotProduct`, with both vectors of unit norm.

No new axioms or `sorry` (verified locally with `lake env lean TNLean/Channel/MaximalOverlap.lean` — clean, no warnings).

## Blueprint / paper-gap
- `ch05_schwarz.tex`: companion entry `thm:maximal_overlap_schmidt_rank_top` (with `\lean`/`\leanok`); the main entry now points to it for the top index instead of declaring it out of range.
- `docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex`: reclassified from *Scope restriction* to **Resolved** — exactly the companion-lemma route its own elimination plan anticipated.
- `MaximalOverlap.lean`: the existing lemma's `**Scope restriction (n < D)**` marker is updated to a plain scope note, since the full range is now formalized across the two theorems.

Chose the **companion-theorem** option from the issue (rather than relaxing `hk` in place), keeping the existing `n < D` proof untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained formal proof and documentation updates; no changes to auth, APIs, or the existing `n < D` argument.
> 
> **Overview**
> Completes Wolf’s Lemma 3.1 for the previously omitted **top index** `n = D` by adding `Matrix.maximalSchmidtOverlap_eq_kyFanNorm_top`, alongside the existing `maximalSchmidtOverlap_eq_kyFanNorm` (`1 ≤ n < D`).
> 
> At `n = D` the Schmidt-rank bound is vacuous; the Ky-Fan `D`-norm equals **trace** (`kyFanNorm_card_eq_trace_re`), so the supremum is **1**, attained at `ψ = φ` and bounded above by Cauchy–Schwarz via the `EuclideanSpace` embedding. Docstrings on the main lemma now point to this companion for the full range `1 ≤ n ≤ D`.
> 
> The blueprint gains `thm:maximal_overlap_schmidt_rank_top` with `\lean` wiring; `docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex` is reclassified from scope restriction to **Resolved**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 051bd72adb3783071609278afa6dab98b08cf6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->