### PR TITLE
doc(Channel): blueprint entry for the differing-factors reduction step (#3521)

### DIFF
--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -683,6 +683,32 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     positive semidefinite matrices is positive semidefinite.
 \end{proof}
 
+\begin{theorem}[Only-if direction for differing bipartite factors]
+    \label{thm:has_schmidt_number_le_tensor_map_id_diff}
+    \lean{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef'}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:tensor_map_id, def:k_positive_map,
+        thm:has_schmidt_number_le_tensor_map_id}
+    Let the second factor satisfy $d'\le d$.  A bipartite state on
+    $\MN{d}\otimes\MN{d'}$ of Schmidt number at most $n$ satisfies
+    \[
+        (T\otimes\id)(\rho)\ge 0
+    \]
+    for every $n$-positive map $T$ on $\MN{d}$.  This lifts the square restriction of
+    Theorem~\ref{thm:has_schmidt_number_le_tensor_map_id} to a smaller second factor,
+    a partial step toward Wolf's general bipartite system
+    $\MN{d}\otimes\MN{d'}$ \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Pad the second factor of each pure summand from $d'$ to $d$ with zero columns;
+    this preserves the Schmidt-rank bound, so the padded state on the square system
+    $\MN{d}\otimes\MN{d}$ still has Schmidt number at most $n$.  The square result
+    makes the padded ampliation positive semidefinite, and the original ampliation is
+    its $d\times d'$ principal submatrix, hence positive semidefinite.
+\end{proof}
+
 \begin{theorem}[Reduction step from the Schmidt-number premise]
     \label{thm:has_schmidt_number_le_tensor_map_id_t_eta}
     \lean{Matrix.HasSchmidtNumberLE.tensorMapId_tEta_posSemidef}


### PR DESCRIPTION
Follow-up to LionSR/TNLean#3529 (which merged `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef'` Lean-only to avoid racing LionSR/TNLean#3526's chapter split).

Adds the blueprint entry `thm:has_schmidt_number_le_tensor_map_id_diff` to the new `ch25_positive_not_cp.tex` for that theorem: the only-if reduction step $(T\otimes\id)(\rho)\ge 0$ for a bipartite state on $M_d\otimes M_{d'}$ of Schmidt number $\le n$ with **$d'\le d$**, for every $n$-positive map $T$ on $M_d$.

- `\leanok` on statement and proof (the Lean theorem is merged, kernel-clean).
- The proof sketch is the padding-to-square reduction (pad second factor $d'\to d$ with zero columns, apply the square entry, restrict to the $d\times d'$ principal submatrix).
- States the $d'\le d$ scope and frames it as a partial step toward Wolf's general $M_d\otimes M_{d'}$ (Prop 3.4); the complementary $d'>d$ case remains tracked on LionSR/QICLean#177.

Reader-facing prose and blueprint–Lean sync checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX; no Lean or runtime behavior changes.
> 
> **Overview**
> Adds a blueprint theorem **`thm:has_schmidt_number_le_tensor_map_id_diff`** in `ch25_positive_not_cp.tex`, linked to existing Lean `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef'`.
> 
> The entry states the **only-if** direction for **$M_d \otimes M_{d'}$** with **$d' \le d$**: Schmidt number $\le n$ implies $(T \otimes \mathrm{id})(\rho) \ge 0$ for every $n$-positive $T$ on the first factor. The proof sketch is **padding** the second factor from $d'$ to $d$ with zero columns, applying the square theorem, then taking the **principal submatrix**; prose frames this as a partial step toward Wolf Prop. 3.4.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf1e59657ac4c40ba05ff57bb9419de18feeecd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->