### PR TITLE
doc(Channel): blueprint + gap note for the general bipartite forward step (#3521)

### DIFF
--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -683,30 +683,32 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     positive semidefinite matrices is positive semidefinite.
 \end{proof}
 
-\begin{theorem}[Only-if direction for differing bipartite factors]
-    \label{thm:has_schmidt_number_le_tensor_map_id_diff}
-    \lean{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef'}
+\begin{theorem}[Only-if direction for a general bipartite system]
+    \label{thm:has_schmidt_number_le_tensor_map_id_general}
+    \lean{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general}
     \leanok
     \uses{def:has_schmidt_number_le, def:tensor_map_id, def:k_positive_map,
         thm:has_schmidt_number_le_tensor_map_id}
-    Let the second factor satisfy $d'\le d$.  A bipartite state on
-    $\MN{d}\otimes\MN{d'}$ of Schmidt number at most $n$ satisfies
+    On a general bipartite system $\MN{d}\otimes\MN{d'}$, with no relation imposed
+    between the two factors, a state of Schmidt number at most $n$ satisfies
     \[
         (T\otimes\id)(\rho)\ge 0
     \]
-    for every $n$-positive map $T$ on $\MN{d}$.  This lifts the square restriction of
-    Theorem~\ref{thm:has_schmidt_number_le_tensor_map_id} to a smaller second factor,
-    a partial step toward Wolf's general bipartite system
-    $\MN{d}\otimes\MN{d'}$ \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}.
+    for every $n$-positive map $T$ on $\MN{d}$.  This is the only-if direction of
+    Wolf's Proposition~3.4, the first step of eq.~(3.18)
+    \cite[Chapter~3, Proposition~3.4]{Wolf2012Quantum}, with no restriction on the
+    bipartite dimensions.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    Pad the second factor of each pure summand from $d'$ to $d$ with zero columns;
-    this preserves the Schmidt-rank bound, so the padded state on the square system
-    $\MN{d}\otimes\MN{d}$ still has Schmidt number at most $n$.  The square result
-    makes the padded ampliation positive semidefinite, and the original ampliation is
-    its $d\times d'$ principal submatrix, hence positive semidefinite.
+    Pad the bipartite state to the square system $\MN{D}\otimes\MN{D}$ with
+    $D=\max(d,d')$ by zero rows and columns: when $d'\le d$ the second factor is padded
+    up to $d$; when $d\le d'$ the first factor is padded up to $d'$ and $T$ is extended
+    to a map on $\MN{d'}$ that preserves $n$-positivity.  Padding preserves the
+    Schmidt-number bound, the square result makes the padded ampliation positive
+    semidefinite, and the original ampliation is its principal submatrix, hence positive
+    semidefinite.
 \end{proof}
 
 \begin{theorem}[Reduction step from the Schmidt-number premise]

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -109,33 +109,40 @@ the map $T_n$ is $n$-positive for all $1\le n<D$.\footnote{Formal declaration:
     $T_\eta$ at $\eta=n$ by \leanid{Matrix.reductionMap_eq_tEta}.}
 
 The pure-state step writes $\psi$ through the maximally entangled vector as a
-\emph{square} right-factor matrix, so the formalized statements fix the two tensor
-factors to a common dimension $D$: they live on the square bipartite system
-$\mathbb{C}^D\otimes\mathbb{C}^D$ rather than on Wolf's general
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$. The restriction enters through the square
-parametrization of a bipartite vector by a maximally-entangled-vector compression,
-which is currently available only for equal-dimension factors. Eliminating it
-requires the rectangular form of that parametrization (a vector on
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$ written as a $d\times d'$ right-factor matrix);
-once that is formalized, the three headline statements generalize verbatim to
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$.
+\emph{square} right-factor matrix, so the $T_n$-specialised \emph{criterion} theorems
+still fix the two tensor factors to a common dimension $D$. The general bipartite
+\emph{forward step} itself, however, no longer carries that restriction: padding the
+bipartite state to the square system $\mathbb{C}^D\otimes\mathbb{C}^D$ with
+$D=\max(d,d')$ — padding the smaller factor by zero rows or columns and, when the
+first factor grows, extending the map by a corner sandwich that preserves
+$n$-positivity — reduces the general case to the square one. Thus
+$(T\otimes\operatorname{id})(\rho)\ge 0$ holds on a general
+$\mathbb{C}^d\otimes\mathbb{C}^{d'}$ for every $n$-positive map $T$, with no relation
+between the factors.\footnote{Formal declaration:
+    \leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general} in
+    \doclink{TNLean/Channel/SchmidtNumberFactors}, with the $n$-positivity-preserving
+    corner extension \leanid{Matrix.isNPositiveMap_cornerExtendMap}.}
 
 \section{Classification}
 
-\emph{Resolved on the square bipartite system $\mathbb{C}^D\otimes\mathbb{C}^D$},
-with two residual scope restrictions. The first, $1\le n<D$, is inherited from the
-$n$-positivity threshold of $T_\eta$, whose top index $n=D$ (complete positivity)
-is documented in \path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The second,
-the equal-dimension condition $d=d'=D$, comes from the square maximally-entangled-vector
-parametrization in the pure-state step; Wolf's eq.~(3.18) is stated for a general
-$\mathbb{C}^d\otimes\mathbb{C}^{d'}$, and its rectangular case awaits the rectangular
-form of that parametrization (elimination plan above). The square-system full
-criterion with Wolf's Schmidt-number premise is now available at
-\leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
-\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}. The operator-half
-theorems \leanid{Matrix.reductionCriterion_left} and
-\leanid{Matrix.reductionCriterion_right} remain as the separability-free
-sub-step, no longer the limit of what is formalized.
+\emph{Resolved.} The general bipartite forward step
+$\operatorname{sn}(\rho)\le n\Rightarrow(T\otimes\operatorname{id})(\rho)\ge 0$ holds
+for every $n$-positive map $T$ on $\mathbb{C}^d\otimes\mathbb{C}^{d'}$ with no relation
+between the factors, at
+\leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general}.
+
+Two residual restrictions remain on the $T_n$-specialised reduction \emph{criterion}
+(the operator inequalities $n\,\rho_1\otimes\mathbf 1\ge\rho$ and
+$n\,\mathbf 1\otimes\rho_2\ge\rho$), not on the forward step. First, the criterion
+theorems \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
+\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE} compose the
+\emph{square} forward step with the operator-implication step and so are still stated
+on $\mathbb{C}^D\otimes\mathbb{C}^D$; generalising them is the routine composition of
+the general forward step with the already dimension-general operator-half theorems
+\leanid{Matrix.reductionCriterion_left} and \leanid{Matrix.reductionCriterion_right}.
+Second, $1\le n<D$ is inherited from the $n$-positivity threshold of $T_\eta$, whose
+top index $n=D$ (complete positivity) is documented in
+\path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Docs follow-up to LionSR/TNLean#3532 (which closed LionSR/QICLean#177 with the Lean theorem `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general`, merged Lean-only).

- **Blueprint** (`ch25_positive_not_cp.tex`): upgrade the only-if entry to point at the general theorem — $(T\otimes\id)(\rho)\ge 0$ on a general $M_d\otimes M_{d'}$ with **no relation** between the factors (`\leanok`); the proof sketch is the padding-to-square reduction in both directions (pad the smaller factor; extend the map by an $n$-positivity-preserving corner when the first factor grows). Supersedes the earlier $d'\le d$ partial entry.
- **Paper-gap note** (`wolf_reduction_criterion_schmidt_premise.tex`): reclassified to *Resolved* for the forward step (general bipartite). The residual square $d=d'=D$ + $1\le n<D$ scope now applies **only** to the $T_n$-specialised reduction *criterion* theorems (`reductionCriterion_*_of_hasSchmidtNumberLE`), whose generalisation is the routine composition of the general forward step with the already dimension-general operator-half lemmas.

Reader-facing prose and blueprint–Lean sync checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates aligning prose with already-merged Lean; no runtime or security impact.
> 
> **Overview**
> **Blueprint** (`ch25_positive_not_cp.tex`) replaces the partial only-if theorem (second factor \(d'\le d\)) with a **general bipartite** statement: Schmidt number \(\le n\) implies \((T\otimes\mathrm{id})(\rho)\ge 0\) for every \(n\)-positive \(T\) on \(M_d\otimes M_{d'}\) with **no** relation between \(d\) and \(d'\), linked to `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general`. The proof sketch is now the full **padding-to-square** reduction (\(D=\max(d,d')\)), including **corner extension** of \(T\) when the first factor is padded.
> 
> The **paper-gap note** (`wolf_reduction_criterion_schmidt_premise.tex`) reclassifies Wolf eq.~(3.18) **step 1** as **resolved** for general \(\mathbb{C}^d\otimes\mathbb{C}^{d'}\). **Square** \(d=d'=D\) and \(1\le n<D\) are documented only as **residual** limits on the **\(T_n\)-specialised reduction criterion** (`reductionCriterion_*_of_hasSchmidtNumberLE`), not on the forward step; extending those criterion theorems is described as composing the general forward step with the existing dimension-general operator-half lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a9a36e2b39422d68d5c456fe869814c6d3968b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->