### PR TITLE
feat(Channel): generalize the reduction criterion to differing bipartite factors (#3536)

### DIFF
--- a/TNLean/Channel/SchmidtNumberFactors.lean
+++ b/TNLean/Channel/SchmidtNumberFactors.lean
@@ -42,6 +42,13 @@ raise its rank.
   `Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general`: the **general bipartite
   forward step** of Wolf Prop 3.4 (only if), with no relation imposed between the two
   tensor factors, combining the two padding directions.
+* `Matrix.reductionCriterion_left_of_hasSchmidtNumberLE_general` and
+  `Matrix.reductionCriterion_right_of_hasSchmidtNumberLE_general`: the **general
+  bipartite reduction criterion** of Wolf eq. (3.18), composing the general forward
+  step with the (already dimension-general) operator-implication step.  A bipartite
+  state on `ℂ^d ⊗ ℂ^{d'}` of Schmidt number at most `n` satisfies `n • (1 ⊗ ρ₂) ≥ ρ`
+  (left form, `1 ≤ n < d`) and `n • (ρ₁ ⊗ 1) ≥ ρ` (right form, `1 ≤ n < d'`), with no
+  square restriction relating the two tensor factors.
 
 ## References
 
@@ -603,5 +610,73 @@ theorem HasSchmidtNumberLE.tensorMapId_posSemidef_general [NeZero d] [NeZero d']
   rcases le_or_gt d' d with h | h
   · exact hρ.tensorMapId_posSemidef' h hTpos
   · exact hρ.tensorMapId_posSemidef'' h.le hTpos
+
+/-! ## The general bipartite reduction criterion (Wolf eq. (3.18))
+
+Composing the general bipartite forward step with the already dimension-general
+operator-implication step (`Matrix.reductionCriterion_left`/`reductionCriterion_right`,
+stated for `ℂ^d ⊗ ℂ^{d'}`) lifts the `T_n`-specialized reduction criterion off the
+square system.  The forward step `(T_n ⊗ id)(ρ) ≥ 0` holds whenever `ρ` has Schmidt
+number at most `n` and `T_n` is `n`-positive; the operator step then yields the
+reduced-density bounds.  The `n`-positivity threshold of `T_n` (Wolf eq. (3.11)) is the
+only restriction: `1 ≤ n < d` for the left form (the map lives on the first factor),
+and `1 ≤ n < d'` for the right form (the factor swap moves the map to the second
+factor). -/
+
+/-- **Wolf's reduction criterion (eq. (3.18)), left form, general bipartite system.**
+A bipartite state `ρ` on `ℂ^d ⊗ ℂ^{d'}` of Schmidt number at most `n` (with
+`1 ≤ n < d`) satisfies `n • (1 ⊗ ρ₂) ≥ ρ`, where `ρ₂ = traceLeft ρ` is the reduced
+density on the second factor.  No relation is imposed between the two tensor factors.
+
+This is Wolf's full two-step argument over a general bipartite system: the
+Schmidt-number premise gives `(T_n ⊗ id)(ρ) ≥ 0` (step 1, the general forward step
+`HasSchmidtNumberLE.tensorMapId_posSemidef_general`), and the dimension-general
+operator inequality `reductionCriterion_left` then yields the bound (step 2).  The only
+scope is the `n`-positivity threshold `1 ≤ n < d` of `T_n` (Wolf eq. (3.11)); the square
+restriction `d = d'` of `reductionCriterion_left_of_hasSchmidtNumberLE` is removed. -/
+theorem reductionCriterion_left_of_hasSchmidtNumberLE_general [NeZero d] [NeZero d']
+    {n : ℕ} (hn1 : 1 ≤ n) (hnd : n < d)
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : HasSchmidtNumberLE n ρ) :
+    ρ ≤ (n : ℂ) • ((1 : Matrix (Fin d) (Fin d) ℂ) ⊗ₖ traceLeft ρ) := by
+  -- `T_n` on the first factor is `n`-positive (Wolf eq. (3.11)).
+  have hTpos : IsNPositiveMap n (tEta d (n : ℝ)) :=
+    (isNPositiveMap_tEta_iff (by positivity) hn1 hnd).mpr (le_refl _)
+  exact reductionCriterion_left (by omega) ρ (hρ.tensorMapId_posSemidef_general hTpos)
+
+/-- **Wolf's reduction criterion (eq. (3.18)), right form, general bipartite system.**
+A bipartite state `ρ` on `ℂ^d ⊗ ℂ^{d'}` of Schmidt number at most `n` (with
+`1 ≤ n < d'`) satisfies `n • (ρ₁ ⊗ 1) ≥ ρ`, where `ρ₁ = traceRight ρ` is the reduced
+density on the first factor.  No relation is imposed between the two tensor factors.
+
+The factor swap `ρ.submatrix Prod.swap Prod.swap` on `ℂ^{d'} ⊗ ℂ^d` again has Schmidt
+number at most `n`, since the swap reindexes each pure summand to a vector with the
+transposed coefficient matrix, of the same rank.  Its first factor is `d'`, so the
+general forward step applied with the map `T_n` on `M_{d'}` (`n`-positive for
+`1 ≤ n < d'`) makes `(T_n ⊗ id)(ρ^swap) ≥ 0`, supplying the symmetric hypothesis of the
+dimension-general operator-implication step `reductionCriterion_right`.  The only scope
+is the `n`-positivity threshold `1 ≤ n < d'` of `T_n`; the square restriction `d = d'`
+of `reductionCriterion_right_of_hasSchmidtNumberLE` is removed. -/
+theorem reductionCriterion_right_of_hasSchmidtNumberLE_general [NeZero d] [NeZero d']
+    {n : ℕ} (hn1 : 1 ≤ n) (hnd' : n < d')
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ} (hρ : HasSchmidtNumberLE n ρ) :
+    ρ ≤ (n : ℂ) • (traceRight ρ ⊗ₖ (1 : Matrix (Fin d') (Fin d') ℂ)) := by
+  classical
+  -- The factor swap of `ρ` again has Schmidt number at most `n`.
+  have hswap : HasSchmidtNumberLE n (ρ.submatrix Prod.swap Prod.swap) := by
+    obtain ⟨ι, _, ψ, hψ, rfl⟩ := hρ
+    refine ⟨ι, inferInstance, fun i => (ψ i) ∘ Prod.swap, fun i => ?_, ?_⟩
+    · -- The swapped vector has the transposed coefficient matrix, of equal rank.
+      have hcoeff :
+          schmidtCoeffMatrix ((ψ i) ∘ Prod.swap) = (schmidtCoeffMatrix (ψ i))ᵀ := by
+        ext a b; simp [schmidtCoeffMatrix, Function.comp]
+      rw [HasSchmidtRankLE, schmidtRank, hcoeff, Matrix.rank_transpose]
+      exact hψ i
+    · ext ⟨i₁, i₂⟩ ⟨j₁, j₂⟩
+      simp only [Matrix.submatrix_apply, Matrix.sum_apply, vecMulVec_apply, Pi.star_apply,
+        Prod.swap_prod_mk, Function.comp_apply]
+  -- `T_n` on the swapped first factor `d'` is `n`-positive (Wolf eq. (3.11)).
+  have hTpos : IsNPositiveMap n (tEta d' (n : ℝ)) :=
+    (isNPositiveMap_tEta_iff (by positivity) hn1 hnd').mpr (le_refl _)
+  exact reductionCriterion_right (by omega) ρ (hswap.tensorMapId_posSemidef_general hTpos)
 
 end Matrix


### PR DESCRIPTION
## Summary

Lifts the `T_n`-specialized reduction **criterion** theorems off the square system `Fin D × Fin D` to a general bipartite system `Fin d × Fin d'`, completing Wolf eq. (3.18) over differing factors. Follow-up to LionSR/QICLean#177 / LionSR/TNLean#3532 (the forward step) — routine composition, no new machinery.

Both new theorems land in `TNLean/Channel/SchmidtNumberFactors.lean`:

- `Matrix.reductionCriterion_left_of_hasSchmidtNumberLE_general` — for `ρ : Fin d × Fin d'` of Schmidt number ≤ `n` with `1 ≤ n < d`, concludes `ρ ≤ n • (1_d ⊗ traceLeft ρ)`.
- `Matrix.reductionCriterion_right_of_hasSchmidtNumberLE_general` — same `ρ` with `1 ≤ n < d'`, concludes `ρ ≤ n • (traceRight ρ ⊗ 1_{d'})`.

## Method

Each composes the now-general forward step `HasSchmidtNumberLE.tensorMapId_posSemidef_general` with the already dimension-general operator-implication step `reductionCriterion_left` / `reductionCriterion_right` (`ReductionCriterion.lean:170`):

- **Left:** obtain `IsNPositiveMap n (tEta d n)` from `isNPositiveMap_tEta_iff` (needs `1 ≤ n < d`), then `reductionCriterion_left (by omega) ρ (hρ.tensorMapId_posSemidef_general hTpos)`.
- **Right (factor swap):** the swap `ρ.submatrix Prod.swap Prod.swap` on `Fin d' × Fin d` again has Schmidt number ≤ `n` (transposed coefficient matrix, equal rank); its first factor is `d'`, so the general forward step with `T = tEta d' n` (`n`-positive for `1 ≤ n < d'`) makes `(T_n ⊗ id)(ρ^swap) ≥ 0`, which is exactly the hypothesis of `reductionCriterion_right`.

The only remaining scope is the `T_n` `n`-positivity threshold (`1 ≤ n < d` resp. `n < d'`, Wolf eq. (3.11)); the square restriction `d = d'` is removed.

## Verification

- `lake build TNLean.Channel.SchmidtNumberFactors` → Build completed successfully (3012 jobs).
- `rg -n "sorry|admit|axiom|native_decide"` on the touched file → empty.
- `#print axioms` on both new theorems → only `propext`, `Classical.choice`, `Quot.sound`.
- File is 682 lines (≤ 1000 gate).

Lean only; blueprint entry to be added separately.

Closes LionSR/QICLean#181

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean proofs in channel/Schmidt formalization; no runtime, security, or API surface changes.
> 
> **Overview**
> Extends Wolf’s reduction criterion to bipartite states on `Fin d × Fin d'` when the two factor dimensions may differ, removing the square `d = d'` restriction from the Schmidt-number versions in `SchmidtNumber.lean`.
> 
> **Left form** (`reductionCriterion_left_of_hasSchmidtNumberLE_general`): from Schmidt number ≤ `n` and `1 ≤ n < d`, concludes `ρ ≤ n • (1 ⊗ traceLeft ρ)` by `n`-positivity of `tEta d` and the general forward step `HasSchmidtNumberLE.tensorMapId_posSemidef_general`, then `reductionCriterion_left`.
> 
> **Right form** (`reductionCriterion_right_of_hasSchmidtNumberLE_general`): for `1 ≤ n < d'`, concludes `ρ ≤ n • (traceRight ρ ⊗ 1)` using a factor swap that preserves Schmidt number (transposed coefficient matrix), `tEta d'` on the swapped system, and `reductionCriterion_right`.
> 
> Module docs are updated to list these as the general bipartite reduction criterion (eq. 3.18).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc933ce249249ae734aeef1a2b7b6bceba2e476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->