### PR TITLE
doc(Channel): general reduction-criterion blueprint + gap-note closure

### DIFF
--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -734,30 +734,31 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
 
 \begin{theorem}[Reduction criterion with the Schmidt-number premise]
     \label{thm:reduction_criterion_of_schmidt_number}
-    \lean{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE,
-        Matrix.reductionCriterion_right_of_hasSchmidtNumberLE}
+    \lean{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE_general,
+        Matrix.reductionCriterion_right_of_hasSchmidtNumberLE_general}
     \leanok
     \uses{def:has_schmidt_number_le, def:t_eta,
-        thm:has_schmidt_number_le_tensor_map_id_t_eta, thm:reduction_criterion}
-    For $1\le n<D$, a bipartite state on the square system $\MN{D}\otimes\MN{D}$ of
-    Schmidt number at most $n$ satisfies the
-    reduction criterion
+        thm:has_schmidt_number_le_tensor_map_id_general, thm:reduction_criterion}
+    On a general bipartite system $\MN{d}\otimes\MN{d'}$, a state of Schmidt number at
+    most $n$ satisfies the reduction criterion
     \[
-        n\,\rho_1\otimes\Id\ge\rho
+        n\,\Id\otimes\rho_2\ge\rho \quad(1\le n<d)
         \qquad\text{and}\qquad
-        n\,\Id\otimes\rho_2\ge\rho,
+        n\,\rho_1\otimes\Id\ge\rho \quad(1\le n<d'),
     \]
     with $\rho_1$ and $\rho_2$ the reduced densities on the first and second factors.
+    No relation is imposed between $d$ and $d'$; each inequality carries only the
+    $n$-positivity threshold of $T_n$ on its acting factor.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The Schmidt-number premise gives $(T_n\otimes\id)(\rho)\ge 0$, which is the first
-    step.  The operator implication then yields $n\,\Id\otimes\rho_2\ge\rho$.  The
-    factor swap of a state of Schmidt number at most $n$ again has Schmidt number at
-    most $n$, since the swap reindexes each pure summand to a vector with the
-    transposed coefficient matrix, of the same rank; applying the first step to the
-    swapped state and the operator implication in its symmetric form gives
-    $n\,\rho_1\otimes\Id\ge\rho$.
+    The Schmidt-number premise gives $(T_n\otimes\id)(\rho)\ge 0$ on the general system
+    (first step), and the dimension-general operator implication then yields
+    $n\,\Id\otimes\rho_2\ge\rho$.  The factor swap of a state of Schmidt number at most
+    $n$ again has Schmidt number at most $n$, since the swap reindexes each pure summand
+    to a vector with the transposed coefficient matrix, of the same rank; applying the
+    first step to the swapped state (whose first factor is $d'$) and the operator
+    implication in its symmetric form gives $n\,\rho_1\otimes\Id\ge\rho$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -756,9 +756,10 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     The Schmidt-number premise gives $(T_n\otimes\id)(\rho)\ge 0$ on the general system
     (first step), and the dimension-general operator implication then yields
     $n\,\Id\otimes\rho_2\ge\rho$.  The factor swap of a state of Schmidt number at most
-    $n$ again has Schmidt number at most $n$, since the swap reindexes each pure summand
-    to a vector with the transposed coefficient matrix, of the same rank; applying the
-    first step to the swapped state (whose first factor is $d'$) and the operator
-    implication in its symmetric form gives $n\,\rho_1\otimes\Id\ge\rho$.
+    $n$ again has Schmidt number at most $n$, since it sends each pure summand $\psi$ to
+    $\psi\circ\mathrm{swap}$, whose Schmidt coefficient matrix is the transpose
+    $M_{\psi\circ\mathrm{swap}}=M_\psi^{\mathsf T}$ of that of $\psi$ and so has the same
+    rank; applying the first step to the swapped state (whose first factor is $d'$) and
+    the operator implication in its symmetric form gives $n\,\rho_1\otimes\Id\ge\rho$.
 \end{proof}
 

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -131,18 +131,22 @@ for every $n$-positive map $T$ on $\mathbb{C}^d\otimes\mathbb{C}^{d'}$ with no r
 between the factors, at
 \leanid{Matrix.HasSchmidtNumberLE.tensorMapId_posSemidef_general}.
 
-Two residual restrictions remain on the $T_n$-specialised reduction \emph{criterion}
-(the operator inequalities $n\,\rho_1\otimes\mathbf 1\ge\rho$ and
-$n\,\mathbf 1\otimes\rho_2\ge\rho$), not on the forward step. First, the criterion
-theorems \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
-\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE} compose the
-\emph{square} forward step with the operator-implication step and so are still stated
-on $\mathbb{C}^D\otimes\mathbb{C}^D$; generalising them is the routine composition of
-the general forward step with the already dimension-general operator-half theorems
+The $T_n$-specialised reduction \emph{criterion} is likewise now general: the
+inequalities $n\,\mathbf 1\otimes\rho_2\ge\rho$ and $n\,\rho_1\otimes\mathbf 1\ge\rho$
+hold on a general $\mathbb{C}^d\otimes\mathbb{C}^{d'}$ at
+\leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE_general} and
+\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE_general}, obtained by
+composing the general forward step with the dimension-general operator-half theorems
 \leanid{Matrix.reductionCriterion_left} and \leanid{Matrix.reductionCriterion_right}.
-Second, $1\le n<D$ is inherited from the $n$-positivity threshold of $T_\eta$, whose
+The square-restricted \leanid{Matrix.reductionCriterion_left_of_hasSchmidtNumberLE} and
+\leanid{Matrix.reductionCriterion_right_of_hasSchmidtNumberLE} remain as the $d=d'$
+specialisations.
+
+The only residual scope is the $n$-positivity threshold of $T_n$ itself: the left
+inequality needs $1\le n<d$ and the right needs $1\le n<d'$ (Wolf eq.~(3.11)), whose
 top index $n=D$ (complete positivity) is documented in
-\path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}.
+\path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The bipartite-dimension
+restriction recorded in this note is thereby fully eliminated.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
+++ b/docs/paper-gaps/wolf_reduction_criterion_schmidt_premise.tex
@@ -144,8 +144,8 @@ specialisations.
 
 The only residual scope is the $n$-positivity threshold of $T_n$ itself: the left
 inequality needs $1\le n<d$ and the right needs $1\le n<d'$ (Wolf eq.~(3.11)), whose
-top index $n=D$ (complete positivity) is documented in
-\path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The bipartite-dimension
+top index ($n=d$ for the left form, $n=d'$ for the right; complete positivity) is
+documented in \path{docs/paper-gaps/wolf_t_eta_top_index_scope.tex}. The bipartite-dimension
 restriction recorded in this note is thereby fully eliminated.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
Docs follow-up to LionSR/QICLean#181/#3539 (the general reduction criterion, merged Lean-only).

- **Blueprint** (`ch25_positive_not_cp.tex`): repoint `thm:reduction_criterion_of_schmidt_number` to the general theorems `reductionCriterion_{left,right}_of_hasSchmidtNumberLE_general` — the criterion $n\,\Id\otimes\rho_2\ge\rho$ ($1\le n<d$) and $n\,\rho_1\otimes\Id\ge\rho$ ($1\le n<d'$) on a general $M_d\otimes M_{d'}$, no square restriction. Label kept so the existing `\ref` still resolves.
- **Paper-gap note** (`wolf_reduction_criterion_schmidt_premise.tex`): both forward step and criterion are now general — the bipartite-dimension restriction recorded in this note is **fully eliminated**; the only residual scope is the $T_n$ n-positivity threshold (Wolf eq. (3.11)), documented separately in `wolf_t_eta_top_index_scope.tex`.

This completes Wolf eq. (3.18) — forward step and full reduction criterion — over general bipartite systems. Prose + blueprint–Lean sync pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> TeX-only documentation and Lean name cross-references; no runtime or proof code changes in this diff.
> 
> **Overview**
> Documentation follow-up to the merged general Lean theorems: **blueprint–Lean links and prose** now describe Wolf eq. (3.18) on a general bipartite system \(M_d \otimes M_{d'}\), not only the square case.
> 
> In **`ch25_positive_not_cp.tex`**, `thm:reduction_criterion_of_schmidt_number` now cites `Matrix.reductionCriterion_{left,right}_of_hasSchmidtNumberLE_general` and states the inequalities with **factor-specific** thresholds \(1 \le n < d\) and \(1 \le n < d'\). The proof sketch is updated to use the general forward step and to justify the swap argument via transposed Schmidt coefficient matrices.
> 
> In **`wolf_reduction_criterion_schmidt_premise.tex`**, the classification section records that the **full \(T_n\) reduction criterion** is general as well; square-named theorems are noted as \(d=d'\) specialisations. The note closes the recorded **bipartite-dimension gap** and points remaining scope to the \(T_n\) \(n\)-positivity thresholds (Wolf eq. (3.11)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c68040da57d1a52510a92e94960ea3f4815e362d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->