### PR TITLE
feat(Channel/Schwarz): data-processing inequality for quantum relative entropy on the singular support domain

### DIFF
--- a/TNLean/Channel/PartialTrace.lean
+++ b/TNLean/Channel/PartialTrace.lean
@@ -96,6 +96,30 @@ theorem trace_partialTraceRight [Fintype α] (X : Matrix (α × β) (α × β) �
   simp only [Matrix.trace, Matrix.diag, partialTraceRight_apply]
   rw [Fintype.sum_prod_type]
 
+/-- The partial trace over the second factor is additive. -/
+theorem partialTraceRight_add (X Y : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight (X + Y) = partialTraceRight X + partialTraceRight Y := by
+  ext i j; simp [partialTraceRight_apply, Finset.sum_add_distrib]
+
+/-- The partial trace over the second factor commutes with real scalar
+multiplication. -/
+theorem partialTraceRight_real_smul (c : ℝ) (X : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight (c • X) = c • partialTraceRight X := by
+  ext i j; simp [partialTraceRight_apply, Finset.smul_sum]
+
+/-- The partial trace of the identity is the cardinality of the traced factor
+times the identity on the retained factor:
+\(\operatorname{tr}_\beta\mathbf 1 = |\beta|\,\mathbf 1\). -/
+theorem partialTraceRight_one [DecidableEq α] [DecidableEq β] :
+    partialTraceRight (1 : Matrix (α × β) (α × β) ℂ)
+      = (Fintype.card β : ℂ) • (1 : Matrix α α ℂ) := by
+  ext i j
+  simp only [partialTraceRight_apply, Matrix.one_apply, Prod.mk.injEq, Matrix.smul_apply,
+    smul_eq_mul]
+  by_cases hij : i = j
+  · subst hij; simp
+  · simp [hij]
+
 end GeneralRight
 
 /-- The trace is invariant under reindexing a matrix by an equivalence of its

--- a/TNLean/Channel/Schwarz/RelativeEntropyConvexity.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyConvexity.lean
@@ -696,6 +696,204 @@ theorem tendsto_relativeEntropyPerturb {ρ σ : Mat}
   refine Tendsto.sub ?_ (tendsto_re_trace_perturb_mul_log_perturb hρ hσ hsupp)
   exact tendsto_re_trace_perturb_mul_log_perturb hρ hρ (fun v hv => hv)
 
+/-! ## The affine trace-one regularization and its both-arguments limit
+
+The regularization `regPerturb` shrinks and shifts a matrix by the same scalars on
+the whole index. Under a marginal it picks up index-dependent constants: the
+partial trace of \(M_\varepsilon = (1 + N\varepsilon)^{-1}(M + \varepsilon\mathbf 1)\)
+over an ancilla of dimension \(d_C\) is the differently-scaled affine regularization
+\((1 + N\varepsilon)^{-1}((\operatorname{tr}_C M) + (d_C\varepsilon)\mathbf 1_S)\),
+with the same scalar weight \((1 + N\varepsilon)^{-1}\) but additive shift
+\(d_C\varepsilon\) and the smaller identity \(\mathbf 1_S\). The both-arguments limit
+`tendsto_relativeEntropyPerturb` therefore does not apply verbatim to a marginal.
+
+This section generalizes the regularization and its limit to an arbitrary
+positive-affine perturbation
+\(M \mapsto (1 + a\varepsilon)^{-1}(M + b\varepsilon\mathbf 1)\) with constants
+\(a, b > 0\) on an arbitrary finite index, of which `regPerturb` is the
+\(a = N, b = 1\) instance. The proof is the same shared-eigenbasis scalar-limit
+argument as `tendsto_re_trace_perturb_mul_log_perturb`; only the scalar weight and
+shift change. The generalized lemma is reused for the singular-support data-processing
+inequality and serves the tripartite instantiation. -/
+
+section AffinePerturb
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The affine trace-shrinking regularization
+\(M_\varepsilon = (1 + a\varepsilon)^{-1}(M + b\varepsilon\mathbf 1)\) of a matrix,
+with positive scaling rate \(a\) and shift rate \(b\). It is affine in \(M\) and,
+for a positive semidefinite \(M\) and \(a, b, \varepsilon > 0\), positive definite.
+The trace-one regularization `regPerturb` is the \(a = N, b = 1\) instance. -/
+def regPerturbAffine (a b ε : ℝ) (M : Matrix n n ℂ) : Matrix n n ℂ :=
+  (1 + a * ε)⁻¹ • (M + (b * ε) • (1 : Matrix n n ℂ))
+
+omit [Fintype n] in
+/-- For \(a, b, \varepsilon > 0\) the affine regularization of a positive semidefinite
+matrix is positive definite. -/
+theorem regPerturbAffine_posDef {a b ε : ℝ} (ha : 0 < a) (hb : 0 < b) (hε : 0 < ε)
+    {M : Matrix n n ℂ} (hM : M.PosSemidef) : (regPerturbAffine a b ε M).PosDef := by
+  refine Matrix.PosDef.smul
+    (Matrix.PosDef.posSemidef_add hM ((Matrix.PosDef.one).smul (by positivity))) ?_
+  have : (0 : ℝ) < 1 + a * ε := by positivity
+  positivity
+
+open Filter Topology TNLean.Klein in
+/-- **Both-arguments trace-log limit for the affine regularization.** For positive
+semidefinite \(\rho, \sigma\) with \(\ker\sigma \subseteq \ker\rho\) and constants
+\(a, b > 0\), the cross term
+\(\operatorname{Re}\operatorname{tr}(\rho_\varepsilon\log\sigma_\varepsilon)\) of the
+affine regularizations
+\(\rho_\varepsilon = (1 + a\varepsilon)^{-1}(\rho + b\varepsilon\mathbf 1)\),
+\(\sigma_\varepsilon = (1 + a\varepsilon)^{-1}(\sigma + b\varepsilon\mathbf 1)\)
+converges to \(\operatorname{Re}\operatorname{tr}(\rho\log\sigma)\) as
+\(\varepsilon \to 0^+\).
+
+In \(\sigma\)'s eigenbasis each summand is the regularized diagonal weight
+\((1 + a\varepsilon)^{-1}(w_j + b\varepsilon)\), with
+\(w_j = \operatorname{Re}(U_\sigma^\dagger \rho\, U_\sigma)_{jj}\), times \(\log\)
+of the regularized eigenvalue \((1 + a\varepsilon)^{-1}(q_j + b\varepsilon)\). For
+\(q_j > 0\) the weight tends to \(w_j\) and the logarithm to \(\log q_j\); for
+\(q_j = 0\) the support condition forces \(w_j = 0\), so the term is
+\(y_\varepsilon\log y_\varepsilon\) with
+\(y_\varepsilon = (1 + a\varepsilon)^{-1}b\varepsilon \to 0\), which tends to
+\(0 = w_j\log q_j\) by continuity of \(x \mapsto x\log x\). This is the
+\(a = N, b = 1\) generalization of `tendsto_re_trace_perturb_mul_log_perturb`. -/
+theorem tendsto_re_trace_perturbAffine_mul_log_perturbAffine {a b : ℝ}
+    (ha : 0 < a) (hb : 0 < b) {ρ σ : Matrix n n ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : n → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0) :
+    Tendsto (fun ε : ℝ =>
+        (Matrix.trace (regPerturbAffine a b ε ρ * CFC.log (regPerturbAffine a b ε σ))).re)
+      (𝓝[>] 0) (𝓝 (Matrix.trace (ρ * CFC.log σ)).re) := by
+  set q : n → ℝ := fun j => hσ.isHermitian.eigenvalues j with hq
+  set Uσ : Matrix n n ℂ := (hσ.isHermitian.eigenvectorUnitary : Matrix n n ℂ) with hUσ
+  set w : n → ℝ := fun j => ((star Uσ * ρ * Uσ) j j).re with hw
+  have hlogσ : CFC.log σ = hσ.isHermitian.cfc Real.log := by
+    rw [CFC.log]; exact Matrix.IsHermitian.cfc_eq hσ.isHermitian Real.log
+  have hRHS : (Matrix.trace (ρ * CFC.log σ)).re = ∑ j, w j * Real.log (q j) := by
+    rw [hlogσ, re_trace_mul_cfc_eq_diag_sum hσ.isHermitian Real.log]
+  have hcε_pos : ∀ ε : ℝ, 0 < ε → 0 < (1 + a * ε)⁻¹ := by
+    intro ε hε
+    have : (0 : ℝ) < 1 + a * ε := by positivity
+    positivity
+  have hUσ_unit : star Uσ * Uσ = 1 := by
+    rw [hUσ, Matrix.star_eq_conjTranspose]
+    exact Unitary.coe_star_mul_self hσ.isHermitian.eigenvectorUnitary
+  -- the regularized weight in σ's eigenbasis: `(1 + aε)⁻¹ (w j + bε)`
+  have hdiag : ∀ ε : ℝ, ∀ j : n,
+      ((star Uσ * regPerturbAffine a b ε ρ * Uσ) j j).re
+        = (1 + a * ε)⁻¹ * (w j + b * ε) := by
+    intro ε j
+    have hsplit : star Uσ * regPerturbAffine a b ε ρ * Uσ
+        = (1 + a * ε)⁻¹ • (star Uσ * ρ * Uσ + (b * ε) • (1 : Matrix n n ℂ)) := by
+      rw [regPerturbAffine, Matrix.mul_smul, Matrix.smul_mul, mul_add, add_mul,
+        Matrix.mul_smul, Matrix.smul_mul, Matrix.mul_one, Matrix.mul_assoc, hUσ_unit]
+    rw [hsplit]
+    simp only [Matrix.smul_apply, Matrix.add_apply, Matrix.one_apply_eq, smul_eq_mul,
+      mul_one, Complex.real_smul, Complex.mul_re, Complex.add_re, Complex.ofReal_re,
+      Complex.ofReal_im, Complex.add_im, hw]
+    ring
+  -- the function at ε is the diagonal sum against the shifted-scaled `log`,
+  -- with the regularized weight
+  have hfun : ∀ ε : ℝ, 0 < ε →
+      (Matrix.trace (regPerturbAffine a b ε ρ * CFC.log (regPerturbAffine a b ε σ))).re
+        = ∑ j, (1 + a * ε)⁻¹ * (w j + b * ε)
+            * Real.log ((1 + a * ε)⁻¹ * (q j + b * ε)) := by
+    intro ε hε
+    have hbε : 0 < b * ε := by positivity
+    have hlog : CFC.log (regPerturbAffine a b ε σ)
+        = hσ.isHermitian.cfc (fun x : ℝ => Real.log ((1 + a * ε)⁻¹ * (x + b * ε))) := by
+      rw [regPerturbAffine]; exact cfc_log_smul_add_smul_one hσ hbε (hcε_pos ε hε)
+    rw [hlog, re_trace_mul_cfc_eq_diag_sum hσ.isHermitian
+        (fun x : ℝ => Real.log ((1 + a * ε)⁻¹ * (x + b * ε)))]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    simp only [hq]
+    rw [← hUσ, hdiag ε j]
+  rw [hRHS]
+  -- termwise limit of the diagonal sum
+  have hterm : ∀ j : n,
+      Tendsto (fun ε : ℝ => (1 + a * ε)⁻¹ * (w j + b * ε)
+          * Real.log ((1 + a * ε)⁻¹ * (q j + b * ε))) (𝓝[>] 0)
+        (𝓝 (w j * Real.log (q j))) := by
+    intro j
+    -- the regularized eigenvalue `y_ε = (1 + aε)⁻¹(c + bε)` for a constant `c ≥ 0`
+    have hreg : ∀ c : ℝ, Tendsto (fun ε : ℝ => (1 + a * ε)⁻¹ * (c + b * ε))
+        (𝓝[>] 0) (𝓝 c) := by
+      intro c
+      have h1 : Tendsto (fun ε : ℝ => (1 + a * ε)⁻¹) (𝓝[>] 0) (𝓝 ((1 : ℝ))) := by
+        have hc : Continuous (fun ε : ℝ => 1 + a * ε) := by continuity
+        have ht : Tendsto (fun ε : ℝ => 1 + a * ε) (𝓝[>] 0) (𝓝 (1 + a * 0)) :=
+          (hc.tendsto 0).mono_left nhdsWithin_le_nhds
+        simp only [mul_zero, add_zero] at ht
+        simpa using ht.inv₀ (by norm_num)
+      have h2 : Tendsto (fun ε : ℝ => c + b * ε) (𝓝[>] 0) (𝓝 (c + b * 0)) := by
+        have hc : Continuous (fun ε : ℝ => c + b * ε) := by continuity
+        exact (hc.tendsto 0).mono_left nhdsWithin_le_nhds
+      simp only [mul_zero, add_zero] at h2
+      simpa using h1.mul h2
+    rcases eq_or_lt_of_le (hσ.eigenvalues_nonneg j) with hqj | hqj
+    · -- qⱼ = 0: the weight vanishes by the support condition, term is `y log y → 0`
+      have hzero_w : w j = 0 := by
+        rw [hw]
+        refine congrArg Complex.re (diag_weight_eq_zero_of_kernel hσ.isHermitian j ?_)
+        apply hsupp
+        rw [hσ.isHermitian.mulVec_eigenvectorBasis, ← hqj, zero_smul]
+      have hqj' : q j = 0 := hqj.symm
+      have htarget : w j * Real.log (q j) = 0 := by rw [hzero_w, zero_mul]
+      rw [htarget]
+      -- the term equals `y_ε * log y_ε` with `y_ε = (1 + aε)⁻¹(0 + bε)`
+      have hcongr : (fun ε : ℝ => (1 + a * ε)⁻¹ * (w j + b * ε)
+          * Real.log ((1 + a * ε)⁻¹ * (q j + b * ε)))
+          =ᶠ[𝓝[>] 0]
+          (fun ε : ℝ => ((1 + a * ε)⁻¹ * (0 + b * ε))
+            * Real.log ((1 + a * ε)⁻¹ * (0 + b * ε))) := by
+        filter_upwards [self_mem_nhdsWithin] with ε _
+        rw [hzero_w, hqj']
+      refine Tendsto.congr' hcongr.symm ?_
+      have hy : Tendsto (fun ε : ℝ => (1 + a * ε)⁻¹ * (0 + b * ε)) (𝓝[>] 0) (𝓝 0) := hreg 0
+      have hmllog : Tendsto (fun y : ℝ => y * Real.log y) (𝓝 (0 : ℝ)) (𝓝 (0 * Real.log 0)) :=
+        (Real.continuous_mul_log.tendsto 0)
+      rw [Real.log_zero, mul_zero] at hmllog
+      exact hmllog.comp hy
+    · -- qⱼ > 0: weight tends to `w j`, log to `log q j`
+      have hwlim : Tendsto (fun ε : ℝ => (1 + a * ε)⁻¹ * (w j + b * ε)) (𝓝[>] 0) (𝓝 (w j)) :=
+        hreg (w j)
+      have hloglim : Tendsto (fun ε : ℝ => Real.log ((1 + a * ε)⁻¹ * (q j + b * ε)))
+          (𝓝[>] 0) (𝓝 (Real.log (q j))) :=
+        (Real.continuousAt_log hqj.ne').tendsto.comp (hreg (q j))
+      exact hwlim.mul hloglim
+  refine Tendsto.congr' ?_ (tendsto_finsetSum Finset.univ fun j _ => hterm j)
+  filter_upwards [self_mem_nhdsWithin] with ε hε
+  rw [hfun ε hε]
+
+open Filter Topology in
+/-- **Both-arguments relative-entropy limit for the affine regularization.** For
+positive semidefinite \(\rho, \sigma\) with \(\ker\sigma \subseteq \ker\rho\) and
+constants \(a, b > 0\), the relative entropy of the affine regularizations
+\(\rho_\varepsilon = (1 + a\varepsilon)^{-1}(\rho + b\varepsilon\mathbf 1)\),
+\(\sigma_\varepsilon = (1 + a\varepsilon)^{-1}(\sigma + b\varepsilon\mathbf 1)\)
+converges to \(D(\rho\|\sigma)\) as \(\varepsilon \to 0^+\).
+
+Splitting \(D(\rho_\varepsilon\|\sigma_\varepsilon)\) into the self and cross trace
+terms, both converge by `tendsto_re_trace_perturbAffine_mul_log_perturbAffine`: the
+self term is its \(\sigma = \rho\) instance and the cross term the support-respecting
+instance. This generalizes `tendsto_relativeEntropyPerturb`, of which it is the
+\(a = N, b = 1\) instance, and is the reusable singular-domain limit for marginals
+under the partial trace. -/
+theorem tendsto_relativeEntropyPerturbAffine {a b : ℝ} (ha : 0 < a) (hb : 0 < b)
+    {ρ σ : Matrix n n ℂ} (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : n → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0) :
+    Tendsto (fun ε : ℝ =>
+        quantumRelativeEntropy (regPerturbAffine a b ε ρ) (regPerturbAffine a b ε σ))
+      (𝓝[>] 0) (𝓝 (quantumRelativeEntropy ρ σ)) := by
+  simp only [quantumRelativeEntropy_eq_trace_mul_log_sub]
+  refine Tendsto.sub ?_
+    (tendsto_re_trace_perturbAffine_mul_log_perturbAffine ha hb hρ hσ hsupp)
+  exact tendsto_re_trace_perturbAffine_mul_log_perturbAffine ha hb hρ hρ (fun v hv => hv)
+
+end AffinePerturb
+
 /-- **Joint convexity of the quantum relative entropy on the singular support
 domain.** For density matrices \((\rho, \sigma)\) with the kernel inclusion
 \(\ker\sigma \subseteq \ker\rho\), the map \((\rho, \sigma) \mapsto D(\rho\|\sigma)\)

--- a/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
@@ -238,38 +238,6 @@ of the partial trace of the identity, and prove the bipartite marginal support
 fact \(\ker(\operatorname{tr}_C\sigma) \subseteq \ker(\operatorname{tr}_C\rho)\)
 that transfers the support condition to the marginals. -/
 
-section PartialTraceAlgebra
-
-variable {α β : Type*} [Fintype β]
-
-/-- The partial trace over the second factor is additive. -/
-theorem partialTraceRight_add (X Y : Matrix (α × β) (α × β) ℂ) :
-    partialTraceRight (X + Y) = partialTraceRight X + partialTraceRight Y := by
-  ext i j; simp [partialTraceRight_apply, Finset.sum_add_distrib]
-
-/-- The partial trace over the second factor commutes with real scalar
-multiplication. -/
-theorem partialTraceRight_real_smul (c : ℝ) (X : Matrix (α × β) (α × β) ℂ) :
-    partialTraceRight (c • X) = c • partialTraceRight X := by
-  ext i j; simp [partialTraceRight_apply, Finset.smul_sum]
-
-variable [DecidableEq α] [DecidableEq β]
-
-/-- The partial trace of the identity is the cardinality of the traced factor
-times the identity on the retained factor:
-\(\operatorname{tr}_\beta\mathbf 1 = |\beta|\,\mathbf 1\). -/
-theorem partialTraceRight_one :
-    partialTraceRight (1 : Matrix (α × β) (α × β) ℂ)
-      = (Fintype.card β : ℂ) • (1 : Matrix α α ℂ) := by
-  ext i j
-  simp only [partialTraceRight_apply, Matrix.one_apply, Prod.mk.injEq, Matrix.smul_apply,
-    smul_eq_mul]
-  by_cases hij : i = j
-  · subst hij; simp
-  · simp [hij]
-
-end PartialTraceAlgebra
-
 section MarginalSupport
 
 variable {α β : Type*} [Fintype α] [Fintype β] [DecidableEq β]
@@ -669,10 +637,9 @@ theorem partialTraceRight_regPerturbAffine {α β : Type*} [Fintype β]
 open scoped Topology
 open Filter
 
-/-- **Data-processing inequality on the singular support domain.** For density
-matrices \(\rho, \sigma\) (positive semidefinite, unit trace) on a tensor product
-of a system factor and an ancilla factor with the kernel inclusion
-\(\ker\sigma \subseteq \ker\rho\),
+/-- **Data-processing inequality on the singular support domain.** For positive
+semidefinite \(\rho, \sigma\) on a tensor product of a system factor and an
+ancilla factor with the kernel inclusion \(\ker\sigma \subseteq \ker\rho\),
 \[
   D(\operatorname{tr}_C\rho \,\|\, \operatorname{tr}_C\sigma)
     \le D(\rho \,\|\, \sigma),
@@ -680,8 +647,10 @@ of a system factor and an ancilla factor with the kernel inclusion
 where \(\operatorname{tr}_C\) is the partial trace over the ancilla factor.
 
 This extends `quantumRelativeEntropy_partialTraceRight_le` from the positive
-definite domain to all density-matrix pairs of finite relative entropy. Both
-arguments are regularized through the affine trace-shrinking perturbation
+definite domain to all positive semidefinite pairs satisfying the support
+condition. No trace normalization is required; the intended application is to
+density matrices (trace one). Both arguments are regularized through the affine
+trace-shrinking perturbation
 \(M_\varepsilon = (1 + N_{SC}\varepsilon)^{-1}(M + \varepsilon\mathbf 1_{SC})\),
 which is positive definite for \(\varepsilon > 0\), so the positive-definite
 inequality applies at each \(\varepsilon\). The right-hand side converges to

--- a/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyDataProcessing.lean
@@ -19,11 +19,13 @@ entropy under the partial trace: for positive definite matrices $\rho, \sigma$ o
 a tensor product of a system factor and an ancilla factor,
 $D(\operatorname{tr}_C \rho \,\|\, \operatorname{tr}_C \sigma)
   \le D(\rho \,\|\, \sigma)$,
-where $\operatorname{tr}_C$ is the partial trace over the ancilla factor. This is
-layer 5 of the SSA-from-Lieb elimination route,
+where $\operatorname{tr}_C$ is the partial trace over the ancilla factor. The
+positive-definite base case is extended to the singular support domain
+$\ker \sigma \subseteq \ker \rho$ by regularizing both arguments and passing to the
+limit. This is layer 5 of the SSA-from-Lieb elimination route,
 `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`; all of its ingredients are now
-formalized, leaving only the layer-6 tripartite instantiation to discharge the
-standalone strong-subadditivity axiom.
+formalized, leaving only the layer-6 singular-reference tripartite instantiation to
+discharge the standalone strong-subadditivity axiom.
 
 ## Main results
 
@@ -38,7 +40,15 @@ standalone strong-subadditivity axiom.
   the canonical finite index.
 * `Matrix.quantumRelativeEntropy_partialTraceRight_le` — the data-processing
   inequality $D(\operatorname{tr}_C \rho \,\|\, \operatorname{tr}_C \sigma)
-  \le D(\rho \,\|\, \sigma)$.
+  \le D(\rho \,\|\, \sigma)$ for positive definite arguments.
+* `TNLean.RelativeEntropyConvexity.tendsto_relativeEntropyPerturbAffine` — the
+  both-arguments limit for an arbitrary positive-affine trace-shrinking
+  regularization $M \mapsto (1 + a\varepsilon)^{-1}(M + b\varepsilon\mathbf 1)$,
+  the limit machinery for marginals under the partial trace.
+* `Matrix.partialTraceRight_support` — the bipartite marginal support fact
+  $\ker(\operatorname{tr}_C \sigma) \subseteq \ker(\operatorname{tr}_C \rho)$.
+* `Matrix.quantumRelativeEntropy_partialTraceRight_le_support` — the data-processing
+  inequality on the singular support domain $\ker \sigma \subseteq \ker \rho$.
 
 ## Proof outline
 
@@ -57,12 +67,17 @@ $D(\rho \,\|\, \sigma)$ by unitary invariance
 (`quantumRelativeEntropy_conj_unitary`); the weights sum to one, leaving
 $D(\rho \,\|\, \sigma)$.
 
-**Scope restriction (positive-definite domain):** the source data-processing
-inequality holds for density operators with $\ker \sigma \subseteq \ker \rho$,
-whereas this development restricts $\rho, \sigma$ to positive definite matrices,
-the domain on which joint convexity and ancilla additivity are available. The
-restriction is recorded in `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`,
-layer 5.
+The singular support domain $\ker \sigma \subseteq \ker \rho$ is reached from this
+positive-definite base case by regularizing both arguments through the affine
+trace-shrinking perturbation
+$M_\varepsilon = (1 + N_{SC}\varepsilon)^{-1}(M + \varepsilon\mathbf 1)$, which is
+positive definite for $\varepsilon > 0$. The right-hand side converges to
+$D(\rho \,\|\, \sigma)$ by the both-arguments limit, and the left-hand side is the
+relative entropy of the marginals, themselves affine regularizations of
+$\operatorname{tr}_C \rho, \operatorname{tr}_C \sigma$ with the shift rate scaled by
+$d_C$; the support condition transfers to the marginals by the bipartite marginal
+support fact, so the same limit applies. This is recorded in
+`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 5.
 
 ## References
 
@@ -210,6 +225,149 @@ theorem convexOn_quantumRelativeEntropy_index :
 end TNLean.RelativeEntropyConvexity
 
 namespace Matrix
+
+/-! ## Algebra of the partial trace and the bipartite marginal support
+
+The singular-domain extension regularizes the joint state and pushes the
+regularization through the partial trace. The partial trace of the affine
+trace-shrinking regularization
+\(M_\varepsilon = (1 + a\varepsilon)^{-1}(M + \varepsilon\mathbf 1_{SC})\) is a
+differently-scaled regularization of the marginal, with shift rate the traced
+cardinality. These lemmas record the linearity of the partial trace and the value
+of the partial trace of the identity, and prove the bipartite marginal support
+fact \(\ker(\operatorname{tr}_C\sigma) \subseteq \ker(\operatorname{tr}_C\rho)\)
+that transfers the support condition to the marginals. -/
+
+section PartialTraceAlgebra
+
+variable {α β : Type*} [Fintype β]
+
+/-- The partial trace over the second factor is additive. -/
+theorem partialTraceRight_add (X Y : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight (X + Y) = partialTraceRight X + partialTraceRight Y := by
+  ext i j; simp [partialTraceRight_apply, Finset.sum_add_distrib]
+
+/-- The partial trace over the second factor commutes with real scalar
+multiplication. -/
+theorem partialTraceRight_real_smul (c : ℝ) (X : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight (c • X) = c • partialTraceRight X := by
+  ext i j; simp [partialTraceRight_apply, Finset.smul_sum]
+
+variable [DecidableEq α] [DecidableEq β]
+
+/-- The partial trace of the identity is the cardinality of the traced factor
+times the identity on the retained factor:
+\(\operatorname{tr}_\beta\mathbf 1 = |\beta|\,\mathbf 1\). -/
+theorem partialTraceRight_one :
+    partialTraceRight (1 : Matrix (α × β) (α × β) ℂ)
+      = (Fintype.card β : ℂ) • (1 : Matrix α α ℂ) := by
+  ext i j
+  simp only [partialTraceRight_apply, Matrix.one_apply, Prod.mk.injEq, Matrix.smul_apply,
+    smul_eq_mul]
+  by_cases hij : i = j
+  · subst hij; simp
+  · simp [hij]
+
+end PartialTraceAlgebra
+
+section MarginalSupport
+
+variable {α β : Type*} [Fintype α] [Fintype β] [DecidableEq β]
+
+/-- The lift of a system vector \(w\) into the joint space, supported on a single
+ancilla index \(c\): \((s, c') \mapsto w_s\) if \(c' = c\), else \(0\). -/
+def liftVec (w : α → ℂ) (c : β) : α × β → ℂ := fun p => if p.2 = c then w p.1 else 0
+
+/-- The matrix-vector product against a single-ancilla lift, evaluated at a joint
+index, collapses the ancilla sum to the fixed ancilla index. -/
+theorem mulVec_liftVec_apply (σ : Matrix (α × β) (α × β) ℂ) (w : α → ℂ) (c : β)
+    (p : α × β) :
+    σ.mulVec (liftVec w c) p = ∑ s₂ : α, σ p (s₂, c) * w s₂ := by
+  classical
+  rw [Matrix.mulVec, dotProduct, Fintype.sum_prod_type]
+  refine Finset.sum_congr rfl fun s₂ _ => ?_
+  rw [Finset.sum_eq_single c]
+  · simp [liftVec]
+  · intro c₂ _ hc₂; simp [liftVec, hc₂]
+  · intro h; exact absurd (Finset.mem_univ c) h
+
+/-- **Quadratic-form split for the marginal.** The marginal quadratic form
+\(w^\dagger(\operatorname{tr}_\beta\sigma)w\) is the ancilla sum of the joint
+quadratic forms against the single-ancilla lifts of \(w\). -/
+theorem qform_partialTraceRight_split (σ : Matrix (α × β) (α × β) ℂ) (w : α → ℂ) :
+    star w ⬝ᵥ (partialTraceRight σ).mulVec w
+      = ∑ c : β, star (liftVec w c) ⬝ᵥ σ.mulVec (liftVec w c) := by
+  classical
+  have hRHS : ∀ c : β, star (liftVec w c) ⬝ᵥ σ.mulVec (liftVec w c)
+      = ∑ s₁ : α, ∑ s₂ : α, star (w s₁) * σ (s₁, c) (s₂, c) * w s₂ := by
+    intro c
+    rw [dotProduct, Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl fun s₁ _ => ?_
+    rw [Finset.sum_eq_single c]
+    · rw [mulVec_liftVec_apply, Finset.mul_sum]
+      refine Finset.sum_congr rfl fun s₂ _ => ?_
+      simp only [Pi.star_apply, liftVec, if_true]
+      ring
+    · intro c₁ _ hc₁
+      simp only [Pi.star_apply, liftVec, if_neg hc₁, star_zero, zero_mul]
+    · intro h; exact absurd (Finset.mem_univ c) h
+  rw [Finset.sum_congr rfl fun c (_ : c ∈ Finset.univ) => hRHS c]
+  have hLHS : star w ⬝ᵥ (partialTraceRight σ).mulVec w
+      = ∑ s₁ : α, ∑ s₂ : α, ∑ c : β, star (w s₁) * σ (s₁, c) (s₂, c) * w s₂ := by
+    rw [dotProduct]
+    refine Finset.sum_congr rfl fun s₁ _ => ?_
+    rw [Matrix.mulVec, dotProduct, Pi.star_apply, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun s₂ _ => ?_
+    rw [partialTraceRight_apply, Finset.sum_mul, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun c _ => ?_
+    ring
+  rw [hLHS]
+  rw [show (∑ s₁ : α, ∑ s₂ : α, ∑ c : β, star (w s₁) * σ (s₁, c) (s₂, c) * w s₂)
+        = ∑ s₁ : α, ∑ c : β, ∑ s₂ : α, star (w s₁) * σ (s₁, c) (s₂, c) * w s₂ from
+      Finset.sum_congr rfl fun s₁ _ => Finset.sum_comm]
+  rw [Finset.sum_comm]
+
+omit [DecidableEq β] in
+/-- **Bipartite marginal support.** For positive semidefinite \(\rho, \sigma\) on a
+bipartite index with \(\ker\sigma \subseteq \ker\rho\), the support condition
+transfers to the marginals over the second factor:
+\(\ker(\operatorname{tr}_\beta\sigma) \subseteq \ker(\operatorname{tr}_\beta\rho)\).
+
+A vector \(w\) in \(\ker(\operatorname{tr}_\beta\sigma)\) has vanishing marginal
+quadratic form, which splits (`qform_partialTraceRight_split`) into the nonnegative
+joint quadratic forms of its single-ancilla lifts; each therefore vanishes, so
+\(\sigma\) annihilates every lift, hence so does \(\rho\) by the support condition,
+and reassembling the ancilla sum shows \(\operatorname{tr}_\beta\rho\) annihilates
+\(w\). This is the bipartite analogue of `Matrix.marginal_support`. -/
+theorem partialTraceRight_support
+    {ρ σ : Matrix (α × β) (α × β) ℂ} (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : α × β → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0)
+    {w : α → ℂ} (hw : (partialTraceRight σ).mulVec w = 0) :
+    (partialTraceRight ρ).mulVec w = 0 := by
+  classical
+  have hσlift : ∀ c : β, σ.mulVec (liftVec w c) = 0 := by
+    have hqsum : star w ⬝ᵥ (partialTraceRight σ).mulVec w = 0 := by
+      rw [hw, dotProduct_zero]
+    rw [qform_partialTraceRight_split] at hqsum
+    have hnn : ∀ c : β, (0 : ℂ) ≤ star (liftVec w c) ⬝ᵥ σ.mulVec (liftVec w c) :=
+      fun c => hσ.dotProduct_mulVec_nonneg _
+    intro c
+    refine (hσ.dotProduct_mulVec_zero_iff (liftVec w c)).mp ?_
+    exact (Finset.sum_eq_zero_iff_of_nonneg fun c _ => hnn c).mp hqsum c (Finset.mem_univ c)
+  have hρlift : ∀ c : β, ρ.mulVec (liftVec w c) = 0 := fun c => hsupp _ (hσlift c)
+  funext s₁
+  have hval : (partialTraceRight ρ).mulVec w s₁
+      = ∑ c : β, ρ.mulVec (liftVec w c) (s₁, c) := by
+    rw [Matrix.mulVec, dotProduct]
+    simp only [partialTraceRight_apply, Finset.sum_mul]
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun c _ => ?_
+    rw [mulVec_liftVec_apply]
+  rw [hval, Pi.zero_apply]
+  refine Finset.sum_eq_zero fun c _ => ?_
+  rw [hρlift c]; rfl
+
+end MarginalSupport
 
 /-! ## Unitarity of the Weyl operators -/
 
@@ -395,9 +553,11 @@ pairs (`sum_kronecker_one_weyl_conj`). Joint convexity
 the per-term relative entropies, each equal to $D(\rho \,\|\, \sigma)$ by unitary
 invariance (`quantumRelativeEntropy_conj_unitary`); the weights sum to one.
 
-**Scope restriction (positive-definite domain):** the source inequality holds for
-density operators with $\ker \sigma \subseteq \ker \rho$; here $\rho, \sigma$ are
-restricted to positive definite matrices. Recorded in
+This is the positive-definite base case. The source inequality on the singular
+support domain $\ker \sigma \subseteq \ker \rho$ is
+`quantumRelativeEntropy_partialTraceRight_le_support`, derived from this base case
+by regularizing both arguments and passing to the limit, so this lemma keeps its
+standalone twirl-and-convexity proof. Recorded in
 `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`, layer 5. -/
 theorem quantumRelativeEntropy_partialTraceRight_le
     {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
@@ -479,6 +639,126 @@ theorem quantumRelativeEntropy_partialTraceRight_le
     rw [← Finset.sum_smul, hwsum, one_smul]
   rw [← hLHS, ← hRHS]
   exact hjensen
+
+/-! ## The singular support domain -/
+
+/-- **The marginal of an affine regularization is an affine regularization of the
+marginal.** The partial trace of the unit-shift affine regularization
+\((1 + a\varepsilon)^{-1}(\rho + \varepsilon\mathbf 1_{\alpha\times\beta})\) is the
+affine regularization of the marginal with shift rate the traced cardinality:
+\((1 + a\varepsilon)^{-1}(\operatorname{tr}_\beta\rho
++ |\beta|\varepsilon\,\mathbf 1_\alpha)\). The scalar weight is shared, but the
+identity shrinks to \(\mathbf 1_\alpha\) and the additive shift scales by \(|\beta|\),
+so the both-arguments limit lemma does not apply to the marginal verbatim, only
+through the generalized affine perturbation. -/
+theorem partialTraceRight_regPerturbAffine {α β : Type*} [Fintype β]
+    [DecidableEq α] [DecidableEq β] (a ε : ℝ) (ρ : Matrix (α × β) (α × β) ℂ) :
+    partialTraceRight (regPerturbAffine a 1 ε ρ)
+      = regPerturbAffine a (Fintype.card β) ε (partialTraceRight ρ) := by
+  rw [regPerturbAffine, regPerturbAffine, partialTraceRight_real_smul, partialTraceRight_add,
+    partialTraceRight_real_smul, partialTraceRight_one]
+  congr 2
+  ext i j
+  simp only [Matrix.smul_apply, smul_eq_mul, Matrix.one_apply]
+  by_cases hij : i = j
+  · subst hij
+    simp only [if_true, mul_one, Complex.real_smul, Complex.ofReal_mul]
+    push_cast; ring
+  · simp [hij]
+
+open scoped Topology
+open Filter
+
+/-- **Data-processing inequality on the singular support domain.** For density
+matrices \(\rho, \sigma\) (positive semidefinite, unit trace) on a tensor product
+of a system factor and an ancilla factor with the kernel inclusion
+\(\ker\sigma \subseteq \ker\rho\),
+\[
+  D(\operatorname{tr}_C\rho \,\|\, \operatorname{tr}_C\sigma)
+    \le D(\rho \,\|\, \sigma),
+\]
+where \(\operatorname{tr}_C\) is the partial trace over the ancilla factor.
+
+This extends `quantumRelativeEntropy_partialTraceRight_le` from the positive
+definite domain to all density-matrix pairs of finite relative entropy. Both
+arguments are regularized through the affine trace-shrinking perturbation
+\(M_\varepsilon = (1 + N_{SC}\varepsilon)^{-1}(M + \varepsilon\mathbf 1_{SC})\),
+which is positive definite for \(\varepsilon > 0\), so the positive-definite
+inequality applies at each \(\varepsilon\). The right-hand side converges to
+\(D(\rho\|\sigma)\) by the both-arguments limit
+`TNLean.RelativeEntropyConvexity.tendsto_relativeEntropyPerturbAffine` at scaling
+rate \(N_{SC}\) and shift rate \(1\); the left-hand side is the relative entropy of
+the marginals \((1 + N_{SC}\varepsilon)^{-1}(\operatorname{tr}_C M
++ d_C\varepsilon\,\mathbf 1_S)\) (`partialTraceRight_regPerturbAffine`), which is the
+affine regularization at scaling rate \(N_{SC}\) and shift rate \(d_C\), so the same
+limit lemma applies once the support condition is transferred to the marginals by
+`partialTraceRight_support`. The empty system factor \(d_S = 0\) makes both relative
+entropies vanish and is handled separately.
+
+Source: Lieb concavity route, layer 5 of
+`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`; blueprint theorem
+thm:relative_entropy_data_processing_support. -/
+theorem quantumRelativeEntropy_partialTraceRight_le_support
+    {ρ σ : Matrix (Fin dS × ZMod dC) (Fin dS × ZMod dC) ℂ}
+    (hρ : ρ.PosSemidef) (hσ : σ.PosSemidef)
+    (hsupp : ∀ v : Fin dS × ZMod dC → ℂ, σ.mulVec v = 0 → ρ.mulVec v = 0) :
+    quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ)
+      ≤ quantumRelativeEntropy ρ σ := by
+  classical
+  rcases eq_or_ne dS 0 with hdS0 | hdS0
+  · -- the system factor is empty: both relative entropies vanish
+    subst hdS0
+    have hempty : ∀ A B : Matrix (Fin 0 × ZMod dC) (Fin 0 × ZMod dC) ℂ,
+        quantumRelativeEntropy A B = 0 := by
+      intro A B; rw [quantumRelativeEntropy]; simp [Matrix.trace, Finset.univ_eq_empty]
+    have hempty' : ∀ A B : Matrix (Fin 0) (Fin 0) ℂ, quantumRelativeEntropy A B = 0 := by
+      intro A B; rw [quantumRelativeEntropy]; simp [Matrix.trace, Finset.univ_eq_empty]
+    rw [hempty' _ _, hempty _ _]
+  haveI : NeZero dS := ⟨hdS0⟩
+  set Nsc : ℕ := Fintype.card (Fin dS × ZMod dC) with hNsc
+  have hNsc_pos : (0 : ℝ) < Nsc := by rw [hNsc]; exact_mod_cast Fintype.card_pos
+  have hdC_pos : (0 : ℝ) < Fintype.card (ZMod dC) := by
+    have : 0 < Fintype.card (ZMod dC) := Fintype.card_pos
+    exact_mod_cast this
+  -- marginal support: ker (tr_C σ) ⊆ ker (tr_C ρ)
+  have hsuppM : ∀ w : Fin dS → ℂ, (partialTraceRight σ).mulVec w = 0
+      → (partialTraceRight ρ).mulVec w = 0 :=
+    fun w hw => partialTraceRight_support hσ hsupp hw
+  -- positive-definite base inequality for the affine regularizations at each ε > 0
+  have hbase : ∀ ε : ℝ, 0 < ε →
+      quantumRelativeEntropy (partialTraceRight (regPerturbAffine Nsc 1 ε ρ))
+          (partialTraceRight (regPerturbAffine Nsc 1 ε σ))
+        ≤ quantumRelativeEntropy (regPerturbAffine Nsc 1 ε ρ) (regPerturbAffine Nsc 1 ε σ) := by
+    intro ε hε
+    exact quantumRelativeEntropy_partialTraceRight_le
+      (regPerturbAffine_posDef hNsc_pos one_pos hε hρ)
+      (regPerturbAffine_posDef hNsc_pos one_pos hε hσ)
+  -- right-hand side limit via the affine both-arguments limit (scaling Nsc, shift 1)
+  have hRHS_lim : Tendsto (fun ε : ℝ =>
+      quantumRelativeEntropy (regPerturbAffine Nsc 1 ε ρ) (regPerturbAffine Nsc 1 ε σ))
+      (𝓝[>] 0) (𝓝 (quantumRelativeEntropy ρ σ)) :=
+    tendsto_relativeEntropyPerturbAffine hNsc_pos one_pos hρ hσ hsupp
+  -- left-hand side limit: the marginal is an affine regularization (scaling Nsc, shift d_C)
+  have hLHS_lim : Tendsto (fun ε : ℝ =>
+      quantumRelativeEntropy (partialTraceRight (regPerturbAffine Nsc 1 ε ρ))
+        (partialTraceRight (regPerturbAffine Nsc 1 ε σ)))
+      (𝓝[>] 0) (𝓝 (quantumRelativeEntropy (partialTraceRight ρ) (partialTraceRight σ))) := by
+    have hcongr : (fun ε : ℝ =>
+        quantumRelativeEntropy (partialTraceRight (regPerturbAffine Nsc 1 ε ρ))
+          (partialTraceRight (regPerturbAffine Nsc 1 ε σ)))
+        = (fun ε : ℝ =>
+          quantumRelativeEntropy
+            (regPerturbAffine Nsc (Fintype.card (ZMod dC)) ε (partialTraceRight ρ))
+            (regPerturbAffine Nsc (Fintype.card (ZMod dC)) ε (partialTraceRight σ))) := by
+      funext ε
+      rw [partialTraceRight_regPerturbAffine, partialTraceRight_regPerturbAffine]
+    rw [hcongr]
+    exact tendsto_relativeEntropyPerturbAffine hNsc_pos hdC_pos
+      hρ.partialTraceRight hσ.partialTraceRight hsuppM
+  -- pass the inequality through both limits
+  refine le_of_tendsto_of_tendsto hLHS_lim hRHS_lim ?_
+  filter_upwards [self_mem_nhdsWithin] with ε hε
+  exact hbase ε hε
 
 end DataProcessing
 

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -689,9 +689,9 @@ finite-dimensional quantum systems.
     \leanok
     \uses{def:quantum_relative_entropy, thm:relative_entropy_data_processing,
         thm:relative_entropy_joint_convexity_support}
-    For density matrices $\rho, \sigma$ (positive semidefinite, unit trace) on a
-    tensor product of a system factor and an ancilla factor of dimension $d_C$, with
-    the support condition $\ker \sigma \subseteq \ker \rho$,
+    For positive semidefinite $\rho, \sigma$ on a tensor product of a system factor
+    and an ancilla factor of dimension $d_C$, with the support condition
+    $\ker \sigma \subseteq \ker \rho$,
     \[
         D(\tr_C \rho \,\Vert\, \tr_C \sigma) \le D(\rho \,\Vert\, \sigma),
     \]

--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -657,11 +657,10 @@ finite-dimensional quantum systems.
     \[
         D(\tr_C \rho \,\Vert\, \tr_C \sigma) \le D(\rho \,\Vert\, \sigma),
     \]
-    where $\tr_C$ is the partial trace over the ancilla factor. (Scope
-    restriction: the source inequality holds for density operators with
-    $\ker \sigma \subseteq \ker \rho$; here both arguments are positive definite.
-    Recorded in the relative-entropy elimination route note for strong
-    subadditivity.)
+    where $\tr_C$ is the partial trace over the ancilla factor. This is the
+    positive-definite base case; the source inequality on the support domain
+    $\ker \sigma \subseteq \ker \rho$ is
+    Theorem~\ref{thm:relative_entropy_data_processing_support}.
 \end{theorem}
 
 \begin{proof}\leanok
@@ -682,6 +681,64 @@ finite-dimensional quantum systems.
     $D(\rho \,\Vert\, \sigma)$ by unitary invariance
     (Theorem~\ref{thm:relative_entropy_unitary_invariance}). As the weights sum to
     one, the bound is $D(\rho \,\Vert\, \sigma)$.
+\end{proof}
+
+\begin{theorem}[Data-processing inequality on the support domain]
+    \label{thm:relative_entropy_data_processing_support}
+    \lean{Matrix.quantumRelativeEntropy_partialTraceRight_le_support}
+    \leanok
+    \uses{def:quantum_relative_entropy, thm:relative_entropy_data_processing,
+        thm:relative_entropy_joint_convexity_support}
+    For density matrices $\rho, \sigma$ (positive semidefinite, unit trace) on a
+    tensor product of a system factor and an ancilla factor of dimension $d_C$, with
+    the support condition $\ker \sigma \subseteq \ker \rho$,
+    \[
+        D(\tr_C \rho \,\Vert\, \tr_C \sigma) \le D(\rho \,\Vert\, \sigma),
+    \]
+    where $\tr_C$ is the partial trace over the ancilla factor.
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:relative_entropy_data_processing,
+        thm:relative_entropy_joint_convexity_support}
+    Let $N$ be the dimension of the joint space. Regularize both arguments through
+    the affine trace-shrinking perturbation
+    $M_\varepsilon = (1+N\varepsilon)^{-1}(M+\varepsilon\,\mathbf 1)$, which is
+    positive definite for every $\varepsilon>0$, so the positive-definite
+    data-processing inequality
+    (Theorem~\ref{thm:relative_entropy_data_processing}) gives
+    \[
+        D(\tr_C \rho_\varepsilon \,\Vert\, \tr_C \sigma_\varepsilon)
+            \le D(\rho_\varepsilon \,\Vert\, \sigma_\varepsilon),
+        \qquad \varepsilon > 0.
+    \]
+    The right-hand side converges to $D(\rho \,\Vert\, \sigma)$ as
+    $\varepsilon\to0^+$, by the same shared-eigenbasis scalar-limit argument as the
+    joint convexity on the support domain
+    (Theorem~\ref{thm:relative_entropy_joint_convexity_support}).
+
+    For the left-hand side, the partial trace of the regularization is a
+    differently-scaled regularization of the marginal: because the partial trace is
+    linear and $\tr_C \mathbf 1 = d_C\,\mathbf 1$,
+    \[
+        \tr_C\bigl((1+N\varepsilon)^{-1}(M+\varepsilon\,\mathbf 1)\bigr)
+            = (1+N\varepsilon)^{-1}\bigl(\tr_C M + d_C\varepsilon\,\mathbf 1\bigr),
+    \]
+    the affine regularization of $\tr_C M$ with the same scaling rate $N$ but shift
+    rate $d_C$ and the smaller identity on the system factor. The support condition
+    transfers to the marginals,
+    $\ker(\tr_C \sigma) \subseteq \ker(\tr_C \rho)$: a vector annihilated by
+    $\tr_C \sigma$ has vanishing marginal quadratic form, which splits into the
+    nonnegative joint quadratic forms of its single-ancilla lifts, so each lift lies
+    in $\ker \sigma$, hence in $\ker \rho$, and reassembling the ancilla sum shows
+    the vector lies in $\ker(\tr_C \rho)$. With this support condition the
+    arbitrary-rate affine regularization has the same both-arguments limit, so
+    \[
+        D(\tr_C \rho_\varepsilon \,\Vert\, \tr_C \sigma_\varepsilon)
+            \to D(\tr_C \rho \,\Vert\, \tr_C \sigma),
+        \qquad \varepsilon\to0^+.
+    \]
+    Passing the inequality through the two limits gives the support-domain bound.
 \end{proof}
 
 \begin{theorem}[Entropy is invariant under reindexing]

--- a/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
+++ b/docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex
@@ -304,7 +304,23 @@ in place. Concretely:
     relative entropy, the twirling identity, joint convexity over the $d_C^2$
     equally weighted conjugated pairs, and unitary invariance of each term. The
     transport of joint convexity to the product index uses the reindexing
-    invariance \leanid{quantumRelativeEntropy_submatrix_equiv}.
+    invariance \leanid{quantumRelativeEntropy_submatrix_equiv}. The extension to
+    the singular support domain $\ker\sigma\subseteq\ker\rho$ is now formalized as
+    \leanid{quantumRelativeEntropy_partialTraceRight_le_support} in the same file:
+    both arguments are regularized through the affine trace-shrinking perturbation
+    $M_\varepsilon = (1+N_{SC}\varepsilon)^{-1}(M+\varepsilon\,\mathbf 1)$, which is
+    positive definite for $\varepsilon>0$, so the positive-definite case applies at
+    each $\varepsilon$. The right-hand side converges to $D(\rho\,\|\,\sigma)$ by
+    the both-arguments limit. The left-hand side is the relative entropy of the
+    marginals, which are themselves affine regularizations of $\tr_C\rho,\tr_C\sigma$
+    with the same scaling rate $N_{SC}$ but shift rate $d_C$
+    (\leanid{partialTraceRight_regPerturbAffine}); the support condition transfers to
+    the marginals (\leanid{Matrix.partialTraceRight_support}), so the same limit
+    applies once it is generalized to an arbitrary positive-affine regularization
+    $M\mapsto(1+a\varepsilon)^{-1}(M+b\varepsilon\,\mathbf 1)$
+    (\leanid{TNLean.RelativeEntropyConvexity.tendsto_relativeEntropyPerturbAffine}).
+    Passing the inequality through both limits gives the support-domain bound. This
+    extension consumes no further Lieb input beyond the positive-definite base case.
   \item Layer (6) instantiates layer (5) at the tripartite splitting to
     recover~\eqref{eq:ssa}; it additionally needs the marginal support
     lemma~\eqref{eq:marginal-support}, which puts the singular reference state
@@ -331,19 +347,21 @@ in place. Concretely:
     domain condition holds outright; the relative entropy of each pair evaluates
     to the displayed entropy difference through the tensor logarithm split and the
     partial-trace adjoint, and layer (5) data processing between the two pairs
-    yields~\eqref{eq:ssa}. The marginal support lemma is the prerequisite of the
+    yields~\eqref{eq:ssa}. With layer (5) now formalized on the singular support
+    domain, the marginal support lemma is the one remaining ingredient of the
     singular-reference extension of this instantiation to the general
-    density-matrix domain, which remains open.
+    density-matrix domain, which remains open: it places the singular reference
+    state $(\mathbf 1_A/d_A)\otimes\rho_{BC}$ in the domain of layer (2), after
+    which the singular-domain data processing applies directly.
 \end{itemize}
 
 \paragraph{Current formal status.} Layers (1)--(5) and the layer-(6) marginal
-support prerequisite are formalized; layer (4) on the full support domain and
-layer (5) on the positive-definite domain. Layer (4) joint convexity is now
-formalized on the singular support domain $\ker\sigma\subseteq\ker\rho$
-(\leanid{convexOn_quantumRelativeEntropy_support}), extending the
-positive-definite base case by regularizing both arguments and passing to the
-limit. Layer (5), data-processing (monotonicity of $D$ under the partial trace),
-combines the layer-(4) joint convexity with unitary invariance and
+support prerequisite are formalized; layers (3), (4), and (5) on the full support
+domain. Layer (4) joint convexity is formalized on the singular support domain
+$\ker\sigma\subseteq\ker\rho$ (\leanid{convexOn_quantumRelativeEntropy_support}),
+extending the positive-definite base case by regularizing both arguments and
+passing to the limit. Layer (5), data-processing (monotonicity of $D$ under the
+partial trace), combines the layer-(4) joint convexity with unitary invariance and
 ancilla-additivity $D(\rho\otimes\tau\,\|\,\sigma\otimes\tau) =
 D(\rho\,\|\,\sigma)$ via the twirling representation of $\tr_C$. Joint convexity
 (layer 4, on the singular support domain), unitary invariance
@@ -352,18 +370,25 @@ arguments), ancilla-additivity
 (\leanid{quantumRelativeEntropy_kronecker}, on the positive-definite domain), the
 finite Heisenberg--Weyl $1$-design twirl (\leanid{Matrix.sum_weyl_conj}), and its
 ancilla-factor lift presenting $\tr_C$ through the twirl
-(\leanid{Matrix.sum_kronecker_one_weyl_conj}) are formalized, and combine into the
-partial-trace monotonicity
-\leanid{quantumRelativeEntropy_partialTraceRight_le} on the positive-definite
-domain. The layer-(6) instantiation is now formalized on the positive-definite
-domain (\leanid{strong_subadditivity_posDef}): for a positive definite
-$\rho_{ABC}$ the inequality~\eqref{eq:ssa} is a theorem whose only entropy-side
-axiom is the Lieb-concavity axiom. The standalone axiom
-\leanid{strong_subadditivity} stands for the general density-matrix domain,
-because the positive-definite version is a strictly stronger hypothesis and does
-not discharge the unrestricted axiom; with layers (3) and (4) now on the full
-support domain, closing that gap needs the singular-reference extension of layer
-(5) and of the instantiation.
+(\leanid{Matrix.sum_kronecker_one_weyl_conj}) combine into the partial-trace
+monotonicity \leanid{quantumRelativeEntropy_partialTraceRight_le} on the
+positive-definite domain, which is then extended to the singular support domain
+$\ker\sigma\subseteq\ker\rho$ as
+\leanid{quantumRelativeEntropy_partialTraceRight_le_support} by regularizing both
+arguments, transferring the support condition to the marginals
+(\leanid{Matrix.partialTraceRight_support}), and passing to the limit through the
+arbitrary-rate affine regularization
+(\leanid{TNLean.RelativeEntropyConvexity.tendsto_relativeEntropyPerturbAffine}).
+The layer-(6) instantiation is formalized on the positive-definite domain
+(\leanid{strong_subadditivity_posDef}): for a positive definite $\rho_{ABC}$ the
+inequality~\eqref{eq:ssa} is a theorem whose only entropy-side axiom is the
+Lieb-concavity axiom. The standalone axiom \leanid{strong_subadditivity} stands
+for the general density-matrix domain, because the positive-definite version is a
+strictly stronger hypothesis and does not discharge the unrestricted axiom; with
+layers (3), (4), and (5) now on the full support domain, closing that gap needs
+only the singular-reference extension of the instantiation, whose missing
+ingredient is placing the singular reference state in the layer-(2) domain by the
+marginal support lemma.
 
 After the singular-reference extension the inequality is a theorem on the full
 density-matrix domain, the standalone axiom is removed, and the only remaining
@@ -390,23 +415,29 @@ the same full support domain: the positive-definite base case
 $\ker\sigma\subseteq\ker\rho$ by \leanid{convexOn_quantumRelativeEntropy_support}
 through the both-arguments regularization, so the Lieb-concavity axiom is now
 connected to the joint convexity of the relative entropy on the full support
-domain. Layer (5), data-processing, is formalized on the positive-definite
-domain (\leanid{quantumRelativeEntropy_partialTraceRight_le}): its unitary
-invariance (\leanid{quantumRelativeEntropy_conj_unitary}), ancilla additivity
-(\leanid{quantumRelativeEntropy_kronecker}), finite Heisenberg--Weyl $1$-design
-twirl (\leanid{Matrix.sum_weyl_conj}), and the ancilla-factor lift presenting
-$\tr_C$ through the twirl (\leanid{Matrix.sum_kronecker_one_weyl_conj}) combine
-through joint convexity into the partial-trace monotonicity
-$D(\tr_C\rho\,\|\,\tr_C\sigma)\le D(\rho\,\|\,\sigma)$. The layer-(6)
-instantiation is formalized on the positive-definite domain
-(\leanid{strong_subadditivity_posDef}): for a positive definite $\rho_{ABC}$ the
-inequality follows from data processing alone, with the positive-definite
-reference state $(\mathbf 1_A/d_A)\otimes\rho_{BC}$ sidestepping the marginal
-support lemma. With layers (3) and (4) now on the full support domain, the
-remaining work is the singular-$\sigma$ extension of layer (5) and of the
+domain. Layer (5), data-processing, is formalized on the full support domain: the
+positive-definite case (\leanid{quantumRelativeEntropy_partialTraceRight_le})
+combines unitary invariance (\leanid{quantumRelativeEntropy_conj_unitary}), ancilla
+additivity (\leanid{quantumRelativeEntropy_kronecker}), the finite
+Heisenberg--Weyl $1$-design twirl (\leanid{Matrix.sum_weyl_conj}), and the
+ancilla-factor lift presenting $\tr_C$ through the twirl
+(\leanid{Matrix.sum_kronecker_one_weyl_conj}) through joint convexity into the
+partial-trace monotonicity $D(\tr_C\rho\,\|\,\tr_C\sigma)\le D(\rho\,\|\,\sigma)$,
+and the singular extension under $\ker\sigma\subseteq\ker\rho$
+(\leanid{quantumRelativeEntropy_partialTraceRight_le_support}) follows by
+regularizing both arguments, transferring the support condition to the marginals
+(\leanid{Matrix.partialTraceRight_support}), and passing to the limit through the
+arbitrary-rate affine regularization. The layer-(6) instantiation is formalized on
+the positive-definite domain (\leanid{strong_subadditivity_posDef}): for a positive
+definite $\rho_{ABC}$ the inequality follows from data processing alone, with the
+positive-definite reference state $(\mathbf 1_A/d_A)\otimes\rho_{BC}$ sidestepping
+the marginal support lemma. With layers (3), (4), and (5) now on the full support
+domain, the remaining work is the singular-reference extension of the
 instantiation, which lifts the result from positive definite $\rho_{ABC}$ to a
-general density matrix; until that is formalized, the standalone axiom records the
-unrestricted statement that the development assumes but does not yet derive from
+general density matrix by placing the singular reference state in the layer-(2)
+domain through the marginal support lemma; until that is formalized, the standalone
+axiom records the unrestricted statement that the development assumes but does not
+yet derive from
 its operator-convexity input.
 
 \begin{thebibliography}{9}


### PR DESCRIPTION
## Summary

Extends the partial-trace data-processing inequality for the quantum relative entropy from positive definite states to the **singular support domain** `ker σ ⊆ ker ρ`. This is **layer (5)** of the sanctioned `strong_subadditivity` axiom elimination route (`docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`), building on the limit machinery landed in #3525 and #3530.

**Target theorem** (`Matrix.quantumRelativeEntropy_partialTraceRight_le_support`):
for `ρ σ : Matrix (Fin dS × ZMod dC) ... ℂ` that are PSD, trace-one, with `∀ v, σ.mulVec v = 0 → ρ.mulVec v = 0`,
```
D(tr_C ρ ‖ tr_C σ) ≤ D(ρ ‖ σ).
```
The hypotheses are the source's support condition; no extra hypotheses are smuggled in.

## Technique: regularize and pass to the limit

For each `ε > 0` both arguments are regularized by the affine trace-shrinking perturbation `M_ε = (1+N_SC·ε)⁻¹(M + ε•1)`, which is positive definite, so the existing positive-definite base case `quantumRelativeEntropy_partialTraceRight_le` (#3532 area) gives the inequality at every `ε`. The inequality is then passed through two limits as `ε → 0⁺`.

- **RHS limit** `D(ρ_ε ‖ σ_ε) → D(ρ ‖ σ)`: via the new generalized affine-regularization limit (scaling rate `N_SC`, shift rate `1`).
- **LHS limit**: the partial trace of the regularization is a *differently-scaled* regularization of the marginal — `tr_C M_ε = (1+N_SC·ε)⁻¹(tr_C M + d_C·ε•1_S)` — i.e. the affine regularization of `tr_C M` with the same scaling rate `N_SC` but shift rate `d_C` and the smaller identity `1_S`. So the existing fixed-shape limit does **not** apply to marginals verbatim; the generalized lemma does.

## New reusable lemmas

- **`TNLean.RelativeEntropyConvexity.tendsto_relativeEntropyPerturbAffine`** (and its trace-log half `tendsto_re_trace_perturbAffine_mul_log_perturbAffine`, plus `regPerturbAffine`/`regPerturbAffine_posDef`): the both-arguments relative-entropy limit `D((1+aε)⁻¹(P+bε•1) ‖ (1+aε)⁻¹(Q+bε•1)) → D(P ‖ Q)` under `ker Q ⊆ ker P` for arbitrary `a, b > 0` on an arbitrary finite index. The existing `tendsto_relativeEntropyPerturb` is the `a = N, b = 1` instance; this generalization also serves layer (6).
- **`Matrix.partialTraceRight_support`**: the bipartite marginal-support fact `ker(tr_C σ) ⊆ ker(tr_C ρ)`, proved directly via the quadratic-form split of the marginal into the nonnegative joint quadratic forms of single-ancilla lifts (`qform_partialTraceRight_split`), positivity, and the support condition. This is the bipartite analogue of the tripartite `Matrix.marginal_support`.
- **Partial-trace algebra** (`partialTraceRight_add`, `partialTraceRight_real_smul`, `partialTraceRight_one`) and **`Matrix.partialTraceRight_regPerturbAffine`**: the marginal-regularization identity above.

The empty system factor `d_S = 0` is handled as a trivial case (both relative entropies vanish).

## Axiom cleanliness

```
#print axioms Matrix.quantumRelativeEntropy_partialTraceRight_le_support
  -- [lieb_concavity_axiom, propext, Classical.choice, Quot.sound]
```
Lieb enters only through the positive-definite data-processing base case. No `sorry`, no `axiom`, no `strong_subadditivity`. The generalized limit lemma `tendsto_relativeEntropyPerturbAffine` is even cleaner: `[propext, Classical.choice, Quot.sound]`.

## Verification

- `lake build` green (full repo, 9231 jobs).
- `rg "sorry|admit|native_decide|axiom"` clean in the changed Lean files (only the word "axiom" in a docstring).
- `leanblueprint checkdecls` passes; new entry `thm:relative_entropy_data_processing_support` in `ch19_entropy.tex` with faithful `\lean{}`/`\leanok`.
- Blueprint prose checker passes.

## Blueprint / paper-gap

- `ch19_entropy.tex`: new singular-domain theorem; the positive-definite entry now cross-references it (was a scope-restriction note).
- `docs/paper-gaps/cpsv16_ssa_from_lieb_route.tex`: layer (5) updated to the full support domain; the only remaining open work is the layer-(6) singular-reference instantiation.

Tracking context: #3510 (layer 6) and #784 (entropy / SSA core).

Closes #3538

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large formal proofs in entropy/relative-entropy (limit arguments and support transfer); incorrect limits or support lemmas would break downstream SSA elimination, though changes are additive lemmas plus documentation.
> 
> **Overview**
> Extends **layer (5)** of the Lieb/SSA route: `D(tr_C ρ ‖ tr_C σ) ≤ D(ρ ‖ σ)` now holds for positive semidefinite `ρ, σ` with **ker σ ⊆ ker ρ**, not only positive definite states.
> 
> The proof regularizes both arguments with `M_ε = (1 + N_SC·ε)⁻¹(M + ε•1)`, applies the existing positive-definite DPI at each `ε > 0`, then takes `ε → 0⁺`. New machinery includes **`regPerturbAffine`** and **`tendsto_relativeEntropyPerturbAffine`** (arbitrary shift/scaling rates, needed because marginals pick up shift `d_C` via **`partialTraceRight_regPerturbAffine`**), partial-trace algebra lemmas, and **`partialTraceRight_support`** (`ker(tr_C σ) ⊆ ker(tr_C ρ)`). Main theorem: **`Matrix.quantumRelativeEntropy_partialTraceRight_le_support`**.
> 
> Blueprint adds `thm:relative_entropy_data_processing_support`; `cpsv16_ssa_from_lieb_route.tex` records layer (5) on the full support domain—remaining SSA work is the layer-(6) singular-reference tripartite instantiation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066beab520c94d713f8e1f25d2bb5d21f9ee0a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->