### PR TITLE
feat(Channel): T_η complete-positivity endpoint (n = D)

### DIFF
--- a/TNLean/Channel/NPositivityChainStrict.lean
+++ b/TNLean/Channel/NPositivityChainStrict.lean
@@ -415,6 +415,65 @@ theorem isNPositiveMap_tEta_iff [NeZero D] {η : ℝ} (hη : 0 < η) {k : ℕ}
         _ = (D : ℝ)⁻¹ * w := one_mul _
     linarith [h1, h2]
 
+/-- **Wolf eq. (3.11) at the top index `n = D`.**  Since `D`-positivity on
+`M_D(ℂ)` is complete positivity, `T_η` is `D`-positive iff its Choi operator is
+positive semidefinite, and — the maximally entangled vector being the worst
+case — this holds iff `D ≤ η`.  Together with `isNPositiveMap_tEta_iff` (the range
+`1 ≤ k < D`) this completes Wolf's threshold criterion over `k = 1, …, D`. -/
+theorem isNPositiveMap_tEta_card_iff [NeZero D] {η : ℝ} (hη : 0 < η) :
+    IsNPositiveMap D (tEta D η) ↔ (D : ℝ) ≤ η := by
+  classical
+  have hDpos : (0 : ℝ) < D := by exact_mod_cast Nat.pos_of_ne_zero (NeZero.ne D)
+  have hΩself : star (omegaVec D) ⬝ᵥ (omegaVec D) = 1 := by
+    rw [star_omegaVec]; exact omegaVec_dotProduct_self (Nat.pos_of_ne_zero (NeZero.ne D))
+  rw [ChoiJamiolkowski.isNPositiveMap_iff_forall_hasSchmidtRankLE_choiMatrix_quadraticForm_nonneg]
+  constructor
+  · intro hpos
+    have hΩrank : Matrix.HasSchmidtRankLE D (omegaVec D) :=
+      Matrix.hasSchmidtRankLE_iff.mpr (by simpa using Matrix.schmidtRank_le_left (omegaVec D))
+    have hquad := choiMatrix_tEta_quadraticForm (D := D) η (omegaVec D)
+    rw [hΩself] at hquad
+    simp only [Complex.one_re, norm_one, one_pow] at hquad
+    have hval := hpos (omegaVec D) hΩrank
+    rw [hquad, ← Complex.ofReal_zero, Complex.real_le_real] at hval
+    have hcancelη : η⁻¹ * η = 1 := inv_mul_cancel₀ (ne_of_gt hη)
+    have hcancelD : (D : ℝ)⁻¹ * D = 1 := inv_mul_cancel₀ (ne_of_gt hDpos)
+    nlinarith [hval, hcancelη, hcancelD, hη, hDpos, mul_pos hDpos hη]
+  · intro hDη ψ _
+    have hquad := choiMatrix_tEta_quadraticForm (D := D) η ψ
+    rw [hquad, ← Complex.ofReal_zero, Complex.real_le_real]
+    set w : ℝ := (star ψ ⬝ᵥ ψ).re with hwdef
+    have hwnn : 0 ≤ w := by rw [hwdef, dotProduct_star_self_re]; positivity
+    have hcs : ‖star (omegaVec D) ⬝ᵥ ψ‖ ^ 2 ≤ w := by
+      have key : (inner (𝕜 := ℂ) (WithLp.toLp 2 (omegaVec D))
+          (WithLp.toLp 2 ψ : EuclideanSpace ℂ (Fin D × Fin D)) : ℂ)
+          = star (omegaVec D) ⬝ᵥ ψ := by
+        rw [EuclideanSpace.inner_eq_star_dotProduct]; exact dotProduct_comm _ _
+      have hΩn : ‖(WithLp.toLp 2 (omegaVec D) : EuclideanSpace ℂ (Fin D × Fin D))‖ = 1 := by
+        have h2 : ‖(WithLp.toLp 2 (omegaVec D) : EuclideanSpace ℂ (Fin D × Fin D))‖ ^ 2 = 1 := by
+          rw [← @inner_self_eq_norm_sq ℂ]
+          have hii : (inner (𝕜 := ℂ) (WithLp.toLp 2 (omegaVec D))
+              (WithLp.toLp 2 (omegaVec D) : EuclideanSpace ℂ (Fin D × Fin D)) : ℂ)
+              = star (omegaVec D) ⬝ᵥ (omegaVec D) := by
+            rw [EuclideanSpace.inner_eq_star_dotProduct]; exact dotProduct_comm _ _
+          rw [hii, hΩself]; simp
+        nlinarith [norm_nonneg (WithLp.toLp 2 (omegaVec D) : EuclideanSpace ℂ (Fin D × Fin D)), h2]
+      have hψn : ‖(WithLp.toLp 2 ψ : EuclideanSpace ℂ (Fin D × Fin D))‖ ^ 2 = w := by
+        rw [← @inner_self_eq_norm_sq ℂ, hwdef]
+        have hii : (inner (𝕜 := ℂ) (WithLp.toLp 2 ψ)
+            (WithLp.toLp 2 ψ : EuclideanSpace ℂ (Fin D × Fin D)) : ℂ) = star ψ ⬝ᵥ ψ := by
+          rw [EuclideanSpace.inner_eq_star_dotProduct]; exact dotProduct_comm _ _
+        rw [hii]; rfl
+      calc ‖star (omegaVec D) ⬝ᵥ ψ‖ ^ 2
+          = ‖(inner (𝕜 := ℂ) (WithLp.toLp 2 (omegaVec D))
+              (WithLp.toLp 2 ψ : EuclideanSpace ℂ (Fin D × Fin D)) : ℂ)‖ ^ 2 := by rw [key]
+        _ ≤ (‖(WithLp.toLp 2 (omegaVec D) : EuclideanSpace ℂ (Fin D × Fin D))‖
+              * ‖(WithLp.toLp 2 ψ : EuclideanSpace ℂ (Fin D × Fin D))‖) ^ 2 := by
+            gcongr; exact norm_inner_le_norm _ _
+        _ = w := by rw [hΩn, one_mul, hψn]
+    have hinvle : η⁻¹ ≤ (D : ℝ)⁻¹ := by rw [inv_le_inv₀ hη hDpos]; exact hDη
+    nlinarith [hcs, hwnn, hinvle, inv_pos.mpr hη, inv_pos.mpr hDpos]
+
 /-- **Strictness witness for Wolf's chain (3.3).** For `1 ≤ k` with `k + 1 < D`,
 the map `T_η` with `k ≤ η < k + 1` is `k`-positive but not `(k+1)`-positive. -/
 theorem tEta_isNPositiveMap_not_succ [NeZero D] {η : ℝ} {k : ℕ}

--- a/TNLean/Channel/NPositivityChainStrict.lean
+++ b/TNLean/Channel/NPositivityChainStrict.lean
@@ -49,6 +49,9 @@ Choi criterion converts the resulting sign condition into `k`-positivity.
   nonnegative scalar multiple `c • 1` of the identity is `k • c` for `k < card`.
 * `Matrix.isNPositiveMap_tEta_iff` -- **Wolf eq. (3.11):** for `0 < η` and
   `1 ≤ k < D`, the map `T_η` is `k`-positive if and only if `η ≥ k`.
+* `Matrix.isNPositiveMap_tEta_card_iff` -- **Wolf eq. (3.11) at the top index
+  `k = D`:** for `0 < η`, the map `T_η` is `D`-positive (i.e. completely positive)
+  if and only if `η ≥ D`.
 * `Matrix.tEta_isNPositiveMap_not_succ` and
   `Matrix.exists_isNPositiveMap_not_succ` -- the strictness witness: a
   `k`-positive map that is not `(k+1)`-positive, for `1 ≤ k` with `k + 1 < D`.
@@ -415,11 +418,12 @@ theorem isNPositiveMap_tEta_iff [NeZero D] {η : ℝ} (hη : 0 < η) {k : ℕ}
         _ = (D : ℝ)⁻¹ * w := one_mul _
     linarith [h1, h2]
 
-/-- **Wolf eq. (3.11) at the top index `n = D`.**  Since `D`-positivity on
-`M_D(ℂ)` is complete positivity, `T_η` is `D`-positive iff its Choi operator is
-positive semidefinite, and — the maximally entangled vector being the worst
-case — this holds iff `D ≤ η`.  Together with `isNPositiveMap_tEta_iff` (the range
-`1 ≤ k < D`) this completes Wolf's threshold criterion over `k = 1, …, D`. -/
+/-- **Wolf eq. (3.11) at the top index n = D.**  Since D-positivity on M_D(ℂ) is
+complete positivity, T_η is D-positive iff its Choi operator is positive
+semidefinite, and — the maximally entangled vector being the worst case — this
+holds iff D ≤ η.  Together with the lower-range threshold equivalence
+`isNPositiveMap_tEta_iff` (the range 1 ≤ k < D) this completes Wolf's threshold
+criterion over k = 1, …, D. -/
 theorem isNPositiveMap_tEta_card_iff [NeZero D] {η : ℝ} (hη : 0 < η) :
     IsNPositiveMap D (tEta D η) ↔ (D : ℝ) ≤ η := by
   classical
@@ -436,9 +440,8 @@ theorem isNPositiveMap_tEta_card_iff [NeZero D] {η : ℝ} (hη : 0 < η) :
     simp only [Complex.one_re, norm_one, one_pow] at hquad
     have hval := hpos (omegaVec D) hΩrank
     rw [hquad, ← Complex.ofReal_zero, Complex.real_le_real] at hval
-    have hcancelη : η⁻¹ * η = 1 := inv_mul_cancel₀ (ne_of_gt hη)
-    have hcancelD : (D : ℝ)⁻¹ * D = 1 := inv_mul_cancel₀ (ne_of_gt hDpos)
-    nlinarith [hval, hcancelη, hcancelD, hη, hDpos, mul_pos hDpos hη]
+    simp only [mul_one] at hval
+    exact (inv_le_inv₀ hη hDpos).mp (by linarith)
   · intro hDη ψ _
     have hquad := choiMatrix_tEta_quadraticForm (D := D) η ψ
     rw [hquad, ← Complex.ofReal_zero, Complex.real_le_real]

--- a/TNLean/Channel/NPositivityChainStrict.lean
+++ b/TNLean/Channel/NPositivityChainStrict.lean
@@ -50,7 +50,7 @@ Choi criterion converts the resulting sign condition into `k`-positivity.
 * `Matrix.isNPositiveMap_tEta_iff` -- **Wolf eq. (3.11):** for `0 < η` and
   `1 ≤ k < D`, the map `T_η` is `k`-positive if and only if `η ≥ k`.
 * `Matrix.isNPositiveMap_tEta_card_iff` -- **Wolf eq. (3.11) at the top index
-  `k = D`:** for `0 < η`, the map `T_η` is `D`-positive (i.e. completely positive)
+  k = D:** for `0 < η`, the map `T_η` is `D`-positive (i.e. completely positive)
   if and only if `η ≥ D`.
 * `Matrix.tEta_isNPositiveMap_not_succ` and
   `Matrix.exists_isNPositiveMap_not_succ` -- the strictness witness: a
@@ -421,9 +421,8 @@ theorem isNPositiveMap_tEta_iff [NeZero D] {η : ℝ} (hη : 0 < η) {k : ℕ}
 /-- **Wolf eq. (3.11) at the top index n = D.**  Since D-positivity on M_D(ℂ) is
 complete positivity, T_η is D-positive iff its Choi operator is positive
 semidefinite, and — the maximally entangled vector being the worst case — this
-holds iff D ≤ η.  Together with the lower-range threshold equivalence
-`isNPositiveMap_tEta_iff` (the range 1 ≤ k < D) this completes Wolf's threshold
-criterion over k = 1, …, D. -/
+holds iff D ≤ η.  Together with the lower-range threshold equivalence (the range
+1 ≤ k < D) this completes Wolf's threshold criterion over k = 1, …, D. -/
 theorem isNPositiveMap_tEta_card_iff [NeZero D] {η : ℝ} (hη : 0 < η) :
     IsNPositiveMap D (tEta D η) ↔ (D : ℝ) ≤ η := by
   classical

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1455,8 +1455,9 @@ adjacent cones.
     \label{thm:t_eta_threshold_top}
     \lean{Matrix.isNPositiveMap_tEta_card_iff}
     \leanok
-    \uses{def:t_eta, thm:choi_matrix_t_eta}
-    Let $\eta>0$.  Then $T_\eta$ is $D$-positive if and only if $\eta\ge D$.
+    \uses{def:t_eta, thm:choi_matrix_t_eta, thm:schmidt_rank_choi_test_iff}
+    Let $\eta>0$ and $D\ge 1$.  Then $T_\eta$ is $D$-positive if and only if
+    $\eta\ge D$.
     Together with Theorem~\ref{thm:t_eta_threshold} this is
     \cite[Equation~(3.11)]{Wolf2012Quantum} over the full range $1\le k\le D$,
     where the top index $k=D$ is complete positivity.

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1427,10 +1427,9 @@ adjacent cones.
     \uses{def:t_eta, thm:choi_matrix_t_eta, thm:schmidt_rank_choi_test_iff,
         thm:maximal_overlap_schmidt_rank}
     Let $\eta>0$ and $1\le k<D$.  Then $T_\eta$ is $k$-positive if and only if
-    $\eta\ge k$.  This is \cite[Equation~(3.11)]{Wolf2012Quantum}, stated here for
-    $1\le k<D$; the top index $k=D$, where $k$-positivity is complete positivity,
-    lies outside the range of the maximal-overlap principle in
-    Theorem~\ref{thm:maximal_overlap_schmidt_rank}.
+    $\eta\ge k$.  This is \cite[Equation~(3.11)]{Wolf2012Quantum} for $1\le k<D$;
+    the top index $k=D$, where $k$-positivity is complete positivity, is
+    Theorem~\ref{thm:t_eta_threshold_top}.
 \end{theorem}
 
 \begin{proof}
@@ -1450,6 +1449,28 @@ adjacent cones.
     which is nonnegative precisely when $\eta\ge k$.  Degree-two homogeneity
     extends the bound from normalized vectors to all vectors of Schmidt rank at
     most $k$.
+\end{proof}
+
+\begin{theorem}[Positivity threshold of $T_\eta$ at the top index]
+    \label{thm:t_eta_threshold_top}
+    \lean{Matrix.isNPositiveMap_tEta_card_iff}
+    \leanok
+    \uses{def:t_eta, thm:choi_matrix_t_eta}
+    Let $\eta>0$.  Then $T_\eta$ is $D$-positive if and only if $\eta\ge D$.
+    Together with Theorem~\ref{thm:t_eta_threshold} this is
+    \cite[Equation~(3.11)]{Wolf2012Quantum} over the full range $1\le k\le D$,
+    where the top index $k=D$ is complete positivity.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    On $M_D(\mathbb C)$, $D$-positivity is complete positivity, which is
+    positive semidefiniteness of the Choi operator
+    $\tau_\eta=D^{-1}\Id-\eta^{-1}\ket{\Omega}\bra{\Omega}$.  Its quadratic form on
+    a vector $\psi$ is $D^{-1}\|\psi\|^2-\eta^{-1}|\braket{\Omega}{\psi}|^2$; since
+    $\ket\Omega$ is normalized, Cauchy--Schwarz gives
+    $|\braket{\Omega}{\psi}|^2\le\|\psi\|^2$ with equality at $\psi=\Omega$, so the
+    form is nonnegative for all $\psi$ precisely when $\eta\ge D$.
 \end{proof}
 
 \begin{corollary}[Strictness of the positivity chain]

--- a/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
@@ -87,16 +87,15 @@ The formal declarations are
 
 \section{Classification}
 
-\emph{Scope restriction.} The formal threshold proves the source
-equivalence~(3.11) for Schmidt ranks $1\le k<D$, a special case of the source's
-full range $1\le k\le D$. For $T_\eta$ both tensor factors of the Choi operator
-have dimension $D$ (the maximally entangled vector lies in
-$\mathbb C^{D}\otimes\mathbb C^{D}$), so the first-factor dimension that bounds
-the Ky--Fan index coincides with $D$; no separate $D'$ enters. The conclusion
-matches the source on $1\le k<D$, and only the top index $k=D$ is omitted, where
-the bound degenerates to complete positivity. No hypothesis foreign to the
-source is used, so the deviation is a scope restriction rather than an
-unfaithful theorem.
+\emph{Resolved.} The top index $k=D$ is now formalized as
+\leanid{Matrix.isNPositiveMap_tEta_card_iff}: since $D$-positivity on
+$M_D(\mathbb C)$ is complete positivity (\leanid{isCPMap_iff_isNPositiveMap_card}),
+$T_\eta$ is $D$-positive iff its Choi operator is positive semidefinite, and the
+maximally entangled vector $\ket\Omega$ is the worst case (Cauchy--Schwarz), so
+this holds iff $D\le\eta$. Together with \leanid{Matrix.isNPositiveMap_tEta_iff}
+(the range $1\le k<D$) this covers the full source range $1\le k\le D$ of
+equivalence~(3.11), supplying the top inclusion
+$\mathcal T_D\subseteq\mathcal T_{D-1}$ of Wolf's chain~(3.3).
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
@@ -94,8 +94,10 @@ $T_\eta$ is $D$-positive iff its Choi operator is positive semidefinite, and the
 maximally entangled vector $\ket\Omega$ is the worst case (Cauchy--Schwarz), so
 this holds iff $D\le\eta$. Together with \leanid{Matrix.isNPositiveMap_tEta_iff}
 (the range $1\le k<D$) this covers the full source range $1\le k\le D$ of
-equivalence~(3.11), supplying the top inclusion
-$\mathcal T_D\subseteq\mathcal T_{D-1}$ of Wolf's chain~(3.3).
+equivalence~(3.11), formalizing the completely-positive endpoint $k=D$ of Wolf's
+chain~(3.3). (This is the threshold equivalence at $k=D$; the strictness of the
+top inclusion $\mathcal T_D\subsetneq\mathcal T_{D-1}$ would follow by combining
+the $k=D-1$ and $k=D$ thresholds, but is not recorded as a separate witness.)
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_t_eta_top_index_scope.tex
@@ -71,33 +71,32 @@ $(D-1)$-positivity and requires the $k=D$ index.
 
 \section{Status}
 
-The deviation is a scope restriction, not a mathematical error: the formal
-equivalence and the strictness witnesses are correct as stated for the indices
-they cover.  The omitted boundary case $k=D$ is mathematically true in the
-source and would follow once the maximal-overlap principle and the Ky--Fan
-maximum principle are extended to the top index $k=D$ (where the bound reads
-$\|\rho\|_{(D)}=\tr\rho=1$ and the optimizing projection is the
-identity).  Extending those two principles to $k=D$ removes this restriction and
-supplies the top inclusion $\mathcal T_D\subseteq\mathcal T_{D-1}$.
+The boundary case $k=D$ is resolved by a route that bypasses the $k<D$
+restriction of the maximal-overlap and Ky--Fan principles entirely.  On
+$M_D(\mathbb C)$, $D$-positivity is complete positivity
+(\leanid{isCPMap_iff_isNPositiveMap_card}), which is positive semidefiniteness of
+the Choi operator $\tau_\eta$.  Its quadratic form on a vector $\psi$ is
+$D^{-1}\|\psi\|^2-\eta^{-1}|\braket{\Omega}{\psi}|^2$, and since $\ket\Omega$ is
+normalized the Cauchy--Schwarz bound $|\braket{\Omega}{\psi}|^2\le\|\psi\|^2$
+(saturated at $\psi=\Omega$) makes that form nonnegative for every $\psi$ exactly
+when $\eta\ge D$.  Hence $T_\eta$ is $D$-positive iff $\eta\ge D$, the equivalence
+at the top index.
 
-The formal declarations are
-\leanid{Matrix.isNPositiveMap_tEta_iff} for the threshold equivalence and
-\leanid{Matrix.exists_isNPositiveMap_not_succ} for the strictness witness, in
-\doclink{TNLean/Channel/NPositivityChainStrict}.
+The formal declarations are \leanid{Matrix.isNPositiveMap_tEta_iff} for the
+range $1\le k<D$ and \leanid{Matrix.isNPositiveMap_tEta_card_iff} for the top
+index $k=D$, together covering the full equivalence~(3.11) over $1\le k\le D$, in
+\doclink{TNLean/Channel/NPositivityChainStrict}.  The strictness witness
+\leanid{Matrix.exists_isNPositiveMap_not_succ} remains stated for $k+1<D$; the
+strictness of the top inclusion $\mathcal T_D\subsetneq\mathcal T_{D-1}$ follows
+from the $k=D-1$ and $k=D$ thresholds but is not recorded as a separate witness.
 
 \section{Classification}
 
-\emph{Resolved.} The top index $k=D$ is now formalized as
-\leanid{Matrix.isNPositiveMap_tEta_card_iff}: since $D$-positivity on
-$M_D(\mathbb C)$ is complete positivity (\leanid{isCPMap_iff_isNPositiveMap_card}),
-$T_\eta$ is $D$-positive iff its Choi operator is positive semidefinite, and the
-maximally entangled vector $\ket\Omega$ is the worst case (Cauchy--Schwarz), so
-this holds iff $D\le\eta$. Together with \leanid{Matrix.isNPositiveMap_tEta_iff}
-(the range $1\le k<D$) this covers the full source range $1\le k\le D$ of
-equivalence~(3.11), formalizing the completely-positive endpoint $k=D$ of Wolf's
-chain~(3.3). (This is the threshold equivalence at $k=D$; the strictness of the
-top inclusion $\mathcal T_D\subsetneq\mathcal T_{D-1}$ would follow by combining
-the $k=D-1$ and $k=D$ thresholds, but is not recorded as a separate witness.)
+\emph{Resolved.} The full source range $1\le k\le D$ of equivalence~(3.11) is now
+formalized: \leanid{Matrix.isNPositiveMap_tEta_iff} for $1\le k<D$ and
+\leanid{Matrix.isNPositiveMap_tEta_card_iff} for the completely-positive endpoint
+$k=D$, the latter by the Choi-operator route detailed in the Status above.  No
+hypothesis foreign to the source is used.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
Addresses the **T_η half of LionSR/QICLean#179** (follow-up to LionSR/TNLean#3528, which resolved the Lemma 3.1 top index).

Adds `Matrix.isNPositiveMap_tEta_card_iff`: **T_η is D-positive iff D ≤ η** — the complete-positivity endpoint (top index `k = D`) of Wolf eq. (3.11), completing the threshold criterion over the full range `1 ≤ k ≤ D` together with `isNPositiveMap_tEta_iff` (`1 ≤ k < D`).

## Proof
On `M_D(ℂ)`, `D`-positivity **is** complete positivity (`isCPMap_iff_isNPositiveMap_card`), hence positive-semidefiniteness of the Choi operator `τ_η = D⁻¹·1 − η⁻¹|Ω⟩⟨Ω|`. Its quadratic form `D⁻¹‖ψ‖² − η⁻¹|⟨Ω|ψ⟩|²` is nonnegative for all `ψ` iff `η ≥ D`: the maximally entangled `Ω` (normalized) is the worst case by Cauchy–Schwarz (`|⟨Ω|ψ⟩|² ≤ ‖ψ‖²`, equality at `ψ=Ω`). No new axioms or `sorry` (verified with `lake env lean`).

## Notes / blueprint
- `docs/paper-gaps/wolf_t_eta_top_index_scope.tex`: reclassified **Scope restriction → Resolved** (its stale "tracked in LionSR/QICLean#174" restriction is now formalized).
- `ch05_schwarz.tex`: companion entry `thm:t_eta_threshold_top`; the main `thm:t_eta_threshold` now points to it for the top index.

## Scope
This is the T_η part of LionSR/QICLean#179. The **Prop 3.2 top-index** case (`wolf_prop_3_2_top_index_scope.tex`) remains a follow-up; LionSR/QICLean#179 stays open until that lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in an existing channel file; no runtime, auth, or API surface changes.
> 
> **Overview**
> Closes the **top Schmidt-rank index** for Wolf’s map **T_η**: **`Matrix.isNPositiveMap_tEta_card_iff`** proves **D-positivity iff η ≥ D** (complete positivity endpoint), pairing with the existing **`isNPositiveMap_tEta_iff`** for **1 ≤ k < D**.
> 
> The Lean proof uses the Schmidt-rank Choi criterion and **`choiMatrix_tEta_quadraticForm`**: **Ω** witnesses the forward direction; the converse bounds **|⟨Ω|ψ⟩|²** by **‖ψ‖²** (Euclidean **Cauchy–Schwarz**), without extending the maximal-overlap / Ky–Fan machinery to **k = D**.
> 
> **Blueprint** adds **`thm:t_eta_threshold_top`** and points the main **`thm:t_eta_threshold`** at it for **k = D**. **`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`** is reclassified from a scope restriction to **Resolved**; **`exists_isNPositiveMap_not_succ`** is unchanged (**k + 1 < D**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371b0e0278cc2df18d18e2869df66718d52ff3b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->