### PR TITLE
feat(Channel): entanglement witness from separating hyperplane (Wolf Prop 3.3)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -128,6 +128,7 @@ import TNLean.Channel.ReductionCriterion
 import TNLean.Channel.PartialTranspose
 import TNLean.Channel.SchmidtNumber
 import TNLean.Channel.SchmidtNumberCompact
+import TNLean.Channel.EntanglementWitness
 import TNLean.Channel.SchmidtNumberFactors
 import TNLean.Channel.Separable
 import TNLean.Channel.Schwarz.MultiplicativeDomain

--- a/TNLean/Channel/EntanglementWitness.lean
+++ b/TNLean/Channel/EntanglementWitness.lean
@@ -1,0 +1,306 @@
+/-
+Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import TNLean.Channel.SchmidtNumberCompact
+import Mathlib.Analysis.LocallyConvex.Separation
+
+/-!
+# Entanglement witnesses from a separating hyperplane
+
+Wolf's Chapter 3, Section 3.2 (the paragraph *Detecting entanglement*, Proposition 3.3)
+constructs an **entanglement witness** for every bipartite state of Schmidt number
+larger than `n`: a Hermitian operator `W` with negative expectation on the given
+state but nonnegative expectation on every state of Schmidt number at most `n`.
+The construction separates the given state from the compact convex set `S_n` of
+trace-one states of Schmidt number at most `n` by a hyperplane, and reads the witness
+off the separating functional.
+
+This file supplies the capstone of that argument: the separation, the representation
+of the separating functional as a trace form, and the witness it produces.
+
+## The separating-hyperplane construction
+
+The two geometric inputs are already in place: `S_n` is convex
+(`Matrix.convex_setOf_hasSchmidtNumberLE_trace_one`) and compact
+(`Matrix.isCompact_setOf_hasSchmidtNumberLE_trace_one`).  A trace-one Hermitian
+state ρ of Schmidt number exceeding `n` lies outside `S_n`, so the geometric
+Hahn–Banach theorem produces a continuous real-linear functional `f` and a constant
+`c` with `f ρ < c` and `c < f σ` for every `σ ∈ S_n`.
+
+Every real-linear functional on the matrix space is a **trace form**: it equals
+`X ↦ Re tr(X H)` for some matrix `H`.  This is the existence half of the Riesz
+representation for the nondegenerate real bilinear pairing
+`(X, H) ↦ Re tr(X H)`, whose nondegeneracy is `Re tr(H Hᴴ) = ‖H‖²_F`.  Replacing `H`
+by its Hermitian part `H₀ = (H + Hᴴ)/2` keeps the value on Hermitian inputs and makes
+`H₀` Hermitian.
+
+The witness is `W = H₀ − c • 1`.  Its expectation `Re tr(W ρ)` is `f ρ − c < 0`,
+while on a unit Schmidt-rank-≤`n` vector ψ the projector `|ψ⟩⟨ψ|` lies in `S_n`, so
+its expectation is `f σ − c > 0`; scaling back to a general such ψ keeps the
+expectation nonnegative.
+
+## Main results
+
+* `Matrix.exists_isHermitian_trace_form_re`: every real-linear functional on the
+  matrix space is a trace form `X ↦ Re tr(X H)` with `H` Hermitian — the Riesz
+  representation underlying the witness construction.
+* `Matrix.exists_isHermitian_witness`: **an entanglement witness exists for every
+  trace-one Hermitian state of Schmidt number larger than `n`** (Wolf §3.2,
+  Proposition 3.3, the only-if direction).
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Section 3.2, the *Detecting entanglement* paragraph, Proposition 3.3][Wolf2012QChannels]
+-/
+
+open scoped BigOperators Matrix ComplexOrder
+open Matrix
+
+-- The Frobenius norm equips the matrix space with a finite-dimensional real normed
+-- structure whose topology agrees with the entrywise-convergence topology used for the
+-- merged compactness input; it supplies the `NormedSpace ℝ`/`FiniteDimensional ℝ`/
+-- `LocallyConvexSpace ℝ` instances the separation theorem requires.
+open scoped Matrix.Norms.Frobenius
+
+namespace Matrix
+
+variable {N : Type*} [Fintype N]
+
+/-! ## The trace bilinear form and its nondegeneracy -/
+
+/-- The real bilinear trace pairing `(X, H) ↦ Re tr(X H)` on the matrix space,
+packaged as a real-bilinear map.  It is symmetric in the sense `Re tr(X H) = Re tr(H X)`
+and nondegenerate, with `Re tr(H Hᴴ) = ‖H‖²_F`. -/
+noncomputable def traceFormReal : Matrix N N ℂ →ₗ[ℝ] Matrix N N ℂ →ₗ[ℝ] ℝ :=
+  LinearMap.mk₂ ℝ (fun X H => ((X * H).trace).re)
+    (fun X₁ X₂ H => by rw [add_mul, trace_add, Complex.add_re])
+    (fun c X H => by
+      rw [smul_mul_assoc, trace_smul, Complex.smul_re, smul_eq_mul])
+    (fun X H₁ H₂ => by rw [mul_add, trace_add, Complex.add_re])
+    (fun c X H => by
+      rw [mul_smul_comm, trace_smul, Complex.smul_re, smul_eq_mul])
+
+@[simp]
+theorem traceFormReal_apply (X H : Matrix N N ℂ) :
+    traceFormReal X H = ((X * H).trace).re := rfl
+
+/-- The trace bilinear form on the diagonal pair `(H, Hᴴ)` is the squared Frobenius
+norm of `H`: `Re tr(H Hᴴ) = ‖H‖²_F = ∑ |H i j|²`.  In particular it is positive
+unless `H = 0`, the nondegeneracy underlying the trace-form representation. -/
+theorem traceFormReal_self_conjTranspose_eq_zero_iff (H : Matrix N N ℂ) :
+    traceFormReal H Hᴴ = 0 ↔ H = 0 := by
+  constructor
+  · intro h
+    -- `tr(H Hᴴ)` is a nonnegative real, and its real part vanishes, so it is zero.
+    have hpos : (H * Hᴴ).PosSemidef := posSemidef_self_mul_conjTranspose H
+    have hnn : (0 : ℂ) ≤ (H * Hᴴ).trace := hpos.trace_nonneg
+    have htrace : (H * Hᴴ).trace = 0 := by
+      refine Complex.ext h ?_
+      exact (RCLike.nonneg_iff (K := ℂ).mp hnn).2
+    exact (trace_mul_conjTranspose_self_eq_zero_iff).1 htrace
+  · intro h; subst h; simp
+
+/-! ## The trace-form representation of a real-linear functional -/
+
+/-- The representing map `H ↦ (X ↦ Re tr(X H))` sending a matrix to the trace form it
+defines.  It is the flip of the real bilinear trace pairing. -/
+noncomputable def traceFormRep : Matrix N N ℂ →ₗ[ℝ] (Matrix N N ℂ →ₗ[ℝ] ℝ) :=
+  (traceFormReal (N := N)).flip
+
+@[simp]
+theorem traceFormRep_apply (H X : Matrix N N ℂ) :
+    traceFormRep H X = ((X * H).trace).re := rfl
+
+/-- The trace-form representation map is injective: a matrix `H` whose trace form
+`X ↦ Re tr(X H)` vanishes identically is zero.  Evaluating on `X = Hᴴ` gives
+`Re tr(Hᴴ H) = ‖H‖²_F = 0`, forcing `H = 0`. -/
+theorem traceFormRep_injective : Function.Injective (traceFormRep (N := N)) := by
+  rw [injective_iff_map_eq_zero]
+  intro H hH
+  -- Read off the diagonal value `Re tr(Hᴴ H) = ‖H‖²_F`.
+  have hval : traceFormRep H Hᴴ = 0 := by rw [hH]; rfl
+  rw [traceFormRep_apply, trace_mul_comm] at hval
+  exact (traceFormReal_self_conjTranspose_eq_zero_iff H).1 hval
+
+/-- **Every real-linear functional on the matrix space is a trace form.**  For each
+real-linear functional `g : Matrix N N ℂ →ₗ[ℝ] ℝ` there is a matrix `H` with
+`g X = Re tr(X H)` for all `X`.
+
+This is the existence half of the Riesz representation for the nondegenerate real
+bilinear pairing `(X, H) ↦ Re tr(X H)`: the representing map `H ↦ (X ↦ Re tr(X H))`
+is an injective real-linear map between the matrix space and its real dual, which have
+equal finite dimension, hence is surjective. -/
+theorem exists_trace_form_re (g : Matrix N N ℂ →ₗ[ℝ] ℝ) :
+    ∃ H : Matrix N N ℂ, ∀ X, g X = ((X * H).trace).re := by
+  -- The representing map is injective between two real spaces of equal finite dimension,
+  -- hence surjective; `g` is in its range.
+  have hdim :
+      Module.finrank ℝ (Matrix N N ℂ) = Module.finrank ℝ (Matrix N N ℂ →ₗ[ℝ] ℝ) :=
+    (Subspace.dual_finrank_eq (K := ℝ) (V := Matrix N N ℂ)).symm
+  have hsurj : Function.Surjective (traceFormRep (N := N)) :=
+    (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hdim).1 traceFormRep_injective
+  obtain ⟨H, hH⟩ := hsurj g
+  exact ⟨H, fun X => by rw [← hH]; rfl⟩
+
+/-- **Every real-linear functional is the trace form of a Hermitian matrix.**  Given
+`g : Matrix N N ℂ →ₗ[ℝ] ℝ`, there is a Hermitian `H₀` with `g X = Re tr(X H₀)` for
+every Hermitian `X`.
+
+The trace-form representation `g X = Re tr(X H)` of `exists_trace_form_re` holds with
+some `H`; replacing `H` by its Hermitian part `H₀ = (H + Hᴴ)/2` keeps the value on
+Hermitian inputs, because `tr(X Hᴴ) = conj tr(X H)` when `X` is Hermitian, so the two
+trace forms have equal real part there. -/
+theorem exists_isHermitian_trace_form_re (g : Matrix N N ℂ →ₗ[ℝ] ℝ) :
+    ∃ H₀ : Matrix N N ℂ, H₀.IsHermitian ∧
+      ∀ X : Matrix N N ℂ, X.IsHermitian → g X = ((X * H₀).trace).re := by
+  obtain ⟨H, hH⟩ := exists_trace_form_re g
+  refine ⟨((2⁻¹ : ℝ) : ℂ) • (H + Hᴴ), ?_, ?_⟩
+  · -- The Hermitian part is Hermitian: a self-adjoint real scalar times a Hermitian sum.
+    refine IsHermitian.smul ?_ ?_
+    · rw [IsHermitian, conjTranspose_add, conjTranspose_conjTranspose, add_comm]
+    · rw [isSelfAdjoint_iff, Complex.star_def, Complex.conj_ofReal]
+  · intro X hX
+    rw [hH X]
+    -- On Hermitian `X`, `tr(X Hᴴ) = conj tr(X H)`, so `Re tr(X Hᴴ) = Re tr(X H)`.
+    have hconj : (X * Hᴴ).trace = star ((X * H).trace) := by
+      rw [← trace_conjTranspose, conjTranspose_mul, hX, trace_mul_comm]
+    have hre : ((X * Hᴴ).trace).re = ((X * H).trace).re := by
+      rw [hconj, Complex.star_def, Complex.conj_re]
+    -- Expand the Hermitian-part trace form and use `Re tr(X Hᴴ) = Re tr(X H)`.
+    have hexpand : (X * (((2⁻¹ : ℝ) : ℂ) • (H + Hᴴ))).trace
+        = ((2⁻¹ : ℝ) : ℂ) * ((X * H).trace + (X * Hᴴ).trace) := by
+      rw [mul_smul_comm, trace_smul, mul_add, trace_add, smul_eq_mul]
+    have hrhs : ((X * (((2⁻¹ : ℝ) : ℂ) • (H + Hᴴ))).trace).re = ((X * H).trace).re := by
+      rw [hexpand, Complex.re_ofReal_mul, Complex.add_re, hre]
+      ring
+    rw [hrhs]
+
+end Matrix
+
+/-! ## The separating-hyperplane witness -/
+
+namespace Matrix
+
+variable {d d' : ℕ}
+
+open scoped ComplexOrder
+
+/-- The trace of a pure-state projector `|ψ⟩⟨ψ|` is the squared Euclidean norm of ψ,
+which is real, so its real part recovers `ψ ⬝ᵥ star ψ`. -/
+private theorem re_trace_vecMulVec (ψ : Fin d × Fin d' → ℂ) :
+    ((vecMulVec ψ (star ψ)).trace).re = (ψ ⬝ᵥ star ψ).re := by
+  rw [trace_vecMulVec]
+
+/-- **An entanglement witness exists for every trace-one Hermitian state of Schmidt
+number larger than `n`** (Wolf §3.2, Proposition 3.3, only-if direction).
+
+A trace-one Hermitian bipartite state ρ that is not of Schmidt number at most `n`
+admits a Hermitian operator `W` whose expectation on ρ is negative and whose
+expectation on every pure state of Schmidt rank at most `n` is nonnegative.
+
+The set `S_n` of trace-one states of Schmidt number at most `n` is compact and convex;
+ρ lies outside it, so the geometric Hahn–Banach theorem separates `{ρ}` from `S_n` by a
+continuous real-linear functional `f` and a constant `c` with `f ρ < c < f σ` for every
+`σ ∈ S_n`.  Representing `f` as the trace form of a Hermitian `H₀` and setting
+`W = H₀ − c • 1` makes `Re tr(W ρ) = f ρ − c < 0`, while for a unit Schmidt-rank-≤`n`
+vector the projector lies in `S_n` and gives a nonnegative expectation; a general such
+vector scales this by its squared norm. -/
+theorem exists_isHermitian_witness (n : ℕ)
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hρH : ρ.IsHermitian) (hρtr : ρ.trace = 1) (hρ : ¬ HasSchmidtNumberLE n ρ) :
+    ∃ W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ, W.IsHermitian ∧
+      (W * ρ).trace.re < 0 ∧
+      ∀ ψ : Fin d × Fin d' → ℂ, HasSchmidtRankLE n ψ →
+        0 ≤ (W * Matrix.vecMulVec ψ (star ψ)).trace.re := by
+  classical
+  -- The Frobenius normed structure makes the matrix space a real locally convex space,
+  -- the ambient hypothesis of the geometric Hahn–Banach separation theorem.
+  haveI : LocallyConvexSpace ℝ (Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :=
+    NormedSpace.toLocallyConvexSpace (E := Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ)
+  -- ρ is separated from the compact convex set `S_n` by a hyperplane.
+  set Sn : Set (Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ) :=
+    {σ | HasSchmidtNumberLE n σ ∧ σ.trace = 1} with hSn
+  have hconv : Convex ℝ Sn := convex_setOf_hasSchmidtNumberLE_trace_one n
+  have hcomp : IsCompact Sn := isCompact_setOf_hasSchmidtNumberLE_trace_one n
+  have hρnotmem : ρ ∉ Sn := by
+    rw [hSn]; rintro ⟨hmem, _⟩; exact hρ hmem
+  -- Separate the closed convex `{ρ}` from the compact convex `S_n`.
+  obtain ⟨f, u, v, hfρ, huv, hfSn⟩ :=
+    geometric_hahn_banach_closed_compact (convex_singleton ρ) isClosed_singleton hconv hcomp
+      (by rw [Set.disjoint_singleton_left]; exact hρnotmem)
+  -- A constant strictly between the two sides.
+  set c : ℝ := (u + v) / 2 with hc
+  have hfρc : f ρ < c := by
+    have := hfρ ρ rfl; rw [hc]; linarith
+  have hcSn : ∀ σ ∈ Sn, c < f σ := fun σ hσ => by
+    have := hfSn σ hσ; rw [hc]; linarith
+  -- Represent the separating functional as the trace form of a Hermitian matrix.
+  obtain ⟨H₀, hH₀herm, hH₀rep₀⟩ :=
+    exists_isHermitian_trace_form_re (N := Fin d × Fin d') f.toLinearMap
+  have hH₀rep : ∀ X : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ, X.IsHermitian →
+      f X = ((X * H₀).trace).re := fun X hX => by
+    have := hH₀rep₀ X hX; rwa [ContinuousLinearMap.coe_coe] at this
+  -- The witness.
+  refine ⟨H₀ - (c : ℂ) • 1, ?_, ?_, ?_⟩
+  · -- `W` is Hermitian: a difference of Hermitian matrices.
+    refine hH₀herm.sub ?_
+    rw [IsHermitian, conjTranspose_smul, conjTranspose_one, Complex.star_def,
+      Complex.conj_ofReal]
+  · -- `Re tr(W ρ) = f ρ − c < 0`.
+    have hWρ : ((H₀ - (c : ℂ) • 1) * ρ).trace.re = (f ρ) - c := by
+      rw [sub_mul, trace_sub, Complex.sub_re, smul_mul_assoc, one_mul, trace_smul,
+        smul_eq_mul, Complex.re_ofReal_mul, hρtr, Complex.one_re, mul_one,
+        trace_mul_comm, ← hH₀rep ρ hρH]
+    rw [hWρ]; linarith
+  · -- For each Schmidt-rank-≤`n` vector ψ the expectation is nonnegative.
+    intro ψ hψ
+    -- The expectation, scaled out as a value on the projector.
+    have hWψ : ((H₀ - (c : ℂ) • 1) * vecMulVec ψ (star ψ)).trace.re
+        = (f (vecMulVec ψ (star ψ))) - c * (ψ ⬝ᵥ star ψ).re := by
+      rw [sub_mul, trace_sub, Complex.sub_re, smul_mul_assoc, one_mul, trace_smul,
+        smul_eq_mul, Complex.re_ofReal_mul, re_trace_vecMulVec,
+        trace_mul_comm,
+        ← hH₀rep (vecMulVec ψ (star ψ)) (posSemidef_vecMulVec_self_star ψ).isHermitian]
+    rw [hWψ]
+    -- The squared norm `s = ‖ψ‖²` is nonnegative.
+    set s : ℝ := (ψ ⬝ᵥ star ψ).re with hs
+    have hs_nonneg : 0 ≤ s := by
+      rw [hs, ← re_trace_vecMulVec]
+      exact (RCLike.nonneg_iff (K := ℂ).mp
+        (posSemidef_vecMulVec_self_star ψ).trace_nonneg).1
+    -- Split on whether ψ vanishes.
+    by_cases hψ0 : ψ = 0
+    · subst hψ0
+      simp only [hs, star_zero, dotProduct_zero, Complex.zero_re, mul_zero, sub_zero,
+        vecMulVec_zero]
+      simp
+    · -- Normalize ψ to a unit vector whose projector lies in `S_n`.
+      obtain ⟨φ, hφnorm, hφrank, hφeq⟩ :=
+        exists_unit_smul_euclideanProj_eq hψ0 hψ
+      -- The trace identity for the squared norm.
+      have hsval :
+          ((‖(WithLp.toLp 2 ψ : EuclideanSpace ℂ (Fin d × Fin d'))‖ : ℝ) ^ 2 : ℝ)
+            = s := by
+        have h := ofReal_normSq_eq_dotProduct_star ψ
+        rw [hs, ← h, Complex.ofReal_re]
+      -- The normalized projector is a state of `S_n`.
+      have hP : euclideanProj φ ∈ Sn := by
+        rw [hSn]
+        refine ⟨hasSchmidtNumberLE_vecMulVec hφrank, ?_⟩
+        rw [trace_euclideanProj, hφnorm]; norm_num
+      have hfP : c < f (euclideanProj φ) := hcSn _ hP
+      -- `|ψ⟩⟨ψ| = s • (euclideanProj φ)`, so `f` and the norm-factor relate the two.
+      have hproj_eq : vecMulVec ψ (star ψ) = (s : ℝ) • euclideanProj φ := by
+        rw [← hsval]; exact hφeq.symm
+      have hfψ : f (vecMulVec ψ (star ψ)) = s * f (euclideanProj φ) := by
+        rw [hproj_eq, map_smul, smul_eq_mul]
+      rw [hfψ]
+      -- `s * f(P) - c * s = s * (f(P) - c) ≥ 0`.
+      have : s * f (euclideanProj φ) - c * s = s * (f (euclideanProj φ) - c) := by ring
+      rw [this]
+      exact mul_nonneg hs_nonneg (by linarith)
+
+end Matrix

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -807,3 +807,65 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     the operator implication in its symmetric form gives $n\,\rho_1\otimes\Id\ge\rho$.
 \end{proof}
 
+
+\begin{theorem}[Trace-form representation of a real-linear functional]
+    \label{thm:exists_isHermitian_trace_form_re}
+    \lean{Matrix.exists_isHermitian_trace_form_re}
+    \leanok
+    Every real-linear functional $g$ on the space of square complex matrices is the
+    trace form of a Hermitian matrix: there is a Hermitian $H_0$ with
+    \[
+        g(X)=\operatorname{Re}\tr(X H_0)
+        \qquad\text{for every Hermitian }X.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The real bilinear pairing $(X,H)\mapsto\operatorname{Re}\tr(X H)$ is nondegenerate,
+    because on the diagonal pair $(H,H^{\dagger})$ it equals the squared Frobenius norm
+    $\operatorname{Re}\tr(H H^{\dagger})=\sum_{i,j}\lvert H_{ij}\rvert^2$, which is positive
+    unless $H=0$.  Hence the map sending $H$ to the functional
+    $X\mapsto\operatorname{Re}\tr(X H)$ is an injective real-linear map from the matrix
+    space to its real dual.  These two spaces have the same finite real dimension, so the
+    map is also surjective, and every $g$ is represented by some $H$.  Replacing $H$ by
+    its Hermitian part $\tfrac12(H+H^{\dagger})$ keeps the value on Hermitian inputs,
+    since $\tr(X H^{\dagger})=\overline{\tr(X H)}$ when $X$ is Hermitian, and produces a
+    Hermitian representing matrix.
+\end{proof}
+
+\begin{theorem}[Entanglement witness from a separating hyperplane]
+    \label{thm:exists_entanglement_witness}
+    \lean{Matrix.exists_isHermitian_witness}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:schmidt_rank,
+        thm:convex_setOf_has_schmidt_number_le,
+        thm:compact_setOf_has_schmidt_number_le_trace_one,
+        thm:exists_isHermitian_trace_form_re}
+    Let $\rho$ be a trace-one Hermitian bipartite state whose Schmidt number exceeds $n$.
+    Then there is a Hermitian operator $W$ with
+    \[
+        \operatorname{Re}\tr(W\rho)<0,
+        \qquad
+        \operatorname{Re}\bra{\psi}W\ket{\psi}\ge 0
+        \quad\text{for every $\psi$ of Schmidt rank at most }n.
+    \]
+    This is the only-if direction of Wolf's Proposition~3.3
+    \cite[Chapter~3, Proposition~3.3]{Wolf2012Quantum}: a state of Schmidt number larger
+    than $n$ is detected by an entanglement witness for $S_n$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The set $S_n$ of trace-one states of Schmidt number at most $n$ is convex and
+    compact, and $\rho\notin S_n$.  The geometric Hahn--Banach theorem separates the
+    closed convex set $\{\rho\}$ from the compact convex set $S_n$ by a continuous
+    real-linear functional $f$ and a constant $c$ with $f(\rho)<c<f(\sigma)$ for every
+    $\sigma\in S_n$.  Representing $f$ as the trace form of a Hermitian $H_0$ and setting
+    $W=H_0-c\,\Id$ gives $\operatorname{Re}\tr(W\rho)=f(\rho)-c<0$.  For a vector $\psi$
+    of Schmidt rank at most $n$ the projector $\ket{\psi}\bra{\psi}$, after
+    normalization by $\lVert\psi\rVert^2$, is a trace-one state of $S_n$, so its value
+    under $f$ is at least $c$; multiplying back by the squared norm gives
+    $\operatorname{Re}\bra{\psi}W\ket{\psi}\ge 0$, with the zero vector giving the value
+    $0$ directly.
+\end{proof}


### PR DESCRIPTION
## Summary

Completes the **only-if direction of Wolf's Proposition 3.3** (Chapter 3, *Detecting entanglement*): every trace-one Hermitian bipartite state of Schmidt number larger than `n` admits an entanglement witness separating it from the set `S_n` of states of Schmidt number at most `n`.

New file `TNLean/Channel/EntanglementWitness.lean` (306 lines), with the capstone theorem:

```lean
theorem Matrix.exists_isHermitian_witness (n : ℕ)
    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
    (hρH : ρ.IsHermitian) (hρtr : ρ.trace = 1) (hρ : ¬ HasSchmidtNumberLE n ρ) :
    ∃ W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ, W.IsHermitian ∧
      (W * ρ).trace.re < 0 ∧
      ∀ ψ : Fin d × Fin d' → ℂ, HasSchmidtRankLE n ψ →
        0 ≤ (W * Matrix.vecMulVec ψ (star ψ)).trace.re
```

## Method

1. **Trace-form representation** (`Matrix.exists_isHermitian_trace_form_re`, independently useful): every real-linear functional on the matrix space equals `X ↦ Re tr(X H)` for some Hermitian `H`. This is the existence half of the Riesz representation for the nondegenerate real bilinear pairing `(X, H) ↦ Re tr(X H)`, whose nondegeneracy is `Re tr(H Hᴴ) = ‖H‖²_F`. The representing map is an injective real-linear map between the matrix space and its real dual, which have equal finite dimension, hence surjective. Hermitizing `H ↦ (H + Hᴴ)/2` preserves the value on Hermitian inputs.

2. **Separation.** `S_n` is convex (`convex_setOf_hasSchmidtNumberLE_trace_one`) and compact (`isCompact_setOf_hasSchmidtNumberLE_trace_one`); `ρ ∉ S_n`. The geometric Hahn–Banach theorem (`geometric_hahn_banach_closed_compact`) separates `{ρ}` from `S_n` by a continuous real-linear functional `f` and a constant `c` with `f ρ < c < f σ` on `S_n`.

3. **Witness.** With `H₀` the Hermitian representative of `f` and `W = H₀ − c • 1`: `Re tr(W ρ) = f ρ − c < 0`, and for a Schmidt-rank-≤`n` vector `ψ` the normalized projector lies in `S_n`, giving `Re ⟨ψ|W|ψ⟩ = ‖ψ‖²·(f P − c) ≥ 0`.

## Verification

- `lake build TNLean` succeeds (9235 jobs).
- `#print axioms` on both new theorems: only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no custom axioms.
- No `sorry`/`admit`/`axiom`/`native_decide`/`maxHeartbeats`.
- `scripts/blueprint_lean_sync.py`: in sync (ch25 100%).
- `scripts/check_reader_facing_prose.py --diff-base origin/main`: clean.

## Blueprint

Adds `thm:exists_isHermitian_trace_form_re` and `thm:exists_entanglement_witness` to `blueprint/src/chapter/ch25_positive_not_cp.tex` (both `\leanok`), `\uses` the convexity, compactness, and trace-form-representation entries, cites Wolf Prop 3.3.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained formal mathematics on existing Schmidt-number infrastructure; no auth, runtime, or API surface changes beyond a new library import.
> 
> **Overview**
> Adds **`TNLean/Channel/EntanglementWitness.lean`** and wires it into the root import list, completing the **only-if direction of Wolf Proposition 3.3**: a trace-one Hermitian bipartite state with Schmidt number **greater than** `n` admits a Hermitian entanglement witness `W` with negative expectation on `ρ` and nonnegative expectations on pure states of Schmidt rank at most `n`.
> 
> The file first proves **`Matrix.exists_isHermitian_trace_form_re`**: every real-linear functional on matrices is `Re tr(X H₀)` for some Hermitian `H₀`, via nondegeneracy of `Re tr(X H)` and finite-dimensional surjectivity of the representing map. **`Matrix.exists_isHermitian_witness`** then separates `{ρ}` from the compact convex set `S_n` of trace-one states with `HasSchmidtNumberLE n` using geometric Hahn–Banach, builds `W = H₀ − c • 1`, and handles general Schmidt-rank-≤`n` vectors by normalizing projectors into `S_n`.
> 
> **Blueprint** `ch25_positive_not_cp.tex` gains matching `\leanok` entries for the trace-form theorem and the entanglement-witness theorem, with `\uses` on the existing Schmidt-number convexity/compactness lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebf781b39ea4fa66a81064cf1f06b8a0bd3b00d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->