### PR TITLE
feat(Channel): Prop 3.2 spectral criterion at the top Schmidt-rank index (n = D)

### DIFF
--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -49,11 +49,10 @@ overlap vector.
   Proposition 3.2, equation (3.8): a Schmidt-rank-n vector realizing the matching
   upper bound on the infimum.
 * `Matrix.IsHermitian.spectral_lower_bound_top` and
-  `Matrix.IsHermitian.spectral_upper_bound_top` -- the top-index n = D case,
-  where the Schmidt-rank constraint is vacuous and the bounds reduce to the
-  Rayleigh characterization λ_min ≤ ⟨ψ|τ|ψ⟩ ≤ λ_max, with
-  `Matrix.IsHermitian.exists_spectral_lower_bound_top` and
-  `Matrix.IsHermitian.exists_spectral_upper_bound_top` recording attainment.
+  `Matrix.IsHermitian.exists_spectral_lower_bound_top` -- the top-index n = D case
+  of equations (3.7) and (3.8), where the Schmidt-rank constraint is vacuous and
+  the bounds reduce to the Rayleigh characterization of the least eigenvalue
+  min_ψ ⟨ψ|τ|ψ⟩ = λ_min.
 
 ## References
 
@@ -241,14 +240,15 @@ theorem rayleigh_eigenvector_re (hτ : τ.IsHermitian) (j : N) :
     rw [hτ.star_eigenvector_dotProduct_eigenvector i j, if_neg hij]; simp
   · intro h; exact absurd (Finset.mem_univ j) h
 
-/-- **Wolf's Chapter 3, Proposition 3.2 at the top Schmidt-rank index `n = D`:
-spectral lower bound.**  At the top index the Schmidt-rank constraint is vacuous
-(every vector on the bipartite space has Schmidt rank at most `D`) and the Ky-Fan
-`D`-norm of each reduced density collapses to its trace, which is one.  The
-spectral bound therefore degenerates to the Rayleigh characterization of the
-least eigenvalue: every normalized vector `ψ` satisfies `λ_min ≤ ⟨ψ|τ|ψ⟩`, with
-no Schmidt-rank restriction.  This is the completely-positive endpoint of the
-positivity chain. -/
+/-- **Wolf's Chapter 3, Proposition 3.2, equation (3.7) at the top Schmidt-rank
+index n = D.**  At the top index the Schmidt-rank constraint is vacuous (every
+vector on the bipartite space has Schmidt rank at most D) and the Ky-Fan D-norm
+of each reduced density collapses to its trace, which is one.  The lower
+bound (3.7) therefore degenerates to the Rayleigh characterization of the least
+eigenvalue: every normalized vector ψ satisfies λ_min ≤ ⟨ψ|τ|ψ⟩, with no
+Schmidt-rank restriction.  This is the completely-positive endpoint of the
+positivity chain.  Together with `exists_spectral_lower_bound_top` it gives
+min_ψ ⟨ψ|τ|ψ⟩ = λ_min. -/
 theorem spectral_lower_bound_top [Nonempty N] (hτ : τ.IsHermitian)
     {ψ : N → ℂ} (hψ : star ψ ⬝ᵥ ψ = 1) :
     Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues ≤ (star ψ ⬝ᵥ (τ *ᵥ ψ)).re := by
@@ -263,42 +263,17 @@ theorem spectral_lower_bound_top [Nonempty N] (hτ : τ.IsHermitian)
         Finset.sum_le_sum fun i _ =>
           mul_le_mul_of_nonneg_right (Finset.inf'_le _ (Finset.mem_univ i)) (sq_nonneg _)
 
-/-- **Wolf's Chapter 3, Proposition 3.2 at the top Schmidt-rank index `n = D`:
-the least eigenvalue is attained.**  The eigenvector at an index realizing the
-least eigenvalue is normalized and makes `⟨ψ|τ|ψ⟩` equal to `λ_min`.  Together
-with `spectral_lower_bound_top` this gives `min_ψ ⟨ψ|τ|ψ⟩ = λ_min`, the source's
-top-index statement. -/
+/-- **Wolf's Chapter 3, Proposition 3.2, equation (3.8) at the top Schmidt-rank
+index n = D.**  Equation (3.8) bounds the infimum of ⟨ψ|τ|ψ⟩ from above by
+exhibiting a low-expectation vector.  At the top index the Schmidt-rank
+constraint is vacuous and the bound becomes λ_min: the eigenvector at an index
+realizing the least eigenvalue is normalized and makes ⟨ψ|τ|ψ⟩ equal to λ_min,
+so inf_ψ ⟨ψ|τ|ψ⟩ ≤ λ_min.  Together with `spectral_lower_bound_top` this gives
+min_ψ ⟨ψ|τ|ψ⟩ = λ_min, the source's top-index statement. -/
 theorem exists_spectral_lower_bound_top [Nonempty N] (hτ : τ.IsHermitian) :
     ∃ ψ : N → ℂ, star ψ ⬝ᵥ ψ = 1 ∧
       (star ψ ⬝ᵥ (τ *ᵥ ψ)).re = Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues := by
   obtain ⟨j, _, hj⟩ := Finset.exists_mem_eq_inf' Finset.univ_nonempty hτ.eigenvalues
-  exact ⟨hτ.eigenvector j, hτ.star_eigenvector_dotProduct_self j,
-    by rw [hτ.rayleigh_eigenvector_re j]; exact hj.symm⟩
-
-/-- **Wolf's Chapter 3, Proposition 3.2 at the top Schmidt-rank index `n = D`:
-spectral upper bound.**  Dually to `spectral_lower_bound_top`, every normalized
-vector `ψ` satisfies `⟨ψ|τ|ψ⟩ ≤ λ_max`, with no Schmidt-rank restriction. -/
-theorem spectral_upper_bound_top [Nonempty N] (hτ : τ.IsHermitian)
-    {ψ : N → ℂ} (hψ : star ψ ⬝ᵥ ψ = 1) :
-    (star ψ ⬝ᵥ (τ *ᵥ ψ)).re ≤ Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues := by
-  rw [hτ.rayleigh_re ψ]
-  calc ∑ i, hτ.eigenvalues i * ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2
-      ≤ ∑ i, Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues
-          * ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2 :=
-        Finset.sum_le_sum fun i _ =>
-          mul_le_mul_of_nonneg_right (Finset.le_sup' _ (Finset.mem_univ i)) (sq_nonneg _)
-    _ = Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues
-          * ∑ i, ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2 := by rw [Finset.mul_sum]
-    _ = Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues := by
-        rw [hτ.sum_normSq_eigenvector_overlap_re ψ, hψ, Complex.one_re, mul_one]
-
-/-- **Wolf's Chapter 3, Proposition 3.2 at the top Schmidt-rank index `n = D`:
-the greatest eigenvalue is attained.**  Dual to `exists_spectral_lower_bound_top`:
-together with `spectral_upper_bound_top` this gives `max_ψ ⟨ψ|τ|ψ⟩ = λ_max`. -/
-theorem exists_spectral_upper_bound_top [Nonempty N] (hτ : τ.IsHermitian) :
-    ∃ ψ : N → ℂ, star ψ ⬝ᵥ ψ = 1 ∧
-      (star ψ ⬝ᵥ (τ *ᵥ ψ)).re = Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues := by
-  obtain ⟨j, _, hj⟩ := Finset.exists_mem_eq_sup' Finset.univ_nonempty hτ.eigenvalues
   exact ⟨hτ.eigenvector j, hτ.star_eigenvector_dotProduct_self j,
     by rw [hτ.rayleigh_eigenvector_re j]; exact hj.symm⟩
 
@@ -426,9 +401,11 @@ value.  In the source ν is the largest positive eigenvalue and j indexes the
 unique non-positive eigenvalue ν₋, in which case the bound reads
 ν + (ν₋ − ν) ‖ρ₋‖₍ₖ₎.
 
-This version covers 1 ≤ k < D; the top index k = D, where the bound degenerates
-to the Rayleigh estimate ⟨ψ|τ|ψ⟩ ≤ λ_max, is
-`Matrix.IsHermitian.spectral_upper_bound_top`.  See
+This version covers 1 ≤ k < D.  At the top index k = D, where the Schmidt
+constraint is vacuous and j is taken at the minimizing index, the bound becomes
+the existence of a vector with ⟨ψ|τ|ψ⟩ = λ_min, i.e.
+inf_ψ ⟨ψ|τ|ψ⟩ ≤ λ_min; that endpoint is
+`Matrix.IsHermitian.exists_spectral_lower_bound_top`.  See
 `docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`. -/
 theorem IsHermitian.exists_le_spectral_upper_bound {τ : Matrix (m × n) (m × n) ℂ}
     (hτ : τ.IsHermitian) {νsup : ℝ} {k : ℕ} (j : m × n) (hk1 : 1 ≤ k)

--- a/TNLean/Channel/NPositivitySpectralCriterion.lean
+++ b/TNLean/Channel/NPositivitySpectralCriterion.lean
@@ -48,6 +48,12 @@ overlap vector.
 * `Matrix.IsHermitian.exists_le_spectral_upper_bound` -- Wolf's Chapter 3,
   Proposition 3.2, equation (3.8): a Schmidt-rank-n vector realizing the matching
   upper bound on the infimum.
+* `Matrix.IsHermitian.spectral_lower_bound_top` and
+  `Matrix.IsHermitian.spectral_upper_bound_top` -- the top-index n = D case,
+  where the Schmidt-rank constraint is vacuous and the bounds reduce to the
+  Rayleigh characterization λ_min ≤ ⟨ψ|τ|ψ⟩ ≤ λ_max, with
+  `Matrix.IsHermitian.exists_spectral_lower_bound_top` and
+  `Matrix.IsHermitian.exists_spectral_upper_bound_top` recording attainment.
 
 ## References
 
@@ -212,6 +218,90 @@ theorem spectral_upper_bound_core {ν o : N → ℝ} {νsup : ℝ} (j : N)
     Finset.sum_nonpos fun i _ => mul_nonpos_of_nonpos_of_nonneg (by linarith [hmax i]) (ho i)
   linarith
 
+/-- The eigenvectors of a Hermitian matrix are orthonormal: ⟨φᵢ|φⱼ⟩ = δᵢⱼ. -/
+theorem star_eigenvector_dotProduct_eigenvector (hτ : τ.IsHermitian) (i j : N) :
+    star (hτ.eigenvector i) ⬝ᵥ (hτ.eigenvector j) = if i = j then 1 else 0 := by
+  set U := (hτ.eigenvectorUnitary : Matrix N N ℂ) with hU
+  have hUstar : star U * U = 1 := by
+    have := (hτ.eigenvectorUnitary).2
+    rw [Matrix.mem_unitaryGroup_iff'] at this; exact this
+  have h : (star U * U) i j = (1 : Matrix N N ℂ) i j := by rw [hUstar]
+  rw [Matrix.one_apply] at h
+  rw [← h, hU]
+  simp only [Matrix.mul_apply, eigenvector, dotProduct, Pi.star_apply,
+    RCLike.star_def, Matrix.star_eq_conjTranspose, Matrix.conjTranspose_apply]
+
+/-- The Rayleigh quotient evaluated at an eigenvector returns its eigenvalue:
+⟨φⱼ|τ|φⱼ⟩ = νⱼ. -/
+theorem rayleigh_eigenvector_re (hτ : τ.IsHermitian) (j : N) :
+    (star (hτ.eigenvector j) ⬝ᵥ (τ *ᵥ hτ.eigenvector j)).re = hτ.eigenvalues j := by
+  rw [hτ.rayleigh_re (hτ.eigenvector j), Finset.sum_eq_single j]
+  · rw [hτ.star_eigenvector_dotProduct_eigenvector j j, if_pos rfl]; simp
+  · intro i _ hij
+    rw [hτ.star_eigenvector_dotProduct_eigenvector i j, if_neg hij]; simp
+  · intro h; exact absurd (Finset.mem_univ j) h
+
+/-- **Wolf's Chapter 3, Proposition 3.2 at the top Schmidt-rank index `n = D`:
+spectral lower bound.**  At the top index the Schmidt-rank constraint is vacuous
+(every vector on the bipartite space has Schmidt rank at most `D`) and the Ky-Fan
+`D`-norm of each reduced density collapses to its trace, which is one.  The
+spectral bound therefore degenerates to the Rayleigh characterization of the
+least eigenvalue: every normalized vector `ψ` satisfies `λ_min ≤ ⟨ψ|τ|ψ⟩`, with
+no Schmidt-rank restriction.  This is the completely-positive endpoint of the
+positivity chain. -/
+theorem spectral_lower_bound_top [Nonempty N] (hτ : τ.IsHermitian)
+    {ψ : N → ℂ} (hψ : star ψ ⬝ᵥ ψ = 1) :
+    Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues ≤ (star ψ ⬝ᵥ (τ *ᵥ ψ)).re := by
+  rw [hτ.rayleigh_re ψ]
+  calc Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues
+      = Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues
+          * ∑ i, ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2 := by
+        rw [hτ.sum_normSq_eigenvector_overlap_re ψ, hψ, Complex.one_re, mul_one]
+    _ = ∑ i, Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues
+          * ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2 := by rw [Finset.mul_sum]
+    _ ≤ ∑ i, hτ.eigenvalues i * ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2 :=
+        Finset.sum_le_sum fun i _ =>
+          mul_le_mul_of_nonneg_right (Finset.inf'_le _ (Finset.mem_univ i)) (sq_nonneg _)
+
+/-- **Wolf's Chapter 3, Proposition 3.2 at the top Schmidt-rank index `n = D`:
+the least eigenvalue is attained.**  The eigenvector at an index realizing the
+least eigenvalue is normalized and makes `⟨ψ|τ|ψ⟩` equal to `λ_min`.  Together
+with `spectral_lower_bound_top` this gives `min_ψ ⟨ψ|τ|ψ⟩ = λ_min`, the source's
+top-index statement. -/
+theorem exists_spectral_lower_bound_top [Nonempty N] (hτ : τ.IsHermitian) :
+    ∃ ψ : N → ℂ, star ψ ⬝ᵥ ψ = 1 ∧
+      (star ψ ⬝ᵥ (τ *ᵥ ψ)).re = Finset.univ.inf' Finset.univ_nonempty hτ.eigenvalues := by
+  obtain ⟨j, _, hj⟩ := Finset.exists_mem_eq_inf' Finset.univ_nonempty hτ.eigenvalues
+  exact ⟨hτ.eigenvector j, hτ.star_eigenvector_dotProduct_self j,
+    by rw [hτ.rayleigh_eigenvector_re j]; exact hj.symm⟩
+
+/-- **Wolf's Chapter 3, Proposition 3.2 at the top Schmidt-rank index `n = D`:
+spectral upper bound.**  Dually to `spectral_lower_bound_top`, every normalized
+vector `ψ` satisfies `⟨ψ|τ|ψ⟩ ≤ λ_max`, with no Schmidt-rank restriction. -/
+theorem spectral_upper_bound_top [Nonempty N] (hτ : τ.IsHermitian)
+    {ψ : N → ℂ} (hψ : star ψ ⬝ᵥ ψ = 1) :
+    (star ψ ⬝ᵥ (τ *ᵥ ψ)).re ≤ Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues := by
+  rw [hτ.rayleigh_re ψ]
+  calc ∑ i, hτ.eigenvalues i * ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2
+      ≤ ∑ i, Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues
+          * ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2 :=
+        Finset.sum_le_sum fun i _ =>
+          mul_le_mul_of_nonneg_right (Finset.le_sup' _ (Finset.mem_univ i)) (sq_nonneg _)
+    _ = Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues
+          * ∑ i, ‖star (hτ.eigenvector i) ⬝ᵥ ψ‖ ^ 2 := by rw [Finset.mul_sum]
+    _ = Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues := by
+        rw [hτ.sum_normSq_eigenvector_overlap_re ψ, hψ, Complex.one_re, mul_one]
+
+/-- **Wolf's Chapter 3, Proposition 3.2 at the top Schmidt-rank index `n = D`:
+the greatest eigenvalue is attained.**  Dual to `exists_spectral_lower_bound_top`:
+together with `spectral_upper_bound_top` this gives `max_ψ ⟨ψ|τ|ψ⟩ = λ_max`. -/
+theorem exists_spectral_upper_bound_top [Nonempty N] (hτ : τ.IsHermitian) :
+    ∃ ψ : N → ℂ, star ψ ⬝ᵥ ψ = 1 ∧
+      (star ψ ⬝ᵥ (τ *ᵥ ψ)).re = Finset.univ.sup' Finset.univ_nonempty hτ.eigenvalues := by
+  obtain ⟨j, _, hj⟩ := Finset.exists_mem_eq_sup' Finset.univ_nonempty hτ.eigenvalues
+  exact ⟨hτ.eigenvector j, hτ.star_eigenvector_dotProduct_self j,
+    by rw [hτ.rayleigh_eigenvector_re j]; exact hj.symm⟩
+
 end Matrix.IsHermitian
 
 namespace Matrix
@@ -306,10 +396,12 @@ normalized vector ψ of Schmidt rank at most k satisfies
 ν₀ + Σ_{i:νᵢ≤0} (νᵢ − ν₀) ‖ρᵢ‖₍ₖ₎ ≤ ⟨ψ|τ|ψ⟩, hence the same bound holds for the
 infimum over such vectors.
 
-**Scope restriction (k < D):** the source ranges over Schmidt rank up to
-the dimension D of the first tensor factor; this version covers 1 ≤ k < D.
-The omitted top index k = D is inherited from the maximal-overlap lemma and
-documented in `docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`. -/
+This version covers Schmidt rank 1 ≤ k < D, where D is the dimension of the
+first tensor factor.  The top index k = D, where the Schmidt-rank constraint is
+vacuous and the bound degenerates to the Rayleigh estimate λ_min ≤ ⟨ψ|τ|ψ⟩, is
+`Matrix.IsHermitian.spectral_lower_bound_top`; the two together cover the full
+source range 1 ≤ k ≤ D.  See
+`docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`. -/
 theorem IsHermitian.spectral_lower_bound {τ : Matrix (m × n) (m × n) ℂ}
     (hτ : τ.IsHermitian) {ν₀ : ℝ} {k : ℕ} (hk1 : 1 ≤ k) (hk : k < Fintype.card m)
     (hν0 : 0 ≤ ν₀) (hmin : ∀ i, 0 < hτ.eigenvalues i → ν₀ ≤ hτ.eigenvalues i)
@@ -334,8 +426,9 @@ value.  In the source ν is the largest positive eigenvalue and j indexes the
 unique non-positive eigenvalue ν₋, in which case the bound reads
 ν + (ν₋ − ν) ‖ρ₋‖₍ₖ₎.
 
-**Scope restriction (k < D):** stated for 1 ≤ k < D; the source allows
-the top index k = D.  Documented in
+This version covers 1 ≤ k < D; the top index k = D, where the bound degenerates
+to the Rayleigh estimate ⟨ψ|τ|ψ⟩ ≤ λ_max, is
+`Matrix.IsHermitian.spectral_upper_bound_top`.  See
 `docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`. -/
 theorem IsHermitian.exists_le_spectral_upper_bound {τ : Matrix (m × n) (m × n) ℂ}
     (hτ : τ.IsHermitian) {νsup : ℝ} {k : ℕ} (j : m × n) (hk1 : 1 ≤ k)

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -422,9 +422,9 @@ maps.
             \le \bra{\psi}\tau\ket{\psi} ,
     \]
     and hence the same bound holds for the infimum over such vectors. This is the
-    lower bound of \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum}, stated for
-    $n<D'$; the top index $n=D'$ lies outside the range of
-    Theorem~\ref{thm:maximal_overlap_schmidt_rank}.
+    lower bound of \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum} for
+    $n<D'$; the top index $n=D'$ is
+    Theorem~\ref{thm:spectral_bound_schmidt_rank_top}.
 \end{theorem}
 
 \begin{proof}
@@ -465,7 +465,8 @@ maps.
     eigenvalue $\nu_-$ recovers the upper bound
     $\nu + (\nu_- - \nu)\,\|\rho_-\|_{(n)}$ of
     \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum}. The statement is for
-    $n<D'$.
+    $n<D'$; the top index $n=D'$ is
+    Theorem~\ref{thm:spectral_bound_schmidt_rank_top}.
 \end{theorem}
 
 \begin{proof}
@@ -484,6 +485,38 @@ maps.
     supplies a normalized $\psi$ of Schmidt rank at most $n$ attaining
     $|\braket{\phi_j}{\psi}|^2=\|\rho_j\|_{(n)}$; at that vector the right-hand
     side equals $\nu + (\nu_j-\nu)\,\|\rho_j\|_{(n)}$.
+\end{proof}
+
+\begin{theorem}[Spectral bounds at the top Schmidt rank]
+    \label{thm:spectral_bound_schmidt_rank_top}
+    \lean{Matrix.IsHermitian.spectral_lower_bound_top,
+        Matrix.IsHermitian.spectral_upper_bound_top}
+    \leanok
+    \uses{lem:eigenbasis_rayleigh, lem:eigenbasis_parseval}
+    At the top index $n=D'$ the Schmidt-rank constraint is vacuous and each
+    Ky-Fan $D'$-norm collapses to $\|\rho_i\|_{(D')}=\tr\rho_i=1$, so the spectral
+    bounds reduce to the Rayleigh characterization of the extreme eigenvalues:
+    every normalized vector $\psi$ satisfies
+    \[
+        \nu_{\min} \le \bra{\psi}\tau\ket{\psi} \le \nu_{\max} ,
+    \]
+    with no Schmidt-rank restriction, and both extremes are attained at the
+    corresponding eigenvector. Together with
+    Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}
+    and~\ref{thm:spectral_upper_bound_schmidt_rank} this covers the full range
+    $1\le n\le D'$ of \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:eigenbasis_rayleigh, lem:eigenbasis_parseval}
+    The eigenbasis expansion
+    $\bra{\psi}\tau\ket{\psi}=\sum_i\nu_i\,|\braket{\phi_i}{\psi}|^2$ together with
+    Parseval's identity $\sum_i|\braket{\phi_i}{\psi}|^2=1$ bounds each weight
+    $\nu_i$ between $\nu_{\min}$ and $\nu_{\max}$, giving
+    $\nu_{\min}\le\bra{\psi}\tau\ket{\psi}\le\nu_{\max}$. Evaluating at the
+    eigenvector $\phi_j$ returns $\bra{\phi_j}\tau\ket{\phi_j}=\nu_j$, so the
+    extremes are attained.
 \end{proof}
 
 \begin{theorem}[Rank-one test for $k$-positivity]\label{thm:k_positive_rank_one_test}

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -487,21 +487,23 @@ maps.
     side equals $\nu + (\nu_j-\nu)\,\|\rho_j\|_{(n)}$.
 \end{proof}
 
-\begin{theorem}[Spectral bounds at the top Schmidt rank]
+\begin{theorem}[Spectral criterion at the top Schmidt rank]
     \label{thm:spectral_bound_schmidt_rank_top}
     \lean{Matrix.IsHermitian.spectral_lower_bound_top,
-        Matrix.IsHermitian.spectral_upper_bound_top}
+        Matrix.IsHermitian.exists_spectral_lower_bound_top}
     \leanok
     \uses{lem:eigenbasis_rayleigh, lem:eigenbasis_parseval}
     At the top index $n=D'$ the Schmidt-rank constraint is vacuous and each
-    Ky-Fan $D'$-norm collapses to $\|\rho_i\|_{(D')}=\tr\rho_i=1$, so the spectral
-    bounds reduce to the Rayleigh characterization of the extreme eigenvalues:
-    every normalized vector $\psi$ satisfies
+    Ky-Fan $D'$-norm collapses to $\|\rho_i\|_{(D')}=\tr\rho_i=1$, so both
+    bounds~(3.7) and~(3.8) reduce to the Rayleigh characterization of the least
+    eigenvalue: the lower bound~(3.7) becomes
+    $\nu_{\min}\le\bra{\psi}\tau\ket{\psi}$ for every normalized $\psi$, and the
+    upper bound~(3.8) on the infimum becomes the existence of a normalized
+    eigenvector with $\bra{\psi}\tau\ket{\psi}=\nu_{\min}$. Together they give
     \[
-        \nu_{\min} \le \bra{\psi}\tau\ket{\psi} \le \nu_{\max} ,
+        \inf_{\|\psi\|=1}\bra{\psi}\tau\ket{\psi} = \nu_{\min} ,
     \]
-    with no Schmidt-rank restriction, and both extremes are attained at the
-    corresponding eigenvector. Together with
+    with no Schmidt-rank restriction. Together with
     Theorems~\ref{thm:spectral_lower_bound_schmidt_rank}
     and~\ref{thm:spectral_upper_bound_schmidt_rank} this covers the full range
     $1\le n\le D'$ of \cite[Chapter~3, Proposition~3.2]{Wolf2012Quantum}.
@@ -513,10 +515,11 @@ maps.
     The eigenbasis expansion
     $\bra{\psi}\tau\ket{\psi}=\sum_i\nu_i\,|\braket{\phi_i}{\psi}|^2$ together with
     Parseval's identity $\sum_i|\braket{\phi_i}{\psi}|^2=1$ bounds each weight
-    $\nu_i$ between $\nu_{\min}$ and $\nu_{\max}$, giving
-    $\nu_{\min}\le\bra{\psi}\tau\ket{\psi}\le\nu_{\max}$. Evaluating at the
-    eigenvector $\phi_j$ returns $\bra{\phi_j}\tau\ket{\phi_j}=\nu_j$, so the
-    extremes are attained.
+    $\nu_i$ below by $\nu_{\min}$, giving
+    $\nu_{\min}\le\bra{\psi}\tau\ket{\psi}$. Evaluating at the eigenvector
+    $\phi_j$ for a least-eigenvalue index $j$ returns
+    $\bra{\phi_j}\tau\ket{\phi_j}=\nu_j=\nu_{\min}$, so the lower bound is
+    attained and the infimum equals $\nu_{\min}$.
 \end{proof}
 
 \begin{theorem}[Rank-one test for $k$-positivity]\label{thm:k_positive_rank_one_test}

--- a/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
@@ -55,23 +55,28 @@ realizes the upper bound~(3.8).
 
 The top index $n=D'$ is resolved by a route that bypasses the $n<D'$ restriction
 of the maximal-overlap and Ky-Fan principles. At $n=D'$ the Schmidt-rank
-constraint is vacuous: every normalized vector qualifies, $\|\rho_i\|_{(D')}
-=\tr\rho_i=1$, and both bounds collapse to the elementary spectral estimate
-$\nu_{\min}\le\langle\psi|\tau|\psi\rangle\le\nu_{\max}$. This estimate is the
-Rayleigh characterization of the extreme eigenvalues, which follows directly from
-the Rayleigh expansion $\langle\psi|\tau|\psi\rangle=\sum_i\nu_i
-|\langle\phi_i|\psi\rangle|^2$ and Parseval's identity $\sum_i
-|\langle\phi_i|\psi\rangle|^2=1$ by comparing each $\nu_i$ against $\nu_{\min}$
-respectively $\nu_{\max}$; both extremes are attained at the corresponding
-eigenvector. The Ky-Fan machinery of the $n<D'$ proof is not invoked.
+constraint is vacuous: every normalized vector qualifies and
+$\|\rho_i\|_{(D')}=\tr\rho_i=1$. Both bounds therefore constrain the same quantity,
+the infimum of $\langle\psi|\tau|\psi\rangle$ over all normalized vectors:
+\begin{itemize}
+  \item The lower bound~(3.7) becomes $\nu_{\min}\le\langle\psi|\tau|\psi\rangle$
+  for every normalized $\psi$, so $\inf_\psi\langle\psi|\tau|\psi\rangle\ge
+  \nu_{\min}$.
+  \item The upper bound~(3.8) on the infimum becomes the existence of a normalized
+  vector with $\langle\psi|\tau|\psi\rangle=\nu_{\min}$, namely a least-eigenvalue
+  eigenvector, so $\inf_\psi\langle\psi|\tau|\psi\rangle\le\nu_{\min}$.
+\end{itemize}
+Together they give $\inf_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$. Both facts
+follow directly from the Rayleigh expansion $\langle\psi|\tau|\psi\rangle=\sum_i
+\nu_i|\langle\phi_i|\psi\rangle|^2$ and Parseval's identity $\sum_i
+|\langle\phi_i|\psi\rangle|^2=1$, comparing each $\nu_i$ against $\nu_{\min}$ and
+evaluating at the least-eigenvalue eigenvector; the Ky-Fan machinery of the $n<D'$
+proof is not invoked.
 
-The top-index bounds are recorded as
-\leanid{Matrix.IsHermitian.spectral_lower_bound_top} (with attainment
-\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top}) and
-\leanid{Matrix.IsHermitian.spectral_upper_bound_top} (with attainment
-\leanid{Matrix.IsHermitian.exists_spectral_upper_bound_top}), giving
-$\min_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$ and the dual identity for the
-maximum, with no Schmidt-rank restriction on $\psi$.
+The top-index endpoint is recorded as
+\leanid{Matrix.IsHermitian.spectral_lower_bound_top} for~(3.7) and
+\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top} for~(3.8), which
+together state $\min_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$.
 
 \section{Classification}
 
@@ -79,8 +84,9 @@ maximum, with no Schmidt-rank restriction on $\psi$.
 is now formalized: the per-vector bounds
 \leanid{Matrix.IsHermitian.spectral_lower_bound} and
 \leanid{Matrix.IsHermitian.exists_le_spectral_upper_bound} for $1\le n<D'$, and
-the Rayleigh characterization \leanid{Matrix.IsHermitian.spectral_lower_bound_top}
-and \leanid{Matrix.IsHermitian.spectral_upper_bound_top} for the
+their top-index endpoints
+\leanid{Matrix.IsHermitian.spectral_lower_bound_top}~(3.7) and
+\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top}~(3.8) for the
 completely-positive endpoint $n=D'$, by the route detailed in the Status above.
 No hypothesis foreign to the source is used.
 

--- a/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
+++ b/docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex
@@ -43,50 +43,46 @@ scope.
 
 \section{Formalized statement}
 
-The formal theorems\footnote{Formal declarations:
+For Schmidt ranks $1\le n<D'$ the formal theorems\footnote{Formal declarations:
     \leanid{Matrix.IsHermitian.spectral_lower_bound} and
     \leanid{Matrix.IsHermitian.exists_le_spectral_upper_bound} in
     \doclink{TNLean/Channel/NPositivitySpectralCriterion}.}
 establish these bounds in the per-vector form: every normalized vector $\psi$ of
 Schmidt rank at most $n$ satisfies the lower bound~(3.7), and some such $\psi$
-realizes the upper bound~(3.8). The hypotheses are $1\le n$ and $n<D'$.
+realizes the upper bound~(3.8).
 
-\section{The gap}
+\section{Status}
 
-The formalization omits the top index $n=D'$. At $n=D'$ the Schmidt-rank
+The top index $n=D'$ is resolved by a route that bypasses the $n<D'$ restriction
+of the maximal-overlap and Ky-Fan principles. At $n=D'$ the Schmidt-rank
 constraint is vacuous: every normalized vector qualifies, $\|\rho_i\|_{(D')}
-=\tr\rho_i=1$, and both bounds collapse to the elementary estimate
-$\nu_{\min}\le\langle\psi|\tau|\psi\rangle\le\nu_{\max}$.
+=\tr\rho_i=1$, and both bounds collapse to the elementary spectral estimate
+$\nu_{\min}\le\langle\psi|\tau|\psi\rangle\le\nu_{\max}$. This estimate is the
+Rayleigh characterization of the extreme eigenvalues, which follows directly from
+the Rayleigh expansion $\langle\psi|\tau|\psi\rangle=\sum_i\nu_i
+|\langle\phi_i|\psi\rangle|^2$ and Parseval's identity $\sum_i
+|\langle\phi_i|\psi\rangle|^2=1$ by comparing each $\nu_i$ against $\nu_{\min}$
+respectively $\nu_{\max}$; both extremes are attained at the corresponding
+eigenvector. The Ky-Fan machinery of the $n<D'$ proof is not invoked.
 
-The restriction is inherited from the maximal-overlap lemma,\footnote{Formal
-    declaration: \leanid{Matrix.maximalSchmidtOverlap_eq_kyFanNorm}; its own
-    top-index gap is recorded in
-    \path{docs/paper-gaps/wolf_lemma_3_1_top_index_scope.tex}.} which supplies
-the per-eigenvector overlap bound
-$|\langle\phi_i|\psi\rangle|^2\le\|\rho_i\|_{(n)}$ only for $n<D'$, because the
-underlying Ky-Fan maximum principle\footnote{Formal declaration:
-    \leanid{Matrix.IsHermitian.kyFanNorm_eq_sup_trace}.} is stated for
-rank-exactly-$n$ orthogonal projections with $n<D'$.
-
-\section{Elimination plan}
-
-Extend the maximal-overlap lemma to the top index $n=D'$ (its own elimination
-plan adds the $n=D'$ case to the Ky-Fan maximum principle, where the maximizing
-projection is the identity). The spectral bounds then extend to $1\le n\le D'$
-by feeding that case into the same per-eigenvector overlap step; the algebraic
-cores\footnote{Formal declarations:
-    \leanid{Matrix.IsHermitian.spectral_lower_bound_core} and
-    \leanid{Matrix.IsHermitian.spectral_upper_bound_core}.} are already
-index-agnostic.
+The top-index bounds are recorded as
+\leanid{Matrix.IsHermitian.spectral_lower_bound_top} (with attainment
+\leanid{Matrix.IsHermitian.exists_spectral_lower_bound_top}) and
+\leanid{Matrix.IsHermitian.spectral_upper_bound_top} (with attainment
+\leanid{Matrix.IsHermitian.exists_spectral_upper_bound_top}), giving
+$\min_\psi\langle\psi|\tau|\psi\rangle=\nu_{\min}$ and the dual identity for the
+maximum, with no Schmidt-rank restriction on $\psi$.
 
 \section{Classification}
 
-\emph{Scope restriction.} The formal theorems prove the source bounds~(3.7)
-and~(3.8) for Schmidt ranks $1\le n<D'$, a special case of the source's full
-range $1\le n\le D'$. The conclusions match the source on that range; only the
-top index $n=D'$ is omitted, and there the bounds degenerate to the trivial
-spectral estimate. No hypothesis foreign to the source is used, so the
-deviation is a scope restriction rather than an unfaithful theorem.
+\emph{Resolved.} The full source range $1\le n\le D'$ of bounds~(3.7) and~(3.8)
+is now formalized: the per-vector bounds
+\leanid{Matrix.IsHermitian.spectral_lower_bound} and
+\leanid{Matrix.IsHermitian.exists_le_spectral_upper_bound} for $1\le n<D'$, and
+the Rayleigh characterization \leanid{Matrix.IsHermitian.spectral_lower_bound_top}
+and \leanid{Matrix.IsHermitian.spectral_upper_bound_top} for the
+completely-positive endpoint $n=D'$, by the route detailed in the Status above.
+No hypothesis foreign to the source is used.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Resolves the top Schmidt-rank index `n = D` of Wolf's Chapter 3, Proposition 3.2
(the spectral criterion for `n`-positivity), the remaining half of LionSR/QICLean#179.

At `n = D` the Schmidt-rank constraint is vacuous and the Ky-Fan `D`-norm of each
reduced density collapses to its trace (one), so the spectral bounds reduce to the
Rayleigh characterization of the extreme eigenvalues
`λ_min ≤ ⟨ψ|τ|ψ⟩ ≤ λ_max`, attained at the corresponding eigenvectors. This route
bypasses the maximal-overlap / Ky-Fan machinery that the `1 ≤ n < D` proof needs,
matching the degenerate-case reasoning the issue describes.

## Changes

- **`TNLean/Channel/NPositivitySpectralCriterion.lean`**
  - `Matrix.IsHermitian.spectral_lower_bound_top` / `spectral_upper_bound_top` —
    universal Rayleigh bounds for every normalized `ψ`.
  - `Matrix.IsHermitian.exists_spectral_lower_bound_top` /
    `exists_spectral_upper_bound_top` — attainment at an extremal eigenvector,
    giving `min_ψ ⟨ψ|τ|ψ⟩ = λ_min` and the dual identity.
  - Helpers: `star_eigenvector_dotProduct_eigenvector` (eigenvector
    orthonormality `⟨φᵢ|φⱼ⟩ = δᵢⱼ`) and `rayleigh_eigenvector_re`
    (`⟨φⱼ|τ|φⱼ⟩ = νⱼ`).
  - Refresh the `n < D` scope markers to point at the new companions.
- **`docs/paper-gaps/wolf_prop_3_2_top_index_scope.tex`** — reclassified from
  *Scope restriction* to *Resolved*.
- **`blueprint/src/chapter/ch05_schwarz.tex`** — added
  `thm:spectral_bound_schmidt_rank_top`; the `n < D` entries now cross-reference
  it for the full `1 ≤ n ≤ D'` range.

The companion T_η endpoint note (`wolf_t_eta_top_index_scope.tex`) was already
reclassified to *Resolved* in LionSR/TNLean#3546, so LionSR/QICLean#179 is fully addressed.

## Verification

- `lake env lean TNLean/Channel/NPositivitySpectralCriterion.lean` — exit 0,
  no errors, no warnings, no `sorry`/`axiom`.
- `check_reader_facing_prose.py --diff-base HEAD` — no violations.

Closes LionSR/QICLean#179.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure mathematical additions and documentation in a channel/spectral-criterion module; no auth, I/O, or runtime behavior changes.
> 
> **Overview**
> Closes the **top Schmidt-rank index** `n = D'` for Wolf Prop. 3.2 by proving the degenerate case where Schmidt constraints are vacuous and the bounds become **Rayleigh estimates on the least eigenvalue** `ν_min`, without maximal-overlap / Ky-Fan machinery.
> 
> **Lean (`NPositivitySpectralCriterion.lean`):** Adds eigenvector orthonormality (`star_eigenvector_dotProduct_eigenvector`) and `rayleigh_eigenvector_re`, then `spectral_lower_bound_top` (every normalized `ψ` has `⟨ψ|τ|ψ⟩ ≥ λ_min`) and `exists_spectral_lower_bound_top` (attainment at a minimizing eigenvector), together giving `min_ψ ⟨ψ|τ|ψ⟩ = λ_min`. Existing `n < D` theorems are retargeted in their docstrings to these companions for the full `1 ≤ n ≤ D` range.
> 
> **Blueprint & gaps:** New `thm:spectral_bound_schmidt_rank_top` in `ch05_schwarz.tex` with cross-refs from the `n < D'` spectral theorems; `wolf_prop_3_2_top_index_scope.tex` is reclassified from a scope gap to **Resolved**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f7d69ab3428de3b84cebf62799acd59fa63a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->