### PR TITLE
doc(Channel/Schwarz): correct \uses on the data-processing-support blueprint entry

### DIFF
--- a/blueprint/src/chapter/ch19_entropy.tex
+++ b/blueprint/src/chapter/ch19_entropy.tex
@@ -687,8 +687,7 @@ finite-dimensional quantum systems.
     \label{thm:relative_entropy_data_processing_support}
     \lean{Matrix.quantumRelativeEntropy_partialTraceRight_le_support}
     \leanok
-    \uses{def:quantum_relative_entropy, thm:relative_entropy_data_processing,
-        thm:relative_entropy_joint_convexity_support}
+    \uses{def:quantum_relative_entropy, thm:relative_entropy_data_processing}
     For positive semidefinite $\rho, \sigma$ on a tensor product of a system factor
     and an ancilla factor of dimension $d_C$, with the support condition
     $\ker \sigma \subseteq \ker \rho$,
@@ -699,8 +698,7 @@ finite-dimensional quantum systems.
 \end{theorem}
 
 \begin{proof}\leanok
-    \uses{thm:relative_entropy_data_processing,
-        thm:relative_entropy_joint_convexity_support}
+    \uses{thm:relative_entropy_data_processing}
     Let $N$ be the dimension of the joint space. Regularize both arguments through
     the affine trace-shrinking perturbation
     $M_\varepsilon = (1+N\varepsilon)^{-1}(M+\varepsilon\,\mathbf 1)$, which is


### PR DESCRIPTION
## Summary

Addresses #3543. The blueprint entry `thm:relative_entropy_data_processing_support`
(`ch19_entropy.tex`) listed `thm:relative_entropy_joint_convexity_support` in both
its statement-level and proof-level `\uses`, but the Lean proof of
`Matrix.quantumRelativeEntropy_partialTraceRight_le_support` calls only the
positive-definite data-processing inequality
(`quantumRelativeEntropy_partialTraceRight_le`); it never invokes
`convexOn_quantumRelativeEntropy_support`. `\uses` must track the actual proof
dependency, so the spurious joint-convexity entry is removed from both blocks.

The joint-convexity mention in the proof prose ("by the same shared-eigenbasis
scalar-limit argument as the joint convexity on the support domain") is a genuine
analogy, so its `\ref` is kept.

## On the issue's other two items (already addressed at `origin/main`)

- **"unit trace" overstatement in the statement** — the current statement already
  reads "For positive semidefinite $\rho, \sigma$"; there is no "unit trace" phrase.
- **Lean docstring** — the docstring of
  `quantumRelativeEntropy_partialTraceRight_le_support` already disclaims
  normalization: "No trace normalization is required; the intended application is to
  density matrices (trace one)." This is faithful (it states normalization is *not* a
  hypothesis), so no change is needed there.

## Verification

- `check_reader_facing_prose.py --diff-base HEAD` — no violations.
- Blueprint-only change; no Lean code touched. `\lean{}` target unchanged, so
  `leanblueprint checkdecls` is unaffected.

Closes #3543.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only `\uses` correction in the blueprint; no code or mathematical statement changes.
> 
> **Overview**
> **Blueprint metadata fix** for `thm:relative_entropy_data_processing_support` in `ch19_entropy.tex`: `\uses` no longer lists `thm:relative_entropy_joint_convexity_support` on the theorem statement or in its proof block, because the linked Lean proof `Matrix.quantumRelativeEntropy_partialTraceRight_le_support` only depends on the positive-definite data-processing inequality (`thm:relative_entropy_data_processing`).
> 
> The proof text still **cross-references** joint convexity on the support domain as an analogy for the regularization limit; that `\ref` is unchanged. No Lean or statement wording changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b52541b86580d8153a20dc065157ec3693695142. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->