### PR TITLE
feat(Channel): converse and iff for the entanglement-witness criterion (Wolf Prop 3.3)

### DIFF
--- a/TNLean/Channel/EntanglementWitness.lean
+++ b/TNLean/Channel/EntanglementWitness.lean
@@ -49,6 +49,12 @@ expectation nonnegative.
 * `Matrix.exists_isHermitian_witness`: **an entanglement witness exists for every
   trace-one Hermitian state of Schmidt number larger than `n`** (Wolf §3.2,
   Proposition 3.3, the only-if direction).
+* `Matrix.not_hasSchmidtNumberLE_of_exists_witness`: the converse — a state detected by a
+  Schmidt-`n` witness has Schmidt number larger than `n` (no density-matrix hypotheses
+  needed).
+* `Matrix.not_hasSchmidtNumberLE_iff_exists_witness`: **Wolf §3.2, Proposition 3.3** as an
+  iff, for a trace-one Hermitian state: Schmidt number larger than `n` is equivalent to
+  detection by an entanglement witness for `S_n`.
 
 ## References
 
@@ -302,5 +308,52 @@ theorem exists_isHermitian_witness (n : ℕ)
       have : s * f (euclideanProj φ) - c * s = s * (f (euclideanProj φ) - c) := by ring
       rw [this]
       exact mul_nonneg hs_nonneg (by linarith)
+
+/-- **A state detected by a Schmidt-`n` witness is not of Schmidt number at most `n`**
+(Wolf §3.2, Proposition 3.3, if direction).
+
+If a Hermitian operator `W` has negative expectation on ρ but nonnegative expectation on
+every pure state of Schmidt rank at most `n`, then ρ is not of Schmidt number at most `n`.
+This direction needs no density-matrix hypotheses on ρ: if ρ were a sum
+`∑ i, |ψ_i⟩⟨ψ_i|` of pure projectors of Schmidt rank at most `n`, the linearity of the
+trace would make `Re tr(W ρ)` the sum of the nonnegative numbers `Re tr(W |ψ_i⟩⟨ψ_i|)`,
+contradicting its negativity. -/
+theorem not_hasSchmidtNumberLE_of_exists_witness (n : ℕ)
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hW : ∃ W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ, W.IsHermitian ∧
+      (W * ρ).trace.re < 0 ∧
+      ∀ ψ : Fin d × Fin d' → ℂ, HasSchmidtRankLE n ψ →
+        0 ≤ (W * Matrix.vecMulVec ψ (star ψ)).trace.re) :
+    ¬ HasSchmidtNumberLE n ρ := by
+  obtain ⟨W, _, hneg, hpos⟩ := hW
+  rintro ⟨ι, _, ψ, hψ, rfl⟩
+  -- Push the witness multiplication and the trace through the finite sum.
+  have hsum : (W * ∑ i, vecMulVec (ψ i) (star (ψ i))).trace.re
+      = ∑ i, (W * vecMulVec (ψ i) (star (ψ i))).trace.re := by
+    rw [Finset.mul_sum, trace_sum, Complex.re_sum]
+  -- Each summand is nonnegative, so the total is nonnegative, contradicting `hneg`.
+  rw [hsum] at hneg
+  have : 0 ≤ ∑ i, (W * vecMulVec (ψ i) (star (ψ i))).trace.re :=
+    Finset.sum_nonneg fun i _ => hpos (ψ i) (hψ i)
+  linarith
+
+/-- **Wolf's entanglement-witness criterion** (Wolf §3.2, Proposition 3.3).  A trace-one
+Hermitian bipartite state ρ has Schmidt number larger than `n` if and only if there is a
+Hermitian operator `W` whose expectation on ρ is negative while its expectation on every
+pure state of Schmidt rank at most `n` is nonnegative.
+
+The forward implication is the separating-hyperplane construction
+`exists_isHermitian_witness`; the converse `not_hasSchmidtNumberLE_of_exists_witness`
+needs no density-matrix hypotheses on ρ and holds by the linearity of the trace. -/
+theorem not_hasSchmidtNumberLE_iff_exists_witness (n : ℕ)
+    {ρ : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ}
+    (hρH : ρ.IsHermitian) (hρtr : ρ.trace = 1) :
+    ¬ HasSchmidtNumberLE n ρ ↔
+      ∃ W : Matrix (Fin d × Fin d') (Fin d × Fin d') ℂ, W.IsHermitian ∧
+        (W * ρ).trace.re < 0 ∧
+        ∀ ψ : Fin d × Fin d' → ℂ, HasSchmidtRankLE n ψ →
+          0 ≤ (W * Matrix.vecMulVec ψ (star ψ)).trace.re :=
+  ⟨fun hρ => exists_isHermitian_witness n hρH hρtr hρ,
+   not_hasSchmidtNumberLE_of_exists_witness n⟩
 
 end Matrix

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -869,3 +869,33 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     $\operatorname{Re}\bra{\psi}W\ket{\psi}\ge 0$, with the zero vector giving the value
     $0$ directly.
 \end{proof}
+
+\begin{theorem}[Witness criterion for Schmidt number]
+    \label{thm:not_has_schmidt_number_le_iff_exists_witness}
+    \lean{Matrix.not_hasSchmidtNumberLE_iff_exists_witness}
+    \leanok
+    \uses{def:has_schmidt_number_le, def:schmidt_rank,
+        thm:exists_entanglement_witness}
+    Let $\rho$ be a trace-one Hermitian bipartite state.  Then the Schmidt number of
+    $\rho$ exceeds $n$ if and only if there is a Hermitian operator $W$ with
+    \[
+        \operatorname{Re}\tr(W\rho)<0,
+        \qquad
+        \operatorname{Re}\bra{\psi}W\ket{\psi}\ge 0
+        \quad\text{for every $\psi$ of Schmidt rank at most }n.
+    \]
+    This is Wolf's Proposition~3.3 \cite[Chapter~3, Proposition~3.3]{Wolf2012Quantum}: a
+    state has Schmidt number larger than $n$ exactly when it is detected by an
+    entanglement witness for $S_n$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The forward implication is the separating-hyperplane construction
+    (\ref{thm:exists_entanglement_witness}).  For the converse, suppose $\rho$ had Schmidt
+    number at most $n$, so $\rho=\sum_i\ket{\psi_i}\bra{\psi_i}$ with each $\psi_i$ of
+    Schmidt rank at most $n$.  By linearity of the trace,
+    $\operatorname{Re}\tr(W\rho)=\sum_i\operatorname{Re}\tr\!\bigl(W\ket{\psi_i}\bra{\psi_i}\bigr)$,
+    a sum of nonnegative terms, contradicting $\operatorname{Re}\tr(W\rho)<0$.  This
+    converse uses no density-matrix hypotheses on $\rho$.
+\end{proof}


### PR DESCRIPTION
Completes both directions of Wolf's Proposition 3.3 (Chapter 3, Section 3.2, *Detecting entanglement*). The hard only-if direction (`Matrix.exists_isHermitian_witness`, the separating-hyperplane construction) was merged in #3553; this PR adds the short converse and assembles the iff.

## New results (in `TNLean/Channel/EntanglementWitness.lean`)

- `Matrix.not_hasSchmidtNumberLE_of_exists_witness`: the converse — if a Hermitian `W` has negative expectation on ρ but nonnegative expectation on every pure state of Schmidt rank at most `n`, then ρ is not of Schmidt number at most `n`. Proof: if ρ were `∑ i, |ψ_i⟩⟨ψ_i|`, linearity of the trace makes `Re tr(W ρ)` a sum of nonnegative terms, contradicting its negativity. This direction needs no density-matrix hypotheses on ρ, so the signature is kept hypothesis-minimal.
- `Matrix.not_hasSchmidtNumberLE_iff_exists_witness`: Wolf Prop 3.3 as an iff, for a trace-one Hermitian state.

## Blueprint

Adds `thm:not_has_schmidt_number_le_iff_exists_witness` (the iff) to `ch25_positive_not_cp.tex`, with `\lean` + `\leanok` and `\uses{thm:exists_entanglement_witness, ...}`, citing Wolf Prop 3.3.

## Verification

- `lake build TNLean.Channel.EntanglementWitness` succeeds (3027 jobs).
- No `sorry`/`axiom`/`native_decide`.
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` clean.
- `python3 scripts/blueprint_lean_sync.py --ci` in sync (ch25 44/44).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and blueprint sync only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Completes **Wolf Proposition 3.3** as a biconditional for trace-one Hermitian bipartite states: Schmidt number larger than `n` iff a Hermitian witness has negative expectation on ρ and nonnegative expectation on every pure state of Schmidt rank at most `n`.
> 
> Adds **`Matrix.not_hasSchmidtNumberLE_of_exists_witness`**, the short converse (trace linearity over a Schmidt-number-≤`n` decomposition contradicts negative `Re tr(Wρ)`), with **no extra density-matrix hypotheses** on ρ. **`Matrix.not_hasSchmidtNumberLE_iff_exists_witness`** packages that with the existing separating-hyperplane construction `exists_isHermitian_witness`.
> 
> The module header documents the new results; the blueprint gains **`thm:not_has_schmidt_number_le_iff_exists_witness`** in `ch25_positive_not_cp.tex` with `\lean` / `\uses` wiring to the forward witness theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968fe33385be4497c7f81fcf662095ba7e97bb3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->