### PR TITLE
doc(Channel): blueprint coverage for HasSchmidtNumberLE.smul (#3545)

### DIFF
--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -559,12 +559,13 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
 \begin{theorem}[Basic properties of bounded Schmidt number]
     \label{thm:has_schmidt_number_le_basic}
     \lean{Matrix.HasSchmidtNumberLE.posSemidef, Matrix.HasSchmidtNumberLE.add,
-        Matrix.HasSchmidtNumberLE.mono}
+        Matrix.HasSchmidtNumberLE.mono, Matrix.HasSchmidtNumberLE.smul}
     \leanok
     \uses{def:has_schmidt_number_le}
     A matrix of Schmidt number at most $n$ is positive semidefinite.  States of
-    Schmidt number at most $n$ are closed under addition, and a bound on the Schmidt
-    number relaxes to any larger bound.
+    Schmidt number at most $n$ are closed under addition and under multiplication by a
+    nonnegative real scalar, and a bound on the Schmidt number relaxes to any larger
+    bound.
 \end{theorem}
 
 \begin{proof}
@@ -574,7 +575,9 @@ of its weight scales its coefficient matrix and so leaves the Schmidt rank uncha
     semidefinite.  Concatenating two pure-state families realizes a sum as a single
     finite sum of pure-state projectors of Schmidt rank at most $n$, and a pure
     summand of Schmidt rank at most $n$ also has Schmidt rank at most any larger
-    bound.
+    bound.  Multiplication by a nonnegative real $a$ rescales each pure summand
+    $\psi_i$ to $\sqrt a\,\psi_i$, which leaves its Schmidt rank unchanged and
+    reproduces $a$ times the original state.
 \end{proof}
 
 \begin{theorem}[Schmidt number one is separability]


### PR DESCRIPTION
Closes LionSR/QICLean#184.

The convexity lemma `Matrix.convex_setOf_hasSchmidtNumberLE` already gained its blueprint entry (`thm:convex_setOf_has_schmidt_number_le`) in LionSR/TNLean#3551. The remaining piece was `Matrix.HasSchmidtNumberLE.smul` (closure under nonnegative real scaling), now folded into the existing basic-properties entry `thm:has_schmidt_number_le_basic` next to `posSemidef`/`add`/`mono` (`\leanok`), with the statement and proof prose updated. Reader-facing prose and blueprint–Lean sync pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in a LaTeX blueprint chapter; no runtime or proof code in the diff.
> 
> **Overview**
> Updates the blueprint theorem **`thm:has_schmidt_number_le_basic`** so it documents closure of bounded Schmidt-number states under **nonnegative real scaling**, alongside the existing `posSemidef`, `add`, and `mono` facts.
> 
> The `\lean{...}` line now includes **`Matrix.HasSchmidtNumberLE.smul`**, and the theorem statement and proof prose explain that scaling by \(a \ge 0\) replaces each pure summand \(\psi_i\) with \(\sqrt{a}\,\psi_i\), preserving Schmidt rank and yielding \(a\) times the original state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 262837667f9c92ec4b9e595174230997521a383c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->