### PR TITLE
feat(Algebra): semisimple/Wedderburn decomposition of a finite-dimensional *-subalgebra of complex matrices

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -38,6 +38,7 @@ import TNLean.Algebra.ScalarCommutant
 import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.SpinCover
 import TNLean.Algebra.MatrixRankClosed
+import TNLean.Algebra.StarSubalgebraSemisimple
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ProjectionGeometry

--- a/TNLean/Algebra/StarSubalgebraSemisimple.lean
+++ b/TNLean/Algebra/StarSubalgebraSemisimple.lean
@@ -18,8 +18,8 @@ numbers it therefore decomposes as a finite product of matrix algebras
 (its Wedderburn–Artin form).
 
 This is the algebraic core of Wolf Ch. 6, towards Thm 6.14 (the structure of the
-fixed-point set of a Schwarz map), and resolves the missing decomposition step
-recorded in issue #27.
+fixed-point set of a Schwarz map), supplying the semisimple-decomposition step of
+that structure theory.
 
 ## Main results
 
@@ -47,7 +47,7 @@ The full theorem also asserts that the decomposition is implemented by a single
 *unitary* conjugation bringing the subalgebra to block-diagonal form (each block a
 full matrix algebra times the identity on a multiplicity space). That ⋆- and
 unitary-upgrade of the abstract algebra isomorphism is not formalized here; it is
-the remaining step for issue #27.
+the remaining step towards Wolf Thm 6.14.
 -/
 
 open scoped Matrix ComplexOrder
@@ -80,7 +80,7 @@ instance instIsArtinianRing : IsArtinianRing S :=
   IsArtinianRing.of_finite ℂ S
 
 /-- A finite-dimensional ⋆-subalgebra of the complex matrix algebra is a semisimple
-ring. Wolf Ch. 6, towards Thm 6.14; see issue #27. -/
+ring. Wolf Ch. 6, towards Thm 6.14. -/
 instance isSemisimpleRing : IsSemisimpleRing S := by
   rw [IsArtinianRing.isSemisimpleRing_iff_jacobson]
   -- The Jacobson radical is nilpotent because the ring is Artinian.
@@ -107,7 +107,7 @@ instance isSemisimpleRing : IsSemisimpleRing S := by
 
 /-- The Wedderburn–Artin decomposition of a finite-dimensional ⋆-subalgebra of
 the complex matrix algebra: it is isomorphic, as a `ℂ`-algebra, to a finite
-product of complex matrix algebras. Wolf Ch. 6, towards Thm 6.14; see issue #27. -/
+product of complex matrix algebras. Wolf Ch. 6, towards Thm 6.14. -/
 theorem exists_algEquiv_pi_matrix :
     ∃ (k : ℕ) (d : Fin k → ℕ),
       Nonempty (S ≃ₐ[ℂ] Π i, Matrix (Fin (d i)) (Fin (d i)) ℂ) := by

--- a/TNLean/Algebra/StarSubalgebraSemisimple.lean
+++ b/TNLean/Algebra/StarSubalgebraSemisimple.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Coeff
+import Mathlib.Algebra.Star.Subalgebra
+import Mathlib.RingTheory.Artinian.Module
+import Mathlib.RingTheory.Jacobson.Semiprimary
+import Mathlib.RingTheory.SimpleModule.IsAlgClosed
+import Mathlib.Analysis.Complex.Polynomial.Basic
+
+/-!
+# Semisimplicity of a finite-dimensional ⋆-subalgebra of complex matrices
+
+A ⋆-subalgebra of the complex matrix algebra is semisimple, and over the complex
+numbers it therefore decomposes as a finite product of matrix algebras
+(its Wedderburn–Artin form).
+
+This is the algebraic core of Wolf Ch. 6, towards Thm 6.14 (the structure of the
+fixed-point set of a Schwarz map), and resolves the missing decomposition step
+recorded in issue #27.
+
+## Main results
+
+* `Matrix.eq_zero_of_isNilpotent_conjTranspose_mul_self` — if the positive
+  semidefinite matrix `Aᴴ * A` is nilpotent, then `A = 0`.
+* `StarSubalgebra.isSemisimpleRing` — a ⋆-subalgebra of `Matrix n n ℂ` is a
+  semisimple ring.
+* `StarSubalgebra.exists_algEquiv_pi_matrix` — such a ⋆-subalgebra is isomorphic,
+  as a `ℂ`-algebra, to a finite product of complex matrix algebras.
+
+## Proof outline
+
+A finite-dimensional algebra over a field is Artinian, so its Jacobson radical is
+nilpotent. If `x` lies in the radical, then `x⋆ * x` lies there too (the radical
+is a two-sided ideal), hence is nilpotent. In `Matrix n n ℂ` the element
+`x⋆ * x = (↑x)ᴴ * ↑x` is positive semidefinite, and a nilpotent positive
+semidefinite matrix vanishes (its trace is a nilpotent complex number, hence
+zero, and `(Aᴴ * A).trace = 0 ↔ A = 0`). Therefore `↑x = 0`, so the radical is
+trivial and the subalgebra is semisimple. Wedderburn–Artin over an algebraically
+closed field then gives the product-of-matrix-algebras decomposition.
+
+## Remaining gap towards Wolf Thm 6.14
+
+The full theorem also asserts that the decomposition is implemented by a single
+*unitary* conjugation bringing the subalgebra to block-diagonal form (each block a
+full matrix algebra times the identity on a multiplicity space). That ⋆- and
+unitary-upgrade of the abstract algebra isomorphism is not formalized here; it is
+the remaining step for issue #27.
+-/
+
+open scoped Matrix ComplexOrder
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- A nilpotent positive semidefinite complex matrix is zero: if `Aᴴ * A` is
+nilpotent then `A = 0`. The trace of a nilpotent matrix is a nilpotent complex
+number, hence zero, and `(Aᴴ * A).trace = 0 ↔ A = 0`. -/
+theorem eq_zero_of_isNilpotent_conjTranspose_mul_self {A : Matrix n n ℂ}
+    (h : IsNilpotent (Aᴴ * A)) : A = 0 := by
+  have htr : IsNilpotent (Aᴴ * A).trace := Matrix.isNilpotent_trace_of_isNilpotent h
+  exact Matrix.trace_conjTranspose_mul_self_eq_zero_iff.mp htr.eq_zero
+
+end Matrix
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+/-- A ⋆-subalgebra of `Matrix n n ℂ` is module-finite over `ℂ`, being a `ℂ`-submodule
+of the finite-dimensional algebra `Matrix n n ℂ`. -/
+instance instModuleFinite : Module.Finite ℂ S :=
+  (inferInstance : Module.Finite ℂ S.toSubalgebra)
+
+instance instIsArtinianRing : IsArtinianRing S :=
+  IsArtinianRing.of_finite ℂ S
+
+/-- A finite-dimensional ⋆-subalgebra of the complex matrix algebra is a semisimple
+ring. Wolf Ch. 6, towards Thm 6.14; see issue #27. -/
+instance isSemisimpleRing : IsSemisimpleRing S := by
+  rw [IsArtinianRing.isSemisimpleRing_iff_jacobson]
+  -- The Jacobson radical is nilpotent because the ring is Artinian.
+  obtain ⟨k, hk⟩ := (IsSemiprimaryRing.isNilpotent (R := S))
+  refine le_antisymm (fun x hx => ?_) bot_le
+  rw [Submodule.mem_bot]
+  -- `x⋆ * x` lies in the (two-sided) radical, hence is nilpotent.
+  have hmem : star x * x ∈ Ring.jacobson S := Ideal.mul_mem_left _ _ hx
+  have hnil : IsNilpotent (star x * x) := by
+    refine ⟨k, ?_⟩
+    have hpow : (star x * x) ^ k ∈ Ring.jacobson S ^ k := Ideal.pow_mem_pow hmem k
+    rw [hk] at hpow
+    exact (Submodule.mem_bot _).mp hpow
+  -- Transfer the nilpotency to the matrix `Aᴴ * A` and apply the matrix lemma.
+  set A : Matrix n n ℂ := (x : Matrix n n ℂ) with hA
+  have hcoe : ((star x * x : S) : Matrix n n ℂ) = Aᴴ * A := by
+    push_cast
+    rw [StarMemClass.coe_star, Matrix.star_eq_conjTranspose, hA]
+  have hnilM : IsNilpotent (Aᴴ * A) := by
+    rw [← hcoe]
+    exact hnil.map S.subtype.toRingHom
+  have hx0 : A = 0 := Matrix.eq_zero_of_isNilpotent_conjTranspose_mul_self hnilM
+  exact Subtype.ext (hx0.trans (ZeroMemClass.coe_zero S).symm)
+
+/-- The Wedderburn–Artin decomposition of a finite-dimensional ⋆-subalgebra of
+the complex matrix algebra: it is isomorphic, as a `ℂ`-algebra, to a finite
+product of complex matrix algebras. Wolf Ch. 6, towards Thm 6.14; see issue #27. -/
+theorem exists_algEquiv_pi_matrix :
+    ∃ (k : ℕ) (d : Fin k → ℕ),
+      Nonempty (S ≃ₐ[ℂ] Π i, Matrix (Fin (d i)) (Fin (d i)) ℂ) := by
+  obtain ⟨k, d, _, he⟩ := IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed ℂ S
+  exact ⟨k, d, he⟩
+
+end StarSubalgebra

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1117,6 +1117,48 @@ Jacobson radical characterization of semisimplicity together with the
 Wedderburn--Artin structure theorem for finite-dimensional semisimple
 algebras over an algebraically closed field.
 
+The algebraic core is the semisimplicity of an arbitrary $*$-subalgebra of a
+complex matrix algebra, from which the abstract Wedderburn--Artin decomposition
+follows. The fixed-point algebra of a trace-preserving Kraus map is then the
+special case used in this section.
+
+\begin{lemma}[A $*$-subalgebra of a matrix algebra is semisimple]%
+    \label{lem:starSubalgebra_isSemisimpleRing}
+    \lean{StarSubalgebra.isSemisimpleRing}
+    \leanok
+    Every $*$-subalgebra of $\MN{D}$ is a semisimple ring.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The subalgebra is finite-dimensional, hence Artinian, so its Jacobson
+    radical $J$ is nilpotent. If $x \in J$ then $x^*x \in J$, since the radical
+    is a two-sided ideal. In the matrix algebra $x^*x$ is positive
+    semidefinite, and a positive semidefinite nilpotent matrix vanishes: its
+    trace is a nilpotent complex number, hence zero, and the trace of $x^*x$
+    vanishes only when $x = 0$. Thus $J = 0$ and the subalgebra is semisimple.
+\end{proof}
+
+\begin{theorem}[Abstract Wedderburn--Artin decomposition for $*$-subalgebras]%
+    \label{thm:starSubalgebra_wedderburnArtin}
+    \lean{StarSubalgebra.exists_algEquiv_pi_matrix}
+    \leanok
+    \uses{lem:starSubalgebra_isSemisimpleRing}
+    There exist $n \in \N$ and dimensions $d_1,\ldots,d_n \ge 1$ such that every
+    $*$-subalgebra of $\MN{D}$ is $\C$-algebra isomorphic to
+    \[
+        \prod_{k=1}^{n} \MN{d_k}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_isSemisimpleRing}
+    Combine semisimplicity (Lemma~\ref{lem:starSubalgebra_isSemisimpleRing})
+    with the Wedderburn--Artin structure theorem for finite-dimensional
+    semisimple algebras over the algebraically closed field $\C$.
+\end{proof}
+
 \begin{theorem}[Fixed-point algebra is semisimple]%
     \label{thm:fixedPointAlgebra_isSemisimpleRing}
     \lean{Kraus.fixedPointAlgebra_isSemisimpleRing}


### PR DESCRIPTION
## Summary

Adds `TNLean/Algebra/StarSubalgebraSemisimple.lean`: a finite-dimensional ⋆-subalgebra of the complex matrix algebra is a **semisimple ring**, and over ℂ it **decomposes as a finite product of matrix algebras** (its Wedderburn–Artin form).

This is the algebraic core of **Wolf Ch. 6, towards Thm 6.14** (the structure of the fixed-point set of a Schwarz map), and resolves the missing decomposition step recorded in **issue LionSR/QICLean#39**.

## Main results

- `Matrix.eq_zero_of_isNilpotent_conjTranspose_mul_self` — a nilpotent positive semidefinite matrix is zero: if `Aᴴ * A` is nilpotent then `A = 0`.
- `StarSubalgebra.isSemisimpleRing` — a ⋆-subalgebra of `Matrix n n ℂ` is a semisimple ring.
- `StarSubalgebra.exists_algEquiv_pi_matrix` — such a ⋆-subalgebra is isomorphic, as a ℂ-algebra, to a finite product of complex matrix algebras.

Supporting instances `StarSubalgebra.instModuleFinite` and `StarSubalgebra.instIsArtinianRing` are provided.

## Proof outline

A finite-dimensional algebra over a field is Artinian, so its Jacobson radical is nilpotent (`IsSemiprimaryRing`). If `x` lies in the radical, then `star x * x` lies there too (two-sided ideal), hence is nilpotent. In `Matrix n n ℂ` this element is `(↑x)ᴴ * ↑x`, a positive semidefinite matrix; a nilpotent matrix has nilpotent trace, which over ℂ (reduced) is `0`, and `(Aᴴ * A).trace = 0 ↔ A = 0` forces `↑x = 0`. Hence the radical is trivial (`IsArtinianRing.isSemisimpleRing_iff_jacobson`), so the subalgebra is semisimple. Wedderburn–Artin over an algebraically closed field (`IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`) gives the product decomposition.

Built entirely from existing Mathlib API; no new sorrys or axioms.

## Out of scope (remaining gap for LionSR/QICLean#39 Thm 6.14)

The full theorem also asserts the decomposition is implemented by a single **unitary** conjugation bringing the subalgebra to block-diagonal form. That ⋆-/unitary upgrade of the abstract algebra isomorphism is not formalized here and is noted as the remaining step in the module docstring.

## Verification

- `lake env lean TNLean/Algebra/StarSubalgebraSemisimple.lean` exits 0.
- `#print axioms` on all three results: `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no custom axioms).
- No `sorry`/`admit`/`axiom`/`native_decide` in the file.
- `lake exe lint-style` on the file: clean.

Refs LionSR/QICLean#39.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib-only algebra with no changes to channel/runtime logic; only adds a root import and blueprint documentation.
> 
> **Overview**
> Adds **`TNLean/Algebra/StarSubalgebraSemisimple.lean`** and exports it from **`TNLean.lean`**, formalizing that any finite-dimensional ⋆-subalgebra of `Matrix n n ℂ` is **semisimple** and **ℂ-algebra isomorphic to a finite product of matrix algebras** (abstract Wedderburn–Artin), toward Wolf Ch. 6 / Thm 6.14 (#27).
> 
> The proof kills the Jacobson radical via **`star x * x`** (nilpotent PSD ⇒ zero, using new **`Matrix.eq_zero_of_isNilpotent_conjTranspose_mul_self`**), then applies Mathlib’s semisimple-over-ℂ decomposition. **Unitary block-diagonal realization** is explicitly left out of scope.
> 
> **`blueprint/src/chapter/ch07_spectral.tex`** now states this general ⋆-subalgebra layer (new lemma + theorem with `\lean` links) before the existing Kraus fixed-point semisimplicity/Wedderburn theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9308a12b46604133afaf861a210b2816586f645e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->