### PR TITLE
fix(Algebra): assert positive block sizes in the *-subalgebra Wedderburn decomposition

### DIFF
--- a/TNLean/Algebra/StarSubalgebraSemisimple.lean
+++ b/TNLean/Algebra/StarSubalgebraSemisimple.lean
@@ -28,7 +28,8 @@ that structure theory.
 * `StarSubalgebra.isSemisimpleRing` — a ⋆-subalgebra of `Matrix n n ℂ` is a
   semisimple ring.
 * `StarSubalgebra.exists_algEquiv_pi_matrix` — such a ⋆-subalgebra is isomorphic,
-  as a `ℂ`-algebra, to a finite product of complex matrix algebras.
+  as a `ℂ`-algebra, to a finite product of complex matrix algebras with positive
+  block sizes.
 
 ## Proof outline
 
@@ -107,11 +108,12 @@ instance isSemisimpleRing : IsSemisimpleRing S := by
 
 /-- The Wedderburn–Artin decomposition of a finite-dimensional ⋆-subalgebra of
 the complex matrix algebra: it is isomorphic, as a `ℂ`-algebra, to a finite
-product of complex matrix algebras. Wolf Ch. 6, towards Thm 6.14. -/
+product of complex matrix algebras with positive block sizes. Wolf Ch. 6,
+towards Thm 6.14. -/
 theorem exists_algEquiv_pi_matrix :
-    ∃ (k : ℕ) (d : Fin k → ℕ),
+    ∃ (k : ℕ) (d : Fin k → ℕ), (∀ i, NeZero (d i)) ∧
       Nonempty (S ≃ₐ[ℂ] Π i, Matrix (Fin (d i)) (Fin (d i)) ℂ) := by
-  obtain ⟨k, d, _, he⟩ := IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed ℂ S
-  exact ⟨k, d, he⟩
+  obtain ⟨k, d, hd, he⟩ := IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed ℂ S
+  exact ⟨k, d, hd, he⟩
 
 end StarSubalgebra


### PR DESCRIPTION
## Summary

Follow-up to #3561. A re-review thread flagged that the blueprint entry `thm:starSubalgebra_wedderburnArtin` ("dimensions $d_1,\ldots,d_n \ge 1$", `\leanok`) was **stronger** than the Lean statement: `StarSubalgebra.exists_algEquiv_pi_matrix` only produced `d : Fin k → ℕ` with no positivity, so the `\leanok` was not faithful (Category A.1/A.2).

The fix keeps the positivity clause that the Mathlib source already returns. `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed` yields

```
∃ (n) (d), (∀ i, NeZero (d i)) ∧ Nonempty (R ≃ₐ[F] Π i, Matrix (Fin (d i)) (Fin (d i)) F)
```

and the original proof discarded the `(∀ i, NeZero (d i))` component as `_`. Re-adding it:

- makes the statement match the blueprint entry ($d_i \ge 1$) and restores the `\leanok`;
- aligns with the Kraus-specialised `Kraus.fixedPointAlgebra_wedderburnArtin`, which already asserts `∀ i, NeZero (dims i)`;
- strengthens the general lemma (positive block sizes) at no proof cost, a better foundation for the Prop 3.8 cone-automorphism classification.

No blueprint change is needed — the existing `≥ 1` statement is now faithful. The theorem has no downstream consumers yet, so the signature change cascades nowhere.

## Verification
- `rg sorry|admit|native_decide`: clean.
- Proof is a direct repackaging of the Mathlib lemma's existing output; no new imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-theorem signature/doc tweak with no new proof steps; no downstream callers of this wrapper were found that would break.
> 
> **Overview**
> **`StarSubalgebra.exists_algEquiv_pi_matrix`** is strengthened so the Wedderburn–Artin decomposition includes **`∀ i, NeZero (d i)`** (each block dimension is at least 1), matching the blueprint’s $d_i \ge 1$ and the Kraus fixed-point variant that already had this clause.
> 
> The proof only changes how the result is unpacked from **`IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`**: the **`hd`** positivity component is kept and returned instead of being ignored as **`_`**. Module docstrings for the main result and theorem are updated to mention positive block sizes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d47bb6a62e6b0301d5045792ff0a32da6ec8c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->