### PR TITLE
feat(Channel): positivity of the Breuer-Hall map (Wolf Example 3.1)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -56,6 +56,7 @@ import TNLean.Topology.CompactRetractFixedPoint
 -- Layer 2: Quantum channels (general theory)
 import TNLean.Channel.Basic
 import TNLean.Channel.PositiveExamples
+import TNLean.Channel.BreuerHallMap
 import TNLean.Channel.DensityRetract
 
 -- Layer 2 (Ch. 2 infrastructure): Choi–Jamiolkowski, Kraus, Stinespring

--- a/TNLean/Channel/BreuerHallMap.lean
+++ b/TNLean/Channel/BreuerHallMap.lean
@@ -1,0 +1,276 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import Mathlib.Analysis.InnerProductSpace.PiL2
+import TNLean.Channel.Basic
+import TNLean.Algebra.MatrixSpectralDecomp
+
+/-!
+# Positivity of the Breuer-Hall map
+
+This file records the **Breuer-Hall map**, one of the concrete positive maps of
+Wolf Chapter 3, Example 3.1, equation (3.19).  For a fixed antisymmetric
+contraction `U` on `M_D(ℂ)` it is the map
+`T_BH(X) = (tr X) I - X - U Xᵀ Uᴴ`.
+
+The main result `Matrix.breuerHallMap_isPositiveMap` shows that `T_BH` is a
+positive map: it sends positive semidefinite matrices to positive semidefinite
+matrices.
+
+The proof reduces positivity to the rank-one case: a positive semidefinite
+matrix is a sum of rank-one outer products `v vᴴ`
+(`Matrix.PosSemidef.eq_sum_vecMulVec_nonzero_eigs`), and on such a matrix
+`T_BH(v vᴴ) = ‖v‖² I - v vᴴ - (U v̄)(U v̄)ᴴ`.  The two vectors `v` and `U v̄` are
+orthogonal (by antisymmetry of `U`) and `‖U v̄‖ ≤ ‖v‖` (by the contraction
+property), so the quadratic form is nonnegative by a two-vector form of Bessel's
+inequality.
+
+Indecomposability of the Breuer-Hall map and the `n`-positivity threshold are
+not treated here; only positivity is established.
+
+## Main declarations
+
+* `Matrix.breuerHallMap` -- the Breuer-Hall map `T_BH`.
+* `Matrix.breuerHallMap_isPositiveMap` -- `T_BH` is a positive map.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Example 3.1, equation (3.19)][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder InnerProductSpace
+open Matrix
+
+namespace Matrix
+
+variable {d : ℕ}
+
+/-! ## A two-vector orthogonal Bessel inequality -/
+
+section InnerProductAux
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℂ E]
+
+/-- For orthogonal vectors `x ⟂ y` with `‖y‖ ≤ ‖x‖`, the squared overlaps of any
+`w` with `x` and `y` add up to at most `‖x‖² ‖w‖²`.  This is the two-vector form
+of Bessel's inequality used to control the quadratic form of the Breuer-Hall
+map. -/
+theorem orthogonal_two_inner_normSq_le {x y : E} (hxy : ⟪x, y⟫_ℂ = 0)
+    (hyx : ‖y‖ ≤ ‖x‖) (w : E) :
+    ‖⟪x, w⟫_ℂ‖ ^ 2 + ‖⟪y, w⟫_ℂ‖ ^ 2 ≤ ‖x‖ ^ 2 * ‖w‖ ^ 2 := by
+  set s : ℝ := ‖x‖ ^ 2 with hs
+  have hs0 : 0 ≤ s := by positivity
+  set g : E := (s : ℂ) • w - ⟪x, w⟫_ℂ • x with hg
+  have hyx' : ⟪y, x⟫_ℂ = 0 := inner_eq_zero_symm.mp hxy
+  have hyg : ⟪y, g⟫_ℂ = (s : ℂ) * ⟪y, w⟫_ℂ := by
+    rw [hg, inner_sub_right, inner_smul_right, inner_smul_right, hyx', mul_zero, sub_zero]
+  have hcross : ⟪(s : ℂ) • w, ⟪x, w⟫_ℂ • x⟫_ℂ = ((s * ‖⟪x, w⟫_ℂ‖ ^ 2 : ℝ) : ℂ) := by
+    rw [inner_smul_left, inner_smul_right, ← inner_conj_symm w x, Complex.conj_ofReal,
+      Complex.mul_conj, Complex.normSq_eq_norm_sq]
+    push_cast; ring
+  have hcrossre : RCLike.re (⟪(s : ℂ) • w, ⟪x, w⟫_ℂ • x⟫_ℂ) = s * ‖⟪x, w⟫_ℂ‖ ^ 2 := by
+    rw [hcross]; exact Complex.ofReal_re _
+  have hgnorm : ‖g‖ ^ 2 = s ^ 2 * ‖w‖ ^ 2 - s * ‖⟪x, w⟫_ℂ‖ ^ 2 := by
+    have hxs : ‖x‖ ^ 2 = s := hs.symm
+    rw [hg, norm_sub_sq (𝕜 := ℂ), hcrossre, norm_smul, norm_smul, Complex.norm_real,
+      Real.norm_of_nonneg hs0]
+    linear_combination ‖⟪x, w⟫_ℂ‖ ^ 2 * hxs
+  have hCSx : ‖⟪x, w⟫_ℂ‖ ^ 2 ≤ s * ‖w‖ ^ 2 := by
+    have hCS := norm_inner_le_norm (𝕜 := ℂ) x w
+    have hsq : ‖⟪x, w⟫_ℂ‖ ^ 2 ≤ (‖x‖ * ‖w‖) ^ 2 := pow_le_pow_left₀ (norm_nonneg _) hCS 2
+    calc ‖⟪x, w⟫_ℂ‖ ^ 2 ≤ (‖x‖ * ‖w‖) ^ 2 := hsq
+      _ = s * ‖w‖ ^ 2 := by rw [hs]; ring
+  have hCSy : s ^ 2 * ‖⟪y, w⟫_ℂ‖ ^ 2 ≤ ‖y‖ ^ 2 * ‖g‖ ^ 2 := by
+    have hCS := norm_inner_le_norm (𝕜 := ℂ) y g
+    have hnorm : ‖⟪y, g⟫_ℂ‖ = s * ‖⟪y, w⟫_ℂ‖ := by
+      rw [hyg, norm_mul, Complex.norm_real, Real.norm_of_nonneg hs0]
+    rw [hnorm] at hCS
+    have hsq : (s * ‖⟪y, w⟫_ℂ‖) ^ 2 ≤ (‖y‖ * ‖g‖) ^ 2 := pow_le_pow_left₀ (by positivity) hCS 2
+    nlinarith [hsq]
+  rcases eq_or_lt_of_le hs0 with hs00 | hspos
+  · have hxnorm : ‖x‖ = 0 := by
+      have hx2 : ‖x‖ ^ 2 = 0 := by rw [← hs, ← hs00]
+      nlinarith [norm_nonneg x]
+    have hx0 : x = 0 := norm_eq_zero.mp hxnorm
+    have hy0 : y = 0 := norm_eq_zero.mp (le_antisymm (by rw [hxnorm] at hyx; exact hyx)
+      (norm_nonneg _))
+    rw [hx0, hy0]
+    simp [← hs00]
+  · have hgnonneg : 0 ≤ ‖g‖ ^ 2 := by positivity
+    have hyg2 : s ^ 2 * ‖⟪y, w⟫_ℂ‖ ^ 2 ≤ s * ‖g‖ ^ 2 := by
+      have hys : ‖y‖ ^ 2 ≤ s := by rw [hs]; exact pow_le_pow_left₀ (norm_nonneg _) hyx 2
+      calc s ^ 2 * ‖⟪y, w⟫_ℂ‖ ^ 2 ≤ ‖y‖ ^ 2 * ‖g‖ ^ 2 := hCSy
+        _ ≤ s * ‖g‖ ^ 2 := by nlinarith [hgnonneg]
+    rw [hgnorm] at hyg2
+    have hkey : s ^ 2 * ‖⟪y, w⟫_ℂ‖ ^ 2 ≤ s ^ 2 * (s * ‖w‖ ^ 2 - ‖⟪x, w⟫_ℂ‖ ^ 2) := by
+      nlinarith [hyg2]
+    have hb : ‖⟪y, w⟫_ℂ‖ ^ 2 ≤ s * ‖w‖ ^ 2 - ‖⟪x, w⟫_ℂ‖ ^ 2 :=
+      le_of_mul_le_mul_left hkey (by positivity)
+    linarith
+
+end InnerProductAux
+
+/-! ## The Breuer-Hall map -/
+
+/-- **Wolf Chapter 3, Example 3.1, equation (3.19).** The Breuer-Hall map
+`T_BH(X) = (tr X) I - X - U Xᵀ Uᴴ` on `M_D(ℂ)`, parametrised by a matrix `U`. -/
+noncomputable def breuerHallMap (U : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ where
+  toFun X := Matrix.trace X • (1 : Matrix (Fin d) (Fin d) ℂ) - X - U * Xᵀ * Uᴴ
+  map_add' X Y := by
+    simp only [Matrix.transpose_add, Matrix.mul_add, Matrix.add_mul, Matrix.trace_add, add_smul]
+    abel
+  map_smul' c X := by
+    simp only [RingHom.id_apply, Matrix.transpose_smul, Matrix.mul_smul, Matrix.smul_mul,
+      Matrix.trace_smul, smul_sub, smul_smul, smul_eq_mul]
+
+@[simp]
+theorem breuerHallMap_apply (U : Matrix (Fin d) (Fin d) ℂ) (X : Matrix (Fin d) (Fin d) ℂ) :
+    breuerHallMap U X =
+      Matrix.trace X • (1 : Matrix (Fin d) (Fin d) ℂ) - X - U * Xᵀ * Uᴴ :=
+  rfl
+
+/-! ## Quadratic-form helper -/
+
+/-- The quadratic form of a rank-one outer product `vecMulVec a b` reads off as
+`(b ⬝ᵥ w)(w̄ ⬝ᵥ a)`. -/
+theorem star_dotProduct_vecMulVec_mulVec (a b w : Fin d → ℂ) :
+    star w ⬝ᵥ (Matrix.vecMulVec a b *ᵥ w) = (b ⬝ᵥ w) * (star w ⬝ᵥ a) := by
+  have lhs : star w ⬝ᵥ (Matrix.vecMulVec a b *ᵥ w)
+      = ∑ i, ∑ j, star (w i) * a i * b j * w j := by
+    simp only [dotProduct, Matrix.mulVec, Matrix.vecMulVec_apply, Pi.star_apply, Finset.mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have rhs : (b ⬝ᵥ w) * (star w ⬝ᵥ a) = ∑ i, ∑ j, star (w i) * a i * b j * w j := by
+    simp only [dotProduct, Pi.star_apply]
+    rw [Finset.sum_mul_sum, Finset.sum_comm]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  rw [lhs, rhs]
+
+/-! ## Positivity on rank-one outer products -/
+
+/-- On a rank-one outer product `v vᴴ`, the Breuer-Hall map is positive
+semidefinite.  This is the heart of the positivity proof: the image is
+`‖v‖² I - v vᴴ - (U v̄)(U v̄)ᴴ`, whose quadratic form is nonnegative by the
+two-vector Bessel inequality applied to the orthogonal pair `v ⟂ U v̄` with
+`‖U v̄‖ ≤ ‖v‖`. -/
+theorem breuerHallMap_vecMulVec_posSemidef (U : Matrix (Fin d) (Fin d) ℂ)
+    (hUanti : Uᵀ = -U) (hUcontr : Uᴴ * U ≤ 1) (v : Fin d → ℂ) :
+    (breuerHallMap U (Matrix.vecMulVec v (star v))).PosSemidef := by
+  classical
+  set p : Fin d → ℂ := U *ᵥ star v with hp
+  set A : Matrix (Fin d) (Fin d) ℂ := Matrix.vecMulVec v (star v) with hA
+  set B : Matrix (Fin d) (Fin d) ℂ := Matrix.vecMulVec p (star p) with hB
+  -- the image is `tr A • 1 - A - B`
+  have hUterm : U * Aᵀ * Uᴴ = B := by
+    rw [hA, Matrix.transpose_vecMulVec, Matrix.mul_vecMulVec, Matrix.vecMulVec_mul, hB, hp,
+      Matrix.vecMul_conjTranspose]
+  have hM : breuerHallMap U A = Matrix.trace A • (1 : Matrix (Fin d) (Fin d) ℂ) - A - B := by
+    rw [breuerHallMap_apply, hUterm]
+  rw [hM]
+  -- inner-product avatars
+  set V : EuclideanSpace ℂ (Fin d) := WithLp.toLp 2 v with hV
+  set P : EuclideanSpace ℂ (Fin d) := WithLp.toLp 2 p with hP
+  have bridge : ∀ a b : Fin d → ℂ,
+      star a ⬝ᵥ b = ⟪(WithLp.toLp 2 a : EuclideanSpace ℂ (Fin d)), WithLp.toLp 2 b⟫_ℂ := by
+    intro a b
+    rw [EuclideanSpace.inner_toLp_toLp]
+    exact dotProduct_comm (star a) b
+  -- orthogonality `v ⟂ U v̄`
+  have hzero : star v ⬝ᵥ (U *ᵥ star v) = 0 := by
+    have key : star v ⬝ᵥ (U *ᵥ star v) = -(star v ⬝ᵥ (U *ᵥ star v)) := by
+      calc star v ⬝ᵥ (U *ᵥ star v)
+          = (star v ᵥ* U) ⬝ᵥ star v := dotProduct_mulVec (star v) U (star v)
+        _ = (Uᵀ *ᵥ star v) ⬝ᵥ star v := by rw [← Matrix.mulVec_transpose]
+        _ = ((-U) *ᵥ star v) ⬝ᵥ star v := by rw [hUanti]
+        _ = -((U *ᵥ star v) ⬝ᵥ star v) := by rw [Matrix.neg_mulVec, neg_dotProduct]
+        _ = -(star v ⬝ᵥ (U *ᵥ star v)) := by rw [dotProduct_comm]
+    rwa [eq_neg_iff_add_eq_zero, add_self_eq_zero] at key
+  have horth : ⟪V, P⟫_ℂ = 0 := by
+    rw [hV, hP, ← bridge v p, hp]; exact hzero
+  -- contraction bound `‖U v̄‖ ≤ ‖v‖`
+  have hPV : ‖P‖ ≤ ‖V‖ := by
+    have hpsd : (1 - Uᴴ * U).PosSemidef := by rw [← Matrix.le_iff]; exact hUcontr
+    have hquad : (0 : ℂ) ≤ star (star v) ⬝ᵥ ((1 - Uᴴ * U) *ᵥ star v) :=
+      hpsd.dotProduct_mulVec_nonneg _
+    have hval : star (star v) ⬝ᵥ ((1 - Uᴴ * U) *ᵥ star v) = v ⬝ᵥ star v - star p ⬝ᵥ p := by
+      rw [star_star, Matrix.sub_mulVec, Matrix.one_mulVec, dotProduct_sub,
+        ← Matrix.mulVec_mulVec, hp]
+      congr 1
+      rw [dotProduct_mulVec, Matrix.vecMul_conjTranspose]
+    rw [hval] at hquad
+    have hre : (star p ⬝ᵥ p).re ≤ (v ⬝ᵥ star v).re := by
+      have hle := (Complex.le_def.mp hquad).1
+      simpa using hle
+    have hnP : ‖P‖ ^ 2 = (star p ⬝ᵥ p).re := by
+      rw [hP, ← inner_self_eq_norm_sq (𝕜 := ℂ), EuclideanSpace.inner_toLp_toLp,
+        dotProduct_comm p (star p)]
+      rfl
+    have hnV : ‖V‖ ^ 2 = (v ⬝ᵥ star v).re := by
+      rw [hV, ← inner_self_eq_norm_sq (𝕜 := ℂ), EuclideanSpace.inner_toLp_toLp]
+      rfl
+    have hsq : ‖P‖ ^ 2 ≤ ‖V‖ ^ 2 := by rw [hnP, hnV]; exact hre
+    nlinarith [norm_nonneg P, norm_nonneg V, hsq]
+  -- now show PSD via the quadratic form
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
+  · -- Hermitian
+    have hAherm : A.IsHermitian := (Matrix.posSemidef_vecMulVec_self_star v).1
+    have hcSA : IsSelfAdjoint (Matrix.trace A) := by
+      rw [isSelfAdjoint_iff, ← Matrix.trace_conjTranspose, hAherm]
+    exact ((isHermitian_one.smul hcSA).sub hAherm).sub
+      (Matrix.posSemidef_vecMulVec_self_star p).1
+  · intro w
+    set W : EuclideanSpace ℂ (Fin d) := WithLp.toLp 2 w with hW
+    -- expand the quadratic form
+    have hQ : star w ⬝ᵥ ((Matrix.trace A • (1 : Matrix (Fin d) (Fin d) ℂ) - A - B) *ᵥ w) =
+        Matrix.trace A * (star w ⬝ᵥ w) - (star v ⬝ᵥ w) * (star w ⬝ᵥ v)
+          - (star p ⬝ᵥ w) * (star w ⬝ᵥ p) := by
+      rw [Matrix.sub_mulVec, Matrix.sub_mulVec, dotProduct_sub, dotProduct_sub,
+        Matrix.smul_mulVec, Matrix.one_mulVec, dotProduct_smul, smul_eq_mul, hA, hB,
+        star_dotProduct_vecMulVec_mulVec, star_dotProduct_vecMulVec_mulVec]
+    rw [hQ]
+    -- rewrite trace and overlaps as inner products
+    have htr : Matrix.trace A = ⟪V, V⟫_ℂ := by
+      rw [hA, Matrix.trace_vecMulVec, hV, EuclideanSpace.inner_toLp_toLp]
+    have h1 : star v ⬝ᵥ w = ⟪V, W⟫_ℂ := by rw [hV, hW]; exact bridge v w
+    have h2 : star w ⬝ᵥ v = ⟪W, V⟫_ℂ := by rw [hV, hW]; exact bridge w v
+    have h3 : star w ⬝ᵥ w = ⟪W, W⟫_ℂ := by rw [hW]; exact bridge w w
+    have h4 : star p ⬝ᵥ w = ⟪P, W⟫_ℂ := by rw [hP, hW]; exact bridge p w
+    have h5 : star w ⬝ᵥ p = ⟪W, P⟫_ℂ := by rw [hP, hW]; exact bridge w p
+    rw [htr, h1, h2, h3, h4, h5]
+    -- collapse the products of conjugate inner products to squared norms
+    have hVV : ⟪V, V⟫_ℂ = ((‖V‖ ^ 2 : ℝ) : ℂ) := by
+      rw [inner_self_eq_norm_sq_to_K (𝕜 := ℂ)]; norm_cast
+    have hWW : ⟪W, W⟫_ℂ = ((‖W‖ ^ 2 : ℝ) : ℂ) := by
+      rw [inner_self_eq_norm_sq_to_K (𝕜 := ℂ)]; norm_cast
+    have e1 : ⟪V, V⟫_ℂ * ⟪W, W⟫_ℂ = ((‖V‖ ^ 2 * ‖W‖ ^ 2 : ℝ) : ℂ) := by
+      rw [hVV, hWW]; push_cast; ring
+    have e2 : ⟪V, W⟫_ℂ * ⟪W, V⟫_ℂ = ((‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) := by
+      rw [← inner_conj_symm W V, Complex.mul_conj, Complex.normSq_eq_norm_sq]
+    have e3 : ⟪P, W⟫_ℂ * ⟪W, P⟫_ℂ = ((‖⟪P, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) := by
+      rw [← inner_conj_symm W P, Complex.mul_conj, Complex.normSq_eq_norm_sq]
+    rw [e1, e2, e3,
+      show ((‖V‖ ^ 2 * ‖W‖ ^ 2 : ℝ) : ℂ) - ((‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ)
+          - ((‖⟪P, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ)
+        = ((‖V‖ ^ 2 * ‖W‖ ^ 2 - ‖⟪V, W⟫_ℂ‖ ^ 2 - ‖⟪P, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) by push_cast; ring]
+    rw [Complex.zero_le_real]
+    have hbessel := orthogonal_two_inner_normSq_le horth hPV W
+    linarith
+
+/-! ## Positivity of the Breuer-Hall map -/
+
+/-- **Wolf Chapter 3, Example 3.1, equation (3.19).** The Breuer-Hall map
+`T_BH(X) = (tr X) I - X - U Xᵀ Uᴴ` of an antisymmetric contraction `U`
+(`Uᵀ = -U` and `Uᴴ U ≤ 1`) is a positive map. -/
+theorem breuerHallMap_isPositiveMap (U : Matrix (Fin d) (Fin d) ℂ)
+    (hUanti : Uᵀ = -U) (hUcontr : Uᴴ * U ≤ 1) :
+    IsPositiveMap (breuerHallMap U) := by
+  classical
+  intro X hX
+  rw [hX.eq_sum_vecMulVec_nonzero_eigs, map_sum]
+  refine Matrix.posSemidef_sum _ (fun i _ => ?_)
+  exact breuerHallMap_vecMulVec_posSemidef U hUanti hUcontr _
+
+end Matrix

--- a/TNLean/Channel/BreuerHallMap.lean
+++ b/TNLean/Channel/BreuerHallMap.lean
@@ -20,13 +20,11 @@ positive map: it sends positive semidefinite matrices to positive semidefinite
 matrices.
 
 The proof reduces positivity to the rank-one case: a positive semidefinite
-matrix is a sum of rank-one outer products `v vᴴ`
-(`Matrix.PosSemidef.eq_sum_vecMulVec_nonzero_eigs`), and on such a matrix
-`T_BH(v vᴴ) = ‖v‖² I - v vᴴ - (U (conj v))(U (conj v))ᴴ`.  The two vectors `v`
-and `U (conj v)` are orthogonal (by antisymmetry of `U`) and
-`‖U (conj v)‖ ≤ ‖v‖` (by the contraction
-property), so the quadratic form is nonnegative by a two-vector form of Bessel's
-inequality.
+matrix is a sum of rank-one outer products `v vᴴ`, and on such a matrix
+`T_BH(v vᴴ) = ‖v‖² I - v vᴴ - w wᴴ`, where `w = U *ᵥ star v` applies `U` to the
+entrywise conjugate of `v`.  The two vectors `v` and `w` are orthogonal (by
+antisymmetry of `U`) and `‖w‖ ≤ ‖v‖` (by the contraction property), so the
+quadratic form is nonnegative by a two-vector form of Bessel's inequality.
 
 Indecomposability of the Breuer-Hall map and the `n`-positivity threshold are
 not treated here; only positivity is established.

--- a/TNLean/Channel/BreuerHallMap.lean
+++ b/TNLean/Channel/BreuerHallMap.lean
@@ -45,10 +45,6 @@ not treated here; only positivity is established.
 open scoped Matrix ComplexOrder MatrixOrder InnerProductSpace
 open Matrix
 
-namespace Matrix
-
-variable {d : ℕ}
-
 /-! ## A two-vector orthogonal Bessel inequality -/
 
 section InnerProductAux
@@ -114,6 +110,10 @@ theorem orthogonal_two_inner_normSq_le {x y : E} (hxy : ⟪x, y⟫_ℂ = 0)
 
 end InnerProductAux
 
+namespace Matrix
+
+variable {d : ℕ}
+
 /-! ## The Breuer-Hall map -/
 
 /-- **Wolf Chapter 3, Example 3.1, equation (3.19).** The Breuer-Hall map
@@ -153,7 +153,7 @@ theorem star_dotProduct_vecMulVec_mulVec (a b w : Fin d → ℂ) :
 /-! ## Positivity on rank-one outer products -/
 
 /-- On a rank-one outer product `v vᴴ`, the Breuer-Hall map is positive
-semidefinite.  This is the heart of the positivity proof: the image is
+semidefinite.  This is the key step in the positivity proof: the image is
 `‖v‖² I - v vᴴ - (U (conj v))(U (conj v))ᴴ`, whose quadratic form is nonnegative
 by the two-vector Bessel inequality applied to the orthogonal pair
 `v ⟂ U (conj v)` with `‖U (conj v)‖ ≤ ‖v‖`. -/

--- a/TNLean/Channel/BreuerHallMap.lean
+++ b/TNLean/Channel/BreuerHallMap.lean
@@ -22,8 +22,9 @@ matrices.
 The proof reduces positivity to the rank-one case: a positive semidefinite
 matrix is a sum of rank-one outer products `v vᴴ`
 (`Matrix.PosSemidef.eq_sum_vecMulVec_nonzero_eigs`), and on such a matrix
-`T_BH(v vᴴ) = ‖v‖² I - v vᴴ - (U v̄)(U v̄)ᴴ`.  The two vectors `v` and `U v̄` are
-orthogonal (by antisymmetry of `U`) and `‖U v̄‖ ≤ ‖v‖` (by the contraction
+`T_BH(v vᴴ) = ‖v‖² I - v vᴴ - (U (conj v))(U (conj v))ᴴ`.  The two vectors `v`
+and `U (conj v)` are orthogonal (by antisymmetry of `U`) and
+`‖U (conj v)‖ ≤ ‖v‖` (by the contraction
 property), so the quadratic form is nonnegative by a two-vector form of Bessel's
 inequality.
 
@@ -136,7 +137,7 @@ theorem breuerHallMap_apply (U : Matrix (Fin d) (Fin d) ℂ) (X : Matrix (Fin d)
 /-! ## Quadratic-form helper -/
 
 /-- The quadratic form of a rank-one outer product `vecMulVec a b` reads off as
-`(b ⬝ᵥ w)(w̄ ⬝ᵥ a)`. -/
+`(b ⬝ᵥ w)((conj w) ⬝ᵥ a)`. -/
 theorem star_dotProduct_vecMulVec_mulVec (a b w : Fin d → ℂ) :
     star w ⬝ᵥ (Matrix.vecMulVec a b *ᵥ w) = (b ⬝ᵥ w) * (star w ⬝ᵥ a) := by
   have lhs : star w ⬝ᵥ (Matrix.vecMulVec a b *ᵥ w)
@@ -153,9 +154,9 @@ theorem star_dotProduct_vecMulVec_mulVec (a b w : Fin d → ℂ) :
 
 /-- On a rank-one outer product `v vᴴ`, the Breuer-Hall map is positive
 semidefinite.  This is the heart of the positivity proof: the image is
-`‖v‖² I - v vᴴ - (U v̄)(U v̄)ᴴ`, whose quadratic form is nonnegative by the
-two-vector Bessel inequality applied to the orthogonal pair `v ⟂ U v̄` with
-`‖U v̄‖ ≤ ‖v‖`. -/
+`‖v‖² I - v vᴴ - (U (conj v))(U (conj v))ᴴ`, whose quadratic form is nonnegative
+by the two-vector Bessel inequality applied to the orthogonal pair
+`v ⟂ U (conj v)` with `‖U (conj v)‖ ≤ ‖v‖`. -/
 theorem breuerHallMap_vecMulVec_posSemidef (U : Matrix (Fin d) (Fin d) ℂ)
     (hUanti : Uᵀ = -U) (hUcontr : Uᴴ * U ≤ 1) (v : Fin d → ℂ) :
     (breuerHallMap U (Matrix.vecMulVec v (star v))).PosSemidef := by
@@ -178,7 +179,7 @@ theorem breuerHallMap_vecMulVec_posSemidef (U : Matrix (Fin d) (Fin d) ℂ)
     intro a b
     rw [EuclideanSpace.inner_toLp_toLp]
     exact dotProduct_comm (star a) b
-  -- orthogonality `v ⟂ U v̄`
+  -- orthogonality `v ⟂ U (conj v)`
   have hzero : star v ⬝ᵥ (U *ᵥ star v) = 0 := by
     have key : star v ⬝ᵥ (U *ᵥ star v) = -(star v ⬝ᵥ (U *ᵥ star v)) := by
       calc star v ⬝ᵥ (U *ᵥ star v)
@@ -190,7 +191,7 @@ theorem breuerHallMap_vecMulVec_posSemidef (U : Matrix (Fin d) (Fin d) ℂ)
     rwa [eq_neg_iff_add_eq_zero, add_self_eq_zero] at key
   have horth : ⟪V, P⟫_ℂ = 0 := by
     rw [hV, hP, ← bridge v p, hp]; exact hzero
-  -- contraction bound `‖U v̄‖ ≤ ‖v‖`
+  -- contraction bound `‖U (conj v)‖ ≤ ‖v‖`
   have hPV : ‖P‖ ≤ ‖V‖ := by
     have hpsd : (1 - Uᴴ * U).PosSemidef := by rw [← Matrix.le_iff]; exact hUcontr
     have hquad : (0 : ℂ) ≤ star (star v) ⬝ᵥ ((1 - Uᴴ * U) *ᵥ star v) :=

--- a/TNLean/Channel/BreuerHallMap.lean
+++ b/TNLean/Channel/BreuerHallMap.lean
@@ -151,10 +151,11 @@ theorem star_dotProduct_vecMulVec_mulVec (a b w : Fin d → ℂ) :
 /-! ## Positivity on rank-one outer products -/
 
 /-- On a rank-one outer product `v vᴴ`, the Breuer-Hall map is positive
-semidefinite.  This is the key step in the positivity proof: the image is
-`‖v‖² I - v vᴴ - (U (conj v))(U (conj v))ᴴ`, whose quadratic form is nonnegative
-by the two-vector Bessel inequality applied to the orthogonal pair
-`v ⟂ U (conj v)` with `‖U (conj v)‖ ≤ ‖v‖`. -/
+semidefinite.  This is the key step in the positivity proof: with
+`w = U *ᵥ star v` the image under `U` of the entrywise conjugate of `v`, the
+image is `‖v‖² I - v vᴴ - w wᴴ`, whose quadratic form is nonnegative by the
+two-vector Bessel inequality applied to the orthogonal pair `v ⟂ w` with
+`‖w‖ ≤ ‖v‖`. -/
 theorem breuerHallMap_vecMulVec_posSemidef (U : Matrix (Fin d) (Fin d) ℂ)
     (hUanti : Uᵀ = -U) (hUcontr : Uᴴ * U ≤ 1) (v : Fin d → ℂ) :
     (breuerHallMap U (Matrix.vecMulVec v (star v))).PosSemidef := by
@@ -177,7 +178,7 @@ theorem breuerHallMap_vecMulVec_posSemidef (U : Matrix (Fin d) (Fin d) ℂ)
     intro a b
     rw [EuclideanSpace.inner_toLp_toLp]
     exact dotProduct_comm (star a) b
-  -- orthogonality `v ⟂ U (conj v)`
+  -- orthogonality `v ⟂ U *ᵥ star v`
   have hzero : star v ⬝ᵥ (U *ᵥ star v) = 0 := by
     have key : star v ⬝ᵥ (U *ᵥ star v) = -(star v ⬝ᵥ (U *ᵥ star v)) := by
       calc star v ⬝ᵥ (U *ᵥ star v)
@@ -189,7 +190,7 @@ theorem breuerHallMap_vecMulVec_posSemidef (U : Matrix (Fin d) (Fin d) ℂ)
     rwa [eq_neg_iff_add_eq_zero, add_self_eq_zero] at key
   have horth : ⟪V, P⟫_ℂ = 0 := by
     rw [hV, hP, ← bridge v p, hp]; exact hzero
-  -- contraction bound `‖U (conj v)‖ ≤ ‖v‖`
+  -- contraction bound `‖U *ᵥ star v‖ ≤ ‖v‖`
   have hPV : ‖P‖ ≤ ‖V‖ := by
     have hpsd : (1 - Uᴴ * U).PosSemidef := by rw [← Matrix.le_iff]; exact hUcontr
     have hquad : (0 : ℂ) ≤ star (star v) ⬝ᵥ ((1 - Uᴴ * U) *ᵥ star v) :=

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -178,21 +178,21 @@ fails to be completely positive, are not treated here.
     \]
 \end{definition}
 
-\begin{theorem}[The Breuer--Hall map is positive]
-    \label{thm:breuer_hall_positive}
-    \lean{Matrix.breuerHallMap_isPositiveMap}
+\begin{lemma}[The Breuer--Hall map on rank-one operators]
+    \label{lem:breuer_hall_rankone}
+    \lean{Matrix.breuerHallMap_vecMulVec_posSemidef}
     \leanok
     \uses{def:breuer_hall_map}
     If $U$ is antisymmetric, $U^{\mathsf T}=-U$, and a contraction,
-    $U^{\dagger}U\le\Id$, then the Breuer--Hall map $T_{\mathrm{BH}}$ sends every
-    positive semidefinite matrix to a positive semidefinite matrix.
-\end{theorem}
+    $U^{\dagger}U\le\Id$, then for every vector $v$ the image
+    $T_{\mathrm{BH}}(\ket{v}\bra{v})$ of the rank-one operator $\ket{v}\bra{v}$ is
+    positive semidefinite.
+\end{lemma}
 
 \begin{proof}
     \leanok
-    A linear map is positive once it sends every rank-one positive operator
-    $\ket{v}\bra{v}$ to a positive one, because a positive semidefinite matrix is
-    a sum of such rank-one operators.  On $\ket{v}\bra{v}$ the image is
+    \uses{def:breuer_hall_map}
+    On $\ket{v}\bra{v}$ the image is
     \[
         T_{\mathrm{BH}}(\ket{v}\bra{v})
         =\lVert v\rVert^{2}\,\Id-\ket{v}\bra{v}-\ket{U\overline{v}}\bra{U\overline{v}},
@@ -221,6 +221,26 @@ fails to be completely positive, are not treated here.
         +\lvert\braket{U\overline{v}}{w}\rvert^{2}
         \le\lVert v\rVert^{2}\lVert w\rVert^{2}.
     \]
+\end{proof}
+
+\begin{theorem}[The Breuer--Hall map is positive]
+    \label{thm:breuer_hall_positive}
+    \lean{Matrix.breuerHallMap_isPositiveMap}
+    \leanok
+    \uses{def:breuer_hall_map}
+    If $U$ is antisymmetric, $U^{\mathsf T}=-U$, and a contraction,
+    $U^{\dagger}U\le\Id$, then the Breuer--Hall map $T_{\mathrm{BH}}$ sends every
+    positive semidefinite matrix to a positive semidefinite matrix.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:breuer_hall_rankone}
+    A positive semidefinite matrix is a sum of rank-one operators
+    $\ket{v}\bra{v}$.  By Lemma~\ref{lem:breuer_hall_rankone} the Breuer--Hall map
+    sends each such operator to a positive semidefinite matrix, and a sum of
+    positive semidefinite matrices is positive semidefinite, so $T_{\mathrm{BH}}$
+    is positive.
 \end{proof}
 
 \section{The partial transpose and the PPT property}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -198,9 +198,15 @@ fails to be completely positive, are not treated here.
         =\lVert v\rVert^{2}\,\Id-\ket{v}\bra{v}-\ket{U\overline{v}}\bra{U\overline{v}},
     \]
     with $\overline{v}$ the entrywise conjugate of $v$.  The two vectors $v$ and
-    $U\overline{v}$ are orthogonal: antisymmetry of $U$ forces the scalar
-    $\braket{v}{U\overline{v}}$ to equal its own negative, hence to vanish.  The
-    contraction bound gives $\lVert U\overline{v}\rVert\le\lVert v\rVert$.  For any
+    $U\overline{v}$ are orthogonal: antisymmetry of $U$ gives
+    \[
+        \braket{v}{U\overline{v}}
+        =\overline{v}^{\,\mathsf T}U\,\overline{v}
+        =\overline{v}^{\,\mathsf T}(-U^{\mathsf T})\overline{v}
+        =-\braket{v}{U\overline{v}},
+    \]
+    hence $\braket{v}{U\overline{v}}=0$.  The contraction bound gives
+    $\lVert U\overline{v}\rVert\le\lVert v\rVert$.  For any
     $w$ the quadratic form is
     \[
         \lVert v\rVert^{2}\lVert w\rVert^{2}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -213,8 +213,14 @@ fails to be completely positive, are not treated here.
         -\lvert\braket{v}{w}\rvert^{2}
         -\lvert\braket{U\overline{v}}{w}\rvert^{2},
     \]
-    which is nonnegative by Bessel's inequality for the orthogonal pair $v$,
-    $U\overline{v}$ together with $\lVert U\overline{v}\rVert\le\lVert v\rVert$.
+    which is nonnegative because the two-vector Bessel inequality for the
+    orthogonal pair $v$, $U\overline{v}$ with
+    $\lVert U\overline{v}\rVert\le\lVert v\rVert$ gives
+    \[
+        \lvert\braket{v}{w}\rvert^{2}
+        +\lvert\braket{U\overline{v}}{w}\rvert^{2}
+        \le\lVert v\rVert^{2}\lVert w\rVert^{2}.
+    \]
 \end{proof}
 
 \section{The partial transpose and the PPT property}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -156,6 +156,61 @@ of a bipartite state whose Schmidt number is at most $n$.
     $n\,\rho_1\otimes\Id-\rho\ge 0$.
 \end{proof}
 
+\section{The Breuer--Hall map}
+
+A second concrete positive map of \cite[Chapter~3, Example~3.1]{Wolf2012Quantum}
+is built from an antisymmetric contraction $U$ on $\C^{D}$, a matrix with
+$U^{\mathsf T}=-U$ and $U^{\dagger}U\le\Id$.  The associated Breuer--Hall map
+\cite[Equation~(3.19)]{Wolf2012Quantum} is
+\[
+    T_{\mathrm{BH}}(X)=\tr(X)\,\Id-X-U\,X^{\mathsf T}U^{\dagger}.
+\]
+It is positive; whether it is decomposable, and the threshold beyond which it
+fails to be completely positive, are not treated here.
+
+\begin{definition}[Breuer--Hall map]
+    \label{def:breuer_hall_map}
+    \lean{Matrix.breuerHallMap}
+    \leanok
+    For a matrix $U$ on $\MN{D}$, the Breuer--Hall map on $\MN{D}$ is
+    \[
+        T_{\mathrm{BH}}(X)=\tr(X)\,\Id-X-U\,X^{\mathsf T}U^{\dagger}.
+    \]
+\end{definition}
+
+\begin{theorem}[The Breuer--Hall map is positive]
+    \label{thm:breuer_hall_positive}
+    \lean{Matrix.breuerHallMap_isPositiveMap}
+    \leanok
+    \uses{def:breuer_hall_map}
+    If $U$ is antisymmetric, $U^{\mathsf T}=-U$, and a contraction,
+    $U^{\dagger}U\le\Id$, then the Breuer--Hall map $T_{\mathrm{BH}}$ sends every
+    positive semidefinite matrix to a positive semidefinite matrix.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    A linear map is positive once it sends every rank-one positive operator
+    $\ket{v}\bra{v}$ to a positive one, because a positive semidefinite matrix is
+    a sum of such rank-one operators.  On $\ket{v}\bra{v}$ the image is
+    \[
+        T_{\mathrm{BH}}(\ket{v}\bra{v})
+        =\lVert v\rVert^{2}\,\Id-\ket{v}\bra{v}-\ket{U\overline{v}}\bra{U\overline{v}},
+    \]
+    with $\overline{v}$ the entrywise conjugate of $v$.  The two vectors $v$ and
+    $U\overline{v}$ are orthogonal: antisymmetry of $U$ forces the scalar
+    $\braket{v}{U\overline{v}}$ to equal its own negative, hence to vanish.  The
+    contraction bound gives $\lVert U\overline{v}\rVert\le\lVert v\rVert$.  For any
+    $w$ the quadratic form is
+    \[
+        \lVert v\rVert^{2}\lVert w\rVert^{2}
+        -\lvert\braket{v}{w}\rvert^{2}
+        -\lvert\braket{U\overline{v}}{w}\rvert^{2},
+    \]
+    which is nonnegative by Bessel's inequality for the orthogonal pair $v$,
+    $U\overline{v}$ together with $\lVert U\overline{v}\rVert\le\lVert v\rVert$.
+\end{proof}
+
 \section{The partial transpose and the PPT property}
 
 Transposition is a positive map that is not completely positive, so applying it


### PR DESCRIPTION
## Summary

Adds the **Breuer-Hall map** and proves it is a **positive map**, one of the concrete positive maps of Wolf, *Quantum Channels & Operations*, Chapter 3, Example 3.1, eq. (3.19). This is one independent sub-task of LionSR/QICLean#21.

For a fixed antisymmetric contraction `U` (`Uᵀ = -U` and `Uᴴ U ≤ 1`) the map is
```
T_BH(X) = (tr X) • 1 − X − U * Xᵀ * Uᴴ
```
and `Matrix.breuerHallMap_isPositiveMap` shows it sends every PSD matrix to a PSD matrix, matching the repo's `IsPositiveMap` predicate (same one used by `reductionMap`/`tEta`).

## Proof strategy

Positivity reduces to the rank-one case via the existing spectral decomposition `Matrix.PosSemidef.eq_sum_vecMulVec_nonzero_eigs`: a PSD matrix is a sum of outer products `v vᴴ`, and `T_BH` is linear. On `v vᴴ` the image is
```
‖v‖² • 1 − v vᴴ − (U v̄)(U v̄)ᴴ
```
whose quadratic form `‖v‖²‖w‖² − |⟨v,w⟩|² − |⟨U v̄,w⟩|²` is nonnegative by a two-vector form of Bessel's inequality, using:
- `v ⟂ U v̄` — the scalar `vᴴ(U v̄)` equals its own negative by antisymmetry `Uᵀ = -U`;
- `‖U v̄‖ ≤ ‖v‖` — from the contraction bound `Uᴴ U ≤ 1`.

## Scope

**Indecomposability** of the Breuer-Hall map and the **n-positivity threshold** are out of scope (noted in the module docstring); this PR establishes positivity only.

## Verification

- `lake env lean TNLean/Channel/BreuerHallMap.lean` exits 0.
- No `sorry`/`admit`/`axiom`/`native_decide` in the file.
- `#print axioms Matrix.breuerHallMap_isPositiveMap` → `[propext, Classical.choice, Quot.sound]`.
- `lake exe lint-style` passes (100-char lines).

## Blueprint

Adds a "The Breuer-Hall map" section to `ch25_positive_not_cp.tex` (Wolf Ch. 3) with the definition and positivity theorem tagged `\lean{}`/`\leanok`.

Closes part of LionSR/QICLean#21.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formalized theory and documentation only; no changes to auth, runtime, or existing channel APIs beyond adding an import and a new module.
> 
> **Overview**
> Adds **`Matrix.breuerHallMap`** and proves **`Matrix.breuerHallMap_isPositiveMap`**: for antisymmetric contraction `U` (`Uᵀ = -U`, `Uᴴ U ≤ 1`), Wolf’s map `T_BH(X) = (tr X)•1 − X − U Xᵀ Uᴴ` is a **`IsPositiveMap`**.
> 
> The proof is rank-one first (`breuerHallMap_vecMulVec_posSemidef`), then extends to all PSD matrices via **`PosSemidef.eq_sum_vecMulVec_nonzero_eigs`**. Supporting lemmas include a two-vector Bessel bound (`orthogonal_two_inner_normSq_le`) and a quadratic-form identity for outer products. **Indecomposability** and **n-positivity** are explicitly out of scope.
> 
> **`TNLean.lean`** exports the new module; **`ch25_positive_not_cp.tex`** gets a Breuer–Hall section with `\lean{}` links to the Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f574a99efb33094b73667539aa0a3fcb57ca21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->