### PR TITLE
feat(Channel/FixedPoint): algebra decomposition of the fixed-point *-algebra (toward Wolf Thm 6.14)

### DIFF
--- a/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
+++ b/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
@@ -166,10 +166,9 @@ section SchrodingerDecomp
 
 /-- **Wolf Theorem 6.14**, Schrödinger-picture form (abstract structure).
 
-The fixed-point `*`-subalgebra `{X | map K X = X}` of a unital Schwarz map
-whose adjoint map has a positive definite fixed point decomposes, as a
-ℂ-algebra, into a finite product of full complex matrix algebras
-`Π i, Matrix (Fin (dims i)) (Fin (dims i)) ℂ` with positive block sizes.
+The fixed-point `*`-subalgebra of a unital Schwarz map whose adjoint map has a
+positive definite fixed point decomposes, as a ℂ-algebra, into a finite product
+of full complex matrix algebras with positive block sizes.
 
 This is the structure-of-the-algebra content of Wolf Ch. 6, Thm 6.14, applied
 to the fixed-point `*`-subalgebra `fixedPointsStarSubalgebra` of the
@@ -178,8 +177,9 @@ Schrödinger-picture map `map K`. It is the companion of
 adjoint-fixed-point algebra.
 
 The remaining step toward the full Wolf Thm 6.14 is the unitary block-diagonal
-refinement that exhibits each summand as `M_{d_k} ⊗ 1_{m_k}` weighted by a state
-`ρ_k`; that refinement is not formalized here. -/
+refinement that exhibits each summand as a full matrix algebra tensored with an
+identity on a multiplicity space, weighted by a density operator; that
+refinement is not formalized here. -/
 theorem fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix
     (K : Fin d → Mat) (h_unital : IsUnital K)
     {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ) :

--- a/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
+++ b/TNLean/Channel/FixedPoint/WedderburnDecomp.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.Channel.FixedPoint.Algebra
+import TNLean.Algebra.StarSubalgebraSemisimple
 import Mathlib.RingTheory.SimpleModule.IsAlgClosed
 import Mathlib.RingTheory.Artinian.Module
 import Mathlib.Analysis.CStarAlgebra.Matrix
@@ -29,6 +30,9 @@ decomposition `ℂ^D = ℂ^{d₀} ⊕ ⊕_k ℂ^{d_k} ⊗ ℂ^{m_k}`.
 * `Kraus.fixedPointAlgebra_wedderburnArtin`: there exist `n : ℕ` and
   `dims : Fin n → ℕ` such that the fixed-point algebra is algebra-isomorphic
   to `Π i, Matrix (Fin (dims i)) (Fin (dims i)) ℂ`.
+* `Kraus.fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix`: the
+  Schrödinger-picture form, decomposing the fixed-point `*`-subalgebra of a
+  unital Schwarz map whose adjoint has a positive definite fixed point.
 
 ## Strategy
 
@@ -155,6 +159,37 @@ theorem fixedPointAlgebra_wedderburnArtin
     (↥(adjointFixedPointsStarSubalgebra (d := d) (D := D) K h_tp hρ hρ_fix))
 
 end AbstractDecomp
+
+/-! ## Schrödinger-picture fixed-point algebra decomposition -/
+
+section SchrodingerDecomp
+
+/-- **Wolf Theorem 6.14**, Schrödinger-picture form (abstract structure).
+
+The fixed-point `*`-subalgebra `{X | map K X = X}` of a unital Schwarz map
+whose adjoint map has a positive definite fixed point decomposes, as a
+ℂ-algebra, into a finite product of full complex matrix algebras
+`Π i, Matrix (Fin (dims i)) (Fin (dims i)) ℂ` with positive block sizes.
+
+This is the structure-of-the-algebra content of Wolf Ch. 6, Thm 6.14, applied
+to the fixed-point `*`-subalgebra `fixedPointsStarSubalgebra` of the
+Schrödinger-picture map `map K`. It is the companion of
+`fixedPointAlgebra_wedderburnArtin`, which decomposes the Heisenberg-picture
+adjoint-fixed-point algebra.
+
+The remaining step toward the full Wolf Thm 6.14 is the unitary block-diagonal
+refinement that exhibits each summand as `M_{d_k} ⊗ 1_{m_k}` weighted by a state
+`ρ_k`; that refinement is not formalized here. -/
+theorem fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix
+    (K : Fin d → Mat) (h_unital : IsUnital K)
+    {ρ : Mat} (hρ : ρ.PosDef) (hρ_fix : adjointMap K ρ = ρ) :
+    ∃ (n : ℕ) (dims : Fin n → ℕ), (∀ i, NeZero (dims i)) ∧
+      Nonempty
+        (fixedPointsStarSubalgebra K h_unital hρ hρ_fix ≃ₐ[ℂ]
+          Π i : Fin n, Matrix (Fin (dims i)) (Fin (dims i)) ℂ) :=
+  StarSubalgebra.exists_algEquiv_pi_matrix _
+
+end SchrodingerDecomp
 
 /-! ## Concrete block-diagonal embedding (Wolf Equations 1.39–1.40) -/
 

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1201,6 +1201,33 @@ special case used in this section.
     semisimple algebras over an algebraically closed field.
 \end{proof}
 
+\begin{theorem}[Wedderburn--Artin decomposition of the unital fixed-point algebra]%
+    \label{thm:fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix}
+    \lean{Kraus.fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix}
+    \leanok
+    \uses{thm:starSubalgebra_wedderburnArtin, thm:fixedPointsStarSubalgebra}
+    Let $E$ be a unital Kraus map on $\MN{D}$ whose adjoint map $E^*$ has a
+    positive definite fixed point $\rho > 0$. There exist $n \in \N$ and
+    dimensions $d_1,\ldots,d_n \ge 1$ such that the fixed-point $*$-subalgebra
+    $\mathrm{Fix}(E)$ is $\C$-algebra isomorphic to
+    \[
+        \mathrm{Fix}(E) \;\cong\; \prod_{k=1}^{n} \MN{d_k}.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:starSubalgebra_wedderburnArtin, thm:fixedPointsStarSubalgebra}
+    By Theorem~\ref{thm:fixedPointsStarSubalgebra} the fixed-point set
+    $\mathrm{Fix}(E)$ is a $*$-subalgebra of $\MN{D}$. Applying the abstract
+    Wedderburn--Artin decomposition for $*$-subalgebras
+    (Theorem~\ref{thm:starSubalgebra_wedderburnArtin}) gives
+    \[
+        \mathrm{Fix}(E) \;\cong\; \prod_{k=1}^{n} \MN{d_k}
+    \]
+    with each block size $d_k \ge 1$.
+\end{proof}
+
 \begin{theorem}[Fixed-point algebra decomposition with multiplicities]%
     \label{thm:adjointFixedPoints_wedderburnDecomp}
     \lean{Kraus.adjointFixedPoints_wedderburnDecomp}


### PR DESCRIPTION
## Summary

Adds `Kraus.fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix`, the Schrödinger-picture companion of the existing `Kraus.fixedPointAlgebra_wedderburnArtin`. It states that the fixed-point `*`-subalgebra of a unital Schwarz map whose adjoint map has a positive definite fixed point decomposes, as a ℂ-algebra, into a finite product of full complex matrix algebras with positive block sizes:

```
Fix(E) ≅ ∏ₖ M_{dₖ}(ℂ),   dₖ ≥ 1.
```

This is the structure-of-the-algebra content of Wolf Ch. 6, Theorem 6.14. The proof is a one-line application of the foundation lemma `StarSubalgebra.exists_algEquiv_pi_matrix` (merged in `TNLean/Algebra/StarSubalgebraSemisimple.lean`) to the `*`-subalgebra `Kraus.fixedPointsStarSubalgebra` of Wolf Theorem 6.12.

The remaining step toward the full Wolf Theorem 6.14 — the unitary block-diagonal refinement exhibiting each summand as `M_{dₖ} ⊗ 1_{mₖ}` weighted by a state `ρₖ` — is out of scope and noted in the docstring as future work.

Toward LionSR/QICLean#39.

## Changes

- `TNLean/Channel/FixedPoint/WedderburnDecomp.lean`: new theorem `fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix` in a new `SchrodingerDecomp` section; imports `TNLean.Algebra.StarSubalgebraSemisimple`; module docstring updated.
- `blueprint/src/chapter/ch07_spectral.tex`: new theorem entry `thm:fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix` with `\lean`/`\leanok` and `\uses{thm:starSubalgebra_wedderburnArtin, thm:fixedPointsStarSubalgebra}`.

## Verification

- `lake env lean TNLean/Channel/FixedPoint/WedderburnDecomp.lean` exits 0.
- `#print axioms Kraus.fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix` = `[propext, Classical.choice, Quot.sound]` (no `sorry`/`axiom`).
- `lake exe lint-style` exits 0.
- `scripts/check_reader_facing_prose.py --diff-base origin/main` reports no violations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive formalization and blueprint sync; no changes to channel maps, auth, or runtime behavior—only a one-line proof delegating to existing algebra infrastructure.
> 
> **Overview**
> This PR extends the Wolf Thm 6.14 formalization with the **Schrödinger-picture** fixed-point algebra: under unital `map K` and a positive definite adjoint fixed point `ρ`, **`Kraus.fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix`** states that `fixedPointsStarSubalgebra` is ℂ-algebra isomorphic to a finite product `Π_k M_{d_k}(ℂ)` with each `d_k ≥ 1`. The proof is a direct call to **`StarSubalgebra.exists_algEquiv_pi_matrix`** from the new import `TNLean.Algebra.StarSubalgebraSemisimple`, paralleling the existing Heisenberg **`fixedPointAlgebra_wedderburnArtin`** result.
> 
> `WedderburnDecomp.lean` gains a **`SchrodingerDecomp`** section and an updated module docstring; **`ch07_spectral.tex`** adds theorem **`thm:fixedPointsStarSubalgebra_exists_algEquiv_pi_matrix`** with `\lean`/`\leanok` and a short proof via `fixedPointsStarSubalgebra` + abstract `*`-subalgebra Wedderburn–Artin. The docstring still notes that the full Wolf block-diagonal / multiplicity refinement remains future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2759bb9d6a2e357002df704f9c0de0a870032bec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->