### PR TITLE
feat(Algebra): orthogonal reducibility of a star-subalgebra (toward Wolf Thm 6.14 spatial realization)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -39,6 +39,7 @@ import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.SpinCover
 import TNLean.Algebra.MatrixRankClosed
 import TNLean.Algebra.StarSubalgebraSemisimple
+import TNLean.Algebra.StarSubalgebraSpatial
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ProjectionGeometry

--- a/TNLean/Algebra/StarSubalgebraSpatial.lean
+++ b/TNLean/Algebra/StarSubalgebraSpatial.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.InnerProductSpace.Adjoint
+import Mathlib.Analysis.InnerProductSpace.Projection.Submodule
+import Mathlib.Algebra.Module.Submodule.Invariant
+import Mathlib.Algebra.Star.Subalgebra
+import Mathlib.LinearAlgebra.Matrix.ConjTranspose
+
+/-!
+# Orthogonal reducibility for a star-subalgebra of complex matrices
+
+The spatial input to the structure theory of Wolf Ch. 6 (towards Thm 6.14) is the
+fact that a star-closed set of operators reduces orthogonally: whenever a subspace
+is invariant, its orthogonal complement is invariant as well. This is the feature
+distinguishing a star-subalgebra from a general subalgebra; the abstract
+Wedderburn-Artin decomposition only produces a direct sum of matrix algebras,
+while the star structure forces that direct sum to be orthogonal, hence realizable
+by a single unitary change of basis.
+
+## Main results
+
+* `orthogonal_mem_invtSubmodule_of_adjoint` -- for an operator on a
+  finite-dimensional inner product space, the orthogonal complement of a submodule
+  invariant under the adjoint is invariant under the operator itself.
+* `Matrix.orthogonal_mem_invtSubmodule_toEuclideanLin` -- the matrix form: if a
+  subspace of Euclidean space is invariant under the conjugate transpose, its
+  orthogonal complement is invariant under the matrix.
+* `StarSubalgebra.orthogonal_mem_invtSubmodule` -- for a star-subalgebra of complex
+  matrices, the orthogonal complement of a subspace invariant under every member is
+  again invariant under every member.
+* `StarSubalgebra.isCompl_orthogonal_of_invariant` -- an invariant subspace of a
+  star-subalgebra has its orthogonal complement as an invariant complement: the two
+  subspaces are complementary and both are invariant.
+
+## Remaining gap towards Wolf Thm 6.14
+
+Orthogonal reducibility supplies an invariant orthogonal complement to every
+invariant subspace, which is the central ingredient for an orthogonal
+decomposition of the representation space into irreducible pieces. The full
+theorem additionally asserts that, after grouping the irreducible pieces into
+isotypic components, each component carries a tensor identification of the form
+"matrix block on the multiplicity space" and that the assembled change of basis is
+a single unitary. That tensor identification and the unitary assembly are not
+formalized here; they remain the open steps towards Wolf Thm 6.14.
+-/
+
+open scoped Matrix ComplexOrder
+open scoped InnerProductSpace
+
+namespace StarSubalgebraSpatial
+
+variable {𝕜 E : Type*} [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+  [FiniteDimensional 𝕜 E]
+
+/-- The orthogonal complement of a submodule invariant under the adjoint of an
+operator is invariant under the operator. If `p` is mapped into itself by the
+adjoint of `f`, then for `x` orthogonal to `p` and `y` in `p` one has
+`inner y (f x) = inner (adjoint f y) x = 0`, so `f x` is orthogonal to `p`. -/
+theorem orthogonal_mem_invtSubmodule_of_adjoint
+    {f : Module.End 𝕜 E} {p : Submodule 𝕜 E}
+    (hp : p ∈ Module.End.invtSubmodule (LinearMap.adjoint f)) :
+    pᗮ ∈ Module.End.invtSubmodule f :=
+  fun _ hx y hy ↦ LinearMap.adjoint_inner_left f _ y ▸ hx (LinearMap.adjoint f y) (hp hy)
+
+end StarSubalgebraSpatial
+
+namespace Matrix
+
+open StarSubalgebraSpatial
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- The orthogonal complement of a subspace invariant under the conjugate transpose
+`Aᴴ` is invariant under `A`, viewing matrices as operators on Euclidean space. The
+adjoint of the operator of `A` is the operator of `Aᴴ`. -/
+theorem orthogonal_mem_invtSubmodule_toEuclideanLin {A : Matrix n n ℂ}
+    {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : p ∈ Module.End.invtSubmodule (Matrix.toEuclideanLin Aᴴ)) :
+    pᗮ ∈ Module.End.invtSubmodule (Matrix.toEuclideanLin A) := by
+  refine orthogonal_mem_invtSubmodule_of_adjoint ?_
+  rwa [Matrix.toEuclideanLin_conjTranspose_eq_adjoint] at hp
+
+end Matrix
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+/-- For a star-subalgebra of complex matrices, the orthogonal complement of a
+subspace invariant under every member of the subalgebra is again invariant under
+every member. The orthogonal complement of an invariant subspace is invariant for a
+single member precisely when the conjugate transpose of that member is also a
+member, which holds for every element of a star-subalgebra. Wolf Ch. 6, towards
+Thm 6.14. -/
+theorem orthogonal_mem_invtSubmodule {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : ∀ A ∈ S, p ∈ Module.End.invtSubmodule (Matrix.toEuclideanLin A)) (A : Matrix n n ℂ)
+    (hA : A ∈ S) : pᗮ ∈ Module.End.invtSubmodule (Matrix.toEuclideanLin A) := by
+  refine Matrix.orthogonal_mem_invtSubmodule_toEuclideanLin ?_
+  have hAstar : Aᴴ ∈ S := by
+    have := star_mem hA
+    rwa [Matrix.star_eq_conjTranspose] at this
+  exact hp Aᴴ hAstar
+
+/-- An invariant subspace of a star-subalgebra of complex matrices has its
+orthogonal complement as an invariant complement: the subspace and its orthogonal
+complement are complementary, and both are invariant under every member of the
+subalgebra. This is the spatial semisimplicity of the representation: every
+invariant subspace splits off orthogonally. Wolf Ch. 6, towards Thm 6.14. -/
+theorem isCompl_orthogonal_of_invariant {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : ∀ A ∈ S, p ∈ Module.End.invtSubmodule (Matrix.toEuclideanLin A)) :
+    IsCompl p pᗮ ∧ ∀ A ∈ S, pᗮ ∈ Module.End.invtSubmodule (Matrix.toEuclideanLin A) :=
+  ⟨Submodule.isCompl_orthogonal (K := p), S.orthogonal_mem_invtSubmodule hp⟩
+
+end StarSubalgebra

--- a/TNLean/Algebra/StarSubalgebraSpatial.lean
+++ b/TNLean/Algebra/StarSubalgebraSpatial.lean
@@ -46,7 +46,7 @@ a single unitary. That tensor identification and the unitary assembly are not
 formalized here; they remain the open steps towards Wolf Thm 6.14.
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix
 open scoped InnerProductSpace
 
 namespace StarSubalgebraSpatial

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1173,9 +1173,9 @@ direct sum of them.
     Let $S$ be a $*$-subalgebra of $\MN{D}$, and let $W \subseteq \C^{D}$ be a
     subspace invariant under every member of $S$, meaning $A\,W \subseteq W$ for
     all $A \in S$. Then the orthogonal complement $W^{\perp}$ is also invariant
-    under every member of $S$:
+    under every member of $S$: for each $A \in S$,
     \[
-        A\, W^{\perp} \subseteq W^{\perp} \qquad \text{for all } A \in S.
+        A\, W^{\perp} \subseteq W^{\perp}.
     \]
 \end{lemma}
 
@@ -1202,7 +1202,8 @@ direct sum of them.
     \[
         \C^{D} = W \oplus W^{\perp},
     \]
-    in which both $W$ and $W^{\perp}$ are invariant under every member of $S$.
+    in which the orthogonal complement $W^{\perp}$ is invariant under every
+    member of $S$.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1159,6 +1159,61 @@ special case used in this section.
     semisimple algebras over the algebraically closed field $\C$.
 \end{proof}
 
+The abstract decomposition records only the ring structure. To realize it by a
+single unitary change of basis, as in~\cite[Theorem~6.14]{Wolf2012Quantum}, one
+uses the spatial feature of a $*$-subalgebra: it reduces orthogonally. Whenever a
+subspace is invariant, so is its orthogonal complement, so the representation
+space splits into mutually orthogonal invariant pieces rather than merely into a
+direct sum of them.
+
+\begin{lemma}[Orthogonal reducibility of a $*$-subalgebra]%
+    \label{lem:starSubalgebra_orthogonal_reducibility}
+    \lean{StarSubalgebra.orthogonal_mem_invtSubmodule}
+    \leanok
+    Let $S$ be a $*$-subalgebra of $\MN{D}$, and let $W \subseteq \C^{D}$ be a
+    subspace invariant under every member of $S$, meaning $A\,W \subseteq W$ for
+    all $A \in S$. Then the orthogonal complement $W^{\perp}$ is also invariant
+    under every member of $S$:
+    \[
+        A\, W^{\perp} \subseteq W^{\perp} \qquad \text{for all } A \in S.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Fix $A \in S$. Since $S$ is closed under the adjoint, $A^{\dagger} \in S$,
+    and therefore $A^{\dagger} W \subseteq W$. For $v \in W^{\perp}$ and
+    $w \in W$,
+    \[
+        \langle w, A v \rangle = \langle A^{\dagger} w, v \rangle = 0,
+    \]
+    because $A^{\dagger} w \in W$ while $v$ is orthogonal to $W$. Hence
+    $A v \in W^{\perp}$.
+\end{proof}
+
+\begin{lemma}[Invariant subspaces split off orthogonally]%
+    \label{lem:starSubalgebra_isCompl_orthogonal}
+    \lean{StarSubalgebra.isCompl_orthogonal_of_invariant}
+    \leanok
+    \uses{lem:starSubalgebra_orthogonal_reducibility}
+    With $S$ and $W$ as in
+    Lemma~\ref{lem:starSubalgebra_orthogonal_reducibility}, the representation
+    space decomposes as the orthogonal direct sum
+    \[
+        \C^{D} = W \oplus W^{\perp},
+    \]
+    in which both $W$ and $W^{\perp}$ are invariant under every member of $S$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_orthogonal_reducibility}
+    In a finite-dimensional inner product space the orthogonal complement of a
+    subspace is a vector-space complement, which gives the orthogonal direct
+    sum. Invariance of $W^{\perp}$ is
+    Lemma~\ref{lem:starSubalgebra_orthogonal_reducibility}.
+\end{proof}
+
 \begin{theorem}[Fixed-point algebra is semisimple]%
     \label{thm:fixedPointAlgebra_isSemisimpleRing}
     \lean{Kraus.fixedPointAlgebra_isSemisimpleRing}


### PR DESCRIPTION
## Summary

Follow-up to LionSR/TNLean#3561, toward the spatial (unitary) realization of Wolf Thm. 6.14.
This PR lands the genuine `*`-specific ingredient that the abstract Wedderburn-Artin
iso lacks: a `*`-subalgebra **reduces orthogonally**. New file
`TNLean/Algebra/StarSubalgebraSpatial.lean`.

## What is landed (sorry-free, axiom-clean)

- `StarSubalgebraSpatial.orthogonal_mem_invtSubmodule_of_adjoint` — general
  inner-product lemma (root-level): on a finite-dimensional inner product space,
  the orthogonal complement of a submodule invariant under `adjoint f` is invariant
  under `f`. This is the adjoint-closure generalization of Mathlib's single-operator
  `LinearMap.IsSymmetric.orthogonalComplement_mem_invtSubmodule` (which only covers
  `f = f†`).
- `Matrix.orthogonal_mem_invtSubmodule_toEuclideanLin` — matrix form via
  `Matrix.toEuclideanLin_conjTranspose_eq_adjoint` (adjoint of `A` is `Aᴴ`).
- `StarSubalgebra.orthogonal_mem_invtSubmodule` — for a `*`-subalgebra
  `S ⊆ Matrix (Fin D) ℂ`: the orthogonal complement of an `S`-invariant subspace is
  `S`-invariant (uses `Aᴴ ∈ S` for every `A ∈ S`).
- `StarSubalgebra.isCompl_orthogonal_of_invariant` — every `S`-invariant subspace
  splits off orthogonally: `IsCompl p pᗮ` and both `p`, `pᗮ` are `S`-invariant. This
  is the spatial semisimplicity of the representation.

Blueprint: two new `\lean`/`\leanok` lemma entries in
`ch07_spectral.tex` (`lem:starSubalgebra_orthogonal_reducibility`,
`lem:starSubalgebra_isCompl_orthogonal`) after the abstract Wedderburn theorem.

## Verification

- `lake env lean TNLean/Algebra/StarSubalgebraSpatial.lean` exits 0.
- `#print axioms` for all four lemmas: `[propext, Classical.choice, Quot.sound]`.
- `lake exe lint-style` exits 0; reader-facing prose checker passes.
- No `sorry`/`axiom`/`native_decide`.

## What remains (honest)

This PR lands the reusable `*`-specific reducibility layer, **not** the full
`∃ U, U⁻¹ S U = ⊕ₖ (M_{d_k} ⊗ 1_{m_k})`. The remaining steps:

1. Iterate reducibility to an orthogonal decomposition of `ℂ^D` into `S`-irreducible
   subspaces (induction on dimension; well-founded recursion building the family).
2. Group the irreducibles into isotypic components and exhibit, on each, the tensor
   identification `M_{d_k} ⊗ 1_{m_k}` (multiplicity-space structure). Mathlib's
   `RingTheory/SimpleModule/Isotypic.lean` supplies the abstract isotypic /
   endomorphism-algebra side but not the spatial tensor factorization.
3. Assemble an adapted orthonormal basis into a single unitary `U` and verify
   `U⁻¹ S U` is block-diagonal.

Steps 1-3 are the open work toward Wolf Thm. 6.14; this PR supplies the orthogonality
input they rely on.

Refs LionSR/QICLean#186, LionSR/TNLean#3561.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Mathlib algebra/analysis additions with no changes to channels, auth, or runtime behavior; only new proofs and blueprint linkage.
> 
> **Overview**
> Adds **`TNLean/Algebra/StarSubalgebraSpatial.lean`** and wires it into the root import list, formalizing the *-specific spatial ingredient behind Wolf Thm. 6.14: invariant subspaces of a complex matrix *-subalgebra split off **orthogonally**, not only as a direct sum.
> 
> The Lean layer chains a general inner-product lemma (`orthogonal_mem_invtSubmodule_of_adjoint`) through matrix operators (`Matrix.orthogonal_mem_invtSubmodule_toEuclideanLin`, using `Aᴴ` as the adjoint) to **`StarSubalgebra.orthogonal_mem_invtSubmodule`** and **`StarSubalgebra.isCompl_orthogonal_of_invariant`** (`IsCompl p pᗮ` with both pieces *-invariant).
> 
> **`blueprint/src/chapter/ch07_spectral.tex`** documents this after the abstract Wedderburn theorem: narrative on orthogonal reducibility vs. ring-only decomposition, plus `\lean`/`\leanok` entries for `lem:starSubalgebra_orthogonal_reducibility` and `lem:starSubalgebra_isCompl_orthogonal`. Full block/tensor unitary realization of Thm. 6.14 remains future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b82889647bd766e679a649498ed095770d623d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->