### PR TITLE
feat(Algebra): Schur's lemma on the irreducible pieces of a star-subalgebra (toward Wolf Thm 6.14 spatial realization)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -39,6 +39,7 @@ import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.SpinCover
 import TNLean.Algebra.MatrixRankClosed
 import TNLean.Algebra.StarSubalgebraIrreducibleDecomp
+import TNLean.Algebra.StarSubalgebraSchur
 import TNLean.Algebra.StarSubalgebraSemisimple
 import TNLean.Algebra.StarSubalgebraSpatial
 

--- a/TNLean/Algebra/StarSubalgebraSchur.lean
+++ b/TNLean/Algebra/StarSubalgebraSchur.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.StarSubalgebraIrreducibleDecomp
+import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
+import Mathlib.Analysis.Complex.Polynomial.Basic
+
+/-!
+# Schur's lemma on the irreducible pieces of a star-subalgebra
+
+This file proves the Schur step in the structure theory of Wolf Ch. 6 (towards Thm 6.14):
+on an irreducible invariant subspace of a star-subalgebra of complex matrices, every
+operator commuting with the subalgebra acts as a scalar.
+
+The orthogonal irreducible decomposition (companion file) splits the representation space
+into mutually orthogonal pieces on each of which the subalgebra acts irreducibly. The next
+step towards the structure theorem groups these pieces by isomorphism type; the grouping is
+driven by the size of the commutant of the subalgebra on each piece, and Schur's lemma pins
+that commutant down to the scalars over an algebraically closed field.
+
+## Main results
+
+* `StarSubalgebra.intertwiner_zero_or_isomorphism` -- a complex-linear operator carrying one
+  irreducible invariant subspace into another and commuting there with the subalgebra is
+  either zero on the source or an isomorphism of the source onto the target.
+* `StarSubalgebra.exists_eq_smul_of_commute_of_irreducible` -- on an irreducible invariant
+  subspace, a complex-linear operator that preserves the subspace and commutes there with
+  every member of the subalgebra is a scalar multiple of the identity on that subspace.
+
+## Proof outline
+
+Restrict the commuting operator to the irreducible piece, which is a nonzero
+finite-dimensional complex vector space, so over the complex numbers it has an eigenvalue.
+The corresponding eigenspace intersected with the piece is invariant under the subalgebra
+(the operator commutes with the subalgebra and the scalar commutes with everything) and is
+nonzero, so by irreducibility it is the whole piece: the operator equals that scalar there.
+
+## Remaining gap towards Wolf Thm 6.14
+
+The scalar commutant identified here measures the multiplicity with which an irreducible type
+occurs. The remaining steps are to group the irreducible pieces into isotypic components, to
+equip each component with a tensor identification of the form "matrix block on the
+multiplicity space", and to assemble a single unitary change of basis. Those steps are not
+formalized here.
+-/
+
+open scoped Matrix
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+/-- Schur's lemma for distinct irreducible pieces of a star-subalgebra of complex matrices: a
+complex-linear operator `f` that carries an irreducible invariant subspace `p` into another
+irreducible invariant subspace `q` and commutes on `p` with every member of the subalgebra is
+either zero on `p` or an isomorphism of `p` onto `q` (injective on `p` with image exactly `q`).
+The kernel of `f` inside `p` and the image of `p` under `f` are both invariant under the
+subalgebra, so irreducibility of `p` and of `q` forces each to be trivial or everything. Wolf
+Ch. 6, towards Thm 6.14. -/
+theorem intertwiner_zero_or_isomorphism
+    {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)
+    (hq : S.IsIrreducibleSubspace q) {f : Module.End ℂ (EuclideanSpace ℂ n)}
+    (hmap : Submodule.map f p ≤ q)
+    (hcomm : ∀ A ∈ S, ∀ x ∈ p,
+      f (Matrix.toEuclideanLin A x) = Matrix.toEuclideanLin A (f x)) :
+    (∀ x ∈ p, f x = 0) ∨ (Set.InjOn f p ∧ Submodule.map f p = q) := by
+  obtain ⟨hpinv, -, hpmax⟩ := hp
+  obtain ⟨hqinv, -, hqmax⟩ := hq
+  by_cases hzero : ∀ x ∈ p, f x = 0
+  · exact Or.inl hzero
+  refine Or.inr ⟨?_, ?_⟩
+  · -- The kernel of `f` inside `p` is invariant, hence trivial since `f` is not zero on `p`.
+    have hker_inv : S.IsInvariantSubspace (p ⊓ LinearMap.ker f) := by
+      intro A hA
+      refine (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem
+        (f := Matrix.toEuclideanLin A)).mpr fun x hx => ?_
+      rw [Submodule.mem_inf, LinearMap.mem_ker] at hx ⊢
+      refine ⟨(Module.End.mem_invtSubmodule_iff_forall_mem_of_mem
+        (f := Matrix.toEuclideanLin A)).mp (hpinv A hA) x hx.1, ?_⟩
+      rw [hcomm A hA x hx.1, hx.2, map_zero]
+    have hker : p ⊓ LinearMap.ker f = ⊥ := by
+      rcases hpmax _ hker_inv inf_le_left with h | h
+      · exact h
+      · have hple : p ≤ LinearMap.ker f := h ▸ inf_le_right
+        exact absurd (fun x hx => LinearMap.mem_ker.mp (hple hx)) hzero
+    intro x hx y hy hxy
+    have : x - y ∈ p ⊓ LinearMap.ker f :=
+      Submodule.mem_inf.mpr ⟨p.sub_mem hx hy, by rw [LinearMap.mem_ker, map_sub, hxy, sub_self]⟩
+    rw [hker, Submodule.mem_bot, sub_eq_zero] at this
+    exact this
+  · -- The image of `p` under `f` is invariant, hence all of `q` since it is nonzero.
+    have him_inv : S.IsInvariantSubspace (Submodule.map f p) := by
+      intro A hA
+      refine (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem
+        (f := Matrix.toEuclideanLin A)).mpr fun y hy => ?_
+      obtain ⟨x, hxp, rfl⟩ := Submodule.mem_map.mp hy
+      refine Submodule.mem_map.mpr ⟨Matrix.toEuclideanLin A x,
+        (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem
+          (f := Matrix.toEuclideanLin A)).mp (hpinv A hA) x hxp, hcomm A hA x hxp⟩
+    rcases hqmax _ him_inv hmap with h | h
+    · refine absurd (fun x hx => ?_) hzero
+      have : f x ∈ Submodule.map f p := Submodule.mem_map.mpr ⟨x, hx, rfl⟩
+      rw [h, Submodule.mem_bot] at this
+      exact this
+    · exact h
+
+/-- Schur's lemma for the irreducible pieces of a star-subalgebra of complex matrices: if `p`
+is an irreducible invariant subspace and `f` is a complex-linear operator that maps `p` into
+itself and commutes on `p` with every member of the subalgebra, then `f` acts on `p` as a
+scalar multiple of the identity. Over the complex numbers the commutant of the subalgebra on
+an irreducible piece is exactly the scalars. Wolf Ch. 6, towards Thm 6.14. -/
+theorem exists_eq_smul_of_commute_of_irreducible
+    {p : Submodule ℂ (EuclideanSpace ℂ n)} (hirr : S.IsIrreducibleSubspace p)
+    {f : Module.End ℂ (EuclideanSpace ℂ n)} (hf : p ∈ Module.End.invtSubmodule f)
+    (hcomm : ∀ A ∈ S, ∀ x ∈ p,
+      f (Matrix.toEuclideanLin A x) = Matrix.toEuclideanLin A (f x)) :
+    ∃ c : ℂ, ∀ x ∈ p, f x = c • x := by
+  obtain ⟨hinv, hpne, hmax⟩ := hirr
+  -- `f` restricts to an operator on the irreducible piece `p`.
+  have hmaps : ∀ x ∈ p, f x ∈ p :=
+    (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem (f := f)).mp hf
+  have hpnt : Nontrivial p := Submodule.nontrivial_iff_ne_bot.mpr hpne
+  -- Over `ℂ` the restricted operator has an eigenvalue, hence an eigenvector inside `p`.
+  obtain ⟨c, hc⟩ := Module.End.exists_eigenvalue (f.restrict hmaps)
+  obtain ⟨w, hw_mem, hw_ne⟩ := hc.exists_hasEigenvector
+  rw [Module.End.mem_eigenspace_iff] at hw_mem
+  have hfw : f (w : EuclideanSpace ℂ n) = c • (w : EuclideanSpace ℂ n) := by
+    have hcoe := congrArg (Subtype.val) hw_mem
+    rwa [LinearMap.coe_restrict_apply, Submodule.coe_smul] at hcoe
+  -- The `c`-eigenspace of `f` inside `p`.
+  set q : Submodule ℂ (EuclideanSpace ℂ n) := p ⊓ Module.End.eigenspace f c with hq
+  have hmemq : ∀ x : EuclideanSpace ℂ n, x ∈ q ↔ x ∈ p ∧ f x = c • x := fun x => by
+    rw [hq, Submodule.mem_inf, Module.End.mem_eigenspace_iff]
+  have hq_le : q ≤ p := inf_le_left
+  -- The eigenspace inside `p` is invariant under the subalgebra: the operator commutes with the
+  -- subalgebra and the eigenvalue scalar commutes with everything.
+  have hq_inv : S.IsInvariantSubspace q := by
+    intro A hA
+    refine (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem
+      (f := Matrix.toEuclideanLin A)).mpr fun x hx => ?_
+    obtain ⟨hxp, hxe⟩ := (hmemq x).mp hx
+    refine (hmemq _).mpr ⟨(Module.End.mem_invtSubmodule_iff_forall_mem_of_mem
+      (f := Matrix.toEuclideanLin A)).mp (hinv A hA) x hxp, ?_⟩
+    rw [hcomm A hA x hxp, hxe, map_smul]
+  -- The eigenvector lies in `q` and is nonzero, so `q` is not the zero subspace.
+  have hq_ne : q ≠ ⊥ :=
+    (Submodule.ne_bot_iff q).mpr ⟨w, (hmemq _).mpr ⟨w.2, hfw⟩, fun h => hw_ne (Subtype.ext h)⟩
+  -- By irreducibility `q` is all of `p`, so `f` equals `c • id` on `p`.
+  rcases hmax q hq_inv hq_le with h | h
+  · exact absurd h hq_ne
+  · exact ⟨c, fun x hx => ((hmemq x).mp (h.symm ▸ hx)).2⟩
+
+end StarSubalgebra

--- a/TNLean/Algebra/StarSubalgebraSchur.lean
+++ b/TNLean/Algebra/StarSubalgebraSchur.lean
@@ -52,7 +52,7 @@ namespace StarSubalgebra
 variable {n : Type*} [Fintype n] [DecidableEq n]
 variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
 
-/-- Schur's lemma for distinct irreducible pieces of a star-subalgebra of complex matrices: a
+/-- Schur's lemma for irreducible pieces of a star-subalgebra of complex matrices: a
 complex-linear operator `f` that carries an irreducible invariant subspace `p` into another
 irreducible invariant subspace `q` and commutes on `p` with every member of the subalgebra is
 either zero on `p` or an isomorphism of `p` onto `q` (injective on `p` with image exactly `q`).
@@ -121,7 +121,7 @@ theorem exists_eq_smul_of_commute_of_irreducible
   -- `f` restricts to an operator on the irreducible piece `p`.
   have hmaps : ∀ x ∈ p, f x ∈ p :=
     (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem (f := f)).mp hf
-  have hpnt : Nontrivial p := Submodule.nontrivial_iff_ne_bot.mpr hpne
+  haveI hpnt : Nontrivial p := Submodule.nontrivial_iff_ne_bot.mpr hpne
   -- Over `ℂ` the restricted operator has an eigenvalue, hence an eigenvector inside `p`.
   obtain ⟨c, hc⟩ := Module.End.exists_eigenvalue (f.restrict hmaps)
   obtain ⟨w, hw_mem, hw_ne⟩ := hc.exists_hasEigenvector

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1271,6 +1271,69 @@ step the two pieces are.
     whole space $W = \C^{D}$, which is invariant under every member of $S$.
 \end{proof}
 
+The next step towards the structure theorem groups the irreducible pieces by
+isomorphism type. The grouping is governed by Schur's lemma: a map commuting with
+$S$ between two pieces is either zero or an isomorphism, and over the complex
+numbers the commutant of $S$ on a single piece is the scalars.
+
+\begin{lemma}[Schur's lemma for distinct irreducible pieces]%
+    \label{lem:starSubalgebra_intertwiner_irreducible}
+    \lean{StarSubalgebra.intertwiner_zero_or_isomorphism}
+    \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$ and let $W, W' \subseteq \C^{D}$ be irreducible
+    under $S$. Let $f \colon \C^{D} \to \C^{D}$ be a linear operator that carries $W$ into
+    $W'$ and commutes on $W$ with every member of $S$, that is,
+    \[
+        f(A x) = A\,(f x)
+    \]
+    for every $A \in S$ and every $x \in W$. Then either $f$ is zero on $W$, or $f$ is
+    injective on $W$ and maps $W$ onto $W'$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace}
+    The vectors of $W$ annihilated by $f$ form a subspace of $W$ that is invariant under
+    $S$, because $f$ commutes with $S$ on $W$. By irreducibility of $W$ this kernel is
+    either all of $W$, in which case $f$ is zero on $W$, or trivial, in which case $f$ is
+    injective on $W$. Likewise the image of $W$ under $f$ is a subspace of $W'$ invariant
+    under $S$, so by irreducibility of $W'$ it is either trivial, again forcing $f$ to be
+    zero on $W$, or all of $W'$. Hence $f$ is zero on $W$, or it is injective on $W$ with
+    image $W'$.
+\end{proof}
+
+\begin{lemma}[Scalar commutant on an irreducible piece]%
+    \label{lem:starSubalgebra_scalar_commutant_irreducible}
+    \lean{StarSubalgebra.exists_eq_smul_of_commute_of_irreducible}
+    \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$ and let $W \subseteq \C^{D}$ be irreducible
+    under $S$. Let $f \colon \C^{D} \to \C^{D}$ be a linear operator that maps $W$ into
+    itself and commutes on $W$ with every member of $S$, that is,
+    \[
+        f(A x) = A\,(f x)
+    \]
+    for every $A \in S$ and every $x \in W$. Then $f$ acts on $W$ as a scalar: there is a
+    complex number $c$ with
+    \[
+        f x = c\,x
+    \]
+    for every $x \in W$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace}
+    Restricting $f$ to $W$ gives an operator on a nonzero finite-dimensional complex
+    vector space, which over the complex numbers has an eigenvalue $c$ together with an
+    eigenvector inside $W$. The set of vectors of $W$ on which $f$ acts as multiplication
+    by $c$ is a subspace contained in $W$; it is nonzero because it contains that
+    eigenvector, and it is invariant under $S$ because $f$ commutes with every member of
+    $S$ on $W$ while the scalar $c$ commutes with everything. By irreducibility this
+    subspace is all of $W$, so $f$ acts as multiplication by $c$ throughout $W$.
+\end{proof}
+
 \begin{theorem}[Fixed-point algebra is semisimple]%
     \label{thm:fixedPointAlgebra_isSemisimpleRing}
     \lean{Kraus.fixedPointAlgebra_isSemisimpleRing}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1276,7 +1276,7 @@ isomorphism type. The grouping is governed by Schur's lemma: a map commuting wit
 $S$ between two pieces is either zero or an isomorphism, and over the complex
 numbers the commutant of $S$ on a single piece is the scalars.
 
-\begin{lemma}[Schur's lemma for distinct irreducible pieces]%
+\begin{lemma}[Schur's lemma: an intertwiner of irreducible pieces is zero or an isomorphism]%
     \label{lem:starSubalgebra_intertwiner_irreducible}
     \lean{StarSubalgebra.intertwiner_zero_or_isomorphism}
     \leanok


### PR DESCRIPTION
## Summary

Lands the **Schur step** toward the spatial realization of Wolf Thm 6.14
(`U(0 ⊕ ⊕_k M_{d_k} ⊗ 1_{m_k})U†`), building directly on the orthogonal
irreducible decomposition merged in LionSR/TNLean#3573. Part of the program tracked in LionSR/QICLean#186.

New file `TNLean/Algebra/StarSubalgebraSchur.lean` with two axiom-clean theorems
(`#print axioms` = `[propext, Classical.choice, Quot.sound]` for both):

- `StarSubalgebra.intertwiner_zero_or_isomorphism` — Schur's lemma for *distinct*
  pieces: a complex-linear operator carrying one irreducible invariant subspace `p`
  into another `q` and commuting with the subalgebra on `p` is either zero on `p`
  or an isomorphism `p ≅ q` (injective on `p`, image exactly `q`). Field-independent;
  the engine for grouping pieces by isomorphism type.
- `StarSubalgebra.exists_eq_smul_of_commute_of_irreducible` — Schur's lemma for a
  *single* piece: over `ℂ` the commutant of the subalgebra on an irreducible piece
  is the scalars. Uses the algebraically-closed input via Mathlib's
  `Module.End.exists_eigenvalue`.

Both are stated directly in terms of the existing `IsIrreducibleSubspace` predicate
and the `Matrix.toEuclideanLin` action, so they need no new module/algebra instances.

Blueprint: two entries added to `ch07_spectral.tex` next to the orthogonal-decomposition
entries (`lem:starSubalgebra_intertwiner_irreducible`,
`lem:starSubalgebra_scalar_commutant_irreducible`), each with `\lean`/`\leanok`/`\uses`.

## What did NOT land (honest scope)

The abstract Schur-scalar result (a) already exists in Mathlib as
`IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed`, so this PR contributes the
*spatial bridge* of Schur rather than re-deriving it. The remaining hard steps toward
Thm 6.14 are **not** in this PR:

- **(b) Isotypic grouping** — Mathlib's `IsIsotypic`/`isotypicComponent` machinery
  needs the representation space carried as a genuine `Module ↥S (EuclideanSpace ℂ n)`
  (via `Module.compHom` over the multiplicative `toEuclideanLin`) plus
  `IsScalarTower ℂ ↥S _` and a bridge `IsIrreducibleSubspace p ↔ IsSimpleModule ↥S p`.
  The two Schur lemmas here supply the equivalence-relation engine for the grouping; the
  module-instance bridge is the missing infrastructure.
- **(c) Per-component tensor factorization** `M_{d_k} ⊗ 1_{m_k}` — the genuine
  Mathlib-level gap (no finite-dim ⋆-algebra spatial tensor factorization in Mathlib).
- **(d) Unitary assembly** into a single `Matrix.unitaryGroup` element.

Verification: `lake env lean` exit 0, `lake exe lint-style` exit 0,
`check_reader_facing_prose.py --diff-base origin/main` clean, no `sorry`/`axiom`/`admit`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive formalization and documentation on top of existing decomposition infrastructure; no changes to runtime, auth, or channel logic.
> 
> **Overview**
> Adds the **Schur step** after the orthogonal irreducible decomposition: formal Lean proofs and matching blueprint lemmas toward Wolf Thm 6.14 spatial realization.
> 
> **`TNLean/Algebra/StarSubalgebraSchur.lean`** introduces two results on `IsIrreducibleSubspace` and `Matrix.toEuclideanLin` action: **`intertwiner_zero_or_isomorphism`** (an intertwiner between two irreducible pieces is zero on the source or an isomorphism onto the target, via invariant kernel/image arguments) and **`exists_eq_smul_of_commute_of_irreducible`** (on one irreducible piece, a commuting endomorphism is a scalar on that piece, using `Module.End.exists_eigenvalue` over ℂ). The module is wired into the public import surface via **`TNLean.lean`**.
> 
> **`blueprint/src/chapter/ch07_spectral.tex`** documents the same step with `\lean`/`\leanok` links (`lem:starSubalgebra_intertwiner_irreducible`, `lem:starSubalgebra_scalar_commutant_irreducible`) immediately after the orthogonal decomposition theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f854d51fbf0509628d1bf31a43e39a15451b396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->