### PR TITLE
doc(Analysis): blueprint entries for the resolvent-antitonicity Lieb route

### DIFF
--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -552,3 +552,52 @@ are not developed elsewhere in this document.
     Specialize Theorem~\ref{thm:lieb_concavity} at $A_1=A_2=A$, so that
     the convex combination collapses: $tA+(1-t)A=A$.
 \end{proof}
+
+\section{Resolvent monotonicity toward the Lieb concavity theorem}
+
+The integral-representation route toward the Lieb concavity theorem rests on the
+antitonicity of the resolvent of the commuting left- and right-multiplication
+superoperators. Its matrix-order foundation is the inverse-antitonicity of the
+Loewner order.
+
+\begin{lemma}[Loewner inverse-antitonicity]\label{lem:loewner_inv_antitone}
+    \lean{Matrix.PosDef.inv_le_inv_of_le}
+    \leanok
+    For positive-definite matrices $A$ and $B$ with $A\le B$ in the Loewner
+    order, the inverses satisfy $B^{-1}\le A^{-1}$.
+\end{lemma}
+
+\begin{proof}\leanok
+    Compare the two Schur complements of the block matrix
+    $\begin{psmallmatrix}A^{-1}&\Id\\\Id&B\end{psmallmatrix}$. Complementing its
+    $(1,1)$ block gives $B-(A^{-1})^{-1}=B-A\ge 0$, so the block matrix is
+    positive semidefinite; complementing the $(2,2)$ block of the same matrix
+    gives $A^{-1}-B^{-1}$, which is therefore positive semidefinite as well.
+\end{proof}
+
+\begin{lemma}[Joint Loewner-antitonicity of the commuting-multiplication resolvent]
+    \label{lem:superop_resolvent_antitone}
+    \lean{superop_resolvent_antitone}
+    \leanok
+    \uses{lem:loewner_inv_antitone}
+    Fix $t>0$ and positive-definite matrices with $A_1\le A_2$ and $B_1\le B_2$.
+    The resolvent of the Kronecker model $A\otimes\Id+t\,(\Id\otimes B^{\top})$ of
+    the commuting left- and right-multiplication superoperators is antitone:
+    \[
+        \bigl(A_2\otimes\Id+t\,(\Id\otimes B_2^{\top})\bigr)^{-1}
+        \le
+        \bigl(A_1\otimes\Id+t\,(\Id\otimes B_1^{\top})\bigr)^{-1}.
+    \]
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:loewner_inv_antitone}
+    Each operator $A\otimes\Id+t\,(\Id\otimes B^{\top})$ is positive definite,
+    being the sum of the positive-definite $A\otimes\Id$ and the
+    positive-semidefinite $t\,(\Id\otimes B^{\top})$. From $A_1\le A_2$ and
+    $B_1\le B_2$ one gets $A_1\otimes\Id\le A_2\otimes\Id$ and
+    $\Id\otimes B_1^{\top}\le\Id\otimes B_2^{\top}$, so the two operators are
+    Loewner-ordered. Inverse-antitonicity
+    (Lemma~\ref{lem:loewner_inv_antitone}) reverses the order on passing to the
+    resolvents.
+\end{proof}


### PR DESCRIPTION
## Summary

Closes LionSR/QICLean#187. PR LionSR/TNLean#3563 added two fully-proved, sorry-free declarations in `TNLean/Analysis/SuperoperatorResolvent.lean` without blueprint entries; the LionSR/TNLean#3563 review flagged this and it was tracked as LionSR/QICLean#187. This adds the two entries in `ch18_operator_convexity.tex`:

- `lem:loewner_inv_antitone` → `\lean{Matrix.PosDef.inv_le_inv_of_le}` (Loewner inverse-antitonicity, Schur-complement proof; `\uses{}` empty — Mathlib Schur API only).
- `lem:superop_resolvent_antitone` → `\lean{superop_resolvent_antitone}`, `\uses{lem:loewner_inv_antitone}` (antitonicity of the commuting-multiplication resolvent, the matrix-order input of the integral-representation route toward the Lieb concavity theorem).

Both carry statement- and proof-level `\leanok` (the Lean proofs are complete and sorry-free). Placed in a new closing section of the operator-convexity chapter.

## Faithfulness
The blueprint statements and proof sketches mirror the Lean declarations exactly (verified against `SuperoperatorResolvent.lean:56,:98`): the Schur-complement comparison for inverse-antitonicity, and positive-definiteness + Loewner ordering of the Kronecker model $A\otimes\Id+t(\Id\otimes B^\top)$ for the resolvent step. Notation matches the chapter (`\Id`, `psmallmatrix`, `\otimes`).

## Verification
- `check_reader_facing_prose.py --ci`: no new violations.
- Both `\lean{}` targets exist on `main` (merged via LionSR/TNLean#3563); `leanblueprint checkdecls` will resolve them.
- No Lean source touched — blueprint-only, no build risk.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX additions with no runtime or proof changes.
> 
> **Overview**
> Adds a closing section **“Resolvent monotonicity toward the Lieb concavity theorem”** to `ch18_operator_convexity.tex`, wiring two already-proved Lean results into the blueprint.
> 
> **`lem:loewner_inv_antitone`** maps to `Matrix.PosDef.inv_le_inv_of_le` with a Schur-complement proof sketch for Loewner inverse-antitonicity. **`lem:superop_resolvent_antitone`** maps to `superop_resolvent_antitone`, cites the first lemma via `\uses`, and states joint antitonicity of the commuting-multiplication Kronecker resolvent—the matrix-order step on the integral-representation path toward Lieb concavity. Both entries use `\leanok` on statement and proof; no Lean sources change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6ce738f294d06a3896db82de22735d42da2f37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->