### PR TITLE
doc(Analysis): display the additive Loewner step in the resolvent-antitonicity proof

### DIFF
--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -688,8 +688,13 @@ Loewner order.
     being the sum of the positive-definite $A\otimes\Id$ and the
     positive-semidefinite $t\,(\Id\otimes B^{\top})$. From $A_1\le A_2$ and
     $B_1\le B_2$ one gets $A_1\otimes\Id\le A_2\otimes\Id$ and
-    $\Id\otimes B_1^{\top}\le\Id\otimes B_2^{\top}$, so the two operators are
-    Loewner-ordered. Inverse-antitonicity
-    (Lemma~\ref{lem:loewner_inv_antitone}) reverses the order on passing to the
-    resolvents.
+    $\Id\otimes B_1^{\top}\le\Id\otimes B_2^{\top}$; since $t>0$, adding these
+    yields
+    \[
+        A_1\otimes\Id+t\,(\Id\otimes B_1^{\top})
+        \le
+        A_2\otimes\Id+t\,(\Id\otimes B_2^{\top}).
+    \]
+    Inverse-antitonicity (Lemma~\ref{lem:loewner_inv_antitone}) reverses this
+    inequality on passing to the resolvents.
 \end{proof}


### PR DESCRIPTION
Follow-up to #3579. The reviewer flagged (Category B, formula-first) that the `superop_resolvent_antitone` blueprint proof summarized the key additive step verbally ("so the two operators are Loewner-ordered"). This replaces that phrase with the explicit displayed inequality
$$A_1\otimes\Id+t(\Id\otimes B_1^\top)\le A_2\otimes\Id+t(\Id\otimes B_2^\top),$$
making the additive combination (with the $t>0$ scaling) explicit before inverse-antitonicity is applied. Blueprint-only; prose check passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX in the blueprint; no Lean or runtime behavior changes.
> 
> **Overview**
> In the blueprint proof of **joint Loewner-antitonicity of the commuting-multiplication resolvent** (`lem:superop_resolvent_antitone` in `ch18_operator_convexity.tex`), the step that combines the tensor-factor inequalities is no longer summarized as “so the two operators are Loewner-ordered.”
> 
> The proof now states that **\(t>0\)** lets you add \(A_i\otimes\Id\) and \(t(\Id\otimes B_i^\top)\), and it **displays** the resulting Loewner inequality before invoking inverse-antitonicity. Wording after that step is tightened to say the inequality is **reversed** on taking resolvents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2523fd67fcde35a24f02e36a0a4e8c900d0a7a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->