### PR TITLE
feat(Algebra): isotypic-component decomposition of a star-subalgebra (toward Wolf Thm 6.14 spatial realization)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -40,6 +40,7 @@ import TNLean.Algebra.SpinCover
 import TNLean.Algebra.MatrixRankClosed
 import TNLean.Algebra.StarSubalgebraIrreducibleDecomp
 import TNLean.Algebra.StarSubalgebraIsotypic
+import TNLean.Algebra.StarSubalgebraIsotypicDecomp
 import TNLean.Algebra.StarSubalgebraSchur
 import TNLean.Algebra.StarSubalgebraSemisimple
 import TNLean.Algebra.StarSubalgebraSpatial

--- a/TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean
+++ b/TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.StarSubalgebraIsotypic
+
+/-!
+# Isotypic-component decomposition for a star-subalgebra of complex matrices
+
+Building on the orthogonal decomposition into irreducible pieces and the same-type relation
+on those pieces, this file collects the pieces of a single type into one isotypic component
+and shows that the whole representation space is the orthogonal direct sum of the isotypic
+components. This is the isotypic-grouping step in the structure theory of
+*Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14.
+
+Given the finite, pairwise orthogonal family of irreducible pieces produced by the orthogonal
+decomposition, the same-type relation partitions the family into finitely many classes. Each
+isotypic component is the supremum of one class. Two pieces drawn from different classes are
+orthogonal, because pieces that are not of the same type are orthogonal; lifting this across
+the suprema makes distinct isotypic components orthogonal. Since the classes cover the whole
+family, the components span the whole space.
+
+## Main results
+
+* `StarSubalgebra.isOrtho_sSup_of_not_sameIsotype` -- if no piece of one same-type class is of
+  the same type as any piece of another class, then the suprema of the two classes are
+  orthogonal.
+* `StarSubalgebra.exists_orthogonal_isotypic_decomposition` -- the whole representation space
+  is the supremum of a finite, pairwise orthogonal family of isotypic components, each of
+  which is the supremum of a finite same-type class of irreducible pieces.
+-/
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+/-- If every piece of one set is irreducible, every piece of another set is irreducible, and no
+piece of the first set is of the same type as any piece of the second set, then the supremum of
+the first set is orthogonal to the supremum of the second set. Pieces of different type are
+orthogonal, and orthogonality lifts across suprema. See *Quantum Channels & Operations*
+(Wolf 2012), Chapter 6, towards Theorem 6.14. -/
+theorem isOrtho_sSup_of_not_sameIsotype
+    {D₁ D₂ : Set (Submodule ℂ (EuclideanSpace ℂ n))}
+    (h₁ : ∀ p ∈ D₁, S.IsIrreducibleSubspace p) (h₂ : ∀ q ∈ D₂, S.IsIrreducibleSubspace q)
+    (h : ∀ p ∈ D₁, ∀ q ∈ D₂, ¬ S.SameIsotype p q) : sSup D₁ ⟂ sSup D₂ := by
+  rw [Submodule.isOrtho_sSup_left]
+  intro p hp
+  rw [Submodule.isOrtho_sSup_right]
+  intro q hq
+  exact S.isOrtho_of_not_sameIsotype (h₁ p hp) (h₂ q hq) (h p hp q hq)
+
+/-- The whole representation space of a finite-dimensional star-subalgebra of complex matrices
+is the supremum of a finite, pairwise orthogonal family of isotypic components. Each component
+is the supremum of a finite same-type class of irreducible pieces. The orthogonal decomposition
+into irreducible pieces supplies the family; the same-type relation groups it into classes; and
+pieces of different type are orthogonal, so distinct components are orthogonal. See
+*Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
+theorem exists_orthogonal_isotypic_decomposition :
+    ∃ C : Set (Submodule ℂ (EuclideanSpace ℂ n)), C.Finite ∧
+      C.Pairwise (· ⟂ ·) ∧ sSup C = ⊤ ∧
+      ∀ c ∈ C, ∃ Dc : Set (Submodule ℂ (EuclideanSpace ℂ n)),
+        Dc.Finite ∧ (∀ p ∈ Dc, S.IsIrreducibleSubspace p) ∧ c = sSup Dc ∧
+          Dc.Pairwise fun p q => S.SameIsotype p q := by
+  classical
+  obtain ⟨D, hDfin, hDirr, hDpair, hDsup⟩ := S.exists_orthogonal_irreducible_decomposition
+  -- The same-type class of a piece `p`, taken within the family `D`.
+  set cls : Submodule ℂ (EuclideanSpace ℂ n) → Set (Submodule ℂ (EuclideanSpace ℂ n)) :=
+    fun p => {q ∈ D | S.SameIsotype p q} with hcls
+  -- Each class is a finite set of irreducible pieces of one type, and a piece lies in its own
+  -- class by reflexivity of the same-type relation.
+  have hcls_fin : ∀ p, (cls p).Finite := fun p => hDfin.sep _
+  have hcls_irr : ∀ p, ∀ q ∈ cls p, S.IsIrreducibleSubspace q := fun _ q hq => hDirr q hq.1
+  have hcls_self : ∀ p ∈ D, p ∈ cls p := fun p hp => ⟨hp, S.sameIsotype_refl (hDirr p hp)⟩
+  -- Pieces inside one class are of the same type with each other (through the representative).
+  have hcls_same : ∀ p ∈ D, (cls p).Pairwise fun a b => S.SameIsotype a b := by
+    intro p hp a ha b hb _
+    exact S.sameIsotype_trans (hDirr a ha.1) (hDirr p hp) (hDirr b hb.1)
+      (S.sameIsotype_symm (hDirr p hp) (hDirr a ha.1) ha.2) hb.2
+  -- If two representatives are of the same type, they generate the same class, hence the same
+  -- isotypic component.
+  have hcls_eq : ∀ p ∈ D, ∀ p' ∈ D, S.SameIsotype p p' → cls p = cls p' := by
+    intro p hp p' hp' hsame
+    ext q
+    simp only [hcls, Set.mem_setOf_eq]
+    refine and_congr_right fun hqD => ⟨fun hpq => ?_, fun hp'q => ?_⟩
+    · exact S.sameIsotype_trans (hDirr p' hp') (hDirr p hp) (hDirr q hqD)
+        (S.sameIsotype_symm (hDirr p hp) (hDirr p' hp') hsame) hpq
+    · exact S.sameIsotype_trans (hDirr p hp) (hDirr p' hp') (hDirr q hqD) hsame hp'q
+  -- The isotypic components are the suprema of the classes.
+  refine ⟨(fun p => sSup (cls p)) '' D, hDfin.image _, ?_, ?_, ?_⟩
+  · -- Distinct components come from representatives of different type, so they are orthogonal.
+    rintro _ ⟨p, hp, rfl⟩ _ ⟨p', hp', rfl⟩ hne
+    have hnot : ¬ S.SameIsotype p p' :=
+      fun hsame => hne (congrArg sSup (hcls_eq p hp p' hp' hsame))
+    -- Cross-class pieces are not of the same type, by transitivity through the representatives.
+    refine S.isOrtho_sSup_of_not_sameIsotype (hcls_irr p) (hcls_irr p') ?_
+    intro a ha b hb hsame
+    refine hnot ?_
+    have hpb : S.SameIsotype p b := S.sameIsotype_trans (hDirr p hp) (hDirr a ha.1) (hDirr b hb.1)
+      ha.2 hsame
+    exact S.sameIsotype_trans (hDirr p hp) (hDirr b hb.1) (hDirr p' hp') hpb
+      (S.sameIsotype_symm (hDirr p' hp') (hDirr b hb.1) hb.2)
+  · -- The classes cover the whole family, so the components span the whole space.
+    rw [← hDsup]
+    refine le_antisymm (sSup_le ?_) (sSup_le fun p hp => ?_)
+    · rintro c ⟨p, _, rfl⟩
+      exact sSup_le fun q hq => le_sSup hq.1
+    · -- Each piece sits inside the supremum of its own class, hence inside that component.
+      exact le_trans (le_sSup (hcls_self p hp)) (le_sSup ⟨p, hp, rfl⟩)
+  · -- Each component carries its class as the requested witness.
+    rintro c ⟨p, hp, rfl⟩
+    exact ⟨cls p, hcls_fin p, hcls_irr p, rfl, hcls_same p hp⟩
+
+end StarSubalgebra

--- a/TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean
+++ b/TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean
@@ -27,7 +27,7 @@ family, the components span the whole space.
   orthogonal.
 * `StarSubalgebra.exists_orthogonal_isotypic_decomposition` -- the whole representation space
   is the supremum of a finite, pairwise orthogonal family of isotypic components, each of
-  which is the supremum of a finite same-type class of irreducible pieces.
+  which is the supremum of a finite, nonempty same-type class of irreducible pieces.
 -/
 
 namespace StarSubalgebra
@@ -52,18 +52,19 @@ theorem isOrtho_sSup_of_not_sameIsotype
 
 /-- The whole representation space of a finite-dimensional star-subalgebra of complex matrices
 is the supremum of a finite, pairwise orthogonal family of isotypic components. Each component
-is the supremum of a finite same-type class of irreducible pieces. The orthogonal decomposition
-into irreducible pieces supplies the family; the same-type relation groups it into classes; and
-pieces of different type are orthogonal, so distinct components are orthogonal. See
+is the supremum of a finite, nonempty same-type class of irreducible pieces. The orthogonal
+decomposition into irreducible pieces supplies the family; the same-type relation groups it
+into classes; and pieces of different type are orthogonal, so distinct components are
+orthogonal. See
 *Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
 theorem exists_orthogonal_isotypic_decomposition :
     ∃ C : Set (Submodule ℂ (EuclideanSpace ℂ n)), C.Finite ∧
       C.Pairwise (· ⟂ ·) ∧ sSup C = ⊤ ∧
       ∀ c ∈ C, ∃ Dc : Set (Submodule ℂ (EuclideanSpace ℂ n)),
-        Dc.Finite ∧ (∀ p ∈ Dc, S.IsIrreducibleSubspace p) ∧ c = sSup Dc ∧
+        Dc.Nonempty ∧ Dc.Finite ∧ (∀ p ∈ Dc, S.IsIrreducibleSubspace p) ∧ c = sSup Dc ∧
           Dc.Pairwise fun p q => S.SameIsotype p q := by
   classical
-  obtain ⟨D, hDfin, hDirr, hDpair, hDsup⟩ := S.exists_orthogonal_irreducible_decomposition
+  obtain ⟨D, hDfin, hDirr, -, hDsup⟩ := S.exists_orthogonal_irreducible_decomposition
   -- The same-type class of a piece `p`, taken within the family `D`.
   set cls : Submodule ℂ (EuclideanSpace ℂ n) → Set (Submodule ℂ (EuclideanSpace ℂ n)) :=
     fun p => {q ∈ D | S.SameIsotype p q} with hcls
@@ -110,6 +111,7 @@ theorem exists_orthogonal_isotypic_decomposition :
       exact le_trans (le_sSup (hcls_self p hp)) (le_sSup ⟨p, hp, rfl⟩)
   · -- Each component carries its class as the requested witness.
     rintro c ⟨p, hp, rfl⟩
-    exact ⟨cls p, hcls_fin p, hcls_irr p, rfl, hcls_same p hp⟩
+    exact ⟨cls p, ⟨p, hcls_self p hp⟩, hcls_fin p, hcls_irr p, rfl, hcls_same p hp⟩
 
 end StarSubalgebra
+

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1499,6 +1499,72 @@ irreducible pieces such an intertwiner is automatically an isomorphism.
     that is, $W$ lies in the orthogonal complement of $W'$.
 \end{proof}
 
+The grouping is now assembled. Collecting the pieces of one type into the supremum of a
+same-type class, the suprema of two different classes are orthogonal, and the classes cover
+the whole family, so the components span $\C^{D}$.
+
+\begin{lemma}[Suprema of cross-type classes are orthogonal]%
+    \label{lem:starSubalgebra_isOrtho_sSup_not_sameIsotype}
+    \lean{StarSubalgebra.isOrtho_sSup_of_not_sameIsotype}
+    \leanok
+    \uses{lem:starSubalgebra_isOrtho_not_sameIsotype}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$, and let $\mathcal{D}_1, \mathcal{D}_2$ be two sets
+    of subspaces irreducible under $S$. If no piece of $\mathcal{D}_1$ is of the same type as any
+    piece of $\mathcal{D}_2$, then
+    \[
+        \bigvee_{W \in \mathcal{D}_1} W \;\perp\; \bigvee_{W' \in \mathcal{D}_2} W'.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_isOrtho_not_sameIsotype}
+    Each pair $W \in \mathcal{D}_1$, $W' \in \mathcal{D}_2$ is of different type, hence orthogonal
+    by Lemma~\ref{lem:starSubalgebra_isOrtho_not_sameIsotype}. Orthogonality to a fixed subspace
+    is preserved by suprema on each side, so the supremum of $\mathcal{D}_1$ is orthogonal to the
+    supremum of $\mathcal{D}_2$.
+\end{proof}
+
+\begin{theorem}[Isotypic-component decomposition]%
+    \label{thm:starSubalgebra_orthogonal_isotypic_decomposition}
+    \lean{StarSubalgebra.exists_orthogonal_isotypic_decomposition}
+    \leanok
+    \uses{thm:starSubalgebra_orthogonal_irreducible_decomposition,
+        lem:starSubalgebra_isOrtho_sSup_not_sameIsotype,
+        lem:starSubalgebra_sameIsotype_refl, lem:starSubalgebra_sameIsotype_symm,
+        lem:starSubalgebra_sameIsotype_trans}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$. Then $\C^{D}$ is the supremum of a finite family
+    $\mathcal{C}$ of pairwise orthogonal subspaces, the isotypic components, and each component
+    $C \in \mathcal{C}$ is the supremum of a finite class $\mathcal{D}_C$ of subspaces irreducible
+    under $S$ that are pairwise of the same type:
+    \[
+        C = \bigvee_{W \in \mathcal{D}_C} W.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:starSubalgebra_orthogonal_irreducible_decomposition,
+        lem:starSubalgebra_isOrtho_sSup_not_sameIsotype,
+        lem:starSubalgebra_sameIsotype_refl, lem:starSubalgebra_sameIsotype_symm,
+        lem:starSubalgebra_sameIsotype_trans}
+    The orthogonal irreducible decomposition
+    (Theorem~\ref{thm:starSubalgebra_orthogonal_irreducible_decomposition}) supplies a finite,
+    pairwise orthogonal family $\mathcal{D}$ of irreducible pieces with
+    $\bigvee_{W \in \mathcal{D}} W = \C^{D}$. For each piece $W$ let $\mathcal{D}_W$ be the class
+    of pieces of $\mathcal{D}$ of the same type as $W$, and let $C_W$ be its supremum. Each piece
+    lies in its own class by reflexivity
+    (Lemma~\ref{lem:starSubalgebra_sameIsotype_refl}), so the classes cover $\mathcal{D}$ and the
+    components span $\C^{D}$. Two pieces of one class are of the same type with each other through
+    the representative, by symmetry and transitivity
+    (Lemmas~\ref{lem:starSubalgebra_sameIsotype_symm}
+    and~\ref{lem:starSubalgebra_sameIsotype_trans}). If two representatives are of the same type,
+    transitivity makes their classes equal, hence their components equal; so two distinct
+    components come from representatives of different type, and then no piece of one class is of
+    the same type as any piece of the other, whence the components are orthogonal
+    (Lemma~\ref{lem:starSubalgebra_isOrtho_sSup_not_sameIsotype}).
+\end{proof}
+
 \begin{theorem}[Fixed-point algebra is semisimple]%
     \label{thm:fixedPointAlgebra_isSemisimpleRing}
     \lean{Kraus.fixedPointAlgebra_isSemisimpleRing}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1499,9 +1499,9 @@ irreducible pieces such an intertwiner is automatically an isomorphism.
     that is, $W$ lies in the orthogonal complement of $W'$.
 \end{proof}
 
-The grouping is now assembled. Collecting the pieces of one type into the supremum of a
-same-type class, the suprema of two different classes are orthogonal, and the classes cover
-the whole family, so the components span $\C^{D}$.
+Each isotypic component is the supremum of one same-type class; the suprema of two different
+classes are orthogonal, and the classes cover the whole family, so the components span
+$\C^{D}$.
 
 \begin{lemma}[Suprema of cross-type classes are orthogonal]%
     \label{lem:starSubalgebra_isOrtho_sSup_not_sameIsotype}
@@ -1560,9 +1560,16 @@ the whole family, so the components span $\C^{D}$.
     (Lemmas~\ref{lem:starSubalgebra_sameIsotype_symm}
     and~\ref{lem:starSubalgebra_sameIsotype_trans}). If two representatives are of the same type,
     transitivity makes their classes equal, hence their components equal; so two distinct
-    components come from representatives of different type, and then no piece of one class is of
-    the same type as any piece of the other, whence the components are orthogonal
-    (Lemma~\ref{lem:starSubalgebra_isOrtho_sSup_not_sameIsotype}).
+    components come from representatives $W, W'$ that are not of the same type. Write $\sim$ for
+    the same-type relation. For $a \in \mathcal{D}_W$ and $b \in \mathcal{D}_{W'}$ one has
+    $W \sim a$ and $W' \sim b$ by definition of the classes; were $a \sim b$, symmetry and
+    transitivity would give
+    \[
+        W \sim a \sim b \sim W',
+    \]
+    hence $W \sim W'$, contradicting that $W$ and $W'$ are not of the same type. So no piece of
+    $\mathcal{D}_W$ is of the same type as any piece of $\mathcal{D}_{W'}$, and the components are
+    orthogonal (Lemma~\ref{lem:starSubalgebra_isOrtho_sSup_not_sameIsotype}).
 \end{proof}
 
 \begin{theorem}[Fixed-point algebra is semisimple]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1535,8 +1535,8 @@ $\C^{D}$.
         lem:starSubalgebra_sameIsotype_trans}
     Let $S$ be a $*$-subalgebra of $\MN{D}$. Then $\C^{D}$ is the supremum of a finite family
     $\mathcal{C}$ of pairwise orthogonal subspaces, the isotypic components, and each component
-    $C \in \mathcal{C}$ is the supremum of a finite class $\mathcal{D}_C$ of subspaces irreducible
-    under $S$ that are pairwise of the same type:
+    $C \in \mathcal{C}$ is the supremum of a finite, nonempty class $\mathcal{D}_C$ of subspaces
+    irreducible under $S$ that are pairwise of the same type:
     \[
         C = \bigvee_{W \in \mathcal{D}_C} W.
     \]
@@ -1554,8 +1554,8 @@ $\C^{D}$.
     $\bigvee_{W \in \mathcal{D}} W = \C^{D}$. For each piece $W$ let $\mathcal{D}_W$ be the class
     of pieces of $\mathcal{D}$ of the same type as $W$, and let $C_W$ be its supremum. Each piece
     lies in its own class by reflexivity
-    (Lemma~\ref{lem:starSubalgebra_sameIsotype_refl}), so the classes cover $\mathcal{D}$ and the
-    components span $\C^{D}$. Two pieces of one class are of the same type with each other through
+    (Lemma~\ref{lem:starSubalgebra_sameIsotype_refl}), so each class is nonempty, the classes
+    cover $\mathcal{D}$, and the components span $\C^{D}$. Two pieces of one class are of the same type with each other through
     the representative, by symmetry and transitivity
     (Lemmas~\ref{lem:starSubalgebra_sameIsotype_symm}
     and~\ref{lem:starSubalgebra_sameIsotype_trans}). If two representatives are of the same type,


### PR DESCRIPTION
## What was proven

Continues the Wolf Theorem 6.14 spatial-realization chain with the isotypic-component
grouping step. New file `TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean`:

- `StarSubalgebra.isOrtho_sSup_of_not_sameIsotype` — if every piece of one set is irreducible,
  every piece of another set is irreducible, and no piece of the first set is of the same type
  as any piece of the second, then `sSup D₁ ⟂ sSup D₂`. (Lifts pairwise cross-type
  orthogonality across the suprema via Mathlib's `Submodule.isOrtho_sSup_left/right`.)
- `StarSubalgebra.exists_orthogonal_isotypic_decomposition` — the whole representation space is
  the supremum of a finite, pairwise orthogonal family `C` of isotypic components, each of
  which is the supremum of a finite same-type class `Dc` of irreducible pieces that are
  pairwise of the same type:
  ```
  ∃ C, C.Finite ∧ C.Pairwise (· ⟂ ·) ∧ sSup C = ⊤ ∧
    ∀ c ∈ C, ∃ Dc, Dc.Finite ∧ (∀ p ∈ Dc, S.IsIrreducibleSubspace p) ∧ c = sSup Dc ∧
      Dc.Pairwise fun p q => S.SameIsotype p q
  ```

The construction groups the family `D` from `exists_orthogonal_irreducible_decomposition` by
the `SameIsotype` equivalence (using reflexivity / symmetry / transitivity), forms each
component as the supremum of a class, and proves orthogonality of distinct components and that
the components span. **No `Submodule.sSup`/`IsOrtho` API gap was hit** — Mathlib's
`isOrtho_sSup_left`/`isOrtho_sSup_right` provide exactly the needed lifting of orthogonality
across suprema.

## Blueprint

Two `\leanok` entries added to `blueprint/src/chapter/ch07_spectral.tex` after the
"pieces of different type are orthogonal" lemma:

- `lem:starSubalgebra_isOrtho_sSup_not_sameIsotype` →
  `StarSubalgebra.isOrtho_sSup_of_not_sameIsotype`
- `thm:starSubalgebra_orthogonal_isotypic_decomposition` →
  `StarSubalgebra.exists_orthogonal_isotypic_decomposition`

with `\uses` pointing to the irreducible-decomposition theorem, the cross-type orthogonality
supremum lemma, and the reflexivity/symmetry/transitivity lemmas actually invoked.

## Verification

- `lake build TNLean.Algebra.StarSubalgebraIsotypicDecomp`: exit 0 (Build completed
  successfully, 2835 jobs).
- `git grep "sorry\|admit\|axiom"` on the new file: empty.
- `#print axioms` on both theorems: `[propext, Classical.choice, Quot.sound]` (no new axioms).
- `lake exe lint-style` on the new file: passes (exit 0, no output).
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`: passes
  ("No newly added reader-facing prose violations found").

## Issues

Advances LionSR/QICLean#188 / LionSR/QICLean#186 toward Wolf Theorem 6.14 (spatial realization).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal algebra on top of existing `StarSubalgebraIsotypic` / irreducible-decomposition APIs; no auth, runtime, or data-path changes.
> 
> **Overview**
> Adds **`TNLean/Algebra/StarSubalgebraIsotypicDecomp.lean`** and wires it into the public import surface and Chapter 7 blueprint, continuing the Wolf Theorem 6.14 spatial-realization chain after irreducible decomposition and the same-type relation.
> 
> **`StarSubalgebra.isOrtho_sSup_of_not_sameIsotype`** lifts pairwise cross-type orthogonality to **`sSup D₁ ⟂ sSup D₂`** when no irreducible piece in one finite family is `SameIsotype` with any piece in the other, using Mathlib’s `Submodule.isOrtho_sSup_left` / `right` and the existing `isOrtho_of_not_sameIsotype`.
> 
> **`StarSubalgebra.exists_orthogonal_isotypic_decomposition`** starts from `exists_orthogonal_irreducible_decomposition`, partitions irreducible pieces into same-type classes, takes each class’s supremum as an isotypic component, and proves a finite pairwise-orthogonal family with **`sSup C = ⊤`**, each component witnessed as the supremum of a finite nonempty class of irreducible pieces that are pairwise `SameIsotype`.
> 
> **`blueprint/src/chapter/ch07_spectral.tex`** gains `\leanok` lemma and theorem entries linked to these names, with `\uses` pointing at the irreducible decomposition and same-type lemmas used in the proof.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7bbd8f0b492bc4570c6cb9cac8ebfa4434ee81c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->