### PR TITLE
doc(Analysis): blueprint entry for Matrix.diagonal_lieb_integral

### DIFF
--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -533,10 +533,27 @@ of $A^s B^{1-s}$.
     \]
 \end{proof}
 
+\begin{lemma}[Diagonal Lieb integral identity]\label{lem:diagonal_lieb_integral}
+    \lean{Matrix.diagonal_lieb_integral}
+    \leanok
+    \uses{lem:scalar_lieb_integral}
+    For positive diagonal matrices $M$ and $N$ and $s\in(0,1)$,
+    \[
+        M^s N^{1-s}
+        = \frac{\sin(\pi s)}{\pi}\int_0^\infty t^{s-1}\,M\,(M+tN)^{-1}\,N\,dt.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:scalar_lieb_integral}
+    Both sides are diagonal, so the identity holds entry by entry; on each
+    diagonal entry it is the scalar Lieb integral identity
+    (Lemma~\ref{lem:scalar_lieb_integral}).
+\end{proof}
+
 \begin{lemma}[Operator integral representation]\label{lem:op_lieb_integral_rep}
     \lean{superop_lieb_integral_rep}
     \leanok
-    \uses{lem:scalar_lieb_integral}
+    \uses{lem:diagonal_lieb_integral}
     For positive-definite matrices $A$, $B$ and $s\in(0,1)$,
     \[
         (A\otimes I)^s\,(I\otimes B^\top)^{1-s}
@@ -551,8 +568,9 @@ of $A^s B^{1-s}$.
 \begin{proof}\leanok
     The pair $(A\otimes I,\,I\otimes B^\top)$ is simultaneously diagonalized by
     $V = U_A\otimes U_{B^\top}$ (eigenbases of $A$ and $B^\top$).
-    In that basis both sides are diagonal, and the identity holds entrywise by
-    Lemma~\ref{lem:scalar_lieb_integral}.
+    In that basis the pair becomes a commuting pair of positive diagonal
+    matrices, and the identity follows from the diagonal case
+    (Lemma~\ref{lem:diagonal_lieb_integral}).
 \end{proof}
 
 \begin{lemma}[Concavity of the parallel sum]\label{lem:parallel_sum_concave}


### PR DESCRIPTION
Closes #3581. Follow-up to #3578. The operator integral representation `lem:op_lieb_integral_rep` previously `\uses`d `lem:scalar_lieb_integral` directly, skipping the intermediate `Matrix.diagonal_lieb_integral` that the Lean proof actually goes through. This:

1. Inserts `lem:diagonal_lieb_integral` → `\lean{Matrix.diagonal_lieb_integral}` (`\uses{lem:scalar_lieb_integral}`) between the scalar and operator lemmas;
2. Redirects `lem:op_lieb_integral_rep`'s `\uses` to the diagonal lemma and updates its proof prose to reference the diagonal case.

The proof graph now reflects the real scalar → diagonal → operator dependency chain (so `checkdecls` tracks `Matrix.diagonal_lieb_integral`). Statement/proof mirror the Lean (`LiebOperatorIntegral.lean:260`: positive diagonal $M,N$; $s\in(0,1)$; entrywise scalar identity). Blueprint-only; prose check passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to blueprint LaTeX; no changes to Lean proofs or application logic.
> 
> **Overview**
> Aligns the Lieb integral section of **ch18_operator_convexity** with the Lean proof chain by documenting the missing diagonal step.
> 
> A new **`lem:diagonal_lieb_integral`** (`\lean{Matrix.diagonal_lieb_integral}`) is inserted between the scalar and operator lemmas, stating the integral identity for positive diagonal \(M,N\) and depending on **`lem:scalar_lieb_integral`** entrywise. **`lem:op_lieb_integral_rep`** now `\uses` the diagonal lemma instead of the scalar one directly, and its proof text cites simultaneous diagonalization plus the diagonal case rather than invoking the scalar identity on each entry.
> 
> Blueprint-only; no Lean or runtime behavior changes—**`checkdecls`** can track **`Matrix.diagonal_lieb_integral`** in the dependency graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7d0c3578316c829677fda7afe8597769fac71b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->