### PR TITLE
feat(Axioms): eliminate lieb_concavity_axiom via the operator integral representation

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -50,6 +50,7 @@ import TNLean.Analysis.ProjectionGeometry
 -- Layer 0b: Trace of the Hermitian functional calculus (Mathlib-only matrix lemma)
 import TNLean.Analysis.TraceCFC
 import TNLean.Analysis.CfcLogAdditive
+import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.MatrixTraceInequalities
 import TNLean.Analysis.KyFanNorm
 import TNLean.Analysis.ConvexHullCompact

--- a/TNLean/Analysis/CfcKronecker.lean
+++ b/TNLean/Analysis/CfcKronecker.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sirui Lu
+-/
+import Mathlib.LinearAlgebra.Matrix.Kronecker
+import Mathlib.Analysis.Matrix.Order
+
+/-!
+# Continuous functional calculus through the unital tensor embeddings
+
+The unital tensor embeddings $A \mapsto A \otimes \mathbf 1$ and
+$B \mapsto \mathbf 1 \otimes B$ are continuous star-algebra homomorphisms of the
+finite-dimensional matrix algebra. Because the continuous functional calculus
+commutes with continuous star-algebra homomorphisms (`StarAlgHomClass.map_cfc`),
+applying a real function $f$ through either embedding agrees with applying it to
+the embedded factor:
+$$f(A \otimes \mathbf 1) = f(A) \otimes \mathbf 1, \qquad
+  f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B).$$
+
+These are pure matrix facts about the functional calculus on Kronecker products.
+They are gathered here, at the foundational analysis layer, so that the relative
+entropy stack and the operator convexity boundary can both use them without
+either depending on the other.
+
+## Main results
+
+* `Matrix.cfc_kronecker_one` — the continuous functional calculus through the
+  unital left tensor embedding: $f(A \otimes \mathbf 1) = f(A) \otimes \mathbf 1$.
+* `Matrix.cfc_one_kronecker` — the right embedding version:
+  $f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B)$.
+-/
+
+open scoped Kronecker
+
+namespace Matrix
+
+variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
+
+/-- The unital left tensor embedding $A \mapsto A \otimes \mathbf 1$ as a star
+algebra homomorphism of complex matrix algebras. -/
+noncomputable def leftKroneckerEmbed :
+    Matrix m m ℂ →⋆ₐ[ℂ] Matrix (m × n) (m × n) ℂ where
+  toFun A := A ⊗ₖ (1 : Matrix n n ℂ)
+  map_one' := one_kronecker_one
+  map_mul' A B := by rw [← mul_kronecker_mul, mul_one]
+  map_zero' := zero_kronecker _
+  map_add' A B := add_kronecker A B _
+  commutes' r := by
+    rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one,
+      smul_kronecker, one_kronecker_one]
+  map_star' A := by
+    rw [star_eq_conjTranspose, star_eq_conjTranspose, conjTranspose_kronecker,
+      conjTranspose_one]
+
+@[simp] theorem leftKroneckerEmbed_apply (A : Matrix m m ℂ) :
+    leftKroneckerEmbed (n := n) A = A ⊗ₖ (1 : Matrix n n ℂ) := rfl
+
+/-- The unital right tensor embedding $B \mapsto \mathbf 1 \otimes B$ as a star
+algebra homomorphism of complex matrix algebras. -/
+noncomputable def rightKroneckerEmbed :
+    Matrix n n ℂ →⋆ₐ[ℂ] Matrix (m × n) (m × n) ℂ where
+  toFun B := (1 : Matrix m m ℂ) ⊗ₖ B
+  map_one' := one_kronecker_one
+  map_mul' A B := by rw [← mul_kronecker_mul, mul_one]
+  map_zero' := kronecker_zero _
+  map_add' A B := kronecker_add _ A B
+  commutes' r := by
+    rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one,
+      kronecker_smul, one_kronecker_one]
+  map_star' B := by
+    rw [star_eq_conjTranspose, star_eq_conjTranspose, conjTranspose_kronecker,
+      conjTranspose_one]
+
+@[simp] theorem rightKroneckerEmbed_apply (B : Matrix n n ℂ) :
+    rightKroneckerEmbed (m := m) B = (1 : Matrix m m ℂ) ⊗ₖ B := rfl
+
+/-- **Functional calculus through the left tensor embedding.** For a Hermitian
+matrix $A$ and a real function $f$,
+$f(A \otimes \mathbf 1) = f(A) \otimes \mathbf 1$. This is the instance of
+`StarAlgHomClass.map_cfc` at the unital embedding `leftKroneckerEmbed`. -/
+theorem cfc_kronecker_one {A : Matrix m m ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ) :
+    cfc f (A ⊗ₖ (1 : Matrix n n ℂ)) = (cfc f A) ⊗ₖ (1 : Matrix n n ℂ) := by
+  have hcont : ContinuousOn f (spectrum ℝ A) := A.finite_real_spectrum.continuousOn f
+  have hcontφ : Continuous (leftKroneckerEmbed (m := m) (n := n)) :=
+    LinearMap.continuous_of_finiteDimensional
+      ((leftKroneckerEmbed (m := m) (n := n) :
+        Matrix m m ℂ →ₗ[ℂ] Matrix (m × n) (m × n) ℂ))
+  have hsa : IsSelfAdjoint A := hA
+  have hsa' : IsSelfAdjoint (leftKroneckerEmbed (n := n) A) := by
+    rw [leftKroneckerEmbed_apply, IsSelfAdjoint, star_eq_conjTranspose,
+      conjTranspose_kronecker, hA.eq, conjTranspose_one]
+  simpa [leftKroneckerEmbed_apply] using
+    (StarAlgHomClass.map_cfc (leftKroneckerEmbed (m := m) (n := n)) f A
+      hcont hcontφ hsa hsa').symm
+
+/-- **Functional calculus through the right tensor embedding.** For a Hermitian
+matrix $B$ and a real function $f$,
+$f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B)$. This is the instance of
+`StarAlgHomClass.map_cfc` at the unital embedding `rightKroneckerEmbed`. -/
+theorem cfc_one_kronecker {B : Matrix n n ℂ} (hB : B.IsHermitian) (f : ℝ → ℝ) :
+    cfc f ((1 : Matrix m m ℂ) ⊗ₖ B) = (1 : Matrix m m ℂ) ⊗ₖ (cfc f B) := by
+  have hcont : ContinuousOn f (spectrum ℝ B) := B.finite_real_spectrum.continuousOn f
+  have hcontφ : Continuous (rightKroneckerEmbed (m := m) (n := n)) :=
+    LinearMap.continuous_of_finiteDimensional
+      ((rightKroneckerEmbed (m := m) (n := n) :
+        Matrix n n ℂ →ₗ[ℂ] Matrix (m × n) (m × n) ℂ))
+  have hsa : IsSelfAdjoint B := hB
+  have hsa' : IsSelfAdjoint (rightKroneckerEmbed (m := m) B) := by
+    rw [rightKroneckerEmbed_apply, IsSelfAdjoint, star_eq_conjTranspose,
+      conjTranspose_kronecker, hB.eq, conjTranspose_one]
+  simpa [rightKroneckerEmbed_apply] using
+    (StarAlgHomClass.map_cfc (rightKroneckerEmbed (m := m) (n := n)) f B
+      hcont hcontφ hsa hsa').symm
+
+end Matrix

--- a/TNLean/Analysis/CfcKronecker.lean
+++ b/TNLean/Analysis/CfcKronecker.lean
@@ -20,7 +20,7 @@ $$f(A \otimes \mathbf 1) = f(A) \otimes \mathbf 1, \qquad
 
 These are pure matrix facts about the functional calculus on Kronecker products.
 They are gathered here, at the foundational analysis layer, so that the relative
-entropy stack and the operator convexity boundary can both use them without
+entropy modules and the operator convexity boundary can both use them without
 either depending on the other.
 
 ## Main results

--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -187,7 +187,7 @@ private local instance instAxiomOCCStarRing : CStarRing Mat :=
   Matrix.instCStarRing
 private local instance instAxiomOCCStarAlgebra : CStarAlgebra Mat where
 
-/-! ## Jensen inequality axioms for positive maps -/
+/-! ## Operator Jensen inequalities for positive maps -/
 
 private lemma cfc_rpow_sub_one_eq
     {p : ℝ} {A : Mat} (hA : A.PosDef) :

--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -7,7 +7,6 @@ import TNLean.Channel.Basic
 import TNLean.Channel.Schwarz.OperatorJensenAux
 import TNLean.Analysis.LiebOperatorConcave
 import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
-import TNLean.Analysis.TraceCFC
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
@@ -676,7 +675,7 @@ private lemma lieb_kronecker_reduction (A B : Mat) (hA : A.PosDef) (hB : B.PosDe
       Matrix.cfc_one_kronecker hB.transpose.isHermitian]
   rw [hAk, hBk, ← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul]
 
-/-- The vectorization bridge: the quadratic form of `A^s ⊗ₖ (Bᵀ)^{1-s}` at the vector
+/-- The vectorization identity: the quadratic form of `A^s ⊗ₖ (Bᵀ)^{1-s}` at the vector
 `vec Kᵀ` recovers the Lieb trace functional `Tr(K† A^s K B^{1-s})`. -/
 private lemma lieb_quad_eq_trace (A B K : Mat) (hB : B.PosDef) (s : ℝ) :
     star (Matrix.vec Kᵀ) ⬝ᵥ (((A ^ s) ⊗ₖ ((Bᵀ) ^ (1 - s))) *ᵥ Matrix.vec Kᵀ)

--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -699,6 +699,12 @@ the trace functional is the quadratic form of that Kronecker product at the vect
 the positive quadratic form transfers the operator inequality to the trace.  The endpoints
 `s = 0` and `s = 1` are linear in the varying argument and hold with equality.
 
+**Scope restriction (positive-definite inputs; boundary exponent `s, 1−s`):** the
+source Ando–Lieb theorem (Wolf Thm 5.15) covers positive *semidefinite* `A, B` and
+all exponents `x, y ≥ 0` with `x + y ≤ 1`; the statement here is the
+positive-definite, boundary-line (`x + y = 1`) case. Documented in
+`docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`.
+
 References:
 * Lieb, *Convex trace functions*, Adv. Math. 11, 1973
 * Ando, *Concavity of certain maps on positive definite matrices*, 1979 -/

--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -5,21 +5,24 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.Basic
 import TNLean.Channel.Schwarz.OperatorJensenAux
+import TNLean.Analysis.LiebOperatorConcave
+import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
+import TNLean.Analysis.TraceCFC
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.ExpLog.Order
 import Mathlib.LinearAlgebra.Matrix.Trace
+import Mathlib.LinearAlgebra.Matrix.Vec
 import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 
 /-!
 # Operator convexity and concavity boundary
 
-This module collects the remaining axioms for the **operator Jensen
-inequalities** for matrix powers and logarithms under positive maps, and the
-**Lieb concavity theorem**.  It also contains the now-proved concave and convex
-real-power Jensen theorems, since downstream files already import this boundary
-module.
+This module collects the **operator Jensen inequalities** for matrix powers and
+logarithms under positive maps, together with the **Lieb concavity theorem**,
+which is now proved here.  It also contains the concave and convex real-power
+Jensen theorems, since downstream files already import this boundary module.
 
 Mathlib 4.31 proves the operator concavity inputs for `x ↦ x ^ p`,
 `0 ≤ p ≤ 1`, and for `log`, via `CFC.concaveOn_rpow` and
@@ -37,23 +40,24 @@ Jensen inequality is then obtained as the right limit of
 proved analogously, by integrating the reversed pointwise positive-map
 inequality for the convex Löwner integrand `g p t` over the interior interval
 `(1, 2)` and passing to the endpoint `p = 2` by continuity of the matrix power
-`q ↦ M ^ q` in the exponent.  Only the Lieb statement remains an axiom, because
-the joint-concavity integral representation is not yet formalized.
-Operator convexity of `x ↦ x ^ p` for `1 ≤ p ≤ 2`, the scalar input of the
-convex case, is available as `CFC.convexOn_rpow` in
+`q ↦ M ^ q` in the exponent.  Lieb's joint concavity theorem is proved below by
+pairing the Loewner concavity of the commuting-Kronecker fractional product
+`(A ⊗ₖ 1)^s (1 ⊗ₖ Bᵀ)^{1-s}` (the operator integral representation in
+`TNLean.Analysis.LiebOperatorConcave`) with the vectorization isometry, which
+turns the trace functional `Tr(K† A^s K B^{1-s})` into a quadratic form of the
+Kronecker product.  Operator convexity of `x ↦ x ^ p` for `1 ≤ p ≤ 2`, the
+scalar input of the convex case, is available as `CFC.convexOn_rpow` in
 `TNLean.Analysis.RpowConvexity`.
 
-## Axioms
+## Main results
 
-The following results are standard in matrix analysis:
+The following results are standard in matrix analysis and are all proved here:
 
-* `posMap_rpow_concave_jensen` — Jensen inequality for concave `rpow`,
-  now a theorem.
-* `posMap_rpow_convex_jensen` — Jensen inequality for convex `rpow`,
-  now a theorem.
-* `posMap_log_concave_jensen` — Jensen inequality for concave `log`,
-  now a theorem.
-* `lieb_concavity_axiom` — Lieb concavity theorem.
+* `posMap_rpow_concave_jensen` — Jensen inequality for concave `rpow`.
+* `posMap_rpow_convex_jensen` — Jensen inequality for convex `rpow`.
+* `posMap_log_concave_jensen` — Jensen inequality for concave `log`.
+* `lieb_concavity_axiom` — Lieb concavity theorem (joint concavity of
+  `(A, B) ↦ Re Tr(K† A^s K B^{1-s})`).
 
 The trace concavity/convexity statements for `A ↦ Re Tr(A^p)` that used to
 live here (`trace_rpow_concave_axiom`, `trace_rpow_convex_axiom`) have been
@@ -62,11 +66,12 @@ via the spectral theorem and the scalar Jensen inequality.
 
 ## Status
 
-The concave real-power, convex real-power, and logarithmic declarations are now
-proved.  Only Lieb's joint concavity theorem remains an axiom.  Mathlib 4.31
-supplies the C-star functional-calculus concavity inputs and the Löwner integral
-representation for both power cases.  Earlier status notes recorded the integral
-representation as missing; that is no longer accurate.
+All four declarations are now proved.  Mathlib 4.31 supplies the C-star
+functional-calculus concavity inputs and the Löwner integral representation for
+both power cases, and `TNLean.Analysis.LiebOperatorConcave` supplies the
+operator integral representation underlying Lieb concavity.  Earlier status
+notes recorded these integral representations as missing; that is no longer
+accurate.
 
 The remaining Mathlib or local formalization gaps are:
 
@@ -99,7 +104,10 @@ The remaining Mathlib or local formalization gaps are:
   `TNLean.Analysis.RpowConvexity`; the convex case is now proved directly from
   the reversed Löwner integrand inequality
   `TNLean.OperatorJensen.positiveMap_rpowIntegrand₁₂_jensen`.
-* Lieb concavity integral representation: absent from Mathlib.
+* Lieb concavity integral representation: absent from Mathlib, but formalized
+  locally as `Matrix.superop_lieb_concave` in
+  `TNLean.Analysis.LiebOperatorConcave`, from which `lieb_concavity_axiom` below
+  is derived by the vectorization argument.
 
 ## Proof plan
 
@@ -134,11 +142,16 @@ The remaining Mathlib or local formalization gaps are:
 3. **Concave Jensen for `log`**: derive it from the right-limit formula
    `CFC.tendsto_cfc_rpow_sub_one_log` and the concave real-power theorem,
    using unitality to rewrite `T(1)=1`.
-4. **Lieb concavity**: requires the integral representation
-   `A^s B^{1-s} = (sin πs/π) ∫₀^∞ t^{s-1} A(A+tB)⁻¹ B dt` and
-   resolvent monotonicity.
-
-Lieb concavity remains a separate integral representation problem.
+4. **Lieb concavity**: pair the Loewner concavity of the commuting-Kronecker
+   fractional product `M(A, B) = (A ⊗ₖ 1)^s (1 ⊗ₖ Bᵀ)^{1-s}`
+   (`Matrix.superop_lieb_concave`, itself proved from the operator integral
+   representation `A^s B^{1-s} = (sin πs/π) ∫₀^∞ t^{s-1} A(A+tB)⁻¹ B dt` and
+   resolvent monotonicity) with the vectorization isometry `vec`.  Writing
+   `M(A, B) = A^s ⊗ₖ (Bᵀ)^{1-s}`, the trace functional
+   `Tr(K† A^s K B^{1-s})` equals the quadratic form `⟨vec Kᵀ, M(A, B) vec Kᵀ⟩`,
+   so applying that positive quadratic form to the Loewner inequality transfers
+   the concavity to the trace.  The endpoints `s = 0` and `s = 1` are linear in
+   the varying argument, hence equalities.
 
 ## References
 
@@ -590,21 +603,107 @@ theorem posMap_log_concave_jensen
     simpa [G] using hlimTA
   exact le_of_tendsto_of_tendsto hlimF hlimG hle
 
-/-! ## Lieb concavity axiom -/
+/-! ## Lieb concavity theorem -/
+
+section Lieb
+
+open scoped Kronecker
+
+/-- Entrywise complex conjugation of square matrices as an `ℝ`-`⋆`-algebra hom. -/
+private def conjMatStarAlgHom : Mat →⋆ₐ[ℝ] Mat :=
+  { (RCLike.conjAe (K := ℂ)).mapMatrix.toAlgHom with
+    map_star' := fun M => by
+      change ((star M).map (RCLike.conjAe (K := ℂ))) = star (M.map (RCLike.conjAe (K := ℂ)))
+      ext i j
+      simp [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_apply, Matrix.map_apply,
+        RCLike.conjAe_coe] }
+
+private lemma conjMatStarAlgHom_apply (M : Mat) :
+    conjMatStarAlgHom M = M.map (starRingEnd ℂ) := rfl
+
+private lemma conjMatStarAlgHom_continuous : Continuous (conjMatStarAlgHom (D := D)) :=
+  conjMatStarAlgHom.toLinearMap.continuous_of_finiteDimensional
+
+/-- For Hermitian `A`, the transpose equals entrywise complex conjugation. -/
+private lemma transpose_eq_map_conj {A : Mat} (hA : A.IsHermitian) :
+    Aᵀ = A.map (starRingEnd ℂ) := by
+  have h1 : Aᵀ = (Aᴴ).map star := by
+    rw [Matrix.conjTranspose, Matrix.map_map]; simp [Function.comp_def]
+  rw [h1, hA.eq]; rfl
+
+/-- The continuous functional calculus commutes with transpose on a Hermitian matrix:
+`(cfc f A)ᵀ = cfc f Aᵀ`, since the transpose of a Hermitian matrix is its entrywise
+conjugate, and entrywise conjugation is an `ℝ`-`⋆`-algebra hom commuting with the calculus. -/
+private lemma cfc_transpose {A : Mat} (hA : A.IsHermitian) (f : ℝ → ℝ)
+    (hf : ContinuousOn f (spectrum ℝ A)) :
+    (cfc f A)ᵀ = cfc f (Aᵀ) := by
+  have hsa : IsSelfAdjoint A := hA
+  have hcfc : (cfc f A).IsHermitian :=
+    Matrix.isHermitian_iff_isSelfAdjoint.mpr (cfc_predicate f A)
+  rw [transpose_eq_map_conj hcfc, transpose_eq_map_conj hA,
+    ← conjMatStarAlgHom_apply, ← conjMatStarAlgHom_apply]
+  exact StarAlgHomClass.map_cfc conjMatStarAlgHom f A hf conjMatStarAlgHom_continuous hsa
+    (hsa.map conjMatStarAlgHom)
+
+/-- The real power of a positive-definite matrix commutes with transpose:
+`(Bᵀ) ^ r = (B ^ r)ᵀ`. -/
+private lemma rpow_transpose (B : Mat) (hB : B.PosDef) (r : ℝ) : (Bᵀ) ^ r = (B ^ r)ᵀ := by
+  have h0B : (0 : Mat) ≤ B := hB.posSemidef.nonneg
+  have h0BT : (0 : Mat) ≤ Bᵀ := hB.transpose.posSemidef.nonneg
+  rw [CFC.rpow_eq_cfc_real h0BT, CFC.rpow_eq_cfc_real h0B]
+  refine (cfc_transpose hB.isHermitian (fun x : ℝ => x ^ r) ?_).symm
+  apply ContinuousOn.rpow_const continuousOn_id
+  intro x hx
+  left
+  rw [hB.isHermitian.spectrum_real_eq_range_eigenvalues] at hx
+  obtain ⟨i, rfl⟩ := hx
+  exact (hB.eigenvalues_pos i).ne'
+
+/-- The reduction `(A ⊗ₖ 1)^s (1 ⊗ₖ Bᵀ)^{1-s} = A^s ⊗ₖ (Bᵀ)^{1-s}`, obtained by pushing the
+continuous functional calculus through each unital tensor embedding. -/
+private lemma lieb_kronecker_reduction (A B : Mat) (hA : A.PosDef) (hB : B.PosDef) (s : ℝ) :
+    (A ⊗ₖ (1 : Mat)) ^ s * ((1 : Mat) ⊗ₖ Bᵀ) ^ (1 - s)
+      = (A ^ s) ⊗ₖ ((Bᵀ) ^ (1 - s)) := by
+  have hAk : (A ⊗ₖ (1 : Mat)) ^ s = (A ^ s) ⊗ₖ (1 : Mat) := by
+    rw [CFC.rpow_eq_cfc_real (a := A ⊗ₖ (1 : Mat))
+        (hA.kronecker Matrix.PosDef.one).posSemidef.nonneg,
+      CFC.rpow_eq_cfc_real (a := A) hA.posSemidef.nonneg,
+      Matrix.cfc_kronecker_one hA.isHermitian]
+  have hBk : ((1 : Mat) ⊗ₖ Bᵀ) ^ (1 - s) = (1 : Mat) ⊗ₖ ((Bᵀ) ^ (1 - s)) := by
+    rw [CFC.rpow_eq_cfc_real (a := (1 : Mat) ⊗ₖ Bᵀ)
+        (Matrix.PosDef.one.kronecker hB.transpose).posSemidef.nonneg,
+      CFC.rpow_eq_cfc_real (a := Bᵀ) hB.transpose.posSemidef.nonneg,
+      Matrix.cfc_one_kronecker hB.transpose.isHermitian]
+  rw [hAk, hBk, ← Matrix.mul_kronecker_mul, Matrix.mul_one, Matrix.one_mul]
+
+/-- The vectorization bridge: the quadratic form of `A^s ⊗ₖ (Bᵀ)^{1-s}` at the vector
+`vec Kᵀ` recovers the Lieb trace functional `Tr(K† A^s K B^{1-s})`. -/
+private lemma lieb_quad_eq_trace (A B K : Mat) (hB : B.PosDef) (s : ℝ) :
+    star (Matrix.vec Kᵀ) ⬝ᵥ (((A ^ s) ⊗ₖ ((Bᵀ) ^ (1 - s))) *ᵥ Matrix.vec Kᵀ)
+      = (Kᴴ * A ^ s * K * B ^ (1 - s)).trace := by
+  rw [Matrix.kronecker_mulVec_vec ((Bᵀ) ^ (1 - s)) Kᵀ (A ^ s),
+    Matrix.star_vec_dotProduct_vec, ← Matrix.mul_assoc, ← Matrix.mul_assoc,
+    rpow_transpose B hB (1 - s), Matrix.transpose_conjTranspose K,
+    ← Matrix.trace_transpose (Kᴴ * A ^ s * K * B ^ (1 - s))]
+  simp only [Matrix.transpose_mul, Matrix.conjTranspose_transpose, Matrix.mul_assoc]
+  rw [Matrix.trace_mul_comm (K.map star)]
+  simp only [Matrix.mul_assoc]
 
 /-- **Lieb concavity theorem** (Lieb 1973, Ando 1979).
 
-For `s ∈ [0, 1]`, any matrix `K`, and PD matrices `A₁, A₂, B₁, B₂`:
-  the map `(A, B) ↦ Tr(K† A^s K B^{1−s})` is jointly concave.
+For `s ∈ [0, 1]`, any matrix `K`, and positive-definite matrices `A₁, A₂, B₁, B₂`, the map
+`(A, B) ↦ Re Tr(K† A^s K B^{1−s})` is jointly concave.
 
-Requires the integral representation
-`A^s B^{1-s} = (sin πs / π) ∫₀^∞ t^{s-1} A(A + tB)⁻¹ B dt`
-and resolvent monotonicity, which are not yet in Mathlib.
+The interior case `s ∈ (0, 1)` follows from the Loewner concavity of the commuting-Kronecker
+fractional product `Matrix.superop_lieb_concave`: writing the product as `A^s ⊗ₖ (Bᵀ)^{1-s}`,
+the trace functional is the quadratic form of that Kronecker product at the vector `vec Kᵀ`, so
+the positive quadratic form transfers the operator inequality to the trace.  The endpoints
+`s = 0` and `s = 1` are linear in the varying argument and hold with equality.
 
 References:
 * Lieb, *Convex trace functions*, Adv. Math. 11, 1973
 * Ando, *Concavity of certain maps on positive definite matrices*, 1979 -/
-axiom lieb_concavity_axiom
+theorem lieb_concavity_axiom
     {s : ℝ} (hs : s ∈ Set.Icc (0 : ℝ) 1)
     {A₁ A₂ B₁ B₂ K : Mat}
     (hA₁ : A₁.PosDef) (hA₂ : A₂.PosDef)
@@ -613,6 +712,74 @@ axiom lieb_concavity_axiom
     t * (trace (Kᴴ * A₁ ^ s * K * B₁ ^ (1 - s))).re +
       (1 - t) * (trace (Kᴴ * A₂ ^ s * K * B₂ ^ (1 - s))).re ≤
     (trace (Kᴴ * (t • A₁ + (1 - t) • A₂) ^ s * K *
-      (t • B₁ + (1 - t) • B₂) ^ (1 - s))).re
+      (t • B₁ + (1 - t) • B₂) ^ (1 - s))).re := by
+  classical
+  obtain ⟨ht0, ht1⟩ := ht
+  have ht1' : (0 : ℝ) ≤ 1 - t := by linarith
+  have hsum : t + (1 - t) = 1 := by ring
+  set Aθ := t • A₁ + (1 - t) • A₂ with hAθ
+  set Bθ := t • B₁ + (1 - t) • B₂ with hBθ
+  have hAθpd : Aθ.PosDef := Matrix.PosDef.convex_comb ht0 ht1' hsum hA₁ hA₂
+  have hBθpd : Bθ.PosDef := Matrix.PosDef.convex_comb ht0 ht1' hsum hB₁ hB₂
+  rcases lt_or_eq_of_le hs.1 with hs0 | hs0
+  · rcases lt_or_eq_of_le hs.2 with hs1 | hs1
+    · -- Interior case `s ∈ (0, 1)`.
+      have hsIoo : s ∈ Set.Ioo (0 : ℝ) 1 := ⟨hs0, hs1⟩
+      have hconc := superop_lieb_concave (D := D) hsIoo hA₁ hA₂ hB₁ hB₂ (θ := t) ⟨ht0, ht1⟩
+      rw [Matrix.le_iff] at hconc
+      have hquad := hconc.dotProduct_mulVec_nonneg (Matrix.vec Kᵀ)
+      set w := Matrix.vec Kᵀ with hw
+      set N₁ := (A₁ ⊗ₖ (1 : Mat)) ^ s * ((1 : Mat) ⊗ₖ B₁ᵀ) ^ (1 - s) with hN₁
+      set N₂ := (A₂ ⊗ₖ (1 : Mat)) ^ s * ((1 : Mat) ⊗ₖ B₂ᵀ) ^ (1 - s) with hN₂
+      set Nθ := (Aθ ⊗ₖ (1 : Mat)) ^ s * ((1 : Mat) ⊗ₖ Bθᵀ) ^ (1 - s) with hNθ
+      have hexp : star w ⬝ᵥ ((Nθ - (t • N₁ + (1 - t) • N₂)) *ᵥ w)
+          = (star w ⬝ᵥ (Nθ *ᵥ w))
+            - ((t : ℂ) * (star w ⬝ᵥ (N₁ *ᵥ w))
+              + ((1 : ℂ) - t) * (star w ⬝ᵥ (N₂ *ᵥ w))) := by
+        rw [Matrix.sub_mulVec, Matrix.add_mulVec, Matrix.smul_mulVec, Matrix.smul_mulVec,
+          dotProduct_sub, dotProduct_add, dotProduct_smul, dotProduct_smul,
+          Complex.real_smul, Complex.real_smul]
+        push_cast
+        ring
+      rw [hexp] at hquad
+      have hq₁ : star w ⬝ᵥ (N₁ *ᵥ w) = (Kᴴ * A₁ ^ s * K * B₁ ^ (1 - s)).trace := by
+        rw [hw, hN₁, lieb_kronecker_reduction A₁ B₁ hA₁ hB₁ s, lieb_quad_eq_trace A₁ B₁ K hB₁ s]
+      have hq₂ : star w ⬝ᵥ (N₂ *ᵥ w) = (Kᴴ * A₂ ^ s * K * B₂ ^ (1 - s)).trace := by
+        rw [hw, hN₂, lieb_kronecker_reduction A₂ B₂ hA₂ hB₂ s, lieb_quad_eq_trace A₂ B₂ K hB₂ s]
+      have hqθ : star w ⬝ᵥ (Nθ *ᵥ w) = (Kᴴ * Aθ ^ s * K * Bθ ^ (1 - s)).trace := by
+        rw [hw, hNθ, lieb_kronecker_reduction Aθ Bθ hAθpd hBθpd s,
+          lieb_quad_eq_trace Aθ Bθ K hBθpd s]
+      rw [hq₁, hq₂, hqθ] at hquad
+      have hre := (Complex.le_def.mp hquad).1
+      simp only [Complex.zero_re, Complex.sub_re, Complex.add_re, Complex.mul_re,
+        Complex.ofReal_re, Complex.ofReal_im, Complex.sub_im, Complex.one_re, Complex.one_im,
+        zero_mul, sub_zero] at hre
+      linarith [hre]
+    · -- Endpoint `s = 1`.
+      subst hs1
+      simp only [CFC.rpow_one _ hA₁.posSemidef.nonneg, CFC.rpow_one _ hA₂.posSemidef.nonneg,
+        CFC.rpow_one _ hAθpd.posSemidef.nonneg, sub_self, CFC.rpow_zero _ hB₁.posSemidef.nonneg,
+        CFC.rpow_zero _ hB₂.posSemidef.nonneg, CFC.rpow_zero _ hBθpd.posSemidef.nonneg,
+        Matrix.mul_one]
+      have hlin : Kᴴ * Aθ * K = t • (Kᴴ * A₁ * K) + (1 - t) • (Kᴴ * A₂ * K) := by
+        rw [hAθ]; simp only [Matrix.mul_add, Matrix.add_mul, Matrix.mul_smul, Matrix.smul_mul]
+      rw [hlin, Matrix.trace_add, Matrix.trace_smul, Matrix.trace_smul,
+        Complex.add_re, Complex.real_smul, Complex.real_smul, Complex.mul_re, Complex.mul_re,
+        Complex.ofReal_re, Complex.ofReal_im, zero_mul, sub_zero, Complex.ofReal_re,
+        Complex.ofReal_im, zero_mul, sub_zero]
+  · -- Endpoint `s = 0`.
+    subst hs0
+    simp only [CFC.rpow_zero _ hA₁.posSemidef.nonneg, CFC.rpow_zero _ hA₂.posSemidef.nonneg,
+      CFC.rpow_zero _ hAθpd.posSemidef.nonneg, sub_zero, CFC.rpow_one _ hB₁.posSemidef.nonneg,
+      CFC.rpow_one _ hB₂.posSemidef.nonneg, CFC.rpow_one _ hBθpd.posSemidef.nonneg,
+      Matrix.mul_one]
+    have hlin : Kᴴ * K * Bθ = t • (Kᴴ * K * B₁) + (1 - t) • (Kᴴ * K * B₂) := by
+      rw [hBθ]; simp only [Matrix.mul_add, Matrix.mul_smul]
+    rw [hlin, Matrix.trace_add, Matrix.trace_smul, Matrix.trace_smul,
+      Complex.add_re, Complex.real_smul, Complex.real_smul, Complex.mul_re, Complex.mul_re,
+      Complex.ofReal_re, Complex.ofReal_im, zero_mul, sub_zero, Complex.ofReal_re,
+      Complex.ofReal_im, zero_mul, sub_zero]
+
+end Lieb
 
 end

--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -6,7 +6,7 @@ import TNLean.Algebra.HermitianHelpers
 import TNLean.Channel.Basic
 import TNLean.Channel.Schwarz.OperatorJensenAux
 import TNLean.Analysis.LiebOperatorConcave
-import TNLean.Channel.Schwarz.RelativeEntropyAncillaAdditivity
+import TNLean.Analysis.CfcKronecker
 import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Order
@@ -143,9 +143,16 @@ The remaining Mathlib or local formalization gaps are:
    using unitality to rewrite `T(1)=1`.
 4. **Lieb concavity**: pair the Loewner concavity of the commuting-Kronecker
    fractional product `M(A, B) = (A ⊗ₖ 1)^s (1 ⊗ₖ Bᵀ)^{1-s}`
-   (`Matrix.superop_lieb_concave`, itself proved from the operator integral
-   representation `A^s B^{1-s} = (sin πs/π) ∫₀^∞ t^{s-1} A(A+tB)⁻¹ B dt` and
-   resolvent monotonicity) with the vectorization isometry `vec`.  Writing
+   (`Matrix.superop_lieb_concave`, itself proved from the integral
+   representation of the commuting left/right multiplication superoperators
+   `L_A^s R_B^{1-s} = (sin πs/π) ∫₀^∞ t^{s-1} L_A (L_A + t R_B)⁻¹ R_B dt`,
+   where `L_A : X ↦ A X` and `R_B : X ↦ X B` are realized on the Kronecker
+   model as `A ⊗ₖ 1` and `1 ⊗ₖ Bᵀ`, and resolvent monotonicity of
+   `(L_A + t R_B)⁻¹`).  The matrix-product identity
+   `A^s B^{1-s} = (sin πs/π) ∫₀^∞ t^{s-1} A (A + t B)⁻¹ B dt` holds only when
+   `A` and `B` commute, so it is the commuting superoperators `L_A`, `R_B` —
+   not the matrices `A`, `B` — that carry the representation.  Pair this with
+   the vectorization isometry `vec`.  Writing
    `M(A, B) = A^s ⊗ₖ (Bᵀ)^{1-s}`, the trace functional
    `Tr(K† A^s K B^{1-s})` equals the quadratic form `⟨vec Kᵀ, M(A, B) vec Kᵀ⟩`,
    so applying that positive quadratic form to the Loewner inequality transfers

--- a/TNLean/Channel/Schwarz/RelativeEntropyAncillaAdditivity.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyAncillaAdditivity.lean
@@ -5,6 +5,7 @@ Authors: Sirui Lu
 -/
 import Mathlib.LinearAlgebra.Matrix.Kronecker
 import Mathlib.Analysis.Matrix.Order
+import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.CfcLogAdditive
 import TNLean.Analysis.Entropy
 
@@ -25,15 +26,17 @@ convexity (layer 4, `convexOn_quantumRelativeEntropy`) and unitary invariance
 
 ## Main results
 
-* `Matrix.cfc_kronecker_one` — the continuous functional calculus through the
-  unital left tensor embedding: $f(A \otimes \mathbf 1) = f(A) \otimes \mathbf 1$.
-* `Matrix.cfc_one_kronecker` — the right embedding version:
-  $f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B)$.
 * `Matrix.log_kronecker` — the tensor-product logarithm split for positive
   definite factors:
   $\log(\rho \otimes \tau) = \log\rho \otimes \mathbf 1 + \mathbf 1 \otimes \log\tau$.
 * `quantumRelativeEntropy_kronecker` — ancilla additivity:
   $D(\rho \otimes \tau \,\|\, \sigma \otimes \tau) = D(\rho\|\sigma)$.
+
+The functional-calculus facts through the unital tensor embeddings,
+$f(A \otimes \mathbf 1) = f(A) \otimes \mathbf 1$ and
+$f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B)$
+(`Matrix.cfc_kronecker_one`, `Matrix.cfc_one_kronecker`), are the pure matrix
+inputs to the logarithm split; they live in `TNLean.Analysis.CfcKronecker`.
 
 ## Proof outline
 
@@ -69,82 +72,6 @@ open scoped Kronecker Matrix.Norms.L2Operator MatrixOrder ComplexOrder
 namespace Matrix
 
 variable {m n : Type*} [Fintype m] [DecidableEq m] [Fintype n] [DecidableEq n]
-
-/-- The unital left tensor embedding $A \mapsto A \otimes \mathbf 1$ as a star
-algebra homomorphism of complex matrix algebras. -/
-noncomputable def leftKroneckerEmbed :
-    Matrix m m ℂ →⋆ₐ[ℂ] Matrix (m × n) (m × n) ℂ where
-  toFun A := A ⊗ₖ (1 : Matrix n n ℂ)
-  map_one' := one_kronecker_one
-  map_mul' A B := by rw [← mul_kronecker_mul, mul_one]
-  map_zero' := zero_kronecker _
-  map_add' A B := add_kronecker A B _
-  commutes' r := by
-    rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one,
-      smul_kronecker, one_kronecker_one]
-  map_star' A := by
-    rw [star_eq_conjTranspose, star_eq_conjTranspose, conjTranspose_kronecker,
-      conjTranspose_one]
-
-@[simp] theorem leftKroneckerEmbed_apply (A : Matrix m m ℂ) :
-    leftKroneckerEmbed (n := n) A = A ⊗ₖ (1 : Matrix n n ℂ) := rfl
-
-/-- The unital right tensor embedding $B \mapsto \mathbf 1 \otimes B$ as a star
-algebra homomorphism of complex matrix algebras. -/
-noncomputable def rightKroneckerEmbed :
-    Matrix n n ℂ →⋆ₐ[ℂ] Matrix (m × n) (m × n) ℂ where
-  toFun B := (1 : Matrix m m ℂ) ⊗ₖ B
-  map_one' := one_kronecker_one
-  map_mul' A B := by rw [← mul_kronecker_mul, mul_one]
-  map_zero' := kronecker_zero _
-  map_add' A B := kronecker_add _ A B
-  commutes' r := by
-    rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one,
-      kronecker_smul, one_kronecker_one]
-  map_star' B := by
-    rw [star_eq_conjTranspose, star_eq_conjTranspose, conjTranspose_kronecker,
-      conjTranspose_one]
-
-@[simp] theorem rightKroneckerEmbed_apply (B : Matrix n n ℂ) :
-    rightKroneckerEmbed (m := m) B = (1 : Matrix m m ℂ) ⊗ₖ B := rfl
-
-/-- **Functional calculus through the left tensor embedding.** For a Hermitian
-matrix $A$ and a real function $f$,
-$f(A \otimes \mathbf 1) = f(A) \otimes \mathbf 1$. This is the instance of
-`StarAlgHomClass.map_cfc` at the unital embedding `leftKroneckerEmbed`. -/
-theorem cfc_kronecker_one {A : Matrix m m ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ) :
-    cfc f (A ⊗ₖ (1 : Matrix n n ℂ)) = (cfc f A) ⊗ₖ (1 : Matrix n n ℂ) := by
-  have hcont : ContinuousOn f (spectrum ℝ A) := A.finite_real_spectrum.continuousOn f
-  have hcontφ : Continuous (leftKroneckerEmbed (m := m) (n := n)) :=
-    LinearMap.continuous_of_finiteDimensional
-      ((leftKroneckerEmbed (m := m) (n := n) :
-        Matrix m m ℂ →ₗ[ℂ] Matrix (m × n) (m × n) ℂ))
-  have hsa : IsSelfAdjoint A := hA
-  have hsa' : IsSelfAdjoint (leftKroneckerEmbed (n := n) A) := by
-    rw [leftKroneckerEmbed_apply, IsSelfAdjoint, star_eq_conjTranspose,
-      conjTranspose_kronecker, hA.eq, conjTranspose_one]
-  simpa [leftKroneckerEmbed_apply] using
-    (StarAlgHomClass.map_cfc (leftKroneckerEmbed (m := m) (n := n)) f A
-      hcont hcontφ hsa hsa').symm
-
-/-- **Functional calculus through the right tensor embedding.** For a Hermitian
-matrix $B$ and a real function $f$,
-$f(\mathbf 1 \otimes B) = \mathbf 1 \otimes f(B)$. This is the instance of
-`StarAlgHomClass.map_cfc` at the unital embedding `rightKroneckerEmbed`. -/
-theorem cfc_one_kronecker {B : Matrix n n ℂ} (hB : B.IsHermitian) (f : ℝ → ℝ) :
-    cfc f ((1 : Matrix m m ℂ) ⊗ₖ B) = (1 : Matrix m m ℂ) ⊗ₖ (cfc f B) := by
-  have hcont : ContinuousOn f (spectrum ℝ B) := B.finite_real_spectrum.continuousOn f
-  have hcontφ : Continuous (rightKroneckerEmbed (m := m) (n := n)) :=
-    LinearMap.continuous_of_finiteDimensional
-      ((rightKroneckerEmbed (m := m) (n := n) :
-        Matrix n n ℂ →ₗ[ℂ] Matrix (m × n) (m × n) ℂ))
-  have hsa : IsSelfAdjoint B := hB
-  have hsa' : IsSelfAdjoint (rightKroneckerEmbed (m := m) B) := by
-    rw [rightKroneckerEmbed_apply, IsSelfAdjoint, star_eq_conjTranspose,
-      conjTranspose_kronecker, hB.eq, conjTranspose_one]
-  simpa [rightKroneckerEmbed_apply] using
-    (StarAlgHomClass.map_cfc (rightKroneckerEmbed (m := m) (n := n)) f B
-      hcont hcontφ hsa hsa').symm
 
 /-- **Logarithm of a tensor product of positive definite matrices.** For positive
 definite $\rho$ and $\tau$,

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -650,6 +650,10 @@ of $A^s B^{1-s}$.
         \Re\tr\!(K^\dagger(tA_1+(1-t)A_2)^s K (tB_1+(1-t)B_2)^{1-s}).
     \end{equation}
     See \cite{Lieb1973Convex,Ando1979Concavity}.
+    This statement is the positive-definite, boundary-exponent ($x+y=1$) case of
+    the Ando--Lieb theorem \cite[Theorem~5.15]{Wolf2012Quantum}, which holds for
+    positive semidefinite $A,B$ and all exponents $x,y\ge 0$ with $x+y\le 1$.
+    % Scope restriction recorded in docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:op_lieb_concave}

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -641,7 +641,7 @@ of $A^s B^{1-s}$.
     \leanok
     For $s\in[0,1]$, any matrix~$K$, and positive-definite matrices
     $A_1,A_2,B_1,B_2$, the map
-    $(A,B)\mapsto\tr(K^\dagger A^s K B^{1-s})$
+    $(A,B)\mapsto\Re\tr(K^\dagger A^s K B^{1-s})$
     is jointly concave:
     \begin{equation}\label{eq:opconv_lieb_joint_concavity}
         t\,\Re\tr(K^\dagger A_1^s K B_1^{1-s})
@@ -658,7 +658,12 @@ of $A^s B^{1-s}$.
     gives a Loewner-order inequality between positive-semidefinite matrices on
     the model space $\mathbb{C}^D\otimes\mathbb{C}^D$. Writing that product as
     $A^s\otimes(B^\top)^{1-s}$ and pairing it with the vectorization of $K^\top$,
-    the trace functional $\tr(K^\dagger A^s K B^{1-s})$ becomes the quadratic form
+    \[
+        \langle \operatorname{vec}K^\top,\,
+            (A^s\otimes(B^\top)^{1-s})\operatorname{vec}K^\top\rangle
+        = \Re\tr(K^\dagger A^s K B^{1-s}),
+    \]
+    expresses the trace functional as the quadratic form
     of the Kronecker product at that vector. Applying this positive quadratic form
     to the Loewner inequality transfers the concavity to the real part of the
     trace. The endpoints $s=0$ and $s=1$ reduce the varying side to a linear

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -686,7 +686,7 @@ of $A^s B^{1-s}$.
 \end{theorem}
 
 \begin{proof}\leanok
-    Direct application of the axiom.
+    Follows directly from Theorem~\ref{thm:lieb_concavity_axiom}.
 \end{proof}
 
 \begin{corollary}[Lieb concavity, $K=\Id$ case]\label{cor:lieb_concavity_id}

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -5,10 +5,12 @@ inequalities, the operator Jensen inequality for positive maps, and the
 Lieb concavity theorem. These are standard results in matrix analysis
 (\cite[Chapter~V]{Bhatia1997Matrix}; \cite[Theorems~5.12 and~5.13]{Wolf2012Quantum};
 Hansen--Pedersen's Jensen inequality~\cite{HansenPedersen1982Jensen};
-and Lieb's concavity theorem~\cite{Lieb1973Convex}). They are
-provided here as cited inputs, since the corresponding matrix-analysis proofs for
-real powers $x\mapsto x^p$ on the Loewner order and for the matrix logarithm
-are not developed elsewhere in this document.
+and Lieb's concavity theorem~\cite{Lieb1973Convex}). The operator Jensen
+inequalities for real powers $x\mapsto x^p$ on the Loewner order are obtained from
+the Loewner integral representation of the power function. Lieb's concavity theorem
+is derived from the operator integral representation of the fractional product
+together with the vectorization isometry, which turns the trace functional into a
+quadratic form of a positive-semidefinite matrix.
 
 \section{Diagonal Jensen inequality}
 
@@ -636,7 +638,7 @@ of $A^s B^{1-s}$.
 
 \begin{theorem}[Lieb concavity]\label{thm:lieb_concavity_axiom}
     \lean{lieb_concavity_axiom}
-    \notready
+    \leanok
     For $s\in[0,1]$, any matrix~$K$, and positive-definite matrices
     $A_1,A_2,B_1,B_2$, the map
     $(A,B)\mapsto\tr(K^\dagger A^s K B^{1-s})$
@@ -649,6 +651,19 @@ of $A^s B^{1-s}$.
     \end{equation}
     See \cite{Lieb1973Convex,Ando1979Concavity}.
 \end{theorem}
+\begin{proof}\leanok
+    \uses{lem:op_lieb_concave}
+    For $s\in(0,1)$, the concavity of the fractional product of the commuting
+    left and right multiplication operators (Lemma~\ref{lem:op_lieb_concave})
+    gives a Loewner-order inequality between positive-semidefinite matrices on
+    the model space $\mathbb{C}^D\otimes\mathbb{C}^D$. Writing that product as
+    $A^s\otimes(B^\top)^{1-s}$ and pairing it with the vectorization of $K^\top$,
+    the trace functional $\tr(K^\dagger A^s K B^{1-s})$ becomes the quadratic form
+    of the Kronecker product at that vector. Applying this positive quadratic form
+    to the Loewner inequality transfers the concavity to the real part of the
+    trace. The endpoints $s=0$ and $s=1$ reduce the varying side to a linear
+    function of the convex-combination argument, hence hold with equality.
+\end{proof}
 
 \begin{theorem}[Map form of Lieb concavity]\label{thm:lieb_concavity}
     \lean{lieb_concavity}

--- a/docs/PROOF_INTEGRITY.md
+++ b/docs/PROOF_INTEGRITY.md
@@ -56,7 +56,16 @@ treated as blockers.
 | `hayashi_ssa_equality_characterization_forward` | `TNLean/Axioms/Entropy.lean` | **Forward** direction of the SSA-equality characterization: SSA equality forces the quantum-Markov-chain structure on the middle subsystem (rests on recovery-map / Petz theory). The biconditional `hayashi_ssa_equality_characterization` is now a **derived theorem** (`⟨forward, reverse⟩`); the reverse direction is proved in `TNLean/Analysis/EntropyMarkovReverse.lean`, so this forward axiom is the only remaining axiomatic content. Sanctioned for issue #632 / gate #236. Citations: Hayashi, *Quantum Information: An Introduction*, Springer 2006, Theorem 5.24; Ruskai, JMP 43, 4358 (2002); equivalent structural formulation also appears in Hayden–Jozsa–Petz–Winter, CMP 246, 359–374 (2004). Consumed (via the biconditional theorem) by the theorem wrappers in `TNLean/Entropy/MarkovChain.lean`. |
 | `Axioms.rfp_to_nncph_commute` | `TNLean/Axioms/Beigi.lean` | arXiv:1606.00608 Section 3.3 Theorem 3.10 (product-of-entangled-pairs structural form from Appendix B — *not* gated on Beigi 2012); consumed by `MPSTensor.rfp_implies_nncph` in `TNLean/MPS/ParentHamiltonian/Commuting.lean`. |
 | `Axioms.beigi_nncph_to_rfp` | `TNLean/Axioms/Beigi.lean` | S. Beigi, *J. Phys. A: Math. Theor.* **45** (2012) 025306 — ground-space characterization of 1D commuting nearest-neighbor Hamiltonians with finite degeneracy; consumed by `MPSTensor.nncph_implies_rfp` in `TNLean/MPS/ParentHamiltonian/Commuting.lean` from the explicit BNT relation `MPSTensor.IsBNT` and the all-chain NNCPH ground-space condition `MPSTensor.HasNNCPHGroundSpaces` (arXiv:1606.00608 Section 3.3 Theorem 3.10, reverse direction only). |
-| Operator-convexity axioms (`posMap_rpow_convex_jensen`, `lieb_concavity_axiom`) | `TNLean/Axioms/OperatorConvexity.lean` | The concave real-power Jensen statement `posMap_rpow_concave_jensen` and the logarithmic Jensen statement `posMap_log_concave_jensen` have been discharged. The former `trace_rpow_concave_axiom` / `trace_rpow_convex_axiom` have also been discharged; see `TNLean/Analysis/OperatorConvexity.lean`. |
+
+`TNLean/Axioms/OperatorConvexity.lean` no longer declares any axioms: the operator
+Jensen inequalities for the concave real power, convex real power, and logarithm
+(`posMap_rpow_concave_jensen`, `posMap_rpow_convex_jensen`,
+`posMap_log_concave_jensen`) and Lieb's concavity theorem (`lieb_concavity_axiom`)
+are all proved there, the former three from the Loewner integral representation of
+the power function and the last from the operator integral representation of the
+fractional product together with the vectorization isometry. The former
+`trace_rpow_concave_axiom` / `trace_rpow_convex_axiom` were discharged earlier; see
+`TNLean/Analysis/OperatorConvexity.lean`.
 
 ### Circular reasoning
 

--- a/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
@@ -21,9 +21,10 @@ operator-convexity boundary\footnote{%
     The declarations are
     \leanid{posMap_rpow_concave_jensen}, \leanid{posMap_rpow_convex_jensen},
     \leanid{posMap_log_concave_jensen}, and \leanid{lieb_concavity_axiom} in
-    \doclink{TNLean/Axioms/OperatorConvexity}; the first and third are now
-    theorems, and the convex real-power Jensen and Lieb declarations remain
-    axioms.}
+    \doclink{TNLean/Axioms/OperatorConvexity}; the first, third, and fourth are
+    now theorems (the Lieb declaration in its positive-definite, boundary-exponent
+    scope, see Section~\ref{sec:lieb}), and only the convex real-power Jensen
+    declaration remains an axiom.}
 together with the cited sources, the precise gaps, and the first concrete step
 toward eliminating each remaining gap.  The positive-map Jensen declarations
 underlie \cite[Corollary~5.2]{Wolf2012Quantum} (the second corollary of Wolf's
@@ -76,7 +77,7 @@ representation\footnote{%
     \leanid{CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁}
     and its $[1,2]$ companion in
     \path{Mathlib/Analysis/SpecialFunctions/ContinuousFunctionalCalculus/Rpow/IntegralRepresentation.lean},
-    together with the Bochner-integral convexity bridge for C\textsuperscript{*}-algebras.}
+    together with the Bochner-integral convexity transfer for C\textsuperscript{*}-algebras.}
 and, through it, the operator concavity of $x\mapsto x^p$ on $[0,1]$
 (\leanid{CFC.concaveOn_rpow}) and of $\log$ (\leanid{CFC.concaveOn_log}).  The
 scalar input of the convex axiom, operator convexity of $x\mapsto x^p$ on
@@ -195,7 +196,7 @@ elimination still needs the corresponding positive-map operator Jensen step.
 The integral representation of the power integrand, previously named as the
 obstruction, is present.
 
-\section{The Lieb concavity axiom}
+\section{The Lieb concavity theorem (scope-restricted)}\label{sec:lieb}
 
 \subsection{The assertion}
 
@@ -207,19 +208,23 @@ For $s\in[0,1]$, an arbitrary matrix $K$, and positive-definite $A,B$, the map
 is jointly concave on pairs of positive-definite matrices.  This is the
 boundary-exponent specialization of the Lieb concavity theorem
 (\cite[Theorem~5.15, the Ando--Lieb functional]{Wolf2012Quantum}), the trace
-functional underlying the Wigner--Yanase--Dyson conjecture.
+functional underlying the Wigner--Yanase--Dyson conjecture.  It is now
+\emph{proved} in this scope --- \leanid{lieb_concavity_axiom} is a theorem,
+derived from the commuting-superoperator integral representation
+(\S\ref{ssec:lieb-gap}) --- and the two scope restrictions below record how it
+differs from the unrestricted source theorem.
 
 \paragraph{Scope restriction (boundary exponent).}  Wolf's Theorem~5.15 is
-stated for two exponents $x,y\ge 0$ with $x+y\le 1$.  The formal axiom
+stated for two exponents $x,y\ge 0$ with $x+y\le 1$.  The formal theorem
 \leanid{lieb_concavity_axiom} records only the boundary line $x=s$, $y=1-s$,
 where $x+y=1$.  This is sufficient for the current downstream Lieb-concavity
 corollaries, but it is not the full source theorem; the sub-boundary range
-$x+y<1$ remains unformalized unless it is derived separately or the axiom is
+$x+y<1$ remains unformalized unless it is derived separately or the theorem is
 generalized.
 
 \paragraph{Scope restriction (positive-definite versus positive
 semidefinite).}  Wolf's Theorem~5.15 states the Ando--Lieb concavity for
-positive (semidefinite) operators, including singular ones.  The formal axiom
+positive (semidefinite) operators, including singular ones.  The formal theorem
 \leanid{lieb_concavity_axiom} is stated only for positive-\emph{definite} $A,B$
 (its hypotheses are \leanid{Matrix.PosDef}), so it does not yet cover singular
 positive inputs on which the source theorem still applies.  This is a scope
@@ -227,8 +232,8 @@ restriction, not an unfaithful statement: the powers $A^s$ and $B^{1-s}$ and the
 resolvent factors $(L_A+tR_B)^{-1}$ used in the elimination route
 (\S\ref{ssec:lieb-gap}) are most directly defined for invertible $A,B$, and the
 positive-definite case extends to the positive-semidefinite case by continuity.
-The unrestricted source theorem remains unformalized until the axiom is
-discharged for positive semidefinite $A,B$; this is recorded here so the
+The unrestricted source theorem remains unformalized until the theorem is
+extended to positive semidefinite $A,B$; this is recorded here so the
 restriction is auditable.
 
 \subsection{The point at issue}\label{ssec:lieb-gap}
@@ -262,20 +267,25 @@ linearity, yields the result.
 
 Mathlib~4.31 contains neither this superoperator integral representation nor a
 matrix-mean / resolvent-monotonicity API of the required form for the commuting
-pair $(L_A,R_B)$.  Supplying it is a library-level contribution, not a short
-local bridge.
+pair $(L_A,R_B)$.  Both were therefore developed within the formalization
+itself rather than drawn from the library.
 
 \subsection{Verdict}
 
 The Lieb concavity statement is correct
-\cite[Theorem~5.15]{Wolf2012Quantum}.  Its elimination requires the Ando
+\cite[Theorem~5.15]{Wolf2012Quantum}.  Its elimination required the Ando
 integral representation of the commuting left/right multiplication superoperators
 $L_A^{\,s}R_B^{\,1-s}$ (not the matrix product $A^sB^{1-s}$, whose resolvent
 formula holds only when $A,B$ commute) together with resolvent monotonicity of
-$(L_A+tR_B)^{-1}$, both absent from Mathlib~4.31.  The axiom is therefore blocked at
-the library level.  Three downstream corollaries already build on it (the
-$K=\mathbf 1$ case and separate concavity in each argument); these inherit the
-same blocked status until the integral representation is formalized.
+$(L_A+tR_B)^{-1}$.  Both were formalized over a sequence of steps --- the scalar
+boundary integral, the operator integral representation on the Kronecker model,
+the concavity of the resolvent integrand, and the resulting operator concavity ---
+and \leanid{lieb_concavity_axiom} is now a theorem in its positive-definite,
+boundary-exponent scope.  Three downstream corollaries build on it (the
+$K=\mathbf 1$ case and separate concavity in each argument); these are now
+axiom-free.  The remaining open generalizations are the two scope extensions
+recorded above: the sub-boundary range $x+y<1$ and singular (positive
+semidefinite) inputs.
 
 \section*{References}
 

--- a/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
@@ -23,15 +23,14 @@ operator-convexity boundary\footnote{%
     \leanid{posMap_log_concave_jensen}, and \leanid{lieb_concavity_axiom} in
     \doclink{TNLean/Axioms/OperatorConvexity}; the first, third, and fourth are
     now theorems (the Lieb declaration in its positive-definite, boundary-exponent
-    scope, see Section~\ref{sec:lieb}), and only the convex real-power Jensen
-    declaration remains an axiom.}
+    scope, see Section~\ref{sec:lieb}); none remains an axiom.}
 together with the cited sources, the precise gaps, and the first concrete step
 toward eliminating each remaining gap.  The positive-map Jensen declarations
 underlie \cite[Corollary~5.2]{Wolf2012Quantum} (the second corollary of Wolf's
 \S5.4) and rest on the operator-convexity and
 operator-monotonicity-versus-positive-maps results
-\cite[Theorems~5.10--5.13]{Wolf2012Quantum}; the Lieb axiom is the Ando--Lieb
-trace functional \cite[Theorem~5.15]{Wolf2012Quantum}.  (Wolf's Theorem~5.1 is
+\cite[Theorems~5.10--5.13]{Wolf2012Quantum}; the Lieb declaration is the
+Ando--Lieb trace functional \cite[Theorem~5.15]{Wolf2012Quantum}.  (Wolf's Theorem~5.1 is
 Douglas' theorem and is unrelated to this development.)
 
 The notation is fixed throughout.  Operators act on a finite-dimensional Hilbert
@@ -80,7 +79,7 @@ representation\footnote{%
     together with the Bochner-integral convexity transfer for C\textsuperscript{*}-algebras.}
 and, through it, the operator concavity of $x\mapsto x^p$ on $[0,1]$
 (\leanid{CFC.concaveOn_rpow}) and of $\log$ (\leanid{CFC.concaveOn_log}).  The
-scalar input of the convex axiom, operator convexity of $x\mapsto x^p$ on
+scalar input of the convex case, operator convexity of $x\mapsto x^p$ on
 $[1,2]$, is also now present as \leanid{CFC.convexOn_rpow} in
 \doclink{TNLean/Analysis/RpowConvexity}.  Thus the scalar functional-calculus
 inputs for the three Jensen declarations are available in the formal
@@ -98,15 +97,15 @@ discharged by the special Löwner-integrand route recorded in
 with ordered Bochner integral monotonicity.  The logarithmic case has also been
 discharged, not by a general Choi--Davis--Jensen theorem, but by taking the
 right limit $p\to 0^+$ in the concave real-power inequality and using
-\leanid{CFC.tendsto_cfc_rpow_sub_one_log}.  The convex real-power case remains
-blocked on the corresponding positive-map Jensen step, not on the integral
-representation of the power integrand.
+\leanid{CFC.tendsto_cfc_rpow_sub_one_log}.  The convex real-power case is now
+likewise proved, by the same positive-map Jensen step applied to the convex
+integrand of $x\mapsto x^p$ on $[1,2]$.
 
 \subsection{The compression scaffold is faithful to bare
 positivity}\label{ssec:caveat}
 
 A faithfulness worry would arise if the only available proof route needed a
-\emph{completely positive} $T$, since the axioms assume only that $T$ is
+\emph{completely positive} $T$, since the statements assume only that $T$ is
 positive (the hypothesis recorded in the formal statements is
 \leanid{IsPositiveMap}) and a complete-positivity hypothesis would be the
 stronger-hypothesis variant forbidden by the faithfulness rule.  That worry does
@@ -157,7 +156,7 @@ identity used in Wolf's block-positivity step in the proof of
   real-power Jensen inequality after integration.  The logarithmic Jensen theorem
   follows from this real-power result by the right-limit formula for
   $(A^p-\mathbf 1)/p$ as $p\to 0^+$.  The convex real-power Jensen declaration
-  remains open.
+  is now proved the same way, with the convex integrand on $[1,2]$.
 
 For the concave real-power case, the analytic step has now been supplied: the
 Löwner-integral argument carries the pointwise finite-POVM resolvent inequality
@@ -191,8 +190,9 @@ real-power statement \leanid{posMap_rpow_concave_jensen} has been discharged by
 the finite-POVM resolvent scaffold, the pointwise integrand inequality, and
 ordered Bochner integral monotonicity.  The logarithmic statement
 \leanid{posMap_log_concave_jensen} has been discharged as the right limit of the
-concave real-power result.  The convex real-power statement remains open; its
-elimination still needs the corresponding positive-map operator Jensen step.
+concave real-power result.  The convex real-power statement
+\leanid{posMap_rpow_convex_jensen} has likewise been discharged, by the same
+positive-map operator Jensen step applied to the convex integrand.
 The integral representation of the power integrand, previously named as the
 obstruction, is present.
 
@@ -302,8 +302,8 @@ The relevant formal-library inputs now available are
 \leanid{CFC.exists_measure_nnrpow_eq_integral_cfcₙ_rpowIntegrand₀₁},
 \leanid{CFC.concaveOn_rpow}, \leanid{CFC.convexOn_rpow}, and
 \leanid{CFC.concaveOn_log}.  Thus the scalar functional-calculus inputs are
-available; the remaining unproved theorem is the positive-map Jensen step
-described above.
+available, and all four positive-map Jensen and Lieb declarations of this
+boundary are now proved theorems.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Replaces the sanctioned `lieb_concavity_axiom` in `TNLean/Axioms/OperatorConvexity.lean` with a genuine proof, completing the multi-PR program that built the operator-integral-representation chain. The axiom→theorem keeps the exact name and signature, so the two downstream consumers are unchanged.

## The L4→L5→L6→L8 chain

The proof rests on the now-complete chain (all axiom-free):

- **L4** scalar Lieb integral identity (`Real.integral_lieb_integrand`)
- **L5** operator integral representation `Â^s B̂^{1-s} = (sin πs/π) ∫₀^∞ t^{s-1} Â(Â+tB̂)⁻¹ B̂ dt` (`superop_lieb_integral_rep`)
- **L6** Loewner concavity of the commuting-Kronecker fractional product `M(A,B) = (A⊗ₖ1)^s (1⊗ₖBᵀ)^{1-s}` (`superop_lieb_concave`)
- **L8** (this PR) transfer to the trace functional

### Mechanism (this PR)

For `s ∈ (0,1)`, `superop_lieb_concave` gives a Loewner inequality between PSD matrices on `ℂ^D ⊗ ℂ^D`. Pushing the continuous functional calculus through each unital tensor embedding (`cfc_kronecker_one`/`cfc_one_kronecker`) rewrites `M(A,B) = A^s ⊗ₖ (Bᵀ)^{1-s}`. The vectorization isometry (`Matrix.vec`, `star_vec_dotProduct_vec`, `kronecker_mulVec_vec`) then identifies `Tr(K† A^s K B^{1-s})` with the quadratic form `⟨vec Kᵀ, M(A,B) · vec Kᵀ⟩`. Applying this positive quadratic form (`PosSemidef.dotProduct_mulVec_nonneg`) to the Loewner inequality and taking real parts transfers the concavity to the trace. The vec orientation uses `vec Kᵀ` and a trace-transpose + `rpow`-transpose step to land `Tr(K† A^s K B^{1-s})` with the correct `K`/`K†` placement.

A small `rpow`-transpose lemma `(Bᵀ)^r = (B^r)ᵀ` is proved via entrywise complex conjugation as an ℝ-⋆-algebra hom commuting with the calculus (`StarAlgHomClass.map_cfc`).

The endpoints `s = 0` (`A^0 = 1`) and `s = 1` (`B^0 = 1`) make the varying side linear in the convex-combination argument, hence equalities.

## Axiom-drop evidence

```
'lieb_concavity_axiom' depends on axioms: [propext, Classical.choice, Quot.sound]
'lieb_concavity' depends on axioms: [propext, Classical.choice, Quot.sound]
```

(`lieb_concavity` in `Channel/Schwarz/AndoLieb.lean` is the downstream consumer whose proof called `lieb_concavity_axiom`; it no longer lists the custom axiom.) `TNLean/Axioms/OperatorConvexity.lean` now declares no axioms.

## Verification

- Full `lake build`: **Build completed successfully (9251 jobs).**
- `lake exe lint-style`: clean.

## Other changes

- `docs/PROOF_INTEGRITY.md`: removed `lieb_concavity_axiom` from the sanctioned-axiom registry (the file no longer declares any axioms).
- `blueprint/src/chapter/ch18_operator_convexity.tex`: `thm:lieb_concavity_axiom` now carries `\lean{}` + `\leanok` (statement and proof) with `\uses{lem:op_lieb_concave}`; removed `\notready`; adjusted the chapter intro so Lieb concavity is presented as derived rather than a cited input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change is a large formal proof in operator convexity and entropy infrastructure with axiom elimination, so regressions would affect downstream Lieb/relative-entropy consumers; scope remains restricted to positive-definite inputs and boundary exponents `s, 1-s`.
> 
> **Overview**
> **Lieb concavity is no longer an axiom:** `lieb_concavity_axiom` in `TNLean/Axioms/OperatorConvexity.lean` is now a **theorem** with the same name and signature. For `s ∈ (0,1)` the proof uses `superop_lieb_concave`, rewrites `(A⊗1)^s (1⊗Bᵀ)^{1-s}` as `A^s ⊗ (Bᵀ)^{1-s}` via new Kronecker CFC lemmas, and transfers the Loewner inequality to `Re Tr(K† A^s K B^{1-s})` through the `vec Kᵀ` quadratic form; `s = 0` and `s = 1` are linear endpoint cases. Supporting lemmas cover transpose/CFC (`rpow_transpose`) and the vec–trace identity (`lieb_quad_eq_trace`).
> 
> **Shared Kronecker CFC layer:** New `TNLean/Analysis/CfcKronecker.lean` defines `leftKroneckerEmbed` / `rightKroneckerEmbed` and proves `cfc_kronecker_one` / `cfc_one_kronecker`. These are wired into the root import list and **removed** from `RelativeEntropyAncillaAdditivity.lean` (that file now imports `CfcKronecker` for `log_kronecker`).
> 
> **Documentation:** `OperatorConvexity` module docs state all four boundary results are proved; `docs/PROOF_INTEGRITY.md` drops operator-convexity from the sanctioned-axiom table; blueprint ch18 marks Lieb as `\leanok` with a proof sketch; `wolf_ch5_operator_jensen_lieb.tex` records Lieb as proved (positive-definite, boundary-exponent scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d95ed2f8e3cc56bd13b3885d3c628be8a9b6efa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->