### PR TITLE
feat(Algebra): intertwiner isometry-normalization on irreducible pieces (toward Wolf Thm 6.14 spatial realization)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -38,6 +38,7 @@ import TNLean.Algebra.ScalarCommutant
 import TNLean.Algebra.CocycleCohomology
 import TNLean.Algebra.SpinCover
 import TNLean.Algebra.MatrixRankClosed
+import TNLean.Algebra.StarSubalgebraIntertwinerIsometry
 import TNLean.Algebra.StarSubalgebraIrreducibleDecomp
 import TNLean.Algebra.StarSubalgebraIsotypic
 import TNLean.Algebra.StarSubalgebraIsotypicDecomp

--- a/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
+++ b/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.StarSubalgebraIsotypic
+
+/-!
+# Intertwiners on irreducible pieces are isometries up to a nonnegative scale
+
+Continuing the structure theory of *Quantum Channels & Operations* (Wolf 2012), Chapter 6,
+towards Theorem 6.14, this file shows that an operator carrying an irreducible piece of a
+star-subalgebra into another piece, and commuting there with the subalgebra, preserves the
+inner product up to a single nonnegative real factor. On the irreducible source it is, after
+dividing by the square root of that factor, an isometry onto its image.
+
+This is the metric input to the assembly of a single unitary change of basis: each
+isomorphism between pieces of the same type can be normalized to a partial isometry, so the
+pieces of one type are unitarily identified.
+
+## Proof outline
+
+Compose the operator with the Euclidean adjoint and project back onto the source. The result
+maps the source into itself and commutes there with the subalgebra, because the orthogonal
+projection onto an invariant subspace commutes with the subalgebra and the adjoint of every
+member of the subalgebra is again a member. Schur's lemma on the irreducible source makes
+this composite a scalar, and pairing against the source identifies that scalar with the inner
+product of the images. Pairing a nonzero source vector with itself shows the scalar is a
+nonnegative real, since it equals the squared norm of the image divided by the squared norm
+of the vector.
+-/
+
+open scoped Matrix InnerProductSpace ComplexConjugate
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+omit [DecidableEq n] in
+/-- Pairing the orthogonal projection onto a subspace with a vector of that subspace ignores
+the projection. -/
+private theorem inner_starProjection_left_mem
+    {p : Submodule ℂ (EuclideanSpace ℂ n)} (z : EuclideanSpace ℂ n)
+    {w : EuclideanSpace ℂ n} (hw : w ∈ p) :
+    ⟪p.starProjection z, w⟫_ℂ = ⟪z, w⟫_ℂ := by
+  have h := Submodule.starProjection_inner_eq_zero (K := p) z w hw
+  rw [inner_sub_left, sub_eq_zero] at h
+  exact h.symm
+
+/-- A vector of an invariant subspace, mapped by a member of the subalgebra, stays in the
+subspace. -/
+private theorem toEuclideanLin_mem_of_mem {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : S.IsInvariantSubspace p) {A : Matrix n n ℂ} (hA : A ∈ S)
+    {x : EuclideanSpace ℂ n} (hx : x ∈ p) : Matrix.toEuclideanLin A x ∈ p :=
+  (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem (f := Matrix.toEuclideanLin A)).mp
+    (hp A hA) x hx
+
+/-- For an intertwiner `f` of a star-subalgebra `S` of complex matrices from `p` into `q`,
+projecting the Euclidean adjoint of `f` applied at a vector of `q` back onto an invariant
+subspace `p` commutes with every member of the subalgebra. The adjoint of every member is
+again a member and the source is invariant, so the intertwining identity of `f` transfers to
+the projected adjoint. See *Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards
+Theorem 6.14. -/
+private theorem starProjection_adjoint_comm
+    {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsInvariantSubspace p)
+    {f : Module.End ℂ (EuclideanSpace ℂ n)} (hf : S.IsIntertwiner p q f)
+    {A : Matrix n n ℂ} (hA : A ∈ S) (y : EuclideanSpace ℂ n) :
+    p.starProjection (LinearMap.adjoint f (Matrix.toEuclideanLin A y)) =
+      Matrix.toEuclideanLin A (p.starProjection (LinearMap.adjoint f y)) := by
+  -- The conjugate transpose of `A` is again a member of `S`.
+  have hAstar : Aᴴ ∈ S := by simpa [Matrix.star_eq_conjTranspose] using star_mem hA
+  -- Both vectors lie in `p`; it suffices to test them against every vector of `p`.
+  set u := p.starProjection (LinearMap.adjoint f (Matrix.toEuclideanLin A y)) with hu
+  set v := Matrix.toEuclideanLin A (p.starProjection (LinearMap.adjoint f y)) with hv
+  have hu_mem : u ∈ p := p.starProjection_apply_mem _
+  have hv_mem : v ∈ p :=
+    S.toEuclideanLin_mem_of_mem hp hA (p.starProjection_apply_mem _)
+  have hsub_mem : u - v ∈ p := p.sub_mem hu_mem hv_mem
+  -- Against any `w ∈ p`, the difference of the two vectors pairs to zero.
+  have hpair : ∀ w ∈ p, ⟪u - v, w⟫_ℂ = 0 := by
+    intro w hw
+    have hAw : Matrix.toEuclideanLin Aᴴ w ∈ p := S.toEuclideanLin_mem_of_mem hp hAstar hw
+    have hLHS : ⟪u, w⟫_ℂ = ⟪Matrix.toEuclideanLin A y, f w⟫_ℂ := by
+      rw [hu, inner_starProjection_left_mem _ hw, LinearMap.adjoint_inner_left]
+    have hRHS : ⟪v, w⟫_ℂ = ⟪Matrix.toEuclideanLin A y, f w⟫_ℂ := by
+      rw [hv, ← LinearMap.adjoint_inner_right, ← Matrix.toEuclideanLin_conjTranspose_eq_adjoint,
+        inner_starProjection_left_mem _ hAw, LinearMap.adjoint_inner_left, hf.2 Aᴴ hAstar w hw,
+        Matrix.toEuclideanLin_conjTranspose_eq_adjoint, LinearMap.adjoint_inner_right]
+    rw [inner_sub_left, hLHS, hRHS, sub_self]
+  -- A vector of `p` orthogonal to all of `p` is zero.
+  have hzero : u - v = 0 := inner_self_eq_zero.mp (hpair _ hsub_mem)
+  rw [sub_eq_zero] at hzero
+  exact hzero
+
+/-- On an irreducible piece `p` of a star-subalgebra `S` of complex matrices, an intertwiner
+`f` carrying `p` into a piece `q` preserves the inner product up to a single nonnegative real
+factor `c`: for all `x` and `y` in `p`,
+$$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle .$$
+Following `f` with its Euclidean adjoint and the orthogonal projection onto `p` gives an
+operator that maps `p` into itself and commutes there with the subalgebra, so Schur's lemma
+makes it a scalar; pairing against `p` identifies the scalar with the inner product of the
+images, and pairing a nonzero vector with itself shows the scalar is a nonnegative real. See
+*Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
+theorem exists_real_smul_inner_of_intertwiner
+    {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)
+    {f : Module.End ℂ (EuclideanSpace ℂ n)} (hf : S.IsIntertwiner p q f) :
+    ∃ c : ℝ, 0 ≤ c ∧ ∀ x ∈ p, ∀ y ∈ p, ⟪f x, f y⟫_ℂ = (c : ℂ) * ⟪x, y⟫_ℂ := by
+  obtain ⟨hpinv, hpne, hpmax⟩ := hp
+  -- The composite operator: apply `f`, the Euclidean adjoint of `f`, and project onto `p`.
+  set g : Module.End ℂ (EuclideanSpace ℂ n) :=
+    p.starProjection.toLinearMap ∘ₗ (LinearMap.adjoint f ∘ₗ f) with hg
+  have hg_apply : ∀ z, g z = p.starProjection (LinearMap.adjoint f (f z)) := fun z => rfl
+  -- `g` maps `p` into itself, since the projection lands in `p`.
+  have hg_mem : p ∈ Module.End.invtSubmodule g :=
+    (Module.End.mem_invtSubmodule_iff_forall_mem_of_mem (f := g)).mpr fun x _ =>
+      hg_apply x ▸ p.starProjection_apply_mem _
+  -- `g` commutes on `p` with every member: combine the adjoint identity with that of `f`.
+  have hg_comm : ∀ A ∈ S, ∀ x ∈ p,
+      g (Matrix.toEuclideanLin A x) = Matrix.toEuclideanLin A (g x) := by
+    intro A hA x hx
+    rw [hg_apply, hg_apply, hf.2 A hA x hx,
+      S.starProjection_adjoint_comm hpinv hf hA (f x)]
+  -- Schur's lemma makes `g` a scalar on the irreducible piece `p`.
+  obtain ⟨c, hc⟩ :=
+    S.exists_eq_smul_of_commute_of_irreducible ⟨hpinv, hpne, hpmax⟩ hg_mem hg_comm
+  -- Pairing `g` against `p` recovers the inner product of the images.
+  have hinner : ∀ x ∈ p, ∀ y ∈ p, ⟪f x, f y⟫_ℂ = (starRingEnd ℂ) c * ⟪x, y⟫_ℂ := by
+    intro x hx y hy
+    have h1 : ⟪f x, f y⟫_ℂ = ⟪g x, y⟫_ℂ := by
+      rw [hg_apply, inner_starProjection_left_mem _ hy, LinearMap.adjoint_inner_left]
+    rw [h1, hc x hx, inner_smul_left]
+  -- Evaluate the scalar at a nonzero vector to see it is a nonnegative real.
+  obtain ⟨x₀, hx₀p, hx₀ne⟩ := (Submodule.ne_bot_iff p).mp hpne
+  have hx₀norm : (0 : ℝ) < ‖x₀‖ ^ 2 := by positivity
+  have hkey : (starRingEnd ℂ) c * (‖x₀‖ ^ 2 : ℂ) = (‖f x₀‖ ^ 2 : ℂ) := by
+    have h := hinner x₀ hx₀p x₀ hx₀p
+    rw [inner_self_eq_norm_sq_to_K, inner_self_eq_norm_sq_to_K] at h
+    exact h.symm
+  -- The conjugate scalar is the ratio of squared norms, a nonnegative real.
+  refine ⟨‖f x₀‖ ^ 2 / ‖x₀‖ ^ 2, by positivity, fun x hx y hy => ?_⟩
+  have hconj : (starRingEnd ℂ) c = ((‖f x₀‖ ^ 2 / ‖x₀‖ ^ 2 : ℝ) : ℂ) := by
+    rw [Complex.ofReal_div, Complex.ofReal_pow, Complex.ofReal_pow, eq_div_iff (by
+      exact_mod_cast ne_of_gt hx₀norm)]
+    exact_mod_cast hkey
+  rw [hinner x hx y hy, hconj]
+
+/-- On an irreducible piece `p` of a star-subalgebra `S` of complex matrices, an intertwiner
+`f` carrying `p` into a piece `q` that does not vanish on `p` preserves the inner product up
+to a strictly positive real factor `c`: for all `x` and `y` in `p`,
+$$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle , \qquad c > 0 .$$
+The nonnegative factor from the inner-product identity is strictly positive here, since
+evaluating it at a vector of `p` on which `f` is nonzero gives a positive squared norm. After
+dividing `f` by the square root of `c`, the restriction to `p` is an isometry onto `q`. See
+*Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
+theorem exists_pos_smul_inner_of_intertwiner_ne_zero
+    {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)
+    {f : Module.End ℂ (EuclideanSpace ℂ n)} (hf : S.IsIntertwiner p q f)
+    (hne : ¬ ∀ x ∈ p, f x = 0) :
+    ∃ c : ℝ, 0 < c ∧ ∀ x ∈ p, ∀ y ∈ p, ⟪f x, f y⟫_ℂ = (c : ℂ) * ⟪x, y⟫_ℂ := by
+  obtain ⟨c, -, hceq⟩ := S.exists_real_smul_inner_of_intertwiner hp hf
+  -- Choose a vector of `p` on which `f` does not vanish.
+  obtain ⟨x₀, hx₀p, hfx₀ne⟩ : ∃ x ∈ p, f x ≠ 0 := by simpa using hne
+  have hx₀ne0 : x₀ ≠ 0 := fun h => hfx₀ne (by rw [h, map_zero])
+  refine ⟨c, ?_, hceq⟩
+  -- Evaluating the identity at `x₀` gives `‖f x₀‖² = c‖x₀‖²` with both norms positive.
+  have hval : (‖f x₀‖ ^ 2 : ℂ) = (c : ℂ) * (‖x₀‖ ^ 2 : ℂ) := by
+    have h := hceq x₀ hx₀p x₀ hx₀p
+    rwa [inner_self_eq_norm_sq_to_K, inner_self_eq_norm_sq_to_K] at h
+  have hvalℝ : ‖f x₀‖ ^ 2 = c * ‖x₀‖ ^ 2 := by exact_mod_cast hval
+  have hfpos : (0 : ℝ) < ‖f x₀‖ ^ 2 := by positivity
+  have hxpos : (0 : ℝ) < ‖x₀‖ ^ 2 := by positivity
+  nlinarith [hvalℝ, hfpos, hxpos]
+
+end StarSubalgebra

--- a/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
+++ b/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
@@ -148,7 +148,7 @@ theorem exists_real_smul_inner_of_intertwiner
 /-- On an irreducible piece `p` of a star-subalgebra `S` of complex matrices, an intertwiner
 `f` carrying `p` into a piece `q` that does not vanish on `p` preserves the inner product up
 to a strictly positive real factor `c`: for all `x` and `y` in `p`,
-$$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle , \qquad c > 0 .$$
+$$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle .$$
 The nonnegative factor from the inner-product identity is strictly positive here, since
 evaluating it at a vector of `p` on which `f` is nonzero gives a positive squared norm. See
 *Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/

--- a/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
+++ b/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
@@ -10,10 +10,11 @@ import TNLean.Algebra.StarSubalgebraIsotypic
 Continuing the structure theory of *Quantum Channels & Operations* (Wolf 2012), Chapter 6,
 towards Theorem 6.14, this file shows that an operator carrying an irreducible piece of a
 star-subalgebra into another piece, and commuting there with the subalgebra, preserves the
-inner product up to a single nonnegative real factor. On the irreducible source it is, after
-dividing by the square root of that factor, an isometry onto its image.
+inner product up to a single nonnegative real factor. When it does not vanish on the
+irreducible source, that factor is positive, and dividing by its square root makes it an
+isometry onto its image.
 
-This is the metric input to the assembly of a single unitary change of basis: each
+This is the metric input to the construction of a single unitary change of basis: each
 isomorphism between pieces of the same type can be normalized to a partial isometry, so the
 pieces of one type are unitarily identified.
 

--- a/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
+++ b/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
@@ -21,9 +21,10 @@ pieces of one type are unitarily identified.
 ## Proof outline
 
 Compose the operator with the Euclidean adjoint and project back onto the source. The result
-maps the source into itself and commutes there with the subalgebra, because the orthogonal
-projection onto an invariant subspace commutes with the subalgebra and the adjoint of every
-member of the subalgebra is again a member. Schur's lemma on the irreducible source makes
+maps the source into itself, since the projection lands there, and commutes there with the
+subalgebra: the adjoint of every member is again a member, so the intertwining identity
+transfers through the adjoint to the projected composite. Schur's lemma on the irreducible
+source makes
 this composite a scalar, and pairing against the source identifies that scalar with the inner
 product of the images. Pairing a nonzero source vector with itself shows the scalar is a
 nonnegative real, since it equals the squared norm of the image divided by the squared norm

--- a/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
+++ b/TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean
@@ -149,8 +149,7 @@ theorem exists_real_smul_inner_of_intertwiner
 to a strictly positive real factor `c`: for all `x` and `y` in `p`,
 $$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle , \qquad c > 0 .$$
 The nonnegative factor from the inner-product identity is strictly positive here, since
-evaluating it at a vector of `p` on which `f` is nonzero gives a positive squared norm. After
-dividing `f` by the square root of `c`, the restriction to `p` is an isometry onto `q`. See
+evaluating it at a vector of `p` on which `f` is nonzero gives a positive squared norm. See
 *Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
 theorem exists_pos_smul_inner_of_intertwiner_ne_zero
     {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1353,8 +1353,9 @@ irreducible pieces such an intertwiner is automatically an isomorphism.
 \end{definition}
 
 An intertwiner whose source is irreducible scales the inner product by one nonnegative real
-factor, so after rescaling it is an isometry. This is the metric ingredient that turns each
-same-type isomorphism into a partial isometry.
+factor; when the intertwiner does not vanish on the source, that factor is positive, so after
+rescaling it is an isometry. This is the metric ingredient that turns each same-type
+isomorphism into a partial isometry.
 
 \begin{lemma}[Intertwiner scales the inner product]%
     \label{lem:starSubalgebra_intertwiner_inner_scale}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1340,12 +1340,12 @@ it carries $W$ into $W'$ and commutes on $W$ with every member of $S$. Two piece
 the same type when some intertwiner between them does not vanish on the source; on
 irreducible pieces such an intertwiner is automatically an isomorphism.
 
-\begin{definition}[Intertwiner between invariant subspaces]%
+\begin{definition}[Intertwiner between subspaces]%
     \label{def:starSubalgebra_intertwiner}
     \lean{StarSubalgebra.IsIntertwiner}
     \leanok
-    Let $S$ be a $*$-subalgebra of $\MN{D}$ and let $W, W' \subseteq \C^{D}$ be invariant
-    under $S$. A linear operator $f \colon \C^{D} \to \C^{D}$ is an intertwiner from $W$ into
+    Let $S$ be a $*$-subalgebra of $\MN{D}$ and let $W, W' \subseteq \C^{D}$ be subspaces. A
+    linear operator $f \colon \C^{D} \to \C^{D}$ is an intertwiner from $W$ into
     $W'$ when it carries $W$ into $W'$ and, for every $A \in S$ and every $x \in W$,
     \[
         f(A x) = A\,(f x).
@@ -1364,7 +1364,7 @@ isomorphism into a partial isometry.
     \uses{def:starSubalgebra_intertwiner, def:starSubalgebra_irreducibleSubspace,
         lem:starSubalgebra_scalar_commutant_irreducible}
     Let $S$ be a $*$-subalgebra of $\MN{D}$, let $W \subseteq \C^{D}$ be irreducible under $S$,
-    and let $f$ be an intertwiner from $W$ into an invariant subspace $W'$. Then there is a
+    and let $f$ be an intertwiner from $W$ into a subspace $W'$. Then there is a
     real number $c \ge 0$ such that for all $x, y \in W$,
     \[
         \langle f(x), f(y) \rangle = c\,\langle x, y \rangle .
@@ -1393,7 +1393,7 @@ isomorphism into a partial isometry.
     \leanok
     \uses{lem:starSubalgebra_intertwiner_inner_scale}
     Let $S$ be a $*$-subalgebra of $\MN{D}$, let $W \subseteq \C^{D}$ be irreducible under $S$,
-    and let $f$ be an intertwiner from $W$ into an invariant subspace $W'$ that does not vanish
+    and let $f$ be an intertwiner from $W$ into a subspace $W'$ that does not vanish
     on $W$. Then there is a real number $c > 0$ such that for all $x, y \in W$,
     \[
         \langle f(x), f(y) \rangle = c\,\langle x, y \rangle .

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1365,11 +1365,10 @@ isomorphism into a partial isometry.
         lem:starSubalgebra_scalar_commutant_irreducible}
     Let $S$ be a $*$-subalgebra of $\MN{D}$, let $W \subseteq \C^{D}$ be irreducible under $S$,
     and let $f$ be an intertwiner from $W$ into an invariant subspace $W'$. Then there is a
-    real number $c \ge 0$ with
+    real number $c \ge 0$ such that for all $x, y \in W$,
     \[
-        \langle f(x), f(y) \rangle = c\,\langle x, y \rangle
+        \langle f(x), f(y) \rangle = c\,\langle x, y \rangle .
     \]
-    for all $x, y \in W$.
 \end{lemma}
 
 \begin{proof}
@@ -1377,9 +1376,10 @@ isomorphism into a partial isometry.
     \uses{def:starSubalgebra_intertwiner, def:starSubalgebra_irreducibleSubspace,
         lem:starSubalgebra_scalar_commutant_irreducible}
     Following $f$ with its adjoint and the orthogonal projection $P_{W}$ onto $W$ gives an
-    operator $g = P_{W} f^{*} f$ that maps $W$ into itself and commutes on $W$ with every
-    member of $S$, because $P_{W}$ commutes with $S$ and the adjoint of every member of $S$ is
-    again a member. By Schur's lemma
+    operator $g = P_{W} f^{*} f$ that maps $W$ into itself, since the projection lands in $W$.
+    On $W$ it commutes with every member of $S$: for $A \in S$ the adjoint $A^{*}$ is again a
+    member, and combining the intertwining identity of $f$ with the pairing of the projected
+    adjoint against $W$ gives $g(A x) = A\,(g x)$ for $x \in W$. By Schur's lemma
     (Lemma~\ref{lem:starSubalgebra_scalar_commutant_irreducible}) the operator $g$ acts on $W$
     as a scalar, $g x = \lambda\,x$. Pairing with a vector $y \in W$ and using that $P_{W}$ is
     invisible against $W$ gives $\langle f(x), f(y) \rangle = \langle g(x), y \rangle =
@@ -1394,11 +1394,10 @@ isomorphism into a partial isometry.
     \uses{lem:starSubalgebra_intertwiner_inner_scale}
     Let $S$ be a $*$-subalgebra of $\MN{D}$, let $W \subseteq \C^{D}$ be irreducible under $S$,
     and let $f$ be an intertwiner from $W$ into an invariant subspace $W'$ that does not vanish
-    on $W$. Then there is a real number $c > 0$ with
+    on $W$. Then there is a real number $c > 0$ such that for all $x, y \in W$,
     \[
-        \langle f(x), f(y) \rangle = c\,\langle x, y \rangle
+        \langle f(x), f(y) \rangle = c\,\langle x, y \rangle .
     \]
-    for all $x, y \in W$.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1380,10 +1380,10 @@ same-type isomorphism into a partial isometry.
     member of $S$, because $P_{W}$ commutes with $S$ and the adjoint of every member of $S$ is
     again a member. By Schur's lemma
     (Lemma~\ref{lem:starSubalgebra_scalar_commutant_irreducible}) the operator $g$ acts on $W$
-    as a scalar, $g x = c\,x$. Pairing with a vector $y \in W$ and using that $P_{W}$ is
+    as a scalar, $g x = \lambda\,x$. Pairing with a vector $y \in W$ and using that $P_{W}$ is
     invisible against $W$ gives $\langle f(x), f(y) \rangle = \langle g(x), y \rangle =
-    \overline{c}\,\langle x, y \rangle$. Pairing a nonzero $x \in W$ with itself shows
-    $\overline{c} = \|f(x)\|^{2} / \|x\|^{2}$, a nonnegative real.
+    \overline{\lambda}\,\langle x, y \rangle$. Pairing a nonzero $x \in W$ with itself shows
+    that $c = \overline{\lambda} = \|f(x)\|^{2} / \|x\|^{2}$, a nonnegative real.
 \end{proof}
 
 \begin{lemma}[Nonzero intertwiner scales by a positive factor]%
@@ -1397,8 +1397,7 @@ same-type isomorphism into a partial isometry.
     \[
         \langle f(x), f(y) \rangle = c\,\langle x, y \rangle
     \]
-    for all $x, y \in W$. After dividing $f$ by $\sqrt{c}$, its restriction to $W$ is an
-    isometry onto $W'$.
+    for all $x, y \in W$.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1352,6 +1352,64 @@ irreducible pieces such an intertwiner is automatically an isomorphism.
     \]
 \end{definition}
 
+An intertwiner whose source is irreducible scales the inner product by one nonnegative real
+factor, so after rescaling it is an isometry. This is the metric ingredient that turns each
+same-type isomorphism into a partial isometry.
+
+\begin{lemma}[Intertwiner scales the inner product]%
+    \label{lem:starSubalgebra_intertwiner_inner_scale}
+    \lean{StarSubalgebra.exists_real_smul_inner_of_intertwiner}
+    \leanok
+    \uses{def:starSubalgebra_intertwiner, def:starSubalgebra_irreducibleSubspace,
+        lem:starSubalgebra_scalar_commutant_irreducible}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$, let $W \subseteq \C^{D}$ be irreducible under $S$,
+    and let $f$ be an intertwiner from $W$ into an invariant subspace $W'$. Then there is a
+    real number $c \ge 0$ with
+    \[
+        \langle f(x), f(y) \rangle = c\,\langle x, y \rangle
+    \]
+    for all $x, y \in W$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:starSubalgebra_intertwiner, def:starSubalgebra_irreducibleSubspace,
+        lem:starSubalgebra_scalar_commutant_irreducible}
+    Following $f$ with its adjoint and the orthogonal projection $P_{W}$ onto $W$ gives an
+    operator $g = P_{W} f^{*} f$ that maps $W$ into itself and commutes on $W$ with every
+    member of $S$, because $P_{W}$ commutes with $S$ and the adjoint of every member of $S$ is
+    again a member. By Schur's lemma
+    (Lemma~\ref{lem:starSubalgebra_scalar_commutant_irreducible}) the operator $g$ acts on $W$
+    as a scalar, $g x = c\,x$. Pairing with a vector $y \in W$ and using that $P_{W}$ is
+    invisible against $W$ gives $\langle f(x), f(y) \rangle = \langle g(x), y \rangle =
+    \overline{c}\,\langle x, y \rangle$. Pairing a nonzero $x \in W$ with itself shows
+    $\overline{c} = \|f(x)\|^{2} / \|x\|^{2}$, a nonnegative real.
+\end{proof}
+
+\begin{lemma}[Nonzero intertwiner scales by a positive factor]%
+    \label{lem:starSubalgebra_intertwiner_inner_scale_pos}
+    \lean{StarSubalgebra.exists_pos_smul_inner_of_intertwiner_ne_zero}
+    \leanok
+    \uses{lem:starSubalgebra_intertwiner_inner_scale}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$, let $W \subseteq \C^{D}$ be irreducible under $S$,
+    and let $f$ be an intertwiner from $W$ into an invariant subspace $W'$ that does not vanish
+    on $W$. Then there is a real number $c > 0$ with
+    \[
+        \langle f(x), f(y) \rangle = c\,\langle x, y \rangle
+    \]
+    for all $x, y \in W$. After dividing $f$ by $\sqrt{c}$, its restriction to $W$ is an
+    isometry onto $W'$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_intertwiner_inner_scale}
+    The nonnegative factor from
+    Lemma~\ref{lem:starSubalgebra_intertwiner_inner_scale} satisfies $\|f(x)\|^{2} =
+    c\,\|x\|^{2}$. Choosing $x \in W$ with $f(x) \neq 0$ forces both squared norms to be
+    positive, so $c > 0$.
+\end{proof}
+
 \begin{definition}[Same type for invariant subspaces]%
     \label{def:starSubalgebra_sameIsotype}
     \lean{StarSubalgebra.SameIsotype}


### PR DESCRIPTION
## Summary

Adds the Schur isometry-normalization step toward the spatial realization of Wolf
Theorem 6.14 (advances LionSR/QICLean#189 / LionSR/QICLean#186). An intertwiner of a `*`-subalgebra `S` of complex
matrices whose source is an irreducible piece preserves the inner product up to one
nonnegative real factor; if it does not vanish on the source the factor is strictly
positive, so after dividing by its square root the restriction is an isometry onto the
image.

## What was proved

New file `TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean` (imports
`StarSubalgebraIsotypic`), in `namespace StarSubalgebra` over
`{n : Type*} [Fintype n] [DecidableEq n]`, `(S : StarSubalgebra ℂ (Matrix n n ℂ))`:

```
theorem exists_real_smul_inner_of_intertwiner
    {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)
    {f : Module.End ℂ (EuclideanSpace ℂ n)} (hf : S.IsIntertwiner p q f) :
    ∃ c : ℝ, 0 ≤ c ∧ ∀ x ∈ p, ∀ y ∈ p, ⟪f x, f y⟫_ℂ = (c : ℂ) * ⟪x, y⟫_ℂ

theorem exists_pos_smul_inner_of_intertwiner_ne_zero
    {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)
    {f : Module.End ℂ (EuclideanSpace ℂ n)} (hf : S.IsIntertwiner p q f)
    (hne : ¬ ∀ x ∈ p, f x = 0) :
    ∃ c : ℝ, 0 < c ∧ ∀ x ∈ p, ∀ y ∈ p, ⟪f x, f y⟫_ℂ = (c : ℂ) * ⟪x, y⟫_ℂ
```

Proof route: follow `f` with its Euclidean adjoint and the orthogonal projection onto `p`,
giving `g = P_p ∘ f* ∘ f`. This maps `p` into itself and commutes there with `S` (the
projection commutes with `S` and the conjugate transpose of every member of `S` is again a
member, so the adjoint of `f` carries the intertwining identity). Schur's lemma
(`exists_eq_smul_of_commute_of_irreducible`) makes `g` a scalar on `p`; pairing against `p`
identifies the scalar with the inner product of the images, and pairing a nonzero source
vector with itself shows it is a nonnegative real.

Three private helpers support the proof (projection-pairing, invariance under members, and
the projected-adjoint commutation).

## Blueprint

Two entries added to `blueprint/src/chapter/ch07_spectral.tex` after the intertwiner
definition (`def:starSubalgebra_intertwiner`):

- `lem:starSubalgebra_intertwiner_inner_scale` (`\lean` + `\leanok`,
  `\uses{def:starSubalgebra_intertwiner, def:starSubalgebra_irreducibleSubspace,
  lem:starSubalgebra_scalar_commutant_irreducible}`)
- `lem:starSubalgebra_intertwiner_inner_scale_pos` (`\lean` + `\leanok`,
  `\uses{lem:starSubalgebra_intertwiner_inner_scale}`)

## Verification

- `lake build TNLean.Algebra.StarSubalgebraIntertwinerIsometry`: exit 0 (only the standard
  3-line-header "Copyright too short" warning shared by every sibling file).
- `git grep -nE "sorry|admit|axiom" <file>`: empty.
- `#print axioms` on both theorems: `[propext, Classical.choice, Quot.sound]` (line removed
  after checking).
- `lake exe lint-style <file>`: passes (no style errors; longest line 100 display columns).
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`: passes.

Reuses Mathlib `Matrix.toEuclideanLin_conjTranspose_eq_adjoint`,
`LinearMap.adjoint_inner_left`/`adjoint_inner_right`, `Submodule.starProjection_*`,
`inner_self_eq_norm_sq_to_K`, `inner_smul_left`.

Advances LionSR/QICLean#189 / LionSR/QICLean#186 toward Wolf Theorem 6.14 (spatial realization).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and blueprint documentation in star-subalgebra representation theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TNLean/Algebra/StarSubalgebraIntertwinerIsometry.lean`** and wires it into **`TNLean.lean`**, toward Wolf Theorem 6.14 spatial realization.
> 
> **Lean:** For an intertwiner `f` from an **irreducible** piece `p`, proves `exists_real_smul_inner_of_intertwiner` (some `c ≥ 0` with `⟪f x, f y⟫ = c ⟪x, y⟫` on `p`) via `P_p ∘ f* ∘ f`, Schur scalar commutant, and norm ratios; `exists_pos_smul_inner_of_intertwiner_ne_zero` strengthens to `c > 0` when `f` is not identically zero on `p`. Private lemmas cover projection–inner-product identities, invariance under `S`, and commutation of the projected adjoint with `S`.
> 
> **Blueprint (`ch07_spectral.tex`):** Broadens the intertwiner definition from invariant subspaces to arbitrary subspaces; documents the metric scaling story and adds **`lem:starSubalgebra_intertwiner_inner_scale`** and **`lem:starSubalgebra_intertwiner_inner_scale_pos`** with `\leanok` links to the new theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 281c8f4ff8a99d78d39fb3a64e0202443c0a8170. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->