### PR TITLE
feat(Axioms): Lieb concavity for positive semidefinite inputs (full Wolf Thm 5.15 boundary)

### DIFF
--- a/TNLean/Axioms/OperatorConvexity.lean
+++ b/TNLean/Axioms/OperatorConvexity.lean
@@ -792,6 +792,159 @@ theorem lieb_concavity_axiom
       Complex.ofReal_re, Complex.ofReal_im, zero_mul, sub_zero, Complex.ofReal_re,
       Complex.ofReal_im, zero_mul, sub_zero]
 
+/-- The real matrix power `a ↦ a ^ s` for `s > 0` is continuous on the
+positive-semidefinite cone.  The strict positivity of the exponent makes the scalar
+map `x ↦ x ^ s` continuous at `0`, so the functional-calculus power is continuous on
+the whole cone (not only at strictly positive matrices). -/
+private lemma continuousOn_rpow_psd {s : ℝ} (hs : 0 < s) :
+    ContinuousOn (fun a : Mat => a ^ s) {a : Mat | 0 ≤ a} := by
+  have hns : (0 : ℝ≥0) < s.toNNReal := by rw [Real.toNNReal_pos]; exact hs
+  have hcont := CFC.continuousOn_nnrpow (A := Mat) s.toNNReal
+  have hfun : (fun a : Mat => a ^ (s.toNNReal : ℝ≥0)) = fun a : Mat => a ^ s := by
+    funext a; rw [CFC.nnrpow_eq_rpow hns, Real.coe_toNNReal s hs.le]
+  rwa [hfun] at hcont
+
+/-- For positive-semidefinite `A` and `s > 0`, the regularized power
+`(A + ε • 1) ^ s` converges to `A ^ s` as `ε → 0⁺`.  The regularized matrices stay in
+the positive-semidefinite cone, where `· ^ s` is continuous. -/
+private lemma tendsto_reg_rpow {s : ℝ} (hs : 0 < s) {A : Mat} (hA : A.PosSemidef) :
+    Tendsto (fun ε : ℝ => (A + ε • (1 : Mat)) ^ s) (𝓝[>] 0) (𝓝 (A ^ s)) := by
+  have hcontbase : Continuous (fun ε : ℝ => A + ε • (1 : Mat)) := by fun_prop
+  have hbase : Tendsto (fun ε : ℝ => A + ε • (1 : Mat)) (𝓝[>] 0) (𝓝 A) := by
+    have h0 : Tendsto (fun ε : ℝ => A + ε • (1 : Mat)) (𝓝 0) (𝓝 A) := by
+      have := hcontbase.tendsto (0 : ℝ); simpa using this
+    exact h0.mono_left nhdsWithin_le_nhds
+  have hmem : ∀ᶠ ε : ℝ in 𝓝[>] 0, (A + ε • (1 : Mat)) ∈ {a : Mat | 0 ≤ a} := by
+    filter_upwards [self_mem_nhdsWithin] with ε hε
+    exact Matrix.nonneg_iff_posSemidef.mpr (hA.add (Matrix.PosSemidef.one.smul hε.le))
+  have hA0 : A ∈ {a : Mat | 0 ≤ a} := Matrix.nonneg_iff_posSemidef.mpr hA
+  have hcwa : ContinuousWithinAt (fun a : Mat => a ^ s) {a : Mat | 0 ≤ a} A :=
+    (continuousOn_rpow_psd hs).continuousWithinAt hA0
+  have hbase' : Tendsto (fun ε : ℝ => A + ε • (1 : Mat)) (𝓝[>] 0)
+      (𝓝[{a : Mat | 0 ≤ a}] A) := tendsto_nhdsWithin_iff.mpr ⟨hbase, hmem⟩
+  have hcomp : Tendsto (fun ε : ℝ => (A + ε • (1 : Mat)) ^ s) (𝓝[>] 0)
+      (𝓝 (A ^ s)) := hcwa.tendsto.comp hbase'
+  exact hcomp
+
+/-- The regularized trace functional `ε ↦ Re Tr(K† (A + ε)^s K (B + ε)^{1−s})`
+converges to its un-regularized value as `ε → 0⁺`, for `s, 1 − s > 0` and
+positive-semidefinite `A, B`.  The trace functional is continuous in its two matrix
+arguments and each regularized power converges by `tendsto_reg_rpow`. -/
+private lemma tendsto_reg_trace {s : ℝ} (hs0 : 0 < s) (hs1 : 0 < 1 - s) {K A B : Mat}
+    (hA : A.PosSemidef) (hB : B.PosSemidef) :
+    Tendsto
+      (fun ε : ℝ => (trace (Kᴴ * (A + ε • (1:Mat)) ^ s * K * (B + ε • (1:Mat)) ^ (1 - s))).re)
+      (𝓝[>] 0)
+      (𝓝 (trace (Kᴴ * A ^ s * K * B ^ (1 - s))).re) := by
+  have hg : Continuous (fun p : Mat × Mat => (trace (Kᴴ * p.1 * K * p.2)).re) := by
+    have hmul : Continuous (fun p : Mat × Mat => Kᴴ * p.1 * K * p.2) := by fun_prop
+    exact Complex.continuous_re.comp hmul.matrix_trace
+  have hprod : Tendsto
+      (fun ε : ℝ => ((A + ε • (1:Mat)) ^ s, (B + ε • (1:Mat)) ^ (1 - s)))
+      (𝓝[>] 0) (𝓝 (A ^ s, B ^ (1 - s))) :=
+    (tendsto_reg_rpow hs0 hA).prodMk_nhds (tendsto_reg_rpow hs1 hB)
+  change Tendsto ((fun p : Mat × Mat => (trace (Kᴴ * p.1 * K * p.2)).re) ∘
+      (fun ε : ℝ => ((A + ε • (1:Mat)) ^ s, (B + ε • (1:Mat)) ^ (1 - s)))) _ _
+  exact (hg.tendsto (A ^ s, B ^ (1 - s))).comp hprod
+
+/-- **Lieb concavity theorem for positive-semidefinite inputs** (Lieb 1973, Ando 1979;
+Wolf Theorem 5.15 on the boundary line `x + y = 1`).
+
+For `s ∈ [0, 1]`, any matrix `K`, and positive-*semidefinite* matrices `A₁, A₂, B₁, B₂`,
+the map `(A, B) ↦ Re Tr(K† A^s K B^{1−s})` is jointly concave.  This lifts the
+positive-definiteness restriction of `lieb_concavity_axiom`: it is the full Ando–Lieb
+theorem (Wolf Thm 5.15) on the boundary line `x + y = 1`, with `x = s`, `y = 1 − s`.
+
+The interior case `s ∈ (0, 1)` follows from `lieb_concavity_axiom` by regularization.
+For `ε > 0` each input is replaced by the positive-definite matrix `Aᵢ + ε • 1`; the
+positive-definite inequality holds for every `ε`, and the limit `ε → 0⁺` recovers the
+semidefinite statement because `x ↦ x^s` is continuous at `0` for `s ∈ (0, 1)`, so each
+regularized power converges in norm.  The endpoints `s = 0` and `s = 1` are linear in
+the varying argument and hold with equality.
+
+The sole remaining restriction relative to Wolf Thm 5.15 is the boundary line
+`x + y = 1`; the general region `x + y ≤ 1` is documented in
+`docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`.
+
+References:
+* Lieb, *Convex trace functions*, Adv. Math. 11, 1973
+* Ando, *Concavity of certain maps on positive definite matrices*, 1979 -/
+theorem lieb_concavity_psd
+    {s : ℝ} (hs : s ∈ Set.Icc (0 : ℝ) 1)
+    {A₁ A₂ B₁ B₂ K : Mat}
+    (hA₁ : A₁.PosSemidef) (hA₂ : A₂.PosSemidef)
+    (hB₁ : B₁.PosSemidef) (hB₂ : B₂.PosSemidef)
+    {t : ℝ} (ht : t ∈ Set.Icc (0 : ℝ) 1) :
+    t * (trace (Kᴴ * A₁ ^ s * K * B₁ ^ (1 - s))).re +
+      (1 - t) * (trace (Kᴴ * A₂ ^ s * K * B₂ ^ (1 - s))).re ≤
+    (trace (Kᴴ * (t • A₁ + (1 - t) • A₂) ^ s * K *
+      (t • B₁ + (1 - t) • B₂) ^ (1 - s))).re := by
+  classical
+  obtain ⟨ht0, ht1⟩ := ht
+  have ht1' : (0 : ℝ) ≤ 1 - t := by linarith
+  set Aθ := t • A₁ + (1 - t) • A₂ with hAθ
+  set Bθ := t • B₁ + (1 - t) • B₂ with hBθ
+  have hAθ' : Aθ.PosSemidef := (hA₁.smul ht0).add (hA₂.smul ht1')
+  have hBθ' : Bθ.PosSemidef := (hB₁.smul ht0).add (hB₂.smul ht1')
+  rcases lt_or_eq_of_le hs.1 with hs0 | hs0
+  · rcases lt_or_eq_of_le hs.2 with hs1 | hs1
+    · -- Interior case `s ∈ (0, 1)`: regularize to positive definite and take `ε → 0⁺`.
+      have hs1' : (0 : ℝ) < 1 - s := by linarith
+      have havgA : ∀ ε : ℝ,
+          t • (A₁ + ε • (1 : Mat)) + (1 - t) • (A₂ + ε • (1 : Mat)) = Aθ + ε • (1 : Mat) := by
+        intro ε; rw [hAθ]; module
+      have havgB : ∀ ε : ℝ,
+          t • (B₁ + ε • (1 : Mat)) + (1 - t) • (B₂ + ε • (1 : Mat)) = Bθ + ε • (1 : Mat) := by
+        intro ε; rw [hBθ]; module
+      have hineq : ∀ᶠ ε : ℝ in 𝓝[>] 0,
+          t * (trace (Kᴴ * (A₁ + ε • (1:Mat)) ^ s * K * (B₁ + ε • (1:Mat)) ^ (1-s))).re +
+            (1 - t) *
+              (trace (Kᴴ * (A₂ + ε • (1:Mat)) ^ s * K * (B₂ + ε • (1:Mat)) ^ (1-s))).re ≤
+          (trace (Kᴴ * (Aθ + ε • (1:Mat)) ^ s * K * (Bθ + ε • (1:Mat)) ^ (1-s))).re := by
+        filter_upwards [self_mem_nhdsWithin] with ε hε
+        have hone : ((ε : ℝ) • (1 : Mat)).PosDef := Matrix.PosDef.one.smul hε
+        have hpd :=
+          lieb_concavity_axiom (s := s) hs (A₁ := A₁ + ε • (1:Mat))
+            (A₂ := A₂ + ε • (1:Mat)) (B₁ := B₁ + ε • (1:Mat)) (B₂ := B₂ + ε • (1:Mat)) (K := K)
+            (Matrix.PosDef.posSemidef_add hA₁ hone) (Matrix.PosDef.posSemidef_add hA₂ hone)
+            (Matrix.PosDef.posSemidef_add hB₁ hone) (Matrix.PosDef.posSemidef_add hB₂ hone)
+            (t := t) ⟨ht0, ht1⟩
+        rwa [havgA ε, havgB ε] at hpd
+      have hcvgL : Tendsto
+          (fun ε : ℝ =>
+            t * (trace (Kᴴ * (A₁ + ε • (1:Mat)) ^ s * K * (B₁ + ε • (1:Mat)) ^ (1-s))).re +
+              (1 - t) *
+                (trace (Kᴴ * (A₂ + ε • (1:Mat)) ^ s * K * (B₂ + ε • (1:Mat)) ^ (1-s))).re)
+          (𝓝[>] 0)
+          (𝓝 (t * (trace (Kᴴ * A₁ ^ s * K * B₁ ^ (1 - s))).re +
+            (1 - t) * (trace (Kᴴ * A₂ ^ s * K * B₂ ^ (1 - s))).re)) :=
+        ((tendsto_reg_trace hs0 hs1' hA₁ hB₁).const_mul t).add
+          ((tendsto_reg_trace hs0 hs1' hA₂ hB₂).const_mul (1 - t))
+      have hcvgR := tendsto_reg_trace (K := K) hs0 hs1' hAθ' hBθ'
+      exact le_of_tendsto_of_tendsto hcvgL hcvgR hineq
+    · -- Endpoint `s = 1`.
+      subst hs1
+      simp only [CFC.rpow_one _ hA₁.nonneg, CFC.rpow_one _ hA₂.nonneg,
+        CFC.rpow_one _ hAθ'.nonneg, sub_self, CFC.rpow_zero _ hB₁.nonneg,
+        CFC.rpow_zero _ hB₂.nonneg, CFC.rpow_zero _ hBθ'.nonneg, Matrix.mul_one]
+      have hlin : Kᴴ * Aθ * K = t • (Kᴴ * A₁ * K) + (1 - t) • (Kᴴ * A₂ * K) := by
+        rw [hAθ]; simp only [Matrix.mul_add, Matrix.add_mul, Matrix.mul_smul, Matrix.smul_mul]
+      rw [hlin, Matrix.trace_add, Matrix.trace_smul, Matrix.trace_smul,
+        Complex.add_re, Complex.real_smul, Complex.real_smul, Complex.mul_re, Complex.mul_re,
+        Complex.ofReal_re, Complex.ofReal_im, zero_mul, sub_zero, Complex.ofReal_re,
+        Complex.ofReal_im, zero_mul, sub_zero]
+  · -- Endpoint `s = 0`.
+    subst hs0
+    simp only [CFC.rpow_zero _ hA₁.nonneg, CFC.rpow_zero _ hA₂.nonneg,
+      CFC.rpow_zero _ hAθ'.nonneg, sub_zero, CFC.rpow_one _ hB₁.nonneg,
+      CFC.rpow_one _ hB₂.nonneg, CFC.rpow_one _ hBθ'.nonneg, Matrix.mul_one]
+    have hlin : Kᴴ * K * Bθ = t • (Kᴴ * K * B₁) + (1 - t) • (Kᴴ * K * B₂) := by
+      rw [hBθ]; simp only [Matrix.mul_add, Matrix.mul_smul]
+    rw [hlin, Matrix.trace_add, Matrix.trace_smul, Matrix.trace_smul,
+      Complex.add_re, Complex.real_smul, Complex.real_smul, Complex.mul_re, Complex.mul_re,
+      Complex.ofReal_re, Complex.ofReal_im, zero_mul, sub_zero, Complex.ofReal_re,
+      Complex.ofReal_im, zero_mul, sub_zero]
+
 end Lieb
 
 end

--- a/blueprint/src/chapter/ch18_operator_convexity.tex
+++ b/blueprint/src/chapter/ch18_operator_convexity.tex
@@ -692,6 +692,39 @@ of $A^s B^{1-s}$.
     function of the convex-combination argument, hence hold with equality.
 \end{proof}
 
+\begin{theorem}[Lieb concavity, positive-semidefinite inputs]
+    \label{thm:lieb_concavity_psd}
+    \lean{lieb_concavity_psd}
+    \leanok
+    \uses{thm:lieb_concavity_axiom}
+    For $s\in[0,1]$, any matrix~$K$, and positive-\emph{semidefinite} matrices
+    $A_1,A_2,B_1,B_2$, the map
+    $(A,B)\mapsto\Re\tr(K^\dagger A^s K B^{1-s})$
+    is jointly concave, satisfying the
+    inequality~(\ref{eq:opconv_lieb_joint_concavity}) of
+    Theorem~\ref{thm:lieb_concavity_axiom}.
+    This is the full Ando--Lieb theorem
+    \cite[Theorem~5.15]{Wolf2012Quantum} on the boundary line $x+y=1$
+    (with $x=s$, $y=1-s$): the positive-definiteness restriction of
+    Theorem~\ref{thm:lieb_concavity_axiom} is lifted. The only remaining
+    restriction relative to Theorem~5.15 is the boundary line $x+y=1$; the
+    general region $x+y\le 1$ remains open.
+    % General-region gap in docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:lieb_concavity_axiom}
+    For the interior exponents $s\in(0,1)$, replace each input $A_i$ by the
+    positive-definite matrix $A_i+\varepsilon\Id$, and likewise for the $B_i$.
+    Theorem~\ref{thm:lieb_concavity_axiom} applies to these positive-definite
+    matrices for every $\varepsilon>0$, and the average of the regularized
+    inputs is the regularization of the average. Letting $\varepsilon\to 0^+$,
+    each regularized power $(A_i+\varepsilon\Id)^s$ converges to $A_i^s$, since
+    $x\mapsto x^s$ is continuous on the nonnegative reals for $0<s<1$, including
+    at the origin; the trace functional is continuous, so the regularized
+    inequality passes to the limit. The endpoints $s=0$ and $s=1$ are linear in
+    the convex-combination argument and hold with equality.
+\end{proof}
+
 \begin{theorem}[Map form of Lieb concavity]\label{thm:lieb_concavity}
     \lean{lieb_concavity}
     \leanok

--- a/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
+++ b/docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex
@@ -196,7 +196,7 @@ positive-map operator Jensen step applied to the convex integrand.
 The integral representation of the power integrand, previously named as the
 obstruction, is present.
 
-\section{The Lieb concavity theorem (scope-restricted)}\label{sec:lieb}
+\section{The Lieb concavity theorem (boundary exponent)}\label{sec:lieb}
 
 \subsection{The assertion}
 
@@ -209,10 +209,13 @@ is jointly concave on pairs of positive-definite matrices.  This is the
 boundary-exponent specialization of the Lieb concavity theorem
 (\cite[Theorem~5.15, the Ando--Lieb functional]{Wolf2012Quantum}), the trace
 functional underlying the Wigner--Yanase--Dyson conjecture.  It is now
-\emph{proved} in this scope --- \leanid{lieb_concavity_axiom} is a theorem,
+\emph{proved} --- \leanid{lieb_concavity_axiom} is a theorem,
 derived from the commuting-superoperator integral representation
-(\S\ref{ssec:lieb-gap}) --- and the two scope restrictions below record how it
-differs from the unrestricted source theorem.
+(\S\ref{ssec:lieb-gap}) --- and \leanid{lieb_concavity_psd} extends it to
+positive-semidefinite inputs by regularization.  The two paragraphs below record
+how the formalization now relates to the unrestricted source theorem: the
+positive-semidefinite restriction is resolved, and only the boundary-exponent
+restriction $x+y=1$ remains.
 
 \paragraph{Scope restriction (boundary exponent).}  Wolf's Theorem~5.15 is
 stated for two exponents $x,y\ge 0$ with $x+y\le 1$.  The formal theorem
@@ -222,19 +225,21 @@ corollaries, but it is not the full source theorem; the sub-boundary range
 $x+y<1$ remains unformalized unless it is derived separately or the theorem is
 generalized.
 
-\paragraph{Scope restriction (positive-definite versus positive
-semidefinite).}  Wolf's Theorem~5.15 states the Ando--Lieb concavity for
-positive (semidefinite) operators, including singular ones.  The formal theorem
-\leanid{lieb_concavity_axiom} is stated only for positive-\emph{definite} $A,B$
-(its hypotheses are \leanid{Matrix.PosDef}), so it does not yet cover singular
-positive inputs on which the source theorem still applies.  This is a scope
-restriction, not an unfaithful statement: the powers $A^s$ and $B^{1-s}$ and the
-resolvent factors $(L_A+tR_B)^{-1}$ used in the elimination route
-(\S\ref{ssec:lieb-gap}) are most directly defined for invertible $A,B$, and the
-positive-definite case extends to the positive-semidefinite case by continuity.
-The unrestricted source theorem remains unformalized until the theorem is
-extended to positive semidefinite $A,B$; this is recorded here so the
-restriction is auditable.
+\paragraph{Positive-definite versus positive semidefinite (resolved).}  Wolf's
+Theorem~5.15 states the Ando--Lieb concavity for positive (semidefinite)
+operators, including singular ones.  The first formalization
+\leanid{lieb_concavity_axiom} was stated only for positive-\emph{definite}
+$A,B$ (its hypotheses are \leanid{Matrix.PosDef}).  The positive-semidefinite
+case is now also proved, as \leanid{lieb_concavity_psd}, with hypotheses
+\leanid{Matrix.PosSemidef} on $A_1,A_2,B_1,B_2$.  The proof is by
+regularization: each input is replaced by $A_i+\varepsilon\Id$ (positive
+definite for $\varepsilon>0$), the positive-definite theorem is applied for
+every $\varepsilon>0$, and the limit $\varepsilon\to 0^+$ recovers the
+semidefinite inequality.  The regularized powers converge because $x\mapsto x^s$
+is continuous on the nonnegative reals for $0<s<1$, including at the origin ---
+the logarithmic singularity that obstructs the entropy-continuity route does not
+arise here --- and the trace functional is continuous.  This scope restriction
+is therefore eliminated; only the boundary-exponent restriction below remains.
 
 \subsection{The point at issue}\label{ssec:lieb-gap}
 
@@ -281,11 +286,14 @@ $(L_A+tR_B)^{-1}$.  Both were formalized over a sequence of steps --- the scalar
 boundary integral, the operator integral representation on the Kronecker model,
 the concavity of the resolvent integrand, and the resulting operator concavity ---
 and \leanid{lieb_concavity_axiom} is now a theorem in its positive-definite,
-boundary-exponent scope.  Three downstream corollaries build on it (the
-$K=\mathbf 1$ case and separate concavity in each argument); these are now
-axiom-free.  The remaining open generalizations are the two scope extensions
-recorded above: the sub-boundary range $x+y<1$ and singular (positive
-semidefinite) inputs.
+boundary-exponent scope.  The positive-semidefinite case is also proved, as
+\leanid{lieb_concavity_psd}, by regularizing each input to positive definite and
+passing to the limit; this is the full Ando--Lieb theorem on the boundary line
+$x+y=1$.  Three downstream corollaries build on the positive-definite version
+(the $K=\mathbf 1$ case and separate concavity in each argument); these are now
+axiom-free.  The sole remaining open generalization is the sub-boundary range
+$x+y<1$; the singular (positive-semidefinite) input restriction has been
+eliminated.
 
 \section*{References}
 


### PR DESCRIPTION
## Summary

Generalizes the just-proved Lieb concavity theorem from positive-**definite** to
positive-**semidefinite** inputs, making it the full Ando–Lieb theorem (Wolf
Thm 5.15) on the boundary line `x + y = 1` (with `x = s`, `y = 1 - s`).

New theorem `lieb_concavity_psd` in `TNLean/Axioms/OperatorConvexity.lean`, placed
right after `lieb_concavity_axiom` (which is kept unchanged). Same conclusion, with
`Matrix.PosSemidef` hypotheses on `A₁ A₂ B₁ B₂` (arbitrary `K`, `s, t ∈ [0,1]`).

## Proof route — regularization

For PSD `A`, set `Aε := A + ε•1` (positive definite for `ε > 0` via
`Matrix.PosDef.posSemidef_add`). Apply `lieb_concavity_axiom` to the regularized
positive-definite inputs for each `ε > 0`, then take `ε → 0⁺` over the filter
`𝓝[>] 0`:

- `Aε^s → A^s`: both `Aε` and `A` are PSD; `· ^ s` is continuous on the PSD cone
  for `s > 0`. Established via Mathlib `CFC.continuousOn_nnrpow` (on `{a | 0 ≤ a}`)
  composed with `CFC.nnrpow_eq_rpow` to relate `nnrpow` to the file's real `rpow`.
  (Note: Mathlib's `CFC.continuousOn_rpow` is only on the strictly-positive cone, so
  the `nnrpow` route is used to reach the full PSD cone.)
- The averaged term `t•A₁ε + (1-t)•A₂ε = (t•A₁+(1-t)•A₂) + ε•1`, so it is the
  regularization of the average and its power converges likewise.
- The trace functional `Re Tr(K† X K Y)` is continuous in `(X, Y)`, so each of the
  three trace terms converges; the per-`ε` inequality passes to the limit with
  `le_of_tendsto_of_tendsto`.

The log-singularity that blocks the SSA continuity route does not occur here because
`x ↦ x^s` for `s ∈ (0,1)` is continuous at `0`. Endpoints `s ∈ {0,1}` are linear and
handled directly (PSD-compatible, reusing the `lieb_concavity_axiom` endpoint scheme).

Three private helper lemmas are added: `continuousOn_rpow_psd`, `tendsto_reg_rpow`,
`tendsto_reg_trace`.

## Blueprint and paper-gap

- `blueprint/src/chapter/ch18_operator_convexity.tex`: new `thm:lieb_concavity_psd`
  entry (`\lean{lieb_concavity_psd}`, `\leanok`, `\uses{thm:lieb_concavity_axiom}`),
  stating the PSD case and noting it lifts the positive-definiteness restriction.
- `docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`: the positive-definite-vs-
  semidefinite scope restriction is now marked **resolved** (PSD proved by
  regularization). The boundary-exponent restriction (`x + y = 1` vs the general
  `x + y ≤ 1`) remains the sole open generalization; the verdict is updated.

## Verification

- `lake env lean TNLean/Axioms/OperatorConvexity.lean`: exit 0, no errors/sorry.
- `lake build TNLean.Axioms.OperatorConvexity`: `Build completed successfully (3045 jobs)`.
- `#print axioms lieb_concavity_psd` → `[propext, Classical.choice, Quot.sound]`
  (the three standard axioms; no `sorry`, no sanctioned axiom).
- All new Lean lines ≤ 100 code points (verified with python `len()`).
- Blueprint prose checker: no violations. `blueprint_lean_sync.py --ci`: in sync.

`lieb_concavity_axiom` left unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New limit/continuity lemmas on matrix powers and trace functionals extend a central inequality; mistakes would affect downstream Lieb corollaries, but the route is localized and reuses the existing positive-definite theorem.
> 
> **Overview**
> Adds **`lieb_concavity_psd`**, the same joint concavity inequality as `lieb_concavity_axiom` but with **`Matrix.PosSemidef`** on `A₁,A₂,B₁,B₂` instead of positive definite.
> 
> For **`s ∈ (0,1)`**, inputs are regularized as **`A + ε•1`** (and the same for `B`), **`lieb_concavity_axiom`** is applied for each **`ε > 0`**, and the inequality is passed to **`ε → 0⁺`** using new helpers: PSD-cone continuity of **`·^s`** via **`CFC.continuousOn_nnrpow`**, **`tendsto_reg_rpow`**, and **`tendsto_reg_trace`**. Endpoints **`s ∈ {0,1}`** are handled directly like the existing axiom proof.
> 
> Blueprint **ch18** gets **`thm:lieb_concavity_psd`**; **`docs/paper-gaps/wolf_ch5_operator_jensen_lieb.tex`** marks the PSD-vs-PD scope gap **resolved** and leaves only the **`x + y = 1`** (vs general **`x + y ≤ 1`**) generalization open. **`lieb_concavity_axiom`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db542e5f1641a4007ca86527bff9359ca2bb0d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->