### PR TITLE
feat(Algebra): unitary intertwiner between same-type irreducible pieces (toward Wolf Thm 6.14 spatial realization)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -45,6 +45,7 @@ import TNLean.Algebra.StarSubalgebraIsotypicDecomp
 import TNLean.Algebra.StarSubalgebraSchur
 import TNLean.Algebra.StarSubalgebraSemisimple
 import TNLean.Algebra.StarSubalgebraSpatial
+import TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
 
 -- Layer 0b: General analysis
 import TNLean.Analysis.ProjectionGeometry

--- a/TNLean/Algebra/StarSubalgebraIsotypic.lean
+++ b/TNLean/Algebra/StarSubalgebraIsotypic.lean
@@ -77,7 +77,7 @@ def SameIsotype (p q : Submodule ℂ (EuclideanSpace ℂ n)) : Prop :=
 
 omit [Fintype n] [DecidableEq n] in
 /-- If the image of `p` under `f` is a nonzero subspace, then `f` is not zero on `p`. -/
-private theorem not_forall_apply_eq_zero_of_map_ne_bot
+theorem not_forall_apply_eq_zero_of_map_ne_bot
     {p : Submodule ℂ (EuclideanSpace ℂ n)} {f : Module.End ℂ (EuclideanSpace ℂ n)}
     (hne : Submodule.map f p ≠ ⊥) : ¬ ∀ x ∈ p, f x = 0 := by
   intro hzero

--- a/TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean
+++ b/TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean
@@ -33,12 +33,12 @@ namespace StarSubalgebra
 variable {n : Type*} [Fintype n] [DecidableEq n]
 variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
 
-/-- For two irreducible pieces `p` and `q` of a star-subalgebra `S` of complex matrices that
-are of the same type, there is an operator `u` that is an intertwiner from `p` into `q`, maps
-`p` onto `q`, and preserves the inner product on `p`: for all `x` and `y` in `p`,
+/-- For two irreducible pieces $p$ and $q$ of a star-subalgebra $S$ of complex matrices that
+are of the same type, there is an operator $u$ that is an intertwiner from $p$ into $q$, maps
+$p$ onto $q$, and preserves the inner product on $p$: for all $x, y \in p$,
 $$\langle u(x), u(y)\rangle = \langle x, y\rangle .$$
-Same type gives an intertwiner injective on `p` with image `q`; since `q` is nonzero it does
-not vanish on `p`, so the scaled inner-product identity gives a positive real factor $c$ with
+Same type gives an intertwiner injective on $p$ with image $q$; since $q$ is nonzero it does
+not vanish on $p$, so the scaled inner-product identity gives a positive real factor $c$ with
 $\langle f(x), f(y)\rangle = c\,\langle x, y\rangle$. Dividing the intertwiner by $\sqrt{c}$
 keeps the commuting identity and the image and turns the factor into one,
 $$\langle u(x), u(y)\rangle = \tfrac{1}{c}\,\langle f(x), f(y)\rangle = \langle x, y\rangle .$$
@@ -51,14 +51,7 @@ theorem exists_isometry_intertwiner_of_sameIsotype
   -- Same type gives an intertwiner `f` injective on `p` with image exactly `q`.
   obtain ⟨f, hf, _, hfeq⟩ := (S.sameIsotype_iff_exists_isomorphism hp hq).mp h
   -- Since `q` is nonzero, `f` does not vanish on `p`, giving a positive inner-product factor.
-  have hne : ¬ ∀ x ∈ p, f x = 0 := by
-    intro hzero
-    refine hq.2.1 (eq_bot_iff.mpr ?_)
-    rw [← hfeq]
-    rintro y hy
-    obtain ⟨x, hx, rfl⟩ := Submodule.mem_map.mp hy
-    rw [hzero x hx]
-    exact Submodule.zero_mem _
+  have hne : ¬ ∀ x ∈ p, f x = 0 := not_forall_apply_eq_zero_of_map_ne_bot (hfeq ▸ hq.2.1)
   obtain ⟨c, hcpos, hceq⟩ := S.exists_pos_smul_inner_of_intertwiner_ne_zero hp hf hne
   -- The normalizing real scalar `s = 1 / √c`, nonzero since `c > 0`.
   set s : ℝ := (Real.sqrt c)⁻¹ with hs
@@ -75,7 +68,7 @@ theorem exists_isometry_intertwiner_of_sameIsotype
     rw [LinearMap.smul_apply, LinearMap.smul_apply, hf.2 A hA x hx, map_smul]
   · -- `u` maps `p` onto `q`, again by the scaling-invariance of the image.
     rw [Submodule.map_smul f p (s : ℂ) hs_ne, hfeq]
-  · -- `u` preserves the inner product: the factor `s² c` equals one.
+  · -- `u` preserves the inner product: the factor s² c equals one.
     intro x hx y hy
     rw [LinearMap.smul_apply, LinearMap.smul_apply, inner_smul_left, inner_smul_right,
       Complex.conj_ofReal, hceq x hx y hy]
@@ -90,3 +83,4 @@ theorem exists_isometry_intertwiner_of_sameIsotype
     simp
 
 end StarSubalgebra
+

--- a/TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean
+++ b/TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.StarSubalgebraIntertwinerIsometry
+
+/-!
+# Same-type irreducible pieces are unitarily identified
+
+Continuing the structure theory of *Quantum Channels & Operations* (Wolf 2012), Chapter 6,
+towards Theorem 6.14, this file produces, for two irreducible pieces of a star-subalgebra of
+complex matrices that are of the same type, an intertwiner that is an isometry of the first
+piece onto the second. Such an operator commutes on the source with every member of the
+subalgebra, maps the source onto the target, and preserves the inner product on the source, so
+it is a unitary identification of the two pieces.
+
+## Proof outline
+
+Same type gives an intertwiner that is injective on the source and maps it onto the target.
+Since the target is nonzero, the intertwiner does not vanish on the source, so the scaled
+inner-product identity for nonvanishing intertwiners gives a positive real factor `c` with
+`⟪f x, f y⟫ = c ⟪x, y⟫` on the source. Normalizing the intertwiner by `1 / √c` keeps the
+commuting identity, keeps the image (scaling by a nonzero scalar preserves the image
+subspace), and turns the inner-product factor into one, making the normalized operator an
+isometry of the source onto the target.
+-/
+
+open scoped Matrix InnerProductSpace ComplexConjugate
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+/-- For two irreducible pieces `p` and `q` of a star-subalgebra `S` of complex matrices that
+are of the same type, there is an operator `u` that is an intertwiner from `p` into `q`, maps
+`p` onto `q`, and preserves the inner product on `p`: for all `x` and `y` in `p`,
+$$\langle u(x), u(y)\rangle = \langle x, y\rangle .$$
+Same type gives an intertwiner injective on `p` with image `q`; since `q` is nonzero it does
+not vanish on `p`, so the scaled inner-product identity gives a positive real factor `c` with
+$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle$, and dividing the intertwiner by
+$\sqrt{c}$ keeps the commuting identity and the image while turning the factor into one. See
+*Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
+theorem exists_isometry_intertwiner_of_sameIsotype
+    {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)
+    (hq : S.IsIrreducibleSubspace q) (h : S.SameIsotype p q) :
+    ∃ u : Module.End ℂ (EuclideanSpace ℂ n), S.IsIntertwiner p q u ∧
+      Submodule.map u p = q ∧ ∀ x ∈ p, ∀ y ∈ p, ⟪u x, u y⟫_ℂ = ⟪x, y⟫_ℂ := by
+  -- Same type gives an intertwiner `f` injective on `p` with image exactly `q`.
+  obtain ⟨f, hf, _, hfeq⟩ := (S.sameIsotype_iff_exists_isomorphism hp hq).mp h
+  -- Since `q` is nonzero, `f` does not vanish on `p`, giving a positive inner-product factor.
+  have hne : ¬ ∀ x ∈ p, f x = 0 := by
+    intro hzero
+    refine hq.2.1 (eq_bot_iff.mpr ?_)
+    rw [← hfeq]
+    rintro y hy
+    obtain ⟨x, hx, rfl⟩ := Submodule.mem_map.mp hy
+    rw [hzero x hx]
+    exact Submodule.zero_mem _
+  obtain ⟨c, hcpos, hceq⟩ := S.exists_pos_smul_inner_of_intertwiner_ne_zero hp hf hne
+  -- The normalizing real scalar `s = 1 / √c`, nonzero since `c > 0`.
+  set s : ℝ := (Real.sqrt c)⁻¹ with hs
+  have hsqrt_pos : 0 < Real.sqrt c := Real.sqrt_pos.mpr hcpos
+  have hs_ne : (s : ℂ) ≠ 0 := by
+    rw [hs]; exact_mod_cast inv_ne_zero (ne_of_gt hsqrt_pos)
+  -- The normalized operator `u = s • f`.
+  refine ⟨(s : ℂ) • f, ⟨?_, ?_⟩, ?_, ?_⟩
+  · -- `u` carries `p` into `q`, since scaling by a nonzero scalar preserves the image.
+    rw [Submodule.map_smul f p (s : ℂ) hs_ne, hfeq]
+  · -- `u` commutes on `p` with every member: scaling commutes with the linear matrix action.
+    intro A hA x hx
+    rw [LinearMap.smul_apply, LinearMap.smul_apply, hf.2 A hA x hx, map_smul]
+  · -- `u` maps `p` onto `q`, again by the scaling-invariance of the image.
+    rw [Submodule.map_smul f p (s : ℂ) hs_ne, hfeq]
+  · -- `u` preserves the inner product: the factor `s² c` equals one.
+    intro x hx y hy
+    rw [LinearMap.smul_apply, LinearMap.smul_apply, inner_smul_left, inner_smul_right,
+      Complex.conj_ofReal, hceq x hx y hy]
+    have hsc : (s : ℝ) * (s * c) = 1 := by
+      have hsqrt : Real.sqrt c * Real.sqrt c = c := Real.mul_self_sqrt hcpos.le
+      rw [hs]
+      field_simp
+      linarith [hsqrt]
+    have : (s : ℂ) * ((s : ℂ) * ((c : ℂ) * ⟪x, y⟫_ℂ)) =
+        (((s * (s * c) : ℝ)) : ℂ) * ⟪x, y⟫_ℂ := by push_cast; ring
+    rw [this, hsc]
+    simp
+
+end StarSubalgebra

--- a/TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean
+++ b/TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean
@@ -66,7 +66,8 @@ theorem exists_isometry_intertwiner_of_sameIsotype
   -- The normalized operator `u = s • f`.
   refine ⟨(s : ℂ) • f, ⟨?_, ?_⟩, ?_, ?_⟩
   · -- `u` carries `p` into `q`, since scaling by a nonzero scalar preserves the image.
-    rw [Submodule.map_smul f p (s : ℂ) hs_ne, hfeq]
+    rw [Submodule.map_smul f p (s : ℂ) hs_ne]
+    exact hfeq.le
   · -- `u` commutes on `p` with every member: scaling commutes with the linear matrix action.
     intro A hA x hx
     rw [LinearMap.smul_apply, LinearMap.smul_apply, hf.2 A hA x hx, map_smul]

--- a/TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean
+++ b/TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean
@@ -18,11 +18,12 @@ it is a unitary identification of the two pieces.
 
 Same type gives an intertwiner that is injective on the source and maps it onto the target.
 Since the target is nonzero, the intertwiner does not vanish on the source, so the scaled
-inner-product identity for nonvanishing intertwiners gives a positive real factor `c` with
-`⟪f x, f y⟫ = c ⟪x, y⟫` on the source. Normalizing the intertwiner by `1 / √c` keeps the
-commuting identity, keeps the image (scaling by a nonzero scalar preserves the image
-subspace), and turns the inner-product factor into one, making the normalized operator an
-isometry of the source onto the target.
+inner-product identity for nonvanishing intertwiners gives a positive real factor $c$ with
+$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle$ on the source. Normalizing the
+intertwiner to $u = f / \sqrt{c}$ keeps the commuting identity and the image (scaling by a
+nonzero scalar preserves the image subspace), and turns the factor into one,
+$$\langle u(x), u(y)\rangle = \tfrac{1}{c}\,\langle f(x), f(y)\rangle = \langle x, y\rangle,$$
+making the normalized operator an isometry of the source onto the target.
 -/
 
 open scoped Matrix InnerProductSpace ComplexConjugate
@@ -37,10 +38,11 @@ are of the same type, there is an operator `u` that is an intertwiner from `p` i
 `p` onto `q`, and preserves the inner product on `p`: for all `x` and `y` in `p`,
 $$\langle u(x), u(y)\rangle = \langle x, y\rangle .$$
 Same type gives an intertwiner injective on `p` with image `q`; since `q` is nonzero it does
-not vanish on `p`, so the scaled inner-product identity gives a positive real factor `c` with
-$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle$, and dividing the intertwiner by
-$\sqrt{c}$ keeps the commuting identity and the image while turning the factor into one. See
-*Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
+not vanish on `p`, so the scaled inner-product identity gives a positive real factor $c$ with
+$\langle f(x), f(y)\rangle = c\,\langle x, y\rangle$. Dividing the intertwiner by $\sqrt{c}$
+keeps the commuting identity and the image and turns the factor into one,
+$$\langle u(x), u(y)\rangle = \tfrac{1}{c}\,\langle f(x), f(y)\rangle = \langle x, y\rangle .$$
+See *Quantum Channels & Operations* (Wolf 2012), Chapter 6, towards Theorem 6.14. -/
 theorem exists_isometry_intertwiner_of_sameIsotype
     {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)
     (hq : S.IsIrreducibleSubspace q) (h : S.SameIsotype p q) :

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1438,6 +1438,32 @@ isomorphism into a partial isometry.
     vanish on $W$, since $W'$ is nonzero, so the two pieces are of the same type.
 \end{proof}
 
+\begin{lemma}[Same-type pieces are unitarily identified]%
+    \label{lem:starSubalgebra_sameIsotype_isometry}
+    \lean{StarSubalgebra.exists_isometry_intertwiner_of_sameIsotype}
+    \leanok
+    \uses{lem:starSubalgebra_sameIsotype_iso, lem:starSubalgebra_intertwiner_inner_scale_pos}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$ and let $W, W' \subseteq \C^{D}$ be irreducible
+    under $S$. If $W$ is of the same type as $W'$, then there is an intertwiner $u$ from $W$
+    into $W'$ that maps $W$ onto $W'$ and preserves the inner product on $W$: for all
+    $x, y \in W$,
+    \[
+        \langle u(x), u(y) \rangle = \langle x, y \rangle .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_sameIsotype_iso, lem:starSubalgebra_intertwiner_inner_scale_pos}
+    Same type gives, by Lemma~\ref{lem:starSubalgebra_sameIsotype_iso}, an intertwiner $f$ that
+    is injective on $W$ with image $W'$. Since $W'$ is nonzero, $f$ does not vanish on $W$, so
+    by Lemma~\ref{lem:starSubalgebra_intertwiner_inner_scale_pos} there is a real number
+    $c > 0$ with $\langle f(x), f(y) \rangle = c\,\langle x, y \rangle$ for all $x, y \in W$.
+    Set $u = f / \sqrt{c}$. Scaling by the nonzero factor $1 / \sqrt{c}$ keeps the commuting
+    identity and the image $W'$, and turns the inner-product factor into one, so $u$ maps $W$
+    onto $W'$ and is an isometry on $W$.
+\end{proof}
+
 \begin{lemma}[Reflexivity of the same-type relation]%
     \label{lem:starSubalgebra_sameIsotype_refl}
     \lean{StarSubalgebra.sameIsotype_refl}

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1460,8 +1460,11 @@ isomorphism into a partial isometry.
     by Lemma~\ref{lem:starSubalgebra_intertwiner_inner_scale_pos} there is a real number
     $c > 0$ with $\langle f(x), f(y) \rangle = c\,\langle x, y \rangle$ for all $x, y \in W$.
     Set $u = f / \sqrt{c}$. Scaling by the nonzero factor $1 / \sqrt{c}$ keeps the commuting
-    identity and the image $W'$, and turns the inner-product factor into one, so $u$ maps $W$
-    onto $W'$ and is an isometry on $W$.
+    identity and the image $W'$, and turns the inner-product factor into one,
+    \[
+        \langle u(x), u(y) \rangle = \tfrac{1}{c}\langle f(x), f(y) \rangle = \langle x, y \rangle,
+    \]
+    so $u$ maps $W$ onto $W'$ and is an isometry on $W$.
 \end{proof}
 
 \begin{lemma}[Reflexivity of the same-type relation]%


### PR DESCRIPTION
## What this proves

A new lemma in the Wolf-6.14 spatial chain: two same-type irreducible pieces of a
star-subalgebra of complex matrices admit an intertwiner that is an **isometry onto** the
target.

`StarSubalgebra.exists_isometry_intertwiner_of_sameIsotype` (in
`TNLean/Algebra/StarSubalgebraUnitaryIntertwiner.lean`):

```
theorem exists_isometry_intertwiner_of_sameIsotype
    {p q : Submodule ℂ (EuclideanSpace ℂ n)} (hp : S.IsIrreducibleSubspace p)
    (hq : S.IsIrreducibleSubspace q) (h : S.SameIsotype p q) :
    ∃ u : Module.End ℂ (EuclideanSpace ℂ n), S.IsIntertwiner p q u ∧
      Submodule.map u p = q ∧ ∀ x ∈ p, ∀ y ∈ p, ⟪u x, u y⟫_ℂ = ⟪x, y⟫_ℂ
```

The operator `u` is an `S`-intertwiner that maps `p` **onto** `q` (`Submodule.map u p = q`,
i.e. surjective onto `q`, not merely into it) and preserves the inner product on `p` (an
isometry). Together these give a unitary identification of `p` with `q`.

## Proof

From `sameIsotype_iff_exists_isomorphism` get an intertwiner `f` injective on `p` with image
`q`. Since `q ≠ ⊥` (irreducible), `f` does not vanish on `p`, so
`exists_pos_smul_inner_of_intertwiner_ne_zero` gives `c > 0` with `⟪f x, f y⟫ = c ⟪x, y⟫`.
Normalizing `u = (1 / √c) • f`:
- intertwiner: scaling by the real constant keeps the commuting identity and `map u p ≤ q`;
- onto: `Submodule.map (a • f) p = Submodule.map f p = q` for `a = 1/√c ≠ 0`;
- isometry: `⟪u x, u y⟫ = (1/c) ⟪f x, f y⟫ = ⟪x, y⟫` (real scalar, `Real.mul_self_sqrt`).

## Blueprint

Added lemma `lem:starSubalgebra_sameIsotype_isometry` to
`blueprint/src/chapter/ch07_spectral.tex` near the intertwiner-isometry entries, with
`\lean{}`, `\leanok` on statement and proof, and
`\uses{lem:starSubalgebra_sameIsotype_iso, lem:starSubalgebra_intertwiner_inner_scale_pos}`.

## Verification

- `lake build` -> `Build completed successfully (9254 jobs).` (no new errors; the `ᴴ`-token
  header-linter info lines are pre-existing in unrelated `Spectral/` files I did not touch).
- `git grep -nE "sorry|admit|axiom"` on the new file -> empty.
- `#print axioms StarSubalgebra.exists_isometry_intertwiner_of_sameIsotype` ->
  `[propext, Classical.choice, Quot.sound]`.
- `lake exe lint-style <file>` -> exit 0, no findings.
- `scripts/check_reader_facing_prose.py --diff-base origin/main` -> no violations.

Advances LionSR/QICLean#189 / LionSR/QICLean#186.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics in the star-subalgebra theory track; no runtime, auth, or data-path changes, only a small API visibility tweak plus a new lemma module.
> 
> **Overview**
> Adds **`StarSubalgebra.exists_isometry_intertwiner_of_sameIsotype`**, showing that two same-type irreducible invariant subspaces of a matrix star-subalgebra admit an **S-intertwiner** that maps the first **onto** the second and is an **isometry on the source**—a unitary identification of the two pieces in the Wolf Ch. 6 / Theorem 6.14 spatial chain.
> 
> The proof takes an isomorphism from `sameIsotype_iff_exists_isomorphism`, uses **`exists_pos_smul_inner_of_intertwiner_ne_zero`** to get a positive scaling factor for inner products, then sets **`u = (1/√c) • f`** so intertwiner and surjectivity are preserved while **`⟪u x, u y⟫ = ⟪x, y⟫`**. **`not_forall_apply_eq_zero_of_map_ne_bot`** is promoted from `private` to public so the new module can cite it.
> 
> The new module is wired into **`TNLean.lean`**, and blueprint **`lem:starSubalgebra_sameIsotype_isometry`** is added in **`ch07_spectral.tex`** with `\leanok` and the expected `\uses` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b7561468129be918fb24a93a97c66c1d2e4747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->