### PR TITLE
refactor(Analysis): extract cfc_conj_unitary to a low-level module

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -50,6 +50,8 @@ import TNLean.Algebra.StarSubalgebraSpatial
 import TNLean.Analysis.ProjectionGeometry
 -- Layer 0b: Trace of the Hermitian functional calculus (Mathlib-only matrix lemma)
 import TNLean.Analysis.TraceCFC
+import TNLean.Analysis.CfcConjugation
+import TNLean.Analysis.MatrixOrderTopology
 import TNLean.Analysis.CfcLogAdditive
 import TNLean.Analysis.CfcKronecker
 import TNLean.Analysis.MatrixTraceInequalities

--- a/TNLean/Analysis/CfcConjugation.lean
+++ b/TNLean/Analysis/CfcConjugation.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Matrix.HermitianFunctionalCalculus
+
+/-!
+# Covariance of the matrix continuous functional calculus under unitary conjugation
+
+This file records the single fact that, for a Hermitian matrix $A$, a real
+function $f$, and a unitary $U$, the continuous functional calculus satisfies
+$$f(U A U^\dagger) = U\,f(A)\,U^\dagger.$$
+This is the matrix instance of the general statement that a continuous
+star-algebra automorphism commutes with the continuous functional calculus,
+specialized to the conjugation automorphism $x \mapsto U x U^\dagger$.
+
+The result is purely a property of the functional calculus and unitary
+conjugation, with no quantum-information content. It is isolated in this
+low-level analysis module so that consumers such as the operator-monotone and
+operator-concave machinery can use it without pulling in the quantum
+relative-entropy stack.
+
+## Main results
+
+* `Matrix.cfc_conj_unitary` — covariance of the continuous functional calculus
+  under conjugation by a unitary: $f(U A U^\dagger) = U\,f(A)\,U^\dagger$.
+-/
+
+namespace Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- **Covariance of the continuous functional calculus under unitary
+conjugation.** For a Hermitian matrix $A$, a real function $f$, and a unitary
+$U$, the continuous functional calculus satisfies
+$f(U A U^\dagger) = U\,f(A)\,U^\dagger$.
+
+This is the matrix instance of the general fact that the continuous functional
+calculus commutes with the continuous star-algebra automorphism
+$x \mapsto U x U^\dagger$ (`Unitary.conjStarAlgAut`). -/
+theorem cfc_conj_unitary {A : Matrix n n ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ)
+    (U : unitary (Matrix n n ℂ)) :
+    cfc f ((U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ))
+      = (U : Matrix n n ℂ) * cfc f A * star (U : Matrix n n ℂ) := by
+  set φ := Unitary.conjStarAlgAut ℂ (Matrix n n ℂ) U with hφ
+  have hcont : ContinuousOn f (spectrum ℝ A) := A.finite_real_spectrum |>.continuousOn f
+  have hcontφ : Continuous φ :=
+    LinearMap.continuous_of_finiteDimensional ((φ : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ))
+  have hsa : IsSelfAdjoint A := hA
+  have happ : ∀ x, φ x = (U : Matrix n n ℂ) * x * star (U : Matrix n n ℂ) :=
+    fun x => Unitary.conjStarAlgAut_apply U x
+  have hsa' : IsSelfAdjoint (φ A) := by rw [happ]; exact hsa.conjugate (U : Matrix n n ℂ)
+  have hconj := StarAlgHomClass.map_cfc φ f A hcont hcontφ hsa hsa'
+  rw [happ, happ] at hconj
+  exact hconj.symm
+
+end Matrix

--- a/TNLean/Analysis/LiebOperatorIntegral.lean
+++ b/TNLean/Analysis/LiebOperatorIntegral.lean
@@ -3,9 +3,11 @@ Copyright (c) 2026 Sirui Lu and TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sirui Lu
 -/
+import TNLean.Analysis.CfcConjugation
 import TNLean.Analysis.LiebScalarIntegral
+import TNLean.Analysis.MatrixOrderTopology
 import TNLean.Analysis.TraceCFC
-import TNLean.Channel.Schwarz.RelativeEntropyUnitaryInvariance
+import Mathlib.Analysis.CStarAlgebra.Matrix
 import Mathlib.Analysis.SpecialFunctions.ContinuousFunctionalCalculus.Rpow.Basic
 import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 import Mathlib.MeasureTheory.SpecificCodomains.Pi

--- a/TNLean/Analysis/MatrixOrderTopology.lean
+++ b/TNLean/Analysis/MatrixOrderTopology.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2025 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import Mathlib.Analysis.Matrix.Order
+import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.Topology.Instances.Matrix
+import Mathlib.Topology.Order.OrderClosed
+
+/-!
+# Order-closedness of the Loewner order on finite matrices
+
+This file records that the Loewner (positive semidefinite) order on finite
+complex matrices is compatible with the matrix topology: the positive
+semidefinite cone is closed, the order graph $\{(X, Y) : X \le Y\}$ is closed,
+and consequently the order topology is closed (`OrderClosedTopology`).
+
+These are purely topological facts about the matrix order, with no quantum
+channel content. They are isolated in this low-level analysis module so that
+both the channel theory and the operator-monotone and operator-concave
+machinery (which integrate matrix-valued functions against the Loewner order)
+can use them without depending on one another.
+
+## Main results
+
+* `matrix_isClosed_posSemidef` — the positive semidefinite cone is closed.
+* `matrix_isClosed_le` — the Loewner order graph is closed.
+* `matrixOrderClosedTopology` — the Loewner order on finite matrices has a closed
+  order topology (`OrderClosedTopology`), registered as a scoped instance in the
+  `MatrixOrder` namespace.
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Matrix
+
+/-- The quadratic form `X ↦ star v ⬝ᵥ X.mulVec v` is continuous. -/
+private lemma continuous_quadraticForm {m : Type*} [Fintype m] (v : m → ℂ) :
+    Continuous (fun X : Matrix m m ℂ => star v ⬝ᵥ X.mulVec v) :=
+  Continuous.dotProduct continuous_const (Continuous.matrix_mulVec continuous_id continuous_const)
+
+/-- The positive semidefinite cone is closed for matrices over any finite index
+type. -/
+theorem matrix_isClosed_posSemidef {m : Type*} [Finite m] :
+    IsClosed {X : Matrix m m ℂ | X.PosSemidef} := by
+  classical
+  letI := Fintype.ofFinite m
+  have : {X : Matrix m m ℂ | X.PosSemidef}
+      = {X | X.IsHermitian} ∩
+        ⋂ (v : m → ℂ), {X | 0 ≤ star v ⬝ᵥ X.mulVec v} := by
+    ext X
+    simp only [Set.mem_setOf_eq, Set.mem_inter_iff, Set.mem_iInter,
+      Matrix.posSemidef_iff_dotProduct_mulVec]
+  rw [this]
+  exact (isClosed_eq continuous_star continuous_id).inter
+    (isClosed_iInter fun v =>
+      (isClosed_le continuous_const continuous_id).preimage (continuous_quadraticForm v))
+
+/-- The Loewner order graph is closed for matrices over any finite index type. -/
+theorem matrix_isClosed_le {m : Type*} [Finite m] :
+    IsClosed {p : Matrix m m ℂ × Matrix m m ℂ | p.1 ≤ p.2} := by
+  have hset :
+      {p : Matrix m m ℂ × Matrix m m ℂ | p.1 ≤ p.2}
+        = (fun p : Matrix m m ℂ × Matrix m m ℂ => p.2 - p.1) ⁻¹'
+          {X : Matrix m m ℂ | X.PosSemidef} := by
+    ext p
+    simp [Matrix.le_iff]
+  rw [hset]
+  exact matrix_isClosed_posSemidef.preimage (continuous_snd.sub continuous_fst)
+
+/-- The Loewner order on finite complex matrices has closed order topology. -/
+@[reducible]
+def matrixOrderClosedTopology {m : Type*} [Finite m] :
+    OrderClosedTopology (Matrix m m ℂ) where
+  isClosed_le' := matrix_isClosed_le
+
+scoped[MatrixOrder] attribute [instance] matrixOrderClosedTopology

--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2025 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Analysis.MatrixOrderTopology
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.Analysis.Matrix.Order
 import Mathlib.Analysis.Matrix.Spectrum
@@ -32,8 +33,7 @@ Chapters 3 and 6 of Wolf's lecture notes.
 * `Matrix.transposeLinearMapComplex_isTracePreservingMap`: matrix transposition is
   trace-preserving
 * `IsPositiveMap.map_isHermitian`: positive maps preserve Hermiticity
-* `matrix_isClosed_posSemidef`: the positive semidefinite cone is closed
-* `matrixOrderClosedTopology`: the Loewner order on finite matrices is order-closed
+* `isClosed_posSemidef`: the positive semidefinite cone is closed
 * `densityMatrices_isCompact`: the set of density matrices is compact
 * `densityMatrices_isConvex`: the set of density matrices is convex
 * `IsChannel.map_densityMatrices`: channels map density matrices to density matrices
@@ -171,11 +171,6 @@ def densityMatrices (D : ℕ) : Set (Matrix (Fin D) (Fin D) ℂ) :=
 @[simp] lemma mem_densityMatrices {ρ : Matrix (Fin D) (Fin D) ℂ} :
     ρ ∈ densityMatrices D ↔ ρ.PosSemidef ∧ trace ρ = 1 := Iff.rfl
 
-/-- The quadratic form `X ↦ star v ⬝ᵥ X.mulVec v` is continuous. -/
-private lemma continuous_quadraticForm {m : Type*} [Fintype m] (v : m → ℂ) :
-    Continuous (fun X : Matrix m m ℂ => star v ⬝ᵥ X.mulVec v) :=
-  Continuous.dotProduct continuous_const (Continuous.matrix_mulVec continuous_id continuous_const)
-
 /-! ### Auxiliary lemmas for boundedness -/
 
 /-- For PSD `X`, each diagonal entry norm is bounded by the trace norm. -/
@@ -265,51 +260,10 @@ theorem posSemidef_trace_bounded_isBounded (c : ℝ) :
           pow_le_pow_left₀ (norm_nonneg _) (hentry i j) 2
     _ = (↑D * c) ^ 2 := by simp [sum_const]; ring
 
-/-- The PSD cone is closed for matrices over any finite index type.
-
-Proof: `PosSemidef X ↔ X.IsHermitian ∧ ∀ v, 0 ≤ star v ⬝ᵥ X.mulVec v`.
-- `{X | X.IsHermitian}` is closed (continuous `conjTranspose`).
-- Each `{X | 0 ≤ star v ⬝ᵥ X.mulVec v}` is closed (preimage of closed
-  nonneg cone under continuous quadratic form). -/
-theorem matrix_isClosed_posSemidef {m : Type*} [Finite m] :
-    IsClosed {X : Matrix m m ℂ | X.PosSemidef} := by
-  classical
-  letI := Fintype.ofFinite m
-  have : {X : Matrix m m ℂ | X.PosSemidef}
-      = {X | X.IsHermitian} ∩
-        ⋂ (v : m → ℂ), {X | 0 ≤ star v ⬝ᵥ X.mulVec v} := by
-    ext X
-    simp only [Set.mem_setOf_eq, Set.mem_inter_iff, Set.mem_iInter,
-      Matrix.posSemidef_iff_dotProduct_mulVec]
-  rw [this]
-  exact (isClosed_eq continuous_star continuous_id).inter
-    (isClosed_iInter fun v =>
-      (isClosed_le continuous_const continuous_id).preimage (continuous_quadraticForm v))
-
 /-- The PSD cone is closed on `Fin D`-indexed matrices. -/
 theorem isClosed_posSemidef :
     IsClosed {X : Matrix (Fin D) (Fin D) ℂ | X.PosSemidef} :=
   matrix_isClosed_posSemidef
-
-/-- The Loewner order graph is closed for matrices over any finite index type. -/
-theorem matrix_isClosed_le {m : Type*} [Finite m] :
-    IsClosed {p : Matrix m m ℂ × Matrix m m ℂ | p.1 ≤ p.2} := by
-  have hset :
-      {p : Matrix m m ℂ × Matrix m m ℂ | p.1 ≤ p.2}
-        = (fun p : Matrix m m ℂ × Matrix m m ℂ => p.2 - p.1) ⁻¹'
-          {X : Matrix m m ℂ | X.PosSemidef} := by
-    ext p
-    simp [Matrix.le_iff]
-  rw [hset]
-  exact matrix_isClosed_posSemidef.preimage (continuous_snd.sub continuous_fst)
-
-/-- The Loewner order on finite complex matrices has closed order topology. -/
-@[reducible]
-def matrixOrderClosedTopology {m : Type*} [Finite m] :
-    OrderClosedTopology (Matrix m m ℂ) where
-  isClosed_le' := matrix_isClosed_le
-
-scoped[MatrixOrder] attribute [instance] matrixOrderClosedTopology
 
 /-- The set of density matrices is compact (Heine-Borel).
 

--- a/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
+++ b/TNLean/Channel/Schwarz/RelativeEntropyUnitaryInvariance.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.Analysis.CfcConjugation
 import TNLean.Analysis.KleinInequality
 
 /-!
@@ -19,10 +20,6 @@ convexity (layer 4, `convexOn_quantumRelativeEntropy`) and ancilla additivity.
 
 ## Main results
 
-* `Matrix.cfc_conj_unitary` — covariance of the continuous functional calculus
-  under conjugation by a unitary: $f(U A U^\dagger) = U\,f(A)\,U^\dagger$. This is
-  the matrix instance of the fact that the continuous functional calculus
-  commutes with the star-algebra automorphism $x \mapsto U x U^\dagger$.
 * `Matrix.log_conj_unitary` — the special case $f = \log$:
   $\log(U A U^\dagger) = U\,(\log A)\,U^\dagger$.
 * `quantumRelativeEntropy_conj_unitary` — unitary invariance of the relative
@@ -53,30 +50,6 @@ open scoped Matrix.Norms.L2Operator
 namespace Matrix
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
-
-/-- **Covariance of the continuous functional calculus under unitary
-conjugation.** For a Hermitian matrix $A$, a real function $f$, and a unitary
-$U$, the continuous functional calculus satisfies
-$f(U A U^\dagger) = U\,f(A)\,U^\dagger$.
-
-This is the matrix instance of the general fact that the continuous functional
-calculus commutes with the continuous star-algebra automorphism
-$x \mapsto U x U^\dagger$ (`Unitary.conjStarAlgAut`). -/
-theorem cfc_conj_unitary {A : Matrix n n ℂ} (hA : A.IsHermitian) (f : ℝ → ℝ)
-    (U : unitary (Matrix n n ℂ)) :
-    cfc f ((U : Matrix n n ℂ) * A * star (U : Matrix n n ℂ))
-      = (U : Matrix n n ℂ) * cfc f A * star (U : Matrix n n ℂ) := by
-  set φ := Unitary.conjStarAlgAut ℂ (Matrix n n ℂ) U with hφ
-  have hcont : ContinuousOn f (spectrum ℝ A) := A.finite_real_spectrum |>.continuousOn f
-  have hcontφ : Continuous φ :=
-    LinearMap.continuous_of_finiteDimensional ((φ : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ))
-  have hsa : IsSelfAdjoint A := hA
-  have happ : ∀ x, φ x = (U : Matrix n n ℂ) * x * star (U : Matrix n n ℂ) :=
-    fun x => Unitary.conjStarAlgAut_apply U x
-  have hsa' : IsSelfAdjoint (φ A) := by rw [happ]; exact hsa.conjugate (U : Matrix n n ℂ)
-  have hconj := StarAlgHomClass.map_cfc φ f A hcont hcontφ hsa hsa'
-  rw [happ, happ] at hconj
-  exact hconj.symm
 
 /-- **The matrix logarithm is covariant under unitary conjugation.** For a
 Hermitian matrix $A$ and a unitary $U$,


### PR DESCRIPTION
## Summary

Completes the layering hygiene of the just-merged Lieb axiom-elimination work by
decoupling the `Axioms/` boundary from the quantum-relative-entropy layer (the
accepted reviewer follow-up from #3586).

`Axioms/OperatorConvexity.lean` (a layer-0 boundary file) was transitively
reaching the relative-entropy stack: its Lieb chain
(`LiebOperatorConcave → LiebOperatorIntegral`) imported
`Channel/Schwarz/RelativeEntropyUnitaryInvariance` (which imports
`KleinInequality`, the entropy stack), but used only the pure matrix-CFC fact
`Matrix.cfc_conj_unitary` from it.

## Changes

- **New `TNLean/Analysis/CfcConjugation.lean`**: `Matrix.cfc_conj_unitary` (CFC
  covariance under unitary conjugation) moved verbatim from
  `RelativeEntropyUnitaryInvariance.lean`, with minimal imports (matrix CFC +
  unitary conjugation, no entropy).
- **New `TNLean/Analysis/MatrixOrderTopology.lean`**: the Lieb chain was also
  silently borrowing the `OrderClosedTopology (Matrix m m ℂ)` instance and its
  closed-cone helpers (`matrix_isClosed_posSemidef`, `matrix_isClosed_le`,
  `matrixOrderClosedTopology`) from the channel layer through that same import.
  These are pure matrix-order topology facts, so they are moved verbatim into
  this second low-level module.
- `RelativeEntropyUnitaryInvariance.lean`: imports `CfcConjugation`, drops the
  moved theorem; `log_conj_unitary`/`quantumRelativeEntropy_conj_unitary` keep
  working through the new import.
- `Channel/Basic.lean`: re-imports `MatrixOrderTopology`, drops the moved
  topology helpers; `isClosed_posSemidef` and downstream channel files keep
  working through the new import.
- `LiebOperatorIntegral.lean`: imports `CfcConjugation` + `MatrixOrderTopology`
  (plus the matrix C*-norm it had transitively relied on) instead of the
  relative-entropy module.
- Both modules added to root `TNLean.lean` in the Layer-0b Analysis section.

The moved declarations keep their fully-qualified names
(`Matrix.cfc_conj_unitary`, etc.), so the blueprint `\lean{}` tag in
`ch19_entropy.tex` still resolves.

## Verification

- Full `lake build` green: `Build completed successfully (9255 jobs).`
- `git grep RelativeEntropyUnitaryInvariance TNLean/Analysis/LiebOperatorIntegral.lean`
  returns nothing. The transitive import closure of `Axioms/OperatorConvexity`
  no longer reaches `RelativeEntropyUnitaryInvariance`, `KleinInequality`, or the
  entropy modules.
- `#print axioms lieb_concavity_axiom` unchanged:
  `[propext, Classical.choice, Quot.sound]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Verbatim moves and import rewiring only; no proof or API renames beyond deleting duplicate local proofs in `Channel/Basic`.
> 
> **Overview**
> **Layering refactor** so layer-0 operator-convexity / Lieb code stops depending on quantum relative entropy.
> 
> Two new **Layer 0b** modules hold lemmas that were duplicated or only reachable through channel/entropy imports: **`TNLean/Analysis/CfcConjugation.lean`** (`Matrix.cfc_conj_unitary`, verbatim from `RelativeEntropyUnitaryInvariance`) and **`TNLean/Analysis/MatrixOrderTopology.lean`** (`matrix_isClosed_posSemidef`, `matrix_isClosed_le`, `matrixOrderClosedTopology`, verbatim from `Channel/Basic`). Both are wired into root **`TNLean.lean`**.
> 
> **`LiebOperatorIntegral`** now imports `CfcConjugation`, `MatrixOrderTopology`, and `Mathlib.Analysis.CStarAlgebra.Matrix` instead of **`RelativeEntropyUnitaryInvariance`**, so the Lieb integral route gets CFC conjugation and `OrderClosedTopology` without **`KleinInequality`** / entropy. **`RelativeEntropyUnitaryInvariance`** imports `CfcConjugation` and keeps `log_conj_unitary` and `quantumRelativeEntropy_conj_unitary` unchanged in behavior. **`Channel/Basic`** imports `MatrixOrderTopology` and delegates **`isClosed_posSemidef`** to `matrix_isClosed_posSemidef`.
> 
> Public names are unchanged (`Matrix.cfc_conj_unitary`, etc.), so blueprint tags should still resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 738b43e7ac763293b4409b2bfcf117e79e1a52db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->