### PR TITLE
chore(MPS/MPDO): cite the math note, not issue numbers, in hPF-elimination markers

### DIFF
--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -115,8 +115,9 @@ hypotheses already available in `SimpleLocalStructure.lean`.
 `sal_zcl_implies_rank_one_T`, whose `hPF` hypothesis is not supplied by
 arXiv:1606.00608, Lemma C.5, lines 1484--1502. Documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. Elimination: use
-`ofSALZCLOfPosSemidef` and `sal_zcl_implies_rank_one_T_of_posSemidef`; tracked
-in issue #1041. -/
+`ofSALZCLOfPosSemidef` and `sal_zcl_implies_rank_one_T_of_posSemidef` once
+positive-semidefiniteness of the sector trace matrix is available as a
+hypothesis; the open follow-up is tracked in that note. -/
 def ofSALZCL
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -205,7 +206,9 @@ variable {K : MPOTensor d D}
 and hence relies on the conditional `hPF` shortcut absent from arXiv:1606.00608,
 Lemma C.5, lines 1484--1502. Documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. Elimination: use
-`ofSALZCLAndCommutingFormOfPosSemidef`; tracked in issue #1041. -/
+`ofSALZCLAndCommutingFormOfPosSemidef` once positive-semidefiniteness of the
+sector trace matrix is available as a hypothesis; the open follow-up is tracked
+in that note. -/
 def ofSALZCLAndCommutingForm
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
@@ -286,7 +289,9 @@ tracked by issue #823.
 `SimpleMPDOLocalStructureData.ofSALZCL`, whose `hPF` shortcut is absent from
 arXiv:1606.00608, Lemma C.5, lines 1484--1502. Documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. Elimination: use
-`ofSALZCLAndEtaLocalStructureOfPosSemidef`; tracked in issue #1041. -/
+`ofSALZCLAndEtaLocalStructureOfPosSemidef` once positive-semidefiniteness of the
+sector trace matrix is available as a hypothesis; the open follow-up is tracked
+in that note. -/
 def ofSALZCLAndEtaLocalStructure
     {dA dB dC n : ℕ}
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -337,8 +337,9 @@ which restates the conclusion and is false in general (counterexample in
 C.5 (`SALZCL`, lines 1484--1502) instead derives the factorization from
 Perron--Frobenius fixed-point theory. Documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. Elimination: discharge via the
-PSD-corrected variant `sal_zcl_implies_rank_one_T_of_posSemidef` once the MPDO
-call site supplies positivity of `T`. -/
+PSD-corrected variant `sal_zcl_implies_rank_one_T_of_posSemidef` once
+positive-semidefiniteness of `T` is available as a hypothesis; the open
+follow-up is tracked in that note. -/
 theorem sal_zcl_implies_rank_one_T
     (T : Matrix (Fin n) (Fin n) ℝ)
     (hPrimitive : Matrix.IsPrimitive T)

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -26,7 +26,11 @@ underlying question was isolated in
 counterexample was added in
 \href{https://github.com/LionSR/TNLean/pull/849}{pull request \#849}; and the
 positive-semidefinite replacement theorem was added in
-\href{https://github.com/LionSR/TNLean/pull/917}{pull request \#917}. The
+\href{https://github.com/LionSR/TNLean/pull/917}{pull request \#917}. The open
+follow-up --- supplying matrix-level positive-semidefiniteness of the sector
+trace matrix at the MPDO call site so the replacement theorem discharges the
+\texttt{hPF} shortcut --- is tracked in
+\href{https://github.com/LionSR/TNLean/issues/3593}{issue \#3593}. The
 source passage is
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1394--1499}.}
 


### PR DESCRIPTION
## Summary

Tracking-reference hygiene for the MPDO RFP `**Unfaithful:**` markers, following
`docs/prose_style.md` (enforced by `check_reader_facing_prose.py`): **Lean
docstrings should cite the mathematical note, not an issue number.**

The `hPF`-elimination markers routed their elimination to **closed** issue #1041
— a latent prose-convention violation that was grandfathered only because the
lines were never in a diff. (#1041 was the paper-gap doc-note task, now done; the
note lives at `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. The corrected
rank-one-step issue #832 is also closed — PR #917 added the PSD-corrected
theorem `sal_zcl_implies_rank_one_T_of_posSemidef`.)

## Changes

- Drop the `tracked in issue #N` clauses from the four `hPF`-elimination markers
  (3 in `BlockedRFPConstruction.lean`, 1 in `SimpleLocalStructure.lean`); the
  paper-gap `.tex` note is already cited in each.
- Clarify the missing input is **positive-semidefiniteness of the sector trace
  matrix** (`traceMatrixRe_nonneg` only gives entrywise nonnegativity).

Comment-only; no proof or signature changes. `python3
scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
passes.

## GitHub tracking

The remaining elimination step now lives in the issue tracker, not in Lean prose:
issue #3593 (created), parent tracker #236 (body corrected: #832 is closed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX note edits only; no executable or proof logic changes.
> 
> **Overview**
> **Documentation-only** update to MPDO `**Unfaithful:**` markers so reader-facing prose follows the repo convention: cite `docs/paper-gaps/cpgsv17_pf_rank_one.tex`, not GitHub issue numbers.
> 
> In **`BlockedRFPConstruction.lean`** (three constructors) and **`SimpleLocalStructure.lean`** (`sal_zcl_implies_rank_one_T`), the elimination text no longer says the work is “tracked in issue #1041”. It now states that the path forward is the PSD-corrected constructors/theorems once **positive-semidefiniteness of the sector trace matrix** is available as a hypothesis, with the open follow-up described in that paper-gap note.
> 
> **`docs/paper-gaps/cpgsv17_pf_rank_one.tex`** adds an explicit tracker for that remaining step: issue #3593 (supplying matrix-level PSD at the MPDO call site so `hPF` can be discharged). No Lean proofs or API signatures change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 202f0c01d1fc3c2bdd839dc46747b667c73fd7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->