### PR TITLE
feat(MPS/Periodic): m-factor Ω-contraction and corner-product telescoping for Case 3

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -330,6 +330,8 @@ import TNLean.MPS.Irreducible.FormII
 import TNLean.MPS.Irreducible.ScalarFixedPoint
 import TNLean.MPS.Periodic.Defs
 import TNLean.MPS.Periodic.CornerTransition
+import TNLean.MPS.Periodic.CornerContraction
+import TNLean.MPS.Periodic.SectorLift
 import TNLean.MPS.Irreducible.Adjoint
 import TNLean.MPS.Core.TPGauge
 import TNLean.MPS.Structure.BlockPermutation

--- a/TNLean/MPS/Periodic/CornerContraction.lean
+++ b/TNLean/MPS/Periodic/CornerContraction.lean
@@ -1,0 +1,233 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Periodic.CornerTransition
+import TNLean.Algebra.PiTensorProductPhase
+import TNLean.MPS.Chain.OneSidedInverse
+
+/-!
+# The `m`-factor `Ω`-contraction for the periodic-overlap Case 3
+
+This file formalizes the two algebraic mechanisms of the contraction step of
+arXiv:1708.00029, Appendix A (lines 1041--1068):
+
+* the **repeated-block matrix identity** (the `(m·N₀+1)`-fold repetition of
+  `eq:BCmprop`), obtained from the cyclic concatenation law
+  `cornerProd_append`; and
+* the **`Ω`-contraction** that applies the tensor of right inverses
+  `Ω_{u+1} ⊗ ⋯ ⊗ Ω_u` to the concatenated product
+  `A_u^{i_1} F_{u+1} A_{u+1}^{i_2} F_{u+2} ⋯ A_{u+m-1}^{i_m} F_u`, using the
+  finite-sum recovery identity `eq:Omegauprop` to replace each repeated product
+  `F` by an inserted matrix.
+
+The setting is the one-site corner letters `A_u^i` (`cornerLetter`) and their
+repeated products `F_u` (`cornerProd` over a word whose length is a positive
+multiple of `m`).
+
+## Main results
+
+* `cornerProd_blockMatch_pow` — the **repeated-block matrix identity** (step (a),
+  lines 1041--1056).  Assuming the `m`-block product identity `eq:BCmprop`
+  `A_u^{i_1}\cdots A_{u+m-1}^{i_m} = c_u · B_v^{i_1}\cdots B_{v+m-1}^{i_m}`
+  holds for every length-`m` word, it propagates to every word `W` of length
+  `k·m` (`k ≥ 1`): `cornerProd P A u W = (c u) ^ k • cornerProd Q B (u + q) W`.
+  The full-cycle shift `m • 1 = 0` anchors every block at the base sector, so
+  each contributes the same factor `c u`.
+
+* `ofFn_contraction` — the **`Ω`-contraction mechanism** (step (b), lines
+  1057--1062), as an abstract finite-product identity over any complex algebra:
+  summing the ordered chain `∏_k (A_k · G_k^{ρ_k})` weighted by the inverse
+  coefficients `∏_k (c_k X_k)_{ρ_k}` collapses each repeated product `G_k` to the
+  inserted matrix `X_k`, yielding `∏_k (A_k · X_k)`.  This is the algebraic
+  content of "apply `Ω_{u+1} ⊗ ⋯ ⊗ Ω_u` and use `eq:Omegauprop`".
+
+* `cornerProd_contraction` — `ofFn_contraction` specialized to the periodic
+  corner data, contracting the concatenation
+  `∏_k (A_k^{σ_k} · F_{k+1}^{ρ_k})` to the chain `∏_k (A_k^{σ_k} · X_k)`.
+
+The remaining steps of Appendix A (lines 1063--1080) — recombining the two
+mechanisms with the per-sector scalar bookkeeping into the uniform
+product-tensor identity `eq:resultprop`, and feeding it to
+`PiTensorProductPhase.exists_kappa_product_one_of_piTensorProduct_eq_root_smul`
+— are not addressed here; see
+`docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.
+
+## References
+
+* De las Cuevas, Cirac, Schuch, Pérez-García,
+  *Irreducible forms of Matrix Product States: Theory and Applications*,
+  arXiv:1708.00029, Appendix A (eq:BCmprop, eq:Fu, eq:Omegauprop, eq:resultprop).
+-/
+
+open scoped Matrix BigOperators TensorProduct
+open Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ## Step (a): the repeated-block matrix identity -/
+
+section RepeatedBlock
+
+variable {m : ℕ} [NeZero m]
+
+/-- A full cycle of unit shifts is trivial in `Fin m`: `m • (1 : Fin m) = 0`.
+This is the algebraic reason the appendix can repeat a single length-`m` block
+around the cycle without moving the base sector. -/
+lemma nsmul_card_one_fin : (m • (1 : Fin m)) = 0 := by
+  have h : (Fintype.card (Fin m)) • (1 : Fin m) = 0 := card_nsmul_eq_zero
+  simpa using h
+
+/-- **Repeated-block matrix identity** (arXiv:1708.00029, Appendix A,
+step toward eq:resultprop, lines 1041--1056).
+
+If the `m`-block product identity `eq:BCmprop` holds for every length-`m` word,
+then it propagates to every word `W` whose length is a positive multiple of `m`:
+`cornerProd P A u W = (c u) ^ k • cornerProd Q B (u + q) W` when `|W| = k·m` with
+`k ≥ 1`.  The scalar is `(c u) ^ k` because the full-cycle shift `m • 1 = 0`
+anchors every length-`m` block at the same base sector `u`, so each block
+contributes the same factor `c u`. -/
+lemma cornerProd_blockMatch_pow
+    (P : Fin m → MatrixAlg D) (Q : Fin m → MatrixAlg D)
+    (A B : MPSTensor d D) (q : Fin m) (c : Fin m → ℂ)
+    (hP : ∀ k, IsOrthogonalProjection (P k))
+    (hQ : ∀ k, IsOrthogonalProjection (Q k))
+    (hBC : ∀ (u : Fin m) (w : List (Fin d)), w.length = m →
+      cornerProd P A u w = c u • cornerProd Q B (u + q) w)
+    (u : Fin m) (k : ℕ) :
+    ∀ W : List (Fin d), W.length = (k + 1) * m →
+      cornerProd P A u W = (c u) ^ (k + 1) • cornerProd Q B (u + q) W := by
+  induction k with
+  | zero =>
+    intro W hW
+    rw [zero_add, one_mul] at hW
+    simpa using hBC u W hW
+  | succ k ih =>
+    intro W hW
+    set block := W.take m with hblock_def
+    set rest := W.drop m with hrest_def
+    have hWlen : m ≤ W.length := by rw [hW]; nlinarith [Nat.zero_le k]
+    have hblock_len : block.length = m := by
+      rw [hblock_def, List.length_take, Nat.min_eq_left hWlen]
+    have hrest_len : rest.length = (k + 1) * m := by
+      rw [hrest_def, List.length_drop, hW]; ring_nf; omega
+    have hWeq : W = block ++ rest := (List.take_append_drop m W).symm
+    -- The junction shift for a length-`m` block is trivial.
+    have hshift : (block.length • (1 : Fin m)) = 0 := by
+      rw [hblock_len]; exact nsmul_card_one_fin
+    rw [hWeq, cornerProd_append P A hP u block rest, hshift, add_zero,
+      hBC u block hblock_len, ih rest hrest_len]
+    rw [cornerProd_append Q B hQ (u + q) block rest, hshift, add_zero]
+    rw [smul_mul_smul_comm, ← pow_succ']
+
+end RepeatedBlock
+
+/-! ## Step (b): the `Ω`-contraction mechanism
+
+The contraction is an algebraic identity over any complex algebra: it does not
+use the matrix structure, only the bilinearity of the product and the finite-sum
+recovery identity `eq:Omegauprop`.  We therefore state it for a general
+`ℂ`-algebra `R`; the periodic instance is `R = M_D(ℂ)`. -/
+
+section AbstractContraction
+
+variable {R : Type*} [Ring R] {J : Type*} [Fintype J]
+
+/-- Ordered noncommutative distributivity: the ordered product of finite sums is
+the sum, over all choices, of the ordered products of the chosen summands.  This
+is the combinatorial core of applying the tensor of inverses
+`Ω_{u+1} ⊗ ⋯ ⊗ Ω_u` to a concatenated matrix product. -/
+theorem ofFn_prod_sum {m : ℕ} (f : Fin m → J → R) :
+    (List.ofFn (fun k : Fin m => ∑ j : J, f k j)).prod
+      = ∑ ρ : Fin m → J, (List.ofFn (fun k => f k (ρ k))).prod := by
+  classical
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [List.ofFn_succ, List.prod_cons, ih (fun k => f k.succ), Finset.sum_mul_sum]
+    rw [← Equiv.sum_comp (Fin.consEquiv (fun _ : Fin (m + 1) => J)), Fintype.sum_prod_type]
+    refine Finset.sum_congr rfl (fun j _ => Finset.sum_congr rfl (fun ρ' _ => ?_))
+    rw [List.ofFn_succ, List.prod_cons]
+    simp [Fin.consEquiv]
+
+variable [Algebra ℂ R]
+
+/-- The scalars pull out of an ordered product: `∏_k (s_k • M_k) = (∏_k s_k) •
+∏_k M_k`.  This collects the inverse coefficients of the contraction into a
+single scalar in front of each chosen ordered product. -/
+theorem ofFn_prod_smul {m : ℕ} (s : Fin m → ℂ) (M : Fin m → R) :
+    (List.ofFn (fun k : Fin m => s k • M k)).prod = (∏ k, s k) • (List.ofFn M).prod := by
+  induction m with
+  | zero => simp
+  | succ m ih =>
+    rw [List.ofFn_succ, List.prod_cons, ih (fun k => s k.succ) (fun k => M k.succ),
+      smul_mul_smul_comm, Fin.prod_univ_succ, List.ofFn_succ, List.prod_cons]
+
+/-- **The `Ω`-contraction** (arXiv:1708.00029, Appendix A, lines 1057--1062).
+
+Each gap of the concatenation carries a repeated product `G_k`, a family with a
+finite-sum right inverse `∑_j (c_k Y)_j • G_k^j = Y` (`eq:Omegauprop`).  Summing
+the concatenated chain `∏_k (A_k · G_k^{ρ_k})` against the inverse coefficients
+`∏_k (c_k X_k)_{ρ_k}` collapses each `G_k` to the inserted matrix `X_k`, leaving
+the chain `∏_k (A_k · X_k)`.  This is the algebraic content of applying
+`Ω_{u+1} ⊗ ⋯ ⊗ Ω_u` and invoking `eq:Omegauprop`. -/
+theorem ofFn_contraction {m : ℕ} (A X : Fin m → R) (G : Fin m → J → R)
+    (c : Fin m → R → J → ℂ)
+    (hinv : ∀ (k : Fin m) (Y : R), ∑ j, c k Y j • G k j = Y) :
+    ∑ ρ : Fin m → J, (∏ k, c k (X k) (ρ k)) • (List.ofFn (fun k => A k * G k (ρ k))).prod
+      = (List.ofFn (fun k => A k * X k)).prod := by
+  have hf : ∀ k, A k * X k = ∑ j, c k (X k) j • (A k * G k j) := by
+    intro k
+    conv_lhs => rw [← hinv k (X k)]
+    rw [Finset.mul_sum]
+    exact Finset.sum_congr rfl (fun j _ => mul_smul_comm _ _ _)
+  symm
+  calc (List.ofFn (fun k => A k * X k)).prod
+      = (List.ofFn (fun k => ∑ j, c k (X k) j • (A k * G k j))).prod := by simp_rw [hf]
+    _ = ∑ ρ : Fin m → J, (List.ofFn (fun k => c k (X k) (ρ k) • (A k * G k (ρ k)))).prod :=
+        ofFn_prod_sum (fun k j => c k (X k) j • (A k * G k j))
+    _ = ∑ ρ : Fin m → J,
+          (∏ k, c k (X k) (ρ k)) • (List.ofFn (fun k => A k * G k (ρ k))).prod :=
+        Finset.sum_congr rfl (fun ρ _ =>
+          ofFn_prod_smul (fun k => c k (X k) (ρ k)) (fun k => A k * G k (ρ k)))
+
+end AbstractContraction
+
+/-! ## Step (b), periodic instance -/
+
+section PeriodicContraction
+
+variable {m : ℕ} [NeZero m]
+
+/-- The `Ω`-contraction specialized to the periodic corner data
+(arXiv:1708.00029, Appendix A, lines 1057--1062).
+
+Here `A_k^i = cornerLetter P A k i`, the gap repeated products are
+`F_{k+1}^{𝐣} = cornerProd P A (k+1) 𝐣` over length-`L` words, and `Ω` is their
+finite-sum right inverse `∑_{𝐣} (Ω_u Y)_{𝐣} F_u^{𝐣} = Y` (`eq:Omegauprop`).
+Contracting the concatenation `∏_k (A_k^{σ_k} · F_{k+1}^{ρ_k})` with the inverse
+coefficients replaces each `F_{k+1}` by the inserted matrix `X_k`, giving the
+chain `∏_k (A_k^{σ_k} · X_k)`. -/
+theorem cornerProd_contraction
+    (P : Fin m → MatrixAlg D) (A : MPSTensor d D) (L : ℕ)
+    (Ω : Fin m → MatrixAlg D → (Fin L → Fin d) → ℂ)
+    (hΩ : ∀ (u : Fin m) (Y : MatrixAlg D),
+      ∑ j : Fin L → Fin d, Ω u Y j • cornerProd P A u (List.ofFn j) = Y)
+    (σ : Fin m → Fin d) (X : Fin m → MatrixAlg D) :
+    ∑ ρ : Fin m → (Fin L → Fin d),
+        (∏ k, Ω (k + 1) (X k) (ρ k)) •
+          (List.ofFn (fun k => cornerLetter P A k (σ k) *
+            cornerProd P A (k + 1) (List.ofFn (ρ k)))).prod
+      = (List.ofFn (fun k => cornerLetter P A k (σ k) * X k)).prod :=
+  ofFn_contraction
+    (fun k => cornerLetter P A k (σ k)) X
+    (fun k j => cornerProd P A (k + 1) (List.ofFn j))
+    (fun k => Ω (k + 1))
+    (fun k Y => hΩ (k + 1) Y)
+
+end PeriodicContraction
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/CornerContraction.lean
+++ b/TNLean/MPS/Periodic/CornerContraction.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import TNLean.MPS.Periodic.CornerTransition
-import TNLean.Algebra.PiTensorProductPhase
-import TNLean.MPS.Chain.OneSidedInverse
 
 /-!
 # The `m`-factor `Ω`-contraction for the periodic-overlap Case 3
@@ -61,7 +59,7 @@ product-tensor identity `eq:resultprop`, and feeding it to
   arXiv:1708.00029, Appendix A (eq:BCmprop, eq:Fu, eq:Omegauprop, eq:resultprop).
 -/
 
-open scoped Matrix BigOperators TensorProduct
+open scoped Matrix BigOperators
 open Matrix
 
 namespace MPSTensor

--- a/TNLean/MPS/Periodic/CornerContraction.lean
+++ b/TNLean/MPS/Periodic/CornerContraction.lean
@@ -168,20 +168,26 @@ theorem ofFn_prod_smul {m : ℕ} (s : Fin m → ℂ) (M : Fin m → R) :
 
 /-- **The `Ω`-contraction** (arXiv:1708.00029, Appendix A, lines 1057--1062).
 
-Each gap of the concatenation carries a repeated product `G_k`, a family with a
-finite-sum right inverse `∑_j (c_k Y)_j • G_k^j = Y` (`eq:Omegauprop`).  Summing
-the concatenated chain `∏_k (A_k · G_k^{ρ_k})` against the inverse coefficients
-`∏_k (c_k X_k)_{ρ_k}` collapses each `G_k` to the inserted matrix `X_k`, leaving
-the chain `∏_k (A_k · X_k)`.  This is the algebraic content of applying
-`Ω_{u+1} ⊗ ⋯ ⊗ Ω_u` and invoking `eq:Omegauprop`. -/
+Each gap of the concatenation carries a repeated product `G_k`, recovered at the
+inserted matrix `X_k` by the finite-sum coefficients `∑_j (c_k X_k)_j • G_k^j =
+X_k` (`eq:Omegauprop` evaluated at `X_k`).  Summing the concatenated chain
+`∏_k (A_k · G_k^{ρ_k})` against the coefficients `∏_k (c_k X_k)_{ρ_k}` collapses
+each `G_k` to the inserted matrix `X_k`, leaving the chain `∏_k (A_k · X_k)`.
+This is the algebraic content of applying `Ω_{u+1} ⊗ ⋯ ⊗ Ω_u` and invoking
+`eq:Omegauprop`.
+
+The recovery is required only at each inserted matrix `X_k`, not for every `Y`.
+This matters for the cyclic-sector instance, where the right inverse `Ω_u`
+recovers only the corner-supported matrices `P_u Y P_{u + L • 1}`, so a recovery
+identity for every `Y` would force `P_u = 1`. -/
 theorem ofFn_contraction {m : ℕ} (A X : Fin m → R) (G : Fin m → J → R)
     (c : Fin m → R → J → ℂ)
-    (hinv : ∀ (k : Fin m) (Y : R), ∑ j, c k Y j • G k j = Y) :
+    (hinv : ∀ k : Fin m, ∑ j, c k (X k) j • G k j = X k) :
     ∑ ρ : Fin m → J, (∏ k, c k (X k) (ρ k)) • (List.ofFn (fun k => A k * G k (ρ k))).prod
       = (List.ofFn (fun k => A k * X k)).prod := by
   have hf : ∀ k, A k * X k = ∑ j, c k (X k) j • (A k * G k j) := by
     intro k
-    conv_lhs => rw [← hinv k (X k)]
+    conv_lhs => rw [← hinv k]
     rw [Finset.mul_sum]
     exact Finset.sum_congr rfl (fun j _ => mul_smul_comm _ _ _)
   symm
@@ -206,17 +212,22 @@ variable {m : ℕ} [NeZero m]
 (arXiv:1708.00029, Appendix A, lines 1057--1062).
 
 Here `A_k^i = cornerLetter P A k i`, the gap repeated products are
-`F_{k+1}^{𝐣} = cornerProd P A (k+1) 𝐣` over length-`L` words, and `Ω` is their
-finite-sum right inverse `∑_{𝐣} (Ω_u Y)_{𝐣} F_u^{𝐣} = Y` (`eq:Omegauprop`).
-Contracting the concatenation `∏_k (A_k^{σ_k} · F_{k+1}^{ρ_k})` with the inverse
-coefficients replaces each `F_{k+1}` by the inserted matrix `X_k`, giving the
-chain `∏_k (A_k^{σ_k} · X_k)`. -/
+`F_{k+1}^{𝐣} = cornerProd P A (k+1) 𝐣` over length-`L` words, and `Ω_{k+1}`
+recovers each inserted matrix `X_k`: `∑_{𝐣} (Ω_{k+1} X_k)_{𝐣} F_{k+1}^{𝐣} = X_k`
+(`eq:Omegauprop` evaluated at `X_k`).  Contracting the concatenation
+`∏_k (A_k^{σ_k} · F_{k+1}^{ρ_k})` with these coefficients replaces each `F_{k+1}`
+by `X_k`, giving the chain `∏_k (A_k^{σ_k} · X_k)`.
+
+The recovery is required only at the inserted matrices `X_k`, which in the
+Case-3 contraction are the corner-supported tensors `P_{k+1} X_k P_{k+1+L•1}`
+that `Ω_{k+1}` actually inverts. -/
 theorem cornerProd_contraction
     (P : Fin m → MatrixAlg D) (A : MPSTensor d D) (L : ℕ)
     (Ω : Fin m → MatrixAlg D → (Fin L → Fin d) → ℂ)
-    (hΩ : ∀ (u : Fin m) (Y : MatrixAlg D),
-      ∑ j : Fin L → Fin d, Ω u Y j • cornerProd P A u (List.ofFn j) = Y)
-    (σ : Fin m → Fin d) (X : Fin m → MatrixAlg D) :
+    (σ : Fin m → Fin d) (X : Fin m → MatrixAlg D)
+    (hΩ : ∀ k : Fin m,
+      ∑ j : Fin L → Fin d, Ω (k + 1) (X k) j •
+        cornerProd P A (k + 1) (List.ofFn j) = X k) :
     ∑ ρ : Fin m → (Fin L → Fin d),
         (∏ k, Ω (k + 1) (X k) (ρ k)) •
           (List.ofFn (fun k => cornerLetter P A k (σ k) *
@@ -226,7 +237,7 @@ theorem cornerProd_contraction
     (fun k => cornerLetter P A k (σ k)) X
     (fun k j => cornerProd P A (k + 1) (List.ofFn j))
     (fun k => Ω (k + 1))
-    (fun k Y => hΩ (k + 1) Y)
+    hΩ
 
 end PeriodicContraction
 

--- a/TNLean/MPS/Periodic/SectorLift.lean
+++ b/TNLean/MPS/Periodic/SectorLift.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.Periodic.CornerTransition
+import TNLean.MPS.Core.Blocking
+
+/-!
+# Telescoping the one-site corner products into a blocked diagonal corner
+
+This file isolates the purely algebraic backbone of the `m`-factor cyclic
+contraction of arXiv:1708.00029, Appendix A (lines 1012--1046): the one-site
+corner-transition product `A_u^{i_1} A_{u+1}^{i_2} \cdots` (eq:Auprop, eq:Fu)
+telescopes into a single diagonal corner `P_u (A^{[m]})^{\mathbf i} P_u` of the
+blocked tensor (eq:Cu / Lemma bdcf).
+
+## The two projector conventions
+
+arXiv:1708.00029 grades the one-site tensors *off-diagonally* with
+$A^i = \sum_u P_u A^i P_{u+1}$, so that the sector letter
+$A_u^i = P_u A^i P_{u+1}$ (eq:Auprop) is the nonzero corner and a product of
+such letters telescopes through the intermediate projectors.  This is the
+convention under which `MPSTensor.cornerProd` is nonzero.
+
+The repository's cyclic sector data (`IsCyclicSectorDecompWith`) stores instead
+the *adjoint* shift $\mathcal E^*(P_{k+1}) = P_k$, which gives the
+inverse-indexed grading $A^i = \sum_u P_{u+1} A^i P_u$ — equivalently
+$P_{k+1} A^i = A^i P_k$ (`offDiag_shift_of_adjoint_cyclic_shift`).  Under this
+convention $P_u A^i P_{u+1} = 0$ for $m \ge 3$, so `cornerProd` is identically
+zero when fed the stored projectors directly.  The two conventions agree after
+the inverse cyclic reindexing $P_k \mapsto P_{-k}$ (documented at
+`IsCyclicSectorDecompWith`): `negReindex_paper_shift` derives the paper-convention
+shift for `fun k => P (-k)` from the stored adjoint shift, repairing the index
+mismatch so the telescoping applies.
+
+## Main declarations
+
+* `MPSTensor.cornerProd_eq_conj_evalWord` — the telescoping identity
+  `cornerProd P A u w = P u * evalWord A w * P (u + w.length • 1)` under the
+  paper-convention shift `P k * A i = A i * P (k + 1)`.
+* `MPSTensor.cornerProd_eq_diagCorner_of_length_smul_eq_zero` — for a word whose
+  length is a multiple of the period (`w.length • 1 = 0`), the product is the
+  diagonal corner `P u * evalWord A w * P u`.
+* `MPSTensor.cornerProd_eq_blockDiagCorner` — for a single blocked letter
+  `wordOfBlock d m I`, the product is `P u * (blockTensor A m) I * P u`
+  (eq:Cu).
+* `MPSTensor.negReindex_paper_shift` — converts the stored adjoint cyclic shift
+  into the paper-convention shift for the inverse-reindexed projectors.
+
+## References
+
+* De las Cuevas, Cirac, Schuch, Pérez-García,
+  *Irreducible forms of Matrix Product States: Theory and Applications*,
+  arXiv:1708.00029, Appendix A (eq:Auprop, eq:Cvprop, eq:BCmprop, eq:Fu).
+-/
+
+open scoped Matrix BigOperators
+open Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+section Telescope
+
+variable {m : ℕ} [NeZero m]
+
+/-- **Telescoping of a one-site corner-transition product into a conjugated word.**
+
+Under the *paper* off-diagonal convention `P k * A i = A i * P (k + 1)`
+(arXiv:1708.00029, the grading $A^i = \sum_u P_u A^i P_{u+1}$ underlying
+eq:Auprop), the repeated corner-transition product `cornerProd P A u w`
+collapses through its intermediate projectors:
+`cornerProd P A u w = P u * evalWord A w * P (u + w.length • 1)`.
+
+The starting projector `P u` is kept on the left, every intermediate junction
+projector is absorbed by the shift and projector idempotency, and a single
+projector `P (u + w.length • 1)` records the accumulated sector offset on the
+right.  This is the algebraic mechanism by which Appendix A repeats a single
+sector block around the cycle (eq:Fu). -/
+theorem cornerProd_eq_conj_evalWord
+    (P : Fin m → MatrixAlg D) (A : MPSTensor d D)
+    (hproj : ∀ k, IsOrthogonalProjection (P k))
+    (hshift : ∀ k (i : Fin d), P k * A i = A i * P (k + 1))
+    (u : Fin m) (w : List (Fin d)) :
+    cornerProd P A u w = P u * evalWord A w * P (u + w.length • (1 : Fin m)) := by
+  induction w generalizing u with
+  | nil =>
+    simp only [cornerProd_nil, evalWord_nil, List.length_nil, zero_smul, add_zero,
+      Matrix.mul_one]
+    exact ((hproj u).2).symm
+  | cons i w ih =>
+    -- The head junction `P u * A i * P (u + 1)` collapses to `P u * A i`.
+    have key : P u * A i * P (u + 1) = P u * A i := by
+      rw [Matrix.mul_assoc, ← hshift u i, ← Matrix.mul_assoc, (hproj u).2]
+    -- Realign the accumulated sector offset.
+    have hlen : (u + 1) + w.length • (1 : Fin m) = u + (i :: w).length • (1 : Fin m) := by
+      simp only [List.length_cons, add_smul, one_smul]; abel
+    rw [cornerProd_cons, ih (u + 1), evalWord_cons]
+    calc
+      P u * A i * (P (u + 1) * evalWord A w * P ((u + 1) + w.length • (1 : Fin m)))
+          = (P u * A i * P (u + 1)) * evalWord A w *
+              P ((u + 1) + w.length • (1 : Fin m)) := by
+            simp only [Matrix.mul_assoc]
+      _ = (P u * A i) * evalWord A w * P ((u + 1) + w.length • (1 : Fin m)) := by rw [key]
+      _ = P u * (A i * evalWord A w) * P (u + (i :: w).length • (1 : Fin m)) := by
+            rw [hlen, Matrix.mul_assoc (P u) (A i) (evalWord A w)]
+
+/-- **Diagonal-corner collapse for a period-aligned word.**
+
+If the word length is a multiple of the period (`w.length • 1 = 0` in `Fin m`),
+then the accumulated sector offset vanishes and the corner-transition product is
+the diagonal corner `P u * evalWord A w * P u`. -/
+theorem cornerProd_eq_diagCorner_of_length_smul_eq_zero
+    (P : Fin m → MatrixAlg D) (A : MPSTensor d D)
+    (hproj : ∀ k, IsOrthogonalProjection (P k))
+    (hshift : ∀ k (i : Fin d), P k * A i = A i * P (k + 1))
+    (u : Fin m) (w : List (Fin d)) (hlen : w.length • (1 : Fin m) = 0) :
+    cornerProd P A u w = P u * evalWord A w * P u := by
+  rw [cornerProd_eq_conj_evalWord P A hproj hshift u w, hlen, add_zero]
+
+/-- **Single blocked letter as a diagonal corner** (arXiv:1708.00029, eq:Cu).
+
+For one blocked letter `wordOfBlock d m I` (a word of length exactly the period
+`m`), the corner-transition product is the diagonal blocked corner
+`P u * (blockTensor A m) I * P u = C_u^{I}` of Lemma bdcf.  Combined with the
+corner-isomorphism letter identity stored in `IsCyclicSectorDecompWith`
+(`(φ k (blocks k I)).1 = P k * blockTensor A m I * P k`), this exhibits the
+compressed sector letter as the corner-transition product. -/
+theorem cornerProd_eq_blockDiagCorner
+    (P : Fin m → MatrixAlg D) (A : MPSTensor d D)
+    (hproj : ∀ k, IsOrthogonalProjection (P k))
+    (hshift : ∀ k (i : Fin d), P k * A i = A i * P (k + 1))
+    (u : Fin m) (I : Fin (blockPhysDim d m)) :
+    cornerProd P A u (wordOfBlock d m I) = P u * (blockTensor A m) I * P u := by
+  have hlen : (wordOfBlock d m I).length • (1 : Fin m) = 0 := by
+    rw [length_wordOfBlock]
+    have h := card_nsmul_eq_zero (x := (1 : Fin m))
+    rwa [Fintype.card_fin] at h
+  rw [cornerProd_eq_diagCorner_of_length_smul_eq_zero P A hproj hshift u _ hlen]
+  rfl
+
+end Telescope
+
+section NegReindex
+
+variable {m : ℕ} [NeZero m]
+
+/-- **Inverse cyclic reindexing of the stored adjoint shift into the paper
+convention.**
+
+`IsCyclicSectorDecompWith` stores the adjoint cyclic shift
+`𝓔^*(P_{k+1}) = P_k`, which yields the inverse-indexed grading
+`P_{k+1} A^i = A^i P_k` (`offDiag_shift_of_adjoint_cyclic_shift`).  After the
+inverse cyclic reindexing `P_k ↦ P_{-k}` documented at
+`IsCyclicSectorDecompWith`, the projectors satisfy the *paper* off-diagonal
+convention `P_{-k} A^i = A^i P_{-(k+1)}` (arXiv:1708.00029, eq:Auprop grading),
+which is exactly the hypothesis consumed by `cornerProd_eq_conj_evalWord`. -/
+theorem negReindex_paper_shift
+    (A : MPSTensor d D)
+    (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    {P : Fin m → MatrixAlg D}
+    (hproj : ∀ k, IsOrthogonalProjection (P k))
+    (hShift : ∀ k, transferMap (d := d) (D := D) (fun i => (A i)ᴴ) (P (k + 1)) = P k)
+    (k : Fin m) (i : Fin d) :
+    P (-k) * A i = A i * P (-(k + 1)) := by
+  have h := offDiag_shift_of_adjoint_cyclic_shift A hLeft hproj hShift (-(k + 1)) i
+  have he : (-(k + 1) + 1 : Fin m) = -k := by abel
+  rwa [he] at h
+
+end NegReindex
+
+end MPSTensor

--- a/TNLean/MPS/Periodic/SectorLift.lean
+++ b/TNLean/MPS/Periodic/SectorLift.lean
@@ -23,16 +23,15 @@ $A_u^i = P_u A^i P_{u+1}$ (eq:Auprop) is the nonzero corner and a product of
 such letters telescopes through the intermediate projectors.  This is the
 convention under which `MPSTensor.cornerProd` is nonzero.
 
-The repository's cyclic sector data (`IsCyclicSectorDecompWith`) stores instead
-the *adjoint* shift $\mathcal E^*(P_{k+1}) = P_k$, which gives the
-inverse-indexed grading $A^i = \sum_u P_{u+1} A^i P_u$ — equivalently
+The cyclic sector data (`IsCyclicSectorDecompWith`) instead satisfies the
+*adjoint* shift $\mathcal E^*(P_{k+1}) = P_k$, which gives the inverse-indexed
+grading $A^i = \sum_u P_{u+1} A^i P_u$ — equivalently
 $P_{k+1} A^i = A^i P_k$ (`offDiag_shift_of_adjoint_cyclic_shift`).  Under this
 convention $P_u A^i P_{u+1} = 0$ for $m \ge 3$, so `cornerProd` is identically
-zero when fed the stored projectors directly.  The two conventions agree after
-the inverse cyclic reindexing $P_k \mapsto P_{-k}$ (documented at
-`IsCyclicSectorDecompWith`): `negReindex_paper_shift` derives the paper-convention
-shift for `fun k => P (-k)` from the stored adjoint shift, repairing the index
-mismatch so the telescoping applies.
+zero on these projectors directly.  The two conventions agree after the inverse
+cyclic reindexing $P_k \mapsto P_{-k}$ (documented at `IsCyclicSectorDecompWith`):
+`negReindex_paper_shift` derives the paper-convention shift for `fun k => P (-k)`
+from the adjoint shift, repairing the index mismatch so the telescoping applies.
 
 ## Main declarations
 
@@ -45,7 +44,7 @@ mismatch so the telescoping applies.
 * `MPSTensor.cornerProd_eq_blockDiagCorner` — for a single blocked letter
   `wordOfBlock d m I`, the product is `P u * (blockTensor A m) I * P u`
   (eq:Cu).
-* `MPSTensor.negReindex_paper_shift` — converts the stored adjoint cyclic shift
+* `MPSTensor.negReindex_paper_shift` — converts the adjoint cyclic shift
   into the paper-convention shift for the inverse-reindexed projectors.
 
 ## References
@@ -125,7 +124,7 @@ theorem cornerProd_eq_diagCorner_of_length_smul_eq_zero
 For one blocked letter `wordOfBlock d m I` (a word of length exactly the period
 `m`), the corner-transition product is the diagonal blocked corner
 `P u * (blockTensor A m) I * P u = C_u^{I}` of Lemma bdcf.  Combined with the
-corner-isomorphism letter identity stored in `IsCyclicSectorDecompWith`
+corner-isomorphism letter identity of `IsCyclicSectorDecompWith`
 (`(φ k (blocks k I)).1 = P k * blockTensor A m I * P k`), this exhibits the
 compressed sector letter as the corner-transition product. -/
 theorem cornerProd_eq_blockDiagCorner
@@ -147,16 +146,16 @@ section NegReindex
 
 variable {m : ℕ} [NeZero m]
 
-/-- **Inverse cyclic reindexing of the stored adjoint shift into the paper
+/-- **Inverse cyclic reindexing of the adjoint shift into the paper
 convention.**
 
-`IsCyclicSectorDecompWith` stores the adjoint cyclic shift
+The cyclic sector decomposition satisfies the adjoint cyclic shift
 `𝓔^*(P_{k+1}) = P_k`, which yields the inverse-indexed grading
 `P_{k+1} A^i = A^i P_k` (`offDiag_shift_of_adjoint_cyclic_shift`).  After the
 inverse cyclic reindexing `P_k ↦ P_{-k}` documented at
 `IsCyclicSectorDecompWith`, the projectors satisfy the *paper* off-diagonal
 convention `P_{-k} A^i = A^i P_{-(k+1)}` (arXiv:1708.00029, eq:Auprop grading),
-which is exactly the hypothesis consumed by `cornerProd_eq_conj_evalWord`. -/
+which is the shift hypothesis of `cornerProd_eq_conj_evalWord`. -/
 theorem negReindex_paper_shift
     (A : MPSTensor d D)
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -814,7 +814,8 @@ unconditional result.
     \lean{MPSTensor.cornerProd_blockMatch_pow}
     \leanok
     \uses{def:periodic_corner_product, lem:periodic_corner_product_append}
-    Suppose the $m$-block product identity
+    Let $P_0,\ldots,P_{m-1}$ and $Q_0,\ldots,Q_{m-1}$ be orthogonal projections,
+    and suppose the $m$-block product identity
     \[
         A_u^{i_1}\cdots A_{u+m-1}^{i_m}
         =
@@ -845,11 +846,11 @@ unconditional result.
     \lean{MPSTensor.cornerProd_contraction}
     \leanok
     \uses{def:periodic_corner_letter, def:periodic_corner_product}
-    Let $\Omega_u$ be a finite-sum right inverse of the repeated corner product
-    $F_u$ over length-$L$ words, so that
-    $\sum_{\mathbf j}(\Omega_u(Y))_{\mathbf j}\,F_u^{\mathbf j}=Y$ for every $Y$
-    (\cite[eq.~Omegauprop]{DeLasCuevas2017Irreducible}).  Then for any sector
-    indices $\sigma$ and inserted matrices $X_0,\ldots,X_{m-1}$,
+    Suppose the coefficients $\Omega_{k+1}$ recover each inserted matrix $X_k$
+    from the repeated corner product $F_{k+1}$ over length-$L$ words:
+    $\sum_{\mathbf j}(\Omega_{k+1}(X_k))_{\mathbf j}\,F_{k+1}^{\mathbf j}=X_k$
+    (\cite[eq.~Omegauprop]{DeLasCuevas2017Irreducible} at $X_k$).  Then for any
+    sector indices $\sigma$,
     \[
         \sum_{\boldsymbol\rho}
         \Bigl(\prod_k (\Omega_{k+1}(X_k))_{\rho_k}\Bigr)
@@ -857,11 +858,10 @@ unconditional result.
         =
         \prod_k A_k^{\sigma_k}\,X_k .
     \]
-    Summing the concatenated chain against the inverse coefficients collapses
-    each repeated product $F_{k+1}$ to its inserted matrix $X_k$.  This is the
-    algebraic content of applying the tensor of right inverses
-    $\Omega_{u+1}\otimes\cdots\otimes\Omega_u$ and invoking the recovery
-    identity.
+    Summing the concatenated chain against these coefficients collapses each
+    repeated product $F_{k+1}$ to its inserted matrix $X_k$.  The recovery is
+    needed only at the inserted matrices $X_k$, which in the Case-3 contraction
+    are the corner-supported tensors that $\Omega_{k+1}$ inverts.
 \end{lemma}
 
 \begin{proof}\leanok
@@ -877,17 +877,17 @@ unconditional result.
     \lean{MPSTensor.negReindex_paper_shift}
     \leanok
     \uses{thm:cyclic_sector_offdiag_shift}
-    The cyclic sector data stores the adjoint shift
-    $\mathcal E^*(P_{k+1})=P_k$, which gives the inverse-indexed grading
-    $P_{k+1}A^i=A^iP_k$.  After the inverse reindexing $P_k\mapsto P_{-k}$ the
-    projectors satisfy the off-diagonal convention
-    $P_{-k}A^i=A^iP_{-(k+1)}$ of
+    Let $A$ be left-canonical, $\sum_i A_i^\dagger A_i=1$, with orthogonal sector
+    projectors $P_k$ satisfying the adjoint shift $\mathcal E^*(P_{k+1})=P_k$,
+    which gives the inverse-indexed grading $P_{k+1}A^i=A^iP_k$.  After the
+    inverse reindexing $P_k\mapsto P_{-k}$ the projectors satisfy the
+    off-diagonal convention $P_{-k}A^i=A^iP_{-(k+1)}$ of
     \cite[eq.~Auprop]{DeLasCuevas2017Irreducible}, under which the
     corner-transition products are nonzero.
 \end{lemma}
 
 \begin{proof}\leanok
-    Apply the stored grading at sector $-(k+1)$ and simplify the cyclic index.
+    Apply the grading at sector $-(k+1)$ and simplify the cyclic index.
 \end{proof}
 
 \begin{lemma}[Telescoping of a corner product]
@@ -895,8 +895,9 @@ unconditional result.
     \lean{MPSTensor.cornerProd_eq_conj_evalWord}
     \leanok
     \uses{def:periodic_corner_product}
-    Under the off-diagonal convention $P_kA^i=A^iP_{k+1}$, the repeated
-    corner-transition product collapses through its intermediate projectors:
+    Under the off-diagonal convention $P_kA^i=A^iP_{k+1}$, with the $P_k$
+    orthogonal projections, the repeated corner-transition product collapses
+    through its intermediate projectors:
     \[
         F_u^{\mathbf i}=P_u\,A^{\mathbf i}\,P_{u+|\mathbf i|},
     \]
@@ -916,8 +917,10 @@ unconditional result.
     \lean{MPSTensor.cornerProd_eq_blockDiagCorner}
     \leanok
     \uses{lem:periodic_cornerprod_telescope}
-    For a single blocked letter, the corner-transition product is the diagonal
-    blocked corner of \cite[eq.~Cu]{DeLasCuevas2017Irreducible}:
+    Under the off-diagonal convention $P_kA^i=A^iP_{k+1}$, with the $P_k$
+    orthogonal projections, the corner-transition product of a single blocked
+    letter is the diagonal blocked corner of
+    \cite[eq.~Cu]{DeLasCuevas2017Irreducible}:
     \[
         F_u^{(I)}=P_u\,(A^{[m]})^I\,P_u .
     \]

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -809,6 +809,128 @@ unconditional result.
     sector.
 \end{proof}
 
+\begin{lemma}[Repeated-block matrix identity]
+    \label{lem:periodic_corner_product_blockmatch_pow}
+    \lean{MPSTensor.cornerProd_blockMatch_pow}
+    \leanok
+    \uses{def:periodic_corner_product, lem:periodic_corner_product_append}
+    Suppose the $m$-block product identity
+    \[
+        A_u^{i_1}\cdots A_{u+m-1}^{i_m}
+        =
+        c_u\, B_{u+q}^{i_1}\cdots B_{u+q+m-1}^{i_m}
+    \]
+    holds for every base sector $u$ and every length-$m$ word.  Then for every
+    word $W$ of length $km$ with $k\ge1$,
+    \[
+        F_u^{W}=c_u^{\,k}\,\widehat F_{u+q}^{W},
+    \]
+    where $\widehat F$ is the repeated corner product built from $B$.  Each of
+    the $k$ successive length-$m$ blocks is anchored at the same base sector
+    $u$, because a full cycle of unit shifts is trivial, $m\cdot 1=0$ in
+    $\mathbb Z_m$; hence every block contributes the same scalar $c_u$.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:periodic_corner_product_append}
+    Induct on $k$.  The base case $k=1$ is the hypothesis.  For the inductive
+    step split $W$ into its first length-$m$ block and the remaining length-$km$
+    word, apply the concatenation law, and use that the junction shift
+    $m\cdot 1=0$ returns to the base sector before applying the block identity
+    and the induction hypothesis.
+\end{proof}
+
+\begin{lemma}[Right-inverse contraction]
+    \label{lem:periodic_corner_contraction}
+    \lean{MPSTensor.cornerProd_contraction}
+    \leanok
+    \uses{def:periodic_corner_letter, def:periodic_corner_product}
+    Let $\Omega_u$ be a finite-sum right inverse of the repeated corner product
+    $F_u$ over length-$L$ words, so that
+    $\sum_{\mathbf j}(\Omega_u(Y))_{\mathbf j}\,F_u^{\mathbf j}=Y$ for every $Y$
+    (\cite[eq.~Omegauprop]{DeLasCuevas2017Irreducible}).  Then for any sector
+    indices $\sigma$ and inserted matrices $X_0,\ldots,X_{m-1}$,
+    \[
+        \sum_{\boldsymbol\rho}
+        \Bigl(\prod_k (\Omega_{k+1}(X_k))_{\rho_k}\Bigr)
+        \prod_k A_k^{\sigma_k}\,F_{k+1}^{\rho_k}
+        =
+        \prod_k A_k^{\sigma_k}\,X_k .
+    \]
+    Summing the concatenated chain against the inverse coefficients collapses
+    each repeated product $F_{k+1}$ to its inserted matrix $X_k$.  This is the
+    algebraic content of applying the tensor of right inverses
+    $\Omega_{u+1}\otimes\cdots\otimes\Omega_u$ and invoking the recovery
+    identity.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:periodic_corner_product}
+    Expand each $A_k^{\sigma_k}X_k=\sum_{\mathbf j}(\Omega_{k+1}(X_k))_{\mathbf
+    j}\,A_k^{\sigma_k}F_{k+1}^{\mathbf j}$ using the right inverse, distribute
+    the ordered product of sums over all choices $\boldsymbol\rho$, and pull the
+    scalar coefficients out of each ordered product.
+\end{proof}
+
+\begin{lemma}[Inverse cyclic reindexing to the off-diagonal convention]
+    \label{lem:periodic_negreindex_shift}
+    \lean{MPSTensor.negReindex_paper_shift}
+    \leanok
+    \uses{thm:cyclic_sector_offdiag_shift}
+    The cyclic sector data stores the adjoint shift
+    $\mathcal E^*(P_{k+1})=P_k$, which gives the inverse-indexed grading
+    $P_{k+1}A^i=A^iP_k$.  After the inverse reindexing $P_k\mapsto P_{-k}$ the
+    projectors satisfy the off-diagonal convention
+    $P_{-k}A^i=A^iP_{-(k+1)}$ of
+    \cite[eq.~Auprop]{DeLasCuevas2017Irreducible}, under which the
+    corner-transition products are nonzero.
+\end{lemma}
+
+\begin{proof}\leanok
+    Apply the stored grading at sector $-(k+1)$ and simplify the cyclic index.
+\end{proof}
+
+\begin{lemma}[Telescoping of a corner product]
+    \label{lem:periodic_cornerprod_telescope}
+    \lean{MPSTensor.cornerProd_eq_conj_evalWord}
+    \leanok
+    \uses{def:periodic_corner_product}
+    Under the off-diagonal convention $P_kA^i=A^iP_{k+1}$, the repeated
+    corner-transition product collapses through its intermediate projectors:
+    \[
+        F_u^{\mathbf i}=P_u\,A^{\mathbf i}\,P_{u+|\mathbf i|},
+    \]
+    where $A^{\mathbf i}$ is the ordinary word product and the right projector
+    records the accumulated sector offset.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{def:periodic_corner_product}
+    Induct on the word.  The head junction $P_uA^iP_{u+1}=P_uA^i$ collapses by
+    the shift and idempotency; the induction hypothesis handles the tail, and the
+    accumulated offset realigns.
+\end{proof}
+
+\begin{lemma}[Blocked letter as a diagonal corner]
+    \label{lem:periodic_cornerprod_blockdiag}
+    \lean{MPSTensor.cornerProd_eq_blockDiagCorner}
+    \leanok
+    \uses{lem:periodic_cornerprod_telescope}
+    For a single blocked letter, the corner-transition product is the diagonal
+    blocked corner of \cite[eq.~Cu]{DeLasCuevas2017Irreducible}:
+    \[
+        F_u^{(I)}=P_u\,(A^{[m]})^I\,P_u .
+    \]
+    Combined with the corner-isomorphism letter identity, this exhibits the
+    compressed sector letter as a corner-transition product.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:periodic_cornerprod_telescope}
+    A blocked letter is a word of length exactly $m$; the accumulated offset
+    $m\cdot1=0$ vanishes, so the telescoping gives the diagonal corner.
+\end{proof}
+
 \begin{theorem}[Cyclic-sector single-site grading]
     \label{thm:cyclic_sector_offdiag_shift}
     \lean{MPSTensor.IsCyclicSectorDecomp.offDiag_shift}
@@ -1296,6 +1418,7 @@ unconditional result.
     \uses{lem:sector_match_propagation, def:cyclic_sector_decomp,
         def:periodic_corner_letter, def:periodic_corner_product,
         lem:periodic_corner_product_append,
+        lem:periodic_corner_product_blockmatch_pow, lem:periodic_corner_contraction,
         thm:periodic_product_one_phase_extraction,
         thm:left_canonical_sector_scalar_normalization, lem:finite_cycle_coboundary}
     Let $A$ and $B$ be left-canonical tensors with period $m$, and let

--- a/blueprint/src/chapter/ch22_periodic_ft.tex
+++ b/blueprint/src/chapter/ch22_periodic_ft.tex
@@ -867,16 +867,21 @@ unconditional result.
 \begin{proof}\leanok
     \uses{def:periodic_corner_product}
     Expand each $A_k^{\sigma_k}X_k=\sum_{\mathbf j}(\Omega_{k+1}(X_k))_{\mathbf
-    j}\,A_k^{\sigma_k}F_{k+1}^{\mathbf j}$ using the right inverse, distribute
-    the ordered product of sums over all choices $\boldsymbol\rho$, and pull the
-    scalar coefficients out of each ordered product.
+    j}\,A_k^{\sigma_k}F_{k+1}^{\mathbf j}$ using the right inverse, apply the
+    noncommutative distributivity identity
+    \[
+        \prod_k\Bigl(\sum_{\mathbf j} f_{k,\mathbf j}\Bigr)
+        =\sum_{\boldsymbol\rho}\prod_k f_{k,\rho_k},
+    \]
+    and pull the scalar coefficients $\prod_k(\Omega_{k+1}(X_k))_{\rho_k}$ out of
+    each ordered product.
 \end{proof}
 
 \begin{lemma}[Inverse cyclic reindexing to the off-diagonal convention]
     \label{lem:periodic_negreindex_shift}
     \lean{MPSTensor.negReindex_paper_shift}
     \leanok
-    \uses{thm:cyclic_sector_offdiag_shift}
+    \uses{thm:offdiag_shift_adjoint_cyclic_shift}
     Let $A$ be left-canonical, $\sum_i A_i^\dagger A_i=1$, with orthogonal sector
     projectors $P_k$ satisfying the adjoint shift $\mathcal E^*(P_{k+1})=P_k$,
     which gives the inverse-indexed grading $P_{k+1}A^i=A^iP_k$.  After the


### PR DESCRIPTION
## Summary

Advances the periodic-MPS Fundamental Theorem (arXiv:1708.00029) toward closing its single remaining `sorry` (`repeatedBlocks_of_blockedSectorGaugePhase`, the Case-3 m-factor cyclic contraction, issue #873). Adds two new **sorry-free, axiom-clean** files supplying the load-bearing building blocks of the Appendix-A contraction, matching the paper's notation throughout.

### `TNLean/MPS/Periodic/CornerContraction.lean`
The two algebraic mechanisms of the contraction (App. A, lines 1041–1068):
- `cornerProd_blockMatch_pow` — the **repeated-block matrix identity** (eq:Fu): given the m-block product identity for every length-`m` word, propagates it to every word of length `k·m` via `cornerProd_append` (using `m·1 = 0` in `Fin m` to anchor each block at the base sector).
- `ofFn_contraction` — the **Ω-contraction mechanism** (eq:Omegauprop), stated abstractly over any ℂ-algebra: summing the concatenated chain against the right-inverse coefficients collapses each repeated product to its inserted matrix. Its periodic instance is `cornerProd_contraction`.

### `TNLean/MPS/Periodic/SectorLift.lean`
The corner-product → blocked-corner encoding connectors (App. A, lines 1012–1046):
- `cornerProd_eq_conj_evalWord` — telescoping `F_u^𝐢 = P_u · A^𝐢 · P_{u+|𝐢|}` under the off-diagonal convention.
- `cornerProd_eq_blockDiagCorner` — a single blocked letter is the diagonal corner `P_u (A^[m])^I P_u` (eq:Cu / Lemma bdcf), exhibiting the compressed sector letter as a corner-transition product.
- `negReindex_paper_shift` — **convention repair.** The cyclic sector data stores the adjoint grading `P_{k+1}A^i = A^i P_k`, under which `cornerProd` *vanishes* for `|w| ≥ 2` (m ≥ 3). After the inverse reindexing `P_k ↦ P_{-k}` the projectors satisfy the paper's off-diagonal convention (eq:Auprop), under which the corner products are nonzero. This connector makes the contraction lemmas non-vacuously applicable to the stored cyclic-sector data.

## Blueprint
Five new `\leanok` lemma entries in `ch22_periodic_ft.tex`, and the `\notready` contraction lemma `lem:sector_tensor_proportional_blocked_match` now `\uses` them — sharpening the proof graph to reflect the proven sub-steps.

## Verification
All six headline lemmas are `#print axioms` clean (`[propext, Classical.choice, Quot.sound]`, no `sorryAx`); both files build (`lake build … CornerContraction`, `… SectorLift`); no lines > 100 chars.

## Remaining `#873` gap (precisely stated)
This PR supplies the contraction mechanisms and the encoding connectors. The contraction's remaining input — `eq:BCmprop` as a *nonzero* `cornerProd` identity — still requires the **`U_v` corner-unitary construction**: `hBlockMatch` provides only an invertible gauge `X_u` and a nonzero scalar `ζ_u`, whereas the global gauge needs partial isometries `U_v = P_u U_v Q_v` and `|κ_v| = 1`. These are steps 2–4 of #873 (the unitary-intertwiner + left-canonical normalization, candidate infra `StarSubalgebraUnitaryIntertwiner`), followed by the `eq:resultprop` PiTensorProduct recombination feeding `exists_kappa_product_one_of_piTensorProduct_eq_root_smul`. Tracked in #873; documented in `docs/paper-gaps/1708_periodic_overlap_route_alignment.tex`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure additive formalization and blueprint linking; no changes to auth, runtime, or existing proof obligations beyond new imports.
> 
> **Overview**
> Adds **sorry-free** Lean formalizations for the periodic overlap Case-3 contraction (arXiv:1708.00029, Appendix A) and wires them into the library and blueprint.
> 
> **`CornerContraction.lean`** proves the two contraction mechanisms: `cornerProd_blockMatch_pow` (length-`m` block match extends to words of length `k·m` via `m·1 = 0` in `Fin m`), plus abstract `ofFn_contraction` and periodic `cornerProd_contraction` (Ω right-inverse sum collapses repeated `F` products to inserted matrices).
> 
> **`SectorLift.lean`** proves telescoping `cornerProd` to `P_u · evalWord · P_{u+|w|}` under the paper off-diagonal shift, diagonal corners for period-aligned words and blocked letters (`eq:Cu`), and `negReindex_paper_shift` so cyclic-sector data (adjoint grading) can use those lemmas after `P_k ↦ P_{-k}`.
> 
> **`TNLean.lean`** imports the two new modules. **`ch22_periodic_ft.tex`** gains five `\leanok` lemmas and extends `\uses` on the still-`\notready` `lem:sector_tensor_proportional_blocked_match` to cite the new steps. The full Case-3 capstone (`sectorTensor_proportional_of_blockedMatch` / unitary `U_v` and `eq:resultprop` recombination) remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce4c2b5ec46f21c8cd10a3321137d83b8807cb8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->