### PR TITLE
chore(MPS/ParentHamiltonian): repoint stale closed-#2971 tracking pointers to #3597

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChain.lean
@@ -108,7 +108,7 @@ open-boundary span \(\bigvee_jG_N(A_j)\) by
 \(\sum_j\mathcal G_{N,L}(A_j)\) — is the separate comparison of
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_groundSpace_of_ge_of_bnt_directSum_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -192,7 +192,7 @@ windows. The periodic-boundary upgrade replacing \(S_N\) by
 \(\sum_j\mathcal G_{N,L}(A_j)\) is the separate comparison of
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_le_iSup_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -242,7 +242,7 @@ block-separation independence, both independent of the boundary-condition
 comparison at boundary-crossing windows. That periodic-boundary comparison
 (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128) is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem exists_unique_sum_groundSpace_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -325,7 +325,7 @@ the boundary-condition comparison at boundary-crossing windows. The
 periodic-boundary upgrade to \(\mathcal G_{N,L}(A_j)\) (arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456; arXiv:2011.12127, Section IV.C, lines
 2126--2128) is the separate step recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_of_chainGroundSpace_toTensorFromBlocks_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -442,7 +442,7 @@ comparison at boundary-crossing windows. The periodic-boundary upgrade
 replacing \(\bigvee_jG_N(A_j)\) by \(\sum_j\mathcal G_{N,L}(A_j)\)
 (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128) is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` (issue 2971). -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_two_inclusions_and_iSupIndep_of_bnt_unital_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -857,7 +857,7 @@ proved (its components lie in \(G_N(A_j)\)); the periodic-boundary upgrade is th
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
 from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_blockBoundary
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalChainBoundary.lean
@@ -43,7 +43,7 @@ hypothesis `hBoundary` here. The span-based open-boundary decomposition is prove
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
 from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_bnt_c1_boundary_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossing.lean
@@ -820,7 +820,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by `hIdentit
 is the boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof
 lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet
 derived from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_complementary_identities_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -885,7 +885,7 @@ comparison. The periodic-boundary upgrade encoded by `hIdentity` is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
 from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -69,7 +69,7 @@ comparison. The periodic-boundary upgrade encoded by `hComparison` is the
 boundary-condition comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines
 1446--1456, and arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived
 from the periodic ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -261,8 +261,7 @@ boundary-crossing comparison.
 crossing-tail span hypothesis noted above, which supplies the periodic-boundary
 upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in
-issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -350,8 +349,7 @@ boundary-crossing comparison.
 crossing-tail span hypothesis noted above, which supplies the periodic-boundary
 upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in
-issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -419,8 +417,7 @@ boundary-crossing comparison.
 crossing-tail span hypothesis noted above, which supplies the periodic-boundary
 upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in
-issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -480,7 +477,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -550,7 +547,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
@@ -612,7 +609,7 @@ boundary-crossing comparison. The periodic-boundary upgrade encoded by
 `hComparison` is the boundary-condition comparison of arXiv:quant-ph/0608197,
 Theorem 12, proof lines 1446--1456, and arXiv:2011.12127, Section IV.C, lines
 2126--2128, not yet derived from the periodic ground-space constraint. Documented
-in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+in `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_comparison
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
     (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalTraceDecomposition.lean
@@ -180,8 +180,7 @@ trace decompositions.
 
 **Scope restriction (boundary representation and trace decomposition):** The
 block-diagonal boundary representation of \(\psi\) and the displayed trace
-decompositions are hypotheses here. Removing these remaining inputs is tracked
-in issue 2971 and documented in
+decompositions are hypotheses here. Removing these remaining inputs is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_of_boundary
     {r : ℕ} {dim : Fin r → ℕ}
@@ -260,7 +259,7 @@ hypothesis.
 
 **Scope restriction (boundary representation):** The block-diagonal boundary
 representation of \(\psi\) is a hypothesis here. Removing this remaining input
-is tracked in issue 2971 and documented in
+is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem blockDiagonal_boundary_crossing_trace_decomposition_of_boundary
     {r : ℕ} {dim : Fin r → ℕ}
@@ -376,7 +375,7 @@ replace the separate common product-spanning length hypothesis.
 
 **Scope restriction (boundary representation):** The block-diagonal boundary
 representation of \(\psi\) is a hypothesis here. Removing this remaining
-hypothesis is tracked in issue 2971 and documented in
+hypothesis is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem blockDiagonal_boundary_crossing_trace_decompositions_of_boundary
     {r : ℕ} {dim : Fin r → ℕ}
@@ -468,7 +467,7 @@ arXiv:quant-ph/0608197, Theorem 12, lines 1446--1451.
 
 **Scope restriction (boundary representation):** The block-diagonal boundary
 representation of \(\psi\) is a hypothesis here. Removing this remaining input
-is tracked in issue 2971 and documented in
+is documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem exists_blockDiagonal_boundary_chainGroundSpace_of_pgvwc_comparison_of_boundary
     {r : ℕ} {dim : Fin r → ℕ}
@@ -546,7 +545,7 @@ comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-conditio
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
 ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -622,7 +621,7 @@ comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-conditio
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
 ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -701,7 +700,7 @@ comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-conditio
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
 ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
@@ -772,7 +771,7 @@ comparison with \(D^j_\beta=(\mu_j^NX_j)A^j_\beta\) — is the boundary-conditio
 comparison of arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456, and
 arXiv:2011.12127, Section IV.C, lines 2126--2128, not yet derived from the periodic
 ground-space constraint. Documented in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`; tracked in issue 2971. -/
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
     chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span
     {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -55,9 +55,13 @@ canonical form notation, while $b$ follows
 Cirac et al. describe the degenerate parent-Hamiltonian ground space for a
 matrix product state with more than one block in canonical form in Section~IV.C
 of \cite{Cirac2021Matrix}.\footnote{For
-	traceability, the remaining derivation of the source comparison currently
-	assumed by the conditional theorems is tracked by
-	\href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}. Pull
+	traceability, the source comparison is now proved on the main branch
+	(\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean}); the
+	remaining step, discharging the explicit comparison hypothesis still assumed
+	by the conditional theorems, is tracked by
+	\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} (the earlier
+	tracker \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971} for
+	proving the comparison is now closed). Pull
 	request~\#2724 records the conditional reduction on the main branch, reducing
 	the unconditional target to the boundary-crossing comparison identities.
 	Earlier reductions were tracked by


### PR DESCRIPTION
## Summary

Tracking-reference hygiene for the block-diagonal parent-Hamiltonian markers,
following the same pattern as #3594.

Issue #2971 (*PGVWC07 boundary comparison for block-diagonal parent spaces*) is
**closed as COMPLETED**: per its own closing analysis, the boundary-crossing
`C^j/D^j` comparison is now **proved** source-faithfully in
`blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup`
(`BNTBlockDiagonalCrossingTrace.lean`), with "no invented path". The **residual**
— discharging the explicit `hComparison` hypothesis still carried by the
conditional `*_of_pgvwc_comparison_*` theorems by wiring in the proved
comparison — is the genuine open work, now tracked in **#3597**.

But **24 in-source markers** across the five `BNTBlockDiagonal*.lean` files (and
the paper-gap note) still cited the **closed** #2971 as if it tracked that
residual — a dead forward pointer that makes the markers "annoying to check".

## Changes

- Remove the `#2971` issue-number clauses from the 24 markers. Per
  `docs/prose_style.md` (enforced by `check_reader_facing_prose.py`), Lean
  docstrings cite the paper-gap note, not an issue number — the note
  `cpgsv21_block_diagonal_parent_ground_space.tex` remains cited in each marker.
- Repoint the note's own tracker line from #2971 to #3597, and record that the
  comparison is now proved on `main`.

Comment-only; no proof or signature changes. `check_reader_facing_prose.py`
passes; no line exceeds 100 chars.

Companion: issue #3597 (created), parent tracker #190. The proving milestone
remains correctly closed under #2971.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only tracking and docstring edits; no executable or proof logic changes.
> 
> **Overview**
> **Documentation hygiene** for block-diagonal parent-Hamiltonian periodic-boundary scope markers, with no Lean proof or signature changes.
> 
> Across **five** `BNTBlockDiagonal*.lean` files, **~24** docstring edits drop clauses that pointed at **closed** issue **#2971** (e.g. `(issue 2971)`, `tracked in issue 2971`). Each marker still cites `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`, matching reader-facing prose rules (paper-gap note, not issue numbers in Lean).
> 
> In **`cpgsv21_block_diagonal_parent_ground_space.tex`**, the traceability footnote is updated: the PGVWC boundary comparison is **proved** on main (`BNTBlockDiagonalCrossingTrace.lean`); **#3597** tracks discharging the explicit `hComparison` / conditional hypotheses; **#2971** is noted as closed for proving the comparison.
> 
> Some **TraceDecomposition** markers are reworded from “tracked in issue 2971” to “documented in” the paper-gap note only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0779be408a10ba47b222e995cd8b38602ded4472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->