### PR TITLE
doc: correct misused and stale scope-restriction markers (SchmidtNumber, equalMPS)

### DIFF
--- a/TNLean/Channel/SchmidtNumberFactors.lean
+++ b/TNLean/Channel/SchmidtNumberFactors.lean
@@ -511,9 +511,9 @@ corner sandwich, which stays `n`-positive; the square pure-state step makes the 
 ampliation positive semidefinite; and the original ampliation is its `d × d'`
 principal-corner submatrix.
 
-**Scope restriction (d ≤ d'):** the first factor is padded up to the second factor
-`d'`; the complementary case `d' ≤ d` is `tensorMapId_posSemidef_of_hasSchmidtRankLE'`.
-Both are combined without restriction in
+This lemma handles the case `d ≤ d'`, padding the first factor up to `d'`; the
+complementary case `d' ≤ d` is `tensorMapId_posSemidef_of_hasSchmidtRankLE'`, and
+the two are combined without restriction in
 `tensorMapId_posSemidef_of_hasSchmidtRankLE_general`. -/
 theorem tensorMapId_posSemidef_of_hasSchmidtRankLE'' [NeZero d'] {n : ℕ} (h : d ≤ d')
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
@@ -545,9 +545,10 @@ which preserves the Schmidt-number bound; the corner extension of `T` stays
 `n`-positive; the square forward step makes the padded ampliation positive
 semidefinite; and the original ampliation is its `d × d'` principal-corner submatrix.
 
-**Scope restriction (d ≤ d'):** inherited from the pure-state step; the complementary
-case `d' ≤ d` is `HasSchmidtNumberLE.tensorMapId_posSemidef'`.  Both are combined
-without restriction in `HasSchmidtNumberLE.tensorMapId_posSemidef_general`. -/
+This lemma handles the case `d ≤ d'` (inherited from the pure-state step); the
+complementary case `d' ≤ d` is `HasSchmidtNumberLE.tensorMapId_posSemidef'`, and the
+two are combined without restriction in
+`HasSchmidtNumberLE.tensorMapId_posSemidef_general`. -/
 theorem HasSchmidtNumberLE.tensorMapId_posSemidef'' [NeZero d'] {n : ℕ} (h : d ≤ d')
     {T : Matrix (Fin d) (Fin d) ℂ →ₗ[ℂ] Matrix (Fin d) (Fin d) ℂ}
     (hTpos : IsNPositiveMap n T)

--- a/TNLean/MPS/FundamentalTheorem/Proportional.lean
+++ b/TNLean/MPS/FundamentalTheorem/Proportional.lean
@@ -222,12 +222,14 @@ cross-transfer-matrix spectral radius (computed via
 together with the rigidity theorem
 `modulus_one_eigenvalue_implies_gauge_of_irreducible_TP`.
 
-**Scope restriction (same bond dimension):** The source Lemma equalMPS also
-concludes equality of the two bond dimensions in the unit-overlap case. This
-theorem proves the gauge recovery after the common bond dimension has already
-been identified. The rectangular component is proved separately as
-`dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP` in this file; together
-the two theorems recover the full structural conclusion of the source lemma. -/
+**Scope restriction (same bond dimension):** this theorem proves the gauge
+recovery for two tensors of a common bond dimension `D`. The source Lemma
+equalMPS additionally concludes `D_a = D_b` in the unit-overlap case; that
+bond-dimension matching follows from the rectangular overlap-decay theorem
+`mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP` (distinct bond dimensions
+force the overlap to decay, so a non-decaying overlap forces equal dimensions),
+which is applied directly where blocks of differing dimension arise. Documented
+in `docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex`. -/
 theorem gaugePhaseEquiv_of_overlap_norm_tendsto_one_of_irreducible_TP
     (A B : MPSTensor d D)
     (hA_irr : IsIrreducibleTensor (d := d) (D := D) A)

--- a/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
+++ b/docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex
@@ -97,13 +97,16 @@ between the two bond spaces and then uses normality of the larger tensor to rule
 out a proper missing subspace, forcing equality of dimensions
 \cite[lines~1115--1117]{Cirac2016MPDO_arXiv}.
 
-The formalization records this conclusion as
-\leanid{MPSTensor.dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP}
-in \path{TNLean/MPS/FundamentalTheorem/Proportional.lean}. Its proof uses the
-contrapositive of the rectangular overlap-decay theorem
-\leanid{MPSTensor.mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP}:
-if the bond dimensions differ, the overlap tends to zero, contradicting the
-unit-modulus overlap hypothesis.
+This bond-dimension matching is obtained from the rectangular overlap-decay
+theorem
+\leanid{MPSTensor.mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP}
+in \path{TNLean/Spectral/TransferOperatorGapNT.lean}: if the bond dimensions
+differ, the overlap tends to zero, contradicting the unit-modulus overlap
+hypothesis, so a non-decaying overlap forces $D_a=D_b$. (A standalone
+contrapositive packaging of this step in
+\path{TNLean/MPS/FundamentalTheorem/Proportional.lean} was removed as part of a
+superseded route; the decay theorem is now applied directly where blocks of
+differing dimension arise.)
 
 This rectangular dimension recovery is genuinely needed in the proof of
 Theorem~\texttt{thm1}
@@ -118,7 +121,8 @@ after the rectangular dimension conclusion has been supplied separately.
 
 The same-bond-dimension gauge component is formalized without the
 source-absent MPV proportionality hypothesis. The rectangular
-bond-dimension conclusion $D_a=D_b$ is now formalized as a separate theorem.
+bond-dimension conclusion $D_a=D_b$ follows from the rectangular overlap-decay
+theorem, which is applied directly where blocks of differing dimension arise.
 Together these two components recover the structural conclusion of the
 unit-overlap branch of Lemma~\texttt{equalMPS}, though the upstream normal-tensor
 periodicity and dichotomy statements remain separate from this note.


### PR DESCRIPTION
## Summary

A citation-integrity audit of faithfulness markers found two marker-accuracy defects that misrepresent what is actually formalized — exactly the kind of "annoying to check" mismatch we want to eliminate.

### 1. `Channel/SchmidtNumberFactors.lean` — misused marker (2 occurrences)

`tensorMapId_posSemidef_of_hasSchmidtRankLE''` and
`HasSchmidtNumberLE.tensorMapId_posSemidef''` carried a
`**Scope restriction (d ≤ d'):**` marker. But the general (unrestricted) case **is**
formalized — `..._general` (lines 587/605, no `d ≤ d'` hypothesis), which is what
the blueprint cites (`ch25_positive_not_cp.tex:822`). These are internal case-split
helpers, not an unformalized paper gap, so the marker (which signals a paper
deviation requiring a note) is the wrong framing. Rephrased to plain case-split
prose; the cross-references to the sibling and `_general` lemmas are kept.

### 2. `Proportional.lean` + `cpsv16_equalMPS_gauge_phase_gap.tex` — stale phantom citation

Both the in-source marker and the paper-gap note cited
`dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP` as recording the equalMPS
`D_a = D_b` conclusion. That theorem **does not exist** — it was deliberately removed
by refactor 49cbb95c2 ("remove the superseded sector-basis-matching route", −58
lines, blueprint `\lean` ref also removed), but the two prose citations were left
behind. The marker further over-claimed that "the two theorems recover the full
structural conclusion."

Corrected both to credit the theorem that **does** exist and carries the content:
the rectangular overlap-decay theorem
`MPSTensor.mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP`
(`TNLean/Spectral/TransferOperatorGapNT.lean`), whose contrapositive forces
`D_a = D_b`, and noted that the standalone packaging was removed as superseded.

## Notes

Comment-only; no proof or signature changes. `check_reader_facing_prose.py` passes;
no line exceeds 100 chars. Relates to the equalMPS faithfulness area
(`docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no Lean proofs, types, or APIs change.
> 
> **Overview**
> **Documentation-only** fixes to faithfulness / scope markers so prose matches what is actually formalized (no proof or signature changes).
> 
> In **`SchmidtNumberFactors.lean`**, two docstrings for the `d ≤ d'` case-split lemmas (`tensorMapId_posSemidef_of_hasSchmidtRankLE''` and `HasSchmidtNumberLE.tensorMapId_posSemidef''`) no longer use **`Scope restriction (d ≤ d')`**, which wrongly implied a paper gap. They now describe these as the `d ≤ d'` branch, with pointers to the `d' ≤ d` sibling and the unrestricted **`_general`** lemmas.
> 
> In **`Proportional.lean`** and **`docs/paper-gaps/cpsv16_equalMPS_gauge_phase_gap.tex`**, prose that cited the removed theorem **`dim_eq_of_overlap_norm_tendsto_one_of_irreducible_TP`** now credits **`mpvOverlap_tendsto_zero_of_dim_ne_of_irreducible_TP`** (`TransferOperatorGapNT.lean`): differing bond dimensions force overlap decay, so unit-modulus overlap implies **`D_a = D_b`**, applied directly where rectangular blocks appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16ff85c8ea3e0011e0489777d11ec25b5839644b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->