### PR TITLE
feat(MPS/RFP): cross-block orthogonality of the RFP isometry via mixed-transfer spectral gap (arXiv:1606.00608, #3488)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -387,6 +387,7 @@ import TNLean.MPS.RFP.CommutingBridge
 import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Assembly
 import TNLean.MPS.RFP.Decorrelation
+import TNLean.MPS.RFP.BNTOrthogonality
 
 -- Layer 6a: Quantum Wielandt span-growth infrastructure
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -45,7 +45,7 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
-/-! ## Stage 1: block decomposition of a block-diagonal transfer sum -/
+/-! ## Block decomposition of a block-diagonal transfer sum -/
 
 section BlockDecomposition
 
@@ -96,7 +96,7 @@ private lemma blockDiagonal'_mul_mul_toBlock
   refine Finset.sum_congr rfl fun b _ => ?_
   rw [Matrix.blockDiagonal'_apply_eq, Matrix.submatrix_apply, blockIncl, blockIncl]
 
-/-- **Stage 1 (Σ-level).** The `(j, j')` bond block of the block-diagonal
+/-- The `(j, j')` bond block of the block-diagonal
 transfer sum `∑_i (⊕_k B_k^i) X (⊕_k B_k^i)^†` is the mixed transfer operator
 `mixedTransferMap₂ (B j) (B j')` applied to the `(j, j')` bond block of `X`.
 
@@ -156,7 +156,7 @@ theorem transferMap_directSumTensor_reindex
   rw [Matrix.conjTranspose_submatrix, Matrix.submatrix_mul_equiv _ _ _ e.symm _,
     Matrix.submatrix_mul_equiv _ _ _ e.symm _]
 
-/-- **Stage 2 (idempotence transfer).** Whole-tensor RFP of the direct sum makes
+/-- Whole-tensor RFP of the direct sum makes
 the block-diagonal transfer sum idempotent. -/
 theorem blockTransferSum_blockTransferSum
     (B : (k : Fin r) → MPSTensor d (dim k))
@@ -198,7 +198,7 @@ private lemma exists_toBlock_eq (j j' : Fin r) [NeZero (dim j)] [NeZero (dim j')
     funext (Function.leftInverse_invFun hinj_j')
   rw [Matrix.submatrix_submatrix, hj, hj', Matrix.submatrix_id_id]
 
-/-- **Stage 2 (off-diagonal idempotence).** Whole-tensor RFP of the direct sum
+/-- Whole-tensor RFP of the direct sum
 makes every (in particular off-diagonal) mixed transfer operator idempotent. -/
 theorem mixedTransferMap₂_isIdempotentElem_of_isRFP_directSum
     (B : (k : Fin r) → MPSTensor d (dim k))
@@ -230,7 +230,7 @@ theorem mixedTransferMap₂_isIdempotentElem_of_isRFP_directSum
 
 end BlockDecomposition
 
-/-! ## Stage 2: spectral gap forces the off-diagonal operator to vanish -/
+/-! ## Spectral gap forces the off-diagonal operator to vanish -/
 
 section Spectral
 
@@ -306,7 +306,7 @@ private lemma mixedTransferSpectralRadius₂_lt_one_of_dim_eq
 
 end Spectral
 
-/-! ## Stage 2 main theorem -/
+/-! ## Cross-block orthogonality of the blocks -/
 
 section Main
 

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -1,0 +1,350 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.ZeroCorrelationLength
+import TNLean.MPS.Core.MultiBlock
+import TNLean.Spectral.TransferOperatorGapNT
+
+/-!
+# Cross-block orthogonality of the renormalization fixed-point isometry
+
+This file proves the cross-block (`j ≠ j'`) vanishing of the mixed transfer
+operator for a multi-block tensor whose direct sum is a renormalization fixed
+point, the off-diagonal content of the isometry condition `eq:III_isometry`
+(arXiv:1606.00608, line 551):
+\[
+  \sum_i (U_j^i)_{\alpha,\beta}\,\overline{(U_{j'}^i)_{\alpha',\beta'}}
+    = \delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
+\]
+The diagonal `j = j'` case is `IsIsometryCanonicalForm`
+(`TNLean/MPS/RFP/StructuralFull.lean`).
+
+## Main results
+
+* `blockDiagonal'_transferSum_toBlock` — block decomposition of the direct-sum
+  transfer sum: its `(j, j')` bond block acts as
+  `mixedTransferMap₂ (B j) (B j')`.  This is the reusable foundation, parallel
+  to `evalWord_blockDiagonal'`.
+
+## Route
+
+The off-diagonal mixed transfer operator `F_{j,j'} = mixedTransferMap₂ (B j)
+(B j')` is shown to be idempotent (whole-tensor RFP, via the block
+decomposition), and then to have spectral radius `< 1` (distinct irreducible
+left-canonical blocks, splitting on equal versus unequal bond dimension); an
+idempotent operator with spectral radius `< 1` is `0`.  The diagonal lemma
+`transferMap_eq_fixedPointProj_of_isRFP_injective` does *not* compose across
+blocks and is not used here.
+-/
+
+open scoped Matrix BigOperators Matrix.Norms.Operator
+open Filter Topology
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-! ## Stage 1: block decomposition of a block-diagonal transfer sum -/
+
+section BlockDecomposition
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+
+/-- The canonical inclusion of the `k`-th bond block into the direct-sum bond
+space, `α ↦ ⟨k, α⟩`. -/
+def blockIncl (k : Fin r) (dim : Fin r → ℕ) :
+    Fin (dim k) → (k : Fin r) × Fin (dim k) :=
+  fun a => ⟨k, a⟩
+
+/-- Submatrices commute with finite sums. -/
+private lemma submatrix_sum' {ι l m p q : Type*}
+    (s : Finset ι) (M : ι → Matrix m p ℂ) (f : l → m) (g : q → p) :
+    (∑ i ∈ s, M i).submatrix f g = ∑ i ∈ s, (M i).submatrix f g := by
+  ext a b
+  simp only [Matrix.submatrix_apply, Matrix.sum_apply]
+
+/-- The `(j, j')` bond block of `(⊕_k L_k) X (⊕_k R_k)` is `L_j · X_{j,j'} · R_{j'}`. -/
+private lemma blockDiagonal'_mul_mul_toBlock
+    (L R : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
+    (X : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ)
+    (j j' : Fin r) :
+    (Matrix.blockDiagonal' L * X * Matrix.blockDiagonal' R).submatrix
+        (blockIncl j dim) (blockIncl j' dim) =
+      L j * X.submatrix (blockIncl j dim) (blockIncl j' dim) * R j' := by
+  classical
+  ext a a'
+  rw [Matrix.submatrix_apply]
+  change (Matrix.blockDiagonal' L * X * Matrix.blockDiagonal' R) (⟨j, a⟩ :
+      (k : Fin r) × Fin (dim k)) ⟨j', a'⟩ = _
+  rw [Matrix.mul_apply, Fintype.sum_sigma]
+  -- reduce the outer (right block-diagonal) index to `j'`
+  rw [Finset.sum_eq_single j'
+    (fun k' _ hk' => Finset.sum_eq_zero fun b' _ => by
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ hk', mul_zero])
+    (fun h => absurd (Finset.mem_univ j') h)]
+  rw [Matrix.mul_apply]
+  refine Finset.sum_congr rfl fun b' _ => ?_
+  rw [Matrix.blockDiagonal'_apply_eq]
+  congr 1
+  -- now reduce the inner (left block-diagonal) index to `j`
+  rw [Matrix.mul_apply, Fintype.sum_sigma, Matrix.mul_apply]
+  rw [Finset.sum_eq_single j
+    (fun k _ hk => Finset.sum_eq_zero fun b _ => by
+      rw [Matrix.blockDiagonal'_apply_ne _ _ _ (Ne.symm hk), zero_mul])
+    (fun h => absurd (Finset.mem_univ j) h)]
+  refine Finset.sum_congr rfl fun b _ => ?_
+  rw [Matrix.blockDiagonal'_apply_eq, Matrix.submatrix_apply, blockIncl, blockIncl]
+
+/-- **Stage 1 (Σ-level).** The `(j, j')` bond block of the block-diagonal
+transfer sum `∑_i (⊕_k B_k^i) X (⊕_k B_k^i)^†` is the mixed transfer operator
+`mixedTransferMap₂ (B j) (B j')` applied to the `(j, j')` bond block of `X`.
+
+This is the transfer-operator analogue of `evalWord_blockDiagonal'`, and the
+reusable foundation for the cross-block content of `eq:III_isometry`
+(arXiv:1606.00608, line 551). -/
+theorem blockDiagonal'_transferSum_toBlock
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (X : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ)
+    (j j' : Fin r) :
+    (∑ i : Fin d, Matrix.blockDiagonal' (fun k => B k i) * X *
+        (Matrix.blockDiagonal' (fun k => B k i))ᴴ).submatrix
+        (blockIncl j dim) (blockIncl j' dim) =
+      mixedTransferMap₂ (B j) (B j')
+        (X.submatrix (blockIncl j dim) (blockIncl j' dim)) := by
+  classical
+  rw [mixedTransferMap₂_apply, submatrix_sum']
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [Matrix.blockDiagonal'_conjTranspose, blockDiagonal'_mul_mul_toBlock]
+
+/-- The block-diagonal transfer sum `∑_i (⊕_k B_k^i) Y (⊕_k B_k^i)^†` on the
+direct-sum bond space (`Σ`-indexed). -/
+noncomputable def blockTransferSum
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
+    Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ :=
+  ∑ i : Fin d, Matrix.blockDiagonal' (fun k => B k i) * Y *
+    (Matrix.blockDiagonal' (fun k => B k i))ᴴ
+
+/-- The direct sum of a finite family of MPS tensors, as a single tensor on the
+total bond space `Fin (∑ k, dim k)`.
+
+This coincides with `CanonicalForm.toTensor` of the canonical form with block
+tensors `B`, all scalar weights `μ_k = 1`, mirroring its `blockDiagonal'`/`Σ`-reindex
+construction (`TNLean/MPS/Core/MultiBlock.lean`). -/
+noncomputable def directSumTensor (B : (k : Fin r) → MPSTensor d (dim k)) :
+    MPSTensor d (∑ k : Fin r, dim k) := fun i =>
+  Matrix.reindex (finSigmaFinEquiv (n := dim)) (finSigmaFinEquiv (n := dim))
+    (Matrix.blockDiagonal' (fun k => B k i))
+
+/-- The transfer map of the direct-sum tensor equals the block-diagonal transfer
+sum conjugated by the `Σ ≃ Fin` reindexing. -/
+theorem transferMap_directSumTensor_reindex
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
+    transferMap (directSumTensor B)
+        (Matrix.reindex (finSigmaFinEquiv (n := dim)) (finSigmaFinEquiv (n := dim)) Y) =
+      Matrix.reindex (finSigmaFinEquiv (n := dim)) (finSigmaFinEquiv (n := dim))
+        (blockTransferSum B Y) := by
+  classical
+  set e := finSigmaFinEquiv (m := r) (n := dim) with he
+  rw [transferMap_apply, blockTransferSum]
+  simp only [Matrix.reindex_apply]
+  rw [submatrix_sum']
+  refine Finset.sum_congr rfl fun i _ => ?_
+  simp only [directSumTensor, Matrix.reindex_apply]
+  rw [Matrix.conjTranspose_submatrix, Matrix.submatrix_mul_equiv _ _ _ e.symm _,
+    Matrix.submatrix_mul_equiv _ _ _ e.symm _]
+
+/-- **Stage 2 (idempotence transfer).** Whole-tensor RFP of the direct sum makes
+the block-diagonal transfer sum idempotent. -/
+theorem blockTransferSum_blockTransferSum
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hRFP : IsRFP (directSumTensor B))
+    (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
+    blockTransferSum B (blockTransferSum B Y) = blockTransferSum B Y := by
+  classical
+  set e := finSigmaFinEquiv (m := r) (n := dim) with he
+  apply (Matrix.reindex e e).injective
+  calc
+    Matrix.reindex e e (blockTransferSum B (blockTransferSum B Y))
+        = transferMap (directSumTensor B) (Matrix.reindex e e (blockTransferSum B Y)) :=
+          (transferMap_directSumTensor_reindex B (blockTransferSum B Y)).symm
+    _ = transferMap (directSumTensor B)
+          (transferMap (directSumTensor B) (Matrix.reindex e e Y)) := by
+            rw [transferMap_directSumTensor_reindex B Y]
+    _ = transferMap (directSumTensor B) (Matrix.reindex e e Y) := by
+          have h := LinearMap.congr_fun hRFP (Matrix.reindex e e Y)
+          simpa only [LinearMap.comp_apply] using h
+    _ = Matrix.reindex e e (blockTransferSum B Y) :=
+          transferMap_directSumTensor_reindex B Y
+
+/-- The `(j, j')` bond-block restriction is surjective: every block matrix is the
+restriction of a direct-sum bond matrix. -/
+private lemma exists_toBlock_eq (j j' : Fin r) [NeZero (dim j)] [NeZero (dim j')]
+    (Z : Matrix (Fin (dim j)) (Fin (dim j')) ℂ) :
+    ∃ Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ,
+      Y.submatrix (blockIncl j dim) (blockIncl j' dim) = Z := by
+  classical
+  have hinj_j : Function.Injective (blockIncl j dim) := by
+    intro a b h; simpa [blockIncl] using h
+  have hinj_j' : Function.Injective (blockIncl j' dim) := by
+    intro a b h; simpa [blockIncl] using h
+  refine ⟨Z.submatrix (Function.invFun (blockIncl j dim))
+      (Function.invFun (blockIncl j' dim)), ?_⟩
+  have hj : Function.invFun (blockIncl j dim) ∘ blockIncl j dim = id :=
+    funext (Function.leftInverse_invFun hinj_j)
+  have hj' : Function.invFun (blockIncl j' dim) ∘ blockIncl j' dim = id :=
+    funext (Function.leftInverse_invFun hinj_j')
+  rw [Matrix.submatrix_submatrix, hj, hj', Matrix.submatrix_id_id]
+
+/-- **Stage 2 (off-diagonal idempotence).** Whole-tensor RFP of the direct sum
+makes every (in particular off-diagonal) mixed transfer operator idempotent. -/
+theorem mixedTransferMap₂_isIdempotentElem_of_isRFP_directSum
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hRFP : IsRFP (directSumTensor B)) (j j' : Fin r)
+    [NeZero (dim j)] [NeZero (dim j')] :
+    IsIdempotentElem (mixedTransferMap₂ (B j) (B j')) := by
+  classical
+  have hStage1 : ∀ Y, (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) =
+      mixedTransferMap₂ (B j) (B j') (Y.submatrix (blockIncl j dim) (blockIncl j' dim)) := by
+    intro Y
+    simpa only [blockTransferSum] using blockDiagonal'_transferSum_toBlock B Y j j'
+  change mixedTransferMap₂ (B j) (B j') * mixedTransferMap₂ (B j) (B j') =
+    mixedTransferMap₂ (B j) (B j')
+  refine LinearMap.ext fun Z => ?_
+  rw [Module.End.mul_apply]
+  obtain ⟨Y, hY⟩ := exists_toBlock_eq j j' Z
+  have e1 : mixedTransferMap₂ (B j) (B j') Z =
+      (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
+    rw [hStage1, hY]
+  calc
+    mixedTransferMap₂ (B j) (B j') (mixedTransferMap₂ (B j) (B j') Z)
+        = mixedTransferMap₂ (B j) (B j')
+            ((blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim)) := by rw [e1]
+    _ = (blockTransferSum B (blockTransferSum B Y)).submatrix
+          (blockIncl j dim) (blockIncl j' dim) := (hStage1 (blockTransferSum B Y)).symm
+    _ = (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
+          rw [blockTransferSum_blockTransferSum B hRFP]
+    _ = mixedTransferMap₂ (B j) (B j') Z := e1.symm
+
+end BlockDecomposition
+
+/-! ## Stage 2: spectral gap forces the off-diagonal operator to vanish -/
+
+section Spectral
+
+variable {D₁ D₂ : ℕ}
+
+attribute [local instance]
+  ContinuousLinearMap.toNormedAddCommGroup
+  ContinuousLinearMap.toNormedRing
+  ContinuousLinearMap.toSeminormedRing
+  ContinuousLinearMap.toNormedAlgebra
+
+local notation "V" => Matrix (Fin D₁) (Fin D₂) ℂ
+
+/-- An idempotent rectangular mixed transfer operator with spectral radius `< 1`
+is the zero map. -/
+private lemma mixedTransferMap₂_eq_zero_of_isIdempotentElem
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hidem : IsIdempotentElem (mixedTransferMap₂ A B))
+    (hsr : mixedTransferSpectralRadius₂ A B < 1) :
+    mixedTransferMap₂ A B = 0 := by
+  classical
+  let Φ : (V →ₗ[ℂ] V) ≃ₐ[ℂ] (V →L[ℂ] V) := Module.End.toContinuousLinearMap V
+  let F' : V →L[ℂ] V := Φ (mixedTransferMap₂ A B)
+  letI : NormedAddCommGroup (V →L[ℂ] V) := ContinuousLinearMap.toNormedAddCommGroup
+  letI : SeminormedRing (V →L[ℂ] V) := ContinuousLinearMap.toSeminormedRing
+  letI : NormedRing (V →L[ℂ] V) := ContinuousLinearMap.toNormedRing
+  letI : NormedSpace ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedSpace
+  letI : NormedAlgebra ℂ (V →L[ℂ] V) := ContinuousLinearMap.toNormedAlgebra
+  haveI : FiniteDimensional ℂ (V →L[ℂ] V) := Φ.toLinearEquiv.finiteDimensional
+  haveI hComplete : CompleteSpace (V →L[ℂ] V) := FiniteDimensional.complete ℂ _
+  have hSpectF : spectralRadius ℂ F' < 1 := by
+    change spectralRadius ℂ
+      (((Module.End.toContinuousLinearMap V)
+        (mixedTransferMap₂ (d := d) (D₁ := D₁) (D₂ := D₂) A B)) : V →L[ℂ] V) < 1
+    rw [mixedTransferSpectralRadius₂_eq] at hsr
+    simpa only [] using hsr
+  have hpow : Tendsto (fun n => F' ^ n) atTop (nhds 0) :=
+    @pow_tendsto_zero_of_spectralRadius_lt_one (V →L[ℂ] V)
+      (ContinuousLinearMap.toNormedRing : NormedRing (V →L[ℂ] V)) hComplete
+      (ContinuousLinearMap.toNormedAlgebra : NormedAlgebra ℂ (V →L[ℂ] V)) F' hSpectF
+  have hFpow : ∀ n, F' ^ (n + 1) = F' := by
+    intro n
+    change (Φ (mixedTransferMap₂ A B)) ^ (n + 1) = Φ (mixedTransferMap₂ A B)
+    rw [← map_pow, hidem.pow_succ_eq n]
+  have hshift : Tendsto (fun n => F' ^ (n + 1)) atTop (nhds 0) :=
+    hpow.comp (tendsto_add_atTop_nat 1)
+  have hconst : Tendsto (fun n => F' ^ (n + 1)) atTop (nhds F') := by
+    simp only [hFpow]; exact tendsto_const_nhds
+  have hF'0 : F' = 0 := tendsto_nhds_unique hconst hshift
+  have hF0 : Φ (mixedTransferMap₂ A B) = Φ 0 := by rw [map_zero]; exact hF'0
+  exact Φ.injective hF0
+
+/-- **Same-dimension spectral gap (cast form).** For distinct irreducible
+left-canonical blocks of equal bond dimension that are not gauge-phase
+equivalent, the rectangular mixed transfer spectral radius is `< 1`. -/
+private lemma mixedTransferSpectralRadius₂_lt_one_of_dim_eq
+    [NeZero D₁] [NeZero D₂]
+    (A : MPSTensor d D₁) (B : MPSTensor d D₂)
+    (hA_irr : IsIrreducibleTensor A) (hB_irr : IsIrreducibleTensor B)
+    (hA_left : ∑ i : Fin d, (A i)ᴴ * A i = 1)
+    (hB_left : ∑ i : Fin d, (B i)ᴴ * B i = 1)
+    (hD : D₁ = D₂)
+    (hgpe : ¬ GaugePhaseEquiv (cast (congrArg (MPSTensor d) hD) A) B) :
+    mixedTransferSpectralRadius₂ A B < 1 := by
+  subst hD
+  simp only [cast_eq] at hgpe
+  have hagree : mixedTransferMap₂ (d := d) (D₁ := D₁) (D₂ := D₁) A B =
+      mixedTransferMap A B := by
+    ext X; simp
+  rw [mixedTransferSpectralRadius₂_eq, hagree, ← mixedTransferSpectralRadius_eq]
+  exact spectralRadius_mixedTransfer_lt_one_of_irreducible_TP A B hA_irr hB_irr
+    hA_left hB_left hgpe
+
+end Spectral
+
+/-! ## Stage 2 main theorem -/
+
+section Main
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+
+/-- **Cross-block orthogonality of the RFP isometry (mixed-transfer form).**
+
+For a family of distinct irreducible left-canonical blocks `B`, if the
+whole direct-sum tensor `⊕_k B_k` is a renormalization fixed point, then every
+off-diagonal mixed transfer operator vanishes:
+`mixedTransferMap₂ (B j) (B j') = 0` for `j ≠ j'`.
+
+This is the `δ_{j,j'}` (cross-block) content of the isometry condition
+`eq:III_isometry` (arXiv:1606.00608, line 551), towards Corollary III.cor3
+(line 584).
+
+The load-bearing hypothesis is whole-tensor RFP of the direct sum (the source's
+"`A` in CF is RFP"), strictly stronger than per-block RFP.  The diagonal
+`j = j'` case is `IsIsometryCanonicalForm`. -/
+theorem isBNTLocallyOrthogonal_of_isRFP_directSum
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    [∀ k, NeZero (dim k)]
+    (hirr : ∀ k, IsIrreducibleTensor (B k))
+    (hleft : ∀ k, ∑ i : Fin d, (B k i)ᴴ * B k i = 1)
+    (hdist : ∀ j k : Fin r, j ≠ k → ∀ h : dim j = dim k,
+      ¬ GaugePhaseEquiv (cast (congrArg (MPSTensor d) h) (B j)) (B k))
+    (hRFP : IsRFP (directSumTensor B)) :
+    IsBNTLocallyOrthogonal B := by
+  intro j j' hjj'
+  have hidem := mixedTransferMap₂_isIdempotentElem_of_isRFP_directSum B hRFP j j'
+  have hsr : mixedTransferSpectralRadius₂ (B j) (B j') < 1 := by
+    by_cases hdim : dim j = dim j'
+    · exact mixedTransferSpectralRadius₂_lt_one_of_dim_eq (B j) (B j')
+        (hirr j) (hirr j') (hleft j) (hleft j') hdim (hdist j j' hjj' hdim)
+    · exact mixedTransferSpectralRadius₂_lt_one_of_dim_ne_of_irreducible_TP (B j) (B j')
+        (hirr j) (hirr j') (hleft j) (hleft j') hdim
+  exact mixedTransferMap₂_eq_zero_of_isIdempotentElem (B j) (B j') hidem hsr
+
+end Main
+
+end MPSTensor

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -718,16 +718,20 @@ and rates for the single-tensor transfer map $\E_A$.
 \end{lemma}
 \begin{proof}\leanok
     A block-diagonal factor connects only matching blocks, so the $(j,j')$ block
-    of the product is $\sum_i B_j^i\,X_{j,j'}\,(B_{j'}^i)^\dagger$, which is the
-    mixed transfer operator of the two blocks applied to $X_{j,j'}$.
+    of the product is
+    \[
+        \Bigl(\sum_i \bigl(\bigoplus_k B_k^i\bigr)\,X\,
+            \bigl(\bigoplus_k B_k^i\bigr)^\dagger\Bigr)_{j,j'}
+        = \sum_i B_j^i\,X_{j,j'}\,(B_{j'}^i)^\dagger
+        = \E_{j,j'}(X_{j,j'}) .
+    \]
 \end{proof}
 
 \begin{theorem}[Cross-block transfer vanishing for a direct-sum fixed point]%
     \label{thm:bnt_locally_orthogonal_of_rfp_direct_sum}
     \lean{MPSTensor.isBNTLocallyOrthogonal_of_isRFP_directSum}
     \leanok
-    \uses{def:is_bnt_locally_orthogonal, def:is_rfp, def:mixed_transfer_rect,
-        lem:block_diagonal_transfer_sum_to_block}
+    \uses{def:is_bnt_locally_orthogonal, def:is_rfp, def:mixed_transfer_rect}
     Let $(A_j)_j$ be a family of distinct irreducible left-canonical blocks, no
     two of which are gauge-phase equivalent, and suppose the direct sum
     $\bigoplus_j A_j$ is a renormalization fixed point. Then for every pair of
@@ -738,19 +742,19 @@ and rates for the single-tensor transfer map $\E_A$.
     This is the cross-block ($\delta_{j,j'}$) content of the isometry condition
     of \cite[Theorem~III \& Corollary~III.3]{Cirac2016MPDO_arXiv} at the level of
     the normal-tensor blocks; converting it to the residual isometries $U_j$ is a
-    further step recorded in
-    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+    further step left open.
+% The U-level conversion is recorded in docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
 \end{theorem}
 \begin{proof}\leanok
     \uses{lem:block_diagonal_transfer_sum_to_block}
     By Lemma~\ref{lem:block_diagonal_transfer_sum_to_block} the $(j,j')$ bond
     block of the direct-sum transfer map acts as $\E_{j,j'}$. Whole-tensor
-    idempotence therefore makes each $\E_{j,j'}$ idempotent. For distinct
-    irreducible left-canonical blocks that are not gauge-phase equivalent the
-    mixed transfer operator has spectral radius below one --- by the
-    same-dimension gauge rigidity when the bond dimensions agree, and by the
-    dimension-mismatch gap otherwise --- so an idempotent operator with spectral
-    radius below one must be zero.
+    idempotence $\E^2=\E$ therefore restricts to each block as
+    $\E_{j,j'}^2=\E_{j,j'}$. For distinct irreducible left-canonical blocks that
+    are not gauge-phase equivalent the mixed transfer operator has spectral radius
+    below one, $\rho(\E_{j,j'})<1$ --- by the same-dimension gauge rigidity when
+    the bond dimensions agree, and by the dimension-mismatch gap otherwise. Then
+    $\E_{j,j'} = \E_{j,j'}^n \to 0$ as $n\to\infty$, so $\E_{j,j'}=0$.
 \end{proof}
 
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -702,6 +702,57 @@ and rates for the single-tensor transfer map $\E_A$.
     Apply Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt} to each block.
 \end{proof}
 
+\begin{lemma}[Block decomposition of the direct-sum transfer map]%
+    \label{lem:block_diagonal_transfer_sum_to_block}
+    \lean{MPSTensor.blockDiagonal'_transferSum_toBlock}
+    \leanok
+    \uses{def:mixed_transfer_rect}
+    Let $(B_k)_k$ be a family of tensors and let $\bigoplus_k B_k$ be their
+    direct sum on the total bond space. For every bond matrix $X$ and every pair
+    of blocks, the $(j,j')$ bond block of the transfer sum
+    \[
+        \sum_i \Bigl(\bigoplus_k B_k^i\Bigr)\,X\,
+            \Bigl(\bigoplus_k B_k^i\Bigr)^\dagger
+    \]
+    equals $\E_{j,j'}$ applied to the $(j,j')$ bond block of $X$.
+\end{lemma}
+\begin{proof}\leanok
+    A block-diagonal factor connects only matching blocks, so the $(j,j')$ block
+    of the product is $\sum_i B_j^i\,X_{j,j'}\,(B_{j'}^i)^\dagger$, which is the
+    mixed transfer operator of the two blocks applied to $X_{j,j'}$.
+\end{proof}
+
+\begin{theorem}[Cross-block transfer vanishing for a direct-sum fixed point]%
+    \label{thm:bnt_locally_orthogonal_of_rfp_direct_sum}
+    \lean{MPSTensor.isBNTLocallyOrthogonal_of_isRFP_directSum}
+    \leanok
+    \uses{def:is_bnt_locally_orthogonal, def:is_rfp, def:mixed_transfer_rect,
+        lem:block_diagonal_transfer_sum_to_block}
+    Let $(A_j)_j$ be a family of distinct irreducible left-canonical blocks, no
+    two of which are gauge-phase equivalent, and suppose the direct sum
+    $\bigoplus_j A_j$ is a renormalization fixed point. Then for every pair of
+    distinct components the mixed transfer operator vanishes,
+    \[
+        \E_{j,j'} = \sum_i A_j^i\otimes\overline{A_{j'}^i} = 0 .
+    \]
+    This is the cross-block ($\delta_{j,j'}$) content of the isometry condition
+    of \cite[Theorem~III \& Corollary~III.3]{Cirac2016MPDO_arXiv} at the level of
+    the normal-tensor blocks; converting it to the residual isometries $U_j$ is a
+    further step recorded in
+    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:block_diagonal_transfer_sum_to_block}
+    By Lemma~\ref{lem:block_diagonal_transfer_sum_to_block} the $(j,j')$ bond
+    block of the direct-sum transfer map acts as $\E_{j,j'}$. Whole-tensor
+    idempotence therefore makes each $\E_{j,j'}$ idempotent. For distinct
+    irreducible left-canonical blocks that are not gauge-phase equivalent the
+    mixed transfer operator has spectral radius below one --- by the
+    same-dimension gauge rigidity when the bond dimensions agree, and by the
+    dimension-mismatch gap otherwise --- so an idempotent operator with spectral
+    radius below one must be zero.
+\end{proof}
+
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}
     \leanok

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -300,6 +300,28 @@ $\sqrt\Lambda$ of the unit isometry.  The remaining open part of the source
 isometry condition is the cross-block $\delta_{j,j'}$ orthogonality equations
 between distinct normal-tensor blocks.
 
+\section{Progress on the cross-block equations}
+
+The cross-block $\delta_{j,j'}$ orthogonality is now established at the level of
+the normal-tensor blocks, before the passage to the residual isometries.  For a
+family of distinct irreducible left-canonical blocks $(A_j)_j$, no two
+gauge-phase equivalent, whose direct sum $\bigoplus_j A_j$ is a renormalization
+fixed point, the mixed transfer operators between distinct blocks vanish,
+\[
+  \E_{j,j'}=\sum_i A_j^i\otimes\overline{A_{j'}^i}=0
+  \qquad (j\ne j'),
+\]
+formalized by \leanid{MPSTensor.isBNTLocallyOrthogonal_of_isRFP_directSum}.  The
+argument decomposes the direct-sum transfer map block by block
+(\leanid{MPSTensor.blockDiagonal'_transferSum_toBlock}): whole-tensor idempotence
+makes each $\E_{j,j'}$ idempotent, and the same-dimension and dimension-mismatch
+transfer-operator gaps force an idempotent of spectral radius below one to be
+zero.  Writing $A_j^i = X_j\sqrt{\Lambda_j}\,U_j^i X_j^{-1}$ and cancelling the
+invertible factors converts $\E_{j,j'}=0$ to the residual-isometry equation
+$\sum_i (U_j^i)_{\alpha,\beta}\overline{(U_{j'}^i)_{\alpha',\beta'}}=0$; this
+last conversion, together with a faithful multi-block isometry predicate, is the
+remaining step.
+
 \bibliographystyle{alpha}
 \bibliography{references}
 

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -308,16 +308,16 @@ family of distinct irreducible left-canonical blocks $(A_j)_j$, no two
 gauge-phase equivalent, whose direct sum $\bigoplus_j A_j$ is a renormalization
 fixed point, the mixed transfer operators between distinct blocks vanish,
 \[
-  \E_{j,j'}=\sum_i A_j^i\otimes\overline{A_{j'}^i}=0
+  \mathcal{E}_{j,j'}=\sum_i A_j^i\otimes\overline{A_{j'}^i}=0
   \qquad (j\ne j'),
 \]
 formalized by \leanid{MPSTensor.isBNTLocallyOrthogonal_of_isRFP_directSum}.  The
 argument decomposes the direct-sum transfer map block by block
 (\leanid{MPSTensor.blockDiagonal'_transferSum_toBlock}): whole-tensor idempotence
-makes each $\E_{j,j'}$ idempotent, and the same-dimension and dimension-mismatch
+makes each $\mathcal{E}_{j,j'}$ idempotent, and the same-dimension and dimension-mismatch
 transfer-operator gaps force an idempotent of spectral radius below one to be
 zero.  Writing $A_j^i = X_j\sqrt{\Lambda_j}\,U_j^i X_j^{-1}$ and cancelling the
-invertible factors converts $\E_{j,j'}=0$ to the residual-isometry equation
+invertible factors converts $\mathcal{E}_{j,j'}=0$ to the residual-isometry equation
 $\sum_i (U_j^i)_{\alpha,\beta}\overline{(U_{j'}^i)_{\alpha',\beta'}}=0$; this
 last conversion, together with a faithful multi-block isometry predicate, is the
 remaining step.


### PR DESCRIPTION
## Summary

Formalizes the **cross-block (`j ≠ j'`) orthogonality** content of the
renormalization-fixed-point isometry condition `eq:III_isometry`
(arXiv:1606.00608, line 551), at the level of the normal-tensor blocks
(`E_{j,j'} = 0`). New file `TNLean/MPS/RFP/BNTOrthogonality.lean`.

The diagonal `j = j'` case was already `IsIsometryCanonicalForm`
(`StructuralFull.lean`); this PR adds the off-diagonal vanishing.

Addresses #3488.

## Stages landed (both sorry-free, axiom-clean)

- **Stage 1 — reusable block decomposition** (`blockDiagonal'_transferSum_toBlock`):
  the `(j, j')` bond block of the direct-sum transfer sum
  `∑ᵢ (⊕ₖ Bₖⁱ) X (⊕ₖ Bₖⁱ)†` acts as `mixedTransferMap₂ (B j) (B j')` on the
  `(j, j')` bond block of `X`. The transfer-operator analogue of
  `evalWord_blockDiagonal'`.
- **Stage 2 — `IsBNTLocallyOrthogonal`** (`isBNTLocallyOrthogonal_of_isRFP_directSum`):
  from whole-tensor `IsRFP (directSumTensor B)` plus distinct irreducible
  left-canonical blocks (no two gauge-phase equivalent), every off-diagonal
  `mixedTransferMap₂ (B j) (B j') = 0`.

## Corrected route (as flagged in the issue scope)

Uses **`mixedTransferMap₂` + spectral gap**, NOT the diagonal lemma
`transferMap_eq_fixedPointProj_of_isRFP_injective` (which does not compose
across blocks). Concretely:

1. Block decomposition (Stage 1) + the reindex compatibility of
   `transferMap (directSumTensor B)` shows whole-tensor RFP makes each
   off-diagonal `mixedTransferMap₂ (B j) (B j')` **idempotent**.
2. For distinct irreducible left-canonical blocks the mixed transfer operator
   has **spectral radius < 1** — `spectralRadius_mixedTransfer_lt_one_of_irreducible_TP`
   (equal dimension, via a cast/`subst` helper) or
   `mixedTransferSpectralRadius₂_lt_one_of_dim_ne_of_irreducible_TP` (different
   dimension).
3. An idempotent operator with spectral radius < 1 is `0`
   (`pow_tendsto_zero_of_spectralRadius_lt_one` + `IsIdempotentElem.pow_succ_eq`).

## Faithfulness

The load-bearing hypothesis is **whole-tensor `IsRFP` of the direct sum**
(the source's "A in CF is RFP"), strictly stronger than per-block RFP.
`directSumTensor B` is `CanonicalForm.toTensor` with all scalar weights `μₖ = 1`
(same `blockDiagonal'`/`Σ`-reindex construction). The result is the cross-block
content of `eq:III_isometry` **at the `A`-block level** (`E_{j,j'}=0`), a
faithful step toward Corollary III.cor3 (line 584).

## Not in this PR (Stage 3, remaining)

Converting `E_{j,j'}=0` to the literal residual-isometry equation
`∑ᵢ (U_jⁱ)_{αβ} conj((U_{j'}ⁱ)_{α'β'}) = 0` through the invertible `X_j, √Λ_j`
of `IsIsometryCanonicalForm`, plus a faithful multi-block isometry predicate.
This (and the per-block RFP/isometry data derivation from whole-tensor RFP) is
the remaining step, recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`
(new "Progress on the cross-block equations" section).

## Verification

- `lake build`: completed successfully (9257 jobs).
- `#print axioms` for all 5 new theorems: `[propext, Classical.choice, Quot.sound]` only.
- No `sorry` / `admit` / `native_decide`; no `maxHeartbeats`.
- Blueprint: `ch14_correlations.tex` gains
  `lem:block_diagonal_transfer_sum_to_block` and
  `thm:bnt_locally_orthogonal_of_rfp_direct_sum` (both `\leanok`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formal mathematics on the RFP track using existing spectral-gap lemmas; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`TNLean/MPS/RFP/BNTOrthogonality.lean`** (wired into the root import) and proves that when distinct irreducible left-canonical blocks have a **whole-tensor** `IsRFP` direct sum, every off-diagonal **`mixedTransferMap₂`** vanishes—i.e. **`IsBNTLocallyOrthogonal`**, the cross-block part of CPSV16 `eq:III_isometry` at the normal-tensor block level.
> 
> The proof route is new infrastructure, not the per-block rank-one projection lemma: **`blockDiagonal'_transferSum_toBlock`** and **`directSumTensor`** / **`blockTransferSum`** show RFP makes each cross-block operator idempotent; existing mixed-transfer spectral-gap inputs plus an idempotent-with-ρ&lt;1 argument force **`0`**.
> 
> Blueprint **`ch14_correlations.tex`** gets the matching lemma and theorem (`\leanok`); **`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`** documents this progress and still flags conversion to residual-isometry **`U_j`** equations as open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c4fc19d07a45aaa0254c6aab5ead92c1e41365d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->