### PR TITLE
feat(MPS/RFP): residual-isometry form of cross-block RFP orthogonality (arXiv:1606.00608, #3488)

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -388,6 +388,7 @@ import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Assembly
 import TNLean.MPS.RFP.Decorrelation
 import TNLean.MPS.RFP.BNTOrthogonality
+import TNLean.MPS.RFP.ResidualIsometry
 
 -- Layer 6a: Quantum Wielandt span-growth infrastructure
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -1,0 +1,269 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.BNTOrthogonality
+import TNLean.MPS.RFP.StructuralFull
+
+/-!
+# Residual-isometry form of the renormalization fixed-point structure
+
+For a family of normal-tensor blocks `B` whose direct sum is a renormalization
+fixed point, this file converts the block-level cross-block vanishing
+`mixedTransferMap₂ (B j) (B j') = 0` (arXiv:1606.00608, Theorem charact-MPS,
+the cross-block part of `eq:III_isometry`, line 551) into the literal
+residual-isometry equation between the residual tensors `U_j`,
+\[
+  \sum_i (U_j^i)_{\alpha,\beta}\,\overline{(U_{j'}^i)_{\alpha',\beta'}}
+    = \delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'} ,
+\]
+the full isometry condition of Corollary III.cor3 (arXiv:1606.00608, line 584).
+
+## Main results
+
+* `mixedTransferMap₂_conj_apply` — covariance of the mixed transfer operator
+  under a two-sided change of variables `A^i = X_A D_A U^i X_A^{-1}`.
+* `mixedTransferMap₂_eq_zero_of_conj` — cancelling the invertible outer factors
+  turns `mixedTransferMap₂ A B = 0` into `mixedTransferMap₂ U V = 0`.
+* `residual_isometry_entry_of_mixedTransferMap₂_eq_zero` — reading off a matrix
+  entry turns the vanishing operator into the entrywise residual-isometry sum.
+* `IsResidualIsometryFamily` — the full `eq:III_isometry` predicate on a family
+  of residual tensors (the within-block orthonormality together with the
+  cross-block vanishing).
+* `exists_residualIsometryFamily_of_isRFP_directSum` — under whole-tensor RFP of
+  the direct sum, the residual tensors of the isometry canonical forms of the
+  blocks satisfy `IsResidualIsometryFamily`.
+
+## Route
+
+Each block in isometry canonical form is `A_j^i = X_j \sqrt{\Lambda_j} U_j^i
+X_j^{-1}` with `X_j` and `\sqrt{\Lambda_j}` invertible.  Substituting the
+decomposition into the mixed transfer operator exposes the residual operator
+`mixedTransferMap₂ U_j U_{j'}` conjugated by the invertible outer factors, so the
+block-level vanishing transfers to the residual operator; reading the
+`(\alpha,\alpha')` entry of the operator applied to a matrix unit `Matrix.single
+\beta \beta' 1` recovers the entrywise sum.  The within-block diagonal `j = j'`
+case is already `IsIsometryCanonicalForm`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d : ℕ}
+
+/-! ## Cancelling invertible factors -/
+
+section Cancellation
+
+variable {D₁ D₂ : ℕ}
+
+/-- If `M P N = 0` with `M` and `N` invertible, then `P = 0`. -/
+private lemma eq_zero_of_invertible_mul_mul
+    (M : Matrix (Fin D₁) (Fin D₁) ℂ) (N : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (P : Matrix (Fin D₁) (Fin D₂) ℂ)
+    (hM : M.det ≠ 0) (hN : N.det ≠ 0)
+    (h : M * P * N = 0) : P = 0 := by
+  have hMu : IsUnit M.det := isUnit_iff_ne_zero.mpr hM
+  have hNu : IsUnit N.det := isUnit_iff_ne_zero.mpr hN
+  have e : M⁻¹ * (M * P * N) * N⁻¹ = P := by
+    rw [Matrix.mul_assoc M P N, ← Matrix.mul_assoc M⁻¹ M (P * N),
+      Matrix.nonsing_inv_mul M hMu, Matrix.one_mul, Matrix.mul_assoc P N N⁻¹,
+      Matrix.mul_nonsing_inv N hNu, Matrix.mul_one]
+  have h2 : M⁻¹ * (M * P * N) * N⁻¹ = 0 := by rw [h, Matrix.mul_zero, Matrix.zero_mul]
+  rwa [e] at h2
+
+/-- **Covariance of the mixed transfer operator under a two-sided change of
+variables.** If `A^i = X_A D_A U^i X_A^{-1}` and `B^i = X_B D_B V^i X_B^{-1}`,
+then the mixed transfer operator of `A, B` is the mixed transfer operator of the
+residual tensors `U, V`, conjugated by the invertible outer factors:
+\[
+  \mathcal{E}_{A,B}(Y)
+    = X_A D_A\,\mathcal{E}_{U,V}\!\bigl(X_A^{-1} Y (X_B^{-1})^\dagger\bigr)\,
+      (X_B D_B)^\dagger .
+\]
+This is the algebraic identity underlying the passage from the block-level
+vanishing to `eq:III_isometry` (arXiv:1606.00608, line 551). -/
+lemma mixedTransferMap₂_conj_apply
+    (A U : MPSTensor d D₁) (B V : MPSTensor d D₂)
+    (Xa Da : Matrix (Fin D₁) (Fin D₁) ℂ) (Xb Db : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hA : ∀ i, A i = Xa * Da * U i * Xa⁻¹)
+    (hB : ∀ i, B i = Xb * Db * V i * Xb⁻¹)
+    (Y : Matrix (Fin D₁) (Fin D₂) ℂ) :
+    mixedTransferMap₂ A B Y
+      = Xa * Da * mixedTransferMap₂ U V (Xa⁻¹ * Y * (Xb⁻¹)ᴴ) * (Xb * Db)ᴴ := by
+  simp only [mixedTransferMap₂_apply, Matrix.mul_sum, Matrix.sum_mul]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [hA i, hB i]
+  simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
+
+/-- **The residual operator vanishes.** If `A, B` decompose with invertible outer
+factors as `A^i = X_A D_A U^i X_A^{-1}`, `B^i = X_B D_B V^i X_B^{-1}`, and the
+mixed transfer operator of `A, B` vanishes, then the mixed transfer operator of
+the residual tensors `U, V` vanishes.
+
+This cancels the invertible conjugation in `mixedTransferMap₂_conj_apply`
+(arXiv:1606.00608, line 551). -/
+lemma mixedTransferMap₂_eq_zero_of_conj
+    (A U : MPSTensor d D₁) (B V : MPSTensor d D₂)
+    (Xa Da : Matrix (Fin D₁) (Fin D₁) ℂ) (Xb Db : Matrix (Fin D₂) (Fin D₂) ℂ)
+    (hA : ∀ i, A i = Xa * Da * U i * Xa⁻¹)
+    (hB : ∀ i, B i = Xb * Db * V i * Xb⁻¹)
+    (hXa : Xa.det ≠ 0) (hDa : Da.det ≠ 0)
+    (hXb : Xb.det ≠ 0) (hDb : Db.det ≠ 0)
+    (hAB : mixedTransferMap₂ A B = 0) :
+    mixedTransferMap₂ U V = 0 := by
+  have hXau : IsUnit Xa.det := isUnit_iff_ne_zero.mpr hXa
+  have hXbu : IsUnit Xb.det := isUnit_iff_ne_zero.mpr hXb
+  refine LinearMap.ext fun Z => ?_
+  rw [LinearMap.zero_apply]
+  have hXaInv : Xa⁻¹ * Xa = 1 := Matrix.nonsing_inv_mul Xa hXau
+  have hXbInv : Xbᴴ * (Xb⁻¹)ᴴ = 1 := by
+    rw [← Matrix.conjTranspose_mul, Matrix.nonsing_inv_mul Xb hXbu, Matrix.conjTranspose_one]
+  have hCV : Xa⁻¹ * (Xa * Z * Xbᴴ) * (Xb⁻¹)ᴴ = Z := by
+    rw [Matrix.mul_assoc Xa Z Xbᴴ, ← Matrix.mul_assoc Xa⁻¹ Xa (Z * Xbᴴ), hXaInv,
+      Matrix.one_mul, Matrix.mul_assoc Z Xbᴴ (Xb⁻¹)ᴴ, hXbInv, Matrix.mul_one]
+  have hcov := mixedTransferMap₂_conj_apply A U B V Xa Da Xb Db hA hB (Xa * Z * Xbᴴ)
+  rw [hCV] at hcov
+  have hAB_app : mixedTransferMap₂ A B (Xa * Z * Xbᴴ) = 0 := by simp [hAB]
+  rw [hAB_app] at hcov
+  refine eq_zero_of_invertible_mul_mul (Xa * Da) ((Xb * Db)ᴴ)
+    (mixedTransferMap₂ U V Z) ?_ ?_ hcov.symm
+  · rw [Matrix.det_mul]; exact mul_ne_zero hXa hDa
+  · rw [Matrix.det_conjTranspose, Matrix.det_mul]
+    exact star_ne_zero.mpr (mul_ne_zero hXb hDb)
+
+/-- **Entrywise form of the vanishing residual operator.** If
+`mixedTransferMap₂ U V = 0`, then for all virtual indices
+\[
+  \sum_i (U^i)_{\alpha,\beta}\,\overline{(V^i)_{\alpha',\beta'}} = 0 .
+\]
+This is the entrywise reading of the operator equation (arXiv:1606.00608,
+line 551), obtained by evaluating at the matrix unit `Matrix.single β β' 1` and
+reading the `(α, α')` entry. -/
+lemma residual_isometry_entry_of_mixedTransferMap₂_eq_zero
+    (U : MPSTensor d D₁) (V : MPSTensor d D₂)
+    (h : mixedTransferMap₂ U V = 0)
+    (α β : Fin D₁) (α' β' : Fin D₂) :
+    ∑ i : Fin d, U i α β * star (V i α' β') = 0 := by
+  have key : ∀ i : Fin d, U i α β * star (V i α' β') =
+      (U i * Matrix.single β β' (1 : ℂ) * (V i)ᴴ) α α' := by
+    intro i
+    rw [Matrix.mul_apply, Finset.sum_eq_single β']
+    · rw [Matrix.mul_single_apply_same, Matrix.conjTranspose_apply, mul_one]
+    · intro t _ ht
+      rw [Matrix.mul_single_apply_of_ne (M := U i) (hbj := ht), zero_mul]
+    · intro hmem; exact absurd (Finset.mem_univ β') hmem
+  simp_rw [key]
+  rw [← Matrix.sum_apply, ← mixedTransferMap₂_apply, h]
+  simp
+
+end Cancellation
+
+/-! ## Per-block renormalization fixed point -/
+
+section Blocks
+
+variable {r : ℕ} {dim : Fin r → ℕ}
+
+/-- Whole-tensor RFP of the direct sum makes each block a renormalization fixed
+point: the diagonal `j = j'` mixed transfer operator is `transferMap (B j)`,
+whose idempotence is `IsRFP (B j)` (arXiv:1606.00608, Definition 3.2). -/
+lemma isRFP_block_of_isRFP_directSum [∀ k, NeZero (dim k)]
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hRFP : IsRFP (directSumTensor B)) (j : Fin r) :
+    IsRFP (B j) := by
+  have hidem := mixedTransferMap₂_isIdempotentElem_of_isRFP_directSum B hRFP j j
+  have hself : mixedTransferMap₂ (B j) (B j) = transferMap (B j) := by
+    ext X
+    simp only [mixedTransferMap₂_apply, transferMap_apply]
+  rwa [hself] at hidem
+
+/-- **Residual isometry family** (arXiv:1606.00608, `eq:III_isometry`, line 551).
+A family of residual tensors `U_j` satisfies the source isometry condition when
+the within-block pair-index orthonormality holds for each block and the
+cross-block sums vanish between distinct blocks:
+\[
+  \sum_i (U_j^i)_{\alpha,\beta}\,\overline{(U_{j'}^i)_{\alpha',\beta'}}
+    = \delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
+\]
+The two fields are the `j = j'` and `j \ne j'` cases of that displayed equation. -/
+def IsResidualIsometryFamily (U : (j : Fin r) → MPSTensor d (dim j)) : Prop :=
+  (∀ (j : Fin r) (α β α' β' : Fin (dim j)),
+      ∑ i : Fin d, U j i α β * star (U j i α' β') =
+        if α = α' ∧ β = β' then 1 else 0) ∧
+  (∀ (j j' : Fin r), j ≠ j' →
+      ∀ (α β : Fin (dim j)) (α' β' : Fin (dim j')),
+        ∑ i : Fin d, U j i α β * star (U j' i α' β') = 0)
+
+/-- **Residual-isometry form of the cross-block RFP structure.**
+
+For a family of normal, irreducible, left-canonical blocks `B`, no two
+gauge-phase equivalent, whose direct sum is a renormalization fixed point, the
+residual tensors of the per-block isometry canonical forms satisfy the full
+source isometry condition `eq:III_isometry` (arXiv:1606.00608, line 551): there
+are invertible `X_j`, positive trace-normalized diagonal weights `Λ_j`, and
+residual tensors `U_j` with `B_j^i = X_j \sqrt{Λ_j} U_j^i X_j^{-1}` and
+`IsResidualIsometryFamily U`.  This is the residual-isometry content of
+Corollary III.cor3 (arXiv:1606.00608, line 584) at the level of the
+normal-tensor blocks.
+
+**Scope restriction (whole-tensor canonical form):** the load-bearing hypothesis
+is whole-tensor RFP of the direct sum together with the explicit per-block
+normal/irreducible/left-canonical/distinctness data of a basis of normal
+tensors.  Corollary III.cor3 starts instead from a single predicate "`A` in
+canonical form is RFP"; extracting the per-block data from that predicate is a
+separate step.  This restriction is recorded in
+`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+theorem exists_residualIsometryFamily_of_isRFP_directSum [∀ k, NeZero (dim k)]
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hnormal : ∀ k, IsNormal (B k))
+    (hirr : ∀ k, IsIrreducibleTensor (B k))
+    (hleft : ∀ k, ∑ i : Fin d, (B k i)ᴴ * B k i = 1)
+    (hdist : ∀ j k : Fin r, j ≠ k → ∀ h : dim j = dim k,
+      ¬ GaugePhaseEquiv (cast (congrArg (MPSTensor d) h) (B j)) (B k))
+    (hRFP : IsRFP (directSumTensor B)) :
+    ∃ (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+      (Λ : (j : Fin r) → Fin (dim j) → ℝ)
+      (U : (j : Fin r) → MPSTensor d (dim j)),
+      (∀ j, (X j).det ≠ 0) ∧
+      (∀ j k, 0 < Λ j k) ∧
+      (∀ j, ∑ k, Λ j k = 1) ∧
+      (∀ j i, B j i =
+        X j * Matrix.diagonal (fun k => (Real.sqrt (Λ j k) : ℂ)) * U j i * (X j)⁻¹) ∧
+      IsResidualIsometryFamily U := by
+  classical
+  have hICF : ∀ j, IsIsometryCanonicalForm (B j) := fun j =>
+    isIsometryCanonicalForm_of_rfp_nt (B j) (hnormal j)
+      (isRFP_block_of_isRFP_directSum B hRFP j) (hleft j)
+  choose X Λ U hXdet hΛpos hΛsum hUiso hdecomp using hICF
+  have hDdet : ∀ j,
+      (Matrix.diagonal (fun k => (Real.sqrt (Λ j k) : ℂ))).det ≠ 0 := by
+    intro j
+    rw [Matrix.det_diagonal, Finset.prod_ne_zero_iff]
+    intro k _
+    exact Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr (hΛpos j k)).ne'
+  have hBNT : IsBNTLocallyOrthogonal B :=
+    isBNTLocallyOrthogonal_of_isRFP_directSum B hirr hleft hdist hRFP
+  refine ⟨X, Λ, U, hXdet, hΛpos, hΛsum, hdecomp, ?_, ?_⟩
+  · -- within-block orthonormality, conjugate of the isometry-canonical-form field
+    intro j α β α' β'
+    have h := hUiso j (α, β) (α', β')
+    have hstar := congrArg star h
+    rw [star_sum] at hstar
+    simp only [star_mul', star_star] at hstar
+    rw [hstar]
+    simp only [apply_ite (star : ℂ → ℂ), star_one, star_zero, Prod.mk.injEq]
+  · -- cross-block vanishing via the residual-operator route
+    intro j j' hjj' α β α' β'
+    have hUjj' : mixedTransferMap₂ (U j) (U j') = 0 :=
+      mixedTransferMap₂_eq_zero_of_conj (B j) (U j) (B j') (U j')
+        (X j) (Matrix.diagonal (fun k => (Real.sqrt (Λ j k) : ℂ)))
+        (X j') (Matrix.diagonal (fun k => (Real.sqrt (Λ j' k) : ℂ)))
+        (hdecomp j) (hdecomp j')
+        (hXdet j) (hDdet j) (hXdet j') (hDdet j') (hBNT j j' hjj')
+    exact residual_isometry_entry_of_mixedTransferMap₂_eq_zero (U j) (U j') hUjj' α β α' β'
+
+end Blocks
+
+end MPSTensor

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -8,11 +8,11 @@ import TNLean.MPS.RFP.StructuralFull
 /-!
 # Residual-isometry form of the renormalization fixed-point structure
 
-For a family of normal-tensor blocks `B` whose direct sum is a renormalization
-fixed point, this file converts the block-level cross-block vanishing
-`mixedTransferMap₂ (B j) (B j') = 0` (arXiv:1606.00608, Theorem charact-MPS,
-the cross-block part of `eq:III_isometry`, line 551) into the literal
-residual-isometry equation between the residual tensors `U_j`,
+For a family of normal-tensor blocks $B$ whose direct sum is a renormalization
+fixed point, this file converts the block-level cross-block vanishing of
+`mixedTransferMap₂ (B j) (B j')` (arXiv:1606.00608, Theorem charact-MPS, the
+cross-block part of eq:III_isometry, line 551) into the literal residual-isometry
+equation between the residual tensors $U_j$,
 \[
   \sum_i (U_j^i)_{\alpha,\beta}\,\overline{(U_{j'}^i)_{\alpha',\beta'}}
     = \delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'} ,
@@ -22,28 +22,29 @@ the full isometry condition of Corollary III.cor3 (arXiv:1606.00608, line 584).
 ## Main results
 
 * `mixedTransferMap₂_conj_apply` — covariance of the mixed transfer operator
-  under a two-sided change of variables `A^i = X_A D_A U^i X_A^{-1}`.
+  under a two-sided change of variables $A^i = X_A D_A U^i X_A^{-1}$.
 * `mixedTransferMap₂_eq_zero_of_conj` — cancelling the invertible outer factors
-  turns `mixedTransferMap₂ A B = 0` into `mixedTransferMap₂ U V = 0`.
+  turns the vanishing of `mixedTransferMap₂ A B` into that of
+  `mixedTransferMap₂ U V`.
 * `residual_isometry_entry_of_mixedTransferMap₂_eq_zero` — reading off a matrix
   entry turns the vanishing operator into the entrywise residual-isometry sum.
-* `IsResidualIsometryFamily` — the full `eq:III_isometry` predicate on a family
-  of residual tensors (the within-block orthonormality together with the
-  cross-block vanishing).
+* `IsResidualIsometryFamily` — the full isometry condition eq:III_isometry as a
+  predicate on a family of residual tensors (the within-block orthonormality
+  together with the cross-block vanishing).
 * `exists_residualIsometryFamily_of_isRFP_directSum` — under whole-tensor RFP of
   the direct sum, the residual tensors of the isometry canonical forms of the
   blocks satisfy `IsResidualIsometryFamily`.
 
 ## Route
 
-Each block in isometry canonical form is `A_j^i = X_j \sqrt{\Lambda_j} U_j^i
-X_j^{-1}` with `X_j` and `\sqrt{\Lambda_j}` invertible.  Substituting the
+Each block in isometry canonical form is $A_j^i = X_j \sqrt{\Lambda_j} U_j^i
+X_j^{-1}$ with $X_j$ and $\sqrt{\Lambda_j}$ invertible.  Substituting the
 decomposition into the mixed transfer operator exposes the residual operator
-`mixedTransferMap₂ U_j U_{j'}` conjugated by the invertible outer factors, so the
-block-level vanishing transfers to the residual operator; reading the
-`(\alpha,\alpha')` entry of the operator applied to a matrix unit `Matrix.single
-\beta \beta' 1` recovers the entrywise sum.  The within-block diagonal `j = j'`
-case is already `IsIsometryCanonicalForm`.
+`mixedTransferMap₂ (U j) (U j')` conjugated by the invertible outer factors, so
+the block-level vanishing transfers to the residual operator; reading the
+$(\alpha,\alpha')$ entry of the operator applied to the matrix unit
+`Matrix.single β β' 1` recovers the entrywise sum.  The within-block diagonal
+$j = j'$ case is already `IsIsometryCanonicalForm`.
 -/
 
 open scoped Matrix BigOperators
@@ -58,7 +59,7 @@ section Cancellation
 
 variable {D₁ D₂ : ℕ}
 
-/-- If `M P N = 0` with `M` and `N` invertible, then `P = 0`. -/
+/-- If $M P N = 0$ with $M$ and $N$ invertible, then $P = 0$. -/
 private lemma eq_zero_of_invertible_mul_mul
     (M : Matrix (Fin D₁) (Fin D₁) ℂ) (N : Matrix (Fin D₂) (Fin D₂) ℂ)
     (P : Matrix (Fin D₁) (Fin D₂) ℂ)
@@ -74,16 +75,16 @@ private lemma eq_zero_of_invertible_mul_mul
   rwa [e] at h2
 
 /-- **Covariance of the mixed transfer operator under a two-sided change of
-variables.** If `A^i = X_A D_A U^i X_A^{-1}` and `B^i = X_B D_B V^i X_B^{-1}`,
-then the mixed transfer operator of `A, B` is the mixed transfer operator of the
-residual tensors `U, V`, conjugated by the invertible outer factors:
+variables.** If $A^i = X_A D_A U^i X_A^{-1}$ and $B^i = X_B D_B V^i X_B^{-1}$,
+then the mixed transfer operator of $A$ and $B$ is the mixed transfer operator of
+the residual tensors $U$ and $V$, conjugated by the invertible outer factors:
 \[
   \mathcal{E}_{A,B}(Y)
     = X_A D_A\,\mathcal{E}_{U,V}\!\bigl(X_A^{-1} Y (X_B^{-1})^\dagger\bigr)\,
       (X_B D_B)^\dagger .
 \]
 This is the algebraic identity underlying the passage from the block-level
-vanishing to `eq:III_isometry` (arXiv:1606.00608, line 551). -/
+vanishing to eq:III_isometry (arXiv:1606.00608, line 551). -/
 lemma mixedTransferMap₂_conj_apply
     (A U : MPSTensor d D₁) (B V : MPSTensor d D₂)
     (Xa Da : Matrix (Fin D₁) (Fin D₁) ℂ) (Xb Db : Matrix (Fin D₂) (Fin D₂) ℂ)
@@ -97,10 +98,10 @@ lemma mixedTransferMap₂_conj_apply
   rw [hA i, hB i]
   simp only [Matrix.conjTranspose_mul, Matrix.mul_assoc]
 
-/-- **The residual operator vanishes.** If `A, B` decompose with invertible outer
-factors as `A^i = X_A D_A U^i X_A^{-1}`, `B^i = X_B D_B V^i X_B^{-1}`, and the
-mixed transfer operator of `A, B` vanishes, then the mixed transfer operator of
-the residual tensors `U, V` vanishes.
+/-- **The residual operator vanishes.** If $A$ and $B$ decompose with invertible
+outer factors as $A^i = X_A D_A U^i X_A^{-1}$, $B^i = X_B D_B V^i X_B^{-1}$, and
+the mixed transfer operator of $A$ and $B$ vanishes, then the mixed transfer
+operator of the residual tensors $U$ and $V$ vanishes.
 
 This cancels the invertible conjugation in `mixedTransferMap₂_conj_apply`
 (arXiv:1606.00608, line 551). -/
@@ -134,13 +135,13 @@ lemma mixedTransferMap₂_eq_zero_of_conj
     exact star_ne_zero.mpr (mul_ne_zero hXb hDb)
 
 /-- **Entrywise form of the vanishing residual operator.** If
-`mixedTransferMap₂ U V = 0`, then for all virtual indices
+`mixedTransferMap₂ U V` vanishes, then for all virtual indices
 \[
   \sum_i (U^i)_{\alpha,\beta}\,\overline{(V^i)_{\alpha',\beta'}} = 0 .
 \]
 This is the entrywise reading of the operator equation (arXiv:1606.00608,
 line 551), obtained by evaluating at the matrix unit `Matrix.single β β' 1` and
-reading the `(α, α')` entry. -/
+reading the $(\alpha, \alpha')$ entry. -/
 lemma residual_isometry_entry_of_mixedTransferMap₂_eq_zero
     (U : MPSTensor d D₁) (V : MPSTensor d D₂)
     (h : mixedTransferMap₂ U V = 0)
@@ -167,7 +168,7 @@ section Blocks
 variable {r : ℕ} {dim : Fin r → ℕ}
 
 /-- Whole-tensor RFP of the direct sum makes each block a renormalization fixed
-point: the diagonal `j = j'` mixed transfer operator is `transferMap (B j)`,
+point: the diagonal $j = j'$ mixed transfer operator is `transferMap (B j)`,
 whose idempotence is `IsRFP (B j)` (arXiv:1606.00608, Definition 3.2). -/
 lemma isRFP_block_of_isRFP_directSum [∀ k, NeZero (dim k)]
     (B : (k : Fin r) → MPSTensor d (dim k))
@@ -199,7 +200,7 @@ def IsResidualIsometryFamily (U : (j : Fin r) → MPSTensor d (dim j)) : Prop :=
 
 /-- **Residual-isometry form of the cross-block RFP structure.**
 
-For a family of normal, irreducible, left-canonical blocks `B`, no two
+For a family of normal, irreducible, left-canonical blocks $B$, no two
 gauge-phase equivalent, whose direct sum is a renormalization fixed point, the
 residual tensors of the per-block isometry canonical forms satisfy the full
 source isometry condition eq:III_isometry (arXiv:1606.00608, line 551): there
@@ -216,7 +217,7 @@ distinctness of a basis of normal tensors.  Corollary III.cor3 starts instead
 from a single predicate "$A$ in canonical form is RFP"; extracting the per-block
 normality, irreducibility, left-canonical condition, and gauge-phase
 distinctness from that predicate is a separate step.  This restriction is
-recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+recorded in the paper-gap note docs/paper-gaps/cpsv16_rfp_isometry_scope.tex. -/
 theorem exists_residualIsometryFamily_of_isRFP_directSum [∀ k, NeZero (dim k)]
     (B : (k : Fin r) → MPSTensor d (dim k))
     (hnormal : ∀ k, IsNormal (B k))

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -179,15 +179,16 @@ lemma isRFP_block_of_isRFP_directSum [∀ k, NeZero (dim k)]
     simp only [mixedTransferMap₂_apply, transferMap_apply]
   rwa [hself] at hidem
 
-/-- **Residual isometry family** (arXiv:1606.00608, `eq:III_isometry`, line 551).
-A family of residual tensors `U_j` satisfies the source isometry condition when
+/-- **Residual isometry family** (arXiv:1606.00608, eq:III_isometry, line 551).
+A family of residual tensors $U_j$ satisfies the source isometry condition when
 the within-block pair-index orthonormality holds for each block and the
 cross-block sums vanish between distinct blocks:
 \[
   \sum_i (U_j^i)_{\alpha,\beta}\,\overline{(U_{j'}^i)_{\alpha',\beta'}}
     = \delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'} .
 \]
-The two fields are the `j = j'` and `j \ne j'` cases of that displayed equation. -/
+The $j = j'$ case is the within-block orthonormality and the $j \ne j'$ case is
+the cross-block vanishing between distinct blocks. -/
 def IsResidualIsometryFamily (U : (j : Fin r) → MPSTensor d (dim j)) : Prop :=
   (∀ (j : Fin r) (α β α' β' : Fin (dim j)),
       ∑ i : Fin d, U j i α β * star (U j i α' β') =
@@ -201,20 +202,21 @@ def IsResidualIsometryFamily (U : (j : Fin r) → MPSTensor d (dim j)) : Prop :=
 For a family of normal, irreducible, left-canonical blocks `B`, no two
 gauge-phase equivalent, whose direct sum is a renormalization fixed point, the
 residual tensors of the per-block isometry canonical forms satisfy the full
-source isometry condition `eq:III_isometry` (arXiv:1606.00608, line 551): there
-are invertible `X_j`, positive trace-normalized diagonal weights `Λ_j`, and
-residual tensors `U_j` with `B_j^i = X_j \sqrt{Λ_j} U_j^i X_j^{-1}` and
+source isometry condition eq:III_isometry (arXiv:1606.00608, line 551): there
+are invertible $X_j$, positive trace-normalized diagonal weights $\Lambda_j$, and
+residual tensors $U_j$ with $B_j^i = X_j \sqrt{\Lambda_j} U_j^i X_j^{-1}$ and
 `IsResidualIsometryFamily U`.  This is the residual-isometry content of
 Corollary III.cor3 (arXiv:1606.00608, line 584) at the level of the
 normal-tensor blocks.
 
 **Scope restriction (whole-tensor canonical form):** the load-bearing hypothesis
 is whole-tensor RFP of the direct sum together with the explicit per-block
-normal/irreducible/left-canonical/distinctness data of a basis of normal
-tensors.  Corollary III.cor3 starts instead from a single predicate "`A` in
-canonical form is RFP"; extracting the per-block data from that predicate is a
-separate step.  This restriction is recorded in
-`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
+normality, irreducibility, left-canonical condition, and gauge-phase
+distinctness of a basis of normal tensors.  Corollary III.cor3 starts instead
+from a single predicate "$A$ in canonical form is RFP"; extracting the per-block
+normality, irreducibility, left-canonical condition, and gauge-phase
+distinctness from that predicate is a separate step.  This restriction is
+recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. -/
 theorem exists_residualIsometryFamily_of_isRFP_directSum [∀ k, NeZero (dim k)]
     (B : (k : Fin r) → MPSTensor d (dim k))
     (hnormal : ∀ k, IsNormal (B k))

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -830,8 +830,9 @@ and rates for the single-tensor transfer map $\E_A$.
     \lean{MPSTensor.isRFP_block_of_isRFP_directSum}
     \leanok
     \uses{def:is_rfp, def:mixed_transfer_rect}
-    If the direct sum $\bigoplus_k B_k$ is a renormalization fixed point, then
-    each block $B_j$ is a renormalization fixed point.
+    If the direct sum $\bigoplus_k B_k$ is a renormalization fixed point, with
+    $\dim_k \ge 1$ for all $k$, then each block $B_j$ is a renormalization fixed
+    point.
 \end{lemma}
 \begin{proof}\leanok
     \uses{lem:block_diagonal_transfer_sum_to_block}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -794,6 +794,52 @@ and rates for the single-tensor transfer map $\E_A$.
     which are independent of the summation index, outside the sum.
 \end{proof}
 
+\begin{lemma}[Vanishing of the residual transfer operator]%
+    \label{lem:mixed_transfer_eq_zero_of_conj}
+    \lean{MPSTensor.mixedTransferMap₂_eq_zero_of_conj}
+    \leanok
+    \uses{def:mixed_transfer_rect}
+    With decompositions $A^i = X_A D_A U^i X_A^{-1}$ and
+    $B^i = X_B D_B V^i X_B^{-1}$ whose factors $X_A, D_A, X_B, D_B$ are
+    invertible, if $\E_{A,B}=0$ then $\E_{U,V}=0$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:mixed_transfer_conj_apply}
+    The covariance identity Lemma~\ref{lem:mixed_transfer_conj_apply} expresses
+    $\E_{A,B}$ as $\E_{U,V}$ conjugated by the invertible outer factors
+    $X_A D_A$ and $(X_B D_B)^\dagger$, so $\E_{A,B}=0$ forces $\E_{U,V}=0$.
+\end{proof}
+
+\begin{lemma}[Entrywise residual isometry sum]%
+    \label{lem:residual_isometry_entry}
+    \lean{MPSTensor.residual_isometry_entry_of_mixedTransferMap₂_eq_zero}
+    \leanok
+    \uses{def:mixed_transfer_rect}
+    If $\E_{U,V}=0$, then for all virtual indices
+    \[
+        \sum_i (U^i)_{\alpha,\beta}\,\overline{(V^i)_{\alpha',\beta'}} = 0 .
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    Apply $\E_{U,V}=0$ to the matrix unit supported at $(\beta,\beta')$ and read
+    the $(\alpha,\alpha')$ entry.
+\end{proof}
+
+\begin{lemma}[Each block of a direct-sum fixed point is a fixed point]%
+    \label{lem:isrfp_block_of_rfp_direct_sum}
+    \lean{MPSTensor.isRFP_block_of_isRFP_directSum}
+    \leanok
+    \uses{def:is_rfp, def:mixed_transfer_rect}
+    If the direct sum $\bigoplus_k B_k$ is a renormalization fixed point, then
+    each block $B_j$ is a renormalization fixed point.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:block_diagonal_transfer_sum_to_block}
+    The diagonal mixed transfer operator $\E_{j,j}$ is the transfer map of
+    $B_j$, and whole-tensor idempotence makes it idempotent, which is exactly the
+    renormalization fixed-point condition for $B_j$.
+\end{proof}
+
 \begin{theorem}[Residual-isometry form of the cross-block structure]%
     \label{thm:residual_isometry_of_rfp_direct_sum}
     \lean{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}
@@ -801,8 +847,9 @@ and rates for the single-tensor transfer map $\E_A$.
     \uses{def:is_residual_isometry_family, def:is_rfp,
         def:is_isometry_canonical_form}
     Let $(A_j)_j$ be a family of normal, irreducible, left-canonical blocks, no
-    two of which are gauge-phase equivalent, and suppose the direct sum
-    $\bigoplus_j A_j$ is a renormalization fixed point. Then there are invertible
+    two of which are gauge-phase equivalent, with $\dim_j \ge 1$ for all $j$, and
+    suppose the direct sum $\bigoplus_j A_j$ is a renormalization fixed point.
+    Then there are invertible
     $X_j$, positive trace-normalized diagonal weights $\Lambda_j$, and residual
     tensors $U_j$ with
     \[
@@ -811,15 +858,18 @@ and rates for the single-tensor transfer map $\E_A$.
     such that $(U_j)_j$ is a residual isometry family. This is the
     residual-isometry content of Corollary~III.cor3
     \cite[Corollary~III.3]{Cirac2016MPDO_arXiv} at the level of the normal-tensor
-    blocks. The load-bearing hypothesis is whole-tensor renormalization fixed
-    point of the direct sum, together with the explicit per-block data of a basis
-    of normal tensors; extracting that data from a single canonical-form
-    renormalization-fixed-point predicate is a separate step, recorded in
-    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+    blocks.
+% Scope restriction: the Lean theorem takes the per-block normality,
+% irreducibility, left-canonical condition, and gauge-phase distinctness as
+% explicit hypotheses; extracting these from a single canonical-form RFP
+% predicate is the remaining step
+% (docs/paper-gaps/cpsv16_rfp_isometry_scope.tex).
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:bnt_locally_orthogonal_of_rfp_direct_sum,
-        thm:isometry_canonical_form_of_rfp_nt, lem:mixed_transfer_conj_apply}
+        thm:isometry_canonical_form_of_rfp_nt, lem:mixed_transfer_conj_apply,
+        lem:isrfp_block_of_rfp_direct_sum, lem:mixed_transfer_eq_zero_of_conj,
+        lem:residual_isometry_entry}
     Whole-tensor idempotence makes the diagonal mixed transfer operator of each
     block its own transfer map, hence each block is a renormalization fixed
     point; the isometry canonical form

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -757,6 +757,83 @@ and rates for the single-tensor transfer map $\E_A$.
     $\E_{j,j'} = \E_{j,j'}^n \to 0$ as $n\to\infty$, so $\E_{j,j'}=0$.
 \end{proof}
 
+\begin{definition}[Residual isometry family]%
+    \label{def:is_residual_isometry_family}
+    \lean{MPSTensor.IsResidualIsometryFamily}
+    \leanok
+    A family of residual tensors $(U_j)_j$ is a \emph{residual isometry family}
+    when it satisfies the source isometry condition
+    \[
+        \sum_i (U_j^i)_{\alpha,\beta}\,\overline{(U_{j'}^i)_{\alpha',\beta'}}
+        = \delta_{j,j'}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'} :
+    \]
+    each block satisfies the within-block pair-index orthonormality, and the
+    cross-block sums between distinct blocks vanish. This is the isometry
+    condition of \cite[Theorem~III]{Cirac2016MPDO_arXiv}, split into its $j=j'$
+    and $j\ne j'$ cases.
+\end{definition}
+
+\begin{lemma}[Covariance of the mixed transfer operator]%
+    \label{lem:mixed_transfer_conj_apply}
+    \lean{MPSTensor.mixedTransferMap₂_conj_apply}
+    \leanok
+    \uses{def:mixed_transfer_rect}
+    For decompositions $A^i = X_A D_A U^i X_A^{-1}$ and
+    $B^i = X_B D_B V^i X_B^{-1}$, the mixed transfer operator of $A,B$ is the
+    mixed transfer operator of the residual tensors $U,V$ conjugated by the outer
+    factors:
+    \[
+        \E_{A,B}(Y)
+        = X_A D_A\,\E_{U,V}\!\bigl(X_A^{-1}\,Y\,(X_B^{-1})^\dagger\bigr)\,
+            (X_B D_B)^\dagger .
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    Substitute the two decompositions into
+    $\E_{A,B}(Y)=\sum_i A^i\,Y\,(B^i)^\dagger$ and collect the outer factors,
+    which are independent of the summation index, outside the sum.
+\end{proof}
+
+\begin{theorem}[Residual-isometry form of the cross-block structure]%
+    \label{thm:residual_isometry_of_rfp_direct_sum}
+    \lean{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}
+    \leanok
+    \uses{def:is_residual_isometry_family, def:is_rfp,
+        def:is_isometry_canonical_form}
+    Let $(A_j)_j$ be a family of normal, irreducible, left-canonical blocks, no
+    two of which are gauge-phase equivalent, and suppose the direct sum
+    $\bigoplus_j A_j$ is a renormalization fixed point. Then there are invertible
+    $X_j$, positive trace-normalized diagonal weights $\Lambda_j$, and residual
+    tensors $U_j$ with
+    \[
+        A_j^i = X_j\,\sqrt{\Lambda_j}\,U_j^i\,X_j^{-1},
+    \]
+    such that $(U_j)_j$ is a residual isometry family. This is the
+    residual-isometry content of Corollary~III.cor3
+    \cite[Corollary~III.3]{Cirac2016MPDO_arXiv} at the level of the normal-tensor
+    blocks. The load-bearing hypothesis is whole-tensor renormalization fixed
+    point of the direct sum, together with the explicit per-block data of a basis
+    of normal tensors; extracting that data from a single canonical-form
+    renormalization-fixed-point predicate is a separate step, recorded in
+    \path{docs/paper-gaps/cpsv16_rfp_isometry_scope.tex}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:bnt_locally_orthogonal_of_rfp_direct_sum,
+        thm:isometry_canonical_form_of_rfp_nt, lem:mixed_transfer_conj_apply}
+    Whole-tensor idempotence makes the diagonal mixed transfer operator of each
+    block its own transfer map, hence each block is a renormalization fixed
+    point; the isometry canonical form
+    (Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt}) supplies the
+    decomposition $A_j^i = X_j\sqrt{\Lambda_j}U_j^iX_j^{-1}$ with the within-block
+    orthonormality, which is the $j=j'$ case. For $j\ne j'$,
+    Theorem~\ref{thm:bnt_locally_orthogonal_of_rfp_direct_sum} gives
+    $\E_{A_j,A_{j'}}=0$; by the covariance
+    Lemma~\ref{lem:mixed_transfer_conj_apply} and invertibility of the outer
+    factors $\E_{U_j,U_{j'}}=0$, and reading the entry of this operator at a
+    matrix unit yields the cross-block sum
+    $\sum_i (U_j^i)_{\alpha,\beta}\overline{(U_{j'}^i)_{\alpha',\beta'}}=0$.
+\end{proof}
+
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}
     \leanok

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -316,11 +316,37 @@ argument decomposes the direct-sum transfer map block by block
 (\leanid{MPSTensor.blockDiagonal'_transferSum_toBlock}): whole-tensor idempotence
 makes each $\mathcal{E}_{j,j'}$ idempotent, and the same-dimension and dimension-mismatch
 transfer-operator gaps force an idempotent of spectral radius below one to be
-zero.  Writing $A_j^i = X_j\sqrt{\Lambda_j}\,U_j^i X_j^{-1}$ and cancelling the
-invertible factors converts $\mathcal{E}_{j,j'}=0$ to the residual-isometry equation
-$\sum_i (U_j^i)_{\alpha,\beta}\overline{(U_{j'}^i)_{\alpha',\beta'}}=0$; this
-last conversion, together with a faithful multi-block isometry predicate, is the
-remaining step.
+zero.
+
+The passage to the residual isometries is now formalized.  Writing
+$A_j^i = X_j\sqrt{\Lambda_j}\,U_j^i X_j^{-1}$ with $X_j$ and $\sqrt{\Lambda_j}$
+invertible, the mixed transfer operator is covariant under the two-sided change
+of variables,
+\[
+  \mathcal{E}_{A_j,A_{j'}}(Y)
+    = X_j\sqrt{\Lambda_j}\,
+      \mathcal{E}_{U_j,U_{j'}}\!\bigl(X_j^{-1}Y(X_{j'}^{-1})^\dagger\bigr)\,
+      (X_{j'}\sqrt{\Lambda_{j'}})^\dagger,
+\]
+formalized by \leanid{MPSTensor.mixedTransferMap₂_conj_apply}.  Cancelling the
+invertible outer factors converts $\mathcal{E}_{A_j,A_{j'}}=0$ into
+$\mathcal{E}_{U_j,U_{j'}}=0$, and reading the matrix entry at a matrix unit
+yields the residual-isometry equation
+$\sum_i (U_j^i)_{\alpha,\beta}\overline{(U_{j'}^i)_{\alpha',\beta'}}=0$.  Together
+with the within-block orthonormality of the isometry canonical form, this is the
+faithful multi-block isometry predicate
+\leanid{MPSTensor.IsResidualIsometryFamily}, established under whole-tensor
+renormalization fixed point of the direct sum by
+\leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  This is the
+residual-isometry content of Corollary~III.cor3 at the level of the
+normal-tensor blocks.
+
+The remaining scope restriction is the source's starting point.
+Corollary~III.cor3 assumes a single predicate ``$A$ in canonical form is a
+renormalization fixed point'', whereas the formal theorem takes the per-block
+normal, irreducible, left-canonical and distinctness data of a basis of normal
+tensors as explicit hypotheses.  Extracting that per-block data from the single
+canonical-form predicate is the remaining step.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -158,9 +158,8 @@ matching condition fails.  The disjoint adjacent-pair product is instead
 Thus the adjacent physical-pair coefficient identity is not a consequence of
 the unit pair-index isometry alone.
 
-There is still no conclusion relating $U_k$ and $U_\ell$ for $k\ne \ell$.  Thus
-the formal theorems record only a separate isometry condition for each block;
-they do not record the cross-block equations
+The per-block isometry form does not by itself relate $U_k$ and $U_\ell$ for
+$k\ne \ell$.  The cross-block equations
 \begin{align}
   \sum_i
   (U_k^i)_{\alpha,\beta}\,
@@ -169,7 +168,9 @@ they do not record the cross-block equations
   0
   \qquad (k\ne \ell),
 \end{align}
-which are part of the source condition \path{eq:III_isometry}.
+the $j\ne j'$ part of the source condition \path{eq:III_isometry}, are
+established separately at the normal-tensor-block level, in the section on the
+cross-block residual isometry below.
 
 \section{Square-root diagonal (local correction)}
 
@@ -247,34 +248,65 @@ $\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$.  The identity
 $\sum_\alpha\Lambda_\alpha=1$ is the trace identity
 $\sum_\alpha\rho_{\alpha,\alpha}=\tr\rho$ for the diagonal fixed point.
 
-This discharges the trace-normalization scope item.  The remaining open part of
-the source isometry condition is the cross-block $\delta_{j,j'}$ orthogonality
-between distinct normal-tensor blocks, treated below.
+This discharges the trace-normalization scope item.  The cross-block
+$\delta_{j,j'}$ orthogonality between distinct normal-tensor blocks is treated in
+the next section.
+
+\section{Cross-block residual isometry}
+
+The cross-block $\delta_{j,j'}$ orthogonality is formalized at the level of the
+normal-tensor blocks.  For a family of normal, irreducible, left-canonical
+blocks $(A_j)_j$, no two gauge-phase equivalent, with $\dim_j\ge 1$ and whose
+direct sum $\bigoplus_j A_j$ is a renormalization fixed point, the mixed transfer
+operators between distinct blocks vanish,
+\[
+  \mathcal{E}_{j,j'}=\sum_i A_j^i\otimes\overline{A_{j'}^i}=0
+  \qquad (j\ne j'),
+\]
+formalized by \leanid{MPSTensor.isBNTLocallyOrthogonal_of_isRFP_directSum}.  The
+argument decomposes the direct-sum transfer map block by block
+(\leanid{MPSTensor.blockDiagonal'_transferSum_toBlock}): whole-tensor idempotence
+makes each $\mathcal{E}_{j,j'}$ idempotent, and the same-dimension and
+dimension-mismatch transfer-operator gaps force an idempotent of spectral radius
+below one to be zero.
+
+Passing to the residual isometries uses the isometry canonical form of each
+block.  Writing $A_j^i = X_j\sqrt{\Lambda_j}\,U_j^i X_j^{-1}$ with $X_j$ and
+$\sqrt{\Lambda_j}$ invertible, the mixed transfer operator is covariant under the
+two-sided change of variables,
+\[
+  \mathcal{E}_{A_j,A_{j'}}(Y)
+    = X_j\sqrt{\Lambda_j}\,
+      \mathcal{E}_{U_j,U_{j'}}\!\bigl(X_j^{-1}Y(X_{j'}^{-1})^\dagger\bigr)\,
+      (X_{j'}\sqrt{\Lambda_{j'}})^\dagger,
+\]
+formalized by \leanid{MPSTensor.mixedTransferMap₂_conj_apply}.  Cancelling the
+invertible outer factors converts $\mathcal{E}_{A_j,A_{j'}}=0$ into
+$\mathcal{E}_{U_j,U_{j'}}=0$, and reading the matrix entry at a matrix unit yields
+the residual-isometry equation
+$\sum_i (U_j^i)_{\alpha,\beta}\overline{(U_{j'}^i)_{\alpha',\beta'}}=0$.  Together
+with the within-block orthonormality of the isometry canonical form, this is the
+full source isometry condition \path{eq:III_isometry}, packaged as the predicate
+\leanid{MPSTensor.IsResidualIsometryFamily} and established under whole-tensor
+renormalization fixed point of the direct sum by
+\leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  This is the
+residual-isometry content of Corollary~III.cor3 at the normal-tensor-block level.
 
 \section{Elimination plan}
 
-A source-faithful version of Corollary~III.cor3 should be stated for a
-BNT-family or whole-tensor canonical-form datum, not merely for independent
-blocks.  Its conclusion should first expose the full pair-index isometry for a
-single block, with the normalization compared to the source convention, and
-then include a joint family $U$ satisfying
-\begin{align}
-  \sum_i
-  (U_k^i)_{\alpha,\beta}\,
-  \overline{(U_\ell^i)_{\alpha',\beta'}}
-  =
-  \delta_{k,\ell}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
-\end{align}
-Such a statement must account for the common physical space into which all
-blocks embed; in particular, the joint isometry condition has the dimensional
-content that the block-pair spaces fit orthogonally inside the physical space.
+The one remaining gap is the source's starting point.  Corollary~III.cor3 assumes
+a single predicate ``$A$ in canonical form is a renormalization fixed point'',
+whereas the formal theorem takes the per-block normality, irreducibility,
+left-canonical condition, and gauge-phase distinctness of a basis of normal
+tensors as explicit hypotheses.  A source-faithful version should derive those
+per-block conditions from the single canonical-form renormalization-fixed-point
+predicate, so that the residual isometry family follows from the whole-tensor
+predicate alone, by the block-level argument of the previous section.
 
 \section{Conclusion}
 
-The current theorem is a scope restriction.  It is a useful per-block
-consequence of the single-block RFP isometry form, but it is not the full
-isometry assertion of Corollary~III.cor3.  The formal development now exposes
-two normalization conventions.  In the $D_k^{-1/2}$ convention the residual
+The per-block isometry form exposes two normalization conventions, which the
+formal development makes explicit.  In the $D_k^{-1/2}$ convention the residual
 tensor satisfies the contracted per-block identity
 \[
   \sum_i (U_k^i)^\dagger U_k^i=I
@@ -296,57 +328,14 @@ for a single block by the named predicate
 \leanid{MPSTensor.IsIsometryCanonicalForm} and the theorem
 \leanid{MPSTensor.isIsometryCanonicalForm_of_rfp_nt}, with the diagonal weight
 $\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$ and the square-root dressing
-$\sqrt\Lambda$ of the unit isometry.  The remaining open part of the source
-isometry condition is the cross-block $\delta_{j,j'}$ orthogonality equations
-between distinct normal-tensor blocks.
-
-\section{Progress on the cross-block equations}
-
-The cross-block $\delta_{j,j'}$ orthogonality is now established at the level of
-the normal-tensor blocks, before the passage to the residual isometries.  For a
-family of distinct irreducible left-canonical blocks $(A_j)_j$, no two
-gauge-phase equivalent, whose direct sum $\bigoplus_j A_j$ is a renormalization
-fixed point, the mixed transfer operators between distinct blocks vanish,
-\[
-  \mathcal{E}_{j,j'}=\sum_i A_j^i\otimes\overline{A_{j'}^i}=0
-  \qquad (j\ne j'),
-\]
-formalized by \leanid{MPSTensor.isBNTLocallyOrthogonal_of_isRFP_directSum}.  The
-argument decomposes the direct-sum transfer map block by block
-(\leanid{MPSTensor.blockDiagonal'_transferSum_toBlock}): whole-tensor idempotence
-makes each $\mathcal{E}_{j,j'}$ idempotent, and the same-dimension and dimension-mismatch
-transfer-operator gaps force an idempotent of spectral radius below one to be
-zero.
-
-The passage to the residual isometries is now formalized.  Writing
-$A_j^i = X_j\sqrt{\Lambda_j}\,U_j^i X_j^{-1}$ with $X_j$ and $\sqrt{\Lambda_j}$
-invertible, the mixed transfer operator is covariant under the two-sided change
-of variables,
-\[
-  \mathcal{E}_{A_j,A_{j'}}(Y)
-    = X_j\sqrt{\Lambda_j}\,
-      \mathcal{E}_{U_j,U_{j'}}\!\bigl(X_j^{-1}Y(X_{j'}^{-1})^\dagger\bigr)\,
-      (X_{j'}\sqrt{\Lambda_{j'}})^\dagger,
-\]
-formalized by \leanid{MPSTensor.mixedTransferMap₂_conj_apply}.  Cancelling the
-invertible outer factors converts $\mathcal{E}_{A_j,A_{j'}}=0$ into
-$\mathcal{E}_{U_j,U_{j'}}=0$, and reading the matrix entry at a matrix unit
-yields the residual-isometry equation
-$\sum_i (U_j^i)_{\alpha,\beta}\overline{(U_{j'}^i)_{\alpha',\beta'}}=0$.  Together
-with the within-block orthonormality of the isometry canonical form, this is the
-faithful multi-block isometry predicate
-\leanid{MPSTensor.IsResidualIsometryFamily}, established under whole-tensor
-renormalization fixed point of the direct sum by
-\leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  This is the
-residual-isometry content of Corollary~III.cor3 at the level of the
-normal-tensor blocks.
-
-The remaining scope restriction is the source's starting point.
-Corollary~III.cor3 assumes a single predicate ``$A$ in canonical form is a
-renormalization fixed point'', whereas the formal theorem takes the per-block
-normal, irreducible, left-canonical and distinctness data of a basis of normal
-tensors as explicit hypotheses.  Extracting that per-block data from the single
-canonical-form predicate is the remaining step.
+$\sqrt\Lambda$ of the unit isometry.  The cross-block $\delta_{j,j'}$
+orthogonality equations of \path{eq:III_isometry} are formalized at the
+normal-tensor-block level by
+\leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  The only
+part not yet formalized is the extraction of the per-block normality,
+irreducibility, left-canonical condition, and gauge-phase distinctness from a
+single canonical-form renormalization-fixed-point predicate, the hypothesis form
+of Corollary~III.cor3.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## What landed

Converts the block-level cross-block vanishing `mixedTransferMap₂ (B j) (B j') = 0` (from `isBNTLocallyOrthogonal_of_isRFP_directSum`, the existing whole-tensor-RFP result) into the **literal residual-isometry equation** of `eq:III_isometry` (arXiv:1606.00608, Theorem charact-MPS, line 551; Corollary III.cor3, line 584) between the residual tensors `U_j`:
```
∑_i (U_j^i)_{αβ} conj((U_{j'}^i)_{α'β'}) = δ_{j,j'} δ_{αα'} δ_{ββ'}.
```

New file `TNLean/MPS/RFP/ResidualIsometry.lean`:

- `mixedTransferMap₂_conj_apply` — **covariance** of the mixed transfer operator under the two-sided change of variables `A^i = X_A D_A U^i X_A^{-1}`, `B^i = X_B D_B V^i X_B^{-1}`:
  `E_{A,B}(Y) = X_A D_A · E_{U,V}(X_A⁻¹ Y (X_B⁻¹)ᴴ) · (X_B D_B)ᴴ`.
- `mixedTransferMap₂_eq_zero_of_conj` — cancelling the invertible outer factors turns `E_{A,B}=0` into `E_{U,V}=0`.
- `residual_isometry_entry_of_mixedTransferMap₂_eq_zero` — reading the `(α,α')` entry of `E_{U,V}` applied to the matrix unit `Matrix.single β β' 1` gives the entrywise sum.
- `isRFP_block_of_isRFP_directSum` — per-block RFP from whole-tensor RFP (diagonal `j=j'` of the idempotence lemma; `mixedTransferMap₂ (B j) (B j) = transferMap (B j)`).
- `IsResidualIsometryFamily` — the full `eq:III_isometry` predicate (within-block orthonormality ⊕ cross-block vanishing).
- `exists_residualIsometryFamily_of_isRFP_directSum` — **headline**: for normal/irreducible/left-canonical/distinct blocks whose direct sum is a renormalization fixed point, the residual tensors of the per-block isometry canonical forms satisfy `IsResidualIsometryFamily`, with the decomposition `B_j^i = X_j √Λ_j U_j^i X_j⁻¹`.

## A → U covariance route

The per-block isometry canonical form (`isIsometryCanonicalForm_of_rfp_nt`, with per-block RFP derived from the whole-tensor fixed point) gives `B_j^i = X_j √Λ_j U_j^i X_j⁻¹` with `X_j`, `√Λ_j` invertible. Substituting into the mixed transfer operator exposes `E_{U_j,U_{j'}}` conjugated by invertible factors, so the block-level vanishing transfers to the residual operator; the entry reading recovers the source sum. The diagonal `j=j'` case is the within-block orthonormality already inside `IsIsometryCanonicalForm`.

## Faithfulness

The load-bearing hypothesis is **whole-tensor RFP of the direct sum** together with the explicit per-block data of a basis of normal tensors. Corollary III.cor3 instead starts from a single predicate "`A` in canonical form is RFP"; extracting the per-block data from that predicate is a separate step. Recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` (Progress section updated to reflect this landing). Blueprint entries added in `ch14_correlations.tex` with `\lean{}`+`\leanok` for the definition, the covariance lemma, and the headline theorem.

## Verification

- `lake build` green (9258 jobs).
- `rg 'sorry|admit|native_decide'` over the new file → NONE.
- `#print axioms` for all 5 new declarations → only `[propext, Classical.choice, Quot.sound]`.
- `lake exe lint-style` exit 0, no findings.

Addresses #3488 (Stage 3).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds ~270 lines of load-bearing MPS/RFP formal proofs that compose existing spectral and canonical-form infrastructure; risk is mathematical/regression in the proof chain rather than runtime or security impact.
> 
> **Overview**
> This PR **bridges block-level BNT orthogonality to the source residual-isometry equations** for renormalization fixed points of a direct sum of normal-tensor blocks.
> 
> A new module `TNLean/MPS/RFP/ResidualIsometry.lean` proves that when `mixedTransferMap₂ (B j) (B j') = 0` for distinct blocks (from existing `isBNTLocallyOrthogonal_of_isRFP_directSum`), the residual tensors `U_j` in the isometry canonical decomposition `B_j^i = X_j √Λ_j U_j^i X_j⁻¹` satisfy the **full** pair-index condition packaged as `IsResidualIsometryFamily`. The route is algebraic: **covariance** of `mixedTransferMap₂` under invertible two-sided gauge (`mixedTransferMap₂_conj_apply`), **cancellation** to `mixedTransferMap₂ U V = 0` (`mixedTransferMap₂_eq_zero_of_conj`), and an **entry readoff** on matrix units (`residual_isometry_entry_of_mixedTransferMap₂_eq_zero`). A helper `isRFP_block_of_isRFP_directSum` derives per-block RFP from whole-tensor RFP for the within-block (`j = j'`) case via `isIsometryCanonicalForm_of_rfp_nt`. The headline theorem is `exists_residualIsometryFamily_of_isRFP_directSum`.
> 
> `TNLean.lean` imports the new file. **Blueprint** `ch14_correlations.tex` gains matching definitions/lemmas/theorem with `\lean{}` links. **`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`** is updated to record that cross-block `δ_{j,j'}` orthogonality at the `U` level is now formalized; the **remaining gap** is deriving explicit per-block hypotheses from a single “canonical form is RFP” predicate (Corollary III.cor3 scope).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca0d24dc65e9d0ba18e875d26c2f04056e9573f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->