### PR TITLE
feat(MPS/RFP): isometry canonical form implies RFP (arXiv:1606.00608, #2598)

### DIFF
--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -872,4 +872,128 @@ theorem rfp_nt_structural_full_blocks_unit_pair {r : ℕ} {dim : Fin r → ℕ}
       (∀ i, A k i = X * Matrix.diagonal (fun j => (Λ j : ℂ)) * U i * X⁻¹) :=
   fun k => rfp_nt_structural_full_unit_pair (A k) (hNT k) (hRFP k) (hLeft k)
 
+/-- **Reference-tensor transfer identity for a unit pair-index isometry family.**
+
+If a family `U` satisfies the unit pair-index isometry condition
+\[
+  \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+    = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'},
+\]
+then the contracted sum $Z \mapsto \sum_i U^i\,Z\,(U^i)^\dagger$ sends every $Z$
+to $(\operatorname{tr} Z)\,I$.
+
+This is the transfer identity behind the reference tensor in the proof of
+arXiv:1606.00608, Lemma charact-NT-pure-RFP (lines 1271--1301): the reference
+tensor $\widehat A^{(\alpha',\beta')}_{\alpha,\beta}
+  = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha}$ gives the
+rank-one transfer map $|R)(L|$ with $(L| = \sum_\alpha (\alpha,\alpha|$, and the
+unit isometry dressing $U$ preserves this contracted identity. -/
+theorem unitPairIsometry_transfer (U : MPSTensor d D)
+    (hU : ∀ p q : Fin D × Fin D,
+      ∑ i : Fin d, star (U i p.1 p.2) * U i q.1 q.2 = if p = q then 1 else 0)
+    (Z : Mat) :
+    ∑ i : Fin d, U i * Z * (U i)ᴴ = Matrix.trace Z • (1 : Mat) := by
+  classical
+  have inner : ∀ x y a b : Fin D,
+      (∑ i : Fin d, U i x a * star (U i y b)) = if x = y ∧ a = b then 1 else 0 := by
+    intro x y a b
+    have h : (∑ i : Fin d, star (U i y b) * U i x a) = if (y, b) = (x, a) then (1 : ℂ) else 0 :=
+      hU (y, b) (x, a)
+    rw [show (∑ i : Fin d, U i x a * star (U i y b))
+          = ∑ i : Fin d, star (U i y b) * U i x a from
+        Finset.sum_congr rfl fun i _ => mul_comm _ _, h]
+    by_cases hxy : x = y <;> by_cases hab : a = b <;> simp [Prod.ext_iff, hxy, hab, eq_comm]
+  ext x y
+  rw [Matrix.smul_apply, Matrix.one_apply, smul_eq_mul, Matrix.sum_apply]
+  calc ∑ i : Fin d, (U i * Z * (U i)ᴴ) x y
+      = ∑ i : Fin d, ∑ j : Fin D, ∑ k : Fin D, U i x k * Z k j * star (U i y j) := by
+        simp only [Matrix.mul_apply, Matrix.conjTranspose_apply, Finset.sum_mul]
+    _ = ∑ j : Fin D, ∑ k : Fin D, Z k j * ∑ i : Fin d, U i x k * star (U i y j) := by
+        rw [Finset.sum_comm]
+        refine Finset.sum_congr rfl fun j _ => ?_
+        rw [Finset.sum_comm]
+        refine Finset.sum_congr rfl fun k _ => ?_
+        rw [Finset.mul_sum]
+        exact Finset.sum_congr rfl fun i _ => by ring
+    _ = ∑ j : Fin D, ∑ k : Fin D, Z k j * (if x = y ∧ k = j then 1 else 0) := by
+        simp_rw [inner]
+    _ = Matrix.trace Z * (if x = y then 1 else 0) := by
+        by_cases hxy : x = y
+        · rw [if_pos hxy, mul_one]
+          have hcond : ∀ k j : Fin D,
+              (if x = y ∧ k = j then (1 : ℂ) else 0) = if k = j then 1 else 0 :=
+            fun k j => by by_cases hkj : k = j <;> simp [hxy, hkj]
+          simp_rw [hcond, mul_ite, mul_one, mul_zero]
+          rw [Matrix.trace]
+          refine Finset.sum_congr rfl fun j _ => ?_
+          rw [Matrix.diag_apply]
+          exact Fintype.sum_ite_eq' j (fun k => Z k j)
+        · rw [if_neg hxy, mul_zero]
+          refine Finset.sum_eq_zero fun j _ => Finset.sum_eq_zero fun k _ => ?_
+          rw [if_neg (fun h => hxy h.1), mul_zero]
+
+/-- **Backward direction of the structural characterization of pure-state
+renormalization fixed points** (arXiv:1606.00608, Theorem charact-MPS,
+line 543; single-block Lemma charact-NT-pure-RFP, lines 1271--1301).
+
+A normal tensor in isometry canonical form is a renormalization fixed point: if
+$A^i = X\sqrt\Lambda\,U^i X^{-1}$ with $\Lambda$ diagonal, positive,
+trace-normalized, and $U$ a unit pair-index isometry, then `transferMap A` is
+idempotent, so `IsRFP A` holds. The source calls this implication trivial
+(line 1297).
+
+The transfer map has the rank-one closed form $E_A(Y) = \varphi(Y)\,R$ with
+$R = X\,\Lambda\,X^\dagger$ and
+$\varphi(Y) = \operatorname{tr}(X^{-1} Y (X^{-1})^\dagger)$, so idempotence
+reduces to $\varphi(R) = \operatorname{tr}\Lambda = 1$, the trace normalization.
+This is a faithful formalization of the source implication: it carries no
+hypothesis beyond `IsIsometryCanonicalForm`. -/
+theorem isRFP_of_isIsometryCanonicalForm (A : MPSTensor d D)
+    (h : IsIsometryCanonicalForm A) : IsRFP A := by
+  classical
+  obtain ⟨X, Λ, U, hX_det, hΛ_pos, hΛ_sum, hU_pair, hA_eq⟩ := h
+  set Dr : Mat := Matrix.diagonal (fun k => (Real.sqrt (Λ k) : ℂ)) with hDr
+  have hDr_herm : Drᴴ = Dr := by
+    rw [hDr, Matrix.diagonal_conjTranspose]
+    congr 1
+    funext k
+    simp
+  have hDr_sq : Dr * Dr = Matrix.diagonal (fun k => (Λ k : ℂ)) := by
+    rw [hDr, Matrix.diagonal_mul_diagonal]
+    congr 1
+    funext k
+    rw [← Complex.ofReal_mul, Real.mul_self_sqrt (le_of_lt (hΛ_pos k))]
+  have hXunit : IsUnit X.det := Ne.isUnit hX_det
+  have hXinvX : X⁻¹ * X = 1 := Matrix.nonsing_inv_mul X hXunit
+  set R : Mat := X * Matrix.diagonal (fun k => (Λ k : ℂ)) * Xᴴ with hR
+  have hXDrDrX : (X * Dr) * (Dr * Xᴴ) = R := by
+    rw [hR, Matrix.mul_assoc X Dr (Dr * Xᴴ), ← Matrix.mul_assoc Dr Dr Xᴴ,
+      ← Matrix.mul_assoc X (Dr * Dr) Xᴴ, hDr_sq]
+  have hclosed : ∀ Y : Mat, transferMap A Y = Matrix.trace (X⁻¹ * Y * (X⁻¹)ᴴ) • R := by
+    intro Y
+    have hsumm : ∀ i, A i * Y * (A i)ᴴ
+        = (X * Dr) * (U i * (X⁻¹ * Y * (X⁻¹)ᴴ) * (U i)ᴴ) * (Dr * Xᴴ) := by
+      intro i
+      rw [hA_eq i]
+      simp only [Matrix.conjTranspose_mul, hDr_herm, Matrix.mul_assoc]
+    rw [transferMap_apply]
+    simp_rw [hsumm]
+    rw [← Finset.sum_mul, ← Finset.mul_sum,
+      unitPairIsometry_transfer U hU_pair (X⁻¹ * Y * (X⁻¹)ᴴ),
+      Matrix.mul_smul, mul_one, Matrix.smul_mul, hXDrDrX]
+  have hφR : Matrix.trace (X⁻¹ * R * (X⁻¹)ᴴ) = 1 := by
+    rw [hR,
+      show X⁻¹ * (X * Matrix.diagonal (fun k => (Λ k : ℂ)) * Xᴴ) * (X⁻¹)ᴴ
+          = (X⁻¹ * X) * Matrix.diagonal (fun k => (Λ k : ℂ)) * (Xᴴ * (X⁻¹)ᴴ) from by
+        simp only [Matrix.mul_assoc],
+      hXinvX, Matrix.one_mul,
+      show Xᴴ * (X⁻¹)ᴴ = (X⁻¹ * X)ᴴ from (Matrix.conjTranspose_mul X⁻¹ X).symm,
+      hXinvX, Matrix.conjTranspose_one, Matrix.mul_one, Matrix.trace_diagonal,
+      ← Complex.ofReal_sum, hΛ_sum, Complex.ofReal_one]
+  show transferMap A ∘ₗ transferMap A = transferMap A
+  apply LinearMap.ext
+  intro Y
+  simp only [LinearMap.comp_apply]
+  rw [hclosed Y, map_smul, hclosed R, hφR, one_smul]
+
 end MPSTensor

--- a/TNLean/MPS/RFP/StructuralFull.lean
+++ b/TNLean/MPS/RFP/StructuralFull.lean
@@ -936,7 +936,7 @@ theorem unitPairIsometry_transfer (U : MPSTensor d D)
 renormalization fixed points** (arXiv:1606.00608, Theorem charact-MPS,
 line 543; single-block Lemma charact-NT-pure-RFP, lines 1271--1301).
 
-A normal tensor in isometry canonical form is a renormalization fixed point: if
+A tensor in isometry canonical form is a renormalization fixed point: if
 $A^i = X\sqrt\Lambda\,U^i X^{-1}$ with $\Lambda$ diagonal, positive,
 trace-normalized, and $U$ a unit pair-index isometry, then `transferMap A` is
 idempotent, so `IsRFP A` holds. The source calls this implication trivial

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -685,6 +685,54 @@ and rates for the single-tensor transfer map $\E_A$.
     decomposition $A^i = X\sqrt\Lambda\,U^i X^{-1}$.
 \end{proof}
 
+\begin{lemma}[Reference-tensor transfer identity for a unit pair-index isometry]%
+    \label{lem:unit_pair_isometry_transfer}
+    \lean{MPSTensor.unitPairIsometry_transfer}
+    \leanok
+    Let $U$ be a family of bond matrices satisfying the unit pair-index isometry
+    condition
+    \[
+        \sum_i \overline{(U^i)_{\alpha,\beta}}\,(U^i)_{\alpha',\beta'}
+        = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
+    \]
+    Then for every bond matrix $Z$,
+    \[
+        \sum_i U^i\,Z\,(U^i)^\dagger = \tr(Z)\,I.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    Reading off the $(x,y)$ entry, the pair-index condition gives
+    $\sum_i (U^i)_{x,\alpha}\,\overline{(U^i)_{y,\beta}}
+        = \delta_{x,y}\,\delta_{\alpha,\beta}$, so the entry collapses to
+    $\delta_{x,y}\sum_\alpha Z_{\alpha,\alpha} = \delta_{x,y}\,\tr(Z)$, which is
+    the $(x,y)$ entry of $\tr(Z)\,I$.
+\end{proof}
+
+\begin{theorem}[Isometry canonical form implies the renormalization fixed-point property]%
+    \label{thm:is_rfp_of_isometry_canonical_form}
+    \lean{MPSTensor.isRFP_of_isIsometryCanonicalForm}
+    \leanok
+    \uses{def:is_isometry_canonical_form, def:is_rfp}
+    A tensor in isometry canonical form is a renormalization fixed point. This is
+    the backward direction of the structural characterization of pure-state
+    renormalization fixed points in \cite[Section~3]{Cirac2016MPDO_arXiv}, which
+    the source states as immediate.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{lem:unit_pair_isometry_transfer}
+    Write $A^i = X\sqrt\Lambda\,U^i X^{-1}$. Substituting into the transfer map
+    and pulling the index-independent factors $X\sqrt\Lambda$ and
+    $\sqrt\Lambda\,X^\dagger$ outside the sum, the unit pair-index isometry
+    identity (Lemma~\ref{lem:unit_pair_isometry_transfer}) gives the rank-one form
+    \[
+        \E_A(Y) = \tr\!\bigl(X^{-1} Y (X^{-1})^\dagger\bigr)\,R,
+        \qquad R = X\,\Lambda\,X^\dagger.
+    \]
+    Idempotence then reduces to
+    $\tr\!\bigl(X^{-1} R (X^{-1})^\dagger\bigr) = \tr(\Lambda) = 1$, the trace
+    normalization, so $\E_A \circ \E_A = \E_A$.
+\end{proof}
+
 \begin{theorem}[Per-block trace-normalized isometry canonical form]%
     \label{thm:isometry_canonical_form_of_rfp_nt_blocks}
     \lean{MPSTensor.isIsometryCanonicalForm_of_rfp_nt_blocks}


### PR DESCRIPTION
## Statement

```lean
theorem MPSTensor.isRFP_of_isIsometryCanonicalForm (A : MPSTensor d D)
    (h : IsIsometryCanonicalForm A) : IsRFP A
```

This is the backward direction of the structural characterization of pure-state
renormalization fixed points (arXiv:1606.00608, Theorem `thm:charact-MPS`, line
543; single-block Lemma `charact-NT-pure-RFP`, lines 1271-1301). The source
calls this implication trivial (line 1297).

## Proof route

For a tensor in isometry canonical form `A^i = X √Λ U^i X⁻¹` (with `Λ` diagonal,
positive, trace-normalized, and `U` a unit pair-index isometry), the transfer
map has the rank-one closed form

```
E_A(Y) = tr(X⁻¹ Y (X⁻¹)ᴴ) · R,   R = X Λ Xᴴ.
```

Idempotence `E_A ∘ E_A = E_A` then reduces to `φ(R) = tr(Λ) = 1`, the trace
normalization. The reusable helper `MPSTensor.unitPairIsometry_transfer` records
the reference-tensor identity `∑ᵢ Uⁱ Z (Uⁱ)ᴴ = tr(Z) · I` for a unit pair-index
isometry family, obtained by reading off the `(x,y)` entry and collapsing with
the pair-index condition.

## Faithfulness

This is a faithful formalization of the source implication: the only hypothesis
is `IsIsometryCanonicalForm` (the paper's trivial backward direction). No extra
hypotheses (in particular no `[NeZero D]`), so no scope-restriction marker is
needed.

## Blueprint

`blueprint/src/chapter/ch14_correlations.tex` gains
`lem:unit_pair_isometry_transfer` and `thm:is_rfp_of_isometry_canonical_form`,
both with `\lean` + `\leanok`, placed next to the forward-direction isometry
canonical form material.

## Verification

- `lake build` green (9258 jobs).
- `#print axioms MPSTensor.isRFP_of_isIsometryCanonicalForm` →
  `[propext, Classical.choice, Quot.sound]` (same for the helper).
- No `sorry` / `admit` / `native_decide`.
- `scripts/check_reader_facing_prose.py --diff-base main --ci` exit 0.

Addresses #2598 (single-block backward direction of `thm:charact-MPS`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Mathlib proofs in MPS/RFP structural theory only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds the **backward** implication of the pure-state RFP structural characterization (Cirac et al. arXiv:1606.00608): **`IsIsometryCanonicalForm A → IsRFP A`**, formalized as `MPSTensor.isRFP_of_isIsometryCanonicalForm` with hypothesis only `IsIsometryCanonicalForm` (no extra `NeZero`).
> 
> The proof shows the transfer map is rank-one, `E_A(Y) = tr(X⁻¹ Y (X⁻¹)†) · R` with `R = X Λ X†`, then uses trace normalization `∑ Λ = 1` so `E_A ∘ E_A = E_A`. A reusable lemma **`unitPairIsometry_transfer`** proves `∑ᵢ Uⁱ Z (Uⁱ)† = tr(Z)·I` under the unit pair-index isometry on `U`.
> 
> **Blueprint** (`ch14_correlations.tex`): new lemma and theorem with `\lean` / `\leanok`, placed after the forward trace-normalized isometry canonical form material.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed2b3d4b09074c2f2de992d0e68c0113d3ac6541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->