### PR TITLE
feat(MPS/RFP): direct sum of isometry-canonical-form blocks is RFP (arXiv:1606.00608, #2598)

### DIFF
--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -175,10 +175,7 @@ lemma isRFP_block_of_isRFP_directSum [∀ k, NeZero (dim k)]
     (hRFP : IsRFP (directSumTensor B)) (j : Fin r) :
     IsRFP (B j) := by
   have hidem := mixedTransferMap₂_isIdempotentElem_of_isRFP_directSum B hRFP j j
-  have hself : mixedTransferMap₂ (B j) (B j) = transferMap (B j) := by
-    ext X
-    simp only [mixedTransferMap₂_apply, transferMap_apply]
-  rwa [hself] at hidem
+  rwa [mixedTransferMap₂_self] at hidem
 
 /-- **Residual isometry family** (arXiv:1606.00608, eq:III_isometry, line 551).
 A family of residual tensors $U_j$ satisfies the source isometry condition when
@@ -307,9 +304,7 @@ theorem blockTransferSum_idempotent_of_isIsometryCanonicalForm
     rw [hStage1 (blockTransferSum B Y) j j', hStage1 Y j j']
     by_cases hjj' : j = j'
     · subst hjj'
-      have hself : mixedTransferMap₂ (B j) (B j) = transferMap (B j) := by
-        ext X; simp only [mixedTransferMap₂_apply, transferMap_apply]
-      rw [hself]
+      rw [mixedTransferMap₂_self]
       have hRFPj : IsRFP (B j) := isRFP_of_isIsometryCanonicalForm (B j) (hCF j)
       simpa only [LinearMap.comp_apply] using
         LinearMap.congr_fun hRFPj (Y.submatrix (blockIncl j dim) (blockIncl j dim))
@@ -348,7 +343,7 @@ theorem isRFP_directSumTensor_of_isIsometryCanonicalForm
     (hortho : ∀ j j' : Fin r, j ≠ j' → mixedTransferMap₂ (B j) (B j') = 0) :
     IsRFP (directSumTensor B) := by
   classical
-  set e := finSigmaFinEquiv (m := r) (n := dim) with he
+  set e := finSigmaFinEquiv (m := r) (n := dim)
   change transferMap (directSumTensor B) ∘ₗ transferMap (directSumTensor B)
       = transferMap (directSumTensor B)
   refine LinearMap.ext fun Z => ?_

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -267,6 +267,103 @@ theorem exists_residualIsometryFamily_of_isRFP_directSum [∀ k, NeZero (dim k)]
         (hXdet j) (hDdet j) (hXdet j') (hDdet j') (hBNT j j' hjj')
     exact residual_isometry_entry_of_mixedTransferMap₂_eq_zero (U j) (U j') hUjj' α β α' β'
 
+/-! ## Backward direction: a direct sum of isometry-canonical-form blocks is a
+renormalization fixed point -/
+
+/-- Idempotence of the block-diagonal transfer sum when each block is in isometry
+canonical form and the cross-block mixed transfer operators vanish.
+
+The $(j,j')$ bond block of the transfer sum acts as `mixedTransferMap₂ (B j)
+(B j')` on the $(j,j')$ block of the argument
+(`blockDiagonal'_transferSum_toBlock`).  Each diagonal block contributes
+`transferMap (B j)`, which is idempotent because `B j` is a renormalization fixed
+point (`isRFP_of_isIsometryCanonicalForm`); each off-diagonal block vanishes by
+`hortho`.  This is the block-space form of the backward direction of the
+structural characterization of pure-state renormalization fixed points
+(arXiv:1606.00608, Theorem charact-MPS, line 543). -/
+theorem blockTransferSum_idempotent_of_isIsometryCanonicalForm
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : ∀ k, IsIsometryCanonicalForm (B k))
+    (hortho : ∀ j j' : Fin r, j ≠ j' → mixedTransferMap₂ (B j) (B j') = 0)
+    (Y : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ) :
+    blockTransferSum B (blockTransferSum B Y) = blockTransferSum B Y := by
+  classical
+  have hStage1 : ∀ (W : Matrix ((k : Fin r) × Fin (dim k))
+        ((k : Fin r) × Fin (dim k)) ℂ) (j j' : Fin r),
+      (blockTransferSum B W).submatrix (blockIncl j dim) (blockIncl j' dim) =
+        mixedTransferMap₂ (B j) (B j')
+          (W.submatrix (blockIncl j dim) (blockIncl j' dim)) := by
+    intro W j j'
+    simpa only [blockTransferSum] using blockDiagonal'_transferSum_toBlock B W j j'
+  have blockEq : ∀ j j' : Fin r,
+      (blockTransferSum B (blockTransferSum B Y)).submatrix
+          (blockIncl j dim) (blockIncl j' dim) =
+        (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
+    intro j j'
+    rw [hStage1 (blockTransferSum B Y) j j', hStage1 Y j j']
+    by_cases hjj' : j = j'
+    · subst hjj'
+      have hself : mixedTransferMap₂ (B j) (B j) = transferMap (B j) := by
+        ext X; simp only [mixedTransferMap₂_apply, transferMap_apply]
+      rw [hself]
+      have hRFPj : IsRFP (B j) := isRFP_of_isIsometryCanonicalForm (B j) (hCF j)
+      simpa only [LinearMap.comp_apply] using
+        LinearMap.congr_fun hRFPj (Y.submatrix (blockIncl j dim) (blockIncl j dim))
+    · rw [hortho j j' hjj']
+      simp
+  ext jx jy
+  obtain ⟨j, a⟩ := jx
+  obtain ⟨j', a'⟩ := jy
+  simpa only [Matrix.submatrix_apply, blockIncl] using
+    congrFun (congrFun (blockEq j j') a) a'
+
+/-- **Backward direction of the structural characterization of pure-state
+renormalization fixed points** (arXiv:1606.00608, Theorem charact-MPS, line 543),
+multiplicity-one case.
+
+A direct sum of blocks each in isometry canonical form whose cross-block mixed
+transfer operators vanish is a renormalization fixed point.  The cross-block
+hypothesis `hortho` is the off-diagonal ($j \ne j'$) content of the isometry
+condition eq:III_isometry (arXiv:1606.00608, line 551), so it belongs to the
+source's isometry form rather than being an added assumption; the within-block
+diagonal content is `IsIsometryCanonicalForm`.
+
+The direct-sum transfer map is block diagonal as a superoperator: its $(j,j')$
+bond block acts as `mixedTransferMap₂ (B j) (B j')` on the $(j,j')$ block of the
+argument.  The diagonal blocks are idempotent (per-block renormalization fixed
+point) and the off-diagonal blocks vanish, so the whole map is idempotent.
+
+**Scope restriction (multiplicity-one canonical form):** the source's canonical
+form III_CFI_RFP allows each normal tensor to repeat with a multiplicity and a
+phase; this is the distinct-blocks (multiplicity-one, phase-one) case, where the
+direct sum carries one copy of each block.  Recorded in the paper-gap note
+docs/paper-gaps/cpsv16_rfp_isometry_scope.tex. -/
+theorem isRFP_directSumTensor_of_isIsometryCanonicalForm
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : ∀ k, IsIsometryCanonicalForm (B k))
+    (hortho : ∀ j j' : Fin r, j ≠ j' → mixedTransferMap₂ (B j) (B j') = 0) :
+    IsRFP (directSumTensor B) := by
+  classical
+  set e := finSigmaFinEquiv (m := r) (n := dim) with he
+  change transferMap (directSumTensor B) ∘ₗ transferMap (directSumTensor B)
+      = transferMap (directSumTensor B)
+  refine LinearMap.ext fun Z => ?_
+  rw [LinearMap.comp_apply]
+  obtain ⟨Y, rfl⟩ : ∃ Y, Matrix.reindex e e Y = Z :=
+    ⟨(Matrix.reindex e e).symm Z, (Matrix.reindex e e).apply_symm_apply Z⟩
+  calc
+    transferMap (directSumTensor B)
+          (transferMap (directSumTensor B) (Matrix.reindex e e Y))
+        = transferMap (directSumTensor B)
+            (Matrix.reindex e e (blockTransferSum B Y)) := by
+          rw [transferMap_directSumTensor_reindex B Y]
+    _ = Matrix.reindex e e (blockTransferSum B (blockTransferSum B Y)) :=
+          transferMap_directSumTensor_reindex B (blockTransferSum B Y)
+    _ = Matrix.reindex e e (blockTransferSum B Y) := by
+          rw [blockTransferSum_idempotent_of_isIsometryCanonicalForm B hCF hortho Y]
+    _ = transferMap (directSumTensor B) (Matrix.reindex e e Y) :=
+          (transferMap_directSumTensor_reindex B Y).symm
+
 end Blocks
 
 end MPSTensor

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -278,7 +278,8 @@ The $(j,j')$ bond block of the transfer sum acts as `mixedTransferMap₂ (B j)
 (`blockDiagonal'_transferSum_toBlock`).  Each diagonal block contributes
 `transferMap (B j)`, which is idempotent because `B j` is a renormalization fixed
 point (`isRFP_of_isIsometryCanonicalForm`); each off-diagonal block vanishes by
-`hortho`.  This is the block-space form of the backward direction of the
+the cross-block orthogonality hypothesis.  This is the block-space form of the
+backward direction of the
 structural characterization of pure-state renormalization fixed points
 (arXiv:1606.00608, Theorem charact-MPS, line 543). -/
 theorem blockTransferSum_idempotent_of_isIsometryCanonicalForm
@@ -323,8 +324,8 @@ multiplicity-one case.
 
 A direct sum of blocks each in isometry canonical form whose cross-block mixed
 transfer operators vanish is a renormalization fixed point.  The cross-block
-hypothesis `hortho` is the off-diagonal ($j \ne j'$) content of the isometry
-condition eq:III_isometry (arXiv:1606.00608, line 551), so it belongs to the
+hypothesis is the off-diagonal ($j \ne j'$) content of the isometry
+condition (arXiv:1606.00608, line 551), so it belongs to the
 source's isometry form rather than being an added assumption; the within-block
 diagonal content is `IsIsometryCanonicalForm`.
 
@@ -334,7 +335,7 @@ argument.  The diagonal blocks are idempotent (per-block renormalization fixed
 point) and the off-diagonal blocks vanish, so the whole map is idempotent.
 
 **Scope restriction (multiplicity-one canonical form):** the source's canonical
-form III_CFI_RFP allows each normal tensor to repeat with a multiplicity and a
+form allows each normal tensor to repeat with a multiplicity and a
 phase; this is the distinct-blocks (multiplicity-one, phase-one) case, where the
 direct sum carries one copy of each block.  Recorded in the paper-gap note
 docs/paper-gaps/cpsv16_rfp_isometry_scope.tex. -/

--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -276,7 +276,7 @@ canonical form and the cross-block mixed transfer operators vanish.
 The $(j,j')$ bond block of the transfer sum acts as `mixedTransferMap₂ (B j)
 (B j')` on the $(j,j')$ block of the argument
 (`blockDiagonal'_transferSum_toBlock`).  Each diagonal block contributes
-`transferMap (B j)`, which is idempotent because `B j` is a renormalization fixed
+`transferMap (B j)`, which is idempotent because $B_j$ is a renormalization fixed
 point (`isRFP_of_isIsometryCanonicalForm`); each off-diagonal block vanishes by
 the cross-block orthogonality hypothesis.  This is the block-space form of the
 backward direction of the
@@ -301,6 +301,9 @@ theorem blockTransferSum_idempotent_of_isIsometryCanonicalForm
           (blockIncl j dim) (blockIncl j' dim) =
         (blockTransferSum B Y).submatrix (blockIncl j dim) (blockIncl j' dim) := by
     intro j j'
+    -- Rewrite both the doubly-applied outer block and the once-applied inner
+    -- block to `mixedTransferMap₂ (B j) (B j')` of the corresponding submatrix
+    -- of `Y`, so the goal becomes idempotence of that per-pair operator.
     rw [hStage1 (blockTransferSum B Y) j j', hStage1 Y j j']
     by_cases hjj' : j = j'
     · subst hjj'

--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -164,7 +164,7 @@ lemma mixedTransferMap₂_apply {d D₁ D₂ : ℕ}
     mixedTransferMap₂ A B X = ∑ i : Fin d, A i * X * (B i)ᴴ := by
   simp [mixedTransferMap₂, Matrix.mul_assoc]
 
-/-- The rectangular mixed transfer operator with `A = B` is the standard transfer
+/-- When $A = B$, the rectangular mixed transfer operator is the standard transfer
 map.  This is the rectangular analogue of `mixedTransferMap_self`. -/
 @[simp]
 lemma mixedTransferMap₂_self {d D : ℕ} (A : MPSTensor d D) :

--- a/TNLean/Spectral/MixedTransfer.lean
+++ b/TNLean/Spectral/MixedTransfer.lean
@@ -164,6 +164,13 @@ lemma mixedTransferMap₂_apply {d D₁ D₂ : ℕ}
     mixedTransferMap₂ A B X = ∑ i : Fin d, A i * X * (B i)ᴴ := by
   simp [mixedTransferMap₂, Matrix.mul_assoc]
 
+/-- The rectangular mixed transfer operator with `A = B` is the standard transfer
+map.  This is the rectangular analogue of `mixedTransferMap_self`. -/
+@[simp]
+lemma mixedTransferMap₂_self {d D : ℕ} (A : MPSTensor d D) :
+    mixedTransferMap₂ A A = transferMap (d := d) (D := D) A := by
+  ext X; simp only [mixedTransferMap₂_apply, transferMap_apply]
+
 end MixedTransferRect
 
 section IteratedTransferRect

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -959,9 +959,16 @@ and rates for the single-tensor transfer map $\E_A$.
     block $\E_{j,j}$ is the transfer map of $B_j$, which is idempotent because
     $B_j$ is a renormalization fixed point
     (Theorem~\ref{thm:is_rfp_of_isometry_canonical_form}); each off-diagonal block
-    $\E_{j,j'}$ with $j\ne j'$ vanishes by hypothesis. The squared transfer map
-    therefore agrees with the transfer map on every bond block, hence is equal to
-    it, so the direct sum is a renormalization fixed point.
+    $\E_{j,j'}$ with $j\ne j'$ vanishes by hypothesis. Therefore, for every bond
+    block,
+    \[
+        \bigl[\mathcal{E}_{\bigoplus B}^2(Y)\bigr]_{j,j'}
+        = \E_{j,j'}\!\bigl(\E_{j,j'}(Y_{j,j'})\bigr)
+        = \E_{j,j'}(Y_{j,j'})
+        = \bigl[\mathcal{E}_{\bigoplus B}(Y)\bigr]_{j,j'},
+    \]
+    so $\mathcal{E}_{\bigoplus B}^2 = \mathcal{E}_{\bigoplus B}$ and the direct
+    sum is a renormalization fixed point.
 \end{proof}
 
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -933,6 +933,37 @@ and rates for the single-tensor transfer map $\E_A$.
     $\sum_i (U_j^i)_{\alpha,\beta}\overline{(U_{j'}^i)_{\alpha',\beta'}}=0$.
 \end{proof}
 
+\begin{theorem}[A direct sum of isometry-canonical-form blocks is a renormalization fixed point]%
+    \label{thm:is_rfp_of_isometry_canonical_form_direct_sum}
+    \lean{MPSTensor.isRFP_directSumTensor_of_isIsometryCanonicalForm}
+    \leanok
+    \uses{def:is_isometry_canonical_form, def:is_rfp, def:mixed_transfer_rect}
+    Let $(B_k)_k$ be a family of tensors, each in isometry canonical form, whose
+    cross-block mixed transfer operators vanish, $\E_{j,j'}=0$ for $j\ne j'$. Then
+    the direct sum $\bigoplus_k B_k$ is a renormalization fixed point. This is the
+    backward direction of the structural characterization of pure-state
+    renormalization fixed points \cite[Section~3]{Cirac2016MPDO_arXiv}, in the
+    distinct-blocks case where each normal tensor appears once; the cross-block
+    vanishing is the $j\ne j'$ part of the isometry condition of that
+    characterization, so it belongs to the source isometry form.
+% Scope restriction (multiplicity-one): the source canonical form allows each
+% normal tensor to repeat with a multiplicity and a phase; this is the
+% single-copy case (docs/paper-gaps/cpsv16_rfp_isometry_scope.tex).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:is_rfp_of_isometry_canonical_form,
+        lem:block_diagonal_transfer_sum_to_block}
+    The direct-sum transfer map decouples block by block: by
+    Lemma~\ref{lem:block_diagonal_transfer_sum_to_block} its $(j,j')$ bond block
+    acts as $\E_{j,j'}$ on the $(j,j')$ bond block of the argument. Each diagonal
+    block $\E_{j,j}$ is the transfer map of $B_j$, which is idempotent because
+    $B_j$ is a renormalization fixed point
+    (Theorem~\ref{thm:is_rfp_of_isometry_canonical_form}); each off-diagonal block
+    $\E_{j,j'}$ with $j\ne j'$ vanishes by hypothesis. The squared transfer map
+    therefore agrees with the transfer map on every bond block, hence is equal to
+    it, so the direct sum is a renormalization fixed point.
+\end{proof}
+
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}
     \leanok

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -292,6 +292,31 @@ renormalization fixed point of the direct sum by
 \leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  This is the
 residual-isometry content of Corollary~III.cor3 at the normal-tensor-block level.
 
+\section{Backward direction (multiplicity-one)}
+
+The backward direction of the characterization is also formalized at the
+normal-tensor-block level.  If each block $B_k$ is in isometry canonical form and
+the cross-block mixed transfer operators vanish, $\mathcal{E}_{j,j'}=0$ for
+$j\ne j'$, then the direct sum $\bigoplus_k B_k$ is a renormalization fixed
+point,\footnote{Formal declaration:
+\leanid{MPSTensor.isRFP_directSumTensor_of_isIsometryCanonicalForm} in
+\doclink{TNLean/MPS/RFP/ResidualIsometry}.} by
+\leanid{MPSTensor.blockTransferSum_idempotent_of_isIsometryCanonicalForm}.  The
+direct-sum transfer map decomposes block by block
+(\leanid{MPSTensor.blockDiagonal'_transferSum_toBlock}): the diagonal blocks are
+the per-block transfer maps, idempotent by
+\leanid{MPSTensor.isRFP_of_isIsometryCanonicalForm}, and the off-diagonal blocks
+vanish by the cross-block hypothesis, which is the $j\ne j'$ part of
+\path{eq:III_isometry} and so belongs to the source isometry form rather than
+being an added assumption.
+
+This handles the distinct-blocks (multiplicity-one, phase-one) case of the
+source canonical form \path{III_CFI_RFP}, where the inner direct sum over
+copies $q=1,\ldots,r_j$ has a single summand and the phases $\mu_{j,q}$ are all
+$1$, so the direct sum carries one copy of each normal-tensor block.  The
+full-multiplicity backward direction, summing repeated copies of each block with
+their phases and scalar weights, is a further step.
+
 \section{Elimination plan}
 
 The one remaining gap is the source's starting point.  Corollary~III.cor3 assumes


### PR DESCRIPTION
## Statement

Adds the multi-block (distinct-blocks) **backward direction** of `thm:charact-MPS`
(arXiv:1606.00608, line 543), in `TNLean/MPS/RFP/ResidualIsometry.lean`:

```lean
theorem isRFP_directSumTensor_of_isIsometryCanonicalForm
    (B : (k : Fin r) → MPSTensor d (dim k))
    (hCF : ∀ k, IsIsometryCanonicalForm (B k))
    (hortho : ∀ j j' : Fin r, j ≠ j' → mixedTransferMap₂ (B j) (B j') = 0) :
    IsRFP (directSumTensor B)
```

plus the reusable block-space lemma
`blockTransferSum_idempotent_of_isIsometryCanonicalForm`.

## Route (block-diagonal superoperator)

The direct-sum transfer map is block diagonal as a superoperator: by
`blockDiagonal'_transferSum_toBlock`, its `(j, j')` bond block acts as
`mixedTransferMap₂ (B j) (B j')` on the `(j, j')` block of the argument. The
diagonal blocks are the per-block transfer maps, idempotent because each block is
a renormalization fixed point (`isRFP_of_isIsometryCanonicalForm`); the
off-diagonal blocks vanish by `hortho`. So `E ∘ E` agrees with `E` on every bond
block, hence `E ∘ E = E`, i.e. `IsRFP (directSumTensor B)`. The block-to-whole
reduction goes through `transferMap_directSumTensor_reindex` and the
`Σ ≃ Fin` bond reindexing; no `NeZero (dim k)` instances are needed (the converse
direction does not use surjectivity of the block restriction).

## Faithfulness

This is the distinct-blocks (multiplicity-one, phase-one) case of the backward
direction of `thm:charact-MPS`. The cross-block hypothesis `hortho` is the
off-diagonal (`j ≠ j'`) content of the isometry condition `eq:III_isometry`
(line 551), so it is part of the source's isometry form, not an added assumption.
A `**Scope restriction (multiplicity-one canonical form):**` marker records the
single-copy specialization, documented in
`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` (new section "Backward direction
(multiplicity-one)"). No smuggled hypotheses.

## Verification

- `lake build TNLean.MPS.RFP.ResidualIsometry`: success (8658 jobs).
- `#print axioms isRFP_directSumTensor_of_isIsometryCanonicalForm` and the helper:
  only `[propext, Classical.choice, Quot.sound]`.
- No `sorry`/`admit`/`native_decide` in the touched file.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci`: exit 0.
- Blueprint entry `thm:is_rfp_of_isometry_canonical_form_direct_sum` added near the
  isometry-canonical-form material in `ch14_correlations.tex`.

Addresses #2598.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formal proofs and documentation in MPS spectral/RFP theory; no runtime, auth, or data paths. Residual risk is mathematical correctness of the new lemmas, mitigated by the project's Lean build and axiom checks.
> 
> **Overview**
> Adds the **multiplicity-one backward direction** of the pure-state RFP structural characterization (arXiv:1606.00608): if every block is in **isometry canonical form** and off-diagonal `mixedTransferMap₂` operators vanish, then **`directSumTensor B` is an RFP**.
> 
> The proof works in **block bond space** via `blockTransferSum_idempotent_of_isIsometryCanonicalForm` (diagonal blocks use per-block RFP from `isRFP_of_isIsometryCanonicalForm`; off-diagonals are zero), then lifts to the whole transfer map with `transferMap_directSumTensor_reindex`.
> 
> Also introduces **`mixedTransferMap₂_self`** so `mixedTransferMap₂ A A = transferMap A`, simplifying `isRFP_block_of_isRFP_directSum`. Blueprint theorem `thm:is_rfp_of_isometry_canonical_form_direct_sum` and a **Backward direction (multiplicity-one)** section in `cpsv16_rfp_isometry_scope.tex` document scope (single copy per block; full multiplicity still open).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99758bf0656fbf4f0fafae766a9b498da4907e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->