### PR TITLE
feat(MPS/RFP): distinct-blocks RFP iff isometry canonical form (arXiv:1606.00608, #2598)

### DIFF
--- a/TNLean/MPS/RFP/ResidualIsometry.lean
+++ b/TNLean/MPS/RFP/ResidualIsometry.lean
@@ -34,6 +34,10 @@ the full isometry condition of Corollary III.cor3 (arXiv:1606.00608, line 584).
 * `exists_residualIsometryFamily_of_isRFP_directSum` — under whole-tensor RFP of
   the direct sum, the residual tensors of the isometry canonical forms of the
   blocks satisfy `IsResidualIsometryFamily`.
+* `isRFP_directSumTensor_iff` — the distinct-blocks renormalization-fixed-point
+  characterization: the direct sum is a renormalization fixed point if and only
+  if each block is in isometry canonical form and the cross-block mixed transfer
+  operators vanish.
 
 ## Route
 
@@ -362,6 +366,49 @@ theorem isRFP_directSumTensor_of_isIsometryCanonicalForm
           rw [blockTransferSum_idempotent_of_isIsometryCanonicalForm B hCF hortho Y]
     _ = transferMap (directSumTensor B) (Matrix.reindex e e Y) :=
           (transferMap_directSumTensor_reindex B Y).symm
+
+/-- **Distinct-blocks structural characterization of pure-state renormalization
+fixed points** (arXiv:1606.00608, Theorem charact-MPS, line 543),
+multiplicity-one case.
+
+For a family of normal, irreducible, left-canonical blocks $B$, no two
+gauge-phase equivalent and each of positive bond dimension ($\dim_k \ge 1$), the
+direct sum is a renormalization fixed point if and only if each block is in
+isometry canonical form and the mixed transfer operators between distinct blocks
+vanish.  In symbols, `IsRFP (directSumTensor B)` holds exactly when both
+`IsIsometryCanonicalForm (B k)` for every $k$ and
+`mixedTransferMap₂ (B j) (B j') = 0` for all $j \ne j'$.
+
+The forward direction combines the per-block isometry canonical form — each
+block is a renormalization fixed point by `isRFP_block_of_isRFP_directSum`, hence
+in isometry canonical form by `isIsometryCanonicalForm_of_rfp_nt` — with the
+cross-block vanishing `isBNTLocallyOrthogonal_of_isRFP_directSum`.  The backward
+direction is `isRFP_directSumTensor_of_isIsometryCanonicalForm`.
+
+**Scope restriction (multiplicity-one canonical form):** the source canonical
+form $A^i = \bigoplus_{j} \bigoplus_{q} \mu_{j,q} X_{j,q} \Lambda_j U^i_j
+X_{j,q}^{-1}$ allows each normal tensor to repeat with a multiplicity $r_j$ and a
+unit-modulus phase $\mu_{j,q}$; this is the distinct-blocks (multiplicity-one,
+phase-one) case, where the direct sum carries one copy of each block.  Recorded
+in the paper-gap note docs/paper-gaps/cpsv16_rfp_isometry_scope.tex. -/
+theorem isRFP_directSumTensor_iff [∀ k, NeZero (dim k)]
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    (hnormal : ∀ k, IsNormal (B k))
+    (hirr : ∀ k, IsIrreducibleTensor (B k))
+    (hleft : ∀ k, ∑ i : Fin d, (B k i)ᴴ * B k i = 1)
+    (hdist : ∀ j k : Fin r, j ≠ k → ∀ h : dim j = dim k,
+      ¬ GaugePhaseEquiv (cast (congrArg (MPSTensor d) h) (B j)) (B k)) :
+    IsRFP (directSumTensor B) ↔
+      ((∀ k, IsIsometryCanonicalForm (B k)) ∧
+        (∀ j j' : Fin r, j ≠ j' → mixedTransferMap₂ (B j) (B j') = 0)) := by
+  constructor
+  · intro hRFP
+    refine ⟨fun k => ?_, ?_⟩
+    · exact isIsometryCanonicalForm_of_rfp_nt (B k) (hnormal k)
+        (isRFP_block_of_isRFP_directSum B hRFP k) (hleft k)
+    · exact isBNTLocallyOrthogonal_of_isRFP_directSum B hirr hleft hdist hRFP
+  · rintro ⟨hCF, hortho⟩
+    exact isRFP_directSumTensor_of_isIsometryCanonicalForm B hCF hortho
 
 end Blocks
 

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -971,6 +971,54 @@ and rates for the single-tensor transfer map $\E_A$.
     sum is a renormalization fixed point.
 \end{proof}
 
+\begin{theorem}[Distinct-blocks renormalization fixed-point characterization]%
+    \label{thm:rfp_directSumTensor_iff}
+    \lean{MPSTensor.isRFP_directSumTensor_iff}
+    \leanok
+    \uses{def:is_rfp, def:is_isometry_canonical_form, def:mixed_transfer_rect,
+        def:normal, def:irreducible_tensor, def:gauge_phase_equiv}
+    Let $(B_k)_k$ be a family of normal, irreducible, left-canonical blocks with
+    $\dim_k \ge 1$ for all $k$, no two of which are gauge-phase equivalent. Then
+    the direct sum $\bigoplus_k B_k$ is a renormalization fixed point if and only
+    if each block is in isometry canonical form and the mixed transfer operators
+    between distinct blocks vanish:
+    \[
+        \Bigl(\bigoplus_k B_k \text{ is a RFP}\Bigr)
+        \iff
+        \Bigl(\forall k,\ B_k \text{ in isometry CF}\Bigr)
+        \;\wedge\;
+        \Bigl(\forall j\ne j',\ \E_{j,j'} = 0\Bigr).
+    \]
+    This is the distinct-blocks (multiplicity-one, phase-one) case of the
+    structural characterization of pure-state renormalization fixed points
+    \cite[Theorem~III]{Cirac2016MPDO_arXiv}, combining its forward and backward
+    directions.
+% Scope restriction (multiplicity-one): the source canonical form
+% A^i = \oplus_j \oplus_q mu_{j,q} X_{j,q} Lambda_j U^i_j X_{j,q}^{-1} allows
+% each normal tensor to repeat with multiplicity r_j and a unit-modulus phase
+% mu_{j,q}; this is the single-copy case
+% (docs/paper-gaps/cpsv16_rfp_isometry_scope.tex).
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:isometry_canonical_form_of_rfp_nt,
+        lem:isrfp_block_of_rfp_direct_sum,
+        thm:bnt_locally_orthogonal_of_rfp_direct_sum,
+        thm:is_rfp_of_isometry_canonical_form_direct_sum}
+    For the forward direction, whole-tensor idempotence makes each diagonal mixed
+    transfer operator the transfer map of its block
+    (Lemma~\ref{lem:isrfp_block_of_rfp_direct_sum}), so each block is a
+    renormalization fixed point and hence in isometry canonical form
+    (Theorem~\ref{thm:isometry_canonical_form_of_rfp_nt}), while the off-diagonal
+    operators vanish,
+    \[
+        \E_{j,j'} = 0 \qquad (j\ne j'),
+    \]
+    by Theorem~\ref{thm:bnt_locally_orthogonal_of_rfp_direct_sum}. Conversely, a
+    direct sum of isometry-canonical-form blocks whose cross-block operators
+    vanish is a renormalization fixed point
+    (Theorem~\ref{thm:is_rfp_of_isometry_canonical_form_direct_sum}).
+\end{proof}
+
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}
     \leanok


### PR DESCRIPTION
## Summary

Adds the distinct-blocks (multiplicity-one, phase-one) IFF capstone of `thm:charact-MPS` (arXiv:1606.00608, line 543) to `TNLean/MPS/RFP/ResidualIsometry.lean`:

```lean
theorem isRFP_directSumTensor_iff [∀ k, NeZero (dim k)]
    (B : (k : Fin r) → MPSTensor d (dim k))
    (hnormal : ∀ k, IsNormal (B k))
    (hirr : ∀ k, IsIrreducibleTensor (B k))
    (hleft : ∀ k, ∑ i : Fin d, (B k i)ᴴ * B k i = 1)
    (hdist : ∀ j k : Fin r, j ≠ k → ∀ h : dim j = dim k,
      ¬ GaugePhaseEquiv (cast (congrArg (MPSTensor d) h) (B j)) (B k)) :
    IsRFP (directSumTensor B) ↔
      ((∀ k, IsIsometryCanonicalForm (B k)) ∧
        (∀ j j' : Fin r, j ≠ j' → mixedTransferMap₂ (B j) (B j') = 0))
```

It ties together the already-merged forward helpers and the backward direction (#3604) into one equivalence:

- **Forward**: per-block isometry canonical form (`isRFP_block_of_isRFP_directSum` then `isIsometryCanonicalForm_of_rfp_nt`) plus cross-block vanishing (`isBNTLocallyOrthogonal_of_isRFP_directSum`).
- **Backward**: `isRFP_directSumTensor_of_isIsometryCanonicalForm`.

## Scope restriction

This is the distinct-blocks (multiplicity-one, phase-one) case. The source canonical form allows each normal tensor to repeat with a multiplicity and a unit-modulus phase; the multiplicity/phase general form is the deferred case, recorded in `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`. The Lean docstring and the blueprint entry carry a `Scope restriction (multiplicity-one canonical form)` marker.

## Blueprint

Adds `thm:rfp_directSumTensor_iff` to `ch14_correlations.tex` next to the direct-sum RFP material, with `\lean{MPSTensor.isRFP_directSumTensor_iff}` and `\leanok`.

## Verification

- `lake build`: clean (9258 jobs).
- `#print axioms MPSTensor.isRFP_directSumTensor_iff`: `[propext, Classical.choice, Quot.sound]`.
- No `sorry`/`admit`/`native_decide` in touched files.
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base main --ci`: exit 0.

Addresses #2598.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization wiring existing theorems; no runtime, auth, or data paths. Scope is explicitly limited to the distinct-blocks case.
> 
> **Overview**
> Adds the **distinct-blocks (multiplicity-one)** capstone for Cirac et al. pure-state RFP structure: `IsRFP (directSumTensor B)` iff every block is in **isometry canonical form** and all **off-diagonal** `mixedTransferMap₂` operators vanish.
> 
> Lean introduces `MPSTensor.isRFP_directSumTensor_iff` in `ResidualIsometry.lean` as a short `constructor` proof—forward via `isRFP_block_of_isRFP_directSum` + `isIsometryCanonicalForm_of_rfp_nt` and `isBNTLocallyOrthogonal_of_isRFP_directSum`, backward via existing `isRFP_directSumTensor_of_isIsometryCanonicalForm`. The file header and docstring note the **multiplicity/phase** generalization is still out of scope (`docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`).
> 
> The blueprint gains matching `thm:rfp_directSumTensor_iff` in `ch14_correlations.tex` with `\leanok` and a proof sketch citing the same lemmas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a539609f8ba202c6143d6e0ad4c2822cb5ab254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->