### PR TITLE
feat(Channel): the reduction map T_k is k-positive (Wolf Ch3 Example 3.1)

### DIFF
--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -109,8 +109,9 @@ theorem reductionMap_eq_tEta (D k : ℕ) : reductionMap D k = tEta D (k : ℝ) :
 `T_k(X) = tr(X) • 1 − k⁻¹ • X` is `k`-positive for `1 ≤ k < D`. It is the family
 map `tEta D k` at parameter `η = k`, and `tEta D η` is `k`-positive exactly when
 `η ≥ k`, so the threshold is attained at `η = k`. -/
-theorem reductionMap_isNPositiveMap [NeZero D] {k : ℕ} (hk1 : 1 ≤ k) (hk : k < D) :
+theorem reductionMap_isNPositiveMap {k : ℕ} (hk1 : 1 ≤ k) (hk : k < D) :
     IsNPositiveMap k (reductionMap D k) := by
+  haveI : NeZero D := ⟨by omega⟩
   rw [reductionMap_eq_tEta]
   have hη : (0 : ℝ) < (k : ℝ) := by
     have : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk1

--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -105,6 +105,18 @@ theorem reductionMap_eq_tEta (D k : ℕ) : reductionMap D k = tEta D (k : ℝ) :
   intro X
   rw [reductionMap_apply, tEta_apply, Complex.ofReal_natCast]
 
+/-- **Wolf Chapter 3, Example 3.1 (Proposition 3.2).** The reduction map
+`T_k(X) = tr(X) • 1 − k⁻¹ • X` is `k`-positive for `1 ≤ k < D`. It is the family
+map `tEta D k` at parameter `η = k`, and `tEta D η` is `k`-positive exactly when
+`η ≥ k`, so the threshold is attained at `η = k`. -/
+theorem reductionMap_isNPositiveMap [NeZero D] {k : ℕ} (hk1 : 1 ≤ k) (hk : k < D) :
+    IsNPositiveMap k (reductionMap D k) := by
+  rw [reductionMap_eq_tEta]
+  have hη : (0 : ℝ) < (k : ℝ) := by
+    have : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk1
+    linarith
+  exact (isNPositiveMap_tEta_iff hη hk1 hk).mpr le_rfl
+
 /-- **Wolf's reduction witness.** The entanglement witness attached to `T_n` is
 `W_n = D⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|` on `M_D(ℂ) ⊗ M_D(ℂ)`.  It is exactly the Choi
 operator of `T_n`. -/

--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -106,17 +106,22 @@ theorem reductionMap_eq_tEta (D k : ℕ) : reductionMap D k = tEta D (k : ℝ) :
   rw [reductionMap_apply, tEta_apply, Complex.ofReal_natCast]
 
 /-- **Wolf Chapter 3, Example 3.1 (Proposition 3.2).** The reduction map
-`T_k(X) = tr(X) • 1 − k⁻¹ • X` is `k`-positive for `1 ≤ k < D`. It is the family
-map `tEta D k` at parameter `η = k`, and `tEta D η` is `k`-positive exactly when
-`η ≥ k`, so the threshold is attained at `η = k`. -/
-theorem reductionMap_isNPositiveMap {k : ℕ} (hk1 : 1 ≤ k) (hk : k < D) :
+$T_k(X) = \operatorname{tr}(X)\cdot\mathbf 1 - k^{-1}X$ on $M_D(\mathbb C)$ is
+$k$-positive for $1 \le k \le D$. It equals the parametric map $T_\eta$ at
+$\eta = k$, which is $k$-positive exactly when $\eta \ge k$; the threshold is met
+with equality at $\eta = k$. The top index $k = D$ is the completely positive
+endpoint, handled through the dimension-indexed threshold. -/
+theorem reductionMap_isNPositiveMap {k : ℕ} (hk1 : 1 ≤ k) (hk : k ≤ D) :
     IsNPositiveMap k (reductionMap D k) := by
   haveI : NeZero D := ⟨by omega⟩
   rw [reductionMap_eq_tEta]
   have hη : (0 : ℝ) < (k : ℝ) := by
     have : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk1
     linarith
-  exact (isNPositiveMap_tEta_iff hη hk1 hk).mpr le_rfl
+  rcases lt_or_eq_of_le hk with hlt | heq
+  · exact (isNPositiveMap_tEta_iff hη hk1 hlt).mpr le_rfl
+  · subst heq
+    exact (isNPositiveMap_tEta_card_iff hη).mpr le_rfl
 
 /-- **Wolf's reduction witness.** The entanglement witness attached to `T_n` is
 `W_n = D⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|` on `M_D(ℂ) ⊗ M_D(ℂ)`.  It is exactly the Choi

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -44,15 +44,18 @@ of a bipartite state whose Schmidt number is at most $n$.
     \label{thm:reduction_map_is_n_positive}
     \lean{Matrix.reductionMap_isNPositiveMap}
     \leanok
-    \uses{def:reduction_map, thm:reduction_map_eq_t_eta, thm:t_eta_threshold}
-    For $1\le k<D$ the reduction map $T_k$ on $\MN{D}$ is $k$-positive.
+    \uses{def:reduction_map, thm:reduction_map_eq_t_eta, thm:t_eta_threshold,
+        thm:t_eta_threshold_top}
+    For $1\le k\le D$ the reduction map $T_k$ on $\MN{D}$ is $k$-positive.
 \end{theorem}
 
 \begin{proof}
     \leanok
     The reduction map equals the family map $T_\eta$ at $\eta=k$, and $T_\eta$ is
     $k$-positive exactly when $\eta\ge k$; the threshold is met with equality at
-    $\eta=k$.
+    $\eta=k$.  For $k<D$ this is the Schmidt-rank threshold, and the top index
+    $k=D$ is the completely positive endpoint supplied by the dimension-indexed
+    threshold.
 \end{proof}
 
 \begin{definition}[Reduction witness]

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -40,6 +40,21 @@ of a bipartite state whose Schmidt number is at most $n$.
     are equal.
 \end{proof}
 
+\begin{theorem}[The reduction map $T_k$ is $k$-positive]
+    \label{thm:reduction_map_is_n_positive}
+    \lean{Matrix.reductionMap_isNPositiveMap}
+    \leanok
+    \uses{def:reduction_map, thm:reduction_map_eq_t_eta, thm:t_eta_threshold}
+    For $1\le k<D$ the reduction map $T_k$ on $\MN{D}$ is $k$-positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The reduction map equals the family map $T_\eta$ at $\eta=k$, and $T_\eta$ is
+    $k$-positive exactly when $\eta\ge k$; the threshold is met with equality at
+    $\eta=k$.
+\end{proof}
+
 \begin{definition}[Reduction witness]
     \label{def:reduction_witness}
     \lean{Matrix.reductionWitness}


### PR DESCRIPTION
## Summary

Surfaces the reduction map's n-positivity directly on `reductionMap`, advancing **#3401** (Wolf Ch3, §3.2, Example 3.1 — concrete positive maps).

`reductionMap_isNPositiveMap`: for `1 ≤ k ≤ D`, the reduction map
`T_k(X) = tr(X)·1 − k⁻¹·X` on `M_D(ℂ)` is **k-positive** — the full
"`T_n` is n-positive" statement of Wolf Example 3.1 / Proposition 3.2,
including the top index `k = D` (the completely positive endpoint).

## Why

The sharp n-positivity threshold is already formalized for the family `tEta`
(`isNPositiveMap_tEta_iff`: `T_η` is `k`-positive iff `η ≥ k`, for `k < D`; and
`isNPositiveMap_tEta_card_iff` for the top index `k = D`), and
`reductionMap D k = tEta D k`. But the reduction map's n-positivity was only
reachable *through* `tEta`; there was no direct statement on `reductionMap`. This
adds it, matching the existing direct `reductionMap_one_isPositiveMap`, and
reusing the existing machinery.

## Faithfulness

The hypotheses are exactly the source's range `1 ≤ k ≤ D` (Wolf
`ch03_positive_not_completely.tex:330`; the full range is marked resolved in
`docs/paper-gaps/wolf_t_eta_top_index_scope.tex`). The proof case-splits on
`k < D` (Schmidt-rank threshold) vs `k = D` (completely positive endpoint, via
the dimension-indexed threshold). No scope-restriction marker — this is the full
source result. Routes only through already-proven lemmas.

## Verification

- `lake build TNLean.Channel.ReductionCriterion` succeeds; single-file
  `lake env lean` clean; sorry/axiom-free.
- Blueprint: `thm:reduction_map_is_n_positive` in `ch25_positive_not_cp.tex`
  (range `1 ≤ k ≤ D`, `\uses` both thresholds). Docstring uses LaTeX math.
  `check_reader_facing_prose.py` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small corollary on top of proven lemmas; no new axioms or changes to auth, data, or core infrastructure.
> 
> **Overview**
> Adds **`Matrix.reductionMap_isNPositiveMap`**: for `1 ≤ k ≤ D`, Wolf’s reduction map `T_k(X) = tr(X)•1 − k⁻¹•X` is **k-positive**, stated on `reductionMap` instead of only via `tEta`. The proof rewrites with `reductionMap_eq_tEta`, then applies the existing `tEta` threshold (`isNPositiveMap_tEta_iff` when `k < D`, `isNPositiveMap_tEta_card_iff` at `k = D`).
> 
> The blueprint chapter **`ch25_positive_not_cp.tex`** gets matching theorem **`thm:reduction_map_is_n_positive`** (`\lean{Matrix.reductionMap_isNPositiveMap}`), wired to the identification and threshold results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c3fd9b34ffd7425eae6f32cdafbc7b13a6ce54c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->