### PR TITLE
feat(Channel): the reduction map T_k is not (k+1)-positive (Wolf Ch3 chain strictness)

### DIFF
--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -123,6 +123,25 @@ theorem reductionMap_isNPositiveMap {k : ℕ} (hk1 : 1 ≤ k) (hk : k ≤ D) :
   · subst heq
     exact (isNPositiveMap_tEta_card_iff hη).mpr le_rfl
 
+/-- **Wolf Chapter 3, Example 3.1 (chain strictness, eq. (3.3)).** The reduction
+map $T_k$ on $M_D(\mathbb C)$ is *not* $(k+1)$-positive for $1 \le k < D$.
+Together with `reductionMap_isNPositiveMap` this shows $T_k$ is *exactly*
+$k$-positive: it equals the parametric map $T_\eta$ at $\eta = k$, and $T_\eta$
+is $(k+1)$-positive only when $\eta \ge k+1$, which fails at $\eta = k$. -/
+theorem reductionMap_not_isNPositiveMap_succ {k : ℕ} (hk1 : 1 ≤ k) (hk : k < D) :
+    ¬ IsNPositiveMap (k + 1) (reductionMap D k) := by
+  haveI : NeZero D := ⟨by omega⟩
+  rw [reductionMap_eq_tEta]
+  have hη : (0 : ℝ) < (k : ℝ) := by
+    have : (1 : ℝ) ≤ (k : ℝ) := by exact_mod_cast hk1
+    linarith
+  rcases lt_or_eq_of_le (show k + 1 ≤ D by omega) with hlt | heq
+  · rw [isNPositiveMap_tEta_iff hη (by omega) hlt]
+    push_cast
+    exact not_le.mpr (by linarith)
+  · rw [heq, isNPositiveMap_tEta_card_iff hη]
+    exact not_le.mpr (by exact_mod_cast hk)
+
 /-- **Wolf's reduction witness.** The entanglement witness attached to `T_n` is
 `W_n = D⁻¹ • 1 − n⁻¹ • |Ω⟩⟨Ω|` on `M_D(ℂ) ⊗ M_D(ℂ)`.  It is exactly the Choi
 operator of `T_n`. -/

--- a/TNLean/Channel/ReductionCriterion.lean
+++ b/TNLean/Channel/ReductionCriterion.lean
@@ -125,7 +125,7 @@ theorem reductionMap_isNPositiveMap {k : ℕ} (hk1 : 1 ≤ k) (hk : k ≤ D) :
 
 /-- **Wolf Chapter 3, Example 3.1 (chain strictness, eq. (3.3)).** The reduction
 map $T_k$ on $M_D(\mathbb C)$ is *not* $(k+1)$-positive for $1 \le k < D$.
-Together with `reductionMap_isNPositiveMap` this shows $T_k$ is *exactly*
+Together with $k$-positivity of $T_k$, this shows $T_k$ is *exactly*
 $k$-positive: it equals the parametric map $T_\eta$ at $\eta = k$, and $T_\eta$
 is $(k+1)$-positive only when $\eta \ge k+1$, which fails at $\eta = k$. -/
 theorem reductionMap_not_isNPositiveMap_succ {k : ℕ} (hk1 : 1 ≤ k) (hk : k < D) :

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -58,6 +58,23 @@ of a bipartite state whose Schmidt number is at most $n$.
     threshold.
 \end{proof}
 
+\begin{theorem}[The reduction map $T_k$ is not $(k+1)$-positive]
+    \label{thm:reduction_map_not_n_positive_succ}
+    \lean{Matrix.reductionMap_not_isNPositiveMap_succ}
+    \leanok
+    \uses{def:reduction_map, thm:reduction_map_eq_t_eta, thm:t_eta_threshold,
+        thm:t_eta_threshold_top}
+    For $1\le k<D$ the reduction map $T_k$ on $\MN{D}$ is not $(k+1)$-positive;
+    together with the previous theorem, $T_k$ is exactly $k$-positive.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The reduction map equals $T_\eta$ at $\eta=k$, which is $(k+1)$-positive only
+    when $\eta\ge k+1$; this fails at $\eta=k$.  For $k+1<D$ this is the
+    Schmidt-rank threshold, and for $k+1=D$ the dimension-indexed threshold.
+\end{proof}
+
 \begin{definition}[Reduction witness]
     \label{def:reduction_witness}
     \lean{Matrix.reductionWitness}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -64,16 +64,24 @@ of a bipartite state whose Schmidt number is at most $n$.
     \leanok
     \uses{def:reduction_map, thm:reduction_map_eq_t_eta, thm:t_eta_threshold,
         thm:t_eta_threshold_top}
-    For $1\le k<D$ the reduction map $T_k$ on $\MN{D}$ is not $(k+1)$-positive;
-    together with the previous theorem, $T_k$ is exactly $k$-positive.
+    For $1\le k<D$ the reduction map $T_k$ on $\MN{D}$ is not $(k+1)$-positive.
 \end{theorem}
 
 \begin{proof}
     \leanok
-    The reduction map equals $T_\eta$ at $\eta=k$, which is $(k+1)$-positive only
-    when $\eta\ge k+1$; this fails at $\eta=k$.  For $k+1<D$ this is the
-    Schmidt-rank threshold, and for $k+1=D$ the dimension-indexed threshold.
+    The reduction map equals $T_\eta$ at $\eta=k$.  For $k+1<D$ the threshold
+    gives that $T_\eta$ is $(k+1)$-positive iff $\eta\ge k+1$, so $T_k$ would
+    require $k\ge k+1$, which is false.  For $k+1=D$ the dimension-indexed
+    threshold gives that $T_\eta$ is $D$-positive iff $\eta\ge D$, so $T_k$ would
+    require $k\ge D$, contradicting $k<D$.
 \end{proof}
+
+\begin{remark}
+    Together with the $k$-positivity of $T_k$
+    (\ref{thm:reduction_map_is_n_positive}), this shows that $T_k$ is
+    \emph{exactly} $k$-positive for $1\le k<D$: every inclusion in Wolf's chain
+    $T_{\mathrm{cp}}=T_D\subsetneq\cdots\subsetneq T_1$ is strict.
+\end{remark}
 
 \begin{definition}[Reduction witness]
     \label{def:reduction_witness}


### PR DESCRIPTION
## Summary

Completes the sharp positivity characterization of the reduction map, advancing **#3401** (Wolf Ch3, Example 3.1).

`reductionMap_not_isNPositiveMap_succ`: for `1 ≤ k < D`, the reduction map
`T_k(X) = tr(X)·1 − k⁻¹·X` on `M_D(ℂ)` is **not** `(k+1)`-positive. Paired with
the just-merged `reductionMap_isNPositiveMap` (#3607), this shows `T_k` is
**exactly** `k`-positive — the canonical witness for the strictness of every
inclusion in Wolf's positivity chain (3.3) `T_cp = T_D ⊊ … ⊊ T_1`.

## Why / how

Direct corollary of existing, proven machinery: `reductionMap D k = tEta D k`
(`reductionMap_eq_tEta`), and `T_η` is `(k+1)`-positive only when `η ≥ k+1`
(`isNPositiveMap_tEta_iff` for `k+1 < D`; `isNPositiveMap_tEta_card_iff` for the
`k+1 = D` endpoint), which fails at `η = k`. Case-split on `k+1 < D` vs `k+1 = D`.

## Faithfulness

The range `1 ≤ k < D` is exactly where the strict inclusion `T_k ⊋ T_{k+1}` holds
(at `k = D` the map is completely positive, the chain endpoint). Routes only
through already-proven lemmas; sorry/axiom-free.

## Verification

- `lake build TNLean.Channel.ReductionCriterion` succeeds; single-file `lake env lean` clean.
- Blueprint: `thm:reduction_map_not_n_positive_succ` added to `ch25_positive_not_cp.tex`.
  `check_reader_facing_prose.py` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, axiom-free formalization that only composes existing `tEta` threshold lemmas; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`Matrix.reductionMap_not_isNPositiveMap_succ`**: for `1 ≤ k < D`, Wolf’s reduction map `T_k` is **not** `(k+1)`-positive. The proof rewrites `T_k` as `tEta D k` and applies the existing `T_η` positivity thresholds (`isNPositiveMap_tEta_iff` / `isNPositiveMap_tEta_card_iff`), splitting on `k+1 < D` vs `k+1 = D`.
> 
> The blueprint gains **`thm:reduction_map_not_n_positive_succ`** plus a remark that, together with `T_k` being `k`-positive, each `T_k` is **exactly** `k`-positive and every step in Wolf’s chain `T_cp = T_D ⊊ … ⊊ T_1` is strict.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e8f34f58b808025357880022ec09ab6a6bc8ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->