### PR TITLE
feat(Channel): add Choi-type map formalization

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -73,6 +73,7 @@ import TNLean.Topology.CompactRetractFixedPoint
 import TNLean.Channel.Basic
 import TNLean.Channel.PositiveExamples
 import TNLean.Channel.BreuerHallMap
+import TNLean.Channel.ChoiTypeMap
 import TNLean.Channel.DensityRetract
 
 -- Layer 2 (Ch. 2 infrastructure): Choi–Jamiolkowski, Kraus, Stinespring

--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import TNLean.Channel.Basic
+import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.Permutation
 
 /-!
@@ -28,7 +28,7 @@ proved here.
   Example 3.1, equation (3.20)][Wolf2012QChannels]
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder
+open scoped Matrix
 open Finset
 
 namespace Matrix
@@ -37,13 +37,14 @@ variable {d : ℕ} [NeZero d]
 
 /-! ## Basic cyclic and diagonal operations -/
 
-/-- The cyclic shift matrix on `ZMod d`, indexed by addition by `k`. -/
+/-- The cyclic shift matrix \(U_{k0}\) from Wolf, equation (2.24), sending
+\(\ket r\) to \(\ket{k+r}\). -/
 def choiTypeShift (k : ZMod d) : Matrix (ZMod d) (ZMod d) ℂ :=
-  (Equiv.addRight k).permMatrix ℂ
+  (Equiv.addRight (-k)).permMatrix ℂ
 
 /-- The diagonal projection \(D(X)\), which keeps the diagonal entries and
 sets all off-diagonal entries to zero. -/
-noncomputable def diagonalProjection (d : ℕ) [NeZero d] :
+def diagonalProjection (d : ℕ) :
     Matrix (ZMod d) (ZMod d) ℂ →ₗ[ℂ] Matrix (ZMod d) (ZMod d) ℂ where
   toFun X := diagonal fun i => X i i
   map_add' X Y := by
@@ -53,13 +54,18 @@ noncomputable def diagonalProjection (d : ℕ) [NeZero d] :
     ext i j
     by_cases h : i = j <;> simp [h]
 
+omit [NeZero d] in
 @[simp]
 theorem diagonalProjection_apply (X : Matrix (ZMod d) (ZMod d) ℂ) :
     diagonalProjection d X = diagonal fun i => X i i :=
   rfl
 
-/-- Conjugation by a matrix, as a linear map. -/
-noncomputable def conjugationLinearMap {n : Type*} [Fintype n]
+/-- Conjugation by a matrix, as the linear map \(X\mapsto AXA^\dagger\).
+
+Wolf's Choi-type maps use this operation in the terms
+\(U_{k0}XU_{k0}^{\dagger}\).  As a map on matrices it is completely positive;
+that fact is not used in this file. -/
+def conjugationLinearMap {n : Type*} [Fintype n]
     (A : Matrix n n ℂ) : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ where
   toFun X := A * X * Aᴴ
   map_add' X Y := by
@@ -77,12 +83,12 @@ theorem conjugationLinearMap_apply {n : Type*} [Fintype n]
 theorem diagonalProjection_conj_choiTypeShift
     (k : ZMod d) (X : Matrix (ZMod d) (ZMod d) ℂ) :
     diagonalProjection d (choiTypeShift k * X * (choiTypeShift k)ᴴ) =
-      diagonal fun i => X (i + k) (i + k) := by
+      diagonal fun i => X (i - k) (i - k) := by
   ext i j
   by_cases h : i = j
   · subst h
     simp [diagonalProjection, choiTypeShift, Equiv.Perm.permMatrix,
-      PEquiv.toMatrix, Matrix.mul_apply]
+      PEquiv.toMatrix, Matrix.mul_apply, sub_eq_add_neg]
   · simp [diagonalProjection, h]
 
 /-! ## The Choi-type map -/
@@ -94,7 +100,7 @@ theorem diagonalProjection_conj_choiTypeShift
 on matrices indexed by the cyclic group `ZMod d`.  The coefficient `d - n` is
 the scalar difference appearing in the source; the positivity theorem uses the
 range `1 ≤ n ≤ d - 2`. -/
-noncomputable def choiTypeMap (d n : ℕ) [NeZero d] :
+def choiTypeMap (d n : ℕ) [NeZero d] :
     Matrix (ZMod d) (ZMod d) ℂ →ₗ[ℂ] Matrix (ZMod d) (ZMod d) ℂ :=
   ((d : ℂ) - (n : ℂ)) • diagonalProjection d - LinearMap.id +
     ∑ k : Fin n,
@@ -120,8 +126,8 @@ theorem choiTypeMap_vecMulVec
       diagonal (fun i =>
         ((d : ℂ) - (n : ℂ)) * (v i * star (v i)) +
           ∑ k : Fin n,
-            v (i + ((k.1 + 1 : ℕ) : ZMod d)) *
-              star (v (i + ((k.1 + 1 : ℕ) : ZMod d)))) -
+            v (i - ((k.1 + 1 : ℕ) : ZMod d)) *
+              star (v (i - ((k.1 + 1 : ℕ) : ZMod d)))) -
         vecMulVec v (star v) := by
   rw [choiTypeMap_apply]
   simp_rw [diagonalProjection_conj_choiTypeShift]

--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.Channel.Basic
+import Mathlib.LinearAlgebra.Matrix.Permutation
+
+/-!
+# Choi-type positive maps
+
+This file records the Choi-type maps appearing in Wolf Chapter 3, Example 3.1,
+equation (3.20).  The map is written on the cyclic index set `ZMod d`, which is
+the natural home for the shift matrices \(U_{k0}\):
+\[
+  T_C(X)=(d-n)D(X)-X+\sum_{k=1}^{n}D(U_{k0}XU_{k0}^{\dagger}),
+\]
+where `D` projects a matrix to its diagonal part.
+
+The main theorem in this file is the exact action on rank-one projectors.  This
+is the algebraic reduction needed for the later positivity proof of Wolf
+Example 3.1.  Positivity and indecomposability of the Choi-type maps are not
+proved here.
+
+## References
+
+* [M. Wolf, *Quantum Channels & Operations: Guided Tour*, Chapter 3,
+  Example 3.1, equation (3.20)][Wolf2012QChannels]
+-/
+
+open scoped Matrix ComplexOrder MatrixOrder
+open Finset
+
+namespace Matrix
+
+variable {d : ℕ} [NeZero d]
+
+/-! ## Basic cyclic and diagonal operations -/
+
+/-- The cyclic shift matrix on `ZMod d`, indexed by addition by `k`. -/
+def choiTypeShift (k : ZMod d) : Matrix (ZMod d) (ZMod d) ℂ :=
+  (Equiv.addRight k).permMatrix ℂ
+
+/-- The diagonal projection \(D(X)\), which keeps the diagonal entries and
+sets all off-diagonal entries to zero. -/
+noncomputable def diagonalProjection (d : ℕ) [NeZero d] :
+    Matrix (ZMod d) (ZMod d) ℂ →ₗ[ℂ] Matrix (ZMod d) (ZMod d) ℂ where
+  toFun X := diagonal fun i => X i i
+  map_add' X Y := by
+    ext i j
+    by_cases h : i = j <;> simp [h]
+  map_smul' c X := by
+    ext i j
+    by_cases h : i = j <;> simp [h]
+
+@[simp]
+theorem diagonalProjection_apply (X : Matrix (ZMod d) (ZMod d) ℂ) :
+    diagonalProjection d X = diagonal fun i => X i i :=
+  rfl
+
+/-- Conjugation by a matrix, as a linear map. -/
+noncomputable def conjugationLinearMap {n : Type*} [Fintype n]
+    (A : Matrix n n ℂ) : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ where
+  toFun X := A * X * Aᴴ
+  map_add' X Y := by
+    simp only [Matrix.mul_add, Matrix.add_mul]
+  map_smul' c X := by
+    simp only [Matrix.mul_smul, Matrix.smul_mul, RingHom.id_apply]
+
+@[simp]
+theorem conjugationLinearMap_apply {n : Type*} [Fintype n]
+    (A : Matrix n n ℂ) (X : Matrix n n ℂ) :
+    conjugationLinearMap A X = A * X * Aᴴ :=
+  rfl
+
+/-- The diagonal part of a cyclically conjugated matrix is the shifted diagonal. -/
+theorem diagonalProjection_conj_choiTypeShift
+    (k : ZMod d) (X : Matrix (ZMod d) (ZMod d) ℂ) :
+    diagonalProjection d (choiTypeShift k * X * (choiTypeShift k)ᴴ) =
+      diagonal fun i => X (i + k) (i + k) := by
+  ext i j
+  by_cases h : i = j
+  · subst h
+    simp [diagonalProjection, choiTypeShift, Equiv.Perm.permMatrix,
+      PEquiv.toMatrix, Matrix.mul_apply]
+  · simp [diagonalProjection, h]
+
+/-! ## The Choi-type map -/
+
+/-- **Wolf Chapter 3, Example 3.1, equation (3.20).**  The Choi-type map
+\[
+  T_C(X)=(d-n)D(X)-X+\sum_{k=1}^{n}D(U_{k0}XU_{k0}^{\dagger})
+\]
+on matrices indexed by the cyclic group `ZMod d`.  The coefficient `d - n` is
+the scalar difference appearing in the source; the positivity theorem uses the
+range `1 ≤ n ≤ d - 2`. -/
+noncomputable def choiTypeMap (d n : ℕ) [NeZero d] :
+    Matrix (ZMod d) (ZMod d) ℂ →ₗ[ℂ] Matrix (ZMod d) (ZMod d) ℂ :=
+  ((d : ℂ) - (n : ℂ)) • diagonalProjection d - LinearMap.id +
+    ∑ k : Fin n,
+      (diagonalProjection d).comp
+        (conjugationLinearMap (choiTypeShift ((k.1 + 1 : ℕ) : ZMod d)))
+
+@[simp]
+theorem choiTypeMap_apply (n : ℕ) (X : Matrix (ZMod d) (ZMod d) ℂ) :
+    choiTypeMap d n X =
+      ((d : ℂ) - (n : ℂ)) • diagonalProjection d X - X +
+        ∑ k : Fin n,
+          diagonalProjection d
+            (choiTypeShift ((k.1 + 1 : ℕ) : ZMod d) * X *
+              (choiTypeShift ((k.1 + 1 : ℕ) : ZMod d))ᴴ) := by
+  simp [choiTypeMap]
+
+/-- The Choi-type map applied to a rank-one projector is a diagonal matrix minus
+that projector.  This is the rank-one reduction underlying Wolf's positivity
+argument for equation (3.20). -/
+theorem choiTypeMap_vecMulVec
+    (n : ℕ) (v : ZMod d → ℂ) :
+    choiTypeMap d n (vecMulVec v (star v)) =
+      diagonal (fun i =>
+        ((d : ℂ) - (n : ℂ)) * (v i * star (v i)) +
+          ∑ k : Fin n,
+            v (i + ((k.1 + 1 : ℕ) : ZMod d)) *
+              star (v (i + ((k.1 + 1 : ℕ) : ZMod d)))) -
+        vecMulVec v (star v) := by
+  rw [choiTypeMap_apply]
+  simp_rw [diagonalProjection_conj_choiTypeShift]
+  ext i j
+  by_cases h : i = j
+  · subst h
+    simp [Matrix.sum_apply, vecMulVec_apply, smul_eq_mul]
+    ring_nf
+  · simp [Matrix.sum_apply, vecMulVec_apply, h, smul_eq_mul]
+
+end Matrix

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -319,7 +319,7 @@ assertions for the range $1\le n\le d-2$ remain open.
         T_C(\ket{v}\bra{v})
         =
         \operatorname{diag}\!\left(
-            (d-n)|v_i|^2+\sum_{k=1}^n |v_{i+k}|^2
+            (d-n)|v_i|^2+\sum_{k=1}^n |v_{i-k}|^2
         \right)
         -\ket{v}\bra{v}.
     \]
@@ -330,7 +330,7 @@ assertions for the range $1\le n\le d-2$ remain open.
     The diagonal projection of a shifted rank-one projector records the shifted
     squared moduli:
     \[
-        D(U_{k0}\ket{v}\bra{v}U_{k0}^{\dagger})_{ii}=|v_{i+k}|^2.
+        D(U_{k0}\ket{v}\bra{v}U_{k0}^{\dagger})_{ii}=|v_{i-k}|^2.
     \]
     Substituting this into the definition of $T_C$ gives the displayed diagonal
     matrix minus the original rank-one projector.

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -286,6 +286,56 @@ fails to be completely positive, are not treated here.
     is positive.
 \end{proof}
 
+\section{Choi-type maps}
+
+The Choi-type maps in Wolf's Example~3.1 are built from the diagonal projection
+$D(X)$ and cyclic shifts $U_{k0}$:
+\[
+    T_C(X)=(d-n)D(X)-X+\sum_{k=1}^nD(U_{k0}XU_{k0}^{\dagger}).
+\]
+The formal statements below record the map and the rank-one reduction used in
+the standard positivity argument.  The positivity and indecomposability
+assertions for the range $1\le n\le d-2$ remain open.
+
+\begin{definition}[Choi-type map]
+    \label{def:choi_type_map}
+    \lean{Matrix.choiTypeMap}
+    \leanok
+    On the cyclic index set $\mathbb Z/d\mathbb Z$, the Choi-type map is
+    \[
+        T_C(X)=(d-n)D(X)-X+\sum_{k=1}^nD(U_{k0}XU_{k0}^{\dagger}),
+    \]
+    where $D$ keeps the diagonal of a matrix and $U_{k0}$ is the cyclic shift by
+    $k$.
+\end{definition}
+
+\begin{lemma}[The Choi-type map on rank-one projectors]
+    \label{lem:choi_type_map_rankone}
+    \lean{Matrix.choiTypeMap_vecMulVec}
+    \leanok
+    \uses{def:choi_type_map}
+    For a vector $v$ on $\mathbb Z/d\mathbb Z$,
+    \[
+        T_C(\ket{v}\bra{v})
+        =
+        \operatorname{diag}\!\left(
+            (d-n)|v_i|^2+\sum_{k=1}^n |v_{i+k}|^2
+        \right)
+        -\ket{v}\bra{v}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The diagonal projection of a shifted rank-one projector records the shifted
+    squared moduli:
+    \[
+        D(U_{k0}\ket{v}\bra{v}U_{k0}^{\dagger})_{ii}=|v_{i+k}|^2.
+    \]
+    Substituting this into the definition of $T_C$ gives the displayed diagonal
+    matrix minus the original rank-one projector.
+\end{proof}
+
 \section{The partial transpose and the PPT property}
 
 Transposition is a positive map that is not completely positive, so applying it


### PR DESCRIPTION
## Summary
- add `Matrix.choiTypeMap` for Wolf Chapter 3 Example 3.1 on cyclic indices `ZMod d`
- prove the rank-one projector expansion `Matrix.choiTypeMap_vecMulVec`
- expose the new module through `TNLean.lean` and add matching blueprint entries in Chapter 25

## Staleness check
- branch was created from current `origin/main` after `git fetch origin --prune`
- local base and `origin/main` were even before branching (`0 ahead / 0 behind`)

## Validation
- `git diff --check`
- `lake env lean TNLean/Channel/ChoiTypeMap.lean`
- `lake env lean TNLean.lean`
- `chktex -q -l ../.chktexrc chapter/ch25_positive_not_cp.tex`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --warn-missing-blueprint --diff-base origin/main --changed-files TNLean.lean TNLean/Channel/ChoiTypeMap.lean`
- `lake build TNLean.Channel.ChoiTypeMap`
- `lake build -q --log-level=info` (passes; emits pre-existing warnings/sorry notices elsewhere)
- `leanblueprint web` (completed without `ERROR:` lines)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New Lean definitions and proofs only, plus blueprint documentation; no changes to auth, runtime, or existing channel APIs beyond a root import.
> 
> **Overview**
> Adds **`Matrix.choiTypeMap`** (Wolf Ch. 3, Ex. 3.1, eq. (3.20)) on `ZMod d`, with helpers for cyclic shifts, diagonal projection, and conjugation, and proves **`choiTypeMap_vecMulVec`**: rank-one projectors map to a diagonal matrix (with the \((d-n)|v_i|^2 + \sum_k |v_{i-k}|^2\) entries) minus the projector.
> 
> Registers the module in **`TNLean.lean`** and adds a **Choi-type maps** section in blueprint Chapter 25 (`def:choi_type_map`, `lem:choi_type_map_rankone`). **Positivity and indecomposability** for \(1 \le n \le d-2\) are documented as still open, matching the Lean file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ecb621f7f7456d41db3b4c2ecbe4f3e5a49a31a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->