### PR TITLE
feat(MPS/ParentHamiltonian): extract PGVWC comparison and add kernel containment

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -32,6 +32,113 @@ namespace MPSTensor
 
 variable {d : ℕ}
 
+/-- Boundary-crossing local constraints give the \(C^j,D^j\) comparison for a
+fixed block-diagonal boundary representation.
+
+Let
+\[
+  \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right)
+  \in \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right).
+\]
+For a cyclic interval beginning at \(i\) and crossing the chosen boundary cut,
+the local constraint puts the restricted block sum in \(\bigvee_jG_L(A_j)\).
+If the simultaneous tail-word products
+\[
+  w\longmapsto (A^1_w,\ldots,A^r_w),
+  \qquad |w|=N-i,
+\]
+span the product algebra, then there are matrices \(C^j_{i,\rho}\) such that,
+for every block \(j\), outside word \(\rho\), and word \(\beta\) before the cut,
+\[
+  A^j_\beta C^j_{i,\rho}
+  =
+  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+\]
+
+This is the fixed-boundary form of the \(C^j,D^j\) comparison in
+arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456, specialized to the
+block-diagonal boundary conditions used in arXiv:2011.12127, Section IV.C,
+lines 2126--2128.
+
+**Scope restriction (crossing span):** The statement assumes the short
+tail-word span at length \(N-i\) for each boundary-crossing interval. This is
+the remaining visible source-range gap recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace
+    {r : ℕ} {dim : Fin r → ℕ}
+    (μ : Fin r → ℂ) (A : (j : Fin r) → MPSTensor d (dim j))
+    (hμ : ∀ j : Fin r, μ j ≠ 0)
+    {L N : ℕ} [NeZero d] (hN : 0 < N) (hLN : L ≤ N)
+    (hCrossingSpan :
+      ∀ i : Fin N, N < i.val + L → WordTupleSpanTop A (N - i.val))
+    {ψ : NSiteSpace d N}
+    (hψ : ψ ∈ chainGroundSpace (toTensorFromBlocks (d := d) (μ := μ) A) L N)
+    (X : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ)
+    (hψX :
+      ψ = groundSpaceMap (toTensorFromBlocks (d := d) (μ := μ) A) N
+        ((Matrix.reindex finSigmaFinEquiv finSigmaFinEquiv) (Matrix.blockDiagonal' X))) :
+    ∃ C : ∀ (j : Fin r) (_ : Fin N),
+      (Fin (N - L) → Fin d) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+      ∀ (j : Fin r) (i : Fin N),
+        N < i.val + L →
+          ∀ ρ : Fin (N - L) → Fin d,
+            ∀ β : Fin (i.val + L - N) → Fin d,
+              evalWord (A j) (List.ofFn β) * C j i ρ =
+                (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                  evalWord (A j) (List.ofFn ρ) := by
+  classical
+  have hExists :
+      ∀ i : Fin N, ∀ ρ : Fin (N - L) → Fin d,
+        ∃ C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
+          N < i.val + L →
+            ∀ j : Fin r, ∀ β : Fin (i.val + L - N) → Fin d,
+              evalWord (A j) (List.ofFn β) * C j =
+                (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
+                  evalWord (A j) (List.ofFn ρ) := by
+    intro i ρ
+    by_cases hcross : N < i.val + L
+    · let τ : Fin N → Fin d := fun t =>
+        if htail : i.val + L - N ≤ t.val ∧ t.val < i.val then
+          ρ ⟨t.val - (i.val + L - N), by omega⟩
+        else
+          default
+      have hρ : (List.ofFn fun k : Fin (N - L) =>
+          τ ⟨i.val + L - N + k.val, by omega⟩) = List.ofFn ρ := by
+        apply List.ext_getElem
+        · simp
+        · intro n hn₁ hn₂
+          simp only [List.getElem_ofFn]
+          have hn : n < N - L := by
+            simpa using hn₂
+          have htail :
+              i.val + L ≤ i.val + L - N + n + N ∧
+                (⟨i.val + L - N + n, by omega⟩ : Fin N) < i := by
+            constructor
+            · omega
+            · change i.val + L - N + n < i.val
+              omega
+          simp [τ, htail]
+      have hmem :
+          (∑ j : Fin r,
+              cyclicRestrictₗ hN L i τ
+                (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
+            ⨆ j : Fin r, groundSpace (A j) L :=
+        blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
+          μ A hμ hN hLN hψ X hψX i τ
+      obtain ⟨C, hC⟩ :=
+        blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
+          μ A hN hLN X i τ hcross (hCrossingSpan i hcross) hmem
+      refine ⟨C, ?_⟩
+      intro _ j β
+      simpa [hρ] using hC j β
+    · refine ⟨fun j => 0, ?_⟩
+      intro hi
+      exact False.elim (hcross hi)
+  choose C hC using hExists
+  refine ⟨fun j i ρ => C i ρ j, ?_⟩
+  intro j i hi ρ β
+  exact hC i ρ hi j β
+
 /-- The \(C^j,D^j\) boundary-condition comparison upgrades a block-diagonal
 boundary representation to periodic single-block states.
 
@@ -168,60 +275,12 @@ theorem
         groundSpaceMap (A j) N ((μ j) ^ N • X j) ∈ chainGroundSpace (A j) L N := by
   classical
   obtain ⟨X, hψX⟩ := hBoundary
-  have hExists :
-      ∀ i : Fin N, ∀ ρ : Fin (N - L) → Fin d,
-        ∃ C : (j : Fin r) → Matrix (Fin (dim j)) (Fin (dim j)) ℂ,
-          N < i.val + L →
-            ∀ j : Fin r, ∀ β : Fin (i.val + L - N) → Fin d,
-              evalWord (A j) (List.ofFn β) * C j =
-                (((μ j) ^ N • X j) * evalWord (A j) (List.ofFn β)) *
-                  evalWord (A j) (List.ofFn ρ) := by
-    intro i ρ
-    by_cases hcross : N < i.val + L
-    · let τ : Fin N → Fin d := fun t =>
-        if htail : i.val + L - N ≤ t.val ∧ t.val < i.val then
-          ρ ⟨t.val - (i.val + L - N), by omega⟩
-        else
-          default
-      have hρ : (List.ofFn fun k : Fin (N - L) =>
-          τ ⟨i.val + L - N + k.val, by omega⟩) = List.ofFn ρ := by
-        apply List.ext_getElem
-        · simp
-        · intro n hn₁ hn₂
-          simp only [List.getElem_ofFn]
-          have hn : n < N - L := by
-            simpa using hn₂
-          have htail :
-              i.val + L ≤ i.val + L - N + n + N ∧
-                (⟨i.val + L - N + n, by omega⟩ : Fin N) < i := by
-            constructor
-            · omega
-            · change i.val + L - N + n < i.val
-              omega
-          simp [τ, htail]
-      have hmem :
-          (∑ j : Fin r,
-              cyclicRestrictₗ hN L i τ
-                (groundSpaceMap (A j) N ((μ j) ^ N • X j))) ∈
-            ⨆ j : Fin r, groundSpace (A j) L :=
-        blockDiagonal_boundary_cyclicRestrict_sum_mem_iSup_groundSpace
-          μ A hμ hN hLN hψ X hψX i τ
-      obtain ⟨C, hC⟩ :=
-        blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup
-          μ A hN hLN X i τ hcross (hCrossingSpan i hcross) hmem
-      refine ⟨C, ?_⟩
-      intro _ j β
-      simpa [hρ] using hC j β
-    · refine ⟨fun j => 0, ?_⟩
-      intro hi
-      exact False.elim (hcross hi)
-  choose C hC using hExists
+  obtain ⟨C, hC⟩ :=
+    blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace
+      μ A hμ hN hLN hCrossingSpan hψ X hψX
   refine ⟨X, hψX, ?_⟩
   exact blockDiagonal_boundary_component_chainGroundSpace_of_pgvwc_comparison_of_injective
-    μ A hN hLN X hBlk hUnital hNlarge (fun j i ρ => C i ρ j)
-    (by
-      intro j i hi ρ β
-      exact hC i ρ hi j β)
+    μ A hN hLN X hBlk hUnital hNlarge C hC
 
 /-- Boundary-crossing local constraints supply the \(C^j,D^j\) comparison.
 
@@ -652,5 +711,70 @@ theorem ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_pgvwc_co
     (chainGroundSpace_toTensorFromBlocks_eq_iSup_of_pgvwc_comparison
       μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
       hNlarge hComparison)
+
+/-- Boundary-crossing local constraints give the fixed-chain kernel containment
+needed for the block-diagonal parent-Hamiltonian spanning clause, provided each
+block chain space is already contained in its periodic MPS line.
+
+Let \(B=\bigoplus_j\mu_jA_j\).  For each cyclic interval crossing the chosen
+cut, the local constraint on a vector in \(\mathcal G_{N,L}(B)\), together with
+the simultaneous span of the tail-word products \(w\mapsto(A^1_w,\ldots,A^r_w)\)
+at length \(N-i\), gives the Pérez-García--Verstraete--Wolf--Cirac
+\(C^j,D^j\) comparison
+\[
+  A^j_\beta C^j_{i,\rho}
+  =
+  \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+\]
+This yields
+\[
+  \mathcal G_{N,L}(B)\subseteq\bigvee_j\mathcal G_{N,L}(A_j).
+\]
+If also \(\mathcal G_{N,L}(A_j)\subseteq\mathbb C V^{(N)}(A_j)\) for every
+block \(j\), then
+\[
+  \ker H_L^{(N)}(B)\subseteq
+  \operatorname{span}\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+\]
+
+This is the parent-Hamiltonian form of arXiv:quant-ph/0608197, Theorem 12,
+proof lines 1436--1456, specialized as in arXiv:2011.12127, Section IV.C,
+lines 2126--2128.
+
+**Scope restriction (crossing span):** The statement assumes that the
+simultaneous tail-word products of length \(N-i\) span the product algebra for
+each boundary-crossing interval. This is the remaining visible gap relative to
+the source comparison; it is recorded in
+`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
+theorem
+    ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_crossing_pgvwc_comparison
+    {r : ℕ} {dim : Fin r → ℕ} [∀ k, NeZero (dim k)]
+    (μ : Fin r → ℂ) (A : (k : Fin r) → MPSTensor d (dim k))
+    (hμ : ∀ k : Fin r, μ k ≠ 0)
+    {L₀ L N : ℕ}
+    (hIrr : HasIrreducibleBlocks (d := d) A)
+    (hLeft : IsLeftCanonicalBlockFamily (d := d) A)
+    (hOverlap : HasNormalizedSelfOverlap (d := d) A)
+    (hBlocks : BlocksNotGaugePhaseEquiv (d := d) A)
+    (hBlk : ∀ k : Fin r, IsNBlkInjective (A k) L₀)
+    (hL₀ : 0 < L₀)
+    (hUnital : ∀ j : Fin r, ∑ a : Fin d, A j a * (A j a)ᴴ = 1)
+    [NeZero d] (hN : 0 < N) (hL : 0 < L) (hLN : L ≤ N)
+    (hRange :
+      (L₀ + 1) + (r - 1) * ((L₀ + 1) + ((L₀ + 1) + (L₀ + 1))) + 1 ≤ L)
+    (hNlarge : L + L₀ ≤ N)
+    (hCrossingSpan :
+      ∀ i : Fin N, N < i.val + L → WordTupleSpanTop A (N - i.val))
+    (hBlock :
+      ∀ j : Fin r, chainGroundSpace (A j) L N ≤ mpvSubmodule (A j) N) :
+    LinearMap.ker (parentHamiltonian
+      (toTensorFromBlocks (d := d) (μ := μ) A) L N) ≤
+      bntMPSVectorSpan A N := by
+  refine ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan
+    μ A hN hLN ?_ hBlock
+  exact le_of_eq
+    (chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison
+      μ A hμ hIrr hLeft hOverlap hBlocks hBlk hL₀ hUnital hN hL hLN hRange
+      hNlarge hCrossingSpan)
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -322,8 +322,9 @@ in both cases.
         \qquad
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
     \]
-    Assume $0<N$ and $L\le N$. For every boundary-crossing interval beginning
-    at $i$, assume that the simultaneous products
+    Assume that the physical alphabet is nonempty, that every $\mu_j$ is
+    nonzero, that $0<N$, and that $L\le N$. For every boundary-crossing
+    interval beginning at $i$, assume that the simultaneous products
     \[
         w\longmapsto(A^1_w,\ldots,A^r_w),
         \qquad |w|=N-i,

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -309,6 +309,49 @@ in both cases.
     $X_j$ replaced by $\mu_j^NX_j$, gives the displayed matrix identity.
 \end{proof}
 
+\begin{theorem}[$C^j,D^j$ comparison for a block-diagonal boundary representation]
+    \label{thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space}
+    \lean{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        thm:block_diagonal_boundary_crossing_pgvwc_comparison}
+    Let
+    \[
+        \psi\in
+        \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right),
+        \qquad
+        \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right).
+    \]
+    Assume $0<N$ and $L\le N$. For every boundary-crossing interval beginning
+    at $i$, assume that the simultaneous products
+    \[
+        w\longmapsto(A^1_w,\ldots,A^r_w),
+        \qquad |w|=N-i,
+    \]
+    span the product algebra $\prod_j\MN{D_j}$. Then there are matrices
+    $C^j_{i,\rho}$ such that, for every boundary-crossing interval $i$, every
+    outside word $\rho$ of length $N-L$, every block $j$, and every word
+    $\beta$ before the cut,
+    \[
+        A^j_\beta C^j_{i,\rho}
+        =
+        \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:block_diagonal_boundary_local_sum_mem,
+        thm:block_diagonal_boundary_crossing_pgvwc_comparison}
+    For a boundary-crossing interval beginning at $i$ and an outside word
+    $\rho$, choose a configuration whose outside segment is $\rho$. The local
+    constraint on $\psi$ gives a vector in $\bigvee_jG_L(A_j)$ by
+    Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}.
+    Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison}
+    applied with the stated span at length $N-i$ gives the displayed
+    \(C^j,D^j\) comparison for that interval and outside word.
+\end{proof}
+
 \begin{theorem}[Fixed boundary-crossing component in the local block space]
     \label{thm:block_diagonal_boundary_crossing_component_mem_ground_space}
     \lean{MPSTensor.blockDiagonal_boundary_crossing_component_mem_groundSpace_of_pgvwc_comparison_of_sum_mem_iSup}
@@ -905,8 +948,7 @@ in both cases.
     \label{lem:block_diagonal_boundary_periodic_components_from_crossing_boundary}
     \lean{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary}
     \leanok
-    \uses{lem:block_diagonal_boundary_local_sum_mem,
-        thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+    \uses{thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space,
         lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
     Assume $0<N$, $L\le N$, and $L+L_0\le N$. Suppose each block $A_j$
     is $L_0$-block-injective and satisfies
@@ -930,13 +972,10 @@ in both cases.
 
 \begin{proof}
     \leanok
-    \uses{lem:block_diagonal_boundary_local_sum_mem,
-        thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+    \uses{thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space,
         lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
-    For a boundary-crossing interval, the local constraint on $\psi$ and the
-    boundary representation give a vector in $\bigvee_jG_L(A_j)$ by
-    Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}. The crossing
-    comparison theorem supplies matrices $C^j_{i,\rho}$ satisfying
+    Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space}
+    supplies matrices $C^j_{i,\rho}$ satisfying
     \[
         A^j_\beta C^j_{i,\rho}
         =

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -349,7 +349,7 @@ in both cases.
     Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem}.
     Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison}
     applied with the stated span at length $N-i$ gives the displayed
-    \(C^j,D^j\) comparison for that interval and outside word.
+    $C^j,D^j$ comparison for that interval and outside word.
 \end{proof}
 
 \begin{theorem}[Fixed boundary-crossing component in the local block space]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -365,8 +365,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison}
     \leanok
     \uses{lem:bnt_block_diagonal_boundary_representation_equality,
-        lem:block_diagonal_boundary_local_sum_mem,
-        thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+        thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space,
         lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
     With the hypotheses and notation of
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality}, assume
@@ -400,17 +399,13 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
 \begin{proof}
     \leanok
     \uses{lem:bnt_block_diagonal_boundary_representation_equality,
-        lem:block_diagonal_boundary_local_sum_mem,
-        thm:block_diagonal_boundary_crossing_pgvwc_comparison,
+        thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space,
         lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
     For each $\psi$,
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality} gives
-    block-diagonal boundary conditions $X_j$.  For a boundary-crossing interval,
-    Lemma~\ref{lem:block_diagonal_boundary_local_sum_mem} puts the sum of the
-    restricted block components in $\bigvee_jG_L(A_j)$.  The stated product-span
-    hypothesis and
-    Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison} give the
-    matrices $C^j_{i,\rho}$ satisfying
+    block-diagonal boundary conditions $X_j$. The stated tail-word spans and
+    Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space}
+    give the matrices $C^j_{i,\rho}$ satisfying
     \[
         A^j_\beta C^j_{i,\rho}
         =

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -613,6 +613,61 @@ the specialization $L=2$.
     then applies to this equality and to the blockwise containments.
 \end{proof}
 
+\begin{lemma}[Kernel containment from boundary-crossing comparisons]
+    \label{lem:block_diagonal_kernel_to_bnt_span_from_crossing_pgvwc_comparison}
+    \lean{MPSTensor.ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_crossing_pgvwc_comparison}
+    \leanok
+    \uses{lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting,
+        lem:bnt_block_diagonal_crossing_pgvwc_comparison_ground_space}
+    Let $B=\bigoplus_{j=0}^{r-1}\mu_jA_j$, with every $\mu_j\ne0$.
+    Suppose the physical alphabet and all block dimensions are nonempty. Assume
+    that the block family is irreducible, left-canonical, has normalized
+    self-overlap, and has no two blocks gauge-phase equivalent. Suppose also
+    that each $A_j$ is $L_0$-block-injective, that $L_0>0$, and that
+    \[
+        \sum_a A^j_a(A^j_a)^\dagger=I
+        \qquad (0\le j<r).
+    \]
+    Let $N>0$, $L>0$, $L\le N$, $L+L_0\le N$, and
+    \[
+        (L_0+1)
+        +(r-1)\bigl((L_0+1)+((L_0+1)+(L_0+1))\bigr)+1
+        \le L.
+    \]
+    Assume that, for every boundary-crossing interval beginning at $i$, the
+    simultaneous products
+    \[
+        w\longmapsto(A^1_w,\ldots,A^r_w),
+        \qquad |w|=N-i,
+    \]
+    span the product algebra $\prod_j\MN{D_j}$. If every block chain space is
+    contained in its periodic MPS line,
+    \[
+        \mathcal G_{N,L}(A_j)\subseteq \mathbb C V^{(N)}(A_j)
+        \qquad (0\le j<r),
+    \]
+    then
+    \[
+        \ker H_L^{(N)}(B)
+        \subseteq
+        \spn\{V^{(N)}(A_j):j=0,\ldots,r-1\}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_ground_space}
+    gives
+    \[
+        \mathcal G_{N,L}(B)=
+        \bigvee_{j=0}^{r-1}\mathcal G_{N,L}(A_j)
+    \]
+    from the block hypotheses, the local boundary-crossing constraints, and the
+    stated tail-word span.
+    Lemma~\ref{lem:block_diagonal_kernel_to_bnt_span_from_chain_splitting}
+    then applies to this equality and to the blockwise containments.
+\end{proof}
+
 \begin{lemma}[Block-diagonal spanning is equivalent to the reverse inclusion]
     \label{lem:block_diagonal_parent_spanning_reverse_inclusion}
     \lean{MPSTensor.hasParentHamiltonianGroundSpaceSpanning_toTensorFromBlocks_iff_ker_le_bntMPSVectorSpan}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -86,9 +86,8 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
   parent-Hamiltonian block-diagonal boundary-condition theorem behind the
   periodic block decomposition and the BNT ground-space span. The fixed-window
   PGVWC07 \(C^j,D^j\) comparison is now formalized under a crossing-tail
-  word-span hypothesis; the remaining boundary is the source-range
-  block-diagonal boundary representation and replacement of that span-dependent
-  route by the source \(C^j,D^j,E^j\) comparison.
+  word-span hypothesis; the remaining boundary is the replacement of that
+  span-dependent short-tail statement by the source \(C^j,D^j,E^j\) comparison.
 - `cpgsv21_martingale_overlap.tex` records the spectral-gap martingale
   comparison: the finite-row cyclic-window reduction is formalized, while the
   remaining source comparison is the overlapping-window anticommutator estimate;

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -456,9 +456,10 @@ every block $j$,
   \quad\Longrightarrow\quad
   \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal K_{N,L}(A_j).
 \end{align}
-This is the conditional reduction recorded by pull request~\#2724.  There are
-now two proved conditional routes to the boundary-condition comparison. The
-boundary-trace route records the following implication. Assume the common
+This is the conditional reduction recorded by pull request~\#2724. There are
+now two proved conditional implications leading to the boundary-condition
+comparison. The boundary-trace implication records the following statement.
+Assume the common
 word-span property for the middle-word length \(m\). If, for every
 boundary-crossing interval, word
 $\beta$ before the cut, outside word $\rho$, and middle word $w$ of length \(m\),
@@ -514,14 +515,14 @@ then the normalized block-separation theorem gives
   =
   \prod_j M_{D_j}(\mathbb C).
 \end{align}
-Consequently the boundary-trace implication in the finite range only keeps
-the displayed trace equality and the block-diagonal boundary representation
-as external inputs.\footnote{Lean declarations:
+Consequently the finite-range trace-decomposition implication only keeps the
+displayed trace equality as an external input once a block-diagonal boundary
+representation of the vector has been chosen.\footnote{Lean declarations:
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_trace_decomposition_bnt_c1_span}
 and
 \leanid{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_trace_decomposition_bnt_c1_span}.}
 
-The \(C^j,D^j\) opened-boundary route is closer to the proof of
+The \(C^j,D^j\) comparison after opening the boundary is closer to the proof of
 \cite[Theorem~12]{PerezGarcia2007MPSReps}.
 The words \(\beta\) and \(\rho\) are local word coordinates introduced after
 opening and blocking the cyclic boundary comparison; they reindex the source
@@ -539,13 +540,17 @@ length \(N-i\) now give matrices
 This is formalized as
 \leanid{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup}
 and, once a block-diagonal boundary representation of \(\psi\) is fixed, into
+\leanid{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace}
+and then into
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary}.
 The current BNT specialization then obtains that boundary representation through
 \leanid{MPSTensor.exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_bnt_c1}.
 Thus the crossing comparison is not an independent trace-comparison assumption:
 the present proof boundary is the crossing-tail word-span hypothesis and the
-still-used block-diagonal boundary representation of a vector
-\(\psi\in\mathcal K_{N,L}(\widehat A)\).
+choice of block-diagonal boundary representation for a vector
+\(\psi\in\mathcal K_{N,L}(\widehat A)\).  In the normalized BNT specialization,
+that representation is supplied by the block-diagonal boundary theorem displayed
+below.
 This crossing-tail span hypothesis should not be confused with the
 large-length BNT product-span bound: if the boundary-crossing interval begins
 at \(i=N-1\), the required tail length is \(N-i=1\), so it is not supplied by
@@ -568,9 +573,8 @@ product-span input, whose derivation is the normal-range reduction recorded in
 periodic-boundary comparison tracked here.
 
 The remaining source-comparison target is tracked by
-\href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}: remove the
-remaining external boundary-representation input, and replace the
-span-dependent crossing-tail route by the \(C^j,D^j,E^j\) comparison from
+\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597}: replace the
+span-dependent short-tail statement by the \(C^j,D^j,E^j\) comparison from
 \cite[Theorem~12]{PerezGarcia2007MPSReps} in the source range
 \begin{align}
   b\ge2,


### PR DESCRIPTION
### Motivation

- The conditional block-diagonal parent ground-space theorems in `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonal*.lean` carry an explicit `hComparison` hypothesis: the opened-boundary \(C^j, D^j\) periodic-boundary upgrade of the Pérez-García–Verstraete–Wolf–Cirac comparison (arXiv:quant-ph/0608197, Theorem 12; arXiv:2011.12127, Section IV.C). Eliminating this hypothesis is the remaining step tracked in #3597.
- This PR partially reduces the hypothesis burden: it separates the comparison step into a named theorem and uses it to derive parent-Hamiltonian kernel containment in the BNT MPS span via the crossing-span route.
- The short-tail word-span hypothesis remains; the source \((C^j, D^j, E^j)\) comparison in the source range is not yet discharged.

### Description

- **`TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`**: adds `blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace`, a theorem stating that a block-diagonal chain-ground-space vector together with fixed block-diagonal boundary data \(X_j\) and the crossing-tail word-span hypothesis at length \(N - i\) implies the \((C^j, D^j)\) PGVWC comparison.
- Restates `exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary` to invoke the extracted theorem rather than repeat the interval-by-interval construction (local sum in \(\bigvee_j G_L(A_j)\) → per-interval comparison).
- Adds `ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_crossing_pgvwc_comparison`, deriving kernel \(\ker H_\mathrm{parent} \subseteq \mathrm{span}_\mathrm{BNT}\) from the crossing-span route plus blockwise chain \(\subseteq\) MPS-line hypotheses.
- **Blueprint** (`ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex`, `ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`, `ch13_parent_hamiltonian_commuting_gap.tex`): adds theorem and proof citations for the new results; places the kernel lemma in the commuting-gap section.
- **`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`**: narrows the remaining gap to replacing the crossing-tail span hypothesis with the source \((C^j, D^j, E^j)\) comparison. This PR does not close the source theorem.

### Testing

- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Refs #3597

> [!NOTE]
> **Low Risk**
> Changes are localized formal proofs and blueprint/gap documentation for block-diagonal parent Hamiltonian theory; no runtime, auth, or data-handling impact.
>
> **Overview**
> **Extracts** the boundary-crossing \(C^j,D^j\) PGVWC comparison into a named Lean theorem `blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace`, taking a block-diagonal chain-ground-space vector, fixed block-diagonal boundary data \(X_j\), and the visible **crossing-tail word-span** hypothesis at length \(N-i\).
>
> **Refactors** `exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary` to call that theorem instead of duplicating the interval-by-interval construction (local sum in \(\bigvee_j G_L(A_j)\) → per-interval comparison).
>
> **Adds** `ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_crossing_pgvwc_comparison`, deriving parent-Hamiltonian kernel ⊆ BNT MPS span from the crossing-span route plus blockwise chain⊆MPS-line hypotheses, parallel to the existing explicit-comparison kernel lemma.
>
> Blueprint chapters and `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` are synced: new theorem/proof cites, kernel lemma in the commuting-gap section, and the **remaining gap** is narrowed to replacing the short-tail span assumption with the source \(C^j,D^j,E^j\) comparison (issue **#3597**). This does **not** close the source theorem.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81243ac343ee859361d7d1e0cef88784469ec24d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof and documentation refactor only in formal MPS parent-Hamiltonian theory; no runtime, security, or data paths.
> 
> **Overview**
> **Extracts** the boundary-crossing \(C^j,D^j\) PGVWC comparison into a named Lean theorem `blockDiagonal_boundary_crossing_pgvwc_comparison_of_chainGroundSpace`, for a vector in block-diagonal chain ground space with fixed boundary data \(X_j\) and the **crossing-tail word-span** hypothesis at length \(N-i\).
> 
> **Refactors** `exists_blockDiagonal_boundary_chainGroundSpace_of_crossing_pgvwc_comparison_of_boundary` to call that theorem instead of repeating the per-interval construction (local sum in \(\bigvee_j G_L(A_j)\) → comparison matrices).
> 
> **Adds** `ker_parentHamiltonian_toTensorFromBlocks_le_bntMPSVectorSpan_of_crossing_pgvwc_comparison`, deriving \(\ker H_\mathrm{parent} \subseteq\) BNT MPS span from the crossing-span route plus blockwise chain \(\subseteq\) MPS-line hypotheses, parallel to the existing explicit-comparison kernel lemma.
> 
> Blueprint (`ch13` boundary-crossing, chain equality, commuting gap) and `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` are synced; the **remaining gap** is narrowed to replacing the short-tail span assumption with the source \(C^j,D^j,E^j\) comparison (**#3597**). This does **not** close that source theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2895a14630aa8ba753a9c6bbb6617ab9c39be356. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->