### PR TITLE
feat(MPS/RFP): prove idempotency of Appendix B projectors

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -15,7 +15,27 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-! ### Key lemma: parent interaction kills ground space elements -/
+/-! ### Parent interaction as a projector -/
+
+/-- The parent interaction is idempotent.
+
+This is the algebraic form of the fact that it is the orthogonal projector onto
+\(G_L(A)^\perp\). -/
+theorem parentInteraction_idempotent (A : MPSTensor d D) (L : ℕ) :
+    parentInteraction A L * parentInteraction A L = parentInteraction A L := by
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d L)
+  let P : EuclideanSpace ℂ (Cfg d L) →ₗ[ℂ] EuclideanSpace ℂ (Cfg d L) :=
+    (groundSpaceES A L)ᗮ.starProjection.toLinearMap
+  have hP : P * P = P := by
+    simpa [P] using
+      (Submodule.isSymmetricProjection_starProjection ((groundSpaceES A L)ᗮ)).isIdempotentElem.eq
+  apply LinearMap.ext
+  intro v
+  change e (P (e.symm (e (P (e.symm v))))) = e (P (e.symm v))
+  rw [LinearEquiv.symm_apply_apply]
+  exact congr_arg e (LinearMap.congr_fun hP (e.symm v))
+
+/-! ### Parent interaction kills ground space elements -/
 
 /-- The parent interaction annihilates any vector in the ground space.
 This is the core property: `parentInteraction A L` is the orthogonal projector

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import TNLean.MPS.ParentHamiltonian.Basic
 import TNLean.MPS.ParentHamiltonian.LocalSupport
 import TNLean.MPS.Core.CyclicTrace
 import TNLean.MPS.RFP.StructuralFull
@@ -42,7 +43,7 @@ The declarations below separate four mathematical statements:
 **Scope restriction (overlapping two-site terms):** The three-site support maps
 for the source \(AX\) and \(XB\) windows are represented in
 `TNLean.MPS.ParentHamiltonian.LocalSupport`. Appendix B supplies the
-basic-vector form, while Appendix D.2 of arXiv:1606.00608 supplies the
+basic-vector form, while Definition D.2 of arXiv:1606.00608 supplies the
 parent-commuting condition for the \(Q_{AX}\) and \(Q_{XB}\) projectors. The
 remaining local step is to identify those projectors with the translated
 length-two parent terms and prove their overlapping commutation. For this reason
@@ -435,6 +436,46 @@ theorem AppendixBStructuralData.appendixBQXB_eq_parentInteraction {A : MPSTensor
     hStruct.appendixBQXB = parentInteraction A 2 := by
   rw [AppendixBStructuralData.appendixBQXB]
   exact hStruct.appendixBQAX_eq_parentInteraction
+
+/-- The Appendix B \(AX\) two-site operator is idempotent.
+
+Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
+2205--2218. -/
+theorem AppendixBStructuralData.appendixBQAX_idempotent {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) :
+    hStruct.appendixBQAX * hStruct.appendixBQAX = hStruct.appendixBQAX := by
+  rw [hStruct.appendixBQAX_eq_parentInteraction]
+  exact parentInteraction_idempotent A 2
+
+/-- The Appendix B \(XB\) two-site operator is idempotent.
+
+Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
+2205--2218. -/
+theorem AppendixBStructuralData.appendixBQXB_idempotent {A : MPSTensor d D}
+    (hStruct : AppendixBStructuralData A) :
+    hStruct.appendixBQXB * hStruct.appendixBQXB = hStruct.appendixBQXB := by
+  rw [hStruct.appendixBQXB_eq_parentInteraction]
+  exact parentInteraction_idempotent A 2
+
+/-- The Appendix B two-site operators satisfy the algebraic part of Definition
+D.2 once their \(AX\) and \(XB\) lifts commute.
+
+The idempotency of \(Q_{AX}\) and \(Q_{XB}\) follows from their identification
+with the canonical two-site parent interaction; the sole hypothesis is the
+commutation of the lifted operators.
+
+Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
+2205--2218. -/
+theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lifts
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hcomm :
+      leftPairLift hStruct.appendixBQAX * rightPairLift hStruct.appendixBQXB =
+        rightPairLift hStruct.appendixBQXB * leftPairLift hStruct.appendixBQAX) :
+    HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAX
+      hStruct.appendixBQXB where
+  left_idempotent := hStruct.appendixBQAX_idempotent
+  right_idempotent := hStruct.appendixBQXB_idempotent
+  commute_lifts := hcomm
 
 /-- On a three-site window, the first translated length-two parent term is the
 \(AX\) lift of the Appendix B \(Q_{AX}\) projector.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -941,6 +941,49 @@ the specialization $L=2$.
     change leaves \(q_2\) unchanged.
 \end{proof}
 
+\begin{lemma}[Appendix B two-site idempotents]
+    \label{lem:appendixB_qax_qxb_idempotent}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQAX_idempotent}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQXB_idempotent}
+    \leanok
+    \uses{lem:parent_interaction_idempotent,
+        lem:appendixB_qax_qxb_parent_interaction}
+    The two Appendix~B two-site operators are idempotent:
+    \[
+        Q_{AX}^{2}=Q_{AX},\qquad Q_{XB}^{2}=Q_{XB}.
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By the preceding identification, both \(Q_{AX}\) and \(Q_{XB}\) are the
+    canonical two-site parent interaction \(q_2(A)\).  The latter is an
+    orthogonal projector, hence is idempotent.
+\end{proof}
+
+\begin{lemma}[Appendix B overlapping condition from the lifted commutator]
+    \label{lem:appendixB_overlapping_condition_from_lift_commutator}
+    \lean{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lifts}
+    \leanok
+    \uses{def:overlapping_two_site_supports, lem:appendixB_qax_qxb_idempotent}
+    Suppose the lifted \(AX\) and \(XB\) operators commute:
+    \[
+        (Q_{AX})_{AX}(Q_{XB})_{XB}
+        =
+        (Q_{XB})_{XB}(Q_{AX})_{AX}.
+    \]
+    Then \(Q_{AX}\) and \(Q_{XB}\) satisfy the algebraic overlapping two-site
+    condition of Definition~\ref{def:overlapping_two_site_supports}.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The idempotency clauses are supplied by
+    Lemma~\ref{lem:appendixB_qax_qxb_idempotent}.  The only remaining clause
+    in Definition~\ref{def:overlapping_two_site_supports} is exactly the
+    displayed lifted commutator.
+\end{proof}
+
 \begin{lemma}[Three-site lifts of the Appendix B two-site operators]
     \label{lem:appendixB_three_site_parent_lifts}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_eq_leftPairLift_appendixBQAX}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
@@ -175,6 +175,24 @@ orthogonal projector is the canonical representative used here.
     on the local $L$-site space.
 \end{definition}
 
+\begin{lemma}[Parent interaction is idempotent]
+    \label{lem:parent_interaction_idempotent}
+    \lean{MPSTensor.parentInteraction_idempotent}
+    \leanok
+    \uses{def:parent_interaction}
+    The local parent interaction is a projector:
+    \[
+        h_L(A)^2=h_L(A).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    This is the idempotency of the orthogonal projector onto
+    \(G_L(A)^\perp\), transported from the Hilbert-space realization of the
+    local coefficient space.
+\end{proof}
+
 \begin{lemma}[Parent interaction annihilates ground-space elements]%
     \label{lem:parent_interaction_apply_mem_ground_space}
     \lean{MPSTensor.parentInteraction_apply_mem_groundSpace}


### PR DESCRIPTION
### Motivation

Issue #3373 requires the Appendix B projectors Q_AX and Q_XB to be related to translated two-site parent interactions before the commuting-projector bridge can be completed. This PR records the projector part of that local algebra, while leaving the lifted commutator and the all-chain witness open.

### Description

- `TNLean/MPS/ParentHamiltonian/Basic.lean`: proves `parentInteraction_idempotent`.
- `TNLean/MPS/RFP/CommutingBridge.lean`: proves idempotency of `appendixBQAX` and `appendixBQXB`, and records that `HasOverlappingTwoSiteCommutation` follows once the lifted AX/XB commutator is supplied.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex` and `blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex`: add the corresponding blueprint entries.

The lifted commutator and the finite-chain `HasProductPairLocalProjectors` construction remain source-faithful obligations.

Refs #3373

### Testing

- `lake build TNLean.MPS.RFP.CommutingBridge`
- `lake build TNLean`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/ParentHamiltonian/Basic.lean TNLean/MPS/RFP/CommutingBridge.lean`