### PR TITLE
feat(parent): transport Appendix B commutator to local terms

### DIFF
--- a/TNLean/Axioms/LiebSubBoundary.lean
+++ b/TNLean/Axioms/LiebSubBoundary.lean
@@ -30,11 +30,12 @@ The result reduces to the boundary case `lieb_concavity_psd`.  Set `r = x + y`. 
 `r = 0` both exponents vanish and the functional is the constant `Re Tr(K† K)`.  When
 `0 < r ≤ 1`, put `s = x / r ∈ [0, 1]`, so `x = r·s` and `y = r·(1 − s)`.  The rpow
 composition law `(Cʳ)ˢ = C^{r·s}` (`CFC.rpow_rpow_of_exponent_nonneg`) rewrites the
-functional as `G(Aʳ, Bʳ)`, where `G(Ã, B̃) = Re Tr(K† Ãˢ K B̃^{1-s})` is the boundary
+functional as `G(Aʳ, Bʳ)`, where
+`G(A_tilde, B_tilde) = Re Tr(K† A_tildeˢ K B_tilde^{1-s})` is the boundary
 functional.  Joint concavity of `(A, B) ↦ G(Aʳ, Bʳ)` then follows by composing:
 
 * operator concavity of `C ↦ Cʳ` for `r ∈ [0, 1]` (`CFC.concaveOn_rpow`), giving the
-  Loewner inequality `(t·A₁ + (1-t)·A₂)ʳ ⪰ t·A₁ʳ + (1-t)·A₂ʳ`;
+  Loewner inequality `t·A₁ʳ + (1-t)·A₂ʳ <= (t·A₁ + (1-t)·A₂)ʳ`;
 * Loewner monotonicity of `G` in each matrix argument (`trace_conj_mono` below), from
   operator monotonicity of rpow (`CFC.rpow_le_rpow`) and nonnegativity of the trace of
   a product of positive-semidefinite matrices (`Matrix.PosSemidef.trace_mul_nonneg`);
@@ -193,7 +194,7 @@ theorem lieb_concavity_subboundary
       (Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg)
       (Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg)
       (Matrix.nonneg_iff_posSemidef.mp CFC.rpow_nonneg) (t := t) ⟨ht0, ht1⟩
-    -- Operator concavity of `· ^ r`: `t·A₁ʳ + (1-t)·A₂ʳ ⪯ Aθʳ`, similarly for `B`.
+    -- Operator concavity of `· ^ r`: `t·A₁ʳ + (1-t)·A₂ʳ <= Aθʳ`, similarly for `B`.
     have hAle_r : t • A₁ ^ r + (1 - t) • A₂ ^ r ≤ Aθ ^ r := by
       have h := (CFC.concaveOn_rpow hrmem).2 (Set.mem_Ici.mpr hA₁.nonneg)
         (Set.mem_Ici.mpr hA₂.nonneg) ht0 ht1' hsum

--- a/TNLean/Axioms/LiebSubBoundary.lean
+++ b/TNLean/Axioms/LiebSubBoundary.lean
@@ -30,8 +30,9 @@ The result reduces to the boundary case `lieb_concavity_psd`.  Set `r = x + y`. 
 `r = 0` both exponents vanish and the functional is the constant `Re Tr(K† K)`.  When
 `0 < r ≤ 1`, put `s = x / r ∈ [0, 1]`, so `x = r·s` and `y = r·(1 − s)`.  The rpow
 composition law `(Cʳ)ˢ = C^{r·s}` (`CFC.rpow_rpow_of_exponent_nonneg`) rewrites the
-functional as the boundary functional evaluated at the auxiliary matrices
-`Aʳ` and `Bʳ`.  Joint concavity of the resulting expression then follows by composing:
+functional as `G(Aʳ, Bʳ)`, where \(G(C,D)=\operatorname{Re}\operatorname{Tr}
+(K^\dagger C^s K D^{1-s})\) is the boundary functional.  Joint concavity of
+the resulting expression then follows by composing:
 
 * operator concavity of `C ↦ Cʳ` for `r ∈ [0, 1]` (`CFC.concaveOn_rpow`), giving the
   Loewner inequality `t·A₁ʳ + (1-t)·A₂ʳ <= (t·A₁ + (1-t)·A₂)ʳ`;

--- a/TNLean/Axioms/LiebSubBoundary.lean
+++ b/TNLean/Axioms/LiebSubBoundary.lean
@@ -30,9 +30,9 @@ The result reduces to the boundary case `lieb_concavity_psd`.  Set `r = x + y`. 
 `r = 0` both exponents vanish and the functional is the constant `Re Tr(K† K)`.  When
 `0 < r ≤ 1`, put `s = x / r ∈ [0, 1]`, so `x = r·s` and `y = r·(1 − s)`.  The rpow
 composition law `(Cʳ)ˢ = C^{r·s}` (`CFC.rpow_rpow_of_exponent_nonneg`) rewrites the
-functional as `G(Aʳ, Bʳ)`, where \(G(C,D)=\operatorname{Re}\operatorname{Tr}
+functional as \(G(A^r,B^r)\), where \(G(C,D)=\operatorname{Re}\operatorname{Tr}
 (K^\dagger C^s K D^{1-s})\) is the boundary functional.  Joint concavity of
-the resulting expression then follows by composing:
+\((A,B)\mapsto G(A^r,B^r)\) then follows by composing:
 
 * operator concavity of `C ↦ Cʳ` for `r ∈ [0, 1]` (`CFC.concaveOn_rpow`), giving the
   Loewner inequality `t·A₁ʳ + (1-t)·A₂ʳ <= (t·A₁ + (1-t)·A₂)ʳ`;

--- a/TNLean/Axioms/LiebSubBoundary.lean
+++ b/TNLean/Axioms/LiebSubBoundary.lean
@@ -30,9 +30,8 @@ The result reduces to the boundary case `lieb_concavity_psd`.  Set `r = x + y`. 
 `r = 0` both exponents vanish and the functional is the constant `Re Tr(K† K)`.  When
 `0 < r ≤ 1`, put `s = x / r ∈ [0, 1]`, so `x = r·s` and `y = r·(1 − s)`.  The rpow
 composition law `(Cʳ)ˢ = C^{r·s}` (`CFC.rpow_rpow_of_exponent_nonneg`) rewrites the
-functional as `G(Aʳ, Bʳ)`, where
-`G(A_tilde, B_tilde) = Re Tr(K† A_tildeˢ K B_tilde^{1-s})` is the boundary
-functional.  Joint concavity of `(A, B) ↦ G(Aʳ, Bʳ)` then follows by composing:
+functional as the boundary functional evaluated at the auxiliary matrices
+`Aʳ` and `Bʳ`.  Joint concavity of the resulting expression then follows by composing:
 
 * operator concavity of `C ↦ Cʳ` for `r ∈ [0, 1]` (`CFC.concaveOn_rpow`), giving the
   Loewner inequality `t·A₁ʳ + (1-t)·A₂ʳ <= (t·A₁ + (1-t)·A₂)ʳ`;

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -499,6 +499,64 @@ theorem AppendixBStructuralData.localTerm_two_three_one_eq_rightPairLift_appendi
   rw [localTerm_two_three_one_eq_rightPairLift_parentInteraction,
     hStruct.appendixBQXB_eq_parentInteraction]
 
+/-- The algebraic overlapping condition for the Appendix B two-site projectors
+transports to commutation of the first two three-site parent terms.
+
+This is only the local transport from the Definition D.2 \(AX/XB\) equation to
+the translated parent interactions.  It does not construct the source
+projectors or prove their lifted commutator from the Appendix B basic-vector
+form.
+
+Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
+2205--2218. -/
+theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapping
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (h : HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAX
+      hStruct.appendixBQXB) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) := by
+  rw [hStruct.localTerm_two_three_zero_eq_leftPairLift_appendixBQAX,
+    hStruct.localTerm_two_three_one_eq_rightPairLift_appendixBQXB]
+  exact h.commute_lifts
+
+/-- If the lifted Appendix B \(AX\) and \(XB\) projectors commute, then the
+first two translated length-two parent terms commute on the three-site window.
+
+This is the composed local consequence of the already isolated idempotency
+statements and the supplied Definition D.2 lifted commutator.
+
+Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
+2205--2218. -/
+theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_lifts
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (hcomm :
+      leftPairLift hStruct.appendixBQAX * rightPairLift hStruct.appendixBQXB =
+        rightPairLift hStruct.appendixBQXB * leftPairLift hStruct.appendixBQAX) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) :=
+  hStruct.localTerm_two_three_zero_one_commute_of_overlapping
+    (hStruct.hasOverlappingTwoSiteCommutation_of_commute_lifts hcomm)
+
+/-- Definition D.2 data for the Appendix B \(AX\) and \(XB\) projectors gives
+commutation of the first two translated length-two parent terms on the
+three-site window.
+
+This theorem only transports already-supplied Definition D.2 data to the
+canonical parent interactions identified above.  The construction of that data
+from the Appendix B basic-vector form remains a separate source-level
+obligation.
+
+Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
+2205--2218. -/
+theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    {KAXB : Submodule ℂ (NSiteSpace d 3)}
+    (hD2 : HasAppendixD2ParentCommutingHamiltonian
+      (d := d) KAXB hStruct.appendixBQAX hStruct.appendixBQXB) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) :=
+  hStruct.localTerm_two_three_zero_one_commute_of_overlapping hD2.to_overlapping
+
 /-- The Appendix B basis change does not change any MPV coefficient. -/
 theorem AppendixBStructuralData.mpv_eq_coreTensor {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) {N : ℕ} (σ : Cfg d N) :

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -543,8 +543,7 @@ three-site window.
 
 This theorem only transports already-supplied Definition D.2 data to the
 canonical parent interactions identified above.  The construction of that data
-from the Appendix B basic-vector form remains a separate source-level
-obligation.
+remains to be derived from the Appendix B basic-vector form.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1012,8 +1012,10 @@ the specialization $L=2$.
     \leanok
     \uses{lem:appendixB_three_site_parent_lifts}
     If the Appendix~B \(AX\) and \(XB\) projectors satisfy the overlapping
-    two-site commutation datum, namely idempotency together with
+    two-site commutation datum
     \[
+        Q_{AX}^2=Q_{AX},\qquad
+        Q_{XB}^2=Q_{XB},\qquad
         (Q_{AX})_{AX}(Q_{XB})_{XB}
         =
         (Q_{XB})_{XB}(Q_{AX})_{AX},

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1006,6 +1006,41 @@ the specialization $L=2$.
     two-site identifications.
 \end{proof}
 
+\begin{lemma}[Appendix B lifted commutator gives three-site parent-term commutation]
+    \label{lem:appendixB_lift_commutator_parent_terms}
+    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapping}
+    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_lifts}
+    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2}
+    \leanok
+    \uses{lem:appendixB_overlapping_condition_from_lift_commutator,
+        lem:appendixB_three_site_parent_lifts}
+    If the Appendix~B \(AX\) and \(XB\) projectors satisfy the lifted
+    Definition~D.2 commutator
+    \[
+        (Q_{AX})_{AX}(Q_{XB})_{XB}
+        =
+        (Q_{XB})_{XB}(Q_{AX})_{AX},
+    \]
+    then the corresponding first two translated length-two parent terms on the
+    three-site window commute:
+    \[
+        h_0^{(3)}(A,2)h_1^{(3)}(A,2)
+        =
+        h_1^{(3)}(A,2)h_0^{(3)}(A,2).
+    \]
+    The same conclusion holds if the full Definition~D.2 local data are given
+    for these two Appendix~B projectors.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By Lemma~\ref{lem:appendixB_three_site_parent_lifts}, the two translated
+    parent terms are exactly the \(AX\) and \(XB\) lifts of \(Q_{AX}\) and
+    \(Q_{XB}\).  The displayed equality is therefore the lifted commutator
+    itself.  Full Definition~D.2 data imply this commutator by forgetting the
+    kernel-intersection clause.
+\end{proof}
+
 \begin{remark}[Basic-vector coefficients and nearest-neighbor parent-term commutation]%
     \label{rem:product_pair_projectors}
     \lean{MPSTensor.productPairWindow}
@@ -1053,7 +1088,8 @@ the specialization $L=2$.
         lem:appendixB_basis_change_parent_interaction,
         def:appendixB_two_site_basic_space, def:appendixB_qax,
         def:appendixB_qxb, lem:appendixB_qax_qxb_parent_interaction,
-        lem:appendixB_three_site_parent_lifts}
+        lem:appendixB_three_site_parent_lifts,
+        lem:appendixB_lift_commutator_parent_terms}
     The Appendix~B structural form supplies
     \[
         A^i=X\Lambda U^iX^{-1}.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1011,7 +1011,7 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapping}
     \leanok
     \uses{lem:appendixB_three_site_parent_lifts}
-    If the Appendix~B \(AX\) and \(XB\) projectors satisfy the overlapping
+    If the Appendix~B $AX$ and $XB$ projectors satisfy the overlapping
     two-site commutation datum
     \[
         Q_{AX}^2=Q_{AX},\qquad
@@ -1032,8 +1032,8 @@ the specialization $L=2$.
 \begin{proof}
     \leanok
     By Lemma~\ref{lem:appendixB_three_site_parent_lifts}, the two translated
-    parent terms are exactly the \(AX\) and \(XB\) lifts of \(Q_{AX}\) and
-    \(Q_{XB}\).  The displayed equality is therefore the commutation clause of
+    parent terms are exactly the $AX$ and $XB$ lifts of $Q_{AX}$ and
+    $Q_{XB}$.  The displayed equality is therefore the commutation clause of
     the overlapping two-site datum.
 \end{proof}
 
@@ -1044,7 +1044,7 @@ the specialization $L=2$.
     \leanok
     \uses{lem:appendixB_overlapping_condition_from_lift_commutator,
         lem:appendixB_overlapping_condition_parent_terms}
-    If the Appendix~B \(AX\) and \(XB\) projectors satisfy the lifted
+    If the Appendix~B $AX$ and $XB$ projectors satisfy the lifted
     Definition~D.2 commutator
     \[
         (Q_{AX})_{AX}(Q_{XB})_{XB}
@@ -1066,8 +1066,15 @@ the specialization $L=2$.
     \leanok
     The lifted commutator, together with the Appendix~B idempotency already
     recorded above, gives the overlapping two-site commutation datum.  Full
-    Definition~D.2 data imply the same conclusion by retaining its commutation
-    clause and not using its kernel-intersection clause.
+    Definition~D.2 data imply the same conclusion by retaining their commutation
+    clause and not using the kernel-intersection condition
+    \[
+        K_{AXB}
+        =
+        \ker\bigl((Q_{AX})_{AX}\bigr)
+        \cap
+        \ker\bigl((Q_{XB})_{XB}\bigr).
+    \]
 \end{proof}
 
 \begin{remark}[Basic-vector coefficients and nearest-neighbor parent-term commutation]%

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1006,14 +1006,42 @@ the specialization $L=2$.
     two-site identifications.
 \end{proof}
 
+\begin{lemma}[Appendix B overlapping condition gives three-site parent-term commutation]
+    \label{lem:appendixB_overlapping_condition_parent_terms}
+    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapping}
+    \leanok
+    \uses{lem:appendixB_three_site_parent_lifts}
+    If the Appendix~B \(AX\) and \(XB\) projectors satisfy the overlapping
+    two-site commutation datum, namely idempotency together with
+    \[
+        (Q_{AX})_{AX}(Q_{XB})_{XB}
+        =
+        (Q_{XB})_{XB}(Q_{AX})_{AX},
+    \]
+    then the corresponding first two translated length-two parent terms on the
+    three-site window commute:
+    \[
+        h_0^{(3)}(A,2)h_1^{(3)}(A,2)
+        =
+        h_1^{(3)}(A,2)h_0^{(3)}(A,2).
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By Lemma~\ref{lem:appendixB_three_site_parent_lifts}, the two translated
+    parent terms are exactly the \(AX\) and \(XB\) lifts of \(Q_{AX}\) and
+    \(Q_{XB}\).  The displayed equality is therefore the commutation clause of
+    the overlapping two-site datum.
+\end{proof}
+
 \begin{lemma}[Appendix B lifted commutator gives three-site parent-term commutation]
     \label{lem:appendixB_lift_commutator_parent_terms}
-    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapping}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_lifts}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2}
     \leanok
     \uses{lem:appendixB_overlapping_condition_from_lift_commutator,
-        lem:appendixB_three_site_parent_lifts}
+        lem:appendixB_overlapping_condition_parent_terms}
     If the Appendix~B \(AX\) and \(XB\) projectors satisfy the lifted
     Definition~D.2 commutator
     \[
@@ -1034,11 +1062,10 @@ the specialization $L=2$.
 
 \begin{proof}
     \leanok
-    By Lemma~\ref{lem:appendixB_three_site_parent_lifts}, the two translated
-    parent terms are exactly the \(AX\) and \(XB\) lifts of \(Q_{AX}\) and
-    \(Q_{XB}\).  The displayed equality is therefore the lifted commutator
-    itself.  Full Definition~D.2 data imply this commutator by forgetting the
-    kernel-intersection clause.
+    The lifted commutator, together with the Appendix~B idempotency already
+    recorded above, gives the overlapping two-site commutation datum.  Full
+    Definition~D.2 data imply the same conclusion by retaining its commutation
+    clause and not using its kernel-intersection clause.
 \end{proof}
 
 \begin{remark}[Basic-vector coefficients and nearest-neighbor parent-term commutation]%

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -115,9 +115,15 @@ For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
 Appendix~B supplies the basic-vector form, while the projectors
 \(Q_{AX}\) and \(Q_{XB}\) belong to the Appendix~D.2 parent-commuting
-condition.  The remaining local step is to identify those projectors with the
-translated two-site parent terms and prove the overlapping commutation relation
-for them.  On the coefficient side, the source statement is the basic-vector formula
+condition.  The coefficient-space representatives
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQAX} and
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQXB} are now identified with
+the canonical two-site parent interaction, and their lifted commutator has been
+transported to the first two translated three-site parent terms.  The remaining
+local step is to construct the source Appendix~D.2 data from the Appendix~B
+basic-vector form, prove the lifted \(AX/XB\) commutator, and extend the local
+transport to the all-chain family of two-site parent projectors.  On the
+coefficient side, the source statement is the basic-vector formula
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), where
 \(\varphi_j\) is shared between neighboring virtual spins.  The current
 disjoint adjacent-pair condition is a separate conditional statement and should
@@ -151,9 +157,10 @@ The present formal boundary is therefore: the reverse implication has the
 source ground-space hypothesis, but its proof is still the Beigi axiom; the
 forward implication has the source-unit Appendix~B structural datum, the
 three-site \(AX/XB\) support maps, and the coefficient form of
-\(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks the source projector
-identification and a justified relation between the source formula and any
-disjoint adjacent-pair condition used by the conditional theorem.
+\(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks the construction of the
+source Appendix~D.2 projectors and their lifted commutator from that datum, the
+all-chain local-projector witness, and a justified relation between the source
+formula and any disjoint adjacent-pair condition used by the conditional theorem.
 The axiom-backed theorem still supplies the commutation direction used by the
 unconditional statements.
 

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -83,6 +83,16 @@ available in both conventions: directly for \(Q_{AX},Q_{XB}\) through
 \leanid{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2}, and for
 their complements through
 \leanid{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2_complement}.
+For the Appendix~B structural datum itself, the coefficient-space
+representatives are
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQAX} and
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQXB}; they are identified
+with the canonical two-site parent interaction, and the supplied lifted
+commutator or supplied Definition~D.2 datum is transported to the corresponding
+three-site translated parent terms by
+\leanid{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_lifts}
+and
+\leanid{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2}.
 
 \section{Elimination plan}
 


### PR DESCRIPTION
## Summary

This PR adds the local transport step from the Appendix B lifted \(AX/XB\) commutator to commutation of the first two translated length-two parent terms on a three-site window.

It also updates the parent-Hamiltonian blueprint and the two paper-gap notes to record the new boundary: the lifted commutator can now be transported to the canonical parent terms, but the source Appendix D.2 data and all-chain parent-projector witness are still not constructed from the Appendix B basic-vector form.

A follow-up style-only commit removes unsupported Unicode from comments in `TNLean/Axioms/LiebSubBoundary.lean`, because the CI style pass failed there after the Lean build itself had succeeded.

Refs #3373.

## Validation

- `lake build TNLean.MPS.RFP.CommutingBridge`
- `lake build TNLean`
- augmented `lake exe checkdecls` including the three new declarations and the current generated declaration list
- `rg -n "sorry|axiom|native_decide|unsafeCast" TNLean/MPS/RFP/CommutingBridge.lean || true`
- `lake env lean TNLean/Axioms/LiebSubBoundary.lean`
- `lake exe lint_style --github`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive documentation and conditional transport lemmas on the MPS parent-Hamiltonian bridge, plus comment-only edits in LiebSubBoundary; no axioms, auth, or runtime behavior are touched.
> 
> **Overview**
> Adds **Appendix B–specific Lean theorems** that turn overlapping two-site data (or a lifted \(AX/XB\) commutator, or full Appendix D.2 input) into commutation of the first two translated length-two parent terms on a three-site window, using the existing `appendixBQAX` / `appendixBQXB` ↔ `parentInteraction` identifications and lift equations.
> 
> The **parent-Hamiltonian blueprint** gains matching lemmas (`appendixB_overlapping_condition_parent_terms`, `appendixB_lift_commutator_parent_terms`) and wires them into the product-pair remark; **paper-gap notes** now state that this transport is done while construction of source D.2 projectors, the lifted commutator from basic-vector form, and all-chain local projectors remain open.
> 
> **`LiebSubBoundary.lean`** only adjusts module comments (Unicode → ASCII / `<=`) for the style CI pass—no proof changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dc5c4f7d1ba35a351f6d11eda8e8d1e699e6965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->