### PR TITLE
feat(MPS/ParentHamiltonian): local parent term idempotency and projector constructors

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Basic.lean
+++ b/TNLean/MPS/ParentHamiltonian/Basic.lean
@@ -35,6 +35,43 @@ theorem parentInteraction_idempotent (A : MPSTensor d D) (L : ℕ) :
   rw [LinearEquiv.symm_apply_apply]
   exact congr_arg e (LinearMap.congr_fun hP (e.symm v))
 
+/-- Pointwise formula for a translated local term when the window length is at
+most the chain length. -/
+@[simp] theorem localTerm_apply_of_le (A : MPSTensor d D) (L N : ℕ)
+    (hLN : L ≤ N) (i : Fin N) (ψ : NSiteSpace d N) (σ : Cfg d N) :
+    localTerm A L N i ψ σ =
+      parentInteraction A L
+        (fun τ => ψ (replaceWindow L hLN i σ τ)) (extractWindow L i σ) := by
+  rw [localTerm, dif_pos hLN]
+  rfl
+
+/-- Every translated local parent interaction is idempotent.
+
+This is the finite-chain form of the fact that the local parent interaction is an
+orthogonal projector. -/
+theorem localTerm_idempotent (A : MPSTensor d D) (L N : ℕ) (i : Fin N) :
+    localTerm A L N i * localTerm A L N i = localTerm A L N i := by
+  by_cases hLN : L ≤ N
+  · apply LinearMap.ext
+    intro ψ
+    ext σ
+    rw [Module.End.mul_apply]
+    rw [localTerm_apply_of_le A L N hLN i (localTerm A L N i ψ) σ]
+    rw [localTerm_apply_of_le A L N hLN i ψ σ]
+    let f : NSiteSpace d L := fun τ => ψ (replaceWindow L hLN i σ τ)
+    have hwindow :
+        (fun τ => localTerm A L N i ψ (replaceWindow L hLN i σ τ)) =
+          parentInteraction A L f := by
+      funext τ
+      rw [localTerm_apply_of_le A L N hLN i ψ (replaceWindow L hLN i σ τ)]
+      simp [f]
+    rw [hwindow]
+    change parentInteraction A L (parentInteraction A L f) (extractWindow L i σ) =
+      parentInteraction A L f (extractWindow L i σ)
+    exact congr_fun (LinearMap.congr_fun (parentInteraction_idempotent A L) f)
+      (extractWindow L i σ)
+  · simp [localTerm, hLN]
+
 /-! ### Parent interaction kills ground space elements -/
 
 /-- The parent interaction annihilates any vector in the ground space.

--- a/TNLean/MPS/ParentHamiltonian/Defs.lean
+++ b/TNLean/MPS/ParentHamiltonian/Defs.lean
@@ -158,6 +158,18 @@ that configuration unchanged. -/
     exact congr_arg σ (Fin.ext key)
   · rw [dif_neg hoffset]
 
+/-- Replacing the same cyclic window twice is the same as keeping only the
+second replacement. -/
+@[simp] lemma replaceWindow_replaceWindow_same (L : ℕ) (hLN : L ≤ N) {α : Type*}
+    (i : Fin N) (σ : Fin N → α) (τ υ : Fin L → α) :
+    replaceWindow L hLN i (replaceWindow L hLN i σ τ) υ =
+      replaceWindow L hLN i σ υ := by
+  funext ⟨k, hk⟩
+  unfold replaceWindow
+  by_cases hoffset : (k + N - i.val) % N < L
+  · simp [hoffset]
+  · simp [hoffset]
+
 /-! ### Local term (site embedding) -/
 
 /-- Translated local term on an \(N\)-site periodic chain: embeds

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -163,6 +163,19 @@ theorem HasProductPairLocalProjectors.commuting_twoSite_localTerms
   rw [hPair.hlocal i, hPair.hlocal j]
   exact hPair.hcomm i j
 
+/-- A commuting family of translated length-two parent terms gives the local
+projector witness, since each translated parent term is already idempotent. -/
+noncomputable def HasProductPairLocalProjectors.of_commuting_localTerms
+    {A : MPSTensor d D} {N : ℕ}
+    (hcomm : ∀ i j : Fin N,
+      localTerm A 2 N i * localTerm A 2 N j =
+        localTerm A 2 N j * localTerm A 2 N i) :
+    HasProductPairLocalProjectors A N where
+  proj := fun i => localTerm A 2 N i
+  hidem := fun i => _root_.MPSTensor.localTerm_idempotent A 2 N i
+  hlocal := fun _ => rfl
+  hcomm := hcomm
+
 /-- Conditional hypotheses for a tensor whose positive even-chain coefficients
 factor through one disjoint adjacent two-site amplitude and whose
 nearest-neighbor parent terms are commuting idempotents on every finite chain. -/
@@ -646,6 +659,23 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
     rw [hStruct.mpv_eq_coreTensor σ]
     exact hCore N hN σ
   localProjectors := hProj
+
+/-- Construct the conditional Appendix B extraction from the coefficient
+factorization and the all-chain commutation equations for the translated
+length-two parent terms.
+
+The idempotency of the local terms is supplied by `localTerm_idempotent`; the
+source-dependent obligation in this constructor is only the commutation family. -/
+noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndCommutation
+    {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
+    (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
+      mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
+    (hComm : ∀ N, ∀ i j : Fin N,
+      localTerm A 2 N i * localTerm A 2 N j =
+        localTerm A 2 N j * localTerm A 2 N i) :
+    AppendixBProductPairExtraction hStruct :=
+  AppendixBProductPairExtraction.ofCoreTensorFactorization hCore
+    (fun N => HasProductPairLocalProjectors.of_commuting_localTerms (hComm N))
 
 /-- The conditional Appendix B hypotheses yield the `ProductPairBridge`
 structure used by the parent-Hamiltonian statements. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1085,6 +1085,7 @@ the specialization $L=2$.
     \lean{MPSTensor.productPairState_one}
     \lean{MPSTensor.HasProductPairMPV}
     \lean{MPSTensor.HasProductPairLocalProjectors}
+    \lean{MPSTensor.HasProductPairLocalProjectors.of_commuting_localTerms}
     \lean{MPSTensor.HasProductPairLocalProjectors.isNNCPH}
     \lean{MPSTensor.ProductPairBridge}
     \lean{MPSTensor.ProductPairBridge.localTerm_idempotent}
@@ -1114,6 +1115,7 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.mpv_eq_productPairState_one}
     \lean{MPSTensor.AppendixBProductPairExtraction}
     \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorization}
+    \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorizationAndCommutation}
     \lean{MPSTensor.AppendixBProductPairExtraction.toProductPairBridge}
     \lean{MPSTensor.AppendixBProductPairExtraction.commuting_twoSite_localTerms}
     \lean{MPSTensor.commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction}
@@ -1125,7 +1127,7 @@ the specialization $L=2$.
         def:appendixB_two_site_basic_space, def:appendixB_qax,
         def:appendixB_qxb, lem:appendixB_qax_qxb_parent_interaction,
         lem:appendixB_three_site_parent_lifts,
-        lem:appendixB_lift_commutator_parent_terms}
+        lem:appendixB_lift_commutator_parent_terms, lem:local_term_idempotent}
     The Appendix~B structural form supplies
     \[
         A^i=X\Lambda U^iX^{-1}.
@@ -1238,17 +1240,14 @@ the specialization $L=2$.
     Appendix~B supplies the basic-vector expression, while Appendix~D.2 supplies
     the parent-commuting projector condition. The local two-site projector
     identification above does not prove the overlapping commutation relation
-    \(Q_{AX}Q_{XB}=Q_{XB}Q_{AX}\). For the all-chain statement, the resulting
-    two-site parent projectors must also be identified with idempotents \(p_i\)
-    satisfying
+    $Q_{AX}Q_{XB}=Q_{XB}Q_{AX}$. For the all-chain statement, the remaining
+    local projector equation is the following commutation condition: for every
+    finite chain and every pair of sites $i,j$,
     \[
-        h_i(A,2)=p_i,\qquad p_i^2=p_i,\qquad p_ip_j=p_jp_i.
+        h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2).
     \]
-    These equations give
-    \[
-        h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2),
-    \]
-    which is the nearest-neighbor commuting conclusion for every finite chain.
+    The projector equation $h_i(A,2)^2=h_i(A,2)$ is already
+    Lemma~\ref{lem:local_term_idempotent}.
     The overlapping commutation theorem and the justification of any passage
     from the source coefficients to this adjacent-pair condition are the
     remaining obligations before the conditional theorem can be applied; once

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
@@ -272,6 +272,23 @@ orthogonal projector is the canonical representative used here.
     $\sigma$; outside the interval both sides already agree with $\sigma$.
 \end{proof}
 
+\begin{lemma}[Replacing the same window twice]\label{lem:replace_window_replace_window_same}
+    \lean{MPSTensor.replaceWindow_replaceWindow_same}
+    \leanok
+    \uses{def:replace_window}
+    If $L \le N$, then two prescriptions on the same cyclic interval reduce to
+    the second prescription:
+    \[
+        \left(\sigma^{[i,i+L-1]\leftarrow\tau}\right)^{[i,i+L-1]\leftarrow\upsilon}
+        =
+        \sigma^{[i,i+L-1]\leftarrow\upsilon}.
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    On the cyclic interval both sides take the value prescribed by $\upsilon$.
+    Away from that interval neither second prescription changes the value.
+\end{proof}
+
 For a periodic chain of length $N$, the parent Hamiltonian is the sum of
 translated copies of the local interaction.
 
@@ -294,6 +311,58 @@ translated copies of the local interaction.
         \end{cases}
     \]
 \end{definition}
+
+\begin{lemma}[Pointwise form of a translated local term]\label{lem:local_term_apply_of_le}
+    \lean{MPSTensor.localTerm_apply_of_le}
+    \leanok
+    \uses{def:local_term_parent}
+    If $L \le N$, then the translated term is obtained by applying the local
+    parent interaction on the chosen cyclic window:
+    \[
+        \bigl(h_i(A,L)\psi\bigr)(\sigma)
+        =
+        \left[
+            h_L(A)
+            \bigl(\tau\mapsto
+            \psi(\sigma^{[i,i+L-1]\leftarrow\tau})\bigr)
+        \right]\!\bigl(\sigma|_{[i,i+L-1]}\bigr).
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    This is the first case in the definition of the translated local term.
+\end{proof}
+
+\begin{lemma}[Translated local terms are idempotent]\label{lem:local_term_idempotent}
+    \lean{MPSTensor.localTerm_idempotent}
+    \leanok
+    \uses{def:local_term_parent, lem:parent_interaction_idempotent,
+        lem:local_term_apply_of_le, lem:extract_window_replace_window,
+        lem:replace_window_replace_window_same}
+    For every site $i$,
+    \[
+        h_i(A,L)^2=h_i(A,L).
+    \]
+\end{lemma}
+\begin{proof}\leanok
+    If $L>N$, the translated term is zero. Suppose $L\le N$ and put
+    \[
+        f_{\sigma,i}(\tau)
+        =
+        \psi(\sigma^{[i,i+L-1]\leftarrow\tau}).
+    \]
+    The pointwise formula for translated terms, together with
+    Lemmas~\ref{lem:extract_window_replace_window} and
+    \ref{lem:replace_window_replace_window_same}, gives
+    \[
+        \bigl(h_i(A,L)^2\psi\bigr)(\sigma)
+        =
+        \bigl(h_L(A)^2 f_{\sigma,i}\bigr)
+        \bigl(\sigma|_{[i,i+L-1]}\bigr).
+    \]
+    Lemma~\ref{lem:parent_interaction_idempotent} turns the right-hand side into
+    $\bigl(h_L(A)f_{\sigma,i}\bigr)(\sigma|_{[i,i+L-1]})$, which is
+    $\bigl(h_i(A,L)\psi\bigr)(\sigma)$.
+\end{proof}
 
 \begin{definition}[Parent Hamiltonian]\label{def:parent_hamiltonian}
     \lean{MPSTensor.parentHamiltonian}


### PR DESCRIPTION
### Motivation

The product-pair extraction in the parent-Hamiltonian bridge needs translated local parent terms satisfying
\[
  h_i(A,L)^2=h_i(A,L)
\]
and, separately, pairwise commutation. The idempotency part is intrinsic to the local parent interaction and should not be an external Appendix B hypothesis. This PR proves that idempotency directly and leaves the source-dependent Appendix B obligation as the commutation family
\[
  h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2).
\]

### Description

- `TNLean/MPS/ParentHamiltonian/Defs.lean`: adds the cyclic-window identity saying that replacing the same window twice keeps only the second replacement.
- `TNLean/MPS/ParentHamiltonian/Basic.lean`: records the pointwise formula for a translated local term when `L <= N`, and proves every translated local parent term is idempotent.
- `TNLean/MPS/RFP/CommutingBridge.lean`: adds constructors turning all-chain commutation of translated length-two parent terms into the local-projector data needed by the product-pair bridge, and packages this with Appendix B coefficient factorization.
- `blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex` and `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: records the new projector equations and clarifies that commutation, not idempotency, is the remaining Appendix B input.

Refs #3373.

### Testing

- `lake build TNLean.MPS.RFP.CommutingBridge`
- `lake build TNLean` before the final proof-style amendment; the final amendment was rechecked by the focused build above
- `lake exe lint_style --github`
- `git diff --check`
- `lake exe checkdecls <new declarations + existing blueprint declaration list>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formal math and blueprint documentation only; no runtime, auth, or data-path changes. Risk is limited to proof maintenance if `localTerm` or window definitions change.
> 
> **Overview**
> **Translated local parent terms** \(h_i(A,L)\) are now proved idempotent in Lean (`localTerm_idempotent`), using a new cyclic-window lemma (`replaceWindow_replaceWindow_same`), a pointwise application formula (`localTerm_apply_of_le`), and the existing `parentInteraction_idempotent` result.
> 
> **RFP / Appendix B bridge:** `HasProductPairLocalProjectors.of_commuting_localTerms` constructs the local-projector witness when only all-pairs commutation of length-two `localTerm`s is assumed—idempotency is filled in via the new theorem. `AppendixBProductPairExtraction.ofCoreTensorFactorizationAndCommutation` packages core-tensor coefficient factorization with that commutation family, so the remaining Appendix B obligation is **commutation**, not \(h_i^2=h_i\).
> 
> **Blueprint** (`ch13_parent_hamiltonian_injective_ground_spaces.tex`, `ch13_parent_hamiltonian_commuting_gap.tex`): records the new lemmas and revises the product-pair remark to state idempotency as proved and all-chain commutation as the open input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460177b3722276f8c32477627028923d7840257a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->