### PR TITLE
doc(MPS/RFP): distinguish Appendix B coefficient representatives

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -40,20 +40,19 @@ The declarations below separate four mathematical statements:
   used before the \(AX\) and \(XB\) lifts;
 * the already formalized Appendix B structural form.
 
-**Scope restriction (overlapping two-site terms):** The three-site support maps
-for the source \(AX\) and \(XB\) windows are represented in
-`TNLean.MPS.ParentHamiltonian.LocalSupport`. Appendix B supplies the
-basic-vector form, while Definition D.2 of arXiv:1606.00608 supplies the
-parent-commuting condition for the \(Q_{AX}\) and \(Q_{XB}\) projectors. The
-objects `appendixBQAX` and `appendixBQXB` below are only the common two-site
-coefficient-space representative \(q_2(\Lambda U)\), identified with \(q_2(A)\)
-after the Appendix B core-tensor comparison, before it is placed on the \(AX\)
-and \(XB\) faces. They do not by themselves construct the source projectors on
+**Scope restriction (overlapping two-site terms):** The source \(AX\) and
+\(XB\) support maps are treated in their basic-vector form. Definition D.2 of
+arXiv:1606.00608 supplies the parent-commuting condition for the \(Q_{AX}\) and
+\(Q_{XB}\) projectors. The coefficient representatives \(\widehat Q_{AX}\) and
+\(\widehat Q_{XB}\) below are only the common two-site coefficient-space
+representative \(q_2(\Lambda U)\), identified with \(q_2(A)\) after the
+Appendix B core-tensor comparison, before it is placed on the \(AX\) and \(XB\)
+faces. They do not by themselves construct the source projectors on
 \(\mathcal H_A\otimes\mathcal H_X\) and
 \(\mathcal H_X\otimes\mathcal H_B\), nor do they prove the lifted commutator.
-For this reason commutativity of the translated idempotents is an explicit
-hypothesis in `HasProductPairLocalProjectors`. Eliminating this hypothesis is
-the source projector-construction and commutator step recorded in
+For this reason commutativity of the translated idempotents is kept as an
+explicit hypothesis. Eliminating this hypothesis is the source
+projector-construction and commutator step recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -46,7 +46,8 @@ for the source \(AX\) and \(XB\) windows are represented in
 basic-vector form, while Definition D.2 of arXiv:1606.00608 supplies the
 parent-commuting condition for the \(Q_{AX}\) and \(Q_{XB}\) projectors. The
 objects `appendixBQAX` and `appendixBQXB` below are only the common two-site
-coefficient-space representative \(q_2(A)\) before it is placed on the \(AX\)
+coefficient-space representative \(q_2(\Lambda U)\), identified with \(q_2(A)\)
+after the Appendix B core-tensor comparison, before it is placed on the \(AX\)
 and \(XB\) faces. They do not by themselves construct the source projectors on
 \(\mathcal H_A\otimes\mathcal H_X\) and
 \(\mathcal H_X\otimes\mathcal H_B\), nor do they prove the lifted commutator.
@@ -427,8 +428,8 @@ noncomputable def AppendixBStructuralData.appendixBQAX {A : MPSTensor d D}
 /-- The \(XB\) two-site coefficient-space representative associated with the
 Appendix B core tensor.
 
-This is the same common two-site operator as `appendixBQAX`, now reserved for
-the later \(XB\)-lift. It is not, by itself, a construction of the source
+This is the same common two-site operator \(\widehat Q_{AX}\), now reserved
+for the later \(XB\)-lift. It is not, by itself, a construction of the source
 projector \(Q_{XB}\) as an operator on
 \(\mathcal H_X\otimes\mathcal H_B\).
 

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -36,8 +36,8 @@ The declarations below separate four mathematical statements:
 
 * the coefficient expression for \(U^{\otimes L}\varphi_j^{\otimes L}\);
 * the disjoint adjacent-pair coefficient condition used later in this file;
-* the identification of the translated two-site parent terms with commuting
-  idempotents on each finite chain;
+* the coefficient-space representatives of the two local two-site operators
+  used before the \(AX\) and \(XB\) lifts;
 * the already formalized Appendix B structural form.
 
 **Scope restriction (overlapping two-site terms):** The three-site support maps
@@ -45,11 +45,14 @@ for the source \(AX\) and \(XB\) windows are represented in
 `TNLean.MPS.ParentHamiltonian.LocalSupport`. Appendix B supplies the
 basic-vector form, while Definition D.2 of arXiv:1606.00608 supplies the
 parent-commuting condition for the \(Q_{AX}\) and \(Q_{XB}\) projectors. The
-remaining local step is to identify those projectors with the translated
-length-two parent terms and prove their overlapping commutation. For this reason
-commutativity of the translated idempotents is an explicit hypothesis in
-`HasProductPairLocalProjectors`. Eliminating this hypothesis is the source
-projector-identification step recorded in
+objects `appendixBQAX` and `appendixBQXB` below are only the common two-site
+coefficient-space representative \(q_2(A)\) before it is placed on the \(AX\)
+and \(XB\) faces. They do not by themselves construct the source projectors on
+\(\mathcal H_A\otimes\mathcal H_X\) and
+\(\mathcal H_X\otimes\mathcal H_B\), nor do they prove the lifted commutator.
+For this reason commutativity of the translated idempotents is an explicit
+hypothesis in `HasProductPairLocalProjectors`. Eliminating this hypothesis is
+the source projector-construction and commutator step recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 
@@ -408,9 +411,12 @@ noncomputable def AppendixBStructuralData.twoSiteBasicSpace {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) : Submodule ℂ (NSiteSpace d 2) :=
   groundSpace hStruct.coreTensor 2
 
-/-- The \(AX\) two-site operator named for Definition D.2, represented in the
-two-site coefficient space by the canonical parent interaction of the Appendix
-B core tensor.
+/-- The \(AX\) two-site coefficient-space representative associated with the
+Appendix B core tensor.
+
+This is the common two-site operator \(q_2(\Lambda U)\) before it is placed on
+the \(AX\) face. It is not, by itself, a construction of the source projector
+\(Q_{AX}\) as an operator on \(\mathcal H_A\otimes\mathcal H_X\).
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -418,9 +424,13 @@ noncomputable def AppendixBStructuralData.appendixBQAX {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
   parentInteraction hStruct.coreTensor 2
 
-/-- The \(XB\) source projector named in Definition D.2, represented in the
-two-site coefficient space by the same Appendix B two-site projector before it
-is lifted to the \(XB\) face.
+/-- The \(XB\) two-site coefficient-space representative associated with the
+Appendix B core tensor.
+
+This is the same common two-site operator as `appendixBQAX`, now reserved for
+the later \(XB\)-lift. It is not, by itself, a construction of the source
+projector \(Q_{XB}\) as an operator on
+\(\mathcal H_X\otimes\mathcal H_B\).
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -428,8 +438,8 @@ noncomputable def AppendixBStructuralData.appendixBQXB {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
   hStruct.appendixBQAX
 
-/-- The Appendix B \(AX\) projector is the canonical two-site parent interaction
-of the original tensor.
+/-- The Appendix B \(AX\) coefficient representative is the canonical two-site
+parent interaction of the original tensor.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -439,8 +449,8 @@ theorem AppendixBStructuralData.appendixBQAX_eq_parentInteraction {A : MPSTensor
   rw [AppendixBStructuralData.appendixBQAX]
   exact (hStruct.parentInteraction_eq_coreTensor 2).symm
 
-/-- The Appendix B \(XB\) projector is the canonical two-site parent interaction
-of the original tensor.
+/-- The Appendix B \(XB\) coefficient representative is the canonical two-site
+parent interaction of the original tensor.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -470,12 +480,12 @@ theorem AppendixBStructuralData.appendixBQXB_idempotent {A : MPSTensor d D}
   rw [hStruct.appendixBQXB_eq_parentInteraction]
   exact parentInteraction_idempotent A 2
 
-/-- The Appendix B two-site operators satisfy the algebraic part of Definition
-D.2 once their \(AX\) and \(XB\) lifts commute.
+/-- The Appendix B two-site coefficient representatives satisfy the algebraic
+part of Definition D.2 once their \(AX\) and \(XB\) lifts commute.
 
-The idempotency of \(Q_{AX}\) and \(Q_{XB}\) follows from their identification
+The idempotency of the two representatives follows from their identification
 with the canonical two-site parent interaction; the sole hypothesis is the
-commutation of the lifted operators.
+commutation of their lifted operators.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -491,7 +501,7 @@ theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lift
   commute_lifts := hcomm
 
 /-- On a three-site window, the first translated length-two parent term is the
-\(AX\) lift of the Appendix B \(Q_{AX}\) projector.
+\(AX\) lift of the Appendix B \(AX\) coefficient representative.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -502,7 +512,7 @@ theorem AppendixBStructuralData.localTerm_two_three_zero_eq_leftPairLift_appendi
     hStruct.appendixBQAX_eq_parentInteraction]
 
 /-- On a three-site window, the second translated length-two parent term is the
-\(XB\) lift of the Appendix B \(Q_{XB}\) projector.
+\(XB\) lift of the Appendix B \(XB\) coefficient representative.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -512,8 +522,9 @@ theorem AppendixBStructuralData.localTerm_two_three_one_eq_rightPairLift_appendi
   rw [localTerm_two_three_one_eq_rightPairLift_parentInteraction,
     hStruct.appendixBQXB_eq_parentInteraction]
 
-/-- The algebraic overlapping condition for the Appendix B two-site projectors
-transports to commutation of the first two three-site parent terms.
+/-- The algebraic overlapping condition for the Appendix B two-site coefficient
+representatives transports to commutation of the first two three-site parent
+terms.
 
 This is only the local transport from the Definition D.2 \(AX/XB\) equation to
 the translated parent interactions.  It does not construct the source
@@ -532,8 +543,9 @@ theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapp
     hStruct.localTerm_two_three_one_eq_rightPairLift_appendixBQXB]
   exact h.commute_lifts
 
-/-- If the lifted Appendix B \(AX\) and \(XB\) projectors commute, then the
-first two translated length-two parent terms commute on the three-site window.
+/-- If the lifted Appendix B \(AX\) and \(XB\) coefficient representatives
+commute, then the first two translated length-two parent terms commute on the
+three-site window.
 
 This is the composed local consequence of the already isolated idempotency
 statements and the supplied Definition D.2 lifted commutator.
@@ -550,9 +562,9 @@ theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_
   hStruct.localTerm_two_three_zero_one_commute_of_overlapping
     (hStruct.hasOverlappingTwoSiteCommutation_of_commute_lifts hcomm)
 
-/-- Definition D.2 data for the Appendix B \(AX\) and \(XB\) projectors gives
-commutation of the first two translated length-two parent terms on the
-three-site window.
+/-- Definition D.2 data for the Appendix B \(AX\) and \(XB\) coefficient
+representatives gives commutation of the first two translated length-two parent
+terms on the three-site window.
 
 This theorem only transports already-supplied Definition D.2 data to the
 canonical parent interactions identified above.  The construction of that data

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -36,8 +36,8 @@ The declarations below separate four mathematical statements:
 
 * the coefficient expression for \(U^{\otimes L}\varphi_j^{\otimes L}\);
 * the disjoint adjacent-pair coefficient condition used later in this file;
-* the coefficient-space representatives of the two local two-site operators
-  used before the \(AX\) and \(XB\) lifts;
+* the two local coefficient-space representatives used before the \(AX\) and
+  \(XB\) lifts;
 * the already formalized Appendix B structural form.
 
 **Scope restriction (overlapping two-site terms):** The source \(AX\) and
@@ -414,9 +414,10 @@ noncomputable def AppendixBStructuralData.twoSiteBasicSpace {A : MPSTensor d D}
 /-- The \(AX\) two-site coefficient-space representative associated with the
 Appendix B core tensor.
 
-This is the common two-site operator \(q_2(\Lambda U)\) before it is placed on
-the \(AX\) face. It is not, by itself, a construction of the source projector
-\(Q_{AX}\) as an operator on \(\mathcal H_A\otimes\mathcal H_X\).
+This is the common two-site coefficient representative \(q_2(\Lambda U)\)
+before it is placed on the \(AX\) face. It is not, by itself, a construction of
+the source projector \(Q_{AX}\) as an operator on
+\(\mathcal H_A\otimes\mathcal H_X\).
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -427,9 +428,9 @@ noncomputable def AppendixBStructuralData.appendixBQAX {A : MPSTensor d D}
 /-- The \(XB\) two-site coefficient-space representative associated with the
 Appendix B core tensor.
 
-This is the same common two-site operator \(\widehat Q_{AX}\), now reserved
-for the later \(XB\)-lift. It is not, by itself, a construction of the source
-projector \(Q_{XB}\) as an operator on
+This is the same common two-site coefficient representative
+\(\widehat Q_{AX}\), now reserved for the later \(XB\)-lift. It is not, by
+itself, a construction of the source projector \(Q_{XB}\) as an operator on
 \(\mathcal H_X\otimes\mathcal H_B\).
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
@@ -460,7 +461,7 @@ theorem AppendixBStructuralData.appendixBQXB_eq_parentInteraction {A : MPSTensor
   rw [AppendixBStructuralData.appendixBQXB]
   exact hStruct.appendixBQAX_eq_parentInteraction
 
-/-- The Appendix B \(AX\) two-site operator is idempotent.
+/-- The Appendix B \(AX\) two-site coefficient representative is idempotent.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -470,7 +471,7 @@ theorem AppendixBStructuralData.appendixBQAX_idempotent {A : MPSTensor d D}
   rw [hStruct.appendixBQAX_eq_parentInteraction]
   exact parentInteraction_idempotent A 2
 
-/-- The Appendix B \(XB\) two-site operator is idempotent.
+/-- The Appendix B \(XB\) two-site coefficient representative is idempotent.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -383,8 +383,8 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \]
     and the $N$-site ground spaces $G_N(A_j)=\mathcal G_{N,N}(A_j)$
     have internal sum.
-    The present statement is the equality-level consequence of the
-    boundary-condition comparison in
+    The present statement is the span-dependent opened-boundary consequence of
+    the boundary-condition comparison in
     \cite[Theorem~12, proof lines~1436--1451]{PerezGarcia2007Matrix} in the
     length-$L_0$ injectivity range
     \[
@@ -433,13 +433,14 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
         =
         \bigvee_j\mathcal G_{N,L}(A_j).
     \]
-    This records only the ground-space equality conclusion of
-    \cite[Theorem~12]{PerezGarcia2007Matrix}; the independence of the
-    $N$-site spaces is a separate conclusion of
+    This records the ground-space equality conclusion of the conditional
+    crossing-span version above. It is the corresponding part of
+    \cite[Theorem~12]{PerezGarcia2007Matrix}, but only under the visible
+    tail-word span hypothesis and in the longer current range. The independence
+    of the $N$-site spaces is a separate conclusion of
     Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
-    The statement is still in the length-$L_0$ injectivity range displayed in
-    that lemma, not the shorter range in
-    \cite[Theorem~12]{PerezGarcia2007Matrix}.
+    The source-faithful replacement of the tail-word span hypothesis is tracked
+    separately.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -439,8 +439,9 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     tail-word span hypothesis and in the longer current range. The independence
     of the $N$-site spaces is a separate conclusion of
     Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
-    The source-faithful replacement of the tail-word span hypothesis is tracked
-    separately.
+    Thus the statement remains a conditional opened-boundary comparison, not
+    the unconditional boundary-condition comparison in the source theorem.
+    % Source-faithful replacement of the tail-word span hypothesis is tracked in issue~\#3597.
 \end{lemma}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -898,31 +898,38 @@ the specialization $L=2$.
     \]
 \end{definition}
 
-\begin{definition}[Appendix B \(AX\) two-site operator]
+\begin{definition}[Appendix B \(AX\) coefficient representative]
     \label{def:appendixB_qax}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQAX}
     \leanok
     \uses{def:appendixB_two_site_basic_space, def:parent_interaction}
-    The \(AX\) two-site operator is represented, before the \(AX\)-lift, by
+    The \(AX\) coefficient-space representative is, before the \(AX\)-lift,
     the canonical two-site parent interaction of the core tensor:
     \[
-        Q_{AX}=q_2(A_{\mathrm{core}}).
+        \widehat Q_{AX}=q_2(A_{\mathrm{core}}).
     \]
+    The source projector \(Q_{AX}\) of Definition~D.2 acts on
+    \(H_A\otimes H_X\).  The displayed operator is the two-site coefficient
+    representative that will be placed on the \(AX\) face; it is not by itself
+    the construction of that source projector.
 \end{definition}
 
-\begin{definition}[Appendix B \(XB\) two-site operator]
+\begin{definition}[Appendix B \(XB\) coefficient representative]
     \label{def:appendixB_qxb}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQXB}
     \leanok
     \uses{def:appendixB_qax}
-    The \(XB\) two-site operator is represented, before the \(XB\)-lift, by the
+    The \(XB\) coefficient-space representative is, before the \(XB\)-lift, the
     same two-site operator:
     \[
-        Q_{XB}=Q_{AX}.
+        \widehat Q_{XB}=\widehat Q_{AX}.
     \]
+    The source projector \(Q_{XB}\) of Definition~D.2 acts on
+    \(H_X\otimes H_B\).  The displayed operator is the coefficient
+    representative later placed on the \(XB\) face.
 \end{definition}
 
-\begin{lemma}[Appendix B two-site operators and the parent interaction]
+\begin{lemma}[Appendix B coefficient representatives and the parent interaction]
     \label{lem:appendixB_qax_qxb_parent_interaction}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQAX_eq_parentInteraction}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQXB_eq_parentInteraction}
@@ -931,7 +938,7 @@ the specialization $L=2$.
         def:appendixB_qxb}
     As two-site operators in the coefficient-space representation,
     \[
-        Q_{AX}=q_2(A),\qquad Q_{XB}=q_2(A).
+        \widehat Q_{AX}=q_2(A),\qquad \widehat Q_{XB}=q_2(A).
     \]
 \end{lemma}
 
@@ -941,24 +948,25 @@ the specialization $L=2$.
     change leaves \(q_2\) unchanged.
 \end{proof}
 
-\begin{lemma}[Appendix B two-site idempotents]
+\begin{lemma}[Appendix B two-site representative idempotents]
     \label{lem:appendixB_qax_qxb_idempotent}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQAX_idempotent}
     \lean{MPSTensor.AppendixBStructuralData.appendixBQXB_idempotent}
     \leanok
     \uses{lem:parent_interaction_idempotent,
         lem:appendixB_qax_qxb_parent_interaction}
-    The two Appendix~B two-site operators are idempotent:
+    The two Appendix~B two-site coefficient representatives are idempotent:
     \[
-        Q_{AX}^{2}=Q_{AX},\qquad Q_{XB}^{2}=Q_{XB}.
+        \widehat Q_{AX}^{2}=\widehat Q_{AX},\qquad
+        \widehat Q_{XB}^{2}=\widehat Q_{XB}.
     \]
 \end{lemma}
 
 \begin{proof}
     \leanok
-    By the preceding identification, both \(Q_{AX}\) and \(Q_{XB}\) are the
-    canonical two-site parent interaction \(q_2(A)\).  The latter is an
-    orthogonal projector, hence is idempotent.
+    By the preceding identification, both representatives are the canonical
+    two-site parent interaction \(q_2(A)\).  The latter is an orthogonal
+    projector, hence is idempotent.
 \end{proof}
 
 \begin{lemma}[Appendix B overlapping condition from the lifted commutator]
@@ -966,14 +974,15 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lifts}
     \leanok
     \uses{def:overlapping_two_site_supports, lem:appendixB_qax_qxb_idempotent}
-    Suppose the lifted \(AX\) and \(XB\) operators commute:
+    Suppose the lifted \(AX\) and \(XB\) representatives commute:
     \[
-        (Q_{AX})_{AX}(Q_{XB})_{XB}
+        (\widehat Q_{AX})_{AX}(\widehat Q_{XB})_{XB}
         =
-        (Q_{XB})_{XB}(Q_{AX})_{AX}.
+        (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX}.
     \]
-    Then \(Q_{AX}\) and \(Q_{XB}\) satisfy the algebraic overlapping two-site
-    condition of Definition~\ref{def:overlapping_two_site_supports}.
+    Then \(\widehat Q_{AX}\) and \(\widehat Q_{XB}\) satisfy the algebraic
+    overlapping two-site condition of
+    Definition~\ref{def:overlapping_two_site_supports}.
 \end{lemma}
 
 \begin{proof}
@@ -994,16 +1003,16 @@ the specialization $L=2$.
     On the three-site \(A,X,B\) window, the two adjacent length-two parent terms
     are the two local lifts
     \[
-        h_0^{(3)}(A,2)=(Q_{AX})_{AX},\qquad
-        h_1^{(3)}(A,2)=(Q_{XB})_{XB}.
+        h_0^{(3)}(A,2)=(\widehat Q_{AX})_{AX},\qquad
+        h_1^{(3)}(A,2)=(\widehat Q_{XB})_{XB}.
     \]
 \end{lemma}
 
 \begin{proof}
     \leanok
     Apply the three-site translated parent-term identities to \(q_2(A)\), and
-    replace \(q_2(A)\) by \(Q_{AX}\) or \(Q_{XB}\) using the preceding
-    two-site identifications.
+    replace \(q_2(A)\) by \(\widehat Q_{AX}\) or \(\widehat Q_{XB}\) using the
+    preceding two-site identifications.
 \end{proof}
 
 \begin{lemma}[Appendix B overlapping condition gives three-site parent-term commutation]
@@ -1011,14 +1020,14 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapping}
     \leanok
     \uses{lem:appendixB_three_site_parent_lifts}
-    If the Appendix~B $AX$ and $XB$ projectors satisfy the overlapping
-    two-site commutation datum
+    If the Appendix~B \(AX\) and \(XB\) coefficient representatives satisfy the
+    overlapping two-site commutation datum
     \[
-        Q_{AX}^2=Q_{AX},\qquad
-        Q_{XB}^2=Q_{XB},\qquad
-        (Q_{AX})_{AX}(Q_{XB})_{XB}
+        \widehat Q_{AX}^2=\widehat Q_{AX},\qquad
+        \widehat Q_{XB}^2=\widehat Q_{XB},\qquad
+        (\widehat Q_{AX})_{AX}(\widehat Q_{XB})_{XB}
         =
-        (Q_{XB})_{XB}(Q_{AX})_{AX},
+        (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX},
     \]
     then the corresponding first two translated length-two parent terms on the
     three-site window commute:
@@ -1032,9 +1041,9 @@ the specialization $L=2$.
 \begin{proof}
     \leanok
     By Lemma~\ref{lem:appendixB_three_site_parent_lifts}, the two translated
-    parent terms are exactly the $AX$ and $XB$ lifts of $Q_{AX}$ and
-    $Q_{XB}$.  The displayed equality is therefore the commutation clause of
-    the overlapping two-site datum.
+    parent terms are exactly the \(AX\) and \(XB\) lifts of
+    \(\widehat Q_{AX}\) and \(\widehat Q_{XB}\).  The displayed equality is
+    therefore the commutation clause of the overlapping two-site datum.
 \end{proof}
 
 \begin{lemma}[Appendix B lifted commutator gives three-site parent-term commutation]
@@ -1044,12 +1053,12 @@ the specialization $L=2$.
     \leanok
     \uses{lem:appendixB_overlapping_condition_from_lift_commutator,
         lem:appendixB_overlapping_condition_parent_terms}
-    If the Appendix~B $AX$ and $XB$ projectors satisfy the lifted
+    If the Appendix~B \(AX\) and \(XB\) coefficient representatives satisfy the lifted
     Definition~D.2 commutator
     \[
-        (Q_{AX})_{AX}(Q_{XB})_{XB}
+        (\widehat Q_{AX})_{AX}(\widehat Q_{XB})_{XB}
         =
-        (Q_{XB})_{XB}(Q_{AX})_{AX},
+        (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX},
     \]
     then the corresponding first two translated length-two parent terms on the
     three-site window commute:
@@ -1186,17 +1195,20 @@ the specialization $L=2$.
         q_L(A)=q_L(\Lambda U).
     \]
     At length two, the Appendix~B two-site basic support is
-    \(G_2(\Lambda U)\), and the corresponding \(Q_{AX}\) and \(Q_{XB}\)
-    projectors are the two copies of \(q_2(\Lambda U)\) before they are lifted
-    to the \(AX\) and \(XB\) faces. Hence
+    \(G_2(\Lambda U)\), and the coefficient-space representatives
+    \(\widehat Q_{AX}\) and \(\widehat Q_{XB}\) are the two copies of
+    \(q_2(\Lambda U)\) before they are lifted to the \(AX\) and \(XB\) faces.
+    Hence
     \[
-        Q_{AX}=q_2(A),\qquad Q_{XB}=q_2(A),
+        \widehat Q_{AX}=q_2(A),\qquad \widehat Q_{XB}=q_2(A),
     \]
-    as two-site operators in this coefficient-space representation. On the
-    three-site window this gives the local identifications
+    as two-site operators in this coefficient-space representation. This is not
+    yet the construction of the source projectors \(Q_{AX}\) and \(Q_{XB}\) on
+    \(H_A\otimes H_X\) and \(H_X\otimes H_B\). On the three-site window the
+    coefficient representatives give the local identifications
     \[
-        h_0^{(3)}(A,2)=(Q_{AX})_{AX},\qquad
-        h_1^{(3)}(A,2)=(Q_{XB})_{XB}.
+        h_0^{(3)}(A,2)=(\widehat Q_{AX})_{AX},\qquad
+        h_1^{(3)}(A,2)=(\widehat Q_{XB})_{XB}.
     \]
     Consequently, for every chain length \(L\geq1\), the original tensor has
     the same cyclic coefficient formula:
@@ -1240,9 +1252,15 @@ the specialization $L=2$.
     Appendix~B supplies the basic-vector expression, while Appendix~D.2 supplies
     the parent-commuting projector condition. The local two-site projector
     identification above does not prove the overlapping commutation relation
-    $Q_{AX}Q_{XB}=Q_{XB}Q_{AX}$. For the all-chain statement, the remaining
-    local projector equation is the following commutation condition: for every
-    finite chain and every pair of sites $i,j$,
+    \[
+        (\widehat Q_{AX})_{AX}(\widehat Q_{XB})_{XB}
+        =
+        (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX}.
+    \]
+    Nor does it construct the source \(Q_{AX},Q_{XB}\) projectors on the
+    tripartite Hilbert space. For the all-chain statement, the remaining local
+    projector equation is the following commutation condition: for every finite
+    chain and every pair of sites $i,j$,
     \[
         h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2).
     \]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -909,9 +909,9 @@ the specialization $L=2$.
         \widehat Q_{AX}=q_2(A_{\mathrm{core}}).
     \]
     The source projector \(Q_{AX}\) of Definition~D.2 acts on
-    \(H_A\otimes H_X\).  The displayed operator is the two-site coefficient
-    representative that will be placed on the \(AX\) face; it is not by itself
-    the construction of that source projector.
+    \(\mathcal H_A\otimes\mathcal H_X\).  The displayed operator is the
+    two-site coefficient representative that will be placed on the \(AX\) face;
+    it is not by itself the construction of that source projector.
 \end{definition}
 
 \begin{definition}[Appendix B \(XB\) coefficient representative]
@@ -925,8 +925,8 @@ the specialization $L=2$.
         \widehat Q_{XB}=\widehat Q_{AX}.
     \]
     The source projector \(Q_{XB}\) of Definition~D.2 acts on
-    \(H_X\otimes H_B\).  The displayed operator is the coefficient
-    representative later placed on the \(XB\) face.
+    \(\mathcal H_X\otimes\mathcal H_B\).  The displayed operator is the
+    coefficient representative later placed on the \(XB\) face.
 \end{definition}
 
 \begin{lemma}[Appendix B coefficient representatives and the parent interaction]
@@ -1204,7 +1204,8 @@ the specialization $L=2$.
     \]
     as two-site operators in this coefficient-space representation. This is not
     yet the construction of the source projectors \(Q_{AX}\) and \(Q_{XB}\) on
-    \(H_A\otimes H_X\) and \(H_X\otimes H_B\). On the three-site window the
+    \(\mathcal H_A\otimes\mathcal H_X\) and
+    \(\mathcal H_X\otimes\mathcal H_B\). On the three-site window the
     coefficient representatives give the local identifications
     \[
         h_0^{(3)}(A,2)=(\widehat Q_{AX})_{AX},\qquad

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -55,15 +55,17 @@ canonical form notation, while $b$ follows
 Cirac et al. describe the degenerate parent-Hamiltonian ground space for a
 matrix product state with more than one block in canonical form in Section~IV.C
 of \cite{Cirac2021Matrix}.\footnote{For
-	traceability, the source comparison is now proved on the main branch
-	(\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean}); the
-	remaining step, discharging the explicit comparison hypothesis still assumed
-	by the conditional theorems, is tracked by
+	traceability, the boundary-crossing comparison has a formal span-dependent
+	form on the main branch
+	(\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean} and
+	\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean}).
+	The remaining step is to replace the short crossing-tail span hypothesis by
+	the source \(C^j,D^j,E^j\) boundary-condition comparison; this is tracked by
 	\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} (the earlier
 	tracker \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971} for
-	proving the comparison is now closed). Pull
-	request~\#2724 records the conditional reduction on the main branch, reducing
-	the unconditional target to the boundary-crossing comparison identities.
+	the first comparison extraction is now closed). Pull
+	request~\#2724 records the earlier conditional reduction on the main branch,
+	reducing the unconditional target to boundary-crossing comparison identities.
 	Earlier reductions were tracked by
 	\href{https://github.com/LionSR/TNLean/issues/2641}{issue \#2641},
 	\href{https://github.com/LionSR/TNLean/issues/905}{issue \#905}, and

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -59,11 +59,11 @@ of \cite{Cirac2021Matrix}.\footnote{For
 	form on the main branch
 	(\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalCrossingTrace.lean} and
 	\path{TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean}).
-	The remaining step is to replace the short crossing-tail span hypothesis by
-	the source \(C^j,D^j,E^j\) boundary-condition comparison; this is tracked by
-	\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} (the earlier
-	tracker \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971} for
-	the first comparison extraction is now closed). Pull
+		The remaining step is to replace the short crossing-tail span hypothesis by
+		the source \(C^j,D^j,E^j\) boundary-condition comparison; this is tracked by
+		\href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597} (the earlier
+		tracker \href{https://github.com/LionSR/TNLean/issues/2971}{issue \#2971}, which
+		tracked proving the boundary-crossing comparison itself, is now closed). Pull
 	request~\#2724 records the earlier conditional reduction on the main branch,
 	reducing the unconditional target to boundary-crossing comparison identities.
 	Earlier reductions were tracked by

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -118,12 +118,15 @@ Appendix~B supplies the basic-vector form, while the projectors
 condition.  The coefficient-space representatives
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAX} and
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXB} are now identified with
-the canonical two-site parent interaction, and their lifted commutator has been
-transported to the first two translated three-site parent terms.  The remaining
-local step is to construct the source Appendix~D.2 data from the Appendix~B
-basic-vector form, prove the lifted \(AX/XB\) commutator, and extend the local
-transport to the all-chain family of two-site parent projectors.  On the
-coefficient side, the source statement is the basic-vector formula
+the canonical two-site parent interaction \(q_2(A)\) before placement on the
+\(AX\) and \(XB\) faces.  They should not be read as the source tripartite
+projectors themselves.  A supplied lifted commutator for these representatives
+has been transported to the first two translated three-site parent terms.  The
+remaining local step is to construct the source Appendix~D.2 data from the
+Appendix~B basic-vector form, relate its \(Q_{AX},Q_{XB}\) projectors to these
+coefficient representatives, prove the lifted \(AX/XB\) commutator, and extend
+the local transport to the all-chain family of two-site parent projectors.  On
+the coefficient side, the source statement is the basic-vector formula
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), where
 \(\varphi_j\) is shared between neighboring virtual spins.  The current
 disjoint adjacent-pair condition is a separate conditional statement and should

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -83,12 +83,16 @@ available in both conventions: directly for \(Q_{AX},Q_{XB}\) through
 \leanid{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2}, and for
 their complements through
 \leanid{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2_complement}.
-For the Appendix~B structural datum itself, the coefficient-space
+For the Appendix~B structural datum itself, the current coefficient-space
 representatives are
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAX} and
-\leanid{MPSTensor.AppendixBStructuralData.appendixBQXB}; they are identified
-with the canonical two-site parent interaction, and the supplied lifted
-commutator or supplied Definition~D.2 datum is transported to the corresponding
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQXB}; both are identified
+with the canonical two-site parent interaction \(q_2(A)\) before placement on
+the \(AX\) and \(XB\) faces.  These representatives are not yet the source
+orthogonal projectors \(Q_{AX}\) and \(Q_{XB}\) on
+\(\mathcal H_A\otimes\mathcal H_X\) and
+\(\mathcal H_X\otimes\mathcal H_B\).  A supplied lifted commutator or supplied
+Definition~D.2 datum for the representatives is transported to the corresponding
 three-site translated parent terms by
 \leanid{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_lifts}
 and
@@ -99,9 +103,10 @@ and
 A source-faithful version should build on the existing \(AX/XB\) support layer
 by constructing the local subspaces \(K_{AX}\) and \(K_{XB}\), the corresponding
 orthogonal projectors \(Q_{AX}\) and \(Q_{XB}\), and the source
-orthogonal-projector hypotheses from the Appendix~B data.  From those
-hypotheses it should derive the idempotent-product declaration above as a
-lemma, with \(P_K=P_{AXB}\).
+orthogonal-projector hypotheses from the Appendix~B data.  It should then
+explain why their coefficient representatives are the two lifted copies of
+\(q_2(A)\), prove the lifted commutator, and derive the idempotent-product
+declaration above as a lemma, with \(P_K=P_{AXB}\).
 
 After that source-level version is available, the blueprint entry for the source
 parent commuting Hamiltonian condition should point to that statement.  The


### PR DESCRIPTION
### Motivation

- The Lean module `CommutingBridge` and related blueprint entries were conflating two mathematically distinct objects: the coefficient-space representatives $\widehat{Q}_{AX}$, $\widehat{Q}_{XB}$ (the two-site parent interaction $q_2(A)$ placed on the $AX$ and $XB$ faces) with the source Definition D.2 projectors $Q_{AX}$, $Q_{XB}$ (acting on $H_A \otimes H_X$ and $H_X \otimes H_B$ respectively). This deviation is tracked in #3373 (arXiv:1606.00608, §3.3, Appendix B, Definition D.2).
- The PGVWC block-diagonal ground-space prose was presenting the crossing-span equality as the unconditional source theorem, without noting that the Lean theorem is conditional on the visible tail-word span hypothesis. This deviation is tracked in #3597.
- Both mismatches require explicit documentation of the source-faithfulness boundary and elimination plan per `docs/PROOF_INTEGRITY.md`.

### Description

- `TNLean/MPS/RFP/CommutingBridge.lean`: updates module docstrings to describe `appendixBQAX` and `appendixBQXB` as coefficient-space representatives $\widehat{Q}_{AX}$, $\widehat{Q}_{XB}$ identified with $q_2(A)$ before $AX$/$XB$ lifts, not as the source D.2 projectors $Q_{AX}$, $Q_{XB}$.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: blueprint definitions and lemmas adopt hat notation; the elimination plan is now explicit — construct the D.2 subspaces/projectors from Appendix B, relate them to the coefficient representatives, prove the lifted commutator, then transport to the all-chain local projectors.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`: qualifies the current block-diagonal ground-space theorem as the span-dependent crossing-span version, not the unconditioned source statement.
- `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`, `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`, `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: elimination plans updated to be explicit.
- No Lean proofs or executable definitions change; all edits are to docstrings, blueprint prose, and paper-gap notes.

### Testing

- `lake build TNLean.MPS.RFP.CommutingBridge`
- `lake build TNLean`
- `leanblueprint checkdecls`
- `lake exe lint_style --github`

---
Refs #3373
Refs #3597

> [!NOTE]
> **Low Risk**
> Comment and documentation edits only; no executable Lean or proof logic changes.
> 
> **Overview**
> Documentation-only alignment around **source-faithfulness** for parent-Hamiltonian commuting arguments. No Lean definitions or proofs change; only module docstrings, blueprint prose, and paper-gap notes.
> 
> **Appendix B / Definition D.2:** `appendixBQAX` and `appendixBQXB` are now described as two-site **coefficient-space representatives** \(\widehat Q_{AX}\), \(\widehat Q_{XB}\) (both \(q_2(A)\) before \(AX\)/\(XB\) lifts), not as the tripartite source projectors \(Q_{AX}\), \(Q_{XB}\) on \(H_A\otimes H_X\) and \(H_X\otimes H_B\). Blueprint definitions and lemmas use the hat notation; remaining work is explicitly **construct** D.2 projectors, **relate** them to these representatives, and **prove** the lifted commutator.
> 
> **PGVWC block-diagonal ground space:** Prose now states that the crossing-span equality is **conditional** on the visible tail-word span hypothesis and the **longer** Lean injectivity range, with source-faithful replacement of that hypothesis tracked separately (issue #3597).
> 
> **Paper-gap trackers** (`cpsv16_*`, `cpgsv21_*`) are updated to match the elimination plans above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842d7097e47830b5081b4758b7e7bf40db6f7281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment, blueprint, and paper-gap edits only; no executable Lean or proof logic changes.
> 
> **Overview**
> **Documentation-only** alignment for source-faithfulness (#3373, #3597). No Lean definitions or proofs change.
> 
> **Appendix B / Definition D.2:** `appendixBQAX` and `appendixBQXB` are now described as two-site **coefficient-space representatives** \(\widehat Q_{AX}\), \(\widehat Q_{XB}\) (both \(q_2(A)\) before \(AX\)/\(XB\) lifts), not as tripartite source projectors \(Q_{AX}\), \(Q_{XB}\). Matching updates in `CommutingBridge.lean` docstrings, blueprint (`ch13_parent_hamiltonian_commuting_gap.tex`), and `cpsv16_*` paper-gap notes; remaining work is explicitly to **construct** D.2 projectors, **relate** them to these representatives, and **prove** the lifted commutator.
> 
> **PGVWC block-diagonal ground space:** Blueprint and `cpgsv21_block_diagonal_parent_ground_space.tex` now state that the crossing-span equality is **conditional** on the visible tail-word span hypothesis and the **longer** Lean injectivity range, with unconditional source replacement tracked in #3597.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1733547cbd5a0322de7dd6291212a46c0f23b187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->