### PR TITLE
doc(parent): align Appendix B representative prose

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -920,7 +920,7 @@ the specialization $L=2$.
     \leanok
     \uses{def:appendixB_qax}
     The \(XB\) coefficient-space representative is, before the \(XB\)-lift, the
-    same two-site operator:
+    same coefficient-space representative:
     \[
         \widehat Q_{XB}=\widehat Q_{AX}.
     \]
@@ -936,7 +936,7 @@ the specialization $L=2$.
     \leanok
     \uses{lem:appendixB_basis_change_parent_interaction, def:appendixB_qax,
         def:appendixB_qxb}
-    As two-site operators in the coefficient-space representation,
+    As coefficient-space representatives,
     \[
         \widehat Q_{AX}=q_2(A),\qquad \widehat Q_{XB}=q_2(A).
     \]
@@ -993,7 +993,7 @@ the specialization $L=2$.
     displayed lifted commutator.
 \end{proof}
 
-\begin{lemma}[Three-site lifts of the Appendix B two-site operators]
+\begin{lemma}[Three-site lifts of the Appendix B coefficient representatives]
     \label{lem:appendixB_three_site_parent_lifts}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_eq_leftPairLift_appendixBQAX}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_one_eq_rightPairLift_appendixBQXB}
@@ -1202,8 +1202,8 @@ the specialization $L=2$.
     \[
         \widehat Q_{AX}=q_2(A),\qquad \widehat Q_{XB}=q_2(A),
     \]
-    as two-site operators in this coefficient-space representation. This is not
-    yet the construction of the source projectors \(Q_{AX}\) and \(Q_{XB}\) on
+    as coefficient-space representatives. This is not yet the construction of
+    the source projectors \(Q_{AX}\) and \(Q_{XB}\) on
     \(\mathcal H_A\otimes\mathcal H_X\) and
     \(\mathcal H_X\otimes\mathcal H_B\). On the three-site window the
     coefficient representatives give the local identifications


### PR DESCRIPTION
### Motivation
- The blueprint prose for Appendix B in `ch13_parent_hamiltonian_commuting_gap.tex` described the coefficient representatives $\widehat Q_{AX}$ and $\widehat Q_{XB}$ as "two-site operators", blurring the distinction between these coefficient-space objects and the source projectors $Q_{AX}$, $Q_{XB}$ from arXiv:1606.00608, Appendix B.
- Consistent terminology is needed so the blueprint accurately reflects that $\widehat Q_{AX}$ and $\widehat Q_{XB}$ are coefficient-space representatives, not yet the source projectors, as the formalization in #3373 works toward identifying them.

### Description
- Modified `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex` (5 additions, 5 deletions): blueprint prose only.
- Replaced "two-site operator" with "coefficient-space representative" for $\widehat Q_{AX}$ and $\widehat Q_{XB}$ in the $XB$-definition sentence, the parent-interaction lemma, the three-site lift lemma heading, and the basic-vector remark.
- Added a line break so the disclaimer that these are not yet the source projectors $Q_{AX}$, $Q_{XB}$ reads as a separate sentence.
- No Lean declarations or theorem statements changed.

### Testing
- `lake exe cache get`
- `lake build TNLean`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `lake exe lint_style --github`
- Stale-phrase scan for the edited chapter confirms no remaining "two-site operator" misuse.

---
Addresses #3373
Refs #190

> [!NOTE]
> **Low Risk**
> Documentation-only edits to blueprint LaTeX; no formal statements or code behavior change.
>
> **Overview**
> Blueprint prose in `ch13_parent_hamiltonian_commuting_gap.tex` is updated so Appendix B $\widehat Q_{AX}$ and $\widehat Q_{XB}$ are consistently described as **coefficient-space representatives**, not as generic **two-site operators** in the coefficient representation.
>
> The $XB$ definition now says $\widehat Q_{XB}$ is the same coefficient-space representative as $\widehat Q_{AX}$ (not the same two-site operator). Matching wording appears in the parent-interaction lemma, the three-site lift lemma title, and the basic-vector remark, including a line break so the disclaimer that these are not yet the source projectors $Q_{AX}, Q_{XB}$ reads more clearly.
>
> **Lean declarations and theorem statements are unchanged**—only LaTeX narrative and one lemma heading.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f2637c99e4fc889eb0fdf50566479c603cd4f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>