### PR TITLE
refactor(MPS/RFP): rename Appendix B coefficient representatives

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -421,7 +421,7 @@ the source projector \(Q_{AX}\) as an operator on
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
-noncomputable def AppendixBStructuralData.appendixBQAX {A : MPSTensor d D}
+noncomputable def AppendixBStructuralData.appendixBQAXOnCoeffSpace {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
   parentInteraction hStruct.coreTensor 2
 
@@ -435,19 +435,19 @@ itself, a construction of the source projector \(Q_{XB}\) as an operator on
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
-noncomputable def AppendixBStructuralData.appendixBQXB {A : MPSTensor d D}
+noncomputable def AppendixBStructuralData.appendixBQXBOnCoeffSpace {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
-  hStruct.appendixBQAX
+  hStruct.appendixBQAXOnCoeffSpace
 
 /-- The Appendix B \(AX\) coefficient representative is the canonical two-site
 parent interaction of the original tensor.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
-theorem AppendixBStructuralData.appendixBQAX_eq_parentInteraction {A : MPSTensor d D}
+theorem AppendixBStructuralData.appendixBQAXOnCoeffSpace_eq_parentInteraction {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) :
-    hStruct.appendixBQAX = parentInteraction A 2 := by
-  rw [AppendixBStructuralData.appendixBQAX]
+    hStruct.appendixBQAXOnCoeffSpace = parentInteraction A 2 := by
+  rw [AppendixBStructuralData.appendixBQAXOnCoeffSpace]
   exact (hStruct.parentInteraction_eq_coreTensor 2).symm
 
 /-- The Appendix B \(XB\) coefficient representative is the canonical two-site
@@ -455,30 +455,32 @@ parent interaction of the original tensor.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
-theorem AppendixBStructuralData.appendixBQXB_eq_parentInteraction {A : MPSTensor d D}
+theorem AppendixBStructuralData.appendixBQXBOnCoeffSpace_eq_parentInteraction {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) :
-    hStruct.appendixBQXB = parentInteraction A 2 := by
-  rw [AppendixBStructuralData.appendixBQXB]
-  exact hStruct.appendixBQAX_eq_parentInteraction
+    hStruct.appendixBQXBOnCoeffSpace = parentInteraction A 2 := by
+  rw [AppendixBStructuralData.appendixBQXBOnCoeffSpace]
+  exact hStruct.appendixBQAXOnCoeffSpace_eq_parentInteraction
 
 /-- The Appendix B \(AX\) two-site coefficient representative is idempotent.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
-theorem AppendixBStructuralData.appendixBQAX_idempotent {A : MPSTensor d D}
+theorem AppendixBStructuralData.appendixBQAXOnCoeffSpace_idempotent {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) :
-    hStruct.appendixBQAX * hStruct.appendixBQAX = hStruct.appendixBQAX := by
-  rw [hStruct.appendixBQAX_eq_parentInteraction]
+    hStruct.appendixBQAXOnCoeffSpace * hStruct.appendixBQAXOnCoeffSpace =
+      hStruct.appendixBQAXOnCoeffSpace := by
+  rw [hStruct.appendixBQAXOnCoeffSpace_eq_parentInteraction]
   exact parentInteraction_idempotent A 2
 
 /-- The Appendix B \(XB\) two-site coefficient representative is idempotent.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
-theorem AppendixBStructuralData.appendixBQXB_idempotent {A : MPSTensor d D}
+theorem AppendixBStructuralData.appendixBQXBOnCoeffSpace_idempotent {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) :
-    hStruct.appendixBQXB * hStruct.appendixBQXB = hStruct.appendixBQXB := by
-  rw [hStruct.appendixBQXB_eq_parentInteraction]
+    hStruct.appendixBQXBOnCoeffSpace * hStruct.appendixBQXBOnCoeffSpace =
+      hStruct.appendixBQXBOnCoeffSpace := by
+  rw [hStruct.appendixBQXBOnCoeffSpace_eq_parentInteraction]
   exact parentInteraction_idempotent A 2
 
 /-- The Appendix B two-site coefficient representatives satisfy the algebraic
@@ -493,12 +495,14 @@ Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lifts
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (hcomm :
-      leftPairLift hStruct.appendixBQAX * rightPairLift hStruct.appendixBQXB =
-        rightPairLift hStruct.appendixBQXB * leftPairLift hStruct.appendixBQAX) :
-    HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAX
-      hStruct.appendixBQXB where
-  left_idempotent := hStruct.appendixBQAX_idempotent
-  right_idempotent := hStruct.appendixBQXB_idempotent
+      leftPairLift hStruct.appendixBQAXOnCoeffSpace *
+          rightPairLift hStruct.appendixBQXBOnCoeffSpace =
+        rightPairLift hStruct.appendixBQXBOnCoeffSpace *
+          leftPairLift hStruct.appendixBQAXOnCoeffSpace) :
+    HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAXOnCoeffSpace
+      hStruct.appendixBQXBOnCoeffSpace where
+  left_idempotent := hStruct.appendixBQAXOnCoeffSpace_idempotent
+  right_idempotent := hStruct.appendixBQXBOnCoeffSpace_idempotent
   commute_lifts := hcomm
 
 /-- On a three-site window, the first translated length-two parent term is the
@@ -506,22 +510,22 @@ theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lift
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
-theorem AppendixBStructuralData.localTerm_two_three_zero_eq_leftPairLift_appendixBQAX
+theorem AppendixBStructuralData.localTerm_two_three_zero_eq_appendixBQAXOnCoeffSpace_lift
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
-    localTerm A 2 3 (0 : Fin 3) = leftPairLift hStruct.appendixBQAX := by
+    localTerm A 2 3 (0 : Fin 3) = leftPairLift hStruct.appendixBQAXOnCoeffSpace := by
   rw [localTerm_two_three_zero_eq_leftPairLift_parentInteraction,
-    hStruct.appendixBQAX_eq_parentInteraction]
+    hStruct.appendixBQAXOnCoeffSpace_eq_parentInteraction]
 
 /-- On a three-site window, the second translated length-two parent term is the
 \(XB\) lift of the Appendix B \(XB\) coefficient representative.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
-theorem AppendixBStructuralData.localTerm_two_three_one_eq_rightPairLift_appendixBQXB
+theorem AppendixBStructuralData.localTerm_two_three_one_eq_appendixBQXBOnCoeffSpace_lift
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
-    localTerm A 2 3 (1 : Fin 3) = rightPairLift hStruct.appendixBQXB := by
+    localTerm A 2 3 (1 : Fin 3) = rightPairLift hStruct.appendixBQXBOnCoeffSpace := by
   rw [localTerm_two_three_one_eq_rightPairLift_parentInteraction,
-    hStruct.appendixBQXB_eq_parentInteraction]
+    hStruct.appendixBQXBOnCoeffSpace_eq_parentInteraction]
 
 /-- The algebraic overlapping condition for the Appendix B two-site coefficient
 representatives transports to commutation of the first two three-site parent
@@ -536,12 +540,12 @@ Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
 theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapping
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
-    (h : HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAX
-      hStruct.appendixBQXB) :
+    (h : HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAXOnCoeffSpace
+      hStruct.appendixBQXBOnCoeffSpace) :
     localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
       localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) := by
-  rw [hStruct.localTerm_two_three_zero_eq_leftPairLift_appendixBQAX,
-    hStruct.localTerm_two_three_one_eq_rightPairLift_appendixBQXB]
+  rw [hStruct.localTerm_two_three_zero_eq_appendixBQAXOnCoeffSpace_lift,
+    hStruct.localTerm_two_three_one_eq_appendixBQXBOnCoeffSpace_lift]
   exact h.commute_lifts
 
 /-- If the lifted Appendix B \(AX\) and \(XB\) coefficient representatives
@@ -556,8 +560,10 @@ Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_lifts
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     (hcomm :
-      leftPairLift hStruct.appendixBQAX * rightPairLift hStruct.appendixBQXB =
-        rightPairLift hStruct.appendixBQXB * leftPairLift hStruct.appendixBQAX) :
+      leftPairLift hStruct.appendixBQAXOnCoeffSpace *
+          rightPairLift hStruct.appendixBQXBOnCoeffSpace =
+        rightPairLift hStruct.appendixBQXBOnCoeffSpace *
+          leftPairLift hStruct.appendixBQAXOnCoeffSpace) :
     localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
       localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) :=
   hStruct.localTerm_two_three_zero_one_commute_of_overlapping
@@ -577,7 +583,7 @@ theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendix
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
     {KAXB : Submodule ℂ (NSiteSpace d 3)}
     (hD2 : HasAppendixD2ParentCommutingHamiltonian
-      (d := d) KAXB hStruct.appendixBQAX hStruct.appendixBQXB) :
+      (d := d) KAXB hStruct.appendixBQAXOnCoeffSpace hStruct.appendixBQXBOnCoeffSpace) :
     localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
       localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) :=
   hStruct.localTerm_two_three_zero_one_commute_of_overlapping hD2.to_overlapping

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -900,7 +900,7 @@ the specialization $L=2$.
 
 \begin{definition}[Appendix B \(AX\) coefficient representative]
     \label{def:appendixB_qax}
-    \lean{MPSTensor.AppendixBStructuralData.appendixBQAX}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace}
     \leanok
     \uses{def:appendixB_two_site_basic_space, def:parent_interaction}
     The \(AX\) coefficient-space representative is, before the \(AX\)-lift,
@@ -916,7 +916,7 @@ the specialization $L=2$.
 
 \begin{definition}[Appendix B \(XB\) coefficient representative]
     \label{def:appendixB_qxb}
-    \lean{MPSTensor.AppendixBStructuralData.appendixBQXB}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace}
     \leanok
     \uses{def:appendixB_qax}
     The \(XB\) coefficient-space representative is, before the \(XB\)-lift, the
@@ -931,8 +931,8 @@ the specialization $L=2$.
 
 \begin{lemma}[Appendix B coefficient representatives and the parent interaction]
     \label{lem:appendixB_qax_qxb_parent_interaction}
-    \lean{MPSTensor.AppendixBStructuralData.appendixBQAX_eq_parentInteraction}
-    \lean{MPSTensor.AppendixBStructuralData.appendixBQXB_eq_parentInteraction}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace_eq_parentInteraction}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace_eq_parentInteraction}
     \leanok
     \uses{lem:appendixB_basis_change_parent_interaction, def:appendixB_qax,
         def:appendixB_qxb}
@@ -950,8 +950,8 @@ the specialization $L=2$.
 
 \begin{lemma}[Appendix B two-site representative idempotents]
     \label{lem:appendixB_qax_qxb_idempotent}
-    \lean{MPSTensor.AppendixBStructuralData.appendixBQAX_idempotent}
-    \lean{MPSTensor.AppendixBStructuralData.appendixBQXB_idempotent}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace_idempotent}
+    \lean{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace_idempotent}
     \leanok
     \uses{lem:parent_interaction_idempotent,
         lem:appendixB_qax_qxb_parent_interaction}
@@ -995,8 +995,8 @@ the specialization $L=2$.
 
 \begin{lemma}[Three-site lifts of the Appendix B coefficient representatives]
     \label{lem:appendixB_three_site_parent_lifts}
-    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_eq_leftPairLift_appendixBQAX}
-    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_one_eq_rightPairLift_appendixBQXB}
+    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_eq_appendixBQAXOnCoeffSpace_lift}
+    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_one_eq_appendixBQXBOnCoeffSpace_lift}
     \leanok
     \uses{thm:local_term_two_three_ax_xb_lifts,
         lem:appendixB_qax_qxb_parent_interaction}
@@ -1068,7 +1068,7 @@ the specialization $L=2$.
         h_1^{(3)}(A,2)h_0^{(3)}(A,2).
     \]
     The same conclusion holds if the full Definition~D.2 local data are given
-    for these two Appendix~B projectors.
+    for these two coefficient-space representatives.
 \end{lemma}
 
 \begin{proof}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -116,8 +116,8 @@ are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
 Appendix~B supplies the basic-vector form, while the projectors
 \(Q_{AX}\) and \(Q_{XB}\) belong to the Appendix~D.2 parent-commuting
 condition.  The coefficient-space representatives
-\leanid{MPSTensor.AppendixBStructuralData.appendixBQAX} and
-\leanid{MPSTensor.AppendixBStructuralData.appendixBQXB} are now identified with
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace} are now identified with
 the canonical two-site parent interaction \(q_2(A)\) before placement on the
 \(AX\) and \(XB\) faces.  They should not be read as the source tripartite
 projectors themselves.  A supplied lifted commutator for these representatives

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -85,8 +85,8 @@ their complements through
 \leanid{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2_complement}.
 For the Appendix~B structural datum itself, the current coefficient-space
 representatives are
-\leanid{MPSTensor.AppendixBStructuralData.appendixBQAX} and
-\leanid{MPSTensor.AppendixBStructuralData.appendixBQXB}; both are identified
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
+\leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace}; both are identified
 with the canonical two-site parent interaction \(q_2(A)\) before placement on
 the \(AX\) and \(XB\) faces.  These representatives are not yet the source
 orthogonal projectors \(Q_{AX}\) and \(Q_{XB}\) on


### PR DESCRIPTION
### Motivation

- The declarations `appendixBQAX` and `appendixBQXB` in `CommutingBridge.lean`
  were named for the source projectors from arXiv:1606.00608, §3.3 and Appendix B,
  but actually define their *coefficient-space representatives*, not the projectors
  themselves. This naming ambiguity obscures the distinction between the source
  projectors and their coefficient-space lifts required by Definition D.2, making
  the formalization harder to audit against the paper.
- Part of the ongoing alignment of `MPS/RFP/CommutingBridge.lean` with
  arXiv:1606.00608 Appendix B and Definition D.2; see #3373.

### Description

- Renames `appendixBQAX` → `appendixBQAXOnCoeffSpace` and `appendixBQXB` →
  `appendixBQXBOnCoeffSpace` in `TNLean/MPS/RFP/CommutingBridge.lean`, together
  with all dependent idempotency, parent-interaction, lift, and commutation
  theorems referencing these declarations.
- Updates `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`:
  renames `\lean{...}` tags to match new declaration names; adds a note clarifying
  that the Definition D.2 local data apply to the coefficient-space representatives,
  not the source projectors.
- Updates `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` and
  `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`: renames
  `\leanid{...}` references to the new declaration names.
- No mathematical content is changed; only declaration names are updated.
- **No compatibility alias is provided.** The old names conflate the source
  projectors with their coefficient-space representatives — a conceptual ambiguity,
  not merely imprecise terminology
  (see [`docs/CONTRIBUTING.md` §Mathematical-language renames](../blob/main/docs/CONTRIBUTING.md#mathematical-language-renames)).

### Testing

- `lake build TNLean`
- `lake exe lint_style --github`
- `cd blueprint && leanblueprint web`
- `cd blueprint && leanblueprint checkdecls`
- `git diff --check`
- Stale-name scan for old `appendixBQAX` / `appendixBQXB` references confirmed clean.

---
Addresses #3373
Refs #190

> [!NOTE]
> **Low Risk**
> Naming and documentation alignment only; theorem proofs and statements are unchanged aside from identifiers.
> 
> **Overview**
> **Renames** the Appendix B two-site operators in `CommutingBridge.lean` from `appendixBQAX` / `appendixBQXB` to **`appendixBQAXOnCoeffSpace`** and **`appendixBQXBOnCoeffSpace`**, with matching renames for the idempotency, parent-interaction, lift, and commutation theorems that reference them.
> 
> **Syncs** blueprint `\lean{...}` tags in `ch13_parent_hamiltonian_commuting_gap.tex` and `\leanid{...}` pointers in the NNCPH and parent-commuting scope docs to the new names. One blueprint lemma note now says Definition D.2 local data apply to **coefficient-space representatives**, not the source projectors.
> 
> No mathematical content changes beyond declaration names; no deprecated aliases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a285b7f3cfa48e1ca20cccae5f439b4d63861d4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>