### PR TITLE
feat(Channel): add Choi-type rank-one positivity reduction

### DIFF
--- a/TNLean/Algebra/MatrixAux.lean
+++ b/TNLean/Algebra/MatrixAux.lean
@@ -45,6 +45,26 @@ open scoped Matrix BigOperators ComplexOrder Kronecker Matrix.Norms.Frobenius
 
 namespace Matrix
 
+section RankOneQuadratic
+
+variable {ι : Type*} [Fintype ι]
+
+/-- The quadratic form of a rank-one outer product `vecMulVec a b` reads off as
+`(b ⬝ᵥ w)((conj w) ⬝ᵥ a)`. -/
+theorem star_dotProduct_vecMulVec_mulVec (a b w : ι → ℂ) :
+    star w ⬝ᵥ (Matrix.vecMulVec a b *ᵥ w) = (b ⬝ᵥ w) * (star w ⬝ᵥ a) := by
+  have lhs : star w ⬝ᵥ (Matrix.vecMulVec a b *ᵥ w)
+      = ∑ i, ∑ j, star (w i) * a i * b j * w j := by
+    simp only [dotProduct, Matrix.mulVec, Matrix.vecMulVec_apply, Pi.star_apply, Finset.mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have rhs : (b ⬝ᵥ w) * (star w ⬝ᵥ a) = ∑ i, ∑ j, star (w i) * a i * b j * w j := by
+    simp only [dotProduct, Pi.star_apply]
+    rw [Finset.sum_mul_sum, Finset.sum_comm]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  rw [lhs, rhs]
+
+end RankOneQuadratic
+
 section FrobeniusTrace
 
 variable {m n : Type*} [Fintype m] [Fintype n]

--- a/TNLean/Channel/BreuerHallMap.lean
+++ b/TNLean/Channel/BreuerHallMap.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
 import Mathlib.Analysis.InnerProductSpace.PiL2
+import TNLean.Algebra.MatrixAux
 import TNLean.Channel.Basic
 import TNLean.Algebra.MatrixSpectralDecomp
 
@@ -131,22 +132,6 @@ theorem breuerHallMap_apply (U : Matrix (Fin d) (Fin d) ℂ) (X : Matrix (Fin d)
     breuerHallMap U X =
       Matrix.trace X • (1 : Matrix (Fin d) (Fin d) ℂ) - X - U * Xᵀ * Uᴴ :=
   rfl
-
-/-! ## Quadratic-form helper -/
-
-/-- The quadratic form of a rank-one outer product `vecMulVec a b` reads off as
-`(b ⬝ᵥ w)((conj w) ⬝ᵥ a)`. -/
-theorem star_dotProduct_vecMulVec_mulVec (a b w : Fin d → ℂ) :
-    star w ⬝ᵥ (Matrix.vecMulVec a b *ᵥ w) = (b ⬝ᵥ w) * (star w ⬝ᵥ a) := by
-  have lhs : star w ⬝ᵥ (Matrix.vecMulVec a b *ᵥ w)
-      = ∑ i, ∑ j, star (w i) * a i * b j * w j := by
-    simp only [dotProduct, Matrix.mulVec, Matrix.vecMulVec_apply, Pi.star_apply, Finset.mul_sum]
-    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
-  have rhs : (b ⬝ᵥ w) * (star w ⬝ᵥ a) = ∑ i, ∑ j, star (w i) * a i * b j * w j := by
-    simp only [dotProduct, Pi.star_apply]
-    rw [Finset.sum_mul_sum, Finset.sum_comm]
-    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
-  rw [lhs, rhs]
 
 /-! ## Positivity on rank-one outer products -/
 

--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -7,7 +7,6 @@ import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.Permutation
 import TNLean.Algebra.MatrixAux
-import TNLean.Channel.Basic
 
 /-!
 # Choi-type positive maps
@@ -31,7 +30,7 @@ proved here.
   Example 3.1, equation (3.20)][Wolf2012QChannels]
 -/
 
-open scoped Matrix ComplexOrder MatrixOrder InnerProductSpace
+open scoped Matrix ComplexOrder InnerProductSpace
 open Finset
 
 namespace Matrix
@@ -289,8 +288,8 @@ noncomputable def choiTypeRankOneWeight (d n : ℕ) [NeZero d] (v : ZMod d → �
 /-- Rank-one positivity of the Choi-type map reduced to the cyclic reciprocal
 bound for the diagonal weights.
 
-For Wolf's range \(1 \le n \le d-2\), the remaining scalar task is to prove the
-displayed bound for all vectors `v`. -/
+In the range \(n \le d-2\), the remaining scalar task is to prove the displayed
+bound for all vectors `v`. -/
 theorem choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one
     (n : ℕ) (v : ZMod d → ℂ) (hn₂ : n ≤ d - 2)
     (hbound : ∑ i, ‖v i‖ ^ 2 / choiTypeRankOneWeight d n v i ≤ 1) :

--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -3,8 +3,11 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
+import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.Permutation
+import TNLean.Algebra.MatrixAux
+import TNLean.Channel.Basic
 
 /-!
 # Choi-type positive maps
@@ -28,7 +31,7 @@ proved here.
   Example 3.1, equation (3.20)][Wolf2012QChannels]
 -/
 
-open scoped Matrix
+open scoped Matrix ComplexOrder MatrixOrder InnerProductSpace
 open Finset
 
 namespace Matrix
@@ -59,6 +62,145 @@ omit [NeZero d] in
 theorem diagonalProjection_apply (X : Matrix (ZMod d) (ZMod d) ℂ) :
     diagonalProjection d X = diagonal fun i => X i i :=
   rfl
+
+/-! ## Rank-one diagonal positivity criterion -/
+
+section DiagonalRankOne
+
+variable {ι : Type*} [Fintype ι]
+variable [DecidableEq ι]
+
+/-- If the squared norm of a vector is at most one, then `I - |v><v|` is
+positive semidefinite. -/
+theorem one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one (v : ι → ℂ)
+    (hv : ∑ i, ‖v i‖ ^ 2 ≤ 1) :
+    ((1 : Matrix ι ι ℂ) - vecMulVec v (star v)).PosSemidef := by
+  classical
+  set V : EuclideanSpace ℂ ι := WithLp.toLp 2 v with hV
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
+  · exact isHermitian_one.sub (Matrix.posSemidef_vecMulVec_self_star v).1
+  · intro w
+    set W : EuclideanSpace ℂ ι := WithLp.toLp 2 w with hW
+    have hQ :
+        star w ⬝ᵥ (((1 : Matrix ι ι ℂ) - vecMulVec v (star v)) *ᵥ w) =
+          star w ⬝ᵥ w - (star v ⬝ᵥ w) * (star w ⬝ᵥ v) := by
+      rw [Matrix.sub_mulVec, dotProduct_sub, Matrix.one_mulVec,
+        star_dotProduct_vecMulVec_mulVec]
+    rw [hQ]
+    have hVW : star v ⬝ᵥ w = ⟪V, W⟫_ℂ := by
+      rw [hV, hW, EuclideanSpace.inner_toLp_toLp]
+      exact (dotProduct_comm w (star v)).symm
+    have hWV : star w ⬝ᵥ v = ⟪W, V⟫_ℂ := by
+      rw [hV, hW, EuclideanSpace.inner_toLp_toLp]
+      exact (dotProduct_comm v (star w)).symm
+    have hWW : star w ⬝ᵥ w = ⟪W, W⟫_ℂ := by
+      rw [hW, EuclideanSpace.inner_toLp_toLp]
+      exact (dotProduct_comm w (star w)).symm
+    rw [hVW, hWV, hWW]
+    have hVVnorm : ‖V‖ ^ 2 ≤ 1 := by
+      rw [hV, EuclideanSpace.norm_sq_eq]
+      simpa using hv
+    have hinner_le : ‖⟪V, W⟫_ℂ‖ ^ 2 ≤ ‖W‖ ^ 2 := by
+      have hCS := norm_inner_le_norm (𝕜 := ℂ) V W
+      have hsq : ‖⟪V, W⟫_ℂ‖ ^ 2 ≤ (‖V‖ * ‖W‖) ^ 2 :=
+        pow_le_pow_left₀ (norm_nonneg _) hCS 2
+      have hWnonneg : 0 ≤ ‖W‖ ^ 2 := by positivity
+      nlinarith [hVVnorm, hsq, norm_nonneg V, norm_nonneg W]
+    have hWWreal : ⟪W, W⟫_ℂ = ((‖W‖ ^ 2 : ℝ) : ℂ) := by
+      rw [inner_self_eq_norm_sq_to_K (𝕜 := ℂ) W]
+      norm_cast
+    have hprod : ⟪V, W⟫_ℂ * ⟪W, V⟫_ℂ = ((‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) := by
+      rw [← inner_conj_symm W V, Complex.mul_conj, Complex.normSq_eq_norm_sq]
+    rw [hWWreal, hprod]
+    rw [show ((‖W‖ ^ 2 : ℝ) : ℂ) - ((‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) =
+        ((‖W‖ ^ 2 - ‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) by norm_num]
+    rw [Complex.zero_le_real]
+    linarith
+
+/-- Weighted Schur-complement form of the rank-one diagonal criterion.
+
+The hypothesis `hvzero` is the usual support condition at zero diagonal
+entries: if the diagonal weight vanishes, the corresponding component of the
+rank-one vector must vanish. -/
+theorem diagonal_sub_vecMulVec_posSemidef_of_sum_normSq_div_le_one
+    (a : ι → ℝ) (v : ι → ℂ) (ha : ∀ i, 0 ≤ a i)
+    (hvzero : ∀ i, a i = 0 → v i = 0)
+    (hbound : ∑ i, ‖v i‖ ^ 2 / a i ≤ 1) :
+    (diagonal (fun i => (a i : ℂ)) - vecMulVec v (star v)).PosSemidef := by
+  classical
+  let s : ι → ℝ := fun i => Real.sqrt (a i)
+  let p : ι → ℂ := fun i => if a i = 0 then 0 else v i / (s i : ℂ)
+  let D : Matrix ι ι ℂ := diagonal fun i => (s i : ℂ)
+  have hs_nonneg : ∀ i, 0 ≤ s i := fun i => Real.sqrt_nonneg _
+  have hp_norm : ∑ i, ‖p i‖ ^ 2 ≤ 1 := by
+    have hterm : ∀ i, ‖p i‖ ^ 2 = ‖v i‖ ^ 2 / a i := by
+      intro i
+      by_cases hi : a i = 0
+      · simp [p, hi, hvzero i hi]
+      · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
+        have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
+        have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
+        rw [show p i = v i / (s i : ℂ) by simp [p, hi]]
+        rw [norm_div]
+        rw [show (‖v i‖ / ‖(s i : ℂ)‖) ^ 2 =
+            ‖v i‖ ^ 2 / ‖(s i : ℂ)‖ ^ 2 by ring]
+        rw [← Complex.normSq_eq_norm_sq ((s i : ℂ)), Complex.normSq_ofReal]
+        rw [show s i * s i = a i by
+          rw [← pow_two]
+          simpa [s] using Real.sq_sqrt (ha i)]
+    simpa [hterm] using hbound
+  have hp_psd : ((1 : Matrix ι ι ℂ) - vecMulVec p (star p)).PosSemidef :=
+    one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one p hp_norm
+  have hD_mulVec (x : ι → ℂ) : D *ᵥ x = fun i => (s i : ℂ) * x i := by
+    ext i
+    simp [D, Matrix.mulVec]
+  have hD_conj : Dᴴ = D := by
+    ext i j
+    by_cases hij : i = j
+    · subst hij
+      simp [D]
+    · simp [D, hij, eq_comm]
+  have hDp : D *ᵥ p = v := by
+    rw [hD_mulVec]
+    ext i
+    by_cases hi : a i = 0
+    · simp [p, hi, hvzero i hi]
+    · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
+      have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
+      have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
+      simp [p, hi]
+      field_simp [hsi_ne]
+  have hpD : star p ᵥ* Dᴴ = star v := by
+    rw [hD_conj]
+    ext i
+    rw [Matrix.vecMul_diagonal]
+    by_cases hi : a i = 0
+    · simp [p, hi, hvzero i hi]
+    · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
+      have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
+      have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
+      simp [p, hi, div_eq_mul_inv]
+      field_simp [hsi_ne]
+  have hDone : D * (1 : Matrix ι ι ℂ) * Dᴴ = diagonal (fun i => (a i : ℂ)) := by
+    rw [hD_conj, Matrix.mul_one, Matrix.diagonal_mul_diagonal]
+    ext i j
+    by_cases hij : i = j
+    · subst hij
+      rw [Matrix.diagonal_apply_eq, Matrix.diagonal_apply_eq, ← Complex.ofReal_mul]
+      exact_mod_cast (by
+        rw [← pow_two]
+        simpa [s] using Real.sq_sqrt (ha i))
+    · rw [Matrix.diagonal_apply_ne _ hij, Matrix.diagonal_apply_ne _ hij]
+  have hdrank : D * vecMulVec p (star p) * Dᴴ = vecMulVec v (star v) := by
+    rw [Matrix.mul_vecMulVec, Matrix.vecMulVec_mul, hDp, hpD]
+  have hfactor :
+      D * ((1 : Matrix ι ι ℂ) - vecMulVec p (star p)) * Dᴴ =
+        diagonal (fun i => (a i : ℂ)) - vecMulVec v (star v) := by
+    rw [Matrix.mul_sub, Matrix.sub_mul, hDone, hdrank]
+  rw [← hfactor]
+  exact hp_psd.mul_mul_conjTranspose_same D
+
+end DiagonalRankOne
 
 /-- Conjugation by a matrix, as the linear map \(X\mapsto AXA^\dagger\).
 
@@ -137,5 +279,64 @@ theorem choiTypeMap_vecMulVec
     simp [Matrix.sum_apply, vecMulVec_apply, smul_eq_mul]
     ring_nf
   · simp [Matrix.sum_apply, vecMulVec_apply, h, smul_eq_mul]
+
+/-- The real diagonal weight appearing in the rank-one Choi-type image. -/
+noncomputable def choiTypeRankOneWeight (d n : ℕ) [NeZero d] (v : ZMod d → ℂ)
+    (i : ZMod d) : ℝ :=
+  ((d : ℝ) - (n : ℝ)) * ‖v i‖ ^ 2 +
+    ∑ k : Fin n, ‖v (i - ((k.1 + 1 : ℕ) : ZMod d))‖ ^ 2
+
+/-- Rank-one positivity of the Choi-type map reduced to the cyclic reciprocal
+bound for the diagonal weights.
+
+For Wolf's range \(1 \le n \le d-2\), the remaining scalar task is to prove the
+displayed bound for all vectors `v`. -/
+theorem choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one
+    (n : ℕ) (v : ZMod d → ℂ) (hn₂ : n ≤ d - 2)
+    (hbound : ∑ i, ‖v i‖ ^ 2 / choiTypeRankOneWeight d n v i ≤ 1) :
+    (choiTypeMap d n (vecMulVec v (star v))).PosSemidef := by
+  classical
+  let a : ZMod d → ℝ := fun i => choiTypeRankOneWeight d n v i
+  have hdpos : 0 < d := Nat.pos_of_ne_zero (NeZero.ne d)
+  have hnlt : n < d := by omega
+  have hnle : n ≤ d := le_of_lt hnlt
+  have hdn_nonneg : 0 ≤ (d : ℝ) - (n : ℝ) := by
+    have hnleR : (n : ℝ) ≤ (d : ℝ) := by exact_mod_cast hnle
+    linarith
+  have hdn_pos : 0 < (d : ℝ) - (n : ℝ) := by
+    have hnltR : (n : ℝ) < (d : ℝ) := by exact_mod_cast hnlt
+    linarith
+  have ha : ∀ i, 0 ≤ a i := by
+    intro i
+    dsimp [a, choiTypeRankOneWeight]
+    exact add_nonneg (mul_nonneg hdn_nonneg (sq_nonneg _))
+      (Finset.sum_nonneg fun k _ => sq_nonneg _)
+  have hvzero : ∀ i, a i = 0 → v i = 0 := by
+    intro i hi
+    have hfirst_nonneg : 0 ≤ ((d : ℝ) - (n : ℝ)) * ‖v i‖ ^ 2 :=
+      mul_nonneg hdn_nonneg (sq_nonneg _)
+    have hsum_nonneg :
+        0 ≤ ∑ k : Fin n, ‖v (i - ((k.1 + 1 : ℕ) : ZMod d))‖ ^ 2 :=
+      Finset.sum_nonneg fun k _ => sq_nonneg _
+    have hsum_eq :
+        ((d : ℝ) - (n : ℝ)) * ‖v i‖ ^ 2 +
+            ∑ k : Fin n, ‖v (i - ((k.1 + 1 : ℕ) : ZMod d))‖ ^ 2 = 0 := by
+      simpa [a, choiTypeRankOneWeight] using hi
+    have hfirst_zero : ((d : ℝ) - (n : ℝ)) * ‖v i‖ ^ 2 = 0 := by
+      nlinarith
+    have hnormsq_zero : ‖v i‖ ^ 2 = 0 := by
+      nlinarith [hfirst_zero, hdn_pos, sq_nonneg (‖v i‖)]
+    exact norm_eq_zero.mp (sq_eq_zero_iff.mp hnormsq_zero)
+  have hdiag :
+      (diagonal (fun i => (a i : ℂ)) - vecMulVec v (star v)).PosSemidef :=
+    diagonal_sub_vecMulVec_posSemidef_of_sum_normSq_div_le_one a v ha hvzero
+      (by simpa [a] using hbound)
+  rw [choiTypeMap_vecMulVec]
+  convert hdiag using 1
+  ext i j
+  by_cases hij : i = j
+  · subst hij
+    simp [a, choiTypeRankOneWeight, Complex.mul_conj, Complex.normSq_eq_norm_sq]
+  · simp [hij]
 
 end Matrix

--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -103,7 +103,6 @@ theorem one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one (v : ι → ℂ)
       have hCS := norm_inner_le_norm (𝕜 := ℂ) V W
       have hsq : ‖⟪V, W⟫_ℂ‖ ^ 2 ≤ (‖V‖ * ‖W‖) ^ 2 :=
         pow_le_pow_left₀ (norm_nonneg _) hCS 2
-      have hWnonneg : 0 ≤ ‖W‖ ^ 2 := by positivity
       nlinarith [hVVnorm, hsq, norm_nonneg V, norm_nonneg W]
     have hWWreal : ⟪W, W⟫_ℂ = ((‖W‖ ^ 2 : ℝ) : ℂ) := by
       rw [inner_self_eq_norm_sq_to_K (𝕜 := ℂ) W]
@@ -130,7 +129,6 @@ theorem diagonal_sub_vecMulVec_posSemidef_of_sum_normSq_div_le_one
   let s : ι → ℝ := fun i => Real.sqrt (a i)
   let p : ι → ℂ := fun i => if a i = 0 then 0 else v i / (s i : ℂ)
   let D : Matrix ι ι ℂ := diagonal fun i => (s i : ℂ)
-  have hs_nonneg : ∀ i, 0 ≤ s i := fun i => Real.sqrt_nonneg _
   have hp_norm : ∑ i, ‖p i‖ ^ 2 ≤ 1 := by
     have hterm : ∀ i, ‖p i‖ ^ 2 = ‖v i‖ ^ 2 / a i := by
       intro i

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -336,6 +336,43 @@ assertions for the range $1\le n\le d-2$ remain open.
     matrix minus the original rank-one projector.
 \end{proof}
 
+\begin{definition}[The Choi rank-one diagonal weight]
+    \label{def:choi_type_rankone_weight}
+    \lean{Matrix.choiTypeRankOneWeight}
+    \leanok
+    For a vector \(v\) on \(\mathbb Z/d\mathbb Z\), set
+    \[
+        a_i=(d-n)|v_i|^2+\sum_{k=1}^n |v_{i-k}|^2 .
+    \]
+\end{definition}
+
+\begin{lemma}[Rank-one positivity from the cyclic reciprocal bound]
+    \label{lem:choi_type_rankone_positive_from_weight_bound}
+    \lean{Matrix.choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one}
+    \leanok
+    \uses{def:choi_type_map, lem:choi_type_map_rankone,
+        def:choi_type_rankone_weight}
+    Assume \(n\le d-2\). If
+    \[
+        \sum_i \frac{|v_i|^2}{a_i}\le 1,
+    \]
+    where \(a_i\) is the weight of
+    Definition~\ref{def:choi_type_rankone_weight}, then
+    \[
+        T_C(\ket{v}\bra{v})\ge 0 .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The matrix in Lemma~\ref{lem:choi_type_map_rankone} has the form
+    \(\operatorname{diag}(a_i)-\ket{v}\bra{v}\).  Conjugating by the diagonal
+    matrix with entries \(\sqrt{a_i}\) reduces the claim to
+    \(I-\ket{p}\bra{p}\ge0\), where \(p_i=v_i/\sqrt{a_i}\) on the support of
+    \(a_i\).  The displayed bound says \(\|p\|^2\le1\), and the conclusion is
+    Cauchy's inequality.
+\end{proof}
+
 \section{The partial transpose and the PPT property}
 
 Transposition is a positive map that is not completely positive, so applying it

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -340,23 +340,89 @@ assertions for the range $1\le n\le d-2$ remain open.
     \label{def:choi_type_rankone_weight}
     \lean{Matrix.choiTypeRankOneWeight}
     \leanok
-    For a vector \(v\) on \(\mathbb Z/d\mathbb Z\), set
+    For a vector $v$ on $\mathbb Z/d\mathbb Z$, set
     \[
         a_i=(d-n)|v_i|^2+\sum_{k=1}^n |v_{i-k}|^2 .
     \]
 \end{definition}
+
+\begin{lemma}[Rank-one complement from a unit bound]
+    \label{lem:rankone_complement_from_unit_bound}
+    \lean{Matrix.one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one}
+    \leanok
+    If $p$ is a vector with
+    \[
+        \sum_i |p_i|^2\le 1,
+    \]
+    then
+    \[
+        I-\ket{p}\bra{p}\ge 0 .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    For every vector $w$,
+    \[
+        \bra{w}\bigl(I-\ket{p}\bra{p}\bigr)\ket{w}
+        =
+        \|w\|^2-|\braket{p}{w}|^2 .
+    \]
+    Since $\|p\|^2=\sum_i |p_i|^2\le 1$, Cauchy's inequality gives
+    \[
+        |\braket{p}{w}|^2\le \|p\|^2\|w\|^2\le \|w\|^2,
+    \]
+    so the quadratic form is nonnegative.
+\end{proof}
+
+\begin{lemma}[Diagonal rank-one Schur-complement criterion]
+    \label{lem:diagonal_rankone_schur_complement}
+    \lean{Matrix.diagonal_sub_vecMulVec_posSemidef_of_sum_normSq_div_le_one}
+    \leanok
+    \uses{lem:rankone_complement_from_unit_bound}
+    Let $a_i\ge0$ and suppose $v_i=0$ whenever $a_i=0$.  If, with the convention
+    that $|v_i|^2/a_i$ is read as $0$ when $a_i=0$,
+    \[
+        \sum_i \frac{|v_i|^2}{a_i}\le 1,
+    \]
+    then
+    \[
+        \operatorname{diag}(a_i)-\ket{v}\bra{v}\ge 0 .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Put $p_i=0$ when $a_i=0$ and $p_i=v_i/\sqrt{a_i}$ otherwise.  Then
+    \[
+        \|p\|^2=\sum_i |p_i|^2
+        =\sum_i \frac{|v_i|^2}{a_i}\le 1
+    \]
+    under the same zero-term convention.  Lemma~\ref{lem:rankone_complement_from_unit_bound}
+    gives $I-\ket{p}\bra{p}\ge0$.  If $S=\operatorname{diag}(\sqrt{a_i})$, then
+    the support condition gives
+    \[
+        S\bigl(I-\ket{p}\bra{p}\bigr)S^\dagger
+        =
+        \operatorname{diag}(a_i)-\ket{v}\bra{v}.
+    \]
+    Conjugation by $S$ preserves positive semidefiniteness, which proves the
+    claim.
+\end{proof}
 
 \begin{lemma}[Rank-one positivity from the cyclic reciprocal bound]
     \label{lem:choi_type_rankone_positive_from_weight_bound}
     \lean{Matrix.choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one}
     \leanok
     \uses{def:choi_type_map, lem:choi_type_map_rankone,
-        def:choi_type_rankone_weight}
-    Assume \(n\le d-2\). If
+        def:choi_type_rankone_weight, lem:diagonal_rankone_schur_complement,
+        lem:rankone_complement_from_unit_bound}
+    Assume $n\le d-2$. If, with the convention that the summand is $0$ at
+    indices where $a_i=0$,
     \[
         \sum_i \frac{|v_i|^2}{a_i}\le 1,
     \]
-    where \(a_i\) is the weight of
+    where $a_i$ is the weight of
     Definition~\ref{def:choi_type_rankone_weight}, then
     \[
         T_C(\ket{v}\bra{v})\ge 0 .
@@ -366,11 +432,11 @@ assertions for the range $1\le n\le d-2$ remain open.
 \begin{proof}
     \leanok
     The matrix in Lemma~\ref{lem:choi_type_map_rankone} has the form
-    \(\operatorname{diag}(a_i)-\ket{v}\bra{v}\).  Conjugating by the diagonal
-    matrix with entries \(\sqrt{a_i}\) reduces the claim to
-    \(I-\ket{p}\bra{p}\ge0\), where \(p_i=v_i/\sqrt{a_i}\) on the support of
-    \(a_i\).  The displayed bound says \(\|p\|^2\le1\), and the conclusion is
-    Cauchy's inequality.
+    $\operatorname{diag}(a_i)-\ket{v}\bra{v}$.  Each $a_i$ is nonnegative.  Since
+    $n\le d-2$, the coefficient $d-n$ is positive; hence $a_i=0$ forces
+    $v_i=0$.  The hypotheses of
+    Lemma~\ref{lem:diagonal_rankone_schur_complement} therefore apply and give
+    the stated positivity.
 \end{proof}
 
 \section{The partial transpose and the PPT property}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -415,8 +415,7 @@ assertions for the range $1\le n\le d-2$ remain open.
     \lean{Matrix.choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one}
     \leanok
     \uses{def:choi_type_map, lem:choi_type_map_rankone,
-        def:choi_type_rankone_weight, lem:diagonal_rankone_schur_complement,
-        lem:rankone_complement_from_unit_bound}
+        def:choi_type_rankone_weight, lem:diagonal_rankone_schur_complement}
     Assume $n\le d-2$. If, with the convention that the summand is $0$ at
     indices where $a_i=0$,
     \[


### PR DESCRIPTION
### Motivation

- Follow-up to LionSR/TNLean#3619, which defined `Matrix.choiTypeMap` on ZMod d and proved the rank-one reduction `choiTypeMap_vecMulVec`, but deferred positivity and indecomposability.
- Continues the formalization of Wolf Ch. 3, Example 3.1 (eq. 3.20): for 1 ≤ n ≤ d−2, the map T_C is positive.
- This PR reduces rank-one positivity to a scalar cyclic reciprocal inequality; see LionSR/QICLean#19.

### Description

- `TNLean/Algebra/MatrixAux.lean`: extracted `star_dotProduct_vecMulVec_mulVec` from `BreuerHallMap` into the shared `MatrixAux` module (generalized to arbitrary `ι → ℂ`).
- `TNLean/Channel/BreuerHallMap.lean`: removed the local copy; imports from `MatrixAux` unchanged.
- `TNLean/Channel/ChoiTypeMap.lean`:
  - Added a PSD criterion for `diag(a) − |v⟩⟨v|` via diagonal conjugation.
  - Defined `choiTypeRankOneWeight`: the diagonal entry a_i = (d−n)|v_i|² + Σ_{k=1}^n |v_{i−k}|².
  - Proved `choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one`: T_C(|v⟩⟨v|) ≥ 0 under the assumption Σ_i ‖v_i‖²/a_i ≤ 1.
- `blueprint/src/chapter/ch25_positive_not_cp.tex`: added blueprint entries for the rank-one weight definition and the conditional positivity lemma.
- **Still open:** the cyclic reciprocal inequality Σ_i |v_i|²/a_i ≤ 1 for all v in the Wolf parameter range; this remaining step is needed to close `Matrix.choiTypeMap_isPositive`.

### Testing

- `lake build TNLean.Algebra.MatrixAux TNLean.Channel.BreuerHallMap TNLean.Channel.ChoiTypeMap`
- `lake build TNLean`
- `lake exe lint_style --github`
- `rg -n "sorry|admit|native_decide|unsafeCast|axiom" TNLean/Algebra/MatrixAux.lean TNLean/Channel/BreuerHallMap.lean TNLean/Channel/ChoiTypeMap.lean`
- `leanblueprint web` and `leanblueprint checkdecls`
- Pre-existing warnings and `sorry` markers outside the touched files are unchanged.

---
Refs LionSR/QICLean#19. Refs LionSR/QICLean#21.

> [!NOTE]
> **Medium Risk**
> Adds substantial formal PSD proofs and a new conditional positivity step; incorrect lemmas would undermine the Choi-type development, but scope is confined to channel/algebra math with no runtime or security surface.
>
> **Overview**
> This PR **reduces Choi-type rank-one positivity** to a scalar cyclic reciprocal bound, without closing full Wolf Example 3.1 positivity.
>
> **Shared algebra:** `star_dotProduct_vecMulVec_mulVec` moves from `BreuerHallMap` into `MatrixAux` (general `ι → ℂ`); Breuer-Hall now imports it unchanged in spirit.
>
> **New Lean in `ChoiTypeMap`:** PSD criteria for `I - |v⟩⟨v|` and weighted `diag(a) - |v⟩⟨v|` via diagonal conjugation; `choiTypeRankOneWeight`; theorem `choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one` assuming `∑ᵢ ‖vᵢ‖²/aᵢ ≤ 1` for the cyclic diagonal weights.
>
> **Blueprint:** documents the rank-one weight definition and the conditional positivity lemma matching the Lean reduction.
>
> **Still open:** prove the cyclic reciprocal inequality for all `v` in the Wolf parameter range.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e507b906e0b7717306c7556e9b7783eb430c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds substantial formal PSD proofs on the Choi-type path; incorrect lemmas would undermine that development, but scope is confined to channel/algebra math with no runtime or security surface.
> 
> **Overview**
> This PR **reduces Choi-type rank-one positivity** to a scalar cyclic reciprocal bound; it does not yet prove full Wolf Example 3.1 positivity.
> 
> **Shared algebra:** `star_dotProduct_vecMulVec_mulVec` moves from `BreuerHallMap` into `MatrixAux` for general `ι → ℂ`; Breuer-Hall imports it unchanged.
> 
> **`ChoiTypeMap`:** Adds PSD criteria for `I - |v⟩⟨v|` and weighted `diag(a) - |v⟩⟨v|` (Schur complement via diagonal conjugation), defines `choiTypeRankOneWeight`, and proves `choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one` when `∑ᵢ ‖vᵢ‖²/aᵢ ≤ 1`.
> 
> **Blueprint:** Documents the rank-one weight and the conditional positivity lemma.
> 
> **Still open:** the cyclic reciprocal inequality for all `v` in the Wolf parameter range (needed to close `choiTypeMap_isPositive`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb8ced22f2b740cc1a5c5276b80eb27b3e40cf6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->