### PR TITLE
refactor(Algebra): move rank-one PSD criteria

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -2,6 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Analysis.Matrix.PosDef
 import TNLean.Algebra.MatrixAux
 
@@ -9,12 +10,155 @@ import TNLean.Algebra.MatrixAux
 # Hermitian matrix extremal eigenvalues
 
 This file provides lemmas for Hermitian complex matrices over an arbitrary finite
-index type: the extremal eigenvalue lemmas and scalar-shift spectral formulae.
+index type: rank-one positive semidefinite criteria, the extremal eigenvalue
+lemmas, and scalar-shift spectral formulae.
 -/
 
-open scoped Matrix ComplexOrder
+open scoped Matrix ComplexOrder InnerProductSpace
 
 variable {n : Type*} [Fintype n] [DecidableEq n]
+
+namespace Matrix
+
+/-! ## Rank-one diagonal positivity criteria -/
+
+section DiagonalRankOne
+
+variable {ι : Type*} [Fintype ι] [DecidableEq ι]
+
+/-- If the squared norm of a vector is at most one, then `I - |v><v|` is
+positive semidefinite. -/
+theorem one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one (v : ι → ℂ)
+    (hv : ∑ i, ‖v i‖ ^ 2 ≤ 1) :
+    ((1 : Matrix ι ι ℂ) - vecMulVec v (star v)).PosSemidef := by
+  classical
+  set V : EuclideanSpace ℂ ι := WithLp.toLp 2 v with hV
+  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
+  · exact isHermitian_one.sub (Matrix.posSemidef_vecMulVec_self_star v).1
+  · intro w
+    set W : EuclideanSpace ℂ ι := WithLp.toLp 2 w with hW
+    have hQ :
+        star w ⬝ᵥ (((1 : Matrix ι ι ℂ) - vecMulVec v (star v)) *ᵥ w) =
+          star w ⬝ᵥ w - (star v ⬝ᵥ w) * (star w ⬝ᵥ v) := by
+      rw [Matrix.sub_mulVec, dotProduct_sub, Matrix.one_mulVec,
+        star_dotProduct_vecMulVec_mulVec]
+    rw [hQ]
+    have hVW : star v ⬝ᵥ w = ⟪V, W⟫_ℂ := by
+      rw [hV, hW, EuclideanSpace.inner_toLp_toLp]
+      exact (dotProduct_comm w (star v)).symm
+    have hWV : star w ⬝ᵥ v = ⟪W, V⟫_ℂ := by
+      rw [hV, hW, EuclideanSpace.inner_toLp_toLp]
+      exact (dotProduct_comm v (star w)).symm
+    have hWW : star w ⬝ᵥ w = ⟪W, W⟫_ℂ := by
+      rw [hW, EuclideanSpace.inner_toLp_toLp]
+      exact (dotProduct_comm w (star w)).symm
+    rw [hVW, hWV, hWW]
+    have hVVnorm : ‖V‖ ^ 2 ≤ 1 := by
+      rw [hV, EuclideanSpace.norm_sq_eq]
+      simpa using hv
+    have hinner_le : ‖⟪V, W⟫_ℂ‖ ^ 2 ≤ ‖W‖ ^ 2 := by
+      have hCS := norm_inner_le_norm (𝕜 := ℂ) V W
+      have hsq : ‖⟪V, W⟫_ℂ‖ ^ 2 ≤ (‖V‖ * ‖W‖) ^ 2 :=
+        pow_le_pow_left₀ (norm_nonneg _) hCS 2
+      nlinarith [hVVnorm, hsq, norm_nonneg V, norm_nonneg W]
+    have hWWreal : ⟪W, W⟫_ℂ = ((‖W‖ ^ 2 : ℝ) : ℂ) := by
+      rw [inner_self_eq_norm_sq_to_K (𝕜 := ℂ) W]
+      norm_cast
+    have hprod : ⟪V, W⟫_ℂ * ⟪W, V⟫_ℂ =
+        ((‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) := by
+      rw [← inner_conj_symm W V, Complex.mul_conj, Complex.normSq_eq_norm_sq]
+    rw [hWWreal, hprod]
+    rw [show ((‖W‖ ^ 2 : ℝ) : ℂ) - ((‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) =
+        ((‖W‖ ^ 2 - ‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) by norm_num]
+    rw [Complex.zero_le_real]
+    linarith
+
+/-- Weighted Schur-complement form of the rank-one diagonal criterion.
+
+The hypothesis `hvzero` is the usual support condition at zero diagonal entries:
+if the diagonal weight vanishes, the corresponding component of the rank-one
+vector must vanish. -/
+theorem diagonal_sub_vecMulVec_posSemidef_of_sum_normSq_div_le_one
+    (a : ι → ℝ) (v : ι → ℂ) (ha : ∀ i, 0 ≤ a i)
+    (hvzero : ∀ i, a i = 0 → v i = 0)
+    (hbound : ∑ i, ‖v i‖ ^ 2 / a i ≤ 1) :
+    (diagonal (fun i => (a i : ℂ)) - vecMulVec v (star v)).PosSemidef := by
+  classical
+  let s : ι → ℝ := fun i => Real.sqrt (a i)
+  let p : ι → ℂ := fun i => if a i = 0 then 0 else v i / (s i : ℂ)
+  let D : Matrix ι ι ℂ := diagonal fun i => (s i : ℂ)
+  have hp_norm : ∑ i, ‖p i‖ ^ 2 ≤ 1 := by
+    have hterm : ∀ i, ‖p i‖ ^ 2 = ‖v i‖ ^ 2 / a i := by
+      intro i
+      by_cases hi : a i = 0
+      · simp [p, hi, hvzero i hi]
+      · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
+        have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
+        have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
+        rw [show p i = v i / (s i : ℂ) by simp [p, hi]]
+        rw [norm_div]
+        rw [show (‖v i‖ / ‖(s i : ℂ)‖) ^ 2 =
+            ‖v i‖ ^ 2 / ‖(s i : ℂ)‖ ^ 2 by ring]
+        rw [← Complex.normSq_eq_norm_sq ((s i : ℂ)), Complex.normSq_ofReal]
+        rw [show s i * s i = a i by
+          rw [← pow_two]
+          simpa [s] using Real.sq_sqrt (ha i)]
+    simpa [hterm] using hbound
+  have hp_psd : ((1 : Matrix ι ι ℂ) - vecMulVec p (star p)).PosSemidef :=
+    one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one p hp_norm
+  have hD_mulVec (x : ι → ℂ) : D *ᵥ x = fun i => (s i : ℂ) * x i := by
+    ext i
+    simp [D, Matrix.mulVec]
+  have hD_conj : Dᴴ = D := by
+    ext i j
+    by_cases hij : i = j
+    · subst hij
+      simp [D]
+    · simp [D, hij, eq_comm]
+  have hDp : D *ᵥ p = v := by
+    rw [hD_mulVec]
+    ext i
+    by_cases hi : a i = 0
+    · simp [p, hi, hvzero i hi]
+    · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
+      have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
+      have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
+      simp [p, hi]
+      field_simp [hsi_ne]
+  have hpD : star p ᵥ* Dᴴ = star v := by
+    rw [hD_conj]
+    ext i
+    rw [Matrix.vecMul_diagonal]
+    by_cases hi : a i = 0
+    · simp [p, hi, hvzero i hi]
+    · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
+      have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
+      have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
+      simp [p, hi, div_eq_mul_inv]
+      field_simp [hsi_ne]
+  have hDone : D * (1 : Matrix ι ι ℂ) * Dᴴ =
+      diagonal (fun i => (a i : ℂ)) := by
+    rw [hD_conj, Matrix.mul_one, Matrix.diagonal_mul_diagonal]
+    ext i j
+    by_cases hij : i = j
+    · subst hij
+      rw [Matrix.diagonal_apply_eq, Matrix.diagonal_apply_eq, ← Complex.ofReal_mul]
+      exact_mod_cast (by
+        rw [← pow_two]
+        simpa [s] using Real.sq_sqrt (ha i))
+    · rw [Matrix.diagonal_apply_ne _ hij, Matrix.diagonal_apply_ne _ hij]
+  have hdrank : D * vecMulVec p (star p) * Dᴴ = vecMulVec v (star v) := by
+    rw [Matrix.mul_vecMulVec, Matrix.vecMulVec_mul, hDp, hpD]
+  have hfactor :
+      D * ((1 : Matrix ι ι ℂ) - vecMulVec p (star p)) * Dᴴ =
+        diagonal (fun i => (a i : ℂ)) - vecMulVec v (star v) := by
+    rw [Matrix.mul_sub, Matrix.sub_mul, hDone, hdrank]
+  rw [← hfactor]
+  exact hp_psd.mul_mul_conjTranspose_same D
+
+end DiagonalRankOne
+
+end Matrix
 
 /-- Smallest eigenvalue of a Hermitian matrix on a nonempty finite space. -/
 noncomputable def minEigenvalue [Nonempty n]

--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -3,10 +3,9 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: TNLean contributors
 -/
-import Mathlib.Analysis.InnerProductSpace.PiL2
 import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.Permutation
-import TNLean.Algebra.MatrixAux
+import TNLean.Algebra.HermitianHelpers
 
 /-!
 # Choi-type positive maps
@@ -61,143 +60,6 @@ omit [NeZero d] in
 theorem diagonalProjection_apply (X : Matrix (ZMod d) (ZMod d) ℂ) :
     diagonalProjection d X = diagonal fun i => X i i :=
   rfl
-
-/-! ## Rank-one diagonal positivity criterion -/
-
-section DiagonalRankOne
-
-variable {ι : Type*} [Fintype ι]
-variable [DecidableEq ι]
-
-/-- If the squared norm of a vector is at most one, then `I - |v><v|` is
-positive semidefinite. -/
-theorem one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one (v : ι → ℂ)
-    (hv : ∑ i, ‖v i‖ ^ 2 ≤ 1) :
-    ((1 : Matrix ι ι ℂ) - vecMulVec v (star v)).PosSemidef := by
-  classical
-  set V : EuclideanSpace ℂ ι := WithLp.toLp 2 v with hV
-  refine Matrix.PosSemidef.of_dotProduct_mulVec_nonneg ?_ ?_
-  · exact isHermitian_one.sub (Matrix.posSemidef_vecMulVec_self_star v).1
-  · intro w
-    set W : EuclideanSpace ℂ ι := WithLp.toLp 2 w with hW
-    have hQ :
-        star w ⬝ᵥ (((1 : Matrix ι ι ℂ) - vecMulVec v (star v)) *ᵥ w) =
-          star w ⬝ᵥ w - (star v ⬝ᵥ w) * (star w ⬝ᵥ v) := by
-      rw [Matrix.sub_mulVec, dotProduct_sub, Matrix.one_mulVec,
-        star_dotProduct_vecMulVec_mulVec]
-    rw [hQ]
-    have hVW : star v ⬝ᵥ w = ⟪V, W⟫_ℂ := by
-      rw [hV, hW, EuclideanSpace.inner_toLp_toLp]
-      exact (dotProduct_comm w (star v)).symm
-    have hWV : star w ⬝ᵥ v = ⟪W, V⟫_ℂ := by
-      rw [hV, hW, EuclideanSpace.inner_toLp_toLp]
-      exact (dotProduct_comm v (star w)).symm
-    have hWW : star w ⬝ᵥ w = ⟪W, W⟫_ℂ := by
-      rw [hW, EuclideanSpace.inner_toLp_toLp]
-      exact (dotProduct_comm w (star w)).symm
-    rw [hVW, hWV, hWW]
-    have hVVnorm : ‖V‖ ^ 2 ≤ 1 := by
-      rw [hV, EuclideanSpace.norm_sq_eq]
-      simpa using hv
-    have hinner_le : ‖⟪V, W⟫_ℂ‖ ^ 2 ≤ ‖W‖ ^ 2 := by
-      have hCS := norm_inner_le_norm (𝕜 := ℂ) V W
-      have hsq : ‖⟪V, W⟫_ℂ‖ ^ 2 ≤ (‖V‖ * ‖W‖) ^ 2 :=
-        pow_le_pow_left₀ (norm_nonneg _) hCS 2
-      nlinarith [hVVnorm, hsq, norm_nonneg V, norm_nonneg W]
-    have hWWreal : ⟪W, W⟫_ℂ = ((‖W‖ ^ 2 : ℝ) : ℂ) := by
-      rw [inner_self_eq_norm_sq_to_K (𝕜 := ℂ) W]
-      norm_cast
-    have hprod : ⟪V, W⟫_ℂ * ⟪W, V⟫_ℂ = ((‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) := by
-      rw [← inner_conj_symm W V, Complex.mul_conj, Complex.normSq_eq_norm_sq]
-    rw [hWWreal, hprod]
-    rw [show ((‖W‖ ^ 2 : ℝ) : ℂ) - ((‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) =
-        ((‖W‖ ^ 2 - ‖⟪V, W⟫_ℂ‖ ^ 2 : ℝ) : ℂ) by norm_num]
-    rw [Complex.zero_le_real]
-    linarith
-
-/-- Weighted Schur-complement form of the rank-one diagonal criterion.
-
-The hypothesis `hvzero` is the usual support condition at zero diagonal
-entries: if the diagonal weight vanishes, the corresponding component of the
-rank-one vector must vanish. -/
-theorem diagonal_sub_vecMulVec_posSemidef_of_sum_normSq_div_le_one
-    (a : ι → ℝ) (v : ι → ℂ) (ha : ∀ i, 0 ≤ a i)
-    (hvzero : ∀ i, a i = 0 → v i = 0)
-    (hbound : ∑ i, ‖v i‖ ^ 2 / a i ≤ 1) :
-    (diagonal (fun i => (a i : ℂ)) - vecMulVec v (star v)).PosSemidef := by
-  classical
-  let s : ι → ℝ := fun i => Real.sqrt (a i)
-  let p : ι → ℂ := fun i => if a i = 0 then 0 else v i / (s i : ℂ)
-  let D : Matrix ι ι ℂ := diagonal fun i => (s i : ℂ)
-  have hp_norm : ∑ i, ‖p i‖ ^ 2 ≤ 1 := by
-    have hterm : ∀ i, ‖p i‖ ^ 2 = ‖v i‖ ^ 2 / a i := by
-      intro i
-      by_cases hi : a i = 0
-      · simp [p, hi, hvzero i hi]
-      · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
-        have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
-        have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
-        rw [show p i = v i / (s i : ℂ) by simp [p, hi]]
-        rw [norm_div]
-        rw [show (‖v i‖ / ‖(s i : ℂ)‖) ^ 2 =
-            ‖v i‖ ^ 2 / ‖(s i : ℂ)‖ ^ 2 by ring]
-        rw [← Complex.normSq_eq_norm_sq ((s i : ℂ)), Complex.normSq_ofReal]
-        rw [show s i * s i = a i by
-          rw [← pow_two]
-          simpa [s] using Real.sq_sqrt (ha i)]
-    simpa [hterm] using hbound
-  have hp_psd : ((1 : Matrix ι ι ℂ) - vecMulVec p (star p)).PosSemidef :=
-    one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one p hp_norm
-  have hD_mulVec (x : ι → ℂ) : D *ᵥ x = fun i => (s i : ℂ) * x i := by
-    ext i
-    simp [D, Matrix.mulVec]
-  have hD_conj : Dᴴ = D := by
-    ext i j
-    by_cases hij : i = j
-    · subst hij
-      simp [D]
-    · simp [D, hij, eq_comm]
-  have hDp : D *ᵥ p = v := by
-    rw [hD_mulVec]
-    ext i
-    by_cases hi : a i = 0
-    · simp [p, hi, hvzero i hi]
-    · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
-      have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
-      have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
-      simp [p, hi]
-      field_simp [hsi_ne]
-  have hpD : star p ᵥ* Dᴴ = star v := by
-    rw [hD_conj]
-    ext i
-    rw [Matrix.vecMul_diagonal]
-    by_cases hi : a i = 0
-    · simp [p, hi, hvzero i hi]
-    · have hai_pos : 0 < a i := lt_of_le_of_ne (ha i) (Ne.symm hi)
-      have hsi_pos : 0 < s i := by simpa [s] using Real.sqrt_pos.2 hai_pos
-      have hsi_ne : (s i : ℂ) ≠ 0 := by exact_mod_cast hsi_pos.ne'
-      simp [p, hi, div_eq_mul_inv]
-      field_simp [hsi_ne]
-  have hDone : D * (1 : Matrix ι ι ℂ) * Dᴴ = diagonal (fun i => (a i : ℂ)) := by
-    rw [hD_conj, Matrix.mul_one, Matrix.diagonal_mul_diagonal]
-    ext i j
-    by_cases hij : i = j
-    · subst hij
-      rw [Matrix.diagonal_apply_eq, Matrix.diagonal_apply_eq, ← Complex.ofReal_mul]
-      exact_mod_cast (by
-        rw [← pow_two]
-        simpa [s] using Real.sq_sqrt (ha i))
-    · rw [Matrix.diagonal_apply_ne _ hij, Matrix.diagonal_apply_ne _ hij]
-  have hdrank : D * vecMulVec p (star p) * Dᴴ = vecMulVec v (star v) := by
-    rw [Matrix.mul_vecMulVec, Matrix.vecMulVec_mul, hDp, hpD]
-  have hfactor :
-      D * ((1 : Matrix ι ι ℂ) - vecMulVec p (star p)) * Dᴴ =
-        diagonal (fun i => (a i : ℂ)) - vecMulVec v (star v) := by
-    rw [Matrix.mul_sub, Matrix.sub_mul, hDone, hdrank]
-  rw [← hfactor]
-  exact hp_psd.mul_mul_conjTranspose_same D
-
-end DiagonalRankOne
 
 /-- Conjugation by a matrix, as the linear map \(X\mapsto AXA^\dagger\).
 


### PR DESCRIPTION
### Motivation

- The rank-one positive semidefiniteness criteria were placed in `TNLean/Channel/ChoiTypeMap.lean`, a file specializing in Choi-type map formalization, despite having no channel-theoretic content — they concern general matrix inequalities.
- Moving these lemmas to `TNLean/Algebra/HermitianHelpers.lean` places them with other Hermitian and spectral matrix results, improving discoverability and future reuse.
- Continues the Choi-type map formalization of Wolf Ch. 3, Ex. 3.1 (eq. (3.20)) begun in LionSR/TNLean#3619, as tracked in LionSR/QICLean#19 and LionSR/QICLean#21.

### Description

- Modified `TNLean/Algebra/HermitianHelpers.lean`: moved `one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one` and `diagonal_sub_vecMulVec_posSemidef_of_sum_normSq_div_le_one` into a new `Matrix.DiagonalRankOne` section; added `PiL2` / `InnerProductSpace` imports and updated the module docstring.
- Modified `TNLean/Channel/ChoiTypeMap.lean`: removed the two relocated lemmas; added an import of `HermitianHelpers`; removed the `PiL2` and `MatrixAux` imports that exclusively served the moved proofs. The Choi-type positivity result `choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one` remains in this file.
- Theorem names are unchanged, so all blueprint `\lean{}` references and downstream call sites continue to resolve without modification.

### Testing

- `lake build TNLean.Algebra.HermitianHelpers`
- `lake build TNLean.Channel.ChoiTypeMap`
- `lake exe lint_style --github`
- `git diff --check`
- Proof-integrity grep on both modified Lean files
- `lake build TNLean`
- `leanblueprint web`
- `leanblueprint checkdecls`

---
Addresses LionSR/QICLean#19

> [!NOTE]
> **Low Risk**
> Pure relocation with no proof or API renames; behavior and blueprint declaration names stay the same.
> 
> **Overview**
> **Moves** the generic rank-one positive semidefinite lemmas from `ChoiTypeMap.lean` into `HermitianHelpers.lean`, under a new `Matrix.DiagonalRankOne` section, so they sit with other Hermitian/matrix spectral tooling instead of channel-specific code.
> 
> The two theorems—`one_sub_vecMulVec_posSemidef_of_sum_normSq_le_one` and `diagonal_sub_vecMulVec_posSemidef_of_sum_normSq_div_le_one`—are unchanged in name and proof; `ChoiTypeMap` now imports `HermitianHelpers` and still calls the weighted criterion in `choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one`. `HermitianHelpers` gains `PiL2` / `InnerProductSpace` imports and an updated module blurb; `ChoiTypeMap` drops the direct `PiL2` and `MatrixAux` imports that only served the moved proofs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3893526853675a0c4032722e89d2a93405ab5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>