### PR TITLE
doc(parent): clarify D2 representative condition

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -569,13 +569,14 @@ theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_
   hStruct.localTerm_two_three_zero_one_commute_of_overlapping
     (hStruct.hasOverlappingTwoSiteCommutation_of_commute_lifts hcomm)
 
-/-- Definition D.2 data for the Appendix B \(AX\) and \(XB\) coefficient
-representatives gives commutation of the first two translated length-two parent
-terms on the three-site window.
+/-- A supplied Definition D.2-shaped condition on the Appendix B \(AX\) and
+\(XB\) coefficient representatives gives commutation of the first two translated
+length-two parent terms on the three-site window.
 
-This theorem only transports already-supplied Definition D.2 data to the
-canonical parent interactions identified above.  The construction of that data
-remains to be derived from the Appendix B basic-vector form.
+This theorem only transports the supplied idempotency and lifted-commutator
+clauses to the canonical parent interactions identified above; the
+kernel-intersection clause is not used here.  It does not construct the source
+projectors \(Q_{AX}\) and \(Q_{XB}\) from the Appendix B basic-vector form.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1067,22 +1067,24 @@ the specialization $L=2$.
         =
         h_1^{(3)}(A,2)h_0^{(3)}(A,2).
     \]
-    The same conclusion holds if the full Definition~D.2 local data are given
-    for these two coefficient-space representatives.
+    The same conclusion holds if one supplies a Definition~D.2-shaped local
+    condition whose two operators are these coefficient-space representatives,
+    rather than the source projectors themselves.
 \end{lemma}
 
 \begin{proof}
     \leanok
     The lifted commutator, together with the Appendix~B idempotency already
-    recorded above, gives the overlapping two-site commutation datum.  Full
-    Definition~D.2 data imply the same conclusion by retaining their commutation
-    clause and not using the kernel-intersection condition
+    recorded above, gives the overlapping two-site commutation datum.  A supplied
+    Definition~D.2-shaped local condition on the coefficient representatives
+    implies the same conclusion by retaining its commutation clause and not using
+    the kernel-intersection condition
     \[
         K_{AXB}
         =
-        \ker\bigl((Q_{AX})_{AX}\bigr)
+        \ker\bigl((\widehat Q_{AX})_{AX}\bigr)
         \cap
-        \ker\bigl((Q_{XB})_{XB}\bigr).
+        \ker\bigl((\widehat Q_{XB})_{XB}\bigr).
     \]
 \end{proof}
 


### PR DESCRIPTION
### Motivation

The parent-Hamiltonian blueprint should distinguish the Appendix B coefficient-space representatives from the source projectors in Definition D.2 of arXiv:1606.00608.

### Description

This PR clarifies the matching Lean docstring and blueprint prose. It states that the theorem transports a supplied D.2-shaped local condition on the coefficient representatives; it does not construct the source projectors Q_AX and Q_XB from the Appendix B basic-vector form.

Refs #3373

### Testing

- `lake env lean TNLean/MPS/RFP/CommutingBridge.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose only; no changes to theorem statements or proofs beyond documentation.
> 
> **Overview**
> Documentation-only clarification for the Appendix B → three-site parent-term commutation bridge: **Definition D.2** is described as a **supplied local condition on the coefficient-space representatives** \(\widehat Q_{AX}\), \(\widehat Q_{XB}\), not as “full D.2 data” that builds the paper’s source projectors \(Q_{AX}\), \(Q_{XB}\) from the basic-vector form.
> 
> The Lean docstring on `AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2` now states explicitly that the result only **transports** idempotency and the lifted-commutator clauses (via `hD2.to_overlapping`), that the **kernel-intersection** clause of D.2 is **unused** here, and that **no construction** of the source projectors is claimed.
> 
> Matching blueprint edits in `ch13_parent_hamiltonian_commuting_gap.tex` align the lemma proof with the same distinction and write the unused kernel condition with \(\widehat Q_{AX}\)/\(\widehat Q_{XB}\) instead of bare \(Q_{AX}\)/\(Q_{XB}\).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa55764f8edd51e1422c8515497e67377c88d305. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->