### PR TITLE
doc(parent): distinguish norm compression gap condition

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean
@@ -721,20 +721,22 @@ theorem parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_lt
   exact parentHamiltonianES_gap_bound_of_cyclic_window_overlap_norm_bound_of_le
     A L hL hγpos hγle hηle hOverlapNorm
 
-/-- Finite-row norm-compression form of the martingale argument.
+/-- Finite-row norm-compression sufficient condition for the martingale argument.
 
 Cirac--Perez-Garcia--Schuch--Verstraete 2021, Section IV.C, lines 2168--2182,
 relates the parent-Hamiltonian gap to the principal angles between overlapping
-local ground spaces, equivalently to a norm-compression estimate for the
-corresponding excitation projections. In the cyclic-window specialization, if
-every overlapping pair satisfies
+local ground spaces. This theorem does not formalize that principal-angle
+estimate itself; it assumes directly a norm-compression bound for the excitation
+projections. In the cyclic-window specialization, if every overlapping pair
+satisfies
 \[
   \|p_i p_j v\| \le \eta \|p_i v\|,
   \qquad \eta\,2(L-1)<1,
 \]
 then the Euclidean-space parent Hamiltonians have the displayed uniform lower
-bound. The MPS-specific proof of this principal-angle estimate remains separate;
-it is recorded in `docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
+bound. The MPS-specific passage from the source principal-angle estimate to such
+an excitation-projection bound remains separate; it is recorded in
+`docs/paper-gaps/cpgsv21_martingale_overlap.tex`. -/
 theorem parentHamiltonianES_gap_bound_of_principal_angle_compression
     (A : MPSTensor d D) (L : ℕ) (hL : 1 < L) {η : ℝ}
     (hηnonneg : 0 ≤ η)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -1133,7 +1133,8 @@ sufficient stronger hypotheses.
     \[
         (1-\eta m)\|v\|\le \|H_{N,L}^{\mathrm{ES}}(A)v\|.
     \]
-    This strict compression form is a sufficient strengthening of the
+    This strict compression form is a norm-compression sufficient condition, not
+    the principal-angle estimate itself. It is a sufficient strengthening of the
     anticommutator martingale estimate in
     Cirac--Perez-Garcia--Schuch--Verstraete~\cite[Section~IV.C]{Cirac2021Matrix}.
     It does not prove the remaining MPS-specific estimate; it isolates the


### PR DESCRIPTION
### Motivation

The martingale gap reduction should not read as though the formal norm-compression hypothesis is the source principal-angle estimate. The paper-gap note records this as a conditional reduction, not the missing MPS-specific estimate.

### Description

- Reword the Lean docstring for the cyclic-window compression reduction to say it assumes an excitation-projection norm-compression bound directly.
- State that the passage from the source principal-angle estimate to such a bound remains separate.
- Align the blueprint lemma prose with the same distinction.

Refs #952

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Reduction.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `leanblueprint checkdecls`
- `git diff --check`