### PR TITLE
doc(Channel): record Choi cyclic bound obstruction

### DIFF
--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -22,8 +22,8 @@ The main theorem in this file is the exact action on rank-one projectors.  This
 is the algebraic reduction needed for the later positivity proof of Wolf
 Example 3.1.  Positivity and indecomposability of the Choi-type maps are not
 proved here.  The remaining positivity step is a genuine cyclic reciprocal
-inequality for the diagonal weights; it does not follow merely from equality
-between the total numerator weight and the total denominator weight.
+inequality for the diagonal weights; it does not follow merely from equality of
+the total numerator and denominator weights.
 
 ## References
 

--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -21,7 +21,9 @@ where `D` projects a matrix to its diagonal part.
 The main theorem in this file is the exact action on rank-one projectors.  This
 is the algebraic reduction needed for the later positivity proof of Wolf
 Example 3.1.  Positivity and indecomposability of the Choi-type maps are not
-proved here.
+proved here.  The remaining positivity step is a genuine cyclic reciprocal
+inequality for the diagonal weights; it does not follow merely from equality
+between the total numerator weight and the total denominator weight.
 
 ## References
 
@@ -149,7 +151,8 @@ noncomputable def choiTypeRankOneWeight (d n : ℕ) [NeZero d] (v : ZMod d → �
 bound for the diagonal weights.
 
 In the range \(n \le d-2\), the remaining scalar task is to prove the displayed
-bound for all vectors `v`. -/
+bound for all vectors `v`.  The cyclic placement of the shifted weights is
+essential; equality of the two total sums alone does not imply such a bound. -/
 theorem choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one
     (n : ℕ) (v : ZMod d → ℂ) (hn₂ : n ≤ d - 2)
     (hbound : ∑ i, ‖v i‖ ^ 2 / choiTypeRankOneWeight d n v i ≤ 1) :

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -297,8 +297,8 @@ The formal statements below record the map and the rank-one reduction used in
 the standard positivity argument.  The positivity and indecomposability
 assertions for the range $1\le n\le d-2$ remain open.  The missing positivity
 step is a cyclic reciprocal estimate for the weights in the rank-one reduction;
-it does not follow merely from equality between the total numerator weight and
-the total denominator weight.
+it does not follow merely from equality of the total numerator and denominator
+weights.
 
 \begin{definition}[Choi-type map]
     \label{def:choi_type_map}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -295,7 +295,10 @@ $D(X)$ and cyclic shifts $U_{k0}$:
 \]
 The formal statements below record the map and the rank-one reduction used in
 the standard positivity argument.  The positivity and indecomposability
-assertions for the range $1\le n\le d-2$ remain open.
+assertions for the range $1\le n\le d-2$ remain open.  The missing positivity
+step is a cyclic reciprocal estimate for the weights in the rank-one reduction;
+it does not follow merely from equality between the total numerator weight and
+the total denominator weight.
 
 \begin{definition}[Choi-type map]
     \label{def:choi_type_map}

--- a/docs/audits/2026-07-02_issue3622_choi_cyclic_bound.md
+++ b/docs/audits/2026-07-02_issue3622_choi_cyclic_bound.md
@@ -1,7 +1,8 @@
 # Issue #3622: Choi-Type Cyclic Bound
 
 Issue #3622 asks for the positivity of the Choi-type map in Wolf Chapter 3,
-Example 3.1, equation (3.20), for \(1 \le n \le d-2\).
+Example 3.1, equation (3.20), for \(1 \le n \le d-2\).  The indices below are
+taken in \(\mathbb Z/d\mathbb Z\), so \(i-k\) is interpreted cyclically.
 
 The current reduction is:
 

--- a/docs/audits/2026-07-02_issue3622_choi_cyclic_bound.md
+++ b/docs/audits/2026-07-02_issue3622_choi_cyclic_bound.md
@@ -1,0 +1,35 @@
+# Issue #3622: Choi-Type Cyclic Bound
+
+Issue #3622 asks for the positivity of the Choi-type map in Wolf Chapter 3,
+Example 3.1, equation (3.20), for \(1 \le n \le d-2\).
+
+The current reduction is:
+
+\[
+T_C(|v\rangle\langle v|)
+= \operatorname{diag}(a_i)-|v\rangle\langle v|,
+\qquad
+a_i=(d-n)|v_i|^2+\sum_{k=1}^n |v_{i-k}|^2.
+\]
+
+The Schur-complement criterion already formalized reduces rank-one positivity
+to the scalar estimate
+
+\[
+\sum_i \frac{|v_i|^2}{a_i}\le 1.
+\]
+
+The equality of the total weights is not sufficient for this estimate.  In
+general, from \(\sum_i x_i=\sum_i y_i\) one cannot conclude
+\(\sum_i x_i/y_i\le 1\).  The Choi-type problem needs the cyclic placement of
+the shifted weights in \(a_i\).  Thus the remaining theorem should isolate a
+cyclic reciprocal inequality for nonnegative \(x_i\):
+
+\[
+\sum_i
+\frac{x_i}{(d-n)x_i+\sum_{k=1}^n x_{i-k}}\le 1.
+\]
+
+Once this inequality is proved for \(1 \le n \le d-2\), it can be applied with
+\(x_i=|v_i|^2\) to discharge the conditional rank-one positivity lemma and then
+the positive-map statement for \(T_C\).


### PR DESCRIPTION
### Motivation

Issue LionSR/QICLean#19 (Wolf Ch. 3, Ex. 3.1: positivity of the Choi-type map) reduces positivity to a cyclic reciprocal estimate. The current source-facing text should make clear that this estimate is the remaining mathematical step and does not follow merely from equality of the total numerator and denominator weights.

### Description

- Clarify the Choi-type map module docstring and the conditional rank-one positivity lemma docstring (`TNLean/Channel/ChoiTypeMap.lean`).
- Align the blueprint paragraph for Choi-type maps with the same distinction (`blueprint/src/chapter/ch25_positive_not_cp.tex`).
- Add an audit note recording the precise scalar inequality still needed for Wolf Chapter 3, Example 3.1 (`docs/audits/2026-07-02_issue3622_choi_cyclic_bound.md`).

### Testing

- `lake env lean TNLean/Channel/ChoiTypeMap.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Refs LionSR/QICLean#19

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no executable logic or proof changes.
> 
> **Overview**
> Documents the **remaining open step** for Wolf Choi-type map positivity (#3622): rank-one positivity still hinges on a **cyclic reciprocal inequality** on the diagonal weights, not on equality of total numerator and denominator weights alone.
> 
> **`TNLean/Channel/ChoiTypeMap.lean`** — module and `choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one` docstrings now state that explicitly. **`blueprint/src/chapter/ch25_positive_not_cp.tex`** — Choi-type section matches the same distinction. **`docs/audits/2026-07-02_issue3622_choi_cyclic_bound.md`** — new audit note spelling out the scalar bound \(\sum_i x_i / \bigl((d-n)x_i + \sum_k x_{i-k}\bigr) \le 1\) and how it would close the conditional lemma.
> 
> No changes to definitions, proofs, or formal statements beyond prose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fbffaae91df0f572693c4b585f867ba4ad1c334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->