### PR TITLE
doc(MPS/RFP): clarify product-pair factorization prose

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -63,7 +63,7 @@ namespace MPSTensor
 variable {d D : ℕ}
 
 /-- Extract the `p`-th two-site physical pair from a configuration on `2 * N`
-sites, using the pairs `(0,1), (2,3), ...`. -/
+sites, using the pairs \((0,1),(2,3),\ldots\). -/
 def productPairWindow (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N) : Cfg d 2 :=
   fun j => σ ⟨2 * p.val + j.val, by
     have hp : p.val < N := p.isLt
@@ -84,7 +84,7 @@ def productPairWindow (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N) : Cfg d 2 :=
   simp [productPairWindow]
 
 /-- The even-chain state obtained by repeating a fixed two-site amplitude on the
-physical pairs `(0,1), (2,3), ...`.
+physical pairs \((0,1),(2,3),\ldots\).
 
 This is the physical-pair factorization used by the conditional
 nearest-neighbor parent-term theorem below. It is not the basic-vector formula
@@ -130,9 +130,9 @@ theorem HasProductPairMPV.exists_twoSiteAmplitude {A : MPSTensor d D}
       mpv A σ = productPairState ψ₂ N σ :=
   hA
 
-/-- Local-projector data saying that the nearest-neighbor local terms of \(A\)
-are idempotents \(p_i\) associated to the two-site factors on an \(N\)-site
-chain, with \(p_i p_j = p_j p_i\).
+/-- Hypotheses asserting that the nearest-neighbor local terms of \(A\) are
+commuting idempotents \(p_i\) on an \(N\)-site chain, with
+\(p_i p_j = p_j p_i\).
 
 **Scope restriction (local projectors):** The three-site \(AX/XB\) support maps
 for adjacent windows give the local support maps. This structure does not
@@ -166,8 +166,9 @@ theorem HasProductPairLocalProjectors.commuting_twoSite_localTerms
   rw [hPair.hlocal i, hPair.hlocal j]
   exact hPair.hcomm i j
 
-/-- A commuting family of translated length-two parent terms gives the required
-local-projector data, since each translated parent term is already idempotent. -/
+/-- A commuting family of translated length-two parent terms satisfies the
+local-projector hypotheses, since each translated parent term is already
+idempotent. -/
 noncomputable def HasProductPairLocalProjectors.of_commuting_localTerms
     {A : MPSTensor d D} {N : ℕ}
     (hcomm : ∀ i j : Fin N,
@@ -368,7 +369,7 @@ This is the coefficient form of
   |\varphi_j\rangle=\sum_m\lambda_m|m,m\rangle,
 \]
 with \(\varphi_j\) shared between \(b_t\) and \(a_{t+1}\). It is not the
-disjoint adjacent physical-pair condition used later for nearest-neighbor
+even-chain physical-pair factorization used later for nearest-neighbor
 parent-term commutation. -/
 theorem AppendixBStructuralData.mpv_coreTensor_eq_cyclicVirtualPairState
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
@@ -601,8 +602,8 @@ Source: arXiv:1606.00608, lines 543--555.
 
 This combines the gauge-invariance of MPV coefficients with the coefficient
 formula for the core tensor \(\Lambda U^i\).  The conclusion is the source
-cyclic virtual-pair expression, not the disjoint adjacent physical-pair
-condition used later in the conditional parent-Hamiltonian theorem. -/
+cyclic virtual-pair expression, not the even-chain physical-pair factorization
+used later in the conditional parent-Hamiltonian theorem. -/
 theorem AppendixBStructuralData.mpv_eq_cyclicVirtualPairState {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) {L : ℕ} (hL : 0 < L) (σ : Cfg d L) :
     mpv A σ = hStruct.cyclicVirtualPairState hL σ := by

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -35,7 +35,7 @@ basic-vector form to commutativity of the translated two-site terms
 The declarations below separate four mathematical statements:
 
 * the coefficient expression for \(U^{\otimes L}\varphi_j^{\otimes L}\);
-* the disjoint adjacent-pair coefficient condition used later in this file;
+* the even-chain physical-pair factorization condition used later in this file;
 * the two local coefficient-space representatives used before the \(AX\) and
   \(XB\) lifts;
 * the already formalized Appendix B structural form.
@@ -62,8 +62,8 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Extract the `p`-th adjacent two-site block from a configuration on `2N`
-sites. -/
+/-- Extract the `p`-th two-site physical pair from a configuration on `2N`
+sites, using the pairs `(0,1), (2,3), ...`. -/
 def productPairWindow (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N) : Cfg d 2 :=
   fun j => σ ⟨2 * p.val + j.val, by
     have hp : p.val < N := p.isLt
@@ -77,20 +77,20 @@ def productPairWindow (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N) : Cfg d 2 :=
       have hj : j.val < 2 := j.isLt
       omega⟩ := rfl
 
-/-- On one adjacent pair, the extracted window is the whole two-site configuration. -/
+/-- For one physical pair, the extracted window is the whole two-site configuration. -/
 @[simp] theorem productPairWindow_one (σ : Cfg d (2 * 1)) :
     productPairWindow 1 σ 0 = σ := by
   funext j
   simp [productPairWindow]
 
-/-- The even-chain state obtained by repeating a fixed two-site amplitude on
-disjoint adjacent pairs.
+/-- The even-chain state obtained by repeating a fixed two-site amplitude on the
+physical pairs `(0,1), (2,3), ...`.
 
-This is the disjoint adjacent-pair expression used by the conditional
+This is the physical-pair factorization used by the conditional
 nearest-neighbor parent-term theorem below. It is not the basic-vector formula
 of arXiv:1606.00608, lines 570--578, by itself: the source formula first puts
 \(\varphi_j\) between \(b_n\) and \(a_{n+1}\) and then applies \(U\) to
-\((a_n,b_n)\) at every site. Any use of this disjoint adjacent-pair expression
+\((a_n,b_n)\) at every site. Any use of this physical-pair factorization
 therefore has to be justified separately from the source formula. -/
 def productPairState (ψ₂ : NSiteSpace d 2) (N : ℕ) : NSiteSpace d (2 * N) :=
   fun σ => ∏ p : Fin N, ψ₂ (productPairWindow N σ p)
@@ -100,12 +100,12 @@ def productPairState (ψ₂ : NSiteSpace d 2) (N : ℕ) : NSiteSpace d (2 * N) :
   funext σ
   simp [productPairState]
 
-/-- On a single adjacent pair, the product state is the original two-site amplitude. -/
+/-- For one physical pair, the product state is the original two-site amplitude. -/
 @[simp] theorem productPairState_one (ψ₂ : NSiteSpace d 2) (σ : Cfg d (2 * 1)) :
     productPairState ψ₂ 1 σ = ψ₂ σ := by
   simp [productPairState]
 
-/-- An MPS tensor has disjoint adjacent-pair MPVs when every positive
+/-- An MPS tensor has even-chain physical-pair factorization when every positive
 even-length coefficient factors as a repeated copy of one fixed two-site
 amplitude on the pairs \((0,1),(2,3),\ldots\).
 
@@ -117,8 +117,8 @@ identify the translated two-site parent terms in the RFP-to-NNCPH direction of
 arXiv:1606.00608, Theorem 3.10.
 
 **Scope restriction:** Appendix B first produces the basic-vector expression
-\(U^{\otimes N}\varphi_j^{\otimes N}\). This predicate is the later disjoint
-adjacent-pair condition used by the present formal statement; it is not, by
+\(U^{\otimes N}\varphi_j^{\otimes N}\). This predicate is the later even-chain
+physical-pair condition used by the present formal statement; it is not, by
 itself, the full Appendix B factorization theorem. -/
 def HasProductPairMPV (A : MPSTensor d D) : Prop :=
   ∃ ψ₂ : NSiteSpace d 2, ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
@@ -130,7 +130,7 @@ theorem HasProductPairMPV.exists_twoSiteAmplitude {A : MPSTensor d D}
       mpv A σ = productPairState ψ₂ N σ :=
   hA
 
-/-- Witness that the nearest-neighbor local terms of \(A\) are idempotents
+/-- Local-projector data saying that the nearest-neighbor local terms of \(A\) are idempotents
 \(p_i\) associated to the adjacent two-site factors on an \(N\)-site chain, with
 \(p_i p_j=p_j p_i\).
 
@@ -166,8 +166,8 @@ theorem HasProductPairLocalProjectors.commuting_twoSite_localTerms
   rw [hPair.hlocal i, hPair.hlocal j]
   exact hPair.hcomm i j
 
-/-- A commuting family of translated length-two parent terms gives the local
-projector witness, since each translated parent term is already idempotent. -/
+/-- A commuting family of translated length-two parent terms gives the required
+local-projector data, since each translated parent term is already idempotent. -/
 noncomputable def HasProductPairLocalProjectors.of_commuting_localTerms
     {A : MPSTensor d D} {N : ℕ}
     (hcomm : ∀ i j : Fin N,
@@ -180,7 +180,7 @@ noncomputable def HasProductPairLocalProjectors.of_commuting_localTerms
   hcomm := hcomm
 
 /-- Conditional hypotheses for a tensor whose positive even-chain coefficients
-factor through one disjoint adjacent two-site amplitude and whose
+factor through one repeated two-site amplitude and whose
 nearest-neighbor parent terms are commuting idempotents on every finite chain. -/
 structure ProductPairBridge (A : MPSTensor d D) where
   pairAmplitude : NSiteSpace d 2
@@ -199,7 +199,7 @@ theorem ProductPairBridge.hasProductPairMPV {A : MPSTensor d D}
     HasProductPairMPV A :=
   ⟨hBridge.pairAmplitude, hBridge.hmpv⟩
 
-/-- The conditional adjacent-pair hypotheses yield the unfolded `IsNNCPH`
+/-- The conditional physical-pair hypotheses yield the unfolded `IsNNCPH`
 conclusion: all two-site local terms commute on every finite chain.
 
 The statement is written as the commutation equation for the translated
@@ -264,7 +264,7 @@ theorem AppendixBStructuralData.exists_ofRFP (A : MPSTensor d D) [NeZero D]
 
 /-- Extract the Appendix B structural form from the proved structural theorem.
 
-This is a noncomputable definition only because it chooses a witness from the
+This is a noncomputable definition only because it chooses an element of the
 nonempty type produced by `AppendixBStructuralData.exists_ofRFP`; it introduces
 no new assumptions or trusted constants. -/
 noncomputable def AppendixBStructuralData.ofRFP (A : MPSTensor d D) [NeZero D]
@@ -631,7 +631,7 @@ theorem AppendixBStructuralData.cyclicVirtualPairState_two_eq_twoSiteAmplitude
   rw [← hStruct.mpv_coreTensor_eq_cyclicVirtualPairState (by decide : 0 < 2) σ,
     hStruct.twoSiteAmplitude_eq_coreTensor_mpv]
 
-/-- The length-two case of the disjoint adjacent-pair coefficient condition. -/
+/-- The length-two case of the even-chain physical-pair factorization. -/
 theorem AppendixBStructuralData.mpv_coreTensor_eq_productPairState_one {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) (σ : Cfg d (2 * 1)) :
     mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude 1 σ := by
@@ -645,19 +645,18 @@ theorem AppendixBStructuralData.mpv_eq_productPairState_one {A : MPSTensor d D}
     mpv A σ = productPairState hStruct.twoSiteAmplitude 1 σ := by
   rw [productPairState_one, hStruct.twoSiteAmplitude_eq_mpv]
 
-/-- The remaining disjoint adjacent-pair condition needed after the source
+/-- The remaining even-chain physical-pair factorization needed after the source
 basic-vector expression.
 
 For a fixed structural form, this captures the two facts that are still not
 produced by the Appendix B structural datum: the coefficient formula for
 \(U^{\otimes N}\varphi_j^{\otimes N}\) must be related to the repeated
-disjoint adjacent two-site amplitude stated here, and the nearest-neighbor
+physical-pair two-site amplitude stated here, and the nearest-neighbor
 parent projectors on each finite chain must be identified with a commuting
 family attached to the source projectors \(Q_{AX}\) and \(Q_{XB}\). -/
 structure AppendixBProductPairExtraction {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) where
-  /-- Positive even-chain adjacent-pair factorization through the structural
-  two-site amplitude. -/
+  /-- Positive even-chain factorization through the structural two-site amplitude. -/
   hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState hStruct.twoSiteAmplitude N σ
   /-- Local projectors realizing the nearest-neighbor parent terms. -/
@@ -720,7 +719,7 @@ theorem AppendixBProductPairExtraction.commuting_twoSite_localTerms
 /-- Conditional form of the forward implication in arXiv:1606.00608,
 Theorem 3.10:
 RFP plus the proved Appendix B structural theorem implies the nearest-neighbor
-commutation equation as soon as the disjoint adjacent-pair coefficient condition
+commutation equation as soon as the even-chain physical-pair coefficient condition
 and the two-site projector identities are supplied for the resulting structural
 form.
 

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -117,9 +117,9 @@ identify the translated two-site parent terms in the RFP-to-NNCPH direction of
 arXiv:1606.00608, Theorem 3.10.
 
 **Scope restriction:** Appendix B first produces the basic-vector expression
-\(U^{\otimes N}\varphi_j^{\otimes N}\). This predicate is the later even-chain
-physical-pair condition used by the present formal statement; it is not, by
-itself, the full Appendix B factorization theorem. -/
+\(U^{\otimes N}\varphi_j^{\otimes N}\). The condition above instead asks for an
+even-chain physical-pair factorization; by itself, it is not the full Appendix B
+factorization theorem. -/
 def HasProductPairMPV (A : MPSTensor d D) : Prop :=
   ∃ ψ₂ : NSiteSpace d 2, ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState ψ₂ N σ

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -62,7 +62,7 @@ namespace MPSTensor
 
 variable {d D : ℕ}
 
-/-- Extract the `p`-th two-site physical pair from a configuration on `2N`
+/-- Extract the `p`-th two-site physical pair from a configuration on `2 * N`
 sites, using the pairs `(0,1), (2,3), ...`. -/
 def productPairWindow (N : ℕ) (σ : Cfg d (2 * N)) (p : Fin N) : Cfg d 2 :=
   fun j => σ ⟨2 * p.val + j.val, by
@@ -130,9 +130,9 @@ theorem HasProductPairMPV.exists_twoSiteAmplitude {A : MPSTensor d D}
       mpv A σ = productPairState ψ₂ N σ :=
   hA
 
-/-- Local-projector data saying that the nearest-neighbor local terms of \(A\) are idempotents
-\(p_i\) associated to the adjacent two-site factors on an \(N\)-site chain, with
-\(p_i p_j=p_j p_i\).
+/-- Local-projector data saying that the nearest-neighbor local terms of \(A\)
+are idempotents \(p_i\) associated to the two-site factors on an \(N\)-site
+chain, with \(p_i p_j = p_j p_i\).
 
 **Scope restriction (local projectors):** The three-site \(AX/XB\) support maps
 for adjacent windows give the local support maps. This structure does not

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -111,8 +111,8 @@ amplitude on the pairs \((0,1),(2,3),\ldots\).
 
 This is a generic factorization predicate: it does not assert that the two-site
 amplitude is entangled. The zero-pair case is omitted because the empty-chain
-MPV coefficient is the bond dimension, whereas the empty disjoint-pair amplitude
-is \(1\). Odd chain lengths are omitted because this predicate is used only to
+MPV coefficient is the bond dimension, whereas the empty physical-pair product is
+\(1\). Odd chain lengths are omitted because this predicate is used only to
 identify the translated two-site parent terms in the RFP-to-NNCPH direction of
 arXiv:1606.00608, Theorem 3.10.
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1226,16 +1226,15 @@ the specialization $L=2$.
         =
         V^{(2)}(\Lambda U)(a,b).
     \]
-    Thus the adjacent-pair factorization is already verified for one physical
-    pair in the core tensor:
+    Thus the one-pair case of the factorization is already verified for the core
+    tensor:
     \[
         V^{(2)}(\Lambda U)(\sigma)
         =
         \phi_2(\sigma_0,\sigma_1).
     \]
-    The disjoint adjacent-pair condition presently used in the formal statement
-    is the even-chain factorization, for a positive number $n$ of adjacent
-    pairs,
+    The even-chain physical-pair factorization presently used in the formal
+    statement is the following condition, for a positive number $n$ of pairs,
     \[
         V^{(2n)}(A)(\sigma)
         =
@@ -1249,7 +1248,7 @@ the specialization $L=2$.
     expansion of the closed matrix product and is the coefficient form of
     $U^{\otimes L}\varphi_j^{\otimes L}$. The remaining coefficient step is
     to relate this source expression, with the physical word $\sigma$ fixed, to
-    the disjoint adjacent-pair condition above.
+    the even-chain physical-pair factorization above.
     On a three-site chain, the two adjacent length-two parent terms are the
     \(AX\) and \(XB\) actions of the canonical two-site parent interaction.
     Appendix~B supplies the basic-vector expression, while Appendix~D.2 supplies
@@ -1270,23 +1269,23 @@ the specialization $L=2$.
     The projector equation $h_i(A,2)^2=h_i(A,2)$ is already
     Lemma~\ref{lem:local_term_idempotent}.
     The overlapping commutation theorem and the justification of any passage
-    from the source coefficients to this adjacent-pair condition are the
+    from the source coefficients to this even-chain factorization are the
     remaining obligations before the conditional theorem can be applied; once
     they are proved, the local terms commute. Together with
-    Lemma~\ref{lem:parent_hamiltonian_ff}, the adjacent-pair condition also gives the
-    zero-energy equation for $V^{(N)}(A)$, still without asserting the source
-    ground-space spanning condition.
+    Lemma~\ref{lem:parent_hamiltonian_ff}, the same factorization also gives
+    the zero-energy equation for $V^{(N)}(A)$, still without asserting the
+    source ground-space spanning condition.
 \end{remark}
 
-\begin{theorem}[Adjacent-pair condition and ground-space spanning give all-chain NNCPH]%
+\begin{theorem}[Even-chain factorization and ground-space spanning give all-chain NNCPH]%
     \label{thm:appendixB_product_pair_has_nncph_ground_spaces}
     \lean{MPSTensor.ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning}
     \lean{MPSTensor.rfp_implies_hasNNCPHGroundSpaces_of_appendixBExtraction_of_groundSpaceSpanning}
     \leanok
     \uses{rem:product_pair_projectors, def:has_nncph_ground_spaces,
         def:parent_hamiltonian_ground_space_spanning}
-    Suppose the conditional adjacent-pair hypotheses give commuting two-site
-    parent terms for a tensor \(B\). If the nearest-neighbor parent Hamiltonian also
+    Suppose the conditional even-chain hypotheses give commuting two-site parent
+    terms for a tensor \(B\). If the nearest-neighbor parent Hamiltonian also
     satisfies the ground-space spanning equation of
     Definition~\ref{def:parent_hamiltonian_ground_space_spanning}, with BNT
     components \(A_1,\ldots,A_g\), then \(B\) satisfies the all-chain
@@ -1302,7 +1301,7 @@ the specialization $L=2$.
 \begin{proof}
     \uses{lem:parent_hamiltonian_ff, def:has_nncph_ground_space}
     \leanok
-    The adjacent-pair hypotheses give \(h_i h_j=h_j h_i\) for all translated
+    The conditional hypotheses give \(h_i h_j=h_j h_i\) for all translated
     two-site parent terms. Lemma~\ref{lem:parent_hamiltonian_ff} gives
     \(h_iV^{(N)}(B)=0\). For every \(N>2\), the spanning hypothesis supplies
     \[

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1233,8 +1233,8 @@ the specialization $L=2$.
         =
         \phi_2(\sigma_0,\sigma_1).
     \]
-    The even-chain physical-pair factorization presently used in the formal
-    statement is the following condition, for a positive number $n$ of pairs,
+    The even-chain physical-pair factorization is the following condition, for a
+    positive number $n$ of pairs,
     \[
         V^{(2n)}(A)(\sigma)
         =

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -53,7 +53,7 @@ space \(E\), it asks for endomorphisms \(P_{AX},P_{XB}:E\to E\) such that
 It does not assert a tensor decomposition of \(E\), local action on the
 \(AX\) and \(XB\) tensor factors, self-adjointness, orthogonality, or the
 existence of source projectors \(Q_{AX}\) and \(Q_{XB}\).  Consequently every
-idempotent \(P_K\) has the tautological witness
+idempotent \(P_K\) has the tautological choice
 \(P_{AX}=P_{XB}=P_K\), recorded by
 \leanid{Decorrelation.HasCommutingParentHam.ofIdem}.
 
@@ -112,7 +112,7 @@ After that source-level version is available, the blueprint entry for the source
 parent commuting Hamiltonian condition should point to that statement.  The
 current idempotent-product declaration can remain as the
 algebraic lemma used in the backward direction of Proposition~D.3.  The work is
-tracked by \ghissue{2633} and \ghissue{190}.
+tracked by \ghissue{3373}, \ghissue{2633}, and \ghissue{190}.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- The RFP-to-NNCPH bridge docstrings in `CommutingBridge.lean` used ambiguous
  "disjoint adjacent-pair" wording that conflated the source Appendix B
  basic-vector form (U^⊗L φ_j^⊗L) with the even-chain physical-pair
  factorization (pairs (0,1), (2,3), …) used by the conditional formal statements;
  see arXiv:1606.00608, Appendix B.
- The parent-Hamiltonian blueprint chapter
  (`ch13_parent_hamiltonian_commuting_gap.tex`) used inconsistent terminology
  for the same factorization.
- The paper-gap tracking file (`cpsv16_parent_commuting_hamiltonian_scope.tex`)
  did not yet reference issue #3373, which tracks the Appendix B projector
  identification step; see docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex.
- Continues parent-Hamiltonian prose alignment work toward #2633 and tracker #190.

### Description

- `TNLean/MPS/RFP/CommutingBridge.lean`: rewrote docstrings to distinguish
  the source Appendix B basic-vector form from the even-chain physical-pair
  factorization used by the conditional formal statements. No Lean definitions,
  proofs, or APIs changed.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: updated
  a remark and theorem title to use consistent even-chain physical-pair
  terminology matching the Lean docstrings.
- `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`: added
  reference to issue #3373 in the parent-commuting gap tracking sentence.

No Lean proof obligations were added or removed.

### Testing

- `lake env lean TNLean/MPS/RFP/CommutingBridge.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && python3 scripts/blueprint_lean_sync.py --root . --ci && lake exe checkdecls blueprint/lean_decls`
- `git diff --check`

---
Refs #3373. Refs #2633. Refs #190.

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no executable or proof logic changes.
>
> **Overview**
> **Documentation-only** alignment of how the RFP→NNCPH bridge talks about coefficient factorization: prose now consistently uses **even-chain physical-pair factorization** (pairs `(0,1), (2,3), …`) instead of **disjoint adjacent-pair** wording, and stresses that this is **not** the same as the source Appendix B basic-vector form \(U^{\otimes L}\varphi_j^{\otimes L}\).
>
> Updates span `CommutingBridge.lean` docstrings, the parent-Hamiltonian blueprint remark and theorem title in `ch13_parent_hamiltonian_commuting_gap.tex`, and a minor wording tweak plus **#3373** in `cpsv16_parent_commuting_hamiltonian_scope.tex`. **No Lean definitions, proofs, or APIs change.**
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8984fea7defb09e1da648ce992a443850f5613be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and LaTeX documentation only; no executable logic or proof obligations were added or removed.
> 
> **Overview**
> **Documentation-only** alignment for the RFP→NNCPH bridge: prose now consistently uses **even-chain physical-pair factorization** (pairs `(0,1), (2,3), …`) instead of **disjoint adjacent-pair** wording, and stresses that this condition is **not** the same as the Appendix B source basic-vector form \(U^{\otimes L}\varphi_j^{\otimes L}\).
> 
> Updates are in `CommutingBridge.lean` docstrings (definitions like `productPairWindow`, `HasProductPairMPV`, `AppendixBProductPairExtraction`, and related theorems), the parent-Hamiltonian blueprint remark and theorem title in `ch13_parent_hamiltonian_commuting_gap.tex`, and a small tracking tweak in `cpsv16_parent_commuting_hamiltonian_scope.tex` (adds **#3373**, “witness” → “choice”). **No Lean definitions, proofs, or APIs change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bd64dddf58ef4b50b9291ed6fa46a4510f318ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->