### PR TITLE
doc(MPS/ParentHamiltonian): align physical-pair terminology

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -45,8 +45,8 @@ clause from Definition 3.9.
   \(hᵢhⱼ = hⱼhᵢ\).
 * `MPSTensor.rfp_implies_nncph_of_appendixBExtraction` — a conditional theorem
   deriving NNCPH from the Appendix B structural form
-  \(A^i = X\Lambda U^iX^{-1}\), the disjoint adjacent-pair coefficient
-  condition, and the two-site projector identities, without invoking
+  \(A^i = X\Lambda U^iX^{-1}\), the even-chain physical-pair factorization,
+  and the two-site projector identities, without invoking
   `Axioms.rfp_to_nncph_commute`.
 * `MPSTensor.rfp_implies_nncph_ground_state_of_appendixBExtraction` — the same
   conditional theorem with the zero-energy equation for \(V^{(N)}(A)\) included.
@@ -346,17 +346,17 @@ theorem HasProductPairLocalProjectors.isNNCPH {A : MPSTensor d D} {N : ℕ}
     IsNNCPH A N :=
   hPair.commuting_twoSite_localTerms
 
-/-- The disjoint adjacent-pair coefficient condition and the two-site projector
+/-- The even-chain physical-pair factorization and the two-site projector
 identities give NNCPH on each finite chain. -/
 theorem ProductPairBridge.isNNCPH {A : MPSTensor d D} (hBridge : ProductPairBridge A)
     (N : ℕ) :
     IsNNCPH A N :=
   (hBridge.localProjectors N).isNNCPH
 
-/-- The conditional adjacent-pair hypotheses and the ground-space spanning
+/-- The conditional even-chain hypotheses and the ground-space spanning
 equation give the full all-chain nearest-neighbor parent-Hamiltonian condition.
 
-The adjacent-pair hypotheses supply the translated length-two commutation
+The even-chain hypotheses supply the translated length-two commutation
 equations. The usual parent-Hamiltonian frustration-free equation gives
 zero energy of \(V^{(N)}(B)\). The separate hypothesis
 `HasParentHamiltonianGroundSpaceSpanning B 2 A` supplies the remaining
@@ -374,8 +374,8 @@ theorem ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning
 
 A normal left-canonical RFP tensor has the Appendix B structural form
 \(A^i = X\Lambda U^iX^{-1}\) by `AppendixBStructuralData.ofRFP`. If the
-associated two-site amplitude gives the disjoint adjacent-pair coefficient
-condition and the two-site parent terms are identified with commuting
+associated two-site amplitude gives the even-chain physical-pair factorization
+and the two-site parent terms are identified with commuting
 idempotents, then the nearest-neighbor parent Hamiltonian is commuting on every
 finite chain.
 

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -128,9 +128,9 @@ coefficient representatives, prove the lifted \(AX/XB\) commutator, and extend
 the local transport to the all-chain family of two-site parent projectors.  On
 the coefficient side, the source statement is the basic-vector formula
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), where
-\(\varphi_j\) is shared between neighboring virtual spins.  The current
-disjoint adjacent-pair condition is a separate conditional statement and should
-not be read as the source formula itself.
+\(\varphi_j\) is shared between neighboring virtual spins.  The even-chain
+physical-pair factorization is a separate conditional statement and should not
+be read as the source formula itself.
 The reverse theorem now consumes both the explicit BNT relation
 \leanid{MPSTensor.IsBNT} and the named all-chain condition
 \leanid{MPSTensor.HasNNCPHGroundSpaces}, but the implication still depends on
@@ -156,14 +156,15 @@ one-dimensional nearest-neighbor commuting-Hamiltonian ground-space
 classification and identify the resulting locally orthogonal states with the
 basis of normal tensors of $A$.\footnote{Tracked by \ghissue{2633}.}
 
-The present formal boundary is therefore: the reverse implication has the
+The current proof boundary is therefore: the reverse implication has the
 source ground-space hypothesis, but its proof is still the Beigi axiom; the
 forward implication has the source-unit Appendix~B structural datum, the
 three-site \(AX/XB\) support maps, and the coefficient form of
 \(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks the construction of the
 source Appendix~D.2 projectors and their lifted commutator from that datum, the
-all-chain local-projector witness, and a justified relation between the source
-formula and any disjoint adjacent-pair condition used by the conditional theorem.
+all-chain local-projector hypotheses, and a justified relation between the source
+formula and the even-chain physical-pair factorization used by the conditional
+theorem.
 The axiom-backed theorem still supplies the commutation direction used by the
 unconditional statements.
 

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -117,8 +117,8 @@ Appendix~B first gives the coefficient form of the basic-vector expression
 \end{align}
 which is the coefficient form of
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), with
-\(\varphi_j\) shared between \(b_t\) and \(a_{t+1}\).  The disjoint adjacent
-physical-pair condition used by the current conditional parent-Hamiltonian
+\(\varphi_j\) shared between \(b_t\) and \(a_{t+1}\).  The even-chain
+physical-pair factorization considered in the conditional parent-Hamiltonian
 theorem is therefore a separate statement, not the source expression itself.
 The formal development proves this cyclic coefficient formula for the original
 tensor after the Appendix~B change of basis, for every nonempty chain length
@@ -128,11 +128,11 @@ and a chosen structural datum:
 \]
 This is the declaration
 \leanid{MPSTensor.AppendixBStructuralData.mpv_eq_cyclicVirtualPairState}.  It
-does not prove the disjoint adjacent physical-pair condition.
+does not prove the even-chain physical-pair factorization.
 The pair-index isometry above is an orthogonality equation after summing over
 the physical letter \(i\).  It is therefore not, by itself, a coefficient
 identity for a fixed physical word \(\sigma\).  Any proof of a fixed-word
-adjacent-pair factorization must use the source basic-vector expression
+physical-pair factorization must use the source basic-vector expression
 \(U^{\otimes L}\varphi_j^{\otimes L}\), or an equivalent construction of the
 corresponding local projectors, rather than applying the summed isometry as if
 the physical labels were also summed in \(C_L(\sigma)\).
@@ -149,13 +149,13 @@ length-four word
   \sigma=((0,1),(1,0),(1,0),(0,1)),
 \]
 the cyclic coefficient \(C_4(\sigma)\) vanishes, because the middle virtual
-matching condition fails.  The disjoint adjacent-pair product is instead
+matching condition fails.  The physical-pair product is instead
 \[
   (\lambda_0\lambda_1)(\lambda_1\lambda_0)
   =
   \lambda_0^2\lambda_1^2\ne 0.
 \]
-Thus the adjacent physical-pair coefficient identity is not a consequence of
+Thus the even-chain physical-pair coefficient identity is not a consequence of
 the unit pair-index isometry alone.
 
 The per-block isometry form does not by itself relate $U_k$ and $U_\ell$ for


### PR DESCRIPTION
### Motivation

- Follow-up to #3637: aligns the remaining parent-Hamiltonian and RFP paper-gap
  notes with the even-chain physical-pair terminology introduced in that PR.
- Removes stale adjacent-pair and local-projector witness wording from the
  conditional RFP-to-NNCPH prose in
  `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` and
  `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.
- Keeps the source Appendix B basic-vector expression
  (arXiv:1606.00608, Appendix B) distinct from the conditional even-chain
  factorization, per the scope boundary recorded in #3373.

### Description

- `TNLean/MPS/ParentHamiltonian/Commuting.lean`: updated module docstring to
  replace adjacent-pair / local-projector witness language with even-chain
  physical-pair factorization terminology.
- `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`: removed stale
  adjacent-pair condition and local-projector witness wording; renamed
  "formal boundary" to "proof boundary" in the elimination-plan paragraph.
- `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`: aligned even-chain
  physical-pair terminology; preserved the distinction between the source
  Appendix B basic-vector formula and the conditional factorization.
- No Lean definitions, theorems, or proofs change — module docstrings and
  paper-gap notes only.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`

---
Addresses #3373.
Refs #2633.
Refs #190.

> [!NOTE]
> **Low Risk**
> Comment and documentation edits only; no executable Lean or proof logic is modified.
>
> **Overview**
> **Documentation-only** follow-up to #3637: prose in `Commuting.lean` and two paper-gap notes now consistently say **even-chain physical-pair factorization** instead of **disjoint adjacent-pair** (coefficient condition / hypotheses).
>
> The NNCPH and RFP scope documents repeat that the source Appendix B basic-vector formula \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\) is **not** the same object as this conditional factorization, and they drop stale wording about adjacent-pair conditions and local-projector "witnesses." The ground-state scope note also renames "formal boundary" to **proof boundary** in the elimination-plan paragraph.
>
> No Lean definitions, theorems, or proofs change—only module docstrings and reader-facing `.tex` text.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d1c3c09085ec4e16d9393733591164ed81ea40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>