### PR TITLE
feat(Channel): prove first Choi cyclic subcase

### DIFF
--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -6,6 +6,7 @@ Authors: TNLean contributors
 import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.Permutation
 import TNLean.Algebra.HermitianHelpers
+import TNLean.Analysis.MatrixTraceInequalities
 
 /-!
 # Choi-type positive maps
@@ -147,6 +148,63 @@ noncomputable def choiTypeRankOneWeight (d n : ℕ) [NeZero d] (v : ZMod d → �
   ((d : ℝ) - (n : ℝ)) * ‖v i‖ ^ 2 +
     ∑ k : Fin n, ‖v (i - ((k.1 + 1 : ℕ) : ZMod d))‖ ^ 2
 
+/-- The first nontrivial Choi cyclic reciprocal estimate.
+
+For the case \(d=3\), \(n=1\), the cyclic reciprocal bound reduces to
+\[
+  \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le 1.
+\]
+Clearing denominators gives
+\[
+  x^2y+y^2z+z^2x\ge 3xyz,
+\]
+which is AM--GM applied to \(x^2y,y^2z,z^2x\).
+
+**Scope restriction:** See
+`docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`.  This proves
+only the strict-positive three-variable subcase of the scalar estimate needed
+for Wolf Chapter 3, Example 3.1, equation (3.20).  The full nonnegative cyclic
+estimate for \(1\le n\le d-2\) remains separate. -/
+theorem choiType_cyclic_reciprocal_three_one_of_pos
+    {x y z : ℝ} (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) :
+    x / (2 * x + z) + y / (2 * y + x) + z / (2 * z + y) ≤ 1 := by
+  have hA : 0 < 2 * x + z := by positivity
+  have hB : 0 < 2 * y + x := by positivity
+  have hC : 0 < 2 * z + y := by positivity
+  rw [← sub_nonneg]
+  field_simp [hA.ne', hB.ne', hC.ne']
+  have hamgm : x ^ 2 * y + y ^ 2 * z + z ^ 2 * x - 3 * x * y * z ≥ 0 := by
+    let f : Fin 3 → ℝ := ![x ^ 2 * y, y ^ 2 * z, z ^ 2 * x]
+    have hf : ∀ i, 0 ≤ f i := by
+      intro i
+      fin_cases i <;> simp [f] <;> positivity
+    have h := pow_card_mul_prod_le_sum_pow (D := 3) f hf
+    have hcube : (3 * x * y * z) ^ 3 ≤
+        (x ^ 2 * y + y ^ 2 * z + z ^ 2 * x) ^ 3 := by
+      simpa [f, Fin.prod_univ_three, Fin.sum_univ_three, pow_succ, pow_two,
+        mul_assoc, mul_left_comm, mul_comm] using h
+    have hleft_nonneg : 0 ≤ 3 * x * y * z := by positivity
+    have hright_nonneg : 0 ≤ x ^ 2 * y + y ^ 2 * z + z ^ 2 * x := by positivity
+    have hle : 3 * x * y * z ≤ x ^ 2 * y + y ^ 2 * z + z ^ 2 * x := by
+      exact (pow_le_pow_iff_left₀ hleft_nonneg hright_nonneg
+        (by decide : (3 : ℕ) ≠ 0)).mp hcube
+    linarith
+  nlinarith
+
+/-- The cyclic reciprocal sum for the Choi rank-one weights when \(d=3\) and
+\(n=1\), written in the three explicit cyclic coordinates. -/
+theorem choiTypeRankOneWeight_reciprocal_sum_three_one (v : ZMod 3 → ℂ) :
+    ∑ i : ZMod 3, ‖v i‖ ^ 2 / choiTypeRankOneWeight 3 1 v i =
+      ‖v 0‖ ^ 2 / (2 * ‖v 0‖ ^ 2 + ‖v 2‖ ^ 2) +
+        ‖v 1‖ ^ 2 / (2 * ‖v 1‖ ^ 2 + ‖v 0‖ ^ 2) +
+          ‖v 2‖ ^ 2 / (2 * ‖v 2‖ ^ 2 + ‖v 1‖ ^ 2) := by
+  have hfin2 : (ZMod.finEquiv 3) 2 = (2 : ZMod 3) := by decide
+  have hminus : (-(1 : ZMod 3)) = 2 := by decide
+  rw [← (ZMod.finEquiv 3).toEquiv.sum_comp]
+  rw [Fin.sum_univ_three]
+  simp [choiTypeRankOneWeight, hfin2, hminus]
+  ring_nf
+
 /-- Rank-one positivity of the Choi-type map reduced to the cyclic reciprocal
 bound for the diagonal weights.
 
@@ -200,5 +258,27 @@ theorem choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one
   · subst hij
     simp [a, choiTypeRankOneWeight, Complex.mul_conj, Complex.normSq_eq_norm_sq]
   · simp [hij]
+
+/-- Strict-nonzero-coordinate rank-one positivity for the first Choi map.
+
+For \(d=3\), \(n=1\), if all three coordinates of \(v\) are nonzero, then the
+rank-one image \(T_C(|v\rangle\langle v|)\) is positive semidefinite.
+
+**Scope restriction:** See
+`docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`.  This is only a
+strict-coordinate subcase of the positivity assertion in Wolf Chapter 3,
+Example 3.1, equation (3.20).  It does not prove positivity of \(T_C\) on every
+positive semidefinite matrix, and it does not treat the general range
+\(1\le n\le d-2\). -/
+theorem choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero
+    (v : ZMod 3 → ℂ) (h0 : v 0 ≠ 0) (h1 : v 1 ≠ 0) (h2 : v 2 ≠ 0) :
+    (choiTypeMap 3 1 (vecMulVec v (star v))).PosSemidef := by
+  refine choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one
+    (d := 3) (n := 1) v (by decide) ?_
+  have hpos0 : 0 < ‖v 0‖ ^ 2 := sq_pos_of_ne_zero (by simpa [norm_eq_zero] using h0)
+  have hpos1 : 0 < ‖v 1‖ ^ 2 := sq_pos_of_ne_zero (by simpa [norm_eq_zero] using h1)
+  have hpos2 : 0 < ‖v 2‖ ^ 2 := sq_pos_of_ne_zero (by simpa [norm_eq_zero] using h2)
+  rw [choiTypeRankOneWeight_reciprocal_sum_three_one]
+  exact choiType_cyclic_reciprocal_three_one_of_pos hpos0 hpos1 hpos2
 
 end Matrix

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -441,6 +441,37 @@ weights.
     the stated positivity.
 \end{proof}
 
+\begin{lemma}[The first Choi cyclic reciprocal subcase]
+    \label{lem:choi_type_first_cyclic_reciprocal_subcase}
+    \lean{Matrix.choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero}
+    \leanok
+    \uses{def:choi_type_map, def:choi_type_rankone_weight,
+        lem:choi_type_rankone_positive_from_weight_bound}
+    For $d=3$ and $n=1$, let $v=(v_0,v_1,v_2)$ have no zero coordinate.  Then
+    \[
+        T_C(\ket{v}\bra{v})\ge0 .
+    \]
+    Equivalently, with
+    $x=|v_0|^2$, $y=|v_1|^2$, and $z=|v_2|^2$, the needed cyclic estimate is
+    \[
+        \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le1 .
+    \]
+    This is only the strict-coordinate $3\times3$ rank-one subcase; the
+    nonnegative estimate for all $1\le n\le d-2$ remains open.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Since $x,y,z>0$, the denominators in the displayed inequality are positive.
+    After multiplying by their product, the inequality is equivalent to
+    \[
+        x^2y+y^2z+z^2x\ge3xyz .
+    \]
+    This follows from AM--GM applied to the three positive numbers
+    $x^2y$, $y^2z$, and $z^2x$.  The rank-one positivity then follows from
+    Lemma~\ref{lem:choi_type_rankone_positive_from_weight_bound}.
+\end{proof}
+
 \section{The partial transpose and the PPT property}
 
 Transposition is a positive map that is not completely positive, so applying it

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -102,6 +102,13 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
   consequence of CPSV16 Definition D.2, while the source definition also has
   tensor-product locality and orthogonal-projector hypotheses.
 
+For Wolf Chapter 3 positive maps:
+
+- `wolf_ex3_1_choi_positivity_subcase_scope.tex` records that the current
+  Choi-type positivity theorem is only the strict-coordinate \(d=3,n=1\)
+  rank-one subcase of Wolf Example 3.1.  The full nonnegative cyclic reciprocal
+  estimate and the extension to positivity of \(T_C\) remain open.
+
 For the periodic (irreducible-form) MPS Fundamental Theorem of
 arXiv:1708.00029, the overlap-dichotomy development has one route-alignment
 note.

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -1,0 +1,77 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Scope of the First Choi-Type Positivity Subcase (Wolf Example~3.1)}
+\author{}
+\date{2026-07-02}
+
+\begin{document}
+\maketitle
+
+\section{Source statement}
+
+Wolf's Chapter~3, Example~3.1 introduces the Choi-type maps
+\cite{Wolf2012Quantum}\footnote{Local source:
+\path{Notes/WolfNoteTexSource/ch03_positive_not_completely.tex}, lines
+357--365.}  With \(D\) the diagonal projection on \(\mathcal M_d\) and
+\(U_{k0}\) the cyclic shift, the map is
+\begin{align}
+  T_C(X)
+  =(d-n)D(X)-X+\sum_{k=1}^{n}D(U_{k0}XU_{k0}^{\dagger}).
+  \tag{3.20}
+\end{align}
+The source states that \(T_C\) is positive and indecomposable for every
+\(1\le n\le d-2\).  No nonzero-coordinate hypothesis is present.
+
+\section{Restricted statement now proved}
+
+The present development proves only the first strict-coordinate rank-one
+subcase.  For \(d=3\), \(n=1\), and a vector
+\(v=(v_0,v_1,v_2)\) with all coordinates nonzero, it proves
+\begin{align}
+  T_C(|v\rangle\langle v|)\ge 0.
+\end{align}
+The scalar input is the strict-positive cyclic reciprocal inequality
+\begin{align}
+  \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le 1,
+  \qquad x,y,z>0,
+\end{align}
+proved by clearing denominators and applying AM--GM to
+\(x^2y,y^2z,z^2x\).\footnote{Formal declarations:
+\leanid{Matrix.choiType\_cyclic\_reciprocal\_three\_one\_of\_pos} and
+\leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_three\_one\_of\_forall\_ne\_zero}
+in \doclink{TNLean/Channel/ChoiTypeMap}.}
+
+\section{Missing hypotheses and elimination plan}
+
+This is a scope restriction, not the source theorem.  The full positivity
+statement still requires the nonnegative cyclic reciprocal estimate
+\begin{align}
+  \sum_{i\in\mathbb Z/d\mathbb Z}
+  \frac{x_i}{(d-n)x_i+\sum_{k=1}^{n}x_{i-k}}\le 1
+  \qquad (x_i\ge0,\;1\le n\le d-2),
+\end{align}
+with the usual zero-term convention.  Once this estimate is available, it
+should be applied to \(x_i=|v_i|^2\) to remove the nonzero-coordinate
+restriction from the rank-one statement.  A positive-semidefinite decomposition
+will then extend the rank-one result to positivity of \(T_C\) on all positive
+semidefinite matrices.  This is tracked by \ghissue{3622}.  The
+indecomposability assertion of the same source paragraph is separate and is
+tracked by \ghissue{3623}.
+
+\section{Classification}
+
+\emph{Scope restriction.}  The current theorem is mathematically correct as a
+strict \(3\times3\) rank-one subcase, but it should not be cited as the
+formalization of Wolf's full Choi-type positivity theorem.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
### Motivation

- PR LionSR/TNLean#3619 formalized `Matrix.choiTypeMap` (Wolf Ch. 3, Ex. 3.1, eq. (3.20)) and proved the rank-one reduction `choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one`, but deferred positivity for 1 ≤ n ≤ d−2 (see LionSR/QICLean#19).
- This PR proves the first subcase: for d=3, n=1, the map $T_C$ satisfies $T_C(\lvert v\rangle\langle v\rvert) \ge 0$ when all three coordinates of $v$ are nonzero.
- Source: Wolf Lecture Notes, Ch. 3, Example 3.1.

### Description

- `TNLean/Channel/ChoiTypeMap.lean`: added proof of the scalar inequality $\frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le 1$ via AM–GM (applied to $x^2y,\,y^2z,\,z^2x$), then invoked the existing rank-one Choi reduction to obtain positive semidefiniteness of $T_C(\lvert v\rangle\langle v\rvert)$ for the d=3, n=1 strict-coordinate case.
- `blueprint/src/chapter/ch25_positive_not_cp.tex`: added a blueprint entry explicitly marking this as the strict-coordinate 3×3 subcase, distinct from Wolf's full 1 ≤ n ≤ d−2 positivity theorem (which remains open, tracked in LionSR/QICLean#19).

### Testing

- `lake env lean TNLean/Channel/ChoiTypeMap.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web` (succeeds with pre-existing plasTeX and bibliography warnings)
- `leanblueprint checkdecls` could not run because the local worktree did not emit `blueprint/lean_decls`; source-level blueprint-to-Lean sync check passed.

---
Refs LionSR/QICLean#19

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized formal math and documentation in `ChoiTypeMap.lean`; no auth, data, or runtime behavior changes. Scope is explicitly bounded to a strict-positive \(3\times3\) rank-one subcase.
> 
> **Overview**
> Adds the first **proved positivity slice** for Wolf’s Choi-type map \(T_C\): for **\(d=3\)**, **\(n=1\)**, and **\(v\)** with **no zero coordinate**, **`choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero`** shows \(T_C(|v\rangle\langle v|)\) is positive semidefinite.
> 
> The missing scalar step is **`choiType_cyclic_reciprocal_three_one_of_pos`** (\(\frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le 1\) for \(x,y,z>0\)), proved via AM–GM on \(x^2y,y^2z,z^2x\) using **`pow_card_mul_prod_le_sum_pow`** from a new **`TNLean.Analysis.MatrixTraceInequalities`** import. **`choiTypeRankOneWeight_reciprocal_sum_three_one`** rewrites the rank-one weight reciprocal sum into those three terms, then plugs into the existing **`choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one`** reduction.
> 
> Blueprint **`ch25_positive_not_cp.tex`** gets a lemma entry for this subcase; **`docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`** and **`README.md`** document that this is **not** Wolf’s full \(1\le n\le d-2\) / nonnegative cyclic estimate (still LionSR/QICLean#19).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b9171223005b7c09ca9c6c05fdfeac9b93a0395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

