### PR TITLE
feat(Channel): remove Choi subcase zero restriction

### DIFF
--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -148,48 +148,89 @@ noncomputable def choiTypeRankOneWeight (d n : ℕ) [NeZero d] (v : ZMod d → �
   ((d : ℝ) - (n : ℝ)) * ‖v i‖ ^ 2 +
     ∑ k : Fin n, ‖v (i - ((k.1 + 1 : ℕ) : ZMod d))‖ ^ 2
 
-/-- The first nontrivial Choi cyclic reciprocal estimate.
+private theorem choiType_cyclic_reciprocal_three_one_amgm
+    {x y z : ℝ} (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    3 * x * y * z ≤ x ^ 2 * y + y ^ 2 * z + z ^ 2 * x := by
+  let f : Fin 3 → ℝ := ![x ^ 2 * y, y ^ 2 * z, z ^ 2 * x]
+  have hf : ∀ i, 0 ≤ f i := by
+    intro i
+    fin_cases i <;> simp [f] <;> positivity
+  have h := pow_card_mul_prod_le_sum_pow (D := 3) f hf
+  have hcube : (3 * x * y * z) ^ 3 ≤
+      (x ^ 2 * y + y ^ 2 * z + z ^ 2 * x) ^ 3 := by
+    simpa [f, Fin.prod_univ_three, Fin.sum_univ_three, pow_succ, pow_two,
+      mul_assoc, mul_left_comm, mul_comm] using h
+  have hleft_nonneg : 0 ≤ 3 * x * y * z := by positivity
+  have hright_nonneg : 0 ≤ x ^ 2 * y + y ^ 2 * z + z ^ 2 * x := by positivity
+  exact (pow_le_pow_iff_left₀ hleft_nonneg hright_nonneg
+    (by decide : (3 : ℕ) ≠ 0)).mp hcube
 
-For the case \(d=3\), \(n=1\), the cyclic reciprocal bound reduces to
-\[
-  \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le 1.
-\]
-Clearing denominators gives
-\[
-  x^2y+y^2z+z^2x\ge 3xyz,
-\]
-which is AM--GM applied to \(x^2y,y^2z,z^2x\).
+/-- The first Choi cyclic reciprocal estimate, including boundary points.
 
 **Scope restriction:** See
 `docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`.  This proves
-only the strict-positive three-variable subcase of the scalar estimate needed
-for Wolf Chapter 3, Example 3.1, equation (3.20).  The full nonnegative cyclic
-estimate for \(1\le n\le d-2\) remains separate. -/
+only the three-variable scalar estimate needed for the \(d=3,n=1\) rank-one
+subcase of Wolf Chapter 3, Example 3.1, equation (3.20).  The general
+nonnegative cyclic estimate for \(1\le n\le d-2\) remains separate. -/
+theorem choiType_cyclic_reciprocal_three_one_of_nonneg
+    {x y z : ℝ} (hx : 0 ≤ x) (hy : 0 ≤ y) (hz : 0 ≤ z) :
+    x / (2 * x + z) + y / (2 * y + x) + z / (2 * z + y) ≤ 1 := by
+  by_cases hA : x * 2 + z = 0
+  · have hx0 : x = 0 := by nlinarith
+    have hz0 : z = 0 := by nlinarith
+    subst x
+    subst z
+    simp
+    by_cases hy0 : y = 0
+    · subst y
+      norm_num
+    · have hypos : 0 < y := lt_of_le_of_ne hy (Ne.symm hy0)
+      have h2y : 2 * y ≠ 0 := by positivity
+      field_simp [h2y, hypos.ne']
+      linarith
+  by_cases hB : 2 * y + x = 0
+  · have hy0 : y = 0 := by nlinarith
+    have hx0 : x = 0 := by nlinarith
+    subst y
+    subst x
+    simp
+    by_cases hz0 : z = 0
+    · subst z
+      norm_num
+    · have hzpos : 0 < z := lt_of_le_of_ne hz (Ne.symm hz0)
+      have h2z : 2 * z ≠ 0 := by positivity
+      field_simp [h2z, hzpos.ne']
+      linarith
+  by_cases hC : 2 * z + y = 0
+  · have hz0 : z = 0 := by nlinarith
+    have hy0 : y = 0 := by nlinarith
+    subst z
+    subst y
+    simp
+    by_cases hx0 : x = 0
+    · subst x
+      norm_num
+    · have hxpos : 0 < x := lt_of_le_of_ne hx (Ne.symm hx0)
+      have h2x : 2 * x ≠ 0 := by positivity
+      field_simp [h2x, hxpos.ne']
+      linarith
+  have hApos : 0 < x * 2 + z :=
+    lt_of_le_of_ne (by positivity : 0 ≤ x * 2 + z) (Ne.symm hA)
+  have hBpos : 0 < 2 * y + x :=
+    lt_of_le_of_ne (by positivity : 0 ≤ 2 * y + x) (Ne.symm hB)
+  have hCpos : 0 < 2 * z + y :=
+    lt_of_le_of_ne (by positivity : 0 ≤ 2 * z + y) (Ne.symm hC)
+  rw [← sub_nonneg]
+  field_simp [hApos.ne', hBpos.ne', hCpos.ne']
+  have hamgm := choiType_cyclic_reciprocal_three_one_amgm hx hy hz
+  nlinarith [hamgm]
+
+/-- The strict-positive form of the first Choi cyclic reciprocal estimate. -/
 theorem choiType_cyclic_reciprocal_three_one_of_pos
     {x y z : ℝ} (hx : 0 < x) (hy : 0 < y) (hz : 0 < z) :
-    x / (2 * x + z) + y / (2 * y + x) + z / (2 * z + y) ≤ 1 := by
-  have hA : 0 < 2 * x + z := by positivity
-  have hB : 0 < 2 * y + x := by positivity
-  have hC : 0 < 2 * z + y := by positivity
-  rw [← sub_nonneg]
-  field_simp [hA.ne', hB.ne', hC.ne']
-  have hamgm : x ^ 2 * y + y ^ 2 * z + z ^ 2 * x - 3 * x * y * z ≥ 0 := by
-    let f : Fin 3 → ℝ := ![x ^ 2 * y, y ^ 2 * z, z ^ 2 * x]
-    have hf : ∀ i, 0 ≤ f i := by
-      intro i
-      fin_cases i <;> simp [f] <;> positivity
-    have h := pow_card_mul_prod_le_sum_pow (D := 3) f hf
-    have hcube : (3 * x * y * z) ^ 3 ≤
-        (x ^ 2 * y + y ^ 2 * z + z ^ 2 * x) ^ 3 := by
-      simpa [f, Fin.prod_univ_three, Fin.sum_univ_three, pow_succ, pow_two,
-        mul_assoc, mul_left_comm, mul_comm] using h
-    have hleft_nonneg : 0 ≤ 3 * x * y * z := by positivity
-    have hright_nonneg : 0 ≤ x ^ 2 * y + y ^ 2 * z + z ^ 2 * x := by positivity
-    have hle : 3 * x * y * z ≤ x ^ 2 * y + y ^ 2 * z + z ^ 2 * x := by
-      exact (pow_le_pow_iff_left₀ hleft_nonneg hright_nonneg
-        (by decide : (3 : ℕ) ≠ 0)).mp hcube
-    linarith
-  nlinarith
+    x / (2 * x + z) + y / (2 * y + x) + z / (2 * z + y) ≤ 1 :=
+  choiType_cyclic_reciprocal_three_one_of_nonneg
+    (le_of_lt hx) (le_of_lt hy) (le_of_lt hz)
 
 /-- The cyclic reciprocal sum for the Choi rank-one weights when \(d=3\) and
 \(n=1\), written in the three explicit cyclic coordinates. -/
@@ -259,26 +300,32 @@ theorem choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one
     simp [a, choiTypeRankOneWeight, Complex.mul_conj, Complex.normSq_eq_norm_sq]
   · simp [hij]
 
-/-- Strict-nonzero-coordinate rank-one positivity for the first Choi map.
+/-- Rank-one positivity for the first Choi map.
 
-For \(d=3\), \(n=1\), if all three coordinates of \(v\) are nonzero, then the
-rank-one image \(T_C(|v\rangle\langle v|)\) is positive semidefinite.
+For \(d=3\), \(n=1\), the rank-one image \(T_C(|v\rangle\langle v|)\) is
+positive semidefinite.
 
 **Scope restriction:** See
-`docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`.  This is only a
-strict-coordinate subcase of the positivity assertion in Wolf Chapter 3,
+`docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`.  This is only
+the \(3\times3\) rank-one subcase of the positivity assertion in Wolf Chapter 3,
 Example 3.1, equation (3.20).  It does not prove positivity of \(T_C\) on every
 positive semidefinite matrix, and it does not treat the general range
 \(1\le n\le d-2\). -/
-theorem choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero
-    (v : ZMod 3 → ℂ) (h0 : v 0 ≠ 0) (h1 : v 1 ≠ 0) (h2 : v 2 ≠ 0) :
+theorem choiTypeMap_vecMulVec_posSemidef_three_one (v : ZMod 3 → ℂ) :
     (choiTypeMap 3 1 (vecMulVec v (star v))).PosSemidef := by
   refine choiTypeMap_vecMulVec_posSemidef_of_weight_sum_le_one
     (d := 3) (n := 1) v (by decide) ?_
-  have hpos0 : 0 < ‖v 0‖ ^ 2 := sq_pos_of_ne_zero (by simpa [norm_eq_zero] using h0)
-  have hpos1 : 0 < ‖v 1‖ ^ 2 := sq_pos_of_ne_zero (by simpa [norm_eq_zero] using h1)
-  have hpos2 : 0 < ‖v 2‖ ^ 2 := sq_pos_of_ne_zero (by simpa [norm_eq_zero] using h2)
+  have hnonneg0 : 0 ≤ ‖v 0‖ ^ 2 := sq_nonneg _
+  have hnonneg1 : 0 ≤ ‖v 1‖ ^ 2 := sq_nonneg _
+  have hnonneg2 : 0 ≤ ‖v 2‖ ^ 2 := sq_nonneg _
   rw [choiTypeRankOneWeight_reciprocal_sum_three_one]
-  exact choiType_cyclic_reciprocal_three_one_of_pos hpos0 hpos1 hpos2
+  exact choiType_cyclic_reciprocal_three_one_of_nonneg hnonneg0 hnonneg1 hnonneg2
+
+/-- Strict-coordinate rank-one positivity for the first Choi map, kept as an
+immediate consequence of the all-coordinate rank-one result. -/
+theorem choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero
+    (v : ZMod 3 → ℂ) (_h0 : v 0 ≠ 0) (_h1 : v 1 ≠ 0) (_h2 : v 2 ≠ 0) :
+    (choiTypeMap 3 1 (vecMulVec v (star v))).PosSemidef :=
+  choiTypeMap_vecMulVec_posSemidef_three_one v
 
 end Matrix

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -441,13 +441,13 @@ weights.
     the stated positivity.
 \end{proof}
 
-\begin{lemma}[The first Choi cyclic reciprocal subcase]
+\begin{lemma}[The first Choi rank-one positivity subcase]
     \label{lem:choi_type_first_cyclic_reciprocal_subcase}
-    \lean{Matrix.choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero}
+    \lean{Matrix.choiTypeMap_vecMulVec_posSemidef_three_one}
     \leanok
     \uses{def:choi_type_map, def:choi_type_rankone_weight,
         lem:choi_type_rankone_positive_from_weight_bound}
-    For $d=3$ and $n=1$, let $v=(v_0,v_1,v_2)$ have no zero coordinate.  Then
+    For $d=3$ and $n=1$, every vector $v=(v_0,v_1,v_2)$ satisfies
     \[
         T_C(\ket{v}\bra{v})\ge0 .
     \]
@@ -456,19 +456,27 @@ weights.
     \[
         \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le1 .
     \]
-    This is only the strict-coordinate $3\times3$ rank-one subcase; the
-    nonnegative estimate for all $1\le n\le d-2$ remains open.
+    The zero-denominator terms are read as $0$, as in the preceding
+    Schur-complement criterion.  This is only the $3\times3$ rank-one subcase;
+    the cyclic estimate for all $1\le n\le d-2$ remains open.
 \end{lemma}
 
 \begin{proof}
     \leanok
-    Since $x,y,z>0$, the denominators in the displayed inequality are positive.
-    After multiplying by their product, the inequality is equivalent to
+    First assume that the denominators are nonzero.  After multiplying by their
+    product, the inequality is equivalent to
     \[
         x^2y+y^2z+z^2x\ge3xyz .
     \]
-    This follows from AM--GM applied to the three positive numbers
-    $x^2y$, $y^2z$, and $z^2x$.  The rank-one positivity then follows from
+    This follows from AM--GM applied to the three nonnegative numbers
+    $x^2y$, $y^2z$, and $z^2x$.  If one of the denominators vanishes, the
+    corresponding two variables vanish.  For example, if $2x+z=0$, then
+    $x=z=0$, and the remaining term is
+    \[
+        \frac{y}{2y}\le\frac12\le1
+    \]
+    when $y>0$, while all terms vanish when $y=0$.  The rank-one positivity then
+    follows from
     Lemma~\ref{lem:choi_type_rankone_positive_from_weight_bound}.
 \end{proof}
 

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -105,9 +105,9 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
 For Wolf Chapter 3 positive maps:
 
 - `wolf_ex3_1_choi_positivity_subcase_scope.tex` records that the current
-  Choi-type positivity theorem is only the strict-coordinate \(d=3,n=1\)
-  rank-one subcase of Wolf Example 3.1.  The full nonnegative cyclic reciprocal
-  estimate and the extension to positivity of \(T_C\) remain open.
+  Choi-type positivity theorem is only the \(d=3,n=1\) rank-one subcase of
+  Wolf Example 3.1.  The general cyclic reciprocal estimate and the extension
+  to positivity of \(T_C\) remain open.
 
 For the periodic (irreducible-form) MPS Fundamental Theorem of
 arXiv:1708.00029, the overlap-dichotomy development has one route-alignment

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -31,21 +31,21 @@ The source states that \(T_C\) is positive and indecomposable for every
 
 \section{Restricted statement now proved}
 
-The present development proves only the first strict-coordinate rank-one
-subcase.  For \(d=3\), \(n=1\), and a vector
-\(v=(v_0,v_1,v_2)\) with all coordinates nonzero, it proves
+The present development proves only the first rank-one subcase.  For \(d=3\),
+\(n=1\), and an arbitrary vector \(v=(v_0,v_1,v_2)\), it proves
 \begin{align}
   T_C(|v\rangle\langle v|)\ge 0.
 \end{align}
-The scalar input is the strict-positive cyclic reciprocal inequality
+The scalar input is the boundary-inclusive cyclic reciprocal inequality
 \begin{align}
   \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le 1,
-  \qquad x,y,z>0,
+  \qquad x,y,z\ge 0,
 \end{align}
-proved by clearing denominators and applying AM--GM to
-\(x^2y,y^2z,z^2x\).\footnote{Formal declarations:
-\leanid{Matrix.choiType\_cyclic\_reciprocal\_three\_one\_of\_pos} and
-\leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_three\_one\_of\_forall\_ne\_zero}
+with zero-denominator summands read as \(0\).  Away from the boundary this is
+proved by clearing denominators and applying AM--GM to \(x^2y,y^2z,z^2x\); the
+boundary cases reduce to a single half-bound.\footnote{Formal declarations:
+\leanid{Matrix.choiType\_cyclic\_reciprocal\_three\_one\_of\_nonneg} and
+\leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_three\_one}
 in \doclink{TNLean/Channel/ChoiTypeMap}.}
 
 \section{Missing hypotheses and elimination plan}
@@ -58,18 +58,17 @@ statement still requires the nonnegative cyclic reciprocal estimate
   \qquad (x_i\ge0,\;1\le n\le d-2),
 \end{align}
 with the usual zero-term convention.  Once this estimate is available, it
-should be applied to \(x_i=|v_i|^2\) to remove the nonzero-coordinate
-restriction from the rank-one statement.  A positive-semidefinite decomposition
-will then extend the rank-one result to positivity of \(T_C\) on all positive
-semidefinite matrices.  This is tracked by \ghissue{3622}.  The
-indecomposability assertion of the same source paragraph is separate and is
-tracked by \ghissue{3623}.
+should be applied to \(x_i=|v_i|^2\) to obtain the rank-one statement for the
+full parameter range.  A positive-semidefinite decomposition will then extend
+the rank-one result to positivity of \(T_C\) on all positive semidefinite
+matrices.  This is tracked by \ghissue{3622}.  The indecomposability assertion
+of the same source paragraph is separate and is tracked by \ghissue{3623}.
 
 \section{Classification}
 
 \emph{Scope restriction.}  The current theorem is mathematically correct as a
-strict \(3\times3\) rank-one subcase, but it should not be cited as the
-formalization of Wolf's full Choi-type positivity theorem.
+\(3\times3\) rank-one subcase, but it should not be cited as the formalization
+of Wolf's full Choi-type positivity theorem.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

This PR removes the nonzero-coordinate restriction from the first Choi-type positivity subcase.  For the Wolf Chapter 3 Choi-type map at `d = 3`, `n = 1`, it proves rank-one positivity for every vector, including boundary cases with zero coordinates.

Mathematically, the new scalar input is the nonnegative three-variable estimate

\[
  \frac{x}{2x+z}+\frac{y}{2y+x}+\frac{z}{2z+y}\le 1,
  \qquad x,y,z\ge0,
\]

with zero-denominator summands interpreted by the formal zero-term convention already used in the Schur-complement criterion.  Away from the boundary the proof is the AM--GM argument on \(x^2y,y^2z,z^2x\); the boundary cases reduce to a single half-bound.

The blueprint and paper-gap note are updated so they state the proved result as the full-coordinate `d = 3`, `n = 1` rank-one subcase, not as Wolf's full positivity theorem.

Refs LionSR/QICLean#19.

## Validation

- `lake env lean TNLean/Channel/ChoiTypeMap.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `git diff --check`
- `leanblueprint web` (exits 0 locally; local plasTeX package/bibliography warnings remain pre-existing)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized formal math and documentation in `ChoiTypeMap.lean`; no auth, IO, or broad API surface changes.
> 
> **Overview**
> **Removes the nonzero-coordinate requirement** from the Wolf Choi-type map at `d = 3`, `n = 1`: rank-one PSD is now proved for **every** `v`, including zeros on some coordinates.
> 
> The scalar lemma is generalized from strict positivity to **`x,y,z ≥ 0`**, with AM--GM factored into `choiType_cyclic_reciprocal_three_one_amgm` and **case splits** when a denominator `2x+z`, `2y+x`, or `2z+y` vanishes. The main entry point is `choiTypeMap_vecMulVec_posSemidef_three_one`; the old strict-coordinate theorem is a thin wrapper.
> 
> Blueprint lemma **ch25** and **`wolf_ex3_1_choi_positivity_subcase_scope.tex`** now describe the full-coordinate `3×3` rank-one subcase (zero terms as 0), not Wolf’s full `T_C` positivity theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d386a4854abb50e9fb7a9e64d5b33d31c7e31ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->