### PR TITLE
feat(Channel): prove first Choi positive-map subcase

### DIFF
--- a/TNLean/Channel/ChoiTypeMap.lean
+++ b/TNLean/Channel/ChoiTypeMap.lean
@@ -6,7 +6,9 @@ Authors: TNLean contributors
 import Mathlib.Data.Complex.Basic
 import Mathlib.LinearAlgebra.Matrix.Permutation
 import TNLean.Algebra.HermitianHelpers
+import TNLean.Algebra.MatrixSpectralDecomp
 import TNLean.Analysis.MatrixTraceInequalities
+import TNLean.Channel.Basic
 
 /-!
 # Choi-type positive maps
@@ -20,11 +22,11 @@ the natural home for the shift matrices \(U_{k0}\):
 where `D` projects a matrix to its diagonal part.
 
 The main theorem in this file is the exact action on rank-one projectors.  This
-is the algebraic reduction needed for the later positivity proof of Wolf
-Example 3.1.  Positivity and indecomposability of the Choi-type maps are not
-proved here.  The remaining positivity step is a genuine cyclic reciprocal
-inequality for the diagonal weights; it does not follow merely from equality of
-the total numerator and denominator weights.
+is the algebraic reduction needed for the positivity proof of Wolf Example 3.1.
+For the first case \(d=3,n=1\), this file proves positivity.  The general
+positivity theorem still requires a genuine cyclic reciprocal inequality for
+the diagonal weights; it does not follow merely from equality of the total
+numerator and denominator weights.  Indecomposability is not proved here.
 
 ## References
 
@@ -327,5 +329,24 @@ theorem choiTypeMap_vecMulVec_posSemidef_three_one_of_forall_ne_zero
     (v : ZMod 3 → ℂ) (_h0 : v 0 ≠ 0) (_h1 : v 1 ≠ 0) (_h2 : v 2 ≠ 0) :
     (choiTypeMap 3 1 (vecMulVec v (star v))).PosSemidef :=
   choiTypeMap_vecMulVec_posSemidef_three_one v
+
+/-- Positivity of the first Choi map.
+
+**Scope restriction:** See
+`docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`.  This proves
+only the \(d=3,n=1\) case of Wolf Chapter 3, Example 3.1, equation (3.20).
+The general range \(1\le n\le d-2\) remains separate. -/
+theorem choiTypeMap_isPositiveMap_three_one :
+    IsPositiveMap (choiTypeMap 3 1) := by
+  intro X hX
+  rw [hX.eq_sum_vecMulVec_nonzero_eigs]
+  rw [map_sum]
+  exact Matrix.posSemidef_sum Finset.univ fun i _ => by
+    let v : ZMod 3 → ℂ := fun p =>
+      ((Real.sqrt (hX.1.eigenvalues i.1) : ℂ)) *
+        hX.1.eigenvectorUnitary p i.1
+    convert choiTypeMap_vecMulVec_posSemidef_three_one v using 2
+    ext p q
+    simp [v, Matrix.vecMulVec_apply]
 
 end Matrix

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -491,12 +491,21 @@ follow merely from equality of the total numerator and denominator weights.
 
 \begin{proof}
     \leanok
-    A positive semidefinite matrix is a finite sum of rank-one positive
-    semidefinite matrices coming from its spectral decomposition.  The preceding
-    lemma shows that the $d=3$, $n=1$ Choi map sends each summand to a positive
-    semidefinite matrix.  Since the map is linear and finite sums of positive
-    semidefinite matrices are positive semidefinite, this proves positivity of
-    the map.
+    Let $X\ge0$.  By the spectral decomposition, there are vectors $w_\alpha$
+    such that
+    \[
+        X=\sum_\alpha \ket{w_\alpha}\bra{w_\alpha},
+    \]
+    where each summand is rank-one and positive semidefinite.  Linearity gives
+    \[
+        T_C(X)=\sum_\alpha T_C(\ket{w_\alpha}\bra{w_\alpha}).
+    \]
+    The preceding lemma gives
+    \[
+        T_C(\ket{w_\alpha}\bra{w_\alpha})\ge0
+    \]
+    for every $\alpha$.  Hence the displayed sum is positive semidefinite, so
+    $T_C(X)\ge0$.
 \end{proof}
 
 \section{The partial transpose and the PPT property}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -491,11 +491,12 @@ follow merely from equality of the total numerator and denominator weights.
 
 \begin{proof}
     \leanok
-    A positive semidefinite matrix is a finite sum of rank-one projectors coming
-    from its spectral decomposition.  The preceding lemma shows that the
-    $d=3$, $n=1$ Choi map sends each summand to a positive semidefinite matrix.
-    Since the map is linear and finite sums of positive semidefinite matrices
-    are positive semidefinite, this proves positivity of the map.
+    A positive semidefinite matrix is a finite sum of rank-one positive
+    semidefinite matrices coming from its spectral decomposition.  The preceding
+    lemma shows that the $d=3$, $n=1$ Choi map sends each summand to a positive
+    semidefinite matrix.  Since the map is linear and finite sums of positive
+    semidefinite matrices are positive semidefinite, this proves positivity of
+    the map.
 \end{proof}
 
 \section{The partial transpose and the PPT property}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -294,11 +294,11 @@ $D(X)$ and cyclic shifts $U_{k0}$:
     T_C(X)=(d-n)D(X)-X+\sum_{k=1}^nD(U_{k0}XU_{k0}^{\dagger}).
 \]
 The formal statements below record the map and the rank-one reduction used in
-the standard positivity argument.  The positivity and indecomposability
-assertions for the range $1\le n\le d-2$ remain open.  The missing positivity
-step is a cyclic reciprocal estimate for the weights in the rank-one reduction;
-it does not follow merely from equality of the total numerator and denominator
-weights.
+the standard positivity argument.  The first case $d=3$, $n=1$ is positive.
+The positivity and indecomposability assertions for the full range
+$1\le n\le d-2$ remain open.  The missing general positivity step is a cyclic
+reciprocal estimate for the weights in the rank-one reduction; it does not
+follow merely from equality of the total numerator and denominator weights.
 
 \begin{definition}[Choi-type map]
     \label{def:choi_type_map}
@@ -478,6 +478,24 @@ weights.
     when $y>0$, while all terms vanish when $y=0$.  The rank-one positivity then
     follows from
     Lemma~\ref{lem:choi_type_rankone_positive_from_weight_bound}.
+\end{proof}
+
+\begin{theorem}[The first Choi map is positive]
+    \label{thm:choi_type_first_positive_subcase}
+    \lean{Matrix.choiTypeMap_isPositiveMap_three_one}
+    \leanok
+    \uses{def:choi_type_map, lem:choi_type_first_cyclic_reciprocal_subcase}
+    For $d=3$ and $n=1$, the Choi-type map $T_C$ sends every positive
+    semidefinite matrix to a positive semidefinite matrix.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    A positive semidefinite matrix is a finite sum of rank-one projectors coming
+    from its spectral decomposition.  The preceding lemma shows that the
+    $d=3$, $n=1$ Choi map sends each summand to a positive semidefinite matrix.
+    Since the map is linear and finite sums of positive semidefinite matrices
+    are positive semidefinite, this proves positivity of the map.
 \end{proof}
 
 \section{The partial transpose and the PPT property}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -105,9 +105,9 @@ non-periodic FT cleanup loop unless explicitly brought back into scope.
 For Wolf Chapter 3 positive maps:
 
 - `wolf_ex3_1_choi_positivity_subcase_scope.tex` records that the current
-  Choi-type positivity theorem is only the \(d=3,n=1\) rank-one subcase of
-  Wolf Example 3.1.  The general cyclic reciprocal estimate and the extension
-  to positivity of \(T_C\) remain open.
+  Choi-type positivity theorem is only the \(d=3,n=1\) positive-map subcase of
+  Wolf Example 3.1.  The general cyclic reciprocal estimate, and hence
+  positivity of \(T_C\) for the full range \(1\le n\le d-2\), remain open.
 
 For the periodic (irreducible-form) MPS Fundamental Theorem of
 arXiv:1708.00029, the overlap-dichotomy development has one route-alignment

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -48,9 +48,9 @@ boundary cases reduce to a single half-bound.\footnote{Formal declarations:
 \leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_three\_one}
 in \doclink{TNLean/Channel/ChoiTypeMap}.}
 Using the spectral decomposition of a positive semidefinite matrix into
-rank-one projectors, the development then proves that this first Choi map is
-positive on all positive semidefinite inputs.\footnote{Formal declaration:
-\leanid{Matrix.choiTypeMap\_isPositiveMap\_three\_one}.}
+rank-one positive semidefinite summands, the development then proves that this
+first Choi map is positive on all positive semidefinite inputs.\footnote{Formal
+declaration: \leanid{Matrix.choiTypeMap\_isPositiveMap\_three\_one}.}
 
 \section{Missing hypotheses and elimination plan}
 

--- a/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
+++ b/docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex
@@ -31,8 +31,8 @@ The source states that \(T_C\) is positive and indecomposable for every
 
 \section{Restricted statement now proved}
 
-The present development proves only the first rank-one subcase.  For \(d=3\),
-\(n=1\), and an arbitrary vector \(v=(v_0,v_1,v_2)\), it proves
+The present development proves only the first subcase.  For \(d=3\), \(n=1\),
+and an arbitrary vector \(v=(v_0,v_1,v_2)\), it proves
 \begin{align}
   T_C(|v\rangle\langle v|)\ge 0.
 \end{align}
@@ -47,6 +47,10 @@ boundary cases reduce to a single half-bound.\footnote{Formal declarations:
 \leanid{Matrix.choiType\_cyclic\_reciprocal\_three\_one\_of\_nonneg} and
 \leanid{Matrix.choiTypeMap\_vecMulVec\_posSemidef\_three\_one}
 in \doclink{TNLean/Channel/ChoiTypeMap}.}
+Using the spectral decomposition of a positive semidefinite matrix into
+rank-one projectors, the development then proves that this first Choi map is
+positive on all positive semidefinite inputs.\footnote{Formal declaration:
+\leanid{Matrix.choiTypeMap\_isPositiveMap\_three\_one}.}
 
 \section{Missing hypotheses and elimination plan}
 
@@ -59,15 +63,16 @@ statement still requires the nonnegative cyclic reciprocal estimate
 \end{align}
 with the usual zero-term convention.  Once this estimate is available, it
 should be applied to \(x_i=|v_i|^2\) to obtain the rank-one statement for the
-full parameter range.  A positive-semidefinite decomposition will then extend
-the rank-one result to positivity of \(T_C\) on all positive semidefinite
-matrices.  This is tracked by \ghissue{3622}.  The indecomposability assertion
-of the same source paragraph is separate and is tracked by \ghissue{3623}.
+full parameter range.  The same positive-semidefinite decomposition used in
+the \(d=3,n=1\) case will then extend the rank-one result to positivity of
+\(T_C\) on all positive semidefinite matrices.  This is tracked by
+\ghissue{3622}.  The indecomposability assertion of the same source paragraph
+is separate and is tracked by \ghissue{3623}.
 
 \section{Classification}
 
 \emph{Scope restriction.}  The current theorem is mathematically correct as a
-\(3\times3\) rank-one subcase, but it should not be cited as the formalization
+\(3\times3\) positive-map subcase, but it should not be cited as the formalization
 of Wolf's full Choi-type positivity theorem.
 
 \bibliographystyle{alpha}


### PR DESCRIPTION
### Motivation

- Wolf Ch. 3, Example 3.1 (eq. (3.20)) asserts that the Choi-type map $T_C$ on $M_d(\mathbb{C})$ is positive for $1 \le n \le d-2$; this PR formalizes the $d=3$, $n=1$ subcase (issue LionSR/QICLean#19).
- PR LionSR/TNLean#3619 proved the rank-one reduction `Matrix.choiTypeMap_vecMulVec`; lifting positivity to all positive semidefinite inputs was deferred and is addressed here for the $d=3$, $n=1$ case by spectral decomposition.
- Source: `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`, Wolf Ch. 3, Ex. 3.1, eq. (3.20).

### Description

- `TNLean/Channel/ChoiTypeMap.lean`: proves `Matrix.choiTypeMap_isPositiveMap_three_one`, lifting the rank-one positivity result for $d=3$, $n=1$ to all positive semidefinite inputs via spectral decomposition.
- `blueprint/src/chapter/ch25_positive_not_cp.tex`: adds blueprint entry for the positive-map theorem with `\lean{}` and `\leanok` annotations.
- `docs/paper-gaps/wolf_ex3_1_choi_positivity_subcase_scope.tex`, `docs/paper-gaps/README.md`: updates the paper-gap note to characterize the scope as a $d=3$, $n=1$ positive-map subcase rather than merely a rank-one subcase.
- The general positivity theorem for $1 \le n \le d-2$ and the indecomposability assertion remain open.

### Testing

- `lake env lean TNLean/Channel/ChoiTypeMap.lean`
- `lake build TNLean.Channel.ChoiTypeMap`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web` (passes locally with pre-existing package/bibliography warnings)

---
Refs LionSR/QICLean#19

> [!NOTE]
> **Low Risk**
> Localized formal math in the Choi-type channel file using an established PSD decomposition pattern; no changes to auth, runtime, or broad infrastructure.
>
> **Overview**
> Extends the Wolf Example 3.1 Choi-type development from **rank-one** \(d=3,n=1\) positivity to a full **`IsPositiveMap`** result for `choiTypeMap 3 1`, by decomposing any PSD input into eigenvalue-weighted rank-one summands and applying the existing rank-one theorem.
>
> Adds **`Matrix.choiTypeMap_isPositiveMap_three_one`** in `ChoiTypeMap.lean` (with spectral-decomposition and `IsPositiveMap` imports), updates the module commentary, and documents the new theorem in the blueprint (`ch25_positive_not_cp.tex`) and paper-gap notes so scope is described as a **positive-map** subcase—not only rank-one—while the general \(1\le n\le d-2\) positivity and indecomposability claims stay open.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0aba05b18611d8269af2fb9b36dc0de904f04d3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized formal proof in one channel file using an established PSD-decomposition lift; no auth, runtime, or broad infrastructure changes.
> 
> **Overview**
> **Lifts** Wolf Example 3.1 Choi-type positivity from the existing **rank-one** $d=3,n=1$ result to a full **`IsPositiveMap`** theorem for `choiTypeMap 3 1`: PSD inputs are written as a sum of eigenvalue-weighted rank-one terms (`eq_sum_vecMulVec_nonzero_eigs`), then each summand uses `choiTypeMap_vecMulVec_posSemidef_three_one` (same pattern as Breuer–Hall).
> 
> Adds **`Matrix.choiTypeMap_isPositiveMap_three_one`** in `ChoiTypeMap.lean` with imports for spectral decomposition and `IsPositiveMap`, refreshes the module header, and adds a **blueprint theorem** plus **paper-gap** wording so scope is a **positive-map** subcase—not only rank-one—while general $1\le n\le d-2$ positivity and indecomposability stay open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d7beeb32b4fb9d3b2a86aa7f1a17bf077a716f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

