### PR TITLE
feat(MPS/ParentHamiltonian): reduce commutation to overlapping local terms

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -205,7 +205,7 @@ theorem HasNNCPHGroundSpace.isNNCPHGroundState {B : MPSTensor d D}
   h.1
 
 /-- The full fixed-chain NNCPH ground-space condition includes length-two
-translated parent-term commutation. -/
+local-term commutation. -/
 theorem HasNNCPHGroundSpace.isNNCPH {B : MPSTensor d D}
     {r : ℕ} {dim : Fin r → ℕ} {A : (j : Fin r) → MPSTensor d (dim j)}
     {N : ℕ} (h : HasNNCPHGroundSpace B A N) :

--- a/TNLean/MPS/ParentHamiltonian/Martingale.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.ParentHamiltonian.Martingale.AbstractCriterion
 import TNLean.MPS.ParentHamiltonian.Martingale.Transport
+import TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Reduction
 import TNLean.MPS.ParentHamiltonian.Martingale.Gap
 

--- a/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
@@ -1,0 +1,51 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.ParentHamiltonian.Commuting
+import TNLean.MPS.ParentHamiltonian.Martingale.Transport
+
+/-!
+# Overlap reduction for commuting parent-Hamiltonian local terms
+
+For a finite periodic parent Hamiltonian, local terms with disjoint cyclic
+supports commute by locality.  Hence the source commutation condition for
+interacting translates reduces the all-pairs commuting condition to the pairs
+whose cyclic supports overlap.
+-/
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- To prove that a finite periodic parent Hamiltonian has commuting local
+terms, it suffices to check pairs of translated local terms with overlapping
+cyclic supports.
+
+The disjoint pairs commute by locality, as recorded in the coefficient-space
+non-overlap lemma. This is the finite-chain reduction behind the source
+condition \([\tau_j(P_L),P_L]=0\) for interacting translates in
+arXiv:1606.00608, Definition 3.9. -/
+theorem isCommutingParentHam_of_cyclicWindowsOverlap_commute
+    {A : MPSTensor d D} {L N : ℕ} (hLN : L ≤ N)
+    (hOverlap : ∀ i j : Fin N, cyclicWindowsOverlap N L i j →
+      localTerm A L N i * localTerm A L N j =
+        localTerm A L N j * localTerm A L N i) :
+    IsCommutingParentHam A L N := by
+  intro i j
+  by_cases hij : cyclicWindowsOverlap N L i j
+  · exact hOverlap i j hij
+  · exact localTerm_commute_of_cyclic_windows_disjoint A hLN
+      (CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap hij)
+
+/-- Nearest-neighbor specialization of the overlap reduction for the source
+NNCPH commutation equations. -/
+theorem isNNCPH_of_twoSite_cyclicWindowsOverlap_commute
+    {A : MPSTensor d D} {N : ℕ} (hN : 2 ≤ N)
+    (hOverlap : ∀ i j : Fin N, cyclicWindowsOverlap N 2 i j →
+      localTerm A 2 N i * localTerm A 2 N j =
+        localTerm A 2 N j * localTerm A 2 N i) :
+    IsNNCPH A N :=
+  isCommutingParentHam_of_cyclicWindowsOverlap_commute (A := A) (L := 2) hN hOverlap
+
+end MPSTensor

--- a/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean
@@ -733,6 +733,22 @@ theorem localTermES_commute_of_cyclic_windows_disjoint {N : ℕ} (A : MPSTensor 
   simpa [P] using separateLinearMap_apply_commute P P F (extractWindow L i σ)
     (extractWindow L j σ)
 
+/-- Local parent-Hamiltonian terms with disjoint cyclic supports commute.
+
+This is the coefficient-space form of
+`localTermES_commute_of_cyclic_windows_disjoint`, transported back from
+`EuclideanSpace` by the canonical `WithLp` equivalence. -/
+theorem localTerm_commute_of_cyclic_windows_disjoint {N : ℕ} (A : MPSTensor d D)
+    {L : ℕ} (hLN : L ≤ N) {i j : Fin N} (hij : CyclicWindowsDisjoint L i j) :
+    localTerm A L N i * localTerm A L N j =
+      localTerm A L N j * localTerm A L N i := by
+  apply LinearMap.ext
+  intro ψ
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d N)
+  have h :=
+    localTermES_commute_of_cyclic_windows_disjoint A hLN hij (e.symm ψ)
+  simpa [localTermES, Module.End.mul_apply, e] using congrArg e h
+
 /-- Non-overlap positivity for Euclidean-space local terms on disjoint cyclic windows.
 
 For \(L ≤ N\), if the cyclic windows based at \(i\) and \(j\) have no common site, then

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1,8 +1,8 @@
-\section{Translated parent-term commutation}\label{sec:commuting_parent_ham}
+\section{Commuting Local Terms for Parent Hamiltonians}\label{sec:commuting_parent_ham}
 
-This section concerns the commutation equation for translated parent terms in a
+This section concerns the commutation equation for local terms in a
 periodic chain. For normal tensors it relates renormalization fixed points to
-the tensors whose length-two parent terms commute,
+the tensors whose length-two local terms commute,
 $h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2)$; the implication from commuting terms back
 to a renormalization fixed point uses a left-canonical normalization.
 
@@ -96,7 +96,7 @@ the specialization $L=2$.
     the three-site space.
 \end{definition}
 
-\begin{theorem}[Three-site translated parent terms]
+\begin{theorem}[Three-site translated local terms]
     \label{thm:local_term_two_three_ax_xb_lifts}
     \lean{MPSTensor.localTerm_two_three_zero_eq_leftPairLift_parentInteraction}
     \lean{MPSTensor.localTerm_two_three_one_eq_rightPairLift_parentInteraction}
@@ -151,14 +151,14 @@ the specialization $L=2$.
         h^{(3)}_1(A,2)h^{(3)}_0(A,2).
     \]
     This is only the local transport from the \(AX/XB\) condition to translated
-    parent terms; the construction of the
+    local terms; the construction of the
     \cite[Appendix~D.2]{Cirac2016MPDO_arXiv} projectors associated with the
     \cite[Appendix~B]{Cirac2016MPDO_arXiv} basic-vector form is a separate step.
 \end{theorem}
 
 \begin{proof}\leanok
     By Theorem~\ref{thm:local_term_two_three_ax_xb_lifts}, the two translated
-    parent interactions are \(q(A)_{AX}\) and \(q(A)_{XB}\). The assumed
+    local terms are \(q(A)_{AX}\) and \(q(A)_{XB}\). The assumed
     overlapping support condition says exactly that these two lifted
     endomorphisms commute.
 \end{proof}
@@ -179,7 +179,7 @@ the specialization $L=2$.
         q(A)_{AX}=(Q_{AX})_{AX},\qquad
         q(A)_{XB}=(Q_{XB})_{XB}.
     \]
-    Then the first two translated length-two parent terms on the three-site
+    Then the first two translated length-two local terms on the three-site
     chain commute,
     \[
         h^{(3)}_0(A,2)h^{(3)}_1(A,2)
@@ -209,7 +209,7 @@ the specialization $L=2$.
     \[
         q(A)=1-Q_{AX}=1-Q_{XB}.
     \]
-    Then the first two translated length-two parent terms on the three-site
+    Then the first two translated length-two local terms on the three-site
     chain commute,
     \[
         h^{(3)}_0(A,2)h^{(3)}_1(A,2)
@@ -228,7 +228,7 @@ the specialization $L=2$.
     commutation relation.
 \end{proof}
 
-\begin{definition}[Translated parent-term commutation]\label{def:is_commuting_parent_ham}
+\begin{definition}[Commuting local terms for a parent Hamiltonian]\label{def:is_commuting_parent_ham}
     \lean{MPSTensor.IsCommutingParentHam}
     \leanok
     \uses{def:local_term_parent}
@@ -242,7 +242,7 @@ the specialization $L=2$.
     MPS vectors of the BNT components.
 \end{definition}
 
-\begin{definition}[Nearest-neighbor translated parent-term commutation]\label{def:is_nncph}
+\begin{definition}[Nearest-neighbor commuting parent Hamiltonian]\label{def:is_nncph}
     \lean{MPSTensor.IsNNCPH}
     \leanok
     \uses{def:is_commuting_parent_ham}
@@ -257,20 +257,43 @@ the specialization $L=2$.
     the prescribed ground-space spanning property for $N>2$.
 \end{definition}
 
-\begin{definition}[Commutation and zero-energy equations for nearest-neighbor parent terms]%
+\begin{lemma}[Overlap reduction for commuting local terms]
+    \label{lem:commuting_parent_ham_overlap_reduction}
+    \lean{MPSTensor.isCommutingParentHam_of_cyclicWindowsOverlap_commute}
+    \lean{MPSTensor.isNNCPH_of_twoSite_cyclicWindowsOverlap_commute}
+    \leanok
+    \uses{def:is_commuting_parent_ham, def:is_nncph,
+        def:cyclic_windows_overlap, lem:transported_es_nonoverlap_positive}
+    Let $L\le N$. Suppose that $h_i h_j=h_j h_i$ whenever the length-$L$
+    cyclic supports of the two local terms meet. Then the parent Hamiltonian
+    has commuting local terms:
+    \[
+        h_i h_j=h_j h_i \qquad \text{for all } i,j.
+    \]
+    In the case $L=2$, this gives the nearest-neighbor commuting condition.
+\end{lemma}
+
+\begin{proof}\leanok
+    \uses{lem:transported_es_nonoverlap_positive}
+    If the two cyclic supports meet, the hypothesis gives the commutation
+    relation. If they are disjoint, the corresponding local terms commute by
+    locality.
+\end{proof}
+
+\begin{definition}[Commutation and zero-energy equations for nearest-neighbor local terms]%
     \label{def:is_nncph_ground_state}
     \lean{MPSTensor.IsNNCPHGroundState}
     \leanok
     \uses{def:is_nncph, def:is_frustration_free}
     This condition records the commutation equation and the zero-energy equation
-    for the nearest-neighbor parent terms:
+    for the nearest-neighbor local terms:
     \[
         h_i h_j = h_j h_i,\qquad
         h_i V^{(N)}(A)=0.
     \]
     This is the zero-energy part of the condition appearing in
     \cite[Theorem~3.10(iii)]{Cirac2016MPDO_arXiv}: the MPS vector has zero
-    energy for the translated two-site parent terms, and those terms commute.
+    energy for the translated two-site local terms, and those terms commute.
     The missing source assertion is that the whole parent-Hamiltonian ground
     space is spanned by the corresponding periodic MPS vectors from the BNT
     components, as recorded in
@@ -786,13 +809,13 @@ the specialization $L=2$.
     \(G_L^{(N)}(A_j)=\spn\{V^{(N)}(A_j)\}\) give the previous hypothesis.
 \end{proof}
 
-\begin{theorem}[Renormalization fixed points have commuting nearest-neighbor parent terms]\label{thm:rfp_implies_nncph}
+\begin{theorem}[Renormalization fixed points have commuting nearest-neighbor local terms]\label{thm:rfp_implies_nncph}
     \lean{MPSTensor.rfp_implies_nncph}
     \lean{Axioms.rfp_to_nncph_commute}
     \leanok
     \uses{def:is_rfp, def:is_nncph, def:normal}
     If $A$ has nonzero virtual dimension and is a normal renormalization fixed
-    point, then for every chain length $N \ge 2$ the two-site parent terms
+    point, then for every chain length $N \ge 2$ the two-site local terms
     commute. This theorem records the commutation part of the nearest-neighbor
     source condition, not the ground-space spanning part.
     This implication is cited here from the structural characterization theorem
@@ -813,7 +836,7 @@ the specialization $L=2$.
     If $A$ has nonzero virtual dimension and is a normal renormalization fixed
     point, then for every chain length $N \ge 2$ the MPS vector $V^{(N)}(A)$
     satisfies the commutation and zero-energy equations for nearest-neighbor
-    parent terms:
+    local terms:
     \[
         h_i h_j = h_j h_i,\qquad
         h_i V^{(N)}(A)=0.
@@ -1000,7 +1023,7 @@ the specialization $L=2$.
     \leanok
     \uses{thm:local_term_two_three_ax_xb_lifts,
         lem:appendixB_qax_qxb_parent_interaction}
-    On the three-site \(A,X,B\) window, the two adjacent length-two parent terms
+    On the three-site \(A,X,B\) window, the two adjacent length-two local terms
     are the two local lifts
     \[
         h_0^{(3)}(A,2)=(\widehat Q_{AX})_{AX},\qquad
@@ -1010,12 +1033,12 @@ the specialization $L=2$.
 
 \begin{proof}
     \leanok
-    Apply the three-site translated parent-term identities to \(q_2(A)\), and
+    Apply the three-site local-term identities to \(q_2(A)\), and
     replace \(q_2(A)\) by \(\widehat Q_{AX}\) or \(\widehat Q_{XB}\) using the
     preceding two-site identifications.
 \end{proof}
 
-\begin{lemma}[Appendix B overlapping condition gives three-site parent-term commutation]
+\begin{lemma}[Appendix B overlapping condition gives three-site local-term commutation]
     \label{lem:appendixB_overlapping_condition_parent_terms}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_overlapping}
     \leanok
@@ -1029,7 +1052,7 @@ the specialization $L=2$.
         =
         (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX},
     \]
-    then the corresponding first two translated length-two parent terms on the
+    then the corresponding first two translated length-two local terms on the
     three-site window commute:
     \[
         h_0^{(3)}(A,2)h_1^{(3)}(A,2)
@@ -1041,12 +1064,12 @@ the specialization $L=2$.
 \begin{proof}
     \leanok
     By Lemma~\ref{lem:appendixB_three_site_parent_lifts}, the two translated
-    parent terms are exactly the \(AX\) and \(XB\) lifts of
+    local terms are exactly the \(AX\) and \(XB\) lifts of
     \(\widehat Q_{AX}\) and \(\widehat Q_{XB}\).  The displayed equality is
     therefore the commutation clause of the overlapping two-site datum.
 \end{proof}
 
-\begin{lemma}[Appendix B lifted commutator gives three-site parent-term commutation]
+\begin{lemma}[Appendix B lifted commutator gives three-site local-term commutation]
     \label{lem:appendixB_lift_commutator_parent_terms}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_commute_lifts}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2}
@@ -1060,7 +1083,7 @@ the specialization $L=2$.
         =
         (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX},
     \]
-    then the corresponding first two translated length-two parent terms on the
+    then the corresponding first two translated length-two local terms on the
     three-site window commute:
     \[
         h_0^{(3)}(A,2)h_1^{(3)}(A,2)
@@ -1088,7 +1111,7 @@ the specialization $L=2$.
     \]
 \end{proof}
 
-\begin{remark}[Basic-vector coefficients and nearest-neighbor parent-term commutation]%
+\begin{remark}[Basic-vector coefficients and nearest-neighbor local-term commutation]%
     \label{rem:product_pair_projectors}
     \lean{MPSTensor.productPairWindow}
     \lean{MPSTensor.productPairWindow_one}
@@ -1249,7 +1272,7 @@ the specialization $L=2$.
     $U^{\otimes L}\varphi_j^{\otimes L}$. The remaining coefficient step is
     to relate this source expression, with the physical word $\sigma$ fixed, to
     the even-chain physical-pair factorization above.
-    On a three-site chain, the two adjacent length-two parent terms are the
+    On a three-site chain, the two adjacent length-two local terms are the
     \(AX\) and \(XB\) actions of the canonical two-site parent interaction.
     Appendix~B supplies the basic-vector expression, while Appendix~D.2 supplies
     the parent-commuting projector condition. The local two-site projector
@@ -1302,7 +1325,7 @@ the specialization $L=2$.
     \uses{lem:parent_hamiltonian_ff, def:has_nncph_ground_space}
     \leanok
     The conditional hypotheses give \(h_i h_j=h_j h_i\) for all translated
-    two-site parent terms. Lemma~\ref{lem:parent_hamiltonian_ff} gives
+    two-site local terms. Lemma~\ref{lem:parent_hamiltonian_ff} gives
     \(h_iV^{(N)}(B)=0\). For every \(N>2\), the spanning hypothesis supplies
     \[
         \ker H_2^{(N)}(B)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex
@@ -368,6 +368,7 @@ sufficient stronger hypotheses.
     \lean{MPSTensor.CyclicWindowsDisjoint}
     \lean{MPSTensor.CyclicWindowsDisjoint.symm}
     \lean{MPSTensor.CyclicWindowsDisjoint.of_not_cyclicWindowsOverlap}
+    \lean{MPSTensor.localTerm_commute_of_cyclic_windows_disjoint}
     \lean{MPSTensor.localTermES_commute_of_cyclic_windows_disjoint}
     \lean{MPSTensor.localTermES_re_inner_nonneg_of_cyclic_windows_disjoint}
     \leanok
@@ -380,7 +381,8 @@ sufficient stronger hypotheses.
         h_{i,\mathrm{ES}}(h_{j,\mathrm{ES}}v)
         = h_{j,\mathrm{ES}}(h_{i,\mathrm{ES}}v),
     \]
-    and their ordered cross term is non-negative:
+    The same commutation identity holds for the corresponding local terms before
+    passing to the Hilbert-space model. Their ordered cross term is non-negative:
     \[
         0\le \operatorname{Re}\langle h_{i,\mathrm{ES}}v,
         h_{j,\mathrm{ES}}v\rangle.


### PR DESCRIPTION
### Motivation
- Disjoint cyclic local parent-Hamiltonian terms commute by locality; transporting this to the coefficient-space model and reducing `IsCommutingParentHam` to overlapping windows is a prerequisite for the overlap-reduction step in the martingale spectral-gap proof (arXiv:2011.12127 §IV.C; see #952).
- Connects the existing Hilbert-space disjoint-window commutation to the coefficient-space `localTerm` representation, addressing a gap in the RFP Appendix B projector identification (#3373; arXiv:1606.00608, §3.3 and Appendix B).

### Description
- `TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean`: adds `localTerm_commute_of_cyclic_windows_disjoint`, transporting disjoint cyclic-window commutation from Hilbert-space to coefficient-space `localTerm`s via the `WithLp` equivalence.
- `TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean` (new file): proves
  - `isCommutingParentHam_of_cyclicWindowsOverlap_commute`: commutation of all overlapping cyclic-window pairs implies `IsCommutingParentHam`;
  - `isNNCPH_of_twoSite_cyclicWindowsOverlap_commute`: the length-two variant implies `IsNNCPH`.
- `TNLean/MPS/ParentHamiltonian/Martingale.lean`: imports `OverlapReduction`.
- `TNLean/MPS/ParentHamiltonian/Commuting.lean`: doc fix replacing "length-two translated parent-term" with "local-term".
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: adds the overlap-reduction lemma and retitles "translated parent terms" to "commuting local terms"; syncs blueprint entries.
- `blueprint/src/chapter/ch13_parent_hamiltonian_spectral_gap.tex`: the spectral-gap non-overlap lemma now cites coefficient-space commutation alongside the ES form.

### Testing
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/Transport.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale.lean`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`

---
Refs #3373.
Refs #952.

> [!NOTE]
> **Low Risk**
> Formal Lean proofs and blueprint sync only; no runtime, auth, or data-path changes.
>
> **Overview**
> This PR **reduces** parent-Hamiltonian commutation checks to **overlapping** cyclic window pairs: disjoint supports commute by locality, so verifying overlap pairs is enough for full `IsCommutingParentHam` (and length-2 for `IsNNCPH`).
>
> **Lean:** `localTerm_commute_of_cyclic_windows_disjoint` in `Transport.lean` transports the existing Hilbert-space disjoint-window commutation back to coefficient-space `localTerm`s via `WithLp`. New `OverlapReduction.lean` proves `isCommutingParentHam_of_cyclicWindowsOverlap_commute` and `isNNCPH_of_twoSite_cyclicWindowsOverlap_commute`; `Martingale.lean` imports it. A small doc fix in `Commuting.lean` renames "length-two translated parent-term" to "local-term".
>
> **Blueprint:** Chapter 13 commuting-gap section adds the overlap-reduction lemma and retitles "translated parent terms" to **commuting local terms**; the spectral-gap non-overlap lemma now cites coefficient-space commutation alongside the ES form.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dd626cd1f40b79b44031e61dc7435705f885d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>