### PR TITLE
refactor(MPS/RFP): restrict product-pair witnesses to N >= 2

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Commuting.lean
+++ b/TNLean/MPS/ParentHamiltonian/Commuting.lean
@@ -347,11 +347,11 @@ theorem HasProductPairLocalProjectors.isNNCPH {A : MPSTensor d D} {N : ℕ}
   hPair.commuting_twoSite_localTerms
 
 /-- The even-chain physical-pair factorization and the two-site projector
-identities give NNCPH on each finite chain. -/
+identities give NNCPH on each finite chain of length at least two. -/
 theorem ProductPairBridge.isNNCPH {A : MPSTensor d D} (hBridge : ProductPairBridge A)
-    (N : ℕ) :
+    (N : ℕ) (hN : 2 ≤ N) :
     IsNNCPH A N :=
-  (hBridge.localProjectors N).isNNCPH
+  (hBridge.localProjectors N hN).isNNCPH
 
 /-- The conditional even-chain hypotheses and the ground-space spanning
 equation give the full all-chain nearest-neighbor parent-Hamiltonian condition.
@@ -368,7 +368,8 @@ theorem ProductPairBridge.hasNNCPHGroundSpaces_of_groundSpaceSpanning
     (hSpan : HasParentHamiltonianGroundSpaceSpanning B 2 A) :
     HasNNCPHGroundSpaces B A := by
   intro N hN
-  exact ⟨(hBridge.isNNCPH N).isNNCPHGroundState (le_of_lt hN), hSpan N hN⟩
+  exact ⟨(hBridge.isNNCPH N (le_of_lt hN)).isNNCPHGroundState (le_of_lt hN),
+    hSpan N hN⟩
 
 /-- Conditional internal theorem for Theorem 3.10(i)⟹(iii).
 
@@ -377,7 +378,7 @@ A normal left-canonical RFP tensor has the Appendix B structural form
 associated two-site amplitude gives the even-chain physical-pair factorization
 and the two-site parent terms are identified with commuting
 idempotents, then the nearest-neighbor parent Hamiltonian is commuting on every
-finite chain.
+finite chain of length at least two.
 
 This theorem does not use `Axioms.rfp_to_nncph_commute`; it states the precise
 conditional theorem left after the structural form has been internalized. -/
@@ -385,10 +386,10 @@ theorem rfp_implies_nncph_of_appendixBExtraction (A : MPSTensor d D) [NeZero D]
     (hRFP : IsRFP A) (hNT : IsNormal A) (hLeft : IsLeftCanonical A)
     (hExtract : AppendixBProductPairExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
-    (N : ℕ) :
+    (N : ℕ) (hN : 2 ≤ N) :
     IsNNCPH A N :=
   commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction
-    A hNT hRFP hLeft hExtract N
+    A hNT hRFP hLeft hExtract N hN
 
 /-- Conditional ground-vector form of Theorem 3.10(i)⟹(iii).
 
@@ -410,8 +411,8 @@ theorem rfp_implies_nncph_ground_state_of_appendixBExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
     (N : ℕ) (hN : 2 ≤ N) :
     IsNNCPHGroundState A N :=
-  (rfp_implies_nncph_of_appendixBExtraction A hRFP hNT hLeft hExtract N).isNNCPHGroundState
-    hN
+  have hNN := rfp_implies_nncph_of_appendixBExtraction A hRFP hNT hLeft hExtract N hN
+  hNN.isNNCPHGroundState hN
 
 /-- Conditional full source form of Theorem 3.10(i)⟹(iii).
 

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -181,13 +181,13 @@ noncomputable def HasProductPairLocalProjectors.of_commuting_localTerms
   hcomm := hcomm
 
 /-- Conditional hypotheses for a tensor whose positive even-chain coefficients
-factor through one repeated two-site amplitude and whose
-nearest-neighbor parent terms are commuting idempotents on every finite chain. -/
+factor through one repeated two-site amplitude and whose nearest-neighbor parent
+terms are commuting idempotents on every finite chain of length at least two. -/
 structure ProductPairBridge (A : MPSTensor d D) where
   pairAmplitude : NSiteSpace d 2
   hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState pairAmplitude N σ
-  localProjectors : ∀ N, HasProductPairLocalProjectors A N
+  localProjectors : ∀ N, 2 ≤ N → HasProductPairLocalProjectors A N
 
 theorem ProductPairBridge.mpv_eq_productPairState {A : MPSTensor d D}
     (hBridge : ProductPairBridge A) :
@@ -201,22 +201,24 @@ theorem ProductPairBridge.hasProductPairMPV {A : MPSTensor d D}
   ⟨hBridge.pairAmplitude, hBridge.hmpv⟩
 
 /-- The conditional physical-pair hypotheses yield the unfolded `IsNNCPH`
-conclusion: all two-site local terms commute on every finite chain.
+conclusion: all two-site local terms commute on every finite chain of length at
+least two.
 
 The statement is written as the commutation equation for the translated
 two-site parent terms, which is the nearest-neighbor commutation condition in
 arXiv:1606.00608, Definition 3.9. -/
 theorem ProductPairBridge.commuting_twoSite_localTerms
-    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) :
+    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 2 ≤ N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=
-  (hBridge.localProjectors N).commuting_twoSite_localTerms
+  (hBridge.localProjectors N hN).commuting_twoSite_localTerms
 
 theorem ProductPairBridge.localTerm_idempotent
-    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (i : Fin N) :
+    {A : MPSTensor d D} (hBridge : ProductPairBridge A) (N : ℕ) (hN : 2 ≤ N)
+    (i : Fin N) :
     localTerm A 2 N i * localTerm A 2 N i = localTerm A 2 N i :=
-  (hBridge.localProjectors N).localTerm_idempotent i
+  (hBridge.localProjectors N hN).localTerm_idempotent i
 
 /-! ### Appendix B structural form used below -/
 
@@ -660,8 +662,9 @@ structure AppendixBProductPairExtraction {A : MPSTensor d D}
   /-- Positive even-chain factorization through the structural two-site amplitude. -/
   hmpv : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
     mpv A σ = productPairState hStruct.twoSiteAmplitude N σ
-  /-- Local projectors realizing the nearest-neighbor parent terms. -/
-  localProjectors : ∀ N, HasProductPairLocalProjectors A N
+  /-- Local projectors realizing the nearest-neighbor parent terms for chains
+  of length at least two. -/
+  localProjectors : ∀ N, 2 ≤ N → HasProductPairLocalProjectors A N
 
 /-- Construct the coefficient part of the conditional structure from the
 Appendix B core tensor.
@@ -672,7 +675,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hProj : ∀ N, HasProductPairLocalProjectors A N) :
+    (hProj : ∀ N, 2 ≤ N → HasProductPairLocalProjectors A N) :
     AppendixBProductPairExtraction hStruct where
   hmpv := by
     intro N hN σ
@@ -681,7 +684,7 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
   localProjectors := hProj
 
 /-- Construct the conditional Appendix B extraction from the coefficient
-factorization and the all-chain commutation equations for the translated
+factorization and the \(N \ge 2\) commutation equations for the translated
 length-two parent terms.
 
 The idempotency of the local terms is supplied by `localTerm_idempotent`; the
@@ -690,12 +693,12 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndCom
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
       mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
-    (hComm : ∀ N, ∀ i j : Fin N,
+    (hComm : ∀ N, 2 ≤ N → ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i) :
     AppendixBProductPairExtraction hStruct :=
   AppendixBProductPairExtraction.ofCoreTensorFactorization hCore
-    (fun N => HasProductPairLocalProjectors.of_commuting_localTerms (hComm N))
+    (fun N hN => HasProductPairLocalProjectors.of_commuting_localTerms (hComm N hN))
 
 /-- The conditional Appendix B hypotheses yield the `ProductPairBridge`
 structure used by the parent-Hamiltonian statements. -/
@@ -708,14 +711,14 @@ noncomputable def AppendixBProductPairExtraction.toProductPairBridge
   localProjectors := hExtract.localProjectors
 
 /-- The conditional Appendix B hypotheses give the unfolded nearest-neighbor
-commutation statement on every finite chain. -/
+commutation statement on every finite chain of length at least two. -/
 theorem AppendixBProductPairExtraction.commuting_twoSite_localTerms
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
-    (hExtract : AppendixBProductPairExtraction hStruct) (N : ℕ) :
+    (hExtract : AppendixBProductPairExtraction hStruct) (N : ℕ) (hN : 2 ≤ N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=
-  hExtract.toProductPairBridge.commuting_twoSite_localTerms N
+  hExtract.toProductPairBridge.commuting_twoSite_localTerms N hN
 
 /-- Conditional form of the forward implication in arXiv:1606.00608,
 Theorem 3.10:
@@ -734,10 +737,10 @@ theorem commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction
     (hLeft : ∑ i : Fin d, (A i)ᴴ * A i = 1)
     (hExtract : AppendixBProductPairExtraction
       (AppendixBStructuralData.ofRFP A hNT hRFP hLeft))
-    (N : ℕ) :
+    (N : ℕ) (hN : 2 ≤ N) :
     ∀ i j : Fin N,
       localTerm A 2 N i * localTerm A 2 N j =
         localTerm A 2 N j * localTerm A 2 N i :=
-  hExtract.commuting_twoSite_localTerms N
+  hExtract.commuting_twoSite_localTerms N hN
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1284,8 +1284,8 @@ the specialization $L=2$.
     \]
     Nor does it construct the source \(Q_{AX},Q_{XB}\) projectors on the
     tripartite Hilbert space. For the all-chain statement, the remaining local
-    projector equation is the following commutation condition: for every finite
-    chain and every pair of sites $i,j$,
+    projector equation is the following commutation condition: for every chain
+    length $N\geq2$ and every pair of sites $i,j\in\mathbb Z/N\mathbb Z$,
     \[
         h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2).
     \]
@@ -1296,8 +1296,8 @@ the specialization $L=2$.
     remaining obligations before the conditional theorem can be applied; once
     they are proved, the local terms commute. Together with
     Lemma~\ref{lem:parent_hamiltonian_ff}, the same factorization also gives
-    the zero-energy equation for $V^{(N)}(A)$, still without asserting the
-    source ground-space spanning condition.
+    the zero-energy equation for $V^{(N)}(A)$ when $N\geq2$, still without
+    asserting the source ground-space spanning condition.
 \end{remark}
 
 \begin{theorem}[Even-chain factorization and ground-space spanning give all-chain NNCPH]%

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -161,10 +161,10 @@ source ground-space hypothesis, but its proof is still the Beigi axiom; the
 forward implication has the source-unit Appendix~B structural datum, the
 three-site \(AX/XB\) support maps, and the coefficient form of
 \(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks the construction of the
-source Appendix~D.2 projectors and their lifted commutator from that datum, the
-all-chain local-projector hypotheses, and a justified relation between the source
-formula and the even-chain physical-pair factorization used by the conditional
-theorem.
+source Appendix~D.2 projectors and their lifted commutator from that datum,
+the local-projector hypotheses for all chains of length at least two, and a
+justified relation between the source formula and the even-chain physical-pair
+factorization used by the conditional theorem.
 The axiom-backed theorem still supplies the commutation direction used by the
 unconditional statements.
 


### PR DESCRIPTION
### Motivation

- The previous quantifier on `ProductPairBridge.localProjectors` and
  `AppendixBProductPairExtraction.localProjectors` required a chain-length witness for
  every positive `N`, an artificial strengthening not present in the source
  (arXiv:1606.00608, Appendix B).
- Nearest-neighbor parent-Hamiltonian terms are defined for chains of length at least two;
  restricting the local-projector obligation to `N ≥ 2` aligns the bridge hypothesis with
  the RFP-to-NNCPH statements it supports.
- Continues the Appendix B product-pair extraction formalization; see #3373.

### Description

- `ProductPairBridge.localProjectors` and `AppendixBProductPairExtraction.localProjectors`
  now quantify over `N` with `2 ≤ N` (previously quantifying over all positive `N`).
- Conditional NNCPH wrappers (`isNNCPH`, `commuting_twoSite_localTerms`,
  `ofCoreTensorFactorizationAndCommutation`, RFP→NNCPH extraction theorems) carry the same
  `2 ≤ N` hypothesis; `le_of_lt` threads through all-chain statements that use `N > 2`.
- `rfp_implies_nncph_ground_state_of_appendixBExtraction` is rewritten to go through
  `IsNNCPH.isNNCPHGroundState` explicitly.
- Blueprint remark in `ch13_parent_hamiltonian_commuting_gap.tex` and paper-gap note
  `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` updated to describe the remaining
  local-projector obligation as an all-`N ≥ 2` condition.
- The Appendix D.2 `AX/XB` lifted commutator and source projector construction remain open
  (see #3373).

### Testing

- `lake env lean TNLean/MPS/RFP/CommutingBridge.lean`
- `lake env lean TNLean/MPS/ParentHamiltonian/Commuting.lean`
- `lake build TNLean.MPS.ParentHamiltonian.Commuting`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Addresses #3373

> [!NOTE]
> **Low Risk**
> Pure API and documentation alignment with existing `2 ≤ N` on axiom-backed NNCPH; no change to proof obligations for Appendix D.2 or open gaps.
>
> **Overview**
> **Restricts** the Appendix B product-pair bridge so local-projector witnesses are required only for chain lengths **\(N \ge 2\)**, not every positive \(N\).
>
> `ProductPairBridge.localProjectors` and `AppendixBProductPairExtraction.localProjectors` now quantify with `2 ≤ N`. Dependent lemmas (`isNNCPH`, `commuting_twoSite_localTerms`, `ofCoreTensorFactorizationAndCommutation`, RFP→NNCPH extraction theorems) take the same hypothesis and thread `le_of_lt` where all-chain statements use `N > 2`. `rfp_implies_nncph_ground_state_of_appendixBExtraction` is rewritten to go through `IsNNCPH.isNNCPHGroundState` explicitly.
>
> Blueprint remark and `cpsv16_nncph_ground_state_scope.tex` describe the remaining obligation as commutation for **\(N \ge 2\)**, aligned with nearest-neighbor parent terms and axiom-backed `rfp_implies_nncph`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 424273471ad2b9671decfdf483344769dd965129. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hypothesis-only API and documentation alignment with existing `2 ≤ N` on unconditional NNCPH; no change to Appendix D.2 obligations or axiom-backed proofs.
> 
> **Overview**
> **Aligns** the Appendix B product-pair bridge with nearest-neighbor parent terms by requiring local-projector witnesses only for chain lengths **\(N \ge 2\)**, not every positive \(N\).
> 
> `ProductPairBridge.localProjectors` and `AppendixBProductPairExtraction.localProjectors` now quantify with `2 ≤ N`. Dependent lemmas (`isNNCPH`, `commuting_twoSite_localTerms`, `ofCoreTensorFactorizationAndCommutation`, RFP→NNCPH extraction theorems) take the same hypothesis; all-chain results that assume `N > 2` pass `le_of_lt` into those lemmas. `rfp_implies_nncph_ground_state_of_appendixBExtraction` is refactored to derive `IsNNCPHGroundState` via an explicit `IsNNCPH` step.
> 
> Blueprint remark in `ch13_parent_hamiltonian_commuting_gap.tex` and `cpsv16_nncph_ground_state_scope.tex` now describe the remaining commutation obligation for **\(N \ge 2\)**, matching axiom-backed `rfp_implies_nncph`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 727952beb873d385daab8013005d6bc6e4b1be64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->