### PR TITLE
feat(Channel): add decomposable positive map predicates

### DIFF
--- a/TNLean/Channel/Basic.lean
+++ b/TNLean/Channel/Basic.lean
@@ -27,6 +27,9 @@ Chapters 3 and 6 of Wolf's lecture notes.
 
 * `IsPositiveMap`: a linear map that preserves the PSD cone
 * `IsCPMap`: a linear map that admits a Kraus representation
+* `IsCompletelyCopositiveMap`: a map whose composition with transposition is CP
+* `IsDecomposablePositiveMap`: a sum of a CP map and a completely copositive map
+* `IsIndecomposablePositiveMap`: a positive map that is not decomposable
 * `IsCPMap.isPositiveMap`: completely positive maps are positive
 * `IsChannel`: completely positive + trace-preserving (CPTP)
 * `Matrix.transposeLinearMapComplex_isPositiveMap`: matrix transposition is positive
@@ -112,6 +115,26 @@ section PositiveMap
 
 variable {n : Type*} [Fintype n]
 
+/-- A map is **completely copositive** if composing it with transposition gives a
+completely positive map.
+
+This is the convention used in Wolf Chapter 3: a decomposable positive map is
+written as a completely positive map plus a map `F` for which `F ∘ transpose` is
+completely positive. -/
+def IsCompletelyCopositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
+  IsCPMap (E.comp (Matrix.transposeLinearMapComplex n))
+
+/-- A **decomposable positive map** is a sum of a completely positive map and a
+completely copositive map.  This is the class used in Wolf Chapter 3 to describe
+positive maps that cannot detect PPT entanglement. -/
+def IsDecomposablePositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
+  ∃ Ecp Eccp : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ,
+    IsCPMap Ecp ∧ IsCompletelyCopositiveMap Eccp ∧ E = Ecp + Eccp
+
+/-- An **indecomposable positive map** is positive but not decomposable. -/
+def IsIndecomposablePositiveMap (E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ) : Prop :=
+  IsPositiveMap E ∧ ¬ IsDecomposablePositiveMap E
+
 /-- A completely positive map is positive. -/
 theorem IsCPMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
     (h : IsCPMap E) : IsPositiveMap E := by
@@ -120,6 +143,35 @@ theorem IsCPMap.isPositiveMap {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
   rw [hK]
   exact Matrix.posSemidef_sum (s := Finset.univ) (x := fun i => K i * X * (K i)ᴴ)
     (fun i _ => by simpa [Matrix.mul_assoc] using hX.mul_mul_conjTranspose_same (B := K i))
+
+/-- Completely copositive maps are positive. -/
+theorem IsCompletelyCopositiveMap.isPositiveMap
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (h : IsCompletelyCopositiveMap E) : IsPositiveMap E := by
+  intro X hX
+  have hXt : (Matrix.transposeLinearMapComplex n X).PosSemidef :=
+    Matrix.transposeLinearMapComplex_isPositiveMap X hX
+  have hcp : IsCPMap (E.comp (Matrix.transposeLinearMapComplex n)) := h
+  have hEXt :=
+    IsCPMap.isPositiveMap hcp (Matrix.transposeLinearMapComplex n X) hXt
+  have hdouble :
+      Matrix.transposeLinearMapComplex n (Matrix.transposeLinearMapComplex n X) = X := by
+    ext i j
+    simp [Matrix.transposeLinearMapComplex]
+  have hEX :
+      (E (Matrix.transposeLinearMapComplex n
+        (Matrix.transposeLinearMapComplex n X))).PosSemidef := by
+    simpa [IsCompletelyCopositiveMap, LinearMap.comp_apply] using hEXt
+  simpa [hdouble] using hEX
+
+/-- Decomposable positive maps are positive. -/
+theorem IsDecomposablePositiveMap.isPositiveMap
+    {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}
+    (h : IsDecomposablePositiveMap E) : IsPositiveMap E := by
+  obtain ⟨Ecp, Eccp, hcp, hccp, rfl⟩ := h
+  intro X hX
+  simpa [LinearMap.add_apply] using
+    (hcp.isPositiveMap X hX).add (hccp.isPositiveMap X hX)
 
 /-- A channel is a positive map (derived from complete positivity). -/
 theorem IsChannel.pos {E : Matrix n n ℂ →ₗ[ℂ] Matrix n n ℂ}

--- a/blueprint/src/chapter/ch25_positive_not_cp.tex
+++ b/blueprint/src/chapter/ch25_positive_not_cp.tex
@@ -508,6 +508,29 @@ follow merely from equality of the total numerator and denominator weights.
     $T_C(X)\ge0$.
 \end{proof}
 
+\section{Decomposable positive maps}
+
+The Choi-type maps are stated in Wolf's Example~3.1 as positive and
+indecomposable.  The formal language for the second adjective is the following
+standard one: a positive map is decomposable when it is the sum of a completely
+positive map and a completely copositive map.
+
+\begin{definition}[Decomposable and indecomposable positive maps]
+    \label{def:decomposable_positive_map}
+    \lean{IsCompletelyCopositiveMap, IsDecomposablePositiveMap,
+        IsIndecomposablePositiveMap}
+    \leanok
+    A map $\Phi\colon\MN{D}\to\MN{D}$ is completely copositive if
+    $\Phi\circ\theta$ is completely positive, where $\theta$ is transposition.
+    It is decomposable if
+    \[
+        \Phi=\Phi_{\mathrm{cp}}+\Phi_{\mathrm{ccp}}
+    \]
+    with $\Phi_{\mathrm{cp}}$ completely positive and
+    $\Phi_{\mathrm{ccp}}$ completely copositive.  It is indecomposable if it is
+    positive and not decomposable.
+\end{definition}
+
 \section{The partial transpose and the PPT property}
 
 Transposition is a positive map that is not completely positive, so applying it


### PR DESCRIPTION
### Motivation

- Wolf Ch. 3, Example 3.1 (eq. (3.20), `Notes/WolfNoteTexSource/ch03_positive_not_completely.tex`) requires a notion of indecomposable positive maps to state the indecomposability of `Matrix.choiTypeMap`; that notion was absent from `Channel/Basic.lean` (see LionSR/QICLean#18, formalization target item 1).
- This PR adds the three predicates needed to state and eventually prove `Matrix.choiTypeMap_isIndecomposable`.

### Description

- `TNLean/Channel/Basic.lean`: adds three predicates and two positivity lemmas:
  - `IsCompletelyCopositiveMap`: a map `E` is completely co-positive when `E ∘ transpose` is completely positive.
  - `IsDecomposablePositiveMap`: a map is decomposable when it can be written as a sum of a completely positive map and a completely co-positive map.
  - `IsIndecomposablePositiveMap`: a map is indecomposable when it is positive and not decomposable.
  - `IsCompletelyCopositiveMap.isPositiveMap`: completely co-positive maps are positive (transposition positivity and double-transpose on PSD inputs).
  - `IsDecomposablePositiveMap.isPositiveMap`: decomposable maps are positive.
- `blueprint/src/chapter/ch25_positive_not_cp.tex`: adds a "Decomposable positive maps" section with `\leanok` links for the three definitions.
- Does **not** prove `Matrix.choiTypeMap_isIndecomposable`; that remains the goal of LionSR/QICLean#18.

### Testing

- `lake build TNLean.Channel.Basic`
- `lake build TNLean.Channel.ChoiTypeMap`
- `lake build TNLean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls && cd blueprint && leanblueprint checkdecls`
- `git diff --check`

---
Addresses LionSR/QICLean#18

> [!NOTE]
> **Low Risk**
> New definitions and small derived positivity lemmas on existing channel infrastructure; no behavioral or security-sensitive changes.
>
> **Overview**
> Introduces formal predicates for **decomposable** and **indecomposable** positive maps (Wolf Ch. 3): `IsCompletelyCopositiveMap` (`E ∘ transpose` is CP), `IsDecomposablePositiveMap` (CP + completely copositive sum), and `IsIndecomposablePositiveMap` (positive and not decomposable).
>
> Proves that completely copositive and decomposable maps are **positive**, using transposition positivity and double-transpose on PSD inputs for the copositive case.
>
> Adds a **"Decomposable positive maps"** section in blueprint Chapter 25 with a synced definition and `\leanok` links; does **not** prove Choi-type indecomposability yet.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08ae63b86c13e0cfaad4bb40c5e46335090ec7c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>