### PR TITLE
doc(parent): clarify PGVWC comparison prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -385,18 +385,9 @@ specialized to the block-diagonal boundary conditions of
 arXiv:2011.12127, Section IV.C, lines 2126--2128.
 
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
-arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
-range derived from length-\(L_0\) block injectivity,
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated
+in the current BNT range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
-
-**Scope restriction (crossing span):** The theorem assumes that the simultaneous
-block-word tuples of length \(N-i\) span the product algebra for each
-boundary-crossing interval beginning at \(i\). The finite BNT range gives
-large-length simultaneous product spans; it does not by itself supply the
-shortest crossing tails, where \(N-i\) can be \(1\). Replacing this visible
-span hypothesis is part of the remaining source-faithful boundary comparison
-recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
 The block-diagonal boundary representation used here is the
@@ -404,9 +395,13 @@ boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/0608197,
 Theorem 12 (its block components lie in \(G_N(A_j)\)) and does not assume the
 boundary-crossing comparison.
 
-**Scope restriction (crossing span):** The residual source-scope gap is the
-crossing-tail span hypothesis noted above, which supplies the periodic-boundary
-upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
+**Scope restriction (crossing span):** The theorem assumes that the simultaneous
+block-word tuples of length \(N-i\) span the product algebra for each
+boundary-crossing interval beginning at \(i\). The finite BNT range gives
+large-length simultaneous product spans; it does not by itself supply the
+shortest crossing tails, where \(N-i\) can be \(1\). This visible hypothesis is
+the residual source-scope gap in the periodic-boundary upgrade
+(arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem
@@ -453,18 +448,9 @@ the equality conclusion
 which is the ground-space assertion in the source theorem.
 
 **Scope restriction (length-\(L_0\) injectivity range):** Theorem 12 of
-arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated in the current BNT
-range derived from length-\(L_0\) block injectivity,
+arXiv:quant-ph/0608197 assumes \(L\ge 3(b-1)(L_0+1)+1\). This theorem is stated
+in the current BNT range derived from length-\(L_0\) block injectivity,
 \((L_0+1)+3(r-1)(L_0+1)+1\le L\). The source-range comparison is recorded in
-`docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
-
-**Scope restriction (crossing span):** The theorem assumes that the simultaneous
-block-word tuples of length \(N-i\) span the product algebra for each
-boundary-crossing interval beginning at \(i\). The finite BNT range gives
-large-length simultaneous product spans; it does not by itself supply the
-shortest crossing tails, where \(N-i\) can be \(1\). Replacing this visible
-span hypothesis is part of the remaining source-faithful boundary comparison
-recorded in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`.
 
 The block-diagonal boundary representation used here is the
@@ -472,9 +458,13 @@ boundary-comparison-free open-boundary inclusion of arXiv:quant-ph/0608197,
 Theorem 12 (its block components lie in \(G_N(A_j)\)) and does not assume the
 boundary-crossing comparison.
 
-**Scope restriction (crossing span):** The residual source-scope gap is the
-crossing-tail span hypothesis noted above, which supplies the periodic-boundary
-upgrade (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
+**Scope restriction (crossing span):** The theorem assumes that the simultaneous
+block-word tuples of length \(N-i\) span the product algebra for each
+boundary-crossing interval beginning at \(i\). The finite BNT range gives
+large-length simultaneous product spans; it does not by itself supply the
+shortest crossing tails, where \(N-i\) can be \(1\). This visible hypothesis is
+the residual source-scope gap in the periodic-boundary upgrade
+(arXiv:quant-ph/0608197, Theorem 12, proof lines 1446--1456;
 arXiv:2011.12127, Section IV.C, lines 2126--2128). Documented in
 `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`. -/
 theorem chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -401,7 +401,6 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \uses{lem:bnt_block_diagonal_boundary_representation_equality,
         thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space,
         lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
-    The equality wrapper
     Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality} reduces
     the claim to producing, for each $\psi$, block-diagonal boundary conditions
     \(X_j\) whose single-block components lie in
@@ -420,8 +419,8 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
     \]
-    for every $j$, and the equality wrapper gives the displayed equality and
-    internality.
+    for every $j$. Applying the same lemma to these boundary data gives the
+    displayed equality and internality.
 \end{proof}
 
 \begin{lemma}[Boundary-crossing comparisons give the periodic block ground-space equality]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -215,7 +215,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     Lemma~\ref{lem:bnt_block_diagonal_periodic_constraints_internal_sum}.
 \end{proof}
 
-\begin{lemma}[Boundary-condition identities reduce to periodic-boundary equality]
+\begin{lemma}[Complementary-word matrix identities reduce to periodic-boundary equality]
     \label{lem:bnt_block_diagonal_complementary_identities_equality}
     \lean{MPSTensor.chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_complementary_identities}
     \leanok
@@ -232,7 +232,7 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \[
         \psi=\Gamma_N^{\oplus_j\mu_jA_j}\!\left(\bigoplus_jX_j\right),
     \]
-    the block-diagonal boundary-condition equations hold: for every block $j$,
+    the complementary-word matrix identities hold: for every block $j$,
     boundary-crossing interval $i$, word $\beta$ before the cut, and outside
     word $\rho$ of length $N-L$, there is a matrix $E_{j,i,\rho}$ such that
     \[
@@ -401,11 +401,15 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \uses{lem:bnt_block_diagonal_boundary_representation_equality,
         thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space,
         lem:block_diagonal_boundary_component_pgvwc_comparison_injective}
-    For each $\psi$,
-    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality} gives
-    block-diagonal boundary conditions $X_j$. The stated tail-word spans and
+    The equality wrapper
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality} reduces
+    the claim to producing, for each $\psi$, block-diagonal boundary conditions
+    \(X_j\) whose single-block components lie in
+    \(\mathcal G_{N,L}(A_j)\). The crossing comparison theorem supplies this:
+    it first uses the boundary-comparison-free BNT representation to obtain
+    \(X_j\), and then uses the stated tail-word spans and
     Theorem~\ref{thm:block_diagonal_boundary_crossing_pgvwc_comparison_chain_ground_space}
-    give the matrices $C^j_{i,\rho}$ satisfying
+    to produce matrices $C^j_{i,\rho}$ satisfying
     \[
         A^j_\beta C^j_{i,\rho}
         =
@@ -416,9 +420,8 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
     \]
-    for every $j$. Applying
-    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality} again
-    gives the displayed equality and internality.
+    for every $j$, and the equality wrapper gives the displayed equality and
+    internality.
 \end{proof}
 
 \begin{lemma}[Boundary-crossing comparisons give the periodic block ground-space equality]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -419,8 +419,9 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \[
         \Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)
     \]
-    for every $j$. Applying the same lemma to these boundary data gives the
-    displayed equality and internality.
+    for every $j$. Applying
+    Lemma~\ref{lem:bnt_block_diagonal_boundary_representation_equality} to these
+    boundary conditions gives the displayed equality and internality.
 \end{proof}
 
 \begin{lemma}[Boundary-crossing comparisons give the periodic block ground-space equality]


### PR DESCRIPTION
### Motivation

- Blueprint prose for the crossing-comparison conditional reduction used "boundary-condition identities", which does not match the mathematical terminology in the formalization; continues alignment with arXiv:2011.12127 Section IV.C (see #3597).
- The blueprint narration of the crossing-comparison periodic equality did not follow the Lean proof structure.
- Docstrings on two related theorems in `BNTBlockDiagonalPGVWCComparison.lean` contained duplicated crossing-span scope notes.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`: deduplicated crossing-span scope notes on `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison` and `chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison` into a single paragraph stating the simultaneous tail-word span hypothesis, why finite BNT range does not cover shortest tails (\(N-i=1\)), and that this remains the residual gap for the periodic-boundary upgrade.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`: renamed "boundary-condition identities" to "complementary-word matrix identities" in the conditional reduction lemma; rewrote the proof narration of the crossing-comparison periodic equality to follow the Lean proof flow (boundary-representation equality reduces to block-diagonal \(X_j\) via BNT representation, tail-word spans, the crossing comparison theorem, and the injective component lemma).
- No theorem statements or Lean proof terms changed.

### Testing

- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe cache get`
- `lake build TNLean.MPS.ParentHamiltonian.BNTBlockDiagonalPGVWCComparison` (passes; imported files still emit pre-existing style warnings)

---
Addresses #3597

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comments and LaTeX narration only; no changes to proofs, hypotheses, or theorem statements.
> 
> **Overview**
> **Documentation-only** alignment for block-diagonal parent ground-space material (#3597). No Lean theorem statements or proof terms change.
> 
> In `BNTBlockDiagonalPGVWCComparison.lean`, the crossing-span **scope notes** on `chainGroundSpace_toTensorFromBlocks_eq_iSup_and_iSupIndep_of_crossing_pgvwc_comparison` and `chainGroundSpace_toTensorFromBlocks_eq_iSup_of_crossing_pgvwc_comparison` are **deduplicated** into one paragraph: the simultaneous tail-word span hypothesis, why finite BNT range does not cover shortest crossing tails (\(N-i=1\)), and that this remains the residual gap for the periodic-boundary upgrade.
> 
> In `ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`, the conditional reduction lemma is retitled from **boundary-condition identities** to **complementary-word matrix identities**, matching formalization terminology. The proof of the crossing-comparison periodic equality is **rewritten** to follow the Lean argument: boundary-representation equality reduces to block-diagonal \(X_j\) with single-block components in \(\mathcal G_{N,L}(A_j)\); the crossing comparison theorem (BNT boundary representation, tail-word spans, PGVWC comparison, injective component lemma) supplies those conditions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4be1081665f1a3936206fa4a1e33f33139f7ac3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->