### PR TITLE
doc(parent): align Appendix D2 projector prose

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
+++ b/TNLean/MPS/ParentHamiltonian/LocalSupport.lean
@@ -342,9 +342,10 @@ theorem HasOverlappingTwoSiteCommutation.complement
 two-site commutation predicate on the \(AX\) and \(XB\) faces, then the first two
 translated parent terms on the three-site chain commute.
 
-This is the local transport from the Appendix D.2 projectors of
-arXiv:1606.00608 to the translated parent terms. It does not construct those
-source projectors associated with the Appendix B basic-vector form. -/
+This identifies the first two translated terms with the lifted \(AX\) and
+\(XB\) actions of the canonical two-site parent interaction. It does not
+construct the source projectors associated with the Appendix B basic-vector
+form. -/
 theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation
     (A : MPSTensor d D)
     (h : HasOverlappingTwoSiteCommutation (d := d)
@@ -356,7 +357,7 @@ theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_commutation
   exact h.commute_lifts
 
 /-- If the two-site parent interaction is identified with the Appendix D.2
-projectors \(Q_{AX}\) and \(Q_{XB}\) on the two faces, then the first two
+projectors \(Q_{AX}\) and \(Q_{XB}\) before lifting, then the first two
 translated parent terms on the three-site chain commute. -/
 theorem localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors
     (A : MPSTensor d D) {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -534,10 +534,10 @@ theorem AppendixBStructuralData.localTerm_two_three_one_eq_appendixBQXBOnCoeffSp
 representatives transports to commutation of the first two three-site parent
 terms.
 
-This is only the local transport from the Definition D.2 \(AX/XB\) equation to
-the translated parent interactions.  It does not construct the source
-projectors or prove their lifted commutator from the Appendix B basic-vector
-form.
+This identifies the first two translated parent interactions with the lifted
+\(AX\) and \(XB\) actions of the coefficient representatives.  It does not
+construct the source projectors or prove their lifted commutator from the
+Appendix B basic-vector form.
 
 Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
 2205--2218. -/
@@ -654,9 +654,10 @@ basic-vector expression.
 For a fixed structural form, this captures the two facts that are still not
 produced by the Appendix B structural datum: the coefficient formula for
 \(U^{\otimes N}\varphi_j^{\otimes N}\) must be related to the repeated
-physical-pair two-site amplitude stated here, and the nearest-neighbor
-parent projectors on each finite chain must be identified with a commuting
-family attached to the source projectors \(Q_{AX}\) and \(Q_{XB}\). -/
+physical-pair two-site amplitude stated here, and the translated length-two
+parent terms on each finite chain must be shown to commute.  The latter step is
+the source \(Q_{AX},Q_{XB}\) projector construction and lifted-commutator
+argument, not a consequence of the coefficient representatives alone. -/
 structure AppendixBProductPairExtraction {A : MPSTensor d D}
     (hStruct : AppendixBStructuralData A) where
   /-- Positive even-chain factorization through the structural two-site amplitude. -/
@@ -670,7 +671,7 @@ structure AppendixBProductPairExtraction {A : MPSTensor d D}
 Appendix B core tensor.
 
 This reduces the coefficient computation to the core tensor \(\Lambda U^i\);
-the local projector identities remain a separate hypothesis. -/
+the translated length-two commutation identities remain a separate hypothesis. -/
 noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorization
     {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
     (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
@@ -724,8 +725,8 @@ theorem AppendixBProductPairExtraction.commuting_twoSite_localTerms
 Theorem 3.10:
 RFP plus the proved Appendix B structural theorem implies the nearest-neighbor
 commutation equation as soon as the even-chain physical-pair coefficient condition
-and the two-site projector identities are supplied for the resulting structural
-form.
+and the translated two-site commutation identities are supplied for the
+resulting structural form.
 
 This theorem deliberately stops short of claiming the full Beigi-independent
 `rfp_implies_nncph`: the missing hypothesis is exactly

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -150,8 +150,8 @@ the specialization $L=2$.
         =
         h^{(3)}_1(A,2)h^{(3)}_0(A,2).
     \]
-    This is only the local transport from the \(AX/XB\) condition to translated
-    local terms; the construction of the
+    This only identifies the first two translated local terms with the lifted
+    \(AX\) and \(XB\) actions; the construction of the
     \cite[Appendix~D.2]{Cirac2016MPDO_arXiv} projectors associated with the
     \cite[Appendix~B]{Cirac2016MPDO_arXiv} basic-vector form is a separate step.
 \end{theorem}
@@ -163,9 +163,29 @@ the specialization $L=2$.
     endomorphisms commute.
 \end{proof}
 
+\begin{theorem}[Three-site commutation from two-site representatives]
+    \label{thm:local_term_two_three_commute_from_two_site_q}
+    \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors}
+    \leanok
+    \uses{def:overlapping_two_site_supports,
+        thm:local_term_two_three_ax_xb_lifts}
+    Let $Q_{AX}$ and $Q_{XB}$ be two-site projectors whose lifted \(AX\) and
+    \(XB\) actions commute. Suppose that
+    \[
+        q(A)=Q_{AX},\qquad q(A)=Q_{XB}.
+    \]
+    Then the first two translated length-two local terms on the three-site
+    chain commute.
+\end{theorem}
+
+\begin{proof}\leanok
+    The lift identities identify the translated terms with the lifted actions
+    of \(Q_{AX}\) and \(Q_{XB}\). The assumed overlapping commutation condition
+    is precisely the commutation of those two lifted actions.
+\end{proof}
+
 \begin{theorem}[Three-site commutation from source projectors]
     \label{thm:local_term_two_three_commute_from_source_q}
-    \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors}
     \lean{MPSTensor.localTerm_two_three_zero_one_commute_of_appendixD2}
     \leanok
     \uses{def:overlapping_two_site_supports,
@@ -173,14 +193,14 @@ the specialization $L=2$.
     Suppose the projectors $Q_{AX}$ and $Q_{XB}$ satisfy the
     \cite[Definition~D.2]{Cirac2016MPDO_arXiv} local parent-commuting
     condition on $A X B$, and suppose that the canonical two-site parent
-    interaction is identified with these projectors after lifting to the two
-    faces:
+    interaction is identified, as a two-site operator, with the two source
+    projectors:
     \[
-        q(A)_{AX}=(Q_{AX})_{AX},\qquad
-        q(A)_{XB}=(Q_{XB})_{XB}.
+        q(A)=Q_{AX},\qquad q(A)=Q_{XB}.
     \]
-    Then the first two translated length-two local terms on the three-site
-    chain commute,
+    After lifting these two equalities to the \(AX\) and \(XB\) faces, the first
+    two translated length-two local terms on the three-site chain commute.
+    Thus
     \[
         h^{(3)}_0(A,2)h^{(3)}_1(A,2)
         =
@@ -1275,21 +1295,23 @@ the specialization $L=2$.
     On a three-site chain, the two adjacent length-two local terms are the
     \(AX\) and \(XB\) actions of the canonical two-site parent interaction.
     Appendix~B supplies the basic-vector expression, while Appendix~D.2 supplies
-    the parent-commuting projector condition. The local two-site projector
-    identification above does not prove the overlapping commutation relation
+    the parent-commuting condition for the source projectors. The
+    coefficient-representative identification above does not prove the
+    overlapping commutation relation
     \[
         (\widehat Q_{AX})_{AX}(\widehat Q_{XB})_{XB}
         =
         (\widehat Q_{XB})_{XB}(\widehat Q_{AX})_{AX}.
     \]
-    Nor does it construct the source \(Q_{AX},Q_{XB}\) projectors on the
-    tripartite Hilbert space. For the all-chain statement, the remaining local
-    projector equation is the following commutation condition: for every chain
-    length $N\geq2$ and every pair of sites $i,j\in\mathbb Z/N\mathbb Z$,
+    Nor does it construct the source projectors \(Q_{AX},Q_{XB}\) on the
+    two overlapping tensor factors, or their lifted actions on the tripartite
+    space. For the all-chain statement, the remaining local condition is the
+    following commutation equation: for every chain length $N\geq2$ and every
+    pair of sites $i,j\in\mathbb Z/N\mathbb Z$,
     \[
         h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2).
     \]
-    The projector equation $h_i(A,2)^2=h_i(A,2)$ is already
+    The idempotency equation $h_i(A,2)^2=h_i(A,2)$ is already
     Lemma~\ref{lem:local_term_idempotent}.
     The overlapping commutation theorem and the justification of any passage
     from the source coefficients to this even-chain factorization are the


### PR DESCRIPTION
### Motivation

- The blueprint statement for the commuting parent Hamiltonians result (arXiv:1606.00608, Appendix D.2) described "local transport from Appendix D.2 projectors," which misrepresented what the Lean theorems actually prove: they identify coefficient representatives with lifted $AX$/$XB$ two-site actions, and do not construct the source projectors $Q_{AX}$, $Q_{XB}$ or derive the lifted commutator from the basic-vector form.
- The blueprint theorem on commutation from source projectors stated assumptions in a form that did not match the Lean theorem's unlifted two-site hypotheses before the $AX$/$XB$ lifts.
- Continues documentation accuracy work for the RFP parent Hamiltonian gap; see #3373.

### Description

- `TNLean/MPS/ParentHamiltonian/LocalSupport.lean`: docstring updates clarifying that the current results identify coefficient representatives with the canonical two-site interaction under lifted $AX$/$XB$ actions, and do not construct the source Appendix D.2 projectors.
- `TNLean/MPS/RFP/CommutingBridge.lean`: docstring updates replacing ambiguous "local transport" wording with the actual lifted $AX$/$XB$ identification.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: blueprint prose rewritten so that the commutation theorem states the unlifted two-site equalities $q(A) = Q_{AX}$ and $q(A) = Q_{XB}$ before explaining the lift step, matching `localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors`. The RFP→NNCPH gap is reframed to require translated length-two commutation (projector construction and lifted commutator), not merely identification of coefficient representatives with a commuting projector family.
- No proof or Lean elaboration changes; all edits are documentation and blueprint prose only.

### Testing

- `lake build TNLean.MPS.RFP.CommutingBridge` passes.
- Blueprint prose validated via `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci` and `python3 scripts/blueprint_lean_sync.py --root . --ci`.

---
Addresses #3373

> [!NOTE]
> **Low Risk**
> Comment and blueprint text only; no executable Lean or proof logic changes.
> 
> **Overview**
> **Documentation-only** updates in `LocalSupport.lean`, `CommutingBridge.lean`, and `ch13_parent_hamiltonian_commuting_gap.tex`—no proof or API changes.
> 
> The edits replace vague "local transport from Appendix D.2 projectors" wording with what the lemmas actually do: they **identify** the first two three-site parent terms with **lifted** \(AX\) / \(XB\) actions of the canonical two-site interaction or Appendix B **coefficient representatives**, and they **do not** construct the source \(Q_{AX}, Q_{XB}\) projectors or derive the lifted commutator from the basic-vector form alone.
> 
> The blueprint theorem on commutation from source projectors now states **unlifted** two-site equalities \(q(A)=Q_{AX}\) and \(q(A)=Q_{XB}\) before explaining the lift step, matching `localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors`. Related prose reframes the RFP→NNCPH gap as needing **translated length-two commutation** (projector construction + lifted commutator), not merely identifying coefficient representatives with a commuting projector family.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5f2028bbefd6dc8c3af2b814eb623236b19bc59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and blueprint prose only; no executable Lean or proof logic changes.
> 
> **Overview**
> **Documentation-only** updates in `LocalSupport.lean`, `CommutingBridge.lean`, and `ch13_parent_hamiltonian_commuting_gap.tex`—no proof or API changes.
> 
> Lean docstrings and blueprint text now say the relevant lemmas **identify** the first two three-site parent terms with **lifted** \(AX\) / \(XB\) actions of the canonical two-site interaction or Appendix B **coefficient representatives**, and explicitly **do not** construct source \(Q_{AX}, Q_{XB}\) or derive the lifted commutator from the basic-vector form alone. Wording that suggested “local transport from Appendix D.2 projectors” is removed.
> 
> The blueprint adds **Theorem** `thm:local_term_two_three_commute_from_two_site_q` (lean: `localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors`) with **unlifted** hypotheses \(q(A)=Q_{AX}\) and \(q(A)=Q_{XB}\). The “source projectors” theorem is retargeted to `localTerm_two_three_zero_one_commute_of_appendixD2` and reframes the RFP→NNCPH gap as needing **translated length-two commutation** (projector construction + lifted commutator), not merely identifying representatives with a commuting projector family.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54edd1dbbedcc0bed6be32e9a06a1ee66ab98c63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->