### PR TITLE
feat(MPS/ParentHamiltonian): add overlap commutation constructors for local projectors

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
@@ -48,4 +48,38 @@ theorem isNNCPH_of_twoSite_cyclicWindowsOverlap_commute
     IsNNCPH A N :=
   isCommutingParentHam_of_cyclicWindowsOverlap_commute (A := A) (L := 2) hN hOverlap
 
+/-- Overlapping length-two cyclic-window commutation supplies the
+local-projector hypotheses used by the conditional Appendix B extraction.
+
+The idempotency part is the general translated-parent-term idempotency; the
+overlap reduction supplies the missing all-pairs commutation equations. -/
+noncomputable def HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute
+    {A : MPSTensor d D} {N : ℕ} (hN : 2 ≤ N)
+    (hOverlap : ∀ i j : Fin N, cyclicWindowsOverlap N 2 i j →
+      localTerm A 2 N i * localTerm A 2 N j =
+        localTerm A 2 N j * localTerm A 2 N i) :
+    HasProductPairLocalProjectors A N :=
+  HasProductPairLocalProjectors.of_commuting_localTerms
+    (isNNCPH_of_twoSite_cyclicWindowsOverlap_commute (A := A) hN hOverlap)
+
+/-- Construct the conditional Appendix B extraction from the coefficient
+factorization and the overlapping length-two cyclic-window commutation
+equations on every chain.
+
+This is only the locality reduction from overlapping pairs to all pairs; the
+source \(Q_{AX},Q_{XB}\) projectors and their lifted commutator remain separate
+inputs to the proof of the overlap hypotheses. -/
+noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOverlapCommutation
+    {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
+    (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
+      mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
+    (hOverlap : ∀ N, 2 ≤ N → ∀ i j : Fin N, cyclicWindowsOverlap N 2 i j →
+      localTerm A 2 N i * localTerm A 2 N j =
+        localTerm A 2 N j * localTerm A 2 N i) :
+    AppendixBProductPairExtraction hStruct :=
+  AppendixBProductPairExtraction.ofCoreTensorFactorization hCore
+    (fun N hN =>
+      HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute
+        (A := A) hN (hOverlap N hN))
+
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -300,6 +300,26 @@ the specialization $L=2$.
     locality.
 \end{proof}
 
+\begin{lemma}[Local-projector hypotheses from overlapping two-site commutation]
+    \label{lem:product_pair_local_projectors_from_overlap}
+    \lean{MPSTensor.HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute}
+    \leanok
+    \uses{lem:commuting_parent_ham_overlap_reduction, lem:local_term_idempotent}
+    Let $N\ge2$. Suppose that the translated length-two local terms commute for
+    every pair of overlapping cyclic windows:
+    \[
+        h_i(A,2)h_j(A,2)=h_j(A,2)h_i(A,2).
+    \]
+    Then the family $p_i=h_i(A,2)$ gives the finite-chain local-projector
+    hypotheses used in the conditional Appendix~B extraction.
+\end{lemma}
+
+\begin{proof}\leanok
+    Lemma~\ref{lem:commuting_parent_ham_overlap_reduction} turns the
+    overlapping-pair commutation equations into commutation for all pairs. The
+    idempotency equation is Lemma~\ref{lem:local_term_idempotent}.
+\end{proof}
+
 \begin{definition}[Commutation and zero-energy equations for nearest-neighbor local terms]%
     \label{def:is_nncph_ground_state}
     \lean{MPSTensor.IsNNCPHGroundState}
@@ -1170,6 +1190,7 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBProductPairExtraction}
     \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorization}
     \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorizationAndCommutation}
+    \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOverlapCommutation}
     \lean{MPSTensor.AppendixBProductPairExtraction.toProductPairBridge}
     \lean{MPSTensor.AppendixBProductPairExtraction.commuting_twoSite_localTerms}
     \lean{MPSTensor.commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction}


### PR DESCRIPTION
### Motivation
- Issue #3373 requires the RFP-to-NNCPH path to separate source-projector construction from the finite-chain locality reduction; once overlapping length-two commutation is available, the existing cyclic-window reduction feeds the local-projector hypotheses directly.
- Continues formalization of arXiv:1606.00608, §3.3 and Appendix B (Definition D.2); gap notes in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` and `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`.

### Description
- `TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean`: adds `HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute`, which derives `HasProductPairLocalProjectors A N` from overlapping length-two cyclic-window commutation via `isNNCPH_of_twoSite_cyclicWindowsOverlap_commute` and `HasProductPairLocalProjectors.of_commuting_localTerms`.
- Adds `AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOverlapCommutation`, which combines core-tensor product-pair factorization with per-chain overlap commutation and delegates to the existing `ofCoreTensorFactorization` path. Source projector construction (`Q_AX`, `Q_XB`) and lifted commutators remain separate inputs, as documented in the docstrings.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: adds lemma `lem:product_pair_local_projectors_from_overlap` and registers the new extraction constructor alongside existing Appendix B Lean names; does not claim the missing source projector construction.

### Testing
- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean`
- `git diff --check`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`

---
Refs #3373

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation only; no changes to existing proof bodies or runtime behavior.
>
> **Overview**
> Adds wiring so **overlapping** length-two cyclic-window commutation is enough to supply the finite-chain **local-projector** hypotheses for conditional Appendix B extraction, without requiring all-pairs commutation up front.
>
> In Lean, `HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute` runs overlap reduction (`isNNCPH_of_twoSite_cyclicWindowsOverlap_commute`) into `HasProductPairLocalProjectors.of_commuting_localTerms`. `AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOverlapCommutation` pairs core-tensor product-pair factorization with per-chain overlap commutation and delegates to the existing `ofCoreTensorFactorization` path. Docstrings stress that **source** \(Q_{AX},Q_{XB}\) construction and lifted commutators remain separate inputs.
>
> The parent-Hamiltonian blueprint gains lemma `lem:product_pair_local_projectors_from_overlap` and registers the new extraction constructor alongside the existing Appendix B lean names.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5125032a5bf98eabbc562f9a2be4bc4805ecb0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Lean definitions and blueprint documentation only; no changes to existing proof bodies or runtime behavior.
> 
> **Overview**
> Adds **wiring** so overlapping length-two cyclic-window commutation is enough to supply the finite-chain **local-projector** hypotheses for conditional Appendix B extraction, without assuming all-pairs commutation up front.
> 
> In Lean, `HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute` runs the existing overlap reduction into `HasProductPairLocalProjectors.of_commuting_localTerms`. `AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOverlapCommutation` pairs core-tensor product-pair factorization with per-chain overlap commutation and delegates to `ofCoreTensorFactorization`. Docstrings and the blueprint stress that **source** \(Q_{AX},Q_{XB}\) construction and lifted commutators remain separate inputs.
> 
> The parent-Hamiltonian blueprint gains lemma `lem:product_pair_local_projectors_from_overlap` and registers the new extraction constructor alongside existing Appendix B Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7394896c52b26cade1a735763b0f28f9a538454f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->