### PR TITLE
doc(parent): display D2 proof equations

### DIFF
--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -180,8 +180,20 @@ the specialization $L=2$.
 
 \begin{proof}\leanok
     The lift identities identify the translated terms with the lifted actions
-    of \(Q_{AX}\) and \(Q_{XB}\). The assumed overlapping commutation condition
-    is precisely the commutation of those two lifted actions.
+    of the two projectors:
+    \[
+        h^{(3)}_0(A,2)=(Q_{AX})_{AX},
+        \qquad
+        h^{(3)}_1(A,2)=(Q_{XB})_{XB}.
+    \]
+    The overlapping-support hypothesis is the equation
+    \[
+        (Q_{AX})_{AX}(Q_{XB})_{XB}
+        =
+        (Q_{XB})_{XB}(Q_{AX})_{AX}.
+    \]
+    Substituting the two lifted identities gives the desired commutation of
+    \(h^{(3)}_0(A,2)\) and \(h^{(3)}_1(A,2)\).
 \end{proof}
 
 \begin{theorem}[Three-site commutation from source projectors]


### PR DESCRIPTION
### Motivation
The proof sketch for the three-site commutation statement from two-site representatives should show the two equations that carry the argument, rather than only paraphrasing them.

### Description
- Modified `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`, proof body of `thm:local_term_two_three_commute_from_two_site_q` (Lean: `MPSTensor.localTerm_two_three_zero_one_commute_of_overlapping_two_site_projectors`)
- Added displayed equations for the lift identities $h^{(3)}_0(A,2) = (Q_{AX})_{AX}$ and $h^{(3)}_1(A,2) = (Q_{XB})_{XB}$
- Added displayed equation for the overlapping-support commutation $(Q_{AX})_{AX}(Q_{XB})_{XB} = (Q_{XB})_{XB}(Q_{AX})_{AX}$
- Theorem statement and Lean tags are unchanged

### Testing
- git diff --check
- python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci
- python3 scripts/blueprint_lean_sync.py --root . --ci
- lake build TNLean.Channel.Basic TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction
- python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls
- lake exe checkdecls blueprint/lean_decls
- leanblueprint checkdecls

---
Closes #3648

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blueprint LaTeX proof exposition only; no formal or runtime behavior changes.
> 
> **Overview**
> Expands the proof of **three-site commutation from two-site representatives** so the argument is visible in math, not only in prose.
> 
> The proof now **displays** the lift identities \(h^{(3)}_0(A,2)=(Q_{AX})_{AX}\) and \(h^{(3)}_1(A,2)=(Q_{XB})_{XB}\), then the overlapping-support commutation \((Q_{AX})_{AX}(Q_{XB})_{XB}=(Q_{XB})_{XB}(Q_{AX})_{AX}\), and closes by substituting those into the commutation of the two translated local terms. Theorem statement and Lean tags are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e8c987e2366e5b7faf6e398bd04578dbe54d46b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->