### PR TITLE
doc(MPS/ParentHamiltonian): clarify PGVWC comparison boundary gap

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
+++ b/TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean
@@ -24,6 +24,16 @@ The source proof writes this comparison with boundary-indexed matrices
 \(C^j_{i_1}\), \(D^j_{i_{m+1}}\), and the derived matrix \(E^j\). The words
 \(\beta\) and \(\rho\) below are the word coordinates obtained by opening the
 periodic boundary at the chosen cut, not additional source terminology.
+
+**Proof-state note:** The \(E^j\)-normalization calculation is formalized by
+`pgvwc07_complementary_word_cde_identities_of_block_boundary_trace_decomposition`
+and `pgvwc07_complementary_word_boundary_identities_formula_of_compatibility`.
+The remaining comparison problem is to derive the displayed \(C^j,D^j\)
+compatibility from periodic-boundary membership in the source range
+\(b\ge2\), \(L\ge3(b-1)(L_0+1)+1\), and \(N\ge L+L_0\), where \(b\) is the
+number of blocks in arXiv:quant-ph/0608197, Theorem 12. This derivation should
+not use the short tail-word span hypothesis assumed by the conditional
+statements below.
 -/
 
 open scoped Matrix BigOperators
@@ -55,7 +65,7 @@ for every block \(j\), outside word \(\rho\), and word \(\beta\) before the cut,
   \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
 \]
 
-This is the fixed-boundary form of the \(C^j,D^j\) comparison in
+This is a span-dependent fixed-boundary form of the \(C^j,D^j\) comparison in
 arXiv:quant-ph/0608197, Theorem 12, proof lines 1436--1456, specialized to the
 block-diagonal boundary conditions used in arXiv:2011.12127, Section IV.C,
 lines 2126--2128.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex
@@ -13,15 +13,22 @@ comparison in the periodic ring. The source proof
 \cite{PerezGarcia2007Matrix} writes this comparison with $C^j_{i_1}$,
 $D^j_{i_{m+1}}$, and the normalized matrix $E^j$; the symbols $\beta$ and
 $\rho$ below are the words obtained after opening the periodic boundary at the
-chosen cut. In these coordinates the source comparison becomes
+chosen cut. The source theorem writes the number of blocks as $b$ and assumes
+$b\ge2$; here the same number is denoted by $g$. In these coordinates the
+source comparison input becomes
 \[
     A^j_\beta C^j_{i,\rho}
     =
     \bigl(\mu_j^N X_j A^j_\beta\bigr)A^j_\rho,
 \]
-which is the opened-boundary form of
+which is the form obtained after opening the boundary from
 $A^j_{i_{m+1}}C^j_{i_1}=D^j_{i_{m+1}}A^j_{i_1}$ with
 $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
+Once this compatibility is known, the normalized $E^j$ calculation is the
+matrix identity of
+Lemma~\ref{lem:block_boundary_cde_identities_from_trace_decompositions};
+the local boundary form used after opening the periodic boundary is
+Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc}.
 
 \begin{lemma}[The block-diagonal periodic-boundary space lies between two block sums]
     \label{lem:bnt_block_diagonal_periodic_chain_inclusions}
@@ -298,6 +305,9 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
         =
         \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
     \]
+    This is the $C^j,D^j$ compatibility input; the subsequent normalized
+    $E^j$ identities follow from
+    Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc}.
     Then
     \[
         \mathcal G_{N,L}\!\left(\bigoplus_j\mu_jA_j\right)
@@ -344,10 +354,12 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
         =
         \bigvee_j\mathcal G_{N,L}(A_j).
     \]
-    This records only the ground-space equality conclusion obtained from the
-    \(C^j,D^j\) boundary-condition comparison in
+    This records only the ground-space equality conclusion obtained after the
+    $C^j,D^j$ boundary-condition comparison input in
     \cite[Theorem~12, proof lines~1446--1456]{PerezGarcia2007Matrix}; the
-    independence of the \(N\)-site spaces is a separate conclusion of
+    local normalized $E^j$ calculation is
+    Lemma~\ref{lem:complementary_word_boundary_identities_from_pgvwc}.
+    The independence of the $N$-site spaces is a separate conclusion of
     Lemma~\ref{lem:bnt_block_diagonal_pgvwc_comparison_equality}.
     The statement is still in the length-$L_0$ injectivity range displayed in
     that lemma, not the shorter range in
@@ -383,8 +395,8 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     \]
     and the $N$-site ground spaces $G_N(A_j)=\mathcal G_{N,N}(A_j)$
     have internal sum.
-    The present statement is the span-dependent opened-boundary consequence of
-    the boundary-condition comparison in
+    The present statement is the span-dependent consequence, after opening the
+    boundary, of the $C^j,D^j$ compatibility input in
     \cite[Theorem~12, proof lines~1436--1451]{PerezGarcia2007Matrix} in the
     length-$L_0$ injectivity range
     \[
@@ -442,8 +454,8 @@ $D^j_\beta=(\mu_j^NX_j)A^j_\beta$.
     tail-word span hypothesis and in the longer current range. The independence
     of the $N$-site spaces is a separate conclusion of
     Lemma~\ref{lem:bnt_block_diagonal_crossing_pgvwc_comparison_equality}.
-    Thus the statement remains a conditional opened-boundary comparison, not
-    the unconditional boundary-condition comparison in the source theorem.
+    Thus the statement remains conditional on the short tail-word spans; it is
+    not the unconditional boundary-condition comparison in the source theorem.
     % Source-faithful replacement of the tail-word span hypothesis is tracked in issue~\#3597.
 \end{lemma}
 

--- a/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
+++ b/docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex
@@ -539,6 +539,23 @@ length \(N-i\) now give matrices
   =
   \bigl((\mu_j^NX_j)A^j_\beta\bigr)A^j_\rho .
 \end{align}
+Once this compatibility identity is available, the normalized \(E^j\)
+calculation is no longer a gap: the adjoint-corrected formula
+\begin{align}
+  E^j_i=\sum_\rho C^j_{i,\rho}(A^j_\rho)^\dagger
+\end{align}
+and the identities
+\begin{align}
+  (\mu_j^NX_j)A^j_\beta=A^j_\beta E^j_i,
+  \qquad
+  A^j_\beta C^j_{i,\rho}=A^j_\beta E^j_iA^j_\rho
+\end{align}
+are formalized by
+\leanid{MPSTensor.pgvwc07_complementary_word_cde_identities_of_block_boundary_trace_decomposition}.
+The local boundary formula with \(E_{j,i,\rho}=E^j_iA^j_\rho\) is formalized by
+\leanid{MPSTensor.pgvwc07_complementary_word_boundary_identities_formula_of_compatibility};
+its existential consequence is
+\leanid{MPSTensor.pgvwc07_complementary_word_boundary_identities_of_compatibility}.
 This is formalized as
 \leanid{MPSTensor.blockDiagonal_boundary_crossing_pgvwc_comparison_of_sum_mem_iSup}
 and, once a block-diagonal boundary representation of \(\psi\) is fixed, into
@@ -565,10 +582,10 @@ derives it from the span-based one-step intersection identity
 \leanid{MPSTensor.pgvwc07_iSup_restriction_intersection_of_ge_of_bnt_directSum_unital_c1};
 its block components lie in the open-boundary ground spaces $\mathcal G_N^{A_j}$,
 and its proof does not use the periodic-boundary comparison at boundary-crossing
-windows. The conditional block-diagonal parent-space wrappers therefore hold the
+windows. The conditional block-diagonal parent-space statements therefore hold the
 periodic-boundary comparison only as an explicit hypothesis---a scope
 restriction---rather than as a smuggled dependency. The residual transitive
-source-faithfulness gap carried by those wrappers is the normalized BNT
+source-faithfulness gap carried by those statements is the normalized BNT
 product-span input, whose derivation is the normal-range reduction recorded in
 \path{docs/paper-gaps/cpgsv21_normal_range_reduction.tex} (lines 2078--2079 of
 \path{Papers/2011.12127/TN-Review-main.tex}); that gap is independent of the
@@ -576,7 +593,7 @@ periodic-boundary comparison tracked here.
 
 The remaining source-comparison target is tracked by
 \href{https://github.com/LionSR/TNLean/issues/3597}{issue \#3597}: replace the
-span-dependent short-tail statement by the \(C^j,D^j,E^j\) comparison from
+span-dependent short-tail statement by the \(C^j,D^j\) comparison input from
 \cite[Theorem~12]{PerezGarcia2007MPSReps} in the source range
 \begin{align}
   b\ge2,


### PR DESCRIPTION
### Motivation

- The paper-gap note `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex` conflated two distinct obligations: the source (C^j, D^j) compatibility input from the PGVWC periodic-boundary comparison (arXiv:quant-ph/0608197, Theorem 12, proof lines 1446–1456; arXiv:2011.12127, Section IV.C, lines 2126–2128), and the already-formalized (E^j) normalization step covered by `pgvwc07_complementary_word_cde_identities_of_block_boundary_trace_decomposition` and `pgvwc07_complementary_word_boundary_identities_of_compatibility`. The conflation obscured what issue #3597 needs to prove.
- The PGVWC source uses b ≥ 2 for the number of blocks while the local blueprint uses g; recording this notation mapping allows reviewers to cross-check the gap note against the source.

### Description

- `TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`: updated docstring to explicitly separate the (C^j, D^j) compatibility obligation from the (E^j) normalization, citing the two lemmas that already cover E^j.
- `blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_chain_equality.tex`: added notation mapping b ≥ 2 (PGVWC) ↔ g (local); reframed conditional lemmas to state that the (C^j, D^j) input is needed and (E^j) is supplied by the cited lemmas; scope of issue #3597 narrowed to (C^j, D^j) alone.
- `docs/paper-gaps/cpgsv21_block_diagonal_parent_ground_space.tex`: updated gap note to reference the formal (C^j, D^j, E^j) declarations and the local boundary-identity results.
- No Lean proof or statement changes; no new `sorry`.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/BNTBlockDiagonalPGVWCComparison.lean`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`

---
Addresses #3597

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and docstring edits only; no executable Lean or proof logic changes.
> 
> **Overview**
> **Documentation-only** updates (Lean docstrings, blueprint ch13, paper-gap note); no theorem statements or proofs change.
> 
> The docs now **split** the PGVWC boundary comparison into two obligations: the **\(C^j,D^j\) compatibility** input (still open, issue **#3597**) versus the **\(E^j\) normalization**, which is already covered by `pgvwc07_complementary_word_cde_identities_of_block_boundary_trace_decomposition` and `pgvwc07_complementary_word_boundary_identities_formula_of_compatibility`.
> 
> The blueprint adds **\(b\ge2\) (PGVWC) ↔ \(g\) (local)** block-count notation and reframes conditional lemmas so **\(E^j\)** is cited as a consequence of existing lemmas, not part of the remaining gap. The gap note states that once \(C^j,D^j\) holds, the \(E^j\) step is **not** a separate gap, and renames some “wrapper” wording to “statements” for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513b7bcd1281bcf868ace1660d47ded73b5ed8b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->