### PR TITLE
feat(MPS/RFP): add D.2 projector identification and overlap commutation

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -508,6 +508,28 @@ theorem AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_commute_lift
   right_idempotent := hStruct.appendixBQXBOnCoeffSpace_idempotent
   commute_lifts := hcomm
 
+/-- A Definition D.2 projector pair gives the Appendix B overlapping condition
+once the source projectors are transported to coefficient space and identified
+with the coefficient-space representatives.
+
+This statement does not construct the source projectors \(Q_{AX}\) and
+\(Q_{XB}\).  It records the exact transport step that will be used after those
+projectors are constructed from the Appendix B basic-vector form.
+
+Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
+2205--2218. -/
+theorem
+    AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_appendixD2_identified_projectors
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    {KAXB : Submodule ℂ (NSiteSpace d 3)}
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (hD2 : HasAppendixD2ParentCommutingHamiltonian (d := d) KAXB QAX QXB)
+    (hAX : QAX = hStruct.appendixBQAXOnCoeffSpace)
+    (hXB : QXB = hStruct.appendixBQXBOnCoeffSpace) :
+    HasOverlappingTwoSiteCommutation (d := d) hStruct.appendixBQAXOnCoeffSpace
+      hStruct.appendixBQXBOnCoeffSpace := by
+  simpa [hAX, hXB] using hD2.to_overlapping
+
 /-- On a three-site window, the first translated length-two parent term is the
 \(AX\) lift of the Appendix B \(AX\) coefficient representative.
 
@@ -591,6 +613,29 @@ theorem AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendix
     localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
       localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) :=
   hStruct.localTerm_two_three_zero_one_commute_of_overlapping hD2.to_overlapping
+
+/-- A Definition D.2 projector pair gives commutation of the first two
+translated length-two parent terms, once the source projectors are transported
+to coefficient space and identified with the Appendix B representatives.
+
+This is still conditional on the source-projector identification.  It does not
+construct \(Q_{AX}\) and \(Q_{XB}\) from the Appendix B basic-vector form.
+
+Source: arXiv:1606.00608, lines 543--578 and Definition D.2, lines
+2205--2218. -/
+theorem
+    AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2_identified_projectors
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    {KAXB : Submodule ℂ (NSiteSpace d 3)}
+    {QAX QXB : NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2}
+    (hD2 : HasAppendixD2ParentCommutingHamiltonian (d := d) KAXB QAX QXB)
+    (hAX : QAX = hStruct.appendixBQAXOnCoeffSpace)
+    (hXB : QXB = hStruct.appendixBQXBOnCoeffSpace) :
+    localTerm A 2 3 (0 : Fin 3) * localTerm A 2 3 (1 : Fin 3) =
+      localTerm A 2 3 (1 : Fin 3) * localTerm A 2 3 (0 : Fin 3) :=
+  hStruct.localTerm_two_three_zero_one_commute_of_overlapping
+    (hStruct.hasOverlappingTwoSiteCommutation_of_appendixD2_identified_projectors
+      hD2 hAX hXB)
 
 /-- The Appendix B basis change does not change any MPV coefficient. -/
 theorem AppendixBStructuralData.mpv_eq_coreTensor {A : MPSTensor d D}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1068,6 +1068,42 @@ the specialization $L=2$.
     displayed lifted commutator.
 \end{proof}
 
+\begin{lemma}[Definition D.2 projectors identified with Appendix B representatives]
+    \label{lem:appendixB_d2_projectors_identified_with_representatives}
+    \lean{MPSTensor.AppendixBStructuralData.hasOverlappingTwoSiteCommutation_of_appendixD2_identified_projectors}
+    \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_one_commute_of_appendixD2_identified_projectors}
+    \leanok
+    \uses{def:overlapping_two_site_supports, def:appendixB_qax,
+        def:appendixB_qxb, lem:appendixB_overlapping_condition_parent_terms}
+    Let $Q_{AX}$ and $Q_{XB}$ be the two-site coefficient-space transports of
+    source projectors satisfying the Definition~D.2 local condition on
+    $A X B$.  If these transported projectors agree with the Appendix~B
+    coefficient representatives,
+    \[
+        Q_{AX}=\widehat Q_{AX},
+        \qquad
+        Q_{XB}=\widehat Q_{XB},
+    \]
+    then $\widehat Q_{AX}$ and $\widehat Q_{XB}$ satisfy the algebraic
+    overlapping two-site condition of
+    Definition~\ref{def:overlapping_two_site_supports}.  Consequently,
+    \[
+        h_0^{(3)}(A,2)h_1^{(3)}(A,2)
+        =
+        h_1^{(3)}(A,2)h_0^{(3)}(A,2).
+    \]
+    % Maintainer note: this conditional identification statement does not
+    % construct $Q_{AX}$ and $Q_{XB}$ from the Appendix~B basic-vector form.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Rewriting the two projectors in the Definition~D.2 condition as
+    $\widehat Q_{AX}$ and $\widehat Q_{XB}$ gives the algebraic overlapping
+    condition.  The three-site commutation is then
+    Lemma~\ref{lem:appendixB_overlapping_condition_parent_terms}.
+\end{proof}
+
 \begin{lemma}[Three-site lifts of the Appendix B coefficient representatives]
     \label{lem:appendixB_three_site_parent_lifts}
     \lean{MPSTensor.AppendixBStructuralData.localTerm_two_three_zero_eq_appendixBQAXOnCoeffSpace_lift}


### PR DESCRIPTION
### Motivation

- Continues the formalization of arXiv:1606.00608, §3.3, Appendix B, and Definition D.2 (see #3373, sub-task of the RFP/NNCPH equivalence tracker #2633).
- The local-support maps for overlapping two-site parent terms are in place (PR #3384); the remaining step is to derive the Appendix B coefficient-space overlapping condition from a source Definition D.2 projector pair.
- Records the new conditional results in the blueprint chapter without asserting that the source projector construction is complete.

### Description

- `TNLean/MPS/RFP/CommutingBridge.lean`: adds a conditional derivation from a genuine Definition D.2 projector pair (arXiv:1606.00608, Appendix D) to the Appendix B coefficient-space overlapping condition, after explicit source-projector identification; adds the corresponding three-site local-term commutation theorem.
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: records the new statements in the parent-Hamiltonian blueprint chapter (`ch13_parent_hamiltonian_commuting_gap`), without claiming the source projector construction is complete.

### Testing

- `lake env lean TNLean/MPS/RFP/CommutingBridge.lean`
- `lake build TNLean.MPS.RFP.CommutingBridge`
- `lake exe checkdecls blueprint/lean_decls`
- `leanblueprint web`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `git diff --check`

---
Addresses #3373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proof-only formalization and blueprint sync with no runtime, auth, or data-path changes; scope is explicitly conditional and does not close the open projector-construction gap.
> 
> **Overview**
> Adds **conditional** bridge lemmas: from a Definition D.2 parent-commuting projector pair, once the transported two-site operators are **identified** with the Appendix B coefficient representatives \(\widehat Q_{AX}\) and \(\widehat Q_{XB}\), the formalization derives the overlapping two-site commutation datum and commutation of the first two three-site translated length-two parent terms.
> 
> In `CommutingBridge.lean`, the new theorems are thin rewrites via `HasAppendixD2ParentCommutingHamiltonian.to_overlapping` and the existing overlapping-to-local-term pipeline; they **do not** construct source projectors from the basic-vector form. The blueprint chapter `ch13_parent_hamiltonian_commuting_gap.tex` records the same statements with an explicit maintainer note that projector construction remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979bf5f51bfd6314191ba78bff4088fda72d9b1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->