### PR TITLE
feat(parent): reduce NNCPH to adjacent commutation

### DIFF
--- a/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
+++ b/TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean
@@ -48,6 +48,92 @@ theorem isNNCPH_of_twoSite_cyclicWindowsOverlap_commute
     IsNNCPH A N :=
   isCommutingParentHam_of_cyclicWindowsOverlap_commute (A := A) (L := 2) hN hOverlap
 
+/-- Two length-two cyclic windows can overlap only when their starting sites
+coincide or are cyclic nearest neighbors.
+
+This is the finite-chain form of the source observation that, for
+nearest-neighbor terms, the only interacting translates are \(P_2\) and
+\(\tau_{\pm 1}(P_2)\). -/
+theorem cyclicWindowsOverlap_twoSite_cases {N : ℕ} {i j : Fin N}
+    (h : cyclicWindowsOverlap N 2 i j) :
+    j = i ∨ j = cyclicForwardSite i 1 ∨ i = cyclicForwardSite j 1 := by
+  rcases h with ⟨k, hki, hkj⟩
+  rw [cyclicWindowSupport] at hki hkj
+  rcases Finset.mem_image.mp hki with ⟨ri, hri, hri_eq⟩
+  rcases Finset.mem_image.mp hkj with ⟨rj, hrj, hrj_eq⟩
+  have hri_cases : ri = 0 ∨ ri = 1 := by
+    have hri_lt : ri < 2 := by simpa using hri
+    omega
+  have hrj_cases : rj = 0 ∨ rj = 1 := by
+    have hrj_lt : rj < 2 := by simpa using hrj
+    omega
+  rcases hri_cases with rfl | rfl <;> rcases hrj_cases with rfl | rfl
+  · have hij : i = j := by
+      apply Fin.ext
+      have hval : i.val % N = j.val % N := by
+        simpa [cyclicForwardSite] using congrArg Fin.val (hri_eq.trans hrj_eq.symm)
+      have hmodi : i.val % N = i.val := Nat.mod_eq_of_lt i.isLt
+      have hmodj : j.val % N = j.val := Nat.mod_eq_of_lt j.isLt
+      rwa [hmodi, hmodj] at hval
+    exact Or.inl hij.symm
+  · have hij : i = cyclicForwardSite j 1 := by
+      apply Fin.ext
+      have hval : i.val % N = (j.val + 1) % N := by
+        simpa [cyclicForwardSite] using congrArg Fin.val (hri_eq.trans hrj_eq.symm)
+      have hmodi : i.val % N = i.val := Nat.mod_eq_of_lt i.isLt
+      rwa [hmodi] at hval
+    exact Or.inr (Or.inr hij)
+  · have hji : j = cyclicForwardSite i 1 := by
+      apply Fin.ext
+      have hval : j.val % N = (i.val + 1) % N := by
+        simpa [cyclicForwardSite] using congrArg Fin.val (hri_eq.trans hrj_eq.symm).symm
+      have hmodj : j.val % N = j.val := Nat.mod_eq_of_lt j.isLt
+      rwa [hmodj] at hval
+    exact Or.inr (Or.inl hji)
+  · have hsucc : cyclicForwardSite i 1 = cyclicForwardSite j 1 :=
+      hri_eq.trans hrj_eq.symm
+    have hval : (i.val + 1) % N = (j.val + 1) % N := by
+      simpa [cyclicForwardSite] using congrArg Fin.val hsucc
+    have hij : i = j := by
+      apply Fin.ext
+      by_cases hi : i.val + 1 < N
+      · have hmodi : (i.val + 1) % N = i.val + 1 := Nat.mod_eq_of_lt hi
+        by_cases hj : j.val + 1 < N
+        · have hmodj : (j.val + 1) % N = j.val + 1 := Nat.mod_eq_of_lt hj
+          omega
+        · have hjN : j.val + 1 = N := by omega
+          have hmodj : (j.val + 1) % N = 0 := by rw [hjN, Nat.mod_self]
+          omega
+      · have hiN : i.val + 1 = N := by omega
+        have hmodi : (i.val + 1) % N = 0 := by rw [hiN, Nat.mod_self]
+        by_cases hj : j.val + 1 < N
+        · have hmodj : (j.val + 1) % N = j.val + 1 := Nat.mod_eq_of_lt hj
+          omega
+        · have hjN : j.val + 1 = N := by omega
+          omega
+    exact Or.inl hij.symm
+
+/-- For nearest-neighbor parent Hamiltonians, commutation of each local term with
+its cyclic right neighbor implies the full pairwise commutation condition.
+
+The proof uses the preceding case split for overlapping length-two windows and
+the locality lemma for disjoint windows. -/
+theorem isNNCPH_of_adjacent_twoSite_commute
+    {A : MPSTensor d D} {N : ℕ} (hN : 2 ≤ N)
+    (hAdjacent : ∀ i : Fin N,
+      localTerm A 2 N i * localTerm A 2 N (cyclicForwardSite i 1) =
+        localTerm A 2 N (cyclicForwardSite i 1) * localTerm A 2 N i) :
+    IsNNCPH A N := by
+  refine isNNCPH_of_twoSite_cyclicWindowsOverlap_commute (A := A) hN ?_
+  intro i j hOverlap
+  rcases cyclicWindowsOverlap_twoSite_cases hOverlap with hji | hji | hij
+  · subst j
+    rfl
+  · subst j
+    exact hAdjacent i
+  · subst i
+    exact (hAdjacent j).symm
+
 /-- Overlapping length-two cyclic-window commutation supplies the
 local-projector hypotheses used by the conditional Appendix B extraction.
 
@@ -61,6 +147,21 @@ noncomputable def HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_
     HasProductPairLocalProjectors A N :=
   HasProductPairLocalProjectors.of_commuting_localTerms
     (isNNCPH_of_twoSite_cyclicWindowsOverlap_commute (A := A) hN hOverlap)
+
+/-- Adjacent length-two cyclic-window commutation supplies the local-projector
+hypotheses used by the conditional Appendix B extraction.
+
+This is the nearest-neighbor specialization of the overlap reduction: for
+length-two windows, it is enough to check each local term against its cyclic right
+neighbor. -/
+noncomputable def HasProductPairLocalProjectors.of_adjacent_twoSite_commute
+    {A : MPSTensor d D} {N : ℕ} (hN : 2 ≤ N)
+    (hAdjacent : ∀ i : Fin N,
+      localTerm A 2 N i * localTerm A 2 N (cyclicForwardSite i 1) =
+        localTerm A 2 N (cyclicForwardSite i 1) * localTerm A 2 N i) :
+    HasProductPairLocalProjectors A N :=
+  HasProductPairLocalProjectors.of_commuting_localTerms
+    (isNNCPH_of_adjacent_twoSite_commute (A := A) hN hAdjacent)
 
 /-- Construct the conditional Appendix B extraction from the coefficient
 factorization and the overlapping length-two cyclic-window commutation
@@ -81,5 +182,25 @@ noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOve
     (fun N hN =>
       HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute
         (A := A) hN (hOverlap N hN))
+
+/-- Construct the conditional Appendix B extraction from the coefficient
+factorization and the adjacent length-two cyclic-window commutation equations on
+every chain.
+
+This is the finite-chain reduction from the source nearest-neighbor commutator
+\([\tau_1(P_2),P_2]=0\) to full pairwise commutation of all translated two-site
+local terms. It does not prove the Appendix B source-projector commutator. -/
+noncomputable def AppendixBProductPairExtraction.ofCoreTensorFactorizationAndAdjacentCommutation
+    {A : MPSTensor d D} {hStruct : AppendixBStructuralData A}
+    (hCore : ∀ N, 0 < N → ∀ σ : Cfg d (2 * N),
+      mpv hStruct.coreTensor σ = productPairState hStruct.twoSiteAmplitude N σ)
+    (hAdjacent : ∀ N, 2 ≤ N → ∀ i : Fin N,
+      localTerm A 2 N i * localTerm A 2 N (cyclicForwardSite i 1) =
+        localTerm A 2 N (cyclicForwardSite i 1) * localTerm A 2 N i) :
+    AppendixBProductPairExtraction hStruct :=
+  AppendixBProductPairExtraction.ofCoreTensorFactorization hCore
+    (fun N hN =>
+      HasProductPairLocalProjectors.of_adjacent_twoSite_commute
+        (A := A) hN (hAdjacent N hN))
 
 end MPSTensor

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -312,6 +312,63 @@ the specialization $L=2$.
     locality.
 \end{proof}
 
+\begin{lemma}[Length-two cyclic-overlap alternatives]
+    \label{lem:two_site_cyclic_window_overlap_cases}
+    \lean{MPSTensor.cyclicWindowsOverlap_twoSite_cases}
+    \leanok
+    \uses{def:cyclic_windows_overlap}
+    For $i,j\in\mathbb Z/N\mathbb Z$, if the two length-two cyclic supports
+    starting at $i$ and $j$ overlap, then
+    \[
+        j=i
+        \quad\text{or}\quad
+        j\equiv i+1\pmod N
+        \quad\text{or}\quad
+        i\equiv j+1\pmod N .
+    \]
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expanding each length-two cyclic support gives shifts
+    $r_i,r_j\in\{0,1\}$ and an equality of sites
+    $i+r_i\equiv j+r_j\pmod N$.  The four possible pairs
+    $(r_i,r_j)$ give exactly the three alternatives displayed above.
+\end{proof}
+
+\begin{lemma}[Adjacent two-site translates suffice for nearest-neighbor commutation]
+    \label{lem:nncph_from_adjacent_two_site_commutation}
+    \lean{MPSTensor.isNNCPH_of_adjacent_twoSite_commute}
+    \lean{MPSTensor.HasProductPairLocalProjectors.of_adjacent_twoSite_commute}
+    \leanok
+    \uses{lem:two_site_cyclic_window_overlap_cases,
+        lem:commuting_parent_ham_overlap_reduction, lem:local_term_idempotent}
+    Let $N\ge2$. Suppose that, for every $i\in\mathbb Z/N\mathbb Z$, the
+    translated length-two local term commutes with its cyclic right neighbor:
+    \[
+        h_i(A,2)\,h_{i+1}(A,2)=h_{i+1}(A,2)\,h_i(A,2).
+    \]
+    Then all translated length-two local terms commute, and the family
+    $p_i=h_i(A,2)$ satisfies the finite-chain local-projector hypotheses used
+    in the conditional Appendix~B extraction.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    By Lemma~\ref{lem:two_site_cyclic_window_overlap_cases}, overlapping
+    length-two cyclic supports force
+    \[
+        j=i
+        \quad\text{or}\quad
+        j\equiv i+1\pmod N
+        \quad\text{or}\quad
+        i\equiv j+1\pmod N .
+    \]
+    The equal-start case gives $h_i(A,2)=h_j(A,2)$.  The two nearest-neighbor
+    cases are the displayed hypothesis and its transpose.  The overlap-reduction
+    lemma supplies the remaining disjoint pairs by locality.
+\end{proof}
+
 \begin{lemma}[Local-projector hypotheses from overlapping two-site commutation]
     \label{lem:product_pair_local_projectors_from_overlap}
     \lean{MPSTensor.HasProductPairLocalProjectors.of_twoSite_cyclicWindowsOverlap_commute}
@@ -1239,6 +1296,7 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorization}
     \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorizationAndCommutation}
     \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorizationAndOverlapCommutation}
+    \lean{MPSTensor.AppendixBProductPairExtraction.ofCoreTensorFactorizationAndAdjacentCommutation}
     \lean{MPSTensor.AppendixBProductPairExtraction.toProductPairBridge}
     \lean{MPSTensor.AppendixBProductPairExtraction.commuting_twoSite_localTerms}
     \lean{MPSTensor.commuting_twoSite_localTerms_of_rfp_of_appendixBExtraction}


### PR DESCRIPTION
### Motivation

- The nearest-neighbor commuting parent-Hamiltonian (NNCPH) condition on a cyclic chain requires commutation of translated two-site parent terms at every overlapping pair of length-two windows. This PR shows that adjacent two-site commutation alone is sufficient: any two overlapping length-two cyclic windows have either equal or cyclic-neighbor starting sites, so adjacent commutation propagates to all overlapping pairs.
- Continues the formalization of arXiv:1606.00608, §3.3 and Appendix B (projector identification and commutation for the RFP-to-NNCPH direction); see #3373 (sub-task of #2633).

### Description

Modified `TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean` (+122 lines):

- `cyclicWindowsOverlap_twoSite_cases`: overlapping length-two cyclic windows have either equal or cyclic-neighbor starting sites.
- `isNNCPH_of_adjacent_twoSite_commute`: derives the NNCPH condition from adjacent two-site commutation only.
- `HasProductPairLocalProjectors.of_adjacent_twoSite_commute`: constructor for the product-pair local-projector predicate under the weaker adjacency hypothesis.
- `AppendixBProductPairExtraction.ofCoreTensorFactorizationAndAdjacentCommutation`: Appendix B extraction constructor under adjacent commutation.

Modified `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex` (+28 lines):

- Adds lemma `lem:nncph_from_adjacent_two_site_commutation` with `\lean{}` and `\leanok` tags.
- Registers the new declarations in the product-pair remark.

The remaining step — proving the Appendix B source-projector commutator that supplies the adjacent two-site commutation hypothesis — is tracked in #3373.

### Testing

- `lake env lean TNLean/MPS/ParentHamiltonian/Martingale/OverlapReduction.lean`
- `lake build TNLean.MPS.ParentHamiltonian.Martingale.OverlapReduction`
- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint web`
- `lake exe checkdecls blueprint/lean_decls`

---
Addresses #3373
Refs #2633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and blueprint sync in parent-Hamiltonian martingale theory; no runtime, auth, or data-path changes.
> 
> **Overview**
> Shows that **nearest-neighbor commuting parent Hamiltonian (NNCPH)** on a cyclic chain needs only **adjacent** two-site commutation, not commutation for every overlapping length-two window pair.
> 
> Adds `cyclicWindowsOverlap_twoSite_cases`: overlapping length-two cyclic windows have starting sites that are equal or cyclic neighbors. From that, `isNNCPH_of_adjacent_twoSite_commute` derives full NNCPH from `h_i h_{i+1} = h_{i+1} h_i`, reusing the existing overlap-reduction pipeline. Parallel constructors wire the weaker hypothesis into **Appendix B** product-pair extraction: `HasProductPairLocalProjectors.of_adjacent_twoSite_commute` and `AppendixBProductPairExtraction.ofCoreTensorFactorizationAndAdjacentCommutation`.
> 
> The blueprint chapter gains matching lemmas (`lem:two_site_cyclic_window_overlap_cases`, `lem:nncph_from_adjacent_two_site_commutation`) and registers the new Lean names in the product-pair remark. Proving the Appendix B source-projector commutator that supplies adjacent commutation remains out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc326a17771691ab08bdb4dbf46b6987d1c97b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->