### PR TITLE
ci(blueprint): publish first-12-chapter blueprint PDF on GitHub Pages

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -79,6 +79,9 @@ jobs:
             exit 1
           fi
 
+      - name: Build first-12-chapters release PDF
+        run: ./scripts/build_blueprint_ch01_12.sh
+
       - name: Deploy to gh-pages
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/home_page/_layouts/default.html
+++ b/home_page/_layouts/default.html
@@ -29,6 +29,7 @@
       }}</h2>
     <a href="blueprint" class="btn">Blueprint (web)</a>
     <a href="blueprint.pdf" class="btn">Blueprint (pdf)</a>
+    <a href="blueprint-ch01-12.pdf" class="btn">Blueprint ch. 1&ndash;12 (pdf)</a>
     <a href="docs" class="btn">Documentation</a>
     {% if site.github.is_project_page %}
     <a href="{{ site.github.repository_url }}" class="btn">GitHub</a>

--- a/scripts/build_blueprint_ch01_12.sh
+++ b/scripts/build_blueprint_ch01_12.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Build the paper-release blueprint PDF restricted to the first twelve
+# chapters (ch01_intro through ch12_symmetry) as blueprint/print/print12.pdf.
+#
+# Run after scripts/blueprint_bibtex.py (which refreshes src/references.bib).
+# The blueprint sources are copied to a temporary directory, content.tex is
+# truncated there, and latexmk (XeLaTeX, via blueprint/latexmkrc) runs in the
+# copy, so the checked-out blueprint directory is never modified; only the
+# gitignored blueprint/print/print12.pdf artifact is written back.
+#
+# Cross-references from the kept chapters into dropped ones render as "??";
+# these are expected (the full PDF remains the authoritative version).
+set -euo pipefail
+
+N_CHAPTERS="${N_CHAPTERS:-12}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "==> Copying blueprint sources..."
+mkdir -p "$WORK_DIR/blueprint"
+cp -R "$REPO_ROOT/blueprint/src" "$WORK_DIR/blueprint/src"
+
+echo "==> Restricting content.tex to the first $N_CHAPTERS chapters..."
+awk -v cap="$N_CHAPTERS" '
+  /^[[:space:]]*\\input\{chapter\// {
+    n++
+    if (n > cap) { print "% [first-" cap "-chapters build] " $0; next }
+  }
+  { print }
+' "$REPO_ROOT/blueprint/src/content.tex" > "$WORK_DIR/blueprint/src/content.tex"
+
+kept="$(grep -c '^[[:space:]]*\\input{chapter/' "$WORK_DIR/blueprint/src/content.tex")"
+if [ "$kept" -ne "$N_CHAPTERS" ]; then
+  echo "::error::Expected $N_CHAPTERS active chapter inputs after truncation, found $kept"
+  exit 1
+fi
+
+# Same engine and flags as the leanblueprint-generated latexmkrc
+# ($pdflatex = 'xelatex -synctex=1'), stated explicitly because that rc is
+# an untracked artifact not present on a fresh checkout.
+echo "==> Building with latexmk (XeLaTeX)..."
+(cd "$WORK_DIR/blueprint/src" \
+  && latexmk -pdfxe -pdfxelatex='xelatex -synctex=1 %O %S' \
+       -interaction=nonstopmode print.tex)
+
+mkdir -p "$REPO_ROOT/blueprint/print"
+cp "$WORK_DIR/blueprint/src/print.pdf" "$REPO_ROOT/blueprint/print/print12.pdf"
+echo "==> Wrote blueprint/print/print12.pdf"

--- a/scripts/build_blueprint_ch01_12.sh
+++ b/scripts/build_blueprint_ch01_12.sh
@@ -4,15 +4,14 @@
 #
 # Run after scripts/blueprint_bibtex.py (which refreshes src/references.bib).
 # The blueprint sources are copied to a temporary directory, content.tex is
-# truncated there, and latexmk (XeLaTeX, via blueprint/latexmkrc) runs in the
-# copy, so the checked-out blueprint directory is never modified; only the
-# gitignored blueprint/print/print12.pdf artifact is written back.
+# filtered there, and latexmk runs in the copy, so the checked-out blueprint
+# directory is never modified; only the gitignored
+# blueprint/print/print12.pdf artifact is written back.
 #
 # Cross-references from the kept chapters into dropped ones render as "??";
 # these are expected (the full PDF remains the authoritative version).
 set -euo pipefail
 
-N_CHAPTERS="${N_CHAPTERS:-12}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "$WORK_DIR"' EXIT
@@ -21,23 +20,31 @@ echo "==> Copying blueprint sources..."
 mkdir -p "$WORK_DIR/blueprint"
 cp -R "$REPO_ROOT/blueprint/src" "$WORK_DIR/blueprint/src"
 
-echo "==> Restricting content.tex to the first $N_CHAPTERS chapters..."
-awk -v cap="$N_CHAPTERS" '
+# Keep exactly the ch01_* ... ch12_* chapter inputs, selected by chapter-name
+# prefix rather than by position, so reordering or inserting chapters in
+# content.tex cannot silently change what this volume contains.
+echo "==> Restricting content.tex to chapters ch01-ch12..."
+awk '
   /^[[:space:]]*\\input\{chapter\// {
-    n++
-    if (n > cap) { print "% [first-" cap "-chapters build] " $0; next }
+    if ($0 !~ /\\input\{chapter\/ch(0[1-9]|1[0-2])_/) {
+      print "% [ch01-12 release build] " $0
+      next
+    }
   }
   { print }
 ' "$REPO_ROOT/blueprint/src/content.tex" > "$WORK_DIR/blueprint/src/content.tex"
 
-kept="$(grep -c '^[[:space:]]*\\input{chapter/' "$WORK_DIR/blueprint/src/content.tex")"
-if [ "$kept" -ne "$N_CHAPTERS" ]; then
-  echo "::error::Expected $N_CHAPTERS active chapter inputs after truncation, found $kept"
+expected="$(printf 'ch%02d\n' $(seq 1 12))"
+kept="$(grep '^[[:space:]]*\\input{chapter/' "$WORK_DIR/blueprint/src/content.tex" \
+  | sed -E 's|.*chapter/(ch[0-9]{2})_.*|\1|' | sort -u)"
+if [ "$kept" != "$expected" ]; then
+  echo "::error::Active chapters after filtering are not exactly ch01..ch12; got:"
+  echo "$kept"
   exit 1
 fi
 
 # Same engine and flags as the leanblueprint-generated latexmkrc
-# ($pdflatex = 'xelatex -synctex=1'), stated explicitly because that rc is
+# ($pdflatex = 'xelatex -synctex=1'), passed explicitly because that rc is
 # an untracked artifact not present on a fresh checkout.
 echo "==> Building with latexmk (XeLaTeX)..."
 (cd "$WORK_DIR/blueprint/src" \

--- a/scripts/deploy-to-gh-pages.sh
+++ b/scripts/deploy-to-gh-pages.sh
@@ -78,6 +78,14 @@ if [ ! -f "$REPO_ROOT/blueprint/print/print.pdf" ]; then
 fi
 cp "$REPO_ROOT/blueprint/print/print.pdf" "$WORK_DIR/site/blueprint.pdf"
 
+# Update the first-12-chapters release PDF (optional artifact; built by
+# scripts/build_blueprint_ch01_12.sh). If absent, keep the existing site copy.
+if [ -f "$REPO_ROOT/blueprint/print/print12.pdf" ]; then
+  cp "$REPO_ROOT/blueprint/print/print12.pdf" "$WORK_DIR/site/blueprint-ch01-12.pdf"
+else
+  echo "No first-12-chapters PDF at blueprint/print/print12.pdf; keeping existing site copy"
+fi
+
 # Update homepage (remove all homepage files first, then copy fresh)
 echo "==> Updating homepage..."
 rm -rf "$WORK_DIR/site/_layouts" "$WORK_DIR/site/assets" \


### PR DESCRIPTION
## Summary

The companion paper describes the blueprint through its first twelve chapters (`ch01_intro` through `ch12_symmetry`: the fundamental-theorem chain plus symmetry/string order). This PR releases that restriction as a **separate PDF on the GitHub Pages site**, alongside the existing full `blueprint.pdf`.

The artifact is served at:
`https://lionsr.github.io/TNLean/blueprint-ch01-12.pdf`

## Changes

- **`scripts/build_blueprint_ch01_12.sh`** (new): copies `blueprint/src` to a temporary directory, truncates `content.tex` to the first 12 `\input{chapter/...}` lines (with an exact-count guard that fails the build if the chapter list shape changes), compiles with latexmk/XeLaTeX, and writes the gitignored `blueprint/print/print12.pdf`. The checked-out blueprint tree is never modified.
- **`.github/workflows/blueprint.yml`**: runs the script after the full `leanblueprint pdf`/`web` build.
- **`scripts/deploy-to-gh-pages.sh`**: copies the artifact to `site/blueprint-ch01-12.pdf` when present (optional, like the paper-gap PDFs).
- **`home_page/_layouts/default.html`**: adds a header button "Blueprint ch. 1–12 (pdf)".

## Verification

Built locally: 151 pages. 19 cross-references from kept chapters into dropped ones render as `??`, expected for the restricted volume; the full PDF remains the authoritative version. Bibliography resolves cleanly; the first excluded chapter is `ch13_parent_hamiltonian`.