### PR TITLE
doc(blueprint): set author names on the title pages

### DIFF
--- a/blueprint/src/print.tex
+++ b/blueprint/src/print.tex
@@ -14,7 +14,7 @@
 
 \title{Fundamental Theorem of Matrix Product States\\
   \large A Formalization Blueprint}
-\author{Authors}
+\author{Sirui Lu \and Erickson Tjoa \and J.\ Ignacio Cirac}
 \date{Last update: \today}
 
 \begin{document}

--- a/blueprint/src/web.tex
+++ b/blueprint/src/web.tex
@@ -19,7 +19,7 @@
 \dochome{../docs}
 
 \title{Fundamental Theorem of Matrix Product States}
-\author{Authors}
+\author{Sirui Lu, Erickson Tjoa, and J.\ Ignacio Cirac}
 \date{Last update: \today}
 
 \begin{document}


### PR DESCRIPTION
The published blueprint volumes (including the new `blueprint-ch01-12.pdf`) should carry the author names. Both `print.tex` and `web.tex` had the placeholder `\author{Authors}`.

- `print.tex`: `\author{Sirui Lu \and Erickson Tjoa \and J.\ Ignacio Cirac}` — the standard report-class multi-author title; inherited by both the full `blueprint.pdf` and the first-12-chapters volume (verified by building the volume on this branch: the title page shows all three names).
- `web.tex`: plain comma list, since the current web build renders the author field as literal text and does not typeset `\and`.