### PR TITLE
chore(notes): ignore Wolf note history exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ External/.lake/
 Notes/Wolf/.texpadtmp/
 Notes/Wolf/History/
 Notes/Wolf/build/
+Notes/WolfNoteTexSource/History/
 
 
 # Compiled PDFs (regenerable)


### PR DESCRIPTION
## Summary

- ignore `Notes/WolfNoteTexSource/History/` so exported Wolf note history files are not reintroduced

## Context

The directory was removed from `main` in `6aed25088`; this follow-up keeps future local exports out of ordinary commits.

## Validation

- inspected `.gitignore` diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `.gitignore` entry with no runtime or application behavior impact.
> 
> **Overview**
> Adds **`Notes/WolfNoteTexSource/History/`** to `.gitignore`, alongside the existing Wolf note ignore rules, so local Wolf note history exports stay out of git after that tree was dropped from `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77500f82ba6cb82694898731dfe391430482d5f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->