### PR TITLE
doc(blueprint): clarify prose conventions and intro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ blueprint/src/Packages/__pycache__/
 
 # Local notes / mail exports
 MeetingNotes/*.eml
+/References/
 
 blueprint/src/print.xdv
 

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -20,9 +20,10 @@ Run these commands from the repository root:
 
 ```bash
 lake build
-cd blueprint && leanblueprint checkdecls
-cd blueprint && leanblueprint pdf
-cd blueprint && leanblueprint web
+cd blueprint
+leanblueprint checkdecls
+leanblueprint pdf
+leanblueprint web
 ```
 
 `leanblueprint checkdecls` should be run after adding or changing `\lean{...}`

--- a/blueprint/README.md
+++ b/blueprint/README.md
@@ -1,0 +1,49 @@
+# Blueprint
+
+This directory contains the mathematical blueprint for TNLean.  The blueprint is
+the reader-facing account of the formalization: it states the definitions,
+lemmas, and theorems in mathematical language and links them to the
+corresponding Lean declarations with `\lean{...}` and `\leanok` tags.
+
+## Layout
+
+- `src/` contains the LaTeX source.
+- `src/chapter/` contains one file per chapter.
+- `src/content.tex` is the chapter router.
+- `src/macros/` contains blueprint-specific macros and diagram commands.
+- `src/references.bib` is the blueprint bibliography.
+- `print/` and `web/` are generated outputs.
+
+## Build and Check
+
+Run these commands from the repository root:
+
+```bash
+lake build
+cd blueprint && leanblueprint checkdecls
+cd blueprint && leanblueprint pdf
+cd blueprint && leanblueprint web
+```
+
+`leanblueprint checkdecls` should be run after adding or changing `\lean{...}`
+tags.  The PDF and web builds regenerate `blueprint/print/` and
+`blueprint/web/`.
+
+## Writing Conventions
+
+Blueprint prose should be mathematical prose.  Avoid Lean-specific explanations
+in visible text; the `\lean{...}` tag supplies the link to the formal
+declaration.  Maintainer notes about proof status, local formalization choices,
+or paper-gap documents should be written as LaTeX comments unless they are part
+of the mathematical statement being presented to readers.
+
+When a result is claimed to formalize a source theorem, the blueprint statement
+must match the source hypotheses.  If the current Lean theorem has extra
+hypotheses, the source theorem should not be marked as fully formalized until a
+source-faithful statement exists.
+
+The detailed style rules are in:
+
+- `docs/blueprint_style_guide.md`
+- `docs/prose_style.md`
+- `docs/MATHLIB_doc.md`

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -85,7 +85,7 @@ not to any additional input for the Fundamental Theorem.
 The later chapters develop parent-Hamiltonian consequences, correlation
 estimates, examples, channel representations, normal forms, quantum dynamical
 semigroups, operator convexity, and entropy. They also include the standard
-examples of positive maps which fail to be completely positive.
+examples of positive maps that fail to be completely positive.
 % Draft chapters also treat the direct Fundamental Theorem for periodically
 % repeated tensors in irreducible form, together with compatibility theorems
 % for physical-index rotation (Definition~\ref{def:rotate_physical} in

--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -68,28 +68,24 @@ control normal blocks. Chapters~\ref{ch:wielandt} and~\ref{ch:canonical}
 supply the blocking, primitivity, irreducibility, and canonical-form reductions.
 Chapter~\ref{ch:canonical} includes the invariant-projection splitting.
 Chapter~\ref{ch:bnt} supplies bases of normal tensors and the
-power-sum comparison. The
-after-blocking reductions in Section~\ref{sec:reduction_to_normal_form} give
-the common primitive block decompositions used immediately in
-Chapter~\ref{ch:ft_proof}, which records the conditional theorem
-statements.
+power-sum comparison.
 % Maintainer note: the same-index direct-sum lemmas used after a block
 % correspondence has already been fixed are collected later in
 % the algebraic-FT draft chapter, because they are facts about block-diagonal
 % gauges, not part of the canonical-form reduction or of the BNT block-matching
 % proof. The remaining BNT matching and fixed-length span inputs are kept as
-% explicit hypotheses until the corresponding source steps are supplied.
+% explicit hypotheses until the corresponding source steps are supplied. Paper-gap
+% note: docs/paper-gaps/conditional_after_blocking_ft_cpsv_statement.tex.
 
-The chapters after Chapter~\ref{ch:ft_proof} collect applications,
-alternative formulations, and later tensor-network material.
 Chapter~\ref{ch:symmetry} uses the Fundamental Theorem to obtain virtual
 symmetry gauges, projective bond representations, and string-order criteria;
 its Kraus-mixing step appeals only to the later channel-representation chapter,
 not to any additional input for the Fundamental Theorem.
-Parent Hamiltonians, correlations, examples, channel representations, normal
-forms, quantum dynamical semigroups, operator convexity, and entropy are then
-collected, followed by examples of positive maps that are not completely
-positive.
+
+The later chapters develop parent-Hamiltonian consequences, correlation
+estimates, examples, channel representations, normal forms, quantum dynamical
+semigroups, operator convexity, and entropy. They also include the standard
+examples of positive maps which fail to be completely positive.
 % Draft chapters also treat the direct Fundamental Theorem for periodically
 % repeated tensors in irreducible form, together with compatibility theorems
 % for physical-index rotation (Definition~\ref{def:rotate_physical} in

--- a/blueprint/src/chapter/ch02_mps.tex
+++ b/blueprint/src/chapter/ch02_mps.tex
@@ -54,7 +54,7 @@ boundary conditions (PBC).
 
 \begin{proof}\leanok
     \uses{def:eval_word}
-    Immediate from the definition of $A^w$.
+    The claim follows from the definition of $A^w$.
 \end{proof}
 
 \begin{lemma}[Centre of $\MN{D}$]\label{lem:center_scalar}
@@ -539,7 +539,7 @@ boundary conditions (PBC).
 \end{lemma}
 
 \begin{proof}\leanok
-    The forward direction is immediate from the definition of a direct sum of
+    The forward direction follows from the definition of a direct sum of
     matrices. Conversely, if all off-block entries vanish, the diagonal blocks
     reconstruct the original matrix.
 \end{proof}

--- a/blueprint/src/chapter/ch04_channels.tex
+++ b/blueprint/src/chapter/ch04_channels.tex
@@ -1373,7 +1373,7 @@ matching the weighted-trace argument in
 
 \begin{proof}\leanok
     \uses{thm:kadison_schwarz_channels, thm:left_multiplicative_identity_channels}
-    Closure under addition and scalar multiplication is immediate from
+    Closure under addition and scalar multiplication follows from
     linearity.
     Closure under $\dagger$: if $E(X) = X$ then $E(X^\dagger) = X^\dagger$
     because fixed points are stable under adjoint.

--- a/blueprint/src/chapter/ch05_schwarz.tex
+++ b/blueprint/src/chapter/ch05_schwarz.tex
@@ -1868,7 +1868,7 @@ adjacent cones.
 \begin{proof}
     \leanok
     \uses{thm:kraus_commute}
-    Multiplicativity on $\mc{A}(E)$ is immediate from the definition.
+    Multiplicativity on $\mc{A}(E)$ follows from the definition.
     For $X \in \mc{A}(E)$, the Kraus commutation relation from
     Theorem~\ref{thm:kraus_commute} gives $E(X^\dagger) = E(X)^\dagger$,
     so the restriction preserves adjoints.

--- a/blueprint/src/chapter/ch08_wielandt.tex
+++ b/blueprint/src/chapter/ch08_wielandt.tex
@@ -477,7 +477,7 @@ The results follow~\cite{Sanz2010Quantum}.
 \begin{proof}
     \leanok
     \uses{thm:cumulative_eq_top}
-    Immediate from Theorem~\ref{thm:cumulative_eq_top}.
+    The claim follows from Theorem~\ref{thm:cumulative_eq_top}.
 \end{proof}
 
 \begin{remark}[Explicit blocking-length estimates]\leanok
@@ -1315,7 +1315,7 @@ used to produce rank-one elements.
 \end{theorem}
 
 \begin{proof}\leanok\uses{thm:primitive_overlap}
-    Immediate from the self-overlap convergence under a
+    The claim follows from the self-overlap convergence under a
     complementary transfer-map gap
     (Theorem~\ref{thm:primitive_overlap}).
 \end{proof}

--- a/blueprint/src/chapter/ch10_bnt.tex
+++ b/blueprint/src/chapter/ch10_bnt.tex
@@ -654,7 +654,7 @@ and the combined-family linear independence.
 \end{lemma}
 
 \begin{proof}\leanok
-    Immediate from the definition of the sector coefficient.
+    The claim follows from the definition of the sector coefficient.
 \end{proof}
 
 \begin{lemma}[Cross-overlap decay between distinct basis blocks]%

--- a/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
+++ b/blueprint/src/chapter/ch11_fundamental_theorem_proof.tex
@@ -489,13 +489,13 @@ of the proportionality, recorded next.
     global proportionality scalar of two BNT canonical forms is a pure phase
     power is a length-scalar control statement requiring peripheral-spectrum /
     almost-periodicity analysis of the bounded power sums $c_N^{(j)}(\cdot)$; it
-    is not derivable from~(\ref{eq:ft_coeff_identity_threaded}) alone. The
-    obstruction is recorded in
-    \texttt{docs/paper-gaps/cpsv16\_proportional\_length\_scalar\_gap.tex}. Until
-    it is discharged, the unconditional full-tensor proportional gauge
-    equivalence is not stated; the unconditional per-normal-tensor proportional
-    fundamental theorem is
+    is not derivable from~(\ref{eq:ft_coeff_identity_threaded}) alone. Until this
+    length-scalar control is supplied, the unconditional full-tensor
+    proportional gauge equivalence is not stated; the unconditional
+    per-normal-tensor proportional fundamental theorem is
     Theorem~\ref{thm:cpgsv_multiblock_ft_source}.
+    % Paper-gap note:
+    % docs/paper-gaps/cpsv16_proportional_length_scalar_gap.tex.
 \end{remark}
 
 In the equal-MPV case all ingredients are unconditional.

--- a/blueprint/src/chapter/ch12_symmetry.tex
+++ b/blueprint/src/chapter/ch12_symmetry.tex
@@ -451,7 +451,7 @@ make this precise and establish the quotient $H^2(G,\C^{\times})$.
 \end{theorem}
 
 \begin{proof}\leanok\uses{def:projectively_equivalent}
-    This is immediate from the definition of projective equivalence as
+    This follows from the definition of projective equivalence as
     cohomology-class equality for factor systems.
 \end{proof}
 
@@ -558,7 +558,7 @@ reordering basis states rather than by a general linear map. % The statements of
 \end{lemma}
 
 \begin{proof}\leanok\uses{def:perm_twisted_tensor}
-    Immediate from $\sigma(1)(i) = i$ for all~$i$.
+    The claim follows from $\sigma(1)(i) = i$ for all~$i$.
 \end{proof}
 
 \noindent\emph{Composition order.}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_block_diagonal_boundary_crossing.tex
@@ -1,8 +1,8 @@
 \subsection{Cyclic windows at the boundary cut}\label{subsec:block_diagonal_boundary_crossing}
 
 A cyclic length-$L$ window either stays inside the chosen linear interval
-($i+L\le N$) or crosses the boundary cut ($N<i+L$). The non-wrapping case is
-immediate from trace cyclicity, while the crossing case requires a boundary-matrix
+($i+L\le N$) or crosses the boundary cut ($N<i+L$). The non-wrapping case follows
+from trace cyclicity, while the crossing case requires a boundary-matrix
 identity $\mu_j^NX_jA^j_\beta=A^j_\beta Y$. The lemmas below establish the
 single-block periodic membership $\Gamma_N^{A_j}(\mu_j^NX_j)\in\mathcal G_{N,L}(A_j)$
 in both cases.

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -929,7 +929,7 @@ the specialization $L=2$.
     source condition, not the ground-space spanning part.
     This implication is cited here from the structural characterization theorem
     for renormalization fixed points in~\cite{Cirac2016MPDO_arXiv}; the source
-    proof says that RFP $\Rightarrow$ NNCPH is immediate from that theorem.
+    proof says that RFP $\Rightarrow$ NNCPH follows from that theorem.
     At present this implication remains an unproved hypothesis. The source
     derivation from the basic-vector formula
     $V^{(N)}(A_j)=U^{\otimes N}\varphi_j^{\otimes N}$ and the corresponding

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_decorrelation.tex
@@ -212,7 +212,7 @@ orthogonal-projector, or ground-space-intersection hypotheses of Appendix~D.2.
 \begin{proof}
     \leanok
     \uses{def:has_commuting_parent_ham}
-    This is immediate from commutativity of $P_{AX}$ and $P_{XB}$ together
+    This follows from commutativity of $P_{AX}$ and $P_{XB}$ together
     with the identity $P_{AX} \circ P_{XB} = P_K$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_boundary.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_boundary.tex
@@ -180,8 +180,8 @@ and combines them into the commutation $X A^j = A^j X$.
     $L_0,\ldots,M-1$ with $\mu$ for the support crossing the last site, and fill
     the sites $1,\ldots,M-L_0$ with $\mu$ for the second boundary-crossing
     support.
-    The two complement-extraction identities are then immediate from the index
-    arithmetic. The same outside-site calculation gives, for any $\rho$ with
+    The two complement-extraction identities follow from the index arithmetic.
+    The same outside-site calculation gives, for any $\rho$ with
     $\rho_{k+L_0}=\mu_k$,
     \[
         \operatorname{Res}^{\rho}_{M,L_0+1}\psi

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_injective_ground_spaces.tex
@@ -442,7 +442,7 @@ translated copies of the local interaction.
 
 \begin{proof}
     \leanok
-    Immediate from Lemma~\ref{lem:local_term_annihilates_mpv}.
+    The claim follows from Lemma~\ref{lem:local_term_annihilates_mpv}.
 \end{proof}
 
 \section{Intersection property and unique ground state}\label{sec:intersection_unique}
@@ -674,7 +674,7 @@ Given a state $\psi$ on $L+1$ sites, we define two restriction maps.
 
 \begin{proof}
     \leanok
-    Immediate from the two forward-direction lemmas and
+    The claim follows from the two forward-direction lemmas and
     Theorem~\ref{thm:ground_space_intersection}.
 \end{proof}
 

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1024,12 +1024,11 @@ and rates for the single-tensor transfer map $\E_A$.
     \leanok
     \uses{def:is_canonical_form, def:injective}
     For a family of tensors in canonical form, every block is injective.
-    This is a direct projection of the injectivity field of the canonical-form
-    predicate; see \cite[Section~2.3]{Cirac2016MPDO_arXiv}.
+    This is part of the canonical-form hypotheses in
+    \cite[Section~2.3]{Cirac2016MPDO_arXiv}.
 \end{theorem}
 \begin{proof}\leanok
-    Immediate from the \texttt{block\_injective} field of
-    \texttt{IsCanonicalForm}.
+    The canonical-form hypotheses include injectivity of each block.
 \end{proof}
 
 

--- a/blueprint/src/chapter/ch15_examples.tex
+++ b/blueprint/src/chapter/ch15_examples.tex
@@ -83,7 +83,7 @@ non-injective, renormalization-fixed-point MPS.
 \begin{proof}
     \leanok
     \uses{thm:ghz_transfer_idempotent}
-    Immediate from Theorem~\ref{thm:ghz_transfer_idempotent}.
+    The claim follows from Theorem~\ref{thm:ghz_transfer_idempotent}.
 \end{proof}
 
 \begin{theorem}[GHZ tensor is not injective]\label{thm:ghz_not_injective}
@@ -185,7 +185,7 @@ non-injective, renormalization-fixed-point MPS.
 \begin{proof}
     \leanok
     \uses{thm:zcl_iff_idempotent_transfer, thm:ghz_is_rfp}
-    Immediate from the idempotence of the GHZ transfer map and the equivalence
+    The claim follows from the idempotence of the GHZ transfer map and the equivalence
     of zero correlation length with transfer-map idempotence
     (Theorem~\ref{thm:zcl_iff_idempotent_transfer}).
 \end{proof}
@@ -1028,7 +1028,7 @@ computation and provides another example of a non-trivial SPT phase.
 \begin{proof}
     \leanok
     \uses{thm:zcl_iff_idempotent_transfer, thm:cluster_blocked_idempotent}
-    Immediate from the idempotence of the blocked cluster transfer map and the
+    The claim follows from the idempotence of the blocked cluster transfer map and the
     equivalence of zero correlation length with transfer-map idempotence
     (Theorem~\ref{thm:zcl_iff_idempotent_transfer}).
 \end{proof}

--- a/blueprint/src/chapter/ch17_semigroup.tex
+++ b/blueprint/src/chapter/ch17_semigroup.tex
@@ -431,7 +431,7 @@ and proves the GKSL theorem.
 \begin{proof}
     \leanok
     \uses{thm:dyson_series_eq_ch12}
-    Immediate from Theorem~\ref{thm:dyson_series_eq_ch12}.
+    The claim follows from Theorem~\ref{thm:dyson_series_eq_ch12}.
 \end{proof}
 
 %% ---------------------------------------------------------

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_coefficients.tex
@@ -191,7 +191,7 @@
     respect to the same $\chi$-family.
 \end{theorem}
 \begin{proof}\leanok
-    This is immediate from the definition of the canonical coefficient family.
+    This follows from the definition of the canonical coefficient family.
 \end{proof}
 
 \begin{definition}[Positive BNT-label $\chi$ trace-power witness]%

--- a/blueprint/src/chapter/ch24_peps_ft_foundations.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_foundations.tex
@@ -286,7 +286,7 @@ sections.
     \]
 \end{theorem}
 \begin{proof}\leanok
-    This is immediate from $\Psi_v \circ \Phi_v = \Id$.
+    This follows from $\Psi_v \circ \Phi_v = \Id$.
 \end{proof}
 
 \begin{theorem}[Injectivity of local physical realization]%

--- a/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
@@ -546,8 +546,8 @@ every finite union of injective regions.
     \[
         \operatorname{inj}(R).
     \]
-    The positive-bond restriction is recorded in
-    \texttt{docs/paper-gaps/peps\_injective\_ft\_section3\_route.tex}.
+    The positive-bond restriction is part of the present statement.
+    % Paper-gap note: docs/paper-gaps/peps_injective_ft_section3_route.tex.
 \end{theorem}
 \begin{proof}\leanok
     Let $(c_\rho)_\rho$ be a finitely supported coefficient family on the
@@ -580,8 +580,8 @@ every finite union of injective regions.
         \Longrightarrow
         \operatorname{inj}(R\cup S).
     \]
-    The positive-bond restriction is recorded in
-    \texttt{docs/paper-gaps/peps\_injective\_ft\_section3\_route.tex}.
+    The positive-bond restriction is part of the present statement.
+    % Paper-gap note: docs/paper-gaps/peps_injective_ft_section3_route.tex.
 \end{theorem}
 \begin{proof}\leanok
     The kernel descent theorem gives

--- a/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
+++ b/blueprint/src/chapter/ch24_peps_ft_normal_union.tex
@@ -546,8 +546,7 @@ every finite union of injective regions.
     \[
         \operatorname{inj}(R).
     \]
-    The positive-bond restriction is part of the present statement.
-    % Paper-gap note: docs/paper-gaps/peps_injective_ft_section3_route.tex.
+% Paper-gap note: docs/paper-gaps/peps_injective_ft_section3_route.tex.
 \end{theorem}
 \begin{proof}\leanok
     Let $(c_\rho)_\rho$ be a finitely supported coefficient family on the
@@ -580,8 +579,7 @@ every finite union of injective regions.
         \Longrightarrow
         \operatorname{inj}(R\cup S).
     \]
-    The positive-bond restriction is part of the present statement.
-    % Paper-gap note: docs/paper-gaps/peps_injective_ft_section3_route.tex.
+% Paper-gap note: docs/paper-gaps/peps_injective_ft_section3_route.tex.
 \end{theorem}
 \begin{proof}\leanok
     The kernel descent theorem gives

--- a/home_page/_layouts/default.html
+++ b/home_page/_layouts/default.html
@@ -21,8 +21,6 @@
 </head>
 
 <body>
-  <a id="skip-to-content" href="#content">Skip to the content.</a>
-
   <header class="page-header" role="banner">
     <h1 class="project-name">{{ page.title | default: site.title | default: site.github.repository_name }}</h1>
     <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -26,6 +26,7 @@ the source code.
 
 ## Companion Paper
 
-A companion paper on the multi-agent, blueprint-guided formalization of
-TNLean is in preparation. A bibliographic citation and public link will be
-added here once the paper is available.
+The companion paper "Autoformalizing the fundamental theorem of matrix product
+states: A multi-agent, blueprint-guided formalization in Lean 4" is in
+preparation. A bibliographic citation and public link will be added here once
+the paper is available.

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -23,3 +23,9 @@ at varying levels of completeness.
 The header buttons link to the blueprint (web and full PDF), the
 fundamental-theorem volume (chapters 1&ndash;12), the API documentation, and
 the source code.
+
+## Companion Paper
+
+A companion paper on the multi-agent, blueprint-guided formalization of
+TNLean is in preparation. A bibliographic citation and public link will be
+added here once the paper is available.

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -20,10 +20,6 @@ quantum Markov semigroups, entropy inequalities, and projected entangled pair
 states are developed in the later blueprint chapters and in the source tree,
 at varying levels of completeness.
 
-The header buttons link to the blueprint (web and full PDF), the
-fundamental-theorem volume (chapters 1&ndash;12), the API documentation, and
-the source code.
-
 ## Companion Paper
 
 The companion paper "Autoformalizing the fundamental theorem of matrix product


### PR DESCRIPTION
### Motivation

- The blueprint prose contained visible Lean predicate names (e.g., `IsCanonicalForm`, `block_injective`) and references to internal proof-status markers (`ft_proof`, paper-gap file paths), violating the project rule that blueprint text must read as standard mathematics.
- The Chapter 1 introduction included proof-status wording referencing omitted internal labels, making the roadmap confusing to mathematical readers.
- No `blueprint/README.md` existed to document the directory layout, build commands, and prose conventions for contributors.
- This is a standalone housekeeping change; there is no associated issue.

### Description

- Added `blueprint/README.md` (49 lines) documenting blueprint directory layout, `leanblueprint` build and check commands, and the rule that visible blueprint prose must be mathematical text (maintainer and paper-gap notes belong in LaTeX comments).
- Revised `blueprint/src/chapter/ch01_intro.tex`: removed references to omitted `ft_proof` label and internal proof-status wording; rewrote the later-chapter overview as plain mathematical prose.
- Across `ch02_mps.tex`, `ch04_channels.tex`, `ch05_schwarz.tex`, `ch08_wielandt.tex`, `ch10_bnt.tex`, `ch11_fundamental_theorem_proof.tex`, `ch12_symmetry.tex`, `ch13_parent_hamiltonian_*.tex`, `ch15_examples.tex`, `ch17_semigroup.tex`, `ch21_mpdo_rfp_bnt_coefficients.tex`, `ch24_peps_ft_foundations.tex`, `ch24_peps_ft_normal_union.tex`: rephrased trivial proof lines from "Immediate from …" to "The claim follows from …"; moved paper-gap file-path mentions from visible prose into LaTeX comments; removed visible Lean-style predicate names from canonical-form block injectivity entry in `ch14_correlations.tex`.
- Added `/References/` to `.gitignore` to suppress local bibliography files.
- Added a homepage placeholder for the companion paper, using the title
  "Autoformalizing the fundamental theorem of matrix product states: A
  multi-agent, blueprint-guided formalization in Lean 4".
- Removed the visible `Skip to the content.` link and the redundant header-button
  description from the homepage.
- No Lean source files are modified; no `sorry` is introduced or removed.

### Testing

- Searched blueprint chapters for visible `Is…` / `Has…` predicate-style names; remaining hits are inside `\lean{...}` or `\uses{...}` metadata only.
- Searched for visible `\texttt{...}`; remaining uses are the accepted source label `thm1`.
- Relies on Lean CI (`lean_action_ci.yml`) and Blueprint Lint (`lint-blueprint.yml`) to validate the build.

---

> [!NOTE]
> **Low Risk**
> Documentation and LaTeX prose only; no Lean or runtime behavior changes.
>
> **Overview**
> Adds **`blueprint/README.md`** documenting blueprint layout, `leanblueprint` build/check commands, and reader-facing prose rules (mathematical text only; maintainer and paper-gap notes in comments).
>
> **Chapter 1** is tightened so the roadmap no longer references omitted `ft_proof` / internal proof-status wording; later-chapter overview is rewritten as plain mathematical prose, with paper-gap paths moved into comments.
>
> Across many chapters, trivial proof lines that said *"Immediate from …"* are rephrased (*"The claim follows from …"*, *"follows from …"*). **Fundamental Theorem** and **PEPS** sections stop citing `docs/paper-gaps/...` in visible text (those paths are comments). **Correlations** drops visible Lean-style names (`IsCanonicalForm`, `block_injective`) in favor of mathematical wording about canonical-form hypotheses.
>
> **`.gitignore`** now ignores local **`/References/`**.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6bb22f5b68f6cce0256c2fd4972aa684fe1ebb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> LaTeX and markdown documentation only; no Lean or runtime behavior changes.
> 
> **Overview**
> Documentation-only housekeeping for the TNLean blueprint and site: no Lean sources change.
> 
> **`blueprint/README.md`** is new. It documents layout, `leanblueprint` build/check commands, and the rule that reader-facing text stays mathematical (maintainer and paper-gap notes belong in LaTeX comments).
> 
> **Chapter 1** no longer cites omitted `ft_proof` / internal proof-status wording in visible prose; the later-chapter overview is plain mathematical text, with paper-gap paths kept as comments.
> 
> Across many blueprint chapters, trivial proofs that said *"Immediate from …"* are rephrased (*"The claim follows from …"*, *"follows from …"*). **Fundamental Theorem** and **PEPS** sections stop citing `docs/paper-gaps/...` in visible text (those paths are comments). **Correlations** drops visible Lean-style names in favor of wording about canonical-form hypotheses.
> 
> **`.gitignore`** now ignores local **`/References/`**. The **home page** adds a companion-paper placeholder and trims accessibility/header copy (e.g. skip-to-content link).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57bf8d3ff5a334b52097c3ad308e7c12f1c30c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


