### PR TITLE
doc(homepage): update companion paper title

### DIFF
--- a/home_page/index.md
+++ b/home_page/index.md
@@ -22,7 +22,6 @@ at varying levels of completeness.
 
 ## Companion Paper
 
-The companion paper "Autoformalizing the fundamental theorem of matrix product
-states: A multi-agent, blueprint-guided formalization in Lean 4" is in
-preparation. A bibliographic citation and public link will be added here once
+The companion paper "Multi-agent Autoformalization of Tensor Network Theory" is
+in preparation. A bibliographic citation and public link will be added here once
 the paper is available.


### PR DESCRIPTION
### Motivation

- The companion-paper blurb on the public homepage used an outdated working title; the paper is now titled "Multi-agent Autoformalization of Tensor Network Theory".
- Keeping the homepage text current ensures visitors see the correct paper name.

### Description

- Modified `home_page/index.md`: replaced the old placeholder companion-paper title with the current published title "Multi-agent Autoformalization of Tensor Network Theory".
- No Lean source, blueprint, or CI changes.

### Testing

- Confirmed the updated title appears in `home_page/index.md` and the old working title no longer appears in `home_page/` or `docs/`.
- No Lean build impact; relies on Lean CI (`lean_action_ci.yml`) to validate the build remains unaffected.

---

> [!NOTE]
> **Low Risk**
> Single-line public documentation change with no effect on the Lean library, tooling, or site behavior beyond displayed text.
>
> **Overview**
> Updates the **Companion Paper** blurb on the public homepage so it names the current working title, **"Multi-agent Autoformalization of Tensor Network Theory"**, instead of the older placeholder about autoformalizing the fundamental theorem of MPS.
>
> No code, build, or blueprint content changes—only the quoted title string in `home_page/index.md`.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67914053c2f642d2b9cdb0ccc91fc840240636be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>