### PR TITLE
doc(blueprint): enable and polish MPDO chapters

### DIFF
--- a/blueprint/src/chapter/ch01_intro.tex
+++ b/blueprint/src/chapter/ch01_intro.tex
@@ -85,7 +85,9 @@ not to any additional input for the Fundamental Theorem.
 The later chapters develop parent-Hamiltonian consequences, correlation
 estimates, examples, channel representations, normal forms, quantum dynamical
 semigroups, operator convexity, and entropy. They also include the standard
-examples of positive maps that fail to be completely positive.
+examples of positive maps that fail to be completely positive. The final two
+chapters introduce matrix product operators and density operators and study
+their zero-correlation-length and renormalization fixed-point conditions.
 % Draft chapters also treat the direct Fundamental Theorem for periodically
 % repeated tensors in irreducible form, together with compatibility theorems
 % for physical-index rotation (Definition~\ref{def:rotate_physical} in
@@ -93,8 +95,7 @@ examples of positive maps that fail to be completely positive.
 % Maintainer note: the rotation definition is internal bookkeeping for the
 % periodic MPS material, not an external-paper input or part of the Molnar
 % algebraic-FT chapter.
-% The matrix-product-operator, periodic, algebraic, and PEPS draft chapters
-% remain in the repository but are omitted from the generated blueprint while
-% their statements are being stabilized. These later topics use the Fundamental
-% Theorem, or develop later finite-dimensional channel theory, rather than enter
-% its proof.
+% The periodic, algebraic, and PEPS chapters remain in the repository but are
+% omitted from the generated blueprint while their statements are being
+% stabilized. These topics use the Fundamental Theorem, or develop later
+% finite-dimensional channel theory, rather than enter its proof.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_area_law.tex
@@ -131,7 +131,7 @@
     $I_L = S_L + S_{N-L} - S_N$, using $N-(N-L) = L$.
 \end{proof}
 
-\begin{lemma}[Empty-block entropy vanishes]
+\begin{lemma}[Entropy of the empty block]
     \label{lem:block_entropy_zero}
     \lean{blockEntropy_zero}
     \leanok
@@ -219,9 +219,11 @@
 \end{lemma}
 \begin{proof}\leanok
     The word product of doubled-tensor entries is the Kronecker product of the
-    bra word product and the conjugated ket word product (mixed-product property
-    of the Kronecker product), so its trace factors as
-    $\overline{V^{(N)}(A)(\tau)}\,V^{(N)}(A)(\sigma)$, the matrix element of
+    bra word product and the conjugated ket word product. Thus its trace is
+    \[
+        \overline{V^{(N)}(A)(\tau)}\,V^{(N)}(A)(\sigma),
+    \]
+    the corresponding matrix element of
     $\ketbra{V^{(N)}(A)}{V^{(N)}(A)}$.
 \end{proof}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -244,12 +244,14 @@
 
 \begin{proof}\leanok
     The $\eta$-local structure supplies the commuting nearest-neighbor product
-    form. The remaining two implications are
+    form. One then has
     \[
         \E_K\circ\E_K=\E_K \Longrightarrow
         \operatorname{RFP}(K) \Longrightarrow
-        \operatorname{RFP}_{\mathrm{fusion}}(K)
-        \quad\text{and}\quad
+        \operatorname{RFP}_{\mathrm{fusion}}(K),
+    \]
+    and
+    \[
         \E_K\circ\E_K=\E_K \Longrightarrow
         \operatorname{RFP}(K) \Longrightarrow
         \operatorname{FusionWitness}_{2}(K).

--- a/blueprint/src/chapter/ch21_mpdo_rfp_bnt_witnesses.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_bnt_witnesses.tex
@@ -108,10 +108,12 @@
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum}
-    An existential BNT-label theorem witness gives the product identity
-    $O_L(M_\alpha)O_L(M_\beta)
-        = \sum_\gamma c_{\alpha,\beta,\gamma}^{(L)} O_L(M_\gamma)$
-    for every positive length $L$.
+    For every positive length $L$, an existential BNT-label theorem witness
+    gives the product identity
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
+        = \sum_\gamma c_{\alpha,\beta,\gamma}^{(L)} O_L(M_\gamma).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -160,11 +162,13 @@
     \leanok
     \uses{def:mpdo_bnt_label_theorem_witness,
         thm:mpdo_bnt_label_theorem_data_same_length_product_eq_sum_chi_trace_pow}
-    An existential BNT-label theorem witness gives, for every positive length
-    $L$, the identity
-    $O_L(M_\alpha)O_L(M_\beta)
+    For every positive length $L$, an existential BNT-label theorem witness
+    gives
+    \[
+        O_L(M_\alpha)O_L(M_\beta)
         = \sum_\gamma
-        \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L}) O_L(M_\gamma)$.
+          \operatorname{tr}(\chi_{\alpha,\beta,\gamma}^{\,L}) O_L(M_\gamma).
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.
@@ -178,9 +182,11 @@
         thm:mpdo_bnt_label_theorem_data_idempotent_eq_sum_chi_trace}
     An existential BNT-label theorem witness gives the idempotent scalar
     identity
-    $m_\gamma =
-        \sum_{\alpha,\beta}
-        \operatorname{tr}(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta$.
+    \[
+        m_\gamma
+        = \sum_{\alpha,\beta}
+          \operatorname{tr}(\chi_{\alpha,\beta,\gamma})m_\alpha m_\beta.
+    \]
 \end{theorem}
 \begin{proof}\leanok
     Apply the corresponding theorem-data identity carried by the witness.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_commuting_form_gsnnch.tex
@@ -10,7 +10,7 @@
     periodic chain commute pairwise.
 \end{definition}
 
-\begin{definition}[Commuting-form property]
+\begin{definition}[Commuting form]
     \label{def:mpdo_has_commuting_form}
     \lean{MPOTensor.HasCommutingForm}
     \leanok
@@ -99,7 +99,7 @@
     length.
 \end{definition}
 
-\begin{definition}[Finite-chain data from a translation-invariant bond]
+\begin{definition}[Finite-chain bond form]
     \label{def:mpdo_translation_invariant_bond_to_commuting_form_data}
     \lean{MPOTensor.TranslationInvariantBondData.toCommutingFormData}
     \leanok

--- a/blueprint/src/content.tex
+++ b/blueprint/src/content.tex
@@ -19,8 +19,8 @@
 \input{chapter/ch19_entropy}
 \input{chapter/ch19_entropy_corollaries}
 \input{chapter/ch25_positive_not_cp}
-% \input{chapter/ch20_mpdo}
-% \input{chapter/ch21_mpdo_rfp}
+\input{chapter/ch20_mpdo}
+\input{chapter/ch21_mpdo_rfp}
 % \input{chapter/ch22_periodic_ft}
 % \input{chapter/ch23_algebraic_ft}
 % \input{chapter/ch24_peps_ft}


### PR DESCRIPTION
### Motivation
- Restore the generated blueprint coverage of matrix product operators, matrix product density operators, and their renormalization fixed points after the corresponding chapters advanced beyond their earlier draft state.
- The mathematical scope is arXiv:1606.00608, especially Sections 4 and Appendix C, as tracked by #2380.

### Description
- Enable the MPO/MPDO foundations chapter and the dependent MPDO/RFP chapter in the blueprint router.
- Update the introduction to describe the added chapters.
- Reflow the long BNT coefficient and blocked-RFP formulas and shorten two headings so the enabled chapters have no overfull boxes.
- Preserve every mathematical statement and every declaration-status tag.

### Testing
- leanblueprint checkdecls
- leanblueprint pdf
- PATH=/Users/siruilu/Library/Python/3.9/bin:/opt/homebrew/bin:/usr/bin:/bin /Users/siruilu/Library/Python/3.9/bin/leanblueprint web
- python3 scripts/check_reader_facing_prose.py --diff-base origin/main
- Visual inspection of PDF pages 375--415; no clipped text, overlaps, unreadable formulas, or MPO/MPDO overfull boxes.

---
Addresses #2380

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and LaTeX typography only; no Lean or theorem statement changes, with validation via leanblueprint and PDF checks.
> 
> **Overview**
> Re-enables **matrix product operator** and **MPDO renormalization fixed-point** chapters in the blueprint build (`content.tex`) and updates the introduction so the generated document describes those final two chapters (ZCL/RFP material) instead of leaving them commented out.
> 
> **Presentation-only** edits in the enabled chapter sources: shorter definition/lemma titles, display-math line breaks for long BNT and blocked-RFP identities, and a clearer purification proof—aimed at fixing overfull boxes without changing statements or `\lean`/`\leanok` tags. Maintainer notes now treat periodic/algebraic/PEPS as the remaining omitted drafts, not MPO/MPDO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5797e979db2f435dbc65db81a7f183299a4dd715. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->