### PR TITLE
fix(MPS/MPDO): delimit the sector trace PSD route

### DIFF
--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -44,6 +44,11 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   Kronecker product of the sector-indexed neighboring reduced states.
 - `MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg`: positivity of each
   neighboring operator gives entrywise nonnegativity of the real trace matrix.
+- `MPOTensor.ExplicitEtaOperators.traceMatrixRe_ofHayashiMarkov_posSemidef`:
+  the special sector-reduced extraction has the positive-semidefinite all-ones
+  trace matrix.
+- `MPOTensor.ExplicitEtaOperators.trace_traceMatrixRe_ofHayashiMarkov`: the
+  trace of that all-ones matrix is the number of sectors.
 - `MPOTensor.sal_zcl_implies_rank_one_T`: the conditional Lemma C.5 consequence,
   proved relative to the Perron–Frobenius rank-one input.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`: the same consequence
@@ -84,10 +89,12 @@ normalization and constant trace powers, supplies the missing diagonalizability
 and forces a rank-one factorization. The theorem
 `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef` connects this corrected
 criterion to the Lemma C.5 structure. What remains on
-the MPDO side is to prove that the sector trace matrix `T` extracted from the
-η-operators is itself positive semidefinite or Hermitian; positivity of the
-individual η-operators alone only gives entrywise nonnegativity of the trace
-matrix.
+the MPDO side is to prove that the sector trace matrix `T` from the paper's
+inverse-map construction has additional structure excluding the nilpotent
+zero-eigenspace. Positivity of the individual η-operators alone gives only
+entrywise nonnegativity of the trace matrix. The special sector-reduced family
+`ofHayashiMarkov` does have a positive-semidefinite all-ones trace matrix, but
+its identification with the paper's inverse-map family is not available.
 
 ## References
 
@@ -303,6 +310,34 @@ rank-one trace matrix (the all-ones matrix). -/
   have h := traceMatrix_ofHayashiMarkov hη k h
   simp only [traceMatrix_apply] at h
   simp [traceMatrixRe_apply, h]
+
+/-- The trace of the real all-ones matrix from the Hayashi--Markov extraction
+is the number of sectors.
+
+This concerns the sector-reduced family in `ofHayashiMarkov`, not yet the
+inverse-map family of arXiv:1606.00608, Appendix C.2, lines 1413--1455. -/
+@[simp] theorem trace_traceMatrixRe_ofHayashiMarkov
+    (hη : EtaStructure ρ_ABC) :
+    Matrix.trace (ofHayashiMarkov hη).traceMatrixRe = hη.m := by
+  rw [Matrix.trace]
+  change ∑ i, (ofHayashiMarkov hη).traceMatrixRe i i = _
+  simp_rw [traceMatrixRe_ofHayashiMarkov]
+  simp
+
+/-- The real trace matrix of the Hayashi--Markov extraction is positive
+semidefinite.
+
+This is the positive-semidefinite all-ones matrix. It concerns the
+sector-reduced family in `ofHayashiMarkov`; identifying that family with the
+inverse-map construction of arXiv:1606.00608, Appendix C.2, lines 1413--1455,
+is a separate question. -/
+theorem traceMatrixRe_ofHayashiMarkov_posSemidef
+    (hη : EtaStructure ρ_ABC) :
+    (ofHayashiMarkov hη).traceMatrixRe.PosSemidef := by
+  convert Matrix.posSemidef_vecMulVec_self_star (fun _ : Fin hη.m => (1 : ℝ)) using 1
+  ext k h
+  rw [traceMatrixRe_ofHayashiMarkov]
+  simp [Matrix.vecMulVec]
 
 /-- Positivity of each neighboring operator makes the corresponding real trace
 entry nonnegative.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -143,13 +143,14 @@ strong subadditivity for a normalized three-site reduced state.
     \label{thm:mpdo_eta_of_hayashi_markov_trace_matrix}
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrix_ofHayashiMarkov}
     \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_ofHayashiMarkov}
+    \lean{MPOTensor.ExplicitEtaOperators.trace_traceMatrixRe_ofHayashiMarkov}
     \leanok
     \uses{def:mpdo_eta_of_hayashi_markov,
         def:mpdo_explicit_eta_trace_matrix}
     The trace matrix induced by the extracted family is entrywise
-    $T_{k,h} = 1$ in both its complex-valued form and its real-valued form,
-    matching the normalization $T_{k,h} = a_k b_h$ used in
-    $a_k = b_h = 1$.
+    $T_{k,h} = 1$ in both its complex-valued form and its real-valued form.
+    If there are $m$ sectors, then $T=\mathbf{1}\mathbf{1}^{\mathsf T}$ and
+    $\tr(T)=m$.
 \end{theorem}
 
 \begin{proof}
@@ -160,7 +161,24 @@ strong subadditivity for a normalized three-site reduced state.
     partial trace $\tr_C$ preserves the trace. The analogous statement holds
     for $\tr_A \rho_{A b_1}^{(h)}$. Multiplicativity of the trace under
     Kronecker products gives $T_{k,h} = 1 \cdot 1 = 1$, and taking real parts
-    gives the real-valued statement.
+    gives the real-valued statement. Summing the $m$ diagonal entries gives
+    $\tr(T)=m$.
+\end{proof}
+
+\begin{theorem}[Positive semidefiniteness of the Hayashi--Markov trace matrix]
+    \label{thm:mpdo_eta_of_hayashi_markov_trace_matrix_psd}
+    \lean{MPOTensor.ExplicitEtaOperators.traceMatrixRe_ofHayashiMarkov_posSemidef}
+    \leanok
+    \uses{thm:mpdo_eta_of_hayashi_markov_trace_matrix}
+    The real trace matrix of the sector-reduced family is positive
+    semidefinite.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_eta_of_hayashi_markov_trace_matrix}
+    This trace matrix is the all-ones matrix
+    $\mathbf{1}\mathbf{1}^{\mathsf T}$, hence is positive semidefinite.
 \end{proof}
 
 \begin{theorem}[Entrywise nonnegativity of the real trace matrix]

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -185,12 +185,12 @@ nonnegativity is not matrix-level positive semidefiniteness or Hermitian
 symmetry of $T$.
 \footnote{The entrywise nonnegativity result is
 \texttt{MPOTensor.ExplicitEtaOperators.traceMatrixRe\_nonneg} in
-\path{TNLean/MPS/MPDO/SimpleLocalStructure.lean:306--318}. The
+\path{TNLean/MPS/MPDO/SimpleLocalStructure.lean:350--352}. The
 positive-semidefinite reformulation for the rank-one conclusion is
 \texttt{MPOTensor.sal\_zcl\_implies\_rank\_one\_T\_of\_posSemidef} in
-\path{TNLean/MPS/MPDO/SimpleLocalStructure.lean:350--366}. The corresponding
+\path{TNLean/MPS/MPDO/SimpleLocalStructure.lean:398--406}. The corresponding
 blueprint discussion is
-\path{blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex:44--303}.}
+\path{blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex:184--324}.}
 
 \section{Conclusion}
 

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -131,6 +131,50 @@ this forces exactly one $\lambda_i$ to be $1$ and all the others to be
 $0$. Therefore the diagonal form has rank one, and unitary conjugation gives
 an outer-product factorization of $T$.
 
+\section{Audit of the positive-semidefinite route}
+
+The neighboring-operator construction displayed in the source does not by
+itself exhibit $T$ as a Gram matrix. Immediately before Lemma~C.5, the paper
+writes
+\[
+  T_{k,h}=(r_k\mid l_h),
+\]
+with two different families $(r_k)_k$ and $(l_h)_h$
+\cite[Appendix~C.2, lines 1473--1482]{Cirac2016MPDO_arXiv}. No equality or
+adjoint relation between these two families is stated. Consequently this is a
+cross-pairing, rather than a Gram representation, and it gives neither symmetry
+nor positive semidefiniteness of $T$.
+
+The present type of explicit neighboring operators records only
+$\eta_{k,h}\geq 0$ for each ordered pair $(k,h)$. This hypothesis implies
+$T_{k,h}\geq 0$ entrywise, but contains no relation between $\eta_{k,h}$ and
+$\eta_{h,k}$. Thus matrix-level positive semidefiniteness cannot be deduced
+from that type alone.
+
+There is one special positive-semidefinite case in the formal development. The
+sector-reduced Hayashi--Markov family is defined by
+\[
+  \eta_{k,h}
+    =\tr_C(\rho_{b_2C}^{(k)})\otimes
+      \tr_A(\rho_{Ab_1}^{(h)}).
+\]
+Since each reduced density matrix has trace one, its trace matrix is the
+all-ones matrix. The theorem
+\path{MPOTensor.ExplicitEtaOperators.traceMatrixRe_ofHayashiMarkov_posSemidef}
+proves its positive
+semidefiniteness. This does not discharge Lemma~C.5: the sector-reduced family
+has not been identified with the inverse-map family constructed in lines
+1413--1455, and the trace of its all-ones matrix is the number of sectors, not
+one unless there is a single sector.
+
+The remaining argument must therefore use more of the MPDO construction than
+the separate inequalities $\eta_{k,h}\geq 0$. One possible completion is to
+derive an additional adjoint or Gram relation from the inverse-map tensors. If
+no such relation holds, the alternative is to combine the ZCL identity in
+lines 1489--1497 with injectivity and the tensor realization to rule out the
+nilpotent generalized zero-eigenspace directly. Positive semidefiniteness of
+the source trace matrix is not presently established by the cited passage.
+
 This corrected theorem does not refute the intended MPDO result. It identifies
 a matrix-level hypothesis sufficient for the rank-one step. The remaining
 question is whether the trace matrix


### PR DESCRIPTION
## Motivation

Issue #3593 proposed positive semidefiniteness of the sector trace matrix as the missing route to the rank-one conclusion in Lemma C.5 of arXiv:1606.00608. Appendix C.2, lines 1473–1482, instead writes the matrix as the cross-pairing T_{k,h}=(r_k|l_h) of two distinct Perron families. The cited passage supplies neither an adjoint relation nor a Gram representation.

The existing Hayashi–Markov extraction is a useful test case, but its trace matrix is the all-ones matrix. Its trace is therefore the number of sectors, rather than one except in the one-sector case. It cannot yet be identified with the source's inverse-map trace matrix.

## Description

- prove that the Hayashi–Markov real trace matrix is positive semidefinite;
- prove that its trace is the number of sectors;
- state this special case precisely in the MPDO/RFP blueprint;
- expand the paper-gap note to distinguish cross-pairing, entrywise positivity, and matrix positive semidefiniteness;
- record the two remaining mathematically faithful routes: derive an additional Gram-type relation from the inverse-map tensors, or rule out the nilpotent zero-eigenspace directly from the ZCL identity and injectivity.

This pull request does not claim to complete Lemma C.5. It corrects the proposed intermediate target and makes the remaining obligation explicit.

## Testing

- lake env lean TNLean/MPS/MPDO/SimpleLocalStructure.lean
- lake build TNLean.MPS.MPDO.SimpleLocalStructure
- lake build TNLean.MPS.Periodic.Symmetry.Theorem41Forward
- cd blueprint && leanblueprint checkdecls
- cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv17_pf_rank_one.tex
- python3 scripts/check_reader_facing_prose.py --diff-base origin/main
- git diff HEAD^ --check

A repository-wide lake build reached the final periodic-symmetry modules but encountered a transient missing-output-file error while writing EqualCaseFTHyp.olean. The targeted rebuild of the dependent Theorem41Forward module then succeeded. The build also reports the pre-existing, documented sorry in TNLean/MPS/Periodic/Overlap/Case3.lean; this change adds none.

Addresses #3593

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and small proved lemmas on an already-isolated MPDO formalization path; no changes to auth, runtime behavior, or core proof obligations beyond clearer scope.
> 
> **Overview**
> Clarifies that **positive semidefiniteness of the sector trace matrix** is not a free consequence of neighboring-operator positivity, and pins down what the formal **Hayashi–Markov** extraction actually proves.
> 
> **Lean:** Adds `trace_traceMatrixRe_ofHayashiMarkov` (trace equals sector count `m`) and `traceMatrixRe_ofHayashiMarkov_posSemidef` (real trace matrix is the all-ones matrix, hence PSD). Module docs now stress that this family is **sector-reduced**, not yet identified with the paper’s **inverse-map** `η` construction, and that the open step is ruling out a **nilpotent zero-eigenspace** rather than assuming PSD from entrywise nonnegativity alone.
> 
> **Blueprint:** Extends the Hayashi–Markov trace-matrix theorem with \(\tr(T)=m\) and adds a dedicated PSD theorem for that special case.
> 
> **Paper-gap note:** New “Audit of the positive-semidefinite route” section contrasts cross-pairing \((r_k \mid l_h)\), entrywise \(T_{k,h}\ge 0\), and matrix PSD; records why the all-ones Hayashi–Markov matrix does not close Lemma C.5; and lists the two remaining faithful completions (Gram-type structure from inverse maps, or ZCL + injectivity against nilpotency). Updates Lean line references for related theorems.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8e087f766f045ae09e34b25c773582530fbccb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->