### PR TITLE
fix(MPS/MPDO): disprove the support-algebra converse

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -363,6 +363,7 @@ import TNLean.MPS.MPDO.LocalPurificationRFP
 import TNLean.MPS.MPDO.SimpleLocalStructure
 import TNLean.MPS.MPDO.FusionIsometries
 import TNLean.MPS.MPDO.AlgebraStructure
+import TNLean.MPS.MPDO.AlgebraFusionCounterexample
 import TNLean.MPS.MPDO.BNTCoefficients
 import TNLean.MPS.MPDO.BNTTheoremData
 import TNLean.MPS.MPDO.BNTTheoremWitness

--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -50,8 +50,10 @@ private theorem phaseFlipTensor_transferMap_apply
     (X : Matrix (Fin 2) (Fin 2) ℂ) (i j : Fin 2) :
     MPSTensor.transferMap phaseFlipTensor X i j =
       if i = j then X i j else (-7 / 25 : ℂ) * X i j := by
-  have hstarFour : (starRingEnd ℂ) (4 : ℂ) = 4 := map_natCast (starRingEnd ℂ) 4
-  have hstarFive : (starRingEnd ℂ) (5 : ℂ) = 5 := map_natCast (starRingEnd ℂ) 5
+  have hstarFour : (starRingEnd ℂ) (4 : ℂ) = 4 :=
+    map_natCast (starRingEnd ℂ) 4
+  have hstarFive : (starRingEnd ℂ) (5 : ℂ) = 5 :=
+    map_natCast (starRingEnd ℂ) 5
   fin_cases i <;> fin_cases j <;>
     simp only [phaseFlipTensor, Fin.zero_eta, Fin.isValue, Fin.mk_one,
       MPSTensor.transferMap_apply, Fin.sum_univ_two, Matrix.add_apply,

--- a/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
+++ b/TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
@@ -1,0 +1,213 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
+-/
+import TNLean.MPS.MPDO.AlgebraStructure
+import TNLean.MPS.MPDO.FusionIsometries
+
+/-!
+# Counterexample to the support-algebra converse
+
+This file gives an explicit trace-preserving MPO tensor with a positive-definite
+fixed point which satisfies `MPOTensor.IsRFP_MPDO_via_algebra` but not
+`MPOTensor.IsRFP_MPDO_via_fusion`.
+
+## References
+
+* arXiv:1606.00608, Theorem 4.14(ii) and Appendix C.4, lines 2046--2085
+-/
+
+open scoped Matrix BigOperators ComplexOrder MatrixOrder
+
+noncomputable section
+
+namespace MPOTensor
+
+local instance instMatrixNormedAddCommGroup :
+    NormedAddCommGroup (Matrix (Fin 2) (Fin 2) ℂ) :=
+  Matrix.toMatrixNormedAddCommGroup (n := Fin 2) (𝕜 := ℂ) 1
+    (Matrix.PosDef.one (n := Fin 2) (R := ℂ))
+
+local instance instMatrixInnerProductSpace :
+    InnerProductSpace ℂ (Matrix (Fin 2) (Fin 2) ℂ) :=
+  Matrix.toMatrixInnerProductSpace (n := Fin 2) (𝕜 := ℂ) 1
+    (Matrix.PosDef.one (n := Fin 2) (R := ℂ)).posSemidef
+
+private def phaseFlipTensor : MPSTensor 2 2 := fun i =>
+  if i = 0 then (↑(3 / 5 : ℝ) : ℂ) • 1
+  else (↑(4 / 5 : ℝ) : ℂ) • !![1, 0; 0, -1]
+
+private theorem phaseFlipTensor_conjTranspose (i : Fin 2) :
+    (phaseFlipTensor i)ᴴ = phaseFlipTensor i := by
+  fin_cases i <;>
+    ext j k <;>
+    fin_cases j <;>
+    fin_cases k <;>
+    simp [phaseFlipTensor, Matrix.conjTranspose_apply]
+
+private theorem phaseFlipTensor_transferMap_apply
+    (X : Matrix (Fin 2) (Fin 2) ℂ) (i j : Fin 2) :
+    MPSTensor.transferMap phaseFlipTensor X i j =
+      if i = j then X i j else (-7 / 25 : ℂ) * X i j := by
+  have hstarFour : (starRingEnd ℂ) (4 : ℂ) = 4 := map_natCast (starRingEnd ℂ) 4
+  have hstarFive : (starRingEnd ℂ) (5 : ℂ) = 5 := map_natCast (starRingEnd ℂ) 5
+  fin_cases i <;> fin_cases j <;>
+    simp only [phaseFlipTensor, Fin.zero_eta, Fin.isValue, Fin.mk_one,
+      MPSTensor.transferMap_apply, Fin.sum_univ_two, Matrix.add_apply,
+      zero_ne_one, one_ne_zero, ↓reduceIte]
+  all_goals simp [Matrix.vecMul, dotProduct, Fin.sum_univ_two, Matrix.mul_apply,
+    Matrix.conjTranspose_apply, RCLike.star_def]
+  all_goals simp only [hstarFour, hstarFive]
+  all_goals norm_num
+  all_goals ring
+
+private theorem phaseFlipTensor_transferMap_adjoint :
+    (MPSTensor.transferMap phaseFlipTensor).adjoint =
+      MPSTensor.transferMap phaseFlipTensor := by
+  apply LinearMap.ext
+  intro X
+  rw [MPSTensor.transferMap_adjoint_apply_eq_adjointMap]
+  simp [Kraus.adjointMap, MPSTensor.transferMap_apply,
+    phaseFlipTensor_conjTranspose]
+
+private theorem phaseFlipTensor_transferMap_pow_adjoint (n : ℕ) :
+    ((MPSTensor.transferMap phaseFlipTensor) ^ n).adjoint =
+      (MPSTensor.transferMap phaseFlipTensor) ^ n := by
+  have hSymmetric : (MPSTensor.transferMap phaseFlipTensor).IsSymmetric :=
+    (LinearMap.eq_adjoint_iff _ _).mp phaseFlipTensor_transferMap_adjoint.symm
+  exact (hSymmetric.pow n).adjoint_eq
+
+private theorem phaseFlipTensor_transferMap_pow_apply
+    (n : ℕ) (X : Matrix (Fin 2) (Fin 2) ℂ) (i j : Fin 2) :
+    ((MPSTensor.transferMap phaseFlipTensor) ^ n) X i j =
+      if i = j then X i j else (-7 / 25 : ℂ) ^ n * X i j := by
+  induction n generalizing X with
+  | zero =>
+      simp [Module.End.one_eq_id]
+  | succ n ih =>
+      rw [pow_succ, Module.End.mul_eq_comp, LinearMap.comp_apply]
+      rw [ih]
+      rw [phaseFlipTensor_transferMap_apply]
+      by_cases hij : i = j
+      · simp [hij]
+      · simp only [hij, ↓reduceIte]
+        rw [pow_succ]
+        ring
+
+private theorem phaseFlip_eigenvalue_pow_ne_one {n : ℕ} (hn : 0 < n) :
+    (-7 / 25 : ℂ) ^ n ≠ 1 := by
+  intro h
+  have hnorm := congrArg norm h
+  rw [norm_pow, neg_div, norm_neg, Complex.norm_div] at hnorm
+  norm_num at hnorm
+  have hlt : (7 / 25 : ℝ) ^ n < 1 :=
+    pow_lt_one₀ (by norm_num) (by norm_num) (Nat.ne_of_gt hn)
+  linarith
+
+private theorem phaseFlipTensor_transferMap_pow_fixed
+    {X : Matrix (Fin 2) (Fin 2) ℂ}
+    (hX : MPSTensor.transferMap phaseFlipTensor X = X) (n : ℕ) :
+    (MPSTensor.transferMap phaseFlipTensor ^ n) X = X := by
+  induction n with
+  | zero =>
+      simp [Module.End.one_eq_id]
+  | succ n ih =>
+      rw [pow_succ, Module.End.mul_eq_comp, LinearMap.comp_apply, hX, ih]
+
+private theorem phaseFlipTensor_transferMap_pow_fixed_iff
+    {n : ℕ} (hn : 0 < n) (X : Matrix (Fin 2) (Fin 2) ℂ) :
+    (MPSTensor.transferMap phaseFlipTensor ^ n) X = X ↔
+      MPSTensor.transferMap phaseFlipTensor X = X := by
+  constructor
+  · intro hX
+    apply Matrix.ext
+    intro i j
+    rw [phaseFlipTensor_transferMap_apply]
+    by_cases hij : i = j
+    · simp [hij]
+    · have hentry := congrArg (fun Y => Y i j) hX
+      rw [phaseFlipTensor_transferMap_pow_apply] at hentry
+      simp only [hij, ↓reduceIte] at hentry
+      have hzero : ((-7 / 25 : ℂ) ^ n - 1) * X i j = 0 := by
+        linear_combination hentry
+      rcases mul_eq_zero.mp hzero with hcoeff | hentryZero
+      · exact ((phaseFlip_eigenvalue_pow_ne_one hn) (sub_eq_zero.mp hcoeff)).elim
+      · simp [hij, hentryZero]
+  · intro hX
+    exact phaseFlipTensor_transferMap_pow_fixed hX n
+
+private theorem phaseFlipMPO_isTP :
+    Kraus.IsTP phaseFlipTensor.toMPOTensor.toMPSTensor := by
+  suffices hAdjointOne :
+      Kraus.adjointMap phaseFlipTensor.toMPOTensor.toMPSTensor 1 = 1 by
+    simpa [Kraus.IsTP, Kraus.adjointMap, Matrix.mul_one] using hAdjointOne
+  rw [← MPSTensor.transferMap_adjoint_apply_eq_adjointMap]
+  have hMap : MPSTensor.transferMap phaseFlipTensor.toMPOTensor.toMPSTensor =
+      MPSTensor.transferMap phaseFlipTensor := by
+    rw [← MPOTensor.transferMap_eq_toMPSTensor,
+      MPSTensor.toMPOTensor_transferMap]
+  rw [hMap, phaseFlipTensor_transferMap_adjoint]
+  apply Matrix.ext
+  intro i j
+  rw [phaseFlipTensor_transferMap_apply]
+  by_cases hij : i = j <;> simp [hij]
+
+private theorem phaseFlipMPO_adjointFixedPoints_eq
+    (n : ℕ) (hn : 0 < n) (X : Matrix (Fin 2) (Fin 2) ℂ) :
+    (MPOTensor.transferMap phaseFlipTensor.toMPOTensor).adjoint X = X ↔
+      (blockedTransferMap phaseFlipTensor.toMPOTensor n).adjoint X = X := by
+  rw [blockedTransferMap_eq_pow, MPSTensor.toMPOTensor_transferMap,
+    phaseFlipTensor_transferMap_adjoint,
+    phaseFlipTensor_transferMap_pow_adjoint]
+  exact (phaseFlipTensor_transferMap_pow_fixed_iff hn X).symm
+
+private theorem phaseFlipMPO_one_fixed :
+    MPOTensor.transferMap phaseFlipTensor.toMPOTensor 1 = 1 := by
+  rw [MPSTensor.toMPOTensor_transferMap]
+  apply Matrix.ext
+  intro i j
+  rw [phaseFlipTensor_transferMap_apply]
+  by_cases hij : i = j <;> simp [hij]
+
+private theorem phaseFlipMPO_isRFP_MPDO_via_algebra :
+    IsRFP_MPDO_via_algebra phaseFlipTensor.toMPOTensor :=
+  isRFP_MPDO_via_algebra_of_adjointFixedPoints_eq_of_isTP_of_posDef_fixed
+    phaseFlipMPO_isTP (Matrix.PosDef.one (n := Fin 2) (R := ℂ))
+      phaseFlipMPO_one_fixed phaseFlipMPO_adjointFixedPoints_eq
+
+private theorem phaseFlipMPO_not_isRFP_MPDO_via_fusion :
+    ¬IsRFP_MPDO_via_fusion phaseFlipTensor.toMPOTensor := by
+  intro hFusion
+  have hRFP := isRFP_of_isRFP_MPDO_via_fusion hFusion
+  change MPOTensor.transferMap phaseFlipTensor.toMPOTensor ∘ₗ
+      MPOTensor.transferMap phaseFlipTensor.toMPOTensor =
+        MPOTensor.transferMap phaseFlipTensor.toMPOTensor at hRFP
+  let X : Matrix (Fin 2) (Fin 2) ℂ := !![0, 1; 0, 0]
+  have hEntry := congrArg (fun E => E X 0 1) hRFP
+  simp only [LinearMap.comp_apply, MPSTensor.toMPOTensor_transferMap] at hEntry
+  rw [phaseFlipTensor_transferMap_apply,
+    phaseFlipTensor_transferMap_apply] at hEntry
+  norm_num [X] at hEntry
+
+/-- The support-algebra predicate does not imply the fusion predicate, even
+under trace preservation and the existence of a positive-definite fixed point.
+
+The witness is the qubit phase-flip channel with Kraus operators
+\(K_0=\frac35 I\) and \(K_1=\frac45 Z\). Its off-diagonal eigenvalue is
+\(-\frac7{25}\), so every positive power has the same fixed-point algebra,
+while the transfer map is not idempotent.
+
+This does not contradict arXiv:1606.00608, Theorem 4.14(ii). The converse in
+Appendix C.4, lines 2046--2085, assumes the positive BNT-label coefficient
+formula and the length-one idempotent trace identity, neither of which is part
+of `IsRFP_MPDO_via_algebra`. -/
+theorem exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion :
+    ∃ (M : MPOTensor 2 2) (ρ : Matrix (Fin 2) (Fin 2) ℂ),
+      Kraus.IsTP M.toMPSTensor ∧ ρ.PosDef ∧ MPOTensor.transferMap M ρ = ρ ∧
+        IsRFP_MPDO_via_algebra M ∧ ¬IsRFP_MPDO_via_fusion M := by
+  exact ⟨phaseFlipTensor.toMPOTensor, 1, phaseFlipMPO_isTP,
+    Matrix.PosDef.one (n := Fin 2) (R := ℂ), phaseFlipMPO_one_fixed,
+    phaseFlipMPO_isRFP_MPDO_via_algebra, phaseFlipMPO_not_isRFP_MPDO_via_fusion⟩
+
+end MPOTensor

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -253,9 +253,30 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     predicate to the stationary tower constructed from the faithful fixed point.
 \end{proof}
 
+\begin{theorem}[The support-algebra condition does not imply fusion]%
+    \label{thm:mpdo_algebra_not_imply_fusion}
+    \lean{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion}
+    \leanok
+    \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion,
+        thm:mpdo_algebra_from_stabilized_adjoint_fixedpoints}
+    There exists an MPO tensor of physical and bond dimension two such that the
+    doubled tensor is trace-preserving, the transfer map has a
+    positive-definite fixed point, and the support-algebra condition holds, but
+    the fusion condition does not hold.
+\end{theorem}
+\begin{proof}\leanok
+    Take the phase-flip channel with Kraus operators
+    $K_0=\frac35 I$ and $K_1=\frac45 Z$.  Its transfer map fixes diagonal
+    entries and multiplies off-diagonal entries by $-\frac7{25}$.  Therefore
+    every positive power has the same adjoint fixed-point algebra.  On the
+    other hand, the off-diagonal eigenvalue is neither zero nor one, so the
+    transfer map is not idempotent and cannot admit a fusion retract.
+\end{proof}
+
 \begin{remark}[Why algebra data do not imply fusion data]%
     \label{rem:mpdo_algebra_to_fusion_gap}
-    \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion, thm:newton_girard}
+    \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion,
+        thm:mpdo_algebra_not_imply_fusion, thm:newton_girard}
     Write $E=E_1$ for the one-site transfer map. The present algebra predicate
     gives, for every $n>0$,
     \[
@@ -265,8 +286,9 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     Hence a vector $X$ with $E^\dagger X=\lambda X$ and $\lambda^n=1$ lies in
     $\operatorname{Fix}(E^\dagger)$, so $(\lambda-1)X=0$ and $\lambda=1$ by
     Theorem~\ref{thm:mpdo_algebra_root_of_unity_eigenvalue}. It does not imply
-    $E^2=E$. For instance, if $\Pi_{\mathrm{diag}}$ is the projection onto
-    diagonal matrices and $0<\varepsilon<1$, set
+    $E^2=E$, as Theorem~\ref{thm:mpdo_algebra_not_imply_fusion} shows.  More
+    generally, if $\Pi_{\mathrm{diag}}$ is the projection onto diagonal
+    matrices and $0<\varepsilon<1$, set
     \[
         E(X)
         = \varepsilon\, X
@@ -330,9 +352,14 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     $S=\widetilde R_1\widetilde S R_2$. The scalar
     Newton--Girard power-sum identity needed to obtain the trace-power form is
     already available as
-    Theorem~\ref{thm:newton_girard}; what remains is the MPDO construction of
-    the BNT-label witness carrying (\ref{eq:mpdo_nu_chi_witness}) and
-    (\ref{eq:mpdo_reconstruction_maps}).
+    Theorem~\ref{thm:newton_girard}.  A source-faithful completion must state
+    the BNT-label hypotheses of
+    \cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv} as a separate condition,
+    relate them to the one-site and two-site vertical canonical forms, and
+    then construct the maps in
+    (\ref{eq:mpdo_reconstruction_maps}).  These hypotheses cannot be derived
+    from the support-algebra condition, by
+    Theorem~\ref{thm:mpdo_algebra_not_imply_fusion}.
 \end{remark}
 
 \subsection{Diagonal \texorpdfstring{$\chi$}{chi}-matrices and the trace-power formula}
@@ -393,4 +420,3 @@ the elementary trace-power identity for diagonal matrices.
     version---``there exists $\chi$ for which $(c,\chi)$ has trace-power
     form''---is obtained by quantifying over $\chi$.
 \end{definition}
-

--- a/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_algebra_tower.tex
@@ -258,6 +258,7 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
     \lean{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion}
     \leanok
     \uses{def:mpdo_rfp_via_algebra, def:mpdo_rfp_via_fusion,
+        thm:mpdo_rfp_of_fusion,
         thm:mpdo_algebra_from_stabilized_adjoint_fixedpoints}
     There exists an MPO tensor of physical and bond dimension two such that the
     doubled tensor is trace-preserving, the transfer map has a
@@ -266,11 +267,28 @@ family, and the corresponding multiplication / inclusion coefficient arrays.
 \end{theorem}
 \begin{proof}\leanok
     Take the phase-flip channel with Kraus operators
-    $K_0=\frac35 I$ and $K_1=\frac45 Z$.  Its transfer map fixes diagonal
-    entries and multiplies off-diagonal entries by $-\frac7{25}$.  Therefore
-    every positive power has the same adjoint fixed-point algebra.  On the
-    other hand, the off-diagonal eigenvalue is neither zero nor one, so the
-    transfer map is not idempotent and cannot admit a fusion retract.
+    $K_0=\frac35 I$ and $K_1=\frac45 Z$. Its transfer map satisfies
+    \[
+        E(X)_{ij}
+        = \begin{cases}
+            X_{ij}, & i=j, \\
+            -\frac7{25}X_{ij}, & i\neq j.
+        \end{cases}
+    \]
+    Hence, for every $n>0$ and $i\neq j$,
+    \[
+        E^n(X)_{ij}=\left(-\frac7{25}\right)^n X_{ij}.
+    \]
+    Since $(-7/25)^n\neq 1$ for every $n>0$ and $E$ is self-adjoint,
+    \[
+        \operatorname{Fix}((E^n)^\dagger)=\operatorname{Fix}(E^\dagger).
+    \]
+    Thus the support-algebra condition holds. On the other hand,
+    \[
+        E^2(X)_{01}=\frac{49}{625}X_{01}
+        \neq -\frac7{25}X_{01}=E(X)_{01}.
+    \]
+    Therefore $E^2\neq E$, so the fusion condition fails.
 \end{proof}
 
 \begin{remark}[Why algebra data do not imply fusion data]%

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -9,15 +9,15 @@
 
 \title{CPGSV17 Blocked-Basis Chi Families and Uniform BNT Labels}
 \author{}
-\date{2026-05-24}
+\date{2026-07-09}
 
 \begin{document}
 \maketitle
 
 \section{Source statement}
 
-Cirac--P\'erez-Garc\'ia--Schuch--Verstraete 2017 state in
-\cite[Theorem~IV.13(ii)]{Cirac2017MPDO_AnnPhys} that there is a set of
+Cirac--P\'erez-Garc\'ia--Schuch--Verstraete state in
+\cite[Theorem~4.14(ii)]{Cirac2016MPDO_arXiv} that there is a set of
 diagonal matrices
 \[
     \chi_{\alpha,\beta,\gamma}
@@ -74,7 +74,7 @@ positive-chain statement.
 Verdict: scope restriction.
 
 This blocked-basis analogue is not the uniform BNT-label statement of
-Theorem~IV.13(ii). It allows the diagonal matrix to depend on $n$, because
+Theorem~4.14(ii). It allows the diagonal matrix to depend on $n$, because
 the available indices themselves depend on the blocked bases
 $\mathcal A_n$ and $\mathcal A_{2n}$. The source theorem instead provides
 one matrix for each triple of BNT labels and uses that same matrix for every
@@ -99,10 +99,10 @@ in a basis at length $2n$. The exponent $n$ in
 \]
 is therefore the source length of the two factors, not the codomain length.
 This convention is only a blocked-basis analogue; it is not a replacement for
-the same-length multiplication statement in Theorem~IV.13(ii).
+the same-length multiplication statement in Theorem~4.14(ii).
 
 This note isolates the chi-uniformity and same-length coefficient comparison
-part of Theorem~IV.13(ii).  The idempotent condition
+part of Theorem~4.14(ii).  The idempotent condition
 \[
     m_\gamma =
       \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma} m_\alpha m_\beta
@@ -112,11 +112,19 @@ not represented by the blocked-basis trace-power predicate.
 
 Consequently,
 \leanid{MPOTensor.AlgebraStructureData.HasBlockedStructureChiTracePowerForm}
-should not be cited as a formalization of Theorem~IV.13(ii). It is a local
+should not be cited as a formalization of Theorem~4.14(ii). It is a local
 blocked-basis coefficient statement, useful only after the
 uniform BNT-label statement has been separated from the chosen blocked bases.
 
 \section{Relation to the algebra-to-fusion converse}
+
+The line ranges must be kept distinct.  Lines~1830--1922 prove
+Proposition~4.13, the vertical canonical-form statement; they do not extract
+$\chi_{\alpha,\beta,\gamma}$.  The construction of $\chi$ in the forward
+direction $(\mathrm{i})\Rightarrow(\mathrm{ii})$ occurs at lines~2020--2042.
+The converse $(\mathrm{ii})\Rightarrow(\mathrm{i})$ begins at line~2046 and
+takes the positive $\chi$-coefficient formula and the idempotent identity as
+hypotheses.
 
 Let $E=E_1$ be the one-site transfer map.  The present algebra predicate gives
 the fixed-point-space identity
@@ -128,8 +136,18 @@ the fixed-point-space identity
 This rules out root-of-unity peripheral eigenvalues of $E^\dagger$, but it does
 not imply the fusion-side idempotence equation $E^2=E$.
 
+This failure is formalized by
+\leanid{MPOTensor.exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion}.
+The counterexample is the phase-flip channel with Kraus operators
+$K_0=\frac35 I$ and $K_1=\frac45 Z$.  It is trace-preserving, fixes the
+positive-definite matrix $I$, and has off-diagonal eigenvalue $-\frac7{25}$.
+Thus every positive power has the same adjoint fixed-point algebra, while the
+transfer map is not idempotent.  Consequently, the requested implication from
+the present support-algebra predicate is false even under the additional
+trace-preserving and faithful-fixed-point hypotheses.
+
 The converse direction $(\mathrm{ii})\Rightarrow(\mathrm{i})$ in the proof of
-Theorem~IV.13 uses a stronger coefficient argument.  In Appendix~C.4,
+Theorem~4.14 uses a stronger coefficient argument.  In Appendix~C.4,
 lines~2046--2085, the authors compare the two BNT expansions coming from the
 one-site and two-site decompositions.  The source identity
 \texttt{eq:algebra-appendix} is stated at lines~1933--1936 and used in this
@@ -170,7 +188,7 @@ Summing this identity gives
       = m_\gamma .
 \]
 Only after this trace equality is obtained do the normalizing maps in
-\cite[lines~2065--2085]{Cirac2017MPDO_AnnPhys} have the form
+\cite[lines~2065--2085]{Cirac2016MPDO_arXiv} have the form
 \[
     \widetilde R_2\Bigl(\bigoplus_\gamma X_\gamma\Bigr)
       = \bigoplus_\gamma \frac{\nu_\gamma}{m_\gamma}\otimes X_\gamma,
@@ -249,7 +267,7 @@ basis of $\mathcal A_{2n}$, while the source theorem's BNT product law is
 same-length. It therefore records the formal blocked-basis comparison
 predicate; constructing the source label maps from an MPDO tensor is still part
 of the Appendix C.3--C.4 witness construction. The predicate is not itself the
-same-length product statement of Theorem~IV.13(ii).
+same-length product statement of Theorem~4.14(ii).
 These declarations specify the BNT-label coefficient objects and the comparison
 statement, but they do not yet construct the operators, trace scalars,
 coefficients, comparison maps, or $\chi$-matrices from an MPDO tensor.
@@ -442,32 +460,35 @@ exists_blocked_coeff_eq_trace_pow},
 \leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_posEntries},
 \leanid{MPOTensor.BNTLabelTheoremWitness.positiveBlockedChi_entry_pos},
 \leanid{MPOTensor.BNTLabelTheoremWitness.%
-blocked_coeff_eq_positiveBlockedChi_trace_pow}.}  The remaining step is still the
-construction of this existential witness from the MPDO tensor.
+blocked_coeff_eq_positiveBlockedChi_trace_pow}.}
 
-To eliminate the remaining gap, the formalization should introduce:
+The witness must not be constructed from an arbitrary MPDO tensor or from the
+present support-algebra predicate.  Such a construction would imply the false
+converse exhibited above.  In Theorem~4.14(ii), the BNT-label coefficients,
+their positive trace-power representation, and the length-one idempotent
+identity are the hypothesis of the converse, not consequences of the mere
+existence of stabilized adjoint fixed-point algebras.
+
+To eliminate the source-theorem gap, the formalization should instead:
 \begin{enumerate}
-    \item construction of the comparison maps relating the BNT-label
-        coefficients to the chosen blocked bases of $\mathcal A_n$;
-    \item construction of the same-length BNT operator family and product law
-        from the MPDO tensor, together with the comparison to the blocked
-        support-algebra product
-        $\mathcal A_n \times \mathcal A_n \to \mathcal A_{2n}$;
-    \item construction of the positive BNT-label
-        $\chi_{\alpha,\beta,\gamma}$-witness from the paper's Appendix C.3
-        and C.4 hypotheses;
-    \item construction of the idempotent condition
-        $m_\gamma =
-          \sum_{\alpha,\beta} c^{(1)}_{\alpha,\beta,\gamma}
-          m_\alpha m_\beta$ from the MPDO tensor;
-    \item construction of the single
-        \leanid{MPOTensor.BNTLabelTheoremWitness} from these source
-        objects, and hence of the underlying
-        \leanid{MPOTensor.BNTLabelTheoremData} record.  The blocked-basis
-        trace-power statement, with its
-        source-length exponent convention, is then a derived corollary of the
-        uniform BNT-label theorem, rather than a separate replacement for the
-        theorem itself.
+    \item define a separate, source-faithful predicate for
+        Theorem~4.14(ii), bundling the vertical canonical-form decomposition
+        from Proposition~4.13, the BNT operators $O_L(M_\alpha)$, the weights
+        $m_\alpha=\tr(\mu_\alpha)$, the positive matrices
+        $\chi_{\alpha,\beta,\gamma}$, the same-length product law, and the
+        length-one idempotent identity;
+    \item relate that predicate to the one-site and two-site vertical
+        decompositions used in Appendix~C.4, lines~2048--2058, and prove the
+        unitary relabelling and the positive multiset identity for the
+        $\nu_{\gamma,k}$;
+    \item deduce $\tr(\nu_\gamma)=m_\gamma$ and construct the maps
+        $T=\widetilde R_2\widetilde T R_1$ and
+        $S=\widetilde R_1\widetilde S R_2$ exactly as in lines~2065--2085;
+    \item conclude the paper's renormalization fixed-point predicate, namely
+        the existence of the two trace-preserving completely positive maps in
+        Definition~4.1.  Any comparison with the transfer-map fusion predicate
+        must then be stated separately, because the latter is presently
+        equivalent to transfer-map idempotence rather than Definition~4.1.
 \end{enumerate}
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
+++ b/docs/paper-gaps/cpgsv17_blocked_chi_uniformity.tex
@@ -165,7 +165,7 @@ up to relabelling (line~2053),
     A_\gamma
       = e^{i\theta_\gamma} Z_\gamma M_\gamma Z_\gamma^{-1}.
 \]
-Proposition~IV.12 then removes the phase and identifies $Z_\gamma$ with a
+Proposition~4.13 then removes the phase and identifies $Z_\gamma$ with a
 unitary $U_\gamma$, as in line~2057, so
 \[
     A_\gamma = U_\gamma M_\gamma U_\gamma^{-1}


### PR DESCRIPTION
## Motivation

Issue #826 asked for the converse from the present support-algebra predicate to the fusion-isometry predicate. That implication is false, even after adding trace preservation and a faithful fixed point.

The source does not assert this weaker implication. Theorem 4.14(ii) of arXiv:1606.00608 assumes positive diagonal BNT-label matrices, a same-length product formula, and a length-one idempotent weight identity. Appendix C.4, lines 2046–2085, uses those hypotheses to construct the trace-preserving maps. The vertical canonical-form argument at lines 1830–1922 proves Proposition 4.13 and does not supply the missing coefficient data.

## Description

- construct a qubit phase-flip MPO with Kraus operators K₀=(3/5)I and K₁=(4/5)Z;
- prove that it is trace-preserving and fixes the positive-definite matrix I;
- prove that every positive blocked power has the same adjoint fixed-point algebra;
- prove that its transfer map is not idempotent, hence it cannot satisfy the fusion predicate;
- state the counterexample in the enabled MPDO/RFP blueprint;
- correct the source discussion and give a faithful completion plan for Theorem 4.14(ii).

The off-diagonal transfer eigenvalue is −7/25. Its positive powers never equal one, so all positive powers have the same diagonal fixed-point algebra, while the map is not a projection.

## Testing

- lake env lean TNLean/MPS/MPDO/AlgebraFusionCounterexample.lean
- lake build TNLean
- cd blueprint && leanblueprint checkdecls
- cd blueprint && leanblueprint pdf
- cd docs/paper-gaps && latexmk -pdf -interaction=nonstopmode -halt-on-error cpgsv17_blocked_chi_uniformity.tex
- python3 scripts/check_reader_facing_prose.py --diff-base origin/main
- git diff HEAD^ --check
- visual inspection of the affected blueprint pages

The build reports only pre-existing warnings, including the documented periodic-overlap sorry in TNLean/MPS/Periodic/Overlap/Case3.lean. This change adds no sorry or axiom.

Closes #826

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formal proof and documentation; no changes to runtime behavior or security-sensitive paths. Main impact is clarifying which MPDO implications are false and how future formalization should proceed.
> 
> **Overview**
> **Disproves** the converse from `IsRFP_MPDO_via_algebra` to `IsRFP_MPDO_via_fusion`, even with trace preservation and a positive-definite fixed point.
> 
> Adds `AlgebraFusionCounterexample.lean` with a **qubit phase-flip** MPO (`K₀ = (3/5)I`, `K₁ = (4/5)Z`): proves trace preservation, `I` as a faithful fixed point, stabilized adjoint fixed-point algebras at all block lengths (off-diagonal eigenvalue **−7/25**), and **non-idempotent** transfer map so fusion fails. Exposes `exists_isRFP_MPDO_via_algebra_not_isRFP_MPDO_via_fusion` via the root import.
> 
> The blueprint chapter gains a matching theorem and updates the algebra-to-fusion gap remark. The CPGSV17 paper-gap note cites the Lean witness, retargets Theorem 4.14(ii) references, and replaces “build BNT witness from arbitrary MPDO” with a **source-faithful predicate** completion plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffb2067a37d3794502a1fd33443665cdd8b53254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->