### PR TITLE
fix(MPS/MPDO): state vertical-sector regrouping faithfully

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -180,7 +180,7 @@ theorem mpv_diagonalTensor (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) 
 tensor of `M` generates the same MPV family as the block-diagonal assembly, on the
 physical index `Fin d`, of the diagonally-restricted blocks.  This is a preliminary
 coefficient identity for arXiv:1606.00608, Proposition 4.13 (source label
-`Prop:IV.12`), not the vertical canonical decomposition: diagonal restriction need
+Prop:IV.12), not the vertical canonical decomposition: diagonal restriction need
 not preserve normality, and the horizontal weights need not be positive. -/
 theorem mpv_diagonalTensor_eq_blocks (M : MPOTensor d D)
     {r : ℕ} {dim : Fin r → ℕ} (μ : Fin r → ℂ)
@@ -343,7 +343,7 @@ families.
 
 This is the finite-sum reindexing used after the vertical canonical
 decomposition in arXiv:1606.00608, Proposition 4.13 (source label
-`Prop:IV.12`), lines 1895--1921.  Those lines first produce the vertical
+Prop:IV.12), lines 1895--1921.  Those lines first produce the vertical
 sectors and only then group gauge-equivalent sectors into the repeated copies
 of each basis tensor. -/
 theorem sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv
@@ -382,7 +382,7 @@ the remaining hypotheses identify its bond dimension and weight and its
 positive-length matrix product vector family.
 
 The grouping hypotheses correspond to the vertical decomposition constructed
-in arXiv:1606.00608, Proposition 4.13 (source label `Prop:IV.12`), lines
+in arXiv:1606.00608, Proposition 4.13 (source label Prop:IV.12), lines
 1895--1921.  They are not a consequence of reindexing the horizontal blocks
 alone. -/
 theorem sameMPV₂_diagonalTensor_verticalAssembledTensor_of_equiv
@@ -412,7 +412,7 @@ with one scalar weight per block has the same positive-length MPV family as an
 assembly that repeats each block with several scalar weights.
 
 This is a conditional comparison lemma.  In arXiv:1606.00608, Proposition
-4.13 (source label `Prop:IV.12`), lines 1895--1921, the repeated weights instead
+4.13 (source label Prop:IV.12), lines 1895--1921, the repeated weights instead
 arise by grouping the already constructed vertical canonical sectors; that
 source step is expressed by
 `sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv`. -/
@@ -446,7 +446,7 @@ positive-length MPV family as a repeated-block assembly when their scalar
 weights satisfy the stated positive-length power-sum identities.
 
 This conditional result does not construct the vertical grouping in
-arXiv:1606.00608, Proposition 4.13 (source label `Prop:IV.12`), lines
+arXiv:1606.00608, Proposition 4.13 (source label Prop:IV.12), lines
 1873--1921.  That construction must first identify the vertical BNT sectors
 and their positive weights. -/
 theorem sameMPV₂Pos_diagonalTensor_verticalAssembledTensor_of_power_sums

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -54,10 +54,14 @@ surrogate for the paper's vertical canonical form.
 * `mpv_verticalAssembledTensor_eq_sum`:
   the MPV of the vertical-assembled tensor as a sum over the flattened
   `(block, multiplicity)` index.
+* `sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv`:
+  regrouping an indexed block family along a copy-label equivalence preserves
+  its full MPV family.
+* `sameMPV₂_diagonalTensor_verticalAssembledTensor_of_equiv`:
+  the exact diagonal-tensor consequence once the vertical BNT grouping and
+  pointwise block identifications are supplied.
 * `sameMPV₂Pos_diagonalTensor_verticalAssembledTensor_of_power_sums`:
-  the diagonal tensor has the same positive-length MPV family as the vertical
-  repeated-block assembly once the flattened scalar weights have the required
-  positive-length power sums.
+  a separate positive-length comparison under scalar power-sum identities.
 
 The full passage from horizontal to vertical canonical form
 (Proposition IV.12 / Proposition 4.13 of arXiv:1606.00608) is still outside
@@ -174,8 +178,10 @@ theorem mpv_diagonalTensor (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) 
 
 /-- Under a horizontal canonical-form decomposition of `M.toMPSTensor`, the diagonal
 tensor of `M` generates the same MPV family as the block-diagonal assembly, on the
-physical index `Fin d`, of the diagonally-restricted blocks. This expresses the diagonal
-tensor as a positive-weight block decomposition, the core content of Proposition IV.12. -/
+physical index `Fin d`, of the diagonally-restricted blocks.  This is a preliminary
+coefficient identity for arXiv:1606.00608, Proposition 4.13 (source label
+`Prop:IV.12`), not the vertical canonical decomposition: diagonal restriction need
+not preserve normality, and the horizontal weights need not be positive. -/
 theorem mpv_diagonalTensor_eq_blocks (M : MPOTensor d D)
     {r : ℕ} {dim : Fin r → ℕ} (μ : Fin r → ℂ)
     (A : (k : Fin r) → MPSTensor (d * d) (dim k))
@@ -328,11 +334,88 @@ theorem mpv_verticalAssembledTensor_eq_sum {g : ℕ} (dim : Fin g → ℕ) (mult
   exact Equiv.sum_comp finSigmaFinEquiv.symm
     (fun s : (α : Fin g) × Fin (mult α) => (ω s.1 s.2) ^ N • MPSTensor.mpv (A s.1) σ)
 
-/-- Positive-length scalar power-sum identities are exactly the condition under
-which a block assembly with one scalar weight per block has the same
-positive-length MPV family as the vertical assembly that repeats each block with
-several scalar weights. This is the positive-length flattening step in
-Proposition IV.12 of arXiv:1606.00608. -/
+/-- Regrouping an indexed block assembly into repeated copies of a family of
+representative blocks preserves its full matrix product vector family.  The
+equivalence records which representative and which copy correspond to each
+original block; the pointwise hypotheses identify the bond dimensions and
+weights and give equality of the positive-length matrix product vector
+families.
+
+This is the finite-sum reindexing used after the vertical canonical
+decomposition in arXiv:1606.00608, Proposition 4.13 (source label
+`Prop:IV.12`), lines 1895--1921.  Those lines first produce the vertical
+sectors and only then group gauge-equivalent sectors into the repeated copies
+of each basis tensor. -/
+theorem sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv
+    {r g : ℕ} {dim₀ : Fin r → ℕ} {dim : Fin g → ℕ}
+    (μ : Fin r → ℂ) (B : (k : Fin r) → MPSTensor d (dim₀ k))
+    (mult : Fin g → ℕ) (ω : (α : Fin g) → Fin (mult α) → ℂ)
+    (A : (α : Fin g) → MPSTensor d (dim α))
+    (e : Fin r ≃ (α : Fin g) × Fin (mult α))
+    (hDim : ∀ k, dim₀ k = dim (e k).1)
+    (hWeight : ∀ k, μ k = ω (e k).1 (e k).2)
+    (hBlock : ∀ k, MPSTensor.SameMPV₂Pos (B k) (A (e k).1)) :
+    MPSTensor.SameMPV₂
+      (MPSTensor.toTensorFromBlocks (d := d) (μ := μ) B)
+      (verticalAssembledTensor dim mult ω A) := by
+  refine MPSTensor.SameMPV₂Pos.toSameMPV₂_of_bondDim_eq ?_ ?_
+  · intro N hN σ
+    rw [MPSTensor.mpv_toTensorFromBlocks_eq_sum, mpv_verticalAssembledTensor_eq_sum]
+    trans ∑ k : Fin r, (ω (e k).1 (e k).2) ^ N • MPSTensor.mpv (A (e k).1) σ
+    · refine Finset.sum_congr rfl fun k _ ↦ ?_
+      rw [hWeight k, hBlock k N hN σ]
+    · exact Equiv.sum_comp e
+        (fun p : (α : Fin g) × Fin (mult α) ↦ (ω p.1 p.2) ^ N • MPSTensor.mpv (A p.1) σ)
+  · trans ∑ k : Fin r, dim (e k).1
+    · exact Finset.sum_congr rfl fun k _ ↦ hDim k
+    · trans ∑ p : (α : Fin g) × Fin (mult α), dim p.1
+      · exact Equiv.sum_comp e fun p ↦ dim p.1
+      · change (∑ p : (α : Fin g) × Fin (mult α), dim p.1) =
+          ∑ q : Fin (∑ α : Fin g, mult α), dim ((finSigmaFinEquiv.symm q).1)
+        exact (Equiv.sum_comp finSigmaFinEquiv.symm (fun p ↦ dim p.1)).symm
+
+/-- A horizontal block decomposition yields the full matrix product vector
+equality required by the flattened vertical assembly once the vertical
+canonical-form grouping has been supplied.  The equivalence lists every
+original diagonal restriction as one copy of a representative vertical block;
+the remaining hypotheses identify its bond dimension and weight and its
+positive-length matrix product vector family.
+
+The grouping hypotheses correspond to the vertical decomposition constructed
+in arXiv:1606.00608, Proposition 4.13 (source label `Prop:IV.12`), lines
+1895--1921.  They are not a consequence of reindexing the horizontal blocks
+alone. -/
+theorem sameMPV₂_diagonalTensor_verticalAssembledTensor_of_equiv
+    (M : MPOTensor d D) {r g : ℕ} {dim₀ : Fin r → ℕ} (μ : Fin r → ℂ)
+    (B : (k : Fin r) → MPSTensor (d * d) (dim₀ k))
+    {dim : Fin g → ℕ} (mult : Fin g → ℕ)
+    (ω : (α : Fin g) → Fin (mult α) → ℂ)
+    (A : (α : Fin g) → MPSTensor d (dim α))
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor
+      (MPSTensor.toTensorFromBlocks (d := d * d) (μ := μ) B))
+    (e : Fin r ≃ (α : Fin g) × Fin (mult α))
+    (hDim : ∀ k, dim₀ k = dim (e k).1)
+    (hWeight : ∀ k, μ k = ω (e k).1 (e k).2)
+    (hBlock : ∀ k,
+      MPSTensor.SameMPV₂Pos (MPSTensor.diagBlock (B k)) (A (e k).1)) :
+    MPSTensor.SameMPV₂ (diagonalTensor M) (verticalAssembledTensor dim mult ω A) := by
+  intro N σ
+  trans MPSTensor.mpv
+    (MPSTensor.toTensorFromBlocks (d := d) (μ := μ)
+      (fun k ↦ MPSTensor.diagBlock (B k))) σ
+  · exact mpv_diagonalTensor_eq_blocks M μ B hM σ
+  · exact sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv
+      μ (fun k ↦ MPSTensor.diagBlock (B k)) mult ω A e hDim hWeight hBlock N σ
+
+/-- Positive-length scalar power-sum identities imply that a block assembly
+with one scalar weight per block has the same positive-length MPV family as an
+assembly that repeats each block with several scalar weights.
+
+This is a conditional comparison lemma.  In arXiv:1606.00608, Proposition
+4.13 (source label `Prop:IV.12`), lines 1895--1921, the repeated weights instead
+arise by grouping the already constructed vertical canonical sectors; that
+source step is expressed by
+`sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv`. -/
 theorem sameMPV₂Pos_toTensorFromBlocks_verticalAssembledTensor_of_power_sums
     {g : ℕ} {dim : Fin g → ℕ} (μ : Fin g → ℂ) (mult : Fin g → ℕ)
     (ω : (α : Fin g) → Fin (mult α) → ℂ)
@@ -359,10 +442,13 @@ theorem sameMPV₂Pos_toTensorFromBlocks_verticalAssembledTensor_of_power_sums
             (fun α q => (ω α q) ^ N • MPSTensor.mpv (A α) σ)).symm
 
 /-- Under a horizontal block decomposition, the diagonal tensor has the same
-positive-length MPV family as the vertical repeated-block assembly once the
-flattened scalar weights have the same positive-length power sums as the
-original block weights. This isolates the multiplicity-flattening step in
-Proposition IV.12 of arXiv:1606.00608 from the later BNT-normality argument. -/
+positive-length MPV family as a repeated-block assembly when their scalar
+weights satisfy the stated positive-length power-sum identities.
+
+This conditional result does not construct the vertical grouping in
+arXiv:1606.00608, Proposition 4.13 (source label `Prop:IV.12`), lines
+1873--1921.  That construction must first identify the vertical BNT sectors
+and their positive weights. -/
 theorem sameMPV₂Pos_diagonalTensor_verticalAssembledTensor_of_power_sums
     (M : MPOTensor d D) {g : ℕ} {dim : Fin g → ℕ} (μ : Fin g → ℂ)
     (A : (α : Fin g) → MPSTensor (d * d) (dim α))

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -457,12 +457,28 @@
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
         lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
         lem:diagonal_tensor_vertical_assembly_grouping}
-    Starting from the horizontal canonical-form decomposition, one uses the MPDO
-    positivity condition to compare the first-site action of the doubled-index
-    tensor on the diagonal sector. Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree}
-    then shows that the diagonal tensor splits
-    along the same normal blocks, with the coefficients rearranged into
-    positive scalar weights.
-    Flattening those positive diagonal coefficients produces the required
-    vertical canonical-form decomposition.
+    MPDO positivity and
+    Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree} exclude a one-sided
+    invariant projection for the tensor viewed in the vertical direction.
+    Positivity also excludes nontrivial periodic sectors.  The canonical-form
+    theorem then gives a new vertical family $(B_k)_{k\in I}$ and weights
+    $\nu_k$ satisfying
+    \[
+        V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
+        =V^{(N)}\Bigl(\textstyle\bigoplus_{k\in I}\nu_k B_k\Bigr).
+    \]
+    Group gauge-equivalent vertical sectors by a bijection
+    $e(k)=(\alpha,j)$.  Once the corresponding dimensions, weights, and
+    positive-length matrix product vectors are identified,
+    Lemma~\ref{lem:diagonal_tensor_vertical_assembly_grouping} gives
+    \[
+        V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
+        =V^{(N)}\Bigl(
+          \textstyle\bigoplus_\alpha\bigoplus_{j=1}^{m_\alpha}
+          \omega_{\alpha j}A_\alpha
+        \Bigr)
+    \]
+    for every $N$, including $N=0$.  A final use of positivity gives
+    $\omega_{\alpha j}>0$ and makes the similarities between grouped sectors
+    unitary.
 \end{proof}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -246,8 +246,9 @@
     $\sigma$.
 \end{lemma}
 \begin{proof}\leanok
-    By Lemma~\ref{lem:mpv_diagonal_tensor_eq_density} the value is a diagonal entry of $\rho^{(N)}(M)$, and the
-    diagonal entries of a positive semidefinite matrix are nonnegative.
+    By Lemma~\ref{lem:mpv_diagonal_tensor_eq_density}, the value is a diagonal
+    entry of $\rho^{(N)}(M)$, and the diagonal entries of a positive semidefinite
+    matrix are nonnegative.
 \end{proof}
 
 \begin{lemma}[Matrix product vector of the vertical-assembled tensor]
@@ -284,6 +285,81 @@
         \{1,\dots,\sum_\alpha\mult_\alpha\}$, under which $\widetilde\omega_q=
         \omega_{\alpha j}$ and $\widetilde A_q = A_\alpha$. Reindexing the sum along
     this bijection yields the double sum over $(\alpha, j)$.
+\end{proof}
+
+\begin{lemma}[Regrouping a block family by repeated representatives]
+    \label{lem:vertical_grouping_equiv}
+    \lean{MPOTensor.sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv}
+    \leanok
+    \uses{lem:mpv_vertical_assembled, thm:mpv_decomposition}
+    Let $(B_k)_{k\in I}$ be a finite family of blocks with weights $\nu_k$,
+    and let $(A_\alpha)_{\alpha\in J}$ be a finite family of representative
+    blocks.  Suppose there is a bijection
+    \[
+        e:I\simeq\{(\alpha,j):\alpha\in J, 1\le j\le m_\alpha\}
+    \]
+    such that, writing $e(k)=(\alpha,j)$, the paired blocks have equal bond
+    dimensions, $\nu_k=\omega_{\alpha j}$, and for every positive length $N$,
+    \[
+        V^{(N)}(B_k)=V^{(N)}(A_\alpha)
+    \]
+    Then
+    \[
+        V^{(N)}\Bigl(\textstyle\bigoplus_{k\in I}\nu_k B_k\Bigr)
+        =
+        V^{(N)}\Bigl(
+          \textstyle\bigoplus_{\alpha\in J}\bigoplus_{j=1}^{m_\alpha}
+          \omega_{\alpha j}A_\alpha
+        \Bigr)
+    \]
+    for every length $N$, including $N=0$.  This is the finite-sum
+    reindexing after the vertical sectors have been grouped in
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:mpv_vertical_assembled, thm:mpv_decomposition}
+    Expand both matrix product vectors as finite sums.  The summand indexed by
+    $k$ on the left equals the summand indexed by $e(k)$ on the right by the
+    weight and block hypotheses.  Reindexing the sum by $e$ proves the result.
+    At length zero the pointwise dimension equality gives equality of the
+    paired bond dimensions, so the same reindexing also gives equality of the
+    total bond dimensions.
+\end{proof}
+
+\begin{lemma}[Diagonal tensor under vertical-sector grouping]
+    \label{lem:diagonal_tensor_vertical_assembly_grouping}
+    \lean{MPOTensor.sameMPV₂_diagonalTensor_verticalAssembledTensor_of_equiv}
+    \leanok
+    \uses{lem:mpv_diagonal_tensor_eq_blocks, lem:vertical_grouping_equiv}
+    Suppose the doubled-index tensor $\widehat M$ has the same matrix product
+    vector family as $\bigoplus_{k\in I}\nu_k B_k$.  Suppose further that a
+    bijection $e(k)=(\alpha,j)$ groups the diagonal restrictions
+    $B_k^{\mathrm{diag}}$ so that the paired blocks have equal bond dimensions,
+    $\nu_k=\omega_{\alpha j}$, and for every positive length $N$,
+    \[
+        V^{(N)}(B_k^{\mathrm{diag}})=V^{(N)}(A_\alpha)
+    \]
+    Then the diagonal tensor has the full matrix product
+    vector equality
+    \[
+        V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
+        =
+        V^{(N)}\Bigl(
+          \textstyle\bigoplus_\alpha\bigoplus_{j=1}^{m_\alpha}
+          \omega_{\alpha j}A_\alpha
+        \Bigr)
+    \]
+    for every length $N$, including $N=0$.
+\end{lemma}
+\begin{proof}\leanok
+    \uses{lem:mpv_diagonal_tensor_eq_blocks, lem:vertical_grouping_equiv}
+    The horizontal block decomposition identifies the diagonal tensor with
+    the block sum
+    \[
+        \bigoplus_k\nu_k B_k^{\mathrm{diag}}.
+    \]
+    Lemma~\ref{lem:vertical_grouping_equiv} applies to the stated grouping of
+    these diagonal restrictions.
 \end{proof}
 
 \begin{lemma}[Power-sum flattening of repeated vertical blocks]
@@ -373,13 +449,14 @@
         lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
         lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg,
         lem:mpv_vertical_assembled,
-        lem:diagonal_tensor_vertical_assembly_power_sums}
+        lem:diagonal_tensor_vertical_assembly_grouping}
     Every MPDO in horizontal canonical form is also in vertical canonical form.
 \end{theorem}
 
 \begin{proof}
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
-        lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor}
+        lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
+        lem:diagonal_tensor_vertical_assembly_grouping}
     Starting from the horizontal canonical-form decomposition, one uses the MPDO
     positivity condition to compare the first-site action of the doubled-index
     tensor on the diagonal sector. Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -256,9 +256,10 @@
     \lean{MPOTensor.mpv_verticalAssembledTensor_eq_sum}
     \leanok
     \uses{thm:mpv_decomposition, def:block_diagonal_tensor}
-    Let $g$ be a block count, $\dim,\mult:\{1,\dots,g\}\to\mathbb N$, weights
-    $\omega_{\alpha j}\in\mathbb C$ for $j\le\mult_\alpha$, and blocks $A_\alpha$ of
-    bond dimension $\dim_\alpha$. The vertical-assembled tensor is the
+    Let $g$ be a block count,
+    $\dim,\mult:\{0,\dots,g-1\}\to\mathbb N$, weights
+    $\omega_{\alpha j}\in\mathbb C$ for $0\le j<\mult_\alpha$, and blocks
+    $A_\alpha$ of bond dimension $\dim_\alpha$. The vertical-assembled tensor is the
     block-diagonal assembly over the flattened index $(\alpha, j)$ that repeats
     $A_\alpha$ with weight $\omega_{\alpha j}$, written
     $\bigoplus_\alpha\bigoplus_j \omega_{\alpha j}\, A_\alpha$. Its matrix product
@@ -281,10 +282,13 @@
         = \sum_{q} (\widetilde\omega_q)^N\, V^{(N)}(\widetilde A_q)(\sigma).
     \]
     The flattening identifies $q$ with the pair $(\alpha, j)$ via the bijection
-    $\bigl(\{1,\dots,g\}\times\{1,\dots,\mult_\alpha\}\bigr)\simeq
-        \{1,\dots,\sum_\alpha\mult_\alpha\}$, under which $\widetilde\omega_q=
-        \omega_{\alpha j}$ and $\widetilde A_q = A_\alpha$. Reindexing the sum along
-    this bijection yields the double sum over $(\alpha, j)$.
+    \[
+        \{(\alpha,j):0\le\alpha<g,\ 0\le j<\mult_\alpha\}
+        \simeq \{0,\dots,\textstyle\sum_\alpha\mult_\alpha-1\},
+    \]
+    under which $\widetilde\omega_q=\omega_{\alpha j}$ and
+    $\widetilde A_q=A_\alpha$. Reindexing the sum along this bijection yields the
+    double sum over $(\alpha,j)$.
 \end{proof}
 
 \begin{lemma}[Regrouping a block family by repeated representatives]
@@ -296,7 +300,7 @@
     and let $(A_\alpha)_{\alpha\in J}$ be a finite family of representative
     blocks.  Suppose there is a bijection
     \[
-        e:I\simeq\{(\alpha,j):\alpha\in J, 1\le j\le m_\alpha\}
+        e:I\simeq\{(\alpha,j):\alpha\in J, 0\le j<m_\alpha\}
     \]
     such that, writing $e(k)=(\alpha,j)$, the paired blocks have equal bond
     dimensions, $\nu_k=\omega_{\alpha j}$, and for every positive length $N$,
@@ -308,7 +312,7 @@
         V^{(N)}\Bigl(\textstyle\bigoplus_{k\in I}\nu_k B_k\Bigr)
         =
         V^{(N)}\Bigl(
-          \textstyle\bigoplus_{\alpha\in J}\bigoplus_{j=1}^{m_\alpha}
+          \textstyle\bigoplus_{\alpha\in J}\bigoplus_{j=0}^{m_\alpha-1}
           \omega_{\alpha j}A_\alpha
         \Bigr)
     \]
@@ -318,12 +322,17 @@
 \end{lemma}
 \begin{proof}\leanok
     \uses{lem:mpv_vertical_assembled, thm:mpv_decomposition}
-    Expand both matrix product vectors as finite sums.  The summand indexed by
-    $k$ on the left equals the summand indexed by $e(k)$ on the right by the
-    weight and block hypotheses.  Reindexing the sum by $e$ proves the result.
-    At length zero the pointwise dimension equality gives equality of the
-    paired bond dimensions, so the same reindexing also gives equality of the
-    total bond dimensions.
+    For $N>0$ and every configuration $\sigma$, the two sides expand as
+    \[
+      \sum_{k\in I}\nu_k^N V^{(N)}(B_k)(\sigma),
+      \qquad
+      \sum_{\alpha\in J}\sum_{j=0}^{m_\alpha-1}
+        \omega_{\alpha j}^N V^{(N)}(A_\alpha)(\sigma).
+    \]
+    The summand indexed by $k$ in the first sum equals the summand indexed by
+    $e(k)$ in the second, so reindexing by $e$ proves the equality.  At length
+    zero the pointwise dimension equality gives equality of the paired bond
+    dimensions; the same reindexing gives equality of the total dimensions.
 \end{proof}
 
 \begin{lemma}[Diagonal tensor under vertical-sector grouping]
@@ -345,7 +354,7 @@
         V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
         =
         V^{(N)}\Bigl(
-          \textstyle\bigoplus_\alpha\bigoplus_{j=1}^{m_\alpha}
+          \textstyle\bigoplus_\alpha\bigoplus_{j=0}^{m_\alpha-1}
           \omega_{\alpha j}A_\alpha
         \Bigr)
     \]
@@ -474,7 +483,7 @@
     \[
         V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
         =V^{(N)}\Bigl(
-          \textstyle\bigoplus_\alpha\bigoplus_{j=1}^{m_\alpha}
+          \textstyle\bigoplus_\alpha\bigoplus_{j=0}^{m_\alpha-1}
           \omega_{\alpha j}A_\alpha
         \Bigr)
     \]

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -458,14 +458,14 @@
         lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
         lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg,
         lem:mpv_vertical_assembled,
-        lem:diagonal_tensor_vertical_assembly_grouping}
+        lem:vertical_grouping_equiv}
     Every MPDO in horizontal canonical form is also in vertical canonical form.
 \end{theorem}
 
 \begin{proof}
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
         lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
-        lem:diagonal_tensor_vertical_assembly_grouping}
+        lem:vertical_grouping_equiv}
     MPDO positivity and
     Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree} exclude a one-sided
     invariant projection for the tensor viewed in the vertical direction.
@@ -479,7 +479,7 @@
     Group gauge-equivalent vertical sectors by a bijection
     $e(k)=(\alpha,j)$.  Once the corresponding dimensions, weights, and
     positive-length matrix product vectors are identified,
-    Lemma~\ref{lem:diagonal_tensor_vertical_assembly_grouping} gives
+    Lemma~\ref{lem:vertical_grouping_equiv} gives
     \[
         V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
         =V^{(N)}\Bigl(

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -57,7 +57,7 @@ Suppose an indexed family of blocks $(B_k)_{k\in I}$ has already been grouped
 into copies of representative blocks $(A_\alpha)_{\alpha\in J}$.  Write
 $m_\alpha$ for the number of copies and let
 \begin{equation}
-  e:I\simeq\{(\alpha,j):\alpha\in J, 1\leq j\leq m_\alpha\}
+  e:I\simeq\{(\alpha,j):\alpha\in J, 0\leq j<m_\alpha\}
   \label{eq:grouping-equivalence}
 \end{equation}
 be the grouping bijection.  If
@@ -75,7 +75,7 @@ then finite-sum reindexing gives
   V^{(N)}\!\left(\bigoplus_{k\in I}\nu_k B_k\right)
   =
   V^{(N)}\!\left(
-    \bigoplus_{\alpha\in J}\bigoplus_{j=1}^{m_\alpha}
+    \bigoplus_{\alpha\in J}\bigoplus_{j=0}^{m_\alpha-1}
     \omega_{\alpha,j}A_\alpha
   \right)
   \label{eq:regrouped-mpv}

--- a/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex
@@ -1,0 +1,137 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Vertical Canonical-Form Grouping in Proposition 4.13}
+\author{}
+\date{2026-07-09}
+
+\begin{document}
+\maketitle
+
+\section{Source statement and proof order}
+
+Proposition~4.13 (source label \path{Prop:IV.12}) of
+\cite{Cirac2016MPDO_arXiv} states that a canonical-form
+tensor generating matrix product density operators is also in canonical form
+in the vertical direction.  After a physical isometry, the tensor has the form
+\begin{equation}
+  U\widetilde M U^\dagger
+  =
+  \bigoplus_\alpha \mu_\alpha\otimes M_\alpha,
+  \label{eq:source-vertical-form}
+\end{equation}
+where each $\mu_\alpha$ is positive and diagonal and the tensors
+$M_\alpha$ form a basis of normal tensors.
+
+The proof has a definite order.  It first uses positivity of the generated
+operators and Lemma~L to exclude one-sided transitions and nontrivial periodic
+sectors.  Only after vertical canonical form has been obtained does it write
+the vertical decomposition as
+\begin{equation}
+  \bigoplus_{\alpha,k}
+  \mu_{\alpha,k}X_{\alpha,k}M_\alpha X_{\alpha,k}^{-1}.
+  \label{eq:source-sector-form}
+\end{equation}
+The remainder of the proof shows that $\mu_{\alpha,k}>0$ and that each gauge
+$X_{\alpha,k}$ is proportional to a unitary.  The copy index $k$ in
+\eqref{eq:source-sector-form} is then the diagonal index of $\mu_\alpha$ in
+\eqref{eq:source-vertical-form}.
+
+Thus the positive diagonal coefficients in the conclusion are obtained from
+the \emph{vertical} canonical decomposition.  They are not obtained by
+flattening the scalar weights of a previously chosen horizontal decomposition
+while retaining the diagonal restrictions of its blocks.
+
+The relevant local source passage is
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:1861--1922}.
+
+\section{Exact finite-sum statement}
+
+Suppose an indexed family of blocks $(B_k)_{k\in I}$ has already been grouped
+into copies of representative blocks $(A_\alpha)_{\alpha\in J}$.  Write
+$m_\alpha$ for the number of copies and let
+\begin{equation}
+  e:I\simeq\{(\alpha,j):\alpha\in J, 1\leq j\leq m_\alpha\}
+  \label{eq:grouping-equivalence}
+\end{equation}
+be the grouping bijection.  If
+\begin{align}
+  \dim B_k&=\dim A_{e(k)_1},
+  \\
+  \nu_k&=\omega_{e(k)},
+  \\
+  V^{(N)}(B_k)&=V^{(N)}(A_{e(k)_1})
+  \qquad (N\geq 1),
+  \label{eq:pointwise-identifications}
+\end{align}
+then finite-sum reindexing gives
+\begin{equation}
+  V^{(N)}\!\left(\bigoplus_{k\in I}\nu_k B_k\right)
+  =
+  V^{(N)}\!\left(
+    \bigoplus_{\alpha\in J}\bigoplus_{j=1}^{m_\alpha}
+    \omega_{\alpha,j}A_\alpha
+  \right)
+  \label{eq:regrouped-mpv}
+\end{equation}
+for every $N$, including $N=0$.  The equality at $N=0$ follows from the
+pointwise dimension equalities in \eqref{eq:pointwise-identifications}.
+Summing these equalities along the bijection
+\eqref{eq:grouping-equivalence} gives the total bond-dimension equality.
+
+This statement is formalized by
+\path{MPOTensor.sameMPV2_toTensorFromBlocks_verticalAssembledTensor_of_equiv}
+and its diagonal-tensor consequence
+\path{MPOTensor.sameMPV2_diagonalTensor_verticalAssembledTensor_of_equiv}.
+In these two displayed names, the plain digit~$2$ denotes the subscripted
+character used in the source declaration.
+
+\section{Boundary of the present result}
+
+The conditional power-sum lemmas already present in the development compare
+one scalar weight $\mu_\alpha$ with several weights $\omega_{\alpha,j}$ under
+the additional identities
+\begin{equation}
+  \mu_\alpha^N=\sum_j\omega_{\alpha,j}^N,
+  \qquad N\geq 1.
+  \label{eq:power-sum-assumption}
+\end{equation}
+They are correct positive-length comparison lemmas, but
+\eqref{eq:power-sum-assumption} is not the flattening argument in
+Proposition~4.13.  In the source, the several weights are already the weights
+of the several vertical sectors in \eqref{eq:source-sector-form}; no single
+horizontal coefficient is replaced by their power sum.
+
+Diagonal restriction also does not preserve injectivity of a horizontal
+block.  For $d=D\geq2$, let the doubled-index matrices be
+\[
+  B^{(i,j)}=d^{-1/2}E_{ij}.
+\]
+They span $M_D(\mathbb C)$ and satisfy
+$\sum_{i,j}(B^{(i,j)})^\dagger B^{(i,j)}=I$.  Their diagonal restriction is
+$B^{(i,i)}=d^{-1/2}E_{ii}$, whose span is only the diagonal subalgebra.  Thus
+the BNT grouping in the conclusion must be obtained from the new vertical
+canonical decomposition, not by declaring the diagonal restrictions of the
+horizontal blocks to be normal blocks.
+
+The exact reindexing step \eqref{eq:regrouped-mpv} is therefore complete once
+the bijection and the pointwise block identifications are known.  The remaining
+source-level gap is to construct the vertical canonical decomposition, its BNT
+grouping, the positive weights, and the unitary gauges from horizontal
+canonical form and MPDO positivity, as done in source lines 1873--1921.  This
+is the mathematical content shared with the normality and grouping problem
+tracked by \ghissue{2537}; it cannot be supplied by a finite-sum identity
+alone.  The original formulation of \ghissue{2536}, interpreted as a direct
+conversion of the horizontal scalar weights and diagonal restrictions, is
+therefore not a consequence of Proposition~4.13.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Mathematical correction

Proposition 4.13 first constructs a new vertical canonical decomposition from MPDO positivity. Only afterwards does it group the resulting vertical sectors into repeated copies of representative normal tensors. It does not flatten the scalar weights of an arbitrary horizontal decomposition while retaining the diagonal restrictions of its blocks.

This pull request formalizes the valid regrouping step. Given a bijection from the original vertical sectors to pairs consisting of a representative label and copy label, together with pointwise equality of bond dimensions, weights, and positive-length matrix product vectors, the two block assemblies have the same full matrix product vector family, including length zero. A corollary composes this result with the existing diagonal-tensor block identity.

A matrix-unit family records why the original direct-diagonal-restriction route is not valid: an injective doubled-index block can restrict to matrices spanning only the diagonal subalgebra.

Source: Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Proposition 4.13, source label `Prop:IV.12`, lines 1861–1922.

## Remaining source theorem

This result does not construct the vertical canonical decomposition, its normal-tensor grouping, positive weights, or unitary gauges. Those are the substantive source steps shared with the corrected analysis of #2537.

## Verification

- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake env lean TNLean.lean`
- `cd blueprint && leanblueprint checkdecls`
- blueprint declaration synchronization
- reader-facing prose and proof-integrity checks
- enabled blueprint PDF build and visual inspection of Chapter 21, pages 379–380
- no Chapter 21 overfull boxes

Closes #2536.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive formalization, blueprint sync, and documentation; no auth, runtime, or API surface outside the MPS/MPDO proof library.
> 
> **Overview**
> Aligns the MPDO vertical canonical-form story with **Proposition 4.13** (arXiv:1606.00608): positivity first yields a **new vertical** decomposition; only then gauge-equivalent sectors are grouped into repeated copies—not by flattening horizontal scalar weights while keeping diagonal restrictions of horizontal blocks.
> 
> **Lean (`VerticalCF.lean`):** Adds `sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv` and `sameMPV₂_diagonalTensor_verticalAssembledTensor_of_equiv`, proving full `SameMPV₂` (including length zero) from a bijection `Fin r ≃ (α, copy)` plus bond dimensions, weights, and positive-length MPV agreement. Tightens docstrings on `mpv_diagonalTensor_eq_blocks` and the existing **power-sum** lemmas so they are explicitly **conditional** reindexing/comparison tools, not the source grouping argument.
> 
> **Blueprint (ch. 20):** New lemmas `vertical_grouping_equiv` and `diagonal_tensor_vertical_assembly_grouping`; vertical-assembled indexing prose uses `0,…,g-1`. The not-ready theorem `vertical_cf_of_horizontal_cf` now cites the grouping lemma and a proof sketch that matches the paper’s order (vertical CF → group sectors → positivity for weights/unitary gauges).
> 
> **Docs:** Adds `docs/paper-gaps/cpgsv17_vertical_cf_grouping.tex` recording proof order, the exact finite-sum statement, a matrix-unit counterexample for diagonal restriction, and the remaining gap (construct vertical BNT grouping from horizontal CF + positivity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d911bbe7dc9967be35b267cd512cc47c0202174. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->