### PR TITLE
fix(MPS/MPDO): correct the diagonal BNT route

### DIFF
--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Counterexample
+import TNLean.MPS.MPDO.BiCFDerivation.DiagonalRestrictionCounterexample
 
 /-!
 # Finite-length sufficient conditions and obstructions for MPDO biCF
@@ -27,6 +28,9 @@ The supporting modules are:
 * `TNLean.MPS.MPDO.BiCFDerivation.Counterexample` — the duplicate scalar-block
   obstruction showing that blockwise injectivity, left-canonicality, and
   nonzero weights do not imply the biCF property.
+* `TNLean.MPS.MPDO.BiCFDerivation.DiagonalRestrictionCounterexample` — an
+  injective, left-canonical single block whose restriction from physical pairs
+  `(i,j)` to `(i,i)` is not normal at any blocking length.
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput` — the trace-dual algebraic
   input from the direct-sum decomposition lemma of
   David--Perez-Garcia--Schuch--Wolf that follows from the two-sided nonzero

--- a/TNLean/MPS/MPDO/BiCFDerivation.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation.lean
@@ -30,7 +30,7 @@ The supporting modules are:
   nonzero weights do not imply the biCF property.
 * `TNLean.MPS.MPDO.BiCFDerivation.DiagonalRestrictionCounterexample` — an
   injective, left-canonical single block whose restriction from physical pairs
-  `(i,j)` to `(i,i)` is not normal at any blocking length.
+  (i,j) to (i,i) is not normal at any blocking length.
 * `TNLean.MPS.MPDO.BiCFDerivation.DirectSumInput` — the trace-dual algebraic
   input from the direct-sum decomposition lemma of
   David--Perez-Garcia--Schuch--Wolf that follows from the two-sided nonzero

--- a/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
@@ -16,16 +16,15 @@ diagonal restriction remains diagonal. The coefficients are chosen so that the t
 left-canonical. Since there is only one block, its injectivity also supplies the
 finite-length block-separation property in `HorizontalCFData`.
 
-This obstruction does not contradict Proposition 4.13 (source label `Prop:IV.12`) of
-arXiv:1606.00608. In the proof at lines 1873--1921, positivity is first used to obtain
-a new canonical form in the
+This obstruction does not contradict arXiv:1606.00608, Proposition 4.13. In the
+proof at lines 1873--1921, positivity is first used to obtain a new canonical form in the
 vertical direction; the vertical basis of normal tensors is obtained from that canonical
 form, not by restricting each horizontal basis tensor to physical pairs `(i, i)`.
 
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Proposition 4.13 (source label `Prop:IV.12`), lines 1863--1921
+  Proposition 4.13, lines 1863--1921
 -/
 
 open scoped Matrix BigOperators
@@ -187,9 +186,9 @@ private theorem diagonalRestrictionBlock_horizontalCFData :
 diagonally restricted blocks, even after arbitrary blocking.
 
 **Local obstruction (Proposition 4.13):** The proposition in arXiv:1606.00608,
-source label `Prop:IV.12`, lines 1873--1921, obtains a new vertical canonical form from
-positivity; it does not assert that the diagonal restrictions of the horizontal blocks
-are normal. The source comparison is documented in
+lines 1873--1921, obtains a new vertical canonical form from positivity; it does not
+assert that the diagonal restrictions of the horizontal blocks are normal. The source
+comparison is documented in
 `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. -/
 theorem horizontalCFData_diagBlock_not_isNormal :
     ∃ (weight : Fin 1 → ℂ) (block : Fin 1 → MPSTensor (2 * 2) 2),

--- a/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
@@ -1,6 +1,7 @@
 /-
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Authors: TNLean contributors
 -/
 import TNLean.MPS.MPDO.BiCFDerivation.Basic
 
@@ -19,7 +20,7 @@ finite-length block-separation property in `HorizontalCFData`.
 This obstruction does not contradict arXiv:1606.00608, Proposition 4.13. In the
 proof at lines 1873--1921, positivity is first used to obtain a new canonical form in the
 vertical direction; the vertical basis of normal tensors is obtained from that canonical
-form, not by restricting each horizontal basis tensor to physical pairs `(i, i)`.
+form, not by restricting each horizontal basis tensor to physical pairs (i, i).
 
 ## References
 
@@ -34,14 +35,14 @@ namespace MPSTensor
 section DiagonalRestrictionCounterexample
 
 /-- A doubled-index tensor consisting of the four matrix units. The first row has
-coefficient `3/5` and the second row has coefficient `4/5`. -/
+coefficient 3/5 and the second row has coefficient 4/5. -/
 private noncomputable def diagonalRestrictionUnits : MPSTensor (2 * 2) 2
   | 0 => (3 / 5 : ℂ) • Matrix.single 0 0 1
   | 1 => (3 / 5 : ℂ) • Matrix.single 0 1 1
   | 2 => (4 / 5 : ℂ) • Matrix.single 1 0 1
   | 3 => (4 / 5 : ℂ) • Matrix.single 1 1 1
 
-/-- Evaluation at the physical pair `(a,b)` gives the corresponding matrix unit with
+/-- Evaluation at the physical pair (a,b) gives the corresponding matrix unit with
 the row-dependent coefficient. -/
 private theorem diagonalRestrictionUnits_finProd (a b : Fin 2) :
     diagonalRestrictionUnits (finProdFinEquiv (a, b)) =
@@ -98,7 +99,7 @@ private theorem diagBlock_diagonalRestrictionUnits_apply (i : Fin 2) :
         else (4 / 5 : ℂ) • Matrix.single 1 1 1) := by
   fin_cases i <;> norm_num [diagBlock, finProdFinEquiv, diagonalRestrictionUnits]
 
-/-- Every word in the diagonal restriction has vanishing `(0,1)` entry. -/
+/-- Every word in the diagonal restriction has vanishing (0,1) entry. -/
 private theorem evalWord_diagBlock_diagonalRestrictionUnits_zero_one (w : List (Fin 2)) :
     evalWord (diagBlock diagonalRestrictionUnits) w 0 1 = 0 := by
   induction w with

--- a/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
@@ -5,16 +5,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import TNLean.MPS.MPDO.BiCFDerivation.Basic
 
 /-!
-# Diagonal restriction need not preserve injectivity
+# Diagonal restriction need not preserve normality
 
 This file gives a two-dimensional counterexample to the assertion that the diagonal
-restriction of a doubled-index horizontal canonical-form block must be injective.
+restriction of a doubled-index horizontal canonical-form block must be normal.
 
 The tensor consists of the four matrix units, with nonzero row-dependent coefficients.
-Thus its four physical matrices span the full matrix algebra, while its diagonal
-restriction contains only the two diagonal matrix units. The coefficients are chosen so
-that the tensor is left-canonical. Since there is only one block, its injectivity also
-supplies the finite-length block-separation property in `HorizontalCFData`.
+Thus its four physical matrices span the full matrix algebra, while every word in its
+diagonal restriction remains diagonal. The coefficients are chosen so that the tensor is
+left-canonical. Since there is only one block, its injectivity also supplies the
+finite-length block-separation property in `HorizontalCFData`.
 
 This obstruction does not contradict Proposition 4.13 (source label `Prop:IV.12`) of
 arXiv:1606.00608. In the proof at lines 1873--1921, positivity is first used to obtain
@@ -98,25 +98,6 @@ private theorem diagBlock_diagonalRestrictionUnits_apply (i : Fin 2) :
       (if i = 0 then (3 / 5 : ℂ) • Matrix.single 0 0 1
         else (4 / 5 : ℂ) • Matrix.single 1 1 1) := by
   fin_cases i <;> norm_num [diagBlock, finProdFinEquiv, diagonalRestrictionUnits]
-
-/-- The diagonal restriction of the doubled-index tensor is not injective. -/
-private theorem diagBlock_diagonalRestrictionUnits_not_isInjective :
-    ¬ IsInjective (diagBlock diagonalRestrictionUnits) := by
-  intro h
-  suffices hzero : ∀ M ∈ Submodule.span ℂ (Set.range (diagBlock diagonalRestrictionUnits)),
-      M 0 1 = 0 by
-    have hmem : Matrix.single 0 1 (1 : ℂ) ∈
-        Submodule.span ℂ (Set.range (diagBlock diagonalRestrictionUnits)) :=
-      h ▸ Submodule.mem_top
-    exact absurd (hzero _ hmem) one_ne_zero
-  intro M hM
-  induction hM using Submodule.span_induction with
-  | mem M hM =>
-      obtain ⟨i, rfl⟩ := hM
-      fin_cases i <;> simp [diagBlock_diagonalRestrictionUnits_apply, Matrix.single]
-  | zero => simp
-  | add M N _ _ hM hN => simp [hM, hN]
-  | smul c M _ hM => simp [hM]
 
 /-- Every word in the diagonal restriction has vanishing `(0,1)` entry. -/
 private theorem evalWord_diagBlock_diagonalRestrictionUnits_zero_one (w : List (Fin 2)) :
@@ -202,28 +183,20 @@ private theorem diagonalRestrictionBlock_horizontalCFData :
       | smul c M _ hM => simp [Matrix.trace_smul, hM])
     simpa using hzero
 
-/-- Horizontal canonical-form hypotheses do not imply injectivity after restriction
-from physical pairs `(i,j)` to diagonal pairs `(i,i)`.
+/-- Horizontal canonical-form hypotheses also do not imply normality of the
+diagonally restricted blocks, even after arbitrary blocking.
 
 **Local obstruction (Proposition 4.13):** The proposition in arXiv:1606.00608,
 source label `Prop:IV.12`, lines 1873--1921, obtains a new vertical canonical form from
 positivity; it does not assert that the diagonal restrictions of the horizontal blocks
 are normal. The source comparison is documented in
 `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. -/
-private theorem horizontalCFData_diagBlock_not_isInjective :
-    MPOTensor.HorizontalCFData diagonalRestrictionWeight diagonalRestrictionBlock ∧
-      ¬ (∀ k, IsInjective (diagBlock (diagonalRestrictionBlock k))) := by
-  refine ⟨diagonalRestrictionBlock_horizontalCFData, ?_⟩
-  intro h
-  exact diagBlock_diagonalRestrictionUnits_not_isInjective (by
-    simpa [diagonalRestrictionBlock] using h 0)
-
-/-- Horizontal canonical-form hypotheses also do not imply normality of the
-diagonally restricted blocks, even after arbitrary blocking. -/
 theorem horizontalCFData_diagBlock_not_isNormal :
-    MPOTensor.HorizontalCFData diagonalRestrictionWeight diagonalRestrictionBlock ∧
-      ¬ (∀ k, IsNormal (diagBlock (diagonalRestrictionBlock k))) := by
-  refine ⟨diagonalRestrictionBlock_horizontalCFData, ?_⟩
+    ∃ (weight : Fin 1 → ℂ) (block : Fin 1 → MPSTensor (2 * 2) 2),
+      MPOTensor.HorizontalCFData weight block ∧
+        ¬ (∀ k, IsNormal (diagBlock (block k))) := by
+  refine ⟨diagonalRestrictionWeight, diagonalRestrictionBlock,
+    diagonalRestrictionBlock_horizontalCFData, ?_⟩
   intro h
   exact diagBlock_diagonalRestrictionUnits_not_isNormal (by
     simpa [diagonalRestrictionBlock] using h 0)

--- a/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
+++ b/TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean
@@ -1,0 +1,233 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.MPDO.BiCFDerivation.Basic
+
+/-!
+# Diagonal restriction need not preserve injectivity
+
+This file gives a two-dimensional counterexample to the assertion that the diagonal
+restriction of a doubled-index horizontal canonical-form block must be injective.
+
+The tensor consists of the four matrix units, with nonzero row-dependent coefficients.
+Thus its four physical matrices span the full matrix algebra, while its diagonal
+restriction contains only the two diagonal matrix units. The coefficients are chosen so
+that the tensor is left-canonical. Since there is only one block, its injectivity also
+supplies the finite-length block-separation property in `HorizontalCFData`.
+
+This obstruction does not contradict Proposition 4.13 (source label `Prop:IV.12`) of
+arXiv:1606.00608. In the proof at lines 1873--1921, positivity is first used to obtain
+a new canonical form in the
+vertical direction; the vertical basis of normal tensors is obtained from that canonical
+form, not by restricting each horizontal basis tensor to physical pairs `(i, i)`.
+
+## References
+
+* [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
+  Proposition 4.13 (source label `Prop:IV.12`), lines 1863--1921
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+section DiagonalRestrictionCounterexample
+
+/-- A doubled-index tensor consisting of the four matrix units. The first row has
+coefficient `3/5` and the second row has coefficient `4/5`. -/
+private noncomputable def diagonalRestrictionUnits : MPSTensor (2 * 2) 2
+  | 0 => (3 / 5 : ℂ) • Matrix.single 0 0 1
+  | 1 => (3 / 5 : ℂ) • Matrix.single 0 1 1
+  | 2 => (4 / 5 : ℂ) • Matrix.single 1 0 1
+  | 3 => (4 / 5 : ℂ) • Matrix.single 1 1 1
+
+/-- Evaluation at the physical pair `(a,b)` gives the corresponding matrix unit with
+the row-dependent coefficient. -/
+private theorem diagonalRestrictionUnits_finProd (a b : Fin 2) :
+    diagonalRestrictionUnits (finProdFinEquiv (a, b)) =
+      (if a = 0 then (3 / 5 : ℂ) else 4 / 5) • Matrix.single a b 1 := by
+  fin_cases a <;> fin_cases b <;> norm_num [finProdFinEquiv, diagonalRestrictionUnits]
+
+/-- Every matrix unit lies in the span of the four physical matrices. -/
+private theorem single_mem_span_diagonalRestrictionUnits (a b : Fin 2) :
+    Matrix.single a b (1 : ℂ) ∈
+      Submodule.span ℂ (Set.range diagonalRestrictionUnits) := by
+  have hmem : diagonalRestrictionUnits (finProdFinEquiv (a, b)) ∈
+      Submodule.span ℂ (Set.range diagonalRestrictionUnits) :=
+    Submodule.subset_span ⟨finProdFinEquiv (a, b), rfl⟩
+  fin_cases a
+  case «0» =>
+    convert Submodule.smul_mem _ (5 / 3 : ℂ) hmem using 1
+    rw [diagonalRestrictionUnits_finProd]
+    ext i j
+    simp [Matrix.single]
+  case «1» =>
+    convert Submodule.smul_mem _ (5 / 4 : ℂ) hmem using 1
+    rw [diagonalRestrictionUnits_finProd]
+    ext i j
+    simp [Matrix.single]
+
+/-- The doubled-index tensor is injective. -/
+private theorem diagonalRestrictionUnits_isInjective : IsInjective diagonalRestrictionUnits := by
+  rw [IsInjective, eq_top_iff]
+  intro M _
+  rw [Matrix.matrix_eq_sum_single M]
+  refine Submodule.sum_mem _ (fun a _ => Submodule.sum_mem _ (fun b _ => ?_))
+  rw [show Matrix.single a b (M a b) = M a b • Matrix.single a b (1 : ℂ) by
+    rw [Matrix.smul_single, smul_eq_mul, mul_one]]
+  exact Submodule.smul_mem _ _ (single_mem_span_diagonalRestrictionUnits a b)
+
+/-- The doubled-index tensor is left-canonical. -/
+private theorem diagonalRestrictionUnits_leftCanonical :
+    ∑ i : Fin (2 * 2), (diagonalRestrictionUnits i)ᴴ * diagonalRestrictionUnits i = 1 := by
+  rw [Fin.sum_univ_four]
+  ext i j
+  fin_cases i <;> fin_cases j
+  all_goals
+    norm_num [diagonalRestrictionUnits, Matrix.mul_apply,
+      Matrix.conjTranspose_apply, Matrix.single]
+  all_goals
+    rw [map_ofNat (starRingEnd ℂ) 3, map_ofNat (starRingEnd ℂ) 4,
+      map_ofNat (starRingEnd ℂ) 5]
+    norm_num
+
+/-- The diagonal restriction contains only the two diagonal matrix units. -/
+private theorem diagBlock_diagonalRestrictionUnits_apply (i : Fin 2) :
+    diagBlock diagonalRestrictionUnits i =
+      (if i = 0 then (3 / 5 : ℂ) • Matrix.single 0 0 1
+        else (4 / 5 : ℂ) • Matrix.single 1 1 1) := by
+  fin_cases i <;> norm_num [diagBlock, finProdFinEquiv, diagonalRestrictionUnits]
+
+/-- The diagonal restriction of the doubled-index tensor is not injective. -/
+private theorem diagBlock_diagonalRestrictionUnits_not_isInjective :
+    ¬ IsInjective (diagBlock diagonalRestrictionUnits) := by
+  intro h
+  suffices hzero : ∀ M ∈ Submodule.span ℂ (Set.range (diagBlock diagonalRestrictionUnits)),
+      M 0 1 = 0 by
+    have hmem : Matrix.single 0 1 (1 : ℂ) ∈
+        Submodule.span ℂ (Set.range (diagBlock diagonalRestrictionUnits)) :=
+      h ▸ Submodule.mem_top
+    exact absurd (hzero _ hmem) one_ne_zero
+  intro M hM
+  induction hM using Submodule.span_induction with
+  | mem M hM =>
+      obtain ⟨i, rfl⟩ := hM
+      fin_cases i <;> simp [diagBlock_diagonalRestrictionUnits_apply, Matrix.single]
+  | zero => simp
+  | add M N _ _ hM hN => simp [hM, hN]
+  | smul c M _ hM => simp [hM]
+
+/-- Every word in the diagonal restriction has vanishing `(0,1)` entry. -/
+private theorem evalWord_diagBlock_diagonalRestrictionUnits_zero_one (w : List (Fin 2)) :
+    evalWord (diagBlock diagonalRestrictionUnits) w 0 1 = 0 := by
+  induction w with
+  | nil => simp [evalWord]
+  | cons i w ih =>
+      fin_cases i <;>
+        simp [evalWord, diagBlock_diagonalRestrictionUnits_apply, Matrix.mul_apply,
+          Matrix.single, ih]
+
+/-- The diagonal restriction is not normal: blocking preserves its diagonal matrix
+algebra and therefore never produces the missing off-diagonal matrix units. -/
+private theorem diagBlock_diagonalRestrictionUnits_not_isNormal :
+    ¬ IsNormal (diagBlock diagonalRestrictionUnits) := by
+  rintro ⟨N, hN⟩
+  have hmem : Matrix.single 0 1 (1 : ℂ) ∈
+      Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
+        evalWord (diagBlock diagonalRestrictionUnits) (List.ofFn σ)) :=
+    hN ▸ Submodule.mem_top
+  suffices hzero : ∀ M ∈
+      Submodule.span ℂ (Set.range fun σ : Fin N → Fin 2 =>
+        evalWord (diagBlock diagonalRestrictionUnits) (List.ofFn σ)), M 0 1 = 0 by
+    exact absurd (hzero _ hmem) one_ne_zero
+  intro M hM
+  induction hM using Submodule.span_induction with
+  | mem M hM =>
+      obtain ⟨σ, rfl⟩ := hM
+      exact evalWord_diagBlock_diagonalRestrictionUnits_zero_one (List.ofFn σ)
+  | zero => simp
+  | add M K _ _ hM hK => simp [hM, hK]
+  | smul c M _ hM => simp [hM]
+
+/-- The single-block bond-dimension family used in the horizontal canonical form. -/
+private abbrev diagonalRestrictionDim : Fin 1 → ℕ := fun _ => 2
+
+/-- The nonzero weight of the single horizontal block. -/
+private def diagonalRestrictionWeight : Fin 1 → ℂ := fun _ => 1
+
+/-- The single horizontal block formed by the doubled-index matrix-unit tensor. -/
+private noncomputable def diagonalRestrictionBlock :
+    (k : Fin 1) → MPSTensor (2 * 2) (diagonalRestrictionDim k) :=
+  fun _ => diagonalRestrictionUnits
+
+/-- The doubled-index matrix-unit block satisfies all assumptions in
+`HorizontalCFData`, including finite-length block separation. -/
+private theorem diagonalRestrictionBlock_horizontalCFData :
+    MPOTensor.HorizontalCFData diagonalRestrictionWeight diagonalRestrictionBlock := by
+  refine {
+    block_injective := ?_
+    left_canonical := ?_
+    weight_ne_zero := ?_
+    biCF := ?_
+  }
+  · intro k
+    fin_cases k
+    exact diagonalRestrictionUnits_isInjective
+  · intro k
+    fin_cases k
+    exact diagonalRestrictionUnits_leftCanonical
+  · intro k
+    simp [diagonalRestrictionWeight]
+  · refine ⟨1, ?_⟩
+    intro Δ hΔ k
+    fin_cases k
+    have hA : ∀ i : Fin (2 * 2),
+        Matrix.trace (Δ 0 * diagonalRestrictionUnits i) = 0 := by
+      intro i
+      let w : Fin 1 → Fin (2 * 2) := fun _ => i
+      have h := hΔ w
+      simpa [w, diagonalRestrictionBlock, List.ofFn_succ, List.ofFn_zero, evalWord] using h
+    have hzero : Δ 0 = 0 := (Matrix.trace_mul_right_eq_zero_iff (Δ 0)).mp (by
+      intro N
+      have hN : N ∈ Submodule.span ℂ (Set.range diagonalRestrictionUnits) := by
+        rw [diagonalRestrictionUnits_isInjective]
+        exact Submodule.mem_top
+      induction hN using Submodule.span_induction with
+      | mem N hN =>
+          obtain ⟨i, rfl⟩ := hN
+          exact hA i
+      | zero => simp
+      | add M N _ _ hM hN => simp [Matrix.mul_add, Matrix.trace_add, hM, hN]
+      | smul c M _ hM => simp [Matrix.trace_smul, hM])
+    simpa using hzero
+
+/-- Horizontal canonical-form hypotheses do not imply injectivity after restriction
+from physical pairs `(i,j)` to diagonal pairs `(i,i)`.
+
+**Local obstruction (Proposition 4.13):** The proposition in arXiv:1606.00608,
+source label `Prop:IV.12`, lines 1873--1921, obtains a new vertical canonical form from
+positivity; it does not assert that the diagonal restrictions of the horizontal blocks
+are normal. The source comparison is documented in
+`docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. -/
+private theorem horizontalCFData_diagBlock_not_isInjective :
+    MPOTensor.HorizontalCFData diagonalRestrictionWeight diagonalRestrictionBlock ∧
+      ¬ (∀ k, IsInjective (diagBlock (diagonalRestrictionBlock k))) := by
+  refine ⟨diagonalRestrictionBlock_horizontalCFData, ?_⟩
+  intro h
+  exact diagBlock_diagonalRestrictionUnits_not_isInjective (by
+    simpa [diagonalRestrictionBlock] using h 0)
+
+/-- Horizontal canonical-form hypotheses also do not imply normality of the
+diagonally restricted blocks, even after arbitrary blocking. -/
+theorem horizontalCFData_diagBlock_not_isNormal :
+    MPOTensor.HorizontalCFData diagonalRestrictionWeight diagonalRestrictionBlock ∧
+      ¬ (∀ k, IsNormal (diagBlock (diagonalRestrictionBlock k))) := by
+  refine ⟨diagonalRestrictionBlock_horizontalCFData, ?_⟩
+  intro h
+  exact diagBlock_diagonalRestrictionUnits_not_isNormal (by
+    simpa [diagonalRestrictionBlock] using h 0)
+
+end DiagonalRestrictionCounterexample
+
+end MPSTensor

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -12,8 +12,8 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 This file introduces a block-decomposed version of the vertical canonical-form
 structure used in the MPDO analysis of arXiv:1606.00608, Section 4.4.
 
-Proposition 4.13 (source label `Prop:IV.12`) writes the tensor, after a local
-isometry on the physical indices, as a direct sum
+Proposition 4.13 of arXiv:1606.00608 writes the tensor, after a local isometry
+on the physical indices, as a direct sum
 `⊕_α μ_α ⊗ M_α`, where the `μ_α` are positive diagonal matrices and the
 `M_α` form a basis of normal tensors (BNT). The current repository formalization
 uses canonical-form and BNT data with scalar block weights. We therefore
@@ -64,9 +64,9 @@ surrogate for the paper's vertical canonical form.
   a separate positive-length comparison under scalar power-sum identities.
 
 The full passage from horizontal to vertical canonical form
-(Proposition 4.13, source label `Prop:IV.12`, of arXiv:1606.00608) is still
-outside this file: its blueprint entry `thm:vertical_cf_of_horizontal_cf` is
-marked `\notready`. The results above supply matrix-product-vector identities
+(arXiv:1606.00608, Proposition 4.13) is still outside this file: its blueprint
+entry `thm:vertical_cf_of_horizontal_cf` is marked `\notready`. The results
+above supply matrix-product-vector identities
 and elementary positivity consequences; the remaining step is an independent
 canonical-form decomposition of the tensor viewed in the vertical direction.
 Its basis cannot be obtained by diagonally restricting the horizontal blocks:
@@ -88,7 +88,7 @@ location matches the existing layering.
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Proposition 4.13 (source label `Prop:IV.12`) and the auxiliary Lemma L in the appendix
+  Proposition 4.13 and the auxiliary Lemma L in the appendix
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -185,9 +185,9 @@ theorem mpv_diagonalTensor (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) 
 /-- Under a horizontal canonical-form decomposition of `M.toMPSTensor`, the diagonal
 tensor of `M` generates the same MPV family as the block-diagonal assembly, on the
 physical index `Fin d`, of the diagonally-restricted blocks.  This is a preliminary
-coefficient identity for arXiv:1606.00608, Proposition 4.13 (source label
-Prop:IV.12), not the vertical canonical decomposition: diagonal restriction need
-not preserve normality, and the horizontal weights need not be positive. -/
+coefficient identity for arXiv:1606.00608, Proposition 4.13, not the vertical
+canonical decomposition: diagonal restriction need not preserve normality, and
+the horizontal weights need not be positive. -/
 theorem mpv_diagonalTensor_eq_blocks (M : MPOTensor d D)
     {r : ℕ} {dim : Fin r → ℕ} (μ : Fin r → ℂ)
     (A : (k : Fin r) → MPSTensor (d * d) (dim k))
@@ -348,10 +348,9 @@ weights and give equality of the positive-length matrix product vector
 families.
 
 This is the finite-sum reindexing used after the vertical canonical
-decomposition in arXiv:1606.00608, Proposition 4.13 (source label
-Prop:IV.12), lines 1895--1921.  Those lines first produce the vertical
-sectors and only then group gauge-equivalent sectors into the repeated copies
-of each basis tensor. -/
+decomposition in arXiv:1606.00608, Proposition 4.13, lines 1895--1921. Those
+lines first produce the vertical sectors and only then group gauge-equivalent
+sectors into the repeated copies of each basis tensor. -/
 theorem sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv
     {r g : ℕ} {dim₀ : Fin r → ℕ} {dim : Fin g → ℕ}
     (μ : Fin r → ℂ) (B : (k : Fin r) → MPSTensor d (dim₀ k))
@@ -388,9 +387,8 @@ the remaining hypotheses identify its bond dimension and weight and its
 positive-length matrix product vector family.
 
 The grouping hypotheses correspond to the vertical decomposition constructed
-in arXiv:1606.00608, Proposition 4.13 (source label Prop:IV.12), lines
-1895--1921.  They are not a consequence of reindexing the horizontal blocks
-alone. -/
+in arXiv:1606.00608, Proposition 4.13, lines 1895--1921. They are not a
+consequence of reindexing the horizontal blocks alone. -/
 theorem sameMPV₂_diagonalTensor_verticalAssembledTensor_of_equiv
     (M : MPOTensor d D) {r g : ℕ} {dim₀ : Fin r → ℕ} (μ : Fin r → ℂ)
     (B : (k : Fin r) → MPSTensor (d * d) (dim₀ k))
@@ -417,10 +415,9 @@ theorem sameMPV₂_diagonalTensor_verticalAssembledTensor_of_equiv
 with one scalar weight per block has the same positive-length MPV family as an
 assembly that repeats each block with several scalar weights.
 
-This is a conditional comparison lemma.  In arXiv:1606.00608, Proposition
-4.13 (source label Prop:IV.12), lines 1895--1921, the repeated weights instead
-arise by grouping the already constructed vertical canonical sectors; that
-source step is expressed by
+This is a conditional comparison lemma. In arXiv:1606.00608, Proposition 4.13,
+lines 1895--1921, the repeated weights instead arise by grouping the already
+constructed vertical canonical sectors; that source step is expressed by
 `sameMPV₂_toTensorFromBlocks_verticalAssembledTensor_of_equiv`. -/
 theorem sameMPV₂Pos_toTensorFromBlocks_verticalAssembledTensor_of_power_sums
     {g : ℕ} {dim : Fin g → ℕ} (μ : Fin g → ℂ) (mult : Fin g → ℕ)
@@ -452,9 +449,8 @@ positive-length MPV family as a repeated-block assembly when their scalar
 weights satisfy the stated positive-length power-sum identities.
 
 This conditional result does not construct the vertical grouping in
-arXiv:1606.00608, Proposition 4.13 (source label Prop:IV.12), lines
-1873--1921.  That construction must first identify the vertical BNT sectors
-and their positive weights. -/
+arXiv:1606.00608, Proposition 4.13, lines 1873--1921. That construction must
+first identify the vertical BNT sectors and their positive weights. -/
 theorem sameMPV₂Pos_diagonalTensor_verticalAssembledTensor_of_power_sums
     (M : MPOTensor d D) {g : ℕ} {dim : Fin g → ℕ} (μ : Fin g → ℂ)
     (A : (α : Fin g) → MPSTensor (d * d) (dim α))
@@ -599,8 +595,8 @@ theorem blockwise_insert_eq_of_mpv_agree
     (smul_eq_zero.mp hk).resolve_left hμne
   exact sub_eq_zero.mp hdiff
 
--- The implication `verticalCF_of_horizontalCF` (Proposition 4.13, source label
--- `Prop:IV.12`, of arXiv:1606.00608) — every MPDO in horizontal canonical form is in vertical
+-- The implication `verticalCF_of_horizontalCF` (arXiv:1606.00608,
+-- Proposition 4.13) — every MPDO in horizontal canonical form is in vertical
 -- canonical form — is tracked by the blueprint entry
 -- `thm:vertical_cf_of_horizontal_cf` (currently `\notready`) and will be added
 -- as a theorem together with its proof once the horizontal-to-vertical

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -63,20 +63,18 @@ surrogate for the paper's vertical canonical form.
 * `sameMPV₂Pos_diagonalTensor_verticalAssembledTensor_of_power_sums`:
   a separate positive-length comparison under scalar power-sum identities.
 
-The full passage from horizontal to vertical canonical form
-(arXiv:1606.00608, Proposition 4.13) is still outside this file: its blueprint
-entry `thm:vertical_cf_of_horizontal_cf` is marked `\notready`. The results
-above supply matrix-product-vector identities
-and elementary positivity consequences; the remaining step is an independent
-canonical-form decomposition of the tensor viewed in the vertical direction.
+The results above supply matrix-product-vector identities and elementary
+positivity consequences, but do not give the passage from horizontal to
+vertical canonical form in arXiv:1606.00608, Proposition 4.13. That theorem
+requires an independent canonical-form decomposition of the tensor viewed in
+the vertical direction.
 Its basis cannot be obtained by diagonally restricting the horizontal blocks:
 the finite-dimensional obstruction is proved in
 `TNLean.MPS.MPDO.BiCFDerivation.DiagonalRestrictionCounterexample` and documented
 in `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. A source-faithful
-proof must instead follow arXiv:1606.00608, lines 1873--1921, using MPDO
+argument must instead follow arXiv:1606.00608, lines 1873--1921, using MPDO
 positivity and Lemma L to establish an independent vertical canonical form and
-then proving positivity of its weights. The Lean statement will be introduced
-together with its proof rather than as an empty placeholder.
+then proving positivity of its weights.
 
 ## Module location
 

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -12,7 +12,7 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 This file introduces a block-decomposed version of the vertical canonical-form
 structure used in the MPDO analysis of arXiv:1606.00608, Section 4.4.
 
-The paper's Proposition IV.12 writes the tensor, after a local isometry on the
+Proposition 4.13 (source label `Prop:IV.12`) writes the tensor, after a local isometry on the
 physical indices, as a direct sum
 `⊕_α μ_α ⊗ M_α`, where the `μ_α` are positive diagonal matrices and the
 `M_α` form a basis of normal tensors (BNT). The current repository formalization
@@ -37,7 +37,7 @@ surrogate for the paper's vertical canonical form.
 * `MPSTensor.diagBlock`:
   the diagonal restriction `B ↦ (i ↦ B (i, i))` of a doubled-index block.
 
-## Main results (toward Proposition IV.12)
+## Main results (toward Proposition 4.13)
 
 * `blockwise_insert_eq_of_mpv_agree`:
   Lemma L from the paper's appendix, proved using the block-injective
@@ -64,13 +64,18 @@ surrogate for the paper's vertical canonical form.
   a separate positive-length comparison under scalar power-sum identities.
 
 The full passage from horizontal to vertical canonical form
-(Proposition IV.12 / Proposition 4.13 of arXiv:1606.00608) is still outside
+(Proposition 4.13, source label `Prop:IV.12`, of arXiv:1606.00608) is still outside
 this file: its blueprint entry `thm:vertical_cf_of_horizontal_cf` is marked
-`\notready`. The results above supply the matrix-product-vector and positivity
-groundwork; the remaining step is the basis-of-normal-tensors regrouping of the
-diagonally-restricted blocks (diagonal restriction does not preserve normality),
-together with the resulting weight positivity. The Lean statement will be
-introduced together with its proof rather than as an empty placeholder.
+`\notready`. The results above supply matrix-product-vector identities and elementary
+positivity consequences; the remaining step is an independent canonical-form
+decomposition of the tensor viewed in the vertical direction. Its basis cannot be obtained
+by diagonally restricting the horizontal blocks: the finite-dimensional obstruction
+is proved in `TNLean.MPS.MPDO.BiCFDerivation.DiagonalRestrictionCounterexample` and
+documented in `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. A
+source-faithful proof must instead follow arXiv:1606.00608, lines 1873--1921, using
+MPDO positivity and Lemma L to establish an independent vertical canonical form
+and then proving positivity of its weights. The Lean statement will be introduced
+together with its proof rather than as an empty placeholder.
 
 ## Module location
 
@@ -82,7 +87,7 @@ location matches the existing layering.
 ## References
 
 * [Cirac--Perez-Garcia--Schuch--Verstraete 2017] arXiv:1606.00608,
-  Proposition IV.12 and the auxiliary Lemma L in the appendix
+  Proposition 4.13 (source label `Prop:IV.12`) and the auxiliary Lemma L in the appendix
 -/
 
 open scoped Matrix BigOperators ComplexOrder
@@ -168,7 +173,7 @@ theorem diagonalTensor_apply_eq (M : MPOTensor d D) (i : Fin d) :
 a configuration `σ` equals the MPV of the doubled-index tensor at the diagonal-paired
 configuration `k ↦ (σ k, σ k)`. This lets the horizontal canonical form of
 `M.toMPSTensor` (which constrains all `Fin (d*d)` configurations) be specialized to the
-diagonal configurations seen by `diagonalTensor M`, the first step of Proposition IV.12. -/
+diagonal configurations seen by `diagonalTensor M`, the first step of Proposition 4.13. -/
 theorem mpv_diagonalTensor (M : MPOTensor d D) {N : ℕ} (σ : Fin N → Fin d) :
     MPSTensor.mpv (diagonalTensor M) σ
       = MPSTensor.mpv M.toMPSTensor (fun k => finProdFinEquiv (σ k, σ k)) := by
@@ -593,8 +598,8 @@ theorem blockwise_insert_eq_of_mpv_agree
     (smul_eq_zero.mp hk).resolve_left hμne
   exact sub_eq_zero.mp hdiff
 
--- The implication `verticalCF_of_horizontalCF` (Proposition IV.12 / Proposition 4.13
--- of arXiv:1606.00608) — every MPDO in horizontal canonical form is in vertical
+-- The implication `verticalCF_of_horizontalCF` (Proposition 4.13, source label
+-- `Prop:IV.12`, of arXiv:1606.00608) — every MPDO in horizontal canonical form is in vertical
 -- canonical form — is tracked by the blueprint entry
 -- `thm:vertical_cf_of_horizontal_cf` (currently `\notready`) and will be added
 -- as a theorem together with its proof once the horizontal-to-vertical

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -12,8 +12,8 @@ import TNLean.MPS.SharedInfra.BlockAssembly
 This file introduces a block-decomposed version of the vertical canonical-form
 structure used in the MPDO analysis of arXiv:1606.00608, Section 4.4.
 
-Proposition 4.13 (source label `Prop:IV.12`) writes the tensor, after a local isometry on the
-physical indices, as a direct sum
+Proposition 4.13 (source label `Prop:IV.12`) writes the tensor, after a local
+isometry on the physical indices, as a direct sum
 `⊕_α μ_α ⊗ M_α`, where the `μ_α` are positive diagonal matrices and the
 `M_α` form a basis of normal tensors (BNT). The current repository formalization
 uses canonical-form and BNT data with scalar block weights. We therefore
@@ -64,17 +64,18 @@ surrogate for the paper's vertical canonical form.
   a separate positive-length comparison under scalar power-sum identities.
 
 The full passage from horizontal to vertical canonical form
-(Proposition 4.13, source label `Prop:IV.12`, of arXiv:1606.00608) is still outside
-this file: its blueprint entry `thm:vertical_cf_of_horizontal_cf` is marked
-`\notready`. The results above supply matrix-product-vector identities and elementary
-positivity consequences; the remaining step is an independent canonical-form
-decomposition of the tensor viewed in the vertical direction. Its basis cannot be obtained
-by diagonally restricting the horizontal blocks: the finite-dimensional obstruction
-is proved in `TNLean.MPS.MPDO.BiCFDerivation.DiagonalRestrictionCounterexample` and
-documented in `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. A
-source-faithful proof must instead follow arXiv:1606.00608, lines 1873--1921, using
-MPDO positivity and Lemma L to establish an independent vertical canonical form
-and then proving positivity of its weights. The Lean statement will be introduced
+(Proposition 4.13, source label `Prop:IV.12`, of arXiv:1606.00608) is still
+outside this file: its blueprint entry `thm:vertical_cf_of_horizontal_cf` is
+marked `\notready`. The results above supply matrix-product-vector identities
+and elementary positivity consequences; the remaining step is an independent
+canonical-form decomposition of the tensor viewed in the vertical direction.
+Its basis cannot be obtained by diagonally restricting the horizontal blocks:
+the finite-dimensional obstruction is proved in
+`TNLean.MPS.MPDO.BiCFDerivation.DiagonalRestrictionCounterexample` and documented
+in `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. A source-faithful
+proof must instead follow arXiv:1606.00608, lines 1873--1921, using MPDO
+positivity and Lemma L to establish an independent vertical canonical form and
+then proving positivity of its weights. The Lean statement will be introduced
 together with its proof rather than as an empty placeholder.
 
 ## Module location

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -202,6 +202,38 @@
     product vector of the single-spin block-diagonal assembly.
 \end{proof}
 
+\begin{theorem}[Diagonal restriction need not preserve normality]
+    \label{thm:diagonal_restriction_not_normal}
+    \lean{MPSTensor.horizontalCFData_diagBlock_not_isNormal}
+    \leanok
+    \uses{def:horizontal_cf_mpdo}
+    There is a left-canonical, injective doubled-index tensor satisfying the
+    finite-length block-separation hypothesis whose restriction to the diagonal
+    physical pairs is not normal.  On bond space $\mathbb C^2$, take
+    \[
+        A^{(a,b)}=c_a E_{ab},
+        \qquad c_0=\frac35,\qquad c_1=\frac45.
+    \]
+    Then the four matrices $A^{(a,b)}$ span $M_2(\mathbb C)$ and
+    \[
+        \sum_{a,b}\bigl(A^{(a,b)}\bigr)^*A^{(a,b)}=I.
+    \]
+    For a single block, injectivity also gives finite-length block separation.
+    The diagonal restriction, however, consists only of
+    \[
+        A^{\mathrm{diag}}(0)=\frac35 E_{00},
+        \qquad A^{\mathrm{diag}}(1)=\frac45 E_{11}.
+    \]
+    Every product of these two matrices is diagonal, so no blocking length spans
+    $M_2(\mathbb C)$.
+\end{theorem}
+\begin{proof}\leanok
+    The four nonzero scalar multiples of the matrix units span the full matrix
+    algebra.  The identity
+    $(3/5)^2+(4/5)^2=1$ gives left-canonicality.  After diagonal restriction,
+    every word has vanishing $(0,1)$ entry, whereas $E_{01}$ does not.
+\end{proof}
+
 \begin{lemma}[Diagonal tensor word evaluation]
     \label{lem:eval_word_diagonal_tensor}
     \lean{MPOTensor.evalWord_diagonalTensor}
@@ -471,7 +503,9 @@
     invariant projection for the tensor viewed in the vertical direction.
     Positivity also excludes nontrivial periodic sectors.  The canonical-form
     theorem then gives a new vertical family $(B_k)_{k\in I}$ and weights
-    $\nu_k$ satisfying
+    $\nu_k$.  This family is not obtained by restricting the horizontal blocks
+    to diagonal physical pairs, as
+    Theorem~\ref{thm:diagonal_restriction_not_normal} shows.  Instead it satisfies
     \[
         V^{(N)}\bigl(i\mapsto M^{ii}\bigr)
         =V^{(N)}\Bigl(\textstyle\bigoplus_{k\in I}\nu_k B_k\Bigr).

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -207,9 +207,10 @@
     \lean{MPSTensor.horizontalCFData_diagBlock_not_isNormal}
     \leanok
     \uses{def:horizontal_cf_mpdo}
-    There is a left-canonical, injective doubled-index tensor satisfying the
-    finite-length block-separation hypothesis whose restriction to the diagonal
-    physical pairs is not normal.  On bond space $\mathbb C^2$, take
+    There is a left-canonical, injective doubled-index tensor with a nonzero
+    block weight satisfying the finite-length block-separation hypothesis whose
+    restriction to the diagonal physical pairs is not normal.  On bond space
+    $\mathbb C^2$, take
     \[
         A^{(a,b)}=c_a E_{ab},
         \qquad c_0=\frac35,\qquad c_1=\frac45.

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -232,7 +232,12 @@
     The four nonzero scalar multiples of the matrix units span the full matrix
     algebra.  The identity
     $(3/5)^2+(4/5)^2=1$ gives left-canonicality.  After diagonal restriction,
-    every word has vanishing $(0,1)$ entry, whereas $E_{01}$ does not.
+    \[
+        E_{ii}E_{jj}=\delta_{ij}E_{ii}.
+    \]
+    Hence every word is either zero or a scalar multiple of some $E_{ii}$, and
+    therefore has vanishing $(0,1)$ entry.  Since $E_{01}$ does not, it lies
+    outside the span at every blocking length.
 \end{proof}
 
 \begin{lemma}[Diagonal tensor word evaluation]

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -16,11 +16,10 @@
 
 \section{The source argument}
 
-Proposition~4.13 (source label \path{Prop:IV.12}) of Cirac,
-P\'erez-Garc\'ia, Schuch, and Verstraete concerns a tensor in horizontal
-canonical form that generates positive semidefinite density operators at every
-system size.  Its conclusion is that the same tensor, now viewed in the vertical
-direction, admits a vertical canonical form
+Proposition~4.13 of Cirac, P\'erez-Garc\'ia, Schuch, and Verstraete concerns a
+tensor in horizontal canonical form that generates positive semidefinite
+density operators at every system size. Its conclusion is that the same
+tensor, now viewed in the vertical direction, admits a vertical canonical form
 \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.  The local source is
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex}, lines~1863--1921.
 
@@ -42,9 +41,10 @@ matrices.
 
 \section{A finite-dimensional obstruction}
 
-The stronger assertion suggested in issue
-\href{https://github.com/LionSR/TNLean/issues/2537}{\#2537} is false under the
-stated horizontal canonical-form hypotheses.  On bond space $\mathbb C^2$, let
+The stronger assertion is false under the stated horizontal canonical-form
+hypotheses.\footnote{The correction is tracked in
+\href{https://github.com/LionSR/TNLean/issues/2537}{issue 2537}.}
+On bond space $\mathbb C^2$, let
 \[
     A^{(a,b)}=c_aE_{ab},
     \qquad c_0=\frac35,
@@ -98,6 +98,11 @@ restriction remains useful as an auxiliary identity.  It cannot supply the
 normal blocks of the vertical canonical form.  In particular, Newton--Girard
 identities for scalar weights address only the multiplicity coefficients; they
 cannot restore matrix directions discarded by the restriction $(i,j)\mapsto(i,i)$.
+
+\paragraph{Verdict.}
+This is an open gap: the source-faithful horizontal-to-vertical implication of
+Proposition~4.13 remains unformalized. The diagonal-restriction route is a
+false strengthening and cannot close that gap.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -1,0 +1,105 @@
+\documentclass{article}
+
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{Diagonal Restriction and the Vertical Canonical Form in Proposition 4.13}
+\author{}
+\date{2026-07-09}
+
+\begin{document}
+\maketitle
+
+\section{The source argument}
+
+Proposition~4.13 (source label \path{Prop:IV.12}) of Cirac,
+P\'erez-Garc\'ia, Schuch, and Verstraete concerns a tensor in horizontal
+canonical form that generates positive semidefinite density operators at every
+system size.  Its conclusion is that the same tensor, now viewed in the vertical
+direction, admits a vertical canonical form
+\cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.  The local source is
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex}, lines~1863--1921.
+
+The proof does not restrict each horizontal normal tensor from physical pairs
+$(i,j)$ to diagonal pairs $(i,i)$ and then assert that the restricted tensor is
+normal.  Instead, it constructs a new canonical form in the vertical direction.
+Positivity and the first-site insertion lemma rule out a one-sided invariant
+projection at lines~1873--1887.  Positivity then excludes nontrivial periodic
+sectors at lines~1889--1893.  Only after these two steps does the proof invoke a
+canonical-form decomposition in the vertical direction.  The remainder of the
+argument, lines~1895--1921, proves positivity of its multiplicity weights and
+reduces the corresponding similarities to unitary changes of basis.
+
+The block-injectivity proposition at lines~340--345 has a different role.  It
+separates the normal blocks belonging to one fixed canonical-form decomposition.
+It does not compare horizontal blocks with their diagonal restrictions, and it
+does not imply that injectivity survives deletion of all off-diagonal physical
+matrices.
+
+\section{A finite-dimensional obstruction}
+
+The stronger assertion suggested in issue
+\href{https://github.com/LionSR/TNLean/issues/2537}{\#2537} is false under the
+stated horizontal canonical-form hypotheses.  On bond space $\mathbb C^2$, let
+\[
+    A^{(a,b)}=c_aE_{ab},
+    \qquad c_0=\frac35,
+    \qquad c_1=\frac45,
+    \qquad a,b\in\{0,1\}.
+\]
+The four matrices are nonzero scalar multiples of the matrix units, hence span
+$M_2(\mathbb C)$.  They also satisfy
+\[
+    \sum_{a,b}\bigl(A^{(a,b)}\bigr)^*A^{(a,b)}
+      =\bigl(c_0^2+c_1^2\bigr)I=I.
+\]
+Taking a single horizontal block makes the simultaneous block-separation
+condition identical to ordinary injectivity.  Thus this example satisfies the
+injectivity, left-canonicality, nonzero-weight, and finite-length block-separation
+assumptions in the current horizontal canonical-form structure.
+
+Its diagonal restriction is
+\[
+    A^{\mathrm{diag}}(0)=\frac35E_{00},
+    \qquad
+    A^{\mathrm{diag}}(1)=\frac45E_{11}.
+\]
+Every word in these two matrices is diagonal.  Consequently, no blocking length
+can span $M_2(\mathbb C)$, so the restricted tensor is not normal.  This example
+is formalized in
+\path{TNLean/MPS/MPDO/BiCFDerivation/DiagonalRestrictionCounterexample.lean}.
+
+The example is not presented as a counterexample to Proposition~4.13.  The
+formal horizontal structure records properties of a block decomposition but does
+not assume that the associated tensor generates positive semidefinite operators
+at every length.  That positivity hypothesis is essential in the source proof.
+More importantly, even with positivity available, the proposition constructs a
+new vertical basis of normal tensors rather than reusing the diagonal
+restrictions of the horizontal basis.
+
+\section{The corrected formal target}
+
+A source-faithful proof of Proposition~4.13 should begin with both horizontal
+canonical form and the MPDO positivity hypothesis.  It should then formalize the
+three stages visible in the source:
+\begin{enumerate}
+    \item use positivity and the first-site insertion lemma to rule out one-sided
+      invariant projections in the vertical direction;
+    \item use positivity to rule out nontrivial vertical periods;
+    \item obtain the vertical canonical-form blocks independently, and prove the
+      positivity and unitary normalization of their multiplicity coefficients.
+\end{enumerate}
+The already formalized equality of matrix product vectors after diagonal
+restriction remains useful as an auxiliary identity.  It cannot supply the
+normal blocks of the vertical canonical form.  In particular, Newton--Girard
+identities for scalar weights address only the multiplicity coefficients; they
+cannot restore matrix directions discarded by the restriction $(i,j)\mapsto(i,i)$.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Mathematical correction

The theorem proposed in #2537 is false under the stated horizontal canonical-form hypotheses. On bond space C^2, take

A^(a,b) = c_a E_ab,    c_0 = 3/5,    c_1 = 4/5.

The four doubled-index matrices span M_2(C), satisfy the left-canonical identity, and form a one-block horizontal canonical-form datum with finite-length block separation. Their diagonal restriction consists only of (3/5)E_00 and (4/5)E_11. Every word in the restricted tensor is diagonal, so no blocking length spans the full matrix algebra.

This does not contradict Proposition 4.13. The source uses MPDO positivity and Lemma L to construct an independent canonical form in the vertical direction; it does not obtain the vertical normal tensors by restricting the horizontal blocks to diagonal physical pairs.

Source: Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, Proposition 4.13, source label `Prop:IV.12`, lines 1863–1921.

## Changes

- formalize the matrix-unit counterexample and the failure of normality at every blocking length;
- expose only the capstone theorem as public API, keeping the proof scaffolding private;
- correct the Chapter 21 proof sketch to follow the source order;
- add a paper-gap note separating the false diagonal-restriction route from the genuine positivity-based vertical decomposition.

## Verification

- targeted build of the counterexample module
- direct check of the BiCF derivation aggregate and `TNLean.lean`
- `leanblueprint checkdecls`
- blueprint declaration synchronization
- blueprint PDF build and visual inspection of Chapter 21
- reader-facing prose, line-length, and proof-integrity checks

Closes #2537.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mathematical correction and documentation with a self-contained obstruction proof; no changes to auth, runtime, or critical infrastructure paths.
> 
> **Overview**
> Refutes the claim that **horizontal canonical-form data** forces **normality** of diagonally restricted blocks. A new Lean module proves `horizontalCFData_diagBlock_not_isNormal`: a **C²** matrix-unit tensor with coefficients **3/5** and **4/5** is injective, left-canonical, and satisfies finite block separation, yet `diagBlock` stays diagonal at every blocking length and cannot span off-diagonal directions.
> 
> **`VerticalCF.lean`** and the blueprint are updated so Proposition **4.13** is described as building an **independent vertical** canonical form via MPDO positivity (arXiv:1606.00608, lines 1873–1921), not by restricting horizontal blocks to **(i,i)**. Chapter 20 adds theorem **`thm:diagonal_restriction_not_normal`** and revises the horizontal→vertical proof sketch accordingly. A **`docs/paper-gaps`** note records the false diagonal-BNT route versus the genuine positivity-based decomposition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c655cb69df15f17d208030c5b213b8da6b7f275. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->