### PR TITLE
fix(MPS/Periodic): preserve SectorUnitary re-exports

### DIFF
--- a/TNLean/MPS/Periodic/SectorUnitary.lean
+++ b/TNLean/MPS/Periodic/SectorUnitary.lean
@@ -2,7 +2,7 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.FundamentalTheorem.UnitaryGauge
+import TNLean.MPS.Periodic.Overlap.GaugePhase
 
 /-!
 # Unitary gauges in the periodic theory


### PR DESCRIPTION
Restores the historical import surface of `TNLean.MPS.Periodic.SectorUnitary` after the CFII unitary-gauge refactor.

`SectorUnitary` previously imported `Periodic.Overlap.GaugePhase`, thereby exposing both the shared unitary-gauge theorem and the periodic repeated-block helpers to downstream users. PR #3670 replaced that import by `FundamentalTheorem.UnitaryGauge`, which unintentionally hid the repeated-block declarations from callers using the old import path.

This changes the compatibility module to import `Periodic.Overlap.GaugePhase` again. That module already imports the shared `UnitaryGauge`, so the dependency direction remains acyclic and the full historical surface is restored.

Validation: `lake build TNLean.MPS.Periodic.SectorUnitary`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single import-line change in a compatibility re-export module with no logic edits; build validation is scoped to `TNLean.MPS.Periodic.SectorUnitary`.
> 
> **Overview**
> **`TNLean.MPS.Periodic.SectorUnitary`** again imports **`Periodic.Overlap.GaugePhase`** instead of **`FundamentalTheorem.UnitaryGauge`**, restoring the compatibility module’s historical re-exports (shared unitary-gauge theorem plus periodic repeated-block helpers) for callers that only import `SectorUnitary`.
> 
> Because **`GaugePhase`** already depends on **`UnitaryGauge`**, the dependency graph stays acyclic; only the public names visible through this shim change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d08f639c9084b5fe2b8a1a3b198d0505aab7a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->