### PR TITLE
doc(MPS/MPDO): identify inverse-map sector gap

### DIFF
--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -22,15 +22,19 @@ and `SimpleLocalStructure` gives a canonical sector-reduced family through
 `MPOTensor.ExplicitEtaOperators.ofHayashiMarkov`. That family is not the
 inverse-map family used in Appendix C.2: its trace matrix is identically one,
 whereas the source allows a general primitive trace matrix. The earliest
-remaining result is therefore Lemma `propSN`, which derives from the concrete
-tensor `K` a sector factorization whose cyclic contractions realize `mpo K N`
-for every `N`. The later Proposition `3to4` step assembles those source
+remaining result is therefore Lemma propSN, which derives from the concrete
+tensor `K` a sector factorization satisfying, for every `N`,
+\[
+  \widetilde\sigma^{(N)}(K)
+    = \bigoplus_{k_1,\ldots,k_N}\bigotimes_{n=1}^N \eta_{k_n,k_{n+1}}.
+\]
+The later Proposition 3to4 step assembles those source
 operators into a single translation-invariant positive two-site bond whose
 translated copies commute.
 
 *Proof-state note.* The strongest unconditional conclusion currently available
 starts from `EtaLocalStructureData M`.  To reach it from SAL, one must first
-establish the inverse-map sector factorization of Lemma `propSN` and then
+establish the inverse-map sector factorization of Lemma propSN and then
 construct the neighboring operators carried by `EtaLocalStructureData M`.
 The theorem `hasCommutingForm_of_etaLocalStructure` then gives the global
 commuting-form conclusion.

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -28,12 +28,12 @@ for every `N`. The later Proposition `3to4` step assembles those source
 operators into a single translation-invariant positive two-site bond whose
 translated copies commute.
 
-This is the strongest unconditional forward step currently available.
-The intended future Proposition C.8 proof should first establish the
-inverse-map sector factorization of Lemma `propSN` and then construct
-`EtaLocalStructureData M` from its neighboring operators; the existing
-theorem `hasCommutingForm_of_etaLocalStructure` will then discharge the global
-commuting-form target.
+*Proof-state note.* The strongest unconditional conclusion currently available
+starts from `EtaLocalStructureData M`.  To reach it from SAL, one must first
+establish the inverse-map sector factorization of Lemma `propSN` and then
+construct the neighboring operators carried by `EtaLocalStructureData M`.
+The theorem `hasCommutingForm_of_etaLocalStructure` then gives the global
+commuting-form conclusion.
 
 ## Main declarations
 

--- a/TNLean/MPS/MPDO/CommutingFormBridge.lean
+++ b/TNLean/MPS/MPDO/CommutingFormBridge.lean
@@ -18,17 +18,20 @@ The current repository already exposes the local entropy-side ingredients
 * `MPOTensor.sal_implies_eta_structure`, and
 * `MPOTensor.sal_zcl_implies_rank_one_T`,
 
-and `SimpleLocalStructure` now gives the sector-reduced neighboring operators
-`MPOTensor.ExplicitEtaOperators.ofHayashiMarkov`. The remaining Appendix C.2
-step is no longer merely to write down such sector-local operators; it is to
-assemble the simple-MPDO tensor coordinates into a single translation-invariant
-positive two-site bond whose translated copies commute on all periodic chains
-and realize the MPO on every finite length.
+and `SimpleLocalStructure` gives a canonical sector-reduced family through
+`MPOTensor.ExplicitEtaOperators.ofHayashiMarkov`. That family is not the
+inverse-map family used in Appendix C.2: its trace matrix is identically one,
+whereas the source allows a general primitive trace matrix. The earliest
+remaining result is therefore Lemma `propSN`, which derives from the concrete
+tensor `K` a sector factorization whose cyclic contractions realize `mpo K N`
+for every `N`. The later Proposition `3to4` step assembles those source
+operators into a single translation-invariant positive two-site bond whose
+translated copies commute.
 
 This is the strongest unconditional forward step currently available.
-The intended future Proposition C.8 proof should construct
-`EtaLocalStructureData M` from the SAL hypotheses, using the sector-reduced
-`η_{k,h}` operators and the inverse-map layer; the existing
+The intended future Proposition C.8 proof should first establish the
+inverse-map sector factorization of Lemma `propSN` and then construct
+`EtaLocalStructureData M` from its neighboring operators; the existing
 theorem `hasCommutingForm_of_etaLocalStructure` will then discharge the global
 commuting-form target.
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -79,11 +79,14 @@ is the trace of ηₖₕ. Consequently these two families cannot simply be
 identified.
 
 The earliest missing connection to Appendix C.2 is the conclusion of Lemma
-`propSN`: the inverse-map calculation must produce a sector factorization of
-the concrete tensor `K`, together with neighboring operators whose cyclic
-sector contractions agree with `mpo K N` for every `N`. Only after that
-statement is available can its sector operators be assembled into the common
-two-site bond of Proposition `3to4`.
+propSN: the inverse-map calculation must produce a sector factorization of the
+concrete tensor `K` satisfying, for every `N`,
+\[
+  \widetilde\sigma^{(N)}(K)
+    = \bigoplus_{k_1,\ldots,k_N}\bigotimes_{n=1}^N \eta_{k_n,k_{n+1}}.
+\]
+Only after that identity is available can its sector operators be assembled
+into the common two-site bond of Proposition 3to4.
 
 Lemma C.5 is further isolated to the finite-dimensional Perron–Frobenius step:
 for a primitive nonnegative matrix `T`, constant traces of positive powers are

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -69,12 +69,13 @@ that inverse-map layer for an injective simple MPO tensor, given by
 
 `MPOTensor.ExplicitEtaOperators.ofHayashiMarkov` constructs a canonical family
 directly from the Hayashi decomposition witness as the Kronecker product of
-the sector-indexed neighboring reduced states,
-`tr_C(ρ_right k) ⊗ tr_A(ρ_left h)`. This extraction is strictly weaker than
+the sector-indexed neighboring reduced states: the right reduced state in
+sector k and the left reduced state in sector h. This extraction is strictly
+weaker than
 the paper's `K⁻¹`-based construction: it does not invoke the inverse-map layer
 and its trace matrix is identically one. By contrast, the paper's neighboring
-operators have the generally nonconstant primitive trace matrix
-`T_{k,h} = tr(η_{k,h})`. Consequently these two families cannot simply be
+operators have the generally nonconstant primitive trace matrix whose kh-entry
+is the trace of ηₖₕ. Consequently these two families cannot simply be
 identified.
 
 The earliest missing connection to Appendix C.2 is the conclusion of Lemma

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -67,17 +67,22 @@ that inverse-map layer for an injective simple MPO tensor, given by
 `MPOTensor.inverseTensor`, `MPOTensor.physRealize`, and
 `MPOTensor.physRealizeLeft`.
 
-The target `η_{k,h}` family is populated by
-`MPOTensor.ExplicitEtaOperators.ofHayashiMarkov`, which constructs the family
+`MPOTensor.ExplicitEtaOperators.ofHayashiMarkov` constructs a canonical family
 directly from the Hayashi decomposition witness as the Kronecker product of
 the sector-indexed neighboring reduced states,
-`η_{k,h} := tr_C(ρ_right k) ⊗ tr_A(ρ_left h)`. This extraction is strictly
-weaker than the paper's `K⁻¹`-based construction — it does not invoke the
-injective inverse-map layer — but it supplies a canonical positive
-semidefinite family of the current `ExplicitEtaOperators` type, with trace
-matrix `T_{k,h} = 1`. The remaining connection to the Appendix C.2 proof is
-the identification of this sector-reduced family with the inverse-map
-construction in the original simple-MPDO tensor coordinates.
+`tr_C(ρ_right k) ⊗ tr_A(ρ_left h)`. This extraction is strictly weaker than
+the paper's `K⁻¹`-based construction: it does not invoke the inverse-map layer
+and its trace matrix is identically one. By contrast, the paper's neighboring
+operators have the generally nonconstant primitive trace matrix
+`T_{k,h} = tr(η_{k,h})`. Consequently these two families cannot simply be
+identified.
+
+The earliest missing connection to Appendix C.2 is the conclusion of Lemma
+`propSN`: the inverse-map calculation must produce a sector factorization of
+the concrete tensor `K`, together with neighboring operators whose cyclic
+sector contractions agree with `mpo K N` for every `N`. Only after that
+statement is available can its sector operators be assembled into the common
+two-site bond of Proposition `3to4`.
 
 Lemma C.5 is further isolated to the finite-dimensional Perron–Frobenius step:
 for a primitive nonnegative matrix `T`, constant traces of positive powers are

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -110,7 +110,7 @@ missing result.  Its operators are partial traces of normalized sector states,
 and hence its trace matrix is identically one.  In the source inverse-map
 construction the trace matrix
 \[
-  T_{k,h}=\operatorname{tr}(\eta_{k,h})
+  T_{k,h}=\tr(\eta_{k,h})
 \]
 is a generally nonconstant primitive nonnegative matrix.  Thus the two
 families cannot be identified without an additional theorem; in general they

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -28,9 +28,14 @@ where $B_{n,n+1}\geq 0$ and the translated two-site operators commute
 source file this is Proposition \texttt{3to4},
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1571--1593}.
 
-The proof uses the sector decomposition obtained earlier in Appendix C.2:
+Let
+$\tilde\sigma^{(N)}({\cal K})
+=U^{\dagger\otimes N}\sigma^{(N)}({\cal K})U^{\otimes N}$
+denote the density operator after the local unitary from Lemma
+\texttt{propSN}. The proof uses the sector decomposition obtained earlier in
+Appendix C.2:
 \[
-  \tilde\sigma
+  \tilde\sigma^{(N)}({\cal K})
   =
   \bigoplus_{k_1,\ldots,k_N}
   \bigotimes_{n=1}^N \eta_{k_n,k_{n+1}},
@@ -46,7 +51,7 @@ and the left subspace of site $n+1$. It then defines
   \operatorname{Id}_{H_{R,n+1}^{(k_{n+1})}},
 \]
 regarded as the identity away from sites $n,n+1$. With this definition,
-$\tilde\sigma=\prod_n B_{n,n+1}$ and the commutation of the translated
+$\tilde\sigma^{(N)}({\cal K})=\prod_n B_{n,n+1}$ and the commutation of the translated
 $B$-operators follows from their sector-local action.
 
 \section{Current formalization}
@@ -91,7 +96,7 @@ ${\cal K}^{-1}$ to that state and proves Lemma \texttt{propSN}: the concrete
 tensor ${\cal K}$ has a sector factorization by tensors $r_k$ and $l_k$, and
 the resulting neighboring operators $\eta_{k,h}$ satisfy
 \[
-  \widetilde\sigma^{(N)}({\cal K})
+  \tilde\sigma^{(N)}({\cal K})
   =
   \bigoplus_{k_1,\ldots,k_N}
   \bigotimes_{n=1}^{N}\eta_{k_n,k_{n+1}}

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -84,11 +84,38 @@ bonds from SAL.
 
 \section{Missing step}
 
-After the entropy equality above, two mathematical steps remain.  First, the
-sector operators $\eta_{k,h}$ must be identified with the original tensor
-coordinates.  The translation-invariant bond $B_{n,n+1}$ above must then be
-defined and proved positive, with commuting translates.  Second, one must
-prove the finite-chain realization
+After the entropy equality above, the first missing result is not merely a
+change of coordinates.  The Hayashi witness presently gives the decomposition
+of one reduced state.  The source next applies the inverse tensor
+${\cal K}^{-1}$ to that state and proves Lemma \texttt{propSN}: the concrete
+tensor ${\cal K}$ has a sector factorization by tensors $r_k$ and $l_k$, and
+the resulting neighboring operators $\eta_{k,h}$ satisfy
+\[
+  \widetilde\sigma^{(N)}({\cal K})
+  =
+  \bigoplus_{k_1,\ldots,k_N}
+  \bigotimes_{n=1}^{N}\eta_{k_n,k_{n+1}}
+\]
+for every chain length.  No current declaration states this tensor
+factorization or its all-length contraction identity.
+
+The canonical family
+\leanid{MPOTensor.ExplicitEtaOperators.ofHayashiMarkov} does not supply this
+missing result.  Its operators are partial traces of normalized sector states,
+and hence its trace matrix is identically one.  In the source inverse-map
+construction the trace matrix
+\[
+  T_{k,h}=\operatorname{tr}(\eta_{k,h})
+\]
+is a generally nonconstant primitive nonnegative matrix.  Thus the two
+families cannot be identified without an additional theorem; in general they
+are not equal.
+
+Once the inverse-map sector factorization is available, two further steps
+remain.  First, the translation-invariant bond $B_{n,n+1}$ above must be
+defined in the original physical coordinates and proved positive, with
+commuting translates.  Second, one must transport the cyclic sector identity
+through the local unitary to prove the finite-chain realization
 \[
   \sigma^{(N)}(K)=c_N\prod_{n=1}^N B_{n,n+1}
 \]
@@ -96,8 +123,11 @@ for positive scalars $c_N$.  These two steps construct
 \leanid{MPOTensor.EtaLocalStructureData} from the Appendix C.2 local structure
 of a simple MPDO satisfying SAL.  ZCL is not a hypothesis of this construction.
 
-ZCL enters only after this commuting product form has been obtained, in the
-later step that derives the GSNNCH--ZCL and RFP conclusions.
+The source Proposition \texttt{3to4} assumes SAL, not ZCL.  ZCL enters only
+after this commuting product form has been obtained, in the later step that
+derives the GSNNCH--ZCL and RFP conclusions.  Accordingly, adding ZCL to an
+assembly theorem would not repair the missing inverse-map sector
+factorization.
 
 This is tracked by
 \href{https://github.com/LionSR/TNLean/issues/823}{issue \#823}. Until that


### PR DESCRIPTION
## Mathematical correction

This corrects the remaining-path description for arXiv:1606.00608, Appendix C.2.

The present Hayashi–Markov extraction is a normalized partial-trace family whose trace matrix is identically one. It is not the inverse-map family of Lemma `propSN`, whose generally nonconstant primitive matrix is (T_{k,h}=\operatorname{tr}(\eta_{k,h})) and whose cyclic sector contractions realize the concrete MPO at every chain length.

The corrected order of work is:

1. prove the inverse-map sector factorization and all-length cyclic contraction identity of Lemma `propSN`;
2. define the physical two-site bond and prove positivity and commutation;
3. transport the identity to the original tensor coordinates and obtain the product realization.

The prose also records that Proposition `3to4` assumes SAL alone; ZCL enters only in the subsequent RFP conclusion.

This is a source-alignment correction toward #823 and does not claim to close that issue.

## Source

- `Papers/1606.00608/MPDO-22-12-17-2.tex`, Appendix C.2, Lemma `propSN` and Proposition `3to4`
- `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`

## Verification

- both changed Lean files compile;
- `git diff --check`;
- touched-file 100-column scan;
- standalone paper-gap PDF compilation with `latexmk`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prose and module docstring updates only; no proofs or APIs changed.
> 
> **Overview**
> Aligns Appendix C.2 documentation with the paper: **`ofHayashiMarkov`** is documented as a weaker partial-trace family (trace matrix identically one), **not** the inverse-map **η** from Lemma **`propSN`**, which has a generally nonconstant primitive trace matrix and the all-length cyclic sector contraction on **K̃σ⁽ᴺ⁾(K)**.
> 
> The **remaining proof order** is reframed: first prove **`propSN`** (inverse-map sector factorization + contraction identity for every **N**), then assemble the physical two-site bond (Proposition **`3to4`**), then reach **`EtaLocalStructureData`**; **`hasCommutingForm_of_etaLocalStructure`** is described as the step after that data exists, not as closing the SAL→bond gap.
> 
> The paper-gap note **`cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`** is expanded: explicit **σ̃⁽ᴺ⁾(K)** notation, a dedicated “missing step” on the undeclared **`propSN`** factorization, and clarification that Proposition **`3to4`** assumes **SAL** only—**ZCL** is not part of fixing the inverse-map gap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 495b20c731f85665028f2b62e0e456a95331e914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->