### PR TITLE
feat(MPS/MPDO): formalize Proposition 4.13 positivity step

### DIFF
--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -357,26 +357,27 @@ theorem maxEigenvalue_smul_one_sub_posSemidef [Nonempty n]
   rw [smul_one_sub_hermitian_spectral hM (maxEigenvalue hM)]
   simpa [U, Λ] using hconj
 
-namespace Matrix.PosSemidef
-
 /-- The opposite corner vanishes for a one-sided invariant Hermitian matrix.
 
 More precisely, if `P * H = P * H * P`, then Hermiticity of `H` and `P` gives
 `H * P = P * H * P` by taking adjoints. Thus `(1 - P) * H * P = 0`.
 This is the finite-dimensional operator identity used in arXiv:1606.00608,
 Proposition 4.13, lines 1873--1887 (equation `eq1:proof.IV.12`). -/
-theorem opposite_corner_eq_zero {H P : Matrix n n ℂ} (hH : H.PosSemidef)
+theorem Matrix.IsHermitian.opposite_corner_eq_zero {H P : Matrix n n ℂ}
+    (hH : H.IsHermitian)
     (hP : P.IsHermitian) (hInv : P * H = P * H * P) :
     (1 - P) * H * P = 0 := by
   have hRight : H * P = P * H * P := by
     calc
       H * P = (P * H)ᴴ := by
-        rw [Matrix.conjTranspose_mul, hP.eq, hH.isHermitian.eq]
+        rw [Matrix.conjTranspose_mul, hP.eq, hH.eq]
       _ = (P * H * P)ᴴ := congrArg Matrix.conjTranspose hInv
       _ = P * H * P := by
         rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul, hP.eq,
-          hH.isHermitian.eq, Matrix.mul_assoc]
+          hH.eq, Matrix.mul_assoc]
   rw [Matrix.sub_mul, Matrix.one_mul, Matrix.sub_mul, hRight, sub_self]
+
+namespace Matrix.PosSemidef
 
 /-- The largest eigenvalue of a positive semidefinite matrix is bounded by its
 trace. -/

--- a/TNLean/Algebra/HermitianHelpers.lean
+++ b/TNLean/Algebra/HermitianHelpers.lean
@@ -359,6 +359,25 @@ theorem maxEigenvalue_smul_one_sub_posSemidef [Nonempty n]
 
 namespace Matrix.PosSemidef
 
+/-- The opposite corner vanishes for a one-sided invariant Hermitian matrix.
+
+More precisely, if `P * H = P * H * P`, then Hermiticity of `H` and `P` gives
+`H * P = P * H * P` by taking adjoints. Thus `(1 - P) * H * P = 0`.
+This is the finite-dimensional operator identity used in arXiv:1606.00608,
+Proposition 4.13, lines 1873--1887 (equation `eq1:proof.IV.12`). -/
+theorem opposite_corner_eq_zero {H P : Matrix n n ℂ} (hH : H.PosSemidef)
+    (hP : P.IsHermitian) (hInv : P * H = P * H * P) :
+    (1 - P) * H * P = 0 := by
+  have hRight : H * P = P * H * P := by
+    calc
+      H * P = (P * H)ᴴ := by
+        rw [Matrix.conjTranspose_mul, hP.eq, hH.isHermitian.eq]
+      _ = (P * H * P)ᴴ := congrArg Matrix.conjTranspose hInv
+      _ = P * H * P := by
+        rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul, hP.eq,
+          hH.isHermitian.eq, Matrix.mul_assoc]
+  rw [Matrix.sub_mul, Matrix.one_mul, Matrix.sub_mul, hRight, sub_self]
+
 /-- The largest eigenvalue of a positive semidefinite matrix is bounded by its
 trace. -/
 theorem maxEigenvalue_le_trace_re [Nonempty n]

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -2,8 +2,9 @@
 Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-import TNLean.MPS.MPDO.Defs
+import TNLean.Algebra.HermitianHelpers
 import TNLean.MPS.BNT.Basic
+import TNLean.MPS.MPDO.Defs
 import TNLean.MPS.SharedInfra.BlockAssembly
 
 /-!
@@ -51,7 +52,7 @@ surrogate for the paper's vertical canonical form.
 * `mpv_diagonalTensor_eq_mpo_diag` / `mpv_diagonalTensor_nonneg`:
   the diagonal-tensor MPV equals the density-operator diagonal `⟨σ|ρ^{(N)}(M)|σ⟩`,
   hence is nonnegative when `M` generates an MPDO.
-* `opposite_corner_eq_zero_of_posSemidef` / `mpo_opposite_corner_eq_zero`:
+* `Matrix.PosSemidef.opposite_corner_eq_zero` / `mpo_opposite_corner_eq_zero`:
   the positivity identity `P H = P H P ⇒ (1 - P) H P = 0` used in the first
   step of Proposition 4.13.
 * `mpv_verticalAssembledTensor_eq_sum`:
@@ -232,27 +233,6 @@ theorem mpv_diagonalTensor_nonneg (M : MPOTensor d D) {N : ℕ}
 
 /-! ### Positivity and one-sided invariant projections -/
 
-/-- The opposite corner vanishes for a one-sided invariant Hermitian matrix.
-
-More precisely, if `P * H = P * H * P`, then Hermiticity of `H` and `P` gives
-`H * P = P * H * P` by taking adjoints.  Thus the complementary corner
-`(1 - P) * H * P` vanishes.  This is the finite-dimensional operator identity
-used in the first step of arXiv:1606.00608, Proposition 4.13, lines 1873--1887
-(equation `eq1:proof.IV.12`). -/
-theorem opposite_corner_eq_zero_of_posSemidef {n : Type*} [Fintype n] [DecidableEq n]
-    (H P : Matrix n n ℂ) (hH : H.PosSemidef) (hP : P.IsHermitian)
-    (hInv : P * H = P * H * P) :
-    (1 - P) * H * P = 0 := by
-  have hRight : H * P = P * H * P := by
-    calc
-      H * P = (P * H)ᴴ := by
-        rw [Matrix.conjTranspose_mul, hP.eq, hH.isHermitian.eq]
-      _ = (P * H * P)ᴴ := congrArg Matrix.conjTranspose hInv
-      _ = P * H * P := by
-        rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul, hP.eq,
-          hH.isHermitian.eq, Matrix.mul_assoc]
-  rw [Matrix.sub_mul, Matrix.one_mul, Matrix.sub_mul, hRight, hInv, sub_self]
-
 /-- For an MPDO, a one-sided invariant Hermitian matrix for an `N`-site density
 operator has zero opposite corner.
 
@@ -264,8 +244,8 @@ and Hermiticity of `P`. -/
 theorem mpo_opposite_corner_eq_zero (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
     (P : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) (hP : P.IsHermitian)
     (hInv : P * mpo M N = P * mpo M N * P) :
-    (1 - P) * mpo M N * P = 0 := by
-  exact opposite_corner_eq_zero_of_posSemidef (mpo M N) P (hM N) hP hInv
+    (1 - P) * mpo M N * P = 0 :=
+  Matrix.PosSemidef.opposite_corner_eq_zero (hM N) hP hInv
 
 /-- The vertical transfer map of an MPO tensor:
 `E_vert(X) = Σ_i M^{ii} X (M^{ii})†`. -/

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -232,7 +232,7 @@ theorem mpv_diagonalTensor_nonneg (M : MPOTensor d D) {N : ℕ}
 
 /-! ### Positivity and one-sided invariant projections -/
 
-/-- A one-sided invariant corner of a positive semidefinite matrix is reducing.
+/-- The opposite corner vanishes for a one-sided invariant Hermitian matrix.
 
 More precisely, if `P * H = P * H * P`, then Hermiticity of `H` and `P` gives
 `H * P = P * H * P` by taking adjoints.  Thus the complementary corner
@@ -253,14 +253,14 @@ theorem opposite_corner_eq_zero_of_posSemidef {n : Type*} [Fintype n] [Decidable
           hH.isHermitian.eq, Matrix.mul_assoc]
   rw [Matrix.sub_mul, Matrix.one_mul, Matrix.sub_mul, hRight, hInv, sub_self]
 
-/-- For an MPDO, a one-sided invariant projection of an `N`-site density
+/-- For an MPDO, a one-sided invariant Hermitian matrix for an `N`-site density
 operator has zero opposite corner.
 
 This is equation `eq1:proof.IV.12` in the proof of Proposition 4.13 of
 arXiv:1606.00608, lines 1873--1887.  The subsequent use of Lemma L transfers
 this operator equality back to the tensor blocks; the present lemma isolates
-the positivity argument without adding assumptions beyond the one-sided
-invariance and orthogonality of the projection. -/
+the positivity argument without adding assumptions beyond one-sided invariance
+and Hermiticity of `P`. -/
 theorem mpo_opposite_corner_eq_zero (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
     (P : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) (hP : P.IsHermitian)
     (hInv : P * mpo M N = P * mpo M N * P) :

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -51,6 +51,9 @@ surrogate for the paper's vertical canonical form.
 * `mpv_diagonalTensor_eq_mpo_diag` / `mpv_diagonalTensor_nonneg`:
   the diagonal-tensor MPV equals the density-operator diagonal `⟨σ|ρ^{(N)}(M)|σ⟩`,
   hence is nonnegative when `M` generates an MPDO.
+* `opposite_corner_eq_zero_of_posSemidef` / `mpo_opposite_corner_eq_zero`:
+  the positivity identity `P H = P H P ⇒ (1 - P) H P = 0` used in the first
+  step of Proposition 4.13.
 * `mpv_verticalAssembledTensor_eq_sum`:
   the MPV of the vertical-assembled tensor as a sum over the flattened
   `(block, multiplicity)` index.
@@ -62,6 +65,10 @@ surrogate for the paper's vertical canonical form.
   pointwise block identifications are supplied.
 * `sameMPV₂Pos_diagonalTensor_verticalAssembledTensor_of_power_sums`:
   a separate positive-length comparison under scalar power-sum identities.
+* `blockwise_opposite_insert_eq_of_mpv_agree`:
+  once the two first-site equalities in the positivity argument are supplied,
+  Lemma L transfers them to the opposite corner of every horizontal
+  canonical-form block.
 
 The results above supply matrix-product-vector identities and elementary
 positivity consequences, but do not give the passage from horizontal to
@@ -222,6 +229,43 @@ theorem mpv_diagonalTensor_nonneg (M : MPOTensor d D) {N : ℕ}
     0 ≤ MPSTensor.mpv (diagonalTensor M) σ := by
   rw [mpv_diagonalTensor_eq_mpo_diag]
   exact hM.diag_nonneg
+
+/-! ### Positivity and one-sided invariant projections -/
+
+/-- A one-sided invariant corner of a positive semidefinite matrix is reducing.
+
+More precisely, if `P * H = P * H * P`, then Hermiticity of `H` and `P` gives
+`H * P = P * H * P` by taking adjoints.  Thus the complementary corner
+`(1 - P) * H * P` vanishes.  This is the finite-dimensional operator identity
+used in the first step of arXiv:1606.00608, Proposition 4.13, lines 1873--1887
+(equation `eq1:proof.IV.12`). -/
+theorem opposite_corner_eq_zero_of_posSemidef {n : Type*} [Fintype n] [DecidableEq n]
+    (H P : Matrix n n ℂ) (hH : H.PosSemidef) (hP : P.IsHermitian)
+    (hInv : P * H = P * H * P) :
+    (1 - P) * H * P = 0 := by
+  have hRight : H * P = P * H * P := by
+    calc
+      H * P = (P * H)ᴴ := by
+        rw [Matrix.conjTranspose_mul, hP.eq, hH.isHermitian.eq]
+      _ = (P * H * P)ᴴ := congrArg Matrix.conjTranspose hInv
+      _ = P * H * P := by
+        rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul, hP.eq,
+          hH.isHermitian.eq, Matrix.mul_assoc]
+  rw [Matrix.sub_mul, Matrix.one_mul, Matrix.sub_mul, hRight, hInv, sub_self]
+
+/-- For an MPDO, a one-sided invariant projection of an `N`-site density
+operator has zero opposite corner.
+
+This is equation `eq1:proof.IV.12` in the proof of Proposition 4.13 of
+arXiv:1606.00608, lines 1873--1887.  The subsequent use of Lemma L transfers
+this operator equality back to the tensor blocks; the present lemma isolates
+the positivity argument without adding assumptions beyond the one-sided
+invariance and orthogonality of the projection. -/
+theorem mpo_opposite_corner_eq_zero (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
+    (P : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) (hP : P.IsHermitian)
+    (hInv : P * mpo M N = P * mpo M N * P) :
+    (1 - P) * mpo M N * P = 0 := by
+  exact opposite_corner_eq_zero_of_posSemidef (mpo M N) P (hM N) hP hInv
 
 /-- The vertical transfer map of an MPO tensor:
 `E_vert(X) = Σ_i M^{ii} X (M^{ii})†`. -/
@@ -592,6 +636,38 @@ theorem blockwise_insert_eq_of_mpv_agree
       MPSTensor.insertedTensor Z (A k₀) s = 0 :=
     (smul_eq_zero.mp hk).resolve_left hμne
   exact sub_eq_zero.mp hdiff
+
+/-- **One-sided invariance becomes reduction, block by block.**
+
+Let `Yleft`, `Ycorner`, and `Yright` encode respectively the first-site
+coefficients of `P H⁽ᴺ⁾`, `P H⁽ᴺ⁾ P`, and `H⁽ᴺ⁾ P`.  If the
+one-sided invariance gives agreement of the first two actions, while positivity
+gives agreement of the first and third actions, then Lemma L shows that the
+opposite corner vanishes on every canonical-form block: the `Yright` insertion
+equals the `Ycorner` insertion.
+
+This is the tensor-block conclusion of equation `eq1:proof.IV.12` in
+arXiv:1606.00608, Proposition 4.13, lines 1873--1887.  The two hypotheses are
+precisely the coefficient-level equalities displayed in that equation; they do
+not posit a vertical canonical decomposition. -/
+theorem blockwise_opposite_insert_eq_of_mpv_agree
+    {r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
+    (A : (k : Fin r) → MPSTensor d (dim k))
+    (hCF : HorizontalCFData (d := d) μ A)
+    (Yleft Ycorner Yright : Matrix (Fin d) (Fin d) ℂ)
+    (hInv : MPSTensor.FirstSiteActionAgree
+      (MPSTensor.toTensorFromBlocks (d := d) (μ := μ) A) Yleft Ycorner)
+    (hPos : MPSTensor.FirstSiteActionAgree
+      (MPSTensor.toTensorFromBlocks (d := d) (μ := μ) A) Yleft Yright) :
+    ∀ k, MPSTensor.insertedTensor Yright (A k) =
+      MPSTensor.insertedTensor Ycorner (A k) := by
+  intro k
+  calc
+    MPSTensor.insertedTensor Yright (A k) =
+        MPSTensor.insertedTensor Yleft (A k) :=
+      (blockwise_insert_eq_of_mpv_agree A hCF hPos k).symm
+    _ = MPSTensor.insertedTensor Ycorner (A k) :=
+      blockwise_insert_eq_of_mpv_agree A hCF hInv k
 
 -- The implication `verticalCF_of_horizontalCF` (arXiv:1606.00608,
 -- Proposition 4.13) — every MPDO in horizontal canonical form is in vertical

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -52,7 +52,7 @@ surrogate for the paper's vertical canonical form.
 * `mpv_diagonalTensor_eq_mpo_diag` / `mpv_diagonalTensor_nonneg`:
   the diagonal-tensor MPV equals the density-operator diagonal `⟨σ|ρ^{(N)}(M)|σ⟩`,
   hence is nonnegative when `M` generates an MPDO.
-* `Matrix.PosSemidef.opposite_corner_eq_zero` / `mpo_opposite_corner_eq_zero`:
+* `Matrix.IsHermitian.opposite_corner_eq_zero` / `mpo_opposite_corner_eq_zero`:
   the positivity identity `P H = P H P ⇒ (1 - P) H P = 0` used in the first
   step of Proposition 4.13.
 * `mpv_verticalAssembledTensor_eq_sum`:
@@ -245,7 +245,7 @@ theorem mpo_opposite_corner_eq_zero (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ
     (P : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) (hP : P.IsHermitian)
     (hInv : P * mpo M N = P * mpo M N * P) :
     (1 - P) * mpo M N * P = 0 :=
-  Matrix.PosSemidef.opposite_corner_eq_zero (hM N) hP hInv
+  Matrix.IsHermitian.opposite_corner_eq_zero (hM N).isHermitian hP hInv
 
 /-- The vertical transfer map of an MPO tensor:
 `E_vert(X) = Σ_i M^{ii} X (M^{ii})†`. -/
@@ -634,7 +634,7 @@ theorem blockwise_opposite_insert_eq_of_mpv_agree
     {r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
     (A : (k : Fin r) → MPSTensor d (dim k))
     (hCF : HorizontalCFData (d := d) μ A)
-    (Yleft Ycorner Yright : Matrix (Fin d) (Fin d) ℂ)
+    {Yleft Ycorner Yright : Matrix (Fin d) (Fin d) ℂ}
     (hInv : MPSTensor.FirstSiteActionAgree
       (MPSTensor.toTensorFromBlocks (d := d) (μ := μ) A) Yleft Ycorner)
     (hPos : MPSTensor.FirstSiteActionAgree

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -67,9 +67,10 @@ surrogate for the paper's vertical canonical form.
 * `sameMPV₂Pos_diagonalTensor_verticalAssembledTensor_of_power_sums`:
   a separate positive-length comparison under scalar power-sum identities.
 * `blockwise_opposite_insert_eq_of_mpv_agree`:
-  once the two first-site equalities in the positivity argument are supplied,
-  Lemma L transfers them to the opposite corner of every horizontal
-  canonical-form block.
+  if two pairs of first-site matrices satisfy `FirstSiteActionAgree` with a
+  common left matrix, then the corresponding inserted tensors agree on every
+  horizontal canonical-form block, by two applications of
+  `blockwise_insert_eq_of_mpv_agree`.
 
 The results above supply matrix-product-vector identities and elementary
 positivity consequences, but do not give the passage from horizontal to
@@ -238,9 +239,9 @@ operator has zero opposite corner.
 
 This is equation `eq1:proof.IV.12` in the proof of Proposition 4.13 of
 arXiv:1606.00608, lines 1873--1887.  The subsequent use of Lemma L transfers
-this operator equality back to the tensor blocks; the present lemma isolates
-the positivity argument without adding assumptions beyond one-sided invariance
-and Hermiticity of `P`. -/
+this operator equality back to the tensor blocks. Positivity supplies the
+Hermiticity of the density operator; the algebraic corner argument then uses
+only that Hermiticity, one-sided invariance, and Hermiticity of `P`. -/
 theorem mpo_opposite_corner_eq_zero (M : MPOTensor d D) (hM : IsMPDO M) (N : ℕ)
     (P : Matrix (Fin N → Fin d) (Fin N → Fin d) ℂ) (hP : P.IsHermitian)
     (hInv : P * mpo M N = P * mpo M N * P) :

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -152,7 +152,7 @@
 
 \begin{theorem}[One-sided invariant corners of positive operators]
     \label{thm:mpdo_opposite_corner_zero}
-    \lean{Matrix.PosSemidef.opposite_corner_eq_zero}
+    \lean{Matrix.IsHermitian.opposite_corner_eq_zero}
     \lean{MPOTensor.mpo_opposite_corner_eq_zero}
     \leanok
     \uses{def:mpdo}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -152,7 +152,7 @@
 
 \begin{theorem}[One-sided invariant corners of positive operators]
     \label{thm:mpdo_opposite_corner_zero}
-    \lean{MPOTensor.opposite_corner_eq_zero_of_posSemidef}
+    \lean{Matrix.PosSemidef.opposite_corner_eq_zero}
     \lean{MPOTensor.mpo_opposite_corner_eq_zero}
     \leanok
     \uses{def:mpdo}

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -150,6 +150,56 @@
     of the two first-site insertions.
 \end{proof}
 
+\begin{theorem}[One-sided invariant corners of positive operators]
+    \label{thm:mpdo_opposite_corner_zero}
+    \lean{MPOTensor.opposite_corner_eq_zero_of_posSemidef}
+    \lean{MPOTensor.mpo_opposite_corner_eq_zero}
+    \leanok
+    \uses{def:mpdo}
+    Let $H\geq 0$ and let $P=P^\dagger$.  If
+    \[
+        PH=PHP,
+    \]
+    then
+    \[
+        (\Id-P)HP=0.
+    \]
+    In particular, this conclusion holds for every density operator generated
+    by an MPDO.  This is the operator identity used in the proof of
+    \cite[Proposition~4.13]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Since $H$ and $P$ are Hermitian, taking adjoints gives
+    \[
+        HP=(PH)^\dagger=(PHP)^\dagger=PHP.
+    \]
+    Therefore $(\Id-P)HP=HP-PHP=0$.
+\end{proof}
+
+\begin{theorem}[Blockwise reduction from first-site contractions]
+    \label{thm:blockwise_opposite_insert_eq}
+    \lean{MPOTensor.blockwise_opposite_insert_eq_of_mpv_agree}
+    \leanok
+    \uses{def:block_diagonal_tensor, thm:propblockinj_abstract}
+    Let $\bigoplus_k\mu_kA_k$ be in block-injective canonical form.  Suppose
+    three first-site contractions represent $PH^{(N)}$, $PH^{(N)}P$, and
+    $H^{(N)}P$, respectively.  If the first and second contractions agree for
+    every $N$, and the first and third contractions agree for every $N$, then
+    the insertions representing $H^{(N)}P$ and $PH^{(N)}P$ agree on each block
+    $A_k$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:blockwise_insert_eq_of_mpv_agree}
+    Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree} first identifies the
+    insertions representing $PH^{(N)}$ and $H^{(N)}P$ on each block.  A second
+    application identifies those representing $PH^{(N)}$ and $PH^{(N)}P$.
+    Transitivity gives the stated equality.
+\end{proof}
+
 \begin{lemma}[Matrix product vector of the diagonal tensor]
     \label{lem:mpv_diagonal_tensor}
     \lean{MPOTensor.mpv_diagonalTensor}
@@ -493,7 +543,8 @@
     \label{thm:vertical_cf_of_horizontal_cf}
     \notready
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
-        lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
+        thm:mpdo_opposite_corner_zero, thm:blockwise_opposite_insert_eq,
+        lem:mpv_diagonal_tensor,
         lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg,
         lem:mpv_vertical_assembled,
         lem:vertical_grouping_equiv}
@@ -502,15 +553,19 @@
 
 \begin{proof}
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
-        lem:blockwise_insert_eq_of_mpv_agree, lem:mpv_diagonal_tensor,
+        thm:mpdo_opposite_corner_zero, thm:blockwise_opposite_insert_eq,
+        lem:mpv_diagonal_tensor,
         lem:vertical_grouping_equiv}
-    MPDO positivity and
-    Lemma~\ref{lem:blockwise_insert_eq_of_mpv_agree} exclude a one-sided
-    invariant projection for the tensor viewed in the vertical direction.
-    Positivity also excludes nontrivial periodic sectors.  The canonical-form
-    theorem then gives a new vertical family $(B_k)_{k\in I}$ and weights
-    $\nu_k$.  This family is not obtained by restricting the horizontal blocks
-    to diagonal physical pairs, as
+    Theorem~\ref{thm:mpdo_opposite_corner_zero} gives the positive-operator
+    identity needed to exclude a one-sided invariant projection, and
+    Theorem~\ref{thm:blockwise_opposite_insert_eq} gives its blockwise
+    consequence once the corresponding first-site contractions have been
+    identified.  It remains to identify those contractions with
+    $PH^{(N)}$, $PH^{(N)}P$, and $H^{(N)}P$ for the tensor viewed in the
+    vertical direction.  One must then exclude nontrivial periodic sectors and
+    apply the canonical-form theorem to obtain a new vertical family
+    $(B_k)_{k\in I}$ and weights $\nu_k$.  This family is not obtained by
+    restricting the horizontal blocks to diagonal physical pairs, as
     Theorem~\ref{thm:diagonal_restriction_not_normal} shows.  Instead it satisfies
     \[
         V^{(N)}\bigl(i\mapsto M^{ii}\bigr)

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -99,6 +99,22 @@ normal blocks of the vertical canonical form.  In particular, Newton--Girard
 identities for scalar weights address only the multiplicity coefficients; they
 cannot restore matrix directions discarded by the restriction $(i,j)\mapsto(i,i)$.
 
+The first operator identity at lines~1873--1887 is now formalized: if $H\geq0$,
+$P=P^*$, and $PH=PHP$, then
+\[
+    HP=(PH)^*=(PHP)^*=PHP,
+    \qquad
+    (I-P)HP=0.
+\]
+The corresponding two applications of the first-site insertion lemma are also
+formalized: agreement of the contractions representing $PH^{(N)}$ and
+$PH^{(N)}P$, together with agreement of those representing $PH^{(N)}$ and
+$H^{(N)}P$, forces equality of the opposite-corner insertions on every
+horizontal canonical-form block.  Completing the first stage still requires
+the explicit identification of these three contractions with the rotated
+vertical tensor.  The exclusion of periodic sectors and the independent
+vertical canonical-form construction also remain open.
+
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of
 Proposition~4.13 remains unformalized. The diagonal-restriction route is a


### PR DESCRIPTION
## Mathematical result

This formalizes the first two algebraic ingredients in the positivity argument of arXiv:1606.00608, Proposition 4.13, lines 1873–1887.

- If (H\ge 0), (P=P^\dagger), and (PH=PHP), then Hermiticity gives (HP=PHP), hence ((I-P)HP=0).
- For a block-injective canonical-form family, two applications of Lemma L transfer the corresponding first-site equalities to each horizontal block.

The chapter-20 blueprint records both proved statements with declaration links and proof tags.

This is a source-faithful increment toward #3674, not the full horizontal-to-vertical theorem. Proposition 4.13 remains explicitly unfinished. The next missing statement is the doubled-index rotation/contraction identification relating the abstract first-site actions to (PH^{(N)}), (PH^{(N)}P), and (H^{(N)}P). Exclusion of nontrivial periods and construction of the independent vertical canonical form also remain open.

## Source

- arXiv:1606.00608, Proposition 4.13, lines 1863–1921
- equation `eq1:proof.IV.12`, lines 1873–1887
- `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`

## Verification

- `lake env lean TNLean/MPS/MPDO/VerticalCF.lean`
- `lake build TNLean.MPS.MPDO.VerticalCF`
- proof-integrity scan
- prose check
- blueprint synchronization and declaration checking
- `git diff --check`

Partially addresses #3674.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure Lean formalization and blueprint/documentation updates with no runtime, auth, or data-path changes; main theorem remains explicitly unfinished.
> 
> **Overview**
> Formalizes the **first algebraic steps** of arXiv:1606.00608 Proposition 4.13 (lines 1873–1887): one-sided invariant Hermitian projections and their blockwise tensor consequence.
> 
> Adds **`Matrix.IsHermitian.opposite_corner_eq_zero`**: from Hermitian `H`, `P` and `P * H = P * H * P`, derives `(1 - P) * H * P = 0` via adjoints. **`MPOTensor.mpo_opposite_corner_eq_zero`** instantiates this on MPDO density operators using positivity Hermiticity.
> 
> Adds **`blockwise_opposite_insert_eq_of_mpv_agree`**, which applies existing Lemma L twice so matching first-site actions for `PH^{(N)}`, `PH^{(N)}P`, and `H^{(N)}P` force opposite-corner insertions to agree on every horizontal canonical-form block.
> 
> **Blueprint** chapter 20 gains two `\leanok` theorems with proofs; the still-`\notready` horizontal→vertical theorem proof now cites these lemmas and states what remains (vertical contraction identification, periodic sectors, independent vertical CF). The **paper-gap note** records this increment while keeping the full Proposition 4.13 open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7fc7a6759a8d3e39960b9b2b1605a7669919fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->