### PR TITLE
fix(MPS/MPDO): isolate the missing ZCL rank-one input

### DIFF
--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.Matrix.PosDef
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
+import Mathlib.LinearAlgebra.Projection
+import Mathlib.LinearAlgebra.Trace
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Ring
@@ -24,6 +26,11 @@ positive powers, then it factors as an outer product.  Primitivity is not needed
 for this strengthened statement; it remains among the surrounding MPDO
 hypotheses because it is part of the paper's construction of the auxiliary
 matrix `T`.
+
+The theorem `Matrix.hasRankOneFactorization_of_mul_self_eq_self` records the
+alternative exact condition suggested by the operator-valued ZCL identity: an
+idempotent trace-one matrix is the projection onto a one-dimensional range and
+therefore factors as an outer product.
 -/
 
 open scoped BigOperators Matrix ComplexOrder
@@ -58,6 +65,43 @@ has trace one. -/
 def PrimitiveTracePowersConstantImpliesRankOne
     (T : Matrix (Fin n) (Fin n) ℝ) : Prop :=
   Matrix.IsPrimitive T → TracePowersConstant T → HasRankOneFactorization T
+
+/-- An idempotent real matrix of trace one has a rank-one factorization.
+
+This criterion excludes precisely the nilpotent generalized zero-eigenspace
+which is invisible to traces of powers.  It is the algebraic conclusion needed
+after retaining the operator-valued ZCL identity in arXiv:1606.00608,
+Appendix C.2, lines 1489--1497. -/
+theorem hasRankOneFactorization_of_mul_self_eq_self
+    {T : Matrix (Fin n) (Fin n) ℝ}
+    (hTT : T * T = T) (hTrace : Matrix.trace T = 1) :
+    HasRankOneFactorization T := by
+  classical
+  let f : (Fin n → ℝ) →ₗ[ℝ] (Fin n → ℝ) := Matrix.toLin' T
+  have hf : IsIdempotentElem f := by
+    change Matrix.toLin' T ∘ₗ Matrix.toLin' T = Matrix.toLin' T
+    rw [← Matrix.toLin'_mul, hTT]
+  have hrank : Module.finrank ℝ (LinearMap.range f) = 1 := by
+    have h := (LinearMap.isProj_range_iff_isIdempotentElem f).2 hf |>.trace
+    rw [Matrix.trace_toLin'_eq, hTrace] at h
+    exact_mod_cast h.symm
+  rcases finrank_eq_one_iff'.mp hrank with ⟨u, hu, hspan⟩
+  let b : Fin n → ℝ := fun j ↦
+    Classical.choose (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
+  refine ⟨u.1, b, ?_⟩
+  ext i j
+  have hb := Classical.choose_spec
+    (hspan ⟨f (Pi.single j 1), LinearMap.mem_range_self f _⟩)
+  have hb' := congrArg (fun x : LinearMap.range f ↦ x.1 i) hb
+  have heval : f (Pi.single j 1) i = T i j := by
+    simp only [f, Matrix.toLin'_apply, Matrix.mulVec, dotProduct]
+    rw [Fintype.sum_eq_single j]
+    · simp
+    · intro x hx
+      simp [hx]
+  change Classical.choose _ * u.1 i = f (Pi.single j 1) i at hb'
+  rw [heval] at hb'
+  simpa [b, Matrix.vecMulVec_apply, mul_comm] using hb'.symm
 
 /-- A finite family of nonnegative real numbers with sum and sum of squares both
 one has exactly one nonzero entry, and that entry is one. -/

--- a/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
+++ b/TNLean/Archive/PerronFrobeniusRankOneCounterexample.lean
@@ -123,6 +123,14 @@ theorem T_tracePowersConstant :
   · interval_cases k; simp
   · rw [T_pow_eq_P k h, trace_T, trace_P]
 
+/-- The counterexample also satisfies the consequence `T ^ 2 = T ^ 3` of the
+operator-valued ZCL identity in arXiv:1606.00608, Appendix C.2, lines
+1489--1497.  Indeed, writing `T = R L`, the displayed identity
+`L R = (L R) ^ 2` gives only `T ^ 2 = T ^ 3`; it does not give
+`T = T ^ 2`. -/
+theorem T_sq_eq_cube : T ^ 2 = T ^ 3 := by
+  rw [T_pow_eq_P 2 (by norm_num), T_pow_eq_P 3 (by norm_num)]
+
 /-- `T` has no rank-one factorization. -/
 theorem T_not_rankOne : ¬ ∃ a b : Fin 3 → ℝ, T = Matrix.vecMulVec a b := by
   rintro ⟨a, b, hT⟩
@@ -152,5 +160,16 @@ theorem counterexample :
       (∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T) ∧
       ¬ ∃ a b : Fin 3 → ℝ, T = Matrix.vecMulVec a b :=
   ⟨T_isPrimitive, T_tracePowersConstant, T_not_rankOne⟩
+
+/-- Even the matrix consequence of the operator-valued ZCL identity does not
+repair the Perron--Frobenius step: the same primitive trace-normalized matrix
+has constant traces, satisfies `T ^ 2 = T ^ 3`, and is not an outer product. -/
+theorem counterexample_with_zcl_operator_consequence :
+    Matrix.IsPrimitive T ∧
+      Matrix.trace T = 1 ∧
+      (∀ k : ℕ, 0 < k → Matrix.trace (T ^ k) = Matrix.trace T) ∧
+      T ^ 2 = T ^ 3 ∧
+      ¬ ∃ a b : Fin 3 → ℝ, T = Matrix.vecMulVec a b :=
+  ⟨T_isPrimitive, trace_T, T_tracePowersConstant, T_sq_eq_cube, T_not_rankOne⟩
 
 end TNLean.Archive.PerronFrobeniusRankOneCounterexample

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -291,6 +291,26 @@ strong subadditivity for a normalized three-site reduced state.
     outer-product factorization.
 \end{proof}
 
+\begin{theorem}[Idempotent trace-one criterion]
+    \label{thm:matrix_idempotent_trace_one_rank_one}
+    \lean{Matrix.hasRankOneFactorization_of_mul_self_eq_self}
+    \leanok
+    Let $T$ be a finite real square matrix. If
+    \[
+        T^2=T,
+        \qquad \operatorname{tr}(T)=1,
+    \]
+    then there are real vectors $a,b$ such that $T=a b^\top$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    The endomorphism defined by $T$ is a projection onto its range. Its trace
+    is therefore the dimension of that range, which is one. Choosing a
+    nonzero vector spanning the range expresses every column of $T$ as a
+    scalar multiple of that vector and gives the required outer product.
+\end{proof}
+
 % Unfaithful: thm:sal_zcl_implies_rank_one_t mirrors the Lean theorem
 % MPOTensor.sal_zcl_implies_rank_one_T, whose conditional Perron--Frobenius
 % hypothesis is false as a universal statement (counterexample in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -305,8 +305,8 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    The endomorphism defined by $T$ is a projection onto its range. Its trace
-    is therefore the dimension of that range, which is one. Choosing a
+    The endomorphism defined by $T$ is idempotent, so its trace is the
+    dimension of its range. That dimension is one. Choosing a
     nonzero vector spanning the range expresses every column of $T$ as a
     scalar multiple of that vector and gives the required outer product.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -305,10 +305,14 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}
     \leanok
-    The endomorphism defined by $T$ is idempotent, so its trace is the
-    dimension of its range. That dimension is one. Choosing a
-    nonzero vector spanning the range expresses every column of $T$ as a
-    scalar multiple of that vector and gives the required outer product.
+    \uses{def:matrix_trace_rankone_predicates}
+    For an idempotent endomorphism $f$ one has
+    \[
+        \operatorname{tr}(f)=\dim(\operatorname{range}(f)).
+    \]
+    Hence the range of $T$ has dimension one. Choosing a nonzero vector $a$
+    spanning it expresses every column of $T$ as $b_j a$ for a scalar $b_j$,
+    and therefore $T=ab^\top$.
 \end{proof}
 
 % Unfaithful: thm:sal_zcl_implies_rank_one_t mirrors the Lean theorem

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -109,6 +109,36 @@ $(xy^{\top})^2=0$ and is annihilated by $P$ on both sides. It therefore
 leaves all traces of positive powers unchanged from the Perron projector while
 raising the rank of $T$.
 
+\section{What the operator-valued ZCL identity implies}
+
+The source uses more than the trace equalities before passing to
+Perron--Frobenius theory.  With $L e_k=l_k$ and
+$(R v)_k=(r_k\mid v)$, one has $T=RL$, while the displayed ZCL identity in
+lines 1489--1493 is
+\[
+  LR=L(RL)R=(LR)^2.
+\]
+This identity makes the operator $LR$ idempotent.  Multiplication on the left
+by $R$ and on the right by $L$ gives only
+\[
+  T^2=T^3,
+\]
+not $T=T^2$.  The counterexample above already satisfies this weaker identity:
+$T^2=T^3=P$.  Thus retaining the displayed operator equation, without a
+further property of the inverse-map families $l_k$ and $r_k$, does not remove
+the nilpotent part of $T$.
+
+The exact sufficient conclusion is transparent.  If the inverse-map
+construction were shown to give $T^2=T$, then $T$ itself would be idempotent.
+An idempotent real matrix has trace equal to the dimension of its range;
+hence trace one makes that range one-dimensional and gives
+$T=a b^{\top}$.  This argument is formalized as
+\leanid{Matrix.hasRankOneFactorization_of_mul_self_eq_self}.  The remaining
+source-faithful task is therefore to derive $T^2=T$, or another condition
+excluding the generalized zero-eigenspace, from a property of the concrete
+inverse-map tensors not currently recorded in
+\leanid{MPOTensor.ExplicitEtaOperators}.
+
 \section{The corrected statement}
 
 The formal development proves a corrected sufficient matrix theorem. Let $T$


### PR DESCRIPTION
## Mathematical correction

This isolates the exact unresolved step in arXiv:1606.00608, Lemma C.5.

Writing (L e_k=l_k), ((Rv)_k=(r_k\mid v)), and (T=RL), the displayed operator identity at lines 1489–1493 is
[
LR=(LR)^2.
]
Multiplying by (R) and (L) yields only
[
T^2=T^3,
]
not (T=T^2).

The archived primitive trace-one counterexample already satisfies (T^2=T^3), has constant traces of all positive powers, and nevertheless has rank two. This PR formalizes that strengthened counterexample. It also proves the exact sufficient replacement: an idempotent real matrix of trace one has one-dimensional range and therefore an outer-product factorization.

The paper-gap note and Chapter 21 blueprint now state this distinction explicitly. No PSD/Gram hypothesis is introduced, and the unfaithful conditional theorem is not relabelled as complete.

This advances #3593 but does not close it. The remaining source-faithful task is to find an additional property of the concrete inverse-map tensors that excludes the generalized zero-eigenspace, or directly proves (T^2=T).

## Source

- arXiv:1606.00608, Appendix C.2, Lemma C.5, lines 1484–1502
- `docs/paper-gaps/cpgsv17_pf_rank_one.tex`

## Verification

- targeted Lean checks;
- full `lake build` (9,271 jobs);
- blueprint synchronization and `leanblueprint checkdecls`;
- reader-facing prose and diff checks;
- no new `sorry`, axiom, or kernel bypass.

Partially addresses #3593.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds Lean proofs and documentation around an already-archived counterexample; no runtime, auth, or data-path changes.
> 
> **Overview**
> Clarifies that the operator-valued ZCL identity in Appendix C.2 yields only **\(T^2 = T^3\)** on the trace matrix \(T = RL\), not idempotence \(T^2 = T\), and that this weaker condition does not fix the known Perron–Frobenius rank-one gap.
> 
> The archive counterexample is extended with **`T_sq_eq_cube`** and **`counterexample_with_zcl_operator_consequence`**, showing the same primitive, trace-normalized matrix still has constant positive-power traces, satisfies \(T^2 = T^3\), and is not an outer product. Lean adds **`Matrix.hasRankOneFactorization_of_mul_self_eq_self`**: a real matrix with \(T^2 = T\) and \(\operatorname{tr}(T)=1\) has one-dimensional range and factors as \(ab^\top\).
> 
> The Chapter 21 blueprint gains the idempotent trace-one theorem, and **`docs/paper-gaps/cpgsv17_pf_rank_one.tex`** documents the ZCL implication versus the sufficient \(T^2=T\) condition. The open source-faithful step is to derive idempotence (or another hypothesis excluding the nilpotent zero eigenspace) from the concrete inverse-map tensors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c72da9ef2f49e3cd2f93d0a3f9e1509c4c5967e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->