### PR TITLE
feat(MPS/RFP): construct Appendix B physical isometry

### DIFF
--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -248,6 +248,107 @@ structure AppendixBStructuralData (A : MPSTensor d D) where
   /-- The original tensor has the Appendix B structural form. -/
   hA_eq : ∀ i, A i = X * Matrix.diagonal (fun k => (Λ k : ℂ)) * U i * X⁻¹
 
+/-! ### The physical isometry in the basic-vector expression -/
+
+/-- The physical isometry \(U:\mathcal H_a\otimes\mathcal H_b\to
+\mathcal H_{\mathrm{phys}}\) in the Appendix B basic-vector expression.
+
+The virtual tensor product is written in the basis indexed by pairs
+\((\alpha,\beta)\). Thus a vector is a function on
+`Fin D × Fin D`, and its image has coefficient
+
+\[
+  (Uv)_i=\sum_{\alpha,\beta}U^i_{\alpha,\beta}v_{\alpha,\beta}.
+\]
+
+Source: arXiv:1606.00608, Theorem 3.11 and lines 543--578. -/
+noncomputable def AppendixBStructuralData.physicalIsometry
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    ((Fin D × Fin D → ℂ) →ₗ[ℂ] (Fin d → ℂ)) where
+  toFun v i := ∑ p : Fin D × Fin D, hStruct.U i p.1 p.2 * v p
+  map_add' v w := by
+    funext i
+    simp only [Pi.add_apply, mul_add, Finset.sum_add_distrib]
+  map_smul' c v := by
+    funext i
+    change (∑ p : Fin D × Fin D, hStruct.U i p.1 p.2 * (c * v p)) =
+      c * ∑ p : Fin D × Fin D, hStruct.U i p.1 p.2 * v p
+    calc
+      _ = ∑ p : Fin D × Fin D, c * (hStruct.U i p.1 p.2 * v p) := by
+        apply Finset.sum_congr rfl
+        intro p _
+        ring
+      _ = _ := by rw [Finset.mul_sum]
+
+/-- The coefficient map \(U^*:\mathcal H_{\mathrm{phys}}\to
+\mathcal H_a\otimes\mathcal H_b\) associated with the Appendix B physical
+isometry.
+
+Source: arXiv:1606.00608, isometry equation (3.16), lines 549--554. -/
+noncomputable def AppendixBStructuralData.physicalIsometryLeftInverse
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    ((Fin d → ℂ) →ₗ[ℂ] (Fin D × Fin D → ℂ)) where
+  toFun ψ p := ∑ i : Fin d, star (hStruct.U i p.1 p.2) * ψ i
+  map_add' ψ φ := by
+    funext p
+    simp only [Pi.add_apply, mul_add, Finset.sum_add_distrib]
+  map_smul' c ψ := by
+    funext p
+    change (∑ i : Fin d, star (hStruct.U i p.1 p.2) * (c * ψ i)) =
+      c * ∑ i : Fin d, star (hStruct.U i p.1 p.2) * ψ i
+    calc
+      _ = ∑ i : Fin d, c * (star (hStruct.U i p.1 p.2) * ψ i) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        ring
+      _ = _ := by rw [Finset.mul_sum]
+
+/-- The source pair-index isometry equation says that \(U^*U=1\).
+
+Source: arXiv:1606.00608, isometry equation (3.16), lines 549--554. -/
+@[simp] theorem AppendixBStructuralData.physicalIsometryLeftInverse_comp
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.physicalIsometryLeftInverse.comp hStruct.physicalIsometry = 1 := by
+  classical
+  apply LinearMap.ext
+  intro v
+  funext p
+  change (∑ i : Fin d, star (hStruct.U i p.1 p.2) *
+      ∑ q : Fin D × Fin D, hStruct.U i q.1 q.2 * v q) = v p
+  calc
+    _ = ∑ i : Fin d, ∑ q : Fin D × Fin D,
+        (star (hStruct.U i p.1 p.2) * hStruct.U i q.1 q.2) * v q := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro q _
+      simp only [mul_assoc]
+    _ = ∑ q : Fin D × Fin D, ∑ i : Fin d,
+        (star (hStruct.U i p.1 p.2) * hStruct.U i q.1 q.2) * v q :=
+      Finset.sum_comm
+    _ = ∑ q : Fin D × Fin D, (∑ i : Fin d,
+        star (hStruct.U i p.1 p.2) * hStruct.U i q.1 q.2) * v q := by
+      apply Finset.sum_congr rfl
+      intro q _
+      rw [Finset.sum_mul]
+    _ = v p := by
+      simp_rw [hStruct.hU_pair p]
+      simp
+
+/-- The physical map in the Appendix B basic-vector expression is injective.
+
+Source: arXiv:1606.00608, Theorem 3.11 and isometry equation (3.16), lines
+543--578. -/
+theorem AppendixBStructuralData.physicalIsometry_injective
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Function.Injective hStruct.physicalIsometry := by
+  intro v w hvw
+  have hv := LinearMap.congr_fun hStruct.physicalIsometryLeftInverse_comp v
+  have hw := LinearMap.congr_fun hStruct.physicalIsometryLeftInverse_comp w
+  have hvw' := congrArg hStruct.physicalIsometryLeftInverse hvw
+  exact hv.symm.trans (hvw'.trans hw)
+
 /-- The proved structural form gives a nonempty bundled Appendix B form. -/
 theorem AppendixBStructuralData.exists_ofRFP (A : MPSTensor d D) [NeZero D]
     (hNT : IsNormal A) (hRFP : IsRFP A)

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -998,6 +998,56 @@ the specialization $L=2$.
     Substituting $\alpha_L=\alpha_0$ in the trace gives the cyclic formula.
 \end{proof}
 
+\begin{definition}[Physical isometry in the basic-vector expression]
+    \label{def:appendixB_physical_isometry}
+    \lean{MPSTensor.AppendixBStructuralData.physicalIsometry}
+    \lean{MPSTensor.AppendixBStructuralData.physicalIsometryLeftInverse}
+    \leanok
+    Let $\mathcal H_a$ and $\mathcal H_b$ have bases indexed by
+    $\alpha,\beta\in\{0,\ldots,D-1\}$.  The coefficients
+    $U^i_{\alpha,\beta}$ in the Appendix~B basic-vector expression define maps
+    \[
+        U:\mathcal H_a\otimes\mathcal H_b\longrightarrow
+            \mathcal H_{\mathrm{phys}},
+        \qquad
+        (Uv)_i=\sum_{\alpha,\beta}U^i_{\alpha,\beta}v_{\alpha,\beta},
+    \]
+    and
+    \[
+        (U^*\psi)_{\alpha,\beta}
+        =\sum_i\overline{U^i_{\alpha,\beta}}\,\psi_i.
+    \]
+\end{definition}
+
+\begin{theorem}[The physical map is an isometric embedding]
+    \label{thm:appendixB_physical_isometry_left_inverse}
+    \lean{MPSTensor.AppendixBStructuralData.physicalIsometryLeftInverse_comp}
+    \lean{MPSTensor.AppendixBStructuralData.physicalIsometry_injective}
+    \leanok
+    \uses{def:appendixB_physical_isometry}
+    The pair-index isometry equation
+    \[
+        \sum_i\overline{U^i_{\alpha,\beta}}
+          U^i_{\alpha',\beta'}
+        =\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}
+    \]
+    implies $U^*U=1$.  In particular, $U$ is injective.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Expanding the coefficient of $U^*Uv$ at $(\alpha,\beta)$ and interchanging
+    the two finite sums gives
+    \[
+        (U^*Uv)_{\alpha,\beta}
+        =\sum_{\alpha',\beta'}
+          \left(\sum_i\overline{U^i_{\alpha,\beta}}
+            U^i_{\alpha',\beta'}\right)v_{\alpha',\beta'}
+        =v_{\alpha,\beta}.
+    \]
+    A map with a left inverse is injective.
+\end{proof}
+
 \begin{theorem}[Appendix B basis change and the parent interaction]
     \label{lem:appendixB_basis_change_parent_interaction}
     \lean{MPSTensor.AppendixBStructuralData.parentInteraction_eq_coreTensor}

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1003,9 +1003,13 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.physicalIsometry}
     \lean{MPSTensor.AppendixBStructuralData.physicalIsometryLeftInverse}
     \leanok
-    Let $\mathcal H_a$ and $\mathcal H_b$ have bases indexed by
-    $\alpha,\beta\in\{0,\ldots,D-1\}$.  The coefficients
-    $U^i_{\alpha,\beta}$ in the Appendix~B basic-vector expression define maps
+    Suppose that $A$ is equipped with Appendix~B structural data
+    $(X,\Lambda,U)$: the matrix $X$ is invertible, the diagonal entries of
+    $\Lambda$ are strictly positive,
+    $A^i=X\Lambda U^iX^{-1}$, and $U$ satisfies the pair-index isometry
+    equation below.  Let $\mathcal H_a$ and $\mathcal H_b$ have bases indexed
+    by $\alpha,\beta\in\{0,\ldots,D-1\}$.  The coefficients
+    $U^i_{\alpha,\beta}$ define maps
     \[
         U:\mathcal H_a\otimes\mathcal H_b\longrightarrow
             \mathcal H_{\mathrm{phys}},
@@ -1025,7 +1029,9 @@ the specialization $L=2$.
     \lean{MPSTensor.AppendixBStructuralData.physicalIsometry_injective}
     \leanok
     \uses{def:appendixB_physical_isometry}
-    The pair-index isometry equation
+    Let $A$ be equipped with Appendix~B structural data $(X,\Lambda,U)$ as in
+    Definition~\ref{def:appendixB_physical_isometry}.  Its pair-index
+    isometry equation
     \[
         \sum_i\overline{U^i_{\alpha,\beta}}
           U^i_{\alpha',\beta'}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -115,16 +115,29 @@ For the forward RFP-to-NNCPH direction, the three-site \(AX/XB\) support maps
 are now represented in \leanid{MPSTensor.HasOverlappingTwoSiteCommutation};
 Appendix~B supplies the basic-vector form, while the projectors
 \(Q_{AX}\) and \(Q_{XB}\) belong to the Appendix~D.2 parent-commuting
-condition.  The coefficient-space representatives
+condition.  The coefficients in the basic-vector form now define the physical
+isometry
+\begin{align}
+  (Uv)_i=\sum_{\alpha,\beta}U^i_{\alpha,\beta}v_{\alpha,\beta},
+  \qquad U^*U=1,
+\end{align}
+recorded by
+\leanid{MPSTensor.AppendixBStructuralData.physicalIsometry} and
+\leanid{MPSTensor.AppendixBStructuralData.physicalIsometryLeftInverse_comp}.
+The coefficient-space representatives
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace} are now identified with
 the canonical two-site parent interaction \(q_2(A)\) before placement on the
 \(AX\) and \(XB\) faces.  They should not be read as the source tripartite
 projectors themselves.  A supplied lifted commutator for these representatives
 has been transported to the first two translated three-site parent terms.  The
-remaining local step is to construct the source Appendix~D.2 data from the
-Appendix~B basic-vector form, relate its \(Q_{AX},Q_{XB}\) projectors to these
-coefficient representatives, prove the lifted \(AX/XB\) commutator, and extend
+remaining local step is to form the tensor powers of this physical embedding,
+transport the rank-one projector onto
+\(\varphi=\sum_m\lambda_m|m,m\rangle\) to the two adjacent bonds, identify the
+resulting two-site ranges with \(G_2(A_{\mathrm{core}})\), and hence identify
+their complementary projectors with the coefficient representatives above.
+Only after these range equalities are proved does the disjoint-bond
+commutation give the lifted \(AX/XB\) commutator.  One must then extend
 the local transport to the all-chain family of two-site parent projectors.  On
 the coefficient side, the source statement is the basic-vector formula
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), where
@@ -158,10 +171,13 @@ basis of normal tensors of $A$.\footnote{Tracked by \ghissue{2633}.}
 
 The current proof boundary is therefore: the reverse implication has the
 source ground-space hypothesis, but its proof is still the Beigi axiom; the
-forward implication has the source-unit Appendix~B structural datum, the
-three-site \(AX/XB\) support maps, and the coefficient form of
-\(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks the construction of the
-source Appendix~D.2 projectors and their lifted commutator from that datum,
+forward implication has the source-unit Appendix~B structural datum, its
+physical isometric embedding with explicit left inverse, the three-site
+\(AX/XB\) support maps, and the coefficient form of
+\(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks tensor-product maps for
+the virtual factors, the transported bond projectors, the equality of their
+ranges with the two-site local ground spaces, and the resulting lifted
+commutator,
 the local-projector hypotheses for all chains of length at least two, and a
 justified relation between the source formula and the even-chain physical-pair
 factorization used by the conditional theorem.

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -75,6 +75,13 @@ is now recorded by
 projection gives the algebraic overlapping-commutation predicate.  What remains
 outside this local package is the orthogonal-projector identification and the
 construction of \(Q_{AX}\) and \(Q_{XB}\) from the Appendix~B basic-vector form.
+The scalar pair-index equation has now been assembled into the physical map
+\begin{align}
+  (Uv)_i=\sum_{\alpha,\beta}U^i_{\alpha,\beta}v_{\alpha,\beta},
+  \qquad U^*U=1,
+\end{align}
+in \leanid{MPSTensor.AppendixBStructuralData.physicalIsometry} and
+\leanid{MPSTensor.AppendixBStructuralData.physicalIsometryLeftInverse_comp}.
 The elementary passage from \(Q_{AX},Q_{XB}\) to their complements
 \(1-Q_{AX},1-Q_{XB}\) is recorded by
 \leanid{MPSTensor.HasOverlappingTwoSiteCommutation.complement}.  The
@@ -101,9 +108,14 @@ and
 \section{Elimination plan}
 
 A source-faithful version should build on the existing \(AX/XB\) support layer
-by constructing the local subspaces \(K_{AX}\) and \(K_{XB}\), the corresponding
-orthogonal projectors \(Q_{AX}\) and \(Q_{XB}\), and the source
-orthogonal-projector hypotheses from the Appendix~B data.  It should then
+by constructing tensor-product maps for the virtual factors and transporting
+the rank-one projector onto
+\(\varphi=\sum_m\lambda_m|m,m\rangle\) through the physical isometry.  The
+ranges of the resulting two-site maps must be proved equal to the local spaces
+\(K_{AX}\) and \(K_{XB}\); their complementary orthogonal projectors then give
+\(Q_{AX}\) and \(Q_{XB}\).  Commutation follows at the virtual level because
+the two bond projectors act on distinct bonds, and must then be transported to
+the common three-site physical space.  It should finally
 explain why their coefficient representatives are the two lifted copies of
 \(q_2(A)\), prove the lifted commutator, and derive the idempotent-product
 declaration above as a lemma, with \(P_K=P_{AXB}\).


### PR DESCRIPTION
### Motivation

- Formalize the first unconditional linear maps in the Appendix B basic-vector construction (arXiv:1606.00608, §3.3, Appendix B and Definition D.2), advancing #3373.
- From the pair-index coefficients $U^i_{\alpha,\beta}$, define the physical map $U : \mathcal{H}_a \otimes \mathcal{H}_b \to \mathcal{H}_{\mathrm{phys}}$, $(Uv)_i = \sum_{\alpha,\beta} U^i_{\alpha,\beta} v_{\alpha,\beta}$, and the coefficient-level adjoint $U^*$. The isometry equation $U^* U = 1$ follows from existing orthonormality of the pair-index coefficients, hence $U$ is injective.
- This is the strongest unconditional step currently supported by the Appendix B structural data; it does not assume or construct the missing projectors $Q_{AX}$, $Q_{XB}$.

### Description

- `TNLean/MPS/RFP/CommutingBridge.lean`: adds the definition of $U$ and $U^*$ on virtual pair indices $(\alpha, \beta)$, and proves $U^* U = 1$ (injectivity of $U$) from `hU_pair` orthonormality. (+101 lines)
- `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`: adds `def:appendixB_physical_isometry` and `thm:appendixB_physical_isometry_left_inverse` with `\lean{}` and `\leanok` tags. (+50 lines)
- `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` and `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`: updated to record this step and sharpen what remains — tensor powers of the embedding, transport of the rank-one $\varphi = \sum_m \lambda_m |m,m\rangle$ projector to adjacent bonds, range identification with $G_2(A_{\mathrm{core}})$, and lifted $AX/XB$ commutation.
- The source projector identification and `HasProductPairLocalProjectors` witness (the task of #3373) remain unproved.

### Testing

- `lake build TNLean.MPS.RFP.CommutingBridge` (8,667 jobs).
- Blueprint synchronization and declaration checking (`leanblueprint checkdecls`).
- Both paper-gap notes compiled successfully.
- Lean CI (`lean_action_ci.yml`) validates the full build.

---
Partially addresses #3373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal definitions and proofs in an existing MPS/RFP bridge file plus documentation; no auth, runtime, or API surface changes.
> 
> **Overview**
> Adds the **Appendix B basic-vector physical isometry** on `AppendixBStructuralData`: linear maps `physicalIsometry` and `physicalIsometryLeftInverse` from virtual pair indices `(α,β)` to physical coefficients, with **`physicalIsometryLeftInverse_comp`** proving **U*U = 1** from existing `hU_pair` orthonormality and **`physicalIsometry_injective`** as a corollary.
> 
> The blueprint chapter gains **`def:appendixB_physical_isometry`** and **`thm:appendixB_physical_isometry_left_inverse`** with Lean tags. The NNCPH and parent-commuting Hamiltonian **paper-gap** notes record this unconditional step and refine what is still missing (tensor powers of the embedding, bond projectors, range identification with two-site ground spaces, lifted AX/XB commutator).
> 
> This does **not** construct source projectors `Q_AX` / `Q_XB` or close the RFP→NNCPH gap by itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 301689e180eb78e2f791f352debfdd4b11576d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->