### PR TITLE
feat(MPS/RFP): add phase-multiplicity counterexample and gap note

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -399,6 +399,7 @@ import TNLean.MPS.RFP.Assembly
 import TNLean.MPS.RFP.Decorrelation
 import TNLean.MPS.RFP.BNTOrthogonality
 import TNLean.MPS.RFP.ResidualIsometry
+import TNLean.MPS.RFP.PhaseMultiplicityCounterexample
 
 -- Layer 6a: Quantum Wielandt span-growth infrastructure
 import TNLean.Wielandt.SpanGrowth.CumulativeSpan

--- a/TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean
+++ b/TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.StructuralFull
+
+/-!
+# Literal repeated-phase formula and the physical-isometry obstruction
+
+The displayed formula `III_CFI_RFP` in arXiv:1606.00608 (lines 543--550) permits
+repeated virtual blocks indexed by `q`, with independent unit-modulus phases.
+Read literally as a virtual block diagonal, its smallest repeated-phase example
+is the one-letter tensor `diag(1, -1)`, made from two scalar blocks with phases
+`1` and `-1`.
+
+The prose immediately following the display says that `j,q` also give a direct
+sum in the physical space after applying the isometry (lines 559--563).  The
+one-letter virtual-block reading does not realize that additional physical
+direct sum: its blocked matrix is the identity and is not a scalar multiple of
+`diag(1, -1)`.  It therefore fails the defining physical-isometry relation
+`AA=A` (lines 396--425), and its transfer map is not idempotent.  The example
+records an ambiguity between the literal displayed matrix formula and its
+accompanying physical-space interpretation; it is not asserted to be a source
+renormalization fixed point.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+/-- The one-dimensional representative normal tensor in the counterexample. -/
+def scalarUnitTensor : MPSTensor 1 1 := fun _ => 1
+
+/-- The two unit-modulus phases `1` and `-1`. -/
+def signPhase : Fin 2 → ℂ
+  | 0 => 1
+  | 1 => -1
+
+/-- Two phase copies of `scalarUnitTensor`, assembled on the bond direct sum. -/
+def phaseFlipTensor : MPSTensor 1 2 := fun _ => !![1, 0; 0, -1]
+
+/-- Both copy coefficients have unit modulus. -/
+lemma norm_signPhase (q : Fin 2) : ‖signPhase q‖ = 1 := by
+  fin_cases q <;> simp [signPhase]
+
+/-- `phaseFlipTensor` is the literal virtual block-diagonal reading of two
+copies of the same scalar tensor with phases `1` and `-1` in equation
+`III_CFI_RFP` of arXiv:1606.00608, lines 543--550.  This assertion does not
+include the physical direct-sum interpretation described at lines 559--563. -/
+lemma phaseFlipTensor_is_two_phase_copies :
+    (∀ q : Fin 2, ‖signPhase q‖ = 1) ∧
+    (∀ (i : Fin 1) (q : Fin 2),
+      phaseFlipTensor i q q = signPhase q * scalarUnitTensor i 0 0) ∧
+    (∀ (i : Fin 1) (q r : Fin 2), q ≠ r → phaseFlipTensor i q r = 0) := by
+  refine ⟨norm_signPhase, ?_, ?_⟩
+  · intro i q
+    fin_cases i
+    fin_cases q <;> simp [phaseFlipTensor, signPhase, scalarUnitTensor]
+  · intro i q r hqr
+    fin_cases i
+    fin_cases q <;> fin_cases r <;> simp_all [phaseFlipTensor]
+
+/-- The scalar representative is in the trace-normalized unit-isometry form of
+arXiv:1606.00608, Lemma `charact-NT-pure-RFP`, lines 1271--1301. -/
+lemma scalarUnitTensor_isIsometryCanonicalForm :
+    IsIsometryCanonicalForm scalarUnitTensor := by
+  refine ⟨1, fun _ => 1, scalarUnitTensor, ?_, ?_, ?_, ?_, ?_⟩
+  · simp
+  · intro k
+    simp
+  · simp
+  · intro p q
+    fin_cases p
+    fin_cases q
+    simp [scalarUnitTensor]
+  · intro i
+    fin_cases i
+    ext a b
+    fin_cases a
+    fin_cases b
+    simp [scalarUnitTensor]
+
+/-- The one-letter virtual-block tensor does not satisfy even the scalar form
+of the defining physical-isometry relation `AA=A` from arXiv:1606.00608,
+lines 396--425.  Its blocked matrix is the identity, which is not a scalar
+multiple of `diag(1, -1)`. -/
+lemma phaseFlipTensor_no_blocking_coefficient :
+    ¬ ∃ v : ℂ,
+      phaseFlipTensor 0 * phaseFlipTensor 0 = v • phaseFlipTensor 0 := by
+  rintro ⟨v, hv⟩
+  have h00 := congrFun (congrFun hv 0) 0
+  have h11 := congrFun (congrFun hv 1) 1
+  norm_num [phaseFlipTensor, Matrix.mul_apply] at h00 h11
+  subst v
+  norm_num at h11
+
+/-- The two-phase assembly is not a renormalization fixed point under the
+present whole-tensor definition.  Evaluation on the off-diagonal matrix unit
+`E₀₁` gives `E²(E₀₁) = E₀₁` but `E(E₀₁) = -E₀₁` after one application.
+
+Together with `phaseFlipTensor_no_blocking_coefficient`, this distinguishes the
+literal virtual-block reading of `III_CFI_RFP` from the physical-isometry
+interpretation in arXiv:1606.00608, lines 559--563. -/
+theorem phaseFlipTensor_not_isRFP : ¬ IsRFP phaseFlipTensor := by
+  intro hRFP
+  have h := LinearMap.congr_fun hRFP (!![0, 1; 0, 0] : Matrix (Fin 2) (Fin 2) ℂ)
+  have h01 := congrFun (congrFun h 0) 1
+  norm_num [IsRFP, LinearMap.comp_apply, transferMap_apply, phaseFlipTensor,
+    Matrix.mul_apply, Matrix.conjTranspose_apply] at h01
+  norm_num [Matrix.vecMul, dotProduct] at h01
+  norm_num [Matrix.mul_apply, Matrix.conjTranspose_apply] at h01
+
+/-- The scalar representative and two unit phases satisfy the literal virtual
+block-diagonal reading of `III_CFI_RFP`, but the resulting one-letter tensor
+fails both `AA=A` and whole-tensor transfer-map idempotence.  Hence the example
+exhibits an ambiguity between the display at arXiv:1606.00608, lines 543--554,
+and its physical direct-sum interpretation at lines 559--563; it is not a
+source renormalization fixed point. -/
+theorem phaseFlipTensor_literal_display_ambiguity :
+    ((∀ q : Fin 2, ‖signPhase q‖ = 1) ∧
+      (∀ (i : Fin 1) (q : Fin 2),
+        phaseFlipTensor i q q = signPhase q * scalarUnitTensor i 0 0) ∧
+      (∀ (i : Fin 1) (q r : Fin 2), q ≠ r → phaseFlipTensor i q r = 0)) ∧
+    IsIsometryCanonicalForm scalarUnitTensor ∧
+    (¬ ∃ v : ℂ,
+      phaseFlipTensor 0 * phaseFlipTensor 0 = v • phaseFlipTensor 0) ∧
+    ¬ IsRFP phaseFlipTensor := by
+  exact ⟨phaseFlipTensor_is_two_phase_copies,
+    scalarUnitTensor_isIsometryCanonicalForm, phaseFlipTensor_no_blocking_coefficient,
+    phaseFlipTensor_not_isRFP⟩
+
+end MPSTensor

--- a/TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean
+++ b/TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean
@@ -7,18 +7,19 @@ import TNLean.MPS.RFP.StructuralFull
 /-!
 # Literal repeated-phase formula and the physical-isometry obstruction
 
-The displayed formula `III_CFI_RFP` in arXiv:1606.00608 (lines 543--550) permits
-repeated virtual blocks indexed by `q`, with independent unit-modulus phases.
+The displayed repeated-copy formula in arXiv:1606.00608 (lines 543--550) permits
+repeated virtual blocks indexed by $q$, with independent unit-modulus phases.
 Read literally as a virtual block diagonal, its smallest repeated-phase example
-is the one-letter tensor `diag(1, -1)`, made from two scalar blocks with phases
-`1` and `-1`.
+is the one-letter tensor $\operatorname{diag}(1,-1)$, made from two scalar blocks
+with phases $1$ and $-1$.
 
-The prose immediately following the display says that `j,q` also give a direct
+The prose immediately following the display says that $j,q$ also give a direct
 sum in the physical space after applying the isometry (lines 559--563).  The
 one-letter virtual-block reading does not realize that additional physical
 direct sum: its blocked matrix is the identity and is not a scalar multiple of
-`diag(1, -1)`.  It therefore fails the defining physical-isometry relation
-`AA=A` (lines 396--425), and its transfer map is not idempotent.  The example
+$\operatorname{diag}(1,-1)$.  It therefore fails the defining physical-isometry
+relation $AA=A$ (lines 396--425), and its transfer map is not idempotent.  The
+example
 records an ambiguity between the literal displayed matrix formula and its
 accompanying physical-space interpretation; it is not asserted to be a source
 renormalization fixed point.
@@ -31,7 +32,7 @@ namespace MPSTensor
 /-- The one-dimensional representative normal tensor in the counterexample. -/
 def scalarUnitTensor : MPSTensor 1 1 := fun _ => 1
 
-/-- The two unit-modulus phases `1` and `-1`. -/
+/-- The two unit-modulus phases $1$ and $-1$. -/
 def signPhase : Fin 2 → ℂ
   | 0 => 1
   | 1 => -1
@@ -44,8 +45,8 @@ lemma norm_signPhase (q : Fin 2) : ‖signPhase q‖ = 1 := by
   fin_cases q <;> simp [signPhase]
 
 /-- `phaseFlipTensor` is the literal virtual block-diagonal reading of two
-copies of the same scalar tensor with phases `1` and `-1` in equation
-`III_CFI_RFP` of arXiv:1606.00608, lines 543--550.  This assertion does not
+copies of the same scalar tensor with phases $1$ and $-1$ in equation
+III_CFI_RFP of arXiv:1606.00608, lines 543--550.  This assertion does not
 include the physical direct-sum interpretation described at lines 559--563. -/
 lemma phaseFlipTensor_is_two_phase_copies :
     (∀ q : Fin 2, ‖signPhase q‖ = 1) ∧
@@ -61,7 +62,7 @@ lemma phaseFlipTensor_is_two_phase_copies :
     fin_cases q <;> fin_cases r <;> simp_all [phaseFlipTensor]
 
 /-- The scalar representative is in the trace-normalized unit-isometry form of
-arXiv:1606.00608, Lemma `charact-NT-pure-RFP`, lines 1271--1301. -/
+arXiv:1606.00608, lines 1271--1301. -/
 lemma scalarUnitTensor_isIsometryCanonicalForm :
     IsIsometryCanonicalForm scalarUnitTensor := by
   refine ⟨1, fun _ => 1, scalarUnitTensor, ?_, ?_, ?_, ?_, ?_⟩
@@ -81,9 +82,9 @@ lemma scalarUnitTensor_isIsometryCanonicalForm :
     simp [scalarUnitTensor]
 
 /-- The one-letter virtual-block tensor does not satisfy even the scalar form
-of the defining physical-isometry relation `AA=A` from arXiv:1606.00608,
+of the defining physical-isometry relation $AA=A$ from arXiv:1606.00608,
 lines 396--425.  Its blocked matrix is the identity, which is not a scalar
-multiple of `diag(1, -1)`. -/
+multiple of $\operatorname{diag}(1,-1)$. -/
 lemma phaseFlipTensor_no_blocking_coefficient :
     ¬ ∃ v : ℂ,
       phaseFlipTensor 0 * phaseFlipTensor 0 = v • phaseFlipTensor 0 := by
@@ -96,10 +97,11 @@ lemma phaseFlipTensor_no_blocking_coefficient :
 
 /-- The two-phase assembly is not a renormalization fixed point under the
 present whole-tensor definition.  Evaluation on the off-diagonal matrix unit
-`E₀₁` gives `E²(E₀₁) = E₀₁` but `E(E₀₁) = -E₀₁` after one application.
+$E_{01}$ gives $\mathcal E^2(E_{01})=E_{01}$ but
+$\mathcal E(E_{01})=-E_{01}$ after one application.
 
 Together with `phaseFlipTensor_no_blocking_coefficient`, this distinguishes the
-literal virtual-block reading of `III_CFI_RFP` from the physical-isometry
+literal virtual-block reading of III_CFI_RFP from the physical-isometry
 interpretation in arXiv:1606.00608, lines 559--563. -/
 theorem phaseFlipTensor_not_isRFP : ¬ IsRFP phaseFlipTensor := by
   intro hRFP
@@ -111,8 +113,8 @@ theorem phaseFlipTensor_not_isRFP : ¬ IsRFP phaseFlipTensor := by
   norm_num [Matrix.mul_apply, Matrix.conjTranspose_apply] at h01
 
 /-- The scalar representative and two unit phases satisfy the literal virtual
-block-diagonal reading of `III_CFI_RFP`, but the resulting one-letter tensor
-fails both `AA=A` and whole-tensor transfer-map idempotence.  Hence the example
+block-diagonal reading of III_CFI_RFP, but the resulting one-letter tensor
+fails both $AA=A$ and whole-tensor transfer-map idempotence.  Hence the example
 exhibits an ambiguity between the display at arXiv:1606.00608, lines 543--554,
 and its physical direct-sum interpretation at lines 559--563; it is not a
 source renormalization fixed point. -/

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1035,8 +1035,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \cite[Section~3]{Cirac2016MPDO_arXiv}. It does not, however, satisfy the
     accompanying interpretation in which the copy index also belongs to the
     physical direct sum: there is no scalar $v$ such that
-    $(A^0)^2=vA^0$. In particular, $A$ is not asserted to be a renormalization
-    fixed point in the source sense, and it is not a renormalization fixed point
+    $(A^0)^2=vA^0$. In particular, $A$ is not a renormalization fixed point
     in the sense of Definition~\ref{def:is_rfp}.
 % Source ambiguity: equation III_CFI_RFP at lines 543--554 admits this literal
 % virtual-block substitution, while lines 559--563 require j,q to contribute
@@ -1044,7 +1043,10 @@ and rates for the single-tensor transfer map $\E_A$.
 % docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
 \end{theorem}
 \begin{proof}\leanok
-    The scalar representative has $X=\Lambda=U^0=(1)$, and
+    Taking the witness data of
+    Definition~\ref{def:is_isometry_canonical_form} to be
+    $X=\Lambda=U^0=(1)$, the scalar representative is in isometry canonical
+    form; moreover,
     $|1|=|-1|=1$.
     Direct multiplication gives $(A^0)^2=I$. Comparing diagonal entries in
     $I=vA^0$ would give simultaneously $v=1$ and $v=-1$, which is impossible.

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1019,6 +1019,44 @@ and rates for the single-tensor transfer map $\E_A$.
     (Theorem~\ref{thm:is_rfp_of_isometry_canonical_form_direct_sum}).
 \end{proof}
 
+\begin{theorem}[Ambiguity of the literal repeated-phase display]%
+    \label{thm:phase_flip_tensor_not_rfp}
+    \lean{MPSTensor.phaseFlipTensor_literal_display_ambiguity}
+    \leanok
+    \uses{def:is_rfp, def:is_isometry_canonical_form}
+    Let $B$ be the one-letter, one-dimensional tensor $B^0=(1)$, and form two
+    block-diagonal copies with phases $1$ and $-1$:
+    \[
+        A^0=\begin{pmatrix}1&0\\0&-1\end{pmatrix}.
+    \]
+    The representative $B$ is in isometry canonical form, and both copy
+    coefficients have unit modulus. Thus $A$ satisfies the literal virtual
+    block-diagonal reading of the displayed repeated-copy formula in
+    \cite[Section~3]{Cirac2016MPDO_arXiv}. It does not, however, satisfy the
+    accompanying interpretation in which the copy index also belongs to the
+    physical direct sum: there is no scalar $v$ such that
+    $(A^0)^2=vA^0$. In particular, $A$ is not asserted to be a renormalization
+    fixed point in the source sense, and it is not a renormalization fixed point
+    in the sense of Definition~\ref{def:is_rfp}.
+% Source ambiguity: equation III_CFI_RFP at lines 543--554 admits this literal
+% virtual-block substitution, while lines 559--563 require j,q to contribute
+% to both physical and virtual direct sums; see
+% docs/paper-gaps/cpsv16_rfp_isometry_scope.tex.
+\end{theorem}
+\begin{proof}\leanok
+    The scalar representative has $X=\Lambda=U^0=(1)$, and
+    $|1|=|-1|=1$.
+    Direct multiplication gives $(A^0)^2=I$. Comparing diagonal entries in
+    $I=vA^0$ would give simultaneously $v=1$ and $v=-1$, which is impossible.
+    On the off-diagonal matrix unit $E_{01}$, the transfer map is conjugation by
+    $A^0$, so
+    \[
+        \E_A(E_{01})=-E_{01},\qquad
+        \E_A^2(E_{01})=E_{01}.
+    \]
+    Hence $\E_A^2\ne\E_A$.
+\end{proof}
+
 \begin{theorem}[Canonical-form blocks are injective]\label{thm:rfp_cf_structural}
     \lean{MPSTensor.rfp_cf_structural}
     \leanok

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -49,10 +49,12 @@ For MPDO renormalization fixed points:
   pure-MPS ZCL theorem is a single-block idempotence/CID equivalence. The
   source theorem also includes the BNT-level local-orthogonality equations
   between distinct blocks.
-- `cpsv16_rfp_isometry_scope.tex` records that the current per-block RFP
-  isometry theorem exposes only a contracted per-block isometry condition,
-  while the source's equation `III_isometry` imposes full pair-index
-  orthonormality and cross-block orthogonality.
+- `cpsv16_rfp_isometry_scope.tex` records the normalization and cross-block
+  content of the source's equation `III_isometry`, together with the remaining
+  canonical-form hypotheses. It also records the ambiguity between a literal
+  virtual-block reading of the repeated-copy display `III_CFI_RFP` and the
+  accompanying physical direct-sum interpretation: the one-letter phase-flip
+  tensor fails both `AA=A` and whole-tensor transfer-map idempotence.
 - `cpsv16_zcl_canonical_form_normalization.tex` records the corresponding
   normalization issue for mixed-state ZCL.
 

--- a/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
+++ b/docs/paper-gaps/cpsv16_rfp_isometry_scope.tex
@@ -83,7 +83,7 @@ therefore the compatible pair-index equation is
   D_k^{-1}\delta_{\alpha,\alpha'}\delta_{\beta,\beta'}.
 \end{align}
 The remaining normalization comparison with the source equation
-\eqref{eq:III_isometry} is therefore explicit rather than hidden.
+\path{eq:III_isometry} is therefore explicit rather than hidden.
 
 A subsequent comparison theorem rescales the same single-block decomposition by
 $U_k^i\mapsto D_k^{1/2}U_k^i$ and
@@ -194,7 +194,7 @@ reference tensor\footnote{Local source:
   \widehat A^{(\alpha',\beta')}_{\alpha,\beta}
     = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}\sqrt{\Lambda_\alpha},
 \end{align}
-which is left-canonical and has fixed point $\diag(\Lambda)$ with
+which is left-canonical and has fixed point $\operatorname{diag}(\Lambda)$ with
 $\tr(\Lambda)=1$.  Writing $\widehat A = \Lambda\,U$ would force
 $U^{(\alpha',\beta')}_{\alpha,\beta}
   = \delta_{\alpha,\alpha'}\delta_{\beta,\beta'}/\sqrt{\Lambda_\alpha}$, whose pair-index
@@ -243,7 +243,7 @@ The square root on the diagonal matches the source reference tensor (the
 square-root correction is documented separately in the previous section); the
 trace
 condition $\tr(\Lambda)=1$ is imposed on $\Lambda$ itself, equivalently on the
-normalized diagonal fixed point $\rho=\diag(\Lambda)$,
+normalized diagonal fixed point $\rho=\operatorname{diag}(\Lambda)$,
 $\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$.  The identity
 $\sum_\alpha\Lambda_\alpha=1$ is the trace identity
 $\sum_\alpha\rho_{\alpha,\alpha}=\tr\rho$ for the diagonal fixed point.
@@ -315,11 +315,81 @@ source canonical form \path{III_CFI_RFP}, where the inner direct sum over
 copies $q=1,\ldots,r_j$ has a single summand and the phases $\mu_{j,q}$ are all
 $1$, so the direct sum carries one copy of each normal-tensor block.  The
 full-multiplicity backward direction, summing repeated copies of each block with
-their phases and scalar weights, is a further step.
+their phases and scalar weights, requires care about the physical direct sum
+carried by the copy index.  A literal virtual-block substitution need not
+satisfy the defining physical-isometry relation.
+
+\section{Ambiguity of a literal repeated-phase reading}
+
+Equation~\path{III_CFI_RFP} allows a fixed normal tensor indexed by $j$ to occur
+several times, indexed by $q$, with independent coefficients
+$\mu_{j,q}$ satisfying $|\mu_{j,q}|=1$.
+Take one physical letter, one scalar representative
+\[
+  B^0=(1),
+\]
+and two copies with $\mu_{1,1}=1$ and $\mu_{1,2}=-1$.  With trivial gauges and
+$\Lambda=(1)$, a literal reading of the displayed virtual block diagonal gives
+\[
+  A^0=\operatorname{diag}(1,-1).
+\]
+The representative $B$ satisfies the trace-normalized unit-isometry form: take
+$X=(1)$, $\Lambda=(1)$, and $U^0=(1)$.  Both copy phases have unit modulus.
+For $g=1$ and a one-dimensional representative, the displayed joint equation
+\path{eq:III_isometry} also reduces to $|U^0|^2=1$ and is satisfied.  Notice,
+however, that this equation carries the index $j$ but not the copy index $q$.
+These facts are formalized by
+\leanid{MPSTensor.scalarUnitTensor_isIsometryCanonicalForm} and
+\leanid{MPSTensor.phaseFlipTensor_is_two_phase_copies} in
+\doclink{TNLean/MPS/RFP/PhaseMultiplicityCounterexample}.
+
+The prose following the display supplies additional meaning: the indices $j,q$
+connect the physical and virtual indices and therefore give a direct sum in
+both spaces, up to the physical isometry (local source
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:559--563}).  The one-letter tensor
+above realizes the virtual direct sum but cannot realize a nontrivial physical
+direct sum.  Indeed,
+\[
+  (A^0)^2=I,
+\]
+and there is no scalar $v$ with $I=vA^0$: the two diagonal entries would require
+$v=1$ and $v=-1$ simultaneously.  Thus this tensor fails even the unrestricted
+scalar-coefficient version of the defining relation \path{AA=A}.  This is
+formalized by \leanid{MPSTensor.phaseFlipTensor_no_blocking_coefficient}.
+
+Its transfer map is
+\[
+  \mathcal E_A(Y)=A^0Y(A^0)^\dagger.
+\]
+For the matrix unit $E_{01}$ one has
+\[
+  \mathcal E_A(E_{01})=-E_{01},
+  \qquad
+  \mathcal E_A^2(E_{01})=E_{01}.
+\]
+Thus $\mathcal E_A^2\ne\mathcal E_A$.  The formal theorem
+\leanid{MPSTensor.phaseFlipTensor_not_isRFP} proves that this tensor does not
+satisfy the present predicate \leanid{MPSTensor.IsRFP}.
+
+The calculation therefore does not show that a source RFP is rejected by the
+formal predicate.  Rather, it exposes an ambiguity in taking the displayed
+matrix formula independently of its accompanying physical-space
+interpretation.  The source definition of a pure-state RFP is the physical
+isometry relation
+\path{AA=A} (local source
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:420--425}), whereas the present
+formal predicate is literal idempotence of the transfer map.  The source then
+states the repeated-copy form in Theorem~\path{charact-MPS}, including the
+independent unit phases (local source
+\path{Papers/1606.00608/MPDO-22-12-17-2.tex:543--554}).  For the two-phase
+virtual-block reading above, neither \path{AA=A} nor literal whole-tensor
+idempotence holds.  Consequently this tensor must not be called a source RFP.
+Before formalizing the full characterization, the copy index must be represented
+in a way that implements the physical direct sum described at lines 559--563.
 
 \section{Elimination plan}
 
-The one remaining gap is the source's starting point.  Corollary~III.cor3 assumes
+There are two remaining gaps.  First, Corollary~III.cor3 assumes
 a single predicate ``$A$ in canonical form is a renormalization fixed point'',
 whereas the formal theorem takes the per-block normality, irreducibility,
 left-canonical condition, and gauge-phase distinctness of a basis of normal
@@ -327,6 +397,16 @@ tensors as explicit hypotheses.  A source-faithful version should derive those
 per-block conditions from the single canonical-form renormalization-fixed-point
 predicate, so that the residual isometry family follows from the whole-tensor
 predicate alone, by the block-level argument of the previous section.
+
+Second, the repeated-copy index $q$ must be represented at the level at which
+the source physical isometry acts.  It cannot be collapsed into a block-diagonal
+bond tensor and then tested by literal whole-tensor transfer-map idempotence,
+because the phase-flip tensor then fails the source relation \path{AA=A} as well
+as transfer-map idempotence.  A
+source-faithful characterization should formalize the relation \path{AA=A}
+itself, or an equivalent physical-isometry predicate, and prove its precise
+relation to transfer-map idempotence after stating the necessary canonical-form
+or quotient conditions.
 
 \section{Conclusion}
 
@@ -350,17 +430,20 @@ while the contracted identity is instead
 $\sum_i (U_k^i)^\dagger U_k^i=D_k I$.  Thus the scalar normalization comparison
 is explicit.  The source trace-normalization $\tr(\Lambda)=1$ is now formalized
 for a single block by the named predicate
-\leanid{MPSTensor.IsIsometryCanonicalForm} and the theorem
 \leanid{MPSTensor.isIsometryCanonicalForm_of_rfp_nt}, with the diagonal weight
 $\Lambda_\alpha=\rho_{\alpha,\alpha}/\tr\rho$ and the square-root dressing
 $\sqrt\Lambda$ of the unit isometry.  The cross-block $\delta_{j,j'}$
 orthogonality equations of \path{eq:III_isometry} are formalized at the
 normal-tensor-block level by
-\leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  The only
-part not yet formalized is the extraction of the per-block normality,
+\leanid{MPSTensor.exists_residualIsometryFamily_of_isRFP_directSum}.  Two parts
+remain: the extraction of the per-block normality,
 irreducibility, left-canonical condition, and gauge-phase distinctness from a
 single canonical-form renormalization-fixed-point predicate, the hypothesis form
-of Corollary~III.cor3.
+of Corollary~III.cor3; and a faithful treatment of repeated phase copies at the
+physical-isometry level.  The tensor $A^0=\operatorname{diag}(1,-1)$ proves that the latter
+cannot be represented by a literal virtual block diagonal on a one-dimensional
+physical space: that reading fails both \path{AA=A} and whole-tensor
+transfer-map idempotence.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
### Motivation

- arXiv:1606.00608 (thm:charact-MPS, line 543) permits a literal reading of the repeated-copy formula `III_CFI_RFP` that is ambiguous: a virtual block diagonal $A^0 = \operatorname{diag}(1,-1)$ satisfies the displayed matrix pattern (unit phases, block-diagonal copies) but does not realize the accompanying physical direct-sum interpretation.
- The tensor fails the source physical-isometry relation ($AA = A$, lines 396–425) and its transfer map is not idempotent, so it is not a renormalization fixed point. Without a formal record of this scope, a full-multiplicity characterization could be stated falsely against the source.
- Continues formalization coverage of the pure-state RFP structural theory (see #2598).

### Description

- Added `TNLean/MPS/RFP/PhaseMultiplicityCounterexample.lean` (132 lines): defines `phaseFlipTensor` (the two-phase tensor $A^0 = \operatorname{diag}(1,-1)$) and proves `phaseFlipTensor_literal_display_ambiguity`, recording the literal copy structure, isometry canonical form of the scalar block, failure of the scalar $AA = A$-style blocking relation, and `¬ IsRFP` via transfer-map non-idempotence on $E_{01}$.
- Modified `TNLean.lean` to import the new module.
- Updated `blueprint/src/chapter/ch14_correlations.tex`: adds Theorem `phase_flip_tensor_not_rfp` tagged with `\lean{MPSTensor.phaseFlipTensor_literal_display_ambiguity}`.
- Updated `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` (9 deletions, 92 additions): adds a section on the phase-copy scope ambiguity and updates the elimination plan to require representing the copy index $q$ at the physical-isometry level.
- Updated `docs/paper-gaps/README.md` cross-reference.

Sources: arXiv:1606.00608, Definition 3.2 and relation `AA=A` (lines 396–425); Theorem `charact-MPS`, equations `III_CFI_RFP` and `III_isometry` (lines 543–563); `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex`.

### Testing

- Targeted and full Lean builds (9,272 jobs); root build succeeded.
- Blueprint synchronization and declaration checks.
- Prose, diff, and proof-integrity checks.
- Paper-gap PDF compiled (eight pages); affected pages visually inspected.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build on merge.

---
Partially addresses #2598

> [!NOTE]
> **Low Risk**
> Documentation and a small, self-contained formal counterexample; no changes to existing RFP theorems or predicates beyond a new import and gap notes.
> 
> **Overview**
> Documents a **scope ambiguity** in CPSV16's repeated-copy formula `III_CFI_RFP`: a literal two-phase virtual block diagonal `diag(1,-1)` matches the displayed matrix pattern (unit phases, block-diagonal copies) but **does not** realize the prose's physical direct-sum interpretation and is **not** a renormalization fixed point.
> 
> A new Lean module `PhaseMultiplicityCounterexample` defines `phaseFlipTensor` and proves `phaseFlipTensor_literal_display_ambiguity`—literal copy structure, isometry canonical form of the scalar block, failure of a scalar `AA=A`-style blocking relation, and `¬ IsRFP` via transfer-map non-idempotence on `E₀₁`. The module is wired into the root import `TNLean.lean`.
> 
> The blueprint chapter adds **Theorem** `phase_flip_tensor_not_rfp` (`\lean{MPSTensor.phaseFlipTensor_literal_display_ambiguity}`). `docs/paper-gaps/cpsv16_rfp_isometry_scope.tex` gains a section on this ambiguity and updates the elimination plan to require representing copy index `q` at the physical-isometry level; `README.md` cross-references the note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455cf94f590a3d4a8bd13fb7f9adc04035794290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Self-contained new Lean proofs and documentation only; no modifications to existing RFP definitions or theorems beyond a root import.
> 
> **Overview**
> Adds a **formal counterexample** for CPSV16’s repeated-copy display `III_CFI_RFP`: the two-phase bond tensor `phaseFlipTensor` (`diag(1,-1)`) matches a literal virtual block-diagonal reading (unit phases, off-diagonal zeros) while the scalar block stays in **isometry canonical form**, yet it **fails** a scalar blocking form of `AA=A` and **`¬ IsRFP`** via non-idempotent transfer on `E₀₁`. The capstone theorem `phaseFlipTensor_literal_display_ambiguity` bundles these facts; the module is imported from `TNLean.lean`.
> 
> **Blueprint** chapter 14 gains Theorem `phase_flip_tensor_not_rfp` linked to that Lean declaration.
> 
> **Paper-gap docs** expand `cpsv16_rfp_isometry_scope.tex` with a section on literal vs physical direct-sum ambiguity, refresh the elimination plan (copy index `q` at physical-isometry level; optional `\operatorname{diag}` fixes), and update `README.md` to cross-reference the note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1761da1a31dfecef65ac733925c2f5b9ff4ce0a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->