### PR TITLE
feat(MPS/CanonicalForm): isolate projector closure step

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -320,6 +320,7 @@ import TNLean.MPS.Periodic.Applications
 import TNLean.MPS.Periodic.NormalCanonicalPeriodOne
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
 import TNLean.MPS.CanonicalForm.Reduction
+import TNLean.MPS.CanonicalForm.ProjectorClosure
 import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.CanonicalForm.Existence
 import TNLean.MPS.CanonicalForm.NormalReduction

--- a/TNLean/MPS/CanonicalForm/ProjectorClosure.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosure.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.Reduction
+
+/-!
+# Invariant-projector closure
+
+This file isolates the normalization-free algebraic step in the sufficient
+condition for canonical form from Cirac, Pérez-García, Schuch, and Verstraete,
+arXiv:1606.00608, lines 253--254.
+
+The source assumes that every orthogonal projection satisfying
+\(P A^i = P A^i P\) also satisfies \(A^i P = P A^i P\).  The recursive
+decomposition in `MPSTensor.exists_irreducible_blockDecomp` uses the opposite
+orientation, \((1-P)A^iP=0\).  Applying the source hypothesis to \(1-P\)
+shows that such a projection commutes with every tensor matrix.  This argument
+does not require a left-canonical or unital normalization.
+
+The subsequent passage from these reducing projections to primitive,
+spectral-radius-one blocks is not proved here.  Its missing spectral statement
+is recorded in
+`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`.
+-/
+
+open scoped Matrix
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- The invariant-projector closure condition of arXiv:1606.00608, lines
+253--254: every left-invariant orthogonal projection is also right-invariant. -/
+def HasInvariantProjectorClosure (A : MPSTensor d D) : Prop :=
+  ∀ P : Matrix (Fin D) (Fin D) ℂ,
+    IsOrthogonalProjection P →
+    (∀ i : Fin d, P * A i = P * A i * P) →
+    ∀ i : Fin d, A i * P = P * A i * P
+
+/-- Under invariant-projector closure, every invariant orthogonal projection
+reduces all tensor matrices.
+
+This is the projection step in the sufficient condition for canonical form in
+arXiv:1606.00608, lines 253--254.  It is independent of any left-canonical or
+unital normalization. -/
+theorem commutes_of_hasInvariantProjectorClosure_of_lowerZero
+    (A : MPSTensor d D) (P : Matrix (Fin D) (Fin D) ℂ)
+    (hClosure : HasInvariantProjectorClosure A)
+    (hP : IsOrthogonalProjection P)
+    (hLower : ∀ i : Fin d, (1 - P) * A i * P = 0) :
+    ∀ i : Fin d, P * A i = A i * P := by
+  intro i
+  have hLeftComplement : ∀ j : Fin d,
+      (1 - P) * A j = (1 - P) * A j * (1 - P) := by
+    intro j
+    have h := hLower j
+    calc
+      (1 - P) * A j = (1 - P) * A j * P + (1 - P) * A j * (1 - P) := by
+        noncomm_ring
+      _ = (1 - P) * A j * (1 - P) := by rw [h, zero_add]
+  have hRightComplement := hClosure (1 - P) hP.one_sub hLeftComplement i
+  have hAP : A i * P = P * A i * P := by
+    have h := hLower i
+    apply eq_of_sub_eq_zero
+    calc
+      A i * P - P * A i * P = (1 - P) * A i * P := by noncomm_ring
+      _ = 0 := h
+  have hPcomp : P * (1 - P) = 0 := by
+    rw [mul_sub, mul_one, hP.2, sub_self]
+  have hUpper : P * A i * (1 - P) = 0 := by
+    calc
+      P * A i * (1 - P) = P * (A i * (1 - P)) := by noncomm_ring
+      _ = P * ((1 - P) * A i * (1 - P)) := by rw [hRightComplement]
+      _ = (P * (1 - P)) * A i * (1 - P) := by noncomm_ring
+      _ = 0 := by rw [hPcomp, zero_mul, zero_mul]
+  calc
+    P * A i = P * A i * P + P * A i * (1 - P) := by noncomm_ring
+    _ = P * A i * P := by rw [hUpper, add_zero]
+    _ = A i * P := hAP.symm
+
+/-- If a tensor with invariant-projector closure has a nontrivial invariant
+orthogonal projection, then it has a nontrivial reducing projection. -/
+theorem exists_reducing_projection_of_hasInvariantProj
+    (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A)
+    (hInv : HasInvariantProj A) :
+    ∃ P : Matrix (Fin D) (Fin D) ℂ,
+      IsOrthogonalProjection P ∧ P ≠ 0 ∧ P ≠ 1 ∧
+        (∀ i : Fin d, P * A i = A i * P) := by
+  obtain ⟨P, hP, hP0, hP1, hLower⟩ := hInv
+  exact ⟨P, hP, hP0, hP1,
+    commutes_of_hasInvariantProjectorClosure_of_lowerZero A P hClosure hP hLower⟩
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/ProjectorClosure.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosure.lean
@@ -80,7 +80,12 @@ theorem commutes_of_hasInvariantProjectorClosure_of_lowerZero
     _ = A i * P := hAP.symm
 
 /-- If a tensor with invariant-projector closure has a nontrivial invariant
-orthogonal projection, then it has a nontrivial reducing projection. -/
+orthogonal projection, then it has a nontrivial reducing projection.
+
+This is the reducing-projection consequence of the sufficient condition for
+canonical form in arXiv:1606.00608, lines 253--254.  The remaining spectral
+step is recorded in
+`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`. -/
 theorem exists_reducing_projection_of_hasInvariantProj
     (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A)
     (hInv : HasInvariantProj A) :

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -295,6 +295,73 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     no nontrivial invariant projection (Definition~\ref{def:irreducible_tensor}).
 \end{definition}
 
+\begin{definition}[Invariant-projector closure]
+    \label{def:invariant_projector_closure}
+    \lean{MPSTensor.HasInvariantProjectorClosure}
+    \leanok
+    \uses{def:mps_tensor}
+    An MPS tensor $A$ has \emph{invariant-projector closure} if every
+    orthogonal projection $P$ satisfying
+    \[
+        PA^i=PA^iP \qquad\text{for all }i
+    \]
+    also satisfies
+    \[
+        A^iP=PA^iP \qquad\text{for all }i.
+    \]
+    This is the projector hypothesis in the sufficient condition for canonical
+    form of \cite[Section~2]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Invariant projections are reducing under projector closure]
+    \label{thm:invariant_projector_closure_commutes}
+    \lean{MPSTensor.commutes_of_hasInvariantProjectorClosure_of_lowerZero}
+    \leanok
+    \uses{def:invariant_projector_closure}
+    Suppose that $A$ has invariant-projector closure and that $P$ is an
+    orthogonal projection with
+    \[
+        (\Id-P)A^iP=0 \qquad\text{for all }i.
+    \]
+    Then $P$ reduces every tensor matrix:
+    \[
+        PA^i=A^iP \qquad\text{for all }i.
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:invariant_projector_closure}
+    The lower-corner equation gives
+    \[
+        (\Id-P)A^i=(\Id-P)A^i(\Id-P).
+    \]
+    Applying projector closure to $\Id-P$ gives
+    $A^i(\Id-P)=(\Id-P)A^i(\Id-P)$, hence the upper corner
+    $PA^i(\Id-P)$ also vanishes. Therefore
+    \[
+        PA^i=PA^iP=A^iP.
+    \]
+\end{proof}
+
+\begin{theorem}[Invariant-projector closure gives a reducing projection]
+    \label{thm:exists_reducing_projection_of_invariant_projector}
+    \lean{MPSTensor.exists_reducing_projection_of_hasInvariantProj}
+    \leanok
+    \uses{def:has_inv_proj, def:invariant_projector_closure,
+        thm:invariant_projector_closure_commutes}
+    If $A$ has invariant-projector closure and admits a nontrivial invariant
+    projection, then it admits a nontrivial orthogonal projection commuting
+    with every $A^i$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:invariant_projector_closure_commutes}
+    Apply Theorem~\ref{thm:invariant_projector_closure_commutes} to the
+    projection supplied by Definition~\ref{def:has_inv_proj}.
+\end{proof}
+
 \begin{theorem}[PSD fixed point gives invariant projection]\label{thm:fp_inv_proj}
     \lean{MPSTensor.lowerZero_of_posSemidef_fixedPoint}
     \leanok

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -301,14 +301,8 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \leanok
     \uses{def:mps_tensor}
     An MPS tensor $A$ has \emph{invariant-projector closure} if every
-    orthogonal projection $P$ satisfying
-    \[
-        PA^i=PA^iP \qquad\text{for all }i
-    \]
-    also satisfies
-    \[
-        A^iP=PA^iP \qquad\text{for all }i.
-    \]
+    orthogonal projection $P$ satisfying $PA^i=PA^iP$ for all~$i$ also
+    satisfies $A^iP=PA^iP$ for all~$i$.
     This is the projector hypothesis in the sufficient condition for canonical
     form of \cite[Section~2]{Cirac2016MPDO_arXiv}.
 \end{definition}
@@ -319,14 +313,8 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \leanok
     \uses{def:invariant_projector_closure}
     Suppose that $A$ has invariant-projector closure and that $P$ is an
-    orthogonal projection with
-    \[
-        (\Id-P)A^iP=0 \qquad\text{for all }i.
-    \]
-    Then $P$ reduces every tensor matrix:
-    \[
-        PA^i=A^iP \qquad\text{for all }i.
-    \]
+    orthogonal projection satisfying $(\Id-P)A^iP=0$ for all~$i$. Then $P$
+    reduces every tensor matrix: $PA^i=A^iP$ for all~$i$.
 \end{theorem}
 
 \begin{proof}
@@ -348,8 +336,7 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \label{thm:exists_reducing_projection_of_invariant_projector}
     \lean{MPSTensor.exists_reducing_projection_of_hasInvariantProj}
     \leanok
-    \uses{def:has_inv_proj, def:invariant_projector_closure,
-        thm:invariant_projector_closure_commutes}
+    \uses{def:has_inv_proj, def:invariant_projector_closure}
     If $A$ has invariant-projector closure and admits a nontrivial invariant
     projection, then it admits a nontrivial orthogonal projection commuting
     with every $A^i$.

--- a/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
+++ b/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
@@ -1,0 +1,38 @@
+% Source-faithfulness note for arXiv:1606.00608, lines 253--254.
+\section*{The projector-closure sufficient condition for canonical form}
+
+Cirac, Pérez-García, Schuch, and Verstraete state that a tensor without
+nontrivial periodic vectors is in canonical form if every orthogonal projection
+$P$ satisfying
+\[
+  P A^i = P A^i P
+\]
+also satisfies
+\[
+  A^i P = P A^i P.
+\]
+This is the proposition in arXiv:1606.00608, lines 253--254.
+
+The algebraic projection step is formalized without normalization.  Indeed, if
+$(1-P)A^iP=0$, then the first displayed hypothesis holds for $1-P$.  Its
+conclusion gives $A^i(1-P)=(1-P)A^i(1-P)$, and hence $P A^i=A^iP$.  Thus every
+projection used in the invariant-subspace decomposition is reducing.
+
+The remaining implication is spectral.  The current decomposition theorem
+produces irreducible blocks and equality of all finite-ring traces, but it does
+not transport a global absence-of-periodicity hypothesis to the transfer maps
+of the individual blocks.  Moreover, the source first rescales each block so
+that its transfer map has spectral radius one; the corresponding coefficients
+are then carried by the scalars $\mu_k$.  A faithful completion therefore needs
+a theorem which simultaneously:
+\begin{enumerate}
+\item constructs the reducing direct-sum decomposition from the closure
+  condition;
+\item rescales every nonzero irreducible block to spectral radius one; and
+\item identifies the source's absence of nontrivial periodic vectors with
+  primitivity of each rescaled block transfer map.
+\end{enumerate}
+
+No left-canonical identity such as
+$\sum_i (A^i)^\dagger A^i=1$ occurs in the cited proposition, so it cannot be
+assumed in this completion.

--- a/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
+++ b/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
@@ -1,38 +1,94 @@
-% Source-faithfulness note for arXiv:1606.00608, lines 253--254.
-\section*{The projector-closure sufficient condition for canonical form}
+\documentclass{article}
 
-Cirac, Pérez-García, Schuch, and Verstraete state that a tensor without
-nontrivial periodic vectors is in canonical form if every orthogonal projection
-$P$ satisfying
-\[
-  P A^i = P A^i P
-\]
+\usepackage{amsmath,amssymb}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\setlength{\emergencystretch}{2em}
+
+\input{command}
+
+\title{The Projector-Closure Sufficient Condition for Canonical Form}
+\author{}
+\date{2026-07-10}
+
+\begin{document}
+\maketitle
+
+\section{The source assertion}
+
+Cirac, P\'erez-Garc\'ia, Schuch, and Verstraete state a sufficient condition for
+canonical form in Section~II of their analysis of matrix product density
+operators \cite{Cirac2016MPDO_arXiv}.  In the notation of that paper, assume
+that the tensor has no nontrivial periodic vectors and that every orthogonal
+projection $P$ satisfying
+\begin{align}
+    PA^i &= PA^iP \qquad\text{for every }i
+\end{align}
 also satisfies
-\[
-  A^i P = P A^i P.
-\]
-This is the proposition in arXiv:1606.00608, lines 253--254.
+\begin{align}
+    A^iP &= PA^iP \qquad\text{for every }i.
+\end{align}
+The paper then asserts that the tensor is in canonical form.  This is the
+proposition at arXiv:1606.00608, lines 253--254.
 
-The algebraic projection step is formalized without normalization.  Indeed, if
-$(1-P)A^iP=0$, then the first displayed hypothesis holds for $1-P$.  Its
-conclusion gives $A^i(1-P)=(1-P)A^i(1-P)$, and hence $P A^i=A^iP$.  Thus every
-projection used in the invariant-subspace decomposition is reducing.
+\section{The algebraic projection step}
 
-The remaining implication is spectral.  The current decomposition theorem
-produces irreducible blocks and equality of all finite-ring traces, but it does
-not transport a global absence-of-periodicity hypothesis to the transfer maps
-of the individual blocks.  Moreover, the source first rescales each block so
-that its transfer map has spectral radius one; the corresponding coefficients
-are then carried by the scalars $\mu_k$.  A faithful completion therefore needs
-a theorem which simultaneously:
+The projector hypothesis has a normalization-free consequence.  Suppose that
+$P$ is an orthogonal projection for which
+\begin{align}
+    (1-P)A^iP=0 \qquad\text{for every }i.
+\end{align}
+Then
+\begin{align}
+    (1-P)A^i=(1-P)A^i(1-P).
+\end{align}
+Applying the source hypothesis to $1-P$ gives
+\begin{align}
+    A^i(1-P)=(1-P)A^i(1-P),
+\end{align}
+and hence both off-diagonal corners vanish.  Consequently
+\begin{align}
+    PA^i=A^iP \qquad\text{for every }i.
+\end{align}
+Thus every projection used in the invariant-subspace decomposition is a
+reducing projection.  This implication is formalized directly, without a
+left-canonical or unital normalization.\footnote{Formal declarations:
+\leanid{MPSTensor.commutes_of_hasInvariantProjectorClosure_of_lowerZero} and
+\leanid{MPSTensor.exists_reducing_projection_of_hasInvariantProj} in
+\doclink{TNLean/MPS/CanonicalForm/ProjectorClosure}.}
+
+\section{The remaining spectral implication}
+
+The present decomposition theorem produces irreducible blocks and preserves
+all finite-ring traces, but it does not yet transport the global absence of
+periodic vectors to the transfer maps of the individual blocks.  The source
+also rescales each nonzero block so that its transfer map has spectral radius
+one, with the removed scale carried by the corresponding scalar coefficient.
+A source-faithful completion therefore still requires a theorem which
+simultaneously:
 \begin{enumerate}
-\item constructs the reducing direct-sum decomposition from the closure
-  condition;
+\item constructs the reducing direct-sum decomposition from projector closure;
 \item rescales every nonzero irreducible block to spectral radius one; and
-\item identifies the source's absence of nontrivial periodic vectors with
-  primitivity of each rescaled block transfer map.
+\item identifies absence of nontrivial periodic vectors with primitivity of
+  every rescaled block transfer map.
 \end{enumerate}
+No identity of the form
+\begin{align}
+    \sum_i (A^i)^\dagger A^i=1
+\end{align}
+occurs among the hypotheses of the cited proposition, so such a normalization
+cannot be assumed in this completion.
 
-No left-canonical identity such as
-$\sum_i (A^i)^\dagger A^i=1$ occurs in the cited proposition, so it cannot be
-assumed in this completion.
+\section{Conclusion}
+
+The classification is an \emph{open gap}.  The normalization-free
+reducing-projection step is established, but the spectral-radius rescaling and
+the deduction of blockwise primitivity from the absence of periodic vectors
+remain to be proved.  Until these spectral statements are available, the full
+sufficient condition for canonical form at arXiv:1606.00608, lines 253--254,
+is not formalized.
+
+\bibliographystyle{alpha}
+\bibliography{references}
+
+\end{document}


### PR DESCRIPTION
## Summary

This pull request isolates the normalization-free projection argument in the sufficient canonical-form condition of Cirac–Pérez-García–Schuch–Verstraete, arXiv:1606.00608, lines 253–254.

It introduces the invariant-projector closure condition and proves that every invariant orthogonal projection arising in the recursive decomposition is reducing. The corresponding blueprint statements and source-faithfulness note record that the remaining work is spectral: blockwise normalization and the passage from absence of periodic vectors to primitivity.

Partially addresses #2634.

## Verification

- `lake build TNLean`
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- reader-facing prose check
- `git diff --check`

No new proof placeholders are introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds self-contained Lean proofs and documentation only; no changes to existing reduction or channel logic.
> 
> **Overview**
> Introduces **invariant-projector closure** (`HasInvariantProjectorClosure`) from CPSV arXiv:1606.00608 and formalizes the **normalization-free** step: invariant orthogonal projections with `(1-P)A^iP=0` **commute** with every `A^i`, yielding a nontrivial **reducing** projection when a nontrivial invariant one exists.
> 
> New module `TNLean/MPS/CanonicalForm/ProjectorClosure.lean` is wired into the root import; blueprint chapter 9 adds matching definitions and theorems; `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex` records that **spectral** completion (block rescaling to spectral radius one and primitivity from absence of periodic vectors) is still open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b687b16ea88a5e8e72e5469d34c4d92a3f60e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->