### PR TITLE
feat(MPS/RFP): formalize positive-gap physical CID

### DIFF
--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -345,6 +345,40 @@ theorem isBNTLocallyOrthogonal_of_isRFP_directSum
         (hirr j) (hirr j') (hleft j) (hleft j') hdim
   exact mixedTransferMap₂_eq_zero_of_isIdempotentElem (B j) (B j') hidem hsr
 
+/-- **Canonical direct-sum RFP tensors have positive-gap BNT zero correlation
+length.**
+
+Let `B` be a basis of normal tensors consisting of nonzero-dimensional,
+irreducible, left-canonical, pairwise gauge-phase-distinct blocks.  If its
+direct-sum tensor has idempotent transfer map, then it has positive-gap
+physical CID and the mixed transfer operators between distinct BNT components
+vanish.
+
+This is the positive-gap part of the forward implication in arXiv:1606.00608,
+Theorem `TheoremZCLPure` (lines 498--502 and 1248--1250), for the explicit
+unweighted direct-sum representative.  The physical CID part follows from
+equation `Corr`; the local-orthogonality part is
+`isBNTLocallyOrthogonal_of_isRFP_directSum`.
+
+**Scope restriction (positive gaps and explicit direct sum):** the source CID
+definition includes adjacent regions, whereas the predicate below assumes both
+complementary gaps are positive.  The source also allows scalar multiplicities
+and a possible bond gauge.  Both restrictions are recorded in
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
+theorem isPositiveGapBNTZCL_of_isRFP_directSum
+    (B : (k : Fin r) → MPSTensor d (dim k))
+    [∀ k, NeZero (dim k)]
+    (hBNT : IsCPSVBasisOfNormalTensors (directSumTensor B)
+      (fun k => ⟨dim k, B k⟩))
+    (hirr : ∀ k, IsIrreducibleTensor (B k))
+    (hleft : ∀ k, ∑ i : Fin d, (B k i)ᴴ * B k i = 1)
+    (hdist : ∀ j k : Fin r, j ≠ k → ∀ h : dim j = dim k,
+      ¬ GaugePhaseEquiv (cast (congrArg (MPSTensor d) h) (B j)) (B k))
+    (hRFP : IsRFP (directSumTensor B)) :
+    IsPositiveGapBNTZCL (directSumTensor B) B := by
+  refine ⟨hBNT, isPositiveGapPhysicalCID_of_isRFP (directSumTensor B) hRFP, ?_⟩
+  exact isBNTLocallyOrthogonal_of_isRFP_directSum B hirr hleft hdist hRFP
+
 end Main
 
 end MPSTensor

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -11,7 +11,7 @@ import TNLean.Spectral.TransferOperatorGapNT
 
 This file proves the cross-block (`j ≠ j'`) vanishing of the mixed transfer
 operator for a multi-block tensor whose direct sum is a renormalization fixed
-point, the off-diagonal content of the isometry condition `eq:III_isometry`
+point, the off-diagonal content of the isometry condition eq:III_isometry
 (arXiv:1606.00608, line 551):
 \[
   \sum_i (U_j^i)_{\alpha,\beta}\,\overline{(U_{j'}^i)_{\alpha',\beta'}}
@@ -29,8 +29,8 @@ The diagonal `j = j'` case is `IsIsometryCanonicalForm`
 
 ## Route
 
-The off-diagonal mixed transfer operator `F_{j,j'} = mixedTransferMap₂ (B j)
-(B j')` is shown to be idempotent (whole-tensor RFP, via the block
+The off-diagonal mixed transfer operator `mixedTransferMap₂ (B j) (B j')` is
+shown to be idempotent (whole-tensor RFP, via the block
 decomposition), and then to have spectral radius `< 1` (distinct irreducible
 left-canonical blocks, splitting on equal versus unequal bond dimension); an
 idempotent operator with spectral radius `< 1` is `0`.  The diagonal lemma
@@ -64,7 +64,8 @@ private lemma submatrix_sum' {ι l m p q : Type*}
   ext a b
   simp only [Matrix.submatrix_apply, Matrix.sum_apply]
 
-/-- The `(j, j')` bond block of `(⊕_k L_k) X (⊕_k R_k)` is `L_j · X_{j,j'} · R_{j'}`. -/
+/-- The `(j, j')` bond block of $(\bigoplus_k L_k)\, X\, (\bigoplus_k R_k)$ is
+$L_j X_{j,j'} R_{j'}$. -/
 private lemma blockDiagonal'_mul_mul_toBlock
     (L R : (k : Fin r) → Matrix (Fin (dim k)) (Fin (dim k)) ℂ)
     (X : Matrix ((k : Fin r) × Fin (dim k)) ((k : Fin r) × Fin (dim k)) ℂ)
@@ -96,12 +97,13 @@ private lemma blockDiagonal'_mul_mul_toBlock
   refine Finset.sum_congr rfl fun b _ => ?_
   rw [Matrix.blockDiagonal'_apply_eq, Matrix.submatrix_apply, blockIncl, blockIncl]
 
-/-- The `(j, j')` bond block of the block-diagonal
-transfer sum `∑_i (⊕_k B_k^i) X (⊕_k B_k^i)^†` is the mixed transfer operator
-`mixedTransferMap₂ (B j) (B j')` applied to the `(j, j')` bond block of `X`.
+/-- The `(j, j')` bond block of the block-diagonal transfer sum
+$\sum_i (\bigoplus_k B_k^i)\, X\, (\bigoplus_k B_k^i)^{\dagger}$ is the mixed
+transfer operator `mixedTransferMap₂ (B j) (B j')` applied to the `(j, j')`
+bond block of `X`.
 
 This is the transfer-operator analogue of `evalWord_blockDiagonal'`, and the
-reusable foundation for the cross-block content of `eq:III_isometry`
+reusable foundation for the cross-block content of eq:III_isometry
 (arXiv:1606.00608, line 551). -/
 theorem blockDiagonal'_transferSum_toBlock
     (B : (k : Fin r) → MPSTensor d (dim k))
@@ -117,7 +119,8 @@ theorem blockDiagonal'_transferSum_toBlock
   refine Finset.sum_congr rfl fun i _ => ?_
   rw [Matrix.blockDiagonal'_conjTranspose, blockDiagonal'_mul_mul_toBlock]
 
-/-- The block-diagonal transfer sum `∑_i (⊕_k B_k^i) Y (⊕_k B_k^i)^†` on the
+/-- The block-diagonal transfer sum
+$\sum_i (\bigoplus_k B_k^i)\, Y\, (\bigoplus_k B_k^i)^{\dagger}$ on the
 direct-sum bond space (`Σ`-indexed). -/
 noncomputable def blockTransferSum
     (B : (k : Fin r) → MPSTensor d (dim k))
@@ -130,7 +133,7 @@ noncomputable def blockTransferSum
 total bond space `Fin (∑ k, dim k)`.
 
 This coincides with `CanonicalForm.toTensor` of the canonical form with block
-tensors `B`, all scalar weights `μ_k = 1`, mirroring its `blockDiagonal'`/`Σ`-reindex
+tensors `B`, all scalar weights $\mu_k = 1$, mirroring its `blockDiagonal'`/`Σ`-reindex
 construction (`TNLean/MPS/Core/MultiBlock.lean`). -/
 noncomputable def directSumTensor (B : (k : Fin r) → MPSTensor d (dim k)) :
     MPSTensor d (∑ k : Fin r, dim k) := fun i =>
@@ -315,12 +318,13 @@ variable {r : ℕ} {dim : Fin r → ℕ}
 /-- **Cross-block orthogonality of the RFP isometry (mixed-transfer form).**
 
 For a family of distinct irreducible left-canonical blocks `B`, if the
-whole direct-sum tensor `⊕_k B_k` is a renormalization fixed point, then every
+whole direct-sum tensor $\bigoplus_k B_k$ is a renormalization fixed point,
+then every
 off-diagonal mixed transfer operator vanishes:
 `mixedTransferMap₂ (B j) (B j') = 0` for `j ≠ j'`.
 
-This is the `δ_{j,j'}` (cross-block) content of the isometry condition
-`eq:III_isometry` (arXiv:1606.00608, line 551), towards Corollary III.cor3
+This is the $\delta_{j,j'}$ (cross-block) content of the isometry condition
+eq:III_isometry (arXiv:1606.00608, line 551), towards Corollary III.cor3
 (line 584).
 
 The load-bearing hypothesis is whole-tensor RFP of the direct sum (the source's
@@ -355,9 +359,9 @@ physical CID and the mixed transfer operators between distinct BNT components
 vanish.
 
 This is the positive-gap part of the forward implication in arXiv:1606.00608,
-Theorem `TheoremZCLPure` (lines 498--502 and 1248--1250), for the explicit
+Theorem TheoremZCLPure (lines 498--502 and 1248--1250), for the explicit
 unweighted direct-sum representative.  The physical CID part follows from
-equation `Corr`; the local-orthogonality part is
+equation Corr; the local-orthogonality part is
 `isBNTLocallyOrthogonal_of_isRFP_directSum`.
 
 **Scope restriction (positive gaps and explicit direct sum):** the source CID

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -29,8 +29,8 @@ The diagonal `j = j'` case is `IsIsometryCanonicalForm`
 
 ## Route
 
-The off-diagonal mixed transfer operator `mixedTransferMap₂ (B j) (B j')` is
-shown to be idempotent (whole-tensor RFP, via the block
+The off-diagonal mixed transfer operator $\mathcal E_{j,j'}$ is shown to be
+idempotent (whole-tensor RFP, via the block
 decomposition), and then to have spectral radius `< 1` (distinct irreducible
 left-canonical blocks, splitting on equal versus unequal bond dimension); an
 idempotent operator with spectral radius `< 1` is `0`.  The diagonal lemma

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -11,7 +11,7 @@ import TNLean.Spectral.TransferOperatorGapNT
 
 This file proves the cross-block (`j ≠ j'`) vanishing of the mixed transfer
 operator for a multi-block tensor whose direct sum is a renormalization fixed
-point, the off-diagonal content of the isometry condition eq:III_isometry
+point, the off-diagonal content of the isometry condition
 (arXiv:1606.00608, line 551):
 \[
   \sum_i (U_j^i)_{\alpha,\beta}\,\overline{(U_{j'}^i)_{\alpha',\beta'}}
@@ -103,7 +103,7 @@ transfer operator `mixedTransferMap₂ (B j) (B j')` applied to the `(j, j')`
 bond block of `X`.
 
 This is the transfer-operator analogue of `evalWord_blockDiagonal'`, and the
-reusable foundation for the cross-block content of eq:III_isometry
+reusable foundation for the cross-block content of the isometry condition
 (arXiv:1606.00608, line 551). -/
 theorem blockDiagonal'_transferSum_toBlock
     (B : (k : Fin r) → MPSTensor d (dim k))
@@ -324,8 +324,8 @@ off-diagonal mixed transfer operator vanishes:
 `mixedTransferMap₂ (B j) (B j') = 0` for `j ≠ j'`.
 
 This is the $\delta_{j,j'}$ (cross-block) content of the isometry condition
-eq:III_isometry (arXiv:1606.00608, line 551), towards Corollary III.cor3
-(line 584).
+at arXiv:1606.00608, line 551, used toward the local-orthogonality conclusion
+at line 584.
 
 The load-bearing hypothesis is whole-tensor RFP of the direct sum (the source's
 "`A` in CF is RFP"), strictly stronger than per-block RFP.  The diagonal
@@ -360,10 +360,11 @@ physical CID and, for all distinct BNT components $j \ne j'$,
   \mathcal E_{j,j'}=0.
 \]
 
-This is the positive-gap part of the forward implication in arXiv:1606.00608,
-Theorem TheoremZCLPure (lines 498--502 and 1248--1250), for the explicit
-unweighted direct-sum representative.  The physical CID part follows from
-equation Corr; the local-orthogonality part is
+This is the positive-gap part of the forward implication at
+arXiv:1606.00608, lines 498--502 and 1248--1250, for the explicit unweighted
+direct-sum representative. The physical CID part follows from
+$\mathcal E_A^n=\mathcal E_A$ for $n\geq 1$ in the two-observable transfer
+formula at lines 490--496; the local-orthogonality part is
 `isBNTLocallyOrthogonal_of_isRFP_directSum`.
 
 **Scope restriction (positive gaps and explicit direct sum):** the source CID

--- a/TNLean/MPS/RFP/BNTOrthogonality.lean
+++ b/TNLean/MPS/RFP/BNTOrthogonality.lean
@@ -355,8 +355,10 @@ length.**
 Let `B` be a basis of normal tensors consisting of nonzero-dimensional,
 irreducible, left-canonical, pairwise gauge-phase-distinct blocks.  If its
 direct-sum tensor has idempotent transfer map, then it has positive-gap
-physical CID and the mixed transfer operators between distinct BNT components
-vanish.
+physical CID and, for all distinct BNT components $j \ne j'$,
+\[
+  \mathcal E_{j,j'}=0.
+\]
 
 This is the positive-gap part of the forward implication in arXiv:1606.00608,
 Theorem TheoremZCLPure (lines 498--502 and 1248--1250), for the explicit

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -44,16 +44,17 @@ variable {g : ℕ} {dim : Fin g → ℕ}
 
 /-- The transfer insertion associated with an observable on a block of `L`
 physical spins.  If `σ, τ : Fin L → Fin d` label basis words, then
-`physicalObservableTransfer A O X` is
+`physicalObservableTransfer A L O X` is
 `∑_{σ,τ} O_{τ,σ} A^σ X (A^τ)†`.
 
 This is the matrix `𝔼_O` appearing in arXiv:1606.00608, equation `Corr`
 (lines 490--496), written as a map on virtual matrices. -/
 noncomputable def physicalObservableTransfer (A : MPSTensor d D) (L : ℕ)
-    (O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ)
-    (X : Matrix (Fin D) (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ :=
+    (O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
+    Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
   ∑ σ : Fin L → Fin d, ∑ τ : Fin L → Fin d,
-    O τ σ • (evalWord A (List.ofFn σ) * X * (evalWord A (List.ofFn τ))ᴴ)
+    O τ σ • ((LinearMap.mulLeft ℂ (evalWord A (List.ofFn σ))).comp
+      (LinearMap.mulRight ℂ (evalWord A (List.ofFn τ))ᴴ))
 
 /-- The periodic-chain two-region expectation obtained by placing observables
 `O₁` and `O₂` on physical blocks, with `n₁` and `n₂` unobserved sites in the two
@@ -64,9 +65,9 @@ noncomputable def physicalTwoPointExpectation (A : MPSTensor d D)
     (O₁ : Matrix (Fin L₁ → Fin d) (Fin L₁ → Fin d) ℂ)
     (O₂ : Matrix (Fin L₂ → Fin d) (Fin L₂ → Fin d) ℂ)
     (n₁ n₂ : ℕ) : ℂ :=
-  Matrix.trace (physicalObservableTransfer A L₂ O₂
-    (((transferMap A) ^ n₂) (physicalObservableTransfer A L₁ O₁
-      (((transferMap A) ^ n₁) 1))))
+  LinearMap.trace ℂ (Matrix (Fin D) (Fin D) ℂ)
+    (physicalObservableTransfer A L₂ O₂ ∘ₗ ((transferMap A) ^ n₂) ∘ₗ
+      physicalObservableTransfer A L₁ O₁ ∘ₗ ((transferMap A) ^ n₁))
 
 /-- Positive-gap physical correlations independent of distance, in the transfer
 formula surrounding arXiv:1606.00608, Definition 3.3 and equation `Corr` (lines
@@ -210,6 +211,15 @@ def IsPositiveGapBNTZCL (A : MPSTensor d D)
     (blocks : (j : Fin g) → MPSTensor d (dim j)) : Prop :=
   IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
     IsPositiveGapPhysicalCID A ∧ IsBNTLocallyOrthogonal blocks
+
+/-- Unfolding of positive-gap BNT zero correlation length into the BNT
+relation, positive-gap physical CID, and BNT local orthogonality. -/
+lemma isPositiveGapBNTZCL_iff (A : MPSTensor d D)
+    (blocks : (j : Fin g) → MPSTensor d (dim j)) :
+    IsPositiveGapBNTZCL A blocks ↔
+      IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
+        IsPositiveGapPhysicalCID A ∧ IsBNTLocallyOrthogonal blocks :=
+  Iff.rfl
 
 /-- Zero correlation length in the single-block convention: a tensor has ZCL
 when it satisfies the local idempotence convention above and has correlations

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -100,7 +100,7 @@ for all virtual bond matrices.
 For every positive definite right fixed point `ρR` of the transfer map, the
 connected correlator
 $C(X,Y;n) = \langle X_0 Y_n \rangle - \langle X \rangle \langle Y \rangle$ is
-the same for all separations `n ≥ 1` and all bond matrices `X`, `Y`.
+the same for all separations $n \geq 1$ and all bond matrices `X`, `Y`.
 
 **Scope restriction:** this is a virtual-insertion surrogate, not Definition
 3.3 of the source.  It is also vacuous when no positive definite fixed point
@@ -292,7 +292,8 @@ theorem isCID_implies_isRFP
 /-- Single-block ZCL is equivalent to transfer-map idempotence (i.e. `IsRFP`).
 
 Forward: `IsZCL → IsRFP` is immediate since `IsLocallyOrthogonal = IsRFP`.
-Reverse: $E^2 = E$ implies $E^n = E$ for `n ≥ 1` by `IsIdempotentElem.pow_eq`,
+Reverse: $E^2 = E$ implies $E^n = E$ for $n \geq 1$ by
+`IsIdempotentElem.pow_eq`,
 so the connected correlator is independent of separation, giving CID.
 
 **Scope restriction (arXiv:1606.00608, Theorem TheoremZCLPure):** the source

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -44,10 +44,10 @@ variable {g : ℕ} {dim : Fin g → ℕ}
 
 /-- The transfer insertion associated with an observable on a block of `L`
 physical spins.  If `σ, τ : Fin L → Fin d` label basis words, then
-`physicalObservableTransfer A L O X` is
-`∑_{σ,τ} O_{τ,σ} A^σ X (A^τ)†`.
+`physicalObservableTransfer A L O X` equals
+$\sum_{\sigma,\tau} O_{\tau,\sigma}\, A^{\sigma} X (A^{\tau})^{\dagger}$.
 
-This is the matrix `𝔼_O` appearing in arXiv:1606.00608, equation `Corr`
+This is the matrix $\mathbb{E}_O$ appearing in arXiv:1606.00608, equation Corr
 (lines 490--496), written as a map on virtual matrices. -/
 noncomputable def physicalObservableTransfer (A : MPSTensor d D) (L : ℕ)
     (O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
@@ -59,7 +59,7 @@ noncomputable def physicalObservableTransfer (A : MPSTensor d D) (L : ℕ)
 /-- The periodic-chain two-region expectation obtained by placing observables
 `O₁` and `O₂` on physical blocks, with `n₁` and `n₂` unobserved sites in the two
 complementary arcs.  This is the trace formula in arXiv:1606.00608, equation
-`Corr` (lines 490--496). -/
+Corr (lines 490--496). -/
 noncomputable def physicalTwoPointExpectation (A : MPSTensor d D)
     (L₁ L₂ : ℕ)
     (O₁ : Matrix (Fin L₁ → Fin d) (Fin L₁ → Fin d) ℂ)
@@ -70,7 +70,7 @@ noncomputable def physicalTwoPointExpectation (A : MPSTensor d D)
       physicalObservableTransfer A L₁ O₁ ∘ₗ ((transferMap A) ^ n₁))
 
 /-- Positive-gap physical correlations independent of distance, in the transfer
-formula surrounding arXiv:1606.00608, Definition 3.3 and equation `Corr` (lines
+formula surrounding arXiv:1606.00608, Definition 3.3 and equation Corr (lines
 437--445 and 490--496): translating either of two physical block observables
 through the unobserved part of a fixed periodic chain does not change their
 two-region expectation.  Thus the two complementary gaps may change while
@@ -81,8 +81,8 @@ does not replace physical observables by arbitrary virtual bond matrices.
 
 **Scope restriction (arXiv:1606.00608, Definition 3.3):** the source quantifies
 over all disjoint regions, including adjacent regions.  Here both complementary
-gaps are required to be positive.  If a gap is zero, equation `Corr` contains
-`𝔼⁰ = 1`, which does not follow from `𝔼² = 𝔼`.  See
+gaps are required to be positive.  If a gap is zero, equation Corr contains
+$\mathbb{E}^0 = 1$, which does not follow from $\mathbb{E}^2 = \mathbb{E}$.  See
 `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 def IsPositiveGapPhysicalCID (A : MPSTensor d D) : Prop :=
   ∀ (L₁ L₂ : ℕ)
@@ -98,8 +98,9 @@ two-point expression through the transfer map is constant in the separation
 for all virtual bond matrices.
 
 For every positive definite right fixed point `ρR` of the transfer map, the
-connected correlator `C(X,Y;n) = ⟨X₀Yₙ⟩ − ⟨X⟩⟨Y⟩` is the same for all
-separations `n ≥ 1` and all bond matrices `X`, `Y`.
+connected correlator
+$C(X,Y;n) = \langle X_0 Y_n \rangle - \langle X \rangle \langle Y \rangle$ is
+the same for all separations `n ≥ 1` and all bond matrices `X`, `Y`.
 
 **Scope restriction:** this is a virtual-insertion surrogate, not Definition
 3.3 of the source.  It is also vacuous when no positive definite fixed point
@@ -116,12 +117,12 @@ def IsCID (A : MPSTensor d D) : Prop :=
 /-- Idempotence of the transfer map implies positive-gap physical CID.
 
 This is the positive-gap part of the forward implication stated immediately
-before arXiv:1606.00608, Theorem `TheoremZCLPure` (lines 498--502).  Equation
-`Corr` shows the reason directly: every positive power of an idempotent
+before arXiv:1606.00608, Theorem TheoremZCLPure (lines 498--502).  Equation
+Corr shows the reason directly: every positive power of an idempotent
 transfer map equals the transfer map itself.
 
 **Scope restriction:** adjacent regions are not covered because idempotence
-does not identify `𝔼⁰` with `𝔼`.  This is recorded in
+does not identify $\mathbb{E}^0$ with $\mathbb{E}$.  This is recorded in
 `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem isPositiveGapPhysicalCID_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) :
     IsPositiveGapPhysicalCID A := by
@@ -157,7 +158,7 @@ lemma isLocallyOrthogonal_iff_isRFP (A : MPSTensor d D) :
 
 /-- BNT-level local orthogonality (arXiv:1606.00608, Definition 3.5):
 for distinct BNT components `j ≠ j'`, the mixed-sector transfer matrix
-`𝔼_{j,j'} = ∑ i, A_j^i ⊗ \overline{A_{j'}^i}` vanishes.
+$\mathbb{E}_{j,j'} = \sum_i A_j^i \otimes \overline{A_{j'}^i}$ vanishes.
 
 This is the source local-orthogonality condition used in the pure-state ZCL
 theorem. The rectangular mixed transfer operator is the corresponding linear
@@ -203,7 +204,8 @@ gaps are positive.
 
 **Scope restriction (arXiv:1606.00608, Definition 3.6):** the source permits
 arbitrary disjoint regions, including adjacent regions for which a
-complementary transfer power is `𝔼⁰`.  This predicate excludes those cases.
+complementary transfer power is $\mathbb{E}^0$.  This predicate excludes those
+cases.
 It is therefore a positive-gap consequence of transfer idempotence, not the
 source ZCL predicate.  See
 `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
@@ -237,9 +239,10 @@ def IsZCL (A : MPSTensor d D) : Prop :=
 for a tensor with a PosDef fixed point, correlations independent of distance
 implies the transfer map is idempotent.
 
-The proof uses trace nondegeneracy: IsCID forces `tr(Y · Eⁿ(X · ρR))` to be
-constant in `n` for all `X`, `Y`, so `Eⁿ(X · ρR)` is constant. Since `ρR` is
-PosDef (hence invertible), `X · ρR` ranges over all matrices, giving `E² = E`. -/
+The proof uses trace nondegeneracy: IsCID forces
+$\operatorname{tr}(Y\, E^n(X \rho_R))$ to be constant in `n` for all `X`, `Y`,
+so $E^n(X \rho_R)$ is constant. Since `ρR` is PosDef (hence invertible),
+$X \rho_R$ ranges over all matrices, giving $E^2 = E$. -/
 theorem isCID_implies_isRFP
     (A : MPSTensor d D)
     (ρR : Matrix (Fin D) (Fin D) ℂ)
@@ -282,10 +285,10 @@ theorem isCID_implies_isRFP
 /-- Single-block ZCL is equivalent to transfer-map idempotence (i.e. `IsRFP`).
 
 Forward: `IsZCL → IsRFP` is immediate since `IsLocallyOrthogonal = IsRFP`.
-Reverse: `E² = E` implies `Eⁿ = E` for `n ≥ 1` by `IsIdempotentElem.pow_eq`,
+Reverse: $E^2 = E$ implies $E^n = E$ for `n ≥ 1` by `IsIdempotentElem.pow_eq`,
 so the connected correlator is independent of separation, giving CID.
 
-**Scope restriction (arXiv:1606.00608, Theorem `TheoremZCLPure`):** the source
+**Scope restriction (arXiv:1606.00608, Theorem TheoremZCLPure):** the source
 theorem is stated for canonical-form tensors and includes the BNT-level local
 orthogonality equations for distinct components. This result proves the
 single-block idempotence/CID equivalence under the convention above; it is not

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -241,8 +241,8 @@ For a tensor with a positive-definite fixed point, independence of the
 virtual-insertion correlator implies that the transfer map is idempotent.
 
 The proof uses trace nondegeneracy: IsCID forces
-$\operatorname{tr}(Y\, E^n(X \rho_R))$ to be constant in `n` for all `X`, `Y`,
-so $E^n(X \rho_R)$ is constant. Since `ρR` is PosDef (hence invertible),
+$\operatorname{tr}(Y\, E^n(X \rho_R))$ to be constant in $n$ for all $X,Y$,
+so $E^n(X \rho_R)$ is constant. Since $\rho_R$ is positive definite and hence invertible,
 $X \rho_R$ ranges over all matrices, giving $E^2 = E$.
 
 **Scope restriction (virtual insertions):** `IsCID` quantifies over arbitrary

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -235,14 +235,21 @@ read as the full source definition for a multi-block BNT family. See
 def IsZCL (A : MPSTensor d D) : Prop :=
   IsLocallyOrthogonal A ∧ IsCID A
 
-/-- **CID implies RFP** (arXiv:1606.00608, Theorem 3.8 reverse direction):
-for a tensor with a PosDef fixed point, correlations independent of distance
-implies the transfer map is idempotent.
+/-- **Virtual-insertion distance independence implies RFP.**
+
+For a tensor with a positive-definite fixed point, independence of the
+virtual-insertion correlator implies that the transfer map is idempotent.
 
 The proof uses trace nondegeneracy: IsCID forces
 $\operatorname{tr}(Y\, E^n(X \rho_R))$ to be constant in `n` for all `X`, `Y`,
 so $E^n(X \rho_R)$ is constant. Since `ρR` is PosDef (hence invertible),
-$X \rho_R$ ranges over all matrices, giving $E^2 = E$. -/
+$X \rho_R$ ranges over all matrices, giving $E^2 = E$.
+
+**Scope restriction (virtual insertions):** `IsCID` quantifies over arbitrary
+virtual bond matrices, rather than the physical block observables in
+arXiv:1606.00608, Definition 3.3 and Theorem TheoremZCLPure.  The missing
+physical-realization step from lines 1250--1258 is recorded in
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem isCID_implies_isRFP
     (A : MPSTensor d D)
     (ρR : Matrix (Fin D) (Fin D) ℂ)

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -15,21 +15,23 @@ This file defines single-block zero-correlation-length (ZCL) conditions for MPS
 tensors, following arXiv:1606.00608 Section 3.2
 (Cirac–Pérez-García–Schuch–Verstraete).
 
-Three conditions are introduced:
+The following conditions are introduced:
 
-* `IsCID A` — correlations are independent of distance.
+* `IsPositiveGapPhysicalCID A` — physical block-observable correlations are
+  independent of distance when both complementary gaps are positive.
+* `IsCID A` — the stronger virtual-insertion CID condition used by the current
+  converse theorem.
 * `IsLocallyOrthogonal A` — the local single-block convention used here; it is
   transfer-map idempotence.
 * `IsBNTLocallyOrthogonal blocks` — the source BNT-level mixed-sector
   equations.
-* `IsBNTZCL A blocks` — the family `blocks` is a BNT for `A`, and `A`
-  satisfies CID together with the BNT-level mixed-sector equations.
+* `IsBNTZCL A blocks` — the older virtual-insertion BNT surrogate.
+* `IsPositiveGapBNTZCL A blocks` — the physical positive-gap BNT condition.
 * `IsZCL A` — the conjunction of local orthogonality and CID.
 
 The proved local result identifies this single-block convention with an
-idempotent transfer map (`IsRFP`). The BNT-family predicate records the source
-definition with an explicit BNT relation between `A` and `blocks`; the full
-BNT-level ZCL theorem is still tracked in
+idempotent transfer map (`IsRFP`).  Neither BNT predicate records the source
+condition for all disjoint regions; the full BNT-level ZCL theorem is tracked in
 `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`.
 -/
 
@@ -40,21 +42,99 @@ namespace MPSTensor
 variable {d D : ℕ}
 variable {g : ℕ} {dim : Fin g → ℕ}
 
-/-- Correlations independent of distance (arXiv:1606.00608, Definition 3.3):
-the connected two-point correlation function through the transfer map is
-constant in the separation for all local observables.
+/-- The transfer insertion associated with an observable on a block of `L`
+physical spins.  If `σ, τ : Fin L → Fin d` label basis words, then
+`physicalObservableTransfer A O X` is
+`∑_{σ,τ} O_{τ,σ} A^σ X (A^τ)†`.
+
+This is the matrix `𝔼_O` appearing in arXiv:1606.00608, equation `Corr`
+(lines 490--496), written as a map on virtual matrices. -/
+noncomputable def physicalObservableTransfer (A : MPSTensor d D) (L : ℕ)
+    (O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ)
+    (X : Matrix (Fin D) (Fin D) ℂ) : Matrix (Fin D) (Fin D) ℂ :=
+  ∑ σ : Fin L → Fin d, ∑ τ : Fin L → Fin d,
+    O τ σ • (evalWord A (List.ofFn σ) * X * (evalWord A (List.ofFn τ))ᴴ)
+
+/-- The periodic-chain two-region expectation obtained by placing observables
+`O₁` and `O₂` on physical blocks, with `n₁` and `n₂` unobserved sites in the two
+complementary arcs.  This is the trace formula in arXiv:1606.00608, equation
+`Corr` (lines 490--496). -/
+noncomputable def physicalTwoPointExpectation (A : MPSTensor d D)
+    (L₁ L₂ : ℕ)
+    (O₁ : Matrix (Fin L₁ → Fin d) (Fin L₁ → Fin d) ℂ)
+    (O₂ : Matrix (Fin L₂ → Fin d) (Fin L₂ → Fin d) ℂ)
+    (n₁ n₂ : ℕ) : ℂ :=
+  Matrix.trace (physicalObservableTransfer A L₂ O₂
+    (((transferMap A) ^ n₂) (physicalObservableTransfer A L₁ O₁
+      (((transferMap A) ^ n₁) 1))))
+
+/-- Positive-gap physical correlations independent of distance, in the transfer
+formula surrounding arXiv:1606.00608, Definition 3.3 and equation `Corr` (lines
+437--445 and 490--496): translating either of two physical block observables
+through the unobserved part of a fixed periodic chain does not change their
+two-region expectation.  Thus the two complementary gaps may change while
+their sum, and hence the chain length, remains fixed.
+
+The definition permits observables on blocks of arbitrary finite lengths and
+does not replace physical observables by arbitrary virtual bond matrices.
+
+**Scope restriction (arXiv:1606.00608, Definition 3.3):** the source quantifies
+over all disjoint regions, including adjacent regions.  Here both complementary
+gaps are required to be positive.  If a gap is zero, equation `Corr` contains
+`𝔼⁰ = 1`, which does not follow from `𝔼² = 𝔼`.  See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
+def IsPositiveGapPhysicalCID (A : MPSTensor d D) : Prop :=
+  ∀ (L₁ L₂ : ℕ)
+    (O₁ : Matrix (Fin L₁ → Fin d) (Fin L₁ → Fin d) ℂ)
+    (O₂ : Matrix (Fin L₂ → Fin d) (Fin L₂ → Fin d) ℂ)
+    (n₁ n₂ m₁ m₂ : ℕ),
+    1 ≤ n₁ → 1 ≤ n₂ → 1 ≤ m₁ → 1 ≤ m₂ → n₁ + n₂ = m₁ + m₂ →
+    physicalTwoPointExpectation A L₁ L₂ O₁ O₂ n₁ n₂ =
+      physicalTwoPointExpectation A L₁ L₂ O₁ O₂ m₁ m₂
+
+/-- Virtual-insertion correlations independent of distance: the connected
+two-point expression through the transfer map is constant in the separation
+for all virtual bond matrices.
 
 For every positive definite right fixed point `ρR` of the transfer map, the
 connected correlator `C(X,Y;n) = ⟨X₀Yₙ⟩ − ⟨X⟩⟨Y⟩` is the same for all
-separations `n ≥ 1` and all observables `X`, `Y`. Requiring `ρR.PosDef`
-(positive definite) ensures the condition is non-vacuous — CID is only
-meaningful for genuine quantum states, not the zero matrix. -/
+separations `n ≥ 1` and all bond matrices `X`, `Y`.
+
+**Scope restriction:** this is a virtual-insertion surrogate, not Definition
+3.3 of the source.  It is also vacuous when no positive definite fixed point
+exists.  It is retained for the existing virtual converse theorem; the
+positive-gap physical predicate is `IsPositiveGapPhysicalCID` above.  See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 def IsCID (A : MPSTensor d D) : Prop :=
   ∀ (ρR : Matrix (Fin D) (Fin D) ℂ),
     ρR.PosDef → transferMap A ρR = ρR →
     ∀ (X Y : Matrix (Fin D) (Fin D) ℂ) (n m : ℕ),
       1 ≤ n → 1 ≤ m →
       connectedCorrelator A ρR X Y n = connectedCorrelator A ρR X Y m
+
+/-- Idempotence of the transfer map implies positive-gap physical CID.
+
+This is the positive-gap part of the forward implication stated immediately
+before arXiv:1606.00608, Theorem `TheoremZCLPure` (lines 498--502).  Equation
+`Corr` shows the reason directly: every positive power of an idempotent
+transfer map equals the transfer map itself.
+
+**Scope restriction:** adjacent regions are not covered because idempotence
+does not identify `𝔼⁰` with `𝔼`.  This is recorded in
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
+theorem isPositiveGapPhysicalCID_of_isRFP (A : MPSTensor d D) (hRFP : IsRFP A) :
+    IsPositiveGapPhysicalCID A := by
+  intro L₁ L₂ O₁ O₂ n₁ n₂ m₁ m₂ hn₁ hn₂ hm₁ hm₂ _
+  have hIdem : IsIdempotentElem (transferMap A) := hRFP
+  have hpow_n₁ : (transferMap A) ^ n₁ = transferMap A :=
+    hIdem.pow_eq (by omega)
+  have hpow_n₂ : (transferMap A) ^ n₂ = transferMap A :=
+    hIdem.pow_eq (by omega)
+  have hpow_m₁ : (transferMap A) ^ m₁ = transferMap A :=
+    hIdem.pow_eq (by omega)
+  have hpow_m₂ : (transferMap A) ^ m₂ = transferMap A :=
+    hIdem.pow_eq (by omega)
+  simp only [physicalTwoPointExpectation, hpow_n₁, hpow_n₂, hpow_m₁, hpow_m₂]
 
 /-- Local orthogonality in the single-block convention used by this file:
 the self-transfer map is idempotent. Thus, for one tensor `A`, this is
@@ -93,10 +173,14 @@ lemma isBNTLocallyOrthogonal_iff
       ∀ j j' : Fin g, j ≠ j' → mixedTransferMap₂ (blocks j) (blocks j') = 0 :=
   Iff.rfl
 
-/-- BNT-level zero correlation length (arXiv:1606.00608, Definition 3.6):
-`blocks` is a basis of normal tensors for `A`, the generated family has
-correlations independent of distance, and its BNT components satisfy the
-mixed-sector local-orthogonality equations. -/
+/-- BNT-level virtual-insertion zero correlation length: `blocks` is a basis of
+normal tensors for `A`, the virtual correlator is independent of distance, and
+the mixed-sector local-orthogonality equations hold.
+
+**Scope restriction (arXiv:1606.00608, Definition 3.6):** `IsCID` is the older
+virtual-insertion surrogate, rather than the source predicate on all disjoint
+physical regions.  Thus this definition is not the source ZCL definition.  See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 def IsBNTZCL (A : MPSTensor d D)
     (blocks : (j : Fin g) → MPSTensor d (dim j)) : Prop :=
   IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
@@ -110,6 +194,22 @@ lemma isBNTZCL_iff (A : MPSTensor d D)
       IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
         IsCID A ∧ IsBNTLocallyOrthogonal blocks :=
   Iff.rfl
+
+/-- Positive-gap BNT zero correlation length: a BNT family satisfies the
+mixed-sector local-orthogonality equations, while physical block-observable
+correlations are independent of the separation whenever both complementary
+gaps are positive.
+
+**Scope restriction (arXiv:1606.00608, Definition 3.6):** the source permits
+arbitrary disjoint regions, including adjacent regions for which a
+complementary transfer power is `𝔼⁰`.  This predicate excludes those cases.
+It is therefore a positive-gap consequence of transfer idempotence, not the
+source ZCL predicate.  See
+`docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
+def IsPositiveGapBNTZCL (A : MPSTensor d D)
+    (blocks : (j : Fin g) → MPSTensor d (dim j)) : Prop :=
+  IsCPSVBasisOfNormalTensors A (fun j => ⟨dim j, blocks j⟩) ∧
+    IsPositiveGapPhysicalCID A ∧ IsBNTLocallyOrthogonal blocks
 
 /-- Zero correlation length in the single-block convention: a tensor has ZCL
 when it satisfies the local idempotence convention above and has correlations

--- a/TNLean/MPS/RFP/ZeroCorrelationLength.lean
+++ b/TNLean/MPS/RFP/ZeroCorrelationLength.lean
@@ -42,13 +42,14 @@ namespace MPSTensor
 variable {d D : ℕ}
 variable {g : ℕ} {dim : Fin g → ℕ}
 
-/-- The transfer insertion associated with an observable on a block of `L`
-physical spins.  If `σ, τ : Fin L → Fin d` label basis words, then
+/-- The transfer insertion associated with an observable on a block of $L$
+physical spins. If $\sigma,\tau:\operatorname{Fin}(L)\to\operatorname{Fin}(d)$
+label basis words, then
 `physicalObservableTransfer A L O X` equals
 $\sum_{\sigma,\tau} O_{\tau,\sigma}\, A^{\sigma} X (A^{\tau})^{\dagger}$.
 
-This is the matrix $\mathbb{E}_O$ appearing in arXiv:1606.00608, equation Corr
-(lines 490--496), written as a map on virtual matrices. -/
+This is the inserted transfer map $\mathbb{E}_O$ in the two-observable formula
+at arXiv:1606.00608, lines 490--496, written as a map on virtual matrices. -/
 noncomputable def physicalObservableTransfer (A : MPSTensor d D) (L : ℕ)
     (O : Matrix (Fin L → Fin d) (Fin L → Fin d) ℂ) :
     Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] Matrix (Fin D) (Fin D) ℂ :=
@@ -57,9 +58,9 @@ noncomputable def physicalObservableTransfer (A : MPSTensor d D) (L : ℕ)
       (LinearMap.mulRight ℂ (evalWord A (List.ofFn τ))ᴴ))
 
 /-- The periodic-chain two-region expectation obtained by placing observables
-`O₁` and `O₂` on physical blocks, with `n₁` and `n₂` unobserved sites in the two
-complementary arcs.  This is the trace formula in arXiv:1606.00608, equation
-Corr (lines 490--496). -/
+$O_1$ and $O_2$ on physical blocks, with $n_1$ and $n_2$ unobserved sites in
+the two complementary arcs. This is the trace formula at arXiv:1606.00608,
+lines 490--496. -/
 noncomputable def physicalTwoPointExpectation (A : MPSTensor d D)
     (L₁ L₂ : ℕ)
     (O₁ : Matrix (Fin L₁ → Fin d) (Fin L₁ → Fin d) ℂ)
@@ -70,9 +71,9 @@ noncomputable def physicalTwoPointExpectation (A : MPSTensor d D)
       physicalObservableTransfer A L₁ O₁ ∘ₗ ((transferMap A) ^ n₁))
 
 /-- Positive-gap physical correlations independent of distance, in the transfer
-formula surrounding arXiv:1606.00608, Definition 3.3 and equation Corr (lines
-437--445 and 490--496): translating either of two physical block observables
-through the unobserved part of a fixed periodic chain does not change their
+formula surrounding arXiv:1606.00608, Definition 3.3 (lines 437--445) and the
+two-observable formula at lines 490--496: translating either physical block
+observable through the unobserved part of a fixed periodic chain does not change their
 two-region expectation.  Thus the two complementary gaps may change while
 their sum, and hence the chain length, remains fixed.
 
@@ -81,8 +82,9 @@ does not replace physical observables by arbitrary virtual bond matrices.
 
 **Scope restriction (arXiv:1606.00608, Definition 3.3):** the source quantifies
 over all disjoint regions, including adjacent regions.  Here both complementary
-gaps are required to be positive.  If a gap is zero, equation Corr contains
-$\mathbb{E}^0 = 1$, which does not follow from $\mathbb{E}^2 = \mathbb{E}$.  See
+gaps are required to be positive. If a gap is zero, the transfer formula
+contains $\mathbb{E}^0=1$, which does not follow from
+$\mathbb{E}^2=\mathbb{E}$. See
 `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 def IsPositiveGapPhysicalCID (A : MPSTensor d D) : Prop :=
   ∀ (L₁ L₂ : ℕ)
@@ -116,10 +118,11 @@ def IsCID (A : MPSTensor d D) : Prop :=
 
 /-- Idempotence of the transfer map implies positive-gap physical CID.
 
-This is the positive-gap part of the forward implication stated immediately
-before arXiv:1606.00608, Theorem TheoremZCLPure (lines 498--502).  Equation
-Corr shows the reason directly: every positive power of an idempotent
-transfer map equals the transfer map itself.
+This is the positive-gap part of the forward implication at
+arXiv:1606.00608, lines 498--502. The relation
+$\mathbb E_A^n=\mathbb E_A$ for $n\geq 1$ shows the reason directly:
+substitution in the two-observable formula makes the expectation independent
+of both positive gap sizes.
 
 **Scope restriction:** adjacent regions are not covered because idempotence
 does not identify $\mathbb{E}^0$ with $\mathbb{E}$.  This is recorded in
@@ -242,12 +245,12 @@ virtual-insertion correlator implies that the transfer map is idempotent.
 
 The proof uses trace nondegeneracy: IsCID forces
 $\operatorname{tr}(Y\, E^n(X \rho_R))$ to be constant in $n$ for all $X,Y$,
-so $E^n(X \rho_R)$ is constant. Since $\rho_R$ is positive definite and hence invertible,
-$X \rho_R$ ranges over all matrices, giving $E^2 = E$.
+so $E^n(X \rho_R)$ is constant. Since $\rho_R$ is positive definite and hence
+invertible, $X \rho_R$ ranges over all matrices, giving $E^2 = E$.
 
 **Scope restriction (virtual insertions):** `IsCID` quantifies over arbitrary
 virtual bond matrices, rather than the physical block observables in
-arXiv:1606.00608, Definition 3.3 and Theorem TheoremZCLPure.  The missing
+arXiv:1606.00608, Definition 3.3 and the theorem at lines 498--502. The missing
 physical-realization step from lines 1250--1258 is recorded in
 `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex`. -/
 theorem isCID_implies_isRFP
@@ -296,8 +299,8 @@ Reverse: $E^2 = E$ implies $E^n = E$ for $n \geq 1$ by
 `IsIdempotentElem.pow_eq`,
 so the connected correlator is independent of separation, giving CID.
 
-**Scope restriction (arXiv:1606.00608, Theorem TheoremZCLPure):** the source
-theorem is stated for canonical-form tensors and includes the BNT-level local
+**Scope restriction (arXiv:1606.00608, lines 498--502):** the source theorem is
+stated for canonical-form tensors and includes the BNT-level local
 orthogonality equations for distinct components. This result proves the
 single-block idempotence/CID equivalence under the convention above; it is not
 the full BNT-level theorem. See

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -385,10 +385,12 @@ and rates for the single-tensor transfer map $\E_A$.
     \leanok
     \uses{def:bnt_cpsv, def:is_positive_gap_physical_cid,
         def:is_bnt_locally_orthogonal}
-    A BNT family has positive-gap zero correlation length when it is locally
-    orthogonal and its physical correlations are independent of separation
-    whenever both complementary gaps are positive.  Adjacent regions are not
-    included.
+    A family $(A_j)_j$ of MPS tensors has positive-gap BNT zero correlation
+    length for $A$ when $(A_j)_j$ is a basis of normal tensors for $A$ in the
+    sense of Definition~\ref{def:bnt_cpsv}, its components are locally
+    orthogonal, and the physical correlations of $A$ are independent of
+    separation whenever both complementary gaps are positive. Adjacent regions
+    are not included.
 \end{definition}
 
 \begin{lemma}[Positive-gap BNT zero correlation length, unfolded]%

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1175,7 +1175,7 @@ and rates for the single-tensor transfer map $\E_A$.
         \langle\boldsymbol j|O|\boldsymbol i\rangle
         A^{\boldsymbol i}X(A^{\boldsymbol j})^\dagger .
     \]
-    This is the observable transfer map in equation~\path{Corr} of
+    This is the observable transfer map of
     \cite[lines~490--496]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
@@ -1193,7 +1193,7 @@ and rates for the single-tensor transfer map $\E_A$.
         \right).
     \]
     The trace is the operator trace on the virtual matrix space, as in
-    equation~\path{Corr} of \cite[lines~490--496]{Cirac2016MPDO_arXiv}.
+    \cite[lines~490--496]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{definition}[Positive-gap physical distance independence]%

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -391,6 +391,19 @@ and rates for the single-tensor transfer map $\E_A$.
     included.
 \end{definition}
 
+\begin{lemma}[Positive-gap BNT zero correlation length, unfolded]%
+    \label{lem:is_positive_gap_bnt_zcl_iff}
+    \lean{MPSTensor.isPositiveGapBNTZCL_iff}
+    \leanok
+    \uses{def:is_positive_gap_bnt_zcl}
+    Positive-gap BNT zero correlation length is equivalent to the conjunction
+    of the BNT relation, positive-gap physical distance independence, and BNT
+    local orthogonality.
+\end{lemma}
+\begin{proof}\leanok
+    This is the defining conjunction.
+\end{proof}
+
 \begin{definition}[BNT zero correlation length]%
     \label{def:source_bnt_zcl}
     \notready
@@ -422,10 +435,20 @@ and rates for the single-tensor transfer map $\E_A$.
     \uses{thm:is_positive_gap_physical_cid_of_is_rfp,
         thm:bnt_locally_orthogonal_of_rfp_direct_sum}
     Idempotence implies positive-gap physical CID by
-    Theorem~\ref{thm:is_positive_gap_physical_cid_of_is_rfp}.  On every off-diagonal bond
-    block, idempotence of $\E_A$ makes $\E_{j,j'}$ idempotent.  Distinct
-    irreducible left-canonical blocks have mixed spectral radius strictly less
-    than one.  Hence the idempotent $\E_{j,j'}$ is zero.
+    Theorem~\ref{thm:is_positive_gap_physical_cid_of_is_rfp}.  On each
+    off-diagonal bond block, idempotence of $\E_A$ gives
+    \[
+        \E_{j,j'}\circ\E_{j,j'}=\E_{j,j'}.
+    \]
+    Distinct irreducible left-canonical blocks satisfy
+    $\rho(\E_{j,j'})<1$.  Since the spectrum of an idempotent is contained in
+    $\{0,1\}$,
+    \[
+        \E_{j,j'}^2=\E_{j,j'},\qquad
+        \rho(\E_{j,j'})<1
+        \quad\Longrightarrow\quad
+        \E_{j,j'}=0.
+    \]
 \end{proof}
 
 \begin{theorem}[RFP normal tensor is injective]\label{thm:rfp_nt_injective}
@@ -1157,11 +1180,11 @@ and rates for the single-tensor transfer map $\E_A$.
     is unchanged upon replacing these gaps by positive $m_1,m_2$ satisfying
     $n_1+n_2=m_1+m_2$:
     \[
-      \operatorname{tr}\!\left[\E_{O_2}\E_A^{n_2}
-        \E_{O_1}\E_A^{n_1}(1)\right]
+      \operatorname{Tr}_{\MN{D}}\!\left(
+        \E_{O_2}\circ\E_A^{n_2}\circ\E_{O_1}\circ\E_A^{n_1}\right)
       =
-      \operatorname{tr}\!\left[\E_{O_2}\E_A^{m_2}
-        \E_{O_1}\E_A^{m_1}(1)\right].
+      \operatorname{Tr}_{\MN{D}}\!\left(
+        \E_{O_2}\circ\E_A^{m_2}\circ\E_{O_1}\circ\E_A^{m_1}\right).
     \]
     This is the transfer-matrix form of
     \cite[Definition~3.3 and the correlation formula preceding

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1163,11 +1163,45 @@ and rates for the single-tensor transfer map $\E_A$.
     \cite[Definition~3.3]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
+\begin{definition}[Physical observable transfer]
+    \label{def:physical_observable_transfer}
+    \lean{MPSTensor.physicalObservableTransfer}
+    \leanok
+    \uses{def:eval_word}
+    For an observable $O$ on a block of $L$ physical spins, define the linear
+    map on the virtual matrix space by
+    \[
+        \E_O(X)=\sum_{\boldsymbol i,\boldsymbol j}
+        \langle\boldsymbol j|O|\boldsymbol i\rangle
+        A^{\boldsymbol i}X(A^{\boldsymbol j})^\dagger .
+    \]
+    This is the observable transfer map in equation~\path{Corr} of
+    \cite[lines~490--496]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[Two-observable periodic expectation]
+    \label{def:physical_two_point_expectation}
+    \lean{MPSTensor.physicalTwoPointExpectation}
+    \leanok
+    \uses{def:physical_observable_transfer, def:transfer_map}
+    Let $O_1,O_2$ act on blocks of $L_1,L_2$ physical spins, separated around
+    the periodic chain by complementary gaps of lengths $n_1,n_2$.  Their
+    two-observable expectation is
+    \[
+        \operatorname{Tr}_{\MN{D}}\!\left(
+        \E_{O_2}\circ\E_A^{n_2}\circ\E_{O_1}\circ\E_A^{n_1}
+        \right).
+    \]
+    The trace is the operator trace on the virtual matrix space, as in
+    equation~\path{Corr} of \cite[lines~490--496]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
 \begin{definition}[Positive-gap physical distance independence]%
     \label{def:is_positive_gap_physical_cid}
     \lean{MPSTensor.IsPositiveGapPhysicalCID}
     \leanok
-    \uses{def:transfer_map}
+    \uses{def:physical_observable_transfer,
+        def:physical_two_point_expectation}
     For an observable $O$ on a block of $L$ physical spins, write
     \[
         \E_O(X)=\sum_{\boldsymbol i,\boldsymbol j}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -360,7 +360,8 @@ and rates for the single-tensor transfer map $\E_A$.
     \cite[Definition~3.5]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
-\begin{definition}[BNT zero correlation length]\label{def:is_bnt_zcl}
+\begin{definition}[Virtual-insertion BNT zero correlation length]%
+    \label{def:is_bnt_zcl}
     \lean{MPSTensor.IsBNTZCL}
     \leanok
     \uses{def:bnt_cpsv, def:is_cid, def:is_bnt_locally_orthogonal}
@@ -373,8 +374,59 @@ and rates for the single-tensor transfer map $\E_A$.
     \[
         \E_{j,j'}=0.
     \]
-    This is \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
+    This virtual-insertion condition is not
+    \cite[Definition~3.6]{Cirac2016MPDO_arXiv}, which quantifies over physical
+    observables on all disjoint regions.
 \end{definition}
+
+\begin{definition}[Positive-gap BNT zero correlation length]%
+    \label{def:is_positive_gap_bnt_zcl}
+    \lean{MPSTensor.IsPositiveGapBNTZCL}
+    \leanok
+    \uses{def:bnt_cpsv, def:is_positive_gap_physical_cid,
+        def:is_bnt_locally_orthogonal}
+    A BNT family has positive-gap zero correlation length when it is locally
+    orthogonal and its physical correlations are independent of separation
+    whenever both complementary gaps are positive.  Adjacent regions are not
+    included.
+\end{definition}
+
+\begin{definition}[BNT zero correlation length]%
+    \label{def:source_bnt_zcl}
+    \notready
+    \uses{def:bnt_cpsv, def:source_physical_cid,
+        def:is_bnt_locally_orthogonal}
+    A BNT family has zero correlation length when the associated matrix-product
+    vectors have correlations independent of distance for all disjoint physical
+    regions and the BNT components are locally orthogonal.  This is
+    \cite[Definition~3.6]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Direct-sum RFP implies positive-gap BNT zero correlation length]%
+    \label{thm:is_positive_gap_bnt_zcl_of_is_rfp_direct_sum}
+    \lean{MPSTensor.isPositiveGapBNTZCL_of_isRFP_directSum}
+    \leanok
+    \uses{def:is_positive_gap_bnt_zcl, def:is_rfp}
+    Let $(A_j)_j$ be nonzero-dimensional, irreducible, left-canonical,
+    pairwise gauge-phase-distinct BNT components.  If the direct-sum tensor
+    $A=\bigoplus_j A_j$ satisfies $\E_A^2=\E_A$, then $A$ has positive-gap
+    physical CID and
+    \[
+        \E_{j,j'}=0 \qquad (j\ne j').
+    \]
+    Thus this explicit direct-sum representative has positive-gap BNT zero
+    correlation length.  This does not include the adjacent-region cases in
+    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}.
+\end{theorem}
+\begin{proof}\leanok
+    \uses{thm:is_positive_gap_physical_cid_of_is_rfp,
+        thm:bnt_locally_orthogonal_of_rfp_direct_sum}
+    Idempotence implies positive-gap physical CID by
+    Theorem~\ref{thm:is_positive_gap_physical_cid_of_is_rfp}.  On every off-diagonal bond
+    block, idempotence of $\E_A$ makes $\E_{j,j'}$ idempotent.  Distinct
+    irreducible left-canonical blocks have mixed spectral radius strictly less
+    than one.  Hence the idempotent $\E_{j,j'}$ is zero.
+\end{proof}
 
 \begin{theorem}[RFP normal tensor is injective]\label{thm:rfp_nt_injective}
     \lean{MPSTensor.rfp_nt_structural}
@@ -1066,17 +1118,69 @@ and rates for the single-tensor transfer map $\E_A$.
     is deferred here.
 \end{remark}
 
-\begin{definition}[Correlations independent of distance]\label{def:is_cid}
+\begin{definition}[Virtual-insertion distance independence]\label{def:is_cid}
     \lean{MPSTensor.IsCID}
     \leanok
     \uses{def:connected_correlator}
-    For a positive definite right fixed point $\rho^R > 0$, an MPS tensor has
-    \emph{correlations independent of distance} (CID) when for all local
-    observables $X$ and $Y$ and all separations $n,m \ge 1$,
+    For a positive definite right fixed point $\rho^R > 0$, the virtual
+    insertion expression is independent of distance when for all virtual bond
+    matrices $X$ and $Y$ and all separations $n,m \ge 1$,
     \[
         C(X,Y;n) = C(X,Y;m).
     \]
 \end{definition}
+
+\begin{definition}[Physical correlations independent of distance]%
+    \label{def:source_physical_cid}
+    \notready
+    \uses{def:transfer_map}
+    For every pair of observables supported on disjoint physical regions,
+    translating either observable without crossing the other leaves their
+    expectation unchanged.  This includes adjacent regions and is
+    \cite[Definition~3.3]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{definition}[Positive-gap physical distance independence]%
+    \label{def:is_positive_gap_physical_cid}
+    \lean{MPSTensor.IsPositiveGapPhysicalCID}
+    \leanok
+    \uses{def:transfer_map}
+    For an observable $O$ on a block of $L$ physical spins, write
+    \[
+        \E_O(X)=\sum_{\boldsymbol i,\boldsymbol j}
+        \langle\boldsymbol j|O|\boldsymbol i\rangle
+        A^{\boldsymbol i}X(A^{\boldsymbol j})^\dagger .
+    \]
+    Place two finite-block observables $O_1,O_2$ on a periodic chain, with
+    positive complementary gap lengths $n_1,n_2$.  The tensor has
+    \emph{positive-gap physical correlations independent of distance} when the expectation
+    is unchanged upon replacing these gaps by positive $m_1,m_2$ satisfying
+    $n_1+n_2=m_1+m_2$:
+    \[
+      \operatorname{tr}\!\left[\E_{O_2}\E_A^{n_2}
+        \E_{O_1}\E_A^{n_1}(1)\right]
+      =
+      \operatorname{tr}\!\left[\E_{O_2}\E_A^{m_2}
+        \E_{O_1}\E_A^{m_1}(1)\right].
+    \]
+    This is the transfer-matrix form of
+    \cite[Definition~3.3 and the correlation formula preceding
+    Theorem~3.8]{Cirac2016MPDO_arXiv}, restricted to positive complementary
+    gaps.  It excludes adjacent regions.
+\end{definition}
+
+\begin{theorem}[Idempotent transfer implies positive-gap physical CID]%
+    \label{thm:is_positive_gap_physical_cid_of_is_rfp}
+    \lean{MPSTensor.isPositiveGapPhysicalCID_of_isRFP}
+    \leanok
+    \uses{def:is_rfp, def:is_positive_gap_physical_cid}
+    If $\E_A^2=\E_A$, then physical correlations are independent of distance
+    whenever both complementary gaps are positive.
+\end{theorem}
+\begin{proof}\leanok
+    Idempotence gives $\E_A^n=\E_A$ for every $n\geq1$.  Substitution in the
+    two-observable transfer formula makes the separation disappear.
+\end{proof}
 
 \begin{definition}[Zero correlation length]\label{def:is_zcl}
     \lean{MPSTensor.IsZCL}
@@ -1089,18 +1193,21 @@ and rates for the single-tensor transfer map $\E_A$.
         \qquad\text{and}\qquad
         \operatorname{CID}(A)
     \]
-    both hold. The source definition is the BNT condition in
-    Definition~\ref{def:is_bnt_zcl}.
+    both hold. The source definition is
+    Definition~\ref{def:source_bnt_zcl}; the present condition uses virtual
+    insertions instead.
 \end{definition}
 
-\begin{theorem}[CID implies RFP]\label{thm:isCID_implies_isRFP}
+\begin{theorem}[Virtual-insertion distance independence implies RFP]%
+    \label{thm:isCID_implies_isRFP}
     \lean{MPSTensor.isCID_implies_isRFP}
     \leanok
     \uses{def:is_cid, def:is_rfp, def:transfer_map}
-    If an MPS tensor admits a positive definite right fixed point of its
-    transfer map and has correlations independent of distance, then
-    its transfer map is idempotent.
-    This is the reverse direction of \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}.
+    If an MPS tensor admits a positive definite right fixed point and its
+    virtual-insertion correlator is independent of distance, then its transfer
+    map is idempotent.  The reverse direction of
+    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv} additionally requires the
+    realization of the virtual insertions by physical block observables.
 \end{theorem}
 \begin{proof}\leanok
     Trace nondegeneracy and invertibility of the fixed point reduce

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -1263,7 +1263,8 @@ and rates for the single-tensor transfer map $\E_A$.
     \]
     This is the idempotence/CID part of
     \cite[Theorem~3.8]{Cirac2016MPDO_arXiv}. The full source theorem for
-    canonical-form tensors also uses Definition~\ref{def:is_bnt_zcl}.
+    canonical-form tensors instead uses the unrestricted physical condition in
+    Definition~\ref{def:source_bnt_zcl}.
 \end{theorem}
 \begin{proof}\leanok
     The forward direction extracts the idempotence hypothesis. The reverse uses
@@ -1284,7 +1285,7 @@ and rates for the single-tensor transfer map $\E_A$.
     \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}. The ZCL condition in the source
     theorem is the BNT-family condition: CID together with the local
     orthogonality equations $\mathbb E_{j,j'}=0$ for all $j\ne j'$,
-    as in Definition~\ref{def:is_bnt_zcl}.
+    as in Definition~\ref{def:source_bnt_zcl}.
 \end{theorem}
 \begin{proof}\leanok
     \uses{thm:zcl_iff_idempotent_transfer}

--- a/blueprint/src/chapter/ch14_correlations.tex
+++ b/blueprint/src/chapter/ch14_correlations.tex
@@ -423,9 +423,9 @@ and rates for the single-tensor transfer map $\E_A$.
     Let $(A_j)_j$ be nonzero-dimensional, irreducible, left-canonical,
     pairwise gauge-phase-distinct BNT components.  If the direct-sum tensor
     $A=\bigoplus_j A_j$ satisfies $\E_A^2=\E_A$, then $A$ has positive-gap
-    physical CID and
+    physical CID and, for all $j\ne j'$,
     \[
-        \E_{j,j'}=0 \qquad (j\ne j').
+        \E_{j,j'}=0.
     \]
     Thus this explicit direct-sum representative has positive-gap BNT zero
     correlation length.  This does not include the adjacent-region cases in
@@ -1201,8 +1201,19 @@ and rates for the single-tensor transfer map $\E_A$.
     whenever both complementary gaps are positive.
 \end{theorem}
 \begin{proof}\leanok
-    Idempotence gives $\E_A^n=\E_A$ for every $n\geq1$.  Substitution in the
-    two-observable transfer formula makes the separation disappear.
+    Idempotence gives $\E_A^n=\E_A$ for every $n\geq1$.  Substituting
+    $\E_A^{n_1}=\E_A^{n_2}=\E_A^{m_1}=\E_A^{m_2}=\E_A$ in the two-observable
+    transfer formula gives
+    \[
+      \operatorname{Tr}_{\MN{D}}\!\left(
+        \E_{O_2}\circ\E_A^{n_2}\circ\E_{O_1}\circ\E_A^{n_1}\right)
+      =
+      \operatorname{Tr}_{\MN{D}}\!\left(
+        \E_{O_2}\circ\E_A\circ\E_{O_1}\circ\E_A\right)
+      =
+      \operatorname{Tr}_{\MN{D}}\!\left(
+        \E_{O_2}\circ\E_A^{m_2}\circ\E_{O_1}\circ\E_A^{m_1}\right).
+    \]
 \end{proof}
 
 \begin{definition}[Zero correlation length]\label{def:is_zcl}
@@ -1228,9 +1239,10 @@ and rates for the single-tensor transfer map $\E_A$.
     \uses{def:is_cid, def:is_rfp, def:transfer_map}
     If an MPS tensor admits a positive definite right fixed point and its
     virtual-insertion correlator is independent of distance, then its transfer
-    map is idempotent.  The reverse direction of
-    \cite[Theorem~3.8]{Cirac2016MPDO_arXiv} additionally requires the
-    realization of the virtual insertions by physical block observables.
+    map is idempotent.
+    % The reverse direction of Theorem 3.8 in arXiv:1606.00608 additionally
+    % requires realizing the virtual insertions by physical block observables;
+    % that realization step is not yet formalized.
 \end{theorem}
 \begin{proof}\leanok
     Trace nondegeneracy and invertibility of the fixed point reduce
@@ -1271,10 +1283,7 @@ and rates for the single-tensor transfer map $\E_A$.
     This is the single-block consequence of
     \cite[Theorem~3.10]{Cirac2016MPDO_arXiv}. The ZCL condition in the source
     theorem is the BNT-family condition: CID together with the local
-    orthogonality equations
-    \[
-        \mathbb E_{j,j'}=0 \qquad (j\ne j'),
-    \]
+    orthogonality equations $\mathbb E_{j,j'}=0$ for all $j\ne j'$,
     as in Definition~\ref{def:is_bnt_zcl}.
 \end{theorem}
 \begin{proof}\leanok

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -44,7 +44,6 @@ The pure-state theorem states that, for a tensor $A$ in canonical form,
   \mathrm{ZCL}(A)
   \quad\Longleftrightarrow\quad
   \mathbb E_A^2=\mathbb E_A.
-  \tag{\path{TheoremZCLPure}}
 \end{align}
 In the proof, the source first identifies local orthogonality with the equations
 $\mathbb E_{j,j'}=0$ for $j\ne j'$.  After assuming those equations, it proves
@@ -81,8 +80,8 @@ obtained from $\mathbb E_A^n=\mathbb E_A$ for all $n\ge 1$.  The reverse
 direction of that displayed equivalence is immediate because the left-hand side
 already contains $\mathbb E_A^2=\mathbb E_A$.
 
-This is a useful local statement, but it is not the source theorem
-\path{TheoremZCLPure}.  The source theorem uses unrestricted physical CID
+This is a useful local statement, but it is not the source theorem at
+lines 498--502 and 1248--1268. The source theorem uses unrestricted physical CID
 together with the BNT-family mixed-sector equations (LO).  That source
 predicate has no formal counterpart; in particular, it is not the
 virtual-insertion predicate \leanid{MPSTensor.IsBNTZCL}.
@@ -103,8 +102,9 @@ virtual-insertion condition,
   \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr),
 \]
 where $\mathrm{CID}_{\mathrm{virt}}$ quantifies over arbitrary virtual bond
-matrices, and the predicate \leanid{MPSTensor.IsPositiveGapBNTZCL} uses the
-positive-gap physical condition,
+matrices. The positive-gap formal predicate uses the physical condition below,
+\footnote{The formal predicate is
+\path{MPSTensor.IsPositiveGapBNTZCL}.}
 \[
   \mathrm{ZCL}^{\mathrm{pos}}_{\mathrm{BNT}}(A)
   :=
@@ -113,7 +113,8 @@ positive-gap physical condition,
   \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr),
 \]
 where $\mathrm{CID}^{\mathrm{pos}}_{\mathrm{physical}}$ is the positive-gap
-physical predicate \leanid{MPSTensor.IsPositiveGapPhysicalCID}.  Neither
+physical predicate.\footnote{The formal predicate is
+\path{MPSTensor.IsPositiveGapPhysicalCID}.} Neither
 predicate contains the unrestricted physical CID of Definition~3.3, so the
 source zero-correlation-length predicate
 \[
@@ -137,9 +138,9 @@ canonical-form theorem is stated with the BNT predicate.\footnote{Tracked by
 The present theorem is therefore a scope restriction: it records the one-block
 idempotence/CID consequence, while the BNT-level equivalence remains open.
 
-There is a second distinction in the correlation predicate.  Definition~3.3
-quantifies over physical observables on arbitrary finite regions, and
-equation~\path{Corr} inserts such an observable through
+There is a second distinction in the correlation predicate. Definition~3.3
+quantifies over physical observables on arbitrary finite regions, and the
+two-observable formula at lines 490--496 inserts such an observable through
 
 \[
   \mathbb E_O(X)
@@ -159,9 +160,10 @@ It is not the matrix trace obtained by applying this composition to the
 identity matrix; the latter gives a different contraction for a general Kraus
 family.
 
-The predicate \leanid{MPSTensor.IsPositiveGapPhysicalCID} records this formula
-when both complementary gaps between the observed regions are positive.  The
-theorem \leanid{MPSTensor.isPositiveGapPhysicalCID_of_isRFP} proves
+The formal positive-gap predicate records this formula when both complementary
+gaps between the observed regions are positive. The corresponding theorem
+proves\footnote{The formal theorem is
+\path{MPSTensor.isPositiveGapPhysicalCID_of_isRFP}.}
 \[
   \mathbb E_A^2=\mathbb E_A
   \quad\Longrightarrow\quad
@@ -169,12 +171,12 @@ theorem \leanid{MPSTensor.isPositiveGapPhysicalCID_of_isRFP} proves
 \]
 
 This is not yet Definition~3.3, which quantifies over all disjoint regions and
-therefore includes adjacent regions.  For an adjacent pair, one complementary
-transfer power in equation~\path{Corr} is $\mathbb E_A^0=1$.  Idempotence gives
+therefore includes adjacent regions. For an adjacent pair, one complementary
+transfer power in the formula at lines 490--496 is $\mathbb E_A^0=1$. Idempotence gives
 $\mathbb E_A^n=\mathbb E_A$ only for $n\geq1$ and does not identify
 $\mathbb E_A^0$ with $\mathbb E_A$.  The positive-gap theorem is consequently
-a scope restriction, not the full forward implication of
-\path{TheoremZCLPure}.
+a scope restriction, not the full forward implication of the source theorem
+at lines 498--502.
 The older predicate \leanid{MPSTensor.IsCID} instead quantifies directly over
 arbitrary virtual matrices $X,Y$.  Its converse to idempotence is valid, but it
 is stronger than physical CID: the source obtains the required virtual

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -88,18 +88,40 @@ mixed-sector equations (LO).
 
 \section{Elimination plan}
 
-The formalization now has a BNT-family version of local orthogonality carrying
-the equations
+The formalization now has a BNT-family version of local orthogonality,
+\leanid{MPSTensor.IsBNTLocallyOrthogonal}, carrying the equations
+$\mathbb E_{j,j'}=0$ for all $j\ne j'$, and two BNT-family predicates built on
+it.  Writing $\mathrm{BNT}(A)$ for the condition that the family is a basis of
+normal tensors for $A$, the predicate \leanid{MPSTensor.IsBNTZCL} uses the
+virtual-insertion condition,
 \[
-  \mathbb E_{j,j'}=0 \qquad (j\ne j'),
+  \mathrm{ZCL}^{\mathrm{virt}}_{\mathrm{BNT}}(A)
+  :=
+  \mathrm{BNT}(A)\wedge
+  \mathrm{CID}_{\mathrm{virt}}(A)\wedge
+  \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr),
 \]
-and a BNT-family ZCL predicate
+where $\mathrm{CID}_{\mathrm{virt}}$ quantifies over arbitrary virtual bond
+matrices, and the predicate \leanid{MPSTensor.IsPositiveGapBNTZCL} uses the
+positive-gap physical condition,
+\[
+  \mathrm{ZCL}^{\mathrm{pos}}_{\mathrm{BNT}}(A)
+  :=
+  \mathrm{BNT}(A)\wedge
+  \mathrm{CID}^{\mathrm{pos}}_{\mathrm{physical}}(A)\wedge
+  \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr),
+\]
+where $\mathrm{CID}^{\mathrm{pos}}_{\mathrm{physical}}$ is the positive-gap
+physical predicate \leanid{MPSTensor.IsPositiveGapPhysicalCID}.  Neither
+predicate contains the unrestricted physical CID of Definition~3.3, so the
+source zero-correlation-length predicate
 \[
   \mathrm{ZCL}_{\mathrm{BNT}}(A)
   :=
   \mathrm{CID}_{\rm physical}(A)\wedge
-  \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr).
+  \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr)
 \]
+remains without a formal counterpart.
 The remaining target theorem for tensors in canonical form is then
 \[
   \mathrm{ZCL}_{\mathrm{BNT}}(A)
@@ -128,7 +150,7 @@ equation~\path{Corr} inserts such an observable through
 For two observed blocks on a periodic chain, the contraction is the operator
 trace on the virtual matrix space,
 \[
-  \operatorname{Tr}_{\MN{D}}\!\left(
+  \operatorname{Tr}_{M_D(\mathbb C)}\!\left(
     \mathbb E_{O_2}\circ\mathbb E_A^{n_2}\circ
     \mathbb E_{O_1}\circ\mathbb E_A^{n_1}\right).
 \]

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -97,7 +97,7 @@ and a BNT-family ZCL predicate
 \[
   \mathrm{ZCL}_{\mathrm{BNT}}(A)
   :=
-  \mathrm{CID}(A)\wedge
+  \mathrm{CID}_{\rm physical}(A)\wedge
   \bigl(\forall j\ne j',\, \mathbb E_{j,j'}=0\bigr).
 \]
 The remaining target theorem for tensors in canonical form is then
@@ -113,6 +113,51 @@ canonical-form theorem is stated with the BNT predicate.\footnote{Tracked by
 
 The present theorem is therefore a scope restriction: it records the one-block
 idempotence/CID consequence, while the BNT-level equivalence remains open.
+
+There is a second distinction in the correlation predicate.  Definition~3.3
+quantifies over physical observables on arbitrary finite regions, and
+equation~path{Corr} inserts such an observable through
+
+\[
+  \mathbb E_O(X)
+  =\sum_{\boldsymbol i,\boldsymbol j}
+    \langle\boldsymbol j|O|\boldsymbol i\rangle
+    A^{\boldsymbol i}X(A^{\boldsymbol j})^\dagger .
+\]
+
+The predicate \leanid{MPSTensor.IsPositiveGapPhysicalCID} records this formula
+when both complementary gaps between the observed regions are positive.  The
+theorem \leanid{MPSTensor.isPositiveGapPhysicalCID_of_isRFP} proves
+\[
+  \mathbb E_A^2=\mathbb E_A
+  \quad\Longrightarrow\quad
+  \operatorname{CID}_{\rm physical}^{\text{positive gaps}}(A).
+\]
+
+This is not yet Definition~3.3, which quantifies over all disjoint regions and
+therefore includes adjacent regions.  For an adjacent pair, one complementary
+transfer power in equation~\path{Corr} is $\mathbb E_A^0=1$.  Idempotence gives
+$\mathbb E_A^n=\mathbb E_A$ only for $n\geq1$ and does not identify
+$\mathbb E_A^0$ with $\mathbb E_A$.  The positive-gap theorem is consequently
+a scope restriction, not the full forward implication of
+\path{TheoremZCLPure}.
+The older predicate \leanid{MPSTensor.IsCID} instead quantifies directly over
+arbitrary virtual matrices $X,Y$.  Its converse to idempotence is valid, but it
+is stronger than physical CID: the source obtains the required virtual
+insertions from physical observables by block injectivity
+(lines 1250--1258).  Closing the reverse implication therefore requires a
+formal physical-realization theorem for block observables, followed by the
+nonzero power-sum argument in lines 1260--1268.  One must not identify the two
+CID predicates before that realization theorem is proved.  Since the older
+predicate universally quantifies over positive definite fixed points, it is
+also vacuous for a tensor without such a fixed point.  The periodic-chain
+predicate avoids this boundary-state issue.
+
+Accordingly, \leanid{MPSTensor.IsBNTZCL} remains the virtual-insertion
+surrogate, while \leanid{MPSTensor.IsPositiveGapBNTZCL} names the physical
+positive-gap condition.  Neither is Definition~3.6.  The unrestricted source
+BNT zero-correlation-length predicate and its equivalence with transfer
+idempotence remain open.
 
 \bibliographystyle{alpha}
 \bibliography{references}

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -82,9 +82,10 @@ direction of that displayed equivalence is immediate because the left-hand side
 already contains $\mathbb E_A^2=\mathbb E_A$.
 
 This is a useful local statement, but it is not the source theorem
-\path{TheoremZCLPure}: the source theorem uses the BNT-family predicate
-\leanid{MPSTensor.IsBNTZCL}, whose local-orthogonality part is the
-mixed-sector equations (LO).
+\path{TheoremZCLPure}.  The source theorem uses unrestricted physical CID
+together with the BNT-family mixed-sector equations (LO).  That source
+predicate has no formal counterpart; in particular, it is not the
+virtual-insertion predicate \leanid{MPSTensor.IsBNTZCL}.
 
 \section{Elimination plan}
 

--- a/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
+++ b/docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex
@@ -116,7 +116,7 @@ idempotence/CID consequence, while the BNT-level equivalence remains open.
 
 There is a second distinction in the correlation predicate.  Definition~3.3
 quantifies over physical observables on arbitrary finite regions, and
-equation~path{Corr} inserts such an observable through
+equation~\path{Corr} inserts such an observable through
 
 \[
   \mathbb E_O(X)
@@ -124,6 +124,17 @@ equation~path{Corr} inserts such an observable through
     \langle\boldsymbol j|O|\boldsymbol i\rangle
     A^{\boldsymbol i}X(A^{\boldsymbol j})^\dagger .
 \]
+
+For two observed blocks on a periodic chain, the contraction is the operator
+trace on the virtual matrix space,
+\[
+  \operatorname{Tr}_{\MN{D}}\!\left(
+    \mathbb E_{O_2}\circ\mathbb E_A^{n_2}\circ
+    \mathbb E_{O_1}\circ\mathbb E_A^{n_1}\right).
+\]
+It is not the matrix trace obtained by applying this composition to the
+identity matrix; the latter gives a different contraction for a general Kraus
+family.
 
 The predicate \leanid{MPSTensor.IsPositiveGapPhysicalCID} records this formula
 when both complementary gaps between the observed regions are positive.  The


### PR DESCRIPTION
## Summary

This pull request distinguishes physical-observable correlations from the older virtual-insertion surrogate and formalizes the positive-gap part of the forward RFP implication.

It introduces the physical block-observable transfer map and proves that an idempotent transfer map makes two-region expectations independent of the two positive complementary gap lengths. For an explicit canonical direct sum, it combines this result with mixed-sector orthogonality to obtain a positive-gap BNT statement.

The unrestricted source definitions remain explicitly `\notready`: adjacent regions introduce the power `\mathbb E^0=1`, which does not collapse under idempotence, and the reverse implication still requires the block-injectivity realization and nonvanishing power-sum argument. The paper-gap note and chapter 14 blueprint record these restrictions.

Partially addresses #2597.

## Verification

- `lake build TNLean` (9271 jobs)
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- complete 421-page blueprint PDF build
- reader-facing prose and proof-integrity checks
- `git diff --check`

No new proof placeholders are introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive Lean definitions and proofs with explicit scope restrictions; no runtime, auth, or data-path impact. Main risk is conceptual—misreading the new predicates as full CPSV16 ZCL without the documented gaps.
> 
> **Overview**
> Introduces **physical** zero-correlation-length machinery alongside the existing **virtual-insertion** `IsCID` / `IsBNTZCL` surrogates: `physicalObservableTransfer`, `physicalTwoPointExpectation`, `IsPositiveGapPhysicalCID`, and `IsPositiveGapBNTZCL`, with `isPositiveGapPhysicalCID_of_isRFP` showing $\mathbb{E}_A^2=\mathbb{E}_A$ collapses positive gap powers in the two-observable trace formula.
> 
> For an explicit unweighted **direct-sum** BNT family, `isPositiveGapBNTZCL_of_isRFP_directSum` packages positive-gap physical CID with the existing cross-block mixed-transfer vanishing (`isBNTLocallyOrthogonal_of_isRFP_directSum`).
> 
> Blueprint chapter 14 and `docs/paper-gaps/cpsv16_pure_zcl_local_orthogonality_scope.tex` are updated to name the split, mark unrestricted source Definition 3.3/3.6 as `\notready`, and record why **adjacent regions** ($\mathbb{E}^0=1$) and the physical→virtual converse are still out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ee6767ae4ab4f2aa1d62c9c49d2e60a33e5ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->