### PR TITLE
feat(MPS/MPDO): identify Proposition 4.13 contractions

### DIFF
--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -71,6 +71,9 @@ surrogate for the paper's vertical canonical form.
   common left matrix, then the corresponding inserted tensors agree on every
   horizontal canonical-form block, by two applications of
   `blockwise_insert_eq_of_mpv_agree`.
+* `blockwise_opposite_insert_eq_of_rotated_mpo_entries`:
+  the preceding abstract matrices are identified explicitly with the
+  doubled-index contractions of `P H⁽ᴺ⁾`, `P H⁽ᴺ⁾ P`, and `H⁽ᴺ⁾ P`.
 
 The results above supply matrix-product-vector identities and elementary
 positivity consequences, but do not give the passage from horizontal to
@@ -83,7 +86,9 @@ the finite-dimensional obstruction is proved in
 in `docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`. A source-faithful
 argument must instead follow arXiv:1606.00608, lines 1873--1921, using MPDO
 positivity and Lemma L to establish an independent vertical canonical form and
-then proving positivity of its weights.
+then proving positivity of its weights.  The doubled-index coefficient
+identification in the first step is formalized below; deriving its one-sided
+operator identity from a vertical invariant projection remains open.
 
 ## Module location
 
@@ -117,6 +122,198 @@ def FirstSiteActionAgree (A : MPSTensor d D)
   ∀ (N : ℕ) (σ : Fin (N + 1) → Fin d),
     ∑ i : Fin d, Y (σ 0) i * MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ)) =
       ∑ i : Fin d, Z (σ 0) i * MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ))
+
+/-- Equality of all matrix product vectors transports a first-site action
+identity between tensors of possibly different bond dimensions. -/
+theorem FirstSiteActionAgree.of_sameMPV {D' : ℕ} {A : MPSTensor d D}
+    {B : MPSTensor d D'} {Y Z : Matrix (Fin d) (Fin d) ℂ}
+    (hAB : MPSTensor.SameMPV₂ A B) (h : FirstSiteActionAgree A Y Z) :
+    FirstSiteActionAgree B Y Z := by
+  intro N σ
+  calc
+    ∑ i : Fin d, Y (σ 0) i * MPSTensor.mpv B (Fin.cons i (σ ∘ Fin.succ)) =
+        ∑ i : Fin d, Y (σ 0) i * MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ)) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [hAB (N + 1) (Fin.cons i (σ ∘ Fin.succ))]
+    _ = ∑ i : Fin d, Z (σ 0) i *
+        MPSTensor.mpv A (Fin.cons i (σ ∘ Fin.succ)) := h N σ
+    _ = ∑ i : Fin d, Z (σ 0) i *
+        MPSTensor.mpv B (Fin.cons i (σ ∘ Fin.succ)) := by
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [hAB (N + 1) (Fin.cons i (σ ∘ Fin.succ))]
+
+/-! ### Doubled-index form of the three contractions in Proposition 4.13 -/
+
+/-- The doubled-index action obtained by multiplying the ket index by `P`.
+
+For the horizontal MPO contraction this is the first-site form of
+`P H⁽ᴺ⁾`.  It is the leftmost contraction in equation
+`eq1:proof.IV.12` of arXiv:1606.00608, lines 1873--1887. -/
+noncomputable def ketLeftAction (P : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
+  fun p q => if p.modNat = q.modNat then P p.divNat q.divNat else 0
+
+/-- The doubled-index action obtained by multiplying the bra index by `P` on
+the right.  For the horizontal MPO contraction this is the first-site form of
+`H⁽ᴺ⁾ P` in equation `eq1:proof.IV.12` of arXiv:1606.00608,
+lines 1873--1887. -/
+noncomputable def braRightAction (P : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
+  fun p q => if p.divNat = q.divNat then P q.modNat p.modNat else 0
+
+/-- The doubled-index action obtained by multiplying the ket index by `P` and
+the bra index by `P` on the right.  For the horizontal MPO contraction this is
+the first-site form of `P H⁽ᴺ⁾ P` in equation `eq1:proof.IV.12` of
+arXiv:1606.00608, lines 1873--1887. -/
+noncomputable def ketLeftBraRightAction (P : Matrix (Fin d) (Fin d) ℂ) :
+    Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
+  fun p q => P p.divNat q.divNat * P q.modNat p.modNat
+
+@[simp] private theorem finProdFinEquiv_divNat (i j : Fin d) :
+    (finProdFinEquiv (i, j) : Fin (d * d)).divNat = i := by
+  exact congrArg Prod.fst (finProdFinEquiv.symm_apply_apply (i, j))
+
+@[simp] private theorem finProdFinEquiv_modNat (i j : Fin d) :
+    (finProdFinEquiv (i, j) : Fin (d * d)).modNat = j := by
+  exact congrArg Prod.snd (finProdFinEquiv.symm_apply_apply (i, j))
+
+/-- Reading the doubled physical index as a ket--bra pair recovers the
+corresponding matrix entry of the horizontal MPO contraction. -/
+theorem mpv_toMPSTensor_pairConfig (M : MPOTensor d D) {N : ℕ}
+    (σ τ : Fin N → Fin d) :
+    MPSTensor.mpv M.toMPSTensor (fun n => finProdFinEquiv (σ n, τ n)) =
+      MPOTensor.mpo M N σ τ := by
+  simp only [MPSTensor.mpv, MPSTensor.coeff, MPOTensor.mpo_apply,
+    MPOTensor.mpoMatrixEntry]
+  congr 1
+  induction N with
+  | zero => simp
+  | succ N ih =>
+      simp only [List.ofFn_succ, MPSTensor.evalWord_cons, MPOTensor.evalWord_cons,
+        MPOTensor.toMPSTensor]
+      rw [finProdFinEquiv_divNat, finProdFinEquiv_modNat]
+      congr 1
+      convert ih (σ ∘ Fin.succ) (τ ∘ Fin.succ) using 1 <;> rfl
+
+/-- The preceding identity with one doubled index separated from an arbitrary
+doubled-index tail. -/
+theorem mpv_toMPSTensor_cons_pair (M : MPOTensor d D) {N : ℕ}
+    (i j : Fin d) (ρ : Fin N → Fin (d * d)) :
+    MPSTensor.mpv M.toMPSTensor (Fin.cons (finProdFinEquiv (i, j)) ρ) =
+      MPOTensor.mpo M (N + 1) (Fin.cons i (fun n => (ρ n).divNat))
+        (Fin.cons j (fun n => (ρ n).modNat)) := by
+  rw [← mpv_toMPSTensor_pairConfig]
+  congr 1
+  funext n
+  refine Fin.cases ?_ (fun k => ?_) n
+  · rfl
+  · change ρ k = finProdFinEquiv ((ρ k).divNat, (ρ k).modNat)
+    exact (finProdFinEquiv.apply_symm_apply (ρ k)).symm
+
+/-- Coefficient identity identifying the first-site doubled-index ket action
+with the matrix entries of `P H⁽ᴺ⁾`. -/
+theorem ketLeftAction_mpv (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    {N : ℕ} (ρ : Fin (N + 1) → Fin (d * d)) :
+    ∑ q : Fin (d * d), ketLeftAction P (ρ 0) q *
+        MPSTensor.mpv M.toMPSTensor (Fin.cons q (ρ ∘ Fin.succ)) =
+      ∑ i : Fin d, P (ρ 0).divNat i *
+        MPOTensor.mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons (ρ 0).modNat (fun n => (ρ (Fin.succ n)).modNat)) := by
+  rw [← finProdFinEquiv.sum_comp]
+  rw [Fintype.sum_prod_type]
+  simp only [ketLeftAction, finProdFinEquiv_divNat, finProdFinEquiv_modNat]
+  apply Finset.sum_congr rfl
+  intro i _
+  rw [Finset.sum_eq_single (ρ 0).modNat]
+  · simp only [if_true]
+    rw [mpv_toMPSTensor_cons_pair]
+    rfl
+  · intro j _ hj
+    simp only [hj.symm, if_false, zero_mul]
+  · intro hj
+    exact (hj (Finset.mem_univ _)).elim
+
+/-- Coefficient identity identifying the first-site doubled-index bra action
+with the matrix entries of `H⁽ᴺ⁾ P`. -/
+theorem braRightAction_mpv (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    {N : ℕ} (ρ : Fin (N + 1) → Fin (d * d)) :
+    ∑ q : Fin (d * d), braRightAction P (ρ 0) q *
+        MPSTensor.mpv M.toMPSTensor (Fin.cons q (ρ ∘ Fin.succ)) =
+      ∑ j : Fin d,
+        MPOTensor.mpo M (N + 1)
+          (Fin.cons (ρ 0).divNat (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons j (fun n => (ρ (Fin.succ n)).modNat)) * P j (ρ 0).modNat := by
+  rw [← finProdFinEquiv.sum_comp]
+  rw [Fintype.sum_prod_type]
+  simp only [braRightAction, finProdFinEquiv_divNat, finProdFinEquiv_modNat,
+    ite_mul]
+  rw [Finset.sum_eq_single (ρ 0).divNat]
+  · apply Finset.sum_congr rfl
+    intro j _
+    simp only [if_true]
+    rw [mpv_toMPSTensor_cons_pair]
+    simp only [Function.comp_apply, mul_comm]
+  · intro i _ hi
+    simp only [hi.symm, if_false, zero_mul, Finset.sum_const_zero]
+  · intro hi
+    exact (hi (Finset.mem_univ _)).elim
+
+/-- Coefficient identity identifying the two-sided first-site doubled-index
+action with the matrix entries of `P H⁽ᴺ⁾ P`. -/
+theorem ketLeftBraRightAction_mpv (M : MPOTensor d D)
+    (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ} (ρ : Fin (N + 1) → Fin (d * d)) :
+    ∑ q : Fin (d * d), ketLeftBraRightAction P (ρ 0) q *
+        MPSTensor.mpv M.toMPSTensor (Fin.cons q (ρ ∘ Fin.succ)) =
+      ∑ i : Fin d, ∑ j : Fin d, P (ρ 0).divNat i *
+        MPOTensor.mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons j (fun n => (ρ (Fin.succ n)).modNat)) * P j (ρ 0).modNat := by
+  rw [← finProdFinEquiv.sum_comp]
+  rw [Fintype.sum_prod_type]
+  simp only [ketLeftBraRightAction, finProdFinEquiv_divNat, finProdFinEquiv_modNat]
+  apply Finset.sum_congr rfl
+  intro i _
+  apply Finset.sum_congr rfl
+  intro j _
+  rw [mpv_toMPSTensor_cons_pair]
+  simp only [Function.comp_apply]
+  ring
+
+/-- Entrywise equality `P H⁽ᴺ⁾ = P H⁽ᴺ⁾ P` gives the first of
+the two doubled-index first-site equalities used in Lemma L. -/
+theorem firstSiteActionAgree_ketLeft_ketLeftBraRight
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (hInv : ∀ (N : ℕ) (ρ : Fin (N + 1) → Fin (d * d)),
+      (∑ i : Fin d, P (ρ 0).divNat i *
+        MPOTensor.mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons (ρ 0).modNat (fun n => (ρ (Fin.succ n)).modNat)) =
+      ∑ i : Fin d, ∑ j : Fin d, P (ρ 0).divNat i *
+        MPOTensor.mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons j (fun n => (ρ (Fin.succ n)).modNat)) * P j (ρ 0).modNat)) :
+    MPSTensor.FirstSiteActionAgree M.toMPSTensor
+      (ketLeftAction P) (ketLeftBraRightAction P) := by
+  intro N ρ
+  rw [ketLeftAction_mpv, ketLeftBraRightAction_mpv]
+  exact hInv N ρ
+
+/-- Entrywise equality `P H⁽ᴺ⁾ = H⁽ᴺ⁾ P` gives the second of the
+two doubled-index first-site equalities used in Lemma L. -/
+theorem firstSiteActionAgree_ketLeft_braRight
+    (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
+    (hComm : ∀ (N : ℕ) (ρ : Fin (N + 1) → Fin (d * d)),
+      (∑ i : Fin d, P (ρ 0).divNat i *
+        MPOTensor.mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons (ρ 0).modNat (fun n => (ρ (Fin.succ n)).modNat)) =
+      ∑ j : Fin d,
+        MPOTensor.mpo M (N + 1)
+          (Fin.cons (ρ 0).divNat (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons j (fun n => (ρ (Fin.succ n)).modNat)) * P j (ρ 0).modNat)) :
+    MPSTensor.FirstSiteActionAgree M.toMPSTensor
+      (ketLeftAction P) (braRightAction P) := by
+  intro N ρ
+  rw [ketLeftAction_mpv, braRightAction_mpv]
+  exact hComm N ρ
 
 /-- Evaluating a reindexed word: `evalWord B (l.map g) = evalWord (B ∘ g) l`. -/
 lemma evalWord_map {d' : ℕ} (B : MPSTensor d' D) (g : Fin d → Fin d') (l : List (Fin d)) :
@@ -649,6 +846,50 @@ theorem blockwise_opposite_insert_eq_of_mpv_agree
       (blockwise_insert_eq_of_mpv_agree A hCF hPos k).symm
     _ = MPSTensor.insertedTensor Ycorner (A k) :=
       blockwise_insert_eq_of_mpv_agree A hCF hInv k
+
+/-- **The three contractions in Proposition 4.13, with their indices fixed.**
+
+Suppose the horizontal doubled-index tensor of `M` has the displayed
+block-diagonal canonical form.  The entrywise identities
+`P H⁽ᴺ⁾ = P H⁽ᴺ⁾ P` and `P H⁽ᴺ⁾ = H⁽ᴺ⁾ P` then identify
+the three abstract first-site matrices in Lemma L with `ketLeftAction P`,
+`ketLeftBraRightAction P`, and `braRightAction P`.  Consequently the last two
+insertions agree on every canonical-form block.
+
+This formalizes the doubled-index rotation implicit in equation
+`eq1:proof.IV.12` of arXiv:1606.00608, Proposition 4.13, lines 1873--1887.  It
+does not prove that a one-sided invariant projection for the vertically viewed
+tensor supplies the first entrywise identity; that further identification
+remains part of the horizontal-to-vertical canonical-form argument. -/
+theorem blockwise_opposite_insert_eq_of_rotated_mpo_entries
+    {r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
+    (M : MPOTensor d D) (A : (k : Fin r) → MPSTensor (d * d) (dim k))
+    (hCF : HorizontalCFData (d := d * d) μ A)
+    (hM : MPSTensor.SameMPV₂ M.toMPSTensor
+      (MPSTensor.toTensorFromBlocks (d := d * d) (μ := μ) A))
+    (P : Matrix (Fin d) (Fin d) ℂ)
+    (hInv : ∀ (N : ℕ) (ρ : Fin (N + 1) → Fin (d * d)),
+      (∑ i : Fin d, P (ρ 0).divNat i *
+        mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons (ρ 0).modNat (fun n => (ρ (Fin.succ n)).modNat)) =
+      ∑ i : Fin d, ∑ j : Fin d, P (ρ 0).divNat i *
+        mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons j (fun n => (ρ (Fin.succ n)).modNat)) * P j (ρ 0).modNat))
+    (hComm : ∀ (N : ℕ) (ρ : Fin (N + 1) → Fin (d * d)),
+      (∑ i : Fin d, P (ρ 0).divNat i *
+        mpo M (N + 1) (Fin.cons i (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons (ρ 0).modNat (fun n => (ρ (Fin.succ n)).modNat)) =
+      ∑ j : Fin d,
+        mpo M (N + 1)
+          (Fin.cons (ρ 0).divNat (fun n => (ρ (Fin.succ n)).divNat))
+          (Fin.cons j (fun n => (ρ (Fin.succ n)).modNat)) * P j (ρ 0).modNat)) :
+    ∀ k, MPSTensor.insertedTensor (MPSTensor.braRightAction P) (A k) =
+      MPSTensor.insertedTensor (MPSTensor.ketLeftBraRightAction P) (A k) := by
+  apply blockwise_opposite_insert_eq_of_mpv_agree A hCF
+  · exact MPSTensor.FirstSiteActionAgree.of_sameMPV hM
+      (MPSTensor.firstSiteActionAgree_ketLeft_ketLeftBraRight M P hInv)
+  · exact MPSTensor.FirstSiteActionAgree.of_sameMPV hM
+      (MPSTensor.firstSiteActionAgree_ketLeft_braRight M P hComm)
 
 -- The implication `verticalCF_of_horizontalCF` (arXiv:1606.00608,
 -- Proposition 4.13) — every MPDO in horizontal canonical form is in vertical

--- a/TNLean/MPS/MPDO/VerticalCF.lean
+++ b/TNLean/MPS/MPDO/VerticalCF.lean
@@ -73,7 +73,7 @@ surrogate for the paper's vertical canonical form.
   `blockwise_insert_eq_of_mpv_agree`.
 * `blockwise_opposite_insert_eq_of_rotated_mpo_entries`:
   the preceding abstract matrices are identified explicitly with the
-  doubled-index contractions of `P H⁽ᴺ⁾`, `P H⁽ᴺ⁾ P`, and `H⁽ᴺ⁾ P`.
+  doubled-index contractions of $PH^{(N)}$, $PH^{(N)}P$, and $H^{(N)}P$.
 
 The results above supply matrix-product-vector identities and elementary
 positivity consequences, but do not give the passage from horizontal to
@@ -149,24 +149,24 @@ theorem FirstSiteActionAgree.of_sameMPV {D' : ℕ} {A : MPSTensor d D}
 /-- The doubled-index action obtained by multiplying the ket index by `P`.
 
 For the horizontal MPO contraction this is the first-site form of
-`P H⁽ᴺ⁾`.  It is the leftmost contraction in equation
-`eq1:proof.IV.12` of arXiv:1606.00608, lines 1873--1887. -/
+$PH^{(N)}$.  It is the leftmost contraction in the displayed equation of
+the proof of Proposition 4.13 of arXiv:1606.00608, lines 1873--1887. -/
 noncomputable def ketLeftAction (P : Matrix (Fin d) (Fin d) ℂ) :
     Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
   fun p q => if p.modNat = q.modNat then P p.divNat q.divNat else 0
 
 /-- The doubled-index action obtained by multiplying the bra index by `P` on
 the right.  For the horizontal MPO contraction this is the first-site form of
-`H⁽ᴺ⁾ P` in equation `eq1:proof.IV.12` of arXiv:1606.00608,
-lines 1873--1887. -/
+$H^{(N)}P$ in the displayed equation of the proof of Proposition 4.13 of
+arXiv:1606.00608, lines 1873--1887. -/
 noncomputable def braRightAction (P : Matrix (Fin d) (Fin d) ℂ) :
     Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
   fun p q => if p.divNat = q.divNat then P q.modNat p.modNat else 0
 
 /-- The doubled-index action obtained by multiplying the ket index by `P` and
 the bra index by `P` on the right.  For the horizontal MPO contraction this is
-the first-site form of `P H⁽ᴺ⁾ P` in equation `eq1:proof.IV.12` of
-arXiv:1606.00608, lines 1873--1887. -/
+the first-site form of $PH^{(N)}P$ in the displayed equation of the proof of
+Proposition 4.13 of arXiv:1606.00608, lines 1873--1887. -/
 noncomputable def ketLeftBraRightAction (P : Matrix (Fin d) (Fin d) ℂ) :
     Matrix (Fin (d * d)) (Fin (d * d)) ℂ :=
   fun p q => P p.divNat q.divNat * P q.modNat p.modNat
@@ -213,7 +213,7 @@ theorem mpv_toMPSTensor_cons_pair (M : MPOTensor d D) {N : ℕ}
     exact (finProdFinEquiv.apply_symm_apply (ρ k)).symm
 
 /-- Coefficient identity identifying the first-site doubled-index ket action
-with the matrix entries of `P H⁽ᴺ⁾`. -/
+with the matrix entries of $PH^{(N)}$. -/
 theorem ketLeftAction_mpv (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
     {N : ℕ} (ρ : Fin (N + 1) → Fin (d * d)) :
     ∑ q : Fin (d * d), ketLeftAction P (ρ 0) q *
@@ -236,7 +236,7 @@ theorem ketLeftAction_mpv (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
     exact (hj (Finset.mem_univ _)).elim
 
 /-- Coefficient identity identifying the first-site doubled-index bra action
-with the matrix entries of `H⁽ᴺ⁾ P`. -/
+with the matrix entries of $H^{(N)}P$. -/
 theorem braRightAction_mpv (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
     {N : ℕ} (ρ : Fin (N + 1) → Fin (d * d)) :
     ∑ q : Fin (d * d), braRightAction P (ρ 0) q *
@@ -261,7 +261,7 @@ theorem braRightAction_mpv (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
     exact (hi (Finset.mem_univ _)).elim
 
 /-- Coefficient identity identifying the two-sided first-site doubled-index
-action with the matrix entries of `P H⁽ᴺ⁾ P`. -/
+action with the matrix entries of $PH^{(N)}P$. -/
 theorem ketLeftBraRightAction_mpv (M : MPOTensor d D)
     (P : Matrix (Fin d) (Fin d) ℂ) {N : ℕ} (ρ : Fin (N + 1) → Fin (d * d)) :
     ∑ q : Fin (d * d), ketLeftBraRightAction P (ρ 0) q *
@@ -280,7 +280,7 @@ theorem ketLeftBraRightAction_mpv (M : MPOTensor d D)
   simp only [Function.comp_apply]
   ring
 
-/-- Entrywise equality `P H⁽ᴺ⁾ = P H⁽ᴺ⁾ P` gives the first of
+/-- Entrywise equality $PH^{(N)} = PH^{(N)}P$ gives the first of
 the two doubled-index first-site equalities used in Lemma L. -/
 theorem firstSiteActionAgree_ketLeft_ketLeftBraRight
     (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
@@ -297,7 +297,7 @@ theorem firstSiteActionAgree_ketLeft_ketLeftBraRight
   rw [ketLeftAction_mpv, ketLeftBraRightAction_mpv]
   exact hInv N ρ
 
-/-- Entrywise equality `P H⁽ᴺ⁾ = H⁽ᴺ⁾ P` gives the second of the
+/-- Entrywise equality $PH^{(N)} = H^{(N)}P$ gives the second of the
 two doubled-index first-site equalities used in Lemma L. -/
 theorem firstSiteActionAgree_ketLeft_braRight
     (M : MPOTensor d D) (P : Matrix (Fin d) (Fin d) ℂ)
@@ -434,7 +434,7 @@ theorem mpv_diagonalTensor_nonneg (M : MPOTensor d D) {N : ℕ}
 /-- For an MPDO, a one-sided invariant Hermitian matrix for an `N`-site density
 operator has zero opposite corner.
 
-This is equation `eq1:proof.IV.12` in the proof of Proposition 4.13 of
+This is the displayed equation in the proof of Proposition 4.13 of
 arXiv:1606.00608, lines 1873--1887.  The subsequent use of Lemma L transfers
 this operator equality back to the tensor blocks. Positivity supplies the
 Hermiticity of the density operator; the algebraic corner argument then uses
@@ -818,16 +818,16 @@ theorem blockwise_insert_eq_of_mpv_agree
 /-- **One-sided invariance becomes reduction, block by block.**
 
 Let `Yleft`, `Ycorner`, and `Yright` encode respectively the first-site
-coefficients of `P H⁽ᴺ⁾`, `P H⁽ᴺ⁾ P`, and `H⁽ᴺ⁾ P`.  If the
+coefficients of $PH^{(N)}$, $PH^{(N)}P$, and $H^{(N)}P$.  If the
 one-sided invariance gives agreement of the first two actions, while positivity
 gives agreement of the first and third actions, then Lemma L shows that the
 opposite corner vanishes on every canonical-form block: the `Yright` insertion
 equals the `Ycorner` insertion.
 
-This is the tensor-block conclusion of equation `eq1:proof.IV.12` in
-arXiv:1606.00608, Proposition 4.13, lines 1873--1887.  The two hypotheses are
-precisely the coefficient-level equalities displayed in that equation; they do
-not posit a vertical canonical decomposition. -/
+This is the tensor-block conclusion of the displayed equation in the proof
+of Proposition 4.13 of arXiv:1606.00608, lines 1873--1887.  The two
+hypotheses are precisely the coefficient-level equalities displayed in that
+equation; they do not posit a vertical canonical decomposition. -/
 theorem blockwise_opposite_insert_eq_of_mpv_agree
     {r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
     (A : (k : Fin r) → MPSTensor d (dim k))
@@ -851,16 +851,17 @@ theorem blockwise_opposite_insert_eq_of_mpv_agree
 
 Suppose the horizontal doubled-index tensor of `M` has the displayed
 block-diagonal canonical form.  The entrywise identities
-`P H⁽ᴺ⁾ = P H⁽ᴺ⁾ P` and `P H⁽ᴺ⁾ = H⁽ᴺ⁾ P` then identify
+$PH^{(N)} = PH^{(N)}P$ and $PH^{(N)} = H^{(N)}P$ then identify
 the three abstract first-site matrices in Lemma L with `ketLeftAction P`,
 `ketLeftBraRightAction P`, and `braRightAction P`.  Consequently the last two
 insertions agree on every canonical-form block.
 
-This formalizes the doubled-index rotation implicit in equation
-`eq1:proof.IV.12` of arXiv:1606.00608, Proposition 4.13, lines 1873--1887.  It
-does not prove that a one-sided invariant projection for the vertically viewed
-tensor supplies the first entrywise identity; that further identification
-remains part of the horizontal-to-vertical canonical-form argument. -/
+This formalizes the doubled-index rotation implicit in the displayed
+equation of the proof of Proposition 4.13 of arXiv:1606.00608,
+lines 1873--1887.  It does not prove that a one-sided invariant projection
+for the vertically viewed tensor supplies the first entrywise identity; that
+further identification remains part of the horizontal-to-vertical
+canonical-form argument. -/
 theorem blockwise_opposite_insert_eq_of_rotated_mpo_entries
     {r : ℕ} {dim : Fin r → ℕ} {μ : Fin r → ℂ}
     (M : MPOTensor d D) (A : (k : Fin r) → MPSTensor (d * d) (dim k))

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -229,12 +229,13 @@
         V^{(N)}(\widehat M)_{(\sigma,\tau)}
         =H^{(N)}(M)_{\sigma,\tau}.
     \]
-    If $p_0=(a,b)$ is the first doubled index, contraction with $Y_L$,
-    $Y_R$, and $Y_C$ gives, respectively,
+    If $p_0=(a,b)$ is the first doubled index and $\sigma',\tau'$ are the
+    ket and bra configurations on the remaining $N$ sites, contraction with
+    $Y_L$, $Y_R$, and $Y_C$ gives, respectively,
     \begin{align*}
-        \sum_c P_{a,c}H^{(N)}_{(c,\sigma'),(b,\tau')},\qquad
-        \sum_e H^{(N)}_{(a,\sigma'),(e,\tau')}P_{e,b},\\
-        \sum_{c,e}P_{a,c}H^{(N)}_{(c,\sigma'),(e,\tau')}P_{e,b}.
+        \sum_c P_{a,c}H^{(N+1)}_{(c,\sigma'),(b,\tau')},\qquad
+        \sum_e H^{(N+1)}_{(a,\sigma'),(e,\tau')}P_{e,b},\\
+        \sum_{c,e}P_{a,c}H^{(N+1)}_{(c,\sigma'),(e,\tau')}P_{e,b}.
     \end{align*}
 \end{lemma}
 

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -200,6 +200,86 @@
     Transitivity gives the stated equality.
 \end{proof}
 
+\begin{definition}[Doubled-index forms of the three first-site contractions]
+    \label{def:mpdo_three_first_site_contractions}
+    \lean{MPSTensor.ketLeftAction}
+    \lean{MPSTensor.braRightAction}
+    \lean{MPSTensor.ketLeftBraRightAction}
+    \leanok
+    Let $P\in M_d(\C)$ and write doubled indices as $p=(a,b)$ and
+    $q=(c,e)$.  The first-site matrices corresponding respectively to
+    $PH^{(N)}$, $H^{(N)}P$, and $PH^{(N)}P$ are
+    \[
+        (Y_L)_{p,q}=P_{a,c}\delta_{b,e},\qquad
+        (Y_R)_{p,q}=\delta_{a,c}P_{e,b},\qquad
+        (Y_C)_{p,q}=P_{a,c}P_{e,b}.
+    \]
+\end{definition}
+
+\begin{lemma}[Coefficient form of the three first-site contractions]
+    \label{lem:mpdo_three_first_site_contraction_coefficients}
+    \lean{MPSTensor.mpv_toMPSTensor_pairConfig}
+    \lean{MPSTensor.ketLeftAction_mpv}
+    \lean{MPSTensor.braRightAction_mpv}
+    \lean{MPSTensor.ketLeftBraRightAction_mpv}
+    \leanok
+    \uses{def:mpo_family, def:mpo_three_first_site_contractions}
+    For ket and bra configurations $\sigma,\tau$,
+    \[
+        V^{(N)}(\widehat M)_{(\sigma,\tau)}
+        =H^{(N)}(M)_{\sigma,\tau}.
+    \]
+    If $p_0=(a,b)$ is the first doubled index, contraction with $Y_L$,
+    $Y_R$, and $Y_C$ gives, respectively,
+    \begin{align*}
+        \sum_c P_{a,c}H^{(N)}_{(c,\sigma'),(b,\tau')},\qquad
+        \sum_e H^{(N)}_{(a,\sigma'),(e,\tau')}P_{e,b},\\
+        \sum_{c,e}P_{a,c}H^{(N)}_{(c,\sigma'),(e,\tau')}P_{e,b}.
+    \end{align*}
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Decode the doubled index at every site as a ket--bra pair.  The defining
+    trace of the resulting matrix word is exactly the corresponding entry of
+    $H^{(N)}(M)$.  Summing the first doubled index against $Y_L$, $Y_R$, or
+    $Y_C$ leaves the displayed single or double sums.
+\end{proof}
+
+\begin{theorem}[Blockwise reduction for the MPO contractions]
+    \label{thm:blockwise_opposite_insert_rotated_mpo}
+    \lean{MPSTensor.FirstSiteActionAgree.of_sameMPV}
+    \lean{MPSTensor.firstSiteActionAgree_ketLeft_ketLeftBraRight}
+    \lean{MPSTensor.firstSiteActionAgree_ketLeft_braRight}
+    \lean{MPOTensor.blockwise_opposite_insert_eq_of_rotated_mpo_entries}
+    \leanok
+    \uses{def:mpdo_three_first_site_contractions,
+        lem:mpdo_three_first_site_contraction_coefficients,
+        thm:blockwise_opposite_insert_eq}
+    Let the doubled-index tensor $\widehat M$ have a block-injective
+    canonical-form decomposition $\bigoplus_k\mu_kA_k$.  If, entrywise for
+    every positive length,
+    \[
+        PH^{(N)}=PH^{(N)}P,
+        \qquad
+        PH^{(N)}=H^{(N)}P,
+    \]
+    then for every block $A_k$ the insertions associated with $H^{(N)}P$ and
+    $PH^{(N)}P$ agree.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{lem:mpdo_three_first_site_contraction_coefficients,
+        thm:blockwise_opposite_insert_eq}
+    Lemma~\ref{lem:mpdo_three_first_site_contraction_coefficients} turns the
+    two operator identities into equality of the corresponding first-site
+    contractions.  Equality of matrix product vectors transports these
+    equalities to the chosen canonical-form decomposition.  Apply
+    Theorem~\ref{thm:blockwise_opposite_insert_eq} with
+    $(Y_L,Y_C,Y_R)$.
+\end{proof}
+
 \begin{lemma}[Matrix product vector of the diagonal tensor]
     \label{lem:mpv_diagonal_tensor}
     \lean{MPOTensor.mpv_diagonalTensor}
@@ -544,6 +624,7 @@
     \notready
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
         thm:mpdo_opposite_corner_zero, thm:blockwise_opposite_insert_eq,
+        thm:blockwise_opposite_insert_rotated_mpo,
         lem:mpv_diagonal_tensor,
         lem:mpv_diagonal_tensor_eq_blocks, lem:mpv_diagonal_tensor_nonneg,
         lem:mpv_vertical_assembled,
@@ -554,15 +635,16 @@
 \begin{proof}
     \uses{def:mpdo, def:horizontal_cf_mpdo, def:vertical_cf_mpdo,
         thm:mpdo_opposite_corner_zero, thm:blockwise_opposite_insert_eq,
+        thm:blockwise_opposite_insert_rotated_mpo,
         lem:mpv_diagonal_tensor,
         lem:vertical_grouping_equiv}
     Theorem~\ref{thm:mpdo_opposite_corner_zero} gives the positive-operator
     identity needed to exclude a one-sided invariant projection, and
-    Theorem~\ref{thm:blockwise_opposite_insert_eq} gives its blockwise
-    consequence once the corresponding first-site contractions have been
-    identified.  It remains to identify those contractions with
-    $PH^{(N)}$, $PH^{(N)}P$, and $H^{(N)}P$ for the tensor viewed in the
-    vertical direction.  One must then exclude nontrivial periodic sectors and
+    Theorem~\ref{thm:blockwise_opposite_insert_rotated_mpo} identifies the
+    corresponding doubled-index first-site contractions and gives their
+    blockwise consequence from the two entrywise operator identities.  It
+    remains to derive the first identity from a one-sided invariant projection
+    for the vertically viewed tensor.  One must then exclude nontrivial periodic sectors and
     apply the canonical-form theorem to obtain a new vertical family
     $(B_k)_{k\in I}$ and weights $\nu_k$.  This family is not obtained by
     restricting the horizontal blocks to diagonal physical pairs, as

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -248,9 +248,6 @@
 
 \begin{theorem}[Blockwise reduction for the MPO contractions]
     \label{thm:blockwise_opposite_insert_rotated_mpo}
-    \lean{MPSTensor.FirstSiteActionAgree.of_sameMPV}
-    \lean{MPSTensor.firstSiteActionAgree_ketLeft_ketLeftBraRight}
-    \lean{MPSTensor.firstSiteActionAgree_ketLeft_braRight}
     \lean{MPOTensor.blockwise_opposite_insert_eq_of_rotated_mpo_entries}
     \leanok
     \uses{def:mpdo_three_first_site_contractions,

--- a/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
+++ b/blueprint/src/chapter/ch20_mpdo_canonical_forms.tex
@@ -223,7 +223,7 @@
     \lean{MPSTensor.braRightAction_mpv}
     \lean{MPSTensor.ketLeftBraRightAction_mpv}
     \leanok
-    \uses{def:mpo_family, def:mpo_three_first_site_contractions}
+    \uses{def:mpo_family, def:mpdo_three_first_site_contractions}
     For ket and bra configurations $\sigma,\tau$,
     \[
         V^{(N)}(\widehat M)_{(\sigma,\tau)}

--- a/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
+++ b/docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex
@@ -106,14 +106,24 @@ $P=P^*$, and $PH=PHP$, then
     \qquad
     (I-P)HP=0.
 \]
-The corresponding two applications of the first-site insertion lemma are also
-formalized: agreement of the contractions representing $PH^{(N)}$ and
-$PH^{(N)}P$, together with agreement of those representing $PH^{(N)}$ and
-$H^{(N)}P$, forces equality of the opposite-corner insertions on every
-horizontal canonical-form block.  Completing the first stage still requires
-the explicit identification of these three contractions with the rotated
-vertical tensor.  The exclusion of periodic sectors and the independent
-vertical canonical-form construction also remain open.
+The doubled-index forms of the three first-site contractions are now explicit.
+For doubled indices $p=(a,b)$ and $q=(c,e)$ they are
+\[
+  (Y_L)_{p,q}=P_{a,c}\delta_{b,e},\qquad
+  (Y_R)_{p,q}=\delta_{a,c}P_{e,b},\qquad
+  (Y_C)_{p,q}=P_{a,c}P_{e,b}.
+\]
+Their contractions with the horizontal matrix product vector are proved to be
+the entries of $PH^{(N)}$, $H^{(N)}P$, and $PH^{(N)}P$, respectively.
+Consequently, the corresponding two applications of the first-site insertion
+lemma are formalized without abstract placeholder matrices: the two entrywise
+operator identities force equality of the opposite-corner insertions on every
+horizontal canonical-form block.
+
+Completing the first stage still requires deriving
+$PH^{(N)}=PH^{(N)}P$ from a one-sided invariant projection of the tensor viewed
+vertically.  The exclusion of periodic sectors and the independent vertical
+canonical-form construction also remain open.
 
 \paragraph{Verdict.}
 This is an open gap: the source-faithful horizontal-to-vertical implication of


### PR DESCRIPTION
### Motivation

- Proposition 4.13 of arXiv:1606.00608 (lines 1873–1887) rules out a one-sided invariant projection on the vertical bond space by identifying the doubled physical index of the horizontal MPO with the ket–bra pair; this identification is a prerequisite to formalizing the positivity argument in steps 1–2 of the source proof (issue #3674).
- The diagonal-restriction route was ruled out by PR #3673; this increment advances the source-faithful proof by formalizing the first-site contraction equalities for the operators $PH^{(N)}$, $H^{(N)}P$, and $PH^{(N)}P$.

### Description

- **`TNLean/MPS/MPDO/VerticalCF.lean`** (+242): defines three first-site matrices `ketLeftAction`, `braRightAction`, and `ketLeftBraRightAction` representing $PH^{(N)}$, $H^{(N)}P$, and $PH^{(N)}P$ respectively; proves their coefficient formulas tying `M.toMPSTensor` MPVs to `mpo` entries; adds `FirstSiteActionAgree.of_sameMPV` transporting first-site equalities across a horizontal canonical-form decomposition; adds `blockwise_opposite_insert_eq_of_rotated_mpo_entries` specializing the blockwise opposite-corner argument to the entrywise identities $PH^{(N)} = PH^{(N)}P$ and $H^{(N)}P = PH^{(N)}P$.
- **`blueprint/src/chapter/ch20_mpdo_canonical_forms.tex`** (+87): updates ch20 entries to reflect the new contraction identifications; `thm:vertical_cf_of_horizontal_cf` remains `\notready`.
- **`docs/paper-gaps/cpgsv17_vertical_diagonal_restriction.tex`** (+18): extends the paper-gap note with the current formalization status.
- No new proof placeholders are introduced. The one-sided operator identity from a vertical invariant projection, exclusion of periodic sectors, and independent vertical canonical-form construction remain unformalized.

### Testing

- `lake exe cache get`
- `lake build TNLean` (9271 jobs)
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- Standalone paper-gap LaTeX build
- `git diff --check`

---
Partially addresses #3674

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation in MPS/MPDO theory; no runtime, auth, or data-path changes. Remaining proof obligations are explicitly scoped and not stubbed as completed theorems.
> 
> **Overview**
> Formalizes the **doubled-index first-site operators** for Proposition 4.13 (arXiv:1606.00608): `ketLeftAction`, `braRightAction`, and `ketLeftBraRightAction` for $PH^{(N)}$, $H^{(N)}P$, and $PH^{(N)}P$, plus lemmas tying their contractions on `M.toMPSTensor` to explicit `mpo` entry sums.
> 
> Adds **`FirstSiteActionAgree.of_sameMPV`** to transport first-site equalities along a horizontal canonical-form MPV match, and **`blockwise_opposite_insert_eq_of_rotated_mpo_entries`**, which turns assumed entrywise $PH^{(N)}=PH^{(N)}P$ and $PH^{(N)}=H^{(N)}P$ into blockwise agreement of the $H^{(N)}P$ vs $PH^{(N)}P$ insertions (via the existing Lemma L pipeline).
> 
> **Blueprint** ch20 and the **paper-gap note** are updated to document the new definitions/lemmas and to state that deriving $PH^{(N)}=PH^{(N)}P$ from a vertical one-sided invariant projection—and the full horizontal→vertical CF theorem—remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efb7abd1bf560d2de5571b999ffe0dbe91a28b98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->