### PR TITLE
feat(Algebra/PerronFrobenius): derive trace-matrix idempotence from pairing idempotence

### DIFF
--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -145,9 +145,11 @@ then `T * T = T`.  This is the operator-to-matrix step of Lemma SALZCL,
 lines 1484--1502.
 
 **Scope restriction (linear independence):** the source lemma
-(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) does not assume linear
-independence of the sector tensors; the paper derives it from injectivity of
-$\mathcal{K}$ in the surrounding construction (lines 1457--1470). Documented in
+(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) neither assumes nor derives
+linear independence of the sector tensors; its proof instead uses primitivity
+of the trace matrix, obtained from injectivity of K in the preceding
+construction (lines 1457--1470), in a Perron--Frobenius trace-power argument,
+and primitivity does not entail the independence. Documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hl` is to be
 discharged at the MPDO call site. -/
 theorem mul_self_eq_self_of_pairing_idempotent
@@ -176,9 +178,11 @@ pairing, evaluation at `l k` provides the functionals, and the pairing matrix
 becomes the transpose of `T`.
 
 **Scope restriction (linear independence):** the source lemma
-(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) does not assume linear
-independence of the sector tensors; the paper derives it from injectivity of
-$\mathcal{K}$ in the surrounding construction (lines 1457--1470). Documented in
+(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) neither assumes nor derives
+linear independence of the sector tensors; its proof instead uses primitivity
+of the trace matrix, obtained from injectivity of K in the preceding
+construction (lines 1457--1470), in a Perron--Frobenius trace-power argument,
+and primitivity does not entail the independence. Documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hr` is to be
 discharged at the MPDO call site. -/
 theorem mul_self_eq_self_of_pairing_idempotent_dual
@@ -218,9 +222,11 @@ normalization gives the rank-one factorization of the sector trace matrix
 asserted by Lemma SALZCL, lines 1484--1502.
 
 **Scope restriction (linear independence):** the source lemma
-(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) does not assume linear
-independence of the sector tensors; the paper derives it from injectivity of
-$\mathcal{K}$ in the surrounding construction (lines 1457--1470). Documented in
+(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) neither assumes nor derives
+linear independence of the sector tensors; its proof instead uses primitivity
+of the trace matrix, obtained from injectivity of K in the preceding
+construction (lines 1457--1470), in a Perron--Frobenius trace-power argument,
+and primitivity does not entail the independence. Documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hl` is to be
 discharged at the MPDO call site. -/
 theorem hasRankOneFactorization_of_pairing_idempotent

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -142,7 +142,14 @@ own square; this is the zero-correlation-length identity
 sum_k |l_k)(r_k| = sum_{k,h} T_{k,h} |l_k)(r_h| of arXiv:1606.00608,
 Appendix C.2, lines 1489--1497.  If the vectors `l k` are linearly independent,
 then `T * T = T`.  This is the operator-to-matrix step of Lemma SALZCL,
-lines 1484--1502. -/
+lines 1484--1502.
+
+**Scope restriction (linear independence):** the source lemma
+(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) does not assume linear
+independence of the sector tensors; the paper derives it from injectivity of
+$\mathcal{K}$ in the surrounding construction (lines 1457--1470). Documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hl` is to be
+discharged at the MPDO call site. -/
 theorem mul_self_eq_self_of_pairing_idempotent
     {l : Fin n → V} {r : Fin n → Module.Dual R V} {T : Matrix (Fin n) (Fin n) R}
     (hT : ∀ k h, T k h = r k (l h)) (hl : LinearIndependent R l)
@@ -166,7 +173,14 @@ theorem mul_self_eq_self_of_pairing_idempotent
 independence placed on the functionals `r k` instead of the vectors `l k`.  The
 proof passes to the dual space, where the functionals become the vectors of the
 pairing, evaluation at `l k` provides the functionals, and the pairing matrix
-becomes the transpose of `T`. -/
+becomes the transpose of `T`.
+
+**Scope restriction (linear independence):** the source lemma
+(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) does not assume linear
+independence of the sector tensors; the paper derives it from injectivity of
+$\mathcal{K}$ in the surrounding construction (lines 1457--1470). Documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hr` is to be
+discharged at the MPDO call site. -/
 theorem mul_self_eq_self_of_pairing_idempotent_dual
     {l : Fin n → V} {r : Fin n → Module.Dual R V} {T : Matrix (Fin n) (Fin n) R}
     (hT : ∀ k h, T k h = r k (l h)) (hr : LinearIndependent R r)
@@ -201,7 +215,14 @@ end PairingIdempotence
 Combining the idempotence `T * T = T` obtained from the zero-correlation-length
 identity of arXiv:1606.00608, Appendix C.2, lines 1489--1497 with the trace
 normalization gives the rank-one factorization of the sector trace matrix
-asserted by Lemma SALZCL, lines 1484--1502. -/
+asserted by Lemma SALZCL, lines 1484--1502.
+
+**Scope restriction (linear independence):** the source lemma
+(arXiv:1606.00608, Lemma SALZCL, lines 1484--1502) does not assume linear
+independence of the sector tensors; the paper derives it from injectivity of
+$\mathcal{K}$ in the surrounding construction (lines 1457--1470). Documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`; the hypothesis `hl` is to be
+discharged at the MPDO call site. -/
 theorem hasRankOneFactorization_of_pairing_idempotent
     {V : Type*} [AddCommGroup V] [Module ℝ V]
     {l : Fin n → V} {r : Fin n → Module.Dual ℝ V} {T : Matrix (Fin n) (Fin n) ℝ}

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -3,6 +3,8 @@ Copyright (c) 2026 TNLean contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 import Mathlib.Analysis.Matrix.PosDef
+import Mathlib.LinearAlgebra.Dual.Defs
+import Mathlib.LinearAlgebra.LinearIndependent.Defs
 import Mathlib.LinearAlgebra.Matrix.Irreducible.Defs
 import Mathlib.LinearAlgebra.Projection
 import Mathlib.LinearAlgebra.Trace
@@ -31,6 +33,16 @@ The theorem `Matrix.hasRankOneFactorization_of_mul_self_eq_self` records the
 alternative exact condition suggested by the operator-valued ZCL identity: an
 idempotent trace-one matrix is the projection onto a one-dimensional range and
 therefore factors as an outer product.
+
+The theorems `Matrix.mul_self_eq_self_of_pairing_idempotent` and
+`Matrix.mul_self_eq_self_of_pairing_idempotent_dual` supply this idempotence:
+for the sector trace matrix T_{k,h} = (r_k|l_h) of arXiv:1606.00608,
+Appendix C.2, the zero-correlation-length identity
+sum_k |l_k)(r_k| = sum_{k,h} T_{k,h} |l_k)(r_h| (lines 1489--1497) states that
+the pairing operator equals its own square, and linear independence of the
+tensors on one side of the pairing turns this into `T * T = T`.  The theorem
+`Matrix.hasRankOneFactorization_of_pairing_idempotent` combines the two steps
+into the rank-one conclusion of Lemma SALZCL (lines 1484--1502).
 -/
 
 open scoped BigOperators Matrix ComplexOrder
@@ -102,6 +114,103 @@ theorem hasRankOneFactorization_of_mul_self_eq_self
   change Classical.choose _ * u.1 i = f (Pi.single j 1) i at hb'
   rw [heval] at hb'
   simpa [b, Matrix.vecMulVec_apply, mul_comm] using hb'.symm
+
+/-! ### Idempotence of the sector trace matrix
+
+Appendix C.2 of arXiv:1606.00608 pairs the tensors l_k and r_k into the
+sector trace matrix T_{k,h} = (r_k|l_h).  Zero correlation length gives the
+operator identity sum_k |l_k)(r_k| = sum_{k,h} T_{k,h} |l_k)(r_h|
+(lines 1489--1497), whose right-hand side is the square of its left-hand side.
+The lemmas below turn this identity into the matrix identity `T * T = T` when
+the tensors on one side of the pairing are linearly independent.  Together with
+the trace normalization and
+`Matrix.hasRankOneFactorization_of_mul_self_eq_self`, this recovers the
+rank-one factorization of Lemma SALZCL (lines 1484--1502).
+-/
+
+section PairingIdempotence
+
+variable {R : Type*} [CommRing R] {V : Type*} [AddCommGroup V] [Module R V]
+
+/-- **Idempotence of the sector trace matrix.**
+
+Let `T k h = r k (l h)` be the matrix pairing a family of vectors `l` against a
+family of linear functionals `r`; for the tensors of arXiv:1606.00608,
+Appendix C.2 this is the sector trace matrix T_{k,h} = (r_k|l_h).  Suppose the
+map `v ↦ ∑ k, r k v • l k`, which is the operator sum_k |l_k)(r_k|, equals its
+own square; this is the zero-correlation-length identity
+sum_k |l_k)(r_k| = sum_{k,h} T_{k,h} |l_k)(r_h| of arXiv:1606.00608,
+Appendix C.2, lines 1489--1497.  If the vectors `l k` are linearly independent,
+then `T * T = T`.  This is the operator-to-matrix step of Lemma SALZCL,
+lines 1484--1502. -/
+theorem mul_self_eq_self_of_pairing_idempotent
+    {l : Fin n → V} {r : Fin n → Module.Dual R V} {T : Matrix (Fin n) (Fin n) R}
+    (hT : ∀ k h, T k h = r k (l h)) (hl : LinearIndependent R l)
+    (hM : ∀ v : V, ∑ k, r k (∑ j, r j v • l j) • l k = ∑ k, r k v • l k) :
+    T * T = T := by
+  classical
+  -- The functionals do not distinguish a vector from its image under the pairing map.
+  have hinv : ∀ (v : V) (k : Fin n), r k (∑ j, r j v • l j) = r k v := by
+    intro v k
+    have hzero : ∑ i, (r i (∑ j, r j v • l j) - r i v) • l i = 0 := by
+      simp only [sub_smul, Finset.sum_sub_distrib, hM v, sub_self]
+    exact sub_eq_zero.mp (Fintype.linearIndependent_iff.mp hl _ hzero k)
+  ext k h
+  rw [Matrix.mul_apply]
+  have hexpand : r k (∑ j, r j (l h) • l j) = ∑ j, T k j * T j h := by
+    rw [map_sum]
+    exact Finset.sum_congr rfl fun j _ => by rw [map_smul, smul_eq_mul, hT k j, hT j h]; ring
+  rw [← hexpand, hinv (l h) k, hT k h]
+
+/-- Variant of `Matrix.mul_self_eq_self_of_pairing_idempotent` with the linear
+independence placed on the functionals `r k` instead of the vectors `l k`.  The
+proof passes to the dual space, where the functionals become the vectors of the
+pairing, evaluation at `l k` provides the functionals, and the pairing matrix
+becomes the transpose of `T`. -/
+theorem mul_self_eq_self_of_pairing_idempotent_dual
+    {l : Fin n → V} {r : Fin n → Module.Dual R V} {T : Matrix (Fin n) (Fin n) R}
+    (hT : ∀ k h, T k h = r k (l h)) (hr : LinearIndependent R r)
+    (hM : ∀ v : V, ∑ k, r k (∑ j, r j v • l j) • l k = ∑ k, r k v • l k) :
+    T * T = T := by
+  classical
+  have hTt : Tᵀ * Tᵀ = Tᵀ := by
+    refine mul_self_eq_self_of_pairing_idempotent (l := r)
+      (r := fun k => Module.Dual.eval R V (l k)) (fun k h => ?_) hr fun f => ?_
+    · simp only [Matrix.transpose_apply, Module.Dual.eval_apply]
+      exact hT h k
+    · simp only [Module.Dual.eval_apply]
+      ext v
+      simp only [LinearMap.sum_apply, LinearMap.smul_apply, smul_eq_mul]
+      have h1 := congrArg f (hM v)
+      simp only [map_sum, map_smul, smul_eq_mul] at h1
+      calc ∑ k, (∑ j, f (l j) * r j (l k)) * r k v
+          = ∑ k, ∑ j, f (l j) * r j (l k) * r k v := by simp only [Finset.sum_mul]
+        _ = ∑ j, ∑ k, f (l j) * r j (l k) * r k v := Finset.sum_comm
+        _ = ∑ k, (∑ j, r j v * r k (l j)) * f (l k) := by
+            simp only [Finset.sum_mul]
+            exact Finset.sum_congr rfl fun k _ => Finset.sum_congr rfl fun j _ => by ring
+        _ = ∑ k, r k v * f (l k) := h1
+        _ = ∑ k, f (l k) * r k v := Finset.sum_congr rfl fun k _ => mul_comm _ _
+  have h := congrArg Matrix.transpose hTt
+  simpa only [Matrix.transpose_mul, Matrix.transpose_transpose] using h
+
+end PairingIdempotence
+
+/-- **Rank-one factorization of the sector trace matrix.**
+
+Combining the idempotence `T * T = T` obtained from the zero-correlation-length
+identity of arXiv:1606.00608, Appendix C.2, lines 1489--1497 with the trace
+normalization gives the rank-one factorization of the sector trace matrix
+asserted by Lemma SALZCL, lines 1484--1502. -/
+theorem hasRankOneFactorization_of_pairing_idempotent
+    {V : Type*} [AddCommGroup V] [Module ℝ V]
+    {l : Fin n → V} {r : Fin n → Module.Dual ℝ V} {T : Matrix (Fin n) (Fin n) ℝ}
+    (hT : ∀ k h, T k h = r k (l h)) (hl : LinearIndependent ℝ l)
+    (hM : ∀ v : V, ∑ k, r k (∑ j, r j v • l j) • l k = ∑ k, r k v • l k)
+    (hTrace : Matrix.trace T = 1) :
+    HasRankOneFactorization T :=
+  hasRankOneFactorization_of_mul_self_eq_self
+    (mul_self_eq_self_of_pairing_idempotent hT hl hM) hTrace
 
 /-- A finite family of nonnegative real numbers with sum and sum of squares both
 one has exactly one nonzero entry, and that entry is one. -/

--- a/blueprint/.chktexrc
+++ b/blueprint/.chktexrc
@@ -13,8 +13,10 @@ CmdLine
   -n 7   # Accent command heuristic.
   -n 8   # Dash-length heuristic.
   -n 9   # Optional-argument bracket heuristic.
+  -n 10  # Solo-parenthesis heuristic; round-bracket bra-ket pairing notation.
   -n 12  # Interword-spacing heuristic.
   -n 13  # Intersentence-spacing heuristic.
+  -n 15  # Unmatched-parenthesis heuristic; round-bracket bra-ket/valence-bond notation.
   -n 17  # Bracket-balance heuristic; noisy in blueprint macro arguments.
   -n 18  # Quote-style heuristic.
   -n 24  # Page-reference spacing heuristic.

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -325,6 +325,69 @@ strong subadditivity for a normalized three-site reduced state.
     and therefore $T=ab^\top$.
 \end{proof}
 
+\begin{theorem}[Idempotence of the sector trace matrix]
+    \label{thm:matrix_pairing_idempotent}
+    \lean{Matrix.mul_self_eq_self_of_pairing_idempotent}
+    \lean{Matrix.mul_self_eq_self_of_pairing_idempotent_dual}
+    \leanok
+    Let $V$ be a module over a commutative ring, let $l_1,\dots,l_n \in V$,
+    let $r_1,\dots,r_n$ be linear functionals on $V$, and let
+    $T_{k,h}=(r_k|l_h)$ be the pairing matrix; for the tensors of
+    \cite[Appendix~C.2]{Cirac2016MPDO_arXiv} this is the sector trace matrix.
+    Assume the identity
+    \[
+        \sum_k |l_k)(r_k| = \sum_{k,h} T_{k,h}\, |l_k)(r_h|,
+    \]
+    whose right-hand side is the square of its left-hand side, so that the
+    operator $M = \sum_k |l_k)(r_k|$ satisfies $M^2 = M$. If the vectors
+    $l_1,\dots,l_n$ are linearly independent, then
+    \[
+        T^2 = T.
+    \]
+    The same conclusion holds if instead the functionals $r_1,\dots,r_n$ are
+    linearly independent.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Evaluating $M^2 v = M v$ at an arbitrary $v \in V$ gives
+    \[
+        \sum_k \bigl((r_k|Mv) - (r_k|v)\bigr)\, l_k = 0,
+    \]
+    so linear independence of the $l_k$ yields $(r_k|Mv)=(r_k|v)$ for all $k$
+    and $v$. Taking $v = l_h$ and expanding
+    $M l_h = \sum_j T_{j,h}\, l_j$ turns the left-hand side into
+    $\sum_j T_{k,j} T_{j,h} = (T^2)_{k,h}$ and the right-hand side into
+    $T_{k,h}$. For linearly independent functionals, the same argument applied
+    in the dual space, with the $r_k$ as vectors and evaluation at $l_k$ as
+    functionals, gives the idempotence of the transposed pairing matrix, and
+    transposing back gives $T^2 = T$.
+\end{proof}
+
+\begin{theorem}[Rank-one factorization of the sector trace matrix]
+    \label{thm:matrix_pairing_rank_one}
+    \lean{Matrix.hasRankOneFactorization_of_pairing_idempotent}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates}
+    In the setting of Theorem~\ref{thm:matrix_pairing_idempotent} with real
+    scalars and linearly independent vectors $l_1,\dots,l_n$, if in addition
+    $\operatorname{tr}(T)=1$, then there are real vectors $a,b$ such that
+    $T = a b^\top$. This is the factorization $T_{k,h} = a_k b_h$ obtained in
+    the proof of \cite[Appendix~C.2, Lemma~C.5]{Cirac2016MPDO_arXiv} for the
+    sector trace matrix, derived here from the displayed
+    zero-correlation-length identity instead of the Perron--Frobenius
+    trace-power argument.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:matrix_pairing_idempotent, thm:matrix_idempotent_trace_one_rank_one}
+    Theorem~\ref{thm:matrix_pairing_idempotent} gives $T^2 = T$, and the
+    idempotent trace-one criterion of
+    Theorem~\ref{thm:matrix_idempotent_trace_one_rank_one} gives the
+    factorization $T = a b^\top$.
+\end{proof}
+
 % Unfaithful: thm:sal_zcl_implies_rank_one_t mirrors the Lean theorem
 % MPOTensor.sal_zcl_implies_rank_one_T, whose conditional Perron--Frobenius
 % hypothesis is false as a universal statement (counterexample in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -360,10 +360,18 @@ strong subadditivity for a normalized three-site reduced state.
     $\sum_j T_{k,j} T_{j,h} = (T^2)_{k,h}$ and the right-hand side into
     $T_{k,h}$. For linearly independent functionals, the same argument applied
     in the dual space, with the $r_k$ as vectors and evaluation at $l_k$ as
-    functionals, gives the idempotence of the transposed pairing matrix, and
-    transposing back gives $T^2 = T$.
+    functionals, gives $(T^\top)^2 = T^\top$, and transposing back gives
+    $T^2 = T$.
 \end{proof}
 
+% Scope restriction (linear independence): the source Lemma C.5 neither
+% assumes nor derives linear independence of the sector tensors. Its proof
+% instead uses primitivity of the trace matrix, obtained from the injectivity
+% of the tensor K in the preceding construction (arXiv:1606.00608,
+% lines 1457--1470), in a Perron--Frobenius trace-power argument, and
+% primitivity does not entail the independence. The hypothesis below remains
+% to be discharged at the matrix product density operator call site.
+% Recorded in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
 \begin{theorem}[Rank-one factorization of the sector trace matrix]
     \label{thm:matrix_pairing_rank_one}
     \lean{Matrix.hasRankOneFactorization_of_pairing_idempotent}
@@ -375,12 +383,9 @@ strong subadditivity for a normalized three-site reduced state.
     $T = a b^\top$. This is the factorization $T_{k,h} = a_k b_h$ obtained in
     the proof of \cite[Appendix~C.2, Lemma~C.5]{Cirac2016MPDO_arXiv} for the
     sector trace matrix, derived here from the displayed
-    zero-correlation-length identity instead of the Perron--Frobenius
-    trace-power argument. The linear independence of the $l_k$ appears here as
-    an explicit hypothesis; the source lemma does not assume it, since the
-    construction preceding the lemma derives it from the injectivity of the
-    tensor $K$. This restriction is recorded in
-    \path{docs/paper-gaps/cpgsv17_pf_rank_one.tex}.
+    zero-correlation-length identity together with the linear independence of
+    the $l_k$, instead of the Perron--Frobenius trace-power argument of the
+    source.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -376,7 +376,11 @@ strong subadditivity for a normalized three-site reduced state.
     the proof of \cite[Appendix~C.2, Lemma~C.5]{Cirac2016MPDO_arXiv} for the
     sector trace matrix, derived here from the displayed
     zero-correlation-length identity instead of the Perron--Frobenius
-    trace-power argument.
+    trace-power argument. The linear independence of the $l_k$ appears here as
+    an explicit hypothesis; the source lemma does not assume it, since the
+    construction preceding the lemma derives it from the injectivity of the
+    tensor $K$. This restriction is recorded in
+    \path{docs/paper-gaps/cpgsv17_pf_rank_one.tex}.
 \end{theorem}
 
 \begin{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -358,10 +358,16 @@ strong subadditivity for a normalized three-site reduced state.
     and $v$. Taking $v = l_h$ and expanding
     $M l_h = \sum_j T_{j,h}\, l_j$ turns the left-hand side into
     $\sum_j T_{k,j} T_{j,h} = (T^2)_{k,h}$ and the right-hand side into
-    $T_{k,h}$. For linearly independent functionals, the same argument applied
+    $T_{k,h}$. For linearly independent functionals, apply the same argument
     in the dual space, with the $r_k$ as vectors and evaluation at $l_k$ as
-    functionals, gives $(T^\top)^2 = T^\top$, and transposing back gives
-    $T^2 = T$.
+    functionals.  The dual pairing matrix therefore satisfies
+    \[
+        (T^\top)^2=T^\top.
+    \]
+    Taking transposes gives
+    \[
+        T^2=T.
+    \]
 \end{proof}
 
 % Scope restriction (linear independence): the source Lemma C.5 neither

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -160,14 +160,19 @@ Lemma~C.5.\footnote{The formal statements are
 \path{TNLean/Algebra/PerronFrobenius/RankOne.lean}, added in \ghpr{3685}.}
 
 The linear-independence hypothesis is a scope restriction relative to the
-source.  Lemma~C.5 does not assume it: the paper derives the relevant
-independence from the injectivity of $\mathcal{K}$ in the construction
-preceding the lemma
-\cite[Appendix~C.2, lines~1457--1470]{Cirac2016MPDO_arXiv}, where injectivity
-forces the sector decomposition of the trace matrix to be trivial.  The
-formal lemmas therefore state the independence as an explicit hypothesis, to
-be discharged at the matrix product density operator call site from the
-injectivity of $\mathcal{K}$.
+source.  Lemma~C.5 neither assumes nor derives it: the construction
+preceding the lemma uses the injectivity of $\mathcal{K}$ to prove that the
+sector decomposition of the trace matrix is trivial, that is, that $T$ is
+primitive \cite[Appendix~C.2, lines~1457--1470]{Cirac2016MPDO_arXiv}.
+Primitivity constrains only the support pattern of the non-negative matrix
+$T$; a primitive $T$ can arise from linearly dependent $l_k$, so the cited
+passage does not make the family $(l_k)_k$ or $(r_k)_k$ linearly
+independent.  The proof of Lemma~C.5 then uses primitivity in the
+Perron--Frobenius trace-power step examined above, not any independence of
+the families.  The formal lemmas therefore state the independence as an
+explicit hypothesis; whether the inverse-map construction supplies it ---
+for instance through the injectivity of $\mathcal{K}$ --- remains to be
+established at the matrix product density operator call site.
 
 \section{The corrected statement}
 

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -139,6 +139,36 @@ excluding the generalized zero-eigenspace, from a property of the concrete
 inverse-map tensors not currently recorded in
 \leanid{MPOTensor.ExplicitEtaOperators}.
 
+\subsection{The pairing-idempotence route}
+
+The formal development derives $T^2=T$ from the displayed operator identity
+under one additional hypothesis on the inverse-map tensors.  Suppose the
+family $(l_k)_k$ is linearly independent, so that $L$ is injective.  The
+operator identity $(LR)^2=LR$ gives
+\[
+  L\,T^2=(LR)^2L=(LR)L=L\,T,
+\]
+and cancelling $L$ on the left yields $T^2=T$.  If instead the functionals
+$(r_k)_k$ are linearly independent, the same argument in the dual space gives
+the idempotence of $T^{\top}$, hence of $T$.  Together with the trace
+normalization $\operatorname{tr}(T)=1$ and the idempotent trace-one criterion
+above, this recovers the outer-product factorization asserted by
+Lemma~C.5.\footnote{The formal statements are
+\leanid{Matrix.mul_self_eq_self_of_pairing_idempotent},
+\leanid{Matrix.mul_self_eq_self_of_pairing_idempotent_dual}, and
+\leanid{Matrix.hasRankOneFactorization_of_pairing_idempotent} in
+\path{TNLean/Algebra/PerronFrobenius/RankOne.lean}, added in \ghpr{3685}.}
+
+The linear-independence hypothesis is a scope restriction relative to the
+source.  Lemma~C.5 does not assume it: the paper derives the relevant
+independence from the injectivity of $\mathcal{K}$ in the construction
+preceding the lemma
+\cite[Appendix~C.2, lines~1457--1470]{Cirac2016MPDO_arXiv}, where injectivity
+forces the sector decomposition of the trace matrix to be trivial.  The
+formal lemmas therefore state the independence as an explicit hypothesis, to
+be discharged at the matrix product density operator call site from the
+injectivity of $\mathcal{K}$.
+
 \section{The corrected statement}
 
 The formal development proves a corrected sufficient matrix theorem. Let $T$


### PR DESCRIPTION
## Summary

Formalizes the operator-to-matrix step of the zero-correlation-length argument in arXiv:1606.00608, Appendix C.2, Lemma C.5 (`SALZCL`, `Papers/1606.00608/MPDO-22-12-17-2.tex` lines 1484–1502), as abstract lemmas in `TNLean/Algebra/PerronFrobenius/RankOne.lean`.

The paper's displayed identity (lines 1489–1497)

$$\sum_k |l_k)(r_k| = \sum_{k,h} T_{k,h}\, |l_k)(r_h|, \qquad T_{k,h} = (r_k|l_h)$$

has as its right-hand side the square of its left-hand side, so it states that the pairing operator $Mv = \sum_k (r_k|v)\, l_k$ is idempotent. The new lemmas convert this operator identity into the matrix identity $T^2 = T$:

- `Matrix.mul_self_eq_self_of_pairing_idempotent`: for vectors $l_k$ in a module $V$ over a commutative ring, linear functionals $r_k$ on $V$, and $T_{k,h} = (r_k|l_h)$, if $M^2 = M$ pointwise and the $l_k$ are linearly independent, then $T \cdot T = T$. Proof: independence extracts $(r_k|Mv) = (r_k|v)$ from $\sum_k \big((r_k|Mv) - (r_k|v)\big)\, l_k = 0$; taking $v = l_h$ and expanding $M l_h = \sum_j T_{j,h}\, l_j$ identifies $(r_k|M l_h)$ with $(T^2)_{k,h}$.
- `Matrix.mul_self_eq_self_of_pairing_idempotent_dual`: the mirror variant assuming instead that the functionals $r_k$ are linearly independent, proved by applying the first lemma in the dual space (the $r_k$ become the vectors, evaluation at $l_k$ the functionals, and the pairing matrix becomes $T^\top$).
- `Matrix.hasRankOneFactorization_of_pairing_idempotent`: chains the idempotence with $\operatorname{tr}(T) = 1$ through the existing `Matrix.hasRankOneFactorization_of_mul_self_eq_self` (#3678) to the rank-one factorization $T = ab^\top$ concluded in the proof of Lemma C.5.

This supplies the idempotence route isolated after #3678 in the discussion of #3593: the ZCL identity yields $T^2 = T$ directly (not merely $T^2 = T^3$), which excludes the nilpotent zero-eigenspace exactly and feeds the idempotent trace-one rank-one criterion, so the invented (false-in-general) hypothesis `Matrix.PrimitiveTracePowersConstantImpliesRankOne` is not needed for this step.

## Blueprint

Two new entries in `blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex`, placed after the idempotent trace-one criterion: the idempotence theorem (`thm:matrix_pairing_idempotent`, covering both independence variants) and the rank-one corollary (`thm:matrix_pairing_rank_one`).

## Remaining follow-up

Instantiating the abstract lemma at the MPDO inverse-map call site: derive the linear independence of the sector tensors (or of the paired functionals) from the block-support structure of the inverse-map construction, obtain the pointwise idempotence from the ZCL hypothesis on `MPOTensor.inverseTensor` / `physRealize` / `physRealizeLeft`, and swap the constructors in `BlockedRFPConstruction.lean` and `SimpleLocalStructure.lean` off the `hPF`-conditional path.

Partially addresses #3593.

## Verification

- `lake build TNLean`: success (9273 jobs)
- `rg -n "sorry|axiom" TNLean/Algebra/PerronFrobenius/RankOne.lean`: none
- `leanblueprint checkdecls` (via generated `blueprint/lean_decls`): pass
- `python3 scripts/blueprint_lean_sync.py --ci`: pass
- `lake exe lint_style`: pass
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci`: pass
- `git diff --check`: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation in algebra/blueprint with no runtime or auth changes; remaining risk is mathematical scope (linear independence not yet proved at MPDO instantiation), not deployment.
> 
> **Overview**
> Adds abstract Lean lemmas that turn the **zero-correlation-length (ZCL) pairing-operator identity** into **`T² = T`** for the sector trace matrix `T_{k,h} = (r_k|l_h)`, then chains that with the existing idempotent trace-one rank-one criterion to get **`T = abᵀ`**.
> 
> **`RankOne.lean`:** New `PairingIdempotence` section with `mul_self_eq_self_of_pairing_idempotent` (linearly independent `l_k`) and a dual variant for independent `r_k`; `hasRankOneFactorization_of_pairing_idempotent` composes idempotence + `tr(T)=1` via `hasRankOneFactorization_of_mul_self_eq_self`. Docstrings flag **linear independence as an explicit scope restriction** vs. the paper’s primitivity route, to be discharged at the MPDO call site.
> 
> **Blueprint** (`ch21_mpdo_rfp_simple_local_structure.tex`): Theorems for pairing idempotence and rank-one factorization, wired to the new Lean names.
> 
> **`docs/paper-gaps/cpgsv17_pf_rank_one.tex`:** New subsection on the pairing-idempotence route and the independence gap.
> 
> **`blueprint/.chktexrc`:** Mutes ChkTeX rules for round-bracket bra-ket notation (`|l_k)(r_k|`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fec4c6d696a8acdbea5ad9bf4cf17ce6d435bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->