### PR TITLE
feat(MPS/CanonicalForm): decompose projector-closure tensors into irreducible corners

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -321,6 +321,7 @@ import TNLean.MPS.Periodic.NormalCanonicalPeriodOne
 import TNLean.MPS.Structure.InvariantSubspaceDecomp
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.CanonicalForm.ProjectorClosure
+import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
 import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.CanonicalForm.Existence
 import TNLean.MPS.CanonicalForm.NormalReduction

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean
@@ -1,0 +1,515 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.ProjectorClosure
+import TNLean.MPS.CanonicalForm.CyclicSectors.Compression
+
+/-!
+# Direct-sum decomposition under invariant-projector closure
+
+This file combines the reducing projections produced by the invariant-projector
+closure condition of Cirac, Pérez-García, Schuch, and Verstraete,
+arXiv:1606.00608, lines 253--254, into a direct-sum decomposition into
+irreducible corner tensors.  This is the decomposition step towards the
+canonical form \(A^i = \oplus_k \mu_k A_k^i\) of arXiv:1606.00608,
+eq:II_CF1, lines 237--241.
+
+Under projector closure every invariant orthogonal projection commutes with all
+tensor matrices (`MPSTensor.commutes_of_hasInvariantProjectorClosure_of_lowerZero`),
+so the two corners of such a projection are genuine compressions
+\(V^\dagger A^i V\) along support isometries, not merely trace-equal blocks.
+Strong induction on the bond dimension yields a family of isometries with
+pairwise orthogonal ranges summing to the identity whose corner tensors are all
+irreducible and intertwine the original tensor matrices.  No left-canonical or
+unital normalization is assumed anywhere; the source proposition does not
+provide one.
+
+The remaining steps towards the full sufficient condition for canonical form —
+rescaling each block to spectral radius one and converting the absence of
+nontrivial periodic vectors into primitivity of every rescaled block — are
+recorded in `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`.
+-/
+
+open scoped Matrix BigOperators
+
+/-- Every orthogonal projection is the range projection of an isometry: there
+are `n` and `V` with `Vᴴ * V = 1`, `V * Vᴴ = P`, and `n = tr P`.
+
+This is the support-isometry factorization used by the sector compressions of
+arXiv:1606.00608, Appendix A; it is stated here without any trace-preservation
+hypothesis on a tensor. -/
+theorem IsOrthogonalProjection.exists_support_isometry {D : ℕ}
+    {P : Matrix (Fin D) (Fin D) ℂ} (hP : IsOrthogonalProjection P) :
+    ∃ (n : ℕ) (V : Matrix (Fin D) (Fin n) ℂ),
+      ((n : ℂ) = Matrix.trace P) ∧ Vᴴ * V = 1 ∧ V * Vᴴ = P := by
+  obtain ⟨n, _C, _φ, V, hdim, _hTP, _hMPV, _hInt, _hMul, _hStar, _hLetter,
+      hViso, hVrange, _hEmbed⟩ :=
+    MPSTensor.exists_compressedTensor_of_supported_projection_with_letter_and_isometry
+      (d := 1) (fun _ => P) P hP
+      (fun _ => by simp [hP.2])
+      (by simp [hP.1.eq, hP.2])
+  exact ⟨n, V, hdim, hViso, hVrange⟩
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- If the range projection `V * Vᴴ` of the isometry `V` commutes with every
+tensor matrix, then each `A i` intertwines `V` with the corner matrix
+`Vᴴ * A i * V`.
+
+This records that the corners of a reducing projection in
+arXiv:1606.00608, lines 253--254, are genuine compressions. -/
+private lemma mul_isometry_of_commutes {n : ℕ} (A : MPSTensor d D)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hComm : ∀ i : Fin d, A i * (V * Vᴴ) = (V * Vᴴ) * A i) (i : Fin d) :
+    A i * V = V * (Vᴴ * A i * V) := by
+  have hPV : (V * Vᴴ) * V = V := by rw [Matrix.mul_assoc, hV, Matrix.mul_one]
+  calc A i * V
+      = A i * ((V * Vᴴ) * V) := by rw [hPV]
+    _ = (A i * (V * Vᴴ)) * V := (Matrix.mul_assoc _ _ _).symm
+    _ = ((V * Vᴴ) * A i) * V := by rw [hComm i]
+    _ = V * (Vᴴ * A i * V) := by simp only [Matrix.mul_assoc]
+
+/-- Adjoint counterpart of `mul_isometry_of_commutes`: the corner matrix
+`Vᴴ * A i * V` intertwines `Vᴴ` with `A i`. -/
+private lemma conjTranspose_isometry_mul_of_commutes {n : ℕ} (A : MPSTensor d D)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hComm : ∀ i : Fin d, A i * (V * Vᴴ) = (V * Vᴴ) * A i) (i : Fin d) :
+    Vᴴ * A i = (Vᴴ * A i * V) * Vᴴ := by
+  have hVP : Vᴴ * (V * Vᴴ) = Vᴴ := by rw [← Matrix.mul_assoc, hV, Matrix.one_mul]
+  calc Vᴴ * A i
+      = (Vᴴ * (V * Vᴴ)) * A i := by rw [hVP]
+    _ = Vᴴ * ((V * Vᴴ) * A i) := Matrix.mul_assoc _ _ _
+    _ = Vᴴ * (A i * (V * Vᴴ)) := by rw [← hComm i]
+    _ = (Vᴴ * A i * V) * Vᴴ := by simp only [Matrix.mul_assoc]
+
+/-- Corner tensors inherit invariant-projector closure.
+
+If `A` satisfies the projector hypothesis of arXiv:1606.00608, lines 253--254,
+and `V` is an isometry whose range projection `V * Vᴴ` commutes with every
+tensor matrix, then the corner tensor `Vᴴ * A i * V` satisfies the same
+projector hypothesis.  A left-invariant projection of the corner lifts along
+`V` to a left-invariant projection of `A`, closure applies in the ambient
+algebra, and compressing back returns the closure identity for the corner.
+No normalization on `A` is assumed. -/
+theorem hasInvariantProjectorClosure_compress_of_commutes
+    (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A)
+    {n : ℕ} (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hComm : ∀ i : Fin d, A i * (V * Vᴴ) = (V * Vᴴ) * A i) :
+    HasInvariantProjectorClosure (fun i => Vᴴ * A i * V) := by
+  intro Q hQ hQleft
+  -- The ambient lift `V * Q * Vᴴ` is an orthogonal projection.
+  have hQ' : IsOrthogonalProjection (V * Q * Vᴴ) := by
+    constructor
+    · change (V * Q * Vᴴ)ᴴ = V * Q * Vᴴ
+      rw [Matrix.conjTranspose_mul, Matrix.conjTranspose_mul,
+        Matrix.conjTranspose_conjTranspose, hQ.1.eq]
+      simp only [Matrix.mul_assoc]
+    · show V * Q * Vᴴ * (V * Q * Vᴴ) = V * Q * Vᴴ
+      calc V * Q * Vᴴ * (V * Q * Vᴴ)
+          = V * Q * ((Vᴴ * V) * (Q * Vᴴ)) := by simp only [Matrix.mul_assoc]
+        _ = V * Q * (Q * Vᴴ) := by rw [hV, Matrix.one_mul]
+        _ = V * (Q * Q) * Vᴴ := by simp only [Matrix.mul_assoc]
+        _ = V * Q * Vᴴ := by rw [hQ.2]
+  -- The lift is left-invariant for the ambient tensor.
+  have hlift : ∀ i : Fin d,
+      (V * Q * Vᴴ) * A i = (V * Q * Vᴴ) * A i * (V * Q * Vᴴ) := by
+    intro i
+    have h1 : Vᴴ * A i = (Vᴴ * A i * V) * Vᴴ :=
+      conjTranspose_isometry_mul_of_commutes A V hV hComm i
+    have h2 : Q * (Vᴴ * A i * V) = Q * (Vᴴ * A i * V) * Q := hQleft i
+    set B : Matrix (Fin n) (Fin n) ℂ := Vᴴ * A i * V with hB
+    have hRHS : (V * Q * Vᴴ) * A i * (V * Q * Vᴴ) = V * (Q * B * Q) * Vᴴ := by
+      calc (V * Q * Vᴴ) * A i * (V * Q * Vᴴ)
+          = V * Q * ((Vᴴ * A i) * (V * Q * Vᴴ)) := by simp only [Matrix.mul_assoc]
+        _ = V * Q * ((B * Vᴴ) * (V * Q * Vᴴ)) := by rw [h1]
+        _ = V * Q * (B * ((Vᴴ * V) * (Q * Vᴴ))) := by simp only [Matrix.mul_assoc]
+        _ = V * Q * (B * (Q * Vᴴ)) := by rw [hV, Matrix.one_mul]
+        _ = V * (Q * B * Q) * Vᴴ := by simp only [Matrix.mul_assoc]
+    calc (V * Q * Vᴴ) * A i
+        = V * Q * (Vᴴ * A i) := by simp only [Matrix.mul_assoc]
+      _ = V * Q * (B * Vᴴ) := by rw [h1]
+      _ = V * (Q * B) * Vᴴ := by simp only [Matrix.mul_assoc]
+      _ = V * (Q * B * Q) * Vᴴ := by rw [← h2]
+      _ = (V * Q * Vᴴ) * A i * (V * Q * Vᴴ) := hRHS.symm
+  -- Apply ambient closure and compress back.
+  have happly := hClosure (V * Q * Vᴴ) hQ' hlift
+  intro i
+  change Vᴴ * A i * V * Q = Q * (Vᴴ * A i * V) * Q
+  have h4 : Vᴴ * (A i * (V * Q * Vᴴ)) * V =
+      Vᴴ * ((V * Q * Vᴴ) * A i * (V * Q * Vᴴ)) * V := by
+    rw [happly i]
+  have hL : Vᴴ * (A i * (V * Q * Vᴴ)) * V = Vᴴ * A i * V * Q := by
+    calc Vᴴ * (A i * (V * Q * Vᴴ)) * V
+        = (Vᴴ * A i * V) * (Q * (Vᴴ * V)) := by simp only [Matrix.mul_assoc]
+      _ = (Vᴴ * A i * V) * Q := by rw [hV, Matrix.mul_one]
+  have hR : Vᴴ * ((V * Q * Vᴴ) * A i * (V * Q * Vᴴ)) * V =
+      Q * (Vᴴ * A i * V) * Q := by
+    calc Vᴴ * ((V * Q * Vᴴ) * A i * (V * Q * Vᴴ)) * V
+        = (Vᴴ * V) * (Q * ((Vᴴ * A i * V) * (Q * (Vᴴ * V)))) := by
+          simp only [Matrix.mul_assoc]
+      _ = Q * ((Vᴴ * A i * V) * Q) := by rw [hV, Matrix.one_mul, Matrix.mul_one]
+      _ = Q * (Vᴴ * A i * V) * Q := (Matrix.mul_assoc _ _ _).symm
+  rw [hL, hR] at h4
+  exact h4
+
+/-- Word evaluation is intertwined by an isometry that intertwines the letters. -/
+private lemma evalWord_intertwine {n : ℕ} (A : MPSTensor d D) (B : MPSTensor d n)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hInt : ∀ i : Fin d, A i * V = V * B i) :
+    ∀ w : List (Fin d), evalWord A w * V = V * evalWord B w := by
+  intro w
+  induction w with
+  | nil => rw [evalWord_nil, evalWord_nil, Matrix.one_mul, Matrix.mul_one]
+  | cons i w ihw =>
+      rw [evalWord_cons, evalWord_cons]
+      calc A i * evalWord A w * V
+          = A i * (evalWord A w * V) := Matrix.mul_assoc _ _ _
+        _ = A i * (V * evalWord B w) := by rw [ihw]
+        _ = (A i * V) * evalWord B w := (Matrix.mul_assoc _ _ _).symm
+        _ = (V * B i) * evalWord B w := by rw [hInt i]
+        _ = V * (B i * evalWord B w) := Matrix.mul_assoc _ _ _
+
+/-- If isometries with ranges summing to the identity intertwine the tensor
+matrices with corner tensors, then the matrix product vectors of the tensor
+agree with those of the unit-weight direct sum of the corner tensors.
+
+This is the trace decomposition along the partition of unity used in the
+direct-sum step of arXiv:1606.00608, eq:II_CF1, lines 237--241. -/
+theorem sameMPV₂_toTensorFromBlocks_of_isometry_family
+    {r : ℕ} {dim : Fin r → ℕ} (A : MPSTensor d D)
+    (blocks : (k : Fin r) → MPSTensor d (dim k))
+    (V : (k : Fin r) → Matrix (Fin D) (Fin (dim k)) ℂ)
+    (hiso : ∀ k, (V k)ᴴ * V k = 1)
+    (hsum : ∑ k : Fin r, V k * (V k)ᴴ = 1)
+    (hint : ∀ (k : Fin r) (i : Fin d), A i * V k = V k * blocks k i) :
+    SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) := by
+  intro N σ
+  rw [mpv_toTensorFromBlocks_eq_sum]
+  simp only [one_pow, one_smul]
+  simp only [mpv, coeff]
+  set w : List (Fin d) := List.ofFn σ with hw
+  calc Matrix.trace (evalWord A w)
+      = Matrix.trace ((∑ k : Fin r, V k * (V k)ᴴ) * evalWord A w) := by
+        rw [hsum, Matrix.one_mul]
+    _ = ∑ k : Fin r, Matrix.trace (V k * (V k)ᴴ * evalWord A w) := by
+        rw [Finset.sum_mul, Matrix.trace_sum]
+    _ = ∑ k : Fin r, Matrix.trace (evalWord (blocks k) w) := by
+        refine Finset.sum_congr rfl fun k _ => ?_
+        calc Matrix.trace (V k * (V k)ᴴ * evalWord A w)
+            = Matrix.trace (V k * ((V k)ᴴ * evalWord A w)) := by
+              rw [Matrix.mul_assoc]
+          _ = Matrix.trace (((V k)ᴴ * evalWord A w) * V k) := Matrix.trace_mul_comm _ _
+          _ = Matrix.trace ((V k)ᴴ * (evalWord A w * V k)) := by rw [Matrix.mul_assoc]
+          _ = Matrix.trace ((V k)ᴴ * (V k * evalWord (blocks k) w)) := by
+              rw [evalWord_intertwine A (blocks k) (V k) (hint k) w]
+          _ = Matrix.trace (((V k)ᴴ * V k) * evalWord (blocks k) w) := by
+              rw [Matrix.mul_assoc]
+          _ = Matrix.trace (evalWord (blocks k) w) := by rw [hiso k, Matrix.one_mul]
+
+/-- Strong-induction core of the direct-sum decomposition under
+invariant-projector closure (arXiv:1606.00608, lines 253--254): every tensor with projector
+closure carries a family of isometries with pairwise orthogonal ranges summing
+to the identity whose corner tensors are irreducible and intertwine the tensor
+matrices. -/
+private theorem exists_irreducible_isometry_family_aux :
+    ∀ (D : ℕ) (A : MPSTensor d D), HasInvariantProjectorClosure A →
+      ∃ (r : ℕ) (dim : Fin r → ℕ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+        (V : (k : Fin r) → Matrix (Fin D) (Fin (dim k)) ℂ),
+        (∀ k, 0 < dim k) ∧
+        (∀ k, (V k)ᴴ * V k = 1) ∧
+        (∑ k : Fin r, V k * (V k)ᴴ = 1) ∧
+        (∀ k l, k ≠ l → (V k)ᴴ * V l = 0) ∧
+        (∀ (k : Fin r) (i : Fin d), A i * V k = V k * blocks k i) ∧
+        (∀ (k : Fin r) (i : Fin d), (V k)ᴴ * A i = blocks k i * (V k)ᴴ) ∧
+        (∀ k, IsIrreducibleTensor (blocks k)) := by
+  intro D
+  induction D using Nat.strong_induction_on with
+  | _ D ih =>
+  intro A hClosure
+  rcases Nat.eq_zero_or_pos D with hD0 | hDpos
+  · -- Trivial bond dimension: the empty family.
+    subst hD0
+    exact ⟨0, fun k => k.elim0, fun k => k.elim0, fun k => k.elim0,
+      fun k => k.elim0, fun k => k.elim0,
+      by ext i j; exact i.elim0,
+      fun k => k.elim0, fun k => k.elim0, fun k => k.elim0, fun k => k.elim0⟩
+  by_cases hirrA : IsIrreducibleTensor A
+  · -- Base case: `A` itself is irreducible; take the single corner `V = 1`.
+    refine ⟨1, fun _ => D, fun _ => A, fun _ => (1 : Matrix (Fin D) (Fin D) ℂ),
+      fun _ => hDpos, fun _ => by simp, by simp, ?_, fun _ i => by simp,
+      fun _ i => by simp, fun _ => hirrA⟩
+    intro k l hkl
+    exact absurd (Subsingleton.elim k l) hkl
+  -- Inductive step: split along a reducing projection and recurse on the corners.
+  rw [IsIrreducibleTensor, not_not] at hirrA
+  obtain ⟨P, hPproj, hP0, hP1, hLower⟩ := hirrA
+  have hCommP : ∀ i : Fin d, P * A i = A i * P :=
+    commutes_of_hasInvariantProjectorClosure_of_lowerZero A P hClosure hPproj hLower
+  obtain ⟨n, V₁, hn_tr, hV₁iso, hV₁range⟩ := hPproj.exists_support_isometry
+  obtain ⟨m, V₂, hm_tr, hV₂iso, hV₂range⟩ := hPproj.one_sub.exists_support_isometry
+  -- Corner bond dimensions are positive and sum to `D`.
+  have hn0 : 0 < n := by
+    rcases Nat.eq_zero_or_pos n with h0 | h
+    · exfalso
+      apply hP0
+      rw [← hV₁range]
+      subst h0
+      ext i j
+      simp [Matrix.mul_apply]
+    · exact h
+  have hm0 : 0 < m := by
+    rcases Nat.eq_zero_or_pos m with h0 | h
+    · exfalso
+      apply sub_ne_zero_of_ne (Ne.symm hP1)
+      rw [← hV₂range]
+      subst h0
+      ext i j
+      simp [Matrix.mul_apply]
+    · exact h
+  have hnm : n + m = D := by
+    have h1 : ((n : ℂ) + (m : ℂ)) = (D : ℂ) := by
+      rw [hn_tr, hm_tr, Matrix.trace_sub, Matrix.trace_one, Fintype.card_fin]
+      ring
+    exact_mod_cast h1
+  have hn_lt : n < D := by omega
+  have hm_lt : m < D := by omega
+  -- The two range projections commute with every tensor matrix.
+  have hComm₁ : ∀ i : Fin d, A i * (V₁ * V₁ᴴ) = (V₁ * V₁ᴴ) * A i := by
+    intro i
+    rw [hV₁range]
+    exact (hCommP i).symm
+  have hComm₂ : ∀ i : Fin d, A i * (V₂ * V₂ᴴ) = (V₂ * V₂ᴴ) * A i := by
+    intro i
+    rw [hV₂range, Matrix.mul_sub, Matrix.sub_mul, Matrix.mul_one, Matrix.one_mul,
+      hCommP i]
+  -- Both corners inherit projector closure; recurse.
+  have hClosure₁ : HasInvariantProjectorClosure (fun i => V₁ᴴ * A i * V₁) :=
+    hasInvariantProjectorClosure_compress_of_commutes A hClosure V₁ hV₁iso hComm₁
+  have hClosure₂ : HasInvariantProjectorClosure (fun i => V₂ᴴ * A i * V₂) :=
+    hasInvariantProjectorClosure_compress_of_commutes A hClosure V₂ hV₂iso hComm₂
+  obtain ⟨r₁, dim₁, blocks₁, W₁, hpos₁, hiso₁, hsum₁, horth₁, hint₁raw, hintstar₁raw,
+      hirr₁⟩ := ih n hn_lt (fun i => V₁ᴴ * A i * V₁) hClosure₁
+  obtain ⟨r₂, dim₂, blocks₂, W₂, hpos₂, hiso₂, hsum₂, horth₂, hint₂raw, hintstar₂raw,
+      hirr₂⟩ := ih m hm_lt (fun i => V₂ᴴ * A i * V₂) hClosure₂
+  have hint₁ : ∀ (a : Fin r₁) (i : Fin d),
+      V₁ᴴ * A i * V₁ * W₁ a = W₁ a * blocks₁ a i := hint₁raw
+  have hint₂ : ∀ (a : Fin r₂) (i : Fin d),
+      V₂ᴴ * A i * V₂ * W₂ a = W₂ a * blocks₂ a i := hint₂raw
+  have hintstar₁ : ∀ (a : Fin r₁) (i : Fin d),
+      (W₁ a)ᴴ * (V₁ᴴ * A i * V₁) = blocks₁ a i * (W₁ a)ᴴ := hintstar₁raw
+  have hintstar₂ : ∀ (a : Fin r₂) (i : Fin d),
+      (W₂ a)ᴴ * (V₂ᴴ * A i * V₂) = blocks₂ a i * (W₂ a)ᴴ := hintstar₂raw
+  have hAmb₁ : ∀ i : Fin d, A i * V₁ = V₁ * (V₁ᴴ * A i * V₁) :=
+    mul_isometry_of_commutes A V₁ hV₁iso hComm₁
+  have hAmb₂ : ∀ i : Fin d, A i * V₂ = V₂ * (V₂ᴴ * A i * V₂) :=
+    mul_isometry_of_commutes A V₂ hV₂iso hComm₂
+  have hAmbStar₁ : ∀ i : Fin d, V₁ᴴ * A i = (V₁ᴴ * A i * V₁) * V₁ᴴ :=
+    conjTranspose_isometry_mul_of_commutes A V₁ hV₁iso hComm₁
+  have hAmbStar₂ : ∀ i : Fin d, V₂ᴴ * A i = (V₂ᴴ * A i * V₂) * V₂ᴴ :=
+    conjTranspose_isometry_mul_of_commutes A V₂ hV₂iso hComm₂
+  -- Cross-orthogonality of the two support isometries.
+  have hV₁V₂ : V₁ᴴ * V₂ = 0 := by
+    have hV₂supp : (1 - P) * V₂ = V₂ := by
+      rw [← hV₂range, Matrix.mul_assoc, hV₂iso, Matrix.mul_one]
+    have hV₁P : V₁ᴴ * P = V₁ᴴ := by
+      rw [← hV₁range, ← Matrix.mul_assoc, hV₁iso, Matrix.one_mul]
+    calc V₁ᴴ * V₂
+        = V₁ᴴ * ((1 - P) * V₂) := by rw [hV₂supp]
+      _ = (V₁ᴴ * (1 - P)) * V₂ := (Matrix.mul_assoc _ _ _).symm
+      _ = 0 := by rw [Matrix.mul_sub, Matrix.mul_one, hV₁P, sub_self, Matrix.zero_mul]
+  have hV₂V₁ : V₂ᴴ * V₁ = 0 := by
+    have h := congrArg Matrix.conjTranspose hV₁V₂
+    simpa [Matrix.conjTranspose_mul] using h
+  -- Combine the two recursive families over the sum index type.
+  let dimS : Fin r₁ ⊕ Fin r₂ → ℕ := Sum.elim dim₁ dim₂
+  let blocksS : (s : Fin r₁ ⊕ Fin r₂) → MPSTensor d (dimS s) := fun s =>
+    Sum.rec (motive := fun s => MPSTensor d (dimS s))
+      (fun a => blocks₁ a) (fun a => blocks₂ a) s
+  let VS : (s : Fin r₁ ⊕ Fin r₂) → Matrix (Fin D) (Fin (dimS s)) ℂ := fun s =>
+    Sum.rec (motive := fun s => Matrix (Fin D) (Fin (dimS s)) ℂ)
+      (fun a => V₁ * W₁ a) (fun a => V₂ * W₂ a) s
+  have hposS : ∀ s, 0 < dimS s := by
+    rintro (a | a)
+    exacts [hpos₁ a, hpos₂ a]
+  have hisoS : ∀ s, (VS s)ᴴ * VS s = 1 := by
+    rintro (a | a)
+    · change (V₁ * W₁ a)ᴴ * (V₁ * W₁ a) = 1
+      calc (V₁ * W₁ a)ᴴ * (V₁ * W₁ a)
+          = (W₁ a)ᴴ * ((V₁ᴴ * V₁) * W₁ a) := by
+            rw [Matrix.conjTranspose_mul]; simp only [Matrix.mul_assoc]
+        _ = (W₁ a)ᴴ * W₁ a := by rw [hV₁iso, Matrix.one_mul]
+        _ = 1 := hiso₁ a
+    · change (V₂ * W₂ a)ᴴ * (V₂ * W₂ a) = 1
+      calc (V₂ * W₂ a)ᴴ * (V₂ * W₂ a)
+          = (W₂ a)ᴴ * ((V₂ᴴ * V₂) * W₂ a) := by
+            rw [Matrix.conjTranspose_mul]; simp only [Matrix.mul_assoc]
+        _ = (W₂ a)ᴴ * W₂ a := by rw [hV₂iso, Matrix.one_mul]
+        _ = 1 := hiso₂ a
+  have hsumS : ∑ s : Fin r₁ ⊕ Fin r₂, VS s * (VS s)ᴴ = 1 := by
+    have h₁ : ∀ a : Fin r₁, VS (Sum.inl a) * (VS (Sum.inl a))ᴴ
+        = V₁ * (W₁ a * (W₁ a)ᴴ) * V₁ᴴ := by
+      intro a
+      change (V₁ * W₁ a) * (V₁ * W₁ a)ᴴ = V₁ * (W₁ a * (W₁ a)ᴴ) * V₁ᴴ
+      rw [Matrix.conjTranspose_mul]
+      simp only [Matrix.mul_assoc]
+    have h₂ : ∀ a : Fin r₂, VS (Sum.inr a) * (VS (Sum.inr a))ᴴ
+        = V₂ * (W₂ a * (W₂ a)ᴴ) * V₂ᴴ := by
+      intro a
+      change (V₂ * W₂ a) * (V₂ * W₂ a)ᴴ = V₂ * (W₂ a * (W₂ a)ᴴ) * V₂ᴴ
+      rw [Matrix.conjTranspose_mul]
+      simp only [Matrix.mul_assoc]
+    have hleft : ∑ a : Fin r₁, V₁ * (W₁ a * (W₁ a)ᴴ) * V₁ᴴ = P := by
+      rw [← Matrix.sum_mul, ← Matrix.mul_sum, hsum₁, Matrix.mul_one, hV₁range]
+    have hright : ∑ a : Fin r₂, V₂ * (W₂ a * (W₂ a)ᴴ) * V₂ᴴ = 1 - P := by
+      rw [← Matrix.sum_mul, ← Matrix.mul_sum, hsum₂, Matrix.mul_one, hV₂range]
+    calc ∑ s : Fin r₁ ⊕ Fin r₂, VS s * (VS s)ᴴ
+        = (∑ a : Fin r₁, VS (Sum.inl a) * (VS (Sum.inl a))ᴴ) +
+          (∑ a : Fin r₂, VS (Sum.inr a) * (VS (Sum.inr a))ᴴ) :=
+          Fintype.sum_sum_type (fun s : Fin r₁ ⊕ Fin r₂ => VS s * (VS s)ᴴ)
+      _ = (∑ a : Fin r₁, V₁ * (W₁ a * (W₁ a)ᴴ) * V₁ᴴ) +
+          (∑ a : Fin r₂, V₂ * (W₂ a * (W₂ a)ᴴ) * V₂ᴴ) := by
+          congr 1
+          · exact Finset.sum_congr rfl fun a _ => h₁ a
+          · exact Finset.sum_congr rfl fun a _ => h₂ a
+      _ = P + (1 - P) := by rw [hleft, hright]
+      _ = 1 := by abel
+  have horthS : ∀ s t : Fin r₁ ⊕ Fin r₂, s ≠ t → (VS s)ᴴ * VS t = 0 := by
+    rintro (a | a) (b | b) hst
+    · have hab : a ≠ b := fun h => hst (congrArg Sum.inl h)
+      change (V₁ * W₁ a)ᴴ * (V₁ * W₁ b) = 0
+      calc (V₁ * W₁ a)ᴴ * (V₁ * W₁ b)
+          = (W₁ a)ᴴ * ((V₁ᴴ * V₁) * W₁ b) := by
+            rw [Matrix.conjTranspose_mul]; simp only [Matrix.mul_assoc]
+        _ = (W₁ a)ᴴ * W₁ b := by rw [hV₁iso, Matrix.one_mul]
+        _ = 0 := horth₁ a b hab
+    · change (V₁ * W₁ a)ᴴ * (V₂ * W₂ b) = 0
+      calc (V₁ * W₁ a)ᴴ * (V₂ * W₂ b)
+          = (W₁ a)ᴴ * ((V₁ᴴ * V₂) * W₂ b) := by
+            rw [Matrix.conjTranspose_mul]; simp only [Matrix.mul_assoc]
+        _ = 0 := by rw [hV₁V₂, Matrix.zero_mul, Matrix.mul_zero]
+    · change (V₂ * W₂ a)ᴴ * (V₁ * W₁ b) = 0
+      calc (V₂ * W₂ a)ᴴ * (V₁ * W₁ b)
+          = (W₂ a)ᴴ * ((V₂ᴴ * V₁) * W₁ b) := by
+            rw [Matrix.conjTranspose_mul]; simp only [Matrix.mul_assoc]
+        _ = 0 := by rw [hV₂V₁, Matrix.zero_mul, Matrix.mul_zero]
+    · have hab : a ≠ b := fun h => hst (congrArg Sum.inr h)
+      change (V₂ * W₂ a)ᴴ * (V₂ * W₂ b) = 0
+      calc (V₂ * W₂ a)ᴴ * (V₂ * W₂ b)
+          = (W₂ a)ᴴ * ((V₂ᴴ * V₂) * W₂ b) := by
+            rw [Matrix.conjTranspose_mul]; simp only [Matrix.mul_assoc]
+        _ = (W₂ a)ᴴ * W₂ b := by rw [hV₂iso, Matrix.one_mul]
+        _ = 0 := horth₂ a b hab
+  have hintS : ∀ (s : Fin r₁ ⊕ Fin r₂) (i : Fin d),
+      A i * VS s = VS s * blocksS s i := by
+    rintro (a | a) i
+    · change A i * (V₁ * W₁ a) = (V₁ * W₁ a) * blocks₁ a i
+      have h1 : A i * V₁ = V₁ * (V₁ᴴ * A i * V₁) := hAmb₁ i
+      have h2 : (V₁ᴴ * A i * V₁) * W₁ a = W₁ a * blocks₁ a i := hint₁ a i
+      set B : Matrix (Fin n) (Fin n) ℂ := V₁ᴴ * A i * V₁ with hB
+      calc A i * (V₁ * W₁ a)
+          = (A i * V₁) * W₁ a := (Matrix.mul_assoc _ _ _).symm
+        _ = (V₁ * B) * W₁ a := by rw [h1]
+        _ = V₁ * (B * W₁ a) := Matrix.mul_assoc _ _ _
+        _ = V₁ * (W₁ a * blocks₁ a i) := by rw [h2]
+        _ = (V₁ * W₁ a) * blocks₁ a i := (Matrix.mul_assoc _ _ _).symm
+    · change A i * (V₂ * W₂ a) = (V₂ * W₂ a) * blocks₂ a i
+      have h1 : A i * V₂ = V₂ * (V₂ᴴ * A i * V₂) := hAmb₂ i
+      have h2 : (V₂ᴴ * A i * V₂) * W₂ a = W₂ a * blocks₂ a i := hint₂ a i
+      set B : Matrix (Fin m) (Fin m) ℂ := V₂ᴴ * A i * V₂ with hB
+      calc A i * (V₂ * W₂ a)
+          = (A i * V₂) * W₂ a := (Matrix.mul_assoc _ _ _).symm
+        _ = (V₂ * B) * W₂ a := by rw [h1]
+        _ = V₂ * (B * W₂ a) := Matrix.mul_assoc _ _ _
+        _ = V₂ * (W₂ a * blocks₂ a i) := by rw [h2]
+        _ = (V₂ * W₂ a) * blocks₂ a i := (Matrix.mul_assoc _ _ _).symm
+  have hintStarS : ∀ (s : Fin r₁ ⊕ Fin r₂) (i : Fin d),
+      (VS s)ᴴ * A i = blocksS s i * (VS s)ᴴ := by
+    rintro (a | a) i
+    · change (V₁ * W₁ a)ᴴ * A i = blocks₁ a i * (V₁ * W₁ a)ᴴ
+      rw [Matrix.conjTranspose_mul]
+      have h1 : V₁ᴴ * A i = (V₁ᴴ * A i * V₁) * V₁ᴴ := hAmbStar₁ i
+      have h2 : (W₁ a)ᴴ * (V₁ᴴ * A i * V₁) = blocks₁ a i * (W₁ a)ᴴ := hintstar₁ a i
+      set B : Matrix (Fin n) (Fin n) ℂ := V₁ᴴ * A i * V₁ with hB
+      calc ((W₁ a)ᴴ * V₁ᴴ) * A i
+          = (W₁ a)ᴴ * (V₁ᴴ * A i) := Matrix.mul_assoc _ _ _
+        _ = (W₁ a)ᴴ * (B * V₁ᴴ) := by rw [h1]
+        _ = ((W₁ a)ᴴ * B) * V₁ᴴ := (Matrix.mul_assoc _ _ _).symm
+        _ = (blocks₁ a i * (W₁ a)ᴴ) * V₁ᴴ := by rw [h2]
+        _ = blocks₁ a i * ((W₁ a)ᴴ * V₁ᴴ) := Matrix.mul_assoc _ _ _
+    · change (V₂ * W₂ a)ᴴ * A i = blocks₂ a i * (V₂ * W₂ a)ᴴ
+      rw [Matrix.conjTranspose_mul]
+      have h1 : V₂ᴴ * A i = (V₂ᴴ * A i * V₂) * V₂ᴴ := hAmbStar₂ i
+      have h2 : (W₂ a)ᴴ * (V₂ᴴ * A i * V₂) = blocks₂ a i * (W₂ a)ᴴ := hintstar₂ a i
+      set B : Matrix (Fin m) (Fin m) ℂ := V₂ᴴ * A i * V₂ with hB
+      calc ((W₂ a)ᴴ * V₂ᴴ) * A i
+          = (W₂ a)ᴴ * (V₂ᴴ * A i) := Matrix.mul_assoc _ _ _
+        _ = (W₂ a)ᴴ * (B * V₂ᴴ) := by rw [h1]
+        _ = ((W₂ a)ᴴ * B) * V₂ᴴ := (Matrix.mul_assoc _ _ _).symm
+        _ = (blocks₂ a i * (W₂ a)ᴴ) * V₂ᴴ := by rw [h2]
+        _ = blocks₂ a i * ((W₂ a)ᴴ * V₂ᴴ) := Matrix.mul_assoc _ _ _
+  have hirrS : ∀ s, IsIrreducibleTensor (blocksS s) := by
+    rintro (a | a)
+    exacts [hirr₁ a, hirr₂ a]
+  -- Reindex the sum type to `Fin (r₁ + r₂)`.
+  refine ⟨r₁ + r₂, fun k => dimS (finSumFinEquiv.symm k),
+    fun k => blocksS (finSumFinEquiv.symm k), fun k => VS (finSumFinEquiv.symm k),
+    fun k => hposS (finSumFinEquiv.symm k),
+    fun k => hisoS (finSumFinEquiv.symm k), ?_,
+    fun k l hkl => horthS _ _ fun h => hkl (finSumFinEquiv.symm.injective h),
+    fun k i => hintS (finSumFinEquiv.symm k) i,
+    fun k i => hintStarS (finSumFinEquiv.symm k) i,
+    fun k => hirrS (finSumFinEquiv.symm k)⟩
+  calc ∑ k : Fin (r₁ + r₂), VS (finSumFinEquiv.symm k) * (VS (finSumFinEquiv.symm k))ᴴ
+      = ∑ s : Fin r₁ ⊕ Fin r₂, VS s * (VS s)ᴴ :=
+        Equiv.sum_comp finSumFinEquiv.symm (fun s => VS s * (VS s)ᴴ)
+    _ = 1 := hsumS
+
+/-- **Direct-sum decomposition into irreducible corners under projector
+closure** (arXiv:1606.00608, lines 253--254).
+
+If `A` satisfies the invariant-projector closure condition, then there are
+isometries `V k` with pairwise orthogonal ranges summing to the identity such
+that every tensor matrix `A i` commutes with each range projection, the corner
+tensors `blocks k i = (V k)ᴴ * A i * V k` are irreducible, and the matrix
+product vectors of `A` equal those of the unit-weight direct sum of the corner
+tensors.
+
+This combines the reducing projections of
+`MPSTensor.exists_reducing_projection_of_hasInvariantProj` into the direct-sum
+decomposition of the canonical form of arXiv:1606.00608, eq:II_CF1,
+lines 237--241.
+Unlike `MPSTensor.exists_irreducible_blockDecomp`, the corner tensors are
+related to `A` by the intertwining `A i * V k = V k * blocks k i`, not only by
+equality of matrix product vectors, and no left-canonical normalization is
+assumed.  The remaining spectral steps — rescaling every block to spectral
+radius one and deducing blockwise primitivity from the absence of nontrivial
+periodic vectors — are recorded in
+`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`. -/
+theorem exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure
+    (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ) (blocks : (k : Fin r) → MPSTensor d (dim k))
+      (V : (k : Fin r) → Matrix (Fin D) (Fin (dim k)) ℂ),
+      (∀ k, 0 < dim k) ∧
+      (∀ k, (V k)ᴴ * V k = 1) ∧
+      (∑ k : Fin r, V k * (V k)ᴴ = 1) ∧
+      (∀ k l, k ≠ l → (V k)ᴴ * V l = 0) ∧
+      (∀ (k : Fin r) (i : Fin d), A i * V k = V k * blocks k i) ∧
+      (∀ (k : Fin r) (i : Fin d), (V k)ᴴ * A i = blocks k i * (V k)ᴴ) ∧
+      (∀ (k : Fin r) (i : Fin d), blocks k i = (V k)ᴴ * A i * V k) ∧
+      (∀ k, IsIrreducibleTensor (blocks k)) ∧
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := fun _ : Fin r => (1 : ℂ)) blocks) := by
+  obtain ⟨r, dim, blocks, V, hpos, hiso, hsum, horth, hint, hintstar, hirr⟩ :=
+    exists_irreducible_isometry_family_aux D A hClosure
+  have hcorner : ∀ (k : Fin r) (i : Fin d), blocks k i = (V k)ᴴ * A i * V k := by
+    intro k i
+    calc blocks k i
+        = ((V k)ᴴ * V k) * blocks k i := by rw [hiso k, Matrix.one_mul]
+      _ = (V k)ᴴ * (V k * blocks k i) := Matrix.mul_assoc _ _ _
+      _ = (V k)ᴴ * (A i * V k) := by rw [← hint k i]
+      _ = (V k)ᴴ * A i * V k := (Matrix.mul_assoc _ _ _).symm
+  exact ⟨r, dim, blocks, V, hpos, hiso, hsum, horth, hint, hintstar, hcorner, hirr,
+    sameMPV₂_toTensorFromBlocks_of_isometry_family A blocks V hiso hsum hint⟩
+
+end MPSTensor

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -349,6 +349,105 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     projection supplied by Definition~\ref{def:has_inv_proj}.
 \end{proof}
 
+\begin{lemma}[Support isometry of an orthogonal projection]
+    \label{lem:projection_support_isometry}
+    \lean{IsOrthogonalProjection.exists_support_isometry}
+    \leanok
+    \uses{def:orthogonal_projection_channel}
+    Every orthogonal projection $P$ on $\C^D$ factors through an isometry:
+    there are $n \in \N$ and $V \in \C^{D \times n}$ with
+    $V^\dagger V = \Id$, $V V^\dagger = P$, and $n = \tr(P)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Diagonalize $P$ unitarily; its eigenvalues are $0$ and $1$ because $P$ is
+    Hermitian and idempotent. The columns of the diagonalizing unitary
+    corresponding to eigenvalue $1$ form the required isometry, and their
+    number is $\tr(P)$.
+\end{proof}
+
+\begin{lemma}[Corner tensors inherit projector closure]
+    \label{lem:projector_closure_corner}
+    \lean{MPSTensor.hasInvariantProjectorClosure_compress_of_commutes}
+    \leanok
+    \uses{def:invariant_projector_closure, def:orthogonal_projection_channel}
+    Let $A$ have invariant-projector closure, and let $V$ be an isometry,
+    $V^\dagger V = \Id$, whose range projection $V V^\dagger$ commutes with
+    every $A^i$. Then the corner tensor $B^i = V^\dagger A^i V$ again has
+    invariant-projector closure.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:invariant_projector_closure}
+    Let $Q$ be an orthogonal projection with $Q B^i = Q B^i Q$ for all~$i$.
+    Then $V Q V^\dagger$ is an orthogonal projection, and commutation of
+    $V V^\dagger$ with each $A^i$ gives
+    $(V Q V^\dagger) A^i = (V Q V^\dagger) A^i (V Q V^\dagger)$.
+    Projector closure for $A$ yields
+    $A^i (V Q V^\dagger) = (V Q V^\dagger) A^i (V Q V^\dagger)$, and
+    compressing both sides between $V^\dagger$ and $V$ returns
+    $B^i Q = Q B^i Q$.
+\end{proof}
+
+\begin{lemma}[Matrix product vectors split along an isometric partition]
+    \label{lem:mpv_partition_isometries}
+    \lean{MPSTensor.sameMPV₂_toTensorFromBlocks_of_isometry_family}
+    \leanok
+    \uses{def:same_mpv2, def:block_diagonal_tensor}
+    Let $V_1, \ldots, V_r$ be isometries, $V_k^\dagger V_k = \Id$, with
+    $\sum_k V_k V_k^\dagger = \Id$, and suppose $A^i V_k = V_k A_k^i$ for the
+    corner tensors $A_k^i = V_k^\dagger A^i V_k$. Then
+    $\mc{V}(A) = \mc{V}(\bigoplus_{k=1}^r A_k)$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    The intertwining relation propagates from letters to words, so
+    $A^w V_k = V_k A_k^w$ for every word $w$. Inserting the partition of
+    unity $\sum_k V_k V_k^\dagger = \Id$ into the trace and cycling gives
+    \[
+        \tr(A^w)
+        = \sum_{k=1}^r \tr\bigl(V_k^\dagger A^w V_k\bigr)
+        = \sum_{k=1}^r \tr\bigl(A_k^w\bigr),
+    \]
+    which is the matrix product vector of the direct sum.
+\end{proof}
+
+\begin{theorem}[Decomposition into irreducible corners under projector closure]
+    \label{thm:projector_closure_irreducible_corners}
+    \lean{MPSTensor.exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure}
+    \leanok
+    \uses{def:invariant_projector_closure, def:irreducible_tensor,
+        def:same_mpv2, def:block_diagonal_tensor}
+    Suppose $A$ has invariant-projector closure. Then there are isometries
+    $V_1, \ldots, V_r$ with $V_k^\dagger V_k = \Id$, pairwise orthogonal
+    ranges, and $\sum_k V_k V_k^\dagger = \Id$, such that
+    $A^i V_k = V_k A_k^i$ for the corner tensors
+    $A_k^i = V_k^\dagger A^i V_k$, every corner tensor $A_k$ is irreducible,
+    and $\mc{V}(A) = \mc{V}(\bigoplus_{k=1}^r A_k)$.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{def:has_inv_proj, thm:invariant_projector_closure_commutes,
+        lem:projection_support_isometry, lem:projector_closure_corner,
+        lem:mpv_partition_isometries}
+    Strong induction on the bond dimension. If $A$ is irreducible, the single
+    corner $V = \Id$ suffices. Otherwise $A$ has a nontrivial invariant
+    projection $P$, which commutes with every $A^i$ by
+    Theorem~\ref{thm:invariant_projector_closure_commutes}. Factoring $P$ and
+    $\Id - P$ through support isometries
+    (Lemma~\ref{lem:projection_support_isometry}) splits $A$ into two corner
+    tensors of strictly smaller bond dimension, each of which inherits
+    invariant-projector closure by Lemma~\ref{lem:projector_closure_corner}.
+    The two recursively obtained families are combined; ranges from different
+    corners are orthogonal because the corresponding projections are. The
+    equality of matrix product vectors is
+    Lemma~\ref{lem:mpv_partition_isometries}.
+\end{proof}
+
 \begin{theorem}[PSD fixed point gives invariant projection]\label{thm:fp_inv_proj}
     \lean{MPSTensor.lowerZero_of_posSemidef_fixedPoint}
     \leanok

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -361,10 +361,14 @@ the resulting splitting decomposes any tensor into irreducible blocks.
 
 \begin{proof}
     \leanok
-    Diagonalize $P$ unitarily; its eigenvalues are $0$ and $1$ because $P$ is
-    Hermitian and idempotent. The columns of the diagonalizing unitary
-    corresponding to eigenvalue $1$ form the required isometry, and their
-    number is $\tr(P)$.
+    Since $P$ is Hermitian and idempotent, its eigenvalues are $0$ and $1$,
+    and unitary diagonalization gives
+    \[
+        P = U \diag(\underbrace{1, \ldots, 1}_{n}, 0, \ldots, 0)\, U^\dagger
+    \]
+    with $U$ unitary and $n = \tr(P)$. The matrix $V \in \C^{D \times n}$
+    formed by the first $n$ columns of $U$ satisfies $V^\dagger V = \Id$ and
+    $V V^\dagger = P$.
 \end{proof}
 
 \begin{lemma}[Corner tensors inherit projector closure]
@@ -382,9 +386,15 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \leanok
     \uses{def:invariant_projector_closure}
     Let $Q$ be an orthogonal projection with $Q B^i = Q B^i Q$ for all~$i$.
-    Then $V Q V^\dagger$ is an orthogonal projection, and commutation of
-    $V V^\dagger$ with each $A^i$ gives
-    $(V Q V^\dagger) A^i = (V Q V^\dagger) A^i (V Q V^\dagger)$.
+    Then $V Q V^\dagger$ is an orthogonal projection. Commutation of
+    $V V^\dagger$ with each $A^i$ gives $V^\dagger A^i = B^i V^\dagger$, so
+    left-invariance of $Q$ yields
+    \[
+        (V Q V^\dagger) A^i
+        = V Q B^i V^\dagger
+        = V Q B^i Q V^\dagger
+        = (V Q V^\dagger) A^i (V Q V^\dagger).
+    \]
     Projector closure for $A$ yields
     $A^i (V Q V^\dagger) = (V Q V^\dagger) A^i (V Q V^\dagger)$, and
     compressing both sides between $V^\dagger$ and $V$ returns
@@ -397,20 +407,20 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     \leanok
     \uses{def:same_mpv2, def:block_diagonal_tensor}
     Let $V_1, \ldots, V_r$ be isometries, $V_k^\dagger V_k = \Id$, with
-    $\sum_k V_k V_k^\dagger = \Id$, and suppose $A^i V_k = V_k A_k^i$ for the
-    corner tensors $A_k^i = V_k^\dagger A^i V_k$. Then
-    $\mc{V}(A) = \mc{V}(\bigoplus_{k=1}^r A_k)$.
+    $\sum_k V_k V_k^\dagger = \Id$, and suppose $A^i V_k = V_k B_k^i$ for
+    some tensors $B_1, \ldots, B_r$. Then
+    $\mc{V}(A) = \mc{V}(\bigoplus_{k=1}^r B_k)$.
 \end{lemma}
 
 \begin{proof}
     \leanok
     The intertwining relation propagates from letters to words, so
-    $A^w V_k = V_k A_k^w$ for every word $w$. Inserting the partition of
+    $A^w V_k = V_k B_k^w$ for every word $w$. Inserting the partition of
     unity $\sum_k V_k V_k^\dagger = \Id$ into the trace and cycling gives
     \[
         \tr(A^w)
         = \sum_{k=1}^r \tr\bigl(V_k^\dagger A^w V_k\bigr)
-        = \sum_{k=1}^r \tr\bigl(A_k^w\bigr),
+        = \sum_{k=1}^r \tr\bigl(B_k^w\bigr),
     \]
     which is the matrix product vector of the direct sum.
 \end{proof}
@@ -437,14 +447,22 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     Strong induction on the bond dimension. If $A$ is irreducible, the single
     corner $V = \Id$ suffices. Otherwise $A$ has a nontrivial invariant
     projection $P$, which commutes with every $A^i$ by
-    Theorem~\ref{thm:invariant_projector_closure_commutes}. Factoring $P$ and
-    $\Id - P$ through support isometries
-    (Lemma~\ref{lem:projection_support_isometry}) splits $A$ into two corner
-    tensors of strictly smaller bond dimension, each of which inherits
-    invariant-projector closure by Lemma~\ref{lem:projector_closure_corner}.
-    The two recursively obtained families are combined; ranges from different
-    corners are orthogonal because the corresponding projections are. The
-    equality of matrix product vectors is
+    Theorem~\ref{thm:invariant_projector_closure_commutes}. Factoring
+    $P = V_1 V_1^\dagger$ and $\Id - P = V_2 V_2^\dagger$ through support
+    isometries (Lemma~\ref{lem:projection_support_isometry}) splits $A$ into
+    two corner tensors of strictly smaller bond dimension: for $j = 1, 2$,
+    commutation gives
+    \[
+        A^i V_j = V_j \bigl(V_j^\dagger A^i V_j\bigr),
+    \]
+    and each corner inherits invariant-projector closure by
+    Lemma~\ref{lem:projector_closure_corner}. The two recursively obtained
+    families are combined; ranges from different corners are orthogonal since
+    $V_1^\dagger P = V_1^\dagger$ and $(\Id - P) V_2 = V_2$ give
+    \[
+        V_1^\dagger V_2 = V_1^\dagger P (\Id - P) V_2 = 0.
+    \]
+    The equality of matrix product vectors is
     Lemma~\ref{lem:mpv_partition_isometries}.
 \end{proof}
 


### PR DESCRIPTION
## Summary

Partially addresses #2634.

This PR proves step (1) of the three remaining steps recorded in
`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex` (Section 3) towards the
sufficient condition for canonical form at arXiv:1606.00608, lines 253–254
(`Papers/1606.00608/MPDO-22-12-17-2.tex`; CF definition `eq:II_CF1`, lines 237–241):
the construction of the reducing direct-sum decomposition from projector closure.

New file `TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean`, all sorry-free and
axiom-free:

- `IsOrthogonalProjection.exists_support_isometry` — every orthogonal projection $P$ factors
  as $P = VV^\dagger$ with $V^\dagger V = 1$ and column count $\operatorname{tr}(P)$.
- `MPSTensor.hasInvariantProjectorClosure_compress_of_commutes` — corner tensors
  $V^\dagger A^i V$ inherit invariant-projector closure when $VV^\dagger$ commutes with every
  $A^i$: a left-invariant projection $Q$ of the corner lifts to $VQV^\dagger$, ambient closure
  applies, and compressing back returns the closure identity. No normalization is used.
- `MPSTensor.sameMPV₂_toTensorFromBlocks_of_isometry_family` — if isometries with ranges
  summing to the identity intertwine the tensor matrices with corner tensors, the matrix
  product vectors of the tensor equal those of the unit-weight direct sum of the corners.
- `MPSTensor.exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure` —
  the main statement: under projector closure there are isometries $V_1,\dots,V_r$ with
  $V_k^\dagger V_k = 1$, pairwise orthogonal ranges, $\sum_k V_k V_k^\dagger = 1$,
  intertwinings $A^i V_k = V_k A_k^i$ and $V_k^\dagger A^i = A_k^i V_k^\dagger$ for the corner
  tensors $A_k^i = V_k^\dagger A^i V_k$, every corner tensor irreducible, and
  $\mathcal V(A) = \mathcal V(\bigoplus_k A_k)$. Proof by strong induction on the bond
  dimension, splitting along a reducing projection
  (`commutes_of_hasInvariantProjectorClosure_of_lowerZero`, #3682) and recursing on the two
  corners.

Unlike `MPSTensor.exists_irreducible_blockDecomp`, the corners here are related to $A$ by
intertwining isometries rather than only by equality of matrix product vectors; this is the
structural relation the subsequent spectral steps need. No hypothesis of the form
$\sum_i (A^i)^\dagger A^i = 1$ appears anywhere, matching the source proposition.

## What remains (steps 2–3 of the gap note)

- Rescale every nonzero irreducible block so that its transfer map has spectral radius one,
  carrying the removed scale into the coefficient $\mu_k$.
- Identify the absence of nontrivial $p$-periodic vectors with primitivity of every rescaled
  block transfer map, producing the normal-tensor blocks of `eq:II_CF1`.

## Blueprint

Four new entries in `blueprint/src/chapter/ch09_canonical.tex` next to the
projector-closure entries from #3682: the support-isometry factorization
(`lem:projection_support_isometry`), closure inheritance for corners
(`lem:projector_closure_corner`), the matrix-product-vector split along an isometric
partition (`lem:mpv_partition_isometries`), and the decomposition theorem
(`thm:projector_closure_irreducible_corners`).

## Checks

- `lake build TNLean` (full) passes.
- `rg -n "sorry|axiom"` on the new file: none.
- `lake exe lint_style` passes.
- `python3 scripts/blueprint_lean_sync.py --ci` and `lake exe checkdecls blueprint/lean_decls` pass.
- `scripts/check_reader_facing_prose.py --diff-base origin/main` and
  `scripts/check_forbidden_lean_tokens.py` pass; `git diff --check` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New formal proofs and blueprint documentation on the canonical-form path; no changes to auth, runtime, or existing decomposition APIs beyond an added import and chapter entries.
> 
> **Overview**
> Adds **`TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean`** and wires it into **`TNLean.lean`**, proving the **direct-sum step** toward CPSV canonical form under **invariant-projector closure** (arXiv:1606.00608): reducing projections are merged into an **isometric** block decomposition with **irreducible** corners.
> 
> The main result **`exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure`** builds isometries \(V_k\) with orthogonal ranges summing to the identity, **intertwinings** \(A^i V_k = V_k A_k^i\) for corner tensors \(A_k^i = V_k^\dagger A^i V_k\), irreducibility of each block, and **`SameMPV₂`** with the unit-weight direct sum—**without** left-canonical or unital normalization. Supporting lemmas cover **support isometries** for projections, **closure inheritance** under compression, **MPV splitting** along an isometric partition, and a **strong induction** core that splits along reducing projections and recurses on bond dimension.
> 
> **`blueprint/src/chapter/ch09_canonical.tex`** gains four linked entries (support isometry, corner closure, MPV partition, decomposition theorem) aligned with the new Lean names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb26393f90d35525276c9efbbd8b4103c3bb3d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->