### PR TITLE
feat(Algebra): identify irreducible invariant subspaces with simple modules

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -44,6 +44,7 @@ import TNLean.Algebra.StarSubalgebraIsotypic
 import TNLean.Algebra.StarSubalgebraIsotypicDecomp
 import TNLean.Algebra.StarSubalgebraSchur
 import TNLean.Algebra.StarSubalgebraSemisimple
+import TNLean.Algebra.StarSubalgebraSimpleModule
 import TNLean.Algebra.StarSubalgebraSpatial
 import TNLean.Algebra.StarSubalgebraUnitaryIntertwiner
 

--- a/TNLean/Algebra/StarSubalgebraSimpleModule.lean
+++ b/TNLean/Algebra/StarSubalgebraSimpleModule.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.Algebra.StarSubalgebraIrreducibleDecomp
+import TNLean.Algebra.StarSubalgebraSemisimple
+
+/-!
+# Irreducible invariant subspaces as simple modules over the subalgebra
+
+A star-subalgebra `S` of complex matrices acts on Euclidean space, each member acting as the
+operator its matrix represents. Mathlib already provides this action as a module structure:
+matrices act on `n → ℂ` (`Matrix.instModuleForall`), the action restricts to the subalgebra
+(`Subsemiring.instModuleSubtypeMem`), and it transports to `EuclideanSpace ℂ n`
+(`WithLp.instModule`). This file identifies the invariant-subspace notions used in the
+structure theory of Wolf Ch. 6 (towards Thm 6.14) with their module-theoretic counterparts:
+the submodules over the subalgebra are exactly the invariant subspaces, and the irreducible
+invariant subspaces are exactly the simple submodules.
+
+Through this identification the isotypic grouping behind Wolf Thm 6.14 can draw on the
+general theory of simple and semisimple modules (`IsSimpleModule`, `IsSemisimpleModule`,
+`Mathlib.RingTheory.SimpleModule.Isotypic`) instead of re-deriving it for the spatial
+predicates.
+
+## Main definitions
+
+* `StarSubalgebra.IsInvariantSubspace.toSubmodule` -- an invariant subspace regarded as a
+  submodule over the subalgebra.
+
+## Main results
+
+* `StarSubalgebra.isScalarTower_pi` -- the matrix action of the subalgebra on `n → ℂ` is
+  complex-linear in the subalgebra member; from this the corresponding statement on
+  `EuclideanSpace ℂ n` follows by the general `WithLp` instance.
+* `StarSubalgebra.isInvariantSubspace_iff_exists_restrictScalars` -- the invariant subspaces
+  are exactly the complex subspaces underlying submodules over the subalgebra.
+* `StarSubalgebra.isIrreducibleSubspace_restrictScalars_iff` -- a submodule over the
+  subalgebra is simple precisely when its underlying subspace is irreducible.
+* `StarSubalgebra.isSemisimpleModule_euclideanSpace` -- Euclidean space is a semisimple
+  module over the subalgebra.
+-/
+
+namespace StarSubalgebra
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
+
+/-- Scaling a member of a star-subalgebra of complex matrices scales its action on `n → ℂ`:
+the restriction to the subalgebra of the corresponding property of the full matrix action
+(`Matrix.instIsScalarTowerForall`). Together with the general `WithLp` instance this yields
+`IsScalarTower ℂ ↥S (EuclideanSpace ℂ n)`. Wolf Ch. 6, towards Thm 6.14. -/
+instance isScalarTower_pi : IsScalarTower ℂ ↥S ((i : n) → ℂ) where
+  smul_assoc c s v := by
+    have h := smul_assoc c (s : Matrix n n ℂ) v
+    rwa [← SetLike.val_smul] at h
+
+/-- The module action of a member of the subalgebra on Euclidean space is the operator its
+matrix represents; membership statements about the action can be rewritten to the
+`Matrix.toEuclideanLin` form used by `StarSubalgebra.IsInvariantSubspace`. -/
+theorem euclideanSpace_smul_def (s : ↥S) (v : EuclideanSpace ℂ n) :
+    s • v = Matrix.toEuclideanLin (s : Matrix n n ℂ) v :=
+  rfl
+
+variable {S}
+
+/-- An invariant subspace of a star-subalgebra of complex matrices, regarded as a submodule
+over the subalgebra. Wolf Ch. 6, towards Thm 6.14. -/
+def IsInvariantSubspace.toSubmodule {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : S.IsInvariantSubspace p) : Submodule ↥S (EuclideanSpace ℂ n) where
+  carrier := p
+  add_mem' := p.add_mem
+  zero_mem' := p.zero_mem
+  smul_mem' s {_} hv := hp s.1 s.2 hv
+
+@[simp]
+theorem IsInvariantSubspace.mem_toSubmodule {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : S.IsInvariantSubspace p) {x : EuclideanSpace ℂ n} : x ∈ hp.toSubmodule ↔ x ∈ p :=
+  Iff.rfl
+
+/-- Restricting the scalars of the submodule attached to an invariant subspace recovers the
+subspace. -/
+@[simp]
+theorem IsInvariantSubspace.restrictScalars_toSubmodule {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : S.IsInvariantSubspace p) : hp.toSubmodule.restrictScalars ℂ = p := by
+  ext x
+  exact Iff.rfl
+
+variable (S)
+
+/-- The complex subspace underlying a submodule over the subalgebra is invariant under every
+member of the subalgebra. Wolf Ch. 6, towards Thm 6.14. -/
+theorem isInvariantSubspace_restrictScalars (q : Submodule ↥S (EuclideanSpace ℂ n)) :
+    S.IsInvariantSubspace (q.restrictScalars ℂ) := by
+  intro A hA
+  rw [Module.End.mem_invtSubmodule_iff_forall_mem_of_mem]
+  intro x hx
+  rw [Submodule.restrictScalars_mem] at hx ⊢
+  rw [← euclideanSpace_smul_def S ⟨A, hA⟩ x]
+  exact q.smul_mem _ hx
+
+/-- The invariant subspaces of a star-subalgebra of complex matrices are exactly the complex
+subspaces underlying submodules over the subalgebra. Wolf Ch. 6, towards Thm 6.14. -/
+theorem isInvariantSubspace_iff_exists_restrictScalars (p : Submodule ℂ (EuclideanSpace ℂ n)) :
+    S.IsInvariantSubspace p ↔
+      ∃ q : Submodule ↥S (EuclideanSpace ℂ n), q.restrictScalars ℂ = p :=
+  ⟨fun hp ↦ ⟨hp.toSubmodule, hp.restrictScalars_toSubmodule⟩,
+    fun ⟨q, hq⟩ ↦ hq ▸ S.isInvariantSubspace_restrictScalars q⟩
+
+/-- A submodule of Euclidean space over a star-subalgebra of complex matrices is simple
+precisely when its underlying complex subspace is an irreducible invariant subspace. This
+identifies the spatial irreducibility notion of the structure theory with simplicity of
+modules, so the isotypic grouping behind Wolf Thm 6.14 can draw on the general theory of
+semisimple modules. Wolf Ch. 6, towards Thm 6.14. -/
+theorem isIrreducibleSubspace_restrictScalars_iff (q : Submodule ↥S (EuclideanSpace ℂ n)) :
+    S.IsIrreducibleSubspace (q.restrictScalars ℂ) ↔ IsSimpleModule ↥S q := by
+  rw [isSimpleModule_iff_isAtom]
+  constructor
+  · rintro ⟨-, hne, hmin⟩
+    refine ⟨fun h ↦ hne (by rw [h, Submodule.restrictScalars_bot]), fun q' hq' ↦ ?_⟩
+    rcases hmin (q'.restrictScalars ℂ) (S.isInvariantSubspace_restrictScalars q')
+        (Submodule.restrictScalars_mono ℂ hq'.le) with h | h
+    · rwa [Submodule.restrictScalars_eq_bot_iff] at h
+    · exact absurd (Submodule.restrictScalars_injective ℂ ↥S (EuclideanSpace ℂ n) h) hq'.ne
+  · intro hq
+    refine ⟨S.isInvariantSubspace_restrictScalars q, ?_, fun r hr hle ↦ ?_⟩
+    · rw [Ne, Submodule.restrictScalars_eq_bot_iff]
+      exact hq.1
+    · have hle' : hr.toSubmodule ≤ q := fun x hx ↦ hle hx
+      rcases hq.le_iff.mp hle' with h | h
+      · left
+        have hr' := congrArg (Submodule.restrictScalars ℂ) h
+        rwa [hr.restrictScalars_toSubmodule, Submodule.restrictScalars_bot] at hr'
+      · right
+        have hr' := congrArg (Submodule.restrictScalars ℂ) h
+        rwa [hr.restrictScalars_toSubmodule] at hr'
+
+/-- An invariant subspace of a star-subalgebra of complex matrices is irreducible precisely
+when it is simple as a module over the subalgebra. Wolf Ch. 6, towards Thm 6.14. -/
+theorem isIrreducibleSubspace_iff_isSimpleModule {p : Submodule ℂ (EuclideanSpace ℂ n)}
+    (hp : S.IsInvariantSubspace p) :
+    S.IsIrreducibleSubspace p ↔ IsSimpleModule ↥S hp.toSubmodule := by
+  have h := S.isIrreducibleSubspace_restrictScalars_iff hp.toSubmodule
+  rwa [hp.restrictScalars_toSubmodule] at h
+
+/-- Euclidean space is a semisimple module over a star-subalgebra of complex matrices: every
+submodule over the subalgebra admits a complementary submodule. This is the module-theoretic
+form of the orthogonal irreducible decomposition, obtained here from semisimplicity of the
+subalgebra as a ring (`StarSubalgebra.isSemisimpleRing`). Wolf Ch. 6, towards Thm 6.14. -/
+theorem isSemisimpleModule_euclideanSpace : IsSemisimpleModule ↥S (EuclideanSpace ℂ n) :=
+  inferInstance
+
+end StarSubalgebra

--- a/TNLean/Algebra/StarSubalgebraSimpleModule.lean
+++ b/TNLean/Algebra/StarSubalgebraSimpleModule.lean
@@ -10,16 +10,15 @@ import TNLean.Algebra.StarSubalgebraSemisimple
 
 A star-subalgebra `S` of complex matrices acts on Euclidean space, each member acting as the
 operator its matrix represents. Mathlib already provides this action as a module structure:
-matrices act on `n → ℂ` (`Matrix.instModuleForall`), the action restricts to the subalgebra
-(`Subsemiring.instModuleSubtypeMem`), and it transports to `EuclideanSpace ℂ n`
-(`WithLp.instModule`). This file identifies the invariant-subspace notions used in the
+matrices act on `n → ℂ`, the action restricts to the subalgebra, and it transports to
+`EuclideanSpace ℂ n`. This file identifies the invariant-subspace notions used in the
 structure theory of Wolf Ch. 6 (towards Thm 6.14) with their module-theoretic counterparts:
 the submodules over the subalgebra are exactly the invariant subspaces, and the irreducible
 invariant subspaces are exactly the simple submodules.
 
 Through this identification the isotypic grouping behind Wolf Thm 6.14 can draw on the
-general theory of simple and semisimple modules (`IsSimpleModule`, `IsSemisimpleModule`,
-`Mathlib.RingTheory.SimpleModule.Isotypic`) instead of re-deriving it for the spatial
+general theory of simple and semisimple modules (`IsSimpleModule`, `IsSemisimpleModule` and
+the isotypic decomposition built on them) instead of re-deriving it for the spatial
 predicates.
 
 ## Main definitions
@@ -46,8 +45,8 @@ variable {n : Type*} [Fintype n] [DecidableEq n]
 variable (S : StarSubalgebra ℂ (Matrix n n ℂ))
 
 /-- Scaling a member of a star-subalgebra of complex matrices scales its action on `n → ℂ`:
-the restriction to the subalgebra of the corresponding property of the full matrix action
-(`Matrix.instIsScalarTowerForall`). Together with the general `WithLp` instance this yields
+the restriction to the subalgebra of the corresponding property of the full matrix action.
+Together with the general `WithLp` instance this yields
 `IsScalarTower ℂ ↥S (EuclideanSpace ℂ n)`. Wolf Ch. 6, towards Thm 6.14. -/
 instance isScalarTower_pi : IsScalarTower ℂ ↥S ((i : n) → ℂ) where
   smul_assoc c s v := by

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1273,8 +1273,7 @@ step the two pieces are.
 
 The irreducibility notion just used is simplicity in the language of modules. The
 members of $S$ act on $\C^{D}$ as the operators their matrices represent, making
-$\C^{D}$ a module over the algebra $S$; a subspace of $\C^{D}$ is closed under this
-action precisely when it is invariant under every member of $S$.
+$\C^{D}$ a module over the algebra $S$.
 
 \begin{lemma}[Irreducible invariant subspaces are the simple submodules]%
     \label{lem:starSubalgebra_irreducible_iff_simple}
@@ -1282,22 +1281,32 @@ action precisely when it is invariant under every member of $S$.
       StarSubalgebra.isIrreducibleSubspace_restrictScalars_iff}
     \leanok
     \uses{def:starSubalgebra_irreducibleSubspace}
-    Let $S$ be a $*$-subalgebra of $\MN{D}$, acting on $\C^{D}$. The subspaces of
-    $\C^{D}$ closed under the action of $S$ are exactly the invariant subspaces,
-    and an invariant subspace is irreducible under $S$ precisely when, as a module
-    over $S$, it is simple: nonzero, with no submodule other than $\{0\}$ and
-    itself.
+    Let $S$ be a $*$-subalgebra of $\MN{D}$, acting on $\C^{D}$. A complex
+    subspace $W \subseteq \C^{D}$ is invariant under every member of $S$ if and
+    only if $W$ is the underlying complex subspace of a submodule of $\C^{D}$
+    over $S$. Under this identification an invariant subspace is irreducible
+    under $S$ precisely when, as a module over $S$, it is simple: nonzero, with
+    no submodule other than $\{0\}$ and itself.
 \end{lemma}
 
 \begin{proof}
     \leanok
     \uses{def:starSubalgebra_irreducibleSubspace}
-    A subspace closed under the action of $S$ is invariant, since each member of
-    $S$ maps it into itself; conversely an invariant subspace is closed under the
-    action of every member of $S$ and under the complex scalars, which lie in $S$.
-    Under this correspondence the submodules contained in an invariant subspace
-    $W$ are exactly the invariant subspaces contained in $W$, so irreducibility of
-    $W$ and simplicity of $W$ as a module ask the same of them.
+    The underlying set of a submodule of $\C^{D}$ over $S$ is closed under
+    addition and under the action of every member of $S$; since the complex
+    scalars lie in $S$, it is a complex subspace, and it is invariant.
+    Conversely an invariant complex subspace $W$ is closed under addition and
+    under the action of every member of $S$, so $W$ underlies a submodule $q$
+    of $\C^{D}$ over $S$ with the same members. Under this correspondence the
+    submodules below $q$ are exactly the invariant subspaces below $W$:
+    \[
+        \{\, q' \subseteq q : q' \text{ a submodule over } S \,\}
+        =
+        \{\, W' \subseteq W : W' \text{ invariant under } S \,\}.
+    \]
+    Hence $q$ has a submodule other than $\{0\}$ and $q$ exactly when $W$ has
+    an invariant subspace other than $\{0\}$ and $W$: simplicity of $q$ as a
+    module over $S$ is irreducibility of $W$ under $S$.
 \end{proof}
 
 \begin{lemma}[Euclidean space is a semisimple module over the subalgebra]%

--- a/blueprint/src/chapter/ch07_spectral.tex
+++ b/blueprint/src/chapter/ch07_spectral.tex
@@ -1271,6 +1271,51 @@ step the two pieces are.
     whole space $W = \C^{D}$, which is invariant under every member of $S$.
 \end{proof}
 
+The irreducibility notion just used is simplicity in the language of modules. The
+members of $S$ act on $\C^{D}$ as the operators their matrices represent, making
+$\C^{D}$ a module over the algebra $S$; a subspace of $\C^{D}$ is closed under this
+action precisely when it is invariant under every member of $S$.
+
+\begin{lemma}[Irreducible invariant subspaces are the simple submodules]%
+    \label{lem:starSubalgebra_irreducible_iff_simple}
+    \lean{StarSubalgebra.isInvariantSubspace_iff_exists_restrictScalars,
+      StarSubalgebra.isIrreducibleSubspace_restrictScalars_iff}
+    \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$, acting on $\C^{D}$. The subspaces of
+    $\C^{D}$ closed under the action of $S$ are exactly the invariant subspaces,
+    and an invariant subspace is irreducible under $S$ precisely when, as a module
+    over $S$, it is simple: nonzero, with no submodule other than $\{0\}$ and
+    itself.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:starSubalgebra_irreducibleSubspace}
+    A subspace closed under the action of $S$ is invariant, since each member of
+    $S$ maps it into itself; conversely an invariant subspace is closed under the
+    action of every member of $S$ and under the complex scalars, which lie in $S$.
+    Under this correspondence the submodules contained in an invariant subspace
+    $W$ are exactly the invariant subspaces contained in $W$, so irreducibility of
+    $W$ and simplicity of $W$ as a module ask the same of them.
+\end{proof}
+
+\begin{lemma}[Euclidean space is a semisimple module over the subalgebra]%
+    \label{lem:starSubalgebra_isSemisimpleModule}
+    \lean{StarSubalgebra.isSemisimpleModule_euclideanSpace}
+    \leanok
+    \uses{lem:starSubalgebra_isSemisimpleRing}
+    Let $S$ be a $*$-subalgebra of $\MN{D}$. As a module over $S$, the space
+    $\C^{D}$ is semisimple: every submodule admits a complementary submodule.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{lem:starSubalgebra_isSemisimpleRing}
+    The ring $S$ is semisimple (Lemma~\ref{lem:starSubalgebra_isSemisimpleRing}),
+    and every module over a semisimple ring is semisimple.
+\end{proof}
+
 The next step towards the structure theorem groups the irreducible pieces by
 isomorphism type. The grouping is governed by Schur's lemma: a map commuting with
 $S$ between two pieces is either zero or an isomorphism, and over the complex


### PR DESCRIPTION
## Summary

Delivers the remaining formalization target of LionSR/QICLean#188 (items 1–3): the module structure of a star-subalgebra $S \subseteq M_D(\mathbb{C})$ acting on $\mathbb{C}^D$, the scalar-tower compatibility, and the equivalence between the spatial irreducibility predicate and simplicity of modules, so the isotypic analysis towards Wolf, *Quantum Channels & Operations*, Thm. 6.14 can draw on Mathlib's theory of simple and semisimple modules.

New file `TNLean/Algebra/StarSubalgebraSimpleModule.lean`:

- **No new `Module` instance is needed.** Mathlib already provides the action canonically: matrices act on $n \to \mathbb{C}$ (`Matrix.instModuleForall`), the action restricts to the subalgebra (`Subsemiring.instModuleSubtypeMem`), and transports to `EuclideanSpace ℂ n` (`WithLp.instModule`); the resulting action is definitionally the `Matrix.toEuclideanLin` action used by `StarSubalgebra.IsInvariantSubspace` (`StarSubalgebra.euclideanSpace_smul_def`, proof `rfl`). The `Module.compHom` construction proposed in the issue would duplicate this instance, so it is deliberately not added.
- `StarSubalgebra.isScalarTower_pi` — the missing `IsScalarTower ℂ ↥S ((i : n) → ℂ)` instance, restricting `Matrix.instIsScalarTowerForall` to the subalgebra; `IsScalarTower ℂ ↥S (EuclideanSpace ℂ n)` then follows from the general `WithLp` instance (issue item 2).
- `StarSubalgebra.IsInvariantSubspace.toSubmodule` with `mem_toSubmodule` / `restrictScalars_toSubmodule`, `StarSubalgebra.isInvariantSubspace_restrictScalars`, and `StarSubalgebra.isInvariantSubspace_iff_exists_restrictScalars` — the invariant subspaces are exactly the complex subspaces underlying submodules over the subalgebra.
- `StarSubalgebra.isIrreducibleSubspace_restrictScalars_iff` and `StarSubalgebra.isIrreducibleSubspace_iff_isSimpleModule` — an invariant subspace is irreducible in the sense of `StarSubalgebra.IsIrreducibleSubspace` precisely when it is a simple `↥S`-module (issue item 3), via `isSimpleModule_iff_isAtom` and the order embedding of scalar restriction.
- `StarSubalgebra.isSemisimpleModule_euclideanSpace` — $\mathbb{C}^D$ is a semisimple $S$-module, by instance search from `StarSubalgebra.isSemisimpleRing` (#3561), the entry point to `Mathlib.RingTheory.SimpleModule.Isotypic` for LionSR/QICLean#189.

Item 4 of the issue (orthogonal isotypic decomposition) was already delivered on the direct Schur route by LionSR/TNLean#3582.

## Blueprint

Two new entries in `blueprint/src/chapter/ch07_spectral.tex`, placed after the orthogonal irreducible decomposition: `lem:starSubalgebra_irreducible_iff_simple` and `lem:starSubalgebra_isSemisimpleModule`, both `\leanok` with proofs.

## Verification

- `lake build TNLean` succeeds; the new file compiles with no warnings.
- No `sorry`/`axiom` in the diff.
- `leanblueprint checkdecls` passes; `scripts/blueprint_lean_sync.py --ci` passes (ch07 at 131/131).
- `git diff --check` clean.

Closes LionSR/QICLean#188

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure formalization and documentation: new equivalences and a root import, no runtime or security-sensitive behavior.
> 
> **Overview**
> Adds **`TNLean/Algebra/StarSubalgebraSimpleModule.lean`** and wires it into the public import surface, bridging Wolf Ch. 6 spatial predicates to Mathlib’s module theory on **`EuclideanSpace ℂ n`** over **`↥S`**.
> 
> The new lemmas show that **`S.IsInvariantSubspace`** matches submodules via **`restrictScalars`**, that **`S.IsIrreducibleSubspace`** matches **`IsSimpleModule ↥S`**, and supply **`isScalarTower_pi`** plus **`euclideanSpace_smul_def`** (`rfl`) so the subalgebra action aligns with **`Matrix.toEuclideanLin`**. **`isSemisimpleModule_euclideanSpace`** is obtained by instance from existing semisimplicity of **`S`**, so later isotypic decomposition can use Mathlib’s semisimple-module API instead of re-proving it for invariant subspaces.
> 
> **`blueprint/src/chapter/ch07_spectral.tex`** gains two `\leanok` lemmas after the orthogonal irreducible decomposition: irreducible pieces as simple submodules, and **`ℂ^D`** semisimple as an **`S`**-module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41a1049646b5cd57d05c32672270f992d2a19af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->