### PR TITLE
fix(docs): restore the paper-gaps LaTeX build

### DIFF
--- a/docs/paper-gaps/command.tex
+++ b/docs/paper-gaps/command.tex
@@ -14,3 +14,16 @@
 \newcommand{\ghissue}[1]{\href{\tnleanIssueBase#1}{GitHub issue \##1}}
 \newcommand{\ghpr}[1]{\href{\tnleanPrBase#1}{PR \##1}}
 \newcommand{\doclink}[1]{\href{\tnleanDocBase#1.html}{\path{#1}}}
+
+% Dirac notation and the identity operator, as in blueprint/src/macros/common.tex.
+% \providecommand keeps note-local definitions authoritative.
+\usepackage{dsfont}
+\providecommand{\ket}[1]{|#1\rangle}
+\providecommand{\bra}[1]{\langle #1|}
+\providecommand{\braket}[2]{\langle #1 | #2 \rangle}
+\providecommand{\ketbra}[2]{|#1\rangle\!\langle #2|}
+\providecommand{\Id}{\mathds{1}}
+\providecommand{\one}{\mathds{1}}
+\providecommand{\C}{\mathbb{C}}
+\providecommand{\MN}[1]{M_{#1}(\C)}
+\providecommand{\MD}{M_D(\C)}

--- a/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
+++ b/docs/paper-gaps/peps_normal_ft_2d_overlap.tex
@@ -527,7 +527,7 @@ from spanning families $W_1, W_2$ of \emph{square} matrices
 $\mathrm{Mat}_{D}$ with $F\,a \cdot W_2\,b = W_1\,a \cdot G\,b$. In the
 one-dimensional chain it applies directly because a length-$L$ window has two
 virtual legs --- a left bond and a right bond, both of dimension $D$ --- so the
-window product $\path{arcEval}\,A\,r\,(\mathrm{ofFn}\,a)$ and the deformed
+window product $\text{\path{arcEval}}\,A\,r\,(\mathrm{ofFn}\,a)$ and the deformed
 window $C\,0\,a$ are themselves $D \times D$ matrices. In two dimensions a
 single end window touches the bond $e$ with \emph{one} endpoint, so the
 $e$-leg is a single $\mathrm{Fin}(\mathrm{bondDim}\,e)$ index, not a pair: a
@@ -554,8 +554,8 @@ hypothesis \path{hCB}), which the corollary's minimal size does not provide; the
 overlapping-window replacement plays the second end window $W_{L+K-1}$ in the
 host's role, inverting only the two injective windows. Reaching $X$ from the
 end-pair equality \path{staircasePair_insert_eq_open} therefore needs the
-$\path{extendInsert}\,(W_0 \subseteq S)$-to-single-bond-$e$ peeling: reading the
-corner extension on $S$ as a $\path{regionInsertedCoeff}$-style contraction of
+$\text{\path{extendInsert}}\,(W_0 \subseteq S)$-to-single-bond-$e$ peeling: reading the
+corner extension on $S$ as a $\text{\path{regionInsertedCoeff}}$-style contraction of
 $C_0$ against the genuine $W_{L+K-1}$ block across $e$. That peeling is the
 host-boundary-edge embedding and the $Q$-weight span lemma recorded as the
 unbuilt residual at the close of the previous section; the single-crossing
@@ -853,12 +853,12 @@ $\mathrm{univ} \setminus S$. They are stated here with the machinery each needs.
 transitivity of the corner extension: for nested regions $R \subseteq S
 \subseteq P$ and an insert $C$ on $R$,
 \[
-  \path{extendInsert} (S \subseteq P)\,\bigl(\path{extendInsert} (R \subseteq
-  S)\, C\bigr) \;=\; \path{extendInsert} (R \subseteq P)\, C
+  \text{\path{extendInsert}} (S \subseteq P)\,\bigl(\text{\path{extendInsert}} (R \subseteq
+  S)\, C\bigr) \;=\; \text{\path{extendInsert}} (R \subseteq P)\, C
   \qquad\text{as inserts on } P.
 \]
 Each consecutive-window open-boundary equality lives on the union $U_j$;
-extending both sides through $\path{extendInsert}(U_j \subseteq P)$ and
+extending both sides through $\text{\path{extendInsert}}(U_j \subseteq P)$ and
 collapsing the composition by this transitivity chains the equalities into one
 patch-level insert equality. The identity is \emph{not} reducible to the
 assembled-state collapse \path{deformedRegionState_extend}: both sides have the
@@ -868,9 +868,9 @@ size. Stripping the inverse interior-bond multiplicities (the lemma
 \path{extendInsert_const_smul} commutes the rescaling through), the identity
 reduces to the \emph{bare} composition law
 \[
-  \path{bareExtendInsert} (S \subseteq P)\,\bigl(\path{bareExtendInsert} (R
+  \text{\path{bareExtendInsert}} (S \subseteq P)\,\bigl(\text{\path{bareExtendInsert}} (R
   \subseteq S)\, C\bigr) \;=\; \mathrm{ribp}(\mathrm{univ} \setminus S)\cdot
-  \path{bareExtendInsert} (R \subseteq P)\, C ,
+  \text{\path{bareExtendInsert}} (R \subseteq P)\, C ,
 \]
 which is the blue-coupling composition of \path{ThreeBlockGeometry.threeBlockBlueCoeff}
 across the two nested geometries, glued along the $\mathrm{univ} \setminus S$
@@ -892,17 +892,17 @@ blue-coupling composition is \path{threeBlockBlueCoeff_comp}, the bare law
 \path{bareExtendInsert_trans}, and the transitivity \path{extendInsert_trans}.
 
 \emph{The shared-corner cancellation.} With the patch equality
-$\path{extendInsert} (W_0 \subseteq P)\, C_0 = \path{extendInsert} (W_{L+K-1}
+$\text{\path{extendInsert}} (W_0 \subseteq P)\, C_0 = \text{\path{extendInsert}} (W_{L+K-1}
 \subseteq P)\, C_{L+K-1}$ in hand, the corner cancellation is the injectivity of
-$\path{extendInsert} (S \subseteq R)$ on inserts on $S$, where $R = S \sqcup Q$
-and $Q = \path{horizontalStaircaseCompletedCorner}$ is the injective completed
+$\text{\path{extendInsert}} (S \subseteq R)$ on inserts on $S$, where $R = S \sqcup Q$
+and $Q = \text{\path{horizontalStaircaseCompletedCorner}}$ is the injective completed
 rectangle: extending the patch equality to $R$ (one more transitivity step
 through $P \subseteq R$, since $R = P \sqcup \text{added row}$) and cancelling
 the shared $Q$-block gives the end-pair equality. The cancellation needs
 \emph{only} $Q$ injective, never $\mathrm{univ} \setminus S$. For the nested
 geometry $\mathrm{red} = S$, $\mathrm{blue} = R \setminus S = Q$,
 $\mathrm{complement} = \mathrm{univ} \setminus R$, the corner-extended insert
-contracts the $S$-insert against $\path{ThreeBlockGeometry.threeBlockBlueCoeff}$;
+contracts the $S$-insert against $\text{\path{ThreeBlockGeometry.threeBlockBlueCoeff}}$;
 its $\sigma_{\mathrm{blue}}$-dependence is a combination of the $Q$ blocked
 weights, so $Q$ injectivity (the chosen left inverse
 \path{regionBlockedTensorMap_injective_of_injective} of the $Q$ block) reads off
@@ -917,7 +917,7 @@ lemma's two-step does not isolate.
 
 The shared-corner cancellation is formalized in
 \path{TNLean/PEPS/TorusWindowChain5.lean}. Since the corner extension is linear
-in its insert, the injectivity of $\path{extendInsert}(S\subseteq R)$ reduces
+in its insert, the injectivity of $\text{\path{extendInsert}}(S\subseteq R)$ reduces
 to its kernel: the only insert on $S$ whose corner extension on $R$ vanishes is
 the zero insert. The linearity lemmas \path{extendInsert_add},
 \path{extendInsert_sub}, and \path{extendInsert_const_smul} supply this
@@ -954,7 +954,7 @@ comparison \path{horizontalConsecutiveWindow_extend_eq}: both give
 open-boundary equalities of corner-extended inserts on a consecutive-window
 union. The per-step theorem \path{staircaseStep_patch_extend_eq} lifts such a
 consecutive-window equality from the union $U_j$ to the full patch $P$ by
-extending both sides through $\path{extendInsert}(U_j\subseteq P)$ and using
+extending both sides through $\text{\path{extendInsert}}(U_j\subseteq P)$ and using
 \path{extendInsert_trans} along $W_j\subseteq U_j\subseteq P$. The chained
 equality \path{staircasePatch_insert_eq} advances by induction from $W_0$ to
 $W_{L+K-1}$; the intermediate windows disappear because their deformed states
@@ -982,12 +982,12 @@ back-half of Theorem~3 (Step~5) actually needs.
 
 Step~3 now delivers the open-boundary equality on the end pair $S = W_0 \sqcup
 W_{L+K-1}$ without inverting $\mathrm{univ}\setminus S$: the corner-extension
-composition $\path{extendInsert}(S\subseteq P)\circ\path{extendInsert}(R\subseteq
-S) = \path{extendInsert}(R\subseteq P)$ and the shared-corner cancellation
-$\path{staircasePair\_cancel}$ are landed, and the end-pair equality
+composition $\text{\path{extendInsert}}(S\subseteq P)\circ\text{\path{extendInsert}}(R\subseteq
+S) = \text{\path{extendInsert}}(R\subseteq P)$ and the shared-corner cancellation
+$\text{\path{staircasePair\_cancel}}$ are landed, and the end-pair equality
 \[
-  \path{extendInsert}(W_0\subseteq S)\,C_0 \;=\;
-  \path{extendInsert}(W_{L+K-1}\subseteq S)\,C_{L+K-1}
+  \text{\path{extendInsert}}(W_0\subseteq S)\,C_0 \;=\;
+  \text{\path{extendInsert}}(W_{L+K-1}\subseteq S)\,C_{L+K-1}
   \qquad\text{as inserts on } S
 \]
 is \path{staircasePair_insert_eq_open}, with no $\mathrm{univ}\setminus S$
@@ -996,18 +996,18 @@ edge joining the two end windows, hence the only interior bond of $S$.
 
 The geometric peeling of this equality onto the bond $e$ rests on the complete
 characterization of the boundary $\partial S$. The landed direction
-($\path{isRegionBoundaryEdge\_endPair\_of\_leftWindow}$ and its right-window
+($\text{\path{isRegionBoundaryEdge\_endPair\_of\_leftWindow}}$ and its right-window
 counterpart) shows a boundary edge $f\neq e$ of one window is a boundary edge of
 $S$. The converse, supplying the partition, is
-$\path{isRegionBoundaryEdge\_window\_of\_endPair}$: a boundary edge of $S$ is a
+$\text{\path{isRegionBoundaryEdge\_window\_of\_endPair}}$: a boundary edge of $S$ is a
 boundary edge of one of the two windows, read off the in-region endpoint, whose
 out-of-region endpoint lies outside that window since it lies outside all of $S$.
 Combined with $e$'s interiority, this gives
-$\path{isRegionBoundaryEdge\_endPair\_iff}$: $f$ is a boundary edge of $S$ iff it
+$\text{\path{isRegionBoundaryEdge\_endPair\_iff}}$: $f$ is a boundary edge of $S$ iff it
 is a boundary edge of one window and $f\neq e$; and
-$\path{isRegionBoundaryEdge\_endPair\_exactlyOne\_window}$: each boundary edge of
+$\text{\path{isRegionBoundaryEdge\_endPair\_exactlyOne\_window}}$: each boundary edge of
 $S$ lies on \emph{exactly} one window, since the only edge on both windows is $e$
-($\path{eq\_referenceEdge\_of\_isRegionBoundaryEdge\_both\_endWindows}$), which is
+($\text{\path{eq\_referenceEdge\_of\_isRegionBoundaryEdge\_both\_endWindows}}$), which is
 not a boundary edge of $S$. So $\partial S$ is the disjoint union of the two
 windows' external legs, with $e$ the single interior bond summed over in the
 end-pair contraction. This is the geometric content the bond-$e$ coefficient
@@ -1024,56 +1024,56 @@ Step~3 (that $\mathrm{univ}\setminus S$ is not injective at the minimal size) do
 not propagate to either.
 
 \emph{The witness region.} The per-edge interface
-$\path{EdgeCoeffIdentityWitness}$ bundles a region whose boundary contains $e$,
+$\text{\path{EdgeCoeffIdentityWitness}}$ bundles a region whose boundary contains $e$,
 the second tensor's region and host blocked-tensor injectivity, and the
 conjugation coefficient identities on $e$. Its host field
-$\path{hCB}:\path{RegionBlockedTensorInjective}\,B\,(\mathrm{univ}\setminus
-\path{region})$ is host injectivity of the \emph{witness} region, not of $S$. The
-rectangle route takes $\path{region}$ to be the reference rectangle's red block,
+$\text{\path{hCB}}:\text{\path{RegionBlockedTensorInjective}}\,B\,(\mathrm{univ}\setminus
+\text{\path{region}})$ is host injectivity of the \emph{witness} region, not of $S$. The
+rectangle route takes $\text{\path{region}}$ to be the reference rectangle's red block,
 host injective only at the three-block sizes ($\geq 7$, or the seam-touching
-$+5=\mathrm{width}$ special case). At the window route, $\path{region}$ may be a
+$+5=\mathrm{width}$ special case). At the window route, $\text{\path{region}}$ may be a
 single end window $W$: $e$ is a boundary edge of each end window
-($\path{isRegionBoundaryEdge\_horizontalStaircaseLeftWindow\_referenceEdge}$ and
+($\text{\path{isRegionBoundaryEdge\_horizontalStaircaseLeftWindow\_referenceEdge}}$ and
 its right counterpart), $W$ is region injective
-($\path{horizontalStaircaseLeftWindow\_injective}$), and crucially its host
+($\text{\path{horizontalStaircaseLeftWindow\_injective}}$), and crucially its host
 $\mathrm{univ}\setminus W$ \emph{is} injective at $(2L+1)\times(2K+1)$ --- this is
-the landed $\path{regionBlockedTensorInjective\_windowComplement}$, whose
+the landed $\text{\path{regionBlockedTensorInjective\_windowComplement}}$, whose
 complement decomposition (a full-height band of $\mathrm{width}-L\geq L+1$ columns
 and an $L$-column band of $\mathrm{height}-K\geq K+1$ rows, each an $L\times K$
 window union) needs exactly $2L+1\leq\mathrm{width}$, $2K+1\leq\mathrm{height}$.
-So a single window is a valid $\path{EdgeCoeffIdentityWitness}$ region with host
+So a single window is a valid $\text{\path{EdgeCoeffIdentityWitness}}$ region with host
 injectivity available at the minimal size, once the peeling of \S5.1 produces the
-bond-$e$ coefficient identity $\path{regionInsertedCoeff}\,A\,W\,\langle
-e\rangle\,M = \path{regionInsertedCoeff}\,B\,W\,\langle e\rangle\,(Z\,M\,Z^{-1})$
+bond-$e$ coefficient identity $\text{\path{regionInsertedCoeff}}\,A\,W\,\langle
+e\rangle\,M = \text{\path{regionInsertedCoeff}}\,B\,W\,\langle e\rangle\,(Z\,M\,Z^{-1})$
 with $W$ in place of the rectangle red block.
 
 \emph{The comparison regions.} The scalar extraction
-$\path{lambda\_pow\_card\_torus\_eq\_one}$ takes a single comparison region $R$
+$\text{\path{lambda\_pow\_card\_torus\_eq\_one}}$ takes a single comparison region $R$
 with $R$ and $\mathrm{univ}\setminus R$ injective; the per-vertex relation
-$\path{component\_eq\_gaugeVertex\_of\_cornerProportional}$ compares $R$ against
-$\path{insert}\,v\,R$, needing both regions' hosts injective. The formalized $R$
-is $\path{cornerRegion}$ (the $3\times3$ square minus its corner) and
-$\path{insert}\,v\,R = \path{cornerSquare}$ (the $3\times3$ square), at offset
+$\text{\path{component\_eq\_gaugeVertex\_of\_cornerProportional}}$ compares $R$ against
+$\text{\path{insert}}\,v\,R$, needing both regions' hosts injective. The formalized $R$
+is $\text{\path{cornerRegion}}$ (the $3\times3$ square minus its corner) and
+$\text{\path{insert}}\,v\,R = \text{\path{cornerSquare}}$ (the $3\times3$ square), at offset
 $(2,2)$ with hardcoded $7\leq\mathrm{width}$, $7\leq\mathrm{height}$; their host
-decompositions ($\path{compl\_cornerRegion\_injective}$,
-$\path{compl\_cornerSquare\_injective}$) use both rectangle orientations
-($\path{rect23}$, $\path{rect32}$, $\path{wideRectangle}$, $\path{shortRectangle}$)
+decompositions ($\text{\path{compl\_cornerRegion\_injective}}$,
+$\text{\path{compl\_cornerSquare\_injective}}$) use both rectangle orientations
+($\text{\path{rect23}}$, $\text{\path{rect32}}$, $\text{\path{wideRectangle}}$, $\text{\path{shortRectangle}}$)
 and width-$2$/width-$(\mathrm{width}-5)$ bands tied to the $3\times3$ shape. These
 are the $L=K=2$ instance of the source's $(L+1)\times(K+1)$ comparison pair. The
 one-orientation replacement, as Step~5 of this note prescribes, is the
 $(L+1)\times(K+1)$ cyclic rectangle minus one corner vertex against the full
 $(L+1)\times(K+1)$ rectangle. Both are region injective with one orientation by
-$\path{arcRectangle\_injective}$ (a cyclic rectangle of width $\geq L$, height
+$\text{\path{arcRectangle\_injective}}$ (a cyclic rectangle of width $\geq L$, height
 $\geq K$ is the union of the $L\times K$ windows sliding over it). Both hosts
-decompose at the minimal size: by $\path{compl\_torusArcRectangle}$ the complement
+decompose at the minimal size: by $\text{\path{compl\_torusArcRectangle}}$ the complement
 of a $(L+1)\times(K+1)$ cyclic rectangle is a full-height band of
 $\mathrm{width}-(L+1)\geq L$ columns and an $(L+1)$-column band of
 $\mathrm{height}-(K+1)\geq K$ rows, each injective by
-$\path{arcRectangle\_injective}$; the band widths reach exactly $L$ and the
+$\text{\path{arcRectangle\_injective}}$; the band widths reach exactly $L$ and the
 heights exactly $K$ at $2L+1$, $2K+1$, which is why the corollary needs no larger
 size. The minus-corner region differs by one vertex and decomposes the same way
 with one extra corner rectangle, the transpose of the formalized
-$\path{cornerRegion}$ band decomposition.
+$\text{\path{cornerRegion}}$ band decomposition.
 
 \emph{Verdict.} The back half transfers to the corollary's minimal size with the
 window as witness region and the $(L+1)\times(K+1)$-shaped comparison pair, both
@@ -1085,7 +1085,7 @@ capstone is therefore an \emph{assembly} of landed machinery --- the peeling of
 \S5.1 to the bond-$e$ coefficient identity (the one genuinely-new mechanical
 piece, whose geometric foundation is now landed), the window-region witness with
 its already-available host injectivity, and the re-anchored comparison pair built
-from $\path{arcRectangle\_injective}$ and $\path{compl\_torusArcRectangle}$ ---
+from $\text{\path{arcRectangle\_injective}}$ and $\text{\path{compl\_torusArcRectangle}}$ ---
 not further research. A host-free variant of the back-half engines is \emph{not}
 needed.
 
@@ -1094,21 +1094,21 @@ needed.
 The peeling of \S5.1 onto the single bond $e$ rests on a bridge between the two
 vocabularies the back half mixes: the \emph{deformed-window} inserts the
 overlapping-window staircase produces, and the \emph{region-inserted coefficient}
-$\path{regionInsertedCoeff}$ the per-edge gauge of Step~5 reads.  These were two
+$\text{\path{regionInsertedCoeff}}$ the per-edge gauge of Step~5 reads.  These were two
 parallel developments with no connecting lemma.  The bridge is now in
 \path{TNLean/PEPS/TorusWindowPeel2.lean}.
 
-The bond-inserted insert $\path{bondInsertedRegionInsert}\,A\,R\,f\,M$ on a region
+The bond-inserted insert $\text{\path{bondInsertedRegionInsert}}\,A\,R\,f\,M$ on a region
 $R$ is the insert whose boundary configuration $\nu$ (read by the complement
 contraction) carries the $M$-coupled combination of the genuine $R$ block over the
 boundary configurations agreeing with $\nu$ away from $f$.  Its deformed state is
 exactly the region-inserted coefficient:
-$\path{deformedRegionState\_bondInsertedRegionInsert}$ proves
-$\path{deformedRegionState}\,A\,R\,(\path{bondInsertedRegionInsert}\,A\,R\,f\,M) =
-\path{regionInsertedCoeff}\,A\,R\,f\,M$, the inner boundary sum of the insert
+$\text{\path{deformedRegionState\_bondInsertedRegionInsert}}$ proves
+$\text{\path{deformedRegionState}}\,A\,R\,(\text{\path{bondInsertedRegionInsert}}\,A\,R\,f\,M) =
+\text{\path{regionInsertedCoeff}}\,A\,R\,f\,M$, the inner boundary sum of the insert
 reproducing the double boundary sum of the coefficient.  Composing with the
-corner-extension identity $\path{deformedRegionState\_extend}$ gives
-$\path{regionInsertedCoeff\_eq\_extendInsert\_bondInserted}$: the coefficient on $R$,
+corner-extension identity $\text{\path{deformedRegionState\_extend}}$ gives
+$\text{\path{regionInsertedCoeff\_eq\_extendInsert\_bondInserted}}$: the coefficient on $R$,
 read off a global configuration, equals the assembled deformed state on a superset
 $S$ of the corner-extended bond-inserted insert.  With $R$ an end window and $S$ the
 end pair, the genuine block of the \emph{opposite} window the bond $e$ joins to is
@@ -1118,41 +1118,41 @@ describes, now realized through the landed corner extension rather than a bespok
 contraction split.
 
 The single-bond peeling itself is
-$\path{regionInsertedCoeff\_endWindows\_eq\_of\_staircase}$ in
+$\text{\path{regionInsertedCoeff\_endWindows\_eq\_of\_staircase}}$ in
 \path{TNLean/PEPS/TorusWindowPeel3.lean}.  Feeding the end-pair equality
-$\path{staircasePair\_insert\_eq\_open}$ the bond-inserted inserts on the two end
+$\text{\path{staircasePair\_insert\_eq\_open}}$ the bond-inserted inserts on the two end
 windows (and arbitrary inserts on the intermediate windows), all sharing one deformed
 state, and bridging both sides through
-$\path{regionInsertedCoeff\_eq\_extendInsert\_bondInserted}$, peels the equality onto
+$\text{\path{regionInsertedCoeff\_eq\_extendInsert\_bondInserted}}$, peels the equality onto
 $e$: the two end windows' region-inserted coefficients with $M$ and $M'$ on $e$ agree,
 read off any global configuration.  The reference edge is a boundary edge of each end
 window by the landed single-crossing geometry
-($\path{isRegionBoundaryEdge\_staircaseWindow\_zero\_referenceEdge}$ and its last-window
+($\text{\path{isRegionBoundaryEdge\_staircaseWindow\_zero\_referenceEdge}}$ and its last-window
 counterpart), so $M$ and $M'$ live on the same bond.
 
 The window-region witness packaging of \S5.2 is
-$\path{windowEdgeCoeffIdentityWitness}$ (and its hypotheses form
-$\path{windowEdgeCoeffIdentityWitness\_of\_hypotheses}$) in
+$\text{\path{windowEdgeCoeffIdentityWitness}}$ (and its hypotheses form
+$\text{\path{windowEdgeCoeffIdentityWitness\_of\_hypotheses}}$) in
 \path{TNLean/PEPS/TorusWindowWitness.lean}: given the bond-$e$ conjugation coefficient
-identity, every other $\path{EdgeCoeffIdentityWitness}$ field with the left end window
+identity, every other $\text{\path{EdgeCoeffIdentityWitness}}$ field with the left end window
 as region is discharged from the landed window geometry, the host injectivity supplied
-at the minimal size by $\path{regionBlockedTensorInjective\_windowComplement}$.  The
+at the minimal size by $\text{\path{regionBlockedTensorInjective\_windowComplement}}$.  The
 witness is the reference-edge interface the torus covariant-family machinery consumes.
 
 \medskip
 \noindent\textbf{The residual.}  What remains of \S5.1 is the production of the
 bond-$e$ \emph{conjugation} coefficient identity the witness packaging consumes ---
-$\path{regionInsertedCoeff}\,A\,W\,\langle e\rangle\,M =
-\path{regionInsertedCoeff}\,B\,W\,\langle e\rangle\,(Z\,M\,Z^{-1})$.  The Skolem--Noether
+$\text{\path{regionInsertedCoeff}}\,A\,W\,\langle e\rangle\,M =
+\text{\path{regionInsertedCoeff}}\,B\,W\,\langle e\rangle\,(Z\,M\,Z^{-1})$.  The Skolem--Noether
 back end of this production is now landed and reduces it to a single cross-tensor input.
-The reusable region-level algebra of $\path{RegionInsertionTransfer}$ derives the gauge
+The reusable region-level algebra of $\text{\path{RegionInsertionTransfer}}$ derives the gauge
 $Z$ and the conjugation form of the coefficient identity from a \emph{coefficient
-transfer} on the window: the read-off $\path{exists\_regionEdgeGauge\_of\_coeffTransfer}$
+transfer} on the window: the read-off $\text{\path{exists\_regionEdgeGauge\_of\_coeffTransfer}}$
 turns the two cross-tensor coefficient transfers and the forward-transfer multiplicativity
 into $Z$ and the conjugation identity (the lemma
-$\path{exists\_regionConjCoeffIdentity\_of\_coeffTransfer}$), and feeding that to the
+$\text{\path{exists\_regionConjCoeffIdentity\_of\_coeffTransfer}}$), and feeding that to the
 window-region witness packaging discharges the witness's conjugation field (the lemma
-$\path{exists\_windowEdgeCoeffIdentityWitness\_of\_coeffTransfer}$).  These are in
+$\text{\path{exists\_windowEdgeCoeffIdentityWitness\_of\_coeffTransfer}}$).  These are in
 \path{TNLean/PEPS/TorusWindowMult.lean}.  All region-level algebra --- additivity,
 homogeneity, identity preservation, the two-sided inverse, the Skolem--Noether read-off
 --- is unconditional on the window and host injectivity, both available at the minimal
@@ -1162,8 +1162,8 @@ conjugation field assumed.
 What remains is therefore exactly the staircase \emph{coefficient transfer} on the
 window: for each inserted matrix $M$ on $A$'s edge $e$ a matching matrix $N$ on $B$ with
 equal window coefficient
-($\path{htransferAB}$), its reverse ($\path{htransferBA}$), and the multiplicativity of
-the chosen forward transfer ($\path{hmul}$).  Two pieces feed the transfer.  First, the
+($\text{\path{htransferAB}}$), its reverse ($\text{\path{htransferBA}}$), and the multiplicativity of
+the chosen forward transfer ($\text{\path{hmul}}$).  Two pieces feed the transfer.  First, the
 bond-inserted \emph{family} the single-bond peeling consumes: an insert on every
 staircase window all sharing one deformed state, with the two end windows carrying the
 bond-inserted inserts of $M$ and $M'$.  For the windows containing both endpoints of $e$
@@ -1173,14 +1173,14 @@ genuine block, and the common state is the closed torus state with $M$ inserted 
 containing an endpoint'' correspondence of the sketch, not yet built as an insert family.
 Second, the cross-tensor multiplicative transfer: the homomorphism the rectangle route
 reads from the physical realization of the inserted operator.  The region-level recovery
-$\path{regionInsertionTransfer\_of\_realizes}$ derives all three transfer fields ---
-$\path{htransferAB}$, $\path{htransferBA}$, and $\path{hmul}$ --- from one region
-physical-to-virtual realization $\path{RegionTransferRealizes}$ in each direction, with
+$\text{\path{regionInsertionTransfer\_of\_realizes}}$ derives all three transfer fields ---
+$\text{\path{htransferAB}}$, $\text{\path{htransferBA}}$, and $\text{\path{hmul}}$ --- from one region
+physical-to-virtual realization $\text{\path{RegionTransferRealizes}}$ in each direction, with
 no further hypothesis; so the window route's residual collapses to producing that
 realization on the window from the staircase, in place of the edge-middle injectivity
 ($\mathrm{univ}\setminus\{u,v\}$ injective) the rectangle route uses, which fails at the
 minimal size --- the same obstruction, at the edge, that $\mathrm{univ}\setminus S$
-exhibits at the end pair.  A coefficient transfer alone does not yield $\path{hmul}$: the
+exhibits at the end pair.  A coefficient transfer alone does not yield $\text{\path{hmul}}$: the
 multiplicativity is the homomorphism of the physical insertion operator, which the
 single-bond geometry localizes to one edge but does not on its own make multiplicative.
 
@@ -1189,19 +1189,19 @@ super-bond, not a single-window span}
 
 This section records the definitive resolution of the one residual question the
 overlapping-window corollary reduces to: whether the forward-transfer
-multiplicativity $\path{hmul}$ at the left end window is obtainable from window and
+multiplicativity $\text{\path{hmul}}$ at the left end window is obtainable from window and
 host injectivity at the corollary's minimal size, or genuinely needs a block-level
 construction the landed single-window machinery does not provide.
 
 \subsection{The single-window span does not exist, and is not the mechanism}
 
-The natural reading of $\path{hmul}$ as a single-window fact is the question whether
+The natural reading of $\text{\path{hmul}}$ as a single-window fact is the question whether
 the reference-edge-restricted matrix family of the left end window $W$ --- the bond
 matrix on $e$ read off the window block at fixed external legs and physical
 configuration --- spans the full $\mathrm{Fin}(\mathrm{bondDim}\,e)$ algebra, the way
 a one-dimensional length-$L$ window product spans the full $D\times D$ algebra and
-feeds the homomorphism extraction $\path{exists\_insertionHom}$ through
-$\path{LinearMap.ext\_on\_range}$. It does not. A one-dimensional window has exactly
+feeds the homomorphism extraction $\text{\path{exists\_insertionHom}}$ through
+$\text{\path{LinearMap.ext\_on\_range}}$. It does not. A one-dimensional window has exactly
 two virtual legs, both of dimension $D$, so its product \emph{is} a square matrix on
 the bond and window injectivity is bond-algebra spanning directly. A two-dimensional
 $L\times K$ end window touches $e$ with \emph{one} endpoint, so its $e$-restricted
@@ -1218,7 +1218,7 @@ single-window analogue, and the homomorphism cannot be read from one window's bl
 single-vertex injectivity, but obstructed for the single-window red block at the
 minimal size}
 
-The source supplies $\path{hmul}$ not from a single window but from the homomorphism
+The source supplies $\text{\path{hmul}}$ not from a single window but from the homomorphism
 of the physical insertion operator, which the formalization realizes through the
 \emph{coarse three-site} route already landed for the rectangle blocking: three
 blocked regions (a red block, a blue block meeting it only at $e$, and the
@@ -1226,11 +1226,11 @@ complement) are assembled into a coarse tensor on a three-vertex graph, whose th
 super-sites are injective directly from the three blocked-region injectivities, with
 no single-vertex injectivity of the original tensor. The coarse tensor is
 edge-blocked three-site injective at the distinguished super-bond, so the
-single-vertex transfer-matrix multiplicativity $\path{edgeTransferMatrix\_mul}$
+single-vertex transfer-matrix multiplicativity $\text{\path{edgeTransferMatrix\_mul}}$
 applies \emph{at the super-bond}; conjugated by the two bond models this is
-$\path{regionEdgeTransfer\_mul}$, and through the identification of the chosen forward
-transfer with the concrete one ($\path{coeffTransferMap\_eq\_regionEdgeTransfer}$, by
-$\path{regionInsertedCoeff\_injective}$) it is exactly $\path{hmul}$ for the chosen
+$\text{\path{regionEdgeTransfer\_mul}}$, and through the identification of the chosen forward
+transfer with the concrete one ($\text{\path{coeffTransferMap\_eq\_regionEdgeTransfer}}$, by
+$\text{\path{regionInsertedCoeff\_injective}}$) it is exactly $\text{\path{hmul}}$ for the chosen
 transfer over the red block. The super-vertex injectivity stands in for the
 single-vertex spanning the vertex-injective route would use; this is why the route
 needs only blocked-region injectivity of the three regions.
@@ -1240,13 +1240,13 @@ coarse red block, which requires a blue block making $e$ the single red-to-blue
 crossing and a complement $\mathrm{univ}\setminus(W\cup\mathrm{blue})$ injective. The
 single-crossing requirement is met canonically: the right end window $W'$ is the only
 block joined to $W$ by exactly the reference edge $e$
-($\path{isCrossingEdge\_horizontalStaircaseEndWindows}$). But that forces
+($\text{\path{isCrossingEdge\_horizontalStaircaseEndWindows}}$). But that forces
 $W\cup\mathrm{blue} = W\cup W' = S$, the staircase end pair, so the complement is
 $\mathrm{univ}\setminus S$ --- the very region Step~3 proves is \emph{not} injective
 at the corollary's minimal size, because $S$ occupies all columns of one row and the
 complement band there has width below $L$. So the coarse three-site frame with
 $\mathrm{red}=W$ and the natural single-crossing partner is unbuildable at the minimal
-size: its $\path{complement\_injective}$ field is exactly the obstructed
+size: its $\text{\path{complement\_injective}}$ field is exactly the obstructed
 $\mathrm{univ}\setminus S$ injectivity, the same obstruction the open-boundary
 staircase route was built to circumvent at the \emph{state-equality} level, now
 reappearing at the \emph{multiplicativity} level. Enlarging the blue block beyond
@@ -1265,7 +1265,7 @@ It is the coarse three-site super-bond multiplicativity, which needs a third inj
 block --- the complement of the red-blue pair --- and at the minimal size, with the
 red block a single window and the single-crossing partner forced to be the opposite
 window, that complement is $\mathrm{univ}\setminus S$, non-injective. The read-off
-side ($\path{htransferAB}$, $\path{htransferBA}$, and the whole region-level gauge
+side ($\text{\path{htransferAB}}$, $\text{\path{htransferBA}}$, and the whole region-level gauge
 algebra) \emph{is} powered by window and single-window-complement injectivity, both
 available at the minimal size; only the homomorphism is not.
 
@@ -1278,7 +1278,7 @@ insertion operator and no single-window read-off makes it one. The source's sket
 overlapping-window realization is that the same virtual operation $M$ on $e$ is a
 physical operation on \emph{every} window of the staircase chain, all sharing one
 deformed state; the chain of consecutive-window inversions (landed at the
-state-equality level as $\path{staircasePair\_insert\_eq\_open}$, never inverting
+state-equality level as $\text{\path{staircasePair\_insert\_eq\_open}}$, never inverting
 $\mathrm{univ}\setminus S$) transports $M$ around the corner, and the homomorphism
 $M\cdot M' \mapsto$ (transfer of $M$)\,(transfer of $M'$) is read from the composition
 of two such transports across the chain, not from any one window's block. Building
@@ -1294,13 +1294,13 @@ The reusable multiplicativity is exposed as
 (\path{TNLean/PEPS/RegionBlock/CoarseThreeSiteMul.lean}): two coherent coarse blocking
 frames over the two tensors sharing the three regions, the bond dimensions, and the
 single-crossing edge make the chosen forward transfer over the red block
-multiplicative, with no single-vertex injectivity. This is the $\path{hmul}$ field
+multiplicative, with no single-vertex injectivity. This is the $\text{\path{hmul}}$ field
 extracted from the bundled gauge assembly
 \leanid{TNLean.PEPS.exists\_regionEdgeGauge\_of\_coherentFrames}, so a consumer holding
 only the coefficient transfer can obtain the multiplicativity from a frame. It makes
-the verdict auditable in Lean: the window route's $\path{hmul}$ is one application of
+the verdict auditable in Lean: the window route's $\text{\path{hmul}}$ is one application of
 this theorem with $\mathrm{red}=W$, and the unmet hypothesis is exactly the frame's
-$\path{complement\_injective}$ at $\mathrm{univ}\setminus S$, the documented
+$\text{\path{complement\_injective}}$ at $\mathrm{univ}\setminus S$, the documented
 obstruction. The remaining work is the insert-family transport that produces a
 multiplicative window coefficient transfer without a single-window red-block frame.
 
@@ -1330,7 +1330,7 @@ Two facts pin where the chain composition stops short of the multiplicativity. F
 \leanid{TNLean.PEPS.staircasePatch\_insert\_eq} already composes per-step equalities into
 one comparison of the two end windows on the patch, and the end-pair peeling
 \leanid{TNLean.PEPS.regionInsertedCoeff\_endWindows\_eq\_of\_staircase} reads that off as the
-single-tensor relation $\path{regionInsertedCoeff}(W_0, M) = \path{regionInsertedCoeff}
+single-tensor relation $\text{\path{regionInsertedCoeff}}(W_0, M) = \text{\path{regionInsertedCoeff}}
 (W_{L+K-1}, M')$. So the chain composition delivers the \emph{single-operation}
 window-independence, end to end, with the injective overlaps mediating.
 
@@ -1381,7 +1381,7 @@ spanning \leanid{TNLean.PEPS.span\_stateOpenCoeff\_eq\_top} --- available from
 peeling fires and the homomorphism $M \cdot M' \mapsto (\text{transfer of } M)\,(\text{transfer
 of } M')$ would be read from composing two transports as in
 \leanid{MPSChainTensor.exists\_insertionHom}, whose multiplicativity step
-($\path{eq\_of\_span\_mul\_left}$) consumes the same window-product span. The per-step transport
+($\text{\path{eq\_of\_span\_mul\_left}}$) consumes the same window-product span. The per-step transport
 and the now-uniform rescaling are the foundation of that extraction; the extraction itself ---
 the deformed-window-tensor family on the intermediate windows, requiring the endpoint span ---
 is the unbuilt block-level construction, and it is the same endpoint-spanning residual the


### PR DESCRIPTION
## Summary

The paper-gaps build (`scripts/build-paper-gaps.sh`, exercised by the weekly docs workflow rather than PR CI) has been failing since several notes accumulated LaTeX-level breakage. This PR restores a clean sweep over all 66 notes.

Two fixes:

1. **`docs/paper-gaps/peps_normal_ft_2d_overlap.tex`** — the note used `\path{...}` inside math mode in 110 places. The `url`/`xurl` implementation of `\path` cannot start inside math mode (it enters math internally), so the first such use aborted the build with "Command \$ invalid in math mode". Each math-mode occurrence is now wrapped as `\text{\path{...}}`, which restores text mode locally and preserves the existing verbatim rendering of Lean identifiers. No wording changes.

2. **`docs/paper-gaps/command.tex`** — five notes (`rmp_w_state_ti_bound`, `wolf_ch5_operator_jensen_lieb`, `wolf_prop28_square_case`, `wolf_reduction_criterion_schmidt_premise`, `wolf_t_eta_top_index_scope`) use Dirac and matrix-algebra shorthands (`\ket`, `\bra`, `\ketbra`, `\Id`, `\one`, `\C`, `\MN`, `\MD`) that exist in the blueprint macro set but were never defined for the standalone paper-gap preamble. The shared preamble now provides them via `\providecommand` (so any note-local definition stays authoritative), with `\mathds{1}` for the identity so the glyph actually renders in PDF (`amssymb`'s `\mathbb` has no digits).

## Verification

- `bash scripts/build-paper-gaps.sh`: all 66 notes compile, exit 0 (previously failed at `peps_normal_ft_2d_overlap.tex`).
- The five macro-dependent notes were additionally rebuilt individually.
- `git diff --check` clean; generated PDFs remain gitignored.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only LaTeX preamble and formatting fixes; no application code, auth, or data paths change.
> 
> **Overview**
> Restores a clean compile of all **paper-gaps** notes (66 total) after LaTeX failures that blocked `scripts/build-paper-gaps.sh` and the weekly docs workflow.
> 
> In **`peps_normal_ft_2d_overlap.tex`**, every Lean identifier that used `\path{...}` **inside math mode** is now `\text{\path{...}}`, so `url`/`xurl` no longer trip “Command \$ invalid in math mode” and the note can finish building. Wording is unchanged.
> 
> In **`command.tex`**, the shared preamble now loads **`dsfont`** and defines blueprint-aligned shorthands (`\ket`, `\bra`, `\ketbra`, `\Id`, `\one`, `\C`, `\MN`, `\MD`) via `\providecommand`, so five notes that relied on those macros compile without duplicating definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab20a7dda0e591ac2750ad2a09032435a3f6acbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->