### PR TITLE
doc(README+home_page): link companion paper arXiv:2607.07857

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,12 @@ declaration in the Lean source.
 The agent-driven workflow used to build this library is described in the
 companion paper: S. Lu, E. Tjoa, J. I. Cirac, *Multi-agent Autoformalization
 of Tensor Network Theory*,
-[arXiv:2607.07857](https://arxiv.org/abs/2607.07857).
+[arXiv:2607.07857](https://arxiv.org/abs/2607.07857). Part of the
+formalization effort and this repository's CI ran through
+[TeXRA](https://texra.ai) ([github.com/texra-ai](https://github.com/texra-ai)),
+whose [`lean-env-action`](https://github.com/texra-ai/lean-env-action) sets
+up the Lean and blueprint toolchain used in the workflows under
+`.github/workflows/`.
 
 The library loads as a single import (Lean 4 / Mathlib `v4.31.0`):
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ the fundamental-theorem part that is being released first. The generated
 [API documentation](https://lionsr.github.io/TNLean/docs/) covers every
 declaration in the Lean source.
 
+The agent-driven workflow used to build this library is described in the
+companion paper: S. Lu, E. Tjoa, J. I. Cirac, *Multi-agent Autoformalization
+of Tensor Network Theory*,
+[arXiv:2607.07857](https://arxiv.org/abs/2607.07857).
+
 The library loads as a single import (Lean 4 / Mathlib `v4.31.0`):
 
 ```lean

--- a/README.md
+++ b/README.md
@@ -45,12 +45,10 @@ declaration in the Lean source.
 The agent-driven workflow used to build this library is described in the
 companion paper: S. Lu, E. Tjoa, J. I. Cirac, *Multi-agent Autoformalization
 of Tensor Network Theory*,
-[arXiv:2607.07857](https://arxiv.org/abs/2607.07857). Part of the
-formalization effort and this repository's CI ran through
-[TeXRA](https://texra.ai) ([github.com/texra-ai](https://github.com/texra-ai)),
-whose [`lean-env-action`](https://github.com/texra-ai/lean-env-action) sets
-up the Lean and blueprint toolchain used in the workflows under
-`.github/workflows/`.
+[arXiv:2607.07857](https://arxiv.org/abs/2607.07857). Most of the
+formalization was carried out by agents running on
+[TeXRA](https://texra.ai), whose `lean-env-action` also sets up the Lean and
+blueprint toolchain used in the workflows under `.github/workflows/`.
 
 The library loads as a single import (Lean 4 / Mathlib `v4.31.0`):
 

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -25,7 +25,6 @@ at varying levels of completeness.
 S. Lu, E. Tjoa, J. I. Cirac, *Multi-agent Autoformalization of Tensor Network
 Theory*, [arXiv:2607.07857](https://arxiv.org/abs/2607.07857).
 
-Part of the formalization effort and its CI ran through
-[TeXRA](https://texra.ai) ([github.com/texra-ai](https://github.com/texra-ai)),
-whose [`lean-env-action`](https://github.com/texra-ai/lean-env-action) sets up
-the Lean and blueprint toolchain used throughout this repository's workflows.
+Most of the formalization was carried out by agents running on
+[TeXRA](https://texra.ai), whose `lean-env-action` also sets up the Lean and
+blueprint toolchain used throughout this repository's CI workflows.

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -24,3 +24,8 @@ at varying levels of completeness.
 
 S. Lu, E. Tjoa, J. I. Cirac, *Multi-agent Autoformalization of Tensor Network
 Theory*, [arXiv:2607.07857](https://arxiv.org/abs/2607.07857).
+
+Part of the formalization effort and its CI ran through
+[TeXRA](https://texra.ai) ([github.com/texra-ai](https://github.com/texra-ai)),
+whose [`lean-env-action`](https://github.com/texra-ai/lean-env-action) sets up
+the Lean and blueprint toolchain used throughout this repository's workflows.

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -22,6 +22,5 @@ at varying levels of completeness.
 
 ## Companion Paper
 
-The companion paper "Multi-agent Autoformalization of Tensor Network Theory" is
-in preparation. A bibliographic citation and public link will be added here once
-the paper is available.
+S. Lu, E. Tjoa, J. I. Cirac, *Multi-agent Autoformalization of Tensor Network
+Theory*, [arXiv:2607.07857](https://arxiv.org/abs/2607.07857).


### PR DESCRIPTION
### Motivation

- The companion paper "Multi-agent Autoformalization of Tensor Network Theory" (S. Lu, E. Tjoa, J. I. Cirac, arXiv:2607.07857) is now publicly available; the "in preparation" placeholder on the blueprint home page and in the README are out of date.

### Description

- `home_page/index.md`: replaces the three-line "in preparation" notice under **Companion Paper** with the full bibliographic citation and arXiv link (arXiv:2607.07857).
- `README.md`: adds a short paragraph directing readers to the companion paper with the full citation and link.

### Testing

- Documentation-only change; no Lean code, build, or runtime behaviour is affected.
- Relies on Lean CI (`lean_action_ci.yml`) to validate build.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to README and home page; no Lean code or runtime behavior changes.
> 
> **Overview**
> Updates public docs now that the companion paper is on arXiv, replacing stale “in preparation” messaging.
> 
> **`home_page/index.md`** — The **Companion Paper** section now lists the full citation and [arXiv:2607.07857](https://arxiv.org/abs/2607.07857), and briefly notes TeXRA agents and `lean-env-action` for CI toolchain setup.
> 
> **`README.md`** — Adds a paragraph with the same citation/link and the TeXRA / `.github/workflows/` context for how the library was built.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24d1ee8959faa1d35668ed2e12fa41ffd7bbd4b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->