### PR TITLE
feat(MPS/MPDO): prove inverse-map contraction

### DIFF
--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -24,7 +24,7 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   inverse tensor `K⁻¹` and its matrix-unit contraction identity.
 - `MPOTensor.inverseMapThreeSiteContraction` /
   `MPOTensor.inverseMapThreeSiteContraction_eq`: the double inverse-map
-  contraction used in the proof of Lemma C.4.
+  contraction at lines 1415--1438 of Appendix C.2 in arXiv:1606.00608.
 - `MPOTensor.physRealize` / `MPOTensor.physRealize_spec` /
   `MPOTensor.physRealize_mul`: the physical realization of right virtual
   insertions and its multiplicativity.
@@ -81,9 +81,9 @@ operators have the generally nonconstant primitive trace matrix whose kh-entry
 is the trace of ηₖₕ. Consequently these two families cannot simply be
 identified.
 
-The raw double inverse-map contraction in the proof of Lemma propSN is
-`MPOTensor.inverseMapThreeSiteContraction_eq`. The earliest missing connection
-to Appendix C.2 is the comparison of that contraction with the conjugated,
+The raw double inverse-map contraction (arXiv:1606.00608, Appendix C.2,
+lines 1415--1438) is `MPOTensor.inverseMapThreeSiteContraction_eq`. The earliest
+missing connection is the comparison of that contraction with the conjugated,
 reindexed Hayashi decomposition. This comparison must produce a sector
 factorization of the concrete tensor `K` satisfying, for every `N`,
 \[
@@ -169,10 +169,10 @@ third sites of a three-site MPO word.
 
 Here `R` is the virtual matrix obtained by contracting the remaining sites.
 With $X_{\alpha,\beta}$ denoting the corresponding component of
-${\cal K}^{-1}$, this is the left-hand side of the calculation following
-Equation Qketc in the proof of Lemma propSN.
+${\cal K}^{-1}$, this is the left-hand side of the double-sum contraction
+identity at lines 1415--1438 of arXiv:1606.00608.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma propSN, lines 1415--1438. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1415--1438. -/
 noncomputable def inverseMapThreeSiteContraction
     (K : MPOTensor d D) (hK : K.IsInjective)
     (R : Matrix (Fin D) (Fin D) ℂ)
@@ -192,16 +192,16 @@ middle tensor and the complementary entry of the virtual tail:
   = {\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}.
 \]
 
-This is the inverse-map calculation immediately before Equation formK in
-the proof of Lemma propSN.
+This is the contraction-collapse step at lines 1422--1438 of arXiv:1606.00608,
+immediately before the sector-factorization equation.
 
-**Local fix (tail index):** the source display following Equation Qketc
+**Local fix (tail index):** the source display at lines 1422--1438
 writes $m_{\beta_3,\alpha_3}$. Direct contraction of the two matrix units
 gives $m_{\beta_3,\alpha_1}$, as shown by the formula above. The correction
 is recorded in
 `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
 
-Source: arXiv:1606.00608, Appendix C.2, Lemma propSN, lines 1422--1438. -/
+Source: arXiv:1606.00608, Appendix C.2, lines 1422--1438. -/
 theorem inverseMapThreeSiteContraction_eq
     (K : MPOTensor d D) (hK : K.IsInjective)
     (R : Matrix (Fin D) (Fin D) ℂ)

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -22,6 +22,9 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   doubled-index MPS tensor.
 - `MPOTensor.inverseTensor` / `MPOTensor.inverseTensor_spec`: the concrete
   inverse tensor `K⁻¹` and its matrix-unit contraction identity.
+- `MPOTensor.inverseMapThreeSiteContraction` /
+  `MPOTensor.inverseMapThreeSiteContraction_eq`: the double inverse-map
+  contraction used in the proof of Lemma C.4.
 - `MPOTensor.physRealize` / `MPOTensor.physRealize_spec` /
   `MPOTensor.physRealize_mul`: the physical realization of right virtual
   insertions and its multiplicativity.
@@ -78,9 +81,11 @@ operators have the generally nonconstant primitive trace matrix whose kh-entry
 is the trace of ηₖₕ. Consequently these two families cannot simply be
 identified.
 
-The earliest missing connection to Appendix C.2 is the conclusion of Lemma
-propSN: the inverse-map calculation must produce a sector factorization of the
-concrete tensor `K` satisfying, for every `N`,
+The raw double inverse-map contraction in the proof of Lemma propSN is
+`MPOTensor.inverseMapThreeSiteContraction_eq`. The earliest missing connection
+to Appendix C.2 is the comparison of that contraction with the conjugated,
+reindexed Hayashi decomposition. This comparison must produce a sector
+factorization of the concrete tensor `K` satisfying, for every `N`,
 \[
   \widetilde\sigma^{(N)}(K)
     = \bigoplus_{k_1,\ldots,k_N}\bigotimes_{n=1}^N \eta_{k_n,k_{n+1}}.
@@ -158,6 +163,73 @@ theorem inverseTensor_spec (K : MPOTensor d D) (hK : K.IsInjective)
         = Matrix.single α β (1 : ℂ)
   exact MPSTensor.decompositionMap_sum (A := K.toMPSTensor) hK
     (Matrix.single α β (1 : ℂ))
+
+/-- The contraction obtained by applying the inverse tensor to the first and
+third sites of a three-site MPO word.
+
+Here `R` is the virtual matrix obtained by contracting the remaining sites.
+With $X_{\alpha,\beta}$ denoting the corresponding component of
+${\cal K}^{-1}$, this is the left-hand side of the calculation following
+Equation Qketc in the proof of Lemma propSN.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma propSN, lines 1415--1438. -/
+noncomputable def inverseMapThreeSiteContraction
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ)
+    (α₁ β₁ α₃ β₃ : Fin D) (p₂ : Fin (d * d)) : ℂ :=
+  ∑ p₁ : Fin (d * d), ∑ p₃ : Fin (d * d),
+    inverseTensor K hK p₁ α₁ β₁ * inverseTensor K hK p₃ α₃ β₃ *
+      Matrix.trace
+        (K.toMPSTensor p₁ * K.toMPSTensor p₂ * K.toMPSTensor p₃ * R)
+
+/-- Applying ${\cal K}^{-1}$ to the two end sites leaves one entry of the
+middle tensor and the complementary entry of the virtual tail:
+
+\[
+  \sum_{p_1,p_3} ({\cal K}^{-1})^{\alpha_1,\beta_1}_{p_1}
+    ({\cal K}^{-1})^{\alpha_3,\beta_3}_{p_3}
+    \tr({\cal K}^{p_1}{\cal K}^{p_2}{\cal K}^{p_3}R)
+  = {\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}.
+\]
+
+This is the inverse-map calculation immediately before Equation formK in
+the proof of Lemma propSN.
+
+**Local fix (tail index):** the source display following Equation Qketc
+writes $m_{\beta_3,\alpha_3}$. Direct contraction of the two matrix units
+gives $m_{\beta_3,\alpha_1}$, as shown by the formula above. The correction
+is recorded in
+`docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemma propSN, lines 1422--1438. -/
+theorem inverseMapThreeSiteContraction_eq
+    (K : MPOTensor d D) (hK : K.IsInjective)
+    (R : Matrix (Fin D) (Fin D) ℂ)
+    (α₁ β₁ α₃ β₃ : Fin D) (p₂ : Fin (d * d)) :
+    inverseMapThreeSiteContraction K hK R α₁ β₁ α₃ β₃ p₂ =
+      K.toMPSTensor p₂ β₁ α₃ * R β₃ α₁ := by
+  classical
+  let a : Fin (d * d) → ℂ := fun p ↦ inverseTensor K hK p α₁ β₁
+  let b : Fin (d * d) → ℂ := fun p ↦ inverseTensor K hK p α₃ β₃
+  let C : Fin (d * d) → Matrix (Fin D) (Fin D) ℂ := K.toMPSTensor
+  change
+    (∑ p₁ : Fin (d * d), ∑ p₃ : Fin (d * d),
+      (a p₁ * b p₃) • Matrix.trace (C p₁ * C p₂ * C p₃ * R)) =
+        C p₂ β₁ α₃ * R β₃ α₁
+  simp_rw [← Matrix.trace_smul]
+  simp_rw [← Matrix.trace_sum Finset.univ]
+  have hmat :
+      (∑ i, ∑ j, (a i * b j) • (C i * C p₂ * C j * R)) =
+        (∑ i, a i • C i) * C p₂ * (∑ j, b j • C j) * R := by
+    simp only [Finset.sum_mul, Finset.mul_sum]
+    conv_rhs => rw [Finset.sum_comm]
+    simp [Matrix.mul_assoc, smul_smul, mul_comm]
+  have ha : ∑ i, a i • C i = Matrix.single α₁ β₁ (1 : ℂ) := by
+    simpa [a, C] using inverseTensor_spec K hK α₁ β₁
+  have hb : ∑ i, b i • C i = Matrix.single α₃ β₃ (1 : ℂ) := by
+    simpa [b, C] using inverseTensor_spec K hK α₃ β₃
+  rw [hmat, ha, hb, Matrix.single_mul_mul_single, Matrix.trace_single_mul]
+  simp
 
 /-- The physical realization map for a right virtual insertion on an injective
 simple MPO tensor. This is the MPO encoding of

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -135,9 +135,12 @@ strong subadditivity for a normalized three-site reduced state.
 
 \begin{proof}\leanok
     \uses{thm:mpdo_injective_inverse_layer_spec}
-    Move the two finite sums through the trace. The two inverse-map identities
-    replace the contracted tensors by the matrix units
-    $E_{\alpha_1,\beta_1}$ and $E_{\alpha_3,\beta_3}$. Hence
+    Move the two finite sums through the trace.  By the inverse-map identity
+    \[
+        \sum_p({\cal K}^{-1})^{\alpha,\beta}_p\,{\cal K}^p
+        =E_{\alpha,\beta},
+    \]
+    the double sum collapses to
     \[
         \tr\bigl(E_{\alpha_1,\beta_1}{\cal K}^{p_2}
           E_{\alpha_3,\beta_3}R\bigr)

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -97,6 +97,55 @@ strong subadditivity for a normalized three-site reduced state.
     and the analogous left-insertion statement also holds.
 \end{theorem}
 
+\begin{definition}[Three-site inverse-map contraction]
+    \label{def:mpdo_inverse_map_three_site_contraction}
+    \lean{MPOTensor.inverseMapThreeSiteContraction}
+    \leanok
+    \uses{def:mpdo_injective_inverse_layer}
+    Let ${\cal K}$ be an injective simple MPO tensor, and let $R\in\MN{D}$ be
+    the virtual contraction of the sites following a three-site word. For
+    virtual indices
+    $\alpha_1,\beta_1,\alpha_3,\beta_3$, define
+    \[
+        C_{\alpha_1,\beta_1,\alpha_3,\beta_3}(p_2;R)
+        =\sum_{p_1,p_3}
+        ({\cal K}^{-1})^{\alpha_1,\beta_1}_{p_1}
+        ({\cal K}^{-1})^{\alpha_3,\beta_3}_{p_3}
+        \tr\bigl({\cal K}^{p_1}{\cal K}^{p_2}
+        {\cal K}^{p_3}R\bigr).
+    \]
+    This is the contraction used in the proof of
+    \cite[Appendix~C.2, Lemma~C.4]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Evaluation of the three-site inverse-map contraction]
+    \label{thm:mpdo_inverse_map_three_site_contraction}
+    \lean{MPOTensor.inverseMapThreeSiteContraction_eq}
+    \leanok
+    \uses{def:mpdo_inverse_map_three_site_contraction}
+    % The source display following Qketc repeats alpha_3 in the tail scalar.
+    % Direct matrix-unit contraction gives R_{beta_3,alpha_1}; see the paper-gap note.
+    For every middle physical index $p_2$,
+    \[
+        C_{\alpha_1,\beta_1,\alpha_3,\beta_3}(p_2;R)
+        = {\cal K}^{p_2}_{\beta_1,\alpha_3}
+        R_{\beta_3,\alpha_1}.
+    \]
+\end{theorem}
+
+\begin{proof}\leanok
+    \uses{thm:mpdo_injective_inverse_layer_spec}
+    Move the two finite sums through the trace. The two inverse-map identities
+    replace the contracted tensors by the matrix units
+    $E_{\alpha_1,\beta_1}$ and $E_{\alpha_3,\beta_3}$. Hence
+    \[
+        \tr\bigl(E_{\alpha_1,\beta_1}{\cal K}^{p_2}
+          E_{\alpha_3,\beta_3}R\bigr)
+        = {\cal K}^{p_2}_{\beta_1,\alpha_3}
+          R_{\beta_3,\alpha_1}.
+    \]
+\end{proof}
+
 \begin{definition}[Explicit neighboring $\eta$-operator data]
     \label{def:mpdo_explicit_eta_operators}
     \lean{MPOTensor.etaOperators}

--- a/docs/paper-gaps/README.md
+++ b/docs/paper-gaps/README.md
@@ -38,6 +38,10 @@ unless they are cited by one of the current blueprint chapters above.
 
 For MPDO renormalization fixed points:
 
+- `cpgsv17_mpdo_sal_zcl_eta_local_structure.tex` records the missing
+  inverse-map sector factorization in Appendix C.2. The double end-site
+  inverse contraction is proved, while its comparison with the conjugated
+  Hayashi decomposition and the resulting tensors $l_k,r_k$ remain open.
 - `cpsv16_purification_rfp_definition.tex` records why the former
   local-purification PRFP predicate was removed: it required a generic
   pure-state RFP witness, but did not enforce the source's positive-length

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -114,8 +114,8 @@ then
   \tr({\cal K}^{p_1}{\cal K}^{p_2}{\cal K}^{p_3}R)
   = {\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}.
 \]
-This is the calculation between Equations \path{Qketc} and
-\path{formK} in the proof of Lemma \path{propSN}.\footnote{The formal
+This is the calculation at lines 1415--1438 of Appendix C.2 in
+arXiv:1606.00608.\footnote{The formal
 declarations are \leanid{MPOTensor.inverseMapThreeSiteContraction} and
 \leanid{MPOTensor.inverseMapThreeSiteContraction_eq}.}
 
@@ -143,11 +143,11 @@ missing comparison must commute the two end contractions through this unitary
 and reindexing, obtain the sectorwise product
 $A^{(k)}_{\alpha_1,\beta_1}\otimes
 B^{(k)}_{\alpha_3,\beta_3}$, and then choose a nonzero entry
-$R_{\beta_3,\alpha_1}$ before dividing to obtain Equation
-\path{formK}.  None of the present physical-realization identities states
-this comparison: they rewrite left or right virtual multiplication on one copy
-of ${\cal K}$, whereas the required equality contracts two physical sites
-of a reduced density operator.
+$R_{\beta_3,\alpha_1}$ before dividing to obtain the sector factorization
+displayed at lines 1434--1438.  None of the present physical-realization
+identities states this comparison: they rewrite left or right virtual
+multiplication on one copy of ${\cal K}$, whereas the required equality
+contracts two physical sites of a reduced density operator.
 
 The canonical family
 \leanid{MPOTensor.ExplicitEtaOperators.ofHayashiMarkov} does not supply this

--- a/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
+++ b/docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex
@@ -10,7 +10,7 @@
 \title{The SAL to Eta-Local Structure Step in
 Cirac--Perez-Garcia--Schuch--Verstraete 2017 Appendix C.2}
 \author{}
-\date{2026-07-09}
+\date{2026-07-10}
 
 \begin{document}
 \maketitle
@@ -103,6 +103,51 @@ the resulting neighboring operators $\eta_{k,h}$ satisfy
 \]
 for every chain length.  No current declaration states this tensor
 factorization or its all-length contraction identity.
+
+The double inverse-map contraction preceding this factorization is now
+formalized.  If $R$ denotes the virtual contraction of the remaining sites,
+then
+\[
+  \sum_{p_1,p_3}
+  ({\cal K}^{-1})^{\alpha_1,\beta_1}_{p_1}
+  ({\cal K}^{-1})^{\alpha_3,\beta_3}_{p_3}
+  \tr({\cal K}^{p_1}{\cal K}^{p_2}{\cal K}^{p_3}R)
+  = {\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}.
+\]
+This is the calculation between Equations \path{Qketc} and
+\path{formK} in the proof of Lemma \path{propSN}.\footnote{The formal
+declarations are \leanid{MPOTensor.inverseMapThreeSiteContraction} and
+\leanid{MPOTensor.inverseMapThreeSiteContraction_eq}.}
+
+The source display at line~1427 writes the remaining scalar as
+$m_{\beta_3,\alpha_3}$.  This repeats the third-site left index and loses the
+first-site left index.  Contracting the two matrix units gives
+\[
+  \tr(E_{\alpha_1,\beta_1}{\cal K}^{p_2}
+    E_{\alpha_3,\beta_3}R)
+  = {\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1},
+\]
+so the scalar is $m_{\beta_3,\alpha_1}$.  The diagram defining
+$m_{\beta,\alpha}$ and the subsequent choice of a nonzero pair $(\alpha,\beta)$
+are consistent with this correction.  Thus the repeated $\alpha_3$ is a local
+index typo, not a different mathematical hypothesis.
+
+The next result must compare this contraction of the concrete three-site
+reduced state with the two factors obtained by contracting
+$\rho_{A b_1}^{(k)}$ and $\rho_{b_2 c}^{(k)}$ in the Hayashi
+decomposition.  The equality in that decomposition is written after
+conjugation by the middle-site unitary and reindexing by
+$H_B=\bigoplus_k H_{b_1}^{(k)}\otimes H_{b_2}^{(k)}$; the new
+inverse-map identity is written in the original physical coordinates.  The
+missing comparison must commute the two end contractions through this unitary
+and reindexing, obtain the sectorwise product
+$A^{(k)}_{\alpha_1,\beta_1}\otimes
+B^{(k)}_{\alpha_3,\beta_3}$, and then choose a nonzero entry
+$R_{\beta_3,\alpha_1}$ before dividing to obtain Equation
+\path{formK}.  None of the present physical-realization identities states
+this comparison: they rewrite left or right virtual multiplication on one copy
+of ${\cal K}$, whereas the required equality contracts two physical sites
+of a reduced density operator.
 
 The canonical family
 \leanid{MPOTensor.ExplicitEtaOperators.ofHayashiMarkov} does not supply this


### PR DESCRIPTION
### Motivation
- Continues the formalization of Appendix C.2, Lemma `propSN` (arXiv:1606.00608, lines 1415–1438), which derives the local-to-global commuting form for injective simple MPO tensors; see #823.
- The inverse-map contraction identity proved here is the first step toward deriving the sector tensors $l_k, r_k$ via the conjugated and reindexed Hayashi decomposition.

### Description
- `TNLean/MPS/MPDO/SimpleLocalStructure.lean`: defines `MPOTensor.inverseMapThreeSiteContraction` and proves `MPOTensor.inverseMapThreeSiteContraction_eq`. For an injective simple MPO tensor $\mathcal{K}$, applying $\mathcal{K}^{-1}$ on the first and third sites of a three-site word gives

\[
\sum_{p_1,p_3}(\mathcal K^{-1})^{\alpha_1,\beta_1}_{p_1}
(\mathcal K^{-1})^{\alpha_3,\beta_3}_{p_3}
\operatorname{tr}(\mathcal K^{p_1}\mathcal K^{p_2}\mathcal K^{p_3}R)
=\mathcal K^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}.
\]

- Records a local index typo at arXiv:1606.00608 line 1427 (the display repeats $\alpha_3$; the correct tail index is $\alpha_1$) in `docs/paper-gaps/cpgsv17_mpdo_sal_zcl_eta_local_structure.tex`; `docs/paper-gaps/README.md` updated accordingly.
- `blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex`: adds blueprint entries for the new definition and theorem.
- The step comparing this contraction with the conjugated and reindexed Hayashi decomposition (to derive $l_k, r_k$) remains open.

### Testing
- `lake build TNLean` (9273 jobs)
- `cd blueprint && leanblueprint checkdecls`
- `python3 scripts/blueprint_lean_sync.py --ci`
- Full blueprint PDF and visual page check
- `git diff --check`
- No new proof placeholders introduced.

---
Partially addresses #823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a localized Lean proof on top of existing inverse-map lemmas plus documentation; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`MPOTensor.inverseMapThreeSiteContraction`** and proves **`inverseMapThreeSiteContraction_eq`**: for injective simple MPO tensors, applying **K⁻¹** on the first and third sites of a three-site word collapses the double sum to **K^p₂_{β₁,α₃} R_{β₃,α₁}** (Appendix C.2, arXiv:1606.00608, lines 1415–1438). The proof reuses **`inverseTensor_spec`** after pulling sums through the trace.
> 
> Blueprint **ch21** gets matching definition/theorem entries. **Paper-gap** notes record that this contraction step is now formalized, document a **tail-index typo** in the source (R_{β₃,α₃} vs **R_{β₃,α₁}**), and state that comparing this identity to the conjugated/reindexed Hayashi decomposition (sector **l_k, r_k**) remains open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2dc7bb9a39b7c5661fbef86ed4952fad415b502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->