### PR TITLE
feat(MPS/MPDO): derive rank-one T from the sector tensor pairing

### DIFF
--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -124,8 +124,10 @@ theorem hasRankOneFactorization_of_mul_self_eq_self
 
 /-- An idempotent matrix has constant traces of positive powers.  This recovers
 the display tr(T^N) = tr(T) in the proof of Lemma C.5 (arXiv:1606.00608,
-Appendix C.2, lines 1494--1497) from the idempotence of the sector trace matrix
-supplied by the zero-correlation-length identity. -/
+Appendix C.2, lines 1494--1497) from the idempotence of the sector trace matrix.
+In the pairing route below, this idempotence follows from the
+zero-correlation-length identity together with linear independence of the
+sector tensors. -/
 theorem tracePowersConstant_of_mul_self_eq_self
     {T : Matrix (Fin n) (Fin n) ℝ} (hTT : T * T = T) :
     TracePowersConstant T := by
@@ -145,8 +147,8 @@ In the proof of Lemma C.5 (arXiv:1606.00608, Appendix C.2, lines
 Lemma C.4 (lines 1407--1471).  A primitive matrix has a positive entry in
 every row and in every column, so no sector tensor l_k and no functional r_k
 pairs to zero against the whole opposite family.  These lemmas supply the
-nonvanishing of the sector tensors used to derive their linear independence
-from a block-support decomposition. -/
+nonvanishing used to derive linear independence once each sector tensor lies in
+the corresponding member of an independent family of subspaces. -/
 
 /-- A primitive matrix has a positive entry in every row: a vanishing row of
 `T` would make the same row of every power of `T` vanish. -/

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -42,11 +42,11 @@ sum_k |l_k)(r_k| = sum_{k,h} T_{k,h} |l_k)(r_h| (lines 1489--1497) states that
 the pairing operator equals its own square, and linear independence of the
 tensors on one side of the pairing turns this into `T * T = T`.  The theorem
 `Matrix.hasRankOneFactorization_of_pairing_idempotent` combines the two steps
-into the rank-one conclusion of Lemma SALZCL (lines 1484--1502).
+into the rank-one conclusion of Lemma C.5 (lines 1484--1502).
 
 Two further matrix facts feed the sector trace matrix:
 `Matrix.tracePowersConstant_of_mul_self_eq_self` recovers the constant trace
-powers of Lemma SALZCL from idempotence, and
+powers in the proof of Lemma C.5 from idempotence, and
 `Matrix.IsPrimitive.exists_row_pos` / `Matrix.IsPrimitive.exists_col_pos` show
 that a primitive matrix has a positive entry in every row and in every column,
 which makes the paired sector tensors nonzero.
@@ -123,7 +123,7 @@ theorem hasRankOneFactorization_of_mul_self_eq_self
   simpa [b, Matrix.vecMulVec_apply, mul_comm] using hb'.symm
 
 /-- An idempotent matrix has constant traces of positive powers.  This recovers
-the display tr(T^N) = tr(T) in the proof of Lemma SALZCL (arXiv:1606.00608,
+the display tr(T^N) = tr(T) in the proof of Lemma C.5 (arXiv:1606.00608,
 Appendix C.2, lines 1494--1497) from the idempotence of the sector trace matrix
 supplied by the zero-correlation-length identity. -/
 theorem tracePowersConstant_of_mul_self_eq_self
@@ -140,9 +140,9 @@ theorem tracePowersConstant_of_mul_self_eq_self
 
 /-! ### Primitivity excludes vanishing rows and columns
 
-In the proof of Lemma SALZCL (arXiv:1606.00608, Appendix C.2, lines
+In the proof of Lemma C.5 (arXiv:1606.00608, Appendix C.2, lines
 1484--1499) the sector trace matrix T_{k,h} = (r_k|l_h) is primitive by
-Lemma propSN (lines 1407--1471).  A primitive matrix has a positive entry in
+Lemma C.4 (lines 1407--1471).  A primitive matrix has a positive entry in
 every row and in every column, so no sector tensor l_k and no functional r_k
 pairs to zero against the whole opposite family.  These lemmas supply the
 nonvanishing of the sector tensors used to derive their linear independence

--- a/TNLean/Algebra/PerronFrobenius/RankOne.lean
+++ b/TNLean/Algebra/PerronFrobenius/RankOne.lean
@@ -43,6 +43,13 @@ the pairing operator equals its own square, and linear independence of the
 tensors on one side of the pairing turns this into `T * T = T`.  The theorem
 `Matrix.hasRankOneFactorization_of_pairing_idempotent` combines the two steps
 into the rank-one conclusion of Lemma SALZCL (lines 1484--1502).
+
+Two further matrix facts feed the sector trace matrix:
+`Matrix.tracePowersConstant_of_mul_self_eq_self` recovers the constant trace
+powers of Lemma SALZCL from idempotence, and
+`Matrix.IsPrimitive.exists_row_pos` / `Matrix.IsPrimitive.exists_col_pos` show
+that a primitive matrix has a positive entry in every row and in every column,
+which makes the paired sector tensors nonzero.
 -/
 
 open scoped BigOperators Matrix ComplexOrder
@@ -114,6 +121,64 @@ theorem hasRankOneFactorization_of_mul_self_eq_self
   change Classical.choose _ * u.1 i = f (Pi.single j 1) i at hb'
   rw [heval] at hb'
   simpa [b, Matrix.vecMulVec_apply, mul_comm] using hb'.symm
+
+/-- An idempotent matrix has constant traces of positive powers.  This recovers
+the display tr(T^N) = tr(T) in the proof of Lemma SALZCL (arXiv:1606.00608,
+Appendix C.2, lines 1494--1497) from the idempotence of the sector trace matrix
+supplied by the zero-correlation-length identity. -/
+theorem tracePowersConstant_of_mul_self_eq_self
+    {T : Matrix (Fin n) (Fin n) ℝ} (hTT : T * T = T) :
+    TracePowersConstant T := by
+  have hpow : ∀ m : ℕ, T ^ (m + 1) = T := by
+    intro m
+    induction m with
+    | zero => rw [pow_one]
+    | succ p ih => rw [pow_succ, ih, hTT]
+  intro k hk
+  obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
+  rw [hpow]
+
+/-! ### Primitivity excludes vanishing rows and columns
+
+In the proof of Lemma SALZCL (arXiv:1606.00608, Appendix C.2, lines
+1484--1499) the sector trace matrix T_{k,h} = (r_k|l_h) is primitive by
+Lemma propSN (lines 1407--1471).  A primitive matrix has a positive entry in
+every row and in every column, so no sector tensor l_k and no functional r_k
+pairs to zero against the whole opposite family.  These lemmas supply the
+nonvanishing of the sector tensors used to derive their linear independence
+from a block-support decomposition. -/
+
+/-- A primitive matrix has a positive entry in every row: a vanishing row of
+`T` would make the same row of every power of `T` vanish. -/
+theorem IsPrimitive.exists_row_pos {T : Matrix (Fin n) (Fin n) ℝ}
+    (hT : T.IsPrimitive) (k : Fin n) : ∃ h, 0 < T k h := by
+  by_contra hrow
+  push Not at hrow
+  have hzero : ∀ h, T k h = 0 := fun h => le_antisymm (hrow h) (hT.nonneg k h)
+  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
+  obtain ⟨m', rfl⟩ : ∃ m', m = m' + 1 := ⟨m - 1, by omega⟩
+  have hpow : (T ^ (m' + 1)) k k = 0 := by
+    rw [pow_succ', Matrix.mul_apply]
+    simp [hzero]
+  have h := hpos k k
+  rw [hpow] at h
+  exact lt_irrefl 0 h
+
+/-- A primitive matrix has a positive entry in every column: a vanishing
+column of `T` would make the same column of every power of `T` vanish. -/
+theorem IsPrimitive.exists_col_pos {T : Matrix (Fin n) (Fin n) ℝ}
+    (hT : T.IsPrimitive) (h : Fin n) : ∃ k, 0 < T k h := by
+  by_contra hcol
+  push Not at hcol
+  have hzero : ∀ k, T k h = 0 := fun k => le_antisymm (hcol k) (hT.nonneg k h)
+  obtain ⟨m, hm, hpos⟩ := hT.exists_pos_pow
+  obtain ⟨m', rfl⟩ : ∃ m', m = m' + 1 := ⟨m - 1, by omega⟩
+  have hpow : (T ^ (m' + 1)) h h = 0 := by
+    rw [pow_succ, Matrix.mul_apply]
+    simp [hzero]
+  have hlt := hpos h h
+  rw [hpow] at hlt
+  exact lt_irrefl 0 hlt
 
 /-! ### Idempotence of the sector trace matrix
 

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -191,8 +191,8 @@ Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4 and C.5, lines 1406--1499.
 **Scope restriction (linear independence):** the source lemma neither assumes
 nor derives linear independence of the sector tensors; documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
-by `SectorPairingData.linearIndependent_l` from a block-support
-decomposition. -/
+by `SectorPairingData.linearIndependent_l` once each sector tensor lies in the
+corresponding member of an independent family of subspaces. -/
 def ofSALZCLOfPairingIdempotent
     {dA dB dC n : ℕ} {V : Type*} [AddCommGroup V] [Module ℝ V]
     (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -179,6 +179,46 @@ def ofSALZCLOfPosSemidef
   rankOne :=
     sal_zcl_implies_rank_one_T_of_posSemidef T hPrimitive hPSD hTrace hTraceConst
 
+/-- Construct the local simple-MPDO structure from the Lemma C.2 and C.4
+hypotheses and the pairing-idempotence Lemma C.5 rank-one criterion: the
+sector tensors of arXiv:1606.00608, Appendix C.2, satisfy the displayed
+zero-correlation-length identity (lines 1490--1493), and their linear
+independence turns it into idempotence of the sector trace matrix, from which
+the constant trace powers and the rank-one factorization follow.
+
+Source: arXiv:1606.00608, Appendix C.2, Lemmas C.4 and C.5, lines 1406--1499.
+
+**Scope restriction (linear independence):** the source lemma neither assumes
+nor derives linear independence of the sector tensors; documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
+by `SectorPairingData.linearIndependent_l` from a block-support
+decomposition. -/
+def ofSALZCLOfPairingIdempotent
+    {dA dB dC n : ℕ} {V : Type*} [AddCommGroup V] [Module ℝ V]
+    (rhoABC : Matrix (Fin dA × Fin dB × Fin dC) (Fin dA × Fin dB × Fin dC) ℂ)
+    (hRhoDM : rhoABC.PosSemidef ∧ rhoABC.trace = 1)
+    (hSSA : IsSSAEquality rhoABC hRhoDM.1.isHermitian)
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (data : SectorPairingData T V)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hl : LinearIndependent ℝ data.l)
+    (hTrace : Matrix.trace T = 1) :
+    SimpleMPDOLocalStructureData where
+  dA := dA
+  dB := dB
+  dC := dC
+  rhoABC := rhoABC
+  hRhoDM := hRhoDM
+  hSSA := hSSA
+  eta := sal_implies_eta_structure rhoABC hRhoDM hSSA
+  Tdim := n
+  T := T
+  hPrimitive := hPrimitive
+  hTrace := hTrace
+  hTraceConst := data.tracePowersConstant hl
+  rankOne :=
+    sal_zcl_implies_rank_one_T_of_pairing_idempotent T data hPrimitive hl hTrace
+
 end SimpleMPDOLocalStructureData
 
 /-- Auxiliary structure for the simple-MPDO blocked-RFP argument.

--- a/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
+++ b/TNLean/MPS/MPDO/BlockedRFPConstruction.lean
@@ -217,7 +217,7 @@ def ofSALZCLOfPairingIdempotent
   hTrace := hTrace
   hTraceConst := data.tracePowersConstant hl
   rankOne :=
-    sal_zcl_implies_rank_one_T_of_pairing_idempotent T data hPrimitive hl hTrace
+    sal_zcl_implies_rank_one_T_of_pairing_idempotent T data hl hTrace
 
 end SimpleMPDOLocalStructureData
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -58,18 +58,18 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   proved relative to the Perron–Frobenius rank-one input.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`: the same consequence
   with the Perron–Frobenius input derived from positive semidefiniteness of `T`.
-- `MPOTensor.SectorPairingData`: the sector tensors `|l_k)` and functionals
-  `(r_k|` of arXiv:1606.00608, Appendix C.2, with the pairing
-  T_{k,h} = (r_k|l_h) and the displayed zero-correlation-length identity.
+- `MPOTensor.SectorPairingData`: the sector tensors $|l_k)$ and functionals
+  $(r_k|$ of arXiv:1606.00608, Appendix C.2, with the pairing
+  $T_{k,h}=(r_k|l_h)$ and the displayed zero-correlation-length identity.
 - `MPOTensor.SectorPairingData.mul_self_eq_self` /
   `MPOTensor.SectorPairingData.linearIndependent_l`: idempotence of the sector
   trace matrix from the zero-correlation-length identity, and linear
   independence of the sector tensors from primitivity and a block-support
   decomposition.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent` /
-  `MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports`: the Lemma C.5
-  consequence with the Perron–Frobenius input derived from the
-  zero-correlation-length identity through idempotence of `T`.
+  `MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports`: the rank-one
+  factorization at lines 1484--1499, derived from the zero-correlation-length
+  identity through idempotence of $T$.
 
 ## Implementation note
 
@@ -122,15 +122,15 @@ entrywise nonnegativity of the trace matrix. The special sector-reduced family
 `ofHayashiMarkov` does have a positive-semidefinite all-ones trace matrix, but
 its identification with the paper's inverse-map family is not available.
 
-A second exclusion of the nilpotent zero-eigenspace goes through the pairing:
-`MPOTensor.SectorPairingData` records the closed sector tensors `|l_k)`, the
-functionals `(r_k|`, the pairing T_{k,h} = (r_k|l_h), and the displayed
-zero-correlation-length identity of Lemma C.5, and
+A second exclusion of the nilpotent zero-eigenspace goes through the pairing.
+`MPOTensor.SectorPairingData` records the closed sector tensors $|l_k)$, the
+functionals $(r_k|$, the pairing $T_{k,h}=(r_k|l_h)$, and the
+zero-correlation-length identity at lines 1490--1493. The theorem
 `MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent` derives the
-rank-one factorization once the closed sector tensors are linearly
-independent. The two obligations left open by this route are the construction
-of the sector tensor families from an injective simple tensor (Lemma propSN)
-and the derivation of their linear independence; both are recorded in
+rank-one factorization once the closed sector tensors are linearly independent.
+Three obligations remain: construct the sector families and their pairing from
+the inverse-map factorization at lines 1407--1482, derive the operator identity
+from zero correlation length, and prove linear independence. They are recorded in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
 
 ## References
@@ -625,14 +625,18 @@ theorem linearIndependent_l (data : SectorPairingData T V)
 
 end SectorPairingData
 
-/-- **Lemma C.5, pairing-idempotence form**: for a primitive sector trace
-matrix `T` paired from sector tensors that satisfy the zero-correlation-length
-identity of arXiv:1606.00608, lines 1490--1493, linear independence of the
-closed sector tensors and the trace normalization give the rank-one
-factorization T_{k,h} = a_k b_h with sum_k a_k b_k = 1 (Lemma SALZCL,
-lines 1484--1499).  Unlike the positive-semidefinite variant
+/-- **Lemma C.5, pairing-idempotence form**: for a sector trace matrix `T`
+paired from sector tensors that satisfy the zero-correlation-length identity
+of arXiv:1606.00608, lines 1490--1493, linear independence of the closed
+sector tensors and the trace normalization give the rank-one factorization
+T_{k,h} = a_k b_h with sum_k a_k b_k = 1 (Lemma SALZCL, lines 1484--1499).
+Unlike the positive-semidefinite variant
 `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`, the constant trace
-powers are derived, not assumed.
+powers are derived, not assumed.  The primitivity of `T`, supplied in the
+source by Lemma propSN, is not needed once the independence is assumed; it
+enters the block-support form
+`MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports`, where it makes
+the closed sector tensors nonzero.
 
 **Scope restriction (linear independence):** the source lemma neither assumes
 nor derives linear independence of the sector tensors; documented in
@@ -643,13 +647,15 @@ theorem sal_zcl_implies_rank_one_T_of_pairing_idempotent
     {V : Type*} [AddCommGroup V] [Module ℝ V]
     (T : Matrix (Fin n) (Fin n) ℝ)
     (data : SectorPairingData T V)
-    (hPrimitive : Matrix.IsPrimitive T)
     (hl : LinearIndependent ℝ data.l)
     (hTrace : Matrix.trace T = 1) :
-    ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 :=
-  sal_zcl_implies_rank_one_T T hPrimitive hTrace (data.tracePowersConstant hl)
-    fun _ _ => Matrix.hasRankOneFactorization_of_mul_self_eq_self
+    ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 := by
+  obtain ⟨a, b, hT⟩ :=
+    Matrix.hasRankOneFactorization_of_mul_self_eq_self
       (data.mul_self_eq_self hl) hTrace
+  refine ⟨a, b, hT, ?_⟩
+  rw [← Matrix.trace_vecMulVec, ← hT]
+  exact hTrace
 
 /-- **Lemma C.5, block-support form**: the rank-one factorization of the
 sector trace matrix with the linear independence of the closed sector tensors
@@ -669,7 +675,7 @@ theorem sal_zcl_implies_rank_one_T_of_sector_supports
     (hPrimitive : Matrix.IsPrimitive T)
     (hTrace : Matrix.trace T = 1) :
     ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 :=
-  sal_zcl_implies_rank_one_T_of_pairing_idempotent T data hPrimitive
+  sal_zcl_implies_rank_one_T_of_pairing_idempotent T data
     (data.linearIndependent_l support hmem hsupp hPrimitive) hTrace
 
 end RankOneT

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -8,6 +8,7 @@ import TNLean.MPS.MPDO.MutualInfoMonotone
 import TNLean.MPS.Chain.VirtualInsertion
 import TNLean.Algebra.PerronFrobenius.RankOne
 import Mathlib.Analysis.Matrix.Order
+import Mathlib.LinearAlgebra.DFinsupp
 
 /-!
 # Simple MPDO local structure
@@ -57,6 +58,18 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
   proved relative to the Perron–Frobenius rank-one input.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`: the same consequence
   with the Perron–Frobenius input derived from positive semidefiniteness of `T`.
+- `MPOTensor.SectorPairingData`: the sector tensors `|l_k)` and functionals
+  `(r_k|` of arXiv:1606.00608, Appendix C.2, with the pairing
+  T_{k,h} = (r_k|l_h) and the displayed zero-correlation-length identity.
+- `MPOTensor.SectorPairingData.mul_self_eq_self` /
+  `MPOTensor.SectorPairingData.linearIndependent_l`: idempotence of the sector
+  trace matrix from the zero-correlation-length identity, and linear
+  independence of the sector tensors from primitivity and a block-support
+  decomposition.
+- `MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent` /
+  `MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports`: the Lemma C.5
+  consequence with the Perron–Frobenius input derived from the
+  zero-correlation-length identity through idempotence of `T`.
 
 ## Implementation note
 
@@ -108,6 +121,17 @@ zero-eigenspace. Positivity of the individual η-operators alone gives only
 entrywise nonnegativity of the trace matrix. The special sector-reduced family
 `ofHayashiMarkov` does have a positive-semidefinite all-ones trace matrix, but
 its identification with the paper's inverse-map family is not available.
+
+A second exclusion of the nilpotent zero-eigenspace goes through the pairing:
+`MPOTensor.SectorPairingData` records the closed sector tensors `|l_k)`, the
+functionals `(r_k|`, the pairing T_{k,h} = (r_k|l_h), and the displayed
+zero-correlation-length identity of Lemma C.5, and
+`MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent` derives the
+rank-one factorization once the closed sector tensors are linearly
+independent. The two obligations left open by this route are the construction
+of the sector tensor families from an injective simple tensor (Lemma propSN)
+and the derivation of their linear independence; both are recorded in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.
 
 ## References
 
@@ -476,6 +500,177 @@ theorem sal_zcl_implies_rank_one_T_of_posSemidef
     ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 :=
   sal_zcl_implies_rank_one_T T hPrimitive hTrace hZCL
     (Matrix.primitive_trace_powers_constant_implies_rank_one_of_posSemidef hPSD hTrace)
+
+/-! ### Sector tensors and the pairing route to rank one
+
+Appendix C.2 of arXiv:1606.00608 obtains the sector trace matrix by pairing
+sector tensors: after the isometry `U`, the injective simple tensor splits
+as a direct sum over sectors `k` of pairs `l_k`, `r_k` (eq. formK,
+lines 1436--1448), the closed tensors `|l_k)` and `(r_k|` pair to
+T_{k,h} = (r_k|l_h) (eq. lkrk and eq. Tkn, lines 1473--1482), and the
+zero-correlation-length identity displayed in the proof of Lemma SALZCL
+(lines 1490--1493) states that the operator sum_k |l_k)(r_k| equals its own
+square.  The declarations below record this pairing and derive the rank-one
+factorization of `T` through
+`Matrix.mul_self_eq_self_of_pairing_idempotent`. -/
+
+/-- The sector tensors of arXiv:1606.00608, Appendix C.2, paired into the
+sector trace matrix `T`.
+
+The vector space `V` carries the closed sector tensors `|l_k)` and the
+functionals `(r_k|` of eq. lkrk (lines 1473--1477).  The two recorded
+identities are the paper's displayed equations: the pairing
+T_{k,h} = (r_k|l_h) of eq. Tkn (lines 1478--1482) and the
+zero-correlation-length identity in the proof of Lemma SALZCL
+(lines 1490--1493).  The construction of these families from an injective
+simple tensor is the content of Lemma propSN (eq. formK, lines 1436--1448)
+and is not yet formalized; see the module docstring. -/
+structure SectorPairingData (T : Matrix (Fin n) (Fin n) ℝ)
+    (V : Type*) [AddCommGroup V] [Module ℝ V] where
+  /-- The closed sector tensors `|l_k)`; arXiv:1606.00608, eq. lkrk,
+  lines 1473--1477. -/
+  l : Fin n → V
+  /-- The closed sector functionals `(r_k|`; arXiv:1606.00608, eq. lkrk,
+  lines 1473--1477. -/
+  r : Fin n → Module.Dual ℝ V
+  /-- The pairing identity T_{k,h} = (r_k|l_h); arXiv:1606.00608, eq. Tkn,
+  lines 1478--1482. -/
+  pairing : ∀ k h, T k h = r k (l h)
+  /-- The zero-correlation-length identity
+  sum_k |l_k)(r_k| = sum_{k,h} T_{k,h} |l_k)(r_h|, evaluated on a vector;
+  arXiv:1606.00608, proof of Lemma SALZCL, lines 1490--1493. -/
+  zcl : ∀ v : V, ∑ k, r k v • l k = ∑ k, ∑ h, (T k h * r h v) • l k
+
+namespace SectorPairingData
+
+variable {T : Matrix (Fin n) (Fin n) ℝ} {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- The zero-correlation-length identity makes the pairing operator
+sum_k |l_k)(r_k| equal to its own square: the right-hand side of the displayed
+identity of arXiv:1606.00608, lines 1490--1493, expands to the square of its
+left-hand side once the coefficients T_{k,h} are replaced by the pairing
+(r_k|l_h) of eq. Tkn. -/
+theorem pairing_operator_idempotent (data : SectorPairingData T V) (v : V) :
+    ∑ k, data.r k (∑ j, data.r j v • data.l j) • data.l k
+      = ∑ k, data.r k v • data.l k := by
+  have hexpand : ∀ k, data.r k (∑ j, data.r j v • data.l j)
+      = ∑ j, T k j * data.r j v := by
+    intro k
+    rw [map_sum]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [map_smul, smul_eq_mul, data.pairing k j]
+    ring
+  calc ∑ k, data.r k (∑ j, data.r j v • data.l j) • data.l k
+      = ∑ k, ∑ j, (T k j * data.r j v) • data.l k := by
+        refine Finset.sum_congr rfl fun k _ => ?_
+        rw [hexpand k, Finset.sum_smul]
+    _ = ∑ k, data.r k v • data.l k := (data.zcl v).symm
+
+/-- **Idempotence of the sector trace matrix** for sector tensors satisfying
+the zero-correlation-length identity: `T * T = T`.
+
+**Scope restriction (linear independence):** the source lemma
+(arXiv:1606.00608, Lemma SALZCL, lines 1484--1499) neither assumes nor derives
+linear independence of the sector tensors; see the marker on
+`Matrix.mul_self_eq_self_of_pairing_idempotent` and
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
+by `SectorPairingData.linearIndependent_l` once the sector tensors carry a
+block-support decomposition. -/
+theorem mul_self_eq_self (data : SectorPairingData T V)
+    (hl : LinearIndependent ℝ data.l) : T * T = T :=
+  Matrix.mul_self_eq_self_of_pairing_idempotent data.pairing hl
+    data.pairing_operator_idempotent
+
+/-- The traces of all positive powers of the sector trace matrix agree with
+its trace: the display tr(T^N) = tr(T) of arXiv:1606.00608, lines 1494--1497,
+recovered from idempotence.
+
+**Scope restriction (linear independence):** inherited from
+`SectorPairingData.mul_self_eq_self`; documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+theorem tracePowersConstant (data : SectorPairingData T V)
+    (hl : LinearIndependent ℝ data.l) : Matrix.TracePowersConstant T :=
+  Matrix.tracePowersConstant_of_mul_self_eq_self (data.mul_self_eq_self hl)
+
+/-- Primitivity of the sector trace matrix makes every closed sector tensor
+`|l_k)` nonzero: some entry of the `k`-th column of `T` is positive, and that
+entry is the pairing of `|l_k)` against a functional (arXiv:1606.00608,
+eq. Tkn, lines 1478--1482). -/
+theorem l_ne_zero (data : SectorPairingData T V)
+    (hPrimitive : Matrix.IsPrimitive T) (k : Fin n) : data.l k ≠ 0 := by
+  intro hzero
+  obtain ⟨j, hj⟩ := hPrimitive.exists_col_pos k
+  rw [data.pairing j k, hzero, map_zero] at hj
+  exact lt_irrefl 0 hj
+
+/-- Linear independence of the closed sector tensors from a block-support
+decomposition: if each `|l_k)` lies in its own member of an independent family
+of subspaces of `V` and the sector trace matrix is primitive, then the family
+`|l_k)` is linearly independent.
+
+**Scope restriction (block supports):** the subspace family is not displayed
+in arXiv:1606.00608; eq. formK (lines 1436--1448) gives the sector splitting
+of the physical indices, but the closed tensors `|l_k)` of eq. lkrk live in a
+common bond space after the physical sector legs are contracted.  Whether the
+inverse-map construction of Lemma propSN supplies such supports, or the
+independence by other means, remains open; documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+theorem linearIndependent_l (data : SectorPairingData T V)
+    (support : Fin n → Submodule ℝ V)
+    (hmem : ∀ k, data.l k ∈ support k)
+    (hsupp : iSupIndep support)
+    (hPrimitive : Matrix.IsPrimitive T) :
+    LinearIndependent ℝ data.l :=
+  hsupp.linearIndependent support hmem (data.l_ne_zero hPrimitive)
+
+end SectorPairingData
+
+/-- **Lemma C.5, pairing-idempotence form**: for a primitive sector trace
+matrix `T` paired from sector tensors that satisfy the zero-correlation-length
+identity of arXiv:1606.00608, lines 1490--1493, linear independence of the
+closed sector tensors and the trace normalization give the rank-one
+factorization T_{k,h} = a_k b_h with sum_k a_k b_k = 1 (Lemma SALZCL,
+lines 1484--1499).  Unlike the positive-semidefinite variant
+`MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`, the constant trace
+powers are derived, not assumed.
+
+**Scope restriction (linear independence):** the source lemma neither assumes
+nor derives linear independence of the sector tensors; documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
+by `SectorPairingData.linearIndependent_l` from a block-support
+decomposition. -/
+theorem sal_zcl_implies_rank_one_T_of_pairing_idempotent
+    {V : Type*} [AddCommGroup V] [Module ℝ V]
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (data : SectorPairingData T V)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hl : LinearIndependent ℝ data.l)
+    (hTrace : Matrix.trace T = 1) :
+    ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 :=
+  sal_zcl_implies_rank_one_T T hPrimitive hTrace (data.tracePowersConstant hl)
+    fun _ _ => Matrix.hasRankOneFactorization_of_mul_self_eq_self
+      (data.mul_self_eq_self hl) hTrace
+
+/-- **Lemma C.5, block-support form**: the rank-one factorization of the
+sector trace matrix with the linear independence of the closed sector tensors
+derived, rather than assumed, from primitivity and a block-support
+decomposition.
+
+**Scope restriction (block supports):** the subspace family carrying the
+closed sector tensors is not displayed in arXiv:1606.00608; documented in
+`docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
+theorem sal_zcl_implies_rank_one_T_of_sector_supports
+    {V : Type*} [AddCommGroup V] [Module ℝ V]
+    (T : Matrix (Fin n) (Fin n) ℝ)
+    (data : SectorPairingData T V)
+    (support : Fin n → Submodule ℝ V)
+    (hmem : ∀ k, data.l k ∈ support k)
+    (hsupp : iSupIndep support)
+    (hPrimitive : Matrix.IsPrimitive T)
+    (hTrace : Matrix.trace T = 1) :
+    ∃ a b : Fin n → ℝ, T = Matrix.vecMulVec a b ∧ a ⬝ᵥ b = 1 :=
+  sal_zcl_implies_rank_one_T_of_pairing_idempotent T data hPrimitive
+    (data.linearIndependent_l support hmem hsupp hPrimitive) hTrace
 
 end RankOneT
 

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -64,8 +64,8 @@ arXiv:1606.00608 (Cirac–Pérez-García–Schuch–Verstraete).
 - `MPOTensor.SectorPairingData.mul_self_eq_self` /
   `MPOTensor.SectorPairingData.linearIndependent_l`: idempotence of the sector
   trace matrix from the zero-correlation-length identity, and linear
-  independence of the sector tensors from primitivity and a block-support
-  decomposition.
+  independence of the sector tensors from primitivity and an independent
+  family of subspaces containing each sector tensor.
 - `MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent` /
   `MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports`: the rank-one
   factorization at lines 1484--1499, derived from the zero-correlation-length
@@ -569,8 +569,8 @@ arXiv:1606.00608, lines 1484--1499 neither assumes nor derives
 linear independence of the sector tensors; see the marker on
 `Matrix.mul_self_eq_self_of_pairing_idempotent` and
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
-by `SectorPairingData.linearIndependent_l` once the sector tensors carry a
-block-support decomposition. -/
+by `SectorPairingData.linearIndependent_l` once each sector tensor lies in the
+corresponding member of an independent family of subspaces. -/
 theorem mul_self_eq_self (data : SectorPairingData T V)
     (hl : LinearIndependent ℝ data.l) : T * T = T :=
   Matrix.mul_self_eq_self_of_pairing_idempotent data.pairing hl
@@ -598,12 +598,12 @@ theorem l_ne_zero (data : SectorPairingData T V)
   rw [data.pairing j k, hzero, map_zero] at hj
   exact lt_irrefl 0 hj
 
-/-- Linear independence of the closed sector tensors from a block-support
-decomposition: if each $|l_k)$ lies in its own member of an independent family
-of subspaces of $V$ and the sector trace matrix is primitive, then the family
-$|l_k)$ is linearly independent.
+/-- Linear independence of the closed sector tensors from an independent family
+of subspaces: if each $|l_k)$ lies in the corresponding member of an independent
+family of subspaces of $V$ and the sector trace matrix is primitive, then the
+family $|l_k)$ is linearly independent.
 
-**Scope restriction (block supports):** the subspace family is not displayed
+**Scope restriction (independent subspaces):** the subspace family is not displayed
 in arXiv:1606.00608. Lines 1436--1448 give a sector splitting of the physical
 indices, but the closed tensors $|l_k)$ at lines 1473--1477 live in a common
 bond space after the physical sector legs are contracted. Whether the
@@ -629,15 +629,15 @@ $T_{k,h}=a_kb_h$ with $\sum_k a_kb_k=1$, the conclusion at lines 1484--1499.
 Unlike the positive-semidefinite variant
 `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`, the constant trace
 powers are derived, not assumed. Primitivity of $T$ is not needed once linear
-independence is assumed. It enters the block-support form
+independence is assumed. It enters the independent-subspace form
 `MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports`, where it makes
 the closed sector tensors nonzero.
 
 **Scope restriction (linear independence):** the source lemma neither assumes
 nor derives linear independence of the sector tensors; documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
-by `SectorPairingData.linearIndependent_l` from a block-support
-decomposition. -/
+by `SectorPairingData.linearIndependent_l` when each sector tensor lies in the
+corresponding member of an independent family of subspaces. -/
 theorem sal_zcl_implies_rank_one_T_of_pairing_idempotent
     {V : Type*} [AddCommGroup V] [Module ℝ V]
     (T : Matrix (Fin n) (Fin n) ℝ)
@@ -656,9 +656,9 @@ theorem sal_zcl_implies_rank_one_T_of_pairing_idempotent
 
 This is the rank-one conclusion at arXiv:1606.00608, lines 1484--1499, with
 linear independence of the closed sector tensors derived from primitivity and
-a block-support decomposition.
+an independent family of subspaces containing the respective sector tensors.
 
-**Scope restriction (block supports):** the subspace family carrying the
+**Scope restriction (independent subspaces):** the subspace family carrying the
 closed sector tensors is not displayed in arXiv:1606.00608; documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
 theorem sal_zcl_implies_rank_one_T_of_sector_supports

--- a/TNLean/MPS/MPDO/SimpleLocalStructure.lean
+++ b/TNLean/MPS/MPDO/SimpleLocalStructure.lean
@@ -504,41 +504,36 @@ theorem sal_zcl_implies_rank_one_T_of_posSemidef
 /-! ### Sector tensors and the pairing route to rank one
 
 Appendix C.2 of arXiv:1606.00608 obtains the sector trace matrix by pairing
-sector tensors: after the isometry `U`, the injective simple tensor splits
-as a direct sum over sectors `k` of pairs `l_k`, `r_k` (eq. formK,
-lines 1436--1448), the closed tensors `|l_k)` and `(r_k|` pair to
-T_{k,h} = (r_k|l_h) (eq. lkrk and eq. Tkn, lines 1473--1482), and the
-zero-correlation-length identity displayed in the proof of Lemma SALZCL
-(lines 1490--1493) states that the operator sum_k |l_k)(r_k| equals its own
-square.  The declarations below record this pairing and derive the rank-one
-factorization of `T` through
+sector tensors. After the isometry $U$, the injective simple tensor splits as
+a direct sum over sectors $k$ of pairs $l_k,r_k$ at lines 1436--1448. The
+closed tensors $|l_k)$ and $(r_k|$ pair to $T_{k,h}=(r_k|l_h)$ at lines
+1473--1482. The zero-correlation-length identity at lines 1490--1493 states
+that the operator $\sum_k |l_k)(r_k|$ equals its own square. The declarations
+below record this pairing and derive the rank-one factorization of $T$ through
 `Matrix.mul_self_eq_self_of_pairing_idempotent`. -/
 
 /-- The sector tensors of arXiv:1606.00608, Appendix C.2, paired into the
-sector trace matrix `T`.
+sector trace matrix $T$.
 
-The vector space `V` carries the closed sector tensors `|l_k)` and the
-functionals `(r_k|` of eq. lkrk (lines 1473--1477).  The two recorded
-identities are the paper's displayed equations: the pairing
-T_{k,h} = (r_k|l_h) of eq. Tkn (lines 1478--1482) and the
-zero-correlation-length identity in the proof of Lemma SALZCL
-(lines 1490--1493).  The construction of these families from an injective
-simple tensor is the content of Lemma propSN (eq. formK, lines 1436--1448)
-and is not yet formalized; see the module docstring. -/
+The vector space $V$ carries the closed sector tensors $|l_k)$ and the
+functionals $(r_k|$ at lines 1473--1477. The recorded identities are the
+pairing $T_{k,h}=(r_k|l_h)$ at lines 1478--1482 and the
+zero-correlation-length identity at lines 1490--1493. Constructing these
+families from the injective simple tensor factorization at lines 1436--1448
+remains open; see the module docstring. -/
 structure SectorPairingData (T : Matrix (Fin n) (Fin n) ℝ)
     (V : Type*) [AddCommGroup V] [Module ℝ V] where
-  /-- The closed sector tensors `|l_k)`; arXiv:1606.00608, eq. lkrk,
-  lines 1473--1477. -/
+  /-- The closed sector tensors $|l_k)$; arXiv:1606.00608, lines 1473--1477. -/
   l : Fin n → V
-  /-- The closed sector functionals `(r_k|`; arXiv:1606.00608, eq. lkrk,
+  /-- The closed sector functionals $(r_k|$; arXiv:1606.00608,
   lines 1473--1477. -/
   r : Fin n → Module.Dual ℝ V
-  /-- The pairing identity T_{k,h} = (r_k|l_h); arXiv:1606.00608, eq. Tkn,
+  /-- The pairing identity $T_{k,h}=(r_k|l_h)$; arXiv:1606.00608,
   lines 1478--1482. -/
   pairing : ∀ k h, T k h = r k (l h)
   /-- The zero-correlation-length identity
-  sum_k |l_k)(r_k| = sum_{k,h} T_{k,h} |l_k)(r_h|, evaluated on a vector;
-  arXiv:1606.00608, proof of Lemma SALZCL, lines 1490--1493. -/
+  $\sum_k |l_k)(r_k|=\sum_{k,h}T_{k,h}|l_k)(r_h|$, evaluated on a vector;
+  arXiv:1606.00608, lines 1490--1493. -/
   zcl : ∀ v : V, ∑ k, r k v • l k = ∑ k, ∑ h, (T k h * r h v) • l k
 
 namespace SectorPairingData
@@ -546,10 +541,10 @@ namespace SectorPairingData
 variable {T : Matrix (Fin n) (Fin n) ℝ} {V : Type*} [AddCommGroup V] [Module ℝ V]
 
 /-- The zero-correlation-length identity makes the pairing operator
-sum_k |l_k)(r_k| equal to its own square: the right-hand side of the displayed
-identity of arXiv:1606.00608, lines 1490--1493, expands to the square of its
-left-hand side once the coefficients T_{k,h} are replaced by the pairing
-(r_k|l_h) of eq. Tkn. -/
+$\sum_k |l_k)(r_k|$ equal to its own square. The right-hand side of the
+identity at lines 1490--1493 expands to this square after replacing
+$T_{k,h}$ by the pairing $(r_k|l_h)$ from lines 1478--1482 of
+arXiv:1606.00608. -/
 theorem pairing_operator_idempotent (data : SectorPairingData T V) (v : V) :
     ∑ k, data.r k (∑ j, data.r j v • data.l j) • data.l k
       = ∑ k, data.r k v • data.l k := by
@@ -567,10 +562,10 @@ theorem pairing_operator_idempotent (data : SectorPairingData T V) (v : V) :
     _ = ∑ k, data.r k v • data.l k := (data.zcl v).symm
 
 /-- **Idempotence of the sector trace matrix** for sector tensors satisfying
-the zero-correlation-length identity: `T * T = T`.
+the zero-correlation-length identity: $T^2=T$.
 
-**Scope restriction (linear independence):** the source lemma
-(arXiv:1606.00608, Lemma SALZCL, lines 1484--1499) neither assumes nor derives
+**Scope restriction (linear independence):** the source argument at
+arXiv:1606.00608, lines 1484--1499 neither assumes nor derives
 linear independence of the sector tensors; see the marker on
 `Matrix.mul_self_eq_self_of_pairing_idempotent` and
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`.  The hypothesis `hl` is discharged
@@ -582,8 +577,8 @@ theorem mul_self_eq_self (data : SectorPairingData T V)
     data.pairing_operator_idempotent
 
 /-- The traces of all positive powers of the sector trace matrix agree with
-its trace: the display tr(T^N) = tr(T) of arXiv:1606.00608, lines 1494--1497,
-recovered from idempotence.
+its trace: $\operatorname{tr}(T^N)=\operatorname{tr}(T)$ for $N\geq 1$, as at
+arXiv:1606.00608, lines 1494--1497, recovered from idempotence.
 
 **Scope restriction (linear independence):** inherited from
 `SectorPairingData.mul_self_eq_self`; documented in
@@ -593,9 +588,9 @@ theorem tracePowersConstant (data : SectorPairingData T V)
   Matrix.tracePowersConstant_of_mul_self_eq_self (data.mul_self_eq_self hl)
 
 /-- Primitivity of the sector trace matrix makes every closed sector tensor
-`|l_k)` nonzero: some entry of the `k`-th column of `T` is positive, and that
-entry is the pairing of `|l_k)` against a functional (arXiv:1606.00608,
-eq. Tkn, lines 1478--1482). -/
+$|l_k)$ nonzero: some entry of column $k$ of $T$ is positive, and that entry
+is the pairing of $|l_k)$ against a functional (arXiv:1606.00608,
+lines 1478--1482). -/
 theorem l_ne_zero (data : SectorPairingData T V)
     (hPrimitive : Matrix.IsPrimitive T) (k : Fin n) : data.l k ≠ 0 := by
   intro hzero
@@ -604,16 +599,16 @@ theorem l_ne_zero (data : SectorPairingData T V)
   exact lt_irrefl 0 hj
 
 /-- Linear independence of the closed sector tensors from a block-support
-decomposition: if each `|l_k)` lies in its own member of an independent family
-of subspaces of `V` and the sector trace matrix is primitive, then the family
-`|l_k)` is linearly independent.
+decomposition: if each $|l_k)$ lies in its own member of an independent family
+of subspaces of $V$ and the sector trace matrix is primitive, then the family
+$|l_k)$ is linearly independent.
 
 **Scope restriction (block supports):** the subspace family is not displayed
-in arXiv:1606.00608; eq. formK (lines 1436--1448) gives the sector splitting
-of the physical indices, but the closed tensors `|l_k)` of eq. lkrk live in a
-common bond space after the physical sector legs are contracted.  Whether the
-inverse-map construction of Lemma propSN supplies such supports, or the
-independence by other means, remains open; documented in
+in arXiv:1606.00608. Lines 1436--1448 give a sector splitting of the physical
+indices, but the closed tensors $|l_k)$ at lines 1473--1477 live in a common
+bond space after the physical sector legs are contracted. Whether the
+inverse-map construction supplies such supports, or proves independence by
+another argument, remains open; documented in
 `docs/paper-gaps/cpgsv17_pf_rank_one.tex`. -/
 theorem linearIndependent_l (data : SectorPairingData T V)
     (support : Fin n → Submodule ℝ V)
@@ -625,16 +620,16 @@ theorem linearIndependent_l (data : SectorPairingData T V)
 
 end SectorPairingData
 
-/-- **Lemma C.5, pairing-idempotence form**: for a sector trace matrix `T`
-paired from sector tensors that satisfy the zero-correlation-length identity
-of arXiv:1606.00608, lines 1490--1493, linear independence of the closed
-sector tensors and the trace normalization give the rank-one factorization
-T_{k,h} = a_k b_h with sum_k a_k b_k = 1 (Lemma SALZCL, lines 1484--1499).
+/-- **Rank one from sector-pairing idempotence.**
+
+For a sector trace matrix $T$ paired from sector tensors satisfying the
+zero-correlation-length identity at arXiv:1606.00608, lines 1490--1493,
+linear independence and trace normalization give
+$T_{k,h}=a_kb_h$ with $\sum_k a_kb_k=1$, the conclusion at lines 1484--1499.
 Unlike the positive-semidefinite variant
 `MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef`, the constant trace
-powers are derived, not assumed.  The primitivity of `T`, supplied in the
-source by Lemma propSN, is not needed once the independence is assumed; it
-enters the block-support form
+powers are derived, not assumed. Primitivity of $T$ is not needed once linear
+independence is assumed. It enters the block-support form
 `MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports`, where it makes
 the closed sector tensors nonzero.
 
@@ -657,10 +652,11 @@ theorem sal_zcl_implies_rank_one_T_of_pairing_idempotent
   rw [← Matrix.trace_vecMulVec, ← hT]
   exact hTrace
 
-/-- **Lemma C.5, block-support form**: the rank-one factorization of the
-sector trace matrix with the linear independence of the closed sector tensors
-derived, rather than assumed, from primitivity and a block-support
-decomposition.
+/-- **Rank one from independent sector supports.**
+
+This is the rank-one conclusion at arXiv:1606.00608, lines 1484--1499, with
+linear independence of the closed sector tensors derived from primitivity and
+a block-support decomposition.
 
 **Scope restriction (block supports):** the subspace family carrying the
 closed sector tensors is not displayed in arXiv:1606.00608; documented in

--- a/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_blocked_rfp.tex
@@ -16,17 +16,24 @@
 \begin{theorem}[Local simple-MPDO structure from entropy data and the rank-one criterion]
     \label{thm:simple_mpdo_local_structure_data_of_sal_zcl}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCL}
+    \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent}
     \lean{MPOTensor.SimpleMPDOLocalStructureData.ofSALZCLOfPosSemidef}
     \leanok
     \uses{def:simple_mpdo_local_structure_data, thm:sal_implies_eta_structure,
-        thm:sal_zcl_implies_rank_one_t, thm:psd_trace_powers_rank_one_t}
+        thm:sal_zcl_implies_rank_one_t, thm:psd_trace_powers_rank_one_t,
+        thm:pairing_idempotent_rank_one_t}
     The hypotheses of \cite[Lemmas~C.2, C.4, and~C.5]{Cirac2016MPDO_arXiv}
     determine the local simple-MPDO
-    structure. There are two forms. The conditional form assumes the
+    structure. There are three forms. The conditional form assumes the
     rank-one implication for $T$. The corrected form assumes instead that
     $T\ge 0$ as a matrix, with $\operatorname{tr}(T)=1$ and
     $\operatorname{tr}(T^m)=1$ for every $m>0$, and then applies
-    Theorem~\ref{thm:psd_trace_powers_rank_one_t}.
+    Theorem~\ref{thm:psd_trace_powers_rank_one_t}. The pairing-idempotence
+    form assumes that $T$ is the sector trace matrix of linearly independent
+    sector tensors satisfying the zero-correlation-length identity, with
+    $\operatorname{tr}(T)=1$, and then applies
+    Theorem~\ref{thm:pairing_idempotent_rank_one_t}; the constant trace powers
+    are derived rather than assumed.
 \end{theorem}
 
 \begin{definition}[Simple-MPDO blocked doubled-index structure]

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -360,9 +360,12 @@ strong subadditivity for a normalized three-site reduced state.
     \[
         (T^{m})_{k,k} = \sum_j T_{k,j} (T^{m-1})_{j,k} = 0,
     \]
-    contradicting the strict entrywise positivity of some power of $T$. The
-    column statement follows by the symmetric factorization
-    $T^{m} = T^{m-1} T$.
+    contradicting the strict entrywise positivity of some power of $T$.
+    Likewise, if column $h$ of $T$ vanishes, then for every $m \geq 1$,
+    \[
+        (T^{m})_{h,h} = \sum_j (T^{m-1})_{h,j}\, T_{j,h} = 0,
+    \]
+    again contradicting the strict positivity of some power of $T$.
 \end{proof}
 
 \begin{theorem}[Idempotence of the sector trace matrix]
@@ -507,8 +510,8 @@ strong subadditivity for a normalized three-site reduced state.
     \lean{MPOTensor.SectorPairingData}
     \leanok
     For a real $n \times n$ matrix $T$ and a real vector space $V$, this
-    structure consists of vectors $|l_1), \dots, |l_n) \in V$ and linear
-    functionals $(r_1|, \dots, (r_n|$ on $V$ satisfying the pairing identity
+    structure consists of vectors $|l_0), \dots, |l_{n-1}) \in V$ and linear
+    functionals $(r_0|, \dots, (r_{n-1}|$ on $V$ satisfying the pairing identity
     \[
         T_{k,h} = (r_k|l_h)
     \]
@@ -522,7 +525,7 @@ strong subadditivity for a normalized three-site reduced state.
     splitting of an injective simple tensor.
 \end{definition}
 
-\begin{theorem}[Idempotence of a primitively paired sector trace matrix]
+\begin{theorem}[Idempotence of the sector trace matrix from the zero-correlation-length identity]
     \label{thm:mpdo_sector_pairing_idempotent}
     \lean{MPOTensor.SectorPairingData.pairing_operator_idempotent}
     \lean{MPOTensor.SectorPairingData.mul_self_eq_self}
@@ -532,7 +535,7 @@ strong subadditivity for a normalized three-site reduced state.
     For sector tensors paired into $T$ as in
     Definition~\ref{def:mpdo_sector_pairing_data}, the operator
     $M = \sum_k |l_k)(r_k|$ satisfies $M^2 = M$. If in addition the vectors
-    $|l_1), \dots, |l_n)$ are linearly independent, then $T^2 = T$, and for
+    $|l_0), \dots, |l_{n-1})$ are linearly independent, then $T^2 = T$, and for
     every positive integer $N$,
     \[
         \operatorname{tr}(T^N) = \operatorname{tr}(T).
@@ -567,7 +570,7 @@ strong subadditivity for a normalized three-site reduced state.
     Definition~\ref{def:mpdo_sector_pairing_data} is primitive. Then every
     closed sector tensor satisfies $|l_k) \neq 0$. If moreover each $|l_k)$
     lies in its own member of an independent family of subspaces of $V$, then
-    the vectors $|l_1), \dots, |l_n)$ are linearly independent.
+    the vectors $|l_0), \dots, |l_{n-1})$ are linearly independent.
 \end{theorem}
 
 \begin{proof}
@@ -579,25 +582,25 @@ strong subadditivity for a normalized three-site reduced state.
     family of subspaces, one from each member, are linearly independent.
 \end{proof}
 
-\begin{theorem}[SAL and ZCL imply rank-one $T$ (pairing-idempotence form)]
+\begin{theorem}[Rank one from sector-pairing idempotence under linear independence]
     \label{thm:pairing_idempotent_rank_one_t}
     \lean{MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent}
     \lean{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}
     \leanok
     \uses{def:mpdo_sector_pairing_data, def:matrix_trace_rankone_predicates}
-    Let $T$ be a primitive sector trace matrix with $\operatorname{tr}(T)=1$,
-    paired from sector tensors satisfying the zero-correlation-length identity
-    of Definition~\ref{def:mpdo_sector_pairing_data}. If the closed sector
-    tensors $|l_1), \dots, |l_n)$ are linearly independent --- in particular,
-    if they lie in distinct members of an independent family of subspaces ---
-    then
+    Let $T$ be a sector trace matrix with $\operatorname{tr}(T)=1$, paired
+    from sector tensors satisfying the zero-correlation-length identity of
+    Definition~\ref{def:mpdo_sector_pairing_data}. If the closed sector
+    tensors $|l_0), \dots, |l_{n-1})$ are linearly independent, then
     \[
         T_{k,h} = a_k b_h,
         \qquad
         \sum_k a_k b_k = 1
     \]
-    for some real numbers $a_k, b_h$. In contrast with the
-    positive-semidefinite criterion of
+    for some real numbers $a_k, b_h$. The same conclusion holds if, instead
+    of the independence, $T$ is primitive and the closed sector tensors lie
+    in distinct members of an independent family of subspaces. In contrast
+    with the positive-semidefinite criterion of
     Theorem~\ref{thm:psd_trace_powers_rank_one_t}, the constant trace powers
     are derived rather than assumed.
 \end{theorem}
@@ -606,8 +609,7 @@ strong subadditivity for a normalized three-site reduced state.
     \leanok
     \uses{thm:mpdo_sector_pairing_idempotent,
         thm:mpdo_sector_tensors_independent,
-        thm:matrix_idempotent_trace_one_rank_one,
-        thm:sal_zcl_implies_rank_one_t}
+        thm:matrix_idempotent_trace_one_rank_one}
     Theorem~\ref{thm:mpdo_sector_pairing_idempotent} gives $T^2 = T$ and the
     constant trace powers. The idempotent trace-one criterion of
     Theorem~\ref{thm:matrix_idempotent_trace_one_rank_one} yields the

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -547,14 +547,20 @@ strong subadditivity for a normalized three-site reduced state.
     \uses{thm:matrix_pairing_idempotent,
         thm:matrix_idempotent_trace_powers_constant}
     Substituting $T_{k,h} = (r_k|l_h)$ into the right-hand side of the
-    zero-correlation-length identity exhibits it as the square of the
-    left-hand side, so $M^2 = M$. Linear independence of the $|l_k)$ then
+    zero-correlation-length identity gives, for every $v \in V$,
+    \[
+        \sum_{k,h} T_{k,h}(r_h|v)\,|l_k)
+        = \sum_{k,h} (r_k|l_h)(r_h|v)\,|l_k)
+        = \sum_k (r_k|Mv)\,|l_k)
+        = M^2 v,
+    \]
+    so $M^2 = M$. Linear independence of the $|l_k)$ then
     gives $T^2 = T$ by Theorem~\ref{thm:matrix_pairing_idempotent}, and
     idempotence gives the constant trace powers by
     Theorem~\ref{thm:matrix_idempotent_trace_powers_constant}.
 \end{proof}
 
-% Scope restriction (block supports): the independent subspace family in the
+% Scope restriction (independent subspaces): the independent subspace family in the
 % second statement is not displayed in arXiv:1606.00608; the closed sector
 % tensors of that construction live in a common bond space after the physical
 % sector legs are contracted. Whether the inverse-map construction supplies

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -616,5 +616,6 @@ strong subadditivity for a normalized three-site reduced state.
     factorization $T = a b^\top$, and taking traces gives
     $\sum_k a_k b_k = \operatorname{tr}(T) = 1$. When the independence is not
     assumed directly, Theorem~\ref{thm:mpdo_sector_tensors_independent}
-    derives it from primitivity and the block supports.
+    derives it from primitivity once each sector tensor lies in its own member
+    of an independent family of subspaces.
 \end{proof}

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -325,6 +325,46 @@ strong subadditivity for a normalized three-site reduced state.
     and therefore $T=ab^\top$.
 \end{proof}
 
+\begin{theorem}[Constant trace powers of an idempotent matrix]
+    \label{thm:matrix_idempotent_trace_powers_constant}
+    \lean{Matrix.tracePowersConstant_of_mul_self_eq_self}
+    \leanok
+    \uses{def:matrix_trace_rankone_predicates}
+    Let $T$ be a finite real square matrix with $T^2 = T$. Then for every
+    positive integer $N$,
+    \[
+        \operatorname{tr}(T^N) = \operatorname{tr}(T).
+    \]
+    This recovers the trace identity displayed in the proof of
+    \cite[Appendix~C.2, Lemma~C.5]{Cirac2016MPDO_arXiv} from idempotence.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    Induction on $N$: for $N \geq 1$,
+    $T^{N+1} = T^{N} T = T T = T$, so every positive power of $T$ equals $T$.
+\end{proof}
+
+\begin{theorem}[Positive entries in every row and column of a primitive matrix]
+    \label{thm:matrix_primitive_row_col_pos}
+    \lean{Matrix.IsPrimitive.exists_row_pos}
+    \lean{Matrix.IsPrimitive.exists_col_pos}
+    \leanok
+    Let $T$ be a primitive non-negative matrix. Then every row of $T$ contains
+    a strictly positive entry, and so does every column.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    If row $k$ of $T$ vanishes, then for every $m \geq 1$,
+    \[
+        (T^{m})_{k,k} = \sum_j T_{k,j} (T^{m-1})_{j,k} = 0,
+    \]
+    contradicting the strict entrywise positivity of some power of $T$. The
+    column statement follows by the symmetric factorization
+    $T^{m} = T^{m-1} T$.
+\end{proof}
+
 \begin{theorem}[Idempotence of the sector trace matrix]
     \label{thm:matrix_pairing_idempotent}
     \lean{Matrix.mul_self_eq_self_of_pairing_idempotent}
@@ -460,4 +500,119 @@ strong subadditivity for a normalized three-site reduced state.
     supplies the auxiliary rank-one criterion. The conditional statement of
     \cite[Lemma~C.5]{Cirac2016MPDO_arXiv} then gives the factorization and
     trace normalization.
+\end{proof}
+
+\begin{definition}[Sector tensors paired into the sector trace matrix]
+    \label{def:mpdo_sector_pairing_data}
+    \lean{MPOTensor.SectorPairingData}
+    \leanok
+    For a real $n \times n$ matrix $T$ and a real vector space $V$, this
+    structure consists of vectors $|l_1), \dots, |l_n) \in V$ and linear
+    functionals $(r_1|, \dots, (r_n|$ on $V$ satisfying the pairing identity
+    \[
+        T_{k,h} = (r_k|l_h)
+    \]
+    of \cite[Appendix~C.2]{Cirac2016MPDO_arXiv} together with the
+    zero-correlation-length identity
+    \[
+        \sum_k |l_k)(r_k| = \sum_{k,h} T_{k,h}\, |l_k)(r_h|
+    \]
+    displayed in the proof of \cite[Lemma~C.5]{Cirac2016MPDO_arXiv}. The
+    vectors are the closed sector tensors obtained there from the sector
+    splitting of an injective simple tensor.
+\end{definition}
+
+\begin{theorem}[Idempotence of a primitively paired sector trace matrix]
+    \label{thm:mpdo_sector_pairing_idempotent}
+    \lean{MPOTensor.SectorPairingData.pairing_operator_idempotent}
+    \lean{MPOTensor.SectorPairingData.mul_self_eq_self}
+    \lean{MPOTensor.SectorPairingData.tracePowersConstant}
+    \leanok
+    \uses{def:mpdo_sector_pairing_data}
+    For sector tensors paired into $T$ as in
+    Definition~\ref{def:mpdo_sector_pairing_data}, the operator
+    $M = \sum_k |l_k)(r_k|$ satisfies $M^2 = M$. If in addition the vectors
+    $|l_1), \dots, |l_n)$ are linearly independent, then $T^2 = T$, and for
+    every positive integer $N$,
+    \[
+        \operatorname{tr}(T^N) = \operatorname{tr}(T).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:matrix_pairing_idempotent,
+        thm:matrix_idempotent_trace_powers_constant}
+    Substituting $T_{k,h} = (r_k|l_h)$ into the right-hand side of the
+    zero-correlation-length identity exhibits it as the square of the
+    left-hand side, so $M^2 = M$. Linear independence of the $|l_k)$ then
+    gives $T^2 = T$ by Theorem~\ref{thm:matrix_pairing_idempotent}, and
+    idempotence gives the constant trace powers by
+    Theorem~\ref{thm:matrix_idempotent_trace_powers_constant}.
+\end{proof}
+
+% Scope restriction (block supports): the independent subspace family in the
+% second statement is not displayed in arXiv:1606.00608; the closed sector
+% tensors of that construction live in a common bond space after the physical
+% sector legs are contracted. Whether the inverse-map construction supplies
+% such supports, or the linear independence by other means, remains open.
+% Recorded in docs/paper-gaps/cpgsv17_pf_rank_one.tex.
+\begin{theorem}[Nonvanishing and independence of the sector tensors]
+    \label{thm:mpdo_sector_tensors_independent}
+    \lean{MPOTensor.SectorPairingData.l_ne_zero}
+    \lean{MPOTensor.SectorPairingData.linearIndependent_l}
+    \leanok
+    \uses{def:mpdo_sector_pairing_data, thm:matrix_primitive_row_col_pos}
+    Suppose the sector trace matrix $T$ of
+    Definition~\ref{def:mpdo_sector_pairing_data} is primitive. Then every
+    closed sector tensor satisfies $|l_k) \neq 0$. If moreover each $|l_k)$
+    lies in its own member of an independent family of subspaces of $V$, then
+    the vectors $|l_1), \dots, |l_n)$ are linearly independent.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:matrix_primitive_row_col_pos}
+    By Theorem~\ref{thm:matrix_primitive_row_col_pos}, some entry of the
+    $k$-th column of $T$ is positive, and that entry is the pairing
+    $(r_j|l_k)$, so $|l_k) \neq 0$. Nonzero vectors chosen from an independent
+    family of subspaces, one from each member, are linearly independent.
+\end{proof}
+
+\begin{theorem}[SAL and ZCL imply rank-one $T$ (pairing-idempotence form)]
+    \label{thm:pairing_idempotent_rank_one_t}
+    \lean{MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent}
+    \lean{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}
+    \leanok
+    \uses{def:mpdo_sector_pairing_data, def:matrix_trace_rankone_predicates}
+    Let $T$ be a primitive sector trace matrix with $\operatorname{tr}(T)=1$,
+    paired from sector tensors satisfying the zero-correlation-length identity
+    of Definition~\ref{def:mpdo_sector_pairing_data}. If the closed sector
+    tensors $|l_1), \dots, |l_n)$ are linearly independent --- in particular,
+    if they lie in distinct members of an independent family of subspaces ---
+    then
+    \[
+        T_{k,h} = a_k b_h,
+        \qquad
+        \sum_k a_k b_k = 1
+    \]
+    for some real numbers $a_k, b_h$. In contrast with the
+    positive-semidefinite criterion of
+    Theorem~\ref{thm:psd_trace_powers_rank_one_t}, the constant trace powers
+    are derived rather than assumed.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:mpdo_sector_pairing_idempotent,
+        thm:mpdo_sector_tensors_independent,
+        thm:matrix_idempotent_trace_one_rank_one,
+        thm:sal_zcl_implies_rank_one_t}
+    Theorem~\ref{thm:mpdo_sector_pairing_idempotent} gives $T^2 = T$ and the
+    constant trace powers. The idempotent trace-one criterion of
+    Theorem~\ref{thm:matrix_idempotent_trace_one_rank_one} yields the
+    factorization $T = a b^\top$, and taking traces gives
+    $\sum_k a_k b_k = \operatorname{tr}(T) = 1$. When the independence is not
+    assumed directly, Theorem~\ref{thm:mpdo_sector_tensors_independent}
+    derives it from primitivity and the block supports.
 \end{proof}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -27,9 +27,9 @@ counterexample was added in
 \href{https://github.com/LionSR/TNLean/pull/849}{pull request \#849}; and the
 positive-semidefinite replacement theorem was added in
 \href{https://github.com/LionSR/TNLean/pull/917}{pull request \#917}. The open
-follow-up --- supplying matrix-level positive-semidefiniteness of the sector
-trace matrix at the MPDO call site so the replacement theorem discharges the
-\texttt{hPF} shortcut --- is tracked in
+follow-up --- either supplying matrix-level positive semidefiniteness of the
+sector trace matrix, or completing the sector-pairing and linear-independence
+route described below --- is tracked in
 \href{https://github.com/LionSR/TNLean/issues/3593}{issue \#3593}. The
 source passage is
 \path{Papers/1606.00608/MPDO-22-12-17-2.tex:1394--1499}.}
@@ -176,53 +176,47 @@ established at the matrix product density operator call site.
 
 \subsection{The sector pairing at the matrix product density operator side}
 
-The formal development now states the paper's pairing on the matrix product
-density operator side.  The structure
-\leanid{MPOTensor.SectorPairingData} records vectors $|l_k)$ and functionals
-$(r_k|$ in an abstract real vector space together with the two displayed
-identities of the source: the pairing $T_{k,h}=(r_k|l_h)$
-\cite[Appendix~C.2, lines~1478--1482]{Cirac2016MPDO_arXiv} and the
-zero-correlation-length identity
+The formal development now records the paper's pairing on the matrix product
+density operator side.  In an abstract real vector space, let $|l_k)$ be the
+closed sector tensors and $(r_k|$ the corresponding functionals.  It assumes
+the two displayed identities of the source,
 \[
-  \sum_k |l_k)(r_k| = \sum_{k,h} T_{k,h} |l_k)(r_h|
+  T_{k,h}=(r_k|l_h),
+  \qquad
+  \sum_k |l_k)(r_k| = \sum_{k,h} T_{k,h}|l_k)(r_h|,
 \]
-\cite[Appendix~C.2, lines~1490--1493]{Cirac2016MPDO_arXiv}.  From this the
-development proves, in order: the pairing operator equals its own square
-(\leanid{MPOTensor.SectorPairingData.pairing_operator_idempotent}); with
-linearly independent $(l_k)_k$ the matrix identity $T^2=T$ and the constant
-trace powers of the source follow
-(\leanid{MPOTensor.SectorPairingData.mul_self_eq_self},
-\leanid{MPOTensor.SectorPairingData.tracePowersConstant}); primitivity of $T$
-makes every $|l_k)$ nonzero, because a primitive matrix has a positive entry
-in every row and column
-(\leanid{Matrix.IsPrimitive.exists_row_pos},
-\leanid{Matrix.IsPrimitive.exists_col_pos},
-\leanid{MPOTensor.SectorPairingData.l_ne_zero}); and nonzero vectors lying
-in distinct members of an independent family of subspaces are linearly
-independent
-(\leanid{MPOTensor.SectorPairingData.linearIndependent_l}).  The rank-one
-conclusion of Lemma~C.5, with the trace-power condition derived rather than
-assumed, is
-\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent}
-and, with the independence derived from block supports,
-\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}.
+from lines 1478--1493 of Appendix C.2.  These equations make the pairing
+operator $M=\sum_k|l_k)(r_k|$ idempotent.  If the vectors $(l_k)_k$ are
+linearly independent, then the coefficient map $L$ is injective and
+\[
+  L T^2=M^2L=ML=LT,
+\]
+so $T^2=T$.  Hence all positive powers of $T$ have the same trace; trace one
+then gives the rank-one factorization.  Primitivity separately makes each
+$|l_k)$ nonzero, so an independent family of subspaces carrying the vectors
+is sufficient to derive their linear independence.
+\footnote{The formal declarations are
+\path{MPOTensor.SectorPairingData.pairing_operator_idempotent},
+\path{MPOTensor.SectorPairingData.mul_self_eq_self},
+\path{MPOTensor.SectorPairingData.tracePowersConstant},
+\path{MPOTensor.SectorPairingData.l_ne_zero},
+\path{MPOTensor.SectorPairingData.linearIndependent_l},
+\path{MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent}, and
+\path{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}.}
 
-Two obligations remain before the conditional hypotheses disappear.
-First, the families $(l_k)_k$ and $(r_k)_k$ must be constructed from an
-injective simple tensor: this is the conclusion of Lemma~propSN
-\cite[Appendix~C.2, lines~1407--1471]{Cirac2016MPDO_arXiv}, whose
-inverse-map computation is not yet formalized, and it must produce the
-pairing and zero-correlation-length identities recorded in the structure.
-Second, the linear independence of the closed tensors $|l_k)$ must be
-derived.  The direct sum in the source's sector splitting
-\cite[Appendix~C.2, lines~1436--1448]{Cirac2016MPDO_arXiv} concerns the
-physical indices; the closed tensors $|l_k)$ obtained by contracting the
-physical sector legs live in a common bond space, so their block supports
---- or their independence by another argument --- do not follow from the
-displayed equations alone.  Until then the independence, or the subspace
-family carrying the $|l_k)$, remains an explicit hypothesis.
+Three obligations remain before the conditional hypotheses disappear.
+First, the inverse-map factorization at lines 1407--1482 must construct the
+families $(l_k)_k$ and $(r_k)_k$ from an injective simple tensor and prove the
+pairing $T_{k,h}=(r_k|l_h)$.  Second, zero correlation length must be used to
+derive the operator identity at lines 1490--1493 for those concrete families;
+the present structure records this identity as data.  Third, linear
+independence of the closed tensors must be proved.  The direct sum in the
+source's sector splitting at lines 1436--1448 concerns the physical indices;
+after those indices are contracted, the closed tensors live in a common bond
+space.  Their block supports --- or their independence by another argument ---
+therefore do not follow from the displayed equations alone.
 
-\section{The corrected statement}
+\section{A positive-semidefinite route}
 
 The formal development proves a corrected sufficient matrix theorem. Let $T$
 be a finite real square matrix. If $T$ is positive semidefinite,
@@ -312,14 +306,18 @@ primitive entrywise non-negative matrix with constant traces of positive powers
 need not have rank one. The obstruction is a nilpotent Jordan component at the
 zero eigenvalue, which is not detected by the trace identities.
 
-The formal development proves a corrected sufficient theorem: positive
-semidefiniteness, trace normalization, and the same trace-power hypothesis imply
-the required rank-one factorization. What remains for the unconditional MPDO
-argument is not another Perron--Frobenius statement for arbitrary non-negative
-matrices, but an MPDO-specific proof that the trace matrix obtained from the
-$\eta$-operators has the Hermitian or positive-semidefinite structure needed by
-the corrected theorem. Thus the source proof has a genuine unsupported
-intermediate assertion, while the intended MPDO theorem itself has not been
+The formal development now proves two corrected sufficient theorems.  The
+first derives the rank-one factorization from positive semidefiniteness, trace
+normalization, and the trace-power identities.  The second derives
+$T^2=T$ from the sector-pairing identity and linear independence of the closed
+sector tensors; trace one then gives the same rank-one factorization directly.
+
+For the unconditional matrix product density operator argument, it therefore
+suffices either to prove the required positive-semidefinite structure of the
+trace matrix, or to construct the source sector pairing and derive the needed
+linear independence at the matrix product density operator call site.  The
+source proof has a genuine unsupported intermediate assertion, while the
+intended matrix product density operator theorem itself has not been
 disproved.
 
 \bibliographystyle{alpha}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -214,8 +214,9 @@ the present structure records this identity as data.  Third, linear
 independence of the closed tensors must be proved.  The direct sum in the
 source's sector splitting at lines 1436--1448 concerns the physical indices;
 after those indices are contracted, the closed tensors live in a common bond
-space.  Their block supports --- or their independence by another argument ---
-therefore do not follow from the displayed equations alone.
+space.  Their membership in corresponding members of an independent family of
+subspaces --- or their independence by another argument --- therefore does not
+follow from the displayed equations alone.
 
 \section{A positive-semidefinite route}
 

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -269,7 +269,7 @@ sector-reduced Hayashi--Markov family is defined by
 \]
 Since each reduced density matrix has trace one, its trace matrix is the
 all-ones matrix. The theorem
-\path{MPOTensor.ExplicitEtaOperators.traceMatrixRe_ofHayashiMarkov_posSemidef}
+{\scriptsize\leanid{MPOTensor.ExplicitEtaOperators.traceMatrixRe_ofHayashiMarkov_posSemidef}}
 proves its positive
 semidefiniteness. This does not discharge Lemma~C.5: the sector-reduced family
 has not been identified with the inverse-map family constructed in lines
@@ -292,12 +292,12 @@ identity, and linear independence. Positivity of each $\eta_{k,h}$ gives only
 $T_{k,h}\geq 0$ entry by entry, which implies neither matrix-level positive
 semidefiniteness nor Hermitian symmetry.
 \footnote{The entrywise nonnegativity result is
-\path{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}. The
+{\scriptsize\leanid{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}}. The
 positive-semidefinite reformulation for the rank-one conclusion is
-\path{MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef}. The corresponding
+{\scriptsize\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef}}. The corresponding
 blueprint entries have labels
-\path{thm:mpdo_explicit_eta_trace_matrix_nonneg} and
-\path{thm:psd_trace_powers_rank_one_t} in
+\texttt{\detokenize{thm:mpdo_explicit_eta_trace_matrix_nonneg}} and
+\texttt{\detokenize{thm:psd_trace_powers_rank_one_t}} in
 \path{blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex}.}
 
 \section{Conclusion}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -174,6 +174,54 @@ explicit hypothesis; whether the inverse-map construction supplies it ---
 for instance through the injectivity of $\mathcal{K}$ --- remains to be
 established at the matrix product density operator call site.
 
+\subsection{The sector pairing at the matrix product density operator side}
+
+The formal development now states the paper's pairing on the matrix product
+density operator side.  The structure
+\leanid{MPOTensor.SectorPairingData} records vectors $|l_k)$ and functionals
+$(r_k|$ in an abstract real vector space together with the two displayed
+identities of the source: the pairing $T_{k,h}=(r_k|l_h)$
+\cite[Appendix~C.2, lines~1478--1482]{Cirac2016MPDO_arXiv} and the
+zero-correlation-length identity
+\[
+  \sum_k |l_k)(r_k| = \sum_{k,h} T_{k,h} |l_k)(r_h|
+\]
+\cite[Appendix~C.2, lines~1490--1493]{Cirac2016MPDO_arXiv}.  From this the
+development proves, in order: the pairing operator equals its own square
+(\leanid{MPOTensor.SectorPairingData.pairing_operator_idempotent}); with
+linearly independent $(l_k)_k$ the matrix identity $T^2=T$ and the constant
+trace powers of the source follow
+(\leanid{MPOTensor.SectorPairingData.mul_self_eq_self},
+\leanid{MPOTensor.SectorPairingData.tracePowersConstant}); primitivity of $T$
+makes every $|l_k)$ nonzero, because a primitive matrix has a positive entry
+in every row and column
+(\leanid{Matrix.IsPrimitive.exists_row_pos},
+\leanid{Matrix.IsPrimitive.exists_col_pos},
+\leanid{MPOTensor.SectorPairingData.l_ne_zero}); and nonzero vectors lying
+in distinct members of an independent family of subspaces are linearly
+independent
+(\leanid{MPOTensor.SectorPairingData.linearIndependent_l}).  The rank-one
+conclusion of Lemma~C.5, with the trace-power condition derived rather than
+assumed, is
+\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent}
+and, with the independence derived from block supports,
+\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}.
+
+Two obligations remain before the conditional hypotheses disappear.
+First, the families $(l_k)_k$ and $(r_k)_k$ must be constructed from an
+injective simple tensor: this is the conclusion of Lemma~propSN
+\cite[Appendix~C.2, lines~1407--1471]{Cirac2016MPDO_arXiv}, whose
+inverse-map computation is not yet formalized, and it must produce the
+pairing and zero-correlation-length identities recorded in the structure.
+Second, the linear independence of the closed tensors $|l_k)$ must be
+derived.  The direct sum in the source's sector splitting
+\cite[Appendix~C.2, lines~1436--1448]{Cirac2016MPDO_arXiv} concerns the
+physical indices; the closed tensors $|l_k)$ obtained by contracting the
+physical sector legs live in a common bond space, so their block supports
+--- or their independence by another argument --- do not follow from the
+displayed equations alone.  Until then the independence, or the subspace
+family carrying the $|l_k)$, remains an explicit hypothesis.
+
 \section{The corrected statement}
 
 The formal development proves a corrected sufficient matrix theorem. Let $T$

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -154,9 +154,9 @@ the idempotence of $T^{\top}$, hence of $T$.  Together with the trace
 normalization $\operatorname{tr}(T)=1$ and the idempotent trace-one criterion
 above, this recovers the outer-product factorization asserted by
 Lemma~C.5.\footnote{The formal statements are
-\leanid{Matrix.mul_self_eq_self_of_pairing_idempotent},
-\leanid{Matrix.mul_self_eq_self_of_pairing_idempotent_dual}, and
-\leanid{Matrix.hasRankOneFactorization_of_pairing_idempotent} in
+\path{Matrix.mul_self_eq_self_of_pairing_idempotent},
+\path{Matrix.mul_self_eq_self_of_pairing_idempotent_dual}, and
+\path{Matrix.hasRankOneFactorization_of_pairing_idempotent} in
 \path{TNLean/Algebra/PerronFrobenius/RankOne.lean}, added in \ghpr{3685}.}
 
 The linear-independence hypothesis is a scope restriction relative to the
@@ -274,29 +274,28 @@ has not been identified with the inverse-map family constructed in lines
 1413--1455, and the trace of its all-ones matrix is the number of sectors, not
 one unless there is a single sector.
 
-The remaining argument must therefore use more of the MPDO construction than
-the separate inequalities $\eta_{k,h}\geq 0$. One possible completion is to
-derive an additional adjoint or Gram relation from the inverse-map tensors. If
-no such relation holds, the alternative is to combine the ZCL identity in
-lines 1489--1497 with injectivity and the tensor realization to rule out the
-nilpotent generalized zero-eigenspace directly. Positive semidefiniteness of
-the source trace matrix is not presently established by the cited passage.
+The positive-semidefinite route must therefore use more of the matrix product
+density operator construction than the separate inequalities
+$\eta_{k,h}\geq 0$. One possible completion is to derive an adjoint or Gram
+relation from the inverse-map tensors. Positive semidefiniteness of the source
+trace matrix is not presently established by the cited passage.
 
-This corrected theorem does not refute the intended MPDO result. It identifies
-a matrix-level hypothesis sufficient for the rank-one step. The remaining
-question is whether the trace matrix
-$T_{k,h}=\operatorname{tr}(\eta_{k,h})$ arising from the neighboring operators is
-Hermitian or positive semidefinite. Positivity of each $\eta_{k,h}$ gives
-$T_{k,h}=\operatorname{tr}(\eta_{k,h})\geq 0$ entry by entry, but entrywise
-nonnegativity is not matrix-level positive semidefiniteness or Hermitian
-symmetry of $T$.
+This corrected theorem does not refute the intended matrix product density
+operator result; it supplies one sufficient matrix-level hypothesis. For this
+route, the open question is whether the trace matrix
+$T_{k,h}=\operatorname{tr}(\eta_{k,h})$ is Hermitian or positive semidefinite.
+The pairing-idempotence route of Section~3.1 avoids that hypothesis, but instead
+requires the concrete sector pairing, the zero-correlation-length operator
+identity, and linear independence. Positivity of each $\eta_{k,h}$ gives only
+$T_{k,h}\geq 0$ entry by entry, which implies neither matrix-level positive
+semidefiniteness nor Hermitian symmetry.
 \footnote{The entrywise nonnegativity result is
-\leanid{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}. The
+\path{MPOTensor.ExplicitEtaOperators.traceMatrixRe_nonneg}. The
 positive-semidefinite reformulation for the rank-one conclusion is
-\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef}. The corresponding
+\path{MPOTensor.sal_zcl_implies_rank_one_T_of_posSemidef}. The corresponding
 blueprint entries have labels
-\texttt{thm:mpdo\_explicit\_eta\_trace\_matrix\_nonneg} and
-\texttt{thm:psd\_trace\_powers\_rank\_one\_t} in
+\path{thm:mpdo_explicit_eta_trace_matrix_nonneg} and
+\path{thm:psd_trace_powers_rank_one_t} in
 \path{blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex}.}
 
 \section{Conclusion}

--- a/docs/paper-gaps/cpgsv17_pf_rank_one.tex
+++ b/docs/paper-gaps/cpgsv17_pf_rank_one.tex
@@ -153,11 +153,11 @@ $(r_k)_k$ are linearly independent, the same argument in the dual space gives
 the idempotence of $T^{\top}$, hence of $T$.  Together with the trace
 normalization $\operatorname{tr}(T)=1$ and the idempotent trace-one criterion
 above, this recovers the outer-product factorization asserted by
-Lemma~C.5.\footnote{The formal statements are
-\path{Matrix.mul_self_eq_self_of_pairing_idempotent},
-\path{Matrix.mul_self_eq_self_of_pairing_idempotent_dual}, and
-\path{Matrix.hasRankOneFactorization_of_pairing_idempotent} in
-\path{TNLean/Algebra/PerronFrobenius/RankOne.lean}, added in \ghpr{3685}.}
+Lemma~C.5.\footnote{\sloppy The formal statements are
+{\scriptsize\leanid{Matrix.mul_self_eq_self_of_pairing_idempotent}},
+{\scriptsize\leanid{Matrix.mul_self_eq_self_of_pairing_idempotent_dual}}, and
+{\scriptsize\leanid{Matrix.hasRankOneFactorization_of_pairing_idempotent}} in
+\doclink{TNLean/Algebra/PerronFrobenius/RankOne}, added in \ghpr{3685}.}
 
 The linear-independence hypothesis is a scope restriction relative to the
 source.  Lemma~C.5 neither assumes nor derives it: the construction
@@ -195,14 +195,15 @@ so $T^2=T$.  Hence all positive powers of $T$ have the same trace; trace one
 then gives the rank-one factorization.  Primitivity separately makes each
 $|l_k)$ nonzero, so an independent family of subspaces carrying the vectors
 is sufficient to derive their linear independence.
-\footnote{The formal declarations are
-\path{MPOTensor.SectorPairingData.pairing_operator_idempotent},
-\path{MPOTensor.SectorPairingData.mul_self_eq_self},
-\path{MPOTensor.SectorPairingData.tracePowersConstant},
-\path{MPOTensor.SectorPairingData.l_ne_zero},
-\path{MPOTensor.SectorPairingData.linearIndependent_l},
-\path{MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent}, and
-\path{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}.}
+\footnote{\sloppy The formal declarations are
+{\scriptsize\leanid{MPOTensor.SectorPairingData.pairing_operator_idempotent}},
+{\scriptsize\leanid{MPOTensor.SectorPairingData.mul_self_eq_self}},
+{\scriptsize\leanid{MPOTensor.SectorPairingData.tracePowersConstant}},
+{\scriptsize\leanid{MPOTensor.SectorPairingData.l_ne_zero}},
+{\scriptsize\leanid{MPOTensor.SectorPairingData.linearIndependent_l}},
+{\scriptsize\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent}}, and
+{\scriptsize\leanid{MPOTensor.sal_zcl_implies_rank_one_T_of_sector_supports}} in
+\doclink{TNLean/MPS/MPDO/SimpleLocalStructure}.}
 
 Three obligations remain before the conditional hypotheses disappear.
 First, the inverse-map factorization at lines 1407--1482 must construct the


### PR DESCRIPTION
Partially addresses #3593.

## Summary

Connects the pairing-idempotence lemmas of #3685 to the MPDO side of Lemma C.5 (arXiv:1606.00608, Appendix C.2, Lemma `SALZCL`, lines 1484–1499). The sector tensors are now recorded as a structure whose fields are the paper's own displayed equations, and the rank-one factorization of the sector trace matrix is derived from them, with the trace-power condition derived rather than assumed.

## New declarations

`TNLean/Algebra/PerronFrobenius/RankOne.lean`:
- `Matrix.tracePowersConstant_of_mul_self_eq_self`: an idempotent matrix has constant traces of positive powers — the display $\operatorname{tr}(T^N)=\operatorname{tr}(T)$ (lines 1494–1497) recovered from idempotence.
- `Matrix.IsPrimitive.exists_row_pos` / `Matrix.IsPrimitive.exists_col_pos`: a primitive matrix has a positive entry in every row and in every column (a vanishing row or column would propagate to every power).

`TNLean/MPS/MPDO/SimpleLocalStructure.lean`:
- `MPOTensor.SectorPairingData`: the closed sector tensors $|l_k)$ and functionals $(r_k|$ (eq. `lkrk`, lines 1473–1477) with the pairing $T_{k,h}=(r_k|l_h)$ (eq. `Tkn`, lines 1478–1482) and the zero-correlation-length identity $\sum_k |l_k)(r_k| = \sum_{k,h} T_{k,h}\,|l_k)(r_h|$ (lines 1490–1493). Every field cites its source passage.
- `SectorPairingData.pairing_operator_idempotent`: the displayed identity makes the pairing operator equal to its own square.
- `SectorPairingData.mul_self_eq_self` / `tracePowersConstant`: with linearly independent $|l_k)$, the sector trace matrix satisfies $T^2 = T$ and has constant trace powers.
- `SectorPairingData.l_ne_zero` / `linearIndependent_l`: primitivity of $T$ makes every $|l_k)$ nonzero; if the $|l_k)$ lie in distinct members of an independent family of subspaces, they are linearly independent (via `iSupIndep.linearIndependent`).
- `MPOTensor.sal_zcl_implies_rank_one_T_of_pairing_idempotent` / `..._of_sector_supports`: the Lemma C.5 conclusion $T_{k,h}=a_k b_h$ with $\sum_k a_k b_k = 1$, as a third form beside the conditional (`hPF`) and positive-semidefinite variants; the second form derives the independence from primitivity and membership in an independent family of subspaces.

`TNLean/MPS/MPDO/BlockedRFPConstruction.lean`:
- `SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent`: the matching constructor beside `ofSALZCL` and `ofSALZCLOfPosSemidef`.

## Faithfulness

The linear independence of the closed sector tensors remains a **Scope restriction**, marked on every theorem that assumes it: the source proves primitivity of $T$ from injectivity of $\mathcal K$ (lines 1457–1470), which does not entail independence, and the closed tensors $|l_k)$ live in a common bond space after the physical sector legs are contracted, so membership in an independent family of subspaces does not follow from the displayed equations. `docs/paper-gaps/cpgsv17_pf_rank_one.tex` gains a subsection recording the new declarations and the two remaining obligations:

1. construct the families $(l_k)_k$, $(r_k)_k$ from an injective simple tensor with the pairing and zero-correlation-length identities — the inverse-map computation of Lemma `propSN` (lines 1407–1471), not yet formalized;
2. derive the linear independence of the $|l_k)$ (or exhibit the subspace family carrying them).

The existing `hPF`-conditional path and its Unfaithful markers are unchanged; they are removed only when both obligations close.

## Blueprint

New entries in `ch21_mpdo_rfp_simple_local_structure.tex` (constant trace powers of an idempotent matrix, positive row/column entries of a primitive matrix, the sector pairing definition, its idempotence and independence consequences, and the pairing-idempotence rank-one theorem); the third constructor form documented in `ch21_mpdo_rfp_blocked_rfp.tex`.

## Verification

- `lake build TNLean` — success, no new `sorry`/`axiom`
- `lake exe checkdecls blueprint/lean_decls` — pass
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync; reverse coverage check clean
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main --ci` — clean
- `lake exe lint_style` — pass
- `latexmk` on `docs/paper-gaps/cpgsv17_pf_rank_one.tex` — compiles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New proved lemmas and documentation on an already-gapped MPDO formalization path; no auth, runtime, or breaking API changes beyond additive declarations.
> 
> **Overview**
> Adds a **third route** to Lemma C.5’s rank-one sector trace matrix \(T\): record the paper’s sector tensors and zero-correlation-length (ZCL) pairing as `MPOTensor.SectorPairingData`, then derive \(T^2=T\), constant trace powers, and an outer-product factorization without assuming PSD or the false primitive trace-power shortcut.
> 
> **Lean:** `Matrix.tracePowersConstant_of_mul_self_eq_self` and primitive row/column positivity lemmas support the chain. `SectorPairingData` proves pairing-operator idempotence, \(T^2=T\) under linear independence of \(|l_k)\), trace-power constancy, nonzero sectors from primitivity, and independence via `iSupIndep` subspace supports. `sal_zcl_implies_rank_one_T_of_pairing_idempotent` / `..._of_sector_supports` and `SimpleMPDOLocalStructureData.ofSALZCLOfPairingIdempotent` wire this into local simple-MPDO structure.
> 
> **Docs:** Blueprint gains idempotent trace powers, primitive row/column positivity, sector pairing, and pairing-idempotence rank-one theorems; blocked-RFP documents the third constructor. `cpgsv17_pf_rank_one.tex` reframes the open follow-up as either PSD of \(T\) or completing concrete pairing construction, ZCL-derived operator identity, and linear independence (still scope-restricted vs. the source).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e67aae4ae3912b4f6c3206a2a017f02905b6f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


