### PR TITLE
feat(MPS/CanonicalForm): complete the spectral steps of the canonical-form sufficient condition

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -323,6 +323,7 @@ import TNLean.MPS.Structure.InvariantSubspaceDecomp
 import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.CanonicalForm.ProjectorClosure
 import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
+import TNLean.MPS.CanonicalForm.ProjectorClosureSpectral
 import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.CanonicalForm.Existence
 import TNLean.MPS.CanonicalForm.NormalReduction

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition.lean
@@ -28,7 +28,9 @@ provide one.
 The remaining steps towards the full sufficient condition for canonical form —
 rescaling each block to spectral radius one and converting the absence of
 nontrivial periodic vectors into primitivity of every rescaled block — are
-recorded in `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`.
+carried out in `TNLean.MPS.CanonicalForm.ProjectorClosureSpectral`; the
+length-zero convention for zero blocks is recorded in
+`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`.
 -/
 
 open scoped Matrix BigOperators
@@ -483,10 +485,10 @@ lines 237--241.
 Unlike `MPSTensor.exists_irreducible_blockDecomp`, the corner tensors are
 related to `A` by the intertwining `A i * V k = V k * blocks k i`, not only by
 equality of matrix product vectors, and no left-canonical normalization is
-assumed.  The remaining spectral steps — rescaling every block to spectral
-radius one and deducing blockwise primitivity from the absence of nontrivial
-periodic vectors — are recorded in
-`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`. -/
+assumed.  The spectral steps — rescaling every block to spectral radius one
+and deducing blockwise primitivity from the absence of nontrivial periodic
+vectors — are carried out in
+`TNLean.MPS.CanonicalForm.ProjectorClosureSpectral`. -/
 theorem exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure
     (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A) :
     ∃ (r : ℕ) (dim : Fin r → ℕ) (blocks : (k : Fin r) → MPSTensor d (dim k))

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
@@ -1,0 +1,379 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.CanonicalForm.ProjectorClosureDecomposition
+import TNLean.MPS.CanonicalForm.Definitions
+import TNLean.MPS.SharedInfra.Scaling
+import TNLean.MPS.Irreducible.FormII
+import TNLean.Channel.Irreducible.PerronFrobenius
+
+/-!
+# Spectral steps of the canonical-form sufficient condition
+
+This file completes the spectral part of the sufficient condition for canonical
+form of Cirac, Pérez-García, Schuch, and Verstraete, arXiv:1606.00608,
+lines 253--255: a tensor with no nontrivial `p`-periodic vectors whose
+invariant projections are all two-sided invariant generates the same matrix
+product vectors as a direct sum `⊕ₖ μₖ Aₖ` of normal tensors with nonzero
+weights (eq:II_CF1, lines 237--242).
+
+The two steps beyond the direct-sum decomposition of
+`MPSTensor.exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure`
+are those of arXiv:1606.00608, lines 220--230:
+
+* every nonzero irreducible corner is rescaled so that its transfer map has
+  spectral radius one, the removed scale becoming the weight `μₖ`
+  (lines 224--225); and
+* the absence of nontrivial `p`-periodic vectors — peripheral transfer
+  eigenvalues `exp(2πiq/p) ≠ 1` of the rescaled corners (line 226) — makes
+  every rescaled corner a normal tensor.
+
+Corners carrying the zero tensor cannot be rescaled to spectral radius one;
+they are the zero blocks of eq:II_Aiplusk1 (line 219, `∑ₖ Dₖ ≤ D`).  They
+contribute their bond dimension only to the length-zero coefficient, so the
+main conclusion states matrix-product-vector equality at every positive length
+together with the dimension bound `∑ₖ Dₖ ≤ D`.  When no corner carries the
+zero tensor the equality holds at every length, including zero; this variant
+is stated separately with the explicit no-zero-corner hypothesis.  The
+length-zero convention is recorded in
+`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`.
+-/
+
+open scoped Matrix BigOperators ComplexOrder
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-- **Absence of nontrivial `p`-periodic vectors** (arXiv:1606.00608,
+lines 220--230).
+
+The source attaches to each block `A_k` of the invariant-subspace
+decomposition (eq:II_Aiplusk1, lines 214--219) the completely positive map
+`E_k(X) = ∑ᵢ A_kⁱ X (A_kⁱ)†` and rescales it to spectral radius one
+(lines 220--225); a `p`-periodic vector is an eigenvector of a rescaled `E_k`
+with peripheral eigenvalue `exp(2πiq/p) ≠ 1` (line 226).  Under the projector
+hypothesis of the proposition at lines 253--255 every projection in that
+decomposition commutes with the tensor matrices, so the blocks of any run of
+the source procedure are precisely the restrictions of `A` to minimal
+invariant subspaces: isometries `V` with `A i * V = V * B i` whose corner
+tensor `B` is irreducible.
+
+Accordingly, `A` has no nontrivial `p`-periodic vectors if for every such
+corner `B` and every positive eigenvalue `r` of `transferMap B` with
+positive-definite eigenvector — by Wolf Theorem 6.3(4)
+(`spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp`) this `r` is the
+spectral radius of `transferMap B` — every eigenvalue of `transferMap B` of
+modulus `r` equals `r`.  After rescaling by `r^{-1/2}` this says the corner
+transfer map has no peripheral eigenvalue besides `1`, which is the source's
+condition. -/
+def HasNoPeriodicVectors (A : MPSTensor d D) : Prop :=
+  ∀ ⦃n : ℕ⦄ (V : Matrix (Fin D) (Fin n) ℂ) (B : MPSTensor d n)
+    (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ),
+    Vᴴ * V = 1 → (∀ i : Fin d, A i * V = V * B i) → IsIrreducibleTensor B →
+    ρ.PosDef → 0 < r → transferMap (d := d) (D := n) B ρ = (r : ℂ) • ρ →
+    ∀ μ : ℂ, Module.End.HasEigenvalue (transferMap (d := d) (D := n) B) μ →
+      ‖μ‖ = r → μ = (r : ℂ)
+
+/-- The transfer map of an intertwined corner: if `A i * V = V * B i` for
+every letter, then conjugation by `V` intertwines the transfer maps,
+`E_A(V X V†) = V E_B(X) V†`.
+
+This is the normalization-free relation between the transfer map of a tensor
+and the transfer maps of the corners of its invariant-subspace decomposition
+(arXiv:1606.00608, eq:II_Aiplusk1, lines 214--219 and eq. Ek, lines 220--223). -/
+theorem transferMap_conj_of_intertwine {n : ℕ} (A : MPSTensor d D) (B : MPSTensor d n)
+    (V : Matrix (Fin D) (Fin n) ℂ) (hint : ∀ i : Fin d, A i * V = V * B i)
+    (X : Matrix (Fin n) (Fin n) ℂ) :
+    transferMap (d := d) (D := D) A (V * X * Vᴴ)
+      = V * transferMap (d := d) (D := n) B X * Vᴴ := by
+  rw [transferMap_apply, transferMap_apply, Matrix.mul_sum, Matrix.sum_mul]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  have hstar : Vᴴ * (A i)ᴴ = (B i)ᴴ * Vᴴ := by
+    calc Vᴴ * (A i)ᴴ
+        = (A i * V)ᴴ := (Matrix.conjTranspose_mul _ _).symm
+      _ = (V * B i)ᴴ := by rw [hint i]
+      _ = (B i)ᴴ * Vᴴ := Matrix.conjTranspose_mul _ _
+  calc A i * (V * X * Vᴴ) * (A i)ᴴ
+      = (A i * V) * (X * (Vᴴ * (A i)ᴴ)) := by simp only [Matrix.mul_assoc]
+    _ = (V * B i) * (X * ((B i)ᴴ * Vᴴ)) := by rw [hint i, hstar]
+    _ = V * (B i * X * (B i)ᴴ) * Vᴴ := by simp only [Matrix.mul_assoc]
+
+/-- Eigenvalues of a corner transfer map are eigenvalues of the ambient
+transfer map: if `V` is an isometry with `A i * V = V * B i` for every letter,
+then every eigenvalue of `E_B` is an eigenvalue of `E_A`.
+
+In particular the `p`-periodic vectors of arXiv:1606.00608, line 226 — the
+peripheral eigenvectors of the block transfer maps — give eigenvectors of the
+transfer map of the undecomposed tensor. -/
+theorem hasEigenvalue_transferMap_of_intertwine {n : ℕ} (A : MPSTensor d D)
+    (B : MPSTensor d n) (V : Matrix (Fin D) (Fin n) ℂ) (hV : Vᴴ * V = 1)
+    (hint : ∀ i : Fin d, A i * V = V * B i) {μ : ℂ}
+    (hμ : Module.End.HasEigenvalue (transferMap (d := d) (D := n) B) μ) :
+    Module.End.HasEigenvalue (transferMap (d := d) (D := D) A) μ := by
+  obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+  have hX_eq : transferMap (d := d) (D := n) B X = μ • X :=
+    Module.End.mem_eigenspace_iff.mp (Module.End.hasEigenvector_iff.mp hX).1
+  have hX_ne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
+  refine hasEigenvalue_of_eigenvector_eq _ μ (V * X * Vᴴ) ?_ ?_
+  · rw [transferMap_conj_of_intertwine A B V hint X, hX_eq,
+      Matrix.mul_smul, Matrix.smul_mul]
+  · intro h0
+    apply hX_ne
+    have h1 : Vᴴ * (V * X * Vᴴ) * V = X := by
+      calc Vᴴ * (V * X * Vᴴ) * V
+          = (Vᴴ * V) * X * (Vᴴ * V) := by simp only [Matrix.mul_assoc]
+        _ = X := by rw [hV, Matrix.one_mul, Matrix.mul_one]
+    rw [← h1, h0, Matrix.mul_zero, Matrix.zero_mul]
+
+/-- Perron--Frobenius eigenvalue of a nonzero irreducible tensor: the transfer
+map of a nonzero irreducible tensor has a positive eigenvalue with a
+positive-definite eigenvector (Wolf Theorem 6.3(2), specialized to transfer
+maps).  This is the eigenvalue used for the spectral-radius normalization of
+arXiv:1606.00608, lines 224--225. -/
+theorem exists_posDef_transferMap_eigenvector_of_irreducible {n : ℕ} [NeZero n]
+    (B : MPSTensor d n) (hIrr : IsIrreducibleTensor B) (hB : ∃ i, B i ≠ 0) :
+    ∃ (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ),
+      ρ.PosDef ∧ 0 < r ∧ transferMap (d := d) (D := n) B ρ = (r : ℂ) • ρ := by
+  have hne : transferMap (d := d) (D := n) B ≠ 0 := by
+    intro h0
+    obtain ⟨i, hi⟩ := hB
+    have h1 : transferMap (d := d) (D := n) B 1 = 0 := by rw [h0]; simp
+    rw [transferMap_apply] at h1
+    simp only [Matrix.mul_one] at h1
+    exact hi (Matrix.eq_zero_of_sum_mul_conjTranspose_eq_zero (fun j => B j) h1 i)
+  obtain ⟨ρ, r, hρ, hr, hEig⟩ :=
+    exists_posDef_eigenvector_of_irreducible_cp (transferMap (d := d) (D := n) B)
+      (transferMap_isCPMap B)
+      (isIrreducibleCP_transferMap_of_isIrreducibleTensor B hIrr) hne
+  exact ⟨ρ, r, hρ, hr, hEig⟩
+
+/-- **Spectral normalization of an irreducible block** (arXiv:1606.00608,
+lines 224--226): rescaling a nonzero irreducible tensor by the inverse square
+root of the Perron--Frobenius eigenvalue of its transfer map yields a normal
+tensor, provided the transfer map has no eigenvalue of modulus equal to, but
+different from, that eigenvalue.
+
+Rescaling the tensor by `r^{-1/2}` rescales the transfer map by `r⁻¹`, so the
+positive-definite eigenvector becomes a fixed point and the peripheral
+eigenvalues become the eigenvalues of modulus one; the uniqueness hypothesis
+forces the peripheral eigenvalue set to be `{1}`, which together with
+irreducibility is the normal-tensor condition of arXiv:1606.00608,
+lines 233--235. -/
+theorem isNormalTensor_invSqrt_smul_of_unique_peripheral {n : ℕ} [NeZero n]
+    (B : MPSTensor d n) (hIrr : IsIrreducibleTensor B)
+    (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ) (hρ : ρ.PosDef) (hr : 0 < r)
+    (hEig : transferMap (d := d) (D := n) B ρ = (r : ℂ) • ρ)
+    (huniq : ∀ μ : ℂ, Module.End.HasEigenvalue (transferMap (d := d) (D := n) B) μ →
+      ‖μ‖ = r → μ = (r : ℂ)) :
+    IsNormalTensor (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i) := by
+  have hr_ne : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
+  have hsqrt_ne : ((Real.sqrt r : ℝ) : ℂ) ≠ 0 :=
+    Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr hr).ne'
+  have hc_ne : (((Real.sqrt r : ℝ) : ℂ))⁻¹ ≠ 0 := inv_ne_zero hsqrt_ne
+  have hcc : (((Real.sqrt r : ℝ) : ℂ))⁻¹ *
+      starRingEnd ℂ (((Real.sqrt r : ℝ) : ℂ))⁻¹ = (r : ℂ)⁻¹ := by
+    rw [map_inv₀, Complex.conj_ofReal, ← mul_inv, ← Complex.ofReal_mul,
+      Real.mul_self_sqrt hr.le]
+  have hmap : transferMap (d := d) (D := n) (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i)
+      = (r : ℂ)⁻¹ • transferMap (d := d) (D := n) B := by
+    apply LinearMap.ext
+    intro X
+    rw [transferMap_smul, LinearMap.smul_apply, hcc]
+  have hρ_ne : ρ ≠ 0 := (Matrix.PosDef.isUnit hρ).ne_zero
+  have hfix : transferMap (d := d) (D := n)
+      (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i) ρ = ρ := by
+    rw [hmap, LinearMap.smul_apply, hEig, smul_smul, inv_mul_cancel₀ hr_ne, one_smul]
+  refine ⟨isIrreducibleTensor_smul hc_ne B hIrr, ?_⟩
+  refine isPrimitive_of_unique_norm_one _ ρ hfix hρ_ne ?_
+  intro μ hμ hμnorm
+  obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+  have hX_eq : transferMap (d := d) (D := n)
+      (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i) X = μ • X :=
+    Module.End.mem_eigenspace_iff.mp (Module.End.hasEigenvector_iff.mp hX).1
+  have hX_ne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
+  have hBX : transferMap (d := d) (D := n) B X = ((r : ℂ) * μ) • X := by
+    have h1 : (r : ℂ)⁻¹ • transferMap (d := d) (D := n) B X = μ • X := by
+      rw [← LinearMap.smul_apply, ← hmap]
+      exact hX_eq
+    calc transferMap (d := d) (D := n) B X
+        = (r : ℂ) • ((r : ℂ)⁻¹ • transferMap (d := d) (D := n) B X) := by
+          rw [smul_smul, mul_inv_cancel₀ hr_ne, one_smul]
+      _ = (r : ℂ) • (μ • X) := by rw [h1]
+      _ = ((r : ℂ) * μ) • X := by rw [smul_smul]
+  have hBμ : Module.End.HasEigenvalue (transferMap (d := d) (D := n) B) ((r : ℂ) * μ) :=
+    hasEigenvalue_of_eigenvector_eq _ _ X hBX hX_ne
+  have hnorm : ‖(r : ℂ) * μ‖ = r := by
+    rw [norm_mul, hμnorm, mul_one, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr]
+  exact mul_left_cancel₀ hr_ne ((huniq _ hBμ hnorm).trans (mul_one (r : ℂ)).symm)
+
+/-- At positive length, a tensor whose letter matrices all vanish has vanishing
+matrix product vector coefficients.  These are the zero blocks of
+arXiv:1606.00608, eq:II_Aiplusk1, line 219. -/
+private lemma mpv_eq_zero_of_letter_zero {n : ℕ} (B : MPSTensor d n)
+    (hB : ∀ i, B i = 0) {N : ℕ} (hN : 0 < N) (σ : Fin N → Fin d) :
+    mpv B σ = 0 := by
+  obtain ⟨M, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hN.ne'
+  simp only [mpv, coeff, List.ofFn_succ, evalWord_cons, hB, Matrix.zero_mul,
+    Matrix.trace_zero]
+
+/-- **Sufficient condition for canonical form** (arXiv:1606.00608,
+lines 253--255).
+
+If `A` satisfies the invariant-projector closure condition and has no
+nontrivial `p`-periodic vectors, then there are nonzero weights `μ k` and
+normal tensors `blocks k` of positive bond dimensions summing to at most `D`
+such that `A` and the direct sum `⊕ₖ μₖ blocksₖ` have equal matrix product
+vector coefficients at every positive length.  This is the canonical form
+`A^i = ⊕ₖ μₖ A_kⁱ` of eq:II_CF1 (lines 237--242) at the level of the generated
+matrix product vectors, with the source convention `∑ₖ Dₖ ≤ D` that allows
+zero blocks (eq:II_Aiplusk1, line 219).
+
+Corners of `A` carrying the zero tensor cannot be rescaled to spectral radius
+one and are omitted from the direct sum; each contributes its bond dimension
+only to the length-zero coefficient.  The variant
+`MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure`
+states equality at every length under the explicit additional hypothesis that
+no irreducible corner of `A` carries the zero tensor.  The length-zero
+convention is recorded in
+`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`. -/
+theorem exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure
+    (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A)
+    (hPer : HasNoPeriodicVectors A) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      SameMPV₂Pos A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      (∀ k, IsNormalTensor (blocks k)) ∧
+      (∀ k, μ k ≠ 0) ∧
+      (∀ k, 0 < dim k) ∧
+      (∑ k, dim k) ≤ D := by
+  classical
+  obtain ⟨r₀, dim₀, blocks₀, V, hpos, hiso, hsum, -, hint, -, -, hirr, hSame⟩ :=
+    exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure A hClosure
+  -- Perron--Frobenius eigenvalue and eigenvector of every nonzero corner.
+  have hPF : ∀ k : Fin r₀, (∃ i, blocks₀ k i ≠ 0) →
+      ∃ (ρ : Matrix (Fin (dim₀ k)) (Fin (dim₀ k)) ℂ) (t : ℝ),
+        ρ.PosDef ∧ 0 < t ∧
+        transferMap (d := d) (D := dim₀ k) (blocks₀ k) ρ = (t : ℂ) • ρ := by
+    intro k hk
+    haveI : NeZero (dim₀ k) := ⟨(hpos k).ne'⟩
+    exact exists_posDef_transferMap_eigenvector_of_irreducible (blocks₀ k) (hirr k) hk
+  choose ρf tf hρf htf hEigf using hPF
+  -- The kept indices: corners with a nonzero letter matrix.
+  let κ := {k : Fin r₀ // ∃ i, blocks₀ k i ≠ 0}
+  let e : Fin (Fintype.card κ) ≃ κ := (Fintype.equivFin κ).symm
+  have hsqrt_ne : ∀ x : κ, ((Real.sqrt (tf x.1 x.2) : ℝ) : ℂ) ≠ 0 := fun x =>
+    Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr (htf x.1 x.2)).ne'
+  refine ⟨Fintype.card κ, fun j => dim₀ (e j).1,
+    fun j => ((Real.sqrt (tf (e j).1 (e j).2) : ℝ) : ℂ),
+    fun j => fun i => (((Real.sqrt (tf (e j).1 (e j).2) : ℝ) : ℂ))⁻¹ • blocks₀ (e j).1 i,
+    ?_, ?_, fun j => hsqrt_ne (e j), fun j => hpos (e j).1, ?_⟩
+  · -- Positive-length matrix product vector equality.
+    intro N hN σ
+    have hA : mpv A σ = ∑ k : Fin r₀, mpv (blocks₀ k) σ :=
+      mpv_eq_sum_of_sameMPV₂_toTensorFromBlocks_one A blocks₀ hSame σ
+    have hkeep : ∑ k ∈ Finset.univ.filter (fun k => ∃ i, blocks₀ k i ≠ 0),
+        mpv (blocks₀ k) σ = ∑ k : Fin r₀, mpv (blocks₀ k) σ := by
+      refine Finset.sum_filter_of_ne ?_
+      intro k _ hne
+      by_contra hnot
+      push Not at hnot
+      exact hne (mpv_eq_zero_of_letter_zero (blocks₀ k) hnot hN σ)
+    have hsubtype : ∑ k ∈ Finset.univ.filter (fun k => ∃ i, blocks₀ k i ≠ 0),
+        mpv (blocks₀ k) σ = ∑ x : κ, mpv (blocks₀ x.1) σ :=
+      Finset.sum_subtype _ (by simp) _
+    have hequiv : ∑ x : κ, mpv (blocks₀ x.1) σ
+        = ∑ j : Fin (Fintype.card κ), mpv (blocks₀ (e j).1) σ :=
+      (Equiv.sum_comp e (fun x : κ => mpv (blocks₀ x.1) σ)).symm
+    rw [hA, ← hkeep, hsubtype, hequiv, mpv_toTensorFromBlocks_eq_sum]
+    refine Finset.sum_congr rfl fun j _ => ?_
+    rw [mpv_smul, smul_eq_mul, ← mul_assoc, ← mul_pow,
+      mul_inv_cancel₀ (hsqrt_ne (e j)), one_pow, one_mul]
+  · -- Every kept, rescaled corner is a normal tensor.
+    intro j
+    haveI : NeZero (dim₀ (e j).1) := ⟨(hpos (e j).1).ne'⟩
+    refine isNormalTensor_invSqrt_smul_of_unique_peripheral (blocks₀ (e j).1)
+      (hirr (e j).1) (ρf (e j).1 (e j).2) (tf (e j).1 (e j).2) (hρf (e j).1 (e j).2)
+      (htf (e j).1 (e j).2) (hEigf (e j).1 (e j).2) ?_
+    intro μ hμ hnorm
+    exact hPer (V (e j).1) (blocks₀ (e j).1) (ρf (e j).1 (e j).2) (tf (e j).1 (e j).2)
+      (hiso (e j).1) (hint (e j).1) (hirr (e j).1) (hρf (e j).1 (e j).2)
+      (htf (e j).1 (e j).2) (hEigf (e j).1 (e j).2) μ hμ hnorm
+  · -- The block dimensions sum to at most `D`.
+    have hDim : ∑ k : Fin r₀, dim₀ k = D := by
+      have hc : (∑ k : Fin r₀, (dim₀ k : ℂ)) = (D : ℂ) := by
+        calc ∑ k : Fin r₀, (dim₀ k : ℂ)
+            = ∑ k : Fin r₀, Matrix.trace ((V k)ᴴ * V k) := by
+              refine Finset.sum_congr rfl fun k _ => ?_
+              rw [hiso k, Matrix.trace_one, Fintype.card_fin]
+          _ = ∑ k : Fin r₀, Matrix.trace (V k * (V k)ᴴ) := by
+              refine Finset.sum_congr rfl fun k _ => ?_
+              exact Matrix.trace_mul_comm _ _
+          _ = Matrix.trace (∑ k : Fin r₀, V k * (V k)ᴴ) := (Matrix.trace_sum _ _).symm
+          _ = (D : ℂ) := by rw [hsum, Matrix.trace_one, Fintype.card_fin]
+      exact_mod_cast hc
+    calc ∑ j : Fin (Fintype.card κ), dim₀ (e j).1
+        = ∑ x : κ, dim₀ x.1 := Equiv.sum_comp e (fun x : κ => dim₀ x.1)
+      _ = ∑ k ∈ Finset.univ.filter (fun k => ∃ i, blocks₀ k i ≠ 0), dim₀ k :=
+          (Finset.sum_subtype _ (by simp) _).symm
+      _ ≤ ∑ k : Fin r₀, dim₀ k :=
+          Finset.sum_le_sum_of_subset (Finset.filter_subset _ _)
+      _ = D := hDim
+
+/-- All-lengths variant of the sufficient condition for canonical form
+(arXiv:1606.00608, lines 253--255).
+
+**Scope restriction (no zero corners):** in addition to the source hypotheses,
+every irreducible corner of `A` is assumed to carry a nonzero letter matrix.
+Without this hypothesis a corner may be the zero tensor, which cannot be
+rescaled to spectral radius one; the source drops such zero blocks
+(eq:II_Aiplusk1, line 219, `∑ₖ Dₖ ≤ D`), which changes the length-zero
+coefficient.  The unrestricted positive-length statement is
+`MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure`.
+The restriction is recorded in
+`docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`. -/
+theorem exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure
+    (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A)
+    (hPer : HasNoPeriodicVectors A)
+    (hcorner : ∀ ⦃n : ℕ⦄ (V : Matrix (Fin D) (Fin n) ℂ) (B : MPSTensor d n),
+      Vᴴ * V = 1 → (∀ i : Fin d, A i * V = V * B i) → IsIrreducibleTensor B →
+      ∃ i, B i ≠ 0) :
+    ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
+      (blocks : (k : Fin r) → MPSTensor d (dim k)),
+      SameMPV₂ A (toTensorFromBlocks (d := d) (μ := μ) blocks) ∧
+      (∀ k, IsNormalTensor (blocks k)) ∧
+      (∀ k, μ k ≠ 0) := by
+  classical
+  obtain ⟨r₀, dim₀, blocks₀, V, hpos, hiso, hsum, -, hint, -, -, hirr, hSame⟩ :=
+    exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure A hClosure
+  have hPF : ∀ k : Fin r₀,
+      ∃ (ρ : Matrix (Fin (dim₀ k)) (Fin (dim₀ k)) ℂ) (t : ℝ),
+        ρ.PosDef ∧ 0 < t ∧
+        transferMap (d := d) (D := dim₀ k) (blocks₀ k) ρ = (t : ℂ) • ρ := by
+    intro k
+    haveI : NeZero (dim₀ k) := ⟨(hpos k).ne'⟩
+    exact exists_posDef_transferMap_eigenvector_of_irreducible (blocks₀ k) (hirr k)
+      (hcorner (V k) (blocks₀ k) (hiso k) (hint k) (hirr k))
+  choose ρf tf hρf htf hEigf using hPF
+  have hsqrt_ne : ∀ k : Fin r₀, ((Real.sqrt (tf k) : ℝ) : ℂ) ≠ 0 := fun k =>
+    Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr (htf k)).ne'
+  refine ⟨r₀, dim₀, fun k => ((Real.sqrt (tf k) : ℝ) : ℂ),
+    fun k => fun i => (((Real.sqrt (tf k) : ℝ) : ℂ))⁻¹ • blocks₀ k i,
+    ?_, ?_, fun k => hsqrt_ne k⟩
+  · -- Matrix product vector equality at every length.
+    intro N σ
+    rw [hSame N σ, mpv_toTensorFromBlocks_eq_sum, mpv_toTensorFromBlocks_eq_sum]
+    refine Finset.sum_congr rfl fun k _ => ?_
+    rw [mpv_smul, one_pow, one_smul, smul_eq_mul, ← mul_assoc, ← mul_pow,
+      mul_inv_cancel₀ (hsqrt_ne k), one_pow, one_mul]
+  · -- Every rescaled corner is a normal tensor.
+    intro k
+    haveI : NeZero (dim₀ k) := ⟨(hpos k).ne'⟩
+    refine isNormalTensor_invSqrt_smul_of_unique_peripheral (blocks₀ k) (hirr k)
+      (ρf k) (tf k) (hρf k) (htf k) (hEigf k) ?_
+    intro μ hμ hnorm
+    exact hPer (V k) (blocks₀ k) (ρf k) (tf k) (hiso k) (hint k) (hirr k)
+      (hρf k) (htf k) (hEigf k) μ hμ hnorm
+
+end MPSTensor

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
@@ -325,11 +325,14 @@ theorem exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorCl
 (arXiv:1606.00608, lines 253--255).
 
 **Scope restriction (no zero corners):** in addition to the source hypotheses,
-every irreducible corner of `A` is assumed to carry a nonzero letter matrix.
-Without this hypothesis a corner may be the zero tensor, which cannot be
-rescaled to spectral radius one; the source drops such zero blocks
-(eq:II_Aiplusk1, line 219, `∑ₖ Dₖ ≤ D`), which changes the length-zero
-coefficient.  The unrestricted positive-length statement is
+every irreducible corner of `A` of positive dimension is assumed to carry a
+nonzero letter matrix.  Without this hypothesis a corner may be the zero
+tensor, which cannot be rescaled to spectral radius one; the source drops
+such zero blocks (eq:II_Aiplusk1, line 219, `∑ₖ Dₖ ≤ D`), which changes the
+length-zero coefficient.  The premise `0 < n` excludes only the
+zero-dimensional corner, whose letter matrices all vanish for lack of
+entries; without it no tensor could satisfy the hypothesis.  The
+unrestricted positive-length statement is
 `MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure`.
 The restriction is recorded in
 `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`. -/
@@ -337,7 +340,7 @@ theorem exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosu
     (A : MPSTensor d D) (hClosure : HasInvariantProjectorClosure A)
     (hPer : HasNoPeriodicVectors A)
     (hcorner : ∀ ⦃n : ℕ⦄ (V : Matrix (Fin D) (Fin n) ℂ) (B : MPSTensor d n),
-      Vᴴ * V = 1 → (∀ i : Fin d, A i * V = V * B i) → IsIrreducibleTensor B →
+      0 < n → Vᴴ * V = 1 → (∀ i : Fin d, A i * V = V * B i) → IsIrreducibleTensor B →
       ∃ i, B i ≠ 0) :
     ∃ (r : ℕ) (dim : Fin r → ℕ) (μ : Fin r → ℂ)
       (blocks : (k : Fin r) → MPSTensor d (dim k)),
@@ -354,7 +357,7 @@ theorem exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosu
     intro k
     haveI : NeZero (dim₀ k) := ⟨(hpos k).ne'⟩
     exact exists_posDef_transferMap_eigenvector_of_irreducible (blocks₀ k) (hirr k)
-      (hcorner (V k) (blocks₀ k) (hiso k) (hint k) (hirr k))
+      (hcorner (V k) (blocks₀ k) (hpos k) (hiso k) (hint k) (hirr k))
   choose ρf tf hρf htf hEigf using hPF
   have hsqrt_ne : ∀ k : Fin r₀, ((Real.sqrt (tf k) : ℝ) : ℂ) ≠ 0 := fun k =>
     Complex.ofReal_ne_zero.mpr (Real.sqrt_pos.mpr (htf k)).ne'

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -466,6 +466,169 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     Lemma~\ref{lem:mpv_partition_isometries}.
 \end{proof}
 
+\begin{definition}[No nontrivial periodic vectors]
+    \label{def:no_periodic_vectors}
+    \lean{MPSTensor.HasNoPeriodicVectors}
+    \leanok
+    \uses{def:mps_tensor, def:transfer_map, def:irreducible_tensor}
+    An MPS tensor $A$ has \emph{no nontrivial $p$-periodic vectors} if, for
+    every isometry $V$ with $V^\dagger V = \Id$ and $A^i V = V B^i$ for
+    all~$i$ with $B$ irreducible (equivalently, for every restriction $B$ of
+    $A$ to a minimal invariant subspace), and for every $\rho > 0$ and
+    $r > 0$ with $\E_B(\rho) = r\rho$, every eigenvalue of $\E_B$ of modulus
+    $r$ equals~$r$.
+    The eigenvalue $r$ is the spectral radius of $\E_B$
+    (Theorem~\ref{thm:spectral_radius_pf_irred}), so the condition states
+    that no block of the invariant-subspace decomposition
+    of~\cite[Section~2]{Cirac2016MPDO_arXiv}, rescaled to spectral radius
+    one, has a peripheral eigenvalue $e^{2\pi i q/p} \neq 1$. Eigenvectors
+    with such eigenvalues are the $p$-periodic vectors
+    of~\cite[Section~2]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{lemma}[Transfer map of an intertwined corner]
+    \label{lem:transfer_map_corner_intertwine}
+    \lean{MPSTensor.transferMap_conj_of_intertwine}
+    \lean{MPSTensor.hasEigenvalue_transferMap_of_intertwine}
+    \leanok
+    \uses{def:transfer_map}
+    Let $V$ satisfy $A^i V = V B^i$ for all~$i$. Then for every $X$,
+    \[
+        \E_A(V X V^\dagger) = V \E_B(X) V^\dagger.
+    \]
+    If moreover $V^\dagger V = \Id$, then every eigenvalue of $\E_B$ is an
+    eigenvalue of $\E_A$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    Expanding $\E_A(V X V^\dagger)$ termwise, the intertwining
+    $A^i V = V B^i$ and its adjoint
+    $V^\dagger (A^i)^\dagger = (B^i)^\dagger V^\dagger$ move both factors
+    past $V$ and $V^\dagger$. For the eigenvalue statement, if
+    $\E_B(X) = \mu X$ with $X \neq 0$, then
+    $\E_A(V X V^\dagger) = \mu\, V X V^\dagger$, and $V X V^\dagger \neq 0$
+    because compressing with the isometry returns
+    $V^\dagger (V X V^\dagger) V = X$.
+\end{proof}
+
+\begin{lemma}[Perron eigenpair of a nonzero irreducible tensor]
+    \label{lem:irreducible_transfer_perron_pair}
+    \lean{MPSTensor.exists_posDef_transferMap_eigenvector_of_irreducible}
+    \leanok
+    \uses{def:irreducible_tensor, def:transfer_map}
+    Let $B$ be an irreducible MPS tensor of positive bond dimension, not all
+    of whose matrices vanish. Then there are $\rho > 0$ and $r > 0$ with
+    $\E_B(\rho) = r\rho$.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{thm:pf_eigenvector_existence, def:irreducible_cp}
+    Irreducibility of the tensor makes the transfer map an irreducible
+    completely positive map, and a nonzero matrix makes it nonzero, so it
+    does not annihilate any nonzero PSD matrix. The Perron--Frobenius theorem
+    for positive maps (Theorem~\ref{thm:pf_eigenvector_existence}) gives a
+    nonzero PSD eigenvector with eigenvalue $r > 0$, and irreducibility
+    upgrades it to a positive-definite one
+    (\cite[Theorem~6.3(2)]{Wolf2012Quantum}).
+\end{proof}
+
+\begin{lemma}[Spectral normalization of an irreducible block]
+    \label{lem:irreducible_block_spectral_normalization}
+    \lean{MPSTensor.isNormalTensor_invSqrt_smul_of_unique_peripheral}
+    \leanok
+    \uses{def:irreducible_tensor, def:transfer_map, def:nt_cpsv}
+    Let $B$ be an irreducible MPS tensor of positive bond dimension with
+    $\E_B(\rho) = r\rho$ for some $\rho > 0$ and $r > 0$, and suppose every
+    eigenvalue of $\E_B$ of modulus $r$ equals $r$. Then $r^{-1/2} B$ is a
+    normal tensor.
+\end{lemma}
+
+\begin{proof}
+    \leanok
+    \uses{def:nt_cpsv}
+    Rescaling the tensor by $r^{-1/2}$ rescales the transfer map by
+    $r^{-1}$, so $\rho$ becomes a positive-definite fixed point of
+    $\E_{r^{-1/2}B}$, and the eigenvalues of modulus one of
+    $\E_{r^{-1/2}B}$ are the eigenvalues of modulus $r$ of $\E_B$ divided
+    by $r$. By hypothesis the only such eigenvalue is one, so the peripheral
+    eigenvalue set is $\{1\}$. Irreducibility is unchanged by a nonzero
+    rescaling.
+\end{proof}
+
+\begin{theorem}[Sufficient condition for canonical form]
+    \label{thm:projector_closure_canonical_form}
+    \lean{MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure}
+    \leanok
+    \uses{def:invariant_projector_closure, def:no_periodic_vectors,
+        def:nt_cpsv, def:same_mpv2_pos, def:block_diagonal_tensor}
+    Suppose $A$ has invariant-projector closure and no nontrivial
+    $p$-periodic vectors. Then there are normal tensors $A_1, \ldots, A_r$
+    of positive bond dimensions $D_1, \ldots, D_r$ with $\sum_k D_k \le D$,
+    and nonzero weights $\mu_1, \ldots, \mu_r$, such that
+    \[
+        \mc{V}^+(A) = \mc{V}^+\Bigl(\bigoplus_{k=1}^r \mu_k A_k\Bigr).
+    \]
+    This is the sufficient condition for canonical form
+    of~\cite[Section~2]{Cirac2016MPDO_arXiv}, with that paper's convention
+    $\sum_k D_k \le D$ allowing zero blocks: a corner of $A$ carrying the
+    zero tensor cannot be rescaled to spectral radius one, and contributes
+    its bond dimension only to the length-zero coefficient.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:projector_closure_irreducible_corners,
+        lem:irreducible_transfer_perron_pair,
+        lem:irreducible_block_spectral_normalization}
+    Decompose $A$ into irreducible corners $B_k$ along isometries $V_k$
+    (Theorem~\ref{thm:projector_closure_irreducible_corners}); every matrix
+    product vector coefficient of $A$ is the sum of those of the corners. A
+    corner whose matrices all vanish contributes nothing at positive length
+    and is dropped. Every remaining corner has a Perron eigenpair
+    $\E_{B_k}(\rho_k) = r_k \rho_k$
+    (Lemma~\ref{lem:irreducible_transfer_perron_pair}). The absence of
+    $p$-periodic vectors, applied to the corner $B_k$, gives that every
+    eigenvalue of $\E_{B_k}$ of modulus $r_k$ equals $r_k$, so
+    $A_k := r_k^{-1/2} B_k$ is normal
+    (Lemma~\ref{lem:irreducible_block_spectral_normalization}). Setting
+    $\mu_k := r_k^{1/2}$ restores $\mu_k A_k = B_k$, so the positive-length
+    coefficients of $A$ and of $\bigoplus_k \mu_k A_k$ agree termwise. The
+    kept dimensions satisfy
+    $\sum_k D_k \le \sum_k \tr(V_k V_k^\dagger) = \tr(\Id) = D$.
+\end{proof}
+
+\begin{theorem}[Canonical form at every length without zero corners]
+    \label{thm:projector_closure_canonical_form_all_lengths}
+    \lean{MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure}
+    \leanok
+    \uses{def:invariant_projector_closure, def:no_periodic_vectors,
+        def:nt_cpsv, def:same_mpv2, def:block_diagonal_tensor}
+    Suppose $A$ has invariant-projector closure, has no nontrivial
+    $p$-periodic vectors, and every restriction of $A$ to a minimal
+    invariant subspace has a nonzero matrix. Then there are normal tensors
+    $A_1, \ldots, A_r$ and nonzero weights $\mu_1, \ldots, \mu_r$ with
+    \[
+        \mc{V}(A) = \mc{V}\Bigl(\bigoplus_{k=1}^r \mu_k A_k\Bigr).
+    \]
+    The no-zero-corner hypothesis is not part of the source statement; it
+    excludes exactly the zero blocks
+    of~\cite[Section~2]{Cirac2016MPDO_arXiv}, which change only the
+    length-zero coefficient.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:projector_closure_irreducible_corners,
+        lem:irreducible_transfer_perron_pair,
+        lem:irreducible_block_spectral_normalization}
+    As for Theorem~\ref{thm:projector_closure_canonical_form}, with no
+    corner dropped: every corner is nonzero by hypothesis, so
+    $\bigoplus_k \mu_k A_k$ has the same coefficients as the unit-weight
+    direct sum of the corners at every length, including zero.
+\end{proof}
+
 \begin{theorem}[PSD fixed point gives invariant projection]\label{thm:fp_inv_proj}
     \lean{MPSTensor.lowerZero_of_posSemidef_fixedPoint}
     \leanok

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -548,13 +548,16 @@ the resulting splitting decomposes any tensor into irreducible blocks.
 \begin{proof}
     \leanok
     \uses{def:nt_cpsv}
-    Rescaling the tensor by $r^{-1/2}$ rescales the transfer map by
-    $r^{-1}$, so $\rho$ becomes a positive-definite fixed point of
-    $\E_{r^{-1/2}B}$, and the eigenvalues of modulus one of
-    $\E_{r^{-1/2}B}$ are the eigenvalues of modulus $r$ of $\E_B$ divided
-    by $r$. By hypothesis the only such eigenvalue is one, so the peripheral
-    eigenvalue set is $\{1\}$. Irreducibility is unchanged by a nonzero
-    rescaling.
+    The rescaling identity
+    \[
+        \E_{r^{-1/2}B}(X) = r^{-1}\,\E_B(X)
+    \]
+    gives $\E_{r^{-1/2}B}(\rho) = r^{-1}\cdot r\rho = \rho$, so $\rho$ is a
+    positive-definite fixed point of $\E_{r^{-1/2}B}$. The eigenvalues of
+    modulus one of $\E_{r^{-1/2}B}$ are the eigenvalues of $\E_B$ of modulus
+    $r$, divided by $r$; by hypothesis the only such eigenvalue is one, so
+    the peripheral eigenvalue set is $\{1\}$. Irreducibility is unchanged by
+    a nonzero rescaling.
 \end{proof}
 
 \begin{theorem}[Sufficient condition for canonical form]
@@ -593,9 +596,15 @@ the resulting splitting decomposes any tensor into irreducible blocks.
     eigenvalue of $\E_{B_k}$ of modulus $r_k$ equals $r_k$, so
     $A_k := r_k^{-1/2} B_k$ is normal
     (Lemma~\ref{lem:irreducible_block_spectral_normalization}). Setting
-    $\mu_k := r_k^{1/2}$ restores $\mu_k A_k = B_k$, so the positive-length
-    coefficients of $A$ and of $\bigoplus_k \mu_k A_k$ agree termwise. The
-    kept dimensions satisfy
+    $\mu_k := r_k^{1/2}$ gives $\mu_k A_k = B_k$ at the level of matrices,
+    so for every word $w$ of positive length $N$ the weight cancels,
+    \[
+        \mu_k^N \tr\bigl(A_k^w\bigr)
+        = \bigl(r_k^{1/2}\bigr)^N \bigl(r_k^{-1/2}\bigr)^N \tr\bigl(B_k^w\bigr)
+        = \tr\bigl(B_k^w\bigr),
+    \]
+    and summing over $k$ identifies the positive-length coefficients of
+    $\bigoplus_k \mu_k A_k$ with those of $A$. The kept dimensions satisfy
     $\sum_k D_k \le \sum_k \tr(V_k V_k^\dagger) = \tr(\Id) = D$.
 \end{proof}
 
@@ -607,7 +616,8 @@ the resulting splitting decomposes any tensor into irreducible blocks.
         def:nt_cpsv, def:same_mpv2, def:block_diagonal_tensor}
     Suppose $A$ has invariant-projector closure, has no nontrivial
     $p$-periodic vectors, and every restriction of $A$ to a minimal
-    invariant subspace has a nonzero matrix. Then there are normal tensors
+    invariant subspace of positive dimension has a nonzero matrix. Then
+    there are normal tensors
     $A_1, \ldots, A_r$ and nonzero weights $\mu_1, \ldots, \mu_r$ with
     \[
         \mc{V}(A) = \mc{V}\Bigl(\bigoplus_{k=1}^r \mu_k A_k\Bigr).

--- a/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
+++ b/docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex
@@ -57,36 +57,67 @@ left-canonical or unital normalization.\footnote{Formal declarations:
 \leanid{MPSTensor.exists_reducing_projection_of_hasInvariantProj} in
 \doclink{TNLean/MPS/CanonicalForm/ProjectorClosure}.}
 
-\section{The remaining spectral implication}
+\section{The spectral implication}
 
-The present decomposition theorem produces irreducible blocks and preserves
-all finite-ring traces, but it does not yet transport the global absence of
-periodic vectors to the transfer maps of the individual blocks.  The source
-also rescales each nonzero block so that its transfer map has spectral radius
-one, with the removed scale carried by the corresponding scalar coefficient.
-A source-faithful completion therefore still requires a theorem which
-simultaneously:
+The direct-sum decomposition produces irreducible corner tensors $B_k$ along
+isometries $V_k$ satisfying $A^i V_k = V_k B_k^i$.\footnote{Formal
+declaration:
+\leanid{MPSTensor.exists_irreducible_blockDecomp_with_isometry_of_hasInvariantProjectorClosure}
+in \doclink{TNLean/MPS/CanonicalForm/ProjectorClosureDecomposition}.}  The
+completion of the source proposition consists of two further steps, both now
+formalized without any normalization hypothesis:\footnote{Formal
+declarations:
+\leanid{MPSTensor.isNormalTensor_invSqrt_smul_of_unique_peripheral} and
+\leanid{MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure}
+in \doclink{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral}.}
 \begin{enumerate}
-\item constructs the reducing direct-sum decomposition from projector closure;
-\item rescales every nonzero irreducible block to spectral radius one; and
-\item identifies absence of nontrivial periodic vectors with primitivity of
-  every rescaled block transfer map.
+\item every nonzero irreducible corner has a Perron eigenpair
+  $\mathcal{E}_{B_k}(\rho_k)=r_k\rho_k$ with $\rho_k>0$ and $r_k>0$;
+  rescaling the corner by $r_k^{-1/2}$ moves its transfer map to spectral
+  radius one and the removed scale into the coefficient
+  $\mu_k := r_k^{1/2}$; and
+\item the absence of nontrivial $p$-periodic vectors, stated for every
+  restriction of $A$ to a minimal invariant subspace, forces the peripheral
+  eigenvalue set of every rescaled corner transfer map to be $\{1\}$, so
+  every rescaled corner is a normal tensor.
 \end{enumerate}
 No identity of the form
 \begin{align}
     \sum_i (A^i)^\dagger A^i=1
 \end{align}
-occurs among the hypotheses of the cited proposition, so such a normalization
-cannot be assumed in this completion.
+occurs among the hypotheses of the cited proposition, and none is assumed in
+the formalized completion.
+
+\section{Zero blocks and the length-zero coefficient}
+
+A corner of $A$ whose matrices all vanish cannot be rescaled to spectral
+radius one; these are the zero blocks the source allows through the
+convention $\sum_k D_k \le D$ stated immediately after its invariant-subspace
+decomposition (arXiv:1606.00608, line 219).  Dropping a zero block changes
+exactly one datum of the generated family: the length-zero coefficient,
+which is the bond dimension.  The formalized sufficient condition therefore
+concludes equality of the generated matrix product vectors at every positive
+length, together with the source's dimension bound $\sum_k D_k \le D$.  A
+separate variant concludes equality at every length, including zero, under
+the explicit additional hypothesis that no restriction of $A$ to a minimal
+invariant subspace is the zero tensor; that hypothesis is not part of the
+source statement, and the variant is marked as
+scope-restricted.\footnote{Formal declaration:
+\leanid{MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure}
+in \doclink{TNLean/MPS/CanonicalForm/ProjectorClosureSpectral}.}
+The positive-length formulation is the source-faithful shape of the
+length-zero bookkeeping analyzed in
+\path{docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex}.
 
 \section{Conclusion}
 
-The classification is an \emph{open gap}.  The normalization-free
-reducing-projection step is established, but the spectral-radius rescaling and
-the deduction of blockwise primitivity from the absence of periodic vectors
-remain to be proved.  Until these spectral statements are available, the full
-sufficient condition for canonical form at arXiv:1606.00608, lines 253--254,
-is not formalized.
+The sufficient condition for canonical form at arXiv:1606.00608,
+lines 253--254, is formalized: projector closure and the absence of
+nontrivial $p$-periodic vectors yield a decomposition of the generated
+matrix product vectors into normal-tensor blocks with nonzero weights, at
+every positive length and with $\sum_k D_k \le D$.  The remaining deliberate
+deviation is the treatment of the length-zero coefficient in the presence of
+zero blocks, recorded in the previous section.
 
 \bibliographystyle{alpha}
 \bibliography{references}


### PR DESCRIPTION
## Summary

Completes the spectral steps (steps 2–3 of `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex`) of the sufficient condition for canonical form at arXiv:1606.00608, lines 253–255, on top of the direct-sum decomposition of #3686. New file `TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean`, sorry-free and axiom-free:

- `MPSTensor.HasNoPeriodicVectors` — absence of nontrivial $p$-periodic vectors (arXiv:1606.00608, lines 220–230): for every restriction $B$ of $A$ to a minimal invariant subspace (an isometry $V$ with $A^i V = V B^i$ and $B$ irreducible) and every Perron eigenpair $\mathcal{E}_B(\rho) = r\rho$ with $\rho \succ 0$, $r > 0$, every eigenvalue of $\mathcal{E}_B$ of modulus $r$ equals $r$. By the formalized Wolf Theorem 6.3(4) (`spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp`) this $r$ is the spectral radius of $\mathcal{E}_B$, so the condition says no block of the source's invariant-subspace decomposition, rescaled to spectral radius one, has a peripheral eigenvalue $e^{2\pi i q/p} \neq 1$. Under projector closure every projection of that decomposition commutes with the tensor matrices, so its blocks are exactly these minimal-invariant-subspace restrictions.
- `MPSTensor.transferMap_conj_of_intertwine`, `MPSTensor.hasEigenvalue_transferMap_of_intertwine` — normalization-free transfer-map transport along an intertwined corner: $\mathcal{E}_A(V X V^\dagger) = V \mathcal{E}_B(X) V^\dagger$; for an isometry, every eigenvalue of $\mathcal{E}_B$ is an eigenvalue of $\mathcal{E}_A$.
- `MPSTensor.exists_posDef_transferMap_eigenvector_of_irreducible` — Perron eigenpair of a nonzero irreducible tensor (Wolf Theorem 6.3(2) specialized to transfer maps).
- `MPSTensor.isNormalTensor_invSqrt_smul_of_unique_peripheral` — spectral normalization: rescaling an irreducible block by $r^{-1/2}$ yields a normal tensor when $\mathcal{E}_B$ has no eigenvalue of modulus $r$ besides $r$.
- `MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure` — the sufficient condition: projector closure and no nontrivial $p$-periodic vectors give nonzero weights $\mu_k$ and normal tensors $A_k$ of positive bond dimensions with $\sum_k D_k \le D$ and equal matrix product vectors at every positive length, $\mathcal{V}^+(A) = \mathcal{V}^+(\bigoplus_k \mu_k A_k)$.
- `MPSTensor.exists_normalTensor_blockDecomp_sameMPV₂_of_hasInvariantProjectorClosure` — all-lengths variant under the explicit additional hypothesis that no minimal-invariant-subspace restriction of $A$ is the zero tensor (scope-restriction marker in the docstring, recorded in the gap note).

No left-canonical or unital normalization appears anywhere; the intertwinings from #3686 are the only channel between $\mathcal{E}_A$ and the block transfer maps.

## Why the main conclusion is stated at positive lengths

A corner of $A$ carrying the zero tensor cannot be rescaled to spectral radius one. The source allows exactly this through its convention $\sum_k D_k \le D$ ("there can be zero blocks", line 219); dropping a zero block changes only the length-zero coefficient, which is the bond dimension. Without that convention the all-lengths conclusion is false: for the single-matrix tensor $A = \mathrm{diag}(1,0)$ both hypotheses hold, but a decomposition into normal blocks with nonzero weights would force one-dimensional blocks $b_1, b_2$ with $|b_k| = 1$ and $\mu_1^N b_1^N + \mu_2^N b_2^N = 1$ for all $N \ge 1$; the $N = 1, 2$ equations give $z_1 z_2 = 0$ for $z_k = \mu_k b_k$, a contradiction. The positive-length statement together with $\sum_k D_k \le D$ is the source's own formulation; this is the length-zero bookkeeping already analyzed in `docs/paper-gaps/cpsv16_zero_tail_length_zero_decomposition.tex`, and `docs/paper-gaps/cpsv16_projector_closure_canonical_form.tex` now records it as the only remaining (deliberate, documented) deviation.

## Blueprint

Six new entries in `blueprint/src/chapter/ch09_canonical.tex` next to the #3686 entries: `def:no_periodic_vectors`, `lem:transfer_map_corner_intertwine`, `lem:irreducible_transfer_perron_pair`, `lem:irreducible_block_spectral_normalization`, `thm:projector_closure_canonical_form`, `thm:projector_closure_canonical_form_all_lengths`, with statement- and proof-level `\leanok`.

## Checks

- `lake build TNLean` — clean
- `rg -n "sorry|axiom"` on changed Lean files — clean
- `lake exe checkdecls blueprint/lean_decls` — pass (exit 0)
- `python3 scripts/blueprint_lean_sync.py --ci` — in sync
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main` — no violations
- `lake exe lint_style`, `git diff --check` — clean
- gap note compiles with `latexmk -pdf -halt-on-error`

Closes #2634.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new Lean proof chain in MPS canonical-form theory with subtle MPV length-zero vs positive-length semantics; core math is sorry-free but correctness depends on the formalized periodic-vector and normal-tensor definitions.
> 
> **Overview**
> **Closes the spectral gap** behind Cirac et al.’s sufficient condition for canonical form (arXiv:1606.00608, lines 253–255) on top of the irreducible direct-sum decomposition from #3686.
> 
> Adds **`TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean`**: defines **`HasNoPeriodicVectors`**, proves transfer-map conjugation and eigenvalue transport along intertwined corners, Perron rescaling **`isNormalTensor_invSqrt_smul_of_unique_peripheral`**, and the capstones **`exists_normalTensor_blockDecomp_sameMPV₂Pos_of_hasInvariantProjectorClosure`** (positive lengths, \(\sum_k D_k \le D\), zero corners dropped) plus an all-lengths variant under an explicit no-zero-corner hypothesis.
> 
> **`ProjectorClosureDecomposition`** and the gap note now point here instead of listing spectral steps as open. **`ch09_canonical.tex`** gains six linked blueprint entries; **`cpsv16_projector_closure_canonical_form.tex`** records formalization and documents length-zero bookkeeping for zero blocks as the only deliberate deviation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b57cbf576454916b3dd469e404d79c147194ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->