### PR TITLE
feat(MPS/RFP): construct Appendix B two-site support

### DIFF
--- a/TNLean.lean
+++ b/TNLean.lean
@@ -399,6 +399,7 @@ import TNLean.MPS.MPDO.PureRecovery
 import TNLean.MPS.RFP.StructuralForm
 import TNLean.MPS.RFP.StructuralFull
 import TNLean.MPS.RFP.CommutingBridge
+import TNLean.MPS.RFP.AppendixBSupport
 import TNLean.MPS.RFP.Convergence
 import TNLean.MPS.RFP.Assembly
 import TNLean.MPS.RFP.Decorrelation

--- a/TNLean/MPS/RFP/AppendixBSupport.lean
+++ b/TNLean/MPS/RFP/AppendixBSupport.lean
@@ -254,7 +254,7 @@ weighted boundary reparametrization:
 \]
 
 Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
-theorem AppendixBStructuralData.twoSiteBasicEmbedding_comp_weightedBoundary
+theorem AppendixBStructuralData.twoSiteBasicEmbedding_comp_weightedTwoSiteBoundary
     {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
     hStruct.twoSiteBasicEmbedding.comp hStruct.weightedTwoSiteBoundary =
       groundSpaceMap hStruct.coreTensor 2 := by
@@ -313,10 +313,11 @@ theorem AppendixBStructuralData.twoSiteBasicEmbedding_range
   · rintro ψ ⟨v, rfl⟩
     obtain ⟨X, rfl⟩ := hStruct.weightedTwoSiteBoundary_surjective v
     refine ⟨X, ?_⟩
-    exact (LinearMap.congr_fun hStruct.twoSiteBasicEmbedding_comp_weightedBoundary X).symm
+    exact
+      (LinearMap.congr_fun hStruct.twoSiteBasicEmbedding_comp_weightedTwoSiteBoundary X).symm
   · rintro ψ ⟨X, rfl⟩
     refine ⟨hStruct.weightedTwoSiteBoundary X, ?_⟩
-    exact LinearMap.congr_fun hStruct.twoSiteBasicEmbedding_comp_weightedBoundary X
+    exact LinearMap.congr_fun hStruct.twoSiteBasicEmbedding_comp_weightedTwoSiteBoundary X
 
 /-- The orthogonal support projector of the two-site basic-vector image
 \(G_2(\Lambda U)\).

--- a/TNLean/MPS/RFP/AppendixBSupport.lean
+++ b/TNLean/MPS/RFP/AppendixBSupport.lean
@@ -1,0 +1,465 @@
+/-
+Copyright (c) 2026 TNLean contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+import TNLean.MPS.RFP.CommutingBridge
+
+/-!
+# Appendix B tensor powers and two-site support
+
+This file develops the local support construction arising from the Appendix B
+basic-vector expression in arXiv:1606.00608, equations (3.16)--(3.18).  It
+constructs every tensor power of the physical isometry, inserts the virtual bond
+vector on two sites, identifies the resulting physical image with
+\(G_2(\Lambda U)\), and constructs its orthogonal support projector.
+
+The subsequent three-site commutator still requires the virtual projector onto
+\(\mathbb C\varphi\), its two adjacent placements, and the spectator-complement
+argument for the possibly non-surjective physical isometry.  That boundary is
+recorded in `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
+-/
+
+open scoped Matrix BigOperators
+
+namespace MPSTensor
+
+variable {d D : ℕ}
+
+/-! ### Tensor powers of the physical isometry -/
+
+/-- The coefficient map for the tensor power
+\(U^{\otimes N}:(\mathcal H_a\otimes\mathcal H_b)^{\otimes N}
+\to\mathcal H_{\mathrm{phys}}^{\otimes N}\).
+
+For a virtual-pair configuration \(p=(p_t)_{t=0}^{N-1}\), its image has
+coefficient
+\[
+  (U^{\otimes N}v)_\sigma
+  =\sum_p\prod_{t=0}^{N-1}U^{\sigma_t}_{(p_t)_a,(p_t)_b}\,v_p.
+\]
+
+Source: arXiv:1606.00608, basic-vector equation (3.17), lines 564--578. -/
+noncomputable def AppendixBStructuralData.physicalIsometryTensorPower
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (N : ℕ) :
+    (((Fin N → Fin D × Fin D) → ℂ) →ₗ[ℂ] NSiteSpace d N) where
+  toFun v σ := ∑ p : Fin N → Fin D × Fin D,
+    (∏ t : Fin N, hStruct.U (σ t) (p t).1 (p t).2) * v p
+  map_add' v w := by
+    funext σ
+    simp only [Pi.add_apply, mul_add, Finset.sum_add_distrib]
+  map_smul' c v := by
+    funext σ
+    change (∑ p : Fin N → Fin D × Fin D,
+      (∏ t : Fin N, hStruct.U (σ t) (p t).1 (p t).2) * (c * v p)) =
+        c * ∑ p : Fin N → Fin D × Fin D,
+          (∏ t : Fin N, hStruct.U (σ t) (p t).1 (p t).2) * v p
+    calc
+      _ = ∑ p : Fin N → Fin D × Fin D,
+          c * ((∏ t : Fin N, hStruct.U (σ t) (p t).1 (p t).2) * v p) := by
+        apply Finset.sum_congr rfl
+        intro p _
+        ring
+      _ = _ := by rw [Finset.mul_sum]
+
+/-- The conjugate coefficient map \(U^{*\otimes N}\) associated with the
+physical tensor power.
+
+Source: arXiv:1606.00608, pair-index isometry equation (3.16) and basic-vector
+equation (3.17), lines 549--578. -/
+noncomputable def AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (N : ℕ) :
+    (NSiteSpace d N →ₗ[ℂ] ((Fin N → Fin D × Fin D) → ℂ)) where
+  toFun ψ p := ∑ σ : Cfg d N,
+    (∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) * ψ σ
+  map_add' ψ φ := by
+    funext p
+    simp only [Pi.add_apply, mul_add, Finset.sum_add_distrib]
+  map_smul' c ψ := by
+    funext p
+    change (∑ σ : Cfg d N,
+      (∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) * (c * ψ σ)) =
+        c * ∑ σ : Cfg d N,
+          (∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) * ψ σ
+    calc
+      _ = ∑ σ : Cfg d N,
+          c * ((∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) * ψ σ) := by
+        apply Finset.sum_congr rfl
+        intro σ _
+        ring
+      _ = _ := by rw [Finset.mul_sum]
+
+/-- The source pair-index isometry equation gives
+\(U^{*\otimes N}U^{\otimes N}=1\) at every tensor power.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.17), lines 549--578. -/
+@[simp] theorem AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse_comp
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (N : ℕ) :
+    (hStruct.physicalIsometryTensorPowerLeftInverse N).comp
+        (hStruct.physicalIsometryTensorPower N) = 1 := by
+  classical
+  apply LinearMap.ext
+  intro v
+  funext p
+  change (∑ σ : Cfg d N,
+    (∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) *
+      ∑ q : Fin N → Fin D × Fin D,
+        (∏ t : Fin N, hStruct.U (σ t) (q t).1 (q t).2) * v q) = v p
+  let g (q : Fin N → Fin D × Fin D) (t : Fin N) (i : Fin d) : ℂ :=
+    star (hStruct.U i (p t).1 (p t).2) * hStruct.U i (q t).1 (q t).2
+  have hfactor (q : Fin N → Fin D × Fin D) :
+      Finset.univ.sum (fun σ : Cfg d N ↦
+        Finset.univ.prod fun t : Fin N ↦ g q t (σ t)) =
+        Finset.univ.prod (fun t : Fin N ↦ Finset.univ.sum fun i : Fin d ↦ g q t i) := by
+    simpa only [Fintype.piFinset_univ] using
+      (Finset.sum_prod_piFinset (R := ℂ) (Finset.univ : Finset (Fin d))
+        (fun t i ↦ g q t i))
+  have hdelta (q : Fin N → Fin D × Fin D) :
+      (∏ t : Fin N, if p t = q t then (1 : ℂ) else 0) =
+        if p = q then 1 else 0 := by
+    by_cases hpq : p = q
+    · subst q
+      simp
+    · rw [if_neg hpq]
+      have hpoint : ∃ t : Fin N, p t ≠ q t := by
+        apply not_forall.mp
+        intro h
+        exact hpq (funext h)
+      obtain ⟨t, ht⟩ := hpoint
+      exact Finset.prod_eq_zero (Finset.mem_univ t) (if_neg ht)
+  calc
+    _ = ∑ σ : Cfg d N, ∑ q : Fin N → Fin D × Fin D,
+        ((∏ t : Fin N, star (hStruct.U (σ t) (p t).1 (p t).2)) *
+          (∏ t : Fin N, hStruct.U (σ t) (q t).1 (q t).2)) * v q := by
+      apply Finset.sum_congr rfl
+      intro σ _
+      rw [Finset.mul_sum]
+      apply Finset.sum_congr rfl
+      intro q _
+      ring
+    _ = ∑ q : Fin N → Fin D × Fin D,
+        (∑ σ : Cfg d N, (∏ t : Fin N,
+          star (hStruct.U (σ t) (p t).1 (p t).2) *
+            hStruct.U (σ t) (q t).1 (q t).2)) * v q := by
+      rw [Finset.sum_comm]
+      apply Finset.sum_congr rfl
+      intro q _
+      rw [← Finset.sum_mul]
+      simp_rw [← Finset.prod_mul_distrib]
+    _ = ∑ q : Fin N → Fin D × Fin D,
+        (Finset.univ.prod fun t : Fin N ↦ ∑ i : Fin d,
+          star (hStruct.U i (p t).1 (p t).2) *
+            hStruct.U i (q t).1 (q t).2) * v q := by
+      apply Finset.sum_congr rfl
+      intro q _
+      rw [show (∑ σ : Cfg d N, ∏ t : Fin N,
+          star (hStruct.U (σ t) (p t).1 (p t).2) *
+            hStruct.U (σ t) (q t).1 (q t).2) =
+          ∏ t : Fin N, ∑ i : Fin d,
+            star (hStruct.U i (p t).1 (p t).2) *
+              hStruct.U i (q t).1 (q t).2 by
+        simpa [g] using hfactor q]
+    _ = v p := by
+      simp_rw [hStruct.hU_pair]
+      simp_rw [hdelta]
+      simp
+
+/-- Every tensor power of the physical map is injective.
+
+Source: arXiv:1606.00608, equations (3.16)--(3.17), lines 549--578. -/
+theorem AppendixBStructuralData.physicalIsometryTensorPower_injective
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) (N : ℕ) :
+    Function.Injective (hStruct.physicalIsometryTensorPower N) :=
+  LinearMap.injective_of_comp_eq_id _ _
+    (hStruct.physicalIsometryTensorPowerLeftInverse_comp N)
+
+/-! ### The two-site virtual bond -/
+
+/-- Insert the bond vector
+\(\varphi=\sum_b\lambda_b\lvert b,b\rangle\) between two virtual site pairs.
+
+For outer-boundary coefficients \(v_{a,c}\), the resulting four-index tensor is
+\[
+  (I_\varphi v)_{(a,b),(b',c)}
+  =\delta_{b,b'}\lambda_b v_{a,c}.
+\]
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def AppendixBStructuralData.twoSiteBondInsertion
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    ((Fin D × Fin D → ℂ) →ₗ[ℂ] ((Fin 2 → Fin D × Fin D) → ℂ)) where
+  toFun v p :=
+    if (p 0).2 = (p 1).1 then
+      (hStruct.Λ (p 0).2 : ℂ) * v ((p 0).1, (p 1).2)
+    else 0
+  map_add' v w := by
+    funext p
+    by_cases h : (p 0).2 = (p 1).1
+    · simp [h, mul_add]
+    · simp [h]
+  map_smul' c v := by
+    funext p
+    by_cases h : (p 0).2 = (p 1).1
+    · simp [h, mul_assoc, mul_comm]
+    · simp [h]
+
+/-- The two-site basic-vector embedding
+\(U^{\otimes 2}I_\varphi\), with the bond vector inserted between the two
+neighboring virtual sites.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def AppendixBStructuralData.twoSiteBasicEmbedding
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    ((Fin D × Fin D → ℂ) →ₗ[ℂ] NSiteSpace d 2) :=
+  (hStruct.physicalIsometryTensorPower 2).comp hStruct.twoSiteBondInsertion
+
+/-- Identify a boundary matrix \(Y\) with its two outer virtual indices by
+\(v_{a,c}=\lambda_aY_{c,a}\).
+
+Strict positivity of the diagonal weights makes this map surjective. It is the
+boundary reparametrization that relates the two-site matrix-product map to the
+bond-insertion expression.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+noncomputable def AppendixBStructuralData.weightedTwoSiteBoundary
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    (Matrix (Fin D) (Fin D) ℂ →ₗ[ℂ] (Fin D × Fin D → ℂ)) where
+  toFun X ac := (hStruct.Λ ac.1 : ℂ) * X ac.2 ac.1
+  map_add' X Y := by
+    funext ac
+    simp only [Pi.add_apply, Matrix.add_apply, mul_add]
+  map_smul' c X := by
+    funext ac
+    change (hStruct.Λ ac.1 : ℂ) * (c * X ac.2 ac.1) =
+      c * ((hStruct.Λ ac.1 : ℂ) * X ac.2 ac.1)
+    ring
+
+/-- The weighted outer-boundary parametrization is surjective.
+
+Source: arXiv:1606.00608, Theorem 3.11 and equations (3.17)--(3.18), lines
+543--578. -/
+theorem AppendixBStructuralData.weightedTwoSiteBoundary_surjective
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    Function.Surjective hStruct.weightedTwoSiteBoundary := by
+  intro v
+  refine ⟨fun c a ↦ (hStruct.Λ a : ℂ)⁻¹ * v (a, c), ?_⟩
+  funext ac
+  simp [AppendixBStructuralData.weightedTwoSiteBoundary,
+    ne_of_gt (hStruct.hΛ_pos ac.1)]
+
+/-- The bond-insertion expression is the two-site matrix-product map after the
+weighted boundary reparametrization:
+\[
+  U^{\otimes2}I_\varphi(v_Y)=\Gamma_2(\Lambda U)(Y),
+  \qquad (v_Y)_{a,c}=\lambda_aY_{c,a}.
+\]
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.twoSiteBasicEmbedding_comp_weightedBoundary
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.twoSiteBasicEmbedding.comp hStruct.weightedTwoSiteBoundary =
+      groundSpaceMap hStruct.coreTensor 2 := by
+  classical
+  apply LinearMap.ext
+  intro X
+  funext σ
+  rw [groundSpaceMap_apply]
+  change (∑ p : Fin 2 → Fin D × Fin D,
+      (∏ t : Fin 2, hStruct.U (σ t) (p t).1 (p t).2) *
+        (if (p 0).2 = (p 1).1 then
+          (hStruct.Λ (p 0).2 : ℂ) *
+            ((hStruct.Λ (p 0).1 : ℂ) * X (p 1).2 (p 0).1)
+        else 0)) =
+      Matrix.trace (evalWord hStruct.coreTensor (List.ofFn σ) * X)
+  calc
+    _ = ∑ p₀ : Fin D × Fin D, ∑ p₁ : Fin D × Fin D,
+        hStruct.U (σ 0) p₀.1 p₀.2 * hStruct.U (σ 1) p₁.1 p₁.2 *
+          (if p₀.2 = p₁.1 then
+            (hStruct.Λ p₀.2 : ℂ) * ((hStruct.Λ p₀.1 : ℂ) * X p₁.2 p₀.1)
+          else 0) := by
+      rw [← (finTwoArrowEquiv (Fin D × Fin D)).symm.sum_comp]
+      rw [Fintype.sum_prod_type]
+      simp [finTwoArrowEquiv_symm_apply, Fin.prod_univ_two]
+    _ = ∑ a : Fin D, ∑ b : Fin D, ∑ c : Fin D,
+        hStruct.U (σ 0) a b * hStruct.U (σ 1) b c *
+          ((hStruct.Λ b : ℂ) * ((hStruct.Λ a : ℂ) * X c a)) := by
+      simp [Fintype.sum_prod_type]
+    _ = Matrix.trace (evalWord hStruct.coreTensor (List.ofFn σ) * X) := by
+      rw [show evalWord hStruct.coreTensor (List.ofFn σ) =
+          hStruct.coreTensor (σ 0) * hStruct.coreTensor (σ 1) by
+        simp [evalWord, List.ofFn_succ, List.ofFn_zero]]
+      simp only [Matrix.trace, Matrix.diag_apply, Matrix.mul_apply]
+      simp only [AppendixBStructuralData.coreTensor_apply, Matrix.diagonal_mul]
+      simp_rw [Finset.sum_mul]
+      apply Finset.sum_congr rfl
+      intro a _
+      rw [Finset.sum_comm]
+      apply Finset.sum_congr rfl
+      intro c _
+      apply Finset.sum_congr rfl
+      intro b _
+      ring
+
+/-- The two-site bond-insertion image is exactly the Appendix B basic support:
+\[
+  \operatorname{ran}(U^{\otimes2}I_\varphi)=G_2(\Lambda U).
+\]
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.twoSiteBasicEmbedding_range
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    LinearMap.range hStruct.twoSiteBasicEmbedding = hStruct.twoSiteBasicSpace := by
+  rw [AppendixBStructuralData.twoSiteBasicSpace, groundSpace]
+  apply le_antisymm
+  · rintro ψ ⟨v, rfl⟩
+    obtain ⟨X, rfl⟩ := hStruct.weightedTwoSiteBoundary_surjective v
+    refine ⟨X, ?_⟩
+    exact (LinearMap.congr_fun hStruct.twoSiteBasicEmbedding_comp_weightedBoundary X).symm
+  · rintro ψ ⟨X, rfl⟩
+    refine ⟨hStruct.weightedTwoSiteBoundary X, ?_⟩
+    exact LinearMap.congr_fun hStruct.twoSiteBasicEmbedding_comp_weightedBoundary X
+
+/-- The orthogonal support projector of the two-site basic-vector image
+\(G_2(\Lambda U)\).
+
+The virtual orthogonal projector onto \(\mathbb C\varphi\), its two adjacent
+placements on a three-site virtual chain, and their transport to
+range-restricted overlapping operators remain separate steps. These operators
+must then be extended to the full physical \(AX\) and \(XB\) support projectors.
+Since \(U\) need not be surjective, this extension must account for the
+spectator complement of \(UU^*\).
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578, and
+Definition D.2, lines 2205--2218. -/
+noncomputable def AppendixBStructuralData.twoSiteBasicSupportProjection
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    NSiteSpace d 2 →ₗ[ℂ] NSiteSpace d 2 :=
+  let e := WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)
+  e.toLinearMap.comp ((groundSpaceES hStruct.coreTensor 2).starProjection.toLinearMap.comp
+    e.symm.toLinearMap)
+
+/-- The range of the two-site support projector is the Appendix B basic support.
+
+Source: arXiv:1606.00608, lines 511--524 and 564--578. -/
+theorem AppendixBStructuralData.twoSiteBasicSupportProjection_range
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    LinearMap.range hStruct.twoSiteBasicSupportProjection = hStruct.twoSiteBasicSpace := by
+  rw [AppendixBStructuralData.twoSiteBasicSpace]
+  ext ψ
+  constructor
+  · rintro ⟨v, rfl⟩
+    change (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2))
+      ((groundSpaceES hStruct.coreTensor 2).starProjection
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm v)) ∈
+        groundSpace hStruct.coreTensor 2
+    apply (mem_groundSpaceES_iff hStruct.coreTensor 2 _).1
+    exact Submodule.starProjection_apply_mem _ _
+  · intro hψ
+    refine ⟨ψ, ?_⟩
+    change (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2))
+      ((groundSpaceES hStruct.coreTensor 2).starProjection
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm ψ)) = ψ
+    have hψES : (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm ψ ∈
+        groundSpaceES hStruct.coreTensor 2 := by
+      apply (mem_groundSpaceES_iff hStruct.coreTensor 2 _).2
+      simpa using hψ
+    rw [Submodule.starProjection_eq_self_iff.mpr hψES,
+      LinearEquiv.apply_symm_apply]
+
+/-- The two-site support projector is complementary to the canonical parent
+interaction of the core tensor:
+\(P_{G_2(\Lambda U)}=1-q_2(\Lambda U)\).
+
+Source: arXiv:1606.00608, parent construction, lines 511--524. -/
+theorem AppendixBStructuralData.twoSiteBasicSupportProjection_eq_complement
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.twoSiteBasicSupportProjection =
+      1 - parentInteraction hStruct.coreTensor 2 := by
+  apply LinearMap.ext
+  intro v
+  change (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2))
+      ((groundSpaceES hStruct.coreTensor 2).starProjection
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm v)) =
+    v - (WithLp.linearEquiv 2 ℂ (NSiteSpace d 2))
+      ((groundSpaceES hStruct.coreTensor 2)ᗮ.starProjection
+        ((WithLp.linearEquiv 2 ℂ (NSiteSpace d 2)).symm v))
+  rw [Submodule.starProjection_orthogonal_val]
+  simp
+
+/-- The two-site basic support operator is idempotent.
+
+Source: arXiv:1606.00608, parent construction, lines 511--524. -/
+theorem AppendixBStructuralData.twoSiteBasicSupportProjection_idempotent
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.twoSiteBasicSupportProjection * hStruct.twoSiteBasicSupportProjection =
+      hStruct.twoSiteBasicSupportProjection := by
+  rw [hStruct.twoSiteBasicSupportProjection_eq_complement]
+  apply LinearMap.ext
+  intro v
+  simp only [Module.End.mul_apply, LinearMap.sub_apply, Module.End.one_apply, map_sub]
+  have hq := LinearMap.congr_fun (parentInteraction_idempotent hStruct.coreTensor 2) v
+  simp only [Module.End.mul_apply] at hq
+  rw [hq]
+  abel
+
+/-- The range of the support projector is the range of the bond-insertion
+embedding \(U^{\otimes2}I_\varphi\).
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.twoSiteBasicSupportProjection_range_eq_embedding
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    LinearMap.range hStruct.twoSiteBasicSupportProjection =
+      LinearMap.range hStruct.twoSiteBasicEmbedding := by
+  rw [hStruct.twoSiteBasicSupportProjection_range,
+    hStruct.twoSiteBasicEmbedding_range]
+
+/-- The canonical parent interaction annihilates every vector in the two-site
+bond-insertion image.
+
+Source: arXiv:1606.00608, parent construction, lines 511--524, and equations
+(3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.parentInteraction_apply_twoSiteBasicEmbedding
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (v : Fin D × Fin D → ℂ) :
+    parentInteraction hStruct.coreTensor 2 (hStruct.twoSiteBasicEmbedding v) = 0 := by
+  apply parentInteraction_apply_mem_groundSpace
+  rw [← AppendixBStructuralData.twoSiteBasicSpace]
+  rw [← hStruct.twoSiteBasicEmbedding_range]
+  exact ⟨v, rfl⟩
+
+/-- The two-site support projector fixes the bond-insertion image pointwise.
+
+Source: arXiv:1606.00608, parent construction, lines 511--524, and equations
+(3.17)--(3.18), lines 564--578. -/
+theorem AppendixBStructuralData.twoSiteBasicSupportProjection_apply_embedding
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A)
+    (v : Fin D × Fin D → ℂ) :
+    hStruct.twoSiteBasicSupportProjection (hStruct.twoSiteBasicEmbedding v) =
+      hStruct.twoSiteBasicEmbedding v := by
+  rw [hStruct.twoSiteBasicSupportProjection_eq_complement]
+  simp [LinearMap.sub_apply, Module.End.one_apply,
+    hStruct.parentInteraction_apply_twoSiteBasicEmbedding v]
+
+/-- The range, complement, and pointwise characterization of the two-site
+basic support projector.
+
+Source: arXiv:1606.00608, equations (3.17)--(3.18), lines 564--578, and
+Definition D.2, lines 2205--2218. -/
+theorem AppendixBStructuralData.twoSiteBasicSupportProjection_spec
+    {A : MPSTensor d D} (hStruct : AppendixBStructuralData A) :
+    hStruct.twoSiteBasicSupportProjection * hStruct.twoSiteBasicSupportProjection =
+        hStruct.twoSiteBasicSupportProjection ∧
+      LinearMap.range hStruct.twoSiteBasicSupportProjection =
+        LinearMap.range hStruct.twoSiteBasicEmbedding ∧
+      hStruct.twoSiteBasicSupportProjection =
+        1 - parentInteraction hStruct.coreTensor 2 ∧
+      ∀ v : Fin D × Fin D → ℂ,
+        parentInteraction hStruct.coreTensor 2 (hStruct.twoSiteBasicEmbedding v) = 0 ∧
+        hStruct.twoSiteBasicSupportProjection (hStruct.twoSiteBasicEmbedding v) =
+          hStruct.twoSiteBasicEmbedding v := by
+  exact ⟨hStruct.twoSiteBasicSupportProjection_idempotent,
+    hStruct.twoSiteBasicSupportProjection_range_eq_embedding,
+    hStruct.twoSiteBasicSupportProjection_eq_complement,
+    fun v ↦ ⟨hStruct.parentInteraction_apply_twoSiteBasicEmbedding v,
+      hStruct.twoSiteBasicSupportProjection_apply_embedding v⟩⟩
+
+end MPSTensor

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -32,13 +32,18 @@ where \(\varphi_j\) is shared by \(b_n\) and \(a_{n+1}\), and \(U\) acts on
 basic-vector form to commutativity of the translated two-site terms
 \(h_i=\tau_i(P_2^\perp)\).
 
-The declarations below separate four mathematical statements:
+The declarations below separate the following mathematical statements:
 
-* the coefficient expression for \(U^{\otimes L}\varphi_j^{\otimes L}\);
+* the coefficient expression for
+  \(U^{\otimes L}\varphi_j^{\otimes L}\);
 * the even-chain physical-pair factorization condition used later in this file;
 * the two local coefficient-space representatives used before the \(AX\) and
   \(XB\) lifts;
 * the already formalized Appendix B structural form.
+
+The tensor powers of \(U\), the two-site bond insertion, the equality of its
+physical image with \(G_2(\Lambda U)\), and the orthogonal support projector are
+constructed in `TNLean.MPS.RFP.AppendixBSupport`.
 
 **Scope restriction (overlapping two-site terms):** The source \(AX\) and
 \(XB\) support maps are treated in their basic-vector form. Definition D.2 of
@@ -50,9 +55,17 @@ Appendix B core-tensor comparison, before it is placed on the \(AX\) and \(XB\)
 faces. They do not by themselves construct the source projectors on
 \(\mathcal H_A\otimes\mathcal H_X\) and
 \(\mathcal H_X\otimes\mathcal H_B\), nor do they prove the lifted commutator.
-For this reason commutativity of the translated idempotents is kept as an
-explicit hypothesis. Eliminating this hypothesis is the source
-projector-construction and commutator step recorded in
+The tensor-power and physical support constructions are provided in
+`TNLean.MPS.RFP.AppendixBSupport`.  The remaining step is to construct the
+orthogonal projector onto the virtual bond subspace \(\mathbb C\varphi_j\), place
+two copies on a three-site virtual chain, transport them through
+\(U^{\otimes3}\), and pass from the spectator range projector \(UU^*\) to the
+full physical identity.  This last passage must use the containment of the
+two-site support in \(\operatorname{ran}(U)^{\otimes2}\).  The complements of
+the resulting physical support projectors can then be identified with the two
+coefficient representatives.  For this reason commutativity of the translated
+idempotents is kept as an explicit hypothesis. The remaining commutator step is
+recorded in
 `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex`.
 -/
 

--- a/TNLean/MPS/RFP/CommutingBridge.lean
+++ b/TNLean/MPS/RFP/CommutingBridge.lean
@@ -56,7 +56,7 @@ faces. They do not by themselves construct the source projectors on
 \(\mathcal H_A\otimes\mathcal H_X\) and
 \(\mathcal H_X\otimes\mathcal H_B\), nor do they prove the lifted commutator.
 The tensor-power and physical support constructions are provided in
-`TNLean.MPS.RFP.AppendixBSupport`.  The remaining step is to construct the
+`TNLean.MPS.RFP.AppendixBSupport`. The remaining step is to construct the
 orthogonal projector onto the virtual bond subspace \(\mathbb C\varphi_j\), place
 two copies on a three-site virtual chain, transport them through
 \(U^{\otimes3}\), and pass from the spectator range projector \(UU^*\) to the

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1195,7 +1195,7 @@ the specialization $L=2$.
 
 \begin{theorem}[The two-site basic-vector image]
     \label{thm:appendixB_two_site_basic_embedding_range}
-    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicEmbedding_comp_weightedBoundary}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicEmbedding_comp_weightedTwoSiteBoundary}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicEmbedding_range}
     \leanok
     \uses{def:appendixB_two_site_bond_embedding,
@@ -1240,6 +1240,7 @@ the specialization $L=2$.
 \begin{theorem}[Range and complement of the two-site basic support projector]
     \label{thm:appendixB_two_site_basic_support_projector}
     \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicSupportProjection_spec}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicEmbedding_range}
     \leanok
     \uses{def:appendixB_two_site_basic_support_projector,
         def:appendixB_two_site_bond_embedding, def:parent_interaction}
@@ -1264,7 +1265,17 @@ the specialization $L=2$.
     The preceding theorem identifies this range with
     $\operatorname{ran}(U^{\otimes2}I_\varphi)$.  Orthogonal projection onto
     the complementary subspace is $q_2(\Lambda U)$, hence
-    $P_2=1-q_2(\Lambda U)$. Idempotence and the two pointwise statements follow.
+    $P_2=1-q_2(\Lambda U)$. Since $q_2(\Lambda U)^2=q_2(\Lambda U)$,
+    \[
+        P_2^2=(1-q_2(\Lambda U))^2=1-q_2(\Lambda U)=P_2.
+    \]
+    If $\psi$ lies in $\operatorname{ran}(U^{\otimes2}I_\varphi)$, then
+    $\psi\in G_2(\Lambda U)=\ker q_2(\Lambda U)$, and therefore
+    \[
+        q_2(\Lambda U)\psi=0,
+        \qquad
+        P_2\psi=(1-q_2(\Lambda U))\psi=\psi.
+    \]
 \end{proof}
 
 \begin{definition}[Appendix B \(AX\) coefficient representative]

--- a/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
+++ b/blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex
@@ -1054,6 +1054,72 @@ the specialization $L=2$.
     A map with a left inverse is injective.
 \end{proof}
 
+\begin{definition}[Tensor powers of the physical isometry]
+    \label{def:appendixB_physical_isometry_tensor_power}
+    \lean{MPSTensor.AppendixBStructuralData.physicalIsometryTensorPower}
+    \lean{MPSTensor.AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse}
+    \leanok
+    \uses{def:appendixB_physical_isometry}
+    For every $N\geq 0$, the coefficients of $U$ define
+    \[
+        U^{\otimes N}:
+        (\mathcal H_a\otimes\mathcal H_b)^{\otimes N}
+        \longrightarrow \mathcal H_{\mathrm{phys}}^{\otimes N},
+    \]
+    with
+    \[
+        (U^{\otimes N}v)_\sigma
+        =
+        \sum_{p_0,\ldots,p_{N-1}}
+        \left(\prod_{t=0}^{N-1}
+          U^{\sigma_t}_{(p_t)_a,(p_t)_b}\right)
+        v_{p_0,\ldots,p_{N-1}}.
+    \]
+    The conjugate coefficient map is
+    \[
+        (U^{*\otimes N}\psi)_p
+        =
+        \sum_\sigma
+        \left(\prod_{t=0}^{N-1}
+          \overline{U^{\sigma_t}_{(p_t)_a,(p_t)_b}}\right)
+        \psi_\sigma.
+    \]
+    This is the tensor power occurring in the basic-vector expression
+    \cite[Equation~(3.17)]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[The tensor powers are isometric embeddings]
+    \label{thm:appendixB_physical_isometry_tensor_power}
+    \lean{MPSTensor.AppendixBStructuralData.physicalIsometryTensorPowerLeftInverse_comp}
+    \lean{MPSTensor.AppendixBStructuralData.physicalIsometryTensorPower_injective}
+    \leanok
+    \uses{def:appendixB_physical_isometry_tensor_power}
+    For every $N\geq 0$,
+    \[
+        U^{*\otimes N}U^{\otimes N}=1.
+    \]
+    Hence $U^{\otimes N}$ is injective.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For virtual-pair configurations $p$ and $q$, interchange the two finite
+    sums and factor the sum over physical configurations site by site:
+    \[
+        \sum_\sigma
+        \prod_t
+        \overline{U^{\sigma_t}_{(p_t)_a,(p_t)_b}}
+        U^{\sigma_t}_{(q_t)_a,(q_t)_b}
+        =
+        \prod_t\sum_i
+        \overline{U^i_{(p_t)_a,(p_t)_b}}
+        U^i_{(q_t)_a,(q_t)_b}.
+    \]
+    The pair-index isometry equation turns the last product into
+    $\prod_t\delta_{p_t,q_t}=\delta_{p,q}$. Therefore the coefficient at $p$
+    is $v_p$. A map with a left inverse is injective.
+\end{proof}
+
 \begin{theorem}[Appendix B basis change and the parent interaction]
     \label{lem:appendixB_basis_change_parent_interaction}
     \lean{MPSTensor.AppendixBStructuralData.parentInteraction_eq_coreTensor}
@@ -1085,6 +1151,121 @@ the specialization $L=2$.
         G_2(A_{\mathrm{core}})=G_2(\Lambda U).
     \]
 \end{definition}
+
+\begin{definition}[Two-site bond insertion and basic-vector embedding]
+    \label{def:appendixB_two_site_bond_embedding}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBondInsertion}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicEmbedding}
+    \lean{MPSTensor.AppendixBStructuralData.weightedTwoSiteBoundary}
+    \leanok
+    \uses{def:appendixB_physical_isometry_tensor_power}
+    Put
+    \[
+        \ket{\varphi}=\sum_b\lambda_b\ket{b,b}.
+    \]
+    For outer-boundary coefficients $v_{a,c}$, insertion of this vector on the
+    middle virtual bond is the map $I_\varphi$ defined by
+    \[
+        (I_\varphi v)_{(a,b),(b',c)}
+        =\delta_{b,b'}\lambda_bv_{a,c}.
+    \]
+    The two-site physical map is $U^{\otimes2}I_\varphi$.  A boundary matrix
+    $Y$ determines outer-boundary coefficients by
+    \[
+        (v_Y)_{a,c}=\lambda_aY_{c,a}.
+    \]
+    Opening the outer virtual bond in the two-site contraction of
+    \cite[Equations~(3.17)--(3.18)]{Cirac2016MPDO_arXiv} gives these
+    coefficients.
+\end{definition}
+
+\begin{theorem}[Surjectivity of the weighted boundary parametrization]
+    \label{thm:appendixB_weighted_two_site_boundary_surjective}
+    \lean{MPSTensor.AppendixBStructuralData.weightedTwoSiteBoundary_surjective}
+    \leanok
+    \uses{def:appendixB_two_site_bond_embedding}
+    Strict positivity of the $\lambda_a$ makes $Y\mapsto v_Y$ surjective.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    For prescribed coefficients $v_{a,c}$, take
+    $Y_{c,a}=\lambda_a^{-1}v_{a,c}$.
+\end{proof}
+
+\begin{theorem}[The two-site basic-vector image]
+    \label{thm:appendixB_two_site_basic_embedding_range}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicEmbedding_comp_weightedBoundary}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicEmbedding_range}
+    \leanok
+    \uses{def:appendixB_two_site_bond_embedding,
+        def:appendixB_two_site_basic_space}
+    Opening the outer virtual bond in the two-site contraction of
+    \cite[Equations~(3.17)--(3.18)]{Cirac2016MPDO_arXiv} gives the following
+    local-support family.
+    For every boundary matrix $Y$,
+    \[
+        U^{\otimes2}I_\varphi(v_Y)=\Gamma_2(\Lambda U)(Y).
+    \]
+    Consequently,
+    \[
+        \operatorname{ran}(U^{\otimes2}I_\varphi)=G_2(\Lambda U).
+    \]
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:appendixB_weighted_two_site_boundary_surjective}
+    At a two-site physical configuration $(i,j)$, the bond insertion gives
+    \[
+        \sum_{a,b,c}
+        U^i_{a,b}U^j_{b,c}\lambda_b\lambda_aY_{c,a}.
+    \]
+    Expanding
+    $\operatorname{tr}((\Lambda U^i)(\Lambda U^j)Y)$ gives the same sum, so
+    the two maps agree after the weighted boundary parametrization. Since that
+    parametrization is surjective, their ranges are equal.
+\end{proof}
+
+\begin{definition}[Two-site basic support projector]
+    \label{def:appendixB_two_site_basic_support_projector}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicSupportProjection}
+    \leanok
+    \uses{def:appendixB_two_site_basic_space}
+    Let $P_2$ be the orthogonal projector onto $G_2(\Lambda U)$, as in the
+    local parent-space construction of
+    \cite[Definition~3.9]{Cirac2016MPDO_arXiv}.
+\end{definition}
+
+\begin{theorem}[Range and complement of the two-site basic support projector]
+    \label{thm:appendixB_two_site_basic_support_projector}
+    \lean{MPSTensor.AppendixBStructuralData.twoSiteBasicSupportProjection_spec}
+    \leanok
+    \uses{def:appendixB_two_site_basic_support_projector,
+        def:appendixB_two_site_bond_embedding, def:parent_interaction}
+    The projector $P_2$ satisfies
+    \[
+        P_2^2=P_2,
+        \qquad
+        \operatorname{ran}(P_2)
+        =\operatorname{ran}(U^{\otimes2}I_\varphi)
+        =G_2(\Lambda U),
+        \qquad
+        P_2=1-q_2(\Lambda U).
+    \]
+    In particular, $q_2(\Lambda U)$ annihilates the image of
+    $U^{\otimes2}I_\varphi$, while $P_2$ fixes that image pointwise.
+\end{theorem}
+
+\begin{proof}
+    \leanok
+    \uses{thm:appendixB_two_site_basic_embedding_range}
+    Orthogonal projection onto $G_2(\Lambda U)$ has that subspace as its range.
+    The preceding theorem identifies this range with
+    $\operatorname{ran}(U^{\otimes2}I_\varphi)$.  Orthogonal projection onto
+    the complementary subspace is $q_2(\Lambda U)$, hence
+    $P_2=1-q_2(\Lambda U)$. Idempotence and the two pointwise statements follow.
+\end{proof}
 
 \begin{definition}[Appendix B \(AX\) coefficient representative]
     \label{def:appendixB_qax}

--- a/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
+++ b/docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex
@@ -124,6 +124,36 @@ isometry
 recorded by
 \leanid{MPSTensor.AppendixBStructuralData.physicalIsometry} and
 \leanid{MPSTensor.AppendixBStructuralData.physicalIsometryLeftInverse_comp}.
+For every length \(L\), the tensor power \(U^{\otimes L}\) and its conjugate
+coefficient map now satisfy
+\begin{align}
+  U^{*\otimes L}U^{\otimes L}=1.
+\end{align}
+This identity is recorded by
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{physicalIsometryTensorPowerLeftInverse_comp}.
+The two-site bond insertion
+\begin{align}
+  (I_\varphi v)_{(a,b),(b',c)}
+  =\delta_{b,b'}\lambda_bv_{a,c}
+\end{align}
+has also been transported through \(U^{\otimes2}\).  The range calculation
+\begin{align}
+  \operatorname{ran}(U^{\otimes2}I_\varphi)=G_2(A_{\mathrm{core}})
+\end{align}
+is recorded by
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{twoSiteBasicEmbedding_range}.
+The orthogonal projector \(P_2\) onto this range is
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{twoSiteBasicSupportProjection}; it
+satisfies
+\begin{align}
+  P_2=1-q_2(A_{\mathrm{core}}).
+\end{align}
+The complement identity is
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{twoSiteBasicSupportProjection_eq_complement}.
 The coefficient-space representatives
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQAXOnCoeffSpace} and
 \leanid{MPSTensor.AppendixBStructuralData.appendixBQXBOnCoeffSpace} are now identified with
@@ -131,14 +161,20 @@ the canonical two-site parent interaction \(q_2(A)\) before placement on the
 \(AX\) and \(XB\) faces.  They should not be read as the source tripartite
 projectors themselves.  A supplied lifted commutator for these representatives
 has been transported to the first two translated three-site parent terms.  The
-remaining local step is to form the tensor powers of this physical embedding,
-transport the rank-one projector onto
-\(\varphi=\sum_m\lambda_m|m,m\rangle\) to the two adjacent bonds, identify the
-resulting two-site ranges with \(G_2(A_{\mathrm{core}})\), and hence identify
-their complementary projectors with the coefficient representatives above.
-Only after these range equalities are proved does the disjoint-bond
-commutation give the lifted \(AX/XB\) commutator.  One must then extend
-the local transport to the all-chain family of two-site parent projectors.  On
+remaining local step begins by constructing the orthogonal projector onto the
+one-bond virtual subspace \(\mathbb C\varphi\), which is distinct from the
+physical projector \(P_2\) above.  Two copies must be placed on the adjacent
+virtual bonds of a three-site chain and proved to commute.  Their actions must
+then be transported through \(U^{\otimes3}\) on the isometry range and extended
+to the full physical \(AX\) and \(XB\) support projectors.  Since \(U\) need not
+be surjective, direct transport has the spectator range projector \(R=UU^*\) in
+place of the full identity.  The spectator identity must be decomposed as
+\(R+(1-R)\), and the containment \(P_2\leq R\otimes R\) must be used to show
+that the cross-products involving \(1-R\) vanish.  Taking orthogonal
+complements can then identify the physical projectors with the two coefficient
+representatives above and give their lifted commutator.  One must finally
+extend the local transport to the all-chain family of two-site parent
+projectors.  On
 the coefficient side, the source statement is the basic-vector formula
 \(|V^{(L)}(A_j)\rangle=U^{\otimes L}|\varphi_j\rangle^{\otimes L}\), where
 \(\varphi_j\) is shared between neighboring virtual spins.  The even-chain
@@ -172,13 +208,15 @@ basis of normal tensors of $A$.\footnote{Tracked by \ghissue{2633}.}
 The current proof boundary is therefore: the reverse implication has the
 source ground-space hypothesis, but its proof is still the Beigi axiom; the
 forward implication has the source-unit Appendix~B structural datum, its
-physical isometric embedding with explicit left inverse, the three-site
+physical isometric embedding and all tensor powers with explicit left
+inverses, the two-site bond insertion, the equality of its physical image with
+\(G_2(A_{\mathrm{core}})\), its orthogonal support projector, the three-site
 \(AX/XB\) support maps, and the coefficient form of
-\(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks tensor-product maps for
-the virtual factors, the transported bond projectors, the equality of their
-ranges with the two-site local ground spaces, and the resulting lifted
-commutator,
-the local-projector hypotheses for all chains of length at least two, and a
+\(U^{\otimes L}\varphi_j^{\otimes L}\).  It still lacks the orthogonal
+projector onto \(\mathbb C\varphi_j\), its two adjacent placements on a
+three-site virtual chain, the spectator-complement passage from \(UU^*\) to the
+physical identity, and the resulting lifted commutator, the local-projector
+hypotheses for all chains of length at least two, and a
 justified relation between the source formula and the even-chain physical-pair
 factorization used by the conditional theorem.
 The axiom-backed theorem still supplies the commutation direction used by the

--- a/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
+++ b/docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex
@@ -82,6 +82,32 @@ The scalar pair-index equation has now been assembled into the physical map
 \end{align}
 in \leanid{MPSTensor.AppendixBStructuralData.physicalIsometry} and
 \leanid{MPSTensor.AppendixBStructuralData.physicalIsometryLeftInverse_comp}.
+The tensor-power maps now satisfy
+\begin{align}
+  U^{*\otimes L}U^{\otimes L}=1
+\end{align}
+for every \(L\), as recorded by
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{physicalIsometryTensorPowerLeftInverse_comp}.
+On two sites, the inserted virtual bond
+\begin{align}
+  (I_\varphi v)_{(a,b),(b',c)}
+  =\delta_{b,b'}\lambda_bv_{a,c}
+\end{align}
+has physical image
+\begin{align}
+  \operatorname{ran}(U^{\otimes2}I_\varphi)=G_2(A_{\mathrm{core}}).
+\end{align}
+This is
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{twoSiteBasicEmbedding_range}.
+The orthogonal projector onto this image is
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{twoSiteBasicSupportProjection}, and
+its complementary projector is exactly \(q_2(A_{\mathrm{core}})\), as recorded
+by
+\leanid{MPSTensor.AppendixBStructuralData.}\hspace{0pt}
+\leanid{twoSiteBasicSupportProjection_eq_complement}.
 The elementary passage from \(Q_{AX},Q_{XB}\) to their complements
 \(1-Q_{AX},1-Q_{XB}\) is recorded by
 \leanid{MPSTensor.HasOverlappingTwoSiteCommutation.complement}.  The
@@ -107,18 +133,23 @@ and
 
 \section{Elimination plan}
 
-A source-faithful version should build on the existing \(AX/XB\) support layer
-by constructing tensor-product maps for the virtual factors and transporting
-the rank-one projector onto
-\(\varphi=\sum_m\lambda_m|m,m\rangle\) through the physical isometry.  The
-ranges of the resulting two-site maps must be proved equal to the local spaces
-\(K_{AX}\) and \(K_{XB}\); their complementary orthogonal projectors then give
-\(Q_{AX}\) and \(Q_{XB}\).  Commutation follows at the virtual level because
-the two bond projectors act on distinct bonds, and must then be transported to
-the common three-site physical space.  It should finally
-explain why their coefficient representatives are the two lifted copies of
-\(q_2(A)\), prove the lifted commutator, and derive the idempotent-product
-declaration above as a lemma, with \(P_K=P_{AXB}\).
+A source-faithful continuation should first construct the orthogonal projector
+onto the one-bond virtual subspace \(\mathbb C\varphi\), where
+\(\varphi=\sum_m\lambda_m\lvert m,m\rangle\).  This is distinct from the
+physical two-site support projector constructed above.  Two copies of the
+virtual projector must then be placed on the adjacent bonds of a three-site
+virtual chain.  They commute because they act on distinct bond factors.  Their
+actions must be transported through \(U^{\otimes3}\) on the isometry range and
+then extended to the full physical \(AX\) and \(XB\) support projectors.  Here
+\(U\) is only an isometry.  If \(R=UU^*\), direct transport gives
+\(P_{2,AX}\otimes R_B\) and \(R_A\otimes P_{2,XB}\), rather than the full lifts
+with spectator identity.
+One must decompose each spectator identity as \(R+(1-R)\) and use
+\(P_2\leq R\otimes R\) to show that every cross-product involving a spectator
+complement vanishes.  Passing to orthogonal complements should then identify
+the resulting projectors with the two lifted copies of \(q_2(A)\), prove the
+lifted commutator, and derive the idempotent-product declaration above as a
+lemma, with \(P_K=P_{AXB}\).
 
 After that source-level version is available, the blueprint entry for the source
 parent commuting Hamiltonian condition should point to that statement.  The


### PR DESCRIPTION
### Motivation

- Appendix B of arXiv:1606.00608 (equations (3.16)–(3.18), lines 543–578, and
  Definition D.2, lines 2205–2218) requires identifying the physical two-site
  support of the parent Hamiltonian projectors. This PR formalizes the orthogonal
  projector onto that support and the range equality connecting bond-insertion maps
  to the boundary parametrization — a prerequisite for #3373.
- The local parent-space construction at lines 511–524 provides the coefficient
  identity needed to characterize the image; the projector complement formula
  `P_2 = 1 − q_2(ΛU)` closes the two-site support layer.

### Description

- **New file** `TNLean/MPS/RFP/AppendixBSupport.lean` (465 lines):
  - Constructs tensor powers `U^{⊗N}` of the physical isometry with left inverses
    satisfying `U^{*⊗N} U^{⊗N} = 1`.
  - Defines the bond-insertion map `I_φ` and the weighted outer-boundary
    parametrization.
  - Proves the coefficient identity `U^{⊗2} I_φ(v_Y) = Γ_2(ΛU)(Y)` and hence
    `ran(U^{⊗2} I_φ) = G_2(ΛU)`.
  - Defines the orthogonal projector `P_2` onto the two-site physical support;
    proves `P_2² = P_2`, `ran(P_2) = G_2(ΛU)`, and `P_2 = 1 − q_2(ΛU)`.
- **Modified** `TNLean/MPS/RFP/CommutingBridge.lean`: references `AppendixBSupport`
  and documents remaining open obligations — virtual projectors on the `C_φ` factor,
  spectator-complement transport under `UU†`, adjacent commutation, and the all-chain
  `HasProductPairLocalProjectors` witness.
- **Modified** `blueprint/src/chapter/ch13_parent_hamiltonian_commuting_gap.tex`:
  adds entries for the new definitions and theorems with `\lean{...}` links.
- **Modified** `docs/paper-gaps/cpsv16_nncph_ground_state_scope.tex` and
  `docs/paper-gaps/cpsv16_parent_commuting_hamiltonian_scope.tex`: records the new
  Lean identifiers as complete and refines the elimination plan for the remaining
  commutator step.
- This PR does **not** claim the full Appendix B commuting-projector conclusion;
  the remaining obligations are documented in the existing paper-gap notes.

### Testing

- `lake build TNLean` succeeded.
- Focused Lean checks on both changed RFP modules after rebasing onto current `main`.
- `leanblueprint checkdecls` passed; blueprint/Lean synchronization confirmed.
- Blueprint PDF (430 pages) built; new Appendix B entries visually inspected.
- Axiom audit confirmed principal declarations use only standard axioms.

---
Addresses #3373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive formalization and documentation on the RFP/Appendix B track; no auth, runtime, or API surface changes. Remaining proof obligations are explicitly scoped.
> 
> **Overview**
> Formalizes the **Appendix B** local support layer (arXiv:1606.00608, eqs. 3.16–3.18): tensor powers `U^{⊗N}` with `U^{*⊗N}U^{⊗N}=1`, bond insertion `I_φ`, weighted boundary reparametrization, and **`ran(U^{⊗2}I_φ) = G₂(ΛU)`** via `Γ₂(ΛU)`.
> 
> Defines the orthogonal two-site support projector **`P₂`** and proves **`P₂ = 1 − q₂(ΛU)`**, idempotency, range agreement with the bond-insertion map, and annihilation/fixing properties on that image.
> 
> **New** `TNLean/MPS/RFP/AppendixBSupport.lean`; root import and **`CommutingBridge`** module docs now point here and spell out remaining work (virtual **`ℂφ`** projector, three-site placement, **`UU*`** spectator extension to full physical AX/XB projectors).
> 
> **Blueprint** ch13 and **paper-gap** notes add `\lean{...}` links and refresh elimination plans; the full lifted commutator is **not** claimed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc0e48a4d7e643f286a21f59ef44a40f57323ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->