### PR TITLE
fix(MPS/CanonicalForm): record unit spectral radius in normal tensors

### DIFF
--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -6,7 +6,6 @@ import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Overlap.Basic
 import TNLean.Channel.Peripheral.Spectrum
-import TNLean.Channel.Irreducible.SpectralRadius
 
 /-!
 # Normal tensor and basis of normal tensors (CPSV16)
@@ -64,16 +63,16 @@ A connection is intentionally not provided here:
 
 * A BNT connection `IsCPSVBasisOfNormalTensors.of_isBNT` would require the implication
   `MPSTensor.IsNormal → IsNormalTensor` per block, i.e. from algebraic eventual
-  block injectivity to the CPSV16 (no-invariant-proj + primitive-transfer)
-  formulation. That equivalence requires Wielandt-style spectral arguments not
-  developed at this layer.
+  block injectivity to the CPSV16 conditions of no nontrivial invariant projection,
+  unit spectral radius, and unique peripheral eigenvalue. That equivalence requires
+  Wielandt-style spectral arguments not developed at this layer.
 
 ## Style
 
 Follows `docs/MATHLIB_style.md` and `docs/MATHLIB_naming.md`.
 -/
 
-open scoped Matrix BigOperators
+open scoped Matrix BigOperators Matrix.Norms.Operator
 
 namespace MPSTensor
 

--- a/TNLean/MPS/CanonicalForm/Definitions.lean
+++ b/TNLean/MPS/CanonicalForm/Definitions.lean
@@ -6,6 +6,7 @@ import TNLean.MPS.CanonicalForm.Reduction
 import TNLean.MPS.Core.Transfer
 import TNLean.MPS.Overlap.Basic
 import TNLean.Channel.Peripheral.Spectrum
+import TNLean.Channel.Irreducible.SpectralRadius
 
 /-!
 # Normal tensor and basis of normal tensors (CPSV16)
@@ -45,12 +46,13 @@ The predicates in this file are the CPSV formulations.
 ## Relation to the existing primitive-channel predicate
 
 CPSV16's clause "the associated CPM has a unique eigenvalue of magnitude
-equal to its spectral radius which is equal to one" is the standard
-*primitive transfer map* condition. We reuse `_root_.IsPrimitive`
-(`TNLean.Channel.Peripheral.Spectrum`), which states that the peripheral
-eigenvalue set equals `{1}`. This matches the paper after the spectral-radius
-normalization the paper assumes (cf. `MPDO-22-12-17-2.tex:231`, the block-then-
-renormalize paragraph immediately preceding Definition NT).
+equal to its spectral radius which is equal to one" has two parts.  The field
+`spectral_radius_one` records the spectral-radius normalization, while
+`primitive_transfer` uses `_root_.IsPrimitive`
+(`TNLean.Channel.Peripheral.Spectrum`) to state that the only eigenvalue on
+the unit circle is `1`.  Together they give the paper's peripheral-spectrum
+condition (cf. `MPDO-22-12-17-2.tex:231`, the block-then-renormalize paragraph
+immediately preceding Definition NT).
 
 The TN-Review formulation (`Papers/2011.12127/TN-Review-main.tex:1827-1830`)
 "the transfer operator is a primitive channel" is the same clause and is not
@@ -87,10 +89,10 @@ arXiv:1606.00608, Definition before eq. `II_CF1` (`Papers/1606.00608/MPDO-22-12-
 * (ii) the associated CPM (the transfer map `E_A(X) = ∑_i A_i X A_i^†`) has a unique
   eigenvalue of magnitude equal to its spectral radius which is equal to one.
 
-Clause (ii) is encoded via `_root_.IsPrimitive (transferMap A)`, which states that the
-peripheral eigenvalue set of the transfer map is exactly `{1}`. Combined with the
-implicit spectral-radius normalization the paper assumes (cf. `MPDO-22-12-17-2.tex:231`),
-this is the CPSV formulation.
+Clause (ii) is encoded by an explicit spectral-radius-one field together with
+`_root_.IsPrimitive (transferMap A)`, which states that the eigenvalues of norm
+one form exactly `{1}`.  The explicit field is essential: unit-circle
+uniqueness alone does not exclude eigenvalues of norm greater than one.
 
 This predicate is intentionally *weaker* than the TNLean strong predicate
 `MPSTensor.IsCanonicalFormSepAux.IsNormalCanonicalForm` (it does not require
@@ -99,8 +101,13 @@ left-canonical normalization, weight ordering, or positive bond dimension).
 structure IsNormalTensor (A : MPSTensor d D) : Prop where
   /-- (i) no nontrivial invariant orthogonal projection. -/
   no_invariant_proj : IsIrreducibleTensor A
-  /-- (ii) the associated CPM has a unique eigenvalue of magnitude equal to its
-  spectral radius equal to one (primitive transfer map). -/
+  /-- (ii-a) the associated CPM has spectral radius one, as required after the
+  rescaling of arXiv:1606.00608, lines 224--225 and 233--235. -/
+  spectral_radius_one :
+    spectralRadius ℂ
+      ((Module.End.toContinuousLinearMap (Matrix (Fin D) (Fin D) ℂ))
+        (transferMap (d := d) (D := D) A)) = 1
+  /-- (ii-b) the associated CPM has no unit-modulus eigenvalue other than one. -/
   primitive_transfer : _root_.IsPrimitive (transferMap (d := d) (D := D) A)
 
 /-! ## Basis of normal tensors (BNT) -/

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
@@ -7,6 +7,7 @@ import TNLean.MPS.CanonicalForm.Definitions
 import TNLean.MPS.SharedInfra.Scaling
 import TNLean.MPS.Irreducible.FormII
 import TNLean.Channel.Irreducible.PerronFrobenius
+import TNLean.Channel.Irreducible.SpectralRadius
 
 /-!
 # Spectral steps of the canonical-form sufficient condition
@@ -185,28 +186,38 @@ theorem isNormalTensor_invSqrt_smul_of_unique_peripheral {n : ℕ} [NeZero n]
   have hfix : transferMap (d := d) (D := n)
       (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i) ρ = ρ := by
     rw [hmap, LinearMap.smul_apply, hEig, smul_smul, inv_mul_cancel₀ hr_ne, one_smul]
-  refine ⟨isIrreducibleTensor_smul hc_ne B hIrr, ?_⟩
-  refine isPrimitive_of_unique_norm_one _ ρ hfix hρ_ne ?_
-  intro μ hμ hμnorm
-  obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
-  have hX_eq : transferMap (d := d) (D := n)
-      (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i) X = μ • X :=
-    Module.End.mem_eigenspace_iff.mp (Module.End.hasEigenvector_iff.mp hX).1
-  have hX_ne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
-  have hBX : transferMap (d := d) (D := n) B X = ((r : ℂ) * μ) • X := by
-    have h1 : (r : ℂ)⁻¹ • transferMap (d := d) (D := n) B X = μ • X := by
-      rw [← LinearMap.smul_apply, ← hmap]
-      exact hX_eq
-    calc transferMap (d := d) (D := n) B X
-        = (r : ℂ) • ((r : ℂ)⁻¹ • transferMap (d := d) (D := n) B X) := by
-          rw [smul_smul, mul_inv_cancel₀ hr_ne, one_smul]
-      _ = (r : ℂ) • (μ • X) := by rw [h1]
-      _ = ((r : ℂ) * μ) • X := by rw [smul_smul]
-  have hBμ : Module.End.HasEigenvalue (transferMap (d := d) (D := n) B) ((r : ℂ) * μ) :=
-    hasEigenvalue_of_eigenvector_eq _ _ X hBX hX_ne
-  have hnorm : ‖(r : ℂ) * μ‖ = r := by
-    rw [norm_mul, hμnorm, mul_one, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr]
-  exact mul_left_cancel₀ hr_ne ((huniq _ hBμ hnorm).trans (mul_one (r : ℂ)).symm)
+  have hIrrScaled : IsIrreducibleTensor
+      (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i) :=
+    isIrreducibleTensor_smul hc_ne B hIrr
+  refine ⟨hIrrScaled, ?_, ?_⟩
+  · simpa using
+      (spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp
+        (transferMap (d := d) (D := n)
+          (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i))
+        (transferMap_isCPMap _) (isIrreducibleCP_transferMap_of_isIrreducibleTensor _ hIrrScaled)
+        ρ 1 hρ (by norm_num) (by simpa using hfix))
+  · refine isPrimitive_of_unique_norm_one _ ρ hfix hρ_ne ?_
+    intro μ hμ hμnorm
+    obtain ⟨X, hX⟩ := hμ.exists_hasEigenvector
+    have hX_eq : transferMap (d := d) (D := n)
+        (fun i => (((Real.sqrt r : ℝ) : ℂ))⁻¹ • B i) X = μ • X :=
+      Module.End.mem_eigenspace_iff.mp (Module.End.hasEigenvector_iff.mp hX).1
+    have hX_ne : X ≠ 0 := (Module.End.hasEigenvector_iff.mp hX).2
+    have hBX : transferMap (d := d) (D := n) B X = ((r : ℂ) * μ) • X := by
+      have h1 : (r : ℂ)⁻¹ • transferMap (d := d) (D := n) B X = μ • X := by
+        rw [← LinearMap.smul_apply, ← hmap]
+        exact hX_eq
+      calc transferMap (d := d) (D := n) B X
+          = (r : ℂ) • ((r : ℂ)⁻¹ • transferMap (d := d) (D := n) B X) := by
+            rw [smul_smul, mul_inv_cancel₀ hr_ne, one_smul]
+        _ = (r : ℂ) • (μ • X) := by rw [h1]
+        _ = ((r : ℂ) * μ) • X := by rw [smul_smul]
+    have hBμ : Module.End.HasEigenvalue
+        (transferMap (d := d) (D := n) B) ((r : ℂ) * μ) :=
+      hasEigenvalue_of_eigenvector_eq _ _ X hBX hX_ne
+    have hnorm : ‖(r : ℂ) * μ‖ = r := by
+      rw [norm_mul, hμnorm, mul_one, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr]
+    exact mul_left_cancel₀ hr_ne ((huniq _ hBμ hnorm).trans (mul_one (r : ℂ)).symm)
 
 /-- At positive length, a tensor whose letter matrices all vanish has vanishing
 matrix product vector coefficients.  These are the zero blocks of

--- a/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
+++ b/TNLean/MPS/CanonicalForm/ProjectorClosureSpectral.lean
@@ -157,11 +157,12 @@ tensor, provided the transfer map has no eigenvalue of modulus equal to, but
 different from, that eigenvalue.
 
 Rescaling the tensor by `r^{-1/2}` rescales the transfer map by `r⁻¹`, so the
-positive-definite eigenvector becomes a fixed point and the peripheral
-eigenvalues become the eigenvalues of modulus one; the uniqueness hypothesis
-forces the peripheral eigenvalue set to be `{1}`, which together with
-irreducibility is the normal-tensor condition of arXiv:1606.00608,
-lines 233--235. -/
+positive-definite eigenvector becomes a fixed point. Irreducibility and Wolf
+Theorem 6.3(4) (`spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp`)
+then identify its eigenvalue `1` with the spectral radius. The peripheral
+eigenvalues are therefore the eigenvalues of modulus one; the uniqueness
+hypothesis forces this set to be `{1}`. Together with irreducibility, these are
+the normal-tensor conditions of arXiv:1606.00608, lines 233--235. -/
 theorem isNormalTensor_invSqrt_smul_of_unique_peripheral {n : ℕ} [NeZero n]
     (B : MPSTensor d n) (hIrr : IsIrreducibleTensor B)
     (ρ : Matrix (Fin n) (Fin n) ℂ) (r : ℝ) (hρ : ρ.PosDef) (hr : 0 < r)

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -129,8 +129,8 @@ the coefficient argument of Chapter~\ref{ch:bnt}.
     \emph{normal tensor} if, after the spectral-radius normalization
     of~\cite{Cirac2016MPDO_arXiv}, (i)~$A$ admits no nontrivial invariant
     orthogonal projection and (ii)~the associated CPM
-    $\E_A(X) = \sum_i A^i X (A^i)^\dagger$ has peripheral spectrum
-    $\sigma_\partial(\E_A)=\{1\}$.
+    $\E_A(X) = \sum_i A^i X (A^i)^\dagger$ has spectral radius
+    $r(\E_A)=1$ and peripheral spectrum $\sigma_\partial(\E_A)=\{1\}$.
 \end{definition}
 
 \begin{remark}

--- a/blueprint/src/chapter/ch09_canonical.tex
+++ b/blueprint/src/chapter/ch09_canonical.tex
@@ -151,9 +151,10 @@ Definition~\ref{def:is_normal_canonical_form}, and the global weight
 normalization is invoked as a separate source hypothesis where needed.
 
 \begin{remark}[Relation to the strong predicates]
-    A tensor $A$ which is both irreducible
-    (Definition~\ref{def:irreducible_tensor}) and has primitive transfer map is
-    normal in the sense of Definition~\ref{def:nt_cpsv}. The reverse
+    A tensor $A$ which is irreducible
+    (Definition~\ref{def:irreducible_tensor}), has transfer map of spectral
+    radius one, and has primitive transfer map is normal in the sense of
+    Definition~\ref{def:nt_cpsv}. The reverse
     implications from the stronger predicates of
     Definition~\ref{def:is_normal_canonical_form} and of Chapter~\ref{ch:bnt}
     require the fundamental-theorem step or the algebraic-to-spectral normality
@@ -547,17 +548,20 @@ the resulting splitting decomposes any tensor into irreducible blocks.
 
 \begin{proof}
     \leanok
-    \uses{def:nt_cpsv}
+    \uses{def:nt_cpsv, thm:spectral_radius_pf_irred}
     The rescaling identity
     \[
         \E_{r^{-1/2}B}(X) = r^{-1}\,\E_B(X)
     \]
     gives $\E_{r^{-1/2}B}(\rho) = r^{-1}\cdot r\rho = \rho$, so $\rho$ is a
-    positive-definite fixed point of $\E_{r^{-1/2}B}$. The eigenvalues of
-    modulus one of $\E_{r^{-1/2}B}$ are the eigenvalues of $\E_B$ of modulus
-    $r$, divided by $r$; by hypothesis the only such eigenvalue is one, so
-    the peripheral eigenvalue set is $\{1\}$. Irreducibility is unchanged by
-    a nonzero rescaling.
+    positive-definite fixed point of $\E_{r^{-1/2}B}$. The rescaled map remains
+    irreducible and completely positive, so
+    Theorem~\ref{thm:spectral_radius_pf_irred} identifies its spectral radius
+    with the eigenvalue one. The eigenvalues of modulus one of
+    $\E_{r^{-1/2}B}$ are the eigenvalues of $\E_B$ of modulus $r$, divided by
+    $r$; by hypothesis the only such eigenvalue is one, so the peripheral
+    eigenvalue set is $\{1\}$. Irreducibility is unchanged by a nonzero
+    rescaling.
 \end{proof}
 
 \begin{theorem}[Sufficient condition for canonical form]


### PR DESCRIPTION
## Summary

Repairs the source signature introduced by the already merged #3695.

CPSV normality requires the transfer map of each rescaled block to have spectral
radius exactly one, as well as having no other eigenvalue on that spectral
circle (arXiv:1606.00608, lines 224–225 and 233–235). The existing
`IsNormalTensor` record stored irreducibility and
`peripheralEigenvalues E = {1}`, where that set means eigenvalues on the unit
circle. That condition alone does not exclude eigenvalues of modulus greater
than one and therefore did not encode the source normalization.

This PR:

- adds an explicit `spectral_radius_one` field to `IsNormalTensor`;
- proves the field in
  `isNormalTensor_invSqrt_smul_of_unique_peripheral` from the
  positive-definite fixed point already constructed after rescaling, using the
  irreducible-CP spectral-radius theorem;
- states (r(ℰ_A)=1) explicitly in the Chapter 9 blueprint definition.

The capstone theorems from #3695 already return `IsNormalTensor`, so the
strengthened record propagates the radius-one certificate into their public
signatures without adding any hypothesis.

## Periodicity convention

The `HasNoPeriodicVectors` predicate from #3695 is deliberately blockwise: it
quantifies over irreducible minimal-invariant-subspace restrictions and their
Perron radii. This is the source-faithful condition. It is not merely global
`IsPrimitive (transferMap A)`, which can miss periodic eigenvalues in
subdominant blocks; this corrects the shorthand in the original description of
#3692.

## Checks

- `lake build TNLean` — 9277 jobs, successful
- focused compilation of `Definitions.lean` and
  `ProjectorClosureSpectral.lean`
- `leanblueprint checkdecls`
- strict blueprint/Lean synchronization and reader-facing prose checks
- 427-page blueprint PDF built; the corrected normal-tensor definition and the
  spectral-normalization proof were visually inspected
- independent source-faithfulness audit, including an explicit counterexample
  to the previous weaker signature

Closes #2634
Closes #3691
Closes #3692

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> It changes the formal definition of `IsNormalTensor` used by canonical-form capstone theorems; the strengthened predicate is source-faithful and the main constructive proof is updated, but any downstream uses must still satisfy the new field.
> 
> **Overview**
> **Strengthens `MPSTensor.IsNormalTensor`** so CPSV normality matches arXiv:1606.00608 after block rescaling: clause (ii) is no longer only `_root_.IsPrimitive (transferMap A)` (unique unit-circle eigenvalue `1`), but also an explicit **`spectral_radius_one`** field requiring the transfer map’s spectral radius to be `1`. Docs explain that peripheral uniqueness alone can still allow eigenvalues with modulus **greater than one**.
> 
> **`isNormalTensor_invSqrt_smul_of_unique_peripheral`** is updated to supply the new field via `spectralRadius_eq_of_posDef_eigenvector_of_irreducible_cp` on the rescaled irreducible CP map, alongside the existing primitive-transfer argument.
> 
> **Chapter 9 blueprint** (`ch09_canonical.tex`) states \(r(\mathcal{E}_A)=1\) in the NT definition and extends the spectral-normalization lemma proof to cite the irreducible spectral-radius theorem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f34bb1e31166e2b0c1356b1bf79bf0dd3cbe234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->