### PR TITLE
doc(MPS/MPDO): add inverse-contraction TikZ diagram

### DIFF
--- a/blueprint/src/Packages/tn_diagrams.py
+++ b/blueprint/src/Packages/tn_diagrams.py
@@ -51,6 +51,7 @@ _DIAGRAM_ARGS: dict[str, str] = {
     "TNMPOLocalPurification": "",
     "TNMPORenormalizationTS": "",
     "TNEtaSectorDecomposition": "",
+    "TNMPDOInverseMapThreeSiteContraction": "",
     "TNGaugeConjugation": "left physical right",
     "TNPhysicalRealization": "virtual physical",
     "TNLinearTwist": "twist label",

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -138,8 +138,9 @@ strong subadditivity for a normalized three-site reduced state.
     \TNMPDOInverseMapThreeSiteContraction
     \caption{Applying ${\cal K}^{-1}$ at the first and third sites collapses
     the three-site contraction to
-    ${\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, as in
-    \cite[Appendix~C.2, Lemma~C.4]{Cirac2016MPDO_arXiv}.}
+    ${\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, where
+    $p_2=(i_2,j_2)$ is the doubled physical index; compare
+    \cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}.}
     \label{fig:mpdo_inverse_map_three_site_contraction}
 \end{figure}
 

--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -133,6 +133,16 @@ strong subadditivity for a normalized three-site reduced state.
     \]
 \end{theorem}
 
+\begin{figure}[ht]
+    \centering
+    \TNMPDOInverseMapThreeSiteContraction
+    \caption{Applying ${\cal K}^{-1}$ at the first and third sites collapses
+    the three-site contraction to
+    ${\cal K}^{p_2}_{\beta_1,\alpha_3}R_{\beta_3,\alpha_1}$, as in
+    \cite[Appendix~C.2, Lemma~C.4]{Cirac2016MPDO_arXiv}.}
+    \label{fig:mpdo_inverse_map_three_site_contraction}
+\end{figure}
+
 \begin{proof}\leanok
     \uses{thm:mpdo_injective_inverse_layer_spec}
     Move the two finite sums through the trace.  By the inverse-map identity

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -202,6 +202,66 @@
     \end{tikzpicture}%
 }
 
+% Applying the inverse tensor to the first and third sites of a three-site
+% MPO word leaves one matrix entry of the middle tensor and one entry of the
+% complementary virtual tail.
+\newcommand{\TNMPDOInverseMapThreeSiteContraction}{%
+    \begin{tikzpicture}[tn picture]
+        % Three-site word with the first and third physical indices contracted
+        % against the inverse tensor.
+        \TN@tensordot{tnKone}{(-3.00,0)}
+        \TN@tensordot{tnKtwo}{(-1.60,0)}
+        \TN@tensordot{tnKthree}{(-0.20,0)}
+        \draw[tn leg] (tnKone.east) -- (tnKtwo.west);
+        \draw[tn leg] (tnKtwo.east) -- (tnKthree.west);
+        \node at (-3.00,-0.30) {${\cal K}$};
+        \node at (-1.60,-0.30) {${\cal K}$};
+        \node at (-0.20,-0.30) {${\cal K}$};
+
+        \TN@tensordot{tnInvOne}{(-3.00,1.18)}
+        \TN@tensordot{tnInvThree}{(-0.20,1.18)}
+        \draw[tn phys leg] (tnKone.north) -- (tnInvOne.south);
+        \draw[tn phys leg] (tnKthree.north) -- (tnInvThree.south);
+        \TN@leftleg{tnInvOne}{0.52}
+        \TN@rightleg{tnInvOne}{0.52}
+        \TN@leftleg{tnInvThree}{0.52}
+        \TN@rightleg{tnInvThree}{0.52}
+        \node at (-3.00,1.52) {${\cal K}^{-1}$};
+        \node at (-0.20,1.52) {${\cal K}^{-1}$};
+        \node[anchor=east] at (-3.58,1.18) {$\alpha_1$};
+        \node[anchor=west] at (-2.42,1.18) {$\beta_1$};
+        \node[anchor=east] at (-0.78,1.18) {$\alpha_3$};
+        \node[anchor=west] at (0.38,1.18) {$\beta_3$};
+        \TN@upleg{tnKtwo}{0.52}
+        \node at (-1.60,0.82) {$p_2$};
+
+        % The trace closes the three-site word through the remaining sites R.
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (tnTail) at (-1.60,-1.02) {$R$};
+        \draw[tn leg] (tnKone.west) -- ++(-0.42,0) |- (tnTail.west);
+        \draw[tn leg] (tnTail.east) -| ($(tnKthree.east)+(0.42,0)$) -- (tnKthree.east);
+
+        \node at (0.88,0.20) {$=$};
+
+        % The two surviving factors.
+        \TN@tensordot{tnMiddle}{(2.25,0.20)}
+        \TN@leftleg{tnMiddle}{0.58}
+        \TN@rightleg{tnMiddle}{0.58}
+        \TN@upleg{tnMiddle}{0.52}
+        \node at (2.25,-0.10) {${\cal K}$};
+        \node at (2.25,1.02) {$p_2$};
+        \node[anchor=east] at (1.61,0.20) {$\beta_1$};
+        \node[anchor=west] at (2.89,0.20) {$\alpha_3$};
+        \node at (3.50,0.20) {$\times$};
+        \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
+            (tnTailEntry) at (4.65,0.20) {$R$};
+        \draw[tn leg] (tnTailEntry.west) -- ++(-0.58,0);
+        \draw[tn leg] (tnTailEntry.east) -- ++(0.58,0);
+        \node[anchor=east] at (4.01,0.20) {$\beta_3$};
+        \node[anchor=west] at (5.29,0.20) {$\alpha_1$};
+    \end{tikzpicture}%
+}
+
 \newcommand{\TNGaugeConjugation}[3]{%
     \begin{tikzpicture}[tn picture]
         \TN@opdotabove{tnXl}{(-1.10,0)}{#1}

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -250,8 +250,10 @@
         % The trace closes the three-site word through the remaining sites R.
         \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
             (tnTail) at (-1.60,-1.42) {$R$};
-        \draw[tn leg] (tnKone.west) -- ++(-0.42,0) |- (tnTail.west);
-        \draw[tn leg] (tnTail.east) -| ($(tnKthree.east)+(0.42,0)$) -- (tnKthree.east);
+        \draw[tn leg] (tnKone.west) -- ++(-0.42,0)
+            |- ($(tnTail.east)+(0,-0.40)$) -- (tnTail.east);
+        \draw[tn leg] (tnKthree.east) -- ++(0.42,0)
+            |- ($(tnTail.west)+(0,0.38)$) -- (tnTail.west);
 
         \node at (0.88,0.20) {$=$};
 

--- a/blueprint/src/macros/tn_print.tex
+++ b/blueprint/src/macros/tn_print.tex
@@ -207,37 +207,49 @@
 % complementary virtual tail.
 \newcommand{\TNMPDOInverseMapThreeSiteContraction}{%
     \begin{tikzpicture}[tn picture]
-        % Three-site word with the first and third physical indices contracted
-        % against the inverse tensor.
+        % Three-site MPO word.  At the first and third sites, both physical
+        % legs are contracted against the corresponding inverse tensor.
         \TN@tensordot{tnKone}{(-3.00,0)}
         \TN@tensordot{tnKtwo}{(-1.60,0)}
         \TN@tensordot{tnKthree}{(-0.20,0)}
         \draw[tn leg] (tnKone.east) -- (tnKtwo.west);
         \draw[tn leg] (tnKtwo.east) -- (tnKthree.west);
-        \node at (-3.00,-0.30) {${\cal K}$};
-        \node at (-1.60,-0.30) {${\cal K}$};
-        \node at (-0.20,-0.30) {${\cal K}$};
+        \node[anchor=east] at (-3.14,-0.28) {${\cal K}$};
+        \node[anchor=east] at (-1.74,-0.28) {${\cal K}$};
+        \node[anchor=east] at (-0.34,-0.28) {${\cal K}$};
 
         \TN@tensordot{tnInvOne}{(-3.00,1.18)}
         \TN@tensordot{tnInvThree}{(-0.20,1.18)}
         \draw[tn phys leg] (tnKone.north) -- (tnInvOne.south);
         \draw[tn phys leg] (tnKthree.north) -- (tnInvThree.south);
+        \draw[tn phys leg]
+            (tnKone.south) .. controls (-2.18,-0.38) and (-2.18,1.62) ..
+            (tnInvOne.north);
+        \draw[tn phys leg]
+            (tnKthree.south) .. controls (-0.98,-0.38) and (-0.98,1.62) ..
+            (tnInvThree.north);
         \TN@leftleg{tnInvOne}{0.52}
         \TN@rightleg{tnInvOne}{0.52}
         \TN@leftleg{tnInvThree}{0.52}
         \TN@rightleg{tnInvThree}{0.52}
-        \node at (-3.00,1.52) {${\cal K}^{-1}$};
-        \node at (-0.20,1.52) {${\cal K}^{-1}$};
+        \node[anchor=east] at (-3.12,1.55) {${\cal K}^{-1}$};
+        \node[anchor=west] at (-0.08,1.55) {${\cal K}^{-1}$};
         \node[anchor=east] at (-3.58,1.18) {$\alpha_1$};
         \node[anchor=west] at (-2.42,1.18) {$\beta_1$};
         \node[anchor=east] at (-0.78,1.18) {$\alpha_3$};
         \node[anchor=west] at (0.38,1.18) {$\beta_3$};
         \TN@upleg{tnKtwo}{0.52}
-        \node at (-1.60,0.82) {$p_2$};
+        \TN@downleg{tnKtwo}{0.52}
+        \node at (-1.60,0.82) {$i_2$};
+        \node at (-1.60,-0.82) {$j_2$};
+        \node at (-2.88,0.58) {$i_1$};
+        \node at (-2.08,0.48) {$j_1$};
+        \node at (-0.08,0.58) {$i_3$};
+        \node at (-1.08,0.48) {$j_3$};
 
         % The trace closes the three-site word through the remaining sites R.
         \node[draw, rounded corners, fill=blue!8, inner sep=2pt]
-            (tnTail) at (-1.60,-1.02) {$R$};
+            (tnTail) at (-1.60,-1.42) {$R$};
         \draw[tn leg] (tnKone.west) -- ++(-0.42,0) |- (tnTail.west);
         \draw[tn leg] (tnTail.east) -| ($(tnKthree.east)+(0.42,0)$) -- (tnKthree.east);
 
@@ -248,8 +260,10 @@
         \TN@leftleg{tnMiddle}{0.58}
         \TN@rightleg{tnMiddle}{0.58}
         \TN@upleg{tnMiddle}{0.52}
-        \node at (2.25,-0.10) {${\cal K}$};
-        \node at (2.25,1.02) {$p_2$};
+        \TN@downleg{tnMiddle}{0.52}
+        \node[anchor=east] at (2.11,-0.08) {${\cal K}$};
+        \node at (2.25,1.02) {$i_2$};
+        \node at (2.25,-0.62) {$j_2$};
         \node[anchor=east] at (1.61,0.20) {$\beta_1$};
         \node[anchor=west] at (2.89,0.20) {$\alpha_3$};
         \node at (3.50,0.20) {$\times$};

--- a/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
+++ b/blueprint/src/plastex_templates/TensorNetworkDiagrams.jinja2s
@@ -7,6 +7,9 @@ name: TNMPSLocal TNMPSWord TNMPV TNBlocking TNMPVOverlap TNTransferMap TNMPOCell
 name: TNMPOLocalPurification TNMPORenormalizationTS TNEtaSectorDecomposition
 {{ obj.tn_svg_html }}
 
+name: TNMPDOInverseMapThreeSiteContraction
+{{ obj.tn_svg_html }}
+
 name: TNGaugeConjugation TNPhysicalRealization TNLinearTwist
 {{ obj.tn_svg_html }}
 


### PR DESCRIPTION
## Summary

- Add a native TikZ diagram beside the blueprint theorem evaluating the three-site inverse-map contraction.
- Depict the exact identity formalized by `MPOTensor.inverseMapThreeSiteContraction_eq`: applying the inverse tensor at sites one and three leaves the middle entry `K^{p_2}_{beta_1,alpha_3}` and the tail entry `R_{beta_3,alpha_1}`.
- Register the same public diagram command for PDF TikZ and web SVG rendering. No raster asset is introduced.

This is a diagrammatic follow-up related to #823. It does not close that issue.

## Checks

- `python3 blueprint/src/Packages/tn_diagrams.py --check --smoke-render TNMPDOInverseMapThreeSiteContraction`
- `leanblueprint checkdecls`
- `python3 scripts/check_reader_facing_prose.py --diff-base origin/main`
- `git diff origin/main...HEAD --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and diagram plumbing only; no Lean or runtime logic changes.
> 
> **Overview**
> Adds a **native TikZ diagram** for the three-site MPDO inverse-map contraction and wires it through the same PDF/web diagram pipeline as other `\TN...` macros.
> 
> A new zero-argument macro `\TNMPDOInverseMapThreeSiteContraction` depicts contracting `${\cal K}^{-1}$` on sites 1 and 3 of a three-site word (with tail `$R$`) collapsing to `${\cal K}^{p_2}_{\beta_1,\alpha_3} R_{\beta_3,\alpha_1}$`, matching `MPOTensor.inverseMapThreeSiteContraction_eq`. **Chapter 21** inserts a figure with that macro immediately after the evaluation theorem. **`tn_diagrams.py`** and **`TensorNetworkDiagrams.jinja2s`** register the macro so plasTeX can render cached SVG alongside TikZ PDF output—no new raster assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f15ebe9a293b0d7dfc3738dbfe462881bbaf9610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->