### PR TITLE
doc(blueprint): correct inverse-map contraction citation

### DIFF
--- a/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
+++ b/blueprint/src/chapter/ch21_mpdo_rfp_simple_local_structure.tex
@@ -115,7 +115,7 @@ strong subadditivity for a normalized three-site reduced state.
         {\cal K}^{p_3}R\bigr).
     \]
     This is the contraction used in the proof of
-    \cite[Appendix~C.2, Lemma~C.4]{Cirac2016MPDO_arXiv}.
+    \cite[Appendix~C.2, lines~1415--1438]{Cirac2016MPDO_arXiv}.
 \end{definition}
 
 \begin{theorem}[Evaluation of the three-site inverse-map contraction]


### PR DESCRIPTION
## Summary

The three-site inverse-map contraction definition now cites the exact source passage, Appendix C.2, lines 1415--1438 of arXiv:1606.00608. The former reference to “Lemma C.4” was inaccurate because the source contains no theorem carrying that number at this passage.

This correction makes the definition agree with its Lean docstring and the adjacent figure caption.

## Verification

- `python3 scripts/check_reader_facing_prose.py --root . --diff-base origin/main --ci`
- `python3 scripts/blueprint_lean_sync.py --root . --update-lean-decls`
- `python3 scripts/blueprint_lean_sync.py --root . --ci`
- `leanblueprint checkdecls`
- `leanblueprint pdf`
- visually inspected PDF page 404
- `git diff --check`

Refs #823

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single bibliography string change in blueprint TeX; no code or proof logic affected.
> 
> **Overview**
> The **three-site inverse-map contraction** definition (`def:mpdo_inverse_map_three_site_contraction`) now points to **Appendix C.2, lines 1415--1438** of Cirac et al. instead of **Lemma C.4**, which does not match that passage in the source.
> 
> This aligns the definition prose with the figure caption on the same page and with the Lean docstring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55238e5e12f74a7b24856f2eb599c2bc5499af32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->